### PR TITLE
feat(ai): 新增批注原语 doc_add_comment——解释类文字挂 Word 批注、不进正文

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -700,6 +700,26 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
+    @ToolMeta(displayName = "添加批注", category = "document", fileEffect = "MODIFIED")
+    @Tool("【批注】在指定锚点处的文本上添加 Word 批注（comment）。修订文档时，解释、说明、修改理由等不属于正文的内容" +
+          "**必须**用本工具以批注呈现，禁止写入正文。先 doc_find_text 拿到目标文本的 anchorId，再对它加批注；" +
+          "批注署名 AI Workdeck，附着在目标文本上，保存为 docx 后可在 Word 中查看。")
+    public String doc_add_comment(
+            @P("doc_find_text 返回的 anchorId（批注附着的目标文本）") String anchorId,
+            @P("批注内容（解释/说明/修改理由）") String comment
+    ) {
+        log.info("Tool: doc_add_comment called anchor={}, comment length={}", anchorId, comment != null ? comment.length() : 0);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("anchor", anchorId != null ? anchorId : "");
+            params.put("comment", comment != null ? comment : "");
+            return editorBridgeService.executeEditorCommand("add_comment", params);
+        } catch (Exception e) {
+            log.error("Failed to add comment", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
     // ==================== 调试工具 ====================
 
     @Tool("调试工具：获取文档中所有修订记录的详细信息，包括修订类型、位置、内容等。用于分析和诊断修订模式下的文本操作问题。")

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -459,6 +459,7 @@ for file_id in file_ids:
 | `doc_modify_paragraph(paragraphIndex, newText)` | 整段改写（0 开始） |
 | `doc_insert_under_heading(headingText, content)` | 在指定标题下方插入内容 |
 | `doc_start_stream(fileId, fileName)` | 实时流式写入模式（新建长文档用） |
+| `doc_add_comment(anchorId, comment)` | **批注**：在锚点文本上加 Word 批注。解释/说明/修改理由等非正文内容一律用批注呈现，**禁止写进正文** |
 
 **格式（先选中，再排版）**
 
@@ -482,6 +483,7 @@ for file_id in file_ids:
 5. **格式化前必须有选区**：先 `doc_select_anchor` / `doc_select_paragraph`，再 `doc_format_selection`——这两步无需中间判断，**在同一轮批量输出**
 6. **联动修改按需**：用户的修改可能涉及其他文档时，才用 `doc_search_related_docs` 搜一次；单文档内的修改不要调它
 7. **控制调用次数（CRITICAL）**：一处修改的正常成本是 1-2 个调用（至多找 1 + 改 1）。多处独立修改拿到各自定位后**同一轮批量输出**。禁止「改前选中看一眼 → 改 → 改后再读一遍」的三倍冗余链。
+8. **解释类文字用批注，不进正文**：修订时若要向用户解释某处为何这样改、或提示某处需人工确认，用 `doc_add_comment(anchorId, comment)` 挂在相关文本上；禁止把说明性文字插入正文（正文只承载文件本身应有的内容）。
 
 ### 典型场景
 

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -61,6 +61,9 @@ export const EDITOR_ACTIONS = [
   // [#79 click-to-open] LO WASM 不触发 window.open（v0.7.1 真机证实）：编辑器页
   // 监听 canvas 点击后经此原语读取光标处链接再转发宿主。
   'get_hyperlink_at_cursor',
+  // [批注] Word comment on an anchored range — 解释/说明类文字不进正文的通道
+  // （backend doc_add_comment）。
+  'add_comment',
 ]
 
 /**

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -71,6 +71,7 @@ const NAMES = {
   doc_set_paragraph_format: { zh: '设置段落格式', en: 'Format paragraph' },
   doc_undo: { zh: '撤销修改', en: 'Undo' },
   doc_redo: { zh: '重做修改', en: 'Redo' },
+  doc_add_comment: { zh: '添加批注', en: 'Add comment' },
   doc_debug_revisions: { zh: '检查修订记录', en: 'Inspect revisions' },
   doc_restore_checkpoint: { zh: '恢复文档快照', en: 'Restore snapshot' },
   // PPT

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -1397,6 +1397,35 @@ const EXEC = {
     try { vc.collapseToEnd(); } catch (e) {}
     return { success: true, bytes: u8.length, width: w, height: h };
   },
+  // [批注] add a Word comment (annotation) on the text at an anchorId — the
+  // channel for explanatory notes: 解释/说明类文字不进正文，挂批注。Engine-
+  // native path (same precedent as the PR#164 delete keys): select the anchor
+  // range, then dispatch .uno:InsertAnnotation with Text/Author args. The
+  // API alternative (createInstance Annotation + insertTextContent bAbsorb)
+  // was probe-tested on this build: it throws a spurious RuntimeException from
+  // the post-attach view code AND exports only a point commentReference; the
+  // dispatch is clean and exports a true RANGE comment (commentRangeStart/End
+  // spanning the target text), which is what Word shows attached to the run.
+  // Date is stamped by the engine; author comes from the dispatch arg.
+  add_comment(p) {
+    const anchorId = String(p.anchor || '');
+    const comment = String(p.comment || '');
+    if (!anchorId) return { success: false, message: 'add_comment requires {anchor} (anchorId from find_text_locations)' };
+    if (!comment) return { success: false, message: 'add_comment requires {comment}' };
+    const range = anchorRange(anchorId);
+    if (!range) return { success: false, message: 'anchor not found: ' + anchorId };
+    const annotatedText = (range.getString() || '').slice(0, 120);
+    // 拟人：选中并滚动到被批注的位置——选区同时就是批注的附着区间
+    if (!selectVisibly(range)) return { success: false, message: 'could not select anchor: ' + anchorId };
+    css.frame.DispatchHelper.create(context).executeDispatch(
+      ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
+      [mkProp('Text', comment), mkProp('Author', AI_AUTHOR)]);
+    return {
+      success: true, anchor: anchorId, author: AI_AUTHOR, comment: comment,
+      annotatedText: annotatedText,
+      paragraph: (paragraphTextOf(range) || '').slice(0, 200),
+    };
+  },
   // [diagnostic] 修订记录清单（类型/作者/文本片段）。后端 doc_debug_revisions
   // 一直派发 debug_revisions，worker 此前未实现（一律返回 not implemented）；
   // 补上后同时作为修订署名（AI Workdeck / 用户名）的验证探针。

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -56,6 +56,20 @@ const DEBUG_ACTIONS = `
     const vc = ctrl.getViewCursor();
     return { success: true, value: vc.getPropertyValue(String(p.prop)), selected: (vc.getString() || '').slice(0, 40) };
   },
+  debug_list_comments() {
+    const out = [];
+    const en = xModel.getTextFields().createEnumeration();
+    while (en.hasMoreElements()) {
+      const f = en.nextElement();
+      if (f.supportsService && f.supportsService('com.sun.star.text.textfield.Annotation')) {
+        const item = {};
+        try { item.author = f.getPropertyValue('Author'); } catch (e) {}
+        try { item.content = f.getPropertyValue('Content'); } catch (e) {}
+        out.push(item);
+      }
+    }
+    return { success: true, count: out.length, comments: out };
+  },
 `
 function patchServed(urlPath, content) {
   if (urlPath === '/office_thread.js') {
@@ -66,8 +80,8 @@ function patchServed(urlPath, content) {
   if (/^\/assets\/editor-.*\.js$/.test(urlPath)) {
     const s = content.toString('utf8')
     return Buffer.from(
-      s.replace("'get_hyperlink_at_cursor'", "'get_hyperlink_at_cursor','debug_set_record_changes','debug_char_prop'")
-        .replace('"get_hyperlink_at_cursor"', '"get_hyperlink_at_cursor","debug_set_record_changes","debug_char_prop"'),
+      s.replace("'get_hyperlink_at_cursor'", "'get_hyperlink_at_cursor','debug_set_record_changes','debug_char_prop','debug_list_comments'")
+        .replace('"get_hyperlink_at_cursor"', '"get_hyperlink_at_cursor","debug_set_record_changes","debug_char_prop","debug_list_comments"'),
       'utf8')
   }
   return content
@@ -276,6 +290,19 @@ try {
     rv11.success && delTexts(rv11).includes('三') && delTexts(rv11).every((t2) => (t2 || '').length === 1), JSON.stringify(rv11))
   check('两处插入各自成修订（六 / 全部）', mine(rv11).filter((r) => r.type === 'Insert').length === 2, JSON.stringify(mine(rv11)))
   check('改后段落实文正确', (await doc()) === '甲方应于六十日内向乙方支付全部服务费。', await doc())
+
+  console.log('== 12) add_comment 批注：解释文字挂批注、不进正文 ==')
+  await reset('本合同自签署之日起生效。', true)
+  const ft = await exec('find_text_locations', { keyword: '签署之日' })
+  check('find_text 拿到锚点', ft.success && ft.count === 1 && !!ft.matches[0].anchorId, JSON.stringify(ft))
+  const cm = await exec('add_comment', { anchor: ft.matches[0].anchorId, comment: '建议明确签署日期的认定方式', __agent: true })
+  check('add_comment 成功且附着目标文本', cm.success && cm.annotatedText === '签署之日', JSON.stringify(cm))
+  const lc = await exec('debug_list_comments')
+  check('批注可读回、署名 AI Workdeck、内容完整',
+    lc.success && lc.count === 1 && lc.comments[0].author === 'AI Workdeck' && lc.comments[0].content === '建议明确签署日期的认定方式',
+    JSON.stringify(lc))
+  check('批注文字不进正文', await doc() === '本合同自签署之日起生效。', await doc())
+  check('缺锚点被拒绝', !(await exec('add_comment', { comment: '孤儿批注' })).success)
 
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
 } finally {


### PR DESCRIPTION
## 背景

用户要求 AI 修订文档时，解释/说明类文字不得写进正文，应针对相关文本用 Word 批注（comment）呈现。此前工具集没有任何批注能力。

## 实现（五处改动点）

1. **office_thread.js**：新增 `add_comment` EXEC 处理器——按 anchorId 定位（复用 anchorRange），走引擎原生 `.uno:InsertAnnotation` 派发（Text/Author 参数，署名 AI Workdeck，日期由引擎落盘）
2. **libreofficeExecutorClient.js**：EDITOR_ACTIONS 白名单同步加 `add_comment`（PR#180 坑点）
3. **DocumentEditTools**：新增 `doc_add_comment(anchorId, comment)` @Tool + @ToolMeta（添加批注 / MODIFIED）；system_prompt.md §7 工具表登记 + 使用规范第 8 条
4. **toolDisplayNames.js**：`doc_add_comment` → 添加批注
5. **lowa-e2e**：场景 12 + 测试专用 `debug_list_comments` 读回原语（内存注入，源码/dist 干净）

## 与任务书的一个偏差（真机探针驱动）

任务书建议用 `com.sun.star.text.textfield.Annotation` + insertTextContent。真机探针证实该路线在本引擎构建上：a) 从 attach 后视图代码抛虚假 RuntimeException（字段实际已插入）；b) 导出 docx 只有点锚定 `commentReference`，没有区间标记。改走 `.uno:InsertAnnotation` 派发（PR#164 删除键同一先例）：无异常，且导出真正的**区间批注**（`commentRangeStart/End` 包住目标文本）——Word 里批注附着在文本上而非一个点。

## 验证

- `npm run test:lowa-e2e` **38/38 全绿**（含新场景 12：挂批注→读回验署名/内容→正文不变→缺锚点被拒）
- docx 往返：导出后 `word/comments.xml` 含 `w:author="AI Workdeck"` + 完整内容，`word/document.xml` 含 `commentRangeStart/End/commentReference` 区间标记，Word 可见
- 后端 `mvn compile` 通过（JDK 21）
- EvalHarness 无需改动（未动编排器构造器，工具靠 @Tool 注解自动发现）

🤖 Generated with [Claude Code](https://claude.com/claude-code)