### PR TITLE
fix(desktop): 变量面板接通 LibreOffice——var_* 文档域原语 + getWps 适配器 / wire VariablePanel to LibreOffice (#104), v0.6.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -38,6 +38,10 @@ export const EDITOR_ACTIONS = [
   'export_document',
   // [diagnostic #66] report resolved UI locale (ooLocale) to confirm zh-CN took effect.
   'get_ui_lang',
+  // [#104 变量面板] document variable fields — bookmark-marked spans bound to a
+  // (scope, varName) variable; driven by VariablePanel through the getWps adapter
+  // in project-overview.vue, not by the AI agent pipeline.
+  'var_list', 'var_insert', 'var_update',
 ]
 
 /**

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -864,6 +864,7 @@
                     v-if="activeToolKey === 'variables'"
                     ref="variablePanel"
                     :project-id="projectId"
+                    :get-wps="getLibreVariableBridge"
                     :search-keyword="toolsSearchKeyword"
                     @insert="handleInsertVariable"
                     @update-from-selection="handleUpdateVariable"
@@ -5576,6 +5577,50 @@ export default {
         this.libreOfficeActive = false
         this.libreOfficeExecutor = null
         console.log('[ProjectOverview] LibreOffice editor closed — agent commands unavailable until reopened')
+    },
+
+    // #104: WPS-era getWps() adapter for VariablePanel — the five document-field
+    // methods it expects, implemented over the LibreOffice executor's var_*
+    // commands. Returns null while no editor is active so the panel keeps its
+    // own “请先点击激活一个编辑窗口” fallback.
+    getLibreVariableBridge() {
+      if (!this.libreOfficeActive || !this.libreOfficeExecutor) return null
+      const exec = (action, params) => this.libreOfficeExecutor.executeCommand(action, params)
+      return {
+        async getSelectionText() {
+          const r = await exec('get_selection', {})
+          return (r && r.success && r.text) || ''
+        },
+        async listVariableFields() {
+          const r = await exec('var_list', {})
+          if (!r || !r.success) throw new Error((r && r.message) || '读取文档变量域失败')
+          return r.fields || []
+        },
+        async insertTextWithDocumentField(value, scope, name) {
+          const r = await exec('var_insert', { text: value == null ? '' : String(value), scope, name })
+          if (!r || !r.success) throw new Error((r && r.message) || '插入文档变量域失败')
+        },
+        async updateDocumentField(fieldId, nextText) {
+          const r = await exec('var_update', { id: fieldId, text: nextText == null ? '' : String(nextText) })
+          if (!r || !r.success) throw new Error((r && r.message) || '更新文档变量域失败')
+        },
+        // resolver 是面板本地回调，无法跨 worker 传递：在这一侧枚举字段、逐个求值并回写。
+        // 空值不回写——后端变量缺失时 resolver 返回 ''，同步不应清空文档里的内容。
+        async syncAllDocumentFields(resolver) {
+          const lr = await exec('var_list', {})
+          if (!lr || !lr.success) throw new Error((lr && lr.message) || '读取文档变量域失败')
+          let updated = 0
+          for (const f of lr.fields || []) {
+            let next
+            try { next = resolver(f.scope, f.varName, f.text) } catch (e) { continue }
+            next = next == null ? '' : String(next)
+            if (!next || next === f.text) continue
+            const ur = await exec('var_update', { id: f.id, text: next })
+            if (ur && ur.success) updated++
+          }
+          return { updated }
+        },
+      }
     },
 
     // --- 文件选择/上传 ---

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -79,6 +79,40 @@ function anchorRange(name) {
   return bms.getByName(name).getAnchor(); // XTextRange
 }
 
+// #104 variable fields: a NAMED bookmark spanning the inserted value marks a
+// "document field" bound to a (scope, varName) variable — the WPS 域 semantics
+// VariablePanel expects, on LibreOffice. The binding is encoded in the bookmark
+// NAME (scope + hex-encoded UTF-8 varName, name-safe chars only) so it survives
+// a docx save/reload — bookmarks round-trip through OOXML; no custom XML part
+// needed. (Word caps bookmark names at 40 chars, so a long CJK varName may get
+// mangled if the file is edited in Word itself; LibreOffice round-trips it.)
+const VAR_FIELD_PREFIX = '__ai_var_';
+let varFieldSeq = 0;
+function hexUtf8(s) {
+  const bytes = unescape(encodeURIComponent(String(s))); // UTF-8 byte string
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) out += ('0' + bytes.charCodeAt(i).toString(16)).slice(-2);
+  return out;
+}
+function unhexUtf8(h) {
+  let bytes = '';
+  for (let i = 0; i + 1 < h.length; i += 2) bytes += String.fromCharCode(parseInt(h.substr(i, 2), 16));
+  try { return decodeURIComponent(escape(bytes)); } catch (e) { return bytes; }
+}
+function newVarFieldName(scope, varName) {
+  const bms = xModel.getBookmarks();
+  let name;
+  do { name = VAR_FIELD_PREFIX + scope + '_' + hexUtf8(varName) + '_' + (++varFieldSeq); }
+  while (bms.hasByName(name)); // seq resets per session; skip names already in the doc
+  return name;
+}
+function parseVarFieldName(name) {
+  if (String(name).indexOf(VAR_FIELD_PREFIX) !== 0) return null;
+  const parts = String(name).slice(VAR_FIELD_PREFIX.length).split('_'); // [scope, hex, seq]
+  if (parts.length !== 3 || !parts[0]) return null;
+  return { scope: parts[0], varName: unhexUtf8(parts[1]) };
+}
+
 // ---- 拟人式原语 helpers（感知/验证回路） ------------------------------------
 // Context around a range: the chars immediately before/after, read via a text
 // cursor spawned FROM THE RANGE'S OWN XText (so matches inside table cells /
@@ -868,6 +902,59 @@ const EXEC = {
       try { um.redo(); } catch (e) { break; }
     }
     return Object.assign({ success: done > 0, redone: done }, done > 0 ? verifySnapshot() : { message: 'nothing to redo' });
+  },
+  // ---- #104 文档变量域原语（VariablePanel via the getWps adapter) ------------
+  // list every variable field in the document: {fields: [{id, scope, varName, text}]}
+  var_list() {
+    const bms = xModel.getBookmarks();
+    const names = (bms.getElementNames && bms.getElementNames()) || [];
+    const fields = [];
+    for (let i = 0; i < names.length; i++) {
+      const meta = parseVarFieldName(names[i]);
+      if (!meta) continue;
+      let text = '';
+      try { text = bms.getByName(names[i]).getAnchor().getString(); } catch (e) {}
+      fields.push({ id: names[i], scope: meta.scope, varName: meta.varName, text: text });
+    }
+    return { success: true, count: fields.length, fields: fields };
+  },
+  // insert {text} at the view cursor, marked as a field of (scope, name).
+  var_insert(p) {
+    const name = String(p.name || '').trim();
+    if (!name) return { success: false, message: 'var_insert requires {name}' };
+    const scope = String(p.scope || 'D');
+    // a paragraph break inside the span would split the bookmark, so field
+    // values are inline-only: newlines flatten to spaces
+    const value = String(p.text == null ? '' : p.text).replace(/[\r\n]+/g, ' ');
+    const vc = ctrl.getViewCursor();
+    vc.collapseToEnd();
+    const xText = vc.getText(); // the story the cursor is in (body / table cell / frame)
+    const cur = xText.createTextCursorByRange(vc.getEnd());
+    xText.insertString(cur, value, true); // bAbsorb: cur now spans the inserted value
+    const id = newVarFieldName(scope, name);
+    const bm = xModel.createInstance('com.sun.star.text.Bookmark');
+    bm.setName(id);
+    xText.insertTextContent(cur, bm, true);
+    try { vc.gotoRange(cur.getEnd(), false); } catch (e) {}
+    return Object.assign({ success: true, id: id, scope: scope, varName: name, text: value }, verifySnapshot());
+  },
+  // replace the text span of field {id} with {text}, keeping the marker alive.
+  var_update(p) {
+    const id = String(p.id || '');
+    const bms = xModel.getBookmarks();
+    if (!id || !bms.hasByName(id)) return { success: false, message: 'variable field not found: ' + id };
+    if (!parseVarFieldName(id)) return { success: false, message: 'not a variable field: ' + id };
+    const value = String(p.text == null ? '' : p.text).replace(/[\r\n]+/g, ' ');
+    const bm = bms.getByName(id);
+    const anchor = bm.getAnchor();
+    const xText = anchor.getText();
+    const cur = xText.createTextCursorByRange(anchor);
+    xText.removeTextContent(bm); // setString over the span would swallow the marker; re-add below
+    cur.setString(value);
+    const bm2 = xModel.createInstance('com.sun.star.text.Bookmark');
+    bm2.setName(id);
+    xText.insertTextContent(cur, bm2, true);
+    return { success: true, id: id, text: value, paragraphAfterEdit: (paragraphTextOf(cur) || '').slice(0, 200) };
   },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {


### PR DESCRIPTION
## 问题（#104）

WPS→LibreOffice 迁移后，VariablePanel 依赖的 `getWps()` 五件套（listVariableFields / getSelectionText / insertTextWithDocumentField / updateDocumentField / syncAllDocumentFields）悬空：父组件从未传 `:get-wps`，LibreOffice executor 也没有对应实现。变量 tab 四个动作在桌面端全部只弹「请先点击激活一个编辑窗口」。

## 方案

**worker 侧（office_thread.js）**：新增 3 个 EXEC 原语，语义 = 「文档域是一个跨值文本的命名书签」：
- `var_list` — 枚举 `__ai_var_*` 书签 → `{fields:[{id, scope, varName, text}]}`；(scope, varName) 以 hex-UTF8 编码在书签名里，随 .docx 保存/重载往返存活（OOXML bookmark 原生往返，无需 custom XML）
- `var_insert` — 视图光标处插值 + 同 span 挂书签（值内换行拍平为空格，避免段落断裂拆散书签）
- `var_update` — 先摘书签、`setString` 换文、同名重挂（直接 setString 会吞掉标记）

**app 侧（project-overview.vue）**：`getLibreVariableBridge()` 按 WPS 时代契约适配五个方法并传入 `:get-wps`。`getSelectionText` 复用既有 `get_selection`；`syncAllDocumentFields` 的 resolver 是面板本地回调无法跨 worker，故在适配器侧枚举字段、逐个求值回写（空值不回写，防后端变量缺失时同步清空文档内容）。编辑器未激活时返回 null，面板保留原兜底提示。

## 实测（真实 LOWA 引擎，editor.html?verify=1 + __loExecutor 驱动）

- ✅ CJK 变量名「甲方名称/签署日期」hex 编解码往返正确
- ✅ 同名变量两处实例正确分组（P:甲方名称 ×2），D/P scope 并存
- ✅ `var_update` 只改目标实例，标记存活可再次更新；紧邻的两个域不粘连
- ✅ 周边正文不受损（插入/更新前后段落文本逐字核对）
- ✅ 导出 .docx 解包验证：3 个 `__ai_var_*` 书签原样写入 word/document.xml
- ✅ `npm run build:h5` 通过

注：verify 采用本地自建 zh-CN 引擎，其 zetajs 版本的 `context.getServiceManager` 缺失导致 `load_document` 在该 harness 里不可用（产品 CDN 引擎无此问题），故重载存活改用 docx 解包验证书签落盘。

## 版本

desktop 0.6.1 → **0.6.2**（合并后打 tag `v0.6.2` 发版）。

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)