### PR TITLE
feat(editor): 键盘面主动扫描补齐 + 真人模拟 e2e 回归套件

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "@dcloudio/uni-stacktracey": "3.0.0-4080420251103001",
         "@dcloudio/vite-plugin-uni": "3.0.0-4080420251103001",
         "@vue/runtime-core": "^3.4.21",
+        "puppeteer-core": "^22.15.0",
         "sass": "^1.94.2",
         "vite": "5.2.8"
       }
@@ -4911,6 +4912,86 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
@@ -5291,6 +5372,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5408,7 +5496,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5447,6 +5534,17 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitejs/plugin-legacy": {
       "version": "5.3.2",
@@ -6016,7 +6114,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6070,6 +6167,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6113,6 +6223,21 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -6352,6 +6477,91 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6388,6 +6598,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -6585,6 +6805,16 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -6750,6 +6980,21 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/ci-info": {
@@ -7061,6 +7306,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -7134,6 +7389,21 @@
         "node": ">= 10"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -7189,6 +7459,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -7288,8 +7565,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7299,6 +7575,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -7449,7 +7735,6 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -7472,7 +7757,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -7487,7 +7771,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -7516,6 +7799,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/execa": {
@@ -7640,6 +7933,50 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -7682,6 +8019,16 @@
       "peer": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-type": {
@@ -7906,7 +8253,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -7972,6 +8318,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -8302,6 +8663,16 @@
         "url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -8362,7 +8733,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11160,6 +11530,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -11230,6 +11607,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -11330,7 +11717,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -11404,6 +11790,78 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/pako": {
@@ -11550,6 +12008,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/phin": {
@@ -11891,6 +12356,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11920,6 +12395,81 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -11932,6 +12482,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -11950,6 +12511,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.3.0",
+        "chromium-bidi": "0.6.3",
+        "debug": "^4.3.6",
+        "devtools-protocol": "0.0.1312386",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/qrcode-reader": {
@@ -12173,7 +12751,6 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12738,6 +13315,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12810,6 +13438,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -12852,7 +13492,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12868,7 +13507,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -13021,6 +13659,44 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -13074,6 +13750,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/throat": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
@@ -13081,6 +13767,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/timm": {
       "version": "1.7.1",
@@ -13175,6 +13868,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -13237,13 +13937,23 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
     },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -13483,6 +14193,13 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utif": {
       "version": "2.0.1",
@@ -13820,7 +14537,6 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -13839,7 +14555,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13856,7 +14571,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13869,16 +14583,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -14001,7 +14713,6 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -14050,6 +14761,27 @@
       "peer": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,8 @@
     "build:mp-xhs": "uni build -p mp-xhs",
     "build:quickapp-webview": "uni build -p quickapp-webview",
     "build:quickapp-webview-huawei": "uni build -p quickapp-webview-huawei",
-    "build:quickapp-webview-union": "uni build -p quickapp-webview-union"
+    "build:quickapp-webview-union": "uni build -p quickapp-webview-union",
+    "test:lowa-e2e": "node tests/lowa-e2e/run.mjs"
   },
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-4080420251103001",
@@ -72,6 +73,7 @@
     "@dcloudio/uni-stacktracey": "3.0.0-4080420251103001",
     "@dcloudio/vite-plugin-uni": "3.0.0-4080420251103001",
     "@vue/runtime-core": "^3.4.21",
+    "puppeteer-core": "^22.15.0",
     "sass": "^1.94.2",
     "vite": "5.2.8"
   }

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -43,9 +43,10 @@
 // Control keys (Phase B, when sendCommand is supplied): Enter inserts a paragraph
 // break via onEnter; Backspace/Delete delete around the cursor; arrow keys move
 // the LO view cursor; desktop shortcuts (Cmd/Ctrl+Z/Y undo-redo, +A select all,
