### PR TITLE
feat(ai): 任务清单常驻进度卡 + 防走神注入 + 文档检查点

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -28,19 +28,22 @@ public class AiAgentController {
     private final com.checkba.service.ai.BackgroundTaskService backgroundTaskService;
 
     private final com.checkba.service.ai.tools.PptxTools pptxTools;
+    private final com.checkba.service.ai.TodoListService todoListService;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AiAgentController(SseEmitterService sseEmitterService, 
-                            AgentOrchestrator agentOrchestrator, 
+    public AiAgentController(SseEmitterService sseEmitterService,
+                            AgentOrchestrator agentOrchestrator,
                             com.checkba.service.ProjectAiMessageService messageService,
                             com.checkba.service.ai.BackgroundTaskService backgroundTaskService,
-                            com.checkba.service.ai.tools.PptxTools pptxTools) {
+                            com.checkba.service.ai.tools.PptxTools pptxTools,
+                            com.checkba.service.ai.TodoListService todoListService) {
         this.sseEmitterService = sseEmitterService;
         this.agentOrchestrator = agentOrchestrator;
         this.messageService = messageService;
         this.backgroundTaskService = backgroundTaskService;
         this.pptxTools = pptxTools;
-    } 
+        this.todoListService = todoListService;
+    }
 
     /**
      * 建立 SSE 连接。
@@ -71,11 +74,14 @@ public class AiAgentController {
             // Use a small delay or ensure SseEmitterService sends it properly
             // SseEmitterService.createConnection sends initial "connected" event.
             // We can send this right after.
-            sseEmitterService.send(conversationId, "state_recovery", "{\"content\":\"" + 
-                snapshot.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r") + 
+            sseEmitterService.send(conversationId, "state_recovery", "{\"content\":\"" +
+                snapshot.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r") +
                 "\"}");
         }
-        
+
+        // 重连后把当前任务清单重推给前端（常驻进度卡恢复）
+        todoListService.resendToFrontend(conversationId);
+
         return emitter;
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -48,6 +48,8 @@ public class AgentOrchestrator {
         String lastCallSignature;
         int repeatCount;
         int consecutiveFailures;
+        // 当前活跃文档 ID（来自 activeContext 或 doc_open_file），用于修改前自动创建检查点
+        Long activeFileId;
     }
 
     // 取消状态管理：存储被取消的会话ID
@@ -69,6 +71,8 @@ public class AgentOrchestrator {
     private final com.checkba.service.ProjectFileService projectFileService;
     private final EditorBridgeService editorBridgeService;
     private final ConversationFileChangeService conversationFileChangeService;
+    private final TodoListService todoListService;
+    private final DocumentCheckpointService documentCheckpointService;
 
     // ==================== 取消功能相关方法 ====================
 
@@ -149,14 +153,33 @@ public class AgentOrchestrator {
 
     /**
      * 分发一次工具调用并处理声明式副作用（文件变更通知、文件树刷新）。
+     * 修改类工具（fileEffect=MODIFIED）执行前自动为活跃文档创建本轮检查点。
      */
     private ToolRegistry.ToolResult dispatchTool(String toolName, String argsJson,
                                                  Long projectId, String conversationId,
-                                                 Long userId, String modelId) {
+                                                 Long userId, String modelId, RunGuard guard) {
+        // 检查点：第一个修改类工具执行前快照活跃文档（恢复类工具自身除外）
+        if (guard != null && !"doc_restore_checkpoint".equals(toolName)) {
+            boolean modifies = toolRegistry.resolve(toolName)
+                    .map(t -> t.meta() != null && "MODIFIED".equals(t.meta().fileEffect()))
+                    .orElse(false);
+            if (modifies && guard.activeFileId != null) {
+                documentCheckpointService.ensureCheckpoint(conversationId, guard.activeFileId);
+            }
+        }
+
         com.checkba.service.ai.tools.ToolContext ctx =
                 new com.checkba.service.ai.tools.ToolContext(projectId, conversationId, userId, modelId);
         ToolRegistry.ToolResult result = toolRegistry.execute(toolName, argsJson, ctx);
         applyToolSideEffects(result, argsJson, conversationId);
+
+        // 跟踪活跃文档：模型中途打开新文档时，后续检查点跟着切换
+        if (guard != null && "doc_open_file".equals(toolName)) {
+            try {
+                String fid = extractArg(argsJson, "fileId");
+                if (fid != null && !fid.isEmpty()) guard.activeFileId = Long.parseLong(fid.trim());
+            } catch (Exception ignore) { /* fileId 非数字时保持原值 */ }
+        }
         return result;
     }
 
@@ -265,7 +288,15 @@ public class AgentOrchestrator {
             log.info("Starting runLoop for conversation: {}, mode: {}", conversationId, agentMode);
             // Track tool executions for history persistence
             StringBuilder executionLog = new StringBuilder();
-            runLoop(model, messages, conversationId, projectId, userId, request.getModel(), 0, executionLog, agentMode, new RunGuard());
+            RunGuard guard = new RunGuard();
+            // 记录活跃文档 ID（修改前自动检查点的目标）；每轮一个独立检查点
+            documentCheckpointService.clearForNewRun(conversationId);
+            if (request.getActiveContext() != null && request.getActiveContext().getId() != null) {
+                try {
+                    guard.activeFileId = Long.parseLong(request.getActiveContext().getId().trim());
+                } catch (NumberFormatException ignore) { /* 非数字 ID（如临时文件）不做检查点 */ }
+            }
+            runLoop(model, messages, conversationId, projectId, userId, request.getModel(), 0, executionLog, agentMode, guard);
             
         } catch (Exception e) {
             log.error("Agent Loop Error for conversation: " + conversationId, e);
@@ -383,7 +414,7 @@ public class AgentOrchestrator {
                         success = false;
                     } else {
                         ToolRegistry.ToolResult toolResult = dispatchTool(req.name(), req.arguments(),
-                                Long.parseLong(projectId), conversationId, userId, modelId);
+                                Long.parseLong(projectId), conversationId, userId, modelId, guard);
                         result = toolResult.output();
                         success = toolResult.success();
                     }
@@ -398,6 +429,17 @@ public class AgentOrchestrator {
                     // Log for history persistence (include status attribute)
                     executionLog.append(String.format("<process name=\"%s\"><tool_code>%s(%s)</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
                         displayName.replace("\"", "'"), req.name(), req.arguments(), nativeToolStatus, result));
+                }
+
+                // 防走神注入（Claude Code system-reminder 模式）：每次工具执行后带上任务清单状态，
+                // 防止长任务中模型忘记目标。刚更新过清单的轮次不注入（避免重复唠叨）。
+                boolean justWroteTodo = aiMessage.toolExecutionRequests().stream()
+                        .anyMatch(r -> "todo_write".equals(r.name()));
+                if (!justWroteTodo) {
+                    String reminder = todoListService.reminder(conversationId);
+                    if (reminder != null) {
+                        messages.add(dev.langchain4j.data.message.UserMessage.from("[系统提醒] " + reminder));
+                    }
                 }
 
                 // 增量保存：在工具执行后立即保存AI消息和工具输出，防止对话中断导致上下文丢失
@@ -438,7 +480,7 @@ public class AgentOrchestrator {
                         xmlToolSuccess = false;
                     } else {
                         toolResult = dispatchTool(call.toolName(), call.argsJson(),
-                                Long.parseLong(projectId), conversationId, userId, modelId);
+                                Long.parseLong(projectId), conversationId, userId, modelId, guard);
                         result = toolResult.found()
                                 ? toolResult.output()
                                 : "Unknown tool in custom parser: " + code;
@@ -458,6 +500,14 @@ public class AgentOrchestrator {
                     // Explicitly tell the model to EVALUATE - with strict anti-over-execution instructions
                     String feedbackMsg = String.format("[System Tool Execution Log]\nTool: %s\nStatus: %s\nOutput: %s\n\n(CRITICAL INSTRUCTION: The tool executed successfully. Now compare with the ORIGINAL user request. If the SPECIFIC task the user asked for is complete, output `<final>` IMMEDIATELY. DO NOT perform additional operations unless the user EXPLICITLY requested them. For example, if user asked to 'delete the 3rd z' and you deleted it, you are DONE - do not delete other z's.)",
                         code, statusPrefix, result);
+
+                    // 防走神注入：任务清单状态随工具反馈一起带回（刚更新清单的轮次不注入）
+                    if (!"todo_write".equals(call.toolName())) {
+                        String reminder = todoListService.reminder(conversationId);
+                        if (reminder != null) {
+                            feedbackMsg += "\n\n[系统提醒] " + reminder;
+                        }
+                    }
 
                     messages.add(dev.langchain4j.data.message.UserMessage.from(feedbackMsg));
 

--- a/backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java
+++ b/backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java
@@ -1,0 +1,104 @@
+package com.checkba.service.ai;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.ProjectFileService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 文档检查点服务（run 级快照，Cursor/Cline checkpoint 模式的文件级最简实现）。
+ *
+ * 每轮 Agent 运行在第一个"修改类"文档工具执行前，把目标文件在存储中的当前内容
+ * 复制一份到 checkpoints/ 目录；模型把文档改乱且 doc_undo 无法逐步退回时，
+ * 可用 doc_restore_checkpoint 恢复到本轮开始前的状态（恢复后编辑器自动重载）。
+ *
+ * 局限（已在工具描述中告知模型）：快照取自最近一次保存到存储的内容，
+ * 编辑器中未保存的改动不在快照里；且 AI 修改本身走修订模式，常规纠错优先 doc_undo。
+ */
+@Service
+@RequiredArgsConstructor
+public class DocumentCheckpointService {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DocumentCheckpointService.class);
+
+    private final ProjectFileService projectFileService;
+    private final StorageServiceFactory storageServiceFactory;
+    private final EditorBridgeService editorBridgeService;
+
+    /** conversationId -> 本轮快照信息 */
+    private final Map<String, Checkpoint> checkpoints = new ConcurrentHashMap<>();
+
+    private record Checkpoint(Long fileId, String checkpointKey, long createdAt) {}
+
+    /**
+     * 为指定文件创建本轮快照（幂等：同一会话已有快照则跳过）。
+     * 任何失败只记日志、不阻断工具执行——快照是保险，不是主流程。
+     */
+    public void ensureCheckpoint(String conversationId, Long fileId) {
+        if (conversationId == null || fileId == null) return;
+        if (checkpoints.containsKey(conversationId)) return;
+        try {
+            ProjectFile file = projectFileService.getFile(fileId);
+            if (file == null || file.getFilePath() == null) return;
+            byte[] bytes = projectFileService.getFileBytes(fileId);
+            if (bytes == null || bytes.length == 0) return;
+
+            String checkpointKey = "checkpoints/" + conversationId + "/" + fileId + "_" + System.currentTimeMillis();
+            StorageService storage = storageServiceFactory.getStorageService();
+            storage.save(checkpointKey, new ByteArrayInputStream(bytes));
+            checkpoints.put(conversationId, new Checkpoint(fileId, checkpointKey, System.currentTimeMillis()));
+            log.info("Document checkpoint created: conv={}, fileId={}, key={}, size={}",
+                    conversationId, fileId, checkpointKey, bytes.length);
+        } catch (Exception e) {
+            log.warn("Failed to create document checkpoint for conv={}, fileId={}", conversationId, fileId, e);
+        }
+    }
+
+    /**
+     * 恢复本轮快照：把快照内容写回原文件存储路径，并通知编辑器重载。
+     * 返回给模型的结果描述。
+     */
+    public String restore(String conversationId) {
+        Checkpoint cp = checkpoints.get(conversationId);
+        if (cp == null) {
+            return "Error: 本轮没有可恢复的文档快照（本轮尚未执行过修改类工具，或快照创建失败）。请改用 doc_undo 逐步撤销。";
+        }
+        try {
+            ProjectFile file = projectFileService.getFile(cp.fileId());
+            if (file == null || file.getFilePath() == null) {
+                return "Error: 快照对应的文件已不存在。";
+            }
+            StorageService storage = storageServiceFactory.getStorageService();
+            try (InputStream in = storage.load(cp.checkpointKey()).getInputStream()) {
+                storage.save(file.getFilePath(), in);
+            }
+            // 通知前端编辑器重新加载该文件（丢弃编辑器内当前状态）
+            editorBridgeService.sendReloadFileAction(file);
+            log.info("Document checkpoint restored: conv={}, fileId={}, key={}",
+                    conversationId, cp.fileId(), cp.checkpointKey());
+            return String.format("已将《%s》恢复到本轮开始前的快照，编辑器正在重新加载。本轮所有修改（含修订）已丢弃，请重新规划后再操作。",
+                    file.getName());
+        } catch (Exception e) {
+            log.error("Failed to restore document checkpoint for conv={}", conversationId, e);
+            return "Error: 快照恢复失败：" + e.getMessage();
+        }
+    }
+
+    /**
+     * 新的一轮开始时清除上一轮快照（每轮一个独立检查点）。
+     */
+    public void clearForNewRun(String conversationId) {
+        checkpoints.remove(conversationId);
+    }
+
+    public boolean hasCheckpoint(String conversationId) {
+        return checkpoints.containsKey(conversationId);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/TodoListService.java
+++ b/backend/src/main/java/com/checkba/service/ai/TodoListService.java
@@ -1,0 +1,134 @@
+package com.checkba.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Agent 任务清单服务（Cursor todo_write / Claude Code TodoWrite 模式）。
+ *
+ * 职责：
+ * 1. 维护每个会话的结构化任务清单（整表覆写，无部分更新，状态不会漂移）
+ * 2. 归一化不变式：同一时刻最多一项 in_progress（多余的降级为 pending）
+ * 3. 每次更新通过 SSE `plan_update` 推送完整清单，前端渲染为常驻进度卡
+ * 4. 提供给编排器的"防走神"摘要：每次工具执行后注入当前清单状态
+ *
+ * 清单跨轮次保留（用户回复"继续"时模型能接着上次的清单干），
+ * 由模型下一次 todo_write 整表覆写，或随会话切换自然失效。
+ */
+@Service
+@RequiredArgsConstructor
+public class TodoListService {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TodoListService.class);
+
+    private static final List<String> VALID_STATUSES = List.of("pending", "in_progress", "completed", "failed");
+
+    public record TodoItem(String content, String activeForm, String status) {}
+
+    private final SseEmitterService sseEmitterService;
+    private final ObjectMapper objectMapper;
+
+    // conversationId -> 当前任务清单
+    private final Map<String, List<TodoItem>> lists = new ConcurrentHashMap<>();
+
+    /**
+     * 整表覆写任务清单。返回给模型的确认信息（含归一化说明）。
+     */
+    public String update(String conversationId, String todosJson) {
+        List<TodoItem> todos = new ArrayList<>();
+        boolean demotedExtraInProgress = false;
+        try {
+            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(todosJson);
+            if (!root.isArray()) {
+                return "Error: todos 必须是 JSON 数组，元素形如 {\"content\":\"...\",\"activeForm\":\"...\",\"status\":\"pending\"}";
+            }
+            boolean seenInProgress = false;
+            for (com.fasterxml.jackson.databind.JsonNode n : root) {
+                String content = n.path("content").asText("").trim();
+                if (content.isEmpty()) continue;
+                String activeForm = n.path("activeForm").asText("").trim();
+                if (activeForm.isEmpty()) activeForm = content;
+                String status = n.path("status").asText("pending").trim().toLowerCase();
+                if (!VALID_STATUSES.contains(status)) status = "pending";
+                // 不变式：最多一项 in_progress，多余的降级为 pending
+                if ("in_progress".equals(status)) {
+                    if (seenInProgress) {
+                        status = "pending";
+                        demotedExtraInProgress = true;
+                    } else {
+                        seenInProgress = true;
+                    }
+                }
+                todos.add(new TodoItem(content, activeForm, status));
+            }
+        } catch (Exception e) {
+            return "Error: todos JSON 解析失败（" + e.getMessage() + "）。请传合法 JSON 数组。";
+        }
+        if (todos.isEmpty()) {
+            return "Error: 任务清单为空。至少提供一项，或不要调用 todo_write。";
+        }
+
+        lists.put(conversationId, todos);
+        pushToFrontend(conversationId, todos);
+
+        long done = todos.stream().filter(t -> "completed".equals(t.status())).count();
+        String confirmation = String.format("任务清单已更新：共 %d 项，已完成 %d 项。%s", todos.size(), done,
+                demotedExtraInProgress ? "（注意：同一时刻只允许一项 in_progress，多余的已降级为 pending）" : "");
+        log.info("Todo list updated for {}: {}/{} completed", conversationId, done, todos.size());
+        return confirmation;
+    }
+
+    public boolean hasList(String conversationId) {
+        List<TodoItem> todos = lists.get(conversationId);
+        return todos != null && !todos.isEmpty();
+    }
+
+    /**
+     * 供编排器在每次工具执行后注入的"防走神"摘要（Claude Code system-reminder 模式）。
+     * 清单不存在或已全部完成时返回 null（不注入）。
+     */
+    public String reminder(String conversationId) {
+        List<TodoItem> todos = lists.get(conversationId);
+        if (todos == null || todos.isEmpty()) return null;
+        long done = todos.stream().filter(t -> "completed".equals(t.status())).count();
+        if (done == todos.size()) return null;
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("[任务清单状态 %d/%d 完成]", done, todos.size()));
+        todos.stream().filter(t -> "in_progress".equals(t.status())).findFirst()
+                .ifPresent(t -> sb.append(" 进行中：").append(t.content()).append("。"));
+        List<String> pending = todos.stream().filter(t -> "pending".equals(t.status()))
+                .map(TodoItem::content).toList();
+        if (!pending.isEmpty()) {
+            sb.append(" 待办：").append(String.join("、", pending.subList(0, Math.min(3, pending.size()))));
+            if (pending.size() > 3) sb.append(" 等 ").append(pending.size()).append(" 项");
+            sb.append("。");
+        }
+        sb.append("（完成一项立即用 todo_write 整表更新状态，不要攒批；全部完成后输出 <final> 汇总。）");
+        return sb.toString();
+    }
+
+    /**
+     * 断线重连恢复：把当前清单重新推给前端。
+     */
+    public void resendToFrontend(String conversationId) {
+        List<TodoItem> todos = lists.get(conversationId);
+        if (todos != null && !todos.isEmpty()) {
+            pushToFrontend(conversationId, todos);
+        }
+    }
+
+    private void pushToFrontend(String conversationId, List<TodoItem> todos) {
+        try {
+            String json = objectMapper.writeValueAsString(Map.of("todos", todos));
+            sseEmitterService.send(conversationId, "plan_update", json);
+        } catch (Exception e) {
+            log.warn("Failed to push plan_update for {}", conversationId, e);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/CheckpointTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/CheckpointTools.java
@@ -1,0 +1,34 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.DocumentCheckpointService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 文档检查点工具：恢复本轮开始前的文档快照。
+ * 快照由编排器在本轮第一个修改类工具执行前自动创建。
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CheckpointTools implements AgentToolComponent {
+
+    private final DocumentCheckpointService documentCheckpointService;
+
+    @Tool("【恢复】把文档恢复到本轮开始前的快照（检查点）。这是最后手段：" +
+          "仅在文档已被改乱、doc_undo 无法逐步退回时使用。" +
+          "恢复会丢弃本轮的所有修改（包括修订标记）并让编辑器重新加载文档。" +
+          "常规纠错请优先使用 doc_undo。")
+    @ToolMeta(displayName = "恢复文档快照", category = "document", fileEffect = "MODIFIED")
+    public String doc_restore_checkpoint() {
+        log.info("Tool: doc_restore_checkpoint called");
+        String conversationId = ProjectContextHolder.getConversationId();
+        if (conversationId == null || conversationId.isEmpty()) {
+            return "Error: 无法获取当前会话ID。";
+        }
+        return documentCheckpointService.restore(conversationId);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/TodoTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/TodoTools.java
@@ -1,0 +1,41 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.TodoListService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 任务清单工具（Cursor todo_write / Claude Code TodoWrite 模式）。
+ * 清单既是模型的自我规划工具，也是用户侧的常驻进度 UI（SSE plan_update 驱动）。
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TodoTools implements AgentToolComponent {
+
+    private final TodoListService todoListService;
+
+    @Tool("维护本轮工作的任务清单（整表覆写）。使用规则：" +
+          "1) 多步任务（3 步以上的修改/审查/起草）开工前必须先写清单；" +
+          "2) 每完成一项【立即】调用本工具把该项标为 completed，不要攒批；" +
+          "3) 同一时刻只允许一项 in_progress；" +
+          "4) 计划变化时（增删任务）也用本工具整表覆写。" +
+          "清单会实时显示给用户作为进度面板。")
+    @ToolMeta(displayName = "更新任务清单", category = "planning")
+    public String todo_write(
+            @P("完整任务清单 JSON 数组（整表覆写，含已完成项）。元素形如 " +
+               "{\"content\":\"修订违约条款\",\"activeForm\":\"正在修订违约条款\",\"status\":\"in_progress\"}，" +
+               "status 取值 pending/in_progress/completed/failed") String todos
+    ) {
+        log.info("Tool: todo_write called");
+        String conversationId = ProjectContextHolder.getConversationId();
+        if (conversationId == null || conversationId.isEmpty()) {
+            return "Error: 无法获取当前会话ID，任务清单未更新。";
+        }
+        return todoListService.update(conversationId, todos);
+    }
+}

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -182,7 +182,17 @@ You operate in a [Thought -> Action -> Observation] loop.
 - 你的执行步数有限（约 30 步预算，超出会被系统暂停）。**每一步都要有效**：行动前先想清楚定位方式，避免"试一下再说"。
 - **同一思路失败不要原样重试**：同一工具+同样参数连续失败 2 次后，必须换方法（换定位方式、换工具、或先用读取类工具确认文档当前状态）。系统会拦截第 3 次完全相同的调用。
 - **改错就 undo，但 undo 后必须换思路**：不要陷入"改→撤销→原样再改"的循环。
-- **多项修订任务先列清单**：涉及 3 处以上修改时，先用 `task_list` artifact 列出所有修改点，然后逐项执行、逐项确认，最后用 `<final>` 汇总"已完成 X 处修改、各处改了什么"。
+- **文档被改乱的最后手段**：系统在你第一次修改文档前自动创建了快照，`doc_restore_checkpoint()` 可恢复到本轮开始前的状态（会丢弃本轮全部修改）。常规纠错仍然优先 `doc_undo`。
+
+## Task List Discipline (`todo_write`) (CRITICAL)
+多步任务（3 步以上的修改/审查/起草）必须用 `todo_write` 工具维护任务清单——它会实时显示给用户作为进度面板：
+1. **开工前先写清单**：把任务拆成具体条目（如"修正第四条返佣比例笔误"、"补充甲方保密义务"），全部 status=pending，第一项 in_progress。
+2. **完成一项立即更新**：把该项标为 completed、下一项标为 in_progress，**整表覆写**。不要攒到最后一起更新。
+3. **同一时刻只允许一项 in_progress**。
+4. **计划变化时同步清单**：发现新问题要加项、发现某项不需要做就删掉。
+5. 全部完成后输出 `<final>`，汇总"完成了哪几项、各改了什么"。
+简单任务（1-2 步）不要用 todo_write，直接执行。
+（注意：`todo_write` 用于执行进度跟踪；`task_list` artifact 仅在用户明确要一份清单文件时使用。）
 
 ## Clarification (Using `<question>` Tag)
 If you lack critical details, **STOP and ASK** using the `<question>` tag. Do NOT guess or use placeholders.

--- a/backend/src/test/java/com/checkba/service/ai/TodoListServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/TodoListServiceTest.java
@@ -1,0 +1,85 @@
+package com.checkba.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * TodoListService 归一化不变式测试：
+ * 整表覆写、单一 in_progress、非法输入拒绝、防走神摘要生成。
+ */
+class TodoListServiceTest {
+
+    private SseEmitterService sse;
+    private TodoListService service;
+
+    private static final String CONV = "conv-test-1";
+
+    @BeforeEach
+    void setUp() {
+        sse = Mockito.mock(SseEmitterService.class);
+        service = new TodoListService(sse, new ObjectMapper());
+    }
+
+    @Test
+    void update_validList_storesAndPushesPlanUpdate() {
+        String json = "[{\"content\":\"修订第四条\",\"activeForm\":\"正在修订第四条\",\"status\":\"in_progress\"}," +
+                "{\"content\":\"补充保密义务\",\"status\":\"pending\"}]";
+        String result = service.update(CONV, json);
+
+        assertTrue(result.contains("共 2 项"));
+        assertTrue(service.hasList(CONV));
+        verify(sse).send(eq(CONV), eq("plan_update"), anyString());
+    }
+
+    @Test
+    void update_multipleInProgress_demotesExtras() {
+        String json = "[{\"content\":\"A\",\"status\":\"in_progress\"}," +
+                "{\"content\":\"B\",\"status\":\"in_progress\"}]";
+        String result = service.update(CONV, json);
+
+        assertTrue(result.contains("降级"));
+        // 摘要里只出现一个进行中项（A）
+        String reminder = service.reminder(CONV);
+        assertNotNull(reminder);
+        assertTrue(reminder.contains("进行中：A"));
+        assertTrue(reminder.contains("待办：B"));
+    }
+
+    @Test
+    void update_invalidJson_returnsError() {
+        String result = service.update(CONV, "not json");
+        assertTrue(result.startsWith("Error:"));
+        assertFalse(service.hasList(CONV));
+    }
+
+    @Test
+    void update_emptyList_returnsError() {
+        String result = service.update(CONV, "[]");
+        assertTrue(result.startsWith("Error:"));
+    }
+
+    @Test
+    void reminder_allCompleted_returnsNull() {
+        service.update(CONV, "[{\"content\":\"A\",\"status\":\"completed\"}]");
+        assertNull(service.reminder(CONV));
+    }
+
+    @Test
+    void reminder_noList_returnsNull() {
+        assertNull(service.reminder("conv-unknown"));
+    }
+
+    @Test
+    void update_invalidStatus_fallsBackToPending() {
+        service.update(CONV, "[{\"content\":\"A\",\"status\":\"doing\"}]");
+        String reminder = service.reminder(CONV);
+        assertNotNull(reminder);
+        assertTrue(reminder.contains("待办：A"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
@@ -156,9 +156,13 @@ public final class EvalHarness {
 
         ConversationFileChangeService fileChange = mock(ConversationFileChangeService.class);
 
+        com.checkba.service.ai.TodoListService todoListService = mock(com.checkba.service.ai.TodoListService.class);
+        com.checkba.service.ai.DocumentCheckpointService checkpointService = mock(com.checkba.service.ai.DocumentCheckpointService.class);
+
         AgentOrchestrator orchestrator = new AgentOrchestrator(
                 chatModelFactory, messageService, sse, tokenUsage, assembler,
-                registry, skillRouter, parser, memoryPipeline, projectFileService, editorBridge, fileChange);
+                registry, skillRouter, parser, memoryPipeline, projectFileService, editorBridge, fileChange,
+                todoListService, checkpointService);
 
         AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
         request.setProjectId(1L);

--- a/frontend/src/components/AgentMessage/TodoProgressCard.vue
+++ b/frontend/src/components/AgentMessage/TodoProgressCard.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="todo-progress-card" v-if="todos && todos.length > 0">
+    <div class="todo-header" @click="isCollapsed = !isCollapsed">
+      <div class="todo-header-left">
+        <span class="todo-title">任务进度</span>
+        <span class="todo-counter">{{ completedCount }}/{{ todos.length }}</span>
+      </div>
+      <div class="todo-header-right">
+        <span v-if="currentTodo" class="todo-current-hint">{{ currentTodo.activeForm || currentTodo.content }}</span>
+        <div class="chevron" :class="{ collapsed: isCollapsed }">
+          <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div class="todo-list" v-if="!isCollapsed">
+      <div v-for="(todo, idx) in todos" :key="idx" class="todo-row" :class="todo.status">
+        <span class="todo-marker">
+          <svg v-if="todo.status === 'completed'" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          <span v-else-if="todo.status === 'in_progress'" class="marker-spinner"></span>
+          <svg v-else-if="todo.status === 'failed'" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          <span v-else class="marker-dot"></span>
+        </span>
+        <span class="todo-text">{{ todo.status === 'in_progress' ? (todo.activeForm || todo.content) : todo.content }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  todos: { type: Array, default: () => [] }
+})
+
+const isCollapsed = ref(false)
+
+const completedCount = computed(() => props.todos.filter(t => t.status === 'completed').length)
+const currentTodo = computed(() => props.todos.find(t => t.status === 'in_progress') || null)
+</script>
+
+<style scoped>
+.todo-progress-card {
+  background: #ffffff;
+  border: 1px solid #E9ECEF;
+  border-radius: 8px;
+  margin: 0 0 6px 0;
+  overflow: hidden;
+}
+
+.todo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 5px 10px;
+  cursor: pointer;
+  background: #F8F9FA;
+}
+
+.todo-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.todo-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #1A5336; /* Forest Green */
+}
+
+.todo-counter {
+  font-size: 10px;
+  font-weight: 600;
+  color: #1A5336;
+  background: #E6F9F0; /* Mint Lightest */
+  padding: 0 6px;
+  border-radius: 99px;
+}
+
+.todo-header-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.todo-current-hint {
+  font-size: 10px;
+  color: #6C757D;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+
+.chevron {
+  color: #ADB5BD;
+  display: flex;
+  transition: transform 0.2s ease;
+}
+
+.chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.todo-list {
+  padding: 4px 10px 5px;
+  max-height: 132px;
+  overflow-y: auto;
+}
+
+.todo-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  padding: 2px 0;
+}
+
+.todo-marker {
+  width: 12px;
+  height: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.todo-row.completed .todo-marker { color: #5BD197; }
+.todo-row.failed .todo-marker { color: #E74C3C; }
+
+.marker-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #DEE2E6;
+}
+
+.marker-spinner {
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid #5BD197;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: todo-spin 0.8s linear infinite;
+}
+
+@keyframes todo-spin {
+  to { transform: rotate(360deg); }
+}
+
+.todo-text {
+  font-size: 11px;
+  line-height: 1.45;
+  color: #2C3338;
+}
+
+.todo-row.completed .todo-text {
+  color: #ADB5BD;
+  text-decoration: line-through;
+}
+
+.todo-row.in_progress .todo-text {
+  color: #1A5336;
+  font-weight: 500;
+}
+
+.todo-row.failed .todo-text {
+  color: #C0392B;
+}
+</style>

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -406,6 +406,8 @@
 
     <!-- 4. Regular Bottom Input -->
     <view v-else class="input-area-wrapper">
+       <!-- Agent 任务清单常驻进度卡（todo_write 驱动，plan_update 事件更新） -->
+       <TodoProgressCard :todos="planTodos" />
        <!-- NEW: File Changes & Token Usage Bar (Always visible) -->
        <view class="status-bar-row">
            <!-- Left: File Changes -->
@@ -532,6 +534,7 @@
 <script>
 import RootBubble from './AgentMessage/RootBubble.vue'
 import BackgroundTaskIndicator from './BackgroundTaskIndicator.vue'
+import TodoProgressCard from './AgentMessage/TodoProgressCard.vue'
 import { useAgentStream } from '@/composables/useAgentStream.js'
 import { ref, watch, onMounted, nextTick, getCurrentInstance, computed } from 'vue'
 import { createFile, getProjectFiles, getApiBaseUrl, rollbackConversation, performPptGeneration } from '@/services/api.js'
@@ -539,7 +542,7 @@ import { getAuthHeaders } from '@/utils/auth.js'
 
 export default {
   name: 'ChatInterface',
-  components: { RootBubble, BackgroundTaskIndicator },
+  components: { RootBubble, BackgroundTaskIndicator, TodoProgressCard },
   props: {
     projectId: String,
     projectName: String,
@@ -576,6 +579,7 @@ export default {
       lastHeartbeat,
       tokenUsage,
       fileChanges,
+      planTodos,
       rollbackToMessage,
       currentConversationId,
       loadConversationMetadata
@@ -1815,6 +1819,8 @@ export default {
        confirmPptGeneration,
        // File Changes Status
        fileChanges,
+       // Agent 任务清单进度卡
+       planTodos,
        modifiedFiles,
        createdFiles,
        showModifiedPopup,

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -20,6 +20,9 @@ export function useAgentStream() {
     const backgroundTasks = ref({}) // taskId -> { type, progress, message, stage, startedAt, estimatedDuration }
     const lastHeartbeat = ref(null) // { source, conversationId, timestamp }
 
+    // STATE: Agent 任务清单（todo_write 驱动的常驻进度卡），plan_update 事件整表覆写
+    const planTodos = ref([]) // Array of { content, activeForm, status }
+
     // POINTER: The current bubble we are writing to (Assistant)
     const currentAssistantBubble = ref(null)
 
@@ -90,6 +93,8 @@ export function useAgentStream() {
         // Reset Token Usage (start fresh for new chat context? Or keep per session? Usually per chat.)
         // Ideally we keep it during the chat session. resetSSE is called when switching conversations.
         tokenUsage.value = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+        // 切换会话时清空任务清单进度卡（重连后由后端 plan_update 恢复）
+        planTodos.value = []
         // Clear bubble pointer (will be set fresh on next send)
         currentAssistantBubble.value = null
     }
@@ -323,6 +328,17 @@ export function useAgentStream() {
     const handleEvent = (evt, dataStr) => {
         // 调试日志：显示事件处理
         console.log('[SSE] handleEvent:', evt, 'dataLen:', dataStr?.length || 0, 'time:', new Date().toISOString())
+
+        // 任务清单更新：不依赖活跃气泡（重连恢复时也要能收到），放在气泡守卫之前
+        if (evt === 'plan_update') {
+            try {
+                const d = JSON.parse(dataStr)
+                planTodos.value = Array.isArray(d.todos) ? d.todos : []
+            } catch (e) {
+                console.error('Failed to parse plan_update', e)
+            }
+            return
+        }
 
         if (!currentAssistantBubble.value) return
 
@@ -1111,6 +1127,7 @@ export function useAgentStream() {
         fileChanges,
         backgroundTasks,
         lastHeartbeat,
+        planTodos,
         // Load metadata for historical conversations
         loadConversationMetadata: async (conversationId) => {
             if (!conversationId) return


### PR DESCRIPTION
## 内容

继 #161 修复面板假死后的编排器升级三件套（对照 Cursor / Claude Code / Cline 调研）：

### 1. 任务清单常驻进度卡（todo_write）
- 新工具 `todo_write`：模型维护结构化任务清单，整表覆写、单一 in_progress 不变式
- SSE `plan_update` 驱动前端 `TodoProgressCard`，钉在输入区上方：勾选进度、当前项进行时文案、可折叠；断线重连自动恢复
- 提示词纪律：3 步以上任务开工前先列清单、完成一项立即打勾、不许攒批

### 2. 防走神注入（system-reminder 模式）
- 每次工具执行后把清单状态注回模型（N/M 完成、进行中、待办），两条工具轨道全覆盖，防长任务跑偏

### 3. 文档检查点（run 级快照）
- 本轮第一个修改类工具执行前自动快照活跃文档到 `checkpoints/`
- 新工具 `doc_restore_checkpoint`：文档改乱且 doc_undo 退不回时一键恢复到本轮开始前并重载编辑器（最后手段）

## 验证
- backend `mvn test` 252 绿（新增 TodoListServiceTest 7 例）
- frontend `check:emits`（45 vue）+ `build:h5` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)