### PR TITLE
feat(qa): AI 对话真发送 + 桌面保存链路 e2e + 每日定时 QA

### DIFF
--- a/docs/QA_JOURNEYS.md
+++ b/docs/QA_JOURNEYS.md
@@ -6,7 +6,7 @@
 >
 > 套件：`A` = `npm run test:app-e2e`（浏览器目标，真实鼠标/键盘走 uni-app UI）
 > `L` = `npm run test:lowa-e2e`（真实 LOWA 引擎 + CDP 键盘/IME，编辑器键盘链路）
-> `E` = Electron/CDP 宿主链路（配方见 memory：dev Electron `--remote-debugging-port`）
+> `E` = `npm run test:desktop-e2e`（dev Electron+CDP 宿主链路，会在屏幕弹窗）
 > `真机` = 需 computer-use / 人工（真实输入法、系统菜单、多显示器等）
 
 ## 账号与导航
@@ -27,7 +27,7 @@
 | 上传小文件（UI 文件选择器） | A ✅ | |
 | 上传 >5MB（分片路径，#156 回归） | A ✅ | |
 | 打开文本文件预览 | A ✅ | |
-| 新建文件夹 / 新建 Word | ❌ | Word 打开进编辑器需 E |
+| 新建 Word 并打开编辑器 | E ✅ | desktop-e2e 覆盖；新建文件夹 ❌ |
 | 文件标签增删 | ❌ | 真机配方在 memory（TagChip prop 坑） |
 | 右键菜单全项 | ❌ | H5 冒泡不稳，用 Vue 实例法 |
 | 回收站还原/清空 | ❌ | |
@@ -41,7 +41,7 @@
 | 打字/IME 上屏/退格删除（含修订模式原文，#164） | L ✅ 22 断言 | |
 | Delete/undo/redo/全选/剪贴板/加粗/行词文导航/Tab/软回车/Esc/翻页（#166/167） | L ✅ | |
 | 真实 macOS 输入法候选窗交互 | 真机 | CDP 模拟已很接近，候选窗本身模拟不到 |
-| 文档加载（真实 docx）/保存/自动保存（PR#165） | E | 宿主 IPC 链路，浏览器目标不可达 |
+| 新建 Word→编辑→点保存→docx 落盘（保存链路） | E ✅ | `npm run test:desktop-e2e`（dev Electron+CDP，会弹窗口）；自动保存（PR#165）未单独断言 |
 | 鼠标拖选/双击选词/滚动渲染 | E/真机 | |
 | 变量面板 var_* 域、图片插入、链接点击 | E | 真机配方在 memory |
 
@@ -66,8 +66,8 @@
 
 | 旅程 | 覆盖 | 备注 |
 |---|---|---|
-| 对话发送/流式/任务清单卡（PR#162） | ❌ | 真发消息走真实 provider 花钱——需 mock provider 或专用低价模型配置 |
-| 历史会话加载/轮次不丢（PR#153） | ❌ | 有 H2 直连验证配方 |
+| 对话发送/流式回复 | A ✅ | 真 UI 打字发送，走默认 deepseek-v4-flash（$0.09/M，可 AI_E2E=0 跳过）；任务清单卡未断言 |
+| 历史会话轮次落库（PR#153 回归） | A ✅ | 发送后查 /api/ai/history 断言 AI 回复在库 |
 | 文档检查点/回滚 | ❌ | |
 
 ## 独立页面与系统
@@ -80,6 +80,13 @@
 | 网页 tab（打开/关闭/导航） | ❌(A 可补) | 桌面版是 BrowserView，验证要读 leftFiles/rightFiles 状态非 DOM |
 | API 烟测（9 个只读端点） | A ✅ | |
 | 桌面打包版首启向导/组件下载 | 真机 | PR#142 领域 |
