### PR TITLE
fix(editor): 中文字体 tofu 修复 + 顶部状态条改浮动 + 文档加载提速

### DIFF
--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -1,26 +1,31 @@
 <template>
   <view class="libre-editor-wrapper">
-    <view class="libre-toolbar">
-      <!-- Engine name / debug status are dev-probe chrome: in the 'default'
-           (product) variant the tab already names the file, and a quiet editor
-           shows NO status — only booting/loading/saving/failure speak up. -->
-      <text v-if="variant !== 'default'" class="libre-title">LibreOffice 编辑器（嵌入式 webview · 实验）</text>
+    <!-- Product ('default') variant: NO full-width bar — it read as alien chrome
+         on top of the document (user feedback). Status + save float over the
+         editor's top-right corner instead; the status pill only appears while
+         something is happening (booting/loading/saving/failure) and vanishes
+         when ready. -->
+    <view v-if="variant === 'default'" class="libre-float">
+      <view v-if="displayStatus" class="libre-pill" :class="{ error: isError }">
+        <view v-if="!isError && !ready" class="libre-spin"></view>
+        <text>{{ displayStatus }}</text>
+      </view>
+      <!-- Save is REAL product UI (Track E): without it edits die with the tab. -->
+      <button v-if="file" class="libre-save" :disabled="!ready || saving" @click="saveDocument">
+        {{ saving ? '保存中…' : '保存' }}
+      </button>
+    </view>
+    <!-- Experimental (⌘⇧O overlay) variant keeps the dev-probe toolbar. -->
+    <view v-else class="libre-toolbar">
+      <text class="libre-title">LibreOffice 编辑器（嵌入式 webview · 实验）</text>
       <text v-if="displayStatus" class="libre-status" :class="{ ready, error: isError }">{{ displayStatus }}</text>
-      <!-- Save is REAL product UI (Track E): shown in every variant whenever the
-           editor is bound to a backend file — without it edits die with the tab. -->
       <button v-if="file" class="libre-btn" :disabled="!ready || saving" @click="saveDocument">
         {{ saving ? '保存中…' : '保存' }}
       </button>
