### PR TITLE
fix(clipboard): 复制一次出现多条历史记录（页面栈多实例重复订阅）/ dedup clipboard capture across stacked page instances

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -50,6 +50,8 @@ function emitClipboard(text, source) {
   try {
     const t = String(text || '').trim()
     if (!t) return
+    // 同步轮询指纹：copy/cut 键监听推送过的文本，轮询 watcher 不再重复推送
+    lastClipboardFingerprint = 'TXT_' + t
     if (mainWindow) {
       mainWindow.webContents.send('checkba:clipboard-copied', {
         type: 'TEXT',
@@ -107,14 +109,18 @@ function restoreViewsVisibility() {
 
 // 记录上一次剪贴板内容指纹，防止重复推送
 let lastClipboardFingerprint = ''
+// 首个 tick 只记指纹不推送：启动前就躺在剪贴板里的内容（尤其图片）不算“新复制”，
+// 否则每次重启应用都会把同一张图再入库一次
+let clipboardPrimed = false
 
 function startClipboardWatcher() {
   if (clipboardWatchTimer) return
-  // Init fingerprint
-  lastClipboardFingerprint = (clipboard.readText() || '')
+  clipboardPrimed = false
 
   // 系统级：轮询剪贴板内容变化
   clipboardWatchTimer = setInterval(() => {
+    const priming = !clipboardPrimed
+    clipboardPrimed = true
     try {
       const formats = clipboard.availableFormats()
 
@@ -138,6 +144,7 @@ function startClipboardWatcher() {
           const fingerprint = 'IMG_' + size.width + 'x' + size.height + '_' + bitmap.length + '_' + sample
           if (fingerprint !== lastClipboardFingerprint) {
             lastClipboardFingerprint = fingerprint
+            if (priming) return
             const dataUrl = img.toDataURL()
             console.log('[Clipboard] Image detected, size:', dataUrl.length)
             if (mainWindow) {
@@ -169,6 +176,7 @@ function startClipboardWatcher() {
           const fingerprint = 'FILE_' + cleanPath
           if (fingerprint !== lastClipboardFingerprint) {
             lastClipboardFingerprint = fingerprint
+            if (priming) return
             if (mainWindow) {
               mainWindow.webContents.send('checkba:clipboard-copied', {
                 type: 'FILE',
@@ -201,11 +209,13 @@ function startClipboardWatcher() {
       // 3. 文本 (Text)
       if (hasText) {
         const t = clipboard.readText() || ''
-        const tt = String(t || '')
+        // trim 与 emitClipboard 保持一致，否则两处指纹对不上会反复推送
+        const tt = String(t || '').trim()
         if (!tt) return
         const fingerprint = 'TXT_' + tt
         if (fingerprint !== lastClipboardFingerprint) {
           lastClipboardFingerprint = fingerprint
+          if (priming) return
           emitClipboard(tt, 'system') // reuse emitClipboard for text to keep compat
         }
       }

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -3082,11 +3082,22 @@ export default {
       if (!user) return
       this._clipboardBound = true
       // 统一的“写库 + 立即更新 UI”入口：避免 copy 事件多次触发导致重复入库
-      this._clipboardLast = this._clipboardLast || { ts: 0, text: '' }
+      // 去重状态挂 window 而非组件实例：本页经 navigateTo 反复进入时页面栈里会存在
+      // 多个实例，每个实例都绑定过监听；实例级去重挡不住“一次复制、多实例各入库一条”
+      if (typeof window !== 'undefined' && !window.__checkbaClipLastText) {
+        window.__checkbaClipLastText = { ts: 0, text: '' }
+      }
       const recordClipboardOnce = async (rawText, source = 'doc') => {
         // 1. Electron Payload Object (IMAGE / FILE)
         if (rawText && typeof rawText === 'object') {
            const payload = rawText
+           // 同一事件（ts 相同）会被页面栈里每个实例的监听器各收到一次，只处理第一次；
+           // 图片/文件没有下方文本那样的内容去重，全靠这里挡住重复入库
+           const evKey = String(payload.type || '') + '_' + String(payload.ts || '')
+           if (typeof window !== 'undefined') {
+             if (window.__checkbaClipLastEventKey === evKey) return null
+             window.__checkbaClipLastEventKey = evKey
+           }
            if (payload.type === 'TEXT') {
              return await recordClipboardOnce(payload.text, source)
            } else if (payload.type === 'IMAGE' && payload.data) {
@@ -3163,10 +3174,13 @@ export default {
 
         const now = Date.now()
         // 仅用于防止同一次用户动作被多路监听重复触发（不是业务去重）
-        if (this._clipboardLast.text === t && now - (this._clipboardLast.ts || 0) < 600) {
+        const lastText = (typeof window !== 'undefined' && window.__checkbaClipLastText) || { ts: 0, text: '' }
+        if (lastText.text === t && now - (lastText.ts || 0) < 600) {
           return null
         }
-        this._clipboardLast = { ts: now, text: t, source }
+        if (typeof window !== 'undefined') {
+          window.__checkbaClipLastText = { ts: now, text: t, source }
+        }
 
         try {
           const res = await saveClipboardText(t)


### PR DESCRIPTION
## 问题

用户报告：剪贴板历史里复制一次会出现多条记录，复制一张图有 4 条甚至更多；怀疑与本机 Paste 软件冲突。

## 根因（本机实证，非猜测）

查本机 H2 库 `~/.aiworkdeck/local`：一次复制产生 4 条 IMAGE 记录，文件名 `image_1784018611526/529/532/535.png` 相差仅 3ms —— 同一个 IPC 事件被 **4 个监听器**同时处理。当天记录呈 1→3→4 条递进，与导航次数累积完全吻合。

- 进入 `project-overview` 一律 `uni.navigateTo`（页面入栈、旧实例不销毁）；每个实例都在 `onLoad` 里订阅 `checkba:clipboard-copied`，而解绑在几乎不触发的 `beforeUnmount`。来回切换 4 次 = 4 个活跃订阅 = 一次复制 4 条入库。
- 图片/文件路径此前**完全没有去重**（文本有 600ms 窗口但也是实例级的，挡不住跨实例）。
- **与 Paste 无冲突**：实测（Swift 探针监控 NSPasteboard changeCount）复制一次 changeCount 仅 +1，Paste 只读不改写剪贴板。

## 修复

**渲染端** `project-overview.vue`
- IMAGE/FILE/TEXT 对象事件按 `(type, ts)` 在 `window` 全局去重，同一事件只处理一次（不动订阅生命周期，保留后台/多实例下的捕获能力）
- 文本 600ms 内容去重从实例级改为 window 级

**主进程** `desktop/main/main.js`
- watcher 首个 tick 只记指纹不推送 —— 启动前就在剪贴板里的内容（尤其图片）不再在每次重启后重新入库
- `emitClipboard` 同步轮询指纹 —— 应用内 Cmd+C 键监听与 1s 轮询不再对同一文本双推
- 轮询文本指纹改用 trim 后文本，与 `emitClipboard` 口径一致（否则带首尾空白的文本会每秒反复推送）

## 验证

- 用修复后的 watcher 逻辑做独立 Electron 探针：启动时剪贴板已有图片 → 0 事件；复制新图 → 恰好 1 事件；复制文本 → 恰好 1 事件
- `node --check` main.js 通过；.vue script 块语法检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)