### PR TITLE
feat(editor): 按字形类别捆绑四款开源中文字体并映射（宋/黑/楷/仿宋不再一个面貌）

### DIFF
--- a/desktop/scripts/fetch-lowa-assets.js
+++ b/desktop/scripts/fetch-lowa-assets.js
@@ -42,9 +42,12 @@
 //   dist/zetaoffice/lowa/soffice.data                (brotli)
 //   dist/zetaoffice/lowa/soffice.data.js.metadata
 //   dist/zetaoffice/lowa/.encodings.json             (sidecar: { file: encoding })
-//   dist/zetaoffice/cjk.ttc   (Noto Sans SC Regular, OFL — content is OTF; the
-//                               .ttc name matches editor-main.js's fontUrl default
-//                               and fontconfig sniffs by content, not extension)
+//   dist/zetaoffice/cjk.ttc          (Noto Sans SC Regular, OFL — content is OTF;
+//                                      the .ttc name matches editor-main.js's font
+//                                      default and fontconfig sniffs by content)
+//   dist/zetaoffice/cjk-serif.otf    (Noto Serif SC Regular, OFL — 宋体类映射目标)
+//   dist/zetaoffice/cjk-kai.ttf      (LXGW WenKai / 霞鹜文楷 Regular, OFL — 楷体类)
+//   dist/zetaoffice/cjk-fangsong.ttf (Zhuque Fangsong / 朱雀仿宋 Regular, OFL — 仿宋类)
 //
 // Usage:  node desktop/scripts/fetch-lowa-assets.js   (idempotent; keeps a file
 //         that already validates). Runs in CI before electron-builder, and
@@ -73,11 +76,17 @@ function withTrailingSlash(s) { return s.endsWith('/') ? s : s + '/'; }
 // the sidecar). Anything else trips the build rather than shipping bytes the
 // server can't serve correctly. null = identity (raw bytes).
 const ALLOWED_ENCODINGS = new Set([null, 'br', 'gzip']);
-// Noto Sans SC Regular (OFL-1.1), pinned release tag, served via jsDelivr which
-// resolves the repo's Git-LFS blob to the real font bytes. SubsetOTF/SC = the
-// Simplified-Chinese subset (full SC coverage, ~8 MB) rather than the all-CJK
-// OTF (~16 MB). License: googlefonts/noto-cjk LICENSE (OFL-1.1).
-const FONT_URL = 'https://cdn.jsdelivr.net/gh/googlefonts/noto-cjk@Sans2.004/Sans/SubsetOTF/SC/NotoSansSC-Regular.otf';
+// CJK fonts (all OFL-1.1), pinned versions. 宋体/黑体/微软雅黑/仿宋/楷体 are
+// proprietary and CANNOT ship; instead we bundle one open font per Chinese
+// typeface CATEGORY and zetaOfficeBoot.js's fontconfig aliases map the
+// proprietary names onto them (黑体类→Noto Sans SC, 宋体类→Noto Serif SC,
+// 楷体类→LXGW WenKai, 仿宋类→Zhuque Fangsong). SubsetOTF/SC = the
+// Simplified-Chinese subset rather than the all-CJK OTF.
+const FONT_SANS_URL = 'https://cdn.jsdelivr.net/gh/googlefonts/noto-cjk@Sans2.004/Sans/SubsetOTF/SC/NotoSansSC-Regular.otf';
+const FONT_SERIF_URL = 'https://cdn.jsdelivr.net/gh/googlefonts/noto-cjk@Serif2.002/Serif/SubsetOTF/SC/NotoSerifSC-Regular.otf';
+const FONT_KAI_URL = 'https://github.com/lxgw/LxgwWenKai/releases/download/v1.520/LXGWWenKai-Regular.ttf';
+// Zhuque only publishes a zip; zipEntry extracts the single ttf inside.
+const FONT_FANGSONG_URL = 'https://github.com/TrionesType/zhuque/releases/download/v0.212/ZhuqueFangsong-v0.212.zip';
 
 const distRoot = path.join(__dirname, '../../frontend/dist/zetaoffice');
 
