### PR TITLE
feat(libreoffice): IME 覆盖层控制键 + 滚动感知光标映射 + 50 页 docx 加载性能探针 (Track C, 休眠) / control keys + scroll-aware cursor map + load probe

### DIFF
--- a/experiments/zetaoffice-spike/index.html
+++ b/experiments/zetaoffice-spike/index.html
@@ -29,6 +29,7 @@
     <button id="btnSel" disabled>测选区 selection</button>
     <button id="btnRed" disabled>测修订 redline</button>
     <button id="btnPerf" disabled>测50页性能 perf</button>
+    <button id="btnPerfLoad" disabled>测50页加载 perf-load</button>
     <button id="btnCjk" disabled>插入中文(无IME)</button>
     <button id="btnExec" disabled>executor 自测(产品客户端)</button>
     <button id="btnRect" disabled>测光标矩形 cursor-rect</button>
@@ -69,6 +70,7 @@
     const btnSel = document.getElementById('btnSel');
     const btnRed = document.getElementById('btnRed');
     const btnPerf = document.getElementById('btnPerf');
+    const btnPerfLoad = document.getElementById('btnPerfLoad');
     const btnCjk = document.getElementById('btnCjk');
     const btnExec = document.getElementById('btnExec');
     const btnRect = document.getElementById('btnRect');
@@ -141,6 +143,19 @@
     btnRed.onclick = () => send('redline');
     btnPerf.onclick = () => send('perf', { pages: 50 });
     btnCjk.onclick = () => send('inserttext');
+
+    // perf-load: time the docx IMPORT path (generate -> save .docx -> reload).
+    // Structured result via workerRequest (NOT fire-and-forget) so we can print
+    // gen/save/load ms + page count. Heavy — may stress the headless preview.
+    btnPerfLoad.onclick = async () => {
+      zlog('=== perf-load：生成→存docx→重新加载 50 页（加载耗时见 loadMs）===', 'k');
+      btnPerfLoad.disabled = true;
+      try {
+        const r = await workerRequest('perf_load', { pages: 50 });
+        zlog('perf_load → ' + JSON.stringify(r), 'k');
+      } catch (e) { zlog('perf_load 失败：' + e, 'e'); }
+      btnPerfLoad.disabled = false;
+    };
 
     // Self-test the REAL product executor client end-to-end: client.executeCommand
     // -> worker -> UNO -> result. Proves the product code path (not eval-driven).
@@ -239,7 +254,7 @@
           onLog: function (m) { zlog(m); },
           onReady: function () {
             spinner.style.display = 'none'; canvas.style.visibility = 'visible';
-            btnSel.disabled = btnRed.disabled = btnPerf.disabled = btnCjk.disabled = btnExec.disabled = btnRect.disabled = false;
+            btnSel.disabled = btnRed.disabled = btnPerf.disabled = btnPerfLoad.disabled = btnCjk.disabled = btnExec.disabled = btnRect.disabled = false;
             imeBridge.disabled = false; imeBridge.focus();
             zlog('UI ready ✓ — 现在可以在文档里打中文、点测试按钮');
             try { window.dispatchEvent(new Event('resize')); } catch (err) { zlog('resize warn: ' + err, 'e'); }
@@ -273,9 +288,11 @@
           getCursorRaw: function () { return workerRequest('get_cursor_rect', {}); },
           // Enter -> paragraph break at the LO cursor (single-line input can't).
           onEnter: function () { return workerRequest('insert_paragraph', {}); },
+          // Control-key channel: Backspace -> delete_backward, arrows -> move_cursor.
+          sendCommand: function (action, params) { return workerRequest(action, params); },
           onLog: function (msg) { zlog(msg, 'ime'); },
         });
-        zlog('IME 透明覆盖层已挂载 ✓ (Phase B 自标定) — 点文档放光标后直接打中文、回车换行', 'ime');
+        zlog('IME 透明覆盖层已挂载 ✓ (Phase B 自标定) — 点文档放光标后直接打中文、回车换行、退格/方向键', 'ime');
 
         // Debug hooks. tuneCursorMap({nudgeX,nudgeY}) shifts the box by a constant
         // px to zero out the small click-snap / caret-top residual — click the doc,
