### PR TITLE
fix(overview): 页面栈多实例全局监听审计——桌面 IPC 只让活跃实例处理 / gate stacked-instance desktop IPC handlers to the active overview instance

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -50,6 +50,8 @@ function emitClipboard(text, source) {
   try {
     const t = String(text || '').trim()
     if (!t) return
+    // 同步轮询指纹：copy/cut 键监听推送过的文本，轮询 watcher 不再重复推送
+    lastClipboardFingerprint = 'TXT_' + t
     if (mainWindow) {
       mainWindow.webContents.send('checkba:clipboard-copied', {
         type: 'TEXT',
@@ -107,14 +109,18 @@ function restoreViewsVisibility() {
 
 // 记录上一次剪贴板内容指纹，防止重复推送
 let lastClipboardFingerprint = ''
+// 首个 tick 只记指纹不推送：启动前就躺在剪贴板里的内容（尤其图片）不算“新复制”，
+// 否则每次重启应用都会把同一张图再入库一次
+let clipboardPrimed = false
 
 function startClipboardWatcher() {
   if (clipboardWatchTimer) return
-  // Init fingerprint
-  lastClipboardFingerprint = (clipboard.readText() || '')
+  clipboardPrimed = false
 
   // 系统级：轮询剪贴板内容变化
   clipboardWatchTimer = setInterval(() => {
+    const priming = !clipboardPrimed
+    clipboardPrimed = true
     try {
       const formats = clipboard.availableFormats()
 
@@ -138,6 +144,7 @@ function startClipboardWatcher() {
           const fingerprint = 'IMG_' + size.width + 'x' + size.height + '_' + bitmap.length + '_' + sample
           if (fingerprint !== lastClipboardFingerprint) {
             lastClipboardFingerprint = fingerprint
+            if (priming) return
             const dataUrl = img.toDataURL()
             console.log('[Clipboard] Image detected, size:', dataUrl.length)
             if (mainWindow) {
@@ -169,6 +176,7 @@ function startClipboardWatcher() {
           const fingerprint = 'FILE_' + cleanPath
           if (fingerprint !== lastClipboardFingerprint) {
             lastClipboardFingerprint = fingerprint
+            if (priming) return
             if (mainWindow) {
               mainWindow.webContents.send('checkba:clipboard-copied', {
                 type: 'FILE',
@@ -201,11 +209,13 @@ function startClipboardWatcher() {
       // 3. 文本 (Text)
       if (hasText) {
         const t = clipboard.readText() || ''
-        const tt = String(t || '')
+        // trim 与 emitClipboard 保持一致，否则两处指纹对不上会反复推送
+        const tt = String(t || '').trim()
         if (!tt) return
         const fingerprint = 'TXT_' + tt
         if (fingerprint !== lastClipboardFingerprint) {
           lastClipboardFingerprint = fingerprint
+          if (priming) return
           emitClipboard(tt, 'system') // reuse emitClipboard for text to keep compat
         }
       }

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1736,6 +1736,10 @@ export default {
     }
   },
   beforeUnmount() {
+    // 多实例守卫：只清掉指向自己的活跃指针；返回上一个本页实例时由其 onShow 重新接管
+    if (typeof window !== 'undefined' && window.__checkbaActiveOverviewVm === this) {
+      window.__checkbaActiveOverviewVm = null
+    }
     this.teardownResponsiveListener()
     // Epic #43: 解绑 ⌘⇧O 嵌入式编辑器监听
     try { if (this._zetaOpenEmbedUnsub) { this._zetaOpenEmbedUnsub(); this._zetaOpenEmbedUnsub = null } } catch (e) { /* ignore */ }
@@ -1795,12 +1799,15 @@ export default {
     }
     this._wpsInternalMsgHandler = null
     try {
-      if (typeof window !== 'undefined' && window.__checkbaHandleInternalLink) {
+      // 只删除自己安装的处理器：无条件 delete 会把栈下方旧实例还在用的处理器一并删掉
+      // （A→B 再返回后 A 的 WPS 内链失效）；A 的接管在 onShow 里完成
+      if (typeof window !== 'undefined' && this._wpsInternalLinkFn && window.__checkbaHandleInternalLink === this._wpsInternalLinkFn) {
         delete window.__checkbaHandleInternalLink
       }
     } catch (e) {
       // ignore
     }
+    this._wpsInternalLinkFn = null
 
     // Desktop：解绑 OCR 选区结果监听
     try {
@@ -1879,6 +1886,13 @@ export default {
     this.loadDynamicPlugins() // Fetch dynamic plugins
   },
   onShow() {
+    // 多实例守卫：本实例重新可见（如从个人中心返回）时接管全局事件与 WPS 内链处理，
+    // 否则全局指针仍指向已销毁/被覆盖的后进实例
+    if (typeof window !== 'undefined') {
+      window.__checkbaActiveOverviewVm = this
+      if (this._wpsInternalLinkFn) window.__checkbaHandleInternalLink = this._wpsInternalLinkFn
+    }
+
     // Sync UI state
     this.isRecording = activityTracker.getRecordingState()
 
@@ -1928,12 +1942,19 @@ export default {
     }
   },
   mounted() {
+    // 多实例守卫：本页经 navigateTo 反复进入时页面栈里会有多个存活实例，每个都在
+    // mounted 绑定了全局（ipcRenderer/window 级）监听；全局事件只让最近展示的实例
+    // 处理，否则一次事件触发 N 份副作用（与 PR#148 剪贴板重复入库同源）
+    if (typeof window !== 'undefined') window.__checkbaActiveOverviewVm = this
     this.setupResponsiveListener()
     // Desktop：网页选中“加入网核收藏”（右键菜单触发）
     try {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.onWebMark) {
         if (!this._desktopWebMarkUnsub) {
           this._desktopWebMarkUnsub = window.checkbaDesktop.browser.onWebMark(async (payload) => {
+            // 页面栈里每个实例都订阅了本事件：只让活跃实例入库，否则一次“加入网核收藏”
+            // 会按实例数重复 POST，且旧实例还会把收藏写进它自己的 projectId
+            if (!this.isActiveOverviewInstance()) return
             try {
               const text = payload && payload.text ? String(payload.text).trim() : ''
               const url = payload && payload.url ? String(payload.url).trim() : ''
@@ -1971,6 +1992,7 @@ export default {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.onOpenNewTab) {
         if (!this._desktopRendererOpenUnsub) {
           this._desktopRendererOpenUnsub = window.checkbaDesktop.browser.onOpenNewTab((data) => {
+            if (!this.isActiveOverviewInstance()) return
             try {
               if (!data || data.id !== 'renderer' || !data.url) return
               this.openBrowserTab(String(data.url))
@@ -2007,6 +2029,8 @@ export default {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.zetaoffice && window.checkbaDesktop.zetaoffice.onOpenEmbed) {
         if (!this._zetaOpenEmbedUnsub) {
           this._zetaOpenEmbedUnsub = window.checkbaDesktop.zetaoffice.onOpenEmbed(() => {
+            // 非活跃实例不响应：否则被覆盖的旧实例也置 showLibreEmbed，返回时凭空弹出编辑器
+            if (!this.isActiveOverviewInstance()) return
             if (!this.libreOfficePreferred) this.showLibreEmbed = true
           })
         }
@@ -2020,6 +2044,7 @@ export default {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.app && window.checkbaDesktop.app.onOpenInternal) {
         if (!this._desktopOpenInternalUnsub) {
           this._desktopOpenInternalUnsub = window.checkbaDesktop.app.onOpenInternal((payload) => {
+            if (!this.isActiveOverviewInstance()) return
             try {
               const raw0 = payload && payload.url ? String(payload.url) : ''
               if (!raw0 || !raw0.startsWith('checkba:')) return
@@ -2085,7 +2110,8 @@ export default {
     try {
       // 给 WPS SDK onHyperLinkOpen 直接调用：避免 window.open/postMessage 的不确定性
       if (typeof window !== 'undefined') {
-        window.__checkbaHandleInternalLink = (url) => {
+        // 记住自己的处理器引用：onShow 重新接管 / beforeUnmount 按引用删除都靠它
+        this._wpsInternalLinkFn = (url) => {
           try {
             const raw0 = url ? String(url) : ''
             if (!raw0) return
@@ -2149,6 +2175,7 @@ export default {
             // ignore
           }
         }
+        window.__checkbaHandleInternalLink = this._wpsInternalLinkFn
         window.addEventListener('message', this._wpsInternalMsgHandler)
       }
     } catch (e) {
@@ -2160,6 +2187,8 @@ export default {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.ocr && window.checkbaDesktop.ocr.onSelectionError) {
         if (!this._desktopOcrSelectionErrUnsub) {
           this._desktopOcrSelectionErrUnsub = window.checkbaDesktop.ocr.onSelectionError((data) => {
+            // 只让活跃实例弹一次 toast，避免页面栈里 N 个实例连弹 N 次
+            if (!this.isActiveOverviewInstance()) return
             const msg = data && data.message ? String(data.message) : '截图失败'
             uni.showToast({ title: msg, icon: 'none' })
           })
@@ -2884,6 +2913,13 @@ export default {
           this.triggerClipboardRefresh()
         }
       })
+    },
+    isActiveOverviewInstance() {
+      // 多实例守卫：navigateTo 进入本页不销毁旧实例，页面栈里每个实例都持有一份
+      // 全局监听。全局事件只让“最近展示的实例”处理（onShow/mounted 时登记，
+      // beforeUnmount 注销）。指针缺失时放行，避免误杀单实例场景。
+      if (typeof window === 'undefined') return true
+      return !window.__checkbaActiveOverviewVm || window.__checkbaActiveOverviewVm === this
     },
     setupResponsiveListener() {
       if (typeof window === 'undefined') return

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -3082,11 +3082,22 @@ export default {
       if (!user) return
       this._clipboardBound = true
       // 统一的“写库 + 立即更新 UI”入口：避免 copy 事件多次触发导致重复入库
-      this._clipboardLast = this._clipboardLast || { ts: 0, text: '' }
+      // 去重状态挂 window 而非组件实例：本页经 navigateTo 反复进入时页面栈里会存在
+      // 多个实例，每个实例都绑定过监听；实例级去重挡不住“一次复制、多实例各入库一条”
+      if (typeof window !== 'undefined' && !window.__checkbaClipLastText) {
+        window.__checkbaClipLastText = { ts: 0, text: '' }
+      }
       const recordClipboardOnce = async (rawText, source = 'doc') => {
         // 1. Electron Payload Object (IMAGE / FILE)
         if (rawText && typeof rawText === 'object') {
            const payload = rawText
+           // 同一事件（ts 相同）会被页面栈里每个实例的监听器各收到一次，只处理第一次；
+           // 图片/文件没有下方文本那样的内容去重，全靠这里挡住重复入库
+           const evKey = String(payload.type || '') + '_' + String(payload.ts || '')
+           if (typeof window !== 'undefined') {
+             if (window.__checkbaClipLastEventKey === evKey) return null
+             window.__checkbaClipLastEventKey = evKey
+           }
            if (payload.type === 'TEXT') {
              return await recordClipboardOnce(payload.text, source)
            } else if (payload.type === 'IMAGE' && payload.data) {
@@ -3163,10 +3174,13 @@ export default {
 
         const now = Date.now()
         // 仅用于防止同一次用户动作被多路监听重复触发（不是业务去重）
-        if (this._clipboardLast.text === t && now - (this._clipboardLast.ts || 0) < 600) {
+        const lastText = (typeof window !== 'undefined' && window.__checkbaClipLastText) || { ts: 0, text: '' }
+        if (lastText.text === t && now - (lastText.ts || 0) < 600) {
           return null
         }
-        this._clipboardLast = { ts: now, text: t, source }
+        if (typeof window !== 'undefined') {
+          window.__checkbaClipLastText = { ts: now, text: t, source }
+        }
 
         try {
           const res = await saveClipboardText(t)


### PR DESCRIPTION
## 背景

PR#148 修了剪贴板「复制一次多条记录」，根因是本页经 `navigateTo` 反复进入时页面栈里存在多个存活实例，每个实例都绑定了全局监听。本 PR 是同一地雷的全面审计与修复。

> ⚠️ 本分支包含 #148 的提交（在其之上开发）。#148 先合则本 PR 自动瘦身；本 PR 先合则 #148 可直接关闭。

## 审计结论

**确认有害（一次事件 × N 实例副作用），已修：**

| 绑定点 | 危害 |
|---|---|
| `browser.onWebMark` | 一次「加入网核收藏」重复 POST N 条，且旧实例把收藏写进**它自己的 projectId**（跨项目污染） |
| `browser.onOpenNewTab` | 一次 `window.open` 开 N 个浏览 tab |
| `zetaoffice.onOpenEmbed` | 被覆盖的旧实例也置 `showLibreEmbed=true`，返回旧页时凭空弹出嵌入编辑器 |
| `app.onOpenInternal` | 重复 `getDocFileLink` 请求、重复 toast、隐藏实例弹 fileLinkPicker |
| `ocr.onSelectionError` | 截图失败连弹 N 次 toast |
| `window.__checkbaHandleInternalLink` 无条件 delete | overview A→B 再返回后，B 的 unmount 把 A 还在用的 WPS 内链处理器删掉，内部链接静默失效 |

**确认无害（不改）：**
- 剪贴板 paste/copy/keydown + `clipboard.onCopied`：#148 已用 window 级去重修复
- responsive `resize`：每实例各一份但只改自身布局状态，`beforeUnmount` 正确清理；实例本身就因页面栈存活，无额外泄漏
- OCR 框选 document 监听、拖拽 resize/webLink 监听：均为用户动作期绑定、动作结束即解绑，只有可见实例能触发
- `activityTracker`：模块级单例，`start()` 先 `stop()`，onShow/onHide 只对栈顶页触发，无重复
- `admin.vue` `model.onProgress`：handler 只更新自身状态 + 幂等 GET 刷新，危害可忽略（onUnload 已退订）
- `uni.$on`：全仓页面均未使用

## 修法（与 #148 同源的 window 级模式）

window 级「活跃实例指针」而非改动订阅生命周期：
- `onShow`/`mounted` 登记 `window.__checkbaActiveOverviewVm = this`，`beforeUnmount` 按引用注销
- 五个 IPC handler 首行 `if (!this.isActiveOverviewInstance()) return`；指针缺失时放行（fail-open，不误杀单实例）
- 好处：`onOpenNewTab` 语义保留——即使栈顶是个人中心，最近展示的 overview 实例仍消费 `window.open`（该消费者本就是为修「静默失效」加的）
- WPS 内链处理器改为按实例持引用：`beforeUnmount` 只删自己装的，`onShow` 重新接管

## 为什么不改 `redirectTo`

评估过：`redirectTo` 只替换栈顶页，个人中心→项目 B 时**栈底的项目 A 实例依然存活**，多实例问题不消失；`reLaunch` 能消栈但摧毁返回语义（个人中心/管理页返回全断）。守卫模式不动导航语义，是最小修法。

## 验证

- `npm run build:h5` ✅
- `node scripts/check-emit-bindings.mjs` ✅（44 个 .vue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)