### PR TITLE
fix(ci): grant contents:write so tag builds can publish the Release / 修复 tag 构建无权创建 Release（403）

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -13,6 +13,13 @@ on:
       - 'desktop/**'
       - 'backend/**'
 
+# The "Attach to GitHub Release" step (softprops/action-gh-release) creates the
+# release for a v* tag, which needs write access to repository contents. The
+# default GITHUB_TOKEN is read-only, so without this the tag build fails with
+# "403 Resource not accessible by integration".
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build (${{ matrix.os }})


### PR DESCRIPTION
## 中文

**问题**：v0.2.0 tag 触发的 Desktop Build 在最后一步 `Attach to GitHub Release` 报 `403 Resource not accessible by integration`——安装包已成功构建、签名、公证、冒烟，但默认的 `GITHUB_TOKEN` 是只读的，`softprops/action-gh-release` 无权创建 Release。

**修复**：在 workflow 顶层加最小权限 `permissions: contents: write`。

**说明**：
- v0.2.0 本次已用维护者本地凭证从这批"已验证产物"手动发布，不受影响；本 PR 是为**以后** tag 自动发版解锁。
- PR 构建不会执行 attach 步骤（`if: tag`），故权限路径要等下一个 tag 才能真正验证。
- 若合并后下个 tag 仍 403，则说明仓库"Workflow permissions"被设为只读且不允许 workflow 提权——届时需在 Settings → Actions 改为 Read and write，或由我用 API 调整。

## English

**Problem**: the v0.2.0 tag build failed at `Attach to GitHub Release` with `403 Resource not accessible by integration`. Installers built/signed/notarized/smoke-tested fine, but the default `GITHUB_TOKEN` is read-only, so `softprops/action-gh-release` cannot create a release.

**Fix**: add minimal `permissions: contents: write` at the workflow top level.

**Notes**:
- v0.2.0 was published manually from the validated artifacts, so this only unblocks **future** tag-driven releases.
- The attach step is skipped on PRs (`if: tag`), so this permission path is only exercised on the next tag.
- If a future tag still 403s, the repo's "Workflow permissions" is set to read-only and disallows elevation — then flip Settings → Actions to Read and write.