### PR TITLE
feat(libreoffice): Electron COOP/COEP isolation for embedded editor (dormant) / 内嵌编辑器的 Electron 跨源隔离(休眠)

### DIFF
--- a/desktop/main/zetaoffice-session.js
+++ b/desktop/main/zetaoffice-session.js
@@ -1,0 +1,69 @@
+// zetaoffice-session.js — Electron cross-origin-isolation for the embedded
+// LibreOffice (ZetaOffice / LOWA) editor. Epic #43.
+//
+// WHY a dedicated partition (not the main window):
+// LOWA uses pthreads -> SharedArrayBuffer, which the browser only exposes when
+// the document is cross-origin isolated (COOP:same-origin + COEP:require-corp).
+// But a SUBFRAME can be cross-origin isolated ONLY IF the top-level document is
+// too — and the product main window deliberately is NOT isolated: it runs with
+// webSecurity:false and loads cross-origin subresources (WPS SDK + cookies, AI
+// providers). Forcing COOP/COEP on the main window would break those.
+//
+// Therefore ZetaOffice cannot boot "in place" in the main window. It must live
+// in an Electron <webview> on its OWN partition/session — a separate frame tree
+// that can be isolated independently of the host. This helper installs COOP/COEP
+// on THAT partition's session only, so the main app's cross-origin loads are
+// untouched. The header-injection mechanism is the one proven in the spike's
+// standalone launcher (experiments/zetaoffice-spike/electron-main.js), scoped
+// from defaultSession to a named partition.
+//
+// DORMANT: nothing in main.js calls this yet (the WPS editor still ships). The
+// LibreOffice editor is behind useEditorBridge's EDITOR_LIBREOFFICE switch.
+//
+// ACTIVATION (real-machine step):
+//   1. In main.js after app.whenReady(), once:
+//        require('./zetaoffice-session').installZetaOfficeIsolation()
+//   2. Render the editor inside <webview partition="persist:zetaoffice"
+//        src="...zetaoffice-editor..."> — it boots ZetaOffice via the product
+//        bootZetaOffice() and is cross-origin isolated thanks to this helper.
+//   3. The self-hosted LOWA bundle (soffice.{js,wasm,data}) + baked CJK fonts
+//      ship in extraResources; the webview loads them same-origin so COEP's
+//      require-corp is satisfied. (Until self-hosted, LOWA loads from the CDN,
+//      which serves Cross-Origin-Resource-Policy: cross-origin — also fine.)
+//
+// OPEN (decide on the real machine — needs Electron): how the host (main window)
+// reaches the worker that booted inside the isolated webview. Two candidates:
+//   (a) per-command relay: host postMessage -> webview -> executor.executeCommand
+//       -> postMessage result back. Simple, an extra hop per command.
+//   (b) one-time MessagePort transfer: the webview transfers the office-worker
+//       thread port to the host (postMessage(port,[port])); the host then
+//       connects libreofficeExecutorClient to it directly — IF a MessagePort
+//       transfers across the isolated<->non-isolated boundary in Electron
+//       (our protocol is plain JSON, no SharedArrayBuffer, so it should). (b) is
+//       cleaner but must be validated on the device before we commit.
+
+const { session } = require('electron')
+
+const ZETAOFFICE_PARTITION = 'persist:zetaoffice'
+
+/**
+ * Install COOP/COEP on the ZetaOffice webview partition so a <webview> using it
+ * becomes cross-origin isolated (SharedArrayBuffer available) WITHOUT touching
+ * the main window's session. Idempotent-safe to call once at startup.
+ *
+ * @param {string} [partition=ZETAOFFICE_PARTITION] the webview partition name.
+ * @returns {string} the partition name (use it as the <webview partition>).
+ */
+function installZetaOfficeIsolation(partition = ZETAOFFICE_PARTITION) {
+  const ses = session.fromPartition(partition)
+  ses.webRequest.onHeadersReceived((details, callback) => {
+    const headers = Object.assign({}, details.responseHeaders)
+    headers['Cross-Origin-Opener-Policy'] = ['same-origin']
+    headers['Cross-Origin-Embedder-Policy'] = ['require-corp']
+    headers['Cross-Origin-Resource-Policy'] = ['cross-origin']
+    callback({ responseHeaders: headers })
+  })
+  return partition
+}
+
+module.exports = { installZetaOfficeIsolation, ZETAOFFICE_PARTITION }

