### PR TITLE
refactor(ai): AI 编排器 Phase 2——控制器与配置瘦身 + 拟人化记忆质量 / controller slimming & humanized memory

### DIFF
--- a/backend/src/main/java/com/checkba/config/AiContextProperties.java
+++ b/backend/src/main/java/com/checkba/config/AiContextProperties.java
@@ -1,0 +1,174 @@
+package com.checkba.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI 上下文与压缩相关配置（Phase 2：消灭散落在代码里的硬编码常量）。
+ *
+ * 配置前缀：ai.context
+ *
+ * 覆盖范围：
+ * - token 预算（总预算 + 各项预留），支持按模型覆盖总预算
+ * - token 估算系数（chars-per-token）
+ * - 压缩各层的保留条数
+ * - 文件大小/数量/字符数上限
+ * - OCR 支持的扩展名列表
+ */
+@Component
+@ConfigurationProperties(prefix = "ai.context")
+public class AiContextProperties {
+
+    /** 上下文总 token 预算（默认基于 GPT-4 128K / Gemini 1M 的保守值） */
+    private int maxContextTokens = 100000;
+
+    /** system prompt 预留 token */
+    private int systemPromptReserve = 8000;
+
+    /** 记忆注入预留 token */
+    private int memoryReserve = 5000;
+
+    /** 模型回复预留 token */
+    private int responseReserve = 8000;
+
+    /** token 估算系数：每个 token 约折合多少字符（中文约 1-2 token/字，英文约 0.25-0.5 token/字） */
+    private double charsPerToken = 2.0;
+
+    /**
+     * 按模型覆盖 token 总预算。
+     * key 为模型标识（小写），支持精确匹配或子串包含匹配（如 "gemini" 可匹配 "google/gemini-2.0-flash"）。
+     */
+    private Map<String, Integer> modelTokenBudgets = new HashMap<>();
+
+    /** 压缩各层的保留条数配置 */
+    private Compression compression = new Compression();
+
+    /** 文件上下文的大小/数量上限配置 */
+    private Files files = new Files();
+
+    /** 支持 OCR 的文件扩展名列表 */
+    private List<String> ocrExtensions = Arrays.asList("jpg", "jpeg", "png", "gif", "bmp", "webp", "pdf");
+
+    /**
+     * 解析指定模型的上下文总 token 预算：
+     * 1. 精确匹配 modelTokenBudgets 的 key（不区分大小写）
+     * 2. 子串匹配：key 包含于模型标识中
+     * 3. 否则返回默认 maxContextTokens
+     */
+    public int maxContextTokensFor(String modelKey) {
+        if (modelKey == null || modelKey.isBlank() || modelTokenBudgets.isEmpty()) {
+            return maxContextTokens;
+        }
+        String normalized = modelKey.toLowerCase();
+        Integer exact = modelTokenBudgets.get(normalized);
+        if (exact != null) {
+            return exact;
+        }
+        for (Map.Entry<String, Integer> e : modelTokenBudgets.entrySet()) {
+            if (normalized.contains(e.getKey().toLowerCase())) {
+                return e.getValue();
+            }
+        }
+        return maxContextTokens;
+    }
+
+    public static class Compression {
+        /** 使用已有摘要压缩时，摘要之后保留的最近消息条数 */
+        private int keepRecentWithSummary = 10;
+
+        /** 触发"摘要旧消息"所需的最少消息条数（低于此值不做摘要） */
+        private int minMessagesForSummarize = 6;
+
+        /** 摘要旧消息时保留的最近消息条数 */
+        private int keepRecentOnSummarize = 4;
+
+        /** 激进压缩时保留的最近消息条数 */
+        private int keepRecentAggressive = 2;
+
+        /** 不触发压缩时，历史消息的最大保留条数 */
+        private int maxHistoryMessages = 30;
+
+        /** 工具输出超过该字符数时触发压缩 */
+        private int toolOutputMaxChars = 2000;
+
+        /** 工具输出压缩后的目标字符数 */
+        private int toolOutputTargetChars = 1500;
+
+        public int getKeepRecentWithSummary() { return keepRecentWithSummary; }
+        public void setKeepRecentWithSummary(int keepRecentWithSummary) { this.keepRecentWithSummary = keepRecentWithSummary; }
+        public int getMinMessagesForSummarize() { return minMessagesForSummarize; }
+        public void setMinMessagesForSummarize(int minMessagesForSummarize) { this.minMessagesForSummarize = minMessagesForSummarize; }
+        public int getKeepRecentOnSummarize() { return keepRecentOnSummarize; }
+        public void setKeepRecentOnSummarize(int keepRecentOnSummarize) { this.keepRecentOnSummarize = keepRecentOnSummarize; }
+        public int getKeepRecentAggressive() { return keepRecentAggressive; }
+        public void setKeepRecentAggressive(int keepRecentAggressive) { this.keepRecentAggressive = keepRecentAggressive; }
+        public int getMaxHistoryMessages() { return maxHistoryMessages; }
+        public void setMaxHistoryMessages(int maxHistoryMessages) { this.maxHistoryMessages = maxHistoryMessages; }
+        public int getToolOutputMaxChars() { return toolOutputMaxChars; }
+        public void setToolOutputMaxChars(int toolOutputMaxChars) { this.toolOutputMaxChars = toolOutputMaxChars; }
+        public int getToolOutputTargetChars() { return toolOutputTargetChars; }
+        public void setToolOutputTargetChars(int toolOutputTargetChars) { this.toolOutputTargetChars = toolOutputTargetChars; }
+    }
+
+    public static class Files {
+        /** 单文件大小上限（字节），超过则跳过提取 */
+        private long maxFileSizeBytes = 10 * 1024 * 1024;
+
+        /** 一次上下文注入的最大文件数量（跨文件夹共享配额） */
+        private int maxFilesPerContext = 10;
+
+        /** 单文件注入的最大字符数（超出截断） */
+        private int maxCharsPerFile = 50000;
+
+        /** 文件夹扫描时单文件的最大字符数（超出截断） */
+        private int folderFileMaxChars = 20000;
+
+        /** chat 接口普通文件上下文的最大字符数 */
+        private int chatContextMaxChars = 6000;
+
+        /** chat 接口文件夹上下文的最大字符数 */
+        private int chatFolderContextMaxChars = 50000;
+
+        /** chat 接口选区内容的最大字符数 */
+        private int chatSelectionMaxChars = 1500;
+
+        public long getMaxFileSizeBytes() { return maxFileSizeBytes; }
+        public void setMaxFileSizeBytes(long maxFileSizeBytes) { this.maxFileSizeBytes = maxFileSizeBytes; }
+        public int getMaxFilesPerContext() { return maxFilesPerContext; }
+        public void setMaxFilesPerContext(int maxFilesPerContext) { this.maxFilesPerContext = maxFilesPerContext; }
+        public int getMaxCharsPerFile() { return maxCharsPerFile; }
+        public void setMaxCharsPerFile(int maxCharsPerFile) { this.maxCharsPerFile = maxCharsPerFile; }
+        public int getFolderFileMaxChars() { return folderFileMaxChars; }
+        public void setFolderFileMaxChars(int folderFileMaxChars) { this.folderFileMaxChars = folderFileMaxChars; }
+        public int getChatContextMaxChars() { return chatContextMaxChars; }
+        public void setChatContextMaxChars(int chatContextMaxChars) { this.chatContextMaxChars = chatContextMaxChars; }
+        public int getChatFolderContextMaxChars() { return chatFolderContextMaxChars; }
+        public void setChatFolderContextMaxChars(int chatFolderContextMaxChars) { this.chatFolderContextMaxChars = chatFolderContextMaxChars; }
+        public int getChatSelectionMaxChars() { return chatSelectionMaxChars; }
+        public void setChatSelectionMaxChars(int chatSelectionMaxChars) { this.chatSelectionMaxChars = chatSelectionMaxChars; }
+    }
+
+    public int getMaxContextTokens() { return maxContextTokens; }
+    public void setMaxContextTokens(int maxContextTokens) { this.maxContextTokens = maxContextTokens; }
+    public int getSystemPromptReserve() { return systemPromptReserve; }
+    public void setSystemPromptReserve(int systemPromptReserve) { this.systemPromptReserve = systemPromptReserve; }
+    public int getMemoryReserve() { return memoryReserve; }
+    public void setMemoryReserve(int memoryReserve) { this.memoryReserve = memoryReserve; }
+    public int getResponseReserve() { return responseReserve; }
+    public void setResponseReserve(int responseReserve) { this.responseReserve = responseReserve; }
+    public double getCharsPerToken() { return charsPerToken; }
+    public void setCharsPerToken(double charsPerToken) { this.charsPerToken = charsPerToken; }
+    public Map<String, Integer> getModelTokenBudgets() { return modelTokenBudgets; }
+    public void setModelTokenBudgets(Map<String, Integer> modelTokenBudgets) { this.modelTokenBudgets = modelTokenBudgets; }
+    public Compression getCompression() { return compression; }
+    public void setCompression(Compression compression) { this.compression = compression; }
+    public Files getFiles() { return files; }
+    public void setFiles(Files files) { this.files = files; }
+    public List<String> getOcrExtensions() { return ocrExtensions; }
+    public void setOcrExtensions(List<String> ocrExtensions) { this.ocrExtensions = ocrExtensions; }
+}

--- a/backend/src/main/java/com/checkba/config/PgVectorConfig.java
+++ b/backend/src/main/java/com/checkba/config/PgVectorConfig.java
@@ -17,11 +17,27 @@ import javax.sql.DataSource;
  * PgVector 配置类
  * 配置向量存储用于记忆语义检索
  * 如果 PgVector 不可用，回退到内存存储
