### PR TITLE
chore(release): v0.7.7

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号 0.7.6 → 0.7.7。本版核心（PR #165，另含 #166-#168 编辑器快捷键/删除键修复与 QA 套件）：

- **Word 自动实时保存**：移除手动保存按钮，修改即自动落盘（防抖 2.5s / 连续输入 15s 必存），关标签、切换文档前都会先保存
- **压缩包支持**：zip/7z/rar 打开即预览内部文件列表，一键解压到资源管理器（中文文件名、嵌套目录、重名自动编号）
- **预览修复**：pptx 前端渲染（原来打不开）、PDF 高保真原生渲染（原来乱码）、视频播放修复（原来必失败）

合并后打 tag v0.7.7 触发 desktop-build 出包。

🤖 Generated with [Claude Code](https://claude.com/claude-code)