@@ -284,7 +301,8 @@
         window.overlayRect = function () { return imeOverlay.computeRect(); };
         window.cursorMap = ov.CURSOR_MAP;
         window.tuneCursorMap = function (patch) { Object.assign(ov.CURSOR_MAP, patch || {}); if (imeOverlay) imeOverlay.reposition(); zlog('CURSOR_MAP = ' + JSON.stringify(ov.CURSOR_MAP), 'k'); return ov.CURSOR_MAP; };
-        zlog('调试钩子就绪：tuneCursorMap({nudgeX,nudgeY}) / measureCursor() / overlayRect()', 'k');
+        zlog('调试钩子就绪：tuneCursorMap({nudgeX,nudgeY,viewDataToMm}) / measureCursor() / overlayRect()', 'k');
+        zlog('滚动感知：滚动文档后打字应自动跟随；若不跟随，看 measureCursor().viewData 哪个字段随滚动变、单位是否需 viewDataToMm=2540/1440', 'k');
       } catch (e) {
         zlog('boot 失败：' + e, 'e');
         btnBoot.disabled = false;

--- a/experiments/zetaoffice-spike/office_thread.js
+++ b/experiments/zetaoffice-spike/office_thread.js
@@ -29,6 +29,9 @@ function errStr(e) {
   try { return zetajs.getAnyType(zetajs.catchUnoException(e)) + ' ' + (e && e.message || ''); }
   catch { return String(e && e.message || e); }
 }
+// Build a UNO PropertyValue the zetajs way (struct ctor takes a values object;
+// unset members default). Used for loadComponentFromURL/storeToURL filter args.
+function mkProp(name, value) { return new css.beans.PropertyValue({ Name: name, Value: value }); }
 
 // §0.2 anchors: a bookmark spanning a text range is a STABLE location handle that
 // moves with edits — the model-native replacement for fragile integer offsets.
@@ -365,6 +368,35 @@ const EXEC = {
     vc.collapseToEnd();
     return { success: true };
   },
+  // [spike] move the view cursor (arrow keys in the IME overlay route here — the
+  // overlay's single-line <input> would otherwise navigate the empty input, not
+  // the document). left/right are text-flow steps (XTextCursor.goLeft/goRight),
+  // up/down are visual lines (XViewCursor.goUp/goDown). extend=true (Shift+arrow)
+  // grows the selection. No content change, so no RecordChanges.
+  move_cursor(p) {
+    const vc = ctrl.getViewCursor();
+    const dir = String(p.dir || '');
+    const ex = !!p.extend;
+    switch (dir) {
+      case 'left': vc.goLeft(1, ex); break;
+      case 'right': vc.goRight(1, ex); break;
+      case 'up': vc.goUp(1, ex); break;
+      case 'down': vc.goDown(1, ex); break;
+      default: return { success: false, message: 'move_cursor: unsupported dir: ' + dir };
+    }
+    return { success: true, dir: dir, extend: ex };
+  },
+  // [spike] delete one char before the cursor (Backspace in the IME overlay). If
+  // text is selected, delete the selection; else extend one char left and clear.
+  // Inherits the current RecordChanges state (tracked if tracking is on).
+  delete_backward() {
+    const vc = ctrl.getViewCursor();
+    if ((vc.getString() || '').length === 0) vc.goLeft(1, true); // select char to the left
+    const had = (vc.getString() || '').length;
+    if (had === 0) return { success: true, deleted: 0 };          // at doc start: nothing to delete
+    vc.setString('');
+    return { success: true, deleted: had };
+  },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the
   // mm->px formula can be calibrated on the JS side without restarting LOWA.
@@ -389,7 +421,68 @@ const EXEC = {
       const r = ctrl.getFrame().getComponentWindow().getPosSize();
       out.winPx = { X: r.X, Y: r.Y, W: r.Width, H: r.Height };
     } catch (e) { out.winErr = errStr(e); }
+    // SCROLL-AWARE origin (Phase B): getPosition() is in document coords (from the
+    // page top), so after the view scrolls the click-derived offset goes stale.
+    // The view data carries the scrolled origin — VisibleLeft/Top (or ViewLeft/Top)
+    // — so the overlay can subtract it and follow the cursor WITHOUT re-clicking.
+    // We return the whole bag verbatim: which field tracks scroll AND its unit
+    // (1/100 mm vs twips) is the open question to confirm on a real device, then
+    // bake CURSOR_MAP.viewDataToMm accordingly.
+    try {
+      const vd = xModel.getViewData && xModel.getViewData();
+      if (vd && typeof vd.getByIndex === 'function' && vd.getCount() > 0) {
+        const seq = vd.getByIndex(0);
+        const view = {};
+        if (seq && seq.length) for (let i = 0; i < seq.length; i++) {
+          const pv = seq[i];
+          if (pv && pv.Name != null) view[pv.Name] = pv.Value;
+        }
+        out.viewData = view;
+      }
+    } catch (e) { out.viewDataErr = errStr(e); }
     return out;
+  },
+  // [spike] probe 4b: LOAD performance of a 50-page docx (#56 余项). The existing
+  // testPerf times GENERATION; this times the docx IMPORT path: generate N pages,
+  // store to a .docx in MEMFS, then loadComponentFromURL it (replacing the visible
+  // doc) and time the load. Reports gen/save/load ms + page count. loadMs covers
+  // model load + initial layout trigger; Qt repaint/scroll smoothness still needs
+  // eyes on a real device. Heavy — may stress a headless sandbox (reboot if it
+  // hangs); the authoritative numbers come from a real machine.
+  perf_load(p) {
+    const pages = Number(p.pages) || 50;
+    const r = { success: true, pages: pages };
+    try {
+      const xText = xModel.getText();
+      const cur = xText.createTextCursor();
+      cur.gotoEnd(false);
+      const tGen = performance.now();
+      for (let pg = 0; pg < pages; pg++) {
+        for (let l = 0; l < 28; l++) {
+          xText.insertString(cur, '第' + (pg + 1) + '页 第' + (l + 1) + '行 合同条款示例 / contract clause sample line.', false);
+          xText.insertControlCharacter(cur, css.text.ControlCharacter.PARAGRAPH_BREAK, false);
+        }
+        try { cur.setPropertyValue('BreakType', css.style.BreakType.PAGE_AFTER); } catch (e) {}
+      }
+      r.genMs = Math.round(performance.now() - tGen);
+
+      const url = 'file:///tmp/perf_' + pages + '.docx';
+      const tSave = performance.now();
+      xModel.storeToURL(url, [mkProp('FilterName', 'MS Word 2007 XML')]);
+      r.saveMs = Math.round(performance.now() - tSave);
+
+      const tLoad = performance.now();
+      const loaded = desktop.loadComponentFromURL(url, '_default', 0, []);
+      r.loadMs = Math.round(performance.now() - tLoad);
+
+      // The loaded docx now owns the frame; retarget the worker's model/controller
+      // so subsequent commands act on what's actually displayed.
+      xModel = loaded;
+      ctrl = loaded.getCurrentController();
+      try { const vc = ctrl.getViewCursor(); vc.gotoEnd(false); r.pageCount = vc.getPage(); }
+      catch (e) { r.pageErr = errStr(e); }
+    } catch (e) { r.success = false; r.message = errStr(e); }
+    return r;
   },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -19,21 +19,31 @@
 // cursor; composing text shows inline (color turned visible), then clears on
 // commit while LO renders the real text.
 //