@@ -94,8 +103,46 @@ const ASSETS = [
   { url: LOWA_BASE + 'soffice.wasm',             dest: 'lowa/soffice.wasm',             serve: 'lowa',   encoding: 'br', magic: 'wasm' },
   { url: LOWA_BASE + 'soffice.data',             dest: 'lowa/soffice.data',             serve: 'lowa',   encoding: 'br', magic: 'blob' },
   { url: LOWA_BASE + 'soffice.data.js.metadata', dest: 'lowa/soffice.data.js.metadata', serve: 'lowa',   encoding: null, magic: 'json' },
-  { url: FONT_URL,                               dest: 'cjk.ttc',                       serve: 'static', encoding: null, magic: 'font' },
+  { url: FONT_SANS_URL,                          dest: 'cjk.ttc',                       serve: 'static', encoding: null, magic: 'font' },
+  { url: FONT_SERIF_URL,                         dest: 'cjk-serif.otf',                 serve: 'static', encoding: null, magic: 'font' },
+  { url: FONT_KAI_URL,                           dest: 'cjk-kai.ttf',                   serve: 'static', encoding: null, magic: 'font' },
+  { url: FONT_FANGSONG_URL,                      dest: 'cjk-fangsong.ttf',              serve: 'static', encoding: null, magic: 'font',
+    zipEntry: 'ZhuqueFangsong-Regular.ttf' },
 ];
+
+// Minimal single-entry zip extraction (Zhuque ships a zip with one ttf inside;
+// no unzip dependency in the build scripts). Parses the End-of-Central-Directory
+// record, walks the central directory to the named entry, and inflates it.
+function unzipEntry(buf, entryName) {
+  let eocd = -1;
+  for (let i = buf.length - 22; i >= Math.max(0, buf.length - 22 - 65536); i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
+  }
+  if (eocd < 0) throw new Error('zip: EOCD not found');
+  const count = buf.readUInt16LE(eocd + 10);
+  let off = buf.readUInt32LE(eocd + 16);
+  for (let i = 0; i < count; i++) {
+    if (buf.readUInt32LE(off) !== 0x02014b50) throw new Error('zip: bad central directory entry');
+    const method = buf.readUInt16LE(off + 10);
+    const compSize = buf.readUInt32LE(off + 20);
+    const nameLen = buf.readUInt16LE(off + 28);
+    const extraLen = buf.readUInt16LE(off + 30);
+    const commentLen = buf.readUInt16LE(off + 32);
+    const localOff = buf.readUInt32LE(off + 42);
+    const name = buf.toString('utf8', off + 46, off + 46 + nameLen);
+    if (name === entryName) {
+      const lNameLen = buf.readUInt16LE(localOff + 26);
+      const lExtraLen = buf.readUInt16LE(localOff + 28);
+      const dataStart = localOff + 30 + lNameLen + lExtraLen;
+      const data = buf.subarray(dataStart, dataStart + compSize);
+      if (method === 0) return Buffer.from(data);
+      if (method === 8) return zlib.inflateRawSync(data);
+      throw new Error('zip: unsupported compression method ' + method);
+    }
+    off += 46 + nameLen + extraLen + commentLen;
+  }
+  throw new Error('zip: entry not found: ' + entryName);
+}
 
 // Fetch a URL (http(s) or file://); resolves {encoding, body:Buffer}. file://
 // has no content-encoding, so it's always identity (null) — a self-built engine
@@ -216,12 +263,15 @@ async function fetchAsset(a) {
   if (a.serve === 'static' && enc !== null) {
     throw new Error(a.dest + ': static asset must be identity but source sent ' + JSON.stringify(enc));
   }
-  checkMagic(decode(body, enc), a.magic, a.dest);
+  // Zip-packaged asset: store the extracted entry, not the archive.
+  let out = body;
+  if (a.zipEntry) out = unzipEntry(decode(body, enc), a.zipEntry);
+  checkMagic(decode(out, a.zipEntry ? null : enc), a.magic, a.dest);
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath + '.part', body);
+  fs.writeFileSync(destPath + '.part', out);
   fs.renameSync(destPath + '.part', destPath);
