### PR TITLE
feat(ai): Phase 3C 多智能体第一阶段——dispatch_subtask 委派子任务 / sub-agent delegation

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentProperties.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentProperties.java
@@ -1,0 +1,48 @@
+package com.checkba.service.ai.subagent;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 子 Agent（Phase 3C 多智能体第一阶段）配置。
+ *
+ * 配置前缀：ai.subagent
+ *
+ * 遵循不变式 5（配置外置）：轮数上限、并行度、token 预算、超时等
+ * 限值一律来自本配置，不写死在代码里。
+ */
+@Component
+@ConfigurationProperties(prefix = "ai.subagent")
+public class SubAgentProperties {
+
+    /** 单个子任务的 Thought→Action→Observation 轮数上限 */
+    private int maxRounds = 6;
+
+    /** 子任务专用线程池大小 = 同时运行的子任务数上限 */
+    private int maxParallel = 3;
+
+    /** 单个子任务的总超时（秒），超时返回明确错误结果、不挂死主循环 */
+    private int timeoutSeconds = 180;
+
+    /** 子 Agent 消息栈的 token 预算（估算值，超出即中止并返回错误结果） */
+    private int tokenBudget = 30000;
+
+    /** token 估算系数：每个 token 约折合多少字符（与 ai.context.chars-per-token 口径一致） */
+    private double charsPerToken = 2.0;
+
+    /** 子 Agent 使用的模型 ID；为空则继承主会话所选模型 */
+    private String model = "";
+
+    public int getMaxRounds() { return maxRounds; }
+    public void setMaxRounds(int maxRounds) { this.maxRounds = maxRounds; }
+    public int getMaxParallel() { return maxParallel; }
+    public void setMaxParallel(int maxParallel) { this.maxParallel = maxParallel; }
+    public int getTimeoutSeconds() { return timeoutSeconds; }
+    public void setTimeoutSeconds(int timeoutSeconds) { this.timeoutSeconds = timeoutSeconds; }
+    public int getTokenBudget() { return tokenBudget; }
+    public void setTokenBudget(int tokenBudget) { this.tokenBudget = tokenBudget; }
+    public double getCharsPerToken() { return charsPerToken; }
+    public void setCharsPerToken(double charsPerToken) { this.charsPerToken = charsPerToken; }
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
+}

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentResult.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentResult.java
@@ -1,0 +1,48 @@
+package com.checkba.service.ai.subagent;
+
+import java.util.List;
+
+/**
+ * 子任务的最终结构化结果——子 Agent 的中间过程（消息栈、工具输出）
+ * 不写入主对话历史，只有本结果作为 dispatch_subtask 的工具输出返回给主循环。
+ *
+ * @param subtaskId 子任务 ID（subtask_progress SSE 事件里的 taskId 与此一致）
+ * @param success   是否成功产出最终答案
+ * @param result    成功时的结果文本（失败时为 null）
+ * @param error     失败原因（成功时为 null）
+ * @param toolsUsed 子 Agent 实际调用过的工具名（别名解析后，按调用顺序）
+ * @param rounds    实际消耗的循环轮数
+ */
+public record SubAgentResult(
+        String subtaskId,
+        boolean success,
+        String result,
+        String error,
+        List<String> toolsUsed,
+        int rounds
+) {
+
+    public static SubAgentResult success(String subtaskId, String result, List<String> toolsUsed, int rounds) {
+        return new SubAgentResult(subtaskId, true, result, null, List.copyOf(toolsUsed), rounds);
+    }
+
+    public static SubAgentResult failure(String subtaskId, String error, List<String> toolsUsed, int rounds) {
+        return new SubAgentResult(subtaskId, false, null, error, List.copyOf(toolsUsed), rounds);
+    }
+
+    /** 序列化为返回给主循环 LLM 的 JSON 工具输出 */
+    public String toJson() {
+        cn.hutool.json.JSONObject o = new cn.hutool.json.JSONObject();
+        o.set("subtaskId", subtaskId);
+        o.set("success", success);
+        if (result != null) {
+            o.set("result", result);
+        }
+        if (error != null) {
+            o.set("error", error);
+        }
+        o.set("toolsUsed", toolsUsed);
+        o.set("rounds", rounds);
+        return o.toString();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
@@ -1,0 +1,325 @@
+package com.checkba.service.ai.subagent;
+
+import cn.hutool.json.JSONUtil;
+import com.checkba.dto.ai.TaskProgressEvent;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.SseEmitterService;
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.XmlToolCallParser;
+import com.checkba.service.ai.tools.ToolContext;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 子 Agent 服务（Phase 3C 多智能体协作第一阶段）。
+ *
+ * 一个子 Agent = 独立消息栈（不进主会话历史）+ 受限工具集 + 独立模型
+ * + 轮数上限 + token 预算。它是主循环（AgentOrchestrator.runLoop）的极简版：
+ * 同样支持原生 function calling 与 XML &lt;tool_code&gt; 双协议，
+ * 但**不复用**主循环的 SSE 推流与消息持久化——中间过程对主会话不可见，
+ * 只把最终结构化结果（{@link SubAgentResult}）返回给调用方。
+ *
+ * 约束（见 docs/AI_ARCHITECTURE.md「子 Agent（Phase 3C）」）：
+ * - 复用 {@link ToolRegistry} 分发工具、{@link ChatModelFactory} 建模型；
+ * - 身份继承（不变式 3）：工具调用的 ToolContext 继承主会话的
+ *   projectId/conversationId/userId，LLM 无法伪造；
+ * - 防递归：子 Agent 工具集排除 dispatch_subtask，且分发前二次拦截；
+ * - 并行度/轮数/预算/超时全部来自 {@link SubAgentProperties}（不变式 5）；
+ * - 子任务开始/结束向主会话 SSE 发送 subtask_progress 事件（新增事件，向后兼容）。
+ */
+@Service
+@Slf4j
+public class SubAgentService {
+
+    /** 委派工具名（防递归拦截用，与 SubAgentTools#dispatch_subtask 方法名一致） */
+    public static final String DISPATCH_TOOL_NAME = "dispatch_subtask";
+
+    /** 标记当前线程正在运行子 Agent 循环（防递归的第二道防线） */
+    private static final ThreadLocal<Boolean> IN_SUB_AGENT = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    public static boolean inSubAgent() {
+        return Boolean.TRUE.equals(IN_SUB_AGENT.get());
+    }
+
+    private final ToolRegistry toolRegistry;
+    private final ChatModelFactory chatModelFactory;
+    private final XmlToolCallParser xmlToolCallParser;
+    private final SseEmitterService sseEmitterService;
+    private final SubAgentProperties props;
+    private final ExecutorService executor;
+
+    public SubAgentService(ToolRegistry toolRegistry,
+                           ChatModelFactory chatModelFactory,
+                           XmlToolCallParser xmlToolCallParser,
+                           SseEmitterService sseEmitterService,
+                           SubAgentProperties props) {
+        this.toolRegistry = toolRegistry;
+        this.chatModelFactory = chatModelFactory;
+        this.xmlToolCallParser = xmlToolCallParser;
+        this.sseEmitterService = sseEmitterService;
+        this.props = props;
+        AtomicInteger seq = new AtomicInteger();
+        // 专用线程池：与主循环的 taskExecutor 隔离，池大小 = 子任务并行度上限
+        this.executor = new ThreadPoolExecutor(
+                props.getMaxParallel(), props.getMaxParallel(),
+                60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
+                r -> {
+                    Thread t = new Thread(r, "sub-agent-" + seq.incrementAndGet());
+                    t.setDaemon(true);
+                    return t;
+                });
+        ((ThreadPoolExecutor) this.executor).allowCoreThreadTimeOut(true);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * 委派一个子任务并阻塞等待其结构化结果（带超时保护，不挂死主循环）。
+     *
+     * @param taskDescription 子任务的完整独立描述
+     * @param expectedOutput  期望产出的描述
+     * @param toolScope       子 Agent 可用工具名（空 = 全部工具）；dispatch_subtask 恒被排除
+     * @param parentCtx       主会话工具上下文——projectId/conversationId/userId 由此继承（不变式 3）
+     */
+    public SubAgentResult dispatch(String taskDescription, String expectedOutput,
+                                   List<String> toolScope, ToolContext parentCtx) {
+        String subtaskId = "subtask-" + UUID.randomUUID().toString().substring(0, 8);
+        sendProgress(parentCtx, subtaskId, "started", 0, "子任务开始：" + brief(taskDescription));
+
+        Future<SubAgentResult> future = executor.submit(() -> {
+            IN_SUB_AGENT.set(Boolean.TRUE);
+            try {
+                return runLoop(subtaskId, taskDescription, expectedOutput, toolScope, parentCtx);
+            } finally {
+                IN_SUB_AGENT.remove();
+            }
+        });
+
+        SubAgentResult result;
+        try {
+            result = future.get(props.getTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            result = SubAgentResult.failure(subtaskId,
+                    "sub-agent timed out after " + props.getTimeoutSeconds() + "s", List.of(), 0);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            future.cancel(true);
+            result = SubAgentResult.failure(subtaskId, "sub-agent interrupted", List.of(), 0);
+        } catch (Exception e) {
+            log.error("Sub-agent {} failed unexpectedly", subtaskId, e);
+            result = SubAgentResult.failure(subtaskId,
+                    "sub-agent failed: " + e.getMessage(), List.of(), 0);
+        }
+
+        sendProgress(parentCtx, subtaskId,
+                result.success() ? "succeeded" : "failed", 100,
+                result.success() ? "子任务完成" : "子任务失败：" + brief(result.error()));
+        return result;
+    }
+
+    /**
+     * 子 Agent 循环：主循环的极简版（Thought→Action→Observation，双协议），
+     * 无 SSE 推流、无消息持久化、无 artifact/title 等主会话专属分支。
+     */
+    SubAgentResult runLoop(String subtaskId, String taskDescription, String expectedOutput,
+                           List<String> toolScope, ToolContext parentCtx) {
+        Set<String> allowed = resolveScope(toolScope);
+        List<ToolSpecification> specs = toolRegistry.getAllSpecifications().stream()
+                .filter(s -> allowed.contains(s.name()))
+                .toList();
+
+        String modelId = (props.getModel() != null && !props.getModel().isBlank())
+                ? props.getModel()
+                : (parentCtx != null ? parentCtx.modelId() : null);
+        ChatLanguageModel model = chatModelFactory.getChatModel(modelId);
+        // 子 Agent 的工具调用继承主会话身份（不变式 3），模型可独立
+        ToolContext subCtx = parentCtx == null
+                ? new ToolContext(null, null, null, modelId)
+                : new ToolContext(parentCtx.projectId(), parentCtx.conversationId(), parentCtx.userId(), modelId);
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(SystemMessage.from(buildSystemPrompt(expectedOutput, allowed)));
+        messages.add(UserMessage.from(taskDescription));
+
+        List<String> toolsUsed = new ArrayList<>();
+        long charBudget = (long) (props.getTokenBudget() * props.getCharsPerToken());
+
+        for (int round = 1; round <= props.getMaxRounds(); round++) {
+            if (Thread.currentThread().isInterrupted()) {
+                return SubAgentResult.failure(subtaskId, "sub-agent interrupted", toolsUsed, round - 1);
+            }
+            if (estimateChars(messages) > charBudget) {
+                return SubAgentResult.failure(subtaskId,
+                        "sub-agent token budget exceeded (" + props.getTokenBudget() + " tokens)",
+                        toolsUsed, round - 1);
+            }
+
+            Response<AiMessage> response;
+            try {
+                response = specs.isEmpty() ? model.generate(messages) : model.generate(messages, specs);
+            } catch (Exception e) {
+                log.warn("Sub-agent {} LLM call failed at round {}", subtaskId, round, e);
+                return SubAgentResult.failure(subtaskId,
+                        "sub-agent LLM call failed: " + e.getMessage(), toolsUsed, round - 1);
+            }
+            AiMessage aiMessage = response.content();
+            messages.add(aiMessage);
+
+            // 协议 1：原生 function calling
+            if (aiMessage.hasToolExecutionRequests()) {
+                for (ToolExecutionRequest req : aiMessage.toolExecutionRequests()) {
+                    String output = executeScoped(req.name(), req.arguments(), allowed, subCtx, toolsUsed);
+                    messages.add(ToolExecutionResultMessage.from(req, output));
+                }
+                continue;
+            }
+
+            String text = aiMessage.text() == null ? "" : aiMessage.text();
+
+            // 协议 2：XML <tool_code> 兜底
+            if (xmlToolCallParser.containsToolCall(text)) {
+                boolean executed = false;
+                for (XmlToolCallParser.ParsedCall call : xmlToolCallParser.parse(text)) {
+                    String output = executeScoped(call.toolName(), call.argsJson(), allowed, subCtx, toolsUsed);
+                    messages.add(UserMessage.from("[Tool Execution Result]\nTool: " + call.rawCode()
+                            + "\nOutput: " + output));
+                    executed = true;
+                }
+                if (executed) {
+                    continue;
+                }
+            }
+
+            // 无工具调用 = 最终答案
+            return SubAgentResult.success(subtaskId, text.trim(), toolsUsed, round);
+        }
+
+        return SubAgentResult.failure(subtaskId,
+                "sub-agent reached max rounds (" + props.getMaxRounds() + ") without a final answer",
+                toolsUsed, props.getMaxRounds());
+    }
+
+    /** 受限分发：先别名解析，再做防递归与工具域校验，最后经 ToolRegistry 执行 */
+    private String executeScoped(String rawName, String argsJson, Set<String> allowed,
+                                 ToolContext subCtx, List<String> toolsUsed) {
+        String resolved = ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(rawName, rawName);
+        if (DISPATCH_TOOL_NAME.equals(resolved)) {
+            return "Error: dispatch_subtask is not available inside a sub-agent (nested delegation refused).";
+        }
+        if (!allowed.contains(resolved)) {
+            return "Error: tool '" + resolved + "' is outside this sub-agent's tool scope.";
+        }
+        toolsUsed.add(resolved);
+        ToolRegistry.ToolResult result = toolRegistry.execute(rawName, argsJson, subCtx);
+        return result.output();
+    }
+
+    /**
+     * 解析 tool_scope 为别名解析后的可用工具名集合。
+     * 空 scope = 全部已注册工具；dispatch_subtask 无条件排除（防递归第一道防线）。
+     */
+    private Set<String> resolveScope(List<String> toolScope) {
+        Set<String> allowed = new LinkedHashSet<>();
+        if (toolScope == null || toolScope.isEmpty()) {
+            for (ToolSpecification spec : toolRegistry.getAllSpecifications()) {
+                allowed.add(spec.name());
+            }
+        } else {
+            for (String name : toolScope) {
+                if (name == null || name.isBlank()) {
+                    continue;
+                }
+                allowed.add(ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(name.trim(), name.trim()));
+            }
+        }
+        allowed.remove(DISPATCH_TOOL_NAME);
+        return allowed;
+    }
+
+    private String buildSystemPrompt(String expectedOutput, Set<String> allowed) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("你是一个专注的子任务执行 Agent，只负责完成下面这一个子任务。\n");
+        sb.append("规则：\n");
+        sb.append("1. 需要外部信息时调用可用工具；不需要工具时直接给出答案。\n");
+        sb.append("2. 完成后直接输出最终结果的纯文本，不要输出 <final> 等标签，不要闲聊。\n");
+        sb.append("3. 你不能委派新的子任务（dispatch_subtask 不可用）。\n");
+        if (expectedOutput != null && !expectedOutput.isBlank()) {
+            sb.append("期望产出：").append(expectedOutput).append("\n");
+        }
+        if (!allowed.isEmpty()) {
+            sb.append("可用工具：").append(String.join(", ", allowed)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private long estimateChars(List<ChatMessage> messages) {
+        long total = 0;
+        for (ChatMessage m : messages) {
+            try {
+                String text = m.text();
+                if (text != null) {
+                    total += text.length();
+                }
+            } catch (Exception ignored) {
+                // 多模态等无纯文本表示的消息忽略
+            }
+        }
+        return total;
+    }
+
+    /** 子任务开始/结束向主会话推送 subtask_progress（新增 SSE 事件，结构对齐 TaskProgressEvent） */
+    private void sendProgress(ToolContext ctx, String subtaskId, String stage, int progress, String message) {
+        if (ctx == null || ctx.conversationId() == null) {
+            return;
+        }
+        try {
+            TaskProgressEvent event = TaskProgressEvent.builder()
+                    .taskId(subtaskId)
+                    .taskType("SUBTASK")
+                    .source("SUB_AGENT")
+                    .progress(progress)
+                    .message(message)
+                    .stage(stage)
+                    .timestamp(System.currentTimeMillis())
+                    .build();
+            sseEmitterService.send(ctx.conversationId(), "subtask_progress", JSONUtil.toJsonStr(event));
+        } catch (Exception e) {
+            log.warn("Failed to send subtask_progress for {}", subtaskId, e);
+        }
+    }
+
+    private String brief(String text) {
+        if (text == null) {
+            return "";
+        }
+        String oneLine = text.replaceAll("\\s+", " ").trim();
+        return oneLine.length() > 60 ? oneLine.substring(0, 60) + "…" : oneLine;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/SubAgentTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/SubAgentTools.java
@@ -1,0 +1,85 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.subagent.SubAgentResult;
+import com.checkba.service.ai.subagent.SubAgentService;
+import dev.langchain4j.agent.tool.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 委派子任务工具（Phase 3C 多智能体协作第一阶段）。
+ *
+ * 把一个自包含的复杂子问题交给独立的子 Agent 循环执行，
+ * 子 Agent 的中间过程不进入主会话历史，只返回最终结构化结果。
+ * 身份字段（projectId/conversationId/userId）从 {@link ToolContextHolder}
+ * 继承主会话上下文（不变式 3），LLM 无法伪造。
+ */
+@Component
+public class SubAgentTools implements AgentToolComponent {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SubAgentTools.class);
+
+    private final SubAgentService subAgentService;
+
+    public SubAgentTools(SubAgentService subAgentService) {
+        this.subAgentService = subAgentService;
+    }
+
+    @ToolMeta(displayName = "委派子任务", category = "agent")
+    @Tool("Delegate a self-contained subtask to an independent sub-agent that runs its own tool-use loop "
+            + "and returns only the final structured result (JSON: success/result/error/toolsUsed/rounds). "
+            + "Use ONLY for complex sub-problems that need independent multi-step exploration or produce lots "
+            + "of intermediate output. NEVER delegate simple tasks you can do directly with one or two tool calls. "
+            + "task_description: complete standalone description of the subtask (the sub-agent cannot see this "
+            + "conversation). expected_output: precise description of what the result must contain. "
+            + "tool_scope: tool names the sub-agent may use, as a JSON array or comma-separated string "
+            + "(empty = all tools). dispatch_subtask itself is never available to the sub-agent.")
+    public String dispatch_subtask(String task_description, String expected_output, String tool_scope) {
+        log.info("Tool: dispatch_subtask called, scope='{}'", tool_scope);
+        if (SubAgentService.inSubAgent()) {
+            // 防递归第二道防线（第一道在 SubAgentService 的分发拦截）
+            return "Error: dispatch_subtask is not available inside a sub-agent (nested delegation refused).";
+        }
+        if (task_description == null || task_description.isBlank()) {
+            return "Error: task_description is required.";
+        }
+        ToolContext ctx = ToolContextHolder.get();
+        SubAgentResult result = subAgentService.dispatch(
+                task_description, expected_output, parseToolScope(tool_scope), ctx);
+        return result.toJson();
+    }
+
+    /**
+     * 容错解析 tool_scope：JSON 数组（["a","b"]）或逗号/顿号分隔字符串（"a, b"）均可。
+     */
+    public static List<String> parseToolScope(String toolScope) {
+        List<String> names = new ArrayList<>();
+        if (toolScope == null || toolScope.isBlank()) {
+            return names;
+        }
+        String trimmed = toolScope.trim();
+        if (trimmed.startsWith("[")) {
+            try {
+                for (Object item : cn.hutool.json.JSONUtil.parseArray(trimmed)) {
+                    if (item != null && !String.valueOf(item).isBlank()) {
+                        names.add(String.valueOf(item).trim());
+                    }
+                }
+                return names;
+            } catch (Exception ignored) {
+                // 非法 JSON 数组，退回分隔符解析
+            }
+        }
+        for (String part : trimmed.split("[,，、;\\s]+")) {
+            String name = part.trim()
+                    .replaceAll("^[\\[\"']+", "")
+                    .replaceAll("[\\]\"']+$", "");
+            if (!name.isBlank()) {
+                names.add(name);
+            }
+        }
+        return names;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -132,6 +132,20 @@ ai:
       chat-selection-max-chars: 1500
     # 支持 OCR 的文件扩展名
     ocr-extensions: [jpg, jpeg, png, gif, bmp, webp, pdf]
+  # 子 Agent（dispatch_subtask 委派子任务）配置（对应 SubAgentProperties，以下均为默认值）
+  subagent:
+    # 单个子任务的循环轮数上限
+    max-rounds: 6
+    # 同时运行的子任务数上限（专用线程池大小）
+    max-parallel: 3
+    # 单个子任务超时（秒）
+    timeout-seconds: 180
+    # 子 Agent 消息栈 token 预算（估算）
+    token-budget: 30000
+    # token 估算系数（与 ai.context.chars-per-token 口径一致）
+    chars-per-token: 2.0
+    # 子 Agent 模型 ID；留空则继承主会话所选模型
+    model: ""
 
 # 文件存储配置
 storage:

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -375,6 +375,15 @@ for file_id in file_ids:
 ## 6. Memory (`add_memory`, `query_knowledge_base`)
 - Store and retrieve knowledge from RAG
 
+## 6.5 委派子任务 (`dispatch_subtask`)
+- `dispatch_subtask(task_description, expected_output, tool_scope)`：把一个自包含的复杂子问题交给独立子 Agent 执行，只返回最终结构化结果（JSON：success/result/error/toolsUsed/rounds），中间过程不占用当前对话。
+- **什么时候委派**：子问题需要独立的多步探索（如"检索并整理某专题的裁判观点"），或会产生大量中间产物（多轮搜索/浏览/读文件）而你只需要结论时。
+- **简单任务禁止委派**：一两次工具调用能直接完成的事（一次搜索、读一个文件、一次替换）必须自己做，不要委派。
+- `task_description` 必须自包含：子 Agent 看不到当前对话，把背景、对象、限定条件写全。
+- `expected_output` 要写清楚：明确结果的形式与要点（如"5 条以内的要点列表，每条附来源链接"），不要留空泛表述。
+- `tool_scope` 只给子任务所需的最小工具集（JSON 数组或逗号分隔，如 `"search_web,browse_url"`；留空 = 全部工具）。
+- 子任务失败（超时/超预算/轮数耗尽）会返回 `success=false` 与 error 说明：据此自己接手或换策略，不要重复原样委派。
+
 ## 7. 文档编辑（嵌入式 LibreOffice 编辑器）
 
 你具备直接编辑用户项目中文档的能力，如同一个坐在文档前的人类编辑：移动光标、选中、修改、排版。用户能在编辑器里**实时看到**你的光标跳转和选区高亮。

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -8,6 +8,7 @@ import com.checkba.service.ai.tools.MemoryTools;
 import com.checkba.service.ai.tools.PptxEditTools;
 import com.checkba.service.ai.tools.PptxTools;
 import com.checkba.service.ai.tools.PythonTools;
+import com.checkba.service.ai.tools.SubAgentTools;
 import com.checkba.service.ai.tools.WebTools;
 
 import java.lang.reflect.Constructor;
@@ -40,6 +41,7 @@ final class RealToolBeans {
                 PptxEditTools.class,
                 PptxTools.class,
                 PythonTools.class,
+                SubAgentTools.class,
                 WebTools.class);
         List<AgentToolComponent> beans = new ArrayList<>();
         for (Class<? extends AgentToolComponent> type : toolClasses) {

--- a/backend/src/test/java/com/checkba/service/ai/subagent/SubAgentServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/subagent/SubAgentServiceTest.java
@@ -1,0 +1,211 @@
+package com.checkba.service.ai.subagent;
+
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.SseEmitterService;
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.XmlToolCallParser;
+import com.checkba.service.ai.tools.ToolContext;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * SubAgentService 单测：循环上限 / token 预算 / 超时 / 防递归 / 工具域 / 身份继承（不变式 3）。
+ * LLM 用 Mockito 打桩，ToolRegistry 用 mock 记录分发（不真执行工具）。
+ */
+@DisplayName("子 Agent 服务（Phase 3C）")
+class SubAgentServiceTest {
+
+    private static final ToolContext PARENT_CTX =
+            new ToolContext(42L, "conv-main", 7L, "anthropic/claude-3.5-sonnet");
+
+    private ToolRegistry registry;
+    private ChatModelFactory modelFactory;
+    private ChatLanguageModel model;
+    private SseEmitterService sse;
+    private SubAgentProperties props;
+
+    @BeforeEach
+    void setUp() {
+        registry = mock(ToolRegistry.class);
+        when(registry.getAllSpecifications()).thenReturn(List.of(
+                ToolSpecification.builder().name("search_web").description("web search").build(),
+                ToolSpecification.builder().name("read_document").description("read file").build(),
+                ToolSpecification.builder().name("dispatch_subtask").description("delegate").build()));
+        when(registry.execute(any(), any(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("tool output (test stub)", null, true));
+
+        model = mock(ChatLanguageModel.class);
+        modelFactory = mock(ChatModelFactory.class);
+        when(modelFactory.getChatModel(any())).thenReturn(model);
+
+        sse = mock(SseEmitterService.class);
+        props = new SubAgentProperties();
+    }
+
+    private SubAgentService newService() {
+        return new SubAgentService(registry, modelFactory, new XmlToolCallParser(registry), sse, props);
+    }
+
+    private static Response<AiMessage> toolCallTurn(String toolName, String argsJson) {
+        return Response.from(AiMessage.from(ToolExecutionRequest.builder()
+                .id("req-" + toolName).name(toolName).arguments(argsJson).build()));
+    }
+
+    private static Response<AiMessage> textTurn(String text) {
+        return Response.from(AiMessage.from(text));
+    }
+
+    @Test
+    @DisplayName("身份继承（不变式 3）：子 Agent 工具调用的 ToolContext 与主会话一致 + 进度事件成对发送")
+    void identityInheritedFromParentContext() {
+        when(model.generate(anyList(), anyList())).thenReturn(
+                toolCallTurn("search_web", "{\"query\":\"对赌协议\"}"),
+                textTurn("要点：1……"));
+
+        SubAgentResult result = newService().dispatch("调研对赌协议裁判观点", "要点列表",
+                List.of("search_web"), PARENT_CTX);
+
+        assertTrue(result.success(), "应成功: " + result.toJson());
+        assertEquals(List.of("search_web"), result.toolsUsed());
+        assertEquals(2, result.rounds());
+        assertTrue(result.result().contains("要点"));
+
+        ArgumentCaptor<ToolContext> ctxCaptor = ArgumentCaptor.forClass(ToolContext.class);
+        verify(registry).execute(eq("search_web"), any(), ctxCaptor.capture());
+        ToolContext used = ctxCaptor.getValue();
+        assertNotNull(used);
+        assertEquals(PARENT_CTX.projectId(), used.projectId(), "projectId 必须继承主会话");
+        assertEquals(PARENT_CTX.conversationId(), used.conversationId(), "conversationId 必须继承主会话");
+        assertEquals(PARENT_CTX.userId(), used.userId(), "userId 必须继承主会话");
+        // 未配置独立模型时继承主会话模型
+        assertEquals(PARENT_CTX.modelId(), used.modelId());
+
+        // 子任务开始/结束各发一次 subtask_progress（发到主会话 conversationId）
+        verify(sse, times(2)).send(eq("conv-main"), eq("subtask_progress"), any());
+    }
+
+    @Test
+    @DisplayName("防递归：子 Agent 内调用 dispatch_subtask 被拒绝，不经 ToolRegistry 分发")
+    void recursionRefused() {
+        when(model.generate(anyList(), anyList())).thenReturn(
+                toolCallTurn("dispatch_subtask", "{\"task_description\":\"再拆一层\"}"),
+                textTurn("最终结果"));
+
+        SubAgentResult result = newService().dispatch("任务", "结果", List.of(), PARENT_CTX);
+
+        assertTrue(result.success());
+        // dispatch_subtask 从未真正分发
+        verify(registry, never()).execute(eq("dispatch_subtask"), any(), any());
+        assertTrue(result.toolsUsed().isEmpty(), "拒绝的调用不计入 toolsUsed");
+
+        // 拒绝错误作为工具结果回喂给了子模型
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ChatMessage>> messagesCaptor = ArgumentCaptor.forClass((Class) List.class);
+        verify(model, atLeastOnce()).generate(messagesCaptor.capture(), anyList());
+        boolean refusalFedBack = messagesCaptor.getValue().stream()
+                .anyMatch(m -> {
+                    try {
+                        return m.text() != null && m.text().contains("nested delegation refused");
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+        assertTrue(refusalFedBack, "子模型应收到明确的递归拒绝错误");
+    }
+
+    @Test
+    @DisplayName("轮数上限：耗尽后返回明确失败结果")
+    void maxRoundsExceeded() {
+        props.setMaxRounds(2);
+        when(model.generate(anyList(), anyList()))
+                .thenReturn(toolCallTurn("search_web", "{\"query\":\"a\"}"))
+                .thenReturn(toolCallTurn("search_web", "{\"query\":\"b\"}"));
+
+        SubAgentResult result = newService().dispatch("查不完的任务", null, List.of("search_web"), PARENT_CTX);
+
+        assertFalse(result.success());
+        assertTrue(result.error().contains("max rounds"), "错误信息应说明轮数耗尽: " + result.error());
+        assertEquals(2, result.rounds());
+        assertEquals(List.of("search_web", "search_web"), result.toolsUsed());
+    }
+
+    @Test
+    @DisplayName("token 预算：超出后立即中止，不再调用 LLM")
+    void tokenBudgetExceeded() {
+        props.setTokenBudget(1);
+        props.setCharsPerToken(1.0);
+
+        SubAgentResult result = newService().dispatch("这条任务描述本身就超过一个 token 的预算了",
+                null, List.of("search_web"), PARENT_CTX);
+
+        assertFalse(result.success());
+        assertTrue(result.error().contains("token budget"), "错误信息应说明预算超限: " + result.error());
+        verify(model, never()).generate(anyList(), anyList());
+    }
+
+    @Test
+    @DisplayName("超时：返回明确错误结果，不挂死调用方")
+    void timeoutReturnsExplicitError() {
+        props.setTimeoutSeconds(1);
+        when(model.generate(anyList(), anyList())).thenAnswer(inv -> {
+            Thread.sleep(10_000);
+            return textTurn("太迟了");
+        });
+
+        SubAgentResult result = newService().dispatch("慢任务", null, List.of("search_web"), PARENT_CTX);
+
+        assertFalse(result.success());
+        assertTrue(result.error().contains("timed out"), "错误信息应说明超时: " + result.error());
+    }
+
+    @Test
+    @DisplayName("工具域：scope 外的工具被拒绝，不经 ToolRegistry 分发")
+    void toolScopeEnforced() {
+        when(model.generate(anyList(), anyList())).thenReturn(
+                toolCallTurn("read_document", "{\"fileId\":\"1\"}"),
+                textTurn("好的，我不读文件了，直接给结论"));
+
+        SubAgentResult result = newService().dispatch("任务", null, List.of("search_web"), PARENT_CTX);
+
+        assertTrue(result.success());
+        verify(registry, never()).execute(eq("read_document"), any(), any());
+        assertTrue(result.toolsUsed().isEmpty());
+    }
+
+    @Test
+    @DisplayName("tool_scope 容错解析：JSON 数组与逗号/顿号分隔均可")
+    void parseToolScopeTolerant() {
+        assertEquals(List.of("search_web", "browse_url"),
+                com.checkba.service.ai.tools.SubAgentTools.parseToolScope("[\"search_web\", \"browse_url\"]"));
+        assertEquals(List.of("search_web", "browse_url"),
+                com.checkba.service.ai.tools.SubAgentTools.parseToolScope("search_web, browse_url"));
+        assertEquals(List.of("search_web", "browse_url"),
+                com.checkba.service.ai.tools.SubAgentTools.parseToolScope("search_web、browse_url"));
+        assertTrue(com.checkba.service.ai.tools.SubAgentTools.parseToolScope("  ").isEmpty());
+        assertTrue(com.checkba.service.ai.tools.SubAgentTools.parseToolScope(null).isEmpty());
+    }
+}

--- a/backend/src/test/resources/ai-eval/cases/cases-subagent.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-subagent.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "subagent-dispatch-and-summarize-native",
+    "title": "委派子任务：dispatch_subtask 正确分发，主循环拿到结构化结果后汇总输出",
+    "category": "subagent",
+    "protocol": "native",
+    "userInput": "帮我调研最近法院对对赌协议效力的裁判倾向，单独整理成一份要点摘要",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "dispatch_subtask",
+            "arguments": {
+              "task_description": "检索最高人民法院及各地法院关于对赌协议效力的最新裁判观点，整理成要点摘要",
+              "expected_output": "5 条以内的裁判要点列表，每条附来源",
+              "tool_scope": "search_web,browse_url"
+            }
+          }
+        ]
+      },
+      {
+        "text": "<final>子任务已完成，对赌协议效力裁判要点摘要如下：\n1. 与股东对赌原则上有效；\n2. 与目标公司对赌需完成减资程序方可履行金钱补偿……</final>"
+      }
+    ],
+    "toolStubs": {
+      "dispatch_subtask": "{\"subtaskId\":\"subtask-eval-a\",\"success\":true,\"result\":\"1. 与股东对赌原则上有效（九民纪要第5条）；2. 与目标公司对赌，履行补偿义务须先完成减资……\",\"toolsUsed\":[\"search_web\",\"browse_url\"],\"rounds\":3}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "dispatch_subtask",
+          "argsContain": {
+            "task_description": "对赌协议",
+            "expected_output": "裁判要点",
+            "tool_scope": "search_web"
+          }
+        }
+      ],
+      "structureContains": ["<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "subagent-failure-graceful-xml",
+    "title": "子任务失败（超时）：主循环拿到 success=false 的结构化结果后正常收尾，不崩溃",
+    "category": "subagent",
+    "protocol": "xml",
+    "userInput": "把项目里所有合同的付款条款整理成一张对照表",
+    "turns": [
+      {
+        "text": "<process name=\"委派子任务\"><tool_code>dispatch_subtask({\"task_description\": \"逐个读取项目中的合同文件，抽取付款条款并整理为对照表\", \"expected_output\": \"文件名-付款条款对照表\", \"tool_scope\": [\"list_files\", \"read_document\"]})</tool_code></process>"
+      },
+      {
+        "text": "<final>子任务因超时未能完成（sub-agent timed out）。合同数量较多，建议先告诉我优先处理哪几份合同，我直接为你逐份提取付款条款。</final>"
+      }
+    ],
+    "toolStubs": {
+      "dispatch_subtask": "{\"subtaskId\":\"subtask-eval-b\",\"success\":false,\"error\":\"sub-agent timed out after 180s\",\"toolsUsed\":[\"list_files\",\"read_document\"],\"rounds\":4}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "dispatch_subtask",
+          "argsContain": {
+            "task_description": "付款条款",
+            "tool_scope": "read_document"
+          }
+        }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "subagent-recursion-refused-native",
+    "title": "递归拒绝：子 Agent 内调用 dispatch_subtask 被拒（结果透出拒绝错误），主循环只分发一次委派并正常收尾",
+    "category": "subagent",
+    "protocol": "native",
+    "userInput": "调研数据出境合规要求并整理清单，可以拆成子任务做",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "dispatch_subtask",
+            "arguments": {
+              "task_description": "调研中国数据出境的合规要求（安全评估/标准合同/认证三条路径），整理成清单；如有必要可再拆分子任务",
+              "expected_output": "三条路径的适用条件清单",
+              "tool_scope": "search_web"
+            }
+          }
+        ]
+      },
+      {
+        "text": "<final>子任务已返回：子 Agent 尝试再次委派子任务被系统拒绝（nested delegation refused），其余检索正常完成。数据出境三条路径清单如下：……</final>"
+      }
+    ],
+    "toolStubs": {
+      "dispatch_subtask": "{\"subtaskId\":\"subtask-eval-c\",\"success\":true,\"result\":\"检索完成。注：子任务内再次调用 dispatch_subtask 已被拒绝：Error: dispatch_subtask is not available inside a sub-agent (nested delegation refused). 三条路径清单：1. 安全评估……\",\"toolsUsed\":[\"search_web\"],\"rounds\":4}"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "dispatch_subtask",
+          "argsContain": {
+            "task_description": "数据出境",
+            "tool_scope": "search_web"
+          }
+        }
+      ],
+      "structureContains": ["<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -71,6 +71,31 @@ Phase 2.5 未改动，命名迁移列入 Phase 3：
 | write_docx 输出 JSON 键 | `wps_file_id`（前端有字符串匹配逻辑）|
 | 文件实体字段 | `ProjectFile.wpsFileId` |
 
+### 子 Agent（Phase 3C 多智能体协作第一阶段）
+
+主循环通过 `dispatch_subtask(task_description, expected_output, tool_scope)` 工具
+（`SubAgentTools`，普通 `AgentToolComponent`，不变式 1 保持——编排器无感知）把自包含的
+复杂子问题委派给 `SubAgentService`（`service/ai/subagent/`）。子 Agent = 独立消息栈 +
+受限工具集 + 独立模型 + 主循环的极简版双协议循环（原生 function calling + XML 兜底），
+**不复用**主循环的 SSE 推流与消息持久化，中间过程不进对话历史，只把最终结构化结果
+（success / result / error / toolsUsed / rounds，JSON）作为工具输出返回。
+
+约束清单（限值全部在 `ai.subagent.*` / `SubAgentProperties`，不变式 5）：
+
+| 约束 | 机制 | 默认值 |
+|-----|------|-------|
+| 轮数上限 | 循环轮数达 `max-rounds` 即返回明确失败结果 | 6 |
+| 并行度 | 专用线程池（与主循环 taskExecutor 隔离），池大小 = 同时运行子任务上限 | 3 |
+| token 预算 | 每轮前按 `token-budget × chars-per-token` 估算消息栈字符数，超限中止 | 30000 |
+| 超时 | `dispatch` 阻塞等待 `timeout-seconds`，超时取消任务并返回错误结果，不挂死主循环 | 180s |
+| 防递归 | 双防线：子 Agent 工具集无条件排除 `dispatch_subtask`；分发前二次拦截返回明确拒绝错误 | — |
+| 身份继承 | 子 Agent 工具调用的 `ToolContext` 继承主会话 projectId/conversationId/userId（不变式 3），模型可独立（`ai.subagent.model`，留空继承主会话） | — |
+
+子任务开始/结束向主会话推送 **新增** SSE 事件 `subtask_progress`（结构对齐
+`TaskProgressEvent`，taskType=SUBTASK / source=SUB_AGENT / stage=started|succeeded|failed），
+既有事件字典不变（不变式 4）。回放评测见 `cases-subagent.json`；
+循环上限/预算/超时/防递归/身份继承由 `SubAgentServiceTest` 单测守护。
+
 ### 记忆作用域（Phase 1）
 `MemoryEntry.scope`：`user`（跨项目偏好）/ `project`（默认）/ `conversation` / `file`（配 `sourceFileId`）/ `global`（通用知识）。
 
@@ -133,4 +158,7 @@ Phase 2.5 未改动，命名迁移列入 Phase 3：
   - [ ] 插件进程级运行时沙箱：v2 权限校验是分发层的诚实声明模型，插件代码仍与宿主同进程；
         真正强制 file/network 隔离需进程级沙箱（独立进程 + IPC 或 SecurityManager 替代方案），
         列为后续项。
-  - [ ] MCP SDK 标准化、Skill 体系、多智能体协作。
+  - [x] **多智能体协作第一阶段（Phase 3C）**：`dispatch_subtask` 委派子任务
+        （见 §3「子 Agent」）——独立消息栈/受限工具集/独立模型/轮数与预算与超时限值
+        （`ai.subagent.*`）/防递归/身份继承，新增 SSE 事件 `subtask_progress`。
+  - [ ] MCP SDK 标准化、Skill 体系、多智能体协作后续阶段（子任务规划器、跨子任务共享记忆）。

--- a/docs/AI_EVAL.md
+++ b/docs/AI_EVAL.md
@@ -7,7 +7,7 @@
 
 | 部分 | 位置 | 说明 |
 | --- | --- | --- |
-| 评测用例集 | `backend/src/test/resources/ai-eval/cases/*.json` | 24 个法律场景用例（起草、修订、查法条、PPT、闲聊、记忆、artifact 等） |
+| 评测用例集 | `backend/src/test/resources/ai-eval/cases/*.json` | 27 个法律场景用例（起草、修订、查法条、PPT、闲聊、记忆、artifact、子任务委派等） |
 | 回放测试 | `backend/src/test/java/com/checkba/service/ai/eval/OrchestratorReplayEvalTest.java` | **进默认 `mvn test` 套件**，不调真实 LLM，全程离线毫秒级 |
 | 回放 harness | 同目录 `EvalHarness` / `ScriptedStreamingModel` / `RecordingToolRegistry` / `RealToolBeans` | 见下文原理 |
 | 真实 LLM 冒烟 | 同目录 `RealLlmSmokeTest.java` | 默认跳过；设 `OPENROUTER_API_KEY` 后跑 3 个标注 `smoke` 的关键用例 |
@@ -19,7 +19,7 @@
 
 - **真实**：`AgentOrchestrator`（完整 runLoop：XML 与原生两种工具协议、artifact、`<title>`、Ask 模式）、
   `XmlToolCallParser`（全部容错解析）、`ToolRegistry` 的注册与别名解析、**真实工具类的工具名/参数名**
-  （`RealToolBeans` 以空依赖反射实例化 8 个生产工具组件——重构改了工具名或参数名，评测立刻红）。
+  （`RealToolBeans` 以空依赖反射实例化 9 个生产工具组件——重构改了工具名或参数名，评测立刻红）。
 - **回放**：`ScriptedStreamingModel` 实现 `StreamingChatLanguageModel`，按用例 `turns` 逐轮回放预录的模型输出，
   不访问网络。
 - **记录**：`RecordingToolRegistry` 继承 `ToolRegistry`，`execute()` 只记录 `(toolName, argsJson)` 分发序列并返回

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -336,6 +336,17 @@ export function useAgentStream() {
             } catch (e) {
                 console.error('Failed to parse step_update', e)
             }
+        } else if (evt === 'subtask_progress') {
+            // Sub-agent subtask lifecycle (Phase 3C): show as a one-line status step
+            try {
+                const d = JSON.parse(dataStr)
+                handleStepUpdate({
+                    status: d.stage === 'started' ? 'loading' : 'done',
+                    message: d.message || `子任务${d.stage === 'started' ? '开始' : '结束'}`
+                })
+            } catch (e) {
+                console.error('Failed to parse subtask_progress', e)
+            }
         } else if (evt === 'artifact') {
             const d = JSON.parse(dataStr)
             handleArtifactEvent(d)


### PR DESCRIPTION
## 设计要点

AI 编排器 Phase 3C 多智能体协作第一阶段：主循环可通过新工具 `dispatch_subtask(task_description, expected_output, tool_scope)` 把自包含的复杂子问题委派给独立子 Agent 循环执行。

### 子 Agent（新包 `service/ai/subagent/`）
- **独立消息栈**：自建 `List<ChatMessage>`，中间过程不进主会话历史，只把最终结构化结果（JSON：`success/result/error/toolsUsed/rounds`）作为工具输出返回主循环。
- **主循环的极简版**：同样支持原生 function calling + XML `<tool_code>` 双协议（复用 `XmlToolCallParser`），复用 `ToolRegistry`（分发）与 `ChatModelFactory`（建模型），**不复用**主循环的 SSE 推流与消息持久化。
- **受限工具集**：`tool_scope` 容错解析（JSON 数组或逗号/顿号分隔）；scope 外工具返回明确拒绝；空 scope = 全部工具。
- **防递归双防线**：子 Agent 工具集无条件排除 `dispatch_subtask`；分发前二次拦截返回明确错误 `nested delegation refused`；工具方法本身另有 ThreadLocal 防线。
- **身份继承（不变式 3）**：子 Agent 工具调用的 `ToolContext` 继承主会话 `projectId/conversationId/userId`（单测 `identityInheritedFromParentContext` 证明）；模型可独立（`ai.subagent.model`，留空继承主会话）。

### 配置外置（不变式 5，`ai.subagent.*` / `SubAgentProperties`）
| 限值 | 默认 |
|---|---|
| max-rounds 轮数上限 | 6 |
| max-parallel 并行度（专用线程池，与主循环 taskExecutor 隔离） | 3 |
| timeout-seconds 超时（超时取消并返回错误结果，不挂死主循环） | 180 |
| token-budget（chars-per-token 估算，超限中止） | 30000 |

### SSE 与前端
- **新增**事件 `subtask_progress`（结构对齐 `TaskProgressEvent`：taskType=SUBTASK / source=SUB_AGENT / stage=started|succeeded|failed），子任务开始/结束各发一次；既有事件字典未动（不变式 4）。
- 前端 `useAgentStream.js` 新增一个事件分支，复用现有 `handleStepUpdate` 以一行状态步骤展示；未动任何已有事件处理。
- **`AgentOrchestrator` 零改动**：SSE 由 `SubAgentService` 直接经 `SseEmitterService` 发送，无需在编排器加挂载点；五条架构不变式全部保持。

### system_prompt
新增 §6.5 `dispatch_subtask` 使用指引：何时委派（需独立多步探索/大量中间产物）、**简单任务禁止委派**、task_description 须自包含、expected_output 要写清楚、失败结果的处理。

## 测试数字

- 全量 `mvn test`（JDK 21）：**170 run / 0 fail / 0 error / 1 skip**，BUILD SUCCESS
- 回放评测 `OrchestratorReplayEvalTest`：**27 个用例全绿**（原 24 个未动 + 新增 `cases-subagent.json` 3 个：委派-返回-汇总 / 子任务失败主流程不崩 / 递归拒绝透出）
- 新增单测 `SubAgentServiceTest`：**7 个**（轮数上限 / token 预算 / 超时 / 防递归 / 工具域 / 身份继承+进度事件 / tool_scope 容错解析）

## 共享面改动清单

| 文件 | 改动 |
|---|---|
| `AgentOrchestrator` | **零改动** |
| `ToolRegistry` | **零改动**（`TOOL_NAME_ALIASES` 未动） |
| `system_prompt.md` | 追加 §6.5 委派子任务指引（追加式，未动其他章节） |
| `application.yml` | ai: 下追加 `subagent:` 配置块（均为默认值） |
| `frontend/src/composables/useAgentStream.js` | 新增 `subtask_progress` 事件分支（复用 handleStepUpdate，未动已有分支） |
| `RealToolBeans.java`（评测） | 工具组件清单加入 `SubAgentTools`（8→9） |
| `docs/AI_ARCHITECTURE.md` | §3 新增「子 Agent（Phase 3C）」约束清单 + Phase 3 路线图勾选 |
| `docs/AI_EVAL.md` | 用例数 24→27、工具组件数 8→9（数字同步） |

评测用例文件：原有 `cases-*.json` **未改动**，新增用例全部在新文件 `cases-subagent.json`。

## 人工验证方式

1. 启动后端 + 前端，任选支持 function calling 的模型，在 Agent 模式发送：
   「帮我调研最近法院对对赌协议效力的裁判倾向，这个调研请委派为子任务完成，我只要要点摘要」
2. 观察：过程气泡出现「子任务开始：…」/「子任务完成」状态行（`subtask_progress` 事件）；主对话历史只有 `dispatch_subtask` 的一条工具输出（JSON 结果），无子 Agent 中间搜索过程。
3. 后端日志验证身份继承：子 Agent 内 `search_web` 等工具日志的 projectId/conversationId 与主会话一致。
4. 防递归：把 `ai.subagent.max-rounds` 调小（如 2）或在 task_description 里诱导子 Agent 再委派，工具输出应包含 `nested delegation refused` / `max rounds` 明确错误，主循环正常收尾。
5. 超时：`ai.subagent.timeout-seconds: 5` 后委派一个大任务，应快速拿到 `sub-agent timed out after 5s` 的失败结果，主对话不挂死。

🤖 Generated with [Claude Code](https://claude.com/claude-code)