### PR TITLE
fix(ai): 活跃文档上下文识别——开着的文档不再被 list/open 重新发现

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -240,21 +240,32 @@ public class ContextAssemblerService {
                      activeContext.getId(), activeContext.getName());
             
             String content = legalTools.read_document(activeContext.getId());
+
+            systemText.append("\n\n# Active Document (当前活跃文档)\n");
+            systemText.append("该文档（id=").append(activeContext.getId())
+                      .append(", name=").append(activeContext.getName())
+                      .append("）**已在编辑器中打开**，就是用户此刻正在看的文档。");
+            systemText.append("用户说\"修订一下\"\"这个文档\"\"当前文档\"或未指明对象时，默认就是指它。\n");
+            systemText.append("所有 doc_* 编辑/读取工具直接作用于该文档——**无需也不要**调用 ");
+            systemText.append("`doc_list_project_files` 或 `doc_open_file` 去重新发现/打开它；");
+            systemText.append("只有用户明确要操作**其他**文档时才需要那两个工具。\n\n");
+
             if (content != null && !content.isEmpty()) {
                 // Truncate if too long
                 int maxCharsPerFile = contextProperties.getFiles().getMaxCharsPerFile();
                 if (content.length() > maxCharsPerFile) {
                     content = content.substring(0, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
                 }
-                
-                systemText.append("\n\n# Active Document (当前活跃文档)\n");
-                systemText.append("The user is currently viewing/editing this document. ");
-                systemText.append("Use this context if the user's instruction refers to \"current document\", \"this file\", ");
-                systemText.append("\"line X\", \"paragraph X\", or similar positional references.\n\n");
+
                 systemText.append("<active_document id=\"").append(activeContext.getId())
                           .append("\" name=\"").append(activeContext.getName()).append("\"><![CDATA[\n");
                 systemText.append(content);
                 systemText.append("\n]]></active_document>\n");
+            } else {
+                // 正文暂时读不到也要保留文档标识，模型仍可用 doc_get_document_text 等工具直接读
+                systemText.append("<active_document id=\"").append(activeContext.getId())
+                          .append("\" name=\"").append(activeContext.getName())
+                          .append("\">[正文暂不可读，可用 doc_get_document_text 直接分段读取]</active_document>\n");
             }
         }
 

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -475,7 +475,7 @@ for file_id in file_ids:
 
 ### 使用规范
 
-1. **修改前先打开文档**：使用 `doc_open_file` 打开需要编辑的文档
+1. **优先用当前活跃文档**：系统提示中若有 `<active_document>`（用户此刻在编辑器里打开的文档），用户说"修订一下""这个文档"或未指明对象时就是指它——所有 doc_* 工具已直接作用于它，**禁止**再调 `doc_list_project_files` / `doc_open_file` 去重新发现或打开。只有要编辑**其他**文档（无活跃文档、或用户明确指定了别的文件）时，才先用 `doc_open_file` 打开目标文档
 2. **禁止使用字符偏移定位**：一律使用 `doc_find_text` 返回的 anchorId 或段落号；不要自己数字符位置
 3. **多个匹配必须先消歧**：`doc_find_text` 返回多个匹配时，逐个核对 contextBefore/contextAfter，确定目标后再操作；只有上下文仍分辨不出时才 `doc_select_anchor` 选中人工看一眼
 4. **验证就看编辑工具的返回值**：改动类工具返回 `paragraphAfterEdit`（改后段落实文），核对它即可，**不要改后再调读取类工具复查**；发现不对立刻 `doc_undo` 并换思路重新定位

