### PR TITLE
feat(libreoffice): dedicated Vite build for webview editor page (dormant) / webview 编辑器页专用 Vite 构建(休眠)

### DIFF
--- a/desktop/main/zetaoffice-session.js
+++ b/desktop/main/zetaoffice-session.js
@@ -1,0 +1,69 @@
+// zetaoffice-session.js — Electron cross-origin-isolation for the embedded
+// LibreOffice (ZetaOffice / LOWA) editor. Epic #43.
+//
+// WHY a dedicated partition (not the main window):
+// LOWA uses pthreads -> SharedArrayBuffer, which the browser only exposes when
+// the document is cross-origin isolated (COOP:same-origin + COEP:require-corp).
+// But a SUBFRAME can be cross-origin isolated ONLY IF the top-level document is
+// too — and the product main window deliberately is NOT isolated: it runs with
+// webSecurity:false and loads cross-origin subresources (WPS SDK + cookies, AI
+// providers). Forcing COOP/COEP on the main window would break those.
+//
+// Therefore ZetaOffice cannot boot "in place" in the main window. It must live
+// in an Electron <webview> on its OWN partition/session — a separate frame tree
+// that can be isolated independently of the host. This helper installs COOP/COEP
+// on THAT partition's session only, so the main app's cross-origin loads are
+// untouched. The header-injection mechanism is the one proven in the spike's
+// standalone launcher (experiments/zetaoffice-spike/electron-main.js), scoped
+// from defaultSession to a named partition.
+//
+// DORMANT: nothing in main.js calls this yet (the WPS editor still ships). The
+// LibreOffice editor is behind useEditorBridge's EDITOR_LIBREOFFICE switch.
+//
+// ACTIVATION (real-machine step):
+//   1. In main.js after app.whenReady(), once:
+//        require('./zetaoffice-session').installZetaOfficeIsolation()
+//   2. Render the editor inside <webview partition="persist:zetaoffice"
+//        src="...zetaoffice-editor..."> — it boots ZetaOffice via the product
+//        bootZetaOffice() and is cross-origin isolated thanks to this helper.
+//   3. The self-hosted LOWA bundle (soffice.{js,wasm,data}) + baked CJK fonts
+//      ship in extraResources; the webview loads them same-origin so COEP's
+//      require-corp is satisfied. (Until self-hosted, LOWA loads from the CDN,
+//      which serves Cross-Origin-Resource-Policy: cross-origin — also fine.)
+//
+// OPEN (decide on the real machine — needs Electron): how the host (main window)
+// reaches the worker that booted inside the isolated webview. Two candidates:
+//   (a) per-command relay: host postMessage -> webview -> executor.executeCommand
+//       -> postMessage result back. Simple, an extra hop per command.
+//   (b) one-time MessagePort transfer: the webview transfers the office-worker
+//       thread port to the host (postMessage(port,[port])); the host then
+//       connects libreofficeExecutorClient to it directly — IF a MessagePort
+//       transfers across the isolated<->non-isolated boundary in Electron
+//       (our protocol is plain JSON, no SharedArrayBuffer, so it should). (b) is
+//       cleaner but must be validated on the device before we commit.
+
+const { session } = require('electron')
+
+const ZETAOFFICE_PARTITION = 'persist:zetaoffice'
+
+/**
+ * Install COOP/COEP on the ZetaOffice webview partition so a <webview> using it
+ * becomes cross-origin isolated (SharedArrayBuffer available) WITHOUT touching
+ * the main window's session. Idempotent-safe to call once at startup.
+ *
+ * @param {string} [partition=ZETAOFFICE_PARTITION] the webview partition name.
+ * @returns {string} the partition name (use it as the <webview partition>).
+ */
+function installZetaOfficeIsolation(partition = ZETAOFFICE_PARTITION) {
+  const ses = session.fromPartition(partition)
+  ses.webRequest.onHeadersReceived((details, callback) => {
+    const headers = Object.assign({}, details.responseHeaders)
+    headers['Cross-Origin-Opener-Policy'] = ['same-origin']
+    headers['Cross-Origin-Embedder-Policy'] = ['require-corp']
+    headers['Cross-Origin-Resource-Policy'] = ['cross-origin']
+    callback({ responseHeaders: headers })
+  })
+  return partition
+}
+
+module.exports = { installZetaOfficeIsolation, ZETAOFFICE_PARTITION }

