### PR TITLE
AI 面板线性结构与思考计时真实化 + 文档加载动效 + 修订定位/AI Workdeck 署名

### DIFF
--- a/frontend/src/components/AgentMessage/ProcessCard.vue
+++ b/frontend/src/components/AgentMessage/ProcessCard.vue
@@ -60,7 +60,7 @@
                 </template>
                 <div v-else class="step-row">
                     <span class="step-dot" :class="{ 'done': item.status !== 'doing' }"></span>
-                    <span class="step-text" :class="{ 'is-meta': isSecondaryContent(item.text) }">{{ item.text || 'Working...' }}</span>
+                    <span class="step-text" :class="{ 'is-meta': isSecondaryContent(item.text) }">{{ item.text || '处理中…' }}</span>
                 </div>
             </div>
 
@@ -117,7 +117,8 @@ const props = defineProps({
 const isExpanded = ref(false)
 
 const isSystemActions = computed(() => {
-  return props.process.title === 'System Actions'
+  // '系统操作' 是现名；'System Actions' 兼容历史数据
+  return props.process.title === '系统操作' || props.process.title === 'System Actions'
 })
 
 const isHeadless = computed(() => {
@@ -162,7 +163,7 @@ watch(() => props.process.items?.length, (newLen, oldLen) => {
 }, { immediate: true })
 
 const formatToolName = (code) => {
-    if (!code) return 'Tool Call'
+    if (!code) return '工具调用'
     const name = toolDisplayName(code)
     return name.length > 40 ? name.substring(0, 37) + '...' : name
 }

--- a/frontend/src/components/AgentMessage/RootBubble.vue
+++ b/frontend/src/components/AgentMessage/RootBubble.vue
@@ -29,6 +29,13 @@
             <!-- 2. Title -->
             <TitleCard v-if="bubble.title" :title="bubble.title" />
 
+            <!-- 2b. 计划卡（线性时序结构）：思考结束、制定计划后先展示计划框，
+                 下方才是各步骤的执行进展；每步内部再嵌工具调用记录。
+                 快照挂在气泡上（plan_update 时写入），历史消息各自保留当轮计划。 -->
+            <div v-if="bubble.planTodos && bubble.planTodos.length" class="inline-plan">
+               <TodoProgressCard :todos="bubble.planTodos" />
+            </div>
+
             <!-- 3. Process Stream（工具执行按 plan 步骤分组：最新步骤展开，旧步骤收起，
                  避免整个面板被工具卡片刷满；无步骤归属的保持平铺） -->
             <div class="process-stream">
@@ -119,6 +126,7 @@
 import { computed, ref } from 'vue'
 import ThinkingCard from './ThinkingCard.vue'
 import TitleCard from './TitleCard.vue'
+import TodoProgressCard from './TodoProgressCard.vue'
 import ProcessCard from './ProcessCard.vue'
 import WalkthroughCard from './WalkthroughCard.vue'
 import ArtifactCard from '../ArtifactCard.vue'
@@ -174,16 +182,19 @@ const isGroupDone = (g) => g.procs.every(p =>
 )
 const groupHasError = (g) => g.procs.some(p => (p.items || []).some(it => it.status === 'error'))
 
+const hasPlan = computed(() => !!(props.bubble.planTodos && props.bubble.planTodos.length > 0))
+
 const isReady = computed(() => {
-    // Show full card if we have a Title OR Processes OR Main Content
+    // Show full card if we have a Title OR Plan OR Processes OR Main Content
     // If only "Thinking", remain in Ghost state (unless it's done thinking and has no other content? No, unlikely)
-    return !!(props.bubble.title || props.bubble.processes.length > 0 || props.bubble.content)
+    return !!(props.bubble.title || hasPlan.value || props.bubble.processes.length > 0 || props.bubble.content)
 })
 
 const hasContent = computed(() => {
     // Check if the bubble has any content to display
     return !!(
         props.bubble.title ||
+        hasPlan.value ||
         props.bubble.processes.length > 0 ||
         props.bubble.artifacts.length > 0 ||
         props.bubble.content
@@ -307,6 +318,15 @@ const hasContent = computed(() => {
   inset: 0;
   z-index: 98;
   background: transparent;
+}
+
+/* 内联计划卡：卡片容器内左右留边，与步骤分组视觉对齐 */
+.inline-plan {
+  padding: 8px 10px 2px;
+}
+
+.inline-plan :deep(.todo-progress-card) {
+  margin: 0;
 }
 
 /* ---- plan 步骤分组 ---- */

--- a/frontend/src/components/AgentMessage/ThinkingCard.vue
+++ b/frontend/src/components/AgentMessage/ThinkingCard.vue
@@ -4,8 +4,9 @@
      <div class="h-wrap" @click="isExpanded = !isExpanded">
         <!-- Removed Emoji Icon -->
          <span class="label">
-            <span v-if="status === 'thinking'">Thinking... {{ liveSeconds }}s</span>
-            <span v-else>Thought Process ({{ displayDuration }})</span>
+            <span v-if="status === 'thinking'">思考中… {{ liveSeconds }} 秒</span>
+            <span v-else-if="duration > 0">思考过程（{{ displayDuration }}）</span>
+            <span v-else>思考过程</span>
          </span>
          <span class="chevron" :class="{ 'open': isExpanded }"></span>
      </div>
@@ -23,8 +24,9 @@
           <!-- Removed Emoji Icon -->
         </div>
         <span class="title">
-          <span v-if="status === 'thinking'">Thinking for {{ liveSeconds }}s...</span>
-          <span v-else>Thought for ({{ displayDuration }})</span>
+          <span v-if="status === 'thinking'">思考中… {{ liveSeconds }} 秒</span>
+          <span v-else-if="duration > 0">已思考 {{ displayDuration }}</span>
+          <span v-else>思考过程</span>
         </span>
       </div>
       <div class="right">
@@ -103,11 +105,13 @@ const updateTime = () => {
 const displayDuration = computed(() => {
     // If actively thinking, show live timer
     if (props.status === 'thinking') {
-        return `${liveSeconds.value}s`
+        return `${liveSeconds.value} 秒`
     }
     // Otherwise show the final recorded duration for this segment
     const dur = props.duration || 0
-    return dur > 0 ? `${dur.toFixed(1)}s` : '0s'
+    if (dur <= 0) return ''
+    // 10 秒以内保留一位小数，更真实；更长就取整
+    return dur < 10 ? `${dur.toFixed(1)} 秒` : `${Math.round(dur)} 秒`
 })
 
 const toggle = () => {

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -408,8 +408,8 @@
 
     <!-- 4. Regular Bottom Input -->
     <view v-else class="input-area-wrapper">
-       <!-- Agent 任务清单常驻进度卡（todo_write 驱动，plan_update 事件更新） -->
-       <TodoProgressCard :todos="planTodos" />
+       <!-- 任务清单进度卡已随消息流内联展示（RootBubble），不再常驻输入框上方，
+            避免与气泡内的步骤分组重复（用户反馈：线性时序结构） -->
        <!-- 步数超限暂停：一键继续，免得用户手动输入「继续」 -->
        <view v-if="agentPaused && !isStreaming" class="continue-bar">
           <text class="continue-hint">已达单轮执行步数上限，任务已暂停</text>
@@ -541,7 +541,6 @@
 <script>
 import RootBubble from './AgentMessage/RootBubble.vue'
 import BackgroundTaskIndicator from './BackgroundTaskIndicator.vue'
-import TodoProgressCard from './AgentMessage/TodoProgressCard.vue'
 import { useAgentStream } from '@/composables/useAgentStream.js'
 import { ref, watch, onMounted, nextTick, getCurrentInstance, computed } from 'vue'
 import { createFile, getProjectFiles, getApiBaseUrl, rollbackConversation, performPptGeneration } from '@/services/api.js'
@@ -549,7 +548,7 @@ import { getAuthHeaders } from '@/utils/auth.js'
 
 export default {
   name: 'ChatInterface',
-  components: { RootBubble, BackgroundTaskIndicator, TodoProgressCard },
+  components: { RootBubble, BackgroundTaskIndicator },
   props: {
     projectId: String,
     projectName: String,
@@ -591,7 +590,6 @@ export default {
       lastHeartbeat,
       tokenUsage,
       fileChanges,
-      planTodos,
       agentPaused,
       agentRunStatus,
       reattachSSE,
@@ -1865,8 +1863,6 @@ export default {
        confirmPptGeneration,
        // File Changes Status
        fileChanges,
-       // Agent 任务清单进度卡
-       planTodos,
        // 步数超限一键继续
        agentPaused,
        handleContinue,

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -8,10 +8,35 @@
     <view v-if="variant === 'default'" class="libre-float">
       <!-- No manual save button: edits auto-save (modify listener → debounced
            saveDocument). The pill doubles as the autosave indicator
-           (保存中… / 已保存 / 保存失败). -->
-      <view v-if="displayStatus" class="libre-pill" :class="{ error: isError }">
+           (保存中… / 已保存 / 保存失败). Boot/load 阶段由下方进度面板展示，
+           pill 只负责就绪后的保存状态。 -->
+      <view v-if="displayStatus && !loadingOverlayVisible" class="libre-pill" :class="{ error: isError }">
         <view v-if="!isError && !ready" class="libre-spin"></view>
         <text>{{ displayStatus }}</text>
+      </view>
+    </view>
+    <!-- 加载进度面板：引擎启动 + 文档下载/打开是感知最慢的一段（尤其大文档），
+         把过程阶段化展示出来（用户反馈：不能更快，也要看得见进展）。 -->
+    <view v-if="loadingOverlayVisible" class="libre-loading">
+      <view class="libre-loading-card">
+        <view class="libre-doc-icon">
+          <view class="doc-fold"></view>
+          <view class="doc-line l1"></view>
+          <view class="doc-line l2"></view>
+          <view class="doc-line l3"></view>
+        </view>
+        <text class="libre-loading-name">{{ loadingTitle }}</text>
+        <view class="libre-progress-track">
+          <view class="libre-progress-fill" :style="{ width: bootPct + '%' }">
+            <view class="libre-progress-shimmer"></view>
+          </view>
+        </view>
+        <view class="libre-loading-meta">
+          <text class="libre-loading-stage">{{ bootStage }}</text>
+          <text class="libre-loading-pct">{{ Math.round(bootPct) }}%</text>
+        </view>
+        <text v-if="dlText" class="libre-loading-dl">{{ dlText }}</text>
+        <text class="libre-loading-hint">首次打开需初始化文档引擎，大文档会稍慢，请稍候</text>
       </view>
     </view>
     <!-- Experimental (⌘⇧O overlay) variant keeps the dev-probe toolbar. -->
@@ -54,7 +79,7 @@
 
 import { createWebviewEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
 import { getFileDownloadUrl, getFileUploadUrl } from '@/services/api.js'
-import { getAuthHeaders } from '@/utils/auth.js'
+import { getAuthHeaders, getCurrentUser } from '@/utils/auth.js'
 
 let seq = 0
 
@@ -83,6 +108,13 @@ export default {
       // Autosave: set by the worker's modify signal, cleared when a save starts;
       // read by the host (closeFile / evict) to know if a flush is needed.
       dirty: false,
+      // 加载进度面板状态：bootPct 按里程碑推进（其间缓慢滴答，避免看起来卡死），
+      // bootCap 是当前阶段允许滴到的上限；dl* 是文档字节下载进度。
+      bootPct: 3,
+      bootCap: 12,
+      bootStage: '正在启动文档引擎',
+      dlLoaded: 0,
+      dlTotal: 0,
     }
   },
   computed: {
@@ -93,6 +125,20 @@ export default {
     displayStatus() {
       if (this.variant !== 'default') return this.statusText
       return this.statusText === '就绪' ? '' : this.statusText
+    },
+    loadingOverlayVisible() {
+      // 「仅桌面版可用」是终态（h5 预览等场景），不是加载中——不展示进度面板
+      return this.variant === 'default' && !this.ready && !this.isError && this.statusText !== '仅桌面版可用'
+    },
+    loadingTitle() {
+      return (this.file && this.file.name) ? this.file.name : '正在准备编辑器'
+    },
+    dlText() {
+      if (!this.dlLoaded) return ''
+      const fmt = (n) => n > 1024 * 1024 ? (n / 1024 / 1024).toFixed(1) + ' MB' : Math.max(1, Math.round(n / 1024)) + ' KB'
+      return this.dlTotal > 0
+        ? `文档内容 ${fmt(this.dlLoaded)} / ${fmt(this.dlTotal)}`
+        : `已下载文档内容 ${fmt(this.dlLoaded)}`
     },
   },
   async mounted() {
@@ -107,6 +153,7 @@ export default {
       // them (the old flow: boot → endpoint ready → fetch → load) just added the
       // whole download to the perceived open time.
       if (this.file) this.prefetchBytes()
+      this.startBootTrickle()
       const info = await api.getEditor() // { url, preload, partition }
       this.mountWebview(info)
     } catch (e) {
@@ -119,6 +166,7 @@ export default {
     // by the closer (closeFile / evictLibreInstance await flushSave first) —
     // export needs the live webview, so saving from here is already too late.
     clearTimeout(this._saveTimer)
+    clearInterval(this._bootTimer)
     // Tell the host this editor (and its executor) is going away — so it can
     // stop routing AI commands to a disposed executor when the document tab is
     // closed or switched. The executor ref lets the host ignore stale closes.
@@ -129,6 +177,33 @@ export default {
     this.executor = null
   },
   methods: {
+    // ---- 加载进度面板 ----
+    // 里程碑之间用慢速滴答填充（封顶 bootCap），避免长阶段（WASM 编译/大文档
+    // 排版）看起来像卡死；真正的阶段跳变由 boot-log 里程碑驱动。
+    startBootTrickle() {
+      clearInterval(this._bootTimer)
+      this._bootTimer = setInterval(() => {
+        if (this.ready || this.isError) { clearInterval(this._bootTimer); return }
+        if (this.bootPct < this.bootCap) this.bootPct = Math.min(this.bootCap, this.bootPct + 0.6)
+      }, 400)
+    },
+    bootMilestone(base, cap, stage) {
+      if (this.ready) return
+      this.bootPct = Math.max(this.bootPct, base)
+      this.bootCap = Math.max(this.bootCap, cap)
+      if (stage) this.bootStage = stage
+    },
+    onBootLog(m) {
+      if (!m) return
+      if (m.indexOf('CJK font fetched') !== -1) this.bootMilestone(15, 30, '正在加载中文字体')
+      else if (m.indexOf('soffice.js loaded') !== -1) this.bootMilestone(32, 55, '正在初始化排版引擎')
+      else if (m.indexOf('thread port ready') !== -1) this.bootMilestone(58, 70, '正在启动文档服务')
+      else if (m.indexOf('空白文档就绪') !== -1 || m.indexOf('UI ready') !== -1) {
+        this.bootMilestone(72, 85, this.file ? '正在打开文档' : '即将就绪')
+      } else if (m.indexOf('load_document: 已加载真实文档') !== -1) {
+        this.bootMilestone(96, 99, '正在渲染文档')
+      }
+    },
     appendLog(m) {
       // Mirror to devtools so the product variant (overlay hidden) stays diagnosable.
       console.log('[libre-editor]', m)
@@ -158,6 +233,9 @@ export default {
         } else if (msg.type === 'modified') {
           // Worker modify signal (throttled in editor-main.js) → autosave.
           this.onDocModified()
+        } else if (msg.type === 'boot-log') {
+          // 引擎启动里程碑 → 加载进度面板推进阶段
+          this.onBootLog(String(msg.msg || ''))
         }
       })
       wv.addEventListener('did-fail-load', (e) => this.appendLog('did-fail-load: ' + (e.errorDescription || e.errorCode)))
@@ -197,6 +275,8 @@ export default {
           this.appendLog('load_document failed: ' + (e && e.message ? e.message : e))
         }
       }
+      this.bootPct = 100
+      clearInterval(this._bootTimer)
       this.ready = true
       if (this.statusText.indexOf('失败') === -1) this.statusText = '就绪'
       this.$emit('ready', this.executor)
@@ -209,7 +289,10 @@ export default {
       const fileId = f && (f.wpsFileId || f.id)
       if (!fileId) return
       const t0 = Date.now()
-      this._bytesPromise = this.fetchArrayBuffer(getFileDownloadUrl(fileId))
+      this._bytesPromise = this.fetchArrayBuffer(getFileDownloadUrl(fileId), (loaded, total) => {
+        this.dlLoaded = loaded
+        this.dlTotal = total
+      })
         .then((buf) => { this.appendLog('文档字节预取完成 / prefetched ' + (buf ? buf.byteLength : 0) + ' bytes in ' + (Date.now() - t0) + 'ms'); return buf })
         .catch((e) => { this.appendLog('预取失败（加载时重试）/ prefetch failed: ' + (e && e.message ? e.message : e)); return null })
     },
@@ -231,20 +314,30 @@ export default {
         return
       }
       this.appendLog('▶ load_document「' + name + '」(' + bytes.length + ' bytes) …')
+      this.bootMilestone(86, 95, '正在打开文档')
+      // 当前登录用户名随文档传给 worker：用户本人编辑的修订以用户名署名，
+      // AI 命令产生的修订署名 AI Workdeck（worker execCommand 按 __agent 切换）。
+      const u = getCurrentUser() || {}
+      const authorName = String(u.name || u.nickname || u.username || '')
       const t0 = Date.now()
-      const res = await this.executor.executeCommand('load_document', { bytes, name })
+      const res = await this.executor.executeCommand('load_document', { bytes, name, authorName })
       this.appendLog('  ← ' + (Date.now() - t0) + 'ms ' + JSON.stringify(res))
       if (!res || !res.success) throw new Error((res && res.message) || 'load_document returned no success')
     },
     // Authed binary fetch — same XHR auth pattern as FilePreview.fetchAuthedBlob,
     // but ArrayBuffer (the bytes we relay into the worker).
-    fetchArrayBuffer(url) {
+    fetchArrayBuffer(url, onProgress) {
       return new Promise((resolve, reject) => {
         const headers = getAuthHeaders() || {}
         const xhr = new XMLHttpRequest()
         xhr.open('GET', url, true)
         xhr.responseType = 'arraybuffer'
         Object.keys(headers).forEach((k) => xhr.setRequestHeader(k, headers[k]))
+        if (onProgress) {
+          xhr.onprogress = (ev) => {
+            try { onProgress(ev.loaded || 0, ev.lengthComputable ? ev.total : 0) } catch (e) { /* ignore */ }
+          }
+        }
         xhr.onload = () => (xhr.status === 200 ? resolve(xhr.response) : reject(new Error('HTTP ' + xhr.status)))
         xhr.onerror = () => reject(new Error('网络错误 / network error'))
         xhr.send()
@@ -392,6 +485,34 @@ export default {
 .libre-btn[disabled] { background: #6b7280; cursor: not-allowed; }
 .libre-close { background: #4b5563; margin-left: auto; }
 .libre-host { flex: 1; min-height: 0; width: 100%; }
+/* ---- 加载进度面板 ---- */
+.libre-loading { position: absolute; inset: 0; z-index: 15; display: flex; align-items: center; justify-content: center;
+  background: #F8F9FA; }
+.libre-loading-card { display: flex; flex-direction: column; align-items: center; gap: 10px; width: 320px; max-width: 80%; }
+.libre-doc-icon { position: relative; width: 44px; height: 56px; background: #fff; border: 1.5px solid #DEE2E6;
+  border-radius: 5px; margin-bottom: 4px; overflow: hidden; }
+.doc-fold { position: absolute; top: -1px; right: -1px; width: 14px; height: 14px;
+  background: #F8F9FA; border-left: 1.5px solid #DEE2E6; border-bottom: 1.5px solid #DEE2E6; border-radius: 0 0 0 5px; }
+.doc-line { position: absolute; left: 8px; height: 4px; border-radius: 2px; background: #E6F9F0;
+  animation: doc-line-pulse 1.6s ease-in-out infinite; }
+.doc-line.l1 { top: 20px; width: 26px; animation-delay: 0s; }
+.doc-line.l2 { top: 30px; width: 20px; animation-delay: 0.25s; }
+.doc-line.l3 { top: 40px; width: 24px; animation-delay: 0.5s; }
+@keyframes doc-line-pulse { 0%, 100% { background: #E9ECEF; } 50% { background: #5BD197; } }
+.libre-loading-name { font-size: 14px; font-weight: 600; color: #2C3338; max-width: 100%;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.libre-progress-track { width: 100%; height: 6px; background: #E9ECEF; border-radius: 999px; overflow: hidden; }
+.libre-progress-fill { position: relative; height: 100%; background: #5BD197; border-radius: 999px;
+  transition: width 0.5s ease; overflow: hidden; }
+.libre-progress-shimmer { position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+  animation: libre-shimmer 1.4s linear infinite; }
+@keyframes libre-shimmer { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+.libre-loading-meta { display: flex; justify-content: space-between; width: 100%; }
+.libre-loading-stage { font-size: 12px; color: #495057; }
+.libre-loading-pct { font-size: 12px; color: #1A5336; font-weight: 600; }
+.libre-loading-dl { font-size: 11px; color: #868E96; }
+.libre-loading-hint { font-size: 11px; color: #ADB5BD; margin-top: 6px; }
 .libre-log { position: absolute; right: 8px; bottom: 8px; width: 380px; max-height: 38vh; margin: 0;
   padding: 8px; background: #0b1220; color: #d1fae5; font: 11px/1.45 ui-monospace, monospace;
   overflow: auto; white-space: pre-wrap; word-break: break-all; border-radius: 6px; z-index: 10; }

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -46,6 +46,9 @@ export const EDITOR_ACTIONS = [
   // [diagnostic] registered device font families — ground truth for the CJK
   // font-injection/alias chain (zetaOfficeBoot.js).
   'list_fonts',
+  // [diagnostic] 修订记录清单（类型/作者/文本）。后端 doc_debug_revisions 的
+  // worker 端实现——此前 worker 未实现且未入白名单，一直返回 Unknown action。
+  'debug_revisions',
   // [#104 变量面板] document variable fields — bookmark-marked spans bound to a
   // (scope, varName) variable; driven by VariablePanel through the getWps adapter
   // in project-overview.vue, not by the AI agent pipeline.

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -52,6 +52,9 @@ export function useAgentStream() {
         thinking: { status: 'idle', content: '', duration: 0, startTime: 0, endTime: 0 },
         title: '',
         processes: [],
+        // 本轮的任务清单快照（plan_update 时写入）：计划卡随消息流内联展示，
+        // 历史消息也能保留自己那轮的计划（planTodos 全局值只代表最新一轮）。
+        planTodos: [],
         artifacts: [],
         walkthrough: '',
         content: '', // Main Answer (from <final> tag)
@@ -224,6 +227,10 @@ export function useAgentStream() {
         // 2. Prepare Assistant Bubble
         const newBubble = createAssistantBubble()
         newBubble.isStreaming = true
+        // 思考计时从「发送」那一刻起算（用户感知的等待包含网络/排队），而不是
+        // 等 <thinking> 标签到达才起算——否则经常显示 0 秒且卡顿期间不读秒。
+        newBubble.thinking.status = 'thinking'
+        newBubble.thinking.startTime = Date.now()
         bubbles.value.push(newBubble)
         currentAssistantBubble.value = newBubble
 
@@ -279,7 +286,7 @@ export function useAgentStream() {
             if (err.name !== 'AbortError') {
                 error.value = err.message
                 if (currentAssistantBubble.value) {
-                    currentAssistantBubble.value.content += `\n**Error**: ${err.message}`
+                    currentAssistantBubble.value.content += `\n**错误**: ${err.message}`
                     currentAssistantBubble.value.isStreaming = false
                 }
                 isStreaming.value = false
@@ -346,6 +353,14 @@ export function useAgentStream() {
             try {
                 const d = JSON.parse(dataStr)
                 planTodos.value = Array.isArray(d.todos) ? d.todos : []
+                // 同步快照到当前气泡：计划卡在消息流里按时序内联展示（线性结构）。
+                // 重连/切回历史会话时气泡指针为空，兜底挂到最后一个助手气泡。
+                let target = currentAssistantBubble.value
+                if (!target) {
+                    const last = bubbles.value[bubbles.value.length - 1]
+                    if (last && last.role === 'ASSISTANT') target = last
+                }
+                if (target) target.planTodos = [...planTodos.value]
             } catch (e) {
                 console.error('Failed to parse plan_update', e)
             }
@@ -454,7 +469,7 @@ export function useAgentStream() {
                     currentAssistantBubble.value.isEditorStreaming = true
                     // Add a placeholder message if content is empty
                     if (!currentAssistantBubble.value.content) {
-                        currentAssistantBubble.value.content = '*(Streaming content to document...)*'
+                        currentAssistantBubble.value.content = '*（正在向文档流式写入内容…）*'
                     }
                 }
 
@@ -639,6 +654,8 @@ export function useAgentStream() {
                     bubble.artifacts = []
                     bubble.walkthrough = ''
                 }
+                // 重连恢复：把已收到的任务清单快照挂回本轮气泡（plan_update 可能先到）
+                bubble.planTodos = Array.isArray(planTodos.value) ? [...planTodos.value] : []
 
                 currentAssistantBubble.value = bubble
                 currentAssistantBubble.value.isStreaming = true
@@ -672,7 +689,7 @@ export function useAgentStream() {
             const pid = `proc-sys-${Date.now()}`
             proc = {
                 id: pid,
-                title: 'System Actions',
+                title: '系统操作',
                 isExpanded: true,
                 steps: [],
                 content: ''
@@ -738,7 +755,7 @@ export function useAgentStream() {
                 type: evt.type,
                 status: evt.status,
                 data: evt.data,
-                fileName: evt.name ? evt.name : (evt.type === 'task_list' ? 'Task List' : 'Plan')
+                fileName: evt.name ? evt.name : (evt.type === 'task_list' ? '任务清单' : '计划')
             })
         }
     }
@@ -836,12 +853,26 @@ export function useAgentStream() {
             // Untagged text -> Main Content
             if (!bubble.content && !text.trim()) return
 
+            // 可见正文开始流出 = 思考阶段结束（无 <final> 标签的旧格式也要收敛读秒）
+            settleRootThinking(bubble)
+
             // [Modified] If we are streaming to the document editor, suppress untagged content from chat bubble
             if (bubble.isEditorStreaming) {
                 return
             }
 
             bubble.content += text
+        }
+    }
+
+    // 根级思考收敛：首个可见产出（标题/过程/正文）出现时，思考阶段自然结束。
+    // 计时从发送起算，所以这里的 duration = 用户真实等待的「思考+排队」时长。
+    const settleRootThinking = (bubble) => {
+        const th = bubble && bubble.thinking
+        if (th && th.status === 'thinking') {
+            th.status = 'done'
+            th.endTime = Date.now()
+            th.duration = th.startTime ? (th.endTime - th.startTime) / 1000 : 0
         }
     }
 
@@ -909,13 +940,15 @@ export function useAgentStream() {
                 } else {
                     // Only root thinking if NO processes exist yet
                     bubble.thinking.status = 'thinking'
-                    bubble.thinking.startTime = Date.now()
+                    // 发送时已打过 startTime（读秒从发送起算），这里只兜底补齐
+                    if (!bubble.thinking.startTime) bubble.thinking.startTime = Date.now()
                     activeTag = 'thinking'
                 }
             }
         } else if (tagName === 'title') {
             if (isClose) activeTag = null
             else {
+                settleRootThinking(bubble)
                 activeTag = 'title'
                 bubble.title = ''
             }
@@ -936,6 +969,7 @@ export function useAgentStream() {
                 activeTag = null
                 activeProcessId = null
             } else {
+                settleRootThinking(bubble)
                 const pid = `proc-${Date.now()}`
                 // 新任务开始 = 之前所有任务的文字步骤都已结束（兜底收敛，防止历史卡片停留"执行中"）
                 bubble.processes.forEach(p => p.items?.forEach(item => {
@@ -1067,10 +1101,10 @@ export function useAgentStream() {
             else activeTag = 'walkthrough'
         } else if (tagName === 'final') {
             if (isClose) activeTag = null
-            else activeTag = 'final'
+            else { settleRootThinking(bubble); activeTag = 'final' }
         } else if (tagName === 'question') {
             if (isClose) activeTag = null
-            else activeTag = 'question'
+            else { settleRootThinking(bubble); activeTag = 'question' }
         } else if (tagName === 'artifact') {
             if (!isClose) {
                 const typeMatch = (attrs || '').match(/type="([^"]+)"/)

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -5846,7 +5846,10 @@ export default {
         }
 
         try {
-            const result = await this.libreOfficeExecutor.executeCommand(commandAction, params)
+            // __agent 标记：worker 据此把这条命令产生的修订署名为 AI Workdeck
+            //（用户本人的 IME 输入等不带标记，署用户名），修订面板里可区分来源。
+            const result = await this.libreOfficeExecutor.executeCommand(
+                commandAction, Object.assign({}, params, { __agent: true }))
             const successFlag = result && result.success !== false
             await sendEditorResult(conversationId, requestId, successFlag, result, (result && result.error) || null)
         } catch (e) {

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -94,23 +94,16 @@ const NAMES = {
   pptx_export_editable: { zh: '导出可编辑PPT', en: 'Export editable slides' },
 }
 
-function appLocale() {
-  try {
-    if (typeof uni !== 'undefined' && uni.getLocale) return uni.getLocale() || 'zh-CN'
-  } catch (e) { /* uni 不可用时退回浏览器语言 */ }
-  return (typeof navigator !== 'undefined' && navigator.language) || 'zh-CN'
-}
-
 // code 可以是纯工具名，也可以是 <tool_code> 里的 `tool_name({...})` 完整调用串。
+// 产品是中文优先：显示名一律取 zh（此前按 uni.getLocale() 取语言，Electron 常
+// 返回 en-*，导致面板里中英文混杂——用户反馈统一为中文）。en 列保留给未来 i18n。
 export function toolDisplayName(code) {
   if (!code) return ''
   const m = String(code).match(/^\s*([\w.]+)\s*\(/)
   let name = m ? m[1] : String(code).trim()
   if (name.startsWith('wps_')) name = 'doc_' + name.slice(4) // 灰度别名归一
   const entry = NAMES[name]
-  if (entry) {
-    return appLocale().toLowerCase().startsWith('zh') ? entry.zh : entry.en
-  }
+  if (entry) return entry.zh
   // 兜底：未收录的代号按 snake_case 分词，至少可读
   return name.replace(/_/g, ' ')
 }

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -197,7 +197,13 @@ startEditorEndpoint({
   uiLang: q.get('uilang') === 'env' ? '' : (q.get('uilang') || 'zh-CN'),
   // (#79) The #66 runtime zh-CN langpack injection was removed: the self-built
   // engine ships zh-CN baked in, so injecting 38 files was pure boot overhead.
-  onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
+  onLog: (m) => {
+    console.log('[zeta-editor]', m)
+    if (VERIFY) vlog(m)
+    // 启动里程碑同步给宿主：LibreOfficeEditor 的加载进度面板据此推进阶段
+    // （引擎下载/字体/线程/文档就绪）。宿主在 dom-ready 前就订阅了 lo-relay。
+    try { hostTransport.send({ __lo: 'lo-relay', type: 'boot-log', msg: String(m) }) } catch (e) { /* ignore */ }
+  },
 }).then((endpoint) => {
   console.log('[zeta-editor] endpoint ready — serving host over transport')
   // (#79 click-to-open) LO WASM never calls window.open on hyperlink clicks

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -53,6 +53,28 @@ function readConfigLocale() {
   } catch (e) { return { err: errStr(e) }; }
 }
 
+// ---- 修订作者署名 ----------------------------------------------------------
+// 修订（redline）的作者名取自 UserProfile 配置（givenname+sn）。AI 发起的编辑
+// 统一署名 AI_AUTHOR，用户本人的操作（IME 输入、快捷键）署用户名——同一引擎里
+// 两种来源的修订在修订面板中可区分（用户需求）。execCommand 按 __agent 标记
+// 在每条命令前切换；setRedlineAuthor 有同值短路，切换才真正写配置。
+const AI_AUTHOR = 'AI Workdeck';
+let humanAuthor = '';        // load_document 时由宿主传入（当前登录用户名）
+let currentRedlineAuthor = null;
+function setRedlineAuthor(name) {
+  const n = String(name == null ? '' : name);
+  if (currentRedlineAuthor === n) return;
+  const provider = context.getServiceManager().createInstanceWithContext(
+    'com.sun.star.configuration.ConfigurationProvider', context);
+  const access = provider.createInstanceWithArguments(
+    'com.sun.star.configuration.ConfigurationUpdateAccess',
+    [mkProp('nodepath', '/org.openoffice.UserProfile/Data')]);
+  access.replaceByName('givenname', n);
+  access.replaceByName('sn', '');
+  access.commitChanges();
+  currentRedlineAuthor = n;
+}
+
 // LibreOffice import filter names by extension — used only for the stream-load
 // fallback (private:stream has no URL extension to auto-detect a filter from).
 const IMPORT_FILTERS = {
@@ -417,6 +439,7 @@ const EXEC = {
     const all = p.replaceAll !== false;
     let hit = xModel.findFirst(sd), n = 0;
     while (hit !== null) {
+      selectVisibly(hit); // 拟人：视图滚到正在修订的位置，用户看得见改在哪
       hit.setString(String(p.replaceText || ''));
       n++;
       if (!all) break;
@@ -470,7 +493,11 @@ const EXEC = {
     const idx = Number(p.matchIndex) || 0;
     let hit = xModel.findFirst(sd), i = 0;
     while (hit !== null) {
-      if (i === idx) { hit.setString(String(p.replaceText || '')); return { success: true, replacedIndex: idx }; }
+      if (i === idx) {
+        selectVisibly(hit); // 拟人：先滚到目标位置再动手
+        hit.setString(String(p.replaceText || ''));
+        return { success: true, replacedIndex: idx };
+      }
       hit = xModel.findNext(hit, sd); i++;
     }
     return { success: false, message: 'match index out of range: ' + idx + ' (found ' + i + ')' };
@@ -483,7 +510,11 @@ const EXEC = {
     const idx = Number(p.matchIndex) || 0;
     let hit = xModel.findFirst(sd), i = 0;
     while (hit !== null) {
-      if (i === idx) { hit.setString(''); return { success: true, deletedIndex: idx }; }
+      if (i === idx) {
+        selectVisibly(hit); // 拟人：先滚到目标位置再删
+        hit.setString('');
+        return { success: true, deletedIndex: idx };
+      }
       hit = xModel.findNext(hit, sd); i++;
     }
     return { success: false, message: 'match index out of range: ' + idx };
@@ -495,7 +526,13 @@ const EXEC = {
     sd.setSearchString(String(p.text || ''));
     const all = p.deleteAll !== false;
     let hit = xModel.findFirst(sd), n = 0;
-    while (hit !== null) { hit.setString(''); n++; if (!all) break; hit = xModel.findNext(hit, sd); }
+    while (hit !== null) {
+      selectVisibly(hit); // 拟人：视图滚到正在删除的位置
+      hit.setString('');
+      n++;
+      if (!all) break;
+      hit = xModel.findNext(hit, sd);
+    }
     return { success: true, deleted: n };
   },
   // [verified-extend] read the Nth (0-based) paragraph's text.
@@ -776,6 +813,8 @@ const EXEC = {
   // document. Two independent load strategies (MEMFS file, then private:stream)
   // so a single UNO-API quirk on a device can't blank the user's content.
   load_document(p) {
+    // 宿主随文档带来当前登录用户名：用户本人编辑的修订署名（AI 的署 AI Workdeck）
+    if (p && p.authorName != null) humanAuthor = String(p.authorName);
     const name = String(p && p.name || 'document.docx');
     const m = name.match(/\.([A-Za-z0-9]+)$/);
     const ext = (m ? m[1] : 'docx').toLowerCase();
@@ -1238,6 +1277,25 @@ const EXEC = {
     try { vc.collapseToEnd(); } catch (e) {}
     return { success: true, bytes: u8.length, width: w, height: h };
   },
+  // [diagnostic] 修订记录清单（类型/作者/文本片段）。后端 doc_debug_revisions
+  // 一直派发 debug_revisions，worker 此前未实现（一律返回 not implemented）；
+  // 补上后同时作为修订署名（AI Workdeck / 用户名）的验证探针。
+  debug_revisions() {
+    const out = [];
+    try {
+      const en = xModel.getRedlines().createEnumeration();
+      while (en.hasMoreElements() && out.length < 200) {
+        const r = en.nextElement();
+        const item = {};
+        try { item.type = r.getPropertyValue('RedlineType'); } catch (e) {}
+        try { item.author = r.getPropertyValue('RedlineAuthor'); } catch (e) {}
+        try { item.comment = r.getPropertyValue('RedlineComment'); } catch (e) {}
+        try { if (typeof r.getString === 'function') item.text = String(r.getString() || '').slice(0, 80); } catch (e) {}
+        out.push(item);
+      }
+    } catch (e) { return { success: false, message: errStr(e) }; }
+    return { success: true, count: out.length, redlines: out };
+  },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {
     const bms = xModel.getBookmarks();
@@ -1256,8 +1314,13 @@ const EXEC = {
 function execCommand(reqId, action, params) {
   let result;
   try {
+    const p = params || {};
+    // 修订署名切换：AI 命令（宿主打 __agent 标记）→ AI Workdeck；其余（IME 输入
+    // 等用户本人操作）→ 用户名。失败不阻断命令本身（降级为引擎默认作者）。
+    try { setRedlineAuthor(p.__agent ? AI_AUTHOR : humanAuthor); }
+    catch (e) { log('修订作者设置失败 / redline author failed: ' + errStr(e)); }
     const fn = EXEC[action];
-    result = fn ? fn(params || {}) : { success: false, message: 'not implemented in LibreOffice worker yet: ' + action };
+    result = fn ? fn(p) : { success: false, message: 'not implemented in LibreOffice worker yet: ' + action };
   } catch (e) {
     result = { success: false, message: errStr(e) };
   }

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -243,6 +243,19 @@ try {
     JSON.stringify(cl.clauses && cl.clauses[0]))
   check('首部段落不计入条款', cl.preambleParagraphs === 1, JSON.stringify(cl.preambleParagraphs))
 
+  console.log('== 10) 修订作者署名（AI Workdeck vs 用户名） ==')
+  await reset('署名测试。', true) // rc ON：以下插入都会落成修订
+  // AI 命令：宿主 handleEditorCommand 会打 __agent 标记 → 署名 AI Workdeck
+  await exec('insert_at_cursor', { text: 'AI改动', __agent: true })
+  // 用户操作（IME 提交等）不带标记 → 署当前用户名。load_document 空字节调用
+  // 只用来注入 authorName（与宿主 loadDocument 的传参路径一致）。
+  await exec('load_document', { authorName: '测试用户' })
+  await exec('insert_at_cursor', { text: '用户改动' })
+  const rv = await exec('debug_revisions')
+  const authors = (rv.redlines || []).map((r) => r.author)
+  check('AI 修订署名 AI Workdeck', rv.success && authors.includes('AI Workdeck'), JSON.stringify(rv))
+  check('用户修订署用户名', authors.includes('测试用户'), JSON.stringify(authors))
+
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
 } finally {
   await browser.close()


### PR DESCRIPTION
## 背景（用户反馈五连）

1. **文档加载慢无过程展示** → 新增阶段化加载进度面板
2. **Thought for (0s) 不真实、发送后不读秒** → 计时从发送起算
3. **操作步骤中英文混杂** → 统一中文
4. **右侧面板结构杂乱** → 线性时序结构（思考 → 计划框 → 分步进展+步骤内工具调用 → 正文）
5. **修订体验** → 自动滚动定位到修订位置；AI 修订统一署名 AI Workdeck

## 改动

### 右侧 AI 面板
- `useAgentStream.js`：气泡创建（发送）即打思考 startTime，首个可见产出（title/process/正文）收敛思考态并结算时长；`plan_update` 快照挂当前气泡（重连/历史兜底挂最后助手气泡）
- `ThinkingCard.vue`：中文文案，`思考中… N 秒`（实时）/ `已思考 N 秒`（<10s 保留一位小数）
- `toolDisplayNames.js`：显示名固定取 zh（Electron locale 常为 en-*，是中英混杂根因）；en 列保留给未来 i18n
- `RootBubble.vue`：计划卡（TodoProgressCard）内联到气泡内、置于标题之后步骤分组之前；`ChatInterface.vue` 撤下输入框上方常驻计划卡（去重复）
- 汉化残留：System Actions→系统操作、Working…→处理中…、Tool Call→工具调用等

### 文档编辑器（LOWA）
- `LibreOfficeEditor.vue`：加载进度面板——引擎启动里程碑（字体/引擎核心/文档服务）+ 文档字节下载进度（XHR onprogress）+ 里程碑间缓慢滴答防假死感；`editor-main.js` 把 boot 日志经 lo-relay 转发宿主
- `office_thread.js`：
  - 修订自动定位：`find_replace`/`replace_nth_match`/`delete_match`/`delete_text` 编辑前 `selectVisibly`（视图滚到修订处）
  - 修订署名：`execCommand` 按 `__agent` 标记切换 UserProfile 作者（AI→`AI Workdeck`，用户操作→登录用户名，`load_document` 传入）；同值短路
  - 补 `debug_revisions` 实现并入白名单——后端 `doc_debug_revisions` 此前一直返回 Unknown action（顺带修复）
- `project-overview.vue`：AI 命令派发处统一打 `__agent` 标记

## 验证
- `npm run check:emits` ✓（45 个 .vue）
- `npm run build:h5` ✓、`npm run build:zetaoffice` ✓
- `npm run test:lowa-e2e` **27/27 通过**（新增第 10 节：真实引擎上断言 AI 修订作者=AI Workdeck、用户修订作者=用户名）

🤖 Generated with [Claude Code](https://claude.com/claude-code)