### PR TITLE
feat(settings): 装后随时可改 Key——工作台设置入口 + 向导可重跑

### DIFF
--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -1,7 +1,9 @@
 package com.checkba.controller;
 
 import com.checkba.controller.AdminConfigController.AdminConfigUpdateRequest;
+import com.checkba.model.entity.User;
 import com.checkba.repository.SystemSettingRepository;
+import com.checkba.repository.UserRepository;
 import com.checkba.service.SystemSettingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
@@ -13,13 +15,14 @@ import java.util.Map;
 
 /**
  * 首次运行向导接口（Epic #18 T3）：
- * - GET  /api/admin/wizard  查询是否已初始化（供前端决定是否进入向导）
- * - POST /api/admin/wizard  一次性写入初始配置（复用 AdminConfig 的 DTO 与 key 映射）
+ * - GET  /api/admin/wizard        查询是否已初始化（供前端决定是否进入向导）
+ * - POST /api/admin/wizard        一次性写入初始配置（复用 AdminConfig 的 DTO 与 key 映射）
+ * - POST /api/admin/wizard/reset  管理员重置向导（允许再走一遍——存量安装换 Key/换提供商的入口）
  *
- * 安全模型：仅在"未初始化"状态下可匿名调用。未初始化 = 向导未完成且
- * system_setting 表为空（从未通过管理后台或向导保存过任何配置）；
- * 满足任一条件即视为已初始化，POST 返回 409，后续配置修改一律走
- * /api/admin/config（需管理员会话）。
+ * 安全模型：仅在"未初始化"状态下可匿名调用。未初始化判定：
+ * completed 标记显式存在时以它为准（管理员 reset 后 = "false"，向导可重跑）；
+ * 标记不存在的存量部署退回 system_setting 非空兜底，防止向导端点被匿名滥用。
+ * 后续配置修改一律走 /api/admin/config（需管理员会话）。
  * 注意不能用"是否存在用户"判断：DataInitializer 启动时会自动创建默认 admin。
  */
 @RestController
