### PR TITLE
feat(editor): 桌面快捷键对齐——Cmd+Z 撤销/重做/全选/剪贴板/格式/行导航

### DIFF
--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -30,6 +30,9 @@ export const EDITOR_ACTIONS = [
   // [spike/IME] implemented by the worker since Phase B but never whitelisted
   // (found by the primitive self-test: "Unknown action: move_cursor").
   'move_cursor', 'delete_backward', 'delete_forward', 'insert_paragraph', 'get_cursor_rect',
+  // [overlay 快捷键] desktop-parity keys (Cmd/Ctrl+A/B/I/U, Home/End) — the
+  // worker holds the .uno: allowlist (UI_COMMANDS in office_thread.js).
+  'ui_command',
   // [Track D] load the user's real document into the editor (host-initiated, not
   // an AI-agent command): {bytes, name} -> MEMFS + loadComponentFromURL + retarget.
   'load_document',

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -42,8 +42,10 @@
 //
 // Control keys (Phase B, when sendCommand is supplied): Enter inserts a paragraph
 // break via onEnter; Backspace/Delete delete around the cursor; arrow keys move
-// the LO view cursor — all forwarded to UNO, not applied to the empty <input>.
-// Without sendCommand these keys fall through to the (harmless, empty) input.
+// the LO view cursor; desktop shortcuts (Cmd/Ctrl+Z/Y undo-redo, +A select all,
+// +C/X/V clipboard, +B/I/U format toggles, Home/End & Cmd+arrows line/doc nav)
+// — all forwarded to UNO, not applied to the empty <input>. Without sendCommand
+// these keys fall through to the (harmless, empty) input.
 
 // The STABLE half of the mapping. offset is derived live per click (see above).
 // nudgeX/nudgeY are a small constant px correction for the residual between the
@@ -109,7 +111,8 @@ export function cursorRectToPixels(raw, offset) {
  * @param {(action:string,params:object)=>Promise<any>} [options.sendCommand]
  *        OPTIONAL. A raw UI-command channel to the worker (e.g. (a,p) =>
  *        workerRequest(a,p)). Enables control-key forwarding: Backspace ->
- *        delete_backward, Delete -> delete_forward, arrow keys -> move_cursor.
+ *        delete_backward, Delete -> delete_forward, arrow keys -> move_cursor,
+ *        plus desktop shortcuts (undo/redo/select-all/clipboard/format/line-nav).
  *        Without it, those keys fall through to the (empty) input and the
  *        document is unaffected.
  * @param {(msg:string)=>void} [options.onLog] optional progress/diagnostic log.
@@ -238,6 +241,33 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
   }
   const ARROW_DIR = { ArrowLeft: 'left', ArrowRight: 'right', ArrowUp: 'up', ArrowDown: 'down' }
 
+  // Clipboard: the document selection lives in LO (not the DOM), so native
+  // copy/cut/paste can't see it — bridge through navigator.clipboard + the
+  // worker's selection primitives instead. Paste replaces the selection (same
+  // as desktop); multi-line text becomes real paragraph breaks downstream.
+  const copySelection = (cut) => {
+    log('IME 覆盖层 → ' + (cut ? 'Cmd+X 剪切 / cut' : 'Cmd+C 复制 / copy'))
+    Promise.resolve(sendCommand('get_selection', {}))
+      .then((r) => {
+        const text = r && r.text
+        if (!text) return
+        return navigator.clipboard.writeText(text).then(() => {
+          // selection-aware tracked delete — same engine path as Backspace
+          if (cut) return Promise.resolve(sendCommand('delete_backward', {})).then(reposition)
+        })
+      })
+      .catch((err) => log('overlay clipboard error: ' + (err && err.message || err)))
+  }
+  const pasteClipboard = () => {
+    navigator.clipboard.readText()
+      .then((t) => {
+        if (!t) return
+        log('IME 覆盖层 → Cmd+V 粘贴 / paste「' + (t.length > 20 ? t.slice(0, 20) + '…' : t) + '」')
+        return Promise.resolve(sendCommand('replace_selection', { text: t })).then(reposition)
+      })
+      .catch((err) => log('overlay paste error: ' + (err && err.message || err)))
+  }
+
   // Control keys -> UNO (NOT into the single-line input). Only when NOT composing:
   // during composition these keys drive the IME candidate window. Enter routes to
   // onEnter; Backspace/arrows route through sendCommand (skipped if not supplied,
@@ -253,6 +283,45 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
       return
     }
     if (typeof sendCommand !== 'function') return
