### PR TITLE
fix(ai): 编排层并发与流式健壮性修复（批次A）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -315,16 +315,11 @@ public class AgentOrchestrator {
             
             dev.langchain4j.data.message.AiMessage aiMessage = response.content();
             messages.add(aiMessage);
-            
-            // 更新已生成内容（用于取消时保存）
+
+            // 注意：本轮生成内容已由 onToken 回调逐 token 累加进 activeStreamContent，
+            // 此处不可再 append aiMessage.text()，否则取消/断线恢复的快照内容会翻倍。
             String aiContent = aiMessage.text();
-            if (aiContent != null) {
-                StringBuilder contentBuilder = activeStreamContent.get(conversationId);
-                if (contentBuilder != null) {
-                    contentBuilder.append(aiContent);
-                }
-            }
-            
+
             // 1. Check for Native Tool Requests (Priority 1)
             if (aiMessage.hasToolExecutionRequests()) {
                 log.info("Detected Native Tool Requests: {}", aiMessage.toolExecutionRequests());
@@ -549,9 +544,20 @@ public class AgentOrchestrator {
             sseEmitterService.close(conversationId);
             clearCancelledState(conversationId);
             activeStreamContent.remove(conversationId); // CLEANUP
+          } finally {
+            // 流式回调运行在可复用线程池线程上，用完清理 ThreadLocal，防止会话串号
+            editorBridgeService.clearCurrentConversationId();
           }
         });
-        
+
+        // 流式出错时的清理：关闭 emitter + 复位状态，避免 SSE 连接挂到超时、前端永久加载
+        handler.setOnError(err -> {
+            editorBridgeService.setStreamingMode(conversationId, false);
+            sseEmitterService.close(conversationId);
+            clearCancelledState(conversationId);
+            editorBridgeService.clearCurrentConversationId();
+        });
+
         // Execute Generation with Tools
         // Ask 模式：不传递工具，禁止工具调用
         if (agentMode == AgentMode.ASK) {

--- a/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
@@ -460,10 +460,23 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
         this.onCompleteCallback = callback;
     }
 
