### PR TITLE
fix(security): 清除 application-prod.yml.example 中的企查查密钥字面量

### DIFF
--- a/backend/src/main/resources/application-prod.yml.example
+++ b/backend/src/main/resources/application-prod.yml.example
@@ -20,8 +20,8 @@ spring:
 external:
   qichacha:
     base-url: https://api.qichacha.com
-    key: f4900a7dd885415cb305edc621f5b490
-    secret: 9C16665DB7BA6661FAAC35EF1321FA3C
+    key: 你的企查查Key  # 从企查查开放平台获取
+    secret: 你的企查查Secret  # 从企查查开放平台获取
   wps:
     app-id: 你的WPS_AppID  # 从 WPS 控制台获取
     app-secret: 你的WPS_AppSecret  # 从 WPS 控制台获取


### PR DESCRIPTION
## 概要

修复 #75:\`backend/src/main/resources/application-prod.yml.example\` 中残留的企查查真实 key/secret 字面量,替换为占位符(\`你的企查查Key\` / \`你的企查查Secret\`),风格与同文件 MySQL/WPS 占位符一致。

## 核查结论

- 这对密钥与 2026-06-12 PR #22 从两个正式配置文件清除的企查查密钥**相同**,即 7 家服务轮换前的旧钥;#22 遗漏了 \`.example\` 文件。
- 该文件 git 历史(仅 2 个提交)中无其他真实密钥;当前 HEAD 全树扫描确认其余 6 家服务密钥及通用 API key 模式均无残留。
- 密钥仍存在于历史提交中(自初始提交起)。

## ⚠️ 维护者行动项

请确认 2026-06-12 的轮换是否覆盖了企查查这对密钥。**若仍有效,请立即在企查查控制台轮换**(历史提交中的旧钥随轮换自然失效,无需重写历史)。

## 合并说明

按流程本 PR 需维护者当次授权后合并,不自动合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)