### PR TITLE
chore(desktop): bump version to 0.2.0 / 桌面端版本号升至 0.2.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 中文

为发布 **v0.2.0** 做准备：将 `desktop/package.json` 版本号从 0.1.0 升至 0.2.0，使 electron-builder 产出的安装包文件名/应用版本与即将打的 `v0.2.0` tag 一致。

**背景**：Epic #18 P0（T1–T4）已全部合并——安装包现已捆绑后端 jar + 裁剪版 JRE 并内置首次运行向导，达到"双击可用"。这是发 v0.2.0 的最后一个前置项。

**改动**：仅版本号（package.json + package-lock.json 同步），无逻辑变更。
> 注：lockfile 内 `name` 仍为旧值 `checkba-desktop`（#16 改名时遗漏），属预存债，本 PR 不顺手处理。

## English

Prep for the **v0.2.0** release: bump `desktop/package.json` from 0.1.0 to 0.2.0 so electron-builder's artifact names / app version match the upcoming `v0.2.0` tag.

**Context**: Epic #18 P0 (T1–T4) is fully merged — installers now bundle the backend jar + trimmed JRE and ship the first-run wizard (double-click usable). This is the last prerequisite before tagging v0.2.0.

**Change**: version only (package.json + lockfile kept in sync), no logic changes.
> Note: the lockfile `name` is still the legacy `checkba-desktop` (missed during the #16 rename) — pre-existing debt, left untouched here.

Refs #18