### PR TITLE
fix(ai): 修复 AI 面板假死与任务静默中断，任务卡紧凑化

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -33,6 +33,23 @@ public class AgentOrchestrator {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AgentOrchestrator.class);
 
+    // 循环步数预算：达到上限时优雅收尾（保存进度 + 告知用户可继续），而不是静默中断
+    private static final int MAX_LOOP_DEPTH = 30;
+    // 同一工具+同参数连续重复调用达到该次数后，拒绝执行并要求模型换思路
+    private static final int MAX_IDENTICAL_TOOL_CALLS = 3;
+    // 工具连续失败达到该次数后，向模型注入强提示要求收敛
+    private static final int CONSECUTIVE_FAILURE_NUDGE = 3;
+
+    /**
+     * 单次 Agent 运行的循环守卫状态（随递归传递）：
+     * 重复调用检测 + 连续失败计数，防止模型原地打转耗尽步数预算。
+     */
+    private static class RunGuard {
+        String lastCallSignature;
+        int repeatCount;
+        int consecutiveFailures;
+    }
+
     // 取消状态管理：存储被取消的会话ID
     private final Set<String> cancelledConversations = ConcurrentHashMap.newKeySet();
     // 存储当前活跃会话的已生成内容（用于取消时保存部分内容）
@@ -248,7 +265,7 @@ public class AgentOrchestrator {
             log.info("Starting runLoop for conversation: {}, mode: {}", conversationId, agentMode);
             // Track tool executions for history persistence
             StringBuilder executionLog = new StringBuilder();
-            runLoop(model, messages, conversationId, projectId, userId, request.getModel(), 0, executionLog, agentMode);
+            runLoop(model, messages, conversationId, projectId, userId, request.getModel(), 0, executionLog, agentMode, new RunGuard());
             
         } catch (Exception e) {
             log.error("Agent Loop Error for conversation: " + conversationId, e);
@@ -257,20 +274,26 @@ public class AgentOrchestrator {
         }
     }
 
