### PR TITLE
fix(ai): OpenRouter 供应商切换生效 + 模型清单对齐在线模型 / honor DB provider & refresh model catalog

### DIFF
--- a/backend/src/main/java/com/checkba/config/AiModelProperties.java
+++ b/backend/src/main/java/com/checkba/config/AiModelProperties.java
@@ -91,7 +91,7 @@ public class AiModelProperties {
         /**
          * Default model to use if not specified.
          */
-        private String defaultModel = "anthropic/claude-3.5-sonnet";
+        private String defaultModel = "google/gemini-2.5-flash-lite";
         /**
          * Timeout.
          */

--- a/backend/src/main/java/com/checkba/config/AiModelProperties.java
+++ b/backend/src/main/java/com/checkba/config/AiModelProperties.java
@@ -91,7 +91,7 @@ public class AiModelProperties {
         /**
          * Default model to use if not specified.
          */
-        private String defaultModel = "google/gemini-2.5-flash-lite";
+        private String defaultModel = "deepseek/deepseek-v4-flash";
         /**
          * Timeout.
          */

--- a/backend/src/main/java/com/checkba/controller/AdminConfigController.java
+++ b/backend/src/main/java/com/checkba/controller/AdminConfigController.java
@@ -37,18 +37,21 @@ public class AdminConfigController {
     private final AiModelProperties aiModelProperties;
     private final com.checkba.service.AdminAccessService adminAccessService;
     private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    private final com.checkba.service.ai.ChatModelFactory chatModelFactory;
 
     @org.springframework.beans.factory.annotation.Autowired
     public AdminConfigController(SystemSettingService systemSettingService,
                                  UserRepository userRepository,
                                  AiModelProperties aiModelProperties,
                                  com.checkba.service.AdminAccessService adminAccessService,
-                                 com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+                                 com.fasterxml.jackson.databind.ObjectMapper objectMapper,
+                                 com.checkba.service.ai.ChatModelFactory chatModelFactory) {
         this.systemSettingService = systemSettingService;
         this.userRepository = userRepository;
         this.aiModelProperties = aiModelProperties;
         this.adminAccessService = adminAccessService;
         this.objectMapper = objectMapper;
+        this.chatModelFactory = chatModelFactory;
     }
 
     // ... (rest of the file remains same until DTOs)
@@ -307,6 +310,8 @@ public class AdminConfigController {
         }
 
         systemSettingService.setMany(updates);
+        // 立即让新的 key/baseUrl/供应商生效，避免旧配置的模型实例缓存到进程重启
+        chatModelFactory.clearCache();
 
         Map<String, Object> ok = new HashMap<>();
         ok.put("code", 0);

--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -36,17 +36,20 @@ public class WizardController {
     private final UserRepository userRepository;
     private final com.checkba.service.AdminAccessService adminAccessService;
     private final ObjectMapper objectMapper;
+    private final com.checkba.service.ai.ChatModelFactory chatModelFactory;
 
     public WizardController(SystemSettingService systemSettingService,
                             SystemSettingRepository systemSettingRepository,
                             UserRepository userRepository,
                             com.checkba.service.AdminAccessService adminAccessService,
-                            ObjectMapper objectMapper) {
+                            ObjectMapper objectMapper,
+                            com.checkba.service.ai.ChatModelFactory chatModelFactory) {
         this.systemSettingService = systemSettingService;
         this.systemSettingRepository = systemSettingRepository;
         this.userRepository = userRepository;
         this.adminAccessService = adminAccessService;
         this.objectMapper = objectMapper;
+        this.chatModelFactory = chatModelFactory;
     }
 
     @GetMapping
@@ -79,6 +82,8 @@ public class WizardController {
         }
         updates.put(KEY_WIZARD_COMPLETED, "true");
         systemSettingService.setMany(updates);
+        // 向导保存的 key/供应商立即生效（与管理后台保存行为一致）
+        chatModelFactory.clearCache();
 
         Map<String, Object> ok = new HashMap<>();
         ok.put("code", 0);

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -179,7 +179,7 @@ public class AgentOrchestrator {
                     try {
                         log.info("Generating conversation title for: {}", convId);
                         // Use a lightweight model for title generation
-                        dev.langchain4j.model.chat.ChatLanguageModel titleModel = chatModelFactory.getChatModel("google/gemini-2.0-flash-exp:free");
+                        dev.langchain4j.model.chat.ChatLanguageModel titleModel = chatModelFactory.getChatModel("google/gemini-2.5-flash-lite");
                         String title = messageService.generateConversationTitle(userMsg, titleModel);
                         messageService.updateConversationTitle(convId, title);
                         log.info("Conversation title generated: {} -> {}", convId, title);

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -179,7 +179,7 @@ public class AgentOrchestrator {
                     try {
                         log.info("Generating conversation title for: {}", convId);
                         // Use a lightweight model for title generation
-                        dev.langchain4j.model.chat.ChatLanguageModel titleModel = chatModelFactory.getChatModel("google/gemini-2.5-flash-lite");
+                        dev.langchain4j.model.chat.ChatLanguageModel titleModel = chatModelFactory.getChatModel("deepseek/deepseek-v4-flash");
                         String title = messageService.generateConversationTitle(userMsg, titleModel);
                         messageService.updateConversationTitle(convId, title);
                         log.info("Conversation title generated: {} -> {}", convId, title);

--- a/backend/src/main/java/com/checkba/service/ai/AllowedModels.java
+++ b/backend/src/main/java/com/checkba/service/ai/AllowedModels.java
@@ -6,26 +6,29 @@ package com.checkba.service.ai;
  */
 public enum AllowedModels {
 
-    // Anthony
+    // 模型清单与 OpenRouter 实际在线模型对齐（2026-07 校验），
+    // 下线模型请求会返回 404 "No endpoints found"，必须及时清理。
     // Google (via OpenRouter)
-    GEMINI_2_0_FLASH_EXP_FREE("google/gemini-2.0-flash-exp:free", 0.0, 0.0),
-    GEMINI_2_0_FLASH_001("google/gemini-2.0-flash-001", 0.1, 0.4),
-    GEMINI_2_5_PRO("google/gemini-2.5-pro", 1.25, 5.0),
-    GEMINI_2_5_FLASH("google/gemini-2.5-flash", 0.1, 0.4),
-    GEMINI_3_PRO_PREVIEW("google/gemini-3-pro-preview", 1.25, 5.0),
-    GEMINI_3_FLASH_PREVIEW("google/gemini-3-flash-preview", 0.1, 0.4),
-    
-    // Anthony
-    CLAUDE_3_5_SONNET("anthropic/claude-3.5-sonnet", 3.0, 15.0), 
+    GEMINI_2_5_PRO("google/gemini-2.5-pro", 1.25, 10.0),
+    GEMINI_2_5_FLASH("google/gemini-2.5-flash", 0.3, 2.5),
+    GEMINI_2_5_FLASH_LITE("google/gemini-2.5-flash-lite", 0.1, 0.4),
+    GEMINI_3_FLASH_PREVIEW("google/gemini-3-flash-preview", 0.5, 3.0),
+    GEMINI_3_1_PRO_PREVIEW("google/gemini-3.1-pro-preview", 2.0, 12.0),
+
+    // Anthropic
+    CLAUDE_SONNET_5("anthropic/claude-sonnet-5", 2.0, 10.0),
+    CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 1.0, 5.0),
     CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 0.25, 1.25),
-    
-    // OpenAI 
-    GPT_4O("openai/gpt-4o", 5.0, 15.0),
+
+    // OpenAI
+    GPT_5_2("openai/gpt-5.2", 1.75, 14.0),
+    GPT_4O("openai/gpt-4o", 2.5, 10.0),
     GPT_4O_MINI("openai/gpt-4o-mini", 0.15, 0.6),
-    
+
     // Open Source
-    LLAMA_3_70_B("meta-llama/llama-3-70b-instruct", 0.9, 0.9),
-    QWEN_2_5_72B("qwen/qwen-2.5-72b-instruct", 0.35, 0.4);
+    LLAMA_3_3_70B("meta-llama/llama-3.3-70b-instruct", 0.1, 0.32),
+    QWEN_2_5_72B("qwen/qwen-2.5-72b-instruct", 0.36, 0.4),
+    DEEPSEEK_V3_2("deepseek/deepseek-v3.2", 0.21, 0.32);
 
 
 

--- a/backend/src/main/java/com/checkba/service/ai/AllowedModels.java
+++ b/backend/src/main/java/com/checkba/service/ai/AllowedModels.java
@@ -6,29 +6,38 @@ package com.checkba.service.ai;
  */
 public enum AllowedModels {
 
-    // 模型清单与 OpenRouter 实际在线模型对齐（2026-07 校验），
+    // 模型清单与 OpenRouter 实际在线模型对齐（2026-07 真机校验），
     // 下线模型请求会返回 404 "No endpoints found"，必须及时清理。
-    // Google (via OpenRouter)
+    // 注意：Google/Anthropic/OpenAI 系在国内网络环境会被 OpenRouter 返回
+    // 403 "This model is not available in your region"，默认模型必须选区域无关的。
+
+    // 区域无关（国内外均实测可用）
+    DEEPSEEK_V4_FLASH("deepseek/deepseek-v4-flash", 0.09, 0.18),
+    DEEPSEEK_V4_PRO("deepseek/deepseek-v4-pro", 0.43, 0.87),
+    DEEPSEEK_V3_2("deepseek/deepseek-v3.2", 0.21, 0.32),
+    QWEN_3_235B("qwen/qwen3-235b-a22b-2507", 0.09, 0.55),
+    QWEN_2_5_72B("qwen/qwen-2.5-72b-instruct", 0.36, 0.4),
+    GLM_5("z-ai/glm-5", 0.6, 1.92),
+    KIMI_K2_6("moonshotai/kimi-k2.6", 0.66, 3.41),
+    MINIMAX_M3("minimax/minimax-m3", 0.3, 1.2),
+    LLAMA_3_3_70B("meta-llama/llama-3.3-70b-instruct", 0.1, 0.32),
+
+    // Google (via OpenRouter，部分地区不可用)
     GEMINI_2_5_PRO("google/gemini-2.5-pro", 1.25, 10.0),
     GEMINI_2_5_FLASH("google/gemini-2.5-flash", 0.3, 2.5),
     GEMINI_2_5_FLASH_LITE("google/gemini-2.5-flash-lite", 0.1, 0.4),
     GEMINI_3_FLASH_PREVIEW("google/gemini-3-flash-preview", 0.5, 3.0),
     GEMINI_3_1_PRO_PREVIEW("google/gemini-3.1-pro-preview", 2.0, 12.0),
 
-    // Anthropic
+    // Anthropic (部分地区不可用)
     CLAUDE_SONNET_5("anthropic/claude-sonnet-5", 2.0, 10.0),
     CLAUDE_HAIKU_4_5("anthropic/claude-haiku-4.5", 1.0, 5.0),
     CLAUDE_3_HAIKU("anthropic/claude-3-haiku", 0.25, 1.25),
 
-    // OpenAI
+    // OpenAI (部分地区不可用)
     GPT_5_2("openai/gpt-5.2", 1.75, 14.0),
     GPT_4O("openai/gpt-4o", 2.5, 10.0),
-    GPT_4O_MINI("openai/gpt-4o-mini", 0.15, 0.6),
-
-    // Open Source
-    LLAMA_3_3_70B("meta-llama/llama-3.3-70b-instruct", 0.1, 0.32),
-    QWEN_2_5_72B("qwen/qwen-2.5-72b-instruct", 0.36, 0.4),
-    DEEPSEEK_V3_2("deepseek/deepseek-v3.2", 0.21, 0.32);
+    GPT_4O_MINI("openai/gpt-4o-mini", 0.15, 0.6);
 
 
 

--- a/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
+++ b/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
@@ -45,6 +45,16 @@ public class ChatModelFactory {
     }
 
     /**
+     * 读取系统设置，DB 里的空白值视为未配置、回退默认值。
+     * 向导/管理后台保存时未填的字段会以空串写入 DB（toSettingsUpdates 的 safe()），
+     * 直接用会把 baseUrl 等必填项置空导致构建模型失败。
+     */
+    private String getSetting(String key, String fallback) {
+        String value = systemSettingService.get(key, null);
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
+
+    /**
      * 清空模型实例缓存。管理后台/向导保存 API key、baseUrl 等配置后必须调用，
      * 否则旧配置构建的实例会一直用到进程重启。
      */
@@ -93,7 +103,7 @@ public class ChatModelFactory {
         // Fallback to configured default provider (Legacy behavior)
         // If the user wants to force specific internal models (Gemini/Ollama) via "default"
         if (provider == AiModelProperties.Provider.GEMINI || (targetModel.toLowerCase().contains("gemini") && !targetModel.contains("/"))) {
-            String defaultModel = systemSettingService.get("external.google.modelName", aiModelProperties.getGemini().getModelName());
+            String defaultModel = getSetting("external.google.modelName", aiModelProperties.getGemini().getModelName());
             return getOrCreateGeminiModel(defaultModel); // fallback to config model name if generic request
         }
 
@@ -107,8 +117,8 @@ public class ChatModelFactory {
             log.info("Creating new OpenRouter ChatModel instance for: {}", modelId);
             AiModelProperties.OpenRouter config = aiModelProperties.getOpenRouter();
             
-            String apiKey = systemSettingService.get("external.openrouter.apiKey", config.getApiKey());
-            String baseUrl = systemSettingService.get("external.openrouter.baseUrl", config.getBaseUrl());
+            String apiKey = getSetting("external.openrouter.apiKey", config.getApiKey());
+            String baseUrl = getSetting("external.openrouter.baseUrl", config.getBaseUrl());
             
             return OpenAiChatModel.builder()
                     .apiKey(apiKey)
@@ -146,8 +156,8 @@ public class ChatModelFactory {
             log.info("Creating new Gemini ChatModel instance for: {}", modelName);
             AiModelProperties.Gemini config = aiModelProperties.getGemini();
             
-            String apiKey = systemSettingService.get("external.google.apiKey", config.getApiKey());
-            String baseUrl = systemSettingService.get("external.google.apiBaseUrl", config.getApiBaseUrl());
+            String apiKey = getSetting("external.google.apiKey", config.getApiKey());
+            String baseUrl = getSetting("external.google.apiBaseUrl", config.getApiBaseUrl());
 
             return new GeminiChatLanguageModel(
                     baseUrl,
@@ -198,8 +208,8 @@ public class ChatModelFactory {
             log.info("Creating new OpenRouter StreamingChatModel for: {}", modelId);
             AiModelProperties.OpenRouter config = aiModelProperties.getOpenRouter();
             
-            String apiKey = systemSettingService.get("external.openrouter.apiKey", config.getApiKey());
-            String baseUrl = systemSettingService.get("external.openrouter.baseUrl", config.getBaseUrl());
+            String apiKey = getSetting("external.openrouter.apiKey", config.getApiKey());
+            String baseUrl = getSetting("external.openrouter.baseUrl", config.getBaseUrl());
             
             return dev.langchain4j.model.openai.OpenAiStreamingChatModel.builder()
                     .apiKey(apiKey)

--- a/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
+++ b/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
@@ -29,13 +29,39 @@ public class ChatModelFactory {
     private final Map<String, ChatLanguageModel> modelCache = new ConcurrentHashMap<>();
 
     /**
+     * 解析当前生效的供应商：优先读管理后台/向导写入 system_setting 的 ai.activeProvider，
+     * 未配置或值非法时回退 application.yml 的静态配置。
+     */
+    private AiModelProperties.Provider resolveProvider() {
+        String configured = systemSettingService.get("ai.activeProvider", null);
+        if (configured != null && !configured.isBlank()) {
+            try {
+                return AiModelProperties.Provider.valueOf(configured.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                log.warn("Unknown ai.activeProvider value '{}', falling back to static config", configured);
+            }
+        }
+        return aiModelProperties.getProvider();
+    }
+
+    /**
+     * 清空模型实例缓存。管理后台/向导保存 API key、baseUrl 等配置后必须调用，
+     * 否则旧配置构建的实例会一直用到进程重启。
+     */
+    public void clearCache() {
+        modelCache.clear();
+        streamingModelCache.clear();
+        log.info("ChatModel caches cleared (config updated)");
+    }
+
+    /**
      * 获取或创建 ChatLanguageModel。
      * @param modelId 前端传来的模型ID (e.g. "anthropic/claude-3.5-sonnet")。如果是 null，使用默认配置。
      * @return ChatLanguageModel 实例
      */
     public ChatLanguageModel getChatModel(String modelId) {
         // 1. Determine Provider and Normalized Model Name
-        AiModelProperties.Provider provider = aiModelProperties.getProvider();
+        AiModelProperties.Provider provider = resolveProvider();
         String targetModel = modelId;
 
         if (targetModel == null || targetModel.isEmpty()) {
@@ -44,7 +70,7 @@ public class ChatModelFactory {
 
         // Logic to switch provider based on modelId pattern if Provider is set to OPENROUTER or dynamic
         // For now, if modelId contains "/", we assume it's OpenRouter style (except for "google/gemini" if we treat it specially, but OpenRouter handles google too)
-        
+
         // Strategy:
         // - If modelID is "default" or local-looking => use Configured Provider (Ollama/Gemini) properties.
         // - If modelID looks like "provider/model" (e.g. "anthropic/claude") => Force OpenRouter if generic, or check allowed list.
@@ -52,6 +78,16 @@ public class ChatModelFactory {
         if (AllowedModels.isAllowed(targetModel)) {
             // It's a valid OpenRouter/Cloud model
             return getOrCreateOpenRouterModel(targetModel);
+        }
+
+        // 供应商为 OPENROUTER 时，空/非白名单的 modelId 统一走 OpenRouter 默认模型，
+        // 不能回退本地 Ollama（用户可能根本没装，导致 Connection refused）
+        if (provider == AiModelProperties.Provider.OPENROUTER) {
+            String defaultModel = aiModelProperties.getOpenRouter().getDefaultModel();
+            if (!"default".equals(targetModel)) {
+                log.warn("Model '{}' is not in the allowed list, falling back to OpenRouter default: {}", targetModel, defaultModel);
+            }
+            return getOrCreateOpenRouterModel(defaultModel);
         }
 
         // Fallback to configured default provider (Legacy behavior)
@@ -126,13 +162,23 @@ public class ChatModelFactory {
 
     public dev.langchain4j.model.chat.StreamingChatLanguageModel getStreamingChatModel(String modelId) {
         String targetModel = (modelId == null || modelId.isEmpty()) ? "default" : modelId;
-        
+
         if (AllowedModels.isAllowed(targetModel)) {
             return getOrCreateOpenRouterStreamingModel(targetModel);
         }
 
         // Fallback or Local
-        AiModelProperties.Provider provider = aiModelProperties.getProvider();
+        AiModelProperties.Provider provider = resolveProvider();
+
+        // 同 getChatModel：OPENROUTER 供应商下不回退本地 Ollama
+        if (provider == AiModelProperties.Provider.OPENROUTER) {
+            String defaultModel = aiModelProperties.getOpenRouter().getDefaultModel();
+            if (!"default".equals(targetModel)) {
+                log.warn("Model '{}' is not in the allowed list, falling back to OpenRouter default: {}", targetModel, defaultModel);
+            }
+            return getOrCreateOpenRouterStreamingModel(defaultModel);
+        }
+
         if (provider == AiModelProperties.Provider.GEMINI || (targetModel.toLowerCase().contains("gemini") && !targetModel.contains("/"))) {
             // TODO: Implement Gemini Streaming. For now, throw or fallback? 
             // Or use OpenRouter for Gemini if configured?

--- a/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
+++ b/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
@@ -29,7 +29,9 @@ public class TokenUsageService {
             com.checkba.model.entity.TokenUsage entity = new com.checkba.model.entity.TokenUsage();
             entity.setProjectId(projectId);
             entity.setUserId(userId);
-            entity.setModel(modelId);
+            // model 列非空约束：空 modelId（走供应商默认模型的请求）落 "default"，
+            // 否则 save 失败会把整个流式事务标记 rollback-only，对话在收尾时报错
+            entity.setModel((modelId == null || modelId.isBlank()) ? "default" : modelId);
             entity.setConversationId(conversationId);
             
             int promptTokens = usage.inputTokenCount() != null ? usage.inputTokenCount() : 0;

--- a/backend/src/main/java/com/checkba/service/ai/context/ConversationSummarizer.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/ConversationSummarizer.java
@@ -83,7 +83,7 @@ public class ConversationSummarizer {
         String prompt = String.format(SUMMARY_PROMPT, content);
         
         try {
-            ChatLanguageModel model = chatModelFactory.getChatModel("google/gemini-2.0-flash-exp:free");
+            ChatLanguageModel model = chatModelFactory.getChatModel("google/gemini-2.5-flash-lite");
             String summaryText = model.generate(prompt);
             
             // 清理输出
@@ -123,7 +123,7 @@ public class ConversationSummarizer {
         String content = formatMessagesCompact(messages);
         
         try {
-            ChatLanguageModel model = chatModelFactory.getChatModel("google/gemini-2.0-flash-exp:free");
+            ChatLanguageModel model = chatModelFactory.getChatModel("google/gemini-2.5-flash-lite");
             String summary = model.generate(String.format(QUICK_SUMMARY_PROMPT, content));
             summary = cleanSummaryOutput(summary);
             

--- a/backend/src/main/java/com/checkba/service/ai/context/ConversationSummarizer.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/ConversationSummarizer.java
@@ -83,7 +83,7 @@ public class ConversationSummarizer {
         String prompt = String.format(SUMMARY_PROMPT, content);
         
         try {
-            ChatLanguageModel model = chatModelFactory.getChatModel("google/gemini-2.5-flash-lite");
+            ChatLanguageModel model = chatModelFactory.getChatModel("deepseek/deepseek-v4-flash");
             String summaryText = model.generate(prompt);
             
             // 清理输出
@@ -123,7 +123,7 @@ public class ConversationSummarizer {
         String content = formatMessagesCompact(messages);
         
         try {
-            ChatLanguageModel model = chatModelFactory.getChatModel("google/gemini-2.5-flash-lite");
+            ChatLanguageModel model = chatModelFactory.getChatModel("deepseek/deepseek-v4-flash");
             String summary = model.generate(String.format(QUICK_SUMMARY_PROMPT, content));
             summary = cleanSummaryOutput(summary);
             

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -45,7 +45,7 @@ ai:
     open-router:
       api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
-      default-model: google/gemini-2.0-flash-exp:free
+      default-model: google/gemini-2.5-flash-lite
       timeout: 120s
     ollama:
       base-url: ${OLLAMA_BASE_URL:http://localhost:11434}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -45,7 +45,7 @@ ai:
     open-router:
       api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
-      default-model: google/gemini-2.5-flash-lite
+      default-model: deepseek/deepseek-v4-flash
       timeout: 120s
     ollama:
       base-url: ${OLLAMA_BASE_URL:http://localhost:11434}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -103,7 +103,7 @@ ai:
       # OpenRouter API Key (必填)
       api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
-      default-model: google/gemini-2.5-flash-lite
+      default-model: deepseek/deepseek-v4-flash
       timeout: 120s
   # AI 上下文与压缩配置（对应 AiContextProperties，以下均为默认值，可按需覆盖）
   context:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -103,7 +103,7 @@ ai:
       # OpenRouter API Key (必填)
       api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
-      default-model: google/gemini-2.0-flash-exp:free
+      default-model: google/gemini-2.5-flash-lite
       timeout: 120s
   # AI 上下文与压缩配置（对应 AiContextProperties，以下均为默认值，可按需覆盖）
   context:

--- a/backend/src/test/java/com/checkba/controller/WizardControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/WizardControllerTest.java
@@ -40,9 +40,12 @@ class WizardControllerTest {
     @Mock
     private AdminAccessService adminAccessService;
 
+    @Mock
+    private com.checkba.service.ai.ChatModelFactory chatModelFactory;
+
     private WizardController newController() {
         return new WizardController(systemSettingService, systemSettingRepository,
-                userRepository, adminAccessService, new ObjectMapper());
+                userRepository, adminAccessService, new ObjectMapper(), chatModelFactory);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
@@ -101,6 +101,18 @@ class ChatModelFactoryTest {
     }
 
     @Test
+    @DisplayName("DB 中 baseUrl 为空串（向导只填了 key 的场景）：应回退默认 baseUrl 而非报错")
+    void blankBaseUrlInDbFallsBackToDefault() {
+        properties.setProvider(AiModelProperties.Provider.OPENROUTER);
+        // 向导/后台保存时未填字段会以空串入库（toSettingsUpdates 的 safe()）
+        when(systemSettingService.get(eq("external.openrouter.baseUrl"), any())).thenReturn("");
+        when(systemSettingService.get(eq("external.openrouter.apiKey"), any())).thenReturn("sk-or-db-key");
+
+        // 修复前这里抛 IllegalArgumentException: baseUrl cannot be null or empty
+        assertInstanceOf(OpenAiChatModel.class, factory.getChatModel(null));
+    }
+
+    @Test
     @DisplayName("clearCache：清空缓存后重建实例（保存新 key 后无需重启）")
     void clearCacheRebuildsModels() {
         properties.setProvider(AiModelProperties.Provider.OPENROUTER);
@@ -116,11 +128,14 @@ class ChatModelFactoryTest {
     @Test
     @DisplayName("白名单应包含前端下拉与内部硬编码使用的全部模型（OpenRouter 2026-07 实测在线）")
     void allowedModelsCoverFrontendAndInternalIds() {
-        // 前端 ChatInterface.vue availableModels + 标题/摘要用的轻量模型
+        // 前端 ChatInterface.vue availableModels + 标题/摘要/默认用的轻量模型
         String[] required = {
-                "google/gemini-2.5-flash",
-                "google/gemini-2.5-flash-lite",
-                "google/gemini-2.5-pro",
+                "deepseek/deepseek-v4-flash",
+                "deepseek/deepseek-v4-pro",
+                "qwen/qwen3-235b-a22b-2507",
+                "moonshotai/kimi-k2.6",
+                "z-ai/glm-5",
+                "anthropic/claude-sonnet-5",
                 "google/gemini-3.1-pro-preview",
                 "openai/gpt-5.2",
         };

--- a/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
@@ -1,0 +1,131 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiModelProperties;
+import com.checkba.service.SystemSettingService;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * ChatModelFactory 供应商路由测试。
+ *
+ * 回归背景：管理后台把供应商写入 system_setting 的 ai.activeProvider，
+ * 但工厂此前只读 application.yml 的静态配置；且 provider=OPENROUTER 时
+ * 空 modelId / 非白名单 modelId 会静默回退到本地 Ollama，导致配好
+ * OpenRouter key 后仍然连不上 AI（Connection refused :11434）。
+ */
+class ChatModelFactoryTest {
+
+    private AiModelProperties properties;
+    private SystemSettingService systemSettingService;
+    private ChatModelFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AiModelProperties();
+        properties.getOpenRouter().setApiKey("sk-or-static-key");
+        systemSettingService = mock(SystemSettingService.class);
+        // 默认：DB 无该配置时返回调用方给的默认值
+        when(systemSettingService.get(anyString(), any()))
+                .thenAnswer(inv -> inv.getArgument(1));
+        factory = new ChatModelFactory(properties, systemSettingService);
+    }
+
+    private void setDbProvider(String provider) {
+        when(systemSettingService.get(eq("ai.activeProvider"), any())).thenReturn(provider);
+    }
+
+    @Test
+    @DisplayName("DB 供应商=OPENROUTER 且 modelId 为空：应走 OpenRouter 默认模型而非 Ollama")
+    void openRouterProviderWithNullModelUsesOpenRouter() {
+        properties.setProvider(AiModelProperties.Provider.OLLAMA); // 静态配置故意留 OLLAMA
+        setDbProvider("OPENROUTER");
+
+        ChatLanguageModel model = factory.getChatModel(null);
+        assertInstanceOf(OpenAiChatModel.class, model,
+                "供应商切到 OPENROUTER 后空 modelId 不应回退本地 Ollama");
+
+        StreamingChatLanguageModel streaming = factory.getStreamingChatModel(null);
+        assertInstanceOf(OpenAiStreamingChatModel.class, streaming);
+    }
+
+    @Test
+    @DisplayName("OPENROUTER 供应商 + 非白名单 modelId：回退 OpenRouter 默认模型而非 Ollama")
+    void openRouterProviderWithUnknownModelFallsBackToOpenRouterDefault() {
+        properties.setProvider(AiModelProperties.Provider.OPENROUTER);
+
+        ChatLanguageModel model = factory.getChatModel("vendor/some-unlisted-model");
+        assertInstanceOf(OpenAiChatModel.class, model);
+
+        StreamingChatLanguageModel streaming = factory.getStreamingChatModel("vendor/some-unlisted-model");
+        assertInstanceOf(OpenAiStreamingChatModel.class, streaming);
+    }
+
+    @Test
+    @DisplayName("白名单模型：无论静态供应商是什么都走 OpenRouter")
+    void allowedModelAlwaysUsesOpenRouter() {
+        properties.setProvider(AiModelProperties.Provider.OLLAMA);
+        ChatLanguageModel model = factory.getChatModel("openai/gpt-5.2");
+        assertInstanceOf(OpenAiChatModel.class, model,
+                "前端下拉提供的 openai/gpt-5.2 必须在白名单内并走 OpenRouter");
+    }
+
+    @Test
+    @DisplayName("供应商=OLLAMA（DB 未配置）：空 modelId 仍走本地 Ollama（回归保护）")
+    void ollamaProviderStillUsesOllama() {
+        properties.setProvider(AiModelProperties.Provider.OLLAMA);
+
+        assertInstanceOf(OllamaChatModel.class, factory.getChatModel(null));
+        assertInstanceOf(OllamaStreamingChatModel.class, factory.getStreamingChatModel(null));
+    }
+
+    @Test
+    @DisplayName("DB 供应商值非法时回退静态配置，不抛异常")
+    void invalidDbProviderFallsBackToStaticConfig() {
+        properties.setProvider(AiModelProperties.Provider.OLLAMA);
+        setDbProvider("not-a-provider");
+
+        assertInstanceOf(OllamaChatModel.class, factory.getChatModel(null));
+    }
+
+    @Test
+    @DisplayName("clearCache：清空缓存后重建实例（保存新 key 后无需重启）")
+    void clearCacheRebuildsModels() {
+        properties.setProvider(AiModelProperties.Provider.OPENROUTER);
+
+        ChatLanguageModel first = factory.getChatModel("openai/gpt-4o-mini");
+        assertSame(first, factory.getChatModel("openai/gpt-4o-mini"), "命中缓存应返回同一实例");
+
+        factory.clearCache();
+        assertNotSame(first, factory.getChatModel("openai/gpt-4o-mini"),
+                "clearCache 后应使用最新配置重建模型实例");
+    }
+
+    @Test
+    @DisplayName("白名单应包含前端下拉与内部硬编码使用的全部模型（OpenRouter 2026-07 实测在线）")
+    void allowedModelsCoverFrontendAndInternalIds() {
+        // 前端 ChatInterface.vue availableModels + 标题/摘要用的轻量模型
+        String[] required = {
+                "google/gemini-2.5-flash",
+                "google/gemini-2.5-flash-lite",
+                "google/gemini-2.5-pro",
+                "google/gemini-3.1-pro-preview",
+                "openai/gpt-5.2",
+        };
+        for (String id : required) {
+            assertTrue(AllowedModels.isAllowed(id), "白名单缺失: " + id);
+        }
+    }
+}

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -610,12 +610,18 @@ export default {
 
     // Model Selection
     const showModelDropdown = ref(false)
-    // 模型 ID 必须与后端 AllowedModels 白名单一致，且为 OpenRouter 当前在线模型
+    // 模型 ID 必须与后端 AllowedModels 白名单一致，且为 OpenRouter 当前在线模型。
+    // 排序：区域无关模型在前（Google/Anthropic/OpenAI 系在国内网络会被
+    // OpenRouter 返回 403 region 错误，仅国际网络可用）
     const availableModels = [
-      { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash' },
-      { id: 'google/gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro' },
-      { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' },
-      { id: 'openai/gpt-5.2', name: 'GPT-5.2' }
+      { id: 'deepseek/deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+      { id: 'deepseek/deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+      { id: 'qwen/qwen3-235b-a22b-2507', name: 'Qwen3 235B' },
+      { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
+      { id: 'z-ai/glm-5', name: 'GLM-5' },
+      { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5 (国际网络)' },
+      { id: 'google/gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro (国际网络)' },
+      { id: 'openai/gpt-5.2', name: 'GPT-5.2 (国际网络)' }
     ]
     const currentModelId = ref(availableModels[0].id)
     const currentModelName = ref(availableModels[0].name)

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -610,9 +610,11 @@ export default {
 
     // Model Selection
     const showModelDropdown = ref(false)
+    // 模型 ID 必须与后端 AllowedModels 白名单一致，且为 OpenRouter 当前在线模型
     const availableModels = [
-      { id: 'google/gemini-2.0-flash-001', name: 'Gemini 2.0 Flash' },
-      { id: 'google/gemini-3-pro-preview', name: 'Gemini 3 Pro' },
+      { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash' },
+      { id: 'google/gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro' },
+      { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' },
       { id: 'openai/gpt-5.2', name: 'GPT-5.2' }
     ]
     const currentModelId = ref(availableModels[0].id)


### PR DESCRIPTION
## 问题

配置了 OpenRouter key 并在 AI 设置中把供应商切到 OpenRouter 后，仍然无法与 AI 对话。

## 根因（真机日志 + 真实 key 端到端验证，共 6 处）

1. **供应商切换从未生效**：管理后台写入 system_setting 的 `ai.activeProvider`，但 `ChatModelFactory` 只读 application.yml 静态配置，该 DB 键从未被聊天链路读取。
2. **静默回退本地 Ollama**：`provider=OPENROUTER` 时，空/非白名单 modelId（如下拉里的 `openai/gpt-5.2`）直接落到 Ollama → `localhost:11434 Connection refused`。
3. **模型清单过时**：默认 `google/gemini-2.0-flash-001`、标题/摘要用的 `gemini-2.0-flash-exp:free`、白名单里的 `claude-3.5-sonnet` 等已从 OpenRouter 下线 → `404 No endpoints found`。
4. **区域屏蔽**：国内网络下 Google/Anthropic/OpenAI 全系被 OpenRouter 返回 `403 not available in your region`（真实 key 逐一实测）；可用的只有 DeepSeek/Qwen/GLM/Kimi/MiniMax/Llama——默认模型必须区域无关。
5. **向导只填 key 时 baseUrl 以空串入库**（`toSettingsUpdates` 的 `safe()`）→ `baseUrl cannot be null or empty`。
6. **空 modelId 请求计量落库**违反 `TokenUsage.model` 非空约束 → 流式事务 rollback-only，对话收尾报错。

## 修复

- `ChatModelFactory.resolveProvider()` 优先读 DB `ai.activeProvider`；OPENROUTER 下空/非白名单模型统一走默认模型，不再回退 Ollama
- `getSetting()`：DB 空白值回退 yml 默认（key/baseUrl 均适用）
- 默认模型（含标题生成/对话摘要/yml/Java 默认）→ `deepseek/deepseek-v4-flash`（$0.09/$0.18 per M，区域无关）
- `AllowedModels` 按 2026-07 OpenRouter 在线清单更新：区域无关组（DeepSeek V4/V3.2、Qwen3 235B、GLM-5、Kimi K2.6、MiniMax M3、Llama 3.3）+ 国际组（Gemini 2.5/3.1、Claude Sonnet 5/Haiku、GPT-5.2/4o）
- 前端下拉与白名单对齐，区域无关模型在前，国际模型标注"(国际网络)"
- 管理后台/向导保存后 `clearCache()`，新配置即时生效
- `TokenUsageService` 空 modelId 落 "default"

## 验证

- `ChatModelFactoryTest` 8 例（供应商路由/回退/空白配置/缓存/白名单覆盖）
- 全量 `mvn test`（JDK 21）：225 tests, 0 failures
- **端到端**（隔离实例 :9797 + 真实 OpenRouter key）：向导写配置 → 登录 → SSE `/api/agent/chat`，空 model 与显式 deepseek-v4-pro 均正常流式回复「测试成功」，标题生成正常，无 error 事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
