### PR TITLE
fix(frontend): 生命周期/SSE健壮性/会话竞态/还原失效

### DIFF
--- a/frontend/src/components/DocDiffViewer.vue
+++ b/frontend/src/components/DocDiffViewer.vue
@@ -183,13 +183,13 @@ export default {
           wordWrap: 'on'
         })
         
-        // 设置模型
-        const originalModel = monaco.editor.createModel(this.sourceText, 'plaintext')
-        const modifiedModel = monaco.editor.createModel(this.targetText, 'plaintext')
-        
+        // 设置模型（存到 this 以便 dispose，否则反复开合对比会累积泄漏 Monaco text model）
+        this._originalModel = monaco.editor.createModel(this.sourceText, 'plaintext')
+        this._modifiedModel = monaco.editor.createModel(this.targetText, 'plaintext')
+
         this.diffEditor.setModel({
-          original: originalModel,
-          modified: modifiedModel
+          original: this._originalModel,
+          modified: this._modifiedModel
         })
         
         // 计算差异数量
@@ -280,6 +280,8 @@ export default {
         this.diffEditor.dispose()
         this.diffEditor = null
       }
+      if (this._originalModel) { this._originalModel.dispose(); this._originalModel = null }
+      if (this._modifiedModel) { this._modifiedModel.dispose(); this._modifiedModel = null }
     },
     // #endif
     

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -1150,12 +1150,16 @@ export default {
     this.refreshProjectTags() // Tag Management
 
     // Listen for global drag events to show/hide root drop zone
-    uni.$on('file-drag-start', () => { this.isAnyDragging = true })
-    uni.$on('file-drag-end', () => { this.isAnyDragging = false })
+    // 具名 handler + Vue3 的 beforeUnmount（beforeDestroy 在 Vue3 不触发，导致监听泄漏）；
+    // $off 必须带 handler，否则会连带移除其它 FileTree 实例（FileStagingArea 内嵌）的同名监听。
+    this._onDragStart = () => { this.isAnyDragging = true }
+    this._onDragEnd = () => { this.isAnyDragging = false }
+    uni.$on('file-drag-start', this._onDragStart)
+    uni.$on('file-drag-end', this._onDragEnd)
   },
-  beforeDestroy() {
-    uni.$off('file-drag-start')
-    uni.$off('file-drag-end')
+  beforeUnmount() {
+    uni.$off('file-drag-start', this._onDragStart)
+    uni.$off('file-drag-end', this._onDragEnd)
   },
   methods: {
     // 让文件树容器可聚焦，接收键盘事件（H5）
@@ -2037,26 +2041,6 @@ export default {
         console.error('批量操作失败:', e)
         uni.showToast({ title: e.message || '批量操作失败', icon: 'none' })
       }
-    },
-    restoreFile(item) {
-      const itemsToRestore = []
-      if (item.isFolder) {
-         // Find descendants in recycle bin
-         const descendantIds = this.getDescendantIds(item.id, true)
-         this.recycleBin.forEach(f => {
-            if (descendantIds.includes(f.id)) {
-               itemsToRestore.push(f.id)
-            }
-         })
-      } else {
-         itemsToRestore.push(item.id)
-      }
-
-      // Filter out restored items
-      const restoreSet = new Set(itemsToRestore)
-      this.recycleBin = this.recycleBin.filter(f => !restoreSet.has(f.id))
-
-      uni.showToast({ title: '已恢复', icon: 'success' })
     },
     handleDownload(item) {
         if (!item || item.isFolder) return

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -247,12 +247,16 @@ export function useAgentStream() {
                 } : null
             }
 
-            await fetch(`${getApiBaseUrl()}/api/agent/chat`, {
+            const chatResp = await fetch(`${getApiBaseUrl()}/api/agent/chat`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'X-Session-Id': getSessionId() || '' },
                 body: JSON.stringify(payload),
                 signal: messageAbortController.signal
             })
+            // fetch 对 4xx/5xx 不 reject，需显式校验，否则会话过期/后端错误时加载态永久卡死
+            if (!chatResp.ok) {
+                throw new Error(`对话请求失败: HTTP ${chatResp.status}`)
+            }
 
         } catch (err) {
             if (err.name !== 'AbortError') {
@@ -363,8 +367,13 @@ export function useAgentStream() {
                 console.error('Failed to parse subtask_progress', e)
             }
         } else if (evt === 'artifact') {
-            const d = JSON.parse(dataStr)
-            handleArtifactEvent(d)
+            try {
+                const d = JSON.parse(dataStr)
+                handleArtifactEvent(d)
+            } catch (e) {
+                // 单个 artifact 事件解析失败不应打断整条 SSE 流（否则气泡卡加载、后续事件全丢）
+                console.error('Failed to parse artifact event', e)
+            }
         } else if (evt === 'client_action') {
             try {
                 const d = JSON.parse(dataStr)

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -6256,6 +6256,8 @@ export default {
                 projectId: this.projectId,
                 conversationId: chat.conversationId
             })
+            // 竞态防护：快速切换会话时，丢弃已不是当前选中会话的旧响应，避免旧数据覆盖新会话
+            if (this.currentConversationId !== chat.conversationId) return
             // Pass conversationId and messages to ChatInterface via $refs
             if (this.$refs.chatInterface && typeof this.$refs.chatInterface.loadMessages === 'function') {
                 this.$refs.chatInterface.loadMessages(chat.conversationId, msgs)


### PR DESCRIPTION
自主代码体检 **前端工作台** 修复。

| # | 严重度 | 问题 | 修复 |
|---|---|---|---|
| 1 | 高 | FileTree `beforeDestroy` 在 Vue3 不触发 → 拖拽事件监听泄漏累积 | 具名 handler + `beforeUnmount` + 带 handler 的 `$off` |
| 2 | 高 | FileTree `restoreFile` 重复定义,坏版本(只改本地不调后端)生效 → 回收站还原假成功 | 删坏的重复定义 |
| 3 | 中 | useAgentStream `artifact` JSON.parse 无 try/catch → 打断整条 SSE 流 | 加 try/catch |
| 4 | 中 | chat POST 未校验 `response.ok` → 401/500 时加载态卡死 | 显式校验抛错复位 |
| 5 | 中 | loadHistoryChat 无竞态防护 → 快速切会话旧响应覆盖新的 | await 后校验会话未变 |
| 7 | 低 | DocDiffViewer 两个 Monaco model 未 dispose | 存 this 并 dispose |

未改(记录,低影响):粘贴图片 `URL.createObjectURL` 未 revoke。

回归：frontend H5 **构建通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)