### PR TITLE
style(plugin-market): 插件广场按 AI Workdeck 风格重做 UI / restyle plugin marketplace

### DIFF
--- a/frontend/src/pages/plugin-market/plugin-market.vue
+++ b/frontend/src/pages/plugin-market/plugin-market.vue
@@ -1,102 +1,124 @@
 <template>
   <view class="page-plugin-market">
-    <!-- 顶部 -->
-    <view class="header-card">
-      <view class="title-row">
-        <text class="page-title">插件广场</text>
-        <text class="page-subtitle">管理 plugins/ 目录下已安装的插件（规范见 docs/PLUGIN_SPEC.md）</text>
+    <view class="market-container">
+      <!-- 顶部 -->
+      <view class="header-card">
+        <view class="header-left">
+          <view class="header-icon">🧩</view>
+          <view class="title-row">
+            <text class="page-title">插件广场</text>
+            <text class="page-subtitle">管理 plugins/ 目录下已安装的插件（规范见 docs/PLUGIN_SPEC.md）</text>
+          </view>
+        </view>
+        <view class="toolbar">
+          <button class="btn-secondary" @tap="goBack">返回</button>
+          <button class="btn-primary" :disabled="rescanning" @tap="rescan">
+            {{ rescanning ? '扫描中...' : '重新扫描' }}
+          </button>
+        </view>
       </view>
-      <view class="toolbar">
-        <button class="btn" type="primary" size="mini" :disabled="rescanning" @tap="rescan">
-          {{ rescanning ? '扫描中...' : '重新扫描' }}
-        </button>
-        <button class="btn" type="default" size="mini" @tap="goBack">返回</button>
-      </view>
+
+      <!-- 插件列表 -->
+      <scroll-view class="plugin-list" scroll-y="true">
+        <view class="section-header">
+          <text class="section-title">插件</text>
+          <text v-if="plugins.length" class="section-count">{{ plugins.length }}</text>
+        </view>
+
+        <view v-if="loading" class="empty">
+          <text class="empty-icon">⏳</text>
+          <text class="empty-title">加载中...</text>
+        </view>
+        <view v-else-if="plugins.length === 0" class="empty">
+          <text class="empty-icon">🧩</text>
+          <text class="empty-title">暂无插件</text>
+          <text class="empty-hint">将插件目录（含 manifest.json）放入服务端 plugins/ 目录后，点击"重新扫描"</text>
+        </view>
+        <view v-else class="card-grid">
+          <view v-for="p in plugins" :key="p.id" class="plugin-card" :class="{ disabled: !p.enabled }">
+            <view class="card-header">
+              <view class="plugin-icon-wrap">
+                <image v-if="isImageIcon(p.icon)" :src="p.icon" class="plugin-icon-img" mode="aspectFit" />
+                <text v-else class="plugin-icon">{{ p.icon || '🧩' }}</text>
+              </view>
+              <view class="title-block">
+                <view class="name-row">
+                  <text class="plugin-name">{{ p.name || p.id }}</text>
+                  <text class="plugin-version" v-if="p.version">v{{ p.version }}</text>
+                </view>
+                <text class="plugin-meta" v-if="p.author">作者：{{ p.author }}</text>
+              </view>
+              <switch
+                class="plugin-switch"
+                color="#1A5336"
+                :checked="p.enabled"
+                :disabled="switching"
+                @change="onToggle(p, $event)"
+              />
+            </view>
+
+            <text class="plugin-desc">{{ p.description || '暂无描述' }}</text>
+
+            <view class="tag-row">
+              <text class="tool-count-tag">{{ p.toolCount }} 个工具</text>
+              <text
+                v-for="perm in p.permissions"
+                :key="perm"
+                class="perm-tag"
+              >{{ permissionLabel(perm) }}</text>
+            </view>
+
+            <view class="tool-list" v-if="p.tools && p.tools.length">
+              <view v-for="t in p.tools" :key="t.name" class="tool-item">
+                <text class="tool-name">{{ t.name }}</text>
+                <text class="tool-desc">{{ t.description }}</text>
+              </view>
+            </view>
+          </view>
+        </view>
+
+        <!-- Skill 区块（规范见 docs/SKILL_SPEC.md） -->
+        <view class="section-header">
+          <text class="section-title">Skill</text>
+          <text v-if="skills.length" class="section-count">{{ skills.length }}</text>
+          <text class="section-subtitle">命中触发词时自动注入提示模板并裁剪可用工具</text>
+        </view>
+        <view v-if="skills.length === 0" class="empty">
+          <text class="empty-icon">🎯</text>
+          <text class="empty-title">暂无 Skill</text>
+          <text class="empty-hint">将 Skill 目录（含 skill.yml）放入服务端 skills/ 目录后，点击"重新扫描"</text>
+        </view>
+        <view v-else class="card-grid">
+          <view v-for="s in skills" :key="s.id" class="plugin-card" :class="{ disabled: !s.enabled }">
+            <view class="card-header">
+              <view class="plugin-icon-wrap">
+                <text class="plugin-icon">🎯</text>
+              </view>
+              <view class="title-block">
+                <view class="name-row">
+                  <text class="plugin-name">{{ s.name || s.id }}</text>
+                  <text class="plugin-version" v-if="s.sourcePluginId">来自插件 {{ s.sourcePluginId }}</text>
+                </view>
+                <text class="plugin-meta">触发方式：关键词匹配</text>
+              </view>
+              <switch
+                class="plugin-switch"
+                color="#1A5336"
+                :checked="s.enabled"
+                :disabled="switching"
+                @change="onToggleSkill(s, $event)"
+              />
+            </view>
+
+            <text class="plugin-desc">{{ s.description || '暂无描述' }}</text>
+
+            <view class="tag-row">
+              <text v-for="t in s.triggers" :key="t" class="trigger-tag">{{ t }}</text>
+            </view>
+          </view>
+        </view>
+      </scroll-view>
     </view>
