### PR TITLE
fix(cleanup): 遗留项清理——N+1/OCR超时/Tag归属/ASK禁工具

### DIFF
--- a/backend/src/main/java/com/checkba/controller/TagController.java
+++ b/backend/src/main/java/com/checkba/controller/TagController.java
@@ -61,7 +61,7 @@ public class TagController {
             @RequestBody UpdateTagRequest request,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireMember(sessionId, projectId);
-        return tagService.updateTag(tagId, request.getName(), request.getColor(), request.getDescription());
+        return tagService.updateTag(projectId, tagId, request.getName(), request.getColor(), request.getDescription());
     }
 
     /**
@@ -73,7 +73,7 @@ public class TagController {
             @PathVariable Long tagId,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireMember(sessionId, projectId);
-        tagService.deleteTag(tagId);
+        tagService.deleteTag(projectId, tagId);
     }
 
     @Data

--- a/backend/src/main/java/com/checkba/service/DdService.java
+++ b/backend/src/main/java/com/checkba/service/DdService.java
@@ -379,27 +379,29 @@ public class DdService {
     public void deleteItem(Long itemId, Long userId) {
         DdItem item = ddItemRepository.findById(itemId).orElse(null);
         if (item == null) return;
-        
-        // Handle Children first (Recursion)
-        List<DdItem> children = ddItemRepository.findByDdRequestIdOrderBySortOrderAsc(item.getDdRequestId())
-                .stream().filter(i -> itemId.equals(i.getParentId())).collect(Collectors.toList());
-        for (DdItem child : children) {
-            deleteItem(child.getId(), userId);
+        // 一次性载入该请求全部项，构建 parentId→children 映射，避免逐节点全表查询（此前 O(N²)）
+        java.util.Map<Long, List<DdItem>> childrenByParent = ddItemRepository
+                .findByDdRequestIdOrderBySortOrderAsc(item.getDdRequestId())
+                .stream().filter(i -> i.getParentId() != null)
+                .collect(Collectors.groupingBy(DdItem::getParentId));
+        deleteItemCascade(item, childrenByParent, userId);
+    }
+
+    private void deleteItemCascade(DdItem item, java.util.Map<Long, List<DdItem>> childrenByParent, Long userId) {
+        // 先递归删子项
+        for (DdItem child : childrenByParent.getOrDefault(item.getId(), java.util.List.of())) {
+            deleteItemCascade(child, childrenByParent, userId);
         }
-        
-        // Handle File linked to this item
+        // 关联文件
         if (item.getUploadedFileId() != null) {
             verifyAndSafeDeleteFile(item, userId);
         }
-        
-        // Handle the Folder for this item
+        // 该项对应的文件夹
         verifyAndSafeDeleteFolder(item, userId);
-
-        // Delete Comments
-        List<DdComment> comments = ddCommentRepository.findByDdItemIdOrderByCreatedAtAsc(itemId);
+        // 评论
+        List<DdComment> comments = ddCommentRepository.findByDdItemIdOrderByCreatedAtAsc(item.getId());
         ddCommentRepository.deleteAll(comments);
-
-        // Delete Item
+        // DB 记录
         ddItemRepository.delete(item);
     }
     

--- a/backend/src/main/java/com/checkba/service/TagService.java
+++ b/backend/src/main/java/com/checkba/service/TagService.java
@@ -66,10 +66,14 @@ public class TagService {
      * 更新标签
      */
     @Transactional
-    public Tag updateTag(Long tagId, String name, String color, String description) {
+    public Tag updateTag(Long projectId, Long tagId, String name, String color, String description) {
         Tag tag = tagRepository.findById(tagId)
                 .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
-        
+        // 归属校验：tagId 必须属于该 projectId，防止本项目成员改动其它项目的标签
+        if (!tag.getProjectId().equals(projectId)) {
+            throw new IllegalArgumentException("标签不属于该项目");
+        }
+
         // check duplicate name if name changed
         if (!tag.getName().equals(name)) {
              if (tagRepository.existsByProjectIdAndName(tag.getProjectId(), name)) {
@@ -89,7 +93,12 @@ public class TagService {
      * 删除标签
      */
     @Transactional
-    public void deleteTag(Long tagId) {
+    public void deleteTag(Long projectId, Long tagId) {
+        Tag tag = tagRepository.findById(tagId).orElse(null);
+        if (tag == null) return;
+        if (!tag.getProjectId().equals(projectId)) {
+            throw new IllegalArgumentException("标签不属于该项目");
+        }
         tagRepository.deleteById(tagId);
         // Note: Foreign key constraints in FileTag/DB should handle cascade or we should delete manually in FileTagService
         // Ideally we should delete relations in FileTagRepository first? 

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -357,7 +357,7 @@ public class AgentOrchestrator {
             // 2. Check for XML Tool Requests (Fallback for Root Bubble Protocol)
             // Pattern: <tool_code>legal_tools.method(args)</tool_code> OR <code>...</code>
             // We need to parse this manually because we forced XML output in System Prompt.
-            if (xmlToolCallParser.containsToolCall(content)) {
+            if (agentMode != AgentMode.ASK && xmlToolCallParser.containsToolCall(content)) {
                 log.info("Detected XML Tool Code in content. Parsing...");
 
                 // 提取LLM选择的process name，用于历史记录保存时保持一致性

--- a/backend/src/main/java/com/checkba/service/ocr/AliyunOcrClient.java
+++ b/backend/src/main/java/com/checkba/service/ocr/AliyunOcrClient.java
@@ -41,6 +41,9 @@ public class AliyunOcrClient {
                 .setType("Advanced"); // 通用文字识别高精版
 
         RuntimeOptions runtime = new RuntimeOptions();
+        // 显式超时：此前无超时，网络卡死会无限期挂起并占用请求线程
+        runtime.setConnectTimeout(10000);
+        runtime.setReadTimeout(30000);
         RecognizeAllTextResponse resp = client.recognizeAllTextWithOptions(req, runtime);
 
         if (resp == null || resp.getBody() == null || resp.getBody().getData() == null) {


### PR DESCRIPTION
自主代码体检 **遗留项清理**。

| 项 | 问题 | 修复 |
|---|---|---|
| DdService.deleteItem | 递归删每节点全表加载(O(N²)) | 一次性载入建 parentId→children 映射 |
| AliyunOcrClient | RecognizeAllText 无超时 | 加 connect/read 超时 |
| TagService update/delete | tagId 未强制归属 projectId(次要越权面) | 加归属校验,控制器传 projectId |
| AgentOrchestrator ASK 模式 | 正文 `<tool_code>` 兜底仍执行工具,违反只读意图 | 加 `agentMode != ASK` 守卫 |

**未做(已评估)**:变量库 `@Version` 乐观锁——`ddl-auto=update` 下加列会让存量行 version 为 null、破坏现有(含桌面捆绑库)用户升级,需专门迁移方案,不宜随手加。

回归 **210/210 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)