### PR TITLE
ci: Backend job 升级 mvn compile → mvn test（JDK 21）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,18 @@ on:
 
 jobs:
   backend:
-    name: Backend (mvn compile)
+    name: Backend (mvn test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
-      - name: Compile
+      - name: Test
         working-directory: backend
-        run: mvn -B compile -DskipTests
+        run: mvn -B test
 
   frontend:
     name: Frontend (build:h5)


### PR DESCRIPTION
## 背景

PR#87 与 PR#89 并行合入后，master 的测试代码编译损坏，但 CI 全绿未拦截（后由 PR#90 修复）。根因：CI Backend job 只跑 `mvn compile -DskipTests`，测试代码完全不在门禁内。

## 改动

- Backend job：`mvn -B compile -DskipTests` → `mvn -B test`，测试编译 + 全部 127 个用例进入 PR 门禁
- setup-java：JDK 17 → 21（项目约定 JDK 21；`backend/pom.xml` 的 `java.version=17` 仍兼容编译目标）

## 验证

- 本地 JDK 21 下 `mvn -B test`：**127 个用例，0 失败，1 跳过**（RealLlmSmokeTest 无 `OPENROUTER_API_KEY` 自动跳过，无需任何 secret），总耗时约 6 秒
- OrchestratorReplayEvalTest（AI 编排器回归评测）为毫秒级离线回放测试，随套件一起进入门禁
- 本 PR 自身的 CI 即为端到端验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)