-
-    <!-- 插件列表 -->
-    <scroll-view class="plugin-list" scroll-y="true">
-      <view v-if="loading" class="empty">加载中...</view>
-      <view v-else-if="plugins.length === 0" class="empty">
-        <text>暂无插件</text>
-        <text class="empty-hint">将插件目录（含 manifest.json）放入服务端 plugins/ 目录后，点击"重新扫描"</text>
-      </view>
-      <view v-else>
-        <view v-for="p in plugins" :key="p.id" class="plugin-card" :class="{ disabled: !p.enabled }">
-          <view class="card-header">
-            <image v-if="isImageIcon(p.icon)" :src="p.icon" class="plugin-icon-img" mode="aspectFit" />
-            <text v-else class="plugin-icon">{{ p.icon || '🧩' }}</text>
-            <view class="title-block">
-              <view class="name-row">
-                <text class="plugin-name">{{ p.name || p.id }}</text>
-                <text class="plugin-version" v-if="p.version">v{{ p.version }}</text>
-              </view>
-              <text class="plugin-meta" v-if="p.author">作者：{{ p.author }}</text>
-            </view>
-            <switch
-              class="plugin-switch"
-              :checked="p.enabled"
-              :disabled="switching"
-              @change="onToggle(p, $event)"
-            />
-          </view>
-
-          <text class="plugin-desc">{{ p.description || '暂无描述' }}</text>
-
-          <view class="tag-row">
-            <text class="tool-count-tag">{{ p.toolCount }} 个工具</text>
-            <text
-              v-for="perm in p.permissions"
-              :key="perm"
-              class="perm-tag"
-            >{{ permissionLabel(perm) }}</text>
-          </view>
-
-          <view class="tool-list" v-if="p.tools && p.tools.length">
-            <view v-for="t in p.tools" :key="t.name" class="tool-item">
-              <text class="tool-name">{{ t.name }}</text>
-              <text class="tool-desc">{{ t.description }}</text>
-            </view>
-          </view>
-        </view>
-      </view>
-
-      <!-- Skill 区块（规范见 docs/SKILL_SPEC.md） -->
-      <view class="section-header">
-        <text class="section-title">Skill</text>
-        <text class="section-subtitle">命中触发词时自动注入提示模板并裁剪可用工具</text>
-      </view>
-      <view v-if="skills.length === 0" class="empty">
-        <text>暂无 Skill</text>
-        <text class="empty-hint">将 Skill 目录（含 skill.yml）放入服务端 skills/ 目录后，点击"重新扫描"</text>
-      </view>
-      <view v-else>
-        <view v-for="s in skills" :key="s.id" class="plugin-card" :class="{ disabled: !s.enabled }">
-          <view class="card-header">
-            <text class="plugin-icon">🎯</text>
-            <view class="title-block">
-              <view class="name-row">
-                <text class="plugin-name">{{ s.name || s.id }}</text>
-                <text class="plugin-version" v-if="s.sourcePluginId">来自插件 {{ s.sourcePluginId }}</text>
-              </view>
-              <text class="plugin-meta">触发方式：关键词匹配</text>
-            </view>
-            <switch
-              class="plugin-switch"
-              :checked="s.enabled"
-              :disabled="switching"
-              @change="onToggleSkill(s, $event)"
-            />
-          </view>
-
-          <text class="plugin-desc">{{ s.description || '暂无描述' }}</text>
-
-          <view class="tag-row">
-            <text v-for="t in s.triggers" :key="t" class="trigger-tag">{{ t }}</text>
-          </view>
-        </view>
-      </view>
-    </scroll-view>
   </view>
 </template>
 