-//   MAPPING — doc 1/100 mm -> canvas CSS px is affine: px = scale*doc + offset.
+//   MAPPING — doc 1/100 mm -> canvas CSS px is affine: px = origin + scale*(doc - scroll).
 //   * scale is STABLE: 96/2540 CSS px per 1/100 mm at 100% zoom (CSS defines
 //     96 px/in; 2540 (1/100 mm)/in), times ZoomValue%. Verified exact against a
 //     real LibreOffice (click-correspondence calibration).
-//   * offset is VIEW-STATE-DEPENDENT (window size, scroll, LO chrome) so it is
-//     NOT a constant. We derive it LIVE: every canvas click gives both the click
-//     pixel AND (after Qt positions the cursor) the cursor's doc coords, so
-//     offset = clickPx - scale*docPos. The normal flow is "click to place the
-//     cursor, then type", so the anchor is always fresh where you're about to
-//     type — robust to any window/scroll without magic numbers. Before the first
-//     click we have no anchor, so the overlay stays full-cover (Phase A) and the
-//     candidate box sits top-left until the first click.
+//   * scroll is the SCROLLED view origin (VisibleTop/Left from get_cursor_rect's
+//     viewData). getPosition() is in document coords (from the page top), so once
+//     the view scrolls the cursor's doc Y jumps while its pixel stays in view.
+//     Subtracting `scroll` makes the mapping track the cursor through scroll
+//     WITHOUT re-clicking — the fix for the "anchor goes stale after auto-scroll"
+//     limitation. Absent viewData (older LOWA) -> scroll=0 -> identical to the
+//     pre-scroll-aware behavior. Unit (1/100 mm vs twips) is baked once on a real
+//     device via CURSOR_MAP.viewDataToMm.
+//   * origin is the canvas pixel of the visible-area top-left — VIEW-STATE-
+//     DEPENDENT (window size, LO chrome) but STABLE under scroll. We derive it
+//     LIVE from each canvas click: the click gives both the click pixel AND
+//     (after Qt positions the cursor) the cursor's doc coords + scroll, so
+//     origin = clickPx - scale*(docPos - scroll). The normal flow is "click to
+//     place the cursor, then type", so the anchor is always fresh. Before the
+//     first click we have no anchor, so the overlay stays full-cover (Phase A)
+//     and the candidate box sits top-left until the first click.
 //