--- a/experiments/zetaoffice-spike/README.md
+++ b/experiments/zetaoffice-spike/README.md
@@ -48,6 +48,16 @@ node serve.mjs            # 起带 COOP/COEP 头的本地服务器（默认 http
 # 浏览器打开 http://localhost:8777 —— 页面会先自检 crossOriginIsolated 是否为 true
 ```
 
+**这个 spike 现在驱动的是产品代码，不是副本**（Epic #43）：`serve.mjs` 的 `/shared/<file>`
+路由把请求映射到 `frontend/src/composables/`，index.html 经 `/shared/` 动态 import 两个**真实
+产品模块**——
+- `zetaOfficeBoot.js`（boot 核心：设 emscripten `Module`、注 `soffice.js`、preRun 注入 CJK 字体、
+  握手主线程 `Module.uno_main` 端口）——app 的编辑器组件将 import 同一份；
+- `libreofficeExecutorClient.js`（executor 客户端：`executeCommand(action,params)`→worker→UNO）。
+
+所以真机跑这个 spike＝直接验证产品 boot + executor 代码（环境差异——CDN vs 自托管 bundle、
+字体路径——是 `bootZetaOffice({...})` 的参数，spike 传 CDN/本地、产品传自托管/焙进路径）。
+
 页面加载后：
 1. 看顶部状态条 `crossOriginIsolated` 是否 ✅（否则 SharedArrayBuffer 不可用，WASM 起不来）。
 2. 点 **Boot ZetaOffice** 等运行时下载+初始化（首次慢，看日志面板进度）。

--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -170,90 +170,47 @@
     btnBoot.onclick = async function () {
       btnBoot.disabled = true;
       zlog('Loading LOWA from ' + SOFFICE_BASE_URL + ' …');
-
-      // ---- CJK font PoC (#39) -------------------------------------------------
-      // The CDN LOWA build ships NO CJK font, so Chinese renders as tofu (口口).
-      // Fix proven here: fetch a CJK font (served same-origin) and write it into
-      // the LOWA font dir in preRun — i.e. BEFORE LibreOffice's fontconfig startup
-      // scan (writing after boot is too late; fonts are scanned once at init).
-      // In the product this font ships inside the self-hosted LOWA bundle.
-      // Optional: if ./cjk-test.ttc isn't served (it's gitignored), skip cleanly.
-      let cjkBytes = null;
       try {
-        const r = await fetch('./cjk-test.ttc');
-        if (r.ok) { cjkBytes = new Uint8Array(await r.arrayBuffer()); zlog('CJK 字体已取 (' + Math.round(cjkBytes.length / 1024) + ' KB)，将在 boot 前注入 LOWA 字体目录'); }
-        else { zlog('未找到 ./cjk-test.ttc（跳过字体注入；中文仍会是豆腐块）', 'e'); }
-      } catch (e) { zlog('CJK 字体 fetch 失败：' + e + '（跳过）', 'e'); }
-
-      // The two globals `canvas` and `Module` must exist before soffice.js loads.
-      window.Module = {
-        canvas,
-        uno_scripts: [ZETA_JS, './office_thread.js'],
-        locateFile: function (path, prefix) { return (prefix || SOFFICE_BASE_URL) + path; },
-        preRun: cjkBytes ? [function () {
-          // Runs before LibreOffice init. At this point /instdir is NOT mounted
-          // yet (FS / = tmp,home,dev,proc), but creating the dir tree and writing
-          // the font here WORKS: the LOWA data mount merges into MEMFS rather than
-          // replacing, so the font is present when fontconfig scans at startup.
-          // PROVEN: tofu (口口) -> real Chinese glyphs. In the product the font is
-          // baked into the self-hosted LOWA bundle's font dir at build time.
-          var dir = '/instdir/share/fonts/truetype';
-          var parts = dir.split('/').filter(Boolean), cur = '';
-          for (var i = 0; i < parts.length; i++) { cur += '/' + parts[i]; try { FS.mkdir(cur); } catch (e) {} }
-          try { FS.writeFile(dir + '/AAA-CJK-test.ttc', cjkBytes); zlog('CJK 字体已写入 ' + dir + ' ✓（boot 前，fontconfig 启动会扫到）'); }
-          catch (e) { zlog('CJK 字体写入 FS 失败：' + e, 'e'); }
-        }] : undefined,
-      };
-      if (SOFFICE_BASE_URL !== '') {
-        window.Module.mainScriptUrlOrBlob = new Blob(
-          ["importScripts('" + SOFFICE_BASE_URL + "soffice.js');"], { type: 'text/javascript' });
-      }
-
-      function onWorkerMessage(e) {
-        const d = e.data;
-        switch (d.cmd) {
-          case 'thr_running': zlog('worker running ✓'); break;
-          case 'ui_ready':
+        // Drive the REAL product boot core (frontend/src/composables) via the
+        // server's /shared/ route, so this spike verifies product code on a real
+        // LibreOffice — same module the app's editor component will import. The
+        // CJK font PoC (preRun injection) and the Module.uno_main main-thread
+        // port handshake now live inside bootZetaOffice(). ./cjk-test.ttc is
+        // gitignored; boot skips it cleanly if absent (CJK stays tofu).
+        const { bootZetaOffice } = await import('/shared/zetaOfficeBoot.js');
+        const { port } = await bootZetaOffice({
+          canvas,
+          sofficeBaseUrl: SOFFICE_BASE_URL,
+          zetaJsUrl: ZETA_JS,
+          workerScriptUrl: './office_thread.js',
+          fontUrl: './cjk-test.ttc',
+          onLog: function (m) { zlog(m); },
+          onReady: function () {
             spinner.style.display = 'none'; canvas.style.visibility = 'visible';
             btnSel.disabled = btnRed.disabled = btnPerf.disabled = btnCjk.disabled = btnExec.disabled = false;
             imeBridge.disabled = false; imeBridge.focus();
             zlog('UI ready ✓ — 现在可以在文档里打中文、点测试按钮');
-            // resize last + guarded: a Qt relayout during init can throw, and it
-            // must not swallow the log line above or stall the message pump.
             try { window.dispatchEvent(new Event('resize')); } catch (err) { zlog('resize warn: ' + err, 'e'); }
-            break;
-          case 'log': zlog(d.msg); break;
-          case 'key': zlog('[UNO key ' + d.phase + '] code=' + d.code + ' char=' + JSON.stringify(d.ch), 'k'); break;
-          default: zlog('main: unknown cmd ' + d.cmd, 'e');
-        }
+          },
+          onWorkerMessage: function (d) {
+            if (d.cmd === 'thr_running') zlog('worker running ✓');
+            else if (d.cmd === 'key') zlog('[UNO key ' + d.phase + '] code=' + d.code + ' char=' + JSON.stringify(d.ch), 'k');
+            else if (d.cmd !== 'log' && d.cmd !== 'ui_ready' && d.cmd !== 'result') zlog('main: unknown cmd ' + d.cmd, 'e');
+          },
+        });
+        thrPort = port;
+        zlog('thread port ready ✓');
+        // Connect the REAL product executor client to the same worker port.
+        // connect() uses addEventListener so it coexists with the boot core's
+        // port.onmessage dispatcher (which ignores cmd:'result').
+        const m = await import('/shared/libreofficeExecutorClient.js');
+        loExec = m.createLibreOfficeExecutor({ onError: function (e) { zlog('executor error: ' + e, 'e'); } });
+        loExec.connect(thrPort);
+        zlog('产品 executor 客户端已连接 ✓ (libreofficeExecutorClient)');
+      } catch (e) {
+        zlog('boot 失败：' + e, 'e');
+        btnBoot.disabled = false;
       }
-
-      // Keep the embedded Qt window sized to the canvas.
-      setInterval(function () { window.dispatchEvent(new Event('resize')); }, 1000);
-
-      const s = document.createElement('script');
-      s.src = SOFFICE_BASE_URL + 'soffice.js';
-      s.onerror = () => zlog('soffice.js 加载失败 / failed to load — 检查网络与 CDN 路径', 'e');
-      // On the MAIN thread the thread port is Module.uno_main (NOT Module.zetajs,
-      // which only exists inside the office worker), and it is only available
-      // after soffice.js has run — so wire it in onload. (Verified against the
-      // allotropia/zetajs web-office example.)
-      s.onload = function () {
-        zlog('soffice.js loaded — 初始化 office 线程…');
-        Module.uno_main.then(function (pThrPort) {
-          thrPort = pThrPort;
-          thrPort.onmessage = onWorkerMessage;
-          zlog('thread port ready ✓');
-          // Import + connect the REAL product executor client (verifies the
-          // useLibreOfficeBridge core path drives the worker, not just hand rolled).
-          import('/shared/libreofficeExecutorClient.js').then(function (m) {
-            loExec = m.createLibreOfficeExecutor({ onError: function (e) { zlog('executor error: ' + e, 'e'); } });
-            loExec.connect(thrPort);
-            zlog('产品 executor 客户端已连接 ✓ (libreofficeExecutorClient)');
-          }).catch(function (e) { zlog('executor import 失败: ' + e, 'e'); });
-        }, function (err) { zlog('uno_main rejected: ' + err, 'e'); });
-      };
-      document.body.appendChild(s);
     };
   </script>
 </body>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "dev:quickapp-webview-union": "uni -p quickapp-webview-union",
     "build:custom": "uni build -p",
     "build:h5": "uni build",
+    "build:zetaoffice": "vite build --config vite.zetaoffice.config.js",
     "build:h5:ssr": "uni build --ssr",
     "build:mp-alipay": "uni build -p mp-alipay",
     "build:mp-baidu": "uni build -p mp-baidu",

--- a/frontend/src/composables/useEditorBridge.js
+++ b/frontend/src/composables/useEditorBridge.js
@@ -1,0 +1,68 @@
+// useEditorBridge.js — editor-agnostic dispatch seam for the AI agent command pipeline.
+//
+// Epic #43 (LibreOffice migration). The agent command pipeline is:
+//   backend SSE `client_action` -> useAgentStream -> ChatInterface emits
+//   -> project-overview.vue handleWpsCommand -> executor.executeCommand(action, params)
+//   -> POST /api/ai/agent/wps-result
+// Today handleWpsCommand (project-overview.vue) HARDCODES the WPS executor:
+//   useWpsBridge().executeCommand(commandAction, params, wpsInstance)
+//
+// RFC v2's thesis (docs/LIBREOFFICE_MIGRATION_PLAN.md) is that the backend agent
+// contract is editor-agnostic and ONLY the frontend executor changes. This
+// composable is that seam: ONE place that routes an editor-agnostic command
+// {action, params} to either the WPS executor or the LibreOffice (ZetaOffice)
+// executor, normalizing the single signature difference between them:
+//   - WPS         needs the live document instance: executeCommand(action, params, wpsInstance)
+//   - LibreOffice talks to a pre-connected worker port: executeCommand(action, params)
+//
+// DORMANT: not yet imported by the live WPS dispatch path, so the WPS product is
+// byte-for-byte unaffected. Default editor = 'wps', so activation is a
+// zero-behavior-change switch until LibreOffice is explicitly selected.
+//
+// ACTIVATION (real-machine step — sandbox can't boot ZetaOffice/backend):
+//   1. In project-overview.vue handleWpsCommand, replace the inline
+//      `useWpsBridge().executeCommand(commandAction, params, wpsInstance)` with a
+//      shared editorBridge.executeCommand(commandAction, params, { wpsInstance }).
+//   2. When the embedded ZetaOffice finishes booting, call
+//      editorBridge.connectLibreOffice(port) with the worker thread port
+//      (the value Module.uno_main resolves to in the host).
+//   3. Flip the active editor with editorBridge.setEditor(EDITOR_LIBREOFFICE)
+//      (e.g. behind a system_setting / gray-rollout flag — Phase 3).
+
+import { ref } from 'vue'
+import { useWpsBridge } from './useWpsBridge.js'
+import { useLibreOfficeBridge } from './useLibreOfficeBridge.js'
+
+export const EDITOR_WPS = 'wps'
+export const EDITOR_LIBREOFFICE = 'libreoffice'
+
+export function useEditorBridge(initialEditor = EDITOR_WPS) {
+  const activeEditor = ref(initialEditor)
+  const wps = useWpsBridge()
+  const libre = useLibreOfficeBridge()
+
+  // Wire the embedded ZetaOffice worker thread port (Module.uno_main result).
+  // Called once when the ZetaOffice editor finishes booting; safe to leave
+  // uncalled while the active editor stays WPS.
+  const connectLibreOffice = (port) => libre.connect(port)
+
+  // Editor-agnostic dispatch. `ctx` carries editor-specific handles the seam
+  // normalizes away — currently only WPS's live document instance, which the
+  // LibreOffice executor does not need (its worker port is pre-connected).
+  const executeCommand = async (action, params = {}, ctx = {}) => {
+    if (activeEditor.value === EDITOR_LIBREOFFICE) {
+      return libre.executeCommand(action, params)
+    }
+    return wps.executeCommand(action, params, ctx.wpsInstance)
+  }
+
+  const setEditor = (kind) => { activeEditor.value = kind }
+
+  return {
+    activeEditor,
+    setEditor,
+    executeCommand,
+    connectLibreOffice,
+    isLibreOfficeConnected: libre.isConnected,
+  }
+}

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -1,0 +1,148 @@
+// zetaOfficeBoot.js — framework-agnostic ZetaOffice (LibreOffice WASM) boot core.
+//
+// Epic #43. Extracted verbatim (parameterized) from the proven Phase 0 spike
+// boot sequence (experiments/zetaoffice-spike/index.html). Plain ES module (NO
+// Vue) so BOTH the spike harness (loaded via the dev server's /shared/ route,
+// driving product code against a real LibreOffice) AND the app's editor
+// component import the SAME boot code. This is the heart of "embed ZetaOffice in
+// the app": it sets up the emscripten Module, loads the LOWA runtime, injects
+// CJK fonts before fontconfig's startup scan, and resolves the office-worker
+// thread port that useEditorBridge.connectLibreOffice(port) / the executor
+// client connect to.
+//
+// Environment-specific values are parameters, NOT hardcoded, so the spike passes
+// CDN + local paths and the product passes self-hosted-bundle paths:
+//   - sofficeBaseUrl : where soffice.{js,wasm,data} live (CDN for the spike;
+//                      a self-hosted bundle inside the installer for the product)
+//   - zetaJsUrl      : the zetajs bridge — NOT on the CDN, must be vendored
+//                      (allotropia/zetajs source/zeta.js, MIT). Loading it from
+//                      the CDN fails with a worker importScripts NetworkError.
+//   - workerScriptUrl: the office worker (office_thread.js) injected into the
+//                      LO office thread via Module.uno_scripts.
+//   - fontUrl        : optional CJK font fetched same-origin and written into the
+//                      LOWA font dir in preRun (the product bakes Noto/思源 CJK
+//                      OFL into the self-hosted bundle's font dir at build time).
+//
+// COOP/COEP: the page MUST be cross-origin isolated (SharedArrayBuffer). That
+// comes ONLY from HTTP response headers (spike: serve.mjs; product Electron:
+// session.webRequest.onHeadersReceived on a dedicated partition). boot() throws
+// early with a clear message if it is not.
+
+const DEFAULT_SOFFICE_BASE_URL = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
+
+/**
+ * Boot ZetaOffice into the given canvas and resolve with the office-worker
+ * thread port (Module.uno_main's value). Connect an executor / the editor bridge
+ * to the returned port to drive UNO commands.
+ *
+ * @param {object} options
+ * @param {HTMLCanvasElement} options.canvas REQUIRED. MUST have id="qtcanvas"
+ *        and no border/padding (Qt requirement; outline is fine).
+ * @param {string}   [options.sofficeBaseUrl] LOWA runtime base URL.
+ * @param {string}   [options.zetaJsUrl='./zeta.js'] vendored zetajs bridge URL.
+ * @param {string}   [options.workerScriptUrl='./office_thread.js'] office worker URL.
+ * @param {string}   [options.fontUrl] optional same-origin CJK font to inject.
+ * @param {(msg:string)=>void}     [options.onLog] worker 'log' lines + milestones.
+ * @param {()=>void}                [options.onReady] fired on worker 'ui_ready'
+ *        (document loaded, canvas interactive).
+ * @param {(data:any)=>void}        [options.onWorkerMessage] raw worker messages.
+ * @returns {Promise<{port: MessagePort, dispose: ()=>void}>}
+ */
+export function bootZetaOffice(options = {}) {
+  const {
+    canvas,
+    sofficeBaseUrl = DEFAULT_SOFFICE_BASE_URL,
+    zetaJsUrl = './zeta.js',
+    workerScriptUrl = './office_thread.js',
+    fontUrl,
+    onLog,
+    onReady,
+    onWorkerMessage,
+  } = options
+
+  const log = (m) => { if (onLog) onLog(m) }
+
+  if (!canvas) return Promise.reject(new Error('bootZetaOffice: canvas is required'))
+  if (typeof self !== 'undefined' && self.crossOriginIsolated === false) {
+    return Promise.reject(new Error(
+      'bootZetaOffice: page is not cross-origin isolated (SharedArrayBuffer unavailable). ' +
+      'Serve with COOP:same-origin + COEP:require-corp headers ' +
+      '(spike: node serve.mjs; product: Electron onHeadersReceived).'))
+  }
+
+  return new Promise(async (resolve, reject) => {
+    // --- optional CJK font fetch (injected in preRun, before fontconfig scan) ---
+    let cjkBytes = null
+    if (fontUrl) {
+      try {
+        const r = await fetch(fontUrl)
+        if (r.ok) {
+          cjkBytes = new Uint8Array(await r.arrayBuffer())
+          log('CJK font fetched (' + Math.round(cjkBytes.length / 1024) + ' KB), will inject before boot')
+        } else {
+          log('CJK font not found at ' + fontUrl + ' (skipping; CJK will be tofu)')
+        }
+      } catch (e) {
+        log('CJK font fetch failed: ' + e + ' (skipping)')
+      }
+    }
+
+    // The globals `canvas` and `Module` must exist before soffice.js loads.
+    const Module = {
+      canvas,
+      uno_scripts: [zetaJsUrl, workerScriptUrl],
+      locateFile: function (path, prefix) { return (prefix || sofficeBaseUrl) + path },
+      preRun: cjkBytes ? [function () {
+        // Runs before LibreOffice init. /instdir is NOT mounted yet at this point
+        // (FS / = tmp,home,dev,proc) but creating the dir tree and writing the
+        // font here WORKS: the LOWA data mount MERGES into MEMFS rather than
+        // replacing, so the font is present when fontconfig scans at startup.
+        // PROVEN in the spike: tofu (口口) -> real Chinese glyphs. The product
+        // bakes the font into the self-hosted LOWA bundle's font dir at build time.
+        const FS = globalThis.FS
+        const dir = '/instdir/share/fonts/truetype'
+        const parts = dir.split('/').filter(Boolean)
+        let cur = ''
+        for (let i = 0; i < parts.length; i++) { cur += '/' + parts[i]; try { FS.mkdir(cur) } catch (e) { /* exists */ } }
+        try { FS.writeFile(dir + '/AAA-CJK.ttc', cjkBytes); log('CJK font written to ' + dir + ' (before fontconfig scan)') }
+        catch (e) { log('CJK font write to FS failed: ' + e) }
+      }] : undefined,
+    }
+    if (sofficeBaseUrl !== '') {
+      Module.mainScriptUrlOrBlob = new Blob(
+        ["importScripts('" + sofficeBaseUrl + "soffice.js');"], { type: 'text/javascript' })
+    }
+    globalThis.Module = Module
+
+    function onMessage(e) {
+      const d = (e && e.data) || {}
+      if (d.cmd === 'log') log(d.msg)
+      else if (d.cmd === 'ui_ready') { log('UI ready'); if (onReady) onReady() }
+      if (onWorkerMessage) onWorkerMessage(d)
+    }
+
+    // Keep the embedded Qt window sized to the canvas.
+    const resizeTimer = setInterval(function () {
+      try { globalThis.dispatchEvent(new Event('resize')) } catch (e) { /* ignore */ }
+    }, 1000)
+
+    const dispose = () => { clearInterval(resizeTimer) }
+
+    const s = document.createElement('script')
+    s.src = sofficeBaseUrl + 'soffice.js'
+    s.onerror = () => { dispose(); reject(new Error('failed to load soffice.js from ' + sofficeBaseUrl)) }
+    // On the MAIN thread the office-thread port is Module.uno_main (NOT
+    // Module.zetajs, which exists only inside the office worker) and is available
+    // only after soffice.js has run — so wire it in onload. (Verified against the
+    // allotropia/zetajs web-office example.)
+    s.onload = function () {
+      log('soffice.js loaded — initializing office thread…')
+      Module.uno_main.then(function (port) {
+        port.onmessage = onMessage
+        log('thread port ready')
+        resolve({ port, dispose })
+      }, function (err) { dispose(); reject(new Error('uno_main rejected: ' + err)) })
+    }
+    document.body.appendChild(s)
+  })
+}

--- a/frontend/src/composables/zetaOfficeEditorEndpoint.js
+++ b/frontend/src/composables/zetaOfficeEditorEndpoint.js
@@ -1,0 +1,64 @@
+// zetaOfficeEditorEndpoint.js — the webview-side endpoint of the embedded
+// LibreOffice editor. Epic #43.
+//
+// This is the single product entry point for "what runs INSIDE the isolated
+// <webview>". It composes the three verified building blocks into one unit:
+//   1. bootZetaOffice()            (#46) — boot LOWA, get the office-worker port
+//   2. createLibreOfficeExecutor() (executor client) — drive UNO over that port
+//   3. serveExecutor()             (#48) — expose the executor to the HOST over a
+//                                          caller-supplied transport
+// so the host's createRelayExecutor(...).executeCommand(action, params) reaches
+// real LibreOffice across the isolation boundary.
+//
+// Transport-agnostic: the caller passes `transport = {send, subscribe}` (e.g.
+// portTransport(port) for a MessageChannel in the spike harness, or an Electron
+// <webview> IPC adapter in the product — ipcRenderer.sendToHost / ipcRenderer.on).
+// No Electron dependency here, so the endpoint is harness-verifiable.
+//
+// DORMANT until a webview page imports it (see the build/shell plan in the Epic
+// #43 thread): the page is a separate bundle because uni-app's h5 build won't let
+// a static/ HTML import src/ modules — it needs its own Vite entry or to inline
+// this module. That bundling + the Electron <webview partition="persist:zetaoffice">
+// host wiring is the remaining on-device step; this module is its verified core.
+//
+// IME: user typing in the canvas is a separate concern from agent commands (the
+// transparent-overlay IME layer is its own #43 task). When added, it commits
+// composed text via the SAME verified path — executor.executeCommand(
+// 'insert_at_cursor', {text}) — so it is not duplicated here.
+
+import { bootZetaOffice } from './zetaOfficeBoot.js'
+import { createLibreOfficeExecutor } from './libreofficeExecutorClient.js'
+import { serveExecutor } from './zetaOfficeRelay.js'
+
+/**
+ * Boot ZetaOffice in `canvas` and serve its executor to the host over `transport`.
+ *
+ * @param {object} opts
+ * @param {HTMLCanvasElement} opts.canvas REQUIRED (id="qtcanvas").
+ * @param {{send:(m:any)=>void, subscribe:(h:(m:any)=>void)=>(()=>void)}} opts.transport
+ *        REQUIRED host transport (e.g. portTransport(port) or an Electron IPC adapter).
+ * @param {string} [opts.sofficeBaseUrl] @param {string} [opts.zetaJsUrl]
+ * @param {string} [opts.workerScriptUrl] @param {string} [opts.fontUrl]
+ * @param {(msg:string)=>void} [opts.onLog] @param {()=>void} [opts.onReady]
+ * @returns {Promise<{executor:object, port:MessagePort, dispose:()=>void}>}
+ */
+export async function startEditorEndpoint(opts = {}) {
+  const { canvas, transport, onLog, onReady, ...bootOpts } = opts
+  if (!canvas) throw new Error('startEditorEndpoint: canvas is required')
+  if (!transport || typeof transport.send !== 'function' || typeof transport.subscribe !== 'function') {
+    throw new Error('startEditorEndpoint: transport {send, subscribe} is required')
+  }
+
+  const { port, dispose: disposeBoot } = await bootZetaOffice({ canvas, onLog, onReady, ...bootOpts })
+
+  const executor = createLibreOfficeExecutor({ onError: onLog })
+  executor.connect(port)
+
+  const served = serveExecutor({ executor, send: transport.send, subscribe: transport.subscribe })
+
+  return {
+    executor,
+    port,
+    dispose() { served.dispose(); disposeBoot() },
+  }
+}

--- a/frontend/src/composables/zetaOfficeRelay.js
+++ b/frontend/src/composables/zetaOfficeRelay.js
@@ -1,0 +1,111 @@
+// zetaOfficeRelay.js — transport-agnostic command relay across the
+// host <-> isolated-webview boundary for the embedded LibreOffice editor.
+// Epic #43.
+//
+// WHY a relay: ZetaOffice boots inside an isolated Electron <webview> (it needs
+// cross-origin isolation, which the main window can't have — see
+// desktop/main/zetaoffice-session.js). But the AI agent command pipeline runs in
+// the HOST (project-overview.vue's handleWpsCommand). So a host executeCommand
+// must cross the boundary: the host sends {action, params}, the webview runs it
+// against the booted executor (libreofficeExecutorClient -> worker -> UNO), and
+// returns the result. This module is that relay.
+//
+// Transport-agnostic ON PURPOSE: the caller supplies `send(msg)` and
+// `subscribe(handler) -> unsubscribe`. That lets the SAME relay run over
+// window.postMessage / a MessageChannel (how the Phase 0 spike verifies it
+// against a real LibreOffice) AND over Electron <webview> IPC
+// (webview.send / ipcRenderer.sendToHost) in the product — no Electron
+// dependency in this module, so it is unit-verifiable.
+//
+// Chosen over a one-time MessagePort transfer (webview -> host) because a
+// per-command relay does not depend on a MessagePort surviving the
+// isolated<->non-isolated boundary, which would need on-device validation
+// first. (Transfer stays a possible later optimization — see #47 notes.)
+
+const TAG = 'lo-relay' // ignore unrelated messages on a shared channel
+
+/**
+ * WEBVIEW side: serve a booted executor to the host. Listens for exec requests
+ * and replies with results, correlated by reqId.
+ *
+ * @param {object} args
+ * @param {{executeCommand:(a:string,p:object)=>Promise<any>}} args.executor
+ *        the booted LibreOffice executor (e.g. libreofficeExecutorClient).
+ * @param {(msg:any)=>void} args.send post a message to the host.
+ * @param {(handler:(msg:any)=>void)=>(()=>void)} args.subscribe register a
+ *        host-message handler; returns an unsubscribe fn.
+ * @returns {{dispose:()=>void}}
+ */
+export function serveExecutor({ executor, send, subscribe }) {
+  const off = subscribe(async (msg) => {
+    if (!msg || msg.__lo !== TAG || msg.type !== 'exec') return
+    let result
+    try {
+      result = await executor.executeCommand(msg.action, msg.params || {})
+    } catch (e) {
+      result = { success: false, message: e && e.message ? e.message : String(e) }
+    }
+    send({ __lo: TAG, type: 'result', reqId: msg.reqId, result })
+  })
+  return { dispose: off }
+}
+
+/**
+ * HOST side: an executeCommand(action, params) that round-trips to the webview.
+ * SAME contract as useWpsBridge / libreofficeExecutorClient, so useEditorBridge
+ * can use it as the LibreOffice executor when the editor lives in a webview.
+ *
+ * @param {object} args
+ * @param {(msg:any)=>void} args.send post a message to the webview.
+ * @param {(handler:(msg:any)=>void)=>(()=>void)} args.subscribe register a
+ *        webview-message handler; returns an unsubscribe fn.
+ * @param {number} [args.timeoutMs=30000]
+ * @returns {{executeCommand:(a:string,p?:object)=>Promise<any>, dispose:()=>void}}
+ */
+export function createRelayExecutor({ send, subscribe, timeoutMs = 30000 }) {
+  let seq = 0
+  const pending = new Map() // reqId -> {resolve, timer}
+  const off = subscribe((msg) => {
+    if (!msg || msg.__lo !== TAG || msg.type !== 'result') return
+    const entry = pending.get(msg.reqId)
+    if (!entry) return
+    clearTimeout(entry.timer)
+    pending.delete(msg.reqId)
+    entry.resolve(msg.result)
+  })
+
+  function executeCommand(action, params = {}) {
+    const reqId = 'rly_' + Date.now() + '_' + (++seq)
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        if (pending.has(reqId)) {
+          pending.delete(reqId)
+          resolve({ success: false, message: 'LibreOffice relay timeout: ' + action })
+        }
+      }, timeoutMs)
+      pending.set(reqId, { resolve, timer })
+      send({ __lo: TAG, type: 'exec', reqId, action, params })
+    })
+  }
+
+  return { executeCommand, dispose: off }
+}
+
+/**
+ * Adapter: build {send, subscribe} for a MessagePort (MessageChannel port or an
+ * <iframe>/worker port). Used by the spike harness to simulate the
+ * host<->webview boundary, and reusable wherever a MessagePort is the transport.
+ *
+ * @param {MessagePort} port
+ */
+export function portTransport(port) {
+  return {
+    send: (msg) => port.postMessage(msg),
+    subscribe: (handler) => {
+      const f = (e) => handler(e.data)
+      port.addEventListener('message', f)
+      if (typeof port.start === 'function') port.start()
+      return () => port.removeEventListener('message', f)
+    },
+  }
+}

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -1,0 +1,71 @@
+// editor-main.js — entry for the embedded LibreOffice editor page that runs
+// INSIDE the isolated <webview>. Epic #43.
+//
+// Bundled by the dedicated Vite build (frontend/vite.zetaoffice.config.js), NOT
+// by uni-app: uni-app's h5 build won't let a static/ page import src/ modules,
+// so this page is its own self-contained bundle that pulls in the verified
+// product composables (startEditorEndpoint -> bootZetaOffice + executor +
+// serveExecutor). The build output (dist/zetaoffice/) ships in the desktop app
+// and is loaded by <webview partition="persist:zetaoffice"> (isolated by
+// desktop/main/zetaoffice-session.js).
+//
+// Transport auto-detect keeps the page verifiable OUTSIDE Electron too: in an
+// Electron <webview> it talks to the host over ipcRenderer; in a plain browser /
+// iframe it falls back to window.parent.postMessage, so the Phase 0 spike (and a
+// browser) can drive it the same way the host will.
+
+import { startEditorEndpoint } from '../composables/zetaOfficeEditorEndpoint.js'
+
+// Electron renderer require is a runtime property access (NOT a static import),
+// so the bundler leaves it alone and the browser fallback path stays clean.
+function getIpcRenderer() {
+  try {
+    if (typeof window !== 'undefined' && typeof window.require === 'function') {
+      return window.require('electron').ipcRenderer
+    }
+  } catch (e) { /* not Electron */ }
+  return null
+}
+
+// {send, subscribe} over the host boundary — Electron <webview> IPC if present,
+// else postMessage to the parent (browser/iframe/spike harness).
+function pickTransport() {
+  const ipc = getIpcRenderer()
+  if (ipc) {
+    return {
+      send: (m) => ipc.sendToHost('lo-relay', m),
+      subscribe: (h) => {
+        const f = (_e, m) => h(m)
+        ipc.on('lo-relay', f)
+        return () => ipc.removeListener('lo-relay', f)
+      },
+    }
+  }
+  const target = window.parent && window.parent !== window ? window.parent : window
+  return {
+    send: (m) => target.postMessage(m, '*'),
+    subscribe: (h) => {
+      const f = (e) => h(e.data)
+      window.addEventListener('message', f)
+      return () => window.removeEventListener('message', f)
+    },
+  }
+}
+
+// Runtime-configurable asset locations (query string), so the same bundle works
+// against the CDN LOWA in dev and a self-hosted bundle in the packaged app.
+const q = new URLSearchParams(location.search)
+
+startEditorEndpoint({
+  canvas: document.getElementById('qtcanvas'),
+  transport: pickTransport(),
+  sofficeBaseUrl: q.get('lowa') || 'https://cdn.zetaoffice.net/zetaoffice_latest/',
+  zetaJsUrl: q.get('zeta') || './zeta.js',
+  workerScriptUrl: q.get('worker') || './office_thread.js',
+  fontUrl: q.get('font') || undefined,
+  onLog: (m) => console.log('[zeta-editor]', m),
+}).then(() => {
+  console.log('[zeta-editor] endpoint ready — serving host over transport')
+}).catch((e) => {
+  console.error('[zeta-editor] boot failed:', e)
+})

--- a/frontend/src/zetaoffice/editor.html
+++ b/frontend/src/zetaoffice/editor.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- Embedded LibreOffice editor page — runs inside the isolated <webview>. Epic #43. -->
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <title>LibreOffice Editor</title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100vh; overflow: hidden; background: #fff; }
+    /* Qt REQUIRES id="qtcanvas"; canvas must have no border/padding (outline ok). */
+    #qtcanvas { width: 100%; height: 100%; border: 0; padding: 0; outline: 0; visibility: hidden; }
+  </style>
+</head>
+<body>
+  <canvas id="qtcanvas" contenteditable="true"
+    oncontextmenu="event.preventDefault()" onkeydown="event.preventDefault()"></canvas>
+  <script type="module" src="./editor-main.js"></script>
+</body>
+</html>

--- a/frontend/vite.zetaoffice.config.js
+++ b/frontend/vite.zetaoffice.config.js
@@ -1,0 +1,27 @@
+// vite.zetaoffice.config.js — DEDICATED build for the embedded LibreOffice
+// editor page (Epic #43). Separate from vite.config.js (uni-app) on purpose:
+// uni-app's h5 build won't let a static/ page import src/ modules, so the
+// webview editor page is its own self-contained bundle. This config does NOT use
+// the uni plugin — it is a plain Vite multi-asset build of src/zetaoffice/.
+//
+// Build:  npm run build:zetaoffice   (-> dist/zetaoffice/)
+// The output is loaded by <webview partition="persist:zetaoffice"> in the desktop
+// app. base:'./' so it works from a file/relative origin.
+
+import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'node:url'
+
+const r = (p) => fileURLToPath(new URL(p, import.meta.url))
+
+export default defineConfig({
+  root: r('src/zetaoffice'),
+  base: './',
+  build: {
+    outDir: r('dist/zetaoffice'),
+    emptyOutDir: true,
+    target: 'esnext', // top-level structured-clone / modern APIs; Electron Chromium is current
+    rollupOptions: {
+      input: r('src/zetaoffice/editor.html'),
+    },
+  },
+})


### PR DESCRIPTION
## 中文

Epic #43。解掉**装包阻塞**：uni-app h5 build 不让 `static/` 页 import `src/` 模块，故内嵌 LibreOffice 编辑器页自带一个**自包含 bundle**。

**做了什么**：
- [`frontend/src/zetaoffice/editor.html`](frontend/src/zetaoffice/editor.html) + [`editor-main.js`](frontend/src/zetaoffice/editor-main.js)：跑在隔离 `<webview>` 里的页。editor-main import 已验证的产品端点（`startEditorEndpoint` → boot + executor + serveExecutor），**自动探测宿主传输**：有 Electron `<webview>` IPC（`ipcRenderer.sendToHost`）就用它，否则退回 `window.parent.postMessage`——**故在普通浏览器/spike 里也可验证**。资产 URL（LOWA base / zeta.js / worker / 字体）走 query 配置：dev 用 CDN、装包用自托管。
- [`frontend/vite.zetaoffice.config.js`](frontend/vite.zetaoffice.config.js) + `npm run build:zetaoffice`：**纯 Vite 构建（不带 uni 插件）** `src/zetaoffice` → `dist/zetaoffice`。

**已验证**：`build:zetaoffice` 把 5 个客户端模块打成**自包含 6.1KB 产物**（无裸 import；relay/boot/executor 逻辑以字面量常量在场 `lo-relay`/`/instdir/share/fonts`/`cdn.zetaoffice.net`），**主 `build:h5` 无回归**。休眠：app 侧零 importer。

> worker 侧逻辑（`requires {anchor}`/`RecordChanges`）**正确地不在** bundle 内——那是 worker（office_thread.js）作为独立运行时资产，本就不该打进客户端 bundle。

**剩真机/装包**：①把 worker 资产（zeta.js、office_thread.js）+ 自托管 LOWA + 字体拷进 `dist/zetaoffice`，经 extraResources 打进安装包；②宿主侧接 `<webview partition=\"persist:zetaoffice\">` + `createRelayExecutor` + `installZetaOfficeIsolation()`（#47）+ 过接缝 `setEditor(EDITOR_LIBREOFFICE)`。

## English

Epic #43. Solves the packaging blocker (uni-app h5 build won't let a static/ page import src/ modules): the embedded LibreOffice editor page gets its own self-contained bundle. `editor.html`+`editor-main.js` run inside the isolated `<webview>`, import the verified `startEditorEndpoint`, and auto-detect the host transport (Electron `<webview>` IPC, else `window.parent.postMessage` so it stays browser-verifiable). `vite.zetaoffice.config.js` + `npm run build:zetaoffice` is a plain Vite build (no uni plugin) → `dist/zetaoffice`.

Verified: build:zetaoffice bundles all 5 client modules into a self-contained 6.1 kB output (no bare imports; relay/boot/executor logic present), and build:h5 is unaffected. Worker-side logic correctly stays OUT of the bundle (office_thread.js is a separate runtime asset). Dormant. Remaining (on-device): copy worker/LOWA/font assets into dist/zetaoffice + extraResources packaging, and the host-side webview + createRelayExecutor + setEditor wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)