+ *
+ * 向量维度从 EmbeddingModel 动态读取（如 nomic-embed-text=768、OpenAI=1536），
+ * 读取失败时回退到默认值。
  */
 @Configuration
 public class PgVectorConfig {
 
     private static final Logger log = LoggerFactory.getLogger(PgVectorConfig.class);
+
+    /** EmbeddingModel 维度探测失败时的回退维度（历史默认值） */
+    static final int FALLBACK_DIMENSION = 1536;
+
+    /** 维度探测结果缓存（探测可能触发一次真实 embed 调用，避免每个 store bean 各探测一次） */
+    private volatile Integer cachedDimension;
+
+    private int dimensionFor(EmbeddingModel embeddingModel) {
+        if (cachedDimension == null) {
+            cachedDimension = resolveDimension(embeddingModel);
+        }
+        return cachedDimension;
+    }
 
     @Value("${spring.datasource.url}")
     private String jdbcUrl;
@@ -38,13 +54,13 @@ public class PgVectorConfig {
      * 如果 PgVector 不可用，回退到内存存储
      */
     @Bean(name = "memoryEmbeddingStore")
-    public EmbeddingStore<TextSegment> memoryEmbeddingStore() {
+    public EmbeddingStore<TextSegment> memoryEmbeddingStore(EmbeddingModel embeddingModel) {
         // 从 JDBC URL 提取主机和数据库信息
         // jdbc:postgresql://localhost:5432/checkba
         String host = "localhost";
         int port = 5432;
         String database = "checkba";
-        
+
         try {
             String urlWithoutPrefix = jdbcUrl.replace("jdbc:postgresql://", "");
             String[] parts = urlWithoutPrefix.split("/");
@@ -68,7 +84,7 @@ public class PgVectorConfig {
                     .user(username)
                     .password(password)
                     .table("memory_embedding_store")  // 自动创建的表
-                    .dimension(1536)  // OpenAI embedding 维度，Ollama nomic-embed-text 是 768
+                    .dimension(dimensionFor(embeddingModel))
                     .createTable(true)
                     .build();
         } catch (Exception e) {
@@ -78,12 +94,28 @@ public class PgVectorConfig {
     }
 
     /**
+     * 从 EmbeddingModel 动态读取向量维度（替换原硬编码 1536）。
+     * 读取可能触发一次真实 embed 调用；模型不可用时回退到默认维度，保持原有启动行为。
+     */
+    static int resolveDimension(EmbeddingModel embeddingModel) {
+        try {
+            int dimension = embeddingModel.dimension();
+            log.info("Embedding dimension resolved from model: {}", dimension);
+            return dimension;
+        } catch (Exception e) {
+            log.warn("Failed to resolve embedding dimension from model, falling back to {}. 错误: {}",
+                    FALLBACK_DIMENSION, e.getMessage());
+            return FALLBACK_DIMENSION;
+        }
+    }
+
+    /**
      * 项目文档向量存储
      * 用于 RAG 检索项目文档
      * 如果 PgVector 不可用，回退到内存存储
      */
     @Bean(name = "projectDocEmbeddingStore")
-    public EmbeddingStore<TextSegment> projectDocEmbeddingStore() {
+    public EmbeddingStore<TextSegment> projectDocEmbeddingStore(EmbeddingModel embeddingModel) {
         String host = "localhost";
         int port = 5432;
         String database = "checkba";
@@ -111,7 +143,7 @@ public class PgVectorConfig {
                     .user(username)
                     .password(password)
                     .table("project_doc_embedding")
-                    .dimension(1536)
+                    .dimension(dimensionFor(embeddingModel))
                     .createTable(true)
                     .build();
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
@@ -4,94 +4,51 @@ import com.checkba.config.AiModelProperties;
 import com.checkba.controller.AuthController;
 import com.checkba.service.ProjectAiMessageService;
 import com.checkba.service.SystemSettingService;
-import com.checkba.service.UserService;
+import com.checkba.service.ai.AiChatService;
 import com.checkba.service.ai.AiDocxExportService;
-import com.checkba.service.ai.DynamicContentRetriever;
-import com.checkba.service.ai.GeminiChatLanguageModel;
-import com.checkba.service.ai.ProjectAssistant;
-import com.checkba.service.ai.context.ProjectContextHolder;
-import com.checkba.service.ai.tools.FileTools;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.service.AiServices;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import com.checkba.service.ai.AiAssistantService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.util.StringUtils;
 
 import java.util.Map;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import cn.hutool.json.JSONObject;
-import cn.hutool.json.JSONArray;
 
+/**
+ * AI Chat HTTP 接入层。
+ *
+ * 只负责 HTTP 出入口、鉴权（session → userId）与 DTO 定义；
+ * 业务编排下沉至 AiChatService 及各专职 Service（Phase 2 fat controller 治理）。
+ */
 @RestController
 @RequestMapping("/api/ai")
 public class AiChatController {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AiChatController.class);
 
-    private final ProjectAssistant defaultProjectAssistant;
+    private final AiChatService aiChatService;
+    private final AiAssistantService aiAssistantService;
     private final ProjectAiMessageService projectAiMessageService;
     private final AiDocxExportService aiDocxExportService;
-    private final UserService userService;
     private final AiModelProperties aiModelProperties;
-    private final DynamicContentRetriever dynamicContentRetriever;
-    private final FileTools fileTools;
     private final SystemSettingService systemSettingService;
-    private final com.checkba.service.ai.MediaProcessingService mediaProcessingService;
-    private final com.checkba.service.ProjectFileService projectFileService;
-    private final com.checkba.service.ai.ChatModelFactory chatModelFactory;
-    private final com.checkba.service.ai.TokenUsageService tokenUsageService;
-    private final com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService;
-
-    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
-    private static final String KEY_AI_ASSISTANTS = "ai.assistants";
-    
-    // For conversation metadata API
     private final com.checkba.service.ai.ConversationFileChangeService conversationFileChangeService;
     private final com.checkba.repository.TokenUsageRepository tokenUsageRepository;
-    
-    // Cache for Gemini Cache IDs: Map<ContentHash, CacheName>
-    // Simple in-memory cache to avoid re-uploading same content in short term. Ttl is handled by Gemini.
-    private final Map<String, String> activeGeminiCaches = new ConcurrentHashMap<>();
-
-    private final Map<String, ProjectAssistant> assistantCache = new ConcurrentHashMap<>();
-    
-
 
     public AiChatController(
-            ProjectAssistant defaultProjectAssistant,
+            AiChatService aiChatService,
+            AiAssistantService aiAssistantService,
             ProjectAiMessageService projectAiMessageService,
             AiDocxExportService aiDocxExportService,
-            UserService userService,
             AiModelProperties aiModelProperties,
-            DynamicContentRetriever dynamicContentRetriever,
-            FileTools fileTools,
             SystemSettingService systemSettingService,
-            com.checkba.service.ai.MediaProcessingService mediaProcessingService,
-            com.checkba.service.ProjectFileService projectFileService,
-            com.checkba.service.ai.ChatModelFactory chatModelFactory,
-            com.checkba.service.ai.TokenUsageService tokenUsageService,
-            com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService,
-            com.fasterxml.jackson.databind.ObjectMapper objectMapper,
             com.checkba.service.ai.ConversationFileChangeService conversationFileChangeService,
             com.checkba.repository.TokenUsageRepository tokenUsageRepository) {
-        this.defaultProjectAssistant = defaultProjectAssistant;
+        this.aiChatService = aiChatService;
+        this.aiAssistantService = aiAssistantService;
         this.projectAiMessageService = projectAiMessageService;
         this.aiDocxExportService = aiDocxExportService;
-        this.userService = userService;
         this.aiModelProperties = aiModelProperties;
-        this.dynamicContentRetriever = dynamicContentRetriever;
-        this.fileTools = fileTools;
         this.systemSettingService = systemSettingService;
-        this.mediaProcessingService = mediaProcessingService;
-        this.projectFileService = projectFileService;
-        this.chatModelFactory = chatModelFactory;
-        this.tokenUsageService = tokenUsageService;
-        this.fileContentExtractorService = fileContentExtractorService;
-        this.objectMapper = objectMapper;
         this.conversationFileChangeService = conversationFileChangeService;
         this.tokenUsageRepository = tokenUsageRepository;
     }
@@ -99,210 +56,26 @@ public class AiChatController {
     @PostMapping("/chat")
     public AiChatResponse chat(@RequestBody AiChatRequest request, @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         log.info("Received AI chat request for project {}: {} (model={})", request.getProjectId(), request.getMessage(), request.getModel());
-        try {
-            ProjectContextHolder.setProjectId(request.getProjectId());
 
-            // Get User ID
-            Long userId = null;
-            if (sessionId != null) {
-                userId = AuthController.getUserIdFromSession(sessionId);
-            }
-            
-            // 0. Handle Conversation ID
-            String conversationId = request.getConversationId();
-            if (!StringUtils.hasText(conversationId)) {
-                conversationId = java.util.UUID.randomUUID().toString();
-            }
-
-            // 1. Get Assistant Config
-            // 1. Get Assistant Config
-            String assistantId = StringUtils.hasText(request.getAssistantId()) ? request.getAssistantId() : "default";
-            
-            // Dynamic Load
-            Map<String, com.checkba.model.ai.AiAssistantConfig> currentAssistants = loadAssistants();
-            com.checkba.model.ai.AiAssistantConfig assistantConfig = currentAssistants.get(assistantId);
-            
-            if (assistantConfig == null && "default".equals(assistantId)) {
-                // Should not happen if DB is empty? Wait, user said "don't fallback".
-                // So if DB is empty, currentAssistants is empty, default is null.
-                // We must handle null config gracefully or throw error?
-                // "don't fallback or I won't know" -> throw error or handle as specific "System Default"? 
-                // Using a hardcoded fall-through minimal default just to prevent NPE if user hasn't config'd yet?
-                // The prompt logic handles null assistantConfig, so let's allow it to be null if not found.
-            }
-            
-            
-            // 2. Define Model Key and Initial Final Prompt
-            String modelKey = (request.getModel() != null ? request.getModel() : "default").toLowerCase();
-            String finalPrompt;
-            
-            // Logic: Skip context validation for Gemini as requested by user ("Gemini doesnt support context")
-            // Only Ollama/Local models get the full context injection.
-            if (modelKey.contains("gemini") || modelKey.contains("google")) {
-                 // Gemini: Just use the message (plus system prompt from assistant config if needed, but buildPromptWithContext adds system prompt too)
-                 // We should probably still use buildPromptWithContext but mocked context or null context?
-                 // Or just modify buildPromptWithContext to respect flag?
-                 // Let's manually construct prompt without context for Gemini.
-                 
-                 // However, we still might want System Prompt (role). 
-                 // The buildPromptWithContext does: System Prompt + Context + User Message.
-                 // We want: System Prompt + User Message.
-                 AiChatContext emptyContext = null;
-                 finalPrompt = buildPromptWithContext(request, assistantConfig, true); // Enabled context for Gemini standard files
-            } else {
-                 finalPrompt = buildPromptWithContext(request, assistantConfig, true);
-            }
-
-            // 3. Get LLM Service
-            ProjectAssistant assistant = getAssistant(request.getModel(), assistantConfig);
-            String response = "";
-            dev.langchain4j.service.Result<String> result = null;
-
-            // Handle Multi-Modal Context (Image/Video) or Native PDF for Gemini
-            // For now, only handle FIRST valid multi-modal context if multiple are present? 
-            // Or iterate. Let's simplify: if any context is image/video/pdf(gemini), we use the FIRST one found for multi-modal chat.
-            // Supporting multiple images is possible if we iterate.
-            
-            java.util.List<AiChatContext> contexts = request.getContexts();
-            if (contexts == null) {
-                contexts = new java.util.ArrayList<>();
-                if (request.getContext() != null) contexts.add(request.getContext());
-            }
-
-            boolean handledAsMultiModal = false;
-            boolean isGemini = modelKey.contains("gemini") || modelKey.contains("google");
-            
-            // Check for Native PDF (Gemini) or Images
-            // Basic strategy: Collect all images/pdfs and send in one message if supported.
-            // langchain4j UserMessage supports multiple Content items.
-            
-            java.util.List<dev.langchain4j.data.message.Content> multiModalContents = new java.util.ArrayList<>();
-            // Always add text prompt first
-            multiModalContents.add(dev.langchain4j.data.message.TextContent.from(finalPrompt));
-            
-            boolean hasMedia = false;
-            
-            for (AiChatContext ctx : contexts) {
-                if (ctx == null) continue;
-                String fType = ctx.getFileType() != null ? ctx.getFileType().toLowerCase() : "";
-                
-                // 1. Native PDF (Gemini)
-                if (isGemini && (fType.equals("pdf") || fType.endsWith("pdf"))) {
-                     try {
-                          Long fId = Long.parseLong(ctx.getFileId());
-                          byte[] fileBytes = projectFileService.getFileBytes(fId);
-                          if (fileBytes != null && fileBytes.length > 0) {
-                               String base64 = java.util.Base64.getEncoder().encodeToString(fileBytes);
-                               multiModalContents.add(dev.langchain4j.data.message.ImageContent.from(base64, "application/pdf"));
-                               hasMedia = true;
-                          }
-                     } catch (Exception e) {
-                          log.warn("Failed to attach PDF for Gemini", e);
-                     }
-                }
-                
-                // 2. Images / Video
-                boolean isImage = fType.matches("jpg|jpeg|png|gif|bmp|webp") || (fType.equals("image"));
-                boolean isVideo = fType.matches("mp4|mov|avi|mkv") || (fType.equals("video"));
-                
-                if (isImage || isVideo) {
-                    try {
-                        Long fileId = Long.parseLong(ctx.getFileId());
-                        // Use getFileBytes for safe retrieval
-                        byte[] fileBytes = projectFileService.getFileBytes(fileId);
-                        
-                        if (fileBytes != null && fileBytes.length > 0) {
-                            java.util.List<String> images = new java.util.ArrayList<>();
-                            
-                            if (isImage) {
-                                images.add(java.util.Base64.getEncoder().encodeToString(fileBytes));
-                            } else if (isVideo) {
-                                // For video keyframes, we need a physical temp file
-                                String ext = fType != null ? "." + fType : ".mp4";
-                                java.nio.file.Path tempVid = java.nio.file.Files.createTempFile("vid_ctx_" + fileId, ext);
-                                java.nio.file.Files.write(tempVid, fileBytes);
-                                try {
-                                    images = mediaProcessingService.extractKeyframes(tempVid.toFile(), 5); 
-                                } finally {
-                                    java.nio.file.Files.deleteIfExists(tempVid);
-                                }
-                            }
-
-                            for (String base64 : images) {
-                                String mimeType = isImage ? "image/" + fType.replace("jpg", "jpeg") : "image/jpeg";
-                                if (mimeType.equals("image/image")) mimeType = "image/jpeg";
-                                multiModalContents.add(dev.langchain4j.data.message.ImageContent.from(base64, mimeType));
-                                hasMedia = true;
-                            }
-                        }
-                    } catch (Exception e) {
-                        log.warn("Failed to process media content", e);
-                    }
-                }
-            }
-            
-            if (hasMedia) {
-                 dev.langchain4j.data.message.UserMessage userMessage = dev.langchain4j.data.message.UserMessage.from(multiModalContents);
-                 result = assistant.chat(userMessage);
-                 handledAsMultiModal = true;
-            } else {
-                 // Text Only
-                 result = assistant.chat(finalPrompt);
-            }
-            
-            // Extract content and usage
-            response = result.content();
-            if (result.tokenUsage() != null) {
-                tokenUsageService.recordUsage(
-                    Long.parseLong(request.getProjectId()), 
-                    userId, 
-                    request.getModel(), 
-                    result.tokenUsage(),
-                    conversationId
-                );
-            }
-
-            // Skip the old logic blocks below since we handled it above
-            boolean legacySkip = true; 
-            if (!legacySkip) {
-
-
-            }
-            
-            // 4. Record History
-            try {
-                projectAiMessageService.saveUserAndAssistantMessage(
-                        request.getProjectId(),
-                        userId,
-                        conversationId, // Pass conversationId
-                        request.getMessage(), 
-                        response
-                );
-            } catch (Exception logEx) {
-                log.warn("Failed to save AI chat history for project {}", request.getProjectId(), logEx);
-            }
-            // 6. Response
-            return new AiChatResponse(response, conversationId);
-            
-        } catch (Exception e) {
-            log.error("Error during AI chat", e);
-            return new AiChatResponse("Sorry, I encountered an error: " + e.getMessage(), request.getConversationId());
-        } finally {
-            ProjectContextHolder.clear();
+        Long userId = null;
+        if (sessionId != null) {
+            userId = AuthController.getUserIdFromSession(sessionId);
         }
+
+        return aiChatService.chat(request, userId);
     }
 
     @GetMapping("/history")
     public java.util.List<com.checkba.model.entity.ProjectAiMessage> getChatHistory(
-            @RequestParam(required = false) Long projectId, 
+            @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) String conversationId,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
-        
+
         // If conversationId is provided, return specific messages
         if (StringUtils.hasText(conversationId)) {
              return projectAiMessageService.listByConversationId(conversationId);
         }
-        
+
         // Fallback (or deprecated): List all messages for project/user if conversationId is missing
         // This keeps backward compatibility for now, or returns empty list if we want to enforce sessions.
         Long userId = null;
@@ -313,108 +86,6 @@ public class AiChatController {
              return projectAiMessageService.listByProjectAndUser(projectId, userId);
         }
         return java.util.Collections.emptyList();
-    }
-    
-    // --- Helper Methods for Folder Context & Caching ---
-    
-    // Use a counter class to pass by reference
-    private static class FileCountWrapper {
-        int count = 0;
-    }
-
-    private String collectFolderContent(Long projectId, Long folderId) {
-        StringBuilder sb = new StringBuilder();
-        FileCountWrapper counter = new FileCountWrapper();
-        collectFilesRecursive(projectId, folderId, sb, 0, counter);
-        return sb.toString();
-    }
-    
-    private void collectFilesRecursive(Long projectId, Long parentId, StringBuilder sb, int depth, FileCountWrapper counter) {
-        if (depth > 20) return; // depth safety
-        if (counter.count >= 10) return; // max file limit enforcement
-
-        List<com.checkba.model.entity.ProjectFile> children = projectFileService.getFilesByParent(projectId, parentId);
-        
-        // Sort children: files first, then folders? Or mixed. 
-        // Let's prioritize text files if we want to be smart, but simple interaction is fine.
-        
-        for (com.checkba.model.entity.ProjectFile file : children) {
-            if (counter.count >= 10) break;
-
-            if (Boolean.TRUE.equals(file.getIsFolder())) {
-                collectFilesRecursive(projectId, file.getId(), sb, depth + 1, counter);
-            } else {
-                // Try to extract text only if it's a supported file (text or binary)
-                // The service handles size check and type check.
-                if (Boolean.TRUE.equals(file.getIsFolder())) continue; // Just in case
-                
-                try {
-                    byte[] fileBytes = projectFileService.getFileBytes(file.getId());
-                    if (fileBytes != null && fileBytes.length > 0) {
-                        java.nio.file.Path tempP = java.nio.file.Files.createTempFile("folder_scan_" + file.getId(), ".tmp");
-                        try {
-                            java.nio.file.Files.write(tempP, fileBytes);
-                            String extracted = fileContentExtractorService.extractText(tempP.toFile());
-                            
-                            if (StringUtils.hasText(extracted)) {
-                                sb.append("\n--- File: ").append(file.getName()).append(" ---\n");
-                                sb.append(extracted).append("\n");
-                                counter.count++;
-                            }
-                        } finally {
-                            java.nio.file.Files.deleteIfExists(tempP);
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("Failed to read folder file content: {}", file.getName(), e);
-                }
-            }
-        }
-    }
-    
-
-
-    private String getOrCreateGeminiCache(String content) {
-        // Simple hash content to key
-        String hash = cn.hutool.crypto.digest.DigestUtil.md5Hex(content);
-        if (activeGeminiCaches.containsKey(hash)) {
-            // Validate validity? For now assume valid until TTL (default 1h). We can store timestamp.
-            return activeGeminiCaches.get(hash);
-        }
-        
-        // Create Cache via REST
-        AiModelProperties.Gemini geminiCfg = aiModelProperties.getGemini();
-        if (geminiCfg.getApiKey() == null) throw new RuntimeException("No API Key");
-        
-        String url = geminiCfg.getApiBaseUrl() + "/cachedContents?key=" + geminiCfg.getApiKey();
-        
-        JSONObject payload = new JSONObject();
-        payload.set("model", "models/" + geminiCfg.getModelName());
-        
-        JSONObject contentObj = new JSONObject();
-        contentObj.set("role", "user");
-        JSONArray parts = new JSONArray();
-        JSONObject part = new JSONObject();
-        part.set("text", content);
-        parts.add(part);
-        contentObj.set("parts", parts);
-        
-        payload.set("contents", java.util.Collections.singletonList(contentObj));
-        // payload.set("ttl", "600s"); // default 1h is fine
-        
-        String resp = cn.hutool.http.HttpRequest.post(url)
-                .body(payload.toString())
-                .execute()
-                .body();
-        
-        JSONObject json = cn.hutool.json.JSONUtil.parseObj(resp);
-        if (json.containsKey("name")) {
-            String cacheName = json.getStr("name");
-            activeGeminiCaches.put(hash, cacheName);
-            return cacheName;
-        } else {
-            throw new RuntimeException("Failed to create cache: " + resp);
-        }
     }
 
     @GetMapping("/conversations")
@@ -465,24 +136,7 @@ public class AiChatController {
 
     @GetMapping("/assistants")
     public java.util.Collection<com.checkba.model.ai.AiAssistantConfig> getAssistants() {
-        return loadAssistants().values();
-    }
-    
-    // Helper to load assistants
-    private Map<String, com.checkba.model.ai.AiAssistantConfig> loadAssistants() {
-        Map<String, com.checkba.model.ai.AiAssistantConfig> map = new java.util.LinkedHashMap<>(); // Preserve order
-        String json = systemSettingService.get(KEY_AI_ASSISTANTS, null);
-        if (json != null && !json.isBlank()) {
-            try {
-                java.util.List<com.checkba.model.ai.AiAssistantConfig> list = objectMapper.readValue(json, new com.fasterxml.jackson.core.type.TypeReference<java.util.List<com.checkba.model.ai.AiAssistantConfig>>() {});
-                for (com.checkba.model.ai.AiAssistantConfig cfg : list) {
-                    map.put(cfg.getId(), cfg);
-                }
-            } catch (Exception e) {
-                log.error("Failed to parse assistants config", e);
-            }
-        }
-        return map;
+        return aiAssistantService.loadAssistants().values();
     }
 
     /**
@@ -490,231 +144,13 @@ public class AiChatController {
      */
     @GetMapping("/config")
     public ResponseEntity<?> getAiConfig() {
-        String activeProvider = systemSettingService.get("ai.activeProvider", 
+        String activeProvider = systemSettingService.get("ai.activeProvider",
                 aiModelProperties.getProvider() != null ? aiModelProperties.getProvider().name() : "OLLAMA");
-        
+
         // Return a simple map or DTO
         Map<String, String> config = new java.util.HashMap<>();
         config.put("activeProvider", activeProvider);
         return ResponseEntity.ok(config);
-    }
-
-    private ProjectAssistant getAssistant(String modelId, com.checkba.model.ai.AiAssistantConfig assistantConfig) {
-        String key = (StringUtils.hasText(modelId) ? modelId : "default").toLowerCase();
-        boolean needsTools = assistantConfig != null && assistantConfig.getTools() != null && !assistantConfig.getTools().isEmpty();
-        
-        // Use a composite key for cache: model + assistantId
-        String assistantId = assistantConfig != null ? assistantConfig.getId() : "default";
-        String cacheKey = key + "_" + assistantId;
-
-        return assistantCache.computeIfAbsent(cacheKey, k -> {
-            ChatLanguageModel chatModel = chatModelFactory.getChatModel(modelId);
-            
-            var builder = AiServices.builder(ProjectAssistant.class)
-                    .chatLanguageModel(chatModel);
-
-            // Tools support (only for Ollama or if Model supports it)
-            // For now, only Ollama and OpenRouter (via OpenAI) support tools well in LangChain4j.
-            // Gemini manual impl does NOT support tools yet.
-            AiModelProperties.Provider provider = aiModelProperties.getProvider();
-            boolean isGemini = key.contains("gemini") || provider == AiModelProperties.Provider.GEMINI;
-            
-            if (needsTools && !isGemini) {
-                // builder.tools(fileTools); // Temporarily simplified: we need ContentRetriever to handle context
-            }
-            
-            // Inject Retriever if needed (usually RAG)
-            // builder.contentRetriever(dynamicContentRetriever); 
-            
-            return builder.build();
-        });
-    }
-
-    private static final int MAX_CONTEXT_CHARS = 6000;
-
-    private String buildPromptWithContext(AiChatRequest request, com.checkba.model.ai.AiAssistantConfig assistantConfig, boolean includeContext) {
-        // Consolidate contexts: list > single. If list is present, use it. If not, check single.
-        java.util.List<AiChatContext> contexts = request.getContexts();
-        if (contexts == null) {
-            contexts = new java.util.ArrayList<>();
-            if (request.getContext() != null) {
-                contexts.add(request.getContext());
-            }
-        }
-        
-        StringBuilder builder = new StringBuilder();
-
-        // 1. Inject Prompt (User Override or System)
-        // 1.1 Dynamic System Prompt from Admin (Model Specific)
-        String modelKey = (request.getModel() != null ? request.getModel() : "default").toLowerCase();
-        String dynamicSystemKey = null;
-        if (modelKey.contains("gemini") || modelKey.contains("google")) {
-            dynamicSystemKey = "ai.systemPrompt.GEMINI";
-        } else if (modelKey.contains("local") || modelKey.contains("ollama")) {
-            dynamicSystemKey = "ai.systemPrompt.OLLAMA";
-        }
-        
-        String dynamicSystemPrompt = dynamicSystemKey != null ? systemSettingService.get(dynamicSystemKey, "") : "";
-        if (StringUtils.hasText(dynamicSystemPrompt)) {
-             builder.append("【系统设定】\n").append(dynamicSystemPrompt).append("\n\n");
-        }
-
-        if (assistantConfig != null) {
-            String promptToUse = assistantConfig.getSystemPrompt();
-            String label = "【系统指令】";
-
-            // "User Prompt Prevails" Logic
-            if (StringUtils.hasText(assistantConfig.getUserPrompt())) {
-                promptToUse = assistantConfig.getUserPrompt();
-                label = "【用户自定义指令】(已覆盖系统默认)";
-            }
-
-            if (StringUtils.hasText(promptToUse)) {
-                builder.append(label).append("\n").append(promptToUse).append("\n\n");
-            }
-        }
-
-        if (!includeContext || contexts.isEmpty()) {
-            builder.append(request.getMessage());
-            return builder.toString();
-        }
-
-        builder.append("【当前上下文】\n");
-        
-        for (AiChatContext ctx : contexts) {
-            if (ctx == null) continue;
-            
-            builder.append("--- 文件: ")
-                    .append(StringUtils.hasText(ctx.getFileName()) ? ctx.getFileName() : "未命名文件");
-            if (StringUtils.hasText(ctx.getFileType())) {
-                builder.append(" (").append(ctx.getFileType()).append(")");
-            }
-            builder.append(" ---\n");
-            
-            // Fallback: If documentText is empty but fileId is present, try to read file content via backend
-            String documentText = ctx.getDocumentText();
-            if (!StringUtils.hasText(documentText) && StringUtils.hasText(ctx.getFileId()) && !"folder".equals(ctx.getFileType())) {
-                try {
-                    Long fileId = Long.parseLong(ctx.getFileId());
-                    com.checkba.model.entity.ProjectFile fileEntity = projectFileService.getFile(fileId);
-                    if (fileEntity != null && StringUtils.hasText(fileEntity.getFilePath())) {
-                        // Use getFileBytes to support both Local and OSS, avoiding relative path issues
-                        String fType = ctx.getFileType() != null ? ctx.getFileType().toLowerCase() : "";
-                        boolean isMediaFile = fType.matches("pdf|jpg|jpeg|png|gif|bmp|webp|image") || 
-                                              fileContentExtractorService.isOcrSupported(fileEntity.getName());
-                        
-                        boolean isMultiModalCapable = modelKey.contains("gemini") || 
-                                                      modelKey.contains("gpt-4") || 
-                                                      modelKey.contains("claude-3");
-                        
-                        boolean isPdf = fType.endsWith("pdf");
-                        boolean isImage = fType.matches("jpg|jpeg|png|gif|bmp|webp|image");
-                        
-                        // 决策：这类文件是否可以直接发送给模型（从而跳过文本提取）
-                        boolean canDirectSend = false;
-                        
-                        if (isPdf) {
-                            // 目前只有 Gemini 原生支持 PDF 直传
-                            canDirectSend = modelKey.contains("gemini") || modelKey.contains("google");
-                        } else if (isImage) {
-                            // 图片通常所有多模态模型都支持
-                            canDirectSend = isMultiModalCapable;
-                        }
-                        
-                        if (isMediaFile) { // isMediaFile 包含了 OCR_EXTENSIONS (pdf, images)
-                            log.info("Process Context File: name={}, type={}, isMultiModal={}, canDirectSend={}", 
-                                    fileEntity.getName(), fType, isMultiModalCapable, canDirectSend);
-                                    
-                            if (canDirectSend) {
-                                // 多模态模型：跳过文本提取，将在多模态路径直传原文件
-                                documentText = "[多模态模型将直接处理该文件，无需文本提取]";
-                                log.info("-> Skip extraction for multimodal (Direct Send)");
-                            }
-                        }
-                        
-                        // 4. 读取文件内容（针对非多模态模型或 PDF 回退 OCR）
-                        java.nio.file.Path tempPath = null;
-                        try {
-                            if (documentText == null) { // 如果上面多模态直传没处理
-                                log.info("-> Text extraction needed. Retrieving file content...");
-                                
-                                byte[] fileBytes = projectFileService.getFileBytes(fileEntity.getId());
-                                if (fileBytes != null && fileBytes.length > 0) {
-                                    // 创建临时文件用于 OCR/Tika
-                                    String tempName = "ocr_ctx_" + fileEntity.getId() + "_" + System.currentTimeMillis();
-                                    String ext = fileEntity.getFileType() != null ? "." + fileEntity.getFileType() : ".tmp";
-                                    tempPath = java.nio.file.Files.createTempFile(tempName, ext);
-                                    java.nio.file.Files.write(tempPath, fileBytes);
-                                    java.io.File physicalFile = tempPath.toFile();
-                                    
-                                    if (fileContentExtractorService.isOcrSupported(fileEntity.getName())) {
-                                        log.info("-> Using OCR extraction for: {}", fileEntity.getName());
-                                        documentText = fileContentExtractorService.extractTextWithOcr(physicalFile);
-                                    } else {
-                                        log.info("-> Using standard extraction for: {}", fileEntity.getName());
-                                        documentText = fileContentExtractorService.extractText(physicalFile);
-                                    }
-                                } else {
-                                     log.warn("File content is empty or not found via service: {}", fileEntity.getName());
-                                     documentText = "[文件内容为空或无法读取]";
-                                }
-                            }
-                        } catch (Exception e) {
-                            log.warn("Failed to read context file content in backend", e);
-                            documentText = "[读取文件失败: " + e.getMessage() + "]";
-                        } finally {
-                            if (tempPath != null) {
-                                try {
-                                    java.nio.file.Files.deleteIfExists(tempPath);
-                                } catch (Exception ignore) {}
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                     log.warn("Failed to read context file content in backend", e);
-                     documentText = "[System: Error reading file content: " + e.getMessage() + "]";
-                }
-            } else if ("folder".equals(ctx.getFileType()) && StringUtils.hasText(ctx.getFileId())) {
-                // Inline Folder Content Logic (moved from main chat method to allow multi-folder)
-                try {
-                     Long folderId = Long.parseLong(ctx.getFileId());
-                     documentText = collectFolderContent(Long.parseLong(request.getProjectId()), folderId);
-                } catch (Exception e) {
-                     documentText = "[System: Failed to load folder content: " + e.getMessage() + "]";
-                }
-            }
-            
-            String selection = safeContextBlock(ctx.getSelectionText(), 1500);
-            if (StringUtils.hasText(selection)) {
-                builder.append("选区内容:\n```\n")
-                        .append(selection)
-                        .append("\n```\n");
-            }
-            // For folders, we allow larger context
-            int maxChars = "folder".equals(ctx.getFileType()) ? 50000 : MAX_CONTEXT_CHARS; 
-            String document = safeContextBlock(documentText, maxChars);
-            if (StringUtils.hasText(document)) {
-                builder.append("正文内容:\n```\n")
-                        .append(document)
-                        .append("\n```\n");
-            }
-            builder.append("\n");
-        }
-        
-        builder.append("\n【用户请求】\n")
-                .append(request.getMessage());
-        return builder.toString();
-    }
-
-    private String safeContextBlock(String raw, int maxLen) {
-        if (!StringUtils.hasText(raw)) {
-            return "";
-        }
-        String cleaned = raw.trim();
-        if (cleaned.length() <= maxLen) {
-            return cleaned;
-        }
-        return cleaned.substring(0, maxLen) + "\n...[上下文截断 " + (cleaned.length() - maxLen) + " 字]";
     }
 
     /**
@@ -758,7 +194,7 @@ public class AiChatController {
             return ResponseEntity.status(500).body("导出 Word 失败: " + e.getMessage());
         }
     }
-    
+
     public static class AiChatRequest {
         private String projectId;
         private String message;
@@ -783,13 +219,13 @@ public class AiChatController {
         public String getConversationId() { return conversationId; }
         public void setConversationId(String conversationId) { this.conversationId = conversationId; }
     }
-    
+
     public static class AiChatResponse {
         private String response;
         private String conversationId;
         public AiChatResponse(String response) { this.response = response; }
-        public AiChatResponse(String response, String conversationId) { 
-            this.response = response; 
+        public AiChatResponse(String response, String conversationId) {
+            this.response = response;
             this.conversationId = conversationId;
         }
         public String getResponse() { return response; }

--- a/backend/src/main/java/com/checkba/model/entity/MemoryEntry.java
+++ b/backend/src/main/java/com/checkba/model/entity/MemoryEntry.java
@@ -113,6 +113,18 @@ public class MemoryEntry {
     @Column(name = "expires_at")
     private LocalDateTime expiresAt;
 
+    /**
+     * 最近一次检索命中时间（用于检索排序的时间衰减；受保护记忆不衰减）
+     */
+    @Column(name = "last_accessed_at")
+    private LocalDateTime lastAccessedAt;
+
+    /**
+     * 累计检索命中次数（"复述效应"：被反复想起的记忆衰减更慢）
+     */
+    @Column(name = "access_count")
+    private Integer accessCount = 0;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
@@ -164,6 +176,10 @@ public class MemoryEntry {
     public void setIsProtected(Boolean isProtected) { this.isProtected = isProtected; }
     public LocalDateTime getExpiresAt() { return expiresAt; }
     public void setExpiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; }
+    public LocalDateTime getLastAccessedAt() { return lastAccessedAt; }
+    public void setLastAccessedAt(LocalDateTime lastAccessedAt) { this.lastAccessedAt = lastAccessedAt; }
+    public Integer getAccessCount() { return accessCount; }
+    public void setAccessCount(Integer accessCount) { this.accessCount = accessCount; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
@@ -173,6 +189,9 @@ public class MemoryEntry {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
+        if (lastAccessedAt == null) {
+            lastAccessedAt = createdAt;
+        }
     }
 
     @PreUpdate

--- a/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
@@ -74,6 +74,15 @@ public interface MemoryEntryRepository extends JpaRepository<MemoryEntry, Long> 
     void deleteExpiredMemories(@Param("now") LocalDateTime now);
 
     /**
+     * 批量更新检索命中时间与命中次数（时间衰减 + 复述效应依据；
+     * JPQL 批量更新绕过 @PreUpdate，不影响 updatedAt）
+     */
+    @org.springframework.transaction.annotation.Transactional
+    @org.springframework.data.jpa.repository.Modifying
+    @Query("UPDATE MemoryEntry m SET m.lastAccessedAt = :now, m.accessCount = COALESCE(m.accessCount, 0) + 1 WHERE m.id IN :ids")
+    void touchLastAccessedAt(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
+
+    /**
      * 根据项目ID和用户ID查找记忆
      */
     List<MemoryEntry> findByProjectIdAndUserIdOrderByCreatedAtDesc(Long projectId, Long userId);

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -206,7 +206,8 @@ public class AgentOrchestrator {
                 planId,
                 projectId,
                 agentMode,
-                userId
+                userId,
+                request.getModel()
             );
             
             log.info("Message assembly complete. Total messages: {}", messages.size());

--- a/backend/src/main/java/com/checkba/service/ai/AiAssistantService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AiAssistantService.java
@@ -1,0 +1,105 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiModelProperties;
+import com.checkba.model.ai.AiAssistantConfig;
+import com.checkba.service.SystemSettingService;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.service.AiServices;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * AI 助手配置与实例管理服务。
+ *
+ * 职责：
+ * - 从系统设置动态加载助手配置（ai.assistants）
+ * - 按 模型 + 助手 维度构建并缓存 ProjectAssistant 实例
+ *
+ * 历史背景：原为 AiChatController 的 loadAssistants/getAssistant 私有方法
+ * 与 assistantCache 字段，Phase 2 下沉为专职服务。
+ */
+@Service
+public class AiAssistantService {
+
+    private static final Logger log = LoggerFactory.getLogger(AiAssistantService.class);
+
+    private static final String KEY_AI_ASSISTANTS = "ai.assistants";
+
+    private final SystemSettingService systemSettingService;
+    private final AiModelProperties aiModelProperties;
+    private final ChatModelFactory chatModelFactory;
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+
+    private final Map<String, ProjectAssistant> assistantCache = new ConcurrentHashMap<>();
+
+    public AiAssistantService(SystemSettingService systemSettingService,
+                              AiModelProperties aiModelProperties,
+                              ChatModelFactory chatModelFactory,
+                              com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+        this.systemSettingService = systemSettingService;
+        this.aiModelProperties = aiModelProperties;
+        this.chatModelFactory = chatModelFactory;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 从系统设置加载助手配置（保留插入顺序）。
+     */
+    public Map<String, AiAssistantConfig> loadAssistants() {
+        Map<String, AiAssistantConfig> map = new LinkedHashMap<>(); // Preserve order
+        String json = systemSettingService.get(KEY_AI_ASSISTANTS, null);
+        if (json != null && !json.isBlank()) {
+            try {
+                List<AiAssistantConfig> list = objectMapper.readValue(json,
+                        new com.fasterxml.jackson.core.type.TypeReference<List<AiAssistantConfig>>() {});
+                for (AiAssistantConfig cfg : list) {
+                    map.put(cfg.getId(), cfg);
+                }
+            } catch (Exception e) {
+                log.error("Failed to parse assistants config", e);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * 获取（或构建并缓存）指定模型 + 助手配置的 ProjectAssistant 实例。
+     */
+    public ProjectAssistant getAssistant(String modelId, AiAssistantConfig assistantConfig) {
+        String key = (StringUtils.hasText(modelId) ? modelId : "default").toLowerCase();
+        boolean needsTools = assistantConfig != null && assistantConfig.getTools() != null && !assistantConfig.getTools().isEmpty();
+
+        // Use a composite key for cache: model + assistantId
+        String assistantId = assistantConfig != null ? assistantConfig.getId() : "default";
+        String cacheKey = key + "_" + assistantId;
+
+        return assistantCache.computeIfAbsent(cacheKey, k -> {
+            ChatLanguageModel chatModel = chatModelFactory.getChatModel(modelId);
+
+            var builder = AiServices.builder(ProjectAssistant.class)
+                    .chatLanguageModel(chatModel);
+
+            // Tools support (only for Ollama or if Model supports it)
+            // For now, only Ollama and OpenRouter (via OpenAI) support tools well in LangChain4j.
+            // Gemini manual impl does NOT support tools yet.
+            AiModelProperties.Provider provider = aiModelProperties.getProvider();
+            boolean isGemini = key.contains("gemini") || provider == AiModelProperties.Provider.GEMINI;
+
+            if (needsTools && !isGemini) {
+                // builder.tools(fileTools); // Temporarily simplified: we need ContentRetriever to handle context
+            }
+
+            // Inject Retriever if needed (usually RAG)
+            // builder.contentRetriever(dynamicContentRetriever);
+
+            return builder.build();
+        });
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/AiChatService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AiChatService.java
@@ -1,0 +1,307 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.controller.ai.AiChatController.AiChatContext;
+import com.checkba.controller.ai.AiChatController.AiChatRequest;
+import com.checkba.controller.ai.AiChatController.AiChatResponse;
+import com.checkba.model.ai.AiAssistantConfig;
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.SystemSettingService;
+import com.checkba.service.ai.context.FileContextLoader;
+import com.checkba.service.ai.context.FileContentExtractorService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 同步 Chat 接口（/api/ai/chat）的业务编排服务。
+ *
+ * 职责：会话 ID 处理、助手配置解析、带上下文的 prompt 构建、
+ * 多模态消息组装、token 用量记录、历史落库。
+ *
+ * 文件读取/OCR → FileContextLoader；多模态分类与内容构建 → MultiModalContentService；
+ * 助手实例 → AiAssistantService。控制器只保留 HTTP 出入口、鉴权与 DTO。
+ */
+@Service
+public class AiChatService {
+
+    private static final Logger log = LoggerFactory.getLogger(AiChatService.class);
+
+    private final AiAssistantService aiAssistantService;
+    private final ProjectAiMessageService projectAiMessageService;
+    private final SystemSettingService systemSettingService;
+    private final ProjectFileService projectFileService;
+    private final FileContextLoader fileContextLoader;
+    private final FileContentExtractorService fileContentExtractorService;
+    private final MultiModalContentService multiModalContentService;
+    private final TokenUsageService tokenUsageService;
+    private final AiContextProperties contextProperties;
+
+    public AiChatService(AiAssistantService aiAssistantService,
+                         ProjectAiMessageService projectAiMessageService,
+                         SystemSettingService systemSettingService,
+                         ProjectFileService projectFileService,
+                         FileContextLoader fileContextLoader,
+                         FileContentExtractorService fileContentExtractorService,
+                         MultiModalContentService multiModalContentService,
+                         TokenUsageService tokenUsageService,
+                         AiContextProperties contextProperties) {
+        this.aiAssistantService = aiAssistantService;
+        this.projectAiMessageService = projectAiMessageService;
+        this.systemSettingService = systemSettingService;
+        this.projectFileService = projectFileService;
+        this.fileContextLoader = fileContextLoader;
+        this.fileContentExtractorService = fileContentExtractorService;
+        this.multiModalContentService = multiModalContentService;
+        this.tokenUsageService = tokenUsageService;
+        this.contextProperties = contextProperties;
+    }
+
+    /**
+     * 处理一次同步 chat 请求（含多模态与上下文注入）。
+     */
+    public AiChatResponse chat(AiChatRequest request, Long userId) {
+        try {
+            ProjectContextHolder.setProjectId(request.getProjectId());
+
+            // 0. Handle Conversation ID
+            String conversationId = request.getConversationId();
+            if (!StringUtils.hasText(conversationId)) {
+                conversationId = java.util.UUID.randomUUID().toString();
+            }
+
+            // 1. Get Assistant Config
+            String assistantId = StringUtils.hasText(request.getAssistantId()) ? request.getAssistantId() : "default";
+            Map<String, AiAssistantConfig> currentAssistants = aiAssistantService.loadAssistants();
+            AiAssistantConfig assistantConfig = currentAssistants.get(assistantId);
+
+            // 2. Build Final Prompt with Context
+            String modelKey = (request.getModel() != null ? request.getModel() : "default").toLowerCase();
+            String finalPrompt = buildPromptWithContext(request, assistantConfig, true);
+
+            // 3. Get LLM Service
+            ProjectAssistant assistant = aiAssistantService.getAssistant(request.getModel(), assistantConfig);
+            dev.langchain4j.service.Result<String> result;
+
+            // Handle Multi-Modal Context (Image/Video) or Native PDF for Gemini
+            List<AiChatContext> contexts = consolidateContexts(request);
+            List<Content> mediaContents = multiModalContentService.buildMediaContents(contexts, modelKey);
+
+            if (!mediaContents.isEmpty()) {
+                List<Content> multiModalContents = new ArrayList<>();
+                // Always add text prompt first
+                multiModalContents.add(TextContent.from(finalPrompt));
+                multiModalContents.addAll(mediaContents);
+                result = assistant.chat(UserMessage.from(multiModalContents));
+            } else {
+                // Text Only
+                result = assistant.chat(finalPrompt);
+            }
+
+            // Extract content and usage
+            String response = result.content();
+            if (result.tokenUsage() != null) {
+                tokenUsageService.recordUsage(
+                        Long.parseLong(request.getProjectId()),
+                        userId,
+                        request.getModel(),
+                        result.tokenUsage(),
+                        conversationId
+                );
+            }
+
+            // 4. Record History
+            try {
+                projectAiMessageService.saveUserAndAssistantMessage(
+                        request.getProjectId(),
+                        userId,
+                        conversationId,
+                        request.getMessage(),
+                        response
+                );
+            } catch (Exception logEx) {
+                log.warn("Failed to save AI chat history for project {}", request.getProjectId(), logEx);
+            }
+
+            return new AiChatResponse(response, conversationId);
+
+        } catch (Exception e) {
+            log.error("Error during AI chat", e);
+            return new AiChatResponse("Sorry, I encountered an error: " + e.getMessage(), request.getConversationId());
+        } finally {
+            ProjectContextHolder.clear();
+        }
+    }
+
+    /**
+     * 合并上下文：contexts 列表优先，其次兼容单个 context 字段。
+     */
+    private List<AiChatContext> consolidateContexts(AiChatRequest request) {
+        List<AiChatContext> contexts = request.getContexts();
+        if (contexts == null) {
+            contexts = new ArrayList<>();
+            if (request.getContext() != null) {
+                contexts.add(request.getContext());
+            }
+        }
+        return contexts;
+    }
+
+    /**
+     * 构建带上下文的完整 prompt（系统设定 + 助手指令 + 文件上下文 + 用户请求）。
+     */
+    String buildPromptWithContext(AiChatRequest request, AiAssistantConfig assistantConfig, boolean includeContext) {
+        List<AiChatContext> contexts = consolidateContexts(request);
+
+        StringBuilder builder = new StringBuilder();
+
+        // 1. Inject Prompt (User Override or System)
+        // 1.1 Dynamic System Prompt from Admin (Model Specific)
+        String modelKey = (request.getModel() != null ? request.getModel() : "default").toLowerCase();
+        String dynamicSystemKey = null;
+        if (modelKey.contains("gemini") || modelKey.contains("google")) {
+            dynamicSystemKey = "ai.systemPrompt.GEMINI";
+        } else if (modelKey.contains("local") || modelKey.contains("ollama")) {
+            dynamicSystemKey = "ai.systemPrompt.OLLAMA";
+        }
+
+        String dynamicSystemPrompt = dynamicSystemKey != null ? systemSettingService.get(dynamicSystemKey, "") : "";
+        if (StringUtils.hasText(dynamicSystemPrompt)) {
+            builder.append("【系统设定】\n").append(dynamicSystemPrompt).append("\n\n");
+        }
+
+        if (assistantConfig != null) {
+            String promptToUse = assistantConfig.getSystemPrompt();
+            String label = "【系统指令】";
+
+            // "User Prompt Prevails" Logic
+            if (StringUtils.hasText(assistantConfig.getUserPrompt())) {
+                promptToUse = assistantConfig.getUserPrompt();
+                label = "【用户自定义指令】(已覆盖系统默认)";
+            }
+
+            if (StringUtils.hasText(promptToUse)) {
+                builder.append(label).append("\n").append(promptToUse).append("\n\n");
+            }
+        }
+
+        if (!includeContext || contexts.isEmpty()) {
+            builder.append(request.getMessage());
+            return builder.toString();
+        }
+
+        builder.append("【当前上下文】\n");
+
+        for (AiChatContext ctx : contexts) {
+            if (ctx == null) continue;
+
+            builder.append("--- 文件: ")
+                    .append(StringUtils.hasText(ctx.getFileName()) ? ctx.getFileName() : "未命名文件");
+            if (StringUtils.hasText(ctx.getFileType())) {
+                builder.append(" (").append(ctx.getFileType()).append(")");
+            }
+            builder.append(" ---\n");
+
+            String documentText = resolveDocumentText(ctx, request, modelKey);
+
+            String selection = safeContextBlock(ctx.getSelectionText(), contextProperties.getFiles().getChatSelectionMaxChars());
+            if (StringUtils.hasText(selection)) {
+                builder.append("选区内容:\n```\n")
+                        .append(selection)
+                        .append("\n```\n");
+            }
+            // For folders, we allow larger context
+            int maxChars = "folder".equals(ctx.getFileType())
+                    ? contextProperties.getFiles().getChatFolderContextMaxChars()
+                    : contextProperties.getFiles().getChatContextMaxChars();
+            String document = safeContextBlock(documentText, maxChars);
+            if (StringUtils.hasText(document)) {
+                builder.append("正文内容:\n```\n")
+                        .append(document)
+                        .append("\n```\n");
+            }
+            builder.append("\n");
+        }
+
+        builder.append("\n【用户请求】\n")
+                .append(request.getMessage());
+        return builder.toString();
+    }
+
+    /**
+     * 解析单个上下文的正文内容：
+     * - 前端已带 documentText 时直接使用
+     * - 文件夹：递归收集文件夹内容
+     * - 普通文件：多模态可直传的跳过提取，否则走 FileContextLoader（OCR/标准提取）
+     */
+    private String resolveDocumentText(AiChatContext ctx, AiChatRequest request, String modelKey) {
+        String documentText = ctx.getDocumentText();
+        if (StringUtils.hasText(documentText)) {
+            return documentText;
+        }
+
+        if ("folder".equals(ctx.getFileType()) && StringUtils.hasText(ctx.getFileId())) {
+            try {
+                Long folderId = Long.parseLong(ctx.getFileId());
+                return fileContextLoader.collectFolderContent(Long.parseLong(request.getProjectId()), folderId);
+            } catch (Exception e) {
+                return "[System: Failed to load folder content: " + e.getMessage() + "]";
+            }
+        }
+
+        if (!StringUtils.hasText(ctx.getFileId())) {
+            return documentText;
+        }
+
+        try {
+            Long fileId = Long.parseLong(ctx.getFileId());
+            com.checkba.model.entity.ProjectFile fileEntity = projectFileService.getFile(fileId);
+            if (fileEntity == null || !StringUtils.hasText(fileEntity.getFilePath())) {
+                return documentText;
+            }
+
+            String fType = ctx.getFileType() != null ? ctx.getFileType().toLowerCase() : "";
+            boolean isMediaFile = fType.matches("pdf|jpg|jpeg|png|gif|bmp|webp|image") ||
+                    fileContentExtractorService.isOcrSupported(fileEntity.getName());
+            boolean canDirectSend = multiModalContentService.canDirectSend(modelKey, fType);
+
+            if (isMediaFile) {
+                log.info("Process Context File: name={}, type={}, isMultiModal={}, canDirectSend={}",
+                        fileEntity.getName(), fType, multiModalContentService.isMultiModalCapable(modelKey), canDirectSend);
+
+                if (canDirectSend) {
+                    // 多模态模型：跳过文本提取，将在多模态路径直传原文件
+                    log.info("-> Skip extraction for multimodal (Direct Send)");
+                    return "[多模态模型将直接处理该文件，无需文本提取]";
+                }
+            }
+
+            log.info("-> Text extraction needed. Retrieving file content...");
+            return fileContextLoader.extractFileText(fileEntity);
+        } catch (Exception e) {
+            log.warn("Failed to read context file content in backend", e);
+            return "[System: Error reading file content: " + e.getMessage() + "]";
+        }
+    }
+
+    private String safeContextBlock(String raw, int maxLen) {
+        if (!StringUtils.hasText(raw)) {
+            return "";
+        }
+        String cleaned = raw.trim();
+        if (cleaned.length() <= maxLen) {
+            return cleaned;
+        }
+        return cleaned.substring(0, maxLen) + "\n...[上下文截断 " + (cleaned.length() - maxLen) + " 字]";
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -1,10 +1,12 @@
 package com.checkba.service.ai;
 
+import com.checkba.config.AiContextProperties;
 import com.checkba.model.ai.AgentMode;
 import com.checkba.model.entity.ConversationSummary;
 import com.checkba.model.entity.MemoryEntry;
 import com.checkba.model.entity.ProjectMemory;
 import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.FileContextLoader;
 import com.checkba.service.ai.context.ProjectContextHolder;
 import com.checkba.service.ai.memory.MemoryManager;
 import com.checkba.service.ai.tools.LegalTools;
@@ -19,11 +21,14 @@ import java.util.Optional;
 /**
  * Service to assemble context from files and other sources.
  * Injects <file> tags into the System Message.
- * 
+ *
  * 增强功能：
  * - 智能上下文压缩
  * - 记忆系统集成
  * - 法律信息保护
+ *
+ * Phase 2：本服务只负责"组装消息"，不再直接读文件系统——
+ * 文件/文件夹内容加载统一走 FileContextLoader。
  */
 @Service
 @RequiredArgsConstructor
@@ -33,9 +38,9 @@ public class ContextAssemblerService {
 
     private final LegalTools legalTools;
     private final ProjectAiMessageService messageService;
-    private final com.checkba.service.ProjectFileService projectFileService;
-    private final com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService;
-    
+    private final FileContextLoader fileContextLoader;
+    private final AiContextProperties contextProperties;
+
     // 记忆系统组件（读侧：写侧见 MemoryPipelineService）
     private final MemoryManager memoryManager;
     private final ContextCompressor contextCompressor;
@@ -48,17 +53,19 @@ public class ContextAssemblerService {
      * 
      * @param agentMode Agent 运行模式 (ASK, PLAN, AGENT)
      * @param activeContext NEW: 当前激活标签页（自动上下文，可为null）
+     * @param modelKey 当前使用的模型标识（用于按模型解析 token 预算，可为 null）
      */
     public java.util.List<dev.langchain4j.data.message.ChatMessage> assemble(
-            String conversationId, 
-            String userPrompt, 
+            String conversationId,
+            String userPrompt,
             java.util.List<com.checkba.controller.ai.AiAgentController.ContextItem> contextItems,
             com.checkba.controller.ai.AiAgentController.ContextItem activeContext,
             String taskListId,
             String planId,
             String projectId,
             AgentMode agentMode,
-            Long userId) {
+            Long userId,
+            String modelKey) {
 
         java.util.List<dev.langchain4j.data.message.ChatMessage> messages = new java.util.ArrayList<>();
 
@@ -170,15 +177,18 @@ public class ContextAssemblerService {
         if (contextItems != null && !contextItems.isEmpty()) {
             systemText.append("\n\n# User Context Files\n");
             systemText.append("The user has provided the following files/folders for context:\n");
-            
-            int totalFileCount = 0; // Limit to 10 files max across all items
-            
+
+            int maxFiles = contextProperties.getFiles().getMaxFilesPerContext();
+            int maxCharsPerFile = contextProperties.getFiles().getMaxCharsPerFile();
+            int totalFileCount = 0; // Limit files max across all items
+
             for (com.checkba.controller.ai.AiAgentController.ContextItem item : contextItems) {
-                log.info("[Context] Processing item: id={}, name={}, isDir={}, fileType={}", 
+                log.info("[Context] Processing item: id={}, name={}, isDir={}, fileType={}",
                          item.getId(), item.getName(), item.isDir(), item.getFileType());
-                         
-                if (totalFileCount >= 10) {
-                    systemText.append("\n[System Note: Context limit reached (10 files max). Remaining items ignored.]\n");
+
+                if (totalFileCount >= maxFiles) {
+                    systemText.append("\n[System Note: Context limit reached (").append(maxFiles)
+                              .append(" files max). Remaining items ignored.]\n");
                     break;
                 }
 
@@ -186,23 +196,23 @@ public class ContextAssemblerService {
                     // Folder Logic
                     systemText.append("\n## Folder: ").append(item.getName())
                               .append(" (ID: ").append(item.getId()).append(")\n");
-                              
-                    String folderContent = buildFolderContext(item.getId(), projectId, totalFileCount);
+
+                    String folderContent = fileContextLoader.buildFolderContext(item.getId(), projectId, totalFileCount);
                     systemText.append(folderContent);
-                    
-                    // Update count based on how many files were read in folder? 
+
+                    // Update count based on how many files were read in folder?
                     // buildFolderContext returns string, we need to pass counter reference or approximate.
                     // Let's refine buildFolderContext to assume it consumes remaining slots.
-                    // Actually, simpler: just let buildFolderContext run and we don't strictly update 'totalFileCount' 
-                    // precisely here unless we return a count object. 
-                    // For simplicity, we assume a folder consumes slots. 
+                    // Actually, simpler: just let buildFolderContext run and we don't strictly update 'totalFileCount'
+                    // precisely here unless we return a count object.
+                    // For simplicity, we assume a folder consumes slots.
                     // Better: Pass proper AtomicInteger to buildFolderContext.
                 } else {
                     // Single File Logic
                     String content = legalTools.read_document(item.getId());
-                    // Truncate if too long (max 50000 chars per file)
-                    if (content != null && content.length() > 50000) {
-                        content = content.substring(0, 50000) + "\n... [TRUNCATED - File too long]";
+                    // Truncate if too long
+                    if (content != null && content.length() > maxCharsPerFile) {
+                        content = content.substring(0, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
                     }
                     systemText.append("<file id=\"").append(item.getId())
                               .append("\" name=\"").append(item.getName()).append("\"><![CDATA[\n");
@@ -223,8 +233,9 @@ public class ContextAssemblerService {
             String content = legalTools.read_document(activeContext.getId());
             if (content != null && !content.isEmpty()) {
                 // Truncate if too long
-                if (content.length() > 50000) {
-                    content = content.substring(0, 50000) + "\n... [TRUNCATED - File too long]";
+                int maxCharsPerFile = contextProperties.getFiles().getMaxCharsPerFile();
+                if (content.length() > maxCharsPerFile) {
+                    content = content.substring(0, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
                 }
                 
                 systemText.append("\n\n# Active Document (当前活跃文档)\n");
@@ -307,32 +318,32 @@ public class ContextAssemblerService {
             }
         }
         
-        // 检查是否需要压缩
-        if (contextCompressor.needsCompression(historyMessages)) {
+        // 检查是否需要压缩（token 预算按模型解析，可在 ai.context.model-token-budgets 覆盖）
+        if (contextCompressor.needsCompression(historyMessages, modelKey)) {
             log.info("Context compression triggered: {} messages, estimated {} tokens",
                     historyMessages.size(), contextCompressor.estimateTokens(historyMessages));
-            
+
             // 获取已有的对话摘要
             ConversationSummary existingSummary = memoryManager.getConversationSummary(conversationId)
                     .orElse(null);
-            
+
             // 获取项目记忆
-            ProjectMemory pm = projectIdLong != null ? 
+            ProjectMemory pm = projectIdLong != null ?
                     memoryManager.getProjectMemory(projectIdLong).orElse(null) : null;
-            
+
             // 执行压缩
             historyMessages = contextCompressor.compress(
                     historyMessages,
                     pm,
                     existingSummary,
-                    contextCompressor.getAvailableTokensForHistory()
+                    contextCompressor.getAvailableTokensForHistory(modelKey)
             );
-            
+
             log.info("Context compressed: {} messages, estimated {} tokens",
                     historyMessages.size(), contextCompressor.estimateTokens(historyMessages));
         } else {
-            // 不需要压缩时，仍然限制为最近 30 条消息
-            int maxHistory = 30;
+            // 不需要压缩时，仍然限制最近消息条数
+            int maxHistory = contextProperties.getCompression().getMaxHistoryMessages();
             if (historyMessages.size() > maxHistory) {
                 historyMessages = historyMessages.subList(historyMessages.size() - maxHistory, historyMessages.size());
             }
@@ -378,77 +389,6 @@ public class ContextAssemblerService {
               .append("\n</file>\n");
         }
         return sb.toString();
-    }
-    /**
-     * Builds folder context: Directory structure + Content of top files.
-     * Uses simple recursion limit and file count limit.
-     */
-    private String buildFolderContext(String folderIdStr, String projectIdStr, int currentTotalCount) {
-        StringBuilder sb = new StringBuilder();
-        try {
-            Long folderId = Long.parseLong(folderIdStr);
-            Long projectId = Long.parseLong(projectIdStr);
-            
-            // Get all children (flat list or just direct children? service usually returns direct)
-            // We need deep traversal? projectFileService.getFilesByParent returns direct children.
-            // We'll implement a simple BFS or recursive helper here.
-            
-            List<com.checkba.model.entity.ProjectFile> allFiles = new java.util.ArrayList<>();
-            collectFilesRecursive(projectId, folderId, allFiles, 0);
-            
-            // 1. Directory Structure
-            sb.append("### Directory Content:\n");
-            for (com.checkba.model.entity.ProjectFile f : allFiles) {
-                 String type = Boolean.TRUE.equals(f.getIsFolder()) ? "[DIR]" : "[FILE]";
-                 sb.append("- ").append(type).append(" ").append(f.getName())
-                   .append(" (ID: ").append(f.getId()).append(")\n");
-            }
-            sb.append("\n");
-            
-            // 2. File Contents (Limit total)
-            int reads = 0;
-            int maxReads = 10 - currentTotalCount; 
-            if (maxReads <= 0) return sb.toString();
-            
-            sb.append("### Folder Document Contents (First " + maxReads + " files):\n");
-            
-            for (com.checkba.model.entity.ProjectFile f : allFiles) {
-                if (reads >= maxReads) break;
-                if (Boolean.TRUE.equals(f.getIsFolder())) continue;
-                
-                // Read content
-                try {
-                    java.io.File physicalFile = new java.io.File(f.getFilePath());
-                    if (physicalFile.exists() && physicalFile.length() < 10 * 1024 * 1024) { // 10MB limit check
-                        String text = fileContentExtractorService.extractText(physicalFile);
-                        if (text != null && !text.isEmpty()) {
-                            if (text.length() > 20000) text = text.substring(0, 20000) + "...[Truncated]";
-                            
-                            sb.append("\n#### File: ").append(f.getName()).append("\n");
-                            sb.append("```\n").append(text).append("\n```\n");
-                            reads++;
-                        }
-                    }
-                } catch (Exception e) {
-                    // Ignore read errors for individual files
-                }
-            }
-            
-        } catch (Exception e) {
-            sb.append("\n[Error reading folder: ").append(e.getMessage()).append("]\n");
-        }
-        return sb.toString();
-    }
-    
-    private void collectFilesRecursive(Long projectId, Long parentId, List<com.checkba.model.entity.ProjectFile> collector, int depth) {
-        if (depth > 5) return; // safety
-        List<com.checkba.model.entity.ProjectFile> children = projectFileService.getFilesByParent(projectId, parentId);
-        for (com.checkba.model.entity.ProjectFile child : children) {
-            collector.add(child);
-            if (Boolean.TRUE.equals(child.getIsFolder())) {
-                collectFilesRecursive(projectId, child.getId(), collector, depth + 1);
-            }
-        }
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/GeminiCacheService.java
+++ b/backend/src/main/java/com/checkba/service/ai/GeminiCacheService.java
@@ -1,0 +1,78 @@
+package com.checkba.service.ai;
+
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import com.checkba.config.AiModelProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Gemini Context Cache 管理服务。
+ *
+ * 通过内容哈希做内存级缓存，避免短期内重复上传相同内容；
+ * 缓存条目的 TTL 由 Gemini 侧管理（默认 1 小时）。
+ *
+ * 历史背景：原为 AiChatController 私有方法 getOrCreateGeminiCache + 控制器字段
+ * activeGeminiCaches，Phase 2 下沉为专职服务。
+ */
+@Service
+public class GeminiCacheService {
+
+    private static final Logger log = LoggerFactory.getLogger(GeminiCacheService.class);
+
+    private final AiModelProperties aiModelProperties;
+
+    // Cache for Gemini Cache IDs: Map<ContentHash, CacheName>
+    private final Map<String, String> activeGeminiCaches = new ConcurrentHashMap<>();
+
+    public GeminiCacheService(AiModelProperties aiModelProperties) {
+        this.aiModelProperties = aiModelProperties;
+    }
+
+    public String getOrCreateGeminiCache(String content) {
+        // Simple hash content to key
+        String hash = cn.hutool.crypto.digest.DigestUtil.md5Hex(content);
+        if (activeGeminiCaches.containsKey(hash)) {
+            // Validate validity? For now assume valid until TTL (default 1h). We can store timestamp.
+            return activeGeminiCaches.get(hash);
+        }
+
+        // Create Cache via REST
+        AiModelProperties.Gemini geminiCfg = aiModelProperties.getGemini();
+        if (geminiCfg.getApiKey() == null) throw new RuntimeException("No API Key");
+
+        String url = geminiCfg.getApiBaseUrl() + "/cachedContents?key=" + geminiCfg.getApiKey();
+
+        JSONObject payload = new JSONObject();
+        payload.set("model", "models/" + geminiCfg.getModelName());
+
+        JSONObject contentObj = new JSONObject();
+        contentObj.set("role", "user");
+        JSONArray parts = new JSONArray();
+        JSONObject part = new JSONObject();
+        part.set("text", content);
+        parts.add(part);
+        contentObj.set("parts", parts);
+
+        payload.set("contents", java.util.Collections.singletonList(contentObj));
+        // payload.set("ttl", "600s"); // default 1h is fine
+
+        String resp = cn.hutool.http.HttpRequest.post(url)
+                .body(payload.toString())
+                .execute()
+                .body();
+
+        JSONObject json = cn.hutool.json.JSONUtil.parseObj(resp);
+        if (json.containsKey("name")) {
+            String cacheName = json.getStr("name");
+            activeGeminiCaches.put(hash, cacheName);
+            return cacheName;
+        } else {
+            throw new RuntimeException("Failed to create cache: " + resp);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/MultiModalContentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/MultiModalContentService.java
@@ -1,0 +1,157 @@
+package com.checkba.service.ai;
+
+import com.checkba.controller.ai.AiChatController.AiChatContext;
+import com.checkba.service.ProjectFileService;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * 多模态内容处理服务。
+ *
+ * 职责：
+ * - 文件类型 → 多模态能力的分类判断（isImage/isVideo/isPdf/canDirectSend）
+ * - 将上下文中的图片/视频/PDF 转为 LangChain4j 多模态 Content（含视频关键帧抽取的临时文件管理）
+ *
+ * 历史背景：类型分类逻辑原在 AiChatController 的 chat() 与 buildPromptWithContext()
+ * 各写了一遍，Phase 2 收拢至此单一实现。
+ */
+@Service
+public class MultiModalContentService {
+
+    private static final Logger log = LoggerFactory.getLogger(MultiModalContentService.class);
+
+    private final ProjectFileService projectFileService;
+    private final MediaProcessingService mediaProcessingService;
+
+    public MultiModalContentService(ProjectFileService projectFileService,
+                                    MediaProcessingService mediaProcessingService) {
+        this.projectFileService = projectFileService;
+        this.mediaProcessingService = mediaProcessingService;
+    }
+
+    // ==================== 类型分类（单一事实来源） ====================
+
+    public boolean isGeminiModel(String modelKey) {
+        String key = modelKey != null ? modelKey.toLowerCase() : "";
+        return key.contains("gemini") || key.contains("google");
+    }
+
+    public boolean isMultiModalCapable(String modelKey) {
+        String key = modelKey != null ? modelKey.toLowerCase() : "";
+        return key.contains("gemini") || key.contains("gpt-4") || key.contains("claude-3");
+    }
+
+    public boolean isImageType(String fileType) {
+        String fType = fileType != null ? fileType.toLowerCase() : "";
+        return fType.matches("jpg|jpeg|png|gif|bmp|webp") || fType.equals("image");
+    }
+
+    public boolean isVideoType(String fileType) {
+        String fType = fileType != null ? fileType.toLowerCase() : "";
+        return fType.matches("mp4|mov|avi|mkv") || fType.equals("video");
+    }
+
+    public boolean isPdfType(String fileType) {
+        String fType = fileType != null ? fileType.toLowerCase() : "";
+        return fType.equals("pdf") || fType.endsWith("pdf");
+    }
+
+    /**
+     * 该文件是否可以直接发送给模型（跳过文本提取，由多模态路径直传原文件）。
+     * PDF 目前只有 Gemini 原生支持直传；图片则所有多模态模型都支持。
+     */
+    public boolean canDirectSend(String modelKey, String fileType) {
+        if (isPdfType(fileType)) {
+            return isGeminiModel(modelKey);
+        }
+        if (isImageType(fileType)) {
+            return isMultiModalCapable(modelKey);
+        }
+        return false;
+    }
+
+    // ==================== 多模态内容构建 ====================
+
+    /**
+     * 将上下文列表中的媒体文件（PDF/图片/视频）转为多模态 Content 列表。
+     * 行为沿用原 AiChatController.chat() 内联实现：
+     * - Gemini + PDF：整文件 base64 直传
+     * - 图片：base64 直传（jpg 归一化为 jpeg mime）
+     * - 视频：抽取关键帧后按图片发送（临时文件即用即删）
+     *
+     * @return 媒体 Content 列表（不含文本部分）；无可用媒体时为空列表
+     */
+    public List<Content> buildMediaContents(List<AiChatContext> contexts, String modelKey) {
+        List<Content> mediaContents = new ArrayList<>();
+        if (contexts == null) {
+            return mediaContents;
+        }
+        boolean isGemini = isGeminiModel(modelKey);
+
+        for (AiChatContext ctx : contexts) {
+            if (ctx == null) continue;
+            String fType = ctx.getFileType() != null ? ctx.getFileType().toLowerCase() : "";
+
+            // 1. Native PDF (Gemini)
+            if (isGemini && isPdfType(fType)) {
+                try {
+                    Long fId = Long.parseLong(ctx.getFileId());
+                    byte[] fileBytes = projectFileService.getFileBytes(fId);
+                    if (fileBytes != null && fileBytes.length > 0) {
+                        String base64 = Base64.getEncoder().encodeToString(fileBytes);
+                        mediaContents.add(ImageContent.from(base64, "application/pdf"));
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to attach PDF for Gemini", e);
+                }
+            }
+
+            // 2. Images / Video
+            boolean isImage = isImageType(fType);
+            boolean isVideo = isVideoType(fType);
+
+            if (isImage || isVideo) {
+                try {
+                    Long fileId = Long.parseLong(ctx.getFileId());
+                    byte[] fileBytes = projectFileService.getFileBytes(fileId);
+
+                    if (fileBytes != null && fileBytes.length > 0) {
+                        List<String> images = new ArrayList<>();
+
+                        if (isImage) {
+                            images.add(Base64.getEncoder().encodeToString(fileBytes));
+                        } else {
+                            // For video keyframes, we need a physical temp file
+                            String ext = !fType.isEmpty() ? "." + fType : ".mp4";
+                            Path tempVid = Files.createTempFile("vid_ctx_" + fileId, ext);
+                            Files.write(tempVid, fileBytes);
+                            try {
+                                images = mediaProcessingService.extractKeyframes(tempVid.toFile(), 5);
+                            } finally {
+                                Files.deleteIfExists(tempVid);
+                            }
+                        }
+
+                        for (String base64 : images) {
+                            String mimeType = isImage ? "image/" + fType.replace("jpg", "jpeg") : "image/jpeg";
+                            if (mimeType.equals("image/image")) mimeType = "image/jpeg";
+                            mediaContents.add(ImageContent.from(base64, mimeType));
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to process media content", e);
+                }
+            }
+        }
+        return mediaContents;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/context/ContextCompressor.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/ContextCompressor.java
@@ -1,5 +1,6 @@
 package com.checkba.service.ai.context;
 
+import com.checkba.config.AiContextProperties;
 import com.checkba.model.entity.ConversationSummary;
 import com.checkba.model.entity.ProjectMemory;
 import dev.langchain4j.data.message.AiMessage;
@@ -18,6 +19,9 @@ import java.util.stream.Collectors;
 /**
  * 上下文压缩器
  * 实现智能上下文压缩，在保留关键信息的前提下减少 token 使用
+ *
+ * Token 预算、估算系数与各层保留条数均由 AiContextProperties（ai.context.*）配置，
+ * token 总预算支持按模型覆盖（ai.context.model-token-budgets）。
  */
 @Service
 @Slf4j
@@ -26,16 +30,7 @@ public class ContextCompressor {
 
     private final LegalInfoProtector legalInfoProtector;
     private final ConversationSummarizer conversationSummarizer;
-
-    // Token 预算配置（基于 GPT-4 128K 或 Gemini 1M）
-    private static final int MAX_CONTEXT_TOKENS = 100000;
-    private static final int SYSTEM_PROMPT_RESERVE = 8000;
-    private static final int MEMORY_RESERVE = 5000;
-    private static final int RESPONSE_RESERVE = 8000;
-    private static final int AVAILABLE_FOR_HISTORY = MAX_CONTEXT_TOKENS - SYSTEM_PROMPT_RESERVE - MEMORY_RESERVE - RESPONSE_RESERVE;
-
-    // 估算每个字符约 0.5 个 token（中文约 1-2 token/字，英文约 0.25-0.5 token/字）
-    private static final double CHARS_PER_TOKEN = 2.0;
+    private final AiContextProperties contextProperties;
 
     /**
      * 压缩消息历史
@@ -60,26 +55,15 @@ public class ContextCompressor {
         }
 
         List<ChatMessage> result = new ArrayList<>();
-        
+
         // 第一层：如果有已存在的摘要，使用它代替旧消息
         if (conversationSummary != null && conversationSummary.getSummaryText() != null) {
             result.add(SystemMessage.from("[对话历史摘要]\n" + conversationSummary.getSummaryText()));
-            
-            // 只保留摘要之后的新消息
-            Long lastMessageId = conversationSummary.getLastMessageId();
-            if (lastMessageId != null) {
-                // 假设消息按时间顺序排列，找到摘要覆盖的最后一条消息
-                // 这里简化处理，保留最近的 N 条消息
-                int keepRecent = Math.min(10, messages.size());
-                for (int i = messages.size() - keepRecent; i < messages.size(); i++) {
-                    result.add(messages.get(i));
-                }
-            } else {
-                // 保留最近 10 条消息
-                int keepRecent = Math.min(10, messages.size());
-                for (int i = messages.size() - keepRecent; i < messages.size(); i++) {
-                    result.add(messages.get(i));
-                }
+
+            // 只保留摘要之后的新消息（简化处理：保留最近 N 条消息）
+            int keepRecent = Math.min(contextProperties.getCompression().getKeepRecentWithSummary(), messages.size());
+            for (int i = messages.size() - keepRecent; i < messages.size(); i++) {
+                result.add(messages.get(i));
             }
             
             int newTokens = estimateTokens(result);
@@ -138,7 +122,7 @@ public class ContextCompressor {
                 totalChars += text.length();
             }
         }
-        return (int) (totalChars / CHARS_PER_TOKEN);
+        return (int) (totalChars / contextProperties.getCharsPerToken());
     }
 
     /**
@@ -146,7 +130,7 @@ public class ContextCompressor {
      */
     public int estimateTokens(String text) {
         if (text == null) return 0;
-        return (int) (text.length() / CHARS_PER_TOKEN);
+        return (int) (text.length() / contextProperties.getCharsPerToken());
     }
 
     /**
@@ -278,11 +262,11 @@ public class ContextCompressor {
             String content = matcher.group(2);
             String closeTag = matcher.group(3);
             
-            // 如果输出超过 2000 字符，截断
-            if (content.length() > 2000) {
+            // 如果输出超过上限字符数，截断
+            if (content.length() > contextProperties.getCompression().getToolOutputMaxChars()) {
                 // 保留法律关键信息
-                LegalInfoProtector.CompressedResult compressed = 
-                        legalInfoProtector.safeCompress(content, 1500);
+                LegalInfoProtector.CompressedResult compressed =
+                        legalInfoProtector.safeCompress(content, contextProperties.getCompression().getToolOutputTargetChars());
                 content = compressed.getContent();
                 if (compressed.isWasCompressed()) {
                     content += "\n[输出已压缩，保留关键信息]";
@@ -301,15 +285,15 @@ public class ContextCompressor {
      * 第三层：摘要旧消息
      */
     private List<ChatMessage> summarizeOldMessages(List<ChatMessage> messages, int targetTokens) {
-        if (messages.size() <= 6) {
+        if (messages.size() <= contextProperties.getCompression().getMinMessagesForSummarize()) {
             // 消息太少，不需要摘要
             return messages;
         }
-        
+
         List<ChatMessage> result = new ArrayList<>();
-        
-        // 保留最近 4 条消息
-        int keepRecent = 4;
+
+        // 保留最近 N 条消息
+        int keepRecent = contextProperties.getCompression().getKeepRecentOnSummarize();
         List<ChatMessage> oldMessages = messages.subList(0, messages.size() - keepRecent);
         List<ChatMessage> recentMessages = messages.subList(messages.size() - keepRecent, messages.size());
         
@@ -377,9 +361,9 @@ public class ContextCompressor {
         }
         
         result.add(SystemMessage.from(coreContext.toString()));
-        
-        // 只保留最近 2 条消息
-        int keepRecent = Math.min(2, messages.size());
+
+        // 只保留最近 N 条消息
+        int keepRecent = Math.min(contextProperties.getCompression().getKeepRecentAggressive(), messages.size());
         for (int i = messages.size() - keepRecent; i < messages.size(); i++) {
             result.add(messages.get(i));
         }
@@ -388,18 +372,35 @@ public class ContextCompressor {
     }
 
     /**
-     * 检查是否需要压缩
+     * 检查是否需要压缩（使用默认 token 预算）
      */
     public boolean needsCompression(List<ChatMessage> messages) {
-        int tokens = estimateTokens(messages);
-        return tokens > AVAILABLE_FOR_HISTORY;
+        return needsCompression(messages, null);
     }
 
     /**
-     * 获取可用于历史的 token 预算
+     * 检查是否需要压缩（token 预算按模型解析）
+     */
+    public boolean needsCompression(List<ChatMessage> messages, String modelKey) {
+        int tokens = estimateTokens(messages);
+        return tokens > getAvailableTokensForHistory(modelKey);
+    }
+
+    /**
+     * 获取可用于历史的 token 预算（默认预算）
      */
     public int getAvailableTokensForHistory() {
-        return AVAILABLE_FOR_HISTORY;
+        return getAvailableTokensForHistory(null);
+    }
+
+    /**
+     * 获取可用于历史的 token 预算（按模型解析总预算后扣除各项预留）
+     */
+    public int getAvailableTokensForHistory(String modelKey) {
+        return contextProperties.maxContextTokensFor(modelKey)
+                - contextProperties.getSystemPromptReserve()
+                - contextProperties.getMemoryReserve()
+                - contextProperties.getResponseReserve();
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/context/FileContentExtractorService.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/FileContentExtractorService.java
@@ -1,5 +1,6 @@
 package com.checkba.service.ai.context;
 
+import com.checkba.config.AiContextProperties;
 import com.checkba.service.OcrService;
 import com.checkba.service.ocr.OcrResult;
 import org.slf4j.Logger;
@@ -20,7 +21,6 @@ public class FileContentExtractorService {
 
     private static final Logger log = LoggerFactory.getLogger(FileContentExtractorService.class);
 
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
     private static final Set<String> ALLOWED_TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
             "java", "kt", "scala", "groovy", // JVM
             "js", "jsx", "ts", "tsx", "vue", "svelte", // Frontend
@@ -28,16 +28,17 @@ public class FileContentExtractorService {
             "xml", "yml", "yaml", "json", "properties", "toml", // Config
             "md", "txt", "csv", "sql", "sh", "bat", "dockerfile", ".gitignore", ".env" // Misc
     ));
-    
-    // 支持 OCR 的文件扩展名（图片和 PDF）
-    private static final Set<String> OCR_EXTENSIONS = new HashSet<>(Arrays.asList(
-            "jpg", "jpeg", "png", "gif", "bmp", "webp", "pdf"
-    ));
 
     private final OcrService ocrService;
+    private final AiContextProperties contextProperties;
 
-    public FileContentExtractorService(OcrService ocrService) {
+    public FileContentExtractorService(OcrService ocrService, AiContextProperties contextProperties) {
         this.ocrService = ocrService;
+        this.contextProperties = contextProperties;
+    }
+
+    private long maxFileSize() {
+        return contextProperties.getFiles().getMaxFileSizeBytes();
     }
 
     /**
@@ -49,9 +50,9 @@ public class FileContentExtractorService {
             return "";
         }
 
-        if (file.length() > MAX_FILE_SIZE) {
-            log.warn("File skipped due to size limit ({} > 10MB): {}", file.length(), file.getName());
-            return "[System: File skipped - exceeds 10MB limit]";
+        if (file.length() > maxFileSize()) {
+            log.warn("File skipped due to size limit ({} > {}): {}", file.length(), maxFileSize(), file.getName());
+            return "[System: File skipped - exceeds size limit]";
         }
 
         String fileName = file.getName();
@@ -88,9 +89,9 @@ public class FileContentExtractorService {
             return "[System: 该文件类型不支持 OCR]";
         }
 
-        if (file.length() > MAX_FILE_SIZE) {
-            log.warn("File skipped due to size limit ({} > 10MB): {}", file.length(), file.getName());
-            return "[System: 文件超过 10MB 限制]";
+        if (file.length() > maxFileSize()) {
+            log.warn("File skipped due to size limit ({} > {}): {}", file.length(), maxFileSize(), file.getName());
+            return "[System: 文件超过大小限制]";
         }
 
         try {
@@ -171,7 +172,7 @@ public class FileContentExtractorService {
     public boolean isOcrSupported(String fileName) {
         if (!StringUtils.hasText(fileName)) return false;
         String ext = getExtension(fileName);
-        return OCR_EXTENSIONS.contains(ext);
+        return contextProperties.getOcrExtensions().contains(ext);
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/context/FileContextLoader.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/FileContextLoader.java
@@ -1,0 +1,213 @@
+package com.checkba.service.ai.context;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.ProjectFileService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 文件上下文加载器（接入层与组装层共用的"读文件"专职服务）。
+ *
+ * 职责：
+ * - 单文件文本提取（含 OCR 路径与临时文件生命周期管理）
+ * - 文件夹递归遍历与内容收集（带深度/数量/大小上限）
+ *
+ * 历史背景：这些逻辑原分散在 AiChatController（collectFolderContent/OCR 临时文件）
+ * 和 ContextAssemblerService（buildFolderContext/collectFilesRecursive）两处，
+ * Phase 2 收拢至此，使控制器只做 HTTP 出入口、ContextAssembler 只做消息组装。
+ */
+@Service
+public class FileContextLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(FileContextLoader.class);
+
+    /** 文件夹递归的深度保护（chat 场景，行为沿用原控制器实现） */
+    private static final int CHAT_FOLDER_MAX_DEPTH = 20;
+    /** 文件夹递归的深度保护（Agent 上下文组装场景，行为沿用原实现） */
+    private static final int ASSEMBLER_FOLDER_MAX_DEPTH = 5;
+
+    private final ProjectFileService projectFileService;
+    private final FileContentExtractorService fileContentExtractorService;
+    private final AiContextProperties contextProperties;
+
+    public FileContextLoader(ProjectFileService projectFileService,
+                             FileContentExtractorService fileContentExtractorService,
+                             AiContextProperties contextProperties) {
+        this.projectFileService = projectFileService;
+        this.fileContentExtractorService = fileContentExtractorService;
+        this.contextProperties = contextProperties;
+    }
+
+    /**
+     * 读取单个项目文件并提取文本（自动选择 OCR 或标准提取）。
+     * 内部通过临时文件桥接存储层（本地/OSS）与提取器，并保证临时文件被清理。
+     *
+     * @return 提取的文本；文件为空返回提示文本；失败返回带原因的提示文本
+     */
+    public String extractFileText(ProjectFile fileEntity) {
+        if (fileEntity == null) {
+            return "[文件内容为空或无法读取]";
+        }
+        Path tempPath = null;
+        try {
+            byte[] fileBytes = projectFileService.getFileBytes(fileEntity.getId());
+            if (fileBytes == null || fileBytes.length == 0) {
+                log.warn("File content is empty or not found via service: {}", fileEntity.getName());
+                return "[文件内容为空或无法读取]";
+            }
+            String tempName = "ocr_ctx_" + fileEntity.getId() + "_" + System.currentTimeMillis();
+            String ext = fileEntity.getFileType() != null ? "." + fileEntity.getFileType() : ".tmp";
+            tempPath = Files.createTempFile(tempName, ext);
+            Files.write(tempPath, fileBytes);
+            java.io.File physicalFile = tempPath.toFile();
+
+            if (fileContentExtractorService.isOcrSupported(fileEntity.getName())) {
+                log.info("-> Using OCR extraction for: {}", fileEntity.getName());
+                return fileContentExtractorService.extractTextWithOcr(physicalFile);
+            } else {
+                log.info("-> Using standard extraction for: {}", fileEntity.getName());
+                return fileContentExtractorService.extractText(physicalFile);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to read context file content in backend", e);
+            return "[读取文件失败: " + e.getMessage() + "]";
+        } finally {
+            deleteQuietly(tempPath);
+        }
+    }
+
+    /**
+     * 收集文件夹下的文件内容（chat 接口场景：仅正文拼接，最多 N 个文件）。
+     * 行为沿用原 AiChatController.collectFolderContent。
+     */
+    public String collectFolderContent(Long projectId, Long folderId) {
+        StringBuilder sb = new StringBuilder();
+        int[] counter = {0};
+        collectChatFilesRecursive(projectId, folderId, sb, 0, counter);
+        return sb.toString();
+    }
+
+    private void collectChatFilesRecursive(Long projectId, Long parentId, StringBuilder sb, int depth, int[] counter) {
+        int maxFiles = contextProperties.getFiles().getMaxFilesPerContext();
+        if (depth > CHAT_FOLDER_MAX_DEPTH) return;
+        if (counter[0] >= maxFiles) return;
+
+        List<ProjectFile> children = projectFileService.getFilesByParent(projectId, parentId);
+
+        for (ProjectFile file : children) {
+            if (counter[0] >= maxFiles) break;
+
+            if (Boolean.TRUE.equals(file.getIsFolder())) {
+                collectChatFilesRecursive(projectId, file.getId(), sb, depth + 1, counter);
+            } else {
+                Path tempP = null;
+                try {
+                    byte[] fileBytes = projectFileService.getFileBytes(file.getId());
+                    if (fileBytes != null && fileBytes.length > 0) {
+                        tempP = Files.createTempFile("folder_scan_" + file.getId(), ".tmp");
+                        Files.write(tempP, fileBytes);
+                        String extracted = fileContentExtractorService.extractText(tempP.toFile());
+
+                        if (StringUtils.hasText(extracted)) {
+                            sb.append("\n--- File: ").append(file.getName()).append(" ---\n");
+                            sb.append(extracted).append("\n");
+                            counter[0]++;
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to read folder file content: {}", file.getName(), e);
+                } finally {
+                    deleteQuietly(tempP);
+                }
+            }
+        }
+    }
+
+    /**
+     * 构建文件夹上下文（Agent 组装场景：目录结构 + 前 N 个文件的内容）。
+     * 行为沿用原 ContextAssemblerService.buildFolderContext。
+     *
+     * @param currentTotalCount 已消耗的文件配额（跨多个 context item 共享上限）
+     */
+    public String buildFolderContext(String folderIdStr, String projectIdStr, int currentTotalCount) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            Long folderId = Long.parseLong(folderIdStr);
+            Long projectId = Long.parseLong(projectIdStr);
+
+            List<ProjectFile> allFiles = new ArrayList<>();
+            listFilesRecursive(projectId, folderId, allFiles, 0);
+
+            // 1. Directory Structure
+            sb.append("### Directory Content:\n");
+            for (ProjectFile f : allFiles) {
+                String type = Boolean.TRUE.equals(f.getIsFolder()) ? "[DIR]" : "[FILE]";
+                sb.append("- ").append(type).append(" ").append(f.getName())
+                  .append(" (ID: ").append(f.getId()).append(")\n");
+            }
+            sb.append("\n");
+
+            // 2. File Contents (Limit total)
+            int reads = 0;
+            int maxReads = contextProperties.getFiles().getMaxFilesPerContext() - currentTotalCount;
+            if (maxReads <= 0) return sb.toString();
+
+            sb.append("### Folder Document Contents (First ").append(maxReads).append(" files):\n");
+
+            long maxFileSize = contextProperties.getFiles().getMaxFileSizeBytes();
+            int maxChars = contextProperties.getFiles().getFolderFileMaxChars();
+            for (ProjectFile f : allFiles) {
+                if (reads >= maxReads) break;
+                if (Boolean.TRUE.equals(f.getIsFolder())) continue;
+
+                try {
+                    java.io.File physicalFile = new java.io.File(f.getFilePath());
+                    if (physicalFile.exists() && physicalFile.length() < maxFileSize) {
+                        String text = fileContentExtractorService.extractText(physicalFile);
+                        if (text != null && !text.isEmpty()) {
+                            if (text.length() > maxChars) text = text.substring(0, maxChars) + "...[Truncated]";
+
+                            sb.append("\n#### File: ").append(f.getName()).append("\n");
+                            sb.append("```\n").append(text).append("\n```\n");
+                            reads++;
+                        }
+                    }
+                } catch (Exception e) {
+                    // Ignore read errors for individual files
+                }
+            }
+
+        } catch (Exception e) {
+            sb.append("\n[Error reading folder: ").append(e.getMessage()).append("]\n");
+        }
+        return sb.toString();
+    }
+
+    private void listFilesRecursive(Long projectId, Long parentId, List<ProjectFile> collector, int depth) {
+        if (depth > ASSEMBLER_FOLDER_MAX_DEPTH) return;
+        List<ProjectFile> children = projectFileService.getFilesByParent(projectId, parentId);
+        for (ProjectFile child : children) {
+            collector.add(child);
+            if (Boolean.TRUE.equals(child.getIsFolder())) {
+                listFilesRecursive(projectId, child.getId(), collector, depth + 1);
+            }
+        }
+    }
+
+    private void deleteQuietly(Path path) {
+        if (path != null) {
+            try {
+                Files.deleteIfExists(path);
+            } catch (Exception ignore) {
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/context/LegalInfoProtector.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/LegalInfoProtector.java
@@ -12,55 +12,71 @@ import java.util.regex.Pattern;
 /**
  * 法律信息保护器
  * 识别并保护法律关键信息，确保在上下文压缩时不被丢失
+ *
+ * 保护正则外置于资源文件 legal/protected-patterns.yml，此类只负责加载与匹配。
  */
 @Service
 public class LegalInfoProtector {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LegalInfoProtector.class);
 
-    // 需要保护的法律信息类型及其正则模式
-    private static final List<ProtectedPattern> PROTECTED_PATTERNS = Arrays.asList(
-            // 法律法规名称及条款
-            new ProtectedPattern("《[^》]+》(?:第[一二三四五六七八九十百千万]+条)?(?:第[一二三四五六七八九十]+款)?", 
-                    ProtectionLevel.CRITICAL, "法律引用"),
-            
-            // 日期（多种格式）
-            new ProtectedPattern("\\d{4}年\\d{1,2}月\\d{1,2}日", 
-                    ProtectionLevel.CRITICAL, "日期"),
-            new ProtectedPattern("\\d{4}-\\d{2}-\\d{2}", 
-                    ProtectionLevel.HIGH, "日期"),
-            
-            // 金额
-            new ProtectedPattern("[\\d,]+\\.?\\d*\\s*(万元|亿元|元|万|亿)", 
-                    ProtectionLevel.CRITICAL, "金额"),
-            new ProtectedPattern("人民币[\\d,]+\\.?\\d*", 
-                    ProtectionLevel.CRITICAL, "金额"),
-            
-            // 统一社会信用代码
-            new ProtectedPattern("统一社会信用代码[：:]?\\s*[0-9A-Z]{18}", 
-                    ProtectionLevel.HIGH, "信用代码"),
-            new ProtectedPattern("[0-9A-Z]{18}", 
-                    ProtectionLevel.MEDIUM, "信用代码"),
-            
-            // 当事人
-            new ProtectedPattern("(甲方|乙方|丙方|丁方|发行人|标的公司|上市公司|交易对方)[：:：]\\s*[^\\n,，。]+", 
-                    ProtectionLevel.CRITICAL, "当事人"),
-            
-            // 合同编号
-            new ProtectedPattern("(合同|协议|编号)[：:]\\s*[A-Za-z0-9\\-]+", 
-                    ProtectionLevel.HIGH, "合同编号"),
-            
-            // 股权比例
-            new ProtectedPattern("\\d+\\.?\\d*\\s*%", 
-                    ProtectionLevel.HIGH, "比例"),
-            
-            // 期限
-            new ProtectedPattern("\\d+\\s*(个月|年|日|天|工作日)", 
-                    ProtectionLevel.HIGH, "期限"),
-            
-            // 法院/仲裁机构
-            new ProtectedPattern("[\\u4e00-\\u9fa5]+(?:人民法院|仲裁委员会)", 
-                    ProtectionLevel.HIGH, "司法机构")
-    );
+    /** 保护正则配置资源路径（classpath） */
+    static final String PATTERNS_RESOURCE = "legal/protected-patterns.yml";
+
+    // 需要保护的法律信息类型及其正则模式（从资源文件加载）
+    private final List<ProtectedPattern> protectedPatterns;
+
+    // 独立提取器正则（从资源文件加载）
+    private final Pattern legalReferencePattern;
+    private final Pattern amountPattern;
+    private final Pattern datePattern;
+
+    public LegalInfoProtector() {
+        Map<String, Object> config = loadPatternConfig();
+
+        List<ProtectedPattern> patterns = new ArrayList<>();
+        Object rawPatterns = config.get("protected-patterns");
+        if (rawPatterns instanceof List<?> list) {
+            for (Object item : list) {
+                if (item instanceof Map<?, ?> entry) {
+                    String pattern = String.valueOf(entry.get("pattern"));
+                    ProtectionLevel level = ProtectionLevel.valueOf(String.valueOf(entry.get("level")));
+                    String type = String.valueOf(entry.get("type"));
+                    patterns.add(new ProtectedPattern(pattern, level, type));
+                }
+            }
+        }
+        if (patterns.isEmpty()) {
+            throw new IllegalStateException("No protected patterns loaded from " + PATTERNS_RESOURCE);
+        }
+        this.protectedPatterns = Collections.unmodifiableList(patterns);
+
+        Object rawExtractors = config.get("extractors");
+        if (!(rawExtractors instanceof Map<?, ?> extractors)) {
+            throw new IllegalStateException("No extractors section in " + PATTERNS_RESOURCE);
+        }
+        this.legalReferencePattern = Pattern.compile(String.valueOf(extractors.get("legal-reference")));
+        this.amountPattern = Pattern.compile(String.valueOf(extractors.get("amount")));
+        this.datePattern = Pattern.compile(String.valueOf(extractors.get("date")));
+
+        log.info("LegalInfoProtector loaded {} protected patterns from {}", protectedPatterns.size(), PATTERNS_RESOURCE);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> loadPatternConfig() {
+        try (java.io.InputStream in = LegalInfoProtector.class.getClassLoader()
+                .getResourceAsStream(PATTERNS_RESOURCE)) {
+            if (in == null) {
+                throw new IllegalStateException("Pattern resource not found on classpath: " + PATTERNS_RESOURCE);
+            }
+            Object loaded = new org.yaml.snakeyaml.Yaml().load(in);
+            if (!(loaded instanceof Map)) {
+                throw new IllegalStateException("Invalid pattern resource format: " + PATTERNS_RESOURCE);
+            }
+            return (Map<String, Object>) loaded;
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("Failed to load pattern resource: " + PATTERNS_RESOURCE, e);
+        }
+    }
 
     /**
      * 保护级别
@@ -146,7 +162,7 @@ public class LegalInfoProtector {
 
         List<ProtectedSegment> segments = new ArrayList<>();
 
-        for (ProtectedPattern pp : PROTECTED_PATTERNS) {
+        for (ProtectedPattern pp : protectedPatterns) {
             try {
                 Pattern pattern = Pattern.compile(pp.getPattern());
                 Matcher matcher = pattern.matcher(content);
@@ -321,8 +337,7 @@ public class LegalInfoProtector {
      */
     public List<String> extractLegalReferences(String content) {
         List<String> refs = new ArrayList<>();
-        Pattern pattern = Pattern.compile("《[^》]+》(?:第[一二三四五六七八九十百千万]+条)?");
-        Matcher matcher = pattern.matcher(content);
+        Matcher matcher = legalReferencePattern.matcher(content);
         while (matcher.find()) {
             String ref = matcher.group();
             if (!refs.contains(ref)) {
@@ -337,8 +352,7 @@ public class LegalInfoProtector {
      */
     public List<String> extractAmounts(String content) {
         List<String> amounts = new ArrayList<>();
-        Pattern pattern = Pattern.compile("[\\d,]+\\.?\\d*\\s*(万元|亿元|元)");
-        Matcher matcher = pattern.matcher(content);
+        Matcher matcher = amountPattern.matcher(content);
         while (matcher.find()) {
             amounts.add(matcher.group());
         }
@@ -350,8 +364,7 @@ public class LegalInfoProtector {
      */
     public List<String> extractDates(String content) {
         List<String> dates = new ArrayList<>();
-        Pattern pattern = Pattern.compile("\\d{4}年\\d{1,2}月\\d{1,2}日");
-        Matcher matcher = pattern.matcher(content);
+        Matcher matcher = datePattern.matcher(content);
         while (matcher.find()) {
             dates.add(matcher.group());
         }

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemCellExtractor.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemCellExtractor.java
@@ -337,13 +337,13 @@ public class MemCellExtractor {
     }
 
     /**
-     * 批量保存提取的 MemCell
+     * 批量保存提取的 MemCell（写入前做向量相似度去重，见 MemoryManager.saveMemoryDeduplicated）
      */
     public int saveMemCells(List<MemoryEntry> memCells) {
         int saved = 0;
         for (MemoryEntry entry : memCells) {
             try {
-                memoryManager.saveMemory(entry);
+                memoryManager.saveMemoryDeduplicated(entry);
                 saved++;
             } catch (Exception e) {
                 log.error("Failed to save MemCell: {}", e.getMessage());

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
@@ -28,6 +28,38 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MemoryManager {
 
+    /** 检索排序的时间衰减半衰期（天）：未被检索命中的记忆每过 30 天权重减半（受保护记忆不衰减） */
+    private static final double DECAY_HALF_LIFE_DAYS = 30.0;
+
+    /** 语义去重的余弦相似度阈值：cos >= 0.95 视为重复 */
+    private static final double DEDUP_COSINE_THRESHOLD = 0.95;
+
+    // ---- 拟人化检索排序参数 ----
+    // 人的记忆不是纯时间序：重要的事、反复想起的事记得更牢，偶尔还会随机想起冷门片段。
+
+    /** 隐含重要性：受保护记忆（法律关键信息）的显著性加成，类似"闪光灯记忆"不易遗忘 */
+    private static final double PROTECTED_SIGNIFICANCE_BOOST = 0.15;
+
+    /** 隐含重要性：按记忆类型的显著性加成（决策/结论比普通事实更"刻骨铭心"） */
+    private static final Map<String, Double> TYPE_SIGNIFICANCE_BOOST = Map.of(
+            MemoryEntry.MemoryType.DECISION, 0.10,
+            MemoryEntry.MemoryType.CONCLUSION, 0.08,
+            MemoryEntry.MemoryType.REFERENCE, 0.05,
+            MemoryEntry.MemoryType.PREFERENCE, 0.03);
+
+    /** 随机抖动幅度：检索分数乘以 [1-ratio, 1+ratio] 的随机因子，模拟回忆的不确定性 */
+    private static final double JITTER_RATIO = 0.05;
+
+    /** "偶然想起"概率：以小概率用候选池中的冷门记忆替换末位结果（不知道哪条旧记忆什么时候有用） */
+    private static final double SERENDIPITY_PROBABILITY = 0.1;
+
+    /** 随机源（测试可注入固定行为） */
+    private Random random = new Random();
+
+    void setRandom(Random random) {
+        this.random = random;
+    }
+
     private final MemoryEntryRepository memoryEntryRepository;
     private final ConversationSummaryRepository conversationSummaryRepository;
     private final ProjectMemoryRepository projectMemoryRepository;
@@ -73,6 +105,69 @@ public class MemoryManager {
     }
 
     /**
+     * 带语义去重的保存（MemCell 写入路径）。
+     *
+     * 写入前用向量相似度检索近重复记忆（cos >= {@value #DEDUP_COSINE_THRESHOLD} 视为重复，
+     * LangChain4j 的 relevanceScore = (1 + cos) / 2，故转换后过滤）：
+     * - 已有条目 importance 更高（或相等）→ 跳过写入，返回已有条目
+     * - 新条目 importance 更高 → 用新内容覆盖已有条目（保留 importance 更高者）
+     * - 无重复或去重检查失败 → 正常走 saveMemory
+     */
+    @Transactional
+    public MemoryEntry saveMemoryDeduplicated(MemoryEntry entry) {
+        try {
+            String textToEmbed = buildEmbeddingText(entry);
+            Embedding embedding = embeddingModel.embed(textToEmbed).content();
+
+            double minRelevance = (1.0 + DEDUP_COSINE_THRESHOLD) / 2.0;
+            EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                    .queryEmbedding(embedding)
+                    .maxResults(5)
+                    .minScore(minRelevance)
+                    .build();
+            List<EmbeddingMatch<TextSegment>> matches = memoryEmbeddingStore.search(request).matches();
+
+            for (EmbeddingMatch<TextSegment> match : matches) {
+                String pid = match.embedded().metadata().getString("projectId");
+                if (pid == null || !pid.equals(String.valueOf(entry.getProjectId()))) {
+                    continue;
+                }
+                String memoryIdStr = match.embedded().metadata().getString("memoryId");
+                if (memoryIdStr == null) {
+                    continue;
+                }
+                Optional<MemoryEntry> existingOpt = memoryEntryRepository.findById(Long.parseLong(memoryIdStr));
+                if (existingOpt.isEmpty()) {
+                    continue;
+                }
+                MemoryEntry existing = existingOpt.get();
+                double newImportance = entry.getImportanceScore() != null ? entry.getImportanceScore() : 0.5;
+                double oldImportance = existing.getImportanceScore() != null ? existing.getImportanceScore() : 0.5;
+
+                if (newImportance > oldImportance) {
+                    // 新条目更重要：以新内容覆盖旧条目
+                    existing.setMemoryType(entry.getMemoryType());
+                    existing.setMemoryKey(entry.getMemoryKey());
+                    existing.setMemoryValue(entry.getMemoryValue());
+                    existing.setImportanceScore(entry.getImportanceScore());
+                    if (Boolean.TRUE.equals(entry.getIsProtected())) {
+                        existing.setIsProtected(true);
+                    }
+                    log.info("Memory dedup: updated existing id={} with higher-importance content (score={})",
+                            existing.getId(), match.score());
+                    return memoryEntryRepository.save(existing);
+                }
+
+                log.info("Memory dedup: skipped near-duplicate of id={} (score={})", existing.getId(), match.score());
+                return existing;
+            }
+        } catch (Exception e) {
+            log.warn("Memory dedup check failed, falling back to plain save: {}", e.getMessage());
+        }
+        return saveMemory(entry);
+    }
+
+    /**
      * 构建用于嵌入的文本
      */
     private String buildEmbeddingText(MemoryEntry entry) {
@@ -88,28 +183,48 @@ public class MemoryManager {
     }
 
     /**
-     * 根据关键词检索记忆
+     * 根据关键词检索记忆（排序引入时间衰减因子，命中后更新 lastAccessedAt）
      */
     public List<MemoryEntry> retrieveMemories(Long projectId, String query, String memoryType, int limit) {
         log.info("Retrieving memories: projectId={}, query={}, type={}, limit={}",
                 projectId, query, memoryType, limit);
-        
-        if (query == null || query.isBlank()) {
-            // 没有查询时返回最重要的记忆
-            return memoryEntryRepository.findTopImportantMemories(projectId, PageRequest.of(0, limit));
-        }
-        
-        // 关键词搜索
-        return memoryEntryRepository.searchByKeywordAndType(
-                projectId, query, memoryType, PageRequest.of(0, limit));
+
+        List<MemoryEntry> ranked = rankWithTimeDecay(
+                fetchKeywordCandidates(projectId, query, memoryType, limit * 3), limit);
+        touchMemories(ranked);
+        return ranked;
     }
 
     /**
-     * 语义检索记忆
+     * 关键词候选检索（内部使用：不做衰减排序，不更新 lastAccessedAt）
+     */
+    private List<MemoryEntry> fetchKeywordCandidates(Long projectId, String query, String memoryType, int fetchLimit) {
+        if (query == null || query.isBlank()) {
+            // 没有查询时返回最重要的记忆
+            return memoryEntryRepository.findTopImportantMemories(projectId, PageRequest.of(0, fetchLimit));
+        }
+
+        // 关键词搜索
+        return memoryEntryRepository.searchByKeywordAndType(
+                projectId, query, memoryType, PageRequest.of(0, fetchLimit));
+    }
+
+    /**
+     * 语义检索记忆（排序引入时间衰减因子，命中后更新 lastAccessedAt）
      */
     public List<MemoryEntry> semanticSearch(Long projectId, String query, int limit) {
+        List<MemoryEntry> ranked = rankWithTimeDecay(
+                semanticSearchInternal(projectId, query, limit), limit);
+        touchMemories(ranked);
+        return ranked;
+    }
+
+    /**
+     * 语义检索（内部使用：不做衰减排序，不更新 lastAccessedAt）
+     */
+    private List<MemoryEntry> semanticSearchInternal(Long projectId, String query, int limit) {
         log.info("Semantic search: projectId={}, query={}, limit={}", projectId, query, limit);
-        
+
         try {
             Embedding queryEmbedding = embeddingModel.embed(query).content();
             
@@ -139,7 +254,7 @@ public class MemoryManager {
         } catch (Exception e) {
             log.error("Semantic search failed: {}", e.getMessage(), e);
             // 降级到关键词搜索
-            return retrieveMemories(projectId, query, null, limit);
+            return fetchKeywordCandidates(projectId, query, null, limit);
         }
     }
 
@@ -204,15 +319,16 @@ public class MemoryManager {
         
         // 1. 并行执行关键词检索和语义检索
         int fetchLimit = limit * 3;  // 多取一些用于融合
-        List<MemoryEntry> keywordResults = retrieveMemories(projectId, query, null, fetchLimit);
-        List<MemoryEntry> semanticResults = semanticSearch(projectId, query, fetchLimit);
-        
+        List<MemoryEntry> keywordResults = fetchKeywordCandidates(projectId, query, null, fetchLimit);
+        List<MemoryEntry> semanticResults = semanticSearchInternal(projectId, query, fetchLimit);
+
         log.debug("Keyword results: {}, Semantic results: {}", keywordResults.size(), semanticResults.size());
-        
-        // 2. RRF 融合
+
+        // 2. RRF 融合（分数带时间衰减因子）
         List<MemoryEntry> fusedResults = rrfFusion(keywordResults, semanticResults, limit);
-        
+
         log.info("Hybrid search completed: {} results after RRF fusion", fusedResults.size());
+        touchMemories(fusedResults);
         return fusedResults;
     }
 
@@ -256,29 +372,35 @@ public class MemoryManager {
      * @return 融合后的结果列表
      */
     private List<MemoryEntry> rrfFusion(List<MemoryEntry> list1, List<MemoryEntry> list2, int limit) {
-        final int k = 60;  // RRF 常数
+        return rrfFusionMultiple(List.of(list1, list2), limit);
+    }
+
+    /**
+     * 多列表 RRF 融合（支持多个检索源）
+     * 用于 Agentic 多轮召回时融合多个查询结果
+     * 最终分数 = RRF 分数 × 隐含重要性 × 时间衰减 × 随机抖动（受保护记忆不衰减）
+     */
+    public List<MemoryEntry> rrfFusionMultiple(List<List<MemoryEntry>> resultLists, int limit) {
+        final int k = 60;
         Map<Long, Double> scores = new HashMap<>();
         Map<Long, MemoryEntry> memoryMap = new HashMap<>();
-        
-        // 计算第一个列表的 RRF 分数
-        for (int i = 0; i < list1.size(); i++) {
-            MemoryEntry entry = list1.get(i);
-            Long id = entry.getId();
-            double score = 1.0 / (k + i + 1);  // rank 从 1 开始
-            scores.merge(id, score, Double::sum);
-            memoryMap.putIfAbsent(id, entry);
+
+        for (List<MemoryEntry> results : resultLists) {
+            for (int i = 0; i < results.size(); i++) {
+                MemoryEntry entry = results.get(i);
+                Long id = entry.getId();
+                double score = 1.0 / (k + i + 1);  // rank 从 1 开始
+                scores.merge(id, score, Double::sum);
+                memoryMap.putIfAbsent(id, entry);
+            }
         }
-        
-        // 计算第二个列表的 RRF 分数
-        for (int i = 0; i < list2.size(); i++) {
-            MemoryEntry entry = list2.get(i);
-            Long id = entry.getId();
-            double score = 1.0 / (k + i + 1);
-            scores.merge(id, score, Double::sum);
-            memoryMap.putIfAbsent(id, entry);
+
+        // 应用拟人化因子：隐含重要性 × 时间衰减 × 随机抖动
+        for (Map.Entry<Long, Double> e : scores.entrySet()) {
+            MemoryEntry m = memoryMap.get(e.getKey());
+            e.setValue(e.getValue() * impliedSignificance(m) * timeDecayFactor(m) * jitterFactor());
         }
-        
-        // 按 RRF 分数降序排序并返回
+
         return scores.entrySet().stream()
                 .sorted(Map.Entry.<Long, Double>comparingByValue().reversed())
                 .limit(limit)
@@ -287,31 +409,92 @@ public class MemoryManager {
                 .collect(Collectors.toList());
     }
 
+    // ==================== 拟人化检索排序与命中更新 ====================
+
     /**
-     * 多列表 RRF 融合（支持多个检索源）
-     * 用于 Agentic 多轮召回时融合多个查询结果
+     * 计算记忆的时间衰减因子：0.5 ^ (距上次命中天数 / (半衰期 × 记忆强度))。
+     * - 受保护记忆（法律关键信息）不衰减，恒为 1.0（"闪光灯记忆"）
+     * - 复述效应：命中次数越多记忆强度越高，衰减越慢——就像多年后仍记得反复想起过的时刻
      */
-    public List<MemoryEntry> rrfFusionMultiple(List<List<MemoryEntry>> resultLists, int limit) {
-        final int k = 60;
-        Map<Long, Double> scores = new HashMap<>();
-        Map<Long, MemoryEntry> memoryMap = new HashMap<>();
-        
-        for (List<MemoryEntry> results : resultLists) {
-            for (int i = 0; i < results.size(); i++) {
-                MemoryEntry entry = results.get(i);
-                Long id = entry.getId();
-                double score = 1.0 / (k + i + 1);
-                scores.merge(id, score, Double::sum);
-                memoryMap.putIfAbsent(id, entry);
-            }
+    double timeDecayFactor(MemoryEntry entry) {
+        if (entry == null) return 1.0;
+        if (Boolean.TRUE.equals(entry.getIsProtected())) return 1.0;
+        LocalDateTime ref = entry.getLastAccessedAt() != null ? entry.getLastAccessedAt()
+                : (entry.getUpdatedAt() != null ? entry.getUpdatedAt() : entry.getCreatedAt());
+        if (ref == null) return 1.0;
+        double days = java.time.Duration.between(ref, LocalDateTime.now()).toHours() / 24.0;
+        if (days <= 0) return 1.0;
+        int accessCount = entry.getAccessCount() != null ? entry.getAccessCount() : 0;
+        double stability = 1.0 + Math.log1p(accessCount);
+        return Math.pow(0.5, days / (DECAY_HALF_LIFE_DAYS * stability));
+    }
+
+    /**
+     * 隐含重要性（implied significance）：显式 importance 之外，
+     * 从记忆自身特征推断的显著性加成（受保护、类型）。
+     */
+    double impliedSignificance(MemoryEntry entry) {
+        double score = entry.getImportanceScore() != null ? entry.getImportanceScore() : 0.5;
+        if (Boolean.TRUE.equals(entry.getIsProtected())) {
+            score += PROTECTED_SIGNIFICANCE_BOOST;
         }
-        
-        return scores.entrySet().stream()
-                .sorted(Map.Entry.<Long, Double>comparingByValue().reversed())
-                .limit(limit)
-                .map(e -> memoryMap.get(e.getKey()))
-                .filter(Objects::nonNull)
+        if (entry.getMemoryType() != null) {
+            score += TYPE_SIGNIFICANCE_BOOST.getOrDefault(entry.getMemoryType().toLowerCase(), 0.0);
+        }
+        return score;
+    }
+
+    /**
+     * 检索综合分 = 隐含重要性 × 时间衰减 × 随机抖动。
+     */
+    private double retrievalScore(MemoryEntry entry) {
+        return impliedSignificance(entry) * timeDecayFactor(entry) * jitterFactor();
+    }
+
+    /** 随机抖动因子：[1 - JITTER_RATIO, 1 + JITTER_RATIO] */
+    private double jitterFactor() {
+        return 1.0 + (random.nextDouble() * 2 - 1) * JITTER_RATIO;
+    }
+
+    /**
+     * 拟人化排序并截取前 limit 条：
+     * 按综合分排序后，以小概率把候选池中一条"冷门"记忆替换进末位（偶然想起）。
+     */
+    private List<MemoryEntry> rankWithTimeDecay(List<MemoryEntry> candidates, int limit) {
+        if (candidates == null || candidates.isEmpty()) return Collections.emptyList();
+        List<MemoryEntry> ranked = candidates.stream()
+                .sorted(Comparator.comparingDouble(this::retrievalScore).reversed())
                 .collect(Collectors.toList());
+
+        List<MemoryEntry> top = new ArrayList<>(ranked.subList(0, Math.min(limit, ranked.size())));
+
+        // 偶然想起：候选池有落选者时，小概率用其中随机一条替换末位
+        if (ranked.size() > top.size() && !top.isEmpty()
+                && random.nextDouble() < SERENDIPITY_PROBABILITY) {
+            List<MemoryEntry> rest = ranked.subList(top.size(), ranked.size());
+            MemoryEntry lucky = rest.get(random.nextInt(rest.size()));
+            top.set(top.size() - 1, lucky);
+            log.debug("Serendipity recall: surfaced memory id={} into results", lucky.getId());
+        }
+        return top;
+    }
+
+    /**
+     * 检索命中后更新 lastAccessedAt（失败不影响检索主流程）。
+     */
+    private void touchMemories(List<MemoryEntry> hits) {
+        if (hits == null || hits.isEmpty()) return;
+        try {
+            List<Long> ids = hits.stream()
+                    .map(MemoryEntry::getId)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            if (!ids.isEmpty()) {
+                memoryEntryRepository.touchLastAccessedAt(ids, LocalDateTime.now());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to touch lastAccessedAt for memories: {}", e.getMessage());
+        }
     }
 
     /**

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -76,6 +76,38 @@ ai:
       base-url: https://openrouter.ai/api/v1
       default-model: google/gemini-2.0-flash-exp:free
       timeout: 120s
+  # AI 上下文与压缩配置（对应 AiContextProperties，以下均为默认值，可按需覆盖）
+  context:
+    # 上下文总 token 预算
+    max-context-tokens: 100000
+    # 各项 token 预留
+    system-prompt-reserve: 8000
+    memory-reserve: 5000
+    response-reserve: 8000
+    # token 估算系数：每个 token 约折合多少字符
+    chars-per-token: 2.0
+    # 按模型覆盖 token 总预算（key 支持子串匹配模型标识），示例：
+    # model-token-budgets:
+    #   "[gemini]": 500000
+    #   "[qwen3-vl]": 30000
+    compression:
+      keep-recent-with-summary: 10
+      min-messages-for-summarize: 6
+      keep-recent-on-summarize: 4
+      keep-recent-aggressive: 2
+      max-history-messages: 30
+      tool-output-max-chars: 2000
+      tool-output-target-chars: 1500
+    files:
+      max-file-size-bytes: 10485760
+      max-files-per-context: 10
+      max-chars-per-file: 50000
+      folder-file-max-chars: 20000
+      chat-context-max-chars: 6000
+      chat-folder-context-max-chars: 50000
+      chat-selection-max-chars: 1500
+    # 支持 OCR 的文件扩展名
+    ocr-extensions: [jpg, jpeg, png, gif, bmp, webp, pdf]
 
 # 文件存储配置
 storage:

--- a/backend/src/main/resources/legal/protected-patterns.yml
+++ b/backend/src/main/resources/legal/protected-patterns.yml
@@ -1,0 +1,65 @@
+# 法律信息保护正则配置（LegalInfoProtector）
+# 上下文压缩时按以下模式识别并保护法律关键信息；代码只负责加载与匹配。
+#
+# level 取值：CRITICAL（绝对不能丢失）/ HIGH（非常重要）/ MEDIUM（较重要）
+
+protected-patterns:
+  # 法律法规名称及条款
+  - pattern: '《[^》]+》(?:第[一二三四五六七八九十百千万]+条)?(?:第[一二三四五六七八九十]+款)?'
+    level: CRITICAL
+    type: 法律引用
+
+  # 日期（多种格式）
+  - pattern: '\d{4}年\d{1,2}月\d{1,2}日'
+    level: CRITICAL
+    type: 日期
+  - pattern: '\d{4}-\d{2}-\d{2}'
+    level: HIGH
+    type: 日期
+
+  # 金额
+  - pattern: '[\d,]+\.?\d*\s*(万元|亿元|元|万|亿)'
+    level: CRITICAL
+    type: 金额
+  - pattern: '人民币[\d,]+\.?\d*'
+    level: CRITICAL
+    type: 金额
+
+  # 统一社会信用代码
+  - pattern: '统一社会信用代码[：:]?\s*[0-9A-Z]{18}'
+    level: HIGH
+    type: 信用代码
+  - pattern: '[0-9A-Z]{18}'
+    level: MEDIUM
+    type: 信用代码
+
+  # 当事人
+  - pattern: '(甲方|乙方|丙方|丁方|发行人|标的公司|上市公司|交易对方)[：:：]\s*[^\n,，。]+'
+    level: CRITICAL
+    type: 当事人
+
+  # 合同编号
+  - pattern: '(合同|协议|编号)[：:]\s*[A-Za-z0-9\-]+'
+    level: HIGH
+    type: 合同编号
+
+  # 股权比例
+  - pattern: '\d+\.?\d*\s*%'
+    level: HIGH
+    type: 比例
+
+  # 期限
+  - pattern: '\d+\s*(个月|年|日|天|工作日)'
+    level: HIGH
+    type: 期限
+
+  # 法院/仲裁机构
+  - pattern: '[一-龥]+(?:人民法院|仲裁委员会)'
+    level: HIGH
+    type: 司法机构
+
+# 独立提取器使用的正则（extractLegalReferences/extractAmounts/extractDates）
+extractors:
+  legal-reference: '《[^》]+》(?:第[一二三四五六七八九十百千万]+条)?'
+  amount: '[\d,]+\.?\d*\s*(万元|亿元|元)'
+  date: '\d{4}年\d{1,2}月\d{1,2}日'

--- a/backend/src/test/java/com/checkba/config/AiContextPropertiesTest.java
+++ b/backend/src/test/java/com/checkba/config/AiContextPropertiesTest.java
@@ -1,0 +1,75 @@
+package com.checkba.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * AiContextProperties 测试：默认值与按模型覆盖 token 预算
+ */
+class AiContextPropertiesTest {
+
+    @Test
+    @DisplayName("默认值与原硬编码常量一致（行为保持）")
+    void defaultsShouldMatchLegacyConstants() {
+        AiContextProperties props = new AiContextProperties();
+
+        assertEquals(100000, props.getMaxContextTokens());
+        assertEquals(8000, props.getSystemPromptReserve());
+        assertEquals(5000, props.getMemoryReserve());
+        assertEquals(8000, props.getResponseReserve());
+        assertEquals(2.0, props.getCharsPerToken());
+
+        assertEquals(10, props.getCompression().getKeepRecentWithSummary());
+        assertEquals(6, props.getCompression().getMinMessagesForSummarize());
+        assertEquals(4, props.getCompression().getKeepRecentOnSummarize());
+        assertEquals(2, props.getCompression().getKeepRecentAggressive());
+        assertEquals(30, props.getCompression().getMaxHistoryMessages());
+        assertEquals(2000, props.getCompression().getToolOutputMaxChars());
+        assertEquals(1500, props.getCompression().getToolOutputTargetChars());
+
+        assertEquals(10 * 1024 * 1024, props.getFiles().getMaxFileSizeBytes());
+        assertEquals(10, props.getFiles().getMaxFilesPerContext());
+        assertEquals(50000, props.getFiles().getMaxCharsPerFile());
+        assertEquals(20000, props.getFiles().getFolderFileMaxChars());
+        assertEquals(6000, props.getFiles().getChatContextMaxChars());
+        assertEquals(50000, props.getFiles().getChatFolderContextMaxChars());
+        assertEquals(1500, props.getFiles().getChatSelectionMaxChars());
+
+        assertTrue(props.getOcrExtensions().containsAll(
+                java.util.List.of("jpg", "jpeg", "png", "gif", "bmp", "webp", "pdf")));
+    }
+
+    @Test
+    @DisplayName("无覆盖配置时返回默认 token 预算")
+    void shouldReturnDefaultBudgetWithoutOverrides() {
+        AiContextProperties props = new AiContextProperties();
+        assertEquals(100000, props.maxContextTokensFor("google/gemini-2.0-flash-exp:free"));
+        assertEquals(100000, props.maxContextTokensFor(null));
+        assertEquals(100000, props.maxContextTokensFor(""));
+    }
+
+    @Test
+    @DisplayName("按模型精确匹配覆盖 token 预算")
+    void shouldResolveExactModelOverride() {
+        AiContextProperties props = new AiContextProperties();
+        props.setModelTokenBudgets(Map.of("qwen3-vl:8b", 30000));
+
+        assertEquals(30000, props.maxContextTokensFor("qwen3-vl:8b"));
+        assertEquals(30000, props.maxContextTokensFor("QWEN3-VL:8B"));
+        assertEquals(100000, props.maxContextTokensFor("other-model"));
+    }
+
+    @Test
+    @DisplayName("按模型子串匹配覆盖 token 预算")
+    void shouldResolveSubstringModelOverride() {
+        AiContextProperties props = new AiContextProperties();
+        props.setModelTokenBudgets(Map.of("gemini", 500000));
+
+        assertEquals(500000, props.maxContextTokensFor("google/gemini-2.0-flash-exp:free"));
+        assertEquals(100000, props.maxContextTokensFor("qwen3-vl:8b"));
+    }
+}

--- a/backend/src/test/java/com/checkba/config/PgVectorConfigTest.java
+++ b/backend/src/test/java/com/checkba/config/PgVectorConfigTest.java
@@ -1,0 +1,68 @@
+package com.checkba.config;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * PgVectorConfig 测试：向量维度从 EmbeddingModel 动态读取
+ */
+class PgVectorConfigTest {
+
+    /** 固定维度的测试用 EmbeddingModel */
+    private static EmbeddingModel modelWithDimension(int dim) {
+        return new EmbeddingModel() {
+            @Override
+            public Response<Embedding> embed(String text) {
+                return Response.from(Embedding.from(new float[dim]));
+            }
+
+            @Override
+            public Response<Embedding> embed(TextSegment textSegment) {
+                return embed(textSegment.text());
+            }
+
+            @Override
+            public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("维度从 EmbeddingModel 动态读取（如 nomic-embed-text 为 768）")
+    void shouldResolveDimensionFromModel() {
+        assertEquals(768, PgVectorConfig.resolveDimension(modelWithDimension(768)));
+        assertEquals(1536, PgVectorConfig.resolveDimension(modelWithDimension(1536)));
+    }
+
+    @Test
+    @DisplayName("模型不可用时回退到默认维度")
+    void shouldFallBackWhenModelUnavailable() {
+        EmbeddingModel broken = new EmbeddingModel() {
+            @Override
+            public Response<Embedding> embed(String text) {
+                throw new RuntimeException("embedding service down");
+            }
+
+            @Override
+            public Response<Embedding> embed(TextSegment textSegment) {
+                return embed(textSegment.text());
+            }
+
+            @Override
+            public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        assertEquals(PgVectorConfig.FALLBACK_DIMENSION, PgVectorConfig.resolveDimension(broken));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/AiAssistantServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AiAssistantServiceTest.java
@@ -1,0 +1,75 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiModelProperties;
+import com.checkba.model.ai.AiAssistantConfig;
+import com.checkba.service.SystemSettingService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * AiAssistantService 测试：助手配置动态加载与 ProjectAssistant 实例缓存
+ * （原 AiChatController.loadAssistants/getAssistant 下沉后的专职服务）
+ */
+class AiAssistantServiceTest {
+
+    private SystemSettingService systemSettingService;
+    private ChatModelFactory chatModelFactory;
+    private AiAssistantService service;
+
+    @BeforeEach
+    void setUp() {
+        systemSettingService = mock(SystemSettingService.class);
+        chatModelFactory = mock(ChatModelFactory.class);
+        when(chatModelFactory.getChatModel(any())).thenReturn(mock(ChatLanguageModel.class));
+
+        service = new AiAssistantService(systemSettingService, new AiModelProperties(),
+                chatModelFactory, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("loadAssistants：从系统设置解析 JSON 并保留顺序")
+    void loadsAssistantsFromSystemSettings() {
+        when(systemSettingService.get(eq("ai.assistants"), any())).thenReturn(
+                "[{\"id\":\"default\",\"name\":\"默认\"},{\"id\":\"legal\",\"name\":\"法律\"}]");
+
+        Map<String, AiAssistantConfig> assistants = service.loadAssistants();
+
+        assertEquals(2, assistants.size());
+        assertEquals("默认", assistants.get("default").getName());
+        assertEquals(java.util.List.of("default", "legal"),
+                new java.util.ArrayList<>(assistants.keySet()), "应保留配置顺序");
+    }
+
+    @Test
+    @DisplayName("loadAssistants：配置为空或非法 JSON 时返回空表")
+    void handlesMissingOrInvalidConfig() {
+        when(systemSettingService.get(eq("ai.assistants"), any())).thenReturn(null);
+        assertTrue(service.loadAssistants().isEmpty());
+
+        when(systemSettingService.get(eq("ai.assistants"), any())).thenReturn("not-json");
+        assertTrue(service.loadAssistants().isEmpty());
+    }
+
+    @Test
+    @DisplayName("getAssistant：按 模型+助手 缓存实例")
+    void cachesAssistantByModelAndAssistantId() {
+        ProjectAssistant first = service.getAssistant("model-a", null);
+        ProjectAssistant again = service.getAssistant("model-a", null);
+        assertSame(first, again, "同一模型+助手应复用缓存实例");
+
+        ProjectAssistant other = service.getAssistant("model-b", null);
+        assertNotSame(first, other, "不同模型应创建不同实例");
+
+        verify(chatModelFactory, times(2)).getChatModel(any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/MultiModalContentServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/MultiModalContentServiceTest.java
@@ -1,0 +1,106 @@
+package com.checkba.service.ai;
+
+import com.checkba.controller.ai.AiChatController.AiChatContext;
+import com.checkba.service.ProjectFileService;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * MultiModalContentService 测试：类型分类与多模态内容构建
+ * （原 AiChatController 双份分类逻辑去重后的单一实现）
+ */
+class MultiModalContentServiceTest {
+
+    private ProjectFileService projectFileService;
+    private MediaProcessingService mediaProcessingService;
+    private MultiModalContentService service;
+
+    @BeforeEach
+    void setUp() {
+        projectFileService = mock(ProjectFileService.class);
+        mediaProcessingService = mock(MediaProcessingService.class);
+        service = new MultiModalContentService(projectFileService, mediaProcessingService);
+    }
+
+    private static AiChatContext ctx(String fileId, String fileType) {
+        AiChatContext c = new AiChatContext();
+        c.setFileId(fileId);
+        c.setFileType(fileType);
+        return c;
+    }
+
+    @Test
+    @DisplayName("类型分类：PDF 只有 Gemini 可直传，图片所有多模态模型可直传")
+    void canDirectSendClassification() {
+        assertTrue(service.canDirectSend("google/gemini-2.0-flash", "pdf"));
+        assertFalse(service.canDirectSend("gpt-4o", "pdf"), "PDF 直传目前仅限 Gemini");
+        assertTrue(service.canDirectSend("gpt-4o", "png"));
+        assertTrue(service.canDirectSend("claude-3-sonnet", "jpg"));
+        assertFalse(service.canDirectSend("qwen3-vl:8b", "png"), "未知模型不视为多模态");
+        assertFalse(service.canDirectSend("gemini", "docx"), "非媒体文件不直传");
+    }
+
+    @Test
+    @DisplayName("Gemini + PDF：整文件 base64 直传")
+    void buildsPdfContentForGemini() throws Exception {
+        when(projectFileService.getFileBytes(1L)).thenReturn("pdf".getBytes(StandardCharsets.UTF_8));
+
+        List<Content> contents = service.buildMediaContents(List.of(ctx("1", "pdf")), "google/gemini-2.0-flash");
+
+        assertEquals(1, contents.size());
+        ImageContent pdf = (ImageContent) contents.get(0);
+        assertEquals("application/pdf", pdf.image().mimeType());
+    }
+
+    @Test
+    @DisplayName("非 Gemini 模型：PDF 不构建多模态内容")
+    void skipsPdfForNonGemini() {
+        List<Content> contents = service.buildMediaContents(List.of(ctx("1", "pdf")), "gpt-4o");
+        assertTrue(contents.isEmpty());
+    }
+
+    @Test
+    @DisplayName("图片：jpg 归一化为 image/jpeg")
+    void normalizesJpgMimeType() throws Exception {
+        when(projectFileService.getFileBytes(2L)).thenReturn("img".getBytes(StandardCharsets.UTF_8));
+
+        List<Content> contents = service.buildMediaContents(List.of(ctx("2", "jpg")), "gemini");
+
+        assertEquals(1, contents.size());
+        assertEquals("image/jpeg", ((ImageContent) contents.get(0)).image().mimeType());
+    }
+
+    @Test
+    @DisplayName("视频：抽取关键帧后按 image/jpeg 发送")
+    void extractsVideoKeyframes() throws Exception {
+        when(projectFileService.getFileBytes(3L)).thenReturn("video".getBytes(StandardCharsets.UTF_8));
+        when(mediaProcessingService.extractKeyframes(any(), eq(5)))
+                .thenReturn(List.of("frame1", "frame2"));
+
+        List<Content> contents = service.buildMediaContents(List.of(ctx("3", "mp4")), "gemini");
+
+        assertEquals(2, contents.size());
+        assertEquals("image/jpeg", ((ImageContent) contents.get(0)).image().mimeType());
+    }
+
+    @Test
+    @DisplayName("单个文件读取失败不影响其他上下文")
+    void toleratesSingleFileFailure() throws Exception {
+        when(projectFileService.getFileBytes(4L)).thenThrow(new java.io.IOException("gone"));
+        when(projectFileService.getFileBytes(5L)).thenReturn("img".getBytes(StandardCharsets.UTF_8));
+
+        List<Content> contents = service.buildMediaContents(
+                List.of(ctx("4", "png"), ctx("5", "png")), "gemini");
+
+        assertEquals(1, contents.size(), "失败文件跳过，正常文件仍应构建");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/context/ContextCompressorTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/context/ContextCompressorTest.java
@@ -31,7 +31,8 @@ class ContextCompressorTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         legalInfoProtector = new LegalInfoProtector();
-        compressor = new ContextCompressor(legalInfoProtector, conversationSummarizer);
+        compressor = new ContextCompressor(legalInfoProtector, conversationSummarizer,
+                new com.checkba.config.AiContextProperties());
         
         // 模拟摘要生成
         when(conversationSummarizer.generateQuickSummary(anyList()))

--- a/backend/src/test/java/com/checkba/service/ai/context/FileContextLoaderTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/context/FileContextLoaderTest.java
@@ -1,0 +1,136 @@
+package com.checkba.service.ai.context;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.ProjectFileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * FileContextLoader 测试：单文件提取路由（OCR/标准）与文件夹递归收集上限
+ */
+class FileContextLoaderTest {
+
+    private ProjectFileService projectFileService;
+    private FileContentExtractorService extractor;
+    private AiContextProperties props;
+    private FileContextLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        projectFileService = mock(ProjectFileService.class);
+        extractor = mock(FileContentExtractorService.class);
+        props = new AiContextProperties();
+        loader = new FileContextLoader(projectFileService, extractor, props);
+    }
+
+    private static ProjectFile file(Long id, String name, boolean isFolder) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setName(name);
+        f.setIsFolder(isFolder);
+        f.setFilePath("/nonexistent/" + name);
+        return f;
+    }
+
+    @Test
+    @DisplayName("单文件提取：OCR 支持的文件走 OCR 路径")
+    void extractFileTextRoutesToOcr() throws Exception {
+        ProjectFile pdf = file(1L, "contract.pdf", false);
+        pdf.setFileType("pdf");
+        when(projectFileService.getFileBytes(1L)).thenReturn("pdf-bytes".getBytes(StandardCharsets.UTF_8));
+        when(extractor.isOcrSupported("contract.pdf")).thenReturn(true);
+        when(extractor.extractTextWithOcr(any(File.class))).thenReturn("OCR 文本");
+
+        String result = loader.extractFileText(pdf);
+
+        assertEquals("OCR 文本", result);
+        verify(extractor).extractTextWithOcr(any(File.class));
+        verify(extractor, never()).extractText(any(File.class));
+    }
+
+    @Test
+    @DisplayName("单文件提取：普通文件走标准提取路径")
+    void extractFileTextRoutesToStandard() throws Exception {
+        ProjectFile doc = file(2L, "note.txt", false);
+        doc.setFileType("txt");
+        when(projectFileService.getFileBytes(2L)).thenReturn("text".getBytes(StandardCharsets.UTF_8));
+        when(extractor.isOcrSupported("note.txt")).thenReturn(false);
+        when(extractor.extractText(any(File.class))).thenReturn("标准文本");
+
+        String result = loader.extractFileText(doc);
+
+        assertEquals("标准文本", result);
+        verify(extractor).extractText(any(File.class));
+        verify(extractor, never()).extractTextWithOcr(any(File.class));
+    }
+
+    @Test
+    @DisplayName("单文件提取：内容为空时返回提示")
+    void extractFileTextHandlesEmptyBytes() throws Exception {
+        ProjectFile empty = file(3L, "empty.txt", false);
+        when(projectFileService.getFileBytes(3L)).thenReturn(new byte[0]);
+
+        assertEquals("[文件内容为空或无法读取]", loader.extractFileText(empty));
+    }
+
+    @Test
+    @DisplayName("文件夹收集：递归读取子文件夹并拼接文件内容")
+    void collectFolderContentRecursesIntoSubfolders() throws Exception {
+        ProjectFile sub = file(10L, "子文件夹", true);
+        ProjectFile f1 = file(11L, "a.txt", false);
+        ProjectFile f2 = file(12L, "b.txt", false);
+
+        when(projectFileService.getFilesByParent(1L, 100L)).thenReturn(List.of(f1, sub));
+        when(projectFileService.getFilesByParent(1L, 10L)).thenReturn(List.of(f2));
+        when(projectFileService.getFileBytes(any())).thenReturn("x".getBytes(StandardCharsets.UTF_8));
+        when(extractor.extractText(any(File.class))).thenReturn("内容");
+
+        String result = loader.collectFolderContent(1L, 100L);
+
+        assertTrue(result.contains("a.txt"));
+        assertTrue(result.contains("b.txt"));
+    }
+
+    @Test
+    @DisplayName("文件夹收集：文件数量受 maxFilesPerContext 上限约束")
+    void collectFolderContentRespectsFileLimit() throws Exception {
+        props.getFiles().setMaxFilesPerContext(2);
+
+        List<ProjectFile> files = List.of(
+                file(21L, "f1.txt", false), file(22L, "f2.txt", false), file(23L, "f3.txt", false));
+        when(projectFileService.getFilesByParent(1L, 100L)).thenReturn(files);
+        when(projectFileService.getFileBytes(any())).thenReturn("x".getBytes(StandardCharsets.UTF_8));
+        when(extractor.extractText(any(File.class))).thenReturn("内容");
+
+        String result = loader.collectFolderContent(1L, 100L);
+
+        assertTrue(result.contains("f1.txt"));
+        assertTrue(result.contains("f2.txt"));
+        assertFalse(result.contains("f3.txt"), "超出上限的文件不应被读取");
+    }
+
+    @Test
+    @DisplayName("文件夹上下文：配额耗尽时只输出目录结构")
+    void buildFolderContextStopsWhenQuotaExhausted() {
+        ProjectFile f1 = file(31L, "doc.txt", false);
+        when(projectFileService.getFilesByParent(1L, 200L)).thenReturn(List.of(f1));
+
+        String result = loader.buildFolderContext("200", "1",
+                props.getFiles().getMaxFilesPerContext()); // 已用完配额
+
+        assertTrue(result.contains("Directory Content"));
+        assertTrue(result.contains("doc.txt"), "目录结构仍应列出文件");
+        assertFalse(result.contains("Folder Document Contents"), "不应再读取文件内容");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemoryQualityTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemoryQualityTest.java
@@ -1,0 +1,277 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.model.entity.MemoryEntry;
+import com.checkba.repository.ConversationSummaryRepository;
+import com.checkba.repository.MemoryEntryRepository;
+import com.checkba.repository.ProjectMemoryRepository;
+import com.checkba.repository.UserMemoryRepository;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 记忆质量测试（Phase 2）：
+ * - 检索排序的时间衰减（受保护记忆不衰减）
+ * - 检索命中更新 lastAccessedAt
+ * - MemCell 写入前的向量相似度去重（保留 importance 更高者）
+ */
+class MemoryQualityTest {
+
+    private MemoryEntryRepository memoryEntryRepository;
+    private EmbeddingStore<TextSegment> embeddingStore;
+    private EmbeddingModel embeddingModel;
+    private MemoryManager memoryManager;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        memoryEntryRepository = mock(MemoryEntryRepository.class);
+        embeddingStore = (EmbeddingStore<TextSegment>) mock(EmbeddingStore.class);
+        embeddingModel = mock(EmbeddingModel.class);
+
+        memoryManager = new MemoryManager(
+                memoryEntryRepository,
+                mock(ConversationSummaryRepository.class),
+                mock(ProjectMemoryRepository.class),
+                mock(UserMemoryRepository.class),
+                embeddingStore,
+                embeddingModel);
+        // 固定随机源：无抖动、不触发"偶然想起"，保证排序断言确定性
+        memoryManager.setRandom(fixedRandom(0.5));
+
+        when(embeddingModel.embed(anyString()))
+                .thenReturn(Response.from(Embedding.from(new float[]{0.1f, 0.2f, 0.3f})));
+    }
+
+    /** nextDouble 恒定、nextInt 恒为 0 的测试随机源 */
+    private static java.util.Random fixedRandom(double d) {
+        return new java.util.Random() {
+            @Override public double nextDouble() { return d; }
+            @Override public int nextInt(int bound) { return 0; }
+        };
+    }
+
+    private static MemoryEntry entry(Long id, double importance, LocalDateTime lastAccessedAt, boolean isProtected) {
+        MemoryEntry e = MemoryEntry.builder()
+                .id(id)
+                .projectId(1L)
+                .memoryType("fact")
+                .memoryKey("key-" + id)
+                .memoryValue("value-" + id)
+                .importanceScore(importance)
+                .isProtected(isProtected)
+                .build();
+        e.setLastAccessedAt(lastAccessedAt);
+        return e;
+    }
+
+    // ==================== 时间衰减 ====================
+
+    @Test
+    @DisplayName("时间衰减因子：刚命中不衰减，半衰期约减半，受保护记忆恒为 1.0")
+    void timeDecayFactorBasics() {
+        MemoryEntry fresh = entry(1L, 0.9, LocalDateTime.now(), false);
+        assertEquals(1.0, memoryManager.timeDecayFactor(fresh), 0.001);
+
+        MemoryEntry halfLife = entry(2L, 0.9, LocalDateTime.now().minusDays(30), false);
+        assertEquals(0.5, memoryManager.timeDecayFactor(halfLife), 0.05);
+
+        MemoryEntry protectedOld = entry(3L, 0.9, LocalDateTime.now().minusDays(365), true);
+        assertEquals(1.0, memoryManager.timeDecayFactor(protectedOld), 0.001);
+    }
+
+    @Test
+    @DisplayName("检索排序引入时间衰减：陈旧记忆排序下降，受保护记忆不受影响")
+    void retrievalRankingAppliesTimeDecay() {
+        // A: 高重要性但 90 天未命中（衰减后 0.9*0.125=0.1125）
+        MemoryEntry staleImportant = entry(1L, 0.9, LocalDateTime.now().minusDays(90), false);
+        // B: 中等重要性但刚命中（0.6）
+        MemoryEntry freshModerate = entry(2L, 0.6, LocalDateTime.now(), false);
+        // C: 高重要性且受保护，一年未命中也不衰减（0.9）
+        MemoryEntry protectedOld = entry(3L, 0.9, LocalDateTime.now().minusDays(365), true);
+
+        when(memoryEntryRepository.searchByKeywordAndType(any(), anyString(), any(), any()))
+                .thenReturn(List.of(staleImportant, freshModerate, protectedOld));
+
+        List<MemoryEntry> results = memoryManager.retrieveMemories(1L, "查询", null, 3);
+
+        assertEquals(3, results.size());
+        assertEquals(3L, results.get(0).getId(), "受保护记忆不衰减，应排第一");
+        assertEquals(2L, results.get(1).getId(), "新鲜记忆应排在陈旧记忆之前");
+        assertEquals(1L, results.get(2).getId(), "陈旧记忆衰减后应排最后");
+    }
+
+    @Test
+    @DisplayName("检索命中后更新 lastAccessedAt")
+    void retrievalTouchesLastAccessedAt() {
+        MemoryEntry m = entry(9L, 0.8, LocalDateTime.now().minusDays(10), false);
+        when(memoryEntryRepository.searchByKeywordAndType(any(), anyString(), any(), any()))
+                .thenReturn(List.of(m));
+
+        memoryManager.retrieveMemories(1L, "查询", null, 5);
+
+        ArgumentCaptor<List<Long>> idsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(memoryEntryRepository).touchLastAccessedAt(idsCaptor.capture(), any(LocalDateTime.class));
+        assertEquals(List.of(9L), idsCaptor.getValue());
+    }
+
+    // ==================== 拟人化排序：隐含重要性 / 复述效应 / 偶然想起 ====================
+
+    @Test
+    @DisplayName("隐含重要性：受保护与决策类记忆有显著性加成")
+    void impliedSignificanceBoosts() {
+        MemoryEntry plainFact = entry(1L, 0.5, LocalDateTime.now(), false);
+        assertEquals(0.5, memoryManager.impliedSignificance(plainFact), 0.001);
+
+        MemoryEntry protectedFact = entry(2L, 0.5, LocalDateTime.now(), true);
+        assertEquals(0.65, memoryManager.impliedSignificance(protectedFact), 0.001,
+                "受保护记忆应有 +0.15 加成");
+
+        MemoryEntry decision = entry(3L, 0.5, LocalDateTime.now(), false);
+        decision.setMemoryType(MemoryEntry.MemoryType.DECISION);
+        assertEquals(0.6, memoryManager.impliedSignificance(decision), 0.001,
+                "决策类记忆应有 +0.10 加成");
+    }
+
+    @Test
+    @DisplayName("复述效应：被反复想起的记忆衰减更慢")
+    void rehearsalSlowsDecay() {
+        MemoryEntry rarelyRecalled = entry(1L, 0.8, LocalDateTime.now().minusDays(60), false);
+        rarelyRecalled.setAccessCount(0);
+
+        MemoryEntry oftenRecalled = entry(2L, 0.8, LocalDateTime.now().minusDays(60), false);
+        oftenRecalled.setAccessCount(30);
+
+        double rareFactor = memoryManager.timeDecayFactor(rarelyRecalled);
+        double oftenFactor = memoryManager.timeDecayFactor(oftenRecalled);
+
+        assertTrue(oftenFactor > rareFactor,
+                "同样 60 天未命中，命中 30 次的记忆 (" + oftenFactor + ") 应比 0 次的 (" + rareFactor + ") 衰减更慢");
+    }
+
+    @Test
+    @DisplayName("偶然想起：小概率把候选池中的冷门记忆带回结果")
+    void serendipitySurfacesRandomMemory() {
+        MemoryEntry top1 = entry(1L, 0.9, LocalDateTime.now(), false);
+        MemoryEntry top2 = entry(2L, 0.8, LocalDateTime.now(), false);
+        MemoryEntry cold = entry(3L, 0.3, LocalDateTime.now().minusDays(200), false);
+
+        when(memoryEntryRepository.searchByKeywordAndType(any(), anyString(), any(), any()))
+                .thenReturn(List.of(top1, top2, cold));
+
+        // nextDouble=0.0 → 必触发偶然想起；nextInt=0 → 选中落选池第一条
+        memoryManager.setRandom(fixedRandom(0.0));
+        List<MemoryEntry> withSerendipity = memoryManager.retrieveMemories(1L, "查询", null, 2);
+        assertTrue(withSerendipity.stream().anyMatch(m -> m.getId().equals(3L)),
+                "触发偶然想起时，冷门记忆应进入结果");
+
+        // nextDouble=0.5 → 不触发，按分数取前 2
+        memoryManager.setRandom(fixedRandom(0.5));
+        List<MemoryEntry> normal = memoryManager.retrieveMemories(1L, "查询", null, 2);
+        assertEquals(List.of(1L, 2L), normal.stream().map(MemoryEntry::getId).toList());
+    }
+
+    // ==================== 语义去重 ====================
+
+    private void mockStoreMatch(Long existingId, double relevanceScore) {
+        TextSegment segment = TextSegment.from("dup",
+                Metadata.from(Map.of("memoryId", String.valueOf(existingId), "projectId", "1")));
+        EmbeddingMatch<TextSegment> match = new EmbeddingMatch<>(
+                relevanceScore, "emb-1", Embedding.from(new float[]{0.1f, 0.2f, 0.3f}), segment);
+        when(embeddingStore.search(any(EmbeddingSearchRequest.class)))
+                .thenReturn(new EmbeddingSearchResult<>(List.of(match)));
+    }
+
+    @Test
+    @DisplayName("去重：已有条目 importance 更高时跳过写入")
+    void dedupSkipsLowerImportanceDuplicate() {
+        MemoryEntry existing = entry(5L, 0.9, LocalDateTime.now(), false);
+        when(memoryEntryRepository.findById(5L)).thenReturn(Optional.of(existing));
+        mockStoreMatch(5L, 0.98); // relevance 0.98 → cos 0.96 >= 0.95
+
+        MemoryEntry candidate = entry(null, 0.5, null, false);
+        MemoryEntry result = memoryManager.saveMemoryDeduplicated(candidate);
+
+        assertEquals(5L, result.getId(), "应返回已有条目");
+        verify(memoryEntryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("去重：新条目 importance 更高时覆盖旧条目（保留 importance 更高者）")
+    void dedupReplacesWithHigherImportance() {
+        MemoryEntry existing = entry(5L, 0.5, LocalDateTime.now(), false);
+        when(memoryEntryRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(memoryEntryRepository.save(any(MemoryEntry.class))).thenAnswer(inv -> inv.getArgument(0));
+        mockStoreMatch(5L, 0.98);
+
+        MemoryEntry candidate = entry(null, 0.9, null, false);
+        candidate.setMemoryValue("更完整的新内容");
+        MemoryEntry result = memoryManager.saveMemoryDeduplicated(candidate);
+
+        assertEquals(5L, result.getId(), "应复用已有条目的 ID");
+        assertEquals("更完整的新内容", result.getMemoryValue(), "内容应被新条目覆盖");
+        assertEquals(0.9, result.getImportanceScore(), 0.001);
+        verify(memoryEntryRepository).save(existing);
+    }
+
+    @Test
+    @DisplayName("去重：无相似记忆时正常保存")
+    void dedupSavesWhenNoDuplicate() {
+        when(embeddingStore.search(any(EmbeddingSearchRequest.class)))
+                .thenReturn(new EmbeddingSearchResult<>(List.of()));
+        when(memoryEntryRepository.save(any(MemoryEntry.class))).thenAnswer(inv -> {
+            MemoryEntry e = inv.getArgument(0);
+            e.setId(100L);
+            return e;
+        });
+
+        MemoryEntry candidate = entry(null, 0.7, null, false);
+        MemoryEntry result = memoryManager.saveMemoryDeduplicated(candidate);
+
+        assertEquals(100L, result.getId());
+        verify(memoryEntryRepository).save(candidate);
+    }
+
+    @Test
+    @DisplayName("去重：跨项目的相似记忆不参与去重")
+    void dedupIgnoresOtherProjects() {
+        TextSegment segment = TextSegment.from("dup",
+                Metadata.from(Map.of("memoryId", "5", "projectId", "999")));
+        EmbeddingMatch<TextSegment> match = new EmbeddingMatch<>(
+                0.99, "emb-1", Embedding.from(new float[]{0.1f, 0.2f, 0.3f}), segment);
+        when(embeddingStore.search(any(EmbeddingSearchRequest.class)))
+                .thenReturn(new EmbeddingSearchResult<>(List.of(match)));
+        when(memoryEntryRepository.save(any(MemoryEntry.class))).thenAnswer(inv -> {
+            MemoryEntry e = inv.getArgument(0);
+            e.setId(101L);
+            return e;
+        });
+
+        MemoryEntry candidate = entry(null, 0.7, null, false);
+        MemoryEntry result = memoryManager.saveMemoryDeduplicated(candidate);
+
+        assertEquals(101L, result.getId(), "其他项目的相似记忆不应拦截保存");
+        verify(memoryEntryRepository).save(candidate);
+    }
+}


### PR DESCRIPTION
## 背景

Phase 1（PR #83：ToolRegistry 统一工具层、记忆五作用域、MemoryPipelineService）合并后，本 PR 完成 Phase 2 清单：接入层瘦身、配置外置、记忆质量。三块各为独立 commit。

## A. 接入层瘦身（fat controller 治理）

**AiChatController 847 → 290 行**，只留 HTTP 出入口、鉴权（session→userId）与 DTO：

- `AiChatService`：chat 业务编排（prompt 构建、多模态组装、token 记录、历史落库）
- `FileContextLoader`：单文件文本/OCR 提取（含临时文件生命周期管理）+ 文件夹递归收集——原控制器与 ContextAssembler 各写一套，收拢为一处
- `MultiModalContentService`：文件类型分类（isImage/isPdf/canDirectSend）单一实现，去重 chat() 与 buildPromptWithContext() 的两份逻辑；PDF 直传（Gemini）/图片/视频关键帧内容构建
- `GeminiCacheService`、`AiAssistantService`：Gemini Cache 与助手实例缓存下沉
- `ContextAssemblerService` 不再直接读文件系统（buildFolderContext/collectFilesRecursive 移入 FileContextLoader），只负责组装消息；`assemble()` 末位新增 modelKey 参数

## B. 配置外置（消灭硬编码）

- 新增 `AiContextProperties`（`ai.context.*`）：token 预算 5 常量、CHARS_PER_TOKEN、压缩各层保留条数、文件大小/数量/字符上限、OCR 扩展名列表；**token 总预算支持按模型覆盖**（`ai.context.model-token-budgets`，精确或子串匹配），编排器已把 modelKey 穿透到压缩器
- `LegalInfoProtector` 保护正则 + 三个提取器正则外置为 `legal/protected-patterns.yml`，代码只留加载与匹配；资源缺失启动即报错
- application.yml 增加 ai.context 默认段，取值与原硬编码一致（行为保持）

## C. 记忆质量（拟人化）

检索综合分 = **隐含重要性 × 时间衰减 × 随机抖动**，不是纯时间序：

- **时间衰减**：`MemoryEntry.lastAccessedAt/accessCount`，检索命中批量更新；半衰期 30 天；**复述效应**——被反复想起的记忆衰减更慢；受保护记忆（法律关键信息）不衰减（"闪光灯记忆"）
- **隐含重要性**：显式 importance 之外，受保护 +0.15、决策 +0.10、结论 +0.08、引用 +0.05、偏好 +0.03
- **随机性**：分数 ±5% 抖动 + 10% 概率"偶然想起"一条候选池冷门记忆
- **语义去重**：MemCell 写入前向量近重复检测（cos ≥ 0.95），保留 importance 更高者；检查失败回退普通保存
- **向量维度动态化**：PgVectorConfig 从 `EmbeddingModel.dimension()` 读取（nomic-embed-text=768），替换硬编码 1536，失败回退默认值

## 验证

- 全量 `mvn test` **99/99 通过**（JDK 21），新增 31 个单测（配置解析/加载器/多模态分类/助手缓存/衰减/去重/维度）
- 行为保持：SSE 事件字典与前端契约未动；配置默认值与原硬编码一致；chat 接口输出格式不变
- 遵守 Phase 1 不变式：编排器未 import 具体工具类；记忆读写侧分离不变（touch 为 MemoryManager 内部元数据更新）

## 注意事项（需人工确认）

1. **pgvector 旧表**：`memory_embedding_store` / `project_doc_embedding` 若已按 1536 维建表，需手动 DROP 后由 createTable 按新维度重建（此前 768 维向量插入 1536 维表本就失败，属修复既有 bug）
2. **docs/AI_ARCHITECTURE.md 缺失**：PR #83 描述引用了该文档，但实际未随 PR 提交入库，本次无法按原文核对五条不变式全文，建议后续补写入库

🤖 Generated with [Claude Code](https://claude.com/claude-code)