### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 发版 bump

`desktop/package.json` version 0.7.9 → **0.8.0**。

自 v0.7.9 以来将打包的内容（#184–#194）：
- #186 evidence.retrieve.v1 证据检索契约（MCP 降为传输适配层）
- #188 修订颗粒度字符级最小化
- #189/#190/#192 WPS 契约命名双轨迁移（doc_*/editor_command 与 wps_* 并行一个发布周期）
- #191 批注原语 doc_add_comment
- #185/#187/#193 修复：实验探针工具栏移除 / 活跃文档识别 / tool_code 位置参数映射
- #184 fetch-lowa-assets 下载重试
- #194 autosave 空文档覆盖修复（数据丢失洞）

含多项 feature 与契约迁移周期起点，故 minor 升到 0.8.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)