### PR TITLE
docs(agents): 8 份领域 sub-agent 文档 + CLAUDE.md 路由表

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -1,0 +1,68 @@
+---
+name: ai-chat
+description: AI 对话编排领域。任务涉及编排器 AgentOrchestrator、ToolRegistry、SSE 事件流、上下文组装、记忆系统、MCP、子 Agent、模型路由、回放评测时，先读本文档再动代码。
+---
+
+# AI 对话编排 领域地图
+
+职责边界：AI 对话功能本身（编排循环、工具注册分发、记忆、SSE、前端聊天 UI、评测）。AI→编辑器指令链路属 ai-doc-bridge 领域；skill 机制属 plugin-system 领域（但 SkillRouter 在编排循环里有两处旁路接入点）。
+
+## 关键文件（后端包根 backend/src/main/java/com/checkba/）
+
+**编排核心**
+- `controller/ai/AiAgentController.java` — 主入口（/api/agent）：GET /connect/{cid}（建 SSE）、POST /chat（异步 200）、POST /cancel/{cid}、/history/rollback、/tasks/active、/ppt/generate。AiChatController 是已被取代的 v1，非主链路。
+- `service/ai/AgentOrchestrator.java`（862 行）— **编排器**：handleUserMessage（@Async("taskExecutor")）+ runLoop（递归）。RunGuard：重复调用熔断 MAX_IDENTICAL_TOOL_CALLS=3、连续失败提示=3、步数预算 MAX_LOOP_DEPTH=30。工具分发 dispatchTool（~:160）、artifact/<title> 处理、检查点触发。
+- `service/ai/AgentStreamHandler.java`（493 行）— StreamingResponseHandler：token 流→SSE；<bubble_type>/<artifact> 边界解析缓冲、编辑器流过滤、token 用量上报。每次 runLoop 新建实例。
+- `service/ai/AgentRunStateService.java` — 每会话运行状态登记簿（内存）：RUNNING/PAUSED/AWAITING_APPROVAL/FINISHED/ERROR/CANCELLED。**新增终止分支必打状态点**（PR#173 状态机契约）。
+- `service/ai/ContextAssemblerService.java`（507 行）— assemble()：prompts/system_prompt.md + enforcement 段 + 模式约束 + Skill 注入 + 记忆 + 文件上下文 + 历史栈。
+- `service/ai/ChatModelFactory.java` — 供应商路由（OpenRouter/Gemini/Ollama）；provider 优先 DB `ai.activeProvider` 再回退 yml（PR#144）。`AllowedModels.java` 白名单（含单价）。
+- context/ 子包：ContextCompressor、ConversationSummarizer、FileContextLoader、LegalInfoProtector、ProjectContextHolder。
+
+**工具注册与执行**
+- `service/ai/ToolRegistry.java`（428 行）— @PostConstruct 扫 AgentToolComponent 的 @Tool；getAllSpecifications / execute（反射+服务端强注入 projectId/conversationId/userId+容错类型转换）/ resolve；别名表 TOOL_NAME_ALIASES/ARG_ALIASES/LEGACY_DEFAULTS。**插件启停过滤也在这三处消费点**。
+- `service/ai/XmlToolCallParser.java` — XML <tool_code> 协议兜底（位置参数按签名映射为命名参数，PR#193）。
+- tools/：FileTools(8)、LegalTools(5)、WebTools(2)、PythonTools(1)、TodoTools(1)、SubAgentTools(1，**@Lazy 防启动死环** PR#98)、EvidenceTools(1)、MemoryTools(8)、DocumentEditTools(32)、CheckpointTools(1)、PptxTools(13)、PptxEditTools(7)。
+
+**记忆/证据/MCP/子 Agent**
+- memory/：MemoryPipelineService（轮次结束异步触发写侧管线）、MemoryManager（检索）、AgenticRetriever、MemCellExtractor、ProjectMemoryExtractor、MemoryEvidenceFormatter（证据账本：时间锚点/来源/更新信号，PR#155）。记忆五作用域 + 拟人化排序（重要性×衰减×随机）。
+- evidence/：evidence.retrieve.v1（PR#186）——EvidenceRetriever SPI + Registry + Memory/Mcp 实现。两大不变式：**缺定位符即丢弃、缺证据≠矛盾**。
+- mcp/：McpClientService 门面 + StreamableHttpMcpProvider；配置驱动 mcp.servers（langchain4j-mcp 需 1.0.0+）。
+- subagent/：SubAgentService（dispatch_subtask，发 subtask_progress）。
+
+**SSE**
+- `service/ai/SseEmitterService.java` — 连接池（cid→SseEmitter，超时 30 分钟，建连发 connected）。**所有事件唯一出口**。生产者：Orchestrator、StreamHandler、Controller、TodoListService(plan_update)、BackgroundTaskService(background_task_*/heartbeat/task_progress)、SubAgentService、EditorBridgeService。
+
+**前端消费**
+- `frontend/src/composables/useAgentStream.js`（1233 行）— SSE 核心：connectSSE（fetch+ReadableStream，非 EventSource）、sendMessage、abort、handleEvent（~:352 分派）、handleTag/processTextDelta（XML 标签驱动气泡组装）、handleStateRecovery。
+- `frontend/src/components/ChatInterface.vue`（3620 行）+ `AgentMessage/`（RootBubble/ProcessCard/ThinkingCard/TodoProgressCard/WalkthroughCard/TitleCard）。
+
+## 一条消息的完整链路
+
+ChatInterface.handleSubmit（~:927）→ useAgentStream.sendMessage（确保 SSE 已连 → POST /chat）→ Controller 异步 200 → handleUserMessage（@Async：存 USER 消息→标题→SkillRouter.activateForTurn→assemble→取流式模型→mark(RUNNING)→runLoop）→ StreamHandler.onNext 逐 token 发 SSE → onComplete 回调检测工具请求（原生 function calling 或 XML 兜底）→ dispatchTool→ToolRegistry.execute→副作用（file_change/refresh_files）→ 结果追加 messages → **递归 runLoop(depth+1)** → 无工具时收尾：artifact 解析（implementation_plan 停机待审批/task_list 继续）→ 存 ASSISTANT → MemoryPipeline 异步 → mark(FINISHED) → bubble_end → 关 SSE。
+
+## SSE 事件名清单
+
+connected / bubble_start / text_delta / artifact / token_usage / bubble_end（status: finished|paused|awaiting_approval）/ error / cancelled / file_change / client_action / title_update / doc_stream_data（旧名 wps_stream_data 双轨待摘）/ state_recovery（断线重连快照）/ run_state / plan_update / background_task_start|complete / task_progress / heartbeat / subtask_progress。前端分派均在 useAgentStream.handleEvent。超限 paused 契约见 PR#172。
+
+## ChatInterface.vue 内部地图
+
+template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更 :767-817、PPT 配置 :818-862、回滚 :864-920、**提交主链路 handleSubmit :921-1056**、历史加载 :1057-1226、富文本输入/粘贴 :1227-1387、文件上下文 :1388-1450、上传对话框 :1451-1726、上传实现 :1727-1879）；style :1881-3620。
+
+## 配置
+
+`backend/src/main/resources/application.yml` :84 起 `ai:` 段（model.provider 默认 open-router、ai.context.*、ai.subagent.*、ai.skills.*）；生产覆盖 application-prod.yml、桌面 application-desktop.yml。
+
+## 已知地雷
+
+- **改 AgentOrchestrator 构造器必须同步 EvalHarness**（已踩两次）。
+- 新增工具不要改编排器（Phase 1 五条不变式）：实现 AgentToolComponent + @Tool + @ToolMeta 即自动注册；显示名要同步 toolDisplayNames.js。
+- SubAgentTools 注入必须 @Lazy（启动死环）。
+- 30 秒覆盖启发式曾致历史丢回复，现为轮次级 upsert（PR#153）——改历史持久化先读该记录。
+- 防走神注入/todo_write 进度卡/文档检查点机制见 PR#161/162。
+- RunGuard 阈值改动影响回放评测断言。
+
+## 验证
+
+- `cd backend && mvn test`（JDK 21！默认 25 SIGBUS）——含回放评测 OrchestratorReplayEvalTest（用例 `backend/src/test/resources/ai-eval/cases/cases-*.json`，10 组）+ DesktopContextSmokeTest。
+- 只跑回放：`mvn test -Dtest=OrchestratorReplayEvalTest`；真实 LLM 冒烟：`OPENROUTER_API_KEY=… mvn test -Dtest=RealLlmSmokeTest`。
+- 前端：`npm run check:emits`；UI 链路 `npm run test:app-e2e`。

--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -1,0 +1,71 @@
+---
+name: ai-doc-bridge
+description: AI↔文档编辑桥接领域。任务涉及 doc_* 编辑原语、EditorBridgeService、editor_command 契约、修订（redline）、文档检查点、EDITOR_ACTIONS/ui_command 白名单时，先读本文档再动代码。
+---
+
+# AI↔文档编辑桥接 领域地图
+
+职责边界：AI 侧发出编辑指令 → 编辑器执行 的整条链路。不含编辑器内核本身（那是 doc-editor 领域），不含对话编排（ai-chat 领域）。
+
+## 关键文件
+
+**后端工具原语**
+- `backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java` — doc_* 工具原语全集（38 个 @Tool 方法），翻译成 `editorBridgeService.executeEditorCommand(action, params)`。曾名 WpsTools。
+- `backend/src/main/java/com/checkba/service/ai/tools/CheckpointTools.java` — `doc_restore_checkpoint`。
+- `backend/src/main/java/com/checkba/service/ai/tools/ToolMeta.java` — `@ToolMeta(displayName/category/fileEffect)`；`fileEffect="MODIFIED"` 是检查点触发依据。
+
+**桥接服务**
+- `backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java` — 核心桥接：生成 requestId、经 SSE `client_action` 下发、CompletableFuture 阻塞等前端结果（超时 30s）。曾名 WpsActionService。
+- `backend/src/main/java/com/checkba/controller/ai/EditorResultController.java` — `POST /editor-result`（旧别名 `/wps-result`）回调解锁 Future。
+- `backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java` — dispatchTool 在首个 MODIFIED 工具前建检查点（~:168）；doc_open_file 后切 activeFileId（~:179）；流式 token 双发 doc_stream_data/wps_stream_data（~:371-376）。
+- `backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java` — 流式写入编辑器的过滤逻辑（~:69 起）。
+- `backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java` — run 级快照 `ensureCheckpoint/restore/clearForNewRun`，存 `checkpoints/{conversationId}/{fileId}_{ts}`，恢复后 sendReloadFileAction。
+
+**前端桥接消费**
+- `frontend/src/composables/useEditorBridge.js` — 编辑器无关的分发接缝（薄封装），执行器可插拔。
+- `frontend/src/composables/libreofficeExecutorClient.js` — **EDITOR_ACTIONS 白名单定义处**（:15-67）+ reqId 关联的 worker port 客户端；白名单外 action 直接拒绝。
+- `frontend/src/composables/useAgentStream.js` — SSE 消费：`client_action`（~:447）；doc_stream_data/wps_stream_data 双轨去重（~:467-488）。
+- `frontend/src/pages/project-overview/project-overview.vue` — 命令路由中枢：`handleClientAction`（~:5546，双轨去重 latch `_editorContractV2`）→ `handleEditorCommand`（~:5819，打 `__agent:true` 标记后调 executor）。
+- `frontend/src/zetaoffice/public/office_thread.js` — worker 端所有 action 的真实 UNO 实现 + UI_COMMANDS 白名单（:321-332）+ 修订机制。
+- `frontend/src/utils/toolDisplayNames.js` — 工具名→中文显示名映射表（NAMES 表 :8-97）。**新增工具必须同步加中文名**。
+
+**修订机制（redline）**
+- `office_thread.js` 内：`minimalEdits()`（~:212-266，公共前后缀裁剪+有界 LCS 的字符级最小编辑）与 `applyMinimalRedline()`（~:270-307，从右到左应用，只对差异段打修订）；`setRedlineAuthor`（~:1467）：`__agent` → 署名 "AI Workdeck"，否则用户名。
+
+## 核心数据流（以 doc_find_replace 为例）
+
+1. `DocumentEditTools.doc_find_replace` 校验参数 → `executeEditorCommand("find_replace", …)`。
+2. 编排器在此前已因 `fileEffect="MODIFIED"` 对 activeFileId 建检查点（幂等，一轮一次）。
+3. EditorBridgeService 生成 requestId、Future 入 pendingRequests，经 SSE client_action **双轨各发一份**（先 `tool=editor_command` 后 `tool=wps_command`），然后阻塞 30s。
+4. 前端 useAgentStream → project-overview.vue `handleClientAction`（latch 去重）→ `handleEditorCommand` 附 `__agent:true` → executor。
+5. executor 校验 EDITOR_ACTIONS → worker postMessage → office_thread.js 执行（RecordChanges=true → 逐处 applyMinimalRedline，失败回退 setString）。
+6. 结果按 reqId 回流 → `POST /api/ai/agent/editor-result` → completeEditorAction 解锁 Future → 工具返回给模型。
+
+## doc_* 原语速查（工具名 ≠ 下发 action 名）
+
+全集见 DocumentEditTools.java。易混对照：`doc_find_text`→`find_text_locations`、`doc_select_anchor`→`set_selection`、`doc_replace_at_anchor`→`replace_at_position`、`doc_collapse_cursor`→`collapse_selection`、`doc_start_stream`→`doc_open_file_sync`+setStreamingMode。批注 `doc_add_comment`→`add_comment`。
+
+EDITOR_ACTIONS 全集在 `libreofficeExecutorClient.js:15-67`（含宿主自发的 load_document/export_document/insert_image/var_*/*_hyperlink 与诊断类 get_ui_lang/probe_modules/list_fonts/debug_revisions）。`ui_command` 是其中一个 action，worker 端再经 UI_COMMANDS 二级白名单映射 `.uno:` 槽（IME 快捷键用，非 AI 管线）。
+
+## 命名双轨现状（PR#192，下个发布周期摘旧名）
+
+仍活着的 wps_* 旧名：后端 `sendDualNamedAction`（doc_open_file/wps_open_file、doc_reload_file/wps_reload_file）、executeEditorCommand 双发 editor_command/wps_command、doc_open_file_sync↔wps_open_file_sync、doc_stream_data/wps_stream_data 双发、`/wps-result` 路由别名；前端 handleClientAction 显式识别全部旧名+latch 去重、toolDisplayNames 把 wps_* 归一为 doc_*。
+**`wpsFileId` 不属于命令双轨**——是持久化字段名（ProjectFile 实体），贯穿前后端，无改名计划，别动。
+
+## 已知地雷
+
+- **新增 doc_* 工具四件套**：DocumentEditTools 加 @Tool + EDITOR_ACTIONS 白名单加 action + office_thread.js 加实现 + toolDisplayNames.js 加中文名。漏任何一环都是静默失败（PR#180 教训）。
+- **区间批注必须走 `.uno:InsertAnnotation` 派发**；LO API 路线（addAnnotation）会抛虚假异常且只批注锚点（PR#191）。
+- **replace_selection 仅在 RecordChanges 开启时启用最小修订路径**；修订应用必须从右到左，否则前面的编辑使后面的偏移失效（PR#188）。
+- **office 线程会被 export 冻结**：长 export 期间同步命令假死是已知模式，autoSave 需让路（PR#182）。
+- **工具位置参数按签名映射为命名参数**（PR#193），改工具签名要考虑旧会话回放。
+- **删除修订跨 reset 会残留**，相关测试口径见 PR#188 记录。
+- 修订模式下手工删除卡死曾因覆盖层吞键，用 `.uno:` 调度修复（PR#164/166），别退回 DOM 键盘事件路线。
+- 改 AgentOrchestrator 构造器必须同步 EvalHarness（踩过两次）。
+
+## 验证
+
+- 编辑器三件套（原语/白名单/worker）改动后必跑：`cd frontend && npm run test:lowa-e2e`（基线 38 步）。
+- 全链路回归：`npm run test:app-e2e`；前端事件契约 `npm run check:emits`。
+- 后端：`cd backend && mvn test`（JDK 21，默认 25 会 SIGBUS）；EvalHarness 回放评测在其中。
+- 原语级测试不够，必须走完 UI 链路验证（用户明确要求过）。

--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -1,0 +1,65 @@
+---
+name: doc-editor
+description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffice WASM 引擎、编辑器启动/boot、字体/IME、保活池与 LRU、自动保存、.uno: 命令、zetajs 编组时，先读本文档再动代码。
+---
+
+# 文档编辑器（LOWA）领域地图
+
+职责边界：编辑器内核与宿主集成。AI 发编辑指令的链路属 ai-doc-bridge 领域。引擎 = LibreOffice 24.2.8 自建 zh-CN 版（LO core 分支 distro/allotropia/zeta-24-2）。
+
+## 关键文件
+
+**引擎构建与分发**
+- `desktop/lowa-build/`：README.md（为什么自建 zh-CN）、RECIPE.md（精确配方+产物 sha256）、mega-build.sh（裸机全自动构建，PHASE_1..7）、autogen.input、patches/（两阶段 zh-CN 焙入 + ZZZ-aiworkdeck-locale-zh-CN.xcd 默认 ooLocale）。
+- `desktop/scripts/fetch-lowa-assets.js` — 构建期下载 LOWA 运行时 + OFL CJK 字体到 `frontend/dist/zetaoffice/lowa/`，写 `.encodings.json`（brotli 侧车）；`LOWA_BASE_URL` 指自托管引擎（`https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r2/`）。
+- `desktop/scripts/lowa-selfhost.md` — 自托管流程文档。
+
+**桌面壳服务**
+- `desktop/main/zetaoffice-server.js` — 同源本地 HTTP 服务（editor.html + /lowa/* 本地优先、CDN 兜底）；memoized `startEditorServer()`。
+- `desktop/main/zetaoffice-session.js` — persist:zetaoffice 分区注入 COOP/COEP/CORP（webview 跨源隔离，SharedArrayBuffer 可用，不污染主窗口）。
+- `desktop/main/zetaoffice-verify.js` — ⌘⇧L 验证窗口（?verify=1，零副作用验证引擎/中文/AI 命令）。
+- IPC：`checkba:zetaoffice-editor`（main.js ~:1373，返回 {url, preload, partition}）；`desktop/preload/zetaoffice-webview-preload.js` 暴露 `window.zetaHostBridge`（通道 lo-relay）。
+
+**前端 boot 与桥**
+- `frontend/src/zetaoffice/editor.html` + `editor-main.js` — webview 页面入口：选传输、startEditorEndpoint、IME 覆盖层、modified 节流（1/500ms）、boot-log 里程碑。
+- `frontend/src/zetaoffice/public/`：zeta.js（vendored zetajs）、**office_thread.js（worker 内全部 UNO 操作实现，本领域最核心文件）**。
+- composables：`zetaOfficeBoot.js`（emscripten Module、注入 CJK 字体+fontconfig 别名 conf、locale shim、resolve office-worker port）、`zetaOfficeEditorEndpoint.js`（boot+executor+serve 三件套）、`zetaOfficeRelay.js`（跨隔离命令中继：serveExecutor/createRelayExecutor/portTransport）、`libreofficeExecutorClient.js`（EDITOR_ACTIONS 白名单+请求应答）、`useLibreOfficeBridge.js`、`useZetaOfficeWebview.js`（webview 包成 executeCommand 契约）、`zetaOfficeImeOverlay.js`（canvas 透明 IME 层，中文输入+控制键转发）。
+- `frontend/vite.zetaoffice.config.js` — editor 页专用 Vite 构建（脱离 uni-app），产出 dist/zetaoffice/。
+
+**宿主 UI（保活/实例管理/自动保存）**
+- `frontend/src/components/LibreOfficeEditor.vue` — 单文档编辑器组件：webview 创建、prefetch、load/export、autoSave、flushSave。
+- `frontend/src/pages/project-overview/project-overview.vue` — 保活池宿主：leftLibreFiles/rightLibreFiles（v-show 常驻，~:1661）、libreLruKeys/touchLibreLru/evictLibreInstance（~:5886-5906）、syncLibreExecutor 活跃指针（~:5871）、`_libreRefs`/`_libreExecMap` 非响应式注册表；`LIBRE_KEEPALIVE_MAX = 3`（~:1286）。
+
+## 启动链路（打开 docx → 可编辑）
+
+激活文档 → 渲染 LibreOfficeEditor → getEditor() IPC（装隔离+起服务）→ 建 webview（persist:zetaoffice）+ 并行 prefetch 文档字节 → editor.html/editor-main.js 选传输 → bootZetaOffice（校验 crossOriginIsolated、fetch CJK 字体、fontconfig conf、加载 soffice.js、uno_main resolve worker port）→ office_thread.js boot（Desktop.create → 空白 swriter、RecordChanges=true、installModifyListener → ui_ready）→ executor 握手 ready → loadDocument：`load_document {bytes}` 写 MEMFS + loadComponentFromURL 重定位 xModel → ready → onLibreReady 注册 executor + syncLibreExecutor。
+
+## zetajs 编组硬规则（office_thread.js，PR#107）
+
+- UNO 服务构造器首参必须是 component context（Desktop.create(context) 等）；结构体用值对象 `new css.beans.PropertyValue({Name,Value})`。
+- dispatch 的 args sequence 必须是**纯 Array**（不能 typed array）。
+- sequence<byte> 有符号且只收 Array：load_document 字节要 `Array.from(new Int8Array(...))`；省略 `_default` 目标帧会让 zetajs 把字节序列当 context。
+- export 走 XOutputStream.writeBytes 取回（Int8Array 视图）；**不能** storeToURL 到 MEMFS 再 FS.readFile（pthread 代理 ENOENT）。
+- worker 内 `Module.zetajs` 才是 UNO 桥；主线程 resolve 的是 thread port。
+
+## 自动保存（LibreOfficeEditor.vue）
+
+触发链：worker modified → 节流 → onDocModified 置 dirty → scheduleAutoSave（延迟 max(200, min(2500, 15000-脏龄))）→ autoSave：**命令在飞（_cmdBusy>0）或距上次命令<1.5s 且脏龄<60s 时让路 2s 重试**（防 export 冻结 Qt 事件循环，PR#182）→ saveDocument → export_document → 整文件 multipart POST /api/files/{id}/upload。失败保持 dirty、15s 慢速重试。flushSave 在 tab 关闭（~:5051）与 LRU 淘汰前 await。
+
+守卫（防空文档覆盖，PR#194）：`docLoadFailed` 闸——load 失败或"元数据非空却下载 0 字节"（fileSize>0 而 bytes 空）时置位，此后 onDocModified 与 saveDocument 一律拒绝；fileSize==0 才当新建空白。**该编辑器存/取走整文件 XHR，不含分片上传**。
+
+## 已知地雷
+
+- boot 三地雷勿回退（canvas 必须 id=qtcanvas 且禁 border/padding；COOP/COEP 缺失 SharedArrayBuffer 不可用；locale shim）。
+- 引擎仅 Writer+Calc 实锤（PR#165），别承诺 Impress。
+- CJK 字体走类别映射别名（PR#157/158），**不能用 assign 硬替换**；tofu 排查用 list_fonts 诊断 action。
+- 删除键/快捷键必须走 `.uno:` 调度（覆盖层吞键+修订模式手工删卡死教训，PR#164/166）。
+- `npm run build:zetaoffice` 会清空 dist 并删掉已 fetch 的引擎——本地反复跑 e2e 用 `LOWA_ENGINE_DIR` 规避，或从兄弟 worktree 复制引擎（CDN 挂时的配方）。
+- 修订作者：params 带 `__agent:true` → 署名 "AI Workdeck"。
+- webview/uni 存储格式坑与宿主侧 e2e 配方见 lowa-keepalive 记录（PR#159）。
+
+## 验证
+
+- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，12 组人机模拟，基线 38 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
+- 涉桌面壳/webview：`npm run test:desktop-e2e`（弹 dev Electron 窗口，验证保存落盘链路）。
+- 全应用：`npm run test:app-e2e`。改编辑器三件套（原语/白名单/worker）必跑 lowa-e2e。

--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -1,0 +1,73 @@
+---
+name: eng-infra
+description: 工程基建领域。任务涉及构建、发版、CI workflow、签名公证、测试体系（lowa-e2e/app-e2e/desktop-e2e/mvn test）、本地开发启动、Docker 附属服务时，先读本文档再动代码。
+---
+
+# 工程基建 领域地图
+
+职责边界：构建/发版/CI/测试/本地开发。各领域自己的业务测试内容见对应领域文档。
+
+## CI（.github/workflows/）
+
+- **ci.yml**（push master + 所有 PR）：三并行 job——backend（temurin **21**，`mvn -B test`）、frontend（node 20，`npm run check:emits` + `build:h5`）、desktop（仅 `npm ci`）。不打安装包。
+- **desktop-build.yml**（发版主 workflow）：触发 = workflow_dispatch / tag `v*` / PR 改动 desktop|backend|frontend 路径。矩阵：tag 或手动 = mac+win；**普通 PR 只跑 windows**（mac runner 1h+）。每平台步骤顺序（**不可乱**，PR#176）：build:h5 → build:zetaoffice → fetch-lowa-assets（LOWA_BASE_URL=自建 zh-CN 引擎 24.2.8-zhcn-r2）→ desktop npm test → mvn package(-Djavacpp.platform) + prepare-backend(jar+jlink JRE) → 三 Python 服务 prepare-python-service → **(mac)sign-mac-natives.sh → 冒烟（backend /api/admin/wizard 120s、pptx alembic+/health、mineru /docs、kokoro /health+voices 验 zf_001）→ pack-pysvc** → electron-builder（mac 签名+公证，先抬 maxfiles/ulimit 524288 防 EMFILE；win 未签名 issue #12）→ 失败时 notarytool history/log 打印 Apple 拒因 → upload-artifact → tag 时 softprops/action-gh-release 附 dmg/exe + 双语 body。
+- **star-history.yml**（周一 cron）：重画 star SVG 强推 star-history 分支。
+
+## 发版链路
+
+1. 版本号**单一来源 `desktop/package.json` version**（backend jar 固定 0.0.1-SNAPSHOT 归一化为 backend.jar；frontend version 不参与）。
+2. `git tag v<ver> && git push origin v<ver>` → 触发 desktop-build 双平台。auto 模式下 tag 推送不被分支保护拦；可用 Monitor 等 PR 合并后自动打 tag（v0.8.0 配方）。
+3. 产物：mac 仅 dmg（**arm64 only**，已放弃 Intel）；win 仅 nsis exe（x64）。electron-builder 配置在 desktop/package.json "build" 字段（appId com.aiworkdeck.desktop、extraResources 打入 frontend/dist、backend.jar、jre、python、pysvc.tar.gz+meta；notarize teamId X9B97KVA84；entitlements desktop/build/entitlements.mac.plist）。
+4. 签名抖动：Apple 时间戳抖动 = rerun 即可（连挂两次也 rerun）；公证轮询抖动排查见 ci-macos 记录。
+
+## 测试命令总表
+
+| 命令 | 目录 | 覆盖 |
+|---|---|---|
+| `mvn -B test` | backend/ | 51 个 *Test.java：IDOR/鉴权/分片上传/编排/记忆/证据/市场/脱敏 + **回放评测 OrchestratorReplayEvalTest**（resources/ai-eval/cases/ 10 组）+ DesktopContextSmokeTest。**必须 JDK 21**（本机默认 25 SIGBUS） |
+| `OPENROUTER_API_KEY=… mvn test -Dtest=RealLlmSmokeTest` | backend/ | 真实 LLM 冒烟（默认跳过） |
+| `npm test` | desktop/ | service-manager / model-manager / pysvc-runtime |
+| `npm run check:emits` | frontend/ | @event 绑定 vs $emit 声明静态护栏（scripts/check-emit-bindings.mjs） |
+| `npm run test:lowa-e2e` | frontend/ | LOWA 真引擎+键盘链路（tests/lowa-e2e/run.mjs，puppeteer-core 无头，基线 38 步） |
+| `npm run test:app-e2e` | frontend/ | 全应用真人模拟（tests/app-e2e/run.mjs；自注册 qa_bot_* 账号；需 dev:h5 **5174** + 后端 9696）。**发版前必跑** |
+| `npm run test:desktop-e2e` | frontend/ | 桌面保存链路（弹 dev Electron 窗口，webview 真 LOWA 插文本→保存→API 下载验内容） |
+
+每日全量 QA：`scripts/qa-nightly.sh`（crontab，跑在 ~/aiworkdeck-qa/repo 专用克隆，报告 ~/aiworkdeck-qa/reports/，失败 gh 开 issue 标签 qa-nightly，引擎取自已安装 app）。
+
+## 本地开发启动
+
+- 一键：`./restart-all.sh`（Docker 服务 + 后端 + 前端 + 桌面）。
+- 后端：`cd backend && ./restart-backend.sh`（mvn package -DskipTests → kill 9696 → nohup java -jar，prod 配置，日志 backend/app.log）。
+- 前端：`cd frontend && npm run dev:h5`（5173；e2e 用 `npx uni --port 5174`）。**npm 不是 pnpm**。
+- 桌面：`cd desktop && npm run dev`（AIWORKDECK_DESKTOP_DEV=1 electron .；dev Electron 复用已跑的 9696 后端不另起 java）。`npm run clean` 清用户数据目录。
+- Docker 附属：`docker compose up`（mineru 8001、pptx 5001、easyvoice 9549 段已停用改 ElevenLabs）。
+
+## 关键构建脚本（desktop/scripts/）
+
+- `prepare-backend.js` — fat jar→backend.jar + jlink 裁剪 JRE 到 bundled/<plat>/。
+- `prepare-python-service.js` — python-build-standalone 3.11.12 + pip site-packages + 服务源码；mineru 纯 pip 无源码。
+- `pack-pysvc.js` — 上万小文件→单 pysvc.tar.gz + meta（首启解压进度条；解压逻辑在 desktop/main/services/pysvc-runtime.js）。**必须在签名与冒烟之后跑**。
+- `fetch-lowa-assets.js` — LOWA 运行时+CJK 字体进 frontend/dist/zetaoffice/，保留 brotli + .encodings.json 侧车。
+- `sign-mac-natives.sh` — 签 electron-builder 够不到的 Mach-O（JRE + jar 内嵌 dylib），时间戳退避重试，nested jar 用 zip -0 回写。
+- `desktop/lowa-build/mega-build.sh` — 从源码重建 zh-CN LOWA（Ubuntu 22.04，无人值守）。
+
+## 部署与其它
+
+- `deploy/web/` — Web 服务器版（瘦客户端 Phase A2/鸿蒙路线）：nginx.conf.example、能力探针 probe/、后端 prod 只听 127.0.0.1。
+- 官网部署在独立仓库（website/，gitignore 掉），服务器 ssh -i ~/.ssh/aiworkdeck_ops root@47.92.111.102；ECS 8.137.95.63(~/.ssh/checkba_ecs)。
+- 模型不进包：mineru/kokoro 模型首启在"组件管理"下载（下载进度按字节级整体，PR#142）。
+
+## 已知地雷
+
+- CI 签名→冒烟→打包顺序不可乱（PR#176）。
+- macOS CI 红要当真查（Apple 协议过期事件后恢复）；`--admin` 合并与 worktree 删分支技巧见 ci-macos 记录。
+- iCloud 驱逐会掏空本地文件（打包/测试环境两次踩）；EMFILE 用抬 ulimit 解。
+- worktree 冷启动跑双 e2e 完整配方见 v0.7.7 发版实录；worktree merge 报 stash failed 用 cherry-pick 绕。
+- 坏 pnpm node_modules 遇到过——本项目一律 npm。
+- 分支保护拦 gh pr merge 时权宜 = 用户网页点 Bypass rules and merge（白名单未配成）。
+- `docs/` 在 .gitignore，入库要 `git add -f`。
+
+## 验证（改本领域自身时）
+
+- 改 workflow：推 PR 触发 windows 矩阵先验；mac 变更合并后用手动 workflow_dispatch 验证。
+- 改构建脚本：本地跑对应脚本 + desktop `npm test`（pysvc-runtime 有覆盖）。

--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -1,0 +1,54 @@
+---
+name: plugin-marketplace
+description: 插件市场领域。任务涉及插件广场页、在线 Skill 广场 registry 同步、skill 安装/卸载/启停 API、与官网仓库的市场契约时，先读本文档再动代码。
+---
+
+# 插件市场（Marketplace）领域地图
+
+职责边界：插件广场页面、在线广场 registry 同步与安装。skill 的解析/注入机制属 plugin-system 领域；官网仓库（website/）不在本仓库。
+
+## 关键文件
+
+**前端**
+- `frontend/src/pages/plugin-market/plugin-market.vue` — 插件广场单页，三个区块：插件（:23-78）、Skill（:80-119）、在线广场（:121-165）。脚本区 :171-333（loadPlugins/onToggle 失败回滚/loadMarket/installSkill/uninstallSkill/rescan）。
+- `frontend/src/services/api.js` :407-485 — plugins、skills、skills/market 三组 HTTP 封装。
+- 入口：`frontend/src/pages/admin/admin.vue` :584 系统管理侧边栏项 `{key:'plugins', label:'插件广场', route:'/pages/plugin-market/plugin-market'}`。**leftSidebarPlugins.js 不含市场入口**（那是 IDE 左栏业务插件位）。
+
+**后端**
+- `backend/src/main/java/com/checkba/controller/ai/SkillController.java` — /api/skills：list、{id}/enable|disable、rescan、market/list|install|uninstall。
+- `backend/src/main/java/com/checkba/controller/ai/PluginController.java` — /api/plugins：list、启停、rescan。
+- `backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java` — 在线广场客户端（**市场契约的权威定义在此类 Javadoc**，SKILL_SPEC.md §8 未含 market 端点）。
+- `backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java` — 本地扫描/启停/rescan。
+- `backend/src/main/java/com/checkba/service/ai/skill/SkillProperties.java` — ai.skills.*（dir/base-tools/registry-url/ttl）；registry-url 默认 `https://www.aiworkdeck.com/api/registry/skills`（application.yml ~:163）。
+
+## 官网 registry 契约
+
+- **列表**：`GET {registryUrl}` → skill 元数据 JSON 数组，字段对应 MarketSkillView：id/name/description/icon/version/author/authorDisplayName/triggers[]/allowedTools[]/downloads/updatedAt/homepage（`installed` 由本地判定）。
+- **下载**：`GET {registryUrl}/{id}/bundle` → `{id, version, files:{"skill.yml":"…","prompt.md":"…"}}`；只认白名单键 skill.yml/prompt.md（BUNDLE_FILES），值必须字符串，缺任一安装失败。
+- HTTP：hutool，连接 5s/读 10s 超时；非 200 抛 IllegalStateException；`httpGet` 是可覆写测试 seam。
+
+## 安装/卸载链路
+
+- 安装：前端 POST /api/skills/market/install {id} → admin 校验 → `requireValidId`（正则 `^[a-z0-9][a-z0-9-]{1,49}$`，兼防路径穿越）→ 下载 bundle → 写 `{ai.skills.dir}/{id}/` 两文件 → `rescan()`。**重装即覆盖更新**。
+- 卸载：来自插件的 skill 拒绝卸载（走插件管理）；canonical 路径校验防符号链接逃逸，只删 skills 正下方子目录。
+- **安装目标目录 == 内置 skill 扫描目录**（默认 `backend/skills/`），在线安装的与内置的（listing-pathway）并列共存、同一套扫描/启停。
+- 注册表离线只影响"在线广场"区块（marketError 区块内提示，不 500），本地插件/skill 不受影响。
+
+## 数据模型
+
+**插件与 skill 不入库，文件系统为准**。数据库唯一相关表 `system_setting`（config_key/value）：`ai.skills.disabled`、`ai.plugins.disabled` 各存禁用 id 的 JSON 数组，内存缓存 TTL 5s，默认全启用。
+
+## 鉴权
+
+写操作（启停/rescan/install/uninstall）需管理员：`X-Session-Id` 头 → userId → AdminAccessService.isAdmin（桌面单机=全员管理员）；list 类登录即可。
+
+## 已知地雷
+
+- 官网侧 Skill 广场在独立仓库（website/，不在本仓库），改契约要两边同步（参考 skill-marketplace 双仓 PR 惯例）；官网提交表单曾因 invalid_id 挡掉投稿，id 校验规则两侧必须一致。
+- 桌面端 9696 是真实后端端口，测试市场功能别 mock 错对象。
+- bundle files 白名单意味着官网新增文件类型（如图标文件）需要同时改 BUNDLE_FILES 和官网打包端。
+
+## 验证
+
+- 后端：`cd backend && mvn test`（JDK 21；SkillMarketService 有测试 seam）。
+- 页面：dev 起后端(9696)+前端(5173) 从 admin 页进插件广场手测；或 `npm run test:app-e2e`。

--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -1,0 +1,69 @@
+---
+name: plugin-system
+description: 插件系统领域（具体插件实现）。任务涉及尽调/脱敏/股东大会等业务插件、skill 定义与注入、PluginService/SkillRegistry/SkillRouter、动态 JAR 插件时，先读本文档再动代码。
+---
+
+# 插件系统 领域地图
+
+职责边界：各具体业务插件与插件/skill 运行机制。不含插件市场页与 registry 同步（plugin-marketplace 领域），不含左栏 UI 本身（sidebar-shell 领域）。
+
+## 三类插件形态
+
+1. **内置面板型**：前端组件直接内嵌 project-overview.vue 面板区，无启停开关，靠 `leftSidebarPlugins.js` 静态配置 + 角色过滤（`getPluginsForUser`，CLIENT 角色只见 dd-files）。
+2. **Skill 型**：后端 prompt 包（skill.yml + prompt.md），对话关键词触发。
+3. **动态 JAR 插件**：plugins/ 目录下 manifest.json + JAR，前端用 PluginPane iframe 承载。
+
+## 现有插件清单
+
+**尽调（DD）**：前端 `frontend/src/components/DdFilesPanel.vue` + `DdRequestEditor.vue`；后端 `controller/DdController.java`（/api/dd）+ `service/DdService.java`；实体 DdRequest/DdItem/DdComment + 对应 Repository。无 skill。
+
+**脱敏**：前端 `frontend/src/components/DesensitizePane.vue`；后端 `controller/SensitiveController.java`（/api/sensitive：GET /options、POST /desensitize）+ `service/SensitiveService.java`（PDFBox PDFTextStripper 定位涂黑）+ OcrService 辅助。无 skill。
+
+**股东大会**：目前**只是侧栏占位入口**（leftSidebarPlugins.js 里 key `shareholder-meeting`），project-overview.vue 面板区无对应分支，点击落入"加载中..."占位符。前端组件/后端服务/skill 三层均未实现。
+
+**上市路径选择（Skill 型）**：`backend/skills/listing-pathway/`（skill.yml + prompt.md），仓库内唯一内置 skill。无独立面板，对话触发。
+
+**动态 JAR**：前端 `frontend/src/components/PluginPane.vue`（纯 iframe 壳：props url/pluginId，url 空则报"未配置入口地址"；加载哪个插件由父页面按 leftPaneKey + dynamicPlugins[].frontendEntry 决定）；后端 `service/ai/PluginService.java` + `controller/ai/PluginController.java`（/api/plugins）。
+
+## 注册与加载链路
+
+1. 静态注册：`frontend/src/config/leftSidebarPlugins.js` 导出 LEFT_SIDEBAR_PLUGINS + `getPluginsForUser(role)`。
+2. project-overview.vue 计算属性（~:1581）合并静态列表与 dynamicPlugins。
+3. 动态插件：`loadDynamicPlugins()`（~:6261）调 `GET /api/plugins/list`，映射成 `{key:'plugin-<id>', label, icon, isDynamic, frontendEntry}`。
+4. 面板分发（~:531-563）按 leftPaneKey：dd-files→DdFilesPanel、desensitize→DesensitizePane、easyvoice→EasyVoicePane、search→SearchPanel、files→文件树、动态→PluginPane、其余→占位符。
+5. 后端 PluginService：@PostConstruct 扫 `plugins/`（可配 `ai.plugins.dir`），读 manifest.json → PluginMetadata；有 backendJars 时独立 URLClassLoader 加载，扫 langchain4j @Tool 类注册进 ToolRegistry。`POST /api/plugins/rescan` 热重扫。
+
+## skill 文件格式（docs/SKILL_SPEC.md、docs/PLUGIN_SPEC.md）
+
+目录式：`skills/<id>/skill.yml + prompt.md`。skill.yml 字段：`id`（必需，kebab-case，启停键）、`name`、`description`、`triggers`（必需，关键词数组，用户输入"包含"即命中）、`prompt`（默认 prompt.md）、`allowed_tools`（须为 ToolRegistry 真实工具名）、`output`、`requires`（如 evidence.retrieve.v1，v1 仅声明）。未知字段忽略；解析失败跳过不阻断。
+
+插件携带 skill：manifest.json `skills` 字段列子目录名，PluginService 只收集目录（`getPluginSkillDirs()`），解析/启停归 SkillRegistry，记 sourcePluginId。
+
+manifest.json 要点：id（必需）/name/version/icon/author/permissions（file_read/file_write/network/editor）/tools[]/frontendEntry/backendJars[]/skills[]。
+
+## skill 注入对话链路（backend/src/main/java/com/checkba/service/ai/skill/）
+
+- `SkillRegistry.java` — 发现/加载：扫内置 skills/ 目录 + 插件携带目录，SnakeYAML 解析，id 去重（先扫到优先）；`isAvailable` = 自身启用 且 所属插件未禁用。
+- `SkillRouter.java` — `match(userInput)` 取最长命中关键词；`activateForTurn` 每条用户消息刷新命中态；`visibleTools` 命中时裁剪为 allowed_tools ∪ baseTools（白名单零命中则不裁剪）；`promptInjectionFor` 拼 prompt 注入。
+- 编排接入（纯旁路两处）：`AgentOrchestrator.java` activateForTurn（~:255）+ visibleTools（~:709）；`ContextAssemblerService.java` match→promptInjectionFor（~:146）。ASK 模式跳过注入。
+- 配置：`SkillProperties.java`（ai.skills.dir / base-tools / disabled-cache-ttl-ms / registry-url）。
+
+## 启停存储与过滤
+
+- 存 `system_setting` 表（key/value 键值），值为禁用 id 的 JSON 数组，默认全启用，内存缓存 TTL 5s：插件 `ai.plugins.disabled`（PluginService），skill `ai.skills.disabled`（SkillRegistry）。
+- **插件工具的过滤在 ToolRegistry 而非 PluginService**（Phase 3A）：getAllSpecifications / toolNamesLongestFirst / resolve 三处消费点全部隐藏禁用插件的工具；分发前还有 `missingPermissionsForTool` 权限校验。
+- skill 过滤在 SkillRouter.match 的 isAvailable 检查。
+
+## 已知地雷
+
+- 新增面板型插件三步缺一不可：leftSidebarPlugins.js 注册 + project-overview.vue 面板区加 v-else-if 分支 + 组件本身；漏第二步就是"股东大会式"占位符。
+- skill 的 allowed_tools 写错工具名不会报错，只是白名单零命中回退不裁剪——排查工具可见性问题时先核对 ToolRegistry 真名。
+- 插件启停语义只影响可见性，不拦截历史工具调用回放。
+- 改 AgentOrchestrator 构造器（如注入新服务）必须同步 EvalHarness（踩过两次）。
+- SubAgentTools 曾因循环依赖断启动，用 @Lazy 解决（PR#98），插件/工具类注入编排器时注意。
+
+## 验证
+
+- 后端：`cd backend && mvn test`（JDK 21）。
+- skill 触发链路：起后端后对话输入触发词验证注入；skill 管理 API `/api/skills/list|{id}/enable|{id}/disable|rescan`（admin）。
+- 前端面板：`cd frontend && npm run test:app-e2e` 覆盖主要旅程。

--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -1,0 +1,69 @@
+---
+name: sidebar-shell
+description: 侧边栏与工作台外壳领域。任务涉及左侧 rail/左栏、工作台四列布局、面板切换、页面路由与页面栈、设置入口、project-overview.vue 结构、CSS 体系时，先读本文档再动代码。
+---
+
+# 侧边栏与工作台外壳 领域地图
+
+职责边界：工作台整体布局、左侧 rail 与左栏、面板切换状态机、页面路由。各面板内部逻辑归 utility-tools / plugin-system；右栏聊天内容归 ai-chat；编辑器归 doc-editor。
+
+## project-overview.vue 内部地图（10638 行，主战场）
+
+三大块：template :1-1213 / script :1215-6729 / style(scss scoped) :6731-10638。
+布局是四列：常驻 rail（Activity Bar）→ 可收起左栏 sidebar-left → 中间 workbench（含底部工具抽屉）→ 右侧 AI 面板。
+
+**template**
+- :3-168 project-header 顶部条；:47-165 header-tools（开关：左栏:48、底栏:64、右栏:80、分屏:96、截图OCR:112、浏览器:127、活动记录:142、客户视图:159）。
+- :172-295 left-rail：插件按钮 v-for LEFT_SIDEBAR_PLUGINS（:175，@tap toggleLeftPane）、暂存区:209、**系统设置齿轮 :224 goToSystemSettings→admin**、成员堆叠:234、用户头像:288。
+- :354-593 sidebar-left：sidebar-header:358（标题=leftPaneTitle）、sidebar-content:515 按 leftPaneKey 分支（files→FileTree:517、dd-files:532、easyvoice:538、desensitize:544、search:551、动态插件→PluginPane:556）、拖拽手柄:594。
+- :595-911 workbench：Tab 栏（左:602 / 右:639 仅 splitMode）、编辑器区:676（左窗格:688、右窗格:762）、bottom-panel:833（v-if showToolsPanel，activeToolKey：variables/favorites/clipboard）。
+- :912-983 ai-panel（v-if showAiPanel，内容整块交 ChatInterface:924，历史下拉:961）。
+- :984-1213 根级弹窗层（AI导出Word/图片预览/截图保存/OCR浮层/文件关联/拖拽蒙层）。
+
+**script**
+- :1216-1290 imports（配置 leftSidebarPlugins/fileActions/tools/workbenchActions）；:1291-1313 components。
+- :1314-1556 data()：布局状态集中 :1335-1372——sidebarWidth(260)/sidebarCollapsed/leftPaneKey(null)/showAiPanel/aiPanelWidth(360)/showToolsPanel/toolsPanelHeight(260)/activeToolKey('variables')/splitMode/stagingPinned/resizing(统一拖拽对象)/lastActiveIdsByMode；dynamicPlugins :1551。
+- :1557-1780 computed：LEFT_SIDEBAR_PLUGINS:1581（合并动态 :1588）、isClientView:1609、leftPaneTitle:1619。
+- 生命周期：beforeUnmount:1781（多实例守卫，只清指向自身的活跃指针）、onLoad:1882、onShow:1932（返回时重新接管全局处理器）、mounted:1988（事件监听登记）。注意有个 beforeDestroy 误嵌在 methods 内（~:5344）。
+- :2261-6729 methods：**toggleLeftPane :2988**、goToSystemSettings:4498、toggleSidebar:4528、toggleAiPanel:4532、toggleToolsPanel:4544、triggerWorkbenchResize:4550、toggleSplitMode:4817、动态插件加载:6266。
+
+## 面板切换状态机
+
+rail 点击 → toggleLeftPane(key)（:2988）：staging 单独分支 → 把当前 activeFile 存 lastActiveIdsByMode[oldKey]（:3005）→ 同 key 则收/展 sidebarCollapsed（:3011），异 key 则设 leftPaneKey 并展开（:3014）→ 动态插件另在中间开 tab（openFile fileType:'plugin'，:3018）→ 恢复该模式记忆的左右 tab（:3029）→ 持久化到 uni.storage（:3055）。
+顶栏三开关都在 $nextTick 调 triggerWorkbenchResize 派发 window resize 让编辑器/iframe 重排；toggleAiPanel 打开时刷新 AI 上下文 + fetchChatHistory。
+
+## 左栏入口（frontend/src/config/leftSidebarPlugins.js，57 行）
+
+固定入口：files(资源管理器→FileTree)、dd-files(尽调文件)、shareholder-meeting(股东大会，**面板区无分支=占位**)、search、easyvoice、desensitize。辅助函数 getLeftSidebarPlugin(key)（找不到回退第一项）、getPluginsForUser(role)（CLIENT 只见尽调文件）。动态插件后端拉取后追加 rail 并用 PluginPane 渲染。rail 齿轮对所有人可见，admin 页/接口后端 requireAdmin（用户名 admin）。
+
+## 页面路由（frontend/src/pages.json，全部 navigationStyle: custom）
+
+login（**启动页**）/ newproject / project-overview / variable-library / userprofile / admin / plugin-market / wizard。
+导航流：login reLaunch→wizard|project-overview|userprofile；overview navigateTo userprofile/admin；admin→plugin-market；newproject reLaunch→overview；退出 reLaunch login。
+
+**页面栈地雷（本领域核心机制）**：navigateTo 反复进入 project-overview 不销毁旧实例——页面栈多实例并存，每个都持有全局监听。守卫模式：活跃实例指针 `window.__checkbaActiveOverviewVm` + isActiveOverviewInstance() 判活跃、去重状态挂 window 不挂实例、只清/接管指向自己的指针（beforeUnmount/onShow/mounted 三处配合）。切换项目用 reLaunch 避免堆叠。**外壳里新增任何全局订阅必须套用此模式**（PR#148/#151）。
+
+## CSS 体系
+
+- 主题变量：`frontend/src/uni.scss`（SCSS 变量非 CSS 自定义属性）：$brand-color-primary #12344D、$brand-color-gold #C8A45D、$brand-bg-warm #F7F5F0，映射 $uni-* 系列。无 :root/--var 令牌。
+- 全局覆盖：`frontend/src/App.vue`（:15-65 只覆盖 uni-modal/uni-toast）。
+- **awd-\* 类名约定**（King IDE 品牌清零后的通用弹窗/按钮样式，PR#171）：awd-dialog/-mask/-header/-title/-body/-footer、awd-btn/-primary/-secondary/-danger、awd-field/awd-input。**没有集中定义**——在 project-overview.vue（~:10180-10300）、ChatInterface.vue（~:2869 起）、FileTree.vue 各自 scoped 重复定义；改样式要多处同步。
+- 外壳布局类：.header-tools:6904、.rail-btn:7009、.sidebar-left:7403/7905、.workbench:7455、.bottom-panel:7283/7510、.compact-mode:7478、.is-resizing:7927。
+
+## 相关文件
+
+- `frontend/src/config/tools.js` — 底部工具面板 tab（WORKBENCH_TOOLS）；`fileActions.js` — 文件树批量操作；`workbenchActions.js` — OCR/内链 scheme 常量。
+- `frontend/src/components/FileTree.vue`（5195 行）— 左栏文件树。
+- 各页面：login.vue(777)、newproject/index.vue(660)、wizard.vue(593，重跑语义见 PR#134)、userprofile.vue(2158)、variable-library.vue(543)、admin.vue(1648，含插件广场入口)、plugin-market.vue(766)。
+
+## 已知地雷
+
+- sed 子串替换改类名会误伤（king-*→awd-* 迁移教训，PR#171）。
+- uni @tap 在 e2e 驱动下有陷阱（app-e2e 记录）。
+- 布局开关后不调 triggerWorkbenchResize 会导致编辑器/iframe 不重排。
+- 全站（官网侧）禁 emoji 红线不适用于本仓库 UI，但品牌截图有红线（marketing-screenshots 记录）。
+
+## 验证
+
+- `cd frontend && npm run check:emits`（死绑定护栏）+ `npm run test:app-e2e`（登录→项目→上传→打开文件→独立页面全旅程）。
+- 布局/编辑器联动改动加跑 `npm run test:lowa-e2e`。

--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -1,0 +1,66 @@
+---
+name: utility-tools
+description: 辅助小工具领域。任务涉及浏览器面板、截图/OCR、剪贴板、收藏夹、搜索、下载、语音 TTS、文件预览/插入时，先读本文档再动代码。
+---
+
+# 辅助小工具 领域地图
+
+职责边界：工作台各辅助面板与桌面能力（浏览器/截图/剪贴板/收藏/搜索/语音/预览插入/OCR）。不含编辑器（doc-editor）、不含左栏布局本身（sidebar-shell）。
+
+## 分组清单（前端组件 / desktop 宿主 / 后端 API 三层）
+
+**浏览器**：`frontend/src/components/BrowserPane.vue`；desktop `desktop/main/main.js`（BrowserView 创建 ~:634、重复 add 先 remove 再 add 置顶 ~:771-810、window.open 拦截转工作区新 tab ~:290/:674 → 事件 `checkba:browser-open-new-tab`、全屏/黑屏兜底恢复 ~:336/:549/:887/:1189、IPC handlers ~:819-988）；后端 `controller/BrowserProxyController.java`（GET /api/browser/proxy）。
+
+**截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
+
+**剪贴板**：`ClipboardPanel.vue`；desktop main.js 轮询监听 clipboardWatchTimer ~:117-232（指纹去重 ~:110，首 tick 只记指纹）、推送 `checkba:clipboard-copied`；后端 `controller/ClipboardController.java`（/api/clipboard：GET /、POST /text、POST /file、GET /{id}/file、DELETE /{id}）。
+
+**收藏夹**：`ProjectFavoritesPanel.vue`；网页选中收藏经 `checkba:webmark`（preload ~:26）→ project-overview 订阅入库（~:2003）；后端 `controller/WebFavoriteController.java`（/api/favorites/my、/api/projects/{id}/favorites、DELETE、image）。
+
+**搜索**：`SearchPanel.vue`；后端 `controller/SearchController.java`（POST /api/projects/{id}/search）。
+
+**下载**：`DownloadList.vue` 是**孤儿组件**（全仓库无引用、未挂载）；文件下载实际走 FileController `GET /api/files/{fileId}/download`。
+
+**语音 TTS**：`EasyVoicePane.vue`（api：getTtsVoices/generateTtsAudio）；desktop 本地 Kokoro 由 `desktop/main/services/kokoro-service.js` 管理；后端 `controller/TtsController.java`（/api/tts/voices、/generate）+ `service/TtsService.java`——`external.tts.provider`：elevenlabs（云端默认）| local（桌面捆绑 Kokoro，OpenAI 兼容 /v1，base-url=`external.tts.local-base-url`）。easyvoice Docker 段已停用。
+
+**文件预览/插入**：`FilePreview.vue`（docx/pdf/pptx/压缩包分流见 project-overview ~:5110-5157）、`FilePickerDialog.vue`、`FileLinkDropZone.vue`、`FileStagingArea.vue`；图片插入走 `libreofficeExecutorClient.js` insertImage → office_thread.js；desktop `file-service.js` + IPC `checkba:fs-read-file`（含敏感路径拦截+大小上限）；后端 `FileController.java`（download/upload/upload-status/text/compare）、`ProjectFileController.java`（列表/folder/archive/批量/回收站/tags）、`DocFileLinkController.java`（doc-links）。
+
+**OCR**：desktop 框选与抓屏（见截图）；后端 `controller/OcrController.java`（POST /api/ocr/recognize、GET /temp/{fileName}）+ `service/OcrService.java` + `service/ocr/AliyunOcrClient*`——**后端 OCR 实际链路是阿里云**；MinerU 只在 desktop 服务栈（mineru-service.js）与 PPTX 工具链出现，OCR 后端未直接对接 MinerU。
+
+## preload IPC 通道（desktop/preload/preload.js，window.checkbaDesktop）
+
+- app：`checkba:app-open-internal`（订阅）、`checkba:ui-confirm`（应用内确认弹窗，不被 BrowserView 遮挡）
+- browser：invoke create/navigate/set-active/set-bounds/set-views-visible/destroy/get-bounds/wait-ready/get-snapshot/set-ua；订阅 open-new-tab/webmark/title-updated
+- ocr：invoke start-selection/capture-window/desktop/view/screen；订阅 selection-result/selection-error
+- clipboard：订阅 `checkba:clipboard-copied`
+- backend：invoke restart；订阅 status
+- model：invoke status/download/cancel/remove；订阅 progress
+- services：invoke `checkba:service-ensure`
+- utils：invoke `checkba:fs-read-file`（唯一保留的文件读取；旧任意路径 readFile/writeFile 已移除缩小攻击面）
+- fs：invoke `fs:showOpenDialog`
+- zetaoffice：invoke `checkba:zetaoffice-editor`
+
+## IPC 订阅的正确模式（PR#148/#151 权威范例）
+
+navigateTo 页面栈会存活多个 project-overview 实例，各自绑定全局监听 → 一次事件 N 份副作用。这是**全页面级地雷**。正确模式（都在 project-overview.vue）：
+- 活跃实例指针 `window.__checkbaActiveOverviewVm`（mounted ~:1992 置 this，beforeDestroy ~:1783 置空）；守卫 `isActiveOverviewInstance()`（~:2960），全局事件处理先判 `if (!this.isActiveOverviewInstance()) return`（范例 ~:2006/:2046/:2084/:2228）。
+- 剪贴板订阅（~:3274-3290）：`_desktopClipboardUnsub` 保存反订阅函数防重复订阅；去重状态挂 window 而非组件实例（`window.__checkbaClipLastText` ~:3258）。
+- 编辑器同款模式：非响应式注册表 `_libreExecMap`/`_libreRefs` + `syncLibreExecutor()` 活跃指针（~:5855-5904，注释标明"同 PR#151 模式"）。
+**新增任何全局 IPC/事件订阅必须套用此模式。**
+
+## 面板在 project-overview.vue 的挂载点
+
+FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel :550 / PluginPane(左栏) :555 / FileLinkDropZone :570 / FileStagingArea :578 / BrowserPane 左:719 右:786 / FilePreview 左:749 右:816 / ProjectFavoritesPanel :892 / ClipboardPanel :900。import 区 :1217-1233，components 注册 :1293-1312。
+
+## 已知地雷
+
+- BrowserView 弹窗守卫模式与 window.open 消费者、截图假死根因见 v0.6.1 修复（desktop-interaction-bugfix 记录）；改 BrowserView 生命周期务必测全屏/黑屏恢复路径。
+- 剪贴板去重靠指纹+window 级状态，改动监听逻辑先读 PR#148/#151 教训。
+- `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
+- Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。
+
+## 验证
+
+- desktop 服务栈：`cd desktop && npm test`（service-manager/model-manager/pysvc-runtime）。
+- 后端相关单测：TtsServiceTest、FileControllerChunkedUploadTest、ProjectFileService*Test 等；剪贴板/收藏/搜索/OCR/浏览器代理暂无专属测试。
+- UI 链路：`cd frontend && npm run test:app-e2e`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+AI Workdeck（checkba_cloud）：面向法律行业的 AI 工作台。Java Spring 后端（backend/）+ uni-app/Vue3 前端（frontend/）+ Electron 桌面壳（desktop/），文档编辑器为 LibreOffice WASM（代号 LOWA/zetaoffice），另有 pptx/mineru/kokoro/easyvoice 附属服务。
+
+## 领域文档路由表（先读文档，再动代码）
+
+接到任务后，**不要全量扫描代码库**。先按下表判断任务落在哪个领域，读对应的 `.claude/agents/<领域>.md`——里面有该领域的关键文件地图、核心契约、已知地雷和验证命令。跨领域任务读多份。
+
+| 任务涉及 | 领域文档 |
+|---|---|
+| AI 对话、编排器、工具注册、记忆、SSE 流、评测 | `.claude/agents/ai-chat.md` |
+| doc_* 编辑原语、AI 改文档、修订（redline）、检查点、EDITOR_ACTIONS | `.claude/agents/ai-doc-bridge.md` |
+| LOWA/zetaoffice 编辑器、字体、IME、保活、自动保存、.uno: 命令 | `.claude/agents/doc-editor.md` |
+| 浏览器面板、截图、剪贴板、收藏夹、搜索、下载、语音、文件预览/插入、OCR | `.claude/agents/utility-tools.md` |
+| 左侧栏、工作台布局、页面路由、面板切换、设置入口、project-overview.vue 结构 | `.claude/agents/sidebar-shell.md` |
+| 具体插件（尽调/股东大会、脱敏等）、skill 定义与注入 | `.claude/agents/plugin-system.md` |
+| 插件市场页、registry 同步、skill 安装与启停 | `.claude/agents/plugin-marketplace.md` |
+| 构建、发版、CI、测试体系、本地开发启动 | `.claude/agents/eng-infra.md` |
+
+这些文件同时是可派遣的 sub-agent 定义：需要并行探查或委托领域内工作时，可直接用对应 agent 类型派子任务。
+
+## 维护规则
+
+- 合并的 PR 如果改变了某领域的文件布局、契约或新增了地雷，**同一个 PR 里顺手更新对应领域文档**，防止文档腐烂。
+- 新增领域时在本表加一行。
+
+## 全局约定
+
+- `docs/` 目录在 .gitignore 里，向其中添加需入库的文件要 `git add -f`。
+- worktree 有独立的 src/，编辑与构建必须在同一棵树内，不要误用主仓库路径。
+- 本机跑 `mvn` 必须 JDK 21（系统默认 25 会 SIGBUS）。
+- 前端包管理用 npm（不是 pnpm）。
+- 版本号单一来源是 `desktop/package.json`。


### PR DESCRIPTION
## 目的

项目成熟后，每次布置任务都要全量扫描代码库，效率低。本 PR 按代码结构与用户体验逻辑把代码库划成 8 个领域，为每个领域建一份 sub-agent 文档（`.claude/agents/`，Claude Code 原生 sub-agent 格式，自动注册为可派遣 agent 类型），并在根目录 `CLAUDE.md` 建路由表：接任务先读对应领域文档，不再全量扫描。

## 8 个领域

| 文档 | 领域 |
|---|---|
| ai-chat | AI 对话编排（编排器/ToolRegistry/SSE 事件清单/记忆/评测） |
| ai-doc-bridge | AI↔文档桥接（doc_* 原语全集/editor_command 双轨/修订/检查点） |
| doc-editor | LOWA 编辑器（引擎构建/启动链路/zetajs 编组硬规则/自动保存守卫/保活 LRU） |
| utility-tools | 辅助小工具（浏览器/截图/剪贴板/收藏/语音/OCR + preload IPC 通道清单 + 订阅守卫模式） |
| sidebar-shell | 侧边栏与工作台外壳（project-overview.vue 万行文件内部行号地图/面板切换状态机/页面栈守卫） |
| plugin-system | 插件系统（三类插件形态/skill 注入链路/启停过滤位置） |
| plugin-marketplace | 插件市场（广场页/官网 registry 契约/安装卸载链路） |
| eng-infra | 工程基建（CI workflow/发版链路/签名公证顺序/测试总表/本地启动配方） |

每份统一模板：职责边界 → 关键文件地图（含大文件行号区间）→ 核心契约与数据流 → 已知地雷（历次 PR 沉淀）→ 验证命令。

## 制作方式

8 个并行 Explore agent 各自深读一个领域生成事实地图，再逐份与历史 PR 教训（zetajs 编组、IPC 重复订阅、EvalHarness 同步、CI 步骤顺序等）合并校订。

## 维护规则（已写进 CLAUDE.md）

相关 PR 若改变领域的文件布局/契约或新增地雷，同一 PR 顺手更新对应领域文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)