### PR TITLE
feat(ai): WPS 前后端契约命名双轨迁移（doc_*/editor_command 与 wps_* 并行）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
@@ -9,7 +9,8 @@ import org.springframework.web.bind.annotation.*;
 /**
  * 编辑器操作结果接收控制器
  * 
- * 接收前端执行编辑器操作后的结果回调（路由 /wps-result 为前后端契约，保持旧名）
+ * 接收前端执行编辑器操作后的结果回调（双轨迁移：新路由 /editor-result，
+ * 旧路由 /wps-result 保留别名供旧前端使用，一个发布周期后摘除）
  */
 @RestController
 @RequestMapping("/api/ai/agent")
@@ -24,7 +25,7 @@ public class EditorResultController {
      * 
      * 前端执行完编辑器操作后，调用此接口返回结果
      */
-    @PostMapping("/wps-result")
+    @PostMapping({"/editor-result", "/wps-result"})
     public EditorResultResponse receiveEditorResult(@RequestBody EditorResultPayload payload) {
         log.info("Received editor result: requestId={}, success={}", payload.getRequestId(), payload.isSuccess());
         

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -368,9 +368,11 @@ public class AgentOrchestrator {
             }
         });
 
-        // 编辑器实时流式写入拦截（事件名沿用 wps_stream_data，前后端契约）
+        // 编辑器实时流式写入拦截（双轨迁移：新名 doc_stream_data 必须先于旧名 wps_stream_data 发出，
+        // 前端以"先见新名"判定新后端并丢弃旧名去重；一个发布周期后摘旧名，见 docs/AI_ARCHITECTURE.md Phase 3）
         handler.setOnEditorStream(token -> {
             if (editorBridgeService.isStreamingMode(conversationId)) {
+                sseEmitterService.send(conversationId, "doc_stream_data", java.util.Map.of("content", token));
                 sseEmitterService.send(conversationId, "wps_stream_data", java.util.Map.of("content", token));
             }
         });

--- a/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
@@ -66,7 +66,7 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
         }
     }
     
-    // ==================== Editor Stream Filtering Logic（过滤后实时写入编辑器文档；SSE 事件名 wps_stream_data 为前后端契约保留） ====================
+    // ==================== Editor Stream Filtering Logic（过滤后实时写入编辑器文档；SSE 事件名双轨 doc_stream_data/wps_stream_data，见 AgentOrchestrator） ====================
     
     // Buffer for editor stream parser to handle split tags
     private final StringBuilder editorStreamBuffer = new StringBuilder();

--- a/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
@@ -24,12 +24,14 @@ import java.util.concurrent.TimeoutException;
  * 工作流程：
  * 1. Agent 调用文档编辑工具 -> DocumentEditTools 调用 executeEditorCommand
  * 2. EditorBridgeService 生成 requestId，发送 SSE 事件，创建 CompletableFuture
- * 3. 前端执行操作后调用 /api/ai/agent/wps-result 返回结果
+ * 3. 前端执行操作后调用 /api/ai/agent/editor-result 返回结果（旧路由 /wps-result 保留别名）
  * 4. EditorResultController 调用 completeEditorAction 解锁 CompletableFuture
  * 5. executeEditorCommand 获取结果并返回给 DocumentEditTools
  *
  * 历史沿革：原名 WpsActionService（WPS WebOffice 时代）。SSE 事件与路由中的
- * wps_* 字符串是前后端契约（见 docs/ai_agent_dev.md §2.2），保持旧名不变。
+ * wps_* 字符串是前后端契约（见 docs/ai_agent_dev.md §2.2），当前处于双轨迁移期：
+ * 每条指令按"新名在前、旧名在后"各发一份（doc_* 与 editor_command + wps_*），前端凭
+ * "先见新名"判定新后端并丢弃旧名去重；兼容一个发布周期后摘旧名（AI_ARCHITECTURE.md Phase 3）。
  */
 @Service
 @RequiredArgsConstructor
@@ -98,19 +100,17 @@ public class EditorBridgeService {
         }
 
         try {
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "action", "wps_open_file",
+            Map<String, Object> fields = Map.of(
                     "fileId", file.getId(),
                     "fileName", file.getName(),
                     "fileType", file.getFileType(),
                     "wpsFileId", file.getWpsFileId() != null ? file.getWpsFileId() : "",
                     "trackRevisions", true,
                     "userName", "AI Workdeck"
-            ));
-            
-            sseEmitterService.send(conversationId, "client_action", payload);
-            log.info("Sent wps_open_file action for file: {} (id={})", file.getName(), file.getId());
-            
+            );
+            sendDualNamedAction("doc_open_file", "wps_open_file", conversationId, fields);
+            log.info("Sent doc_open_file action for file: {} (id={})", file.getName(), file.getId());
+
         } catch (Exception e) {
             log.error("Failed to send open file action", e);
         }