+
+## 每日定时 QA
+
+`scripts/qa-nightly.sh`（经 `~/aiworkdeck-qa/run.sh` 引导，专用克隆，用户 crontab
+每日 12:45 调起）：跑 lowa-e2e（必跑）+ app-e2e（9696 在跑时），报告写
+`~/aiworkdeck-qa/reports/YYYY-MM-DD.md`，有失败自动开 GitHub issue。
+desktop-e2e 会弹窗，不进每日，改动编辑器/宿主代码时按需跑。
 
 ## 运行环境备忘
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
     "build:quickapp-webview-huawei": "uni build -p quickapp-webview-huawei",
     "build:quickapp-webview-union": "uni build -p quickapp-webview-union",
     "test:lowa-e2e": "node tests/lowa-e2e/run.mjs",
-    "test:app-e2e": "node tests/app-e2e/run.mjs"
+    "test:app-e2e": "node tests/app-e2e/run.mjs",
+    "test:desktop-e2e": "node tests/desktop-e2e/run.mjs"
   },
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-4080420251103001",

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -201,6 +201,25 @@ try {
   }
   await shot('j6-rails')
 
+  // ============ J6.5 AI 对话（真 UI 打字发送；默认模型 deepseek-v4-flash，
+  // $0.09/M tokens，一条消息成本可忽略；AI_E2E=0 跳过） ============
+  if (process.env.AI_E2E !== '0') {
+    console.log('== J6.5 AI 对话 ==')
+    await step('AI 面板发送并收到流式回复', async () => {
+      if (!(await page.$('.chat-input-rich'))) await mouseClickSel('[title="AI 助手"]')
+      await page.waitForSelector('.chat-input-rich', { timeout: 10000 })
+      await mouseClickSel('.chat-input-rich')
+      await page.keyboard.type('这是自动化测试。请只回复四个字：测试通过', { delay: 10 })
+      await mouseClickSel('.send-btn')
+      await waitText('测试通过', 90000) // 流式回复落进气泡
+    })
+    await step('对话历史落库（#153 轮次回归）', async () => {
+      const r = await fetch(BACKEND + '/api/ai/history?projectId=' + QA.projectId, { headers: { 'X-Session-Id': QA.sid } })
+      const body = await r.text()
+      if (!body.includes('测试通过')) throw new Error('历史中未见 AI 回复内容: ' + body.slice(0, 150))
+    })
+  }
+
   // ============ J7 独立页面 ============
   console.log('== J7 独立页面 ==')
   for (const [name, route, expectText] of [

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// 桌面宿主链路 e2e / desktop host-chain e2e (Electron + CDP).
+//
+// 覆盖浏览器目标够不到的一条关键链：新建 Word → 编辑器（<webview> 内真实 LOWA
+// 引擎）boot → 宿主执行器插入文本 → 点保存按钮 → 后端落盘 → API 下载 docx 验证
+// 内容真的写进了文件。这是"编辑器保存链路"的端到端证明。
+//
+// 跑法（本机）：
+//   1) worktree/主仓库 frontend：`npx uni --port 5174`（dev:h5），且
+//      dist/zetaoffice 里有引擎（build 后从打包版复制，见 lowa-e2e README）
+//   2) 桌面后端 9696 在跑（打包版开着即可；dev Electron 会复用不再起 java）
+//   3) cd frontend && npm run test:desktop-e2e
+// 注意：会在屏幕上弹出一个 dev Electron 窗口，跑完自动关闭。
+//
+// Env：DESKTOP_E2E_DEVURL（默认 http://localhost:5174）、APP_E2E_BACKEND（默认 9696）
+
+import { spawn, execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const frontendDir = path.resolve(here, '../..')
+const desktopDir = path.resolve(frontendDir, '../desktop')
+const DEVURL = process.env.DESKTOP_E2E_DEVURL || 'http://localhost:5174'
+const BACKEND = process.env.APP_E2E_BACKEND || 'http://127.0.0.1:9696'
+const CDP_PORT = 9333
+const MARKER = 'QA_SAVE_MARKER_' + Date.now()
+
+let puppeteer
+try { puppeteer = (await import('puppeteer-core')).default }
+catch { console.error('缺少 puppeteer-core：cd frontend && npm i -D puppeteer-core'); process.exit(2) }
+
+// ---- preflight ----
+for (const [what, ok] of [
+  ['dev server ' + DEVURL, await fetch(DEVURL).then(() => true).catch(() => false)],
+  ['后端 ' + BACKEND, await fetch(BACKEND + '/api/skills/market/list').then(() => true).catch(() => false)],
+  ['引擎 dist/zetaoffice/lowa', fs.existsSync(path.join(frontendDir, 'dist/zetaoffice/lowa/soffice.js'))],
+  ['desktop/node_modules', fs.existsSync(path.join(desktopDir, 'node_modules'))],
+]) { if (!ok) { console.error('前置缺失: ' + what); process.exit(2) } }
+
+// ---- provision ----
+const QA = { user: 'qa_desk_' + Date.now(), pass: 'QaBot123456' }
+async function api(ep, opts = {}) {
+  const r = await fetch(BACKEND + ep, {
+    method: opts.method || 'GET',
+    headers: { 'Content-Type': 'application/json', ...(QA.sid ? { 'X-Session-Id': QA.sid } : {}) },
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  })
+  return r.json().catch(() => null)
+}
+{
+  const reg = await api('/api/auth/register', { method: 'POST', body: { username: QA.user, password: QA.pass, displayName: 'QA桌面' } })
+  QA.sid = reg.data.sessionId; QA.userObj = reg.data.user
+  const proj = await api('/api/projects', { method: 'POST', body: { name: '桌面链路QA_' + Date.now(), projectType: 'BLANK' } })
+  QA.projectId = proj.id
+  console.log('QA 账号 ' + QA.user + ' / 项目 #' + QA.projectId)
+}
+
+// ---- launch dev Electron with CDP ----
+console.log('启动 dev Electron（屏幕会出现窗口，结束自动关闭）...')
+const elec = spawn('npx', ['electron', '.', '--remote-debugging-port=' + CDP_PORT], {
+  cwd: desktopDir,
+  env: { ...process.env, AIWORKDECK_DESKTOP_DEV: '1', CHECKBA_DEV_SERVER_URL: DEVURL },
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'desktop-e2e-electron.log'))
+elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+let ws = null
+for (let i = 0; i < 60 && !ws; i++) {
+  await sleep(1000)
+  ws = await fetch('http://127.0.0.1:' + CDP_PORT + '/json/version').then((r) => r.json()).then((j) => j.webSocketDebuggerUrl).catch(() => null)
+}
+if (!ws) { console.error('CDP 端点未就绪'); elec.kill(); process.exit(1) }
+
+let failed = 0
+const step = async (name, fn) => {
+  try { await fn(); console.log('  ✓ ' + name) }
+  catch (e) { failed++; console.log('  ✗ ' + name + ': ' + String(e.message || e).slice(0, 250)) }
+}
+
+const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null })
+try {
+  // main renderer page = the dev URL
+  let page = null
+  for (let i = 0; i < 30 && !page; i++) {
+    await sleep(1000)
+    page = (await browser.pages()).find((p) => p.url().startsWith(DEVURL))
+  }
+  if (!page) throw new Error('找不到主渲染页')
+
+  const mouseClickSel = async (sel) => {
+    await page.waitForSelector(sel, { timeout: 15000 })
+    const box = await page.evaluate((s) => {
+      const el = document.querySelector(s); if (!el) return null
+      const r = el.getBoundingClientRect()
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+    }, sel)
+    await page.mouse.click(box.x, box.y)
+    await sleep(700)
+  }
+
+  await step('注入会话并进入项目', async () => {
+    await page.evaluate((sid, user) => {
+      uni.setStorageSync('checkba_session_id', sid)
+      uni.setStorageSync('checkba_user', user)
+    }, QA.sid, QA.userObj)
+    await page.goto(DEVURL + '/#/pages/project-overview/project-overview?id=' + QA.projectId, { waitUntil: 'networkidle2' })
+    await page.waitForFunction(() => document.body.innerText.includes('资源管理器'), { timeout: 20000 })
+  })
+
+  const mouseClickText = async (label) => {
+    const box = await page.evaluate((lbl) => {
+      const els = [...document.querySelectorAll('*')].filter((el) =>
+        el.children.length === 0 && el.innerText && el.offsetParent !== null && el.innerText.trim().includes(lbl))
+      const el = els[0]; if (!el) return null
+      const r = el.getBoundingClientRect()
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+    }, label)
+    if (!box) throw new Error('找不到文本: ' + label)
+    await page.mouse.click(box.x, box.y)
+    await sleep(700)
+  }
+
+  await step('新建 Word 文档并点击打开（编辑器 webview）', async () => {
+    await mouseClickSel('[title="新建文档"]')
+    // 创建只落文件不开编辑器；等文件出现在树里再点击打开
+    await page.waitForFunction(() => document.body.innerText.includes('newdocument'), { timeout: 15000 })
+    await mouseClickText('newdocument')
+    await page.waitForSelector('webview', { timeout: 30000 })
+  })
+
+  // 宿主侧编辑器组件（executor / statusText / saveDocument 所在）。
+  // 注意：keepalive 池（PR#159）用 createElement 命令式建 webview，元素上没有
+  // __vueParentComponent —— 必须从 Vue 组件树根 DFS 找 saveDocument 组件。
+  const FIND_EDITOR = `
+    function findEditor() {
+      let seed = null
+      for (const el of document.querySelectorAll('*')) { if (el.__vueParentComponent) { seed = el.__vueParentComponent; break } }
+      if (!seed) return null
+      let root = seed; while (root.parent) root = root.parent
+      const q = [root]
+      while (q.length) {
+        const c = q.shift()
+        if (c.proxy && typeof c.proxy.saveDocument === 'function') return c.proxy
+        const stack = [c.subTree]
+        while (stack.length) {
+          const v = stack.pop()
+          if (!v) continue
+          if (v.component) q.push(v.component)
+          else if (Array.isArray(v.children)) stack.push(...v.children)
+        }
+      }
+      return null
+    }`
+  const editorEval = (fnBody) => page.evaluate((finder, body) => {
+    const ed = eval(finder + '; findEditor()')
+    if (!ed) return { err: 'editor component not found' }
+    return new Function('ed', body)(ed)
+  }, FIND_EDITOR, fnBody)
+
+  await step('等待引擎就绪（首次 boot 约 1-2 分钟）', async () => {
+    for (let i = 0; i < 180; i++) {
+      const st = await editorEval('return { status: ed.statusText, ready: ed.ready === true || !!ed.executor }')
+      if (st.err) throw new Error(st.err)
+      if (/就绪|加载文档中/.test(st.status) && st.ready) {
+        // 加载文档中 -> 就绪；等到就绪或超时
+        if (st.status.includes('就绪') || i > 30) return
+      }
+      if (/失败/.test(st.status)) throw new Error('编辑器状态: ' + st.status)
+      await sleep(2000)
+    }
+    throw new Error('引擎未就绪(超时)')
+  })
+
+  await step('宿主执行器插入标记文本', async () => {
+    const r = await page.evaluate(async (finder, marker) => {
+      const ed = eval(finder + '; findEditor()')
+      if (!ed) return { err: 'editor component not found' }
+      return await ed.executor.executeCommand('insert_at_cursor', { text: marker + ' 保存链路中文验证' })
+    }, FIND_EDITOR, MARKER)
+    if (!r || r.success !== true) throw new Error('insert 失败: ' + JSON.stringify(r).slice(0, 150))
+  })
+
+  await step('点保存按钮并等待「已保存」', async () => {
+    await mouseClickSel('.libre-save')
+    for (let i = 0; i < 60; i++) {
+      const st = await editorEval('return { status: ed.statusText, saving: ed.saving }')
+      if (/已保存/.test(st.status)) return
+      if (/失败/.test(st.status)) throw new Error('保存状态: ' + st.status)
+      await sleep(1000)
+    }
+    throw new Error('保存未确认(超时)')
+  })
+
+  await step('API 下载 docx 验证内容落盘', async () => {
+    const files = await api('/api/projects/' + QA.projectId + '/files')
+    const list = Array.isArray(files) ? files : (files && files.data) || []
+    const flat = JSON.stringify(list)
+    const m = flat.match(/"id":(\d+)[^}]*?docx/) || flat.match(/docx[^}]*?"id":(\d+)/)
+    if (!m) throw new Error('项目文件列表中找不到 docx: ' + flat.slice(0, 200))
+    const fileId = m[1]
+    const buf = Buffer.from(await (await fetch(BACKEND + '/api/files/' + fileId + '/download', { headers: { 'X-Session-Id': QA.sid } })).arrayBuffer())
+    const tmp = path.join(os.tmpdir(), 'desktop-e2e-doc.docx')
+    fs.writeFileSync(tmp, buf)
+    const text = execSync('unzip -p "' + tmp + '" word/document.xml | sed "s/<[^>]*>//g"').toString()
+    if (!text.includes(MARKER)) throw new Error('docx 中未找到标记（保存链路断）；大小=' + buf.length)
+    console.log('    docx ' + buf.length + ' 字节，标记命中')
+  })
+} finally {
+  try { await api('/api/projects/' + QA.projectId, { method: 'DELETE' }) } catch {}
+  try { browser.disconnect() } catch {}
+  elec.kill('SIGTERM')
+  await sleep(1500)
+  try { elec.kill('SIGKILL') } catch {}
+}
+console.log(failed ? '\n结果：' + failed + ' 步失败 ❌' : '\n结果：桌面保存链路全通 ✅')
+process.exit(failed ? 1 : 0)

