### PR TITLE
fix(files): 文件接口越权(IDOR)前后端协同修复（批次E2）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/FileController.java
+++ b/backend/src/main/java/com/checkba/controller/FileController.java
@@ -2,6 +2,7 @@ package com.checkba.controller;
 
 import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectMemberService;
 import com.checkba.service.ai.AutoTaggingService;
 import com.checkba.service.ai.ProjectRagService;
 import com.checkba.storage.StorageException;
@@ -52,15 +53,35 @@ public class FileController {
     @Autowired
     private AutoTaggingService autoTaggingService;
 
+    @Autowired
+    private ProjectMemberService projectMemberService;
+
     private StorageService getStorageService() {
         return storageServiceFactory.getStorageService();
+    }
+
+    /**
+     * 校验调用者是否有权访问该文件所属项目。
+     * 浏览器 &lt;a&gt; 下载无法设请求头，只能用 ?token=&lt;sessionId&gt;；fetch/XHR 走 X-Session-Id 头。
+     * 两者取其一解析出 userId 后校验项目成员资格。此前这些接口完全无鉴权，可按数字 id 遍历下载他人文件。
+     */
+    private boolean isAuthorizedForProject(String token, String sessionHeader, Long projectId) {
+        if (projectId == null) {
+            return false;
+        }
+        String sid = StringUtils.hasText(sessionHeader) ? sessionHeader : token;
+        Long userId = AuthController.getUserIdFromSession(sid);
+        return userId != null && projectMemberService.hasReadPermission(projectId, userId);
     }
 
     /**
      * 实际下载接口
      */
     @GetMapping("/{fileId}/download")
-    public ResponseEntity<Resource> downloadFile(@PathVariable("fileId") String fileId) {
+    public ResponseEntity<Resource> downloadFile(
+            @PathVariable("fileId") String fileId,
+            @RequestParam(value = "token", required = false) String token,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionHeader) {
         log.info("[FileDownload] ===== 开始处理下载请求 =====");
         log.info("[FileDownload] 收到下载请求: fileId={}", fileId);
         
@@ -89,7 +110,12 @@ public class FileController {
 
             if (projectFileOpt.isPresent()) {
                 ProjectFile pf = projectFileOpt.get();
-                log.info("[FileDownload] 找到文件记录: id={}, name={}, filePath={}, wpsFileId={}", 
+                // 鉴权：只有该文件所属项目的成员可下载（浏览器下载用 ?token=，其它用 X-Session-Id 头）
+                if (!isAuthorizedForProject(token, sessionHeader, pf.getProjectId())) {
+                    log.warn("[FileDownload] 拒绝越权下载: fileId={}, projectId={}", fileId, pf.getProjectId());
+                    return ResponseEntity.status(403).build();
+                }
+                log.info("[FileDownload] 找到文件记录: id={}, name={}, filePath={}, wpsFileId={}",
                     pf.getId(), pf.getName(), pf.getFilePath(), pf.getWpsFileId());
                 
                 // 如果数据库中有 filePath，优先使用
@@ -109,7 +135,9 @@ public class FileController {
                     }
                 }
             } else {
-                log.warn("[FileDownload] 数据库中未找到文件记录，使用fileId作为路径: {}", path);
+                // 找不到 DB 记录无法确定文件归属，拒绝下载（此前会按裸 fileId 路径直接返回文件，是越权面）
+                log.warn("[FileDownload] 未找到文件记录，拒绝下载: {}", fileId);
+                return ResponseEntity.status(404).build();
             }
 
             log.info("[FileDownload] 准备从存储加载文件: path={}", path);
@@ -212,6 +240,8 @@ public class FileController {
             @PathVariable("fileId") String fileId,
             @RequestPart(value = "file", required = false) MultipartFile multipartFile,
             @RequestHeader(value = "X-File-Offset", required = false) Long offset,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionHeader,
+            @RequestParam(value = "token", required = false) String token,
             HttpServletRequest request) {
 
         InputStream inputStream = null;
@@ -220,9 +250,19 @@ public class FileController {
             Optional<ProjectFile> projectFileOpt = projectFileRepository.findByWpsFileId(fileId).stream().findFirst();
             if (projectFileOpt.isPresent()) {
                 Long projectId = projectFileOpt.get().getProjectId();
+                // 鉴权：只有目标文件所属项目的成员可上传
+                if (!isAuthorizedForProject(token, sessionHeader, projectId)) {
+                    return ResponseEntity.status(403).body(Map.of("code", -1, "message", "无权上传到该文件"));
+                }
                 Long totalSize = projectFileRepository.sumSizeByProjectId(projectId); // Need to add this method to repo
                 if (totalSize != null && totalSize > 20L * 1024 * 1024 * 1024) {
                      return ResponseEntity.status(400).body(Map.of("code", -1, "message", "项目文件总大小超过20GB限制"));
+                }
+            } else {
+                // 找不到目标文件记录时，至少要求已登录用户，拒绝匿名上传
+                String sid = StringUtils.hasText(sessionHeader) ? sessionHeader : token;
+                if (AuthController.getUserIdFromSession(sid) == null) {
+                    return ResponseEntity.status(401).body(Map.of("code", -1, "message", "请先登录"));
                 }
             }
 
@@ -354,13 +394,19 @@ public class FileController {
      * GET /api/files/{fileId}/text
      */
     @GetMapping("/{fileId}/text")
-    public ResponseEntity<Map<String, Object>> getFileText(@PathVariable("fileId") Long fileId) {
+    public ResponseEntity<Map<String, Object>> getFileText(
+            @PathVariable("fileId") Long fileId,
+            @RequestParam(value = "token", required = false) String token,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionHeader) {
         try {
             Optional<ProjectFile> fileOpt = projectFileRepository.findById(fileId);
             if (fileOpt.isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("code", -1, "message", "文件不存在"));
             }
-            
+            if (!isAuthorizedForProject(token, sessionHeader, fileOpt.get().getProjectId())) {
+                return ResponseEntity.status(403).body(Map.of("code", -1, "message", "无权访问该文件"));
+            }
+
             String text = extractDocumentText(fileOpt.get());
             
             return ResponseEntity.ok(Map.of("code", 0, "data", text));
@@ -379,8 +425,10 @@ public class FileController {
     @GetMapping("/compare")
     public ResponseEntity<Map<String, Object>> compareDocuments(
             @RequestParam("sourceId") Long sourceId,
-            @RequestParam("targetId") Long targetId) {
-        
+            @RequestParam("targetId") Long targetId,
+            @RequestParam(value = "token", required = false) String token,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionHeader) {
+
         try {
             log.info("文档比较请求: sourceId={}, targetId={}", sourceId, targetId);
             
@@ -404,7 +452,13 @@ public class FileController {
             
             ProjectFile sourceFile = sourceOpt.get();
             ProjectFile targetFile = targetOpt.get();
-            
+
+            // 鉴权：两个文档所属项目都需当前用户有权访问
+            if (!isAuthorizedForProject(token, sessionHeader, sourceFile.getProjectId())
+                    || !isAuthorizedForProject(token, sessionHeader, targetFile.getProjectId())) {
+                return ResponseEntity.status(403).body(Map.of("code", -1, "message", "无权访问该文件"));
+            }
+
             // 3. 检查文件类型（只支持 doc/docx）
             List<String> supportedTypes = List.of("doc", "docx");
             String sourceType = sourceFile.getFileType() != null ? sourceFile.getFileType().toLowerCase() : "";

--- a/backend/src/test/java/com/checkba/controller/FileControllerAuthTest.java
+++ b/backend/src/test/java/com/checkba/controller/FileControllerAuthTest.java
@@ -1,0 +1,70 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.ai.AutoTaggingService;
+import com.checkba.service.ai.ProjectRagService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定 FileController 的鉴权：此前 download/text/compare/upload 完全无鉴权，
+ * 按数字 id 可遍历下载任意项目文件。现要求 token(query) 或 X-Session-Id(header) → 项目成员。
+ */
+@ExtendWith(MockitoExtension.class)
+class FileControllerAuthTest {
+
+    @Mock
+    private ProjectFileRepository projectFileRepository;
+    @Mock
+    private ProjectMemberService projectMemberService;
+    @Mock
+    private StorageServiceFactory storageServiceFactory;
+    @Mock
+    private ProjectRagService projectRagService;
+    @Mock
+    private AutoTaggingService autoTaggingService;
+
+    @InjectMocks
+    private FileController controller;
+
+    @Test
+    void downloadRejectsNonMemberWith403() {
+        ProjectFile pf = new ProjectFile();
+        pf.setId(5L);
+        pf.setProjectId(42L);
+        pf.setFilePath("projects/42/x.docx");
+        when(projectFileRepository.findById(5L)).thenReturn(Optional.of(pf));
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasReadPermission(42L, 7L)).thenReturn(false);
+
+            ResponseEntity<Resource> resp = controller.downloadFile("5", "sess", null);
+            assertEquals(403, resp.getStatusCode().value());
+        }
+    }
+
+    @Test
+    void downloadRejectsUnknownFileWith404() {
+        when(projectFileRepository.findById(9L)).thenReturn(Optional.empty());
+        when(projectFileRepository.findByWpsFileId("9")).thenReturn(List.of());
+
+        ResponseEntity<Resource> resp = controller.downloadFile("9", "sess", null);
+        assertEquals(404, resp.getStatusCode().value());
+    }
+}

--- a/frontend/src/components/DdRequestEditor.vue
+++ b/frontend/src/components/DdRequestEditor.vue
@@ -378,7 +378,7 @@ export default {
       })
     },
     viewFile(fileId) {
-       const url = `${getApiBaseUrl()}/api/files/${fileId}/download`
+       const url = `${getApiBaseUrl()}/api/files/${fileId}/download?token=${encodeURIComponent(getSessionId())}`
        window.open(url, '_blank')
     },
 

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -104,7 +104,7 @@
 
 <script>
 import { getFileDownloadUrl } from '@/services/api.js'
-import { getAuthHeaders } from '@/utils/auth.js'
+import { getAuthHeaders, getSessionId } from '@/utils/auth.js'
 
 // docx-preview 依赖 Chromium DOM，仅 H5/桌面构建启用；其它平台落 Office 占位分支
 // #ifdef H5
@@ -235,7 +235,8 @@ export default {
       try {
         const response = await uni.request({
           url: this.fileUrl,
-          method: 'GET'
+          method: 'GET',
+          header: getAuthHeaders()
         })
         this.textContent = response.data || ''
       } catch (error) {
@@ -429,11 +430,12 @@ export default {
         console.log('下载文件:', this.fileUrl)
         // #ifdef H5
         // H5端直接打开下载链接
-        window.open(this.fileUrl, '_blank')
+        window.open(this.fileUrl + (this.fileUrl.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(getSessionId()), '_blank')
         // #endif
         // #ifndef H5
         uni.downloadFile({
           url: this.fileUrl,
+          header: getAuthHeaders(),
           success: (res) => {
             if (res.statusCode === 200) {
               uni.openDocument({

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -803,7 +803,7 @@
 
 <script>
 import { getProjectFiles, createFolder, createFile, renameFile, deleteFile, deleteFilePerm, restoreFile as restoreFileApi, getRecycleBinFiles, moveFile, batchDeleteFiles, batchMoveFiles, batchCopyFiles, getApiBaseUrl } from '@/services/api.js'
-import { getAuthHeaders } from '@/utils/auth.js'
+import { getAuthHeaders, getSessionId } from '@/utils/auth.js'
 import CircularProgress from '@/components/CircularProgress.vue'
 import FileTypeIcon from '@/components/FileTypeIcon.vue'
 import TagChip from '@/components/TagChip.vue'
@@ -2001,7 +2001,7 @@ export default {
        uni.showToast({ title: '开始下载...', icon: 'none' })
 
        const baseUrl = getApiBaseUrl()
-       const token = uni.getStorageSync('token') || ''
+       const token = getSessionId() || ''
 
        try {
           const url = `${baseUrl}/api/files/${item.id}/download?token=${encodeURIComponent(token)}`
@@ -2061,7 +2061,7 @@ export default {
     handleDownload(item) {
         if (!item || item.isFolder) return
         const baseUrl = getApiBaseUrl()
-        const token = uni.getStorageSync('token') || ''
+        const token = getSessionId() || ''
         const url = `${baseUrl}/api/files/${item.id}/download?token=${encodeURIComponent(token)}`
 
         // Trigger browser download; handled by Main process to show Save As dialog

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1236,7 +1236,7 @@ import {
   getFileText,
   promptFeatureNotConfigured // 功能未配置统一引导（#18 T7）
 } from '@/services/api.js'
-import { getCurrentUser } from '@/utils/auth.js'
+import { getCurrentUser, getSessionId } from '@/utils/auth.js'
 import { FILE_BATCH_ACTIONS, FILE_TREE_QUICK_ACTIONS } from '@/config/fileActions.js'
 import { WORKBENCH_TOOLS } from '@/config/tools.js'
 import { OCR_ACTION_LABELS, INTERNAL_LINK_SCHEMES, WPS_INTERNAL_HTTP_LINK_BASE } from '@/config/workbenchActions.js'
@@ -3878,7 +3878,7 @@ export default {
 
         // 2. Upload File Content
         const fileToUpload = new File([blob], name, { type: 'image/png' })
-        const token = uni.getStorageSync('token')
+        const token = getSessionId()
         const baseUrl = getApiBaseUrl()
 
         await new Promise((resolve, reject) => {
@@ -3887,7 +3887,7 @@ export default {
                  name: 'file', // Param name expected by backend
                  file: fileToUpload,
                  header: {
-                     'Authorization': token ? `Bearer ${token}` : ''
+                     'X-Session-Id': token || ''
                  },
                  success: (res) => {
                      if (res.statusCode >= 200 && res.statusCode < 300) {


### PR DESCRIPTION
自主代码体检修复系列 **批次 E2**（越权 IDOR 第二部分,前后端协同）：`FileController` 下载/上传/取文本/对比接口零鉴权。

## 问题
`download/text/compare/upload` 完全无鉴权,按数字 id 可遍历下载/读取任意项目机密文件。前端本有 `?token=` 机制但**后端从不校验**,且调用方不一致(下载用的 `'token'` storage 键从未被写入,真实 session 存于 `checkba_session_id`)。

## 后端
- `isAuthorizedForProject(token/query 或 X-Session-Id/header → userId → 项目成员)`。
- download 命中校验归属、未命中 DB 记录直接 404;text/compare/upload 加同款校验。
- `FileControllerAuthTest`(非成员 403 / 未知文件 404)。

## 前端(补齐所有下载/上传入口,防 403)
| 位置 | 修复 |
|---|---|
| FileTree 下载×2 | 空 `'token'` 键 → `getSessionId()` |
| DdRequestEditor.viewFile / FilePreview window.open | 追加 `?token=` |
| FilePreview uni.request / uni.downloadFile | 加 `X-Session-Id` 头 |
| project-overview 截图上传 | 错误的 `Authorization: Bearer`(空) → `X-Session-Id` |

## 验证
backend **202/202**、frontend H5 构建通过。浏览器下载语义受限只能走 `?token=`(=sessionId)。**建议合并后在真实前端回归各下载/上传路径**(下载、预览、尽调查看、截图保存)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)