-      <!-- The dev probe buttons + close are the ⌘⇧O experimental overlay's
-           controls. In the inline 'default' variant (Track B: embedded editor is
-           the document's default editor) they are hidden — the document tab's ×
-           closes it and the AI agent drives commands. -->
-      <template v-if="variant !== 'default'">
-        <button class="libre-btn" :disabled="!ready" @click="runInsert">插入示例</button>
-        <button class="libre-btn" :disabled="!ready" @click="runReplace">查找替换(redline)</button>
-        <button class="libre-btn" :disabled="!ready" @click="runSelection">读选区</button>
-        <button class="libre-btn libre-close" @click="$emit('close')">关闭</button>
-      </template>
+      <button class="libre-btn" :disabled="!ready" @click="runInsert">插入示例</button>
+      <button class="libre-btn" :disabled="!ready" @click="runReplace">查找替换(redline)</button>
+      <button class="libre-btn" :disabled="!ready" @click="runSelection">读选区</button>
+      <button class="libre-btn libre-close" @click="$emit('close')">关闭</button>
     </view>
     <!-- The Electron <webview> is created imperatively (uni-app's template
          compiler does not know the <webview> tag); it mounts into this host. -->
@@ -95,6 +100,11 @@ export default {
         this.statusText = '仅桌面版可用'
         return
       }
+      // Prefetch the document bytes IN PARALLEL with the LOWA boot — the fetch
+      // (backend download) and the engine boot are independent, so serializing
+      // them (the old flow: boot → endpoint ready → fetch → load) just added the
+      // whole download to the perceived open time.
+      if (this.file) this.prefetchBytes()
       const info = await api.getEditor() // { url, preload, partition }
       this.mountWebview(info)
     } catch (e) {
@@ -181,12 +191,25 @@ export default {
       if (this.statusText.indexOf('失败') === -1) this.statusText = '就绪'
       this.$emit('ready', this.executor)
     },
+    // Kick off the (authed) document download without waiting for the engine.
+    // loadDocument() awaits this promise; on failure it falls back to a fresh
+    // fetch there so a transient prefetch error can't kill the load path.
+    prefetchBytes() {
+      const f = this.file
+      const fileId = f && (f.wpsFileId || f.id)
+      if (!fileId) return
+      const t0 = Date.now()
+      this._bytesPromise = this.fetchArrayBuffer(getFileDownloadUrl(fileId))
+        .then((buf) => { this.appendLog('文档字节预取完成 / prefetched ' + (buf ? buf.byteLength : 0) + ' bytes in ' + (Date.now() - t0) + 'ms'); return buf })
+        .catch((e) => { this.appendLog('预取失败（加载时重试）/ prefetch failed: ' + (e && e.message ? e.message : e)); return null })
+    },
     async loadDocument() {
       const f = this.file
       const fileId = f.wpsFileId || f.id
       if (!fileId) throw new Error('file has no id/wpsFileId')
       const url = getFileDownloadUrl(fileId)
-      const buf = await this.fetchArrayBuffer(url)
+      let buf = this._bytesPromise ? await this._bytesPromise : null
+      if (!buf) buf = await this.fetchArrayBuffer(url)
       const bytes = new Uint8Array(buf || new ArrayBuffer(0))
       const name = f.name || (String(fileId) + '.' + String(f.fileType || 'docx'))
       // Empty body = a brand-new / unsaved document — the backend streams HTTP
@@ -198,8 +221,9 @@ export default {
         return
       }
       this.appendLog('▶ load_document「' + name + '」(' + bytes.length + ' bytes) …')
+      const t0 = Date.now()
       const res = await this.executor.executeCommand('load_document', { bytes, name })
-      this.appendLog('  ← ' + JSON.stringify(res))
+      this.appendLog('  ← ' + (Date.now() - t0) + 'ms ' + JSON.stringify(res))
       if (!res || !res.success) throw new Error((res && res.message) || 'load_document returned no success')
     },
     // Authed binary fetch — same XHR auth pattern as FilePreview.fetchAuthedBlob,
@@ -291,7 +315,20 @@ export default {
 </script>
 
 <style scoped>
-.libre-editor-wrapper { display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+.libre-editor-wrapper { position: relative; display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+/* Product variant: floating status pill + save, pinned over the editor's
+   top-right corner (LO's own menubar leaves that region empty). No layout
+   height is reserved — the document canvas gets the full pane. */
+.libre-float { position: absolute; top: 6px; right: 16px; z-index: 20; display: flex; align-items: center; gap: 8px; }
+.libre-pill { display: flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px;
+  background: rgba(31, 41, 55, 0.78); color: #e5e7eb; font-size: 12px; backdrop-filter: blur(4px); }
+.libre-pill.error { background: rgba(153, 27, 27, 0.9); color: #fecaca; }
+.libre-spin { width: 10px; height: 10px; border: 2px solid rgba(229, 231, 235, 0.35); border-top-color: #e5e7eb;
+  border-radius: 50%; animation: libre-rot 0.8s linear infinite; }
+@keyframes libre-rot { to { transform: rotate(360deg); } }
+.libre-save { font-size: 12px; line-height: 1; padding: 5px 12px; border: 0; border-radius: 999px;
+  background: #059669; color: #fff; cursor: pointer; box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18); }
+.libre-save[disabled] { background: #9ca3af; cursor: not-allowed; }
 .libre-toolbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 6px 10px; background: #1F2937; color: #fff; }
 .libre-title { font-size: 13px; font-weight: 600; }
 .libre-status { font-size: 12px; color: #d1d5db; }

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -98,10 +98,14 @@ export function createLibreOfficeExecutor(opts = {}) {
   function request(action, params) {
     if (!workerPort) return Promise.reject(new Error('LibreOffice office worker not connected'))
     const reqId = 'lo_' + Date.now() + '_' + (++reqSeq)
+    // Whole-document transfers get a longer deadline (mirror of the host-side
+    // relay budget in zetaOfficeRelay.js — see the comment there).
+    const budget = (action === 'load_document' || action === 'export_document')
+      ? Math.max(timeoutMs, 180000) : timeoutMs
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         if (pending.has(reqId)) { pending.delete(reqId); reject(new Error('LibreOffice command timeout: ' + action)) }
-      }, timeoutMs)
+      }, budget)
       pending.set(reqId, { resolve, reject, timer })
       workerPort.postMessage({ cmd: 'exec', reqId, action, params: params || {} })
     })

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -102,6 +102,44 @@ export function bootZetaOffice(options = {}) {
       }
     }
 
+    // --- CJK font-name aliases (fontconfig conf.d) ---
+    // Real-world docx name 宋体/黑体/微软雅黑/…; none ship in the engine image,
+    // and the WASM build does NO glyph fallback — every missing family renders
+    // tofu even though the injected Noto Sans SC has the glyphs (real-machine
+    // verified: the same text renders once CharFontName='Noto Sans SC'). Map the
+    // common Chinese families onto the injected font. `append` + binding="weak"
+    // = fallback-only: if an engine ever bundles the real 黑体, the alias loses.
+    if (injections.length) {
+      const CJK_FAMILIES = [
+        '宋体', 'SimSun', '新宋体', 'NSimSun', '宋体-简', 'Songti SC',
+        '黑体', 'SimHei', '黑体-简', 'Heiti SC',
+        '微软雅黑', 'Microsoft YaHei', 'Microsoft YaHei UI',
+        '等线', 'DengXian', '等线 Light', 'DengXian Light',
+        '仿宋', 'FangSong', '仿宋_GB2312', 'FangSong_GB2312',
+        '楷体', 'KaiTi', '楷体_GB2312', 'KaiTi_GB2312', '楷体-简', 'Kaiti SC',
+        '华文宋体', 'STSong', '华文中宋', 'STZhongsong', '华文黑体', 'STHeiti',
+        '华文楷体', 'STKaiti', '华文仿宋', 'STFangsong', '华文细黑', 'STXihei',
+        '思源黑体', 'Source Han Sans SC', 'Source Han Sans CN',
+        '思源宋体', 'Source Han Serif SC', 'Source Han Serif CN',
+        'Noto Sans CJK SC', 'Noto Serif CJK SC', 'Noto Serif SC',
+        'MS Gothic', 'MS Mincho', 'Yu Gothic', 'Malgun Gothic',
+      ]
+      const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      const rules = CJK_FAMILIES.map((fam) =>
+        '  <match target="pattern">\n' +
+        '    <test qual="any" name="family"><string>' + esc(fam) + '</string></test>\n' +
+        '    <edit name="family" mode="append" binding="weak"><string>Noto Sans SC</string></edit>\n' +
+        '  </match>').join('\n')
+      const conf = '<?xml version="1.0"?>\n' +
+        '<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">\n' +
+        '<fontconfig>\n' + rules + '\n</fontconfig>\n'
+      injections.push({
+        path: '/instdir/share/fontconfig/conf.d/69-aiworkdeck-cjk-aliases.conf',
+        bytes: new TextEncoder().encode(conf),
+      })
+      log('CJK font-name alias conf queued (' + CJK_FAMILIES.length + ' families → Noto Sans SC)')
+    }
+
     // The globals `canvas` and `Module` must exist before soffice.js loads.
     const Module = {
       canvas,
@@ -138,7 +176,7 @@ export function bootZetaOffice(options = {}) {
             n++
           } catch (e) { log('FS write failed for ' + f.path + ': ' + e) }
         }
-        log('MEMFS injected ' + n + '/' + injections.length + ' file(s) (CJK font) before main()')
+        log('MEMFS injected ' + n + '/' + injections.length + ' file(s) (CJK font + alias conf) before main()')
       },
     }
     // Force the engine's locale (LANG) by shimming navigator.languages BEFORE

--- a/frontend/src/composables/zetaOfficeRelay.js
+++ b/frontend/src/composables/zetaOfficeRelay.js
@@ -83,13 +83,19 @@ export function createRelayExecutor({ send, subscribe, timeoutMs = 30000, onRead
 
   function executeCommand(action, params = {}) {
     const reqId = 'rly_' + Date.now() + '_' + (++seq)
+    // Whole-document transfers (load/export can be tens of MB and the worker
+    // marshals every byte into UNO) get a longer deadline than interactive
+    // commands — a 18MB docx on a slow disk must not surface as "加载失败" just
+    // because the default 30s ran out mid-import.
+    const budget = (action === 'load_document' || action === 'export_document')
+      ? Math.max(timeoutMs, 180000) : timeoutMs
     return new Promise((resolve) => {
       const timer = setTimeout(() => {
         if (pending.has(reqId)) {
           pending.delete(reqId)
           resolve({ success: false, message: 'LibreOffice relay timeout: ' + action })
         }
-      }, timeoutMs)
+      }, budget)
       pending.set(reqId, { resolve, timer })
       send({ __lo: TAG, type: 'exec', reqId, action, params })
     })


### PR DESCRIPTION
## 三个问题（用户 v0.7.3 真机反馈）

### 1. 文档中文全部显示为方框（tofu）
**根因**：真实 docx 声明 宋体/黑体/微软雅黑 等字体；LOWA 引擎镜像不含任何中文字体，且 WASM 构建**没有字形回退**。boot 时虽已注入 Noto Sans SC（cjk.ttc），但字体名对不上就整篇 tofu。真机实证：同一段文字把 CharFontName 改为 'Noto Sans SC' 立即正常渲染。

**修复**：`zetaOfficeBoot.js` boot 注入第二个 MEMFS 文件 `/instdir/share/fontconfig/conf.d/69-aiworkdeck-cjk-aliases.conf`——52 个常见中日韩字体名 → Noto Sans SC 的 fontconfig 别名（`append` + `binding=weak`，将来引擎若真带这些字体，别名自动让位）。

**验证**（无头 puppeteer + 本机 Chrome + 用户真实 18MB 合同）：修复前后截图对比，全文中文完整渲染，文本提取一致。

### 2. 顶部黑色状态条很怪
default（产品）变体不再渲染整宽工具条：改为右上角**浮动状态胶囊**（仅启动/加载/保存/失败时出现，就绪即消失，带小 spinner）+ **浮动保存按钮**。⌘⇧O 实验变体的调试工具条保留不动。

### 3. 加载慢
- 文档字节预取与 LOWA boot **并行**（原先串行：boot 完才开始下载 18MB）；
- `load_document`/`export_document` 的 relay 与 worker 客户端超时 30s→180s（大文档超时会被误报"文档加载失败"）；
- 宿主日志补预取/加载毫秒计时，后续慢可直接定位。

harness 数据（18MB docx）：boot ~1s、load ~3.4s。切换标签页会销毁并重新 boot 整个引擎的架构性慢点另行处理（不在本 PR 动 AI 指令路由）。

## 测试
- 无头 LOWA harness 回归：boot / load_document / get_document_text / 截图全过
- `npm run check:emits` ✅、`npm run build:h5` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)