-    private void runLoop(StreamingChatLanguageModel model, 
-                         java.util.List<dev.langchain4j.data.message.ChatMessage> messages, 
+    private void runLoop(StreamingChatLanguageModel model,
+                         java.util.List<dev.langchain4j.data.message.ChatMessage> messages,
                          String conversationId, String projectId, Long userId, String modelId, int depth,
-                         StringBuilder executionLog, AgentMode agentMode) {
-        
+                         StringBuilder executionLog, AgentMode agentMode, RunGuard guard) {
+
         // 检查是否被取消
         if (isCancelled(conversationId)) {
             log.info("Conversation {} was cancelled, stopping loop at depth {}", conversationId, depth);
             handleCancellation(conversationId, projectId, userId);
             return;
         }
-        
-        if (depth > 10) {
-            sseEmitterService.send(conversationId, "error", "Max recursion depth reached");
+
+        if (depth > MAX_LOOP_DEPTH) {
+            // 步数预算耗尽：不是报错，而是"存档 + 请示"——保存进度、明确告知用户、干净收尾。
+            log.warn("Agent loop reached max depth {} for conversation {}, stopping gracefully", MAX_LOOP_DEPTH, conversationId);
+            String notice = "\n\n> ⚠️ 本轮已达最大执行步数（" + MAX_LOOP_DEPTH + " 步），先暂停。已完成的修改均已生效，回复\"继续\"可接着执行剩余任务。";
+            sendTextDelta(conversationId, notice);
+            String persisted = (executionLog.length() > 0 ? executionLog.toString() : "") + notice;
+            saveAssistantMessage(conversationId, projectId, userId, persisted);
+            sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"finished\"}");
             sseEmitterService.close(conversationId);
             clearCancelledState(conversationId);
             return;
@@ -339,33 +362,52 @@ public class AgentOrchestrator {
             // 1. Check for Native Tool Requests (Priority 1)
             if (aiMessage.hasToolExecutionRequests()) {
                 log.info("Detected Native Tool Requests: {}", aiMessage.toolExecutionRequests());
-                sseEmitterService.send(conversationId, "step_update", "{\"status\":\"loading\", \"message\":\"Executing tools...\"}");
 
                 // Execute Native Tools (统一分发，无需感知具体工具)
                 for (dev.langchain4j.agent.tool.ToolExecutionRequest req : aiMessage.toolExecutionRequests()) {
-                    ToolRegistry.ToolResult toolResult = dispatchTool(req.name(), req.arguments(),
-                            Long.parseLong(projectId), conversationId, userId, modelId);
-                    String result = toolResult.output();
+                    // 面板可见性：原生工具调用复用 <process> XML 协议推送给前端，
+                    // 与模型自发的 XML tool_code 走同一套任务卡渲染管线（修复：原生轮次面板无任何输出，看似卡死）
+                    String displayName = toolRegistry.resolve(req.name())
+                            .map(ToolRegistry.RegisteredTool::displayName)
+                            .orElse(req.name());
+                    sendTextDelta(conversationId, String.format("<process name=\"%s\"><tool_code>%s(%s)</tool_code></process>",
+                            displayName.replace("\"", "'"), req.name(), truncate(req.arguments(), 200)));
+
+                    String result;
+                    boolean success;
+                    String guardVerdict = checkRepeatedCall(guard, req.name(), req.arguments());
+                    if (guardVerdict != null) {
+                        // 重复调用熔断：不执行，直接把守卫反馈作为工具结果回给模型
+                        log.warn("Loop guard tripped for {}: tool={} repeated {} times", conversationId, req.name(), guard.repeatCount);
+                        result = guardVerdict;
+                        success = false;
+                    } else {
+                        ToolRegistry.ToolResult toolResult = dispatchTool(req.name(), req.arguments(),
+                                Long.parseLong(projectId), conversationId, userId, modelId);
+                        result = toolResult.output();
+                        success = toolResult.success();
+                    }
+                    result = appendFailureNudge(guard, result, success);
                     messages.add(dev.langchain4j.data.message.ToolExecutionResultMessage.from(req, result));
 
                     // Determine status for history and display
-                    String nativeToolStatus = toolResult.success() ? "SUCCESS" : "FAILURE";
+                    String nativeToolStatus = success ? "SUCCESS" : "FAILURE";
+                    sendTextDelta(conversationId, String.format("<tool_output status=\"%s\">%s</tool_output>",
+                            nativeToolStatus, truncate(result, 4000)));
 
                     // Log for history persistence (include status attribute)
                     executionLog.append(String.format("<process name=\"%s\"><tool_code>%s(%s)</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
-                        req.name(), req.name(), req.arguments(), nativeToolStatus, result));
+                        displayName.replace("\"", "'"), req.name(), req.arguments(), nativeToolStatus, result));
                 }
 
-                sseEmitterService.send(conversationId, "step_update", "{\"status\":\"done\", \"message\":\"Tools executed.\"}");
-                
                 // 增量保存：在工具执行后立即保存AI消息和工具输出，防止对话中断导致上下文丢失
                 String intermediateContent = (aiContent != null ? aiContent : "") + "\n" + executionLog.toString();
                 saveAssistantMessage(conversationId, projectId, userId, intermediateContent);
                 log.info("Intermediate save after native tool execution for conversation: {}", conversationId);
-                
-                runLoop(model, messages, conversationId, projectId, userId, modelId, depth + 1, executionLog, agentMode);
+
+                runLoop(model, messages, conversationId, projectId, userId, modelId, depth + 1, executionLog, agentMode, guard);
                 return;
-            } 
+            }
             
             String content = aiMessage.text();
             if (content == null) content = "";
@@ -385,14 +427,27 @@ public class AgentOrchestrator {
                     String code = call.rawCode();
                     log.info("Parsed Tool Code: {}", code);
 
-                    ToolRegistry.ToolResult toolResult = dispatchTool(call.toolName(), call.argsJson(),
-                            Long.parseLong(projectId), conversationId, userId, modelId);
-                    String result = toolResult.found()
-                            ? toolResult.output()
-                            : "Unknown tool in custom parser: " + code;
+                    String result;
+                    boolean xmlToolSuccess;
+                    ToolRegistry.ToolResult toolResult = null;
+                    String guardVerdict = checkRepeatedCall(guard, call.toolName(), call.argsJson());
+                    if (guardVerdict != null) {
+                        // 重复调用熔断：不执行，直接把守卫反馈作为工具结果回给模型
+                        log.warn("Loop guard tripped for {}: tool={} repeated {} times", conversationId, call.toolName(), guard.repeatCount);
+                        result = guardVerdict;
+                        xmlToolSuccess = false;
+                    } else {
+                        toolResult = dispatchTool(call.toolName(), call.argsJson(),
+                                Long.parseLong(projectId), conversationId, userId, modelId);
+                        result = toolResult.found()
+                                ? toolResult.output()
+                                : "Unknown tool in custom parser: " + code;
+                        xmlToolSuccess = toolResult.found() && toolResult.success();
+                    }
+                    result = appendFailureNudge(guard, result, xmlToolSuccess);
 
                     // Add Result to History
-                    String statusPrefix = (toolResult.found() && toolResult.success()) ? "SUCCESS" : "FAILURE";
+                    String statusPrefix = xmlToolSuccess ? "SUCCESS" : "FAILURE";
 
                     // Enhancement for Write Tools: Append explicit success for file creation/modification
                     // The model often sees JSON IDs (wps_file_id) and thinks it failed or needs to do more.
@@ -410,7 +465,7 @@ public class AgentOrchestrator {
                     // 优先使用LLM选择的process name，否则用工具元数据里的中文显示名
                     String processNameForLog = (llmProcessName != null && !llmProcessName.isEmpty())
                         ? llmProcessName
-                        : (toolResult.tool() != null ? toolResult.tool().displayName() : "工具执行");
+                        : (toolResult != null && toolResult.tool() != null ? toolResult.tool().displayName() : "工具执行");
                     executionLog.append(String.format("<process name=\"%s\"><tool_code>%s</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
                         processNameForLog, code, statusPrefix, result));
 
@@ -431,7 +486,7 @@ public class AgentOrchestrator {
                      log.info("Intermediate save after XML tool execution for conversation: {}", conversationId);
 
                      // Recurse with executionLog
-                     runLoop(model, messages, conversationId, projectId, userId, modelId, depth + 1, executionLog, agentMode);
+                     runLoop(model, messages, conversationId, projectId, userId, modelId, depth + 1, executionLog, agentMode, guard);
                      return;
                 }
             }
@@ -591,6 +646,61 @@ public class AgentOrchestrator {
             List<ToolSpecification> allTools = skillRouter.visibleTools(conversationId, toolRegistry.getAllSpecifications());
             model.generate(messages, allTools, handler);
         }
+    }
+
+    // =================================================================================
+    // Loop guard & SSE helpers
+    // =================================================================================
+
+    /**
+     * 通过 text_delta 事件向前端推送一段内容（与流式 token 走同一渲染管线）。
+     */
+    private void sendTextDelta(String conversationId, String content) {
+        String esc = content.replace("\\", "\\\\").replace("\"", "\\\"")
+                .replace("\n", "\\n").replace("\r", "\\r");
+        sseEmitterService.send(conversationId, "text_delta", "{\"content\":\"" + esc + "\"}");
+    }
+
+    private String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max) + "...(截断)";
+    }
+
+    /**
+     * 重复调用检测：同一工具+同参数连续调用达到上限时返回守卫反馈（调用方应跳过执行），否则返回 null。
+     */
+    private String checkRepeatedCall(RunGuard guard, String toolName, String args) {
+        String signature = toolName + "|" + (args == null ? "" : args);
+        if (signature.equals(guard.lastCallSignature)) {
+            guard.repeatCount++;
+        } else {
+            guard.lastCallSignature = signature;
+            guard.repeatCount = 1;
+        }
+        if (guard.repeatCount >= MAX_IDENTICAL_TOOL_CALLS) {
+            return String.format("Error: 检测到你已连续 %d 次以完全相同的参数调用 %s，本次调用已被系统拦截。" +
+                    "请不要原样重试：换一种方法（其他工具、调整参数或先读取文档确认状态）；" +
+                    "如果任务已无法继续，请输出 <final> 向用户说明目前进展和遇到的问题。",
+                    guard.repeatCount, toolName);
+        }
+        return null;
+    }
+
+    /**
+     * 连续失败计数：失败累计到阈值时在工具结果后追加收敛提示，成功则清零。
+     */
+    private String appendFailureNudge(RunGuard guard, String result, boolean success) {
+        if (success) {
+            guard.consecutiveFailures = 0;
+            return result;
+        }
+        guard.consecutiveFailures++;
+        if (guard.consecutiveFailures >= CONSECUTIVE_FAILURE_NUDGE) {
+            return result + String.format("\n\n(System Note: 已连续 %d 次工具执行失败。请停止当前思路，" +
+                    "先用读取类工具确认文档当前状态，或输出 <final> 向用户说明遇到的问题，不要继续盲目重试。)",
+                    guard.consecutiveFailures);
+        }
+        return result;
     }
 
     // =================================================================================

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -178,6 +178,12 @@ You operate in a [Thought -> Action -> Observation] loop.
 - **NEVER output `<final>` in the same turn as `<tool_code>`**
 - When you receive `TOOL_RESULT`, you MUST continue. Do NOT ask "是否继续?"
 
