### PR TITLE
chore: bump 0.7.2——链接点击修复 + 本地全员管理员发版

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
v0.7.2 发版 bump：

- **链接点击可用**（PR#136）：v0.7.1 真机反馈点击关联链接无反应——LO WASM 不触发 window.open，改为 canvas 点击 + 光标超链接探测 seam，无头端到端已验证
- **本地全员管理员**（PR#136）：desktop profile 下所有登录用户都是管理员，新注册账号同样能进「系统管理」配 AI Key / 重跑向导

🤖 Generated with [Claude Code](https://claude.com/claude-code)