### PR TITLE
fix(ai): AI 对话历史丢消息——按轮次跟踪 ASSISTANT 行 ID / assistant reply lost in history

### DIFF
--- a/backend/src/main/java/com/checkba/repository/ProjectAiMessageRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectAiMessageRepository.java
@@ -33,15 +33,6 @@ public interface ProjectAiMessageRepository extends JpaRepository<ProjectAiMessa
      */
     @org.springframework.data.jpa.repository.Query("SELECT m FROM ProjectAiMessage m WHERE m.conversationId = :conversationId ORDER BY m.createdAt ASC LIMIT 1")
     java.util.Optional<ProjectAiMessage> findFirstByConversationId(@org.springframework.data.repository.query.Param("conversationId") String conversationId);
-    
-    /**
-     * 根据 conversationId 和 role 查找最后一条消息
-     * 用于增量保存时检查是否需要更新已有消息
-     */
-    @org.springframework.data.jpa.repository.Query("SELECT m FROM ProjectAiMessage m WHERE m.conversationId = :conversationId AND m.role = :role ORDER BY m.createdAt DESC LIMIT 1")
-    java.util.Optional<ProjectAiMessage> findLastByConversationIdAndRole(
-        @org.springframework.data.repository.query.Param("conversationId") String conversationId,
-        @org.springframework.data.repository.query.Param("role") String role);
 }
 
 

