### PR TITLE
fix(desktop): 桌面端健壮性（孤儿进程/日志/并发/浏览器scheme/启动兜底）

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -667,7 +667,8 @@ function ensureView(id) {
   view.webContents.on('will-navigate', (event, url) => {
     if (!/^https?:\/\//i.test(url)) {
       event.preventDefault()
-      shell.openExternal(url)
+      // 只把 mailto 交给系统；file://、自定义/危险 scheme 一律阻止，不无条件 openExternal
+      if (/^mailto:/i.test(url)) shell.openExternal(url)
     }
   })
 
@@ -801,10 +802,17 @@ function setAllViewsVisible(visible) {
 
 ipcMain.handle('checkba:browser-create', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : `web_${Date.now()}`
-  const url = payload && payload.url ? String(payload.url) : 'about:blank'
+  let url = payload && payload.url ? String(payload.url) : 'about:blank'
+  // 仅允许 http(s)/about，禁止 file:// 等本地 scheme 经内嵌浏览器读取本地文件后回读
+  if (!/^(https?:|about:)/i.test(url)) url = 'about:blank'
   ensureView(id)
   attachView(id)
-  await views.get(id).webContents.loadURL(url)
+  try {
+    await views.get(id).webContents.loadURL(url)
+  } catch (e) {
+    // 避免 loadURL 的 ERR_ABORTED 等成为未处理 rejection（与 navigate 行为一致）
+    return { id, ok: false, code: e && e.code ? String(e.code) : '', message: e && e.message ? String(e.message) : String(e) }
+  }
   return { id }
 })
 
@@ -812,6 +820,7 @@ ipcMain.handle('checkba:browser-navigate', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : null
   const url = payload && payload.url ? String(payload.url) : null
   if (!id || !url) return { ok: false }
+  if (!/^(https?:|about:)/i.test(url)) return { ok: false, message: 'blocked scheme' }
   const view = views.get(id)
   if (!view) return { ok: false }
   try {
@@ -1304,6 +1313,14 @@ app.whenReady().then(() => {
         console.error('[pptx-service]', p.error || 'failed to start')
       }
     })
+    .catch((err) => {
+      // 端口分配/启动链失败也要建出主窗口并提示，避免 app 起来却无窗口无提示（静默失败）
+      console.error('[startup] service init failed', err)
+      try { createMainWindow() } catch (e) { /* ignore */ }
+      try {
+        if (mainWindow) mainWindow.webContents.send('checkba:backend-status', { ok: false, message: String(err && err.message ? err.message : err) })
+      } catch (e) { /* ignore */ }
+    })
 })
 
 app.on('window-all-closed', () => {
@@ -1319,6 +1336,8 @@ app.on('before-quit', async (e) => {
   if (services) {
     try {
       e.preventDefault()
+      // 先终止进行中的模型下载子进程，否则退出时它们会变孤儿继续占用资源
+      if (modelManager) modelManager.killAllActive()
       await services.stopAll()
     } catch (err) {
       // ignore

--- a/desktop/main/services/model-manager.js
+++ b/desktop/main/services/model-manager.js
@@ -212,6 +212,14 @@ class ModelManager {
     })
   }
 
+  /** 退出时批量终止所有进行中的下载子进程，防止孤儿 Python 进程继续占用 CPU/带宽/磁盘。 */
+  killAllActive() {
+    for (const [, child] of this.active) {
+      try { child._awdCancelled = true; child.kill('SIGTERM') } catch (e) { /* ignore */ }
+    }
+    this.active.clear()
+  }
+
   async remove(id) {
     if (this.active.has(id)) await this.cancel(id)
     fs.rmSync(this.dirOf(id), { recursive: true, force: true })

--- a/desktop/main/services/service-manager.js
+++ b/desktop/main/services/service-manager.js
@@ -59,6 +59,8 @@ class ServiceManager {
     this.ports = this.ctx.ports
     this.descriptors = new Map()
     this.procs = new Map()
+    this.starting = new Map() // name -> in-flight start promise（并发去重，防重复 spawn）
+    this.logStreams = new Map() // name -> 日志写入流（跟踪以便关闭，防 fd 泄漏）
   }
 
   register(descriptor) {
@@ -80,6 +82,15 @@ class ServiceManager {
   }
 
   async start(name) {
+    // 并发去重：同名服务的并发 start 复用同一 in-flight promise，防止重复 spawn 产生孤儿进程、抢同一端口
+    const inflight = this.starting.get(name)
+    if (inflight) return inflight
+    const p = this._start(name).finally(() => this.starting.delete(name))
+    this.starting.set(name, p)
+    return p
+  }
+
+  async _start(name) {
     const d = this.descriptors.get(name)
     if (!d) throw new Error(`unknown service: ${name}`)
     if (d.enabled && !d.enabled(this.ctx)) return { ok: false, disabled: true }
@@ -93,7 +104,11 @@ class ServiceManager {
     if (this.procs.get(name)) await this.stop(name)
 
     const timeoutMs = d.startTimeoutMs(this.ctx)
+    // 关闭上一次 start 遗留的日志流，避免每次重启/崩溃-重启累积文件描述符泄漏
+    const prevStream = this.logStreams.get(name)
+    if (prevStream) { try { prevStream.end() } catch (e) { /* ignore */ } this.logStreams.delete(name) }
     const logStream = this.logStreamFor(d)
+    if (logStream) this.logStreams.set(name, logStream)
     const candidates = [...d.commands(this.ctx)]
     let triedFallback = false
 
@@ -197,6 +212,9 @@ class ServiceManager {
       // eslint-disable-next-line no-await-in-loop
       await this.stop(name)
     }
+    // 退出/全停时关闭所有日志流，释放 fd
+    for (const [, s] of this.logStreams) { try { s.end() } catch (e) { /* ignore */ } }
+    this.logStreams.clear()
     return { ok: true }
   }
 

--- a/desktop/main/zetaoffice-server.js
+++ b/desktop/main/zetaoffice-server.js
@@ -103,7 +103,7 @@ function startEditorServer() {
           const rel = urlPath.slice('/lowa/'.length)
           const lowaDir = path.join(root, 'lowa')
           const localPath = path.normalize(path.join(lowaDir, rel))
-          if (localPath.startsWith(lowaDir)) {
+          if (localPath === lowaDir || localPath.startsWith(lowaDir + path.sep)) {
             try {
               const st = await stat(localPath)
               if (st.isFile()) {
@@ -124,7 +124,7 @@ function startEditorServer() {
         }
         if (urlPath === '/') urlPath = '/editor.html'
         const filePath = path.normalize(path.join(root, urlPath))
-        if (!filePath.startsWith(root)) { res.writeHead(403).end('forbidden'); return }
+        if (filePath !== root && !filePath.startsWith(root + path.sep)) { res.writeHead(403).end('forbidden'); return }
         // No COOP/COEP here — Electron injects them on the partition.
         const body = await readFile(filePath)
         res.writeHead(200, { 'Content-Type': TYPES[path.extname(filePath)] || 'application/octet-stream' })


### PR DESCRIPTION
自主代码体检 **桌面端** 修复（来自 Electron 主进程审查）。

| # | 严重度 | 问题 | 修复 |
|---|---|---|---|
| 1 | 高 | 退出不 kill 模型下载子进程 → 孤儿 Python(占~3GB下载) | `ModelManager.killAllActive()` + before-quit 调用 |
| 3 | 中 | `start()` 无重入锁 → 并发重复 spawn/抢端口/孤儿 | in-flight promise 复用 |
| 4 | 中 | 日志流每次 start 新建从不 close → fd 泄漏 | 新 start 关旧流 + stopAll 关全部 |
| 6 | 中(安全) | will-navigate 对任意 scheme `openExternal` | 只放行 mailto,阻止 file://等 |
| 7 | 中(安全) | 内嵌浏览器可 `loadURL('file://')`+getSnapshot 读本地文件 | http(s)/about scheme 白名单 |
| 8 | 中 | whenReady 链无 `.catch` → 端口失败静默无窗口 | 兜底建窗+提示 |
| 9 | 中低 | browser-create loadURL 无 try/catch | 加 try/catch |
| 10 | 低 | 路径前缀 `startsWith(dir)` 误匹配兄弟目录 | 补 `path.sep` |

**未改(记录)**：`fs:readFile/writeFile` 任意路径 IPC 是文件拖入功能的有意能力,confinement 会破坏功能,需配合 `webSecurity` 收紧或路径来源校验单独处理。崩溃后自动重启/UI 上报(#2)属功能增强,单列。

回归：desktop **10/10 全绿**,主进程语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)