### PR TITLE
fix(editor+auth): 链接点击真机失效换 seam + 本地安装全员管理员

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AdminConfigController.java
+++ b/backend/src/main/java/com/checkba/controller/AdminConfigController.java
@@ -35,16 +35,19 @@ public class AdminConfigController {
     private final SystemSettingService systemSettingService;
     private final UserRepository userRepository;
     private final AiModelProperties aiModelProperties;
+    private final com.checkba.service.AdminAccessService adminAccessService;
     private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AdminConfigController(SystemSettingService systemSettingService, 
-                                 UserRepository userRepository, 
-                                 AiModelProperties aiModelProperties, 
+    public AdminConfigController(SystemSettingService systemSettingService,
+                                 UserRepository userRepository,
+                                 AiModelProperties aiModelProperties,
+                                 com.checkba.service.AdminAccessService adminAccessService,
                                  com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
         this.systemSettingService = systemSettingService;
         this.userRepository = userRepository;
         this.aiModelProperties = aiModelProperties;
+        this.adminAccessService = adminAccessService;
         this.objectMapper = objectMapper;
     }
 
@@ -424,7 +427,7 @@ public class AdminConfigController {
             return null;
         }
         return userRepository.findById(userId)
-                .filter(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .filter(adminAccessService::isAdmin)
                 .orElse(null);
     }
 

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -17,6 +17,7 @@ public class AuthController {
 
     private final UserService userService;
     private final ClientInvitationService clientInvitationService;
+    private final com.checkba.service.AdminAccessService adminAccessService;
 
     // 简单的 session 存储（内存中，实际生产环境应使用 Redis 或 JWT）
     // 并发安全：登录写入与每请求读取/移除高频并发，普通 HashMap 扩容会损坏桶结构
@@ -25,10 +26,12 @@ public class AuthController {
 
     private static UserService staticUserService;
 
-    public AuthController(UserService userService, ClientInvitationService clientInvitationService) {
+    public AuthController(UserService userService, ClientInvitationService clientInvitationService,
+                          com.checkba.service.AdminAccessService adminAccessService) {
         this.userService = userService;
         this.clientInvitationService = clientInvitationService;
-        staticUserService = userService; 
+        this.adminAccessService = adminAccessService;
+        staticUserService = userService;
     }
 
     /**
@@ -176,7 +179,9 @@ public class AuthController {
                 "displayName", user.getDisplayName(),
                 "avatarUrl", user.getAvatarUrl() != null ? user.getAvatarUrl() : "",
                 "role", user.getRole(),
-                "subscriptionType", user.getSubscriptionType()
+                "subscriptionType", user.getSubscriptionType(),
+                // 系统管理权限（桌面单机=全员；云端=仅 admin 账号），前端据此显示「系统设置」入口
+                "isAdmin", adminAccessService.isAdmin(user)
         ));
         return result;
     }

--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -34,15 +34,18 @@ public class WizardController {
     private final SystemSettingService systemSettingService;
     private final SystemSettingRepository systemSettingRepository;
     private final UserRepository userRepository;
+    private final com.checkba.service.AdminAccessService adminAccessService;
     private final ObjectMapper objectMapper;
 
     public WizardController(SystemSettingService systemSettingService,
                             SystemSettingRepository systemSettingRepository,
                             UserRepository userRepository,
+                            com.checkba.service.AdminAccessService adminAccessService,
                             ObjectMapper objectMapper) {
         this.systemSettingService = systemSettingService;
         this.systemSettingRepository = systemSettingRepository;
         this.userRepository = userRepository;
+        this.adminAccessService = adminAccessService;
         this.objectMapper = objectMapper;
     }
 
@@ -120,7 +123,7 @@ public class WizardController {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) return null;
         return userRepository.findById(userId)
-                .filter(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .filter(adminAccessService::isAdmin)
                 .orElse(null);
     }
 

--- a/backend/src/main/java/com/checkba/service/AdminAccessService.java
+++ b/backend/src/main/java/com/checkba/service/AdminAccessService.java
@@ -1,0 +1,27 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 管理员判定的唯一出口（AdminConfig / Wizard / auth "me" 共用）。
+ *
+ * 两种模式：
+ * - 云端/多人部署（默认）：仅用户名为 admin 的账号是管理员；
+ * - 桌面/单机（desktop profile 置 security.admin.allow-all-users=true）：
+ *   所有登录用户都是管理员——本地安装是单人产品，新注册的账号也要能
+ *   进「系统管理」配 AI Key，不该被锁在默认 admin 账号外。
+ */
+@Service
+public class AdminAccessService {
+
+    @Value("${security.admin.allow-all-users:false}")
+    private boolean allowAllUsers;
+
+    public boolean isAdmin(User user) {
+        if (user == null) return false;
+        if (allowAllUsers) return true;
+        return "admin".equalsIgnoreCase(user.getUsername());
+    }
+}

--- a/backend/src/main/resources/application-desktop.yml
+++ b/backend/src/main/resources/application-desktop.yml
@@ -20,3 +20,9 @@ spring:
       ddl-auto: update
     show-sql: false
     database-platform: org.hibernate.dialect.H2Dialect
+
+# 桌面/单机：所有登录用户都是管理员（系统管理/向导重置对全员开放）。
+# 云端多人部署不设此项（默认 false，仅 admin 账号）。
+security:
+  admin:
+    allow-all-users: true

--- a/backend/src/test/java/com/checkba/controller/WizardControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/WizardControllerTest.java
@@ -3,6 +3,7 @@ package com.checkba.controller;
 import com.checkba.model.entity.User;
 import com.checkba.repository.SystemSettingRepository;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
 import com.checkba.service.SystemSettingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -36,10 +37,12 @@ class WizardControllerTest {
     private SystemSettingRepository systemSettingRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private AdminAccessService adminAccessService;
 
     private WizardController newController() {
         return new WizardController(systemSettingService, systemSettingRepository,
-                userRepository, new ObjectMapper());
+                userRepository, adminAccessService, new ObjectMapper());
     }
 
     @Test
@@ -76,6 +79,7 @@ class WizardControllerTest {
             User normal = new User();
             normal.setUsername("alice");
             when(userRepository.findById(2L)).thenReturn(Optional.of(normal));
+            when(adminAccessService.isAdmin(normal)).thenReturn(false);
 
             ResponseEntity<?> resp = newController().reset("sess-user");
             assertEquals(403, resp.getStatusCode().value());
@@ -90,6 +94,7 @@ class WizardControllerTest {
             User admin = new User();
             admin.setUsername("admin");
             when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
+            when(adminAccessService.isAdmin(admin)).thenReturn(true);
 
             ResponseEntity<?> resp = newController().reset("sess-admin");
             assertEquals(200, resp.getStatusCode().value());

--- a/backend/src/test/java/com/checkba/service/AdminAccessServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/AdminAccessServiceTest.java
@@ -1,0 +1,44 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 锁定管理员判定的两种模式：
+ * - 默认（云端多人）：仅用户名 admin；
+ * - 桌面单机（security.admin.allow-all-users=true）：所有登录用户都是管理员。
+ */
+class AdminAccessServiceTest {
+
+    private AdminAccessService withFlag(boolean allowAllUsers) {
+        AdminAccessService svc = new AdminAccessService();
+        ReflectionTestUtils.setField(svc, "allowAllUsers", allowAllUsers);
+        return svc;
+    }
+
+    private User user(String name) {
+        User u = new User();
+        u.setUsername(name);
+        return u;
+    }
+
+    @Test
+    void cloudDefaultOnlyAdminUsername() {
+        AdminAccessService svc = withFlag(false);
+        assertTrue(svc.isAdmin(user("admin")));
+        assertTrue(svc.isAdmin(user("Admin"))); // 大小写不敏感（沿用原语义）
+        assertFalse(svc.isAdmin(user("alice")));
+        assertFalse(svc.isAdmin(null));
+    }
+
+    @Test
+    void desktopAllUsersAreAdmins() {
+        AdminAccessService svc = withFlag(true);
+        assertTrue(svc.isAdmin(user("alice")));
+        assertTrue(svc.isAdmin(user("admin")));
+        assertFalse(svc.isAdmin(null)); // 未登录仍然不是
+    }
+}

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -47,6 +47,9 @@ export const EDITOR_ACTIONS = [
   // (insert_link_with_bookmark)、图片插入 (insert_image)。Host-initiated
   // (drag-association / evidence-drop / OCR image), not AI-agent commands.
   'get_selection_hyperlink', 'set_selection_hyperlink', 'insert_link_with_bookmark', 'insert_image',
+  // [#79 click-to-open] LO WASM 不触发 window.open（v0.7.1 真机证实）：编辑器页
+  // 监听 canvas 点击后经此原语读取光标处链接再转发宿主。
+  'get_hyperlink_at_cursor',
 ]
 
 /**

--- a/frontend/src/pages/userprofile/userprofile.vue
+++ b/frontend/src/pages/userprofile/userprofile.vue
@@ -618,7 +618,9 @@ export default {
       }
     },
     checkAdminTab() {
-        if (this.userInfo && this.userInfo.username === 'admin') {
+        // isAdmin 由 /api/auth/me 下发（桌面单机=全员管理员；云端=仅 admin 账号）；
+        // username==='admin' 兜底兼容缓存的旧 userInfo（无 isAdmin 字段）
+        if (this.userInfo && (this.userInfo.isAdmin === true || this.userInfo.username === 'admin')) {
             const hasAdminTab = this.tabs.find(t => t.key === 'system_admin')
             if (!hasAdminTab) {
                 // Insert before 'settings' or at the end

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -176,6 +176,38 @@ startEditorEndpoint({
   onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
 }).then((endpoint) => {
   console.log('[zeta-editor] endpoint ready — serving host over transport')
+  // (#79 click-to-open) LO WASM never calls window.open on hyperlink clicks
+  // (real-machine verified on v0.7.1) — the hook above only covers hypothetical
+  // engine-initiated opens. The working seam: a plain positioning click moves
+  // the LO cursor; ask the worker what link the cursor landed in and forward it.
+  // Guards: primary button only, no drag-selection (>5px move), 800ms cooldown,
+  // and the worker returns '' for non-collapsed cursors (double-click selection).
+  try {
+    const canvas = document.getElementById('qtcanvas')
+    let downAt = null
+    let lastOpen = 0
+    canvas.addEventListener('mousedown', (ev) => {
+      downAt = ev.button === 0 ? { x: ev.clientX, y: ev.clientY } : null
+    }, true)
+    canvas.addEventListener('mouseup', (ev) => {
+      const d = downAt
+      downAt = null
+      if (!d || ev.button !== 0 || ev.shiftKey) return
+      if (Math.abs(ev.clientX - d.x) > 5 || Math.abs(ev.clientY - d.y) > 5) return // drag-selection
+      // let Qt process the click and move the LO cursor first
+      setTimeout(async () => {
+        try {
+          const r = await endpoint.executor.executeCommand('get_hyperlink_at_cursor', {})
+          if (r && r.success && r.url) {
+            const now = Date.now()
+            if (now - lastOpen < 800) return
+            lastOpen = now
+            hostTransport.send({ __lo: 'lo-relay', type: 'open-url', url: String(r.url) })
+          }
+        } catch (e) { /* ignore */ }
+      }, 150)
+    }, true)
+  } catch (e) { console.error('[zeta-editor] link-click seam failed:', e) }
   // Tell the host the office endpoint is booted and serving (serveExecutor is now
   // subscribed). The host (createRelayExecutor onReady) waits for this before
   // pushing load_document — sending it earlier would drop it (no subscriber yet,

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -1025,6 +1025,33 @@ const EXEC = {
     try { vc.gotoRange(cur.getEnd(), false); } catch (e) {}
     return Object.assign({ success: true, bookmarkName: name, text: text, url: url }, verifySnapshot());
   },
+  // read the hyperlink URL at the (collapsed) view cursor — the click-to-open
+  // seam: LO WASM does NOT surface hyperlink activation (no window.open, real-
+  // machine verified on v0.7.1), so the editor page listens for canvas clicks
+  // and asks the worker what link the cursor landed in. Non-collapsed cursor
+  // (drag-selection / double-click) returns '' on purpose — only a plain
+  // positioning click opens a link.
+  get_hyperlink_at_cursor() {
+    const vc = ctrl.getViewCursor();
+    try { if ((vc.getString() || '').length > 0) return { success: true, url: '' }; } catch (e) {}
+    let url = '';
+    try {
+      const v = vc.getPropertyValue('HyperLinkURL');
+      if (typeof v === 'string') url = v;
+    } catch (e) {}
+    if (!url) {
+      // cursor may sit at the run boundary: peek one char to the right
+      try {
+        const xText = vc.getText();
+        const cur = xText.createTextCursorByRange(vc.getStart());
+        if (cur.goRight(1, true)) {
+          const v2 = cur.getPropertyValue('HyperLinkURL');
+          if (typeof v2 === 'string') url = v2;
+        }
+      } catch (e) {}
+    }
+    return { success: true, url: url };
+  },
   // insert an image (data URL / raw base64) at the view cursor — the WPS-era
   // insertImage. Bytes go JS→UNO through SequenceInputStream (same signed-Array
   // marshalling as load_document), GraphicProvider decodes, TextGraphicObject


### PR DESCRIPTION
## 问题一：文档内点击关联链接完全没反应（真机反馈）

v0.7.1 的 click-to-open 走的是"LO 触发 window.open → 转发宿主"假设，真机证实 **LO WASM 点击超链接根本不调 window.open**。换成主动探测 seam：

1. worker 新增 `get_hyperlink_at_cursor` 原语：读光标落点处的 HyperLinkURL；**选区非空一律返回空**（双击选词/拖选不误开）；光标在链接边界时向右窥探一字符。
2. 编辑器页监听 canvas 点击（仅左键、位移 >5px 视为拖选跳过、800ms 冷却），点击后 150ms 等 Qt 移完光标 → 查询原语 → 命中即经 lo-relay `open-url` 转发宿主。宿主路由（PR#133 已就位）解包内部链接 → 打开关联文件 / 网核定位。

**无头端到端验证全绿**（真实自建引擎）：选区守卫 ✓、光标命中返回 URL ✓、合成 canvas 点击 → 转发的 URL 与写入文档的包装链接一致 ✓。

## 问题二：本地安装只有一个 admin，新注册用户配不了 Key

- 新增 `AdminAccessService` 统一管理员判定：**desktop profile（`security.admin.allow-all-users=true`）下所有登录用户都是管理员**——单机产品，新注册账号同样能进「系统管理」配 Key、重跑向导；云端多人部署默认不变（仅 admin 账号）。
- `AdminConfigController` / `WizardController` 的 requireAdmin 收敛到该服务；`/api/auth/me` 下发 `isAdmin`，用户中心「系统设置」tab 据此显示（老缓存无该字段时按 username==='admin' 兜底）。
- 注册入口本来就在登录页「注册」tab，无需注册时选身份——本地装完谁注册谁就是管理员。

## 验证

- `mvn test`：AdminAccessServiceTest ×2 + WizardControllerTest ×4 全绿（JDK 21）
- `build:h5` + `build:zetaoffice` 绿；puppeteer 无头驱动真实引擎端到端绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)