@@ -30,13 +33,16 @@ public class WizardController {
 
     private final SystemSettingService systemSettingService;
     private final SystemSettingRepository systemSettingRepository;
+    private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
 
     public WizardController(SystemSettingService systemSettingService,
                             SystemSettingRepository systemSettingRepository,
+                            UserRepository userRepository,
                             ObjectMapper objectMapper) {
         this.systemSettingService = systemSettingService;
         this.systemSettingRepository = systemSettingRepository;
+        this.userRepository = userRepository;
         this.objectMapper = objectMapper;
     }
 
@@ -77,12 +83,45 @@ public class WizardController {
         return ResponseEntity.ok(ok);
     }
 
-    private boolean isInitialized() {
-        if (Boolean.parseBoolean(systemSettingService.get(KEY_WIZARD_COMPLETED, "false"))) {
-            return true;
+    /**
+     * 管理员重置向导：completed 置 "false"，之后向导页可再走一遍（提交成功
+     * 自动置回 "true"）。这是管理员主动开的窗口，与首次安装等价——期间
+     * POST /api/admin/wizard 恢复匿名可用，可接受。
+     */
+    @PostMapping("/reset")
+    public ResponseEntity<?> reset(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        User admin = requireAdmin(sessionId);
+        if (admin == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(error("仅管理员可重置向导 / Admin only"));
         }
-        // 保存过任何配置的存量部署视为已初始化，防止向导端点被匿名滥用
+        Map<String, String> updates = new HashMap<>();
+        updates.put(KEY_WIZARD_COMPLETED, "false");
+        systemSettingService.setMany(updates);
+
+        Map<String, Object> ok = new HashMap<>();
+        ok.put("code", 0);
+        ok.put("message", "向导已重置，可重新运行 / Wizard reset");
+        return ResponseEntity.ok(ok);
+    }
+
+    private boolean isInitialized() {
+        // completed 标记显式存在时以它为准（reset 后 = "false"，向导重新开放）；
+        // 标记不存在的存量部署退回"保存过任何配置即已初始化"兜底，防匿名滥用
+        String completed = systemSettingService.get(KEY_WIZARD_COMPLETED, null);
+        if (completed != null) {
+            return Boolean.parseBoolean(completed);
+        }
         return systemSettingRepository.count() > 0;
+    }
+
+    private User requireAdmin(String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) return null;
+        return userRepository.findById(userId)
+                .filter(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .orElse(null);
     }
 
     private Map<String, Object> error(String message) {

--- a/backend/src/test/java/com/checkba/controller/WizardControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/WizardControllerTest.java
@@ -1,0 +1,101 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.SystemSettingRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.SystemSettingService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定向导重置语义（存量安装换 Key 的入口）：
+ * - completed 标记显式存在时以它为准（reset 后 "false" → 向导重新开放，
+ *   即使 system_setting 非空）；
+ * - 标记不存在的存量部署仍按"保存过任何配置即已初始化"兜底（防匿名滥用）；
+ * - /reset 仅 admin 会话可调。
+ */
+@ExtendWith(MockitoExtension.class)
+class WizardControllerTest {
+
+    @Mock
+    private SystemSettingService systemSettingService;
+    @Mock
+    private SystemSettingRepository systemSettingRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private WizardController newController() {
+        return new WizardController(systemSettingService, systemSettingRepository,
+                userRepository, new ObjectMapper());
+    }
+
+    @Test
+    void statusReopensAfterReset_evenWithExistingSettings() {
+        // reset 后：标记显式为 "false"，settings 表非空也不再一票否决
+        when(systemSettingService.get(WizardController.KEY_WIZARD_COMPLETED, null)).thenReturn("false");
+
+        ResponseEntity<?> resp = newController().status();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertNotNull(body);
+        assertEquals(false, body.get("initialized"));
+        // 显式标记生效时不应再查兜底 count
+        verify(systemSettingRepository, never()).count();
+    }
+
+    @Test
+    void statusLegacyDeploymentWithoutFlagStaysInitialized() {
+        // 存量部署：无标记但保存过配置 → 视为已初始化（防向导端点匿名滥用）
+        when(systemSettingService.get(WizardController.KEY_WIZARD_COMPLETED, null)).thenReturn(null);
+        when(systemSettingRepository.count()).thenReturn(5L);
+
+        ResponseEntity<?> resp = newController().status();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertNotNull(body);
+        assertEquals(true, body.get("initialized"));
+    }
+
+    @Test
+    void resetRequiresAdminSession() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess-user")).thenReturn(2L);
+            User normal = new User();
+            normal.setUsername("alice");
+            when(userRepository.findById(2L)).thenReturn(Optional.of(normal));
+
+            ResponseEntity<?> resp = newController().reset("sess-user");
+            assertEquals(403, resp.getStatusCode().value());
+            verify(systemSettingService, never()).setMany(anyMap());
+        }
+    }
+
+    @Test
+    void resetByAdminMarksWizardNotCompleted() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess-admin")).thenReturn(1L);
+            User admin = new User();
+            admin.setUsername("admin");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
+
+            ResponseEntity<?> resp = newController().reset("sess-admin");
+            assertEquals(200, resp.getStatusCode().value());
+            verify(systemSettingService).setMany(
+                    argThat((Map<String, String> m) ->
+                            "false".equals(m.get(WizardController.KEY_WIZARD_COMPLETED))));
+        }
+    }
+}

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -24,6 +24,10 @@
             </view>
             
             <view class="nav-footer">
+                <view class="action-item" @tap="handleRerunWizard">
+                  <text class="action-text">重新运行首次向导</text>
+                  <text class="action-arrow">›</text>
+                </view>
                 <view class="action-item" @tap="goToUserProfile">
                   <text class="action-text">返回个人中心</text>
                   <text class="action-arrow">›</text>
@@ -548,7 +552,7 @@
 </template>
 
 <script>