+    // Desktop shortcuts (Cmd on mac / Ctrl on win). Unmatched mod-combos fall
+    // through UNPREVENTED so host-level accelerators (e.g. save) keep working.
+    if (e.metaKey || e.ctrlKey) {
+      const k = String(e.key).toLowerCase()
+      if (k === 'z') {
+        e.preventDefault()
+        forward(e.shiftKey ? 'redo' : 'undo', {}, e.shiftKey ? '重做 / redo' : '撤销 / undo')
+      } else if (k === 'y') {
+        e.preventDefault()
+        forward('redo', {}, '重做 / redo')
+      } else if (k === 'a') {
+        e.preventDefault()
+        forward('ui_command', { name: 'select_all' }, '全选 / select all')
+      } else if (k === 'b' || k === 'i' || k === 'u') {
+        e.preventDefault()
+        const name = k === 'b' ? 'bold' : k === 'i' ? 'italic' : 'underline'
+        forward('ui_command', { name }, '格式 ' + name)
+      } else if (k === 'c') {
+        e.preventDefault(); copySelection(false)
+      } else if (k === 'x') {
+        e.preventDefault(); copySelection(true)
+      } else if (k === 'v') {
+        e.preventDefault(); pasteClipboard()
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        // mac 惯用 Cmd+←/→ = 行首/行尾
+        e.preventDefault()
+        forward('ui_command', { name: e.key === 'ArrowLeft' ? 'line_start' : 'line_end' }, e.key === 'ArrowLeft' ? '行首 / line start' : '行尾 / line end')
+      } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        // mac 惯用 Cmd+↑/↓ = 文首/文尾
+        e.preventDefault()
+        forward('goto', { type: e.key === 'ArrowUp' ? 'start' : 'end' }, e.key === 'ArrowUp' ? '文首 / doc start' : '文尾 / doc end')
+      }
+      return
+    }
+    if (e.key === 'Home' || e.key === 'End') {
+      e.preventDefault()
+      forward('ui_command', { name: e.key === 'Home' ? 'line_start' : 'line_end' }, e.key === 'Home' ? 'Home 行首' : 'End 行尾')
+      return
+    }
     if (e.key === 'Backspace') {
       e.preventDefault()
       forward('delete_backward', {}, 'Backspace 删除 / delete')

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -185,6 +185,16 @@ function dispatchUno(url) {
   css.frame.DispatchHelper.create(context).executeDispatch(ctrl.getFrame(), url, '', 0, []);
 }
 
+// Desktop-keyboard parity set for the IME overlay's ui_command action — an
+// ALLOWLIST map (name -> .uno: slot), deliberately NOT a raw dispatch
+// passthrough. Toggles (bold/italic/underline) are the engine's own, so
+// collapsed-cursor and mixed-selection semantics match the desktop app.
+const UI_COMMANDS = {
+  select_all: '.uno:SelectAll',
+  bold: '.uno:Bold', italic: '.uno:Italic', underline: '.uno:Underline',
+  line_start: '.uno:GoToStartOfLine', line_end: '.uno:GoToEndOfLine',
+};
+
 // Shared verification snapshot returned by mutating commands: where the cursor
 // is now + the paragraph as it reads AFTER the edit ("改完看一眼").
 function verifySnapshot() {
@@ -579,6 +589,13 @@ const EXEC = {
   delete_forward() {
     dispatchUno('.uno:Delete');
     return { success: true };
+  },
+  // Overlay shortcut keys (Cmd/Ctrl+A/B/I/U, Home/End) — see UI_COMMANDS.
+  ui_command(p) {
+    const url = UI_COMMANDS[String(p.name || '')];
+    if (!url) return { success: false, message: 'ui_command not allowed: ' + (p.name || '') };
+    dispatchUno(url);
+    return { success: true, name: String(p.name) };
   },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the


### PR DESCRIPTION
## 背景

真机反馈：LOWA 编辑器里 **Cmd+Z 不能撤销**。根因与 #164 同一类——IME 覆盖层持有键盘焦点,所有快捷键被空 `<input>` 吞掉,从未到达引擎。既然目标是与桌面办公一致的体验,这次把桌面基础快捷键一次接全。

## 内容

| 快捷键 | 行为 | 实现 |
|---|---|---|
| Cmd/Ctrl+Z、Cmd+Shift+Z / Ctrl+Y | 撤销 / 重做 | 已有 undo/redo 原语（UndoManager） |
| Cmd/Ctrl+A | 全选 | `.uno:SelectAll` |
| Cmd/Ctrl+C / X / V | 复制 / 剪切 / 粘贴 | LO 选区不在 DOM,原生剪贴板事件看不见:经 `get_selection` + `navigator.clipboard` 桥接**系统剪贴板**;粘贴走 `replace_selection`（覆盖选区,多行落为真实段落）;剪切复用 Backspace 的引擎删除路径,修订语义一致 |
| Cmd/Ctrl+B / I / U | 加粗 / 斜体 / 下划线 | `.uno:Bold/Italic/Underline` 引擎原生 toggle |
| Home / End、Cmd+←/→、Cmd+↑/↓ | 行首行尾、文首文尾 | `.uno:GoToStart/EndOfLine`、goto start/end |

- worker 新增 `ui_command` 原语:名字 → `.uno:` **白名单映射**,非任意透传
- 未匹配的修饰键组合不 preventDefault,宿主级加速键（如保存）不受影响

## 验证（真实引擎无头 e2e,CDP 按键走完整覆盖层链路）

- Cmd+Z 撤销插入、Cmd+Shift+Z 恢复、退格删除后 Cmd+Z 找回 ✅
- Cmd+A 选中全文;Cmd+B 两次 CharWeight 100→150→100（toggle）✅
- Cmd+C 系统剪贴板收到「abc中文」;Cmd+V 多段粘贴覆盖选区成两段;Cmd+X 剪切入剪贴板且文档清空 ✅
- Home/End/Cmd+方向键光标上下文逐一验证 ✅
- `npm run check:emits` 通过 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)