### PR TITLE
fix(round2): 全面审查第二轮——后端盲区 bug 批量修复

### DIFF
--- a/backend/src/main/java/com/checkba/config/DataInitializer.java
+++ b/backend/src/main/java/com/checkba/config/DataInitializer.java
@@ -1,31 +1,29 @@
 package com.checkba.config;
 
-import com.checkba.model.entity.Project;
 import com.checkba.model.entity.User;
-import com.checkba.repository.ProjectRepository;
 import com.checkba.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 数据初始化器
- * 在应用启动时创建默认用户 admin/123，并将所有项目归到该用户下
+ * 在应用启动时创建默认用户 admin（社区版首启默认账号，生产请及时改密）。
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class DataInitializer implements CommandLineRunner {
 
     private final UserRepository userRepository;
-    private final ProjectRepository projectRepository;
 
     @Override
     public void run(String... args) {
-        // 创建或获取默认用户 admin
-        User adminUser = userRepository.findByUsername("admin")
+        // 创建默认用户 admin（若不存在）。不再打印明文口令到日志。
+        userRepository.findByUsername("admin")
                 .orElseGet(() -> {
                     User user = new User();
                     user.setUsername("admin");
@@ -33,31 +31,11 @@ public class DataInitializer implements CommandLineRunner {
                     user.setDisplayName("管理员");
                     user.setCreatedAt(LocalDateTime.now());
                     user.setUpdatedAt(LocalDateTime.now());
+                    log.info("已创建默认用户 admin（请尽快修改默认密码）");
                     return userRepository.save(user);
                 });
-
-        // 将所有项目都归到 admin 用户下（包括没有 userId、userId 为 0、或其他用户的）
-        List<Project> allProjects = projectRepository.findAll();
-        int updatedCount = 0;
-        for (Project project : allProjects) {
-            // 如果项目不属于 admin 用户，或者 userId 为空/0，则归到 admin 下
-            if (project.getUserId() == null || project.getUserId() == 0 || !project.getUserId().equals(adminUser.getId())) {
-                project.setUserId(adminUser.getId());
-                project.setUpdatedAt(LocalDateTime.now());
-                projectRepository.save(project);
-                updatedCount++;
-            }
-        }
-        
-        if (updatedCount > 0) {
-            System.out.println("已将 " + updatedCount + " 个项目归到 admin 用户下");
-        } else if (!allProjects.isEmpty()) {
-            System.out.println("所有项目已属于 admin 用户，共 " + allProjects.size() + " 个项目");
-        } else {
-            System.out.println("数据库中暂无项目");
-        }
-
-        System.out.println("数据初始化完成，默认用户: admin/123 (ID: " + adminUser.getId() + ")");
+        // 注意：此前每次启动会把所有项目强行归到 admin 名下——在多用户场景会"抢走"其他用户的项目，
+        // 与 ProjectMemberService 等多用户能力冲突，已移除该逻辑。
     }
 }
 

--- a/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
@@ -61,7 +61,8 @@ public class GlobalExceptionHandler {
         log.error("GlobalExceptionHandler caught Exception: ", e);
         Map<String, Object> result = new HashMap<>();
         result.put("code", 1);
-        result.put("message", e.getMessage() != null ? e.getMessage() : "服务器内部错误");
+        // 不回显内部异常 message（可能含 SQL/表名/文件路径/SDK 细节等），统一通用文案；详情仅进日志
+        result.put("message", "服务器内部错误");
         // 统一返回 HTTP 200，通过 code 字段表示失败
         return ResponseEntity.ok().body(result);
     }

--- a/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
+++ b/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
@@ -34,7 +34,8 @@ public class BrowserProxyController {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BrowserProxyController.class);
 
     private static final HttpClient CLIENT = HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NORMAL)
+            // NEVER：不自动跟随重定向，改为手动逐跳做 SSRF 校验，防止允许的外站 302 到内网/元数据端点
+            .followRedirects(HttpClient.Redirect.NEVER)
             .connectTimeout(Duration.ofSeconds(10))
             .build();
 
