### PR TITLE
feat(ai-editor): 拟人式动作原语 — AI 对 LibreOffice 的完整操作

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -280,6 +280,41 @@ public class AgentOrchestrator {
                  return wpsTools.wps_delete_text(text, deleteAll);
             } else if ("wps_debug_revisions".equals(toolName)) {
                  return wpsTools.wps_debug_revisions();
+            // ==================== 拟人式原语（LibreOffice 编辑器） ====================
+            } else if ("wps_get_document_text".equals(toolName)) {
+                 Integer startParagraph = safeParseInt(extractArg(args, "startParagraph"), "startParagraph");
+                 Integer maxParagraphs = safeParseInt(extractArg(args, "maxParagraphs"), "maxParagraphs");
+                 return wpsTools.wps_get_document_text(startParagraph, maxParagraphs);
+            } else if ("wps_get_cursor_context".equals(toolName)) {
+                 return wpsTools.wps_get_cursor_context();
+            } else if ("wps_select_anchor".equals(toolName)) {
+                 return wpsTools.wps_select_anchor(extractArg(args, "anchorId"));
+            } else if ("wps_select_paragraph".equals(toolName)) {
+                 return wpsTools.wps_select_paragraph(safeParseInt(extractArg(args, "index"), "index"));
+            } else if ("wps_collapse_cursor".equals(toolName)) {
+                 return wpsTools.wps_collapse_cursor(extractArg(args, "to"));
+            } else if ("wps_replace_at_anchor".equals(toolName)) {
+                 return wpsTools.wps_replace_at_anchor(extractArg(args, "anchorId"), extractArg(args, "newText"));
+            } else if ("wps_delete_selection".equals(toolName)) {
+                 return wpsTools.wps_delete_selection();
+            } else if ("wps_format_selection".equals(toolName)) {
+                 return wpsTools.wps_format_selection(
+                         safeParseBool(extractArg(args, "bold")),
+                         safeParseBool(extractArg(args, "italic")),
+                         safeParseBool(extractArg(args, "underline")),
+                         safeParseBool(extractArg(args, "strikeout")),
+                         extractArg(args, "highlight"),
+                         extractArg(args, "color"),
+                         safeParseDouble(extractArg(args, "fontSize")),
+                         extractArg(args, "fontName"));
+            } else if ("wps_set_paragraph_format".equals(toolName)) {
+                 return wpsTools.wps_set_paragraph_format(
+                         extractArg(args, "alignment"),
+                         safeParseInt(extractArg(args, "headingLevel"), "headingLevel"));
+            } else if ("wps_undo".equals(toolName)) {
+                 return wpsTools.wps_undo(safeParseInt(extractArg(args, "steps"), "steps"));
+            } else if ("wps_redo".equals(toolName)) {
+                 return wpsTools.wps_redo(safeParseInt(extractArg(args, "steps"), "steps"));
             // ==================== PPTX 文件管理工具 ====================
             } else if ("list_project_folders".equals(toolName)) {
                  return pptxTools.list_project_folders(projectId);
@@ -1231,6 +1266,26 @@ public class AgentOrchestrator {
             return Integer.parseInt(value.trim());
         } catch (NumberFormatException e) {
             log.warn("Failed to parse {} as Integer: {}", argName, value);
+            return null;
+        }
+    }
+
+    /**
+     * 可空 Boolean 解析（缺省参数保持 null，不误传 false）
+     */
+    private Boolean safeParseBool(String value) {
+        if (value == null || value.isEmpty()) return null;
+        return Boolean.valueOf(value.trim());
+    }
+
+    /**
+     * 可空 Double 解析
+     */
+    private Double safeParseDouble(String value) {
+        if (value == null || value.isEmpty()) return null;
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
             return null;
         }
     }

