### PR TITLE
feat(plugins): Phase 3A 插件启停接入 ToolRegistry + 权限分发前校验 / enable-gating & permission enforcement

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -21,10 +21,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * Service to manage backend plugins.
  * Scans 'plugins/' directory for JAR files and registers AI tools.
  *
- * Manifest 规范 v1 见 docs/PLUGIN_SPEC.md；示例插件见 examples/hello-plugin/。
+ * Manifest 规范 v2 见 docs/PLUGIN_SPEC.md；示例插件见 examples/hello-plugin/。
  * 启停状态持久化在 system_setting 表（key = {@link #DISABLED_KEY}，值为被禁用插件 id 的 JSON 数组，
- * 默认全部启用）。{@link #isEnabled(String)} 供将来 ToolRegistry 过滤禁用插件的工具
- * （接入点见 docs/AI_ARCHITECTURE.md 的 Phase 3 TODO，本轮不改 ToolRegistry）。
+ * 默认全部启用）。{@link #isEnabled(String)} 由 ToolRegistry 在三处消费点过滤禁用插件的工具；
+ * {@link #missingPermissionsForTool(String)} 由 ToolRegistry 在分发插件工具前做权限校验（规范 v2）。
  */
 @Service
 @Slf4j
@@ -51,6 +51,15 @@ public class PluginService {
 
     /** 被禁用插件 id 集合（内存缓存，与 system_setting 同步） */
     private final Set<String> disabledPluginIds = ConcurrentHashMap.newKeySet();
+
+    /**
+     * 禁用名单内存缓存的 TTL（毫秒）：同 JVM 内 setEnabled 即时生效；
+     * 外部直接改库（或多实例）在 TTL 内收敛。工具调用高频路径不打库。
+     */
+    @Value("${ai.plugins.disabled-cache-ttl-ms:5000}")
+    long disabledCacheTtlMs = 5000;
+
+    private volatile long disabledStateRefreshedAt = 0L;
 
     private final SystemSettingService systemSettingService;
 
@@ -89,6 +98,8 @@ public class PluginService {
     public static class PluginToolInfo {
         private String name;
         private String description;
+        /** 该工具运行所需的能力（规范 v2）：缺省视为不需要任何敏感能力（v1 兼容） */
+        private List<String> permissions;
     }
 
     @PostConstruct
@@ -113,10 +124,57 @@ public class PluginService {
 
     /**
      * 插件是否启用（默认启用，禁用名单持久化在 system_setting）。
-     * 供 PluginController 与将来的 ToolRegistry 查询。
+     * 供 PluginController 与 ToolRegistry 查询；内存缓存超过 TTL 时从配置表重读。
      */
     public boolean isEnabled(String pluginId) {
+        maybeRefreshDisabledState();
         return !disabledPluginIds.contains(pluginId);
+    }
+
+    private void maybeRefreshDisabledState() {
+        if (systemSettingService == null) {
+            return;
+        }
+        if (System.currentTimeMillis() - disabledStateRefreshedAt < disabledCacheTtlMs) {
+            return;
+        }
+        synchronized (this) {
+            if (System.currentTimeMillis() - disabledStateRefreshedAt < disabledCacheTtlMs) {
+                return;
+            }
+            loadDisabledState();
+        }
+    }
+
+    /**
+     * 插件工具在分发前的权限校验（规范 v2）：工具所需权限（manifest tools[].permissions）
+     * 必须全部包含在插件声明的 permissions 中。
+     *
+     * @return 所需但未在插件 permissions 中声明的权限；空列表 = 校验通过。
+     *         内置工具（不在 toolToPluginId 映射中）与未声明 permissions 的工具（v1 兼容）恒为通过。
+     */
+    public List<String> missingPermissionsForTool(String toolName) {
+        String pluginId = toolToPluginId.get(toolName);
+        if (pluginId == null) {
+            return List.of();
+        }
+        PluginMetadata meta = plugins.stream()
+                .filter(p -> Objects.equals(p.getId(), pluginId))
+                .findFirst().orElse(null);
+        if (meta == null || meta.getTools() == null) {
+            return List.of();
+        }
+        List<String> required = meta.getTools().stream()
+                .filter(t -> Objects.equals(t.getName(), toolName))
+                .findFirst()
+                .map(PluginToolInfo::getPermissions)
+                .orElse(null);
+        if (required == null || required.isEmpty()) {
+            return List.of();
+        }
+        Set<String> declared = meta.getPermissions() != null
+                ? new HashSet<>(meta.getPermissions()) : Set.of();
+        return required.stream().filter(p -> !declared.contains(p)).toList();
     }
 
     /**
@@ -158,6 +216,8 @@ public class PluginService {
             }
         } catch (Exception e) {
             log.error("Failed to load plugin disabled state, default to all enabled", e);
+        } finally {
+            disabledStateRefreshedAt = System.currentTimeMillis();
         }
     }
 
@@ -270,7 +330,7 @@ public class PluginService {
         registerToolObject(toolObject, null);
     }
 
-    private void registerToolObject(Object toolObject, String pluginId) {
+    void registerToolObject(Object toolObject, String pluginId) {
         try {
             List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(toolObject);
             for (ToolSpecification spec : specs) {

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -175,12 +175,26 @@ public class ToolRegistry {
     }
 
     /**
-     * 全部工具规格（内置 + 插件），传给 LLM 做原生 function calling。
+     * 全部工具规格（内置 + 已启用插件），传给 LLM 做原生 function calling。
+     * 禁用插件的工具规格不下发——LLM 看不到即不会调用。
      */
     public List<ToolSpecification> getAllSpecifications() {
         List<ToolSpecification> all = new ArrayList<>(builtinSpecifications);
-        all.addAll(pluginService.getToolSpecifications());
+        for (ToolSpecification spec : pluginService.getToolSpecifications()) {
+            if (pluginToolEnabled(spec.name())) {
+                all.add(spec);
+            }
+        }
         return all;
+    }
+
+    /**
+     * 插件启停过滤：内置工具（不属于任何插件，pid == null）恒可见；
+     * 插件工具仅在所属插件启用时可见。
+     */
+    private boolean pluginToolEnabled(String toolName) {
+        String pid = pluginService.getPluginIdForTool(toolName);
+        return pid == null || pluginService.isEnabled(pid);
     }
 
     public boolean hasTool(String name) {
@@ -193,7 +207,11 @@ public class ToolRegistry {
      */
     public List<String> toolNamesLongestFirst() {
         List<String> names = new ArrayList<>(builtinTools.keySet());
-        names.addAll(pluginService.getPluginTools().keySet());
+        for (String name : pluginService.getPluginTools().keySet()) {
+            if (pluginToolEnabled(name)) {
+                names.add(name);
+            }
+        }
         names.sort(Comparator.comparingInt(String::length).reversed());
         return names;
     }
@@ -206,7 +224,11 @@ public class ToolRegistry {
         if (tool != null) {
             return Optional.of(tool);
         }
-        // 插件工具：懒注册（插件可能在运行期热加载）
+        // 插件工具：先过启停过滤（禁用插件的工具视同不存在，重新启用即恢复）
+        if (!pluginToolEnabled(name)) {
+            return Optional.empty();
+        }
+        // 懒注册（插件可能在运行期热加载）
         RegisteredTool cached = pluginToolCache.get(name);
         if (cached != null) {
             return Optional.of(cached);
@@ -244,6 +266,17 @@ public class ToolRegistry {
             return new ToolResult("Tool not found or arguments invalid.", null, false);
         }
         RegisteredTool tool = toolOpt.get();
+
+        // 插件工具权限校验（规范 v2）：所需权限未在 manifest permissions 中声明即拒绝
+        if (tool.fromPlugin()) {
+            List<String> missing = pluginService.missingPermissionsForTool(resolvedName);
+            if (!missing.isEmpty()) {
+                log.warn("Tool '{}' rejected: requires undeclared permission(s) {}", resolvedName, missing);
+                return new ToolResult("Error: permission denied — tool '" + resolvedName
+                        + "' requires permission(s) " + missing
+                        + " not declared in the plugin manifest \"permissions\".", tool, true);
+            }
+        }
 
         // 装填线程上下文：修复流式回调线程与请求线程不一致导致的 ThreadLocal 丢失/串会话问题
         ToolContextHolder.set(ctx);

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -194,6 +194,71 @@ class PluginServiceTest {
         assertTrue(service.isEnabled("hello-plugin"));
     }
 
+    // ==== 规范 v2：tools[].permissions 与权限校验 ====
+
+    private static final String V2_MANIFEST = """
+            {
+              "id": "v2-plugin",
+              "name": "V2 插件",
+              "permissions": ["file_read"],
+              "tools": [
+                {"name": "readTool", "description": "读文件", "permissions": ["file_read"]},
+                {"name": "netTool", "description": "网络请求", "permissions": ["network", "file_write"]},
+                {"name": "plainTool", "description": "无权限需求"}
+              ]
+            }
+            """;
+
+    @Test
+    @DisplayName("v2：解析 tools[].permissions 字段")
+    void parsesToolLevelPermissions() throws IOException {
+        writeManifest("v2-plugin", V2_MANIFEST);
+        service.init();
+
+        PluginService.PluginMetadata meta = service.getPlugins().get(0);
+        assertEquals(List.of("file_read"), meta.getTools().get(0).getPermissions());
+        assertEquals(List.of("network", "file_write"), meta.getTools().get(1).getPermissions());
+        assertNull(meta.getTools().get(2).getPermissions());
+    }
+
+    @Test
+    @DisplayName("v2：missingPermissionsForTool——覆盖/缺失/无需求/内置工具四种路径")
+    void missingPermissionsForToolPaths() throws IOException {
+        writeManifest("v2-plugin", V2_MANIFEST);
+        service.init();
+        // 手工建立工具归属映射（无 JAR 时 loadPlugins 不注册工具）
+        service.registerToolObject(new Object() {
+            @dev.langchain4j.agent.tool.Tool("read a file")
+            public String readTool(@dev.langchain4j.agent.tool.P("path") String path) { return path; }
+            @dev.langchain4j.agent.tool.Tool("call network")
+            public String netTool(@dev.langchain4j.agent.tool.P("url") String url) { return url; }
+            @dev.langchain4j.agent.tool.Tool("plain")
+            public String plainTool(@dev.langchain4j.agent.tool.P("x") String x) { return x; }
+        }, "v2-plugin");
+
+        assertTrue(service.missingPermissionsForTool("readTool").isEmpty(), "所需 file_read 已声明");
+        assertEquals(List.of("network", "file_write"), service.missingPermissionsForTool("netTool"),
+                "network/file_write 未在插件 permissions 中声明");
+        assertTrue(service.missingPermissionsForTool("plainTool").isEmpty(), "未声明所需权限的工具恒通过");
+        assertTrue(service.missingPermissionsForTool("builtin_tool").isEmpty(), "内置工具不参与校验");
+    }
+
+    // ==== 启停缓存 TTL ====
+
+    @Test
+    @DisplayName("TTL 过期后 isEnabled 从配置表重读（外部改库可收敛）")
+    void ttlRefreshPicksUpExternalChange() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+        assertTrue(service.isEnabled("hello-plugin"));
+
+        // 模拟外部直接改库（不经过 setEnabled）
+        settingStore.put(PluginService.DISABLED_KEY, "[\"hello-plugin\"]");
+        service.disabledCacheTtlMs = 0;
+
+        assertFalse(service.isEnabled("hello-plugin"), "TTL 过期后应从配置表重读");
+    }
+
     // ==== 重新扫描 ====
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
@@ -182,4 +182,90 @@ class ToolRegistryTest {
             }
         });
     }
+
+    // ==== 插件启停过滤 + 权限校验（Phase 3A） ====
+
+    /** 模拟插件 JAR 中的工具类 */
+    static class FakePluginTools {
+        @Tool("Plugin echo tool")
+        public String plugin_echo(@P("text to echo") String text) {
+            return "plugin:" + text;
+        }
+    }
+
+    /** 构造带一个已注册插件工具（plugin_echo）的 PluginService */
+    private PluginService pluginServiceWith(String pluginId, List<String> declaredPermissions,
+                                            List<String> toolRequiredPermissions) {
+        PluginService ps = new PluginService();
+        PluginService.PluginMetadata meta = new PluginService.PluginMetadata();
+        meta.setId(pluginId);
+        meta.setName(pluginId);
+        meta.setPermissions(declaredPermissions);
+        PluginService.PluginToolInfo info = new PluginService.PluginToolInfo();
+        info.setName("plugin_echo");
+        info.setPermissions(toolRequiredPermissions);
+        meta.setTools(List.of(info));
+        ps.getPlugins().add(meta);
+        ps.registerToolObject(new FakePluginTools(), pluginId);
+        return ps;
+    }
+
+    @Test
+    @DisplayName("启停：禁用插件后规格/名单/分发全部不可见，重新启用即恢复，内置工具不受影响")
+    void disabledPluginToolsAreHidden() {
+        PluginService ps = pluginServiceWith("my-plugin", List.of("network"), null);
+        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps);
+        reg.init();
+
+        // 启用态：插件工具可见可分发
+        assertTrue(reg.getAllSpecifications().stream().anyMatch(s -> s.name().equals("plugin_echo")));
+        assertTrue(reg.toolNamesLongestFirst().contains("plugin_echo"));
+        assertEquals("plugin:hi", reg.execute("plugin_echo", "{\"text\":\"hi\"}", ctx).output());
+
+        ps.setEnabled("my-plugin", false);
+
+        assertFalse(reg.getAllSpecifications().stream().anyMatch(s -> s.name().equals("plugin_echo")),
+                "禁用后 LLM 不应看到插件工具规格");
+        assertFalse(reg.toolNamesLongestFirst().contains("plugin_echo"));
+        assertFalse(reg.hasTool("plugin_echo"));
+        ToolRegistry.ToolResult r = reg.execute("plugin_echo", "{\"text\":\"hi\"}", ctx);
+        assertFalse(r.found(), "禁用后分发应返回 not found");
+        // 内置工具不受插件启停影响
+        assertTrue(reg.hasTool("echo"));
+        assertEquals("echo:hi", reg.execute("echo", "{\"text\":\"hi\"}", ctx).output());
+
+        ps.setEnabled("my-plugin", true);
+
+        assertTrue(reg.getAllSpecifications().stream().anyMatch(s -> s.name().equals("plugin_echo")),
+                "重新启用后应恢复可见");
+        assertEquals("plugin:hi", reg.execute("plugin_echo", "{\"text\":\"hi\"}", ctx).output());
+    }
+
+    @Test
+    @DisplayName("权限：工具所需权限未在 manifest permissions 声明时分发被拒绝")
+    void undeclaredPermissionIsRejected() {
+        PluginService ps = pluginServiceWith("my-plugin", List.of("file_read"), List.of("network"));
+        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps);
+        reg.init();
+
+        ToolRegistry.ToolResult r = reg.execute("plugin_echo", "{\"text\":\"hi\"}", ctx);
+        assertTrue(r.found(), "工具存在，只是被权限拒绝");
+        assertFalse(r.success());
+        assertTrue(r.output().startsWith("Error: permission denied"), "应返回明确的权限拒绝错误: " + r.output());
+        assertTrue(r.output().contains("network"), "错误信息应指明缺失的权限: " + r.output());
+    }
+
+    @Test
+    @DisplayName("权限：所需权限已声明时正常执行；未声明所需权限的工具（v1 兼容）不受影响")
+    void declaredPermissionAllowsExecution() {
+        PluginService declared = pluginServiceWith("p1", List.of("network"), List.of("network"));
+        ToolRegistry reg1 = new ToolRegistry(List.of(new FakeTools()), declared);
+        reg1.init();
+        assertEquals("plugin:ok", reg1.execute("plugin_echo", "{\"text\":\"ok\"}", ctx).output());
+
+        PluginService legacy = pluginServiceWith("p2", null, null);
+        ToolRegistry reg2 = new ToolRegistry(List.of(new FakeTools()), legacy);
+        reg2.init();
+        assertEquals("plugin:ok", reg2.execute("plugin_echo", "{\"text\":\"ok\"}", ctx).output());
+    }
 }

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -120,12 +120,17 @@ Phase 2.5 未改动，命名迁移列入 Phase 3：
         `ai.plugins.disabled`，JSON 数组，默认全启用）、`PluginService.isEnabled()` /
         `getPluginIdForTool()` 查询接口、重扫接口、前端插件广场页
         （pages/plugin-market，入口在系统管理侧边栏）；示例插件 examples/hello-plugin/。
-  - [ ] **插件启停接入 ToolRegistry**（一次小改动，下次动 ToolRegistry 时顺手完成）：
-        在消费 `pluginService.getToolSpecifications()` / `getPluginTools()` 的三处
-        （构建 specs、列举工具名、按名取执行对象）过滤禁用插件的工具——
-        `String pid = pluginService.getPluginIdForTool(name)`，
-        `pid == null || pluginService.isEnabled(pid)` 才可见（`pid == null` 为内置工具，
-        不受插件启停影响）。`setEnabled()` 已同步更新内存态，ToolRegistry 无自建缓存则即时生效。
-  - [ ] 插件运行时沙箱：按 manifest `permissions`（file_read/file_write/network/editor，
-        v1 仅声明式展示，见 docs/PLUGIN_SPEC.md §3）做运行时强制。
+  - [x] **插件启停接入 ToolRegistry**（Phase 3A）：三处消费点（`getAllSpecifications` /
+        `toolNamesLongestFirst` / `resolve`）经 `pluginToolEnabled()` 过滤——
+        `pid == null || pluginService.isEnabled(pid)` 才可见（内置工具 `pid == null`
+        不受影响）。禁用后 LLM 看不到规格、XML 解析不识别、分发 not found；启用即恢复。
+        启停查询走内存缓存 + TTL 重读（`ai.plugins.disabled-cache-ttl-ms`，默认 5s），
+        工具调用高频路径不打库。
+  - [x] **manifest permissions 分发前校验**（Phase 3A，规范 v2 见 docs/PLUGIN_SPEC.md §3）：
+        工具级 `tools[].permissions` 声明所需能力，分发前校验「所需 ⊆ 插件声明」，
+        未声明即拒绝并返回明确错误（`PluginService.missingPermissionsForTool()` +
+        `ToolRegistry.execute()`）。
+  - [ ] 插件进程级运行时沙箱：v2 权限校验是分发层的诚实声明模型，插件代码仍与宿主同进程；
+        真正强制 file/network 隔离需进程级沙箱（独立进程 + IPC 或 SecurityManager 替代方案），
+        列为后续项。
   - [ ] MCP SDK 标准化、Skill 体系、多智能体协作。

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -1,6 +1,6 @@
-# 插件规范 v1（Plugin Spec v1）
+# 插件规范 v2（Plugin Spec v2）
 
-> 适用版本：0.4.x 起。示例插件见 [examples/hello-plugin/](../examples/hello-plugin/)。
+> 适用版本：v1 自 0.4.x；v2（权限执行 + 启停过滤）自 Phase 3A。示例插件见 [examples/hello-plugin/](../examples/hello-plugin/)。
 > 后端实现：`PluginService`（扫描/解析/启停）、`PluginController`（HTTP API）；
 > 前端管理页：`frontend/src/pages/plugin-market/plugin-market.vue`（插件广场，入口在系统管理侧边栏）。
 
@@ -47,16 +47,14 @@ plugins/
 | `icon` | string | 否 | emoji（如 `🔌`）或图片 URL/绝对路径；缺省时前端显示 `🧩`。 |
 | `author` | string | 否 | 作者 / 组织名。 |
 | `homepage` | string | 否 | 主页或仓库 URL。 |
-| `permissions` | string[] | 否 | 声明插件需要的能力，见 §3。缺省视为不需要任何敏感能力。 |
-| `tools` | object[] | 否 | 工具清单（`name` + 中文 `description`），用于插件广场展示与人工审查。`name` 应与 JAR 中 `@Tool` 方法名一致。 |
+| `permissions` | string[] | 否 | 声明插件**被授予**的能力，见 §3。缺省视为不需要任何敏感能力。 |
+| `tools` | object[] | 否 | 工具清单（`name` + 中文 `description` + 可选 `permissions`），用于插件广场展示、人工审查与 v2 权限校验。`name` 应与 JAR 中 `@Tool` 方法名一致；`permissions` 声明**该工具运行所需**的能力（v2 新增，见 §3）。 |
 | `frontendEntry` | string | 否 | 前端入口（预留，v1 不加载）。 |
 | `backendJars` | string[] | 否 | 相对插件目录的 JAR 文件名列表，启动/重扫时加载其中带 `@Tool` 注解的类。 |
 
 未知字段被忽略（向前兼容）；`permissions` 中出现 v1 未定义的值仅记录 WARN，不拒绝加载。
 
-## 3. permissions 权限声明（v1）
-
-v1 权限为**声明式**：用于插件广场展示与管理员审查，运行时沙箱强制执行在 Phase 3 后续（见 docs/AI_ARCHITECTURE.md TODO）。
+## 3. permissions 权限模型（v2）
 
 | 值 | 含义 |
 |---|---|
@@ -64,6 +62,22 @@ v1 权限为**声明式**：用于插件广场展示与管理员审查，运行�
 | `file_write` | 创建 / 修改 / 删除项目文件 |
 | `network` | 访问外部网络（HTTP 等出站请求） |
 | `editor` | 操作文档编辑器（LOWA/LibreOffice 相关原语） |
+
+### v2 执行语义（分发前校验）
+
+两级声明 + 分发时校验（实现在 `PluginService.missingPermissionsForTool()` +
+`ToolRegistry.execute()`）：
+
+- **插件级 `permissions`**：插件被授予的能力全集，管理员在插件广场审查的对象。
+- **工具级 `tools[].permissions`**：单个工具运行所需的能力。
+- **校验规则**：分发插件工具前检查「工具所需 ⊆ 插件声明」；有所需权限未在插件级
+  `permissions` 声明时**拒绝执行**，返回
+  `Error: permission denied — tool 'x' requires permission(s) [...] not declared in the plugin manifest "permissions"`。
+- **v1 兼容**：工具未列入 `tools[]` 或未写 `permissions` 视为无敏感能力需求，直接放行；
+  内置工具（不属于任何插件）不参与校验。
+
+> 边界：v2 校验发生在分发层（诚实声明模型），插件代码本身仍与宿主同进程运行，
+> **进程级沙箱（真正阻止未声明的文件/网络访问）是后续项**，见 docs/AI_ARCHITECTURE.md Phase 3 TODO。
 
 ## 4. 后端工具（backendJars）约定
 
@@ -75,7 +89,11 @@ v1 权限为**声明式**：用于插件广场展示与管理员审查，运行�
 
 - 默认**启用**；禁用名单持久化在 `system_setting` 表（key = `ai.plugins.disabled`，值为插件 id 的 JSON 数组），重启后保持。
 - 查询接口：`PluginService.isEnabled(pluginId)`；工具归属：`PluginService.getPluginIdForTool(toolName)`。
-- v1 范围：启停状态已持久化并在插件广场展示，**ToolRegistry 按启停过滤工具的接入是 Phase 3 后续**（接入点见 docs/AI_ARCHITECTURE.md TODO），即 v1 中禁用插件后其工具暂不会立即从 Agent 可用工具中移除。
+- **v2 起 ToolRegistry 按启停过滤**（Phase 3A）：禁用插件后其工具在三处消费点全部不可见——
+  LLM 拿不到工具规格（`getAllSpecifications`）、XML 协议解析不识别（`toolNamesLongestFirst`）、
+  分发返回 not found（`resolve`）；重新启用即时恢复，内置工具不受影响。
+- 启停查询走内存缓存，TTL（配置 `ai.plugins.disabled-cache-ttl-ms`，默认 5000ms）过期后从
+  `system_setting` 重读：同 JVM 内启停即时生效，外部直接改库在 TTL 内收敛，工具调用高频路径不打库。
 
 ## 6. HTTP API
 
@@ -90,5 +108,8 @@ v1 权限为**声明式**：用于插件广场展示与管理员审查，运行�
 
 ## 7. 版本演进
 
-- **v1（当前）**：声明式 manifest + 启停持久化 + 插件广场展示。
-- 规划中（Phase 3 后续，见 AI_ARCHITECTURE.md）：ToolRegistry 按启停/权限过滤、运行时沙箱强制 permissions、frontendEntry 动态加载、插件签名与来源校验。
+- **v1（0.4.x）**：声明式 manifest + 启停持久化 + 插件广场展示。
+- **v2（当前，Phase 3A）**：ToolRegistry 按启停过滤三处消费点 + `tools[].permissions`
+  分发前权限校验（诚实声明模型）+ 启停缓存 TTL。
+- 规划中（见 AI_ARCHITECTURE.md Phase 3 TODO）：进程级运行时沙箱（真正强制 file/network 隔离）、
+  frontendEntry 动态加载、插件签名与来源校验。


### PR DESCRIPTION
## Phase 3A（Phase 3 地基，3B Skill 体系 / 3C 多智能体依赖本 PR 的工具可见性机制）

### 插件启停接入 ToolRegistry
- 三处消费点过滤：`getAllSpecifications`（LLM 看不到禁用插件的工具规格）、`toolNamesLongestFirst`（XML 协议解析不识别）、`resolve`（分发返回 not found）
- 判定：`pid == null || pluginService.isEnabled(pid)`——内置工具 pid==null，不受启停影响；重新启用即时恢复
- `isEnabled` 走内存缓存 + TTL 重读（`ai.plugins.disabled-cache-ttl-ms` 默认 5s）：同 JVM 启停即时生效，外部改库 TTL 内收敛，工具调用不打库

### manifest permissions 从声明升级为执行（规范 v2）
- `tools[].permissions` 声明单个工具所需能力；分发前校验「所需 ⊆ 插件级 permissions」，未声明即拒绝并返回明确错误
- v1 兼容：未列 tools[] 或未写 permissions 的工具直接放行
- 边界：分发层诚实声明模型；进程级沙箱登记为 Phase 3 后续项（docs/AI_ARCHITECTURE.md）

### 测试
`mvn test`（JDK 21）：**160 run / 0 fail / 1 skip**（RealLlmSmokeTest 无 key 预期跳过），评测回放 24 用例全绿。
新增：启停三消费点往返恢复、内置工具不受影响、权限拒绝/放行、v2 manifest 解析、TTL 外部改库收敛。

🤖 Generated with [Claude Code](https://claude.com/claude-code)