### PR TITLE
feat(libreoffice): route backend AI commands to the embedded editor when active / 嵌入式编辑器活跃时把后端 AI 命令路由给它(休眠)

### DIFF
--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -801,6 +801,15 @@
                   </view>
                 </view>
               </view>
+
+              <!-- Epic #43: embedded LibreOffice editor (experimental, ⌘⇧O).
+                   Scoped to the document area so the AI chat panel stays usable —
+                   a real backend AI command can be triggered while it's active.
+                   Dormant: only mounts when explicitly opened; the WPS flow is
+                   untouched. -->
+              <view v-if="showLibreEmbed" class="libre-embed-overlay">
+                <LibreOfficeEditor @ready="onLibreReady" @close="onLibreClose" />
+              </view>
             </view>
 
             <!-- 底部常用工具面板（仅占中间工作区宽度；右侧 AI 面板优先完整显示） -->
@@ -1173,13 +1182,6 @@
 
       <!-- OCR 结果不再使用弹窗：改为框选后的快捷命令条 -->
 
-      <!-- Epic #43: embedded LibreOffice editor overlay (experimental, ⌘⇧O).
-           Dormant — only mounts when explicitly opened; does NOT touch the WPS
-           document flow. -->
-      <view v-if="showLibreEmbed" class="libre-embed-overlay">
-        <LibreOfficeEditor @close="showLibreEmbed = false" />
-      </view>
-
     </view>
   </view>
 </template>
@@ -1458,8 +1460,11 @@ export default {
       draggingTab: null, // { fileId, fromPane }
       tabDragOver: null, // { fileId, pane }
 
-      // Epic #43: embedded LibreOffice editor overlay (experimental, ⌘⇧O)
+      // Epic #43: embedded LibreOffice editor (experimental, ⌘⇧O). When active,
+      // backend AI commands route to it instead of WPS (handleWpsCommand).
       showLibreEmbed: false,
+      libreOfficeActive: false,
+      libreOfficeExecutor: null,
 
       // WPS Config
       wpsAppId: '', // 从后端动态获取
@@ -5831,6 +5836,22 @@ export default {
         const { action: commandAction, params, requestId, conversationId } = action
         console.log('[ProjectOverview] commandAction:', commandAction, 'requestId:', requestId)
 
+        // Epic #43: when the embedded LibreOffice editor is active, route the
+        // (editor-agnostic) backend command to it instead of WPS — the SSE result
+        // contract (sendWpsResult) is identical. The WPS path below is left
+        // byte-for-byte unchanged; this only diverts while LibreOffice is open.
+        if (this.libreOfficeActive && this.libreOfficeExecutor) {
+            try {
+                const result = await this.libreOfficeExecutor.executeCommand(commandAction, params)
+                const successFlag = result && result.success !== false
+                await sendWpsResult(conversationId, requestId, successFlag, result, (result && result.error) || null)
+            } catch (e) {
+                console.error('[ProjectOverview] LibreOffice command error:', e)
+                await sendWpsResult(conversationId, requestId, false, null, e.message)
+            }
+            return
+        }
+
         try {
             // 获取当前活跃的 WPS 实例
             // FIX: 优先使用当前聚焦窗格的 WPS 实例，避免多窗口时操作错误的文档
@@ -5887,6 +5908,20 @@ export default {
             console.error('[ProjectOverview] Error stack:', e.stack)
             await sendWpsResult(conversationId, requestId, false, null, e.message)
         }
+    },
+
+    // Epic #43: embedded LibreOffice editor lifecycle. While ready, backend AI
+    // commands route to it (see handleWpsCommand divert).
+    onLibreReady(executor) {
+        this.libreOfficeExecutor = executor
+        this.libreOfficeActive = true
+        console.log('[ProjectOverview] LibreOffice editor ready — agent commands routed to LibreOffice')
+    },
+    onLibreClose() {
+        this.showLibreEmbed = false
+        this.libreOfficeActive = false
+        this.libreOfficeExecutor = null
+        console.log('[ProjectOverview] LibreOffice editor closed — agent commands routed to WPS')
     },
 
     // --- 文件选择/上传 ---
@@ -10466,14 +10501,16 @@ $bg-white: #FFFFFF;
   opacity: 1;
 }
 
-/* Epic #43: embedded LibreOffice editor overlay (experimental, ⌘⇧O) */
+/* Epic #43: embedded LibreOffice editor (experimental, ⌘⇧O).
+   Absolute within .editors-container (position:relative) so it covers the
+   document area only — the AI chat panel stays usable. */
 .libre-embed-overlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 9999;
+  z-index: 50;
   background: #fff;
 }
 </style>