-// +C/X/V clipboard, +B/I/U format toggles, Home/End & Cmd+arrows line/doc nav)
-// — all forwarded to UNO, not applied to the empty <input>. Without sendCommand
-// these keys fall through to the (harmless, empty) input.
+// +C/X/V clipboard, +B/I/U format toggles, Home/End(+Shift sel), Cmd/Option/Ctrl
+// +arrows line-word-doc nav, Tab, Shift+Enter soft break, Esc deselect, PageUp/
+// Down) — all forwarded to UNO, not applied to the empty <input>. Without
+// sendCommand these keys fall through to the (harmless, empty) input.
 
 // The STABLE half of the mapping. offset is derived live per click (see above).
 // nudgeX/nudgeY are a small constant px correction for the residual between the
@@ -240,6 +241,7 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     catch (err) { log('overlay ' + action + ' error: ' + (err && err.message || err)) }
   }
   const ARROW_DIR = { ArrowLeft: 'left', ArrowRight: 'right', ArrowUp: 'up', ArrowDown: 'down' }
+  const isMac = /Mac/i.test((navigator && navigator.platform) || '')
 
   // Clipboard: the document selection lives in LO (not the DOM), so native
   // copy/cut/paste can't see it — bridge through navigator.clipboard + the
@@ -276,6 +278,11 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     if (composing || e.isComposing) return
     if (e.key === 'Enter') {
       e.preventDefault()
+      // Shift+Enter = soft line break (same paragraph), like the desktop app.
+      if (e.shiftKey && typeof sendCommand === 'function') {
+        forward('ui_command', { name: 'line_break' }, 'Shift+Enter 软回车 / line break')
+        return
+      }
       if (typeof onEnter !== 'function') return
       log('IME 覆盖层 → 回车换行 / paragraph break')
       try { Promise.resolve(onEnter()).then(reposition).catch((err) => log('overlay enter error: ' + (err && err.message || err))) }
@@ -307,9 +314,13 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
       } else if (k === 'v') {
         e.preventDefault(); pasteClipboard()
       } else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        // mac 惯用 Cmd+←/→ = 行首/行尾
+        // mac：Cmd+←/→ = 行首/行尾；Windows：Ctrl+←/→ = 上一词/下一词。
+        // Shift 叠加 = 同方向选择。
         e.preventDefault()
-        forward('ui_command', { name: e.key === 'ArrowLeft' ? 'line_start' : 'line_end' }, e.key === 'ArrowLeft' ? '行首 / line start' : '行尾 / line end')
+        const left = e.key === 'ArrowLeft'
+        const base = isMac ? (left ? 'line_start' : 'line_end') : (left ? 'word_left' : 'word_right')
+        const name = e.shiftKey ? base + '_sel' : base
+        forward('ui_command', { name }, name)
       } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
         // mac 惯用 Cmd+↑/↓ = 文首/文尾
         e.preventDefault()
@@ -317,9 +328,35 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
       }
       return
     }