-  console.log(' ' + (body.length / 1048576).toFixed(1) + ' MB' + (enc ? ' (' + enc + ')' : ''));
-  return { size: body.length, enc };
+  console.log(' ' + (out.length / 1048576).toFixed(1) + ' MB' + (enc ? ' (' + enc + ')' : ''));
+  return { size: out.length, enc: a.zipEntry ? null : enc };
 }
 
 async function main() {

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -38,6 +38,9 @@ export const EDITOR_ACTIONS = [
   'export_document',
   // [diagnostic #66] report resolved UI locale (ooLocale) to confirm zh-CN took effect.
   'get_ui_lang',
+  // [diagnostic] registered device font families — ground truth for the CJK
+  // font-injection/alias chain (zetaOfficeBoot.js).
+  'list_fonts',
   // [#104 变量面板] document variable fields — bookmark-marked spans bound to a
   // (scope, varName) variable; driven by VariablePanel through the getWps adapter
   // in project-overview.vue, not by the AI agent pipeline.

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -42,6 +42,8 @@ const DEFAULT_SOFFICE_BASE_URL = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
  * @param {string}   [options.zetaJsUrl='./zeta.js'] vendored zetajs bridge URL.
  * @param {string}   [options.workerScriptUrl='./office_thread.js'] office worker URL.
  * @param {string}   [options.fontUrl] optional same-origin CJK font to inject.
+ * @param {string[]} [options.fontUrls] optional same-origin CJK fonts (one per
+ *        typeface category: sans/serif/kai/fangsong); merged with fontUrl.
  * @param {(msg:string)=>void}     [options.onLog] worker 'log' lines + milestones.
  * @param {()=>void}                [options.onReady] fired on worker 'ui_ready'
  *        (document loaded, canvas interactive).
@@ -55,6 +57,7 @@ export function bootZetaOffice(options = {}) {
     zetaJsUrl = './zeta.js',
     workerScriptUrl = './office_thread.js',
     fontUrl,
+    fontUrls,
     // UI language for the LibreOffice chrome (issue #66 follow-up). The engine
     // derives its locale from navigator.languages (emscripten getEnvStrings ->
     // LANG), so the UI silently follows the BROWSER/Electron language — an
@@ -86,58 +89,97 @@ export function bootZetaOffice(options = {}) {
     // overhead.)
     const injections = []
 
-    // --- optional CJK font fetch (injected before fontconfig scan) ---
-    if (fontUrl) {
+    // --- optional CJK fonts fetch (injected before fontconfig scan) ---
+    // fontUrls entries are {url, family, category} (or plain URL strings, which
+    // inject without contributing to the alias map — spike/?font= back-compat;
+    // fontUrl merges in the same way). `family` MUST be the name LibreOffice
+    // registers for the file (list_fonts diagnostic; for zh-localized name
+    // tables that is the CHINESE name, e.g. 霞鹜文楷 — real-machine verified
+    // both zh and en names resolve, but we pin what list_fonts reported).
+    const fontList = [].concat(fontUrls || [], fontUrl ? [fontUrl] : [])
+      .map((f) => (typeof f === 'string' ? { url: f } : f))
+    const availableByCategory = {} // category -> registered family name
+    for (let i = 0; i < fontList.length; i++) {
+      const f = fontList[i]
       try {
-        const r = await fetch(fontUrl)
+        const r = await fetch(f.url)
         if (r.ok) {
-          const cjkBytes = new Uint8Array(await r.arrayBuffer())
-          injections.push({ path: '/instdir/share/fonts/truetype/AAA-CJK.ttc', bytes: cjkBytes })
-          log('CJK font fetched (' + Math.round(cjkBytes.length / 1024) + ' KB), will inject before boot')
+          const bytes = new Uint8Array(await r.arrayBuffer())
+          const base = String(f.url).split('?')[0].split('/').pop() || ('font-' + i)
+          injections.push({ path: '/instdir/share/fonts/truetype/AAA-' + base, bytes })
+          if (f.category && f.family && !availableByCategory[f.category]) availableByCategory[f.category] = f.family
+          log('CJK font fetched: ' + base + ' (' + Math.round(bytes.length / 1024) + ' KB)')
         } else {
-          log('CJK font not found at ' + fontUrl + ' (skipping; CJK will be tofu)')
+          log('CJK font not found at ' + f.url + ' (skipping)')
         }
       } catch (e) {
-        log('CJK font fetch failed: ' + e + ' (skipping)')
+        log('CJK font fetch failed: ' + f.url + ' — ' + e + ' (skipping)')
       }
     }
 
     // --- CJK font-name aliases (fontconfig conf.d) ---
-    // Real-world docx name 宋体/黑体/微软雅黑/…; none ship in the engine image,
-    // and the WASM build does NO glyph fallback — every missing family renders
-    // tofu even though the injected Noto Sans SC has the glyphs (real-machine
-    // verified: the same text renders once CharFontName='Noto Sans SC'). Map the
-    // common Chinese families onto the injected font. `append` + binding="weak"
-    // = fallback-only: if an engine ever bundles the real 黑体, the alias loses.
-    if (injections.length) {
-      const CJK_FAMILIES = [
-        '宋体', 'SimSun', '新宋体', 'NSimSun', '宋体-简', 'Songti SC',
-        '黑体', 'SimHei', '黑体-简', 'Heiti SC',
+    // Real-world docx name 宋体/黑体/微软雅黑/仿宋/楷体/…; those are proprietary
+    // (can't ship) and the WASM build does NO glyph fallback — every missing
+    // family renders tofu even when an injected font has the glyphs (real-
+    // machine verified: the same text renders once CharFontName names an
+    // existing family). Map each proprietary family onto the bundled open font
+    // of the SAME typeface category. Rules are `assign` (hard replace) to the
+    // first category font that ACTUALLY fetched this boot — weak `append`
+    // chains were real-machine tested and LOST to generic matching (every
+    // category rendered sans), so the fallback logic lives HERE, not in
+    // fontconfig scoring.
+    const pickFamily = (...cats) => { for (const c of cats) { if (availableByCategory[c]) return availableByCategory[c] } return null }
+    const CJK_ALIAS_GROUPS = [
+      // 黑体类（无衬线）
+      { target: pickFamily('sans'), families: [
+        '黑体', 'SimHei', '黑体-简', 'Heiti SC', '华文黑体', 'STHeiti', '华文细黑', 'STXihei',
         '微软雅黑', 'Microsoft YaHei', 'Microsoft YaHei UI',
         '等线', 'DengXian', '等线 Light', 'DengXian Light',
-        '仿宋', 'FangSong', '仿宋_GB2312', 'FangSong_GB2312',
+        '思源黑体', 'Source Han Sans SC', 'Source Han Sans CN', 'Noto Sans CJK SC',
+        'MS Gothic', 'Yu Gothic', 'Malgun Gothic',
+      ] },
+      // 宋体类（衬线）
+      { target: pickFamily('serif', 'sans'), families: [
+        '宋体', 'SimSun', '新宋体', 'NSimSun', '宋体-简', 'Songti SC',
+        '华文宋体', 'STSong', '华文中宋', 'STZhongsong',
+        '思源宋体', 'Source Han Serif SC', 'Source Han Serif CN', 'Noto Serif CJK SC',
+        'MS Mincho',
+      ] },
+      // 楷体类
+      { target: pickFamily('kai', 'serif', 'sans'), families: [
         '楷体', 'KaiTi', '楷体_GB2312', 'KaiTi_GB2312', '楷体-简', 'Kaiti SC',
-        '华文宋体', 'STSong', '华文中宋', 'STZhongsong', '华文黑体', 'STHeiti',
-        '华文楷体', 'STKaiti', '华文仿宋', 'STFangsong', '华文细黑', 'STXihei',
-        '思源黑体', 'Source Han Sans SC', 'Source Han Sans CN',
-        '思源宋体', 'Source Han Serif SC', 'Source Han Serif CN',
-        'Noto Sans CJK SC', 'Noto Serif CJK SC', 'Noto Serif SC',
-        'MS Gothic', 'MS Mincho', 'Yu Gothic', 'Malgun Gothic',
-      ]
+        '华文楷体', 'STKaiti', 'LXGW WenKai',
+      ] },
+      // 仿宋类（公文常用）
+      { target: pickFamily('fangsong', 'serif', 'sans'), families: [
+        '仿宋', 'FangSong', '仿宋_GB2312', 'FangSong_GB2312',
+        '华文仿宋', 'STFangsong', 'Zhuque Fangsong',
+      ] },
+    ].filter((g) => g.target)
+    if (CJK_ALIAS_GROUPS.length) {
       const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      const rules = CJK_FAMILIES.map((fam) =>
-        '  <match target="pattern">\n' +
-        '    <test qual="any" name="family"><string>' + esc(fam) + '</string></test>\n' +
-        '    <edit name="family" mode="append" binding="weak"><string>Noto Sans SC</string></edit>\n' +
-        '  </match>').join('\n')
+      const rules = []
+      let familyCount = 0
+      for (const g of CJK_ALIAS_GROUPS) {
+        for (const fam of g.families) {
+          if (fam === g.target) continue
+          familyCount++
+          rules.push(
+            '  <match target="pattern">\n' +
+            '    <test qual="any" name="family"><string>' + esc(fam) + '</string></test>\n' +
+            '    <edit name="family" mode="assign" binding="same"><string>' + esc(g.target) + '</string></edit>\n' +
+            '  </match>')
+        }
+      }
       const conf = '<?xml version="1.0"?>\n' +
         '<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">\n' +
-        '<fontconfig>\n' + rules + '\n</fontconfig>\n'
+        '<fontconfig>\n' + rules.join('\n') + '\n</fontconfig>\n'
       injections.push({
         path: '/instdir/share/fontconfig/conf.d/69-aiworkdeck-cjk-aliases.conf',
         bytes: new TextEncoder().encode(conf),
       })
-      log('CJK font-name alias conf queued (' + CJK_FAMILIES.length + ' families → Noto Sans SC)')
+      log('CJK font-name alias conf queued (' + familyCount + ' families → ' +
+        CJK_ALIAS_GROUPS.map((g) => g.target).join(' / ') + ')')
     }
 
     // The globals `canvas` and `Module` must exist before soffice.js loads.

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -164,9 +164,20 @@ startEditorEndpoint({
   sofficeBaseUrl: q.get('lowa') || 'https://cdn.zetaoffice.net/zetaoffice_latest/',
   zetaJsUrl: q.get('zeta') || './zeta.js',
   workerScriptUrl: q.get('worker') || './office_thread.js',
-  // Default to a CJK font served next to the page (the verify build drops one
-  // here); bootZetaOffice skips cleanly if it 404s (Chinese would be tofu then).
-  fontUrl: q.get('font') || './cjk.ttc',
+  // Default to the CJK fonts served next to the page — one per Chinese typeface
+  // category (黑体类 sans / 宋体类 serif / 楷体 / 仿宋), baked by
+  // desktop/scripts/fetch-lowa-assets.js. bootZetaOffice skips any that 404
+  // (its fontconfig alias chains then fall through to the next category font).
+  // ?font= overrides/adds a single extra font (kept for the spike harness).
+  fontUrl: q.get('font') || undefined,
+  // family = the name LibreOffice registers (list_fonts diagnostic) — the
+  // boot's fontconfig alias rules point 宋体/黑体/楷体/仿宋/… at these.
+  fontUrls: [
+    { url: './cjk.ttc', family: 'Noto Sans SC', category: 'sans' },
+    { url: './cjk-serif.otf', family: 'Noto Serif SC', category: 'serif' },
+    { url: './cjk-kai.ttf', family: '霞鹜文楷', category: 'kai' },
+    { url: './cjk-fangsong.ttf', family: '朱雀仿宋（预览测试版）', category: 'fangsong' },
+  ],
   // Deterministic Chinese UI regardless of the browser/Electron language (the
   // engine follows navigator.languages otherwise — v0.3.1 shipped English on an
   // en-GB system). ?uilang=env follows the environment; ?uilang=xx-YY overrides.

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -782,6 +782,20 @@ const EXEC = {
   // [diagnostic #66] report the resolved UI locale (ooLocale) so the host/verify
   // panel can confirm whether the injected zh-CN langpack took effect.
   get_ui_lang() { return Object.assign({ success: true }, readConfigLocale()); },
+  // [diagnostic] the font families the engine actually registered (device font
+  // list). Ground truth for the CJK font-injection/alias chain — a family
+  // missing here can only ever render via an alias to one that is present.
+  list_fonts() {
+    try {
+      const toolkit = css.awt.Toolkit.create(context);
+      const dev = toolkit.createScreenCompatibleDevice(0, 0);
+      const fds = dev.getFontDescriptors();
+      const names = {};
+      for (let i = 0; i < fds.length; i++) { names[fds[i].Name] = true; }
+      const families = Object.keys(names).sort();
+      return { success: true, count: families.length, families: families };
+    } catch (e) { return { success: false, message: errStr(e) }; }
+  },
   // ==================== 拟人式原语（感知 / 定位 / 格式 / 撤销） ====================
   // [感知] read the document as numbered paragraphs — the AI's "eyes". Windowed
   // (startParagraph + maxParagraphs, plus a char budget) so a 200-page contract


### PR DESCRIPTION
## 背景

PR#157 修掉了中文 tofu，但所有字体名都映射到唯一的 Noto Sans SC——用户反馈"难道都看一个字体吗"。

## 方案

宋体/黑体/微软雅黑/仿宋/楷体是商业字体**不能分发**，按字形类别捆绑开源替代（全部 OFL-1.1）：

| 文档声明 | 渲染为 | 新增体积 |
|---|---|---|
| 黑体/微软雅黑/等线/华文黑体… | Noto Sans SC（思源黑体，已有） | — |
| 宋体/新宋体/华文宋体/华文中宋… | **Noto Serif SC**（思源宋体） | 11MB |
| 楷体/楷体_GB2312/华文楷体… | **霞鹜文楷** | 24MB |
| 仿宋/仿宋_GB2312/华文仿宋…（公文常用） | **朱雀仿宋** | 8MB |

关键实现点：
- **assign 而非 weak-append**：weak append 链真机实测输给泛型匹配（四类全落到 sans）；改为 boot 时按"实际加载成功的字体"生成 fontconfig 硬替换规则，类别字体缺失时生成侧顺位回退 serif→sans。
- **族名以 LO 实际注册名为准**：zh 名表的字体注册的是中文名（霞鹜文楷/朱雀仿宋（预览测试版）），新增 `list_fonts` 诊断原语实证——本次根因定位全靠它。
- **朱雀官方只发 zip**：fetch-lowa-assets.js 加了无依赖最小 unzip（EOCD→中央目录→inflateRaw），沙盒树验证幂等。

## 验证（无头 harness，本机 Chrome + 安装版引擎）

- 宋/黑/雅黑/楷/仿宋五段样张：**四种字形清晰可辨**（截图比对）
- 用户真实 18MB 合同：加载渲染无回归，boot ~1s / load ~3.4s
- fetch 脚本沙盒全流程 + 二次幂等运行通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)