### PR TITLE
fix(security): strip hardcoded API key defaults from config / 清除配置文件中硬编码的 API 密钥默认值

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -18,11 +18,11 @@ spring:
 external:
   qichacha:
     base-url: https://api.qichacha.com
-    key: ${QICHACHA_KEY:f4900a7dd885415cb305edc621f5b490}
-    secret: ${QICHACHA_SECRET:9C16665DB7BA6661FAAC35EF1321FA3C}
+    key: ${QICHACHA_KEY:}
+    secret: ${QICHACHA_SECRET:}
   wps:
-    app-id: SX20260104RLPEYU
-    app-secret: ${WPS_APP_SECRET:XwyPtBEirMxtitGECNKhIBYKNCJDVIyA}
+    app-id: ${WPS_APP_ID:}
+    app-secret: ${WPS_APP_SECRET:}
     callback-base-url: https://6e783f5e.r3.cpolar.cn  # 使用 cpolar 内网穿透地址（当前实际URL，每次重启会变化）
   tushare:
     base-url: http://api.tushare.pro

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,21 +31,21 @@ spring:
 external:
   qichacha:
     base-url: https://api.qichacha.com
-    key: ${QICHACHA_KEY:f4900a7dd885415cb305edc621f5b490}
-    secret: ${QICHACHA_SECRET:9C16665DB7BA6661FAAC35EF1321FA3C}
+    key: ${QICHACHA_KEY:}
+    secret: ${QICHACHA_SECRET:}
   wps:
-    app-id: SX20260104RLPEYU
-    app-secret: ${WPS_APP_SECRET:XwyPtBEirMxtitGECNKhIBYKNCJDVIyA}
+    app-id: ${WPS_APP_ID:}
+    app-secret: ${WPS_APP_SECRET:}
     callback-base-url: https://zuolinya.cpolar.top  # 使用 cpolar 内网穿透地址（当前实际URL，每次重启会变化）
   tushare:
     base-url: http://api.tushare.pro
-    token: ${TUSHARE_TOKEN:bc50eb0b3a1840d511a947dc2180628ac763f37e4d7ccdda35eb454a}
+    token: ${TUSHARE_TOKEN:}
   # PKULaw Configuration
   pkulaw:
-    token: ${PKULAW_TOKEN:e71307ee-d6c5-3eed-bed8-c5be239ab824}
+    token: ${PKULAW_TOKEN:}
   # ElevenLabs TTS 配置
   elevenlabs:
-    api-key: ${ELEVENLABS_API_KEY:sk_76aed601410067f390c536eecd3a35f63570ccf0fd4d4d7d}
+    api-key: ${ELEVENLABS_API_KEY:}
     base-url: https://api.elevenlabs.io/v1
     model-id: eleven_multilingual_v2
     default-voice-id: JBFqnCBsd6RMkjVDRZzb
@@ -63,7 +63,7 @@ ai:
     provider: open-router
     gemini:
       # 建议通过环境变量 GEMINI_API_KEY 注入，避免写死在配置文件
-      api-key: ${GEMINI_API_KEY:AIzaSyDpX0_tGBV2MCk-6PTh32whDFEBTgRLUCc}
+      api-key: ${GEMINI_API_KEY:}
       # 默认使用官方当前推荐的通用文本模型，可按需调整为 gemini-2.5-flash 等
       model-name: gemini-2.5-flash
       api-base-url: https://generativelanguage.googleapis.com/v1beta
@@ -76,7 +76,7 @@ ai:
       timeout: 300s
     open-router:
       # OpenRouter API Key (必填)
-      api-key: ${OPENROUTER_API_KEY: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}
+      api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
       default-model: google/gemini-2.0-flash-exp:free
       timeout: 120s


### PR DESCRIPTION
## 中文

### 问题

PR #10 清理了部分泄露密钥，但 `application.yml` 和 `application-prod.yml` 中仍有 **11 处真实密钥**作为环境变量的默认值留在公开仓库：

- 企查查 key + secret（两个文件）
- WPS app-secret（两个文件）
- Tushare token、北大法宝 token、ElevenLabs API key
- Gemini API key、OpenRouter API key

### 修复

全部默认值改为空（如 `${GEMINI_API_KEY:}`），密钥只能通过环境变量或管理后台（system_setting 表）注入。WPS app-id 一并改为环境变量（与已泄露的 secret 配对，建议一起轮换）。

### ⚠️ 维护者必须执行（仓库历史中仍可见，改代码不等于止血）

请轮换以下全部凭据：企查查、WPS、Tushare、北大法宝、ElevenLabs、**Gemini（即此前记录待轮换的 Google key）**、OpenRouter。

### 验证

- `mvn compile` 通过（JDK 21）
- 全仓库密钥模式扫描（AIza/sk-or/sk_/ghp_/AKIA 等）无残留

## English

### Problem

PR #10 removed some leaked keys, but **11 real credentials** remained in the public repo as env-var fallback defaults in `application.yml` / `application-prod.yml` (Qichacha, WPS, Tushare, PKULaw, ElevenLabs, Gemini, OpenRouter).

### Fix

All defaults are now empty (e.g. `${GEMINI_API_KEY:}`); credentials must be injected via environment variables or the admin config UI. WPS app-id moved to an env var as well since its paired secret leaked.

### ⚠️ Maintainer action required

Rotate all affected credentials — they remain visible in git history; removing them from HEAD does not revoke them.

### Verification

- `mvn compile` passes (JDK 21)
- Repo-wide secret-pattern scan is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)