+    // 错误回调（由 AgentOrchestrator 注入，用于在流式出错时清理编排器状态并关闭 emitter）
+    private java.util.function.Consumer<Throwable> onErrorCallback;
+    public void setOnError(java.util.function.Consumer<Throwable> callback) {
+        this.onErrorCallback = callback;
+    }
+
     @Override
     public void onError(Throwable error) {
         log.error("Stream error for {}", conversationId, error);
         sseEmitterService.send(conversationId, "error", "Stream Error: " + error.getMessage());
+        // 关键：出错时必须关闭 emitter 并清理编排器状态，否则 SSE 连接会一直挂到 30 分钟超时，
+        // 且 activeStreamContent / cancelledConversations 条目永不清理、前端永久显示加载态。
+        if (onErrorCallback != null) {
+            onErrorCallback.accept(error);
+        } else {
+            sseEmitterService.close(conversationId);
+        }
     }
     
     private void startBubble(String type) {

--- a/backend/src/main/java/com/checkba/service/ai/BackgroundTaskService.java
+++ b/backend/src/main/java/com/checkba/service/ai/BackgroundTaskService.java
@@ -9,12 +9,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import jakarta.annotation.PreDestroy;
+
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -42,8 +47,24 @@ public class BackgroundTaskService {
      */
     private final Map<Long, List<String>> userTasks = new ConcurrentHashMap<>();
     
+    /**
+     * 共享的守护线程调度器，用于延迟清理已完成任务。
+     * 取代原先逐任务 new Thread() 的做法（非守护线程会拖慢 JVM 关闭，且大量休眠线程堆积）。
+     */
+    private final ScheduledExecutorService cleanupScheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "bg-task-cleanup");
+                t.setDaemon(true);
+                return t;
+            });
+
     public BackgroundTaskService(SseEmitterService sseEmitterService) {
         this.sseEmitterService = sseEmitterService;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        cleanupScheduler.shutdownNow();
     }
     
     /**
@@ -60,8 +81,10 @@ public class BackgroundTaskService {
         TaskInfo taskInfo = TaskInfo.create(taskId, conversationId, userId, taskType, estimatedDurationSec);
         
         activeTasks.put(taskId, taskInfo);
-        conversationTasks.computeIfAbsent(conversationId, k -> new ArrayList<>()).add(taskId);
-        userTasks.computeIfAbsent(userId, k -> new ArrayList<>()).add(taskId);
+        // 内层用 CopyOnWriteArrayList：注册线程、清理线程、查询线程并发 add/remove/遍历，
+        // 普通 ArrayList 会抛 ConcurrentModificationException 或脏读（ConcurrentHashMap 只保护外层 map）。
+        conversationTasks.computeIfAbsent(conversationId, k -> new CopyOnWriteArrayList<>()).add(taskId);
+        userTasks.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(taskId);
         
         // Send background_task_start event
         BackgroundTaskEvent event = BackgroundTaskEvent.started(taskId, taskType.name(), conversationId, estimatedDurationSec);
@@ -278,20 +301,14 @@ public class BackgroundTaskService {
     }
     
     private void scheduleCleanup(String taskId, long delayMs) {
-        // Simple cleanup after delay - in production, use a proper scheduler
-        new Thread(() -> {
-            try {
-                Thread.sleep(delayMs);
-                TaskInfo task = activeTasks.get(taskId);
-                if (task != null && !task.isActive()) {
-                    activeTasks.remove(taskId);
-                    cleanupTaskReferences(taskId, task);
-                    log.debug("Cleaned up completed task: {}", taskId);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+        cleanupScheduler.schedule(() -> {
+            TaskInfo task = activeTasks.get(taskId);
+            if (task != null && !task.isActive()) {
+                activeTasks.remove(taskId);
+                cleanupTaskReferences(taskId, task);
+                log.debug("Cleaned up completed task: {}", taskId);
             }
-        }).start();
+        }, delayMs, TimeUnit.MILLISECONDS);
     }
     
     private void cleanupTaskReferences(String taskId, TaskInfo task) {

--- a/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
@@ -65,6 +65,15 @@ public class EditorBridgeService {
         return currentConversationId.get();
     }
 
+    /**
+     * 清除当前会话 ID。
+     * 流式回调运行在可复用的线程池线程上，用完必须清理，否则残留的 conversationId
+     * 会在该线程被复用于其它会话时被读到，导致编辑器指令发往错误的会话。
+     */
+    public void clearCurrentConversationId() {
+        currentConversationId.remove();
+    }
+
     public void setStreamingMode(String conversationId, boolean enabled) {
         if (enabled) {
             streamingModes.put(conversationId, true);

--- a/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
+++ b/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
@@ -65,8 +65,10 @@ public class SseEmitterService {
         if (emitter != null) {
             try {
                 emitter.send(SseEmitter.event().name(eventName).data(data));
-            } catch (IOException e) {
-                log.warn("Failed to send SSE event to {}, removing emitter.", connectionId);
+            } catch (Exception e) {
+                // IOException：客户端断开；IllegalStateException：emitter 已 complete（与 close() 竞态）。
+                // 两种情况该 emitter 都已失效，一并丢弃，避免异常逃逸打断推事件的调用线程。
+                log.warn("Failed to send SSE event to {} ({}), removing emitter.", connectionId, e.getClass().getSimpleName());
                 emitters.remove(connectionId);
             }
         } else {


### PR DESCRIPTION
自主代码体检修复系列 **批次 A**：AI 编排/SSE/后台任务层的 6 处正确性缺陷，全部不改变正常路径行为。

## 修复项
| # | 严重度 | 问题 | 修复 |
|---|---|---|---|
| A1 | 高 | 流式出错时 `onError` 只发 error 事件，不关闭 emitter → SSE 挂到 30min 超时、状态永不清理、前端永久加载 | `onError` 新增清理回调，关闭 emitter + 复位编排器状态 |
| A2 | 高 | `onComplete` 重复 append `aiMessage.text()`（onToken 已累加）→ 取消/断线恢复快照内容翻倍 | 删除重复 append |
| A3 | 中 | `SseEmitterService.send` 只 catch `IOException`，close 后并发 send 抛 `IllegalStateException` 逃逸 | catch 扩为 `Exception` |
| A4 | 中高 | `conversationTasks/userTasks` 内层 `ArrayList` 无同步 → CME/脏读 | 改 `CopyOnWriteArrayList` |
| A5 | 中 | 逐任务 `new Thread()` 清理，非守护+不复用 → 线程堆积、拖慢关闭 | 共享守护线程调度器 + `@PreDestroy` |
| A6 | 中 | `EditorBridgeService` ThreadLocal 只 set 不 remove → 线程池复用跨会话串号 | 增加清理，onComplete finally + onError 调用 |

## 回归
backend `mvn test` **188/188 全绿**（JDK 21）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)