### PR TITLE
chore(gitignore): 忽略本地软著/个人目录 / ignore local copyright & personal folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ env.production
 .trae/
 King IDE汇报/
 docs/
+软著材料/
+25-宝库/
+26-IDE汇报/
 
 # Website source code (separate repo)
 website/


### PR DESCRIPTION
## 改动 / Changes

把软件著作权登记材料和本地私有工作目录加入 `.gitignore`，避免误提交、不随仓库同步。沿用既有的 `# Local/Private folders` 段，**不影响任何已跟踪文件**。

Add software-copyright registration materials and local-only personal working folders to `.gitignore` so they are never accidentally committed or synced. Extends the existing `# Local/Private folders` section; **no tracked files are affected**.

```
软著材料/
25-宝库/
26-IDE汇报/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)