### PR TITLE
feat(security): 安全加固——密码/CORS/邀请码/SSRF（批次D）

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,6 +25,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <!-- 仅密码哈希（BCrypt），不引入整套 security 过滤器链，避免改变现有接口鉴权行为 -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>

--- a/backend/src/main/java/com/checkba/config/CorsConfig.java
+++ b/backend/src/main/java/com/checkba/config/CorsConfig.java
@@ -3,78 +3,116 @@ package com.checkba.config;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
- * 全局 CORS 配置
- * 解决跨域问题（支持 cpolar 内网穿透等场景）
- * 
- * 使用自定义过滤器处理所有 CORS 请求，设置最高优先级确保在其他过滤器之前执行
+ * 全局 CORS 配置。
+ *
+ * 默认仅允许 localhost/127.0.0.1（开发与桌面 Electron 场景）以及配置的白名单来源携带凭证跨域。
+ * 内网穿透（cpolar 等）的随机域名需在 {@code security.cors.allowed-origins} 中显式配置，
+ * 或临时将 {@code security.cors.allow-all=true} 作为逃生开关恢复“回显任意来源”（不建议生产开启）。
+ *
+ * 此前无条件反射任意 Origin 且允许凭证，等价于任意站点可带凭证跨域访问，已收敛为白名单。
  */
 @Configuration
 public class CorsConfig {
 
-    /**
-     * 自定义 CORS 过滤器，确保 OPTIONS 预检请求能正确响应
-     * 设置最高优先级，在所有其他过滤器之前执行
-     */
+    @Value("${security.cors.allowed-origins:}")
+    private String allowedOriginsCsv;
+
+    @Value("${security.cors.allow-all:false}")
+    private boolean allowAll;
+
     @Bean
     public FilterRegistrationBean<Filter> corsFilterRegistration() {
         FilterRegistrationBean<Filter> bean = new FilterRegistrationBean<>();
-        bean.setFilter(new CorsPreflightFilter());
+        bean.setFilter(new CorsPreflightFilter(parseOrigins(allowedOriginsCsv), allowAll));
         bean.addUrlPatterns("/*");
         bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
         bean.setName("corsPreflightFilter");
         return bean;
     }
 
+    private static Set<String> parseOrigins(String csv) {
+        Set<String> set = new HashSet<>();
+        if (csv != null) {
+            for (String s : csv.split(",")) {
+                String t = s.trim();
+                if (!t.isEmpty()) set.add(t);
+            }
+        }
+        return set;
+    }
+
     /**
-     * 自定义过滤器：处理所有 CORS 请求，特别是 OPTIONS 预检请求
+     * 自定义过滤器：处理所有 CORS 请求，特别是 OPTIONS 预检请求。
+     * 仅对受信来源回显 Origin 并允许携带凭证。
      */
     public static class CorsPreflightFilter implements Filter {
-        
+
+        private final Set<String> allowedOrigins;
+        private final boolean allowAll;
+
+        public CorsPreflightFilter(Set<String> allowedOrigins, boolean allowAll) {
+            this.allowedOrigins = allowedOrigins;
+            this.allowAll = allowAll;
+        }
+
         @Override
         public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
                 throws IOException, ServletException {
             HttpServletResponse response = (HttpServletResponse) res;
             HttpServletRequest request = (HttpServletRequest) req;
-            
-            // 获取请求来源
+
             String origin = request.getHeader("Origin");
-            
-            // 设置 CORS 响应头
-            if (origin != null && !origin.isEmpty()) {
-                // 有 Origin 头时，使用具体的 origin（支持 credentials）
+            if (origin != null && !origin.isEmpty() && isAllowed(origin)) {
+                // 仅对受信来源回显 origin 并允许携带凭证
                 response.setHeader("Access-Control-Allow-Origin", origin);
                 response.setHeader("Access-Control-Allow-Credentials", "true");
-            } else {
-                // 没有 Origin 头时（如直接 curl 访问），允许所有来源但不支持 credentials
-                response.setHeader("Access-Control-Allow-Origin", "*");
-                // 注意：当 Allow-Origin 为 * 时，不能设置 Allow-Credentials 为 true
+                response.setHeader("Vary", "Origin");
             }
-            
+            // 不在白名单的来源：不设置 Allow-Origin，浏览器会阻止其读取响应。
+            // 无 Origin 头（同源/curl）不受影响，正常处理。
+
             response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD");
             response.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Session-Id, Cache-Control, Pragma, X-File-Offset, X-File-Total-Size");
             response.setHeader("Access-Control-Max-Age", "3600");
             response.setHeader("Access-Control-Expose-Headers", "Content-Disposition, X-Suggested-Filename");
-            
+
             // 对于 OPTIONS 预检请求，直接返回 200，不继续处理
             if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
                 response.setStatus(HttpServletResponse.SC_OK);
                 return;
             }
-            
+
             chain.doFilter(req, res);
         }
-        
+
+        private boolean isAllowed(String origin) {
+            if (allowAll) return true;
+            if (allowedOrigins.contains(origin)) return true;
+            // 默认放行本机来源（开发与桌面 Electron 场景）
+            return origin.startsWith("http://localhost:")
+                    || origin.startsWith("https://localhost:")
+                    || origin.equals("http://localhost")
+                    || origin.equals("https://localhost")
+                    || origin.startsWith("http://127.0.0.1:")
+                    || origin.startsWith("https://127.0.0.1:")
+                    || origin.equals("http://127.0.0.1")
+                    || origin.equals("https://127.0.0.1");
+        }
+
         @Override
         public void init(FilterConfig filterConfig) {}
-        
+
         @Override
         public void destroy() {}
     }

--- a/backend/src/main/java/com/checkba/config/DataInitializer.java
+++ b/backend/src/main/java/com/checkba/config/DataInitializer.java
@@ -29,7 +29,7 @@ public class DataInitializer implements CommandLineRunner {
                 .orElseGet(() -> {
                     User user = new User();
                     user.setUsername("admin");
-                    user.setPassword("123"); // 默认密码
+                    user.setPassword(com.checkba.service.UserService.encodePassword("123")); // 默认密码（BCrypt）
                     user.setDisplayName("管理员");
                     user.setCreatedAt(LocalDateTime.now());
                     user.setUpdatedAt(LocalDateTime.now());

--- a/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
+++ b/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
@@ -52,6 +52,9 @@ public class BrowserProxyController {
 
         try {
             URI uri = URI.create(u);
+            if (isBlockedTarget(uri)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("目标地址不被允许（已禁止本地/内网地址）");
+            }
             HttpRequest req = HttpRequest.newBuilder(uri)
                     .GET()
                     .timeout(Duration.ofSeconds(20))
@@ -154,6 +157,26 @@ public class BrowserProxyController {
                 .replace("\"", "&quot;")
                 .replace("<", "&lt;")
                 .replace(">", "&gt;");
+    }
+
+    /**
+     * SSRF 防护：拒绝解析到本地/内网地址的目标，阻止代理被用来打内网服务或云元数据端点
+     * （如 169.254.169.254）。注意 followRedirects=NORMAL 下重定向到内网仍是残余风险，此处仅校验初始目标。
+     */
+    private boolean isBlockedTarget(URI uri) {
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) return true;
+        try {
+            for (java.net.InetAddress addr : java.net.InetAddress.getAllByName(host)) {
+                if (addr.isLoopbackAddress() || addr.isAnyLocalAddress()
+                        || addr.isSiteLocalAddress() || addr.isLinkLocalAddress()) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            return true; // 解析失败按不安全处理
+        }
+        return false;
     }
 }
 

--- a/backend/src/main/java/com/checkba/service/ClientInvitationService.java
+++ b/backend/src/main/java/com/checkba/service/ClientInvitationService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.Random;
 import java.util.UUID;
 
 @Service
@@ -141,7 +140,8 @@ public class ClientInvitationService {
     private String generateUniqueCode() {
         String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         StringBuilder sb = new StringBuilder();
-        Random random = new Random();
+        // 用 SecureRandom：该码是客户访问项目的唯一凭证，可预测的 java.util.Random 可被枚举/预测
+        java.security.SecureRandom random = new java.security.SecureRandom();
         String code;
         do {
             sb.setLength(0);

--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -3,6 +3,7 @@ package com.checkba.service;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -14,6 +15,19 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    /** BCrypt 无状态、线程安全，可静态复用。 */
+    private static final BCryptPasswordEncoder PW_ENCODER = new BCryptPasswordEncoder();
+
+    /** 判断存储的口令是否已是 BCrypt 哈希（$2a/$2b/$2y 前缀）。 */
+    private static boolean isBcryptHash(String stored) {
+        return stored != null && stored.startsWith("$2");
+    }
+
+    /** 供 DataInitializer 等复用的 BCrypt 加密入口。 */
+    public static String encodePassword(String raw) {
+        return PW_ENCODER.encode(raw);
+    }
 
     /**
      * 用户注册
@@ -36,9 +50,7 @@ public class UserService {
 
         User user = new User();
         user.setUsername(username);
-        // 简单密码存储（实际生产环境应使用 BCrypt 加密）
-        // TODO: 后续接入 Spring Security 后使用 BCryptPasswordEncoder
-        user.setPassword(password); // 临时存储明文，后续改为加密
+        user.setPassword(PW_ENCODER.encode(password));
         user.setDisplayName(StringUtils.hasText(displayName) ? displayName : username);
         user.setCreatedAt(LocalDateTime.now());
         user.setUpdatedAt(LocalDateTime.now());
@@ -63,9 +75,19 @@ public class UserService {
         }
 
         User user = userOpt.get();
-        // 简单密码验证（实际生产环境应使用 BCrypt 验证）
-        // TODO: 后续接入 Spring Security 后使用 BCryptPasswordEncoder.matches()
-        if (!password.equals(user.getPassword())) {
+        String stored = user.getPassword();
+        boolean ok;
+        if (isBcryptHash(stored)) {
+            ok = PW_ENCODER.matches(password, stored);
+        } else {
+            // 兼容历史明文口令：比对成功后就地升级为 BCrypt（无需一次性数据迁移）
+            ok = password.equals(stored);
+            if (ok) {
+                user.setPassword(PW_ENCODER.encode(password));
+                userRepository.save(user);
+            }
+        }
+        if (!ok) {
             throw new IllegalArgumentException("用户名或密码错误");
         }
 

--- a/backend/src/test/java/com/checkba/service/UserServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/UserServiceTest.java
@@ -1,0 +1,76 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定口令加密与登录兼容行为：
+ * 注册存 BCrypt 而非明文；历史明文口令登录成功后自动升级；错误口令拒绝。
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void registerStoresBcryptNotPlaintext() {
+        when(userRepository.findByUsername("alice")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User u = userService.register("alice", "secret123", "Alice");
+
+        assertNotEquals("secret123", u.getPassword());
+        assertTrue(u.getPassword().startsWith("$2"), "password should be a BCrypt hash");
+    }
+
+    @Test
+    void loginSucceedsForBcryptUser() {
+        User stored = new User();
+        stored.setUsername("bob");
+        stored.setPassword(UserService.encodePassword("pw123456"));
+        when(userRepository.findByUsername("bob")).thenReturn(Optional.of(stored));
+
+        User u = userService.login("bob", "pw123456");
+
+        assertEquals("bob", u.getUsername());
+    }
+
+    @Test
+    void loginUpgradesLegacyPlaintextInPlace() {
+        User legacy = new User();
+        legacy.setUsername("carol");
+        legacy.setPassword("oldplain"); // 历史明文
+        when(userRepository.findByUsername("carol")).thenReturn(Optional.of(legacy));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        userService.login("carol", "oldplain");
+
+        assertTrue(legacy.getPassword().startsWith("$2"), "legacy plaintext should be upgraded to BCrypt");
+        verify(userRepository).save(legacy);
+    }
+
+    @Test
+    void loginRejectsWrongPassword() {
+        User stored = new User();
+        stored.setUsername("dave");
+        stored.setPassword(UserService.encodePassword("right"));
+        when(userRepository.findByUsername("dave")).thenReturn(Optional.of(stored));
+
+        assertThrows(IllegalArgumentException.class, () -> userService.login("dave", "wrong"));
+    }
+}


### PR DESCRIPTION
自主代码体检修复系列 **批次 D**：按生产标准加固四类安全问题（用户已授权全部加固）。

| # | 严重度 | 问题 | 修复 |
|---|---|---|---|
| 密码 | 高 | 明文存储 + `admin/123` | BCrypt（spring-security-crypto）；登录兼容旧明文并自动升级，无需数据迁移 |
| CORS | 高 | 反射任意 Origin + 允许凭证 | 白名单化（默认 localhost + 配置来源；`allow-all` 逃生开关） |
| 邀请码 | 中 | `java.util.Random` 可预测 | `SecureRandom` |
| SSRF | 高 | 代理可打内网/云元数据 | 拒绝解析到本地/内网地址（残余 redirect SSRF 已标注） |

## 兼容性
- 密码：**不引入整套 security 过滤器链**，仅哈希模块，现有接口鉴权行为不变；现有 `admin/123` 首次登录后自动升级为 BCrypt。
- CORS：内网穿透（cpolar）随机域名需配置 `security.cors.allowed-origins` 或临时 `allow-all=true`。

## 测试
新增 `UserServiceTest`（4 例）。回归 **196/196 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)