### PR TITLE
feat(mineru): 升级到 MinerU 3.x + 兼容性冒烟脚本（待真机验证，勿直接合并）

### DIFF
--- a/mineru-service/Dockerfile
+++ b/mineru-service/Dockerfile
@@ -34,8 +34,9 @@ RUN mkdir -p /app/uploads /app/outputs
 # Install MinerU with core dependencies (official method)
 # Using mineru[core] which includes the API server
 # Note: PIP_NO_CACHE_DIR=1 is set, so no cache purge needed
+# MinerU 3.x 升级：合并前请在真机跑 compat_smoke_test.sh 验证（见 README）
 RUN pip install --upgrade pip && \
-    pip install -U "mineru[core]>=2.7.0" -i https://mirrors.aliyun.com/pypi/simple
+    pip install -U "mineru[core]>=3.4,<4" -i https://mirrors.aliyun.com/pypi/simple
 
 # Download models for pipeline backend (required for offline use)
 # This will download models from modelscope (faster for China users)

--- a/mineru-service/README.md
+++ b/mineru-service/README.md
@@ -56,4 +56,28 @@ pptx-service 会自动检测本地 MinerU 服务：
 MINERU_LOCAL_URL=http://mineru-service:8000
 ```
 
+## 升级到 MinerU 3.x（进行中，需真机验证后合并）
+
+本分支已把 pin 从 `mineru[core]>=2.7.0,<3` 提升到 `>=3.4,<4`（requirements.in + Dockerfile）。
+
+据官方 3.x 说明，我们依赖的接口契约**保留**：`mineru-api` 启动命令、同步端点 `POST /file_parse`
+（向后兼容 legacy plugins）、CPU `pipeline` 后端都还在；3.x 另新增异步 `POST /tasks`（我们不用）。
+主要变化在模型（PP-OCRv6、新 VLM），不影响我们的调用方式。
+
+**但升级仍必须在有模型的真机上做兼容性验证后再合并/发版**（本环境无法跑 ML 服务）：
+
+```bash
+cd mineru-service
+# L1 轻量检查（不需模型，几秒）：CLI 存在性 + 从 /openapi.json 确认 /file_parse 契约仍在
+SKIP_PARSE=1 bash compat_smoke_test.sh
+
+# 全量（含真解析，需先下载 pipeline 模型）：
+mineru-models-download -s modelscope -m pipeline   # 首次
+bash compat_smoke_test.sh
+```
+
+脚本会逐项报 PASS/FAIL，并在契约变化时打印当前 OpenAPI 路径 / 响应结构，指出需要同步调整的位置
+（Dockerfile CMD、desktop `mineru.cli.fast_api` spawn 参数、pptx-service 的 `/file_parse` 调用）。
+全绿后再把本分支合并 master 并重打包桌面版。
+
 

--- a/mineru-service/compat_smoke_test.sh
+++ b/mineru-service/compat_smoke_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# MinerU 3.x 兼容性冒烟测试
+# ---------------------------------------------------------------------------
+# 目的：在真机（有 Python 环境、可选地已下载模型）上验证升级到 mineru 3.x 后，
+#       本项目依赖的接口契约是否仍然成立——无需读源码、只验"输入/输出接口"。
+#
+# 分两级：
+#   L1 轻量检查（不需要 ~3GB 模型，几秒完成）：
+#     - mineru-api / python -m mineru.cli.fast_api / mineru-models-download 三个 CLI 是否存在
+#     - 启动 mineru-api 后，从 /openapi.json 确认 POST /file_parse 端点仍在（我们的核心契约）
+#   L2 真解析（需要已下载 pipeline 模型）：
+#     - 生成一份带文字的样例 PDF，POST /file_parse，断言返回里能提取到该文字
+#
+# 用法：
+#   bash compat_smoke_test.sh            # 跑 L1；若检测到模型则自动跑 L2
+#   SKIP_PARSE=1 bash compat_smoke_test.sh   # 只跑 L1
+#   PORT=8000 bash compat_smoke_test.sh
+#
+# 退出码：0=全部通过；非 0=有不兼容项（见输出）。
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+PORT="${PORT:-8000}"
+HOST="127.0.0.1"
+BASE="http://${HOST}:${PORT}"
+TMPDIR="$(mktemp -d)"
+SERVER_PID=""
+FAIL=0
+
+log()  { printf '\033[1m[compat]\033[0m %s\n' "$*"; }
+ok()   { printf '\033[32m  PASS\033[0m %s\n' "$*"; }
+bad()  { printf '\033[31m  FAIL\033[0m %s\n' "$*"; FAIL=1; }
+
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# ---------- L1a: CLI 存在性 ----------
+log "MinerU 版本：$(mineru --version 2>/dev/null || echo '未知/未安装')"
+
+if mineru-api --help >/dev/null 2>&1; then ok "mineru-api CLI 存在（Dockerfile 用）"; else bad "mineru-api CLI 缺失——Dockerfile 的 CMD 会失效"; fi
+if python -m mineru.cli.fast_api --help >/dev/null 2>&1; then ok "python -m mineru.cli.fast_api 存在（桌面打包用）"; else bad "mineru.cli.fast_api 模块缺失/改名——desktop/main/services/mineru-service.js 的 spawn args 需调整"; fi
+if mineru-models-download --help >/dev/null 2>&1; then ok "mineru-models-download CLI 存在（Dockerfile 拉模型用）"; else bad "mineru-models-download 缺失/改名——Dockerfile 模型下载步骤需调整"; fi
+
+# ---------- L1b: 启动服务并检查 /file_parse 契约 ----------
+log "启动 mineru-api 于 ${BASE} ..."
+mineru-api --host "$HOST" --port "$PORT" >"$TMPDIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+# 等待 /openapi.json 或 /docs 就绪（最多 90s，首启可能加载模型）
+READY=0
+for i in $(seq 1 90); do
+  if curl -fsS "${BASE}/openapi.json" >"$TMPDIR/openapi.json" 2>/dev/null; then READY=1; break; fi
+  curl -fsS "${BASE}/docs" >/dev/null 2>&1 && curl -fsS "${BASE}/openapi.json" >"$TMPDIR/openapi.json" 2>/dev/null && { READY=1; break; }
+  sleep 1
+done
+
+if [ "$READY" != "1" ]; then
+  bad "服务未在 90s 内就绪，见 $TMPDIR/server.log（尾部）："
+  tail -20 "$TMPDIR/server.log" || true
+  exit 1
+fi
+ok "服务已就绪，取到 /openapi.json"
+
+if grep -q '"/file_parse"' "$TMPDIR/openapi.json"; then
+  ok "契约保留：POST /file_parse 仍存在于 OpenAPI（我方集成核心端点）"
+else
+  bad "OpenAPI 中未见 /file_parse——契约变更，pptx-service 侧调用需适配。现有 paths："
+  python -c "import json;print('\n'.join(sorted(json.load(open('$TMPDIR/openapi.json')).get('paths',{}))))" 2>/dev/null | sed 's/^/      /' || true
+fi
+
+# ---------- L2: 真解析（仅当有模型且未 SKIP_PARSE）----------
+if [ "${SKIP_PARSE:-0}" = "1" ]; then
+  log "SKIP_PARSE=1，跳过真解析（L2）"
+else
+  log "尝试真解析（L2，需已下载 pipeline 模型）..."
+  # 生成带文字的样例 PDF；优先 reportlab，缺失则尝试安装
+  SAMPLE="$TMPDIR/sample.pdf"
+  MARKER="MinerUCompat20260708"
+  python - "$SAMPLE" "$MARKER" <<'PY' 2>/dev/null
+import sys
+path, marker = sys.argv[1], sys.argv[2]
+try:
+    from reportlab.pdfgen import canvas
+except Exception:
+    import subprocess; subprocess.check_call([sys.executable,"-m","pip","install","-q","reportlab"])
+    from reportlab.pdfgen import canvas
+c = canvas.Canvas(path); c.drawString(80, 760, marker + " hello mineru"); c.showPage(); c.save()
+PY
+  if [ ! -s "$SAMPLE" ]; then
+    log "  无法生成样例 PDF（reportlab 不可用），跳过 L2。可自备：SAMPLE=/path.pdf 后手动 curl /file_parse"
+  else
+    HTTP=$(curl -s -o "$TMPDIR/parse.json" -w '%{http_code}' -X POST "${BASE}/file_parse" \
+            -F "files=@${SAMPLE};type=application/pdf" 2>/dev/null)
+    if [ "$HTTP" = "200" ]; then
+      if grep -q "$MARKER" "$TMPDIR/parse.json" 2>/dev/null; then
+        ok "真解析成功且提取到样例文字（端到端契约 OK）"
+      else
+        log "  /file_parse 返回 200 但未直接匹配到样例文字——可能是响应结构变化，请人工核对 $TMPDIR/parse.json（首 400 字）："
+        head -c 400 "$TMPDIR/parse.json"; echo
+        log "  （若字段名变了但内容在，属输出结构调整，需同步 pptx-service 的解析）"
+      fi
+    else
+      bad "/file_parse 返回 HTTP $HTTP（可能是模型未下载或请求参数变更）。响应："
+      head -c 400 "$TMPDIR/parse.json" 2>/dev/null; echo
+      log "  若因缺模型：先跑 mineru-models-download -s modelscope -m pipeline 再重试"
+    fi
+  fi
+fi
+
+echo
+if [ "$FAIL" = "0" ]; then
+  log "结论：核心接口契约（mineru-api + /file_parse + pipeline）在 3.x 下保持——可继续验证 L2 后合并。"
+else
+  log "结论：存在不兼容项（见上 FAIL）——需按提示调整 Dockerfile/desktop spawn/pptx-service 后再合并。"
+fi
+exit $FAIL

--- a/mineru-service/requirements.in
+++ b/mineru-service/requirements.in
@@ -1,1 +1,3 @@
-mineru[core]>=2.7.0,<3
+# MinerU 3.x 升级：3.x 保留 mineru-api 与 POST /file_parse（向后兼容）、CPU pipeline 后端仍在。
+# 升级前请在有模型的真机跑 mineru-service/compat_smoke_test.sh 验证契约后再合并/发版。
+mineru[core]>=3.4,<4

--- a/mineru-service/requirements.lock
+++ b/mineru-service/requirements.lock
@@ -6,18 +6,12 @@ aiofiles==24.1.0
     # via
     #   gradio
     #   mineru-vl-utils
-albucore==0.0.24
-    # via albumentations
-albumentations==2.0.8
-    # via doclayout-yolo
 annotated-doc==0.0.4
     # via
     #   fastapi
     #   typer
 annotated-types==0.7.0
     # via pydantic
-antlr4-python3-runtime==4.9.3
-    # via omegaconf
 anyio==4.14.1
     # via
     #   gradio
@@ -26,16 +20,8 @@ anyio==4.14.1
     #   starlette
 audioop-lts==0.2.2 ; python_full_version >= '3.13'
     # via gradio
-av==18.0.0
-    # via qwen-vl-utils
 beautifulsoup4==4.15.0
     # via mineru
-boto3==1.43.40
-    # via mineru
-botocore==1.43.40
-    # via
-    #   boto3
-    #   s3transfer
 brotli==1.2.0
     # via gradio
 certifi==2026.6.17
@@ -43,11 +29,8 @@ certifi==2026.6.17
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0 ; platform_python_implementation != 'PyPy'
-    # via cryptography
 charset-normalizer==3.4.7
     # via
-    #   pdfminer-six
     #   reportlab
     #   requests
 click==8.4.2
@@ -56,6 +39,8 @@ click==8.4.2
     #   mineru
     #   pdftext
     #   uvicorn
+cobble==0.1.4
+    # via mammoth
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
@@ -65,24 +50,16 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   typer
 colorlog==6.10.1
     # via robust-downloader
-contourpy==1.3.3
-    # via matplotlib
-cryptography==49.0.0
-    # via pdfminer-six
 cuda-bindings==13.3.1 ; sys_platform == 'linux'
     # via torch
 cuda-pathfinder==1.5.6 ; sys_platform == 'linux'
     # via cuda-bindings
 cuda-toolkit==13.0.2 ; sys_platform == 'linux'
     # via torch
-cycler==0.12.1
-    # via matplotlib
-dill==0.4.1
-    # via mineru
 distro==1.9.0
     # via openai
-doclayout-yolo==0.0.4
-    # via mineru
+et-xmlfile==2.0.0
+    # via openpyxl
 fast-langdetect==0.2.5
     # via mineru
 fastapi==0.139.0
@@ -102,8 +79,6 @@ filelock==3.29.5
     #   transformers
 flatbuffers==25.12.19
     # via onnxruntime
-fonttools==4.63.0
-    # via matplotlib
 fsspec==2026.6.0
     # via
     #   gradio-client
@@ -153,29 +128,26 @@ idna==3.18
     #   anyio
     #   httpx
     #   requests
-imageio==2.37.3
-    # via scikit-image
 jinja2==3.1.6
     # via
     #   gradio
     #   torch
 jiter==0.16.0
     # via openai
-jmespath==1.1.0
-    # via
-    #   boto3
-    #   botocore
 json-repair==0.61.1
     # via mineru
-kiwisolver==1.5.0
-    # via matplotlib
-lazy-loader==0.5
-    # via scikit-image
 loguru==0.7.3
     # via
     #   mineru
     #   mineru-vl-utils
+lxml==6.1.1
+    # via
+    #   mineru
+    #   pypptx-with-oxml
+    #   python-docx
 magika==1.0.3
+    # via mineru
+mammoth==1.12.0
     # via mineru
 markdown-it-py==4.2.0
     # via rich
@@ -183,17 +155,11 @@ markupsafe==3.0.3
     # via
     #   gradio
     #   jinja2
-matplotlib==3.11.0
-    # via
-    #   doclayout-yolo
-    #   mineru
-    #   seaborn
-    #   ultralytics
 mdurl==0.1.2
     # via markdown-it-py
-mineru==2.7.6
+mineru==3.4.3
     # via -r requirements.in
-mineru-vl-utils==0.2.8
+mineru-vl-utils==1.0.5
     # via mineru
 modelscope==1.38.0
     # via mineru
@@ -202,33 +168,19 @@ modelscope-hub==0.1.6
 mpmath==1.3.0
     # via sympy
 networkx==3.6.1
-    # via
-    #   scikit-image
-    #   torch
+    # via torch
 numpy==2.4.6
     # via
     #   accelerate
-    #   albucore
-    #   albumentations
-    #   contourpy
     #   gradio
-    #   imageio
-    #   matplotlib
     #   mineru
     #   onnxruntime
     #   opencv-python
-    #   opencv-python-headless
     #   pandas
     #   pdftext
-    #   scikit-image
-    #   scipy
-    #   seaborn
     #   shapely
-    #   tifffile
     #   torchvision
     #   transformers
-    #   ultralytics
-    #   ultralytics-thop
 nvidia-cublas==13.1.1.3 ; sys_platform == 'linux'
     # via
     #   nvidia-cudnn-cu13
@@ -258,8 +210,6 @@ nvidia-cusparse==12.6.3.3 ; sys_platform == 'linux'
     #   nvidia-cusolver
 nvidia-cusparselt-cu13==0.8.1 ; sys_platform == 'linux'
     # via torch
-nvidia-ml-py==13.610.43
-    # via ultralytics
 nvidia-nccl-cu13==2.29.7 ; sys_platform == 'linux'
     # via torch
 nvidia-nvjitlink==13.0.88 ; sys_platform == 'linux'
@@ -272,8 +222,6 @@ nvidia-nvshmem-cu13==3.4.5 ; sys_platform == 'linux'
     # via torch
 nvidia-nvtx==13.0.85 ; sys_platform == 'linux'
     # via cuda-toolkit
-omegaconf==2.3.1
-    # via mineru
 onnxruntime==1.27.0
     # via
     #   magika
@@ -281,14 +229,9 @@ onnxruntime==1.27.0
 openai==2.44.0
     # via mineru
 opencv-python==5.0.0.93
-    # via
-    #   doclayout-yolo
-    #   mineru
-    #   ultralytics
-opencv-python-headless==5.0.0.93
-    # via
-    #   albucore
-    #   albumentations
+    # via mineru
+openpyxl==3.1.5
+    # via mineru
 orjson==3.11.9
     # via gradio
 packaging==26.2
@@ -297,55 +240,29 @@ packaging==26.2
     #   gradio
     #   gradio-client
     #   huggingface-hub
-    #   lazy-loader
-    #   matplotlib
     #   modelscope
     #   onnxruntime
-    #   qwen-vl-utils
-    #   scikit-image
     #   transformers
 pandas==2.3.3
-    # via
-    #   doclayout-yolo
-    #   gradio
-    #   seaborn
-pdfminer-six==20260107
-    # via mineru
+    # via gradio
 pdftext==0.7.0
     # via mineru
 pillow==11.3.0
     # via
-    #   doclayout-yolo
     #   gradio
-    #   imageio
-    #   matplotlib
     #   mineru
     #   mineru-vl-utils
-    #   qwen-vl-utils
+    #   pypptx-with-oxml
     #   reportlab
-    #   scikit-image
     #   torchvision
-    #   ultralytics
-polars==1.42.1
-    # via ultralytics
-polars-runtime-32==1.42.1
-    # via polars
 protobuf==7.35.1
     # via onnxruntime
 psutil==7.2.2
-    # via
-    #   accelerate
-    #   doclayout-yolo
-    #   ultralytics
-py-cpuinfo==9.0.0
-    # via doclayout-yolo
+    # via accelerate
 pyclipper==1.4.0
     # via mineru
-pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
-    # via cffi
 pydantic==2.11.10
     # via
-    #   albumentations
     #   fastapi
     #   gradio
     #   mineru-vl-utils
@@ -360,19 +277,20 @@ pydub==0.25.1
     # via gradio
 pygments==2.20.0
     # via rich
-pyparsing==3.3.2
-    # via matplotlib
+pylatexenc==2.10
+    # via mineru
 pypdf==6.14.2
     # via mineru
 pypdfium2==5.9.0
     # via
     #   mineru
     #   pdftext
+pypptx-with-oxml==1.0.3
+    # via mineru
 python-dateutil==2.9.0.post0
-    # via
-    #   botocore
-    #   matplotlib
-    #   pandas
+    # via pandas
+python-docx==1.2.0
+    # via mineru
 python-dotenv==1.2.2
     # via pydantic-settings
 python-multipart==0.0.32
@@ -384,55 +302,36 @@ pytz==2026.2
 pyyaml==6.0.3
     # via
     #   accelerate
-    #   albumentations
-    #   doclayout-yolo
     #   gradio
     #   huggingface-hub
     #   mineru
-    #   omegaconf
     #   transformers
-    #   ultralytics
-qwen-vl-utils==0.0.14
-    # via mineru
 regex==2026.6.28
     # via transformers
 reportlab==5.0.0
     # via mineru
 requests==2.34.2
     # via
-    #   doclayout-yolo
     #   fast-langdetect
     #   huggingface-hub
     #   mineru
     #   modelscope
     #   modelscope-hub
-    #   qwen-vl-utils
     #   robust-downloader
     #   transformers
-    #   ultralytics
 rich==15.0.0
     # via typer
 robust-downloader==0.0.2
     # via fast-langdetect
 ruff==0.15.20
     # via gradio
-s3transfer==0.19.0
-    # via boto3
 safehttpx==0.1.7
     # via gradio
 safetensors==0.8.0
     # via
     #   accelerate
+    #   mineru
     #   transformers
-scikit-image==0.26.0
-    # via mineru
-scipy==1.17.1
-    # via
-    #   albumentations
-    #   doclayout-yolo
-    #   scikit-image
-seaborn==0.13.2
-    # via doclayout-yolo
 semantic-version==2.10.0
     # via gradio
 setuptools==81.0.0
@@ -443,8 +342,6 @@ shapely==2.1.2
     # via mineru
 shellingham==1.5.4
     # via typer
-simsimd==6.5.16
-    # via albucore
 six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
@@ -455,14 +352,8 @@ starlette==0.52.1
     # via
     #   fastapi
     #   gradio
-stringzilla==4.6.2
-    # via albucore
 sympy==1.14.0
     # via torch
-thop==0.1.1.post2209072238
-    # via doclayout-yolo
-tifffile==2026.3.3
-    # via scikit-image
 tokenizers==0.22.2
     # via transformers
 tomlkit==0.13.3
@@ -470,20 +361,12 @@ tomlkit==0.13.3
 torch==2.12.1
     # via
     #   accelerate
-    #   doclayout-yolo
     #   mineru
-    #   thop
     #   torchvision
-    #   ultralytics
-    #   ultralytics-thop
 torchvision==0.27.1
-    # via
-    #   doclayout-yolo
-    #   mineru
-    #   ultralytics
+    # via mineru
 tqdm==4.68.3
     # via
-    #   doclayout-yolo
     #   huggingface-hub
     #   mineru
     #   modelscope
@@ -508,6 +391,8 @@ typing-extensions==4.16.0
     #   openai
     #   pydantic
     #   pydantic-core
+    #   pypptx-with-oxml
+    #   python-docx
     #   starlette
     #   torch
     #   typing-inspection
@@ -518,13 +403,8 @@ typing-inspection==0.4.2
     #   pydantic-settings
 tzdata==2026.2
     # via pandas
-ultralytics==8.4.86
-    # via mineru
-ultralytics-thop==2.0.20
-    # via ultralytics
 urllib3==2.7.0
     # via
-    #   botocore
     #   modelscope
     #   modelscope-hub
     #   requests
@@ -538,3 +418,5 @@ websockets==15.0.1
     # via gradio-client
 win32-setctime==1.2.0 ; sys_platform == 'win32'
     # via loguru
+xlsxwriter==3.2.9
+    # via pypptx-with-oxml


### PR DESCRIPTION
按「模块化升级」路线准备 MinerU 2.7→3.4 升级。**本 PR 先不合并**——ML 服务需 ~3GB 模型、本环境跑不起来,须真机验证后再合。

## 改动
- `requirements.in` / `Dockerfile`:pin `>=2.7.0,<3` → `>=3.4,<4`。
- 新增 `compat_smoke_test.sh`(可跑的兼容性测试):
  - **L1(不需模型,几秒)**:校验 `mineru-api` / `python -m mineru.cli.fast_api` / `mineru-models-download` 三个 CLI 存在;启动后从 `/openapi.json` 确认 `POST /file_parse` 契约仍在。
  - **L2(需 pipeline 模型)**:生成样例 PDF → `POST /file_parse` → 断言提取到样例文字。
  - 契约变化时打印当前 paths/响应结构,指出需同步的位置(Dockerfile CMD、desktop `fast_api` spawn、pptx-service 调用)。
- README 补升级与验证步骤。

## 已知(据官方 3.x 文档,利好)
3.x **保留** `mineru-api` 命令、同步 `POST /file_parse`(向后兼容 legacy plugins)、CPU `pipeline` 后端;主要变化在模型(PP-OCRv6/新 VLM),不影响调用方式。

## 合并前必须做
在有模型的真机/服务器:
```bash
cd mineru-service && SKIP_PARSE=1 bash compat_smoke_test.sh   # 先轻量
mineru-models-download -s modelscope -m pipeline && bash compat_smoke_test.sh   # 再全量
```
全绿后再合并本 PR 并重打包桌面版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)