@@ -52,15 +53,34 @@ public class BrowserProxyController {
 
         try {
             URI uri = URI.create(u);
-            if (isBlockedTarget(uri)) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("目标地址不被允许（已禁止本地/内网地址）");
+            HttpResponse<byte[]> resp = null;
+            // 手动跟随重定向，每一跳都重新做 scheme 白名单 + SSRF 校验，避免自动跳转绕过 isBlockedTarget
+            for (int hop = 0; hop < 5; hop++) {
+                String scheme = uri.getScheme();
+                if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+                    return ResponseEntity.status(HttpStatus.FORBIDDEN).body("仅支持 http/https");
+                }
+                if (isBlockedTarget(uri)) {
+                    return ResponseEntity.status(HttpStatus.FORBIDDEN).body("目标地址不被允许（已禁止本地/内网地址）");
+                }
+                HttpRequest req = HttpRequest.newBuilder(uri)
+                        .GET()
+                        .timeout(Duration.ofSeconds(20))
+                        .header("User-Agent", "checkba-browser/1.0")
+                        .build();
+                resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofByteArray());
+                int sc = resp.statusCode();
+                if (sc >= 300 && sc < 400) {
+                    String loc = resp.headers().firstValue("location").orElse(null);
+                    if (loc == null || loc.isBlank()) break;
+                    uri = uri.resolve(loc); // 支持相对 Location，下一轮重新校验
+                    continue;
+                }
+                break;
             }
-            HttpRequest req = HttpRequest.newBuilder(uri)
-                    .GET()
-                    .timeout(Duration.ofSeconds(20))
-                    .header("User-Agent", "checkba-browser/1.0")
-                    .build();
-            HttpResponse<byte[]> resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            if (resp == null) {
+                return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("代理失败: 无响应");
+            }
 
             String contentType = resp.headers().firstValue("content-type").orElse("application/octet-stream");
             // 只对 HTML 注入脚本，其它资源原样返回（图片/CSS/JS 等）

--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -50,7 +50,8 @@ public class WizardController {
     }
 
     @PostMapping
