### PR TITLE
feat(libreoffice): embed editor as isolated <webview> + prove host↔editor IPC (experimental ⌘⇧O) / 嵌入式 webview 编辑器:证明宿主↔编辑器 IPC 往返(实验 ⌘⇧O)

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -236,7 +236,10 @@ function createMainWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       // 允许跨域 Cookie（解决 WPS SameSite Cookie 被拦截导致 500 错误）
-      webSecurity: false
+      webSecurity: false,
+      // Epic #43: allow <webview> for the embedded LibreOffice editor (isolated
+      // on persist:zetaoffice). Inert until a <webview> is actually rendered.
+      webviewTag: true
     }
   })
 
@@ -1165,6 +1168,23 @@ function createBackendManager() {
   })
 }
 
+// Epic #43: tell the renderer where to load the embedded LibreOffice editor
+// <webview>. Lazily installs COOP/COEP on the persist:zetaoffice partition and
+// starts the shared same-origin server (so LOWA/page are isolated) on first ask,
+// then returns the URL + the webview preload path + the partition. Dormant until
+// the renderer (LibreOfficeEditor.vue) requests it.
+ipcMain.handle('checkba:zetaoffice-editor', async () => {
+  const { installZetaOfficeIsolation, ZETAOFFICE_PARTITION } = require('./zetaoffice-session')
+  const { startEditorServer, editorUrl } = require('./zetaoffice-server')
+  installZetaOfficeIsolation(ZETAOFFICE_PARTITION)
+  const { origin } = await startEditorServer()
+  return {
+    url: editorUrl(origin),
+    preload: 'file://' + path.join(__dirname, '../preload/zetaoffice-webview-preload.js'),
+    partition: ZETAOFFICE_PARTITION,
+  }
+})
+
 app.whenReady().then(() => {
   initLocalFileService()
   // Epic #43: experimental "LibreOffice 验证" window — dedicated, isolated, does
@@ -1175,6 +1195,12 @@ app.whenReady().then(() => {
       require('./zetaoffice-verify')
         .openZetaOfficeVerifyWindow()
         .catch((e) => console.error('[zeta-verify]', e))
+    })
+    // Epic #43: ⌘⇧O opens the embedded LibreOffice editor (a <webview> inside the
+    // MAIN renderer — the real-flow topology, vs ⌘⇧L's standalone window). Tells
+    // the renderer to mount the overlay; dormant until pressed.
+    globalShortcut.register('CommandOrControl+Shift+O', () => {
+      try { if (mainWindow) mainWindow.webContents.send('checkba:zetaoffice-open-embed') } catch (e) { /* ignore */ }
     })
   } catch (e) { /* ignore */ }
   // 桌面端启动时自动拉起本机后端（9696）

--- a/desktop/main/zetaoffice-server.js
+++ b/desktop/main/zetaoffice-server.js
@@ -1,0 +1,121 @@
+// zetaoffice-server.js — shared local HTTP server for the embedded LibreOffice
+// (ZetaOffice / LOWA) editor page. Epic #43.
+//
+// WHY a local http server (not file://): the editor needs cross-origin isolation
+// (SharedArrayBuffer). COEP require-corp is injected by Electron on the dedicated
+// partition (desktop/main/zetaoffice-session.js), but COEP also forbids loading
+// LOWA cross-origin from the CDN
+// (ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep), and
+// injecting CORP on cross-origin responses proved unreliable in Electron (#53).
+// Serving the page + proxying LOWA same-origin (/lowa/*) sidesteps all of that —
+// every resource is same-origin so require-corp is trivially satisfied. This is
+// also the production direction (self-host LOWA in the bundle).
+//
+// This module is the single source of that server. It was first proven in the
+// ⌘⇧L verification window (zetaoffice-verify.js, #53) and is now shared by both
+// the verification window (separate BrowserWindow) and the embedded <webview>
+// in the main renderer. The server is memoized: the first caller starts it, the
+// rest reuse the same origin. Dormant until something calls startEditorServer().
+
+const path = require('path')
+const http = require('node:http')
+const https = require('node:https')
+const { readFile } = require('node:fs/promises')
+const { app } = require('electron')
+
+const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.data': 'application/octet-stream',
+  '.ttc': 'font/collection',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+}
+
+let serverPromise = null
+
+// dist/zetaoffice (built by `npm run build:zetaoffice`): editor.html + the
+// client bundle + worker scripts (zeta.js / office_thread.js). Shipped via
+// electron-builder extraResources (desktop/package.json).
+function editorRoot() {
+  return app.isPackaged
+    ? path.join(process.resourcesPath, 'frontend/dist/zetaoffice')
+    : path.join(__dirname, '../../frontend/dist/zetaoffice')
+}
+
+// Proxy a full https URL to res, following up to 4 redirects. Streams the body
+// and forwards the headers that matter for WASM (content-type/encoding/length).
+function proxyUrl(url, res, redirects = 0) {
+  https.get(url, (up) => {
+    const sc = up.statusCode || 0
+    if (sc >= 300 && sc < 400 && up.headers.location && redirects < 4) {
+      up.resume()
+      const next = new URL(up.headers.location, url).toString()
+      return proxyUrl(next, res, redirects + 1)
+    }
+    const h = {}
+    for (const k of ['content-type', 'content-length', 'content-encoding', 'etag', 'last-modified', 'cache-control']) {
+      if (up.headers[k]) h[k] = up.headers[k]
+    }
+    res.writeHead(sc || 200, h)
+    up.pipe(res)
+  }).on('error', (e) => { try { res.writeHead(502).end('lowa proxy error: ' + e.message) } catch (x) {} })
+}
+
+/**
+ * Start (or reuse) the local editor server. Memoized — safe to call from both
+ * the verify window and the embedded webview wiring.
+ * @returns {Promise<{port:number, origin:string}>}
+ */
+function startEditorServer() {
+  if (serverPromise) return serverPromise
+  const root = editorRoot()
+  serverPromise = new Promise((resolve, reject) => {
+    const s = http.createServer(async (req, res) => {
+      try {
+        let urlPath = decodeURIComponent((req.url || '/').split('?')[0])
+        // Same-origin LOWA proxy: /lowa/<path> -> the LOWA CDN.
+        if (urlPath.startsWith('/lowa/')) {
+          return proxyUrl(LOWA_CDN + urlPath.slice('/lowa/'.length), res)
+        }
+        if (urlPath === '/') urlPath = '/editor.html'
+        const filePath = path.normalize(path.join(root, urlPath))
+        if (!filePath.startsWith(root)) { res.writeHead(403).end('forbidden'); return }
+        // No COOP/COEP here — Electron injects them on the partition.
+        const body = await readFile(filePath)
+        res.writeHead(200, { 'Content-Type': TYPES[path.extname(filePath)] || 'application/octet-stream' })
+        res.end(body)
+      } catch (e) {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' }).end('not found')
+      }
+    })
+    s.on('error', (e) => { serverPromise = null; reject(e) })
+    s.listen(0, '127.0.0.1', () => {
+      const port = s.address().port
+      resolve({ port, origin: 'http://127.0.0.1:' + port })
+    })
+  })
+  return serverPromise
+}
+
+/**
+ * Build the editor page URL for a given origin. LOWA goes through the
+ * same-origin proxy (?lowa=); zeta.js / office_thread.js / cjk.ttc resolve to
+ * their relative defaults served next to the page.
+ * @param {string} origin e.g. http://127.0.0.1:54321
+ * @param {{verify?:boolean}} [opts] verify=1 shows the standalone test panel.
+ */
+function editorUrl(origin, opts = {}) {
+  const q = new URLSearchParams()
+  if (opts.verify) q.set('verify', '1')
+  q.set('lowa', origin + '/lowa/')
+  return origin + '/editor.html?' + q.toString()
+}
+
+module.exports = { startEditorServer, editorUrl }

