### PR TITLE
docs(legal): correct trademark classes (9/35/42), drop certification pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Commercial licensing is available for:
 
 See [LICENSE](legal/LICENSE) and [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md). For commercial licensing, contact [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com).
 
-**AI Workdeck®** is a registered trademark in China (classes 9, 42, 45). Building on the kernel is welcome under the licenses above, but using the **AI Workdeck** name or logo for a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
+**AI Workdeck®** is a registered trademark in China (classes 9, 35, 42). Building on the kernel is welcome under the licenses above, but using the **AI Workdeck** name or logo for a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
 
 ## Background
 

--- a/legal/COMMERCIAL-LICENSE.md
+++ b/legal/COMMERCIAL-LICENSE.md
@@ -28,13 +28,13 @@ Please contact our licensing team to discuss your specific use case and pricing:
 ## Brand & Certification Programs
 **AI Workdeck®** is a registered trademark (see [`TRADEMARKS.md`](TRADEMARKS.md)). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
 
-| Program | What you get | Indicative annual fee |
-|---|---|---|
-| **Certified Deployment** | Right to advertise a hosted/on-premise deployment as "AI Workdeck Certified", logo usage, priority compatibility testing | from ¥30,000 / year *(indicative)* |
-| **Certified Plugin** | Listing and "Certified for AI Workdeck" badge for a proprietary plugin or integration, compatibility review | from ¥20,000 / year *(indicative)* |
-| **Certified Partner** | Co-marketing, named partner status, referral pipeline, joint solution delivery | Contact for quote |
+| Program | What you get |
+|---|---|
+| **Certified Deployment** | Right to advertise a hosted/on-premise deployment as "AI Workdeck Certified", logo usage, priority compatibility testing |
+| **Certified Plugin** | Listing and "Certified for AI Workdeck" badge for a proprietary plugin or integration, compatibility review |
+| **Certified Partner** | Co-marketing, named partner status, referral pipeline, joint solution delivery |
 
-> Pricing above is indicative and subject to scope. For a formal quote, email **hi@aiworkdeck.com** with your use case, deployment size, and target customers.
+> For program details and pricing, email **hi@aiworkdeck.com** with your use case, deployment size, and target customers.
 
 Use of the **AI Workdeck®** name or logo in connection with a commercial offering requires one of these programs or a written agreement. See [`TRADEMARKS.md`](TRADEMARKS.md) for permitted nominative use.
 

--- a/legal/TRADEMARKS.md
+++ b/legal/TRADEMARKS.md
@@ -4,7 +4,7 @@
 The purpose of this policy is to balance the interests of the open-source community with the need to protect the **AI Workdeck** brand and reputation. We want you to feel free to hack on the code, but we must prevent confusion in the marketplace.
 
 ## 2. Product Name
-**AI Workdeck®** and **AI Workdeck Kernel** are registered trademarks of the project maintainers in the People's Republic of China, including Nice Classification classes 9 (software), 42 (SaaS / software services), and 45 (legal services). Unauthorized commercial use of these marks may infringe our registered trademark rights.
+**AI Workdeck®** and **AI Workdeck Kernel** are registered trademarks of the project maintainers in the People's Republic of China, including Nice Classification classes 9 (software), 35 (business services), and 42 (SaaS / software services). Unauthorized commercial use of these marks may infringe our registered trademark rights.
 
 ## 3. Trade Dress & Look and Feel
 In addition to the name, the **distinctive visual appearance and user experience (UX/UI) flow** of the AI Workdeck IDE constitutes our **Trade Dress**.


### PR DESCRIPTION
## What

- Correct China trademark classes to **9, 35, 42** (was 9/42/45) across README and TRADEMARKS.
- Brand & Certification Programs: **remove indicative pricing**, keep contact only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)