@@ -128,20 +128,31 @@ public class EditorBridgeService {
         }
 
         try {
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "action", "wps_reload_file",
+            Map<String, Object> fields = Map.of(
                     "fileId", file.getId(),
                     "fileName", file.getName(),
                     "fileType", file.getFileType(),
                     "wpsFileId", file.getWpsFileId() != null ? file.getWpsFileId() : ""
-            ));
-            
-            sseEmitterService.send(conversationId, "client_action", payload);
-            log.info("Sent wps_reload_file action for file: {} (id={})", file.getName(), file.getId());
-            
+            );
+            sendDualNamedAction("doc_reload_file", "wps_reload_file", conversationId, fields);
+            log.info("Sent doc_reload_file action for file: {} (id={})", file.getName(), file.getId());
+
         } catch (Exception e) {
             log.error("Failed to send reload file action", e);
         }
+    }
+
+    /**
+     * 双轨迁移期的单向 client_action 发送：同一份载荷按"新名在前、旧名在后"各发一次。
+     * 顺序是契约的一部分——前端凭"先见新名"判定新后端并丢弃随后的旧名事件去重。
+     */
+    private void sendDualNamedAction(String newAction, String legacyAction,
+                                     String conversationId, Map<String, Object> fields) throws Exception {
+        java.util.Map<String, Object> payloadMap = new java.util.HashMap<>(fields);
+        payloadMap.put("action", newAction);
+        sseEmitterService.send(conversationId, "client_action", objectMapper.writeValueAsString(payloadMap));
+        payloadMap.put("action", legacyAction);
+        sseEmitterService.send(conversationId, "client_action", objectMapper.writeValueAsString(payloadMap));
     }
 
     /**
@@ -210,16 +221,20 @@ public class EditorBridgeService {
         pendingRequests.put(requestId, future);
 
         try {
-            // 构建并发送 SSE 事件
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "tool", "wps_command",
-                    "action", action,
-                    "params", params != null ? params : Map.of(),
-                    "requestId", requestId,
-                    "conversationId", conversationId
-            ));
-            
-            sseEmitterService.send(conversationId, "client_action", payload);
+            // 构建并发送 SSE 事件（双轨：新名 editor_command 在前、旧名 wps_command 在后，
+            // requestId 相同；action 中仅 doc_open_file_sync 有旧名 wps_open_file_sync 需映射）
+            String legacyAction = "doc_open_file_sync".equals(action) ? "wps_open_file_sync" : action;
+            java.util.Map<String, Object> payloadMap = new java.util.HashMap<>();
+            payloadMap.put("action", action);
+            payloadMap.put("params", params != null ? params : Map.of());
+            payloadMap.put("requestId", requestId);
+            payloadMap.put("conversationId", conversationId);
+
+            payloadMap.put("tool", "editor_command");
+            sseEmitterService.send(conversationId, "client_action", objectMapper.writeValueAsString(payloadMap));
+            payloadMap.put("tool", "wps_command");
+            payloadMap.put("action", legacyAction);
+            sseEmitterService.send(conversationId, "client_action", objectMapper.writeValueAsString(payloadMap));
             log.info("Sent editor command: action={}, requestId={}", action, requestId);
 
             // 等待前端执行结果

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -189,7 +189,7 @@ public class DocumentEditTools implements AgentToolComponent {
             }
 
             // 2. 同步打开文件 (Wait for Ready)
-            String resultJson = editorBridgeService.executeEditorCommand("wps_open_file_sync", java.util.Map.of(
+            String resultJson = editorBridgeService.executeEditorCommand("doc_open_file_sync", java.util.Map.of(
                     "fileId", file.getId(),
                     "fileName", file.getName(),
                     "fileType", file.getFileType(),

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -58,20 +58,30 @@ LLM 面的 30 个文档编辑工具 `wps_*` 更名为 `doc_*`（宿主类 `WpsTo
   （系统提示中只有 `doc_*` 名），无静默失败。
 - 数据库历史消息中的旧工具名只影响展示（displayName 兜底"工具执行"），不做数据迁移。
 
-### 编辑器前后端契约（Phase 2.5 保持旧名）
+### 编辑器前后端契约（双轨迁移期）
 
-以下 `wps_*` 字符串是前后端契约（事件字典见 `docs/ai_agent_dev.md` §2.2），受不变式 4 约束，
-Phase 2.5 未改动，命名迁移列入 Phase 3：
+以下字符串是前后端契约（事件字典见 `docs/ai_agent_dev.md` §2.2），受不变式 4 约束。
+命名迁移已进入**双轨期**：后端对每条指令按"**新名在前、旧名在后**"各发一份（SSE 单连接
+有序），前端凭"先见新名"判定新后端并丢弃旧名事件去重（`project-overview.vue`
+`handleClientAction` 闩锁）；旧前端不认识新名、只执行旧名——两个方向各恰好执行一次。
+兼容一个发布周期后摘旧名：
+
+| 契约 | 新名（主） | 旧名（双轨别名） |
+|-----|-----------|----------------|
+| SSE 流式写入事件 | `doc_stream_data` | `wps_stream_data` |
+| SSE client_action 命令载荷 | `tool: "editor_command"`（内含 action 字典）| `tool: "wps_command"` |
+| SSE client_action 打开/刷新 | `action: "doc_open_file"` / `"doc_reload_file"` | `wps_open_file` / `wps_reload_file` |
+| 同步打开命令 | `doc_open_file_sync` | `wps_open_file_sync` |
+| 结果回调路由 | `POST /api/ai/agent/editor-result` | `/wps-result`（路由别名，新前端已改发新路由）|
+
+以下为**存量数据契约**，不在本次迁移范围（需另立数据迁移方案）：
 
 | 契约 | 现名 |
 |-----|------|
-| SSE 流式写入事件 | `wps_stream_data` |
-| SSE client_action 命令载荷 | `tool: "wps_command"`（内含 action 字典）|
-| SSE client_action 打开/刷新 | `action: "wps_open_file"` / `"wps_reload_file"` |
-| 同步打开命令 | `wps_open_file_sync` |
-| 结果回调路由 | `POST /api/ai/agent/wps-result` |
 | write_docx 输出 JSON 键 | `wps_file_id`（前端有字符串匹配逻辑）|
-| 文件实体字段 | `ProjectFile.wpsFileId` |
+| 文件实体字段 | `ProjectFile.wpsFileId`（含数据库列与 API JSON 字段）|
+| 存储路径前缀 | `wps-files/`（application.yml / application-prod.yml）|
+| 功能未配置标识 | `FeatureNotConfiguredException` 的 `"wps"` |
 
 ### Skill 体系（Phase 3B）
 
@@ -171,15 +181,17 @@ AgentOrchestrator 仅 3 行挂载点（字段 + activateForTurn + visibleTools �
         docs/SKILL_SPEC.md）；插件可携带 Skill（PLUGIN_SPEC v2.1）；
         内置 listing-pathway；前端插件广场 Skill 区块。
 
-  **Phase 3 剩余项（仅此两项）**：
-  - [ ] **SSE 事件名双轨迁移**：`wps_stream_data` → `doc_stream_data`、
+  **Phase 3 剩余项**：
+  - [x] **SSE 事件名双轨迁移（双轨已落地）**：`wps_stream_data` → `doc_stream_data`、
         `client_action.tool: wps_command` → `editor_command`、
         `wps_open_file(_sync)` / `wps_reload_file` → `doc_*`、路由 `/wps-result` →
-        `/editor-result`。方案：后端双发（新旧事件并行）、前端双听，观察一个发布周期后
-        摘旧名；**合并前必须在 Electron 桌面端真机实测文档打开、查找替换、流式写入三条链路**。
-        随迁移一并清理：前端零散 WPS 遗留（`VariablePanel.getWps` prop、
-        `ChatInterface.vue` `wps-tip-*` CSS 类、`ProjectFile.wpsFileId` 字段语义梳理）；
-        `wps_*` 工具名别名已按门槛于 0.7.9 后移除（PR#189，见 §3「工具命名与别名」）。
+        `/editor-result`。已落地：后端双发（新名在前、旧名在后）、前端双听 + 旧名去重闩锁
+        （见 §3「编辑器前后端契约」）；随迁移已清理前端零散 WPS 遗留
+        （`VariablePanel.getWps` → `getEditor` prop、`ChatInterface.vue` `wps-tip-*` →
+        `doc-tip-*` CSS 类）；`wps_*` 工具名别名已按门槛于 0.7.9 后移除（PR#189）。
+  - [ ] **双轨摘旧名**：兼容一个发布周期后，摘除后端旧名双发、前端旧名分支与
+        `/wps-result` 路由别名；`ProjectFile.wpsFileId` / `wps_file_id` / `wps-files/`
+        前缀等存量数据契约需另立数据迁移方案。
   - [ ] **插件进程级运行时沙箱**：v2 权限校验是分发层的诚实声明模型，插件代码仍与宿主同进程；
         真正强制 file/network 隔离需进程级沙箱（独立进程 + IPC 或 SecurityManager 替代方案）。
 

--- a/docs/ai_agent_dev.md
+++ b/docs/ai_agent_dev.md
@@ -17,8 +17,15 @@ v1.8 新增 **"文件化产物生命周期 (File-based Artifact Lifecycle)"**：
 | `text_delta` | `{ content }` | Markdown 增量内容 |
 | `step_update` | `{ bubbleId, stepId, status: "loading|done" }` | 更新步骤进度 |
 | `artifact` | `{ operation: "create|update|resolve", id, type, status?, data?, meta? }` | 产物操作 |
-| `client_action` | `{ tool: "wps_write", action, content, options?: { track_changes: boolean } }` | WPS 本地写入指令 |
+| `client_action`（命令） | `{ tool: "editor_command", action, params, requestId, conversationId }` | 编辑器命令（前端执行后 POST `/api/ai/agent/editor-result` 回传结果）；同步打开为 `action: "doc_open_file_sync"` |
+| `client_action`（打开/刷新） | `{ action: "doc_open_file" \| "doc_reload_file", fileId, fileName, fileType, wpsFileId, ... }` | 单向打开/刷新编辑器文档 |
+| `doc_stream_data` | `{ content }` | 编辑器实时流式写入增量（doc_start_stream 激活后） |
 | `bubble_end` | `{ bubbleId, status: "finished" }` | 气泡结束 |
+
+> **双轨迁移期（AI_ARCHITECTURE.md Phase 3）**：以上编辑器契约的旧名
+> `wps_stream_data` / `tool: "wps_command"` / `wps_open_file(_sync)` / `wps_reload_file` /
+> 路由 `/wps-result` 仍由后端按"新名在前、旧名在后"双发（路由为别名保留），前端凭
+> "先见新名"丢弃旧名去重；兼容一个发布周期后摘旧名。
 
 ### 2.3 事件扩充说明
 - **`artifact` - 命名与存储规则**:

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -139,11 +139,11 @@
         <view class="awd-dialog-body">
           <view class="rollback-warning-content">
             <text class="warning-text">此操作将删除该消息以及之后的所有对话记录，且无法恢复。</text>
-            <view class="wps-tip-box">
-              <text class="wps-tip-icon">💡</text>
-              <view class="wps-tip-text">
+            <view class="doc-tip-box">
+              <text class="doc-tip-icon">💡</text>
+              <view class="doc-tip-text">
                 <text>如果助手在后续对话中修改了文档（Word/PPT），文件内容不会自动回退。</text>
-                <text class="wps-link-text">AI 的文档修改以修订痕迹记录，可在编辑器中「拒绝修订」恢复原文。</text>
+                <text class="doc-link-text">AI 的文档修改以修订痕迹记录，可在编辑器中「拒绝修订」恢复原文。</text>
               </view>
             </view>
             <view class="rollback-preview">
@@ -3475,7 +3475,7 @@ export default {
   display: block;
 }
 
-.wps-tip-box {
+.doc-tip-box {
   background-color: #f0f9ff;
   border: 1px solid #bae6fd;
   border-radius: 6px;
@@ -3485,19 +3485,19 @@ export default {
   margin-bottom: 16px;
 }
 
-.wps-tip-icon {
+.doc-tip-icon {
   font-size: 18px;
   margin-right: 10px;
 }
 
-.wps-tip-text {
+.doc-tip-text {
   font-size: 13px;
   color: #0369a1;
   display: flex;
   flex-direction: column;
 }
 
-.wps-link-text {
+.doc-link-text {
   font-weight: 500;
   margin-top: 2px;
 }

--- a/frontend/src/components/VariablePanel.vue
+++ b/frontend/src/components/VariablePanel.vue
@@ -92,7 +92,7 @@ export default {
       type: [String, Number],
       required: true
     },
-    getWps: {
+    getEditor: {
       type: Function,
       default: null
     },
@@ -233,13 +233,13 @@ export default {
     },
 
     async fetchDocFields() {
-      const wps = this.getWps ? this.getWps() : null
-      if (!wps || typeof wps.listVariableFields !== 'function') {
+      const editor = this.getEditor ? this.getEditor() : null
+      if (!editor || typeof editor.listVariableFields !== 'function') {
         this.docFields = []
         return
       }
       try {
-        this.docFields = await wps.listVariableFields()
+        this.docFields = await editor.listVariableFields()
       } catch (e) {
         this.docFields = []
       }
@@ -309,12 +309,12 @@ export default {
     },
 
     async confirmCreate() {
-      const wps = this.getWps ? this.getWps() : null
-      if (!wps || typeof wps.getSelectionText !== 'function') {
+      const editor = this.getEditor ? this.getEditor() : null
+      if (!editor || typeof editor.getSelectionText !== 'function') {
         uni.showToast({ title: '请先点击激活一个编辑窗口', icon: 'none' })
         return
       }
-      const selected = await wps.getSelectionText()
+      const selected = await editor.getSelectionText()
       const text = (selected || '').trim()
       if (!text) {
         uni.showToast({ title: '请先在文档中选择内容', icon: 'none' })
@@ -331,10 +331,10 @@ export default {
           await saveUserVariable({ name, value: text, type: 'TEXT' })
         }
 
-        if (typeof wps.insertTextWithDocumentField !== 'function') {
+        if (typeof editor.insertTextWithDocumentField !== 'function') {
           throw new Error('当前 WPS 组件未提供“域插入”能力')
         }
-        await wps.insertTextWithDocumentField(text, scope, name)
+        await editor.insertTextWithDocumentField(text, scope, name)
 
         this.closeCreateModal()
         await this.refresh()
@@ -345,14 +345,14 @@ export default {
     },
 
     async insertVariable(it) {
-      const wps = this.getWps ? this.getWps() : null
-      if (!wps || typeof wps.insertTextWithDocumentField !== 'function') {
+      const editor = this.getEditor ? this.getEditor() : null
+      if (!editor || typeof editor.insertTextWithDocumentField !== 'function') {
         uni.showToast({ title: '请先点击激活一个编辑窗口', icon: 'none' })
         return
       }
       try {
         const value = this._resolveValue(it.scope, it.name, it.value)
-        await wps.insertTextWithDocumentField(value, it.scope, it.name)
+        await editor.insertTextWithDocumentField(value, it.scope, it.name)
         uni.showToast({ title: '插入成功', icon: 'success' })
         await this.fetchDocFields()
       } catch (e) {
@@ -361,12 +361,12 @@ export default {
     },
 
     async updateValueFromSelection(it) {
-      const wps = this.getWps ? this.getWps() : null
-      if (!wps || typeof wps.getSelectionText !== 'function') {
+      const editor = this.getEditor ? this.getEditor() : null
+      if (!editor || typeof editor.getSelectionText !== 'function') {
         uni.showToast({ title: '请先点击激活一个编辑窗口', icon: 'none' })
         return
       }
-      const selected = await wps.getSelectionText()
+      const selected = await editor.getSelectionText()
       const text = (selected || '').trim()
       if (!text) {
         uni.showToast({ title: '请先选择内容', icon: 'none' })
@@ -400,12 +400,12 @@ export default {
     },
 
     async _updateAllFieldInstances(scope, varName, nextText) {
-      const wps = this.getWps ? this.getWps() : null
-      if (!wps || typeof wps.updateDocumentField !== 'function') return
+      const editor = this.getEditor ? this.getEditor() : null
+      if (!editor || typeof editor.updateDocumentField !== 'function') return
       const fields = (this.docFields || []).filter(f => f.scope === scope && f.varName === varName)
       for (const f of fields) {
         try {
-          await wps.updateDocumentField(f.id, nextText)
+          await editor.updateDocumentField(f.id, nextText)
         } catch (e) {
           // ignore
         }
@@ -413,8 +413,8 @@ export default {
     },
 
     async syncDocument() {
-      const wps = this.getWps ? this.getWps() : null
-      if (!wps || typeof wps.syncAllDocumentFields !== 'function') {
+      const editor = this.getEditor ? this.getEditor() : null
+      if (!editor || typeof editor.syncAllDocumentFields !== 'function') {
         uni.showToast({ title: '请先点击激活一个编辑窗口', icon: 'none' })
         return
       }
@@ -422,7 +422,7 @@ export default {
       try {
         await this.fetchProjectVars()
         await this.fetchUserVars()
-        const res = await wps.syncAllDocumentFields((scope, varName, currentText) => {
+        const res = await editor.syncAllDocumentFields((scope, varName, currentText) => {
           if (scope === 'P' || scope === 'U') return this._resolveValue(scope, varName, currentText) || ''
           return currentText
         })

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -50,7 +50,7 @@ export const EDITOR_ACTIONS = [
   // worker 端实现——此前 worker 未实现且未入白名单，一直返回 Unknown action。
   'debug_revisions',
   // [#104 变量面板] document variable fields — bookmark-marked spans bound to a
-  // (scope, varName) variable; driven by VariablePanel through the getWps adapter
+  // (scope, varName) variable; driven by VariablePanel through the getEditor adapter
   // in project-overview.vue, not by the AI agent pipeline.
   'var_list', 'var_insert', 'var_update',
   // [#79 债务清偿] WPS-instance-bound features restored on LibreOffice:

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -464,10 +464,11 @@ export function useAgentStream() {
             } catch (e) {
                 console.error('Failed to parse title_update', e)
             }
-        } else if (evt === 'wps_stream_data') {
-            // Live document streaming (backend event name kept for contract
-            // stability, #79). Routed up the same client_action seam so the page
-            // can feed the embedded LibreOffice editor (buffered insert).
+        } else if (evt === 'doc_stream_data' || evt === 'wps_stream_data') {
+            // Live document streaming. Dual-track migration (AI_ARCHITECTURE.md
+            // Phase 3): new backends emit doc_stream_data first then the legacy
+            // wps_stream_data with the same content; both are routed up the
+            // client_action seam and deduped there by the "new-name-first" latch.
             try {
                 // Mark current bubble as doc-streaming to suppress chat duplication
                 if (currentAssistantBubble.value && !currentAssistantBubble.value.isEditorStreaming) {
@@ -480,10 +481,10 @@ export function useAgentStream() {
 
                 const d = JSON.parse(dataStr)
                 if (clientActionHandler.value) {
-                    clientActionHandler.value({ action: 'wps_stream_data', content: d.content || '' })
+                    clientActionHandler.value({ action: evt, content: d.content || '' })
                 }
             } catch (e) {
-                console.error('Failed to handle wps_stream_data', e)
+                console.error('Failed to handle ' + evt, e)
             }
         } else if (evt === 'cancelled') {
             // 处理取消事件

--- a/frontend/src/composables/useEditorBridge.js
+++ b/frontend/src/composables/useEditorBridge.js
@@ -3,7 +3,7 @@
 // Epic #43 (LibreOffice migration), WPS removal #79. The agent command pipeline is:
 //   backend SSE `client_action` -> useAgentStream -> ChatInterface emits
 //   -> project-overview.vue handleEditorCommand -> executor.executeCommand(action, params)
-//   -> POST /api/ai/agent/wps-result
+//   -> POST /api/ai/agent/editor-result (legacy alias /wps-result, dual-track Phase 3)
 //
 // RFC v2's thesis (docs/LIBREOFFICE_MIGRATION_PLAN.md) was that the backend agent
 // contract is editor-agnostic and ONLY the frontend executor changes. With WPS

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -886,7 +886,7 @@
                     v-if="activeToolKey === 'variables'"
                     ref="variablePanel"
                     :project-id="projectId"
-                    :get-wps="getLibreVariableBridge"
+                    :get-editor="getLibreVariableBridge"
                     :search-keyword="toolsSearchKeyword"
                   />
                   <ProjectFavoritesPanel
@@ -1263,7 +1263,7 @@ import {
   getAiConfig,
   getAssistants, // Added
   getPlugins, // Added
-  sendEditorResult, // 编辑器命令结果回调（POST /wps-result，路由名为前后端契约）
+  sendEditorResult, // 编辑器命令结果回调（POST /editor-result，双轨迁移见 docs/AI_ARCHITECTURE.md Phase 3）
   getFileText,
   promptFeatureNotConfigured // 功能未配置统一引导（#18 T7）
 } from '@/services/api.js'
@@ -1493,7 +1493,7 @@ export default {
       // 内嵌编辑器保活 LRU：'pane:fileId'（left:123），最近激活在前。在池中的
       // Office 标签切走时实例不销毁（v-show 隐藏），切回免重 boot/重载。
       libreLruKeys: [],
-      // 后端 wps_stream_data 流式写入的本地缓冲（#79：LibreOffice 消费端）
+      // 后端 doc_stream_data（旧名 wps_stream_data）流式写入的本地缓冲（#79：LibreOffice 消费端）
       _docStreamBuffer: '',
       _docStreamTimer: null,
       _docStreamBusy: false,
@@ -5546,6 +5546,16 @@ export default {
     handleClientAction(action) {
         console.log('[ProjectOverview] Client Action:', action)
 
+        // 双轨迁移（docs/AI_ARCHITECTURE.md Phase 3）：新后端对每条指令按"新名在前、旧名在后"
+        // 各发一份。一旦见到任一新名即判定为新后端（SSE 单连接有序），此后丢弃所有旧名事件，
+        // 保证新旧后端搭配下每条指令都恰好执行一次。
+        const isNewName = action.tool === 'editor_command' ||
+            ['doc_open_file', 'doc_reload_file', 'doc_stream_data'].includes(action.action)
+        const isLegacyName = action.tool === 'wps_command' ||
+            ['wps_open_file', 'wps_reload_file', 'wps_stream_data'].includes(action.action)
+        if (isNewName) this._editorContractV2 = true
+        if (isLegacyName && this._editorContractV2) return
+
         if (action.action === 'refresh_files') {
             if (this.$refs.fileTree && this.$refs.fileTree.loadFiles) {
                 console.log('[ProjectOverview] Refreshing File Tree...')
@@ -5554,24 +5564,24 @@ export default {
             }
         }
         // AI Agent 请求打开文件
-        else if (action.action === 'wps_open_file') {
+        else if (action.action === 'doc_open_file' || action.action === 'wps_open_file') {
             this.handleEditorOpenFile(action)
         }
-        // AI Agent 请求重新加载文件（用于后端修改文件后刷新 WPS）
-        else if (action.action === 'wps_reload_file') {
+        // AI Agent 请求重新加载文件（用于后端修改文件后刷新编辑器）
+        else if (action.action === 'doc_reload_file' || action.action === 'wps_reload_file') {
             this.handleEditorReloadFile(action)
         }
-        // AI Agent 请求执行编辑器命令（事件名沿用 wps_command，前后端契约；双轨迁移见 docs/AI_ARCHITECTURE.md Phase 3）
-        else if (action.tool === 'wps_command') {
-            // 特殊处理 wps_open_file_sync 命令（新建文件流式写入）
-            if (action.action === 'wps_open_file_sync') {
+        // AI Agent 请求执行编辑器命令
+        else if (action.tool === 'editor_command' || action.tool === 'wps_command') {
+            // 特殊处理同步打开命令（新建文件流式写入）
+            if (action.action === 'doc_open_file_sync' || action.action === 'wps_open_file_sync') {
                 this.handleEditorOpenFileSync(action)
             } else {
                 this.handleEditorCommand(action)
             }
         }
-        // 后端流式写入数据（wps_start_stream 工具）：缓冲后经 LibreOffice 执行器落字
-        else if (action.action === 'wps_stream_data') {
+        // 后端流式写入数据（doc_start_stream 工具）：缓冲后经 LibreOffice 执行器落字
+        else if (action.action === 'doc_stream_data' || action.action === 'wps_stream_data') {
             this.handleDocStreamData(action.content || '')
         }
     },
@@ -5619,7 +5629,7 @@ export default {
 
         try {
             if (!params || !params.fileId) {
-                console.error('[ProjectOverview] No fileId in wps_open_file_sync')
+                console.error('[ProjectOverview] No fileId in doc_open_file_sync')
                 await sendEditorResult(conversationId, requestId, false, null, '缺少文件ID')
                 return
             }
@@ -5689,7 +5699,7 @@ export default {
         try {
             const fileId = action.fileId
             if (!fileId) {
-                console.warn('[ProjectOverview] No fileId in wps_open_file action')
+                console.warn('[ProjectOverview] No fileId in doc_open_file action')
                 return
             }
 
@@ -5727,7 +5737,7 @@ export default {
         try {
             const fileId = action.fileId
             if (!fileId) {
-                console.warn('[ProjectOverview] No fileId in wps_reload_file action')
+                console.warn('[ProjectOverview] No fileId in doc_reload_file action')
                 return
             }
 
@@ -5804,7 +5814,7 @@ export default {
 
     /**
      * 处理 AI Agent 的编辑器命令请求（#79：LibreOffice 是唯一执行器；
-     * 结果经 sendEditorResult 回传后端，路由 /wps-result 为前后端契约）
+     * 结果经 sendEditorResult 回传后端，路由 /editor-result，双轨迁移见 Phase 3）
      */
     async handleEditorCommand(action) {
         console.log('[ProjectOverview] ========== Editor Command Start ==========')
@@ -5940,7 +5950,7 @@ export default {
         if (!this.libreOfficeActive) console.log('[ProjectOverview] LibreOffice editor closed — agent commands unavailable until reopened')
     },
 
-    // #104: WPS-era getWps() adapter for VariablePanel — the five document-field
+    // #104: getEditor() adapter for VariablePanel — the five document-field
     // methods it expects, implemented over the LibreOffice executor's var_*
     // commands. Returns null while no editor is active so the panel keeps its
     // own “请先点击激活一个编辑窗口” fallback.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1325,7 +1325,8 @@ export function copyDdRequest(requestId) {
 // ==================== 编辑器操作结果回调 ====================
 
 /**
- * 发送编辑器操作结果到后端（路由 /wps-result 为前后端契约，保持旧名）
+ * 发送编辑器操作结果到后端（双轨迁移：新路由 /editor-result；后端同版本起
+ * 保留旧路由 /wps-result 别名供旧前端使用，见 docs/AI_ARCHITECTURE.md Phase 3）
  * @param {string} conversationId - 会话 ID
  * @param {string} requestId - 请求 ID
  * @param {boolean} success - 是否成功
@@ -1334,7 +1335,7 @@ export function copyDdRequest(requestId) {
  */
 export function sendEditorResult(conversationId, requestId, success, data, error = null) {
   return request({
-    url: '/api/ai/agent/wps-result',
+    url: '/api/ai/agent/editor-result',
     method: 'POST',
     data: {
       conversationId,

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -1216,7 +1216,7 @@ const EXEC = {
     }
     return Object.assign({ success: done > 0, redone: done }, done > 0 ? verifySnapshot() : { message: 'nothing to redo' });
   },
-  // ---- #104 文档变量域原语（VariablePanel via the getWps adapter) ------------
+  // ---- #104 文档变量域原语（VariablePanel via the getEditor adapter) ------------
   // list every variable field in the document: {fields: [{id, scope, varName, text}]}
   var_list() {
     const bms = xModel.getBookmarks();


### PR DESCRIPTION
## 概要

Phase 3 遗留项：把 WPS 时代的前后端契约命名迁到新名，**双轨并行一个发布周期后再摘旧名**（本 PR 只落双轨，不摘旧名）。登记于 docs/AI_ARCHITECTURE.md §编辑器前后端契约。

## 迁移映射

| 契约 | 新名（主） | 旧名（双轨保留） |
|-----|-----------|----------------|
| SSE 流式写入事件 | `doc_stream_data` | `wps_stream_data` |
| client_action 命令载荷 | `tool: "editor_command"` | `tool: "wps_command"` |
| client_action 打开/刷新 | `doc_open_file` / `doc_reload_file` | `wps_open_file` / `wps_reload_file` |
| 同步打开命令 | `doc_open_file_sync` | `wps_open_file_sync` |
| 结果回调路由 | `POST /api/ai/agent/editor-result` | `/wps-result`（路由别名） |

## 双轨机制（顺序即契约）

后端对每条指令按**新名在前、旧名在后**各发一份（SSE 单连接有序）；前端凭"先见新名"置闩锁判定新后端，此后丢弃所有旧名事件。新旧后端 × 新旧前端四种搭配下，每条指令都恰好执行一次。

## 一并清理的前端零散遗留

- `VariablePanel.getWps` prop → `getEditor`
- `ChatInterface.vue` `wps-tip-*` / `wps-link-text` CSS 类 → `doc-tip-*` / `doc-link-text`

## 明确不动（存量数据契约，另立迁移方案）

`ProjectFile.wpsFileId`（含 DB 列与 API JSON 字段）、存储前缀 `wps-files/`、`write_docx` 返回键 `wps_file_id`、`FeatureNotConfiguredException` 的 `"wps"` 标识。

## 验收（AI_ARCHITECTURE.md 门槛全过）

- ✅ backend `mvn test` 全绿（JDK 21）
- ✅ frontend `npm run check:emits` 过
- ✅ **Electron 桌面端真机三链路实测**（dev Electron + CDP）：
  - AI 打开文档：后端日志 `Sent doc_open_file` + 编辑器随即拉取文件内容
  - 查找替换修订：`editor_command`/`wps_command` 双发各 1 次 → 去重后仅执行 1 次 → 新路由 `/editor-result` 200 → `Completed editor action: success=true`
  - 流式写入新文档：`doc_open_file_sync` 同步打开往返成功，流式产物中验收标记**恰好出现一次**（若去重失效每个 token 会写两遍）
- ✅ 双 e2e：`test:lowa-e2e` 33/33，`test:app-e2e` 29 步全过、0 异常信号

## 实测中发现的存量问题（与本迁移无关，已建独立任务）

- `<tool_code>` 文本工具调用的位置参数不映射 → `doc_find_replace` 收到 null 参数 NPE
- 自动保存疑似在文档未加载完成时用空文档覆盖存量文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)