+## Step Budget & Anti-Flailing (CRITICAL)
+- 你的执行步数有限（约 30 步预算，超出会被系统暂停）。**每一步都要有效**：行动前先想清楚定位方式，避免"试一下再说"。
+- **同一思路失败不要原样重试**：同一工具+同样参数连续失败 2 次后，必须换方法（换定位方式、换工具、或先用读取类工具确认文档当前状态）。系统会拦截第 3 次完全相同的调用。
+- **改错就 undo，但 undo 后必须换思路**：不要陷入"改→撤销→原样再改"的循环。
+- **多项修订任务先列清单**：涉及 3 处以上修改时，先用 `task_list` artifact 列出所有修改点，然后逐项执行、逐项确认，最后用 `<final>` 汇总"已完成 X 处修改、各处改了什么"。
+
 ## Clarification (Using `<question>` Tag)
 If you lack critical details, **STOP and ASK** using the `<question>` tag. Do NOT guess or use placeholders.
 

--- a/frontend/src/components/AgentMessage/ProcessCard.vue
+++ b/frontend/src/components/AgentMessage/ProcessCard.vue
@@ -20,7 +20,8 @@
       </div>
       <div class="right">
 
-        <div v-if="isFinished" class="status-badge success">成功</div>
+        <div v-if="hasError" class="status-badge error">出错</div>
+        <div v-else-if="isFinished" class="status-badge success">成功</div>
         <div v-else class="status-badge processing">执行中</div>
         <div class="chevron-wrapper" :class="{ 'is-rotated': isExpanded }">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -97,7 +98,7 @@
             <span class="step-text">{{ step.text }}</span>
          </div>
       </div>