--- a/desktop/main/zetaoffice-verify.js
+++ b/desktop/main/zetaoffice-verify.js
@@ -7,93 +7,17 @@
 // LOWA needs cross-origin isolation (SharedArrayBuffer). The main window can't be
 // isolated (webSecurity:false + cross-origin WPS/AI), so this opens a SEPARATE
 // BrowserWindow on a dedicated partition whose session gets COOP/COEP injected
-// (desktop/main/zetaoffice-session.js, #47).
-//
-// LOWA is served SAME-ORIGIN: the local server proxies /lowa/* -> the LOWA CDN.
-// Loading soffice.{js,wasm,data} cross-origin from the CDN directly is blocked by
-// COEP (ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep) —
-// injecting CORP on cross-origin responses via onHeadersReceived proved
-// unreliable in Electron. Proxying makes every LOWA resource same-origin, so COEP
-// require-corp is satisfied with no CORP gymnastics. (This is also the production
-// direction: self-host LOWA in the bundle.)
+// (desktop/main/zetaoffice-session.js, #47). The page + LOWA are served by the
+// shared local server (desktop/main/zetaoffice-server.js) — same-origin LOWA
+// proxy so COEP require-corp is satisfied with no CORP gymnastics.
 //
 // Dormant until the shortcut fires; nothing imports it at startup.
 
