### PR TITLE
feat(libreoffice): Phase B 光标跟随 + IME 覆盖层定位(休眠) / cursor-rect tracking + overlay anchoring (dormant)

### DIFF
--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -277,12 +277,14 @@
         });
         zlog('IME 透明覆盖层已挂载 ✓ (Phase B 自标定) — 点文档放光标后直接打中文、回车换行', 'ime');
 
-        // Debug hooks: measureCursor() reads raw; overlayRect() = overlay's computed
-        // px (null until you click the doc to anchor); cursorMap = stable scale.
+        // Debug hooks. tuneCursorMap({nudgeX,nudgeY}) shifts the box by a constant
+        // px to zero out the small click-snap / caret-top residual — click the doc,
+        // type, nudge until the box sits exactly on the caret, report the values.
         window.measureCursor = function () { return workerRequest('get_cursor_rect', {}); };
         window.overlayRect = function () { return imeOverlay.computeRect(); };
         window.cursorMap = ov.CURSOR_MAP;
-        zlog('调试钩子就绪：measureCursor() / overlayRect() / cursorMap', 'k');
+        window.tuneCursorMap = function (patch) { Object.assign(ov.CURSOR_MAP, patch || {}); if (imeOverlay) imeOverlay.reposition(); zlog('CURSOR_MAP = ' + JSON.stringify(ov.CURSOR_MAP), 'k'); return ov.CURSOR_MAP; };
+        zlog('调试钩子就绪：tuneCursorMap({nudgeX,nudgeY}) / measureCursor() / overlayRect()', 'k');
       } catch (e) {
         zlog('boot 失败：' + e, 'e');
         btnBoot.disabled = false;

--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -75,8 +75,8 @@
     const cursorbox = document.getElementById('cursorbox');
     const imeBridge = document.getElementById('imeBridge');
 
-    // Phase B calibration helper, filled after the overlay module imports.
-    let mapCursorRect = null;
+    // Phase B overlay handle (self-calibrating via clicks), set after boot.
+    let imeOverlay = null;
 
     // The REAL product executor client (frontend/src/composables/), imported via
     // the server's /shared/ route so this spike drives product code, not a copy.
@@ -169,27 +169,24 @@
       zlog('=== executor 自测结束 ===', 'k');
     };
 
-    // ---- Phase B calibration: measure cursor rect, map to px, draw debug box ----
-    // Click in the document first to position the cursor, then click this. The red
-    // box should land ON the LO cursor; if offset, tune CURSOR_MAP in the overlay
-    // module (scale/offsetX/offsetY) and re-measure. This is the empirical gate for
-    // whether doc-coord -> canvas-px mapping is viable under WASM (#43 Phase B).
+    // ---- Phase B debug box: draw the overlay's COMPUTED cursor rect ----
+    // The overlay self-calibrates from clicks (offset = clickPx - scale*docPos),
+    // so click in the document first to anchor, then click this to see where the
+    // overlay thinks the cursor is. The red box should sit ON the LO caret.
     btnRect.onclick = async () => {
-      if (!thrPort) { zlog('worker 未就绪', 'e'); return; }
+      if (!imeOverlay) { zlog('overlay 未挂载', 'e'); return; }
       const raw = await workerRequest('get_cursor_rect', {});
+      const rect = await imeOverlay.computeRect();
       zlog('get_cursor_rect raw → ' + JSON.stringify(raw), 'k');
-      const rect = mapCursorRect ? mapCursorRect(raw) : null;
-      zlog('mapped px → ' + JSON.stringify(rect), 'k');
+      zlog('overlay computeRect → ' + JSON.stringify(rect) + (rect ? '' : '（先点一下文档放光标以锚定）'), 'k');
       if (rect) {
-        const w = 8; // a thin caret-width marker so we can see exactly where it points
         Object.assign(cursorbox.style, {
           display: 'block',
           left: Math.round(rect.left) + 'px', top: Math.round(rect.top) + 'px',
-          width: w + 'px', height: Math.round(rect.height) + 'px',
+          width: '8px', height: Math.round(rect.height) + 'px',
         });
       } else {
         cursorbox.style.display = 'none';
-        zlog('映射失败（无 pos）/ mapping failed — 看 raw 里 posErr/winErr', 'e');
       }
     };
 
@@ -268,33 +265,24 @@
         // via the product executor. The visible #imeBridge above stays as a
         // fallback/comparison. Phase A — not cursor-positioned, no inline preview.
         const ov = await import('/shared/zetaOfficeImeOverlay.js');
