### PR TITLE
fix(desktop): 打开已有 docx 必失败——load_document 漏传 context + 字节编组修复，bump 0.6.3 / fix load_document ctor context & byte marshalling

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -666,10 +666,9 @@ const EXEC = {
     const m = name.match(/\.([A-Za-z0-9]+)$/);
     const ext = (m ? m[1] : 'docx').toLowerCase();
 
-    // Normalize the transported bytes to the Int8Array a UNO sequence<byte>
-    // expects (zetajs maps sequence<byte> -> Int8Array). The host sends a
-    // Uint8Array; structured clone across the relay/worker hops may surface it
-    // as Uint8Array / ArrayBuffer / Array — accept all.
+    // Normalize the transported bytes. The host sends a Uint8Array; structured
+    // clone across the relay/worker hops may surface it as Uint8Array /
+    // ArrayBuffer / Array — accept all.
     const raw = p && p.bytes;
     let u8 = null;
     if (raw instanceof ArrayBuffer) u8 = new Uint8Array(raw);
@@ -679,7 +678,12 @@ const EXEC = {
     // bytes for it). That is NOT an error: keep the blank boot doc as-is. The
     // host also guards this, but defend here too.
     if (!u8 || u8.length === 0) return { success: true, empty: true, name: name };
-    const bytes = new Int8Array(u8.buffer, u8.byteOffset, u8.byteLength);
+    // zeta.js marshals JS→UNO sequences ONLY from plain Arrays (translateToEmbind
+    // gates on Array.isArray), and sequence<byte> elements are SIGNED — so go
+    // through an Int8Array view, then Array.from. Passing the typed array itself
+    // reaches embind unconverted: 'Cannot pass "80,75,…" as …'. (Int8Array is
+    // the shape of RESULTS only, and only in some zetajs builds.)
+    const bytes = Array.from(new Int8Array(u8.buffer, u8.byteOffset, u8.byteLength));
 
     // Retarget the worker's model/controller onto a freshly-loaded component.
     const retarget = (loaded) => {
@@ -699,7 +703,12 @@ const EXEC = {
       const url = 'file:///tmp/ai_doc_' + (++docSeq) + '.' + ext;
       const sfa = css.ucb.SimpleFileAccess.create(context);
       try { if (sfa.exists(url)) sfa.kill(url); } catch (e) {}
-      const stream = css.io.SequenceInputStream.createStreamFromSequence(bytes);
+      // zetajs named service constructors take the component context as the
+      // implicit FIRST argument (zeta.js: `const context = arguments[0]`).
+      // Omitting it made zetajs treat the byte sequence AS the context —
+      // "context.getServiceManager is not a function" — so load_document never
+      // succeeded on any engine until the host-side repro caught it.
+      const stream = css.io.SequenceInputStream.createStreamFromSequence(context, bytes);
       sfa.writeFile(url, stream);
       try { stream.closeInput(); } catch (e) {}
       const loaded = desktop.loadComponentFromURL(url, '_default', 0, []);
@@ -715,7 +724,7 @@ const EXEC = {
     // an explicit import filter since there is no URL extension to detect from.
     try {
       const filter = IMPORT_FILTERS[ext];
-      const stream2 = css.io.SequenceInputStream.createStreamFromSequence(bytes);
+      const stream2 = css.io.SequenceInputStream.createStreamFromSequence(context, bytes);
       const args = [mkProp('InputStream', stream2)];
       if (filter) args.push(mkProp('FilterName', filter));
       const loaded = desktop.loadComponentFromURL('private:stream', '_default', 0, args);


### PR DESCRIPTION
## 问题

桌面版正式文档编辑器（LibreOfficeEditor.vue，variant=default）打开任何**非空** docx 都报「文档加载失败」，编辑器回退到空白文档。日志显示字节已成功下载并下发（`▶ load_document「…」(5018 bytes)`），失败发生在 worker 的 `load_document` 内。

## 根因（真实引擎端到端复现定位）

用打包所焙的自建引擎（24.2.8-zhcn-r2）headless 复现，拿到的真实错误：

```
load_document failed: file: context.getServiceManager is not a function | stream: context.getServiceManager is not a function
```

两个自 Track D（#64）落地起就存在的编组 bug，都在 office_thread.js：

1. **服务构造器漏传 context**：`css.io.SequenceInputStream.createStreamFromSequence(bytes)` 少传了第一个参数。zetajs 命名服务构造器把 `arguments[0]` 当组件上下文（zeta.js `const context = arguments[0]`），字节序列被误当 context，抛上述 TypeError。**两条加载策略（MEMFS file / private:stream）都经过这行**，所以双双失败、无一兜底。
   - 纠正一条错误记忆：v0.6.2 会话曾记「自建引擎 zetajs 缺 `context.getServiceManager`，产品 CDN 引擎正常」。实测 `get_ui_lang`（同一调用）在自建引擎上一直是通的，报错里的 `context` 其实是那个 Int8Array；此 bug 在**任何引擎**上都必失败，load_document 从未成功过。之前没暴露是因为新建文档走 0 字节早退，编辑器成为默认编辑器后才第一次真正加载非空 docx。
2. **字节序列须为普通 Array**：修掉 1 之后暴露——这版 zeta.js 的 JS→UNO 序列编组只接受普通 Array（`translateToEmbind` 里 `Array.isArray` 检查），传 Int8Array 会漏到 embind 报 `Cannot pass "80,75,…"`。改为 Int8Array 视图（保符号）后 `Array.from` 成普通数组。「zetajs maps sequence<byte> → Int8Array」的旧注释只对 UNO→JS 的结果方向成立，已修正。

## 验证（真实 LOWA 引擎，headless __loExecutor 驱动）

复现用户操作链「新建 → 输入 → 保存 → 重开」：插入中文 → `export_document` → 以导出字节调 `load_document` → **成功（via file）** → `get_document_text` 原样读回「甲方：XYZ集团。保存重开回归验证。」→ 重载后继续插入、再导出均正常；bytes 为 Uint8Array / 普通 Array 两种形态均通过。修复前同环境稳定复现原错误。

真机排障入口：具体错误 message 会出现在 devtools console 的 `[libre-editor]` 镜像（#106 已加）。

## 版本

desktop 0.6.2 → **0.6.3**（合并后打 tag `v0.6.3` 发版）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)