### PR TITLE
feat(ai): evidence.retrieve.v1 证据检索契约——MCP 降为传输适配层（落地 #14 社区建议）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/evidence/ClaimLink.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/ClaimLink.java
@@ -1,0 +1,47 @@
+package com.checkba.service.ai.evidence;
+
+import java.util.List;
+
+/**
+ * 主张与证据的关联（claim_link）——与证据检索分层：检索只负责拿回证据，
+ * 「这些证据支持/矛盾哪个主张」是独立的解释层对象。
+ *
+ * 不变式：证据缺失（missingEvidence）绝不允许被改写成矛盾（CONTRADICTS）——
+ * CONTRADICTS 必须至少援引一条真实证据。"查无此据"和"有据反驳"是两回事，
+ * 对法律工作流混淆二者是危险的。
+ *
+ * @param claimId         主张 ID
+ * @param evidenceIds     援引的证据 ID 列表（{@link EvidenceItem#evidenceId()}）
+ * @param relation        关系：支持 / 矛盾 / 背景
+ * @param confidence      置信度 0-1
+ * @param reviewer        复核人（可选，null = 未经人工复核）
+ * @param missingEvidence 缺失证据清单（描述"还需要什么证据"，可为空）
+ */
+public record ClaimLink(
+        String claimId,
+        List<String> evidenceIds,
+        Relation relation,
+        double confidence,
+        String reviewer,
+        List<String> missingEvidence) {
+
+    public enum Relation { SUPPORTS, CONTRADICTS, CONTEXT }
+
+    public ClaimLink {
+        if (claimId == null || claimId.isBlank()) {
+            throw new IllegalArgumentException("claim_link: claimId 必填");
+        }
+        if (relation == null) {
+            throw new IllegalArgumentException("claim_link: relation 必填");
+        }
+        evidenceIds = evidenceIds == null ? List.of() : List.copyOf(evidenceIds);
+        missingEvidence = missingEvidence == null ? List.of() : List.copyOf(missingEvidence);
+        if (relation == Relation.CONTRADICTS && evidenceIds.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "claim_link: 缺失证据不得改写为矛盾——CONTRADICTS 必须援引至少一条证据，查无此据请用 missingEvidence 表达");
+        }
+        if (confidence < 0 || confidence > 1) {
+            throw new IllegalArgumentException("claim_link: confidence 必须在 [0,1] 区间");
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceItem.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceItem.java
@@ -1,0 +1,58 @@
+package com.checkba.service.ai.evidence;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * evidence.retrieve.v1 的单条证据（稳定契约字段，见 docs/EVIDENCE_CONTRACT.md）。
+ *
+ * 硬约束：evidenceId / sourceUri / locator 缺一不可——没有精确定位符的内容
+ * 不允许伪装成证据返回（实现层必须丢弃并告警，而不是编造定位符）。
+ *
+ * @param evidenceId    稳定证据 ID（同一来源同一内容多次检索必须相同）
+ * @param sourceUri     来源 URI（如 checkba://file/42、https://...）
+ * @param contentHash   内容哈希（sha256 十六进制），内容变更即哈希变更
+ * @param retrievedAt   本次检索时间
+ * @param effectiveDate 生效日期（内容自何时起成立）
+ * @param locator       精确定位符（段落号/条文号/记录主键等）
+ * @param excerpt       有界摘录（不超过 {@link #MAX_EXCERPT_LENGTH} 字符）
+ * @param mimeType      内容类型
+ * @param accessPolicy  访问策略标注（如 "project"、"user:protected"）
+ * @param provenance    溯源链（从原始来源到本条目的传递路径，有序）
+ * @param supersedes    可选事件：本条证据取代的旧证据 ID
+ * @param revokes       可选事件：本条证据吊销的证据 ID
+ * @param supersededAt  可选信号：本条证据已有更新版本时，最新版本的时间
+ */
+public record EvidenceItem(
+        String evidenceId,
+        String sourceUri,
+        String contentHash,
+        LocalDateTime retrievedAt,
+        LocalDate effectiveDate,
+        String locator,
+        String excerpt,
+        String mimeType,
+        String accessPolicy,
+        List<String> provenance,
+        String supersedes,
+        String revokes,
+        LocalDateTime supersededAt) {
+
+    public static final int MAX_EXCERPT_LENGTH = 500;
+
+    public EvidenceItem {
+        if (isBlank(evidenceId) || isBlank(sourceUri) || isBlank(locator)) {
+            throw new IllegalArgumentException(
+                    "evidence.retrieve.v1: evidenceId/sourceUri/locator 为必填，缺定位符的内容不得作为证据返回");
+        }
+        provenance = provenance == null ? List.of() : List.copyOf(provenance);
+        if (excerpt != null && excerpt.length() > MAX_EXCERPT_LENGTH) {
+            excerpt = excerpt.substring(0, MAX_EXCERPT_LENGTH);
+        }
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceProperties.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceProperties.java
@@ -1,0 +1,42 @@
+package com.checkba.service.ai.evidence;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * evidence.retrieve.v1 的 MCP 来源配置（MCP 作为传输适配层接入证据契约）。
+ *
+ * <pre>
+ * ai:
+ *   evidence:
+ *     mcp-sources:
+ *       - source-id: caselaw
+ *         server: some-mcp-server   # 必须已在 mcp.servers 里配置
+ *         tool: retrieve_evidence   # 远端工具须按契约返回 {"items":[...]}
+ * </pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "ai.evidence")
+public class EvidenceProperties {
+
+    private List<McpSource> mcpSources = new ArrayList<>();
+
+    public List<McpSource> getMcpSources() { return mcpSources; }
+    public void setMcpSources(List<McpSource> mcpSources) { this.mcpSources = mcpSources; }
+
+    public static class McpSource {
+        private String sourceId;
+        private String server;
+        private String tool;
+
+        public String getSourceId() { return sourceId; }
+        public void setSourceId(String sourceId) { this.sourceId = sourceId; }
+        public String getServer() { return server; }
+        public void setServer(String server) { this.server = server; }
+        public String getTool() { return tool; }
+        public void setTool(String tool) { this.tool = tool; }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceQuery.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceQuery.java
@@ -1,0 +1,32 @@
+package com.checkba.service.ai.evidence;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * evidence.retrieve.v1 检索请求（RFC #14 讨论产出的稳定契约，勿随意改字段）。
+ *
+ * 契约与传输解耦：本地实现、远程服务、MCP 插件都消费同一份请求结构，
+ * MCP 只是传输适配层之一，不是契约本身。
+ *
+ * @param workspaceId   工作区标识。本地实现解释为项目 ID（纯数字或 "project:<id>"）
+ * @param query         检索文本
+ * @param asOf          时点语义：只返回该日期（含）之前生效的证据；null = 现在
+ * @param sourceFilters 来源过滤（如记忆作用域 project/file/global），空列表 = 不过滤
+ * @param accessContext 访问上下文（userId/conversationId 等），实现据此做权限裁剪
+ * @param limit         结果上限，非正数按实现默认值处理
+ */
+public record EvidenceQuery(
+        String workspaceId,
+        String query,
+        LocalDate asOf,
+        List<String> sourceFilters,
+        Map<String, String> accessContext,
+        int limit) {
+
+    public EvidenceQuery {
+        sourceFilters = sourceFilters == null ? List.of() : List.copyOf(sourceFilters);
+        accessContext = accessContext == null ? Map.of() : Map.copyOf(accessContext);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceRetriever.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceRetriever.java
@@ -1,0 +1,29 @@
+package com.checkba.service.ai.evidence;
+
+import java.util.List;
+
+/**
+ * evidence.retrieve.v1 检索能力 SPI。
+ *
+ * 设计取向（RFC #14）：契约稳定、传输可插拔——本地记忆、远程服务、MCP 服务器
+ * 都以本接口接入，Skill 通过 requires 声明依赖该能力，插件负责实现。
+ *
+ * 实现约定：
+ * 1. 幂等重放：同一 query（含 asOf）重复调用，返回的 evidenceId 与 contentHash 必须一致；
+ * 2. 缺定位符即丢弃：无法给出精确 locator 的内容不得返回（见 {@link EvidenceItem} 构造约束）；
+ * 3. 访问被拒/来源不可用时返回空列表并记日志，不抛异常炸掉编排主流程。
+ */
+public interface EvidenceRetriever {
+
+    String CONTRACT_VERSION = "evidence.retrieve.v1";
+
+    /** 来源标识（如 "memory"、"mcp:pkulaw-semantic"），注册表按此路由 */
+    String sourceId();
+
+    /** 按契约检索证据 */
+    List<EvidenceItem> retrieve(EvidenceQuery query);
+
+    default String contractVersion() {
+        return CONTRACT_VERSION;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceRetrieverRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceRetrieverRegistry.java
@@ -1,0 +1,51 @@
+package com.checkba.service.ai.evidence;
+
+import com.checkba.service.ai.mcp.McpClientService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * evidence.retrieve.v1 能力注册表：Spring Bean 实现（本地）+ 配置驱动的 MCP 来源统一挂在这里。
+ * Skill 的 requires 声明与后续插件实现都以此为发现入口。
+ */
+@Service
+@Slf4j
+public class EvidenceRetrieverRegistry {
+
+    private final Map<String, EvidenceRetriever> bySourceId = new LinkedHashMap<>();
+
+    public EvidenceRetrieverRegistry(List<EvidenceRetriever> beanRetrievers,
+                                     EvidenceProperties evidenceProperties,
+                                     McpClientService mcpClientService) {
+        for (EvidenceRetriever r : beanRetrievers) {
+            bySourceId.put(r.sourceId(), r);
+        }
+        for (EvidenceProperties.McpSource src : evidenceProperties.getMcpSources()) {
+            if (!StringUtils.hasText(src.getSourceId()) || !StringUtils.hasText(src.getServer())
+                    || !StringUtils.hasText(src.getTool())) {
+                log.warn("ai.evidence.mcp-sources 存在不完整配置（需 source-id/server/tool），已跳过");
+                continue;
+            }
+            McpEvidenceRetriever retriever =
+                    new McpEvidenceRetriever(src.getSourceId(), src.getServer(), src.getTool(), mcpClientService);
+            bySourceId.put(retriever.sourceId(), retriever);
+        }
+        log.info("EvidenceRetrieverRegistry: {} 个 {} 来源: {}",
+                bySourceId.size(), EvidenceRetriever.CONTRACT_VERSION, bySourceId.keySet());
+    }
+
+    /** 按来源标识查找；未注册返回 null */
+    public EvidenceRetriever find(String sourceId) {
+        return bySourceId.get(sourceId);
+    }
+
+    public List<EvidenceRetriever> all() {
+        return new ArrayList<>(bySourceId.values());
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/McpEvidenceRetriever.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/McpEvidenceRetriever.java
@@ -1,0 +1,144 @@
+package com.checkba.service.ai.evidence;
+
+import com.checkba.service.ai.mcp.McpClientService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * evidence.retrieve.v1 的 MCP 传输适配器：契约不变，MCP 只负责传输。
+ *
+ * 远端 MCP 工具须返回契约 JSON：{"items":[{evidence_id, source_uri, locator, ...}]}。
+ * 缺 evidence_id/source_uri/locator 的条目直接丢弃并告警——适配层不替远端编造定位符。
+ * 来源不可用/权限被拒（返回 "Error: ..."）时返回空列表，不炸编排主流程。
+ *
+ * 非 Spring Bean：由 {@link EvidenceRetrieverRegistry} 按 ai.evidence.mcp-sources 配置逐个实例化。
+ */
+@Slf4j
+public class McpEvidenceRetriever implements EvidenceRetriever {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String sourceId;
+    private final String server;
+    private final String tool;
+    private final McpClientService mcpClientService;
+
+    public McpEvidenceRetriever(String sourceId, String server, String tool, McpClientService mcpClientService) {
+        this.sourceId = sourceId;
+        this.server = server;
+        this.tool = tool;
+        this.mcpClientService = mcpClientService;
+    }
+
+    @Override
+    public String sourceId() {
+        return "mcp:" + sourceId;
+    }
+
+    @Override
+    public List<EvidenceItem> retrieve(EvidenceQuery query) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("workspace_id", query.workspaceId());
+        args.put("query", query.query());
+        if (query.asOf() != null) {
+            args.put("as_of", query.asOf().toString());
+        }
+        if (!query.sourceFilters().isEmpty()) {
+            args.put("source_filters", query.sourceFilters());
+        }
+        if (!query.accessContext().isEmpty()) {
+            args.put("access_context", query.accessContext());
+        }
+        args.put("limit", query.limit());
+
+        String raw = mcpClientService.callTool(server, tool, args);
+        if (raw == null || raw.startsWith("Error:")) {
+            log.warn("evidence.retrieve.v1[{}]: MCP 来源不可用: {}", sourceId(), raw);
+            return List.of();
+        }
+        return parseItems(raw);
+    }
+
+    private List<EvidenceItem> parseItems(String raw) {
+        JsonNode root;
+        try {
+            root = MAPPER.readTree(raw);
+        } catch (Exception e) {
+            log.warn("evidence.retrieve.v1[{}]: 响应不是合法 JSON，丢弃: {}", sourceId(), e.getMessage());
+            return List.of();
+        }
+        JsonNode itemsNode = root.path("items");
+        if (!itemsNode.isArray()) {
+            log.warn("evidence.retrieve.v1[{}]: 响应缺少 items 数组，丢弃", sourceId());
+            return List.of();
+        }
+        List<EvidenceItem> items = new ArrayList<>();
+        for (JsonNode n : itemsNode) {
+            try {
+                items.add(new EvidenceItem(
+                        text(n, "evidence_id"),
+                        text(n, "source_uri"),
+                        text(n, "content_hash"),
+                        parseDateTime(text(n, "retrieved_at")),
+                        parseDate(text(n, "effective_date")),
+                        text(n, "locator"),
+                        text(n, "excerpt"),
+                        text(n, "mime_type"),
+                        text(n, "access_policy"),
+                        stringList(n.path("provenance")),
+                        text(n, "supersedes"),
+                        text(n, "revokes"),
+                        null));
+            } catch (IllegalArgumentException e) {
+                // 契约硬约束触发（多为缺 locator）：丢弃该条，不编造
+                log.warn("evidence.retrieve.v1[{}]: 丢弃不合契约的条目: {}", sourceId(), e.getMessage());
+            }
+        }
+        return items;
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode v = node.path(field);
+        return v.isMissingNode() || v.isNull() ? null : v.asText();
+    }
+
+    private static List<String> stringList(JsonNode node) {
+        if (!node.isArray()) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>();
+        node.forEach(v -> out.add(v.asText()));
+        return out;
+    }
+
+    private static LocalDateTime parseDateTime(String s) {
+        if (s == null || s.isBlank()) {
+            return LocalDateTime.now();
+        }
+        try {
+            return LocalDateTime.parse(s.replace("Z", ""));
+        } catch (DateTimeParseException e) {
+            return LocalDateTime.now();
+        }
+    }
+
+    private static LocalDate parseDate(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(s);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/evidence/MemoryEvidenceRetriever.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/MemoryEvidenceRetriever.java
@@ -1,0 +1,138 @@
+package com.checkba.service.ai.evidence;
+
+import com.checkba.model.entity.MemoryEntry;
+import com.checkba.service.ai.memory.MemoryManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * evidence.retrieve.v1 的本地实现：把记忆证据账本（PR#155）落到稳定契约上。
+ *
+ * 映射关系：MemoryEntry → EvidenceItem
+ * - evidenceId  = "memory:<id>"（主键稳定，重放一致）
+ * - sourceUri   = 有来源文件时指向文件，其次对话，兜底记忆本身
+ * - contentHash = sha256(memoryValue)，内容变即哈希变
+ * - locator     = "memory_entry#<id>"（数据库主键即精确定位符）
+ * - supersededAt = 证据账本的更新信号（同 memoryKey 存在更晚版本）
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MemoryEvidenceRetriever implements EvidenceRetriever {
+
+    static final String SOURCE_ID = "memory";
+    private static final int DEFAULT_LIMIT = 10;
+
+    private final MemoryManager memoryManager;
+
+    @Override
+    public String sourceId() {
+        return SOURCE_ID;
+    }
+
+    @Override
+    public List<EvidenceItem> retrieve(EvidenceQuery query) {
+        Long projectId = parseWorkspaceId(query.workspaceId());
+        if (projectId == null) {
+            log.warn("evidence.retrieve.v1[memory]: 无法解析 workspaceId '{}'，返回空", query.workspaceId());
+            return List.of();
+        }
+        int limit = query.limit() > 0 ? query.limit() : DEFAULT_LIMIT;
+
+        List<MemoryEntry> entries;
+        try {
+            entries = memoryManager.retrieveMemories(projectId, query.query(), null, limit);
+        } catch (Exception e) {
+            log.warn("evidence.retrieve.v1[memory]: 检索失败，返回空: {}", e.getMessage());
+            return List.of();
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        List<MemoryEntry> visible = entries.stream()
+                .filter(e -> e.getId() != null && e.getMemoryValue() != null)
+                // 吊销语义：过期记忆不作为证据返回
+                .filter(e -> e.getExpiresAt() == null || e.getExpiresAt().isAfter(now))
+                // as_of 时点：晚于时点建立的记录不可见
+                .filter(e -> query.asOf() == null || e.getCreatedAt() == null
+                        || !e.getCreatedAt().toLocalDate().isAfter(query.asOf()))
+                // 来源过滤按作用域解释
+                .filter(e -> query.sourceFilters().isEmpty()
+                        || query.sourceFilters().contains(e.getScope()))
+                .toList();
+
+        Map<Long, LocalDateTime> superseded = memoryManager.findSupersededInfo(visible);
+
+        List<EvidenceItem> items = new ArrayList<>(visible.size());
+        for (MemoryEntry e : visible) {
+            items.add(toItem(e, superseded.get(e.getId()), now));
+        }
+        return items;
+    }
+
+    private EvidenceItem toItem(MemoryEntry e, LocalDateTime supersededAt, LocalDateTime retrievedAt) {
+        String sourceUri;
+        List<String> provenance = new ArrayList<>();
+        provenance.add("memory_entry:" + e.getId());
+        if (e.getSourceFileId() != null) {
+            sourceUri = "checkba://file/" + e.getSourceFileId();
+            provenance.add("file:" + e.getSourceFileId());
+        } else if (e.getConversationId() != null && !e.getConversationId().isBlank()) {
+            sourceUri = "checkba://conversation/" + e.getConversationId();
+            provenance.add("conversation:" + e.getConversationId());
+        } else {
+            sourceUri = "checkba://memory/" + e.getId();
+        }
+
+        String scope = e.getScope() == null ? MemoryEntry.MemoryScope.PROJECT : e.getScope();
+        String accessPolicy = Boolean.TRUE.equals(e.getIsProtected()) ? scope + ":protected" : scope;
+
+        return new EvidenceItem(
+                "memory:" + e.getId(),
+                sourceUri,
+                sha256(e.getMemoryValue()),
+                retrievedAt,
+                e.getCreatedAt() == null ? null : e.getCreatedAt().toLocalDate(),
+                "memory_entry#" + e.getId(),
+                e.getMemoryValue(),
+                "text/plain",
+                accessPolicy,
+                provenance,
+                null,
+                null,
+                supersededAt);
+    }
+
+    /** workspaceId 解释为项目 ID：纯数字或 "project:<id>" */
+    static Long parseWorkspaceId(String workspaceId) {
+        if (workspaceId == null || workspaceId.isBlank()) {
+            return null;
+        }
+        String raw = workspaceId.startsWith("project:")
+                ? workspaceId.substring("project:".length()) : workspaceId;
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    static String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("JVM 缺少 SHA-256 实现", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillDefinition.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillDefinition.java
@@ -35,6 +35,9 @@ public class SkillDefinition {
     /** 输出结构约定（自然语言描述，随 prompt 一起注入） */
     private String output;
 
+    /** 声明依赖的能力契约（如 evidence.retrieve.v1），由插件/内置实现提供；仅声明，不阻断加载 */
+    private List<String> requires = new ArrayList<>();
+
     /** 来源插件 id（插件携带的 skill）；内置 skill 为 null */
     private String sourcePluginId;
 
@@ -54,6 +57,8 @@ public class SkillDefinition {
     public void setAllowedTools(List<String> allowedTools) { this.allowedTools = allowedTools; }
     public String getOutput() { return output; }
     public void setOutput(String output) { this.output = output; }
+    public List<String> getRequires() { return requires; }
+    public void setRequires(List<String> requires) { this.requires = requires; }
     public String getSourcePluginId() { return sourcePluginId; }
     public void setSourcePluginId(String sourcePluginId) { this.sourcePluginId = sourcePluginId; }
 }

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
@@ -195,6 +195,7 @@ public class SkillRegistry {
         skill.setTriggers(asStringList(raw.get("triggers")));
         skill.setAllowedTools(asStringList(raw.get("allowed_tools")));
         skill.setOutput(asString(raw.get("output")));
+        skill.setRequires(asStringList(raw.get("requires")));
         String promptFile = asString(raw.get("prompt"));
         if (promptFile != null && !promptFile.isBlank()) {
             skill.setPromptFile(promptFile);

--- a/backend/src/main/java/com/checkba/service/ai/tools/EvidenceTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/EvidenceTools.java
@@ -1,0 +1,101 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.service.ai.evidence.EvidenceItem;
+import com.checkba.service.ai.evidence.EvidenceQuery;
+import com.checkba.service.ai.evidence.EvidenceRetriever;
+import com.checkba.service.ai.evidence.EvidenceRetrieverRegistry;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 证据检索工具：evidence.retrieve.v1 契约的 LLM 入口。
+ *
+ * 与 query_memory 的区别：本工具返回的是带溯源的结构化证据
+ * （稳定 ID、内容哈希、精确定位符、生效时间、更新信号），
+ * 用于"这个结论的依据是什么"类问题，输出可被引用与复核。
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class EvidenceTools implements AgentToolComponent {
+
+    private final EvidenceRetrieverRegistry evidenceRetrieverRegistry;
+
+    @Tool("检索带溯源的证据。返回每条证据的稳定ID、来源URI、内容哈希、精确定位符、生效日期与更新信号，" +
+          "用于需要引用依据、核对出处或复核结论的场景。与 query_memory 的区别在于结果是可引用、可复核的结构化证据。")
+    @ToolMeta(displayName = "检索证据", category = "memory")
+    public String retrieve_evidence(
+            @P("检索文本，描述要找依据的主张或问题") String query,
+            @P("返回结果数量，默认10") int limit
+    ) {
+        log.info("Tool: retrieve_evidence called query='{}', limit={}", query, limit);
+
+        Long projectId = ProjectContextHolder.getProjectIdAsLong();
+        if (projectId == null) {
+            return "错误：无法获取当前项目ID，请在项目上下文中使用此工具。";
+        }
+        if (limit <= 0 || limit > 20) {
+            limit = 10;
+        }
+
+        Map<String, String> accessContext = new HashMap<>();
+        if (ProjectContextHolder.getUserId() != null) {
+            accessContext.put("userId", String.valueOf(ProjectContextHolder.getUserId()));
+        }
+        if (ProjectContextHolder.getConversationId() != null) {
+            accessContext.put("conversationId", ProjectContextHolder.getConversationId());
+        }
+        EvidenceQuery evidenceQuery = new EvidenceQuery(
+                String.valueOf(projectId), query, null, List.of(), accessContext, limit);
+
+        StringBuilder sb = new StringBuilder();
+        int total = 0;
+        for (EvidenceRetriever retriever : evidenceRetrieverRegistry.all()) {
+            List<EvidenceItem> items;
+            try {
+                items = retriever.retrieve(evidenceQuery);
+            } catch (Exception e) {
+                log.warn("retrieve_evidence: 来源 {} 检索失败: {}", retriever.sourceId(), e.getMessage());
+                continue;
+            }
+            for (EvidenceItem item : items) {
+                if (total >= limit) {
+                    break;
+                }
+                total++;
+                sb.append(total).append(". [").append(item.evidenceId()).append("] ")
+                        .append(item.excerpt() == null ? "(无摘录)" : item.excerpt()).append("\n")
+                        .append("   来源: ").append(item.sourceUri())
+                        .append(" · 定位: ").append(item.locator());
+                if (item.effectiveDate() != null) {
+                    sb.append(" · 生效: ").append(item.effectiveDate());
+                }
+                sb.append(" · 哈希: ").append(shortHash(item.contentHash()));
+                if (item.supersededAt() != null) {
+                    sb.append(" · ⚠️已有更新版本（").append(item.supersededAt().toLocalDate()).append("）");
+                }
+                sb.append("\n");
+            }
+        }
+
+        if (total == 0) {
+            return "未检索到相关证据。注意：查无此据不等于结论矛盾——请如实向用户说明缺少依据，不要将缺失改写为反证。";
+        }
+        return "检索到 " + total + " 条证据（引用时请带证据ID）:\n\n" + sb;
+    }
+
+    private static String shortHash(String hash) {
+        if (hash == null || hash.isBlank()) {
+            return "-";
+        }
+        return hash.length() <= 12 ? hash : hash.substring(0, 12);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -2,6 +2,7 @@ package com.checkba.service.ai.eval;
 
 import com.checkba.service.ai.tools.AgentToolComponent;
 import com.checkba.service.ai.tools.DocumentEditTools;
+import com.checkba.service.ai.tools.EvidenceTools;
 import com.checkba.service.ai.tools.FileTools;
 import com.checkba.service.ai.tools.LegalTools;
 import com.checkba.service.ai.tools.MemoryTools;
@@ -35,6 +36,7 @@ final class RealToolBeans {
     static List<AgentToolComponent> instantiateAll() {
         List<Class<? extends AgentToolComponent>> toolClasses = List.of(
                 DocumentEditTools.class,
+                EvidenceTools.class,
                 FileTools.class,
                 LegalTools.class,
                 MemoryTools.class,

--- a/backend/src/test/java/com/checkba/service/ai/evidence/ClaimLinkTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/evidence/ClaimLinkTest.java
@@ -1,0 +1,41 @@
+package com.checkba.service.ai.evidence;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * claim_link 不变式：证据缺失绝不允许被改写为矛盾。
+ */
+class ClaimLinkTest {
+
+    @Test
+    void missingEvidenceMustNeverBecomeContradiction() {
+        // 没有任何援引证据时标 CONTRADICTS —— 契约必须拒绝
+        assertThrows(IllegalArgumentException.class, () -> new ClaimLink(
+                "claim-1", List.of(), ClaimLink.Relation.CONTRADICTS, 0.9, null, List.of("缺少工商底档")));
+    }
+
+    @Test
+    void missingEvidenceIsExpressedViaMissingList() {
+        ClaimLink link = new ClaimLink(
+                "claim-1", List.of(), ClaimLink.Relation.CONTEXT, 0.3, null, List.of("缺少工商底档"));
+        assertEquals(List.of("缺少工商底档"), link.missingEvidence());
+    }
+
+    @Test
+    void contradictionWithRealEvidenceIsAllowed() {
+        ClaimLink link = new ClaimLink(
+                "claim-1", List.of("memory:42"), ClaimLink.Relation.CONTRADICTS, 0.8, "reviewer-a", List.of());
+        assertEquals(ClaimLink.Relation.CONTRADICTS, link.relation());
+    }
+
+    @Test
+    void confidenceOutOfRangeIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new ClaimLink(
+                "claim-1", List.of("memory:1"), ClaimLink.Relation.SUPPORTS, 1.5, null, List.of()));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/evidence/EvidenceRetrieverRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/evidence/EvidenceRetrieverRegistryTest.java
@@ -1,0 +1,39 @@
+package com.checkba.service.ai.evidence;
+
+import com.checkba.service.ai.mcp.McpClientService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+class EvidenceRetrieverRegistryTest {
+
+    @Test
+    void beanRetrieversAndConfiguredMcpSourcesAreRegistered() {
+        EvidenceRetriever local = new EvidenceRetriever() {
+            @Override public String sourceId() { return "memory"; }
+            @Override public List<EvidenceItem> retrieve(EvidenceQuery query) { return List.of(); }
+        };
+        EvidenceProperties props = new EvidenceProperties();
+        EvidenceProperties.McpSource src = new EvidenceProperties.McpSource();
+        src.setSourceId("caselaw");
+        src.setServer("law-server");
+        src.setTool("retrieve_evidence");
+        EvidenceProperties.McpSource broken = new EvidenceProperties.McpSource();
+        broken.setSourceId("no-server");
+        props.setMcpSources(List.of(src, broken));
+
+        EvidenceRetrieverRegistry registry =
+                new EvidenceRetrieverRegistry(List.of(local), props, mock(McpClientService.class));
+
+        assertEquals(2, registry.all().size());
+        assertNotNull(registry.find("memory"));
+        assertNotNull(registry.find("mcp:caselaw"));
+        assertNull(registry.find("mcp:no-server"));
+        assertEquals("evidence.retrieve.v1", registry.find("memory").contractVersion());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/evidence/McpEvidenceRetrieverTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/evidence/McpEvidenceRetrieverTest.java
@@ -1,0 +1,123 @@
+package com.checkba.service.ai.evidence;
+
+import com.checkba.service.ai.mcp.McpClientService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * evidence.retrieve.v1 的 MCP 传输适配器契约测试：
+ * MCP 只是传输——契约字段编解码、缺定位符丢弃、来源不可用降级、幂等重放。
+ */
+class McpEvidenceRetrieverTest {
+
+    private McpClientService mcp;
+    private McpEvidenceRetriever retriever;
+
+    private static final String VALID_RESPONSE = """
+            {"items":[
+              {"evidence_id":"case-001","source_uri":"https://law.example/case/1",
+               "content_hash":"abc123","effective_date":"2026-01-15",
+               "locator":"para-12","excerpt":"判决要旨……","mime_type":"text/html",
+               "access_policy":"public","provenance":["court-db","mcp:caselaw"],
+               "supersedes":"case-000"}
+            ]}""";
+
+    @BeforeEach
+    void setUp() {
+        mcp = mock(McpClientService.class);
+        retriever = new McpEvidenceRetriever("caselaw", "law-server", "retrieve_evidence", mcp);
+    }
+
+    private static EvidenceQuery query() {
+        return new EvidenceQuery("project:7", "竞业限制", LocalDate.of(2026, 7, 1),
+                List.of("court"), Map.of("userId", "1"), 5);
+    }
+
+    @Test
+    void requestCarriesAllContractFields() {
+        when(mcp.callTool(any(), any(), any())).thenReturn("{\"items\":[]}");
+
+        retriever.retrieve(query());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mcp).callTool(eq("law-server"), eq("retrieve_evidence"), captor.capture());
+        Map<String, Object> args = captor.getValue();
+        assertEquals("project:7", args.get("workspace_id"));
+        assertEquals("竞业限制", args.get("query"));
+        assertEquals("2026-07-01", args.get("as_of"));
+        assertEquals(List.of("court"), args.get("source_filters"));
+        assertEquals(Map.of("userId", "1"), args.get("access_context"));
+        assertEquals(5, args.get("limit"));
+    }
+
+    @Test
+    void wellFormedResponseIsParsed() {
+        when(mcp.callTool(any(), any(), any())).thenReturn(VALID_RESPONSE);
+
+        List<EvidenceItem> items = retriever.retrieve(query());
+
+        assertEquals(1, items.size());
+        EvidenceItem item = items.get(0);
+        assertEquals("case-001", item.evidenceId());
+        assertEquals("para-12", item.locator());
+        assertEquals("case-000", item.supersedes());
+        assertEquals(LocalDate.of(2026, 1, 15), item.effectiveDate());
+        assertEquals(List.of("court-db", "mcp:caselaw"), item.provenance());
+        assertEquals("mcp:caselaw", retriever.sourceId());
+    }
+
+    @Test
+    void missingLocator_itemIsDroppedNotFabricated() {
+        when(mcp.callTool(any(), any(), any())).thenReturn("""
+                {"items":[
+                  {"evidence_id":"no-locator","source_uri":"https://x","excerpt":"没有定位符"},
+                  {"evidence_id":"ok","source_uri":"https://y","locator":"p3","excerpt":"完整"}
+                ]}""");
+
+        List<EvidenceItem> items = retriever.retrieve(query());
+
+        assertEquals(1, items.size());
+        assertEquals("ok", items.get(0).evidenceId());
+    }
+
+    @Test
+    void revokedAccess_errorResponseDegradesToEmpty() {
+        when(mcp.callTool(any(), any(), any())).thenReturn("Error: MCP server is disabled: law-server");
+        assertTrue(retriever.retrieve(query()).isEmpty());
+    }
+
+    @Test
+    void malformedJsonDegradesToEmpty() {
+        when(mcp.callTool(any(), any(), any())).thenReturn("<html>gateway timeout</html>");
+        assertTrue(retriever.retrieve(query()).isEmpty());
+    }
+
+    @Test
+    void idempotentReplay_sameIdsAndHashes() {
+        when(mcp.callTool(any(), any(), any())).thenReturn(VALID_RESPONSE);
+
+        List<EvidenceItem> first = retriever.retrieve(query());
+        List<EvidenceItem> second = retriever.retrieve(query());
+
+        assertEquals(
+                first.stream().map(EvidenceItem::evidenceId).toList(),
+                second.stream().map(EvidenceItem::evidenceId).toList());
+        assertEquals(
+                first.stream().map(EvidenceItem::contentHash).toList(),
+                second.stream().map(EvidenceItem::contentHash).toList());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/evidence/MemoryEvidenceRetrieverTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/evidence/MemoryEvidenceRetrieverTest.java
@@ -1,0 +1,143 @@
+package com.checkba.service.ai.evidence;
+
+import com.checkba.model.entity.MemoryEntry;
+import com.checkba.service.ai.memory.MemoryManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * evidence.retrieve.v1 本地实现（记忆账本）的契约一致性测试。
+ * 覆盖 RFC #14 讨论中点名的场景：文档变更 / 来源冲突 / 缺定位符 / 权限吊销 / 幂等重放。
+ */
+class MemoryEvidenceRetrieverTest {
+
+    private MemoryManager memoryManager;
+    private MemoryEvidenceRetriever retriever;
+
+    private static final LocalDateTime T0 = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+    @BeforeEach
+    void setUp() {
+        memoryManager = mock(MemoryManager.class);
+        when(memoryManager.findSupersededInfo(any())).thenReturn(Map.of());
+        retriever = new MemoryEvidenceRetriever(memoryManager);
+    }
+
+    private static MemoryEntry entry(long id, String key, String value) {
+        return MemoryEntry.builder()
+                .id(id).projectId(7L).memoryType("fact")
+                .memoryKey(key).memoryValue(value)
+                .createdAt(T0)
+                .build();
+    }
+
+    private static EvidenceQuery query() {
+        return new EvidenceQuery("7", "股权转让", null, List.of(), Map.of("userId", "1"), 10);
+    }
+
+    @Test
+    void changedDocument_supersededSignalIsCarried() {
+        MemoryEntry old = entry(1, "尽调结论", "旧结论");
+        when(memoryManager.retrieveMemories(eq(7L), anyString(), any(), anyInt()))
+                .thenReturn(List.of(old));
+        LocalDateTime newer = T0.plusDays(3);
+        when(memoryManager.findSupersededInfo(any())).thenReturn(Map.of(1L, newer));
+
+        List<EvidenceItem> items = retriever.retrieve(query());
+
+        assertEquals(1, items.size());
+        assertEquals(newer, items.get(0).supersededAt());
+    }
+
+    @Test
+    void conflictingSources_bothReturnedWithDistinctHashes() {
+        // 同一关键词两条内容相左的记录：契约要求都返回、不静默合并，由 claim_link 层处理矛盾
+        when(memoryManager.retrieveMemories(eq(7L), anyString(), any(), anyInt()))
+                .thenReturn(List.of(entry(1, "注册资本", "实缴 1000 万"), entry(2, "注册资本", "实缴 500 万")));
+
+        List<EvidenceItem> items = retriever.retrieve(query());
+
+        assertEquals(2, items.size());
+        assertNotEquals(items.get(0).contentHash(), items.get(1).contentHash());
+    }
+
+    @Test
+    void missingLocator_entryWithoutIdIsDropped() {
+        MemoryEntry noId = MemoryEntry.builder()
+                .projectId(7L).memoryType("fact").memoryKey("k").memoryValue("v").createdAt(T0).build();
+        when(memoryManager.retrieveMemories(eq(7L), anyString(), any(), anyInt()))
+                .thenReturn(List.of(noId, entry(2, "k2", "v2")));
+
+        List<EvidenceItem> items = retriever.retrieve(query());
+
+        assertEquals(1, items.size());
+        assertEquals("memory_entry#2", items.get(0).locator());
+        items.forEach(i -> assertNotNull(i.locator()));
+    }
+
+    @Test
+    void revokedAccess_expiredEntriesAreExcluded() {
+        MemoryEntry expired = entry(1, "旧授权", "已失效的内容");
+        expired.setExpiresAt(LocalDateTime.now().minusDays(1));
+        when(memoryManager.retrieveMemories(eq(7L), anyString(), any(), anyInt()))
+                .thenReturn(List.of(expired, entry(2, "有效", "有效内容")));
+
+        List<EvidenceItem> items = retriever.retrieve(query());
+
+        assertEquals(1, items.size());
+        assertEquals("memory:2", items.get(0).evidenceId());
+    }
+
+    @Test
+    void asOf_entriesCreatedLaterAreInvisible() {
+        MemoryEntry later = entry(2, "后见之明", "时点之后才记录的内容");
+        later.setCreatedAt(T0.plusDays(30));
+        when(memoryManager.retrieveMemories(eq(7L), anyString(), any(), anyInt()))
+                .thenReturn(List.of(entry(1, "k", "v"), later));
+
+        EvidenceQuery asOfQuery = new EvidenceQuery(
+                "7", "股权转让", T0.toLocalDate().plusDays(1), List.of(), Map.of(), 10);
+        List<EvidenceItem> items = retriever.retrieve(asOfQuery);
+
+        assertEquals(1, items.size());
+        assertEquals("memory:1", items.get(0).evidenceId());
+    }
+
+    @Test
+    void idempotentReplay_sameIdsAndHashes() {
+        when(memoryManager.retrieveMemories(eq(7L), anyString(), any(), anyInt()))
+                .thenReturn(List.of(entry(1, "k", "内容甲"), entry(2, "k2", "内容乙")));
+
+        List<EvidenceItem> first = retriever.retrieve(query());
+        List<EvidenceItem> second = retriever.retrieve(query());
+
+        assertEquals(
+                first.stream().map(EvidenceItem::evidenceId).toList(),
+                second.stream().map(EvidenceItem::evidenceId).toList());
+        assertEquals(
+                first.stream().map(EvidenceItem::contentHash).toList(),
+                second.stream().map(EvidenceItem::contentHash).toList());
+    }
+
+    @Test
+    void invalidWorkspaceId_returnsEmptyNotThrow() {
+        assertTrue(retriever.retrieve(new EvidenceQuery("not-a-project", "q", null, null, null, 5)).isEmpty());
+        assertEquals(7L, MemoryEvidenceRetriever.parseWorkspaceId("project:7"));
+    }
+}

--- a/docs/EVIDENCE_CONTRACT.md
+++ b/docs/EVIDENCE_CONTRACT.md
@@ -1,0 +1,86 @@
+# 证据检索契约 evidence.retrieve.v1
+
+> 源起：RFC [#14](https://github.com/zeweihan/aiworkdeck/issues/14) 社区讨论（@mheilimo 的评论）。
+> 核心取向：**契约稳定、传输可插拔**——MCP 只是传输适配层之一，不是证据契约本身。
+> 本地记忆、远程服务、MCP 服务器都以同一契约接入；Skill 声明依赖能力，插件负责实现。
+
+## 1. 分层
+
+```
+Skill（requires: evidence.retrieve.v1）
+   │  声明"需要什么能力"，把证据对象映射进法律工作流
+   ▼
+EvidenceRetrieverRegistry（能力发现）
+   │
+   ├─ MemoryEvidenceRetriever      本地：记忆证据账本（PR#155）
+   ├─ McpEvidenceRetriever          MCP 传输适配（ai.evidence.mcp-sources 配置驱动）
+   └─ （插件 JAR 实现 EvidenceRetriever 接口即可接入）
+```
+
+代码位置：`backend/src/main/java/com/checkba/service/ai/evidence/`。
+LLM 入口：工具 `retrieve_evidence`（`EvidenceTools`）。
+
+## 2. 请求（EvidenceQuery）
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `workspace_id` | string | 工作区标识。本地实现解释为项目 ID（纯数字或 `project:<id>`） |
+| `query` | string | 检索文本 |
+| `as_of` | date? | 时点语义：只返回该日期（含）之前生效的证据；缺省 = 现在 |
+| `source_filters` | string[] | 来源过滤（本地实现按记忆作用域解释），空 = 不过滤 |
+| `access_context` | map | 访问上下文（userId / conversationId 等），实现据此做权限裁剪 |
+| `limit` | int | 结果上限 |
+
+## 3. 单条证据（EvidenceItem）
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `evidence_id` | **是** | 稳定证据 ID：同一来源同一内容重复检索必须相同（幂等重放的基础） |
+| `source_uri` | **是** | 来源 URI |
+| `locator` | **是** | 精确定位符（段落号/条文号/记录主键）。**缺定位符的内容必须丢弃，不得编造** |
+| `content_hash` | 否 | 内容哈希（sha256），内容变即哈希变 |
+| `retrieved_at` | 否 | 本次检索时间 |
+| `effective_date` | 否 | 生效日期 |
+| `excerpt` | 否 | 有界摘录（≤500 字符，超长截断） |
+| `mime_type` | 否 | 内容类型 |
+| `access_policy` | 否 | 访问策略标注（如 `project`、`user:protected`） |
+| `provenance` | 否 | 溯源链（有序） |
+| `supersedes` / `revokes` | 否 | 可选事件：本条取代/吊销的证据 ID |
+| `superseded_at` | 否 | 更新信号：本条已有更晚版本时，最新版本时间（证据账本语义） |
+
+## 4. 主张关联（ClaimLink）——与检索分层
+
+检索只负责拿回证据；"证据支持/矛盾哪个主张"是独立的解释层对象：
+`claim_id`、`evidence_ids`、`relation`（supports / contradicts / context）、`confidence`、`reviewer`、`missing_evidence`。
+
+**硬性不变式：证据缺失绝不允许被改写为矛盾。** `CONTRADICTS` 必须援引至少一条真实证据；
+"查无此据"用 `missing_evidence` 表达。构造器强制校验（`ClaimLink.java`）。
+
+## 5. MCP 接入（传输适配）
+
+```yaml
+ai:
+  evidence:
+    mcp-sources:
+      - source-id: caselaw
+        server: some-mcp-server    # 须已在 mcp.servers 配置
+        tool: retrieve_evidence    # 远端工具按本契约返回 {"items":[...]}
+```
+
+远端 MCP 工具收到第 2 节的请求字段（snake_case），返回 `{"items":[EvidenceItem...]}`。
+适配层行为：缺 `evidence_id`/`source_uri`/`locator` 的条目丢弃并告警；来源报错/不可用返回空列表降级，不炸编排主流程。
+
+## 6. 一致性要求（conformance）
+
+任何实现必须通过以下场景（现有用例见 `backend/src/test/java/com/checkba/service/ai/evidence/`）：
+
+1. **文档变更**：内容有更新版本时携带 `superseded_at`/`supersedes` 信号，旧证据不冒充最新；
+2. **来源冲突**：相互矛盾的证据都如实返回（哈希不同），不静默合并，矛盾判定交给 claim_link 层；
+3. **缺定位符**：无法给出精确 locator 的内容直接丢弃，不编造定位符；
+4. **权限吊销**：过期/被吊销/无权访问的内容不返回，来源不可用时降级为空列表；
+5. **幂等重放**：同一请求重复执行，`evidence_id` 与 `content_hash` 序列一致。
+
+## 7. 版本演进
+
+字段只增不改不删；破坏性变更升 `evidence.retrieve.v2`（新接口共存，旧契约继续可用）。
+与 `docs/AI_ARCHITECTURE.md` 的不变式一致：新增证据来源不修改编排器。

--- a/docs/SKILL_SPEC.md
+++ b/docs/SKILL_SPEC.md
@@ -65,6 +65,7 @@ output: |
 | `prompt` | string | 否 | prompt 模板文件名（相对 skill 目录），默认 `prompt.md`。文件缺失则整个 skill 跳过。 |
 | `allowed_tools` | string[] | 否 | 工具白名单（真实注册的工具名，见 `ToolRegistry`）。命中后本轮 LLM 可见工具 = `allowed_tools ∪ ai.skills.base-tools`；白名单与已注册工具零交集时回退为不裁剪（误配置保护）。缺省 `[]` = 只剩基础工具集。 |
 | `output` | string | 否 | 输出结构约定（自然语言），随 prompt 模板一起注入系统消息。 |
+| `requires` | string[] | 否 | 声明依赖的能力契约（如 `evidence.retrieve.v1`，见 `docs/EVIDENCE_CONTRACT.md`）。v1 仅声明不阻断加载：Skill 描述"需要什么能力"，插件/内置实现负责提供，实现缺失时相关工具自然不可见。 |
 
 未知字段被忽略（向前兼容）。
 

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -35,6 +35,7 @@ const NAMES = {
   // 记忆
   save_memory: { zh: '保存记忆', en: 'Save memory' },
   query_memory: { zh: '检索记忆', en: 'Query memory' },
+  retrieve_evidence: { zh: '检索证据', en: 'Retrieve evidence' },
   get_user_profile: { zh: '获取用户画像', en: 'Get user profile' },
   // 子任务 / Python
   dispatch_subtask: { zh: '委派子任务', en: 'Delegate subtask' },


### PR DESCRIPTION
## 背景

RFC #14 中 @mheilimo 提出：**不要把 MCP 当成证据契约本身，MCP 只应是传输适配层之一**；应有一个稳定的 `evidence.retrieve.v1` 接口，同时支撑本地、远程、MCP 三类实现。本 PR 按该建议落地。

## 改动

**契约层**（`service/ai/evidence/`，新增）
- `EvidenceQuery`：workspace_id / query / as_of / source_filters / access_context / limit
- `EvidenceItem`：稳定证据ID、来源URI、内容哈希、检索时间、生效日期、**精确定位符**、有界摘录(≤500字符)、MIME、访问策略、溯源链、可选 supersedes/revokes 事件。**缺 ID/URI/定位符即构造失败**——缺定位符的内容不得伪装成证据。
- `ClaimLink`：主张解释与检索分层（supports/contradicts/context + confidence + reviewer + missing_evidence），构造器强制**「证据缺失绝不改写为矛盾」**不变式。

**实现层**
- `MemoryEvidenceRetriever`：记忆证据账本（PR#155）落到契约上——过期=吊销、as_of 时点可见性、superseded 更新信号、sha256 内容哈希。
- `McpEvidenceRetriever`：MCP 传输适配，`ai.evidence.mcp-sources` 配置驱动（默认不配=不启用）；不合契约条目丢弃告警，来源不可用降级为空列表。
- `EvidenceRetrieverRegistry`：能力发现入口，Bean 实现 + 配置化 MCP 来源统一注册。

**接入面**
- Skill 规范新增可选 `requires` 字段声明能力依赖（仅声明不阻断加载，向前兼容）。
- LLM 工具 `retrieve_evidence`（EvidenceTools）：返回可引用、可复核的结构化证据；前端 toolDisplayNames「检索证据」与 RealToolBeans 已同步。

**契约一致性测试（18 例，全部进 mvn test）**
覆盖评论点名的五场景：文档变更 / 来源冲突 / 缺定位符 / 权限吊销 / 幂等重放。

**文档**：`docs/EVIDENCE_CONTRACT.md`（契约全文+版本演进规则）、SKILL_SPEC.md 补 requires。

## 验证

- 新增 4 个测试类 18 例全绿
- 后端全量 `mvn test`：**277 tests, 0 failures**（回放评测/启动冒烟含在内）
- 未动编排器与既有工具签名；MCP 适配默认不启用,无行为变更风险

## 不做什么

- 不改 registry 契约字段、不动 SSE 事件
- 能力缺失时的运行期阻断留待 v2（与 #14 后续讨论对齐）

🤖 Generated with [Claude Code](https://claude.com/claude-code)