--- a/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
@@ -53,9 +53,7 @@ public class ProjectAiMessageService {
     /**
      * Save a single message (user OR assistant) to the database.
      * Used for streaming scenarios where assistant response comes after user message.
-     * 
-     * 对于 ASSISTANT 消息，如果最后一条同角色消息是最近 30 秒内创建的（即同一个对话轮次），
-     * 则更新它而不是创建新的。这样可以避免增量保存和最终保存产生重复消息。
+     * 总是插入新行；同一轮次内 ASSISTANT 消息的增量更新请用 {@link #upsertAssistantMessage}。
      */
     public void saveMessage(String projectIdStr, Long userId, String conversationId, String role, String content) {
         if (projectIdStr == null || role == null) {
@@ -67,25 +65,6 @@ public class ProjectAiMessageService {
         } catch (NumberFormatException e) {
             return;
         }
-        
-        // 对于 ASSISTANT 消息，检查是否需要更新而不是新建
-        if ("ASSISTANT".equalsIgnoreCase(role) && conversationId != null) {
-            java.util.Optional<ProjectAiMessage> lastMsgOpt = repository.findLastByConversationIdAndRole(conversationId, "ASSISTANT");
-            if (lastMsgOpt.isPresent()) {
-                ProjectAiMessage lastMsg = lastMsgOpt.get();
-                // 如果最后一条 ASSISTANT 消息是 30 秒内创建的，认为是同一个对话轮次，更新它
-                java.time.LocalDateTime threshold = java.time.LocalDateTime.now().minusSeconds(30);
-                if (lastMsg.getCreatedAt() != null && lastMsg.getCreatedAt().isAfter(threshold)) {
-                    // 更新已有消息而不是创建新的
-                    lastMsg.setContent(content);
-                    lastMsg.setCreatedAt(java.time.LocalDateTime.now()); // 更新时间戳
-                    repository.save(lastMsg);
-                    return;
-                }
-            }
-        }
-        
-        // 否则创建新消息
         ProjectAiMessage msg = new ProjectAiMessage();
         msg.setProjectId(projectId);
         msg.setUserId(userId);
@@ -94,6 +73,48 @@ public class ProjectAiMessageService {
         msg.setConversationId(conversationId);
         msg.setCreatedAt(java.time.LocalDateTime.now());
         repository.save(msg);
+    }
+
+    /**
+     * 保存或更新本轮 ASSISTANT 消息。
+     * 编排器按对话轮次跟踪消息 ID：同一轮内的增量保存/最终保存更新同一行，
+     * 新的一轮传 null 插入新行。
+     * （修复历史丢消息：旧实现按"会话最后一条 ASSISTANT 距今 30 秒内则更新"判断，
+     * 没有轮次概念，用户两轮提问间隔小于 30 秒时，第二轮回复会覆盖第一轮回复。）
+     *
+     * @param existingMessageId 本轮已保存过的消息 ID；null 表示本轮首次保存
+     * @return 保存后的消息 ID（供本轮后续增量保存复用）；参数非法时返回 null
+     */
+    public Long upsertAssistantMessage(String projectIdStr, Long userId, String conversationId, Long existingMessageId, String content) {
+        if (projectIdStr == null) {
+            return null;
+        }
+        Long projectId;
+        try {
+            projectId = Long.parseLong(projectIdStr);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+
+        if (existingMessageId != null) {
+            java.util.Optional<ProjectAiMessage> existingOpt = repository.findById(existingMessageId);
+            if (existingOpt.isPresent()) {
+                ProjectAiMessage existing = existingOpt.get();
+                existing.setContent(content);
+                repository.save(existing);
+                return existing.getId();
+            }
+        }
+
+        ProjectAiMessage msg = new ProjectAiMessage();
+        msg.setProjectId(projectId);
+        msg.setUserId(userId);
+        msg.setRole("ASSISTANT");
+        msg.setContent(content);
+        msg.setConversationId(conversationId);
+        msg.setCreatedAt(java.time.LocalDateTime.now());
+        repository.save(msg);
+        return msg.getId();
     }
 
     public List<ProjectAiMessage> listByProject(Long projectId) {

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -37,6 +37,8 @@ public class AgentOrchestrator {
     private final Set<String> cancelledConversations = ConcurrentHashMap.newKeySet();
     // 存储当前活跃会话的已生成内容（用于取消时保存部分内容）
     private final Map<String, StringBuilder> activeStreamContent = new ConcurrentHashMap<>();
+    // 本轮 ASSISTANT 消息的行 ID：同一轮内的增量保存/最终保存更新同一行，跨轮次互不覆盖
+    private final Map<String, Long> activeAssistantMessageId = new ConcurrentHashMap<>();
 
     private final ChatModelFactory chatModelFactory;
     private final ProjectAiMessageService messageService;
@@ -74,6 +76,19 @@ public class AgentOrchestrator {
     private void clearCancelledState(String conversationId) {
         cancelledConversations.remove(conversationId);
         activeStreamContent.remove(conversationId);
+        activeAssistantMessageId.remove(conversationId);
+    }
+
+    /**
+     * 保存/更新本轮 ASSISTANT 消息：首次保存插入新行并记住行 ID，
+     * 本轮内后续（增量/最终）保存更新同一行，避免重复；新的一轮从新行开始，不会覆盖上一轮回复。
+     */
+    private void saveAssistantMessage(String conversationId, String projectId, Long userId, String content) {
+        Long id = messageService.upsertAssistantMessage(
+                projectId, userId, conversationId, activeAssistantMessageId.get(conversationId), content);
+        if (id != null) {
+            activeAssistantMessageId.put(conversationId, id);
+        }
     }
 
     /**
@@ -89,7 +104,7 @@ public class AgentOrchestrator {
         // 如果有部分内容，保存并标记为已中断
         if (!partialContent.isEmpty()) {
             String contentToSave = partialContent + "\n\n[已中断]";
-            messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", contentToSave);
+            saveAssistantMessage(conversationId, projectId, userId, contentToSave);
             log.info("Saved partial content ({} chars) for cancelled conversation: {}", partialContent.length(), conversationId);
         }
         
@@ -158,9 +173,10 @@ public class AgentOrchestrator {
         String projectId = String.valueOf(request.getProjectId());
         AgentMode agentMode = request.getAgentMode(); // 获取 Agent 模式
         
-        // 初始化取消状态和内容收集器
+        // 初始化取消状态和内容收集器（新的一轮：清掉上一轮的 ASSISTANT 行 ID，本轮回复必须落新行）
         cancelledConversations.remove(conversationId);
         activeStreamContent.put(conversationId, new StringBuilder());
+        activeAssistantMessageId.remove(conversationId);
         
         try {
             log.info("Agent Loop Started: conv={}, model={}, mode={}, msg={}", conversationId, request.getModel(), agentMode, request.getMessage());
@@ -344,7 +360,7 @@ public class AgentOrchestrator {
                 
                 // 增量保存：在工具执行后立即保存AI消息和工具输出，防止对话中断导致上下文丢失
                 String intermediateContent = (aiContent != null ? aiContent : "") + "\n" + executionLog.toString();
-                messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", intermediateContent);
+                saveAssistantMessage(conversationId, projectId, userId, intermediateContent);
                 log.info("Intermediate save after native tool execution for conversation: {}", conversationId);
                 
                 runLoop(model, messages, conversationId, projectId, userId, modelId, depth + 1, executionLog, agentMode);
@@ -411,7 +427,7 @@ public class AgentOrchestrator {
                 if (toolExecuted) {
                      // 增量保存：在XML工具执行后立即保存AI消息和工具输出，防止对话中断导致上下文丢失
                      String intermediateXmlContent = content + "\n" + executionLog.toString();
-                     messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", intermediateXmlContent);
+                     saveAssistantMessage(conversationId, projectId, userId, intermediateXmlContent);
                      log.info("Intermediate save after XML tool execution for conversation: {}", conversationId);
 
                      // Recurse with executionLog
@@ -486,7 +502,7 @@ public class AgentOrchestrator {
                     log.info("Detected Implementation Plan. STOPPING LOOP for user approval.");
                     // Save assistant message with execution log prepended
                     String fullContent = executionLog.length() > 0 ? executionLog.toString() + content : content;
-                    messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", fullContent);
+                    saveAssistantMessage(conversationId, projectId, userId, fullContent);
                     // 发送 bubble_end 表示当前响应结束（等待用户审批）
                     sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"awaiting_approval\"}");
                     sseEmitterService.close(conversationId);
@@ -522,7 +538,7 @@ public class AgentOrchestrator {
             if (!content.isEmpty()) {
                 // Prepend execution log for history persistence
                 String fullContent = executionLog.length() > 0 ? executionLog.toString() + content : content;
-                messageService.saveMessage(projectId, userId, conversationId, "ASSISTANT", fullContent);
+                saveAssistantMessage(conversationId, projectId, userId, fullContent);
             }
             // 触发记忆写入管线（异步：对话摘要 / 项目记忆 / MemCell 原子记忆提取）
             try {
@@ -553,6 +569,12 @@ public class AgentOrchestrator {
         // 流式出错时的清理：关闭 emitter + 复位状态，避免 SSE 连接挂到超时、前端永久加载
         handler.setOnError(err -> {
             editorBridgeService.setStreamingMode(conversationId, false);
+            // 保存已生成的部分内容，避免"当时看到了回复、历史里却没有"
+            StringBuilder sb = activeStreamContent.get(conversationId);
+            String partialContent = sb != null ? sb.toString() : "";
+            if (!partialContent.isEmpty()) {
+                saveAssistantMessage(conversationId, projectId, userId, partialContent + "\n\n[生成出错，已中断]");
+            }
             sseEmitterService.close(conversationId);
             clearCancelledState(conversationId);
             editorBridgeService.clearCurrentConversationId();

--- a/backend/src/test/java/com/checkba/service/ProjectAiMessageServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectAiMessageServiceTest.java
@@ -1,0 +1,106 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.repository.ProjectAiMessageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * AI 对话消息持久化的轮次隔离测试。
+ *
+ * 回归背景：旧实现在保存 ASSISTANT 消息时按"会话最后一条 ASSISTANT 距今 30 秒内则更新"
+ * 判断轮次，用户两轮提问间隔小于 30 秒时，第二轮回复会原地覆盖第一轮回复，
+ * 导致历史记录里上一轮的 AI 回复丢失。
+ */
+class ProjectAiMessageServiceTest {
+
+    private ProjectAiMessageRepository repository;
+    private ProjectAiMessageService service;
+    /** 模拟 JPA：save 时给新实体分配自增 ID，并记录所有落库实体 */
+    private final List<ProjectAiMessage> savedRows = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ProjectAiMessageRepository.class);
+        service = new ProjectAiMessageService(repository);
+        savedRows.clear();
+        AtomicLong idGen = new AtomicLong(0);
+        when(repository.save(any(ProjectAiMessage.class))).thenAnswer(inv -> {
+            ProjectAiMessage msg = inv.getArgument(0);
+            if (msg.getId() == null) {
+                msg.setId(idGen.incrementAndGet());
+                savedRows.add(msg);
+            }
+            return msg;
+        });
+        when(repository.findById(anyLong())).thenAnswer(inv -> {
+            Long id = inv.getArgument(0);
+            return savedRows.stream().filter(m -> id.equals(m.getId())).findFirst();
+        });
+    }
+
+    @Test
+    void 两轮回复各自落新行_即使间隔小于30秒() {
+        // 第一轮：首次保存（existingMessageId = null）
+        Long turn1Id = service.upsertAssistantMessage("1", 2L, "conv-1", null, "第一轮回复");
+        // 第二轮紧接着开始（编排器每轮开始会清掉行 ID，再次传 null）
+        Long turn2Id = service.upsertAssistantMessage("1", 2L, "conv-1", null, "第二轮回复");
+
+        assertNotNull(turn1Id);
+        assertNotNull(turn2Id);
+        assertNotEquals(turn1Id, turn2Id, "两轮回复必须是两行，不允许覆盖");
+        assertEquals(2, savedRows.size());
+        assertEquals("第一轮回复", savedRows.get(0).getContent(), "第一轮回复内容不得被第二轮覆盖");
+        assertEquals("第二轮回复", savedRows.get(1).getContent());
+    }
+
+    @Test
+    void 同一轮内增量保存更新同一行不产生重复() {
+        Long firstId = service.upsertAssistantMessage("1", 2L, "conv-1", null, "工具执行中的部分内容");
+        Long secondId = service.upsertAssistantMessage("1", 2L, "conv-1", firstId, "完整的最终回复");
+
+        assertEquals(firstId, secondId, "同一轮内的增量保存应更新同一行");
+        assertEquals(1, savedRows.size(), "同一轮不应产生第二行");
+        assertEquals("完整的最终回复", savedRows.get(0).getContent());
+    }
+
+    @Test
+    void 传入的行ID不存在时退化为插入新行() {
+        Long id = service.upsertAssistantMessage("1", 2L, "conv-1", 999L, "回复内容");
+
+        assertNotNull(id);
+        assertEquals(1, savedRows.size());
+        assertEquals("回复内容", savedRows.get(0).getContent());
+    }
+
+    @Test
+    void saveMessage总是插入新行_不再按时间窗口更新旧消息() {
+        service.saveMessage("1", 2L, "conv-1", "ASSISTANT", "第一条");
+        service.saveMessage("1", 2L, "conv-1", "ASSISTANT", "第二条");
+
+        assertEquals(2, savedRows.size());
+        assertEquals("第一条", savedRows.get(0).getContent());
+        assertEquals("第二条", savedRows.get(1).getContent());
+        // 不应再有"查最后一条同角色消息"之类的轮次猜测查询
+        verify(repository, never()).findById(anyLong());
+    }
+
+    @Test
+    void 项目ID非法时upsert返回null且不落库() {
+        assertNull(service.upsertAssistantMessage(null, 2L, "conv-1", null, "内容"));
+        assertNull(service.upsertAssistantMessage("not-a-number", 2L, "conv-1", null, "内容"));
+        ArgumentCaptor<ProjectAiMessage> captor = ArgumentCaptor.forClass(ProjectAiMessage.class);
+        verify(repository, never()).save(captor.capture());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
@@ -112,6 +112,11 @@ public final class EvalHarness {
             savedMessages.add(new SavedMessage(inv.getArgument(3), inv.getArgument(4)));
             return null;
         }).when(messageService).saveMessage(any(), any(), any(), any(), any());
+        // ASSISTANT 消息走轮次级 upsert（首次插入返回行 ID，本轮内后续保存更新同一行）
+        when(messageService.upsertAssistantMessage(any(), any(), any(), any(), any())).thenAnswer(inv -> {
+            savedMessages.add(new SavedMessage("ASSISTANT", inv.getArgument(4)));
+            return 1L;
+        });
         // 返回 2 条历史消息，跳过「首次对话异步生成标题」分支（评测不关心该路径）
         when(messageService.listByConversationId(any()))
                 .thenReturn(List.of(mock(ProjectAiMessage.class), mock(ProjectAiMessage.class)));


### PR DESCRIPTION
## 问题

用户报告：AI 当时有返回内容，但从历史记录重新打开会话后该条回复消失（截图：12:09 一条用户消息后 AI 回复为空，12:10 下一轮回复正常）。

## 根因（真机 DB + 日志实证）

`ProjectAiMessageService.saveMessage` 保存 ASSISTANT 消息时，用"会话最后一条 ASSISTANT 距今 **30 秒内**则原地更新"的启发式来合并同一轮的增量保存与最终保存。但它**没有轮次概念**：用户两轮提问间隔 < 30 秒时，第二轮回复直接覆盖第一轮回复所在的行。

真机证据：`conv-1784088576535` 中 12:09:42 落库的"你试试"回复（id=8），在 12:10:10 第二轮保存时被情书回复原地覆盖、时间戳一并顶后，历史里只剩两条相邻的 USER 消息。

## 修复

- 新增 `upsertAssistantMessage(existingMessageId, ...)`：编排器按对话轮次持有本轮 ASSISTANT 行 ID，同轮增量/最终保存更新同一行；新一轮从 `null` 开始必然插入新行，**跨轮永不覆盖**
- `AgentOrchestrator` 以 `activeAssistantMessageId` map（与既有 `activeStreamContent` 同模式）跟踪本轮行 ID，开轮清零、收尾清理
- **顺带修复另一条丢失路径**：流式 `onError` 原本完全不落库——现在出错时保存已生成的部分内容（追加 `[生成出错，已中断]` 标记）
- `saveMessage` 退回纯插入；删除因此孤儿化的 `findLastByConversationIdAndRole`

## 验证

- 新增 `ProjectAiMessageServiceTest` 轮次隔离回归测试（两轮各自落行/同轮更新同行/ID 失效退化插入等 5 例）
- `mvn test` 237 项全绿（含 eval 回放与上下文冒烟）
- **真机 e2e**（补丁后端 9797 端口附着真实库）：同会话 5 秒内连续两轮提问 + 第三轮工具调用轮，历史三条 ASSISTANT 全部完整、同轮工具调用无重复行、最终回答落库

🤖 Generated with [Claude Code](https://claude.com/claude-code)