+    // Option/Alt+←/→ = 上一词/下一词（mac 惯用；Shift 叠加选择）
+    if (e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+      e.preventDefault()
+      const base = e.key === 'ArrowLeft' ? 'word_left' : 'word_right'
+      const name = e.shiftKey ? base + '_sel' : base
+      forward('ui_command', { name }, name)
+      return
+    }
     if (e.key === 'Home' || e.key === 'End') {
       e.preventDefault()
-      forward('ui_command', { name: e.key === 'Home' ? 'line_start' : 'line_end' }, e.key === 'Home' ? 'Home 行首' : 'End 行尾')
+      const base = e.key === 'Home' ? 'line_start' : 'line_end'
+      const name = e.shiftKey ? base + '_sel' : base
+      forward('ui_command', { name }, e.key + (e.shiftKey ? '+Shift 选择' : ''))
+      return
+    }
+    if (e.key === 'PageUp' || e.key === 'PageDown') {
+      e.preventDefault()
+      forward('ui_command', { name: e.key === 'PageUp' ? 'page_up' : 'page_down' }, e.key)
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      forward('ui_command', { name: 'escape' }, 'Esc 取消选区 / deselect')
+      return
+    }
+    if (e.key === 'Tab') {
+      // 制表符入文档（浏览器默认的焦点切换在画布上无意义）
+      e.preventDefault()
+      forward('insert_at_cursor', { text: '\t' }, 'Tab 制表符 / tab')
       return
     }
     if (e.key === 'Backspace') {

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -193,6 +193,13 @@ const UI_COMMANDS = {
   select_all: '.uno:SelectAll',
   bold: '.uno:Bold', italic: '.uno:Italic', underline: '.uno:Underline',
   line_start: '.uno:GoToStartOfLine', line_end: '.uno:GoToEndOfLine',
+  // (2nd sweep) the rest of the desktop key surface — all engine-verified:
+  line_break: '.uno:InsertLinebreak',                     // Shift+Enter 软回车
+  word_left: '.uno:GoToPrevWord', word_right: '.uno:GoToNextWord',
+  word_left_sel: '.uno:WordLeftSel', word_right_sel: '.uno:WordRightSel',
+  line_start_sel: '.uno:StartOfLineSel', line_end_sel: '.uno:EndOfLineSel',
+  escape: '.uno:Escape',                                  // 取消选区
+  page_up: '.uno:PageUp', page_down: '.uno:PageDown',
 };
 
 // Shared verification snapshot returned by mutating commands: where the cursor

--- a/frontend/tests/lowa-e2e/README.md
+++ b/frontend/tests/lowa-e2e/README.md
@@ -1,0 +1,52 @@
+# LOWA 编辑器"真人模拟"e2e 回归 / human-simulation e2e
+
+无头启动**真实 LibreOffice WASM 引擎**，用 CDP 键盘事件 + IME 合成走**完整的
+覆盖层键盘链路**（key event → IME overlay → executor → worker → UNO），逐项断言
+文档 / 光标 / 剪贴板状态——和真人在编辑器里打字、删除、按快捷键是同一条链。
+
+## 为什么
+
+原语级测试（直接调 executor 命令）反复通过，但真人却撞上"Backspace 只能删一个"
+（修订模式卡死，PR#164）、"Delete/Cmd+Z 没反应"（覆盖层吞键，PR#164/166）——这类
+bug 只存在于按键事件到 UNO 之间的链路上。本套件测的就是这条链。改动
+zetaOfficeImeOverlay.js / office_thread.js / libreofficeExecutorClient.js 后必跑。
+
+## 运行
+
+```bash
+cd frontend
+npm run build:zetaoffice          # 注意：会清空 dist/zetaoffice（包括引擎文件！）
+node ../desktop/scripts/fetch-lowa-assets.js   # 引擎不在时重新拉取
+npm run test:lowa-e2e
+```
+
+环境变量：
+
+| 变量 | 作用 |
+|---|---|
+| `LOWA_ENGINE_DIR` | 从外部目录服务引擎（soffice.* + .encodings.json），躲开 build:zetaoffice 清空 dist 的坑 |
+| `PUPPETEER_EXECUTABLE_PATH` | Chrome 路径（默认 mac 的 Google Chrome） |
+| `LOWA_E2E_PORT` | 服务器端口（默认 8901） |
+
+引擎启动约 90 秒；全套跑完约 3 分钟。退出码非 0 = 有断言失败。
+
+## 覆盖场景
+
+1. 修订模式下退格删除文档原文——光标逐字越过（PR#164 卡死回归）
+2. Delete 键前删
+3. IME 中文合成上屏 + 退格真删（本人插入）
+4. Cmd+Z / Cmd+Shift+Z 撤销重做
+5. Cmd+A 全选、Cmd+B 加粗 toggle
+6. Cmd+C/V/X 系统剪贴板复制、多段粘贴覆盖选区、剪切
+7. Home / Shift+End 选择 / Option+← 跳词 / Cmd+← 行首 / Cmd+↓ 文尾
+8. Tab 制表符、Shift+Enter 软回车、Esc 取消选区、PageUp/Down
+
+## 机制说明
+
+- 测试专用的 worker 动作（`debug_set_record_changes`、`debug_char_prop`）由测试
+  服务器**在内存中**注入到所服务的 office_thread.js / editor 资产里——源码与
+  dist 均不被改动。锚点是 `const EXEC = {` 与白名单里的
+  `'get_hyperlink_at_cursor'`，若重构了这两处需同步本套件。
+- 服务器按引擎目录的 `.encodings.json` 回放 Content-Encoding（CDN 引擎是 brotli
+  原样存储）。
+- 新增快捷键后：在 run.mjs 加一个场景断言 + README 本表补一行。

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// LOWA 编辑器"真人模拟"端到端回归 / human-simulation e2e for the LibreOffice
+// WASM editor. Boots the REAL engine headlessly and drives the REAL overlay
+// keyboard path (CDP key events + IME composition), asserting document/cursor/
+// clipboard state after every interaction — the same chain a human exercises.
+//
+// WHY this exists: primitive-level tests kept passing while real users hit
+// "Backspace 只能删一个"、"Delete/Cmd+Z 没反应" — bugs that only live in the
+// key-event → overlay → worker → UNO chain. This suite IS that chain.
+//
+// Run:  npm run test:lowa-e2e        (from frontend/)
+// Env:  LOWA_ENGINE_DIR   serve the LOWA runtime (soffice.*) from an external
+//                         dir instead of dist/zetaoffice/lowa — survives
+//                         `npm run build:zetaoffice`, which EMPTIES dist and
+//                         deletes the fetched engine.
+//       PUPPETEER_EXECUTABLE_PATH  Chrome binary (default: mac Google Chrome).
+//       LOWA_E2E_PORT     server port (default 8901).
+//
+// Prereqs: dist/zetaoffice built (npm run build:zetaoffice) + engine files
+// (node ../desktop/scripts/fetch-lowa-assets.js, or LOWA_ENGINE_DIR).
+//
+// Test-only worker actions (debug_*) are injected IN-MEMORY by the server into
+// the served office_thread.js / editor bundle — source and dist stay clean.
+
+import http from 'node:http'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const distDir = path.resolve(here, '../../dist/zetaoffice')
+const engineDir = process.env.LOWA_ENGINE_DIR || path.join(distDir, 'lowa')
+const PORT = Number(process.env.LOWA_E2E_PORT || 8901)
+const ORIGIN = 'http://127.0.0.1:' + PORT
+const CHROME = process.env.PUPPETEER_EXECUTABLE_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+
+// ---------- preflight ----------
+for (const [what, p] of [
+  ['dist/zetaoffice (npm run build:zetaoffice)', path.join(distDir, 'editor.html')],
+  ['LOWA engine (fetch-lowa-assets.js or LOWA_ENGINE_DIR)', path.join(engineDir, 'soffice.js')],
+  ['Chrome (PUPPETEER_EXECUTABLE_PATH)', CHROME],
+]) {
+  if (!fs.existsSync(p)) { console.error('缺少 ' + what + ': ' + p); process.exit(2) }
+}
+let puppeteer
+try { puppeteer = (await import('puppeteer-core')).default }
+catch { console.error('缺少 puppeteer-core：cd frontend && npm i -D puppeteer-core'); process.exit(2) }
+
+// ---------- test-only worker actions, injected in-memory ----------
+const DEBUG_ACTIONS = `
+  debug_set_record_changes(p) {
+    xModel.setPropertyValue('RecordChanges', !!p.on);
+    return { success: true, recordChanges: xModel.getPropertyValue('RecordChanges') };
+  },
+  debug_char_prop(p) {
+    const vc = ctrl.getViewCursor();
+    return { success: true, value: vc.getPropertyValue(String(p.prop)), selected: (vc.getString() || '').slice(0, 40) };
+  },
+`
+function patchServed(urlPath, content) {
+  if (urlPath === '/office_thread.js') {
+    const s = content.toString('utf8')
+    if (!s.includes('const EXEC = {')) throw new Error('office_thread.js: EXEC anchor missing')
+    return Buffer.from(s.replace('const EXEC = {', 'const EXEC = {\n' + DEBUG_ACTIONS), 'utf8')
+  }
+  if (/^\/assets\/editor-.*\.js$/.test(urlPath)) {
+    const s = content.toString('utf8')
+    return Buffer.from(
+      s.replace("'get_hyperlink_at_cursor'", "'get_hyperlink_at_cursor','debug_set_record_changes','debug_char_prop'")
+        .replace('"get_hyperlink_at_cursor"', '"get_hyperlink_at_cursor","debug_set_record_changes","debug_char_prop"'),
+      'utf8')
+  }
+  return content
+}
+
+// ---------- COOP/COEP static server ----------
+const encPath = path.join(engineDir, '.encodings.json')
+const encodings = fs.existsSync(encPath) ? JSON.parse(fs.readFileSync(encPath, 'utf8')) : {}
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm',
+  '.data': 'application/octet-stream', '.json': 'application/json',
+  '.ttc': 'font/collection', '.ttf': 'font/ttf', '.otf': 'font/otf',
+}
+const server = http.createServer((req, res) => {
+  const urlPath = decodeURIComponent(req.url.split('?')[0])
+  const fromEngine = urlPath.startsWith('/lowa/')
+  const fp = fromEngine
+    ? path.join(engineDir, urlPath.slice('/lowa/'.length))
+    : path.join(distDir, urlPath === '/' ? 'editor.html' : urlPath)
+  if (!fs.existsSync(fp) || fs.statSync(fp).isDirectory()) { res.writeHead(404); res.end(); return }
+  const headers = {
+    'Cross-Origin-Opener-Policy': 'same-origin',
+    'Cross-Origin-Embedder-Policy': 'require-corp',
+    'Cache-Control': 'no-store',
+    'Content-Type': MIME[path.extname(fp)] || 'application/octet-stream',
+  }
+  if (fromEngine && encodings[path.basename(fp)]) headers['Content-Encoding'] = encodings[path.basename(fp)]
+  const body = patchServed(urlPath, fs.readFileSync(fp))
+  res.writeHead(200, headers)
+  res.end(body)
+})
+await new Promise((r) => server.listen(PORT, r))
+console.log('serving ' + distDir + ' (engine: ' + engineDir + ') on ' + ORIGIN)
+
+// ---------- assertions ----------
+let passed = 0, failed = 0
+function check(label, cond, detail) {
+  if (cond) { passed++; console.log('  PASS ' + label) }
+  else { failed++; console.log('  FAIL ' + label + (detail ? '  [' + detail + ']' : '')) }
+}
+
+// ---------- drive ----------
+const META = 4, SHIFT = 8, ALT = 1
+const browser = await puppeteer.launch({ executablePath: CHROME, headless: 'new', args: ['--no-sandbox', '--disable-dev-shm-usage'] })
+try {
+  await browser.defaultBrowserContext().overridePermissions(ORIGIN, ['clipboard-read', 'clipboard-write', 'clipboard-sanitized-write'])
+  const page = await browser.newPage()
+  await page.goto(ORIGIN + '/editor.html?verify=1&lowa=/lowa/', { waitUntil: 'domcontentloaded' })
+  console.log('booting engine (~90s)...')
+  await page.waitForFunction('!!window.__loExecutor', { timeout: 240000 })
+  await page.evaluate(() => { window.__overlayInput = document.querySelector('input[aria-hidden]') })
+
+  const cdp = await page.createCDPSession()
+  const key = async (k, code, vk, modifiers = 0) => {
+    await cdp.send('Input.dispatchKeyEvent', { type: 'keyDown', key: k, code, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk, modifiers })
+    await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key: k, code, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk, modifiers })
+    await new Promise((r) => setTimeout(r, 350))
+  }
+  const exec = (a, p) => page.evaluate((a2, p2) => window.__loExecutor.executeCommand(a2, p2 || {}), a, p)
+  const doc = async () => (await exec('get_document_text')).paragraphs.map((x) => x.text).join('|')
+  const cursor = async () => { const r = await exec('get_cursor_context'); return { b: r.before || '', a: r.after || '' } }
+  const focus = () => page.evaluate(() => window.__overlayInput.focus())
+  // hard reset: revisions off so leftovers (incl. redline remnants) truly vanish
+  const reset = async (text, rcOn = true) => {
+    await exec('debug_set_record_changes', { on: false })
+    await exec('ui_command', { name: 'select_all' })
+    await exec('replace_selection', { text: text || '' })
+    await exec('goto', { type: 'end' })
+    await exec('debug_set_record_changes', { on: rcOn })
+    await focus()
+  }
+
+  console.log('== 1) Backspace over pre-existing text (revision-mode jam regression #164) ==')
+  await reset('合同条款abc') // inserted with rc OFF -> "original" text; rc back ON
+  for (let i = 0; i < 3; i++) await key('Backspace', 'Backspace', 8)
+  let c = await cursor()
+  check('3×Backspace 光标逐字越过原文', c.b === '合同条款' && c.a === 'abc', JSON.stringify(c))
+
+  console.log('== 2) Delete key forward-deletes ==')
+  await reset('合同条款abc')
+  for (let i = 0; i < 3; i++) await key('ArrowLeft', 'ArrowLeft', 37)
+  for (let i = 0; i < 2; i++) await key('Delete', 'Delete', 46)
+  c = await cursor()
+  check('2×Delete 前删越过原文', c.b === '合同条款ab' && c.a === 'c', JSON.stringify(c))
+
+  console.log('== 3) IME CJK commit + Backspace hard-deletes own insert ==')
+  await reset('')
+  await cdp.send('Input.imeSetComposition', { text: '中文', selectionStart: 2, selectionEnd: 2 })
+  await cdp.send('Input.insertText', { text: '中文' })
+  await new Promise((r) => setTimeout(r, 500))
+  check('IME 上屏', await doc() === '中文', await doc())
+  await key('Backspace', 'Backspace', 8)
+  check('上屏后退格真删', await doc() === '中', await doc())
+
+  console.log('== 4) undo / redo ==')
+  await reset('')
+  await exec('insert_at_cursor', { text: 'abc中文' })
+  await focus()
+  await key('z', 'KeyZ', 90, META)
+  check('Cmd+Z 撤销插入', await doc() === '', await doc())
+  await key('z', 'KeyZ', 90, META | SHIFT)
+  check('Cmd+Shift+Z 重做', await doc() === 'abc中文', await doc())
+
+  console.log('== 5) select all / bold toggle ==')
+  await key('a', 'KeyA', 65, META)
+  check('Cmd+A 全选', (await exec('get_selection')).text === 'abc中文')
+  await key('b', 'KeyB', 66, META)
+  let w = await exec('debug_char_prop', { prop: 'CharWeight' })
+  check('Cmd+B 加粗', w.value === 150, JSON.stringify(w.value))
+  await key('b', 'KeyB', 66, META)
+  w = await exec('debug_char_prop', { prop: 'CharWeight' })
+  check('Cmd+B 再按取消', w.value === 100, JSON.stringify(w.value))
+
+  console.log('== 6) clipboard copy / paste / cut ==')
+  await key('a', 'KeyA', 65, META)
+  await key('c', 'KeyC', 67, META)
+  await new Promise((r) => setTimeout(r, 500))
+  check('Cmd+C 系统剪贴板', await page.evaluate(() => navigator.clipboard.readText()) === 'abc中文')
+  await page.evaluate(() => navigator.clipboard.writeText('粘贴段一\n粘贴段二'))
+  await key('a', 'KeyA', 65, META)
+  await key('v', 'KeyV', 86, META)
+  await new Promise((r) => setTimeout(r, 500))
+  check('Cmd+V 多段粘贴覆盖选区', await doc() === '粘贴段一|粘贴段二', await doc())
+  await key('a', 'KeyA', 65, META)
+  await key('x', 'KeyX', 88, META)
+  await new Promise((r) => setTimeout(r, 500))
+  check('Cmd+X 剪切入剪贴板', await page.evaluate(() => navigator.clipboard.readText()) === '粘贴段一\n粘贴段二')
+  check('Cmd+X 后文档已空', await doc() === '', await doc())
+
+  console.log('== 7) line / word / doc navigation ==')
+  await reset('甲方 乙方 丙方')
+  await key('Home', 'Home', 36)
+  c = await cursor()
+  check('Home 行首', c.b === '' && c.a === '甲方 乙方 丙方', JSON.stringify(c))
+  await key('End', 'End', 35, SHIFT)
+  check('Shift+End 选至行尾', (await exec('get_selection')).text === '甲方 乙方 丙方')
+  await key('End', 'End', 35)
+  await key('ArrowLeft', 'ArrowLeft', 37, ALT)
+  c = await cursor()
+  check('Option+← 上一词', c.a !== '' && c.b.length < '甲方 乙方 丙方'.length, JSON.stringify(c))
+  await key('ArrowLeft', 'ArrowLeft', 37, META)
+  c = await cursor()
+  check('Cmd+← 行首', c.b === '', JSON.stringify(c))
+  await key('ArrowDown', 'ArrowDown', 40, META)
+  c = await cursor()
+  check('Cmd+↓ 文尾', c.a === '', JSON.stringify(c))
+
+  console.log('== 8) Tab / Shift+Enter / Esc / PageUp/Down ==')
+  await reset('条款')
+  await key('Tab', 'Tab', 9)
+  check('Tab 制表符', (await doc()).includes('\t'), JSON.stringify(await doc()))
+  await reset('第一行')
+  await key('Enter', 'Enter', 13, SHIFT)
+  const t = await exec('get_document_text')
+  check('Shift+Enter 软回车（不分段）', t.totalParagraphs === 1 && t.paragraphs[0].text.includes('\n'), JSON.stringify(t.paragraphs))
+  await reset('选区文本')
+  await key('a', 'KeyA', 65, META)
+  await key('Escape', 'Escape', 27)
+  check('Esc 取消选区', !(await exec('get_selection')).hasSelection)
+  const pu = await exec('ui_command', { name: 'page_up' })
+  const pd = await exec('ui_command', { name: 'page_down' })
+  check('PageUp/PageDown 命令可用', pu.success && pd.success)
+
+  console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
+} finally {
+  await browser.close()
+  server.close()
+}
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
## 背景

