### PR TITLE
docs+deploy: 鸿蒙(HarmonyOS PC)路线定稿 + Web部署配置 + 浏览器能力探针

### DIFF
--- a/deploy/web/README.md
+++ b/deploy/web/README.md
@@ -1,0 +1,45 @@
+# Web 服务器版部署（Phase A2）
+
+背景与整体规划见 [docs/HARMONYOS_PLAN.md](../../docs/HARMONYOS_PLAN.md)。
+这是「瘦客户端」的服务端形态：鸿蒙电脑（或任何设备）用浏览器访问；
+后续的鸿蒙 Electron 壳（Phase B）也连同一个后端。
+
+> 当前限制：LibreOffice 编辑器在纯浏览器里的通道（A1，iframe bridge）尚未实现，
+> 落地前编辑器功能在 Web 版不可用，其余功能（项目/文件/AI 编排/解析/TTS）不受影响。
+
+## 构建产物
+
+```bash
+cd frontend && npm run build:h5 && npm run build:zetaoffice
+node desktop/scripts/fetch-lowa-assets.js   # LOWA 运行时 + CJK 字体（落到 frontend/dist/zetaoffice/lowa/）
+mvn -B -DskipTests -f backend/pom.xml package
+```
+
+## 服务器布局
+
+```
+/opt/aiworkdeck/web/            <- frontend/dist/build/h5/*
+/opt/aiworkdeck/web/zetaoffice/ <- frontend/dist/zetaoffice/*
+/opt/aiworkdeck/web/probe/      <- deploy/web/probe/*（可选，浏览器能力探针）
+后端 jar：java -jar backend.jar --spring.profiles.active=prod   # :9696，只监听 127.0.0.1
+Python 服务：docker compose up（仅内网端口，由后端编排，不对外暴露）
+```
+
+nginx 用 [nginx.conf.example](nginx.conf.example)，改域名和证书即可。
+前端构建时无需设置 `VITE_API_BASE_URL`（默认同源，nginx 反代 `/api/`）。
+
+## 鸿蒙浏览器能力探针（probe/）
+
+判断鸿蒙设备浏览器能否跑 LOWA，只需打开 `https://<域名>/probe/` 看四项是否全绿：
+crossOriginIsolated、SharedArrayBuffer、共享 WASM Memory、Worker 传递 SAB。
+
+- 探针页自带 COI service worker 兜底（`coi-sw.js`）：即使托管方加不了 COOP/COEP 头
+  （如对象存储/静态托管），首次加载注册 SW 后自动刷新一次也能得出结论。
+  正式部署走 nginx 头方案，SW 只是探针的便携兜底。
+- 没有真机：华为体验店现场打开 10 分钟测完，或 DevEco Studio 鸿蒙 PC 模拟器。
+
+## 安全底线
+
+- Python 服务端口（8001/5001 等）绝不对公网开放，只走 127.0.0.1/内网。
+- 后端 9696 只监听本机，由 nginx 统一入口 + TLS。
+- 管理页 `/api/admin` 依赖登录态（requireAdmin），公网部署务必改默认口令。