--- a/backend/src/main/java/com/checkba/service/ai/tools/WpsTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WpsTools.java
@@ -254,7 +254,8 @@ public class WpsTools {
 
     // ==================== 查找和替换 ====================
 
-    @Tool("在 WPS 文档中查找指定文本，返回所有匹配位置的列表（start, end）。建议配合 wps_set_selection 使用。")
+    @Tool("【找】在文档中查找文本。每个匹配返回：anchorId（稳定锚点，编辑后依然有效）、前后文 contextBefore/contextAfter、所在段落 paragraph。" +
+          "有多个匹配时先根据上下文确认哪一个才是目标，再用 anchorId 配合 wps_select_anchor（选中查看）或 wps_replace_at_anchor（精准替换）操作。")
     public String wps_find_text(
             @P("要查找的文本") String keyword,
             @P("是否区分大小写，默认 false") Boolean matchCase
@@ -491,6 +492,190 @@ public class WpsTools {
             
         } catch (Exception e) {
             log.error("Failed to search related docs", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    // ==================== 拟人式原语（嵌入式 LibreOffice 编辑器） ====================
+    // 设计文档：docs/AI_EDITOR_PRIMITIVES.md。工作循环：看 → 找 → 选 → 改 → 验。
+    // 定位一律使用 wps_find_text 返回的 anchorId（书签锚点，随文档编辑自动跟随），
+    // 禁止使用整数字符偏移（跨富文本必然错位）。
+
+    @Tool("【看】分段读取文档正文。返回带编号的段落列表（含标题级别），是了解文档内容的首选工具。" +
+          "文档很长时结果会分页：返回 truncated=true 和 nextStartParagraph，用它继续读下一段。")
+    public String wps_get_document_text(
+            @P("起始段落号（0 开始，默认 0）") Integer startParagraph,
+            @P("最多返回的段落数（默认 200）") Integer maxParagraphs
+    ) {
+        log.info("Tool: wps_get_document_text called start={}, max={}", startParagraph, maxParagraphs);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            if (startParagraph != null) params.put("startParagraph", startParagraph);
+            if (maxParagraphs != null) params.put("maxParagraphs", maxParagraphs);
+            return wpsActionService.executeWpsCommand("get_document_text", params);
+        } catch (Exception e) {
+            log.error("Failed to get document text", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【看】查看当前光标/选区周围的文本（选中内容、前后文、所在段落）。在插入或格式化之前先确认光标位置。")
+    public String wps_get_cursor_context() {
+        log.info("Tool: wps_get_cursor_context called");
+        try {
+            return wpsActionService.executeWpsCommand("get_cursor_context", null);
+        } catch (Exception e) {
+            log.error("Failed to get cursor context", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【选】选中 wps_find_text 返回的某个匹配（按 anchorId）。编辑器会滚动到该处并高亮选区，用户能看到 AI 正在操作哪里。" +
+          "选中后可接 wps_replace_selection / wps_delete_selection / wps_format_selection / wps_collapse_cursor。")
+    public String wps_select_anchor(
+            @P("wps_find_text 返回的 anchorId") String anchorId
+    ) {
+        log.info("Tool: wps_select_anchor called anchor={}", anchorId);
+        try {
+            return wpsActionService.executeWpsCommand("set_selection",
+                    java.util.Map.of("anchor", anchorId != null ? anchorId : ""));
+        } catch (Exception e) {
+            log.error("Failed to select anchor", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【选】按段落号选中整个段落（0 开始，配合 wps_get_document_text 的编号）。编辑器会滚动到该段落并高亮。")
+    public String wps_select_paragraph(
+            @P("段落号（0 开始）") Integer index
+    ) {
+        log.info("Tool: wps_select_paragraph called index={}", index);
+        try {
+            return wpsActionService.executeWpsCommand("select_paragraph",
+                    java.util.Map.of("index", index != null ? index : 0));
+        } catch (Exception e) {
+            log.error("Failed to select paragraph", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【选】把光标落到当前选区的开头或结尾（取消选中）。要在某处'之前/之后'插入文本时：先选中目标，再 collapse 到 start/end，然后 wps_insert_at_cursor。")
+    public String wps_collapse_cursor(
+            @P("start=选区开头, end=选区结尾") String to
+    ) {
+        log.info("Tool: wps_collapse_cursor called to={}", to);
+        try {
+            return wpsActionService.executeWpsCommand("collapse_selection",
+                    java.util.Map.of("to", to != null ? to : "end"));
+        } catch (Exception e) {
+            log.error("Failed to collapse cursor", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【改】把某个锚点（anchorId）处的文本替换为新文本，以修订模式进行。返回改动后所在段落的实际文本，务必核对确认改对了。" +
+          "这是最精准的替换方式：先 wps_find_text 拿到带上下文的匹配列表，选定目标的 anchorId 后用本工具替换。")
+    public String wps_replace_at_anchor(
+            @P("wps_find_text 返回的 anchorId") String anchorId,
+            @P("新文本") String newText
+    ) {
+        log.info("Tool: wps_replace_at_anchor called anchor={}", anchorId);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("anchor", anchorId != null ? anchorId : "");
+            params.put("newText", newText != null ? newText : "");
+            return wpsActionService.executeWpsCommand("replace_at_position", params);
+        } catch (Exception e) {
+            log.error("Failed to replace at anchor", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【改】删除当前选中的文本（以修订模式）。先用 wps_select_anchor / wps_select_paragraph 选中要删的内容。没有选区时会报错。")
+    public String wps_delete_selection() {
+        log.info("Tool: wps_delete_selection called");
+        try {
+            return wpsActionService.executeWpsCommand("delete_selection", null);
+        } catch (Exception e) {
+            log.error("Failed to delete selection", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【格式】给当前选中的文本设置字符格式：加粗/斜体/下划线/删除线/高亮/字色/字号/字体。只传需要改的参数。" +
+          "必须先选中文本（wps_select_anchor / wps_select_paragraph）。高亮支持 yellow/green/cyan/magenta/red/blue/gray/none 或 #RRGGBB；none 取消高亮。")
+    public String wps_format_selection(
+            @P("加粗 true/false，不改则不传") Boolean bold,
+            @P("斜体 true/false，不改则不传") Boolean italic,
+            @P("下划线 true/false，不改则不传") Boolean underline,
+            @P("删除线 true/false，不改则不传") Boolean strikeout,
+            @P("高亮颜色：yellow/green/cyan/magenta/red/blue/gray/none 或 #RRGGBB，不改则不传") String highlight,
+            @P("文字颜色：#RRGGBB 或 auto，不改则不传") String color,
+            @P("字号（磅），不改则不传") Double fontSize,
+            @P("字体名，不改则不传") String fontName
+    ) {
+        log.info("Tool: wps_format_selection called");
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            if (bold != null) params.put("bold", bold);
+            if (italic != null) params.put("italic", italic);
+            if (underline != null) params.put("underline", underline);
+            if (strikeout != null) params.put("strikeout", strikeout);
+            if (highlight != null && !highlight.isEmpty()) params.put("highlight", highlight);
+            if (color != null && !color.isEmpty()) params.put("color", color);
+            if (fontSize != null) params.put("fontSize", fontSize);
+            if (fontName != null && !fontName.isEmpty()) params.put("fontName", fontName);
+            return wpsActionService.executeWpsCommand("format_selection", params);
+        } catch (Exception e) {
+            log.error("Failed to format selection", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【格式】设置当前选区所在段落的段落格式：对齐方式和/或标题级别。" +
+          "headingLevel: 1-9 设为对应级别标题，0 恢复正文。alignment: left/right/center/justify。")
+    public String wps_set_paragraph_format(
+            @P("对齐：left/right/center/justify，不改则不传") String alignment,
+            @P("标题级别：1-9 为标题，0 恢复正文，不改则不传") Integer headingLevel
+    ) {
+        log.info("Tool: wps_set_paragraph_format called alignment={}, headingLevel={}", alignment, headingLevel);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            if (alignment != null && !alignment.isEmpty()) params.put("alignment", alignment);
+            if (headingLevel != null) params.put("headingLevel", headingLevel);
+            return wpsActionService.executeWpsCommand("set_paragraph_format", params);
+        } catch (Exception e) {
+            log.error("Failed to set paragraph format", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【验/撤销】撤销最近的编辑操作。改错了（核对返回的段落文本发现不对）就用它退回，再重新操作。")
+    public String wps_undo(
+            @P("撤销步数，默认 1") Integer steps
+    ) {
+        log.info("Tool: wps_undo called steps={}", steps);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            if (steps != null) params.put("steps", steps);
+            return wpsActionService.executeWpsCommand("undo", params);
+        } catch (Exception e) {
+            log.error("Failed to undo", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【验/撤销】重做刚撤销的操作。")
+    public String wps_redo(
+            @P("重做步数，默认 1") Integer steps
+    ) {
+        log.info("Tool: wps_redo called steps={}", steps);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            if (steps != null) params.put("steps", steps);
+            return wpsActionService.executeWpsCommand("redo", params);
+        } catch (Exception e) {
+            log.error("Failed to redo", e);
             return "Error: " + e.getMessage();
         }
     }

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -375,93 +375,116 @@ for file_id in file_ids:
 ## 6. Memory (`add_memory`, `query_knowledge_base`)
 - Store and retrieve knowledge from RAG
 
-## 7. WPS 文档编辑
+## 7. 文档编辑（嵌入式 LibreOffice 编辑器）
 
-你具备直接编辑用户项目中 WPS 文档的能力，如同另一个编辑者在与用户协同工作。
+你具备直接编辑用户项目中文档的能力，如同一个坐在文档前的人类编辑：移动光标、选中、修改、排版。用户能在编辑器里**实时看到**你的光标跳转和选区高亮。
 
 ### 核心原则 (CORE PRINCIPLES)
 1. **修改优先 (Edit in-place)**: 除非用户明确要求"新建一个文件"，否则**必须**在原文件上进行修改。
 2. **禁止重写 (No Re-creation)**: 禁止通过 `write_docx` 创建一个名为 "xxx(修订版).docx" 的新文件来替代修改。必须打开原文件进行修订。
+3. **修订模式默认开启**: 你的所有改动都以修订痕迹（redline）呈现，用户可逐条接受或拒绝。放心修改，不会破坏原文。
+4. **拟人式工作循环（必须遵守）**: **看 → 找 → 选 → 改 → 验**。
+   - **看**：先用 `wps_get_document_text` / `wps_get_outline` 了解文档，别盲改；
+   - **找**：用 `wps_find_text` 定位，**根据每个匹配的上下文（contextBefore/contextAfter/paragraph）确认哪一个才是目标**；
+   - **选**：用 anchorId 选中目标（`wps_select_anchor`），用户看得见你选了哪里；
+   - **改**：替换/删除/插入/格式化；
+   - **验**：**核对工具返回的 paragraphAfterEdit**，确认改对了；改错就 `wps_undo` 退回重来。
 
 ### 可用工具
+
+**看（感知文档）**
 
 | 工具 | 用途 |
 |-----|------|
 | `wps_list_project_files(projectId)` | 列出项目中的所有可编辑文档（docx, xlsx 等） |
-| `wps_open_file(fileId)` | 打开指定文档进行编辑（在用户的 WPS 编辑器中打开） |
+| `wps_open_file(fileId)` | 打开指定文档进行编辑 |
 | `wps_search_related_docs(keyword, projectId)` | 搜索项目中可能需要修改的相关文档 |
-| `wps_get_selection()` | 获取用户当前选中的文本和位置 |
-| `wps_goto(type, target)` | 移动光标到指定位置（paragraph/bookmark/start/end/line） |
-| `wps_find_text(keyword, matchCase)` | 在文档中查找文本 |
-| `wps_find_replace(findText, replaceText, replaceAll)` | 查找并替换文本（replaceAll=true 全部替换，false 仅替换第一个） |
-| `wps_replace_nth_match(findText, replaceText, matchIndex)` | 替换第 N 个可见的匹配项（索引从1开始，用于精确定位替换） |
-| `wps_delete_match(findText, matchIndex)` | 删除第 N 个可见的匹配项（**删除专用**，索引从1开始） |
-| `wps_delete_text(text, deleteAll)` | 删除文本（**删除专用**，deleteAll=true 删除所有，false 仅删除第一个） |
-| `wps_insert_at_cursor(text)` | 在光标位置插入文本 |
-| `wps_get_paragraph(paragraphIndex)` | 获取指定段落的内容 |
-| `wps_modify_paragraph(paragraphIndex, newText)` | 修改指定段落的内容 |
+| `wps_get_document_text(startParagraph, maxParagraphs)` | **首选**：分段读取全文（带段落编号和标题级别），长文档分页读 |
 | `wps_get_outline()` | 获取文档大纲结构 |
+| `wps_get_selection()` | 获取用户当前选中的文本 |
+| `wps_get_cursor_context()` | 查看光标周围的文本（前后文、所在段落） |
+| `wps_get_paragraph(paragraphIndex)` | 获取指定段落的内容（0 开始） |
+
+**找（定位目标）**
+
+| 工具 | 用途 |
+|-----|------|
+| `wps_find_text(keyword, matchCase)` | 查找文本。每个匹配返回 **anchorId**（稳定锚点）+ 前后文 + 所在段落，多个匹配时靠上下文分辨目标 |
+
+**选（移动光标/选区，用户可见）**
+
+| 工具 | 用途 |
+|-----|------|
+| `wps_select_anchor(anchorId)` | 选中某个匹配，编辑器滚动到该处并高亮 |
+| `wps_select_paragraph(index)` | 按段落号选中整段 |
+| `wps_collapse_cursor(to)` | 光标落到选区开头(start)/结尾(end)——在目标"之前/之后"插入时用 |
+| `wps_goto(type, target)` | 光标到文档开头/结尾（start/end） |
+
+**改（编辑，全部带修订痕迹）**
+
+| 工具 | 用途 |
+|-----|------|
+| `wps_replace_at_anchor(anchorId, newText)` | **最精准的替换**：替换指定锚点处的文本，返回改后段落全文供核对 |
+| `wps_replace_selection(text)` | 替换当前选区内容 |
+| `wps_delete_selection()` | 删除当前选中的文本（先选中再删） |
+| `wps_insert_at_cursor(text)` | 在光标位置插入文本 |
+| `wps_find_replace(findText, replaceText, replaceAll)` | 全局查找替换（确认无歧义时才用 replaceAll=true） |
+| `wps_replace_nth_match(findText, replaceText, matchIndex)` | 替换第 N 个匹配（索引从 1 开始） |
+| `wps_delete_match(findText, matchIndex)` / `wps_delete_text(text, deleteAll)` | 按匹配删除文本 |
+| `wps_modify_paragraph(paragraphIndex, newText)` | 整段改写（0 开始） |
 | `wps_insert_under_heading(headingText, content)` | 在指定标题下方插入内容 |
-| `wps_set_selection(start, end)` | 设置选区范围（start/end 为 0-based 字符索引） |
-| `wps_replace_selection(text)` | 替换当前选区内容为新文本 |
-| `wps_start_stream(fileId, fileName)` | **[NEW] 开启实时流式写入模式**。新建文件时：`wps_start_stream(fileId=null, fileName="文件名.docx")`；打开现有文件：`wps_start_stream(fileId=123)` |
+| `wps_start_stream(fileId, fileName)` | 实时流式写入模式（新建长文档用） |
+
+**格式（先选中，再排版）**
+
+| 工具 | 用途 |
+|-----|------|
+| `wps_format_selection(bold, italic, underline, strikeout, highlight, color, fontSize, fontName)` | 字符格式：加粗/斜体/下划线/删除线/**高亮**/字色/字号/字体，只传要改的参数 |
+| `wps_set_paragraph_format(alignment, headingLevel)` | 段落格式：对齐（left/right/center/justify）、标题级别（1-9，0=正文） |
+
+**验/撤销（安全网）**
+
+| 工具 | 用途 |
+|-----|------|
+| `wps_undo(steps)` / `wps_redo(steps)` | 撤销/重做最近的编辑 |
 
 ### 使用规范
 
 1. **修改前先打开文档**：使用 `wps_open_file` 打开需要编辑的文档
-2. **直接替换模式**：AI 操作时**不使用修订模式**，所有修改会直接替换文本，不会显示修订痕迹
-3. **先了解上下文**：在修改前，使用 `wps_get_selection` 或 `wps_get_paragraph` 了解当前内容
-4. **精确定位**：使用 `wps_goto` 或 `wps_find_text` 定位到正确位置再操作
-5. **批量联动修改**：当修改一处内容时，使用 `wps_search_related_docs` 搜索可能需要同步修改的相关文档
+2. **禁止使用字符偏移定位**：一律使用 `wps_find_text` 返回的 anchorId 或段落号；不要自己数字符位置
+3. **多个匹配必须先消歧**：`wps_find_text` 返回多个匹配时，逐个核对 contextBefore/contextAfter，确定目标后再操作；拿不准就先 `wps_select_anchor` 选中看一眼
+4. **每次修改后核对返回结果**：改动类工具会返回 `paragraphAfterEdit`（改后段落实文），发现不对立刻 `wps_undo` 并重新定位
+5. **格式化前必须有选区**：先 `wps_select_anchor` / `wps_select_paragraph`，再 `wps_format_selection`
+6. **批量联动修改**：当修改一处内容时，使用 `wps_search_related_docs` 搜索可能需要同步修改的相关文档
 
 ### 典型场景
 
-#### 查找与替换场景
+**精准替换（多个相同文本，只改其中一个）**
+- 用户说"把付款条款里的'30日'改成'45日'" →
+  1. `wps_find_text("30日")` → 返回 3 个匹配，各带上下文
+  2. 根据 paragraph/context 判断哪个匹配在付款条款里
+  3. `wps_replace_at_anchor(目标anchorId, "45日")`
+  4. 核对返回的 paragraphAfterEdit
 
-**场景1：全部替换**
-- 用户说"把所有的'该公司'改成'目标公司'" → 用 `wps_find_replace("该公司", "目标公司", true)` 全部替换
-- 用户说"把'甲方'全部替换为'买方'" → 用 `wps_find_replace("甲方", "买方", true)` 全部替换
+**全部替换（无歧义）**
+- 用户说"把所有'甲方'替换为'买方'" → `wps_find_replace("甲方", "买方", true)`
 
-**场景2：仅替换第一个**
-- 用户说"把第一个'该公司'改成'目标公司'" → 用 `wps_find_replace("该公司", "目标公司", false)` 仅替换第一个
-- 用户说"只替换开头的'甲方'" → 用 `wps_find_replace("甲方", "买方", false)` 仅替换第一个
+**删除**
+- 用户说"删掉'其他约定'那一段" → `wps_get_document_text` 找到段落号 → `wps_select_paragraph(index)` 选中给用户看 → `wps_delete_selection()`
 
-**场景3：替换第N个指定的匹配项**
-- 用户说"把第3个'该公司'改成'目标公司'" → 用 `wps_replace_nth_match("该公司", "目标公司", 3)` 替换第3个
-- 用户说"替换第2个'甲方'为'买方'" → 用 `wps_replace_nth_match("甲方", "买方", 2)` 替换第2个
-- 用户说"把倒数第2个'乙方'改为'承包商'" → 先用 `wps_find_text` 查找所有匹配位置，确定倒数第2个的索引，再用 `wps_replace_nth_match`
+**高亮/格式**
+- 用户说"把违约金那句加黄色高亮" → `wps_find_text("违约金")` → `wps_select_anchor(anchorId)` → `wps_format_selection(highlight="yellow")`
+- 用户说"这一段改成二级标题并加粗" → `wps_select_paragraph(index)` → `wps_set_paragraph_format(headingLevel=2)` → `wps_format_selection(bold=true)`
 
-**场景4：删除操作（必须使用删除专用工具）**
-- 用户说"删除所有的'拟'字" → **必须**用 `wps_delete_text("拟", true)` 而不是 find_replace
-- 用户说"删除第3个'临时'" → 用 `wps_delete_match("临时", 3)` 删除第3个匹配项
-- 用户说"删除第一个'草案'" → 用 `wps_delete_text("草案", false)` 或 `wps_delete_match("草案", 1)`
-
-#### 文档编辑场景
-
-- 用户说"帮我把第三段的表述改得更专业" → 先用 `wps_get_paragraph(3)` 获取内容，理解后用 `wps_modify_paragraph(3, newText)` 修改
-- 用户说"在这里插入一个总结" → 用 `wps_insert_at_cursor(text)` 在当前位置插入
-- 用户说"修改董事会决议中的交易方案" → 先用 `wps_search_related_docs("交易方案", projectId)` 找到所有相关文档，然后依次打开并修改
-
-### 替换工具选择决策树
-
-当用户要求替换文本时，按照以下逻辑选择工具：
-
-```
-用户请求：替换/修改文本
-    ↓
-是否指定了具体位置（如"第3个"、"倒数第2个"）？
-    ├─ 是 → 使用 wps_replace_nth_match(findText, replaceText, matchIndex)
-    └─ 否 → 是否要求全部替换？
-        ├─ 是（"全部"、"所有"、"每一个"） → 使用 wps_find_replace(findText, replaceText, true)
-        └─ 否（仅替换第一个或未明确说明） → 使用 wps_find_replace(findText, replaceText, false)
-```
+**在某处之后插入**
+- 用户说"在定义条款后面加一条" → `wps_find_text("定义")` 定位 → `wps_select_anchor(anchorId)` → `wps_collapse_cursor("end")` → `wps_insert_at_cursor("\n新条款…")`
 
 ### 重要提示
 
-1. **删除操作必须使用删除专用工具**：`wps_delete_match` 或 `wps_delete_text`，不要用 `wps_find_replace` 替换为空字符串
-2. **替换前可以先查找**：使用 `wps_find_text(keyword)` 查看所有匹配位置，帮助确定正确的 matchIndex
-3. **索引从1开始**：`wps_replace_nth_match` 和 `wps_delete_match` 的 matchIndex 从 1 开始计数
-4. **直接替换**：AI 操作时会自动关闭修订模式，所有修改直接生效，不会显示修订痕迹
+1. **anchorId 是一次性书签**：来自最近一次 `wps_find_text`；文档大改后建议重新查找获取新锚点
+2. **删除操作使用删除专用工具**：`wps_delete_selection` / `wps_delete_match` / `wps_delete_text`，不要用 `wps_find_replace` 替换为空字符串
+3. **索引口径**：`wps_replace_nth_match` / `wps_delete_match` 的 matchIndex 从 **1** 开始；段落号（`wps_get_document_text` / `wps_select_paragraph` / `wps_get_paragraph` / `wps_modify_paragraph`）从 **0** 开始
+4. **修订痕迹**：所有改动带修订痕迹，用户可接受/拒绝；无需也不要尝试关闭修订模式
 
 ## 8. PPT 演示文稿操作
 

--- a/docs/AI_EDITOR_PRIMITIVES.md
+++ b/docs/AI_EDITOR_PRIMITIVES.md
@@ -1,0 +1,102 @@
+# AI ↔ LibreOffice 拟人式动作原语协议
+
+> 目标：让 AI panel 像一个坐在文档前的人类编辑那样操作嵌入式 LibreOffice——移动光标、选中、
+> 修改、排版，用户全程看得见。本文是原语集的设计依据与协议契约。
+>
+> 关联：docs/LIBREOFFICE_MIGRATION_PLAN.md（RFC v2，§0.2 锚点论）、frontend/src/zetaoffice/README.md（管线架构）。
+
+## 1. 为什么 WPS 时代"找不到 / 替换错"
+
+| 病根 | 机制 | 后果 |
+|------|------|------|
+| 整数偏移定位 | JS 纯文本 `indexOf` 算出的 offset 映射到富文本 Range | 分页符/隐藏字符/表格标记不计入纯文本，映射系统性错位 → **替换错位置** |
+| 匹配无上下文 | 查找只返回位置数字 | 5 个相同的"甲方"无法分辨，AI 只能猜 → **改错对象** |
+| 无验证回路 | 改完不返回改动处新状态 | AI 盲飞，错了也不知道 → **错误累积** |
+| 修订模式冲突 | AI 操作需关闭修订 | 用户分不清 AI 改了什么 |
+
+## 2. 设计原则
+
+1. **锚点，不是偏移（§0.2）**：定位一律用书签锚点（`anchorId`），随文档编辑自动跟随；worker 显式拒绝整数偏移。
+2. **拟人式五步循环**：看 → 找 → 选 → 改 → 验。AI 的每一步都对应人类编辑的一个动作。
+3. **操作可见**：选中/跳转通过视图光标完成（`gotoRange`），编辑器滚动到目标、选区高亮——用户看得见 AI 的"手"在哪。
+4. **修订默认开**：`RecordChanges=true` 在文档 boot/load 时统一设置，所有改动都是可接受/拒绝的修订痕迹。
+5. **每次改动带验证快照**：改动类命令返回 `paragraphAfterEdit`（改后所在段落实文），AI 据此核对；错了用 `undo` 退回。
+6. **最小原语 + 组合**：不做"在 X 后插入 Y"这类复合命令；用 `选中 X → collapse 到 end → 插入 Y` 组合，语义清晰且可视。
+
+## 3. 原语清单（worker `office_thread.js` EXEC 契约）
+
+### 看（感知）
+| action | 参数 | 返回 |
+|--------|------|------|
+| `get_document_text` | `{startParagraph?, maxParagraphs?}` | 带编号段落列表（含标题级别），长文分页（`truncated`/`nextStartParagraph`），单次 ≤15k 字符 |
+| `get_cursor_context` | `{radius?}` | 选中文本、光标前后文、所在段落 |
+| `get_outline` | — | 标题层级列表 |
+| `get_selection` | — | 当前选区文本 |
+| `find_text_locations` | `{keyword, matchCase?}` | 每个匹配：`anchorId` + `contextBefore/After`(40字) + `paragraph`(160字) + `matchIndex`，≤200 个 |
+
+### 移（定位，用户可见）
+| action | 参数 | 说明 |
+|--------|------|------|
+| `set_selection` | `{anchor}` | 选中锚点范围，视图滚动跟随；返回选中文本+上下文 |
+| `select_paragraph` | `{index}` | 选中第 N 段（0 起） |
+| `collapse_selection` | `{to:'start'\|'end'}` | 光标落到选区边缘（"之前/之后插入"的前置动作） |
+| `goto` | `{type:'start'\|'end'}` | 文档头尾 |
+| `move_cursor` | `{dir, extend?}` | 单步移动（IME 层也在用） |
+
+### 改（编辑，全部落修订痕迹）
+| action | 参数 | 验证返回 |
+|--------|------|---------|
+| `insert_at_cursor` | `{text}` | `paragraphAfterEdit` |
+| `replace_selection` | `{text}` | `paragraphAfterEdit` |
+| `replace_at_position` | `{anchor, newText}` | `paragraphAfterEdit` |
+| `delete_selection` | — | `deletedText` + `paragraphAfterEdit`；无选区时报错（先选再删） |
+| `insert_paragraph` | — | 段落分隔符 |
+| `find_replace` / `replace_nth_match` / `delete_match` / `delete_text` / `modify_paragraph` | （沿用） | modify_paragraph 增加 `paragraphAfterEdit` |
+| `undo` / `redo` | `{steps?}` | 撤销/重做 + 快照 |
+
+### 饰（格式，先选中再作用于选区）
+| action | 参数 | 说明 |
+|--------|------|------|
+| `format_selection` | `{bold?, italic?, underline?, strikeout?, highlight?, color?, fontSize?, fontName?}` | 只传要改的参数；`highlight` 支持色名/`#RRGGBB`/`none`；CJK 同步设置 `*Asian/*Complex` 属性 |
+| `set_paragraph_format` | `{alignment?, styleName?, headingLevel?}` | `headingLevel` 1-9 → `Heading N`（programmatic 名，与 UI 语言无关），0 → `Standard` |
+
+## 4. 全链路
+
+```
+LLM @Tool (WpsTools.java)
+  → AgentOrchestrator.executeNativeTool（手工分发表）
+  → WpsActionService.executeWpsCommand → SSE client_action
+  → useAgentStream → ChatInterface → project-overview.handleWpsCommand
+  → (LibreOffice 激活) libreofficeExecutorClient → relay → webview
+  → office_thread.js EXEC[action]（UNO） → 结果原路回传 → LLM 核对
+```
+
+新增后端工具（与 worker action 的映射）：
+
+| @Tool | worker action |
+|-------|---------------|
+| `wps_get_document_text` | `get_document_text` |
+| `wps_get_cursor_context` | `get_cursor_context` |
+| `wps_select_anchor` | `set_selection` |
+| `wps_select_paragraph` | `select_paragraph` |
+| `wps_collapse_cursor` | `collapse_selection` |
+| `wps_replace_at_anchor` | `replace_at_position` |
+| `wps_delete_selection` | `delete_selection` |
+| `wps_format_selection` | `format_selection` |
+| `wps_set_paragraph_format` | `set_paragraph_format` |
+| `wps_undo` / `wps_redo` | `undo` / `redo` |
+
+提示词（`prompts/system_prompt.md` §7）已整节重写为拟人循环 + 消歧规范 + 验证规范。
+
+## 5. 修订模式下的读数口径（重要）
+
+`RecordChanges=true` 且显示修订时，被"删除"的文本仍留在文档流中（带删除线），因此：
+- `get_document_text` / `paragraphAfterEdit` 会同时包含删除痕迹与新文本（与用户屏幕所见一致）；
+- 替换后核对时应检查**新文本已出现**，而不是旧文本已消失；
+- 用户接受修订后读数即恢复"干净"。
+
+## 6. 自测
+
+自动化端到端验证（真实 LOWA 引擎 + 无头浏览器驱动 `window.__loExecutor`，verify 模式暴露）：
+构建 `npm run build:zetaoffice` → COOP/COEP 本地服务（bundle + 自托管引擎）→
+`editor.html?verify=1&lowa=/lowa/` → 逐条原语断言。结果见 PR 描述。

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -21,6 +21,15 @@ export const EDITOR_ACTIONS = [
   'replace_nth_match', 'delete_match', 'delete_text', 'get_paragraph', 'modify_paragraph', 'get_outline', 'goto',
   // [§0.2 anchor-based] take {anchor} from find_text_locations; integer offsets rejected
   'set_selection', 'replace_at_position', 'clear_anchors',
+  // [拟人式原语] anthropomorphic primitive set (docs/AI_EDITOR_PRIMITIVES.md):
+  // perceive (get_document_text/get_cursor_context), position visibly
+  // (select_paragraph/collapse_selection), edit (delete_selection), format
+  // (format_selection/set_paragraph_format), recover (undo/redo).
+  'get_document_text', 'get_cursor_context', 'select_paragraph', 'collapse_selection',
+  'delete_selection', 'format_selection', 'set_paragraph_format', 'undo', 'redo',
+  // [spike/IME] implemented by the worker since Phase B but never whitelisted
+  // (found by the primitive self-test: "Unknown action: move_cursor").
+  'move_cursor', 'delete_backward', 'insert_paragraph', 'get_cursor_rect',
   // [Track D] load the user's real document into the editor (host-initiated, not
   // an AI-agent command): {bytes, name} -> MEMFS + loadComponentFromURL + retarget.
   'load_document',

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -126,12 +126,23 @@ export function bootZetaOffice(options = {}) {
       canvas,
       uno_scripts: [zetaJsUrl, workerScriptUrl],
       locateFile: function (path, prefix) { return (prefix || sofficeBaseUrl) + path },
-      preRun: injections.length ? [function () {
-        // Runs before LibreOffice init. /instdir is NOT mounted yet at this point
-        // (FS / = tmp,home,dev,proc) but creating the dir tree and writing here
-        // WORKS: the LOWA data mount MERGES into MEMFS rather than replacing, so
-        // the files are present when LibreOffice scans at startup. PROVEN for the
-        // font (tofu 口口 -> real Chinese glyphs); the langpack uses the same path.
+      // ALWAYS an array: LOWA's soffice.js prologue does `if(!("preRun" in
+      // Module))Module["preRun"]=[]; Module.preRun.push(...)` — a present-but-
+      // undefined preRun key crashes the engine head with "Cannot read
+      // properties of undefined (reading 'push')" and the boot never starts.
+      preRun: [],
+      // Inject font/langpack AFTER the data package is mounted but BEFORE
+      // LibreOffice main() runs (so fontconfig's startup scan still sees the
+      // font). This CANNOT be a preRun hook: preRun runs before the package
+      // loader processes soffice.data, and any injected path that ALSO exists in
+      // the package (e.g. a self-built engine with the zh-CN langpack baked in,
+      // issue #66) makes the loader's FS_createDataFile throw EEXIST — the
+      // preload stalls forever and the editor never boots. At
+      // onRuntimeInitialized the package files are in MEMFS and FS.writeFile
+      // simply overwrites content, so baked-in engines and runtime injection
+      // coexist.
+      onRuntimeInitialized: function () {
+        if (!injections.length) return
         const FS = globalThis.FS
         const mkdirp = (dir) => {
           const parts = dir.split('/').filter(Boolean)
@@ -146,12 +157,16 @@ export function bootZetaOffice(options = {}) {
             n++
           } catch (e) { log('FS write failed for ' + f.path + ': ' + e) }
         }
-        log('MEMFS injected ' + n + '/' + injections.length + ' file(s) (font + zh-CN langpack) before boot')
-      }] : undefined,
+        log('MEMFS injected ' + n + '/' + injections.length + ' file(s) (font + zh-CN langpack) before main()')
+      },
     }
     if (sofficeBaseUrl !== '') {
+      // Absolutize: this URL is imported from inside a BLOB worker, where a
+      // relative/root path ('/lowa/soffice.js') is invalid — pthread spawn dies
+      // with "The URL ... is invalid" and the office thread never starts.
+      const absBase = new URL(sofficeBaseUrl, globalThis.location ? globalThis.location.href : undefined).href
       Module.mainScriptUrlOrBlob = new Blob(
-        ["importScripts('" + sofficeBaseUrl + "soffice.js');"], { type: 'text/javascript' })
+        ["importScripts('" + absBase + "soffice.js');"], { type: 'text/javascript' })
     }
     globalThis.Module = Module
 

--- a/frontend/src/zetaoffice/README.md
+++ b/frontend/src/zetaoffice/README.md
@@ -71,3 +71,23 @@ host (project-overview)                     isolated <webview partition="persist
    Route `handleWpsCommand` through `editor.executeCommand(action, params, { wpsInstance })`
    and call `editor.setEditor(EDITOR_LIBREOFFICE)` behind a gray-rollout flag.
 5. **IME overlay** + **perf** (load an existing 50-page docx) — separate #43 tasks.
+
+## AI 拟人式动作原语（2026-07）
+
+`office_thread.js` 的 EXEC 契约扩展为完整的拟人式原语集（看→找→选→改→验），
+设计与协议见 **docs/AI_EDITOR_PRIMITIVES.md**：
+
+- 感知：`get_document_text`（编号段落、分页）、`get_cursor_context`、升级版
+  `find_text_locations`（锚点 + 前后文 + 所在段落，用于同词多处消歧）
+- 定位（用户可见）：`set_selection`（视图跟随滚动）、`select_paragraph`、
+  `collapse_selection`
+- 编辑（修订默认开，boot/load 时设 `RecordChanges=true`）：`delete_selection`、
+  `insert_at_cursor`/`replace_selection`（`\n` 转段落分隔）、`undo`/`redo`
+- 格式：`format_selection`（粗/斜/下划线/删除线/高亮/字色/字号/字体，CJK 同步
+  Asian/Complex 属性）、`set_paragraph_format`（对齐 + `Heading N` 样式）
+
+改动类命令返回 `paragraphAfterEdit` 验证快照。后端对应 `wps_*` 新工具见
+`WpsTools.java`；提示词工作流见 `prompts/system_prompt.md` §7。
+
+全部原语已在真实 LOWA 引擎（自建 zh-CN 24.2.8）+ 无头/有头 Chrome 上端到端
+验证（`editor.html?verify=1` 暴露 `window.__loExecutor` 供自动化驱动）。

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -149,7 +149,13 @@ startEditorEndpoint({
       onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
     })
   } catch (e) { console.error('[zeta-editor] IME overlay failed:', e); if (VERIFY) vlog('IME overlay failed: ' + (e && e.message || e)) }
-  if (VERIFY) wireVerifyPanel(endpoint.executor)
+  if (VERIFY) {
+    wireVerifyPanel(endpoint.executor)
+    // Automation hook: lets a headless-browser test driver call the executor
+    // directly (window.__loExecutor.executeCommand(...)) to exercise every
+    // primitive against the real LOWA engine. Verify mode only.
+    window.__loExecutor = endpoint.executor
+  }
 }).catch((e) => {
   console.error('[zeta-editor] boot failed:', e)
   if (VERIFY) vlog('boot failed: ' + (e && e.message ? e.message : e))

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -78,6 +78,101 @@ function anchorRange(name) {
   return bms.getByName(name).getAnchor(); // XTextRange
 }
 
+// ---- 拟人式原语 helpers（感知/验证回路） ------------------------------------
+// Context around a range: the chars immediately before/after, read via a text
+// cursor spawned FROM THE RANGE'S OWN XText (so matches inside table cells /
+// frames read their local story, not the body text). This is what lets the AI
+// tell five identical "甲方" hits apart — the WPS-era failure mode.
+function contextAround(range, radius) {
+  const n = Math.max(1, Math.min(Number(radius) || 50, 200));
+  const out = { before: '', after: '' };
+  try {
+    const t = range.getText();
+    const b = t.createTextCursorByRange(range.getStart());
+    b.goLeft(n, true);
+    out.before = b.getString();
+    const a = t.createTextCursorByRange(range.getEnd());
+    a.goRight(n, true);
+    out.after = a.getString();
+  } catch (e) { out.ctxErr = errStr(e); }
+  return out;
+}
+// The paragraph text enclosing a range (start point), for match disambiguation
+// and post-edit verification. XParagraphCursor via createTextCursorByRange.
+function paragraphTextOf(range) {
+  try {
+    const t = range.getText();
+    const cur = t.createTextCursorByRange(range.getStart());
+    cur.gotoStartOfParagraph(false);
+    cur.gotoEndOfParagraph(true);
+    return cur.getString();
+  } catch (e) { return null; }
+}
+// Enumerate body paragraphs, calling fn(el, index); fn returns true to stop.
+function eachParagraph(fn) {
+  const en = xModel.getText().createEnumeration();
+  let i = 0;
+  while (en.hasMoreElements()) {
+    const el = en.nextElement();
+    if (el.supportsService && el.supportsService('com.sun.star.text.Paragraph')) {
+      if (fn(el, i)) return;
+      i++;
+    }
+  }
+}
+// Select a range THE WAY A HUMAN WOULD: the view cursor jumps there (the view
+// scrolls to it) and the selection is visibly painted. gotoRange(range, false)
+// makes the view cursor span the range — the standard "select the found hit"
+// idiom. Falls back to ctrl.select if the view cursor balks (e.g. range in a
+// story the view cursor can't enter).
+function selectVisibly(range) {
+  try { ctrl.getViewCursor().gotoRange(range, false); return true; }
+  catch (e) { try { ctrl.select(range); return true; } catch (e2) { return false; } }
+}
+// Insert text at the view cursor, honoring '\n' as a PARAGRAPH BREAK.
+// XText.insertString does NOT split paragraphs on '\n' (verified against the
+// real engine: a multi-line insert landed as ONE paragraph), so multi-paragraph
+// inserts must interleave insertControlCharacter(PARAGRAPH_BREAK).
+function insertTextAtCursor(vc, text) {
+  const xText = xModel.getText();
+  const parts = String(text).split('\n');
+  for (let i = 0; i < parts.length; i++) {
+    if (i > 0) xText.insertControlCharacter(vc, css.text.ControlCharacter.PARAGRAPH_BREAK, false);
+    if (parts[i]) xText.insertString(vc, parts[i], false);
+  }
+}
+
+// Shared verification snapshot returned by mutating commands: where the cursor
+// is now + the paragraph as it reads AFTER the edit ("改完看一眼").
+function verifySnapshot() {
+  try {
+    const vc = ctrl.getViewCursor();
+    return { paragraphAfterEdit: paragraphTextOf(vc), selectedText: vc.getString() };
+  } catch (e) { return {}; }
+}
+
+// ---- 格式原语的取值映射 ------------------------------------------------------
+const HIGHLIGHT_COLORS = { // CharHighlight RGB; 'none' clears (-1)
+  yellow: 0xFFFF00, green: 0x00FF00, cyan: 0x00FFFF, magenta: 0xFF00FF,
+  red: 0xFF0000, blue: 0x0000FF, gray: 0xC0C0C0, none: -1,
+};
+function parseColor(v, names) {
+  if (v == null) return null;
+  const s = String(v).trim().toLowerCase();
+  if (names && s in names) return names[s];
+  if (s === 'auto') return -1;
+  const m = s.match(/^#?([0-9a-f]{6})$/);
+  return m ? parseInt(m[1], 16) : null;
+}
+// Set a char property together with its Asian/Complex siblings so CJK runs
+// (the product's main language) pick up the format too.
+function setCharProp(ps, base, value) {
+  ps.setPropertyValue(base, value);
+  for (const sfx of ['Asian', 'Complex']) {
+    try { ps.setPropertyValue(base + sfx, value); } catch (e) { /* not all props have siblings */ }
+  }
+}
+
 // ---- boot: open a fresh BLANK Writer doc ----------------------------------
 // Production: a brand-new / empty document must show a clean blank page (the
 // host loads real bytes via load_document when the file has content). We do NOT
@@ -90,6 +185,10 @@ function bootDoc() {
   xModel = desktop.loadComponentFromURL('private:factory/swriter', '_default', 0, []);
   ctrl = xModel.getCurrentController();
   try { ctrl.getFrame().getContainerWindow().FullScreen = true; } catch {}
+  // RFC v2: revisions default ON — every edit (AI or typed) lands as a tracked
+  // change the lawyer can accept/reject. Set once here (and on retarget) instead
+  // of per-command, so no edit path can slip through untracked.
+  try { xModel.setPropertyValue('RecordChanges', true); } catch {}
 
   installKeyHandler();
   post('ui_ready');
@@ -207,22 +306,21 @@ function testInsertText(text) {
 const EXEC = {
   // [verified] insert at the view cursor (append, not select) — see testInsertText.
   insert_at_cursor(p) {
-    const xText = xModel.getText();
     const vc = ctrl.getViewCursor();
     vc.collapseToEnd();
-    xText.insertString(vc, String(p.text || ''), false);
+    insertTextAtCursor(vc, p.text || '');
     vc.collapseToEnd();
-    return { success: true, inserted: String(p.text || '') };
+    return Object.assign({ success: true, inserted: String(p.text || '') }, verifySnapshot());
   },
-  // [verified] replace selection if any, else insert at cursor.
+  // [verified] replace selection if any, else insert at cursor. '\n' in the new
+  // text becomes a paragraph break (insertTextAtCursor).
   replace_selection(p) {
-    const xText = xModel.getText();
     const vc = ctrl.getViewCursor();
-    const t = String(p.text || '');
-    // bAbsorb=true replaces the cursor's spanned text; for a collapsed cursor it inserts.
-    xText.insertString(vc, t, vc.getString().length > 0);
+    if ((vc.getString() || '').length > 0) vc.setString(''); // drop the selection (tracked)
     vc.collapseToEnd();
-    return { success: true, text: t };
+    insertTextAtCursor(vc, p.text || '');
+    vc.collapseToEnd();
+    return Object.assign({ success: true, text: String(p.text || '') }, verifySnapshot());
   },
   // [verified] model-native search + redline (RFC §0.2: no integer offsets).
   find_replace(p) {
@@ -261,11 +359,19 @@ const EXEC = {
     try { sd.setPropertyValue('SearchCaseSensitive', !!p.matchCase); } catch (e) {}
     const ranges = [];
     let hit = xModel.findFirst(sd);
-    while (hit !== null && ranges.length < 500) { ranges.push(hit); hit = xModel.findNext(hit, sd); }
-    const matches = ranges.map(function (r) {
+    while (hit !== null && ranges.length < 200) { ranges.push(hit); hit = xModel.findNext(hit, sd); }
+    // Each match carries DISAMBIGUATION CONTEXT (chars before/after + enclosing
+    // paragraph), so the AI can tell identical hits apart BEFORE editing — the
+    // WPS-era "replaced the wrong one" class of bug dies here.
+    const matches = ranges.map(function (r, i) {
       let anchorId = null;
       try { anchorId = anchorBookmark(r); } catch (e) {}
-      return { anchorId: anchorId, text: r.getString() };
+      const ctx = contextAround(r, 40);
+      return {
+        matchIndex: i, anchorId: anchorId, text: r.getString(),
+        contextBefore: ctx.before, contextAfter: ctx.after,
+        paragraph: (paragraphTextOf(r) || '').slice(0, 160),
+      };
     });
     return { success: true, count: matches.length, matches: matches };
   },
@@ -328,7 +434,11 @@ const EXEC = {
     while (en.hasMoreElements()) {
       const el = en.nextElement();
       if (el.supportsService && el.supportsService('com.sun.star.text.Paragraph')) {
-        if (i === idx) { el.setString(String(p.newText || '')); return { success: true, index: idx }; }
+        if (i === idx) {
+          selectVisibly(el); // 拟人：先跳到目标段落
+          el.setString(String(p.newText || ''));
+          return { success: true, index: idx, paragraphAfterEdit: el.getString().slice(0, 200) };
+        }
         i++;
       }
     }
@@ -365,8 +475,10 @@ const EXEC = {
     if (!p.anchor) return { success: false, message: 'set_selection requires {anchor}; integer offsets unsupported (§0.2)' };
     const range = anchorRange(String(p.anchor));
     if (!range) return { success: false, message: 'anchor not found: ' + p.anchor };
-    ctrl.select(range);
-    return { success: true, anchor: p.anchor, text: range.getString() };
+    // 拟人：光标跳过去、视图滚过去、选区亮出来 — 用户看得见 AI 在操作哪里。
+    if (!selectVisibly(range)) return { success: false, message: 'could not select anchor: ' + p.anchor };
+    const ctx = contextAround(range, 40);
+    return { success: true, anchor: p.anchor, text: range.getString(), contextBefore: ctx.before, contextAfter: ctx.after };
   },
   // [verified] §0.2 anchor-based replace, under RecordChanges (redline).
   replace_at_position(p) {
@@ -374,8 +486,11 @@ const EXEC = {
     xModel.setPropertyValue('RecordChanges', true);
     const range = anchorRange(String(p.anchor));
     if (!range) return { success: false, message: 'anchor not found: ' + p.anchor };
+    selectVisibly(range); // 拟人：先看见目标再动手
     range.setString(String(p.newText || ''));
-    return { success: true, anchor: p.anchor };
+    // 验证回路：返回改动后所在段落的实际文本，AI 据此确认改对了。
+    return Object.assign({ success: true, anchor: p.anchor, newText: String(p.newText || '') },
+      { paragraphAfterEdit: (paragraphTextOf(range) || '').slice(0, 200) });
   },
   // [verified-extend] insert a paragraph break at the view cursor (Enter key in
   // the IME overlay routes here — the overlay's single-line <input> can't make a
@@ -537,6 +652,8 @@ const EXEC = {
       ctrl = loaded.getCurrentController();
       try { ctrl.getFrame().getContainerWindow().FullScreen = true; } catch (e) {}
       try { installKeyHandler(); } catch (e) {}
+      // Revisions default ON for the real document too (same as bootDoc).
+      try { xModel.setPropertyValue('RecordChanges', true); } catch (e) {}
     };
 
     const errs = [];
@@ -580,6 +697,136 @@ const EXEC = {
   // [diagnostic #66] report the resolved UI locale (ooLocale) so the host/verify
   // panel can confirm whether the injected zh-CN langpack took effect.
   get_ui_lang() { return Object.assign({ success: true }, readConfigLocale()); },
+  // ==================== 拟人式原语（感知 / 定位 / 格式 / 撤销） ====================
+  // [感知] read the document as numbered paragraphs — the AI's "eyes". Windowed
+  // (startParagraph + maxParagraphs, plus a char budget) so a 200-page contract
+  // can be read in passes without blowing the tool-result size.
+  get_document_text(p) {
+    const start = Math.max(0, Number(p && p.startParagraph) || 0);
+    const maxParas = Math.max(1, Math.min(Number(p && p.maxParagraphs) || 200, 500));
+    const charBudget = 15000;
+    const paragraphs = [];
+    let total = 0, chars = 0, truncated = false;
+    eachParagraph(function (el, i) {
+      total = i + 1;
+      if (i < start || paragraphs.length >= maxParas || chars >= charBudget) return false;
+      const item = { index: i, text: el.getString() };
+      try {
+        const lvl = el.getPropertyValue('OutlineLevel') || 0;
+        if (lvl > 0) { item.headingLevel = lvl; item.style = el.getPropertyValue('ParaStyleName') || ''; }
+      } catch (e) {}
+      chars += item.text.length;
+      paragraphs.push(item);
+      return false;
+    });
+    if (start + paragraphs.length < total) truncated = true;
+    const r = { success: true, totalParagraphs: total, startParagraph: start, returned: paragraphs.length, paragraphs: paragraphs };
+    if (truncated) { r.truncated = true; r.nextStartParagraph = start + paragraphs.length; }
+    return r;
+  },
+  // [感知] what's around the cursor right now — selection, chars before/after,
+  // and the enclosing paragraph ("看一眼手边").
+  get_cursor_context(p) {
+    const vc = ctrl.getViewCursor();
+    const ctx = contextAround(vc, Number(p && p.radius) || 80);
+    return {
+      success: true, selectedText: vc.getString(), hasSelection: (vc.getString() || '').length > 0,
+      before: ctx.before, after: ctx.after, paragraph: (paragraphTextOf(vc) || '').slice(0, 300),
+    };
+  },
+  // [定位] select the Nth (0-based) body paragraph, visibly (view scrolls to it).
+  select_paragraph(p) {
+    const idx = Number(p.index) || 0;
+    let found = null;
+    eachParagraph(function (el, i) { if (i === idx) { found = el; return true; } return false; });
+    if (!found) return { success: false, message: 'paragraph index out of range: ' + idx };
+    if (!selectVisibly(found)) return { success: false, message: 'could not select paragraph ' + idx };
+    return { success: true, index: idx, text: found.getString() };
+  },
+  // [定位] drop the cursor at the start/end edge of the current selection — the
+  // human move for "insert BEFORE/AFTER this" (compose with insert_at_cursor).
+  collapse_selection(p) {
+    const vc = ctrl.getViewCursor();
+    const to = String(p && p.to || 'end');
+    if (to === 'start') vc.collapseToStart(); else vc.collapseToEnd();
+    return { success: true, to: to };
+  },
+  // [编辑] delete exactly what is selected (tracked). The anthropomorphic delete:
+  // select first (user sees what's about to go), then cut.
+  delete_selection() {
+    const vc = ctrl.getViewCursor();
+    const had = (vc.getString() || '');
+    if (had.length === 0) return { success: false, message: 'nothing selected — select_paragraph / set_selection first' };
+    vc.setString('');
+    return Object.assign({ success: true, deletedText: had.slice(0, 200), deletedChars: had.length }, verifySnapshot());
+  },
+  // [格式] character formatting on the CURRENT selection (select first, then
+  // format — same order a human works in). Any subset of the params applies;
+  // booleans false/'none' explicitly clear. CJK-safe via Asian/Complex siblings.
+  format_selection(p) {
+    const vc = ctrl.getViewCursor();
+    if ((vc.getString() || '').length === 0) return { success: false, message: 'nothing selected — select first, then format' };
+    const applied = {};
+    if (p.bold != null) { setCharProp(vc, 'CharWeight', p.bold ? css.awt.FontWeight.BOLD : css.awt.FontWeight.NORMAL); applied.bold = !!p.bold; }
+    if (p.italic != null) { setCharProp(vc, 'CharPosture', p.italic ? css.awt.FontSlant.ITALIC : css.awt.FontSlant.NONE); applied.italic = !!p.italic; }
+    if (p.underline != null) { vc.setPropertyValue('CharUnderline', p.underline ? css.awt.FontUnderline.SINGLE : css.awt.FontUnderline.NONE); applied.underline = !!p.underline; }
+    if (p.strikeout != null) { vc.setPropertyValue('CharStrikeout', p.strikeout ? css.awt.FontStrikeout.SINGLE : css.awt.FontStrikeout.NONE); applied.strikeout = !!p.strikeout; }
+    if (p.highlight != null) {
+      const c = parseColor(p.highlight, HIGHLIGHT_COLORS);
+      if (c == null) return { success: false, message: 'bad highlight color: ' + p.highlight + ' (use yellow/green/cyan/magenta/red/blue/gray/none or #RRGGBB)' };
+      vc.setPropertyValue('CharHighlight', c); applied.highlight = String(p.highlight);
+    }
+    if (p.color != null) {
+      const c = parseColor(p.color, { auto: -1 });
+      if (c == null) return { success: false, message: 'bad color: ' + p.color + ' (use #RRGGBB or auto)' };
+      vc.setPropertyValue('CharColor', c); applied.color = String(p.color);
+    }
+    if (p.fontSize != null) { setCharProp(vc, 'CharHeight', Number(p.fontSize)); applied.fontSize = Number(p.fontSize); }
+    if (p.fontName != null) { setCharProp(vc, 'CharFontName', String(p.fontName)); applied.fontName = String(p.fontName); }
+    if (Object.keys(applied).length === 0) return { success: false, message: 'no format params given' };
+    return { success: true, applied: applied, selectedText: vc.getString().slice(0, 100) };
+  },
+  // [格式] paragraph-level formatting on the selection's paragraph(s): alignment
+  // and/or paragraph style. headingLevel 1-9 maps to the programmatic style name
+  // ('Heading N', valid regardless of UI language); 0 = back to body ('Standard').
+  set_paragraph_format(p) {
+    const vc = ctrl.getViewCursor();
+    const applied = {};
+    if (p.alignment != null) {
+      const m = { left: css.style.ParagraphAdjust.LEFT, right: css.style.ParagraphAdjust.RIGHT, center: css.style.ParagraphAdjust.CENTER, justify: css.style.ParagraphAdjust.BLOCK };
+      const v = m[String(p.alignment).toLowerCase()];
+      if (v == null) return { success: false, message: 'bad alignment: ' + p.alignment + ' (left/right/center/justify)' };
+      vc.setPropertyValue('ParaAdjust', v); applied.alignment = String(p.alignment);
+    }
+    let styleName = p.styleName != null ? String(p.styleName) : null;
+    if (p.headingLevel != null) {
+      const lvl = Number(p.headingLevel);
+      styleName = lvl >= 1 && lvl <= 9 ? 'Heading ' + lvl : 'Standard';
+    }
+    if (styleName != null) { vc.setPropertyValue('ParaStyleName', styleName); applied.styleName = styleName; }
+    if (Object.keys(applied).length === 0) return { success: false, message: 'no paragraph format params given' };
+    return Object.assign({ success: true, applied: applied }, verifySnapshot());
+  },
+  // [撤销] the human safety net — back out the last step(s) when a verify shows
+  // the edit landed wrong. Steps clamp at 20.
+  undo(p) {
+    const um = xModel.getUndoManager();
+    const want = Math.max(1, Math.min(Number(p && p.steps) || 1, 20));
+    let done = 0;
+    for (; done < want; done++) {
+      try { um.undo(); } catch (e) { break; } // empty stack ends the loop
+    }
+    return Object.assign({ success: done > 0, undone: done }, done > 0 ? verifySnapshot() : { message: 'nothing to undo' });
+  },
+  redo(p) {
+    const um = xModel.getUndoManager();
+    const want = Math.max(1, Math.min(Number(p && p.steps) || 1, 20));
+    let done = 0;
+    for (; done < want; done++) {
+      try { um.redo(); } catch (e) { break; }
+    }
+    return Object.assign({ success: done > 0, redone: done }, done > 0 ? verifySnapshot() : { message: 'nothing to redo' });
+  },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {
     const bms = xModel.getBookmarks();


### PR DESCRIPTION
## 目标

系统梳理 AI panel ↔ 嵌入式 LibreOffice 的交互，用最小动作原语（看→找→选→改→验）实现 AI 对文档的完整拟人式操作（含高亮、格式），根治 WPS 时代"找不到 / 替换错"的病根。

## 设计（docs/AI_EDITOR_PRIMITIVES.md）

WPS 病根三条：整数偏移定位（富文本映射错位）、匹配无上下文（同词多处无法消歧）、无验证回路（改完盲飞）。对策：

1. **锚点定位（§0.2）**：`find_text_locations` 返回书签锚点 + 前后文 + 所在段落；整数偏移被显式拒绝
2. **拟人五步循环**：看（`get_document_text`/`get_cursor_context`）→ 找 → 选（视图滚动跟随、选区高亮，用户看得见）→ 改 → 验（每个改动返回 `paragraphAfterEdit`，错了 `undo`）
3. **修订默认开**：`RecordChanges=true` 于 boot/load 统一设置，AI 改动全部可接受/拒绝
4. **格式层**：`format_selection`（粗/斜/下划线/删除线/**高亮**/字色/字号/字体，CJK 同步 Asian/Complex）、`set_paragraph_format`（对齐/Heading N）

后端新增 11 个 `wps_*` @Tool + 分发条目；system_prompt §7 整节重写（旧版还在教 AI 用字符偏移和"关闭修订模式"）。

## 顺手修复的 4 个真 bug（自主测试揪出）

| Bug | 后果 | 修复 |
|-----|------|------|
| `preRun` 键存在但值 undefined | 引擎头 `Module.preRun.push` 崩溃，boot 永不启动 | preRun 恒为数组 |
| preRun 预写语言包与自建引擎 data 包同名文件冲突（EEXIST） | **预载死锁，编辑器永远"启动中"**（自建 zh-CN 引擎必现） | 注入移至 `onRuntimeInitialized`（包已挂载、main() 未跑、fontconfig 未扫描） |
| 相对引擎 base URL 在 blob worker 内 `importScripts` 失败 | office 线程起不来 | boot 内绝对化 |
| `insertString` 不把 `\n` 拆段 | 多段文本插成一段 | 逐段插入 PARAGRAPH_BREAK |

另补齐执行器白名单漏配的 `move_cursor` / `delete_backward` / `insert_paragraph` / `get_cursor_rect`。

## 自主测试（真实 LOWA 引擎，非 mock）

自建 zh-CN 24.2.8 引擎 + COOP/COEP 本地服务 + 无头/有头 Chrome，通过 `editor.html?verify=1` 暴露的 `window.__loExecutor` 逐条驱动：

- ✅ 多段插入 → `get_document_text` 段落编号正确（9 段）
- ✅ `find_text_locations("甲方")` → 3 处匹配各带前后文，成功消歧
- ✅ 锚点选中第 2 处 → `replace_at_position` 精准替换 → `paragraphAfterEdit` 核对通过
- ✅ 选中"违约金" → 加粗 + 黄色高亮；`#00FF88` 高亮 + 下划线 + 字号；`highlight:none` 取消
- ✅ `set_paragraph_format(headingLevel=2)` → `get_outline` 确认 `Heading 2`；居中对齐
- ✅ 选段 → collapse end → 插入（"在 X 之后插入"组合）；`delete_selection` 返回被删文本
- ✅ `undo(steps=2)` 精确回退（大纲标记消失）、`redo`
- ✅ `move_cursor`（含 extend）/ `delete_backward` / `insert_paragraph` / `get_cursor_rect` / `goto` / `clear_anchors`
- ✅ 整数偏移 `set_selection({start,end})` 被拒绝："integer offsets unsupported (§0.2)"
- ✅ 后端 `mvn compile` BUILD SUCCESS；`ooLocale=zh-CN` 生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)