连续两轮都是用户先发现基本操作坏了（退格卡死、Delete/Cmd+Z 无效）。根因是验证方式"改哪测哪"、停留在原语级,而 bug 全部位于**按键事件 → IME 覆盖层 → executor → worker → UNO** 这条真人链路上。本 PR 做两件事:

## 1. 主动扫描:把剩余键盘面一次补齐（7 处缺口）

全部为引擎实测可用的 `.uno:` 白名单映射（UI_COMMANDS）:

| 键 | 行为 |
|---|---|
| Tab | 制表符入文档 |
| Shift+Enter | 软回车（同段落内换行,`.uno:InsertLinebreak`） |
| Option+←/→（mac）、Ctrl+←/→（Win） | 跳词;Shift 叠加=选词 |
| Shift+Home/End | 选至行首/行尾 |
| Esc | 取消选区（IME 合成中不拦截） |
| PageUp/PageDown | 翻页 |

mac/Windows 平台分流:mac Cmd+←/→ 保持行首行尾,Windows Ctrl+←/→ 是跳词。

## 2. 真人模拟 e2e 回归套件（常驻,`npm run test:lowa-e2e`）

`frontend/tests/lowa-e2e/`:无头启动**真实 LOWA 引擎**,用 CDP 键盘事件 + IME 合成驱动**完整覆盖层链路**,22 项断言覆盖:

- #164 修订模式退格卡死回归、Delete 前删
- IME 中文上屏与真删、Cmd+Z/Shift+Z 撤销重做
- Cmd+A/B 全选加粗 toggle、Cmd+C/V/X 系统剪贴板三件套
- Home/Shift+End/Option+←/Cmd+←/Cmd+↓ 行词文导航
- Tab / Shift+Enter / Esc / PageUp/Down

机制:测试专用 debug 动作由测试服务器**在内存中**注入到所服务的 worker/编辑器资产,源码与 dist 零污染;`LOWA_ENGINE_DIR` 支持外置引擎目录（`build:zetaoffice` 会清空 dist 引擎的坑);devDep 仅增 puppeteer-core（纯 JS）。

## 验证

本机全套 **22 passed, 0 failed**;`check:emits` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)