### PR TITLE
chore(release): bump desktop to v0.2.2

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 中文
版本号 0.2.1 → 0.2.2(`desktop/package.json` + lockfile root 三处,依赖项 0.2.x 未动)。打 tag `v0.2.2` 触发签名安装包构建 + 自动发 Release。

**本版交付**:#54 捆绑 JRE 崩溃时回退系统 JDK(修部分机器装好后端起不来);其余为 LibreOffice 迁移**休眠/实验**地基(#44–#57),含隐藏的 `⌘⇧L`/`⌘⇧O` 验证/嵌入窗口供真机验 LibreOffice——**现役 WPS 文档流逐字节不变、默认体验无变化**。

## EN
Version bump 0.2.1 → 0.2.2 (root only; dependency 0.2.x untouched). Tag `v0.2.2` triggers signed installers + auto Release. Ships #54 (system-JDK fallback) + dormant/experimental LibreOffice groundwork (#44–#57) behind hidden shortcuts; live WPS flow byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)