--- a/scripts/qa-nightly.sh
+++ b/scripts/qa-nightly.sh
@@ -1,0 +1,91 @@
+#!/bin/zsh
+# 每日全量 QA / daily QA run — 由用户 crontab 经 ~/aiworkdeck-qa/run.sh 调起。
+# 在专用克隆（~/aiworkdeck-qa/repo）上跑，绝不碰维护者的工作 checkout。
+#
+# 跑什么：
+#   1) tests/lowa-e2e  —— 真实 LOWA 引擎 + 覆盖层键盘链路（自包含，必跑）
+#   2) tests/app-e2e   —— 全应用真人模拟（需桌面后端 9696 在跑；不在则跳过并注明）
+# 产出：~/aiworkdeck-qa/reports/YYYY-MM-DD.md；有失败时用 gh 开 issue（标签 qa-nightly）。
+#
+# 引擎来源：打包版 /Applications/AI Workdeck.app 内置的 lowa/ + cjk 字体（离线、稳定，
+# 免 CDN；build:zetaoffice 会清空 dist，故引擎复制必须在 build 之后）。
+
+set -u
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+QA_HOME="$HOME/aiworkdeck-qa"
+REPO="$QA_HOME/repo"
+REPORTS="$QA_HOME/reports"
+APP_RES="/Applications/AI Workdeck.app/Contents/Resources/frontend/dist/zetaoffice"
+DAY=$(date +%F)
+REPORT="$REPORTS/$DAY.md"
+PORT=5199
+mkdir -p "$REPORTS"
+
+FAILED=0
+log() { echo "$(date +%T) $*" }
+section() { echo "\n## $*" >> "$REPORT" }
+
+echo "# AI Workdeck 每日 QA — $DAY" > "$REPORT"
+
+# ---- 更新专用克隆 ----
+if [[ ! -d "$REPO/.git" ]]; then
+  git clone --depth 20 https://github.com/zeweihan/aiworkdeck.git "$REPO" || { echo "clone 失败" >> "$REPORT"; exit 1 }
+fi
+cd "$REPO"
+git fetch origin master --depth 20 && git reset --hard origin/master >> /dev/null
+echo "commit: $(git log -1 --format='%h %s')" >> "$REPORT"
+
+# ---- 前端依赖与构建 ----
+cd "$REPO/frontend"
+npm install --no-audit --no-fund --loglevel=error > /dev/null 2>&1
+npx vite build --config vite.zetaoffice.config.js > /dev/null 2>&1 || { echo "build:zetaoffice 失败" >> "$REPORT"; FAILED=1 }
+
+# ---- 引擎：从打包版复制（build 之后！）----
+if [[ -f "$APP_RES/lowa/soffice.js" ]]; then
+  cp -R "$APP_RES/lowa" dist/zetaoffice/
+  cp "$APP_RES/cjk.ttc" dist/zetaoffice/ 2>/dev/null
+else
+  echo "⚠️ 打包版引擎缺失（$APP_RES），lowa-e2e 跳过" >> "$REPORT"
+fi
+
+# ---- 1) LOWA 编辑器键盘链路 ----
+section "lowa-e2e（编辑器键盘/IME 链路）"
+if [[ -f dist/zetaoffice/lowa/soffice.js ]]; then
+  if npm run test:lowa-e2e > "$QA_HOME/lowa-e2e.log" 2>&1; then
+    tail -3 "$QA_HOME/lowa-e2e.log" >> "$REPORT"
+  else
+    FAILED=1
+    echo '```' >> "$REPORT"; tail -30 "$QA_HOME/lowa-e2e.log" >> "$REPORT"; echo '```' >> "$REPORT"
+  fi
+else
+  echo "跳过（无引擎）" >> "$REPORT"
+fi
+
+# ---- 2) 全应用真人模拟（需 9696）----
+section "app-e2e（全应用真人模拟）"
+if nc -z 127.0.0.1 9696 2>/dev/null; then
+  (npx uni --port $PORT > "$QA_HOME/dev.log" 2>&1 &)
+  DEV_PID=$!
+  sleep 25
+  if APP_E2E_BASE="http://127.0.0.1:$PORT" npm run test:app-e2e > "$QA_HOME/app-e2e.log" 2>&1; then
+    tail -3 "$QA_HOME/app-e2e.log" >> "$REPORT"
+  else
+    FAILED=1
+    echo '```' >> "$REPORT"; tail -40 "$QA_HOME/app-e2e.log" >> "$REPORT"; echo '```' >> "$REPORT"
+  fi
+  pkill -f "uni --port $PORT" 2>/dev/null
+else
+  echo "跳过：桌面后端 9696 未运行（打开 AI Workdeck 后自动恢复覆盖）" >> "$REPORT"
+fi
+
+# ---- 汇报 ----
+if [[ $FAILED -ne 0 ]]; then
+  echo "\n**结论：有失败 ❌**" >> "$REPORT"
+  gh issue create -R zeweihan/aiworkdeck \
+    --title "每日 QA 失败 $DAY / nightly QA failures" \
+    --body-file "$REPORT" --label bug 2>> "$REPORT" || true
+else
+  echo "\n**结论：全部通过 ✅**" >> "$REPORT"
+fi
+exit $FAILED


