### PR TITLE
test(backend): desktop profile 上下文启动冒烟测试 / context-load smoke test for desktop profile

### DIFF
--- a/backend/src/test/java/com/checkba/DesktopContextSmokeTest.java
+++ b/backend/src/test/java/com/checkba/DesktopContextSmokeTest.java
@@ -1,0 +1,45 @@
+package com.checkba;
+
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.tools.WebTools;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * desktop profile 上下文启动冒烟测试。
+ *
+ * 背景：PR #95 引入的 bean 循环依赖（ToolRegistry ← SubAgentTools →
+ * SubAgentService → ToolRegistry，PR #98 用 @Lazy 修复）在单测全绿的情况下
+ * 直到 CI 桌面冒烟测试才暴露——此前没有任何测试真正 refresh 过 Spring 容器。
+ * 本测试把「启动即崩」类回归拦在 mvn test 阶段。
+ *
+ * 环境取自 CI 冒烟测试同款 desktop profile（零外部依赖启动）：
+ * - 数据源覆盖为内存 H2，避免在开发机上写 ~/.aiworkdeck/local.mv.db；
+ * - PgVector / Ollama embedding 不可达时走既有的快速回退路径，无需 mock。
+ */
+@SpringBootTest(properties = {
+        // desktop profile 的 H2 文件库换成内存库（去掉 AUTO_SERVER，加 DB_CLOSE_DELAY 保活）
+        "spring.datasource.url=jdbc:h2:mem:ctx-smoke;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1"
+})
+@ActiveProfiles("desktop")
+class DesktopContextSmokeTest {
+
+    /** 真 WebTools 的 @PostConstruct 会起线程预热/下载 Playwright 浏览器，测试里挡掉 */
+    @MockBean
+    private WebTools webTools;
+
+    @Autowired
+    private ToolRegistry toolRegistry;
+
+    @Test
+    void contextLoadsWithDesktopProfile() {
+        // 能注入进来即代表容器 refresh 成功（循环依赖等启动期问题会直接让本测试失败）
+        assertFalse(toolRegistry.getAllSpecifications().isEmpty(),
+                "ToolRegistry 应在容器启动后注册到内置工具");
+    }
+}


### PR DESCRIPTION
## 背景

PR #95 引入的 bean 循环依赖（`ToolRegistry` ← `SubAgentTools` → `SubAgentService` → `ToolRegistry`，已在 PR #98 用 `@Lazy` 修复）在本地 `mvn test` 185 例全绿的情况下，直到打包进桌面安装包、CI 冒烟测试才暴露。根因：backend 此前没有任何 `@SpringBootTest` 上下文加载测试，Spring 容器从未在测试阶段真正 refresh 过。

## 改动

新增 `DesktopContextSmokeTest`（45 行，唯一改动）：

- `@SpringBootTest`（MOCK web 环境）+ `@ActiveProfiles("desktop")`——与 CI 桌面冒烟同款零外部依赖启动路径
- 数据源覆盖为内存 H2（去 `AUTO_SERVER` 加 `DB_CLOSE_DELAY`），不写 `~/.aiworkdeck/local.mv.db`
- `@MockBean WebTools` 挡掉其 `@PostConstruct` 里的 Playwright 浏览器预热/下载线程
- PgVector（localhost:5432）与 Ollama embedding（localhost:11434）不可达时走既有快速回退路径，无需 mock
- 断言 `ToolRegistry` 注入成功且内置工具非空

## 验证

- ✅ 正向：`mvn test` 全量 186 例通过（JDK 21），容器 6.3s 完成 refresh，ToolRegistry 注册 75 个内置工具
- ✅ 反向：临时摘掉 SubAgentTools 的 `@Lazy` 后，本测试立即以 `BeanCurrentlyInCreationException` 失败，完整报出 #95 那条循环链——「启动即崩」类回归今后在 `mvn test` 阶段即被拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)