### PR TITLE
Agent 后台持续运行：会话运行状态机、切回自动续流、历史列表状态点

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -29,6 +29,7 @@ public class AiAgentController {
 
     private final com.checkba.service.ai.tools.PptxTools pptxTools;
     private final com.checkba.service.ai.TodoListService todoListService;
+    private final com.checkba.service.ai.AgentRunStateService agentRunStateService;
 
     @org.springframework.beans.factory.annotation.Autowired
     public AiAgentController(SseEmitterService sseEmitterService,
@@ -36,13 +37,15 @@ public class AiAgentController {
                             com.checkba.service.ProjectAiMessageService messageService,
                             com.checkba.service.ai.BackgroundTaskService backgroundTaskService,
                             com.checkba.service.ai.tools.PptxTools pptxTools,
-                            com.checkba.service.ai.TodoListService todoListService) {
+                            com.checkba.service.ai.TodoListService todoListService,
+                            com.checkba.service.ai.AgentRunStateService agentRunStateService) {
         this.sseEmitterService = sseEmitterService;
         this.agentOrchestrator = agentOrchestrator;
         this.messageService = messageService;
         this.backgroundTaskService = backgroundTaskService;
         this.pptxTools = pptxTools;
         this.todoListService = todoListService;
+        this.agentRunStateService = agentRunStateService;
     }
 
     /**
@@ -81,6 +84,13 @@ public class AiAgentController {
 
         // 重连后把当前任务清单重推给前端（常驻进度卡恢复）
         todoListService.resendToFrontend(conversationId);
+
+        // 告知前端此会话的运行状态（RUNNING=续流中 / PAUSED=渲染继续按钮 /
+        // AWAITING_APPROVAL=等审批 / null=本进程内没跑过）——切回会话重连时，
+        // 前端靠它决定展示「运行中」还是纯静态历史。
+        String runStatus = agentRunStateService.statusName(conversationId);
+        sseEmitterService.send(conversationId, "run_state",
+                "{\"status\":" + (runStatus == null ? "null" : "\"" + runStatus + "\"") + "}");
 
         return emitter;
     }

--- a/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
@@ -33,6 +33,7 @@ public class AiChatController {
     private final SystemSettingService systemSettingService;
     private final com.checkba.service.ai.ConversationFileChangeService conversationFileChangeService;
     private final com.checkba.repository.TokenUsageRepository tokenUsageRepository;
+    private final com.checkba.service.ai.AgentRunStateService agentRunStateService;
 
     public AiChatController(
             AiChatService aiChatService,
@@ -42,7 +43,8 @@ public class AiChatController {
             AiModelProperties aiModelProperties,
             SystemSettingService systemSettingService,
             com.checkba.service.ai.ConversationFileChangeService conversationFileChangeService,
-            com.checkba.repository.TokenUsageRepository tokenUsageRepository) {
+            com.checkba.repository.TokenUsageRepository tokenUsageRepository,
+            com.checkba.service.ai.AgentRunStateService agentRunStateService) {
         this.aiChatService = aiChatService;
         this.aiAssistantService = aiAssistantService;
         this.projectAiMessageService = projectAiMessageService;
@@ -51,6 +53,7 @@ public class AiChatController {
         this.systemSettingService = systemSettingService;
         this.conversationFileChangeService = conversationFileChangeService;
         this.tokenUsageRepository = tokenUsageRepository;
+        this.agentRunStateService = agentRunStateService;
     }
 
     @PostMapping("/chat")
@@ -94,7 +97,14 @@ public class AiChatController {
         if (sessionId != null) {
             userId = AuthController.getUserIdFromSession(sessionId);
         }
-        return projectAiMessageService.listConversations(projectId, userId);
+        java.util.List<Map<String, Object>> conversations = projectAiMessageService.listConversations(projectId, userId);
+        // 合并 Agent 运行状态（RUNNING/PAUSED/AWAITING_APPROVAL/…，null=本进程内没跑过），
+        // 历史列表的状态提示点靠它；在控制层合并，持久层不感知 AI 运行时。
+        for (Map<String, Object> conv : conversations) {
+            Object cid = conv.get("conversationId");
+            conv.put("runStatus", cid == null ? null : agentRunStateService.statusName(cid.toString()));
+        }
+        return conversations;
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -73,6 +73,7 @@ public class AgentOrchestrator {
     private final ConversationFileChangeService conversationFileChangeService;
     private final TodoListService todoListService;
     private final DocumentCheckpointService documentCheckpointService;
+    private final AgentRunStateService agentRunStateService;
 
     // ==================== 取消功能相关方法 ====================
 
@@ -129,6 +130,7 @@ public class AgentOrchestrator {
             log.info("Saved partial content ({} chars) for cancelled conversation: {}", partialContent.length(), conversationId);
         }
         
+        agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.CANCELLED);
         // 发送取消事件
         sseEmitterService.send(conversationId, "cancelled", "{\"message\":\"用户已停止生成\"}");
         sseEmitterService.close(conversationId);
@@ -217,6 +219,8 @@ public class AgentOrchestrator {
         cancelledConversations.remove(conversationId);
         activeStreamContent.put(conversationId, new StringBuilder());
         activeAssistantMessageId.remove(conversationId);
+        // 状态登记：循环开跑（会话列表状态点/切回续流判断都依赖它）
+        agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.RUNNING);
         
         try {
             log.info("Agent Loop Started: conv={}, model={}, mode={}, msg={}", conversationId, request.getModel(), agentMode, request.getMessage());
@@ -300,6 +304,7 @@ public class AgentOrchestrator {
             
         } catch (Exception e) {
             log.error("Agent Loop Error for conversation: " + conversationId, e);
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
             sseEmitterService.send(conversationId, "error", "Internal Error: " + e.getMessage());
             sseEmitterService.close(conversationId);
         }
@@ -324,6 +329,7 @@ public class AgentOrchestrator {
             sendTextDelta(conversationId, notice);
             String persisted = (executionLog.length() > 0 ? executionLog.toString() : "") + notice;
             saveAssistantMessage(conversationId, projectId, userId, persisted);
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.PAUSED);
             // status=paused 让前端渲染一键「继续」按钮（区别于 finished 的正常收尾）
             sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"paused\",\"reason\":\"max_depth\"}");
             sseEmitterService.close(conversationId);
@@ -334,6 +340,7 @@ public class AgentOrchestrator {
         // Ask 模式限制递归深度为 1（不允许工具调用后的循环）
         if (agentMode == AgentMode.ASK && depth > 0) {
             log.info("Ask mode: stopping loop at depth {}", depth);
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.FINISHED);
             sseEmitterService.send(conversationId, "bubble_end", "{}");
             sseEmitterService.close(conversationId);
             clearCancelledState(conversationId);
@@ -609,6 +616,7 @@ public class AgentOrchestrator {
                     // Save assistant message with execution log prepended
                     String fullContent = executionLog.length() > 0 ? executionLog.toString() + content : content;
                     saveAssistantMessage(conversationId, projectId, userId, fullContent);
+                    agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.AWAITING_APPROVAL);
                     // 发送 bubble_end 表示当前响应结束（等待用户审批）
                     sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"awaiting_approval\"}");
                     sseEmitterService.close(conversationId);
@@ -653,6 +661,7 @@ public class AgentOrchestrator {
             } catch (Exception memEx) {
                 log.warn("Failed to trigger memory pipeline for {}", conversationId, memEx);
             }
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.FINISHED);
             // 发送 bubble_end 表示整个循环真正结束
             sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"finished\"}");
             sseEmitterService.close(conversationId);
@@ -662,6 +671,7 @@ public class AgentOrchestrator {
           } catch (Exception e) {
             // 确保异常时也能正确结束 bubble，避免前端一直显示加载状态
             log.error("Error in onComplete callback for conversation: " + conversationId, e);
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
             sseEmitterService.send(conversationId, "error", "Callback Error: " + e.getMessage());
             sseEmitterService.close(conversationId);
             clearCancelledState(conversationId);
@@ -674,6 +684,7 @@ public class AgentOrchestrator {
 
         // 流式出错时的清理：关闭 emitter + 复位状态，避免 SSE 连接挂到超时、前端永久加载
         handler.setOnError(err -> {
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
             editorBridgeService.setStreamingMode(conversationId, false);
             // 保存已生成的部分内容，避免"当时看到了回复、历史里却没有"
             StringBuilder sb = activeStreamContent.get(conversationId);

--- a/backend/src/main/java/com/checkba/service/ai/AgentRunStateService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentRunStateService.java
@@ -1,0 +1,55 @@
+package com.checkba.service.ai;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 每会话 Agent 运行状态登记簿（内存态）。
+ *
+ * 背景：Agent 循环跑在 @Async 线程上，SSE 断开（用户切走会话）后循环继续执行，
+ * 但此前没有任何地方记录「哪个会话在跑 / 在等审批 / 已跑完」——会话列表因此
+ * 无法显示后台任务状态，前端切回会话也无从判断要不要重连续流。
+ *
+ * 状态仅在 JVM 存活期内有效：进程重启后循环本身已不存在，登记簿清零与事实一致
+ * （不会出现「显示运行中但循环已死」的僵尸状态）。
+ */
+@Service
+public class AgentRunStateService {
+
+    /** 会话运行状态。前端状态点依赖字面量，改名要同步 useAgentStream/历史列表。 */
+    public enum RunStatus {
+        /** 循环执行中 */
+        RUNNING,
+        /** 步数超限暂停，等用户点「继续」 */
+        PAUSED,
+        /** Plan 模式等用户审批 */
+        AWAITING_APPROVAL,
+        /** 正常跑完 */
+        FINISHED,
+        /** 异常终止 */
+        ERROR,
+        /** 用户主动取消 */
+        CANCELLED,
+    }
+
+    public record RunState(RunStatus status, long updatedAt) {}
+
+    private final Map<String, RunState> states = new ConcurrentHashMap<>();
+
+    public void mark(String conversationId, RunStatus status) {
+        if (conversationId == null) return;
+        states.put(conversationId, new RunState(status, System.currentTimeMillis()));
+    }
+
+    /** null = 本进程内从未跑过（历史会话），前端按「无任务」处理。 */
+    public RunState get(String conversationId) {
+        return conversationId == null ? null : states.get(conversationId);
+    }
+
+    public String statusName(String conversationId) {
+        RunState s = get(conversationId);
+        return s == null ? null : s.status().name();
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
@@ -162,7 +162,7 @@ public final class EvalHarness {
         AgentOrchestrator orchestrator = new AgentOrchestrator(
                 chatModelFactory, messageService, sse, tokenUsage, assembler,
                 registry, skillRouter, parser, memoryPipeline, projectFileService, editorBridge, fileChange,
-                todoListService, checkpointService);
+                todoListService, checkpointService, new com.checkba.service.ai.AgentRunStateService());
 
         AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
         request.setProjectId(1L);

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -220,6 +220,7 @@
           <view class="icon-btn" @tap="$emit('toggle-history')" title="History">
              <image class="btn-icon default" src="/static/history.png" />
              <image class="btn-icon hover" src="/static/history_hover.png" />
+             <view v-if="historyBadge" class="conv-dot header-dot" :class="historyBadge"></view>
           </view>
           <view class="icon-btn" @tap="startNewChat" title="New Chat">
              <image class="btn-icon default" src="/static/plus.png" />
@@ -393,6 +394,7 @@
           <view class="recent-history-header">近期对话</view>
           <view class="recent-history" v-if="recentHistory && recentHistory.length > 0">
              <view v-for="h in recentHistory" :key="h.id" class="history-item" @tap="$emit('load-history', h)">
+                <view v-if="recentDotClass(h)" class="conv-dot" :class="recentDotClass(h)"></view>
                 <text class="history-title">{{ cleanTitle(h.title) }}</text>
                 <text class="history-time">{{ formatRelativeTime(h.updatedAt) }}</text>
              </view>
@@ -555,6 +557,11 @@ export default {
       type: Array,
       default: () => []
     },
+    // 历史入口聚合状态点：'' | 'dot-attention' | 'dot-running' | 'dot-unread'（宿主计算）
+    historyBadge: {
+      type: String,
+      default: ''
+    },
     assistants: {
         type: Array,
         default: () => []
@@ -586,6 +593,8 @@ export default {
       fileChanges,
       planTodos,
       agentPaused,
+      agentRunStatus,
+      reattachSSE,
       rollbackToMessage,
       currentConversationId,
       loadConversationMetadata
@@ -1208,7 +1217,22 @@ export default {
           }
        })
 
+       // 后台续跑关键一步：切回会话时重连 SSE。后端 connect 会推 run_state
+       // （运行中还会推 state_recovery 全量续流 + plan_update 恢复任务清单），
+       // 已结束的会话则只是挂一条静默连接，不影响静态历史展示。
+       reattachSSE(conversationId)
+
        scrollToBottom()
+    }
+
+    // 近期对话列表的状态点（数据字段由宿主 fetchChatHistory 映射）
+    const recentDotClass = (h) => {
+       if (!h) return ''
+       if (h.runStatus === 'RUNNING') return 'dot-running'
+       if (h.runStatus === 'PAUSED' || h.runStatus === 'AWAITING_APPROVAL') return 'dot-attention'
+       if (h.runStatus === 'ERROR') return 'dot-error'
+       if (h.unread) return 'dot-unread'
+       return ''
     }
 
     const formatTime = (ts) => {
@@ -1757,6 +1781,8 @@ export default {
        formatTime,
        formatRelativeTime,
        cleanTitle,
+       recentDotClass,
+       agentRunStatus,
        addFile,
        removeContextFile,
        removePastedImage,
@@ -2103,6 +2129,33 @@ export default {
   border-radius: 4px; /* 减小圆角 */
   overflow: hidden;
   background: #fff;
+}
+
+/* 会话后台任务状态点（与宿主抽屉同一套视觉）：
+   动画绿=运行中、黄=等用户（暂停/待审批）、蓝=后台跑完未读、红=出错 */
+.conv-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+.conv-dot.dot-running { background: #5BD197; animation: conv-dot-pulse 1.2s ease-in-out infinite; }
+.conv-dot.dot-attention { background: #F5B60D; }
+.conv-dot.dot-unread { background: #3B82F6; }
+.conv-dot.dot-error { background: #E74C3C; }
+.conv-dot.header-dot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 7px;
+  height: 7px;
+  margin: 0;
+  border: 1px solid #ffffff;
+}
+@keyframes conv-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.8); }
 }
 
 .history-item {

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -26,6 +26,10 @@ export function useAgentStream() {
     // STATE: 步数超限暂停（bubble_end status=paused）——前端据此渲染一键「继续」按钮
     const agentPaused = ref(null) // null | { reason }
 
+    // STATE: 当前会话的后端运行状态（run_state/bubble_end 驱动）
+    // 'RUNNING' | 'PAUSED' | 'AWAITING_APPROVAL' | 'FINISHED' | 'ERROR' | 'CANCELLED' | null(无任务)
+    const agentRunStatus = ref(null)
+
     // POINTER: The current bubble we are writing to (Assistant)
     const currentAssistantBubble = ref(null)
 
@@ -99,6 +103,7 @@ export function useAgentStream() {
         // 切换会话时清空任务清单进度卡（重连后由后端 plan_update 恢复）
         planTodos.value = []
         agentPaused.value = null
+        agentRunStatus.value = null
         // Clear bubble pointer (will be set fresh on next send)
         currentAssistantBubble.value = null
     }
@@ -211,6 +216,7 @@ export function useAgentStream() {
         fileChanges.value = []
         // 新一轮开始即清除暂停态（无论是点「继续」还是发新消息）
         agentPaused.value = null
+        agentRunStatus.value = 'RUNNING'
 
         // 1. Add User Message with images and context files for display
         bubbles.value.push(createUserBubble(prompt, _userImages, _userContextFiles, contentHtml))
@@ -346,6 +352,30 @@ export function useAgentStream() {
             return
         }
 
+        // 会话运行状态（connect 时后端必发）：切回后台运行中的会话时，靠它恢复
+        // 「运行中/已暂停」的 UI 态。必须在气泡守卫之前——重连时气泡指针为 null。
+        if (evt === 'run_state') {
+            try {
+                const d = JSON.parse(dataStr)
+                agentRunStatus.value = d.status || null
+                if (d.status === 'RUNNING') {
+                    isStreaming.value = true // 后台在跑：封发送框，等续流
+                } else if (d.status === 'PAUSED') {
+                    agentPaused.value = { reason: 'max_depth' } // 切回后恢复「继续」按钮
+                }
+            } catch (e) {
+                console.error('Failed to parse run_state', e)
+            }
+            return
+        }
+
+        // 状态恢复（重连续流）：同样必须在气泡守卫之前——切回会话时
+        // currentAssistantBubble 为 null，处理器会自建/复用末尾 ASSISTANT 气泡。
+        if (evt === 'state_recovery') {
+            handleStateRecovery(dataStr)
+            return
+        }
+
         if (!currentAssistantBubble.value) return
 
         if (evt === 'text_delta') {
@@ -469,7 +499,11 @@ export function useAgentStream() {
                 try {
                     const d = JSON.parse(dataStr || '{}')
                     agentPaused.value = d.status === 'paused' ? { reason: d.reason || '' } : null
-                } catch (e) { agentPaused.value = null }
+                    agentRunStatus.value = d.status === 'paused' ? 'PAUSED'
+                        : d.status === 'awaiting_approval' ? 'AWAITING_APPROVAL' : 'FINISHED'
+                } catch (e) { agentPaused.value = null; agentRunStatus.value = 'FINISHED' }
+            } else {
+                agentRunStatus.value = 'ERROR'
             }
             // Ensure error is visible
             // 注意：错误必须写入 content（walkthrough 卡片当前未渲染，写那里用户永远看不到）
@@ -560,8 +594,26 @@ export function useAgentStream() {
             }
         }
 
-        // Handle state recovery (reconnection)
-        if (evt === 'state_recovery') {
+        // Handle File Changes (Added/Modified)
+        if (evt === 'file_change') {
+            try {
+                const d = JSON.parse(dataStr)
+                // d: { fileName: "...", changeType: "ADDED" | "MODIFIED" }
+                // Avoid duplicates?
+                const exists = fileChanges.value.some(f => f.fileName === d.fileName && f.changeType === d.changeType)
+                if (!exists) {
+                    fileChanges.value.push(d)
+                }
+                console.log('[AgentStream] File Change:', d)
+            } catch (e) {
+                console.error('Failed to parse file_change', e)
+            }
+        }
+    }
+
+    // 状态恢复（重连续流）：后端把本轮已生成的全量文本快照重放给前端。
+    // 从 handleEvent 内联块提出来，因为它必须在气泡守卫之前被调用（切回会话场景）。
+    const handleStateRecovery = (dataStr) => {
             try {
                 const d = JSON.parse(dataStr)
                 console.log('[SSE] State Recovery:', d.content.length, 'chars')
@@ -605,23 +657,6 @@ export function useAgentStream() {
             } catch (e) {
                 console.error('Failed to parse state_recovery', e)
             }
-        }
-
-        // Handle File Changes (Added/Modified)
-        if (evt === 'file_change') {
-            try {
-                const d = JSON.parse(dataStr)
-                // d: { fileName: "...", changeType: "ADDED" | "MODIFIED" }
-                // Avoid duplicates?
-                const exists = fileChanges.value.some(f => f.fileName === d.fileName && f.changeType === d.changeType)
-                if (!exists) {
-                    fileChanges.value.push(d)
-                }
-                console.log('[AgentStream] File Change:', d)
-            } catch (e) {
-                console.error('Failed to parse file_change', e)
-            }
-        }
     }
 
     const handleStepUpdate = (data) => {
@@ -1149,6 +1184,12 @@ export function useAgentStream() {
         lastHeartbeat,
         planTodos,
         agentPaused,
+        agentRunStatus,
+        // 切回会话时重连 SSE：后端 connect 会推 run_state（运行中还会推 state_recovery 续流）。
+        reattachSSE: async (conversationId) => {
+            if (!conversationId) return
+            try { await connectSSE(conversationId) } catch (e) { console.warn('[AgentStream] reattach failed', e) }
+        },
         // Load metadata for historical conversations
         loadConversationMetadata: async (conversationId) => {
             if (!conversationId) return

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -938,6 +938,7 @@
               :project-id="String(projectId)"
               :project-name="project.name"
               :recent-history="chatHistoryList.slice(0, 3)"
+              :history-badge="historyBadge"
               :assistants="assistants"
               v-model:current-assistant-id="currentAssistantId"
               :active-tab="currentActiveTab"
@@ -972,11 +973,15 @@
                     <view v-if="loadingHistory" class="menu-item" style="color:#999;">加载中...</view>
                     <view v-else-if="chatHistoryList.length === 0" class="menu-item" style="color:#999;">暂无历史记录</view>
                     <view v-else v-for="chat in chatHistoryList" :key="chat.id" class="menu-item" @tap="loadHistoryChat(chat)">
+                        <view v-if="convDotClass(chat)" class="conv-dot" :class="convDotClass(chat)"></view>
                         <view style="flex:1; overflow:hidden;">
                             <text class="item-title" style="display:block; font-size:13px; color:#333; margin-bottom:2px;">{{ chat.title || '未命名对话' }}</text>
                             <text class="item-preview" style="display:block; font-size:11px; color:#999; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{ chat.lastMessage }}</text>
                         </view>
-                        <text class="item-time" style="font-size:10px; color:#ccc; margin-left:8px;">{{ formatTime(chat.updatedAt) }}</text>
+                        <view style="display:flex; flex-direction:column; align-items:flex-end; margin-left:8px; flex-shrink:0;">
+                            <text class="item-time" style="font-size:10px; color:#ccc;">{{ formatTime(chat.updatedAt) }}</text>
+                            <text v-if="convStatusLabel(chat)" class="conv-status-label" :class="convDotClass(chat)">{{ convStatusLabel(chat) }}</text>
+                        </view>
                     </view>
                 </scroll-view>
             </view>
@@ -1400,6 +1405,10 @@ export default {
       loadingHistory: false,
       chatHistoryList: [],
       currentConversationId: null, // Added for tracking current session
+      // 后台任务状态点：上次轮询的 {conversationId: runStatus} 快照 + 跑完未读集合
+      convStatusSnapshot: {},
+      unreadConversations: [],
+      convStatusPollTimer: null,
       showAssistantMenu: false,
       currentAssistantId: 'default',
       showAssistantConfigDialog: false,
@@ -1556,6 +1565,14 @@ export default {
     }
   },
   computed: {
+    // 历史入口的聚合状态点：等用户操作(黄) > 运行中(绿) > 跑完未读(蓝)
+    historyBadge() {
+      const list = this.chatHistoryList || []
+      if (list.some(c => c.runStatus === 'PAUSED' || c.runStatus === 'AWAITING_APPROVAL')) return 'dot-attention'
+      if (list.some(c => c.runStatus === 'RUNNING' && c.conversationId !== this.currentConversationId)) return 'dot-running'
+      if (list.some(c => c.unread)) return 'dot-unread'
+      return ''
+    },
     // 桌面端：任一全屏蒙层/弹窗打开时为 true。BrowserView 是原生层，永远盖在
     // HTML 之上，所以弹窗期间必须隐藏 BrowserView，否则弹窗会被网页挡住"点了没反应"。
     desktopOverlayActive() {
@@ -1776,6 +1793,8 @@ export default {
     if (typeof window !== 'undefined' && window.__checkbaActiveOverviewVm === this) {
       window.__checkbaActiveOverviewVm = null
     }
+    // 后台任务状态轮询清理
+    if (this.convStatusPollTimer) { clearInterval(this.convStatusPollTimer); this.convStatusPollTimer = null }
     this.teardownResponsiveListener()
     // Epic #43: 解绑 ⌘⇧O 嵌入式编辑器监听
     try { if (this._zetaOpenEmbedUnsub) { this._zetaOpenEmbedUnsub(); this._zetaOpenEmbedUnsub = null } } catch (e) { /* ignore */ }
@@ -1983,6 +2002,13 @@ export default {
     // 处理，否则一次事件触发 N 份副作用（与 PR#148 剪贴板重复入库同源）
     if (typeof window !== 'undefined') window.__checkbaActiveOverviewVm = this
     this.setupResponsiveListener()
+    // 后台任务状态轮询：AI 面板打开时每 15s 刷一次会话状态（驱动历史列表状态点
+    // 与入口角标；quiet 模式不弹错误 toast、不动 loading 态）
+    this.convStatusPollTimer = setInterval(() => {
+      if (this.showAiPanel && this.projectId && this.isActiveOverviewInstance()) {
+        this.fetchChatHistory(true)
+      }
+    }, 15000)
     // Desktop：网页选中“加入网核收藏”（右键菜单触发）
     try {
       if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.onWebMark) {
@@ -6580,34 +6606,51 @@ export default {
       }
     },
 
-    async fetchChatHistory() {
+    async fetchChatHistory(quiet = false) {
       if (!this.projectId) return
-      this.loadingHistory = true
+      if (!quiet) this.loadingHistory = true
       // Note: Do NOT set showHistoryDrawer = true here
       // The drawer should only open when user clicks the toggle button (toggleHistoryDrawer)
       try {
           const res = await getAiConversations(this.projectId)
+          // 后台任务「跑完未读」检测：上次快照 RUNNING → 本次终态，且不是当前正看的
+          // 会话 → 记为未读（蓝点），点开该会话时清除
+          const prevStatuses = this.convStatusSnapshot || {}
+          for (const item of (res || [])) {
+              const cid = item.conversationId
+              if (!cid) continue
+              if (prevStatuses[cid] === 'RUNNING' && item.runStatus && item.runStatus !== 'RUNNING'
+                      && cid !== this.currentConversationId && !this.unreadConversations.includes(cid)) {
+                  this.unreadConversations.push(cid)
+              }
+          }
+          this.convStatusSnapshot = Object.fromEntries((res || []).filter(i => i.conversationId).map(i => [i.conversationId, i.runStatus]))
           // Map to display format
-          // Backend returns: [{conversationId, updatedAt, lastMessage}, ...]
+          // Backend returns: [{conversationId, updatedAt, lastMessage, runStatus}, ...]
           // We map to: { id, title, date }
           this.chatHistoryList = (res || []).map(item => ({
               id: item.conversationId,
               title: item.title ? item.title.replace(/<[^>]+>/g, '').trim() : (item.lastMessage ? (item.lastMessage.substring(0, 20) + (item.lastMessage.length > 20 ? '...' : '')) : '新对话'),
               updatedAt: item.updatedAt,
               lastMessage: item.lastMessage ? item.lastMessage.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').substring(0, 60) + (item.lastMessage.length > 60 ? '...' : '') : '',
-              conversationId: item.conversationId
+              conversationId: item.conversationId,
+              runStatus: item.runStatus || null,
+              unread: this.unreadConversations.includes(item.conversationId)
           }))
       } catch (e) {
         console.error('Fetch history failed', e)
-        uni.showToast({ title: '加载历史失败', icon: 'none' })
+        if (!quiet) uni.showToast({ title: '加载历史失败', icon: 'none' })
       } finally {
-        this.loadingHistory = false
+        if (!quiet) this.loadingHistory = false
       }
     },
 
     async loadHistoryChat(chat) {
         if (!chat || !chat.conversationId) return
         this.currentConversationId = chat.conversationId
+        // 点开即视为已读：清掉「后台跑完未读」蓝点
+        const unreadIdx = this.unreadConversations.indexOf(chat.conversationId)
+        if (unreadIdx >= 0) this.unreadConversations.splice(unreadIdx, 1)
         this.loadingHistory = true // Reuse loading state or local
         try {
             const msgs = await getAiHistory({
@@ -6638,6 +6681,25 @@ export default {
         } finally {
             this.loadingHistory = false
         }
+    },
+    // 会话状态 → 状态点样式类。黄=等用户（暂停/待审批）、蓝=后台跑完未读、
+    // 动画绿=运行中、红=出错；无任务/已读完成不打点。
+    convDotClass(chat) {
+        if (!chat) return ''
+        if (chat.runStatus === 'RUNNING') return 'dot-running'
+        if (chat.runStatus === 'PAUSED' || chat.runStatus === 'AWAITING_APPROVAL') return 'dot-attention'
+        if (chat.runStatus === 'ERROR') return 'dot-error'
+        if (chat.unread) return 'dot-unread'
+        return ''
+    },
+    convStatusLabel(chat) {
+        if (!chat) return ''
+        if (chat.runStatus === 'RUNNING') return '运行中'
+        if (chat.runStatus === 'PAUSED') return '待继续'
+        if (chat.runStatus === 'AWAITING_APPROVAL') return '待审批'
+        if (chat.runStatus === 'ERROR') return '出错'
+        if (chat.unread) return '已完成'
+        return ''
     },
     toggleAssistantMenu() {
         this.showAssistantMenu = !this.showAssistantMenu
@@ -7796,6 +7858,27 @@ $bg-white: #FFFFFF;
 .drawer-list {
     flex: 1;
     overflow-y: auto;
+}
+/* 会话后台任务状态点：动画绿=运行中、黄=等用户、蓝=跑完未读、红=出错 */
+.conv-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-right: 8px;
+}
+.conv-dot.dot-running { background: #5BD197; animation: conv-dot-pulse 1.2s ease-in-out infinite; }
+.conv-dot.dot-attention { background: #F5B60D; }
+.conv-dot.dot-unread { background: #3B82F6; }
+.conv-dot.dot-error { background: #E74C3C; }
+.conv-status-label { font-size: 10px; margin-top: 2px; }
+.conv-status-label.dot-running { color: #1A5336; background: transparent; animation: none; }
+.conv-status-label.dot-attention { color: #8A6D1D; background: transparent; }
+.conv-status-label.dot-unread { color: #3B82F6; background: transparent; }
+.conv-status-label.dot-error { color: #E74C3C; background: transparent; }
+@keyframes conv-dot-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.45; transform: scale(0.8); }
 }
 .drawer-item {
     padding: 12px;


### PR DESCRIPTION
## 需求

1. 切换对话时 Agent 未执行完应继续在后台运行
2. 状态提示点：黄=需要用户输入/审批，蓝=已运行完毕（未读）
3. 历史对话管理列表能看清后台任务状态，不让它们死掉

## 调研结论

「切走继续跑」**后端本来就成立**：循环跑在 `@Async` 线程、SSE 发送失败被 try-catch 吞掉、切会话只断前端流不发 cancel。真正缺的是三件事，本 PR 补齐：

| 缺口 | 修复 |
|---|---|
| 会话列表无运行状态 | 新增 `AgentRunStateService` 状态登记（编排器入口+全部终止分支打点），`/api/ai/conversations` 合并 `runStatus` |
| 切回会话从不重连 | `loadMessages` 重建历史后总是 `reattachSSE`；`/connect` 建连即推 `run_state` 事件 |
| `state_recovery` 有机制无触发路径 | 发现并修复真正根因：恢复处理器排在气泡守卫之后，重连时气泡指针为 null **事件被静默丢弃**；已提到守卫之前 |

## 效果

- **切走**：前端只断展示流，后端循环继续跑完、消息持续 upsert 落库
- **切回**：自动重连 → 运行中的会话收 `state_recovery` 全量续流+任务清单恢复+发送框封锁；暂停的会话恢复「继续执行」按钮；已结束的正常显示历史
- **状态点**（历史抽屉每条 + 近期对话 + 历史入口聚合角标）：
  - 🟢 动画绿 = 运行中
  - 🟡 黄 = 待继续（步数超限）/ 待审批（Plan 模式）
  - 🔵 蓝 = 后台跑完未读（RUNNING→终态迁移检测，点开即清）
  - 🔴 红 = 出错
- 面板打开时每 15s 静默轮询会话状态

## 验证

backend `mvn test` 259 绿（EvalHarness 构造器已同步）；`check:emits` 过；`build:h5` 过；lowa-e2e 25/25；app-e2e 29/29。

## 已知边界（如需再增强）

- 状态是内存态：进程重启后清零——与「循环已死」的事实一致，不会出现僵尸运行中；但暂停/待审批标记也随之丢失（持久化到表是下一步）
- 断线期间的结构化事件（file_change/artifact/token_usage）不回放，只有文本快照续流
- 并发后台任务受 Spring 默认线程池 core=8 限制

🤖 Generated with [Claude Code](https://claude.com/claude-code)