### PR TITLE
feat(libreoffice): consume a self-hosted LOWA engine via LOWA_BASE_URL (#66)

### DIFF
--- a/desktop/scripts/fetch-lowa-assets.js
+++ b/desktop/scripts/fetch-lowa-assets.js
@@ -15,10 +15,25 @@
 // with Brotli (content-encoding: br) and ignores Accept-Encoding: identity — the
 // bytes on the wire ARE brotli. The old proxy "just worked" because it forwarded
 // content-encoding and the browser decompressed. We keep that: the br files are
-// stored compressed (also keeps the bundle ~53 MB instead of ~165 MB raw) and a
-// sidecar lowa/.encodings.json tells the server to replay Content-Encoding: br.
-// Each download asserts the encoding it actually received matches what we expect,
-// so a CDN change trips the build instead of silently shipping garbage.
+// stored as received (also keeps the bundle ~53 MB instead of ~165 MB raw) and a
+// sidecar lowa/.encodings.json records the encoding to REPLAY when serving each
+// file, so zetaoffice-server.js sets Content-Encoding correctly. The sidecar is
+// written from the encoding ACTUALLY received per file (not hardcoded), so a
+// self-hosted engine shipped as raw bytes (identity) records no encoding and the
+// server serves it as plain wasm/data. The decoded-content magic check below is
+// what catches truncation / HTML error bodies / corrupt brotli.
+//
+// SOURCE (self-hosting a custom-built LOWA): LOWA_BASE_URL overrides where the 4
+// runtime files (soffice.js/.wasm/.data/.data.js.metadata) come from. Default is
+// the ZetaOffice CDN, so the build is byte-for-byte unchanged when it's unset.
+// Set it to self-host a LOWA you built yourself (e.g. one compiled --with-lang to
+// include zh-CN — issue #66). The base may be:
+//   - an https/http URL  (e.g. an Aliyun OSS bucket: https://<bucket>.oss-<region>.aliyuncs.com/lowa/)
+//   - a file:// directory (e.g. file:///abs/path/to/lowa-build-output/  — verify locally first)
+// A self-built soffice.data/.wasm is usually raw bytes (identity); that's fine —
+// the encoding is detected per file and the server serves identity as-is. The CJK
+// font (cjk.ttc) is unaffected by LOWA_BASE_URL; it always comes from FONT_URL.
+// See desktop/scripts/lowa-selfhost.md for the end-to-end self-hosting flow.
 //
 // Targets (under the dedicated Vite build output, dist/zetaoffice/, which
 // electron-builder ships via extraResources — package.json):
@@ -38,10 +53,26 @@
 
 const fs = require('fs');
 const path = require('path');
+const http = require('http');
 const https = require('https');
 const zlib = require('zlib');
+const { fileURLToPath } = require('url');
 
 const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/';
+
+// Where the LOWA runtime files come from. Default = the ZetaOffice CDN (so an
+// unset env keeps the build byte-identical). LOWA_BASE_URL self-hosts a custom
+// build — an https/http URL (e.g. Aliyun OSS) or a file:// directory. We force a
+// trailing slash so `base + 'soffice.js'` always joins correctly.
+const LOWA_BASE = withTrailingSlash(process.env.LOWA_BASE_URL || LOWA_CDN);
+const usingCustomBase = LOWA_BASE !== LOWA_CDN;
+
+function withTrailingSlash(s) { return s.endsWith('/') ? s : s + '/'; }
+
+// Content-encodings we know how to decode (for the magic check) AND replay (via
+// the sidecar). Anything else trips the build rather than shipping bytes the
+// server can't serve correctly. null = identity (raw bytes).
+const ALLOWED_ENCODINGS = new Set([null, 'br', 'gzip']);
 // Noto Sans SC Regular (OFL-1.1), pinned release tag, served via jsDelivr which
 // resolves the repo's Git-LFS blob to the real font bytes. SubsetOTF/SC = the
 // Simplified-Chinese subset (full SC coverage, ~8 MB) rather than the all-CJK
@@ -53,20 +84,34 @@ const distRoot = path.join(__dirname, '../../frontend/dist/zetaoffice');
 // serve: 'lowa'   -> served by /lowa/*; stored as received; encoding replayed.
 //        'static' -> served by the plain static handler (no encoding replay), so
 //                    it MUST be identity on disk (we request identity + assert).
-// encoding: the content-encoding we EXPECT (asserted against the response).
+// encoding: the content-encoding EXPECTED from the DEFAULT CDN; asserted only on
+//           the default path so a CDN change still trips the build. With a custom
+//           LOWA_BASE_URL the expected encoding is unknown, so we accept whatever
+//           the source actually sends (any ALLOWED_ENCODINGS) and record that.
 // magic: shape check applied to the DECOMPRESSED content.
 const ASSETS = [
-  { url: LOWA_CDN + 'soffice.js',               dest: 'lowa/soffice.js',               serve: 'lowa',   encoding: null, magic: 'js' },
-  { url: LOWA_CDN + 'soffice.wasm',             dest: 'lowa/soffice.wasm',             serve: 'lowa',   encoding: 'br', magic: 'wasm' },
-  { url: LOWA_CDN + 'soffice.data',             dest: 'lowa/soffice.data',             serve: 'lowa',   encoding: 'br', magic: 'blob' },
-  { url: LOWA_CDN + 'soffice.data.js.metadata', dest: 'lowa/soffice.data.js.metadata', serve: 'lowa',   encoding: null, magic: 'json' },
-  { url: FONT_URL,                              dest: 'cjk.ttc',                       serve: 'static', encoding: null, magic: 'font' },
+  { url: LOWA_BASE + 'soffice.js',               dest: 'lowa/soffice.js',               serve: 'lowa',   encoding: null, magic: 'js' },
+  { url: LOWA_BASE + 'soffice.wasm',             dest: 'lowa/soffice.wasm',             serve: 'lowa',   encoding: 'br', magic: 'wasm' },
+  { url: LOWA_BASE + 'soffice.data',             dest: 'lowa/soffice.data',             serve: 'lowa',   encoding: 'br', magic: 'blob' },
+  { url: LOWA_BASE + 'soffice.data.js.metadata', dest: 'lowa/soffice.data.js.metadata', serve: 'lowa',   encoding: null, magic: 'json' },
+  { url: FONT_URL,                               dest: 'cjk.ttc',                       serve: 'static', encoding: null, magic: 'font' },
 ];
+
+// Fetch a URL (http(s) or file://); resolves {encoding, body:Buffer}. file://
+// has no content-encoding, so it's always identity (null) — a self-built engine
+// dropped into a local directory is served raw.
+function fetchUrl(url, headers) {
+  if (url.startsWith('file://')) {
+    return Promise.resolve({ encoding: null, body: fs.readFileSync(fileURLToPath(url)) });
+  }
+  return get(url, headers);
+}
 
 // GET with up to 5 redirects; resolves {encoding, body:Buffer}.
 function get(url, headers, redirects = 0) {
+  const mod = url.startsWith('http://') ? http : https;
   return new Promise((resolve, reject) => {
-    const req = https.request(url, { method: 'GET', headers }, (res) => {
+    const req = mod.request(url, { method: 'GET', headers }, (res) => {
       const sc = res.statusCode || 0;
       if (sc >= 300 && sc < 400 && res.headers.location && redirects < 5) {
         res.resume();
@@ -116,48 +161,83 @@ function checkMagic(raw, magic, dest) {
   }
 }
 
-// True if an on-disk file already decodes + validates (idempotent re-runs).
+// Encoding each baked file was stored with, from the sidecar a previous run
+// wrote (basename -> encoding). Authoritative for idempotent re-runs on the
+// default CDN: a brotli blob must be decoded as br to validate, and 'blob'/'js'
+// magic is too lenient to infer that from the bytes alone. Missing/stale -> the
+// file just re-downloads.
+function loadExistingEncodings() {
+  try { return JSON.parse(fs.readFileSync(path.join(distRoot, 'lowa/.encodings.json'), 'utf8')); }
+  catch (e) { return {}; }
+}
+const existingEncodings = loadExistingEncodings();
+
+// If an on-disk file already decodes + validates, return {enc} (the encoding it
+// was stored with, for re-recording); else null (re-download).
 function cachedOk(destPath, a) {
+  const enc = existingEncodings[path.basename(a.dest)] || null;
   try {
-    checkMagic(decode(fs.readFileSync(destPath), a.encoding), a.magic, destPath);
-    return true;
-  } catch (e) { return false; }
+    checkMagic(decode(fs.readFileSync(destPath), enc), a.magic, destPath);
+    return { enc };
+  } catch (e) { return null; }
 }
 
+// Returns { size, enc } — enc is the content-encoding the bytes are stored with
+// (null = identity), used to build the sidecar.
 async function fetchAsset(a) {
   const destPath = path.join(distRoot, a.dest);
-  if (fs.existsSync(destPath) && cachedOk(destPath, a)) {
-    const mb = (fs.statSync(destPath).size / 1048576).toFixed(1);
-    console.log('  = ' + a.dest + ' (cached, ' + mb + ' MB on disk)');
-    return fs.statSync(destPath).size;
+  // Cache only on the default path; a custom LOWA_BASE_URL may point at a
+  // different engine than whatever is already on disk, so always re-fetch.
+  if (!usingCustomBase && fs.existsSync(destPath)) {
+    const hit = cachedOk(destPath, a);
+    if (hit) {
+      const mb = (fs.statSync(destPath).size / 1048576).toFixed(1);
+      console.log('  = ' + a.dest + ' (cached, ' + mb + ' MB on disk)');
+      return { size: fs.statSync(destPath).size, enc: hit.enc };
+    }
   }
   process.stdout.write('  ↓ ' + a.dest + ' …');
   // 'static' assets are served without encoding replay, so insist on identity.
   const reqHeaders = a.serve === 'static' ? { 'Accept-Encoding': 'identity' } : {};
-  const { encoding, body } = await get(a.url, reqHeaders);
+  const { encoding, body } = await fetchUrl(a.url, reqHeaders);
   const enc = encoding || null;
-  if (enc !== a.encoding) {
+  // Default CDN: assert the encoding we expect, so a CDN change trips the build.
+  // Custom LOWA_BASE_URL: the encoding is unknown, so accept whatever the source
+  // sends as long as we can decode + replay it (checked next).
+  if (!usingCustomBase && enc !== a.encoding) {
     throw new Error(a.dest + ': expected content-encoding ' + JSON.stringify(a.encoding) +
       ' but CDN sent ' + JSON.stringify(enc) + ' (serving would corrupt; aborting)');
+  }
+  if (!ALLOWED_ENCODINGS.has(enc)) {
+    throw new Error(a.dest + ': content-encoding ' + JSON.stringify(enc) +
+      ' is not supported (expected identity, br, or gzip)');
+  }
+  // 'static' files are served without encoding replay, so they must be identity.
+  if (a.serve === 'static' && enc !== null) {
+    throw new Error(a.dest + ': static asset must be identity but source sent ' + JSON.stringify(enc));
   }
   checkMagic(decode(body, enc), a.magic, a.dest);
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
   fs.writeFileSync(destPath + '.part', body);
   fs.renameSync(destPath + '.part', destPath);
   console.log(' ' + (body.length / 1048576).toFixed(1) + ' MB' + (enc ? ' (' + enc + ')' : ''));
-  return body.length;
+  return { size: body.length, enc };
 }
 
 async function main() {
   console.log('Fetching LOWA runtime + CJK font into ' + distRoot);
-  let total = 0;
-  for (const a of ASSETS) total += await fetchAsset(a);
+  if (usingCustomBase) console.log('  LOWA source: ' + LOWA_BASE + ' (LOWA_BASE_URL)');
 
-  // Sidecar so zetaoffice-server.js replays Content-Encoding for the files the
-  // CDN pre-compressed (otherwise the browser gets brotli bytes as raw wasm).
+  // Build the sidecar from the encoding ACTUALLY stored per file, so a
+  // self-hosted identity engine records nothing (served raw) while the CDN's
+  // brotli files record 'br'. zetaoffice-server.js replays these on serve;
+  // without it the browser would get brotli bytes as raw wasm and fail to boot.
+  let total = 0;
   const encodings = {};
   for (const a of ASSETS) {
-    if (a.serve === 'lowa' && a.encoding) encodings[path.basename(a.dest)] = a.encoding;
+    const { size, enc } = await fetchAsset(a);
+    total += size;
+    if (a.serve === 'lowa' && enc) encodings[path.basename(a.dest)] = enc;
   }
   fs.writeFileSync(path.join(distRoot, 'lowa/.encodings.json'), JSON.stringify(encodings) + '\n');
 

--- a/desktop/scripts/lowa-selfhost.md
+++ b/desktop/scripts/lowa-selfhost.md
@@ -1,0 +1,102 @@
+# 自托管 LOWA 引擎（替换 CDN）/ Self-hosting the LOWA engine
+
+> 中文在前，English below.
+
+嵌入式 LibreOffice 编辑器（LOWA / ZetaOffice WASM）默认从
+`https://cdn.zetaoffice.net/zetaoffice_latest/` 下载运行时，焙进安装包离线使用。
+上游 CDN 的引擎是 `--with-lang=en-US` 单语编译，**UI 全英文且运行期改不动**
+（详见 issue #66）。要得到中文原生 UI，需要**自建一个含 zh-CN 的 LOWA**，然后让构建
+脚本从你自己的来源拉取，而不是 CDN。
+
+`desktop/scripts/fetch-lowa-assets.js` 为此加了一个环境变量 **`LOWA_BASE_URL`**：
+
+- **不设**（默认）：从 ZetaOffice CDN 拉取，行为与历史**逐字节一致**。
+- **设了**：从该 base 拉取 4 个 LOWA 运行时文件
+  （`soffice.js` / `soffice.wasm` / `soffice.data` / `soffice.data.js.metadata`）。
+  base 可以是 **https/http URL** 或 **`file://` 本地目录**，**必须**能直接拼接文件名
+  （脚本自动补尾部 `/`）。CJK 字体 `cjk.ttc` 不受影响，始终从 `FONT_URL` 拉取。
+
+> 自建产物（`desktop/lowa-build/`，由另一条工作线在 ≥64GB 机器/云 VM 上构建）多半是
+> **裸字节（identity，未 brotli 压缩）**。脚本按**实际拿到的 content-encoding** 写
+> `lowa/.encodings.json`——identity 文件不写编码，`zetaoffice-server.js` 就直接当裸
+> wasm/data 发，不做 brotli 回放。无需手工改任何编码配置。
+
+## 怎么把自建产物接上来 / How to wire up a self-built engine
+
+构建机产出 4 个文件后，有两条路径：
+
+### 优先方案：阿里云 OSS（自托管 https）
+
+1. 在阿里云 OSS 建一个 bucket（或复用现有），开公共读，传入 4 个文件，例如放在
+   `lowa/` 前缀下：
+   ```
+   lowa/soffice.js
+   lowa/soffice.wasm
+   lowa/soffice.data
+   lowa/soffice.data.js.metadata
+   ```
+   裸字节直接上传即可（不要让 OSS 给它们设 `Content-Encoding: br`，除非文件确实是
+   brotli——脚本会按实际编码处理，但 identity 最简单）。
+2. 构建时把 `LOWA_BASE_URL` 指向该前缀（**注意尾部斜杠**）：
+   ```sh
+   export LOWA_BASE_URL="https://<bucket>.oss-<region>.aliyuncs.com/lowa/"
+   cd /绝对路径/aiworkdeck && node desktop/scripts/fetch-lowa-assets.js
+   # 然后照常 cd frontend && npm run build:zetaoffice && npm run build:h5
+   # 再 electron-builder 打包
+   ```
+3. CI 里同理：把 `LOWA_BASE_URL` 设为仓库/环境变量（或 secret），在
+   `fetch-lowa-assets.js` 步骤之前导出。不设则继续走 CDN。
+
+### 先本地验证：`file://` 目录
+
+接 OSS 之前，先用本地目录验证 4 个文件能被脚本接受、能打进 bundle：
+
+```sh
+export LOWA_BASE_URL="file:///绝对路径/to/lowa-build-output/"   # 目录里直接放 4 个文件
+cd /绝对路径/aiworkdeck && node desktop/scripts/fetch-lowa-assets.js
+cat frontend/dist/zetaoffice/lowa/.encodings.json   # 裸字节应为 {} ；含 br 的才会列出
+```
+
+`file://` 一律按 identity 处理（本地文件没有 content-encoding 概念）。
+
+## 校验与排错 / Validation
+
+- 脚本对每个文件做 **magic / shape 校验**（wasm 头 `\0asm`、JSON 以 `{` 开头、字体头、
+  非空大小），解压后再校验——截断、HTML 错误页、坏 brotli 都会让构建**直接失败**，
+  不会悄悄发坏包。
+- 支持的编码：`identity`（裸字节）、`br`、`gzip`；其它编码会报错中止。
+- `static` 资产（字体）必须是 identity。
+- 默认 CDN 路径仍**断言**期望编码（wasm/data=br），CDN 变更会让构建失败；自定义
+  `LOWA_BASE_URL` 时编码未知，接受任意可解码/可回放的编码并按实际记录。
+
+**真机验收**：沙箱/CI 起不了 LOWA（无显示器、office 线程 ~2-3 分钟/次），中文 UI
+是否生效**只能在装包后真机确认**——这一步留给打包验收。
+
+---
+
+## English summary
+
+The embedded LibreOffice editor (LOWA / ZetaOffice WASM) is baked into the desktop
+app at build time by `desktop/scripts/fetch-lowa-assets.js`, defaulting to the
+ZetaOffice CDN. The CDN engine is English-only (`--with-lang=en-US`, baked at
+compile time — see issue #66), so a Chinese UI requires a **self-built LOWA** that
+you host yourself.
+
+Set **`LOWA_BASE_URL`** to override the source of the 4 runtime files
+(`soffice.js`, `soffice.wasm`, `soffice.data`, `soffice.data.js.metadata`):
+
+- **Unset (default):** fetch from the CDN — byte-for-byte unchanged.
+- **Set:** fetch from that base — an `https`/`http` URL (e.g. an Aliyun OSS bucket)
+  or a `file://` directory. A trailing `/` is added automatically. The CJK font is
+  unaffected (always from `FONT_URL`).
+
+A self-built `soffice.data`/`.wasm` is usually **raw bytes (identity)**. The script
+records the **actual** content-encoding per file into `lowa/.encodings.json`, so
+identity files get no encoding and `zetaoffice-server.js` serves them raw — no
+brotli replay, no manual config.
+
+**Preferred:** upload the 4 files to an Aliyun OSS bucket (public read) and point
+`LOWA_BASE_URL` at the prefix (with trailing slash). **Verify locally first** with a
+`file://` directory. Magic/shape checks fail the build on truncation or wrong
+encoding. Chinese UI can only be confirmed on a real packaged build (LOWA can't boot
+in CI/sandbox).


### PR DESCRIPTION
## 背景 / Context

接 issue #66：嵌入式 LibreOffice 编辑器（LOWA / ZetaOffice WASM）的 UI 全英文，已证实上游 CDN 引擎是 `--with-lang=en-US` 单语编译、**UI 语言编译期烧死、运行期改不动**（三方实测见日志）。结论＝**自建含 zh-CN 的 LOWA 自托管替换 CDN**。自建产物由另一条工作线在 ≥64GB 机器/云 VM 上构建（`desktop/lowa-build/`，本 PR **不碰**）。

本 PR 是**并行的"消费侧"集成**：让构建脚本能从自建来源拉取引擎，而不是 CDN。**加法式、可回退、默认仍走 CDN**。

This is the consumer-side integration for #66: let the build fetch the LOWA runtime from a self-hosted source instead of the ZetaOffice CDN, so a self-built zh-CN engine can replace the English-only CDN build. Additive, reversible, CDN by default.

## 改动 / Changes

- **`desktop/scripts/fetch-lowa-assets.js`**
  - 新增环境变量 **`LOWA_BASE_URL`**：覆盖 4 个 LOWA 文件（`soffice.js/.wasm/.data/.data.js.metadata`）的来源。base 可为 **https/http URL**（如阿里云 OSS）或 **`file://` 本地目录**，自动补尾部 `/`。CJK 字体不受影响（仍 `FONT_URL`）。
  - **按实际编码写 `.encodings.json`**（不再硬编码 `br`）：自建裸字节（identity）产物不记录编码 → `zetaoffice-server.js` 直接当裸 wasm/data 发，不做 brotli 回放。默认 CDN 路径仍**断言**期望编码（CDN 变更即让构建失败）；自定义 base 接受 identity/br/gzip 任一。magic/shape 校验**沿用**。缓存校验读旧 sidecar（br 文件仍能复验）；自定义 base 每次重拉（来源可能不同）。
- **`desktop/scripts/lowa-selfhost.md`**（新）：双语 runbook——优先方案＝传阿里云 OSS bucket + `LOWA_BASE_URL` 指过去；先 `file://` 本地验证；校验/排错；真机验收说明。

## 验证 / Verification

- ✅ `node --check desktop/scripts/fetch-lowa-assets.js`
- ✅ `npm run build:zetaoffice`（9 模块，绿）
- ✅ `npm run build:h5`（绿；仅既有 Sass 弃用警告。worktree 缺 `docx-preview`(#60) → `npm install docx-preview --no-save` 即解，非本 PR 问题）
- ✅ **默认（不设 `LOWA_BASE_URL`）逐字节一致**：仍从 CDN 拉，`.encodings.json` = `{"soffice.wasm":"br","soffice.data":"br"}`（与现状相同）；二次运行全 cached、幂等。
- ✅ **`file://` identity 来源**：4 文件按 identity 处理，`.encodings.json` = `{}`（服务端发裸字节）。
- ⏳ **真机中文 UI**：沙箱/CI 起不了 LOWA（无显示器、office 线程 ~2-3min/次），中文 UI 生效与否留待**自建引擎落地后真机验收**。

## 不涉及 / Out of scope

- 不碰 `claude/musing-ritchie-72d03e` 分支与 `desktop/lowa-build/`（自建引擎由另一 session 产出）。
- 本 PR 只做"消费接口"，自建引擎产物落地后把 `LOWA_BASE_URL` 指过去即可启用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)