### PR DESCRIPTION
按维护者四项授权（用便宜模型测 AI / 推进 Electron 链路 / computer-use / 每日 routine）落地三件：

## 1. AI 对话旅程（app-e2e 新增,29 项全过）
- 真 UI 打字发送,走默认 **deepseek-v4-flash**（$0.09/M tokens,单条成本≈0.01分;`AI_E2E=0` 跳过）
- 断言:流式回复落气泡 + `/api/ai/history` 轮次落库（PR#153 回归）

## 2. 桌面保存链路 e2e（`npm run test:desktop-e2e`,真机跑通）
dev Electron + CDP 打通浏览器目标够不到的一条关键链:
新建 Word → webview 内**真实引擎** boot → 宿主执行器插入标记 → **点保存按钮** → `已保存` → API 下载 docx 验证标记真落盘（5148 字节命中）。

关键坑（已注释）:keepalive 池（PR#159）的 webview 是命令式创建、元素上无 `__vueParentComponent`,必须从 Vue 组件树根 DFS 找 `saveDocument` 组件。

## 3. 每日定时 QA（`scripts/qa-nightly.sh`）
用户 crontab 经 `~/aiworkdeck-qa/run.sh` 引导,每日在**专用克隆**上自动更新并跑 lowa-e2e + app-e2e（后端 9696 在跑时）,报告写 `~/aiworkdeck-qa/reports/YYYY-MM-DD.md`,**有失败自动开 GitHub issue**。desktop-e2e 会弹窗,不进每日,按需跑。

docs/QA_JOURNEYS.md 覆盖状态同步更新（AI 对话/保存链路/新建 Word 转 ✅）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)