### PR TITLE
fix(plugin/skill): 插件与 Skill 广场管理员判定接入 AdminAccessService

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/PluginController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginController.java
@@ -2,6 +2,7 @@ package com.checkba.controller.ai;
 
 import com.checkba.controller.AuthController;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
 import com.checkba.service.ai.PluginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,6 +32,7 @@ public class PluginController {
 
     private final PluginService pluginService;
     private final UserRepository userRepository;
+    private final AdminAccessService adminAccessService;
 
     @lombok.Data
     public static class PluginView {
@@ -109,14 +111,14 @@ public class PluginController {
         return view;
     }
 
-    /** 与 AdminConfigController 相同的管理员判定：session -> userId -> username == admin */
+    /** 与 AdminConfigController 相同的管理员判定：session -> userId -> AdminAccessService（桌面单机全员管理员的唯一出口） */
     private boolean isAdmin(String sessionId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) {
             return false;
         }
         return userRepository.findById(userId)
-                .map(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .map(adminAccessService::isAdmin)
                 .orElse(false);
     }
 

--- a/backend/src/main/java/com/checkba/controller/ai/SkillController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/SkillController.java
@@ -2,6 +2,7 @@ package com.checkba.controller.ai;
 
 import com.checkba.controller.AuthController;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
 import com.checkba.service.ai.skill.SkillDefinition;
 import com.checkba.service.ai.skill.SkillRegistry;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class SkillController {
 
     private final SkillRegistry skillRegistry;
     private final UserRepository userRepository;
+    private final AdminAccessService adminAccessService;
 
     @lombok.Data
     public static class SkillView {
@@ -99,14 +101,14 @@ public class SkillController {
         return view;
     }
 
-    /** 与 AdminConfigController 相同的管理员判定：session -> userId -> username == admin */
+    /** 与 AdminConfigController 相同的管理员判定：session -> userId -> AdminAccessService（桌面单机全员管理员的唯一出口） */
     private boolean isAdmin(String sessionId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) {
             return false;
         }
         return userRepository.findById(userId)
-                .map(u -> "admin".equalsIgnoreCase(u.getUsername()))
+                .map(adminAccessService::isAdmin)
                 .orElse(false);
     }
 


### PR DESCRIPTION
## 问题

PluginController 与 SkillController 的 `isAdmin(sessionId)` 仍是 PR#88 时代的硬编码判定（`username == "admin"`），未接 PR#134 引入的 AdminAccessService（`security.admin.allow-all-users`，桌面单机全员管理员的唯一出口）。导致桌面版普通用户无法在插件广场/Skill 广场启停插件（skill）与 rescan。

注：原以为 SkillController 在官网 Skill 广场那次 PR 已改，实际 master 上两个控制器都还是旧判定，本 PR 一并修复。

## 改动

- 两个控制器注入 `AdminAccessService`，`isAdmin` 改为 `userRepository.findById(userId).map(adminAccessService::isAdmin).orElse(false)`，与 AdminConfigController 一致。

## 验证

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test -Dtest='Plugin*,Skill*,AdminAccess*'` — 29 个测试全过
- `DesktopContextSmokeTest` — Spring 上下文装配通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)