### PR TITLE
feat: graceful "not configured" degradation for OCR/TTS/WPS / 可选功能未配置时优雅降级（#18 T5–T7）

### DIFF
--- a/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.checkba.config;
 
+import com.checkba.exception.FeatureNotConfiguredException;
 import com.checkba.exception.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,23 @@ public class GlobalExceptionHandler {
         result.put("code", 1);
         result.put("message", e.getMessage() != null ? e.getMessage() : "请先登录");
         // 统一返回 HTTP 200，通过 code 字段表示失败
+        return ResponseEntity.ok().body(result);
+    }
+
+    /**
+     * 功能未配置：返回可识别的 code=4001 + feature 字段，前端据此引导"去设置"
+     * 而非显示通用报错。/ Feature not configured — return a recognizable
+     * code=4001 with a feature id so the frontend can prompt "go to settings".
+     */
+    @ExceptionHandler(FeatureNotConfiguredException.class)
+    public ResponseEntity<Map<String, Object>> handleFeatureNotConfigured(FeatureNotConfiguredException e) {
+        log.info("Feature not configured [{}]: {}", e.getFeature(), e.getMessage());
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 4001);
+        result.put("feature", e.getFeature());
+        result.put("configured", false);
+        result.put("message", e.getMessage());
+        // 统一返回 HTTP 200，通过 code=4001 表示"功能未配置"
         return ResponseEntity.ok().body(result);
     }
 

--- a/backend/src/main/java/com/checkba/controller/WpsApiController.java
+++ b/backend/src/main/java/com/checkba/controller/WpsApiController.java
@@ -1,5 +1,6 @@
 package com.checkba.controller;
 
