### PR TITLE
fix(desktop): Kokoro 大陆下载 401（禁用 hf_xet）+ 组件下载整体进度条

### DIFF
--- a/desktop/main/services/model-manager.js
+++ b/desktop/main/services/model-manager.js
@@ -13,7 +13,26 @@ const { spawn } = require('child_process')
  */
 
 const MARKER = '.aiworkdeck-complete'
-const PROGRESS_THROTTLE_MS = 500
+const PROGRESS_POLL_MS = 1000
+
+// 目标目录累计字节数（含子目录）：整体进度 = 已落盘字节 / estBytes。
+// 下载器的 stdout 百分比是"当前单个文件"的 tqdm（MinerU 十几个模型文件会
+// 反复 0→100%，真机反馈以为下载重跑了），不能当整体进度用。
+function dirSize(root) {
+  let total = 0
+  const stack = [root]
+  while (stack.length) {
+    const cur = stack.pop()
+    let entries
+    try { entries = fs.readdirSync(cur, { withFileTypes: true }) } catch (e) { continue }
+    for (const en of entries) {
+      const fp = path.join(cur, en.name)
+      if (en.isDirectory()) stack.push(fp)
+      else if (en.isFile()) { try { total += fs.statSync(fp).size } catch (e) { /* 下载器可能正在改名/删除 */ } }
+    }
+  }
+  return total
+}
 
 function mineruLib(resourcesPath) {
   return path.join(resourcesPath || '', 'pysvc', 'mineru-service', 'lib')
@@ -31,6 +50,7 @@ const COMPONENTS = [
     id: 'mineru-models',
     name: '文档解析模型（MinerU）',
     sizeHint: '约 3GB',
+    estBytes: 3.0 * 1024 * 1024 * 1024, // 整体进度分母（估计值，进度封顶 99% 直到进程成功退出）
     // 模型根目录（相对 dataDir）
     dir: (ctx) => path.join(ctx.dataDir, 'models', 'mineru'),
     // 官方下载 CLI（前置校证 P1/P2，见 phase2 计划）
@@ -58,6 +78,7 @@ const COMPONENTS = [
     id: 'kokoro-models',
     name: '语音合成模型（Kokoro）',
     sizeHint: '约 300MB',
+    estBytes: 300 * 1024 * 1024,
     dir: (ctx) => path.join(ctx.dataDir, 'models', 'kokoro'),
     // huggingface_hub snapshot（走国内镜像，env 可覆盖）；运行侧 HF_HOME 与此一致
     spawnSpec: (ctx) => {
@@ -72,7 +93,11 @@ const COMPONENTS = [
           ...process.env,
           PYTHONPATH: path.join(ctx.resourcesPath || '', 'pysvc', 'kokoro-service', 'lib'),
           HF_HOME: dir,
-          HF_ENDPOINT: process.env.CHECKBA_HF_ENDPOINT || 'https://hf-mirror.com'
+          HF_ENDPOINT: process.env.CHECKBA_HF_ENDPOINT || 'https://hf-mirror.com',
+          // 打包内带 hf_xet：Xet 路径绕过 HF_ENDPOINT 直连 HF 官方 CAS
+          // (cas-server.xethub.hf.co)，镜像签发的凭证在那边必 401——大陆用户
+          // 无梯子即挂。禁用 xet 走镜像的普通 HTTP 下载（真机 401 实证）。
+          HF_HUB_DISABLE_XET: '1'
         },
         cwd: dir
       }
@@ -89,6 +114,7 @@ class ModelManager {
     }
     this.onProgress = opts.onProgress || (() => {})
     this.spawnSpecOverride = opts.spawnSpecOverride || null
+    this.progressPollMs = opts.progressPollMs || PROGRESS_POLL_MS
     this.active = new Map() // id -> child process
     this.errors = new Map() // id -> last error message
   }
@@ -136,21 +162,18 @@ class ModelManager {
     const child = spawn(spec.cmd, spec.args, { cwd: spec.cwd, env: spec.env, stdio: ['ignore', 'pipe', 'pipe'] })
     this.active.set(id, child)
 
-    let lastEmit = 0
+    // stdout/stderr 只取"最近一行"当状态文案；百分比不再取自下载器输出——
+    // 那是单个文件的 tqdm，十几个模型文件会反复 0→100%（真机反馈"下载完又
+    // 从 0 开始"）。整体进度 = 已落盘字节 / estBytes，按固定间隔轮询目录。
     let lastLine = ''
-    const onLine = (line) => {
-      lastLine = line
-      const m = line.match(/(\d{1,3})%/)
-      const now = Date.now()
-      if (now - lastEmit < PROGRESS_THROTTLE_MS) return
-      lastEmit = now
-      this.onProgress({
-        id,
-        phase: 'progress',
-        percent: m ? Math.min(100, Number(m[1])) : undefined,
-        message: line.slice(0, 200)
-      })
-    }
+    const onLine = (line) => { lastLine = line }
+    const estBytes = c.estBytes || 0
+    const poller = setInterval(() => {
+      const percent = estBytes > 0
+        ? Math.min(99, Math.round(dirSize(dir) / estBytes * 100)) // 封顶 99，成功退出才是 done
+        : undefined
+      this.onProgress({ id, phase: 'progress', percent, message: lastLine.slice(0, 200) })
+    }, this.progressPollMs)
     const hook = (stream) => {
       let buf = ''
       stream.on('data', (d) => {
@@ -165,6 +188,7 @@ class ModelManager {
     hook(child.stderr)
 
     child.on('exit', (code, signal) => {
+      clearInterval(poller)
       const wasCancelled = child._awdCancelled
       this.active.delete(id)
       if (wasCancelled) {
@@ -181,6 +205,7 @@ class ModelManager {
       }
     })
     child.on('error', (e) => {
+      clearInterval(poller)
       this.active.delete(id)
       const msg = String(e && e.message ? e.message : e)
       this.errors.set(id, msg)

--- a/desktop/tests/model-manager.test.js
+++ b/desktop/tests/model-manager.test.js
@@ -5,14 +5,15 @@ const os = require('os')
 const path = require('path')
 const { createModelManager } = require('../main/services/model-manager')
 
-// 假下载进程：打印带百分比的进度行后正常退出
+// 假下载进程：向组件目录落盘字节（整体进度=已落盘字节/estBytes，不再解析
+// stdout 百分比——那是单文件 tqdm，多文件会反复 0→100%），随后正常退出
 const FAKE_DOWNLOAD_OK = `
-  const lines = ['fetching 10%', 'fetching 55%', 'fetching 100%', 'done']
-  let i = 0
-  const t = setInterval(() => {
-    console.log(lines[i++])
-    if (i >= lines.length) { clearInterval(t); process.exit(0) }
-  }, 50)
+  const fs = require('fs'), path = require('path')
+  const dir = path.join(process.cwd(), 'models', 'mineru')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'model.bin'), Buffer.alloc(550)) // 550/1000 -> 55%
+  console.log('fetching model.bin 100%')
+  setTimeout(() => process.exit(0), 300)
 `
 // 假下载进程：挂住直到被杀
 const FAKE_DOWNLOAD_HANG = `console.log('starting 1%'); setInterval(() => {}, 1000)`
@@ -29,6 +30,7 @@ function makeManager(dataDir, script, events) {
     resourcesPath: null,
     packaged: false,
     onProgress: (e) => events.push(e),
+    progressPollMs: 50, // 测试提速：整体进度轮询间隔（生产 1s）
     // 测试注入：覆盖真实的 mineru 下载命令
     spawnSpecOverride: () => ({
       cmd: process.execPath,
@@ -59,6 +61,8 @@ test('status: absent initially, installed after successful download with marker'
   const dataDir = tmpDataDir()
   const events = []
   const mm = makeManager(dataDir, FAKE_DOWNLOAD_OK, events)
+  // 整体进度分母缩到测试规模：假下载落盘 550 字节 → 55%
+  mm.component('mineru-models').estBytes = 1000
 
   assert.strictEqual(mm.isInstalled('mineru-models'), false)
   assert.strictEqual(mm.status().find((c) => c.id === 'mineru-models').state, 'absent')
@@ -69,8 +73,9 @@ test('status: absent initially, installed after successful download with marker'
 
   await waitFor(() => mm.isInstalled('mineru-models'))
   assert.strictEqual(mm.status().find((c) => c.id === 'mineru-models').state, 'installed')
-  // 进度事件：至少一次带百分比 + 一次 done
-  assert.ok(events.some((e) => e.id === 'mineru-models' && typeof e.percent === 'number' && e.percent >= 10))
+  // 进度事件：至少一次字节级整体百分比（55%，且未到 done 前封顶 99）+ 一次 done
+  assert.ok(events.some((e) => e.id === 'mineru-models' && e.percent === 55))
+  assert.ok(events.every((e) => e.phase !== 'progress' || e.percent === undefined || e.percent <= 99))
   assert.ok(events.some((e) => e.phase === 'done'))
 })
 


### PR DESCRIPTION
## 问题一：Kokoro 下载报 401（真机截图）

`CAS Client Error … 401 Unauthorized, domain: cas-server.xethub.hf.co`

**不是需要梯子**——下载本来就配了大陆镜像 `hf-mirror.com`。根因是打包内带了 `hf_xet 1.5.1`：huggingface_hub 检测到仓库是 Xet 存储后，**绕过 HF_ENDPOINT 直连 HF 官方 CAS 服务器**拿数据块，而镜像签发的凭证在官方 CAS 那边必然 401。这是 hf-mirror + Xet 的已知不兼容。

修复：Kokoro 下载 env 加 `HF_HUB_DISABLE_XET=1`，回退为经镜像的普通 HTTP 下载，大陆无梯子可用。MinerU 走 modelscope 源，不受影响。

## 问题二：MinerU 下载完成后进度又从 0% 开始

原实现的百分比是解析下载器 stdout 里的 tqdm——那是**当前单个文件**的进度。MinerU pipeline 有十几个模型文件，每个文件 0→100% 循环一遍，看起来像"下载重跑了"。

修复：进度改为**字节级整体进度**——每秒轮询组件目录累计落盘字节 ÷ 预估总量（MinerU 3GB / Kokoro 300MB），单调递增、封顶 99%，下载进程成功退出才置 done（预估值偏差不会造成假 100%）。stdout 只保留最近一行作状态文案。

## 验证

desktop `npm test` 10/10 绿（model-manager 测试已适配新语义：落盘字节→55% 断言、99% 封顶断言、取消/失败/删除路径不变）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)