-// Control keys: Enter inserts a paragraph break via onEnter (forwarded to UNO),
-// not into the empty <input>. Backspace/arrows are not yet forwarded.
+// Control keys (Phase B, when sendCommand is supplied): Enter inserts a paragraph
+// break via onEnter; Backspace deletes the char before the cursor; arrow keys move
+// the LO view cursor — all forwarded to UNO, not applied to the empty <input>.
+// Without sendCommand these keys fall through to the (harmless, empty) input.
 
 // The STABLE half of the mapping. offset is derived live per click (see above).
 // nudgeX/nudgeY are a small constant px correction for the residual between the
@@ -44,11 +54,26 @@ export const CURSOR_MAP = {
   useZoom: true,
   nudgeX: 0,
   nudgeY: 0,
+  // Unit of viewData scroll (VisibleTop/Left) -> 1/100 mm. 1 if viewData is
+  // already 1/100 mm; set 2540/1440 (~1.7639) if a real device shows it's twips.
+  viewDataToMm: 1,
 }
 
 function scaleFromZoom(raw) {
   const z = (CURSOR_MAP.useZoom && raw && raw.zoom) ? raw.zoom / 100 : 1
   return CURSOR_MAP.scale * z
+}
+
+// Scrolled view origin in 1/100 mm from get_cursor_rect's viewData, or null if
+// absent. Prefer VisibleTop/Left; fall back to ViewTop/Left.
+function scrollMm(raw) {
+  const vd = raw && raw.viewData
+  if (!vd) return null
+  const k = CURSOR_MAP.viewDataToMm || 1
+  const top = typeof vd.VisibleTop === 'number' ? vd.VisibleTop : vd.ViewTop
+  const left = typeof vd.VisibleLeft === 'number' ? vd.VisibleLeft : vd.ViewLeft
+  if (typeof top !== 'number' || typeof left !== 'number') return null
+  return { x: left * k, y: top * k }
 }
 
 /**
@@ -60,9 +85,10 @@ export function cursorRectToPixels(raw, offset) {
   if (!raw || !raw.pos || typeof raw.pos.X !== 'number' || !offset) return null
   const s = scaleFromZoom(raw)
   const z = s / CURSOR_MAP.scale
+  const sc = scrollMm(raw) || { x: 0, y: 0 }
   return {
-    left: offset.x + s * raw.pos.X + (CURSOR_MAP.nudgeX || 0),
-    top: offset.y + s * raw.pos.Y + (CURSOR_MAP.nudgeY || 0),
+    left: offset.x + s * (raw.pos.X - sc.x) + (CURSOR_MAP.nudgeX || 0),
+    top: offset.y + s * (raw.pos.Y - sc.y) + (CURSOR_MAP.nudgeY || 0),
     height: raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z : 18,
   }
 }
@@ -80,10 +106,15 @@ export function cursorRectToPixels(raw, offset) {
  * @param {()=>(any|Promise<any>)} [options.onEnter] OPTIONAL. Inserts a paragraph
  *        break at the LO cursor (e.g. () => executor.executeCommand(
  *        'insert_paragraph')). Without it, Enter does nothing.
+ * @param {(action:string,params:object)=>Promise<any>} [options.sendCommand]
+ *        OPTIONAL. A raw UI-command channel to the worker (e.g. (a,p) =>
+ *        workerRequest(a,p)). Enables control-key forwarding: Backspace ->
+ *        delete_backward, arrow keys -> move_cursor. Without it, those keys fall
+ *        through to the (empty) input and the document is unaffected.
  * @param {(msg:string)=>void} [options.onLog] optional progress/diagnostic log.
  * @returns {{element, focus, reposition, computeRect, destroy}}
  */