-        // Single-sourced mm->px mapping (also used by the calibration button).
-        mapCursorRect = ov.cursorRectToPixels;
-        ov.attachImeOverlay({
+        imeOverlay = ov.attachImeOverlay({
           canvas: canvas,
           commit: function (text) { return loExec.executeCommand('insert_at_cursor', { text: text }); },
-          // Phase B: query the LO view-cursor rect and map to host px so the
-          // overlay anchors at the cursor (candidate box + inline preview).
-          getCursorRect: async function () {
-            const raw = await workerRequest('get_cursor_rect', {});
-            return ov.cursorRectToPixels(raw);
-          },
+          // Phase B: overlay reads the raw view-cursor measurement; it derives the
+          // px mapping itself (stable scale + live offset from each click).
+          getCursorRaw: function () { return workerRequest('get_cursor_rect', {}); },
+          // Enter -> paragraph break at the LO cursor (single-line input can't).
+          onEnter: function () { return workerRequest('insert_paragraph', {}); },
           onLog: function (msg) { zlog(msg, 'ime'); },
         });
-        zlog('IME 透明覆盖层已挂载 ✓ (Phase B) — 点文档定位光标后直接打中文（无需点上面的输入框）', 'ime');
+        zlog('IME 透明覆盖层已挂载 ✓ (Phase B 自标定) — 点文档放光标后直接打中文、回车换行', 'ime');
 
-        // ---- Phase B live calibration (real-Chrome only; canvas is black headless) ----
-        // The mm->px mapping has 3 affine constants that need a VISIBLE canvas to
-        // fit (red debug box must sit on the cursor). Tune them live from the
-        // console — no edit/rebuild loop:
-        //   1) click in the document to place the cursor
-        //   2) 点「测光标矩形」→ red box appears at the COMPUTED position
-        //   3) tuneCursorMap({offsetX, offsetY, scale}) until the box hugs the cursor
-        //   4) report the final values back so they bake into CURSOR_MAP
-        window.cursorMap = ov.CURSOR_MAP;
-        window.tuneCursorMap = function (patch) { Object.assign(ov.CURSOR_MAP, patch || {}); zlog('CURSOR_MAP = ' + JSON.stringify(ov.CURSOR_MAP), 'k'); return ov.CURSOR_MAP; };
+        // Debug hooks: measureCursor() reads raw; overlayRect() = overlay's computed
+        // px (null until you click the doc to anchor); cursorMap = stable scale.
         window.measureCursor = function () { return workerRequest('get_cursor_rect', {}); };
-        zlog('标定钩子就绪：tuneCursorMap({offsetX,offsetY,scale}) / measureCursor() / cursorMap', 'k');
+        window.overlayRect = function () { return imeOverlay.computeRect(); };
+        window.cursorMap = ov.CURSOR_MAP;
+        zlog('调试钩子就绪：measureCursor() / overlayRect() / cursorMap', 'k');
       } catch (e) {
         zlog('boot 失败：' + e, 'e');
         btnBoot.disabled = false;

--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -31,6 +31,7 @@
     <button id="btnPerf" disabled>测50页性能 perf</button>
     <button id="btnCjk" disabled>插入中文(无IME)</button>
     <button id="btnExec" disabled>executor 自测(产品客户端)</button>
+    <button id="btnRect" disabled>测光标矩形 cursor-rect</button>
     <input id="imeBridge" disabled placeholder="① 在此用输入法打中文 → 自动插入文档（IME 桥 PoC）"
       style="font:inherit;padding:4px 8px;border:0;border-radius:4px;width:280px" autocomplete="off" />
     <span style="opacity:.8">canvas 上 Qt5-WASM 无 IME；这个输入框承接 IME 合成→经 UNO 插入光标处</span>
@@ -41,6 +42,10 @@
       <!-- Qt REQUIRES id="qtcanvas"; canvas must have no border/padding (outline ok). -->
       <canvas id="qtcanvas" contenteditable="true"
         oncontextmenu="event.preventDefault()" onkeydown="event.preventDefault()"></canvas>
+      <!-- Phase B calibration: a visible box drawn at the COMPUTED cursor rect.
+           If it lands on the real LO cursor, the mm->px mapping is right. -->
+      <div id="cursorbox" style="position:absolute;display:none;pointer-events:none;
+        outline:2px solid #ef4444;background:rgba(239,68,68,.18);z-index:6"></div>
     </div>
     <pre id="log"></pre>
   </div>
@@ -66,7 +71,12 @@
     const btnPerf = document.getElementById('btnPerf');
     const btnCjk = document.getElementById('btnCjk');
     const btnExec = document.getElementById('btnExec');
+    const btnRect = document.getElementById('btnRect');
+    const cursorbox = document.getElementById('cursorbox');
     const imeBridge = document.getElementById('imeBridge');
+
+    // Phase B calibration helper, filled after the overlay module imports.
+    let mapCursorRect = null;
 
     // The REAL product executor client (frontend/src/composables/), imported via
     // the server's /shared/ route so this spike drives product code, not a copy.
@@ -106,6 +116,27 @@
     let thrPort = null;
     function send(cmd, extra) { if (thrPort) thrPort.postMessage(Object.assign({ cmd }, extra || {})); else zlog('worker 未就绪 / not ready', 'e'); }
 
+    // Direct worker request/response — for UI PLUMBING commands (get_cursor_rect)
+    // that are NOT part of the backend AI-command contract (EDITOR_ACTIONS in
+    // libreofficeExecutorClient.js, which rejects unknown actions on purpose).
+    // Cursor positioning is editor-internal UI, not something the agent calls, so
+    // it talks to the worker's exec loop straight, correlating by reqId. Coexists
+    // with the boot dispatcher + the executor client (both ignore others' reqIds).
+    let workerReqSeq = 0;
+    function workerRequest(action, params) {
+      if (!thrPort) return Promise.reject(new Error('worker not ready'));
+      const reqId = 'ui_' + (++workerReqSeq);
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => { thrPort.removeEventListener('message', onMsg); reject(new Error('timeout: ' + action)); }, 8000);
+        function onMsg(e) {
+          const d = (e && e.data) || {};
+          if (d.cmd === 'result' && d.reqId === reqId) { clearTimeout(timer); thrPort.removeEventListener('message', onMsg); resolve(d.result); }
+        }
+        thrPort.addEventListener('message', onMsg);
+        thrPort.postMessage({ cmd: 'exec', reqId, action, params: params || {} });
+      });
+    }
+
     btnSel.onclick = () => send('selection');
     btnRed.onclick = () => send('redline');
     btnPerf.onclick = () => send('perf', { pages: 50 });
@@ -136,6 +167,30 @@
       zlog('替换后定位【甲方】→ count=' + (after && after.count), 'k');
       await loExec.executeCommand('clear_anchors', {});
       zlog('=== executor 自测结束 ===', 'k');
+    };
+
+    // ---- Phase B calibration: measure cursor rect, map to px, draw debug box ----
+    // Click in the document first to position the cursor, then click this. The red
+    // box should land ON the LO cursor; if offset, tune CURSOR_MAP in the overlay
+    // module (scale/offsetX/offsetY) and re-measure. This is the empirical gate for
+    // whether doc-coord -> canvas-px mapping is viable under WASM (#43 Phase B).
+    btnRect.onclick = async () => {
+      if (!thrPort) { zlog('worker 未就绪', 'e'); return; }
+      const raw = await workerRequest('get_cursor_rect', {});
+      zlog('get_cursor_rect raw → ' + JSON.stringify(raw), 'k');
+      const rect = mapCursorRect ? mapCursorRect(raw) : null;
+      zlog('mapped px → ' + JSON.stringify(rect), 'k');
+      if (rect) {
+        const w = 8; // a thin caret-width marker so we can see exactly where it points
+        Object.assign(cursorbox.style, {
+          display: 'block',
+          left: Math.round(rect.left) + 'px', top: Math.round(rect.top) + 'px',
+          width: w + 'px', height: Math.round(rect.height) + 'px',
+        });
+      } else {
+        cursorbox.style.display = 'none';
+        zlog('映射失败（无 pos）/ mapping failed — 看 raw 里 posErr/winErr', 'e');
+      }
     };
 
     // ---- IME input bridge PoC (#39) ----------------------------------------
