### PR TITLE
chore(release): v0.3.0 — 自建 zh-CN 引擎入包 + 保存管线 / self-built Chinese engine + save pipeline

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -64,6 +64,12 @@ jobs:
           npm run build:zetaoffice
       - name: Bake LOWA runtime + OFL CJK font into the editor bundle (offline)
         shell: bash
+        env:
+          # Self-built zh-CN LOWA engine (issue #66): native Chinese UI incl. Qt
+          # tooltips + FS/callMain exports. Hosted on the project site (versioned,
+          # immutable; wasm/data served brotli so the installer stays small).
+          # Unset -> upstream CDN (English UI). Build recipe: desktop/lowa-build/.
+          LOWA_BASE_URL: https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r2/
         run: |
           # Track A (Epic #43): download the LibreOffice WASM runtime (soffice.*)
           # into dist/zetaoffice/lowa and an OFL-licensed CJK font (Noto Sans SC)

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 发版内容 / Release scope

**v0.3.0 = LibreOffice 本地编辑器里程碑版**:

1. **CI 焙入自建 zh-CN 引擎**(替代上游英文 CDN):`LOWA_BASE_URL=https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r2/`
   - 原生中文 UI(菜单/工具栏/对话框/**tooltip**)——上游 CDN 引擎为 en-US 单语编译,运行期不可改(#66 定论)
   - 版本化 immutable 路径;wasm/data 服务器端 brotli 存储+回放 → **安装包体积与 CDN 焙包持平**(本机端到端验证:解压 sha 与构建产物逐字节一致)
   - 引擎仅构建期下载;用户运行时零依赖该地址
2. **版本 bump 0.2.3 → 0.3.0**(minor:默认编辑器能力实质变化——中文 UI + 真实文档加载(#64)+ **保存回后端**(#69))

## 本 PR 的 Desktop Build 即是发版彩排

PR 触发的 Desktop Build 会首次从官网拉自建引擎焙包(看 bake 步骤日志应有 `(br)` 标记)+ mac 签名公证(协议已续签)。绿了 → 合并 → tag `v0.3.0` → 自动出 Release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)