### PR TITLE
fix(files): 项目文件接口越权(IDOR)修复（批次E1）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ProjectFileController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectFileController.java
@@ -76,6 +76,18 @@ public class ProjectFileController {
     }
 
     /**
+     * 校验目标文件确实属于当前 projectId，防止越权操作他人项目的文件（IDOR）。
+     * checkFileTreeAccess 只校验用户是 URL 中 projectId 的成员；按全局 fileId 操作的接口
+     * 若不校验归属，成员可传入他人项目的 fileId 进行读/写/删。
+     */
+    private void checkFileInProject(Long fileId, Long projectId) {
+        ProjectFile file = projectFileService.getFile(fileId); // 文件不存在会抛异常
+        if (!projectId.equals(file.getProjectId())) {
+            throw new IllegalArgumentException("文件不属于该项目");
+        }
+    }
+
+    /**
      * 创建文件夹
      * POST /api/projects/{projectId}/files/folder
      */
@@ -133,6 +145,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         return projectFileService.rename(fileId, request.getName(), userId);
     }
 
@@ -150,6 +163,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         projectFileService.delete(fileId, userId);
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
@@ -242,6 +256,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         return projectFileService.move(fileId, request.getParentId(), request.getSortOrder(), userId);
     }
 
@@ -259,6 +274,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         return projectFileService.getFile(fileId);
     }
 
@@ -292,6 +308,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         projectFileService.restore(fileId, userId);
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
@@ -313,6 +330,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         projectFileService.permDelete(fileId, userId);
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
@@ -393,6 +411,7 @@ public class ProjectFileController {
             throw new IllegalArgumentException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         fileTagService.addTagToFile(fileId, request.getTagId(), userId);
     }
 
