### PR TITLE
fix(desktop): 剪贴板图片预览被浏览器 BrowserView 遮挡 / clipboard image preview hidden behind BrowserView

### DIFF
--- a/frontend/src/components/ClipboardPanel.vue
+++ b/frontend/src/components/ClipboardPanel.vue
@@ -219,9 +219,9 @@ export default {
     previewImage(it) {
         const url = this.getImageUrl(it)
         if (url) {
-            uni.previewImage({
-                urls: [url]
-            })
+            // 桌面端 BrowserView 会盖住 uni.previewImage 的 DOM 蒙层，
+            // 交给 project-overview 用统一守卫(desktopOverlayActive)的预览层展示
+            this.$emit('preview-image', url)
         }
     }
   }

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -896,6 +896,7 @@
                     ref="clipboardPanel"
                     :query="toolsSearchKeyword"
                     @insert="insertPlainTextToWps"
+                    @preview-image="openImagePreview"
                   />
                 </view>
               </view>
@@ -1029,6 +1030,12 @@
             </view>
           </view>
         </view>
+      </view>
+
+      <!-- 图片预览（剪贴板等）：桌面端 BrowserView 盖 DOM，须走 desktopOverlayActive 守卫 -->
+      <view v-if="imagePreviewUrl" class="image-preview-mask" @tap="closeImagePreview">
+        <image class="image-preview-img" :src="imagePreviewUrl" mode="aspectFit"></image>
+        <view class="image-preview-close" @tap.stop="closeImagePreview">✕</view>
       </view>
 
       <!-- Screenshot Save Dialog -->
@@ -1295,6 +1302,7 @@ export default {
       project: {},
       // Screenshot Save Dialog
       showScreenshotSaveDialog: false,
+      imagePreviewUrl: '',
       screenshotSaveName: '',
       screenshotSaveParentId: null,
       screenshotFolderTree: [],
@@ -1537,6 +1545,7 @@ export default {
         this.showCompareDialog ||
         this.showFilePicker ||
         this.showInviteModal ||
+        !!this.imagePreviewUrl ||
         (this.fileLinkPicker && this.fileLinkPicker.visible)
       )
     },
@@ -3909,6 +3918,14 @@ export default {
     closeScreenshotSaveDialog() {
         this.showScreenshotSaveDialog = false
         this.screenshotSaveDataUrl = ''
+    },
+
+    openImagePreview(url) {
+        if (url) this.imagePreviewUrl = url
+    },
+
+    closeImagePreview() {
+        this.imagePreviewUrl = ''
     },
 
     async confirmSaveScreenshot() {
@@ -9051,6 +9068,41 @@ $bg-white: #FFFFFF;
   align-items: center;
   justify-content: center;
   z-index: 1000;
+}
+
+.image-preview-mask {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  cursor: zoom-out;
+}
+
+.image-preview-img {
+  width: 90%;
+  height: 90%;
+}
+
+.image-preview-close {
+  position: absolute;
+  top: 24px;
+  right: 32px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
 }
 
 .ocr-modal {


### PR DESCRIPTION
## 问题
桌面端打开浏览器 tab 后，在剪贴板面板点击图片预览，预览层被浏览器界面遮挡（BrowserView 是原生层，永远盖在 HTML 之上）。

## 根因
剪贴板用的 `uni.previewImage` 是 DOM 蒙层，且 H5 下无关闭回调，无法接入 v0.6.1 建立的 `desktopOverlayActive` 统一守卫。

## 修复
- ClipboardPanel 不再直接调 `uni.previewImage`，改为 emit `preview-image`
- project-overview 渲染自有全屏图片预览层（`imagePreviewUrl`，点击任意处或 ✕ 关闭）
- 该 flag 纳入 `desktopOverlayActive`：预览打开 → 隐藏 BrowserView；关闭 → 恢复并重同步 bounds（复用既有 watcher，未新写 setViewsVisible）

## 验证
- `npm run build:h5` 构建通过
- 守卫链路与既有弹窗（导出/截图/邀请等）完全同构

🤖 Generated with [Claude Code](https://claude.com/claude-code)