### PR TITLE
chore(release): v0.3.1 — AI 拟人式动作原语

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
bump desktop 0.3.0 → 0.3.1。

变更内容 = PR #71（已在 master）：AI panel 对嵌入式 LibreOffice 的完整拟人式操作（看→找→选→改→验 原语集、锚点定位+上下文消歧、高亮/格式、undo/redo、修订默认开、验证快照），附带三处 boot 地雷修复。

合并后打 tag v0.3.1 触发桌面构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)