### PR TITLE
fix(editor): 文档加载失败/空下载时拒绝自动保存——堵住空文档覆盖真文件的数据丢失洞

### DIFF
--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -84,6 +84,11 @@ export default {
       // Autosave: set by the worker's modify signal, cleared when a save starts;
       // read by the host (closeFile / evict) to know if a flush is needed.
       dirty: false,
+      // 数据安全闸：load_document 失败（或非空文件下载到 0 字节）后置位。此时
+      // worker 里还是空白 boot 文档，任何保存都会用空文档覆盖后端真文件——
+      // autosave/flushSave 一律拒绝。不能复用 isError（'保存失败' 也含'失败'，
+      // 会误杀保存重试）。
+      docLoadFailed: false,
       // 加载进度面板状态：bootPct 按里程碑推进（其间缓慢滴答，避免看起来卡死），
       // bootCap 是当前阶段允许滴到的上限；dl* 是文档字节下载进度。
       bootPct: 3,
@@ -256,7 +261,9 @@ export default {
         } catch (e) {
           // Load failed → the seeded prototype is still showing. Surface it; the
           // editor stays usable (AI/IME act on whatever is shown) but the content
-          // is wrong, so this is loud, not silent.
+          // is wrong, so this is loud, not silent. docLoadFailed 关保存闸——
+          // 空白画布上的任何编辑都不得回传覆盖后端真文件。
+          this.docLoadFailed = true
           this.statusText = '文档加载失败'
           this.appendLog('load_document failed: ' + (e && e.message ? e.message : e))
         }
@@ -296,6 +303,9 @@ export default {
       // editor the worker booted (the user edits + saves into it). Only a real
       // fetch error (non-200, handled in fetchArrayBuffer) surfaces as failed.
       if (bytes.length === 0) {
+        // 元数据说文件非空却下载到 0 字节 = 后端/存储瞬时异常，绝不能当
+        // "新建空白文档"——那会让后续编辑以空文档覆盖真文件。按加载失败走。
+        if (f.fileSize > 0) throw new Error('文件非空（' + f.fileSize + ' bytes）但下载到 0 字节，拒绝按空白文档打开')
         this.appendLog('文档为空（新建/未保存）→ 显示空白文档 / empty doc → blank editor: ' + name)
         return
       }
@@ -334,7 +344,8 @@ export default {
     // press anything. Idle window 2.5s; continuous typing still hits the backend
     // at least every 15s (max-wait), so a crash can't eat a long burst.
     onDocModified() {
-      if (!this.ready || !this.file) return
+      // docLoadFailed：画布上是空白 boot 文档，标脏会引发空文档覆盖真文件
+      if (!this.ready || !this.file || this.docLoadFailed) return
       this.dirty = true
       if (!this._dirtySince) this._dirtySince = Date.now()
       this.scheduleAutoSave()
@@ -390,6 +401,9 @@ export default {
     async saveDocument() {
       const f = this.file
       if (!f || !this.executor || this.saving) return false
+      // 最后一道闸（onDocModified 之外的调用方也拦住）：文档没成功加载，
+      // 导出的只会是空白 boot 文档——拒绝覆盖后端真文件。
+      if (this.docLoadFailed) { this.appendLog('save blocked: 文档未成功加载，拒绝用空白文档覆盖后端文件'); return false }
       const fileId = f.wpsFileId || f.id
       if (!fileId) { this.appendLog('save: file has no id/wpsFileId'); return false }
       this.saving = true

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -185,15 +185,18 @@ try {
     if (!r || r.success !== true) throw new Error('insert 失败: ' + JSON.stringify(r).slice(0, 150))
   })
 
-  await step('点保存按钮并等待「已保存」', async () => {
-    await mouseClickSel('.libre-save')
+  await step('等待自动保存「已保存」', async () => {
+    // 手动保存按钮已随 PR#185 实验工具栏移除——插入即触发 modified → 自动
+    // 保存（约 2.5s 防抖）。「已保存」徽标只停 2.5s，也接受 dirty 已清且不在
+    // 保存中（徽标窗口被轮询错过时的等价完成信号）。
     for (let i = 0; i < 60; i++) {
-      const st = await editorEval('return { status: ed.statusText, saving: ed.saving }')
+      const st = await editorEval('return { status: ed.statusText, saving: ed.saving, dirty: ed.dirty }')
       if (/已保存/.test(st.status)) return
+      if (i > 5 && !st.dirty && !st.saving && !/失败/.test(st.status)) return
       if (/失败/.test(st.status)) throw new Error('保存状态: ' + st.status)
       await sleep(1000)
     }
-    throw new Error('保存未确认(超时)')
+    throw new Error('自动保存未确认(超时)')
   })
 
   await step('API 下载 docx 验证内容落盘', async () => {


### PR DESCRIPTION
## 现象（2026-07-24 真机）

项目文件 qa-dual.docx（原有两段文本）在 LOWA 编辑器多次打开/重载后，后端存储被一份**空 body 的完整 Word 文档**（约 13KB，w:body 只剩一个空段落）覆盖——结构完整说明是编辑器导出保存的。

## 根因

`load_document` 失败后 `onEndpointReady` 仍置 `ready=true` 并照常 `$emit('ready', executor)`（设计如此：编辑器保持可用、状态条报"文档加载失败"）。此时 worker 里 `xModel` 还是**空白 boot 文档**。宿主 closeFile/evictLibreInstance 已有 `isError` 守卫，但**组件内部 autosave 链路没有**：

```
load 失败(ready=true, 画布=空白boot文档)
  → 任何 modified（键入/IME/AI指令，AI 指令仍会路由到失败实例）
  → onDocModified 标脏 → autoSave → export_document 导出空白文档
  → uploadBytes 覆盖后端真文件 ✗
```

旁路洞：下载 0 字节被**无条件**当"新建空白文档"处理——若后端对已有内容的文件瞬时返回 0 字节，同样以空文档身份接受后续覆盖保存。

## 修复（组件内三道闸）

- 新增 `docLoadFailed` 专用标志，load 失败置位。不能复用 `isError`——'保存失败'也含'失败'，会误杀保存重试
- `onDocModified` 对失败实例不再标脏（autosave 永不触发）
- `saveDocument` 兜底拒绝并留日志（`flushSave` 等其他调用方也被拦住）
- 旁路封堵：元数据 `fileSize>0` 却下载 0 字节 → 按加载失败走（真·新建文件 fileSize=0/缺失，行为不变）

顺手修 desktop-e2e 陈旧步骤：手动保存按钮已随 #185 移除，"点保存按钮"改为"等待自动保存"（该步骤自 #185 起在 master 常红）。

## 验证

- 一次性单测 16 项全过；**用 HEAD（修复前）跑同一脚本 8 项失败**，其中"modified 后照样标脏、saveDocument 照样导出上传"准确复现覆盖路径
- `npm run test:desktop-e2e` 保存链路全通（新建空文档→插入→自动保存→API 下载验证落盘；实测 fileSize=0 新文档不受新守卫影响）
- `npm run test:lowa-e2e` 38/38
- `npm run check:emits` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)