### PR TITLE
移除实验探针工具栏与 ⌘⇧O 覆盖层（修复文档顶部深色开发条回归）

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -1393,12 +1393,8 @@ app.whenReady().then(() => {
         .openZetaOfficeVerifyWindow()
         .catch((e) => console.error('[zeta-verify]', e))
     })
-    // Epic #43: ⌘⇧O opens the embedded LibreOffice editor (a <webview> inside the
-    // MAIN renderer — the real-flow topology, vs ⌘⇧L's standalone window). Tells
-    // the renderer to mount the overlay; dormant until pressed.
-    globalShortcut.register('CommandOrControl+Shift+O', () => {
-      try { if (mainWindow) mainWindow.webContents.send('checkba:zetaoffice-open-embed') } catch (e) { /* ignore */ }
-    })
+    // （已移除）⌘⇧O 实验覆盖层：嵌入式编辑器已是产品默认内联编辑器，覆盖层
+    // 只会在文档上凭空盖一条开发工具栏（用户报告）。独立验证窗 ⌘⇧L 保留。
   } catch (e) { /* ignore */ }
   // 桌面端启动时自动拉起本机服务（Java 后端 9696 + 打包态的 pptx-service）；
   // 打包态先确保 pysvc 已解压（首启/升级后带进度窗，常规启动是零开销快路径）

--- a/desktop/preload/preload.js
+++ b/desktop/preload/preload.js
@@ -119,15 +119,10 @@ contextBridge.exposeInMainWorld('checkbaDesktop', {
     showOpenDialog: (options) => ipcRenderer.invoke('fs:showOpenDialog', options)
   },
   // Epic #43: embedded LibreOffice editor <webview> wiring. getEditor() returns
-  // { url, preload, partition } for the host to mount the webview; onOpenEmbed
-  // fires when the ⌘⇧O global shortcut requests the editor overlay.
+  // { url, preload, partition } for the host to mount the webview.
+  // （onOpenEmbed / ⌘⇧O 覆盖层已移除：内联编辑器就是产品默认。）
   zetaoffice: {
-    getEditor: () => ipcRenderer.invoke('checkba:zetaoffice-editor'),
-    onOpenEmbed: (handler) => {
-      const listener = () => handler && handler()
-      ipcRenderer.on('checkba:zetaoffice-open-embed', listener)
-      return () => ipcRenderer.removeListener('checkba:zetaoffice-open-embed', listener)
-    }
+    getEditor: () => ipcRenderer.invoke('checkba:zetaoffice-editor')
   }
 })
 

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -1,11 +1,10 @@
 <template>
   <view class="libre-editor-wrapper">
-    <!-- Product ('default') variant: NO full-width bar — it read as alien chrome
-         on top of the document (user feedback). Status + save float over the
-         editor's top-right corner instead; the status pill only appears while
-         something is happening (booting/loading/saving/failure) and vanishes
-         when ready. -->
-    <view v-if="variant === 'default'" class="libre-float">
+    <!-- NO full-width bar — it read as alien chrome on top of the document
+         (user feedback). Status floats over the editor's top-right corner;
+         the pill only appears while something is happening (saving/failure)
+         and vanishes when ready. -->
+    <view class="libre-float">
       <!-- No manual save button: edits auto-save (modify listener → debounced
            saveDocument). The pill doubles as the autosave indicator
            (保存中… / 已保存 / 保存失败). Boot/load 阶段由下方进度面板展示，
@@ -39,24 +38,9 @@
         <text class="libre-loading-hint">首次打开需初始化文档引擎，大文档会稍慢，请稍候</text>
       </view>
     </view>
-    <!-- Experimental (⌘⇧O overlay) variant keeps the dev-probe toolbar. -->
-    <view v-else class="libre-toolbar">
-      <text class="libre-title">LibreOffice 编辑器（嵌入式 webview · 实验）</text>
-      <text v-if="displayStatus" class="libre-status" :class="{ ready, error: isError }">{{ displayStatus }}</text>
-      <button v-if="file" class="libre-btn" :disabled="!ready || saving" @click="saveDocument">
-        {{ saving ? '保存中…' : '保存' }}
-      </button>
-      <button class="libre-btn" :disabled="!ready" @click="runInsert">插入示例</button>
-      <button class="libre-btn" :disabled="!ready" @click="runReplace">查找替换(redline)</button>
-      <button class="libre-btn" :disabled="!ready" @click="runSelection">读选区</button>
-      <button class="libre-btn libre-close" @click="$emit('close')">关闭</button>
-    </view>
     <!-- The Electron <webview> is created imperatively (uni-app's template
          compiler does not know the <webview> tag); it mounts into this host. -->
     <view :id="hostId" class="libre-host"></view>
