### PR TITLE
docs(readme): 加"下载即用"入口 / add "Download & Run" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ Star AI Workdeck if you care about any of these problems:
 
 AI Workdeck Community Edition is the open-source kernel of AI Workdeck. It is not the full commercial SaaS product. The kernel is published so developers, law firms, legal-tech builders, and document-AI teams can inspect, self-host, integrate, and extend the core workflow infrastructure.
 
+## Download & Run
+
+Just want to try it? You don't need to build from source.
+
+**➡️ [Download the latest desktop app](https://github.com/zeweihan/aiworkdeck/releases/latest)**
+
+| Platform | Installer | Notes |
+|---|---|---|
+| macOS (Apple Silicon) | `AI Workdeck-<version>-arm64.dmg` | Signed and notarized |
+| macOS (Intel) | `AI Workdeck-<version>.dmg` | Signed and notarized |
+| Windows | `AI Workdeck Setup <version>.exe` | Not yet code-signed; SmartScreen may warn |
+
+Double-click to install. On first launch, a setup wizard lets you pick one AI provider — a cloud API key, or a fully local model via [Ollama](https://ollama.com) (zero key, data never leaves your machine). No Java, Docker, or PostgreSQL required: the backend, a trimmed JRE, and a local database are bundled in.
+
+> The desktop build is the fastest way to evaluate AI Workdeck. To self-host the full stack or contribute code, see [Quick Start](#quick-start) below.
+
 ## Demo
 
 | | |
@@ -171,6 +187,8 @@ See [`legal/COMMERCIAL-LICENSE.md`](legal/COMMERCIAL-LICENSE.md) or contact [hi@
 In a self-hosted deployment with Ollama + local storage + Docker services, **documents never leave your network**. No telemetry, no phone-home, no analytics by default. Optional external services (OCR, TTS, cloud AI) are explicitly configured and can be disabled entirely.
 
 ## Quick Start
+
+> For developers who want to self-host the full stack or contribute code. If you just want to try the app, use [Download & Run](#download--run) above instead.
 
 ### Prerequisites
 


### PR DESCRIPTION
## 背景 / Background

我们在 v0.2.0/v0.2.1 已交付「双击可用」的签名桌面安装包，官网下载按钮也接到了 `releases/latest`——但 **README 本身从未告诉访客可以直接下载**：它把所有人径直送进 Quick Start（Docker + PostgreSQL + Java 从源码构建）。一个落到仓库页的律师/法务（最大受众、几乎不会 clone+Docker）看不到任何「下载即用」的入口，第一印象是「这要装 PostgreSQL 才能跑」。直击项目北极星——降低参与门槛。

We already ship a signed, double-click-to-run desktop installer in v0.2.0/v0.2.1, and the website download button points at `releases/latest` — but the **README never tells a visitor they can just download it**. It sends everyone straight to Quick Start (build from source with Docker + PostgreSQL + Java). A lawyer or non-developer landing on the repo sees no "download and run" path. This is friction directly against the project's north star: lowering the barrier to participation.

## 改动 / Changes

- 在「What It Is」之后新增 **`## Download & Run`** 段，链接到 [`releases/latest`](https://github.com/zeweihan/aiworkdeck/releases/latest)（自动跟随最新版，发新版无需改 README），列出三平台安装包，并说明首次运行向导 + 零依赖（后端/JRE/本地库已捆绑）。
- 在 `## Quick Start` 顶部加一行引导：那是面向开发者/自托管的「从源码构建」路径，只想试用请走上面的下载段。
- **仅改 README.md**，纯 markdown，未触碰其它内容。

- New **`## Download & Run`** section after "What It Is", linking to [`releases/latest`](https://github.com/zeweihan/aiworkdeck/releases/latest) (auto-tracks the newest release — no README change on future releases), with the per-platform installers and the zero-dependency first-run wizard.
- A one-line pointer at the top of `## Quick Start` clarifying it is the from-source path for developers/self-hosters.
- **README.md only**, markdown-only, nothing else touched.

## 验证 / Verification

锚点已核对（`#download--run` / `#quick-start`）；安装包文件名与 v0.2.1 release 产物一致；releases/latest 当前指向 v0.2.1。diff 仅 +18 行单文件。

Anchors verified (`#download--run` / `#quick-start`); installer filenames match the v0.2.1 release assets; releases/latest currently resolves to v0.2.1. Diff is +18 lines, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)