### PR TITLE
chore(release): v0.7.8

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 发版 v0.7.8

版本号 bump 至 0.7.8。自 v0.7.7 以来包含:
- #171 King IDE 品牌残留清零(css 类名 king-*→awd-*、旧 logo 移除)
- #172 AI 面板五连修(工具卡片单行化+按 plan 步骤分组、条款识别 doc_get_clauses、页边修订、bocha key 设置、超限一键继续)
- #173 Agent 后台持续运行可观测(会话运行状态机、切回续流、历史列表状态点)
- #174 CI:PR 不再构建 macOS 安装包

发版前回归(本机):backend mvn test 259 过 0 挂;app-e2e 29/29;lowa-e2e 25/25。

🤖 Generated with [Claude Code](https://claude.com/claude-code)