### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkba-desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkba-desktop",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 摘要 / Summary

v0.5.0 发版版本号提升（0.4.0 → 0.5.0），载体为 desktop/package.json（+ package-lock.json 同步）。

Version bump for the v0.5.0 release. Carrier: desktop/package.json (+ package-lock.json sync).

## 本版主线 / Release tracks
1. **AI 编排器整体重构（Phase 1~3 全部落地）**：统一工具层、插件广场（启停+权限分发前校验，PLUGIN_SPEC v2.1）、Skill 体系（内置「上市路径选择比较分析」）、dispatch_subtask 多智能体、记忆拟人化检索、MCP 标准化、回放评测基建、wps_*→doc_* 灰度更名（旧名保留兼容）。
2. **桌面本地化打包**：pptx-service 进包 + 通用 ServiceManager；mac 收敛 Apple Silicon（arm64）。

合并后在 master 打 tag v0.5.0 触发 Desktop Build 发版。

## 已知风险 / Known risk
Playwright CDN（playwright.azureedge.net）当前故障中（400），本 PR 的 Desktop Build 冒烟测试可能因此失败——属外部故障，恢复后 rerun 即可（另有 #98 在做根治）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)