### PR TITLE
chore: bump 0.7.0（MinerU 3.4 / banana-slides 0.4 升级发版）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
bump desktop 0.6.3→0.7.0。合并后打 v0.7.0 tag 触发 Desktop Build 出安装包供真机 QA。

包含（相对 v0.6.3）：#124-#127 体检修复与依赖刷新、#128 MinerU 3.4.3、#129 banana-slides 0.4.0 re-vendor、#130 wizard Key 指引。

🤖 Generated with [Claude Code](https://claude.com/claude-code)