### PR TITLE
fix(business): 脱敏真删文字层 + DOCX跨run + 状态机/事务（批次F）

### DIFF
--- a/backend/src/main/java/com/checkba/service/DdService.java
+++ b/backend/src/main/java/com/checkba/service/DdService.java
@@ -291,6 +291,10 @@ public class DdService {
      */
     @Transactional
     public DdItem updateItemStatus(Long itemId, String status) {
+        // 状态机校验：只接受合法状态值，防止写入任意字符串（PENDING/UPLOADED/APPROVED/REJECTED）
+        if (status == null || !java.util.Set.of("PENDING", "UPLOADED", "APPROVED", "REJECTED").contains(status)) {
+            throw new IllegalArgumentException("非法的清单项状态: " + status);
+        }
         DdItem item = ddItemRepository.findById(itemId)
                 .orElseThrow(() -> new IllegalArgumentException("清单项不存在"));
         item.setStatus(status);

--- a/backend/src/main/java/com/checkba/service/ProjectService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectService.java
@@ -13,6 +13,7 @@ import com.checkba.model.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,7 @@ public class ProjectService {
     private final TushareService tushareService;
     private final ProjectVariableService projectVariableService;
 
+    @Transactional
     public Project createProject(ProjectCreateRequest request, Long userId) {
         if (!StringUtils.hasText(request.getProjectType())) {
             throw new IllegalArgumentException("项目类型不能为空");

--- a/backend/src/main/java/com/checkba/service/SensitiveService.java
+++ b/backend/src/main/java/com/checkba/service/SensitiveService.java
@@ -7,11 +7,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.pdfbox.text.TextPosition;
 import org.apache.poi.xwpf.usermodel.*;
 import org.springframework.stereotype.Service;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -91,24 +97,30 @@ public class SensitiveService {
     }
 
     private void replaceInParagraph(XWPFParagraph p, List<String> strategies) {
-        // Simple approach: combine runs, replace, set runs. 
-        // Complex approach (Preserve formatting): iterate runs.
-        // Given constraint "Format must not change", iterating runs is safer but splitting text across runs (e.g. bold '13', normal '8000') makes regex fail.
-        // We will try per-run replacement first.
-        
         List<XWPFRun> runs = p.getRuns();
-        if (runs != null) {
-            for (XWPFRun r : runs) {
-                String text = r.getText(0);
-                if (text != null && !text.isEmpty()) {
-                    String replaced = text;
-                    for (String strategy : strategies) {
-                        replaced = replaceSensitiveData(replaced, strategy);
-                    }
-                    if (!replaced.equals(text)) {
-                        r.setText(replaced, 0);
-                    }
-                }
+        if (runs == null || runs.isEmpty()) return;
+
+        // 拼接整段文本再匹配：敏感串常因排版被拆到多个 run（如加粗 "138" + 普通 "00001111"），
+        // 逐 run 匹配会漏掉跨 run 的敏感数据。
+        StringBuilder sb = new StringBuilder();
+        for (XWPFRun r : runs) {
+            String t = r.getText(0);
+            if (t != null) sb.append(t);
+        }
+        String original = sb.toString();
+        if (original.isEmpty()) return;
+
+        String replaced = original;
+        for (String strategy : strategies) {
+            replaced = replaceSensitiveData(replaced, strategy);
+        }
+
+        if (!replaced.equals(original)) {
+            // 命中敏感串：整段文本写回首个 run、清空其余 run。
+            // 仅对"含敏感数据"的段落折叠排版（丢失非首 run 的格式），正确性优先于排版保留。
+            runs.get(0).setText(replaced, 0);
+            for (int i = 1; i < runs.size(); i++) {
+                runs.get(i).setText("", 0);
             }
         }
     }
@@ -159,7 +171,23 @@ public class SensitiveService {
                 }
             }
             
-            document.save(dest);
+            // 3. 真删文字层：把已画黑框的每一页栅格化为图片并重建 PDF，移除底层可提取的文字对象。
+            //    此前仅在文字上叠加黑框，接收方复制/文本提取仍可还原原文——脱敏形同虚设。
+            //    权衡：输出为图片型 PDF（体积更大、正文不可再选中），换取"敏感文字不可提取"的安全保证。
+            PDFRenderer renderer = new PDFRenderer(document);
+            try (PDDocument flattened = new PDDocument()) {
+                for (int i = 0; i < document.getNumberOfPages(); i++) {
+                    PDRectangle mediaBox = document.getPage(i).getMediaBox();
+                    BufferedImage image = renderer.renderImageWithDPI(i, 150, ImageType.RGB);
+                    PDPage newPage = new PDPage(mediaBox);
+                    flattened.addPage(newPage);
+                    PDImageXObject xImage = LosslessFactory.createFromImage(flattened, image);
+                    try (PDPageContentStream cs = new PDPageContentStream(flattened, newPage)) {
+                        cs.drawImage(xImage, 0, 0, mediaBox.getWidth(), mediaBox.getHeight());
+                    }
+                }
+                flattened.save(dest);
+            }
         }
     }
 

--- a/backend/src/test/java/com/checkba/service/SensitiveServiceRedactionTest.java
+++ b/backend/src/test/java/com/checkba/service/SensitiveServiceRedactionTest.java
@@ -1,0 +1,74 @@
+package com.checkba.service;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * 锁定脱敏的安全性质：
+ * - PDF：脱敏后为图片型 PDF，底层文字被移除，敏感号码不可再被提取（此前仅画黑框、可复制还原）。
+ * - DOCX：敏感串即使被排版拆到多个 run 也会被脱敏（跨 run 匹配）。
+ */
+class SensitiveServiceRedactionTest {
+
+    @Test
+    void pdfRedactionRemovesExtractableText() throws Exception {
+        File src = File.createTempFile("redact-src-", ".pdf");
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+            try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                cs.beginText();
+                cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                cs.newLineAtOffset(100, 700);
+                cs.showText("Contact 13800001111 today");
+                cs.endText();
+            }
+            doc.save(src);
+        }
+
+        String outPath = new SensitiveService().processFile(src.getAbsolutePath(), List.of("PHONE"));
+
+        try (PDDocument out = Loader.loadPDF(new File(outPath))) {
+            String text = new PDFTextStripper().getText(out);
+            assertFalse(text.contains("13800001111"), "脱敏后敏感号码不应可被提取");
+        }
+    }
+
+    @Test
+    void docxRedactionCatchesCrossRunSensitiveData() throws Exception {
+        File src = File.createTempFile("redact-src-", ".docx");
+        try (XWPFDocument doc = new XWPFDocument()) {
+            XWPFParagraph p = doc.createParagraph();
+            p.createRun().setText("138");        // run 1
+            p.createRun().setText("00001111");   // run 2 → 手机号被拆到两个 run
+            try (FileOutputStream out = new FileOutputStream(src)) {
+                doc.write(out);
+            }
+        }
+
+        String outPath = new SensitiveService().processFile(src.getAbsolutePath(), List.of("PHONE"));
+
+        try (XWPFDocument out = new XWPFDocument(Files.newInputStream(new File(outPath).toPath()))) {
+            String text = out.getParagraphs().stream()
+                    .map(XWPFParagraph::getText)
+                    .collect(Collectors.joining());
+            assertFalse(text.contains("13800001111"), "跨 run 的手机号必须被脱敏");
+        }
+    }
+}


### PR DESCRIPTION
自主代码体检修复系列 **批次 F**（业务逻辑）。

| 项 | 问题 | 修复 |
|---|---|---|
| PDF 脱敏 | 只画黑框、未删底层文字，复制/提取即还原原文 | 画框后逐页栅格化重建 PDF,移除文字层(输出图片型 PDF) |
| DOCX 脱敏 | 敏感串跨 run 时逐 run 匹配漏掉 | 拼接整段文本匹配,命中才回写 |
| DdItem 状态 | 可写入任意字符串 | 校验只接受 PENDING/UPLOADED/APPROVED/REJECTED |
| createProject | 多步写非原子,失败留孤儿项目 | 加 `@Transactional` |

`SensitiveServiceRedactionTest` **直接验证安全性质**:PDF 脱敏后号码不可提取、DOCX 跨 run 手机号被脱敏。

回归 **210/210 全绿**。

注:PDF 脱敏改为图片型输出是安全/可用性权衡(正文不可再选中);如需保留非敏感文字可选中,需后续做内容流级精确删除(更复杂)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)