### PR TITLE
ci: PR 不再构建 macOS 安装包，仅发版与手动触发时构建

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -31,7 +31,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        # macOS runners take 1h+ per build (jlink + dmg + notarization), so PRs
+        # only build Windows; macOS builds run on v* release tags and manual
+        # workflow_dispatch runs.
+        os: ${{ fromJSON((startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && '["macos-latest", "windows-latest"]' || '["windows-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 动机
macOS runner 单次桌面构建耗时 1 小时以上（jlink + dmg 打包 + Apple 公证），拖慢每个 PR 的反馈。

## 改动
`desktop-build.yml` 构建矩阵改为条件表达式：
- **PR**：仅 `windows-latest`
- **v* tag（发 release）/ workflow_dispatch 手动触发**：`macos-latest` + `windows-latest`（不变）

## 验证
- 分支保护未设必需状态检查，跳过 macOS 不会造成必需检查悬挂
- 工作流内所有步骤均按 `runner.os` 条件分流、无跨 leg 依赖，release 附件步骤仅在 tag 上执行，发版产物不受影响
- 本 PR 自身即用新矩阵运行，可直接观察仅派生 Windows job

🤖 Generated with [Claude Code](https://claude.com/claude-code)