### PR TITLE
fix(preview): PDF 本地原生预览，与 WPS 解耦 / render PDF locally without WPS (#36)

### DIFF
--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -40,13 +40,13 @@
           />
         </view>
 
-        <!-- PDF 预览 -->
+        <!-- PDF 预览：本地 blob 由浏览器/Electron 内置 PDF 引擎原生渲染，数据不出本机（#36） -->
         <view v-else-if="isPdf" class="preview-pdf">
           <!-- #ifdef H5 -->
-          <iframe :src="pdfViewerUrl" class="preview-iframe" frameborder="0"></iframe>
+          <iframe v-if="blobUrl" :src="blobUrl" class="preview-iframe" frameborder="0"></iframe>
           <!-- #endif -->
           <!-- #ifndef H5 -->
-          <web-view :src="pdfViewerUrl" />
+          <web-view v-if="blobUrl" :src="blobUrl" />
           <!-- #endif -->
         </view>
 
@@ -147,14 +147,14 @@ export default {
       return url
     },
     isPdf() {
-      // PDF is now handled by isOffice (WpsEditor)
-      return false
+      // PDF 走本地原生渲染（fetch 成 blob → Chromium/Electron 内置 PDF 引擎），无需 WPS（#36）
+      if (!this.file || !this.file.fileType) return false
+      return this.file.fileType.toLowerCase() === 'pdf'
     },
     isOffice() {
       if (!this.file || !this.file.fileType) return false
       const type = this.file.fileType.toLowerCase()
-      // Create 'pdf' as an office type to be handled by WpsEditor
-      return ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'pdf'].includes(type)
+      return ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx'].includes(type)
     },
     isImage() {
       if (!this.file || !this.file.fileType) return false
@@ -186,16 +186,6 @@ export default {
       if (!this.file || !this.file.fileType) return false
       const type = this.file.fileType.toLowerCase()
       return ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx'].includes(type) && !!this.file.wpsFileId
-    },
-    pdfViewerUrl() {
-      // 使用 PDF.js 预览
-      const pdfUrl = encodeURIComponent(this.fileUrl)
-      return `https://mozilla.github.io/pdf.js/web/viewer.html?file=${pdfUrl}`
-    },
-    officeViewerUrl() {
-      // 使用 Office Online 预览
-      const fileUrl = encodeURIComponent(this.fileUrl)
-      return `https://view.officeapps.live.com/op/view.aspx?src=${fileUrl}`
     }
   },
   watch: {
@@ -213,7 +203,7 @@ export default {
 
         if (this.isText) {
           this.loadTextContent()
-        } else if (this.isImage || this.isVideo || this.isAudio) {
+        } else if (this.isImage || this.isVideo || this.isAudio || this.isPdf) {
            this.loadMediaResource()
         }
       }
@@ -318,6 +308,7 @@ export default {
             'webp': 'image/webp',
             'svg': 'image/svg+xml',
             'bmp': 'image/bmp',
+            'pdf': 'application/pdf',
             'mp4': 'video/mp4',
             'webm': 'video/webm',
             'ogg': 'video/ogg',

--- a/frontend/src/pages/wizard/wizard.vue
+++ b/frontend/src/pages/wizard/wizard.vue
@@ -35,6 +35,10 @@
               </text>
             </view>
             <text class="provider-desc">{{ opt.desc }}</text>
+            <view v-if="form.ai.activeProvider === opt.value && opt.setupHint" class="provider-setup">
+              <text class="setup-line">{{ opt.setupHint }}</text>
+              <text class="setup-cmd" selectable>{{ opt.setupCmd }}</text>
+            </view>
             <view v-if="form.ai.activeProvider === opt.value && opt.keyField" class="provider-key">
               <input
                 class="text-input"
@@ -160,6 +164,8 @@ export default {
           local: true,
           desc: '零密钥、零费用，对话数据全程不离开本机。需先在本机安装并启动 Ollama（ollama.com）。',
           keyField: null,
+          setupHint: '安装并启动 Ollama 后，请在终端拉取本产品使用的模型（约 6GB，首次对话前必须完成）：',
+          setupCmd: 'ollama pull qwen3-vl:8b',
         },
         {
           value: 'OPENROUTER',
@@ -484,6 +490,34 @@ export default {
 
 .provider-key {
   margin-top: 10px;
+}
+
+.provider-setup {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #f0fdf4;
+  border: 1px dashed rgba(22, 101, 52, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.setup-line {
+  font-size: 12px;
+  color: #166534;
+  line-height: 1.6;
+}
+
+.setup-cmd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  color: #0f172a;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 6px;
+  padding: 6px 10px;
+  user-select: all;
 }
 
 .compliance-note {


### PR DESCRIPTION
Closes #36

## 中文

**问题**：PDF 预览被 WPS 把持——`FilePreview.vue` 里 `isPdf()` 被硬编码 `return false`、`isOffice()` 含 `'pdf'`，PDF 因此走 `WpsEditor`，零配置首次用户（向导默认不配 WPS）看到的是「去设置」占位而非内容。现成的 PDF.js 分支是死代码，且指向**远程** `mozilla.github.io`——够不到桌面端 localhost 文件、违背「数据不出本机」、离线不可用。PDF 是法律最主流格式，这直接削弱「双击可用」首次体验。

**改动**（纯前端，后端零改）：
- PDF 复用已验证的媒体加载路径 `loadMediaResource()`：带鉴权 XHR 取文件成 `application/pdf` 的 **blob**，`<iframe :src="blobUrl">` 由 **Chromium/Electron 内置 PDF 引擎原生渲染**——零密钥、离线、数据不出本机；`blob:` URL 不受后端 `Content-Disposition: attachment` 影响，故无需改后端。
- `isPdf()` 真正识别 `pdf`；`isOffice()` 移除 `pdf`（Office 文档仍走 WPS + 未配置占位，#18 T6 不变）。
- `getMimeType` 增加 `pdf → application/pdf`；watch 让 PDF 走 blob 加载。
- 顺带删除已弃用的远程死代码 `pdfViewerUrl`（mozilla pdf.js）与 `officeViewerUrl`（officeapps.live.com，本无调用）。

**验证**：`npm run build:h5` 通过；无残留引用。桌面 Electron 真机渲染由维护者自测确认。

## English

**Problem**: PDF preview was WPS-gated — `isPdf()` was hardcoded to `return false` and `isOffice()` included `'pdf'`, so PDFs rendered via `WpsEditor` and showed the "configure WPS" placeholder for any zero-config first-run user (the wizard makes WPS optional). The existing PDF.js branch was dead code pointing at a **remote** `mozilla.github.io` viewer that can't reach the desktop's localhost file, contradicts "data stays local", and is offline-broken. PDF is the dominant legal format, so this undercuts the "double-click usable" first experience.

**Change** (frontend-only, no backend change):
- PDF reuses the proven media path `loadMediaResource()`: fetch the file with auth as an `application/pdf` **blob**, then `<iframe :src="blobUrl">` is rendered natively by **Chromium/Electron's built-in PDF engine** — zero-key, offline, data never leaves the machine; `blob:` URLs ignore the backend's `Content-Disposition: attachment`, so no backend change is needed.
- `isPdf()` now detects `pdf`; `isOffice()` drops `pdf` (Office docs keep the WPS path + unconfigured placeholder, #18 T6 unchanged).
- `getMimeType` gains `pdf → application/pdf`; the watcher loads PDF as a blob.
- Removes the now-dead remote computeds `pdfViewerUrl` (mozilla pdf.js) and `officeViewerUrl` (officeapps.live.com, previously unused).

**Verification**: `npm run build:h5` passes; no dangling references. Desktop Electron on-device rendering to be confirmed by the maintainer.
