### PR TITLE
refactor(ai): AI 编排器 Phase 1——统一工具层 + 记忆作用域分层 / AI orchestrator layering foundation

### DIFF
--- a/backend/src/main/java/com/checkba/model/entity/MemoryEntry.java
+++ b/backend/src/main/java/com/checkba/model/entity/MemoryEntry.java
@@ -20,7 +20,8 @@ import java.util.Map;
     @Index(name = "idx_memory_project", columnList = "project_id"),
     @Index(name = "idx_memory_type", columnList = "memory_type"),
     @Index(name = "idx_memory_key", columnList = "memory_key"),
-    @Index(name = "idx_memory_conversation", columnList = "conversation_id")
+    @Index(name = "idx_memory_conversation", columnList = "conversation_id"),
+    @Index(name = "idx_memory_scope_user", columnList = "scope, user_id")
 })
 public class MemoryEntry {
 
@@ -56,6 +57,23 @@ public class MemoryEntry {
      */
     @Column(name = "memory_type", nullable = false, length = 50)
     private String memoryType;
+
+    /**
+     * 记忆作用域（回答"这条记忆属于谁/什么"）
+     * user: 用户级，跨项目生效（如用户偏好、常用表达）
+     * project: 项目级（默认，如交易结构、核查结论）
+     * conversation: 对话级（仅当前对话相关）
+     * file: 文件级（绑定某个具体文件，配合 sourceFileId）
+     * global: 通用知识（跨用户跨项目的领域知识）
+     */
+    @Column(name = "scope", length = 20)
+    private String scope = MemoryScope.PROJECT;
+
+    /**
+     * 来源文件ID（scope=file 时必填，其他作用域可选，用于溯源）
+     */
+    @Column(name = "source_file_id")
+    private Long sourceFileId;
 
     /**
      * 记忆关键词/标题
@@ -126,6 +144,10 @@ public class MemoryEntry {
     public void setProjectId(Long projectId) { this.projectId = projectId; }
     public Long getUserId() { return userId; }
     public void setUserId(Long userId) { this.userId = userId; }
+    public String getScope() { return scope; }
+    public void setScope(String scope) { this.scope = scope; }
+    public Long getSourceFileId() { return sourceFileId; }
+    public void setSourceFileId(Long sourceFileId) { this.sourceFileId = sourceFileId; }
     public String getConversationId() { return conversationId; }
     public void setConversationId(String conversationId) { this.conversationId = conversationId; }
     public String getMemoryType() { return memoryType; }
@@ -173,6 +195,8 @@ public class MemoryEntry {
         private Map<String, Object> metadata;
         private Double importanceScore = 0.5;
         private Boolean isProtected = false;
+        private String scope = MemoryScope.PROJECT;
+        private Long sourceFileId;
         private LocalDateTime expiresAt;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
@@ -187,12 +211,35 @@ public class MemoryEntry {
         public MemoryEntryBuilder metadata(Map<String, Object> metadata) { this.metadata = metadata; return this; }
         public MemoryEntryBuilder importanceScore(Double importanceScore) { this.importanceScore = importanceScore; return this; }
         public MemoryEntryBuilder isProtected(Boolean isProtected) { this.isProtected = isProtected; return this; }
+        public MemoryEntryBuilder scope(String scope) { this.scope = scope; return this; }
+        public MemoryEntryBuilder sourceFileId(Long sourceFileId) { this.sourceFileId = sourceFileId; return this; }
         public MemoryEntryBuilder expiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; return this; }
         public MemoryEntryBuilder createdAt(LocalDateTime createdAt) { this.createdAt = createdAt; return this; }
         public MemoryEntryBuilder updatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; return this; }
 
         public MemoryEntry build() {
-            return new MemoryEntry(id, projectId, userId, conversationId, memoryType, memoryKey, memoryValue, metadata, importanceScore, isProtected, expiresAt, createdAt, updatedAt);
+            MemoryEntry entry = new MemoryEntry(id, projectId, userId, conversationId, memoryType, memoryKey, memoryValue, metadata, importanceScore, isProtected, expiresAt, createdAt, updatedAt);
+            entry.setScope(scope);
+            entry.setSourceFileId(sourceFileId);
+            return entry;
+        }
+    }
+
+    /**
+     * 记忆作用域枚举
+     */
+    public static class MemoryScope {
+        public static final String USER = "user";
+        public static final String PROJECT = "project";
+        public static final String CONVERSATION = "conversation";
+        public static final String FILE = "file";
+        public static final String GLOBAL = "global";
+
+        public static boolean isValid(String scope) {
+            if (scope == null) return false;
+            String s = scope.toLowerCase();
+            return s.equals(USER) || s.equals(PROJECT) || s.equals(CONVERSATION)
+                    || s.equals(FILE) || s.equals(GLOBAL);
         }
     }
 

--- a/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
@@ -79,6 +79,31 @@ public interface MemoryEntryRepository extends JpaRepository<MemoryEntry, Long> 
     List<MemoryEntry> findByProjectIdAndUserIdOrderByCreatedAtDesc(Long projectId, Long userId);
 
     /**
+     * 按作用域查找用户级记忆（跨项目，如用户偏好）
+     */
+    @Query("SELECT m FROM MemoryEntry m WHERE m.userId = :userId AND m.scope = :scope " +
+           "ORDER BY m.importanceScore DESC, m.updatedAt DESC")
+    List<MemoryEntry> findByUserIdAndScope(@Param("userId") Long userId,
+                                            @Param("scope") String scope,
+                                            Pageable pageable);
+
+    /**
+     * 按作用域查找通用知识记忆（跨用户跨项目）
+     */
+    @Query("SELECT m FROM MemoryEntry m WHERE m.scope = :scope " +
+           "AND (LOWER(m.memoryKey) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(m.memoryValue) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+           "ORDER BY m.importanceScore DESC")
+    List<MemoryEntry> searchByScopeAndKeyword(@Param("scope") String scope,
+                                               @Param("keyword") String keyword,
+                                               Pageable pageable);
+
+    /**
+     * 按来源文件查找文件级记忆
+     */
+    List<MemoryEntry> findBySourceFileIdOrderByImportanceScoreDesc(Long sourceFileId);
+
+    /**
      * 统计项目的记忆数量
      */
     long countByProjectId(Long projectId);

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -7,30 +7,25 @@ import com.checkba.service.ProjectAiMessageService;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.agent.tool.ToolSpecifications;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.util.StreamUtils;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Agent 核心编排器 ("The Brain").
- * 负责：
- * 1. 组装上下文 (Context Assembly)
- * 2. 调用 LLM (Thinking)
- * 3. 处理流式响应 (Streaming)
- * 4. 执行工具 (Tool Execution)
- * 5. 维护循环 (Loop)
+ * Agent 核心编排器（编排层）。
+ * 只负责循环控制与流程编排：
+ * 1. 组装上下文（委托 ContextAssemblerService）
+ * 2. 调用 LLM（委托 ChatModelFactory）
+ * 3. 处理流式响应（委托 AgentStreamHandler）
+ * 4. 分发工具（委托 ToolRegistry / XmlToolCallParser——编排器不感知任何具体工具）
+ * 5. 维护循环、取消与增量持久化
+ * 6. 循环结束后触发记忆写入管线（委托 MemoryPipelineService）
  */
 @Service
 @RequiredArgsConstructor
@@ -48,16 +43,10 @@ public class AgentOrchestrator {
     private final SseEmitterService sseEmitterService;
     private final TokenUsageService tokenUsageService;
     private final ContextAssemblerService contextAssemblerService;
-    private final com.checkba.service.ai.tools.LegalTools legalTools; 
-    private final com.checkba.service.ai.tools.FileTools fileTools;
-    private final com.checkba.service.ai.tools.WebTools webTools;
-    private final com.checkba.service.ai.tools.PythonTools pythonTools;
-    private final com.checkba.service.ai.tools.MemoryTools memoryTools;
-    private final com.checkba.service.ai.tools.WpsTools wpsTools;
-    private final com.checkba.service.ai.tools.PptxTools pptxTools;
-    private final com.checkba.service.ai.tools.PptxEditTools pptxEditTools;
+    private final ToolRegistry toolRegistry;
+    private final XmlToolCallParser xmlToolCallParser;
+    private final com.checkba.service.ai.memory.MemoryPipelineService memoryPipelineService;
     private final com.checkba.service.ProjectFileService projectFileService;
-    private final PluginService pluginService;
     private final WpsActionService wpsActionService;
     private final ConversationFileChangeService conversationFileChangeService;
 
@@ -123,299 +112,39 @@ public class AgentOrchestrator {
         return null;
     }
 
-    // Correct signature accepting projectId, modelId, and userId for progress tracking
-    private String executeNativeTool(dev.langchain4j.agent.tool.ToolExecutionRequest req, Long projectId, String conversationId, String modelId, Long userId) {
-        String toolName = req.name();
-        String args = req.arguments();
-        
-        try {
-            if ("read_document".equals(toolName)) {
-                String fileId = extractArg(args, "fileId");
-                return legalTools.read_document(fileId);
-            } else if ("search_web".equals(toolName)) {
-                 String query = extractArg(args, "query");
-                 return webTools.search_web(query);
-            } else if ("browse_url".equals(toolName)) {
-                 String url = extractArg(args, "url");
-                 return webTools.browse_url(url);
-            } else if ("law_search".equals(toolName)) {
-                 String query = extractArg(args, "query");
-                 return legalTools.law_search(query);
-            } else if ("law_search_keyword".equals(toolName)) {
-                 String title = extractArg(args, "title");
-                 String fulltext = extractArg(args, "fulltext");
-                 return legalTools.law_search_keyword(title, fulltext);
-            } else if ("law_recognition".equals(toolName)) {
-                 String text = extractArg(args, "text");
-                 return legalTools.law_recognition(text);
-            } else if ("get_law_article".equals(toolName)) {
-                 String title = extractArg(args, "title");
-                 String number = extractArg(args, "number");
-                 return legalTools.get_law_article(title, number);
-            } else if ("write_docx".equals(toolName)) {
-                 // write_docx logic - support both naming conventions
-                 String fileName = extractArg(args, "name");
-                 if (fileName == null || fileName.isEmpty()) fileName = extractArg(args, "fileName");
-                 String markdown = extractArg(args, "markdown_content");
-                 if (markdown == null || markdown.isEmpty()) markdown = extractArg(args, "markdownContent");
-                 String result = fileTools.write_docx(fileName, markdown, projectId);
-                 
-                 // Trigger UI Refresh if success
-                 if (result != null && !result.startsWith("Error")) {
-                     sseEmitterService.send(conversationId, "client_action", "{\"action\":\"refresh_files\"}");
-                 }
-                 return result;
-            } else if ("run_python".equals(toolName)) {
-                 String code = extractArg(args, "code");
-                 return pythonTools.run_python(code);
-            } else if ("write_file".equals(toolName)) {
-                 String filename = extractArg(args, "filename");
-                 String content = extractArg(args, "content");
-                 return fileTools.write_file(filename, content, projectId);
-            } else if ("list_files".equals(toolName)) {
-                 String subPath = extractArg(args, "subPath");
-                 return fileTools.list_files(projectId, subPath);
-            } else if ("search_project_files".equals(toolName)) {
-                 String pattern = extractArg(args, "fileNamePattern");
-                 String dir = extractArg(args, "dirPath");
-                 return fileTools.search_project_files(pattern, dir);
-            } else if ("delete_file".equals(toolName)) {
-                 String path = extractArg(args, "filePath");
-                 return fileTools.delete_file(path);
-            } else if ("move_file".equals(toolName)) {
-                 String src = extractArg(args, "sourcePath");
-                 String dst = extractArg(args, "destPath");
-                 return fileTools.move_file(src, dst);
-            } else if ("read_file".equals(toolName)) {
-                 String path = extractArg(args, "filePath");
-                 return fileTools.read_file(path);
-            // ==================== 记忆工具 ====================
-            } else if ("save_memory".equals(toolName)) {
-                 String type = extractArg(args, "type");
-                 String key = extractArg(args, "key");
-                 String value = extractArg(args, "value");
-                 boolean isProtected = "true".equalsIgnoreCase(extractArg(args, "isProtected"));
-                 return memoryTools.save_memory(type, key, value, isProtected);
-            } else if ("query_memory".equals(toolName)) {
-                 String query = extractArg(args, "query");
-                 String type = extractArg(args, "type");
-                 if (type == null || type.isEmpty()) type = "all";
-                 return memoryTools.query_memory(query, type);
-            } else if ("get_project_context".equals(toolName)) {
-                 return memoryTools.get_project_context();
-            } else if ("update_project_info".equals(toolName)) {
-                 String field = extractArg(args, "field");
-                 String value = extractArg(args, "value");
-                 return memoryTools.update_project_info(field, value);
-            } else if ("search_knowledge_base".equals(toolName)) {
-                 String query = extractArg(args, "query");
-                 int limit = 5;
-                 try {
-                     limit = Integer.parseInt(extractArg(args, "limit"));
-                 } catch (Exception e) { /* use default */ }
-                 return memoryTools.search_knowledge_base(query, limit);
-            } else if ("get_conversation_summary".equals(toolName)) {
-                 return memoryTools.get_conversation_summary();
-            } 
-            // ==================== WPS 工具 ====================
-            else if ("wps_list_project_files".equals(toolName)) {
-                 return wpsTools.wps_list_project_files(projectId);
-            } else if ("wps_open_file".equals(toolName)) {
-                 Long fileId = Long.parseLong(extractArg(args, "fileId"));
-                 return wpsTools.wps_open_file(fileId);
-            } else if ("wps_get_selection".equals(toolName)) {
-                 return wpsTools.wps_get_selection();
-            } else if ("wps_set_selection".equals(toolName)) {
-                 Integer start = Integer.parseInt(extractArg(args, "start"));
-                 Integer end = Integer.parseInt(extractArg(args, "end"));
-                 return wpsTools.wps_set_selection(start, end);
-            } else if ("wps_replace_selection".equals(toolName)) {
-                 String text = extractArg(args, "text");
-                 return wpsTools.wps_replace_selection(text);
-            } else if ("wps_goto".equals(toolName)) {
-                 String type = extractArg(args, "type");
-                 String target = extractArg(args, "target");
-                 return wpsTools.wps_goto(type, target);
-            } else if ("wps_find_text".equals(toolName)) {
-                 String keyword = extractArg(args, "keyword");
-                 Boolean matchCase = "true".equalsIgnoreCase(extractArg(args, "matchCase"));
-                 return wpsTools.wps_find_text(keyword, matchCase);
-            } else if ("wps_find_replace".equals(toolName)) {
-                 String findText = extractArg(args, "findText");
-                 String replaceText = extractArg(args, "replaceText");
-                 String replaceAllStr = extractArg(args, "replaceAll");
-                 Boolean replaceAll = replaceAllStr.isEmpty() || "true".equalsIgnoreCase(replaceAllStr);
-                 return wpsTools.wps_find_replace(findText, replaceText, replaceAll);
-            } else if ("wps_insert_at_cursor".equals(toolName)) {
-                 String text = extractArg(args, "text");
-                 return wpsTools.wps_insert_at_cursor(text);
-            } else if ("wps_get_paragraph".equals(toolName)) {
-                 Integer paragraphIndex = Integer.parseInt(extractArg(args, "paragraphIndex"));
-                 return wpsTools.wps_get_paragraph(paragraphIndex);
-            } else if ("wps_modify_paragraph".equals(toolName)) {
-                 Integer paragraphIndex = Integer.parseInt(extractArg(args, "paragraphIndex"));
-                 String newText = extractArg(args, "newText");
-                 return wpsTools.wps_modify_paragraph(paragraphIndex, newText);
-            } else if ("wps_get_outline".equals(toolName)) {
-                 return wpsTools.wps_get_outline();
-            } else if ("wps_insert_under_heading".equals(toolName)) {
-                 String headingText = extractArg(args, "headingText");
-                 String content = extractArg(args, "content");
-                 return wpsTools.wps_insert_under_heading(headingText, content);
-            } else if ("wps_search_related_docs".equals(toolName)) {
-                 String keyword = extractArg(args, "keyword");
-                 return wpsTools.wps_search_related_docs(keyword, projectId);
-            } else if ("wps_replace_nth_match".equals(toolName)) {
-                 String findText = extractArg(args, "findText");
-                 String replaceText = extractArg(args, "replaceText");
-                 Integer matchIndex = Integer.parseInt(extractArg(args, "matchIndex"));
-                 return wpsTools.wps_replace_nth_match(findText, replaceText, matchIndex);
-            } else if ("wps_delete_match".equals(toolName)) {
-                 String findText = extractArg(args, "findText");
-                 Integer matchIndex = Integer.parseInt(extractArg(args, "matchIndex"));
-                 return wpsTools.wps_delete_match(findText, matchIndex);
-            } else if ("wps_delete_text".equals(toolName)) {
-                 String text = extractArg(args, "text");
-                 Boolean deleteAll = "true".equalsIgnoreCase(extractArg(args, "deleteAll"));
-                 return wpsTools.wps_delete_text(text, deleteAll);
-            } else if ("wps_debug_revisions".equals(toolName)) {
-                 return wpsTools.wps_debug_revisions();
-            // ==================== 拟人式原语（LibreOffice 编辑器） ====================
-            } else if ("wps_get_document_text".equals(toolName)) {
-                 Integer startParagraph = safeParseInt(extractArg(args, "startParagraph"), "startParagraph");
-                 Integer maxParagraphs = safeParseInt(extractArg(args, "maxParagraphs"), "maxParagraphs");
-                 return wpsTools.wps_get_document_text(startParagraph, maxParagraphs);
-            } else if ("wps_get_cursor_context".equals(toolName)) {
-                 return wpsTools.wps_get_cursor_context();
-            } else if ("wps_select_anchor".equals(toolName)) {
-                 return wpsTools.wps_select_anchor(extractArg(args, "anchorId"));
-            } else if ("wps_select_paragraph".equals(toolName)) {
-                 return wpsTools.wps_select_paragraph(safeParseInt(extractArg(args, "index"), "index"));
-            } else if ("wps_collapse_cursor".equals(toolName)) {
-                 return wpsTools.wps_collapse_cursor(extractArg(args, "to"));
-            } else if ("wps_replace_at_anchor".equals(toolName)) {
-                 return wpsTools.wps_replace_at_anchor(extractArg(args, "anchorId"), extractArg(args, "newText"));
-            } else if ("wps_delete_selection".equals(toolName)) {
-                 return wpsTools.wps_delete_selection();
-            } else if ("wps_format_selection".equals(toolName)) {
-                 return wpsTools.wps_format_selection(
-                         safeParseBool(extractArg(args, "bold")),
-                         safeParseBool(extractArg(args, "italic")),
-                         safeParseBool(extractArg(args, "underline")),
-                         safeParseBool(extractArg(args, "strikeout")),
-                         extractArg(args, "highlight"),
-                         extractArg(args, "color"),
-                         safeParseDouble(extractArg(args, "fontSize")),
-                         extractArg(args, "fontName"));
-            } else if ("wps_set_paragraph_format".equals(toolName)) {
-                 return wpsTools.wps_set_paragraph_format(
-                         extractArg(args, "alignment"),
-                         safeParseInt(extractArg(args, "headingLevel"), "headingLevel"));
-            } else if ("wps_undo".equals(toolName)) {
-                 return wpsTools.wps_undo(safeParseInt(extractArg(args, "steps"), "steps"));
-            } else if ("wps_redo".equals(toolName)) {
-                 return wpsTools.wps_redo(safeParseInt(extractArg(args, "steps"), "steps"));
-            // ==================== PPTX 文件管理工具 ====================
-            } else if ("list_project_folders".equals(toolName)) {
-                 return pptxTools.list_project_folders(projectId);
-            } else if ("pptx_list_files".equals(toolName)) {
-                 return pptxTools.pptx_list_files(projectId);
-            } else if ("pptx_search_files".equals(toolName)) {
-                 String keyword = extractArg(args, "keyword");
-                 return pptxTools.pptx_search_files(projectId, keyword);
-            } else if ("pptx_open_file".equals(toolName)) {
-                 Long fileId = Long.parseLong(extractArg(args, "fileId"));
-                 return pptxTools.pptx_open_file(fileId);
-            } else if ("pptx_check_service".equals(toolName)) {
-                 return pptxTools.pptx_check_service();
-            } else if ("pptx_generate".equals(toolName)) {
-                 String topic = extractArg(args, "topic");
-                 String parentIdStr = extractArg(args, "parentId");
-                 // 处理 parentId=null/None 的情况（LLM 可能生成字符串 "null" 或 Python 的 "None"）
-                 Long parentId = (parentIdStr != null && !parentIdStr.isEmpty() 
-                     && !"null".equalsIgnoreCase(parentIdStr) && !"none".equalsIgnoreCase(parentIdStr)) 
-                     ? Long.parseLong(parentIdStr) : null;
-                 String fileName = extractArg(args, "fileName");
-                 String style = extractArg(args, "style");
-                 String language = extractArg(args, "language");
-                 return pptxTools.pptx_generate(topic, projectId, parentId, fileName, style, language, modelId);
-            } else if ("pptx_generate_outline".equals(toolName)) {
-                 String topic = extractArg(args, "topic");
-                 String language = extractArg(args, "language");
-                 return pptxTools.pptx_generate_outline(topic, language, modelId);
-            // ==================== PPTX 编辑工具 ====================
-            } else if ("pptx_get_presentation_info".equals(toolName)) {
-                 return pptxEditTools.pptx_get_presentation_info();
-            } else if ("pptx_get_slide_content".equals(toolName)) {
-                 Integer slideIndex = Integer.parseInt(extractArg(args, "slideIndex"));
-                 return pptxEditTools.pptx_get_slide_content(slideIndex);
-            } else if ("pptx_get_selection".equals(toolName)) {
-                 return pptxEditTools.pptx_get_selection();
-            } else if ("pptx_modify_slide_text".equals(toolName)) {
-                 Integer slideIndex = Integer.parseInt(extractArg(args, "slideIndex"));
-                 Integer shapeIndex = Integer.parseInt(extractArg(args, "shapeIndex"));
-                 String newText = extractArg(args, "newText");
-                 return pptxEditTools.pptx_modify_slide_text(slideIndex, shapeIndex, newText);
-            } else if ("pptx_insert_text".equals(toolName)) {
-                 Integer slideIndex = Integer.parseInt(extractArg(args, "slideIndex"));
-                 Integer shapeIndex = Integer.parseInt(extractArg(args, "shapeIndex"));
-                 String text = extractArg(args, "text");
-                 String position = extractArg(args, "position");
-                 return pptxEditTools.pptx_insert_text(slideIndex, shapeIndex, text, position);
-            } else if ("pptx_mark_delete_text".equals(toolName)) {
-                 Integer slideIndex = Integer.parseInt(extractArg(args, "slideIndex"));
-                 Integer shapeIndex = Integer.parseInt(extractArg(args, "shapeIndex"));
-                 String textToDelete = extractArg(args, "textToDelete");
-                 return pptxEditTools.pptx_mark_delete_text(slideIndex, shapeIndex, textToDelete);
-            } else if ("pptx_save".equals(toolName)) {
-                 return pptxEditTools.pptx_save();
-            } else {
-                // Check if it's a dynamic plugin tool
-                Object toolObject = pluginService.getPluginTools().get(toolName);
-                if (toolObject != null) {
-                    log.info("Executing dynamic plugin tool: {}", toolName);
-                    return executeDynamicTool(toolObject, req, projectId, conversationId);
-                }
-            }
-        } catch (Exception e) {
-            return "Error executing tool: " + e.getMessage();
-        }
-        return "Tool not found or arguments invalid.";
+    // ==================== 工具分发（统一走 ToolRegistry，编排器不感知具体工具） ====================
+
+    /**
+     * 分发一次工具调用并处理声明式副作用（文件变更通知、文件树刷新）。
+     */
+    private ToolRegistry.ToolResult dispatchTool(String toolName, String argsJson,
+                                                 Long projectId, String conversationId,
+                                                 Long userId, String modelId) {
+        com.checkba.service.ai.tools.ToolContext ctx =
+                new com.checkba.service.ai.tools.ToolContext(projectId, conversationId, userId, modelId);
+        ToolRegistry.ToolResult result = toolRegistry.execute(toolName, argsJson, ctx);
+        applyToolSideEffects(result, argsJson, conversationId);
+        return result;
     }
 
-    private String executeDynamicTool(Object toolObject, dev.langchain4j.agent.tool.ToolExecutionRequest req, Long projectId, String conversationId) {
-        try {
-            // Use reflection or a more sophisticated dispatcher.
-            // For now, let's find the method with @Tool that matches name.
-            for (Method method : toolObject.getClass().getDeclaredMethods()) {
-                if (method.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class)) {
-                    String name = method.getName(); 
-                    // Actually LangChain4j uses method name as tool name if @Tool value is a description.
-                    
-                    if (method.getName().equals(req.name())) {
-                        // Very naive arg mapping (only supports Map/String/JSONObject)
-                        // In reality, we should use ToolSpecifications to map args.
-                        // Simple version: if it takes Map or String
-                        Class<?>[] params = method.getParameterTypes();
-                        if (params.length == 0) return (String) method.invoke(toolObject);
-                        
-                        // Extract args as Map
-                        cn.hutool.json.JSONObject obj = cn.hutool.json.JSONUtil.parseObj(req.arguments());
-                        Object[] args = new Object[params.length];
-                        
-                        // Just a prototype mapping - assuming first param might be Map or String
-                        if (params[0].equals(Map.class)) args[0] = obj.toBean(Map.class);
-                        else if (params[0].equals(String.class)) args[0] = obj.getStr(method.getParameters()[0].getName());
-                        
-                        return (String) method.invoke(toolObject, args);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            log.error("Dynamic tool execution failed", e);
-            return "Error: " + e.getMessage();
+    /**
+     * 根据 @ToolMeta 元数据处理工具副作用（取代原先散落在手写分发链里的硬编码通知）。
+     */
+    private void applyToolSideEffects(ToolRegistry.ToolResult result, String argsJson, String conversationId) {
+        if (!result.success() || result.tool() == null || result.tool().meta() == null) {
+            return;
         }
-        return "Error: Tool method not found in plugin.";
+        com.checkba.service.ai.tools.ToolMeta meta = result.tool().meta();
+        if (meta.refreshFiles()) {
+            sseEmitterService.send(conversationId, "client_action", "{\"action\":\"refresh_files\"}");
+        }
+        if (!meta.fileEffect().isEmpty()) {
+            String fileName = meta.fileArg().isEmpty() ? null : extractArg(argsJson, meta.fileArg());
+            if (fileName == null || fileName.isEmpty()) {
+                fileName = "Current Document";
+            }
+            notifyFileChange(conversationId, fileName, meta.fileEffect());
+        }
     }
 
 
@@ -476,7 +205,8 @@ public class AgentOrchestrator {
                 taskListId,
                 planId,
                 projectId,
-                agentMode
+                agentMode,
+                userId
             );
             
             log.info("Message assembly complete. Total messages: {}", messages.size());
@@ -595,39 +325,21 @@ public class AgentOrchestrator {
                 log.info("Detected Native Tool Requests: {}", aiMessage.toolExecutionRequests());
                 sseEmitterService.send(conversationId, "step_update", "{\"status\":\"loading\", \"message\":\"Executing tools...\"}");
 
-                // Execute Native Tools
+                // Execute Native Tools (统一分发，无需感知具体工具)
                 for (dev.langchain4j.agent.tool.ToolExecutionRequest req : aiMessage.toolExecutionRequests()) {
-                    String result = executeNativeTool(req, Long.parseLong(projectId), conversationId, modelId, userId);
+                    ToolRegistry.ToolResult toolResult = dispatchTool(req.name(), req.arguments(),
+                            Long.parseLong(projectId), conversationId, userId, modelId);
+                    String result = toolResult.output();
                     messages.add(dev.langchain4j.data.message.ToolExecutionResultMessage.from(req, result));
-                    
+
                     // Determine status for history and display
-                    String nativeToolStatus = (result != null && !result.startsWith("Error")) ? "SUCCESS" : "FAILURE";
-                    
+                    String nativeToolStatus = toolResult.success() ? "SUCCESS" : "FAILURE";
+
                     // Log for history persistence (include status attribute)
                     executionLog.append(String.format("<process name=\"%s\"><tool_code>%s(%s)</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
                         req.name(), req.name(), req.arguments(), nativeToolStatus, result));
-
-                    // --- Notify File Change (Native Tools) ---
-                    if ("SUCCESS".equals(nativeToolStatus)) {
-                         String toolName = req.name();
-                         if ("write_file".equals(toolName)) {
-                             notifyFileChange(conversationId, extractArg(req.arguments(), "filename"), "ADDED");
-                         } else if ("write_docx".equals(toolName)) {
-                             notifyFileChange(conversationId, extractArg(req.arguments(), "fileName"), "ADDED");
-                         } else if ("pptx_generate".equals(toolName)) {
-                             notifyFileChange(conversationId, extractArg(req.arguments(), "fileName"), "ADDED");
-                         } else if (toolName.startsWith("wps_modify") || toolName.startsWith("wps_replace") || toolName.startsWith("wps_insert")) {
-                            // Ideally we need to know WHICH file. 
-                            // But usually Agent works on the "active" file or opened file.
-                            // For now, we might not have the filename easily for modifications unless we track open state.
-                            // However, the requirement says "Modified Files".
-                            // If we don't have the filename, maybe we skip or use "Current File"?
-                            // Let's assume the frontend knows the active file, OR we just say "Current File"
-                            // Actually, better: if we can't get the name, maybe just don't list it or list "Current Document"?
-                         }
-                    }
                 }
-                
+
                 sseEmitterService.send(conversationId, "step_update", "{\"status\":\"done\", \"message\":\"Tools executed.\"}");
                 
                 // 增量保存：在工具执行后立即保存AI消息和工具输出，防止对话中断导致上下文丢失
@@ -645,409 +357,63 @@ public class AgentOrchestrator {
             // 2. Check for XML Tool Requests (Fallback for Root Bubble Protocol)
             // Pattern: <tool_code>legal_tools.method(args)</tool_code> OR <code>...</code>
             // We need to parse this manually because we forced XML output in System Prompt.
-            if (content.contains("<tool_code>") || content.contains("<code>")) {
+            if (xmlToolCallParser.containsToolCall(content)) {
                 log.info("Detected XML Tool Code in content. Parsing...");
-                
+
                 // 提取LLM选择的process name，用于历史记录保存时保持一致性
-                String llmProcessName = null;
-                java.util.regex.Pattern processNamePattern = java.util.regex.Pattern.compile("<process[^>]*name=\"([^\"]*)\"[^>]*>");
-                java.util.regex.Matcher processNameMatcher = processNamePattern.matcher(content);
-                if (processNameMatcher.find()) {
-                    llmProcessName = processNameMatcher.group(1);
-                    log.info("Extracted LLM process name: {}", llmProcessName);
-                }
-                
-                // Regex to match either <tool_code>...</tool_code> or <code>...</code>
-                // Uses backreference \1 to match the opening tag name, and (?s) for DOTALL mode to match newlines
-                java.util.regex.Pattern toolPattern = java.util.regex.Pattern.compile("(?s)<(tool_code|code)>(.*?)</\\1>");
-                java.util.regex.Matcher matcher = toolPattern.matcher(content);
-                
+                String llmProcessName = xmlToolCallParser.extractProcessName(content).orElse(null);
+
                 boolean toolExecuted = false;
-                
-                while (matcher.find()) {
-                    String code = matcher.group(2).trim(); // e.g., legal_tools.search_web(query="...") or print(legal_tools...)
+
+                for (XmlToolCallParser.ParsedCall call : xmlToolCallParser.parse(content)) {
+                    String code = call.rawCode();
                     log.info("Parsed Tool Code: {}", code);
-                    
-                    // Notify Frontend
-                    // String escapedCode = "Executing: " + code.replace("\"", "\\\"");
-                    // sseEmitterService.send(conversationId, "step_update", "{\"status\":\"loading\", \"message\":\"" + escapedCode + "\"}");
-                    
-                    String result = "Error executing tool code: " + code;
-                    try {
-                        // VERY Basic Parsing for specific known tools
-                        // Expecting: legal_tools.search_web(query="...")
-                        // Or: default_api.search_web(...)
-                        
-                        // PRIORITY 1: run_python - Check first to avoid false matches on tools inside Python code
-                        if (code.startsWith("run_python(") || code.contains("run_python(code=")) {
-                             // Extract Python code from run_python(code='...' or code="...")
-                             String pythonCode = extractPythonCodeArg(code);
-                             if (pythonCode != null && !pythonCode.isEmpty()) {
-                                 log.info("Executing Python code via PythonTools, code length: {}", pythonCode.length());
-                                 result = pythonTools.run_python(pythonCode);
-                             } else {
-                                 result = "Error: Could not extract Python code from run_python call.";
-                             }
-                        } else if (code.contains("search_web") || code.contains("search_laws")) {
-                             String query = extractStringArg(code, "query");
-                             // Fallback: search_laws -> search_web
-                             result = webTools.search_web(query);
-                        } else if (code.contains("law_search_keyword")) {
-                             String title = extractStringArg(code, "title");
-                             String fulltext = extractStringArg(code, "fulltext");
-                             result = legalTools.law_search_keyword(title, fulltext);
-                        } else if (code.contains("law_recognition")) {
-                             String text = extractStringArg(code, "text");
-                             result = legalTools.law_recognition(text);
-                        } else if (code.contains("law_search")) {
-                             String query = extractStringArg(code, "query");
-                             result = legalTools.law_search(query);
-                        } else if (code.contains("get_law_article")) {
-                             String title = extractStringArg(code, "title");
-                             String number = extractStringArg(code, "number");
-                             result = legalTools.get_law_article(title, number);
-                        } else if (code.contains("browse_url")) {
-                             String url = extractStringArg(code, "url");
-                             result = webTools.browse_url(url);
-                        } else if (code.contains("read_document")) {
-                             String fileId = extractStringArg(code, "fileId");
-                             // fallback if fileId arg name differs
-                             if (fileId.isEmpty()) fileId = extractStringArg(code, "id"); 
-                             result = legalTools.read_document(fileId);
-                        } else if (code.contains("write_docx")) {
-                             // Extract "name" first (as per system_prompt.md), fallback to "fileName"
-                             String fileName = extractStringArg(code, "name");
-                             if (fileName.isEmpty()) fileName = extractStringArg(code, "fileName");
-                             // Try to extract markdown content with various parameter names
-                             String fileContent = extractStringArg(code, "markdown_content");
-                             if (fileContent.isEmpty()) fileContent = extractStringArg(code, "markdownContent");
-                             if (fileContent.isEmpty()) fileContent = extractStringArg(code, "content");
-                             
-                             result = fileTools.write_docx(fileName, fileContent, Long.parseLong(projectId));
-                             
-                             // Trigger UI Refresh if success
-                             if (result != null && !result.startsWith("Error")) {
-                                 sseEmitterService.send(conversationId, "client_action", "{\"action\":\"refresh_files\"}");
-                                 notifyFileChange(conversationId, fileName, "ADDED");
-                             }
-                        } else if (code.contains("write_file")) {
-                             String fileName = extractStringArg(code, "fileName");
-                             if (fileName.isEmpty()) fileName = extractStringArg(code, "filename");
-                             String fileContent = extractStringArg(code, "content");
-                             result = fileTools.write_file(fileName, fileContent, Long.parseLong(projectId));
-                             if (!result.startsWith("Error")) notifyFileChange(conversationId, fileName, "ADDED");
-                        } else if (code.contains("list_files")) {
-                             String subPath = extractStringArg(code, "subPath");
-                             if (subPath.isEmpty()) subPath = "."; 
-                             result = fileTools.list_files(Long.parseLong(projectId), subPath);
-                        } else if (code.contains("search_project_files")) {
-                             String pattern = extractStringArg(code, "fileNamePattern");
-                             String dir = extractStringArg(code, "dirPath");
-                             result = fileTools.search_project_files(pattern, dir);
-                        } else if (code.contains("read_file")) {
-                             String path = extractStringArg(code, "filePath");
-                             // fallback
-                             if (path.isEmpty()) path = extractStringArg(code, "path");
-                             result = fileTools.read_file(path);
-                        } else if (code.contains("delete_file")) {
-                             String path = extractStringArg(code, "filePath");
-                             result = fileTools.delete_file(path);
-                        } else if (code.contains("move_file")) {
-                             String src = extractStringArg(code, "sourcePath");
-                             String dst = extractStringArg(code, "destPath");
-                             result = fileTools.move_file(src, dst);
-                        // ==================== 记忆工具 (Legacy XML) ====================
-                        } else if (code.contains("save_memory")) {
-                             String type = extractStringArg(code, "type");
-                             String key = extractStringArg(code, "key");
-                             String value = extractStringArg(code, "value");
-                             boolean isProtected = "true".equalsIgnoreCase(extractStringArg(code, "isProtected"));
-                             result = memoryTools.save_memory(type, key, value, isProtected);
-                        } else if (code.contains("query_memory")) {
-                             String query = extractStringArg(code, "query");
-                             String type = extractStringArg(code, "type");
-                             if (type.isEmpty()) type = "all";
-                             result = memoryTools.query_memory(query, type);
-                        } else if (code.contains("get_project_context")) {
-                             result = memoryTools.get_project_context();
-                        } else if (code.contains("update_project_info")) {
-                             String field = extractStringArg(code, "field");
-                             String value = extractStringArg(code, "value");
-                             result = memoryTools.update_project_info(field, value);
-                        } else if (code.contains("search_knowledge_base")) {
-                             String query = extractStringArg(code, "query");
-                             int limit = 5;
-                             try {
-                                 String limitStr = extractStringArg(code, "limit");
-                                 if (!limitStr.isEmpty()) limit = Integer.parseInt(limitStr);
-                             } catch (Exception e) { /* use default */ }
-                             result = memoryTools.search_knowledge_base(query, limit);
-                        } else if (code.contains("get_conversation_summary")) {
-                             result = memoryTools.get_conversation_summary();
-                        // ==================== PPTX 工具 (Legacy XML) ====================
-                        } else if (code.contains("pptx_check_service")) {
-                             result = pptxTools.pptx_check_service();
-                        } else if (code.contains("pptx_generate_outline")) {
-                             String topic = extractStringArg(code, "topic");
-                             String language = extractStringArg(code, "language");
-                             result = pptxTools.pptx_generate_outline(topic, language, modelId);
-                        } else if (code.contains("pptx_generate")) {
-                             String topic = extractStringArg(code, "topic");
-                             String parentIdStr = extractStringArg(code, "parentId");
-                             // 处理 parentId=null/None 的情况（LLM 可能生成字符串 "null" 或 Python 的 "None"）
-                             Long parentId = (parentIdStr != null && !parentIdStr.isEmpty() 
-                                 && !"null".equalsIgnoreCase(parentIdStr) && !"none".equalsIgnoreCase(parentIdStr)) 
-                                 ? Long.parseLong(parentIdStr) : null;
-                             String fileName = extractStringArg(code, "fileName");
-                             String style = extractStringArg(code, "style");
-                             String language = extractStringArg(code, "language");
-                             result = pptxTools.pptx_generate(topic, Long.parseLong(projectId), parentId, fileName, style, language, modelId);
-                             if (!result.startsWith("Error")) notifyFileChange(conversationId, fileName, "ADDED");
-                        // ==================== PPTX 文件管理工具 ====================
-                        } else if (code.contains("list_project_folders")) {
-                             result = pptxTools.list_project_folders(Long.parseLong(projectId));
-                        } else if (code.contains("pptx_list_files")) {
-                             result = pptxTools.pptx_list_files(Long.parseLong(projectId));
-                        } else if (code.contains("pptx_search_files")) {
-                             String keyword = extractStringArg(code, "keyword");
-                             result = pptxTools.pptx_search_files(Long.parseLong(projectId), keyword);
-                        } else if (code.contains("pptx_open_file")) {
-                             String fileIdStr = extractStringArg(code, "fileId");
-                             Long fileId = safeParseLong(fileIdStr, "fileId");
-                             if (fileId == null) {
-                                 result = "Error: fileId 参数无效或为空";
-                             } else {
-                                 result = pptxTools.pptx_open_file(fileId);
-                             }
-                        // ==================== 智能 PPT 修改 ====================
-                        } else if (code.contains("pptx_smart_modify")) {
-                             String fileIdStr = extractStringArg(code, "fileId");
-                             String pageIndexStr = extractStringArg(code, "pageIndex");
-                             String modifyInstruction = extractStringArg(code, "modifyInstruction");
-                             Long fileId = safeParseLong(fileIdStr, "fileId");
-                             Integer pageIndex = safeParseInt(pageIndexStr, "pageIndex");
-                             if (fileId == null || pageIndex == null) {
-                                 result = "Error: 参数解析失败。fileId=" + fileIdStr + ", pageIndex=" + pageIndexStr + 
-                                        "。请确保使用正确的格式，如: pptx_smart_modify(fileId=10, pageIndex=1, modifyInstruction=\"...\")";
-                             } else if (modifyInstruction == null || modifyInstruction.isEmpty()) {
-                                 result = "Error: modifyInstruction 参数不能为空";
-                             } else {
-                                 // 传递 modelId 以便纯图片页面使用正确的图片生成模型
-                                 result = pptxTools.pptx_smart_modify(fileId, pageIndex, modifyInstruction, modelId);
-                             }
-                        // ==================== PPTX 编辑工具 ====================
-                        } else if (code.contains("pptx_edit_page")) {
-                             String serviceProjectId = extractStringArg(code, "serviceProjectId");
-                             String pageIdStr = extractStringArg(code, "pageId");
-                             String editInstruction = extractStringArg(code, "editInstruction");
-                             result = pptxTools.pptx_edit_page(serviceProjectId, pageIdStr, editInstruction);
-                        } else if (code.contains("pptx_get_project_pages")) {
-                             String serviceProjectId = extractStringArg(code, "serviceProjectId");
-                             result = pptxTools.pptx_get_project_pages(serviceProjectId);
-                        } else if (code.contains("pptx_get_page_screenshot")) {
-                             String fileIdStr = extractStringArg(code, "fileId");
-                             String pageIndexStr = extractStringArg(code, "pageIndex");
-                             Long fileId = safeParseLong(fileIdStr, "fileId");
-                             Integer pageIndex = safeParseInt(pageIndexStr, "pageIndex");
-                             if (fileId == null || pageIndex == null) {
-                                 result = "Error: 参数解析失败。fileId=" + fileIdStr + ", pageIndex=" + pageIndexStr;
-                             } else {
-                                 result = pptxTools.pptx_get_page_screenshot(fileId, pageIndex);
-                             }
-                        } else if (code.contains("pptx_refine_outline")) {
-                             String serviceProjectId = extractStringArg(code, "serviceProjectId");
-                             String userRequirement = extractStringArg(code, "userRequirement");
-                             String language = extractStringArg(code, "language");
-                             result = pptxTools.pptx_refine_outline(serviceProjectId, userRequirement, language);
-                        } else if (code.contains("pptx_export_editable")) {
-                             String serviceProjectId = extractStringArg(code, "serviceProjectId");
-                             String filename = extractStringArg(code, "filename");
-                             String exportModelId = extractStringArg(code, "modelId");
-                             result = pptxTools.pptx_export_editable(serviceProjectId, filename, exportModelId);
-                        // ==================== PPTX 编辑工具 (WPS WebOffice API) ====================
-                        } else if (code.contains("pptx_get_presentation_info")) {
-                             result = pptxEditTools.pptx_get_presentation_info();
-                        } else if (code.contains("pptx_get_slide_content")) {
-                             String slideIndexStr = extractStringArg(code, "slideIndex");
-                             Integer slideIndex = Integer.parseInt(slideIndexStr);
-                             result = pptxEditTools.pptx_get_slide_content(slideIndex);
-                        } else if (code.contains("pptx_get_selection")) {
-                             result = pptxEditTools.pptx_get_selection();
-                        } else if (code.contains("pptx_modify_slide_text")) {
-                             String slideIndexStr = extractStringArg(code, "slideIndex");
-                             String shapeIndexStr = extractStringArg(code, "shapeIndex");
-                             String newText = extractStringArg(code, "newText");
-                             Integer slideIndex = Integer.parseInt(slideIndexStr);
-                             Integer shapeIndex = Integer.parseInt(shapeIndexStr);
-                             result = pptxEditTools.pptx_modify_slide_text(slideIndex, shapeIndex, newText);
-                        } else if (code.contains("pptx_insert_text")) {
-                             String slideIndexStr = extractStringArg(code, "slideIndex");
-                             String shapeIndexStr = extractStringArg(code, "shapeIndex");
-                             String text = extractStringArg(code, "text");
-                             String position = extractStringArg(code, "position");
-                             Integer slideIndex = Integer.parseInt(slideIndexStr);
-                             Integer shapeIndex = Integer.parseInt(shapeIndexStr);
-                             result = pptxEditTools.pptx_insert_text(slideIndex, shapeIndex, text, position);
-                        } else if (code.contains("pptx_mark_delete_text")) {
-                             String slideIndexStr = extractStringArg(code, "slideIndex");
-                             String shapeIndexStr = extractStringArg(code, "shapeIndex");
-                             String textToDelete = extractStringArg(code, "textToDelete");
-                             Integer slideIndex = Integer.parseInt(slideIndexStr);
-                             Integer shapeIndex = Integer.parseInt(shapeIndexStr);
-                             result = pptxEditTools.pptx_mark_delete_text(slideIndex, shapeIndex, textToDelete);
-                        } else if (code.contains("pptx_save")) {
-                             result = pptxEditTools.pptx_save();
-                        // ==================== WPS 通用工具 ====================
-                        } else if (code.contains("wps_list_project_files")) {
-                             result = wpsTools.wps_list_project_files(Long.parseLong(projectId));
-                        } else if (code.contains("wps_start_stream")) {
-                             String fileIdStr = extractStringArg(code, "fileId");
-                             String fileNameArg = extractStringArg(code, "fileName");
-                             // Allow null fileId (for new files)
-                             Long fileId = safeParseLong(fileIdStr, "fileId");
-                             // projectId 来自当前上下文
-                             result = wpsTools.wps_start_stream(fileId, fileNameArg, Long.parseLong(projectId));
-                        } else if (code.contains("wps_open_file")) {
-                             String fileIdStr = extractStringArg(code, "fileId");
-                             Long fileId = Long.parseLong(fileIdStr);
-                             result = wpsTools.wps_open_file(fileId);
-                        } else if (code.contains("wps_get_selection")) {
-                             result = wpsTools.wps_get_selection();
-                        } else if (code.contains("wps_find_text")) {
-                             String keyword = extractStringArg(code, "keyword");
-                             result = wpsTools.wps_find_text(keyword, false);
-                        } else if (code.contains("wps_find_replace")) {
-                             String findText = extractStringArg(code, "findText");
-                             String replaceText = extractStringArg(code, "replaceText");
-                             result = wpsTools.wps_find_replace(findText, replaceText, true);
-                             if (!result.startsWith("Error")) notifyFileChange(conversationId, "Current Document", "MODIFIED");
-                        } else if (code.contains("wps_get_outline")) {
-                             result = wpsTools.wps_get_outline();
-                        } else if (code.contains("wps_set_selection")) {
-                             String startStr = extractStringArg(code, "start");
-                             String endStr = extractStringArg(code, "end");
-                             Integer start = safeParseInt(startStr, "start");
-                             Integer end = safeParseInt(endStr, "end");
-                             if (start == null || end == null) {
-                                  result = "Error: Invalid start/end parameters for set_selection";
-                             } else {
-                                  result = wpsTools.wps_set_selection(start, end);
-                             }
-                        } else if (code.contains("wps_replace_selection")) {
-                             String text = extractStringArg(code, "text");
-                             result = wpsTools.wps_replace_selection(text);
-                        } else if (code.contains("wps_goto")) {
-                             String type = extractStringArg(code, "type");
-                             String target = extractStringArg(code, "target");
-                             result = wpsTools.wps_goto(type, target);
-                        } else if (code.contains("wps_insert_at_cursor")) {
-                             String text = extractStringArg(code, "text");
-                             result = wpsTools.wps_insert_at_cursor(text);
-                        } else if (code.contains("wps_get_paragraph")) {
-                             String indexStr = extractStringArg(code, "paragraphIndex");
-                             Integer idx = 1;
-                             try { idx = Integer.parseInt(indexStr); } catch (Exception e) {}
-                             result = wpsTools.wps_get_paragraph(idx);
-                        } else if (code.contains("wps_modify_paragraph")) {
-                             String indexStr = extractStringArg(code, "paragraphIndex");
-                             String newText = extractStringArg(code, "newText");
-                             Integer idx = 1;
-                             try { idx = Integer.parseInt(indexStr); } catch (Exception e) {}
-                             result = wpsTools.wps_modify_paragraph(idx, newText);
-                             if (!result.startsWith("Error")) notifyFileChange(conversationId, "Current Document", "MODIFIED"); // Can't easily get filename
-                        } else if (code.contains("wps_insert_under_heading")) {
-                             String headingText = extractStringArg(code, "headingText");
-                             String insertContent = extractStringArg(code, "content");
-                             result = wpsTools.wps_insert_under_heading(headingText, insertContent);
-                        } else if (code.contains("wps_replace_nth_match")) {
-                             String findText = extractStringArg(code, "findText");
-                             String replaceText = extractStringArg(code, "replaceText");
-                             String matchIndexStr = extractStringArg(code, "matchIndex");
-                             Integer matchIndex = 1;
-                             try { matchIndex = Integer.parseInt(matchIndexStr); } catch (Exception e) {}
-                             result = wpsTools.wps_replace_nth_match(findText, replaceText, matchIndex);
-                        } else if (code.contains("wps_delete_match")) {
-                             String findText = extractStringArg(code, "findText");
-                             String matchIndexStr = extractStringArg(code, "matchIndex");
-                             Integer matchIndex = 1;
-                             try { matchIndex = Integer.parseInt(matchIndexStr); } catch (Exception e) {}
-                             result = wpsTools.wps_delete_match(findText, matchIndex);
-                        } else if (code.contains("wps_delete_text")) {
-                             String text = extractStringArg(code, "text");
-                             String deleteAllStr = extractStringArg(code, "deleteAll");
-                             Boolean deleteAll = deleteAllStr.isEmpty() || "true".equalsIgnoreCase(deleteAllStr);
-                             result = wpsTools.wps_delete_text(text, deleteAll);
-                        } else if (code.contains("wps_debug_revisions")) {
-                             result = wpsTools.wps_debug_revisions();
 
-                         } else {
+                    ToolRegistry.ToolResult toolResult = dispatchTool(call.toolName(), call.argsJson(),
+                            Long.parseLong(projectId), conversationId, userId, modelId);
+                    String result = toolResult.found()
+                            ? toolResult.output()
+                            : "Unknown tool in custom parser: " + code;
 
-                            // Try to check if it's a dynamic plugin tool (e.g., plugin_name.method_name or just method_name)
-                            String dynamicToolName = parseToolName(code);
-                            Object toolObject = pluginService.getPluginTools().get(dynamicToolName);
-                            if (toolObject != null) {
-                                log.info("Executing dynamic plugin tool via XML: {}", dynamicToolName);
-                                // For simplicity, we create a ToolExecutionRequest for the executeDynamicTool method
-                                dev.langchain4j.agent.tool.ToolExecutionRequest req = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
-                                        .name(dynamicToolName)
-                                        .arguments(extractArgsAsJson(code))
-                                        .build();
-                                result = executeDynamicTool(toolObject, req, Long.parseLong(projectId), conversationId);
-                            } else {
-                                // Try to evaluate generalized python-like string?
-                                // For safety, only allow listed tools.
-                                result = "Unknown tool in custom parser: " + code;
-                            }
-                         }
-                        
-                    } catch (Exception e) {
-                        result = "Tool Execution Failed: " + e.getMessage();
-                    }
-                    
                     // Add Result to History
-                    // Since this isn't a native tool role, we append a SYSTEM/USER message with the result
-                    // formatted as <tool_output> so the model recognizes it.
-                    String statusPrefix = result.startsWith("Error") ? "FAILURE" : "SUCCESS";
-                    
+                    String statusPrefix = (toolResult.found() && toolResult.success()) ? "SUCCESS" : "FAILURE";
+
                     // Enhancement for Write Tools: Append explicit success for file creation/modification
                     // The model often sees JSON IDs (wps_file_id) and thinks it failed or needs to do more.
-                    if ("SUCCESS".equals(statusPrefix) && (code.contains("write_docx") || code.contains("write_file") || code.contains("write_"))) {
+                    if ("SUCCESS".equals(statusPrefix) && call.toolName().startsWith("write_")) {
                          result += "\n\n(System Note: File operation completed successfully.)";
                     }
-                    
-                    String toolOutputMsg = String.format("<process><tool_output>%s</tool_output></process>", result);
-                    
+
                     // Explicitly tell the model to EVALUATE - with strict anti-over-execution instructions
-                    String feedbackMsg = String.format("[System Tool Execution Log]\nTool: %s\nStatus: %s\nOutput: %s\n\n(CRITICAL INSTRUCTION: The tool executed successfully. Now compare with the ORIGINAL user request. If the SPECIFIC task the user asked for is complete, output `<final>` IMMEDIATELY. DO NOT perform additional operations unless the user EXPLICITLY requested them. For example, if user asked to 'delete the 3rd z' and you deleted it, you are DONE - do not delete other z's.)", 
+                    String feedbackMsg = String.format("[System Tool Execution Log]\nTool: %s\nStatus: %s\nOutput: %s\n\n(CRITICAL INSTRUCTION: The tool executed successfully. Now compare with the ORIGINAL user request. If the SPECIFIC task the user asked for is complete, output `<final>` IMMEDIATELY. DO NOT perform additional operations unless the user EXPLICITLY requested them. For example, if user asked to 'delete the 3rd z' and you deleted it, you are DONE - do not delete other z's.)",
                         code, statusPrefix, result);
-                        
+
                     messages.add(dev.langchain4j.data.message.UserMessage.from(feedbackMsg));
-                    
+
                     // Log for history persistence (include status attribute)
-                    // 优先使用LLM选择的process name，保持与实时流式一致
-                    String processNameForLog = (llmProcessName != null && !llmProcessName.isEmpty()) 
-                        ? llmProcessName 
-                        : getToolDisplayName(code);
+                    // 优先使用LLM选择的process name，否则用工具元数据里的中文显示名
+                    String processNameForLog = (llmProcessName != null && !llmProcessName.isEmpty())
+                        ? llmProcessName
+                        : (toolResult.tool() != null ? toolResult.tool().displayName() : "工具执行");
                     executionLog.append(String.format("<process name=\"%s\"><tool_code>%s</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
                         processNameForLog, code, statusPrefix, result));
-                    
+
                     // Emit explicit tool_output for frontend parser with status attribute
                     // NOTE: Do NOT wrap in <process> - the tool_output belongs to the existing process
-                    // that contained the tool_code. Wrapping in <process> would create a NEW process
-                    // and the frontend wouldn't find the tool item to update.
-                    String toolOutputXml = String.format("<tool_output status=\"%s\">%s</tool_output>", 
+                    // that contained the tool_code.
+                    String toolOutputXml = String.format("<tool_output status=\"%s\">%s</tool_output>",
                         statusPrefix, result);
                     sseEmitterService.send(conversationId, "text_delta", "{\"content\":\"" + toolOutputXml.replace("\"", "\\\"").replace("\n", "\\n") + "\"}");
 
                     toolExecuted = true;
                 }
-                
+
                 if (toolExecuted) {
                      // 增量保存：在XML工具执行后立即保存AI消息和工具输出，防止对话中断导致上下文丢失
                      String intermediateXmlContent = content + "\n" + executionLog.toString();
                      messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", intermediateXmlContent);
                      log.info("Intermediate save after XML tool execution for conversation: {}", conversationId);
-                     
+
                      // Recurse with executionLog
                      runLoop(model, messages, conversationId, projectId, userId, modelId, depth + 1, executionLog, agentMode);
                      return;
@@ -1158,6 +524,13 @@ public class AgentOrchestrator {
                 String fullContent = executionLog.length() > 0 ? executionLog.toString() + content : content;
                 messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", fullContent);
             }
+            // 触发记忆写入管线（异步：对话摘要 / 项目记忆 / MemCell 原子记忆提取）
+            try {
+                memoryPipelineService.onConversationTurnCompleted(
+                        conversationId, projectId, userId, new java.util.ArrayList<>(messages));
+            } catch (Exception memEx) {
+                log.warn("Failed to trigger memory pipeline for {}", conversationId, memEx);
+            }
             // 发送 bubble_end 表示整个循环真正结束
             sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"finished\"}");
             sseEmitterService.close(conversationId);
@@ -1180,21 +553,8 @@ public class AgentOrchestrator {
             log.info("Ask mode: generating without tools");
             model.generate(messages, handler);
         } else {
-            // Agent 和 Plan 模式：传递工具规格
-            // Combine all tool specifications
-            List<ToolSpecification> allTools = new ArrayList<>();
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(legalTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(webTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(pythonTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(memoryTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(fileTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(wpsTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(pptxTools));
-            allTools.addAll(ToolSpecifications.toolSpecificationsFrom(pptxEditTools));
-            
-            // Add Dynamic Plugin Tools
-            allTools.addAll(pluginService.getToolSpecifications());
-            
+            // Agent 和 Plan 模式：传递工具规格（内置 + 插件，统一来自注册表）
+            List<ToolSpecification> allTools = toolRegistry.getAllSpecifications();
             model.generate(messages, allTools, handler);
         }
     }
@@ -1236,272 +596,7 @@ public class AgentOrchestrator {
         }
     }
     
-    // Naive extraction from code string like: function(key="value")
 
-    /**
-     * 安全解析 Long 类型参数
-     */
-    private Long safeParseLong(String value, String argName) {
-        if (value == null || value.isEmpty()) {
-            log.warn("Empty value for argument: {}", argName);
-            return null;
-        }
-        try {
-            return Long.parseLong(value.trim());
-        } catch (NumberFormatException e) {
-            log.warn("Failed to parse {} as Long: {}", argName, value);
-            return null;
-        }
-    }
-
-    /**
-     * 安全解析 Integer 类型参数
-     */
-    private Integer safeParseInt(String value, String argName) {
-        if (value == null || value.isEmpty()) {
-            log.warn("Empty value for argument: {}", argName);
-            return null;
-        }
-        try {
-            return Integer.parseInt(value.trim());
-        } catch (NumberFormatException e) {
-            log.warn("Failed to parse {} as Integer: {}", argName, value);
-            return null;
-        }
-    }
-
-    /**
-     * 可空 Boolean 解析（缺省参数保持 null，不误传 false）
-     */
-    private Boolean safeParseBool(String value) {
-        if (value == null || value.isEmpty()) return null;
-        return Boolean.valueOf(value.trim());
-    }
-
-    /**
-     * 可空 Double 解析
-     */
-    private Double safeParseDouble(String value) {
-        if (value == null || value.isEmpty()) return null;
-        try {
-            return Double.parseDouble(value.trim());
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private String extractStringArg(String code, String key) {
-        // Extract string argument from code like: function(key="value") or function(key="multi\nline\nvalue")
-        // Must handle multi-line content (e.g., markdown_content for write_docx)
-        // ALSO handles Python triple-quoted strings: key=""" or key='''
-        // NEW: Also handles JSON format: function({"key":"value"})
-        try {
-            // PRIORITY 0: Check for JSON format (e.g., function({"key":"value"}))
-            // This handles cases where LLM generates: wps_find_replace({"findText":"...", "replaceText":"..."})
-            int jsonStart = code.indexOf("({");
-            int jsonEnd = code.lastIndexOf("})");
-            if (jsonStart != -1 && jsonEnd != -1 && jsonEnd > jsonStart) {
-                String jsonStr = code.substring(jsonStart + 1, jsonEnd + 1); // Extract {...}
-                cn.hutool.json.JSONObject json = cn.hutool.json.JSONUtil.parseObj(jsonStr);
-                if (json.containsKey(key)) {
-                    return json.getStr(key, "");
-                }
-            }
-            
-            // PRIORITY 0.5: Check for <ctrl46> delimiter format
-            // LLM sometimes uses <ctrl46> as string delimiter: key:<ctrl46>value<ctrl46>
-            // Common pattern: pptx_generate_outline{language:<ctrl46>zh<ctrl46>,topic:<ctrl46>...<ctrl46>}
-            String ctrlDelimiter = "<ctrl46>";
-            int ctrlKeyStart = code.indexOf(key + ":" + ctrlDelimiter);
-            if (ctrlKeyStart == -1) {
-                // Also try with equals sign: key=<ctrl46>value<ctrl46>
-                ctrlKeyStart = code.indexOf(key + "=" + ctrlDelimiter);
-            }
-            if (ctrlKeyStart != -1) {
-                // Found <ctrl46> delimiter
-                String prefix = ctrlKeyStart == code.indexOf(key + ":") ? key + ":" + ctrlDelimiter : key + "=" + ctrlDelimiter;
-                int valueStart = ctrlKeyStart + prefix.length();
-                int valueEnd = code.indexOf(ctrlDelimiter, valueStart);
-                if (valueEnd != -1) {
-                    String value = code.substring(valueStart, valueEnd);
-                    log.debug("Extracted {} from <ctrl46> format: {}", key, value.length() > 50 ? value.substring(0, 50) + "..." : value);
-                    return value;
-                }
-                // If no closing delimiter, take until next comma or closing brace
-                int commaEnd = code.indexOf(",", valueStart);
-                int braceEnd = code.indexOf("}", valueStart);
-                int end = Math.min(commaEnd != -1 ? commaEnd : Integer.MAX_VALUE, braceEnd != -1 ? braceEnd : Integer.MAX_VALUE);
-                if (end != Integer.MAX_VALUE) {
-                    return code.substring(valueStart, end).trim();
-                }
-                return code.substring(valueStart).trim();
-            }
-            
-            // PRIORITY 1: Check for triple-quoted string first (Python style)
-            // Pattern: key=""" or key='''
-            int tripleDoubleStart = code.indexOf(key + "=\"\"\"");
-            int tripleSingleStart = code.indexOf(key + "='''");
-            
-            if (tripleDoubleStart != -1) {
-                // Found triple double quotes
-                int valueStart = tripleDoubleStart + key.length() + 4; // skip key="""
-                int valueEnd = code.indexOf("\"\"\"", valueStart);
-                if (valueEnd != -1) {
-                    return code.substring(valueStart, valueEnd);
-                }
-                // If no closing """, take everything till the end (shouldn't happen)
-                return code.substring(valueStart);
-            }
-            
-            if (tripleSingleStart != -1) {
-                // Found triple single quotes
-                int valueStart = tripleSingleStart + key.length() + 4; // skip key='''
-                int valueEnd = code.indexOf("'''", valueStart);
-                if (valueEnd != -1) {
-                    return code.substring(valueStart, valueEnd);
-                }
-                return code.substring(valueStart);
-            }
-            
-            // PRIORITY 2: Single quoted string (original logic)
-            // Find the start of key="
-            int keyStart = code.indexOf(key + "=\"");
-            char quoteChar = '"';
-            if (keyStart == -1) {
-                // Try single quotes
-                keyStart = code.indexOf(key + "='");
-                quoteChar = '\'';
-            }
-            
-            // PRIORITY 3: Unquoted value (e.g., fileId=10, pageIndex=1)
-            // 如果没有找到带引号的参数，尝试解析不带引号的参数（如整数）
-            if (keyStart == -1) {
-                int unquotedStart = code.indexOf(key + "=");
-                if (unquotedStart != -1) {
-                    int valueStart = unquotedStart + key.length() + 1;
-                    // 检查值开头不是引号（避免误匹配带引号的情况）
-                    if (valueStart < code.length()) {
-                        char firstChar = code.charAt(valueStart);
-                        if (firstChar != '"' && firstChar != '\'') {
-                            int valueEnd = valueStart;
-                            // 查找结束位置：逗号、右括号、空格或换行
-                            while (valueEnd < code.length()) {
-                                char c = code.charAt(valueEnd);
-                                if (c == ',' || c == ')' || c == ' ' || c == '\n' || c == '\t') break;
-                                valueEnd++;
-                            }
-                            if (valueEnd > valueStart) {
-                                return code.substring(valueStart, valueEnd).trim();
-                            }
-                        }
-                    }
-                }
-                return "";
-            }
-            
-            // Move to the opening quote
-            int valueStart = keyStart + key.length() + 2; // skip key="
-            if (valueStart >= code.length()) return "";
-            
-            // Find the closing quote by scanning character by character
-            // Handle escaped quotes
-            StringBuilder value = new StringBuilder();
-            boolean escaped = false;
-            for (int i = valueStart; i < code.length(); i++) {
-                char c = code.charAt(i);
-                if (escaped) {
-                    // Handle common escape sequences
-                    if (c == 'n') value.append('\n');
-                    else if (c == 't') value.append('\t');
-                    else if (c == 'r') value.append('\r');
-                    else value.append(c); // handles \\, \", \'
-                    escaped = false;
-                } else if (c == '\\') {
-                    escaped = true;
-                } else if (c == quoteChar) {
-                    // Found the closing quote
-                    return value.toString();
-                } else {
-                    value.append(c);
-                }
-            }
-            // If we reach here, no closing quote was found - return what we have
-            return value.toString();
-        } catch (Exception e) {
-            log.warn("Failed to extract arg {} from code {}", key, code.length() > 200 ? code.substring(0, 200) + "..." : code);
-        }
-        return "";
-    }
-    
-    /**
-     * Extract Python code from run_python(code='...') or run_python(code="...")
-     * Handles multi-line code and escaped quotes.
-     */
-    private String extractPythonCodeArg(String input) {
-        if (input == null) return "";
-        
-        try {
-            // Find the start of run_python(code=
-            int codeStart = input.indexOf("run_python(code=");
-            if (codeStart == -1) {
-                // Try alternative format: run_python(code =
-                codeStart = input.indexOf("run_python(code =");
-            }
-            if (codeStart == -1) return "";
-            
-            // Move to after "code="
-            int quoteStart = input.indexOf('=', codeStart) + 1;
-            
-            // Skip whitespace
-            while (quoteStart < input.length() && Character.isWhitespace(input.charAt(quoteStart))) {
-                quoteStart++;
-            }
-            
-            if (quoteStart >= input.length()) return "";
-            
-            char quoteChar = input.charAt(quoteStart);
-            if (quoteChar != '\'' && quoteChar != '"') return "";
-            
-            // Find the matching closing quote, accounting for escaped quotes
-            int quoteEnd = quoteStart + 1;
-            boolean escaped = false;
-            while (quoteEnd < input.length()) {
-                char c = input.charAt(quoteEnd);
-                if (escaped) {
-                    escaped = false;
-                } else if (c == '\\') {
-                    escaped = true;
-                } else if (c == quoteChar) {
-                    // Check if we're at the end: should be followed by ) or whitespace then )
-                    int afterQuote = quoteEnd + 1;
-                    while (afterQuote < input.length() && Character.isWhitespace(input.charAt(afterQuote))) {
-                        afterQuote++;
-                    }
-                    if (afterQuote >= input.length() || input.charAt(afterQuote) == ')') {
-                        break;
-                    }
-                }
-                quoteEnd++;
-            }
-            
-            if (quoteEnd >= input.length()) return "";
-            
-            String extracted = input.substring(quoteStart + 1, quoteEnd);
-            
-            // Unescape common escape sequences
-            extracted = extracted.replace("\\n", "\n");
-            extracted = extracted.replace("\\t", "\t");
-            extracted = extracted.replace("\\'", "'");
-            extracted = extracted.replace("\\\"", "\"");
-            extracted = extracted.replace("\\\\", "\\");
-            
-            return extracted;
-            
-        } catch (Exception e) {
-            log.warn("Failed to extract Python code from: {}", input, e);
-            return "";
-        }
-    }
 
     /**
      * Clean XML control tags from LLM output before saving to DB.
@@ -1555,117 +650,5 @@ public class AgentOrchestrator {
         }).collect(java.util.stream.Collectors.toList());
     }
 
-    /**
-     * 将工具代码转换为用户友好的中文显示名称。
-     * 这确保历史对话加载时显示的工具名称与实时流式时一致。
-     */
-    private String getToolDisplayName(String code) {
-        if (code == null || code.isEmpty()) return "工具执行";
-        
-        // PKULaw 法律工具
-        if (code.contains("get_law_article")) return "查询法条";
-        if (code.contains("law_search_keyword")) return "关键词搜索法规";
-        if (code.contains("law_recognition")) return "法条识别与溯源";
-        if (code.contains("law_search")) return "语义搜索法规";
-        
-        // 网络搜索工具
-        if (code.contains("search_web")) return "网络搜索";
-        if (code.contains("browse_url")) return "浏览网页";
-        
-        // 文档工具
-        if (code.contains("read_document")) return "读取文档";
-        if (code.contains("write_docx")) return "生成Word文档";
-        if (code.contains("write_file")) return "写入文件";
-        if (code.contains("read_file")) return "读取文件";
-        if (code.contains("list_files")) return "列出文件";
-        if (code.contains("search_project_files")) return "搜索项目文件";
-        if (code.contains("delete_file")) return "删除文件";
-        if (code.contains("move_file")) return "移动文件";
-        
-        // Python 工具
-        if (code.contains("run_python")) return "执行Python代码";
-        
-        // 知识库工具
-        if (code.contains("add_memory")) return "添加记忆";
-        if (code.contains("query_knowledge_base")) return "查询知识库";
-        
-        // PPTX 工具
-        if (code.contains("pptx_generate(")) return "生成PPT演示文稿";
-        if (code.contains("pptx_generate_outline")) return "生成PPT大纲";
-        if (code.contains("pptx_check_service")) return "检查PPT服务";
-        
-        return "工具执行";
-    }
-    private String parseToolName(String code) {
-        if (code == null) return "";
-        // e.g., my_plugin.my_tool(arg=...) -> my_tool
-        // or my_tool(arg=...) -> my_tool
-        int dot = code.indexOf('.');
-        int paren = code.indexOf('(');
-        if (paren == -1) return code.trim();
-        
-        if (dot != -1 && dot < paren) {
-            return code.substring(dot + 1, paren).trim();
-        }
-        return code.substring(0, paren).trim();
-    }
 
-    private String extractArgsAsJson(String code) {
-        // Convert method(k1="v1", k2=123, k3=true) to {"k1":"v1", "k2":123, "k3":true}
-        try {
-            int start = code.indexOf('(');
-            int end = code.lastIndexOf(')');
-            if (start == -1 || end == -1 || end <= start) return "{}";
-            
-            String argsStr = code.substring(start + 1, end).trim();
-            if (argsStr.isEmpty()) return "{}";
-            
-            cn.hutool.json.JSONObject json = new cn.hutool.json.JSONObject();
-            
-            // 匹配带双引号的字符串值: key="value"
-            java.util.regex.Pattern stringPattern = java.util.regex.Pattern.compile("(\\w+)\\s*=\\s*\"([^\"]*)\"");
-            java.util.regex.Matcher stringMatcher = stringPattern.matcher(argsStr);
-            while (stringMatcher.find()) {
-                json.set(stringMatcher.group(1), stringMatcher.group(2));
-            }
-            
-            // 匹配不带引号的数字或布尔值: key=123, key=true, key=false
-            java.util.regex.Pattern unquotedPattern = java.util.regex.Pattern.compile("(\\w+)\\s*=\\s*([^,\"\\)]+)");
-            java.util.regex.Matcher unquotedMatcher = unquotedPattern.matcher(argsStr);
-            while (unquotedMatcher.find()) {
-                String key = unquotedMatcher.group(1).trim();
-                String value = unquotedMatcher.group(2).trim();
-                
-                // 跳过已经通过字符串模式匹配的键
-                if (json.containsKey(key)) {
-                    continue;
-                }
-                
-                // 尝试解析为数字或布尔值
-                if ("true".equalsIgnoreCase(value) || "True".equals(value)) {
-                    json.set(key, true);
-                } else if ("false".equalsIgnoreCase(value) || "False".equals(value)) {
-                    json.set(key, false);
-                } else {
-                    try {
-                        // 尝试解析为整数
-                        json.set(key, Integer.parseInt(value));
-                    } catch (NumberFormatException e1) {
-                        try {
-                            // 尝试解析为浮点数
-                            json.set(key, Double.parseDouble(value));
-                        } catch (NumberFormatException e2) {
-                            // 保留为字符串
-                            json.set(key, value);
-                        }
-                    }
-                }
-            }
-            
-            return json.toString();
-        } catch (Exception e) {
-            log.warn("Failed to parse tool args from code: {}", code, e);
-            return "{}";
-        }
-    }
 }

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -5,14 +5,10 @@ import com.checkba.model.entity.ConversationSummary;
 import com.checkba.model.entity.MemoryEntry;
 import com.checkba.model.entity.ProjectMemory;
 import com.checkba.service.ai.context.ContextCompressor;
-import com.checkba.service.ai.context.ConversationSummarizer;
 import com.checkba.service.ai.context.ProjectContextHolder;
-import com.checkba.service.ai.memory.MemCellExtractor;
 import com.checkba.service.ai.memory.MemoryManager;
-import com.checkba.service.ai.memory.ProjectMemoryExtractor;
 import com.checkba.service.ai.tools.LegalTools;
 import com.checkba.service.ProjectAiMessageService;
-import dev.langchain4j.data.message.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,12 +36,9 @@ public class ContextAssemblerService {
     private final com.checkba.service.ProjectFileService projectFileService;
     private final com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService;
     
-    // 记忆系统组件
+    // 记忆系统组件（读侧：写侧见 MemoryPipelineService）
     private final MemoryManager memoryManager;
     private final ContextCompressor contextCompressor;
-    private final ConversationSummarizer conversationSummarizer;
-    private final ProjectMemoryExtractor projectMemoryExtractor;
-    private final MemCellExtractor memCellExtractor;
 
     /**
      * Assembles the full message stack for the LLM.
@@ -64,7 +57,8 @@ public class ContextAssemblerService {
             String taskListId,
             String planId,
             String projectId,
-            AgentMode agentMode) {
+            AgentMode agentMode,
+            Long userId) {
 
         java.util.List<dev.langchain4j.data.message.ChatMessage> messages = new java.util.ArrayList<>();
 
@@ -247,6 +241,9 @@ public class ContextAssemblerService {
         // 设置上下文（供 MemoryTools 使用）
         ProjectContextHolder.setProjectId(projectId);
         ProjectContextHolder.setConversationId(conversationId);
+        if (userId != null) {
+            ProjectContextHolder.setUserId(userId);
+        }
 
         // 2. 注入项目记忆（如果存在）
         Long projectIdLong = null;
@@ -271,6 +268,22 @@ public class ContextAssemblerService {
                 systemText.append("\n\n# 相关记忆\n");
                 for (MemoryEntry mem : relevantMemories) {
                     systemText.append("- [").append(mem.getMemoryType()).append("] ");
+                    if (mem.getMemoryKey() != null) {
+                        systemText.append(mem.getMemoryKey()).append(": ");
+                    }
+                    systemText.append(mem.getMemoryValue()).append("\n");
+                }
+            }
+        }
+
+        // 3. 注入用户级记忆（跨项目：偏好、行文习惯、常用表达）
+        if (userId != null) {
+            List<MemoryEntry> userMemories = memoryManager.retrieveUserMemories(userId, 5);
+            if (!userMemories.isEmpty()) {
+                systemText.append("\n\n# 用户偏好与习惯（跨项目记忆）\n");
+                systemText.append("以下是该用户长期积累的偏好与习惯，输出时应遵循：\n");
+                for (MemoryEntry mem : userMemories) {
+                    systemText.append("- ");
                     if (mem.getMemoryKey() != null) {
                         systemText.append(mem.getMemoryKey()).append(": ");
                     }
@@ -333,78 +346,6 @@ public class ContextAssemblerService {
         return messages;
     }
     
-    /**
-     * 对话结束后的记忆更新
-     * 在对话完成后调用，用于更新摘要和提取记忆
-     */
-    public void postConversationUpdate(String conversationId, String projectId, 
-                                        List<ChatMessage> messages) {
-        log.info("Post-conversation update: conversationId={}, messageCount={}", 
-                conversationId, messages.size());
-        
-        Long projectIdLong = null;
-        try {
-            projectIdLong = projectId != null ? Long.parseLong(projectId) : null;
-        } catch (NumberFormatException e) {
-            // ignore
-        }
-        
-        // 检查是否需要生成新摘要/Episode（超过 15 条消息）
-        if (messages.size() >= 15) {
-            try {
-                // 使用 Episode 生成器（借鉴 EverMemOS 的结构化情景记忆）
-                ConversationSummarizer.EpisodeResult episodeResult = 
-                        conversationSummarizer.generateEpisode(messages, conversationId, projectIdLong);
-                
-                ConversationSummarizer.SummaryResult summaryResult = episodeResult.getSummaryResult();
-                
-                // 更新完整的 Episode 信息
-                ConversationSummary summary = episodeResult.toEntity(conversationId, projectIdLong, null);
-                summary.setTokenCount(contextCompressor.estimateTokens(summaryResult.getSummaryText()));
-                summary.setMessageCount(messages.size());
-                
-                // 保存到数据库
-                memoryManager.updateConversationSummary(
-                        conversationId,
-                        summaryResult.getSummaryText(),
-                        summaryResult.getKeyPoints(),
-                        summaryResult.getLegalReferences(),
-                        summaryResult.getMentionedEntities(),
-                        summaryResult.getPendingTasks(),
-                        contextCompressor.estimateTokens(summaryResult.getSummaryText()),
-                        messages.size(),
-                        null  // lastMessageId - 可以从最后一条消息获取
-                );
-                
-                log.info("Episode generated: type={}, events={}, key points={}, legal refs={}",
-                        episodeResult.getEpisodeType(),
-                        episodeResult.getEvents() != null ? episodeResult.getEvents().size() : 0,
-                        summaryResult.getKeyPoints() != null ? summaryResult.getKeyPoints().size() : 0,
-                        summaryResult.getLegalReferences() != null ? summaryResult.getLegalReferences().size() : 0);
-            } catch (Exception e) {
-                log.error("Failed to generate Episode: {}", e.getMessage(), e);
-            }
-        }
-        
-        // 提取并更新项目记忆
-        if (projectIdLong != null) {
-            try {
-                // 1. 更新项目级记忆（法律引用、金额、日期等）
-                projectMemoryExtractor.extractAndUpdateProjectMemory(projectIdLong, messages);
-                
-                // 2. 使用 MemCellExtractor 自动提取原子记忆单元
-                // 这是借鉴 EverMemOS 的 MemCell 概念，使用 LLM 智能提取
-                int memCellCount = memCellExtractor.extractAndSave(projectIdLong, conversationId, messages);
-                
-                if (memCellCount > 0) {
-                    log.info("MemCell extraction completed: saved {} atomic memory units", memCellCount);
-                }
-            } catch (Exception e) {
-                log.error("Failed to extract project memory: {}", e.getMessage(), e);
-            }
-        }
-    }
-
     /**
      * Determines the current phase based on plan and task list state.
      * - CHAT: No plan, no task list (simple conversation)

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -1,0 +1,379 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.service.ai.tools.AgentToolComponent;
+import com.checkba.service.ai.tools.ToolContext;
+import com.checkba.service.ai.tools.ToolContextHolder;
+import com.checkba.service.ai.tools.ToolMeta;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agent.tool.ToolSpecifications;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 统一工具注册与分发层（能力层核心）。
+ *
+ * 职责：
+ * 1. 启动时扫描所有 {@link AgentToolComponent} Bean 中的 @Tool 方法并注册；
+ * 2. 运行时按需注册插件工具（PluginService 加载的 JAR 工具），使插件真正可被 Agent 调用；
+ * 3. 按工具名分发调用：反射绑定参数、注入 {@link ToolContext}（projectId 等以服务端上下文为准，
+ *    防止 LLM 伪造跨项目 ID）、容错转换 LLM 生成的参数值；
+ * 4. 暴露工具元数据（{@link ToolMeta}）供编排层做展示名与文件副作用处理。
+ *
+ * 编排器（AgentOrchestrator）不再感知任何具体工具类——新增工具只需实现
+ * AgentToolComponent 或作为插件放入 plugins/ 目录。
+ */
+@Service
+@Slf4j
+public class ToolRegistry {
+
+    /** 强制从服务端上下文注入的参数名（LLM 传入值一律忽略） */
+    private static final Set<String> SERVER_CONTEXT_PARAMS = Set.of("projectId", "conversationId", "userId");
+
+    /** LLM 历史上使用过的参数别名（协议容错，保持向后兼容） */
+    private static final Map<String, List<String>> ARG_ALIASES = Map.of(
+            "fileName", List.of("name", "filename"),
+            "markdownContent", List.of("markdown_content", "content"),
+            "filePath", List.of("path"),
+            "fileId", List.of("id")
+    );
+
+    /** 旧编排器为部分工具提供的缺省参数值（行为保持） */
+    private static final Map<String, Object> LEGACY_DEFAULTS = Map.of(
+            "wps_find_replace.replaceAll", Boolean.TRUE,
+            "wps_find_text.matchCase", Boolean.FALSE,
+            "wps_delete_text.deleteAll", Boolean.FALSE,
+            "list_files.subPath", ".",
+            "query_memory.type", "all",
+            "wps_get_paragraph.paragraphIndex", 1,
+            "wps_modify_paragraph.paragraphIndex", 1,
+            "wps_replace_nth_match.matchIndex", 1,
+            "wps_delete_match.matchIndex", 1
+    );
+
+    /** 工具名别名（旧 prompt 中出现过的名称映射到真实工具） */
+    public static final Map<String, String> TOOL_NAME_ALIASES = Map.of(
+            "search_laws", "search_web"
+    );
+
+    /**
+     * 一个已注册工具：宿主 Bean + 方法 + LLM 规格 + 产品元数据。
+     */
+    public record RegisteredTool(Object bean, Method method, ToolSpecification spec, ToolMeta meta, boolean fromPlugin) {
+
+        public String displayName() {
+            if (meta != null && !meta.displayName().isEmpty()) {
+                return meta.displayName();
+            }
+            return "工具执行";
+        }
+    }
+
+    /**
+     * 一次工具分发的结果。found=false 表示注册表中没有该工具。
+     */
+    public record ToolResult(String output, RegisteredTool tool, boolean found) {
+
+        public boolean success() {
+            return found && output != null && !output.startsWith("Error");
+        }
+    }
+
+    private final List<AgentToolComponent> toolComponents;
+    private final PluginService pluginService;
+
+    private final Map<String, RegisteredTool> builtinTools = new ConcurrentHashMap<>();
+    private final Map<String, RegisteredTool> pluginToolCache = new ConcurrentHashMap<>();
+    private final List<ToolSpecification> builtinSpecifications = new ArrayList<>();
+
+    public ToolRegistry(List<AgentToolComponent> toolComponents, PluginService pluginService) {
+        this.toolComponents = toolComponents;
+        this.pluginService = pluginService;
+    }
+
+    @PostConstruct
+    public void init() {
+        for (AgentToolComponent bean : toolComponents) {
+            registerBean(bean);
+        }
+        log.info("ToolRegistry initialized: {} built-in tools from {} components",
+                builtinTools.size(), toolComponents.size());
+    }
+
+    private void registerBean(Object bean) {
+        for (Method method : bean.getClass().getDeclaredMethods()) {
+            if (!method.isAnnotationPresent(Tool.class)) {
+                continue;
+            }
+            try {
+                ToolSpecification spec = ToolSpecifications.toolSpecificationFrom(method);
+                ToolMeta meta = method.getAnnotation(ToolMeta.class);
+                RegisteredTool previous = builtinTools.put(spec.name(),
+                        new RegisteredTool(bean, method, spec, meta, false));
+                if (previous != null) {
+                    log.warn("Duplicate tool name '{}' — {} overrides {}",
+                            spec.name(), bean.getClass().getSimpleName(),
+                            previous.bean().getClass().getSimpleName());
+                } else {
+                    builtinSpecifications.add(spec);
+                }
+            } catch (Exception e) {
+                log.error("Failed to register tool method {}.{}: {}",
+                        bean.getClass().getSimpleName(), method.getName(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 全部工具规格（内置 + 插件），传给 LLM 做原生 function calling。
+     */
+    public List<ToolSpecification> getAllSpecifications() {
+        List<ToolSpecification> all = new ArrayList<>(builtinSpecifications);
+        all.addAll(pluginService.getToolSpecifications());
+        return all;
+    }
+
+    public boolean hasTool(String name) {
+        return resolve(name).isPresent();
+    }
+
+    /**
+     * 已注册工具名，按长度降序（供 XML 协议解析做最长名优先匹配，
+     * 避免 pptx_generate 误匹配 pptx_generate_outline 的调用）。
+     */
+    public List<String> toolNamesLongestFirst() {
+        List<String> names = new ArrayList<>(builtinTools.keySet());
+        names.addAll(pluginService.getPluginTools().keySet());
+        names.sort(Comparator.comparingInt(String::length).reversed());
+        return names;
+    }
+
+    public Optional<RegisteredTool> resolve(String name) {
+        if (name == null || name.isEmpty()) {
+            return Optional.empty();
+        }
+        RegisteredTool tool = builtinTools.get(name);
+        if (tool != null) {
+            return Optional.of(tool);
+        }
+        // 插件工具：懒注册（插件可能在运行期热加载）
+        RegisteredTool cached = pluginToolCache.get(name);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        Object pluginBean = pluginService.getPluginTools().get(name);
+        if (pluginBean != null) {
+            for (Method method : pluginBean.getClass().getDeclaredMethods()) {
+                if (method.isAnnotationPresent(Tool.class) && method.getName().equals(name)) {
+                    try {
+                        ToolSpecification spec = ToolSpecifications.toolSpecificationFrom(method);
+                        RegisteredTool registered = new RegisteredTool(
+                                pluginBean, method, spec, method.getAnnotation(ToolMeta.class), true);
+                        pluginToolCache.put(name, registered);
+                        return Optional.of(registered);
+                    } catch (Exception e) {
+                        log.error("Failed to resolve plugin tool {}: {}", name, e.getMessage());
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 分发一次工具调用。
+     *
+     * @param name     工具名（支持 TOOL_NAME_ALIASES 别名）
+     * @param argsJson LLM 生成的 JSON 参数
+     * @param ctx      服务端上下文（覆盖同名参数）
+     */
+    public ToolResult execute(String name, String argsJson, ToolContext ctx) {
+        String resolvedName = TOOL_NAME_ALIASES.getOrDefault(name, name);
+        Optional<RegisteredTool> toolOpt = resolve(resolvedName);
+        if (toolOpt.isEmpty()) {
+            return new ToolResult("Tool not found or arguments invalid.", null, false);
+        }
+        RegisteredTool tool = toolOpt.get();
+
+        // 装填线程上下文：修复流式回调线程与请求线程不一致导致的 ThreadLocal 丢失/串会话问题
+        ToolContextHolder.set(ctx);
+        if (ctx != null) {
+            if (ctx.projectId() != null) {
+                ProjectContextHolder.setProjectId(String.valueOf(ctx.projectId()));
+            }
+            if (ctx.conversationId() != null) {
+                ProjectContextHolder.setConversationId(ctx.conversationId());
+            }
+            if (ctx.userId() != null) {
+                ProjectContextHolder.setUserId(ctx.userId());
+            }
+        }
+
+        try {
+            cn.hutool.json.JSONObject args = parseArgs(argsJson);
+            Object[] boundArgs = bindArguments(resolvedName, tool.method(), args, ctx);
+            Object result = tool.method().invoke(tool.bean(), boundArgs);
+            return new ToolResult(result != null ? result.toString() : "", tool, true);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            log.error("Tool '{}' execution failed", resolvedName, cause);
+            return new ToolResult("Error executing tool: " + cause.getMessage(), tool, true);
+        } catch (Exception e) {
+            log.error("Tool '{}' dispatch failed", resolvedName, e);
+            return new ToolResult("Error executing tool: " + e.getMessage(), tool, true);
+        } finally {
+            ToolContextHolder.clear();
+        }
+    }
+
+    private cn.hutool.json.JSONObject parseArgs(String argsJson) {
+        if (argsJson == null || argsJson.isBlank()) {
+            return new cn.hutool.json.JSONObject();
+        }
+        try {
+            return cn.hutool.json.JSONUtil.parseObj(argsJson);
+        } catch (Exception e) {
+            log.warn("Failed to parse tool args as JSON, using empty args: {}",
+                    argsJson.length() > 200 ? argsJson.substring(0, 200) + "..." : argsJson);
+            return new cn.hutool.json.JSONObject();
+        }
+    }
+
+    private Object[] bindArguments(String toolName, Method method, cn.hutool.json.JSONObject args, ToolContext ctx) {
+        Parameter[] params = method.getParameters();
+        Object[] values = new Object[params.length];
+
+        for (int i = 0; i < params.length; i++) {
+            Parameter p = params[i];
+            String paramName = p.getName();
+            Object value;
+
+            if (SERVER_CONTEXT_PARAMS.contains(paramName)) {
+                value = fromContext(paramName, ctx, p.getType());
+            } else if ("modelId".equals(paramName)) {
+                // modelId：优先 LLM 显式指定，缺省回落到会话所选模型
+                Object raw = rawArg(args, paramName);
+                value = convert(raw, p.getType());
+                if (value == null && ctx != null) {
+                    value = ctx.modelId();
+                }
+            } else {
+                Object raw = rawArg(args, paramName);
+                if (raw == null) {
+                    raw = LEGACY_DEFAULTS.get(toolName + "." + paramName);
+                }
+                value = convert(raw, p.getType());
+            }
+
+            if (value == null && p.getType().isPrimitive()) {
+                value = primitiveDefault(p.getType());
+            }
+            values[i] = value;
+        }
+        return values;
+    }
+
+    /** 按参数名取值，值为空串时尝试历史别名 */
+    private Object rawArg(cn.hutool.json.JSONObject args, String paramName) {
+        Object raw = args.get(paramName);
+        if (isBlank(raw)) {
+            for (String alias : ARG_ALIASES.getOrDefault(paramName, List.of())) {
+                Object aliased = args.get(alias);
+                if (!isBlank(aliased)) {
+                    return aliased;
+                }
+            }
+            return isBlank(raw) ? null : raw;
+        }
+        return raw;
+    }
+
+    private boolean isBlank(Object v) {
+        return v == null || (v instanceof String s && s.isEmpty());
+    }
+
+    private Object fromContext(String paramName, ToolContext ctx, Class<?> targetType) {
+        if (ctx == null) {
+            return null;
+        }
+        Object value = switch (paramName) {
+            case "projectId" -> ctx.projectId();
+            case "conversationId" -> ctx.conversationId();
+            case "userId" -> ctx.userId();
+            default -> null;
+        };
+        return convert(value, targetType);
+    }
+
+    /**
+     * 容错类型转换：处理 LLM 生成的 "null"/"None" 字符串、数字字符串、字符串布尔值等。
+     * 转换失败返回 null（与旧 safeParseXxx 行为一致：记录日志、不抛异常）。
+     */
+    Object convert(Object raw, Class<?> targetType) {
+        if (raw == null) {
+            return null;
+        }
+        // LLM 常把缺省参数写成字符串 "null"/"None"——对非字符串目标统一归一为 null
+        if (raw instanceof String s && targetType != String.class) {
+            String trimmed = s.trim();
+            if (trimmed.isEmpty() || "null".equalsIgnoreCase(trimmed) || "none".equalsIgnoreCase(trimmed)) {
+                return null;
+            }
+        }
+        try {
+            if (targetType == String.class) {
+                return raw instanceof String ? raw : String.valueOf(raw);
+            }
+            if (targetType == Long.class || targetType == long.class) {
+                return raw instanceof Number n ? n.longValue() : Long.parseLong(raw.toString().trim());
+            }
+            if (targetType == Integer.class || targetType == int.class) {
+                return raw instanceof Number n ? n.intValue() : Integer.parseInt(raw.toString().trim());
+            }
+            if (targetType == Double.class || targetType == double.class) {
+                return raw instanceof Number n ? n.doubleValue() : Double.parseDouble(raw.toString().trim());
+            }
+            if (targetType == Boolean.class || targetType == boolean.class) {
+                return raw instanceof Boolean b ? b : "true".equalsIgnoreCase(raw.toString().trim());
+            }
+            if (targetType == Map.class) {
+                if (raw instanceof cn.hutool.json.JSONObject obj) {
+                    return obj.toBean(Map.class);
+                }
+                return cn.hutool.json.JSONUtil.parseObj(raw.toString()).toBean(Map.class);
+            }
+            return raw;
+        } catch (Exception e) {
+            log.warn("Failed to convert tool arg '{}' to {}", raw, targetType.getSimpleName());
+            return null;
+        }
+    }
+
+    private Object primitiveDefault(Class<?> type) {
+        if (type == boolean.class) return Boolean.FALSE;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == double.class) return 0.0d;
+        return null;
+    }
+
+    /**
+     * 历史参数别名表（供 XML 协议解析器共用）。
+     */
+    public static List<String> aliasesFor(String paramName) {
+        return ARG_ALIASES.getOrDefault(paramName, List.of());
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/XmlToolCallParser.java
+++ b/backend/src/main/java/com/checkba/service/ai/XmlToolCallParser.java
@@ -1,0 +1,404 @@
+package com.checkba.service.ai;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * XML 工具调用协议（Root Bubble Protocol 的 &lt;tool_code&gt; 兜底路径）解析器。
+ *
+ * 部分模型不支持原生 function calling，或在 system prompt 强制 XML 输出时以
+ * <pre>&lt;tool_code&gt;tool_name(key="value", ...)&lt;/tool_code&gt;</pre>
+ * 形式发起调用。本类负责把这种自由文本解析为规范的 (toolName, argsJson)，
+ * 供 {@link ToolRegistry} 统一分发。
+ *
+ * 容错范围（历史行为保持）：
+ * - Python 风格 key="v" / key='v' / 三引号多行字符串 / 转义字符
+ * - JSON 风格 tool({"key":"value"})
+ * - Gemini 偶发的 &lt;ctrl46&gt; 定界符
+ * - 无引号数字参数 key=123
+ * - run_python 的多行代码参数优先解析（避免代码内出现其他工具名造成误匹配）
+ * - 最长工具名优先匹配（pptx_generate_outline 不被 pptx_generate 抢占）
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class XmlToolCallParser {
+
+    private static final Pattern TOOL_CODE_PATTERN = Pattern.compile("(?s)<(tool_code|code)>(.*?)</\\1>");
+    private static final Pattern PROCESS_NAME_PATTERN = Pattern.compile("<process[^>]*name=\"([^\"]*)\"[^>]*>");
+
+    private final ToolRegistry toolRegistry;
+
+    /**
+     * 一次解析出的工具调用。
+     *
+     * @param toolName 解析出的工具名（可能未注册，由分发层判定）
+     * @param argsJson 规范化后的 JSON 参数
+     * @param rawCode  原始 tool_code 文本（用于日志与反馈消息）
+     */
+    public record ParsedCall(String toolName, String argsJson, String rawCode) {
+    }
+
+    /**
+     * 内容中是否包含 XML 工具调用标签。
+     */
+    public boolean containsToolCall(String content) {
+        return content != null && (content.contains("<tool_code>") || content.contains("<code>"));
+    }
+
+    /**
+     * 提取 LLM 自选的 process 展示名（保持历史记录与实时流式一致）。
+     */
+    public Optional<String> extractProcessName(String content) {
+        Matcher m = PROCESS_NAME_PATTERN.matcher(content);
+        if (m.find() && m.group(1) != null && !m.group(1).isEmpty()) {
+            return Optional.of(m.group(1));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 解析内容中的全部工具调用（按出现顺序）。
+     */
+    public List<ParsedCall> parse(String content) {
+        List<ParsedCall> calls = new ArrayList<>();
+        if (content == null) {
+            return calls;
+        }
+        Matcher matcher = TOOL_CODE_PATTERN.matcher(content);
+        while (matcher.find()) {
+            String code = matcher.group(2).trim();
+            if (code.isEmpty()) {
+                continue;
+            }
+            calls.add(parseSingle(code));
+        }
+        return calls;
+    }
+
+    ParsedCall parseSingle(String code) {
+        // 1. run_python 最优先：其 code 参数内经常包含其他工具名，必须整体提取
+        if (code.startsWith("run_python(") || code.contains("run_python(code=")) {
+            String pythonCode = extractPythonCodeArg(code);
+            cn.hutool.json.JSONObject args = new cn.hutool.json.JSONObject();
+            args.set("code", pythonCode);
+            return new ParsedCall("run_python", args.toString(), code);
+        }
+
+        // 2. 解析调用名：优先取括号前的函数名（含 xx.yy 前缀时取 yy）
+        String toolName = resolveToolName(code);
+
+        // 3. JSON 风格整体参数：tool({"key":"value"})
+        String jsonArgs = tryExtractJsonObjectArgs(code);
+        if (jsonArgs != null) {
+            return new ParsedCall(toolName, jsonArgs, code);
+        }
+
+        // 4. 按目标工具的参数名逐个提取（支持多行/转义/三引号/ctrl46/无引号值）
+        cn.hutool.json.JSONObject args = new cn.hutool.json.JSONObject();
+        Optional<ToolRegistry.RegisteredTool> tool = toolRegistry.resolve(
+                ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(toolName, toolName));
+        if (tool.isPresent()) {
+            for (java.lang.reflect.Parameter p : tool.get().method().getParameters()) {
+                String paramName = p.getName();
+                String value = extractStringArg(code, paramName);
+                if (value.isEmpty()) {
+                    for (String alias : ToolRegistry.aliasesFor(paramName)) {
+                        value = extractStringArg(code, alias);
+                        if (!value.isEmpty()) {
+                            break;
+                        }
+                    }
+                }
+                if (!value.isEmpty()) {
+                    args.set(paramName, value);
+                }
+            }
+        } else {
+            // 未注册工具（可能是插件或幻觉调用）：通用 key=value 提取，交由分发层判定
+            args = cn.hutool.json.JSONUtil.parseObj(extractArgsAsJson(code));
+        }
+        return new ParsedCall(toolName, args.toString(), code);
+    }
+
+    /**
+     * 解析工具名：括号前的标识符精确匹配注册表；失败则按最长工具名扫描
+     * （兼容 print(legal_tools.search_web(...)) 之类的包裹写法）。
+     */
+    private String resolveToolName(String code) {
+        String leading = parseLeadingName(code);
+        String aliased = ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(leading, leading);
+        if (toolRegistry.hasTool(aliased)) {
+            return leading;
+        }
+        List<String> namesLongestFirst = toolRegistry.toolNamesLongestFirst();
+        for (String name : namesLongestFirst) {
+            if (code.contains(name + "(")) {
+                return name;
+            }
+        }
+        // 别名工具没有注册实体也允许命中（如 search_laws）
+        for (String alias : ToolRegistry.TOOL_NAME_ALIASES.keySet()) {
+            if (code.contains(alias + "(")) {
+                return alias;
+            }
+        }
+        // 最后兜底：无括号写法（如 Gemini 的 tool{key:<ctrl46>v<ctrl46>}），纯 contains 匹配
+        for (String name : namesLongestFirst) {
+            if (code.contains(name)) {
+                return name;
+            }
+        }
+        return leading;
+    }
+
+    private String parseLeadingName(String code) {
+        if (code == null) {
+            return "";
+        }
+        int paren = code.indexOf('(');
+        if (paren == -1) {
+            return code.trim();
+        }
+        String head = code.substring(0, paren).trim();
+        int dot = head.lastIndexOf('.');
+        return dot != -1 ? head.substring(dot + 1).trim() : head;
+    }
+
+    /**
+     * JSON 风格调用：tool({...}) → 直接返回 {...}；不是该风格返回 null。
+     */
+    private String tryExtractJsonObjectArgs(String code) {
+        int jsonStart = code.indexOf("({");
+        int jsonEnd = code.lastIndexOf("})");
+        if (jsonStart == -1 || jsonEnd == -1 || jsonEnd <= jsonStart) {
+            return null;
+        }
+        String jsonStr = code.substring(jsonStart + 1, jsonEnd + 1);
+        try {
+            return cn.hutool.json.JSONUtil.parseObj(jsonStr).toString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 从代码文本中提取字符串参数值。
+     * 处理顺序：ctrl46 定界符 → 三引号 → 单/双引号（含转义）→ 无引号值。
+     */
+    String extractStringArg(String code, String key) {
+        try {
+            // <ctrl46> 定界符格式：key:<ctrl46>value<ctrl46> 或 key=<ctrl46>value<ctrl46>
+            String ctrlDelimiter = "<ctrl46>";
+            for (String sep : new String[]{":", "="}) {
+                int keyStart = code.indexOf(key + sep + ctrlDelimiter);
+                if (keyStart != -1) {
+                    int valueStart = keyStart + key.length() + sep.length() + ctrlDelimiter.length();
+                    int valueEnd = code.indexOf(ctrlDelimiter, valueStart);
+                    if (valueEnd != -1) {
+                        return code.substring(valueStart, valueEnd);
+                    }
+                    int commaEnd = code.indexOf(",", valueStart);
+                    int braceEnd = code.indexOf("}", valueStart);
+                    int end = Math.min(commaEnd != -1 ? commaEnd : Integer.MAX_VALUE,
+                            braceEnd != -1 ? braceEnd : Integer.MAX_VALUE);
+                    return end != Integer.MAX_VALUE
+                            ? code.substring(valueStart, end).trim()
+                            : code.substring(valueStart).trim();
+                }
+            }
+
+            // Python 三引号：key="""...""" 或 key='''...'''
+            for (String quote : new String[]{"\"\"\"", "'''"}) {
+                int tripleStart = code.indexOf(key + "=" + quote);
+                if (tripleStart != -1) {
+                    int valueStart = tripleStart + key.length() + 1 + quote.length();
+                    int valueEnd = code.indexOf(quote, valueStart);
+                    return valueEnd != -1 ? code.substring(valueStart, valueEnd) : code.substring(valueStart);
+                }
+            }
+
+            // 单/双引号（逐字符扫描处理转义）
+            int keyStart = code.indexOf(key + "=\"");
+            char quoteChar = '"';
+            if (keyStart == -1) {
+                keyStart = code.indexOf(key + "='");
+                quoteChar = '\'';
+            }
+
+            // 无引号值：key=123 / key=true
+            if (keyStart == -1) {
+                int unquotedStart = code.indexOf(key + "=");
+                if (unquotedStart != -1) {
+                    int valueStart = unquotedStart + key.length() + 1;
+                    if (valueStart < code.length()) {
+                        char firstChar = code.charAt(valueStart);
+                        if (firstChar != '"' && firstChar != '\'') {
+                            int valueEnd = valueStart;
+                            while (valueEnd < code.length()) {
+                                char c = code.charAt(valueEnd);
+                                if (c == ',' || c == ')' || c == ' ' || c == '\n' || c == '\t') break;
+                                valueEnd++;
+                            }
+                            if (valueEnd > valueStart) {
+                                return code.substring(valueStart, valueEnd).trim();
+                            }
+                        }
+                    }
+                }
+                return "";
+            }
+
+            int valueStart = keyStart + key.length() + 2;
+            if (valueStart >= code.length()) {
+                return "";
+            }
+            StringBuilder value = new StringBuilder();
+            boolean escaped = false;
+            for (int i = valueStart; i < code.length(); i++) {
+                char c = code.charAt(i);
+                if (escaped) {
+                    if (c == 'n') value.append('\n');
+                    else if (c == 't') value.append('\t');
+                    else if (c == 'r') value.append('\r');
+                    else value.append(c);
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == quoteChar) {
+                    return value.toString();
+                } else {
+                    value.append(c);
+                }
+            }
+            return value.toString();
+        } catch (Exception e) {
+            log.warn("Failed to extract arg {} from code {}", key,
+                    code.length() > 200 ? code.substring(0, 200) + "..." : code);
+            return "";
+        }
+    }
+
+    /**
+     * 提取 run_python(code='...') 的多行代码参数（处理转义与结尾判定）。
+     */
+    String extractPythonCodeArg(String input) {
+        if (input == null) {
+            return "";
+        }
+        try {
+            int codeStart = input.indexOf("run_python(code=");
+            if (codeStart == -1) {
+                codeStart = input.indexOf("run_python(code =");
+            }
+            if (codeStart == -1) {
+                // run_python("...") 无 code= 前缀时退化为第一个引号串
+                return extractStringArg(input, "code");
+            }
+            int quoteStart = input.indexOf('=', codeStart) + 1;
+            while (quoteStart < input.length() && Character.isWhitespace(input.charAt(quoteStart))) {
+                quoteStart++;
+            }
+            if (quoteStart >= input.length()) {
+                return "";
+            }
+            char quoteChar = input.charAt(quoteStart);
+            if (quoteChar != '\'' && quoteChar != '"') {
+                return "";
+            }
+            int quoteEnd = quoteStart + 1;
+            boolean escaped = false;
+            while (quoteEnd < input.length()) {
+                char c = input.charAt(quoteEnd);
+                if (escaped) {
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == quoteChar) {
+                    int afterQuote = quoteEnd + 1;
+                    while (afterQuote < input.length() && Character.isWhitespace(input.charAt(afterQuote))) {
+                        afterQuote++;
+                    }
+                    if (afterQuote >= input.length() || input.charAt(afterQuote) == ')') {
+                        break;
+                    }
+                }
+                quoteEnd++;
+            }
+            if (quoteEnd >= input.length()) {
+                return "";
+            }
+            String extracted = input.substring(quoteStart + 1, quoteEnd);
+            extracted = extracted.replace("\\n", "\n");
+            extracted = extracted.replace("\\t", "\t");
+            extracted = extracted.replace("\\'", "'");
+            extracted = extracted.replace("\\\"", "\"");
+            extracted = extracted.replace("\\\\", "\\");
+            return extracted;
+        } catch (Exception e) {
+            log.warn("Failed to extract Python code from: {}", input, e);
+            return "";
+        }
+    }
+
+    /**
+     * 通用参数提取：method(k1="v1", k2=123, k3=true) → {"k1":"v1","k2":123,"k3":true}。
+     * 用于未注册工具（插件懒加载前/幻觉调用）的兜底。
+     */
+    String extractArgsAsJson(String code) {
+        try {
+            int start = code.indexOf('(');
+            int end = code.lastIndexOf(')');
+            if (start == -1 || end == -1 || end <= start) {
+                return "{}";
+            }
+            String argsStr = code.substring(start + 1, end).trim();
+            if (argsStr.isEmpty()) {
+                return "{}";
+            }
+            cn.hutool.json.JSONObject json = new cn.hutool.json.JSONObject();
+
+            Pattern stringPattern = Pattern.compile("(\\w+)\\s*=\\s*\"([^\"]*)\"");
+            Matcher stringMatcher = stringPattern.matcher(argsStr);
+            while (stringMatcher.find()) {
+                json.set(stringMatcher.group(1), stringMatcher.group(2));
+            }
+
+            Pattern unquotedPattern = Pattern.compile("(\\w+)\\s*=\\s*([^,\"\\)]+)");
+            Matcher unquotedMatcher = unquotedPattern.matcher(argsStr);
+            while (unquotedMatcher.find()) {
+                String key = unquotedMatcher.group(1).trim();
+                String value = unquotedMatcher.group(2).trim();
+                if (json.containsKey(key)) {
+                    continue;
+                }
+                if ("true".equalsIgnoreCase(value)) {
+                    json.set(key, true);
+                } else if ("false".equalsIgnoreCase(value)) {
+                    json.set(key, false);
+                } else {
+                    try {
+                        json.set(key, Integer.parseInt(value));
+                    } catch (NumberFormatException e1) {
+                        try {
+                            json.set(key, Double.parseDouble(value));
+                        } catch (NumberFormatException e2) {
+                            json.set(key, value);
+                        }
+                    }
+                }
+            }
+            return json.toString();
+        } catch (Exception e) {
+            log.warn("Failed to parse tool args from code: {}", code, e);
+            return "{}";
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
@@ -59,6 +59,9 @@ public class MemoryManager {
             segment.metadata().put("memoryId", saved.getId().toString());
             segment.metadata().put("projectId", String.valueOf(entry.getProjectId()));
             segment.metadata().put("memoryType", entry.getMemoryType());
+            if (entry.getScope() != null) {
+                segment.metadata().put("scope", entry.getScope());
+            }
             
             memoryEmbeddingStore.add(embedding, segment);
             log.debug("Memory embedding created for id={}", saved.getId());
@@ -145,6 +148,40 @@ public class MemoryManager {
      */
     public List<MemoryEntry> getProtectedMemories(Long projectId) {
         return memoryEntryRepository.findByProjectIdAndIsProtectedTrue(projectId);
+    }
+
+    // ==================== 作用域记忆操作 ====================
+
+    /**
+     * 获取用户级记忆（跨项目生效：偏好、常用表达、行文习惯）
+     */
+    public List<MemoryEntry> retrieveUserMemories(Long userId, int limit) {
+        if (userId == null) {
+            return Collections.emptyList();
+        }
+        return memoryEntryRepository.findByUserIdAndScope(
+                userId, MemoryEntry.MemoryScope.USER, PageRequest.of(0, limit));
+    }
+
+    /**
+     * 检索通用知识记忆（跨用户跨项目的领域知识）
+     */
+    public List<MemoryEntry> retrieveGlobalKnowledge(String keyword, int limit) {
+        if (keyword == null || keyword.isBlank()) {
+            return Collections.emptyList();
+        }
+        return memoryEntryRepository.searchByScopeAndKeyword(
+                MemoryEntry.MemoryScope.GLOBAL, keyword, PageRequest.of(0, limit));
+    }
+
+    /**
+     * 获取绑定到某个文件的记忆（如"该合同的审查结论"）
+     */
+    public List<MemoryEntry> retrieveFileMemories(Long sourceFileId) {
+        if (sourceFileId == null) {
+            return Collections.emptyList();
+        }
+        return memoryEntryRepository.findBySourceFileIdOrderByImportanceScoreDesc(sourceFileId);
     }
 
     // ==================== RRF 混合检索 ====================

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
@@ -1,0 +1,109 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.model.entity.ConversationSummary;
+import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.ConversationSummarizer;
+import dev.langchain4j.data.message.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 记忆写入管线（记忆层的"写侧"）。
+ *
+ * 在每轮 Agent 循环结束后由编排器异步触发，负责：
+ * 1. 对话摘要 / Episode 生成（消息数 >= EPISODE_THRESHOLD 时）
+ * 2. 项目级记忆提取（正则提取法律引用、金额、日期、当事人——低成本，每轮执行）
+ * 3. MemCell 原子记忆提取（LLM 提取——有成本，消息数 >= MEMCELL_THRESHOLD 时执行）
+ *
+ * 历史背景：此逻辑原以 ContextAssemblerService.postConversationUpdate 存在但从未被调用，
+ * 现拆分为独立服务并接入编排循环，使记忆的"读侧"（ContextAssembler）与"写侧"解耦。
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemoryPipelineService {
+
+    /** 触发 Episode 摘要生成的最小消息数 */
+    private static final int EPISODE_THRESHOLD = 15;
+    /** 触发 LLM MemCell 提取的最小消息数（控制每轮对话的 LLM 成本） */
+    private static final int MEMCELL_THRESHOLD = 4;
+
+    private final MemoryManager memoryManager;
+    private final ConversationSummarizer conversationSummarizer;
+    private final ProjectMemoryExtractor projectMemoryExtractor;
+    private final MemCellExtractor memCellExtractor;
+    private final ContextCompressor contextCompressor;
+
+    /**
+     * 一轮对话（Agent 循环）完成后的记忆更新。异步执行，失败不影响对话主流程。
+     */
+    @Async("taskExecutor")
+    public void onConversationTurnCompleted(String conversationId, String projectId,
+                                            Long userId, List<ChatMessage> messages) {
+        log.info("Memory pipeline triggered: conversationId={}, messageCount={}",
+                conversationId, messages.size());
+
+        Long projectIdLong = null;
+        try {
+            projectIdLong = projectId != null ? Long.parseLong(projectId) : null;
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+
+        // 1. 生成对话摘要 / Episode（借鉴 EverMemOS 的结构化情景记忆）
+        if (messages.size() >= EPISODE_THRESHOLD) {
+            try {
+                ConversationSummarizer.EpisodeResult episodeResult =
+                        conversationSummarizer.generateEpisode(messages, conversationId, projectIdLong);
+
+                ConversationSummarizer.SummaryResult summaryResult = episodeResult.getSummaryResult();
+
+                ConversationSummary summary = episodeResult.toEntity(conversationId, projectIdLong, null);
+                summary.setTokenCount(contextCompressor.estimateTokens(summaryResult.getSummaryText()));
+                summary.setMessageCount(messages.size());
+
+                memoryManager.updateConversationSummary(
+                        conversationId,
+                        summaryResult.getSummaryText(),
+                        summaryResult.getKeyPoints(),
+                        summaryResult.getLegalReferences(),
+                        summaryResult.getMentionedEntities(),
+                        summaryResult.getPendingTasks(),
+                        contextCompressor.estimateTokens(summaryResult.getSummaryText()),
+                        messages.size(),
+                        null
+                );
+
+                log.info("Episode generated: type={}, events={}, key points={}, legal refs={}",
+                        episodeResult.getEpisodeType(),
+                        episodeResult.getEvents() != null ? episodeResult.getEvents().size() : 0,
+                        summaryResult.getKeyPoints() != null ? summaryResult.getKeyPoints().size() : 0,
+                        summaryResult.getLegalReferences() != null ? summaryResult.getLegalReferences().size() : 0);
+            } catch (Exception e) {
+                log.error("Failed to generate Episode: {}", e.getMessage(), e);
+            }
+        }
+
+        // 2. 提取并更新项目记忆
+        if (projectIdLong != null) {
+            try {
+                // 2.1 项目级记忆（正则提取，低成本）
+                projectMemoryExtractor.extractAndUpdateProjectMemory(projectIdLong, messages);
+
+                // 2.2 MemCell 原子记忆（LLM 提取，控制触发频率）
+                if (messages.size() >= MEMCELL_THRESHOLD) {
+                    int memCellCount = memCellExtractor.extractAndSave(projectIdLong, conversationId, messages);
+                    if (memCellCount > 0) {
+                        log.info("MemCell extraction completed: saved {} atomic memory units", memCellCount);
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to extract project memory: {}", e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/AgentToolComponent.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/AgentToolComponent.java
@@ -1,0 +1,9 @@
+package com.checkba.service.ai.tools;
+
+/**
+ * 内置 Agent 工具组件的标记接口。
+ * 实现此接口的 Spring Bean 会被 ToolRegistry 自动扫描，
+ * 其中的 @Tool 方法注册为可分发工具——新增工具类只需实现本接口，无需改动编排器。
+ */
+public interface AgentToolComponent {
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -34,7 +34,7 @@ import java.io.OutputStream;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class FileTools {
+public class FileTools implements AgentToolComponent {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileTools.class);
 
@@ -54,6 +54,7 @@ public class FileTools {
         return backendPath;
     }
 
+    @ToolMeta(displayName = "搜索项目文件", category = "file")
     @Tool("Search for files in the project. Can specify a sub-directory.")
     public String search_project_files(
             @P("Filename pattern (e.g. '*Controller.java' or 'User*.java')") String fileNamePattern,
@@ -108,6 +109,7 @@ public class FileTools {
         }
     }
 
+    @ToolMeta(displayName = "读取文件", category = "file")
     @Tool("Read the content of a file. Provide path (absolute or relative to project root).")
     public String read_file(String filePath) {
         log.info("Tool: read_file called for {}", filePath);
@@ -129,6 +131,7 @@ public class FileTools {
         }
     }
 
+    @ToolMeta(displayName = "列出文件", category = "file")
     @Tool("List files and directories in a project's data folder. Note: This lists physical files, not database records. For database files, use wps_list_project_files or pptx_list_files.")
     public String list_files(
             @P("Project ID - files will be listed from data/projects/{projectId}/") Long projectId,
@@ -181,6 +184,7 @@ public class FileTools {
         }
     }
 
+    @ToolMeta(displayName = "写入文件", category = "file", fileEffect = "ADDED", fileArg = "fileName")
     @Tool("Write content to a text file. Registers the file in the project database for WPS access.")
     public String write_file(
             @P("Target filename (e.g. 'notes.txt')") String fileName, 
@@ -205,6 +209,7 @@ public class FileTools {
         }
     }
 
+    @ToolMeta(displayName = "生成Word文档", category = "file", fileEffect = "ADDED", fileArg = "fileName", refreshFiles = true)
     @Tool("【STRICTLY NEW FILES ONLY】Create a NEW .docx from Markdown. FORBIDDEN for 'revise', 'update', or 'modify' tasks. If a similar file exists, you MUST use wps_open_file to edit it. DO NOT create 'Revised_Version.docx'.")
     public String write_docx(
             @P("新文件名 (如 '报告.docx')") String fileName, 
@@ -265,6 +270,7 @@ public class FileTools {
         }
     }
 
+    @ToolMeta(displayName = "扫描项目文件", category = "file")
     @Tool("Actively scan the project directory and register any missing files to the database. Repair DB inconsistency.")
     public String scan_files(
         @P("Project ID") Long projectId
@@ -310,6 +316,7 @@ public class FileTools {
         }
     }
 
+    @ToolMeta(displayName = "删除文件", category = "file")
     @Tool("Delete a file. DISABLED: AI Agent is not allowed to delete files.")
     public String delete_file(String filePath) {
         log.info("Tool: delete_file called for {} - DENIED (AI Agent cannot delete files)", filePath);
@@ -317,6 +324,7 @@ public class FileTools {
         return "Error: Permission Denied. AI Agent is not allowed to delete files. You can only create, move, or rename files.";
     }
 
+    @ToolMeta(displayName = "移动文件", category = "file")
     @Tool("Move or Rename a file.")
     public String move_file(
             @P("Source path") String sourcePath,

--- a/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class LegalTools {
+public class LegalTools implements AgentToolComponent {
 
     private final ProjectFileService projectFileService;
     private final McpClientService mcpClientService;
@@ -29,6 +29,7 @@ public class LegalTools {
 
     // --- File Operations ---
 
+    @ToolMeta(displayName = "读取文档", category = "file")
     @Tool("Read document content. Use this to read files from the project. Provide fileId.")
     public String read_document(String fileId) {
         log.info("Tool: read_document called for fileId={}", fileId);
@@ -71,12 +72,14 @@ public class LegalTools {
 
     // --- PKULaw MCP Integration (using standard MCP SDK) ---
 
+    @ToolMeta(displayName = "语义搜索法规", category = "legal")
     @Tool("Search for laws and regulations using PKULaw MCP Semantic Search. Use this for general legal questions. Returns a list of relevant articles.")
     public String law_search(String query) {
         log.info("Tool: law_search (semantic) called for query='{}'", query);
         return mcpClientService.callTool("pkulaw-semantic", "search_article", Map.of("query", query));
     }
 
+    @ToolMeta(displayName = "关键词搜索法规", category = "legal")
     @Tool("Search for laws by keywords in title or fulltext. Use this when you need specific laws by name.")
     public String law_search_keyword(String title, String fulltext) {
         log.info("Tool: law_search_keyword called for title='{}', fulltext='{}'", title, fulltext);
@@ -87,12 +90,14 @@ public class LegalTools {
         return mcpClientService.callTool("pkulaw-keyword", "get_law_list", args);
     }
 
+    @ToolMeta(displayName = "法条识别与溯源", category = "legal")
     @Tool("Identify law names and articles from text and trace their source.")
     public String law_recognition(String text) {
         log.info("Tool: law_recognition called for text length={}", text.length());
         return mcpClientService.callTool("pkulaw-recognition", "law_recognition", Map.of("text", text));
     }
 
+    @ToolMeta(displayName = "查询法条", category = "legal")
     @Tool("Get the full content of a specific law article by its title and article number. Use this when you have article info from law_search results.")
     public String get_law_article(String title, String number) {
         log.info("Tool: get_law_article called for title='{}', number='{}'", title, number);

--- a/backend/src/main/java/com/checkba/service/ai/tools/MemoryTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/MemoryTools.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class MemoryTools {
+public class MemoryTools implements AgentToolComponent {
 
     private final MemoryManager memoryManager;
     private final ProjectMemoryExtractor projectMemoryExtractor;
@@ -42,45 +42,116 @@ public class MemoryTools {
     /**
      * 保存结构化记忆
      */
-    @Tool("保存重要信息到项目记忆中。用于存储关键决策、结论、事实、法律引用等需要长期保留的信息。")
+    @Tool("保存重要信息到记忆中。用于存储关键决策、结论、事实、法律引用、用户偏好等需要长期保留的信息。" +
+          "通过 scope 参数指定记忆归属：用户个人习惯用 user，项目事实用 project（默认），通用法律知识用 global。")
+    @ToolMeta(displayName = "保存记忆", category = "memory")
     public String save_memory(
             @P("记忆类型: decision(决策)/conclusion(结论)/fact(事实)/reference(法律引用)/preference(偏好)") String type,
             @P("记忆标题或关键词，用于后续检索") String key,
             @P("记忆内容，详细描述需要保存的信息") String value,
-            @P("是否为法律关键信息需要特别保护（如法条引用、金额、日期等），受保护信息在压缩时不会丢失") boolean isProtected
+            @P("是否为法律关键信息需要特别保护（如法条引用、金额、日期等），受保护信息在压缩时不会丢失") boolean isProtected,
+            @P("记忆作用域(可选，默认project): user(用户级，跨项目的个人偏好与习惯)/project(项目级)/conversation(仅本对话)/file(绑定文件)/global(通用领域知识)") String scope,
+            @P("来源文件ID(可选)，scope=file 时必填，将记忆绑定到具体文件") Long sourceFileId
     ) {
-        log.info("Tool: save_memory called type={}, key={}, protected={}", type, key, isProtected);
-        
+        log.info("Tool: save_memory called type={}, key={}, protected={}, scope={}", type, key, isProtected, scope);
+
         Long projectId = ProjectContextHolder.getProjectIdAsLong();
         String conversationId = ProjectContextHolder.getConversationId();
-        
-        if (projectId == null) {
+        Long userId = ProjectContextHolder.getUserId();
+
+        // 归一化作用域，非法值回落到项目级
+        String normalizedScope = (scope != null && MemoryEntry.MemoryScope.isValid(scope))
+                ? scope.toLowerCase() : MemoryEntry.MemoryScope.PROJECT;
+
+        // 用户级/通用知识不强依赖项目上下文，其余作用域必须有项目ID
+        boolean projectFree = MemoryEntry.MemoryScope.USER.equals(normalizedScope)
+                || MemoryEntry.MemoryScope.GLOBAL.equals(normalizedScope);
+        if (projectId == null && !projectFree) {
             return "错误：无法获取当前项目ID，请确保在项目上下文中使用此工具。";
         }
-        
+        if (MemoryEntry.MemoryScope.USER.equals(normalizedScope) && userId == null) {
+            return "错误：无法获取当前用户ID，无法保存用户级记忆。";
+        }
+        if (MemoryEntry.MemoryScope.FILE.equals(normalizedScope) && sourceFileId == null) {
+            return "错误：文件级记忆(scope=file)必须提供 sourceFileId。";
+        }
+
         // 验证类型
         if (!isValidMemoryType(type)) {
             return "错误：无效的记忆类型。请使用: decision, conclusion, fact, reference, preference";
         }
-        
+
         try {
             MemoryEntry entry = MemoryEntry.builder()
                     .projectId(projectId)
+                    .userId(userId)
                     .conversationId(conversationId)
                     .memoryType(type.toLowerCase())
                     .memoryKey(key)
                     .memoryValue(value)
                     .isProtected(isProtected)
                     .importanceScore(isProtected ? 1.0 : 0.7)
+                    .scope(normalizedScope)
+                    .sourceFileId(sourceFileId)
                     .build();
-            
+
             memoryManager.saveMemory(entry);
-            
-            return String.format("✓ 记忆已保存\n- 类型: %s\n- 关键词: %s\n- 受保护: %s", 
-                    type, key, isProtected ? "是" : "否");
+
+            return String.format("✓ 记忆已保存\n- 类型: %s\n- 作用域: %s\n- 关键词: %s\n- 受保护: %s",
+                    type, normalizedScope, key, isProtected ? "是" : "否");
         } catch (Exception e) {
             log.error("Failed to save memory: {}", e.getMessage(), e);
             return "保存记忆时出错: " + e.getMessage();
+        }
+    }
+
+    /**
+     * 获取用户画像（跨项目的用户级记忆）
+     */
+    @Tool("获取当前用户的画像信息：跨项目的用户偏好、行文习惯、常用表达等。在需要个性化输出（如按用户习惯起草文书）时使用。")
+    @ToolMeta(displayName = "获取用户画像", category = "memory")
+    public String get_user_profile() {
+        log.info("Tool: get_user_profile called");
+
+        Long userId = ProjectContextHolder.getUserId();
+        if (userId == null) {
+            return "错误：无法获取当前用户ID。";
+        }
+
+        try {
+            StringBuilder sb = new StringBuilder("# 用户画像\n\n");
+            boolean hasContent = false;
+
+            // 1. UserMemory 结构化偏好
+            Optional<com.checkba.model.entity.UserMemory> umOpt = memoryManager.getUserMemory(userId);
+            if (umOpt.isPresent() && umOpt.get().getPreferences() != null && !umOpt.get().getPreferences().isEmpty()) {
+                sb.append("## 偏好设置\n");
+                umOpt.get().getPreferences().forEach((k, v) ->
+                        sb.append("- ").append(k).append(": ").append(v).append("\n"));
+                hasContent = true;
+            }
+
+            // 2. 用户级记忆条目
+            List<MemoryEntry> userMemories = memoryManager.retrieveUserMemories(userId, 20);
+            if (!userMemories.isEmpty()) {
+                sb.append("\n## 用户级记忆（跨项目）\n");
+                for (MemoryEntry mem : userMemories) {
+                    sb.append("- [").append(mem.getMemoryType()).append("] ");
+                    if (mem.getMemoryKey() != null) {
+                        sb.append(mem.getMemoryKey()).append(": ");
+                    }
+                    sb.append(mem.getMemoryValue()).append("\n");
+                }
+                hasContent = true;
+            }
+
+            if (!hasContent) {
+                return "当前用户暂无画像信息。可以使用 save_memory(scope=\"user\") 保存用户偏好与习惯。";
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            log.error("Failed to get user profile: {}", e.getMessage(), e);
+            return "获取用户画像时出错: " + e.getMessage();
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/PptxEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PptxEditTools.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class PptxEditTools {
+public class PptxEditTools implements AgentToolComponent {
 
     private final WpsActionService wpsActionService;
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class PptxTools {
+public class PptxTools implements AgentToolComponent {
 
     private final PptxServiceClient pptxServiceClient;
     private final ProjectFileService projectFileService;
@@ -214,6 +214,7 @@ public class PptxTools {
 
     // ==================== 服务检查工具 ====================
 
+    @ToolMeta(displayName = "检查PPT服务", category = "pptx")
     @Tool("检查 PPTX 生成服务是否可用。在生成 PPT 之前应先调用此工具确认服务状态。")
     public String pptx_check_service() {
         log.info("Tool: pptx_check_service called");
@@ -230,6 +231,7 @@ public class PptxTools {
         }
     }
 
+    @ToolMeta(displayName = "生成PPT演示文稿", category = "pptx", fileEffect = "ADDED", fileArg = "fileName")
     @Tool("根据主题一键生成 PPTX 演示文稿。AI 将自动生成大纲、内容描述和幻灯片图片，最终输出可编辑的 PPTX 文件。默认保存到项目根目录（parentId 不传或传 null），只有用户明确指定保存位置时才需要查询文件夹。")
     public String pptx_generate(
             @P("PPT 主题或详细描述，如：'AI 在法律行业的应用' 或 '公司年度总结报告，包含业绩、成就和未来规划'") String topic,
@@ -239,8 +241,8 @@ public class PptxTools {
             @P("PPT 风格描述（可选），如：'科技风'、'商务简约'、'学术正式'。留空则使用默认风格。") String style,
             @P("输出语言：zh（中文，默认）、en（英文）、ja（日语）") String language
     ) {
-        // 调用带 modelId 的重载版本，使用默认模型配置
-        return pptx_generate(topic, projectId, parentId, fileName, style, language, null);
+        // 模型 ID 由 ToolRegistry 通过线程上下文透传（不暴露给 LLM 参数）
+        return pptx_generate(topic, projectId, parentId, fileName, style, language, ToolContextHolder.currentModelId());
     }
     
     /**
@@ -469,13 +471,14 @@ public class PptxTools {
         }
     }
 
+    @ToolMeta(displayName = "生成PPT大纲", category = "pptx")
     @Tool("生成 PPTX 大纲（不生成完整 PPT）。用于让用户先审阅和修改大纲结构，确认后再生成完整 PPT。")
     public String pptx_generate_outline(
             @P("PPT 主题或详细描述") String topic,
             @P("输出语言：zh（中文，默认）、en（英文）、ja（日语）") String language
     ) {
-        // 调用带 modelId 的重载版本
-        return pptx_generate_outline(topic, language, null);
+        // 模型 ID 由 ToolRegistry 通过线程上下文透传
+        return pptx_generate_outline(topic, language, ToolContextHolder.currentModelId());
     }
     
     /**
@@ -539,14 +542,15 @@ public class PptxTools {
 
     // ==================== 智能 PPT 修改工具 ====================
 
+    @ToolMeta(displayName = "智能修改PPT", category = "pptx", fileEffect = "MODIFIED")
     @Tool("智能修改 PPT 页面。会自动判断页面类型：如果是可编辑组件则直接修改文本，如果是纯图片则使用 AI 重新生成。这是修改 PPT 的首选工具。")
     public String pptx_smart_modify(
             @P("文件 ID（从 pptx_list_files 或 pptx_search_files 获取）") Long fileId,
             @P("页面索引（从 1 开始）") Integer pageIndex,
             @P("修改要求，用自然语言描述，如：'把汇报人改成韩泽伟'、'标题改成红色'、'删除第三个要点'") String modifyInstruction
     ) {
-        // 调用带 modelId 的重载版本，使用默认模型配置
-        return pptx_smart_modify(fileId, pageIndex, modifyInstruction, null);
+        // 模型 ID 由 ToolRegistry 通过线程上下文透传
+        return pptx_smart_modify(fileId, pageIndex, modifyInstruction, ToolContextHolder.currentModelId());
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class PythonTools {
+public class PythonTools implements AgentToolComponent {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PythonTools.class);
 
@@ -118,6 +118,7 @@ default_api = _ToolAPI()
 
 """;
 
+    @ToolMeta(displayName = "执行Python代码", category = "python")
     @Tool("Run Python script. Use this for data analysis, Tushare stock data, or Qichacha API. You can call default_api.read_document(fileId='...') to read project files. Returns stdout/stderr.")
     public String run_python(String code) {
         log.info("Tool: run_python called. Code length={}", code.length());

--- a/backend/src/main/java/com/checkba/service/ai/tools/ToolContext.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/ToolContext.java
@@ -1,0 +1,16 @@
+package com.checkba.service.ai.tools;
+
+/**
+ * 单次工具调用的运行时上下文。
+ * 由编排层在分发工具前构造，经 ToolRegistry 注入：
+ * - 与工具方法同名参数（projectId/conversationId/userId）强制以此为准，防止 LLM 伪造跨项目 ID；
+ * - modelId 优先取 LLM 显式传参，缺省时回落到此上下文；
+ * - 同时通过 {@link ToolContextHolder} 暴露给工具内部代码（如 PptxTools 的模型透传）。
+ */
+public record ToolContext(
+        Long projectId,
+        String conversationId,
+        Long userId,
+        String modelId
+) {
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/ToolContextHolder.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/ToolContextHolder.java
@@ -1,0 +1,32 @@
+package com.checkba.service.ai.tools;
+
+/**
+ * 工具执行期间的 ThreadLocal 上下文。
+ * 由 ToolRegistry 在调用工具方法前设置、调用结束后清理，
+ * 供工具实现读取无法（或不应）出现在 @Tool 签名里的上下文信息，
+ * 例如用户当前选择的模型 ID。
+ */
+public class ToolContextHolder {
+
+    private static final ThreadLocal<ToolContext> CONTEXT = new ThreadLocal<>();
+
+    public static void set(ToolContext context) {
+        CONTEXT.set(context);
+    }
+
+    public static ToolContext get() {
+        return CONTEXT.get();
+    }
+
+    public static void clear() {
+        CONTEXT.remove();
+    }
+
+    /**
+     * 当前调用的模型 ID（无上下文时返回 null）。
+     */
+    public static String currentModelId() {
+        ToolContext ctx = CONTEXT.get();
+        return ctx != null ? ctx.modelId() : null;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/ToolMeta.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/ToolMeta.java
@@ -1,0 +1,41 @@
+package com.checkba.service.ai.tools;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 工具的产品层元数据，与 langchain4j 的 @Tool（面向 LLM 的描述）互补。
+ * 声明式地替代编排器里手写的展示名映射和文件副作用通知逻辑，
+ * 新增工具无需再修改编排器。
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ToolMeta {
+
+    /**
+     * 面向用户的中文显示名（历史记录、过程气泡中展示）。
+     */
+    String displayName() default "";
+
+    /**
+     * 工具分类（file/legal/web/memory/document/pptx/python/plugin），用于后续的可见性控制与插件广场分组。
+     */
+    String category() default "";
+
+    /**
+     * 执行成功后对项目文件的影响："ADDED" 或 "MODIFIED"，空串表示无文件副作用。
+     */
+    String fileEffect() default "";
+
+    /**
+     * 携带受影响文件名的参数名；fileEffect 非空但此项为空时，前端显示为"Current Document"。
+     */
+    String fileArg() default "";
+
+    /**
+     * 执行成功后是否通知前端刷新文件树。
+     */
+    boolean refreshFiles() default false;
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  */
 @Component
 @Slf4j
-public class WebTools {
+public class WebTools implements AgentToolComponent {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(WebTools.class);
 
@@ -45,6 +45,7 @@ public class WebTools {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    @ToolMeta(displayName = "网络搜索", category = "web")
     @Tool("Search the web using Bocha AI. Useful for finding latest news, regulations, or legal cases. Returns a summary of search results.")
     public String search_web(String query) {
         log.info("Tool: search_web called for query='{}'", query);
@@ -133,6 +134,7 @@ public class WebTools {
         }
     }
 
+    @ToolMeta(displayName = "浏览网页", category = "web")
     @Tool("Browse a specific URL and extract its main content.")
     public String browse_url(String url) {
         log.info("Tool: browse_url called for url='{}'", url);

--- a/backend/src/main/java/com/checkba/service/ai/tools/WpsTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WpsTools.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class WpsTools {
+public class WpsTools implements AgentToolComponent {
 
     private final ProjectFileService projectFileService;
     private final ProjectFileRepository projectFileRepository;
@@ -271,6 +271,7 @@ public class WpsTools {
         }
     }
 
+    @ToolMeta(displayName = "查找替换", category = "document", fileEffect = "MODIFIED")
     @Tool("在 WPS 文档中查找并替换文本。所有修改将以修订模式进行，用户可以审阅后接受或拒绝。")
     public String wps_find_replace(
             @P("要查找的文本") String findText,
@@ -399,6 +400,7 @@ public class WpsTools {
         }
     }
 
+    @ToolMeta(displayName = "修改段落", category = "document", fileEffect = "MODIFIED")
     @Tool("修改 WPS 文档中指定段落的文本内容。修改将以修订模式进行，用户可以审阅后接受或拒绝。")
     public String wps_modify_paragraph(
             @P("段落索引，从 1 开始") Integer paragraphIndex,

--- a/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
@@ -1,0 +1,165 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.service.ai.tools.AgentToolComponent;
+import com.checkba.service.ai.tools.ToolContext;
+import com.checkba.service.ai.tools.ToolMeta;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ToolRegistry 单元测试：注册、分发、参数绑定、上下文注入、别名与遗留默认值。
+ */
+class ToolRegistryTest {
+
+    /**
+     * 测试用工具组件，覆盖各种参数绑定场景
+     */
+    static class FakeTools implements AgentToolComponent {
+
+        @Tool("Echo the text back")
+        @ToolMeta(displayName = "回声", category = "test", fileEffect = "ADDED", fileArg = "fileName")
+        public String echo(@P("text to echo") String text) {
+            return "echo:" + text;
+        }
+
+        @Tool("Report injected server context")
+        public String context_probe(@P("marker") String marker, Long projectId, String conversationId, Long userId) {
+            return projectId + "|" + conversationId + "|" + userId + "|" + marker;
+        }
+
+        @Tool("Write a docx file (alias binding test)")
+        public String write_docx(@P("file name") String fileName, @P("markdown") String markdownContent, Long projectId) {
+            return fileName + "::" + markdownContent + "::" + projectId;
+        }
+
+        @Tool("Numeric conversion test")
+        public String numbers(@P("an int") Integer a, @P("a long") Long b, @P("a bool") boolean c) {
+            return a + "/" + b + "/" + c;
+        }
+
+        @Tool("Model id passthrough test")
+        public String model_probe(@P("model") String modelId) {
+            return "model:" + modelId;
+        }
+
+        @Tool("Find replace legacy default test")
+        public String wps_find_replace(@P("find") String findText, @P("replace") String replaceText, @P("all") Boolean replaceAll) {
+            return findText + ">" + replaceText + ":" + replaceAll;
+        }
+
+        @Tool("ThreadLocal holder population test")
+        public String holder_probe() {
+            return "holder:" + ProjectContextHolder.getProjectIdAsLong() + "|" + ProjectContextHolder.getUserId();
+        }
+    }
+
+    private ToolRegistry registry;
+    private final ToolContext ctx = new ToolContext(5L, "conv-1", 7L, "google/gemini-2.5-pro");
+
+    @BeforeEach
+    void setUp() {
+        registry = new ToolRegistry(List.of(new FakeTools()), new PluginService());
+        registry.init();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ProjectContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("注册：@Tool 方法全部进入规格列表")
+    void registersAllTools() {
+        assertEquals(7, registry.getAllSpecifications().size());
+        assertTrue(registry.hasTool("echo"));
+        assertTrue(registry.hasTool("wps_find_replace"));
+        assertFalse(registry.hasTool("nonexistent"));
+    }
+
+    @Test
+    @DisplayName("分发：普通字符串参数")
+    void executesSimpleTool() {
+        ToolRegistry.ToolResult r = registry.execute("echo", "{\"text\":\"hi\"}", ctx);
+        assertTrue(r.found());
+        assertEquals("echo:hi", r.output());
+        assertEquals("回声", r.tool().displayName());
+        assertEquals("ADDED", r.tool().meta().fileEffect());
+    }
+
+    @Test
+    @DisplayName("安全：projectId/conversationId/userId 强制来自服务端上下文，LLM 传值被忽略")
+    void serverContextOverridesLlmArgs() {
+        ToolRegistry.ToolResult r = registry.execute("context_probe",
+                "{\"marker\":\"m\",\"projectId\":999,\"conversationId\":\"hacked\",\"userId\":666}", ctx);
+        assertEquals("5|conv-1|7|m", r.output());
+    }
+
+    @Test
+    @DisplayName("兼容：历史参数别名 name→fileName, markdown_content→markdownContent")
+    void bindsAliasedArgs() {
+        ToolRegistry.ToolResult r = registry.execute("write_docx",
+                "{\"name\":\"a.docx\",\"markdown_content\":\"# 标题\"}", ctx);
+        assertEquals("a.docx::# 标题::5", r.output());
+    }
+
+    @Test
+    @DisplayName("容错：数字字符串与 'null'/'None' 归一化")
+    void convertsNumericAndNullStrings() {
+        ToolRegistry.ToolResult r = registry.execute("numbers",
+                "{\"a\":\"3\",\"b\":\"null\",\"c\":\"true\"}", ctx);
+        assertEquals("3/null/true", r.output());
+    }
+
+    @Test
+    @DisplayName("modelId：LLM 未显式传参时回落到会话所选模型")
+    void modelIdFallsBackToContext() {
+        ToolRegistry.ToolResult r = registry.execute("model_probe", "{}", ctx);
+        assertEquals("model:google/gemini-2.5-pro", r.output());
+
+        ToolRegistry.ToolResult explicit = registry.execute("model_probe",
+                "{\"modelId\":\"openai/gpt-4o\"}", ctx);
+        assertEquals("model:openai/gpt-4o", explicit.output());
+    }
+
+    @Test
+    @DisplayName("行为保持：wps_find_replace 缺省 replaceAll=true")
+    void appliesLegacyDefaults() {
+        ToolRegistry.ToolResult r = registry.execute("wps_find_replace",
+                "{\"findText\":\"甲\",\"replaceText\":\"乙\"}", ctx);
+        assertEquals("甲>乙:true", r.output());
+    }
+
+    @Test
+    @DisplayName("修复：工具执行线程的 ProjectContextHolder 由注册表装填")
+    void populatesThreadLocalHolder() {
+        ProjectContextHolder.clear();
+        ToolRegistry.ToolResult r = registry.execute("holder_probe", "{}", ctx);
+        assertEquals("holder:5|7", r.output());
+    }
+
+    @Test
+    @DisplayName("未知工具：found=false 且返回统一提示")
+    void unknownToolNotFound() {
+        ToolRegistry.ToolResult r = registry.execute("no_such_tool", "{}", ctx);
+        assertFalse(r.found());
+        assertFalse(r.success());
+        assertEquals("Tool not found or arguments invalid.", r.output());
+    }
+
+    @Test
+    @DisplayName("别名：search_laws 等工具名别名可分发")
+    void resolvesToolNameAlias() {
+        // search_laws → search_web 不在 FakeTools 中，验证别名解析不误报 found
+        ToolRegistry.ToolResult r = registry.execute("search_laws", "{\"query\":\"q\"}", ctx);
+        assertFalse(r.found());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
@@ -1,0 +1,174 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.ai.tools.AgentToolComponent;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * XmlToolCallParser 单元测试：XML 兜底协议的各种历史容错格式。
+ */
+class XmlToolCallParserTest {
+
+    /**
+     * 用与生产同名的工具签名做解析目标
+     */
+    static class ProtocolFakeTools implements AgentToolComponent {
+
+        @Tool("web search")
+        public String search_web(@P("query") String query) {
+            return "";
+        }
+
+        @Tool("run python")
+        public String run_python(@P("code") String code) {
+            return "";
+        }
+
+        @Tool("write docx")
+        public String write_docx(@P("name") String fileName, @P("md") String markdownContent, Long projectId) {
+            return "";
+        }
+
+        @Tool("find replace")
+        public String wps_find_replace(@P("f") String findText, @P("r") String replaceText, @P("all") Boolean replaceAll) {
+            return "";
+        }
+
+        @Tool("gen ppt")
+        public String pptx_generate(@P("topic") String topic, Long projectId, @P("file") String fileName) {
+            return "";
+        }
+
+        @Tool("gen ppt outline")
+        public String pptx_generate_outline(@P("topic") String topic, @P("lang") String language) {
+            return "";
+        }
+    }
+
+    private XmlToolCallParser parser;
+
+    @BeforeEach
+    void setUp() {
+        ToolRegistry registry = new ToolRegistry(List.of(new ProtocolFakeTools()), new PluginService());
+        registry.init();
+        parser = new XmlToolCallParser(registry);
+    }
+
+    private XmlToolCallParser.ParsedCall single(String content) {
+        List<XmlToolCallParser.ParsedCall> calls = parser.parse(content);
+        assertEquals(1, calls.size(), "expected exactly one parsed call");
+        return calls.get(0);
+    }
+
+    @Test
+    @DisplayName("基本：key=\"value\" 形式")
+    void parsesSimpleCall() {
+        XmlToolCallParser.ParsedCall call = single("<tool_code>search_web(query=\"公司法第16条\")</tool_code>");
+        assertEquals("search_web", call.toolName());
+        assertEquals("公司法第16条", cn.hutool.json.JSONUtil.parseObj(call.argsJson()).getStr("query"));
+    }
+
+    @Test
+    @DisplayName("run_python：多行代码含其他工具名不被误匹配")
+    void parsesMultilinePython() {
+        String content = "<tool_code>run_python(code='import pandas\\n# search_web(query=\"x\") 是注释\\nprint(1)')</tool_code>";
+        XmlToolCallParser.ParsedCall call = single(content);
+        assertEquals("run_python", call.toolName());
+        String code = cn.hutool.json.JSONUtil.parseObj(call.argsJson()).getStr("code");
+        assertTrue(code.contains("import pandas"));
+        assertTrue(code.contains("print(1)"));
+        assertTrue(code.contains("\n"), "escaped newlines should be unescaped");
+    }
+
+    @Test
+    @DisplayName("三引号多行 + 参数别名 name→fileName")
+    void parsesTripleQuotedAndAlias() {
+        String content = "<tool_code>write_docx(name=\"备忘录.docx\", markdown_content=\"\"\"# 标题\n第一行\n第二行\"\"\")</tool_code>";
+        XmlToolCallParser.ParsedCall call = single(content);
+        assertEquals("write_docx", call.toolName());
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("备忘录.docx", args.getStr("fileName"));
+        assertTrue(args.getStr("markdownContent").contains("第二行"));
+    }
+
+    @Test
+    @DisplayName("JSON 风格：tool({\"key\":\"value\"})")
+    void parsesJsonStyleCall() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>wps_find_replace({\"findText\":\"甲方\",\"replaceText\":\"乙方\"})</tool_code>");
+        assertEquals("wps_find_replace", call.toolName());
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("甲方", args.getStr("findText"));
+        assertEquals("乙方", args.getStr("replaceText"));
+    }
+
+    @Test
+    @DisplayName("ctrl46 定界符 + 无括号写法（Gemini 兼容）")
+    void parsesCtrl46Format() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>pptx_generate_outline{language:<ctrl46>zh<ctrl46>,topic:<ctrl46>法律AI应用<ctrl46>}</tool_code>");
+        assertEquals("pptx_generate_outline", call.toolName());
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("zh", args.getStr("language"));
+        assertEquals("法律AI应用", args.getStr("topic"));
+    }
+
+    @Test
+    @DisplayName("最长名优先：pptx_generate_outline 不被 pptx_generate 抢占")
+    void longestNameWins() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>print(pptx_generate_outline(topic=\"年度总结\", language=\"zh\"))</tool_code>");
+        assertEquals("pptx_generate_outline", call.toolName());
+    }
+
+    @Test
+    @DisplayName("工具名别名：search_laws → 保留原名交由注册表映射")
+    void resolvesAliasName() {
+        XmlToolCallParser.ParsedCall call = single("<tool_code>search_laws(query=\"公司法\")</tool_code>");
+        assertEquals("search_laws", call.toolName());
+        assertEquals("公司法", cn.hutool.json.JSONUtil.parseObj(call.argsJson()).getStr("query"));
+    }
+
+    @Test
+    @DisplayName("<code> 标签与多个调用")
+    void parsesMultipleCallsAndCodeTag() {
+        String content = "<code>search_web(query=\"a\")</code>\n中间文本\n<tool_code>search_web(query=\"b\")</tool_code>";
+        List<XmlToolCallParser.ParsedCall> calls = parser.parse(content);
+        assertEquals(2, calls.size());
+        assertEquals("a", cn.hutool.json.JSONUtil.parseObj(calls.get(0).argsJson()).getStr("query"));
+        assertEquals("b", cn.hutool.json.JSONUtil.parseObj(calls.get(1).argsJson()).getStr("query"));
+    }
+
+    @Test
+    @DisplayName("process name 提取")
+    void extractsProcessName() {
+        assertEquals("搜索法规",
+                parser.extractProcessName("<process name=\"搜索法规\"><tool_code>x()</tool_code></process>").orElse(null));
+        assertTrue(parser.extractProcessName("no process here").isEmpty());
+    }
+
+    @Test
+    @DisplayName("转义字符：\\n \\\" 正确还原")
+    void handlesEscapes() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>search_web(query=\"第一行\\n带\\\"引号\\\"\")</tool_code>");
+        String q = cn.hutool.json.JSONUtil.parseObj(call.argsJson()).getStr("query");
+        assertEquals("第一行\n带\"引号\"", q);
+    }
+
+    @Test
+    @DisplayName("containsToolCall 判定")
+    void detectsToolCallPresence() {
+        assertTrue(parser.containsToolCall("<tool_code>x()</tool_code>"));
+        assertTrue(parser.containsToolCall("<code>x()</code>"));
+        assertFalse(parser.containsToolCall("纯文本回答"));
+        assertFalse(parser.containsToolCall(null));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemoryScopeTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemoryScopeTest.java
@@ -1,0 +1,113 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.model.entity.MemoryEntry;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.service.ai.tools.MemoryTools;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 记忆作用域测试：MemoryEntry 作用域模型与 save_memory 工具的作用域路由。
+ */
+class MemoryScopeTest {
+
+    @AfterEach
+    void tearDown() {
+        ProjectContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("作用域常量校验")
+    void validatesScopes() {
+        assertTrue(MemoryEntry.MemoryScope.isValid("user"));
+        assertTrue(MemoryEntry.MemoryScope.isValid("PROJECT"));
+        assertTrue(MemoryEntry.MemoryScope.isValid("file"));
+        assertTrue(MemoryEntry.MemoryScope.isValid("global"));
+        assertTrue(MemoryEntry.MemoryScope.isValid("conversation"));
+        assertFalse(MemoryEntry.MemoryScope.isValid("team"));
+        assertFalse(MemoryEntry.MemoryScope.isValid(null));
+    }
+
+    @Test
+    @DisplayName("实体默认作用域为 project")
+    void defaultsToProjectScope() {
+        MemoryEntry entry = MemoryEntry.builder().memoryType("fact").memoryValue("v").build();
+        assertEquals(MemoryEntry.MemoryScope.PROJECT, entry.getScope());
+    }
+
+    @Test
+    @DisplayName("save_memory：用户级记忆写入 userId 与 scope")
+    void savesUserScopedMemory() {
+        MemoryManager memoryManager = mock(MemoryManager.class);
+        MemoryTools tools = new MemoryTools(memoryManager,
+                mock(ProjectMemoryExtractor.class), mock(AgenticRetriever.class));
+
+        ProjectContextHolder.setProjectId("10");
+        ProjectContextHolder.setConversationId("conv-1");
+        ProjectContextHolder.setUserId(7L);
+
+        String result = tools.save_memory("preference", "行文风格", "偏好书面化、条款式表达", false, "user", null);
+        assertTrue(result.contains("✓"), "should succeed: " + result);
+
+        ArgumentCaptor<MemoryEntry> captor = ArgumentCaptor.forClass(MemoryEntry.class);
+        verify(memoryManager).saveMemory(captor.capture());
+        MemoryEntry saved = captor.getValue();
+        assertEquals(MemoryEntry.MemoryScope.USER, saved.getScope());
+        assertEquals(7L, saved.getUserId());
+        assertEquals("preference", saved.getMemoryType());
+    }
+
+    @Test
+    @DisplayName("save_memory：无 userId 时拒绝用户级记忆")
+    void rejectsUserScopeWithoutUserId() {
+        MemoryTools tools = new MemoryTools(mock(MemoryManager.class),
+                mock(ProjectMemoryExtractor.class), mock(AgenticRetriever.class));
+        ProjectContextHolder.setProjectId("10");
+
+        String result = tools.save_memory("preference", "k", "v", false, "user", null);
+        assertTrue(result.contains("错误"));
+    }
+
+    @Test
+    @DisplayName("save_memory：文件级记忆必须携带 sourceFileId")
+    void requiresSourceFileIdForFileScope() {
+        MemoryManager memoryManager = mock(MemoryManager.class);
+        MemoryTools tools = new MemoryTools(memoryManager,
+                mock(ProjectMemoryExtractor.class), mock(AgenticRetriever.class));
+        ProjectContextHolder.setProjectId("10");
+
+        String rejected = tools.save_memory("conclusion", "审查结论", "该合同存在对赌条款", false, "file", null);
+        assertTrue(rejected.contains("错误"));
+
+        String accepted = tools.save_memory("conclusion", "审查结论", "该合同存在对赌条款", true, "file", 33L);
+        assertTrue(accepted.contains("✓"));
+
+        ArgumentCaptor<MemoryEntry> captor = ArgumentCaptor.forClass(MemoryEntry.class);
+        verify(memoryManager).saveMemory(captor.capture());
+        assertEquals(33L, captor.getValue().getSourceFileId());
+        assertEquals(MemoryEntry.MemoryScope.FILE, captor.getValue().getScope());
+        assertEquals(1.0, captor.getValue().getImportanceScore());
+    }
+
+    @Test
+    @DisplayName("save_memory：非法作用域回落到 project")
+    void fallsBackToProjectScope() {
+        MemoryManager memoryManager = mock(MemoryManager.class);
+        MemoryTools tools = new MemoryTools(memoryManager,
+                mock(ProjectMemoryExtractor.class), mock(AgenticRetriever.class));
+        ProjectContextHolder.setProjectId("10");
+
+        String result = tools.save_memory("fact", "k", "v", false, "galaxy", null);
+        assertTrue(result.contains("✓"));
+
+        ArgumentCaptor<MemoryEntry> captor = ArgumentCaptor.forClass(MemoryEntry.class);
+        verify(memoryManager).saveMemory(captor.capture());
+        assertEquals(MemoryEntry.MemoryScope.PROJECT, captor.getValue().getScope());
+    }
+}


### PR DESCRIPTION
## 背景

AI 编排器缺乏分层设计（1671 行上帝类、~80 个工具的手写 if/else 分发写了两遍）、记忆机制不完善（提取管线是死代码、无用户/文件/通用知识作用域、插件系统加载后无法执行）。本 PR 是架构重构的 Phase 1：打地基。

## 核心改动

### 编排层瘦身（AgentOrchestrator 1671 → 660 行）
- 两套手写工具分发（原生 function calling + XML 兜底各一遍，~700 行）全部删除，统一走 `ToolRegistry`
- XML `<tool_code>` 协议解析抽为 `XmlToolCallParser`（多行 Python / 三引号 / JSON 风格 / `<ctrl46>` / 最长工具名优先，全容错并有单测）
- 编排器不再 import 任何具体工具类——**新增工具/插件不需要改编排器**

### 能力层（新增 ToolRegistry）
- 实现 `AgentToolComponent` 的 Bean 自动注册；**插件 JAR 工具懒注册——修复插件加载后从不被调用的问题**（插件广场地基）
- 安全：`projectId/conversationId/userId` 强制服务端注入，LLM 传值忽略，防伪造跨项目 ID
- 修复：工具执行发生在流式回调线程，原 ThreadLocal 上下文会丢失/串会话；现每次调用统一装填
- `@ToolMeta` 声明式元数据（中文显示名/分类/文件副作用），取代散落的硬编码通知

### 记忆分层
- `MemoryEntry` 新增 `scope`（user/project/conversation/file/global）+ `sourceFileId`（ddl-auto 自动迁移）
- `save_memory` 支持作用域路由；新增 `get_user_profile` 工具；用户级记忆每轮注入 system prompt
- **接线记忆写入管线**：原 `postConversationUpdate`（Episode 摘要 + 项目记忆提取 + MemCell 提取）写好但全仓库无人调用，现拆为 `MemoryPipelineService` 在每轮循环结束后异步触发（LLM 提取带消息数闸值控制成本）

### 文档与测试
- `docs/AI_ARCHITECTURE.md`：七层架构基线、与外包方案对照、Phase 2/3 路线图、5 条不变式
- 新增 27 个单测（工具分发/协议解析/记忆作用域）；全量 `mvn test` 68/68 通过

## 验证
- `mvn compile` / `mvn test` 全绿（JDK 21）
- 行为保持：参数别名（name→fileName 等）、遗留缺省值（replaceAll=true 等）、SSE 事件字典、增量保存、取消逻辑均未变

🤖 Generated with [Claude Code](https://claude.com/claude-code)