-export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog } = {}) {
+export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCommand, onLog } = {}) {
   if (!canvas) throw new Error('attachImeOverlay: canvas is required')
   if (typeof commit !== 'function') throw new Error('attachImeOverlay: commit(text) is required')
   const log = (m) => { if (onLog) onLog(m) }
@@ -146,9 +177,11 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog 
       // X) is a small ~constant the maintainer zeroes once via CURSOR_MAP.nudge.
       const z = s / CURSOR_MAP.scale
       const halfCaret = raw.charHeightPt ? raw.charHeightPt * (96 / 72) * z / 2 : 8
+      const sc = scrollMm(raw) || { x: 0, y: 0 }
+      // origin = visible-area top-left in px (stable under scroll); see header.
       anchor = {
-        x: (clientX - r.left) - s * raw.pos.X,
-        y: (clientY - r.top) - halfCaret - s * raw.pos.Y,
+        x: (clientX - r.left) - s * (raw.pos.X - sc.x),
+        y: (clientY - r.top) - halfCaret - s * (raw.pos.Y - sc.y),
       }
     } catch (e) {
       mapOk = false
@@ -196,8 +229,18 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog 
     reposition()
   })
 
-  // Enter -> paragraph break at the LO cursor (NOT into the single-line input).
-  // Only when NOT composing — during composition Enter confirms the IME candidate.
+  // Forward a worker UI command, then move the box to the (now-moved) cursor.
+  const forward = (action, params, label) => {
+    log('IME 覆盖层 → ' + label)
+    try { Promise.resolve(sendCommand(action, params || {})).then(reposition).catch((err) => log('overlay ' + action + ' error: ' + (err && err.message || err))) }
+    catch (err) { log('overlay ' + action + ' error: ' + (err && err.message || err)) }
+  }
+  const ARROW_DIR = { ArrowLeft: 'left', ArrowRight: 'right', ArrowUp: 'up', ArrowDown: 'down' }
+
+  // Control keys -> UNO (NOT into the single-line input). Only when NOT composing:
+  // during composition these keys drive the IME candidate window. Enter routes to
+  // onEnter; Backspace/arrows route through sendCommand (skipped if not supplied,
+  // letting them fall through to the harmless empty input).
   input.addEventListener('keydown', (e) => {
     if (composing || e.isComposing) return
     if (e.key === 'Enter') {
@@ -206,6 +249,15 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, onLog 
       log('IME 覆盖层 → 回车换行 / paragraph break')
       try { Promise.resolve(onEnter()).then(reposition).catch((err) => log('overlay enter error: ' + (err && err.message || err))) }
       catch (err) { log('overlay enter error: ' + (err && err.message || err)) }
+      return
+    }
+    if (typeof sendCommand !== 'function') return
+    if (e.key === 'Backspace') {
+      e.preventDefault()
+      forward('delete_backward', {}, 'Backspace 删除 / delete')
+    } else if (ARROW_DIR[e.key]) {
+      e.preventDefault()
+      forward('move_cursor', { dir: ARROW_DIR[e.key], extend: e.shiftKey }, '方向键 ' + ARROW_DIR[e.key] + (e.shiftKey ? '+选择' : ''))
     }
   })
 

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -29,6 +29,9 @@ function errStr(e) {
   try { return zetajs.getAnyType(zetajs.catchUnoException(e)) + ' ' + (e && e.message || ''); }
   catch { return String(e && e.message || e); }
 }
