### PR TITLE
chore(release): v0.7.5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
v0.7.5 版本号 bump。相对 v0.7.4 新增（4 个 PR）：

- #156 fix(backend): 分片上传第 2+ 块写散到孤儿路径致大文件截断（>5MB 上传"文档加载失败"根因）
- #157 fix(editor): 中文字体 tofu 修复 + 顶部状态条改浮动 + 文档加载提速
- #158 feat(editor): 按字形类别捆绑四款开源中文字体并映射
- #159 feat(editor): Office 标签 LOWA 实例保活，切换不重启引擎

合并后打 tag v0.7.5 触发 desktop-build 发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)