### PR TITLE
feat(ai): 记忆注入升级为证据账本（HMS 借鉴）/ evidence-ledger memory injection

### DIFF
--- a/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MemoryEntryRepository.java
@@ -115,6 +115,11 @@ public interface MemoryEntryRepository extends JpaRepository<MemoryEntry, Long> 
     List<MemoryEntry> findBySourceFileIdOrderByImportanceScoreDesc(Long sourceFileId);
 
     /**
+     * 按项目与一组 memoryKey 查找记忆（证据账本的"已被更新"信号检测用）
+     */
+    List<MemoryEntry> findByProjectIdAndMemoryKeyIn(Long projectId, java.util.Collection<String> memoryKeys);
+
+    /**
      * 统计项目的记忆数量
      */
     long countByProjectId(Long projectId);

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -285,14 +285,8 @@ public class ContextAssemblerService {
             List<MemoryEntry> relevantMemories = memoryManager.retrieveMemories(
                     projectIdLong, userPrompt, null, 5);
             if (!relevantMemories.isEmpty()) {
-                systemText.append("\n\n# 相关记忆\n");
-                for (MemoryEntry mem : relevantMemories) {
-                    systemText.append("- [").append(mem.getMemoryType()).append("] ");
-                    if (mem.getMemoryKey() != null) {
-                        systemText.append(mem.getMemoryKey()).append(": ");
-                    }
-                    systemText.append(mem.getMemoryValue()).append("\n");
-                }
+                systemText.append("\n\n# 相关记忆（证据账本）\n");
+                systemText.append(memoryManager.formatAsEvidenceLedger(relevantMemories));
             }
         }
 

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryEvidenceFormatter.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryEvidenceFormatter.java
@@ -1,0 +1,69 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.model.entity.MemoryEntry;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 记忆证据账本格式化（借鉴 HMS "答案时证据组织"思想）：
+ * 注入上下文/返回工具结果时，不再是松散的记忆文本堆叠，而是每条附带
+ * 记录时间、作用域、来源文件与更新信号，让模型能够：
+ * - 区分旧状态与最新状态（同一 memoryKey 有更新记录时标注"已被更新"）
+ * - 把"上个月""最近"等相对表述锚定到具体记录时间（顶部提供"今天"锚点）
+ * - 对结论/金额/日期类信息按来源与时效做保守取舍
+ */
+public final class MemoryEvidenceFormatter {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private MemoryEvidenceFormatter() {}
+
+    /**
+     * 将记忆列表格式化为证据账本。
+     *
+     * @param entries      按检索相关度排好序的记忆
+     * @param supersededAt 已被更新条目的信息：entryId → 同 key 更新记录的创建时间
+     *                     （见 {@link MemoryManager#findSupersededInfo}），可为 null
+     * @param today        时间锚点（"今天"）
+     */
+    public static String format(List<MemoryEntry> entries, Map<Long, LocalDateTime> supersededAt, LocalDate today) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("今天是 ").append(today.format(DATE))
+          .append("。以下记忆按检索相关度排序，每条附记录时间与来源；")
+          .append("标注「⚠️已被更新」的条目是旧状态，请以更新时间较新的记录为准。\n");
+        int index = 1;
+        for (MemoryEntry mem : entries) {
+            sb.append(index++).append(". [").append(mem.getMemoryType()).append("] ");
+            if (mem.getMemoryKey() != null) {
+                sb.append(mem.getMemoryKey()).append(": ");
+            }
+            sb.append(mem.getMemoryValue()).append("\n");
+            sb.append("   （").append(provenance(mem, supersededAt)).append("）\n");
+        }
+        return sb.toString();
+    }
+
+    /** 单条记忆的溯源注记：记录时间 · 作用域 · 来源文件 · 受保护 · 更新信号 */
+    private static String provenance(MemoryEntry mem, Map<Long, LocalDateTime> supersededAt) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("记录于").append(mem.getCreatedAt() != null ? mem.getCreatedAt().format(DATE) : "未知时间");
+        if (mem.getScope() != null && !MemoryEntry.MemoryScope.PROJECT.equals(mem.getScope())) {
+            sb.append(" · 作用域:").append(mem.getScope());
+        }
+        if (mem.getSourceFileId() != null) {
+            sb.append(" · 来源文件#").append(mem.getSourceFileId());
+        }
+        if (Boolean.TRUE.equals(mem.getIsProtected())) {
+            sb.append(" · 🔒受保护");
+        }
+        LocalDateTime newer = supersededAt == null ? null : supersededAt.get(mem.getId());
+        if (newer != null) {
+            sb.append(" · ⚠️已被更新，最新记录于").append(newer.format(DATE));
+        }
+        return sb.toString();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -193,6 +194,49 @@ public class MemoryManager {
                 fetchKeywordCandidates(projectId, query, memoryType, limit * 3), limit);
         touchMemories(ranked);
         return ranked;