--- a/experiments/zetaoffice-spike/README.md
+++ b/experiments/zetaoffice-spike/README.md
@@ -48,6 +48,16 @@ node serve.mjs            # 起带 COOP/COEP 头的本地服务器（默认 http
 # 浏览器打开 http://localhost:8777 —— 页面会先自检 crossOriginIsolated 是否为 true
 ```
 
+**这个 spike 现在驱动的是产品代码，不是副本**（Epic #43）：`serve.mjs` 的 `/shared/<file>`
+路由把请求映射到 `frontend/src/composables/`，index.html 经 `/shared/` 动态 import 两个**真实
+产品模块**——
+- `zetaOfficeBoot.js`（boot 核心：设 emscripten `Module`、注 `soffice.js`、preRun 注入 CJK 字体、
+  握手主线程 `Module.uno_main` 端口）——app 的编辑器组件将 import 同一份；
+- `libreofficeExecutorClient.js`（executor 客户端：`executeCommand(action,params)`→worker→UNO）。
+
+所以真机跑这个 spike＝直接验证产品 boot + executor 代码（环境差异——CDN vs 自托管 bundle、
+字体路径——是 `bootZetaOffice({...})` 的参数，spike 传 CDN/本地、产品传自托管/焙进路径）。
+
 页面加载后：
 1. 看顶部状态条 `crossOriginIsolated` 是否 ✅（否则 SharedArrayBuffer 不可用，WASM 起不来）。
 2. 点 **Boot ZetaOffice** 等运行时下载+初始化（首次慢，看日志面板进度）。

--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -170,90 +170,47 @@
     btnBoot.onclick = async function () {
       btnBoot.disabled = true;
       zlog('Loading LOWA from ' + SOFFICE_BASE_URL + ' …');
-
-      // ---- CJK font PoC (#39) -------------------------------------------------
-      // The CDN LOWA build ships NO CJK font, so Chinese renders as tofu (口口).
-      // Fix proven here: fetch a CJK font (served same-origin) and write it into
-      // the LOWA font dir in preRun — i.e. BEFORE LibreOffice's fontconfig startup
-      // scan (writing after boot is too late; fonts are scanned once at init).
-      // In the product this font ships inside the self-hosted LOWA bundle.
-      // Optional: if ./cjk-test.ttc isn't served (it's gitignored), skip cleanly.
-      let cjkBytes = null;
       try {
-        const r = await fetch('./cjk-test.ttc');
-        if (r.ok) { cjkBytes = new Uint8Array(await r.arrayBuffer()); zlog('CJK 字体已取 (' + Math.round(cjkBytes.length / 1024) + ' KB)，将在 boot 前注入 LOWA 字体目录'); }
-        else { zlog('未找到 ./cjk-test.ttc（跳过字体注入；中文仍会是豆腐块）', 'e'); }
-      } catch (e) { zlog('CJK 字体 fetch 失败：' + e + '（跳过）', 'e'); }
-
-      // The two globals `canvas` and `Module` must exist before soffice.js loads.
-      window.Module = {
-        canvas,
-        uno_scripts: [ZETA_JS, './office_thread.js'],
-        locateFile: function (path, prefix) { return (prefix || SOFFICE_BASE_URL) + path; },
-        preRun: cjkBytes ? [function () {
-          // Runs before LibreOffice init. At this point /instdir is NOT mounted
-          // yet (FS / = tmp,home,dev,proc), but creating the dir tree and writing
-          // the font here WORKS: the LOWA data mount merges into MEMFS rather than
-          // replacing, so the font is present when fontconfig scans at startup.
-          // PROVEN: tofu (口口) -> real Chinese glyphs. In the product the font is
-          // baked into the self-hosted LOWA bundle's font dir at build time.
-          var dir = '/instdir/share/fonts/truetype';
-          var parts = dir.split('/').filter(Boolean), cur = '';
-          for (var i = 0; i < parts.length; i++) { cur += '/' + parts[i]; try { FS.mkdir(cur); } catch (e) {} }
-          try { FS.writeFile(dir + '/AAA-CJK-test.ttc', cjkBytes); zlog('CJK 字体已写入 ' + dir + ' ✓（boot 前，fontconfig 启动会扫到）'); }
-          catch (e) { zlog('CJK 字体写入 FS 失败：' + e, 'e'); }
-        }] : undefined,
-      };
-      if (SOFFICE_BASE_URL !== '') {
-        window.Module.mainScriptUrlOrBlob = new Blob(
-          ["importScripts('" + SOFFICE_BASE_URL + "soffice.js');"], { type: 'text/javascript' });
-      }
-
-      function onWorkerMessage(e) {
-        const d = e.data;
-        switch (d.cmd) {
-          case 'thr_running': zlog('worker running ✓'); break;
-          case 'ui_ready':
+        // Drive the REAL product boot core (frontend/src/composables) via the
+        // server's /shared/ route, so this spike verifies product code on a real
+        // LibreOffice — same module the app's editor component will import. The
+        // CJK font PoC (preRun injection) and the Module.uno_main main-thread
+        // port handshake now live inside bootZetaOffice(). ./cjk-test.ttc is
+        // gitignored; boot skips it cleanly if absent (CJK stays tofu).
+        const { bootZetaOffice } = await import('/shared/zetaOfficeBoot.js');
+        const { port } = await bootZetaOffice({
+          canvas,
+          sofficeBaseUrl: SOFFICE_BASE_URL,
+          zetaJsUrl: ZETA_JS,
+          workerScriptUrl: './office_thread.js',
+          fontUrl: './cjk-test.ttc',
+          onLog: function (m) { zlog(m); },
+          onReady: function () {
             spinner.style.display = 'none'; canvas.style.visibility = 'visible';
             btnSel.disabled = btnRed.disabled = btnPerf.disabled = btnCjk.disabled = btnExec.disabled = false;
             imeBridge.disabled = false; imeBridge.focus();
             zlog('UI ready ✓ — 现在可以在文档里打中文、点测试按钮');
-            // resize last + guarded: a Qt relayout during init can throw, and it
-            // must not swallow the log line above or stall the message pump.
             try { window.dispatchEvent(new Event('resize')); } catch (err) { zlog('resize warn: ' + err, 'e'); }
-            break;
-          case 'log': zlog(d.msg); break;
-          case 'key': zlog('[UNO key ' + d.phase + '] code=' + d.code + ' char=' + JSON.stringify(d.ch), 'k'); break;
-          default: zlog('main: unknown cmd ' + d.cmd, 'e');
-        }
+          },
+          onWorkerMessage: function (d) {
+            if (d.cmd === 'thr_running') zlog('worker running ✓');
+            else if (d.cmd === 'key') zlog('[UNO key ' + d.phase + '] code=' + d.code + ' char=' + JSON.stringify(d.ch), 'k');
+            else if (d.cmd !== 'log' && d.cmd !== 'ui_ready' && d.cmd !== 'result') zlog('main: unknown cmd ' + d.cmd, 'e');
+          },
+        });
+        thrPort = port;
+        zlog('thread port ready ✓');
+        // Connect the REAL product executor client to the same worker port.
+        // connect() uses addEventListener so it coexists with the boot core's
+        // port.onmessage dispatcher (which ignores cmd:'result').
+        const m = await import('/shared/libreofficeExecutorClient.js');
+        loExec = m.createLibreOfficeExecutor({ onError: function (e) { zlog('executor error: ' + e, 'e'); } });
+        loExec.connect(thrPort);
+        zlog('产品 executor 客户端已连接 ✓ (libreofficeExecutorClient)');
+      } catch (e) {
+        zlog('boot 失败：' + e, 'e');
+        btnBoot.disabled = false;
       }
-
-      // Keep the embedded Qt window sized to the canvas.
-      setInterval(function () { window.dispatchEvent(new Event('resize')); }, 1000);
-
-      const s = document.createElement('script');
-      s.src = SOFFICE_BASE_URL + 'soffice.js';
-      s.onerror = () => zlog('soffice.js 加载失败 / failed to load — 检查网络与 CDN 路径', 'e');
-      // On the MAIN thread the thread port is Module.uno_main (NOT Module.zetajs,
-      // which only exists inside the office worker), and it is only available
-      // after soffice.js has run — so wire it in onload. (Verified against the
-      // allotropia/zetajs web-office example.)
-      s.onload = function () {
-        zlog('soffice.js loaded — 初始化 office 线程…');
-        Module.uno_main.then(function (pThrPort) {
-          thrPort = pThrPort;
-          thrPort.onmessage = onWorkerMessage;
-          zlog('thread port ready ✓');
-          // Import + connect the REAL product executor client (verifies the
-          // useLibreOfficeBridge core path drives the worker, not just hand rolled).
-          import('/shared/libreofficeExecutorClient.js').then(function (m) {
-            loExec = m.createLibreOfficeExecutor({ onError: function (e) { zlog('executor error: ' + e, 'e'); } });
-            loExec.connect(thrPort);
-            zlog('产品 executor 客户端已连接 ✓ (libreofficeExecutorClient)');
-          }).catch(function (e) { zlog('executor import 失败: ' + e, 'e'); });
-        }, function (err) { zlog('uno_main rejected: ' + err, 'e'); });
-      };
-      document.body.appendChild(s);
     };
   </script>
 </body>

--- a/frontend/src/composables/useEditorBridge.js
+++ b/frontend/src/composables/useEditorBridge.js
@@ -1,0 +1,68 @@
+// useEditorBridge.js — editor-agnostic dispatch seam for the AI agent command pipeline.
+//
+// Epic #43 (LibreOffice migration). The agent command pipeline is:
+//   backend SSE `client_action` -> useAgentStream -> ChatInterface emits
+//   -> project-overview.vue handleWpsCommand -> executor.executeCommand(action, params)
+//   -> POST /api/ai/agent/wps-result
+// Today handleWpsCommand (project-overview.vue) HARDCODES the WPS executor:
+//   useWpsBridge().executeCommand(commandAction, params, wpsInstance)
+//
+// RFC v2's thesis (docs/LIBREOFFICE_MIGRATION_PLAN.md) is that the backend agent
+// contract is editor-agnostic and ONLY the frontend executor changes. This
+// composable is that seam: ONE place that routes an editor-agnostic command
+// {action, params} to either the WPS executor or the LibreOffice (ZetaOffice)
+// executor, normalizing the single signature difference between them:
+//   - WPS         needs the live document instance: executeCommand(action, params, wpsInstance)
+//   - LibreOffice talks to a pre-connected worker port: executeCommand(action, params)
+//
+// DORMANT: not yet imported by the live WPS dispatch path, so the WPS product is
+// byte-for-byte unaffected. Default editor = 'wps', so activation is a
+// zero-behavior-change switch until LibreOffice is explicitly selected.
+//
+// ACTIVATION (real-machine step — sandbox can't boot ZetaOffice/backend):
+//   1. In project-overview.vue handleWpsCommand, replace the inline
+//      `useWpsBridge().executeCommand(commandAction, params, wpsInstance)` with a
+//      shared editorBridge.executeCommand(commandAction, params, { wpsInstance }).
+//   2. When the embedded ZetaOffice finishes booting, call
+//      editorBridge.connectLibreOffice(port) with the worker thread port
+//      (the value Module.uno_main resolves to in the host).
+//   3. Flip the active editor with editorBridge.setEditor(EDITOR_LIBREOFFICE)
+//      (e.g. behind a system_setting / gray-rollout flag — Phase 3).
+
+import { ref } from 'vue'
+import { useWpsBridge } from './useWpsBridge.js'
+import { useLibreOfficeBridge } from './useLibreOfficeBridge.js'
+
+export const EDITOR_WPS = 'wps'
+export const EDITOR_LIBREOFFICE = 'libreoffice'
+
+export function useEditorBridge(initialEditor = EDITOR_WPS) {
+  const activeEditor = ref(initialEditor)
+  const wps = useWpsBridge()
+  const libre = useLibreOfficeBridge()
+
+  // Wire the embedded ZetaOffice worker thread port (Module.uno_main result).
+  // Called once when the ZetaOffice editor finishes booting; safe to leave
+  // uncalled while the active editor stays WPS.
+  const connectLibreOffice = (port) => libre.connect(port)
+
+  // Editor-agnostic dispatch. `ctx` carries editor-specific handles the seam
+  // normalizes away — currently only WPS's live document instance, which the
+  // LibreOffice executor does not need (its worker port is pre-connected).
+  const executeCommand = async (action, params = {}, ctx = {}) => {
+    if (activeEditor.value === EDITOR_LIBREOFFICE) {
+      return libre.executeCommand(action, params)
+    }
+    return wps.executeCommand(action, params, ctx.wpsInstance)
+  }
+
+  const setEditor = (kind) => { activeEditor.value = kind }
+
+  return {
+    activeEditor,
+    setEditor,
+    executeCommand,
+    connectLibreOffice,
+    isLibreOfficeConnected: libre.isConnected,
+  }
+}

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -1,0 +1,148 @@
+// zetaOfficeBoot.js — framework-agnostic ZetaOffice (LibreOffice WASM) boot core.
+//
+// Epic #43. Extracted verbatim (parameterized) from the proven Phase 0 spike
+// boot sequence (experiments/zetaoffice-spike/index.html). Plain ES module (NO
+// Vue) so BOTH the spike harness (loaded via the dev server's /shared/ route,
+// driving product code against a real LibreOffice) AND the app's editor
+// component import the SAME boot code. This is the heart of "embed ZetaOffice in
+// the app": it sets up the emscripten Module, loads the LOWA runtime, injects
+// CJK fonts before fontconfig's startup scan, and resolves the office-worker
+// thread port that useEditorBridge.connectLibreOffice(port) / the executor
+// client connect to.
+//
+// Environment-specific values are parameters, NOT hardcoded, so the spike passes
+// CDN + local paths and the product passes self-hosted-bundle paths:
+//   - sofficeBaseUrl : where soffice.{js,wasm,data} live (CDN for the spike;
+//                      a self-hosted bundle inside the installer for the product)
+//   - zetaJsUrl      : the zetajs bridge — NOT on the CDN, must be vendored
+//                      (allotropia/zetajs source/zeta.js, MIT). Loading it from
+//                      the CDN fails with a worker importScripts NetworkError.
+//   - workerScriptUrl: the office worker (office_thread.js) injected into the
+//                      LO office thread via Module.uno_scripts.
+//   - fontUrl        : optional CJK font fetched same-origin and written into the
+//                      LOWA font dir in preRun (the product bakes Noto/思源 CJK
+//                      OFL into the self-hosted bundle's font dir at build time).
+//
+// COOP/COEP: the page MUST be cross-origin isolated (SharedArrayBuffer). That
+// comes ONLY from HTTP response headers (spike: serve.mjs; product Electron:
+// session.webRequest.onHeadersReceived on a dedicated partition). boot() throws
+// early with a clear message if it is not.
+
+const DEFAULT_SOFFICE_BASE_URL = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
+
+/**
+ * Boot ZetaOffice into the given canvas and resolve with the office-worker
+ * thread port (Module.uno_main's value). Connect an executor / the editor bridge
+ * to the returned port to drive UNO commands.
+ *
+ * @param {object} options
+ * @param {HTMLCanvasElement} options.canvas REQUIRED. MUST have id="qtcanvas"
+ *        and no border/padding (Qt requirement; outline is fine).
+ * @param {string}   [options.sofficeBaseUrl] LOWA runtime base URL.
+ * @param {string}   [options.zetaJsUrl='./zeta.js'] vendored zetajs bridge URL.
+ * @param {string}   [options.workerScriptUrl='./office_thread.js'] office worker URL.
+ * @param {string}   [options.fontUrl] optional same-origin CJK font to inject.
+ * @param {(msg:string)=>void}     [options.onLog] worker 'log' lines + milestones.
+ * @param {()=>void}                [options.onReady] fired on worker 'ui_ready'
+ *        (document loaded, canvas interactive).
+ * @param {(data:any)=>void}        [options.onWorkerMessage] raw worker messages.
+ * @returns {Promise<{port: MessagePort, dispose: ()=>void}>}
+ */
+export function bootZetaOffice(options = {}) {
+  const {
+    canvas,
+    sofficeBaseUrl = DEFAULT_SOFFICE_BASE_URL,
+    zetaJsUrl = './zeta.js',
+    workerScriptUrl = './office_thread.js',
+    fontUrl,
+    onLog,
+    onReady,
+    onWorkerMessage,
+  } = options
+
+  const log = (m) => { if (onLog) onLog(m) }
+
+  if (!canvas) return Promise.reject(new Error('bootZetaOffice: canvas is required'))
+  if (typeof self !== 'undefined' && self.crossOriginIsolated === false) {
+    return Promise.reject(new Error(
+      'bootZetaOffice: page is not cross-origin isolated (SharedArrayBuffer unavailable). ' +
+      'Serve with COOP:same-origin + COEP:require-corp headers ' +
+      '(spike: node serve.mjs; product: Electron onHeadersReceived).'))
+  }
+
+  return new Promise(async (resolve, reject) => {
+    // --- optional CJK font fetch (injected in preRun, before fontconfig scan) ---
+    let cjkBytes = null
+    if (fontUrl) {
+      try {
+        const r = await fetch(fontUrl)
+        if (r.ok) {
+          cjkBytes = new Uint8Array(await r.arrayBuffer())
+          log('CJK font fetched (' + Math.round(cjkBytes.length / 1024) + ' KB), will inject before boot')
+        } else {
+          log('CJK font not found at ' + fontUrl + ' (skipping; CJK will be tofu)')
+        }
+      } catch (e) {
+        log('CJK font fetch failed: ' + e + ' (skipping)')
+      }
+    }
+
+    // The globals `canvas` and `Module` must exist before soffice.js loads.
+    const Module = {
+      canvas,
+      uno_scripts: [zetaJsUrl, workerScriptUrl],
+      locateFile: function (path, prefix) { return (prefix || sofficeBaseUrl) + path },
+      preRun: cjkBytes ? [function () {
+        // Runs before LibreOffice init. /instdir is NOT mounted yet at this point
+        // (FS / = tmp,home,dev,proc) but creating the dir tree and writing the
+        // font here WORKS: the LOWA data mount MERGES into MEMFS rather than
+        // replacing, so the font is present when fontconfig scans at startup.
+        // PROVEN in the spike: tofu (口口) -> real Chinese glyphs. The product
+        // bakes the font into the self-hosted LOWA bundle's font dir at build time.
+        const FS = globalThis.FS
+        const dir = '/instdir/share/fonts/truetype'
+        const parts = dir.split('/').filter(Boolean)
+        let cur = ''
+        for (let i = 0; i < parts.length; i++) { cur += '/' + parts[i]; try { FS.mkdir(cur) } catch (e) { /* exists */ } }
+        try { FS.writeFile(dir + '/AAA-CJK.ttc', cjkBytes); log('CJK font written to ' + dir + ' (before fontconfig scan)') }
+        catch (e) { log('CJK font write to FS failed: ' + e) }
+      }] : undefined,
+    }
+    if (sofficeBaseUrl !== '') {
+      Module.mainScriptUrlOrBlob = new Blob(
+        ["importScripts('" + sofficeBaseUrl + "soffice.js');"], { type: 'text/javascript' })
+    }
+    globalThis.Module = Module
+
+    function onMessage(e) {
+      const d = (e && e.data) || {}
+      if (d.cmd === 'log') log(d.msg)
+      else if (d.cmd === 'ui_ready') { log('UI ready'); if (onReady) onReady() }
+      if (onWorkerMessage) onWorkerMessage(d)
+    }
+
+    // Keep the embedded Qt window sized to the canvas.
+    const resizeTimer = setInterval(function () {
+      try { globalThis.dispatchEvent(new Event('resize')) } catch (e) { /* ignore */ }
+    }, 1000)
+
+    const dispose = () => { clearInterval(resizeTimer) }
+
+    const s = document.createElement('script')
+    s.src = sofficeBaseUrl + 'soffice.js'
+    s.onerror = () => { dispose(); reject(new Error('failed to load soffice.js from ' + sofficeBaseUrl)) }
+    // On the MAIN thread the office-thread port is Module.uno_main (NOT
+    // Module.zetajs, which exists only inside the office worker) and is available
+    // only after soffice.js has run — so wire it in onload. (Verified against the
+    // allotropia/zetajs web-office example.)
+    s.onload = function () {
+      log('soffice.js loaded — initializing office thread…')
+      Module.uno_main.then(function (port) {
+        port.onmessage = onMessage
+        log('thread port ready')
+        resolve({ port, dispose })
+      }, function (err) { dispose(); reject(new Error('uno_main rejected: ' + err)) })
+    }
+    document.body.appendChild(s)
+  })
+}


### PR DESCRIPTION
## 中文

Epic #43。接力 boot 模块（#46，已真机预览验证全绿），落地内嵌的**唯一无歧义地基件：给 ZetaOffice 专用 webview partition 注 COOP/COEP**。

**关键架构约束**（读产品主进程后确认）：LOWA 需页面 `crossOriginIsolated`（SharedArrayBuffer），而**子框架只有在顶层文档也隔离时才能隔离**；但产品主窗口**故意不隔离**——`webSecurity:false`（main.js:239）+ 加载 WPS SDK/Cookie、AI 提供商等跨源资源。给主窗口全局加 COOP/COEP 会切断这些。**结论：ZetaOffice 不能在主窗口就地 boot，必须进独立 partition 的 Electron `<webview>`**（自带 frame tree，可独立隔离；app 已在用 webview）。

**本 PR**：新增 [`desktop/main/zetaoffice-session.js`](desktop/main/zetaoffice-session.js)——`installZetaOfficeIsolation(partition='persist:zetaoffice')` 仅在该 partition 的 session 上注 COOP/COEP，**主应用跨源加载不受影响**。注头机制 grounded 在已验证的 spike `electron-main.js`，由 `defaultSession` 收窄到具名 partition。

**休眠/安全**：`main.js` 不引用（WPS 编辑器照常发），主进程逐字节不变；活化＝主进程 `app.whenReady()` 后一行 `require+call`（模块头写全）。`node --check` 过。

**留作真机决策**（需 Electron 实测）：宿主主窗口怎么够到隔离 webview 里 boot 出来的 worker——(a) 每命令中转（host postMessage→webview→`executeCommand`→回传）；(b) 一次性 `MessagePort` 转移（webview 把 worker 线程端口 transfer 给宿主，宿主直接 `connect`——协议是纯 JSON 无 SAB，理应可跨隔离边界 transfer，但须真机验证）。(b) 更干净，定夺前需设备验证。模块头已记。

## English

Epic #43. Following the boot module (#46, verified green via the preview harness), this lands the one unambiguous foundation every embed path needs: **COOP/COEP cross-origin isolation for ZetaOffice on a dedicated webview partition**.

Constraint (confirmed by reading the product main process): a subframe can be cross-origin isolated only if the top-level is too, but the main window is deliberately NOT isolated (`webSecurity:false` + cross-origin WPS/AI loads). So ZetaOffice must boot inside an Electron `<webview>` on its own partition. `desktop/main/zetaoffice-session.js` isolates that partition's session only, leaving the main app untouched, using the header-injection mechanism proven in the spike's `electron-main.js`.

Dormant: `main.js` doesn't call it; activation is a one-line require+call (documented). `node --check` passes; main process byte-for-byte unchanged. Open question for the real machine: per-command relay vs one-time MessagePort transfer for host↔isolated-webview command flow (documented in the module header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)