### PR TITLE
fix(panel): 剪贴板/收藏夹闪电插入图片修复 / clipboard & favorites quick-insert image fix

### DIFF
--- a/frontend/src/components/ProjectFavoritesPanel.vue
+++ b/frontend/src/components/ProjectFavoritesPanel.vue
@@ -21,7 +21,7 @@
                   <text class="icon">🔗</text>
                 </view>
                 <!-- Insert Button -->
-                <view class="favo-btn" @tap.stop="$emit('insert', fav.content)" title="插入">
+                <view class="favo-btn" @tap.stop="insertFav(fav)" title="插入">
                   <text class="icon">⚡</text>
                 </view>
                 <!-- Delete -->
@@ -107,6 +107,15 @@ export default {
       if (fav.sourceUrl) return 'type-web'
       if (fav.imagePath) return 'type-image'
       return 'type-text'
+    },
+    insertFav(fav) {
+      // 图片收藏（网页摘录截图）content 为空串，按纯文本 emit 会被上层静默丢弃
+      const text = (fav.content || '').trim()
+      if (fav.imagePath && !text) {
+        this.$emit('insert', { type: 'IMAGE', content: getFavoriteImageUrl(fav.id) })
+        return
+      }
+      this.$emit('insert', { type: 'TEXT', content: fav.content })
     },
     openUrl(url) {
       if (!url) return

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -4105,7 +4105,21 @@ export default {
            return
          }
          try {
-           const r = await this.libreOfficeExecutor.executeCommand('insert_image', { dataUrl: content })
+           // 剪贴板/收藏夹面板给的是图片 HTTP URL（/api/...?token=...），
+           // insert_image 只认 data URL/base64，先拉字节转 data URL
+           let dataUrl = content
+           if (!/^data:/i.test(dataUrl)) {
+             const resp = await fetch(dataUrl)
+             if (!resp.ok) throw new Error('图片下载失败')
+             const blob = await resp.blob()
+             dataUrl = await new Promise((resolve, reject) => {
+               const reader = new FileReader()
+               reader.onload = () => resolve(reader.result)
+               reader.onerror = () => reject(new Error('图片读取失败'))
+               reader.readAsDataURL(blob)
+             })
+           }
+           const r = await this.libreOfficeExecutor.executeCommand('insert_image', { dataUrl })
            if (!r || !r.success) throw new Error((r && r.message) || '插入图片失败')
            uni.showToast({ title: '已插入图片', icon: 'success' })
          } catch (e) {


### PR DESCRIPTION
## 问题
1. **剪贴板面板**：图片卡片点 ⚡ 报 `invalid base64: Failed to execute 'atob' on 'WorkerGlobalScope'` —— ClipboardPanel emit 的 content 是图片 HTTP URL（`/api/clipboard/{id}/file?token=…`），project-overview 直接当 `dataUrl` 传给 `insert_image`，worker 里 `atob("http://…")` 必然抛错。
2. **收藏夹面板**：图片收藏（网页摘录截图）点 ⚡ 没反应 —— 只 emit `fav.content` 纯字符串，图片收藏创建时 content 为空串，走 TEXT 分支 `if (!t) return` 静默返回。

## 修复
- `project-overview.vue` IMAGE 分支：content 非 data URL 时先 `fetch` → blob → `FileReader.readAsDataURL` 转码，再喂 `insert_image`（office_thread 解码端不动）。
- `ProjectFavoritesPanel.vue`：⚡ 改走 `insertFav(fav)`——有 `imagePath` 且无文本内容时 emit `{type:'IMAGE', content:getFavoriteImageUrl(id)}`，其余保持 TEXT。

## 验证
- `npm run build:h5` 构建通过。
- CORS：后端白名单放行 localhost（dev 5173→9696），Electron 生产同源，fetch 可用；图片 URL 自带 token 鉴权。

🤖 Generated with [Claude Code](https://claude.com/claude-code)