### PR TITLE
chore(release): v0.7.3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号 0.7.2 → 0.7.3（desktop/package.json，electron-builder 安装包版本单一来源）。

合并后对 master HEAD 打 `v0.7.3` tag 触发 desktop-build workflow，构建 macOS(arm64) + Windows(x64) 安装包并发 GitHub Release。

## 本版累积（自 v0.7.2，均已在 master）
- fix(clipboard): 剪贴板/收藏夹闪电插图 `invalid base64` 修复 + 收藏夹图片按 IMAGE 插入 (#147)
- fix(chat)+ci: 恢复 AI 回复插入/替换/导出按钮 + emit/绑定契约 CI 检查 + 文件树标签删除修复 (#150)
- fix(clipboard): 复制一次多条历史去重 (#148)
- fix(overview): 页面栈多实例全局监听审计 (#151)
- fix(ai): OpenRouter 供应商切换生效 (#144)
- fix(desktop): 剪贴板图片预览 BrowserView 守卫 (#145) / Kokoro 下载 401 + 进度条 (#142)
- feat(skills): 在线 Skill 广场 (#146)
- fix(plugin/skill): 广场管理员判定接入 AdminAccessService (#149)
- style(plugin-market): 插件广场 UI 重做 (#143)

## 验证
- 本机 0.7.2 桌面环境真机点击回归 26 项交互全 PASS（文件树 CRUD、剪贴板文本+图片、收藏夹、变量、AI 回复动作、搜索/脱敏/TTS、编辑器保存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)