+    }
+
+    /**
+     * 检测"已被更新"的条目（证据账本的更新信号）：
+     * 同一项目内存在相同 memoryKey 且 createdAt 更晚的记录时，视为该条目已有更新版本。
+     * 返回 entryId → 最新版本的创建时间；无更新版本的条目不出现在结果中。
+     * 检测失败时返回已算出的部分结果，不影响主流程。
+     */
+    public Map<Long, LocalDateTime> findSupersededInfo(List<MemoryEntry> entries) {
+        Map<Long, LocalDateTime> result = new HashMap<>();
+        Map<Long, List<MemoryEntry>> byProject = entries.stream()
+                .filter(e -> e.getProjectId() != null && e.getMemoryKey() != null && e.getId() != null)
+                .collect(Collectors.groupingBy(MemoryEntry::getProjectId));
+        for (Map.Entry<Long, List<MemoryEntry>> group : byProject.entrySet()) {
+            List<String> keys = group.getValue().stream()
+                    .map(MemoryEntry::getMemoryKey).distinct().collect(Collectors.toList());
+            List<MemoryEntry> sameKeyEntries;
+            try {
+                sameKeyEntries = memoryEntryRepository.findByProjectIdAndMemoryKeyIn(group.getKey(), keys);
+            } catch (Exception e) {
+                log.warn("Superseded check failed for project {}: {}", group.getKey(), e.getMessage());
+                continue;
+            }
+            Map<String, LocalDateTime> latestByKey = new HashMap<>();
+            for (MemoryEntry e : sameKeyEntries) {
+                if (e.getCreatedAt() == null || e.getMemoryKey() == null) continue;
+                latestByKey.merge(e.getMemoryKey(), e.getCreatedAt(), (a, b) -> a.isAfter(b) ? a : b);
+            }
+            for (MemoryEntry e : group.getValue()) {
+                LocalDateTime latest = latestByKey.get(e.getMemoryKey());
+                if (latest != null && e.getCreatedAt() != null && latest.isAfter(e.getCreatedAt())) {
+                    result.put(e.getId(), latest);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * 将检索结果格式化为证据账本（含记录时间/来源/更新信号），供上下文注入与记忆工具复用。
+     */
+    public String formatAsEvidenceLedger(List<MemoryEntry> entries) {
+        return MemoryEvidenceFormatter.format(entries, findSupersededInfo(entries), LocalDate.now());
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/tools/MemoryTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/MemoryTools.java
@@ -180,20 +180,8 @@ public class MemoryTools implements AgentToolComponent {
             }
             
             StringBuilder sb = new StringBuilder("找到 ").append(memories.size()).append(" 条相关记忆:\n\n");
-            int index = 1;
-            for (MemoryEntry mem : memories) {
-                sb.append(index++).append(". ");
-                sb.append("[").append(mem.getMemoryType().toUpperCase()).append("] ");
-                if (mem.getMemoryKey() != null) {
-                    sb.append("**").append(mem.getMemoryKey()).append("**\n");
-                }
-                sb.append("   ").append(mem.getMemoryValue()).append("\n");
-                if (Boolean.TRUE.equals(mem.getIsProtected())) {
-                    sb.append("   🔒 受保护\n");
-                }
-                sb.append("\n");
-            }
-            
+            sb.append(memoryManager.formatAsEvidenceLedger(memories));
+
             return sb.toString();
         } catch (Exception e) {
             log.error("Failed to query memory: {}", e.getMessage(), e);

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemoryEvidenceFormatterTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemoryEvidenceFormatterTest.java
@@ -1,0 +1,86 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.model.entity.MemoryEntry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 证据账本格式化测试：
+ * - 每条记忆附记录时间/作用域/来源文件/受保护/更新信号
+ * - 顶部有"今天"时间锚点
+ */
+class MemoryEvidenceFormatterTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 7, 15);
+
+    private static MemoryEntry entry(Long id, String type, String key, String value) {
+        MemoryEntry e = MemoryEntry.builder()
+                .id(id)
+                .projectId(1L)
+                .memoryType(type)
+                .memoryKey(key)
+                .memoryValue(value)
+                .createdAt(LocalDateTime.of(2026, 5, 2, 10, 0))
+                .build();
+        return e;
+    }
+
+    @Test
+    @DisplayName("账本包含时间锚点、条目内容与记录时间")
+    void basicLedgerFormat() {
+        String ledger = MemoryEvidenceFormatter.format(
+                List.of(entry(1L, "decision", "交易结构", "采用协议收购")), Map.of(), TODAY);
+
+        assertTrue(ledger.contains("今天是 2026-07-15"));
+        assertTrue(ledger.contains("1. [decision] 交易结构: 采用协议收购"));
+        assertTrue(ledger.contains("记录于2026-05-02"));
+        assertFalse(ledger.contains("· ⚠️已被更新"), "无更新记录时不应有条目级更新注记");
+    }
+
+    @Test
+    @DisplayName("受保护/来源文件/非项目作用域有对应注记，project 作用域不冗余标注")
+    void provenanceAnnotations() {
+        MemoryEntry protectedFileMem = entry(2L, "conclusion", "质押核查", "无质押");
+        protectedFileMem.setIsProtected(true);
+        protectedFileMem.setSourceFileId(42L);
+        protectedFileMem.setScope(MemoryEntry.MemoryScope.FILE);
+
+        String ledger = MemoryEvidenceFormatter.format(List.of(protectedFileMem), Map.of(), TODAY);
+        assertTrue(ledger.contains("🔒受保护"));
+        assertTrue(ledger.contains("来源文件#42"));
+        assertTrue(ledger.contains("作用域:file"));
+
+        String projectLedger = MemoryEvidenceFormatter.format(
+                List.of(entry(3L, "fact", "k", "v")), Map.of(), TODAY);
+        assertFalse(projectLedger.contains("作用域:"));
+    }
+
+    @Test
+    @DisplayName("已被更新的条目标注更新信号与最新记录时间")
+    void supersededSignal() {
+        MemoryEntry stale = entry(4L, "fact", "质押情况", "大股东质押 30%");
+        String ledger = MemoryEvidenceFormatter.format(
+                List.of(stale),
+                Map.of(4L, LocalDateTime.of(2026, 6, 30, 9, 0)),
+                TODAY);
+
+        assertTrue(ledger.contains("⚠️已被更新，最新记录于2026-06-30"));
+    }
+
+    @Test
+    @DisplayName("createdAt 为空与 supersededAt 为 null 时不抛异常")
+    void nullSafety() {
+        MemoryEntry noDate = entry(5L, "fact", null, "v");
+        noDate.setCreatedAt(null);
+
+        String ledger = MemoryEvidenceFormatter.format(List.of(noDate), null, TODAY);
+        assertTrue(ledger.contains("记录于未知时间"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemoryQualityTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemoryQualityTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -273,5 +274,49 @@ class MemoryQualityTest {
 
         assertEquals(101L, result.getId(), "其他项目的相似记忆不应拦截保存");
         verify(memoryEntryRepository).save(candidate);
+    }
+
+    // ==================== 证据账本：更新信号 ====================
+
+    private static MemoryEntry keyedEntry(Long id, String key, LocalDateTime createdAt) {
+        MemoryEntry e = MemoryEntry.builder()
+                .id(id)
+                .projectId(1L)
+                .memoryType("fact")
+                .memoryKey(key)
+                .memoryValue("value-" + id)
+                .createdAt(createdAt)
+                .build();
+        return e;
+    }
+
+    @Test
+    @DisplayName("更新信号：同 key 存在更新记录的条目被标记，最新条目不被标记")
+    void supersededInfoDetectsNewerRecords() {
+        LocalDateTime old = LocalDateTime.of(2026, 4, 1, 10, 0);
+        LocalDateTime newer = LocalDateTime.of(2026, 6, 30, 9, 0);
+        MemoryEntry stale = keyedEntry(1L, "质押情况", old);
+        MemoryEntry unrelated = keyedEntry(2L, "交易结构", LocalDateTime.of(2026, 5, 1, 10, 0));
+
+        when(memoryEntryRepository.findByProjectIdAndMemoryKeyIn(eq(1L), any()))
+                .thenReturn(List.of(stale, keyedEntry(3L, "质押情况", newer), unrelated));
+
+        Map<Long, LocalDateTime> superseded =
+                memoryManager.findSupersededInfo(List.of(stale, unrelated));
+
+        assertEquals(newer, superseded.get(1L), "旧条目应标记为已被更新");
+        assertFalse(superseded.containsKey(2L), "无更新记录的条目不应被标记");
+    }
+
+    @Test
+    @DisplayName("更新信号：查询失败时降级为空结果，不抛异常")
+    void supersededInfoDegradesGracefully() {
+        when(memoryEntryRepository.findByProjectIdAndMemoryKeyIn(eq(1L), any()))
+                .thenThrow(new RuntimeException("db down"));
+
+        Map<Long, LocalDateTime> superseded = memoryManager.findSupersededInfo(
+                List.of(keyedEntry(1L, "质押情况", LocalDateTime.of(2026, 4, 1, 10, 0))));
+
+        assertTrue(superseded.isEmpty());
     }
 }


### PR DESCRIPTION
## 背景

评估了 [Shadow-Weave/HMS](https://github.com/Shadow-Weave/HMS)（Holographic Memory System）后结论：整体替换不划算（Python+PostgreSQL/pgvector 强依赖、研究原型、功能面不对等），但其核心创新——**答案时证据组织（evidence ledger）**——非常适合借鉴到咱们的记忆注入链路，对法律场景的日期锚定、新旧状态区分是直接痛点。

## 改动

- **新增 `MemoryEvidenceFormatter`**：记忆注入不再是松散文本堆叠，每条附带记录时间、作用域（非 project 时）、来源文件、受保护标记；顶部带「今天是 YYYY-MM-DD」时间锚点
- **`MemoryManager.findSupersededInfo`**：同一项目内同 `memoryKey` 存在更晚记录时，旧条目标注「⚠️已被更新，最新记录于 X」；一次批量派生查询（`findByProjectIdAndMemoryKeyIn`），失败时降级不影响主流程
- **两处接入**：`ContextAssemblerService` 的「# 相关记忆」系统消息注入段；`MemoryTools.query_memory` 工具返回

## 测试

- 新增 `MemoryEvidenceFormatterTest`（4 用例：基础格式/溯源注记/更新信号/空值安全）
- `MemoryQualityTest` 新增 2 用例（更新信号检测、查询失败降级）
- 后端全量：243 tests, 0 failures, 0 errors（JDK 21）

🤖 Generated with [Claude Code](https://claude.com/claude-code)