### PR TITLE
fix(desktop): 捆绑 JRE 启动崩溃时回退到系统 JDK / fall back to system JDK when bundled JRE crashes

### DIFF
--- a/desktop/main/backend.js
+++ b/desktop/main/backend.js
@@ -28,18 +28,6 @@ function isPortOpen(port, host = '127.0.0.1', timeoutMs = 250) {
   })
 }
 
-async function waitPort(port, timeoutMs = 12000) {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    // eslint-disable-next-line no-await-in-loop
-    const ok = await isPortOpen(port)
-    if (ok) return true
-    // eslint-disable-next-line no-await-in-loop
-    await sleep(200)
-  }
-  return false
-}
-
 class BackendManager {
   constructor(options) {
     const opts = options || {}
@@ -126,26 +114,99 @@ class BackendManager {
       stdio = ['ignore', 'pipe', 'pipe']
     }
 
-    this.proc = spawn(this.javaCmd, ['-jar', this.jarPath], {
-      cwd: this.backendDir,
-      env,
-      stdio
-    })
-    if (logStream) {
-      this.proc.stdout.pipe(logStream)
-      this.proc.stderr.pipe(logStream)
+    // 候选 java：优先捆绑 JRE；仅当其启动失败时，才（惰性）解析系统 JDK 作为回退。
+    // 普通用户捆绑 JRE 正常启动 → 端口先就绪 → 回退分支永不进入（happy path 零开销、CI 冒烟不受影响）。
+    // 回退专为捆绑 JRE 启动即崩的机器（如 SIP 关闭 + amfi 的 macOS，JDK-8326663 SIGBUS）。
+    const candidates = [this.javaCmd]
+
+    for (let i = 0; i < candidates.length; i++) {
+      const javaCmd = candidates[i]
+      this.proc = spawn(javaCmd, ['-jar', this.jarPath], {
+        cwd: this.backendDir,
+        env,
+        stdio
+      })
+      if (logStream) {
+        this.proc.stdout.pipe(logStream)
+        this.proc.stderr.pipe(logStream)
+      }
+
+      // 等"端口就绪"或"进程提前退出（崩溃）"，谁先到算谁
+      // eslint-disable-next-line no-await-in-loop
+      const result = await this.waitStartOrExit(this.proc, this.startTimeoutMs)
+      if (result === 'started') {
+        return { ok: true, reused: false, javaCmd }
+      }
+      if (result === 'timeout') {
+        // 进程还活着但端口没起：杀掉再试下一个候选
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await this.stop()
+        } catch (e) {
+          // ignore
+        }
+      } else {
+        // 'exited'：进程已崩溃退出，丢引用即可，继续尝试下一个候选
+        this.proc = null
+      }
+
+      // 捆绑 JRE（首个候选）启动失败后，才解析系统 JDK 追加为回退候选
+      if (this.packaged && i === 0) {
+        for (const c of this.systemJavaFallbacks()) {
+          if (!candidates.includes(c)) candidates.push(c)
+        }
+      }
     }
 
-    const ok = await waitPort(this.port, this.startTimeoutMs)
-    if (!ok) {
-      try {
-        await this.stop()
-      } catch (e) {
-        // ignore
+    throw new Error(`backend failed to start on port ${this.port}`)
+  }
+
+  // 等后端端口就绪或进程退出，返回 'started' | 'exited' | 'timeout'
+  waitStartOrExit(proc, timeoutMs) {
+    return new Promise((resolve) => {
+      let settled = false
+      const finish = (v) => {
+        if (settled) return
+        settled = true
+        resolve(v)
       }
-      throw new Error(`backend failed to start on port ${this.port}`)
+      proc.once('exit', () => finish('exited'))
+      proc.once('error', () => finish('exited'))
+      const start = Date.now()
+      const poll = async () => {
+        while (!settled && Date.now() - start < timeoutMs) {
+          // eslint-disable-next-line no-await-in-loop
+          if (await isPortOpen(this.port)) return finish('started')
+          // eslint-disable-next-line no-await-in-loop
+          await sleep(200)
+        }
+        finish('timeout')
+      }
+      poll()
+    })
+  }
+
+  // 系统 JDK 回退候选（仅打包态、仅当捆绑 JRE 启动失败时才会被用到）
+  systemJavaFallbacks() {
+    const out = []
+    const exe = process.platform === 'win32' ? 'java.exe' : 'java'
+    if (process.platform === 'darwin') {
+      // 经 java_home 解析本机 JDK（避开 /usr/bin/java 安装存根弹窗）
+      const { execFileSync } = require('child_process')
+      for (const args of [['-v', '21'], []]) {
+        try {
+          const home = execFileSync('/usr/libexec/java_home', args, { encoding: 'utf8' }).trim()
+          if (home) out.push(path.join(home, 'bin', exe))
+        } catch (e) {
+          // 该版本/任意 JDK 不存在，忽略
+        }
+      }
+    } else {
+      // Windows/Linux：优先 JAVA_HOME，再退 PATH
+      if (process.env.JAVA_HOME) out.push(path.join(process.env.JAVA_HOME, 'bin', exe))
+      out.push(exe)
     }
-    return { ok: true, reused: false }
+    return out.filter((c, i) => out.indexOf(c) === i)
   }
 
   async stop() {


### PR DESCRIPTION
## 背景 / Context

部分 macOS 主机（**SIP 关闭 + `amfi_get_out_of_my_way=1`**）上，捆绑的 Temurin JRE 一启动就 **SIGBUS**（已知 **JDK-8326663**，Won't-Fix）：崩溃发生在 JVM 自举阶段的 `CodeHeap::allocate`，**任何 JVM flag（`-Xint`、code-cache 系列）都绕不过**（本机逐一实测确认）。后端因此起不来、9696 不监听、无法登录。

On macOS hosts with **SIP disabled + `amfi_get_out_of_my_way=1`**, the bundled Temurin JRE SIGBUSes at startup (**JDK-8326663**, Won't-Fix) in `CodeHeap::allocate` during JVM bootstrap — no JVM flag (`-Xint`, code-cache flags) avoids it (verified locally one by one). The backend never binds 9696 and login is impossible.

> 普通用户/CI 的 Temurin 完全正常——这是 SIP 禁用机器的专属坑，**不是 ship-blocker**。
> Temurin works fine for normal users and in CI — this only bites SIP-disabled machines; **not a ship-blocker**.

## 改动 / Change

`BackendManager.start()` 先用捆绑 JRE 启动；**仅当其启动失败**才惰性解析系统 JDK（mac: `/usr/libexec/java_home`；win/linux: `JAVA_HOME` → PATH）并重试。启动改为「端口就绪 vs 进程退出」竞速，崩溃 JRE **瞬间检测**、不再空等超时。

`start()` tries the bundled JRE first and, **only if it fails**, lazily resolves a system JDK (mac: `/usr/libexec/java_home`; win/linux: `JAVA_HOME` → PATH) and retries. Startup races port-ready vs process-exit, so a crashing JRE is detected instantly instead of waiting out the timeout.

## 对普通用户零影响 / Zero impact on normal users

捆绑 JRE 正常启动 → 端口在第一个候选就绪 → **回退分支永不进入、`java_home` 永不调用**。CI 冒烟测试与普通用户行为逐字节不变。顺手删掉因此不再使用的 `waitPort()`。

When the bundled JRE boots, the port comes up on the first candidate and the fallback branch is never entered (`java_home` never called). CI smoke tests and normal users are unaffected. Also drops the now-unused `waitPort()` helper.

## 验证 / Verification

- 本机实测：捆绑 Temurin `java -version` 及 `-Xint` / `-XX:-SegmentedCodeCache` / `-XX:ReservedCodeCacheSize=8m` / `-XX:-UseCompiler` 全部仍 SIGBUS；Oracle JDK 21 跑同一 `backend.jar` 正常（9696 起、`/api/auth/login` 返回正常 JSON）。
- 回退集成测试：构造 `BackendManager`（packaged）强制 `javaCmd` 指向崩溃的 Temurin → 自动经 `java_home -v 21` 回退 Oracle → 9696 起，`START RESULT.javaCmd` = Oracle。
- `node --check desktop/main/backend.js` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)