### PR TITLE
test(ai): 评测基建适配 PR#87 doc_* 更名——修复 master 测试编译 / align eval with doc_* rename

### DIFF
--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
@@ -8,10 +8,10 @@ import com.checkba.service.ai.AgentOrchestrator;
 import com.checkba.service.ai.ChatModelFactory;
 import com.checkba.service.ai.ContextAssemblerService;
 import com.checkba.service.ai.ConversationFileChangeService;
+import com.checkba.service.ai.EditorBridgeService;
 import com.checkba.service.ai.PluginService;
 import com.checkba.service.ai.SseEmitterService;
 import com.checkba.service.ai.TokenUsageService;
-import com.checkba.service.ai.WpsActionService;
 import com.checkba.service.ai.XmlToolCallParser;
 import com.checkba.service.ai.memory.MemoryPipelineService;
 import dev.langchain4j.data.message.SystemMessage;
@@ -132,14 +132,14 @@ public final class EvalHarness {
             return null;
         }).when(projectFileService).renameConversationFolder(any(), any(), any());
 
-        WpsActionService wps = mock(WpsActionService.class);
-        when(wps.isStreamingMode(any())).thenReturn(false);
+        EditorBridgeService editorBridge = mock(EditorBridgeService.class);
+        when(editorBridge.isStreamingMode(any())).thenReturn(false);
 
         ConversationFileChangeService fileChange = mock(ConversationFileChangeService.class);
 
         AgentOrchestrator orchestrator = new AgentOrchestrator(
                 chatModelFactory, messageService, sse, tokenUsage, assembler,
-                registry, parser, memoryPipeline, projectFileService, wps, fileChange);
+                registry, parser, memoryPipeline, projectFileService, editorBridge, fileChange);
 
         AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
         request.setProjectId(1L);

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -1,6 +1,7 @@
 package com.checkba.service.ai.eval;
 
 import com.checkba.service.ai.tools.AgentToolComponent;
+import com.checkba.service.ai.tools.DocumentEditTools;
 import com.checkba.service.ai.tools.FileTools;
 import com.checkba.service.ai.tools.LegalTools;
 import com.checkba.service.ai.tools.MemoryTools;
@@ -8,7 +9,6 @@ import com.checkba.service.ai.tools.PptxEditTools;
 import com.checkba.service.ai.tools.PptxTools;
 import com.checkba.service.ai.tools.PythonTools;
 import com.checkba.service.ai.tools.WebTools;
-import com.checkba.service.ai.tools.WpsTools;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -33,14 +33,14 @@ final class RealToolBeans {
     /** 与生产 Spring 容器中注册的 AgentToolComponent 集合保持一致 */
     static List<AgentToolComponent> instantiateAll() {
         List<Class<? extends AgentToolComponent>> toolClasses = List.of(
+                DocumentEditTools.class,
                 FileTools.class,
                 LegalTools.class,
                 MemoryTools.class,
                 PptxEditTools.class,
                 PptxTools.class,
                 PythonTools.class,
-                WebTools.class,
-                WpsTools.class);
+                WebTools.class);
         List<AgentToolComponent> beans = new ArrayList<>();
         for (Class<? extends AgentToolComponent> type : toolClasses) {
             beans.add(instantiate(type));

--- a/backend/src/test/resources/ai-eval/cases/cases-revision.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-revision.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "revise-clause-find-replace-xml",
-    "title": "修订违约金条款（XML 协议 find_replace）",
+    "title": "修订违约金条款（XML 协议，wps_* 旧名→doc_* 别名灰度）",
     "category": "revision",
     "protocol": "xml",
     "userInput": "把合同里的违约金从百分之五改成百分之十",
@@ -14,12 +14,12 @@
       }
     ],
     "toolStubs": {
-      "wps_find_replace": "{\"replaced\":1,\"status\":\"success\"}"
+      "doc_find_replace": "{\"replaced\":1,\"status\":\"success\"}"
     },
     "expect": {
       "toolCalls": [
         {
-          "name": "wps_find_replace",
+          "name": "doc_find_replace",
           "argsContain": {
             "findText": "百分之五",
             "replaceText": "百分之十",
@@ -27,13 +27,16 @@
           }
         }
       ],
-      "structureContains": ["<process", "<final>"],
+      "structureContains": [
+        "<process",
+        "<final>"
+      ],
       "bubbleEndStatus": "finished"
     }
   },
   {
     "id": "revise-clause-find-replace-native",
-    "title": "修订不可抗力条款（原生 function calling）",
+    "title": "修订不可抗力条款（原生 function calling，wps_* 旧名→doc_* 别名灰度）",
     "category": "revision",
     "protocol": "native",
     "userInput": "把不可抗力条款改成包含疫情防控措施",
@@ -55,16 +58,22 @@
       }
     ],
     "toolStubs": {
-      "wps_find_replace": "{\"replaced\":3,\"status\":\"success\"}"
+      "doc_find_replace": "{\"replaced\":3,\"status\":\"success\"}"
     },
     "expect": {
       "toolCalls": [
         {
-          "name": "wps_find_replace",
-          "argsContain": { "findText": "不可抗力", "replaceText": "疫情防控措施" }
+          "name": "doc_find_replace",
+          "argsContain": {
+            "findText": "不可抗力",
+            "replaceText": "疫情防控措施"
+          }
         }
       ],
-      "structureContains": ["<process", "<final>"],
+      "structureContains": [
+        "<process",
+        "<final>"
+      ],
       "bubbleEndStatus": "finished"
     }
   },
