### PR TITLE
feat(libreoffice): 嵌入式编辑器设为 Office 文档默认编辑器 (Track B)

### DIFF
--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -1,12 +1,18 @@
 <template>
   <view class="libre-editor-wrapper">
     <view class="libre-toolbar">
-      <text class="libre-title">LibreOffice 编辑器（嵌入式 webview · 实验）</text>
+      <text class="libre-title">{{ variant === 'default' ? 'LibreOffice 编辑器' : 'LibreOffice 编辑器（嵌入式 webview · 实验）' }}</text>
       <text class="libre-status" :class="{ ready }">{{ statusText }}</text>
-      <button class="libre-btn" :disabled="!ready" @click="runInsert">插入示例</button>
-      <button class="libre-btn" :disabled="!ready" @click="runReplace">查找替换(redline)</button>
-      <button class="libre-btn" :disabled="!ready" @click="runSelection">读选区</button>
-      <button class="libre-btn libre-close" @click="$emit('close')">关闭</button>
+      <!-- The dev probe buttons + close are the ⌘⇧O experimental overlay's
+           controls. In the inline 'default' variant (Track B: embedded editor is
+           the document's default editor) they are hidden — the document tab's ×
+           closes it and the AI agent drives commands. -->
+      <template v-if="variant !== 'default'">
+        <button class="libre-btn" :disabled="!ready" @click="runInsert">插入示例</button>
+        <button class="libre-btn" :disabled="!ready" @click="runReplace">查找替换(redline)</button>
+        <button class="libre-btn" :disabled="!ready" @click="runSelection">读选区</button>
+        <button class="libre-btn libre-close" @click="$emit('close')">关闭</button>
+      </template>
     </view>
     <!-- The Electron <webview> is created imperatively (uni-app's template
          compiler does not know the <webview> tag); it mounts into this host. -->
@@ -39,6 +45,11 @@ let seq = 0
 export default {
   name: 'LibreOfficeEditor',
   emits: ['close', 'ready'],
+  props: {
+    // 'experimental' = the original ⌘⇧O overlay (dev probe toolbar shown).
+    // 'default'      = inline document editor (Track B): toolbar chrome hidden.
+    variant: { type: String, default: 'experimental' },
+  },
   data() {
     return {
       hostId: 'libre-host-' + (++seq),
@@ -64,6 +75,10 @@ export default {
     }
   },
   beforeUnmount() {
+    // Tell the host this editor (and its executor) is going away — so it can
+    // stop routing AI commands to a disposed executor when the document tab is
+    // closed or switched. The executor ref lets the host ignore stale closes.
+    try { this.$emit('close', this.executor) } catch (e) { /* ignore */ }
     try { if (this.executor && typeof this.executor.dispose === 'function') this.executor.dispose() } catch (e) { /* ignore */ }
     try { if (this.webviewEl && this.webviewEl.remove) this.webviewEl.remove() } catch (e) { /* ignore */ }
     this.webviewEl = null

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -694,6 +694,16 @@
                       @title-change="onBrowserTitleChange('left', $event)"
                       @open-new-tab="openBrowserTab($event)"
                     />
+                    <!-- Epic #43 Track B: embedded LibreOffice is the DEFAULT
+                         editor for Office docs when available (desktop). WPS is
+                         the fallback (web/h5 or embed unavailable). -->
+                    <LibreOfficeEditor
+                      v-else-if="useLibreEditor(activeFileLeft)"
+                      :key="'libre-left-' + activeFileLeft.id"
+                      variant="default"
+                      @ready="onLibreReady"
+                      @close="onLibreClose"
+                    />
                     <WpsEditor
                       v-else-if="isWpsFile(activeFileLeft)"
                       ref="wpsLeft"
@@ -755,6 +765,14 @@
                       @url-change="onBrowserUrlChange('right', $event)"
                       @title-change="onBrowserTitleChange('right', $event)"
                       @open-new-tab="openBrowserTab($event)"
+                    />
+                    <!-- Epic #43 Track B: embedded LibreOffice default (see left pane). -->
+                    <LibreOfficeEditor
+                      v-else-if="useLibreEditor(activeFileRight)"
+                      :key="'libre-right-' + activeFileRight.id"
+                      variant="default"
+                      @ready="onLibreReady"
+                      @close="onLibreClose"
                     />
                     <WpsEditor
                       v-else-if="isWpsFile(activeFileRight)"
@@ -1465,6 +1483,10 @@ export default {
       showLibreEmbed: false,
       libreOfficeActive: false,
       libreOfficeExecutor: null,
+      // Epic #43 Track B: when true, opening an Office document defaults to the
+      // inline embedded LibreOffice editor (WPS demoted to fallback). Set at init
+      // from desktop embed availability — install-and-use, no WPS config needed.
+      libreOfficePreferred: false,
 
       // WPS Config
       wpsAppId: '', // 从后端动态获取
@@ -1949,13 +1971,28 @@ export default {
 
     // Manual binding removed (reverted to native modifier)
 
-    // Epic #43: ⌘⇧O 打开嵌入式 LibreOffice 编辑器覆盖层（实验）。仅切换覆盖层标志，
-    // 不触碰 WPS 文档流。
+    // Epic #43 Track B: when the desktop app exposes the embedded editor, make it
+    // the DEFAULT editor for Office documents (inline, no ⌘⇧O needed). WPS is
+    // demoted to a fallback so users can edit without configuring WPS.
+    try {
+      this.libreOfficePreferred = !!(
+        this.isDesktopApp &&
+        window.checkbaDesktop &&
+        window.checkbaDesktop.zetaoffice &&
+        typeof window.checkbaDesktop.zetaoffice.getEditor === 'function'
+      )
+    } catch (e) {
+      this.libreOfficePreferred = false
+    }
+
+    // Epic #43: ⌘⇧O 打开嵌入式 LibreOffice 编辑器覆盖层（实验）。当嵌入式编辑器已是
+    // 文档的默认内联编辑器时（libreOfficePreferred），文档区已经承载它，⌘⇧O 变为
+    // 空操作以避免双重挂载（两个 webview/executor）；仅在未启用内联默认时回退到覆盖层。
     try {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.zetaoffice && window.checkbaDesktop.zetaoffice.onOpenEmbed) {
         if (!this._zetaOpenEmbedUnsub) {
           this._zetaOpenEmbedUnsub = window.checkbaDesktop.zetaoffice.onOpenEmbed(() => {
-            this.showLibreEmbed = true
+            if (!this.libreOfficePreferred) this.showLibreEmbed = true
           })
         }
       }
@@ -5086,6 +5123,14 @@ export default {
       return wpsFormats.includes(type) || (file.wpsFileId && !mediaTypes.includes(type) && type !== 'md' && type !== 'markdown')
     },
 
+    // Epic #43 Track B: should this Office file open in the embedded LibreOffice
+    // editor instead of WPS? True only when the desktop embed is available
+    // (libreOfficePreferred). On web/h5 or when unavailable, returns false so the
+    // existing WPS path still renders the document.
+    useLibreEditor(file) {
+      return this.libreOfficePreferred && this.isWpsFile(file)
+    },
+
     // Check if file is a markdown tab (for AI artifacts or real .md files)
     isMarkdownTab(file) {
       if (!file) return false
@@ -5911,13 +5956,19 @@ export default {
     },
 
     // Epic #43: embedded LibreOffice editor lifecycle. While ready, backend AI
-    // commands route to it (see handleWpsCommand divert).
+    // commands route to it (see handleWpsCommand divert). Used by both the inline
+    // default editor (Track B) and the legacy ⌘⇧O overlay.
     onLibreReady(executor) {
         this.libreOfficeExecutor = executor
         this.libreOfficeActive = true
         console.log('[ProjectOverview] LibreOffice editor ready — agent commands routed to LibreOffice')
     },
-    onLibreClose() {
+    onLibreClose(executor) {
+        // The overlay close button emits no executor; an inline editor unmount
+        // (tab close/switch) emits its own. Only tear down routing if the editor
+        // going away owns the currently-active executor — so a fast switch
+        // between two Office docs can't clobber the newly-ready one.
+        if (executor && executor !== this.libreOfficeExecutor) return
         this.showLibreEmbed = false
         this.libreOfficeActive = false
         this.libreOfficeExecutor = null


### PR DESCRIPTION
## 目标 (Track B)

把嵌入式 LibreOffice 编辑器从 **⌘⇧O 实验覆盖层** 转为 **打开 Office 文档时的默认内联编辑器**,让桌面版用户**装好即用、无需配置 WPS**。WPS 降为可选/回退。

承接 #57(webview 嵌入 + IPC)、#59(后端 AI 命令分流到嵌入式编辑器)。维护者已真机验过 #57+#59 端到端 = GO。

## 改动(仅前端接线,surgical)

产权边界内仅动两文件;`desktop/`、worker、`useEditorBridge.js` 未碰。

**`frontend/src/pages/project-overview/project-overview.vue`**
- 新增 `libreOfficePreferred`:init 时按桌面嵌入能力(`window.checkbaDesktop.zetaoffice.getEditor`)置位。
- 新增 `useLibreEditor(file)`:在左右两窗格 `<WpsEditor>` 之前插入内联 `<LibreOfficeEditor variant="default">` 分支,Office 文档优先用嵌入式编辑器。
- `libreOfficeActive`(#59 的 AI 命令分流开关)触发从「仅 ⌘⇧O」改为「打开文档即激活」。
- ⌘⇧O 覆盖层:当内联默认已启用时变为空操作,避免双重挂载(两个 webview/executor)。
- `onLibreClose(executor)`:按 executor 身份忽略过期 close,避免两个 Office 文档快速切换时误清新就绪的 executor。

**`frontend/src/components/LibreOfficeEditor.vue`**
- 新增 `variant` prop(`'default'` 隐藏实验工具条/关闭按钮)。
- `beforeUnmount` 携 executor 触发 `close`,标签关闭/切换时宿主清理路由状态。

## ⚠️ 已知权衡(维护者已确认「立即设为默认」)

嵌入式编辑器目前**还不能加载用户真实文件**:`getEditor()` 不带文件参数,worker 的 `office_thread.js` `bootDoc()` 硬编码 boot 一个种子原型文档(`private:factory/swriter`)。文件加载属于 Track A/C 产权(office_thread.js / desktop),本 PR 不动。

**因此:在 Track A/C 接好文件加载前,打开已有 .docx 会显示原型示例文字而非真实内容。** 此权衡维护者已知悉并选择「立即设为默认」。

- 影响面:**仅桌面版**(`libreOfficePreferred` 依赖桌面 `getEditor`)。Web/H5 云产品 `libreOfficePreferred=false`,WPS 路径**字节级不变**。
- 可回退:单个 gated flag,改 `libreOfficePreferred` 置位逻辑或还原本 PR 即可。

## 验证

- ✅ `build:h5` 绿(仅既有 SASS 弃用告警,与本改动无关)。
- 🔬 真机体验由维护者验(桌面版):

### 桌面版真机验证项
1. 装好桌面版、**未配置 WPS**,打开一个 Office 文档 → 文档区直接渲染嵌入式 LibreOffice 编辑器(工具条为「LibreOffice 编辑器」,无实验按钮)。
2. 对话区触发一条后端 AI 命令(如查找替换/插入)→ 命令落到嵌入式编辑器(走 #59 分流),结果回传成功。
3. 关闭文档标签 / 切换到非 Office 文件 → 嵌入式编辑器卸载,AI 命令路由复位(再开 WPS 文档时回落 WPS)。
4. 左右分屏各开一个 Office 文档 → 均渲染嵌入式编辑器(注:当前单 executor 模型,AI 命令落到最后就绪的那个 — 已知限制,非本 PR 扩围)。
5. ⌘⇧O 不再叠加第二个覆盖层(空操作),无双 webview。
6. 回退确认:Web/H5 或桌面无嵌入能力时,Office 文档仍由 WPS 正常渲染。

## 未在本 PR 范围(后续 Track)
- 嵌入式编辑器加载用户真实文档(Track A/C:office_thread.js / desktop getEditor 传文件)。
- 分屏多文档的 per-pane executor 路由(当前单 executor)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)