### PR TITLE
refactor(ai): WPS 遗留命名清理——别名灰度更名 wps_* → doc_* / editor-semantic renaming with alias fallback (Phase 2.5)

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
@@ -1,55 +1,55 @@
 package com.checkba.controller.ai;
 
-import com.checkba.service.ai.WpsActionService;
+import com.checkba.service.ai.EditorBridgeService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * WPS 操作结果接收控制器
+ * 编辑器操作结果接收控制器
  * 
- * 接收前端执行 WPS 操作后的结果回调
+ * 接收前端执行编辑器操作后的结果回调（路由 /wps-result 为前后端契约，保持旧名）
  */
 @RestController
 @RequestMapping("/api/ai/agent")
 @CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 @Slf4j
-public class WpsResultController {
+public class EditorResultController {
 
-    private final WpsActionService wpsActionService;
+    private final EditorBridgeService editorBridgeService;
 
     /**
-     * 接收 WPS 操作结果
+     * 接收编辑器操作结果
      * 
-     * 前端执行完 WPS 操作后，调用此接口返回结果
+     * 前端执行完编辑器操作后，调用此接口返回结果
      */
     @PostMapping("/wps-result")
-    public WpsResultResponse receiveWpsResult(@RequestBody WpsResultPayload payload) {
-        log.info("Received WPS result: requestId={}, success={}", payload.getRequestId(), payload.isSuccess());
+    public EditorResultResponse receiveEditorResult(@RequestBody EditorResultPayload payload) {
+        log.info("Received editor result: requestId={}, success={}", payload.getRequestId(), payload.isSuccess());
         
         try {
-            wpsActionService.completeWpsAction(
+            editorBridgeService.completeEditorAction(
                     payload.getRequestId(),
                     payload.isSuccess(),
                     payload.getData(),
                     payload.getError()
             );
             
-            return new WpsResultResponse(true, "Result received");
+            return new EditorResultResponse(true, "Result received");
             
         } catch (Exception e) {
-            log.error("Failed to process WPS result", e);
-            return new WpsResultResponse(false, e.getMessage());
+            log.error("Failed to process editor result", e);
+            return new EditorResultResponse(false, e.getMessage());
         }
     }
 
     /**
-     * WPS 结果请求体
+     * 编辑器结果请求体
      */
     @Data
-    public static class WpsResultPayload {
+    public static class EditorResultPayload {
         /**
          * 请求 ID（与 SSE 发送的 requestId 对应）
          */
@@ -77,10 +77,10 @@ public class WpsResultController {
     }
 
     /**
-     * WPS 结果响应
+     * 编辑器结果响应
      */
     @Data
-    public static class WpsResultResponse {
+    public static class EditorResultResponse {
         private final boolean received;
         private final String message;
     }

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -47,7 +47,7 @@ public class AgentOrchestrator {
     private final XmlToolCallParser xmlToolCallParser;
     private final com.checkba.service.ai.memory.MemoryPipelineService memoryPipelineService;
     private final com.checkba.service.ProjectFileService projectFileService;
-    private final WpsActionService wpsActionService;
+    private final EditorBridgeService editorBridgeService;
     private final ConversationFileChangeService conversationFileChangeService;
 
     // ==================== 取消功能相关方法 ====================
@@ -265,8 +265,8 @@ public class AgentOrchestrator {
             return;
         }
         
-        // 设置当前会话 ID 到 WpsActionService，以便 WPS 工具可以发送 SSE 事件
-        wpsActionService.setCurrentConversationId(conversationId);
+        // 设置当前会话 ID 到 EditorBridgeService，以便文档编辑工具可以发送 SSE 事件
+        editorBridgeService.setCurrentConversationId(conversationId);
 
         AgentStreamHandler handler = new AgentStreamHandler(
             sseEmitterService, 
@@ -286,9 +286,9 @@ public class AgentOrchestrator {
             }
         });
 
-        // WPS Real-time Streaming Interception (Filtered)
+        // 编辑器实时流式写入拦截（事件名沿用 wps_stream_data，前后端契约）
         handler.setOnWpsStream(token -> {
-            if (wpsActionService.isStreamingMode(conversationId)) {
+            if (editorBridgeService.isStreamingMode(conversationId)) {
                 sseEmitterService.send(conversationId, "wps_stream_data", java.util.Map.of("content", token));
             }
         });
@@ -297,7 +297,7 @@ public class AgentOrchestrator {
         handler.setOnComplete(response -> {
           try {
             // Unconditionally turn off streaming mode when generation ends
-            wpsActionService.setStreamingMode(conversationId, false);
+            editorBridgeService.setStreamingMode(conversationId, false);
 
             // 检查是否被取消
             if (isCancelled(conversationId)) {
@@ -307,7 +307,7 @@ public class AgentOrchestrator {
             }
             
             // 确保在回调线程中也能访问 conversationId（解决 ThreadLocal 线程隔离问题）
-            wpsActionService.setCurrentConversationId(conversationId);
+            editorBridgeService.setCurrentConversationId(conversationId);
             
             dev.langchain4j.data.message.AiMessage aiMessage = response.content();
             messages.add(aiMessage);

--- a/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
@@ -14,30 +14,33 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * WPS 操作服务
- * 
+ * 编辑器桥接服务（后端 ↔ 前端嵌入式 LibreOffice 编辑器）
+ *
  * 负责：
- * 1. 发送 WPS 操作指令到前端（通过 SSE client_action）
+ * 1. 发送编辑器操作指令到前端（通过 SSE client_action）
  * 2. 管理请求 ID 与 CompletableFuture 的映射
  * 3. 接收前端执行结果并解锁等待的工具调用
- * 
+ *
  * 工作流程：
- * 1. Agent 调用 WPS 工具 -> WpsTools 调用 executeWpsCommand
- * 2. WpsActionService 生成 requestId，发送 SSE 事件，创建 CompletableFuture
+ * 1. Agent 调用文档编辑工具 -> DocumentEditTools 调用 executeEditorCommand
+ * 2. EditorBridgeService 生成 requestId，发送 SSE 事件，创建 CompletableFuture
  * 3. 前端执行操作后调用 /api/ai/agent/wps-result 返回结果
- * 4. WpsResultController 调用 completeWpsAction 解锁 CompletableFuture
- * 5. executeWpsCommand 获取结果并返回给 WpsTools
+ * 4. EditorResultController 调用 completeEditorAction 解锁 CompletableFuture
+ * 5. executeEditorCommand 获取结果并返回给 DocumentEditTools
+ *
+ * 历史沿革：原名 WpsActionService（WPS WebOffice 时代）。SSE 事件与路由中的
+ * wps_* 字符串是前后端契约（见 docs/ai_agent_dev.md §2.2），保持旧名不变。
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class WpsActionService {
+public class EditorBridgeService {
 
     private final SseEmitterService sseEmitterService;
     private final ObjectMapper objectMapper;
 
     // 请求 ID -> CompletableFuture 的映射
-    private final ConcurrentHashMap<String, CompletableFuture<WpsActionResult>> pendingRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CompletableFuture<EditorActionResult>> pendingRequests = new ConcurrentHashMap<>();
     
     // 当前活跃的 conversationId（由 AgentOrchestrator 设置）
     private final ThreadLocal<String> currentConversationId = new ThreadLocal<>();
@@ -45,8 +48,8 @@ public class WpsActionService {
     // ConversationID -> IsStreaming Mode
     private final ConcurrentHashMap<String, Boolean> streamingModes = new ConcurrentHashMap<>();
     
-    // WPS 操作超时时间（秒）
-    private static final int WPS_ACTION_TIMEOUT = 30;
+    // 编辑器操作超时时间（秒）
+    private static final int EDITOR_ACTION_TIMEOUT = 30;
 
     /**
      * 设置当前会话 ID（由 AgentOrchestrator 在执行工具前调用）
@@ -106,7 +109,7 @@ public class WpsActionService {
 
     /**
      * 发送重新加载文件的 SSE 事件到前端
-     * 用于在后端修改文件后通知前端 WPS 刷新
+     * 用于在后端修改文件后通知前端编辑器刷新
      */
     public void sendReloadFileAction(ProjectFile file) {
         String conversationId = currentConversationId.get();
@@ -181,20 +184,20 @@ public class WpsActionService {
     }
 
     /**
-     * 执行 WPS 命令并等待结果
+     * 执行编辑器命令并等待前端返回结果
      * 
      * @param action 操作类型（如 get_selection, find_replace 等）
      * @param params 操作参数
      * @return 执行结果的 JSON 字符串
      */
-    public String executeWpsCommand(String action, Map<String, Object> params) {
+    public String executeEditorCommand(String action, Map<String, Object> params) {
         String conversationId = currentConversationId.get();
         if (conversationId == null) {
             return "{\"error\": \"No active conversation. Please ensure a document is open.\"}";
         }
 
         String requestId = UUID.randomUUID().toString();
-        CompletableFuture<WpsActionResult> future = new CompletableFuture<>();
+        CompletableFuture<EditorActionResult> future = new CompletableFuture<>();
         pendingRequests.put(requestId, future);
 
         try {
@@ -208,10 +211,10 @@ public class WpsActionService {
             ));
             
             sseEmitterService.send(conversationId, "client_action", payload);
-            log.info("Sent WPS command: action={}, requestId={}", action, requestId);
+            log.info("Sent editor command: action={}, requestId={}", action, requestId);
 
             // 等待前端执行结果
-            WpsActionResult result = future.get(WPS_ACTION_TIMEOUT, TimeUnit.SECONDS);
+            EditorActionResult result = future.get(EDITOR_ACTION_TIMEOUT, TimeUnit.SECONDS);
             
             if (result.isSuccess()) {
                 return objectMapper.writeValueAsString(result.getData());
@@ -220,11 +223,11 @@ public class WpsActionService {
             }
 
         } catch (TimeoutException e) {
-            log.warn("WPS command timed out: action={}, requestId={}", action, requestId);
-            return "{\"error\": \"操作超时。请确保 WPS 编辑器已打开并可用。\"}";
+            log.warn("Editor command timed out: action={}, requestId={}", action, requestId);
+            return "{\"error\": \"操作超时。请确保编辑器已打开并可用。\"}";
             
         } catch (Exception e) {
-            log.error("Failed to execute WPS command: action={}", action, e);
+            log.error("Failed to execute editor command: action={}", action, e);
             return "{\"error\": \"" + e.getMessage() + "\"}";
             
         } finally {
@@ -233,32 +236,32 @@ public class WpsActionService {
     }
 
     /**
-     * 完成 WPS 操作（由 WpsResultController 调用）
+     * 完成编辑器操作（由 EditorResultController 调用）
      * 
      * @param requestId 请求 ID
      * @param success 是否成功
      * @param data 结果数据
      * @param error 错误信息
      */
-    public void completeWpsAction(String requestId, boolean success, Object data, String error) {
-        CompletableFuture<WpsActionResult> future = pendingRequests.get(requestId);
+    public void completeEditorAction(String requestId, boolean success, Object data, String error) {
+        CompletableFuture<EditorActionResult> future = pendingRequests.get(requestId);
         if (future != null) {
-            future.complete(new WpsActionResult(success, data, error));
-            log.info("Completed WPS action: requestId={}, success={}", requestId, success);
+            future.complete(new EditorActionResult(success, data, error));
+            log.info("Completed editor action: requestId={}, success={}", requestId, success);
         } else {
             log.warn("No pending request found for requestId={}", requestId);
         }
     }
 
     /**
-     * WPS 操作结果
+     * 编辑器操作结果
      */
-    public static class WpsActionResult {
+    public static class EditorActionResult {
         private final boolean success;
         private final Object data;
         private final String error;
 
-        public WpsActionResult(boolean success, Object data, String error) {
+        public EditorActionResult(boolean success, Object data, String error) {
             this.success = success;
             this.data = data;
             this.error = error;

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -51,22 +51,59 @@ public class ToolRegistry {
             "fileId", List.of("id")
     );
 
-    /** 旧编排器为部分工具提供的缺省参数值（行为保持） */
+    /** 旧编排器为部分工具提供的缺省参数值（行为保持；键为别名解析后的真实工具名） */
     private static final Map<String, Object> LEGACY_DEFAULTS = Map.of(
-            "wps_find_replace.replaceAll", Boolean.TRUE,
-            "wps_find_text.matchCase", Boolean.FALSE,
-            "wps_delete_text.deleteAll", Boolean.FALSE,
+            "doc_find_replace.replaceAll", Boolean.TRUE,
+            "doc_find_text.matchCase", Boolean.FALSE,
+            "doc_delete_text.deleteAll", Boolean.FALSE,
             "list_files.subPath", ".",
             "query_memory.type", "all",
-            "wps_get_paragraph.paragraphIndex", 1,
-            "wps_modify_paragraph.paragraphIndex", 1,
-            "wps_replace_nth_match.matchIndex", 1,
-            "wps_delete_match.matchIndex", 1
+            "doc_get_paragraph.paragraphIndex", 1,
+            "doc_modify_paragraph.paragraphIndex", 1,
+            "doc_replace_nth_match.matchIndex", 1,
+            "doc_delete_match.matchIndex", 1
     );
 
-    /** 工具名别名（旧 prompt 中出现过的名称映射到真实工具） */
-    public static final Map<String, String> TOOL_NAME_ALIASES = Map.of(
-            "search_laws", "search_web"
+    /**
+     * 工具名别名（旧 prompt / 老对话历史 / 模型惯性输出中出现过的名称映射到真实工具）。
+     *
+     * wps_* → doc_* 是 Phase 2.5 灰度更名（编辑器已从 WPS 迁移到 LibreOffice，
+     * LLM 面工具名同步去 WPS 化）的兜底：老对话历史、老 prompt、模型按惯性输出的
+     * 旧名仍能正确分发。该批别名至少保留两个发布版本（≥0.6.0）后再评估移除。
+     */
+    public static final Map<String, String> TOOL_NAME_ALIASES = Map.ofEntries(
+            Map.entry("search_laws", "search_web"),
+            // ---- Phase 2.5：WPS 时代旧工具名 → doc_*（since 0.4.x，移除不早于 0.6.0）----
+            Map.entry("wps_list_project_files", "doc_list_project_files"),
+            Map.entry("wps_open_file", "doc_open_file"),
+            Map.entry("wps_start_stream", "doc_start_stream"),
+            Map.entry("wps_get_selection", "doc_get_selection"),
+            Map.entry("wps_goto", "doc_goto"),
+            Map.entry("wps_set_selection", "doc_set_selection"),
+            Map.entry("wps_find_text", "doc_find_text"),
+            Map.entry("wps_find_replace", "doc_find_replace"),
+            Map.entry("wps_replace_nth_match", "doc_replace_nth_match"),
+            Map.entry("wps_delete_match", "doc_delete_match"),
+            Map.entry("wps_delete_text", "doc_delete_text"),
+            Map.entry("wps_replace_selection", "doc_replace_selection"),
+            Map.entry("wps_insert_at_cursor", "doc_insert_at_cursor"),
+            Map.entry("wps_get_paragraph", "doc_get_paragraph"),
+            Map.entry("wps_modify_paragraph", "doc_modify_paragraph"),
+            Map.entry("wps_get_outline", "doc_get_outline"),
+            Map.entry("wps_insert_under_heading", "doc_insert_under_heading"),
+            Map.entry("wps_search_related_docs", "doc_search_related_docs"),
+            Map.entry("wps_get_document_text", "doc_get_document_text"),
+            Map.entry("wps_get_cursor_context", "doc_get_cursor_context"),
+            Map.entry("wps_select_anchor", "doc_select_anchor"),
+            Map.entry("wps_select_paragraph", "doc_select_paragraph"),
+            Map.entry("wps_collapse_cursor", "doc_collapse_cursor"),
+            Map.entry("wps_replace_at_anchor", "doc_replace_at_anchor"),
+            Map.entry("wps_delete_selection", "doc_delete_selection"),
+            Map.entry("wps_format_selection", "doc_format_selection"),
+            Map.entry("wps_set_paragraph_format", "doc_set_paragraph_format"),
+            Map.entry("wps_undo", "doc_undo"),
+            Map.entry("wps_redo", "doc_redo"),
+            Map.entry("wps_debug_revisions", "doc_debug_revisions")
     );
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -4,7 +4,7 @@ import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.ProjectFileRepository;
 import com.checkba.service.ProjectFileService;
 import com.checkba.service.ai.SseEmitterService;
-import com.checkba.service.ai.WpsActionService;
+import com.checkba.service.ai.EditorBridgeService;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import lombok.RequiredArgsConstructor;
@@ -15,26 +15,28 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * WPS 文档操作工具集
- * 
- * 提供 Agent 操作 WPS 文档的能力：
+ * 文档编辑工具集（嵌入式 LibreOffice 编辑器）
+ *
+ * 提供 Agent 操作文档的能力：
  * 1. 列出项目文档
  * 2. 打开文档进行编辑
  * 3. 获取选区、查找替换、段落操作等
  * 4. 搜索相关文档
- * 
+ *
  * 技术说明：
  * - wps_open_file 和 wps_list_project_files 可以直接在后端完成
  * - 其他操作需要通过 SSE client_action 发送到前端执行，然后等待结果返回
+ * - 历史沿革：原名 WpsTools（WPS WebOffice 时代）；编辑器已全面迁移到 LibreOffice，
+ *   工具名 wps_* 与 SSE 事件名暂保留旧名（前后端契约），见 docs/ai_agent_dev.md §2.2
  */
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class WpsTools implements AgentToolComponent {
+public class DocumentEditTools implements AgentToolComponent {
 
     private final ProjectFileService projectFileService;
     private final ProjectFileRepository projectFileRepository;
-    private final WpsActionService wpsActionService;
+    private final EditorBridgeService editorBridgeService;
 
     // ==================== 文件管理工具 ====================
 
@@ -85,7 +87,7 @@ public class WpsTools implements AgentToolComponent {
             }
             
             // 通过 SSE 发送打开文件指令到前端
-            wpsActionService.sendOpenFileAction(file);
+            editorBridgeService.sendOpenFileAction(file);
             
             return String.format("已发送打开文件指令。文件名: %s, 类型: %s。请等待文档加载完成后再进行后续操作。", 
                     file.getName(), file.getFileType());
@@ -111,7 +113,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_start_stream called fileId={}, fileName={}, projectId={}", fileId, fileName, projectId);
         try {
-            String conversationId = wpsActionService.getCurrentConversationId();
+            String conversationId = editorBridgeService.getCurrentConversationId();
             if (conversationId == null) {
                 return "Error: 无法获取当前会话上下文";
             }
@@ -178,7 +180,7 @@ public class WpsTools implements AgentToolComponent {
                 log.info("Created new docx file for streaming: id={}, name={}", file.getId(), file.getName());
                 
                 // 通知前端刷新文件列表
-                wpsActionService.sendRefreshFilesAction();
+                editorBridgeService.sendRefreshFilesAction();
             } else {
                 file = projectFileService.getFile(fileId);
                 if (file == null) {
@@ -187,7 +189,7 @@ public class WpsTools implements AgentToolComponent {
             }
 
             // 2. 同步打开文件 (Wait for Ready)
-            String resultJson = wpsActionService.executeWpsCommand("wps_open_file_sync", java.util.Map.of(
+            String resultJson = editorBridgeService.executeEditorCommand("wps_open_file_sync", java.util.Map.of(
                     "fileId", file.getId(),
                     "fileName", file.getName(),
                     "fileType", file.getFileType(),
@@ -200,7 +202,7 @@ public class WpsTools implements AgentToolComponent {
             }
 
             // 3. 开启流式模式
-            wpsActionService.setStreamingMode(conversationId, true);
+            editorBridgeService.setStreamingMode(conversationId, true);
 
             return "WPS 流式写入模式已激活，文件: " + file.getName() + "。请立即开始生成文档内容。**务必使用 Markdown 格式 (H1=#, H2=##) 输出内容。**";
         } catch (Exception e) {
@@ -215,7 +217,7 @@ public class WpsTools implements AgentToolComponent {
     public String wps_get_selection() {
         log.info("Tool: wps_get_selection called");
         try {
-            return wpsActionService.executeWpsCommand("get_selection", null);
+            return editorBridgeService.executeEditorCommand("get_selection", null);
         } catch (Exception e) {
             log.error("Failed to get selection", e);
             return "Error: " + e.getMessage();
@@ -229,7 +231,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_goto called type={}, target={}", type, target);
         try {
-            return wpsActionService.executeWpsCommand("goto", 
+            return editorBridgeService.executeEditorCommand("goto", 
                     java.util.Map.of("type", type, "target", target != null ? target : ""));
         } catch (Exception e) {
             log.error("Failed to goto position", e);
@@ -244,7 +246,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_set_selection called start={}, end={}", start, end);
         try {
-            return wpsActionService.executeWpsCommand("set_selection", 
+            return editorBridgeService.executeEditorCommand("set_selection", 
                     java.util.Map.of("start", start, "end", end));
         } catch (Exception e) {
             log.error("Failed to set selection", e);
@@ -263,7 +265,7 @@ public class WpsTools implements AgentToolComponent {
         log.info("Tool: wps_find_text called keyword={}", keyword);
         try {
             // Updated to call 'find_text_locations' which returns detailed positions
-            return wpsActionService.executeWpsCommand("find_text_locations", 
+            return editorBridgeService.executeEditorCommand("find_text_locations", 
                     java.util.Map.of("keyword", keyword, "matchCase", matchCase != null ? matchCase : false));
         } catch (Exception e) {
             log.error("Failed to find text", e);
@@ -280,7 +282,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_find_replace called find={}, replace={}", findText, replaceText);
         try {
-            return wpsActionService.executeWpsCommand("find_replace", 
+            return editorBridgeService.executeEditorCommand("find_replace", 
                     java.util.Map.of(
                             "findText", findText, 
                             "replaceText", replaceText, 
@@ -305,7 +307,7 @@ public class WpsTools implements AgentToolComponent {
             if (matchIndex == null || matchIndex < 1) {
                 return "Error: matchIndex 必须是从 1 开始的正整数";
             }
-            return wpsActionService.executeWpsCommand("replace_nth_match", 
+            return editorBridgeService.executeEditorCommand("replace_nth_match", 
                     java.util.Map.of(
                             "findText", findText, 
                             "replaceText", replaceText, 
@@ -327,7 +329,7 @@ public class WpsTools implements AgentToolComponent {
             if (matchIndex == null || matchIndex < 1) {
                 return "Error: matchIndex 必须是从 1 开始的正整数";
             }
-            return wpsActionService.executeWpsCommand("delete_match", 
+            return editorBridgeService.executeEditorCommand("delete_match", 
                     java.util.Map.of(
                             "findText", findText, 
                             "matchIndex", matchIndex
@@ -345,7 +347,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_delete_text called text={}, all={}", text, deleteAll);
         try {
-            return wpsActionService.executeWpsCommand("delete_text", 
+            return editorBridgeService.executeEditorCommand("delete_text", 
                     java.util.Map.of(
                             "text", text, 
                             "deleteAll", deleteAll != null ? deleteAll : true
@@ -362,7 +364,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_replace_selection called text length={}", text.length());
         try {
-            return wpsActionService.executeWpsCommand("replace_selection", 
+            return editorBridgeService.executeEditorCommand("replace_selection", 
                     java.util.Map.of("text", text));
         } catch (Exception e) {
             log.error("Failed to replace selection", e);
@@ -378,7 +380,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_insert_at_cursor called, text length={}", text.length());
         try {
-            return wpsActionService.executeWpsCommand("insert_at_cursor", 
+            return editorBridgeService.executeEditorCommand("insert_at_cursor", 
                     java.util.Map.of("text", text));
         } catch (Exception e) {
             log.error("Failed to insert at cursor", e);
@@ -392,7 +394,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_get_paragraph called index={}", paragraphIndex);
         try {
-            return wpsActionService.executeWpsCommand("get_paragraph", 
+            return editorBridgeService.executeEditorCommand("get_paragraph", 
                     java.util.Map.of("index", paragraphIndex));
         } catch (Exception e) {
             log.error("Failed to get paragraph", e);
@@ -408,7 +410,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_modify_paragraph called index={}, new text length={}", paragraphIndex, newText.length());
         try {
-            return wpsActionService.executeWpsCommand("modify_paragraph", 
+            return editorBridgeService.executeEditorCommand("modify_paragraph", 
                     java.util.Map.of("index", paragraphIndex, "newText", newText));
         } catch (Exception e) {
             log.error("Failed to modify paragraph", e);
@@ -422,7 +424,7 @@ public class WpsTools implements AgentToolComponent {
     public String wps_get_outline() {
         log.info("Tool: wps_get_outline called");
         try {
-            return wpsActionService.executeWpsCommand("get_outline", null);
+            return editorBridgeService.executeEditorCommand("get_outline", null);
         } catch (Exception e) {
             log.error("Failed to get outline", e);
             return "Error: " + e.getMessage();
@@ -436,7 +438,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_insert_under_heading called heading={}", headingText);
         try {
-            return wpsActionService.executeWpsCommand("insert_under_heading", 
+            return editorBridgeService.executeEditorCommand("insert_under_heading", 
                     java.util.Map.of("headingText", headingText, "content", content));
         } catch (Exception e) {
             log.error("Failed to insert under heading", e);
@@ -514,7 +516,7 @@ public class WpsTools implements AgentToolComponent {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (startParagraph != null) params.put("startParagraph", startParagraph);
             if (maxParagraphs != null) params.put("maxParagraphs", maxParagraphs);
-            return wpsActionService.executeWpsCommand("get_document_text", params);
+            return editorBridgeService.executeEditorCommand("get_document_text", params);
         } catch (Exception e) {
             log.error("Failed to get document text", e);
             return "Error: " + e.getMessage();
@@ -525,7 +527,7 @@ public class WpsTools implements AgentToolComponent {
     public String wps_get_cursor_context() {
         log.info("Tool: wps_get_cursor_context called");
         try {
-            return wpsActionService.executeWpsCommand("get_cursor_context", null);
+            return editorBridgeService.executeEditorCommand("get_cursor_context", null);
         } catch (Exception e) {
             log.error("Failed to get cursor context", e);
             return "Error: " + e.getMessage();
@@ -539,7 +541,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_select_anchor called anchor={}", anchorId);
         try {
-            return wpsActionService.executeWpsCommand("set_selection",
+            return editorBridgeService.executeEditorCommand("set_selection",
                     java.util.Map.of("anchor", anchorId != null ? anchorId : ""));
         } catch (Exception e) {
             log.error("Failed to select anchor", e);
@@ -553,7 +555,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_select_paragraph called index={}", index);
         try {
-            return wpsActionService.executeWpsCommand("select_paragraph",
+            return editorBridgeService.executeEditorCommand("select_paragraph",
                     java.util.Map.of("index", index != null ? index : 0));
         } catch (Exception e) {
             log.error("Failed to select paragraph", e);
@@ -567,7 +569,7 @@ public class WpsTools implements AgentToolComponent {
     ) {
         log.info("Tool: wps_collapse_cursor called to={}", to);
         try {
-            return wpsActionService.executeWpsCommand("collapse_selection",
+            return editorBridgeService.executeEditorCommand("collapse_selection",
                     java.util.Map.of("to", to != null ? to : "end"));
         } catch (Exception e) {
             log.error("Failed to collapse cursor", e);
@@ -586,7 +588,7 @@ public class WpsTools implements AgentToolComponent {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             params.put("anchor", anchorId != null ? anchorId : "");
             params.put("newText", newText != null ? newText : "");
-            return wpsActionService.executeWpsCommand("replace_at_position", params);
+            return editorBridgeService.executeEditorCommand("replace_at_position", params);
         } catch (Exception e) {
             log.error("Failed to replace at anchor", e);
             return "Error: " + e.getMessage();
@@ -597,7 +599,7 @@ public class WpsTools implements AgentToolComponent {
     public String wps_delete_selection() {
         log.info("Tool: wps_delete_selection called");
         try {
-            return wpsActionService.executeWpsCommand("delete_selection", null);
+            return editorBridgeService.executeEditorCommand("delete_selection", null);
         } catch (Exception e) {
             log.error("Failed to delete selection", e);
             return "Error: " + e.getMessage();
@@ -627,7 +629,7 @@ public class WpsTools implements AgentToolComponent {
             if (color != null && !color.isEmpty()) params.put("color", color);
             if (fontSize != null) params.put("fontSize", fontSize);
             if (fontName != null && !fontName.isEmpty()) params.put("fontName", fontName);
-            return wpsActionService.executeWpsCommand("format_selection", params);
+            return editorBridgeService.executeEditorCommand("format_selection", params);
         } catch (Exception e) {
             log.error("Failed to format selection", e);
             return "Error: " + e.getMessage();
@@ -645,7 +647,7 @@ public class WpsTools implements AgentToolComponent {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (alignment != null && !alignment.isEmpty()) params.put("alignment", alignment);
             if (headingLevel != null) params.put("headingLevel", headingLevel);
-            return wpsActionService.executeWpsCommand("set_paragraph_format", params);
+            return editorBridgeService.executeEditorCommand("set_paragraph_format", params);
         } catch (Exception e) {
             log.error("Failed to set paragraph format", e);
             return "Error: " + e.getMessage();
@@ -660,7 +662,7 @@ public class WpsTools implements AgentToolComponent {
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (steps != null) params.put("steps", steps);
-            return wpsActionService.executeWpsCommand("undo", params);
+            return editorBridgeService.executeEditorCommand("undo", params);
         } catch (Exception e) {
             log.error("Failed to undo", e);
             return "Error: " + e.getMessage();
@@ -675,7 +677,7 @@ public class WpsTools implements AgentToolComponent {
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (steps != null) params.put("steps", steps);
-            return wpsActionService.executeWpsCommand("redo", params);
+            return editorBridgeService.executeEditorCommand("redo", params);
         } catch (Exception e) {
             log.error("Failed to redo", e);
             return "Error: " + e.getMessage();
@@ -688,7 +690,7 @@ public class WpsTools implements AgentToolComponent {
     public String wps_debug_revisions() {
         log.info("Tool: wps_debug_revisions called");
         try {
-            return wpsActionService.executeWpsCommand("debug_revisions", null);
+            return editorBridgeService.executeEditorCommand("debug_revisions", null);
         } catch (Exception e) {
             log.error("Failed to debug revisions", e);
             return "Error: " + e.getMessage();

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -24,10 +24,10 @@ import java.util.stream.Collectors;
  * 4. 搜索相关文档
  *
  * 技术说明：
- * - wps_open_file 和 wps_list_project_files 可以直接在后端完成
+ * - doc_open_file 和 doc_list_project_files 可以直接在后端完成
  * - 其他操作需要通过 SSE client_action 发送到前端执行，然后等待结果返回
  * - 历史沿革：原名 WpsTools（WPS WebOffice 时代）；编辑器已全面迁移到 LibreOffice，
- *   工具名 wps_* 与 SSE 事件名暂保留旧名（前后端契约），见 docs/ai_agent_dev.md §2.2
+ *   工具名 doc_* 与 SSE 事件名暂保留旧名（前后端契约），见 docs/ai_agent_dev.md §2.2
  */
 @Component
 @RequiredArgsConstructor
@@ -41,10 +41,10 @@ public class DocumentEditTools implements AgentToolComponent {
     // ==================== 文件管理工具 ====================
 
     @Tool("列出项目中的所有可编辑文档文件（docx, doc, xlsx, xls, pptx, ppt）。返回文件ID、名称和类型的列表。")
-    public String wps_list_project_files(
+    public String doc_list_project_files(
             @P("项目ID") Long projectId
     ) {
-        log.info("Tool: wps_list_project_files called for projectId={}", projectId);
+        log.info("Tool: doc_list_project_files called for projectId={}", projectId);
         try {
             List<ProjectFile> files = projectFileRepository.findByProjectIdOrderBySortOrderAsc(projectId);
             
@@ -71,11 +71,11 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("打开指定文档进行编辑。文档会在用户的 WPS 编辑器中打开，之后可以使用其他 WPS 工具进行操作。")
-    public String wps_open_file(
-            @P("文件ID（从 wps_list_project_files 获取）") Long fileId
+    @Tool("打开指定文档进行编辑。文档会在编辑器中打开，之后可以使用其他文档编辑工具进行操作。")
+    public String doc_open_file(
+            @P("文件ID（从 doc_list_project_files 获取）") Long fileId
     ) {
-        log.info("Tool: wps_open_file called for fileId={}", fileId);
+        log.info("Tool: doc_open_file called for fileId={}", fileId);
         try {
             ProjectFile file = projectFileService.getFile(fileId);
             if (file == null) {
@@ -102,16 +102,16 @@ public class DocumentEditTools implements AgentToolComponent {
 
     private static final Long AGENT_USER_ID = 10001L;
 
-    @Tool("开始实时流式写入 WPS 文档。使用此工具后，模型生成的后续内容将直接写入打开的文档中。" +
+    @Tool("开始实时流式写入文档。使用此工具后，模型生成的后续内容将直接写入打开的文档中。" +
           "**重要：创建新文件时必须提供 fileName 和 projectId 参数。** " +
           "调用此工具后，你必须立即开始生成文档内容，并且必须使用严格的 Markdown 格式（Markdown Heading #, ##, ### 等）。" +
           "不要在调用此工具后输出任何非文档内容的闲聊，直接开始输出文档标题和正文。")
-    public String wps_start_stream(
+    public String doc_start_stream(
             @P("要打开的文件ID (如果是新建文件则传 null)") Long fileId,
             @P("新建文件名 (如 '法律意见书.docx')，仅当 fileId=null 时必填") String fileName,
             @P("项目ID，仅当 fileId=null 时必填") Long projectId
     ) {
-        log.info("Tool: wps_start_stream called fileId={}, fileName={}, projectId={}", fileId, fileName, projectId);
+        log.info("Tool: doc_start_stream called fileId={}, fileName={}, projectId={}", fileId, fileName, projectId);
         try {
             String conversationId = editorBridgeService.getCurrentConversationId();
             if (conversationId == null) {
@@ -204,18 +204,18 @@ public class DocumentEditTools implements AgentToolComponent {
             // 3. 开启流式模式
             editorBridgeService.setStreamingMode(conversationId, true);
 
-            return "WPS 流式写入模式已激活，文件: " + file.getName() + "。请立即开始生成文档内容。**务必使用 Markdown 格式 (H1=#, H2=##) 输出内容。**";
+            return "文档流式写入模式已激活，文件: " + file.getName() + "。请立即开始生成文档内容。**务必使用 Markdown 格式 (H1=#, H2=##) 输出内容。**";
         } catch (Exception e) {
-            log.error("Failed to start wps stream", e);
+            log.error("Failed to start doc stream", e);
             return "Error: " + e.getMessage();
         }
     }
 
     // ==================== 选区和光标操作 ====================
 
-    @Tool("获取 WPS 文档中当前选区的文本内容和位置信息。用于了解用户当前光标位置和选中的文本。")
-    public String wps_get_selection() {
-        log.info("Tool: wps_get_selection called");
+    @Tool("获取文档中当前选区的文本内容和位置信息。用于了解用户当前光标位置和选中的文本。")
+    public String doc_get_selection() {
+        log.info("Tool: doc_get_selection called");
         try {
             return editorBridgeService.executeEditorCommand("get_selection", null);
         } catch (Exception e) {
@@ -224,12 +224,12 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("移动 WPS 文档的光标到指定位置。")
-    public String wps_goto(
+    @Tool("移动文档的光标到指定位置。")
+    public String doc_goto(
             @P("定位类型: paragraph(段落)/bookmark(书签)/start(文档开头)/end(文档结尾)/line(行号)") String type,
             @P("目标值: 段落号、书签名、行号等。对于 start/end 类型可以为空。") String target
     ) {
-        log.info("Tool: wps_goto called type={}, target={}", type, target);
+        log.info("Tool: doc_goto called type={}, target={}", type, target);
         try {
             return editorBridgeService.executeEditorCommand("goto", 
                     java.util.Map.of("type", type, "target", target != null ? target : ""));
@@ -239,12 +239,12 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("设置 WPS 文档的选区范围（精确控制光标/选区）。Start 和 End 是字符索引位置。")
-    public String wps_set_selection(
+    @Tool("设置文档的选区范围（精确控制光标/选区）。Start 和 End 是字符索引位置。")
+    public String doc_set_selection(
             @P("选区开始位置 (0-based 字符索引)") Integer start,
             @P("选区结束位置 (0-based 字符索引)") Integer end
     ) {
-        log.info("Tool: wps_set_selection called start={}, end={}", start, end);
+        log.info("Tool: doc_set_selection called start={}, end={}", start, end);
         try {
             return editorBridgeService.executeEditorCommand("set_selection", 
                     java.util.Map.of("start", start, "end", end));
@@ -257,12 +257,12 @@ public class DocumentEditTools implements AgentToolComponent {
     // ==================== 查找和替换 ====================
 
     @Tool("【找】在文档中查找文本。每个匹配返回：anchorId（稳定锚点，编辑后依然有效）、前后文 contextBefore/contextAfter、所在段落 paragraph。" +
-          "有多个匹配时先根据上下文确认哪一个才是目标，再用 anchorId 配合 wps_select_anchor（选中查看）或 wps_replace_at_anchor（精准替换）操作。")
-    public String wps_find_text(
+          "有多个匹配时先根据上下文确认哪一个才是目标，再用 anchorId 配合 doc_select_anchor（选中查看）或 doc_replace_at_anchor（精准替换）操作。")
+    public String doc_find_text(
             @P("要查找的文本") String keyword,
             @P("是否区分大小写，默认 false") Boolean matchCase
     ) {
-        log.info("Tool: wps_find_text called keyword={}", keyword);
+        log.info("Tool: doc_find_text called keyword={}", keyword);
         try {
             // Updated to call 'find_text_locations' which returns detailed positions
             return editorBridgeService.executeEditorCommand("find_text_locations", 
@@ -274,13 +274,13 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @ToolMeta(displayName = "查找替换", category = "document", fileEffect = "MODIFIED")
-    @Tool("在 WPS 文档中查找并替换文本。所有修改将以修订模式进行，用户可以审阅后接受或拒绝。")
-    public String wps_find_replace(
+    @Tool("在文档中查找并替换文本。所有修改将以修订模式进行，用户可以审阅后接受或拒绝。")
+    public String doc_find_replace(
             @P("要查找的文本") String findText,
             @P("替换为的文本") String replaceText,
             @P("是否替换全部匹配项，默认 true") Boolean replaceAll
     ) {
-        log.info("Tool: wps_find_replace called find={}, replace={}", findText, replaceText);
+        log.info("Tool: doc_find_replace called find={}, replace={}", findText, replaceText);
         try {
             return editorBridgeService.executeEditorCommand("find_replace", 
                     java.util.Map.of(
@@ -297,12 +297,12 @@ public class DocumentEditTools implements AgentToolComponent {
     @Tool("将文档中第 N 个可见匹配项替换为新文本。" +
           "索引从 1 开始，只计算用户可见的匹配（排除修订模式下被删除的内容）。" +
           "如果要删除文本，将 replaceText 设置为空字符串即可。")
-    public String wps_replace_nth_match(
+    public String doc_replace_nth_match(
             @P("要查找的文本") String findText,
             @P("替换为的文本") String replaceText,
             @P("第几个可见匹配（从 1 开始）") Integer matchIndex
     ) {
-        log.info("Tool: wps_replace_nth_match called find={}, replace={}, index={}", findText, replaceText, matchIndex);
+        log.info("Tool: doc_replace_nth_match called find={}, replace={}, index={}", findText, replaceText, matchIndex);
         try {
             if (matchIndex == null || matchIndex < 1) {
                 return "Error: matchIndex 必须是从 1 开始的正整数";
@@ -319,12 +319,12 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("删除 WPS 文档中第 N 个可见的匹配文本。专门用于删除操作，通过查找文本并执行删除。")
-    public String wps_delete_match(
+    @Tool("删除文档中第 N 个可见的匹配文本。专门用于删除操作，通过查找文本并执行删除。")
+    public String doc_delete_match(
             @P("要删除的文本内容") String findText,
             @P("第几个可见匹配（从 1 开始）") Integer matchIndex
     ) {
-        log.info("Tool: wps_delete_match called find={}, index={}", findText, matchIndex);
+        log.info("Tool: doc_delete_match called find={}, index={}", findText, matchIndex);
         try {
             if (matchIndex == null || matchIndex < 1) {
                 return "Error: matchIndex 必须是从 1 开始的正整数";
@@ -340,12 +340,12 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("删除 WPS 文档中的文本内容。可以删除所有匹配项，或只删除第一个匹配项。")
-    public String wps_delete_text(
+    @Tool("删除文档中的文本内容。可以删除所有匹配项，或只删除第一个匹配项。")
+    public String doc_delete_text(
             @P("要删除的文本内容") String text,
             @P("是否删除所有匹配项，默认 true") Boolean deleteAll
     ) {
-        log.info("Tool: wps_delete_text called text={}, all={}", text, deleteAll);
+        log.info("Tool: doc_delete_text called text={}, all={}", text, deleteAll);
         try {
             return editorBridgeService.executeEditorCommand("delete_text", 
                     java.util.Map.of(
@@ -359,10 +359,10 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @Tool("替换当前选区（或光标位置）的文本内容。如果选区非空，则替换选区；如果只是光标，则插入文本。")
-    public String wps_replace_selection(
+    public String doc_replace_selection(
             @P("用于替换的文本内容") String text
     ) {
-        log.info("Tool: wps_replace_selection called text length={}", text.length());
+        log.info("Tool: doc_replace_selection called text length={}", text.length());
         try {
             return editorBridgeService.executeEditorCommand("replace_selection", 
                     java.util.Map.of("text", text));
@@ -374,11 +374,11 @@ public class DocumentEditTools implements AgentToolComponent {
 
     // ==================== 插入和修改 ====================
 
-    @Tool("在 WPS 文档的当前光标位置插入文本内容。修改将以修订模式进行。")
-    public String wps_insert_at_cursor(
+    @Tool("在文档的当前光标位置插入文本内容。修改将以修订模式进行。")
+    public String doc_insert_at_cursor(
             @P("要插入的文本内容") String text
     ) {
-        log.info("Tool: wps_insert_at_cursor called, text length={}", text.length());
+        log.info("Tool: doc_insert_at_cursor called, text length={}", text.length());
         try {
             return editorBridgeService.executeEditorCommand("insert_at_cursor", 
                     java.util.Map.of("text", text));
@@ -388,11 +388,11 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("获取 WPS 文档中指定段落的文本内容。")
-    public String wps_get_paragraph(
+    @Tool("获取文档中指定段落的文本内容。")
+    public String doc_get_paragraph(
             @P("段落索引，从 1 开始") Integer paragraphIndex
     ) {
-        log.info("Tool: wps_get_paragraph called index={}", paragraphIndex);
+        log.info("Tool: doc_get_paragraph called index={}", paragraphIndex);
         try {
             return editorBridgeService.executeEditorCommand("get_paragraph", 
                     java.util.Map.of("index", paragraphIndex));
@@ -403,12 +403,12 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @ToolMeta(displayName = "修改段落", category = "document", fileEffect = "MODIFIED")
-    @Tool("修改 WPS 文档中指定段落的文本内容。修改将以修订模式进行，用户可以审阅后接受或拒绝。")
-    public String wps_modify_paragraph(
+    @Tool("修改文档中指定段落的文本内容。修改将以修订模式进行，用户可以审阅后接受或拒绝。")
+    public String doc_modify_paragraph(
             @P("段落索引，从 1 开始") Integer paragraphIndex,
             @P("新的段落文本") String newText
     ) {
-        log.info("Tool: wps_modify_paragraph called index={}, new text length={}", paragraphIndex, newText.length());
+        log.info("Tool: doc_modify_paragraph called index={}, new text length={}", paragraphIndex, newText.length());
         try {
             return editorBridgeService.executeEditorCommand("modify_paragraph", 
                     java.util.Map.of("index", paragraphIndex, "newText", newText));
@@ -420,9 +420,9 @@ public class DocumentEditTools implements AgentToolComponent {
 
     // ==================== 文档结构 ====================
 
-    @Tool("获取 WPS 文档的大纲结构，包括各级标题及其位置。")
-    public String wps_get_outline() {
-        log.info("Tool: wps_get_outline called");
+    @Tool("获取文档的大纲结构，包括各级标题及其位置。")
+    public String doc_get_outline() {
+        log.info("Tool: doc_get_outline called");
         try {
             return editorBridgeService.executeEditorCommand("get_outline", null);
         } catch (Exception e) {
@@ -431,12 +431,12 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("在 WPS 文档的指定标题下方插入新内容。修改将以修订模式进行。")
-    public String wps_insert_under_heading(
+    @Tool("在文档的指定标题下方插入新内容。修改将以修订模式进行。")
+    public String doc_insert_under_heading(
             @P("标题文本，用于定位插入位置") String headingText,
             @P("要插入的内容") String content
     ) {
-        log.info("Tool: wps_insert_under_heading called heading={}", headingText);
+        log.info("Tool: doc_insert_under_heading called heading={}", headingText);
         try {
             return editorBridgeService.executeEditorCommand("insert_under_heading", 
                     java.util.Map.of("headingText", headingText, "content", content));
@@ -449,11 +449,11 @@ public class DocumentEditTools implements AgentToolComponent {
     // ==================== 智能搜索 ====================
 
     @Tool("搜索项目中可能需要修改的相关文档。根据关键词在文件名和文档内容中搜索。")
-    public String wps_search_related_docs(
+    public String doc_search_related_docs(
             @P("搜索关键词，如'交易方案'、'股东决议'等") String keyword,
             @P("项目ID") Long projectId
     ) {
-        log.info("Tool: wps_search_related_docs called keyword={}, projectId={}", keyword, projectId);
+        log.info("Tool: doc_search_related_docs called keyword={}, projectId={}", keyword, projectId);
         try {
             List<ProjectFile> allFiles = projectFileRepository.findByProjectIdOrderBySortOrderAsc(projectId);
             
@@ -491,7 +491,7 @@ public class DocumentEditTools implements AgentToolComponent {
                 sb.append(String.format("- ID: %d, 名称: %s, 类型: %s\n", 
                         f.getId(), f.getName(), f.getFileType()));
             }
-            sb.append("\n建议：使用 wps_open_file 打开需要修改的文档，然后使用其他 WPS 工具进行编辑。");
+            sb.append("\n建议：使用 doc_open_file 打开需要修改的文档，然后使用其他文档编辑工具进行编辑。");
             return sb.toString();
             
         } catch (Exception e) {
@@ -502,16 +502,16 @@ public class DocumentEditTools implements AgentToolComponent {
 
     // ==================== 拟人式原语（嵌入式 LibreOffice 编辑器） ====================
     // 设计文档：docs/AI_EDITOR_PRIMITIVES.md。工作循环：看 → 找 → 选 → 改 → 验。
-    // 定位一律使用 wps_find_text 返回的 anchorId（书签锚点，随文档编辑自动跟随），
+    // 定位一律使用 doc_find_text 返回的 anchorId（书签锚点，随文档编辑自动跟随），
     // 禁止使用整数字符偏移（跨富文本必然错位）。
 
     @Tool("【看】分段读取文档正文。返回带编号的段落列表（含标题级别），是了解文档内容的首选工具。" +
           "文档很长时结果会分页：返回 truncated=true 和 nextStartParagraph，用它继续读下一段。")
-    public String wps_get_document_text(
+    public String doc_get_document_text(
             @P("起始段落号（0 开始，默认 0）") Integer startParagraph,
             @P("最多返回的段落数（默认 200）") Integer maxParagraphs
     ) {
-        log.info("Tool: wps_get_document_text called start={}, max={}", startParagraph, maxParagraphs);
+        log.info("Tool: doc_get_document_text called start={}, max={}", startParagraph, maxParagraphs);
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (startParagraph != null) params.put("startParagraph", startParagraph);
@@ -524,8 +524,8 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @Tool("【看】查看当前光标/选区周围的文本（选中内容、前后文、所在段落）。在插入或格式化之前先确认光标位置。")
-    public String wps_get_cursor_context() {
-        log.info("Tool: wps_get_cursor_context called");
+    public String doc_get_cursor_context() {
+        log.info("Tool: doc_get_cursor_context called");
         try {
             return editorBridgeService.executeEditorCommand("get_cursor_context", null);
         } catch (Exception e) {
@@ -534,12 +534,12 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("【选】选中 wps_find_text 返回的某个匹配（按 anchorId）。编辑器会滚动到该处并高亮选区，用户能看到 AI 正在操作哪里。" +
-          "选中后可接 wps_replace_selection / wps_delete_selection / wps_format_selection / wps_collapse_cursor。")
-    public String wps_select_anchor(
-            @P("wps_find_text 返回的 anchorId") String anchorId
+    @Tool("【选】选中 doc_find_text 返回的某个匹配（按 anchorId）。编辑器会滚动到该处并高亮选区，用户能看到 AI 正在操作哪里。" +
+          "选中后可接 doc_replace_selection / doc_delete_selection / doc_format_selection / doc_collapse_cursor。")
+    public String doc_select_anchor(
+            @P("doc_find_text 返回的 anchorId") String anchorId
     ) {
-        log.info("Tool: wps_select_anchor called anchor={}", anchorId);
+        log.info("Tool: doc_select_anchor called anchor={}", anchorId);
         try {
             return editorBridgeService.executeEditorCommand("set_selection",
                     java.util.Map.of("anchor", anchorId != null ? anchorId : ""));
@@ -549,11 +549,11 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("【选】按段落号选中整个段落（0 开始，配合 wps_get_document_text 的编号）。编辑器会滚动到该段落并高亮。")
-    public String wps_select_paragraph(
+    @Tool("【选】按段落号选中整个段落（0 开始，配合 doc_get_document_text 的编号）。编辑器会滚动到该段落并高亮。")
+    public String doc_select_paragraph(
             @P("段落号（0 开始）") Integer index
     ) {
-        log.info("Tool: wps_select_paragraph called index={}", index);
+        log.info("Tool: doc_select_paragraph called index={}", index);
         try {
             return editorBridgeService.executeEditorCommand("select_paragraph",
                     java.util.Map.of("index", index != null ? index : 0));
@@ -563,11 +563,11 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("【选】把光标落到当前选区的开头或结尾（取消选中）。要在某处'之前/之后'插入文本时：先选中目标，再 collapse 到 start/end，然后 wps_insert_at_cursor。")
-    public String wps_collapse_cursor(
+    @Tool("【选】把光标落到当前选区的开头或结尾（取消选中）。要在某处'之前/之后'插入文本时：先选中目标，再 collapse 到 start/end，然后 doc_insert_at_cursor。")
+    public String doc_collapse_cursor(
             @P("start=选区开头, end=选区结尾") String to
     ) {
-        log.info("Tool: wps_collapse_cursor called to={}", to);
+        log.info("Tool: doc_collapse_cursor called to={}", to);
         try {
             return editorBridgeService.executeEditorCommand("collapse_selection",
                     java.util.Map.of("to", to != null ? to : "end"));
@@ -578,12 +578,12 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @Tool("【改】把某个锚点（anchorId）处的文本替换为新文本，以修订模式进行。返回改动后所在段落的实际文本，务必核对确认改对了。" +
-          "这是最精准的替换方式：先 wps_find_text 拿到带上下文的匹配列表，选定目标的 anchorId 后用本工具替换。")
-    public String wps_replace_at_anchor(
-            @P("wps_find_text 返回的 anchorId") String anchorId,
+          "这是最精准的替换方式：先 doc_find_text 拿到带上下文的匹配列表，选定目标的 anchorId 后用本工具替换。")
+    public String doc_replace_at_anchor(
+            @P("doc_find_text 返回的 anchorId") String anchorId,
             @P("新文本") String newText
     ) {
-        log.info("Tool: wps_replace_at_anchor called anchor={}", anchorId);
+        log.info("Tool: doc_replace_at_anchor called anchor={}", anchorId);
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             params.put("anchor", anchorId != null ? anchorId : "");
@@ -595,9 +595,9 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("【改】删除当前选中的文本（以修订模式）。先用 wps_select_anchor / wps_select_paragraph 选中要删的内容。没有选区时会报错。")
-    public String wps_delete_selection() {
-        log.info("Tool: wps_delete_selection called");
+    @Tool("【改】删除当前选中的文本（以修订模式）。先用 doc_select_anchor / doc_select_paragraph 选中要删的内容。没有选区时会报错。")
+    public String doc_delete_selection() {
+        log.info("Tool: doc_delete_selection called");
         try {
             return editorBridgeService.executeEditorCommand("delete_selection", null);
         } catch (Exception e) {
@@ -607,8 +607,8 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @Tool("【格式】给当前选中的文本设置字符格式：加粗/斜体/下划线/删除线/高亮/字色/字号/字体。只传需要改的参数。" +
-          "必须先选中文本（wps_select_anchor / wps_select_paragraph）。高亮支持 yellow/green/cyan/magenta/red/blue/gray/none 或 #RRGGBB；none 取消高亮。")
-    public String wps_format_selection(
+          "必须先选中文本（doc_select_anchor / doc_select_paragraph）。高亮支持 yellow/green/cyan/magenta/red/blue/gray/none 或 #RRGGBB；none 取消高亮。")
+    public String doc_format_selection(
             @P("加粗 true/false，不改则不传") Boolean bold,
             @P("斜体 true/false，不改则不传") Boolean italic,
             @P("下划线 true/false，不改则不传") Boolean underline,
@@ -618,7 +618,7 @@ public class DocumentEditTools implements AgentToolComponent {
             @P("字号（磅），不改则不传") Double fontSize,
             @P("字体名，不改则不传") String fontName
     ) {
-        log.info("Tool: wps_format_selection called");
+        log.info("Tool: doc_format_selection called");
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (bold != null) params.put("bold", bold);
@@ -638,11 +638,11 @@ public class DocumentEditTools implements AgentToolComponent {
 
     @Tool("【格式】设置当前选区所在段落的段落格式：对齐方式和/或标题级别。" +
           "headingLevel: 1-9 设为对应级别标题，0 恢复正文。alignment: left/right/center/justify。")
-    public String wps_set_paragraph_format(
+    public String doc_set_paragraph_format(
             @P("对齐：left/right/center/justify，不改则不传") String alignment,
             @P("标题级别：1-9 为标题，0 恢复正文，不改则不传") Integer headingLevel
     ) {
-        log.info("Tool: wps_set_paragraph_format called alignment={}, headingLevel={}", alignment, headingLevel);
+        log.info("Tool: doc_set_paragraph_format called alignment={}, headingLevel={}", alignment, headingLevel);
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (alignment != null && !alignment.isEmpty()) params.put("alignment", alignment);
@@ -655,10 +655,10 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @Tool("【验/撤销】撤销最近的编辑操作。改错了（核对返回的段落文本发现不对）就用它退回，再重新操作。")
-    public String wps_undo(
+    public String doc_undo(
             @P("撤销步数，默认 1") Integer steps
     ) {
-        log.info("Tool: wps_undo called steps={}", steps);
+        log.info("Tool: doc_undo called steps={}", steps);
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (steps != null) params.put("steps", steps);
@@ -670,10 +670,10 @@ public class DocumentEditTools implements AgentToolComponent {
     }
 
     @Tool("【验/撤销】重做刚撤销的操作。")
-    public String wps_redo(
+    public String doc_redo(
             @P("重做步数，默认 1") Integer steps
     ) {
-        log.info("Tool: wps_redo called steps={}", steps);
+        log.info("Tool: doc_redo called steps={}", steps);
         try {
             java.util.Map<String, Object> params = new java.util.HashMap<>();
             if (steps != null) params.put("steps", steps);
@@ -686,9 +686,9 @@ public class DocumentEditTools implements AgentToolComponent {
 
     // ==================== 调试工具 ====================
 
-    @Tool("调试工具：获取 WPS 文档中所有修订记录的详细信息，包括修订类型、位置、内容等。用于分析和诊断修订模式下的文本操作问题。")
-    public String wps_debug_revisions() {
-        log.info("Tool: wps_debug_revisions called");
+    @Tool("调试工具：获取文档中所有修订记录的详细信息，包括修订类型、位置、内容等。用于分析和诊断修订模式下的文本操作问题。")
+    public String doc_debug_revisions() {
+        log.info("Tool: doc_debug_revisions called");
         try {
             return editorBridgeService.executeEditorCommand("debug_revisions", null);
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -40,7 +40,7 @@ public class FileTools implements AgentToolComponent {
 
     private final ProjectFileService projectFileService;
     private final ProjectFileRepository projectFileRepository;
-    private final com.checkba.service.ai.WpsActionService wpsActionService;
+    private final com.checkba.service.ai.EditorBridgeService editorBridgeService;
     private final com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService;
     private static final Long AGENT_USER_ID = 10001L;
 
@@ -257,7 +257,7 @@ public class FileTools implements AgentToolComponent {
                 );
                 
                 // 通知前端刷新文件列表
-                wpsActionService.sendRefreshFilesAction();
+                editorBridgeService.sendRefreshFilesAction();
                 
                 return String.format("{\"status\":\"success\", \"db_id\":%d, \"wps_file_id\":\"%s\", \"file_path\":\"%s\"}", pf.getId(), wpsId, targetPath.toAbsolutePath().toString().replace("\\", "\\\\"));
             } catch (Exception e) {
@@ -308,7 +308,7 @@ public class FileTools implements AgentToolComponent {
             }
             
             // 通知前端刷新文件列表
-            wpsActionService.sendRefreshFilesAction();
+            editorBridgeService.sendRefreshFilesAction();
             
             return report.toString();
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -132,7 +132,7 @@ public class FileTools implements AgentToolComponent {
     }
 
     @ToolMeta(displayName = "列出文件", category = "file")
-    @Tool("List files and directories in a project's data folder. Note: This lists physical files, not database records. For database files, use wps_list_project_files or pptx_list_files.")
+    @Tool("List files and directories in a project's data folder. Note: This lists physical files, not database records. For database files, use doc_list_project_files or pptx_list_files.")
     public String list_files(
             @P("Project ID - files will be listed from data/projects/{projectId}/") Long projectId,
             @P("Optional: Subdirectory path within the project folder. Use '.' or empty for project root.") String subPath
@@ -175,7 +175,7 @@ public class FileTools implements AgentToolComponent {
                 });
             }
             
-            sb.append("\nNote: These are physical files. Database file records may differ. Use wps_list_project_files for database files.");
+            sb.append("\nNote: These are physical files. Database file records may differ. Use doc_list_project_files for database files.");
             return sb.toString();
 
         } catch (IOException e) {
@@ -210,7 +210,7 @@ public class FileTools implements AgentToolComponent {
     }
 
     @ToolMeta(displayName = "生成Word文档", category = "file", fileEffect = "ADDED", fileArg = "fileName", refreshFiles = true)
-    @Tool("【STRICTLY NEW FILES ONLY】Create a NEW .docx from Markdown. FORBIDDEN for 'revise', 'update', or 'modify' tasks. If a similar file exists, you MUST use wps_open_file to edit it. DO NOT create 'Revised_Version.docx'.")
+    @Tool("【STRICTLY NEW FILES ONLY】Create a NEW .docx from Markdown. FORBIDDEN for 'revise', 'update', or 'modify' tasks. If a similar file exists, you MUST use doc_open_file to edit it. DO NOT create 'Revised_Version.docx'.")
     public String write_docx(
             @P("新文件名 (如 '报告.docx')") String fileName, 
             @P("Markdown 内容") String markdownContent,
@@ -221,7 +221,7 @@ public class FileTools implements AgentToolComponent {
         
         // Block suspicious filenames that suggest revision
         if (fileName.matches(".*(revise|revision|update|modify|change|修改|修订|更新|变动).*")) {
-            return "Error: Creation of files with 'revise/update/modify' in the name is FORBIDDEN. You MUST use 'wps_open_file' to open the original file and use editing tools (wps_find_replace, wps_modify_paragraph, etc.) to apply changes. DO NOT create a new file.";
+            return "Error: Creation of files with 'revise/update/modify' in the name is FORBIDDEN. You MUST use 'doc_open_file' to open the original file and use editing tools (doc_find_replace, doc_modify_paragraph, etc.) to apply changes. DO NOT create a new file.";
         }
         
         try {
@@ -230,7 +230,7 @@ public class FileTools implements AgentToolComponent {
             Path targetPath = projectDataDir.resolve(fileName);
             
             if (Files.exists(targetPath)) {
-                return "Error: File '" + fileName + "' already exists. Please use 'wps_open_file' and editing tools to modify the existing document instead of overwriting it.";
+                return "Error: File '" + fileName + "' already exists. Please use 'doc_open_file' and editing tools to modify the existing document instead of overwriting it.";
             }
             
             Parser parser = Parser.builder().build();

--- a/backend/src/main/java/com/checkba/service/ai/tools/PptxEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PptxEditTools.java
@@ -1,6 +1,6 @@
 package com.checkba.service.ai.tools;
 
-import com.checkba.service.ai.WpsActionService;
+import com.checkba.service.ai.EditorBridgeService;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ import java.util.Map;
  * 
  * 技术说明：
  * - 通过 SSE client_action 发送命令到前端
- * - 前端 useWpsBridge.js 调用 WPS WebOffice SDK 执行操作
+ * - 前端 useEditorBridge.js 分发到嵌入式 LibreOffice 执行器执行操作
  * - PPT 不支持原生修订模式，使用视觉标记替代：
  *   - 新增内容：用【】括起来
  *   - 删除内容：用【删除：xxx】标记
@@ -31,7 +31,7 @@ import java.util.Map;
 @Slf4j
 public class PptxEditTools implements AgentToolComponent {
 
-    private final WpsActionService wpsActionService;
+    private final EditorBridgeService editorBridgeService;
 
     // ==================== 信息获取工具 ====================
 
@@ -39,7 +39,7 @@ public class PptxEditTools implements AgentToolComponent {
     public String pptx_get_presentation_info() {
         log.info("Tool: pptx_get_presentation_info called");
         try {
-            return wpsActionService.executeWpsCommand("ppt_get_presentation_info", null);
+            return editorBridgeService.executeEditorCommand("ppt_get_presentation_info", null);
         } catch (Exception e) {
             log.error("Failed to get presentation info", e);
             return "{\"error\": \"" + e.getMessage() + "\"}";
@@ -55,7 +55,7 @@ public class PptxEditTools implements AgentToolComponent {
             if (slideIndex == null || slideIndex < 1) {
                 return "{\"error\": \"幻灯片页码必须大于 0\"}";
             }
-            return wpsActionService.executeWpsCommand("ppt_get_slide_content", 
+            return editorBridgeService.executeEditorCommand("ppt_get_slide_content", 
                     Map.of("slideIndex", slideIndex));
         } catch (Exception e) {
             log.error("Failed to get slide content", e);
@@ -67,7 +67,7 @@ public class PptxEditTools implements AgentToolComponent {
     public String pptx_get_selection() {
         log.info("Tool: pptx_get_selection called");
         try {
-            return wpsActionService.executeWpsCommand("ppt_get_selection", null);
+            return editorBridgeService.executeEditorCommand("ppt_get_selection", null);
         } catch (Exception e) {
             log.error("Failed to get PPT selection", e);
             return "{\"error\": \"" + e.getMessage() + "\"}";
@@ -94,7 +94,7 @@ public class PptxEditTools implements AgentToolComponent {
                 return "{\"error\": \"新文本内容不能为空\"}";
             }
             
-            return wpsActionService.executeWpsCommand("ppt_modify_slide_text", 
+            return editorBridgeService.executeEditorCommand("ppt_modify_slide_text", 
                     Map.of(
                             "slideIndex", slideIndex,
                             "shapeIndex", shapeIndex,
@@ -132,7 +132,7 @@ public class PptxEditTools implements AgentToolComponent {
                 pos = "end";
             }
             
-            return wpsActionService.executeWpsCommand("ppt_insert_text", 
+            return editorBridgeService.executeEditorCommand("ppt_insert_text", 
                     Map.of(
                             "slideIndex", slideIndex,
                             "shapeIndex", shapeIndex,
@@ -163,7 +163,7 @@ public class PptxEditTools implements AgentToolComponent {
                 return "{\"error\": \"要删除的文本不能为空\"}";
             }
             
-            return wpsActionService.executeWpsCommand("ppt_mark_delete_text", 
+            return editorBridgeService.executeEditorCommand("ppt_mark_delete_text", 
                     Map.of(
                             "slideIndex", slideIndex,
                             "shapeIndex", shapeIndex,
@@ -181,7 +181,7 @@ public class PptxEditTools implements AgentToolComponent {
     public String pptx_save() {
         log.info("Tool: pptx_save called");
         try {
-            return wpsActionService.executeWpsCommand("ppt_save", null);
+            return editorBridgeService.executeEditorCommand("ppt_save", null);
         } catch (Exception e) {
             log.error("Failed to save PPT", e);
             return "{\"error\": \"" + e.getMessage() + "\"}";

--- a/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
@@ -7,7 +7,7 @@ import com.checkba.repository.ProjectFileRepository;
 import com.checkba.service.ProjectFileService;
 import com.checkba.service.ai.BackgroundTaskService;
 import com.checkba.service.ai.PptxServiceClient;
-import com.checkba.service.ai.WpsActionService;
+import com.checkba.service.ai.EditorBridgeService;
 import com.checkba.storage.StorageServiceFactory;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
@@ -48,7 +48,7 @@ public class PptxTools implements AgentToolComponent {
     private final PptxServiceClient pptxServiceClient;
     private final ProjectFileService projectFileService;
     private final ProjectFileRepository projectFileRepository;
-    private final WpsActionService wpsActionService;
+    private final EditorBridgeService editorBridgeService;
     private final StorageServiceFactory storageServiceFactory;
     private final AiModelProperties aiModelProperties;
     private final BackgroundTaskService backgroundTaskService;
@@ -199,7 +199,7 @@ public class PptxTools implements AgentToolComponent {
             }
             
             // 通过 SSE 发送打开文件指令到前端
-            wpsActionService.sendOpenFileAction(file);
+            editorBridgeService.sendOpenFileAction(file);
             
             return String.format("已发送打开文件指令。文件名: %s。请等待 PPT 加载完成后再进行编辑操作。\n" +
                     "加载完成后，可以使用 pptx_get_presentation_info 获取 PPT 信息，" +
@@ -265,7 +265,7 @@ public class PptxTools implements AgentToolComponent {
         params.put("modelId", modelId);
         
         // 发送 SSE 唤起 UI
-        wpsActionService.sendPptConfigAction(params);
+        editorBridgeService.sendPptConfigAction(params);
         
         return "已唤起 PPT 生成配置界面，请在界面上选择生成选项（可编辑版/纯图片版）并确认。等待用户操作...";
     }
@@ -427,7 +427,7 @@ public class PptxTools implements AgentToolComponent {
                 }
                 
                 // 通知前端刷新文件列表
-                wpsActionService.sendRefreshFilesAction();
+                editorBridgeService.sendRefreshFilesAction();
                 
                 successMsg.append("\n文件已显示在项目文件树中。\n\n");
                 
@@ -573,7 +573,7 @@ public class PptxTools implements AgentToolComponent {
             }
             
             // 2. 尝试通过 WPS 获取页面内容
-            String slideContent = wpsActionService.executeWpsCommand("ppt_get_slide_content", 
+            String slideContent = editorBridgeService.executeEditorCommand("ppt_get_slide_content", 
                     java.util.Map.of("slideIndex", pageIndex));
             
             // 3. 分析返回结果，判断是否可编辑
@@ -641,7 +641,7 @@ public class PptxTools implements AgentToolComponent {
                     String newText = extractNewTextFromInstruction(text, instruction);
                     
                     // 调用 WPS 修改
-                    String result = wpsActionService.executeWpsCommand("ppt_modify_slide_text", 
+                    String result = editorBridgeService.executeEditorCommand("ppt_modify_slide_text", 
                             java.util.Map.of(
                                     "slideIndex", pageIndex,
                                     "shapeIndex", shapeIndex,
@@ -745,7 +745,7 @@ public class PptxTools implements AgentToolComponent {
             
             // 4. 通知前端重新加载文件（携带新的 wpsFileId）
             log.info("Notifying frontend to reload file: {}", file.getId());
-            wpsActionService.sendReloadFileAction(file);
+            editorBridgeService.sendReloadFileAction(file);
             
             return String.format("✅ 第 %d 页已使用 AI 成功修改！\n\n" +
                     "修改内容：%s\n\n" +

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -93,13 +93,13 @@ Your response MUST follow this exact sequence. Output **RAW XML** tags directly 
 ## 3. Drafting/Writing Mode
 **Pattern**: User asks to create a NEW document from scratch.
 
-**CRITICAL**: If the user asks to "revise", "update", or "modify" an existing document, or if a file with a similar topic already exists, you MUST use **Section 7 (WPS Document Editing)**.
+**CRITICAL**: If the user asks to "revise", "update", or "modify" an existing document, or if a file with a similar topic already exists, you MUST use **Section 7 (文档编辑)**.
 
 **Pre-flight Check**:
 1. Search for existing files: `search_project_files(name_pattern)`
-2. If found -> Use WPS tools to edit.
+2. If found -> Use document editing tools (doc_*) to edit.
 3. If NOT found ->
-   - **Preferred**: Use `wps_start_stream(fileId=null, fileName="文件名.docx")` to create and stream content in real-time (better UX).
+   - **Preferred**: Use `doc_start_stream(fileId=null, fileName="文件名.docx")` to create and stream content in real-time (better UX).
    - **Alternative**: Use `write_docx` for background batch creation.
 
 <thinking>用户需要起草法律文件，我将使用流式写入让用户看到生成过程。</thinking>
@@ -108,7 +108,7 @@ Your response MUST follow this exact sequence. Output **RAW XML** tags directly 
 
 <process name="撰写文档">
   <step>正在创建文件并开始流式写入...</step>
-  <tool_code>wps_start_stream(fileId=null, fileName="xxx协议.docx")</tool_code>
+  <tool_code>doc_start_stream(fileId=null, fileName="xxx协议.docx")</tool_code>
 </process>
 
 **After tool called, IMMEDIATELY start outputting markdown content.**
@@ -384,11 +384,11 @@ for file_id in file_ids:
 2. **禁止重写 (No Re-creation)**: 禁止通过 `write_docx` 创建一个名为 "xxx(修订版).docx" 的新文件来替代修改。必须打开原文件进行修订。
 3. **修订模式默认开启**: 你的所有改动都以修订痕迹（redline）呈现，用户可逐条接受或拒绝。放心修改，不会破坏原文。
 4. **拟人式工作循环（必须遵守）**: **看 → 找 → 选 → 改 → 验**。
-   - **看**：先用 `wps_get_document_text` / `wps_get_outline` 了解文档，别盲改；
-   - **找**：用 `wps_find_text` 定位，**根据每个匹配的上下文（contextBefore/contextAfter/paragraph）确认哪一个才是目标**；
-   - **选**：用 anchorId 选中目标（`wps_select_anchor`），用户看得见你选了哪里；
+   - **看**：先用 `doc_get_document_text` / `doc_get_outline` 了解文档，别盲改；
+   - **找**：用 `doc_find_text` 定位，**根据每个匹配的上下文（contextBefore/contextAfter/paragraph）确认哪一个才是目标**；
+   - **选**：用 anchorId 选中目标（`doc_select_anchor`），用户看得见你选了哪里；
    - **改**：替换/删除/插入/格式化；
-   - **验**：**核对工具返回的 paragraphAfterEdit**，确认改对了；改错就 `wps_undo` 退回重来。
+   - **验**：**核对工具返回的 paragraphAfterEdit**，确认改对了；改错就 `doc_undo` 退回重来。
 
 ### 可用工具
 
@@ -396,94 +396,94 @@ for file_id in file_ids:
 
 | 工具 | 用途 |
 |-----|------|
-| `wps_list_project_files(projectId)` | 列出项目中的所有可编辑文档（docx, xlsx 等） |
-| `wps_open_file(fileId)` | 打开指定文档进行编辑 |
-| `wps_search_related_docs(keyword, projectId)` | 搜索项目中可能需要修改的相关文档 |
-| `wps_get_document_text(startParagraph, maxParagraphs)` | **首选**：分段读取全文（带段落编号和标题级别），长文档分页读 |
-| `wps_get_outline()` | 获取文档大纲结构 |
-| `wps_get_selection()` | 获取用户当前选中的文本 |
-| `wps_get_cursor_context()` | 查看光标周围的文本（前后文、所在段落） |
-| `wps_get_paragraph(paragraphIndex)` | 获取指定段落的内容（0 开始） |
+| `doc_list_project_files(projectId)` | 列出项目中的所有可编辑文档（docx, xlsx 等） |
+| `doc_open_file(fileId)` | 打开指定文档进行编辑 |
+| `doc_search_related_docs(keyword, projectId)` | 搜索项目中可能需要修改的相关文档 |
+| `doc_get_document_text(startParagraph, maxParagraphs)` | **首选**：分段读取全文（带段落编号和标题级别），长文档分页读 |
+| `doc_get_outline()` | 获取文档大纲结构 |
+| `doc_get_selection()` | 获取用户当前选中的文本 |
+| `doc_get_cursor_context()` | 查看光标周围的文本（前后文、所在段落） |
+| `doc_get_paragraph(paragraphIndex)` | 获取指定段落的内容（0 开始） |
 
 **找（定位目标）**
 
 | 工具 | 用途 |
 |-----|------|
-| `wps_find_text(keyword, matchCase)` | 查找文本。每个匹配返回 **anchorId**（稳定锚点）+ 前后文 + 所在段落，多个匹配时靠上下文分辨目标 |
+| `doc_find_text(keyword, matchCase)` | 查找文本。每个匹配返回 **anchorId**（稳定锚点）+ 前后文 + 所在段落，多个匹配时靠上下文分辨目标 |
 
 **选（移动光标/选区，用户可见）**
 
 | 工具 | 用途 |
 |-----|------|
-| `wps_select_anchor(anchorId)` | 选中某个匹配，编辑器滚动到该处并高亮 |
-| `wps_select_paragraph(index)` | 按段落号选中整段 |
-| `wps_collapse_cursor(to)` | 光标落到选区开头(start)/结尾(end)——在目标"之前/之后"插入时用 |
-| `wps_goto(type, target)` | 光标到文档开头/结尾（start/end） |
+| `doc_select_anchor(anchorId)` | 选中某个匹配，编辑器滚动到该处并高亮 |
+| `doc_select_paragraph(index)` | 按段落号选中整段 |
+| `doc_collapse_cursor(to)` | 光标落到选区开头(start)/结尾(end)——在目标"之前/之后"插入时用 |
+| `doc_goto(type, target)` | 光标到文档开头/结尾（start/end） |
 
 **改（编辑，全部带修订痕迹）**
 
 | 工具 | 用途 |
 |-----|------|
-| `wps_replace_at_anchor(anchorId, newText)` | **最精准的替换**：替换指定锚点处的文本，返回改后段落全文供核对 |
-| `wps_replace_selection(text)` | 替换当前选区内容 |
-| `wps_delete_selection()` | 删除当前选中的文本（先选中再删） |
-| `wps_insert_at_cursor(text)` | 在光标位置插入文本 |
-| `wps_find_replace(findText, replaceText, replaceAll)` | 全局查找替换（确认无歧义时才用 replaceAll=true） |
-| `wps_replace_nth_match(findText, replaceText, matchIndex)` | 替换第 N 个匹配（索引从 1 开始） |
-| `wps_delete_match(findText, matchIndex)` / `wps_delete_text(text, deleteAll)` | 按匹配删除文本 |
-| `wps_modify_paragraph(paragraphIndex, newText)` | 整段改写（0 开始） |
-| `wps_insert_under_heading(headingText, content)` | 在指定标题下方插入内容 |
-| `wps_start_stream(fileId, fileName)` | 实时流式写入模式（新建长文档用） |
+| `doc_replace_at_anchor(anchorId, newText)` | **最精准的替换**：替换指定锚点处的文本，返回改后段落全文供核对 |
+| `doc_replace_selection(text)` | 替换当前选区内容 |
+| `doc_delete_selection()` | 删除当前选中的文本（先选中再删） |
+| `doc_insert_at_cursor(text)` | 在光标位置插入文本 |
+| `doc_find_replace(findText, replaceText, replaceAll)` | 全局查找替换（确认无歧义时才用 replaceAll=true） |
+| `doc_replace_nth_match(findText, replaceText, matchIndex)` | 替换第 N 个匹配（索引从 1 开始） |
+| `doc_delete_match(findText, matchIndex)` / `doc_delete_text(text, deleteAll)` | 按匹配删除文本 |
+| `doc_modify_paragraph(paragraphIndex, newText)` | 整段改写（0 开始） |
+| `doc_insert_under_heading(headingText, content)` | 在指定标题下方插入内容 |
+| `doc_start_stream(fileId, fileName)` | 实时流式写入模式（新建长文档用） |
 
 **格式（先选中，再排版）**
 
 | 工具 | 用途 |
 |-----|------|
-| `wps_format_selection(bold, italic, underline, strikeout, highlight, color, fontSize, fontName)` | 字符格式：加粗/斜体/下划线/删除线/**高亮**/字色/字号/字体，只传要改的参数 |
-| `wps_set_paragraph_format(alignment, headingLevel)` | 段落格式：对齐（left/right/center/justify）、标题级别（1-9，0=正文） |
+| `doc_format_selection(bold, italic, underline, strikeout, highlight, color, fontSize, fontName)` | 字符格式：加粗/斜体/下划线/删除线/**高亮**/字色/字号/字体，只传要改的参数 |
+| `doc_set_paragraph_format(alignment, headingLevel)` | 段落格式：对齐（left/right/center/justify）、标题级别（1-9，0=正文） |
 
 **验/撤销（安全网）**
 
 | 工具 | 用途 |
 |-----|------|
-| `wps_undo(steps)` / `wps_redo(steps)` | 撤销/重做最近的编辑 |
+| `doc_undo(steps)` / `doc_redo(steps)` | 撤销/重做最近的编辑 |
 
 ### 使用规范
 
-1. **修改前先打开文档**：使用 `wps_open_file` 打开需要编辑的文档
-2. **禁止使用字符偏移定位**：一律使用 `wps_find_text` 返回的 anchorId 或段落号；不要自己数字符位置
-3. **多个匹配必须先消歧**：`wps_find_text` 返回多个匹配时，逐个核对 contextBefore/contextAfter，确定目标后再操作；拿不准就先 `wps_select_anchor` 选中看一眼
-4. **每次修改后核对返回结果**：改动类工具会返回 `paragraphAfterEdit`（改后段落实文），发现不对立刻 `wps_undo` 并重新定位
-5. **格式化前必须有选区**：先 `wps_select_anchor` / `wps_select_paragraph`，再 `wps_format_selection`
-6. **批量联动修改**：当修改一处内容时，使用 `wps_search_related_docs` 搜索可能需要同步修改的相关文档
+1. **修改前先打开文档**：使用 `doc_open_file` 打开需要编辑的文档
+2. **禁止使用字符偏移定位**：一律使用 `doc_find_text` 返回的 anchorId 或段落号；不要自己数字符位置
+3. **多个匹配必须先消歧**：`doc_find_text` 返回多个匹配时，逐个核对 contextBefore/contextAfter，确定目标后再操作；拿不准就先 `doc_select_anchor` 选中看一眼
+4. **每次修改后核对返回结果**：改动类工具会返回 `paragraphAfterEdit`（改后段落实文），发现不对立刻 `doc_undo` 并重新定位
+5. **格式化前必须有选区**：先 `doc_select_anchor` / `doc_select_paragraph`，再 `doc_format_selection`
+6. **批量联动修改**：当修改一处内容时，使用 `doc_search_related_docs` 搜索可能需要同步修改的相关文档
 
 ### 典型场景
 
 **精准替换（多个相同文本，只改其中一个）**
 - 用户说"把付款条款里的'30日'改成'45日'" →
-  1. `wps_find_text("30日")` → 返回 3 个匹配，各带上下文
+  1. `doc_find_text("30日")` → 返回 3 个匹配，各带上下文
   2. 根据 paragraph/context 判断哪个匹配在付款条款里
-  3. `wps_replace_at_anchor(目标anchorId, "45日")`
+  3. `doc_replace_at_anchor(目标anchorId, "45日")`
   4. 核对返回的 paragraphAfterEdit
 
 **全部替换（无歧义）**
-- 用户说"把所有'甲方'替换为'买方'" → `wps_find_replace("甲方", "买方", true)`
+- 用户说"把所有'甲方'替换为'买方'" → `doc_find_replace("甲方", "买方", true)`
 
 **删除**
-- 用户说"删掉'其他约定'那一段" → `wps_get_document_text` 找到段落号 → `wps_select_paragraph(index)` 选中给用户看 → `wps_delete_selection()`
+- 用户说"删掉'其他约定'那一段" → `doc_get_document_text` 找到段落号 → `doc_select_paragraph(index)` 选中给用户看 → `doc_delete_selection()`
 
 **高亮/格式**
-- 用户说"把违约金那句加黄色高亮" → `wps_find_text("违约金")` → `wps_select_anchor(anchorId)` → `wps_format_selection(highlight="yellow")`
-- 用户说"这一段改成二级标题并加粗" → `wps_select_paragraph(index)` → `wps_set_paragraph_format(headingLevel=2)` → `wps_format_selection(bold=true)`
+- 用户说"把违约金那句加黄色高亮" → `doc_find_text("违约金")` → `doc_select_anchor(anchorId)` → `doc_format_selection(highlight="yellow")`
+- 用户说"这一段改成二级标题并加粗" → `doc_select_paragraph(index)` → `doc_set_paragraph_format(headingLevel=2)` → `doc_format_selection(bold=true)`
 
 **在某处之后插入**
-- 用户说"在定义条款后面加一条" → `wps_find_text("定义")` 定位 → `wps_select_anchor(anchorId)` → `wps_collapse_cursor("end")` → `wps_insert_at_cursor("\n新条款…")`
+- 用户说"在定义条款后面加一条" → `doc_find_text("定义")` 定位 → `doc_select_anchor(anchorId)` → `doc_collapse_cursor("end")` → `doc_insert_at_cursor("\n新条款…")`
 
 ### 重要提示
 
-1. **anchorId 是一次性书签**：来自最近一次 `wps_find_text`；文档大改后建议重新查找获取新锚点
-2. **删除操作使用删除专用工具**：`wps_delete_selection` / `wps_delete_match` / `wps_delete_text`，不要用 `wps_find_replace` 替换为空字符串
-3. **索引口径**：`wps_replace_nth_match` / `wps_delete_match` 的 matchIndex 从 **1** 开始；段落号（`wps_get_document_text` / `wps_select_paragraph` / `wps_get_paragraph` / `wps_modify_paragraph`）从 **0** 开始
+1. **anchorId 是一次性书签**：来自最近一次 `doc_find_text`；文档大改后建议重新查找获取新锚点
+2. **删除操作使用删除专用工具**：`doc_delete_selection` / `doc_delete_match` / `doc_delete_text`，不要用 `doc_find_replace` 替换为空字符串
+3. **索引口径**：`doc_replace_nth_match` / `doc_delete_match` 的 matchIndex 从 **1** 开始；段落号（`doc_get_document_text` / `doc_select_paragraph` / `doc_get_paragraph` / `doc_modify_paragraph`）从 **0** 开始
 4. **修订痕迹**：所有改动带修订痕迹，用户可接受/拒绝；无需也不要尝试关闭修订模式
 
 ## 8. PPT 演示文稿操作
@@ -529,7 +529,7 @@ for file_id in file_ids:
 
 2. **生成 PPT 到指定文件夹**：
    - 用户说"帮我生成一个AI法律的PPT，放到'汇报材料'文件夹"
-   - 流程：先用 `wps_list_project_files` 找到"汇报材料"文件夹的 ID，然后 `pptx_generate(topic="AI法律", parentId=文件夹ID)`
+   - 流程：先用 `doc_list_project_files` 找到"汇报材料"文件夹的 ID，然后 `pptx_generate(topic="AI法律", parentId=文件夹ID)`
 
 3. **修改 PPT 内容**：
    - 先用 `pptx_get_slide_content(页码)` 查看内容
@@ -539,6 +539,6 @@ for file_id in file_ids:
 
 # Operational Rules
 1. **Evidence First**: Always verify laws via `search_web` before citing.
-2. **WPS Direct Edit**: AI operations use direct replacement (revision mode disabled). All modifications take effect immediately without revision marks.
+2. **Document Direct Edit**: AI operations use direct replacement (revision mode disabled). All modifications take effect immediately without revision marks.
 3. **Safety**: Highlight major risks in **bold**.
-4. **Batch Document Updates**: When modifying content that may exist in multiple documents, use `wps_search_related_docs` to find and update all related files.
+4. **Batch Document Updates**: When modifying content that may exist in multiple documents, use `doc_search_related_docs` to find and update all related files.

--- a/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
@@ -52,7 +52,7 @@ class ToolRegistryTest {
         }
 
         @Tool("Find replace legacy default test")
-        public String wps_find_replace(@P("find") String findText, @P("replace") String replaceText, @P("all") Boolean replaceAll) {
+        public String doc_find_replace(@P("find") String findText, @P("replace") String replaceText, @P("all") Boolean replaceAll) {
             return findText + ">" + replaceText + ":" + replaceAll;
         }
 
@@ -81,7 +81,7 @@ class ToolRegistryTest {
     void registersAllTools() {
         assertEquals(7, registry.getAllSpecifications().size());
         assertTrue(registry.hasTool("echo"));
-        assertTrue(registry.hasTool("wps_find_replace"));
+        assertTrue(registry.hasTool("doc_find_replace"));
         assertFalse(registry.hasTool("nonexistent"));
     }
 
@@ -131,9 +131,9 @@ class ToolRegistryTest {
     }
 
     @Test
-    @DisplayName("行为保持：wps_find_replace 缺省 replaceAll=true")
+    @DisplayName("行为保持：doc_find_replace 缺省 replaceAll=true")
     void appliesLegacyDefaults() {
-        ToolRegistry.ToolResult r = registry.execute("wps_find_replace",
+        ToolRegistry.ToolResult r = registry.execute("doc_find_replace",
                 "{\"findText\":\"甲\",\"replaceText\":\"乙\"}", ctx);
         assertEquals("甲>乙:true", r.output());
     }
@@ -161,5 +161,25 @@ class ToolRegistryTest {
         // search_laws → search_web 不在 FakeTools 中，验证别名解析不误报 found
         ToolRegistry.ToolResult r = registry.execute("search_laws", "{\"query\":\"q\"}", ctx);
         assertFalse(r.found());
+    }
+
+    @Test
+    @DisplayName("灰度更名：旧名 wps_find_replace 经别名命中 doc_find_replace（含遗留默认值）")
+    void dispatchesLegacyWpsNameViaAlias() {
+        ToolRegistry.ToolResult r = registry.execute("wps_find_replace",
+                "{\"findText\":\"甲\",\"replaceText\":\"乙\"}", ctx);
+        assertTrue(r.found());
+        assertEquals("甲>乙:true", r.output());
+    }
+
+    @Test
+    @DisplayName("灰度更名：全部 wps_* 别名映射到同名 doc_* 工具")
+    void allWpsAliasesTargetDocNames() {
+        ToolRegistry.TOOL_NAME_ALIASES.forEach((alias, target) -> {
+            if (alias.startsWith("wps_")) {
+                assertEquals("doc_" + alias.substring(4), target,
+                        "别名 " + alias + " 应映射到同名 doc_* 工具");
+            }
+        });
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
@@ -37,7 +37,7 @@ class XmlToolCallParserTest {
         }
 
         @Tool("find replace")
-        public String wps_find_replace(@P("f") String findText, @P("r") String replaceText, @P("all") Boolean replaceAll) {
+        public String doc_find_replace(@P("f") String findText, @P("r") String replaceText, @P("all") Boolean replaceAll) {
             return "";
         }
 
@@ -102,8 +102,8 @@ class XmlToolCallParserTest {
     @DisplayName("JSON 风格：tool({\"key\":\"value\"})")
     void parsesJsonStyleCall() {
         XmlToolCallParser.ParsedCall call = single(
-                "<tool_code>wps_find_replace({\"findText\":\"甲方\",\"replaceText\":\"乙方\"})</tool_code>");
-        assertEquals("wps_find_replace", call.toolName());
+                "<tool_code>doc_find_replace({\"findText\":\"甲方\",\"replaceText\":\"乙方\"})</tool_code>");
+        assertEquals("doc_find_replace", call.toolName());
         cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
         assertEquals("甲方", args.getStr("findText"));
         assertEquals("乙方", args.getStr("replaceText"));
@@ -134,6 +134,20 @@ class XmlToolCallParserTest {
         XmlToolCallParser.ParsedCall call = single("<tool_code>search_laws(query=\"公司法\")</tool_code>");
         assertEquals("search_laws", call.toolName());
         assertEquals("公司法", cn.hutool.json.JSONUtil.parseObj(call.argsJson()).getStr("query"));
+    }
+
+    @Test
+    @DisplayName("灰度更名：旧名 wps_find_replace(...) 经别名解析命中 doc_find_replace")
+    void resolvesLegacyWpsNameViaAlias() {
+        // 老对话历史 / 模型惯性输出的旧名：参数按 doc_find_replace 的签名正确提取
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>wps_find_replace(findText=\"甲方\", replaceText=\"乙方\", replaceAll=true)</tool_code>");
+        assertEquals("wps_find_replace", call.toolName());
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("甲方", args.getStr("findText"));
+        assertEquals("乙方", args.getStr("replaceText"));
+        // 分发层按别名表映射到 doc_find_replace
+        assertEquals("doc_find_replace", ToolRegistry.TOOL_NAME_ALIASES.get(call.toolName()));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/tools/DocumentReplaceIntentTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/DocumentReplaceIntentTest.java
@@ -8,12 +8,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * WPS 替换意图识别测试
+ * 文档替换意图识别测试
  *
  * 测试 AI 助手能否正确理解用户的替换意图，并选择合适的工具。
  * 这不是测试实际的工具执行，而是测试工具选择逻辑。
  */
-class WpsReplaceIntentTest {
+class DocumentReplaceIntentTest {
 
     /**
      * 工具类型枚举

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -1,0 +1,96 @@
+# AI 编排器架构基线（重建版）
+
+> 本文件在 PR#83 描述中被引用但当时未实际入库；现随 Phase 2.5（WPS 遗留命名清理）
+> 补建，内容依据 PR#83/#84 记录与当前代码重建。SSE 事件字典等接口细节以
+> `docs/ai_agent_dev.md` 为准。
+
+## 1. 分层概览
+
+```
+接入层   AiChatController（薄壳）→ AiChatService（业务）
+上下文层 ContextAssemblerService（只读组装）+ FileContextLoader（文件/OCR/文件夹读取）
+编排层   AgentOrchestrator（ReAct 循环；不 import 任何具体工具类）
+协议层   XmlToolCallParser（<tool_code> 兜底协议，容错解析）
+能力层   ToolRegistry（内置工具自动注册 + 插件 JAR 懒注册 + 统一分发）
+桥接层   EditorBridgeService（SSE client_action ↔ 前端嵌入式 LibreOffice 编辑器）
+记忆层   写侧 MemoryPipelineService / 读侧 MemoryManager（五作用域，拟人化检索排序）
+```
+
+- 配置外置：上下文限值统一在 `AiContextProperties`（yml 前缀 `ai.context`，
+  token 预算可按模型覆盖）；法律信息保护正则在 `resources/legal/protected-patterns.yml`。
+- 记忆五作用域：user / project / conversation / file / global。
+
+## 2. 工具层（ToolRegistry）
+
+- 内置工具：实现 `AgentToolComponent` 标记接口的 Bean 中的 `@Tool` 方法自动注册；
+  插件 JAR 工具懒注册。**新增工具严禁改 AgentOrchestrator**。
+- `@ToolMeta` 提供中文显示名 / 分类 / 文件副作用元数据。
+- `projectId` / `conversationId` / `userId` 由服务端 `ToolContext` 强制注入，
+  LLM 传值一律忽略。
+- `TOOL_NAME_ALIASES`：旧工具名 → 真实工具名的灰度更名机制，原生 function calling
+  与 XML 兜底协议两条分发路径都会先做别名解析。
+
+### 2.1 工具命名规范与现行别名（Phase 2.5）
+
+编辑器已从 WPS WebOffice 全面迁移到 LibreOffice（Epic #43 / #79 / #81），
+Phase 2.5 将 LLM 面的 30 个文档编辑工具 `wps_*` 更名为 `doc_*`
+（宿主类 `WpsTools` → `DocumentEditTools`），`pptx_*` 不变。
+
+- **别名清单**：全部 30 条 `wps_*` → 同名 `doc_*`（如 `wps_find_replace` →
+  `doc_find_replace`），另有历史别名 `search_laws` → `search_web`。
+  完整列表见 `ToolRegistry.TOOL_NAME_ALIASES`。
+- **保留期**：wps_* 别名自 0.4.x 引入，**至少保留两个发布版本，移除不早于
+  0.6.0**；移除前需确认线上老对话历史中旧名调用率足够低。
+- 数据库历史消息中的旧工具名只影响展示（displayName 兜底"工具执行"），
+  不做数据迁移。
+
+## 3. 前后端契约（保持旧名）
+
+以下 `wps_*` 字符串是前后端契约（见 `docs/ai_agent_dev.md` §2.2），
+Phase 2.5 **未改动**，命名迁移列入 Phase 3：
+
+| 契约 | 现名 |
+|-----|------|
+| SSE 流式写入事件 | `wps_stream_data` |
+| SSE client_action 命令载荷 | `tool: "wps_command"`（内含 action 字典）|
+| SSE client_action 打开/刷新 | `action: "wps_open_file"` / `"wps_reload_file"` |
+| 同步打开命令 | `wps_open_file_sync` |
+| 结果回调路由 | `POST /api/ai/agent/wps-result` |
+| write_docx 输出 JSON 键 | `wps_file_id`（前端有字符串匹配逻辑）|
+| 文件实体字段 | `ProjectFile.wpsFileId` |
+
+## 4. Phase 路线图
+
+- **Phase 1（PR#83，已合并）**：ToolRegistry 统一工具层、XML 协议解析器抽取、
+  记忆五作用域 + 写入管线接线。
+- **Phase 2（PR#84，已合并）**：控制器瘦身（AiChatController 847→290 行）、
+  `ai.context` 配置外置、拟人化记忆检索排序（隐含重要性 × 时间衰减 × 随机）。
+- **Phase 2.5（本次）**：WPS 遗留命名清理——内部类名 editor 化、LLM 面工具名
+  `wps_*` → `doc_*`（别名灰度）、前端注释/内部命名 editor 化。
+- **Phase 3（待办清单）**：
+  - [ ] **SSE 事件名双轨迁移**：`wps_stream_data` → `doc_stream_data`、
+        `client_action.tool: wps_command` → `editor_command`、
+        `wps_open_file(_sync)` / `wps_reload_file` → `doc_*`、
+        路由 `/wps-result` → `/editor-result`。方案：后端双发（新旧事件并行）、
+        前端双听，观察一个发布周期后摘旧名；**合并前必须在 Electron 桌面端
+        真机实测文档打开、查找替换、流式写入三条链路**。
+  - [ ] `wps_*` 工具名别名移除（不早于 0.6.0，见 §2.1）。
+  - [ ] 前端零散 WPS 遗留：`VariablePanel.getWps` prop、`ChatInterface.vue`
+        `wps-tip-*` CSS 类、`ProjectFile.wpsFileId` 字段语义梳理。
+  - [ ] 插件广场沙箱 / MCP SDK 标准化 / Skill 体系 / 多智能体（Phase 1 遗留规划）。
+
+## 5. 不变式
+
+> 原五条不变式全文未随 PR#83 入库；以下为依据 PR 记录与代码重建的强约束，
+> 后续修订以本节为准。
+
+1. **编排器不感知具体工具**：AgentOrchestrator 不 import 任何具体工具类；
+   新增工具只实现 `AgentToolComponent` 或放入 plugins/，不改编排器。
+2. **服务端上下文不可伪造**：`projectId/conversationId/userId` 一律由
+   `ToolContext` 注入，LLM 传值忽略。
+3. **读写分离**：ContextAssembler（读侧）不做写操作；记忆写入只走
+   `MemoryPipelineService`。
+4. **配置外置**：上下文限值改 `ai.context` yml，不在代码里加常量；
+   法律保护模式改 `protected-patterns.yml`。
+5. **契约兼容**：SSE 事件字典、参数别名、遗留缺省值等对外行为保持；
+   任何更名必须走别名/双轨灰度，禁止一刀切。

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -8,7 +8,7 @@
 // reqId. The actual UNO operations run in the office worker (the spike's
 // office_thread.js, shared/evolved for the product).
 //
-// Contract = the SAME action names useWpsBridge.executeCommand dispatches
+// Contract = the editor-agnostic action names of the agent command pipeline
 // (get_selection / find_replace / insert_at_cursor / ...). RFC §0.2 invariant:
 // offset-shaped actions must map to anchors on the worker, never integer offsets.
 
@@ -97,11 +97,11 @@ export function createLibreOfficeExecutor(opts = {}) {
 
   /**
    * Editor-agnostic command entry point — SAME signature/contract as
-   * useWpsBridge.executeCommand(action, params). Unknown / ppt_* actions reject.
+   * the WPS-era useWpsBridge.executeCommand (removed #79). Unknown / ppt_* actions reject.
    */
   async function executeCommand(action, params = {}) {
     if (action && action.startsWith && action.startsWith('ppt_')) {
-      const m = 'ppt_* not supported by the LibreOffice executor (use WPS executor): ' + action
+      const m = 'ppt_* not supported by the LibreOffice executor: ' + action
       if (opts.onError) opts.onError(m)
       return { success: false, message: m }
     }

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -365,8 +365,8 @@ export function useAgentStream() {
             // can feed the embedded LibreOffice editor (buffered insert).
             try {
                 // Mark current bubble as doc-streaming to suppress chat duplication
-                if (currentAssistantBubble.value && !currentAssistantBubble.value.isWpsStreaming) {
-                    currentAssistantBubble.value.isWpsStreaming = true
+                if (currentAssistantBubble.value && !currentAssistantBubble.value.isEditorStreaming) {
+                    currentAssistantBubble.value.isEditorStreaming = true
                     // Add a placeholder message if content is empty
                     if (!currentAssistantBubble.value.content) {
                         currentAssistantBubble.value.content = '*(Streaming content to document...)*'
@@ -723,8 +723,8 @@ export function useAgentStream() {
             // Untagged text -> Main Content
             if (!bubble.content && !text.trim()) return
 
-            // [Modified] If we are streaming to WPS, suppress untagged content from chat bubble
-            if (bubble.isWpsStreaming) {
+            // [Modified] If we are streaming to the document editor, suppress untagged content from chat bubble
+            if (bubble.isEditorStreaming) {
                 return
             }
 

--- a/frontend/src/composables/useEditorBridge.js
+++ b/frontend/src/composables/useEditorBridge.js
@@ -2,7 +2,7 @@
 //
 // Epic #43 (LibreOffice migration), WPS removal #79. The agent command pipeline is:
 //   backend SSE `client_action` -> useAgentStream -> ChatInterface emits
-//   -> project-overview.vue handleWpsCommand -> executor.executeCommand(action, params)
+//   -> project-overview.vue handleEditorCommand -> executor.executeCommand(action, params)
 //   -> POST /api/ai/agent/wps-result
 //
 // RFC v2's thesis (docs/LIBREOFFICE_MIGRATION_PLAN.md) was that the backend agent

--- a/frontend/src/composables/useLibreOfficeBridge.js
+++ b/frontend/src/composables/useLibreOfficeBridge.js
@@ -1,11 +1,11 @@
 // useLibreOfficeBridge.js — Vue composable wrapping the framework-agnostic
 // LibreOffice executor client (libreofficeExecutorClient.js).
 //
-// Epic #43 task ④. The editor-agnostic counterpart of useWpsBridge.js: exposes
-// the SAME executeCommand(action, params) contract so the agent command pipeline
-// (backend SSE action -> frontend executor -> result) stays editor-agnostic and
-// the WPS and LibreOffice executors can COEXIST behind a switch (Phase 3 gray
-// rollout). The real client logic + the editor-agnostic command contract live in
+// Epic #43 task ④. The editor-agnostic executor bridge: exposes the standard
+// executeCommand(action, params) contract so the agent command pipeline
+// (backend SSE action -> frontend executor -> result) stays editor-agnostic
+// (the WPS-era useWpsBridge.js implemented the same contract before its removal
+// in #79). The real client logic + the editor-agnostic command contract live in
 // libreofficeExecutorClient.js (plain ESM, verified against a real LibreOffice in
 // the Phase 0 spike); this wrapper only adds Vue reactivity (isProcessing /
 // lastError) and is dormant until connect(port) wires an embedded ZetaOffice.

--- a/frontend/src/composables/zetaOfficeRelay.js
+++ b/frontend/src/composables/zetaOfficeRelay.js
@@ -5,7 +5,7 @@
 // WHY a relay: ZetaOffice boots inside an isolated Electron <webview> (it needs
 // cross-origin isolation, which the main window can't have — see
 // desktop/main/zetaoffice-session.js). But the AI agent command pipeline runs in
-// the HOST (project-overview.vue's handleWpsCommand). So a host executeCommand
+// the HOST (project-overview.vue's handleEditorCommand). So a host executeCommand
 // must cross the boundary: the host sends {action, params}, the webview runs it
 // against the booted executor (libreofficeExecutorClient -> worker -> UNO), and
 // returns the result. This module is that relay.
@@ -52,7 +52,7 @@ export function serveExecutor({ executor, send, subscribe }) {
 
 /**
  * HOST side: an executeCommand(action, params) that round-trips to the webview.
- * SAME contract as useWpsBridge / libreofficeExecutorClient, so useEditorBridge
+ * SAME contract as libreofficeExecutorClient.executeCommand, so useEditorBridge
  * can use it as the LibreOffice executor when the editor lives in a webview.
  *
  * @param {object} args

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1231,7 +1231,7 @@ import {
   getAiConfig,
   getAssistants, // Added
   getPlugins, // Added
-  sendWpsResult, // 编辑器命令结果回调（历史命名，#79 记改名债）
+  sendEditorResult, // 编辑器命令结果回调（POST /wps-result，路由名为前后端契约）
   getFileText,
   promptFeatureNotConfigured // 功能未配置统一引导（#18 T7）
 } from '@/services/api.js'
@@ -1451,7 +1451,7 @@ export default {
       tabDragOver: null, // { fileId, pane }
 
       // Epic #43: embedded LibreOffice editor. When active, backend AI commands
-      // route to it (handleWpsCommand — 历史命名，#79 记改名债).
+      // route to it (handleEditorCommand).
       showLibreEmbed: false,
       libreOfficeActive: false,
       libreOfficeExecutor: null,
@@ -4031,7 +4031,7 @@ export default {
             metaObj.sourceHost = (() => { try { return new URL(metaObj.sourceUrl).host } catch (e) { return '' } })()
           }
           const activeDoc = this.focusedPane === 'right' ? this.activeFileRight : this.activeFileLeft
-          metaObj.docFileName = activeDoc && this.isWpsFile && this.isWpsFile(activeDoc) ? (activeDoc.name || '') : ''
+          metaObj.docFileName = activeDoc && this.isEditorOpenableFile && this.isEditorOpenableFile(activeDoc) ? (activeDoc.name || '') : ''
           metaObj.docSide = this.focusedPane || 'left'
         } catch (e) {
           // ignore
@@ -4800,8 +4800,8 @@ export default {
 
       return supportedTypes.includes(type)
     },
-    isWpsFile(file) {
-      // 判断是否为「文档编辑器可打开」的 Office 类文件（历史命名，#79 记改名债）
+    isEditorOpenableFile(file) {
+      // 判断是否为「文档编辑器可打开」的 Office 类文件
       if (!file || file.tabType === 'web' || file.tabType === 'markdown' || !file.fileType) return false
 
       const type = file.fileType.toLowerCase()
@@ -4841,7 +4841,7 @@ export default {
     // (libreOfficePreferred). On web/h5 or when unavailable, returns false and
     // the file falls through to FilePreview (docx 本地只读渲染).
     useLibreEditor(file) {
-      return this.libreOfficePreferred && this.isWpsFile(file)
+      return this.libreOfficePreferred && this.isEditorOpenableFile(file)
     },
 
     // Check if file is a markdown tab (for AI artifacts or real .md files)
@@ -5042,7 +5042,7 @@ export default {
         candidate = this.activeFileLeft || this.activeFileRight || null
       }
       if (!candidate) return null
-      if (typeof this.isWpsFile === 'function' && !this.isWpsFile(candidate)) {
+      if (typeof this.isEditorOpenableFile === 'function' && !this.isEditorOpenableFile(candidate)) {
         return null
       }
       return candidate
@@ -5240,19 +5240,19 @@ export default {
         }
         // AI Agent 请求打开文件
         else if (action.action === 'wps_open_file') {
-            this.handleWpsOpenFile(action)
+            this.handleEditorOpenFile(action)
         }
         // AI Agent 请求重新加载文件（用于后端修改文件后刷新 WPS）
         else if (action.action === 'wps_reload_file') {
-            this.handleWpsReloadFile(action)
+            this.handleEditorReloadFile(action)
         }
-        // AI Agent 请求执行编辑器命令（事件名沿用 wps_command，#79 记改名债）
+        // AI Agent 请求执行编辑器命令（事件名沿用 wps_command，前后端契约；双轨迁移见 docs/AI_ARCHITECTURE.md Phase 3）
         else if (action.tool === 'wps_command') {
             // 特殊处理 wps_open_file_sync 命令（新建文件流式写入）
             if (action.action === 'wps_open_file_sync') {
-                this.handleWpsOpenFileSync(action)
+                this.handleEditorOpenFileSync(action)
             } else {
-                this.handleWpsCommand(action)
+                this.handleEditorCommand(action)
             }
         }
         // 后端流式写入数据（wps_start_stream 工具）：缓冲后经 LibreOffice 执行器落字
@@ -5298,14 +5298,14 @@ export default {
      * 处理 AI Agent 的同步打开文件请求 (用于流式写入)
      * 打开文件，等待内置 LibreOffice 编辑器就绪后返回结果给后端（#79）
      */
-    async handleWpsOpenFileSync(action) {
+    async handleEditorOpenFileSync(action) {
         console.log('[ProjectOverview] Open File Sync:', action)
         const { params, requestId, conversationId } = action
 
         try {
             if (!params || !params.fileId) {
                 console.error('[ProjectOverview] No fileId in wps_open_file_sync')
-                await sendWpsResult(conversationId, requestId, false, null, '缺少文件ID')
+                await sendEditorResult(conversationId, requestId, false, null, '缺少文件ID')
                 return
             }
 
@@ -5318,7 +5318,7 @@ export default {
             const file = await getFileDetail(this.projectId, params.fileId)
             if (!file) {
                 console.error('[ProjectOverview] File not found:', params.fileId)
-                await sendWpsResult(conversationId, requestId, false, null, '文件不存在')
+                await sendEditorResult(conversationId, requestId, false, null, '文件不存在')
                 return
             }
 
@@ -5340,7 +5340,7 @@ export default {
 
             if (!editorReady) {
                 console.error('[ProjectOverview] LibreOffice editor not ready after timeout')
-                await sendWpsResult(conversationId, requestId, false, null, '编辑器未就绪')
+                await sendEditorResult(conversationId, requestId, false, null, '编辑器未就绪')
                 return
             }
 
@@ -5352,7 +5352,7 @@ export default {
 
             // 6. 返回成功给后端
             console.log('[ProjectOverview] Open File Sync success')
-            await sendWpsResult(conversationId, requestId, true, {
+            await sendEditorResult(conversationId, requestId, true, {
                 fileId: file.id,
                 fileName: file.name,
                 status: 'ready'
@@ -5361,15 +5361,15 @@ export default {
             uni.showToast({ title: `已打开: ${file.name}`, icon: 'none' })
 
         } catch (e) {
-            console.error('[ProjectOverview] handleWpsOpenFileSync error:', e)
-            await sendWpsResult(conversationId, requestId, false, null, e.message)
+            console.error('[ProjectOverview] handleEditorOpenFileSync error:', e)
+            await sendEditorResult(conversationId, requestId, false, null, e.message)
         }
     },
 
     /**
      * 处理 AI Agent 的打开文件请求
      */
-    async handleWpsOpenFile(action) {
+    async handleEditorOpenFile(action) {
         console.log('[ProjectOverview] WPS Open File:', action)
         try {
             const fileId = action.fileId
@@ -5393,7 +5393,7 @@ export default {
             uni.showToast({ title: `已打开: ${file.name}`, icon: 'none' })
 
         } catch (e) {
-            console.error('[ProjectOverview] handleWpsOpenFile error:', e)
+            console.error('[ProjectOverview] handleEditorOpenFile error:', e)
             uni.showToast({ title: '打开文件失败', icon: 'none' })
         }
     },
@@ -5407,7 +5407,7 @@ export default {
      * 2. 前端获取最新文件信息，更新 leftFiles/rightFiles 中的 wpsFileId
      * 3. LibreOfficeEditor 以文件为 key/prop，检测到变化后重新加载
      */
-    async handleWpsReloadFile(action) {
+    async handleEditorReloadFile(action) {
         console.log('[ProjectOverview] WPS Reload File:', action)
         try {
             const fileId = action.fileId
@@ -5472,16 +5472,16 @@ export default {
             }
 
         } catch (e) {
-            console.error('[ProjectOverview] handleWpsReloadFile error:', e)
+            console.error('[ProjectOverview] handleEditorReloadFile error:', e)
             uni.showToast({ title: '刷新文件失败', icon: 'none' })
         }
     },
 
     /**
      * 处理 AI Agent 的编辑器命令请求（#79：LibreOffice 是唯一执行器；
-     * 方法名与 SSE 结果契约 sendWpsResult 沿用历史命名，记改名债）
+     * 结果经 sendEditorResult 回传后端，路由 /wps-result 为前后端契约）
      */
-    async handleWpsCommand(action) {
+    async handleEditorCommand(action) {
         console.log('[ProjectOverview] ========== Editor Command Start ==========')
         console.log('[ProjectOverview] Editor Command:', JSON.stringify(action))
 
@@ -5490,23 +5490,23 @@ export default {
 
         if (!this.libreOfficeActive || !this.libreOfficeExecutor) {
             console.error('[ProjectOverview] No embedded editor available')
-            await sendWpsResult(conversationId, requestId, false, null, '编辑器未就绪，请先打开一个文档')
+            await sendEditorResult(conversationId, requestId, false, null, '编辑器未就绪，请先打开一个文档')
             return
         }
 
         try {
             const result = await this.libreOfficeExecutor.executeCommand(commandAction, params)
             const successFlag = result && result.success !== false
-            await sendWpsResult(conversationId, requestId, successFlag, result, (result && result.error) || null)
+            await sendEditorResult(conversationId, requestId, successFlag, result, (result && result.error) || null)
         } catch (e) {
             console.error('[ProjectOverview] LibreOffice command error:', e)
-            await sendWpsResult(conversationId, requestId, false, null, e.message)
+            await sendEditorResult(conversationId, requestId, false, null, e.message)
         }
         console.log('[ProjectOverview] ========== Editor Command End ==========')
     },
 
     // Epic #43: embedded LibreOffice editor lifecycle. While ready, backend AI
-    // commands route to it (see handleWpsCommand). Used by both the inline
+    // commands route to it (see handleEditorCommand). Used by both the inline
     // default editor (Track B) and the legacy ⌘⇧O overlay.
     onLibreReady(executor) {
         this.libreOfficeExecutor = executor

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1223,17 +1223,17 @@ export function copyDdRequest(requestId) {
   })
 }
 
-// ==================== WPS 操作结果回调 ====================
+// ==================== 编辑器操作结果回调 ====================
 
 /**
- * 发送 WPS 操作结果到后端
+ * 发送编辑器操作结果到后端（路由 /wps-result 为前后端契约，保持旧名）
  * @param {string} conversationId - 会话 ID
  * @param {string} requestId - 请求 ID
  * @param {boolean} success - 是否成功
  * @param {Object} data - 结果数据
  * @param {string} error - 错误信息
  */
-export function sendWpsResult(conversationId, requestId, success, data, error = null) {
+export function sendEditorResult(conversationId, requestId, success, data, error = null) {
   return request({
     url: '/api/ai/agent/wps-result',
     method: 'POST',
@@ -1373,7 +1373,7 @@ export default {
   getSensitiveOptions,
   desensitizeFile,
   // WPS 操作
-  sendWpsResult,
+  sendEditorResult,
   addDdRequestItems(requestId, content) {
     return request({
       url: `/api/dd/requests/${requestId}/items`,

--- a/frontend/src/zetaoffice/README.md
+++ b/frontend/src/zetaoffice/README.md
@@ -67,8 +67,9 @@ host (project-overview)                     isolated <webview partition="persist
      libreExecutor: createWebviewEditorExecutor(this.$refs.zetaWebview),
    })
    ```
-   Route `handleWpsCommand` through `editor.executeCommand(action, params)`
-   (the method/event names keep the historical `wps_` prefix — rename debt, #79).
+   Route `handleEditorCommand` through `editor.executeCommand(action, params)`
+   (SSE event names keep the historical `wps_` prefix — frontend/backend
+   contract; dual-track migration tracked in docs/AI_ARCHITECTURE.md Phase 3).
 5. **IME overlay** + **perf** (load an existing 50-page docx) — separate #43 tasks.
 
 ## AI 拟人式动作原语（2026-07）
@@ -85,8 +86,9 @@ host (project-overview)                     isolated <webview partition="persist
 - 格式：`format_selection`（粗/斜/下划线/删除线/高亮/字色/字号/字体，CJK 同步
   Asian/Complex 属性）、`set_paragraph_format`（对齐 + `Heading N` 样式）
 
-改动类命令返回 `paragraphAfterEdit` 验证快照。后端对应 `wps_*` 新工具见
-`WpsTools.java`；提示词工作流见 `prompts/system_prompt.md` §7。
+改动类命令返回 `paragraphAfterEdit` 验证快照。后端对应 `doc_*` 工具见
+`DocumentEditTools.java`（原 WpsTools，旧名 `wps_*` 经 ToolRegistry 别名兜底）；
+提示词工作流见 `prompts/system_prompt.md` §7。
 
 全部原语已在真实 LOWA 引擎（自建 zh-CN 24.2.8）+ 无头/有头 Chrome 上端到端
 验证（`editor.html?verify=1` 暴露 `window.__loExecutor` 供自动化驱动）。

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -298,7 +298,7 @@ function testInsertText(text) {
 
 // ==========================================================================
 // Editor executor command contract (Epic #43 task ④, worker side).
-// Implements the SAME editor-agnostic actions that useWpsBridge.executeCommand
+// Implements the SAME editor-agnostic actions that the agent command pipeline
 // dispatches, via UNO — so frontend/src/composables/useLibreOfficeBridge.js can
 // drive LibreOffice with the backend's existing commands. Each handler returns a
 // plain result object; the dispatcher posts {cmd:'result', reqId, result} back.


### PR DESCRIPTION
## 背景

编辑器已从 WPS WebOffice 全面迁移到 LibreOffice（#79/#81），但代码里 WpsTools（30 个 wps_* 工具）、WpsActionService、WpsResultController 等命名全是死命名。本 PR 是 AI 编排器 Phase 2.5：利用 Phase 1 落地的 `ToolRegistry.TOOL_NAME_ALIASES` 机制做带别名的灰度更名，分三个独立 commit。

## Step 1 — 纯内部类名（零对外影响）
- `WpsTools` → `DocumentEditTools`、`WpsActionService` → `EditorBridgeService`（含 `executeWpsCommand` → `executeEditorCommand` 等成员）、`WpsResultController` → `EditorResultController`、`WpsReplaceIntentTest` → `DocumentReplaceIntentTest`
- HTTP 路由、SSE 事件名、@Tool 方法名全部不变

## Step 2 — LLM 面工具名（别名兜底）
- 30 个 `wps_*` @Tool 方法更名 `doc_*`（实际 30 个而非任务描述的 28；`pptx_*` 不动）
- `TOOL_NAME_ALIASES` 登记全部 `wps_* → doc_*`：老对话历史、老 prompt、模型惯性输出的旧名仍正确分发（原生 function calling 与 XML 兜底两条路径都先做别名解析）；**别名保留至少两个发布版本（≥0.6.0）**
- `LEGACY_DEFAULTS` 键随更名改为 `doc_*`（查表发生在别名解析之后，行为保持）
- `system_prompt.md` 全部 50 处 `wps_*` 引用与 FileTools @Tool 描述同步更新（ContextAssemblerService 的 enforcement 文本经查在 Phase 2 后已不含工具名）
- 新增测试：旧名 `wps_find_replace(...)` 经 XML 别名解析命中 `doc_find_replace`；ToolRegistry 旧名分发（含遗留默认值）；全部别名与 doc_* 一一对应

## Step 3 — 前端契约（双轨兼容）
- **SSE 事件名保持旧名发送不变**（`wps_stream_data`、`client_action.tool=wps_command` 等，docs/ai_agent_dev.md §2.2 契约）。事件名双轨改造需在 Electron 真机实测文档打开/查找替换/流式写入三条链路后才允许合并，本轮不做，已登记为 Phase 3 项
- 前端内部命名 editor 化：`handleWpsCommand`→`handleEditorCommand`、`sendWpsResult`→`sendEditorResult`、`isWpsFile`→`isEditorOpenableFile`、`isWpsStreaming`→`isEditorStreaming` 等；composable 失实注释更新
- 新建 `docs/AI_ARCHITECTURE.md`（重建版）：分层基线、别名清单与移除计划、Phase 3 清单、五条不变式重建。**发现：`.gitignore` 忽略 `docs/` 是 PR#83 该文档未入库的根因**，本次 `git add -f` 强制入库

## 验证
- 全量 `mvn test` 102/102 绿（JDK 21；Step 2 新增 3 个用例）
- 前端 `npm run build:h5` 构建通过
- 契约不变：SSE 事件字典、`/wps-result` 路由、`wps_open_file_sync`、`wps_file_id` JSON 键、`ProjectFile.wpsFileId` 字段
- 数据库历史消息旧工具名只影响展示，不做数据迁移

🤖 Generated with [Claude Code](https://claude.com/claude-code)