### PR TITLE
feat(libreoffice): experimental "LibreOffice 验证" window in packaged builds / 安装包内置「LibreOffice 验证」窗口(实验性)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -59,6 +59,25 @@ jobs:
         run: |
           npm ci || npm install
           npm run build:h5
+          # Epic #43: build the embedded LibreOffice editor bundle (dist/zetaoffice),
+          # shipped via extraResources for the experimental "LibreOffice 验证" window.
+          npm run build:zetaoffice
+      - name: Bundle a CJK font for the LibreOffice verify window (best-effort)
+        shell: bash
+        run: |
+          # The editor injects this font so Chinese renders (not tofu). Best-effort:
+          # if no system CJK font is found the editor skips it cleanly.
+          dest="frontend/dist/zetaoffice/cjk.ttc"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            for f in "/System/Library/Fonts/Hiragino Sans GB.ttc" "/System/Library/Fonts/PingFang.ttc" "/System/Library/Fonts/Supplemental/Songti.ttc"; do
+              [ -f "$f" ] && cp "$f" "$dest" && break
+            done
+          else
+            for f in "/c/Windows/Fonts/msyh.ttc" "/c/Windows/Fonts/simsun.ttc" "C:/Windows/Fonts/msyh.ttc" "C:/Windows/Fonts/simsun.ttc"; do
+              [ -f "$f" ] && cp "$f" "$dest" && break
+            done
+          fi
+          ls -la "$dest" 2>/dev/null && echo "CJK font bundled" || echo "no CJK font found (Chinese will be tofu in verify window)"
       - name: Install desktop dependencies
         working-directory: desktop
         run: npm ci

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -1167,6 +1167,16 @@ function createBackendManager() {
 
 app.whenReady().then(() => {
   initLocalFileService()
+  // Epic #43: experimental "LibreOffice 验证" window — dedicated, isolated, does
+  // NOT touch the WPS flow. Global shortcut is the only entry; the module is
+  // require()'d lazily on press, so it stays dormant until used.
+  try {
+    globalShortcut.register('CommandOrControl+Shift+L', () => {
+      require('./zetaoffice-verify')
+        .openZetaOfficeVerifyWindow()
+        .catch((e) => console.error('[zeta-verify]', e))
+    })
+  } catch (e) { /* ignore */ }
   // 桌面端启动时自动拉起本机后端（9696）
   backend = createBackendManager()
   backend

--- a/desktop/main/zetaoffice-verify.js
+++ b/desktop/main/zetaoffice-verify.js
@@ -1,0 +1,126 @@
+// zetaoffice-verify.js — dedicated "LibreOffice 验证" window for a packaged
+// build. Epic #43. Lets the maintainer install and SEE the embedded LibreOffice
+// editor boot + render Chinese + run an AI command (redline) inside the real app,
+// WITHOUT touching the WPS document flow (zero blast radius on the shipping
+// product). Triggered by a global shortcut (registered in main.js).
+//
+// LOWA needs cross-origin isolation (SharedArrayBuffer). The main window can't be
+// isolated (webSecurity:false + cross-origin WPS/AI), so this opens a SEPARATE
+// BrowserWindow on a dedicated partition whose session gets COOP/COEP injected
+// (desktop/main/zetaoffice-session.js, #47).
+//
+// LOWA is served SAME-ORIGIN: the local server proxies /lowa/* -> the LOWA CDN.
+// Loading soffice.{js,wasm,data} cross-origin from the CDN directly is blocked by
+// COEP (ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep) —
+// injecting CORP on cross-origin responses via onHeadersReceived proved
+// unreliable in Electron. Proxying makes every LOWA resource same-origin, so COEP
+// require-corp is satisfied with no CORP gymnastics. (This is also the production
+// direction: self-host LOWA in the bundle.)
+//
+// Dormant until the shortcut fires; nothing imports it at startup.
+
+const path = require('path')
+const http = require('node:http')
+const https = require('node:https')
+const { readFile } = require('node:fs/promises')
+const { app, BrowserWindow } = require('electron')
+const { installZetaOfficeIsolation, ZETAOFFICE_PARTITION } = require('./zetaoffice-session')
+
+const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.data': 'application/octet-stream',
+  '.ttc': 'font/collection',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+}
+
+let server = null
+let verifyWin = null
+
+function editorRoot() {
+  return app.isPackaged
+    ? path.join(process.resourcesPath, 'frontend/dist/zetaoffice')
+    : path.join(__dirname, '../../frontend/dist/zetaoffice')
+}
+
+// Proxy a full https URL to res, following up to 4 redirects. Streams the body
+// and forwards the headers that matter for WASM (content-type/encoding/length).
+function proxyUrl(url, res, redirects = 0) {
+  https.get(url, (up) => {
+    const sc = up.statusCode || 0
+    if (sc >= 300 && sc < 400 && up.headers.location && redirects < 4) {
+      up.resume()
+      const next = new URL(up.headers.location, url).toString()
+      return proxyUrl(next, res, redirects + 1)
+    }
+    const h = {}
+    for (const k of ['content-type', 'content-length', 'content-encoding', 'etag', 'last-modified', 'cache-control']) {
+      if (up.headers[k]) h[k] = up.headers[k]
+    }
+    res.writeHead(sc || 200, h)
+    up.pipe(res)
+  }).on('error', (e) => { try { res.writeHead(502).end('lowa proxy error: ' + e.message) } catch (x) {} })
+}
+
+function startServer(root) {
+  if (server) return Promise.resolve(server.address().port)
+  return new Promise((resolve, reject) => {
+    const s = http.createServer(async (req, res) => {
+      try {
+        let urlPath = decodeURIComponent((req.url || '/').split('?')[0])
+        // Same-origin LOWA proxy: /lowa/<path> -> the LOWA CDN.
+        if (urlPath.startsWith('/lowa/')) {
+          return proxyUrl(LOWA_CDN + urlPath.slice('/lowa/'.length), res)
+        }
+        if (urlPath === '/') urlPath = '/editor.html'
+        const filePath = path.normalize(path.join(root, urlPath))
+        if (!filePath.startsWith(root)) { res.writeHead(403).end('forbidden'); return }
+        // No COOP/COEP here — Electron injects them on the partition.
+        const body = await readFile(filePath)
+        res.writeHead(200, { 'Content-Type': TYPES[path.extname(filePath)] || 'application/octet-stream' })
+        res.end(body)
+      } catch (e) {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' }).end('not found')
+      }
+    })
+    s.on('error', reject)
+    s.listen(0, '127.0.0.1', () => { server = s; resolve(s.address().port) })
+  })
+}
+
+/**
+ * Open (or focus) the LibreOffice verification window.
+ */
+async function openZetaOfficeVerifyWindow() {
+  if (verifyWin && !verifyWin.isDestroyed()) { verifyWin.focus(); return verifyWin }
+
+  installZetaOfficeIsolation(ZETAOFFICE_PARTITION)
+  const port = await startServer(editorRoot())
+  const origin = 'http://127.0.0.1:' + port
+
+  verifyWin = new BrowserWindow({
+    width: 1280,
+    height: 860,
+    title: 'AI Workdeck · LibreOffice 验证 (experimental)',
+    webPreferences: {
+      partition: ZETAOFFICE_PARTITION,
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+  verifyWin.on('closed', () => { verifyWin = null })
+  // LOWA via the same-origin proxy (?lowa=). zeta.js / office_thread.js / cjk.ttc
+  // are served locally next to the page (their relative defaults resolve here).
+  verifyWin.loadURL(origin + '/editor.html?verify=1&lowa=' + encodeURIComponent(origin + '/lowa/'))
+  verifyWin.webContents.openDevTools({ mode: 'detach' })
+  return verifyWin
+}
+
+module.exports = { openZetaOfficeVerifyWindow }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -35,6 +35,10 @@
         "to": "frontend/dist/build/h5"
       },
       {
+        "from": "../frontend/dist/zetaoffice",
+        "to": "frontend/dist/zetaoffice"
+      },
+      {
         "from": "bundled/${os}-${arch}/backend.jar",
         "to": "backend/backend.jar"
       },

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -117,7 +117,15 @@ export function bootZetaOffice(options = {}) {
     function onMessage(e) {
       const d = (e && e.data) || {}
       if (d.cmd === 'log') log(d.msg)
-      else if (d.cmd === 'ui_ready') { log('UI ready'); if (onReady) onReady() }
+      else if (d.cmd === 'ui_ready') {
+        // Reveal the canvas (CSS keeps it hidden during boot to avoid showing a
+        // blank/garbage surface) and kick one repaint. The spike's page did this
+        // in its own ui_ready handler; the boot-module extraction (#46) must own
+        // it so every consumer gets a visible, painted canvas.
+        try { canvas.style.visibility = 'visible'; globalThis.dispatchEvent(new Event('resize')) } catch (err) { /* ignore */ }
+        log('UI ready')
+        if (onReady) onReady()
+      }
       if (onWorkerMessage) onWorkerMessage(d)
     }
 

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -55,6 +55,56 @@ function pickTransport() {
 // Runtime-configurable asset locations (query string), so the same bundle works
 // against the CDN LOWA in dev and a self-hosted bundle in the packaged app.
 const q = new URLSearchParams(location.search)
+const VERIFY = q.get('verify') === '1'
+
+// Standalone verification panel (?verify=1): a few buttons + an IME field that
+// drive the booted executor DIRECTLY (no host), so the editor can be exercised
+// inside the dedicated verification window (desktop/main/zetaoffice-verify.js)
+// of a packaged build. In normal (webview) mode the panel stays hidden and the
+// endpoint just serves the host over the transport.
+function vlog(m) {
+  const el = document.getElementById('vlog')
+  if (!el) return
+  el.classList.add('on')
+  el.textContent += m + '\n'
+  el.scrollTop = el.scrollHeight
+}
+
+function wireVerifyPanel(executor) {
+  const panel = document.getElementById('verify')
+  if (panel) panel.classList.add('on')
+  const status = document.getElementById('vstatus')
+  const ime = document.getElementById('vime')
+  const bIns = document.getElementById('vinsert')
+  const bRep = document.getElementById('vreplace')
+  const bSel = document.getElementById('vsel')
+  if (status) status.textContent = '就绪 / ready ✓'
+  for (const b of [ime, bIns, bRep, bSel]) if (b) b.disabled = false
+
+  const run = async (label, action, params) => {
+    vlog('▶ ' + label + ' …')
+    try { vlog('  ← ' + JSON.stringify(await executor.executeCommand(action, params))) }
+    catch (e) { vlog('  ✗ ' + (e && e.message ? e.message : e)) }
+  }
+  if (bIns) bIns.onclick = () => run('插入示例', 'insert_at_cursor',
+    { text: '本协议由甲方与乙方于本日签订；协议自双方签署之日起生效。' })
+  if (bRep) bRep.onclick = () => run('查找替换 协议→合同 (redline)', 'find_replace',
+    { findText: '协议', replaceText: '合同', replaceAll: true })
+  if (bSel) bSel.onclick = () => run('读选区', 'get_selection', {})
+
+  // IME: commit composed/typed text into the document at the cursor.
+  if (ime) {
+    let composing = false, skipNext = false
+    const commit = (t) => { if (t) run('IME 插入「' + t + '」', 'insert_at_cursor', { text: t }); ime.value = '' }
+    ime.addEventListener('compositionstart', () => { composing = true })
+    ime.addEventListener('compositionend', (e) => { composing = false; skipNext = true; commit(e.data) })
+    ime.addEventListener('input', (e) => {
+      if (composing) return
+      if (skipNext) { skipNext = false; return }
+      commit(e.data != null ? e.data : ime.value)
+    })
+  }
+}
 
 startEditorEndpoint({
   canvas: document.getElementById('qtcanvas'),
@@ -62,10 +112,14 @@ startEditorEndpoint({
   sofficeBaseUrl: q.get('lowa') || 'https://cdn.zetaoffice.net/zetaoffice_latest/',
   zetaJsUrl: q.get('zeta') || './zeta.js',
   workerScriptUrl: q.get('worker') || './office_thread.js',
-  fontUrl: q.get('font') || undefined,
-  onLog: (m) => console.log('[zeta-editor]', m),
-}).then(() => {
+  // Default to a CJK font served next to the page (the verify build drops one
+  // here); bootZetaOffice skips cleanly if it 404s (Chinese would be tofu then).
+  fontUrl: q.get('font') || './cjk.ttc',
+  onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
+}).then((endpoint) => {
   console.log('[zeta-editor] endpoint ready — serving host over transport')
+  if (VERIFY) wireVerifyPanel(endpoint.executor)
 }).catch((e) => {
   console.error('[zeta-editor] boot failed:', e)
+  if (VERIFY) vlog('boot failed: ' + (e && e.message ? e.message : e))
 })

--- a/frontend/src/zetaoffice/editor.html
+++ b/frontend/src/zetaoffice/editor.html
@@ -1,16 +1,37 @@
 <!DOCTYPE html>
-<!-- Embedded LibreOffice editor page — runs inside the isolated <webview>. Epic #43. -->
+<!-- Embedded LibreOffice editor page — runs inside the isolated <webview> (or a
+     dedicated verification window with ?verify=1). Epic #43. -->
 <html lang="zh">
 <head>
   <meta charset="utf-8">
   <title>LibreOffice Editor</title>
   <style>
-    html, body { margin: 0; padding: 0; height: 100vh; overflow: hidden; background: #fff; }
+    html, body { margin: 0; padding: 0; height: 100vh; overflow: hidden; background: #fff; font: 13px/1.5 system-ui, sans-serif; }
     /* Qt REQUIRES id="qtcanvas"; canvas must have no border/padding (outline ok). */
     #qtcanvas { width: 100%; height: 100%; border: 0; padding: 0; outline: 0; visibility: hidden; }
+    /* Verification panel (only shown with ?verify=1) */
+    #verify { position: fixed; top: 0; left: 0; right: 0; display: none; gap: 8px; align-items: center;
+      padding: 6px 10px; background: #1F2937; color: #fff; flex-wrap: wrap; z-index: 10; }
+    #verify.on { display: flex; }
+    #verify button { font: inherit; padding: 4px 10px; border: 0; border-radius: 4px; background: #059669; color: #fff; cursor: pointer; }
+    #verify button:disabled { background: #6b7280; cursor: not-allowed; }
+    #verify input { font: inherit; padding: 4px 8px; border: 0; border-radius: 4px; width: 240px; }
+    #vlog { position: fixed; right: 8px; bottom: 8px; width: 380px; max-height: 38vh; display: none;
+      padding: 8px; background: #0b1220; color: #d1fae5; font: 11px/1.45 ui-monospace, monospace;
+      overflow: auto; white-space: pre-wrap; word-break: break-all; border-radius: 6px; z-index: 10; }
+    #vlog.on { display: block; }
   </style>
 </head>
 <body>
+  <div id="verify">
+    <strong>LibreOffice 验证</strong>
+    <span id="vstatus">启动中… / booting…</span>
+    <input id="vime" disabled placeholder="① 在此用输入法打中文 → 插入文档（IME 验证）" autocomplete="off" />
+    <button id="vinsert" disabled>插入示例</button>
+    <button id="vreplace" disabled>查找替换(redline)</button>
+    <button id="vsel" disabled>读选区</button>
+  </div>
+  <pre id="vlog"></pre>
   <canvas id="qtcanvas" contenteditable="true"
     oncontextmenu="event.preventDefault()" onkeydown="event.preventDefault()"></canvas>
   <script type="module" src="./editor-main.js"></script>


### PR DESCRIPTION
## 中文

Epic #43。**让维护者装上一个包，就能在真 app 里看 LibreOffice 编辑器 boot + 渲染中文 + 跑一条 AI 命令(redline)**——完全不碰 WPS 文档流(对在产产品零爆炸半径)。整套休眠,只在按全局快捷键时才起。

**怎么用**：装好后按 **`Cmd/Ctrl+Shift+L`** → 弹出独立「LibreOffice 验证」窗口 → 等运行时下载(首次数百 MB,CDN)→ 在面板里:用输入法打中文、点「插入示例」「查找替换(redline)」「读选区」,看文档里中文渲染 + 修订痕迹。

**改了什么**：
- `desktop/main/zetaoffice-verify.js`：独立 `BrowserWindow`,挂 `persist:zetaoffice` 分区(经 `installZetaOfficeIsolation` #47 注 COOP/COEP),用**本地 http**(非 file://,COEP 需响应头)服务 `dist/zetaoffice`,载 `editor.html?verify=1`;LOWA 从 CDN。
- `desktop/main/main.js`：注册 `Cmd/Ctrl+Shift+L` 开它(lazy require、按了才加载)。**对 live 主进程的唯一改动。**
- `frontend/src/zetaoffice/editor.{html,js}`：`?verify=1` 面板(IME 输入 + 插入/查找替换-redline/读选区 + 日志),直接驱动 booted executor;默认 `fontUrl ./cjk.ttc` 使中文渲染。
- `desktop/package.json`：`dist/zetaoffice` 经 extraResources 打进包。
- `desktop-build.yml`：`build:zetaoffice` + best-effort 拷系统 CJK 字体。

**已验证(浏览器对真 LibreOffice，就是要打进包的那个页 `?verify=1`)**：boot ✓、CJK 字体注入 ✓、插入示例 ✓、查找替换 协议→合同 `replaced:2`+`recordChanges` ✓、读选区 ✓。Electron 外壳(隔离分区窗口 + 本地服务器)grounded 在 spike `electron-main.js`，**装这个包就是它的真机验证**。

**分发**：走 PR 的 **Desktop Build → CI artifact**(`upload-artifact`,非公开 Release)。构建完我把 mac 安装包下载链接给你。

> ⚠️ 诚实标注:Electron 隔离窗口能否真拿到 COOP/COEP 跨源隔离、本地 http 服务在打包后的路径解析,是**装上后第一次真机验**的点。若验证窗口起不来/白屏,大概率是这两处,我按你反馈即修。

## English

Epic #43. A dedicated, isolated "LibreOffice 验证" window so the maintainer can install a build and see the embedded editor boot + render Chinese + run an AI command (redline) in the real app, without touching the WPS flow. Press `Cmd/Ctrl+Shift+L` to open it. The editor verify PAGE is verified end-to-end against a real LibreOffice (insert ✓, find_replace replaced:2 + recordChanges ✓, get_selection ✓); the Electron shell (isolated-partition window + local http server, grounded in the spike's electron-main.js) is verified on-device by installing this build. Distributed as a CI artifact (Desktop Build on PR), not a public Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)