### PR TITLE
fix(storage): 路径遍历加固（批次B）

### DIFF
--- a/backend/src/main/java/com/checkba/service/DdService.java
+++ b/backend/src/main/java/com/checkba/service/DdService.java
@@ -206,12 +206,17 @@ public class DdService {
         // Usually keep original filename is safer, but maybe prefix with Item title if requested.
         // User didn't specify renaming file, just "Sync placement".
         // Let's use original filename.
-        String fileName = originalFilename;
-        // Avoid conflict?
-        fileName = System.currentTimeMillis() + "_" + fileName;
+        // 清洗客户端上传的原始文件名：只取文件名段、剥离路径分隔符与特殊字符（保留中文），
+        // 防止 "../" 或绝对路径注入存储 key。客户端上传是外部可控入口；存储层另有围栏兜底。
+        String rawName = (originalFilename == null) ? "" : originalFilename.replace("\\", "/");
+        int slashIdx = rawName.lastIndexOf('/');
+        if (slashIdx >= 0) rawName = rawName.substring(slashIdx + 1);
+        rawName = rawName.replaceAll("[^A-Za-z0-9._\\u4e00-\\u9fa5-]", "_");
+        if (!StringUtils.hasText(rawName) || ".".equals(rawName) || "..".equals(rawName)) {
+            rawName = "upload";
+        }
+        String fileName = System.currentTimeMillis() + "_" + rawName;
 
-        // Build logical path for storage (just a key, physical structure handled by key)
-        // We can just use the flat storage path, but linking it to the folder system is what matters.
         String storagePath = "projects/" + projectId + "/client_uploads/" + fileName;
         
         // Physical Save

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -69,6 +69,7 @@ public class ProjectFileService {
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException("文件夹名称不能为空");
         }
+        validateNodeName(name);
         if (userId == null) {
             throw new IllegalArgumentException("用户 ID 不能为空");
         }
@@ -96,6 +97,17 @@ public class ProjectFileService {
         folder.setUpdatedAt(LocalDateTime.now());
 
         return projectFileRepository.save(folder);
+    }
+
+    /**
+     * 校验文件/文件夹名合法性：不得含路径分隔符或为 "." / ".."，
+     * 否则该名字会被 buildPhysicalPath 逐级拼进物理路径，导致文件写到项目目录之外。
+     */
+    private void validateNodeName(String name) {
+        String n = name == null ? "" : name.trim();
+        if (n.contains("/") || n.contains("\\") || ".".equals(n) || "..".equals(n)) {
+            throw new IllegalArgumentException("名称包含非法字符: " + name);
+        }
     }
 
     /**
@@ -235,6 +247,7 @@ public class ProjectFileService {
         if (!StringUtils.hasText(newName)) {
             throw new IllegalArgumentException("新名称不能为空");
         }
+        validateNodeName(newName);
 
         ProjectFile file = projectFileRepository.findById(fileId)
                 .orElseThrow(() -> new IllegalArgumentException("文件不存在: " + fileId));

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -349,10 +349,17 @@ public class FileTools implements AgentToolComponent {
     // --- Helpers ---
 
     private Path resolvePath(String fileName) {
-        if (Paths.get(fileName).isAbsolute()) {
-            return Paths.get(fileName);
+        Path root = getProjectRoot().normalize();
+        Path resolved = Paths.get(fileName).isAbsolute()
+                ? Paths.get(fileName).normalize()
+                : root.resolve(fileName).normalize();
+        // 安全围栏：AI 完全可控该路径，normalize 后必须仍在项目根内，
+        // 否则 read/write/move_file 可用绝对路径或 "../" 逃出根读写任意系统文件。
+        // 与同类 list_files/write_docx 已有的 startsWith 校验保持一致。
+        if (!resolved.startsWith(root)) {
+            throw new SecurityException("Access denied: path escapes project root: " + fileName);
         }
-        return getProjectRoot().resolve(fileName);
+        return resolved;
     }
     
     private String getFileType(String fileName) {

--- a/backend/src/main/java/com/checkba/storage/LocalFileStorageService.java
+++ b/backend/src/main/java/com/checkba/storage/LocalFileStorageService.java
@@ -154,12 +154,19 @@ public class LocalFileStorageService implements StorageService {
     /**
      * 解析文件路径
      * 如果 fileId 包含路径分隔符，则直接使用；否则兼容旧逻辑添加 .docx
+     *
+     * 安全围栏：对 fileId 做 normalize 后校验解析结果仍落在 storageDir 内，
+     * 防止 fileId 含 "../" 逃出存储根读写/删除任意文件（纵深防御的最后一道）。
      */
     private Path resolveFilePath(String fileId) {
-        if (fileId.contains("/") || fileId.contains("\\")) {
-            return storageDir.resolve(fileId);
+        String relative = (fileId.contains("/") || fileId.contains("\\")) ? fileId : fileId + ".docx";
+        Path base = storageDir.normalize();
+        Path resolved = base.resolve(relative).normalize();
+        if (!resolved.startsWith(base)) {
+            log.warn("拒绝越界文件路径: fileId={}, resolved={}", fileId, resolved);
+            throw new StorageException("非法文件路径（越出存储根）: " + fileId);
         }
-        return storageDir.resolve(fileId + ".docx");
+        return resolved;
     }
 
     @Override

--- a/backend/src/test/java/com/checkba/storage/LocalFileStorageServiceTest.java
+++ b/backend/src/test/java/com/checkba/storage/LocalFileStorageServiceTest.java
@@ -1,0 +1,56 @@
+package com.checkba.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 锁定 LocalFileStorageService 的路径遍历围栏：
+ * 任何 normalize 后逃出存储根的 fileId 都必须被拒绝，而非读写/删除根外文件。
+ */
+class LocalFileStorageServiceTest {
+
+    private LocalFileStorageService storage;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) {
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(tempDir.toAbsolutePath().toString());
+        props.getLocal().setTemplatePath(tempDir.resolve("no-template.docx").toAbsolutePath().toString());
+        storage = new LocalFileStorageService(props);
+    }
+
+    private ByteArrayInputStream bytes(String s) {
+        return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void savesAndReadsNormalKeyWithinRoot() {
+        storage.save("projects/1/note.txt", bytes("hello"));
+        assertTrue(storage.exists("projects/1/note.txt"));
+    }
+
+    @Test
+    void rejectsRelativeTraversalOnSave() {
+        assertThrows(StorageException.class,
+                () -> storage.save("../escape.txt", bytes("x")));
+    }
+
+    @Test
+    void rejectsDeepTraversalOnExists() {
+        assertThrows(StorageException.class,
+                () -> storage.exists("projects/1/../../../../etc/passwd"));
+    }
+
+    @Test
+    void rejectsTraversalOnDelete() {
+        assertThrows(StorageException.class,
+                () -> storage.delete("../../secret"));
+    }
+}


### PR DESCRIPTION
自主代码体检修复系列 **批次 B**：四处路径遍历 sink 加固，用户/AI 可控路径无法逃出目标目录。

## 修复项
| # | 严重度 | sink | 修复 |
|---|---|---|---|
| B1 | 高 | `LocalFileStorageService.resolveFilePath` 无 normalize/围栏 | normalize + `startsWith(storageDir)` 围栏，单点覆盖全部读写 |
| B2 | 高 | `FileTools.resolvePath` AI 可控路径无围栏（read/write/move） | 项目根围栏，拒绝绝对路径/`../` 逃逸 |
| B3 | 中 | `DdService` 客户端上传 `originalFilename` 未清洗 | 取文件名段 + 剥离分隔符/特殊字符 + 处理 null（保留中文） |
| B4 | 中 | `ProjectFileService` 文件夹/文件名可为 `..`/含 `/` | `validateNodeName` 拒绝非法名 |

## 测试
新增 `LocalFileStorageServiceTest`（4 例）锁定围栏。回归 **192/192 全绿**（188 + 4 新增）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)