### PR TITLE
fix(ai): tool_code 位置参数按工具签名映射为命名参数，doc_find_replace 不再 NPE

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -418,4 +418,11 @@ public class ToolRegistry {
     public static List<String> aliasesFor(String paramName) {
         return ARG_ALIASES.getOrDefault(paramName, List.of());
     }
+
+    /**
+     * 是否为服务端注入参数（对 LLM 不可见，XML 解析器做位置参数映射时须跳过）。
+     */
+    public static boolean isServerContextParam(String paramName) {
+        return SERVER_CONTEXT_PARAMS.contains(paramName);
+    }
 }

--- a/backend/src/main/java/com/checkba/service/ai/XmlToolCallParser.java
+++ b/backend/src/main/java/com/checkba/service/ai/XmlToolCallParser.java
@@ -106,7 +106,8 @@ public class XmlToolCallParser {
         Optional<ToolRegistry.RegisteredTool> tool = toolRegistry.resolve(
                 ToolRegistry.TOOL_NAME_ALIASES.getOrDefault(toolName, toolName));
         if (tool.isPresent()) {
-            for (java.lang.reflect.Parameter p : tool.get().method().getParameters()) {
+            java.lang.reflect.Parameter[] params = tool.get().method().getParameters();
+            for (java.lang.reflect.Parameter p : params) {
                 String paramName = p.getName();
                 String value = extractStringArg(code, paramName);
                 if (value.isEmpty()) {
@@ -120,6 +121,20 @@ public class XmlToolCallParser {
                 if (!value.isEmpty()) {
                     args.set(paramName, value);
                 }
+            }
+            // 5. 位置参数兜底：doc_find_replace("合同", "协议", true) 这类无 key= 写法，
+            //    按签名声明顺序映射到尚未命中的参数（跳过服务端注入参数，避免错位）
+            List<String> positional = extractPositionalArgs(code, toolName);
+            int posIdx = 0;
+            for (java.lang.reflect.Parameter p : params) {
+                if (posIdx >= positional.size()) {
+                    break;
+                }
+                String paramName = p.getName();
+                if (ToolRegistry.isServerContextParam(paramName) || args.containsKey(paramName)) {
+                    continue;
+                }
+                args.set(paramName, positional.get(posIdx++));
             }
         } else {
             // 未注册工具（可能是插件或幻觉调用）：通用 key=value 提取，交由分发层判定
@@ -170,6 +185,116 @@ public class XmlToolCallParser {
         String head = code.substring(0, paren).trim();
         int dot = head.lastIndexOf('.');
         return dot != -1 ? head.substring(dot + 1).trim() : head;
+    }
+
+    private static final Pattern NAMED_ARG_TOKEN_PATTERN = Pattern.compile("^[A-Za-z_]\\w*\\s*=(?!=)");
+
+    /**
+     * 提取调用中的位置参数（不带 key= 的实参），按出现顺序返回还原后的字符串值。
+     * 供 {@link #parseSingle} 在命名参数提取后做签名顺序映射兜底。
+     */
+    private List<String> extractPositionalArgs(String code, String toolName) {
+        List<String> positional = new ArrayList<>();
+        for (String token : splitTopLevelArgs(code, toolName)) {
+            String trimmed = token.trim();
+            if (trimmed.isEmpty() || NAMED_ARG_TOKEN_PATTERN.matcher(trimmed).find()) {
+                continue;
+            }
+            positional.add(unquote(trimmed));
+        }
+        return positional;
+    }
+
+    /**
+     * 把 toolName(...) 括号内的实参按顶层逗号切分（引号内与嵌套括号内的逗号不切）。
+     * 优先定位 toolName( 之后的括号，兼容 print(tool(...)) 包裹写法。
+     */
+    private List<String> splitTopLevelArgs(String code, String toolName) {
+        List<String> tokens = new ArrayList<>();
+        int start = code.indexOf(toolName + "(");
+        if (start != -1) {
+            start += toolName.length() + 1;
+        } else {
+            start = code.indexOf('(');
+            if (start == -1) {
+                return tokens;
+            }
+            start += 1;
+        }
+        int depth = 1;
+        char quote = 0;
+        boolean escaped = false;
+        StringBuilder cur = new StringBuilder();
+        for (int i = start; i < code.length(); i++) {
+            char c = code.charAt(i);
+            if (quote != 0) {
+                cur.append(c);
+                if (escaped) {
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == quote) {
+                    quote = 0;
+                }
+                continue;
+            }
+            if (c == '"' || c == '\'') {
+                quote = c;
+                cur.append(c);
+            } else if (c == '(' || c == '[' || c == '{') {
+                depth++;
+                cur.append(c);
+            } else if (c == ')' || c == ']' || c == '}') {
+                depth--;
+                if (depth == 0) {
+                    break;
+                }
+                cur.append(c);
+            } else if (c == ',' && depth == 1) {
+                tokens.add(cur.toString());
+                cur.setLength(0);
+            } else {
+                cur.append(c);
+            }
+        }
+        if (!cur.toString().trim().isEmpty()) {
+            tokens.add(cur.toString());
+        }
+        return tokens;
+    }
+
+    /**
+     * 还原单个实参字面量：三引号原样取内、单/双引号解转义（\n \t \r）、无引号原样返回。
+     */
+    private String unquote(String token) {
+        for (String triple : new String[]{"\"\"\"", "'''"}) {
+            if (token.length() >= 6 && token.startsWith(triple) && token.endsWith(triple)) {
+                return token.substring(3, token.length() - 3);
+            }
+        }
+        if (token.length() >= 2) {
+            char first = token.charAt(0);
+            if ((first == '"' || first == '\'') && token.charAt(token.length() - 1) == first) {
+                StringBuilder sb = new StringBuilder();
+                boolean escaped = false;
+                for (int i = 1; i < token.length() - 1; i++) {
+                    char c = token.charAt(i);
+                    if (escaped) {
+                        if (c == 'n') sb.append('\n');
+                        else if (c == 't') sb.append('\t');
+                        else if (c == 'r') sb.append('\r');
+                        else sb.append(c);
+                        escaped = false;
+                    } else if (c == '\\') {
+                        escaped = true;
+                    } else {
+                        sb.append(c);
+                    }
+                }
+                return sb.toString();
+            }
+        }
+        return token;
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -282,6 +282,9 @@ public class DocumentEditTools implements AgentToolComponent {
             @P("是否替换全部匹配项，默认 true") Boolean replaceAll
     ) {
         log.info("Tool: doc_find_replace called find={}, replace={}", findText, replaceText);
+        if (findText == null || findText.isEmpty() || replaceText == null) {
+            return "Error: 缺少必填参数 findText/replaceText。请用命名参数重新调用，例如 doc_find_replace(findText=\"原文\", replaceText=\"新文\", replaceAll=true)。";
+        }
         try {
             return editorBridgeService.executeEditorCommand("find_replace", 
                     java.util.Map.of(

--- a/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
@@ -164,6 +164,49 @@ class XmlToolCallParserTest {
     }
 
     @Test
+    @DisplayName("位置参数：doc_find_replace(\"合同\", \"协议\", true) 按签名顺序映射")
+    void parsesPositionalArgs() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>doc_find_replace(\"合同\", \"协议\", true)</tool_code>");
+        assertEquals("doc_find_replace", call.toolName());
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("合同", args.getStr("findText"));
+        assertEquals("协议", args.getStr("replaceText"));
+        assertEquals("true", args.getStr("replaceAll"));
+    }
+
+    @Test
+    @DisplayName("位置参数：跳过服务端注入参数 projectId 不错位")
+    void positionalArgsSkipServerContextParams() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>pptx_generate(\"年度总结\", \"汇报.pptx\")</tool_code>");
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("年度总结", args.getStr("topic"));
+        assertEquals("汇报.pptx", args.getStr("fileName"));
+        assertFalse(args.containsKey("projectId"));
+    }
+
+    @Test
+    @DisplayName("混合写法：位置参数与命名参数共存")
+    void parsesMixedPositionalAndNamedArgs() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>doc_find_replace(\"甲方\", replaceText=\"乙方\")</tool_code>");
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("甲方", args.getStr("findText"));
+        assertEquals("乙方", args.getStr("replaceText"));
+    }
+
+    @Test
+    @DisplayName("位置参数：引号内的逗号与转义不被切分")
+    void positionalArgsKeepQuotedCommas() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>doc_find_replace(\"甲方, 乙方\", \"双方\\n各方\")</tool_code>");
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("甲方, 乙方", args.getStr("findText"));
+        assertEquals("双方\n各方", args.getStr("replaceText"));
+    }
+
+    @Test
     @DisplayName("containsToolCall 判定")
     void detectsToolCallPresence() {
         assertTrue(parser.containsToolCall("<tool_code>x()</tool_code>"));


### PR DESCRIPTION
## 问题

模型走 XML 兜底协议输出 `<tool_code>doc_find_replace("合同", "协议", true)</tool_code>` 这类**位置参数**写法时，`XmlToolCallParser.parseSingle` 只按 `key=value` 提取命名参数，一个都提不到 → 空 args 下发 → `DocumentEditTools.doc_find_replace` 收到 `find=null, replace=null` → `Map.of` 不接受 null 值，抛 NullPointerException。

复现日志：2026-07-24 16:04:39 `Tool: doc_find_replace called find=null, replace=null` + NPE 堆栈。

## 修复

1. **XmlToolCallParser**：命名参数提取后新增位置参数兜底——把 `toolName(...)` 括号内实参按顶层逗号切分（引号内/嵌套括号内逗号不切、处理转义与三引号），不带 `key=` 的实参按注册工具签名声明顺序映射到尚未命中的参数；跳过服务端注入参数（projectId/conversationId/userId）避免错位，兼容 `print(...)` 包裹与命名/位置混合写法。
2. **ToolRegistry**：暴露 `isServerContextParam` 供解析器共用。
3. **DocumentEditTools.doc_find_replace**：入口对 null/空必填参数返回友好错误（引导模型用命名参数重试），不再 NPE。

## 验证

- 新增 4 个解析器用例：纯位置参数（复现日志原始形态）、跳过 projectId 不错位、混合写法、引号内逗号/转义不被切分
- backend 全量 `mvn test`（JDK 21）：**282 tests, 0 failures, BUILD SUCCESS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)