### PR TITLE
feat(backend): desktop H2 profile + first-run wizard endpoint / 单机 H2 profile 与首次运行向导端点（#18 T1/T3）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AdminConfigController.java
+++ b/backend/src/main/java/com/checkba/controller/AdminConfigController.java
@@ -322,6 +322,64 @@ public class AdminConfigController {
                     .body(error("仅管理员可访问此接口"));
         }
 
+        Map<String, String> updates;
+        try {
+            updates = toSettingsUpdates(request, objectMapper);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e.getMessage()));
+        }
+
+        systemSettingService.setMany(updates);
+
+        Map<String, Object> ok = new HashMap<>();
+        ok.put("code", 0);
+        ok.put("message", "保存成功");
+        ok.put("timestamp", LocalDateTime.now().toString());
+        return ResponseEntity.ok(ok);
+    }
+
+    /**
+     * 用户管理：简单返回用户列表（只读）
+     */
+    @GetMapping("/users")
+    public ResponseEntity<?> listUsers(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+
+        User admin = requireAdmin(sessionId);
+        if (admin == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(error("仅管理员可访问此接口"));
+        }
+
+        List<UserSummary> users = userRepository.findAll()
+                .stream()
+                .map(u -> {
+                    UserSummary dto = new UserSummary();
+                    dto.setId(u.getId());
+                    dto.setUsername(u.getUsername());
+                    dto.setDisplayName(u.getDisplayName());
+                    dto.setAvatarUrl(u.getAvatarUrl());
+                    dto.setEmail(u.getEmail());
+                    dto.setCreatedAt(u.getCreatedAt());
+                    dto.setUpdatedAt(u.getUpdatedAt());
+                    return dto;
+                })
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(users);
+    }
+
+    // ============ 辅助方法 & DTO =============
+
+    /**
+     * 将配置更新请求映射为 system_setting 键值对。
+     * 供 /api/admin/config 与首次运行向导 /api/admin/wizard 共用，
+     * 保证两个入口写入的 key 完全一致。
+     *
+     * @throws IllegalArgumentException assistants 序列化失败时抛出
+     */
+    static Map<String, String> toSettingsUpdates(AdminConfigUpdateRequest request,
+                                                 com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
         Map<String, String> updates = new HashMap<>();
 
         if (request.getExternal() != null) {
@@ -383,53 +441,13 @@ public class AdminConfigController {
                     String json = objectMapper.writeValueAsString(ai.getAssistants());
                     updates.put(KEY_AI_ASSISTANTS, json);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    return ResponseEntity.badRequest().body(error("Asssistants JSON serialization failed"));
+                    throw new IllegalArgumentException("Assistants JSON serialization failed", e);
                 }
             }
         }
 
-        systemSettingService.setMany(updates);
-
-        Map<String, Object> ok = new HashMap<>();
-        ok.put("code", 0);
-        ok.put("message", "保存成功");
-        ok.put("timestamp", LocalDateTime.now().toString());
-        return ResponseEntity.ok(ok);
+        return updates;
     }
