### PR TITLE
chore(desktop): bump version to 0.2.1 / 桌面端版本号升至 0.2.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 中文
发版前置：把 `desktop/package.json` + lockfile 版本号从 0.2.0 升到 0.2.1（electron-builder 按它命名产物）。

v0.2.1 内容：
- #18 P1 优雅降级（未配置 OCR/TTS/WPS 引导去设置而非 500，#32）；
- 顺带验证 #28 的 release 权限修复——下个 tag 构建应能自动建 Release（上次因 `GITHUB_TOKEN` 只读报 403、走了手动兜底）。

合并后打 `v0.2.1` tag 触发 Desktop Build 出签名安装包并建 Release。

## English
Pre-release version bump (0.2.0 → 0.2.1) in `desktop/package.json` + lockfile. v0.2.1 ships the #18 P1 graceful-degradation work (#32) and will verify the #28 release-permission fix on the tag build (last release hit a 403 and used a manual workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)