### PR TITLE
fix(backend): 分片上传第2+块写散到孤儿路径致大文件截断

### DIFF
--- a/backend/src/main/java/com/checkba/controller/FileController.java
+++ b/backend/src/main/java/com/checkba/controller/FileController.java
@@ -214,10 +214,43 @@ public class FileController {
         return pathBuilder.toString();
     }
 
+    /**
+     * 解析上传目标的存储路径：优先用 DB 记录的 filePath；没有则按项目逻辑路径
+     * 生成并回写 DB。首块(save)、追加块(append)、断点查询(getSize) 三处必须用
+     * 同一路径，否则分片会写散。
+     */
+    private String resolveUploadStoragePath(String fileId, Optional<ProjectFile> projectFileOpt) {
+        String storagePath = fileId;
+        if (projectFileOpt.isPresent()) {
+            ProjectFile pf = projectFileOpt.get();
+            if (StringUtils.hasText(pf.getFilePath())) {
+                storagePath = pf.getFilePath();
+            } else {
+                String safeName = StringUtils.hasText(pf.getName()) ? pf.getName() : fileId;
+                if (pf.getFileType() != null && !safeName.endsWith("." + pf.getFileType())) {
+                    safeName += "." + pf.getFileType();
+                }
+                String logicalPath = buildLogicalPath(pf);
+                String basePath = String.format("projects/%d", pf.getProjectId());
+                storagePath = StringUtils.hasText(logicalPath) ?
+                    String.format("%s/%s/%s", basePath, logicalPath, safeName) :
+                    String.format("%s/%s", basePath, safeName);
+
+                pf.setFilePath(storagePath);
+                projectFileRepository.save(pf);
+            }
+        }
+        return storagePath;
+    }
+
     @GetMapping("/{fileId}/upload-status")
     public ResponseEntity<Map<String, Object>> getUploadStatus(@PathVariable("fileId") String fileId) {
         try {
-            long size = getStorageService().getSize(fileId);
+            // 与上传同一套路径解析——此前直接 getSize(裸 fileId) 读的是孤儿路径，
+            // 断点续传的 offset 永远对不上真实文件
+            Optional<ProjectFile> pfOpt = projectFileRepository.findByWpsFileId(fileId).stream().findFirst();
+            String path = pfOpt.map(ProjectFile::getFilePath).filter(StringUtils::hasText).orElse(fileId);
+            long size = getStorageService().getSize(path);
             Map<String, Object> data = new HashMap<>();
             data.put("uploadedSize", size);
             
@@ -291,37 +324,17 @@ public class FileController {
             // Wait, replace_file_content replaces a block. I should probably use multi_replace to be precise or rewrite the whole method carefully.
             // I will rewrite the logic to use `append` if offset > 0.
 
+            // 1. 确定存储路径（首块与追加块必须解析到同一路径：此前追加块直接用
+            // 裸 wpsFileId 作路径，>5MB 文件的第 2+ 块被追加到存储根的孤儿文件里，
+            // 正式路径上只剩首块 5MB —— 下载得到截断的 zip，文档加载失败）
+            String storagePath = resolveUploadStoragePath(fileId, projectFileOpt);
+
             String savedPath;
             if (offset != null && offset > 0) {
                  // 追加模式
-                 savedPath = getStorageService().append(fileId, inputStream);
+                 savedPath = getStorageService().append(storagePath, inputStream);
             } else {
                  // 覆盖/新传模式
-                 // ... Path Resolution Logic ...
-                 String storagePath = fileId;
-                 Long projectId = null;
-                 
-                 if (projectFileOpt.isPresent()) {
-                    ProjectFile pf = projectFileOpt.get();
-                    projectId = pf.getProjectId();
-                    if (StringUtils.hasText(pf.getFilePath())) {
-                        storagePath = pf.getFilePath();
-                    } else {
-                         String safeName = StringUtils.hasText(pf.getName()) ? pf.getName() : fileId;
-                          if (pf.getFileType() != null && !safeName.endsWith("." + pf.getFileType())) {
-                               safeName += "." + pf.getFileType();
-                          }
-                          // Removed forced .docx default - rely on fileType or original name
-                          String logicalPath = buildLogicalPath(pf);
-                         String basePath = String.format("projects/%d", pf.getProjectId());
-                         storagePath = StringUtils.hasText(logicalPath) ? 
-                             String.format("%s/%s/%s", basePath, logicalPath, safeName) : 
-                             String.format("%s/%s", basePath, safeName);
-                         
-                         pf.setFilePath(storagePath);
-                         projectFileRepository.save(pf);
-                    }
-                 }
                  savedPath = getStorageService().save(storagePath, inputStream);
             }
 

--- a/backend/src/test/java/com/checkba/controller/FileControllerChunkedUploadTest.java
+++ b/backend/src/test/java/com/checkba/controller/FileControllerChunkedUploadTest.java
@@ -1,0 +1,107 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.ai.AutoTaggingService;
+import com.checkba.service.ai.ProjectRagService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定分片上传的路径一致性：首块(save)、追加块(append)、断点查询(getSize)
+ * 必须解析到 DB 记录的同一 filePath。此前追加块直接用裸 wpsFileId 作路径，
+ * >5MB 文件的第 2+ 块被写进存储根的孤儿文件，正式路径只剩首块 —— 下载得到
+ * 截断的 zip，编辑器"文档加载失败"。
+ */
+@ExtendWith(MockitoExtension.class)
+class FileControllerChunkedUploadTest {
+
+    @Mock
+    private ProjectFileRepository projectFileRepository;
+    @Mock
+    private ProjectMemberService projectMemberService;
+    @Mock
+    private StorageServiceFactory storageServiceFactory;
+    @Mock
+    private ProjectRagService projectRagService;
+    @Mock
+    private AutoTaggingService autoTaggingService;
+    @Mock
+    private StorageService storageService;
+
+    @InjectMocks
+    private FileController controller;
+
+    private static final String WPS_FILE_ID = "project_4_doc_1784101301299_a5d5o6u";
+    private static final String FILE_PATH = "projects/4/big.docx";
+
+    private ProjectFile projectFile() {
+        ProjectFile pf = new ProjectFile();
+        pf.setId(16L);
+        pf.setProjectId(4L);
+        pf.setName("big.docx");
+        pf.setFileType("docx");
+        pf.setFilePath(FILE_PATH);
+        pf.setWpsFileId(WPS_FILE_ID);
+        return pf;
+    }
+
+    @Test
+    void appendChunkGoesToResolvedFilePathNotRawFileId() throws Exception {
+        when(projectFileRepository.findByWpsFileId(WPS_FILE_ID)).thenReturn(List.of(projectFile()));
+        when(projectFileRepository.sumSizeByProjectId(4L)).thenReturn(0L);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+        when(storageService.append(any(), any())).thenReturn(FILE_PATH);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/octet-stream");
+        request.setContent(new byte[]{1, 2, 3});
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasReadPermission(4L, 7L)).thenReturn(true);
+
+            ResponseEntity<Map<String, Object>> resp =
+                controller.uploadFile(WPS_FILE_ID, null, 5242880L, "sess", null, request);
+
+            assertEquals(200, resp.getStatusCode().value());
+        }
+
+        verify(storageService).append(eq(FILE_PATH), any(InputStream.class));
+        verify(storageService, never()).append(eq(WPS_FILE_ID), any(InputStream.class));
+    }
+
+    @Test
+    void uploadStatusReadsSizeFromResolvedFilePath() {
+        when(projectFileRepository.findByWpsFileId(WPS_FILE_ID)).thenReturn(List.of(projectFile()));
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+        when(storageService.getSize(FILE_PATH)).thenReturn(5242880L);
+
+        ResponseEntity<Map<String, Object>> resp = controller.getUploadStatus(WPS_FILE_ID);
+
+        assertEquals(200, resp.getStatusCode().value());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) resp.getBody().get("data");
+        assertEquals(5242880L, data.get("uploadedSize"));
+        verify(storageService).getSize(FILE_PATH);
+        verify(storageService, never()).getSize(WPS_FILE_ID);
+    }
+}