-
-    /**
-     * 用户管理：简单返回用户列表（只读）
-     */
-    @GetMapping("/users")
-    public ResponseEntity<?> listUsers(
-            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
-
-        User admin = requireAdmin(sessionId);
-        if (admin == null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(error("仅管理员可访问此接口"));
-        }
-
-        List<UserSummary> users = userRepository.findAll()
-                .stream()
-                .map(u -> {
-                    UserSummary dto = new UserSummary();
-                    dto.setId(u.getId());
-                    dto.setUsername(u.getUsername());
-                    dto.setDisplayName(u.getDisplayName());
-                    dto.setAvatarUrl(u.getAvatarUrl());
-                    dto.setEmail(u.getEmail());
-                    dto.setCreatedAt(u.getCreatedAt());
-                    dto.setUpdatedAt(u.getUpdatedAt());
-                    return dto;
-                })
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(users);
-    }
-
-    // ============ 辅助方法 & DTO =============
 
     private User requireAdmin(String sessionId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
@@ -448,7 +466,7 @@ public class AdminConfigController {
         return result;
     }
 
-    private String safe(String v) {
+    private static String safe(String v) {
         // 统一 trim，避免用户粘贴 key/secret 时带入换行/空格导致签名不匹配
         return v == null ? "" : v.trim();
     }

--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -1,0 +1,94 @@
+package com.checkba.controller;
+
+import com.checkba.controller.AdminConfigController.AdminConfigUpdateRequest;
+import com.checkba.repository.SystemSettingRepository;
+import com.checkba.service.SystemSettingService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 首次运行向导接口（Epic #18 T3）：
+ * - GET  /api/admin/wizard  查询是否已初始化（供前端决定是否进入向导）
+ * - POST /api/admin/wizard  一次性写入初始配置（复用 AdminConfig 的 DTO 与 key 映射）
+ *
+ * 安全模型：仅在"未初始化"状态下可匿名调用。未初始化 = 向导未完成且
+ * system_setting 表为空（从未通过管理后台或向导保存过任何配置）；
+ * 满足任一条件即视为已初始化，POST 返回 409，后续配置修改一律走
+ * /api/admin/config（需管理员会话）。
+ * 注意不能用"是否存在用户"判断：DataInitializer 启动时会自动创建默认 admin。
+ */
+@RestController
+@RequestMapping("/api/admin/wizard")
+@CrossOrigin(origins = "*")
+public class WizardController {
+
+    static final String KEY_WIZARD_COMPLETED = "system.wizard.completed";
+
+    private final SystemSettingService systemSettingService;
+    private final SystemSettingRepository systemSettingRepository;
+    private final ObjectMapper objectMapper;
+
+    public WizardController(SystemSettingService systemSettingService,
+                            SystemSettingRepository systemSettingRepository,
+                            ObjectMapper objectMapper) {
+        this.systemSettingService = systemSettingService;
+        this.systemSettingRepository = systemSettingRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @GetMapping
+    public ResponseEntity<?> status() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", 0);
+        body.put("initialized", isInitialized());
+        return ResponseEntity.ok(body);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> initialize(@RequestBody AdminConfigUpdateRequest request) {
+        if (isInitialized()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(error("系统已初始化，请通过管理后台修改配置 / Already initialized; use the admin console instead"));
+        }
+        if (request == null || request.getAi() == null
+                || request.getAi().getActiveProvider() == null
+                || request.getAi().getActiveProvider().isBlank()) {
+            return ResponseEntity.badRequest()
+                    .body(error("必须选择一个 AI 提供商 / An AI provider must be selected"));
+        }
+
+        Map<String, String> updates;
+        try {
+            updates = AdminConfigController.toSettingsUpdates(request, objectMapper);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(error(e.getMessage()));
+        }
+        updates.put(KEY_WIZARD_COMPLETED, "true");
+        systemSettingService.setMany(updates);
+
+        Map<String, Object> ok = new HashMap<>();
+        ok.put("code", 0);
+        ok.put("message", "初始化完成 / Initialized");
+        return ResponseEntity.ok(ok);
+    }
+
+    private boolean isInitialized() {
+        if (Boolean.parseBoolean(systemSettingService.get(KEY_WIZARD_COMPLETED, "false"))) {
+            return true;
+        }
+        // 保存过任何配置的存量部署视为已初始化，防止向导端点被匿名滥用
+        return systemSettingRepository.count() > 0;
+    }
+
+    private Map<String, Object> error(String message) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("message", message);
+        return result;
+    }
+}

--- a/backend/src/main/resources/application-desktop.yml
+++ b/backend/src/main/resources/application-desktop.yml
@@ -1,0 +1,22 @@
+# 桌面/单机模式 profile（Epic #18 T1）
+# 激活方式：java -jar backend.jar --spring.profiles.active=desktop
+# （或环境变量 SPRING_PROFILES_ACTIVE=desktop）
+#
+# 设计目标：零外部依赖启动——不需要 PostgreSQL，数据落在用户主目录的 H2 文件库。
+# 向量检索由 PgVectorConfig 自动降级为内存存储（PG 不可达时的既有回退路径）。
+
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    # H2 文件库：~/.aiworkdeck/local.mv.db
+    # MODE=PostgreSQL：兼容实体里的 PG 风格列定义（如 jsonb）
+    # NON_KEYWORDS=VALUE：system_setting.value 列与 H2 保留字冲突的豁免
+    # AUTO_SERVER=TRUE：进程重复启动时附着到已有实例而非文件锁报错
+    url: jdbc:h2:file:${user.home}/.aiworkdeck/local;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;AUTO_SERVER=TRUE
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Part of #18（T1 + T3，两个 P0 后端任务）

## 中文

### T1：`application-desktop.yml` 单机 profile

- H2 文件库 `~/.aiworkdeck/local.mv.db`，**无需 PostgreSQL**
- `MODE=PostgreSQL` 兼容实体中的 `jsonb` 列定义（共 10 处，Epic 勘察时漏掉的坑）；`NON_KEYWORDS=VALUE` 豁免 `system_setting.value` 与 H2 保留字的冲突
- 向量检索走 `PgVectorConfig` 既有降级路径（PG 不可达 → 内存存储）
- 激活：`java -jar backend.jar --spring.profiles.active=desktop`（T2 捆绑时由 Electron 传入）

### T3：`/api/admin/wizard` 首次运行向导端点

- `GET`：返回 `{ initialized }`，供前端（T4）决定是否进入向导
- `POST`：一次性写入初始配置后**自动关闭**（再调返回 409）；必填 AI 提供商，否则 400
- 复用 AdminConfig 的 DTO；key 映射抽成 `AdminConfigController.toSettingsUpdates()` 共用，保证向导与管理后台写入完全一致
- 安全模型：未初始化 = 向导未完成 **且** system_setting 表为空。注意**不能**用"是否存在用户"判断——`DataInitializer` 启动时自动创建默认 admin（实测踩到，已修正）。存量部署只要保存过任何配置即视为已初始化，端点不会暴露

### 验证（本机 JDK 21 实测）

1. `mvn compile` 通过
2. desktop profile 下后端 **5.3 秒启动成功**（本机无 PostgreSQL 服务参与，jsonb 建表正常）
3. 端点全周期：`GET→initialized:false` → 缺 provider `POST→400` → 合法 `POST→200` → `GET→initialized:true` → 再 `POST→409`
4. 重启后端：H2 文件持久化，状态保持 `initialized:true`

## English

### T1: `application-desktop.yml` standalone profile

H2 file database at `~/.aiworkdeck/local.mv.db` — no PostgreSQL required. `MODE=PostgreSQL` keeps the 10 `jsonb` column definitions working (a gap missed in the Epic survey); `NON_KEYWORDS=VALUE` resolves the H2 reserved-word clash with `system_setting.value`. Vector search falls back to the existing in-memory path.

### T3: `/api/admin/wizard` first-run wizard endpoint

`GET` reports `{ initialized }`; `POST` writes the initial config once and self-closes (409 afterwards; 400 without an AI provider). Reuses the AdminConfig DTOs via a shared `toSettingsUpdates()` extraction. "Initialized" = wizard completed **or** any system_setting row exists — user-count checks don't work because `DataInitializer` auto-creates a default admin (caught in live testing); existing deployments are never exposed.

### Verified

`mvn compile` passes (JDK 21); backend boots in 5.3s on the desktop profile without PostgreSQL; full endpoint cycle GET→400→200→409 plus persistence across restart tested against a fresh H2 file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)