### PR TITLE
fix(round2/frontend): 竞态防护 + 重复键

### DIFF
--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -250,8 +250,10 @@ export default {
         if (!this.file || !this.fileUrl) return
 
         this.loading = true
+        // 竞态防护：记录本次请求序号，onload 时若已切到别的文件则丢弃陈旧响应，避免显示错文件
+        const reqId = (this._mediaReqId = (this._mediaReqId || 0) + 1)
         console.log('loadMediaResource: 开始加载', this.fileUrl)
-        
+
         const headers = getAuthHeaders() || {}
         console.log('loadMediaResource: 使用认证头', headers)
         const mimeType = this.getMimeType(this.file.fileType)
@@ -268,6 +270,7 @@ export default {
         })
         
         xhr.onload = function() {
+          if (self._mediaReqId !== reqId) return // 已切换到别的文件，丢弃陈旧响应
           if (xhr.status === 200) {
             const blob = xhr.response
             console.log('loadMediaResource: 获取到数据', blob.size, 'bytes, MIME:', mimeType || blob.type)

--- a/frontend/src/components/ProjectFavoritesPanel.vue
+++ b/frontend/src/components/ProjectFavoritesPanel.vue
@@ -156,8 +156,10 @@ export default {
     },
     async refresh() {
       const now = Date.now()
-      if (this._lastRefreshAt && now - this._lastRefreshAt < 1200) return
+      // query 变化时绕过时间节流（否则搜索框改了结果却不刷新、停留在旧关键字）；仅对相同 query 的高频刷新节流
+      if (this._lastRefreshAt && now - this._lastRefreshAt < 1200 && this.query === this._lastRefreshQuery) return
       this._lastRefreshAt = now
+      this._lastRefreshQuery = this.query
       this.loading = true
       try {
         const pid = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId

--- a/frontend/src/components/SearchPanel.vue
+++ b/frontend/src/components/SearchPanel.vue
@@ -230,6 +230,8 @@ export default {
       // Allow search if query is non-empty OR if tags are selected
       this.loading = true
       this.hasSearched = true
+      // 竞态防护：快速连点标签/选项会并发多次搜索，只让最新一次的结果落地
+      const seq = (this._searchSeq = (this._searchSeq || 0) + 1)
 
       try {
         const response = await searchProjectContent(this.projectId, {
@@ -238,6 +240,8 @@ export default {
           tagIds: this.selectedTagIds,
           fileTypes: ['docx', 'pdf', 'pptx', 'xlsx', 'txt', 'md'] // Explicitly support these types
         })
+
+        if (seq !== this._searchSeq) return // 已有更新的搜索发起，丢弃本次陈旧结果
 
         this.results = response
 
@@ -250,7 +254,7 @@ export default {
         console.error('Search failed:', e)
         uni.showToast({ title: 'Search failed', icon: 'none' })
       } finally {
-        this.loading = false
+        if (seq === this._searchSeq) this.loading = false
       }
     },
     refreshSearch() {

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -752,7 +752,6 @@ export default {
               endpoint: data.external.aliyunOcr?.endpoint || 'ocr-api.cn-hangzhou.aliyuncs.com',
               regionId: data.external.aliyunOcr?.regionId || 'cn-hangzhou',
               publicBaseUrl: data.external.aliyunOcr?.publicBaseUrl || '',
-              publicBaseUrl: data.external.aliyunOcr?.publicBaseUrl || '',
             },
             openRouter: {
               apiKey: data.external.openRouter?.apiKey || '',


### PR DESCRIPTION
第二轮前端盲区修复：FilePreview 媒体加载陈旧XHR竞态、SearchPanel 搜索竞态、ProjectFavoritesPanel 节流吞query、admin 重复key。H5 构建通过。未改：project-overview data() 6组同值重复键(cosmetic)。🤖 Generated with [Claude Code](https://claude.com/claude-code)