### PR TITLE
fix(wizard): 提示本地 Ollama 用户首次运行需拉取的模型 / tell local-Ollama users which model to pull

### DIFF
--- a/frontend/src/pages/wizard/wizard.vue
+++ b/frontend/src/pages/wizard/wizard.vue
@@ -35,6 +35,10 @@
               </text>
             </view>
             <text class="provider-desc">{{ opt.desc }}</text>
+            <view v-if="form.ai.activeProvider === opt.value && opt.setupHint" class="provider-setup">
+              <text class="setup-line">{{ opt.setupHint }}</text>
+              <text class="setup-cmd" selectable>{{ opt.setupCmd }}</text>
+            </view>
             <view v-if="form.ai.activeProvider === opt.value && opt.keyField" class="provider-key">
               <input
                 class="text-input"
@@ -160,6 +164,8 @@ export default {
           local: true,
           desc: '零密钥、零费用，对话数据全程不离开本机。需先在本机安装并启动 Ollama（ollama.com）。',
           keyField: null,
+          setupHint: '安装并启动 Ollama 后，请在终端拉取本产品使用的模型（约 6GB，首次对话前必须完成）：',
+          setupCmd: 'ollama pull qwen3-vl:8b',
         },
         {
           value: 'OPENROUTER',
@@ -484,6 +490,34 @@ export default {
 
 .provider-key {
   margin-top: 10px;
+}
+
+.provider-setup {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #f0fdf4;
+  border: 1px dashed rgba(22, 101, 52, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.setup-line {
+  font-size: 12px;
+  color: #166534;
+  line-height: 1.6;
+}
+
+.setup-cmd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  color: #0f172a;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 6px;
+  padding: 6px 10px;
+  user-select: all;
 }
 
 .compliance-note {


### PR DESCRIPTION
## 中文

**问题**：首次运行向导主打的旗舰路径是「本地 Ollama」（零密钥、`数据不出本机`的差异化卖点）。但一个真正的新用户装好 Ollama、走完向导后，**没有任何地方告诉他还需要拉取后端实际使用的模型** `qwen3-vl:8b`——该模型名在 `application.yml` 中写死、且不可由向导/管理后台运行时覆盖（`ChatModelFactory` 直接读 `ai.model.ollama.model-name`）。结果：用户完成设置后首次对话因模型未拉取而静默失败，正好砸在最该顺滑的零成本入口上。

**改动**：当选中「本地 Ollama」时，展示一个醒目提示框，给出**确切的拉取命令** `ollama pull qwen3-vl:8b`（可一键选中复制）并标注约 6GB、首次对话前必须完成。纯前端文案/展示改动，不触碰任何后端行为。

**验证**：`npm run build:h5` 通过；提示框仅在 Ollama 被选中时出现，云端提供商（OpenRouter/Gemini）不受影响。

## English

**Problem**: The first-run wizard's headline option is local Ollama (zero-key, `data never leaves your machine`). But a fresh user who installs Ollama and finishes the wizard is **never told to pull the model the backend actually uses**, `qwen3-vl:8b` — the model name is fixed in `application.yml` and is not runtime-overridable via the wizard/admin (`ChatModelFactory` reads `ai.model.ollama.model-name` directly). So the first chat fails silently on the very path that should be the smoothest.

**Change**: When the local-Ollama provider is selected, show a callout with the exact pull command `ollama pull qwen3-vl:8b` (selectable to copy) plus the ~6GB / pull-before-first-chat note. Frontend copy/display only; no backend behavior change.

**Verification**: `npm run build:h5` passes; the callout appears only when Ollama is selected; cloud providers (OpenRouter/Gemini) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)