@@ -216,81 +238,238 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+/* AI Workdeck Color System（与 admin 页保持一致） */
+$brand-forest: #1A5336;
+$brand-mint: #5BD197;
+$brand-mint-light: #E6F9F0;
+$brand-forest-dark: #123A26;
+
+$brand-primary: $brand-forest;
+$brand-white: #FFFFFF;
+$text-main: #2C3338;
+$text-secondary: #6C757D;
+$border-color: #E9ECEF;
+
 .page-plugin-market {
   min-height: 100vh;
-  padding: 24rpx;
-  background-color: $uni-bg-color-grey;
+  background: linear-gradient(135deg, #F8F9FA 0%, #E8F3ED 100%);
+  padding: 40px 24px;
   box-sizing: border-box;
 }
 
+.market-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* 顶部 */
 .header-card {
-  background-color: $uni-bg-color;
-  border-radius: 16rpx;
-  padding: 16rpx;
-  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.04);
+  background: $brand-white;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.02);
+  box-shadow: 0 4px 16px rgba(18, 52, 77, 0.05);
+  padding: 24px 28px;
   box-sizing: border-box;
-  margin-bottom: 16rpx;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.header-left {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+
+.header-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: $brand-mint-light;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  flex-shrink: 0;
 }
 
 .title-row {
   display: flex;
   flex-direction: column;
-  row-gap: 4rpx;
-  margin-bottom: 12rpx;
+  row-gap: 4px;
+  min-width: 0;
 }
 
 .page-title {
-  font-size: 34rpx;
-  font-weight: 500;
-  color: $uni-color-title;
+  font-size: 20px;
+  font-weight: 600;
+  color: $text-main;
 }
 
 .page-subtitle {
-  font-size: 24rpx;
-  color: $uni-text-color-grey;
+  font-size: 13px;
+  color: $text-secondary;
 }
 
 .toolbar {
   display: flex;
   flex-direction: row;
-  column-gap: 12rpx;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
 }
 