--- a/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
@@ -1,0 +1,112 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.controller.ai.AiAgentController;
+import com.checkba.model.ai.AgentMode;
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.FileContextLoader;
+import com.checkba.service.ai.memory.MemoryManager;
+import com.checkba.service.ai.skill.SkillRouter;
+import com.checkba.service.ai.tools.LegalTools;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * ContextAssemblerService 的活跃文档（activeContext）注入行为测试。
+ *
+ * 背景：用户在编辑器里开着某个文档时说"帮我修订一下"，模型应直接编辑该文档，
+ * 而不是先 doc_list_project_files / doc_open_file 去重新发现文档。
+ */
+class ContextAssemblerServiceTest {
+
+    private LegalTools legalTools;
+    private ContextAssemblerService assembler;
+
+    @BeforeEach
+    void setUp() {
+        legalTools = mock(LegalTools.class);
+        ProjectAiMessageService messageService = mock(ProjectAiMessageService.class);
+        when(messageService.listByConversationId(anyString())).thenReturn(Collections.emptyList());
+        FileContextLoader fileContextLoader = mock(FileContextLoader.class);
+        SkillRouter skillRouter = mock(SkillRouter.class);
+        when(skillRouter.match(anyString())).thenReturn(Optional.empty());
+        MemoryManager memoryManager = mock(MemoryManager.class);
+        when(memoryManager.getProjectMemory(anyLong())).thenReturn(Optional.empty());
+        when(memoryManager.retrieveMemories(anyLong(), anyString(), any(), anyInt()))
+                .thenReturn(Collections.emptyList());
+        when(memoryManager.retrieveUserMemories(anyLong(), anyInt())).thenReturn(Collections.emptyList());
+        ContextCompressor contextCompressor = mock(ContextCompressor.class);
+        when(contextCompressor.needsCompression(any(), any())).thenReturn(false);
+
+        assembler = new ContextAssemblerService(
+                legalTools, messageService, fileContextLoader,
+                new AiContextProperties(), skillRouter, memoryManager, contextCompressor);
+    }
+
+    private String assembleSystemText(AiAgentController.ContextItem activeContext) {
+        List<ChatMessage> messages = assembler.assemble(
+                "conv-1", "帮我修订一下", null, activeContext,
+                null, null, "88", AgentMode.AGENT, 1L, null);
+        return ((SystemMessage) messages.get(0)).text();
+    }
+
+    private static AiAgentController.ContextItem activeDoc() {
+        AiAgentController.ContextItem item = new AiAgentController.ContextItem();
+        item.setId("123");
+        item.setName("合作框架协议.docx");
+        item.setFileType("docx");
+        return item;
+    }
+
+    @Test
+    @DisplayName("活跃文档注入：声明文档已在编辑器打开，直接编辑，无需再列出/打开")
+    void activeContextInjectionTellsModelDocIsAlreadyOpen() {
+        when(legalTools.read_document("123")).thenReturn("第一条 合作范围……");
+
+        String systemText = assembleSystemText(activeDoc());
+
+        assertTrue(systemText.contains("<active_document id=\"123\""), "应注入 active_document 标签");
+        assertTrue(systemText.contains("已在编辑器中打开"), "应声明该文档已打开");
+        assertTrue(systemText.contains("doc_list_project_files"),
+                "应明确点名无需 doc_list_project_files");
+        assertTrue(systemText.contains("doc_open_file"),
+                "应明确点名无需 doc_open_file");
+    }
+
+    @Test
+    @DisplayName("活跃文档正文读取失败时，仍注入文档标识（id/name），不整块静默丢弃")
+    void activeContextStillInjectedWhenContentUnreadable() {
+        when(legalTools.read_document("123")).thenReturn(null);
+
+        String systemText = assembleSystemText(activeDoc());
+
+        assertTrue(systemText.contains("合作框架协议.docx"), "正文读不到也应保留文档名");
+        assertTrue(systemText.contains("已在编辑器中打开"), "正文读不到也应声明该文档已打开");
+    }
+
+    @Test
+    @DisplayName("无活跃文档时不注入 active_document 段")
+    void noActiveContextNoInjection() {
+        String systemText = assembleSystemText(null);
+
+        assertFalse(systemText.contains("<active_document id="), "无活跃文档不应出现注入段");
+        assertFalse(systemText.contains("# Active Document"), "无活跃文档不应出现注入段标题");
+    }
+}


### PR DESCRIPTION
## 现象

用户在编辑器里开着某个文档（激活 tab），在 AI 面板说"帮我修订一下"，模型不用当前文档，而是先 `doc_list_project_files` 列出所有可编辑文档、再 `doc_open_file` 去猜目标（见面板里 列出可编辑文档→打开文档→通读文档 的连环调用）。

## 根因

`activeContext`（当前激活文档）通路其实早已存在：前端 `ChatInterface.vue` 会把激活 tab 发给后端，`ContextAssemblerService` 也会把正文注入系统提示。问题在语义：

1. **base prompt 反向指令**：`system_prompt.md` 使用规范第 1 条写死"**修改前先打开文档**：使用 `doc_open_file` 打开需要编辑的文档"，且全文没有"活跃文档已打开"的概念——模型 list→open 是**照章办事**；
2. **注入措辞被动**：`<active_document>` 注入只说"用户在看这个文档，定位参考时可用"，没说"它已打开、doc_* 工具直接作用于它"；
3. **静默丢弃**：正文读取失败时整个注入块被跳过，模型完全感知不到活跃文档存在。

## 修复

- `ContextAssemblerService`：注入文案明确"该文档已在编辑器中打开，用户未指明对象时默认指它，无需也不要 `doc_list_project_files` / `doc_open_file`"；正文读不到时也保留 id/name 标识并提示可用 `doc_get_document_text` 直接读；
- `system_prompt.md` 规范第 1 条：改为"优先用当前活跃文档"，仅在编辑**其他**文档时才先 `doc_open_file`；
- 新增 `ContextAssemblerServiceTest`：3 条测试覆盖注入声明、读取失败兜底、无活跃文档不注入。

未改编排器构造器，EvalHarness 无需同步。前端"手动挂文件优先于活跃文档"的既有优先级保持不变。

## 验证

- 新测试先红后绿（TDD）
- 后端全量 `mvn test`（JDK 21）：280 tests, 0 failures（1 skipped 为需用户 key 的 RUN_FULL，历史如此）

🤖 Generated with [Claude Code](https://claude.com/claude-code)