### PR TITLE
feat(libreoffice): load the user's real document into the embedded editor (Track D)

### DIFF
--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -39,6 +39,8 @@
 // (⌘⇧O overlay), so the WPS document flow is byte-for-byte unaffected.
 
 import { createWebviewEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
+import { getFileDownloadUrl } from '@/services/api.js'
+import { getAuthHeaders } from '@/utils/auth.js'
 
 let seq = 0
 
@@ -49,6 +51,11 @@ export default {
     // 'experimental' = the original ⌘⇧O overlay (dev probe toolbar shown).
     // 'default'      = inline document editor (Track B): toolbar chrome hidden.
     variant: { type: String, default: 'experimental' },
+    // Track D: the Office file to load into the editor ({ id, name, fileType,
+    // wpsFileId }). When set, the editor fetches its bytes (authed) and loads the
+    // REAL document once the office endpoint is ready. null (⌘⇧O overlay) keeps
+    // the seeded prototype.
+    file: { type: Object, default: null },
   },
   data() {
     return {
@@ -109,14 +116,64 @@ export default {
     onDomReady(wv) {
       if (this.executor) return // dom-ready can fire again on in-page navigation
       try {
-        this.executor = createWebviewEditorExecutor(wv)
-        this.ready = true
-        this.statusText = '就绪 / ready ✓'
-        this.appendLog('webview dom-ready — executor wired')
-        this.$emit('ready', this.executor)
+        // dom-ready means the webview's renderer is up — NOT that the office is
+        // booted. We wait for the endpoint-ready handshake (onReady) before
+        // marking ready / pushing the document, so load_document can't be dropped
+        // pre-boot. The dev-probe toolbar in the experimental variant stays
+        // disabled until then (ready=false).
+        this.executor = createWebviewEditorExecutor(wv, { onReady: () => this.onEndpointReady() })
+        this.statusText = this.file ? '加载文档中… / loading…' : '启动中… / booting…'
+        this.appendLog('webview dom-ready — executor wired, awaiting office endpoint')
       } catch (e) {
         this.appendLog('executor wiring failed: ' + (e && e.message ? e.message : e))
       }
+    },
+    // The office endpoint inside the webview is booted and serving. Load the real
+    // document (Track D) if we have one, then publish readiness so the host
+    // starts routing AI commands to the (now correctly-targeted) editor.
+    async onEndpointReady() {
+      if (!this.executor) return // unmounted during boot
+      if (this.file) {
+        try {
+          await this.loadDocument()
+        } catch (e) {
+          // Load failed → the seeded prototype is still showing. Surface it; the
+          // editor stays usable (AI/IME act on whatever is shown) but the content
+          // is wrong, so this is loud, not silent.
+          this.statusText = '文档加载失败 / load failed'
+          this.appendLog('load_document failed: ' + (e && e.message ? e.message : e))
+        }
+      }
+      this.ready = true
+      if (this.statusText.indexOf('失败') === -1) this.statusText = '就绪 / ready ✓'
+      this.$emit('ready', this.executor)
+    },
+    async loadDocument() {
+      const f = this.file
+      const fileId = f.wpsFileId || f.id
+      if (!fileId) throw new Error('file has no id/wpsFileId')
+      const url = getFileDownloadUrl(fileId)
+      const buf = await this.fetchArrayBuffer(url)
+      const bytes = new Uint8Array(buf)
+      const name = f.name || (String(fileId) + '.' + String(f.fileType || 'docx'))
+      this.appendLog('▶ load_document「' + name + '」(' + bytes.length + ' bytes) …')
+      const res = await this.executor.executeCommand('load_document', { bytes, name })
+      this.appendLog('  ← ' + JSON.stringify(res))
+      if (!res || !res.success) throw new Error((res && res.message) || 'load_document returned no success')
+    },
+    // Authed binary fetch — same XHR auth pattern as FilePreview.fetchAuthedBlob,
+    // but ArrayBuffer (the bytes we relay into the worker).
+    fetchArrayBuffer(url) {
+      return new Promise((resolve, reject) => {
+        const headers = getAuthHeaders() || {}
+        const xhr = new XMLHttpRequest()
+        xhr.open('GET', url, true)
+        xhr.responseType = 'arraybuffer'
+        Object.keys(headers).forEach((k) => xhr.setRequestHeader(k, headers[k]))
+        xhr.onload = () => (xhr.status === 200 ? resolve(xhr.response) : reject(new Error('HTTP ' + xhr.status)))
+        xhr.onerror = () => reject(new Error('网络错误 / network error'))
+        xhr.send()
+      })
     },
     async run(label, action, params) {
       if (!this.executor) return

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -21,6 +21,9 @@ export const EDITOR_ACTIONS = [
   'replace_nth_match', 'delete_match', 'delete_text', 'get_paragraph', 'modify_paragraph', 'get_outline', 'goto',
   // [§0.2 anchor-based] take {anchor} from find_text_locations; integer offsets rejected
   'set_selection', 'replace_at_position', 'clear_anchors',
+  // [Track D] load the user's real document into the editor (host-initiated, not
+  // an AI-agent command): {bytes, name} -> MEMFS + loadComponentFromURL + retarget.
+  'load_document',
 ]
 
 /**

--- a/frontend/src/composables/useZetaOfficeWebview.js
+++ b/frontend/src/composables/useZetaOfficeWebview.js
@@ -46,10 +46,12 @@ export function webviewTransport(webviewEl) {
  * useEditorBridge(EDITOR_WPS, { libreExecutor: createWebviewEditorExecutor(el) }).
  *
  * @param {HTMLElement} webviewEl an Electron <webview> DOM element.
- * @param {{timeoutMs?:number}} [opts]
+ * @param {{timeoutMs?:number, onReady?:()=>void}} [opts] onReady fires once the
+ *        editor endpoint inside the webview is booted and serving (Track D uses
+ *        it to gate load_document — see createRelayExecutor).
  * @returns {{executeCommand:(a:string,p?:object)=>Promise<any>, dispose:()=>void}}
  */
 export function createWebviewEditorExecutor(webviewEl, opts = {}) {
   const transport = webviewTransport(webviewEl)
-  return createRelayExecutor({ send: transport.send, subscribe: transport.subscribe, timeoutMs: opts.timeoutMs })
+  return createRelayExecutor({ send: transport.send, subscribe: transport.subscribe, timeoutMs: opts.timeoutMs, onReady: opts.onReady })
 }

--- a/frontend/src/composables/zetaOfficeRelay.js
+++ b/frontend/src/composables/zetaOfficeRelay.js
@@ -60,13 +60,20 @@ export function serveExecutor({ executor, send, subscribe }) {
  * @param {(handler:(msg:any)=>void)=>(()=>void)} args.subscribe register a
  *        webview-message handler; returns an unsubscribe fn.
  * @param {number} [args.timeoutMs=30000]
+ * @param {()=>void} [args.onReady] fired once when the webview endpoint signals
+ *        it is booted and serving ({type:'ready'}). The host uses this to know
+ *        when it may push commands that must not be dropped pre-boot (e.g. Track
+ *        D's load_document — sent before this, serveExecutor isn't subscribed yet).
  * @returns {{executeCommand:(a:string,p?:object)=>Promise<any>, dispose:()=>void}}
  */
-export function createRelayExecutor({ send, subscribe, timeoutMs = 30000 }) {
+export function createRelayExecutor({ send, subscribe, timeoutMs = 30000, onReady }) {
   let seq = 0
+  let readyCb = onReady
   const pending = new Map() // reqId -> {resolve, timer}
   const off = subscribe((msg) => {
-    if (!msg || msg.__lo !== TAG || msg.type !== 'result') return
+    if (!msg || msg.__lo !== TAG) return
+    if (msg.type === 'ready') { if (readyCb) { const cb = readyCb; readyCb = null; cb() } return }
+    if (msg.type !== 'result') return
     const entry = pending.get(msg.reqId)
     if (!entry) return
     clearTimeout(entry.timer)

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -701,6 +701,7 @@
                       v-else-if="useLibreEditor(activeFileLeft)"
                       :key="'libre-left-' + activeFileLeft.id"
                       variant="default"
+                      :file="activeFileLeft"
                       @ready="onLibreReady"
                       @close="onLibreClose"
                     />
@@ -771,6 +772,7 @@
                       v-else-if="useLibreEditor(activeFileRight)"
                       :key="'libre-right-' + activeFileRight.id"
                       variant="default"
+                      :file="activeFileRight"
                       @ready="onLibreReady"
                       @close="onLibreClose"
                     />

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -114,9 +114,12 @@ function wireVerifyPanel(executor) {
   }
 }
 
+// One transport instance, reused to both serve the host AND signal readiness.
+const hostTransport = pickTransport()
+
 startEditorEndpoint({
   canvas: document.getElementById('qtcanvas'),
-  transport: pickTransport(),
+  transport: hostTransport,
   sofficeBaseUrl: q.get('lowa') || 'https://cdn.zetaoffice.net/zetaoffice_latest/',
   zetaJsUrl: q.get('zeta') || './zeta.js',
   workerScriptUrl: q.get('worker') || './office_thread.js',
@@ -126,6 +129,11 @@ startEditorEndpoint({
   onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
 }).then((endpoint) => {
   console.log('[zeta-editor] endpoint ready — serving host over transport')
+  // Tell the host the office endpoint is booted and serving (serveExecutor is now
+  // subscribed). The host (createRelayExecutor onReady) waits for this before
+  // pushing load_document — sending it earlier would drop it (no subscriber yet,
+  // office not booted). Track D's real-file load is gated on this handshake.
+  try { hostTransport.send({ __lo: 'lo-relay', type: 'ready' }) } catch (e) { /* ignore */ }
   // Transparent IME overlay over the canvas, so users can type Chinese directly
   // in the document (Qt5-WASM gives the canvas no IME). Commits at the LO cursor
   // via the same verified path as agent commands. Attached in BOTH webview and

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -20,6 +20,7 @@
 let zetajs, css;
 let context, desktop, xModel, ctrl;
 let anchorSeq = 0; // names hidden bookmarks used as stable location anchors (§0.2)
+let docSeq = 0;    // names the MEMFS temp file for each loaded user document
 
 function post(cmd, data) {
   zetajs.mainPort.postMessage(Object.assign({ cmd }, data || {}));
@@ -483,6 +484,58 @@ const EXEC = {
       catch (e) { r.pageErr = errStr(e); }
     } catch (e) { r.success = false; r.message = errStr(e); }
     return r;
+  },
+  // [verified-extend] LOAD the user's REAL document (Track D). Replaces the
+  // seeded prototype with the bytes the host fetched (authed) from the backend.
+  // SAME store→load→retarget mechanism perf_load proved, but the bytes are the
+  // user's file (written into MEMFS via UNO SimpleFileAccess) instead of a
+  // generated docx. After loading we retarget the worker's model/controller so
+  // every subsequent command (AI redline, IME insert, cursor nav) acts on the
+  // real document, not the prototype.
+  load_document(p) {
+    const name = String(p && p.name || 'document.docx');
+    const m = name.match(/\.([A-Za-z0-9]+)$/);
+    const ext = (m ? m[1] : 'docx').toLowerCase();
+
+    // Normalize the transported bytes to the Int8Array a UNO sequence<byte>
+    // expects (zetajs maps sequence<byte> -> Int8Array). The host sends a
+    // Uint8Array; structured clone across the relay/worker hops may surface it
+    // as Uint8Array / ArrayBuffer / Array — accept all.
+    const raw = p && p.bytes;
+    let u8 = null;
+    if (raw instanceof ArrayBuffer) u8 = new Uint8Array(raw);
+    else if (raw && raw.buffer instanceof ArrayBuffer) u8 = new Uint8Array(raw.buffer, raw.byteOffset || 0, raw.byteLength != null ? raw.byteLength : raw.length);
+    else if (Array.isArray(raw)) u8 = new Uint8Array(raw);
+    if (!u8 || u8.length === 0) return { success: false, message: 'load_document: empty/invalid bytes' };
+    const bytes = new Int8Array(u8.buffer, u8.byteOffset, u8.byteLength);
+
+    try {
+      // Write the bytes into MEMFS, then load that file. UNO file IO to
+      // file:///tmp is the same path perf_load's storeToURL/loadComponentFromURL
+      // proved works under WASM.
+      const url = 'file:///tmp/ai_doc_' + (++docSeq) + '.' + ext;
+      const sfa = css.ucb.SimpleFileAccess.create(context);
+      try { if (sfa.exists(url)) sfa.kill(url); } catch (e) {}
+      const stream = css.io.SequenceInputStream.createStreamFromSequence(bytes);
+      sfa.writeFile(url, stream);
+      try { stream.closeInput(); } catch (e) {}
+
+      // '_default' replaces the visible (modified) prototype frame — same target
+      // and empty filter args (extension-based auto-detect) as perf_load.
+      const loaded = desktop.loadComponentFromURL(url, '_default', 0, []);
+      if (!loaded) return { success: false, message: 'loadComponentFromURL returned null for ' + url };
+
+      // Retarget so all subsequent UNO commands act on the loaded document.
+      xModel = loaded;
+      ctrl = loaded.getCurrentController();
+      try { ctrl.getFrame().getContainerWindow().FullScreen = true; } catch (e) {}
+      try { installKeyHandler(); } catch (e) {}
+
+      log('load_document: 已加载真实文档「' + name + '」/ loaded real document (' + u8.length + ' bytes)');
+      return { success: true, name: name, url: url, bytes: u8.length };
+    } catch (e) {
+      return { success: false, message: errStr(e) };
+    }
   },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {


### PR DESCRIPTION
## 摘要 / Summary

补通 LibreOffice 迁移的最后一块（Track D）：**把用户真实文件加载进嵌入式编辑器**。打开 Office 文档时编辑器显示**真实内容**，不再是空白样例原型。

Last piece before "local LibreOffice release usable on real documents". **Track B (#62, embedded editor as the default for Office docs) already merged to master** — this PR rebases on top of it and adds **real document loading**, so together they deliver "default editor + real-file loading", verified together per the maintainer's sequencing.

## 管线 / Pipeline

后端文件 → 宿主鉴权取字节 → 现有 relay → worker 加载进真 LibreOffice：

- **`office_thread.js`** (worker): new `EXEC.load_document({bytes, name})` — writes bytes into MEMFS via UNO `SimpleFileAccess` + `SequenceInputStream`, then `loadComponentFromURL` + retargets `xModel`/`ctrl`. Same store→load→retarget mechanism #63's `perf_load` proved under WASM — bytes are the user's file instead of a generated one.
- **`libreofficeExecutorClient.js`**: whitelist `load_document` in `EDITOR_ACTIONS`.
- **`zetaOfficeRelay.js` / `useZetaOfficeWebview.js` / `editor-main.js`**: an **endpoint-ready handshake**. The webview sends `{type:'ready'}` once the office is booted *and* `serveExecutor` is subscribed; `createRelayExecutor` exposes `onReady`. The host gates `load_document` on it, so the command can't be dropped pre-boot.
- **`LibreOfficeEditor.vue`**: new `file` prop. On endpoint-ready, fetch bytes (authed XHR, same pattern as `FilePreview.fetchAuthedBlob`, but ArrayBuffer) → `load_document` → then mark ready / emit. `file=null` (the ⌘⇧O experimental overlay) keeps the prototype, unchanged.
- **`project-overview.vue`**: pass `:file` to the two inline default editors (2 lines).

## 产权 / Scope & safety

- `desktop/` (getEditor IPC, preload) **untouched** — bytes travel the existing relay, so `getEditor` stays parameterless. `zeta.js` untouched.
- WPS path **byte-for-byte unchanged**; web/H5 cloud product unaffected (`libreOfficePreferred` is desktop-only, gated).

## 验证 / Verification

- ✅ `build:zetaoffice` green (9 modules) · `build:h5` green (`DONE Build complete`)
- ✅ relay endpoint-ready handshake unit-checked (fires once; bytes round-trip)
- ⏳ **真机端到端（沙箱跑不了 LOWA，须维护者验）/ real-device E2E (maintainer):**
  1. 装包 → 打开真实 `.docx` → 编辑器显示**真实文件内容**（不是「AI Workdeck × LibreOffice WASM 原型」样例）。状态 booting → loading → ready ✓；日志见 `load_document ← {success:true,...}`。
  2. 聊天发 AI「改文档」命令 → redline 落在**真实内容**上。
  3. IME 覆盖层打中文 → 上屏进真实文档。
  4. 若内容空白/错误：看编辑器右下角日志。关键设备未知项 = zetajs 是否如本 PR 用法暴露 `css.ucb.SimpleFileAccess.create` + `css.io.SequenceInputStream.createStreamFromSequence`（均为标准 UNO，与已用的 `Desktop.create(context)` 同形）；失败显示 `load_document ← {success:false, message:...}`。

## 后续 / Follow-ups (not in this PR)
- Reuse one booted webview across file switches instead of remount-per-file (`:key`).
- Transfer bytes (transferable) instead of structured-clone copy at each hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)