### PR TITLE
feat(libreoffice): bake LOWA runtime + OFL CJK font for offline rendering (Track A) (#43)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -62,22 +62,18 @@ jobs:
           # Epic #43: build the embedded LibreOffice editor bundle (dist/zetaoffice),
           # shipped via extraResources for the experimental "LibreOffice 验证" window.
           npm run build:zetaoffice
-      - name: Bundle a CJK font for the LibreOffice verify window (best-effort)
+      - name: Bake LOWA runtime + OFL CJK font into the editor bundle (offline)
         shell: bash
         run: |
-          # The editor injects this font so Chinese renders (not tofu). Best-effort:
-          # if no system CJK font is found the editor skips it cleanly.
-          dest="frontend/dist/zetaoffice/cjk.ttc"
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            for f in "/System/Library/Fonts/Hiragino Sans GB.ttc" "/System/Library/Fonts/PingFang.ttc" "/System/Library/Fonts/Supplemental/Songti.ttc"; do
-              [ -f "$f" ] && cp "$f" "$dest" && break
-            done
-          else
-            for f in "/c/Windows/Fonts/msyh.ttc" "/c/Windows/Fonts/simsun.ttc" "C:/Windows/Fonts/msyh.ttc" "C:/Windows/Fonts/simsun.ttc"; do
-              [ -f "$f" ] && cp "$f" "$dest" && break
-            done
-          fi
-          ls -la "$dest" 2>/dev/null && echo "CJK font bundled" || echo "no CJK font found (Chinese will be tofu in verify window)"
+          # Track A (Epic #43): download the LibreOffice WASM runtime (soffice.*)
+          # into dist/zetaoffice/lowa and an OFL-licensed CJK font (Noto Sans SC)
+          # as cjk.ttc, so the packaged app renders Chinese OFFLINE without
+          # reaching cdn.zetaoffice.net. Replaces the old best-effort copy of a
+          # system font (non-deterministic, absent offline). Adds ~60 MB to the
+          # installer. The local HTTP server (zetaoffice-server.js) serves these
+          # first and falls back to the CDN only for anything not bundled.
+          node desktop/scripts/fetch-lowa-assets.js
+          ls -la frontend/dist/zetaoffice/lowa frontend/dist/zetaoffice/cjk.ttc
       - name: Install desktop dependencies
         working-directory: desktop
         run: npm ci

--- a/desktop/main/zetaoffice-server.js
+++ b/desktop/main/zetaoffice-server.js
@@ -7,9 +7,11 @@
 // LOWA cross-origin from the CDN
 // (ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep), and
 // injecting CORP on cross-origin responses proved unreliable in Electron (#53).
-// Serving the page + proxying LOWA same-origin (/lowa/*) sidesteps all of that —
-// every resource is same-origin so require-corp is trivially satisfied. This is
-// also the production direction (self-host LOWA in the bundle).
+// Serving the page + LOWA same-origin (/lowa/*) sidesteps all of that — every
+// resource is same-origin so require-corp is trivially satisfied. LOWA is baked
+// into the bundle at build time (Track A) and served locally so the app renders
+// offline; the same-origin proxy to the CDN remains only as a fallback for any
+// file not bundled.
 //
 // This module is the single source of that server. It was first proven in the
 // ⌘⇧L verification window (zetaoffice-verify.js, #53) and is now shared by both
@@ -20,7 +22,8 @@
 const path = require('path')
 const http = require('node:http')
 const https = require('node:https')
-const { readFile } = require('node:fs/promises')
+const { readFile, stat } = require('node:fs/promises')
+const { createReadStream, readFileSync } = require('node:fs')
 const { app } = require('electron')
 
 const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
@@ -47,6 +50,16 @@ function editorRoot() {
   return app.isPackaged
     ? path.join(process.resourcesPath, 'frontend/dist/zetaoffice')
     : path.join(__dirname, '../../frontend/dist/zetaoffice')
+}
+
+// lowa/.encodings.json (written by desktop/scripts/fetch-lowa-assets.js): map of
+// basename -> content-encoding to REPLAY when serving a baked file, because the
+// CDN ships soffice.wasm/.data brotli-compressed and the bytes are stored as-is.
+// Without this the browser would receive brotli bytes as raw wasm and fail to
+// boot. Empty in dev (nothing baked); then /lowa/* falls back to the CDN proxy.
+function loadLowaEncodings(root) {
+  try { return JSON.parse(readFileSync(path.join(root, 'lowa', '.encodings.json'), 'utf8')) }
+  catch (e) { return {} }
 }
 
 // Proxy a full https URL to res, following up to 4 redirects. Streams the body
@@ -76,13 +89,38 @@ function proxyUrl(url, res, redirects = 0) {
 function startEditorServer() {
   if (serverPromise) return serverPromise
   const root = editorRoot()
+  const lowaEncodings = loadLowaEncodings(root)
   serverPromise = new Promise((resolve, reject) => {
     const s = http.createServer(async (req, res) => {
       try {
         let urlPath = decodeURIComponent((req.url || '/').split('?')[0])
-        // Same-origin LOWA proxy: /lowa/<path> -> the LOWA CDN.
+        // Same-origin LOWA: serve the baked runtime (dist/zetaoffice/lowa/*,
+        // produced at build time by desktop/scripts/fetch-lowa-assets.js) so the
+        // app renders offline; fall back to the CDN proxy only for files not
+        // bundled. Local-first is what makes the packaged app independent of
+        // cdn.zetaoffice.net.
         if (urlPath.startsWith('/lowa/')) {
-          return proxyUrl(LOWA_CDN + urlPath.slice('/lowa/'.length), res)
+          const rel = urlPath.slice('/lowa/'.length)
+          const lowaDir = path.join(root, 'lowa')
+          const localPath = path.normalize(path.join(lowaDir, rel))
+          if (localPath.startsWith(lowaDir)) {
+            try {
+              const st = await stat(localPath)
+              if (st.isFile()) {
+                const headers = {
+                  'Content-Type': TYPES[path.extname(localPath)] || 'application/octet-stream',
+                  'Content-Length': st.size,
+                }
+                // Replay the brotli encoding for files the CDN pre-compressed.
+                const enc = lowaEncodings[path.basename(localPath)]
+                if (enc) headers['Content-Encoding'] = enc
+                res.writeHead(200, headers)
+                createReadStream(localPath).pipe(res)
+                return
+              }
+            } catch (e) { /* not bundled locally — fall through to the CDN proxy */ }
+          }
+          return proxyUrl(LOWA_CDN + rel, res)
         }
         if (urlPath === '/') urlPath = '/editor.html'
         const filePath = path.normalize(path.join(root, urlPath))

--- a/desktop/scripts/fetch-lowa-assets.js
+++ b/desktop/scripts/fetch-lowa-assets.js
@@ -1,0 +1,168 @@
+// Fetch the LOWA (LibreOffice WASM) runtime + an OFL CJK font into the editor
+// bundle, so the packaged desktop app renders Chinese documents OFFLINE without
+// reaching cdn.zetaoffice.net at runtime (Epic #43, Track A).
+//
+// WHY bake instead of proxy: desktop/main/zetaoffice-server.js used to proxy
+// every /lowa/* request to the CDN on demand, so a first render needed network
+// and the CDN being up. This script downloads the runtime at BUILD time into
+// frontend/dist/zetaoffice/lowa/; the server now serves those local files first
+// and only falls back to the CDN proxy for anything not bundled. It also bakes a
+// deterministic OFL-licensed CJK font (Noto Sans SC) as cjk.ttc, replacing the
+// previous best-effort copy of whatever system font the CI runner happened to
+// have (non-deterministic, and absent offline).
+//
+// CONTENT-ENCODING: the CDN serves soffice.wasm and soffice.data pre-compressed
+// with Brotli (content-encoding: br) and ignores Accept-Encoding: identity — the
+// bytes on the wire ARE brotli. The old proxy "just worked" because it forwarded
+// content-encoding and the browser decompressed. We keep that: the br files are
+// stored compressed (also keeps the bundle ~53 MB instead of ~165 MB raw) and a
+// sidecar lowa/.encodings.json tells the server to replay Content-Encoding: br.
+// Each download asserts the encoding it actually received matches what we expect,
+// so a CDN change trips the build instead of silently shipping garbage.
+//
+// Targets (under the dedicated Vite build output, dist/zetaoffice/, which
+// electron-builder ships via extraResources — package.json):
+//   dist/zetaoffice/lowa/soffice.js
+//   dist/zetaoffice/lowa/soffice.wasm                (brotli)
+//   dist/zetaoffice/lowa/soffice.data                (brotli)
+//   dist/zetaoffice/lowa/soffice.data.js.metadata
+//   dist/zetaoffice/lowa/.encodings.json             (sidecar: { file: encoding })
+//   dist/zetaoffice/cjk.ttc   (Noto Sans SC Regular, OFL — content is OTF; the
+//                               .ttc name matches editor-main.js's fontUrl default
+//                               and fontconfig sniffs by content, not extension)
+//
+// Usage:  node desktop/scripts/fetch-lowa-assets.js   (idempotent; keeps a file
+//         that already validates). Runs in CI before electron-builder, and
+//         locally to verify the bundle. Resolves output paths relative to this
+//         script, so cwd does not matter.
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const zlib = require('zlib');
+
+const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/';
+// Noto Sans SC Regular (OFL-1.1), pinned release tag, served via jsDelivr which
+// resolves the repo's Git-LFS blob to the real font bytes. SubsetOTF/SC = the
+// Simplified-Chinese subset (full SC coverage, ~8 MB) rather than the all-CJK
+// OTF (~16 MB). License: googlefonts/noto-cjk LICENSE (OFL-1.1).
+const FONT_URL = 'https://cdn.jsdelivr.net/gh/googlefonts/noto-cjk@Sans2.004/Sans/SubsetOTF/SC/NotoSansSC-Regular.otf';
+
+const distRoot = path.join(__dirname, '../../frontend/dist/zetaoffice');
+
+// serve: 'lowa'   -> served by /lowa/*; stored as received; encoding replayed.
+//        'static' -> served by the plain static handler (no encoding replay), so
+//                    it MUST be identity on disk (we request identity + assert).
+// encoding: the content-encoding we EXPECT (asserted against the response).
+// magic: shape check applied to the DECOMPRESSED content.
+const ASSETS = [
+  { url: LOWA_CDN + 'soffice.js',               dest: 'lowa/soffice.js',               serve: 'lowa',   encoding: null, magic: 'js' },
+  { url: LOWA_CDN + 'soffice.wasm',             dest: 'lowa/soffice.wasm',             serve: 'lowa',   encoding: 'br', magic: 'wasm' },
+  { url: LOWA_CDN + 'soffice.data',             dest: 'lowa/soffice.data',             serve: 'lowa',   encoding: 'br', magic: 'blob' },
+  { url: LOWA_CDN + 'soffice.data.js.metadata', dest: 'lowa/soffice.data.js.metadata', serve: 'lowa',   encoding: null, magic: 'json' },
+  { url: FONT_URL,                              dest: 'cjk.ttc',                       serve: 'static', encoding: null, magic: 'font' },
+];
+
+// GET with up to 5 redirects; resolves {encoding, body:Buffer}.
+function get(url, headers, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method: 'GET', headers }, (res) => {
+      const sc = res.statusCode || 0;
+      if (sc >= 300 && sc < 400 && res.headers.location && redirects < 5) {
+        res.resume();
+        return resolve(get(new URL(res.headers.location, url).toString(), headers, redirects + 1));
+      }
+      if (sc !== 200) { res.resume(); return reject(new Error('GET ' + url + ' -> HTTP ' + sc)); }
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve({ encoding: res.headers['content-encoding'] || null, body: Buffer.concat(chunks) }));
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// Decompress (if br/gzip) then check magic bytes / shape. Catches truncation and
+// HTML error bodies; corrupt brotli throws on decompress.
+function decode(body, encoding) {
+  if (encoding === 'br') return zlib.brotliDecompressSync(body);
+  if (encoding === 'gzip') return zlib.gunzipSync(body);
+  return body;
+}
+
+function checkMagic(raw, magic, dest) {
+  const fail = (why) => { throw new Error('validation failed for ' + dest + ': ' + why); };
+  if (raw.length < 16) fail('too small (' + raw.length + ' bytes)');
+  const tag = raw.toString('latin1', 0, 4);
+  if (raw[0] === 0x3c) fail('looks like HTML (starts with "<")');
+  switch (magic) {
+    case 'wasm':
+      if (!(raw[0] === 0x00 && raw[1] === 0x61 && raw[2] === 0x73 && raw[3] === 0x6d)) fail('not a WASM module (\\0asm)');
+      break;
+    case 'font':
+      if (tag !== 'OTTO' && tag !== 'ttcf' && tag !== 'true' &&
+          !(raw[0] === 0x00 && raw[1] === 0x01 && raw[2] === 0x00 && raw[3] === 0x00)) fail('not a TTF/OTF/TTC font');
+      break;
+    case 'json':
+      if (raw.toString('utf8', 0, 64).trim()[0] !== '{') fail('not JSON');
+      break;
+    case 'js':
+      if (raw.length < 1024) fail('suspiciously small JS (' + raw.length + ' bytes)');
+      break;
+    case 'blob':
+      if (raw.length < 1024) fail('suspiciously small blob (' + raw.length + ' bytes)');
+      break;
+  }
+}
+
+// True if an on-disk file already decodes + validates (idempotent re-runs).
+function cachedOk(destPath, a) {
+  try {
+    checkMagic(decode(fs.readFileSync(destPath), a.encoding), a.magic, destPath);
+    return true;
+  } catch (e) { return false; }
+}
+
+async function fetchAsset(a) {
+  const destPath = path.join(distRoot, a.dest);
+  if (fs.existsSync(destPath) && cachedOk(destPath, a)) {
+    const mb = (fs.statSync(destPath).size / 1048576).toFixed(1);
+    console.log('  = ' + a.dest + ' (cached, ' + mb + ' MB on disk)');
+    return fs.statSync(destPath).size;
+  }
+  process.stdout.write('  ↓ ' + a.dest + ' …');
+  // 'static' assets are served without encoding replay, so insist on identity.
+  const reqHeaders = a.serve === 'static' ? { 'Accept-Encoding': 'identity' } : {};
+  const { encoding, body } = await get(a.url, reqHeaders);
+  const enc = encoding || null;
+  if (enc !== a.encoding) {
+    throw new Error(a.dest + ': expected content-encoding ' + JSON.stringify(a.encoding) +
+      ' but CDN sent ' + JSON.stringify(enc) + ' (serving would corrupt; aborting)');
+  }
+  checkMagic(decode(body, enc), a.magic, a.dest);
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  fs.writeFileSync(destPath + '.part', body);
+  fs.renameSync(destPath + '.part', destPath);
+  console.log(' ' + (body.length / 1048576).toFixed(1) + ' MB' + (enc ? ' (' + enc + ')' : ''));
+  return body.length;
+}
+
+async function main() {
+  console.log('Fetching LOWA runtime + CJK font into ' + distRoot);
+  let total = 0;
+  for (const a of ASSETS) total += await fetchAsset(a);
+
+  // Sidecar so zetaoffice-server.js replays Content-Encoding for the files the
+  // CDN pre-compressed (otherwise the browser gets brotli bytes as raw wasm).
+  const encodings = {};
+  for (const a of ASSETS) {
+    if (a.serve === 'lowa' && a.encoding) encodings[path.basename(a.dest)] = a.encoding;
+  }
+  fs.writeFileSync(path.join(distRoot, 'lowa/.encodings.json'), JSON.stringify(encodings) + '\n');
+
+  console.log('LOWA + font baked: ' + (total / 1048576).toFixed(1) + ' MB total under ' + distRoot);
+  console.log('  encodings: ' + JSON.stringify(encodings));
+}
+
+main().catch((e) => { console.error('fetch-lowa-assets failed:', e.message || e); process.exit(1); });


### PR DESCRIPTION
## 目标 / Goal

让内嵌 LibreOffice(ZetaOffice/LOWA)编辑器**离线**渲染中文文档:装好后不再依赖 `cdn.zetaoffice.net` 也能启动并显示中文(非豆腐块)。这是 LibreOffice 迁移 **Track A**。

Make the embedded LibreOffice editor render Chinese **offline** — no runtime dependency on `cdn.zetaoffice.net`.

## 改动 / Changes (产权边界内 / within ownership)

- **`desktop/scripts/fetch-lowa-assets.js`(新增)** — 构建期从 LOWA CDN 下载 `soffice.js/.wasm/.data/.data.js.metadata`(~53 MB)落进 `dist/zetaoffice/lowa/`,并焙进一个 OFL 字体(Noto Sans SC Regular,锁定 `Sans2.004` tag,~8 MB)为 `cjk.ttc`。每个文件做 magic-byte 校验 + content-encoding 断言,下载损坏/CDN 变更即让构建失败。
- **`desktop/main/zetaoffice-server.js`** — `/lowa/*` 改为**优先读本地**已焙入的文件,缺失才回退 CDN 代理(`proxyUrl` 原逻辑保留)。
- **`.github/workflows/desktop-build.yml`** — 把原来"best-effort 拷贝系统 CJK 字体"那步替换为运行 fetch 脚本(确定性、离线可用)。

`package.json` 的 `extraResources` 已经在打包 `frontend/dist/zetaoffice`,故 **打包配置无需改动**;`lowa/` 与 `cjk.ttc` 自动随包。未触碰 `project-overview.vue` 与 worker 源(`office_thread.js`/`zeta.js`)——Track B/C 产权。

## ⚠️ 安装包体积 / Installer size

**安装包将增大约 60 MB**(LOWA ~53 MB + 字体 ~8 MB)。

关键取舍:CDN 把 `soffice.wasm`/`.data` 以 **Brotli 预压缩**下发(且无视 `Accept-Encoding: identity`)。本 PR 把压缩字节**原样存盘**,由 server 通过 `lowa/.encodings.json` **回放 `Content-Encoding: br`**(浏览器自动解压,与原代理行为一致)。若改成解压后存盘,体积会涨到 **~262 MB**——故选择保留压缩。

## 沙箱验证 / Sandbox verification (done)

跑通 `node desktop/scripts/fetch-lowa-assets.js` 拉取真实 CDN 资产并校验:

```
lowa/soffice.js                0.8 MB
lowa/soffice.wasm             34.6 MB (br) → 解压 161.7 MB, magic \0asm ✓
lowa/soffice.data             15.2 MB (br) → 解压  99.5 MB ✓
lowa/soffice.data.js.metadata  0.2 MB        → 1903 个 FS 条目 ✓
cjk.ttc                        7.9 MB        → OTTO (Noto Sans SC, OFL) ✓
lowa/.encodings.json          {"soffice.wasm":"br","soffice.data":"br"}
```

并对 `zetaoffice-server.js` 做了 stub-electron 的集成测试(server 真实启动 + `fetch`):
- `/lowa/soffice.wasm` → 200,`Content-Encoding: br`,`Content-Length` = 压缩大小,自动解压回 `\0asm` ✓
- `/lowa/soffice.js` → 200,无 content-encoding ✓
- `/lowa/soffice.data` → 200,`Content-Encoding: br` ✓
- `/cjk.ttc` → 200,OTTO,无 content-encoding ✓
- 未焙入路径回退 CDN 代理(`proxyUrl` 未改动)✓

## 真机验证项 / Real-machine verification (maintainer)

- [ ] 断网后启动打包应用,触发 LibreOffice 验证窗口(⌘⇧L),确认 LOWA 正常 boot、中文渲染非豆腐块、redline 命令可用。
- [ ] 确认运行期无对 `cdn.zetaoffice.net` 的网络请求(DevTools Network 全本地 `127.0.0.1`)。
- [ ] 安装包体积增长符合预期(~60 MB)。

## 备注 / Notes

- LOWA 仍取 `zetaoffice_latest`(与现状一致);焙进后实际是**构建期冻结**,比运行期代理 latest 更稳定。LOWA 与 vendored `zeta.js` 的版本对齐属 Track B/C。
- `desktop-build.yml` 因路径匹配会在本 PR 触发,正好实跑新的 fetch 步骤;合并门槛按既有授权为 `ci.yml` 三项绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)