+import com.checkba.exception.FeatureNotConfiguredException;
 import com.checkba.service.WpsService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,11 @@ public class WpsApiController {
      */
     private static final String DEFAULT_USER_ID = "1780305141";
 
+    /** WPS 未配置时的双语提示，前端据 code=4001 降级为只读预览（#18 T6）。 */
+    private static final String WPS_NOT_CONFIGURED_MSG =
+            "文档编辑未配置：请在设置中配置 WPS WebOffice / "
+                    + "Document editing is not configured: set up WPS WebOffice in Settings.";
+
     @Autowired
     private WpsService wpsService;
 
@@ -42,6 +48,10 @@ public class WpsApiController {
             Map<String, Object> error = new HashMap<>();
             error.put("error", "fileId is required");
             return ResponseEntity.badRequest().body(error);
+        }
+
+        if (!wpsService.isConfigured()) {
+            throw new FeatureNotConfiguredException("wps", WPS_NOT_CONFIGURED_MSG);
         }
 
         String editUrl = wpsService.generateEditUrl(fileId, fileName, mode);
@@ -81,6 +91,10 @@ public class WpsApiController {
             Map<String, Object> error = new HashMap<>();
             error.put("error", "fileId is required");
             return ResponseEntity.badRequest().body(error);
+        }
+
+        if (!wpsService.isConfigured()) {
+            throw new FeatureNotConfiguredException("wps", WPS_NOT_CONFIGURED_MSG);
         }
 
         long timestamp = System.currentTimeMillis() / 1000;

--- a/backend/src/main/java/com/checkba/exception/FeatureNotConfiguredException.java
+++ b/backend/src/main/java/com/checkba/exception/FeatureNotConfiguredException.java
@@ -1,0 +1,28 @@
+package com.checkba.exception;
+
+/**
+ * 功能未配置异常 / Feature-not-configured exception.
+ *
+ * <p>当某个可选功能（OCR / TTS / WPS 文档编辑等）所需的密钥或配置缺失时抛出。
+ * 全局异常处理器会把它转成 {@code {code: 4001, feature, message, configured: false}}
+ * 的结构化响应（HTTP 200），前端据此引导用户"去设置"而非显示通用报错。
+ *
+ * <p>Thrown when an optional feature (OCR / TTS / WPS document editing, etc.) is
+ * missing its required keys or configuration. The global handler maps it to a
+ * recognizable {@code {code: 4001, feature, ...}} response so the frontend can
+ * prompt the user to configure it instead of surfacing a generic error.
+ */
+public class FeatureNotConfiguredException extends RuntimeException {
+
+    /** 功能标识，如 "ocr" / "tts" / "wps"，供前端定位设置项。 */
+    private final String feature;
+
+    public FeatureNotConfiguredException(String feature, String message) {
+        super(message);
+        this.feature = feature;
+    }
+
+    public String getFeature() {
+        return feature;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/OcrService.java
+++ b/backend/src/main/java/com/checkba/service/OcrService.java
@@ -1,5 +1,6 @@
 package com.checkba.service;
 
+import com.checkba.exception.FeatureNotConfiguredException;
 import com.checkba.service.ocr.AliyunOcrClientFactory;
 import com.checkba.service.ocr.OcrResult;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +56,9 @@ public class OcrService {
         regionId = regionId == null ? "" : regionId.trim();
 
         if (!StringUtils.hasText(ak) || !StringUtils.hasText(sk)) {
-            throw new IllegalArgumentException("OCR 未配置：请在管理面板配置阿里云 OCR AccessKey");
+            throw new FeatureNotConfiguredException("ocr",
+                    "OCR 未配置：请在设置中配置阿里云 OCR AccessKey / "
+                            + "OCR is not configured: set up Aliyun OCR keys in Settings.");
         }
 
         // 脱敏诊断：只打印长度与尾号，定位“secret 为空/带空格/不成对”

--- a/backend/src/main/java/com/checkba/service/TtsService.java
+++ b/backend/src/main/java/com/checkba/service/TtsService.java
@@ -1,5 +1,6 @@
 package com.checkba.service;
 
+import com.checkba.exception.FeatureNotConfiguredException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -114,6 +115,13 @@ public class TtsService {
      * @param volume Unused (ElevenLabs uses different settings)
      */
     public File generateAudio(String text, String voiceId, String rate, String pitch, String volume) {
+        // 未配置 TTS 密钥时直接返回"功能未配置"，前端引导去设置（#18 T5）
+        String configuredApiKey = systemSettingService.get("external.elevenlabs.apiKey", defaultApiKey);
+        if (configuredApiKey == null || configuredApiKey.isBlank()) {
+            throw new FeatureNotConfiguredException("tts",
+                    "语音合成未配置：请在设置中配置 ElevenLabs TTS / "
+                            + "Text-to-speech is not configured: set up ElevenLabs in Settings.");
+        }
         try {
             String baseUrl = systemSettingService.get("external.elevenlabs.baseUrl", defaultBaseUrl);
             String apiKey = systemSettingService.get("external.elevenlabs.apiKey", defaultApiKey);

--- a/backend/src/main/java/com/checkba/service/WpsService.java
+++ b/backend/src/main/java/com/checkba/service/WpsService.java
@@ -56,6 +56,17 @@ public class WpsService {
     }
 
     /**
+     * WPS 文档编辑是否已配置（appId 与 appSecret 均非空）。
+     * 未配置时前端应降级为只读预览而非加载编辑器（#18 T6）。
+     */
+    public boolean isConfigured() {
+        String appId = getAppId();
+        String appSecret = getAppSecret();
+        return appId != null && !appId.isBlank()
+                && appSecret != null && !appSecret.isBlank();
+    }
+
+    /**
      * 生成 WPS 在线编辑链接（URL 直连方案预留）
      */
     public String generateEditUrl(String fileId, String fileName, String mode) {

--- a/frontend/src/components/EasyVoicePane.vue
+++ b/frontend/src/components/EasyVoicePane.vue
@@ -161,7 +161,7 @@
 </template>
 
 <script>
-import { getTtsVoices, generateTtsAudio } from '@/services/api.js'
+import { getTtsVoices, generateTtsAudio, promptFeatureNotConfigured } from '@/services/api.js'
 
 export default {
   name: 'EasyVoicePane',
@@ -418,7 +418,12 @@ export default {
 
       } catch (e) {
         console.error('[EasyVoicePane] Generation failed', e)
-        uni.showToast({ title: '生成失败', icon: 'none' })
+        if (e && e.featureNotConfigured) {
+          // TTS 未配置：引导去设置而非报"生成失败"（#18 T7）
+          promptFeatureNotConfigured(e)
+        } else {
+          uni.showToast({ title: '生成失败', icon: 'none' })
+        }
       } finally {
         this.generating = false
       }

--- a/frontend/src/components/WpsEditor.vue
+++ b/frontend/src/components/WpsEditor.vue
@@ -17,6 +17,15 @@
           重试
         </button>
       </view>
+
+      <!-- WPS 未配置：降级为只读占位 + 去设置，替代白屏/500（#18 T6） -->
+      <view v-else-if="notConfigured" class="wps-status-overlay wps-not-configured">
+        <text class="error-text">文档在线编辑需配置 WPS WebOffice，当前暂不可编辑。</text>
+        <text class="error-text">Online editing requires WPS WebOffice (not configured).</text>
+        <button type="primary" size="mini" @tap="goToSettings" style="margin-top: 16rpx;">
+          去设置 / Configure
+        </button>
+      </view>
     </view>
   </view>
 </template>
@@ -96,6 +105,8 @@ export default {
     return {
       loading: false,
       error: null,
+      // WPS 未配置时降级为只读占位（#18 T6）
+      notConfigured: false,
       instance: null,
       // 自动生成容器 ID，避免多个组件实例冲突
       generatedContainerId: null,
@@ -185,6 +196,7 @@ export default {
 
       this.loading = true
       this.error = null
+      this.notConfigured = false
 
       try {
         // 1. 创建会话获取 token
@@ -198,6 +210,14 @@ export default {
             token = session.token
           }
         } catch (e) {
+          if (e && e.featureNotConfigured) {
+            // WPS 未配置：降级为只读占位，不再尝试初始化编辑器（否则白屏/报错）（#18 T6）
+            console.warn('WPS 未配置，降级为只读占位:', e)
+            this.loading = false
+            this.notConfigured = true
+            this.$emit('not-configured', e)
+            return
+          }
           console.warn('创建 WPS 会话失败，将使用空 token:', e)
           // 不阻断流程，允许在无 token 情况下继续
         }
@@ -436,6 +456,13 @@ export default {
     handleRetry() {
       this.destroy()
       this.load()
+    },
+
+    /**
+     * 跳转到设置页配置 WPS（#18 T6 未配置降级时使用）
+     */
+    goToSettings() {
+      uni.navigateTo({ url: '/pages/admin/admin' })
     },
 
     /**

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1231,7 +1231,8 @@ import {
   getPlugins, // Added
   sendWpsResult, // WPS 操作结果回调
   getWpsConfig, // WPS 配置获取
-  getFileText
+  getFileText,
+  promptFeatureNotConfigured // 功能未配置统一引导（#18 T7）
 } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
 import { FILE_BATCH_ACTIONS, FILE_TREE_QUICK_ACTIONS } from '@/config/fileActions.js'
@@ -3856,7 +3857,12 @@ export default {
         }
       } catch (e) {
         console.error('OCR 识别失败:', e)
-        uni.showToast({ title: e.message || '识别失败', icon: 'none' })
+        if (e && e.featureNotConfigured) {
+          // OCR 未配置：引导去设置而非报"识别失败"（#18 T7）
+          promptFeatureNotConfigured(e)
+        } else {
+          uni.showToast({ title: e.message || '识别失败', icon: 'none' })
+        }
       } finally {
         uni.hideLoading()
       }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,6 +6,26 @@
 // 导入认证工具
 import { getAuthHeaders, getSessionId } from '@/utils/auth.js'
 
+/**
+ * 功能未配置时的统一引导（#18 T7）。
+ * 调用方在 catch 到 err.featureNotConfigured 时调用，弹出"去设置"引导而非通用报错。
+ * @param {Error} err request() reject 出的错误，带 featureNotConfigured / feature / message
+ */
+export function promptFeatureNotConfigured(err) {
+  const message = (err && err.message) || '该功能尚未配置，请在设置中补充';
+  uni.showModal({
+    title: '功能未配置 / Not configured',
+    content: message,
+    confirmText: '去设置',
+    cancelText: '稍后',
+    success: (r) => {
+      if (r.confirm) {
+        uni.navigateTo({ url: '/pages/admin/admin' });
+      }
+    },
+  });
+}
+
 // 默认后端地址：
 // - 本地 H5 开发（localhost/127.0.0.1）：自动指向后端 9696
 // - 其他环境：可通过 VITE_API_BASE_URL 覆盖；否则使用默认网关地址
@@ -176,11 +196,35 @@ function request(options) {
           return;
         }
 
+        // 以 arraybuffer 接收却实际返回 JSON 时（如 TTS 未配置 → {code:4001}），
+        // 按 content-type 解码为对象，让下面的统一 {code} 逻辑能识别（#18 T5/T7）。
+        if (options.responseType === 'arraybuffer' && res.data && typeof res.data.byteLength === 'number') {
+          const h = res.header || {};
+          const ct = h['content-type'] || h['Content-Type'] || '';
+          if (ct.indexOf('application/json') !== -1) {
+            try {
+              res.data = JSON.parse(new TextDecoder('utf-8').decode(new Uint8Array(res.data)));
+            } catch (e) {
+              console.warn('arraybuffer JSON 解码失败:', e);
+            }
+          }
+        }
+
         // 统一处理后端返回的 { code: 0, data: ... } 或 { code: 1, message: ... } 格式
         if (res.data && typeof res.data.code !== 'undefined') {
           if (res.data.code === 0) {
             // 成功：code=0
             resolve(res.data);
+          } else if (res.data.code === 4001) {
+            // 功能未配置（#18 T7）：reject 时带 featureNotConfigured 标记，
+            // 由调用方决定如何引导（弹"去设置" / 降级为只读），避免在拦截器
+            // 层强弹全局弹窗导致打开文档时反复打扰。
+            const msg = res.data.message || '该功能尚未配置，请在设置中补充';
+            console.warn('功能未配置:', { feature: res.data.feature, message: msg });
+            const err = new Error(msg);
+            err.featureNotConfigured = true;
+            err.feature = res.data.feature || '';
+            reject(err);
           } else {
             // 业务失败：code=1 或其他非0值
             const errorMessage = res.data.message || '服务异常，请稍后重试'


### PR DESCRIPTION
## 中文

实现 Epic #18 的 **P1：T5 + T6 + T7**。

### 问题
可选功能（OCR / TTS / WPS 文档编辑）未配置密钥时，过去直接抛裸异常 → 外显 500 / 通用报错。对刚装好的 v0.2.0（向导跳过、或高级密钥留空）的用户来说，第一次用这些功能就报错，而不是被引导去配置——伤"双击可用"的第一印象。

### 方案：统一"功能未配置"契约
后端抛 `FeatureNotConfiguredException(feature)`，全局处理器映射成**可识别的结构化响应**（沿用项目既有 `{code}` 约定，HTTP 200）：
```json
{ "code": 4001, "feature": "ocr|tts|wps", "configured": false, "message": "<双语友好文案>" }
```
前端据 `code===4001` 引导用户"去设置"，而非显示报错。

### 改动
**后端（T5）**
- 新增 `FeatureNotConfiguredException`；`GlobalExceptionHandler` 加专用处理器 → `{code:4001, feature, configured:false, message}`。
- `OcrService`：未配置时改抛该异常（原为通用 `IllegalArgumentException`）。
- `TtsService.generateAudio`：前置校验密钥，未配置即抛该异常。
- `WpsService.isConfigured()`；`WpsApiController` 的 `/session` 与 `/generate-url` 前置守卫。

**前端（T6/T7）**
- `api.js`：识别 `code===4001`，reject 时带 `err.featureNotConfigured` 标记交由调用方处理（不在拦截器强弹全局弹窗，避免打开文档时反复打扰）；并对**以 arraybuffer 接收实为 JSON** 的响应（TTS）按 content-type 解码，确保信号不丢。导出 `promptFeatureNotConfigured()`（"去设置"弹窗 → `/pages/admin/admin`）。
- OCR / TTS 调用方：未配置时弹"去设置"而非"识别失败/生成失败"toast（T7）。
- `WpsEditor.vue`：未配置时降级为**只读占位 + 去设置按钮**，替代白屏/坏编辑器（T6）。

### 验证
- ✅ 后端 `mvn compile`（JDK 21）BUILD SUCCESS；前端 `npm run build:h5` Build complete（仅 Sass 弃用警告）。
- ✅ 干净 desktop-profile H2（无任何配置）实测：
  - `POST /api/wps/session` → `{code:4001,feature:wps,configured:false,...}`
  - `POST /api/wps/generate-url` → 同上
  - `POST /api/tts/generate` → `{code:4001,feature:tts,...}`，且响应头 `Content-Type: application/json`（证实前端 arraybuffer 解码分支能捕获）
  - `POST /api/ocr/recognize`（无登录）→ 401，接线正常；配置后走同一已验证的 4001 机制

### 说明
T6 的"只读预览"在编辑器组件里以**清晰的未配置占位 + 去设置**落地（消除 500/白屏）；若日后要真正渲染只读文档内容，可在已有 `FilePreview.vue` 的文本/PDF 预览路径上扩展，属后续增强。

## English

Implements Epic #18 **P1: T5 + T6 + T7** — graceful degradation when optional features (OCR / TTS / WPS document editing) are unconfigured.

### Problem
Unconfigured optional features threw raw exceptions → 500 / generic error. A freshly installed v0.2.0 (wizard skipped, or advanced keys left blank) would error on first use instead of guiding the user to configure — hurting the "works on double-click" first impression.

### Approach: one "feature not configured" contract
Backend throws `FeatureNotConfiguredException(feature)`; the global handler maps it to a recognizable structured response (reusing the existing `{code}` convention, HTTP 200):
```json
{ "code": 4001, "feature": "ocr|tts|wps", "configured": false, "message": "<bilingual>" }
```
The frontend recognizes `code===4001` and prompts "go to settings" instead of erroring.

### Changes
**Backend (T5):** new `FeatureNotConfiguredException`; handler in `GlobalExceptionHandler`; `OcrService` throws it; `TtsService.generateAudio` checks the key upfront; `WpsService.isConfigured()` + guards in `WpsApiController` (`/session`, `/generate-url`).

**Frontend (T6/T7):** `api.js` detects `code===4001`, rejects with `err.featureNotConfigured` (callers decide — no intrusive global modal in the interceptor) and decodes arraybuffer-but-JSON responses (TTS) so the signal survives; exports `promptFeatureNotConfigured()` (a "go to settings" modal). OCR/TTS callers prompt go-to-settings instead of a failure toast (T7). `WpsEditor.vue` degrades to a read-only placeholder with a go-to-settings button instead of a broken editor / white screen (T6).

### Verification
`mvn compile` (JDK 21) and `npm run build:h5` both pass. Ran the backend on a clean desktop-profile H2: `/api/wps/session`, `/api/wps/generate-url`, `/api/tts/generate` all return `code:4001` with the correct `feature`; the TTS error carries `Content-Type: application/json` so the frontend decode path catches it; `/api/ocr/recognize` returns 401 without auth (wired correctly), and goes through the same verified 4001 path once authenticated.

### Note
T6's "read-only preview" lands as a clear not-configured placeholder + go-to-settings in the editor component (removing the 500/white screen). Truly rendering read-only document content can build on the existing `FilePreview.vue` text/PDF paths as a later enhancement.

Refs #18 (P1: T5, T6, T7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)