### PR TITLE
feat(skills): 在线 Skill 广场——桌面端接官网 registry 一键安装

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/SkillController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/SkillController.java
@@ -2,7 +2,9 @@ package com.checkba.controller.ai;
 
 import com.checkba.controller.AuthController;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
 import com.checkba.service.ai.skill.SkillDefinition;
+import com.checkba.service.ai.skill.SkillMarketService;
 import com.checkba.service.ai.skill.SkillRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,10 +23,13 @@ import java.util.Map;
 
 /**
  * Skill 管理接口（规范见 docs/SKILL_SPEC.md，鉴权模式与 PluginController 一致）：
- * - GET  /list          Skill 列表（含触发词、工具白名单、启用状态），登录即可查看
- * - POST /{id}/enable   启用 skill（仅 admin）
- * - POST /{id}/disable  禁用 skill（仅 admin）
- * - POST /rescan        重新扫描 skills/ 目录与插件携带的 skill（仅 admin）
+ * - GET  /list                    Skill 列表（含触发词、工具白名单、启用状态），登录即可查看
+ * - POST /{id}/enable             启用 skill（仅 admin）
+ * - POST /{id}/disable            禁用 skill（仅 admin）
+ * - POST /rescan                  重新扫描 skills/ 目录与插件携带的 skill（仅 admin）
+ * - GET  /market/list             在线 Skill 广场列表，登录即可查看
+ * - POST /market/install {id}     安装/重装在线 skill（仅 admin，重装即更新）
+ * - POST /market/uninstall {id}   卸载在线安装的 skill（仅 admin）
  */
 @RestController
 @RequestMapping("/api/skills")
