### PR TITLE
docs(legal): tighten commercialization terms, brand/certification pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,14 @@ The architecture's plugin surface is designed to accommodate these features. If 
 
 ### Can our firm use AI Workdeck internally without disclosing our modifications?
 
-**Yes, in most cases.** AGPLv3's disclosure obligation is triggered when you *convey* modified software to others — i.e., distribute or provide it as a network service to external users. Internal use within a single firm, even with modifications, generally does not require source code disclosure.
+**Usually yes — with one nuance worth understanding.** AGPLv3 affirms your right to run the software and to modify it for your own use. Running an *unmodified* copy internally creates no source-disclosure obligation. If you *modify* AI Workdeck and then make the modified version available to people over a network — which can include your own lawyers and staff using it as an internal web application — AGPLv3 Section 13 can require you to offer **those users** the corresponding source code of your modified version. That source stays within your firm: you are not required to publish it to the public or to us. If you would rather keep your modifications, plugins, or integrations proprietary and free of any AGPLv3 obligation, a commercial license removes the copyleft requirement entirely.
 
 ### What about the network-use clause (AGPLv3 Section 13)?
 
-This clause applies when you host a modified version as a **network service accessible to external users**. If you deploy AI Workdeck as an internal tool behind your firm's firewall, the network-use clause does not apply. If you create a client-facing portal powered by modified AI Workdeck code, AGPLv3 would require offering the source to those clients.
+Section 13 is triggered by **network interaction with a modified version**, and the people entitled to the corresponding source are the **users of that modified version**. Two common cases:
+
+- **Internal tool behind your firewall (modified).** Your staff are the users. You may need to offer them the corresponding source, but you are not required to disclose it publicly or to us. An unmodified deployment carries no such obligation.
+- **Client-facing portal or external service (modified).** Your clients are the users, and AGPLv3 would require offering them the source of your modified version. If you do not want to do that, a commercial license is the clean path.
 
 ### What about proprietary plugins and extensions?
 
@@ -258,6 +261,8 @@ Commercial licensing is available for:
 - Dedicated enterprise support and implementation assistance
 
 See [LICENSE](legal/LICENSE) and [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md). For commercial licensing, contact [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com).
+
+**AI Workdeck®** is a registered trademark in China (classes 9, 42, 45). Building on the kernel is welcome under the licenses above, but using the **AI Workdeck** name or logo for a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
 
 ## Background
 

