### PR TITLE
fix(libreoffice): v0.3.1 真机三连修——中文 UI 确定化 + 保存管线落地 + 控制键 / three device fixes

### DIFF
--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -61,6 +61,13 @@ export function bootZetaOffice(options = {}) {
     // files are fetched before boot and written into MEMFS in preRun so the
     // LibreOffice UI comes up in Chinese. Missing/failed fetch -> skip -> English.
     langpackUrl,
+    // UI language for the LibreOffice chrome (issue #66 follow-up). The engine
+    // derives its locale from navigator.languages (emscripten getEnvStrings ->
+    // LANG), so the UI silently follows the BROWSER/Electron language — an
+    // en-GB system got an English editor even with the zh-CN engine baked in
+    // (v0.3.1 real-machine report). Forcing it makes the product deterministic.
+    // Set to ''/null to follow the environment again.
+    uiLang = 'zh-CN',
     onLog,
     onReady,
     onWorkerMessage,
@@ -160,13 +167,25 @@ export function bootZetaOffice(options = {}) {
         log('MEMFS injected ' + n + '/' + injections.length + ' file(s) (font + zh-CN langpack) before main()')
       },
     }
+    // Force the engine's locale (LANG) by shimming navigator.languages BEFORE
+    // any engine code runs. Must happen on EVERY thread that computes env
+    // strings: the page (below) AND each pthread worker (prepended into the
+    // bootstrap blob, which we control). No engine rebuild needed.
+    const langShim = uiLang
+      ? "try{Object.defineProperty(navigator,'languages',{get:function(){return['" + uiLang + "']}});" +
+        "Object.defineProperty(navigator,'language',{get:function(){return'" + uiLang + "'}})}catch(e){}"
+      : ''
+    if (langShim) {
+      try { (0, eval)(langShim); log('UI language forced to ' + uiLang + ' (navigator shim)') }
+      catch (e) { log('UI language shim failed: ' + e) }
+    }
     if (sofficeBaseUrl !== '') {
       // Absolutize: this URL is imported from inside a BLOB worker, where a
       // relative/root path ('/lowa/soffice.js') is invalid — pthread spawn dies
       // with "The URL ... is invalid" and the office thread never starts.
       const absBase = new URL(sofficeBaseUrl, globalThis.location ? globalThis.location.href : undefined).href
       Module.mainScriptUrlOrBlob = new Blob(
-        ["importScripts('" + absBase + "soffice.js');"], { type: 'text/javascript' })
+        [langShim + "importScripts('" + absBase + "soffice.js');"], { type: 'text/javascript' })
     }
     globalThis.Module = Module
 

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -151,6 +151,10 @@ startEditorEndpoint({
   // Default to a CJK font served next to the page (the verify build drops one
   // here); bootZetaOffice skips cleanly if it 404s (Chinese would be tofu then).
   fontUrl: q.get('font') || './cjk.ttc',
+  // Deterministic Chinese UI regardless of the browser/Electron language (the
+  // engine follows navigator.languages otherwise — v0.3.1 shipped English on an
+  // en-GB system). ?uilang=env follows the environment; ?uilang=xx-YY overrides.
+  uiLang: q.get('uilang') === 'env' ? '' : (q.get('uilang') || 'zh-CN'),
   // zh-CN UI langpack manifest baked into the bundle (issue #66): makes the
   // LibreOffice UI itself Chinese. bootZetaOffice skips cleanly if it 404s
   // (e.g. the CDN-only spike), leaving the English UI. ?lang= overrides/disables.

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -171,6 +171,13 @@ startEditorEndpoint({
     attachImeOverlay({
       canvas: document.getElementById('qtcanvas'),
       commit: (text) => endpoint.executor.executeCommand('insert_at_cursor', { text }),
+      // Control keys: the overlay swallows keystrokes (it IS the focused input),
+      // so Enter/Backspace/arrows must be forwarded to the worker explicitly.
+      // The worker actions (insert_paragraph/delete_backward/move_cursor) have
+      // existed since Track C and are whitelisted — this wiring was the missing
+      // link (v0.3.1 real-machine report: Backspace did nothing).
+      onEnter: () => endpoint.executor.executeCommand('insert_paragraph', {}),
+      sendCommand: (action, params) => endpoint.executor.executeCommand(action, params),
       onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
     })
   } catch (e) { console.error('[zeta-editor] IME overlay failed:', e); if (VERIFY) vlog('IME overlay failed: ' + (e && e.message || e)) }

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -707,19 +707,32 @@ const EXEC = {
     const ext = (m ? m[1] : 'docx').toLowerCase();
     const filter = IMPORT_FILTERS[ext];
 
-    const url = 'file:///tmp/ai_save_' + (++saveSeq) + '.' + ext;
-    const path = '/tmp/ai_save_' + saveSeq + '.' + ext;
-    const props = [mkProp('Overwrite', true)];
+    // Stream the store STRAIGHT INTO JS via a UNO XOutputStream implemented
+    // here. Do NOT storeToURL a MEMFS file and read it back with Module.FS:
+    // this office thread is an em-pthread whose JS-level FS is NOT the main
+    // thread's file system (FS state lives on the main runtime; pthreads only
+    // proxy at the syscall layer), so FS.readFile threw ENOENT on the device
+    // (v0.3.1 real-machine report: save failed "No such file or directory").
+    const chunks = [];
+    let total = 0;
+    const sink = zetajs.unoObject([css.io.XOutputStream], {
+      writeBytes(seq) { // sequence<byte> -> Int8Array view
+        const u8 = new Uint8Array(seq.buffer ? seq.buffer.slice(seq.byteOffset, seq.byteOffset + seq.byteLength) : seq);
+        chunks.push(u8); total += u8.length;
+      },
+      flush() {},
+      closeOutput() {},
+    });
+    const props = [mkProp('OutputStream', sink), mkProp('Overwrite', true)];
     if (filter) props.push(mkProp('FilterName', filter));
-    xModel.storeToURL(url, props);
-
-    // Read the stored bytes straight out of MEMFS. Module.FS is exported by both
-    // the CDN engine (Qt6 build) and our self-built engine (gbuild patch makes
-    // the export unconditional) — office_thread.js already runs with `Module` in
-    // scope (see the boot promise below).
-    const u8 = Module.FS.readFile(path); // Uint8Array (throws if store failed)
-    try { const sfa = css.ucb.SimpleFileAccess.create(context); if (sfa.exists(url)) sfa.kill(url); } catch (e) { /* MEMFS temp cleanup is best-effort */ }
-    if (!u8 || u8.length === 0) return { success: false, message: 'export_document: storeToURL produced 0 bytes' };
+    // private:stream = "write to the OutputStream in the media descriptor" —
+    // the standard LO idiom for exporting to memory (no filesystem involved).
+    xModel.storeToURL('private:stream', props);
+    saveSeq++;
+    if (total === 0) return { success: false, message: 'export_document: store produced 0 bytes' };
+    const u8 = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) { u8.set(c, off); off += c.length; }
     log('export_document: 已导出「' + name + '」/ exported (' + u8.length + ' bytes, filter=' + (filter || 'auto') + ')');
     return { success: true, name: name, size: u8.length, bytes: u8 };
   },


### PR DESCRIPTION
## v0.3.1 真机反馈的三个问题,全部根因定位并修复

### 1️⃣ UI 英文(装了中文引擎却显示英文)
**根因**:引擎 locale 跟随 `navigator.languages`(emscripten `getEnvStrings→LANG`)。维护者系统语言 en-GB → Electron webview 报 en-GB → 英文 UI(状态栏 "English (UK)" 即铁证);其 Chrome 界面语言为中文 → 报 zh-CN → 所以浏览器验证时是中文。引擎本身零问题(装包内引擎与自建产物逐字节一致,已核)。
**修复**:`bootZetaOffice` 新增 `uiLang`(默认 `zh-CN`),在**页面 + pthread bootstrap blob** 两侧 shim `navigator.languages` → 每个线程的 LANG 都被钉死。`?uilang=env` 可恢复跟随环境。
**验证**:en-GB 的 headless 浏览器,shim 前 `ooLocale=en-US` → shim 后 **`ooLocale=zh-CN`**(真引擎实测)。

### 2️⃣ 保存失败 "No such file or directory"
**根因**:`export_document` 先 storeToURL 到 MEMFS 再 `Module.FS.readFile` 读回——但 office 线程是 em-pthread,**JS 层 FS 不是主线程的文件系统**(pthread 只在 syscall 层代理)→ ENOENT。
**修复**:改为 LO 标准内存导出:`storeToURL('private:stream')` + JS 实现的 `css.io.XOutputStream` 收字节,零文件系统依赖。
**验证**:headless 真引擎实测:插入中文 → 导出 **5192 字节、ZIP magic "PK"**,字节完整穿过 worker→页面 relay。

### 3️⃣ Backspace/方向键/回车无效
**根因**:覆盖层(焦点 input)吞按键;各层转发能力齐备,唯 `editor-main.js` 挂载时没传 `onEnter`/`sendCommand`。
**修复**:补两个回调。

## 剩余真机验证项(装下个包)
- 编辑器 UI 中文(含 tooltip)
- 打字→Backspace 删除→回车换段
- 「保存」端到端(导出已验;上传 hop 在 Electron 宿主,待装包验)

建议随 **v0.3.2** 发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)