@@ -83,14 +92,27 @@
       }
     ],
     "toolStubs": {
-      "wps_find_replace": "{\"replaced\":2,\"status\":\"success\"}"
+      "doc_find_replace": "{\"replaced\":2,\"status\":\"success\"}"
     },
     "expect": {
       "toolCalls": [
-        { "name": "wps_find_replace", "argsContain": { "findText": "北京旧名科技有限公司" } },
-        { "name": "wps_find_replace", "argsContain": { "replaceText": "2026年7月1日" } }
+        {
+          "name": "doc_find_replace",
+          "argsContain": {
+            "findText": "北京旧名科技有限公司"
+          }
+        },
+        {
+          "name": "doc_find_replace",
+          "argsContain": {
+            "replaceText": "2026年7月1日"
+          }
+        }
       ],
-      "structureContains": ["<process", "<final>"],
+      "structureContains": [
+        "<process",
+        "<final>"
+      ],
       "bubbleEndStatus": "finished"
     }
   }

--- a/docs/AI_EVAL.md
+++ b/docs/AI_EVAL.md
@@ -69,7 +69,7 @@ OPENROUTER_API_KEY=sk-or-... mvn test -Dtest=RealLlmSmokeTest -Dsurefire.failIfN
   "toolStubs": { "write_docx": "{\"status\":\"success\"}" },  // 回放给模型的工具输出，缺省 "OK (eval stub)"
   "expect": {
     "toolCalls": [                       // 按顺序断言分发序列；null=不断言；[]=断言零调用
-      { "name": "write_docx",            // 别名解析后的工具名（search_laws 写成 search_web）
+      { "name": "write_docx",            // 别名解析后的工具名（search_laws 写 search_web；wps_* 旧名写 doc_*）
         "argsContain": { "fileName": "x" } }   // 参数值子串断言
     ],
     "structureContains": ["<process", "<final>"],  // 最终保存的 ASSISTANT 消息应含的标签


### PR DESCRIPTION
## 问题

#89（评测基建）与 #87（wps_*→doc_* 更名）并行开发、先后 squash 合入，两者内容相互不知情：master 上测试代码引用已被 #87 删除的 `WpsTools`/`WpsActionService`，**`mvn test-compile` 在 master 上编译失败**（PR CI 只跑 `mvn compile` 没拦住）。

## 修复（只动 #89 引入的评测文件）

- `RealToolBeans`: `WpsTools` → `DocumentEditTools`
- `EvalHarness`: `WpsActionService` → `EditorBridgeService`（编排器构造参数同步）
- 修订类 3 个用例：**turns 保留 `wps_find_replace` 旧名**（从此显式覆盖 Phase 2.5 别名灰度路径，0.6.0 前移除别名会被评测拦下），期望分发名与工具桩改为解析后的 `doc_find_replace`
- docs/AI_EVAL.md 补别名说明一句

## 验证

- 基于 master（3fd5326）重置后修复，`mvn test` 全绿：**127 tests, 0 failures**（1 skipped=冒烟按设计）
- 建议后续给 CI 的 Backend job 把 `mvn compile` 升级为 `mvn test`，避免并行合入再漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)