### PR TITLE
feat(libreoffice): editor-agnostic agent-stream dispatch seam (dormant) / agent-stream 编辑器无关接缝(休眠)

### DIFF
--- a/frontend/src/composables/useEditorBridge.js
+++ b/frontend/src/composables/useEditorBridge.js
@@ -1,0 +1,68 @@
+// useEditorBridge.js — editor-agnostic dispatch seam for the AI agent command pipeline.
+//
+// Epic #43 (LibreOffice migration). The agent command pipeline is:
+//   backend SSE `client_action` -> useAgentStream -> ChatInterface emits
+//   -> project-overview.vue handleWpsCommand -> executor.executeCommand(action, params)
+//   -> POST /api/ai/agent/wps-result
+// Today handleWpsCommand (project-overview.vue) HARDCODES the WPS executor:
+//   useWpsBridge().executeCommand(commandAction, params, wpsInstance)
+//
+// RFC v2's thesis (docs/LIBREOFFICE_MIGRATION_PLAN.md) is that the backend agent
+// contract is editor-agnostic and ONLY the frontend executor changes. This
+// composable is that seam: ONE place that routes an editor-agnostic command
+// {action, params} to either the WPS executor or the LibreOffice (ZetaOffice)
+// executor, normalizing the single signature difference between them:
+//   - WPS         needs the live document instance: executeCommand(action, params, wpsInstance)
+//   - LibreOffice talks to a pre-connected worker port: executeCommand(action, params)
+//
+// DORMANT: not yet imported by the live WPS dispatch path, so the WPS product is
+// byte-for-byte unaffected. Default editor = 'wps', so activation is a
+// zero-behavior-change switch until LibreOffice is explicitly selected.
+//
+// ACTIVATION (real-machine step — sandbox can't boot ZetaOffice/backend):
+//   1. In project-overview.vue handleWpsCommand, replace the inline
+//      `useWpsBridge().executeCommand(commandAction, params, wpsInstance)` with a
+//      shared editorBridge.executeCommand(commandAction, params, { wpsInstance }).
+//   2. When the embedded ZetaOffice finishes booting, call
+//      editorBridge.connectLibreOffice(port) with the worker thread port
+//      (the value Module.uno_main resolves to in the host).
+//   3. Flip the active editor with editorBridge.setEditor(EDITOR_LIBREOFFICE)
+//      (e.g. behind a system_setting / gray-rollout flag — Phase 3).
+
+import { ref } from 'vue'
+import { useWpsBridge } from './useWpsBridge.js'
+import { useLibreOfficeBridge } from './useLibreOfficeBridge.js'
+
+export const EDITOR_WPS = 'wps'
+export const EDITOR_LIBREOFFICE = 'libreoffice'
+
+export function useEditorBridge(initialEditor = EDITOR_WPS) {
+  const activeEditor = ref(initialEditor)
+  const wps = useWpsBridge()
+  const libre = useLibreOfficeBridge()
+
+  // Wire the embedded ZetaOffice worker thread port (Module.uno_main result).
+  // Called once when the ZetaOffice editor finishes booting; safe to leave
+  // uncalled while the active editor stays WPS.
+  const connectLibreOffice = (port) => libre.connect(port)
+
+  // Editor-agnostic dispatch. `ctx` carries editor-specific handles the seam
+  // normalizes away — currently only WPS's live document instance, which the
+  // LibreOffice executor does not need (its worker port is pre-connected).
+  const executeCommand = async (action, params = {}, ctx = {}) => {
+    if (activeEditor.value === EDITOR_LIBREOFFICE) {
+      return libre.executeCommand(action, params)
+    }
+    return wps.executeCommand(action, params, ctx.wpsInstance)
+  }
+
+  const setEditor = (kind) => { activeEditor.value = kind }
+
+  return {
+    activeEditor,
+    setEditor,
+    executeCommand,
+    connectLibreOffice,
+    isLibreOfficeConnected: libre.isConnected,
+  }
+}


### PR DESCRIPTION
## 中文

Epic #43（LibreOffice 迁移）。**接「agent-stream 接线」这一棒的可验证、休眠片。**

**背景**：AI agent 命令链路 = 后端 SSE `client_action` → `useAgentStream` → `ChatInterface` emit → `project-overview.vue` `handleWpsCommand` → executor → POST `/api/ai/agent/wps-result`。当前 `handleWpsCommand`（[project-overview.vue:5840](frontend/src/pages/project-overview/project-overview.vue#L5840)）**硬编码** WPS：`useWpsBridge().executeCommand(action, params, wpsInstance)`。

**本 PR**：新增 `useEditorBridge.js`——RFC v2「后端 agent 契约编辑器无关、只换前端 executor」的落地接缝。一处路由 WPS↔LibreOffice，抹平唯一签名差：
- WPS 需 live 文档实例 `executeCommand(action, params, wpsInstance)`
- LibreOffice 用预连接 worker port `executeCommand(action, params)`

**休眠 + 安全**：活路径暂不 import（**零 importer 已验证**），WPS 产品逐字节不受影响；默认 editor=`wps` → 活化是零行为变更的开关。

**为什么只到这一步**：端到端「走通一条真实命令」需后端(SSE)+已 boot 的内嵌 ZetaOffice(LOWA+COOP/COEP+字体)+Electron 三者同时在场，本沙箱三者皆跑不了（后端 JDK SIGBUS / 无 Electron GUI / LOWA 需真显示器）。盲写 boot 移植+注头+IME 覆盖层均不可验证 → 留作真机步骤。本接缝把真机接线从「改 97KB 活契约」降级为「过接缝 + boot 时调一次 `connectLibreOffice(port)`」。

**真机活化 playbook**（模块头注释亦有）：
1. `handleWpsCommand` 内联的 `useWpsBridge().executeCommand(...)` 改走共享 `editorBridge.executeCommand(action, params, { wpsInstance })`；
2. ZetaOffice boot 完成时 `editorBridge.connectLibreOffice(port)`（port = 宿主侧 `Module.uno_main` 解析值）；
3. `editorBridge.setEditor(EDITOR_LIBREOFFICE)` 切换（Phase 3 灰度，可挂 system_setting）。

**验证**：`build:h5` 绿；`node --check` 通过；grep 确认零 importer。

## English

Epic #43. The verifiable, dormant slice of the "agent-stream wiring" task.

Adds `useEditorBridge.js` — the single seam routing an editor-agnostic agent command `{action, params}` to either the WPS or the LibreOffice (ZetaOffice) executor, normalizing the one signature gap (WPS needs the live doc instance; LibreOffice uses a pre-connected worker port). This is RFC v2's "backend agent contract is editor-agnostic, only the frontend executor changes" made concrete at the dispatch point.

Dormant: zero importers on the live path (verified) → WPS product byte-for-byte unaffected; default editor = `wps` makes activation a zero-behavior-change switch. End-to-end "one real command" needs a running backend + booted embedded ZetaOffice + Electron, none runnable in this sandbox, so the boot port + COOP/COEP + real command are left as the documented real-machine step.

Verification: `build:h5` green; `node --check` passes; zero importers confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)