### PR TITLE
fix(scripts): fetch-lowa-assets 下载加退避重试抗 CDN 瞬时 TLS 失败

### DIFF
--- a/desktop/scripts/fetch-lowa-assets.js
+++ b/desktop/scripts/fetch-lowa-assets.js
@@ -154,6 +154,24 @@ function fetchUrl(url, headers) {
   return get(url, headers);
 }
 
+// Transient CDN failures (mid-handshake TLS disconnects, 5xx) can strike several
+// times in a row during a release; retry each download with backoff before
+// failing the build. Deterministic failures (encoding mismatch, magic check on a
+// complete body) happen after this layer and are NOT retried.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function fetchUrlWithRetry(url, headers, attempts = 3) {
+  for (let i = 1; ; i++) {
+    try { return await fetchUrl(url, headers); }
+    catch (e) {
+      if (i >= attempts) throw e;
+      const delay = 2000 * i;
+      console.warn('\n  ! ' + url + ' failed (attempt ' + i + '/' + attempts + '): ' +
+        (e.message || e) + '; retrying in ' + (delay / 1000) + 's');
+      await sleep(delay);
+    }
+  }
+}
+
 // GET with up to 5 redirects; resolves {encoding, body:Buffer}.
 function get(url, headers, redirects = 0) {
   const mod = url.startsWith('http://') ? http : https;
@@ -246,7 +264,7 @@ async function fetchAsset(a) {
   process.stdout.write('  ↓ ' + a.dest + ' …');
   // 'static' assets are served without encoding replay, so insist on identity.
   const reqHeaders = a.serve === 'static' ? { 'Accept-Encoding': 'identity' } : {};
-  const { encoding, body } = await fetchUrl(a.url, reqHeaders);
+  const { encoding, body } = await fetchUrlWithRetry(a.url, reqHeaders);
   const enc = encoding || null;
   // Default CDN: assert the encoding we expect, so a CDN change trips the build.
   // Custom LOWA_BASE_URL: the encoding is unknown, so accept whatever the source


### PR DESCRIPTION
## 背景
2026-07-18 发版时 cdn.zetaoffice.net 瞬时 TLS 断连连续出现 3 次，`fetch-lowa-assets.js` 一次失败即中断构建。

## 改动
- 新增 `fetchUrlWithRetry`：每个资产下载最多 3 次尝试，退避 2s/4s，重试时打印 `! <url> failed (attempt i/3): <原因>`。
- 只重试网络层（TLS 断连、HTTP 非 200、传输中断）；确定性失败（content-encoding 断言、magic 校验）发生在重试层之后，不重试。

## 关于"失败仍 exit 0"的核查
未复现：`main().catch` 一直就有 `process.exit(1)`（三次历史改动均在），假 URL 实测退出码为 1；CI 的 `run:` 步骤默认 `-e` 会正常失败。`loadExistingEncodings`/`cachedOk` 里的 catch 是缓存未命中回退，不吞致命错误。当时看到的 exit 0 疑似来自链条中后一条命令。

## 验证
- 假 URL（`LOWA_BASE_URL=https://nonexistent-host-zzz-12345.invalid/lowa/`）：3 次尝试、两次退避后 `fetch-lowa-assets failed`，**exit 1** ✅
- `LOWA_BASE_URL=https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r2/`（CI 同款）：8 个资产全量下载 107.4 MB，sidecar `{"soffice.wasm":"br","soffice.data":"br"}`，**exit 0** ✅
- 顺带实测：此刻 cdn.zetaoffice.net 直连 curl 也是 TLS 失败（挂的是上游 CDN，自托管引擎正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)