-const path = require('path')
-const http = require('node:http')
-const https = require('node:https')
-const { readFile } = require('node:fs/promises')
-const { app, BrowserWindow } = require('electron')
+const { BrowserWindow } = require('electron')
 const { installZetaOfficeIsolation, ZETAOFFICE_PARTITION } = require('./zetaoffice-session')
+const { startEditorServer, editorUrl } = require('./zetaoffice-server')
 
-const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
-
-const TYPES = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'text/javascript; charset=utf-8',
-  '.mjs': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.wasm': 'application/wasm',
-  '.data': 'application/octet-stream',
-  '.ttc': 'font/collection',
-  '.ttf': 'font/ttf',
-  '.otf': 'font/otf',
-}
-
-let server = null
 let verifyWin = null
-
-function editorRoot() {
-  return app.isPackaged
-    ? path.join(process.resourcesPath, 'frontend/dist/zetaoffice')
-    : path.join(__dirname, '../../frontend/dist/zetaoffice')
-}
-
-// Proxy a full https URL to res, following up to 4 redirects. Streams the body
-// and forwards the headers that matter for WASM (content-type/encoding/length).
-function proxyUrl(url, res, redirects = 0) {
-  https.get(url, (up) => {
-    const sc = up.statusCode || 0
-    if (sc >= 300 && sc < 400 && up.headers.location && redirects < 4) {
-      up.resume()
-      const next = new URL(up.headers.location, url).toString()
-      return proxyUrl(next, res, redirects + 1)
-    }
-    const h = {}
-    for (const k of ['content-type', 'content-length', 'content-encoding', 'etag', 'last-modified', 'cache-control']) {
-      if (up.headers[k]) h[k] = up.headers[k]
-    }
-    res.writeHead(sc || 200, h)
-    up.pipe(res)
-  }).on('error', (e) => { try { res.writeHead(502).end('lowa proxy error: ' + e.message) } catch (x) {} })
-}
-
-function startServer(root) {
-  if (server) return Promise.resolve(server.address().port)
-  return new Promise((resolve, reject) => {
-    const s = http.createServer(async (req, res) => {
-      try {
-        let urlPath = decodeURIComponent((req.url || '/').split('?')[0])
-        // Same-origin LOWA proxy: /lowa/<path> -> the LOWA CDN.
-        if (urlPath.startsWith('/lowa/')) {
-          return proxyUrl(LOWA_CDN + urlPath.slice('/lowa/'.length), res)
-        }
-        if (urlPath === '/') urlPath = '/editor.html'
-        const filePath = path.normalize(path.join(root, urlPath))
-        if (!filePath.startsWith(root)) { res.writeHead(403).end('forbidden'); return }
-        // No COOP/COEP here — Electron injects them on the partition.
-        const body = await readFile(filePath)
-        res.writeHead(200, { 'Content-Type': TYPES[path.extname(filePath)] || 'application/octet-stream' })
-        res.end(body)
-      } catch (e) {
-        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' }).end('not found')
-      }
-    })
-    s.on('error', reject)
-    s.listen(0, '127.0.0.1', () => { server = s; resolve(s.address().port) })
-  })
-}
 
 /**
  * Open (or focus) the LibreOffice verification window.
@@ -102,8 +26,7 @@ async function openZetaOfficeVerifyWindow() {
   if (verifyWin && !verifyWin.isDestroyed()) { verifyWin.focus(); return verifyWin }
 
   installZetaOfficeIsolation(ZETAOFFICE_PARTITION)
-  const port = await startServer(editorRoot())
-  const origin = 'http://127.0.0.1:' + port
+  const { origin } = await startEditorServer()
 
   verifyWin = new BrowserWindow({
     width: 1280,
@@ -116,9 +39,8 @@ async function openZetaOfficeVerifyWindow() {
     },
   })
   verifyWin.on('closed', () => { verifyWin = null })
-  // LOWA via the same-origin proxy (?lowa=). zeta.js / office_thread.js / cjk.ttc
-  // are served locally next to the page (their relative defaults resolve here).
-  verifyWin.loadURL(origin + '/editor.html?verify=1&lowa=' + encodeURIComponent(origin + '/lowa/'))
+  // Standalone verify panel drives the booted executor directly (no host).
+  verifyWin.loadURL(editorUrl(origin, { verify: true }))
   verifyWin.webContents.openDevTools({ mode: 'detach' })
   return verifyWin
 }

--- a/desktop/preload/preload.js
+++ b/desktop/preload/preload.js
@@ -111,6 +111,17 @@ contextBridge.exposeInMainWorld('checkbaDesktop', {
     readFile: (path) => ipcRenderer.invoke('fs:readFile', path),
     writeFile: (path, data) => ipcRenderer.invoke('fs:writeFile', { filePath: path, data }),
     showOpenDialog: (options) => ipcRenderer.invoke('fs:showOpenDialog', options)
+  },
+  // Epic #43: embedded LibreOffice editor <webview> wiring. getEditor() returns
+  // { url, preload, partition } for the host to mount the webview; onOpenEmbed
+  // fires when the ⌘⇧O global shortcut requests the editor overlay.
+  zetaoffice: {
+    getEditor: () => ipcRenderer.invoke('checkba:zetaoffice-editor'),
+    onOpenEmbed: (handler) => {
+      const listener = () => handler && handler()
+      ipcRenderer.on('checkba:zetaoffice-open-embed', listener)
+      return () => ipcRenderer.removeListener('checkba:zetaoffice-open-embed', listener)
+    }
   }
 })
 

--- a/desktop/preload/zetaoffice-webview-preload.js
+++ b/desktop/preload/zetaoffice-webview-preload.js
@@ -1,0 +1,30 @@
+// zetaoffice-webview-preload.js — preload for the embedded LibreOffice editor
+// page running inside <webview partition="persist:zetaoffice">. Epic #43.
+//
+// The editor page (frontend/src/zetaoffice/editor-main.js) talks to the HOST over
+// a {send, subscribe} transport. In an Electron <webview>, guest -> host is
+// ipcRenderer.sendToHost(channel, msg) and host -> guest arrives as an
+// ipcRenderer 'lo-relay' message. contextIsolation stays ON (the page is our own
+// localhost bundle, but defense in depth costs nothing here): this preload
+// exposes a minimal, fixed-shape bridge via contextBridge instead of leaking the
+// whole ipcRenderer. editor-main.js prefers window.zetaHostBridge when present,
+// and falls back to window.parent.postMessage in a plain browser / the spike.
+//
+// Host counterpart: useZetaOfficeWebview.webviewTransport (#52) — webviewEl.send
+// (-> 'lo-relay') and the 'ipc-message' event with the same channel.
+
+const { contextBridge, ipcRenderer } = require('electron')
+
+const CHANNEL = 'lo-relay'
+
+contextBridge.exposeInMainWorld('zetaHostBridge', {
+  // guest -> host
+  send: (msg) => ipcRenderer.sendToHost(CHANNEL, msg),
+  // host -> guest; strips the (non-cloneable) IpcRendererEvent so the page sees
+  // only the message. Returns an unsubscribe fn.
+  subscribe: (handler) => {
+    const listener = (_evt, msg) => handler(msg)
+    ipcRenderer.on(CHANNEL, listener)
+    return () => ipcRenderer.removeListener(CHANNEL, listener)
+  },
+})

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -1,0 +1,138 @@
+<template>
+  <view class="libre-editor-wrapper">
+    <view class="libre-toolbar">
+      <text class="libre-title">LibreOffice 编辑器（嵌入式 webview · 实验）</text>
+      <text class="libre-status" :class="{ ready }">{{ statusText }}</text>
+      <button class="libre-btn" :disabled="!ready" @click="runInsert">插入示例</button>
+      <button class="libre-btn" :disabled="!ready" @click="runReplace">查找替换(redline)</button>
+      <button class="libre-btn" :disabled="!ready" @click="runSelection">读选区</button>
+      <button class="libre-btn libre-close" @click="$emit('close')">关闭</button>
+    </view>
+    <!-- The Electron <webview> is created imperatively (uni-app's template
+         compiler does not know the <webview> tag); it mounts into this host. -->
+    <view :id="hostId" class="libre-host"></view>
+    <pre v-if="log" class="libre-log">{{ log }}</pre>
+  </view>
+</template>
+
+<script>
+// LibreOfficeEditor.vue — HOST-side embed of the LibreOffice editor as an
+// Electron <webview partition="persist:zetaoffice"> inside the MAIN renderer.
+// Epic #43.
+//
+// This is the activation of the dormant foundation: the webview loads
+// dist/zetaoffice/editor.html over the shared same-origin server, gets COOP/COEP
+// isolation from desktop/main/zetaoffice-session.js (so LOWA's SharedArrayBuffer
+// works), and is wrapped by createWebviewEditorExecutor (#52) into the standard
+// executeCommand(action, params) contract. The toolbar buttons drive that
+// executor directly — proving the host -> webview IPC -> office worker -> UNO ->
+// real LibreOffice round-trip on the device (the last unverified link before the
+// backend agent stream is routed through useEditorBridge).
+//
+// Self-contained / dormant: nothing renders this unless explicitly mounted
+// (⌘⇧O overlay), so the WPS document flow is byte-for-byte unaffected.
+
+import { createWebviewEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
+
+let seq = 0
+
+export default {
+  name: 'LibreOfficeEditor',
+  emits: ['close', 'ready'],
+  data() {
+    return {
+      hostId: 'libre-host-' + (++seq),
+      ready: false,
+      statusText: '启动中… / booting…',
+      log: '',
+      webviewEl: null,
+      executor: null,
+    }
+  },
+  async mounted() {
+    try {
+      const api = typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.zetaoffice
+      if (!api || typeof api.getEditor !== 'function') {
+        this.statusText = '仅桌面版可用 / desktop only'
+        return
+      }
+      const info = await api.getEditor() // { url, preload, partition }
+      this.mountWebview(info)
+    } catch (e) {
+      this.statusText = '初始化失败 / init failed'
+      this.appendLog('init failed: ' + (e && e.message ? e.message : e))
+    }
+  },
+  beforeUnmount() {
+    try { if (this.executor && typeof this.executor.dispose === 'function') this.executor.dispose() } catch (e) { /* ignore */ }
+    try { if (this.webviewEl && this.webviewEl.remove) this.webviewEl.remove() } catch (e) { /* ignore */ }
+    this.webviewEl = null
+    this.executor = null
+  },
+  methods: {
+    appendLog(m) {
+      this.log = (this.log + m + '\n').split('\n').slice(-200).join('\n')
+    },
+    mountWebview(info) {
+      const host = document.getElementById(this.hostId)
+      if (!host) { this.appendLog('host element missing'); return }
+      const wv = document.createElement('webview')
+      wv.setAttribute('partition', info.partition)
+      if (info.preload) wv.setAttribute('preload', info.preload)
+      // contextIsolation ON (the preload uses contextBridge), nodeIntegration OFF.
+      wv.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no')
+      wv.style.width = '100%'
+      wv.style.height = '100%'
+      wv.style.border = '0'
+      wv.addEventListener('dom-ready', () => this.onDomReady(wv))
+      wv.addEventListener('did-fail-load', (e) => this.appendLog('did-fail-load: ' + (e.errorDescription || e.errorCode)))
+      wv.addEventListener('console-message', (e) => { if (e.level >= 2) this.appendLog('[webview] ' + e.message) })
+      wv.setAttribute('src', info.url)
+      host.appendChild(wv)
+      this.webviewEl = wv
+    },
+    onDomReady(wv) {
+      if (this.executor) return // dom-ready can fire again on in-page navigation
+      try {
+        this.executor = createWebviewEditorExecutor(wv)
+        this.ready = true
+        this.statusText = '就绪 / ready ✓'
+        this.appendLog('webview dom-ready — executor wired')
+        this.$emit('ready', this.executor)
+      } catch (e) {
+        this.appendLog('executor wiring failed: ' + (e && e.message ? e.message : e))
+      }
+    },
+    async run(label, action, params) {
+      if (!this.executor) return
+      this.appendLog('▶ ' + label + ' …')
+      try { this.appendLog('  ← ' + JSON.stringify(await this.executor.executeCommand(action, params))) }
+      catch (e) { this.appendLog('  ✗ ' + (e && e.message ? e.message : e)) }
+    },
+    runInsert() {
+      this.run('插入示例', 'insert_at_cursor',
+        { text: '本协议由甲方与乙方于本日签订；协议自双方签署之日起生效。' })
+    },
+    runReplace() {
+      this.run('查找替换 协议→合同 (redline)', 'find_replace',
+        { findText: '协议', replaceText: '合同', replaceAll: true })
+    },
+    runSelection() { this.run('读选区', 'get_selection', {}) },
+  },
+}
+</script>
+
+<style scoped>
+.libre-editor-wrapper { display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+.libre-toolbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 6px 10px; background: #1F2937; color: #fff; }
+.libre-title { font-size: 13px; font-weight: 600; }
+.libre-status { font-size: 12px; color: #fca5a5; }
+.libre-status.ready { color: #86efac; }
+.libre-btn { font-size: 12px; padding: 4px 10px; border: 0; border-radius: 4px; background: #059669; color: #fff; cursor: pointer; }
+.libre-btn[disabled] { background: #6b7280; cursor: not-allowed; }
+.libre-close { background: #4b5563; margin-left: auto; }
+.libre-host { flex: 1; min-height: 0; width: 100%; }
+.libre-log { position: absolute; right: 8px; bottom: 8px; width: 380px; max-height: 38vh; margin: 0;
+  padding: 8px; background: #0b1220; color: #d1fae5; font: 11px/1.45 ui-monospace, monospace;
+  overflow: auto; white-space: pre-wrap; word-break: break-all; border-radius: 6px; z-index: 10; }
+</style>

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1173,6 +1173,12 @@
 
       <!-- OCR 结果不再使用弹窗：改为框选后的快捷命令条 -->
 
+      <!-- Epic #43: embedded LibreOffice editor overlay (experimental, ⌘⇧O).
+           Dormant — only mounts when explicitly opened; does NOT touch the WPS
+           document flow. -->
+      <view v-if="showLibreEmbed" class="libre-embed-overlay">
+        <LibreOfficeEditor @close="showLibreEmbed = false" />
+      </view>
 
     </view>
   </view>
@@ -1180,6 +1186,7 @@
 
 <script>
 import WpsEditor from '@/components/WpsEditor.vue'
+import LibreOfficeEditor from '@/components/LibreOfficeEditor.vue'
 import BrowserPane from '@/components/BrowserPane.vue'
 import FileTree from '@/components/FileTree.vue'
 import FilePreview from '@/components/FilePreview.vue'
@@ -1254,6 +1261,7 @@ import ChatInterface from '@/components/ChatInterface.vue'
 export default {
   components: {
     WpsEditor,
+    LibreOfficeEditor,
     BrowserPane,
     FileTree,
     FilePreview,
@@ -1449,6 +1457,9 @@ export default {
       // Tabs 拖拽状态
       draggingTab: null, // { fileId, fromPane }
       tabDragOver: null, // { fileId, pane }
+
+      // Epic #43: embedded LibreOffice editor overlay (experimental, ⌘⇧O)
+      showLibreEmbed: false,
 
       // WPS Config
       wpsAppId: '', // 从后端动态获取
@@ -1707,6 +1718,8 @@ export default {
   },
   beforeUnmount() {
     this.teardownResponsiveListener()
+    // Epic #43: 解绑 ⌘⇧O 嵌入式编辑器监听
+    try { if (this._zetaOpenEmbedUnsub) { this._zetaOpenEmbedUnsub(); this._zetaOpenEmbedUnsub = null } } catch (e) { /* ignore */ }
     // 清理轮询定时器
     if (this.fileInfoPollingIntervals) {
       Object.values(this.fileInfoPollingIntervals).forEach(intervalId => {
@@ -1930,6 +1943,20 @@ export default {
     }
 
     // Manual binding removed (reverted to native modifier)
+
+    // Epic #43: ⌘⇧O 打开嵌入式 LibreOffice 编辑器覆盖层（实验）。仅切换覆盖层标志，
+    // 不触碰 WPS 文档流。
+    try {
+      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.zetaoffice && window.checkbaDesktop.zetaoffice.onOpenEmbed) {
+        if (!this._zetaOpenEmbedUnsub) {
+          this._zetaOpenEmbedUnsub = window.checkbaDesktop.zetaoffice.onOpenEmbed(() => {
+            this.showLibreEmbed = true
+          })
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
 
     // Desktop：拦截 WPS 中点击 “checkba://...” 的内部链接
     try {
@@ -10437,5 +10464,16 @@ $bg-white: #FFFFFF;
 
 .tag-close:hover {
   opacity: 1;
+}
+
+/* Epic #43: embedded LibreOffice editor overlay (experimental, ⌘⇧O) */
+.libre-embed-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  background: #fff;
 }
 </style>

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -31,6 +31,13 @@ function getIpcRenderer() {
 // {send, subscribe} over the host boundary — Electron <webview> IPC if present,
 // else postMessage to the parent (browser/iframe/spike harness).
 function pickTransport() {
+  // Preferred Electron <webview> path: the webview preload
+  // (desktop/preload/zetaoffice-webview-preload.js) exposes a fixed-shape bridge
+  // over contextBridge (contextIsolation stays ON). Already {send, subscribe}.
+  if (typeof window !== 'undefined' && window.zetaHostBridge) {
+    return window.zetaHostBridge
+  }
+  // Legacy fallback: nodeIntegration webview where window.require is available.
   const ipc = getIpcRenderer()
   if (ipc) {
     return {


### PR DESCRIPTION
## 中文

把 Epic #43 的休眠地基**接成活的第一步**:在主渲染进程里用 `<webview partition="persist:zetaoffice">` 嵌入 LibreOffice(ZetaOffice)编辑器——这正是真实文档流的拓扑——并在真机上**走通一条 宿主 → webview IPC → office worker → UNO → 真 LibreOffice 的往返**。这是把后端 agent SSE 经 `useEditorBridge` 路由进来之前的**最后一段未验证链路**。

**为什么是一个 PR**:嵌入、隔离、IPC 桥这几块互相离不开,合在一起才产出"装上 → 按 ⌘⇧O → 跑一条命令看 redline"的可真机验证产物。

### 改了什么(全部加法式/休眠,默认关)
- **`desktop/main/zetaoffice-server.js`(新)**:共享本地服务 + `/lowa/` 同源代理(从 #53 的 `zetaoffice-verify.js` 抽出),memoize;⌘⇧L 验证窗口与嵌入式 webview 共用。
- **`desktop/preload/zetaoffice-webview-preload.js`(新)**:`contextBridge` 暴露 `zetaHostBridge.send/subscribe`(走 `lo-relay` 通道),保持 webview `contextIsolation` 开。
- **`main.js`**:开 `webviewTag`;IPC `checkba:zetaoffice-editor` 首次惰性给 `persist:zetaoffice` 分区注 COOP/COEP + 启服务,返回 `{url, preload, partition}`;`⌘⇧O` 通知渲染层开覆盖层。
- **`preload.js`**:暴露 `checkbaDesktop.zetaoffice.{getEditor,onOpenEmbed}`。
- **`editor-main.js`**:优先用 `window.zetaHostBridge` 传输(浏览器/spike 的 postMessage 后备不变,+7 行)。
- **`LibreOfficeEditor.vue`(新)**:命令式建 `<webview>`(绕开 uni-app 模板编译器不认 `<webview>`),`dom-ready` 后用 `createWebviewEditorExecutor`(#52)包成标准 executor,工具栏按钮跑 插入/查找替换(redline)/读选区 证明往返。
- **`project-overview.vue`**:**仅加 ⌘⇧O 覆盖层**——`handleWpsCommand` 与 WPS 文档流**逐字节不变**。

### 零爆炸半径
flag 默认关:不按 ⌘⇧O 就不挂 webview,WPS 出厂不受影响。

### 真机要验的两个未知(沙箱跑不了:后端 JDK SIGBUS / 无 GUI / LOWA 需真显示器)
- **A**:`<webview>` 的宿主(主窗口 `webSecurity:false`、跨源)**未隔离**时,webview 自身能否经 `onHeadersReceived` 拿到 COOP/COEP 隔离(`crossOriginIsolated`/SharedArrayBuffer)。理论可以(webview 是独立 frame tree,#47 立论),但**首次在 webview 上验**。
- **B**:页面走本地 http(本 PR 选)路径在打包后是否成立。

### 真机验证步骤(装 Desktop Build artifact 后)
1. 打开 app、登录进项目页。
2. 按 **`⌘⇧O`** → 出现「LibreOffice 编辑器(嵌入式 webview)」覆盖层。
3. 看到 Writer 渲染 + 右下角日志 `webview dom-ready — executor wired`、状态变「就绪 ✓」。
4. 点「插入示例」→ 文档插入中文;点「查找替换(redline)」→ 看到 redline 生效;点「读选区」→ 日志返回选区。
   - 这四步过 = 开放问题 A(隔离)+ B(IPC 往返)在 webview 拓扑下**全部成立**。
5. ⚠️ 若白屏:多半是隔离没拿到(A)或 LOWA 同源代理路径(看右下角日志/DevTools)。

### 沙箱已验
`node --check`(6 个 desktop JS)✓;`build:zetaoffice`(9 模块)✓;`build:h5` 全量 uni-app 构建 `DONE Build complete` ✓;relay 协议端到端契约一致(`zetaHostBridge` ↔ `webviewTransport` 同走 `lo-relay`,消息形状对齐)。

### 后续(本 PR 不做)
- 把 `handleWpsCommand` 经 `useEditorBridge` 路由(把**后端真命令**接进来,IPC 已证后即低风险)。
- 自托管 LOWA(`soffice.*`)+ CJK 字体焙进 bundle(体积大,单列);当前 LOWA 走同源代理,字体靠 LOWA 自带。

Epic #43.

## English

First step turning the dormant Epic #43 foundation **live**: embed the LibreOffice (ZetaOffice) editor as an Electron `<webview partition="persist:zetaoffice">` **inside the main renderer** (the real-flow topology) and prove the **host → webview IPC → office worker → UNO → real LibreOffice round-trip** on device — the last unverified link before the backend agent stream is routed through `useEditorBridge`.

All changes are additive / dormant; the WPS document flow (`handleWpsCommand`) is byte-for-byte unchanged. Nothing renders the webview unless `⌘⇧O` is pressed.

**On-device open questions:** (A) a `<webview>` gets COOP/COEP isolation though its embedder (main window, `webSecurity:false`) is not; (B) the http(local-server) load path holds in a packaged build. **Verify:** install the Desktop Build artifact → `⌘⇧O` → editor overlay boots → click insert / find_replace(redline) / get_selection and watch the round-trip succeed.

**Sandbox-verified:** `node --check` (6 desktop JS) ✓; `build:zetaoffice` ✓; full `build:h5` ✓; relay protocol contract consistent end-to-end.

**Follow-ups:** route `handleWpsCommand` through `useEditorBridge` (wires the real backend command); self-host LOWA + bake CJK font into the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)