-import { getAdminConfig, saveAdminConfig, getAdminUsers } from '@/services/api.js'
+import { getAdminConfig, saveAdminConfig, getAdminUsers, resetWizard } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
 
 export default {
@@ -719,6 +723,23 @@ export default {
     goToUserProfile() {
       uni.navigateTo({ url: '/pages/userprofile/userprofile' })
     },
+    // 重跑首次向导：重置 completed 标记后跳向导页。已有配置不清空，
+    // 向导提交时按新填内容覆盖对应 key。
+    handleRerunWizard() {
+      uni.showModal({
+        title: '重新运行首次向导',
+        content: '将重新打开首次运行向导（重新选择 AI 提供商并填写 Key）。现有配置不会被清空，向导提交后按新填内容覆盖。是否继续？',
+        success: async (r) => {
+          if (!r.confirm) return
+          try {
+            await resetWizard()
+            uni.reLaunch({ url: '/pages/wizard/wizard' })
+          } catch (e) {
+            uni.showToast({ title: (e && e.message) || '重置失败', icon: 'none' })
+          }
+        },
+      })
+    },
     onNavTap(nav) {
       // 带 route 的导航项跳转独立页面（如插件广场），其余切换本页内容区
       if (nav.route) {
@@ -782,7 +803,8 @@ export default {
         }
       } catch (e) {
         console.error('加载后台配置失败', e)
-        uni.showToast({ title: '加载配置失败', icon: 'none' })
+        // 403（非 admin 账号）时把后端原因带给用户：请用 admin 账号登录后配置
+        uni.showToast({ title: (e && e.message) || '加载配置失败', icon: 'none' })
       }
     },
     async loadUsers() {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -219,6 +219,17 @@
           />
         </view>
 
+        <!-- 系统设置：AI 提供商 / API Key 等随时可改（不再只藏在首次向导里）。
+             页面与接口仅管理员可用（后端 requireAdmin），入口对所有人可见便于发现。 -->
+        <view class="rail-btn" title="系统设置（AI 提供商 / API Key）" @tap="goToSystemSettings">
+          <view class="rail-icon-wrapper">
+            <svg class="rail-icon-svg" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="rail-icon-path" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="rail-icon-path" />
+            </svg>
+          </view>
+        </view>
+
         <!-- Project Members Stack -->
         <view class="rail-members-container" v-if="projectMembers && projectMembers.length > 0">
            <view class="members-stack-icon">
@@ -4362,6 +4373,9 @@ export default {
     },
     goToUserProfile() {
       uni.navigateTo({ url: '/pages/userprofile/userprofile' })
+    },
+    goToSystemSettings() {
+      uni.navigateTo({ url: '/pages/admin/admin' })
     },
     formatTime(timeStr) {
   if (!timeStr) return '-'

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -530,6 +530,14 @@ export function getWizardStatus() {
   });
 }
 
+// 重置首次运行向导（仅管理员）：completed 置 false，之后可重新走一遍向导
+export function resetWizard() {
+  return request({
+    url: '/api/admin/wizard/reset',
+    method: 'POST',
+  });
+}
+
 // 提交首次运行向导（仅未初始化时可调用，payload 结构同 saveAdminConfig）
 export function submitWizard(payload) {
   return request({


### PR DESCRIPTION
## 背景

维护者反馈：这台电脑之前装过（跳过 wizard），现在所有 AI 功能都测不了——**没有地方配置 Key**；且 wizard 应允许再走一遍。

排查结论：设置界面其实**完整存在**（admin.vue：AI 提供商切换、Gemini/OpenRouter Key、OCR、TTS、企查查、组件管理），但：
1. 唯一入口藏在「用户中心 → 系统设置 tab」，且仅 `admin` 账号显示——可发现性为零；
2. 向导 `initialized`（settings 表非空即算）一票否决，无法重跑。

## 改动

**入口显性化**
- 工作台左栏 Activity Bar 底部新增 ⚙️ 设置齿轮 → 直达系统管理页。入口常显，权限仍由后端 `requireAdmin` 把关；非 admin 进入时把「仅管理员可访问」原因透传成 toast（原来是笼统的"加载配置失败"）。

**向导可重跑**
- `POST /api/admin/wizard/reset`（admin 会话）：completed 置 `false`。
- `isInitialized` 语义修正：completed 标记**显式存在时以它为准**（reset 后向导重新开放）；标记不存在的存量部署仍按「保存过任何配置即已初始化」兜底——防匿名滥用的原防线不回退。
- admin.vue 侧栏新增「重新运行首次向导」：确认弹窗 → reset → reLaunch 向导页。现有配置不清空，向导提交按新填内容覆盖同名 key。

## 验证

- `WizardControllerTest` ×4 锁定语义：reset 后重开（且不再查兜底 count）/ 存量无标记仍视为已初始化 / 非 admin reset 403 / admin reset 写 `false` —— 全绿
- `mvn compile` + `test-compile`（JDK 21）绿；`npm run build:h5` 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)