### PR TITLE
feat(editor): 还清 #79 迁移债——拖拽关联/网核标记/图片插入/链接点击在 LibreOffice 复活

### DIFF
--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -56,7 +56,7 @@ let seq = 0
 
 export default {
   name: 'LibreOfficeEditor',
-  emits: ['close', 'ready'],
+  emits: ['close', 'ready', 'open-url'],
   props: {
     // 'experimental' = the original ⌘⇧O overlay (dev probe toolbar shown).
     // 'default'      = inline document editor (Track B): toolbar chrome hidden.
@@ -130,6 +130,16 @@ export default {
       wv.style.height = '100%'
       wv.style.border = '0'
       wv.addEventListener('dom-ready', () => this.onDomReady(wv))
+      // (#79) document hyperlink clicks: the editor page forwards LO's
+      // window.open over lo-relay as {type:'open-url'} — surface it to the host
+      // (project-overview routes checkba:// internal links / http(s) tabs).
+      wv.addEventListener('ipc-message', (e) => {
+        if (e.channel !== 'lo-relay') return
+        const msg = e.args && e.args[0]
+        if (msg && msg.__lo === 'lo-relay' && msg.type === 'open-url' && msg.url) {
+          this.$emit('open-url', String(msg.url))
+        }
+      })
       wv.addEventListener('did-fail-load', (e) => this.appendLog('did-fail-load: ' + (e.errorDescription || e.errorCode)))
       wv.addEventListener('console-message', (e) => { if (e.level >= 2) this.appendLog('[webview] ' + e.message) })
       wv.setAttribute('src', info.url)

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -42,6 +42,11 @@ export const EDITOR_ACTIONS = [
   // (scope, varName) variable; driven by VariablePanel through the getWps adapter
   // in project-overview.vue, not by the AI agent pipeline.
   'var_list', 'var_insert', 'var_update',
+  // [#79 债务清偿] WPS-instance-bound features restored on LibreOffice:
+  // 选区↔文件超链接关联 (get/set_selection_hyperlink)、网核证据标记
+  // (insert_link_with_bookmark)、图片插入 (insert_image)。Host-initiated
+  // (drag-association / evidence-drop / OCR image), not AI-agent commands.
+  'get_selection_hyperlink', 'set_selection_hyperlink', 'insert_link_with_bookmark', 'insert_image',
 ]
 
 /**

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -704,6 +704,7 @@
                       :file="activeFileLeft"
                       @ready="onLibreReady"
                       @close="onLibreClose"
+                      @open-url="onLibreOpenUrl"
                     />
                     <MarkdownPreview
                       v-else-if="isMarkdownTab(activeFileLeft)"
@@ -763,6 +764,7 @@
                       :file="activeFileRight"
                       @ready="onLibreReady"
                       @close="onLibreClose"
+                      @open-url="onLibreOpenUrl"
                     />
                     <MarkdownPreview
                       v-else-if="isMarkdownTab(activeFileRight)"
@@ -803,7 +805,7 @@
                    a real backend AI command can be triggered while it's active.
                    Dormant: only mounts when explicitly opened. -->
               <view v-if="showLibreEmbed" class="libre-embed-overlay">
-                <LibreOfficeEditor @ready="onLibreReady" @close="onLibreClose" />
+                <LibreOfficeEditor @ready="onLibreReady" @close="onLibreClose" @open-url="onLibreOpenUrl" />
               </view>
             </view>
 
@@ -2450,8 +2452,8 @@ export default {
       return `${base}?u=${encodeURIComponent(inner)}`
     },
     // === 文件拖拽到文档选区建立关联（超链接）===
-    // #79：该功能原依赖 WPS 编辑器实例（选区轮询 + setHyperlinkAtRange），WPS 移除后
-    // 暂不可用（下方守卫会友好提示），LibreOffice 等价实现记债。
+    // #79 债已还：原 WPS 实例能力（选区轮询 + setHyperlinkAtRange）现由 LibreOffice
+    // 执行器原语实现（get/set_selection_hyperlink，见 createWpsSelectionFileLink）。
     onFileLinkDragStart(file) {
       if (!file || !file.id) return
       this.fileLinkDrag.active = true
@@ -2495,10 +2497,82 @@ export default {
       this.fileLinkPicker.linkKey = ''
     },
     async createWpsSelectionFileLink(side, file) {
-      // #79：文档选区↔文件关联原依赖 WPS 编辑器实例（选区读取 + setHyperlinkAtRange），
-      // WPS 移除后暂不可用，LibreOffice 等价实现记债（后端 DocFileLink 契约保留）。
-      console.log('createWpsSelectionFileLink (inert, #79):', { side, fileId: file && file.id })
-      uni.showToast({ title: '当前编辑器暂不支持选区关联', icon: 'none' })
+      // #79 债已还：经 LibreOffice 执行器实现（get_selection_hyperlink 复用已有
+      // linkKey + set_selection_hyperlink 写入），后端 DocFileLink 契约不变。
+      console.log('createWpsSelectionFileLink start:', { side, fileId: file && file.id })
+      if (!this.libreOfficeActive || !this.libreOfficeExecutor) {
+        uni.showToast({ title: '请先打开一个文档', icon: 'none' })
+        return
+      }
+      const exec = (action, params) => this.libreOfficeExecutor.executeCommand(action, params)
+
+      // 1) 读选区（顺带取选区上已有的超链接，用于复用 linkKey）
+      let selText = ''
+      let existingUrl = ''
+      try {
+        const cur = await exec('get_selection_hyperlink', {})
+        if (cur && cur.success) {
+          selText = String(cur.text || '').trim()
+          existingUrl = cur.url ? String(cur.url) : ''
+        }
+      } catch (e) {
+        console.warn('get_selection_hyperlink failed:', e)
+      }
+      if (!selText) {
+        uni.showToast({ title: '请先在文档中高亮一段文本（蓝色选区）', icon: 'none' })
+        return
+      }
+
+      // 2) 生成/复用 linkKey：选区已带内部链接时从中解析（裸 checkba:// 或包装 https 均兼容）
+      let linkKey = ''
+      try {
+        let raw = existingUrl
+        if (raw && this.WPS_INTERNAL_HTTP_LINK_BASE && raw.startsWith(this.WPS_INTERNAL_HTTP_LINK_BASE)) {
+          const q0 = raw.includes('?') ? raw.split('?')[1] : ''
+          const p0 = new URLSearchParams(q0)
+          raw = p0.get('u') ? decodeURIComponent(String(p0.get('u'))) : ''
+        }
+        if (raw && raw.startsWith(this.INTERNAL_LINK_SCHEMES.fileLink)) {
+          const q = raw.includes('?') ? raw.split('?')[1] : ''
+          linkKey = new URLSearchParams(q).get('k') || ''
+        }
+      } catch (e) {
+        // ignore
+      }
+      if (!linkKey) {
+        linkKey = `lk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+        // 与 WPS 时代同款“包装后的 https 链接”：点击经编辑器 open-url 事件回宿主解包，
+        // 文档导出到真实 Word 时也仍是合法链接
+        const inner = `${this.INTERNAL_LINK_SCHEMES.fileLink}?k=${encodeURIComponent(linkKey)}&projectId=${encodeURIComponent(String(this.projectId || ''))}`
+        const url = this.wrapWpsInternalLink(inner)
+        const r = await exec('set_selection_hyperlink', { url })
+        if (!r || !r.success) {
+          console.error('设置超链接失败:', r && r.message)
+          uni.showToast({ title: '设置超链接失败', icon: 'none' })
+          return
+        }
+      }
+
+      // 3) 入库：按 fileId 关联（文件移动/重命名不影响打开）
+      try {
+        const pid = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
+        const doc = side === 'right' ? this.activeFileRight : this.activeFileLeft
+        const docWpsFileId = doc && this.isEditorOpenableFile(doc) ? (doc.wpsFileId || '') : ''
+        if (!docWpsFileId) throw new Error('文档未就绪')
+        const payload = await createDocFileLink(pid, {
+          linkKey,
+          docWpsFileId,
+          anchorText: selText || '',
+          // LibreOffice 路径没有整数偏移（§0.2 锚点语义）；后端字段可空
+          rangeStart: null,
+          rangeEnd: null,
+          fileIds: [Number(file.id)]
+        })
+        if (payload && payload.linkKey) linkKey = payload.linkKey
+        uni.showToast({ title: '已建立关联', icon: 'success' })
+      } catch (e) {
+        uni.showToast({ title: e.message || '关联失败', icon: 'none' })
+      }
     },
 
     // === Staging Area Methods ===
@@ -3996,8 +4070,20 @@ export default {
            uni.showToast({ title: '插入失败', icon: 'none' })
          }
       } else if (type === 'IMAGE') {
-         // #79：内置 LibreOffice 编辑器暂不支持图片插入（原 WPS 能力，记债）
-         uni.showToast({ title: '当前编辑器暂不支持图片插入', icon: 'none' })
+         // #79 债已还：经执行器 insert_image 在光标处插入（data URL → UNO 图形对象）
+         if (!content) return
+         if (!this.libreOfficeActive || !this.libreOfficeExecutor) {
+           uni.showToast({ title: '请先打开一个文档', icon: 'none' })
+           return
+         }
+         try {
+           const r = await this.libreOfficeExecutor.executeCommand('insert_image', { dataUrl: content })
+           if (!r || !r.success) throw new Error((r && r.message) || '插入图片失败')
+           uni.showToast({ title: '已插入图片', icon: 'success' })
+         } catch (e) {
+           console.error(e)
+           uni.showToast({ title: e.message || '插入图片失败', icon: 'none' })
+         }
       }
     },
 
@@ -4181,10 +4267,41 @@ export default {
     },
 
     async handleWebLinkDrop(x, y) {
-      // #79：网核证据插入文档原依赖 WPS 编辑器实例（书签+超链接 API），WPS 移除后
-      // 暂不可用（守卫友好提示），LibreOffice 等价实现记债。
-      this.stopWebLinkDrag()
-      uni.showToast({ title: '当前编辑器暂不支持网核标记插入', icon: 'none' })
+      // #79 债已还：落点命中内置 LibreOffice 编辑器时，经执行器
+      // insert_link_with_bookmark 在光标处插入网核标记（书签+内部超链接）。
+      const hitEditor = () => {
+        if (typeof document === 'undefined') return false
+        const els = document.querySelectorAll('.libre-editor-wrapper')
+        for (const el of els) {
+          const r = el.getBoundingClientRect()
+          if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return true
+        }
+        return false
+      }
+      try {
+        if (!hitEditor()) {
+          uni.showToast({ title: '请拖拽到文档区域进行关联', icon: 'none' })
+          return
+        }
+        if (!this.libreOfficeActive || !this.libreOfficeExecutor) {
+          uni.showToast({ title: '请先打开一个文档', icon: 'none' })
+          return
+        }
+        const favId = this.webLinkDrag.favoriteId
+        const host = this.webLinkDrag.sourceUrl ? (() => { try { return new URL(this.webLinkDrag.sourceUrl).host } catch (e) { return '网核' } })() : '网核'
+        const ts = new Date().toLocaleString()
+        const text = `【网核证据：${host}｜${ts}】`
+        const bookmarkName = `WEB_EVID_${favId || Date.now()}`
+        const internalUrl = this.wrapWpsInternalLink(`checkba://webfav?id=${encodeURIComponent(String(favId || ''))}&projectId=${encodeURIComponent(String(this.projectId || ''))}`)
+        const r = await this.libreOfficeExecutor.executeCommand('insert_link_with_bookmark', { text, bookmarkName, url: internalUrl })
+        if (!r || !r.success) throw new Error((r && r.message) || '插入失败')
+        uni.showToast({ title: '已插入网核标记', icon: 'success' })
+      } catch (e) {
+        console.error('插入网核标记失败:', e)
+        uni.showToast({ title: e.message || '插入失败', icon: 'none' })
+      } finally {
+        this.stopWebLinkDrag()
+      }
     },
     onFileTreeCheckedChange(ids) {
       this.checkedFileIds = Array.isArray(ids) ? ids : []
@@ -5560,6 +5677,23 @@ export default {
         this.libreOfficeExecutor = executor
         this.libreOfficeActive = true
         console.log('[ProjectOverview] LibreOffice editor ready — agent commands routed to LibreOffice')
+    },
+    // (#79) 文档内超链接点击：编辑器把 LO 的 window.open 经 lo-relay 转发上来。
+    // 内部链接（包装 https 或裸 checkba:）走 __checkbaHandleInternalLink（关联
+    // 文件/网核定位，含解包），普通网页开工作区浏览器 tab。
+    onLibreOpenUrl(url) {
+      const u = String(url || '')
+      if (!u) return
+      const isWrapped = this.WPS_INTERNAL_HTTP_LINK_BASE && u.startsWith(this.WPS_INTERNAL_HTTP_LINK_BASE)
+      if (isWrapped || u.startsWith('checkba:')) {
+        try {
+          if (typeof window !== 'undefined' && window.__checkbaHandleInternalLink) window.__checkbaHandleInternalLink(u)
+        } catch (e) {
+          console.error('内部链接处理失败:', e)
+        }
+        return
+      }
+      if (/^https?:\/\//i.test(u)) this.openBrowserTab(u)
     },
     onLibreClose(executor) {
         // The overlay close button emits no executor; an inline editor unmount

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -142,6 +142,22 @@ function wireVerifyPanel(executor) {
 // One transport instance, reused to both serve the host AND signal readiness.
 const hostTransport = pickTransport()
 
+// (#79) Hyperlink clicks: when LO opens a document hyperlink it lands on the
+// page's window.open. Inside the isolated <webview> a popup can't open anything
+// useful anyway — forward the URL to the HOST over the same lo-relay transport,
+// where project-overview routes it (checkba:// internal links → 关联文件/网核
+// 定位, http(s) → workspace browser tab). Wrapped BEFORE boot so no click races.
+try {
+  const nativeOpen = window.open ? window.open.bind(window) : null
+  window.open = (url, name, feats) => {
+    const u = url ? String(url) : ''
+    if (u) {
+      try { hostTransport.send({ __lo: 'lo-relay', type: 'open-url', url: u }); return null } catch (e) { /* fall through */ }
+    }
+    return nativeOpen ? nativeOpen(url, name, feats) : null
+  }
+} catch (e) { console.error('[zeta-editor] window.open hook failed:', e) }
+
 startEditorEndpoint({
   canvas: document.getElementById('qtcanvas'),
   transport: hostTransport,

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -965,6 +965,107 @@ const EXEC = {
     xText.insertTextContent(cur, bm2, true);
     return { success: true, id: id, text: value, paragraphAfterEdit: (paragraphTextOf(cur) || '').slice(0, 200) };
   },
+  // ---- #79 债务清偿：WPS 实例绑定能力的 LibreOffice 等价原语 ----------------
+  // 选区↔文件超链接关联（拖拽关联）、网核证据标记（书签+超链接）、图片插入。
+  // read the hyperlink URL on the current selection (empty string if none) —
+  // the host uses it to REUSE an existing linkKey instead of stacking a new one.
+  get_selection_hyperlink() {
+    const sel = ctrl.getSelection();
+    let range = null;
+    try {
+      if (sel && typeof sel.getByIndex === 'function' && sel.getCount() > 0) range = sel.getByIndex(0);
+    } catch (e) {}
+    if (!range) return { success: true, url: '', hasSelection: false };
+    let url = '';
+    try {
+      const xText = range.getText();
+      const cur = xText.createTextCursorByRange(range);
+      const v = cur.getPropertyValue('HyperLinkURL');
+      if (typeof v === 'string') url = v;
+    } catch (e) {} // mixed/none over the span → treat as no link
+    return { success: true, url: url, hasSelection: (range.getString() || '').length > 0, text: range.getString() };
+  },
+  // set a hyperlink on the current (visible) selection — the WPS-era
+  // setHyperlinkAtRange, minus integer offsets: the selection IS the range.
+  set_selection_hyperlink(p) {
+    const url = String(p.url || '');
+    if (!url) return { success: false, message: 'set_selection_hyperlink requires {url}' };
+    const sel = ctrl.getSelection();
+    let range = null;
+    try {
+      if (sel && typeof sel.getByIndex === 'function' && sel.getCount() > 0) range = sel.getByIndex(0);
+    } catch (e) {}
+    const text = range ? (range.getString() || '') : '';
+    if (!range || !text.length) return { success: false, message: 'no selection to hyperlink' };
+    const xText = range.getText();
+    const cur = xText.createTextCursorByRange(range);
+    cur.setPropertyValue('HyperLinkURL', url);
+    return { success: true, text: text, url: url };
+  },
+  // insert {text} at the view cursor wrapped in a named bookmark, optionally
+  // hyperlinked — the WPS-era insertEvidenceLink/insertTextWithBookmark (网核
+  // 证据标记). Same insert shape as var_insert (bookmark spans the inserted run).
+  insert_link_with_bookmark(p) {
+    const text = String(p.text || '');
+    if (!text) return { success: false, message: 'insert_link_with_bookmark requires {text}' };
+    const requested = String(p.bookmarkName || 'MARK_' + Date.now()).replace(/[^A-Za-z0-9_]/g, '_');
+    const url = String(p.url || '');
+    const vc = ctrl.getViewCursor();
+    vc.collapseToEnd();
+    const xText = vc.getText();
+    const cur = xText.createTextCursorByRange(vc.getEnd());
+    xText.insertString(cur, text, true); // bAbsorb: cur spans the inserted text
+    if (url) cur.setPropertyValue('HyperLinkURL', url);
+    const bms = xModel.getBookmarks();
+    let name = requested, n = 0;
+    while (bms.hasByName(name)) name = requested + '_' + (++n);
+    const bm = xModel.createInstance('com.sun.star.text.Bookmark');
+    bm.setName(name);
+    xText.insertTextContent(cur, bm, true);
+    try { vc.gotoRange(cur.getEnd(), false); } catch (e) {}
+    return Object.assign({ success: true, bookmarkName: name, text: text, url: url }, verifySnapshot());
+  },
+  // insert an image (data URL / raw base64) at the view cursor — the WPS-era
+  // insertImage. Bytes go JS→UNO through SequenceInputStream (same signed-Array
+  // marshalling as load_document), GraphicProvider decodes, TextGraphicObject
+  // anchors AS_CHARACTER at the cursor. Oversized images are scaled to page width.
+  insert_image(p) {
+    const dataUrl = String(p.dataUrl || p.base64 || '');
+    const m = dataUrl.match(/^data:[^,]*;base64,(.*)$/s);
+    const b64 = m ? m[1] : dataUrl;
+    if (!b64) return { success: false, message: 'insert_image requires {dataUrl|base64}' };
+    let bin;
+    try { bin = atob(b64.replace(/\s+/g, '')); } catch (e) { return { success: false, message: 'invalid base64: ' + errStr(e) }; }
+    if (!bin.length) return { success: false, message: 'empty image data' };
+    const u8 = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+    // signed plain Array — the ONLY shape zeta.js marshals into sequence<byte>
+    const bytes = Array.from(new Int8Array(u8.buffer, u8.byteOffset, u8.byteLength));
+    const stream = css.io.SequenceInputStream.createStreamFromSequence(context, bytes);
+    const gp = css.graphic.GraphicProvider.create(context);
+    const graphic = gp.queryGraphic([mkProp('InputStream', stream)]);
+    if (!graphic) return { success: false, message: 'GraphicProvider could not decode the image' };
+    const img = xModel.createInstance('com.sun.star.text.TextGraphicObject');
+    img.setPropertyValue('Graphic', graphic);
+    img.setPropertyValue('AnchorType', css.text.TextContentAnchorType.AS_CHARACTER);
+    // natural size (1/100 mm), fall back to pixels @96dpi; cap to ~15cm text width
+    let w = 0, h = 0;
+    try { const sz = graphic.getPropertyValue('Size100thMM'); w = sz.Width || 0; h = sz.Height || 0; } catch (e) {}
+    if (!w || !h) {
+      try { const px = graphic.getPropertyValue('SizePixel'); w = Math.round((px.Width || 0) * 2540 / 96); h = Math.round((px.Height || 0) * 2540 / 96); } catch (e) {}
+    }
+    if (w > 0 && h > 0) {
+      const MAX_W = 15000;
+      if (w > MAX_W) { h = Math.round(h * MAX_W / w); w = MAX_W; }
+      img.setPropertyValue('Width', w);
+      img.setPropertyValue('Height', h);
+    }
+    const vc = ctrl.getViewCursor();
+    vc.collapseToEnd();
+    vc.getText().insertTextContent(vc, img, false);
+    try { vc.collapseToEnd(); } catch (e) {}
+    return { success: true, bytes: u8.length, width: w, height: h };
+  },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {
     const bms = xModel.getBookmarks();


### PR DESCRIPTION
## 背景

维护者反馈：换掉 WPS 编辑器后「拖拽关联」等功能消失。排查确认是 #80/#81 移除 WPS 时记债的四项 WPS 实例绑定能力（PR#81 提交信息明确记录降级为 toast）：

| 功能 | 降级点 | 状态 |
|---|---|---|
| 变量书签面板 | `getWps` 适配器 | ✅ v0.6.2 已还（PR#105） |
| 文件拖拽到文档选区建立关联（超链接） | `createWpsSelectionFileLink` inert | ✅ 本 PR |
| 网核证据拖拽插入文档标记 | `handleWebLinkDrop` inert | ✅ 本 PR |
| 图片插入（OCR/网页截图→文档） | `insertPlainTextToWps` IMAGE 分支 inert | ✅ 本 PR |
| 文档内链接点击→打开关联文件/网核定位 | LOWA webview 无 window.open 消费者 | ✅ 本 PR（见「待真机」） |

## 实现

- **worker 新原语 ×4**（`office_thread.js`，遵守 zetajs 编组硬规则）：
  - `get_selection_hyperlink` / `set_selection_hyperlink` — 选区超链接读/写；读回用于复用已有 linkKey（兼容裸 `checkba://` 与包装 https）
  - `insert_link_with_bookmark` — 光标处插入「书签+超链接」文本（网核证据标记；书签名冲突自动加后缀）
  - `insert_image` — data URL → `SequenceInputStream`（带符号普通 Array 编组）→ `GraphicProvider` → `TextGraphicObject`，AS_CHARACTER 锚定，超 15cm 等比缩放
- **白名单**：`EDITOR_ACTIONS` 收录 4 个新动作。宿主发起、非 AI 工具——编排器/system prompt/别名表零改动（守住 Phase 1 不变式）
- **前端重接**：三处 inert 分支改走执行器；DocFileLink 后端契约不变（rangeStart/End 置 null，§0.2 无整数偏移语义）
- **链接点击回路**：编辑器页钩 `window.open` → lo-relay `open-url` → `LibreOfficeEditor` 事件 → 宿主路由（内部链接 → `__checkbaHandleInternalLink`；http(s) → 工作区浏览器 tab）

## 验证

- `npm run build:h5` + `npm run build:zetaoffice` 绿
- **真机引擎无头端到端**（puppeteer 驱动 AI Workdeck.app 内自建 zh-CN 引擎，brotli 回放）：
  - 选区设链→读回 URL 一致 ✓（linkKey 复用路径）
  - `insert_link_with_bookmark` 书签落位、文本带链 ✓
  - `insert_image` 成功（1×1 PNG → 26×26 1/100mm）✓
  - `export_document` ZIP 魔数 OK（链接/书签/图片可序列化回 docx）✓
  - `window.open('checkba://…')` → `open-url` 消息转发 ✓

## 待真机确认

LO canvas 内 **ctrl+click 超链接是否触发页面 window.open**（Emscripten 系统 shell 行为）——window.open 之后的全链路已验证；若 LO 不发起 open，关联的建立/入库不受影响，仅点击打开需另寻 seam。

Closes 部分 #79（功能债务清单；存量 wps 命名改名债不在本 PR 范围）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)