### PR TITLE
fix(pptx/desktop): 修 v0.7.0 构建红——0.4.0 端口语义 + PPTX_DATA_DIR 复植

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -220,7 +220,7 @@ jobs:
           PY="$PWD/desktop/bundled/mac-arm64/python/bin/python3.11"
           export PYTHONPATH="$PWD/desktop/bundled/mac-arm64/pysvc/pptx-service/lib"
           (cd "$APP" && "$PY" -m alembic -c alembic.ini upgrade head)
-          PORT=5099 FLASK_ENV=production "$PY" "$APP/app.py" > "$RUNNER_TEMP/pptx-smoke.log" 2>&1 &
+          PORT=5099 BACKEND_PORT=5099 FLASK_ENV=production "$PY" "$APP/app.py" > "$RUNNER_TEMP/pptx-smoke.log" 2>&1 &
           PPTX_PID=$!
           for i in $(seq 1 30); do
             sleep 2
@@ -365,7 +365,7 @@ jobs:
           PY="$PWD/desktop/bundled/win-x64/python/python.exe"
           export PYTHONPATH="$PWD/desktop/bundled/win-x64/pysvc/pptx-service/lib"
           (cd "$APP" && "$PY" -m alembic -c alembic.ini upgrade head)
-          PORT=5099 FLASK_ENV=production "$PY" "$APP/app.py" > "$RUNNER_TEMP/pptx-smoke.log" 2>&1 &
+          PORT=5099 BACKEND_PORT=5099 FLASK_ENV=production "$PY" "$APP/app.py" > "$RUNNER_TEMP/pptx-smoke.log" 2>&1 &
           PPTX_PID=$!
           for i in $(seq 1 30); do
             sleep 2

--- a/desktop/main/services/pptx-service.js
+++ b/desktop/main/services/pptx-service.js
@@ -26,7 +26,9 @@ function spawnEnv(ctx) {
     ...process.env,
     PYTHONPATH: libDir(ctx),
     PPTX_DATA_DIR: dataDir(ctx),
+    // banana-slides 0.4.0 起监听端口读 BACKEND_PORT（0.1 读 PORT）——两个都传，升降级均可用
     PORT: String(ctx.ports['pptx-service']),
+    BACKEND_PORT: String(ctx.ports['pptx-service']),
     FLASK_ENV: 'production'
   }
   // 本地 MinerU 动态端口 + 云端兜底默认关闭（设计 §2.4 出网收口；可用 env 显式放开）

--- a/pptx-service/UPGRADE_CHECKBA.md
+++ b/pptx-service/UPGRADE_CHECKBA.md
@@ -8,6 +8,7 @@
 |---|---|
 | `backend/services/file_parser_service.py` | 本地 MinerU 优先逻辑：`_truthy`/`_should_force_cloud`/`_get_local_mineru_url` 辅助函数、`__init__` 的 `mineru_local_url` 参数（缺省自动读 Flask config/env，调用点无需改动）、`_check_local_service`/`_parse_with_local_service`/`_save_local_mineru_result` 三个方法、`parse_file` 里"本地优先→云端兜底→无 token 报错"路由 |
 | `backend/config.py` | `MINERU_LOCAL_URL`（默认 `http://mineru-service:8000`）与 `MINERU_FORCE_CLOUD`（默认 `'1'`，桌面端 spawn 时会传 env=0 放开本地优先） |
+| `backend/app.py` | `PPTX_DATA_DIR` 数据目录外置（桌面打包态 resources 只读，DB/uploads 必须写到注入目录）；配套测试 `backend/tests/test_data_dir.py`。**v0.7.0 tag 首次构建就是因 re-vendor 漏掉此项+下面端口语义变化而红** |
 | `.env.example` | MinerU 本地服务段 + `BACKEND_PORT=5001` |
 | `docker-compose.yml` / `docker-compose.prod.yml` | 宿主机端口默认 `5001:5000`（对齐 PptxServiceClient 默认 base-url） |
 | `requirements.lock` | 桌面打包/CI 用（`desktop/scripts/prepare-python-service.js`、`.github/workflows/desktop-build.yml`）。再生成：`uv export --no-dev --no-hashes --no-emit-project -o requirements.lock` |
@@ -16,6 +17,10 @@
 > 注：0.4.0 上游把「可编辑 PPTX 导出」改为 image_editability 混合抽取器（MinerU 云端 + 可选百度高精 OCR，
 > 见 `BAIDU_OCR_API_KEY`）。该链路的 FileParserService 未显式传 `mineru_local_url`，但由于缺省会
 > 自动读 config/env，本地优先逻辑同样生效。
