### PR TITLE
build(desktop): pysvc 打成单个 tar.gz 进包，首启解压——消除 macOS 逐文件签名的时间戳抖动

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -282,6 +282,14 @@ jobs:
           tail -60 "$RUNNER_TEMP/kokoro-smoke.log"
           kill $KOKORO_PID 2>/dev/null || true
           exit 1
+      - name: Pack pysvc archive (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # 上万个 Python 小文件不再直接进 .app：签名（sign-mac-natives.sh 已给
+          # 每个 Mach-O 打 Developer ID + 时间戳——公证会扫嵌套压缩包，未签名照拒）
+          # 与冒烟测试之后整体打成单个 pysvc.tar.gz，electron-builder 的签名/公证
+          # 阶段从上万文件降到一个文件，消除时间戳服务抖动。首启由主进程解压。
+          node desktop/scripts/pack-pysvc.js --bundle desktop/bundled/mac-arm64
       - name: Package installers (macOS, signed & notarized)
         if: runner.os == 'macOS'
         working-directory: desktop
@@ -427,6 +435,12 @@ jobs:
           tail -60 "$RUNNER_TEMP/kokoro-smoke.log"
           kill $KOKORO_PID 2>/dev/null || true
           exit 1
+      - name: Pack pysvc archive (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          # 与 macOS 同构：安装包只带一个 pysvc.tar.gz（文件数大降、安装更快），首启解压
+          node desktop/scripts/pack-pysvc.js --bundle desktop/bundled/win-x64
       - name: Package installers (Windows, unsigned)
         if: runner.os == 'Windows'
         working-directory: desktop

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -49,6 +49,9 @@ node desktop/scripts/prepare-python-service.js \
 node desktop/scripts/prepare-python-service.js \
   --service kokoro-service --src kokoro-service \
   --requirements kokoro-service/requirements.lock --out desktop/bundled/mac-arm64
+# 7. pysvc 打成单个 tar.gz（上万个小文件不直接进 .app——逐文件 codesign 的 Apple
+#    时间戳请求会抖动；首次启动由主进程解压到用户数据目录，见 main/services/pysvc-runtime.js）
+node desktop/scripts/pack-pysvc.js --bundle desktop/bundled/mac-arm64
 # 出包（本地不签名）
 cd desktop && CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --publish never
 ```

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -1215,13 +1215,87 @@ const COMPONENT_SERVICE = {
   'kokoro-models': 'kokoro-service'
 }
 
+// 打包态 pysvc 不再随 .app 携带目录，而是 Resources/pysvc.tar.gz 首启解压到
+// 用户数据目录（见 services/pysvc-runtime.js 顶部说明）。返回解压产物里的
+// pysvc 根目录；dev 态或旧布局（无 tar 包，pysvc 目录直接在 Resources）返回 null，
+// 服务代码经 pysvcPath() 回退到 resourcesPath/pysvc。
+function resolvePysvcRoot() {
+  if (!app.isPackaged) return null
+  const fs = require('fs')
+  if (!fs.existsSync(path.join(process.resourcesPath, 'pysvc.tar.gz'))) return null
+  return path.join(app.getPath('userData'), 'pysvc-' + app.getVersion(), 'pysvc')
+}
+
+// 首启/升级后的 pysvc 解压（幂等）。带一个极简进度窗——mineru lib 解压要数十秒，
+// 无提示会被当成"点了没反应"。失败不阻塞主流程：弹框告知后照常开窗，
+// 相关 Python 服务会各自启动失败并落日志。
+async function ensurePysvcReady() {
+  const root = resolvePysvcRoot()
+  if (!root) return
+  const { ensurePysvcExtracted, MARKER } = require('./services/pysvc-runtime')
+  const fs = require('fs')
+  const versionDir = path.dirname(root)
+  if (fs.existsSync(path.join(versionDir, MARKER))) return // 常规启动零开销快路径
+
+  let splash = null
+  const setProgress = (percent) => {
+    if (!splash || splash.isDestroyed()) return
+    const p = typeof percent === 'number' ? percent : -1
+    splash.webContents.executeJavaScript(`window.__setP && window.__setP(${p})`).catch(() => {})
+  }
+  try {
+    splash = new BrowserWindow({
+      width: 420,
+      height: 160,
+      frame: false,
+      resizable: false,
+      show: false,
+      webPreferences: { nodeIntegration: false, contextIsolation: true }
+    })
+    const html = `<!doctype html><meta charset="utf-8">
+      <body style="margin:0;font:14px -apple-system,'Segoe UI',sans-serif;background:#1e1f24;color:#e8e8ea;display:flex;align-items:center;justify-content:center;height:100vh;user-select:none">
+        <div style="width:320px;text-align:center">
+          <div style="margin-bottom:6px">正在准备本地组件…</div>
+          <div style="font-size:12px;color:#9a9aa2;margin-bottom:14px">首次启动或版本更新后需解压，约一分钟</div>
+          <div style="background:#33343c;border-radius:4px;height:8px;overflow:hidden">
+            <div id="bar" style="background:#4f8cff;height:100%;width:0%;transition:width .4s"></div>
+          </div>
+          <div id="pct" style="font-size:12px;color:#9a9aa2;margin-top:8px">&nbsp;</div>
+        </div>
+        <script>window.__setP=function(p){if(p>=0){document.getElementById('bar').style.width=p+'%';document.getElementById('pct').textContent=p+'%'}}</script>
+      </body>`
+    splash.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html))
+    splash.once('ready-to-show', () => { try { splash.show() } catch (e) { /* ignore */ } })
+  } catch (e) {
+    splash = null // 无窗口也照样解压
+  }
+
+  const result = await ensurePysvcExtracted({
+    archive: path.join(process.resourcesPath, 'pysvc.tar.gz'),
+    metaFile: path.join(process.resourcesPath, 'pysvc.meta.json'),
+    versionDir,
+    onProgress: ({ percent }) => setProgress(percent)
+  })
+  try { if (splash && !splash.isDestroyed()) splash.destroy() } catch (e) { /* ignore */ }
+  if (!result.ok) {
+    console.error('[pysvc] extract failed:', result.message)
+    try {
+      const { dialog } = require('electron')
+      dialog.showErrorBox('本地组件解压失败', `部分本地功能（文档解析/PPT/语音）将不可用：\n${result.message || ''}`)
+    } catch (e) { /* ignore */ }
+  }
+}
+
 function createServices() {
-  // 打包模式下 jar/JRE/python 从 resourcesPath 解析（Epic #18 T2），数据落 ~/.aiworkdeck
+  // 打包模式下 jar/JRE/python 从 resourcesPath 解析（Epic #18 T2），数据落 ~/.aiworkdeck；
+  // pysvc 落用户数据目录（首启解压，见 ensurePysvcReady）
   const dataDir = path.join(app.getPath('home'), '.aiworkdeck')
+  const pysvcRoot = resolvePysvcRoot()
   if (!modelManager) {
     modelManager = createModelManager({
       dataDir,
       resourcesPath: process.resourcesPath,
+      pysvcRoot,
       packaged: app.isPackaged,
       onProgress: (evt) => {
         try {
@@ -1239,6 +1313,7 @@ function createServices() {
     projectRoot: path.join(__dirname, '..', '..'),
     packaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
+    pysvcRoot,
     dataDir
   })
   mgr.register(createBackendDescriptor())
@@ -1325,10 +1400,14 @@ app.whenReady().then(() => {
       try { if (mainWindow) mainWindow.webContents.send('checkba:zetaoffice-open-embed') } catch (e) { /* ignore */ }
     })
   } catch (e) { /* ignore */ }
-  // 桌面端启动时自动拉起本机服务（Java 后端 9696 + 打包态的 pptx-service）
-  services = createServices()
-  services
-    .allocatePorts()
+  // 桌面端启动时自动拉起本机服务（Java 后端 9696 + 打包态的 pptx-service）；
+  // 打包态先确保 pysvc 已解压（首启/升级后带进度窗，常规启动是零开销快路径）
+  ensurePysvcReady()
+    .catch((e) => console.error('[pysvc]', e))
+    .then(() => {
+      services = createServices()
+      return services.allocatePorts()
+    })
     .then(() => services.startEager())
     .then((results) => {
       createMainWindow()

--- a/desktop/main/services/kokoro-service.js
+++ b/desktop/main/services/kokoro-service.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs')
 const { findFreePort } = require('./service-manager')
+const { pysvcPath } = require('./pysvc-runtime')
 
 function pyBin(ctx) {
   return process.platform === 'win32'
@@ -9,11 +10,11 @@ function pyBin(ctx) {
 }
 
 function libDir(ctx) {
-  return path.join(ctx.resourcesPath, 'pysvc', 'kokoro-service', 'lib')
+  return pysvcPath(ctx, 'kokoro-service', 'lib')
 }
 
 function appDir(ctx) {
-  return path.join(ctx.resourcesPath, 'pysvc', 'kokoro-service', 'app')
+  return pysvcPath(ctx, 'kokoro-service', 'app')
 }
 
 function modelsDir(ctx) {

--- a/desktop/main/services/mineru-service.js
+++ b/desktop/main/services/mineru-service.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs')
 const { findFreePort } = require('./service-manager')
+const { pysvcPath } = require('./pysvc-runtime')
 
 function pyBin(ctx) {
   return process.platform === 'win32'
@@ -9,7 +10,7 @@ function pyBin(ctx) {
 }
 
 function libDir(ctx) {
-  return path.join(ctx.resourcesPath, 'pysvc', 'mineru-service', 'lib')
+  return pysvcPath(ctx, 'mineru-service', 'lib')
 }
 
 function modelsDir(ctx) {

--- a/desktop/main/services/model-manager.js
+++ b/desktop/main/services/model-manager.js
@@ -34,9 +34,7 @@ function dirSize(root) {
   return total
 }
 
-function mineruLib(resourcesPath) {
-  return path.join(resourcesPath || '', 'pysvc', 'mineru-service', 'lib')
-}
+const { pysvcPath } = require('./pysvc-runtime')
 
 function pyBin(resourcesPath) {
   return process.platform === 'win32'
@@ -64,7 +62,7 @@ const COMPONENTS = [
         ],
         env: {
           ...process.env,
-          PYTHONPATH: mineruLib(ctx.resourcesPath),
+          PYTHONPATH: pysvcPath(ctx, 'mineru-service', 'lib'),
           MINERU_MODEL_SOURCE: 'modelscope',
           MODELSCOPE_CACHE: dir,
           HF_HOME: path.join(dir, 'hf'),
@@ -91,7 +89,7 @@ const COMPONENTS = [
         ],
         env: {
           ...process.env,
-          PYTHONPATH: path.join(ctx.resourcesPath || '', 'pysvc', 'kokoro-service', 'lib'),
+          PYTHONPATH: pysvcPath(ctx, 'kokoro-service', 'lib'),
           HF_HOME: dir,
           HF_ENDPOINT: process.env.CHECKBA_HF_ENDPOINT || 'https://hf-mirror.com',
           // 打包内带 hf_xet：Xet 路径绕过 HF_ENDPOINT 直连 HF 官方 CAS
@@ -110,6 +108,7 @@ class ModelManager {
     this.ctx = {
       dataDir: opts.dataDir,
       resourcesPath: opts.resourcesPath,
+      pysvcRoot: opts.pysvcRoot || null,
       packaged: !!opts.packaged
     }
     this.onProgress = opts.onProgress || (() => {})

--- a/desktop/main/services/pptx-service.js
+++ b/desktop/main/services/pptx-service.js
@@ -2,6 +2,7 @@ const path = require('path')
 const fs = require('fs')
 const { spawnSync } = require('child_process')
 const { findFreePort } = require('./service-manager')
+const { pysvcPath } = require('./pysvc-runtime')
 
 function pyBin(ctx) {
   return process.platform === 'win32'
@@ -10,11 +11,11 @@ function pyBin(ctx) {
 }
 
 function appDir(ctx) {
-  return path.join(ctx.resourcesPath, 'pysvc', 'pptx-service', 'app')
+  return pysvcPath(ctx, 'pptx-service', 'app')
 }
 
 function libDir(ctx) {
-  return path.join(ctx.resourcesPath, 'pysvc', 'pptx-service', 'lib')
+  return pysvcPath(ctx, 'pptx-service', 'lib')
 }
 
 function dataDir(ctx) {

--- a/desktop/main/services/pysvc-runtime.js
+++ b/desktop/main/services/pysvc-runtime.js
@@ -1,0 +1,127 @@
+const path = require('path')
+const fs = require('fs')
+const { spawn } = require('child_process')
+
+/**
+ * pysvc 运行时定位与首启解压。
+ *
+ * 打包产物不再直接携带 pysvc/ 目录（上万个小文件让 macOS 逐文件 codesign 的
+ * Apple 时间戳请求抖动、EMFILE 频发），改为 Resources/pysvc.tar.gz 单文件；
+ * 首次启动（或 app 版本变更）解压到用户数据目录 <userData>/pysvc-<version>/。
+ * 绝不能解压回 .app 内部——会破坏 bundle 签名密封（Gatekeeper 直接拒启）。
+ */
+
+const MARKER = '.aiworkdeck-extracted'
+
+// 服务代码统一经此定位 pysvc 内文件：
+// - 打包态（ctx.pysvcRoot 已设置）→ 用户数据目录里的解压产物
+// - dev 态 / 旧布局（未设置）→ 沿用 resourcesPath/pysvc
+function pysvcPath(ctx, ...segments) {
+  const root = ctx.pysvcRoot || path.join(ctx.resourcesPath || '', 'pysvc')
+  return path.join(root, ...segments)
+}
+
+function dirSize(root) {
+  let total = 0
+  const stack = [root]
+  while (stack.length) {
+    const cur = stack.pop()
+    let entries
+    try { entries = fs.readdirSync(cur, { withFileTypes: true }) } catch (e) { continue }
+    for (const en of entries) {
+      const fp = path.join(cur, en.name)
+      if (en.isDirectory()) stack.push(fp)
+      else if (en.isFile()) { try { total += fs.statSync(fp).size } catch (e) { /* 解压中文件可能在改名 */ } }
+    }
+  }
+  return total
+}
+
+// Windows 优先 System32 的 bsdtar（处理盘符冒号无坑）；PATH 里的 GNU tar 会把
+// "D:\..." 的冒号当远程主机（见 prepare-python-service.js 同款地雷）
+function tarCandidates() {
+  if (process.platform === 'win32') {
+    const sys = process.env.SystemRoot || 'C:\\Windows'
+    return [path.join(sys, 'System32', 'tar.exe'), 'tar.exe']
+  }
+  return ['/usr/bin/tar', 'tar']
+}
+
+function extractTarOnce(cmd, archive, destDir) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, ['-xzf', archive, '-C', destDir], { stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+    proc.stderr.on('data', (d) => { stderr = (stderr + d.toString()).slice(-2000) })
+    proc.once('error', (e) => reject(Object.assign(e, { _spawnError: true })))
+    proc.once('exit', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(`tar exited ${code}: ${stderr}`))
+    })
+  })
+}
+
+async function extractTar(archive, destDir) {
+  let lastErr = null
+  for (const cmd of tarCandidates()) {
+    try {
+      await extractTarOnce(cmd, archive, destDir)
+      return
+    } catch (e) {
+      lastErr = e
+      if (!e._spawnError) throw e // tar 存在但解压失败：不是换候选能解决的
+    }
+  }
+  throw lastErr || new Error('no tar available')
+}
+
+// 成功解压后清理同级旧版本目录（pysvc-<oldVersion>），升级不留双份体积
+function cleanupOldVersions(versionDir) {
+  const parent = path.dirname(versionDir)
+  const current = path.basename(versionDir)
+  let entries
+  try { entries = fs.readdirSync(parent, { withFileTypes: true }) } catch (e) { return }
+  for (const en of entries) {
+    if (!en.isDirectory() || !en.name.startsWith('pysvc-') || en.name === current) continue
+    try { fs.rmSync(path.join(parent, en.name), { recursive: true, force: true }) } catch (e) { /* 尽力而为 */ }
+  }
+}
+
+/**
+ * 确保 pysvc 已解压到 versionDir（幂等：marker 命中直接复用）。
+ * opts = { archive, metaFile, versionDir, onProgress?({percent}) }
+ * 返回 { ok, reused?, message? }，不抛异常。
+ */
+async function ensurePysvcExtracted(opts) {
+  const { archive, metaFile, versionDir, onProgress } = opts
+  const marker = path.join(versionDir, MARKER)
+  if (fs.existsSync(marker)) return { ok: true, reused: true }
+
+  let poller = null
+  try {
+    // 无 marker 的残留（上次解压被打断）整体重来，保证目录内容完整
+    fs.rmSync(versionDir, { recursive: true, force: true })
+    fs.mkdirSync(versionDir, { recursive: true })
+
+    let totalBytes = 0
+    try { totalBytes = JSON.parse(fs.readFileSync(metaFile, 'utf8')).totalBytes || 0 } catch (e) { /* 无元数据则不报百分比 */ }
+    if (onProgress) {
+      poller = setInterval(() => {
+        const percent = totalBytes > 0
+          ? Math.min(99, Math.round(dirSize(versionDir) / totalBytes * 100)) // 封顶 99，tar 成功退出才算完成
+          : undefined
+        try { onProgress({ percent }) } catch (e) { /* ignore */ }
+      }, 500)
+    }
+
+    await extractTar(archive, versionDir)
+    fs.writeFileSync(marker, new Date().toISOString())
+    cleanupOldVersions(versionDir)
+    return { ok: true, reused: false }
+  } catch (e) {
+    return { ok: false, message: String(e && e.message ? e.message : e) }
+  } finally {
+    if (poller) clearInterval(poller)
+  }
+}
+
+module.exports = { pysvcPath, ensurePysvcExtracted, MARKER }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js"
+    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
@@ -52,8 +52,12 @@
         "to": "python"
       },
       {
-        "from": "bundled/${os}-${arch}/pysvc",
-        "to": "pysvc"
+        "from": "bundled/${os}-${arch}/pysvc.tar.gz",
+        "to": "pysvc.tar.gz"
+      },
+      {
+        "from": "bundled/${os}-${arch}/pysvc.meta.json",
+        "to": "pysvc.meta.json"
       }
     ],
     "mac": {

--- a/desktop/scripts/pack-pysvc.js
+++ b/desktop/scripts/pack-pysvc.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/*
+ * 把 bundled/<plat>/pysvc（上万个小文件）打成单个 pysvc.tar.gz + pysvc.meta.json，
+ * electron-builder 只打包这两个文件（见 package.json extraResources），首次启动由
+ * main/services/pysvc-runtime.js 解压到用户数据目录。
+ *
+ * macOS 动机：.app 内每个 Mach-O 都要单独 codesign + Apple 时间戳，上万文件导致
+ * "The timestamp service is not available" 抖动使 release 构建频繁失败（run
+ * 29552522258）。逐文件签名照旧在打包前完成（sign-mac-natives.sh）——Apple 公证
+ * 会扫描嵌套压缩包，未签名二进制照样被拒；本脚本只是让 electron-builder 的
+ * 签名/装订/公证阶段从上万个文件变成一个文件。
+ *
+ * 必须在 sign-mac-natives.sh 与各 pysvc 冒烟测试之后运行（两者都要读目录原样）。
+ *
+ * 用法：node scripts/pack-pysvc.js --bundle bundled/mac-arm64
+ */
+const fs = require('fs')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+function parseArgs() {
+  const out = {}
+  const argv = process.argv.slice(2)
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--') && i + 1 < argv.length) out[argv[i].slice(2)] = argv[++i]
+  }
+  if (!out.bundle) {
+    console.error('missing --bundle <dir> (e.g. bundled/mac-arm64)')
+    process.exit(1)
+  }
+  return out
+}
+
+function dirStats(root) {
+  let totalBytes = 0
+  let fileCount = 0
+  const stack = [root]
+  while (stack.length) {
+    const cur = stack.pop()
+    for (const en of fs.readdirSync(cur, { withFileTypes: true })) {
+      const fp = path.join(cur, en.name)
+      if (en.isDirectory()) stack.push(fp)
+      else if (en.isFile()) { totalBytes += fs.statSync(fp).size; fileCount++ }
+    }
+  }
+  return { totalBytes, fileCount }
+}
+
+function main() {
+  const args = parseArgs()
+  const bundleDir = path.resolve(args.bundle)
+  const pysvcDir = path.join(bundleDir, 'pysvc')
+  if (!fs.existsSync(pysvcDir)) {
+    console.error(`pysvc dir not found: ${pysvcDir}`)
+    process.exit(1)
+  }
+  const stats = dirStats(pysvcDir)
+  // totalBytes 供运行时解压进度条当分母（已落盘字节 / totalBytes）
+  fs.writeFileSync(path.join(bundleDir, 'pysvc.meta.json'), JSON.stringify(stats))
+  // cwd + 相对路径：Windows 上 GNU tar 会把 "D:\..." 的冒号当远程主机（host:file 语法）
+  execFileSync('tar', ['-czf', 'pysvc.tar.gz', 'pysvc'], { cwd: bundleDir, stdio: 'inherit' })
+  const archiveBytes = fs.statSync(path.join(bundleDir, 'pysvc.tar.gz')).size
+  console.log(`packed pysvc: ${stats.fileCount} files, ${(stats.totalBytes / 1048576).toFixed(0)} MB -> pysvc.tar.gz ${(archiveBytes / 1048576).toFixed(0)} MB`)
+}
+
+main()

--- a/desktop/scripts/sign-mac-natives.sh
+++ b/desktop/scripts/sign-mac-natives.sh
@@ -33,7 +33,18 @@ sign_file() {
   if file -b "$f" | grep -q 'executable'; then
     args+=(--entitlements "$ENTITLEMENTS")
   fi
-  codesign "${args[@]}" "$f"
+  # Apple 时间戳服务在大批量签名下会抖动（"The timestamp service is not
+  # available"，run 29552522258），单次失败直接挂整个 release 构建——退避重试
+  local attempt
+  for attempt in 1 2 3; do
+    if codesign "${args[@]}" "$f" 2>/dev/null; then
+      echo "  signed: $f"
+      return 0
+    fi
+    echo "  codesign failed (attempt $attempt), retrying: $f" >&2
+    sleep $((attempt * 10))
+  done
+  codesign "${args[@]}" "$f" # 最后一次不吞 stderr，把真实错误暴露给构建日志
   echo "  signed: $f"
 }
 

--- a/desktop/tests/pysvc-runtime.test.js
+++ b/desktop/tests/pysvc-runtime.test.js
@@ -1,0 +1,92 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { execFileSync } = require('child_process')
+const { pysvcPath, ensurePysvcExtracted, MARKER } = require('../main/services/pysvc-runtime')
+
+const PACK_SCRIPT = path.join(__dirname, '..', 'scripts', 'pack-pysvc.js')
+
+// 造一个最小 pysvc 树（服务名/子目录结构对齐真实布局），返回 bundle 目录
+function makeFakeBundle(root) {
+  const bundle = path.join(root, 'bundle')
+  const files = {
+    'pysvc/mineru-service/lib/mineru/__init__.py': 'print("mineru")',
+    'pysvc/kokoro-service/app/app.py': 'print("kokoro")',
+    'pysvc/kokoro-service/lib/pkg/mod.py': 'x = 1',
+    'pysvc/pptx-service/app/alembic.ini': '[alembic]'
+  }
+  for (const [rel, content] of Object.entries(files)) {
+    const fp = path.join(bundle, rel)
+    fs.mkdirSync(path.dirname(fp), { recursive: true })
+    fs.writeFileSync(fp, content)
+  }
+  return { bundle, files }
+}
+
+test('pack-pysvc.js produces tarball + meta with correct totals', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pysvc-pack-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const { bundle, files } = makeFakeBundle(root)
+
+  execFileSync(process.execPath, [PACK_SCRIPT, '--bundle', bundle])
+
+  assert.ok(fs.existsSync(path.join(bundle, 'pysvc.tar.gz')))
+  const meta = JSON.parse(fs.readFileSync(path.join(bundle, 'pysvc.meta.json'), 'utf8'))
+  const expectedBytes = Object.values(files).reduce((s, c) => s + Buffer.byteLength(c), 0)
+  assert.strictEqual(meta.fileCount, Object.keys(files).length)
+  assert.strictEqual(meta.totalBytes, expectedBytes)
+})
+
+test('ensurePysvcExtracted: extract, marker, reuse, old-version cleanup', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pysvc-extract-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const { bundle, files } = makeFakeBundle(root)
+  execFileSync(process.execPath, [PACK_SCRIPT, '--bundle', bundle])
+  const archive = path.join(bundle, 'pysvc.tar.gz')
+  const metaFile = path.join(bundle, 'pysvc.meta.json')
+
+  // 模拟一份旧版本残留，成功解压后应被清掉
+  const userData = path.join(root, 'userData')
+  const oldDir = path.join(userData, 'pysvc-0.0.1')
+  fs.mkdirSync(path.join(oldDir, 'pysvc'), { recursive: true })
+  fs.writeFileSync(path.join(oldDir, MARKER), 'old')
+
+  const versionDir = path.join(userData, 'pysvc-1.2.3')
+  const r1 = await ensurePysvcExtracted({ archive, metaFile, versionDir })
+  assert.strictEqual(r1.ok, true)
+  assert.strictEqual(r1.reused, false)
+  assert.ok(fs.existsSync(path.join(versionDir, MARKER)))
+  for (const [rel, content] of Object.entries(files)) {
+    assert.strictEqual(fs.readFileSync(path.join(versionDir, rel), 'utf8'), content, rel)
+  }
+  assert.ok(!fs.existsSync(oldDir), 'old pysvc-<version> dir should be cleaned up')
+
+  // marker 命中 → 幂等复用，不重复解压
+  const r2 = await ensurePysvcExtracted({ archive, metaFile, versionDir })
+  assert.strictEqual(r2.ok, true)
+  assert.strictEqual(r2.reused, true)
+})
+
+test('ensurePysvcExtracted: missing archive fails without throwing', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pysvc-miss-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const r = await ensurePysvcExtracted({
+    archive: path.join(root, 'nope.tar.gz'),
+    metaFile: path.join(root, 'nope.json'),
+    versionDir: path.join(root, 'pysvc-9.9.9')
+  })
+  assert.strictEqual(r.ok, false)
+  assert.ok(r.message)
+})
+
+test('pysvcPath: packaged uses pysvcRoot, dev falls back to resourcesPath/pysvc', () => {
+  const packaged = { pysvcRoot: path.join('u', 'pysvc-1.0.0', 'pysvc'), resourcesPath: 'res' }
+  assert.strictEqual(
+    pysvcPath(packaged, 'mineru-service', 'lib'),
+    path.join('u', 'pysvc-1.0.0', 'pysvc', 'mineru-service', 'lib')
+  )
+  const dev = { pysvcRoot: null, resourcesPath: 'res' }
+  assert.strictEqual(pysvcPath(dev, 'kokoro-service', 'app'), path.join('res', 'pysvc', 'kokoro-service', 'app'))
+})


### PR DESCRIPTION
## 问题

macOS release 构建中 `Contents/Resources/pysvc/`（mineru/kokoro/pptx 的 Python 依赖）有上万个小文件，electron-builder 签名阶段逐文件 codesign，每个签名都请求一次 Apple 时间戳服务，高频抖动 "The timestamp service is not available" 使 tag 构建反复失败（run 29552522258）。

## 方案

**构建时**（`.github/workflows/desktop-build.yml` + 新脚本 `desktop/scripts/pack-pysvc.js`）
- 顺序不变：`sign-mac-natives.sh` 先给 pysvc 内每个 Mach-O 打 Developer ID + hardened runtime + 时间戳（Apple 公证会扫描嵌套压缩包，未签名二进制照样被拒），再跑各服务冒烟测试；
- 之后 `pack-pysvc.js` 把 `pysvc/` 整体打成单个 `pysvc.tar.gz` + `pysvc.meta.json`（解压进度分母），electron-builder 只见这一个文件——签名/装订/公证阶段从上万文件降到 1 个；
- `sign-mac-natives.sh` 单文件签名失败追加退避重试（3 次），进一步兜底时间戳抖动;
- Windows 同构处理（安装包文件数大降、安装更快）。

**运行时**（新模块 `desktop/main/services/pysvc-runtime.js`）
- 首次启动或 app 版本变更时解压到 `<userData>/pysvc-<version>/`（mac 即 `~/Library/Application Support/AI Workdeck/`）——**绝不解压回 .app 内部**（破坏签名密封）；
- 解压期间显示极简进度窗（已落盘字节 / meta.totalBytes）；失败弹框告知但不阻塞开窗；
- marker 文件保证幂等（常规启动零开销快路径）；成功后清理旧版本 `pysvc-*` 目录；
- `pptx/mineru/kokoro` 描述符与 ModelManager 的路径统一走 `pysvcPath()`：打包态指向解压目录，dev 态与旧布局（Resources 里直接是 pysvc 目录）自动回退；
- Windows 解压优先用 `System32\tar.exe`（bsdtar，无盘符冒号地雷）。

## 验证

- `npm test` 新增 `tests/pysvc-runtime.test.js`：pack→extract 全链路（真实 tar）、marker 幂等复用、旧版本清理、缺档案不抛异常、路径回退——mac/win CI 都会跑，顺带验证两平台 tar 可用性；14/14 通过。
- 本 PR 的 Windows 构建会走完整 pack → electron-builder 链路；macOS 签名链路在下个 release tag / workflow_dispatch 构建验证（预期签名步骤耗时明显下降）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)