### PR TITLE
fix(chat)+ci: 恢复 AI 回复插入/替换/导出按钮 + emit/绑定契约 CI 检查 / restore AI message actions & emit-binding contract CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         working-directory: frontend
         run: npm ci || npm install
+      - name: Check emit/binding contracts
+        working-directory: frontend
+        run: npm run check:emits
       - name: Build H5
         working-directory: frontend
         run: npm run build:h5

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "uni-preset-vue",
   "version": "0.0.0",
   "scripts": {
+    "check:emits": "node scripts/check-emit-bindings.mjs",
     "dev:custom": "uni -p",
     "dev:h5": "uni",
     "dev:h5:ssr": "uni --ssr",

--- a/frontend/scripts/check-emit-bindings.mjs
+++ b/frontend/scripts/check-emit-bindings.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * emit/绑定契约静态检查（PR#147 剪贴板/收藏夹闪电 bug 后加装的护栏）。
+ *
+ * 规则：父组件模板里对子组件写了 @some-event="handler"，而子组件源码里
+ * 找不到对应的 $emit('some-event') / emit('some-event') / defineEmits 声明，
+ * 即判为"死绑定"（多半是子组件重构时把 emit 弄丢了，或事件名打错）。
+ *
+ * 只查"绑定 → emit"这个方向：emit 了没人听是合法的（可选事件）。
+ * 原生 DOM/uni-app 事件（click/tap/input/...）会透传到子组件根元素，不检查。
+ * 子组件里存在动态 emit（$emit(variable)）时跳过该组件，避免误报。
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname, resolve, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '../src')
+
+// 原生/透传事件白名单（组件上绑这些不要求子组件 emit）
+const NATIVE_EVENTS = new Set([
+  'click', 'dblclick', 'tap', 'longpress', 'contextmenu',
+  'mousedown', 'mouseup', 'mousemove', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'wheel',
+  'touchstart', 'touchmove', 'touchend', 'touchcancel',
+  'keydown', 'keyup', 'keypress',
+  'input', 'change', 'focus', 'blur', 'submit', 'reset', 'confirm', 'select',
+  'scroll', 'scrolltolower', 'scrolltoupper',
+  'load', 'error', 'loaded',
+  'dragstart', 'drag', 'dragenter', 'dragover', 'dragleave', 'dragend',
+  'animationstart', 'animationend', 'transitionend',
+])
+
+const toKebab = (s) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    const st = statSync(p)
+    if (st.isDirectory()) walk(p, out)
+    else if (name.endsWith('.vue')) out.push(p)
+  }
+  return out
+}
+
+const vueFiles = walk(SRC)
+
+// 1) 每个 .vue 组件声明/使用的 emit 事件名（kebab 归一）
+const emitsByFile = new Map()   // absPath -> Set<kebab-name> | null(动态 emit，跳过)
+for (const f of vueFiles) {
+  const code = readFileSync(f, 'utf8')
+  // 动态 emit：$emit(expr) / emit(expr)，无法静态分析 → 该组件不检查
+  if (/[$.\s]emit\(\s*[^'")\s]/.test(code)) { emitsByFile.set(f, null); continue }
+  const names = new Set()
+  for (const m of code.matchAll(/[$.\s]emit\(\s*['"]([\w:-]+)['"]/g)) names.add(toKebab(m[1]))
+  for (const m of code.matchAll(/defineEmits\(\s*\[([^\]]*)\]/gs)) {
+    for (const e of m[1].matchAll(/['"]([\w:-]+)['"]/g)) names.add(toKebab(e[1]))
+  }
+  for (const m of code.matchAll(/emits\s*:\s*\[([^\]]*)\]/gs)) {
+    for (const e of m[1].matchAll(/['"]([\w:-]+)['"]/g)) names.add(toKebab(e[1]))
+  }
+  emitsByFile.set(f, names)
+}
+
+// 2) 逐文件解析 import 出的本地组件标签 → 源文件，再对模板里 <Tag ... @event 检查
+let errors = 0
+for (const f of vueFiles) {
+  const code = readFileSync(f, 'utf8')
+  const tagToFile = new Map()
+  for (const m of code.matchAll(/import\s+(\w+)\s+from\s+['"]([^'"]+\.vue)['"]/g)) {
+    const [, local, spec] = m
+    const abs = spec.startsWith('@/') ? resolve(SRC, spec.slice(2)) : resolve(dirname(f), spec)
+    tagToFile.set(local, abs)
+  }
+  if (tagToFile.size === 0) continue
+
+  for (const [tag, target] of tagToFile) {
+    const emits = emitsByFile.get(target)
+    if (emits === undefined || emits === null) continue // 非本仓组件或动态 emit → 跳过
+    // 标签可能写成 <PascalCase 或 <kebab-case>
+    const tagPattern = new RegExp(`<(?:${tag}|${toKebab(tag)})\\b([^>]*)`, 'g')
+    for (const m of code.matchAll(tagPattern)) {
+      const attrs = m[1]
+      for (const ev of attrs.matchAll(/@([\w-]+(?::[\w-]+)?)(?:\.[\w.]+)*=/g)) {
+        const name = toKebab(ev[1])
+        if (NATIVE_EVENTS.has(name)) continue
+        if (name.startsWith('update:')) continue // v-model 族，另有机制
+        if (!emits.has(name)) {
+          const line = code.slice(0, m.index).split('\n').length
+          console.error(`✗ ${f.replace(SRC, 'src')}:${line}  <${tag}> 绑定了 @${name}，但 ${basename(target)} 从不 emit '${name}'`)
+          errors++
+        }
+      }
+    }
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n共 ${errors} 处死绑定/事件名不匹配。子组件重构丢了 emit，或事件名拼错。`)
+  process.exit(1)
+}
+console.log(`✓ emit/绑定契约检查通过（扫描 ${vueFiles.length} 个 .vue）`)

--- a/frontend/src/components/AgentMessage/RootBubble.vue
+++ b/frontend/src/components/AgentMessage/RootBubble.vue
@@ -59,6 +59,13 @@
                <MarkdownPreview :content="bubble.content" />
             </div>
 
+            <!-- 5b. Message Actions（旧 UI 的插入/替换/导出，ChatInterface 重写时丢失后恢复） -->
+            <div v-if="bubble.content && !bubble.isStreaming" class="message-actions">
+               <span class="msg-act-btn primary" @click="sendAction('insert')">插入当前文档</span>
+               <span class="msg-act-btn" @click="sendAction('replace')">替换选区</span>
+               <span class="msg-act-btn" @click="sendAction('export')">导出为Word</span>
+            </div>
+
             <!-- 6. Walkthrough (Summary) - Temporarily hidden as per user request -->
             <!-- <WalkthroughCard
               v-if="bubble.walkthrough"
@@ -85,7 +92,12 @@ const props = defineProps({
   bubble: { type: Object, required: true }
 })
 
-defineEmits(['open-artifact-tab', 'approve'])
+const emit = defineEmits(['open-artifact-tab', 'approve', 'message-action'])
+
+// 载荷形状对齐 project-overview.handleChatInterfaceAction({ type, msg })，msg 只需 content
+function sendAction(type) {
+  emit('message-action', { type, msg: { content: props.bubble.content } })
+}
 
 const isReady = computed(() => {
     // Show full card if we have a Title OR Processes OR Main Content
@@ -157,6 +169,38 @@ const hasContent = computed(() => {
   font-size: 14px;
   line-height: 1.6;
   color: #2C3338; /* Gray-Dark */
+}
+
+.message-actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 16px 12px;
+  border-top: 1px solid #f1f5f9;
+  margin-top: 6px;
+}
+
+.msg-act-btn {
+  font-size: 12px;
+  padding: 3px 10px;
+  border-radius: 5px;
+  border: 1px solid #E9ECEF;
+  color: #6C757D;
+  background: #FFFFFF;
+  cursor: pointer;
+  transition: all 0.2s;
+  user-select: none;
+}
+
+.msg-act-btn:hover {
+  border-color: #5BD197;
+  color: #1A5336;
+  background: #E6F9F0;
+}
+
+.msg-act-btn.primary {
+  border-color: rgba(91, 209, 151, 0.5);
+  color: #1A5336;
+  background: rgba(91, 209, 151, 0.08);
 }
 
 .main-content:deep(p) {

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -298,6 +298,7 @@
                :bubble="msg"
                @open-artifact-tab="handleArtifactOpenTab"
                @approve="handleArtifactApprove"
+               @message-action="$emit('message-action', $event)"
              />
              <!-- <span v-if="msg.timestamp" class="bubble-timestamp assistant">{{ msg.timestamp }}</span> -->
           </div>

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -135,8 +135,8 @@
                     v-for="tag in (targetFileForTags ? targetFileForTags.tags : [])"
                     :key="tag.id"
                     :tag="tag"
-                    :removable="true"
-                    @remove="handleRemoveTag(tag)"
+                    :closable="true"
+                    @close="handleRemoveTag(tag)"
                   />
               </view>
            </view>

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -879,9 +879,6 @@
                     :project-id="projectId"
                     :get-wps="getLibreVariableBridge"
                     :search-keyword="toolsSearchKeyword"
-                    @insert="handleInsertVariable"
-                    @update-from-selection="handleUpdateVariable"
-                    @sync-document="handleSyncDocument"
                   />
                   <ProjectFavoritesPanel
                     v-else-if="activeToolKey === 'favorites'"
@@ -6353,15 +6350,6 @@ export default {
       this.showHistoryDrawer = false // Close drawer if open
     },
 
-    handleInsertVariable(text) {
-      this.insertPlainTextToWps(text)
-    },
-    handleUpdateVariable() {
-      // Logic handled inside VariablePanel, no extra parent action needed unless event is emitted
-    },
-    handleSyncDocument(e) {
-      // Pass through or log
-    },
     handleOpenCreateVariable() {
       if (this.$refs.variablePanel) this.$refs.variablePanel.openCreateModal()
     },


### PR DESCRIPTION
上一轮剪贴板/收藏夹闪电 bug（#147）暴露的验证缺口的后续：全量交叉核对 emit/绑定契约后发现的功能退化修复 + 防再犯护栏。

## 1. 恢复 AI 回复操作按钮（功能退化）
ChatInterface 重写时，AI 回复气泡上的操作按钮整体丢失：`@message-action` 绑定和 `handleChatInterfaceAction`（插入/替换/导出三个 handler 全部完好）成了死代码。按旧 UI（3f2f804 时代）原样恢复：
- RootBubble 主内容下方新增 **插入当前文档 / 替换选区 / 导出为Word** 动作行（流式输出中不显示）
- ChatInterface 透传 `message-action`，载荷 `{type, msg:{content}}` 与现存 handler 契约一致

## 2. emit/绑定契约 CI 检查（防再犯）
`frontend/scripts/check-emit-bindings.mjs`：静态扫描全部 .vue，父组件模板绑定了子组件从不 emit 的事件 → CI 失败。原生事件白名单、动态 emit 跳过、kebab/camel 归一。挂进 `npm run check:emits` + ci.yml frontend job（build 前跑，秒级）。

## 3. 脚本首跑抓到的真 bug：文件树标签删不掉
FileTree 标签对话框给 TagChip 传了不存在的 `removable` prop、绑了不存在的 `remove` 事件（实际是 `closable`/`close`）——删除 × 从不渲染，文件标签在该对话框里一直无法移除。已修正。

## 4. 死绑定清理
VariablePanel 的 `@insert`/`@update-from-selection`/`@sync-document`（面板从不 emit，逻辑全在面板内部）及孤儿 handler 移除，使契约检查零误报通过。

## 验证
- `npm run check:emits` ✓（44 个 .vue 零违例；曾对 FileTree bug 正确报错）
- `npm run build:h5` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)