### PR TITLE
ci(release): 发版自动生成双语 Release notes / auto bilingual release notes on tag builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -225,3 +225,24 @@ jobs:
           files: |
             desktop/release/*.dmg
             desktop/release/*.exe
+          # Auto-generate a "What's Changed" changelog from merged PRs since the
+          # last tag, appended below the bilingual body template. Without this a
+          # tag build creates a Release with EMPTY notes (had to `gh release edit`
+          # by hand every time). The template is version-agnostic so it stays
+          # correct on every release; per-release highlights can still be edited in.
+          generate_release_notes: true
+          body: |
+            ## AI Workdeck — 律师的 AI 原生工作台 / The lawyer's AI-native workstation
+
+            **中文** · 桌面版「双击即用」：安装包已捆绑后端与精简 JRE，无需预装 PostgreSQL / Java。首次启动有向导，配置一项 AI 提供商即可解锁核心功能；可选「本地 Ollama」实现数据不出本机。
+
+            **English** · Desktop, double-click to run: the installer bundles the backend and a trimmed JRE — no PostgreSQL or Java setup. A first-run wizard gets you started; configure one AI provider to unlock core features. Pick local Ollama to keep all data on-device.
+
+            ### 下载 / Downloads
+            - **macOS · Apple Silicon (M 系列)** — `AI Workdeck-<ver>-arm64.dmg`（已签名公证 / signed & notarized）
+            - **macOS · Intel** — `AI Workdeck-<ver>.dmg`（已签名公证 / signed & notarized）
+            - **Windows · x64** — `AI Workdeck Setup <ver>.exe`（暂未签名，首次运行 SmartScreen 提示属正常 / not yet code-signed; a SmartScreen prompt on first run is expected）
+
+            官网 / Website: https://www.aiworkdeck.com
+
+            ---


### PR DESCRIPTION
## 背景 / Background

**中文** · `desktop-build.yml` 的「Attach to GitHub Release」步骤此前只传 `files:`，没有 `body` 或 `generate_release_notes`。结果：每次打 `v*` tag 自动建的 GitHub Release **notes 为空**——历次发版（v0.2.0/v0.2.1）都要手动 `gh release edit --notes` 补双语说明与下载指引；一旦忘记编辑就会发出一个空白 Release。

**English** · The "Attach to GitHub Release" step passed only `files:` — no `body`, no `generate_release_notes`. So every `v*` tag created a Release with **empty notes**, requiring a manual `gh release edit` each time; a forgotten edit ships a blank release.

## 改动 / Change

- `generate_release_notes: true` —— 自动从上个 tag 以来已合并的 PR 生成「What's Changed」变更日志 / auto "What's Changed" changelog from merged PRs since the last tag.
- 版本无关的双语 `body` 模板 / a version-agnostic bilingual `body` template:
  - 一句话产品介绍（中英）/ one-line product intro (zh + en)
  - 按平台下载指引 / per-platform download guidance: macOS arm64 + Intel（签名公证 / signed & notarized）、Windows x64（暂未签名 + SmartScreen 提示说明 / unsigned + SmartScreen note）
- 模板在前、自动变更日志附在其下 / the template prefixes the auto-generated changelog.

效果 / Effect：今后任何 tag 都产出**完整、非空、双语**的 Release notes，零手动步骤；每版亮点仍可按需手动补充 / every future tag ships complete, non-empty, bilingual notes with zero manual steps; per-release highlights can still be edited in.

## 验证 / Verification

- 本地 YAML 解析通过，release 步骤 `files` / `generate_release_notes` / `body` 三键齐全 / YAML parses; all three keys present.
- 改的是 workflow 自身 → 本 PR 自触发 Desktop Build（mac+win）验证 workflow 结构未坏 / editing the workflow self-triggers the Desktop Build, validating the workflow still builds.
- ⚠️ release 步骤 `if: refs/tags/v` 仅在 tag 上执行，**实际发版行为待下个 tag 验证** / the release step runs only on tags, so the notes behavior is fully verified on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)