-.btn {
-  padding: 0 20rpx;
+.btn-primary {
+  font-size: 13px;
+  font-weight: 500;
+  background: $brand-primary;
+  color: #fff;
+  border: none;
+  padding: 8px 20px;
+  border-radius: 6px;
+  line-height: 1.5;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(26, 83, 54, 0.2);
+  transition: background 0.2s;
+
+  &:after { border: none; }
+
+  &:hover { background: $brand-forest-dark; }
+
+  &[disabled] {
+    background: #A9C5B6;
+    box-shadow: none;
+    color: #fff;
+  }
+}
+
+.btn-secondary {
+  font-size: 13px;
+  font-weight: 500;
+  background: #fff;
+  color: $text-secondary;
+  border: 1px solid $border-color;
+  padding: 8px 20px;
+  border-radius: 6px;
+  line-height: 1.5;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:after { border: none; }
+
+  &:hover {
+    color: $brand-primary;
+    border-color: $brand-primary;
+    background: $brand-mint-light;
+  }
 }
 
 .plugin-list {
-  max-height: calc(100vh - 220rpx);
+  max-height: calc(100vh - 190px);
 }
 
+/* 区块标题 */
+.section-header {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 10px;
+  margin: 8px 4px 14px;
+
+  &:first-child { margin-top: 0; }
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: $text-main;
+}
+
+.section-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: $brand-primary;
+  background: $brand-mint-light;
+  padding: 1px 10px;
+  border-radius: 999px;
+}
+
+.section-subtitle {
+  font-size: 13px;
+  color: $text-secondary;
+}
+
+/* 空状态 */
 .empty {
-  padding: 40rpx 20rpx;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1.5px dashed #C9DED2;
+  border-radius: 12px;
+  padding: 48px 24px;
+  margin-bottom: 32px;
   text-align: center;
-  color: $uni-text-color-grey;
-  font-size: 24rpx;
   display: flex;
   flex-direction: column;
-  row-gap: 8rpx;
+  align-items: center;
+  row-gap: 8px;
+}
+
+.empty-icon {
+  font-size: 36px;
+  line-height: 1;
+  opacity: 0.5;
+  margin-bottom: 4px;
+}
+
+.empty-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: $text-main;
 }
 
 .empty-hint {
-  font-size: 22rpx;
+  font-size: 13px;
+  color: $text-secondary;
+}
+
+/* 卡片网格 */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
 }
 
 .plugin-card {
-  background-color: #ffffff;
-  border-radius: 12rpx;
-  border-width: 1rpx;
-  border-style: solid;
-  border-color: $uni-border-color;
-  padding: 16rpx;
+  background: $brand-white;
+  border: 1px solid $border-color;
+  border-radius: 12px;
+  padding: 20px;
   box-sizing: border-box;
-  margin-bottom: 12rpx;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: $brand-mint;
+    box-shadow: 0 8px 24px rgba(26, 83, 54, 0.08);
+    transform: translateY(-2px);
+  }
 
   &.disabled {
-    opacity: 0.55;
+    opacity: 0.6;
+    background: #FCFCFC;
+
+    &:hover {
+      transform: none;
+      box-shadow: none;
+      border-color: $border-color;
+    }
   }
 }
 