-    <!-- Log overlay is dev-probe UI only; product builds get the same lines via
-         devtools console (appendLog mirrors there). -->
-    <pre v-if="log && variant !== 'default'" class="libre-log">{{ log }}</pre>
   </view>
 </template>
 
@@ -65,17 +49,12 @@
 // Electron <webview partition="persist:zetaoffice"> inside the MAIN renderer.
 // Epic #43.
 //
-// This is the activation of the dormant foundation: the webview loads
-// dist/zetaoffice/editor.html over the shared same-origin server, gets COOP/COEP
-// isolation from desktop/main/zetaoffice-session.js (so LOWA's SharedArrayBuffer
-// works), and is wrapped by createWebviewEditorExecutor (#52) into the standard
-// executeCommand(action, params) contract. The toolbar buttons drive that
-// executor directly — proving the host -> webview IPC -> office worker -> UNO ->
-// real LibreOffice round-trip on the device (the last unverified link before the
-// backend agent stream is routed through useEditorBridge).
-//
-// Self-contained / dormant: nothing renders this unless explicitly mounted
-// (⌘⇧O overlay), so the WPS document flow is byte-for-byte unaffected.
+// The webview loads dist/zetaoffice/editor.html over the shared same-origin
+// server, gets COOP/COEP isolation from desktop/main/zetaoffice-session.js (so
+// LOWA's SharedArrayBuffer works), and is wrapped by createWebviewEditorExecutor
+// (#52) into the standard executeCommand(action, params) contract. Mounted only
+// by the project-overview keep-alive pool as the product inline document editor
+// （原 ⌘⇧O 实验覆盖层与探针工具栏已移除）.
 
 import { createWebviewEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
 import { getFileDownloadUrl, getFileUploadUrl } from '@/services/api.js'
@@ -87,13 +66,10 @@ export default {
   name: 'LibreOfficeEditor',
   emits: ['close', 'ready', 'open-url'],
   props: {
-    // 'experimental' = the original ⌘⇧O overlay (dev probe toolbar shown).
-    // 'default'      = inline document editor (Track B): toolbar chrome hidden.
-    variant: { type: String, default: 'experimental' },
     // Track D: the Office file to load into the editor ({ id, name, fileType,
     // wpsFileId }). When set, the editor fetches its bytes (authed) and loads the
-    // REAL document once the office endpoint is ready. null (⌘⇧O overlay) keeps
-    // the seeded prototype.
+    // REAL document once the office endpoint is ready.
+    // （原 'experimental' ⌘⇧O 探针工具栏变体已移除：产品只有内联编辑器一种形态。）
     file: { type: Object, default: null },
   },
   data() {
@@ -121,14 +97,13 @@ export default {
     isError() {
       return this.statusText.indexOf('失败') !== -1
     },
-    // Product variant stays quiet once ready — no permanent "就绪" badge.
+    // Stays quiet once ready — no permanent "就绪" badge.
     displayStatus() {
-      if (this.variant !== 'default') return this.statusText
       return this.statusText === '就绪' ? '' : this.statusText
     },
     loadingOverlayVisible() {
       // 「仅桌面版可用」是终态（h5 预览等场景），不是加载中——不展示进度面板
-      return this.variant === 'default' && !this.ready && !this.isError && this.statusText !== '仅桌面版可用'
+      return !this.ready && !this.isError && this.statusText !== '仅桌面版可用'
     },
     loadingTitle() {
       return (this.file && this.file.name) ? this.file.name : '正在准备编辑器'
@@ -250,8 +225,7 @@ export default {
         // dom-ready means the webview's renderer is up — NOT that the office is
         // booted. We wait for the endpoint-ready handshake (onReady) before
         // marking ready / pushing the document, so load_document can't be dropped
-        // pre-boot. The dev-probe toolbar in the experimental variant stays
-        // disabled until then (ready=false).
+        // pre-boot.
         this.executor = createWebviewEditorExecutor(wv, { onReady: () => this.onEndpointReady() })
         // 命令繁忙跟踪：AI 命令与用户输入都走这同一个 executor。autoSave 据此
         // 避开活跃期（export_document 会冻结 office 线程上的 Qt 事件循环）。
@@ -468,30 +442,15 @@ export default {
         xhr.send(form)
       })
     },
-    async run(label, action, params) {
-      if (!this.executor) return
-      this.appendLog('▶ ' + label + ' …')
-      try { this.appendLog('  ← ' + JSON.stringify(await this.executor.executeCommand(action, params))) }
-      catch (e) { this.appendLog('  ✗ ' + (e && e.message ? e.message : e)) }
-    },
-    runInsert() {
-      this.run('插入示例', 'insert_at_cursor',
-        { text: '本协议由甲方与乙方于本日签订；协议自双方签署之日起生效。' })
-    },
-    runReplace() {
-      this.run('查找替换 协议→合同 (redline)', 'find_replace',
-        { findText: '协议', replaceText: '合同', replaceAll: true })
-    },
-    runSelection() { this.run('读选区', 'get_selection', {}) },
   },
 }
 </script>
 
 <style scoped>
 .libre-editor-wrapper { position: relative; display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
-/* Product variant: floating status pill + save, pinned over the editor's
-   top-right corner (LO's own menubar leaves that region empty). No layout
-   height is reserved — the document canvas gets the full pane. */
+/* Floating status pill, pinned over the editor's top-right corner (LO's own
+   menubar leaves that region empty). No layout height is reserved — the
+   document canvas gets the full pane. */
 .libre-float { position: absolute; top: 6px; right: 16px; z-index: 20; display: flex; align-items: center; gap: 8px; }
 .libre-pill { display: flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px;
   background: rgba(31, 41, 55, 0.78); color: #e5e7eb; font-size: 12px; backdrop-filter: blur(4px); }
@@ -499,17 +458,6 @@ export default {
 .libre-spin { width: 10px; height: 10px; border: 2px solid rgba(229, 231, 235, 0.35); border-top-color: #e5e7eb;
   border-radius: 50%; animation: libre-rot 0.8s linear infinite; }
 @keyframes libre-rot { to { transform: rotate(360deg); } }
-.libre-save { font-size: 12px; line-height: 1; padding: 5px 12px; border: 0; border-radius: 999px;
-  background: #059669; color: #fff; cursor: pointer; box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18); }
-.libre-save[disabled] { background: #9ca3af; cursor: not-allowed; }
-.libre-toolbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 6px 10px; background: #1F2937; color: #fff; }
-.libre-title { font-size: 13px; font-weight: 600; }
-.libre-status { font-size: 12px; color: #d1d5db; }
-.libre-status.ready { color: #86efac; }
-.libre-status.error { color: #fca5a5; }
-.libre-btn { font-size: 12px; padding: 4px 10px; border: 0; border-radius: 4px; background: #059669; color: #fff; cursor: pointer; }
-.libre-btn[disabled] { background: #6b7280; cursor: not-allowed; }
-.libre-close { background: #4b5563; margin-left: auto; }
 .libre-host { flex: 1; min-height: 0; width: 100%; }
 /* ---- 加载进度面板 ---- */
 .libre-loading { position: absolute; inset: 0; z-index: 15; display: flex; align-items: center; justify-content: center;
@@ -539,7 +487,4 @@ export default {
 .libre-loading-pct { font-size: 12px; color: #1A5336; font-weight: 600; }
 .libre-loading-dl { font-size: 11px; color: #868E96; }
 .libre-loading-hint { font-size: 11px; color: #ADB5BD; margin-top: 6px; }
-.libre-log { position: absolute; right: 8px; bottom: 8px; width: 380px; max-height: 38vh; margin: 0;
-  padding: 8px; background: #0b1220; color: #d1fae5; font: 11px/1.45 ui-monospace, monospace;
-  overflow: auto; white-space: pre-wrap; word-break: break-all; border-radius: 6px; z-index: 10; }
 </style>

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -709,7 +709,6 @@
                   >
                     <LibreOfficeEditor
                       :ref="el => setLibreRef('left', file.id, el)"
-                      variant="default"
                       :file="file"
                       @ready="onLibreReady($event, 'left', file.id)"
                       @close="onLibreClose"
@@ -777,7 +776,6 @@
                   >
                     <LibreOfficeEditor
                       :ref="el => setLibreRef('right', file.id, el)"
-                      variant="default"
                       :file="file"
                       @ready="onLibreReady($event, 'right', file.id)"
                       @close="onLibreClose"
@@ -829,13 +827,6 @@
                 </view>
               </view>
 
-              <!-- Epic #43: embedded LibreOffice editor overlay (legacy ⌘⇧O).
-                   Scoped to the document area so the AI chat panel stays usable —
-                   a real backend AI command can be triggered while it's active.
-                   Dormant: only mounts when explicitly opened. -->
-              <view v-if="showLibreEmbed" class="libre-embed-overlay">
-                <LibreOfficeEditor @ready="onLibreReady" @close="onLibreClose" @open-url="onLibreOpenUrl" />
-              </view>
             </view>
 
             <!-- 底部常用工具面板（仅占中间工作区宽度；右侧 AI 面板优先完整显示） -->
@@ -1497,7 +1488,6 @@ export default {
 
       // Epic #43: embedded LibreOffice editor. When active, backend AI commands
       // route to it (handleEditorCommand).
-      showLibreEmbed: false,
       libreOfficeActive: false,
       libreOfficeExecutor: null,
       // 内嵌编辑器保活 LRU：'pane:fileId'（left:123），最近激活在前。在池中的
@@ -1797,7 +1787,6 @@ export default {
     if (this.convStatusPollTimer) { clearInterval(this.convStatusPollTimer); this.convStatusPollTimer = null }
     this.teardownResponsiveListener()
     // Epic #43: 解绑 ⌘⇧O 嵌入式编辑器监听
-    try { if (this._zetaOpenEmbedUnsub) { this._zetaOpenEmbedUnsub(); this._zetaOpenEmbedUnsub = null } } catch (e) { /* ignore */ }
     // 清理轮询定时器
     if (this.fileInfoPollingIntervals) {
       Object.values(this.fileInfoPollingIntervals).forEach(intervalId => {
@@ -2084,22 +2073,8 @@ export default {
       this.libreOfficePreferred = false
     }
 
-    // Epic #43: ⌘⇧O 打开嵌入式 LibreOffice 编辑器覆盖层（实验）。当嵌入式编辑器已是
-    // 文档的默认内联编辑器时（libreOfficePreferred），文档区已经承载它，⌘⇧O 变为
-    // 空操作以避免双重挂载（两个 webview/executor）；仅在未启用内联默认时回退到覆盖层。
-    try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.zetaoffice && window.checkbaDesktop.zetaoffice.onOpenEmbed) {
-        if (!this._zetaOpenEmbedUnsub) {
-          this._zetaOpenEmbedUnsub = window.checkbaDesktop.zetaoffice.onOpenEmbed(() => {
-            // 非活跃实例不响应：否则被覆盖的旧实例也置 showLibreEmbed，返回时凭空弹出编辑器
-            if (!this.isActiveOverviewInstance()) return
-            if (!this.libreOfficePreferred) this.showLibreEmbed = true
-          })
-        }
-      }
-    } catch (e) {
-      // ignore
-    }
+    // （⌘⇧O 实验覆盖层已移除：内联编辑器就是产品默认，覆盖层只会在文档上
+    // 凭空盖一条开发工具栏——用户报告。）
 
     // Desktop：拦截 WPS 中点击 “checkba://...” 的内部链接
     try {
@@ -2282,7 +2257,6 @@ export default {
     activeFileLeft(f) { this.onActiveOfficeFileChanged('left', f) },
     activeFileRight(f) { this.onActiveOfficeFileChanged('right', f) },
     focusedPane() { this.syncLibreExecutor() },
-    showLibreEmbed() { this.syncLibreExecutor() }
   },
   methods: {
     // EasyVoice Integration
@@ -5860,11 +5834,10 @@ export default {
     },
 
     // Epic #43: embedded LibreOffice editor lifecycle. While ready, backend AI
-    // commands route to it (see handleEditorCommand). Used by both the inline
-    // keep-alive pool (Track B) and the legacy ⌘⇧O overlay.
-    // pane/fileId 由保活池模板内联传入；overlay 不带（落到 'overlay' 键）。
+    // commands route to it (see handleEditorCommand). Used by the inline
+    // keep-alive pool (Track B)；pane/fileId 由保活池模板内联传入。
     onLibreReady(executor, pane, fileId) {
-        const key = pane ? pane + ':' + fileId : 'overlay'
+        const key = pane + ':' + fileId
         this.getLibreExecutorMap()[key] = executor
         this.syncLibreExecutor()
         console.log('[ProjectOverview] LibreOffice editor ready (' + key + ') — agent commands routed to LibreOffice')
@@ -5882,7 +5855,7 @@ export default {
     },
     // 活跃实例指针（同 PR#151 WPS 编辑器模式）：AI 指令路由到焦点 pane 的
     // 活动 Office 编辑器；焦点 pane 不是 Office 文档时回退另一 pane（保持
-    // 旧的"唯一打开的文档也能收指令"行为）；legacy overlay 打开时优先。
+    // 旧的"唯一打开的文档也能收指令"行为）。
     // 活动编辑器尚未 ready（boot 中）时指针为 null，handleEditorCommand
     // 照旧回"编辑器未就绪"。
     syncLibreExecutor() {
@@ -5891,8 +5864,7 @@ export default {
             const f = pane === 'right' ? this.activeFileRight : this.activeFileLeft
             return (f && this.useLibreEditor(f)) ? (map[pane + ':' + f.id] || null) : null
         }
-        let exec = this.showLibreEmbed ? (map['overlay'] || null) : null
-        if (!exec) exec = this.focusedPane === 'right' ? (pick('right') || pick('left')) : (pick('left') || pick('right'))
+        const exec = this.focusedPane === 'right' ? (pick('right') || pick('left')) : (pick('left') || pick('right'))
         this.libreOfficeExecutor = exec || null
         this.libreOfficeActive = !!exec
     },
@@ -5954,21 +5926,15 @@ export default {
       if (/^https?:\/\//i.test(u)) this.openBrowserTab(u)
     },
     onLibreClose(executor) {
-        // The overlay close button emits no executor: collapse the overlay; the
-        // unmount that follows re-enters here WITH the executor for real cleanup.
-        // An inline pool editor unmount (tab close / LRU evict) emits its own —
-        // drop it from the registry by identity and re-sync the active pointer,
-        // so closing a background instance can't clobber the active one.
+        // An inline pool editor unmount (tab close / LRU evict) emits its
+        // executor — drop it from the registry by identity and re-sync the
+        // active pointer, so closing a background instance can't clobber the
+        // active one.
         const map = this.getLibreExecutorMap()
         if (executor) {
             for (const k of Object.keys(map)) {
-                if (map[k] === executor) {
-                    delete map[k]
-                    if (k === 'overlay') this.showLibreEmbed = false
-                }
+                if (map[k] === executor) delete map[k]
             }
-        } else {
-            this.showLibreEmbed = false
         }
         this.syncLibreExecutor()
         if (!this.libreOfficeActive) console.log('[ProjectOverview] LibreOffice editor closed — agent commands unavailable until reopened')
@@ -10659,16 +10625,4 @@ $bg-white: #FFFFFF;
   opacity: 1;
 }
 
-/* Epic #43: embedded LibreOffice editor (experimental, ⌘⇧O).
-   Absolute within .editors-container (position:relative) so it covers the
-   document area only — the AI chat panel stays usable. */
-.libre-embed-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  background: #fff;
-}
 </style>


### PR DESCRIPTION
## 问题
产品态文档顶部凭空出现深色开发条「LibreOffice 编辑器（嵌入式 webview · 实验）保存/插入示例/查找替换/读选区/关闭」（用户截图报告）。

## 根因（如实说明：#1 是我在 PR#180 引入的回归）
1. **PR#180 的 v-else 错位**：插入加载进度面板时，实验工具栏的 `v-else` 从原本的 `v-if="variant === 'default'"` 错接到了面板的 `v-if="loadingOverlayVisible"` 上——内联编辑器加载完成后必然露出开发条。
2. 该工具栏本是 ⌘⇧O 调试浮层的探针 UI（且 `variant` 默认值就是 `experimental`），产品已上线不应保留。

## 修法：全链路摘除（-146 行）
- **desktop/main**：注销 ⌘⇧O 全局快捷键（还占用系统级热键）；⌘⇧L 独立验证窗保留，打包验证流程不受影响
- **preload**：删 `onOpenEmbed` 桥
- **project-overview**：删覆盖层挂载、`showLibreEmbed` 状态/watcher/订阅、执行器路由的 `'overlay'` 分支、覆盖层 CSS
- **LibreOfficeEditor**：删 `variant` 机制与 experimental 工具栏、探针按钮、日志浮层及相关样式——加载进度面板 + 右上角悬浮状态胶囊成为唯一形态

## 验证
- `check:emits` ✓（45 个 .vue）
- `build:h5` ✓
- `showLibreEmbed / onOpenEmbed / zetaoffice-open-embed` 残留引用 grep 为零

🤖 Generated with [Claude Code](https://claude.com/claude-code)