### PR TITLE
test(ai): AI 编排器回归评测基建——离线回放 + 真实 LLM 冒烟 / orchestrator regression eval infra

### DIFF
--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalCase.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalCase.java
@@ -1,0 +1,145 @@
+package com.checkba.service.ai.eval;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * 离线评测用例模型（见 docs/AI_EVAL.md）。
+ *
+ * 每个用例描述：给定用户输入 + 预录的模型输出（turns），
+ * 编排器应当产生怎样的工具分发序列与输出结构（expect）。
+ * 用例存放在 src/test/resources/ai-eval/cases/*.json（每个文件是一个用例数组）。
+ */
+public class EvalCase {
+
+    /** 唯一 ID，用作测试名 */
+    public String id;
+    /** 人类可读标题 */
+    public String title;
+    /** 分类：drafting / revision / legal-research / pptx / chat / memory / files / artifacts */
+    public String category;
+    /** 协议标注（仅文档用途）：xml / native / mixed */
+    public String protocol;
+    /** Agent 模式：AGENT（默认）/ PLAN / ASK */
+    public String mode = "AGENT";
+    /** 用户输入 */
+    public String userInput;
+    /** 非 null 时该用例进入真实 LLM 冒烟集（RealLlmSmokeTest） */
+    public Smoke smoke;
+    /** 预录的模型输出，按轮次回放 */
+    public List<Turn> turns = new ArrayList<>();
+    /** 工具桩输出：resolvedName -> 回放给模型的工具输出（缺省 "OK (eval stub)"） */
+    public Map<String, String> toolStubs = new HashMap<>();
+    /** 断言 */
+    public Expect expect = new Expect();
+
+    /** 一轮预录模型输出：text（XML 协议整段文本）或 toolCalls（原生 function calling），二选一 */
+    public static class Turn {
+        public String text;
+        public List<NativeCall> toolCalls;
+    }
+
+    /** 一次原生 function calling 请求 */
+    public static class NativeCall {
+        public String name;
+        public Map<String, Object> arguments = new HashMap<>();
+    }
+
+    /** 真实 LLM 冒烟断言：首个工具调用应属于集合（空集合 = 期望不调用任何工具） */
+    public static class Smoke {
+        public List<String> anyOfFirstTools = new ArrayList<>();
+    }
+
+    public static class Expect {
+        /**
+         * 期望的工具分发序列（按顺序逐个匹配 resolvedName）。
+         * null = 不断言工具序列；[] = 断言没有任何工具调用。
+         */
+        public List<ExpectedToolCall> toolCalls;
+        /** 最终保存的 ASSISTANT 消息应包含的子串（输出结构标签断言） */
+        public List<String> structureContains = new ArrayList<>();
+        /** 期望保存的 artifact（null = 不断言） */
+        public Artifact artifact;
+        /** 最后一个 bubble_end 事件的 status：finished / awaiting_approval */
+        public String bubbleEndStatus = "finished";
+        /** 每次 LLM 调用是否携带工具规格（null = 不断言；ASK 模式应为 false） */
+        public Boolean toolsOffered;
+        /** 会话文件夹重命名（<title> 协议）应包含的子串（null = 不断言） */
+        public String renamedTitleContains;
+    }
+
+    /** artifact 落盘断言 */
+    public static class Artifact {
+        /** 类型标注（文档用途）：task_list / implementation_plan */
+        public String type;
+        /** saveArtifactFile 收到的文件名应包含的子串 */
+        public String filenameContains;
+    }
+
+    public static class ExpectedToolCall {
+        /** 期望的工具名（别名解析后，如 search_laws -> search_web） */
+        public String name;
+        /** 参数断言：JSON 参数中 key 对应值（String.valueOf）应包含的子串 */
+        public Map<String, String> argsContain = new HashMap<>();
+    }
+
+    /** 加载全部用例（文件名排序，校验 id 唯一） */
+    public static List<EvalCase> loadAll() {
+        Path dir = casesDir();
+        ObjectMapper mapper = new ObjectMapper();
+        List<EvalCase> cases = new ArrayList<>();
+        try (Stream<Path> files = Files.list(dir)) {
+            for (Path p : files.filter(f -> f.getFileName().toString().endsWith(".json")).sorted().toList()) {
+                try {
+                    cases.addAll(mapper.readValue(p.toFile(), new TypeReference<List<EvalCase>>() {
+                    }));
+                } catch (IOException e) {
+                    throw new IllegalStateException("评测用例文件解析失败: " + p, e);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        if (cases.isEmpty()) {
+            throw new IllegalStateException("在 " + dir + " 中没有找到任何评测用例");
+        }
+        Set<String> ids = new HashSet<>();
+        for (EvalCase c : cases) {
+            if (c.id == null || c.id.isBlank()) {
+                throw new IllegalStateException("存在缺少 id 的评测用例（title=" + c.title + "）");
+            }
+            if (!ids.add(c.id)) {
+                throw new IllegalStateException("评测用例 id 重复: " + c.id);
+            }
+            if (c.userInput == null || c.turns.isEmpty()) {
+                throw new IllegalStateException("用例 " + c.id + " 缺少 userInput 或 turns");
+            }
+        }
+        return cases;
+    }
+
+    static Path casesDir() {
+        for (String candidate : List.of(
+                "src/test/resources/ai-eval/cases",
+                "backend/src/test/resources/ai-eval/cases")) {
+            Path p = Path.of(candidate);
+            if (Files.isDirectory(p)) {
+                return p;
+            }
+        }
+        throw new IllegalStateException(
+                "找不到 ai-eval 用例目录（期望 src/test/resources/ai-eval/cases，工作目录应为 backend/）");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
@@ -1,0 +1,157 @@
+package com.checkba.service.ai.eval;
+
+import com.checkba.controller.ai.AiAgentController;
+import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.AgentOrchestrator;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.ContextAssemblerService;
+import com.checkba.service.ai.ConversationFileChangeService;
+import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.SseEmitterService;
+import com.checkba.service.ai.TokenUsageService;
+import com.checkba.service.ai.WpsActionService;
+import com.checkba.service.ai.XmlToolCallParser;
+import com.checkba.service.ai.memory.MemoryPipelineService;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 回放评测 harness：
+ * 用「真实的 AgentOrchestrator + 真实的 ToolRegistry/XmlToolCallParser（分发被记录、不真执行）+
+ * 回放式 LLM（ScriptedStreamingModel）+ Mockito 打桩的外围服务」跑一个用例，
+ * 收集编排器产生的所有可观测行为供断言。
+ *
+ * 覆盖的真实生产代码路径：
+ * AgentOrchestrator.handleUserMessage / runLoop（含 XML 与原生两种工具协议、artifact、
+ * &lt;title&gt;、Ask 模式）、XmlToolCallParser 全部解析逻辑、ToolRegistry 的别名解析。
+ */
+public final class EvalHarness {
+
+    private EvalHarness() {
+    }
+
+    public record SseEvent(String event, String data) {
+    }
+
+    public record SavedMessage(String role, String content) {
+    }
+
+    public record ArtifactSave(String filename, String content) {
+    }
+
+    public record RunResult(
+            EvalCase evalCase,
+            List<RecordingToolRegistry.Dispatch> dispatches,
+            List<SseEvent> sseEvents,
+            List<SavedMessage> savedMessages,
+            List<ArtifactSave> artifactSaves,
+            List<String> folderRenames,
+            List<Boolean> toolsOfferedPerLlmCall,
+            int remainingScriptTurns) {
+
+        /** 最终保存的 ASSISTANT 消息（含 executionLog 前缀） */
+        public Optional<String> lastAssistantMessage() {
+            for (int i = savedMessages.size() - 1; i >= 0; i--) {
+                if ("ASSISTANT".equals(savedMessages.get(i).role())) {
+                    return Optional.of(savedMessages.get(i).content());
+                }
+            }
+            return Optional.empty();
+        }
+
+        public List<SseEvent> events(String name) {
+            return sseEvents.stream().filter(e -> name.equals(e.event())).toList();
+        }
+
+        public List<SseEvent> errorEvents() {
+            return events("error");
+        }
+    }
+
+    /** 同步跑一个用例（handleUserMessage 直接调用，不经 Spring 代理，@Async 不生效） */
+    public static RunResult run(EvalCase c) {
+        RecordingToolRegistry registry =
+                new RecordingToolRegistry(RealToolBeans.instantiateAll(), new PluginService());
+        registry.init();
+        registry.setStubs(c.toolStubs);
+        XmlToolCallParser parser = new XmlToolCallParser(registry);
+        ScriptedStreamingModel scripted = new ScriptedStreamingModel(c.turns);
+
+        ChatModelFactory chatModelFactory = mock(ChatModelFactory.class);
+        when(chatModelFactory.getStreamingChatModel(any())).thenReturn(scripted);
+
+        List<SavedMessage> savedMessages = new CopyOnWriteArrayList<>();
+        ProjectAiMessageService messageService = mock(ProjectAiMessageService.class);
+        doAnswer(inv -> {
+            savedMessages.add(new SavedMessage(inv.getArgument(3), inv.getArgument(4)));
+            return null;
+        }).when(messageService).saveMessage(any(), any(), any(), any(), any());
+        // 返回 2 条历史消息，跳过「首次对话异步生成标题」分支（评测不关心该路径）
+        when(messageService.listByConversationId(any()))
+                .thenReturn(List.of(mock(ProjectAiMessage.class), mock(ProjectAiMessage.class)));
+
+        List<SseEvent> sseEvents = new CopyOnWriteArrayList<>();
+        SseEmitterService sse = mock(SseEmitterService.class);
+        doAnswer(inv -> {
+            sseEvents.add(new SseEvent(inv.getArgument(1), String.valueOf((Object) inv.getArgument(2))));
+            return null;
+        }).when(sse).send(any(), any(), any());
+
+        TokenUsageService tokenUsage = mock(TokenUsageService.class);
+
+        ContextAssemblerService assembler = mock(ContextAssemblerService.class);
+        when(assembler.assemble(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenAnswer(inv -> new ArrayList<>(List.of(
+                        SystemMessage.from("[eval] system prompt placeholder"),
+                        UserMessage.from(c.userInput))));
+
+        MemoryPipelineService memoryPipeline = mock(MemoryPipelineService.class);
+
+        List<ArtifactSave> artifactSaves = new CopyOnWriteArrayList<>();
+        List<String> folderRenames = new CopyOnWriteArrayList<>();
+        ProjectFileService projectFileService = mock(ProjectFileService.class);
+        when(projectFileService.saveArtifactFile(any(), any(), any(), any(), any()))
+                .thenAnswer(inv -> {
+                    artifactSaves.add(new ArtifactSave(inv.getArgument(2), inv.getArgument(3)));
+                    return null;
+                });
+        doAnswer(inv -> {
+            folderRenames.add(inv.getArgument(1));
+            return null;
+        }).when(projectFileService).renameConversationFolder(any(), any(), any());
+
+        WpsActionService wps = mock(WpsActionService.class);
+        when(wps.isStreamingMode(any())).thenReturn(false);
+
+        ConversationFileChangeService fileChange = mock(ConversationFileChangeService.class);
+
+        AgentOrchestrator orchestrator = new AgentOrchestrator(
+                chatModelFactory, messageService, sse, tokenUsage, assembler,
+                registry, parser, memoryPipeline, projectFileService, wps, fileChange);
+
+        AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
+        request.setProjectId(1L);
+        request.setConversationId("eval-" + c.id);
+        request.setMessage(c.userInput);
+        request.setModel("anthropic/claude-3.5-sonnet");
+        request.setMode(c.mode);
+
+        orchestrator.handleUserMessage(request, 7L);
+
+        return new RunResult(c, registry.dispatches(), List.copyOf(sseEvents), List.copyOf(savedMessages),
+                List.copyOf(artifactSaves), List.copyOf(folderRenames),
+                scripted.toolsOfferedPerCall(), scripted.remainingTurns());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/OrchestratorReplayEvalTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/OrchestratorReplayEvalTest.java
@@ -1,0 +1,136 @@
+package com.checkba.service.ai.eval;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * AI 编排器回归评测（离线回放，不调真实 LLM，进默认 mvn test 套件）。
+ *
+ * 对 src/test/resources/ai-eval/cases/*.json 中的每个用例：
+ * 回放预录的模型输出（XML tool_code 与原生 function calling 两种协议），
+ * 断言编排器分发给 ToolRegistry 的工具序列、输出结构标签、artifact 与
+ * 会话收尾行为与期望一致。用法与失败解读见 docs/AI_EVAL.md。
+ */
+@DisplayName("AI 编排器回归评测（回放）")
+class OrchestratorReplayEvalTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TestFactory
+    Stream<DynamicTest> replayCases() {
+        List<EvalCase> cases = EvalCase.loadAll();
+        assertTrue(cases.size() >= 15, "评测集应至少包含 15 个用例，当前 " + cases.size());
+        return cases.stream().map(c ->
+                DynamicTest.dynamicTest("[" + c.category + "] " + c.id + " — " + c.title,
+                        () -> runAndAssert(c)));
+    }
+
+    private void runAndAssert(EvalCase c) {
+        EvalHarness.RunResult r = EvalHarness.run(c);
+
+        // 0. 回放脚本应恰好消费完；不应出现 SSE error 事件
+        assertEquals(0, r.remainingScriptTurns(),
+                "编排器请求的 LLM 轮次少于用例预录轮次（脚本剩余 " + r.remainingScriptTurns() + " 轮）");
+        assertTrue(r.errorEvents().isEmpty(), "不应有 SSE error 事件: " + r.errorEvents());
+
+        // 1. 工具分发序列
+        if (c.expect.toolCalls != null) {
+            List<RecordingToolRegistry.Dispatch> actual = r.dispatches();
+            assertEquals(c.expect.toolCalls.size(), actual.size(),
+                    "工具调用数量不符。实际分发序列: " + describe(actual));
+            for (int i = 0; i < actual.size(); i++) {
+                EvalCase.ExpectedToolCall expected = c.expect.toolCalls.get(i);
+                RecordingToolRegistry.Dispatch d = actual.get(i);
+                assertEquals(expected.name, d.resolvedName(),
+                        "第 " + (i + 1) + " 个工具调用名不符（raw=" + d.rawName() + "）。实际序列: " + describe(actual));
+                assertArgsContain(expected, d, i);
+            }
+        }
+
+        // 2. 输出结构标签：最终保存的 ASSISTANT 消息
+        if (!c.expect.structureContains.isEmpty()) {
+            String last = r.lastAssistantMessage().orElse(null);
+            assertTrue(last != null, "期望保存 ASSISTANT 消息但一条都没有");
+            for (String marker : c.expect.structureContains) {
+                assertTrue(last.contains(marker),
+                        "最终 ASSISTANT 消息缺少结构标签 [" + marker + "]。实际内容:\n" + last);
+            }
+        }
+
+        // 3. artifact 落盘
+        if (c.expect.artifact != null) {
+            assertFalse(r.artifactSaves().isEmpty(), "期望保存 artifact 但 saveArtifactFile 未被调用");
+            if (c.expect.artifact.filenameContains != null) {
+                assertTrue(r.artifactSaves().stream()
+                                .anyMatch(a -> a.filename().contains(c.expect.artifact.filenameContains)),
+                        "artifact 文件名应包含 [" + c.expect.artifact.filenameContains + "]，实际: "
+                                + r.artifactSaves().stream().map(EvalHarness.ArtifactSave::filename).toList());
+            }
+        }
+
+        // 4. 会话收尾：最后一个 bubble_end 的 status
+        List<EvalHarness.SseEvent> ends = r.events("bubble_end");
+        assertFalse(ends.isEmpty(), "未收到 bubble_end 事件，会话没有正常收尾");
+        String lastEnd = ends.get(ends.size() - 1).data();
+        assertTrue(lastEnd.contains(c.expect.bubbleEndStatus),
+                "bubble_end status 应为 [" + c.expect.bubbleEndStatus + "]，实际: " + lastEnd);
+
+        // 5. 是否向 LLM 提供工具规格（ASK 模式应为 false）
+        if (c.expect.toolsOffered != null) {
+            for (int i = 0; i < r.toolsOfferedPerLlmCall().size(); i++) {
+                assertEquals(c.expect.toolsOffered, r.toolsOfferedPerLlmCall().get(i),
+                        "第 " + (i + 1) + " 次 LLM 调用的 toolsOffered 不符（ASK 模式不应携带工具）");
+            }
+        }
+
+        // 6. <title> 协议：会话文件夹重命名
+        if (c.expect.renamedTitleContains != null) {
+            assertTrue(r.folderRenames().stream().anyMatch(t -> t.contains(c.expect.renamedTitleContains)),
+                    "期望会话重命名包含 [" + c.expect.renamedTitleContains + "]，实际: " + r.folderRenames());
+        }
+    }
+
+    private void assertArgsContain(EvalCase.ExpectedToolCall expected,
+                                   RecordingToolRegistry.Dispatch d, int index) {
+        if (expected.argsContain.isEmpty()) {
+            return;
+        }
+        Map<String, Object> args;
+        try {
+            args = MAPPER.readValue(
+                    (d.argsJson() == null || d.argsJson().isBlank()) ? "{}" : d.argsJson(),
+                    new TypeReference<Map<String, Object>>() {
+                    });
+        } catch (Exception e) {
+            throw new AssertionError("第 " + (index + 1) + " 个工具调用参数不是合法 JSON: " + d.argsJson(), e);
+        }
+        for (Map.Entry<String, String> entry : expected.argsContain.entrySet()) {
+            Object actual = args.get(entry.getKey());
+            assertTrue(actual != null && String.valueOf(actual).contains(entry.getValue()),
+                    "第 " + (index + 1) + " 个工具调用 [" + d.resolvedName() + "] 参数 "
+                            + entry.getKey() + " 应包含 [" + entry.getValue() + "]，实际参数: " + d.argsJson());
+        }
+    }
+
+    private String describe(List<RecordingToolRegistry.Dispatch> dispatches) {
+        if (dispatches.isEmpty()) {
+            return "(无工具调用)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (RecordingToolRegistry.Dispatch d : dispatches) {
+            sb.append("\n  - ").append(d.resolvedName()).append(" args=").append(d.argsJson());
+        }
+        return sb.toString();
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealLlmSmokeTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealLlmSmokeTest.java
@@ -1,0 +1,133 @@
+package com.checkba.service.ai.eval;
+
+import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.ToolRegistry;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 真实 LLM 冒烟评测（默认跳过；设置 OPENROUTER_API_KEY 环境变量后启用）。
+ *
+ * 只跑标注了 "smoke" 的最关键用例（约 3 个）：把真实的工具规格
+ * （来自生产工具类）+ 精简系统提示词发给 OpenRouter 上的真实模型，
+ * 断言模型的首个工具选择落在期望集合内（闲聊用例断言不调工具）。
+ *
+ * 可选环境变量：
+ * - OPENROUTER_BASE_URL   默认 https://openrouter.ai/api/v1
+ * - AI_EVAL_SMOKE_MODEL   默认 google/gemini-2.5-flash
+ *
+ * 运行：OPENROUTER_API_KEY=sk-or-... mvn test -Dtest=RealLlmSmokeTest
+ */
+@DisplayName("AI 编排器冒烟评测（真实 LLM，默认跳过）")
+@EnabledIfEnvironmentVariable(named = "OPENROUTER_API_KEY", matches = ".+")
+class RealLlmSmokeTest {
+
+    @TestFactory
+    Stream<DynamicTest> smokeCases() {
+        List<EvalCase> smokeCases = EvalCase.loadAll().stream()
+                .filter(c -> c.smoke != null)
+                .toList();
+        assertFalse(smokeCases.isEmpty(), "没有任何用例标注 smoke 字段");
+
+        ChatLanguageModel model = OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENROUTER_API_KEY"))
+                .baseUrl(envOr("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"))
+                .modelName(envOr("AI_EVAL_SMOKE_MODEL", "google/gemini-2.5-flash"))
+                .temperature(0.0)
+                .timeout(Duration.ofSeconds(120))
+                .build();
+
+        ToolRegistry registry = new RecordingToolRegistry(RealToolBeans.instantiateAll(), new PluginService());
+        registry.init();
+        List<ToolSpecification> specs = registry.getAllSpecifications();
+        String systemPrompt = loadSmokePrompt();
+
+        return smokeCases.stream().map(c ->
+                DynamicTest.dynamicTest("[smoke] " + c.id + " — " + c.title,
+                        () -> assertSmoke(model, specs, systemPrompt, c)));
+    }
+
+    private void assertSmoke(ChatLanguageModel model, List<ToolSpecification> specs,
+                             String systemPrompt, EvalCase c) {
+        List<ChatMessage> messages = List.of(
+                SystemMessage.from(systemPrompt),
+                UserMessage.from(c.userInput));
+        Response<AiMessage> response = model.generate(messages, specs);
+        AiMessage message = response.content();
+
+        Set<String> allowed = new HashSet<>();
+        for (String name : c.smoke.anyOfFirstTools) {
+            allowed.add(ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(name, name));
+        }
+
+        if (allowed.isEmpty()) {
+            // 闲聊用例：不应发起任何工具调用
+            assertFalse(message.hasToolExecutionRequests(),
+                    "闲聊用例不应调用工具，实际: " + describe(message));
+            String text = message.text() == null ? "" : message.text();
+            assertFalse(text.contains("<tool_code>"),
+                    "闲聊用例不应输出 XML 工具调用，实际文本:\n" + text);
+            return;
+        }
+
+        if (message.hasToolExecutionRequests()) {
+            String firstTool = message.toolExecutionRequests().get(0).name();
+            String resolved = ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(firstTool, firstTool);
+            assertTrue(allowed.contains(resolved),
+                    "首个工具应属于 " + allowed + "，实际: " + describe(message));
+        } else {
+            // 部分模型会退化到 XML 协议：文本里应出现期望工具名之一
+            String text = message.text() == null ? "" : message.text();
+            assertTrue(allowed.stream().anyMatch(text::contains),
+                    "模型既未发起原生工具调用，文本中也没有期望工具 " + allowed + "。实际文本:\n" + text);
+        }
+    }
+
+    private String describe(AiMessage message) {
+        if (message.hasToolExecutionRequests()) {
+            return message.toolExecutionRequests().stream()
+                    .map(ToolExecutionRequest::name)
+                    .toList()
+                    .toString();
+        }
+        return "text: " + message.text();
+    }
+
+    private static String envOr(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return (value == null || value.isBlank()) ? defaultValue : value;
+    }
+
+    private static String loadSmokePrompt() {
+        Path path = EvalCase.casesDir().getParent().resolve("smoke-system-prompt.txt");
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -1,0 +1,81 @@
+package com.checkba.service.ai.eval;
+
+import com.checkba.service.ai.tools.AgentToolComponent;
+import com.checkba.service.ai.tools.FileTools;
+import com.checkba.service.ai.tools.LegalTools;
+import com.checkba.service.ai.tools.MemoryTools;
+import com.checkba.service.ai.tools.PptxEditTools;
+import com.checkba.service.ai.tools.PptxTools;
+import com.checkba.service.ai.tools.PythonTools;
+import com.checkba.service.ai.tools.WebTools;
+import com.checkba.service.ai.tools.WpsTools;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 以「空依赖」反射实例化全部生产工具组件。
+ *
+ * 目的：让评测用的 ToolRegistry 注册的是真实的工具名与参数名——
+ * 若重构改了工具名/参数名/别名，评测会立刻失败（这正是回归信号）。
+ *
+ * 安全性：评测中 {@link RecordingToolRegistry} 只记录分发、从不 invoke 工具方法，
+ * 因此构造参数全部传 null 不会触发任何 NPE。
+ */
+final class RealToolBeans {
+
+    private RealToolBeans() {
+    }
+
+    /** 与生产 Spring 容器中注册的 AgentToolComponent 集合保持一致 */
+    static List<AgentToolComponent> instantiateAll() {
+        List<Class<? extends AgentToolComponent>> toolClasses = List.of(
+                FileTools.class,
+                LegalTools.class,
+                MemoryTools.class,
+                PptxEditTools.class,
+                PptxTools.class,
+                PythonTools.class,
+                WebTools.class,
+                WpsTools.class);
+        List<AgentToolComponent> beans = new ArrayList<>();
+        for (Class<? extends AgentToolComponent> type : toolClasses) {
+            beans.add(instantiate(type));
+        }
+        return beans;
+    }
+
+    private static AgentToolComponent instantiate(Class<? extends AgentToolComponent> type) {
+        Constructor<?> ctor = Arrays.stream(type.getDeclaredConstructors())
+                .max(Comparator.comparingInt(Constructor::getParameterCount))
+                .orElseThrow(() -> new IllegalStateException(type.getSimpleName() + " 没有可用构造函数"));
+        Class<?>[] paramTypes = ctor.getParameterTypes();
+        Object[] args = new Object[paramTypes.length];
+        for (int i = 0; i < paramTypes.length; i++) {
+            args[i] = defaultValue(paramTypes[i]);
+        }
+        try {
+            ctor.setAccessible(true);
+            return (AgentToolComponent) ctor.newInstance(args);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("无法实例化工具组件 " + type.getSimpleName(), e);
+        }
+    }
+
+    private static Object defaultValue(Class<?> t) {
+        if (!t.isPrimitive()) {
+            return null;
+        }
+        if (t == boolean.class) return Boolean.FALSE;
+        if (t == char.class) return '\0';
+        if (t == byte.class) return (byte) 0;
+        if (t == short.class) return (short) 0;
+        if (t == int.class) return 0;
+        if (t == long.class) return 0L;
+        if (t == float.class) return 0f;
+        return 0d;
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/RecordingToolRegistry.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RecordingToolRegistry.java
@@ -1,0 +1,54 @@
+package com.checkba.service.ai.eval;
+
+import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.tools.AgentToolComponent;
+import com.checkba.service.ai.tools.ToolContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 记录型 ToolRegistry：注册真实工具（真实工具名/参数名/别名），
+ * 但 execute 只记录分发序列并返回桩输出，从不真正执行工具方法。
+ *
+ * 这样断言的是「编排器 → 注册表」这条边界上的行为：
+ * 给定回放的模型输出，编排器应当分发出怎样的 (toolName, argsJson) 序列。
+ */
+public class RecordingToolRegistry extends ToolRegistry {
+
+    /** 一次分发记录。resolvedName 是别名解析后的工具名（如 search_laws -> search_web） */
+    public record Dispatch(String rawName, String resolvedName, String argsJson) {
+    }
+
+    private final List<Dispatch> dispatches = new ArrayList<>();
+    private Map<String, String> stubs = Map.of();
+
+    public RecordingToolRegistry(List<AgentToolComponent> components, PluginService pluginService) {
+        super(components, pluginService);
+    }
+
+    /** 设置工具桩输出（key = 别名解析后的工具名） */
+    public void setStubs(Map<String, String> stubs) {
+        this.stubs = stubs == null ? Map.of() : stubs;
+    }
+
+    public List<Dispatch> dispatches() {
+        return List.copyOf(dispatches);
+    }
+
+    @Override
+    public ToolResult execute(String name, String argsJson, ToolContext ctx) {
+        String resolved = TOOL_NAME_ALIASES.getOrDefault(name, name);
+        dispatches.add(new Dispatch(name, resolved, argsJson));
+        Optional<RegisteredTool> tool = resolve(resolved);
+        if (tool.isEmpty()) {
+            // 与生产行为一致：未注册工具返回 found=false
+            return new ToolResult("Tool not found or arguments invalid.", null, false);
+        }
+        String output = stubs.getOrDefault(resolved, "OK (eval stub)");
+        return new ToolResult(output, tool.get(), true);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/ScriptedStreamingModel.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/ScriptedStreamingModel.java
@@ -1,0 +1,91 @@
+package com.checkba.service.ai.eval;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 回放式流式模型：不访问任何真实 LLM，按用例中预录的 turns 逐轮回放。
+ *
+ * - text 轮：以单个 token 回放整段文本（XML 协议路径）；
+ * - toolCalls 轮：回放原生 function calling 请求（native 协议路径）。
+ *
+ * 若编排器请求的轮数超过脚本长度，抛异常（说明编排器行为发生了变化）。
+ */
+public class ScriptedStreamingModel implements StreamingChatLanguageModel {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Deque<EvalCase.Turn> remaining;
+    private final List<Boolean> toolsOfferedPerCall = new ArrayList<>();
+
+    public ScriptedStreamingModel(List<EvalCase.Turn> turns) {
+        this.remaining = new ArrayDeque<>(turns);
+    }
+
+    /** 每次 LLM 调用是否携带了工具规格（ASK 模式应全为 false） */
+    public List<Boolean> toolsOfferedPerCall() {
+        return List.copyOf(toolsOfferedPerCall);
+    }
+
+    /** 剩余未消费的脚本轮数（用例结束后应为 0） */
+    public int remainingTurns() {
+        return remaining.size();
+    }
+
+    @Override
+    public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+        serve(false, handler);
+    }
+
+    @Override
+    public void generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications,
+                         StreamingResponseHandler<AiMessage> handler) {
+        serve(true, handler);
+    }
+
+    private void serve(boolean toolsOffered, StreamingResponseHandler<AiMessage> handler) {
+        toolsOfferedPerCall.add(toolsOffered);
+        EvalCase.Turn turn = remaining.poll();
+        if (turn == null) {
+            throw new IllegalStateException(
+                    "回放脚本已耗尽：编排器请求了比用例预录更多的 LLM 轮次（第 "
+                            + (toolsOfferedPerCall.size()) + " 轮）");
+        }
+        if (turn.toolCalls != null && !turn.toolCalls.isEmpty()) {
+            List<ToolExecutionRequest> requests = new ArrayList<>();
+            for (EvalCase.NativeCall call : turn.toolCalls) {
+                requests.add(ToolExecutionRequest.builder()
+                        .id(UUID.randomUUID().toString())
+                        .name(call.name)
+                        .arguments(toJson(call.arguments))
+                        .build());
+            }
+            handler.onComplete(Response.from(AiMessage.from(requests)));
+        } else {
+            String text = (turn.text == null || turn.text.isEmpty()) ? " " : turn.text;
+            handler.onNext(text);
+            handler.onComplete(Response.from(AiMessage.from(text)));
+        }
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value == null ? java.util.Map.of() : value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("无法序列化 native toolCall 参数", e);
+        }
+    }
+}

--- a/backend/src/test/resources/ai-eval/cases/cases-artifacts.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-artifacts.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "task-list-artifact-saved",
+    "title": "任务清单 artifact 落盘且循环正常结束",
+    "category": "artifacts",
+    "protocol": "xml",
+    "userInput": "帮我列一个对目标公司做法律尽调的任务清单",
+    "turns": [
+      {
+        "text": "<artifact type=\"task_list\" name=\"尽调任务清单\">1. 收集目标公司章程与历次修订\n2. 核查股权结构与出资情况\n3. 梳理重大合同与对外担保\n4. 核查诉讼仲裁与行政处罚\n5. 排查劳动用工与社保合规</artifact>\n<final>已为您生成《尽调任务清单》，共 5 项，已保存到本会话的 AI 文件夹。</final>"
+      }
+    ],
+    "expect": {
+      "toolCalls": [],
+      "structureContains": ["<artifact", "<final>"],
+      "artifact": { "type": "task_list", "filenameContains": "尽调任务清单" },
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "implementation-plan-awaits-approval",
+    "title": "PLAN 模式实施计划 artifact：停循环等待用户审批",
+    "category": "artifacts",
+    "protocol": "xml",
+    "mode": "PLAN",
+    "userInput": "给我一个并购重组项目的整体实施计划",
+    "turns": [
+      {
+        "text": "<artifact type=\"implementation_plan\" name=\"并购重组实施计划\">阶段一：尽职调查（4周）\n阶段二：交易架构设计与税务筹划（2周）\n阶段三：协议起草与谈判（3周）\n阶段四：交割与工商变更（2周）</artifact>"
+      }
+    ],
+    "expect": {
+      "toolCalls": [],
+      "structureContains": ["<artifact"],
+      "artifact": { "type": "implementation_plan", "filenameContains": "并购重组实施计划" },
+      "bubbleEndStatus": "awaiting_approval"
+    }
+  },
+  {
+    "id": "title-tag-renames-conversation",
+    "title": "<title> 协议触发会话文件夹重命名",
+    "category": "artifacts",
+    "protocol": "xml",
+    "userInput": "这轮我们主要在审股权转让协议，把会话改个合适的名字",
+    "turns": [
+      {
+        "text": "<title>股权转让协议审查</title>\n<final>好的，已把本会话命名为「股权转让协议审查」。</final>"
+      }
+    ],
+    "expect": {
+      "toolCalls": [],
+      "structureContains": ["<final>"],
+      "bubbleEndStatus": "finished",
+      "renamedTitleContains": "股权转让协议审查"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-chat.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-chat.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "chitchat-no-tools-xml",
+    "title": "闲聊问候不触发任何工具",
+    "category": "chat",
+    "protocol": "xml",
+    "userInput": "你好呀，今天过得怎么样？",
+    "smoke": { "anyOfFirstTools": [] },
+    "turns": [
+      {
+        "text": "<final>你好！我随时在线，状态很好。今天有什么合同、法条或者文档需要我帮忙处理吗？</final>"
+      }
+    ],
+    "expect": {
+      "toolCalls": [],
+      "structureContains": ["<final>"],
+      "bubbleEndStatus": "finished",
+      "toolsOffered": true
+    }
+  },
+  {
+    "id": "ask-mode-consultation-no-tools",
+    "title": "ASK 模式纯咨询：不向 LLM 提供工具规格",
+    "category": "chat",
+    "protocol": "xml",
+    "mode": "ASK",
+    "userInput": "什么是表见代理？给我通俗解释一下",
+    "turns": [
+      {
+        "text": "<final>表见代理是指行为人虽无代理权，但相对人有理由相信其有代理权，该代理行为有效，由被代理人承担法律后果（《民法典》第一百七十二条）。通俗地说：公司让别人误以为某人能代表它，就要为这个误会买单。</final>"
+      }
+    ],
+    "expect": {
+      "toolCalls": [],
+      "structureContains": ["<final>"],
+      "bubbleEndStatus": "finished",
+      "toolsOffered": false
+    }
+  },
+  {
+    "id": "json-style-tool-call-xml",
+    "title": "JSON 风格 tool({...}) 调用解析（协议容错回归）",
+    "category": "chat",
+    "protocol": "xml",
+    "userInput": "查一下最高院关于对赌协议的最新司法解释",
+    "turns": [
+      {
+        "text": "<process name=\"联网检索\"><tool_code>search_web({\"query\": \"最高人民法院 对赌协议 司法解释 最新\"})</tool_code></process>"
+      },
+      {
+        "text": "<final>检索到最高院关于对赌协议的最新裁判观点如下……</final>"
+      }
+    ],
+    "toolStubs": {
+      "search_web": "[{\"title\":\"九民纪要对赌条款解读\",\"snippet\":\"……\"}]"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "search_web", "argsContain": { "query": "对赌协议" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-drafting.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-drafting.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "draft-labor-contract-xml",
+    "title": "起草劳动合同并落盘 docx（XML 协议）",
+    "category": "drafting",
+    "protocol": "xml",
+    "userInput": "帮我起草一份简单的劳动合同，保存为 docx 文件",
+    "smoke": { "anyOfFirstTools": ["write_docx", "write_file"] },
+    "turns": [
+      {
+        "text": "<bubble_type mode=\"execution\" />\n<process name=\"起草劳动合同\"><tool_code>write_docx(fileName=\"劳动合同\", markdownContent=\"# 劳动合同\n\n甲方（用人单位）：____\n乙方（劳动者）：____\n\n## 第一条 合同期限\n本合同自 ____ 年 __ 月 __ 日起至 ____ 年 __ 月 __ 日止。\n\n## 第二条 工作内容\n乙方从事 ____ 岗位工作。\")</tool_code></process>"
+      },
+      {
+        "text": "<final>已为您起草《劳动合同》并保存为 docx 文件，您可以在项目文件区查看和编辑。</final>"
+      }
+    ],
+    "toolStubs": {
+      "write_docx": "{\"status\":\"success\",\"file\":\"劳动合同.docx\",\"wps_file_id\":101}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "write_docx",
+          "argsContain": { "fileName": "劳动合同", "markdownContent": "合同期限" }
+        }
+      ],
+      "structureContains": ["<process", "<tool_code>", "<final>"],
+      "bubbleEndStatus": "finished",
+      "toolsOffered": true
+    }
+  },
+  {
+    "id": "draft-service-contract-native",
+    "title": "起草法律服务合同（原生 function calling）",
+    "category": "drafting",
+    "protocol": "native",
+    "userInput": "起草一份法律服务合同，落成 Word 文件",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "write_docx",
+            "arguments": {
+              "fileName": "法律服务合同",
+              "markdownContent": "# 法律服务合同\n\n委托方：____\n受托方：____律师事务所\n\n## 第一条 委托事项\n受托方接受委托方委托，就 ____ 事项提供法律服务。",
+              "projectId": 999
+            }
+          }
+        ]
+      },
+      {
+        "text": "<final>《法律服务合同》已生成并保存到项目文件，请查收。</final>"
+      }
+    ],
+    "toolStubs": {
+      "write_docx": "{\"status\":\"success\",\"file\":\"法律服务合同.docx\",\"wps_file_id\":102}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "write_docx",
+          "argsContain": { "fileName": "法律服务合同", "markdownContent": "委托事项" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished",
+      "toolsOffered": true
+    }
+  },
+  {
+    "id": "read-then-draft-supplement-xml",
+    "title": "先读原协议再起草补充协议（两轮工具链）",
+    "category": "drafting",
+    "protocol": "xml",
+    "userInput": "看一下 42 号文件那份股权转让协议，然后帮我起草一份补充协议",
+    "turns": [
+      {
+        "text": "<process name=\"阅读原协议\"><tool_code>read_document(fileId=\"42\")</tool_code></process>"
+      },
+      {
+        "text": "<process name=\"起草补充协议\"><tool_code>write_docx(fileName=\"股权转让补充协议\", markdownContent=\"# 股权转让补充协议\n\n鉴于双方已于 ____ 年签署《股权转让协议》，现就交割安排补充约定如下。\")</tool_code></process>"
+      },
+      {
+        "text": "<final>已阅读原《股权转让协议》，并据此起草了《股权转让补充协议》。</final>"
+      }
+    ],
+    "toolStubs": {
+      "read_document": "《股权转让协议》正文：转让方将其持有的目标公司 30% 股权转让给受让方……（略）",
+      "write_docx": "{\"status\":\"success\",\"file\":\"股权转让补充协议.docx\"}"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "read_document", "argsContain": { "fileId": "42" } },
+        { "name": "write_docx", "argsContain": { "fileName": "股权转让补充协议" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-files-python.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-files-python.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "run-python-embedded-toolname-xml",
+    "title": "run_python 代码内含其他工具名不被误匹配（解析优先级回归）",
+    "category": "files",
+    "protocol": "xml",
+    "userInput": "帮我用 Python 统计一下检索脚本里调用了几次搜索",
+    "turns": [
+      {
+        "text": "<process name=\"运行Python\"><tool_code>run_python(code='script = open(\"crawl.py\").read()\ncount = script.count(\"search_web(\")\nprint(f\"search_web called {count} times\")')</tool_code></process>"
+      },
+      {
+        "text": "<final>脚本中共调用 search_web 3 次。</final>"
+      }
+    ],
+    "toolStubs": {
+      "run_python": "search_web called 3 times"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "run_python", "argsContain": { "code": "search_web" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "list-then-read-file-chain-xml",
+    "title": "浏览目录后读取文件（两轮工具链）",
+    "category": "files",
+    "protocol": "xml",
+    "userInput": "看看合同文件夹里有什么，把劳动合同模板打开读一下",
+    "turns": [
+      {
+        "text": "<process name=\"浏览项目文件\"><tool_code>list_files(subPath=\"合同\")</tool_code></process>"
+      },
+      {
+        "text": "<process name=\"读取文件\"><tool_code>read_file(filePath=\"合同/劳动合同模板.docx\")</tool_code></process>"
+      },
+      {
+        "text": "<final>合同文件夹下共有 3 份文件。《劳动合同模板》主要条款包括合同期限、工作内容、劳动报酬与保密义务。</final>"
+      }
+    ],
+    "toolStubs": {
+      "list_files": "合同/\n  - 劳动合同模板.docx\n  - 保密协议模板.docx\n  - 竞业限制协议.docx",
+      "read_file": "劳动合同模板正文：第一条 合同期限……第四条 劳动报酬……"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "list_files", "argsContain": { "subPath": "合同" } },
+        { "name": "read_file", "argsContain": { "filePath": "劳动合同模板" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "browse-url-native",
+    "title": "浏览网页链接（原生 function calling）",
+    "category": "files",
+    "protocol": "native",
+    "userInput": "帮我看看这个链接说了什么：https://example.com/new-company-law",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "browse_url",
+            "arguments": { "url": "https://example.com/new-company-law" }
+          }
+        ]
+      },
+      {
+        "text": "<final>该页面是对新公司法注册资本制度的解读，要点：五年认缴期限、股东失权制度、董事催缴义务。</final>"
+      }
+    ],
+    "toolStubs": {
+      "browse_url": "页面标题：新公司法注册资本制度解读。正文摘要：认缴期限五年、股东失权、董事催缴……"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "browse_url", "argsContain": { "url": "example.com/new-company-law" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-legal-research.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-legal-research.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "law-article-lookup-xml",
+    "title": "查询公司法具体法条（XML 协议）",
+    "category": "legal-research",
+    "protocol": "xml",
+    "userInput": "帮我查一下新公司法第八十八条的内容",
+    "smoke": { "anyOfFirstTools": ["law_search", "law_search_keyword", "get_law_article", "search_web"] },
+    "turns": [
+      {
+        "text": "<process name=\"查询法条\"><tool_code>get_law_article(title=\"中华人民共和国公司法\", number=\"第八十八条\")</tool_code></process>"
+      },
+      {
+        "text": "<final>《公司法》第八十八条规定：股东转让已认缴出资但未届出资期限的股权的，由受让人承担缴纳该出资的义务……（已为您整理全文）</final>"
+      }
+    ],
+    "toolStubs": {
+      "get_law_article": "《中华人民共和国公司法》第八十八条：股东转让已认缴出资但未届出资期限的股权的，由受让人承担缴纳该出资的义务……"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "get_law_article",
+          "argsContain": { "title": "公司法", "number": "第八十八条" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "law-semantic-search-native",
+    "title": "语义检索对赌协议效力规定（原生 function calling）",
+    "category": "legal-research",
+    "protocol": "native",
+    "userInput": "对赌协议的效力有哪些法律规定和司法解释？",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "law_search",
+            "arguments": { "query": "对赌协议 效力 司法解释" }
+          }
+        ]
+      },
+      {
+        "text": "<final>关于对赌协议效力，主要依据《九民纪要》第5条：与目标公司对赌不因此无效，但履行需满足减资等程序……</final>"
+      }
+    ],
+    "toolStubs": {
+      "law_search": "[{\"title\":\"全国法院民商事审判工作会议纪要\",\"article\":\"第5条\",\"summary\":\"投资方与目标公司对赌的效力认定……\"}]"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "law_search", "argsContain": { "query": "对赌协议" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "search-laws-alias-resolution-xml",
+    "title": "search_laws 旧别名应解析为 search_web（协议兼容回归）",
+    "category": "legal-research",
+    "protocol": "xml",
+    "userInput": "查一下2024年公司法修订后注册资本认缴期限的最新报道",
+    "turns": [
+      {
+        "text": "<process name=\"联网检索\"><tool_code>search_laws(query=\"2024 公司法修订 注册资本 认缴期限 五年\")</tool_code></process>"
+      },
+      {
+        "text": "<final>根据检索结果：新公司法规定有限责任公司股东认缴出资应当自公司成立之日起五年内缴足……</final>"
+      }
+    ],
+    "toolStubs": {
+      "search_web": "[{\"title\":\"新公司法注册资本认缴期限解读\",\"snippet\":\"五年实缴过渡安排……\"}]"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "search_web", "argsContain": { "query": "注册资本" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "law-keyword-then-article-chain-xml",
+    "title": "关键词检索后追查具体法条（两轮工具链）",
+    "category": "legal-research",
+    "protocol": "xml",
+    "userInput": "劳动合同法里关于经济补偿的标准是哪一条？内容是什么？",
+    "turns": [
+      {
+        "text": "<process name=\"关键词检索法规\"><tool_code>law_search_keyword(title=\"劳动合同法\", fulltext=\"经济补偿\")</tool_code></process>"
+      },
+      {
+        "text": "<process name=\"查询法条原文\"><tool_code>get_law_article(title=\"中华人民共和国劳动合同法\", number=\"第四十七条\")</tool_code></process>"
+      },
+      {
+        "text": "<final>经济补偿标准规定在《劳动合同法》第四十七条：按劳动者在本单位工作的年限，每满一年支付一个月工资……</final>"
+      }
+    ],
+    "toolStubs": {
+      "law_search_keyword": "[{\"title\":\"中华人民共和国劳动合同法\",\"hit\":\"第四十六条、第四十七条 经济补偿\"}]",
+      "get_law_article": "《劳动合同法》第四十七条：经济补偿按劳动者在本单位工作的年限，每满一年支付一个月工资的标准向劳动者支付……"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "law_search_keyword", "argsContain": { "title": "劳动合同法", "fulltext": "经济补偿" } },
+        { "name": "get_law_article", "argsContain": { "number": "第四十七条" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-memory.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-memory.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "memory-query-decision-xml",
+    "title": "查询项目记忆中的既往决定（XML 协议）",
+    "category": "memory",
+    "protocol": "xml",
+    "userInput": "我们之前关于竞业限制补偿标准是怎么定的来着？",
+    "turns": [
+      {
+        "text": "<process name=\"查询项目记忆\"><tool_code>query_memory(query=\"竞业限制 补偿标准\", type=\"decision\")</tool_code></process>"
+      },
+      {
+        "text": "<final>根据项目记忆：此前已确定竞业限制补偿按离职前十二个月平均工资的 40% 按月支付，期限不超过两年。</final>"
+      }
+    ],
+    "toolStubs": {
+      "query_memory": "[decision] 2026-05-12：竞业限制补偿标准定为离职前十二个月平均工资的40%，期限两年。"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "query_memory",
+          "argsContain": { "query": "竞业限制", "type": "decision" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "memory-update-project-info-native",
+    "title": "更新项目信息记忆（原生 function calling）",
+    "category": "memory",
+    "protocol": "native",
+    "userInput": "记一下：这个项目的交易金额改成 2.3 亿元了",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "update_project_info",
+            "arguments": { "field": "transactionAmount", "value": "2.3亿元" }
+          }
+        ]
+      },
+      {
+        "text": "<final>好的，已把项目交易金额更新为 2.3 亿元。</final>"
+      }
+    ],
+    "toolStubs": {
+      "update_project_info": "✓ 项目信息已更新\n- 字段: transactionAmount\n- 新值: 2.3亿元"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "update_project_info",
+          "argsContain": { "field": "transactionAmount", "value": "2.3亿元" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "memory-user-profile-noarg-xml",
+    "title": "无参工具调用 get_user_profile（XML 协议）",
+    "category": "memory",
+    "protocol": "xml",
+    "userInput": "按我平时的习惯格式，整理一份会议纪要模板的要点",
+    "turns": [
+      {
+        "text": "<process name=\"读取用户偏好\"><tool_code>get_user_profile()</tool_code></process>"
+      },
+      {
+        "text": "<final>根据您的偏好（要点式、先结论后论证），会议纪要模板建议包含：会议要素、结论清单、分歧与待办、责任人与期限。</final>"
+      }
+    ],
+    "toolStubs": {
+      "get_user_profile": "用户偏好：要点式表达；先结论后论证；文书默认宋体小四。"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "get_user_profile" }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-pptx.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-pptx.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "pptx-generate-native",
+    "title": "生成股权激励方案 PPT（原生 function calling）",
+    "category": "pptx",
+    "protocol": "native",
+    "userInput": "把这份股权激励方案做成一个 PPT，商务简约风",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "pptx_generate",
+            "arguments": {
+              "topic": "股权激励方案：授予对象、行权条件与退出机制",
+              "fileName": "股权激励方案",
+              "style": "商务简约",
+              "language": "zh"
+            }
+          }
+        ]
+      },
+      {
+        "text": "<final>《股权激励方案》PPT 已开始生成，完成后会出现在项目文件区。</final>"
+      }
+    ],
+    "toolStubs": {
+      "pptx_generate": "{\"status\":\"generating\",\"task_id\":\"t-001\",\"file\":\"股权激励方案.pptx\"}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "pptx_generate",
+          "argsContain": { "topic": "股权激励", "style": "商务简约" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "pptx-outline-longest-name-match-xml",
+    "title": "pptx_generate_outline 不被 pptx_generate 抢占（最长名优先回归）",
+    "category": "pptx",
+    "protocol": "xml",
+    "userInput": "先给我出一个数据合规专题培训的 PPT 大纲",
+    "turns": [
+      {
+        "text": "<process name=\"生成PPT大纲\"><tool_code>pptx_generate_outline(topic=\"数据合规专题培训：合规义务、跨境传输与执法案例\", language=\"zh\")</tool_code></process>"
+      },
+      {
+        "text": "<final>已生成《数据合规专题培训》PPT 大纲，共 8 个章节，您确认后我再生成完整 PPT。</final>"
+      }
+    ],
+    "toolStubs": {
+      "pptx_generate_outline": "{\"outline\":[\"一、数据合规监管框架\",\"二、企业合规义务\",\"三、跨境数据传输\"]}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "pptx_generate_outline",
+          "argsContain": { "topic": "数据合规", "language": "zh" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-revision.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-revision.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "revise-clause-find-replace-xml",
+    "title": "修订违约金条款（XML 协议 find_replace）",
+    "category": "revision",
+    "protocol": "xml",
+    "userInput": "把合同里的违约金从百分之五改成百分之十",
+    "turns": [
+      {
+        "text": "<process name=\"修订违约金条款\"><tool_code>wps_find_replace(findText=\"违约金为合同总额的百分之五\", replaceText=\"违约金为合同总额的百分之十\", replaceAll=true)</tool_code></process>"
+      },
+      {
+        "text": "<final>已将违约金条款由百分之五修订为百分之十。</final>"
+      }
+    ],
+    "toolStubs": {
+      "wps_find_replace": "{\"replaced\":1,\"status\":\"success\"}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "wps_find_replace",
+          "argsContain": {
+            "findText": "百分之五",
+            "replaceText": "百分之十",
+            "replaceAll": "true"
+          }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "revise-clause-find-replace-native",
+    "title": "修订不可抗力条款（原生 function calling）",
+    "category": "revision",
+    "protocol": "native",
+    "userInput": "把不可抗力条款改成包含疫情防控措施",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "wps_find_replace",
+            "arguments": {
+              "findText": "不可抗力",
+              "replaceText": "不可抗力（包括疫情防控措施）",
+              "replaceAll": true
+            }
+          }
+        ]
+      },
+      {
+        "text": "<final>已将不可抗力条款修订为包含疫情防控措施的表述。</final>"
+      }
+    ],
+    "toolStubs": {
+      "wps_find_replace": "{\"replaced\":3,\"status\":\"success\"}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "wps_find_replace",
+          "argsContain": { "findText": "不可抗力", "replaceText": "疫情防控措施" }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "revise-two-tools-single-reply-xml",
+    "title": "单条回复内两个 tool_code 顺序分发（XML 协议）",
+    "category": "revision",
+    "protocol": "xml",
+    "userInput": "把甲方名称统一改成新公司名，同时把签署日期改成2026年7月1日",
+    "turns": [
+      {
+        "text": "<process name=\"批量修订\"><tool_code>wps_find_replace(findText=\"北京旧名科技有限公司\", replaceText=\"北京新名科技有限公司\", replaceAll=true)</tool_code></process>\n<process name=\"修订签署日期\"><tool_code>wps_find_replace(findText=\"2026年1月1日\", replaceText=\"2026年7月1日\", replaceAll=true)</tool_code></process>"
+      },
+      {
+        "text": "<final>已完成两处修订：甲方名称与签署日期均已更新。</final>"
+      }
+    ],
+    "toolStubs": {
+      "wps_find_replace": "{\"replaced\":2,\"status\":\"success\"}"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "wps_find_replace", "argsContain": { "findText": "北京旧名科技有限公司" } },
+        { "name": "wps_find_replace", "argsContain": { "replaceText": "2026年7月1日" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/smoke-system-prompt.txt
+++ b/backend/src/test/resources/ai-eval/smoke-system-prompt.txt
@@ -1,0 +1,12 @@
+你是「AI Workdeck」法律工作台中的 AI 助手，服务对象是执业律师。
+
+你可以使用系统提供的工具（见 function 定义）完成任务：
+- 起草文书：用 write_docx 把 Markdown 内容落盘为 Word 文档；
+- 法律检索：用 law_search / law_search_keyword / get_law_article 查询法规与法条，或用 search_web 联网检索；
+- 文档修订：用 wps_find_replace 等编辑工具修改已打开的文档；
+- 生成演示：用 pptx_generate 生成 PPT。
+
+规则：
+1. 当用户的请求需要动手完成（起草、检索、修订、生成文件）时，直接调用相应工具，不要只口头描述步骤。
+2. 闲聊、问候或纯咨询时，直接用自然语言回答，不要调用任何工具。
+3. 回答使用中文。

--- a/docs/AI_EVAL.md
+++ b/docs/AI_EVAL.md
@@ -1,0 +1,122 @@
+# AI 编排器回归评测（AI Eval）
+
+编排器重构频繁，「给定用户输入 → 应当分发哪些工具 / 产出什么结构」过去只能真机手测。
+本评测基建把这件事变成 `mvn test` 里的一等公民：**每次重构后，离线回放评测告诉你编排器行为有没有变。**
+
+## 组成
+
+| 部分 | 位置 | 说明 |
+| --- | --- | --- |
+| 评测用例集 | `backend/src/test/resources/ai-eval/cases/*.json` | 24 个法律场景用例（起草、修订、查法条、PPT、闲聊、记忆、artifact 等） |
+| 回放测试 | `backend/src/test/java/com/checkba/service/ai/eval/OrchestratorReplayEvalTest.java` | **进默认 `mvn test` 套件**，不调真实 LLM，全程离线毫秒级 |
+| 回放 harness | 同目录 `EvalHarness` / `ScriptedStreamingModel` / `RecordingToolRegistry` / `RealToolBeans` | 见下文原理 |
+| 真实 LLM 冒烟 | 同目录 `RealLlmSmokeTest.java` | 默认跳过；设 `OPENROUTER_API_KEY` 后跑 3 个标注 `smoke` 的关键用例 |
+| 冒烟系统提示词 | `backend/src/test/resources/ai-eval/smoke-system-prompt.txt` | 冒烟专用精简 prompt |
+
+## 原理（谁是真的、谁是假的）
+
+回放测试用**真实生产代码**跑主链路，只把「外界」换成桩：
+
+- **真实**：`AgentOrchestrator`（完整 runLoop：XML 与原生两种工具协议、artifact、`<title>`、Ask 模式）、
+  `XmlToolCallParser`（全部容错解析）、`ToolRegistry` 的注册与别名解析、**真实工具类的工具名/参数名**
+  （`RealToolBeans` 以空依赖反射实例化 8 个生产工具组件——重构改了工具名或参数名，评测立刻红）。
+- **回放**：`ScriptedStreamingModel` 实现 `StreamingChatLanguageModel`，按用例 `turns` 逐轮回放预录的模型输出，
+  不访问网络。
+- **记录**：`RecordingToolRegistry` 继承 `ToolRegistry`，`execute()` 只记录 `(toolName, argsJson)` 分发序列并返回
+  桩输出，**从不执行工具方法**（所以空依赖实例化是安全的）。
+- **打桩**：SSE、消息持久化、上下文组装、记忆管线等外围服务用 Mockito 打桩并记录调用。
+
+断言的是编排器的**可观测行为**：分发给 ToolRegistry 的工具序列与参数、最终保存消息中的结构标签
+（`<process>`/`<final>`/`<artifact>`）、artifact 落盘、`bubble_end` 收尾状态、ASK 模式是否携带工具规格、
+`<title>` 触发的会话重命名。
+
+## 怎么跑
+
+```bash
+cd backend
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)   # 本机默认 JDK 25 会 SIGBUS 崩溃，务必用 21
+
+# 只跑回放评测（毫秒级）
+mvn test -Dtest=OrchestratorReplayEvalTest -Dsurefire.failIfNoSpecifiedTests=false
+
+# 全量测试（回放评测已包含在内）
+mvn test
+
+# 真实 LLM 冒烟（可选，产生真实 API 费用）
+OPENROUTER_API_KEY=sk-or-... mvn test -Dtest=RealLlmSmokeTest -Dsurefire.failIfNoSpecifiedTests=false
+# 可选环境变量：OPENROUTER_BASE_URL（默认 openrouter.ai/api/v1）、AI_EVAL_SMOKE_MODEL（默认 google/gemini-2.5-flash）
+```
+
+## 怎么添加用例
+
+在 `backend/src/test/resources/ai-eval/cases/` 里挑一个分类文件（或新建 `cases-xxx.json`），往数组里加一条。
+加载器会自动发现所有 `*.json`，并校验 `id` 全局唯一。
+
+```jsonc
+{
+  "id": "my-new-case-xml",              // 唯一 ID（测试名）
+  "title": "一句话描述",
+  "category": "drafting",               // 分类，只影响测试展示名
+  "protocol": "xml",                    // xml / native / mixed，仅文档标注
+  "mode": "AGENT",                      // AGENT（默认）/ PLAN / ASK
+  "userInput": "用户会说的话",
+  "smoke": { "anyOfFirstTools": ["write_docx"] },  // 可选：加入真实 LLM 冒烟集；[] 表示期望不调工具
+  "turns": [                            // 预录的模型输出，一项 = 一轮 LLM 回复
+    { "text": "<process name=\"...\"><tool_code>write_docx(fileName=\"x\", markdownContent=\"y\")</tool_code></process>" },
+    { "toolCalls": [ { "name": "write_docx", "arguments": { "fileName": "x" } } ] },  // 原生 function calling 轮
+    { "text": "<final>收尾话术</final>" }   // 最后一轮必须不含工具调用，否则循环不会结束
+  ],
+  "toolStubs": { "write_docx": "{\"status\":\"success\"}" },  // 回放给模型的工具输出，缺省 "OK (eval stub)"
+  "expect": {
+    "toolCalls": [                       // 按顺序断言分发序列；null=不断言；[]=断言零调用
+      { "name": "write_docx",            // 别名解析后的工具名（search_laws 写成 search_web）
+        "argsContain": { "fileName": "x" } }   // 参数值子串断言
+    ],
+    "structureContains": ["<process", "<final>"],  // 最终保存的 ASSISTANT 消息应含的标签
+    "artifact": { "type": "task_list", "filenameContains": "清单" },  // 可选
+    "bubbleEndStatus": "finished",       // finished / awaiting_approval（PLAN 模式实施计划）
+    "toolsOffered": true,                // 可选：ASK 模式写 false
+    "renamedTitleContains": "..."        // 可选：<title> 协议断言
+  }
+}
+```
+
+预录 `turns` 的取材方式：真机跑一次目标场景，从后端日志里抄 `Response completed ... Full content:` 的原文
+（XML 协议），或 `Detected Native Tool Requests` 的工具名与参数（原生协议）。
+
+经验规则：
+
+- **每个 XML/native 工具轮之后必须还有下一轮**（编排器执行工具后会再问一次模型）；最后一轮必须是纯文本。
+- `turns` 数与编排器实际请求的 LLM 轮次必须精确相等——多了少了都会失败（这本身就是回归信号）。
+- artifact 轮（`task_list`）与 `<title>` 轮不触发递归，可以直接作为最后一轮；
+  PLAN 模式的 `implementation_plan` 轮会停循环等审批（`bubbleEndStatus: "awaiting_approval"`）。
+
+## 怎么解读失败
+
+| 失败信息 | 含义 | 常见原因 |
+| --- | --- | --- |
+| `工具调用数量不符` / `第 N 个工具调用名不符` | 分发序列变了 | 编排器分发逻辑被改动；工具改名；`XmlToolCallParser` 解析行为变化；别名表变动 |
+| `参数 X 应包含 [...]` | 参数提取/绑定变了 | 解析器参数提取回归；工具方法参数改名（解析器按参数名提取，改名会直接丢参数） |
+| `回放脚本已耗尽`（IllegalStateException） | 编排器比预期多问了一轮 LLM | 循环控制变化（如工具执行后新增了一轮确认）；工具结果反馈格式变化导致再次触发工具 |
+| `编排器请求的 LLM 轮次少于用例预录轮次` | 编排器提前结束了循环 | 提前 return / 新增终止条件；XML 工具调用未被识别（containsToolCall 判断变化） |
+| `最终 ASSISTANT 消息缺少结构标签 [...]` | 持久化内容结构变了 | executionLog 拼装格式变化；`<final>`/`<process>` 清洗逻辑变化 |
+| `期望保存 artifact 但未被调用` / 文件名断言失败 | artifact 协议处理变了 | artifact 检测正则、name 提取、文件名清洗逻辑变动 |
+| `bubble_end status 应为 [...]` | 会话收尾协议变了 | PLAN 审批停循环逻辑、bubble_end 事件负载变化 |
+| `toolsOffered 不符` | ASK 模式约束被破坏 | ASK 模式下把工具规格传给了 LLM（或反之） |
+| `不应有 SSE error 事件` | 回放中编排器抛了异常 | 看断言消息里带出的 error 事件内容定位堆栈 |
+
+**失败 ≠ 一定是 bug**：如果这次重构就是有意改变行为（例如调整反馈消息格式、增加一轮循环），
+确认新行为正确后，更新对应用例的 `turns`/`expect` 即可——评测的职责是让行为变化**显式化**，而不是禁止变化。
+
+## 冒烟测试（真实 LLM）怎么解读
+
+冒烟只断言「模型面对真实工具规格时的**首个工具选择**落在期望集合内」（闲聊用例断言不调工具），
+它验证的是 prompt/工具规格与真实模型的兼容性，不验证多轮循环。失败时优先检查：
+模型是否变更（`AI_EVAL_SMOKE_MODEL`）、OpenRouter 是否限流、工具描述是否被改坏。
+冒烟失败不阻塞 CI（默认跳过），但连续失败说明真机体验大概率已受影响。
+
+## 与架构不变式的关系
+
+本评测守护 AI 编排器重构（PR#83/#84）确立的边界：编排器不感知具体工具、统一走 `ToolRegistry` 分发、
+XML `<tool_code>` 兜底协议与原生 function calling 双协议等价。新增工具**不需要**改编排器，
+但建议为新工具补一个评测用例（一个 XML 轮 + 一个 final 轮即可）。


### PR DESCRIPTION
## 背景

编排器重构频繁（#83 #84 及进行中的后续 Phase），但「给定用户输入 → 应当分发哪些工具 / 产出什么结构」此前只能真机手测。本 PR 把它变成 `mvn test` 里的回归门禁。

## 内容（纯新增，零生产代码改动）

**1. 离线评测用例集** — `backend/src/test/resources/ai-eval/cases/*.json`，24 个法律场景用例（起草合同、修订条款、查法条、生成 PPT、闲聊、记忆存取、artifact、`<title>` 协议等），每例含用户输入、预录模型输出（XML `tool_code` 与原生 function calling 双协议）、期望工具序列（工具名 + 参数断言）与输出结构标签。

**2. 回放测试（进默认测试套件）** — `OrchestratorReplayEvalTest`：
- `ScriptedStreamingModel` mock `StreamingChatLanguageModel`，按用例逐轮回放，不调真实 LLM，全程毫秒级；
- 跑的是**真实** `AgentOrchestrator` 完整 runLoop + **真实** `XmlToolCallParser` + **真实** `ToolRegistry` 别名解析；
- `RealToolBeans` 以空依赖反射实例化 8 个生产工具组件——注册的是真实工具名/参数名，重构改名立刻红；
- `RecordingToolRegistry` 只记录分发序列、不执行工具方法，断言「编排器 → 注册表」边界行为。
- 覆盖的回归点包括：`search_laws→search_web` 别名、`pptx_generate_outline` 最长名优先匹配、`run_python` 代码内嵌其他工具名不误匹配、JSON 风格 `tool({...})` 调用、ASK 模式不带工具、PLAN 模式 implementation_plan 停循环待审批。

**3. 真实 LLM 冒烟（默认跳过）** — `RealLlmSmokeTest`：`@EnabledIfEnvironmentVariable(OPENROUTER_API_KEY)`，跑 3 个 smoke 用例，断言真实模型的首个工具选择落在期望集合内。

**4. 文档** — `docs/AI_EVAL.md`：如何添加用例、如何跑、失败信息对照表。

## 验证

- JDK 21，`mvn test` 全绿：**124 tests, 0 failures**（1 skipped = 冒烟测试按设计跳过）
- 回放评测 24/24 通过，耗时 ~1s
- `git diff --stat`：17 files，全部 create mode，无任何既有文件改动（与并行重构 session 零冲突）

🤖 Generated with [Claude Code](https://claude.com/claude-code)