+// Build a UNO PropertyValue the zetajs way (struct ctor takes a values object;
+// unset members default). Used for loadComponentFromURL/storeToURL filter args.
+function mkProp(name, value) { return new css.beans.PropertyValue({ Name: name, Value: value }); }
 
 // §0.2 anchors: a bookmark spanning a text range is a STABLE location handle that
 // moves with edits — the model-native replacement for fragile integer offsets.
@@ -365,6 +368,35 @@ const EXEC = {
     vc.collapseToEnd();
     return { success: true };
   },
+  // [spike] move the view cursor (arrow keys in the IME overlay route here — the
+  // overlay's single-line <input> would otherwise navigate the empty input, not
+  // the document). left/right are text-flow steps (XTextCursor.goLeft/goRight),
+  // up/down are visual lines (XViewCursor.goUp/goDown). extend=true (Shift+arrow)
+  // grows the selection. No content change, so no RecordChanges.
+  move_cursor(p) {
+    const vc = ctrl.getViewCursor();
+    const dir = String(p.dir || '');
+    const ex = !!p.extend;
+    switch (dir) {
+      case 'left': vc.goLeft(1, ex); break;
+      case 'right': vc.goRight(1, ex); break;
+      case 'up': vc.goUp(1, ex); break;
+      case 'down': vc.goDown(1, ex); break;
+      default: return { success: false, message: 'move_cursor: unsupported dir: ' + dir };
+    }
+    return { success: true, dir: dir, extend: ex };
+  },
+  // [spike] delete one char before the cursor (Backspace in the IME overlay). If
+  // text is selected, delete the selection; else extend one char left and clear.
+  // Inherits the current RecordChanges state (tracked if tracking is on).
+  delete_backward() {
+    const vc = ctrl.getViewCursor();
+    if ((vc.getString() || '').length === 0) vc.goLeft(1, true); // select char to the left
+    const had = (vc.getString() || '').length;
+    if (had === 0) return { success: true, deleted: 0 };          // at doc start: nothing to delete
+    vc.setString('');
+    return { success: true, deleted: had };
+  },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the
   // mm->px formula can be calibrated on the JS side without restarting LOWA.
@@ -389,7 +421,68 @@ const EXEC = {
       const r = ctrl.getFrame().getComponentWindow().getPosSize();
       out.winPx = { X: r.X, Y: r.Y, W: r.Width, H: r.Height };
     } catch (e) { out.winErr = errStr(e); }
+    // SCROLL-AWARE origin (Phase B): getPosition() is in document coords (from the
+    // page top), so after the view scrolls the click-derived offset goes stale.
+    // The view data carries the scrolled origin — VisibleLeft/Top (or ViewLeft/Top)
+    // — so the overlay can subtract it and follow the cursor WITHOUT re-clicking.
+    // We return the whole bag verbatim: which field tracks scroll AND its unit
+    // (1/100 mm vs twips) is the open question to confirm on a real device, then
+    // bake CURSOR_MAP.viewDataToMm accordingly.
+    try {
+      const vd = xModel.getViewData && xModel.getViewData();
+      if (vd && typeof vd.getByIndex === 'function' && vd.getCount() > 0) {
+        const seq = vd.getByIndex(0);
+        const view = {};
+        if (seq && seq.length) for (let i = 0; i < seq.length; i++) {
+          const pv = seq[i];
+          if (pv && pv.Name != null) view[pv.Name] = pv.Value;
+        }
+        out.viewData = view;
+      }
+    } catch (e) { out.viewDataErr = errStr(e); }
     return out;
