### PR TITLE
fix(ci): trigger Desktop Build on frontend/** changes / 桌面构建监听 frontend/** 改动

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -12,6 +12,11 @@ on:
       - '.github/workflows/desktop-build.yml'
       - 'desktop/**'
       - 'backend/**'
+      # Installers bundle the built frontend (frontend/dist), so frontend-only
+      # changes affect the installer too and must run the build + smoke test.
+      # Without this, the first-run wizard (PR #25, frontend-only) shipped to
+      # v0.2.0 having never been validated inside an installer. See issue #27.
+      - 'frontend/**'
 
 # The "Attach to GitHub Release" step (softprops/action-gh-release) creates the
 # release for a v* tag, which needs write access to repository contents. The


### PR DESCRIPTION
## 中文

修复 #27。

`desktop-build.yml` 的 `pull_request.paths` 此前只含 `desktop/**`、`backend/**` 和 workflow 自身，**漏了 `frontend/**`**。但安装包会把前端构建产物（`frontend/dist`）打进去，所以纯前端改动同样影响安装包。

**后果（已发生）**：首次运行向导（PR #25，纯前端）从未在 PR 阶段触发桌面构建与冒烟测试——它第一次进安装包是发版打 v0.2.0 tag 时，集成验证整整晚了一步。

**改动**：把 `frontend/**` 加入 `pull_request.paths`，让前端 PR 也跑安装包构建+冒烟，把"向导能否在打包应用里真正启动"挡在合并前。

**成本权衡**：每个前端 PR 会多跑一次 ~25 分钟的 mac/win 构建。前端 PR 是社区最常见的贡献类型，但当前 PR 量低、且这正是安装包集成风险所在，正确性优先。若日后 CI 成本变重，可改为 label 门控（如 `needs-desktop-build`），#27 已记录此后备方案。

## English

Fixes #27.

`desktop-build.yml`'s `pull_request.paths` listed only `desktop/**`, `backend/**` and the workflow itself — it **omitted `frontend/**`**. But installers bundle the built frontend (`frontend/dist`), so frontend-only changes affect the installer too.

**Consequence (already happened)**: the first-run wizard (PR #25, frontend-only) never triggered a desktop build or smoke test at PR time — it first entered an installer at the v0.2.0 release tag, one step too late for integration validation.

**Change**: add `frontend/**` to `pull_request.paths` so frontend PRs run the installer build + smoke test, gating "does the wizard actually boot inside the packaged app" before merge.

**Cost tradeoff**: each frontend PR now runs a ~25-min mac/win build. Frontend PRs are the most common community contribution, but PR volume is low and this is exactly where installer-integration risk lives — correctness first. If CI cost becomes a problem, gate behind a label (e.g. `needs-desktop-build`); #27 records this fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)