### PR TITLE
fix(editor): 退格删除原文卡死 + Delete 键失效 / Backspace jam & dead Delete key

### DIFF
--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -29,7 +29,7 @@ export const EDITOR_ACTIONS = [
   'delete_selection', 'format_selection', 'set_paragraph_format', 'undo', 'redo',
   // [spike/IME] implemented by the worker since Phase B but never whitelisted
   // (found by the primitive self-test: "Unknown action: move_cursor").
-  'move_cursor', 'delete_backward', 'insert_paragraph', 'get_cursor_rect',
+  'move_cursor', 'delete_backward', 'delete_forward', 'insert_paragraph', 'get_cursor_rect',
   // [Track D] load the user's real document into the editor (host-initiated, not
   // an AI-agent command): {bytes, name} -> MEMFS + loadComponentFromURL + retarget.
   'load_document',

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -41,7 +41,7 @@
 //     and the candidate box sits top-left until the first click.
 //
 // Control keys (Phase B, when sendCommand is supplied): Enter inserts a paragraph
-// break via onEnter; Backspace deletes the char before the cursor; arrow keys move
+// break via onEnter; Backspace/Delete delete around the cursor; arrow keys move
 // the LO view cursor — all forwarded to UNO, not applied to the empty <input>.
 // Without sendCommand these keys fall through to the (harmless, empty) input.
 
@@ -109,8 +109,9 @@ export function cursorRectToPixels(raw, offset) {
  * @param {(action:string,params:object)=>Promise<any>} [options.sendCommand]
  *        OPTIONAL. A raw UI-command channel to the worker (e.g. (a,p) =>
  *        workerRequest(a,p)). Enables control-key forwarding: Backspace ->
- *        delete_backward, arrow keys -> move_cursor. Without it, those keys fall
- *        through to the (empty) input and the document is unaffected.
+ *        delete_backward, Delete -> delete_forward, arrow keys -> move_cursor.
+ *        Without it, those keys fall through to the (empty) input and the
+ *        document is unaffected.
  * @param {(msg:string)=>void} [options.onLog] optional progress/diagnostic log.
  * @returns {{element, focus, reposition, computeRect, destroy}}
  */
@@ -255,6 +256,9 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     if (e.key === 'Backspace') {
       e.preventDefault()
       forward('delete_backward', {}, 'Backspace 删除 / delete')
+    } else if (e.key === 'Delete') {
+      e.preventDefault()
+      forward('delete_forward', {}, 'Delete 前删 / forward delete')
     } else if (ARROW_DIR[e.key]) {
       e.preventDefault()
       forward('move_cursor', { dir: ARROW_DIR[e.key], extend: e.shiftKey }, '方向键 ' + ARROW_DIR[e.key] + (e.shiftKey ? '+选择' : ''))

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -177,6 +177,14 @@ function insertTextAtCursor(vc, text) {
   }
 }
 
+// Fire a Writer UI command (.uno:*) on the current frame — the engine-native
+// path for key-equivalent actions (Backspace/Delete), so revision-mode (redline)
+// semantics are the engine's own. zetajs marshalling: create() takes context as
+// first arg; the args sequence must be a plain Array (PR#107 rules).
+function dispatchUno(url) {
+  css.frame.DispatchHelper.create(context).executeDispatch(ctrl.getFrame(), url, '', 0, []);
+}
+
 // Shared verification snapshot returned by mutating commands: where the cursor
 // is now + the paragraph as it reads AFTER the edit ("改完看一眼").
 function verifySnapshot() {
@@ -556,16 +564,21 @@ const EXEC = {
     }
     return { success: true, dir: dir, extend: ex };
   },
-  // [spike] delete one char before the cursor (Backspace in the IME overlay). If
-  // text is selected, delete the selection; else extend one char left and clear.
-  // Inherits the current RecordChanges state (tracked if tracking is on).
+  // Backspace / Delete (IME overlay control keys) — routed through Writer's OWN
+  // key dispatch (.uno:SwBackspace / .uno:Delete), NOT hand-rolled goLeft+
+  // setString. WHY: RecordChanges is ON since boot, and setString('') on
+  // pre-existing (non-own-insert) text only MARKS it as a delete redline — the
+  // view cursor never advances past the marked char, so every further Backspace
+  // re-selected the SAME char and deletion jammed after one press (headless-
+  // verified). The engine dispatch owns revision semantics: mark + step past for
+  // original text, hard-delete for own unaccepted inserts, selection-aware.
   delete_backward() {
-    const vc = ctrl.getViewCursor();
-    if ((vc.getString() || '').length === 0) vc.goLeft(1, true); // select char to the left
-    const had = (vc.getString() || '').length;
-    if (had === 0) return { success: true, deleted: 0 };          // at doc start: nothing to delete
-    vc.setString('');
-    return { success: true, deleted: had };
+    dispatchUno('.uno:SwBackspace');
+    return { success: true };
+  },
+  delete_forward() {
+    dispatchUno('.uno:Delete');
+    return { success: true };
   },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the


### PR DESCRIPTION
## 症状（真机报告）

- LibreOffice 编辑器里用 Backspace 删中文，只能删一个就像被"蒙层限位"卡住，删英文正常
- Delete 键完全无效（中英文都删不了光标后的字符）

## 根因（无头真实引擎复现实证）

**1. Backspace 卡死 ≠ 中英文差异，而是"文档原文 vs 现打文字"**

`RecordChanges`（修订模式）自启动起默认开启（RFC v2：所有编辑留痕）。旧 `delete_backward` 用 `goLeft(1,true)+setString('')` 手工删除：对**文档原文**（非本次会话插入）这只会打一条删除修订标记——字符仍留在原地，视图光标越不过这条修订，之后每次退格都重新选中**同一个字符**。无头实测：连按 5 次退格，只产生 1 条 Delete 修订，文档纹丝不动。

刚打的字是本人未接受的插入修订，删除会真移除——所以现打的英文能连删，删文档里的中文原文（律师文档主体是中文）就卡死。

**2. Delete 键从未接线**

IME 覆盖层持有键盘焦点，keydown 只处理 Enter/Backspace/方向键；Delete 落进透明空 `<input>` 被吞，从未到达引擎。

## 修复

- `delete_backward` 改走 Writer 引擎原生调度 **`.uno:SwBackspace`**（DispatchHelper），修订语义由引擎处理：原文=标记删除并把光标移过去（同 Word 修订模式逐字划线），本人插入=真删除，有选区删选区
- 新增 **`delete_forward`**（`.uno:Delete`），覆盖层 Delete 键转发 + 执行器白名单
- zetajs 编组守规：`create(context)` 首参、args 传普通 Array（PR#107 硬规则）

## 验证（真实引擎无头 e2e，CDP 模拟 IME/键盘走完整覆盖层链路）

| 场景 | 结果 |
|---|---|
| 文档原文（修订开）连按 Backspace ×3 | 光标逐字后退 `合同条款abc→合同条款`，不再卡死 ✅ |
| Delete 键 ×2 | `delete_forward` 正确转发，逐字前删 ✅ |
| IME 上屏「中文」后 Backspace ×2 | 本人插入逐字真删 ✅ |
| `npm run check:emits` | 通过 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)