+  },
+  // [spike] probe 4b: LOAD performance of a 50-page docx (#56 余项). The existing
+  // testPerf times GENERATION; this times the docx IMPORT path: generate N pages,
+  // store to a .docx in MEMFS, then loadComponentFromURL it (replacing the visible
+  // doc) and time the load. Reports gen/save/load ms + page count. loadMs covers
+  // model load + initial layout trigger; Qt repaint/scroll smoothness still needs
+  // eyes on a real device. Heavy — may stress a headless sandbox (reboot if it
+  // hangs); the authoritative numbers come from a real machine.
+  perf_load(p) {
+    const pages = Number(p.pages) || 50;
+    const r = { success: true, pages: pages };
+    try {
+      const xText = xModel.getText();
+      const cur = xText.createTextCursor();
+      cur.gotoEnd(false);
+      const tGen = performance.now();
+      for (let pg = 0; pg < pages; pg++) {
+        for (let l = 0; l < 28; l++) {
+          xText.insertString(cur, '第' + (pg + 1) + '页 第' + (l + 1) + '行 合同条款示例 / contract clause sample line.', false);
+          xText.insertControlCharacter(cur, css.text.ControlCharacter.PARAGRAPH_BREAK, false);
+        }
+        try { cur.setPropertyValue('BreakType', css.style.BreakType.PAGE_AFTER); } catch (e) {}
+      }
+      r.genMs = Math.round(performance.now() - tGen);
+
+      const url = 'file:///tmp/perf_' + pages + '.docx';
+      const tSave = performance.now();
+      xModel.storeToURL(url, [mkProp('FilterName', 'MS Word 2007 XML')]);
+      r.saveMs = Math.round(performance.now() - tSave);
+
+      const tLoad = performance.now();
+      const loaded = desktop.loadComponentFromURL(url, '_default', 0, []);
+      r.loadMs = Math.round(performance.now() - tLoad);
+
+      // The loaded docx now owns the frame; retarget the worker's model/controller
+      // so subsequent commands act on what's actually displayed.
+      xModel = loaded;
+      ctrl = loaded.getCurrentController();
+      try { const vc = ctrl.getViewCursor(); vc.gotoEnd(false); r.pageCount = vc.getPage(); }
+      catch (e) { r.pageErr = errStr(e); }
+    } catch (e) { r.success = false; r.message = errStr(e); }
+    return r;
   },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {


### PR DESCRIPTION
## 中文

Track C：嵌入式 LibreOffice 编辑器打磨（Epic #43）。**全加法 / 休眠**——只在 spike 与验证窗口生效，**WPS 路径逐字节不变**，overlay 改动完全向后兼容（`editor-main.js` 未改）。承接 [#56](https://github.com/zeweihan/aiworkdeck/pull/56) Phase B 余项。

### 改了什么
**Worker（`office_thread.js`，产品 `public/` + spike 两份已同步）**
- `move_cursor {dir,extend}`：方向键 → `XTextCursor.goLeft/goRight` + `XViewCursor.goUp/goDown`（Shift = 扩选）。
- `delete_backward`：Backspace → 向左选一字并清除（有选区则删选区）；沿用当前 `RecordChanges` 状态。
- `get_cursor_rect`：新增返回 `viewData`（`VisibleTop/Left` 等），供 overlay 做**滚动感知 offset**。
- `perf_load {pages}`：测 **docx 导入路径**耗时（生成 → 存 .docx 入 MEMFS → `loadComponentFromURL`），报告 gen/save/load ms + 页数。

**Overlay（`zetaOfficeImeOverlay.js`）**
- 滚动感知映射 `px = origin + scale*(doc - scroll)`。`origin`（可见区左上角像素）仍按点击实时反解，但现在**滚动下保持稳定**——滚动文档后打字，候选框自动跟随光标，**无需再点一次**（修 #56 收口记的「滚动打乱锚点」限制）。无 `viewData` 时退回旧行为。新增 `CURSOR_MAP.viewDataToMm` 单位旋钮（默认 1）。
- 控制键转发：新增可选 `sendCommand(action,params)` 回调，Backspace→`delete_backward`、方向键→`move_cursor`。不传则按键落到（空的）input、文档不受影响——完全向后兼容。

**Spike（`index.html`）**：接 `sendCommand`、加「测50页加载 perf-load」按钮、打印滚动/单位标定提示。

### 已验证（沙箱）
- `npm run build:zetaoffice` 绿（9 模块）；两份 worker + overlay `node --check` 过。
- 滚动感知映射数学单测：无 viewData 时与旧行为逐位相等；滚动被吸收（框不动）；twips 单位换算与 `ViewTop` 回退均正确。
- spike 页面 `crossOriginIsolated:true` 加载、无 JS 报错、新按钮就位、overlay 接线解析正常。

### ⚠️ 待真机验证（沙箱无头标签跑不到 Qt canvas 就绪，本就需真机）
1. **控制键**：spike `node serve.mjs` → 点文档放光标 → Backspace 删字、←→↑↓ 移动光标（Shift+方向扩选）。
2. **滚动感知**：滚动长文后继续打字，候选框应自动跟随光标到正确位置而**无需再点**。若不跟随：控制台看 `measureCursor().viewData` 哪个字段随滚动变化、单位是否需设 `tuneCursorMap({viewDataToMm: 2540/1440})`（twips→1/100mm）。
3. **nudge 归零**：`tuneCursorMap({nudgeX,nudgeY})` 把红框压到真光标上，报数后焙进 `CURSOR_MAP` 默认值（承接 #56）。
4. **50 页加载性能**：点「测50页加载 perf-load」，记录 `loadMs`/`pageCount`（重负载，无头预览可能崩，重启即可）。

> 真机验证三数（viewDataToMm / nudgeX,nudgeY）回报后，焙进 `CURSOR_MAP` 默认值即 Phase B 收口。控制键的**应用内接线**（`editor-main.js` 经 endpoint 暴露 UI 命令通道）属并行宿主集成轨，故本 PR 未动——overlay 已为其留好 `sendCommand` 接口。

## English

Track C: embedded LibreOffice editor polish (Epic #43). **Additive / dormant** — active only in the spike + verify window; **WPS path byte-unchanged**; overlay changes fully backward-compatible (`editor-main.js` untouched). Picks up the #56 Phase B leftovers.

**Worker** (`office_thread.js`, product `public/` + spike copies in sync): `move_cursor` (arrows → goLeft/goRight/goUp/goDown, Shift=extend); `delete_backward` (Backspace); `get_cursor_rect` now also returns `viewData` for a scroll-aware offset; `perf_load` times the docx import path (generate → store .docx → reload).

**Overlay** (`zetaOfficeImeOverlay.js`): scroll-aware mapping `px = origin + scale*(doc - scroll)` — the click-derived origin is now stable under scroll so the box follows the cursor without re-clicking; degrades to prior behavior without `viewData`; new `CURSOR_MAP.viewDataToMm` unit knob. Control-key forwarding via optional `sendCommand` callback (absent → harmless input fallback).

**Verified in sandbox**: `build:zetaoffice` green; `node --check` all JS; scroll-aware math unit-checked; spike loads crossOriginIsolated with no JS errors.

**⚠️ Needs a real-device pass** (the headless tab can't complete the Qt canvas boot): (1) control keys actually edit/navigate; (2) scroll-follow + confirm the `viewData` scroll field/unit; (3) zero the `nudge` residual and bake it; (4) 50-page `perf_load` numbers. In-app wiring of control keys (endpoint UI-command channel in `editor-main.js`) belongs to the parallel host-integration track — the overlay already exposes `sendCommand` for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)