### PR TITLE
feat(plugins): 插件广场 MVP——manifest 规范 v1 + 启停持久化 + 前端管理页 / plugin marketplace MVP

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/PluginController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginController.java
@@ -1,15 +1,28 @@
 package com.checkba.controller.ai;
 
+import com.checkba.controller.AuthController;
+import com.checkba.repository.UserRepository;
 import com.checkba.service.ai.PluginService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Controller to expose plugin information to the frontend.
+ * 插件广场接口（manifest 规范 v1 见 docs/PLUGIN_SPEC.md）：
+ * - GET  /list          插件列表（含工具清单、权限声明、启用状态），登录即可查看
+ * - POST /{id}/enable   启用插件（仅 admin）
+ * - POST /{id}/disable  禁用插件（仅 admin）
+ * - POST /rescan        重新扫描 plugins/ 目录（仅 admin）
  */
 @RestController
 @RequestMapping("/api/plugins")
@@ -17,9 +30,106 @@ import java.util.List;
 public class PluginController {
 
     private final PluginService pluginService;
+    private final UserRepository userRepository;
+
+    @lombok.Data
+    public static class PluginView {
+        private String id;
+        private String name;
+        private String version;
+        private String description;
+        private String icon;
+        private String author;
+        private String homepage;
+        private String frontendEntry;
+        private List<String> permissions;
+        private List<PluginService.PluginToolInfo> tools;
+        private int toolCount;
+        private boolean enabled;
+    }
 
     @GetMapping("/list")
-    public List<PluginService.PluginMetadata> listPlugins() {
-        return pluginService.getPlugins();
+    public List<PluginView> listPlugins() {
+        return pluginService.getPlugins().stream().map(this::toView).toList();
+    }
+
+    @PostMapping("/{id}/enable")
+    public ResponseEntity<Map<String, Object>> enablePlugin(
+            @PathVariable("id") String pluginId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        return setEnabled(pluginId, true, sessionId);
+    }
+
+    @PostMapping("/{id}/disable")
+    public ResponseEntity<Map<String, Object>> disablePlugin(
+            @PathVariable("id") String pluginId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        return setEnabled(pluginId, false, sessionId);
+    }
+
+    @PostMapping("/rescan")
+    public ResponseEntity<Map<String, Object>> rescan(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        pluginService.rescan();
+        Map<String, Object> result = ok();
+        result.put("pluginCount", pluginService.getPlugins().size());
+        result.put("toolCount", pluginService.getPluginTools().size());
+        return ResponseEntity.ok(result);
+    }
+
+    private ResponseEntity<Map<String, Object>> setEnabled(String pluginId, boolean enabled, String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        try {
+            pluginService.setEnabled(pluginId, enabled);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error("插件不存在: " + pluginId));
+        }
+        return ResponseEntity.ok(ok());
+    }
+
+    private PluginView toView(PluginService.PluginMetadata meta) {
+        PluginView view = new PluginView();
+        view.setId(meta.getId());
+        view.setName(meta.getName());
+        view.setVersion(meta.getVersion());
+        view.setDescription(meta.getDescription());
+        view.setIcon(meta.getIcon());
+        view.setAuthor(meta.getAuthor());
+        view.setHomepage(meta.getHomepage());
+        view.setFrontendEntry(meta.getFrontendEntry());
+        view.setPermissions(meta.getPermissions() == null ? List.of() : meta.getPermissions());
+        view.setTools(meta.getTools() == null ? List.of() : meta.getTools());
+        view.setToolCount(view.getTools().size());
+        view.setEnabled(pluginService.isEnabled(meta.getId()));
+        return view;
+    }
+
+    /** 与 AdminConfigController 相同的管理员判定：session -> userId -> username == admin */
+    private boolean isAdmin(String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            return false;
+        }
+        return userRepository.findById(userId)
+                .map(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .orElse(false);
+    }
+
+    private Map<String, Object> ok() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        return result;
+    }
+
+    private Map<String, Object> error(String message) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("message", message);
+        return result;
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -1,9 +1,11 @@
 package com.checkba.service.ai;
 
+import com.checkba.service.SystemSettingService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agent.tool.ToolSpecifications;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PostConstruct;
@@ -13,25 +15,58 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Service to manage backend plugins.
  * Scans 'plugins/' directory for JAR files and registers AI tools.