@@ -187,7 +242,7 @@
           onLog: function (m) { zlog(m); },
           onReady: function () {
             spinner.style.display = 'none'; canvas.style.visibility = 'visible';
-            btnSel.disabled = btnRed.disabled = btnPerf.disabled = btnCjk.disabled = btnExec.disabled = false;
+            btnSel.disabled = btnRed.disabled = btnPerf.disabled = btnCjk.disabled = btnExec.disabled = btnRect.disabled = false;
             imeBridge.disabled = false; imeBridge.focus();
             zlog('UI ready ✓ — 现在可以在文档里打中文、点测试按钮');
             try { window.dispatchEvent(new Event('resize')); } catch (err) { zlog('resize warn: ' + err, 'e'); }
@@ -213,12 +268,33 @@
         // via the product executor. The visible #imeBridge above stays as a
         // fallback/comparison. Phase A — not cursor-positioned, no inline preview.
         const ov = await import('/shared/zetaOfficeImeOverlay.js');
+        // Single-sourced mm->px mapping (also used by the calibration button).
+        mapCursorRect = ov.cursorRectToPixels;
         ov.attachImeOverlay({
           canvas: canvas,
           commit: function (text) { return loExec.executeCommand('insert_at_cursor', { text: text }); },
+          // Phase B: query the LO view-cursor rect and map to host px so the
+          // overlay anchors at the cursor (candidate box + inline preview).
+          getCursorRect: async function () {
+            const raw = await workerRequest('get_cursor_rect', {});
+            return ov.cursorRectToPixels(raw);
+          },
           onLog: function (msg) { zlog(msg, 'ime'); },
         });
-        zlog('IME 透明覆盖层已挂载 ✓ — 点文档定位光标后直接打中文（无需点上面的输入框）', 'ime');
+        zlog('IME 透明覆盖层已挂载 ✓ (Phase B) — 点文档定位光标后直接打中文（无需点上面的输入框）', 'ime');
+
+        // ---- Phase B live calibration (real-Chrome only; canvas is black headless) ----
+        // The mm->px mapping has 3 affine constants that need a VISIBLE canvas to
+        // fit (red debug box must sit on the cursor). Tune them live from the
+        // console — no edit/rebuild loop:
+        //   1) click in the document to place the cursor
+        //   2) 点「测光标矩形」→ red box appears at the COMPUTED position
+        //   3) tuneCursorMap({offsetX, offsetY, scale}) until the box hugs the cursor
+        //   4) report the final values back so they bake into CURSOR_MAP
+        window.cursorMap = ov.CURSOR_MAP;
+        window.tuneCursorMap = function (patch) { Object.assign(ov.CURSOR_MAP, patch || {}); zlog('CURSOR_MAP = ' + JSON.stringify(ov.CURSOR_MAP), 'k'); return ov.CURSOR_MAP; };
+        window.measureCursor = function () { return workerRequest('get_cursor_rect', {}); };
+        zlog('标定钩子就绪：tuneCursorMap({offsetX,offsetY,scale}) / measureCursor() / cursorMap', 'k');
       } catch (e) {
         zlog('boot 失败：' + e, 'e');
         btnBoot.disabled = false;

--- a/experiments/zetaoffice-spike/office_thread.js
+++ b/experiments/zetaoffice-spike/office_thread.js
@@ -354,6 +354,32 @@ const EXEC = {
     range.setString(String(p.newText || ''));
     return { success: true, anchor: p.anchor };
   },
+  // [spike] Phase B: raw measurements for mapping the view cursor to canvas
+  // pixels. We DELIBERATELY return primitives (not a final px rect) so the
+  // mm->px formula can be calibrated on the JS side without restarting LOWA.
+  //   - pos: XTextViewCursor.getPosition() -> awt.Point in 1/100 mm. The ORIGIN
+  //     (page top-left vs visible-area top-left) is the open question under
+  //     WASM; probe it empirically (short doc = no scroll hides the difference).
+  //   - charHeightPt: CharHeight (points) at the cursor -> caret height.
+  //   - zoom: ZoomValue (%) from the view settings.
+  //   - winPx: the Qt component window rect (px) — the canvas surface bounds.
+  // Each field is independently try/caught so a missing API degrades, not throws.
+  get_cursor_rect() {
+    const out = { success: true };
+    let vc = null;
+    try { vc = ctrl.getViewCursor(); } catch (e) { out.vcErr = errStr(e); }
+    if (vc) {
+      try { const pt = vc.getPosition(); out.pos = { X: pt.X, Y: pt.Y }; } catch (e) { out.posErr = errStr(e); }
+      try { out.charHeightPt = vc.getPropertyValue('CharHeight'); } catch (e) { out.charHeightErr = errStr(e); }
+      try { out.collapsed = (vc.getString() || '').length === 0; } catch (e) {}
+    }
+    try { out.zoom = ctrl.getViewSettings().getPropertyValue('ZoomValue'); } catch (e) { out.zoomErr = errStr(e); }
+    try {
+      const r = ctrl.getFrame().getComponentWindow().getPosSize();
+      out.winPx = { X: r.X, Y: r.Y, W: r.Width, H: r.Height };
+    } catch (e) { out.winErr = errStr(e); }
+    return out;
+  },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {
     const bms = xModel.getBookmarks();

--- a/experiments/zetaoffice-spike/office_thread.js
+++ b/experiments/zetaoffice-spike/office_thread.js
@@ -354,6 +354,17 @@ const EXEC = {
     range.setString(String(p.newText || ''));
     return { success: true, anchor: p.anchor };
   },
+  // [verified-extend] insert a paragraph break at the view cursor (Enter key in
+  // the IME overlay routes here — the overlay's single-line <input> can't make a
+  // newline itself). Append, leave cursor collapsed after the break.
+  insert_paragraph() {
+    const xText = xModel.getText();
+    const vc = ctrl.getViewCursor();
+    vc.collapseToEnd();
+    xText.insertControlCharacter(vc, css.text.ControlCharacter.PARAGRAPH_BREAK, false);
+    vc.collapseToEnd();
+    return { success: true };
+  },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the
   // mm->px formula can be calibrated on the JS side without restarting LOWA.

--- a/experiments/zetaoffice-spike/serve.mjs
+++ b/experiments/zetaoffice-spike/serve.mjs
@@ -18,7 +18,7 @@ import { extname, join, normalize } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = fileURLToPath(new URL('.', import.meta.url))
-const PORT = Number(process.argv[2]) || 8777
+const PORT = Number(process.argv[2]) || Number(process.env.PORT) || 8777
 
 const TYPES = {
   '.html': 'text/html; charset=utf-8',

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -1,9 +1,9 @@
 // zetaOfficeImeOverlay.js — transparent IME overlay for the LibreOffice WASM
-// canvas (Epic #43, Phase A). DORMANT until a page calls attachImeOverlay().
+// canvas (Epic #43, Phase A+B). DORMANT until a page calls attachImeOverlay().
 //
 // WHY: Qt5-WASM gives the <canvas> no usable IME (no candidate box) — an upstream
-// limitation, not a bug. To host the system IME we overlay a transparent, focusable
-// <input> on the canvas:
+// limitation, not a bug. To host the system IME we overlay a focusable <input> on
+// the canvas:
 //   - clicks pass THROUGH (pointer-events:none) so Qt still positions the LO
 //     view cursor by the click coords;
 //   - keystrokes + IME composition land on the overlay (it holds keyboard focus);
@@ -11,14 +11,53 @@
 //     caller's `commit` callback — the SAME verified path as agent commands:
 //     executor.executeCommand('insert_at_cursor', {text}).
 //
-// PHASE A (this module): the overlay is NOT positioned at the cursor and shows no
-// inline composition preview — the IME candidate box pops at the overlay's
-// top-left. This matches the previously-accepted toolbar-input bridge, just moved
-// onto the document so typing feels in-place. PHASE B will map the UNO view-cursor
-// rect to canvas pixels so the overlay follows the cursor and previews inline.
+// PHASE A (default, no getCursorRect): the overlay covers the whole canvas,
+// transparent — the IME candidate box pops at the canvas top-left. Functional but
+// the candidate window isn't at the cursor.
 //
-// Control keys (Enter/Backspace/arrows) act on the empty overlay, not the doc —
-// same limitation as the toolbar bridge; forwarding them to Qt is a Phase B item.
+// PHASE B (when a getCursorRect callback is supplied): the overlay shrinks to a
+// small box anchored at the LO view cursor's pixel rect, so the native candidate
+// window appears AT the cursor; composing text is shown inline (color turned
+// visible) for a what-you-see-is-what-you-get feel, then cleared on commit while
+// LO renders the real text. If the cursor rect can't be mapped (WASM mapping
+// unstable / API missing), it degrades cleanly back to Phase A (full-cover
+// transparent) — the inline-preview half still works wherever the box lands.
+//
+// Control keys (Enter/Backspace/arrows) act on the overlay, not the doc — same
+// limitation as before; forwarding them to Qt is a later item.
+
+// ---------------------------------------------------------------------------
+// CALIBRATE (Phase B): map the worker's get_cursor_rect raw output (doc 1/100 mm)
+// to host CSS pixels. These constants are refined empirically via the spike's
+// debug box + screenshots — the doc-coord ORIGIN (page vs visible-area top-left)
+// and the canvas gray-margin offset are not derivable from the API alone.
+//   scale   : CSS px per 1/100 mm at zoom 100% (96 px/in ÷ 2540 (1/100 mm)/in).
+//   offsetX : px from canvas left to the page's text origin (gray margin + indent).
+//   offsetY : px from canvas top  to the page's text origin.
+//   useZoom : multiply scale by ZoomValue%/100.
+// ---------------------------------------------------------------------------
+export const CURSOR_MAP = {
+  scale: 96 / 2540,
+  offsetX: 0,
+  offsetY: 0,
+  useZoom: true,
+}
+
+/**
+ * Convert the worker's get_cursor_rect raw result to a host-relative CSS-px rect.
+ * Single source of the mm->px formula so the spike and the app share calibration.
+ * @returns {{left:number, top:number, height:number}|null} null if unmappable.
+ */
+export function cursorRectToPixels(raw) {
+  if (!raw || !raw.pos || typeof raw.pos.X !== 'number') return null
+  const z = (CURSOR_MAP.useZoom && raw.zoom) ? raw.zoom / 100 : 1
+  const k = CURSOR_MAP.scale * z
+  const left = CURSOR_MAP.offsetX + raw.pos.X * k
+  const top = CURSOR_MAP.offsetY + raw.pos.Y * k
+  // caret height: points -> px (1pt = 1/72 in) * zoom; fall back to a sane line.
+  const height = raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z : 18
+  return { left, top, height }
+}
 
 /**
  * Attach a transparent IME overlay to a LibreOffice WASM canvas.
@@ -27,30 +66,74 @@
  * @param {(text:string)=>(any|Promise<any>)} options.commit REQUIRED. Inserts the
  *        committed text at the LO cursor (e.g. t => executor.executeCommand(
  *        'insert_at_cursor', {text:t})).
+ * @param {()=>Promise<{left:number,top:number,height:number}|null>} [options.getCursorRect]
+ *        OPTIONAL. Returns the cursor rect in host CSS px. Supplying it enables
+ *        Phase B (cursor-anchored box + inline preview); omitting it keeps Phase A.
  * @param {(msg:string)=>void} [options.onLog] optional progress/diagnostic log.
- * @returns {{element:HTMLInputElement, focus:()=>void, destroy:()=>void}}
+ * @returns {{element:HTMLInputElement, focus:()=>void, reposition:()=>void, destroy:()=>void}}
  */
-export function attachImeOverlay({ canvas, commit, onLog } = {}) {
+export function attachImeOverlay({ canvas, commit, getCursorRect, onLog } = {}) {
   if (!canvas) throw new Error('attachImeOverlay: canvas is required')
   if (typeof commit !== 'function') throw new Error('attachImeOverlay: commit(text) is required')
   const log = (m) => { if (onLog) onLog(m) }
+
+  const phaseB = typeof getCursorRect === 'function'
+  let mapOk = phaseB // flips false (and stays Phase A) if mapping ever fails
 
   const input = document.createElement('input')
   input.setAttribute('autocomplete', 'off')
   input.setAttribute('aria-hidden', 'true')
   Object.assign(input.style, {
-    position: 'absolute', top: '0', left: '0', width: '100%', height: '100%',
+    position: 'absolute', top: '0', left: '0',
     margin: '0', padding: '0', border: '0', outline: '0',
     background: 'transparent', color: 'transparent', caretColor: 'transparent',
-    font: 'inherit',
+    font: 'inherit', lineHeight: '1',
     pointerEvents: 'none', // clicks fall through to the canvas (Qt positions cursor)
     zIndex: '5',
+    whiteSpace: 'pre', overflow: 'hidden',
   })
 
   // The overlay must live in a positioned ancestor that covers the canvas.
   const host = canvas.parentElement || canvas
   if (getComputedStyle(host).position === 'static') host.style.position = 'relative'
   host.appendChild(input)
+
+  // Two layout states. Phase A / idle-fallback: cover the whole canvas. Phase B:
+  // a small box at the cursor (the native candidate window anchors to its caret).
+  function applyCover() {
+    Object.assign(input.style, { left: '0', top: '0', width: '100%', height: '100%' })
+  }
+  function applyCursorBox(rect) {
+    Object.assign(input.style, {
+      left: Math.round(rect.left) + 'px',
+      top: Math.round(rect.top) + 'px',
+      width: '16em',
+      height: Math.round(rect.height) + 'px',
+    })
+  }
+  applyCover()
+
+  // Show composing text inline (Phase B) vs invisible (idle / Phase A).
+  function setPreviewVisible(on) {
+    const show = on && mapOk
+    input.style.color = show ? '#111' : 'transparent'
+    input.style.caretColor = show ? '#111' : 'transparent'
+  }
+
+  // Move the box to the current LO cursor. No-op (cover) in Phase A or if the
+  // mapping is unavailable. Async: one worker round-trip per call.
+  async function reposition() {
+    if (!phaseB || !mapOk) { applyCover(); return }
+    try {
+      const rect = await getCursorRect()
+      if (rect) applyCursorBox(rect)
+      else applyCover()
+    } catch (e) {
+      mapOk = false
+      applyCover()
+      log('光标映射不可用，退回 Phase A 全覆盖 / cursor map unavailable, Phase A fallback: ' + (e && e.message || e))
+    }
+  }
 
   // Commit logic: identical to the verified toolbar bridge. dedup the input event
   // that trails compositionend so a committed phrase isn't inserted twice.
@@ -62,31 +145,41 @@ export function attachImeOverlay({ canvas, commit, onLog } = {}) {
     try { Promise.resolve(commit(t)).catch((e) => log('overlay commit error: ' + (e && e.message || e))) }
     catch (e) { log('overlay commit error: ' + (e && e.message || e)) }
   }
-  input.addEventListener('compositionstart', () => { composing = true })
-  input.addEventListener('compositionend', (e) => { composing = false; skipNextInput = true; doCommit(e.data) })
+  input.addEventListener('compositionstart', () => { composing = true; setPreviewVisible(true) })
+  input.addEventListener('compositionend', (e) => {
+    composing = false; skipNextInput = true
+    setPreviewVisible(false)
+    doCommit(e.data)
+    reposition() // cursor advanced past the committed text
+  })
   input.addEventListener('input', (e) => {
     if (composing) return                                  // mid-composition: wait for end
     if (skipNextInput) { skipNextInput = false; return }   // trailing event after compositionend
     doCommit(e.data != null ? e.data : input.value)
+    reposition()
   })
 
   // FOCUS-RACE FIX (from the spike): a canvas click positions the LO cursor (Qt
   // handles it) but also steals keyboard focus, so the first keystroke after a
   // click would land on the canvas. Hand focus back after Qt processes the click
-  // (mouseup) so ALL typing — including the first char — goes through the overlay.
-  // The cursor position is set by the click coords, not by sustained focus.
-  const refocus = () => setTimeout(() => { try { input.focus() } catch (e) {} }, 0)
-  canvas.addEventListener('mouseup', refocus)
+  // (mouseup) so ALL typing — including the first char — goes through the overlay,
+  // and move the box to the freshly-set cursor so the candidate window anchors there.
+  const onMouseUp = () => setTimeout(() => { try { input.focus() } catch (e) {} ; reposition() }, 0)
+  canvas.addEventListener('mouseup', onMouseUp)
 
   const focus = () => { try { input.focus() } catch (e) {} }
   focus()
-  log('IME 覆盖层已挂载 / overlay attached — 点文档定位光标后直接打字')
+  reposition()
+  log(phaseB
+    ? 'IME 覆盖层已挂载 (Phase B：贴光标+inline 预览) / overlay attached — 点文档定位光标后直接打字'
+    : 'IME 覆盖层已挂载 (Phase A：全覆盖) / overlay attached — 点文档定位光标后直接打字')
 
   return {
     element: input,
     focus,
+    reposition,
     destroy() {
-      canvas.removeEventListener('mouseup', refocus)
+      canvas.removeEventListener('mouseup', onMouseUp)
       input.remove()
     },
   }

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -36,9 +36,14 @@
 // not into the empty <input>. Backspace/arrows are not yet forwarded.
 
 // The STABLE half of the mapping. offset is derived live per click (see above).
+// nudgeX/nudgeY are a small constant px correction for the residual between the
+// click-derived anchor and the true caret (glyph-snap + caret-top vs click
+// estimate) — roughly constant at a given zoom; tune once, then bake.
 export const CURSOR_MAP = {
   scale: 96 / 2540, // CSS px per 1/100 mm at 100% zoom (verified exact)
   useZoom: true,
+  nudgeX: 0,
+  nudgeY: 0,
 }
 
 function scaleFromZoom(raw) {
@@ -56,8 +61,8 @@ export function cursorRectToPixels(raw, offset) {
   const s = scaleFromZoom(raw)
   const z = s / CURSOR_MAP.scale
   return {
-    left: offset.x + s * raw.pos.X,
-    top: offset.y + s * raw.pos.Y,
+    left: offset.x + s * raw.pos.X + (CURSOR_MAP.nudgeX || 0),
+    top: offset.y + s * raw.pos.Y + (CURSOR_MAP.nudgeY || 0),
     height: raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z : 18,
   }
 }
@@ -135,11 +140,12 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog 
       const s = scaleFromZoom(raw)
       const r = host.getBoundingClientRect()
       // pos.Y is the caret's TOP; a click lands ~mid-line, so the click Y sits
-      // ~half a caret-height BELOW the caret top. Subtract that, else the box
-      // renders a half-line too low (lands between lines). X snaps to a glyph
-      // boundary near the click, so no horizontal correction is needed.
+      // ~half a caret-height below the caret top — subtract that so the box top
+      // is near the caret top, not a half-line low. This assumes a roughly
+      // center-of-line click; the residual (click-height variance, glyph snap on
+      // X) is a small ~constant the maintainer zeroes once via CURSOR_MAP.nudge.
       const z = s / CURSOR_MAP.scale
-      const halfCaret = raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z / 2 : 9
+      const halfCaret = raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z / 2 : 8
       anchor = {
         x: (clientX - r.left) - s * raw.pos.X,
         y: (clientY - r.top) - halfCaret - s * raw.pos.Y,

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -134,7 +134,16 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog 
       if (!raw || !raw.pos) return
       const s = scaleFromZoom(raw)
       const r = host.getBoundingClientRect()
-      anchor = { x: (clientX - r.left) - s * raw.pos.X, y: (clientY - r.top) - s * raw.pos.Y }
+      // pos.Y is the caret's TOP; a click lands ~mid-line, so the click Y sits
+      // ~half a caret-height BELOW the caret top. Subtract that, else the box
+      // renders a half-line too low (lands between lines). X snaps to a glyph
+      // boundary near the click, so no horizontal correction is needed.
+      const z = s / CURSOR_MAP.scale
+      const halfCaret = raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z / 2 : 9
+      anchor = {
+        x: (clientX - r.left) - s * raw.pos.X,
+        y: (clientY - r.top) - halfCaret - s * raw.pos.Y,
+      }
     } catch (e) {
       mapOk = false
       log('光标映射不可用，退回 Phase A 全覆盖 / cursor map unavailable: ' + (e && e.message || e))

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -11,52 +11,55 @@
 //     caller's `commit` callback — the SAME verified path as agent commands:
 //     executor.executeCommand('insert_at_cursor', {text}).
 //
-// PHASE A (default, no getCursorRect): the overlay covers the whole canvas,
-// transparent — the IME candidate box pops at the canvas top-left. Functional but
-// the candidate window isn't at the cursor.
+// PHASE A (default, no getCursorRaw): the overlay covers the whole canvas,
+// transparent — the IME candidate box pops at the canvas top-left.
 //
-// PHASE B (when a getCursorRect callback is supplied): the overlay shrinks to a
-// small box anchored at the LO view cursor's pixel rect, so the native candidate
-// window appears AT the cursor; composing text is shown inline (color turned
-// visible) for a what-you-see-is-what-you-get feel, then cleared on commit while
-// LO renders the real text. If the cursor rect can't be mapped (WASM mapping
-// unstable / API missing), it degrades cleanly back to Phase A (full-cover
-// transparent) — the inline-preview half still works wherever the box lands.
+// PHASE B (when getCursorRaw is supplied): the overlay anchors a small box at the
+// LO view cursor's pixel rect so the native candidate window appears AT the
+// cursor; composing text shows inline (color turned visible), then clears on
+// commit while LO renders the real text.
 //
-// Control keys (Enter/Backspace/arrows) act on the overlay, not the doc — same
-// limitation as before; forwarding them to Qt is a later item.
+//   MAPPING — doc 1/100 mm -> canvas CSS px is affine: px = scale*doc + offset.
+//   * scale is STABLE: 96/2540 CSS px per 1/100 mm at 100% zoom (CSS defines
+//     96 px/in; 2540 (1/100 mm)/in), times ZoomValue%. Verified exact against a
+//     real LibreOffice (click-correspondence calibration).
+//   * offset is VIEW-STATE-DEPENDENT (window size, scroll, LO chrome) so it is
+//     NOT a constant. We derive it LIVE: every canvas click gives both the click
+//     pixel AND (after Qt positions the cursor) the cursor's doc coords, so
+//     offset = clickPx - scale*docPos. The normal flow is "click to place the
+//     cursor, then type", so the anchor is always fresh where you're about to
+//     type — robust to any window/scroll without magic numbers. Before the first
+//     click we have no anchor, so the overlay stays full-cover (Phase A) and the
+//     candidate box sits top-left until the first click.
+//
+// Control keys: Enter inserts a paragraph break via onEnter (forwarded to UNO),
+// not into the empty <input>. Backspace/arrows are not yet forwarded.
 
-// ---------------------------------------------------------------------------
-// CALIBRATE (Phase B): map the worker's get_cursor_rect raw output (doc 1/100 mm)
-// to host CSS pixels. These constants are refined empirically via the spike's
-// debug box + screenshots — the doc-coord ORIGIN (page vs visible-area top-left)
-// and the canvas gray-margin offset are not derivable from the API alone.
-//   scale   : CSS px per 1/100 mm at zoom 100% (96 px/in ÷ 2540 (1/100 mm)/in).
-//   offsetX : px from canvas left to the page's text origin (gray margin + indent).
-//   offsetY : px from canvas top  to the page's text origin.
-//   useZoom : multiply scale by ZoomValue%/100.
-// ---------------------------------------------------------------------------
+// The STABLE half of the mapping. offset is derived live per click (see above).
 export const CURSOR_MAP = {
-  scale: 96 / 2540,
-  offsetX: 0,
-  offsetY: 0,
+  scale: 96 / 2540, // CSS px per 1/100 mm at 100% zoom (verified exact)
   useZoom: true,
 }
 
+function scaleFromZoom(raw) {
+  const z = (CURSOR_MAP.useZoom && raw && raw.zoom) ? raw.zoom / 100 : 1
+  return CURSOR_MAP.scale * z
+}
+
 /**
- * Convert the worker's get_cursor_rect raw result to a host-relative CSS-px rect.
- * Single source of the mm->px formula so the spike and the app share calibration.
- * @returns {{left:number, top:number, height:number}|null} null if unmappable.
+ * Map a worker get_cursor_rect raw result to a host CSS-px rect, given the live
+ * origin offset. Pure helper (exported for the spike's debug box).
+ * @returns {{left,top,height}|null}
  */
-export function cursorRectToPixels(raw) {
-  if (!raw || !raw.pos || typeof raw.pos.X !== 'number') return null
-  const z = (CURSOR_MAP.useZoom && raw.zoom) ? raw.zoom / 100 : 1
-  const k = CURSOR_MAP.scale * z
-  const left = CURSOR_MAP.offsetX + raw.pos.X * k
-  const top = CURSOR_MAP.offsetY + raw.pos.Y * k
-  // caret height: points -> px (1pt = 1/72 in) * zoom; fall back to a sane line.
-  const height = raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z : 18
-  return { left, top, height }
+export function cursorRectToPixels(raw, offset) {
+  if (!raw || !raw.pos || typeof raw.pos.X !== 'number' || !offset) return null
+  const s = scaleFromZoom(raw)
+  const z = s / CURSOR_MAP.scale
+  return {
+    left: offset.x + s * raw.pos.X,
+    top: offset.y + s * raw.pos.Y,
+    height: raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z : 18,
+  }
 }
 
 /**
@@ -66,19 +69,23 @@ export function cursorRectToPixels(raw) {
  * @param {(text:string)=>(any|Promise<any>)} options.commit REQUIRED. Inserts the
  *        committed text at the LO cursor (e.g. t => executor.executeCommand(
  *        'insert_at_cursor', {text:t})).
- * @param {()=>Promise<{left:number,top:number,height:number}|null>} [options.getCursorRect]
- *        OPTIONAL. Returns the cursor rect in host CSS px. Supplying it enables
- *        Phase B (cursor-anchored box + inline preview); omitting it keeps Phase A.
+ * @param {()=>Promise<object>} [options.getCursorRaw] OPTIONAL. Returns the
+ *        worker's get_cursor_rect raw result ({pos:{X,Y}, zoom, charHeightPt}).
+ *        Supplying it enables Phase B (cursor-anchored box + inline preview).
+ * @param {()=>(any|Promise<any>)} [options.onEnter] OPTIONAL. Inserts a paragraph
+ *        break at the LO cursor (e.g. () => executor.executeCommand(
+ *        'insert_paragraph')). Without it, Enter does nothing.
  * @param {(msg:string)=>void} [options.onLog] optional progress/diagnostic log.
- * @returns {{element:HTMLInputElement, focus:()=>void, reposition:()=>void, destroy:()=>void}}
+ * @returns {{element, focus, reposition, computeRect, destroy}}
  */
-export function attachImeOverlay({ canvas, commit, getCursorRect, onLog } = {}) {
+export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog } = {}) {
   if (!canvas) throw new Error('attachImeOverlay: canvas is required')
   if (typeof commit !== 'function') throw new Error('attachImeOverlay: commit(text) is required')
   const log = (m) => { if (onLog) onLog(m) }
 
-  const phaseB = typeof getCursorRect === 'function'
-  let mapOk = phaseB // flips false (and stays Phase A) if mapping ever fails
+  const phaseB = typeof getCursorRaw === 'function'
+  let mapOk = phaseB     // flips false (-> Phase A) if a raw read ever throws
+  let anchor = null      // {x,y} live origin offset in host px, set on canvas click
 
   const input = document.createElement('input')
   input.setAttribute('autocomplete', 'off')
@@ -98,8 +105,6 @@ export function attachImeOverlay({ canvas, commit, getCursorRect, onLog } = {}) 
   if (getComputedStyle(host).position === 'static') host.style.position = 'relative'
   host.appendChild(input)
 
-  // Two layout states. Phase A / idle-fallback: cover the whole canvas. Phase B:
-  // a small box at the cursor (the native candidate window anchors to its caret).
   function applyCover() {
     Object.assign(input.style, { left: '0', top: '0', width: '100%', height: '100%' })
   }
@@ -113,26 +118,43 @@ export function attachImeOverlay({ canvas, commit, getCursorRect, onLog } = {}) 
   }
   applyCover()
 
-  // Show composing text inline (Phase B) vs invisible (idle / Phase A).
   function setPreviewVisible(on) {
-    const show = on && mapOk
+    const show = on && mapOk && anchor
     input.style.color = show ? '#111' : 'transparent'
     input.style.caretColor = show ? '#111' : 'transparent'
   }
 
-  // Move the box to the current LO cursor. No-op (cover) in Phase A or if the
-  // mapping is unavailable. Async: one worker round-trip per call.
-  async function reposition() {
-    if (!phaseB || !mapOk) { applyCover(); return }
+  // Re-derive the live origin offset from a canvas click: clickPx (host-relative)
+  // and the cursor's doc coords AT that click give offset = clickPx - scale*pos.
+  // Snap (click -> nearest glyph) leaves sub-char error, self-corrected next click.
+  async function anchorFromClick(clientX, clientY) {
+    if (!phaseB || !mapOk) return
     try {
-      const rect = await getCursorRect()
-      if (rect) applyCursorBox(rect)
-      else applyCover()
+      const raw = await getCursorRaw()
+      if (!raw || !raw.pos) return
+      const s = scaleFromZoom(raw)
+      const r = host.getBoundingClientRect()
+      anchor = { x: (clientX - r.left) - s * raw.pos.X, y: (clientY - r.top) - s * raw.pos.Y }
     } catch (e) {
       mapOk = false
-      applyCover()
-      log('光标映射不可用，退回 Phase A 全覆盖 / cursor map unavailable, Phase A fallback: ' + (e && e.message || e))
+      log('光标映射不可用，退回 Phase A 全覆盖 / cursor map unavailable: ' + (e && e.message || e))
     }
+  }
+
+  // Compute the current cursor rect in host px (null until anchored). Exported via
+  // the return for the spike's debug box.
+  async function computeRect() {
+    if (!phaseB || !mapOk || !anchor) return null
+    try {
+      const raw = await getCursorRaw()
+      return cursorRectToPixels(raw, anchor)
+    } catch (e) { mapOk = false; return null }
+  }
+
+  // Move the box to the current LO cursor. Cover (Phase A) until first click.
+  async function reposition() {
+    const rect = await computeRect()
+    if (rect) applyCursorBox(rect); else applyCover()
   }
 
   // Commit logic: identical to the verified toolbar bridge. dedup the input event
@@ -159,25 +181,45 @@ export function attachImeOverlay({ canvas, commit, getCursorRect, onLog } = {}) 
     reposition()
   })
 
+  // Enter -> paragraph break at the LO cursor (NOT into the single-line input).
+  // Only when NOT composing — during composition Enter confirms the IME candidate.
+  input.addEventListener('keydown', (e) => {
+    if (composing || e.isComposing) return
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (typeof onEnter !== 'function') return
+      log('IME 覆盖层 → 回车换行 / paragraph break')
+      try { Promise.resolve(onEnter()).then(reposition).catch((err) => log('overlay enter error: ' + (err && err.message || err))) }
+      catch (err) { log('overlay enter error: ' + (err && err.message || err)) }
+    }
+  })
+
   // FOCUS-RACE FIX (from the spike): a canvas click positions the LO cursor (Qt
   // handles it) but also steals keyboard focus, so the first keystroke after a
   // click would land on the canvas. Hand focus back after Qt processes the click
-  // (mouseup) so ALL typing — including the first char — goes through the overlay,
-  // and move the box to the freshly-set cursor so the candidate window anchors there.
-  const onMouseUp = () => setTimeout(() => { try { input.focus() } catch (e) {} ; reposition() }, 0)
+  // (mouseup), and at the same time re-anchor the live offset + move the box to
+  // the freshly-set cursor so the candidate window shows up there.
+  const onMouseUp = (e) => {
+    const cx = e.clientX, cy = e.clientY
+    setTimeout(() => {
+      try { input.focus() } catch (err) {}
+      anchorFromClick(cx, cy).then(reposition)
+    }, 0)
+  }
   canvas.addEventListener('mouseup', onMouseUp)
 
   const focus = () => { try { input.focus() } catch (e) {} }
   focus()
   reposition()
   log(phaseB
-    ? 'IME 覆盖层已挂载 (Phase B：贴光标+inline 预览) / overlay attached — 点文档定位光标后直接打字'
-    : 'IME 覆盖层已挂载 (Phase A：全覆盖) / overlay attached — 点文档定位光标后直接打字')
+    ? 'IME 覆盖层已挂载 (Phase B：点文档放光标→框贴光标+inline 预览) / overlay attached'
+    : 'IME 覆盖层已挂载 (Phase A：全覆盖) / overlay attached')
 
   return {
     element: input,
     focus,
     reposition,
+    computeRect,
     destroy() {
       canvas.removeEventListener('mouseup', onMouseUp)
       input.remove()

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -354,6 +354,32 @@ const EXEC = {
     range.setString(String(p.newText || ''));
     return { success: true, anchor: p.anchor };
   },
+  // [spike] Phase B: raw measurements for mapping the view cursor to canvas
+  // pixels. We DELIBERATELY return primitives (not a final px rect) so the
+  // mm->px formula can be calibrated on the JS side without restarting LOWA.
+  //   - pos: XTextViewCursor.getPosition() -> awt.Point in 1/100 mm. The ORIGIN
+  //     (page top-left vs visible-area top-left) is the open question under
+  //     WASM; probe it empirically (short doc = no scroll hides the difference).
+  //   - charHeightPt: CharHeight (points) at the cursor -> caret height.
+  //   - zoom: ZoomValue (%) from the view settings.
+  //   - winPx: the Qt component window rect (px) — the canvas surface bounds.
+  // Each field is independently try/caught so a missing API degrades, not throws.
+  get_cursor_rect() {
+    const out = { success: true };
+    let vc = null;
+    try { vc = ctrl.getViewCursor(); } catch (e) { out.vcErr = errStr(e); }
+    if (vc) {
+      try { const pt = vc.getPosition(); out.pos = { X: pt.X, Y: pt.Y }; } catch (e) { out.posErr = errStr(e); }
+      try { out.charHeightPt = vc.getPropertyValue('CharHeight'); } catch (e) { out.charHeightErr = errStr(e); }
+      try { out.collapsed = (vc.getString() || '').length === 0; } catch (e) {}
+    }
+    try { out.zoom = ctrl.getViewSettings().getPropertyValue('ZoomValue'); } catch (e) { out.zoomErr = errStr(e); }
+    try {
+      const r = ctrl.getFrame().getComponentWindow().getPosSize();
+      out.winPx = { X: r.X, Y: r.Y, W: r.Width, H: r.Height };
+    } catch (e) { out.winErr = errStr(e); }
+    return out;
+  },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {
     const bms = xModel.getBookmarks();

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -354,6 +354,17 @@ const EXEC = {
     range.setString(String(p.newText || ''));
     return { success: true, anchor: p.anchor };
   },
+  // [verified-extend] insert a paragraph break at the view cursor (Enter key in
+  // the IME overlay routes here — the overlay's single-line <input> can't make a
+  // newline itself). Append, leave cursor collapsed after the break.
+  insert_paragraph() {
+    const xText = xModel.getText();
+    const vc = ctrl.getViewCursor();
+    vc.collapseToEnd();
+    xText.insertControlCharacter(vc, css.text.ControlCharacter.PARAGRAPH_BREAK, false);
+    vc.collapseToEnd();
+    return { success: true };
+  },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the
   // mm->px formula can be calibrated on the JS side without restarting LOWA.


### PR DESCRIPTION
## 中文

承接 Epic #43 / PR #55(Phase A)。Phase A 已让透明覆盖层承接 IME、上屏到 LO 光标,但覆盖层固定在 canvas 左上角、无合成预览。本 PR 做 **Phase B 地基**:让覆盖层**跟随 LO view cursor**、合成中文**inline 预览**。

**已验证(真 headless Chromium,Preview MCP)——难点通过**:新 worker 命令 `get_cursor_rect` 读 `ctrl.getViewCursor().getPosition()`(1/100mm),跟踪的正是覆盖层 `insert_at_cursor` 提交的**同一 view cursor**:

| 操作 | X(1/100mm) | Y | 解读 |
|---|---|---|---|
| 初始 | 9447 | 1129 | 第 1 行 |
| 插入×1 | 15732 | 1129 | 同行右移 ✓ |
| 插入×2 | 5258 | **1693** | 换行,Y+一行高、X 复位 ✓ |
| 插入×3 | 11628 | 1693 | 换行后右移 ✓ |

→ WASM 下"覆盖层跟随光标"**可行**。

**剩余未知 = 仿射常数**(`scale` 像素/mm + canvas→页面原点 `offsetX/offsetY`):需**可见 canvas 目视标定**(红框压在光标上),而 headless 的 canvas 是黑屏 → 这步留**真 Chrome**。已做成 2 分钟的活(见下)。

### 改动
- `office_thread.js`(两份同步):新增 `get_cursor_rect`,回传**原始测量值**(pos/charHeight/zoom/winPx),映射放 JS 侧 → 调公式不重启 LOWA。
- `zetaOfficeImeOverlay.js`:新增可选 `getCursorRect` 回调启用 Phase B(贴光标 + inline 预览);**不传则行为与 Phase A 逐字节一致**(app 现有调用不变)。导出 `cursorRectToPixels`(单源 mm→px 公式 + `CURSOR_MAP` 标定常数)与 `reposition()`。映射失败优雅退回 Phase A。
- spike `index.html`:「测光标矩形」红框 + 直连 worker 请求(`get_cursor_rect` 是 **UI 管线、非 AI 命令**,绕过 `EDITOR_ACTIONS` 白名单,不碰 `libreofficeExecutorClient.js`)+ 标定钩子。
- `serve.mjs`:支持 `PORT` 环境变量(可与已占 8777 的 spike 并存;argv 仍优先)。

### 真机标定(维护者,~2 分钟)
1. `cd experiments/zetaoffice-spike && cp "/System/Library/Fonts/Hiragino Sans GB.ttc" cjk-test.ttc && node serve.mjs` → 真 Chrome `localhost:8777` → Boot
2. 点文档放光标 → 点「测光标矩形」→ 红框出现在**算出的**位置
3. 控制台 `tuneCursorMap({offsetX, offsetY, scale})` 反复调到红框压住光标(若红框偏出约 2×,八成是 dpr:试 `scale: 96/2540/2`)
4. 把最终三个数报给我 → 焙进 `CURSOR_MAP` 默认值
5. 真输入法打中文,确认候选框在光标旁、合成 inline 预览手感

### 安全
休眠:无 app 代码引用 Phase B 路径;现役 WPS 编辑器逐字节不变。`build:zetaoffice` 通过(9 模块无回归)。

## English

Phase B groundwork for the #43 LibreOffice IME overlay (follows PR #55 / Phase A): make the transparent overlay **follow the LO view cursor** and **preview composing text inline**, instead of pinning the candidate box at the canvas top-left.

**Verified in real headless Chromium (Preview MCP) — the hard part works**: the new `get_cursor_rect` worker command reads `getViewCursor().getPosition()` and tracks the SAME view cursor the overlay commits to (X advances while typing, Y jumps a line height on wrap; table above). Cursor-following is feasible under WASM. The remaining unknown is the affine mapping constants, which need a visible canvas to fit → real-Chrome calibration (headless canvas is black). Live-tune hooks make that a ~2-minute pass.

Dormant — no app code imports the Phase B path; the live WPS editor is byte-for-byte unchanged. Real IME feel + visual calibration is the maintainer's real-Chrome terminal verification, per the Phase A cadence.

Refs #43 #13. Follows #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)