-      <div style="width: 100%; border-bottom: 1px solid #ddd; margin: 0 auto; margin-top: 18px;"></div>
+      <div style="width: 100%; border-bottom: 1px solid #eee; margin: 0 auto; margin-top: 6px;"></div>
 
 
     </div>
@@ -128,10 +129,16 @@ const processTitle = computed(() => {
 })
 
 const isFinished = computed(() => {
-    // Check if any item is still doing or if the process itself marks completion
-    // Given the request, we'll assume it's finished if there are items and none are 'doing'
+    // 有任何条目仍在进行中（步骤 doing / 工具 loading / 思考 thinking）都算未完成
     if (!props.process.items || props.process.items.length === 0) return false
-    return !props.process.items.some(item => item.status === 'doing')
+    return !props.process.items.some(item =>
+        item.status === 'doing' || item.status === 'loading' || item.status === 'thinking'
+    )
+})
+
+const hasError = computed(() => {
+    if (!props.process.items) return false
+    return props.process.items.some(item => item.status === 'error')
 })
 
 const userHasToggled = ref(false)
@@ -196,7 +203,7 @@ const isSecondaryContent = (text) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 7px 12px;
   cursor: pointer;
   background: #ffffff;
   transition: background 0.15s;
@@ -209,7 +216,7 @@ const isSecondaryContent = (text) => {
 .left {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .header-icon-wrapper {
@@ -220,7 +227,7 @@ const isSecondaryContent = (text) => {
 }
 
 .title {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   color: #1A5336; /* Forest Green */
 }
@@ -228,13 +235,13 @@ const isSecondaryContent = (text) => {
 .right {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .status-badge {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
-  padding: 2px 8px;
+  padding: 1px 7px;
   border-radius: 99px;
 }
 
@@ -248,6 +255,11 @@ const isSecondaryContent = (text) => {
   color: #6C757D; /* Gray-Medium */
 }
 
+.status-badge.error {
+  background: #FDEDEC;
+  color: #C0392B;
+}
+
 .chevron-wrapper {
   color: #ADB5BD;
   transition: transform 0.2s ease;
@@ -258,11 +270,11 @@ const isSecondaryContent = (text) => {
 }
 
 .process-body {
-  padding: 8px 16px 6px 16px;
+  padding: 4px 12px 4px 12px;
 }
 
 .process-item {
-    margin-bottom: 8px;
+    margin-bottom: 4px;
 }
 
 /* Step Styling */
@@ -273,16 +285,16 @@ const isSecondaryContent = (text) => {
 .step-row {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  padding-left: 4px;
+  gap: 8px;
+  padding-left: 2px;
 }
 
 .step-dot {
-  width: 6px;
-  height: 6px;
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
   background: #E9ECEF;
-  margin-top: 7px;
+  margin-top: 6px;
   flex-shrink: 0;
 }
 
@@ -291,14 +303,14 @@ const isSecondaryContent = (text) => {
 }
 
 .step-text {
-  font-size: 13px;
+  font-size: 12px;
   color: #2C3338; /* Gray-Dark */
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
 .step-text.is-meta {
     color: #6C757D; /* Gray-Medium */
-    font-size: 12px;
+    font-size: 11px;
 }
 
 /* File Attachment Card */
@@ -308,9 +320,9 @@ const isSecondaryContent = (text) => {
     background: #F8F9FA; /* Gray-Pale */
     border: 1px solid #E9ECEF; /* Gray-Light */
     border-radius: 8px;
-    padding: 10px 14px;
-    gap: 12px;
-    margin: 4px 0 8px 0;
+    padding: 7px 10px;
+    gap: 10px;
+    margin: 3px 0 5px 0;
 }
 
 .file-icon-area {
@@ -364,35 +376,41 @@ const isSecondaryContent = (text) => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 12px;
+  padding: 3px 8px;
   background: #F8F9FA;
-  border-radius: 6px;
+  border-radius: 5px;
   margin-left: 0;
 }
 
 .tool-content {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
+    min-width: 0;
 }
 
 .tool-label {
-    font-size: 11px;
+    font-size: 10px;
     color: #6C757D;
     text-transform: uppercase;
     letter-spacing: 0.5px;
+    flex-shrink: 0;
 }
 
 .tool-name {
     font-family: ui-monospace, SFMono-Regular, monospace;
-    font-size: 12px;
+    font-size: 11px;
     color: #1A5336;
     font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .tool-status {
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 500;
+    flex-shrink: 0;
 }
 
 .status-loading { color: #6C757D; }
@@ -401,6 +419,6 @@ const isSecondaryContent = (text) => {
 
 /* Thinking Row */
 .thinking-row {
-    margin-bottom: 8px;
+    margin-bottom: 4px;
 }
 </style>

--- a/frontend/src/components/AgentMessage/RootBubble.vue
+++ b/frontend/src/components/AgentMessage/RootBubble.vue
@@ -134,7 +134,7 @@ const hasContent = computed(() => {
 .ghost-thinking-wrapper {
     margin-left: 0;
     padding: 0;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .root-bubble-container {
@@ -150,7 +150,7 @@ const hasContent = computed(() => {
   box-sizing: border-box;
   word-wrap: break-word;
   overflow-wrap: break-word;
-  margin-bottom: 32px; /* Breathable spacing between bubbles */
+  margin-bottom: 14px; /* Compact spacing between bubbles */
   user-select: text;
   -webkit-user-select: text;
 }
@@ -165,9 +165,9 @@ const hasContent = computed(() => {
 }
 
 .main-content {
-  padding: 6px 16px; /* Increased padding */
-  font-size: 14px;
-  line-height: 1.6;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.55;
   color: #2C3338; /* Gray-Dark */
 }
 
@@ -204,7 +204,7 @@ const hasContent = computed(() => {
 }
 
 .main-content:deep(p) {
-  margin: 0 0 12px 0;
+  margin: 0 0 8px 0;
 }
 
 .main-content:deep(p:last-child) {
@@ -254,8 +254,8 @@ const hasContent = computed(() => {
 }
 
 .main-content :deep(.markdown-body) {
-  font-size: 14px;
-  line-height: 1.6;
+  font-size: 13px;
+  line-height: 1.55;
   margin: 0;
   padding: 0;
   color: #2C3338;
@@ -265,8 +265,8 @@ const hasContent = computed(() => {
 .main-content :deep(.markdown-body h1),
 .main-content :deep(.markdown-body h2),
 .main-content :deep(.markdown-body h3) {
-  margin-top: 20px !important;
-  margin-bottom: 10px !important;
+  margin-top: 14px !important;
+  margin-bottom: 8px !important;
   font-weight: 600;
   color: #1A5336; /* Forest Green for headings */
 }

--- a/frontend/src/components/AgentMessage/ThinkingCard.vue
+++ b/frontend/src/components/AgentMessage/ThinkingCard.vue
@@ -156,7 +156,7 @@ const toggle = () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
+  padding: 6px 10px;
   cursor: pointer;
   background: #fff;
   transition: background 0.2s;
@@ -271,9 +271,9 @@ const toggle = () => {
 }
 
 .content {
-  padding: 12px 16px;
-  font-size: 13px;
-  line-height: 1.6;
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.5;
   color: #495057; /* Gray-Dark */
 }
 

--- a/frontend/src/components/AgentMessage/TitleCard.vue
+++ b/frontend/src/components/AgentMessage/TitleCard.vue
@@ -12,15 +12,15 @@ defineProps({
 
 <style scoped>
 .title-card {
-  margin-bottom: 10px; /* 减小边距 */
+  margin-bottom: 4px;
   padding: 0 4px;
 }
 
 .title-card h3 {
   margin: 0;
-  font-size: 16px; /* 稍微减小字体 */
+  font-size: 14px;
   font-weight: 600;
   color: #2c3e50;
-  padding: 8px 8px;
+  padding: 6px 8px 2px;
 }
 </style>

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -1930,7 +1930,7 @@ export default {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden; /* Prevent horizontal overflow */
-  padding: 16px;
+  padding: 12px;
   min-width: 0; /* Allow flex shrinking */
   width: 100%;
   box-sizing: border-box;
@@ -1946,7 +1946,7 @@ export default {
 }
 
 .message-row {
-  margin-bottom: 26px;
+  margin-bottom: 14px;
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -293,12 +293,10 @@ export function useAgentStream() {
         isStreaming.value = false
         if (currentAssistantBubble.value) {
             currentAssistantBubble.value.isStreaming = false
-            // 添加已停止标记
-            if (currentAssistantBubble.value.content) {
-                currentAssistantBubble.value.content += '\n\n*[已停止]*'
-            } else if (currentAssistantBubble.value.walkthrough) {
-                currentAssistantBubble.value.walkthrough += '\n\n*[已停止]*'
-            }
+            // 终态收敛：停止后不允许卡片停留在"执行中"
+            finalizeProcesses('error')
+            // 添加已停止标记（必须写 content，walkthrough 当前未渲染）
+            currentAssistantBubble.value.content += '\n\n*[已停止]*'
         }
     }
 
@@ -427,6 +425,7 @@ export function useAgentStream() {
                     thinking.duration = (Date.now() - thinking.startTime) / 1000
                 }
             }
+            finalizeProcesses('error')
             // 不需要在这里添加 [已停止] 标记，因为 abort 函数已经添加了
             isStreaming.value = false
         } else if (evt === 'bubble_end' || evt === 'error') {
@@ -441,22 +440,13 @@ export function useAgentStream() {
                     thinking.duration = (Date.now() - thinking.startTime) / 1000
                 }
             }
+            // 终态收敛：流结束后不允许任何卡片停留在"执行中/加载中"
+            finalizeProcesses(evt === 'error' ? 'error' : 'success')
             // Ensure error is visible
+            // 注意：错误必须写入 content（walkthrough 卡片当前未渲染，写那里用户永远看不到）
             if (evt === 'error') {
                 const errMsg = dataStr || "Unknown Error"
-                currentAssistantBubble.value.walkthrough += `\n\n> [!CAUTION]\n> **Error**: ${errMsg}\n`
-
-                // FORCE UPDATE: Mark active tool as error if any
-                if (activeProcessId) {
-                    const proc = currentAssistantBubble.value.processes.find(p => p.id === activeProcessId)
-                    if (proc && proc.items.length > 0) {
-                        const lastItem = proc.items[proc.items.length - 1]
-                        if (lastItem.type === 'tool' && lastItem.status === 'loading') {
-                            lastItem.status = 'error'
-                            lastItem.output += `\n[System Error: ${errMsg}]`
-                        }
-                    }
-                }
+                currentAssistantBubble.value.content += `\n\n> ⚠️ **执行中断**：${errMsg}\n`
             }
         }
         if (evt === 'bubble_end' || evt === 'cancelled') isStreaming.value = false
@@ -642,6 +632,30 @@ export function useAgentStream() {
     }
 
     // --- PARSER HELPERS ---
+
+    /**
+     * 终态收敛：流结束（正常/出错/取消）时，把所有仍处于进行中的条目落到终态。
+     * finalToolStatus: 'success'（正常结束）| 'error'（出错/取消）
+     */
+    const finalizeProcesses = (finalToolStatus) => {
+        const bubble = currentAssistantBubble.value
+        if (!bubble || !bubble.processes) return
+        bubble.processes.forEach(proc => {
+            const items = proc.items || []
+            items.forEach(item => {
+                if (item.type === 'step' && item.status === 'doing') {
+                    item.status = 'done'
+                } else if (item.type === 'tool' && item.status === 'loading') {
+                    item.status = finalToolStatus
+                } else if (item.type === 'thinking' && item.status === 'thinking') {
+                    item.status = 'done'
+                    if (item.startTime && !item.duration) {
+                        item.duration = (Date.now() - item.startTime) / 1000
+                    }
+                }
+            })
+        })
+    }
 
     // Flush any remaining content in parserBuffer (called when stream ends)
     const flushRemainingBuffer = () => {
@@ -847,10 +861,22 @@ export function useAgentStream() {
                 // 后端在 process 关闭后才发送 <tool_output status="...">
                 // tool_output handler 会正确更新状态
 
+                // 但 step（文字步骤）到 process 关闭即算完成，否则卡片徽标永远停在"执行中"
+                const closingProc = bubble.processes.find(p => p.id === activeProcessId)
+                if (closingProc) {
+                    closingProc.items.forEach(item => {
+                        if (item.type === 'step' && item.status === 'doing') item.status = 'done'
+                    })
+                }
+
                 activeTag = null
                 activeProcessId = null
             } else {
                 const pid = `proc-${Date.now()}`
+                // 新任务开始 = 之前所有任务的文字步骤都已结束（兜底收敛，防止历史卡片停留"执行中"）
+                bubble.processes.forEach(p => p.items?.forEach(item => {
+                    if (item.type === 'step' && item.status === 'doing') item.status = 'done'
+                }))
                 // Only collapse others if this is a NEW top-level process?
                 // For now keep behavior: collapse others
                 bubble.processes.forEach(p => p.isExpanded = false)
@@ -896,7 +922,17 @@ export function useAgentStream() {
             }
         } else if (tagName === 'tool_output') {
             if (isClose) {
-                activeTag = 'process'
+                // 关键修复：tool_output 通常在 </process> 之后才由后端补发，此时 process 已关闭。
+                // 这里必须回到"无标签"状态（而不是 'process'），否则后续所有普通文本都会被
+                // flushContent 的 process 分支静默丢弃 —— 表现为工具执行后正文再也不更新（面板假死）。
+                activeTag = null
+                const borrowedProc = bubble.processes.find(p => p.id === activeProcessId)
+                if (borrowedProc) {
+                    borrowedProc.items.forEach(item => {
+                        if (item.type === 'step' && item.status === 'doing') item.status = 'done'
+                    })
+                }
+                activeProcessId = null
                 // Check if tool output contains file creation success JSON (legacy check, keep for now)
                 // Search in activeProcessId first, then fallback to all processes
                 let toolItem = null


### PR DESCRIPTION
## 问题（用户报告）

1. 修订任务执行到"获取文档大纲"后面板不再更新，看似卡死
2. 任务卡样式过松，不够专业

## 根因（真机日志 + 线程转储实锤）

**面板"假死"其实是三个独立 bug 叠加，后端一直在正常干活：**

1. **原生工具轮次对 UI 不可见**：模型前 3 步用 XML `<process>` 协议（面板能渲染），之后切换到原生 tool call。原生分支只发两条泛泛的 `step_update`（无工具名/参数/结果），面板断粮。日志显示切换后模型还执行了 8 轮修订操作，UI 全程无反应。
2. **前端解析器文本黑洞**：`</tool_output>` 闭合后 `activeTag` 停留在 `'process'`，此后所有普通正文被 `flushContent` 静默丢弃——审阅问题汇总表格就是这样消失的。
3. **静默处死 + 错误不可见**：递归上限 `depth>10`，正好第 11 轮触顶。该分支不写日志、只发一条 `error` 事件——而前端把错误写进**已被注释掉的 walkthrough 卡片**，用户什么也看不到。

## 修复（对照 Cursor / Antigravity / Claude Code 编排器调研）

### 后端
- 原生工具调用复用 `<process>/<tool_code>/<tool_output>` XML 协议推流，前后端统一任务卡管线，工具中文显示名来自 ToolRegistry
- 步数预算 10 → 30，触顶从"静默报错"改为"存档 + 请示"（保存进度、告知可回复"继续"、干净收尾）——Cursor 的 25 步预算 + checkpoint 模式
- 新增 `RunGuard` 循环守卫：同一工具+同参数第 3 次调用熔断（Cline 的 consecutiveMistakeCount 模式）；连续 3 次失败注入收敛提示
- 所有终止路径都有日志

### 前端
- `</tool_output>` 后回到无标签状态，正文不再被吞
- 终态收敛：流结束/出错/取消/手动停止后所有 doing/loading/thinking 条目落到终态，徽标不再永远"执行中"
- 错误信息写入可见的 content，新增"出错"红色徽标
- 步骤在 process 关闭时标记完成（修复：工具已完成但徽标仍"执行中"）

### 提示词
- 步数预算意识、同思路失败 2 次必须换方法、undo 后禁止原样重试、多点修订先列 task_list

### 紧凑化
- ProcessCard / RootBubble / TitleCard / ThinkingCard / ChatInterface 内边距、字号、间距整体收紧约 40%

## 验证
- backend `mvn test`：245 通过（回放评测 + 启动冒烟含在内）
- frontend `check:emits` + `build:h5`：通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)