--- a/legal/COMMERCIAL-LICENSE.md
+++ b/legal/COMMERCIAL-LICENSE.md
@@ -25,11 +25,25 @@ Please contact our licensing team to discuss your specific use case and pricing:
 - **Email:** hi@aiworkdeck.com
 - **Website:** [www.aiworkdeck.com](https://www.aiworkdeck.com)
 
+## Brand & Certification Programs
+**AI Workdeck®** is a registered trademark (see [`TRADEMARKS.md`](TRADEMARKS.md)). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
+
+| Program | What you get | Indicative annual fee |
+|---|---|---|
+| **Certified Deployment** | Right to advertise a hosted/on-premise deployment as "AI Workdeck Certified", logo usage, priority compatibility testing | from ¥30,000 / year *(indicative)* |
+| **Certified Plugin** | Listing and "Certified for AI Workdeck" badge for a proprietary plugin or integration, compatibility review | from ¥20,000 / year *(indicative)* |
+| **Certified Partner** | Co-marketing, named partner status, referral pipeline, joint solution delivery | Contact for quote |
+
+> Pricing above is indicative and subject to scope. For a formal quote, email **hi@aiworkdeck.com** with your use case, deployment size, and target customers.
+
+Use of the **AI Workdeck®** name or logo in connection with a commercial offering requires one of these programs or a written agreement. See [`TRADEMARKS.md`](TRADEMARKS.md) for permitted nominative use.
+
 ## FAQ
 **Q: Can I use the Community Edition for internal company tools?**
-A: Yes, as long as you comply with AGPLv3. Generally, internal use that isn't exposed to external users doesn't trigger distribution clauses, but you should consult your legal counsel.
+A: Yes, as long as you comply with AGPLv3. Running an unmodified copy internally creates no source-disclosure obligation. If you modify AI Workdeck and make the modified version available to people over a network — including your own staff using it internally — AGPLv3 Section 13 can require you to offer those users the corresponding source of your modified version (it stays within your organization; it need not be published). A commercial license removes this obligation entirely. For your specific facts, consult your legal counsel.
 
-A: If the plugin runs in the same process and relies on the kernel, it may be subject to AGPLv3 viral effects. If you want to keep your plugin proprietary while selling a service based on it, a Commercial License is recommended.
+**Q: Can I build proprietary plugins or extensions?**
+A: Under AGPLv3 the answer depends on coupling. The current architecture runs plugins **in the same process** as the kernel, so a plugin that depends on the kernel may be treated as part of the same covered work and subject to AGPLv3's copyleft. If you want to keep a plugin or integration proprietary — or sell a service built on it — a Commercial License gives you a clean legal basis to do so.
 
-**Q: I want to copy the "IDE for Documents" workflow and logic but rewrite the code. Can I do that closed-source?**
-A: **Likely No.** We consider the specific Structure, Sequence, and Organization (SSO) of our IDE workflow to be a protected part of the software's expression. If your product is substantially similar in *function, logic flow, and user experience* to AI Workdeck (a "clone"), we assert that you are creating a derivative work of our protected design. You should acquire a Commercial License to avoid legal ambiguity and potential infringement claims regarding Trade Dress and Copyright in the software's structure.
+**Q: I want to reimplement the "IDE for Documents" workflow and logic from scratch, with my own code. Do I need a license?**
+A: **It depends on what you actually copy.** Copyright does not protect general ideas, workflows, or methods of operation, so you are free to independently implement broad concepts such as a document-centric workspace. However, copying AI Workdeck's source code, documentation, distinctive UI expression, visual assets, naming, logos, or producing a substantially similar product presentation that causes marketplace confusion may infringe our copyright, trademark, trade dress, or unfair-competition rights. If your product would closely track AI Workdeck's specific expression — its code, its distinctive interaction design, or its look and feel — acquire a Commercial License or talk to us first to avoid a dispute.

--- a/legal/TRADEMARKS.md
+++ b/legal/TRADEMARKS.md
@@ -4,13 +4,14 @@
 The purpose of this policy is to balance the interests of the open-source community with the need to protect the **AI Workdeck** brand and reputation. We want you to feel free to hack on the code, but we must prevent confusion in the marketplace.
 
 ## 2. Product Name
-**AI Workdeck** and **AI Workdeck Kernel** are trademarks of the project maintainers.
+**AI Workdeck®** and **AI Workdeck Kernel** are registered trademarks of the project maintainers in the People's Republic of China, including Nice Classification classes 9 (software), 42 (SaaS / software services), and 45 (legal services). Unauthorized commercial use of these marks may infringe our registered trademark rights.
 
 ## 3. Trade Dress & Look and Feel
-In addition to the name, the **distinctive visual appearance and user experience (UK/UI) flow** of the AI Workdeck IDE constitutes our **Trade Dress**.
+In addition to the name, the **distinctive visual appearance and user experience (UX/UI) flow** of the AI Workdeck IDE constitutes our **Trade Dress**.
 
 *   This includes the specific layout of the document panels, the clipboard card interaction model, and the visual integration of the AI chat context.
 *   You **MAY NOT** create a "look-alike" product that mimics the visual identity or interaction flow of AI Workdeck to the point where it creates confusion, even if you change the name.
+*   You **MAY** independently build a product around the same general ideas or workflows — copyright and trademark do not reserve general concepts. What is protected is our specific *expression*: our code, distinctive UI, visual assets, name, and look and feel.
 *   If you fork the project, we encourage you to significantly alter the visual theme (CSS) and layout to distinguish your project.
 
 ## 4. Usage Guidelines
@@ -26,7 +27,7 @@ You **MAY NOT** use the Marks in a way that suggests affiliation, endorsement, o
 - **Domain Names:** You may not register domains containing "aiworkdeck" (e.g., `aiworkdeck-hosting.com`).
 - **Logos:** You may not use the official logo on your own commercial website or product packaging without written permission.
 
-## 5. Rebranding Requirement for Forks
+## 6. Rebranding Requirement for Forks
 If you create a "fork" of this software and publish it (whether free or commercial):
 1.  You **MUST** change the name of the software to something completely different.
 2.  You **MUST** replace the official logos with your own.
@@ -34,5 +35,5 @@ If you create a "fork" of this software and publish it (whether free or commerci
 
 *Example: If you fork the code to build a SaaS called "DocuFlow", you must replace "AI Workdeck" with "DocuFlow" in the UI string resources.*
 
-## 6. Questions?
+## 7. Questions?
 If you are unsure whether your intended use is allowed, please start a discussion via hi@aiworkdeck.com. We are generally friendly to community projects, but we must protect the commercial viability of the name.


### PR DESCRIPTION
## What

Commercialization/legal docs tuning for AI Workdeck.

- **README / COMMERCIAL-LICENSE**: corrected the AGPLv3 law-firm FAQ so Section 13's scope (network interaction with a *modified* version, source owed to *those users*) is accurate; removed an orphaned FAQ answer; downgraded the overclaim that copying general ideas/workflows is infringement — now distinguishes unprotectable ideas from protected expression.
- **TRADEMARKS**: marked **AI Workdeck®** as a registered trademark in China (Nice classes 9 / 42 / 45); fixed duplicate section numbering and a `UK/UI` → `UX/UI` typo.
- **COMMERCIAL-LICENSE**: added a **Brand & Certification Programs** section with indicative pricing and contact path.

## Notes

- Certification prices are indicative placeholders — to be finalized.
- Trademark classes listed as 9/42/45; add 35/41 if also registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)