@@ -411,6 +430,7 @@ public class ProjectFileController {
             throw new IllegalArgumentException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        checkFileInProject(fileId, projectId);
         fileTagService.removeTagFromFile(fileId, tagId);
     }
 }

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -506,6 +506,11 @@ public class ProjectFileService {
         }
         for (Long id : request.getFileIds()) {
             if (id == null) continue;
+            // 归属校验：防止越权批量删除他人项目的文件（delete(id,...) 本身不校验 projectId）
+            ProjectFile owned = projectFileRepository.findById(id).orElse(null);
+            if (owned != null && !Objects.equals(owned.getProjectId(), projectId)) {
+                throw new IllegalArgumentException("跨项目删除不支持: " + id);
+            }
             try {
                 delete(id, userId);
             } catch (IllegalArgumentException e) {
@@ -533,6 +538,11 @@ public class ProjectFileService {
         List<ProjectFile> result = new ArrayList<>();
         for (Long id : request.getFileIds()) {
             if (id == null) continue;
+            // 归属校验：防止越权批量移动他人项目的文件（move(id,...) 本身不校验 projectId）
+            ProjectFile owned = projectFileRepository.findById(id).orElse(null);
+            if (owned != null && !Objects.equals(owned.getProjectId(), projectId)) {
+                throw new IllegalArgumentException("跨项目移动不支持: " + id);
+            }
             result.add(move(id, request.getTargetParentId(), null, userId));
         }
         return result;

--- a/backend/src/test/java/com/checkba/controller/ProjectFileControllerIdorTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectFileControllerIdorTest.java
@@ -1,0 +1,75 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.FileTagService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ProjectMemberService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定 ProjectFileController 的越权(IDOR)防护：
+ * 用户是 URL 中 projectId 的成员，但传入他人项目的 fileId 时必须被拒绝。
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectFileControllerIdorTest {
+
+    @Mock
+    private ProjectFileService projectFileService;
+    @Mock
+    private ProjectMemberService projectMemberService;
+    @Mock
+    private FileTagService fileTagService;
+
+    @InjectMocks
+    private ProjectFileController controller;
+
+    @Test
+    void renameRejectsFileFromAnotherProject() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            // 用户是项目 1 的合法成员
+            when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+            when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+            // 但目标文件属于项目 999
+            ProjectFile foreign = new ProjectFile();
+            foreign.setId(50L);
+            foreign.setProjectId(999L);
+            when(projectFileService.getFile(50L)).thenReturn(foreign);
+
+            ProjectFileController.RenameRequest req = new ProjectFileController.RenameRequest();
+            req.setName("hacked");
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.rename(1L, 50L, req, "sess"));
+            // 校验失败后不得真正执行重命名
+            verify(projectFileService, never()).rename(anyLong(), anyString(), anyLong());
+        }
+    }
+
+    @Test
+    void renameAllowsFileWithinSameProject() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+            when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+            ProjectFile own = new ProjectFile();
+            own.setId(50L);
+            own.setProjectId(1L);
+            when(projectFileService.getFile(50L)).thenReturn(own);
+
+            ProjectFileController.RenameRequest req = new ProjectFileController.RenameRequest();
+            req.setName("ok");
+
+            controller.rename(1L, 50L, req, "sess");
+            verify(projectFileService).rename(50L, "ok", 1L);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
@@ -1,0 +1,59 @@
+package com.checkba.service;
+
+import com.checkba.model.dto.ProjectFileBatchRequest;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * 锁定 ProjectFileService 批量操作的越权(IDOR)防护：
+ * batchDelete/batchMove 委托的 delete/move 不校验 projectId，批量入口须自行拒绝跨项目文件。
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectFileServiceIdorTest {
+
+    @Mock
+    private ProjectFileRepository projectFileRepository;
+
+    @InjectMocks
+    private ProjectFileService projectFileService;
+
+    @Test
+    void batchDeleteRejectsCrossProjectFile() {
+        ProjectFile foreign = new ProjectFile();
+        foreign.setId(77L);
+        foreign.setProjectId(999L);
+        when(projectFileRepository.findById(77L)).thenReturn(Optional.of(foreign));
+
+        ProjectFileBatchRequest req = new ProjectFileBatchRequest();
+        req.setFileIds(List.of(77L));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.batchDelete(1L, req, 1L));
+    }
+
+    @Test
+    void batchMoveRejectsCrossProjectFile() {
+        ProjectFile foreign = new ProjectFile();
+        foreign.setId(88L);
+        foreign.setProjectId(999L);
+        when(projectFileRepository.findById(88L)).thenReturn(Optional.of(foreign));
+
+        ProjectFileBatchRequest req = new ProjectFileBatchRequest();
+        req.setFileIds(List.of(88L));
+        req.setTargetParentId(5L);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.batchMove(1L, req, 1L));
+    }
+}


### PR DESCRIPTION
自主代码体检修复系列 **批次 E1**（越权 IDOR 第一部分）：项目文件接口的跨项目越权。

## 问题
`ProjectFileController` 按 fileId 操作的接口只校验用户是 URL 中 `projectId` 的成员（`checkFileTreeAccess`），不校验目标 `fileId` 是否属于该项目 → 某项目成员可传入他人项目的 fileId 读/写/删他人机密文件。

## 修复
- 新增 `checkFileInProject(fileId, projectId)`，覆盖 8 个单文件端点：rename / delete / move / getFile / restore / permDelete / addTag / removeTag。
- `ProjectFileService.batchDelete` / `batchMove` 循环内补归属校验（二者委托的 delete/move 不校验 projectId；`batchCopy` 早有此校验，属遗漏对齐）。

## 测试
新增 `ProjectFileControllerIdorTest`（跨项目拒绝 / 同项目放行）、`ProjectFileServiceIdorTest`（batch 跨项目拒绝）共 4 例。回归 **200/200 全绿**。

> 越权批次剩余 E2（FileController 零鉴权）、E3（DdController）、E4（其余 controller）将在后续 PR 继续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)