### PR TITLE
docs: add initial English quick start guide

### DIFF
--- a/docs/QUICK_START_EN.md
+++ b/docs/QUICK_START_EN.md
@@ -1,0 +1,42 @@
+# Quick Start (English)
+
+## Overview
+
+AIWorkDeck is a multi-service AI workspace platform built with:
+
+- Spring Boot backend
+- Vue frontend
+- Docker-based supporting services
+- PostgreSQL database
+- External AI provider integrations
+
+This guide helps non-Chinese speakers set up the project locally for development and testing.
+
+---
+
+## Prerequisites
+
+Before starting, make sure the following tools are installed:
+
+### Required
+
+- Java 17
+- Node.js 18+
+- Docker
+- Docker Compose
+- PostgreSQL
+- Git
+
+### Recommended
+
+- VS Code
+- IntelliJ IDEA
+- Postman
+
+---
+
+## Clone the Repository
+
+```bash
+git clone https://github.com/zeweihan/aiworkdeck.git
+cd aiworkdeck


### PR DESCRIPTION
## Description

Adds the initial English Quick Start guide for non-Chinese speakers.

Current sections included:

- project overview
- prerequisites
- repository cloning steps

Planned follow-up additions:

- `.env` configuration walkthrough
- backend/frontend startup flow
- Docker services explanation
- troubleshooting section
- external credential notes
- optional video walkthrough references

## Related Issue

Closes #7

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] I have updated documentation where needed
