### PR TITLE
feat(libreoffice): transparent IME overlay — type Chinese directly in the canvas (dormant) / 透明 IME 覆盖层:直接在文档里打中文(休眠)

### DIFF
--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -207,6 +207,18 @@
         loExec = m.createLibreOfficeExecutor({ onError: function (e) { zlog('executor error: ' + e, 'e'); } });
         loExec.connect(thrPort);
         zlog('产品 executor 客户端已连接 ✓ (libreofficeExecutorClient)');
+
+        // Attach the REAL product IME overlay (frontend/src/composables) over the
+        // canvas: type Chinese directly in the document, commit at the LO cursor
+        // via the product executor. The visible #imeBridge above stays as a
+        // fallback/comparison. Phase A — not cursor-positioned, no inline preview.
+        const ov = await import('/shared/zetaOfficeImeOverlay.js');
+        ov.attachImeOverlay({
+          canvas: canvas,
+          commit: function (text) { return loExec.executeCommand('insert_at_cursor', { text: text }); },
+          onLog: function (msg) { zlog(msg, 'ime'); },
+        });
+        zlog('IME 透明覆盖层已挂载 ✓ — 点文档定位光标后直接打中文（无需点上面的输入框）', 'ime');
       } catch (e) {
         zlog('boot 失败：' + e, 'e');
         btnBoot.disabled = false;

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -1,0 +1,93 @@
+// zetaOfficeImeOverlay.js — transparent IME overlay for the LibreOffice WASM
+// canvas (Epic #43, Phase A). DORMANT until a page calls attachImeOverlay().
+//
+// WHY: Qt5-WASM gives the <canvas> no usable IME (no candidate box) — an upstream
+// limitation, not a bug. To host the system IME we overlay a transparent, focusable
+// <input> on the canvas:
+//   - clicks pass THROUGH (pointer-events:none) so Qt still positions the LO
+//     view cursor by the click coords;
+//   - keystrokes + IME composition land on the overlay (it holds keyboard focus);
+//   - on commit the composed/typed text is inserted at the LO view cursor via the
+//     caller's `commit` callback — the SAME verified path as agent commands:
+//     executor.executeCommand('insert_at_cursor', {text}).
+//
+// PHASE A (this module): the overlay is NOT positioned at the cursor and shows no
+// inline composition preview — the IME candidate box pops at the overlay's
+// top-left. This matches the previously-accepted toolbar-input bridge, just moved
+// onto the document so typing feels in-place. PHASE B will map the UNO view-cursor
+// rect to canvas pixels so the overlay follows the cursor and previews inline.
+//
+// Control keys (Enter/Backspace/arrows) act on the empty overlay, not the doc —
+// same limitation as the toolbar bridge; forwarding them to Qt is a Phase B item.
+
+/**
+ * Attach a transparent IME overlay to a LibreOffice WASM canvas.
+ *
+ * @param {HTMLCanvasElement} options.canvas REQUIRED. The booted qtcanvas.
+ * @param {(text:string)=>(any|Promise<any>)} options.commit REQUIRED. Inserts the
+ *        committed text at the LO cursor (e.g. t => executor.executeCommand(
+ *        'insert_at_cursor', {text:t})).
+ * @param {(msg:string)=>void} [options.onLog] optional progress/diagnostic log.
+ * @returns {{element:HTMLInputElement, focus:()=>void, destroy:()=>void}}
+ */
+export function attachImeOverlay({ canvas, commit, onLog } = {}) {
+  if (!canvas) throw new Error('attachImeOverlay: canvas is required')
+  if (typeof commit !== 'function') throw new Error('attachImeOverlay: commit(text) is required')
+  const log = (m) => { if (onLog) onLog(m) }
+
+  const input = document.createElement('input')
+  input.setAttribute('autocomplete', 'off')
+  input.setAttribute('aria-hidden', 'true')
+  Object.assign(input.style, {
+    position: 'absolute', top: '0', left: '0', width: '100%', height: '100%',
+    margin: '0', padding: '0', border: '0', outline: '0',
+    background: 'transparent', color: 'transparent', caretColor: 'transparent',
+    font: 'inherit',
+    pointerEvents: 'none', // clicks fall through to the canvas (Qt positions cursor)
+    zIndex: '5',
+  })
+
+  // The overlay must live in a positioned ancestor that covers the canvas.
+  const host = canvas.parentElement || canvas
+  if (getComputedStyle(host).position === 'static') host.style.position = 'relative'
+  host.appendChild(input)
+
+  // Commit logic: identical to the verified toolbar bridge. dedup the input event
+  // that trails compositionend so a committed phrase isn't inserted twice.
+  let composing = false, skipNextInput = false
+  const doCommit = (t) => {
+    input.value = ''
+    if (!t) return
+    log('IME 覆盖层 → 上屏「' + t + '」')
+    try { Promise.resolve(commit(t)).catch((e) => log('overlay commit error: ' + (e && e.message || e))) }
+    catch (e) { log('overlay commit error: ' + (e && e.message || e)) }
+  }
+  input.addEventListener('compositionstart', () => { composing = true })
+  input.addEventListener('compositionend', (e) => { composing = false; skipNextInput = true; doCommit(e.data) })
+  input.addEventListener('input', (e) => {
+    if (composing) return                                  // mid-composition: wait for end
+    if (skipNextInput) { skipNextInput = false; return }   // trailing event after compositionend
+    doCommit(e.data != null ? e.data : input.value)
+  })
+
+  // FOCUS-RACE FIX (from the spike): a canvas click positions the LO cursor (Qt
+  // handles it) but also steals keyboard focus, so the first keystroke after a
+  // click would land on the canvas. Hand focus back after Qt processes the click
+  // (mouseup) so ALL typing — including the first char — goes through the overlay.
+  // The cursor position is set by the click coords, not by sustained focus.
+  const refocus = () => setTimeout(() => { try { input.focus() } catch (e) {} }, 0)
+  canvas.addEventListener('mouseup', refocus)
+
+  const focus = () => { try { input.focus() } catch (e) {} }
+  focus()
+  log('IME 覆盖层已挂载 / overlay attached — 点文档定位光标后直接打字')
+
+  return {
+    element: input,
+    focus,
+    destroy() {
+      canvas.removeEventListener('mouseup', refocus)
+      input.remove()
+    },
+  }
+}

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -15,6 +15,7 @@
 // browser) can drive it the same way the host will.
 
 import { startEditorEndpoint } from '../composables/zetaOfficeEditorEndpoint.js'
+import { attachImeOverlay } from '../composables/zetaOfficeImeOverlay.js'
 
 // Electron renderer require is a runtime property access (NOT a static import),
 // so the bundler leaves it alone and the browser fallback path stays clean.
@@ -118,6 +119,17 @@ startEditorEndpoint({
   onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
 }).then((endpoint) => {
   console.log('[zeta-editor] endpoint ready — serving host over transport')
+  // Transparent IME overlay over the canvas, so users can type Chinese directly
+  // in the document (Qt5-WASM gives the canvas no IME). Commits at the LO cursor
+  // via the same verified path as agent commands. Attached in BOTH webview and
+  // verify modes — local typing is a real-user need, not just a verification one.
+  try {
+    attachImeOverlay({
+      canvas: document.getElementById('qtcanvas'),
+      commit: (text) => endpoint.executor.executeCommand('insert_at_cursor', { text }),
+      onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
+    })
+  } catch (e) { console.error('[zeta-editor] IME overlay failed:', e); if (VERIFY) vlog('IME overlay failed: ' + (e && e.message || e)) }
   if (VERIFY) wireVerifyPanel(endpoint.executor)
 }).catch((e) => {
   console.error('[zeta-editor] boot failed:', e)

--- a/frontend/src/zetaoffice/editor.html
+++ b/frontend/src/zetaoffice/editor.html
@@ -26,7 +26,7 @@
   <div id="verify">
     <strong>LibreOffice 验证</strong>
     <span id="vstatus">启动中… / booting…</span>
-    <input id="vime" disabled placeholder="① 在此用输入法打中文 → 插入文档（IME 验证）" autocomplete="off" />
+    <input id="vime" disabled placeholder="备用框：① 点文档里定位光标 → 直接打中文（透明覆盖层）；此框为后备" autocomplete="off" />
     <button id="vinsert" disabled>插入示例</button>
     <button id="vreplace" disabled>查找替换(redline)</button>
     <button id="vsel" disabled>读选区</button>


### PR DESCRIPTION
## 这是什么 / What

LibreOffice 迁移（Epic #43）的剩余 UX 任务：**IME 透明覆盖层**。Qt5-WASM 在 canvas 上不起 IME（上游限制，非 bug），此前中文只能经工具栏单独的 `<input>` 框打。本 PR 把承接 IME 的输入框做成**贴在 canvas 上的透明可编辑层**，让用户感知「直接在文档里打中文」。

The remaining UX task for the LibreOffice migration (Epic #43). Qt5-WASM gives the canvas no usable IME (upstream limitation), so Chinese previously required a separate toolbar `<input>`. This makes the IME-hosting field a **transparent editable layer on the canvas**, so typing feels in-document.

## 机制 / Mechanism

| 维度 | 做法 |
|---|---|
| 点击穿透 | `pointer-events: none` → 鼠标落到 canvas，Qt 定位 LO 光标 |
| 键盘承接 | 覆盖层程序化持焦；复用 spike 的焦点交还修复（`canvas.mouseup → refocus`） |
| 上屏 | `compositionend`/`input` → `executor.executeCommand('insert_at_cursor',{text})`（与 AI 命令同一已验证路径） |
| 隐形 | `color`/`caret-color`/`background: transparent` |

## Phase A / 本轮范围

**仅可用版**：覆盖层尚未精确定位到光标、无 inline 合成预览（候选框弹在覆盖层左上角）——与此前已认可的工具栏桥局限一致，只是搬到文档上。方向键/退格仍作用于覆盖层（同现状）。

**Phase B（下轮）**：从 UNO `getViewCursor().getPosition()`（1/100mm 文档坐标）映射到 canvas 像素 → 覆盖层跟随光标 + inline 合成预览。

## 改动 / Changes

- **新增** `frontend/src/composables/zetaOfficeImeOverlay.js` — `attachImeOverlay({canvas, commit, onLog})`，可复用、框架无关。
- `editor-main.js` — webview 与验证两种模式都挂载（本地打字是真实用户需求）；经端点 executor 上屏。
- `editor.html` — `#vime` 工具栏框降级为后备。
- `experiments/zetaoffice-spike/index.html` — 同一产品模块挂到 `#qtcanvas`，供真 Chrome 快迭代。

## 休眠与验证 / Dormant + verification

- **休眠**：只有内嵌编辑器页 / spike import 它，**现役 WPS 路径逐字节不变**。
- **浏览器已验证**（Preview MCP，真 Chromium，`crossOriginIsolated:true`，11/11）：透明 + pointer-events 结构、自动持焦、IME 一次上屏 + 去重、ASCII 路径、空合成 no-op、焦点交还、destroy 清理。`build:zetaoffice` 通过（9 模块，无回归）。
- **待维护者真机敲键终验**：真系统 IME 候选框 + 合成手感无法无头验证。跑法 A（最快）：`experiments/zetaoffice-spike/` → `cp "/System/Library/Fonts/Hiragino Sans GB.ttc" cjk-test.ttc` → `node serve.mjs` → 真 Chrome `localhost:8777` → Boot → **点文档定位光标后直接打中文**；或装包按 `⌘⇧L` 验证窗口。

Epic #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)