-    public ResponseEntity<?> initialize(@RequestBody AdminConfigUpdateRequest request) {
+    public synchronized ResponseEntity<?> initialize(@RequestBody AdminConfigUpdateRequest request) {
+        // synchronized：串行化初始化，堵住两个并发匿名 POST 同时通过 isInitialized()==false 的 TOCTOU 竞态
         if (isInitialized()) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(error("系统已初始化，请通过管理后台修改配置 / Already initialized; use the admin console instead"));

--- a/backend/src/main/java/com/checkba/repository/ClipboardItemRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ClipboardItemRepository.java
@@ -12,7 +12,7 @@ public interface ClipboardItemRepository extends JpaRepository<ClipboardItem, Lo
 
     List<ClipboardItem> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
-    @Query("select c from ClipboardItem c where c.userId = :userId and (c.text like %:q% or c.meta like %:q%) order by c.createdAt desc")
+    @Query("select c from ClipboardItem c where c.userId = :userId and (c.text like concat('%', :q, '%') or c.meta like concat('%', :q, '%')) order by c.createdAt desc")
     List<ClipboardItem> search(@Param("userId") Long userId, @Param("q") String q, Pageable pageable);
 }
 

--- a/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
@@ -70,6 +70,8 @@ public interface MemoryEntryRepository extends JpaRepository<MemoryEntry, Long> 
     /**
      * 删除过期的记忆
      */
+    @org.springframework.transaction.annotation.Transactional
+    @org.springframework.data.jpa.repository.Modifying
     @Query("DELETE FROM MemoryEntry m WHERE m.expiresAt IS NOT NULL AND m.expiresAt < :now AND m.isProtected = false")
     void deleteExpiredMemories(@Param("now") LocalDateTime now);
 

--- a/backend/src/main/java/com/checkba/service/ClipboardService.java
+++ b/backend/src/main/java/com/checkba/service/ClipboardService.java
@@ -54,8 +54,10 @@ public class ClipboardService {
         // 存储路径：clipboard/{userId}/{uuid}
         String storagePath = "clipboard/" + userId + "/" + uuid;
         
-        // 保存文件到存储服务
-        getStorageService().save(storagePath, file.getInputStream());
+        // 保存文件到存储服务（try-with-resources 关闭上传源流，防句柄泄漏）
+        try (java.io.InputStream in = file.getInputStream()) {
+            getStorageService().save(storagePath, in);
+        }
 
         // 构建元数据 JSON
         String originalFilename = file.getOriginalFilename();

--- a/backend/src/main/java/com/checkba/service/ContentSearchService.java
+++ b/backend/src/main/java/com/checkba/service/ContentSearchService.java
@@ -280,25 +280,16 @@ public class ContentSearchService {
                     int start = matcher.start();
                     int end = matcher.end();
 
-                    // 提取上下文
-                    String context = extractContext(line, start, end);
-
-                    // 计算在 context 中的相对位置
-                    int contextStart = Math.max(0, start - MAX_CONTEXT_CHARS / 2);
-                    int relativeStart = start - contextStart;
-                    int relativeEnd = relativeStart + (end - start);
-
-                    // 如果 context 有前缀 "..."，需要调整偏移
-                    if (contextStart > 0) {
-                        relativeStart += 3; // "..." 的长度
-                        relativeEnd += 3;
-                    }
+                    // 提取上下文并同步得到匹配在其中的相对位置：
+                    // 此前调用方自行按 (start-50 + "...") 推算偏移，与 extractContext 实际的 trim/短行整行/省略号
+                    // 处理不一致，短行或行首有缩进时高亮错位。改由 extractContext 一并返回对齐后的偏移。
+                    MatchContext ctx = extractContext(line, start, end);
 
                     matches.add(MatchInfo.builder()
                         .lineNumber(lineNumber)
-                        .content(context)
-                        .startIndex(relativeStart)
-                        .endIndex(relativeEnd)
+                        .content(ctx.content())
+                        .startIndex(ctx.start())
+                        .endIndex(ctx.end())
                         .build());
 
                     if (matches.size() >= MAX_MATCHES_PER_FILE * 2) {
@@ -354,27 +345,47 @@ public class ContentSearchService {
         public String toString() { return inner.toString(); }
     }
 
+    /** 上下文片段 + 匹配在该片段中的相对起止（已对齐 trim/省略号）。 */
+    private record MatchContext(String content, int start, int end) {}
+
     /**
-     * 提取匹配上下文
+     * 提取匹配上下文，并返回匹配在上下文中的相对起止位置（供前端高亮，与 content 严格对齐）。
      */
-    private String extractContext(String line, int matchStart, int matchEnd) {
+    private MatchContext extractContext(String line, int matchStart, int matchEnd) {
         if (line.length() <= MAX_CONTEXT_CHARS) {
-            return line.trim();
+            // 整行返回，但 trim 会移除前导空白，匹配位置需相应左移
+            int leading = line.length() - line.stripLeading().length();
+            String content = line.trim();
+            int s = clamp(matchStart - leading, 0, content.length());
+            int e = clamp(matchEnd - leading, s, content.length());
+            return new MatchContext(content, s, e);
         }
-        
+
         int contextStart = Math.max(0, matchStart - MAX_CONTEXT_CHARS / 2);
         int contextEnd = Math.min(line.length(), matchEnd + MAX_CONTEXT_CHARS / 2);
-        
-        String context = line.substring(contextStart, contextEnd).trim();
-        
+        String raw = line.substring(contextStart, contextEnd);
+
+        int relStart = matchStart - contextStart;
+        int relEnd = matchEnd - contextStart;
+        // 处理左侧 trim（stripLeading）造成的偏移
+        int leadingTrim = raw.length() - raw.stripLeading().length();
+        String content = raw.trim();
+        relStart = clamp(relStart - leadingTrim, 0, content.length());
+        relEnd = clamp(relEnd - leadingTrim, relStart, content.length());
+
+        int prefixLen = 0;
         if (contextStart > 0) {
-            context = "..." + context;
+            content = "..." + content;
+            prefixLen = 3;
         }
         if (contextEnd < line.length()) {
-            context = context + "...";
+            content = content + "...";
         }
-        
-        return context;
+        return new MatchContext(content, relStart + prefixLen, relEnd + prefixLen);
+    }
+
+    private static int clamp(int v, int lo, int hi) {
+        return Math.max(lo, Math.min(hi, v));
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/DocFileLinkService.java
+++ b/backend/src/main/java/com/checkba/service/DocFileLinkService.java
@@ -56,6 +56,16 @@ public class DocFileLinkService {
         if (!StringUtils.hasText(docWpsFileId)) throw new IllegalArgumentException("docWpsFileId 不能为空");
         if (fileIds == null || fileIds.isEmpty()) throw new IllegalArgumentException("fileIds 不能为空");
 
+        // 归属校验：只接受属于本项目的 fileId，防止把他人项目文件 ID 存入链接后经 getByKey
+        // 读回其文件名/存储路径/wpsFileId 等元数据（IDOR）
+        for (Long fid : fileIds) {
+            if (fid == null) continue;
+            ProjectFile pf = projectFileRepository.findById(fid).orElse(null);
+            if (pf == null || !projectId.equals(pf.getProjectId())) {
+                throw new IllegalArgumentException("文件不属于该项目: " + fid);
+            }
+        }
+
         String key = StringUtils.hasText(linkKey) ? linkKey.trim() : ("lk_" + UUID.randomUUID());
         DocFileLink link = docFileLinkRepository.findByProjectIdAndLinkKey(projectId, key).orElse(null);
         if (link == null) {

--- a/backend/src/main/java/com/checkba/service/ai/GeminiCacheService.java
+++ b/backend/src/main/java/com/checkba/service/ai/GeminiCacheService.java
@@ -26,8 +26,13 @@ public class GeminiCacheService {
 
     private final AiModelProperties aiModelProperties;
 
-    // Cache for Gemini Cache IDs: Map<ContentHash, CacheName>
-    private final Map<String, String> activeGeminiCaches = new ConcurrentHashMap<>();
+    // Cache for Gemini Cache IDs: Map<ContentHash, (CacheName, createdAt)>
+    private final Map<String, CachedEntry> activeGeminiCaches = new ConcurrentHashMap<>();
+
+    // Gemini cachedContent 默认 1 小时过期，留 5 分钟余量后即视为失效重建，避免返回已过期的 cacheName 导致下游 404
+    private static final long CACHE_TTL_MS = 55 * 60 * 1000L;
+
+    private record CachedEntry(String cacheName, long createdAt) {}
 
     public GeminiCacheService(AiModelProperties aiModelProperties) {
         this.aiModelProperties = aiModelProperties;
@@ -36,9 +41,9 @@ public class GeminiCacheService {
     public String getOrCreateGeminiCache(String content) {
         // Simple hash content to key
         String hash = cn.hutool.crypto.digest.DigestUtil.md5Hex(content);
-        if (activeGeminiCaches.containsKey(hash)) {
-            // Validate validity? For now assume valid until TTL (default 1h). We can store timestamp.
-            return activeGeminiCaches.get(hash);
+        CachedEntry cached = activeGeminiCaches.get(hash);
+        if (cached != null && (System.currentTimeMillis() - cached.createdAt()) < CACHE_TTL_MS) {
+            return cached.cacheName();
         }
 
         // Create Cache via REST
@@ -69,7 +74,7 @@ public class GeminiCacheService {
         JSONObject json = cn.hutool.json.JSONUtil.parseObj(resp);
         if (json.containsKey("name")) {
             String cacheName = json.getStr("name");
-            activeGeminiCaches.put(hash, cacheName);
+            activeGeminiCaches.put(hash, new CachedEntry(cacheName, System.currentTimeMillis()));
             return cacheName;
         } else {
             throw new RuntimeException("Failed to create cache: " + resp);

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -37,17 +37,19 @@ public class PluginService {
     private static final Set<String> KNOWN_PERMISSIONS =
             Set.of("file_read", "file_write", "network", "editor");
 
+    // 并发安全：rescan() 会 clear()+重填这些集合，而 ToolRegistry 在高频请求线程上无同步地遍历读取，
+    // 普通 ArrayList/HashMap 会抛 ConcurrentModificationException / 读到半空状态。
     @Getter
-    private final List<PluginMetadata> plugins = new ArrayList<>();
+    private final List<PluginMetadata> plugins = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     @Getter
-    private final Map<String, Object> pluginTools = new HashMap<>(); // toolName -> toolObject
+    private final Map<String, Object> pluginTools = new ConcurrentHashMap<>(); // toolName -> toolObject
 
     @Getter
-    private final List<ToolSpecification> toolSpecifications = new ArrayList<>();
+    private final List<ToolSpecification> toolSpecifications = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     /** toolName -> pluginId，供将来 ToolRegistry 按插件启停过滤工具 */
-    private final Map<String, String> toolToPluginId = new HashMap<>();
+    private final Map<String, String> toolToPluginId = new ConcurrentHashMap<>();
 
     /** 被禁用插件 id 集合（内存缓存，与 system_setting 同步） */
     private final Set<String> disabledPluginIds = ConcurrentHashMap.newKeySet();

--- a/backend/src/main/java/com/checkba/service/ai/context/ContextCompressor.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/ContextCompressor.java
@@ -205,10 +205,11 @@ public class ContextCompressor {
      * 标准化文本用于比较
      */
     private String normalizeForComparison(String text) {
-        return text.replaceAll("\\s+", " ")
+        // 先归一化再截断：substring 上界必须用归一化后的长度，用原串长度会在归一化变短时越界 StringIndexOutOfBounds
+        String normalized = text.replaceAll("\\s+", " ")
                 .replaceAll("<[^>]+>", "")
-                .toLowerCase()
-                .substring(0, Math.min(200, text.length()));
+                .toLowerCase();
+        return normalized.substring(0, Math.min(200, normalized.length()));
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/context/ConversationSummarizer.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/ConversationSummarizer.java
@@ -209,7 +209,11 @@ public class ConversationSummarizer {
      */
     private String extractText(ChatMessage msg) {
         if (msg instanceof UserMessage um) {
-            return um.singleText();
+            // 安全提取：多模态消息 singleText() 会抛异常
+            return um.contents().stream()
+                    .filter(dev.langchain4j.data.message.TextContent.class::isInstance)
+                    .map(c -> ((dev.langchain4j.data.message.TextContent) c).text())
+                    .collect(java.util.stream.Collectors.joining(" "));
         } else if (msg instanceof AiMessage am) {
             return am.text();
         }

--- a/backend/src/main/java/com/checkba/service/ai/context/LegalInfoProtector.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/LegalInfoProtector.java
@@ -226,7 +226,15 @@ public class LegalInfoProtector {
      */
     public CompressedResult safeCompress(String content, int targetLength) {
         List<ProtectedSegment> protectedSegments = markProtectedInfo(content);
-        
+
+        // 无受保护片段时：直接按长度处理。否则下方分段循环不会产生任何内容 → 返回空串丢失整段。
+        if (protectedSegments.isEmpty()) {
+            if (content.length() <= targetLength) {
+                return new CompressedResult(content, protectedSegments, false);
+            }
+            return new CompressedResult(content.substring(0, Math.max(0, targetLength)) + "...", protectedSegments, true);
+        }
+
         // 计算受保护内容的总长度
         int protectedLength = protectedSegments.stream()
                 .mapToInt(s -> s.getContent().length())

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemCellExtractor.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemCellExtractor.java
@@ -150,7 +150,11 @@ public class MemCellExtractor {
             
             if (msg instanceof UserMessage um) {
                 role = "用户";
-                content = um.singleText();
+                // 安全提取：多模态消息 singleText() 会抛异常
+                content = um.contents().stream()
+                        .filter(dev.langchain4j.data.message.TextContent.class::isInstance)
+                        .map(c -> ((dev.langchain4j.data.message.TextContent) c).text())
+                        .collect(java.util.stream.Collectors.joining(" "));
             } else if (msg instanceof AiMessage am) {
                 role = "助理";
                 content = am.text();

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
@@ -462,8 +462,13 @@ public class MemoryManager {
      */
     private List<MemoryEntry> rankWithTimeDecay(List<MemoryEntry> candidates, int limit) {
         if (candidates == null || candidates.isEmpty()) return Collections.emptyList();
+        // 预计算每条综合分（含随机抖动/时间衰减，逐条只算一次）。retrievalScore 每次调用返回不同值，
+        // 直接用作比较器 key 会在排序中被多次调用得到不同结果，违反 Comparator 契约 →
+        // TimSort 抛 IllegalArgumentException（候选多时）或排序错乱（候选少时）。
+        java.util.Map<MemoryEntry, Double> scoreCache = new java.util.IdentityHashMap<>();
+        for (MemoryEntry e : candidates) scoreCache.put(e, retrievalScore(e));
         List<MemoryEntry> ranked = candidates.stream()
-                .sorted(Comparator.comparingDouble(this::retrievalScore).reversed())
+                .sorted(Comparator.comparingDouble((MemoryEntry e) -> scoreCache.get(e)).reversed())
                 .collect(Collectors.toList());
 
         List<MemoryEntry> top = new ArrayList<>(ranked.subList(0, Math.min(limit, ranked.size())));

--- a/backend/src/main/java/com/checkba/service/ai/memory/ProjectMemoryExtractor.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/ProjectMemoryExtractor.java
@@ -49,7 +49,11 @@ public class ProjectMemoryExtractor {
         StringBuilder allContent = new StringBuilder();
         for (ChatMessage msg : messages) {
             if (msg instanceof UserMessage um) {
-                allContent.append(um.singleText()).append("\n");
+                // 安全提取文本：多模态 UserMessage（含图片）调 singleText() 会抛异常导致整轮抽取失败
+                allContent.append(um.contents().stream()
+                        .filter(dev.langchain4j.data.message.TextContent.class::isInstance)
+                        .map(c -> ((dev.langchain4j.data.message.TextContent) c).text())
+                        .collect(java.util.stream.Collectors.joining(" "))).append("\n");
             } else if (msg instanceof AiMessage am) {
                 allContent.append(am.text()).append("\n");
             }

--- a/backend/src/main/java/com/checkba/storage/OssStorageService.java
+++ b/backend/src/main/java/com/checkba/storage/OssStorageService.java
@@ -222,7 +222,10 @@ public class OssStorageService implements StorageService {
         if (prefix != null && !prefix.isEmpty() && !prefix.endsWith("/")) {
             prefix = prefix + "/";
         }
-        return (prefix != null ? prefix : "") + fileId + ".docx";
+        // 与本地存储一致：含路径分隔符的 fileId 原样作为 key（如 avatars/x.png、ocr/tmp/x、clipboard/1/uuid），
+        // 只对无分隔符的旧式裸 id 兼容补 .docx——此前无条件补 .docx 会把头像/OCR/剪贴板文件的 key 写坏
+        String key = (fileId.contains("/") || fileId.contains("\\")) ? fileId : fileId + ".docx";
+        return (prefix != null ? prefix : "") + key;
     }
 
     // ========== 阿里云OSS实现 ==========

--- a/backend/src/main/java/com/checkba/storage/StorageServiceFactory.java
+++ b/backend/src/main/java/com/checkba/storage/StorageServiceFactory.java
@@ -29,9 +29,11 @@ public class StorageServiceFactory {
      */
     public StorageService getStorageService() {
         String type = storageProperties.getType();
-        
+
         log.info("获取存储服务，类型: {}", type);
-        
+
+        // 空值防御：配置里 storage.type: 键存在但值为空时 type 为 null，避免 toLowerCase NPE 拖垮全站文件功能
+        if (type == null) return localFileStorageService;
         switch (type.toLowerCase()) {
             case "local":
                 return localFileStorageService;


### PR DESCRIPTION
「消灭所有代码层 bug」目标下的第二轮**广覆盖**审查（6 个 agent 覆盖之前未深审的层）。本 PR 为后端确认项，19 个文件。

## 崩溃/异常
- `MemoryEntryRepository.deleteExpiredMemories` 缺 `@Modifying` → 清理过期记忆必抛异常
- `ClipboardItemRepository` `like %:q%` → Hibernate6 解析失败 → `concat`
- `MemoryManager` 排序比较器含随机/now → 违反 Comparator 契约（TimSort 抛异常）→ 预计算分数
- `ContextCompressor` substring 越界（StringIndexOutOfBounds）
- `LegalInfoProtector` 无受保护片段时返回空串丢整段

## 安全
- `DocFileLinkService` 越权（fileIds 不校验归属）
- `BrowserProxyController` SSRF 重定向绕过 → NEVER + 手动逐跳校验
- `GlobalExceptionHandler` 回显内部异常 message → 通用文案
- `DataInitializer` 每次启动强夺他人项目 + 明文口令入日志

## 健壮性
- `StorageServiceFactory` type=null NPE / `ClipboardService` 流泄漏 / `WizardController` TOCTOU
- `GeminiCacheService` 无 TTL 致 404 / `OssStorageService` .docx key 写坏 / `PluginService` 并发集合 CME
- 三处 `singleText()` 多模态抛异常致记忆抽取失败 / `ContentSearchService` 高亮偏移错位

## 有意暂缓（风险>收益，见 ROUND2.md）
jsonb（H2 已 MODE=PostgreSQL 兼容，仅 MySQL-prod 模板）、Tag 唯一约束（ddl-auto=update 存量重复会启动失败）、@Data equals（广改）、Gemini 带工具 generate（功能级）、RAG 缓存无界、@CrossOrigin 叠加。

回归 **210/210 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)