### PR TITLE
chore(release): v0.3.2 — 真机三连修发版 / device fixes release

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本 bump 0.3.1→0.3.2。内容=PR #77(中文 UI 确定化 + 保存管线 + 控制键)。合并后打 tag v0.3.2 自动发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)