### PR TITLE
fix(desktop/security): 收紧 fs IPC 任意读写

### DIFF
--- a/desktop/main/file-service.js
+++ b/desktop/main/file-service.js
@@ -1,49 +1,16 @@
-const fs = require('fs/promises');
-const path = require('path');
 const { ipcMain, dialog } = require('electron');
 
 /**
- * Initialize local file service handlers
+ * Initialize local file service handlers.
+ *
+ * 注：原 fs:readFile / fs:writeFile（任意路径读/写）渲染进程从未调用（死暴露），且任意写可覆盖
+ * 用户 dotfile 实现代码执行，已移除。仅保留文件选择对话框；实际文件读取走 checkba:fs-read-file
+ * （见 main.js，已加敏感路径拦截与大小上限）。
  */
 function initLocalFileService() {
     console.log('[LocalFileService] Initializing...');
 
-    // Handler: Read file
-    ipcMain.handle('fs:readFile', async (event, filePath) => {
-        try {
-            console.log(`[LocalFileService] Reading file: ${filePath}`);
-            // Security check: ensure path is valid string
-            if (!filePath || typeof filePath !== 'string') {
-                throw new Error('Invalid file path');
-            }
-
-            const buffer = await fs.readFile(filePath);
-            // Return as Uint8Array (Node.js Buffer is compatible)
-            return buffer;
-        } catch (error) {
-            console.error(`[LocalFileService] Error reading file: ${filePath}`, error);
-            return { error: error.message };
-        }
-    });
-
-    // Handler: Write file
-    ipcMain.handle('fs:writeFile', async (event, { filePath, data }) => {
-        try {
-            console.log(`[LocalFileService] Writing file: ${filePath}, size: ${data ? data.byteLength : 0}`);
-            if (!filePath || typeof filePath !== 'string') {
-                throw new Error('Invalid file path');
-            }
-
-            // data should be Uint8Array or Buffer
-            await fs.writeFile(filePath, Buffer.from(data));
-            return { success: true };
-        } catch (error) {
-            console.error(`[LocalFileService] Error writing file: ${filePath}`, error);
-            return { error: error.message };
-        }
-    });
-
-    // Handler: Open File Dialog
+    // Handler: Open File Dialog（仅弹系统选择框，安全）
     ipcMain.handle('fs:showOpenDialog', async (event, options) => {
         return await dialog.showOpenDialog(options);
     });

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -945,14 +945,29 @@ ipcMain.handle('checkba:fs-read-file', async (_evt, payload) => {
   const p = payload && payload.path ? String(payload.path) : ''
   if (!p) return { ok: false, message: 'path empty' }
   const fs = require('fs')
+  const os = require('os')
   try {
-    // Safety check: only allow reading if user explicitly copied it? 
-    // In this context, it's triggered by clipboard event which contains the path.
-    // For local desktop app, reading local file is acceptable if triggered by user action.
-    const buf = await fs.promises.readFile(p)
-    // Return key info + base64 (since we can't pass Buffer easily over bridge without setup)
-    // Actually Electron handles Buffer in invoke? Yes it does serialize.
-    // But to be safe and easy for frontend Blob creation:
+    // 该接口用于"用户拖入的文件"读取，路径本身由用户操作产生，需要任意位置。
+    // 但 webSecurity 关闭下，被注入的渲染脚本也可能调用它，故做纵深防御：
+    // 1) 拦截明显的敏感路径（凭证/密钥/系统配置），防止读走 ~/.ssh 等；
+    // 2) 大小上限，避免被诱导读超大文件撑爆内存。
+    const resolved = path.resolve(p)
+    const home = os.homedir()
+    const sensitiveHomeDirs = ['.ssh', '.aws', '.gnupg', '.docker', '.kube', '.config']
+    const sensitiveFiles = ['.netrc', '.npmrc', '.pgpass', '.git-credentials']
+    const isSensitive =
+      resolved.startsWith('/etc/') || resolved.startsWith('/private/etc/') ||
+      sensitiveHomeDirs.some((d) => resolved.startsWith(path.join(home, d) + path.sep)) ||
+      sensitiveFiles.some((f) => resolved === path.join(home, f))
+    if (isSensitive) {
+      console.warn('[checkba:fs-read-file] 拒绝读取敏感路径:', resolved)
+      return { ok: false, message: 'access denied: sensitive path' }
+    }
+    const st = await fs.promises.stat(resolved)
+    if (!st.isFile()) return { ok: false, message: 'not a file' }
+    if (st.size > 200 * 1024 * 1024) return { ok: false, message: 'file too large (>200MB)' }
+
+    const buf = await fs.promises.readFile(resolved)
     return { ok: true, data: buf }
   } catch (e) {
     return { ok: false, message: String(e.message) }

--- a/desktop/preload/preload.js
+++ b/desktop/preload/preload.js
@@ -113,8 +113,9 @@ contextBridge.exposeInMainWorld('checkbaDesktop', {
     readFile: (path) => ipcRenderer.invoke('checkba:fs-read-file', { path })
   },
   fs: {
-    readFile: (path) => ipcRenderer.invoke('fs:readFile', path),
-    writeFile: (path, data) => ipcRenderer.invoke('fs:writeFile', { filePath: path, data }),
+    // 注：readFile/writeFile 曾暴露任意路径读/写（渲染进程零调用，属死暴露，其中任意写可覆盖
+    // ~/.zshrc 等实现代码执行），已移除以缩小攻击面。唯一在用的文件读取走 utils.readFile
+    // （checkba:fs-read-file，已加敏感路径拦截与大小上限）。
     showOpenDialog: (options) => ipcRenderer.invoke('fs:showOpenDialog', options)
   },
   // Epic #43: embedded LibreOffice editor <webview> wiring. getEditor() returns


### PR DESCRIPTION
之前标注'需决策'的桌面 fs IPC 经核实可安全收紧：fs:readFile/writeFile 前端零调用(死暴露,含最危险的任意写)→ 删除;checkba:fs-read-file(文件拖入在用)→ 保留+敏感路径拦截+200MB上限。不破坏功能。desktop 10/10。🤖 Generated with [Claude Code](https://claude.com/claude-code)