### PR TITLE
fix(ci): gracefully skip macOS signing on fork PRs / 修复 fork PR 的 macOS 构建失败

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -41,9 +41,12 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Safe here: GitHub never exposes secrets to fork PRs, so CSC_LINK is
-          # empty for untrusted PRs and signing is silently skipped for them.
-          CSC_FOR_PULL_REQUEST: 'true'
+          # GitHub never exposes secrets to fork PRs, so CSC_LINK is empty
+          # there — and force-signing with an empty CSC_LINK makes
+          # electron-builder fail ("not a file"). Only force signing when the
+          # cert secret is actually present; fork PRs fall back to
+          # electron-builder's default unsigned PR build.
+          CSC_FOR_PULL_REQUEST: ${{ secrets.CSC_LINK != '' }}
         run: npx electron-builder --publish never
       - name: Package installers (Windows, unsigned)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## 说明 / Description

**中文**：#19 把 `CSC_FOR_PULL_REQUEST` 硬编码为 `'true'`，当时的假设是 fork PR 拿不到 secrets、空的 `CSC_LINK` 会"静默跳过签名"。实际行为是 electron-builder 把空值当成证书文件路径，报 `not a file` 直接失败——第一个社区 PR（#20）的 macOS 构建就挂在这里。

修复：`CSC_FOR_PULL_REQUEST: ${{ secrets.CSC_LINK != '' }}`——secrets 存在（主仓库 PR / tag 构建）时照常签名+公证；fork PR 取不到 secrets 时求值为 `false`，走 electron-builder 默认的"PR 跳过签名"路径（即 #19 之前一直通过的路径）。签名跳过时公证也会一并跳过，不会因缺 `APPLE_ID` 再失败。

**English**: #19 hardcoded `CSC_FOR_PULL_REQUEST: 'true'`, assuming an empty `CSC_LINK` on fork PRs would silently skip signing. In reality electron-builder treats the empty value as a certificate path and fails with `not a file` — which broke the macOS build of our first community PR (#20).

Fix: `CSC_FOR_PULL_REQUEST: ${{ secrets.CSC_LINK != '' }}` — same-repo PRs and tag builds keep signing + notarizing; fork PRs evaluate to `false` and take electron-builder's default skip-signing-on-PR path (the one that always passed before #19). When signing is skipped, notarization is skipped too, so the missing `APPLE_ID` cannot fail either.

## 关联 / Related Issue

Unblocks #20

## 类型 / Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
