### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
v0.4.0 版本号(minor):WPS 正式退场(#79,#80/#81 已合),内置 LibreOffice 成唯一编辑器。仅动 desktop/package.json 与 lockfile root 两处,依赖版本行未动。/ Version bump only (root fields); WPS officially retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)