### PR DESCRIPTION
## 根因

用户上传 >5MB 的 docx 后点击打开，编辑器报"文档加载失败"。

前端分片上传（FileTree.vue，5MB/块）：
- **首块**（offset=0）→ `save(storagePath)`，storagePath 解析为 DB 记录的 `filePath`（`projects/4/【修订0715】….docx`）✅
- **追加块**（offset>0）→ `append(裸 wpsFileId)` → `LocalFileStorageService.resolveFilePath` 把无分隔符的 id 补成 `<存储根>/<wpsFileId>.docx` ❌

结果：正式路径只有首块 **恰好 5,242,880 字节**，其余 13,612,627 字节全进了存储根的孤儿文件。下载得到截断的 zip（无 central directory），LOWA `load_document` 两种策略都失败。

**实锤验证**：`cat 截断文件 孤儿文件 > merged.docx` → `unzip -t` 无任何错误。

`upload-status` 同病：`getSize(裸 fileId)` 读孤儿路径，断点续传 offset 永远对不上真实文件。

## 修复

三处统一走 `resolveUploadStoragePath()`（原 offset==0 分支内的路径解析逻辑提取为私有方法）：
- 首块 `save(storagePath)`
- 追加块 `append(storagePath)`
- `upload-status` 的 `getSize(filePath)`

## 测试

- 新增 `FileControllerChunkedUploadTest`（2 个用例）：锁定 append 目标路径 = DB filePath ≠ 裸 wpsFileId；upload-status 读 filePath。旧代码下 2/2 失败，修复后通过。
- `com.checkba.controller.* + storage.*` 全套 20 用例通过。

## 已损坏数据

本机 projects/4 的该文档仍是截断态（孤儿文件还在存储根），合并两文件即可修复——命令见会话记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)