### PR TITLE
feat(libreoffice): host-side webview wiring scaffold + editor build assets (dormant) / 宿主侧 webview 接线脚手架 + 编辑器构建资产(休眠)

### DIFF
--- a/frontend/src/composables/useEditorBridge.js
+++ b/frontend/src/composables/useEditorBridge.js
@@ -36,15 +36,20 @@ import { useLibreOfficeBridge } from './useLibreOfficeBridge.js'
 export const EDITOR_WPS = 'wps'
 export const EDITOR_LIBREOFFICE = 'libreoffice'
 
-export function useEditorBridge(initialEditor = EDITOR_WPS) {
+export function useEditorBridge(initialEditor = EDITOR_WPS, opts = {}) {
   const activeEditor = ref(initialEditor)
   const wps = useWpsBridge()
-  const libre = useLibreOfficeBridge()
+  // The LibreOffice executor is pluggable. Default = the in-context bridge (worker
+  // port via connectLibreOffice). The webview architecture passes the host-side
+  // relay executor instead:
+  //   useEditorBridge(EDITOR_WPS, { libreExecutor: createWebviewEditorExecutor(webviewEl) })
+  // — see useZetaOfficeWebview.js. Both expose executeCommand(action, params).
+  const libre = opts.libreExecutor || useLibreOfficeBridge()
 
-  // Wire the embedded ZetaOffice worker thread port (Module.uno_main result).
-  // Called once when the ZetaOffice editor finishes booting; safe to leave
-  // uncalled while the active editor stays WPS.
-  const connectLibreOffice = (port) => libre.connect(port)
+  // Wire the embedded ZetaOffice worker thread port (Module.uno_main result) —
+  // only meaningful for the in-context executor; the webview relay executor owns
+  // the worker on the other side of the boundary, so this is a no-op for it.
+  const connectLibreOffice = (port) => (typeof libre.connect === 'function' ? libre.connect(port) : undefined)
 
   // Editor-agnostic dispatch. `ctx` carries editor-specific handles the seam
   // normalizes away — currently only WPS's live document instance, which the
@@ -63,6 +68,6 @@ export function useEditorBridge(initialEditor = EDITOR_WPS) {
     setEditor,
     executeCommand,
     connectLibreOffice,
-    isLibreOfficeConnected: libre.isConnected,
+    isLibreOfficeConnected: libre.isConnected || (() => true),
   }
 }

--- a/frontend/src/composables/useZetaOfficeWebview.js
+++ b/frontend/src/composables/useZetaOfficeWebview.js
@@ -1,0 +1,55 @@
+// useZetaOfficeWebview.js — HOST-side wiring for the embedded LibreOffice editor.
+// Epic #43.
+//
+// The editor page (frontend/src/zetaoffice/, built by vite.zetaoffice.config.js)
+// runs inside an Electron <webview partition="persist:zetaoffice"> (isolated by
+// desktop/main/zetaoffice-session.js). This module is the HOST counterpart: it
+// turns that <webview> element into a LibreOffice executor with the SAME
+// executeCommand(action, params) contract as the other bridges, so it can be
+// handed to useEditorBridge as the LibreOffice executor.
+//
+// Flow: host createRelayExecutor (#48) --webview IPC--> editor page's
+// serveExecutor --> libreofficeExecutorClient --> office worker --> UNO --> real
+// LibreOffice, and back. The per-command relay protocol + executor are verified
+// against a real LibreOffice (#48/#49); only this Electron <webview> IPC adapter
+// is device-specific.
+//
+// Electron <webview> IPC: host -> page is webviewEl.send(channel, msg); page ->
+// host is ipcRenderer.sendToHost(channel, msg) (see editor-main.js), surfaced on
+// the host as a 'ipc-message' event with {channel, args}. The page side needs a
+// preload exposing ipcRenderer (nodeIntegrationInSubFrames / a preload script).
+//
+// DORMANT until the host renders the <webview> and selects EDITOR_LIBREOFFICE.
+
+import { createRelayExecutor } from './zetaOfficeRelay.js'
+
+const CHANNEL = 'lo-relay'
+
+/**
+ * Build a {send, subscribe} transport over an Electron <webview> element.
+ * @param {HTMLElement} webviewEl an Electron <webview> DOM element.
+ */
+export function webviewTransport(webviewEl) {
+  return {
+    send: (m) => webviewEl.send(CHANNEL, m),
+    subscribe: (h) => {
+      const f = (e) => { if (e.channel === CHANNEL) h(e.args && e.args[0]) }
+      webviewEl.addEventListener('ipc-message', f)
+      return () => webviewEl.removeEventListener('ipc-message', f)
+    },
+  }
+}
+
+/**
+ * Host-side LibreOffice executor driving the editor inside the <webview>.
+ * Same executeCommand(action, params) contract as the bridges → pass to
+ * useEditorBridge(EDITOR_WPS, { libreExecutor: createWebviewEditorExecutor(el) }).
+ *
+ * @param {HTMLElement} webviewEl an Electron <webview> DOM element.
+ * @param {{timeoutMs?:number}} [opts]
+ * @returns {{executeCommand:(a:string,p?:object)=>Promise<any>, dispose:()=>void}}
+ */
+export function createWebviewEditorExecutor(webviewEl, opts = {}) {
+  const transport = webviewTransport(webviewEl)
+  return createRelayExecutor({ send: transport.send, subscribe: transport.subscribe, timeoutMs: opts.timeoutMs })
+}

--- a/frontend/src/zetaoffice/README.md
+++ b/frontend/src/zetaoffice/README.md
@@ -1,0 +1,73 @@
+# Embedded LibreOffice editor (ZetaOffice) — assembly
+
+Epic #43. This directory is the webview-side editor page; the host-side and
+Electron pieces live elsewhere. Everything here is **dormant** — the WPS editor
+still ships unchanged until the host renders the `<webview>` and selects
+`EDITOR_LIBREOFFICE`.
+
+## The six pieces (all landed, dormant)
+
+| Piece | Where | Status |
+|---|---|---|
+| Editor-agnostic dispatch seam | `composables/useEditorBridge.js` | #45 |
+| ZetaOffice boot | `composables/zetaOfficeBoot.js` | #46 ✅ verified vs real LO |
+| Office worker UNO commands | `public/office_thread.js` (+ `zeta.js` bridge) | from #44 |
+| Executor client | `composables/libreofficeExecutorClient.js` | verified |
+| Host↔webview command relay | `composables/zetaOfficeRelay.js` | #48 ✅ verified |
+| Webview-side endpoint | `composables/zetaOfficeEditorEndpoint.js` | #49 ✅ verified |
+| This page (boot+serve) | `zetaoffice/editor.{html,js}` | #51 |
+| Dedicated build | `vite.zetaoffice.config.js` | #51 ✅ self-contained output |
+| Electron partition isolation | `desktop/main/zetaoffice-session.js` | #47 |
+| Host webview executor | `composables/useZetaOfficeWebview.js` | this PR |
+
+## Build
+
+```
+cd frontend && npm run build:zetaoffice      # -> dist/zetaoffice/
+```
+Output = `editor.html` + the client bundle + `zeta.js` + `office_thread.js`. Only
+the LOWA runtime (`soffice.{js,wasm,data}`) + CJK fonts are loaded at runtime
+(CDN in dev via `sofficeBaseUrl`; self-host them for the packaged app).
+
+> `public/{zeta.js,office_thread.js}` are currently **copies** of
+> `experiments/zetaoffice-spike/`. TODO: unify to a single source (make these
+> canonical and have the spike load them) to avoid drift.
+
+## Data flow
+
+```
+host (project-overview)                     isolated <webview partition="persist:zetaoffice">
+  useEditorBridge(EDITOR_LIBREOFFICE)          editor.html -> startEditorEndpoint
+    libreExecutor =                              bootZetaOffice -> office worker (UNO)
+      createWebviewEditorExecutor(webviewEl)     serveExecutor  <—— ipcRenderer.sendToHost
+        createRelayExecutor  ——webview.send——>   (lo-relay channel)
+```
+
+## Remaining on-device wiring (apply on a real machine; needs Electron)
+
+1. **Self-host LOWA + fonts**: download the `zetaoffice_latest` runtime + bake
+   Noto/思源 CJK (OFL) into the bundle; point `editor.html?lowa=...&font=...` (or
+   the defaults) at the packaged copies. Add `dist/zetaoffice` to
+   electron-builder `extraResources`.
+2. **Electron main** (`desktop/main/main.js`, once after `app.whenReady()`):
+   ```js
+   require('./zetaoffice-session').installZetaOfficeIsolation()
+   ```
+   Serve `dist/zetaoffice` to the webview over **http** (a tiny local server like
+   the spike's, or a custom protocol) — NOT file:// (COEP/cross-origin isolation
+   needs response headers). Validate on-device that `onHeadersReceived` on the
+   `persist:zetaoffice` partition makes the webview cross-origin isolated.
+3. **Webview preload**: expose `ipcRenderer` to the editor page so its IPC
+   transport works (`ipcRenderer.sendToHost`/`on`); set `webPreferences`
+   accordingly on the `<webview>`.
+4. **Host (project-overview.vue)**: render
+   `<webview partition="persist:zetaoffice" src="http://.../editor.html">`; build
+   the bridge once with the webview executor:
+   ```js
+   const editor = useEditorBridge(EDITOR_WPS, {
+     libreExecutor: createWebviewEditorExecutor(this.$refs.zetaWebview),
+   })
+   ```
+   Route `handleWpsCommand` through `editor.executeCommand(action, params, { wpsInstance })`
+   and call `editor.setEditor(EDITOR_LIBREOFFICE)` behind a gray-rollout flag.
+5. **IME overlay** + **perf** (load an existing 50-page docx) — separate #43 tasks.

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -1,0 +1,399 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * ZetaOffice spike — OFFICE WORKER thread (#39 Phase 0).
+ *
+ * This file is loaded INTO the LibreOffice WASM em-pthread worker via
+ * Module.uno_scripts. Here `Module.zetajs` resolves to the zetajs UNO bridge
+ * (on the MAIN thread it resolves to the thread *port* instead — see index.html).
+ *
+ * Patterns below are taken verbatim from allotropia/zetajs examples
+ * (simple-examples + web-office). The four #39 acceptance probes are wired as
+ * message handlers driven by buttons on the main thread.
+ *
+ * The deliverable of this spike is the VERDICT on the four probes, run on a real
+ * device — not a green checkmark here. Lines marked VERIFY need a real run to
+ * confirm against the current zetajs beta API.
+ */
+'use strict';
+
+// zetajs environment (global for easier debugging in the worker dev-tools).
+let zetajs, css;
+let context, desktop, xModel, ctrl;
+let anchorSeq = 0; // names hidden bookmarks used as stable location anchors (§0.2)
+
+function post(cmd, data) {
+  zetajs.mainPort.postMessage(Object.assign({ cmd }, data || {}));
+}
+function log(msg) { post('log', { msg: String(msg) }); }
+function errStr(e) {
+  try { return zetajs.getAnyType(zetajs.catchUnoException(e)) + ' ' + (e && e.message || ''); }
+  catch { return String(e && e.message || e); }
+}
+
+// §0.2 anchors: a bookmark spanning a text range is a STABLE location handle that
+// moves with edits — the model-native replacement for fragile integer offsets.
+const ANCHOR_PREFIX = '__ai_anchor_';
+function anchorBookmark(range) {
+  const name = ANCHOR_PREFIX + (++anchorSeq);
+  const bm = xModel.createInstance('com.sun.star.text.Bookmark');
+  bm.setName(name);
+  xModel.getText().insertTextContent(range, bm, true); // bAbsorb: bookmark spans the range
+  return name;
+}
+function anchorRange(name) {
+  const bms = xModel.getBookmarks();
+  if (!bms.hasByName(name)) return null;
+  return bms.getByName(name).getAnchor(); // XTextRange
+}
+
+// ---- boot: open a fresh Writer doc seeded with Chinese + English ----------
+function bootDoc() {
+  context = zetajs.getUnoComponentContext();
+  desktop = css.frame.Desktop.create(context);
+  xModel = desktop.loadComponentFromURL('private:factory/swriter', '_default', 0, []);
+  ctrl = xModel.getCurrentController();
+  try { ctrl.getFrame().getContainerWindow().FullScreen = true; } catch {}
+
+  // Seed REAL paragraphs (PARAGRAPH_BREAK), not '\n' line breaks within one
+  // paragraph — so paragraph-indexed commands (get_paragraph/modify_paragraph/
+  // get_outline) are meaningfully testable.
+  const xText = xModel.getText();
+  const cur = xText.createTextCursor();
+  const lines = [
+    'AI Workdeck × LibreOffice WASM 原型 / prototype.',
+    '请在此用系统输入法输入中文，观察候选与上屏 / Type Chinese here with your IME.',
+    'Search target: LibreOffice — used by the redline probe.'
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    xText.insertString(cur, lines[i], false);
+    if (i < lines.length - 1) xText.insertControlCharacter(cur, css.text.ControlCharacter.PARAGRAPH_BREAK, false);
+  }
+
+  installKeyHandler();
+  post('ui_ready');
+  log('文档就绪 swriter / doc ready');
+}
+
+// ---- probe 1: 中文 IME diagnostics --------------------------------------
+// XKeyHandler reports physical key events. The OPEN QUESTION (#39) is whether
+// IME *composition* (candidate selection -> commit) reaches the canvas at all,
+// or is swallowed by Qt/emscripten. The main thread also logs DOM
+// compositionstart/update/end on the canvas; compare the two streams.
+function installKeyHandler() {
+  const handler = zetajs.unoObject([css.awt.XKeyHandler], {
+    keyPressed(e) { post('key', { phase: 'pressed', code: e.KeyCode, ch: e.KeyChar }); return false; },
+    keyReleased(e) { post('key', { phase: 'released', code: e.KeyCode, ch: e.KeyChar }); return false; }
+  });
+  ctrl.addKeyHandler(handler);  // VERIFY: addKeyHandler (NOT addKeyListener)
+  log('XKeyHandler 已装 / installed — 打中文看 key 日志（IME 合成可能绕过 XKeyHandler，这正是要验证的）');
+}
+
+// ---- probe 2: selection via UNO (model-native, NO text offset) -----------
+function testSelection() {
+  try {
+    const sel = ctrl.getSelection();   // XSelectionSupplier -> usually an XIndexAccess of text ranges
+    const out = [];
+    if (sel && typeof sel.getCount === 'function') {
+      for (let i = 0; i < sel.getCount(); i++) out.push(sel.getByIndex(i).getString());
+    } else if (sel && typeof sel.getString === 'function') {
+      out.push(sel.getString());
+    }
+    log('选区 / selection [' + out.length + ']: ' + JSON.stringify(out));
+  } catch (e) { log('selection ERROR: ' + errStr(e)); }
+}
+
+// ---- probe 3: tracked change (redline) via model-native search -----------
+// This is the RFC v2 thesis in code: replace text found by XSearchable
+// (createSearchDescriptor + findFirst/findNext) — NOT by plain-text offset —
+// with RecordChanges ON, so every edit lands as a tracked change.
+function testRedline() {
+  try {
+    xModel.setPropertyValue('RecordChanges', true);  // RFC: revisions should default ON
+    log('RecordChanges = ' + xModel.getPropertyValue('RecordChanges'));
+    const sd = xModel.createSearchDescriptor();
+    sd.setSearchString('LibreOffice');
+    let hit = xModel.findFirst(sd), n = 0;
+    while (hit !== null && n < 100) {
+      hit.setString('LibreOffice〔AI 修订 / redline〕');
+      hit = xModel.findNext(hit, sd);
+      n++;
+    }
+    log('redline: 经 findFirst/findNext 替换 ' + n + ' 处 / replaced ' + n
+      + ' match(es). 看 canvas 是否出现修订标记 / check canvas for tracked-change marks.');
+  } catch (e) { log('redline ERROR: ' + errStr(e)); }
+}
+
+// ---- probe 4: performance — generate N pages and time it -----------------
+function testPerf(pages) {
+  try {
+    const t0 = performance.now();
+    const xText = xModel.getText();
+    const cur = xText.createTextCursor();
+    for (let p = 0; p < pages; p++) {
+      for (let l = 0; l < 28; l++) {
+        xText.insertString(cur,
+          '第' + (p + 1) + '页 第' + (l + 1) + '行 合同条款示例 / contract clause sample line.\n', false);
+      }
+      try { cur.setPropertyValue('BreakType', css.style.BreakType.PAGE_AFTER); } catch {}  // VERIFY enum
+    }
+    const ms = Math.round(performance.now() - t0);
+    log('perf/generate: ' + pages + ' 页耗时 ' + ms + ' ms（仅写入；渲染/滚动流畅度需肉眼）');
+  } catch (e) { log('perf ERROR: ' + errStr(e)); }
+}
+
+// ---- probe 5: insert CJK via UNO (NO IME) --------------------------------
+// Separates two questions that "can't type Chinese" conflates:
+//   (a) can LibreOffice WASM store + RENDER Chinese?  (this probe)
+//   (b) can you TYPE Chinese via the system IME?      (Qt5-WASM input path)
+// Qt-for-WebAssembly (Qt5) has little/no IME support upstream, so (b) likely
+// fails. If THIS probe makes 中文 appear on the canvas, then the migration's
+// IME answer is a custom JS-composition -> UNO-insert bridge (we control UNO),
+// not Qt's input. If Chinese shows as boxes/tofu, it's a deeper font problem.
+function testInsertText(text) {
+  try {
+    const t = text || '中文渲染测试 中華人民共和國 ABC 123';
+    const xText = xModel.getText();
+    let vc = null;
+    try { vc = ctrl.getViewCursor(); } catch {}
+    if (vc) {
+      // NOT setString(): that REPLACES the cursor's range and leaves the inserted
+      // text SELECTED, so the next insert overwrites it (reported bug). Use
+      // insertString(range, str, bAbsorb=false): inserts at the cursor and leaves
+      // the cursor collapsed AFTER the text, so consecutive inserts append and
+      // nothing stays selected. collapseToEnd() first clears any prior selection
+      // (e.g. from a click-drag) so we append rather than overwrite.
+      try { vc.collapseToEnd(); } catch (e) {}
+      xText.insertString(vc, t, false);
+      try { vc.collapseToEnd(); } catch (e) {}
+      log('inserttext: 经 UNO insertString 在光标处插入「' + t + '」(追加、不选中)。');
+    } else {
+      xText.insertString(xText.getEnd(), '\n' + t, false);
+      log('inserttext: 经 UNO XText.insertString 追加「' + t + '」(无 ViewCursor 回退)。');
+    }
+  } catch (e) { log('inserttext ERROR: ' + errStr(e)); }
+}
+
+// ==========================================================================
+// Editor executor command contract (Epic #43 task ④, worker side).
+// Implements the SAME editor-agnostic actions that useWpsBridge.executeCommand
+// dispatches, via UNO — so frontend/src/composables/useLibreOfficeBridge.js can
+// drive LibreOffice with the backend's existing commands. Each handler returns a
+// plain result object; the dispatcher posts {cmd:'result', reqId, result} back.
+// [verified] handlers use the Phase 0-proven primitives; [todo] are stubs.
+// ==========================================================================
+const EXEC = {
+  // [verified] insert at the view cursor (append, not select) — see testInsertText.
+  insert_at_cursor(p) {
+    const xText = xModel.getText();
+    const vc = ctrl.getViewCursor();
+    vc.collapseToEnd();
+    xText.insertString(vc, String(p.text || ''), false);
+    vc.collapseToEnd();
+    return { success: true, inserted: String(p.text || '') };
+  },
+  // [verified] replace selection if any, else insert at cursor.
+  replace_selection(p) {
+    const xText = xModel.getText();
+    const vc = ctrl.getViewCursor();
+    const t = String(p.text || '');
+    // bAbsorb=true replaces the cursor's spanned text; for a collapsed cursor it inserts.
+    xText.insertString(vc, t, vc.getString().length > 0);
+    vc.collapseToEnd();
+    return { success: true, text: t };
+  },
+  // [verified] model-native search + redline (RFC §0.2: no integer offsets).
+  find_replace(p) {
+    xModel.setPropertyValue('RecordChanges', true);
+    const sd = xModel.createSearchDescriptor();
+    sd.setSearchString(String(p.findText || ''));
+    const all = p.replaceAll !== false;
+    let hit = xModel.findFirst(sd), n = 0;
+    while (hit !== null) {
+      hit.setString(String(p.replaceText || ''));
+      n++;
+      if (!all) break;
+      hit = xModel.findNext(hit, sd);
+    }
+    return { success: true, replaced: n, recordChanges: true };
+  },
+  // [verified] current selection text (anchor, not integer offset).
+  get_selection() {
+    const sel = ctrl.getSelection();
+    let text = '';
+    try {
+      if (sel && typeof sel.getByIndex === 'function' && sel.getCount() > 0) text = sel.getByIndex(0).getString();
+      else if (sel && typeof sel.getString === 'function') text = sel.getString();
+    } catch (e) {}
+    return { success: true, text: text, hasSelection: text.length > 0 };
+  },
+  // [verified] locate matches via XSearchable; return count + texts (anchors held
+  // worker-side in the real impl — NOT integer offsets exposed to the model).
+  // [verified] locate matches and return STABLE ANCHORS (bookmark ids), not
+  // integer offsets (§0.2). Downstream set_selection/replace_at_position take
+  // these anchorIds. Collect ranges first, then bookmark, so anchoring doesn't
+  // perturb the findNext iteration.
+  find_text_locations(p) {
+    const sd = xModel.createSearchDescriptor();
+    sd.setSearchString(String(p.keyword || ''));
+    try { sd.setPropertyValue('SearchCaseSensitive', !!p.matchCase); } catch (e) {}
+    const ranges = [];
+    let hit = xModel.findFirst(sd);
+    while (hit !== null && ranges.length < 500) { ranges.push(hit); hit = xModel.findNext(hit, sd); }
+    const matches = ranges.map(function (r) {
+      let anchorId = null;
+      try { anchorId = anchorBookmark(r); } catch (e) {}
+      return { anchorId: anchorId, text: r.getString() };
+    });
+    return { success: true, count: matches.length, matches: matches };
+  },
+  // [verified-extend] replace the Nth (0-based) match under RecordChanges.
+  replace_nth_match(p) {
+    xModel.setPropertyValue('RecordChanges', true);
+    const sd = xModel.createSearchDescriptor();
+    sd.setSearchString(String(p.findText || ''));
+    const idx = Number(p.matchIndex) || 0;
+    let hit = xModel.findFirst(sd), i = 0;
+    while (hit !== null) {
+      if (i === idx) { hit.setString(String(p.replaceText || '')); return { success: true, replacedIndex: idx }; }
+      hit = xModel.findNext(hit, sd); i++;
+    }
+    return { success: false, message: 'match index out of range: ' + idx + ' (found ' + i + ')' };
+  },
+  // [verified-extend] delete the Nth match (replace with empty) under RecordChanges.
+  delete_match(p) {
+    xModel.setPropertyValue('RecordChanges', true);
+    const sd = xModel.createSearchDescriptor();
+    sd.setSearchString(String(p.findText || ''));
+    const idx = Number(p.matchIndex) || 0;
+    let hit = xModel.findFirst(sd), i = 0;
+    while (hit !== null) {
+      if (i === idx) { hit.setString(''); return { success: true, deletedIndex: idx }; }
+      hit = xModel.findNext(hit, sd); i++;
+    }
+    return { success: false, message: 'match index out of range: ' + idx };
+  },
+  // [verified-extend] delete all/first occurrences under RecordChanges.
+  delete_text(p) {
+    xModel.setPropertyValue('RecordChanges', true);
+    const sd = xModel.createSearchDescriptor();
+    sd.setSearchString(String(p.text || ''));
+    const all = p.deleteAll !== false;
+    let hit = xModel.findFirst(sd), n = 0;
+    while (hit !== null) { hit.setString(''); n++; if (!all) break; hit = xModel.findNext(hit, sd); }
+    return { success: true, deleted: n };
+  },
+  // [verified-extend] read the Nth (0-based) paragraph's text.
+  get_paragraph(p) {
+    const idx = Number(p.index) || 0;
+    const en = xModel.getText().createEnumeration();
+    let i = 0;
+    while (en.hasMoreElements()) {
+      const el = en.nextElement();
+      if (el.supportsService && el.supportsService('com.sun.star.text.Paragraph')) {
+        if (i === idx) return { success: true, index: idx, text: el.getString() };
+        i++;
+      }
+    }
+    return { success: false, message: 'paragraph index out of range: ' + idx + ' (count ' + i + ')' };
+  },
+  // [verified-extend] modify the Nth paragraph's text under RecordChanges.
+  modify_paragraph(p) {
+    xModel.setPropertyValue('RecordChanges', true);
+    const idx = Number(p.index) || 0;
+    const en = xModel.getText().createEnumeration();
+    let i = 0;
+    while (en.hasMoreElements()) {
+      const el = en.nextElement();
+      if (el.supportsService && el.supportsService('com.sun.star.text.Paragraph')) {
+        if (i === idx) { el.setString(String(p.newText || '')); return { success: true, index: idx }; }
+        i++;
+      }
+    }
+    return { success: false, message: 'paragraph index out of range: ' + idx };
+  },
+  // [verified-extend] outline = paragraphs carrying a heading style / outline level.
+  get_outline() {
+    const en = xModel.getText().createEnumeration();
+    const outline = []; let i = 0;
+    while (en.hasMoreElements()) {
+      const el = en.nextElement();
+      if (el.supportsService && el.supportsService('com.sun.star.text.Paragraph')) {
+        let lvl = 0, style = '';
+        try { style = el.getPropertyValue('ParaStyleName') || ''; } catch (e) {}
+        try { lvl = el.getPropertyValue('OutlineLevel') || 0; } catch (e) {}
+        if (lvl > 0 || /^(Heading|标题)/.test(style)) outline.push({ paragraphIndex: i, level: lvl || 1, style: style, text: el.getString() });
+        i++;
+      }
+    }
+    return { success: true, count: outline.length, outline: outline };
+  },
+  // [verified-extend] move the view cursor to doc start/end (line/para/bookmark nav = TODO anchor).
+  goto(p) {
+    const vc = ctrl.getViewCursor();
+    const type = String(p.type || '');
+    if (type === 'start') vc.gotoStart(false);
+    else if (type === 'end') vc.gotoEnd(false);
+    else return { success: false, message: 'goto type not supported yet: ' + type + ' (anchor-based nav TODO, §0.2)' };
+    return { success: true, type: type };
+  },
+  // [verified] §0.2 anchor-based selection. Takes {anchor} (a bookmark id from
+  // find_text_locations), NOT integer offsets — those are rejected on purpose.
+  set_selection(p) {
+    if (!p.anchor) return { success: false, message: 'set_selection requires {anchor}; integer offsets unsupported (§0.2)' };
+    const range = anchorRange(String(p.anchor));
+    if (!range) return { success: false, message: 'anchor not found: ' + p.anchor };
+    ctrl.select(range);
+    return { success: true, anchor: p.anchor, text: range.getString() };
+  },
+  // [verified] §0.2 anchor-based replace, under RecordChanges (redline).
+  replace_at_position(p) {
+    if (!p.anchor) return { success: false, message: 'replace_at_position requires {anchor}; integer offsets unsupported (§0.2)' };
+    xModel.setPropertyValue('RecordChanges', true);
+    const range = anchorRange(String(p.anchor));
+    if (!range) return { success: false, message: 'anchor not found: ' + p.anchor };
+    range.setString(String(p.newText || ''));
+    return { success: true, anchor: p.anchor };
+  },
+  // housekeeping: drop the hidden anchor bookmarks.
+  clear_anchors() {
+    const bms = xModel.getBookmarks();
+    const names = (bms.getElementNames && bms.getElementNames()) || [];
+    const xText = xModel.getText();
+    let n = 0;
+    for (let i = 0; i < names.length; i++) {
+      if (names[i].indexOf(ANCHOR_PREFIX) === 0) {
+        try { xText.removeTextContent(bms.getByName(names[i])); n++; } catch (e) {}
+      }
+    }
+    return { success: true, cleared: n };
+  },
+};
+
+function execCommand(reqId, action, params) {
+  let result;
+  try {
+    const fn = EXEC[action];
+    result = fn ? fn(params || {}) : { success: false, message: 'not implemented in LibreOffice worker yet: ' + action };
+  } catch (e) {
+    result = { success: false, message: errStr(e) };
+  }
+  post('result', { reqId: reqId, result: result });
+}
+
+// ---- message loop --------------------------------------------------------
+Module.zetajs.then(function (pZetajs) {
+  zetajs = pZetajs;
+  css = zetajs.uno.com.sun.star;
+  zetajs.mainPort.onmessage = function (e) {
+    switch (e.data.cmd) {
+      case 'exec': execCommand(e.data.reqId, e.data.action, e.data.params); break;
+      case 'selection': testSelection(); break;
+      case 'redline': testRedline(); break;
+      case 'perf': testPerf(Number(e.data.pages) || 50); break;
+      case 'inserttext': testInsertText(e.data.text); break;
+      default: log('unknown cmd: ' + e.data.cmd);
+    }
+  };
+  bootDoc();
+  post('thr_running');
+});

--- a/frontend/src/zetaoffice/public/zeta.js
+++ b/frontend/src/zetaoffice/public/zeta.js
@@ -1,0 +1,1104 @@
+/* -*- Mode: JS; tab-width: 2; indent-tabs-mode: nil; js-indent-level: 2; fill-column: 100 -*- */
+// SPDX-License-Identifier: MIT
+
+'use strict';
+
+Module.zetajs = new Promise(function (resolve, reject) {
+  Module.zetajs$resolve = function() {
+    // A FinalizationRegistry for zetajs objects that own Embind objects that, in turn, should
+    // be .delete()'d (so that Embind doesn't print any "Embind found a leaked C++ instance"
+    // warnings for them); it is tied to Module so it doesn't itself get GC'ed early:
+    Module.uno$zetajs_deleteRegistry = new FinalizationRegistry(function(value) {
+      value.forEach((val) => val.delete());
+    });
+    const getProxyTarget = Symbol('getProxyTarget');
+    const keepAlive = Symbol('keepAlive');
+    function gcWrap(obj) {
+      // Embind has already registered obj at some FinalizationRegistry that prints the
+      // "Embind found a leaked C++ instance" warning, which we want to suppress; and if we
+      // registered obj itself also at our deleting FinalizationRegistry, the Embind one might
+      // fire first and still print the warning; so instead wrap obj in a Proxy and register
+      // that:
+      const proxy = new Proxy(obj, {});
+      Module.uno$zetajs_deleteRegistry.register(proxy, [obj]);
+      return proxy
+    }
+    function getEmbindSequenceCtor(componentType) {
+      let typename = componentType.toString();
+      let name = 'uno_Sequence';
+      let n = 1;
+      while (typename.startsWith('[]')) {
+        typename = typename.substr(2);
+        ++n;
+      }
+      if (n !== 1) {
+        name += n;
+      }
+      name += '_' + typename.replace(/ /g, '_').replace(/\./g, '$');
+      return Module[name];
+    };
+    function getTypeDescriptionManager() {
+      const ctx = Module.getUnoComponentContext();
+      const tdmAny = ctx.getValueByName(
+        '/singletons/com.sun.star.reflection.theTypeDescriptionManager');
+      ctx.delete();
+      const val = tdmAny.get();
+      tdmAny.delete();
+      const tdm = Module.uno.com.sun.star.container.XHierarchicalNameAccess.query(val);
+      val.delete();
+      return tdm;
+    };
+    function translateTypeDescription(td) {
+      switch (td.getTypeClass()) {
+      case Module.uno.com.sun.star.uno.TypeClass.VOID:
+        return Module.uno_Type.Void();
+      case Module.uno.com.sun.star.uno.TypeClass.BOOLEAN:
+        return Module.uno_Type.Boolean();
+      case Module.uno.com.sun.star.uno.TypeClass.BYTE:
+        return Module.uno_Type.Byte();
+      case Module.uno.com.sun.star.uno.TypeClass.SHORT:
+        return Module.uno_Type.Short();
+      case Module.uno.com.sun.star.uno.TypeClass.UNSIGNED_SHORT:
+        return Module.uno_Type.UnsignedShort();
+      case Module.uno.com.sun.star.uno.TypeClass.LONG:
+        return Module.uno_Type.Long();
+      case Module.uno.com.sun.star.uno.TypeClass.UNSIGNED_LONG:
+        return Module.uno_Type.UnsignedLong();
+      case Module.uno.com.sun.star.uno.TypeClass.HYPER:
+        return Module.uno_Type.Hyper();
+      case Module.uno.com.sun.star.uno.TypeClass.UNSIGNED_HYPER:
+        return Module.uno_Type.UnsignedHyper();
+      case Module.uno.com.sun.star.uno.TypeClass.FLOAT:
+        return Module.uno_Type.Float();
+      case Module.uno.com.sun.star.uno.TypeClass.DOUBLE:
+        return Module.uno_Type.Double();
+      case Module.uno.com.sun.star.uno.TypeClass.CHAR:
+        return Module.uno_Type.Char();
+      case Module.uno.com.sun.star.uno.TypeClass.STRING:
+        return Module.uno_Type.String();
+      case Module.uno.com.sun.star.uno.TypeClass.TYPE:
+        return Module.uno_Type.Type();
+      case Module.uno.com.sun.star.uno.TypeClass.ANY:
+        return Module.uno_Type.Any();
+      case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
+        {
+          const itd = Module.uno.com.sun.star.reflection.XIndirectTypeDescription.query(td);
+          const rtd = itd.getReferencedType();
+          itd.delete();
+          const type = translateTypeDescriptionAndDelete(rtd);
+          try {
+            return Module.uno_Type.Sequence(type);
+          } finally {
+            type.delete();
+          }
+        }
+      case Module.uno.com.sun.star.uno.TypeClass.ENUM:
+        return Module.uno_Type.Enum(td.getName());
+      case Module.uno.com.sun.star.uno.TypeClass.STRUCT:
+        return Module.uno_Type.Struct(td.getName());
+      case Module.uno.com.sun.star.uno.TypeClass.EXCEPTION:
+        return Module.uno_Type.Exception(td.getName());
+      case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+        return Module.uno_Type.Interface(td.getName());
+      default:
+        throw new Error(
+          'bad type description ' + td.getName() + ' type class ' + td.getTypeClass());
+      }
+    };
+    function translateTypeDescriptionAndDelete(td) {
+      try {
+        return translateTypeDescription(td);
+      } finally {
+        td.delete();
+      }
+    }
+    function translateToEmbind(obj, type, toDelete) {
+      switch (type.getTypeClass()) {
+      case Module.uno.com.sun.star.uno.TypeClass.ANY:
+          {
+              const {any, owning} = translateToAny(obj, Module.uno_Type.Any());
+              if (owning) {
+                  toDelete.push(any);
+              }
+              return any;
+          }
+      case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
+          if (Array.isArray(obj)) {
+              const ctype = type.getSequenceComponentType();
+              const seq = new (getEmbindSequenceCtor(ctype))(
+                  obj.length, Module.uno_Sequence.FromSize);
+              for (let i = 0; i !== obj.length; ++i) {
+                  seq.set(i, translateToEmbind(obj[i], ctype, toDelete));
+              }
+              ctype.delete();
+              toDelete.push(seq);
+              return seq;
+          }
+          break;
+      case Module.uno.com.sun.star.uno.TypeClass.STRUCT:
+      case Module.uno.com.sun.star.uno.TypeClass.EXCEPTION:
+          {
+              const val = {};
+              function walk(td) {
+                  const base = td.getBaseType();
+                  if (base !== null) {
+                      const td = Module.uno.com.sun.star.reflection.XCompoundTypeDescription
+                          .query(base);
+                      base.delete();
+                      walk(td);
+                      td.delete();
+                  }
+                  const types = td.getMemberTypes();
+                  const names = td.getMemberNames();
+                  for (let i = 0; i !== types.size(); ++i) {
+                      const name = names.get(i);
+                      const type = translateTypeDescriptionAndDelete(types.get(i));
+                      val[name] = translateToEmbind(obj[name], type, toDelete);
+                      type.delete();
+                  }
+                  types.delete();
+                  names.delete();
+              };
+              const tdm = getTypeDescriptionManager();
+              const tdAny = tdm.getByHierarchicalName(type.toString());
+              tdm.delete();
+              const ifc = tdAny.get();
+              tdAny.delete();
+              const td = Module.uno.com.sun.star.reflection.XCompoundTypeDescription.query(
+                  ifc);
+              ifc.delete();
+              walk(td);
+              td.delete();
+              return val;
+          }
+      case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+          if (obj !== null) {
+              const target = obj[getProxyTarget];
+              const handle = target === undefined ? obj : target;
+              if (handle instanceof Module.ClassHandle) {
+                  if (type.toString() === 'com.sun.star.uno.XInterface') {
+                      return handle;
+                  }
+                  const embindType = 'uno_Type_' + type.toString().replace(/\./g, '$');
+                  if (embindType === handle.$$.ptrType.registeredClass.name) {
+                      return handle;
+                  } else {
+                      const ifc = Module[embindType].query(handle);
+                      toDelete.push(ifc);
+                      return ifc;
+                  }
+              }
+          }
+          break;
+      }
+      return obj;
+    };
+    function translateToAny(obj, type) {
+      try {
+        let any;
+        let owning;
+        if (obj instanceof Module.uno_Any) {
+          any = obj;
+          owning = false;
+        } else {
+          let fromType;
+          let val;
+          if (type.getTypeClass() === Module.uno.com.sun.star.uno.TypeClass.ANY) {
+            fromType = getAnyType(obj);
+            if (fromType === undefined) {
+              throw new Error('bad UNO method call argument ' + obj);
+            }
+            val = fromAny(obj);
+          } else {
+            fromType = type;
+            val = obj;
+          }
+          const toDelete = [];
+          any = new Module.uno_Any(fromType, translateToEmbind(val, fromType, toDelete));
+          owning = true;
+          toDelete.forEach((val) => val.delete());
+        }
+        return {any, owning};
+      } finally {
+        type.delete();
+      }
+    };
+    function translateFromEmbind(val, type, precise, cleanUpVal) {
+      switch (type.getTypeClass()) {
+      case Module.uno.com.sun.star.uno.TypeClass.BOOLEAN:
+        return Boolean(val);
+      case Module.uno.com.sun.star.uno.TypeClass.TYPE:
+        return gcWrap(val);
+      case Module.uno.com.sun.star.uno.TypeClass.ANY:
+        {
+          const ty = gcWrap(val.getType());
+          let v;
+          try {
+            v = translateFromEmbind(val.get(), ty, precise, cleanUpVal);
+          } finally {
+            if (cleanUpVal) {
+              val.delete();
+            }
+          }
+          return precise ? new Any(ty, v) : v;
+        }
+      case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
+        {
+          const td = type.getSequenceComponentType();
+          const arr = [];
+          for (let i = 0; i !== val.size(); ++i) {
+            arr.push(translateFromEmbind(val.get(i), td, precise, cleanUpVal));
+          }
+          if (cleanUpVal) {
+            val.delete();
+          }
+          td.delete();
+          return arr;
+        }
+      case Module.uno.com.sun.star.uno.TypeClass.STRUCT:
+      case Module.uno.com.sun.star.uno.TypeClass.EXCEPTION:
+        {
+          const obj = {
+            [Module.unoTagSymbol]: {
+              kind: type.getTypeClass()
+                == Module.uno.com.sun.star.uno.TypeClass.STRUCT
+                ? 'struct-instance' : 'exception-instance',
+              type: type.toString()
+            }
+          };
+          function walk(td) {
+            const base = td.getBaseType();
+            if (base !== null) {
+              const td = Module.uno.com.sun.star.reflection.XCompoundTypeDescription
+                .query(base);
+              base.delete();
+              walk(td);
+              td.delete();
+            }
+            const types = td.getMemberTypes();
+            const names = td.getMemberNames();
+            for (let i = 0; i !== types.size(); ++i) {
+              const name = names.get(i);
+              const td = translateTypeDescriptionAndDelete(types.get(i));
+              obj[name] = translateFromEmbind(val[name], td, precise, cleanUpVal);
+              td.delete();
+            }
+            types.delete();
+            names.delete();
+          };
+          const tdm = getTypeDescriptionManager();
+          const tdAny = tdm.getByHierarchicalName(type.toString());
+          tdm.delete();
+          const ifc = tdAny.get();
+          tdAny.delete();
+          const td = Module.uno.com.sun.star.reflection.XCompoundTypeDescription.query(
+            ifc);
+          ifc.delete();
+          walk(td);
+          td.delete();
+          return obj;
+        }
+      case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+        return proxy(val);
+      default:
+        return val;
+      }
+    };
+    function translateFromAny(any, type, precise) {
+      if (type.getTypeClass() === Module.uno.com.sun.star.uno.TypeClass.ANY) {
+        return translateFromEmbind(any, type, precise, false);
+      } else {
+        const td = any.getType();
+        const val = translateFromEmbind(any.get(), td, precise, true);
+        td.delete();
+        return val;
+      }
+    };
+    function translateFromAnyAndDelete(any, type, precise) {
+      const val = translateFromAny(any, type, precise);
+      any.delete();
+      return val;
+    };
+    function proxy(unoObject) {
+      if (unoObject === null) {
+        return null;
+      }
+      const prox = {};
+      const toDelete = [unoObject];
+      Module.uno$zetajs_deleteRegistry.register(prox, toDelete);
+      prox[getProxyTarget] = unoObject;
+      prox.$precise = {[getProxyTarget]: unoObject, [keepAlive]: prox};
+      // css.script.XInvocation2::getInfo invents additional members (e.g., an attribute "Foo"
+      // if there is a method "getFoo"), so better determine the actual set of members via
+      // css.lang.XTypeProvider::getTypes:
+      const typeprov = Module.uno.com.sun.star.lang.XTypeProvider.query(unoObject);
+      if (typeprov !== null) {
+        const ty = Module.uno_Type.Interface('com.sun.star.uno.XInterface');
+        const arg = new Module.uno_Any(ty, unoObject);
+        ty.delete();
+        const args = new Module.uno_Sequence_any([arg]);
+        arg.delete();
+        const ctx = Module.getUnoComponentContext();
+        const serv = Module.uno.com.sun.star.script.Invocation.create(ctx);
+        ctx.delete();
+        const inst = serv.createInstanceWithArguments(args);
+        args.delete();
+        serv.delete();
+        const invoke = Module.uno.com.sun.star.script.XInvocation2.query(inst);
+        inst.delete();
+        toDelete.push(invoke);
+        function invokeMethod(name, args, precise) {
+          const info = invoke.getInfoForName(name, true);
+          try {
+            if (args.length != info.aParamTypes.size()) {
+              throw new Error(
+                'bad number of arguments in call to ' + name + ', expected ' +
+                  info.aParamTypes.size() + ' vs. actual ' + args.length);
+            }
+            const unoArgs = new Module.uno_Sequence_any(
+              info.aParamTypes.size(), Module.uno_Sequence.FromSize);
+            const deleteArgs = [];
+            for (let i = 0; i !== info.aParamTypes.size(); ++i) {
+              switch (info.aParamModes.get(i)) {
+              case Module.uno.com.sun.star.reflection.ParamMode.IN:
+                {
+                  const {any, owning} = translateToAny(
+                    args[i], info.aParamTypes.get(i));
+                  unoArgs.set(i, any);
+                  if (owning) {
+                    deleteArgs.push(any);
+                  }
+                  break;
+                }
+              case Module.uno.com.sun.star.reflection.ParamMode.INOUT:
+                {
+                  const {any, owning} = translateToAny(
+                    args[i].val, info.aParamTypes.get(i));
+                  unoArgs.set(i, any);
+                  if (owning) {
+                    deleteArgs.push(any);
+                  }
+                  break;
+                }
+              }
+            }
+            const outparamindex_out = new Module.uno_InOutParam_sequence_short;
+            const outparam_out = new Module.uno_InOutParam_sequence_any;
+            let ret;
+            try {
+              ret = invoke.invoke(name, unoArgs, outparamindex_out, outparam_out);
+            } catch (e) {
+              outparamindex_out.delete();
+              outparam_out.delete();
+              const exc = catchUnoException(e);
+              if (getAnyType(exc) ==
+                'com.sun.star.reflection.InvocationTargetException')
+              {
+                throwUnoException(exc.TargetException);
+              } else {
+                throwUnoException(exc);
+              }
+            } finally {
+              deleteArgs.forEach((arg) => arg.delete());
+              unoArgs.delete();
+            }
+            const outparamindex = outparamindex_out.val;
+            outparamindex_out.delete();
+            const outparam = outparam_out.val;
+            outparam_out.delete();
+            for (let i = 0; i !== outparamindex.size(); ++i) {
+              const j = outparamindex.get(i);
+              const ty = info.aParamTypes.get(j);
+              args[j].val = translateFromAnyAndDelete(outparam.get(i), ty, precise);
+              ty.delete();
+            }
+            outparamindex.delete();
+            outparam.delete();
+            return translateFromAnyAndDelete(ret, info.aType, precise);
+          } finally {
+            info.aType.delete();
+            info.aParamTypes.delete();
+            info.aParamModes.delete();
+          }
+        };
+        function invokeGetter(name, precise) {
+          const info = invoke.getInfoForName(name, true);
+          try {
+            const ret = invoke.getValue(name);
+            return translateFromAnyAndDelete(ret, info.aType, precise);
+          } finally {
+            info.aType.delete();
+            info.aParamTypes.delete();
+            info.aParamModes.delete();
+          }
+        };
+        function invokeSetter(name, value) {
+          const info = invoke.getInfoForName(name, true);
+          const deleteArgs = [];
+          const {any, owning} = translateToAny(value, info.aType);
+          if (owning) {
+            deleteArgs.push(any);
+          }
+          try {
+            invoke.setValue(name, any);
+          } finally {
+            // info.aType already deleted in translateToAny above
+            info.aParamTypes.delete();
+            info.aParamModes.delete();
+          }
+        };
+        prox.queryInterface = function() {
+            return invokeMethod('queryInterface', arguments, false); };
+        prox.$precise.queryInterface = function() {
+            return invokeMethod('queryInterface', arguments, true); };
+        const seen = {'com.sun.star.uno.XInterface': true};
+        function walk(td) {
+          const iname = td.getName();
+          if (!Object.hasOwn(seen, iname)) {
+            seen[iname] = true;
+            if (td.getTypeClass() !== Module.uno.com.sun.star.uno.TypeClass.INTERFACE) {
+              throw new Error('not a UNO interface type: ' + iname);
+            }
+            const itd = Module.uno.com.sun.star.reflection.XInterfaceTypeDescription2
+                .query(td);
+            const bases = itd.getBaseTypes();
+            for (let i = 0; i !== bases.size(); ++i) {
+              const base = bases.get(i);
+              walk(base);
+              base.delete();
+            }
+            bases.delete();
+            const mems = itd.getMembers();
+            for (let i = 0; i !== mems.size(); ++i) {
+              const mem = mems.get(i);
+              const name = mem.getMemberName();
+              const atd = Module.uno.com.sun.star.reflection
+                  .XInterfaceAttributeTypeDescription.query(mem);
+              mem.delete();
+              if (atd !== null) {
+                Object.defineProperty(prox, name, {
+                  enumerable: true,
+                  get() { return invokeGetter(name, false); },
+                  set: atd.isReadOnly()
+                    ? undefined
+                    : function(value) { return invokeSetter(name, value); }});
+                Object.defineProperty(prox.$precise, name, {
+                  enumerable: true,
+                  get() { return invokeGetter(name, true); },
+                  set: atd.isReadOnly()
+                    ? undefined
+                    : function(value) { return invokeSetter(name, value); }});
+                atd.delete();
+              } else {
+                prox[name] = function() { return invokeMethod(name, arguments, false); };
+                prox.$precise[name] = function() { return invokeMethod(name, arguments, true); };
+              }
+            }
+            itd.delete();
+            mems.delete();
+            if (iname === 'com.sun.star.container.XEnumeration') {
+              prox[Symbol.iterator] = function*() {
+                while (prox.hasMoreElements()) {
+                  yield prox.nextElement();
+                }
+              }
+              prox.$precise[Symbol.iterator] = function*() {
+                while (prox.$precise.hasMoreElements()) {
+                  yield prox.$precise.nextElement();
+                }
+              }
+            }
+          }
+        };
+        const tdm = getTypeDescriptionManager();
+        const types = typeprov.getTypes();
+        typeprov.delete();
+        for (let i = 0; i != types.size(); ++i) {
+          const ty = types.get(i);
+          const td = tdm.getByHierarchicalName(ty.toString());
+          ty.delete();
+          const ifc1 = td.get();
+          td.delete();
+          const ifc2 = Module.uno.com.sun.star.reflection.XTypeDescription.query(ifc1);
+          ifc1.delete();
+          walk(ifc2);
+          ifc2.delete();
+        }
+        tdm.delete();
+        types.delete();
+      }
+      return prox;
+    };
+    function singleton(name) {
+      return function(context) {
+        const any = context.getValueByName('/singletons/' + name);
+        if (getAnyType(any).getTypeClass() !==
+            Module.uno.com.sun.star.uno.TypeClass.INTERFACE
+          || any === null)
+        {
+          throwUnoException(
+            new uno.com.sun.star.uno.DeploymentException(
+              {Message: 'cannot get singeleton ' + name}));
+        }
+        return fromAny(any);
+      };
+    };
+    function service(name, td) {
+      const obj = {};
+      const ctors = td.getConstructors();
+      for (let i = 0; i !== ctors.size(); ++i) {
+        const ctor = ctors.get(i);
+        if (ctor.isDefaultConstructor()) {
+          obj.create = function(context) {
+            const ifc = context.getServiceManager().createInstanceWithContext(
+              name, context);
+            if (ifc === null) {
+              throwUnoException(
+                new uno.com.sun.star.uno.DeploymentException(
+                  {Message:
+                   'cannot instantiate single-interface service ' + name}));
+            }
+            return ifc;
+          };
+        } else {
+          obj[ctor.getName()] = function() {
+            const context = arguments[0];
+            const args = [];
+            const params = ctor.getParameters();
+            for (let j = 0; j !== params.size(); ++j) {
+              const param = params.get(j);
+              if (param.isRestParameter()) {
+                for (; j + 1 < arguments.length; ++j) {
+                  args.push(arguments[j + 1]);
+                }
+                break;
+              } else {
+                let arg = arguments[j + 1];
+                const ty = param.getType();
+                if (ty.getTypeClass() !== Module.uno.com.sun.star.uno.TypeClass.ANY)
+                {
+                  arg = new Any(
+                    gcWrap(translateTypeDescriptionAndDelete(param.getType())),
+                    arg);
+                }
+                ty.delete();
+                args.push(arg);
+              }
+              param.delete();
+            }
+            params.delete();
+            const ifc = context.getServiceManager()
+                  .createInstanceWithArgumentsAndContext(name, args, context);
+            if (ifc === null) {
+              throwUnoException(
+                new uno.com.sun.star.uno.DeploymentException(
+                  {Message:
+                   'cannot instantiate single-interface service ' + name}));
+            }
+            return ifc;
+          };
+        }
+      }
+      ctors.delete();
+      return obj;
+    };
+    function defaultValue(type) {
+      switch (type.getTypeClass()) {
+      case Module.uno.com.sun.star.uno.TypeClass.BOOLEAN:
+        return false;
+      case Module.uno.com.sun.star.uno.TypeClass.BYTE:
+      case Module.uno.com.sun.star.uno.TypeClass.SHORT:
+      case Module.uno.com.sun.star.uno.TypeClass.UNSIGNED_SHORT:
+      case Module.uno.com.sun.star.uno.TypeClass.LONG:
+      case Module.uno.com.sun.star.uno.TypeClass.UNSIGNED_LONG:
+      case Module.uno.com.sun.star.uno.TypeClass.FLOAT:
+      case Module.uno.com.sun.star.uno.TypeClass.DOUBLE:
+        return 0;
+      case Module.uno.com.sun.star.uno.TypeClass.HYPER:
+      case Module.uno.com.sun.star.uno.TypeClass.UNSIGNED_HYPER:
+        return 0n;
+      case Module.uno.com.sun.star.uno.TypeClass.CHAR:
+        return '\0';
+      case Module.uno.com.sun.star.uno.TypeClass.STRING:
+        return '';
+      case Module.uno.com.sun.star.uno.TypeClass.TYPE:
+        return Module.uno_Type.Void();
+      case Module.uno.com.sun.star.uno.TypeClass.ANY:
+        return undefined;
+      case Module.uno.com.sun.star.uno.TypeClass.SEQUENCE:
+        return [];
+      case Module.uno.com.sun.star.uno.TypeClass.ENUM:
+        {
+          const tdm = getTypeDescriptionManager();
+          const tdAny = tdm.getByHierarchicalName(type.toString());
+          tdm.delete();
+          const ifc = tdAny.get();
+          tdAny.delete();
+          const td = Module.uno.com.sun.star.reflection.XEnumTypeDescription.query(ifc);
+          ifc.delete();
+          const names = td.getEnumNames();
+          td.delete();
+          const first = names.get(0);
+          names.delete();
+          return Module['uno_Type_' + type.toString().replace(/\./g, '$')][first];
+        }
+      case Module.uno.com.sun.star.uno.TypeClass.STRUCT:
+        {
+          //TODO: Make val an instanceof the corresponding struct constructor function:
+          const tdm = getTypeDescriptionManager();
+          const tdAny = tdm.getByHierarchicalName(type.toString());
+          tdm.delete();
+          const ifc = tdAny.get();
+          tdAny.delete();
+          const td = Module.uno.com.sun.star.reflection.XTypeDescription.query(ifc);
+          ifc.delete();
+          const members = {};
+          computeMembers(td, members);
+          td.delete();
+          const val = {};
+          populate(val, [], members);
+          return val;
+        }
+      case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+        return null;
+      default:
+        throw new Error('bad member type ' + type);
+      }
+    }
+    function TypeArgumentIndex(index) { this.index = index; };
+    function computeMembers(type, obj) {
+      const td = Module.uno.com.sun.star.reflection.XCompoundTypeDescription.query(type);
+      const base = td.getBaseType();
+      if (base !== null) {
+        computeMembers(base, obj);
+        base.delete();
+      }
+      const types = td.getMemberTypes();
+      const names = td.getMemberNames();
+      td.delete();
+      for (let i = 0; i !== types.size(); ++i) {
+        const memtype = types.get(i);
+        let val;
+        if (memtype.getTypeClass() === Module.uno.com.sun.star.uno.TypeClass.UNKNOWN) {
+          const paramName = memtype.getName();
+          const std = Module.uno.com.sun.star.reflection.XStructTypeDescription.query(
+            type);
+          const params = std.getTypeParameters();
+          std.delete();
+          let index = 0;
+          for (; index !== params.size(); ++index) {
+            if (params.get(index) === paramName) {
+              break;
+            }
+          }
+          params.delete();
+          val = new TypeArgumentIndex(index);
+        } else {
+          const type = translateTypeDescription(memtype);
+          val = defaultValue(type);
+          type.delete();
+        }
+        memtype.delete();
+        obj[names.get(i)] = val;
+      }
+      types.delete();
+      names.delete();
+    };
+    function populate(obj, types, members, values) {
+      for (let i in members) {
+        let val;
+        if (values !== undefined && i in values) {
+          val = values[i];
+        } else {
+          val = members[i];
+          if (val instanceof TypeArgumentIndex) {
+            val = defaultValue(types[val.index]);
+          }
+        }
+        obj[i] = val;
+      }
+    };
+    function instantiationName(templateName, types) {
+      let name = templateName + '<';
+      for (let i = 0; i !== types.length; ++i) {
+        if (i !== 0) {
+          name += ',';
+        }
+        name += types[i];
+      }
+      return name + '>';
+    }
+    function unoidlProxy(path, embindObject) {
+      return new Proxy({}, {
+        get(target, prop) {
+          if (!Object.hasOwn(target, prop)) {
+            const name = path + '.' + prop;
+            const tdm = getTypeDescriptionManager();
+            const tdAny = tdm.getByHierarchicalName(name);
+            tdm.delete();
+            const ifc = tdAny.get();
+            tdAny.delete();
+            const td = Module.uno.com.sun.star.reflection.XTypeDescription.query(ifc);
+            ifc.delete();
+            switch (td.getTypeClass()) {
+            case Module.uno.com.sun.star.uno.TypeClass.ENUM:
+              target[prop] = embindObject[prop];
+              target[prop][Module.unoTagSymbol] = {kind: 'enum', type: name};
+              break;
+            case Module.uno.com.sun.star.uno.TypeClass.STRUCT:
+              {
+                const members = {};
+                computeMembers(td, members);
+                const std = Module.uno.com.sun.star.reflection
+                  .XStructTypeDescription.query(td);
+                const params = std.getTypeParameters();
+                std.delete();
+                const paramCount = params.size();
+                params.delete();
+                if (paramCount === 0) {
+                  target[prop] = function(values) {
+                    populate(this, [], members, values);
+                    this[Module.unoTagSymbol] = {
+                      kind: 'struct-instance', type: name};
+                  };
+                } else {
+                  target[prop] = function(types, values) {
+                    if (types.length !== paramCount) {
+                      throw new Error(
+                        'bad number of type arguments in call to ' + name +
+                          ', expected ' + paramCount + ' vs. actual ' +
+                          types.length);
+                    }
+                    populate(this, types, members, values);
+                    this[Module.unoTagSymbol] = {
+                      kind: 'struct-instance',
+                      type: instantiationName(name, types)};
+                  };
+                }
+                target[prop][Module.unoTagSymbol] = {kind: 'struct', type: name};
+                break;
+              }
+            case Module.uno.com.sun.star.uno.TypeClass.EXCEPTION:
+              {
+                const members = {};
+                computeMembers(td, members);
+                target[prop] = function(values) {
+                  populate(this, [], members, values);
+                  this[Module.unoTagSymbol] = {
+                    kind: 'exception-instance', type: name};
+                };
+                target[prop][Module.unoTagSymbol] = {kind: 'exception', type: name};
+                break;
+              }
+            case Module.uno.com.sun.star.uno.TypeClass.INTERFACE:
+              target[prop] = {[Module.unoTagSymbol]: {kind: 'interface', type: name}};
+              break;
+            case Module.uno.com.sun.star.uno.TypeClass.MODULE:
+              target[prop] = unoidlProxy(name, embindObject[prop]);
+              break;
+            case Module.uno.com.sun.star.uno.TypeClass.SINGLETON:
+              target[prop] = singleton(name);
+              break;
+            case Module.uno.com.sun.star.uno.TypeClass.SERVICE:
+              {
+                const std = Module.uno.com.sun.star.reflection
+                  .XServiceTypeDescription2.query(td);
+                if (std.isSingleInterfaceBased()) {
+                  target[prop] = service(name, std);
+                }
+                std.delete();
+                break;
+              }
+            case Module.uno.com.sun.star.uno.TypeClass.CONSTANTS:
+              target[prop] = embindObject[prop];
+              break;
+            }
+            td.delete();
+          }
+          return target[prop];
+        }
+      });
+    };
+    function Any(type, val) {
+      this.type = type;
+      this.val = val;
+    };
+    function getAnyType(val) {
+      switch (typeof val) {
+      case 'undefined':
+        return gcWrap(Module.uno_Type.Void());
+      case 'boolean':
+        return gcWrap(Module.uno_Type.Boolean());
+      case 'number':
+        return gcWrap(
+          Number.isInteger(val) && val >= -0x80000000 && val < 0x80000000
+            ? Module.uno_Type.Long()
+            : Number.isInteger(val) && val >= 0 && val < 0x100000000
+            ? Module.uno_Type.UnsignedLong()
+            : Module.uno_Type.Double());
+      case 'bigint':
+        return gcWrap(
+          val < 0x8000000000000000n
+            ? Module.uno_Type.Hyper() : Module.uno_Type.UnsignedHyper());
+      case 'string':
+        return gcWrap(Module.uno_Type.String());
+      case 'object':
+        if (val === null || Object.hasOwn(val, getProxyTarget)) {
+          return gcWrap(Module.uno_Type.Interface('com.sun.star.uno.XInterface'));
+        } else if (val instanceof Module.uno_Type) {
+          return gcWrap(Module.uno_Type.Type());
+        } else if (val instanceof Any) {
+          return val.type;
+        } else if (val instanceof Array) {
+          const t = Module.uno_Type.Any();
+          try {
+            return gcWrap(Module.uno_Type.Sequence(t));
+          } finally {
+            t.delete();
+          }
+        } else {
+          const tag = val[Module.unoTagSymbol];
+          if (tag !== undefined) {
+            if (tag.kind === 'enumerator') {
+              return gcWrap(Module.uno_Type.Enum(tag.type));
+            } else if (tag.kind === 'struct-instance') {
+              return gcWrap(Module.uno_Type.Struct(tag.type));
+            } else if (tag.kind === 'exception-instance') {
+              return gcWrap(Module.uno_Type.Exception(tag.type));
+            }
+          }
+        }
+        // fallthrough
+      default:
+        return undefined;
+      }
+    };
+    function fromAny(val) { return val instanceof Any ? val.val : val; };
+    function throwUnoException(exception) {
+      const type = gcWrap(Module.uno_Type.Exception(exception[Module.unoTagSymbol].type));
+      const toDelete = [];
+      const val = translateToEmbind(exception, type, toDelete);
+      Module.throwUnoException(type, val, toDelete);
+    };
+    function catchUnoException(exception) {
+        const td = Module.uno_Type.Any();
+        try {
+          return translateFromAnyAndDelete(Module.catchUnoException(exception), td);
+        } finally {
+          td.delete();
+        }
+    };
+    const uno = new Proxy({}, {
+      get(target, prop) {
+        if (!Object.hasOwn(target, prop)) {
+          const tdm = getTypeDescriptionManager();
+          const td = tdm.getByHierarchicalName(prop);
+          tdm.delete();
+          td.delete();
+          target[prop] = unoidlProxy(prop, Module.uno[prop]);
+        }
+        return target[prop];
+      }
+    });
+    const zetajs = {
+      type: {
+        void: gcWrap(Module.uno_Type.Void()),
+        boolean: gcWrap(Module.uno_Type.Boolean()),
+        byte: gcWrap(Module.uno_Type.Byte()),
+        short: gcWrap(Module.uno_Type.Short()),
+        unsigned_short: gcWrap(Module.uno_Type.UnsignedShort()),
+        long: gcWrap(Module.uno_Type.Long()),
+        unsigned_long: gcWrap(Module.uno_Type.UnsignedLong()),
+        hyper: gcWrap(Module.uno_Type.Hyper()),
+        unsigned_hyper: gcWrap(Module.uno_Type.UnsignedHyper()),
+        float: gcWrap(Module.uno_Type.Float()),
+        double: gcWrap(Module.uno_Type.Double()),
+        char: gcWrap(Module.uno_Type.Char()),
+        string: gcWrap(Module.uno_Type.String()),
+        type: gcWrap(Module.uno_Type.Type()),
+        any: gcWrap(Module.uno_Type.Any()),
+        sequence(type) { return gcWrap(Module.uno_Type.Sequence(type)); },
+        enum(name) {
+          if (typeof name === 'function' && Object.hasOwn(name, Module.unoTagSymbol)
+            && name[Module.unoTagSymbol].kind === 'enum')
+          {
+            name = name[Module.unoTagSymbol].type;
+          }
+          return gcWrap(Module.uno_Type.Enum(name));
+        },
+        struct(name) {
+          if (typeof name === 'function' && Object.hasOwn(name, Module.unoTagSymbol)
+            && name[Module.unoTagSymbol].kind === 'struct')
+          {
+            name = name[Module.unoTagSymbol].type;
+          }
+          return gcWrap(Module.uno_Type.Struct(name));
+        },
+        exception(name) {
+          if (typeof name === 'function' && Object.hasOwn(name, Module.unoTagSymbol)
+            && name[Module.unoTagSymbol].kind === 'exception')
+          {
+            name = name[Module.unoTagSymbol].type;
+          }
+          return gcWrap(Module.uno_Type.Exception(name));
+        },
+        interface(name) {
+          if (typeof name === 'object' && Object.hasOwn(name, Module.unoTagSymbol)
+            && name[Module.unoTagSymbol].kind === 'interface')
+          {
+            name = name[Module.unoTagSymbol].type;
+          }
+          return gcWrap(Module.uno_Type.Interface(name));
+        }
+      },
+      Any,
+      getAnyType,
+      fromAny,
+      sameUnoObject: function(obj1, obj2) {
+        const type = Module.uno_Type.Interface('com.sun.star.uno.XInterface');
+        const toDelete = [];
+        try {
+          return Module.sameUnoObject(
+            translateToEmbind(obj1, type, toDelete),
+            translateToEmbind(obj2, type, toDelete));
+        } finally {
+          type.delete();
+          toDelete.forEach((val) => val.delete());
+        }
+      },
+      getUnoComponentContext: function() {
+        return proxy(Module.getUnoComponentContext());
+      },
+      throwUnoException,
+      catchUnoException,
+      uno,
+      unoObject: function(interfaces, obj) {
+        const wrapper = {};
+        const toDelete = [];
+        Module.uno$zetajs_deleteRegistry.register(wrapper, toDelete);
+        const seen = {
+          'com.sun.star.lang.XTypeProvider': true, 'com.sun.star.uno.XInterface': true};
+        function walk(td) {
+          const iname = td.getName();
+          if (!Object.hasOwn(seen, iname)) {
+            seen[iname] = true;
+            if (td.getTypeClass() !== Module.uno.com.sun.star.uno.TypeClass.INTERFACE) {
+              throw new Error('not a UNO interface type: ' + iname);
+            }
+            const itd = Module.uno.com.sun.star.reflection.XInterfaceTypeDescription2
+                  .query(td);
+            const bases = itd.getBaseTypes();
+            for (let i = 0; i !== bases.size(); ++i) {
+              const base = bases.get(i);
+              walk(base);
+              base.delete();
+            }
+            bases.delete();
+            const mems = itd.getMembers();
+            itd.delete();
+            for (let i = 0; i !== mems.size(); ++i) {
+              const ifc = mems.get(i);
+              const atd = Module.uno.com.sun.star.reflection
+                .XInterfaceAttributeTypeDescription.query(ifc);
+              ifc.delete();
+              if (atd !== null) {
+                const aname = atd.getMemberName();
+                const type = translateTypeDescriptionAndDelete(atd.getType());
+                toDelete.push(type);
+                wrapper['get' + aname] = function() {
+                  return translateToEmbind(
+                    obj['get' + aname].apply(obj), type, []);
+                };
+                if (!atd.isReadOnly()) {
+                  wrapper['set' + aname] = function() {
+                    obj['set' + aname].apply(
+                      obj, [translateFromEmbind(arguments[0], type, true, false)]);
+                  };
+                }
+                atd.delete();
+              } else {
+                const ifc = mems.get(i);
+                const mtd = Module.uno.com.sun.star.reflection
+                  .XInterfaceMethodTypeDescription.query(ifc);
+                ifc.delete();
+                const mname = mtd.getMemberName();
+                const retType = translateTypeDescriptionAndDelete(
+                  mtd.getReturnType());
+                toDelete.push(retType);
+                const params = [];
+                const descrs = mtd.getParameters();
+                mtd.delete();
+                for (let j = 0; j !== descrs.size(); ++j) {
+                  const descr = descrs.get(j);
+                  const type = translateTypeDescriptionAndDelete(descr.getType());
+                  toDelete.push(type);
+                  params.push({type, dirIn: descr.isIn(), dirOut: descr.isOut()});
+                  descr.delete();
+                }
+                descrs.delete();
+                wrapper[mname] = function() {
+                  const args = [];
+                  for (let i = 0; i !== params.length; ++i) {
+                    let arg;
+                    if (params[i].dirOut) {
+                      arg = {};
+                      if (params[i].dirIn) {
+                        arg.val = translateFromEmbind(
+                          arguments[i].val, params[i].type, true, false);
+                      }
+                    } else {
+                      arg = translateFromEmbind(
+                        arguments[i], params[i].type, true, false);
+                    }
+                    args.push(arg);
+                  }
+                  const ret = translateToEmbind(
+                    obj[mname].apply(obj, args), retType, []);
+                  for (let i = 0; i !== params.length; ++i) {
+                    if (params[i].dirOut) {
+                      arguments[i].val = translateToEmbind(
+                        args[i].val, params[i].type, []);
+                    }
+                  }
+                  return ret;
+                };
+              }
+            }
+            mems.delete();
+          }
+        };
+        const tdm = getTypeDescriptionManager();
+        const interfaceNames = [];
+        interfaces.forEach((i) => {
+          let name = i;
+          if (typeof name === 'object' && Object.hasOwn(name, Module.unoTagSymbol)
+              && name[Module.unoTagSymbol].kind === 'interface')
+          {
+              name = name[Module.unoTagSymbol].type;
+          } else if (name instanceof Module.uno_Type
+                     && (name.getTypeClass()
+                         === Module.uno.com.sun.star.uno.TypeClass.INTERFACE))
+          {
+            name = name.toString();
+          }
+          interfaceNames.push(name);
+          const tdAny = tdm.getByHierarchicalName(name);
+          const ifc = tdAny.get();
+          const td = Module.uno.com.sun.star.reflection.XTypeDescription.query(ifc);
+          ifc.delete();
+          walk(td);
+          td.delete();
+        })
+        tdm.delete();
+        return proxy(Module.unoObject(interfaceNames, wrapper));
+      },
+      mainPort: Module.uno_mainPort
+    };
+    resolve(zetajs);
+  };
+  Module.zetajs$reject = reject;
+});
+
+Module.uno_init.then(function() { Module.zetajs$resolve(); });
+
+/* vim:set shiftwidth=2 softtabstop=2 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */


### PR DESCRIPTION
## 中文

Epic #43。**铺好内嵌编辑器宿主侧脚手架**——让剩余工作变成「真机激活」而非「再造机制」。

- [`composables/useZetaOfficeWebview.js`](frontend/src/composables/useZetaOfficeWebview.js)：宿主侧接线。`webviewTransport()` 把 Electron `<webview>` 的 IPC（`webview.send` / `ipc-message`）适配成中转的 `{send, subscribe}`；`createWebviewEditorExecutor()` 返回标准 `executeCommand` 契约的 LibreOffice executor，包裹**已验证的中转**（#48）。只有这个 `<webview>` IPC 适配器是真机专属。
- [`composables/useEditorBridge.js`](frontend/src/composables/useEditorBridge.js)：LibreOffice executor 现**可插拔**——`useEditorBridge(EDITOR_WPS, { libreExecutor: createWebviewEditorExecutor(el) })`。默认不变（in-context bridge），**现有行为完全一致**；`connectLibreOffice`/`isLibreOfficeConnected` 对无此方法的 executor 做了守卫。
- [`zetaoffice/public/{zeta.js,office_thread.js}`](frontend/src/zetaoffice/public/)：worker 资产，使 `build:zetaoffice` 产出**完整可部署** `dist/zetaoffice`（editor.html + 客户端 bundle + worker 脚本；运行时只差 LOWA + 字体）。当前是 spike 那份的**副本**——单一来源统一记为后续（README 注明）。
- [`zetaoffice/README.md`](frontend/src/zetaoffice/README.md)：六块 + 数据流 + **真机要应用的精确接线**（自托管 LOWA/字体 + extraResources、Electron main 隔离 + http 服务、webview preload、project-overview 宿主接线、IME）。

**休眠**：app 侧零 importer；`build:zetaoffice` 产自包含可部署 bundle；`build:h5` 无回归；`node --check` 过。**未动 live 产品代码**（main.js / project-overview live 派发）——那些是 README 里的真机激活步骤。

## English

Epic #43. Scaffolds the host side of the embedded LibreOffice editor so the remaining work is on-device activation, not new mechanism. `useZetaOfficeWebview.js` adapts an Electron `<webview>`'s IPC to the verified relay (#48) and exposes a standard-contract LibreOffice executor; `useEditorBridge` now takes a pluggable `libreExecutor` (default unchanged, behavior identical). `zetaoffice/public/{zeta.js,office_thread.js}` make `build:zetaoffice` emit a fully deployable `dist/zetaoffice` (copies of the spike's worker — unify later). `zetaoffice/README.md` documents the six pieces + the exact remaining on-device wiring. Dormant; build:h5 unaffected; no live product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)