### PR TITLE
fix(desktop): v0.6.1 交互修复合集——截图假死/弹窗被网页遮挡/window.open 失效

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -71,6 +71,15 @@ function closeOcrSelectWin() {
     // ignore
   }
   ocrSelectWin = null
+  // 解除跟随监听：否则每次截图都会叠加一个 move/resize 监听器
+  if (ocrSelectWinBound && mainWindow) {
+    try {
+      mainWindow.removeListener('move', syncOcrSelectWinBounds)
+      mainWindow.removeListener('resize', syncOcrSelectWinBounds)
+    } catch (e) {
+      // ignore
+    }
+  }
   ocrSelectWinBound = false
   // 兜底：关闭覆盖窗后解除全局 ESC（避免影响正常使用）
   try {
@@ -383,7 +392,7 @@ ipcMain.handle('checkba:ocr-start-selection', async (_evt, payload) => {
 <body>
   <div class="layer">
     <div class="shade"></div>
-    <div class="hint">拖动框选网页区域 · ESC 退出</div>
+    <div class="hint">拖动框选网页区域 · 点击其它区域或 ESC 退出</div>
     <div id="rect" class="rect"></div>
   </div>
   <script>
@@ -398,8 +407,12 @@ ipcMain.handle('checkba:ocr-start-selection', async (_evt, payload) => {
     window.addEventListener('mousedown', (e) => {
       if (e.button !== 0) return;
       const x = e.clientX, y = e.clientY;
-      // BrowserView 模式：只允许在其区域开始框选；window 模式：全局允许
-      if (!inView(x, y)) return;
+      // BrowserView 模式：只允许在其区域开始框选；区域外点击 = 取消退出
+      // （否则透明置顶窗会吞掉所有点击，用户点底栏/侧栏毫无反应，整个 app 像假死）
+      if (!inView(x, y)) {
+        ipcRenderer.send(ch, { ok: false, cancelled: true });
+        return;
+      }
       down = { x, y };
       rectEl.style.display = 'block';
       rectEl.style.left = x + 'px';
@@ -769,7 +782,13 @@ function setAllViewsVisible(visible) {
     return
   }
   // visible === true：把所有 view 重新 add 回来（按最后一次的 bounds）
+  // 先 remove 再 add：重复 add 已挂载的 view 会抛错，导致 attachedViewIds 不同步
   for (const [id, view] of views.entries()) {
+    try {
+      mainWindow.removeBrowserView(view)
+    } catch (e) {
+      // ignore
+    }
     try {
       mainWindow.addBrowserView(view)
       attachedViewIds.add(id)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -899,6 +899,9 @@ export default {
     }
 
     const handleSubmit = async () => {
+      // 流式进行中禁止再发送（回车路径不走发送按钮的 abort 分支）：
+      // 必须在清空输入框之前拦截，否则用户输入会被静默丢弃
+      if (isStreaming.value) return
       // Create a clone to safely manipulate and extract text without tags
       let text = ''
       let contentHtml = ''

--- a/frontend/src/components/ProjectFavoritesPanel.vue
+++ b/frontend/src/components/ProjectFavoritesPanel.vue
@@ -111,6 +111,12 @@ export default {
     openUrl(url) {
       if (!url) return
       // #ifdef H5
+      // 桌面端（Electron，同为 H5 构建）：window.open 会被主进程拦截后丢弃，
+      // 必须走 emit 让工作区开网页 tab
+      if (typeof window !== 'undefined' && window.checkbaDesktop) {
+        this.$emit('open-url', url)
+        return
+      }
       window.open(url, '_blank')
       // #endif
       // #ifndef H5
@@ -122,10 +128,12 @@ export default {
     },
     focusFavorite(id) {
       if (!id) return
+      if (this._highlightTimer) clearTimeout(this._highlightTimer)
       this.scrollIntoView = this.getCardDomId(id)
       this.highlightId = id
-      setTimeout(() => {
+      this._highlightTimer = setTimeout(() => {
         if (this.highlightId === id) this.highlightId = null
+        this._highlightTimer = null
       }, 1800)
     },
     getFavoriteImageUrl(id) {

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -114,6 +114,9 @@ export function useAgentStream() {
         if (sseAbortController && isConnected.value) return Promise.resolve()
 
         sseAbortController = new AbortController()
+        // 持有本次连接自己的 controller 引用：旧连接结束时的清理（catch/finally）
+        // 只允许作用于"自己还是当前连接"的情况，否则会把新连接的状态清掉（切换会话竞态）
+        const myController = sseAbortController
         const baseUrl = getApiBaseUrl()
         const url = `${baseUrl}/api/agent/connect/${conversationId}`
         const sessionId = getSessionId()
@@ -124,7 +127,7 @@ export function useAgentStream() {
                 const response = await fetch(url, {
                     method: 'GET',
                     headers: { 'Content-Type': 'application/json', 'X-Session-Id': sessionId || '' },
-                    signal: sseAbortController.signal
+                    signal: myController.signal
                 })
 
                 if (!response.ok) throw new Error(`SSE Connection Failed: ${response.status}`)
@@ -157,32 +160,44 @@ export function useAgentStream() {
                     }
                 }
             } catch (err) {
+                // 关键：若本连接已被替换（切换会话后新连接已建立），不得清理全局状态
+                const isCurrent = sseAbortController === myController
                 if (err.name !== 'AbortError') {
                     console.error('[AgentStream] SSE Error:', err)
                     if (!isConnected.value && !isStreaming.value) reject(err)
                     // SSE 连接出错时，确保结束当前 bubble 的加载状态
-                    if (currentAssistantBubble.value && currentAssistantBubble.value.isStreaming) {
+                    if (isCurrent && currentAssistantBubble.value && currentAssistantBubble.value.isStreaming) {
                         currentAssistantBubble.value.isStreaming = false
                         currentAssistantBubble.value.content += '\n\n*[连接中断]*'
                     }
                 }
-                isConnected.value = false
-                isStreaming.value = false
-            } finally {
-                sseAbortController = null
-                isConnected.value = false
-                // SSE 连接结束时（包括正常结束），确保状态正确
-                if (isStreaming.value && currentAssistantBubble.value) {
-                    // 如果仍在流式状态但连接已结束，说明可能是意外断开
-                    console.warn('[AgentStream] SSE connection ended while still streaming')
-                    currentAssistantBubble.value.isStreaming = false
+                if (isCurrent) {
+                    isConnected.value = false
                     isStreaming.value = false
+                }
+            } finally {
+                // 同上：只有"自己仍是当前连接"时才清理，避免旧连接收尾时踩掉新连接
+                if (sseAbortController === myController) {
+                    sseAbortController = null
+                    isConnected.value = false
+                    // SSE 连接结束时（包括正常结束），确保状态正确
+                    if (isStreaming.value && currentAssistantBubble.value) {
+                        // 如果仍在流式状态但连接已结束，说明可能是意外断开
+                        console.warn('[AgentStream] SSE connection ended while still streaming')
+                        currentAssistantBubble.value.isStreaming = false
+                        isStreaming.value = false
+                    }
                 }
             }
         })
     }
 
     const sendMessage = async ({ prompt, contentHtml = '', fileList = [], projectId, modelId = 'default', assistantId, mode = 'AGENT', activeContext = null, _userImages = [], _userContextFiles = [] }) => {
+        // 防重入：流式进行中再触发发送（回车/连点）会产生重复气泡和并发请求
+        if (isStreaming.value) {
+            console.warn('[AgentStream] sendMessage ignored: already streaming')
+            return
+        }
         // Clear file changes for new turn
         fileChanges.value = []
 

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1365,8 +1365,6 @@ export default {
       currentAssistantId: 'default',
       showAssistantConfigDialog: false,
       editingAssistant: null,
-      showAssistantConfigDialog: false,
-      editingAssistant: null,
       assistants: [], // Dynamic now
       selectedContextNode: null, // Picker 中临时选中的节点
       // AI 导出 Word 相关（后端生成 docx）
@@ -1469,6 +1467,8 @@ export default {
       ,
       _desktopWebMarkUnsub: null
       ,
+      _desktopRendererOpenUnsub: null
+      ,
       _desktopOcrSelectionUnsub: null
       ,
       _desktopOcrSelectionErrUnsub: null,
@@ -1518,6 +1518,20 @@ export default {
     }
   },
   computed: {
+    // 桌面端：任一全屏蒙层/弹窗打开时为 true。BrowserView 是原生层，永远盖在
+    // HTML 之上，所以弹窗期间必须隐藏 BrowserView，否则弹窗会被网页挡住"点了没反应"。
+    desktopOverlayActive() {
+      return !!(
+        this.showOcrOverlay ||
+        this.showScreenshotSaveDialog ||
+        this.showExportDialog ||
+        this.showAssistantConfigDialog ||
+        this.showCompareDialog ||
+        this.showFilePicker ||
+        this.showInviteModal ||
+        (this.fileLinkPicker && this.fileLinkPicker.visible)
+      )
+    },
     LEFT_SIDEBAR_PLUGINS() {
       const user = getCurrentUser()
       if (user && user.role === 'CLIENT') {
@@ -1741,6 +1755,14 @@ export default {
     }
     this._desktopWebMarkUnsub = null
 
+    // Desktop：解绑 window.open(id='renderer') 消费监听
+    try {
+      if (this._desktopRendererOpenUnsub) this._desktopRendererOpenUnsub()
+    } catch (e) {
+      // ignore
+    }
+    this._desktopRendererOpenUnsub = null
+
     // Desktop：解绑内部链接打开监听
     try {
       if (this._desktopOpenInternalUnsub) this._desktopOpenInternalUnsub()
@@ -1857,9 +1879,10 @@ export default {
     }
 
     // Desktop：仅在工作区页面展示 BrowserView（否则会“飘”到其它页面）
+    // 注意尊重弹窗状态：若返回页面时仍有全屏弹窗打开，保持隐藏
     try {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-        window.checkbaDesktop.browser.setViewsVisible({ visible: true }).catch(() => {})
+        window.checkbaDesktop.browser.setViewsVisible({ visible: !this.desktopOverlayActive }).catch(() => {})
       }
     } catch (e) {
       // ignore
@@ -1918,6 +1941,27 @@ export default {
             } catch (e) {
               console.error('保存网核收藏失败:', e)
               uni.showToast({ title: e.message || '保存失败', icon: 'none' })
+            }
+          })
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+
+    // Desktop：消费主进程拦截的 window.open（id='renderer'）。
+    // 主进程会把渲染层所有 window.open(http/https) 拦截为
+    // checkba:browser-open-new-tab { id: 'renderer' }，此前无人消费，
+    // 导致桌面端"文件下载/查看/收藏开网页"等 window.open 全部静默失效。
+    try {
+      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.onOpenNewTab) {
+        if (!this._desktopRendererOpenUnsub) {
+          this._desktopRendererOpenUnsub = window.checkbaDesktop.browser.onOpenNewTab((data) => {
+            try {
+              if (!data || data.id !== 'renderer' || !data.url) return
+              this.openBrowserTab(String(data.url))
+            } catch (e) {
+              // ignore
             }
           })
         }
@@ -2109,6 +2153,23 @@ export default {
       }
     } catch (e) {
       // ignore
+    }
+  },
+  watch: {
+    // 桌面端统一守卫：弹窗/蒙层打开 → 隐藏 BrowserView；全部关闭 → 恢复并重同步 bounds
+    desktopOverlayActive(open) {
+      if (!this.isDesktopApp) return
+      try {
+        const api = window.checkbaDesktop && window.checkbaDesktop.browser
+        if (!api || !api.setViewsVisible) return
+        api.setViewsVisible({ visible: !open }).catch(() => {})
+        if (!open) {
+          // 恢复后强制一次布局同步，防止蒙层期间的布局变化（如底部面板开合）留下过期 bounds
+          this.$nextTick(() => this.triggerWorkbenchResize())
+        }
+      } catch (e) {
+        // ignore
+      }
     }
   },
   methods: {
@@ -3162,15 +3223,9 @@ export default {
     },
     closeOcrOverlay() {
       // 关闭蒙层：H5 使用屏幕共享时可能涉及授权；Desktop 不需要授权
+      // Desktop：BrowserView 的恢复由 desktopOverlayActive watcher 统一处理
+      // （若此时还有其它弹窗打开，则保持隐藏，避免弹窗被网页遮挡）
       this.showOcrOverlay = false
-      // Desktop：恢复 BrowserView（否则会遮挡主页面）
-      try {
-        if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-          window.checkbaDesktop.browser.setViewsVisible({ visible: true })
-        }
-      } catch (e) {
-        // ignore
-      }
       // #ifdef H5
       this.unbindOcrGlobalListeners()
       // #endif
@@ -3333,11 +3388,9 @@ export default {
         // 桌面端不需要浏览器授权：避免误导
         const title = this.isDesktopApp ? (e.message || '截图失败') : '截图失败（请允许共享标签页/窗口）'
         uni.showToast({ title, icon: 'none' })
-        // 失败时确保恢复 BrowserView
+        // 失败时统一走 closeOcrOverlay 复位（BrowserView 恢复由 watcher 处理）
         try {
-          if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-            window.checkbaDesktop.browser.setViewsVisible({ visible: true })
-          }
+          this.closeOcrOverlay()
         } catch (err) {
           // ignore
         }
@@ -3708,6 +3761,7 @@ export default {
         }
       } finally {
         uni.hideLoading()
+        this.ocrLoading = false
       }
     },
 
@@ -3885,11 +3939,6 @@ export default {
       await this.startOcrCapture()
     },
 
-    async ocrDoFavorite() {
-      if (!this.ocrImageDataUrl) return
-      await this.saveOcrFavorite()
-    },
-
     async insertClipboardAndCopy(text, options = {}) {
       const t = (text || '').trim()
       if (!t) return
@@ -3977,10 +4026,11 @@ export default {
         // 立即给用户可见反馈：打开收藏夹并高亮新卡片
         this.showToolsPanel = true
         this.activeToolKey = 'favorites'
-        this.$nextTick(() => {
+        this.$nextTick(async () => {
           try {
             const panel = this.$refs.favoritesPanel
-            if (panel && typeof panel.refresh === 'function') panel.refresh()
+            // 先等列表刷新完成，新卡片进入列表后再定位高亮，否则高亮必然落空
+            if (panel && typeof panel.refresh === 'function') await panel.refresh()
             if (favId && panel && typeof panel.focusFavorite === 'function') panel.focusFavorite(Number(favId))
           } catch (e) {
             // ignore
@@ -4405,6 +4455,8 @@ export default {
         window.addEventListener('mouseup', this.boundStopResize, { passive: true })
         window.addEventListener('touchmove', this.boundResizeMove, { passive: false })
         window.addEventListener('touchend', this.boundStopResize, { passive: true })
+        // 兜底：鼠标移出窗口/窗口失焦时 mouseup 可能丢失，避免 is-resizing 卡死
+        window.addEventListener('blur', this.boundStopResize, { passive: true })
       }
     },
 
@@ -4497,6 +4549,7 @@ export default {
         if (this.boundStopResize) {
           window.removeEventListener('mouseup', this.boundStopResize)
           window.removeEventListener('touchend', this.boundStopResize)
+          window.removeEventListener('blur', this.boundStopResize)
         }
       }
 


### PR DESCRIPTION
## 背景

用户报障：打开浏览页 tab → 截图后界面"常驻"，底部收藏夹等栏位打不开，打开后被截图的网页挡住。以此为线索，按使用流程分模块（AI 对话/截图/浏览/收藏/弹窗蒙层）做了一次代码级全面排查，所有修复均有确认的根因。

## 根因与修复

### 用户报障的直接根因（截图假死链）
1. **框选窗吞点击**：桌面端截图的透明置顶框选窗（`ocr-start-selection`）在 BrowserView 模式下，点击网页区域**外**的 mousedown 被直接忽略——点底栏/侧栏/顶栏毫无反应且无法退出，整个 app 假死。现在**区域外点击即取消退出**，提示文案同步更新。
2. **弹窗被网页遮挡（系统性）**：BrowserView 是原生层永远盖在 HTML 之上，但截图保存/导出 Word/助手配置/文档对比/文件关联选择/邀请成员等弹窗打开时都没有隐藏 BrowserView。新增 `desktopOverlayActive` 统一守卫（computed + watch）：任一全屏弹窗打开 → 隐藏 BrowserView；全部关闭 → 恢复并强制重同步 bounds。`closeOcrOverlay`/`onShow` 改为尊重该状态。
3. **恢复后 bounds 过期防御**：蒙层期间发生布局变化（如收藏后自动展开底部面板）时，恢复 BrowserView 后强制一次 `triggerWorkbenchResize()`。

### 排查中发现的其它确认 bug
4. **桌面端 window.open 全部静默失效**：主进程把渲染层 `window.open(http/https)` 拦截为 `id='renderer'` 的 `browser-open-new-tab` 事件，但渲染层从未消费（BrowserPane 只认自己的 viewId）→ 文件下载、尽调查看文件、收藏打开来源网址在桌面端点了没反应。现已在工作区页面接线为 `openBrowserTab`；收藏面板 `openUrl` 桌面端改走 emit。
5. **AI 对话切会话竞态**：旧 SSE 连接收尾（catch/finally）会无条件清掉 `sseAbortController`/`isConnected`/`isStreaming`，把新连接的状态踩掉 → 增加连接身份校验。
6. **流式中回车重复发送**：`handleSubmit`/`sendMessage` 无防重入，流式中回车会清空输入框并产生重复气泡 → 在清空输入前拦截。
7. **`ocrDoFavorite` 定义两次**（前者调用不存在的 `saveOcrFavorite`）、**`showAssistantConfigDialog` data key 重复** → 清理死代码。
8. **截图后收藏高亮必落空**：`refresh()` 未 await 就 `focusFavorite` → await 后定位。
9. **`ocrDoRecognize` 后 `ocrLoading` 永不复位**；**每次截图叠加一个 mainWindow move/resize 监听器**；**`setAllViewsVisible(true)` 重复 add 抛错导致 attach 集合不同步**；**拖拽分隔条 mouseup 丢失导致 is-resizing 卡死**（加 window blur 兜底）；收藏高亮定时器复用清理。

### 排查过但确认不用修的
- ESC 全局快捷键注册/注销逻辑对称（agent 误报）；导出/截图保存对话框每次打开会重置表单（误报）；uni-app tab 事件与 preventDefault 的干扰（不成立）。
- **已知欠账（不在本 PR）**：VariablePanel 的字段变量五件套依赖老 WPS 桥接 `getWps`（`listVariableFields`/`insertTextWithDocumentField` 等），LibreOffice executor 无对应实现，父组件也从未传入——变量面板的插入/同步在桌面端一直不可用，属 WPS→LibreOffice 迁移遗留，需要单独排期实现。

## 验证
- `npm run build:h5` 通过（与 CI 同方式 npm ci 后构建）
- `node --check` main.js/preload.js 通过
- `desktop npm test` 10/10 通过
- 版本 bump 0.6.1（desktop/package.json）

🤖 Generated with [Claude Code](https://claude.com/claude-code)