### PR TITLE
fix(robustness): 工具/记忆作用域+编码 + controller杂项（批次G+H）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ExternalController.java
+++ b/backend/src/main/java/com/checkba/controller/ExternalController.java
@@ -69,6 +69,13 @@ public class ExternalController {
             if (dto == null) {
                 dto = qichachaService.searchCompany(searchKey, request.getRole());
             }
+            // 二次判空：searchCompany 可能返回 null，后续解引用会 NPE→500
+            if (dto == null) {
+                Map<String, String> error = new HashMap<>();
+                error.put("error", "未找到相关企业信息，请检查公司名称是否正确");
+                error.put("message", "查询无结果: " + searchKey);
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+            }
 
             // 如果是股票代码查询且企查查/Tushare返回的 stockCode 为空，则用用户输入的代码兜底
             if (original.matches("\\d{6}") && !StringUtils.hasText(dto.getStockCode())) {

--- a/backend/src/main/java/com/checkba/controller/FileController.java
+++ b/backend/src/main/java/com/checkba/controller/FileController.java
@@ -386,6 +386,11 @@ public class FileController {
         } catch (Exception e) {
             log.error("上传失败", e);
             return ResponseEntity.status(500).body(Map.of("code", -1, "message", e.getMessage()));
+        } finally {
+            // 关闭上传输入流：此前无 finally，multipart/大文件上传每次泄漏一个句柄
+            if (inputStream != null) {
+                try { inputStream.close(); } catch (IOException ignored) {}
+            }
         }
     }
 

--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -147,12 +147,13 @@ public class AiAgentController {
     @PostMapping("/history/rollback")
     public ResponseEntity<?> rollbackHistory(@RequestBody RollbackRequest request,
                                              @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
-        Long userId = null;
-        if (sessionId != null) {
-            userId = AuthController.getUserIdFromSession(sessionId);
+        Long userId = (sessionId != null) ? AuthController.getUserIdFromSession(sessionId) : null;
+        // 归属校验：此前 userId 为 null 也会执行截断（破坏性），且不校验会话归属
+        if (userId == null || !messageService.isConversationOwnedBy(request.getConversationId(), userId)) {
+            return ResponseEntity.status(403).body("{\"status\":\"error\", \"message\":\"无权操作该会话\"}");
         }
         log.info("Rollback request: conv={}, msgId={}, user={}", request.getConversationId(), request.getMessageId(), userId);
-        
+
         try {
             messageService.truncateHistory(request.getConversationId(), request.getMessageId());
             return ResponseEntity.ok().body("{\"status\":\"ok\", \"message\":\"History rolled back\"}");

--- a/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
@@ -111,6 +111,14 @@ public class ProjectAiMessageService {
         return repository.findByConversationIdOrderByCreatedAtAsc(conversationId);
     }
 
+    /** 校验会话是否属于该用户（用于回滚等破坏性操作的越权防护），据首条消息的 userId 判定。 */
+    public boolean isConversationOwnedBy(String conversationId, Long userId) {
+        if (userId == null) return false;
+        return repository.findFirstByConversationId(conversationId)
+                .map(m -> userId.equals(m.getUserId()))
+                .orElse(false);
+    }
+
     public List<java.util.Map<String, Object>> listConversations(Long projectId, Long userId) {
         List<Object[]> results = repository.findConversationSummaries(projectId, userId);
         return results.stream()

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -306,6 +306,9 @@ public class ToolRegistry {
             return new ToolResult("Error executing tool: " + e.getMessage(), tool, true);
         } finally {
             ToolContextHolder.clear();
+            // 同时清理 ProjectContextHolder：装填时设置了它（见上），此前只清 ToolContextHolder，
+            // 池化回调线程复用会残留上个会话的 projectId/userId，导致记忆作用域串号。
+            ProjectContextHolder.clear();
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/context/FileContentExtractorService.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/FileContentExtractorService.java
@@ -58,7 +58,16 @@ public class FileContentExtractorService {
         String fileName = file.getName();
         try {
             if (isTextFile(fileName)) {
-                return Files.readString(file.toPath());
+                byte[] bytes = Files.readAllBytes(file.toPath());
+                try {
+                    return java.nio.charset.StandardCharsets.UTF_8.newDecoder()
+                            .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                            .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+                            .decode(java.nio.ByteBuffer.wrap(bytes)).toString();
+                } catch (java.nio.charset.CharacterCodingException ce) {
+                    // 非 UTF-8（常见 GBK/GB18030 中文 txt/csv）回退，避免整篇内容丢失
+                    return new String(bytes, java.nio.charset.Charset.forName("GBK"));
+                }
             } else {
                 // Non-text files: skip or hint to use OCR
                 return "";

--- a/backend/src/main/java/com/checkba/service/ai/context/FileContextLoader.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/FileContextLoader.java
@@ -112,7 +112,11 @@ public class FileContextLoader {
                 try {
                     byte[] fileBytes = projectFileService.getFileBytes(file.getId());
                     if (fileBytes != null && fileBytes.length > 0) {
-                        tempP = Files.createTempFile("folder_scan_" + file.getId(), ".tmp");
+                        // 保留真实扩展名：extractText 依据扩展名判断是否文本文件，
+                        // 用死的 ".tmp" 会让文件夹内所有 .txt/.md/.docx 正文被判为非文本而丢弃。
+                        String nm = file.getName();
+                        String ext = (nm != null && nm.contains(".")) ? nm.substring(nm.lastIndexOf('.')) : ".txt";
+                        tempP = Files.createTempFile("folder_scan_" + file.getId(), ext);
                         Files.write(tempP, fileBytes);
                         String extracted = fileContentExtractorService.extractText(tempP.toFile());
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -61,6 +61,9 @@ public class FileTools implements AgentToolComponent {
             @P("Optional: Sub-directory to search in (e.g. 'backend/src'). Default is root.") String dirPath
     ) {
         log.info("Tool: search_project_files called pattern='{}', dir='{}'", fileNamePattern, dirPath);
+        if (fileNamePattern == null || fileNamePattern.isBlank()) {
+            return "Error: fileNamePattern is required.";
+        }
         List<String> matches = new ArrayList<>();
         
         Path root = getProjectRoot();
@@ -217,6 +220,9 @@ public class FileTools implements AgentToolComponent {
             @P("项目ID") Long projectId
     ) {
         log.info("Tool: write_docx called for {}", fileName);
+        if (fileName == null || fileName.isBlank()) {
+            return "Error: fileName is required.";
+        }
         if (!fileName.endsWith(".docx")) fileName += ".docx";
         
         // Block suspicious filenames that suggest revision

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -120,6 +120,9 @@ default_api = _ToolAPI()
     @ToolMeta(displayName = "执行Python代码", category = "python")
     @Tool("Run Python script. Use this for data analysis, Tushare stock data, or Qichacha API. You can call default_api.read_document(fileId='...') to read project files. Returns stdout/stderr.")
     public String run_python(String code) {
+        if (code == null || code.isBlank()) {
+            return "Error: code is required.";
+        }
         log.info("Tool: run_python called. Code length={}", code.length());
         
         // Debug: Log API key status (masked for security)

--- a/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
@@ -138,6 +138,9 @@ public class WebTools implements AgentToolComponent {
     @Tool("Browse a specific URL and extract its main content.")
     public String browse_url(String url) {
         log.info("Tool: browse_url called for url='{}'", url);
+        if (url == null || url.isBlank()) {
+            return "Error: url is required.";
+        }
         // Ensure URL has protocol
         if (!url.startsWith("http://") && !url.startsWith("https://")) {
             url = "https://" + url;


### PR DESCRIPTION
自主代码体检修复系列 **批次 G+H**（收尾：工具/记忆层 + controller 杂项健壮性）。

## G — 工具/记忆/上下文层
| 项 | 问题 | 修复 |
|---|---|---|
| ToolRegistry | finally 漏清 ProjectContextHolder → 记忆作用域串号(A用户→B、A项目→B) | 补 `ProjectContextHolder.clear()` |
| FileContextLoader | 临时文件固定 `.tmp` → 文件夹内文本内容全被丢弃 | 保留真实扩展名 |
| FileContentExtractor | UTF-8 严格解码 → GBK 中文文件整篇丢失 | 失败回退 GBK |
| 工具空参 | null 参数抛 NPE 被吞成 "Error: null" | search/write_docx/run_python/browse_url 前置判空返回明确错误 |

## H — controller 杂项
| 项 | 问题 | 修复 |
|---|---|---|
| ExternalController | searchCompany 返回 null → NPE 500 | 二次判空返回 404 |
| FileController.uploadFile | InputStream 从不关闭 → 句柄泄漏 | 加 finally 关闭 |
| AiAgentController.rollbackHistory | userId 为 null 也截断、不校验归属 | `isConversationOwnedBy` 校验,非归属 403 |

回归 **210/210 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)