--- a/deploy/web/nginx.conf.example
+++ b/deploy/web/nginx.conf.example
@@ -1,0 +1,69 @@
+# AI Workdeck Web 服务器版 nginx 配置（Phase A2，见 docs/HARMONYOS_PLAN.md）
+#
+# 三个关键点，缺一个编辑器就起不来：
+# 1) 全站 COOP/COEP —— LOWA 需要 SharedArrayBuffer，crossOriginIsolated 只能来自
+#    响应头（zetaOfficeBoot.js 会检查并报错）。副作用：页面里所有跨域子资源
+#    （图片/脚本）必须带 CORS/CORP，因此 LOWA 与字体一律同源部署，不走 CDN。
+# 2) /lowa/ 预压缩 brotli 回放 —— fetch-lowa-assets.js 落盘的 soffice.wasm/.data
+#    是 CDN 原样的 brotli 字节（省 2/3 体积），必须回放 Content-Encoding: br。
+#    自建引擎若是 identity（看 lowa/.encodings.json），删掉对应 location 即可。
+# 3) /api/ 反代 + SSE 不缓冲 —— AI 编排器事件流是 SSE，nginx 默认缓冲会卡流。
+#
+# 部署布局（root 目录下）：
+#   /opt/aiworkdeck/web/            <- frontend/dist/build/h5 的内容
+#   /opt/aiworkdeck/web/zetaoffice/ <- frontend/dist/zetaoffice（含 lowa/ 与 cjk.ttc）
+#   /opt/aiworkdeck/web/probe/      <- deploy/web/probe（鸿蒙浏览器能力探针，可选）
+#
+# nginx 坑：location 里出现任意 add_header 会丢弃上层继承的 add_header，
+# 所以下面每个带 add_header 的 location 都必须重复 COOP/COEP 两行。
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name app.example.com;   # 改成你的域名
+    # ssl_certificate     /etc/nginx/ssl/fullchain.pem;
+    # ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    root /opt/aiworkdeck/web;
+    index index.html;
+
+    # ---- 跨域隔离（SharedArrayBuffer 前提）----
+    add_header Cross-Origin-Opener-Policy   same-origin  always;
+    add_header Cross-Origin-Embedder-Policy require-corp always;
+
+    # ---- 后端 API（Spring Boot :9696，全部路由在 /api/ 下）----
+    location /api/ {
+        proxy_pass http://127.0.0.1:9696;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # SSE（AI 编排器事件流）：关缓冲、放长超时
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        # 大文件上传（文档解析）
+        client_max_body_size 200m;
+    }
+
+    # ---- LOWA 运行时：brotli 预压缩文件按原编码回放 ----
+    # 若 lowa/.encodings.json 里对应文件不是 "br"（自建引擎 identity），删掉该 location。
+    location = /zetaoffice/lowa/soffice.wasm {
+        add_header Cross-Origin-Opener-Policy   same-origin  always;
+        add_header Cross-Origin-Embedder-Policy require-corp always;
+        add_header Content-Encoding br always;
+        types { } default_type application/wasm;
+    }
+    location = /zetaoffice/lowa/soffice.data {
+        add_header Cross-Origin-Opener-Policy   same-origin  always;
+        add_header Cross-Origin-Embedder-Policy require-corp always;
+        add_header Content-Encoding br always;
+        types { } default_type application/octet-stream;
+    }
+
+    # ---- SPA 回退 ----
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/web/probe/coi-sw.js
+++ b/deploy/web/probe/coi-sw.js
@@ -1,0 +1,18 @@
+// COI service worker：给静态托管（加不了响应头的场景）兜底注入 COOP/COEP，
+// 让探针页拿到 crossOriginIsolated。仅探针使用；正式部署用 nginx 头。
+// 思路同社区通用的 coi-serviceworker（MIT）。
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.cache === 'only-if-cached' && req.mode !== 'same-origin') return;
+  event.respondWith(
+    fetch(req).then((res) => {
+      if (res.status === 0) return res;
+      const headers = new Headers(res.headers);
+      headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+      headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+      return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+    }).catch(() => fetch(req))
+  );
+});

