### PR TITLE
fix(round2): 逐项修复此前暂缓项（jsonb/Tag/@Data/Gemini/RAG/CORS/分页）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ActivityLogController.java
+++ b/backend/src/main/java/com/checkba/controller/ActivityLogController.java
@@ -11,7 +11,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/activity")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 public class ActivityLogController {
 
     private final UserActivityLogService userActivityLogService;

--- a/backend/src/main/java/com/checkba/controller/AdminConfigController.java
+++ b/backend/src/main/java/com/checkba/controller/AdminConfigController.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
  */
 @RestController
 @RequestMapping("/api/admin")
-@CrossOrigin(origins = "*")
 public class AdminConfigController {
 
     private final SystemSettingService systemSettingService;

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
-@CrossOrigin(origins = "*")
 public class AuthController {
 
     private final UserService userService;

--- a/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
+++ b/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
@@ -28,7 +28,6 @@ import java.time.Duration;
  */
 @RestController
 @RequestMapping("/api/browser")
-@CrossOrigin(origins = "*")
 public class BrowserProxyController {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BrowserProxyController.class);

--- a/backend/src/main/java/com/checkba/controller/ClipboardController.java
+++ b/backend/src/main/java/com/checkba/controller/ClipboardController.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/clipboard")
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class ClipboardController {
 

--- a/backend/src/main/java/com/checkba/controller/CustomerController.java
+++ b/backend/src/main/java/com/checkba/controller/CustomerController.java
@@ -15,7 +15,6 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/customers")
-@CrossOrigin(origins = "*")
 public class CustomerController {
 
     private final CompanyMirrorService companyMirrorService;

--- a/backend/src/main/java/com/checkba/controller/DocFileLinkController.java
+++ b/backend/src/main/java/com/checkba/controller/DocFileLinkController.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/projects/{projectId}/doc-links")
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class DocFileLinkController {
 

--- a/backend/src/main/java/com/checkba/controller/ExternalController.java
+++ b/backend/src/main/java/com/checkba/controller/ExternalController.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/external")
-@CrossOrigin(origins = "*") // 允许跨域
 public class ExternalController {
 
     @Autowired

--- a/backend/src/main/java/com/checkba/controller/FileVariableController.java
+++ b/backend/src/main/java/com/checkba/controller/FileVariableController.java
@@ -15,7 +15,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/file-variables")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 public class FileVariableController {
 
     private final FileVariableService fileVariableService;

--- a/backend/src/main/java/com/checkba/controller/OcrController.java
+++ b/backend/src/main/java/com/checkba/controller/OcrController.java
@@ -20,7 +20,6 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/ocr")
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class OcrController {
 

--- a/backend/src/main/java/com/checkba/controller/ProjectController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectController.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/projects")
-@CrossOrigin(origins = "*")
 public class ProjectController {
 
     private final ProjectService projectService;

--- a/backend/src/main/java/com/checkba/controller/ProjectFileController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectFileController.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
  */
 @RestController
 @RequestMapping("/api/projects/{projectId}/files")
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class ProjectFileController {
 

--- a/backend/src/main/java/com/checkba/controller/ProjectMemberController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectMemberController.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/projects")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 public class ProjectMemberController {
 
     private final ProjectMemberService projectMemberService;

--- a/backend/src/main/java/com/checkba/controller/SearchController.java
+++ b/backend/src/main/java/com/checkba/controller/SearchController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/api/projects/{projectId}/search")
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class SearchController {
 

--- a/backend/src/main/java/com/checkba/controller/SensitiveController.java
+++ b/backend/src/main/java/com/checkba/controller/SensitiveController.java
@@ -13,7 +13,6 @@ import java.util.Map;
 @RequestMapping("/api/sensitive")
 @RequiredArgsConstructor
 @Slf4j
-@CrossOrigin(origins = "*", maxAge = 3600)
 public class SensitiveController {
 
     private final SensitiveService sensitiveService;

--- a/backend/src/main/java/com/checkba/controller/UserController.java
+++ b/backend/src/main/java/com/checkba/controller/UserController.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/users")
-@CrossOrigin(origins = "*")
 public class UserController {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(UserController.class);

--- a/backend/src/main/java/com/checkba/controller/WebFavoriteController.java
+++ b/backend/src/main/java/com/checkba/controller/WebFavoriteController.java
@@ -23,7 +23,6 @@ import java.util.Map;
  * - 我的收藏：/api/favorites/my
  */
 @RestController
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class WebFavoriteController {
 

--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -24,7 +24,6 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/admin/wizard")
-@CrossOrigin(origins = "*")
 public class WizardController {
 
     static final String KEY_WIZARD_COMPLETED = "system.wizard.completed";

--- a/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/api/ai/agent")
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 @Slf4j
 public class EditorResultController {

--- a/backend/src/main/java/com/checkba/model/entity/ConversationSummary.java
+++ b/backend/src/main/java/com/checkba/model/entity/ConversationSummary.java
@@ -1,12 +1,13 @@
 package com.checkba.model.entity;
 
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.Map;
 @Entity
 @Table(name = "conversation_summary")
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id：字段型 equals/hashCode 会遍历 List/Map JSON 字段且未持久化时不稳
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -32,6 +34,7 @@ public class ConversationSummary {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     /**
@@ -61,29 +64,29 @@ public class ConversationSummary {
     /**
      * 关键点列表（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "key_points", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "key_points")
     private List<String> keyPoints;
 
     /**
      * 法律引用列表（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "legal_references", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "legal_references")
     private List<String> legalReferences;
 
     /**
      * 提及的实体（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "mentioned_entities", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "mentioned_entities")
     private List<String> mentionedEntities;
 
     /**
      * 待办事项（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "pending_tasks", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "pending_tasks")
     private List<String> pendingTasks;
 
     /**
@@ -122,24 +125,24 @@ public class ConversationSummary {
      * 事件列表（JSON格式）
      * 每个事件包含: timestamp, actor, action, content
      */
-    @Type(JsonType.class)
-    @Column(name = "events", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "events")
     private List<Map<String, Object>> events;
 
     /**
      * 参与者列表（JSON格式）
      * 包含用户和AI助手的标识
      */
-    @Type(JsonType.class)
-    @Column(name = "participants", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "participants")
     private List<Map<String, String>> participants;
 
     /**
      * 时间线摘要（JSON格式）
      * 按时间顺序记录关键节点
      */
-    @Type(JsonType.class)
-    @Column(name = "timeline", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "timeline")
     private List<Map<String, Object>> timeline;
 
     /**
@@ -157,8 +160,8 @@ public class ConversationSummary {
     /**
      * 关联的 MemCell ID 列表
      */
-    @Type(JsonType.class)
-    @Column(name = "related_memcell_ids", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "related_memcell_ids")
     private List<Long> relatedMemCellIds;
 
     @Column(name = "created_at")

--- a/backend/src/main/java/com/checkba/model/entity/FileTag.java
+++ b/backend/src/main/java/com/checkba/model/entity/FileTag.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.time.LocalDateTime;
 
@@ -19,10 +20,12 @@ import java.time.LocalDateTime;
     @UniqueConstraint(columnNames = {"fileId", "tagId"})
 })
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id：join 实体最易被放进 Set 去重，字段型 hashCode 在 save 前后会变
 public class FileTag {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     /**

--- a/backend/src/main/java/com/checkba/model/entity/MemoryEntry.java
+++ b/backend/src/main/java/com/checkba/model/entity/MemoryEntry.java
@@ -1,12 +1,12 @@
 package com.checkba.model.entity;
 
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -90,8 +90,8 @@ public class MemoryEntry {
     /**
      * 额外元数据（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "metadata", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata")
     private Map<String, Object> metadata;
 
     /**

--- a/backend/src/main/java/com/checkba/model/entity/ProjectMemory.java
+++ b/backend/src/main/java/com/checkba/model/entity/ProjectMemory.java
@@ -1,12 +1,13 @@
 package com.checkba.model.entity;
 
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ import java.util.Map;
 @Entity
 @Table(name = "project_memory")
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id，避免遍历 JSON 集合字段/未持久化时不稳
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -27,6 +29,7 @@ public class ProjectMemory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     /**
@@ -74,36 +77,36 @@ public class ProjectMemory {
     /**
      * 关键日期（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "key_dates", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "key_dates")
     private Map<String, String> keyDates;
 
     /**
      * 交易各方（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "parties", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "parties")
     private List<Map<String, String>> parties;
 
     /**
      * 关键变量（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "key_variables", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "key_variables")
     private Map<String, String> keyVariables;
 
     /**
      * 法律引用（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "legal_refs", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "legal_refs")
     private List<String> legalRefs;
 
     /**
      * 核查结论（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "check_conclusions", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "check_conclusions")
     private List<Map<String, String>> checkConclusions;
 
     @Column(name = "created_at")

--- a/backend/src/main/java/com/checkba/model/entity/Tag.java
+++ b/backend/src/main/java/com/checkba/model/entity/Tag.java
@@ -6,7 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.time.LocalDateTime;
 
@@ -14,12 +16,18 @@ import java.time.LocalDateTime;
  * 项目标签实体
  */
 @Entity
-@Table(name = "project_tag")
+@Table(name = "project_tag", uniqueConstraints = {
+    // 同项目内标签名唯一：应用层 existsByProjectIdAndName 是"先查后插"，并发下仍可能重复；
+    // DB 唯一约束兜底，避免重复标签导致 findByProjectIdAndName 抛 NonUniqueResultException。
+    @UniqueConstraint(columnNames = {"projectId", "name"})
+})
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id，与仓库其余实体一致，避免可变字段/未持久化时的 hashCode 陷阱
 public class Tag {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     /**

--- a/backend/src/main/java/com/checkba/model/entity/UserMemory.java
+++ b/backend/src/main/java/com/checkba/model/entity/UserMemory.java
@@ -1,12 +1,13 @@
 package com.checkba.model.entity;
 
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.Map;
 @Entity
 @Table(name = "user_memory")
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id，避免遍历 JSON 集合字段/未持久化时不稳
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -26,6 +28,7 @@ public class UserMemory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     /**
@@ -37,22 +40,22 @@ public class UserMemory {
     /**
      * 用户偏好（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "preferences", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "preferences")
     private Map<String, String> preferences;
 
     /**
      * 常用表达（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "frequent_phrases", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "frequent_phrases")
     private List<String> frequentPhrases;
 
     /**
      * 工具使用统计（JSON格式）
      */
-    @Type(JsonType.class)
-    @Column(name = "tool_usage_stats", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "tool_usage_stats")
     private Map<String, Integer> toolUsageStats;
 
     @Column(name = "created_at")

--- a/backend/src/main/java/com/checkba/repository/UserActivityLogRepository.java
+++ b/backend/src/main/java/com/checkba/repository/UserActivityLogRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface UserActivityLogRepository extends JpaRepository<UserActivityLog, Long> {
-    List<UserActivityLog> findByUserIdOrderByTimestampDesc(Long userId);
+    // 限制返回最近 500 条：活动日志随每次页面访问/开关文件持续增长，无界全量查询有 OOM/慢查询风险；
+    // "最近动态"语义天然有界，500 条足够展示。
+    List<UserActivityLog> findTop500ByUserIdOrderByTimestampDesc(Long userId);
 }

--- a/backend/src/main/java/com/checkba/service/UserActivityLogService.java
+++ b/backend/src/main/java/com/checkba/service/UserActivityLogService.java
@@ -25,6 +25,6 @@ public class UserActivityLogService {
     }
 
     public List<UserActivityLog> getUserLogs(Long userId) {
-        return repository.findByUserIdOrderByTimestampDesc(userId);
+        return repository.findTop500ByUserIdOrderByTimestampDesc(userId);
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/GeminiChatLanguageModel.java
+++ b/backend/src/main/java/com/checkba/service/ai/GeminiChatLanguageModel.java
@@ -36,6 +36,17 @@ public class GeminiChatLanguageModel implements ChatLanguageModel {
     }
 
     @Override
+    public Response<AiMessage> generate(List<ChatMessage> messages,
+                                        List<dev.langchain4j.agent.tool.ToolSpecification> toolSpecifications) {
+        // Gemini function-calling 尚未在本实现中支持：忽略工具规格、退化为纯文本生成，
+        // 避免 langchain4j 默认实现直接抛 "Tools are not supported" 让 Gemini 子代理崩溃。
+        if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
+            log.warn("GeminiChatLanguageModel 暂不支持工具调用，已忽略 {} 个工具规格，退化为纯文本生成", toolSpecifications.size());
+        }
+        return generate(messages);
+    }
+
+    @Override
     public Response<AiMessage> generate(List<ChatMessage> messages) {
         if (apiKey == null || apiKey.isEmpty()) {
             throw new IllegalStateException("Gemini API key is not configured (ai.model.gemini.api-key)");

--- a/backend/src/main/java/com/checkba/service/ai/ProjectRagService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ProjectRagService.java
@@ -41,7 +41,16 @@ public class ProjectRagService {
     private final StorageProperties storageProperties;
     private final EmbeddingModel embeddingModel;
 
-    private final Map<String, ContentRetriever> retrieverCache = new ConcurrentHashMap<>();
+    // 有界 LRU（access-order）：每个 retriever 持有整个项目的向量库，无界缓存会随项目数持续增长占堆。
+    // 超过上限时淘汰最久未访问的项目（下次访问按需重建）。
+    private static final int MAX_CACHED_PROJECTS = 32;
+    private final Map<String, ContentRetriever> retrieverCache = java.util.Collections.synchronizedMap(
+            new java.util.LinkedHashMap<String, ContentRetriever>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, ContentRetriever> eldest) {
+                    return size() > MAX_CACHED_PROJECTS;
+                }
+            });
 
     public ContentRetriever getRetrieverForProject(String projectId) {
         return retrieverCache.computeIfAbsent(projectId, this::buildRetriever);

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1354,8 +1354,6 @@ export default {
       activeAiFileName: '',
       manualContextFiles: [], // Multi Context Support
       dragOverAiPanel: false,
-      aiContextPreview: null,
-      aiContextLoading: false,
 
       // AI New Features
       showHistoryDrawer: false,
@@ -1441,7 +1439,6 @@ export default {
       activeFileIdRight: null, // 右侧当前激活ID
 
       // Members
-      projectMembers: [],
       currentUser: {},
       pageEnterTime: 0,
 
@@ -1489,7 +1486,6 @@ export default {
       hoverSplit: false,
       hoverCapture: false,
       hoverWeb: false,
-      hoverWeb: false,
       hoverRecord: false,
 
       // Sidebar Action Hovers
@@ -1499,8 +1495,6 @@ export default {
       hoverSort: false,
       hoverDownload: false,
       hoverCopy: false,
-      hoverBatchSelect: false, // existing
-      hoverRecycleBin: false,  // existing
 
       // Recording Toast
       showRecordingToast: false,


### PR DESCRIPTION
按要求把第二轮「有意暂缓」的项逐个做掉。全程有 `DesktopContextSmokeTest`（H2 建表启动）兜底验证 DDL。

| 项 | 修复 |
|---|---|
| jsonb 可移植性(MySQL 启动失败) | 4 实体 JSON 字段 `@Type(JsonType)+columnDefinition="jsonb"` → 原生 `@JdbcTypeCode(SqlTypes.JSON)` 方言自适应 |
| Tag 并发重复 | 加 `(projectId,name)` 唯一约束 |
| @Data equals 陷阱(5实体) | 改仅用 id `@EqualsAndHashCode(onlyExplicitlyIncluded)` |
| Gemini 带工具崩溃 | 补 `generate(msgs,tools)` 重载,忽略工具退化纯文本 |
| RAG 缓存无界 | 有界 LRU(上限32) |
| @CrossOrigin 抵消 CORS 收敛 | 移除 19 控制器的 `@CrossOrigin(*)`,统一全局 filter |
| 活动日志无界查询 | `findTop500...` 上限 |
| project-overview 6组重复 data 键 | 清理(cosmetic) |

**关键过程**:先尝试"直接删 columnDefinition"被冒烟测试当场拦下(JsonType 无列类型无法建表)——证明这类 schema 改动必须验证;`@JdbcTypeCode` 才是正确可移植写法,冒烟测试通过。

回归 backend **210 全绿**(含 DDL 冒烟) + frontend 构建通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)