+>
+> **端口语义变化（0.4.0）**：应用监听端口从读 `PORT` 改为读 `BACKEND_PORT`（`IN_DOCKER=1` 时固定 5000）。
+> 桌面 spawn（desktop/main/services/pptx-service.js）与 CI 冒烟（desktop-build.yml）已两个变量都传，
+> 升降级均兼容——再升级时留意上游是否又改此语义。
 
 ## 为什么升级要单独走这个流程
 - 升级 = **重新 vendor 一整份上游源码**（0.1 → 0.4 是大 diff），不是改一行 pin；

--- a/pptx-service/backend/app.py
+++ b/pptx-service/backend/app.py
@@ -55,17 +55,19 @@ def create_app():
     # Load configuration from Config class
     app.config.from_object(Config)
     
-    # Override with environment-specific paths (use absolute path)
+    # Override with environment-specific paths (use absolute path).
+    # [checkba] PPTX_DATA_DIR: desktop 打包态注入（resources 目录只读，数据必须外置）
     backend_dir = os.path.dirname(os.path.abspath(__file__))
-    instance_dir = os.path.join(backend_dir, 'instance')
+    data_dir = os.getenv('PPTX_DATA_DIR')
+    instance_dir = os.path.join(data_dir or backend_dir, 'instance')
     os.makedirs(instance_dir, exist_ok=True)
-    
+
     db_path = os.path.join(instance_dir, 'database.db')
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
-    
+
     # Ensure upload folder exists
     project_root = os.path.dirname(backend_dir)
-    upload_folder = os.path.join(project_root, 'uploads')
+    upload_folder = os.path.join(data_dir or project_root, 'uploads')
     os.makedirs(upload_folder, exist_ok=True)
     app.config['UPLOAD_FOLDER'] = upload_folder
     

--- a/pptx-service/backend/tests/test_data_dir.py
+++ b/pptx-service/backend/tests/test_data_dir.py
@@ -1,0 +1,24 @@
+"""PPTX_DATA_DIR: packaged desktop mode writes DB/uploads outside read-only resources"""
+import os
+
+
+def test_data_dir_env_redirects_db_and_uploads(tmp_path, monkeypatch):
+    monkeypatch.setenv('PPTX_DATA_DIR', str(tmp_path))
+    import app as app_module
+    application = app_module.create_app()
+    expected_db = os.path.join(str(tmp_path), 'instance', 'database.db')
+    assert application.config['SQLALCHEMY_DATABASE_URI'] == f'sqlite:///{expected_db}'
+    assert application.config['UPLOAD_FOLDER'] == os.path.join(str(tmp_path), 'uploads')
+    assert os.path.isdir(os.path.join(str(tmp_path), 'instance'))
+    assert os.path.isdir(os.path.join(str(tmp_path), 'uploads'))
+
+
+def test_without_env_keeps_legacy_paths(monkeypatch):
+    monkeypatch.delenv('PPTX_DATA_DIR', raising=False)
+    import app as app_module
+    application = app_module.create_app()
+    backend_dir = os.path.dirname(os.path.abspath(app_module.__file__))
+    assert application.config['SQLALCHEMY_DATABASE_URI'].endswith(
+        os.path.join(backend_dir, 'instance', 'database.db'))
+    assert application.config['UPLOAD_FOLDER'] == os.path.join(
+        os.path.dirname(backend_dir), 'uploads')


### PR DESCRIPTION
## 根因（tag v0.7.0 首次构建 mac/win 双红,冒烟 60s 起不来）
1. **0.4.0 端口语义变化**：应用从读 `PORT` 改读 `BACKEND_PORT`（IN_DOCKER 固定 5000）,桌面 spawn/CI 冒烟传 PORT 被无视,服务绑死 5000
2. **PPTX_DATA_DIR 定制丢失**：re-vendor 覆盖了 app.py 的数据外置定制（746b38c,打包态 resources 只读）,DB/uploads 会写进只读目录

## 修复
- desktop spawn + CI 冒烟：PORT/BACKEND_PORT 双传（升降级兼容）
- app.py 复植 `[checkba] PPTX_DATA_DIR` 定制 + 恢复 test_data_dir.py
- UPGRADE_CHECKBA.md 定制清单补全

## 验证
- 本地 M 芯片按 CI 同款：prepare-python-service 烙包 → alembic → `BACKEND_PORT=5099` 起服务,**/health 2s 就绪**,DB 落 `$PPTX_DATA_DIR/instance/`
- desktop 10 test 全绿

合并后将把 v0.7.0 tag 移到修复后的 master 重触发构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)