+ *
+ * Manifest 规范 v1 见 docs/PLUGIN_SPEC.md；示例插件见 examples/hello-plugin/。
+ * 启停状态持久化在 system_setting 表（key = {@link #DISABLED_KEY}，值为被禁用插件 id 的 JSON 数组，
+ * 默认全部启用）。{@link #isEnabled(String)} 供将来 ToolRegistry 过滤禁用插件的工具
+ * （接入点见 docs/AI_ARCHITECTURE.md 的 Phase 3 TODO，本轮不改 ToolRegistry）。
  */
 @Service
 @Slf4j
 public class PluginService {
+
+    /** system_setting 中存放被禁用插件 id 列表（JSON 数组）的 key */
+    public static final String DISABLED_KEY = "ai.plugins.disabled";
+
+    /** manifest 规范 v1 已定义的权限值，未知值仅告警不拒绝（向前兼容） */
+    private static final Set<String> KNOWN_PERMISSIONS =
+            Set.of("file_read", "file_write", "network", "editor");
 
     @Getter
     private final List<PluginMetadata> plugins = new ArrayList<>();
 
     @Getter
     private final Map<String, Object> pluginTools = new HashMap<>(); // toolName -> toolObject
-    
+
     @Getter
     private final List<ToolSpecification> toolSpecifications = new ArrayList<>();
 
-    private String pluginsDir = "plugins";
+    /** toolName -> pluginId，供将来 ToolRegistry 按插件启停过滤工具 */
+    private final Map<String, String> toolToPluginId = new HashMap<>();
+
+    /** 被禁用插件 id 集合（内存缓存，与 system_setting 同步） */
+    private final Set<String> disabledPluginIds = ConcurrentHashMap.newKeySet();
+
+    private final SystemSettingService systemSettingService;
+
+    private final String pluginsDir;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public PluginService(SystemSettingService systemSettingService,
+                         @Value("${ai.plugins.dir:plugins}") String pluginsDir) {
+        this.systemSettingService = systemSettingService;
+        this.pluginsDir = pluginsDir;
+    }
+
+    /** 兼容构造器：仅供既有单测直接 new 使用（无持久化，启停状态只存内存） */
+    public PluginService() {
+        this(null, "plugins");
+    }
 
     @lombok.Data
     public static class PluginMetadata {
@@ -40,13 +75,90 @@ public class PluginService {
         private String version;
         private String description;
         private String icon;
+        private String author;
+        private String homepage;
         private String frontendEntry;
         private List<String> backendJars;
+        /** 声明需要的能力：file_read / file_write / network / editor */
+        private List<String> permissions;
+        /** 插件提供的工具清单（名称 + 中文描述） */
+        private List<PluginToolInfo> tools;
+    }
+
+    @lombok.Data
+    public static class PluginToolInfo {
+        private String name;
+        private String description;
     }
 
     @PostConstruct
     public void init() {
+        loadDisabledState();
         loadPlugins();
+    }
+
+    /**
+     * 重新扫描插件目录：清空已加载的元数据与工具后全量重载。
+     * 注意：已由旧 ClassLoader 加载的类不会被卸载（MVP 可接受），重扫主要用于发现新装插件。
+     */
+    public synchronized void rescan() {
+        plugins.clear();
+        pluginTools.clear();
+        toolSpecifications.clear();
+        toolToPluginId.clear();
+        loadDisabledState();
+        loadPlugins();
+        log.info("Plugin rescan done: {} plugins, {} tools", plugins.size(), pluginTools.size());
+    }
+
+    /**
+     * 插件是否启用（默认启用，禁用名单持久化在 system_setting）。
+     * 供 PluginController 与将来的 ToolRegistry 查询。
+     */
+    public boolean isEnabled(String pluginId) {
+        return !disabledPluginIds.contains(pluginId);
+    }
+
+    /**
+     * 启用 / 禁用插件并持久化。
+     * @throws IllegalArgumentException pluginId 不在已加载插件列表中
+     */
+    public synchronized void setEnabled(String pluginId, boolean enabled) {
+        boolean known = plugins.stream().anyMatch(p -> Objects.equals(p.getId(), pluginId));
+        if (!known) {
+            throw new IllegalArgumentException("Unknown plugin: " + pluginId);
+        }
+        if (enabled) {
+            disabledPluginIds.remove(pluginId);
+        } else {
+            disabledPluginIds.add(pluginId);
+        }
+        if (systemSettingService != null) {
+            systemSettingService.set(DISABLED_KEY,
+                    cn.hutool.json.JSONUtil.toJsonStr(new TreeSet<>(disabledPluginIds)));
+        }
+        log.info("Plugin {} {}", pluginId, enabled ? "enabled" : "disabled");
+    }
+
+    /** 工具所属的插件 id（内置工具不在此映射中，返回 null） */
+    public String getPluginIdForTool(String toolName) {
+        return toolToPluginId.get(toolName);
+    }
+
+    private void loadDisabledState() {
+        disabledPluginIds.clear();
+        if (systemSettingService == null) {
+            return;
+        }
+        try {
+            String json = systemSettingService.get(DISABLED_KEY, "[]");
+            List<String> ids = cn.hutool.json.JSONUtil.toList(json, String.class);
+            if (ids != null) {
+                disabledPluginIds.addAll(ids);
+            }
+        } catch (Exception e) {
+            log.error("Failed to load plugin disabled state, default to all enabled", e);
+        }
     }
 
     public void loadPlugins() {
@@ -69,7 +181,16 @@ public class PluginService {
 
                 log.info("Loading plugin metadata from: {}", pluginDir.getName());
                 String json = cn.hutool.core.io.FileUtil.readUtf8String(manifestFile);
-                PluginMetadata meta = cn.hutool.json.JSONUtil.toBean(json, PluginMetadata.class);
+                PluginMetadata meta = parseManifest(json);
+                if (meta == null) {
+                    log.error("Invalid manifest (missing id), skip plugin dir: {}", pluginDir.getName());
+                    continue;
+                }
+                boolean duplicated = plugins.stream().anyMatch(p -> Objects.equals(p.getId(), meta.getId()));
+                if (duplicated) {
+                    log.warn("Duplicate plugin id '{}', skip plugin dir: {}", meta.getId(), pluginDir.getName());
+                    continue;
+                }
                 plugins.add(meta);
 
                 // Load associated JARs if any
@@ -77,7 +198,7 @@ public class PluginService {
                     for (String jarName : meta.getBackendJars()) {
                         File jarFile = new File(pluginDir, jarName);
                         if (jarFile.exists()) {
-                            loadJar(jarFile);
+                            loadJar(jarFile, meta.getId());
                         }
                     }
                 }
@@ -87,16 +208,36 @@ public class PluginService {
         }
     }
 
-    private void loadJar(File jar) throws IOException, ClassNotFoundException {
+    /**
+     * 解析 manifest.json（规范 v1，见 docs/PLUGIN_SPEC.md）。
+     * @return 解析后的元数据；id 缺失时返回 null（插件必须有稳定 id 才能启停）
+     */
+    PluginMetadata parseManifest(String json) {
+        PluginMetadata meta = cn.hutool.json.JSONUtil.toBean(json, PluginMetadata.class);
+        if (meta.getId() == null || meta.getId().isBlank()) {
+            return null;
+        }
+        if (meta.getPermissions() != null) {
+            for (String p : meta.getPermissions()) {
+                if (!KNOWN_PERMISSIONS.contains(p)) {
+                    log.warn("Plugin {} declares unknown permission '{}' (spec v1 knows: {})",
+                            meta.getId(), p, KNOWN_PERMISSIONS);
+                }
+            }
+        }
+        return meta;
+    }
+
+    private void loadJar(File jar, String pluginId) throws IOException, ClassNotFoundException {
         URLClassLoader loader = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader());
-        
+
         try (java.util.jar.JarFile jarFile = new java.util.jar.JarFile(jar)) {
             Enumeration<java.util.jar.JarEntry> entries = jarFile.entries();
-            
+
             while (entries.hasMoreElements()) {
                 java.util.jar.JarEntry entry = entries.nextElement();
                 String name = entry.getName();
-                
+
                 if (name.endsWith(".class")) {
                     String className = name.replace("/", ".").substring(0, name.length() - 6);
                     try {
@@ -104,12 +245,12 @@ public class PluginService {
                         // Check if class has methods with @Tool annotation
                         boolean hasTools = Arrays.stream(cls.getDeclaredMethods())
                                 .anyMatch(m -> m.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class));
-                        
+
                         if (hasTools) {
                             log.info("Found tool class in plugin: {}", className);
                             // Instantiate and register
                             Object instance = cls.getDeclaredConstructor().newInstance();
-                            registerToolObject(instance);
+                            registerToolObject(instance, pluginId);
                         }
                     } catch (Throwable e) {
                         // Skip classes that can't be loaded (e.g. missing dependencies)
@@ -121,17 +262,24 @@ public class PluginService {
             log.error("Error scanning JAR {}: {}", jar.getName(), e.getMessage());
         }
     }
-    
+
     /**
      * Registers a tool object (e.g., from a JAR or hardcoded).
      */
     public void registerToolObject(Object toolObject) {
+        registerToolObject(toolObject, null);
+    }
+
+    private void registerToolObject(Object toolObject, String pluginId) {
         try {
             List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(toolObject);
             for (ToolSpecification spec : specs) {
                 log.info("Registered dynamic tool: {}", spec.name());
                 pluginTools.put(spec.name(), toolObject);
                 toolSpecifications.add(spec);
+                if (pluginId != null) {
+                    toolToPluginId.put(spec.name(), pluginId);
+                }
             }
         } catch (Exception e) {
             log.error("Failed to register tool object: " + toolObject.getClass().getName(), e);

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -1,0 +1,214 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.SystemSettingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * PluginService 测试：manifest 规范 v1 解析 + 插件启停状态持久化 + 重新扫描
+ */
+class PluginServiceTest {
+
+    @TempDir
+    Path pluginsDir;
+
+    /** 模拟 system_setting 表的内存 KV 存储 */
+    private final Map<String, String> settingStore = new HashMap<>();
+
+    private SystemSettingService systemSettingService;
+    private PluginService service;
+
+    @BeforeEach
+    void setUp() {
+        systemSettingService = mock(SystemSettingService.class);
+        when(systemSettingService.get(anyString(), anyString())).thenAnswer(inv ->
+                settingStore.getOrDefault(inv.getArgument(0), inv.getArgument(1)));
+        doAnswer(inv -> settingStore.put(inv.getArgument(0), inv.getArgument(1)))
+                .when(systemSettingService).set(anyString(), anyString());
+
+        service = new PluginService(systemSettingService, pluginsDir.toString());
+    }
+
+    private void writeManifest(String dirName, String json) throws IOException {
+        Path dir = pluginsDir.resolve(dirName);
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("manifest.json"), json, StandardCharsets.UTF_8);
+    }
+
+    private static final String FULL_MANIFEST = """
+            {
+              "id": "hello-plugin",
+              "name": "Hello 示例插件",
+              "version": "1.0.0",
+              "description": "示例插件",
+              "icon": "🔌",
+              "author": "AI Workdeck",
+              "homepage": "https://example.com/hello-plugin",
+              "permissions": ["file_read", "network"],
+              "tools": [
+                {"name": "helloEcho", "description": "原样回显输入文本"},
+                {"name": "helloWordCount", "description": "统计字数"}
+              ],
+              "backendJars": ["hello-plugin-1.0.0.jar"]
+            }
+            """;
+
+    // ==== manifest 解析 ====
+
+    @Test
+    @DisplayName("解析完整 manifest v1：permissions/tools/author/homepage 全部字段")
+    void parsesFullManifest() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+
+        assertEquals(1, service.getPlugins().size());
+        PluginService.PluginMetadata meta = service.getPlugins().get(0);
+        assertEquals("hello-plugin", meta.getId());
+        assertEquals("Hello 示例插件", meta.getName());
+        assertEquals("1.0.0", meta.getVersion());
+        assertEquals("AI Workdeck", meta.getAuthor());
+        assertEquals("https://example.com/hello-plugin", meta.getHomepage());
+        assertEquals(List.of("file_read", "network"), meta.getPermissions());
+        assertEquals(2, meta.getTools().size());
+        assertEquals("helloEcho", meta.getTools().get(0).getName());
+        assertEquals("原样回显输入文本", meta.getTools().get(0).getDescription());
+    }
+
+    @Test
+    @DisplayName("最小 manifest（仅 id/name）可加载，可选字段为空")
+    void parsesMinimalManifest() throws IOException {
+        writeManifest("mini", "{\"id\": \"mini\", \"name\": \"极简插件\"}");
+        service.init();
+
+        assertEquals(1, service.getPlugins().size());
+        PluginService.PluginMetadata meta = service.getPlugins().get(0);
+        assertEquals("mini", meta.getId());
+        assertNull(meta.getPermissions());
+        assertNull(meta.getTools());
+        assertTrue(service.isEnabled("mini"), "默认应为启用");
+    }
+
+    @Test
+    @DisplayName("缺少 id 的 manifest 被跳过")
+    void skipsManifestWithoutId() throws IOException {
+        writeManifest("no-id", "{\"name\": \"没有 id 的插件\"}");
+        service.init();
+
+        assertTrue(service.getPlugins().isEmpty());
+    }
+
+    @Test
+    @DisplayName("非法 JSON 只影响自身，其他插件正常加载")
+    void brokenManifestDoesNotBlockOthers() throws IOException {
+        writeManifest("broken", "{ not valid json !!!");
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+
+        assertEquals(1, service.getPlugins().size());
+        assertEquals("hello-plugin", service.getPlugins().get(0).getId());
+    }
+
+    @Test
+    @DisplayName("重复 id 的插件目录只加载第一个")
+    void skipsDuplicatePluginId() throws IOException {
+        writeManifest("dir-a", "{\"id\": \"dup\", \"name\": \"A\"}");
+        writeManifest("dir-b", "{\"id\": \"dup\", \"name\": \"B\"}");
+        service.init();
+
+        assertEquals(1, service.getPlugins().size());
+    }
+
+    @Test
+    @DisplayName("未知权限值不阻断加载（向前兼容）")
+    void unknownPermissionIsTolerated() throws IOException {
+        writeManifest("p", "{\"id\": \"p\", \"name\": \"P\", \"permissions\": [\"file_read\", \"future_cap\"]}");
+        service.init();
+
+        assertEquals(1, service.getPlugins().size());
+        assertEquals(List.of("file_read", "future_cap"), service.getPlugins().get(0).getPermissions());
+    }
+
+    // ==== 启停状态 ====
+
+    @Test
+    @DisplayName("setEnabled(false/true) 往返生效并持久化到配置表")
+    void setEnabledRoundTripPersists() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+
+        assertTrue(service.isEnabled("hello-plugin"));
+
+        service.setEnabled("hello-plugin", false);
+        assertFalse(service.isEnabled("hello-plugin"));
+        assertTrue(settingStore.get(PluginService.DISABLED_KEY).contains("hello-plugin"),
+                "禁用名单应写入 system_setting");
+
+        service.setEnabled("hello-plugin", true);
+        assertTrue(service.isEnabled("hello-plugin"));
+        assertFalse(settingStore.get(PluginService.DISABLED_KEY).contains("hello-plugin"));
+    }
+
+    @Test
+    @DisplayName("启停状态在重启（重新 init）后从配置表恢复")
+    void disabledStateSurvivesRestart() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        settingStore.put(PluginService.DISABLED_KEY, "[\"hello-plugin\"]");
+
+        service.init();
+
+        assertFalse(service.isEnabled("hello-plugin"));
+        assertTrue(service.isEnabled("some-other-plugin"), "不在名单中的默认启用");
+    }
+
+    @Test
+    @DisplayName("对未知插件 setEnabled 抛 IllegalArgumentException")
+    void setEnabledUnknownPluginThrows() {
+        service.init();
+        assertThrows(IllegalArgumentException.class, () -> service.setEnabled("ghost", false));
+        verify(systemSettingService, never()).set(eq(PluginService.DISABLED_KEY), anyString());
+    }
+
+    @Test
+    @DisplayName("配置表中的禁用名单损坏时降级为全部启用")
+    void corruptDisabledListFallsBackToAllEnabled() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        settingStore.put(PluginService.DISABLED_KEY, "not-a-json-array");
+
+        service.init();
+
+        assertTrue(service.isEnabled("hello-plugin"));
+    }
+
+    // ==== 重新扫描 ====
+
+    @Test
+    @DisplayName("rescan 发现新装插件并重读启停状态")
+    void rescanPicksUpNewPlugins() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+        assertEquals(1, service.getPlugins().size());
+
+        writeManifest("second", "{\"id\": \"second\", \"name\": \"第二个插件\"}");
+        settingStore.put(PluginService.DISABLED_KEY, "[\"second\"]");
+        service.rescan();
+
+        assertEquals(2, service.getPlugins().size());
+        assertFalse(service.isEnabled("second"), "rescan 应重读禁用名单");
+        assertTrue(service.isEnabled("hello-plugin"));
+    }
+}

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -115,4 +115,17 @@ Phase 2.5 未改动，命名迁移列入 Phase 3：
   - [ ] `wps_*` 工具名别名移除（不早于 0.6.0，见 §3「工具命名与别名」）。
   - [ ] 前端零散 WPS 遗留：`VariablePanel.getWps` prop、`ChatInterface.vue` `wps-tip-*`
         CSS 类、`ProjectFile.wpsFileId` 字段语义梳理。
-  - [ ] 插件广场沙箱、MCP SDK 标准化、Skill 体系、多智能体协作。
+  - [x] **插件广场 MVP**（PR #88）：manifest 规范 v1（见 docs/PLUGIN_SPEC.md，新增
+        permissions/tools/author/homepage）、启停持久化（`system_setting` key =
+        `ai.plugins.disabled`，JSON 数组，默认全启用）、`PluginService.isEnabled()` /
+        `getPluginIdForTool()` 查询接口、重扫接口、前端插件广场页
+        （pages/plugin-market，入口在系统管理侧边栏）；示例插件 examples/hello-plugin/。
+  - [ ] **插件启停接入 ToolRegistry**（一次小改动，下次动 ToolRegistry 时顺手完成）：
+        在消费 `pluginService.getToolSpecifications()` / `getPluginTools()` 的三处
+        （构建 specs、列举工具名、按名取执行对象）过滤禁用插件的工具——
+        `String pid = pluginService.getPluginIdForTool(name)`，
+        `pid == null || pluginService.isEnabled(pid)` 才可见（`pid == null` 为内置工具，
+        不受插件启停影响）。`setEnabled()` 已同步更新内存态，ToolRegistry 无自建缓存则即时生效。
+  - [ ] 插件运行时沙箱：按 manifest `permissions`（file_read/file_write/network/editor，
+        v1 仅声明式展示，见 docs/PLUGIN_SPEC.md §3）做运行时强制。
+  - [ ] MCP SDK 标准化、Skill 体系、多智能体协作。

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -1,0 +1,94 @@
+# 插件规范 v1（Plugin Spec v1）
+
+> 适用版本：0.4.x 起。示例插件见 [examples/hello-plugin/](../examples/hello-plugin/)。
+> 后端实现：`PluginService`（扫描/解析/启停）、`PluginController`（HTTP API）；
+> 前端管理页：`frontend/src/pages/plugin-market/plugin-market.vue`（插件广场，入口在系统管理侧边栏）。
+
+## 1. 目录结构
+
+服务端工作目录下的 `plugins/` 目录（可通过配置 `ai.plugins.dir` 覆盖），每个插件一个子目录：
+
+```
+plugins/
+└── hello-plugin/
+    ├── manifest.json          # 必需，插件元数据（本规范核心）
+    └── hello-plugin-1.0.0.jar # 可选，后端工具 JAR（manifest.backendJars 声明）
+```
+
+启动时自动扫描；也可在插件广场点击「重新扫描」或调用 `POST /api/plugins/rescan` 热发现新插件（注意：重扫只能发现新插件/新元数据，已加载进 JVM 的旧类不会被卸载，替换 JAR 需重启后端）。
+
+## 2. manifest.json 字段
+
+```json
+{
+  "id": "hello-plugin",
+  "name": "Hello 示例插件",
+  "version": "1.0.0",
+  "description": "演示插件规范 v1 的最小示例：提供文本回显与字数统计两个 AI 工具。",
+  "icon": "🔌",
+  "author": "AI Workdeck",
+  "homepage": "https://github.com/zeweihan/checkba_cloud",
+  "permissions": ["network"],
+  "tools": [
+    { "name": "helloEcho", "description": "原样回显输入文本，用于验证插件链路" },
+    { "name": "helloWordCount", "description": "统计输入文本的字符数与词数" }
+  ],
+  "frontendEntry": null,
+  "backendJars": ["hello-plugin-1.0.0.jar"]
+}
+```
+
+| 字段 | 类型 | 必需 | 说明 |
+|---|---|---|---|
+| `id` | string | **是** | 全局唯一、稳定的插件标识（kebab-case）。缺失则整个插件被跳过；重复 id 只加载先扫描到的目录。启停状态以 id 为键持久化。 |
+| `name` | string | 是 | 展示名称（中文优先）。 |
+| `version` | string | 是 | 语义化版本，如 `1.0.0`。 |
+| `description` | string | 否 | 一句话描述，展示在插件广场卡片上。 |
+| `icon` | string | 否 | emoji（如 `🔌`）或图片 URL/绝对路径；缺省时前端显示 `🧩`。 |
+| `author` | string | 否 | 作者 / 组织名。 |
+| `homepage` | string | 否 | 主页或仓库 URL。 |
+| `permissions` | string[] | 否 | 声明插件需要的能力，见 §3。缺省视为不需要任何敏感能力。 |
+| `tools` | object[] | 否 | 工具清单（`name` + 中文 `description`），用于插件广场展示与人工审查。`name` 应与 JAR 中 `@Tool` 方法名一致。 |
+| `frontendEntry` | string | 否 | 前端入口（预留，v1 不加载）。 |
+| `backendJars` | string[] | 否 | 相对插件目录的 JAR 文件名列表，启动/重扫时加载其中带 `@Tool` 注解的类。 |
+
+未知字段被忽略（向前兼容）；`permissions` 中出现 v1 未定义的值仅记录 WARN，不拒绝加载。
+
+## 3. permissions 权限声明（v1）
+
+v1 权限为**声明式**：用于插件广场展示与管理员审查，运行时沙箱强制执行在 Phase 3 后续（见 docs/AI_ARCHITECTURE.md TODO）。
+
+| 值 | 含义 |
+|---|---|
+| `file_read` | 读取项目文件内容 |
+| `file_write` | 创建 / 修改 / 删除项目文件 |
+| `network` | 访问外部网络（HTTP 等出站请求） |
+| `editor` | 操作文档编辑器（LOWA/LibreOffice 相关原语） |
+
+## 4. 后端工具（backendJars）约定
+
+- 工具类需有**无参构造函数**，工具方法用 langchain4j 的 `dev.langchain4j.agent.tool.@Tool` 注解（当前宿主版本 **0.36.0**，编译时以 `provided` 作用域依赖 `langchain4j-core`，运行时由宿主提供）。
+- 工具名 = 方法名，全局唯一；与内置工具或其他插件重名时后注册的覆盖先注册的（避免与内置工具重名）。
+- JAR 由独立 `URLClassLoader` 加载（父加载器为应用 ClassLoader），依赖冲突自行规避；无法解析的类会被跳过。
+
+## 5. 启用 / 禁用
+
+- 默认**启用**；禁用名单持久化在 `system_setting` 表（key = `ai.plugins.disabled`，值为插件 id 的 JSON 数组），重启后保持。
+- 查询接口：`PluginService.isEnabled(pluginId)`；工具归属：`PluginService.getPluginIdForTool(toolName)`。
+- v1 范围：启停状态已持久化并在插件广场展示，**ToolRegistry 按启停过滤工具的接入是 Phase 3 后续**（接入点见 docs/AI_ARCHITECTURE.md TODO），即 v1 中禁用插件后其工具暂不会立即从 Agent 可用工具中移除。
+
+## 6. HTTP API
+
+| 方法 | 路径 | 权限 | 说明 |
+|---|---|---|---|
+| GET | `/api/plugins/list` | 登录 | 插件列表：元数据 + `permissions` + `tools` + `toolCount` + `enabled` |
+| POST | `/api/plugins/{id}/enable` | admin | 启用插件 |
+| POST | `/api/plugins/{id}/disable` | admin | 禁用插件 |
+| POST | `/api/plugins/rescan` | admin | 重新扫描 plugins/ 目录，返回 `{ code, pluginCount, toolCount }` |
+
+管理接口鉴权与 AdminConfigController 一致：`X-Session-Id` 请求头 → session 用户名为 `admin`。
+
+## 7. 版本演进
+
+- **v1（当前）**：声明式 manifest + 启停持久化 + 插件广场展示。
+- 规划中（Phase 3 后续，见 AI_ARCHITECTURE.md）：ToolRegistry 按启停/权限过滤、运行时沙箱强制 permissions、frontendEntry 动态加载、插件签名与来源校验。

--- a/examples/hello-plugin/README.md
+++ b/examples/hello-plugin/README.md
@@ -1,0 +1,50 @@
+# hello-plugin 示例插件
+
+插件规范 v1（`docs/PLUGIN_SPEC.md`，本地私有文档目录）的最小可运行示例：
+提供 `helloEcho`（文本回显）与 `helloWordCount`（字数统计）两个 AI 工具。
+
+## 目录
+
+```
+examples/hello-plugin/
+├── manifest.json    # 插件元数据（安装时与 JAR 一起拷贝）
+├── pom.xml          # 独立 Maven 工程（不参与宿主 backend 构建）
+├── README.md
+└── src/main/java/com/example/hello/HelloTools.java
+```
+
+## 构建
+
+需要 JDK 17+ 与 Maven：
+
+```bash
+cd examples/hello-plugin
+mvn -q package
+# 产物：target/hello-plugin-1.0.0.jar
+```
+
+## 安装到 AI Workdeck
+
+把 manifest 和 JAR 拷贝到后端工作目录的 `plugins/hello-plugin/` 下：
+
+```bash
+mkdir -p <后端工作目录>/plugins/hello-plugin
+cp manifest.json target/hello-plugin-1.0.0.jar <后端工作目录>/plugins/hello-plugin/
+```
+
+然后二选一：
+
+1. 重启后端（启动时自动扫描）；
+2. 在「系统管理 → 插件广场」点击「重新扫描」（或 `POST /api/plugins/rescan`，需 admin）。
+
+## 验证
+
+- 插件广场应出现「Hello 示例插件」卡片，含 2 个工具与权限标签（本示例无权限声明）；
+- 在 AI 对话中让 Agent「用 helloEcho 回显 hello world」，应返回 `echo: hello world`。
+
+## 改成自己的插件
+
+1. 换 `manifest.json` 的 `id/name/description/tools`（`id` 全局唯一且稳定，启停状态以它为键）；
+2. 在 `permissions` 中如实声明需要的能力（`file_read` / `file_write` / `network` / `editor`）；
+3. 修改/新增带 `@Tool` 注解的工具类（无参构造、方法名唯一）；
+4. `pom.xml` 的 `artifactId/version` 与 `manifest.json` 的 `backendJars` 文件名保持一致。

--- a/examples/hello-plugin/README.md
+++ b/examples/hello-plugin/README.md
@@ -1,6 +1,6 @@
 # hello-plugin 示例插件
 
-插件规范 v1（`docs/PLUGIN_SPEC.md`，本地私有文档目录）的最小可运行示例：
+插件规范 v1（[docs/PLUGIN_SPEC.md](../../docs/PLUGIN_SPEC.md)）的最小可运行示例：
 提供 `helloEcho`（文本回显）与 `helloWordCount`（字数统计）两个 AI 工具。
 
 ## 目录

--- a/examples/hello-plugin/manifest.json
+++ b/examples/hello-plugin/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "hello-plugin",
+  "name": "Hello 示例插件",
+  "version": "1.0.0",
+  "description": "演示插件规范 v1 的最小示例：提供文本回显与字数统计两个 AI 工具。",
+  "icon": "🔌",
+  "author": "AI Workdeck",
+  "homepage": "https://github.com/zeweihan/checkba_cloud",
+  "permissions": [],
+  "tools": [
+    { "name": "helloEcho", "description": "原样回显输入文本，用于验证插件链路" },
+    { "name": "helloWordCount", "description": "统计输入文本的字符数与词数" }
+  ],
+  "backendJars": ["hello-plugin-1.0.0.jar"]
+}

--- a/examples/hello-plugin/pom.xml
+++ b/examples/hello-plugin/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>hello-plugin</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>hello-plugin</name>
+    <description>AI Workdeck 插件规范 v1 示例插件（见 docs/PLUGIN_SPEC.md）</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- 与宿主 backend/pom.xml 中的 langchain4j 版本保持一致 -->
+        <langchain4j.version>0.36.0</langchain4j.version>
+    </properties>
+
+    <dependencies>
+        <!-- @Tool 注解来自 langchain4j-core；运行时由宿主提供，故 provided -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/hello-plugin/src/main/java/com/example/hello/HelloTools.java
+++ b/examples/hello-plugin/src/main/java/com/example/hello/HelloTools.java
@@ -1,0 +1,29 @@
+package com.example.hello;
+
+import dev.langchain4j.agent.tool.Tool;
+
+/**
+ * 示例插件工具类（插件规范 v1，见 docs/PLUGIN_SPEC.md）。
+ *
+ * 约定：
+ * - 必须有无参构造函数（宿主通过反射实例化）；
+ * - 工具方法用 @Tool 注解，方法名即工具名，需与 manifest.json 的 tools[].name 一致；
+ * - description 用中文写清楚用途，Agent 依赖它决定是否调用。
+ */
+public class HelloTools {
+
+    @Tool("原样回显输入文本，用于验证插件链路是否打通")
+    public String helloEcho(String text) {
+        return "echo: " + (text == null ? "" : text);
+    }
+
+    @Tool("统计输入文本的字符数与词数（按空白分词）")
+    public String helloWordCount(String text) {
+        if (text == null || text.isBlank()) {
+            return "字符数: 0, 词数: 0";
+        }
+        int chars = text.length();
+        int words = text.trim().split("\\s+").length;
+        return "字符数: " + chars + ", 词数: " + words;
+    }
+}

--- a/frontend/src/pages.json
+++ b/frontend/src/pages.json
@@ -43,6 +43,13 @@
 			}
 		},
 		{
+			"path": "pages/plugin-market/plugin-market",
+			"style": {
+				"navigationBarTitleText": "插件广场",
+				"navigationStyle": "custom"
+			}
+		},
+		{
 			"path": "pages/wizard/wizard",
 			"style": {
 				"navigationBarTitleText": "首次运行设置",

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -17,7 +17,7 @@
                   :key="nav.key"
                   class="nav-item"
                   :class="{ active: activeNav === nav.key }"
-                  @tap="activeNav = nav.key"
+                  @tap="onNavTap(nav)"
                 >
                   <text class="nav-text">{{ nav.label }}</text>
                 </view>
@@ -487,6 +487,7 @@ export default {
       navItems: [
         { key: 'config', label: '系统配置' },
         { key: 'ai', label: 'AI 功能设置' },
+        { key: 'plugins', label: '插件广场', route: '/pages/plugin-market/plugin-market' },
         { key: 'users', label: '用户管理' },
       ],
       form: {
@@ -552,6 +553,14 @@ export default {
     },
     goToUserProfile() {
       uni.navigateTo({ url: '/pages/userprofile/userprofile' })
+    },
+    onNavTap(nav) {
+      // 带 route 的导航项跳转独立页面（如插件广场），其余切换本页内容区
+      if (nav.route) {
+        uni.navigateTo({ url: nav.route })
+        return
+      }
+      this.activeNav = nav.key
     },
     async loadConfig() {
       try {

--- a/frontend/src/pages/plugin-market/plugin-market.vue
+++ b/frontend/src/pages/plugin-market/plugin-market.vue
@@ -1,0 +1,343 @@
+<template>
+  <view class="page-plugin-market">
+    <!-- 顶部 -->
+    <view class="header-card">
+      <view class="title-row">
+        <text class="page-title">插件广场</text>
+        <text class="page-subtitle">管理 plugins/ 目录下已安装的插件（规范见 docs/PLUGIN_SPEC.md）</text>
+      </view>
+      <view class="toolbar">
+        <button class="btn" type="primary" size="mini" :disabled="rescanning" @tap="rescan">
+          {{ rescanning ? '扫描中...' : '重新扫描' }}
+        </button>
+        <button class="btn" type="default" size="mini" @tap="goBack">返回</button>
+      </view>
+    </view>
+
+    <!-- 插件列表 -->
+    <scroll-view class="plugin-list" scroll-y="true">
+      <view v-if="loading" class="empty">加载中...</view>
+      <view v-else-if="plugins.length === 0" class="empty">
+        <text>暂无插件</text>
+        <text class="empty-hint">将插件目录（含 manifest.json）放入服务端 plugins/ 目录后，点击"重新扫描"</text>
+      </view>
+      <view v-else>
+        <view v-for="p in plugins" :key="p.id" class="plugin-card" :class="{ disabled: !p.enabled }">
+          <view class="card-header">
+            <image v-if="isImageIcon(p.icon)" :src="p.icon" class="plugin-icon-img" mode="aspectFit" />
+            <text v-else class="plugin-icon">{{ p.icon || '🧩' }}</text>
+            <view class="title-block">
+              <view class="name-row">
+                <text class="plugin-name">{{ p.name || p.id }}</text>
+                <text class="plugin-version" v-if="p.version">v{{ p.version }}</text>
+              </view>
+              <text class="plugin-meta" v-if="p.author">作者：{{ p.author }}</text>
+            </view>
+            <switch
+              class="plugin-switch"
+              :checked="p.enabled"
+              :disabled="switching"
+              @change="onToggle(p, $event)"
+            />
+          </view>
+
+          <text class="plugin-desc">{{ p.description || '暂无描述' }}</text>
+
+          <view class="tag-row">
+            <text class="tool-count-tag">{{ p.toolCount }} 个工具</text>
+            <text
+              v-for="perm in p.permissions"
+              :key="perm"
+              class="perm-tag"
+            >{{ permissionLabel(perm) }}</text>
+          </view>
+
+          <view class="tool-list" v-if="p.tools && p.tools.length">
+            <view v-for="t in p.tools" :key="t.name" class="tool-item">
+              <text class="tool-name">{{ t.name }}</text>
+              <text class="tool-desc">{{ t.description }}</text>
+            </view>
+          </view>
+        </view>
+      </view>
+    </scroll-view>
+  </view>
+</template>
+
+<script>
+import { getPlugins, setPluginEnabled, rescanPlugins } from '@/services/api.js'
+
+const PERMISSION_LABELS = {
+  file_read: '读取文件',
+  file_write: '写入文件',
+  network: '网络访问',
+  editor: '编辑器',
+}
+
+export default {
+  name: 'PluginMarketPage',
+  data() {
+    return {
+      plugins: [],
+      loading: false,
+      switching: false,
+      rescanning: false,
+    }
+  },
+  onLoad() {
+    this.loadPlugins()
+  },
+  methods: {
+    permissionLabel(perm) {
+      return PERMISSION_LABELS[perm] || perm
+    },
+    isImageIcon(icon) {
+      return typeof icon === 'string' && (icon.startsWith('http') || icon.startsWith('/'))
+    },
+    async loadPlugins() {
+      this.loading = true
+      try {
+        const res = await getPlugins()
+        this.plugins = Array.isArray(res) ? res : (res?.data || [])
+      } catch (e) {
+        console.error('加载插件列表失败:', e)
+        uni.showToast({ title: '加载插件列表失败', icon: 'none' })
+      } finally {
+        this.loading = false
+      }
+    },
+    async onToggle(plugin, event) {
+      const enabled = !!(event?.detail?.value)
+      this.switching = true
+      try {
+        await setPluginEnabled(plugin.id, enabled)
+        plugin.enabled = enabled
+        uni.showToast({ title: enabled ? '已启用' : '已禁用', icon: 'none' })
+      } catch (e) {
+        console.error('切换插件状态失败:', e)
+        // 回滚开关显示
+        plugin.enabled = !enabled
+        uni.showToast({ title: e?.message || '操作失败（需要管理员权限）', icon: 'none' })
+        await this.loadPlugins()
+      } finally {
+        this.switching = false
+      }
+    },
+    async rescan() {
+      this.rescanning = true
+      try {
+        const res = await rescanPlugins()
+        uni.showToast({
+          title: `扫描完成：${res?.pluginCount ?? 0} 个插件`,
+          icon: 'none'
+        })
+        await this.loadPlugins()
+      } catch (e) {
+        console.error('重新扫描失败:', e)
+        uni.showToast({ title: e?.message || '扫描失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.rescanning = false
+      }
+    },
+    goBack() {
+      uni.navigateBack({
+        fail: () => {
+          uni.redirectTo({ url: '/pages/admin/admin' })
+        }
+      })
+    },
+  }
+}
+</script>
+
+<style lang="scss">
+.page-plugin-market {
+  min-height: 100vh;
+  padding: 24rpx;
+  background-color: $uni-bg-color-grey;
+  box-sizing: border-box;
+}
+
+.header-card {
+  background-color: $uni-bg-color;
+  border-radius: 16rpx;
+  padding: 16rpx;
+  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.04);
+  box-sizing: border-box;
+  margin-bottom: 16rpx;
+}
+
+.title-row {
+  display: flex;
+  flex-direction: column;
+  row-gap: 4rpx;
+  margin-bottom: 12rpx;
+}
+
+.page-title {
+  font-size: 34rpx;
+  font-weight: 500;
+  color: $uni-color-title;
+}
+
+.page-subtitle {
+  font-size: 24rpx;
+  color: $uni-text-color-grey;
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  column-gap: 12rpx;
+}
+
+.btn {
+  padding: 0 20rpx;
+}
+
+.plugin-list {
+  max-height: calc(100vh - 220rpx);
+}
+
+.empty {
+  padding: 40rpx 20rpx;
+  text-align: center;
+  color: $uni-text-color-grey;
+  font-size: 24rpx;
+  display: flex;
+  flex-direction: column;
+  row-gap: 8rpx;
+}
+
+.empty-hint {
+  font-size: 22rpx;
+}
+
+.plugin-card {
+  background-color: #ffffff;
+  border-radius: 12rpx;
+  border-width: 1rpx;
+  border-style: solid;
+  border-color: $uni-border-color;
+  padding: 16rpx;
+  box-sizing: border-box;
+  margin-bottom: 12rpx;
+
+  &.disabled {
+    opacity: 0.55;
+  }
+}
+
+.card-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  column-gap: 12rpx;
+  margin-bottom: 8rpx;
+}
+
+.plugin-icon {
+  font-size: 48rpx;
+  line-height: 1;
+}
+
+.plugin-icon-img {
+  width: 56rpx;
+  height: 56rpx;
+  border-radius: 8rpx;
+}
+
+.title-block {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  row-gap: 2rpx;
+}
+
+.name-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  column-gap: 8rpx;
+}
+
+.plugin-name {
+  font-size: 30rpx;
+  font-weight: 500;
+  color: $uni-color-title;
+}
+
+.plugin-version {
+  font-size: 22rpx;
+  color: $uni-text-color-grey;
+}
+
+.plugin-meta {
+  font-size: 22rpx;
+  color: $uni-text-color-grey;
+}
+
+.plugin-switch {
+  transform: scale(0.8);
+}
+
+.plugin-desc {
+  font-size: 24rpx;
+  color: $uni-text-color;
+  display: block;
+  margin-bottom: 10rpx;
+}
+
+.tag-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  column-gap: 8rpx;
+  row-gap: 8rpx;
+  margin-bottom: 8rpx;
+}
+
+.tool-count-tag {
+  font-size: 22rpx;
+  padding: 2rpx 12rpx;
+  border-radius: 999rpx;
+  background-color: rgba($uni-color-primary, 0.08);
+  color: $uni-color-primary;
+}
+
+.perm-tag {
+  font-size: 22rpx;
+  padding: 2rpx 12rpx;
+  border-radius: 999rpx;
+  background-color: rgba(#e6a23c, 0.12);
+  color: #b88230;
+}
+
+.tool-list {
+  border-top: 1rpx solid $uni-border-color;
+  padding-top: 8rpx;
+  display: flex;
+  flex-direction: column;
+  row-gap: 4rpx;
+}
+
+.tool-item {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  column-gap: 12rpx;
+}
+
+.tool-name {
+  font-size: 22rpx;
+  font-family: monospace;
+  color: $uni-color-primary;
+  flex-shrink: 0;
+}
+
+.tool-desc {
+  font-size: 22rpx;
+  color: $uni-text-color-grey;
+}
+</style>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -412,6 +412,22 @@ export function getPlugins() {
   });
 }
 
+// 启用 / 禁用插件（仅管理员）
+export function setPluginEnabled(pluginId, enabled) {
+  return request({
+    url: `/api/plugins/${encodeURIComponent(pluginId)}/${enabled ? 'enable' : 'disable'}`,
+    method: 'POST'
+  });
+}
+
+// 重新扫描 plugins/ 目录（仅管理员）
+export function rescanPlugins() {
+  return request({
+    url: '/api/plugins/rescan',
+    method: 'POST'
+  });
+}
+
 /**
  * 将一段 AI 文本（markdown）导出为 Word 文档并落地到项目文件树中（后端生成 docx）
  * payload: { projectId, parentId, fileName, markdown | content }


### PR DESCRIPTION
> ✅ 已按约定完成：Phase 2.5（PR #87）合并后 rebase 到最新 master，全量验证通过。
> 本分支未触碰 ToolRegistry / AgentOrchestrator / WpsTools / system_prompt.md。

## 内容（Phase 3 第 1 项：插件广场 MVP）

### 1. manifest 规范 v1（docs/PLUGIN_SPEC.md，已随本 PR 入库）
- 在原有字段基础上新增 `permissions`（`file_read`/`file_write`/`network`/`editor`，v1 为声明式，运行时沙箱强制在后续）、`tools`（工具名 + 中文描述）、`author`/`homepage`
- 解析收紧：缺 `id` 跳过、重复 `id` 只加载先扫到的目录、未知权限值仅 WARN（向前兼容）
- `examples/hello-plugin/`：可运行示例插件（独立 Maven 工程，`mvn package` 已验证产出 JAR，不参与宿主构建）

### 2. 后端 API（PluginController 25→140 行）
| 接口 | 权限 | 说明 |
|---|---|---|
| `GET /api/plugins/list` | 登录 | 元数据 + 权限 + 工具清单 + `toolCount` + `enabled` |
| `POST /api/plugins/{id}/enable` / `disable` | admin | 持久化到 `system_setting`（key=`ai.plugins.disabled`，JSON 数组，默认全启用） |
| `POST /api/plugins/rescan` | admin | 重扫 plugins/ 目录 |

- `PluginService.isEnabled(pluginId)` + `getPluginIdForTool(toolName)` 已就位，供将来 ToolRegistry 过滤禁用插件的工具；**本 PR 未改 ToolRegistry**，接入点（三处消费点 + 过滤条件代码）已登记在 `docs/AI_ARCHITECTURE.md` Phase 3 路线图 TODO
- `PluginService` 保留无参兼容构造器：master 上 `ToolRegistryTest`/`XmlToolCallParserTest` 及 Phase 2.5 新增的评测基建（`EvalHarness`/`RealLlmSmokeTest`）共 5 处直接 `new PluginService()`

### 3. 前端插件广场
- 新增 `pages/plugin-market/plugin-market.vue`：卡片列表（图标/名称/版本/作者/描述/工具数/权限中文标签/启停开关）+ 重新扫描按钮，风格对齐现有 admin 页
- 系统管理侧边栏新增「插件广场」导航入口

### 4. 测试与验证（rebase 到 f0eb0e7 之后复跑）
- `PluginServiceTest` 11 例：manifest 解析（完整/最小/缺 id/坏 JSON/重复 id/未知权限）+ 启停（往返持久化/重启恢复/未知插件抛错/名单损坏降级）+ 重扫
- `mvn test`（JDK 21）：**138 例全绿**（1 例真实 LLM 冒烟按设计跳过）
- `npm run build:h5`：**通过**
- 示例插件 `mvn package`：**通过**

## 已知边界（MVP 范围内）
- 禁用插件后其工具暂不会从 Agent 可用工具中移除（等 ToolRegistry 接入，见 AI_ARCHITECTURE.md TODO）
- rescan 只能发现新插件/新元数据，旧 JAR 类不卸载（换 JAR 需重启）

🤖 Generated with [Claude Code](https://claude.com/claude-code)