@@ -31,7 +37,9 @@ import java.util.Map;
 public class SkillController {
 
     private final SkillRegistry skillRegistry;
+    private final SkillMarketService skillMarketService;
     private final UserRepository userRepository;
+    private final AdminAccessService adminAccessService;
 
     @lombok.Data
     public static class SkillView {
@@ -75,6 +83,50 @@ public class SkillController {
         return ResponseEntity.ok(result);
     }
 
+    /** 在线广场列表；注册表不可达返回 {code:1, message}，不影响本地区块 */
+    @GetMapping("/market/list")
+    public ResponseEntity<Map<String, Object>> listMarket() {
+        try {
+            Map<String, Object> result = ok();
+            result.put("skills", skillMarketService.listMarket());
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/market/install")
+    public ResponseEntity<Map<String, Object>> installMarketSkill(
+            @RequestBody Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        try {
+            String id = skillMarketService.install(body == null ? null : body.get("id"));
+            Map<String, Object> result = ok();
+            result.put("id", id);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/market/uninstall")
+    public ResponseEntity<Map<String, Object>> uninstallMarketSkill(
+            @RequestBody Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        try {
+            skillMarketService.uninstall(body == null ? null : body.get("id"));
+            return ResponseEntity.ok(ok());
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
     private ResponseEntity<Map<String, Object>> setEnabled(String skillId, boolean enabled, String sessionId) {
         if (!isAdmin(sessionId)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
@@ -99,14 +151,14 @@ public class SkillController {
         return view;
     }
 
-    /** 与 AdminConfigController 相同的管理员判定：session -> userId -> username == admin */
+    /** 管理员判定走 AdminAccessService 唯一出口（桌面单机 allow-all-users 时全员管理员） */
     private boolean isAdmin(String sessionId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) {
             return false;
         }
         return userRepository.findById(userId)
-                .map(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .map(adminAccessService::isAdmin)
                 .orElse(false);
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java
@@ -1,0 +1,168 @@
+package com.checkba.service.ai.skill;
+
+import cn.hutool.core.io.FileUtil;
+import cn.hutool.http.HttpRequest;
+import cn.hutool.http.HttpResponse;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * 在线 Skill 广场客户端（官网公共注册表，配置 ai.skills.registry-url）。
+ *
+ * 注册表契约：
+ * - GET {registryUrl}                返回 skill 元数据 JSON 数组；
+ * - GET {registryUrl}/{id}/bundle    返回 { id, version, files: { "skill.yml": ..., "prompt.md": ... } }。
+ *
+ * 安装 = 把 bundle 中的两个已知文件写入 {ai.skills.dir}/{id}/ 后 rescan（重装即更新）；
+ * 注册表不可达只影响广场功能本身，不影响本地 skill / 插件体系。
+ */
+@Service
+@Slf4j
+public class SkillMarketService {
+
+    /** skill id 白名单（kebab-case），同时兼作路径穿越防护 */
+    private static final Pattern SKILL_ID = Pattern.compile("^[a-z0-9][a-z0-9-]{1,49}$");
+
+    /** 允许从 bundle 落盘的文件名——只认这两个已知文件，其余条目一律忽略 */
+    private static final List<String> BUNDLE_FILES = List.of("skill.yml", "prompt.md");
+
+    private final SkillProperties properties;
+    private final SkillRegistry skillRegistry;
+
+    public SkillMarketService(SkillProperties properties, SkillRegistry skillRegistry) {
+        this.properties = properties;
+        this.skillRegistry = skillRegistry;
+    }
+
+    /** 广场 skill 视图：注册表元数据 + 本地是否已安装 */
+    @lombok.Data
+    public static class MarketSkillView {
+        private String id;
+        private String name;
+        private String description;
+        private String icon;
+        private String version;
+        private String author;
+        private String authorDisplayName;
+        private List<String> triggers = new ArrayList<>();
+        private List<String> allowedTools = new ArrayList<>();
+        private Integer downloads;
+        private String updatedAt;
+        private String homepage;
+        /** 本地 SkillRegistry 中已存在同 id skill */
+        private boolean installed;
+    }
+
+    /**
+     * 拉取在线广场列表并标注安装状态。
+     * @throws IllegalStateException 注册表不可达或返回内容无法解析（调用方转 {code:1}，不阻断本地功能）
+     */
+    public List<MarketSkillView> listMarket() {
+        String body = httpGet(properties.getRegistryUrl());
+        List<MarketSkillView> list;
+        try {
+            list = JSONUtil.toList(JSONUtil.parseArray(body), MarketSkillView.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("注册表返回内容无法解析: " + e.getMessage());
+        }
+        for (MarketSkillView view : list) {
+            view.setInstalled(view.getId() != null && skillRegistry.getSkill(view.getId()).isPresent());
+        }
+        return list;
+    }
+
+    /**
+     * 安装（或重装 = 更新）一个在线 skill：下载 bundle 写入 {ai.skills.dir}/{id}/ 并 rescan。
+     * @return 安装的 skill id
+     * @throws IllegalArgumentException id 非法
+     * @throws IllegalStateException 注册表不可达 / bundle 缺必需文件 / 写盘失败
+     */
+    public synchronized String install(String id) {
+        requireValidId(id);
+        String body = httpGet(properties.getRegistryUrl() + "/" + id + "/bundle");
+        JSONObject files;
+        try {
+            files = JSONUtil.parseObj(body).getJSONObject("files");
+        } catch (Exception e) {
+            throw new IllegalStateException("bundle 内容无法解析: " + e.getMessage());
+        }
+        for (String name : BUNDLE_FILES) {
+            if (files == null || !(files.get(name) instanceof CharSequence)) {
+                throw new IllegalStateException("bundle 缺少必需文件: " + name);
+            }
+        }
+        try {
+            File skillDir = new File(properties.getDir(), id);
+            Files.createDirectories(skillDir.toPath());
+            for (String name : BUNDLE_FILES) {
+                Files.writeString(new File(skillDir, name).toPath(), files.getStr(name), StandardCharsets.UTF_8);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("写入 skill 文件失败: " + e.getMessage());
+        }
+        skillRegistry.rescan();
+        log.info("Installed market skill '{}'", id);
+        return id;
+    }
+
+    /**
+     * 卸载在线安装的 skill：删除 {ai.skills.dir}/{id}/ 目录并 rescan。
+     * @throws IllegalArgumentException id 非法或未安装
+     * @throws IllegalStateException skill 来自插件（应通过插件管理卸载）或删除失败
+     */
+    public synchronized void uninstall(String id) {
+        requireValidId(id);
+        SkillDefinition existing = skillRegistry.getSkill(id).orElse(null);
+        if (existing != null && existing.getSourcePluginId() != null) {
+            throw new IllegalStateException("该 Skill 来自插件 " + existing.getSourcePluginId() + "，请通过插件管理卸载");
+        }
+        try {
+            File skillsDir = new File(properties.getDir());
+            File skillDir = new File(skillsDir, id);
+            // 只允许删除 skills 目录正下方的子目录（canonical 校验防符号链接逃逸）
+            if (!skillDir.getCanonicalPath().startsWith(skillsDir.getCanonicalPath() + File.separator)) {
+                throw new IllegalArgumentException("非法 skill 目录: " + id);
+            }
+            if (!skillDir.isDirectory()) {
+                throw new IllegalArgumentException("Skill 未安装: " + id);
+            }
+            FileUtil.del(skillDir);
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("删除 skill 目录失败: " + e.getMessage());
+        }
+        skillRegistry.rescan();
+        log.info("Uninstalled market skill '{}'", id);
+    }
+
+    private static void requireValidId(String id) {
+        if (id == null || !SKILL_ID.matcher(id).matches()) {
+            throw new IllegalArgumentException("非法 skill id: " + id);
+        }
+    }
+
+    /** HTTP GET（单测覆写此 seam 打桩）；非 200 或网络异常抛 IllegalStateException */
+    protected String httpGet(String url) {
+        HttpResponse resp;
+        try {
+            resp = HttpRequest.get(url)
+                    .setConnectionTimeout(5000)
+                    .setReadTimeout(10000)
+                    .execute();
+        } catch (Exception e) {
+            throw new IllegalStateException("注册表不可达: " + e.getMessage());
+        }
+        if (resp.getStatus() != 200) {
+            throw new IllegalStateException("注册表请求失败 (HTTP " + resp.getStatus() + ")");
+        }
+        return resp.body();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillProperties.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillProperties.java
@@ -27,10 +27,15 @@ public class SkillProperties {
     /** 启停名单内存缓存 TTL（毫秒），做法同 ai.plugins.disabled-cache-ttl-ms */
     private long disabledCacheTtlMs = 5000;
 
+    /** 在线 Skill 广场注册表地址（官网公共注册表，见 SkillMarketService） */
+    private String registryUrl = "https://www.aiworkdeck.com/api/registry/skills";
+
     public String getDir() { return dir; }
     public void setDir(String dir) { this.dir = dir; }
     public List<String> getBaseTools() { return baseTools; }
     public void setBaseTools(List<String> baseTools) { this.baseTools = baseTools; }
     public long getDisabledCacheTtlMs() { return disabledCacheTtlMs; }
     public void setDisabledCacheTtlMs(long disabledCacheTtlMs) { this.disabledCacheTtlMs = disabledCacheTtlMs; }
+    public String getRegistryUrl() { return registryUrl; }
+    public void setRegistryUrl(String registryUrl) { this.registryUrl = registryUrl; }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -159,6 +159,8 @@ ai:
     base-tools: [read_document, list_files, query_memory]
     # 启停名单内存缓存 TTL（毫秒）
     disabled-cache-ttl-ms: 5000
+    # 在线 Skill 广场注册表地址（官网公共注册表，见 SkillMarketService）
+    registry-url: https://www.aiworkdeck.com/api/registry/skills
 
 # 文件存储配置
 storage:

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillMarketServiceTest.java
@@ -1,0 +1,203 @@
+package com.checkba.service.ai.skill;
+
+import com.checkba.service.ai.PluginService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SkillMarketService 单测：注册表列表解析与安装标注、id/文件名安全校验、
+ * 安装写盘 + rescan 生效、卸载（含拒绝插件携带 skill）。httpGet seam 打桩，不走真实网络。
+ */
+class SkillMarketServiceTest {
+
+    private static final String REGISTRY_URL = "https://registry.example/api/registry/skills";
+
+    @TempDir
+    Path tempDir;
+
+    /** httpGet seam 打桩：url -> 响应体；未配置的 url 模拟网络失败 */
+    private static class StubMarketService extends SkillMarketService {
+        final Map<String, String> responses = new HashMap<>();
+        final List<String> requestedUrls = new ArrayList<>();
+
+        StubMarketService(SkillProperties properties, SkillRegistry registry) {
+            super(properties, registry);
+        }
+
+        @Override
+        protected String httpGet(String url) {
+            requestedUrls.add(url);
+            String body = responses.get(url);
+            if (body == null) {
+                throw new IllegalStateException("注册表不可达: stub");
+            }
+            return body;
+        }
+    }
+
+    private SkillProperties props;
+    private SkillRegistry registry;
+
+    private StubMarketService newService(Path skillsDir, PluginService pluginService) {
+        props = new SkillProperties();
+        props.setDir(skillsDir.toString());
+        props.setRegistryUrl(REGISTRY_URL);
+        registry = new SkillRegistry(props, null, pluginService);
+        registry.init();
+        return new StubMarketService(props, registry);
+    }
+
+    private void writeLocalSkill(Path dir, String id) throws IOException {
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("skill.yml"), """
+                id: %s
+                name: 本地技能
+                triggers: [本地关键词]
+                """.formatted(id));
+        Files.writeString(dir.resolve("prompt.md"), "本地指引");
+    }
+
+    private static String bundleJson(String id) {
+        return """
+                { "id": "%s", "version": "1.0.0", "files": {
+                    "skill.yml": "id: %s\\nname: 在线技能\\ntriggers: [在线关键词]\\n",
+                    "prompt.md": "在线指引",
+                    "../../evil.txt": "escape",
+                    "hack.sh": "rm -rf /"
+                } }""".formatted(id, id);
+    }
+
+    @Test
+    @DisplayName("listMarket：解析注册表数组并标注 installed（本地已有同 id 的为 true）")
+    void listMarketMarksInstalled() throws IOException {
+        Path skillsDir = tempDir.resolve("skills");
+        writeLocalSkill(skillsDir.resolve("contract-review"), "contract-review");
+        StubMarketService service = newService(skillsDir, new PluginService());
+        service.responses.put(REGISTRY_URL, """
+                [{ "id": "contract-review", "name": "合同审查", "description": "d", "icon": "🧩",
+                   "version": "1.0.0", "author": "u", "authorDisplayName": "显示名",
+                   "triggers": ["合同审查"], "allowedTools": ["read_document"],
+                   "downloads": 12, "updatedAt": "2026-07-14T00:00:00.000Z",
+                   "homepage": "https://example.com" },
+                 { "id": "other-skill", "name": "其他", "triggers": ["其他"] }]""");
+
+        List<SkillMarketService.MarketSkillView> list = service.listMarket();
+
+        assertEquals(2, list.size());
+        SkillMarketService.MarketSkillView first = list.get(0);
+        assertEquals("contract-review", first.getId());
+        assertEquals("合同审查", first.getName());
+        assertEquals("显示名", first.getAuthorDisplayName());
+        assertEquals(List.of("合同审查"), first.getTriggers());
+        assertEquals(12, first.getDownloads());
+        assertTrue(first.isInstalled());
+        assertFalse(list.get(1).isInstalled());
+    }
+
+    @Test
+    @DisplayName("listMarket：注册表不可达/返回非数组时抛 IllegalStateException")
+    void listMarketFailsCleanly() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService());
+        assertThrows(IllegalStateException.class, service::listMarket, "网络失败");
+
+        service.responses.put(REGISTRY_URL, "<html>error page</html>");
+        assertThrows(IllegalStateException.class, service::listMarket, "解析失败");
+    }
+
+    @Test
+    @DisplayName("install：只落盘 skill.yml + prompt.md（bundle 中其余条目忽略），rescan 后可用")
+    void installWritesKnownFilesAndRescans() throws IOException {
+        Path skillsDir = tempDir.resolve("skills");
+        StubMarketService service = newService(skillsDir, new PluginService());
+        service.responses.put(REGISTRY_URL + "/contract-review/bundle", bundleJson("contract-review"));
+
+        assertEquals("contract-review", service.install("contract-review"));
+
+        Path skillDir = skillsDir.resolve("contract-review");
+        assertTrue(Files.isRegularFile(skillDir.resolve("skill.yml")));
+        assertTrue(Files.isRegularFile(skillDir.resolve("prompt.md")));
+        assertFalse(Files.exists(skillDir.resolve("hack.sh")), "白名单外文件不落盘");
+        assertFalse(Files.exists(tempDir.resolve("evil.txt")), "路径穿越条目不落盘");
+        try (var stream = Files.list(skillDir)) {
+            assertEquals(2, stream.count(), "只写两个已知文件");
+        }
+        // rescan 已被 install 触发，skill 立即可用
+        SkillDefinition skill = registry.getSkill("contract-review").orElseThrow();
+        assertEquals("在线技能", skill.getName());
+
+        // 重装即更新：同 id 再次安装直接覆盖，不报错
+        assertEquals("contract-review", service.install("contract-review"));
+    }
+
+    @Test
+    @DisplayName("install：非法 id 直接拒绝（路径穿越守卫），不发起任何请求")
+    void installRejectsInvalidIds() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService());
+        for (String bad : new String[]{null, "", "../evil", "a/b", "UPPER-Case", "a", "-lead", "a".repeat(51)}) {
+            assertThrows(IllegalArgumentException.class, () -> service.install(bad), String.valueOf(bad));
+        }
+        assertTrue(service.requestedUrls.isEmpty(), "校验失败不应发起网络请求");
+    }
+
+    @Test
+    @DisplayName("install：bundle 缺 skill.yml 或 prompt.md 时拒绝，不写盘")
+    void installRequiresBothFiles() {
+        Path skillsDir = tempDir.resolve("skills");
+        StubMarketService service = newService(skillsDir, new PluginService());
+        service.responses.put(REGISTRY_URL + "/half-skill/bundle",
+                """
+                { "id": "half-skill", "version": "1.0.0", "files": { "skill.yml": "id: half-skill" } }""");
+
+        assertThrows(IllegalStateException.class, () -> service.install("half-skill"));
+        assertFalse(Files.exists(skillsDir.resolve("half-skill")), "校验失败不写盘");
+    }
+
+    @Test
+    @DisplayName("uninstall：删除 skills/ 下的目录并 rescan；未安装/非法 id 拒绝")
+    void uninstallRemovesInstalledSkill() throws IOException {
+        Path skillsDir = tempDir.resolve("skills");
+        writeLocalSkill(skillsDir.resolve("contract-review"), "contract-review");
+        StubMarketService service = newService(skillsDir, new PluginService());
+        assertTrue(registry.getSkill("contract-review").isPresent());
+
+        service.uninstall("contract-review");
+
+        assertFalse(Files.exists(skillsDir.resolve("contract-review")));
+        assertTrue(registry.getSkill("contract-review").isEmpty(), "rescan 后注册表同步移除");
+
+        assertThrows(IllegalArgumentException.class, () -> service.uninstall("contract-review"), "重复卸载=未安装");
+        assertThrows(IllegalArgumentException.class, () -> service.uninstall("../evil"));
+    }
+
+    @Test
+    @DisplayName("uninstall：插件携带的 skill（sourcePluginId != null）拒绝卸载")
+    void uninstallRefusesPluginCarriedSkill() throws IOException {
+        Path pluginDir = tempDir.resolve("plugins").resolve("my-plugin");
+        Files.createDirectories(pluginDir);
+        Files.writeString(pluginDir.resolve("manifest.json"), """
+                { "id": "my-plugin", "name": "带技能的插件", "version": "1.0.0", "skills": ["my-skill"] }""");
+        writeLocalSkill(pluginDir.resolve("my-skill"), "plugin-skill");
+        PluginService pluginService = new PluginService(null, tempDir.resolve("plugins").toString());
+        pluginService.init();
+
+        StubMarketService service = newService(tempDir.resolve("skills"), pluginService);
+        assertTrue(registry.getSkill("plugin-skill").isPresent());
+
+        assertThrows(IllegalStateException.class, () -> service.uninstall("plugin-skill"));
+        assertTrue(registry.getSkill("plugin-skill").isPresent(), "插件 skill 原样保留");
+    }
+}

--- a/frontend/src/pages/plugin-market/plugin-market.vue
+++ b/frontend/src/pages/plugin-market/plugin-market.vue
@@ -96,12 +96,52 @@
           </view>
         </view>
       </view>
+
+      <!-- 在线广场区块（官网 Skill 注册表，重装即更新） -->
+      <view class="section-header">
+        <text class="section-title">在线广场</text>
+        <text class="section-subtitle">来自官网的公开 Skill，安装后写入服务端 skills/ 目录</text>
+      </view>
+      <view v-if="marketError" class="empty">
+        <text>在线广场暂不可用（离线或网络受限）</text>
+        <text class="empty-hint">{{ marketError }}</text>
+      </view>
+      <view v-else-if="marketSkills.length === 0" class="empty">
+        <text>{{ marketLoading ? '加载中...' : '暂无在线 Skill' }}</text>
+      </view>
+      <view v-else>
+        <view v-for="m in marketSkills" :key="m.id" class="plugin-card">
+          <view class="card-header">
+            <text class="plugin-icon">{{ m.icon || '🧩' }}</text>
+            <view class="title-block">
+              <view class="name-row">
+                <text class="plugin-name">{{ m.name || m.id }}</text>
+                <text class="plugin-version" v-if="m.version">v{{ m.version }}</text>
+              </view>
+              <text class="plugin-meta">作者：{{ m.authorDisplayName || m.author || '未知' }} · {{ m.downloads || 0 }} 次下载</text>
+            </view>
+            <view class="market-actions">
+              <button class="btn" type="primary" size="mini" :disabled="!!marketBusyId" @tap="installSkill(m)">
+                {{ marketBusyId === m.id ? '处理中...' : (m.installed ? '更新' : '安装') }}
+              </button>
+              <button v-if="m.installed" class="btn" type="warn" size="mini" plain :disabled="!!marketBusyId" @tap="uninstallSkill(m)">卸载</button>
+            </view>
+          </view>
+
+          <text class="plugin-desc">{{ m.description || '暂无描述' }}</text>
+
+          <view class="tag-row">
+            <text v-if="m.installed" class="installed-tag">已安装</text>
+            <text v-for="t in m.triggers" :key="t" class="trigger-tag">{{ t }}</text>
+          </view>
+        </view>
+      </view>
     </scroll-view>
   </view>
 </template>
 
 <script>
-import { getPlugins, setPluginEnabled, rescanPlugins, getSkills, setSkillEnabled, rescanSkills } from '@/services/api.js'
+import { getPlugins, setPluginEnabled, rescanPlugins, getSkills, setSkillEnabled, rescanSkills, getSkillMarket, installMarketSkill, uninstallMarketSkill } from '@/services/api.js'
 
 const PERMISSION_LABELS = {
   file_read: '读取文件',
@@ -116,6 +156,10 @@ export default {
     return {
       plugins: [],
       skills: [],
+      marketSkills: [],
+      marketLoading: false,
+      marketError: '',
+      marketBusyId: '',
       loading: false,
       switching: false,
       rescanning: false,
@@ -124,6 +168,7 @@ export default {
   onLoad() {
     this.loadPlugins()
     this.loadSkills()
+    this.loadMarket()
   },
   methods: {
     permissionLabel(perm) {
@@ -185,6 +230,49 @@ export default {
         await this.loadSkills()
       } finally {
         this.switching = false
+      }
+    },
+    async loadMarket() {
+      this.marketLoading = true
+      this.marketError = ''
+      try {
+        const res = await getSkillMarket()
+        this.marketSkills = res?.skills || []
+      } catch (e) {
+        // 注册表不可达只在区块内提示，不弹 toast、不影响本地插件 / Skill 区块
+        console.warn('在线广场不可用:', e)
+        this.marketError = e?.message || '网络不可用'
+        this.marketSkills = []
+      } finally {
+        this.marketLoading = false
+      }
+    },
+    async installSkill(skill) {
+      this.marketBusyId = skill.id
+      try {
+        await installMarketSkill(skill.id)
+        uni.showToast({ title: skill.installed ? '已更新' : '已安装', icon: 'none' })
+        await this.loadSkills()
+        await this.loadMarket()
+      } catch (e) {
+        console.error('安装 Skill 失败:', e)
+        uni.showToast({ title: e?.message || '安装失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.marketBusyId = ''
+      }
+    },
+    async uninstallSkill(skill) {
+      this.marketBusyId = skill.id
+      try {
+        await uninstallMarketSkill(skill.id)
+        uni.showToast({ title: '已卸载', icon: 'none' })
+        await this.loadSkills()
+        await this.loadMarket()
+      } catch (e) {
+        console.error('卸载 Skill 失败:', e)
+        uni.showToast({ title: e?.message || '卸载失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.marketBusyId = ''
       }
     },
     async rescan() {
@@ -404,6 +492,21 @@ export default {
   border-radius: 999rpx;
   background-color: rgba(#67c23a, 0.12);
   color: #4f9a2c;
+}
+
+.market-actions {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8rpx;
+  flex-shrink: 0;
+}
+
+.installed-tag {
+  font-size: 22rpx;
+  padding: 2rpx 12rpx;
+  border-radius: 999rpx;
+  background-color: rgba($uni-color-primary, 0.08);
+  color: $uni-color-primary;
 }
 
 .tool-list {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -452,6 +452,38 @@ export function rescanSkills() {
   });
 }
 
+// 在线 Skill 广场：拉取官网注册表列表（登录即可查看）
+export function getSkillMarket() {
+  return request({
+    url: '/api/skills/market/list',
+    method: 'GET'
+  });
+}
+
+// 安装 / 重装在线 Skill（仅管理员，重装即更新）
+export function installMarketSkill(skillId) {
+  return request({
+    url: '/api/skills/market/install',
+    method: 'POST',
+    data: { id: skillId },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+// 卸载在线安装的 Skill（仅管理员）
+export function uninstallMarketSkill(skillId) {
+  return request({
+    url: '/api/skills/market/uninstall',
+    method: 'POST',
+    data: { id: skillId },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
 /**
  * 将一段 AI 文本（markdown）导出为 Word 文档并落地到项目文件树中（后端生成 docx）
  * payload: { projectId, parentId, fileName, markdown | content }


### PR DESCRIPTION
## 概要
桌面端插件广场新增「在线广场」区块，对接官网（zeweihan/aiworkdeck_website）新上线的公开 Skill 注册表：用户在 web 端提交的 Skill，桌面端可直接浏览并一键安装。

## 契约（官网侧已同步实现）
- `GET {ai.skills.registry-url}` → Skill 元数据数组（id/name/description/icon/version/author/triggers/allowedTools/downloads）
- `GET {registry-url}/{id}/bundle` → `{id, version, files: {"skill.yml", "prompt.md"}}`，落盘 `skills/<id>/` + rescan 即完成安装

## 改动
- **SkillMarketService**（新）：registry 拉取（5s/10s 超时）、安装（id 正则 + 文件名白名单双重防路径穿越；重装即更新）、卸载（拒绝插件携带 skill；canonical 路径守卫）
- **SkillController**：`GET /api/skills/market/list`（登录）、`POST /market/install|uninstall`（admin）；**管理员判定改走 AdminAccessService 唯一出口**——修复 PR#88 时代硬编码 `username==admin` 的遗留，桌面单机（allow-all-users）下全员可装
- **plugin-market.vue**：在线广场区块（安装/更新/卸载、离线局部降级不影响本地区块）
- **application.yml**：`ai.skills.registry-url` 默认 `https://www.aiworkdeck.com/api/registry/skills`

## 验证
- `mvn test`（JDK 21）全量 **224 通过 0 失败**（新增 SkillMarketServiceTest 7 例：解析/installed 标记/路径穿越/缺文件拒装/卸载守卫）
- `npm run build:h5` 通过
- 本地端到端：官网 dev server ↔ 后端实测 market/list → install（落盘+rescan+installed:true）→ 官网 downloads 计数 +1 → uninstall 清理，全通过；`../evil` 注入被拒

🤖 Generated with [Claude Code](https://claude.com/claude-code)