--- a/deploy/web/probe/index.html
+++ b/deploy/web/probe/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LOWA 浏览器能力探针 · AI Workdeck</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 640px; margin: 40px auto; padding: 0 16px; }
+  h1 { font-size: 20px; }
+  .item { display: flex; justify-content: space-between; padding: 10px 12px; border-bottom: 1px solid #eee; }
+  .ok { color: #0a7d32; font-weight: 600; }
+  .fail { color: #c0392b; font-weight: 600; }
+  .verdict { margin-top: 20px; padding: 14px; border-radius: 8px; font-weight: 600; }
+  .verdict.ok { background: #e8f7ee; }
+  .verdict.fail { background: #fdecea; }
+  small { color: #888; word-break: break-all; }
+</style>
+</head>
+<body>
+<h1>LOWA（LibreOffice WASM）浏览器能力探针</h1>
+<p>在鸿蒙电脑/平板浏览器打开本页。四项全绿 = 该浏览器能跑 AI Workdeck 的嵌入式编辑器。</p>
+<div id="list"></div>
+<div id="verdict" class="verdict">检测中…</div>
+<p><small id="ua"></small></p>
+<script>
+// COI service worker 兜底：托管方加不了 COOP/COEP 头时，注册 SW 改写响应头后
+// 刷新一次即可获得 crossOriginIsolated。正式部署应直接用 nginx 头（见 ../README.md）。
+(async function () {
+  if (!window.crossOriginIsolated && 'serviceWorker' in navigator && !sessionStorage.getItem('coiReloaded')) {
+    try {
+      const reg = await navigator.serviceWorker.register('coi-sw.js');
+      await navigator.serviceWorker.ready;
+      if (reg.active && !navigator.serviceWorker.controller) {
+        sessionStorage.setItem('coiReloaded', '1');
+        location.reload();
+        return;
+      }
+      if (navigator.serviceWorker.controller) {
+        sessionStorage.setItem('coiReloaded', '1');
+        location.reload();
+        return;
+      }
+    } catch (e) { /* SW 不可用，直接按现状检测 */ }
+  }
+  runChecks();
+})();
+
+function runChecks() {
+  const checks = [];
+  checks.push(['crossOriginIsolated（COOP/COEP 生效）', !!window.crossOriginIsolated]);
+  checks.push(['SharedArrayBuffer 可用', typeof SharedArrayBuffer !== 'undefined']);
+  let sharedMem = false;
+  try { new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true }); sharedMem = true; } catch (e) {}
+  checks.push(['共享 WASM Memory（线程前提）', sharedMem]);
+
+  // Worker 传递 SAB：LOWA 是多 pthread，主线程与 worker 必须能共享内存
+  const workerTest = new Promise((resolve) => {
+    if (typeof SharedArrayBuffer === 'undefined') return resolve(false);
+    try {
+      const blob = new Blob(["onmessage=function(e){postMessage(e.data instanceof SharedArrayBuffer)}"], { type: 'text/javascript' });
+      const w = new Worker(URL.createObjectURL(blob));
+      const t = setTimeout(() => { w.terminate(); resolve(false); }, 3000);
+      w.onmessage = (e) => { clearTimeout(t); w.terminate(); resolve(!!e.data); };
+      w.postMessage(new SharedArrayBuffer(8));
+    } catch (e) { resolve(false); }
+  });
+
+  workerTest.then((workerOk) => {
+    checks.push(['Worker 间传递 SharedArrayBuffer', workerOk]);
+    const list = document.getElementById('list');
+    list.innerHTML = '';
+    let allOk = true;
+    for (const [name, ok] of checks) {
+      allOk = allOk && ok;
+      const div = document.createElement('div');
+      div.className = 'item';
+      div.innerHTML = '<span>' + name + '</span><span class="' + (ok ? 'ok' : 'fail') + '">' + (ok ? '✅ 通过' : '❌ 不支持') + '</span>';
+      list.appendChild(div);
+    }
+    const v = document.getElementById('verdict');
+    v.className = 'verdict ' + (allOk ? 'ok' : 'fail');
+    v.textContent = allOk
+      ? '✅ 结论：该浏览器具备运行 LOWA 编辑器的全部前提。'
+      : '❌ 结论：缺少必要能力，LOWA 编辑器无法在此浏览器运行（其余功能不受影响）。';
+    document.getElementById('ua').textContent = navigator.userAgent;
+  });
+}
+</script>
+</body>
+</html>

--- a/docs/HARMONYOS_PLAN.md
+++ b/docs/HARMONYOS_PLAN.md
@@ -1,0 +1,68 @@
+# 鸿蒙（HarmonyOS PC）版本规划
+
+> 2026-07-13 定稿。目标：release 三件套 —— Windows exe、mac Apple Silicon dmg、鸿蒙可安装包（HAP/App）。
+
+## 一、结论先行
+
+鸿蒙 NEXT（鸿蒙电脑 = HarmonyOS 5/6，麒麟 ARM）**没有 Linux 兼容层、没有 JVM、没有 Python/PyTorch 生态**。
+现有桌面版三层架构在鸿蒙上的命运：
+
+| 现有组件 | 鸿蒙上的命运 |
+|---|---|
+| Electron 前端壳（含 LOWA 编辑器） | ✅ 可跑 —— OpenHarmony SIG 官方移植（[openharmony-sig/electron](https://gitcode.com/openharmony-sig/electron)，Electron 34，预编译 `libelectron.so`）。WPS 鸿蒙 PC 版即此路线 |
+| Spring Boot 后端 + 裁剪 JRE | ❌ 无任何 JVM 发行版支持鸿蒙 NEXT |
+| Python 三服务（MinerU / pptx / Kokoro） | ❌ 无鸿蒙 Python + torch 轮子 |
+
+**因此鸿蒙版必然是瘦客户端**：界面在本机，后端在远端 ——
+用户自己的 ECS，或局域网里一台跑桌面版的 Windows/mac 主机（数据不出内网）。
+
+## 二、路线：A → B 分步走
+
+### Phase A：Web 服务器版（鸿蒙浏览器可用，也是 B 的技术前提）
+
+前端已是 uni-app H5 + `VITE_API_BASE_URL`（默认同源），后端全部路由在 `/api/` 下，
+`application-prod.yml` / docker-compose 已备 —— 服务器化地基现成。缺两块：
+
+1. **A1 · H5 编辑器通道**（核心工程点）：编辑器目前是 Electron `<webview>` 专属
+   （`LibreOfficeEditor.vue` 依赖 `window.checkbaDesktop.zetaoffice`）。
+   纯浏览器需要 iframe + MessageChannel 走同一套 editor bridge/executor 协议。
+   LOWA 在普通浏览器里跑的可行性早已由 `experiments/zetaoffice-spike/`（serve.mjs + COOP/COEP）证明，
+   剩下的是产品化。
+2. **A2 · 部署配置**（本次已落）：`deploy/web/` —— nginx 配置
+   （全站 COOP/COEP、`/lowa/*` brotli 预压缩回放、`/api` 反代 + SSE 不缓冲）+ 部署 README
+   + 鸿蒙浏览器能力探针页（`deploy/web/probe/`，验证 crossOriginIsolated / SharedArrayBuffer / WASM threads）。
+
+**验证**：探针页在鸿蒙电脑浏览器全绿 → LOWA 必然能跑（同为 Chromium 内核 ArkWeb）。
+无真机时可去华为体验店 10 分钟测完，或先在 DevEco 鸿蒙 PC 模拟器里测。
+
+### Phase B：鸿蒙 Electron 壳（正式可安装形态）
+
+用 openharmony-sig/electron 打包现有前端 + 主进程（`zetaoffice-server.js` 等大部分可复用），
+砍掉 JVM/Python 拉起逻辑，改为「连接远端后端」设置页（复用向导）。产出 HAP/App。
+
+前置条件（用户侧）：
+- 华为开发者账号（个人实名免费；上架 AppGallery 建议企业认证 + 软著）
+- 鸿蒙电脑真机（MateBook Pro 约 ¥7,999 起）或先用 DevEco 模拟器
+- 侧载调试：普通账号调试证书 14 天有效期，适合开发期；正式分发走 AppGallery
+
+### Phase C（backlog）：uni-app harmony 原生编译
+
+`package.json` 已带 `@dcloudio/uni-app-harmony` / `build:mp-harmony`。可编译 ArkTS 原生应用，
+顺带覆盖鸿蒙手机/平板；但 PC 窗口形态与 LOWA 嵌 ArkWeb 的跨域隔离风险最高，不作为 PC 首选。
+
+## 三、风险表
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| 华为浏览器/ArkWeb 对 SharedArrayBuffer 的真机支持 | 中 | 探针页 10 分钟验证；ohos Electron 自带 Chromium，不受影响 |
+| ohos Electron 对 Node API（如 child_process）的裁剪边界 | 低 | 鸿蒙壳不需要拉子进程（后端在远端） |
+| 签名/上架资质（软著、企业认证）周期 | 中 | 开发期侧载 + 模拟器并行，资质提前申请 |
+| uni-app H5 编辑器 bridge 协议在 iframe 下的差异 | 中 | A1 单独 issue，spike 先行 |
+
+## 四、预算（截至 2026-07，下单前请核对）
+
+| 项目 | 费用 |
+|---|---|
+| 华为开发者账号（个人/企业认证） | 免费 |
+| 软著（上架用） | 自办免费（2-3 个月）/ 代办加急约 ¥300-800 |
+| 鸿蒙电脑真机 | 约 ¥7,999（MateBook Pro 低配）；验证阶段可先模拟器/体验店，¥0 |


### PR DESCRIPTION
## 背景

用户目标：release 支持 Windows / mac Apple Silicon / 鸿蒙电脑三件套。

## 结论（详见 docs/HARMONYOS_PLAN.md）

鸿蒙 NEXT 无 JVM、无 Python/torch 生态 → 鸿蒙版必然是**瘦客户端**（界面本机、后端在 ECS 或局域网主机）。前端壳可行：openharmony-sig/electron（WPS 鸿蒙 PC 版同款路线）；前端本身已是 uni-app，`@dcloudio/uni-app-harmony` 依赖已就位。

## 本 PR 内容（Phase A2）

- `docs/HARMONYOS_PLAN.md`：可行性结论、A→B→C 三阶段路线、风险表、预算
- `deploy/web/nginx.conf.example`：全站 COOP/COEP（SAB 前提）+ `/lowa` brotli 预压缩回放 + `/api` 反代（SSE 不缓冲）
- `deploy/web/probe/`：鸿蒙浏览器能力探针页（crossOriginIsolated / SAB / 共享 WASM Memory / Worker 传 SAB），自带 COI service worker 兜底，可托管在任意静态服务上，去华为体验店 10 分钟即可验证真机

## 验证

探针页已本机无头浏览器端到端验证：裸 `python3 -m http.server`（无 COOP/COEP 头）场景下，SW 注册 → 自动刷新 → 四项全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)