### PR TITLE
docs(readme): 首图换真实产品截图，新增 Screenshots 区

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.aiworkdeck.com">
-    <img src="https://www.aiworkdeck.com/images/hero-dashboard.png" alt="AI Workdeck dashboard" width="900">
+    <img src="https://www.aiworkdeck.com/images/workspace-ai.png" alt="AI Workdeck — project workspace with document preview and AI agent panel (real product screenshot)" width="900">
   </a>
 </p>
 
@@ -68,6 +68,17 @@ Double-click to install. On first launch, a setup wizard lets you pick one AI pr
 | Website | [aiworkdeck.com](https://www.aiworkdeck.com) |
 | Product walkthrough | [Intro video](https://www.aiworkdeck.com/videos/intro.mp4) |
 | Feature showcase | [AI Workdeck Showcase](https://www.aiworkdeck.com/zh/showcase) |
+
+## Screenshots
+
+The workspace above is a real product screenshot (demo project with fictitious data). Below: the plugin & skill marketplace, and a design preview of where the document workbench is heading.
+
+<p align="center">
+  <img src="https://www.aiworkdeck.com/images/plugin-marketplace.png" alt="Plugin and skill marketplace (design preview)" width="900">
+</p>
+<p align="center">
+  <img src="https://www.aiworkdeck.com/images/workdeck-vision.png" alt="Document workbench with AI redlines (design preview)" width="900">
+</p>
 
 ## Core Capabilities
 


### PR DESCRIPTION
## 变更
- README 顶部 hero 改为官网新上线的真实工作区截图 `workspace-ai.png`（虚构演示项目「星辉科技 A 轮融资尽调」，无真实姓名/客户信息；新文件名可绕开 GitHub camo 对旧 URL 的缓存）
- 新增 **Screenshots** 区：插件/Skill 广场与文档工作台两张设计预览图（原型重制为 AI Workdeck 品牌 + 官网墨绿视觉），并明确标注 real screenshot 与 design preview

## 关联
官网侧图片已在 aiworkdeck_website@18cf291 上线并完成部署验证（hero + 三张功能卡全部换为真实截图/重制稿）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)