### PR DESCRIPTION
## 中文

接 #57(嵌入式 webview 编辑器已合并 master)的**最后一段**:当 `⌘⇧O` 嵌入式 LibreOffice 编辑器打开时,把后端 agent SSE 命令(`client_action`→`handleWpsCommand`)**改路由到 LibreOffice executor**,而非 WPS。至此打通 **后端 SSE → handleWpsCommand → webview 中转 → office worker → UNO → 真 LibreOffice** 端到端。

### 改了什么(单文件,加法/休眠)
- `project-overview.vue`:`handleWpsCommand` 加**早分支**——`libreOfficeActive && libreOfficeExecutor` 时走 LibreOffice,`sendWpsResult` 结果契约不变;**下面的 WPS 派发代码逐字节不动**(早 return)。executor 从 `LibreOfficeEditor` 的 `@ready` 捕获、`@close` 清空(命令回流 WPS)。
- 编辑器从**全屏覆盖层**移进 `.editors-container`(文档区,`position:absolute`),这样**右侧 AI 聊天面板仍可用**——可在编辑器活跃时真的发一条命令触发后端。

### 为什么不走 useEditorBridge 接缝
`useWpsBridge` 是**工厂**(每次新建 refs + 有 stream 状态,`handleWpsOpenFileSync` 还在独立实例上 `resetStreamState`)。把现役 WPS 塞进一个长持有的 editorBridge 实例有**脱节风险**。故只做 **LibreOffice 单向 divert**,WPS 零风险。useEditorBridge 接缝仍在,留作将来全量切换。

### 零爆炸半径
`libreOfficeActive` 默认 false,不开 ⌘⇧O 就走原 WPS 路径。生产 WPS 用户**永不触发** LibreOffice 分支。

### 真机验法(沙箱跑不了:webview/后端)
装 v0.2.x/artifact → 打开一个文档 → **`⌘⇧O`** 开嵌入式 LibreOffice(右侧聊天仍在)→ 在聊天里发一条"改文档"的 AI 指令 → **redline 出现在 LibreOffice 编辑器里** = 后端命令端到端打通。先决:#57 的 ⌘⇧O 本身真机要先 OK(webview 隔离/IPC)。

### 沙箱已验
`build:h5` 全量 `DONE Build complete`;diff 单文件 48+/11−,WPS 派发逐字节不变(git diff 已核)。

Epic #43.

## English

The LAST link after #57 (embedded webview editor, merged): when the `⌘⇧O`
embedded LibreOffice editor is open, the backend agent SSE command
(`client_action` → `handleWpsCommand`) is **diverted to the LibreOffice executor**
instead of WPS — completing backend SSE → handleWpsCommand → webview relay →
office worker → UNO → real LibreOffice end-to-end.

- `project-overview.vue`: `handleWpsCommand` gains an early divert when
  `libreOfficeActive && libreOfficeExecutor`; the WPS dispatch below is
  **byte-for-byte unchanged**. Executor captured from `LibreOfficeEditor`'s
  `@ready`, cleared on `@close`.
- The editor moved from a full-screen overlay into `.editors-container` so the AI
  chat panel stays usable — a real command can be triggered while active.

**Why not the useEditorBridge seam:** `useWpsBridge` is a factory with per-call
stream state; funneling the live WPS path through a held bridge instance risks
desyncing it. The divert is LibreOffice-only — zero WPS risk. The seam stays for
a future full cutover.

**Dormant:** `libreOfficeActive` is false until ⌘⇧O mounts the editor, so
production WPS users never hit the LibreOffice path.

**Real-machine gate** (sandbox can't boot webview/backend): open a doc → ⌘⇧O →
send an AI doc-edit from chat → the redline appears in the LibreOffice editor.
Sandbox: `build:h5` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)