### PR TITLE
fix(backend): 外部服务与输入健壮性（批次C）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -20,7 +20,9 @@ public class AuthController {
     private final ClientInvitationService clientInvitationService;
 
     // 简单的 session 存储（内存中，实际生产环境应使用 Redis 或 JWT）
-    private static final Map<String, Long> SESSION_STORE = new HashMap<>();
+    // 并发安全：登录写入与每请求读取/移除高频并发，普通 HashMap 扩容会损坏桶结构
+    // （丢 session 导致误判未登录，甚至 CPU 空转死循环）。
+    private static final Map<String, Long> SESSION_STORE = new java.util.concurrent.ConcurrentHashMap<>();
 
     private static UserService staticUserService;
 

--- a/backend/src/main/java/com/checkba/service/ContentSearchService.java
+++ b/backend/src/main/java/com/checkba/service/ContentSearchService.java
@@ -271,40 +271,87 @@ public class ContentSearchService {
         int lineNumber = 0;
         for (String line : lines) {
             lineNumber++;
-            Matcher matcher = pattern.matcher(line);
-            
-            while (matcher.find()) {
-                int start = matcher.start();
-                int end = matcher.end();
-                
-                // 提取上下文
-                String context = extractContext(line, start, end);
-                
-                // 计算在 context 中的相对位置
-                int contextStart = Math.max(0, start - MAX_CONTEXT_CHARS / 2);
-                int relativeStart = start - contextStart;
-                int relativeEnd = relativeStart + (end - start);
-                
-                // 如果 context 有前缀 "..."，需要调整偏移
-                if (contextStart > 0) {
-                    relativeStart += 3; // "..." 的长度
-                    relativeEnd += 3;
+            try {
+                // 用超时感知的 CharSequence 包装，防止用户提供的正则触发灾难性回溯挂死搜索线程
+                Matcher matcher = pattern.matcher(
+                        new TimeLimitedCharSequence(line, System.currentTimeMillis() + REGEX_TIMEOUT_MS));
+
+                while (matcher.find()) {
+                    int start = matcher.start();
+                    int end = matcher.end();
+
+                    // 提取上下文
+                    String context = extractContext(line, start, end);
+
+                    // 计算在 context 中的相对位置
+                    int contextStart = Math.max(0, start - MAX_CONTEXT_CHARS / 2);
+                    int relativeStart = start - contextStart;
+                    int relativeEnd = relativeStart + (end - start);
+
+                    // 如果 context 有前缀 "..."，需要调整偏移
+                    if (contextStart > 0) {
+                        relativeStart += 3; // "..." 的长度
+                        relativeEnd += 3;
+                    }
+
+                    matches.add(MatchInfo.builder()
+                        .lineNumber(lineNumber)
+                        .content(context)
+                        .startIndex(relativeStart)
+                        .endIndex(relativeEnd)
+                        .build());
+
+                    if (matches.size() >= MAX_MATCHES_PER_FILE * 2) {
+                        return matches;
+                    }
                 }
-                
-                matches.add(MatchInfo.builder()
-                    .lineNumber(lineNumber)
-                    .content(context)
-                    .startIndex(relativeStart)
-                    .endIndex(relativeEnd)
-                    .build());
-                
-                if (matches.size() >= MAX_MATCHES_PER_FILE * 2) {
-                    return matches;
-                }
+            } catch (RegexTimeoutException e) {
+                log.warn("正则匹配超时（可能 ReDoS），放弃该文件剩余匹配（行 {}）", lineNumber);
+                return matches;
             }
         }
-        
+
         return matches;
+    }
+
+    private static final long REGEX_TIMEOUT_MS = 2000;
+
+    /** 正则匹配超时（用于中断灾难性回溯）。无堆栈以降低开销。 */
+    private static final class RegexTimeoutException extends RuntimeException {
+        RegexTimeoutException() { super(null, null, false, false); }
+    }
+
+    /**
+     * 包装 CharSequence，在正则回溯大量访问字符时检测超时，
+     * 阻止 catastrophic backtracking（如 (a+)+）挂死搜索线程。
+     */
+    private static final class TimeLimitedCharSequence implements CharSequence {
+        private final CharSequence inner;
+        private final long deadline;
+
+        TimeLimitedCharSequence(CharSequence inner, long deadline) {
+            this.inner = inner;
+            this.deadline = deadline;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new RegexTimeoutException();
+            }
+            return inner.charAt(index);
+        }
+
+        @Override
+        public int length() { return inner.length(); }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new TimeLimitedCharSequence(inner.subSequence(start, end), deadline);
+        }
+
+        @Override
+        public String toString() { return inner.toString(); }
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/TtsService.java
+++ b/backend/src/main/java/com/checkba/service/TtsService.java
@@ -49,11 +49,37 @@ public class TtsService {
     @Value("${external.tts.local-base-url:}")
     private String defaultLocalBaseUrl;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate = buildRestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static RestTemplate buildRestTemplate() {
+        // 显式超时：此前无 connect/read timeout，ElevenLabs 或本地 Kokoro 网络卡死会无限期
+        // 挂起并占满请求线程。TTS 合成可能较慢，read 超时给宽松值。
+        org.springframework.http.client.SimpleClientHttpRequestFactory factory =
+                new org.springframework.http.client.SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10_000);
+        factory.setReadTimeout(60_000);
+        return new RestTemplate(factory);
+    }
 
     public TtsService() {
         new File(TEMP_AUDIO_DIR).mkdirs();
+    }
+
+    /**
+     * 定时清理临时音频目录：合成的 mp3/wav 写入 TEMP_AUDIO_DIR 后返回 File，此前无任何清理，
+     * 长期运行会撑满系统临时目录。每小时清理超过 1 小时未修改的文件（保留最近文件供下载/播放）。
+     */
+    @org.springframework.scheduling.annotation.Scheduled(fixedRate = 60 * 60 * 1000)
+    public void cleanupOldAudioFiles() {
+        File[] files = new File(TEMP_AUDIO_DIR).listFiles();
+        if (files == null) return;
+        long cutoff = System.currentTimeMillis() - 60 * 60 * 1000;
+        for (File f : files) {
+            if (f.isFile() && f.lastModified() < cutoff && !f.delete()) {
+                logger.warn("Failed to delete stale TTS audio: {}", f.getName());
+            }
+        }
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -14,7 +14,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Python Tools for the Agent (Dockerized).
@@ -186,7 +185,14 @@ default_api = _ToolAPI()
             log.info("Executing Docker command: {}", String.join(" ", command));
             
             process = pb.start();
-            
+
+            // 并发排空 stdout/stderr：子进程输出超过 OS 管道缓冲区(~64KB)时会阻塞在 write，
+            // 若主线程等进程退出后才读，进程将永不退出 → 假超时。必须边跑边读。
+            final StringBuilder stdoutBuf = new StringBuilder();
+            final StringBuilder stderrBuf = new StringBuilder();
+            Thread outPump = pumpStream(process.getInputStream(), stdoutBuf);
+            Thread errPump = pumpStream(process.getErrorStream(), stderrBuf);
+
             // 3. Monitor for tool call requests (IPC loop)
             Path requestReadyPath = tempDir.resolve("_request_ready");
             Path requestPath = tempDir.resolve("_tool_request.json");
@@ -247,11 +253,13 @@ default_api = _ToolAPI()
                 Thread.sleep(100);
             }
             
-            // 4. Capture Output
-            String stdout = new BufferedReader(new InputStreamReader(process.getInputStream()))
-                            .lines().collect(Collectors.joining("\n"));
-            String stderr = new BufferedReader(new InputStreamReader(process.getErrorStream()))
-                            .lines().collect(Collectors.joining("\n"));
+            // 4. Capture Output（等排空线程收齐后再读缓冲）
+            outPump.join(5000);
+            errPump.join(5000);
+            String stdout;
+            String stderr;
+            synchronized (stdoutBuf) { stdout = stdoutBuf.toString().trim(); }
+            synchronized (stderrBuf) { stderr = stderrBuf.toString().trim(); }
             
             // 5. Return
             if (process.exitValue() != 0) {
@@ -280,6 +288,26 @@ default_api = _ToolAPI()
         }
     }
     
+    /**
+     * 后台守护线程持续读取进程输出流到缓冲，防止管道写阻塞导致子进程挂死。
+     */
+    private Thread pumpStream(java.io.InputStream in, StringBuilder sink) {
+        Thread t = new Thread(() -> {
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(in, java.nio.charset.StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    synchronized (sink) { sink.append(line).append('\n'); }
+                }
+            } catch (java.io.IOException ignored) {
+                // 进程结束/流关闭时正常退出
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
     /**
      * Execute a tool requested by Python code.
      */


### PR DESCRIPTION
自主代码体检修复系列 **批次 C**：五处会导致挂死/损坏/资源耗尽的健壮性缺陷。

| # | 严重度 | 问题 | 修复 |
|---|---|---|---|
| 并发 | 高 | `AuthController.SESSION_STORE` 用 HashMap，并发扩容损坏桶 → 丢 session/死循环 | 改 `ConcurrentHashMap` |
| 死锁 | 高 | `PythonTools` 进程退出后才读 stdout，输出 >~64KB 时子进程写阻塞永不退出 → 假超时 | 守护线程并发排空 stdout/stderr |
| 超时 | 高 | `TtsService.restTemplate` 无 connect/read 超时 → 网络卡死挂满线程 | 显式 10s/60s 超时 |
| 泄漏 | 中 | TTS 临时音频从不清理 → 撑满 tmpdir | `@Scheduled` 每小时清理超龄文件 |
| ReDoS | 中 | `ContentSearchService` 用户正则灾难性回溯挂死搜索线程 | 超时感知 `CharSequence` 包装，2s 中断 |

回归 **192/192 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)