@@ -298,19 +477,30 @@ export default {
   display: flex;
   flex-direction: row;
   align-items: center;
-  column-gap: 12rpx;
-  margin-bottom: 8rpx;
+  column-gap: 12px;
+  margin-bottom: 12px;
+}
+
+.plugin-icon-wrap {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background: $brand-mint-light;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
 }
 
 .plugin-icon {
-  font-size: 48rpx;
+  font-size: 24px;
   line-height: 1;
 }
 
 .plugin-icon-img {
-  width: 56rpx;
-  height: 56rpx;
-  border-radius: 8rpx;
+  width: 32px;
+  height: 32px;
 }
 
 .title-block {
@@ -318,118 +508,118 @@ export default {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  row-gap: 2rpx;
+  row-gap: 2px;
 }
 
 .name-row {
   display: flex;
   flex-direction: row;
   align-items: center;
-  column-gap: 8rpx;
+  column-gap: 8px;
 }
 
 .plugin-name {
-  font-size: 30rpx;
-  font-weight: 500;
-  color: $uni-color-title;
+  font-size: 15px;
+  font-weight: 600;
+  color: $text-main;
 }
 
 .plugin-version {
-  font-size: 22rpx;
-  color: $uni-text-color-grey;
+  font-size: 12px;
+  color: $text-secondary;
+  background: #F1F3F5;
+  padding: 1px 8px;
+  border-radius: 999px;
 }
 
 .plugin-meta {
-  font-size: 22rpx;
-  color: $uni-text-color-grey;
+  font-size: 12px;
+  color: $text-secondary;
 }
 
 .plugin-switch {
   transform: scale(0.8);
+  flex-shrink: 0;
 }
 
 .plugin-desc {
-  font-size: 24rpx;
-  color: $uni-text-color;
+  font-size: 13px;
+  line-height: 1.6;
+  color: $text-secondary;
   display: block;
-  margin-bottom: 10rpx;
+  margin-bottom: 12px;
 }
 
 .tag-row {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  column-gap: 8rpx;
-  row-gap: 8rpx;
-  margin-bottom: 8rpx;
+  gap: 8px;
+  margin-bottom: 12px;
+
+  &:last-child { margin-bottom: 0; }
 }
 
 .tool-count-tag {
-  font-size: 22rpx;
-  padding: 2rpx 12rpx;
-  border-radius: 999rpx;
-  background-color: rgba($uni-color-primary, 0.08);
-  color: $uni-color-primary;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: $brand-mint-light;
+  color: $brand-primary;
 }
 
 .perm-tag {
-  font-size: 22rpx;
-  padding: 2rpx 12rpx;
-  border-radius: 999rpx;
-  background-color: rgba(#e6a23c, 0.12);
-  color: #b88230;
-}
-
-.section-header {
-  display: flex;
-  flex-direction: column;
-  row-gap: 4rpx;
-  margin: 24rpx 4rpx 12rpx;
-}
-
-.section-title {
-  font-size: 30rpx;
-  font-weight: 500;
-  color: $uni-color-title;
-}
-
-.section-subtitle {
-  font-size: 22rpx;
-  color: $uni-text-color-grey;
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(230, 162, 60, 0.12);
+  color: #B47D2B;
 }
 
 .trigger-tag {
-  font-size: 22rpx;
-  padding: 2rpx 12rpx;
-  border-radius: 999rpx;
-  background-color: rgba(#67c23a, 0.12);
-  color: #4f9a2c;
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(103, 194, 58, 0.12);
+  color: #4F9A2C;
 }
 
+/* 工具清单 */
 .tool-list {
-  border-top: 1rpx solid $uni-border-color;
-  padding-top: 8rpx;
+  background: #FAFAFA;
+  border: 1px solid $border-color;
+  border-radius: 8px;
+  padding: 12px 14px;
   display: flex;
   flex-direction: column;
-  row-gap: 4rpx;
+  row-gap: 6px;
 }
 
 .tool-item {
   display: flex;
   flex-direction: row;
   align-items: baseline;
-  column-gap: 12rpx;
+  column-gap: 12px;
 }
 
 .tool-name {
-  font-size: 22rpx;
-  font-family: monospace;
-  color: $uni-color-primary;
+  font-size: 12px;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  color: $brand-primary;
+  font-weight: 500;
   flex-shrink: 0;
 }
 
 .tool-desc {
-  font-size: 22rpx;
-  color: $uni-text-color-grey;
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+/* 窄窗口回退为单列 */
+@media (max-width: 920px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>


### PR DESCRIPTION
## 摘要
插件广场页面此前是无风格的裸卡片布局（全宽、原生 mini 按钮），与 admin 管理页的 AI Workdeck 设计体系不一致。本 PR 仅重做模板结构与样式，**逻辑与 API 调用零改动**。

## 变更点
- 页面背景渐变、1080px 居中容器、白色头部卡片，与 admin 页统一（森林绿 `#1A5336` / 薄荷绿 `#5BD197` 配色）
- 插件与 Skill 列表改为响应式双列卡片网格（`minmax(420px,1fr)`），hover 浮起 + 描边高亮，窄窗口回退单列
- 自定义主/次按钮替换原生 `button type=primary size=mini`；switch 换品牌绿
- 空状态改为虚线卡片 + 图标 + 标题 + 提示
- 区块标题带数量徽标；标签（工具数/权限/触发词）与工具清单内嵌面板统一配色
- 禁用插件卡片降透明度并取消 hover 效果

## 验证
- `npm run dev:h5` 起本地 H5，真机浏览器截图验证：
  - 空状态（无插件/无 Skill）渲染正常
  - 注入 3 插件 + 2 Skill 模拟数据验证卡片网格、标签、工具清单、禁用态
- 未启动后端时接口失败仅 toast，布局不受影响（原行为保持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)