### PR TITLE
AI 面板体验五连修：工具卡片分组、条款识别、页边修订、搜索配置、超限一键继续

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AdminConfigController.java
+++ b/backend/src/main/java/com/checkba/controller/AdminConfigController.java
@@ -99,6 +99,10 @@ public class AdminConfigController {
     @Value("${external.pkulaw.token:}")
     private String defaultPkulawToken;
 
+    // 博查搜索默认值（search_web 工具使用；与 WebTools 的 bocha.api.key 同源）
+    @Value("${bocha.api.key:}")
+    private String defaultBochaApiKey;
+
     // ElevenLabs 默认值
     @Value("${external.elevenlabs.api-key:}")
     private String defaultElevenLabsApiKey;
@@ -146,6 +150,9 @@ public class AdminConfigController {
 
     // PKULaw
     private static final String KEY_PKULAW_TOKEN = "external.pkulaw.token";
+
+    // 博查搜索（Bocha AI）
+    private static final String KEY_BOCHA_API_KEY = "external.bocha.apiKey";
 
     // ElevenLabs
     private static final String KEY_ELEVENLABS_API_KEY = "external.elevenlabs.apiKey";
@@ -197,6 +204,9 @@ public class AdminConfigController {
 
         // PKULaw
         defaults.put(KEY_PKULAW_TOKEN, defaultPkulawToken);
+
+        // 博查搜索
+        defaults.put(KEY_BOCHA_API_KEY, defaultBochaApiKey);
 
         // ElevenLabs
         defaults.put(KEY_ELEVENLABS_API_KEY, defaultElevenLabsApiKey);
@@ -253,6 +263,9 @@ public class AdminConfigController {
         ));
         external.setPkulaw(new PkulawConfig(
                 all.get(KEY_PKULAW_TOKEN)
+        ));
+        external.setBocha(new BochaConfig(
+                all.get(KEY_BOCHA_API_KEY)
         ));
         external.setElevenLabs(new ElevenLabsConfig(
                 all.get(KEY_ELEVENLABS_API_KEY),
@@ -394,6 +407,9 @@ public class AdminConfigController {
             if (ext.getPkulaw() != null) {
                 updates.put(KEY_PKULAW_TOKEN, safe(ext.getPkulaw().getToken()));
             }
+            if (ext.getBocha() != null) {
+                updates.put(KEY_BOCHA_API_KEY, safe(ext.getBocha().getApiKey()));
+            }
             if (ext.getElevenLabs() != null) {
                 updates.put(KEY_ELEVENLABS_API_KEY, safe(ext.getElevenLabs().getApiKey()));
                 updates.put(KEY_ELEVENLABS_BASE_URL, safe(ext.getElevenLabs().getBaseUrl()));
@@ -477,6 +493,7 @@ public class AdminConfigController {
         private TushareConfig tushare;
         private AliyunOcrConfig aliyunOcr;
         private PkulawConfig pkulaw;
+        private BochaConfig bocha;
         private ElevenLabsConfig elevenLabs;
 
         public GoogleConfig getGoogle() { return google; }
@@ -491,6 +508,8 @@ public class AdminConfigController {
         public void setAliyunOcr(AliyunOcrConfig aliyunOcr) { this.aliyunOcr = aliyunOcr; }
         public PkulawConfig getPkulaw() { return pkulaw; }
         public void setPkulaw(PkulawConfig pkulaw) { this.pkulaw = pkulaw; }
+        public BochaConfig getBocha() { return bocha; }
+        public void setBocha(BochaConfig bocha) { this.bocha = bocha; }
         public ElevenLabsConfig getElevenLabs() { return elevenLabs; }
         public void setElevenLabs(ElevenLabsConfig elevenLabs) { this.elevenLabs = elevenLabs; }
     }
@@ -589,6 +608,14 @@ public class AdminConfigController {
         public PkulawConfig(String token) { this.token = token; }
         public String getToken() { return token; }
         public void setToken(String token) { this.token = token; }
+    }
+
+    public static class BochaConfig {
+        private String apiKey;
+        public BochaConfig() {}
+        public BochaConfig(String apiKey) { this.apiKey = apiKey; }
+        public String getApiKey() { return apiKey; }
+        public void setApiKey(String apiKey) { this.apiKey = apiKey; }
     }
 
     public static class ElevenLabsConfig {

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -320,11 +320,12 @@ public class AgentOrchestrator {
         if (depth > MAX_LOOP_DEPTH) {
             // 步数预算耗尽：不是报错，而是"存档 + 请示"——保存进度、明确告知用户、干净收尾。
             log.warn("Agent loop reached max depth {} for conversation {}, stopping gracefully", MAX_LOOP_DEPTH, conversationId);
-            String notice = "\n\n> ⚠️ 本轮已达最大执行步数（" + MAX_LOOP_DEPTH + " 步），先暂停。已完成的修改均已生效，回复\"继续\"可接着执行剩余任务。";
+            String notice = "\n\n> ⚠️ 本轮已达最大执行步数（" + MAX_LOOP_DEPTH + " 步），先暂停。已完成的修改均已生效，点击下方「继续」按钮可接着执行剩余任务。";
             sendTextDelta(conversationId, notice);
             String persisted = (executionLog.length() > 0 ? executionLog.toString() : "") + notice;
             saveAssistantMessage(conversationId, projectId, userId, persisted);
-            sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"finished\"}");
+            // status=paused 让前端渲染一键「继续」按钮（区别于 finished 的正常收尾）
+            sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"paused\",\"reason\":\"max_depth\"}");
             sseEmitterService.close(conversationId);
             clearCancelledState(conversationId);
             return;

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -523,6 +523,21 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
+    @ToolMeta(displayName = "识别合同条款", category = "document")
+    @Tool("【看】识别合同/协议的条款结构。按「第X条 / 第X章 / 一、二、」等编号文本把段落归并成条款，" +
+          "返回每条条款的编号、标题和段落范围（startParagraph~endParagraph）。" +
+          "统计条款数、按条款定位或修订时必须先用本工具，禁止把段落数/行数当条款数。" +
+          "拿到段落范围后可用 doc_get_document_text(startParagraph) 精读某条条款。")
+    public String doc_get_clauses() {
+        log.info("Tool: doc_get_clauses called");
+        try {
+            return editorBridgeService.executeEditorCommand("get_clauses", null);
+        } catch (Exception e) {
+            log.error("Failed to get clauses", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
     @Tool("【看】查看当前光标/选区周围的文本（选中内容、前后文、所在段落）。在插入或格式化之前先确认光标位置。")
     public String doc_get_cursor_context() {
         log.info("Tool: doc_get_cursor_context called");

--- a/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
@@ -37,6 +37,11 @@ public class WebTools implements AgentToolComponent {
     @Value("${bocha.api.key:}")
     private String bochaApiKey;
 
+    // 桌面打包版不注入 BOCHA_API_KEY，环境变量默认为空；管理员可在设置页
+    // （external.bocha.apiKey）填 key，DB 值优先于环境变量/配置文件。
+    @org.springframework.beans.factory.annotation.Autowired
+    private com.checkba.service.SystemSettingService systemSettingService;
+
     private final OkHttpClient httpClient = new OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -49,8 +54,10 @@ public class WebTools implements AgentToolComponent {
     @Tool("Search the web using Bocha AI. Useful for finding latest news, regulations, or legal cases. Returns a summary of search results.")
     public String search_web(String query) {
         log.info("Tool: search_web called for query='{}'", query);
-        if (bochaApiKey == null || bochaApiKey.isBlank()) {
-            return "Error searching web: Bocha API key is not configured. Set BOCHA_API_KEY in your environment.";
+        String apiKey = systemSettingService.get("external.bocha.apiKey", bochaApiKey);
+        if (apiKey == null || apiKey.isBlank()) {
+            return "网络搜索未配置：缺少博查（Bocha AI）搜索的 API Key。请管理员在「设置 → 外部服务」中填写博查 API Key"
+                    + "（可在 bochaai.com 申请），保存后重试。本次已跳过网络搜索，请基于已有信息继续完成任务。";
         }
         try {
             // Build request body
@@ -66,7 +73,7 @@ public class WebTools implements AgentToolComponent {
             Request request = new Request.Builder()
                     .url(BOCHA_API_URL)
                     .post(RequestBody.create(requestBody, MediaType.parse("application/json")))
-                    .addHeader("Authorization", "Bearer " + bochaApiKey)
+                    .addHeader("Authorization", "Bearer " + apiKey)
                     .addHeader("Content-Type", "application/json")
                     .build();
 

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -409,7 +409,7 @@ for file_id in file_ids:
 2. **禁止重写 (No Re-creation)**: 禁止通过 `write_docx` 创建一个名为 "xxx(修订版).docx" 的新文件来替代修改。必须打开原文件进行修订。
 3. **修订模式默认开启**: 你的所有改动都以修订痕迹（redline）呈现，用户可逐条接受或拒绝。放心修改，不会破坏原文。
 4. **拟人式工作循环（必须遵守）**: **看 → 找 → 选 → 改 → 验**。
-   - **看**：先用 `doc_get_document_text` / `doc_get_outline` 了解文档，别盲改；
+   - **看**：先用 `doc_get_document_text` / `doc_get_outline` 了解文档，别盲改；处理合同/协议时**先用 `doc_get_clauses` 拿条款结构**——段落号≠条款号，一条条款往往横跨多个段落，禁止把段落数/行数当条款数；
    - **找**：用 `doc_find_text` 定位，**根据每个匹配的上下文（contextBefore/contextAfter/paragraph）确认哪一个才是目标**；
    - **选**：用 anchorId 选中目标（`doc_select_anchor`），用户看得见你选了哪里；
    - **改**：替换/删除/插入/格式化；
@@ -425,7 +425,8 @@ for file_id in file_ids:
 | `doc_open_file(fileId)` | 打开指定文档进行编辑 |
 | `doc_search_related_docs(keyword, projectId)` | 搜索项目中可能需要修改的相关文档 |
 | `doc_get_document_text(startParagraph, maxParagraphs)` | **首选**：分段读取全文（带段落编号和标题级别），长文档分页读 |
-| `doc_get_outline()` | 获取文档大纲结构 |
+| `doc_get_clauses()` | **合同/协议必用**：按「第X条/第X章/一、」编号识别条款结构，返回每条条款的段落范围；数条款、按条款修订都以它为准 |
+| `doc_get_outline()` | 获取文档大纲结构（只认标题样式，合同条款请用 `doc_get_clauses`） |
 | `doc_get_selection()` | 获取用户当前选中的文本 |
 | `doc_get_cursor_context()` | 查看光标周围的文本（前后文、所在段落） |
 | `doc_get_paragraph(paragraphIndex)` | 获取指定段落的内容（0 开始） |

--- a/frontend/src/components/AgentMessage/ProcessCard.vue
+++ b/frontend/src/components/AgentMessage/ProcessCard.vue
@@ -75,10 +75,9 @@
                 />
             </div>
 
-            <!-- CASE 3: Tool Execution -->
-            <div v-else-if="item.type === 'tool'" class="tool-row">
+            <!-- CASE 3: Tool Execution（单行：人性化名称 + 状态；原始代号收进 title 提示） -->
+            <div v-else-if="item.type === 'tool'" class="tool-row" :title="rawToolName(item.code)">
                 <div class="tool-content">
-                     <span class="tool-label">执行工具</span>
                      <span class="tool-name">{{ formatToolName(item.code) }}</span>
                 </div>
                 <div class="tool-status">
@@ -109,6 +108,7 @@
 import { computed, ref, watch } from 'vue'
 import ThinkingCard from './ThinkingCard.vue'
 import FileTypeIcon from '../FileTypeIcon.vue'
+import { toolDisplayName, toolRawName } from '@/utils/toolDisplayNames.js'
 
 const props = defineProps({
   process: { type: Object, required: true }
@@ -125,7 +125,14 @@ const isHeadless = computed(() => {
 })
 
 const processTitle = computed(() => {
-    return props.process.title || 'Processing...'
+    const t = props.process.title || 'Processing...'
+    // 模型偶尔把 process 命名成笼统的「工具执行」——与内部的「执行工具 xxx」行
+    // 冗余（用户反馈）。此时直接用第一个工具的人性化名称当标题。
+    if (t === '工具执行' || t === 'Processing...' || t === 'Tool Execution') {
+        const firstTool = (props.process.items || []).find(it => it.type === 'tool' && it.code)
+        if (firstTool) return toolDisplayName(firstTool.code)
+    }
+    return t
 })
 
 const isFinished = computed(() => {
@@ -156,13 +163,11 @@ watch(() => props.process.items?.length, (newLen, oldLen) => {
 
 const formatToolName = (code) => {
     if (!code) return 'Tool Call'
-    if (code.includes('read_document')) return '读取文档'
-    if (code.includes('write_docx')) return '撰写文档'
-    if (code.includes('pptx_generate')) return '生成幻灯片'
-
-    const match = code.match(/^([\w_.]+)\(/)
-    return match ? match[1] : (code.length > 40 ? code.substring(0, 37) + '...' : code)
+    const name = toolDisplayName(code)
+    return name.length > 40 ? name.substring(0, 37) + '...' : name
 }
+
+const rawToolName = (code) => toolRawName(code)
 
 const detectFile = (text) => {
     if (!text) return null
@@ -389,17 +394,8 @@ const isSecondaryContent = (text) => {
     min-width: 0;
 }
 
-.tool-label {
-    font-size: 10px;
-    color: #6C757D;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    flex-shrink: 0;
-}
-
 .tool-name {
-    font-family: ui-monospace, SFMono-Regular, monospace;
-    font-size: 11px;
+    font-size: 12px;
     color: #1A5336;
     font-weight: 500;
     white-space: nowrap;

--- a/frontend/src/components/AgentMessage/RootBubble.vue
+++ b/frontend/src/components/AgentMessage/RootBubble.vue
@@ -29,13 +29,37 @@
             <!-- 2. Title -->
             <TitleCard v-if="bubble.title" :title="bubble.title" />
 
-            <!-- 3. Process Stream -->
+            <!-- 3. Process Stream（工具执行按 plan 步骤分组：最新步骤展开，旧步骤收起，
+                 避免整个面板被工具卡片刷满；无步骤归属的保持平铺） -->
             <div class="process-stream">
-               <ProcessCard
-                 v-for="proc in bubble.processes"
-                 :key="proc.id"
-                 :process="proc"
-               />
+               <template v-for="(group, gi) in processGroups" :key="group.key + '-' + gi">
+                  <div v-if="group.title" class="step-group">
+                     <div class="step-group-header" @click="toggleGroup(group.key, gi)">
+                        <span class="step-group-marker" :class="{ done: isGroupDone(group), error: groupHasError(group) }"></span>
+                        <span class="step-group-title">{{ group.title }}</span>
+                        <span class="step-group-count">{{ group.procs.length }}</span>
+                        <div class="step-chevron" :class="{ 'is-rotated': isGroupExpanded(group.key, gi) }">
+                           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                              <polyline points="6 9 12 15 18 9"></polyline>
+                           </svg>
+                        </div>
+                     </div>
+                     <div v-show="isGroupExpanded(group.key, gi)" class="step-group-body">
+                        <ProcessCard
+                          v-for="proc in group.procs"
+                          :key="proc.id"
+                          :process="proc"
+                        />
+                     </div>
+                  </div>
+                  <template v-else>
+                     <ProcessCard
+                       v-for="proc in group.procs"
+                       :key="proc.id"
+                       :process="proc"
+                     />
+                  </template>
+               </template>
             </div>
 
             <!-- 4. Artifacts -->
@@ -59,11 +83,23 @@
                <MarkdownPreview :content="bubble.content" />
             </div>
 
-            <!-- 5b. Message Actions（旧 UI 的插入/替换/导出，ChatInterface 重写时丢失后恢复） -->
+            <!-- 5b. Message Actions：插入/替换/导出收进一个图标，点开再选（用户反馈三个
+                 平铺按钮太占地方）。菜单向上弹，透明遮罩点外即收。 -->
             <div v-if="bubble.content && !bubble.isStreaming" class="message-actions">
-               <span class="msg-act-btn primary" @click="sendAction('insert')">插入当前文档</span>
-               <span class="msg-act-btn" @click="sendAction('replace')">替换选区</span>
-               <span class="msg-act-btn" @click="sendAction('export')">导出为Word</span>
+               <div class="msg-act-trigger" :class="{ active: showActions }" @click.stop="showActions = !showActions">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                     <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path>
+                     <polyline points="14 2 14 8 20 8"></polyline>
+                     <line x1="9" y1="15" x2="15" y2="15"></line>
+                  </svg>
+                  <span>用到文档</span>
+               </div>
+               <div v-if="showActions" class="msg-act-menu">
+                  <div class="msg-act-item" @click="pickAction('insert')">插入当前文档</div>
+                  <div class="msg-act-item" @click="pickAction('replace')">替换选区</div>
+                  <div class="msg-act-item" @click="pickAction('export')">导出为Word</div>
+               </div>
+               <div v-if="showActions" class="msg-act-mask" @click.stop="showActions = false"></div>
             </div>
 
             <!-- 6. Walkthrough (Summary) - Temporarily hidden as per user request -->
@@ -80,7 +116,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import ThinkingCard from './ThinkingCard.vue'
 import TitleCard from './TitleCard.vue'
 import ProcessCard from './ProcessCard.vue'
@@ -98,6 +134,45 @@ const emit = defineEmits(['open-artifact-tab', 'approve', 'message-action'])
 function sendAction(type) {
   emit('message-action', { type, msg: { content: props.bubble.content } })
 }
+
+const showActions = ref(false)
+function pickAction(type) {
+  showActions.value = false
+  sendAction(type)
+}
+
+// ---- 工具执行按 plan 步骤分组 ----
+// process 在创建时被 useAgentStream 打上 stepIndex/stepTitle（当时 in_progress 的
+// plan 项）。这里把相邻同步骤的 process 收进一个可折叠组；历史消息没有该标记，
+// 落入 key='' 的平铺组，渲染不变。
+const processGroups = computed(() => {
+  const groups = []
+  let cur = null
+  for (const p of props.bubble.processes) {
+    const grouped = typeof p.stepIndex === 'number' && p.stepIndex >= 0
+    const key = grouped ? `s${p.stepIndex}` : ''
+    if (!cur || cur.key !== key) {
+      cur = { key, title: grouped ? (p.stepTitle || `步骤 ${p.stepIndex + 1}`) : '', procs: [] }
+      groups.push(cur)
+    }
+    cur.procs.push(p)
+  }
+  return groups
+})
+
+// 默认只展开最新一组（正在进行的步骤）；用户手动开合后以用户为准
+const groupToggles = ref({})
+const isGroupExpanded = (key, gi) => {
+  if (key in groupToggles.value) return groupToggles.value[key]
+  return gi === processGroups.value.length - 1
+}
+const toggleGroup = (key, gi) => {
+  groupToggles.value = { ...groupToggles.value, [key]: !isGroupExpanded(key, gi) }
+}
+const isGroupDone = (g) => g.procs.every(p =>
+  !(p.items || []).some(it => it.status === 'doing' || it.status === 'loading' || it.status === 'thinking')
+)
+const groupHasError = (g) => g.procs.some(p => (p.items || []).some(it => it.status === 'error'))
 
 const isReady = computed(() => {
     // Show full card if we have a Title OR Processes OR Main Content
@@ -172,14 +247,17 @@ const hasContent = computed(() => {
 }
 
 .message-actions {
+  position: relative;
   display: flex;
-  gap: 8px;
   padding: 8px 16px 12px;
   border-top: 1px solid #f1f5f9;
   margin-top: 6px;
 }
 
-.msg-act-btn {
+.msg-act-trigger {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   font-size: 12px;
   padding: 3px 10px;
   border-radius: 5px;
@@ -191,16 +269,114 @@ const hasContent = computed(() => {
   user-select: none;
 }
 
-.msg-act-btn:hover {
+.msg-act-trigger:hover, .msg-act-trigger.active {
   border-color: #5BD197;
   color: #1A5336;
   background: #E6F9F0;
 }
 
-.msg-act-btn.primary {
-  border-color: rgba(91, 209, 151, 0.5);
+.msg-act-menu {
+  position: absolute;
+  left: 16px;
+  bottom: calc(100% - 2px);
+  background: #FFFFFF;
+  border: 1px solid #E9ECEF;
+  border-radius: 8px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.10);
+  padding: 4px;
+  z-index: 99;
+  min-width: 140px;
+}
+
+.msg-act-item {
+  font-size: 12px;
+  color: #2C3338;
+  padding: 6px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.msg-act-item:hover {
+  background: #E6F9F0;
   color: #1A5336;
-  background: rgba(91, 209, 151, 0.08);
+}
+
+.msg-act-mask {
+  position: fixed;
+  inset: 0;
+  z-index: 98;
+  background: transparent;
+}
+
+/* ---- plan 步骤分组 ---- */
+.step-group {
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.step-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.step-group-header:hover {
+  background: #F8F9FA;
+}
+
+.step-group-marker {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #ADB5BD;
+  flex-shrink: 0;
+}
+
+.step-group-marker.done {
+  background: #5BD197;
+}
+
+.step-group-marker.error {
+  background: #E74C3C;
+}
+
+.step-group-title {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: #2C3338;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.step-group-count {
+  font-size: 10px;
+  color: #6C757D;
+  background: #F1F3F5;
+  border-radius: 99px;
+  padding: 0 6px;
+  flex-shrink: 0;
+}
+
+.step-chevron {
+  color: #ADB5BD;
+  transition: transform 0.2s ease;
+  display: flex;
+  align-items: center;
+}
+
+.step-chevron.is-rotated {
+  transform: rotate(180deg);
+}
+
+.step-group-body {
+  padding-left: 10px;
+  border-left: 2px solid #E6F9F0;
+  margin-left: 14px;
 }
 
 .main-content:deep(p) {

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -408,6 +408,11 @@
     <view v-else class="input-area-wrapper">
        <!-- Agent 任务清单常驻进度卡（todo_write 驱动，plan_update 事件更新） -->
        <TodoProgressCard :todos="planTodos" />
+       <!-- 步数超限暂停：一键继续，免得用户手动输入「继续」 -->
+       <view v-if="agentPaused && !isStreaming" class="continue-bar">
+          <text class="continue-hint">已达单轮执行步数上限，任务已暂停</text>
+          <view class="continue-btn" @tap="handleContinue">继续执行</view>
+       </view>
        <!-- NEW: File Changes & Token Usage Bar (Always visible) -->
        <view class="status-bar-row">
            <!-- Left: File Changes -->
@@ -580,6 +585,7 @@ export default {
       tokenUsage,
       fileChanges,
       planTodos,
+      agentPaused,
       rollbackToMessage,
       currentConversationId,
       loadConversationMetadata
@@ -1024,6 +1030,20 @@ export default {
         _userContextFiles: contextFilesToShow
       })
 
+      scrollToBottom()
+    }
+
+    // 步数超限后的一键续跑：等价于用户输入「继续」（后端 depth 归零重新起循环），
+    // 复用 sendMessage 的会话/模型/助手上下文。
+    const handleContinue = async () => {
+      if (isStreaming.value) return
+      await sendMessage({
+        prompt: '继续',
+        projectId: props.projectId,
+        modelId: currentModelId.value,
+        mode: currentModeId.value,
+        assistantId: props.currentAssistantId
+      })
       scrollToBottom()
     }
 
@@ -1821,6 +1841,9 @@ export default {
        fileChanges,
        // Agent 任务清单进度卡
        planTodos,
+       // 步数超限一键继续
+       agentPaused,
+       handleContinue,
        modifiedFiles,
        createdFiles,
        showModifiedPopup,
@@ -3133,6 +3156,40 @@ export default {
   color: #6C757D;
 }
 
+
+/* 步数超限一键继续条 */
+.continue-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 12px 6px;
+  padding: 6px 12px;
+  background: #FFF9E8;
+  border: 1px solid #F5DFA6;
+  border-radius: 8px;
+}
+
+.continue-hint {
+  font-size: 11px;
+  color: #8A6D1D;
+}
+
+.continue-btn {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #FFFFFF;
+  background: #1A5336;
+  border-radius: 6px;
+  padding: 4px 14px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.continue-btn:hover {
+  background: #14402A;
+}
 
 /* Status Bar Row (File Changes + Tokens) */
 .status-bar-row {

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -25,7 +25,7 @@ export const EDITOR_ACTIONS = [
   // perceive (get_document_text/get_cursor_context), position visibly
   // (select_paragraph/collapse_selection), edit (delete_selection), format
   // (format_selection/set_paragraph_format), recover (undo/redo).
-  'get_document_text', 'get_cursor_context', 'select_paragraph', 'collapse_selection',
+  'get_document_text', 'get_cursor_context', 'get_clauses', 'select_paragraph', 'collapse_selection',
   'delete_selection', 'format_selection', 'set_paragraph_format', 'undo', 'redo',
   // [spike/IME] implemented by the worker since Phase B but never whitelisted
   // (found by the primitive self-test: "Unknown action: move_cursor").

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -23,6 +23,9 @@ export function useAgentStream() {
     // STATE: Agent 任务清单（todo_write 驱动的常驻进度卡），plan_update 事件整表覆写
     const planTodos = ref([]) // Array of { content, activeForm, status }
 
+    // STATE: 步数超限暂停（bubble_end status=paused）——前端据此渲染一键「继续」按钮
+    const agentPaused = ref(null) // null | { reason }
+
     // POINTER: The current bubble we are writing to (Assistant)
     const currentAssistantBubble = ref(null)
 
@@ -95,6 +98,7 @@ export function useAgentStream() {
         tokenUsage.value = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
         // 切换会话时清空任务清单进度卡（重连后由后端 plan_update 恢复）
         planTodos.value = []
+        agentPaused.value = null
         // Clear bubble pointer (will be set fresh on next send)
         currentAssistantBubble.value = null
     }
@@ -205,6 +209,8 @@ export function useAgentStream() {
         }
         // Clear file changes for new turn
         fileChanges.value = []
+        // 新一轮开始即清除暂停态（无论是点「继续」还是发新消息）
+        agentPaused.value = null
 
         // 1. Add User Message with images and context files for display
         bubbles.value.push(createUserBubble(prompt, _userImages, _userContextFiles, contentHtml))
@@ -458,6 +464,13 @@ export function useAgentStream() {
             }
             // 终态收敛：流结束后不允许任何卡片停留在"执行中/加载中"
             finalizeProcesses(evt === 'error' ? 'error' : 'success')
+            // 步数超限暂停（后端 status=paused）：置位供 UI 渲染「继续」按钮
+            if (evt === 'bubble_end') {
+                try {
+                    const d = JSON.parse(dataStr || '{}')
+                    agentPaused.value = d.status === 'paused' ? { reason: d.reason || '' } : null
+                } catch (e) { agentPaused.value = null }
+            }
             // Ensure error is visible
             // 注意：错误必须写入 content（walkthrough 卡片当前未渲染，写那里用户永远看不到）
             if (evt === 'error') {
@@ -899,12 +912,19 @@ export function useAgentStream() {
 
                 const processTitle = attributes['name'] || 'Processing...'
 
+                // 归组到 plan 步骤：plan_update 与文本流在同一 SSE 流里按序到达，
+                // 新 process 打开那一刻的 in_progress 项就是它所属的步骤。
+                // （todo_write 自己所在的 process 会归到上一步/未分组，可接受。）
+                const stepIdx = planTodos.value.findIndex(t => t.status === 'in_progress')
+
                 bubble.processes.push({
                     id: pid,
                     title: processTitle,
                     isExpanded: true,
                     items: [], // CHANGED: from steps -> items
-                    content: ''
+                    content: '',
+                    stepIndex: stepIdx,
+                    stepTitle: stepIdx >= 0 ? (planTodos.value[stepIdx].content || '') : ''
                 })
                 activeProcessId = pid
                 activeTag = 'process'
@@ -1128,6 +1148,7 @@ export function useAgentStream() {
         backgroundTasks,
         lastHeartbeat,
         planTodos,
+        agentPaused,
         // Load metadata for historical conversations
         loadConversationMetadata: async (conversationId) => {
             if (!conversationId) return

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -225,6 +225,21 @@
                 </view>
               </view>
 
+              <!-- 博查搜索（AI 网络搜索工具） -->
+              <view class="provider-card">
+                <view class="provider-header">
+                  <text class="provider-name">博查搜索 (Bocha AI)</text>
+                </view>
+                <view class="form-row">
+                  <text class="form-label">API Key</text>
+                  <input
+                    v-model="form.external.bocha.apiKey"
+                    class="form-input"
+                    placeholder="AI 助手「网络搜索」所需，bochaai.com 申请"
+                  />
+                </view>
+              </view>
+
               <!-- ElevenLabs -->
               <view class="provider-card">
                 <view class="provider-header">
@@ -578,6 +593,7 @@ export default {
           tushare: { baseUrl: '', token: '' },
           aliyunOcr: { accessKeyId: '', accessKeySecret: '', endpoint: '', regionId: '', publicBaseUrl: '' },
           pkulaw: { token: '' },
+          bocha: { apiKey: '' },
           elevenLabs: { apiKey: '', baseUrl: '', modelId: '', defaultVoiceId: '' },
         },
         ai: {
@@ -780,6 +796,9 @@ export default {
             },
             pkulaw: {
               token: data.external.pkulaw?.token || '',
+            },
+            bocha: {
+              apiKey: data.external.bocha?.apiKey || '',
             },
             elevenLabs: {
               apiKey: data.external.elevenLabs?.apiKey || '',

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1272,6 +1272,7 @@ import {
   promptFeatureNotConfigured // 功能未配置统一引导（#18 T7）
 } from '@/services/api.js'
 import { getCurrentUser, getSessionId } from '@/utils/auth.js'
+import { markdownToPlainText } from '@/utils/markdownPlain.js'
 import { FILE_BATCH_ACTIONS, FILE_TREE_QUICK_ACTIONS } from '@/config/fileActions.js'
 import { WORKBENCH_TOOLS } from '@/config/tools.js'
 import { OCR_ACTION_LABELS, INTERNAL_LINK_SCHEMES, WPS_INTERNAL_HTTP_LINK_BASE } from '@/config/workbenchActions.js'
@@ -5992,7 +5993,8 @@ export default {
 
     insertAiMessageToDoc(message) {
       if (!message || !message.content) return
-      this.insertPlainTextToWps(message.content)
+      // AI 回复是 Markdown，纯文本原语会把 **、# 原样落字——先剥离标记
+      this.insertPlainTextToWps(markdownToPlainText(message.content))
     },
     async applyAiMessageToSelection(message) {
       if (!message || !message.content) return
@@ -6006,7 +6008,7 @@ export default {
           uni.showToast({ title: '请先在文档中选择要替换的内容', icon: 'none' })
           return
         }
-        await this.libreOfficeExecutor.executeCommand('replace_selection', { text: message.content })
+        await this.libreOfficeExecutor.executeCommand('replace_selection', { text: markdownToPlainText(message.content) })
         uni.showToast({ title: '已替换选区', icon: 'success' })
         return
       } catch (e) {

--- a/frontend/src/utils/markdownPlain.js
+++ b/frontend/src/utils/markdownPlain.js
@@ -1,0 +1,32 @@
+// markdownPlain.js — AI 回复（Markdown）落入文档前的纯文本化。
+//
+// 「插入当前文档 / 替换选区」走 LOWA 的纯文本原语（insert_at_cursor /
+// replace_selection），直接传原始 Markdown 会把 **、#、``` 等符号原样写进
+// 法律文书。这里只做符号剥离，不做富文本转换（导出 Word 走后端 flexmark，
+// 不经此函数）。
+export function markdownToPlainText(md) {
+  let s = String(md || '')
+  // 代码块围栏（保留围栏内文本）
+  s = s.replace(/^```[^\n]*$/gm, '')
+  // 标题前缀
+  s = s.replace(/^#{1,6}\s+/gm, '')
+  // 粗体/斜体/删除线/行内代码
+  s = s.replace(/\*\*([^*]+)\*\*/g, '$1')
+  s = s.replace(/__([^_]+)__/g, '$1')
+  s = s.replace(/\*([^*\n]+)\*/g, '$1')
+  s = s.replace(/(^|[^\w])_([^_\n]+)_(?=[^\w]|$)/g, '$1$2')
+  s = s.replace(/~~([^~]+)~~/g, '$1')
+  s = s.replace(/`([^`]+)`/g, '$1')
+  // 图片/链接：留可读文字
+  s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+  s = s.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+  // 引用块前缀
+  s = s.replace(/^\s*>\s?/gm, '')
+  // 列表符号：- * + 统一成中文常用的「• 」，有序列表保留编号
+  s = s.replace(/^(\s*)[-*+]\s+/gm, '$1• ')
+  // 分隔线
+  s = s.replace(/^\s*([-*_]\s?){3,}\s*$/gm, '')
+  // 折叠 3+ 连续空行
+  s = s.replace(/\n{3,}/g, '\n\n')
+  return s.trim()
+}

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -1,0 +1,122 @@
+// toolDisplayNames.js — 工具代号 → 人性化名称（按软件语言环境取 zh/en）。
+//
+// 卡片里的「search_web」「doc_open_file」对律师用户是噪音；这里维护一份与后端
+// @ToolMeta(displayName) 对齐的映射（后端元数据不随 SSE 下发，前端只能自备一份）。
+// 后端新增工具时同步补一行；未收录的代号按 snake_case → 空格分词兜底展示。
+// wps_* 是 doc_* 的灰度别名（PR#87），查表前先归一化。
+
+const NAMES = {
+  // 计划 / 项目
+  todo_write: { zh: '更新任务清单', en: 'Update plan' },
+  get_project_context: { zh: '获取项目信息', en: 'Get project context' },
+  update_project_info: { zh: '更新项目信息', en: 'Update project info' },
+  get_conversation_summary: { zh: '回顾会话记录', en: 'Recall conversation' },
+  list_project_folders: { zh: '列出项目文件夹', en: 'List folders' },
+  // 网络
+  search_web: { zh: '网络搜索', en: 'Web search' },
+  browse_url: { zh: '浏览网页', en: 'Browse page' },
+  deep_search: { zh: '深度检索', en: 'Deep search' },
+  search_knowledge_base: { zh: '搜索知识库', en: 'Search knowledge base' },
+  // 法律
+  law_search: { zh: '语义搜索法规', en: 'Search regulations' },
+  law_search_keyword: { zh: '关键词搜索法规', en: 'Keyword law search' },
+  law_recognition: { zh: '法条识别与溯源', en: 'Identify citations' },
+  get_law_article: { zh: '查询法条', en: 'Look up article' },
+  // 文件
+  read_document: { zh: '读取文档', en: 'Read document' },
+  search_project_files: { zh: '搜索项目文件', en: 'Search files' },
+  read_file: { zh: '读取文件', en: 'Read file' },
+  list_files: { zh: '列出文件', en: 'List files' },
+  write_file: { zh: '写入文件', en: 'Write file' },
+  write_docx: { zh: '生成Word文档', en: 'Create Word doc' },
+  scan_files: { zh: '扫描项目文件', en: 'Scan files' },
+  delete_file: { zh: '删除文件', en: 'Delete file' },
+  move_file: { zh: '移动文件', en: 'Move file' },
+  // 记忆
+  save_memory: { zh: '保存记忆', en: 'Save memory' },
+  query_memory: { zh: '检索记忆', en: 'Query memory' },
+  get_user_profile: { zh: '获取用户画像', en: 'Get user profile' },
+  // 子任务 / Python
+  dispatch_subtask: { zh: '委派子任务', en: 'Delegate subtask' },
+  run_python: { zh: '执行Python代码', en: 'Run Python' },
+  // 文档编辑（LibreOffice 拟人式原语）
+  doc_list_project_files: { zh: '列出可编辑文档', en: 'List documents' },
+  doc_open_file: { zh: '打开文档', en: 'Open document' },
+  doc_start_stream: { zh: '流式写入文档', en: 'Stream to document' },
+  doc_get_document_text: { zh: '通读文档', en: 'Read document text' },
+  doc_get_clauses: { zh: '识别合同条款', en: 'Map contract clauses' },
+  doc_get_outline: { zh: '获取文档大纲', en: 'Get outline' },
+  doc_get_selection: { zh: '读取选区', en: 'Read selection' },
+  doc_get_cursor_context: { zh: '查看光标位置', en: 'Inspect cursor' },
+  doc_get_paragraph: { zh: '读取段落', en: 'Read paragraph' },
+  doc_goto: { zh: '跳转光标', en: 'Move cursor' },
+  doc_set_selection: { zh: '设置选区', en: 'Set selection' },
+  doc_find_text: { zh: '查找定位', en: 'Find in document' },
+  doc_find_replace: { zh: '查找替换', en: 'Find & replace' },
+  doc_replace_nth_match: { zh: '替换指定匹配', en: 'Replace match' },
+  doc_delete_match: { zh: '删除匹配文本', en: 'Delete match' },
+  doc_delete_text: { zh: '删除文本', en: 'Delete text' },
+  doc_replace_selection: { zh: '替换选区', en: 'Replace selection' },
+  doc_insert_at_cursor: { zh: '插入文本', en: 'Insert text' },
+  doc_modify_paragraph: { zh: '修改段落', en: 'Edit paragraph' },
+  doc_insert_under_heading: { zh: '标题下插入', en: 'Insert under heading' },
+  doc_search_related_docs: { zh: '搜索相关文档', en: 'Find related docs' },
+  doc_select_anchor: { zh: '选中定位点', en: 'Select anchor' },
+  doc_select_paragraph: { zh: '选中段落', en: 'Select paragraph' },
+  doc_collapse_cursor: { zh: '收起光标', en: 'Collapse cursor' },
+  doc_replace_at_anchor: { zh: '锚点替换', en: 'Replace at anchor' },
+  doc_delete_selection: { zh: '删除选区', en: 'Delete selection' },
+  doc_format_selection: { zh: '设置文字格式', en: 'Format text' },
+  doc_set_paragraph_format: { zh: '设置段落格式', en: 'Format paragraph' },
+  doc_undo: { zh: '撤销修改', en: 'Undo' },
+  doc_redo: { zh: '重做修改', en: 'Redo' },
+  doc_debug_revisions: { zh: '检查修订记录', en: 'Inspect revisions' },
+  doc_restore_checkpoint: { zh: '恢复文档快照', en: 'Restore snapshot' },
+  // PPT
+  pptx_check_service: { zh: '检查PPT服务', en: 'Check PPT service' },
+  pptx_generate: { zh: '生成PPT演示文稿', en: 'Generate slides' },
+  pptx_generate_outline: { zh: '生成PPT大纲', en: 'Outline slides' },
+  pptx_refine_outline: { zh: '优化PPT大纲', en: 'Refine outline' },
+  pptx_smart_modify: { zh: '智能修改PPT', en: 'Modify slides' },
+  pptx_open_file: { zh: '打开PPT', en: 'Open slides' },
+  pptx_save: { zh: '保存PPT', en: 'Save slides' },
+  pptx_list_files: { zh: '列出PPT文件', en: 'List slide files' },
+  pptx_search_files: { zh: '搜索PPT文件', en: 'Search slide files' },
+  pptx_get_presentation_info: { zh: '读取PPT信息', en: 'Get slides info' },
+  pptx_get_project_pages: { zh: '读取PPT页面', en: 'Get slide pages' },
+  pptx_get_slide_content: { zh: '读取幻灯片内容', en: 'Read slide' },
+  pptx_get_page_screenshot: { zh: '截取幻灯片', en: 'Screenshot slide' },
+  pptx_get_selection: { zh: '读取PPT选区', en: 'Read slide selection' },
+  pptx_edit_page: { zh: '编辑幻灯片', en: 'Edit slide' },
+  pptx_insert_text: { zh: '插入PPT文本', en: 'Insert slide text' },
+  pptx_modify_slide_text: { zh: '修改幻灯片文本', en: 'Edit slide text' },
+  pptx_mark_delete_text: { zh: '标记删除文本', en: 'Mark text deletion' },
+  pptx_export_editable: { zh: '导出可编辑PPT', en: 'Export editable slides' },
+}
+
+function appLocale() {
+  try {
+    if (typeof uni !== 'undefined' && uni.getLocale) return uni.getLocale() || 'zh-CN'
+  } catch (e) { /* uni 不可用时退回浏览器语言 */ }
+  return (typeof navigator !== 'undefined' && navigator.language) || 'zh-CN'
+}
+
+// code 可以是纯工具名，也可以是 <tool_code> 里的 `tool_name({...})` 完整调用串。
+export function toolDisplayName(code) {
+  if (!code) return ''
+  const m = String(code).match(/^\s*([\w.]+)\s*\(/)
+  let name = m ? m[1] : String(code).trim()
+  if (name.startsWith('wps_')) name = 'doc_' + name.slice(4) // 灰度别名归一
+  const entry = NAMES[name]
+  if (entry) {
+    return appLocale().toLowerCase().startsWith('zh') ? entry.zh : entry.en
+  }
+  // 兜底：未收录的代号按 snake_case 分词，至少可读
+  return name.replace(/_/g, ' ')
+}
+
+export function toolRawName(code) {
+  if (!code) return ''
+  const m = String(code).match(/^\s*([\w.]+)\s*\(/)
+  return m ? m[1] : String(code).trim().split(/\s/)[0]
+}

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -233,6 +233,16 @@ function setCharProp(ps, base, value) {
   }
 }
 
+// LO 7.1+ (tdf#34355): tracked DELETIONS render in the page margin next to the
+// changed-line mark instead of inline strikethrough — the body stays readable
+// (original text + colored insertions only). This is a VIEW setting on the
+// controller, not the model, so it must be re-applied whenever the controller
+// changes (boot AND load_document retarget).
+function showDeletionsInMargin() {
+  try { ctrl.getViewSettings().setPropertyValue('ShowChangesInMargin', true); }
+  catch (e) { log('ShowChangesInMargin 设置失败 / failed: ' + errStr(e)); }
+}
+
 // ---- boot: open a fresh BLANK Writer doc ----------------------------------
 // Production: a brand-new / empty document must show a clean blank page (the
 // host loads real bytes via load_document when the file has content). We do NOT
@@ -249,6 +259,7 @@ function bootDoc() {
   // change the lawyer can accept/reject. Set once here (and on retarget) instead
   // of per-command, so no edit path can slip through untracked.
   try { xModel.setPropertyValue('RecordChanges', true); } catch {}
+  showDeletionsInMargin();
 
   installKeyHandler();
   try { installModifyListener(xModel); } catch (e) { log('XModifyListener 安装失败 / install failed: ' + errStr(e)); }
@@ -536,6 +547,56 @@ const EXEC = {
     }
     return { success: true, count: outline.length, outline: outline };
   },
+  // [感知] contract clause map — group paragraphs into legal clauses by their
+  // NUMBERING TEXT (第X条 / 第X章 / 一、), NOT by Word heading styles: contracts
+  // rarely use heading styles, which is why get_outline sees nothing there and
+  // the model degraded to counting paragraphs/lines as "clauses".
+  get_clauses() {
+    const RE_TIAO  = /^\s*第[一二三四五六七八九十百千零〇0-9１-９]+\s*条/;       // 第X条 — the clause proper
+    const RE_ZHANG = /^\s*第[一二三四五六七八九十百千零〇0-9１-９]+\s*[章节编]/;  // 第X章/节/编 — section above clauses
+    const RE_ENUM  = /^\s*[一二三四五六七八九十]{1,3}\s*、/;                      // 一、 二、 — top-level enum many contracts use
+    const marks = []; let total = 0;
+    eachParagraph(function (el, i) {
+      total = i + 1;
+      const t = el.getString() || '';
+      let type = null;
+      if (RE_TIAO.test(t)) type = 'tiao';
+      else if (RE_ZHANG.test(t)) type = 'zhang';
+      else if (RE_ENUM.test(t)) type = 'enum';
+      if (type) marks.push({ index: i, type: type, text: t });
+      return false;
+    });
+    // Granularity: 第X条 wins when present (一、 then is usually a sub-item);
+    // otherwise fall back to the 一、 enum as the clause level. 章/节 always kept.
+    const hasTiao = marks.some(function (m) { return m.type === 'tiao'; });
+    const boundaries = marks.filter(function (m) {
+      return m.type === 'zhang' || m.type === (hasTiao ? 'tiao' : 'enum');
+    });
+    const clauses = [];
+    for (let k = 0; k < boundaries.length && clauses.length < 300; k++) {
+      const b = boundaries[k];
+      const end = (k + 1 < boundaries.length) ? boundaries[k + 1].index - 1 : total - 1;
+      const line = b.text.trim();
+      const re = b.type === 'tiao' ? RE_TIAO : (b.type === 'zhang' ? RE_ZHANG : RE_ENUM);
+      const m = line.match(re);
+      clauses.push({
+        no: (m ? m[0] : line.slice(0, 8)).trim(),
+        type: b.type,
+        title: line.slice(0, 60),
+        startParagraph: b.index,
+        endParagraph: end,
+        paragraphCount: end - b.index + 1,
+      });
+    }
+    const firstBoundary = boundaries.length ? boundaries[0].index : total;
+    return {
+      success: true, totalParagraphs: total, clauseCount: clauses.length,
+      granularity: hasTiao ? '第X条' : (boundaries.length ? '一、二、…' : 'none'),
+      // 0..preambleParagraphs-1 = 首部（合同名称/当事人信息），不属于任何条款
+      preambleParagraphs: firstBoundary,
+      clauses: clauses,
+    };
+  },
   // [verified-extend] move the view cursor to doc start/end (line/para/bookmark nav = TODO anchor).
   goto(p) {
     const vc = ctrl.getViewCursor();
@@ -748,6 +809,7 @@ const EXEC = {
       try { installModifyListener(xModel); } catch (e) { log('XModifyListener 安装失败 / install failed: ' + errStr(e)); }
       // Revisions default ON for the real document too (same as bootDoc).
       try { xModel.setPropertyValue('RecordChanges', true); } catch (e) {}
+      showDeletionsInMargin();
     };
 
     const errs = [];

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -140,18 +140,22 @@ try {
     await focus()
   }
 
+  // NOTE: ShowChangesInMargin (tdf#34355) is ON since the margin-redlines change —
+  // tracked DELETIONS leave the inline text (they render in the page margin), so
+  // the cursor context no longer contains the struck-through originals. The old
+  // expectations (deleted chars still inline) date from inline-strikethrough mode.
   console.log('== 1) Backspace over pre-existing text (revision-mode jam regression #164) ==')
   await reset('合同条款abc') // inserted with rc OFF -> "original" text; rc back ON
   for (let i = 0; i < 3; i++) await key('Backspace', 'Backspace', 8)
   let c = await cursor()
-  check('3×Backspace 光标逐字越过原文', c.b === '合同条款' && c.a === 'abc', JSON.stringify(c))
+  check('3×Backspace 删除移入页边（正文不留）', c.b === '合同条款' && c.a === '', JSON.stringify(c))
 
   console.log('== 2) Delete key forward-deletes ==')
   await reset('合同条款abc')
   for (let i = 0; i < 3; i++) await key('ArrowLeft', 'ArrowLeft', 37)
   for (let i = 0; i < 2; i++) await key('Delete', 'Delete', 46)
   c = await cursor()
-  check('2×Delete 前删越过原文', c.b === '合同条款ab' && c.a === 'c', JSON.stringify(c))
+  check('2×Delete 前删移入页边（正文不留）', c.b === '合同条款' && c.a === 'c', JSON.stringify(c))
 
   console.log('== 3) IME CJK commit + Backspace hard-deletes own insert ==')
   await reset('')
@@ -230,6 +234,14 @@ try {
   const pu = await exec('ui_command', { name: 'page_up' })
   const pd = await exec('ui_command', { name: 'page_down' })
   check('PageUp/PageDown 命令可用', pu.success && pd.success)
+
+  console.log('== 9) get_clauses 条款识别（条款≠段落，一条横跨多段） ==')
+  await reset('技术服务合同\n第一条 服务内容\n乙方提供服务。\n具体范围双方另行约定。\n第二条 服务费用\n费用总计人民币10万元。\n第三条 违约责任\n任何一方违约应赔偿。', false)
+  const cl = await exec('get_clauses')
+  check('识别出 3 条条款（8 个段落）', cl.success && cl.clauseCount === 3 && cl.totalParagraphs === 8, JSON.stringify(cl))
+  check('第一条横跨 3 段', cl.clauses && cl.clauses[0] && cl.clauses[0].no === '第一条' && cl.clauses[0].paragraphCount === 3,
+    JSON.stringify(cl.clauses && cl.clauses[0]))
+  check('首部段落不计入条款', cl.preambleParagraphs === 1, JSON.stringify(cl.preambleParagraphs))
 
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
 } finally {


### PR DESCRIPTION
## 背景

用户实测反馈的 5 个问题（合同修订场景截图）：

1. 「工具执行」卡片标题与内部「执行工具 doc_open_file」冗余，代号不人性化，且工具卡片刷屏
2. 网络搜索工具报错
3. 条款识别不准，疑似把行数当条款数
4. 希望修订的删除内容显示在批注框/页边，正文只留原文+新增
5. 三个消息按钮太占地方；工具超限要手动输入「继续」

## 修复

### 1. 工具执行卡片（frontend）
- 工具行单行化，去掉「执行工具」前缀；新增 `utils/toolDisplayNames.js` 按语言环境（zh/en）显示人性化工具名，与后端 `@ToolMeta(displayName)` 对齐，`wps_*` 别名归一，原始代号收进 hover 提示
- **按 plan 步骤分组折叠**：`useAgentStream` 在 process 创建时打上当前 `in_progress` todo 标记（`plan_update` 与文本流同一 SSE 流内天然有序，零后端改动）；`RootBubble` 按步骤收组渲染，最新步骤展开、旧步骤自动收起；历史消息无标记时平铺不变

### 2. search_web 失败根因与修复（backend + admin 页）
根因：桌面打包版不注入 `BOCHA_API_KEY`，`bocha.api.key` 默认空串，必然报错。
- key 纳入系统设置 `external.bocha.apiKey`（DB 值优先于环境变量），管理页新增「博查搜索」配置卡
- 错误文案中文化：提示管理员去「设置 → 外部服务」配置

### 3. 条款识别（office_thread + backend 工具 + prompt）
根因：全栈只有「段落」粒度——`get_outline` 只认 Word 标题样式，而合同条款通常是正文样式，AI 数条款退化为数段落/行。
- 新增 `get_clauses` 原语：按「第X条 / 第X章 / 一、」编号文本把段落归并成条款，返回编号+标题+段落范围；`第X条` 存在时优先作条款粒度
- 后端暴露 `doc_get_clauses` 工具，system_prompt「看」步骤明确「合同必用、禁止段落数当条款数」

### 4. 修订页边显示（office_thread）
调研结论：LibreOffice 7.1+ 原生支持（tdf#34355，引擎 LO 24.2.8 满足）。启用 `ViewSettings.ShowChangesInMargin`：**删除的文字移入页边竖线旁，正文只保留原文+新增（带颜色）**。boot 与 load_document retarget 双点设置（view 级设置随 controller 重建失效）。

### 5. 消息按钮与一键继续（frontend + backend）
- 插入/替换/导出收成「用到文档」单图标 + 向上弹出菜单（透明遮罩点外收起）
- 三按钮链路验证均正常；同时修复实质缺陷：插入/替换先做 Markdown→纯文本清洗（`utils/markdownPlain.js`），不再把 `**`、`#` 落进文书
- 步数超限的 `bubble_end` 改发 `{"status":"paused","reason":"max_depth"}` 结构化标记，输入区上方渲染一键「继续执行」按钮

## 验证

| 套件 | 结果 |
|---|---|
| backend `mvn test`（JDK 21） | 259 通过 |
| `npm run check:emits` | 通过 |
| `npm run build:h5` | 通过 |
| `npm run test:lowa-e2e` | **25/25**（含新增 get_clauses 真机步骤；删除键断言同步到页边语义——删除字符确实移出正文，即 #4 真机生效证据） |
| `npm run test:app-e2e` | **29/29** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)