### PR TITLE
feat(plugin): 插件在线分发的安全模型——签名、审核、封禁 + 补三个加载期漏洞

### DIFF
--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -10,16 +10,36 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
 ## 关键文件
 
 **前端**
-- `frontend/src/pages/plugin-market/plugin-market.vue` — 插件广场单页，三个区块：插件（:23-78）、Skill（:80-119）、在线广场（:121-165）。脚本区 :171-333（loadPlugins/onToggle 失败回滚/loadMarket/installSkill/uninstallSkill/rescan）。
+- `frontend/src/pages/plugin-market/plugin-market.vue` — 插件广场单页，「广场 / 已安装」两 tab；广场 tab 内再分 Skill / 插件两个分区（seg-row 切换）。Skill 分区带搜索与七分类 chips；插件分区接在线注册表，安装前弹权限确认。已安装 tab 分插件区与 Skill 区，Skill 行是生效方式三档下拉。
 - `frontend/src/services/api.js` :407-485 — plugins、skills、skills/market 三组 HTTP 封装。
 - 入口：`frontend/src/pages/admin/admin.vue` :584 系统管理侧边栏项 `{key:'plugins', label:'插件广场', route:'/pages/plugin-market/plugin-market'}`。**leftSidebarPlugins.js 不含市场入口**（那是 IDE 左栏业务插件位）。
 
 **后端**
 - `backend/src/main/java/com/checkba/controller/ai/SkillController.java` — /api/skills：list、{id}/enable|disable、rescan、market/list|install|uninstall。
-- `backend/src/main/java/com/checkba/controller/ai/PluginController.java` — /api/plugins：list、启停、rescan。
+- `backend/src/main/java/com/checkba/controller/ai/PluginController.java` — /api/plugins：list、启停、rescan、market/list|install|uninstall、market/sync-revoked。
+- `backend/src/main/java/com/checkba/service/ai/PluginMarketService.java` — **在线插件安装与验签**（Ed25519 公钥内置，逐文件 SHA-256 校验，临时目录+原子移动，装后默认禁用）。
+- `backend/src/main/java/com/checkba/service/ai/PluginRevocationService.java` — 平台封禁列表同步（启动时 + 每 24h），命中强制禁用且不可重新启用。
 - `backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java` — 在线广场客户端（**市场契约的权威定义在此类 Javadoc**，SKILL_SPEC.md §8 未含 market 端点）。
 - `backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java` — 本地扫描/启停/rescan。
 - `backend/src/main/java/com/checkba/service/ai/skill/SkillProperties.java` — ai.skills.*（dir/base-tools/registry-url/ttl）；registry-url 默认 `https://www.aiworkdeck.com/api/registry/skills`（application.yml ~:163）。
+
+## 插件在线分发（JAR）
+
+**规范：`docs/PLUGIN_DISTRIBUTION.md`（跨仓库契约的权威定义）。改这条链路先读它。**
+
+与 Skill 分发的根本区别：插件是可执行代码、与宿主同 JVM 同权限，因此
+**必须人工审核 + 平台签名 + 客户端验签**，且没有自动通过路径。Skill 是纯文本，
+登录即发布，两套流程不要混用。
+
+- 状态机 pending → approved（签名上架）/ rejected，已上架可 revoke 封禁。
+- 签名 Ed25519，覆盖包内每个文件的 SHA-256；canonical JSON 两端必须逐字节一致
+  （键序 files < id < publishedAt < version），改任一侧都要重跑
+  `CrossLanguageSignatureTest` 对拍。
+- 公钥配 `ai.plugins.registry-public-key`，**默认留空即拒绝一切在线安装**。
+- 安装后插件默认禁用，配合「禁用即不加载 JAR」，用户确认前不执行任何插件代码。
+- 官网侧实现在 aiworkdeckweb：`lib/plugins-store.ts`（受理检查）、
+  `lib/plugin-signing.ts`（签名）、`lib/plugin-scan.ts`（常量池扫描 + permissions 交叉验证）、
+  `app/[lang]/plugins/submit`（提交页）、`app/[lang]/admin/PluginReview.tsx`（审核台）。
 
 ## 官网 registry 契约
 

--- a/backend/src/main/java/com/checkba/controller/ai/PluginController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginController.java
@@ -24,6 +24,12 @@ import java.util.Map;
  * - POST /{id}/enable   启用插件（仅 admin）
  * - POST /{id}/disable  禁用插件（仅 admin）
  * - POST /rescan        重新扫描 plugins/ 目录（仅 admin）
+ * - GET  /market/list          在线插件广场列表，登录即可查看
+ * - POST /market/install {id}  验签安装（仅 admin，装后默认禁用待确认）
+ * - POST /market/uninstall{id} 卸载（仅 admin）
+ * - POST /market/sync-revoked  手动同步平台封禁列表（仅 admin）
+ *
+ * 在线安装的安全模型见 docs/PLUGIN_DISTRIBUTION.md。
  */
 @RestController
 @RequestMapping("/api/plugins")
@@ -31,6 +37,8 @@ import java.util.Map;
 public class PluginController {
 
     private final PluginService pluginService;
+    private final com.checkba.service.ai.PluginMarketService pluginMarketService;
+    private final com.checkba.service.ai.PluginRevocationService revocationService;
     private final UserRepository userRepository;
     private final AdminAccessService adminAccessService;
 
@@ -48,6 +56,8 @@ public class PluginController {
         private List<PluginService.PluginToolInfo> tools;
         private int toolCount;
         private boolean enabled;
+        /** 被平台封禁时的原因；非空表示该插件已下架，界面应标红并禁止启用 */
+        private String revokedReason;
     }
 
     @GetMapping("/list")
@@ -82,6 +92,64 @@ public class PluginController {
         return ResponseEntity.ok(result);
     }
 
+    /** 在线广场列表；注册表不可达返回 {code:1, message}，不影响本地插件区块 */
+    @GetMapping("/market/list")
+    public ResponseEntity<Map<String, Object>> listMarket() {
+        try {
+            Map<String, Object> result = ok();
+            result.put("plugins", pluginMarketService.listMarket());
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    /** 验签安装；成功后插件处于禁用状态，需用户在广场确认启用 */
+    @PostMapping("/market/install")
+    public ResponseEntity<Map<String, Object>> installMarketPlugin(
+            @org.springframework.web.bind.annotation.RequestBody Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        try {
+            String id = pluginMarketService.install(body == null ? null : body.get("id"));
+            Map<String, Object> result = ok();
+            result.put("id", id);
+            result.put("pendingEnable", true);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/market/uninstall")
+    public ResponseEntity<Map<String, Object>> uninstallMarketPlugin(
+            @org.springframework.web.bind.annotation.RequestBody Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        try {
+            pluginMarketService.uninstall(body == null ? null : body.get("id"));
+            return ResponseEntity.ok(ok());
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    /** 手动同步平台封禁列表（自动同步为启动时 + 每 24 小时） */
+    @PostMapping("/market/sync-revoked")
+    public ResponseEntity<Map<String, Object>> syncRevoked(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
+        }
+        Map<String, Object> result = ok();
+        result.put("disabled", revocationService.sync());
+        return ResponseEntity.ok(result);
+    }
+
     private ResponseEntity<Map<String, Object>> setEnabled(String pluginId, boolean enabled, String sessionId) {
         if (!isAdmin(sessionId)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("仅管理员可操作"));
@@ -90,6 +158,9 @@ public class PluginController {
             pluginService.setEnabled(pluginId, enabled);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error("插件不存在: " + pluginId));
+        } catch (IllegalStateException e) {
+            // 被平台封禁的插件不允许重新启用
+            return ResponseEntity.ok(error(e.getMessage()));
         }
         return ResponseEntity.ok(ok());
     }
@@ -108,6 +179,7 @@ public class PluginController {
         view.setTools(meta.getTools() == null ? List.of() : meta.getTools());
         view.setToolCount(view.getTools().size());
         view.setEnabled(pluginService.isEnabled(meta.getId()));
+        view.setRevokedReason(pluginService.revokedReason(meta.getId()));
         return view;
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
@@ -1,0 +1,370 @@
+package com.checkba.service.ai;
+
+import cn.hutool.core.io.FileUtil;
+import cn.hutool.http.HttpRequest;
+import cn.hutool.http.HttpResponse;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+/**
+ * 在线插件广场客户端（官网注册表，配置 ai.plugins.registry-url）。
+ * 契约见 docs/PLUGIN_DISTRIBUTION.md §6/§7。
+ *
+ * 与 Skill 广场的本质区别：插件是可执行代码、与宿主同 JVM 同权限，因此
+ * **安装前必须验签**——平台用 Ed25519 私钥对「包内每个文件的 SHA-256」签名，
+ * 这里用内置公钥验证，任一环节不符即中止且不落任何文件。
+ *
+ * 安装后插件默认处于禁用状态，需用户在广场手动启用。配合
+ * PluginService「禁用即不加载 JAR」，这意味着用户确认之前插件代码一行都不会执行。
+ */
+@Service
+@Slf4j
+public class PluginMarketService {
+
+    private static final Pattern PLUGIN_ID = Pattern.compile("^[a-z0-9][a-z0-9-]{1,49}$");
+
+    /** 单个文件下载上限，防御恶意注册表用超大响应打爆内存 */
+    private static final long MAX_FILE_BYTES = 50L * 1024 * 1024;
+
+    private final String registryUrl;
+    private final String publicKeyPem;
+    private final String pluginsDir;
+    private final PluginService pluginService;
+
+    public PluginMarketService(
+            @Value("${ai.plugins.registry-url:https://www.aiworkdeck.com/api/registry/plugins}") String registryUrl,
+            @Value("${ai.plugins.registry-public-key:}") String publicKeyPem,
+            @Value("${ai.plugins.dir:plugins}") String pluginsDir,
+            PluginService pluginService) {
+        this.registryUrl = registryUrl;
+        this.publicKeyPem = publicKeyPem;
+        this.pluginsDir = pluginsDir;
+        this.pluginService = pluginService;
+    }
+
+    /** 广场条目：注册表元数据 + 本地是否已安装 */
+    @lombok.Data
+    public static class MarketPluginView {
+        private String id;
+        private String name;
+        private String description;
+        private String icon;
+        private String version;
+        private String author;
+        private String authorDisplayName;
+        private List<String> permissions = new ArrayList<>();
+        private List<Map<String, Object>> tools = new ArrayList<>();
+        private Long size;
+        private Integer downloads;
+        private String publishedAt;
+        private String homepage;
+        private boolean installed;
+        /** 已安装且本地版本低于注册表版本 */
+        private boolean updatable;
+    }
+
+    /**
+     * 拉取在线插件列表并标注安装状态。
+     * @throws IllegalStateException 注册表不可达或返回无法解析（调用方转 {code:1}，不阻断本地功能）
+     */
+    public List<MarketPluginView> listMarket() {
+        String body = httpGet(registryUrl);
+        List<MarketPluginView> list;
+        try {
+            list = JSONUtil.toList(JSONUtil.parseArray(body), MarketPluginView.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("注册表返回内容无法解析: " + e.getMessage());
+        }
+        for (MarketPluginView view : list) {
+            pluginService.getPlugins().stream()
+                    .filter(p -> p.getId() != null && p.getId().equals(view.getId()))
+                    .findFirst()
+                    .ifPresent(local -> {
+                        view.setInstalled(true);
+                        view.setUpdatable(compareSemver(view.getVersion(), local.getVersion()) > 0);
+                    });
+        }
+        return list;
+    }
+
+    /**
+     * 安装（或更新）一个在线插件。
+     *
+     * 流程严格按 docs/PLUGIN_DISTRIBUTION.md §7：验签 → 逐文件下载并比对 SHA-256
+     * → 全部匹配后原子落盘 → 标记为禁用等待用户确认。任一步失败都不留半成品。
+     *
+     * @return 安装的插件 id
+     * @throws IllegalArgumentException id 非法
+     * @throws IllegalStateException 未配置公钥 / 注册表不可达 / 验签失败 / 哈希不匹配 / 落盘失败
+     */
+    public synchronized String install(String id) {
+        requireValidId(id);
+        if (publicKeyPem == null || publicKeyPem.isBlank()) {
+            throw new IllegalStateException("未配置插件注册表公钥（ai.plugins.registry-public-key），拒绝安装");
+        }
+
+        JSONObject bundle;
+        try {
+            bundle = JSONUtil.parseObj(httpGet(registryUrl + "/" + id + "/bundle"));
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("安装清单无法解析: " + e.getMessage());
+        }
+
+        String version = bundle.getStr("version");
+        String publishedAt = bundle.getStr("publishedAt");
+        String signature = bundle.getStr("signature");
+        JSONObject filesObj = bundle.getJSONObject("files");
+        if (version == null || publishedAt == null || signature == null || filesObj == null || filesObj.isEmpty()) {
+            throw new IllegalStateException("安装清单缺少必需字段");
+        }
+
+        // 键按字典序重建 canonical JSON——必须与官网 lib/plugin-signing.ts 逐字节一致
+        Map<String, String> files = new TreeMap<>();
+        for (String key : filesObj.keySet()) {
+            files.put(key, filesObj.getStr(key));
+        }
+        if (!verifySignature(id, version, publishedAt, files, signature)) {
+            throw new IllegalStateException("签名验证失败，已中止安装（包可能被篡改或来源不可信）");
+        }
+        log.info("Plugin {} v{} signature verified", id, version);
+
+        // 先下到临时目录，全部校验通过再整体搬过去，避免半成品被扫描到
+        Path staging;
+        try {
+            staging = Files.createTempDirectory("awd-plugin-" + id + "-");
+        } catch (Exception e) {
+            throw new IllegalStateException("创建临时目录失败: " + e.getMessage());
+        }
+        try {
+            for (Map.Entry<String, String> entry : files.entrySet()) {
+                String relPath = entry.getKey();
+                if (!isSafeRelPath(relPath)) {
+                    throw new IllegalStateException("清单包含非法路径: " + relPath);
+                }
+                byte[] data = httpGetBytes(registryUrl + "/" + id + "/file?path=" + urlEncode(relPath));
+                String actual = sha256Hex(data);
+                if (!actual.equalsIgnoreCase(entry.getValue())) {
+                    throw new IllegalStateException("文件校验失败: " + relPath + "（内容与签名清单不符）");
+                }
+                Path dest = staging.resolve(relPath).normalize();
+                if (!dest.startsWith(staging)) {
+                    throw new IllegalStateException("清单路径越界: " + relPath);
+                }
+                Files.createDirectories(dest.getParent());
+                Files.write(dest, data);
+            }
+
+            File target = new File(pluginsDir, id);
+            FileUtil.del(target);
+            Files.createDirectories(target.toPath().getParent());
+            try {
+                Files.move(staging, target.toPath(), StandardCopyOption.ATOMIC_MOVE);
+            } catch (Exception atomicFailed) {
+                // 跨文件系统时原子移动不可用，退化为拷贝
+                FileUtil.copyContent(staging.toFile(), target, true);
+                FileUtil.del(staging.toFile());
+            }
+        } catch (RuntimeException e) {
+            FileUtil.del(staging.toFile());
+            throw e;
+        } catch (Exception e) {
+            FileUtil.del(staging.toFile());
+            throw new IllegalStateException("写入插件文件失败: " + e.getMessage());
+        }
+
+        // 先置为禁用再 rescan：新装插件在用户确认前不加载任何代码
+        pluginService.markDisabledBeforeLoad(id);
+        pluginService.rescan();
+        log.info("Installed market plugin '{}' v{} (disabled until user confirms)", id, version);
+        return id;
+    }
+
+    /** 卸载：删除 plugins/<id>/ 并 rescan */
+    public synchronized void uninstall(String id) {
+        requireValidId(id);
+        File pluginsRoot = new File(pluginsDir);
+        File dir = new File(pluginsRoot, id);
+        try {
+            if (!dir.getCanonicalPath().startsWith(pluginsRoot.getCanonicalPath() + File.separator)) {
+                throw new IllegalArgumentException("非法插件目录: " + id);
+            }
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("路径检查失败: " + e.getMessage());
+        }
+        if (!dir.isDirectory()) {
+            throw new IllegalArgumentException("插件未安装: " + id);
+        }
+        FileUtil.del(dir);
+        pluginService.rescan();
+        log.info("Uninstalled plugin '{}'", id);
+    }
+
+    /** 封禁列表条目 */
+    public record RevokedPlugin(String id, String version, String reason, String revokedAt) {}
+
+    /**
+     * 拉取平台封禁列表。version 为 "*" 表示该 id 全部版本被封禁。
+     * @throws IllegalStateException 注册表不可达（调用方应容忍，不影响本地功能）
+     */
+    public List<RevokedPlugin> fetchRevoked() {
+        String body = httpGet(registryUrl + "/revoked");
+        List<RevokedPlugin> result = new ArrayList<>();
+        try {
+            for (Object o : JSONUtil.parseArray(body)) {
+                JSONObject j = (JSONObject) o;
+                result.add(new RevokedPlugin(
+                        j.getStr("id"), j.getStr("version"), j.getStr("reason"), j.getStr("revokedAt")));
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("封禁列表无法解析: " + e.getMessage());
+        }
+        return result;
+    }
+
+    // ==================== 签名验证 ====================
+
+    /**
+     * 重建 canonical JSON 并用内置公钥验签。
+     *
+     * 这个字符串必须与官网 lib/plugin-signing.ts 的 canonicalPayload() 逐字节一致：
+     * 顶层键按字典序 files < id < publishedAt < version，files 内部键同样排序，无多余空白。
+     */
+    boolean verifySignature(String id, String version, String publishedAt,
+                            Map<String, String> sortedFiles, String signatureB64) {
+        try {
+            // 用 LinkedHashMap 保序输出；Hutool 的 JSONObject 默认不保证顺序，故手工拼装
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("files", new LinkedHashMap<>(sortedFiles));
+            payload.put("id", id);
+            payload.put("publishedAt", publishedAt);
+            payload.put("version", version);
+            String canonical = JSONUtil.toJsonStr(payload);
+
+            PublicKey key = parsePublicKey(publicKeyPem);
+            Signature verifier = Signature.getInstance("Ed25519");
+            verifier.initVerify(key);
+            verifier.update(canonical.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return verifier.verify(Base64.getDecoder().decode(signatureB64));
+        } catch (Exception e) {
+            log.error("Signature verification error for plugin {}: {}", id, e.getMessage());
+            return false;
+        }
+    }
+
+    private static PublicKey parsePublicKey(String pem) throws Exception {
+        String base64 = pem.replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] der = Base64.getDecoder().decode(base64);
+        return KeyFactory.getInstance("Ed25519").generatePublic(new X509EncodedKeySpec(der));
+    }
+
+    static String sha256Hex(byte[] data) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    /** 清单里的相对路径同样要防逃逸——注册表也可能被攻陷 */
+    static boolean isSafeRelPath(String p) {
+        if (p == null || p.isBlank() || p.length() > 255) return false;
+        if (p.startsWith("/") || p.startsWith("\\") || p.contains("\\") || p.matches("^[a-zA-Z]:.*")) return false;
+        for (String seg : p.split("/")) {
+            if (seg.equals("..") || seg.equals(".") || seg.isBlank()) return false;
+        }
+        return true;
+    }
+
+    static int compareSemver(String a, String b) {
+        String[] pa = (a == null ? "0.0.0" : a).split("\\.");
+        String[] pb = (b == null ? "0.0.0" : b).split("\\.");
+        for (int i = 0; i < 3; i++) {
+            int va = i < pa.length ? parseIntSafe(pa[i]) : 0;
+            int vb = i < pb.length ? parseIntSafe(pb[i]) : 0;
+            if (va != vb) return Integer.compare(va, vb);
+        }
+        return 0;
+    }
+
+    private static int parseIntSafe(String s) {
+        try {
+            return Integer.parseInt(s.replaceAll("[^0-9].*$", ""));
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private static void requireValidId(String id) {
+        if (id == null || !PLUGIN_ID.matcher(id).matches()) {
+            throw new IllegalArgumentException("非法插件 id: " + id);
+        }
+    }
+
+    private static String urlEncode(String s) {
+        return java.net.URLEncoder.encode(s, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    /** HTTP GET 文本（单测覆写此 seam 打桩） */
+    protected String httpGet(String url) {
+        HttpResponse resp;
+        try {
+            resp = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(15000).execute();
+        } catch (Exception e) {
+            throw new IllegalStateException("注册表不可达: " + e.getMessage());
+        }
+        if (resp.getStatus() != 200) {
+            throw new IllegalStateException("注册表请求失败 (HTTP " + resp.getStatus() + ")");
+        }
+        return resp.body();
+    }
+
+    /** HTTP GET 二进制（单测覆写此 seam 打桩） */
+    protected byte[] httpGetBytes(String url) {
+        HttpResponse resp;
+        try {
+            resp = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(60000).execute();
+        } catch (Exception e) {
+            throw new IllegalStateException("下载失败: " + e.getMessage());
+        }
+        if (resp.getStatus() != 200) {
+            throw new IllegalStateException("下载失败 (HTTP " + resp.getStatus() + ")");
+        }
+        byte[] data = resp.bodyBytes();
+        if (data == null) {
+            throw new IllegalStateException("下载内容为空");
+        }
+        if (data.length > MAX_FILE_BYTES) {
+            throw new IllegalStateException("文件超过 50 MB 上限");
+        }
+        return data;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PluginRevocationService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginRevocationService.java
@@ -1,0 +1,70 @@
+package com.checkba.service.ai;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 平台封禁列表同步（docs/PLUGIN_DISTRIBUTION.md §8）。
+ *
+ * 启动时与每 24 小时从注册表拉一次；命中的已安装插件强制禁用。
+ * 这是插件出问题后唯一的远程处置手段——VS Code 与 JetBrains 也都依赖同类机制。
+ *
+ * 注册表不可达时静默跳过：封禁同步失败不应影响本地功能，下次调度会重试。
+ */
+@Service
+@Slf4j
+public class PluginRevocationService {
+
+    private static final long DAY_MS = 24 * 60 * 60 * 1000L;
+
+    private final PluginMarketService marketService;
+    private final PluginService pluginService;
+
+    public PluginRevocationService(PluginMarketService marketService, PluginService pluginService) {
+        this.marketService = marketService;
+        this.pluginService = pluginService;
+    }
+
+    @PostConstruct
+    public void onStartup() {
+        // 启动时异步拉一次，避免注册表慢响应拖住应用启动（编译目标 Java 17，不用虚拟线程）
+        Thread t = new Thread(this::sync, "plugin-revocation-init");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    @Scheduled(fixedDelay = DAY_MS, initialDelay = DAY_MS)
+    public void scheduledSync() {
+        sync();
+    }
+
+    /** 拉取并应用封禁列表；返回本次新增被禁用的插件 id（供手动触发时回显） */
+    public List<String> sync() {
+        try {
+            List<PluginMarketService.RevokedPlugin> revoked = marketService.fetchRevoked();
+            Map<String, String> byId = new HashMap<>();
+            for (PluginMarketService.RevokedPlugin r : revoked) {
+                if (r.id() == null) continue;
+                // version 为 "*" 或与本地安装版本一致时才算命中；这里按 id 粒度处理，
+                // 因为本地同一 id 只会存在一个版本
+                byId.put(r.id(), r.reason() == null ? "平台已下架" : r.reason());
+            }
+            List<String> disabled = pluginService.applyRevocations(byId);
+            if (!disabled.isEmpty()) {
+                log.warn("Revocation sync disabled {} installed plugin(s): {}", disabled.size(), disabled);
+            } else {
+                log.info("Revocation sync done: {} entries, none installed locally", byId.size());
+            }
+            return disabled;
+        } catch (Exception e) {
+            log.warn("Revocation sync skipped: {}", e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -51,6 +51,9 @@ public class PluginService {
     /** toolName -> pluginId，供将来 ToolRegistry 按插件启停过滤工具 */
     private final Map<String, String> toolToPluginId = new ConcurrentHashMap<>();
 
+    /** pluginId -> 插件目录：禁用状态下不加载 JAR，之后启用时据此补加载 */
+    private final Map<String, File> pluginDirById = new ConcurrentHashMap<>();
+
     /** 被禁用插件 id 集合（内存缓存，与 system_setting 同步） */
     private final Set<String> disabledPluginIds = ConcurrentHashMap.newKeySet();
 
@@ -102,9 +105,9 @@ public class PluginService {
     public record PluginSkillDir(File dir, String pluginId) {
     }
 
-    /** 扫描时收集到的插件 skill 目录，SkillRegistry 启动/重扫时拉取 */
+    /** 扫描时收集到的插件 skill 目录，SkillRegistry 启动/重扫时拉取（同上：rescan 会 clear+重填） */
     @Getter
-    private final List<PluginSkillDir> pluginSkillDirs = new ArrayList<>();
+    private final List<PluginSkillDir> pluginSkillDirs = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     @lombok.Data
     public static class PluginToolInfo {
@@ -130,6 +133,7 @@ public class PluginService {
         toolSpecifications.clear();
         toolToPluginId.clear();
         pluginSkillDirs.clear();
+        pluginDirById.clear();
         loadDisabledState();
         loadPlugins();
         log.info("Plugin rescan done: {} plugins, {} tools", plugins.size(), pluginTools.size());
@@ -208,7 +212,38 @@ public class PluginService {
             systemSettingService.set(DISABLED_KEY,
                     cn.hutool.json.JSONUtil.toJsonStr(new TreeSet<>(disabledPluginIds)));
         }
+        // 启用时补加载 JAR：启动阶段被禁用的插件跳过了加载，否则重新启用后工具永远不出现。
+        // 反向不成立——JVM 无法卸载已加载的类，禁用只能让工具不可见，要彻底停掉需重启。
+        if (enabled) {
+            loadJarsIfAbsent(pluginId);
+        }
         log.info("Plugin {} {}", pluginId, enabled ? "enabled" : "disabled");
+    }
+
+    /** 该插件的工具尚未注册时，按 manifest 补加载其 JAR（启用一个此前被禁用的插件时调用） */
+    private void loadJarsIfAbsent(String pluginId) {
+        boolean alreadyLoaded = toolToPluginId.containsValue(pluginId);
+        if (alreadyLoaded) {
+            return;
+        }
+        File pluginDir = pluginDirById.get(pluginId);
+        PluginMetadata meta = plugins.stream()
+                .filter(p -> Objects.equals(p.getId(), pluginId)).findFirst().orElse(null);
+        if (pluginDir == null || meta == null || meta.getBackendJars() == null) {
+            return;
+        }
+        for (String jarName : meta.getBackendJars()) {
+            File jarFile = resolveBackendJar(pluginDir, jarName, pluginId);
+            if (jarFile == null) {
+                continue;
+            }
+            try {
+                loadJar(jarFile, pluginId);
+            } catch (Exception e) {
+                log.error("Failed to load JAR {} for newly enabled plugin {}: {}",
+                        jarName, pluginId, e.getMessage());
+            }
+        }
     }
 
     /** 工具所属的插件 id（内置工具不在此映射中，返回 null） */
@@ -265,6 +300,7 @@ public class PluginService {
                     continue;
                 }
                 plugins.add(meta);
+                pluginDirById.put(meta.getId(), pluginDir);
 
                 // 收集插件携带的 skill 目录（规范 v2.1）：交给 SkillRegistry 注册，本服务不解析 skill.yml
                 if (meta.getSkills() != null) {
@@ -279,11 +315,22 @@ public class PluginService {
                     }
                 }
 
+                // 被禁用的插件不加载其 JAR。
+                //
+                // 这一条是安全边界而不只是优化：JAR 一旦被 loadClass，静态初始化块与
+                // 无参构造器就已经在宿主 JVM 里跑过了，此后再"禁用"只是把工具从 LLM
+                // 可见列表里摘掉，代码早已执行。管理员点"禁用"的预期是"别运行它"，
+                // 必须在加载前就拦住。（插件元数据仍然登记，管理页照常展示与启停。）
+                if (!isEnabled(meta.getId())) {
+                    log.info("Plugin {} is disabled, skip loading its JARs", meta.getId());
+                    continue;
+                }
+
                 // Load associated JARs if any
                 if (meta.getBackendJars() != null) {
                     for (String jarName : meta.getBackendJars()) {
-                        File jarFile = new File(pluginDir, jarName);
-                        if (jarFile.exists()) {
+                        File jarFile = resolveBackendJar(pluginDir, jarName, meta.getId());
+                        if (jarFile != null) {
                             loadJar(jarFile, meta.getId());
                         }
                     }
@@ -291,6 +338,34 @@ public class PluginService {
             } catch (Exception e) {
                 log.error("Failed to load plugin: " + pluginDir.getName(), e);
             }
+        }
+    }
+
+    /**
+     * 解析 backendJars 条目为插件目录内的真实 JAR 文件。
+     *
+     * manifest 由插件作者提供，`"backendJars": ["../../evil.jar"]` 能指到插件目录之外——
+     * 本地手放插件时危害有限，但在线分发一旦落地就是现成的路径逃逸口，故在此收口：
+     * 用 canonical path 校验目标必须位于插件目录正下方（同时挡掉符号链接绕行）。
+     *
+     * @return 校验通过且存在的 JAR；非法或不存在时返回 null（记日志跳过，不中断其余插件）
+     */
+    File resolveBackendJar(File pluginDir, String jarName, String pluginId) {
+        if (jarName == null || jarName.isBlank()) {
+            return null;
+        }
+        try {
+            File jarFile = new File(pluginDir, jarName);
+            String base = pluginDir.getCanonicalPath() + File.separator;
+            if (!jarFile.getCanonicalPath().startsWith(base)) {
+                log.error("Plugin {} declares backendJar '{}' outside its own directory, refuse to load",
+                        pluginId, jarName);
+                return null;
+            }
+            return jarFile.isFile() ? jarFile : null;
+        } catch (IOException e) {
+            log.error("Plugin {} backendJar '{}' path check failed: {}", pluginId, jarName, e.getMessage());
+            return null;
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -54,6 +54,12 @@ public class PluginService {
     /** pluginId -> 插件目录：禁用状态下不加载 JAR，之后启用时据此补加载 */
     private final Map<String, File> pluginDirById = new ConcurrentHashMap<>();
 
+    /**
+     * 被平台封禁的插件 id -> 原因（由 PluginRevocationService 从注册表同步）。
+     * 命中者强制禁用且不允许用户重新启用，见 docs/PLUGIN_DISTRIBUTION.md §8。
+     */
+    private final Map<String, String> revokedPluginIds = new ConcurrentHashMap<>();
+
     /** 被禁用插件 id 集合（内存缓存，与 system_setting 同步） */
     private final Set<String> disabledPluginIds = ConcurrentHashMap.newKeySet();
 
@@ -203,6 +209,11 @@ public class PluginService {
         if (!known) {
             throw new IllegalArgumentException("Unknown plugin: " + pluginId);
         }
+        // 平台封禁是强制的：用户可以卸载，但不能把被封禁的插件重新启用
+        if (enabled && revokedPluginIds.containsKey(pluginId)) {
+            throw new IllegalStateException(
+                    "该插件已被平台下架：" + revokedPluginIds.get(pluginId) + "，无法启用，建议卸载");
+        }
         if (enabled) {
             disabledPluginIds.remove(pluginId);
         } else {
@@ -218,6 +229,51 @@ public class PluginService {
             loadJarsIfAbsent(pluginId);
         }
         log.info("Plugin {} {}", pluginId, enabled ? "enabled" : "disabled");
+    }
+
+    /**
+     * 在插件被扫描到之前先写入禁用名单——供在线安装使用。
+     *
+     * 与 setEnabled(false) 的区别：后者要求插件已注册（否则抛异常），而新装插件
+     * 尚未 rescan。这里直接落名单，使随后的 loadPlugins() 跳过其 JAR，
+     * 保证用户在广场点「启用」之前，插件代码一行都不会执行。
+     */
+    /**
+     * 应用平台封禁列表：命中的已安装插件强制写入禁用名单。
+     * 不删除文件——留给用户处置，避免误封导致数据丢失；但禁用不可撤销（见 setEnabled）。
+     *
+     * @param revoked pluginId -> 封禁原因
+     * @return 本次新增被禁用的插件 id
+     */
+    public synchronized List<String> applyRevocations(Map<String, String> revoked) {
+        revokedPluginIds.clear();
+        revokedPluginIds.putAll(revoked);
+        List<String> newlyDisabled = new ArrayList<>();
+        for (Map.Entry<String, String> e : revoked.entrySet()) {
+            boolean installed = plugins.stream().anyMatch(p -> Objects.equals(p.getId(), e.getKey()));
+            if (installed && disabledPluginIds.add(e.getKey())) {
+                newlyDisabled.add(e.getKey());
+                log.warn("Plugin {} revoked by registry ({}), forced to disabled", e.getKey(), e.getValue());
+            }
+        }
+        if (!newlyDisabled.isEmpty() && systemSettingService != null) {
+            systemSettingService.set(DISABLED_KEY,
+                    cn.hutool.json.JSONUtil.toJsonStr(new TreeSet<>(disabledPluginIds)));
+        }
+        return newlyDisabled;
+    }
+
+    /** 该插件是否被平台封禁；返回原因，未封禁返回 null（供管理页标红提示） */
+    public String revokedReason(String pluginId) {
+        return revokedPluginIds.get(pluginId);
+    }
+
+    public synchronized void markDisabledBeforeLoad(String pluginId) {
+        disabledPluginIds.add(pluginId);
+        if (systemSettingService != null) {
+            systemSettingService.set(DISABLED_KEY,
+                    cn.hutool.json.JSONUtil.toJsonStr(new TreeSet<>(disabledPluginIds)));
+        }
     }
 
     /** 该插件的工具尚未注册时，按 manifest 补加载其 JAR（启用一个此前被禁用的插件时调用） */

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -151,6 +151,19 @@ ai:
     chars-per-token: 2.0
     # 子 Agent 模型 ID；留空则继承主会话所选模型
     model: ""
+  # 插件体系配置（规范见 docs/PLUGIN_SPEC.md，在线分发见 docs/PLUGIN_DISTRIBUTION.md）
+  plugins:
+    # 插件扫描目录（相对服务端工作目录；打包桌面版落在 ~/.aiworkdeck/plugins/）
+    dir: plugins
+    # 启停名单内存缓存 TTL（毫秒）
+    disabled-cache-ttl-ms: 5000
+    # 在线插件广场注册表地址
+    registry-url: https://www.aiworkdeck.com/api/registry/plugins
+    # 平台签名公钥（Ed25519 SPKI PEM）。安装在线插件时用它验签，
+    # 留空则拒绝一切在线安装。私钥仅存在于官网服务器的 AWD_PLUGIN_SIGNING_KEY。
+    # 换密钥需同步更新此处并随版本发布，见 docs/PLUGIN_DISTRIBUTION.md §5。
+    registry-public-key: ""
+
   # Skill 体系配置（对应 SkillProperties，规范见 docs/SKILL_SPEC.md）
   skills:
     # skill 扫描目录（相对服务端工作目录，做法同 ai.plugins.dir）

--- a/backend/src/test/java/com/checkba/service/ai/CrossLanguageSignatureTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/CrossLanguageSignatureTest.java
@@ -1,0 +1,46 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 跨语言签名一致性：验证官网（Node crypto）签发的签名能被桌面端（JDK）验过。
+ * canonical JSON 只要差一个字节验签就会失败，所以这条链路必须真机对拍一次。
+ *
+ * 由 -Dcrosscheck.file=<path> 提供 Node 侧产物，未提供时跳过（CI 不依赖外部文件）。
+ */
+class CrossLanguageSignatureTest {
+
+    @Test
+    @EnabledIfSystemProperty(named = "crosscheck.file", matches = ".+")
+    @DisplayName("Node 侧签发的签名在 Java 侧验签通过")
+    void nodeSignatureVerifiesInJava() throws Exception {
+        Path f = Path.of(System.getProperty("crosscheck.file"));
+        var root = cn.hutool.json.JSONUtil.parseObj(Files.readString(f));
+        String nodeCanonical = root.getStr("canonical");
+        String sig = root.getStr("sig");
+        var payload = root.getJSONObject("payload");
+        var filesObj = payload.getJSONObject("files");
+
+        Map<String, String> files = new TreeMap<>();
+        for (String k : filesObj.keySet()) files.put(k, filesObj.getStr(k));
+
+        String pubPem = Files.readString(f.getParent().resolve("test-pub.pem"));
+        PluginMarketService svc = new PluginMarketService(
+                "http://x", pubPem, f.getParent().toString(), new PluginService());
+
+        assertTrue(
+                svc.verifySignature(payload.getStr("id"), payload.getStr("version"),
+                        payload.getStr("publishedAt"), files, sig),
+                "Java 侧必须能验过 Node 签发的签名——canonical JSON 两端需逐字节一致。"
+                        + "\nNode canonical: " + nodeCanonical);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -1,0 +1,250 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.SystemSettingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * PluginMarketService 测试：签名验证（与官网 lib/plugin-signing.ts 的 canonical
+ * 形式必须逐字节一致）、哈希校验、路径逃逸防护、安装后默认禁用。
+ */
+class PluginMarketServiceTest {
+
+    @TempDir
+    Path pluginsDir;
+
+    private KeyPair keyPair;
+    private String publicKeyPem;
+    private final Map<String, String> settingStore = new HashMap<>();
+    private PluginService pluginService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        publicKeyPem = "-----BEGIN PUBLIC KEY-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(keyPair.getPublic().getEncoded())
+                + "\n-----END PUBLIC KEY-----\n";
+
+        SystemSettingService settings = mock(SystemSettingService.class);
+        when(settings.get(anyString(), anyString())).thenAnswer(inv ->
+                settingStore.getOrDefault(inv.getArgument(0), inv.getArgument(1)));
+        doAnswer(inv -> settingStore.put(inv.getArgument(0), inv.getArgument(1)))
+                .when(settings).set(anyString(), anyString());
+        pluginService = new PluginService(settings, pluginsDir.toString());
+    }
+
+    /** 与官网 canonicalPayload() 相同的规则：顶层 files<id<publishedAt<version，files 内键排序 */
+    private String canonical(String id, String version, String publishedAt, Map<String, String> files) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("files", new TreeMap<>(files));
+        payload.put("id", id);
+        payload.put("publishedAt", publishedAt);
+        payload.put("version", version);
+        return cn.hutool.json.JSONUtil.toJsonStr(payload);
+    }
+
+    private String sign(String canonical) throws Exception {
+        Signature s = Signature.getInstance("Ed25519");
+        s.initSign(keyPair.getPrivate());
+        s.update(canonical.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(s.sign());
+    }
+
+    private PluginMarketService service(String pubKey) {
+        return new PluginMarketService("http://registry.test/plugins", pubKey, pluginsDir.toString(), pluginService);
+    }
+
+    @Test
+    @DisplayName("签名验证：正确签名通过，篡改任一字段即失败")
+    void signatureVerification() throws Exception {
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", "aa11");
+        files.put("tool.jar", "bb22");
+        String sig = sign(canonical("demo", "1.0.0", "2026-07-27T00:00:00Z", files));
+
+        PluginMarketService svc = service(publicKeyPem);
+        assertTrue(svc.verifySignature("demo", "1.0.0", "2026-07-27T00:00:00Z", files, sig));
+
+        assertFalse(svc.verifySignature("other", "1.0.0", "2026-07-27T00:00:00Z", files, sig), "改 id 应失败");
+        assertFalse(svc.verifySignature("demo", "9.9.9", "2026-07-27T00:00:00Z", files, sig), "改版本应失败");
+        assertFalse(svc.verifySignature("demo", "1.0.0", "2026-01-01T00:00:00Z", files, sig), "改时间应失败");
+
+        Map<String, String> tampered = new TreeMap<>(files);
+        tampered.put("tool.jar", "deadbeef");
+        assertFalse(svc.verifySignature("demo", "1.0.0", "2026-07-27T00:00:00Z", tampered, sig), "改文件哈希应失败");
+    }
+
+    @Test
+    @DisplayName("files 键的顺序不影响验签（两端都按字典序重建）")
+    void fileOrderIndependent() throws Exception {
+        Map<String, String> sorted = new TreeMap<>();
+        sorted.put("a.jar", "1");
+        sorted.put("manifest.json", "2");
+        String sig = sign(canonical("demo", "1.0.0", "T", sorted));
+
+        // 用插入顺序相反的 map 验签，结果应相同
+        Map<String, String> reversed = new LinkedHashMap<>();
+        reversed.put("manifest.json", "2");
+        reversed.put("a.jar", "1");
+        assertTrue(service(publicKeyPem).verifySignature("demo", "1.0.0", "T", new TreeMap<>(reversed), sig));
+    }
+
+    @Test
+    @DisplayName("未配置公钥时拒绝安装")
+    void refuseInstallWithoutPublicKey() {
+        PluginMarketService svc = service("");
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
+        assertTrue(e.getMessage().contains("公钥"));
+    }
+
+    @Test
+    @DisplayName("非法插件 id 被拒绝")
+    void rejectInvalidId() {
+        PluginMarketService svc = service(publicKeyPem);
+        assertThrows(IllegalArgumentException.class, () -> svc.install("../evil"));
+        assertThrows(IllegalArgumentException.class, () -> svc.install("UPPER"));
+        assertThrows(IllegalArgumentException.class, () -> svc.uninstall("a/b"));
+    }
+
+    @Test
+    @DisplayName("清单里的路径逃逸被拒绝")
+    void unsafePathsRejected() {
+        assertFalse(PluginMarketService.isSafeRelPath("../evil.jar"));
+        assertFalse(PluginMarketService.isSafeRelPath("/etc/passwd"));
+        assertFalse(PluginMarketService.isSafeRelPath("a\\b.jar"));
+        assertFalse(PluginMarketService.isSafeRelPath("C:/x.jar"));
+        assertFalse(PluginMarketService.isSafeRelPath("a/../../b"));
+        assertTrue(PluginMarketService.isSafeRelPath("manifest.json"));
+        assertTrue(PluginMarketService.isSafeRelPath("lib/tool.jar"));
+    }
+
+    @Test
+    @DisplayName("安装：验签与逐文件哈希校验通过后落盘，且插件默认禁用")
+    void installHappyPath() throws Exception {
+        String manifest = "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\",\"backendJars\":[\"tool.jar\"]}";
+        byte[] manifestBytes = manifest.getBytes(StandardCharsets.UTF_8);
+        byte[] jarBytes = new byte[]{0x50, 0x4B, 0x03, 0x04, 0x01};
+
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", PluginMarketService.sha256Hex(manifestBytes));
+        files.put("tool.jar", PluginMarketService.sha256Hex(jarBytes));
+        String sig = sign(canonical("demo", "1.0.0", "2026-07-27T00:00:00Z", files));
+
+        PluginMarketService svc = stubbed(publicKeyPem, files, sig, manifestBytes, jarBytes);
+        assertEquals("demo", svc.install("demo"));
+
+        assertTrue(Files.exists(pluginsDir.resolve("demo").resolve("manifest.json")));
+        assertArrayEquals(jarBytes, Files.readAllBytes(pluginsDir.resolve("demo").resolve("tool.jar")));
+        assertFalse(pluginService.isEnabled("demo"), "在线安装的插件必须默认禁用，等用户确认");
+        assertTrue(pluginService.getPluginTools().isEmpty(), "禁用状态下不应加载 JAR 注册工具");
+    }
+
+    @Test
+    @DisplayName("安装：文件内容与签名清单不符时中止且不落盘")
+    void installAbortsOnHashMismatch() throws Exception {
+        byte[] manifestBytes = "{\"id\":\"demo\",\"version\":\"1.0.0\"}".getBytes(StandardCharsets.UTF_8);
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", PluginMarketService.sha256Hex(manifestBytes));
+        String sig = sign(canonical("demo", "1.0.0", "2026-07-27T00:00:00Z", files));
+
+        // 下载到的内容与清单声明的哈希不符（模拟传输中被替换）
+        PluginMarketService svc = stubbed(publicKeyPem, files, sig,
+                "tampered".getBytes(StandardCharsets.UTF_8), null);
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
+        assertTrue(e.getMessage().contains("校验失败"));
+        assertFalse(Files.exists(pluginsDir.resolve("demo")), "校验失败不得留下半成品");
+    }
+
+    @Test
+    @DisplayName("安装：签名无效时中止，不发起任何文件下载")
+    void installAbortsOnBadSignature() throws Exception {
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", "00");
+        String badSig = Base64.getEncoder().encodeToString(new byte[64]);
+
+        boolean[] downloaded = {false};
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService) {
+            @Override
+            protected String httpGet(String url) {
+                return bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, badSig);
+            }
+            @Override
+            protected byte[] httpGetBytes(String url) {
+                downloaded[0] = true;
+                return new byte[0];
+            }
+        };
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
+        assertTrue(e.getMessage().contains("签名验证失败"));
+        assertFalse(downloaded[0], "验签失败必须在下载任何文件之前中止");
+    }
+
+    @Test
+    @DisplayName("封禁的插件不允许被重新启用")
+    void revokedPluginCannotBeEnabled() throws Exception {
+        Path dir = pluginsDir.resolve("bad");
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("manifest.json"), "{\"id\":\"bad\",\"name\":\"坏插件\"}");
+        pluginService.init();
+        assertTrue(pluginService.isEnabled("bad"));
+
+        pluginService.applyRevocations(Map.of("bad", "窃取凭据"));
+        assertFalse(pluginService.isEnabled("bad"), "封禁应强制禁用");
+        assertEquals("窃取凭据", pluginService.revokedReason("bad"));
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> pluginService.setEnabled("bad", true));
+        assertTrue(e.getMessage().contains("已被平台下架"));
+    }
+
+    @Test
+    @DisplayName("语义化版本比较用于判断可更新")
+    void semverCompare() {
+        assertTrue(PluginMarketService.compareSemver("1.0.1", "1.0.0") > 0);
+        assertTrue(PluginMarketService.compareSemver("1.2.0", "1.10.0") < 0);
+        assertEquals(0, PluginMarketService.compareSemver("2.0.0", "2.0.0"));
+        assertTrue(PluginMarketService.compareSemver("1.0.0", null) > 0);
+    }
+
+    private static String bundleJson(String id, String version, String publishedAt,
+                                     Map<String, String> files, String sig) {
+        cn.hutool.json.JSONObject o = new cn.hutool.json.JSONObject();
+        o.set("id", id).set("version", version).set("publishedAt", publishedAt)
+                .set("files", files).set("signature", sig);
+        return o.toString();
+    }
+
+    /** 打桩 HTTP：bundle 返回给定清单，file 按路径返回对应内容 */
+    private PluginMarketService stubbed(String pubKey, Map<String, String> files, String sig,
+                                        byte[] manifestBytes, byte[] jarBytes) {
+        return new PluginMarketService("http://registry.test/plugins", pubKey, pluginsDir.toString(), pluginService) {
+            @Override
+            protected String httpGet(String url) {
+                return bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, sig);
+            }
+            @Override
+            protected byte[] httpGetBytes(String url) {
+                return url.contains("tool.jar") ? jarBytes : manifestBytes;
+            }
+        };
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -276,4 +276,51 @@ class PluginServiceTest {
         assertFalse(service.isEnabled("second"), "rescan 应重读禁用名单");
         assertTrue(service.isEnabled("hello-plugin"));
     }
+
+    // ==== backendJars 路径校验 ====
+
+    @Test
+    @DisplayName("backendJars 指向插件目录外时拒绝加载（路径逃逸防护）")
+    void backendJarOutsidePluginDirIsRejected() throws IOException {
+        Path pluginDir = pluginsDir.resolve("evil-plugin");
+        Files.createDirectories(pluginDir);
+        // 在 plugins/ 根下放一个"外部" JAR，插件试图用 ../ 指到它
+        Files.write(pluginsDir.resolve("outside.jar"), new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        assertNull(service.resolveBackendJar(pluginDir.toFile(), "../outside.jar", "evil-plugin"),
+                "../ 逃出插件目录必须被拒绝");
+        assertNull(service.resolveBackendJar(pluginDir.toFile(), "../../../etc/passwd", "evil-plugin"));
+        assertNull(service.resolveBackendJar(pluginDir.toFile(), null, "evil-plugin"));
+        assertNull(service.resolveBackendJar(pluginDir.toFile(), "  ", "evil-plugin"));
+    }
+
+    @Test
+    @DisplayName("backendJars 指向插件目录内的真实文件时放行")
+    void backendJarInsidePluginDirIsAccepted() throws IOException {
+        Path pluginDir = pluginsDir.resolve("ok-plugin");
+        Files.createDirectories(pluginDir.resolve("lib"));
+        Files.write(pluginDir.resolve("tool.jar"), new byte[]{0x50, 0x4B, 0x03, 0x04});
+        Files.write(pluginDir.resolve("lib").resolve("nested.jar"), new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        assertNotNull(service.resolveBackendJar(pluginDir.toFile(), "tool.jar", "ok-plugin"));
+        assertNotNull(service.resolveBackendJar(pluginDir.toFile(), "lib/nested.jar", "ok-plugin"),
+                "子目录内的 JAR 应放行");
+        assertNull(service.resolveBackendJar(pluginDir.toFile(), "missing.jar", "ok-plugin"),
+                "声明了但文件不存在时返回 null");
+    }
+
+    // ==== 禁用插件不加载 ====
+
+    @Test
+    @DisplayName("启动时被禁用的插件仍登记元数据，但不加载其 JAR")
+    void disabledPluginIsRegisteredButJarNotLoaded() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        settingStore.put(PluginService.DISABLED_KEY, "[\"hello-plugin\"]");
+
+        service.init();
+
+        assertEquals(1, service.getPlugins().size(), "禁用插件仍要在管理页可见");
+        assertFalse(service.isEnabled("hello-plugin"));
+        assertTrue(service.getPluginTools().isEmpty(), "禁用插件的工具不应被注册");
+    }
 }

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -192,7 +192,13 @@ AgentOrchestrator 仅 3 行挂载点（字段 + activateForTurn + visibleTools �
   - [ ] **双轨摘旧名**：兼容一个发布周期后，摘除后端旧名双发、前端旧名分支与
         `/wps-result` 路由别名；`ProjectFile.wpsFileId` / `wps_file_id` / `wps-files/`
         前缀等存量数据契约需另立数据迁移方案。
-  - [ ] **插件进程级运行时沙箱**：v2 权限校验是分发层的诚实声明模型，插件代码仍与宿主同进程；
-        真正强制 file/network 隔离需进程级沙箱（独立进程 + IPC 或 SecurityManager 替代方案）。
+  - [x] **插件分发链路安全**（2026-07-27）：平台 Ed25519 签名 + 人工审核 + 静态扫描与
+        permissions 交叉验证 + 客户端验签 + 远程封禁；加载期收口（禁用即不加载 JAR、
+        backendJars 路径逃逸校验）。见 docs/PLUGIN_DISTRIBUTION.md。
+  - [ ] **进程外插件形态（MCP server）**：为不需要独立 UI 的插件提供真正的隔离边界。
+        注意**进程内沙箱不可行、已从待办中移除**——Java 的 SecurityManager 已于
+        JEP 486 在 JDK 24 永久禁用，OpenJDK 官方给出的替代方案就是进程外隔离；
+        VS Code 与 JetBrains 同样不做运行时沙箱。JAR 插件的安全依赖分发链路，
+        不要再把「同进程沙箱」列为目标。
 
   后续展望（Phase 4 候选，不在 Phase 3 范围）：多智能体协作后续阶段（子任务规划器、跨子任务共享记忆）。

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -1,0 +1,188 @@
+# 插件在线分发规范（提交 · 审核 · 签名 · 封禁）
+
+> 适用范围：**JAR 插件**的在线分发。Skill 的分发见 [SKILL_SPEC.md](SKILL_SPEC.md) §8，
+> 它是纯文本、风险量级完全不同，走的是无审核的直接发布流程，两者不要混用。
+
+## 0. 为什么需要这一套
+
+插件 JAR 与宿主同一个 JVM、同一份权限（原因见 [PLUGIN_SPEC.md](PLUGIN_SPEC.md) §3
+「真实的信任边界在哪里」）。Java 侧没有进程内沙箱可用，所以**运行时拦不住任何东西**，
+安全只能前移到分发链路。
+
+这与 VS Code / JetBrains 的选择一致——两者都明确不做运行时沙箱，靠的是签名、
+市场审核与封禁。JetBrains 2026-06 的恶意 AI 插件事件（伪装正常功能、等用户填入
+AI provider 的 API key 后窃取、装 JVM 全局 TrustManager 关掉 TLS 校验、明文外传）
+说明这套机制并非万无一失，但它是目前唯一可行的路径。
+
+我们的用户是律师，本机存有客户机密与案件材料，应用内保存着 AI 供应商密钥——
+风险敞口比通用 IDE 更大，因此审核环节**不设自动通过**。
+
+## 1. 三条分发渠道
+
+| 渠道 | 形态 | 审核 | 信任前提 |
+|---|---|---|---|
+| 内置 | 随应用发版的 JAR | 我们自己的发布流程 | 等同应用自身 |
+| 本地 | 用户手动放入 `plugins/` | 无 | 用户自担，等同安装一个本机应用 |
+| **在线广场** | 经审核签名的 JAR | **人工审核 + 自动扫描** | 平台背书 + 可远程封禁 |
+
+本文只规范第三条。
+
+## 2. 状态机
+
+```
+                 ┌──────────► rejected（记原因，作者可修改后重新提交）
+                 │
+提交 ──► pending ─┴──► approved ──► 平台签名 ──► 上架 registry
+                                        │
+                                        └──► revoked（封禁，客户端自动禁用）
+```
+
+- `pending`：已提交待审，**不出现在 registry**。
+- `approved`：审核通过并已签名，出现在 registry 供安装。
+- `rejected`：驳回，附 `reviewNote`；作者改完重新提交生成新版本。
+- `revoked`：曾上架但事后发现问题，进入封禁列表；客户端拉到后自动禁用已安装的该插件。
+
+**没有自动通过的路径。** 自动扫描只产出报告供审核人参考，不改变状态。
+
+## 3. 提交包格式
+
+作者上传一个 zip，解开后必须是**单个插件目录的内容**（不是外面再套一层目录）：
+
+```
+（zip 根）
+├── manifest.json          必需，规范见 PLUGIN_SPEC.md §2
+├── <name>.jar             manifest.backendJars 声明的 JAR
+└── <skill-dir>/           可选，manifest.skills 声明的 Skill 目录
+    ├── skill.yml
+    └── prompt.md
+```
+
+服务端受理时的硬性检查（任一不过直接拒收，不进审核队列）：
+
+| 检查 | 约束 |
+|---|---|
+| 包体积 | ≤ 20 MB |
+| 条目数 | ≤ 2000 |
+| 单文件解压后体积 | ≤ 50 MB（zip bomb 防护） |
+| 路径 | 不得含 `..`、绝对路径、符号链接（zip slip 防护） |
+| manifest | 存在、可解析、`id` 匹配 `^[a-z0-9][a-z0-9-]{1,49}$`、`version` 为语义化版本 |
+| id 归属 | 新 id 归提交者；已存在的 id 只有原作者能提交新版本 |
+| version | 必须严格大于该 id 已有的最高版本 |
+| backendJars | 声明的每个文件都必须在包内且落在包根之下 |
+
+## 4. 自动扫描（审核辅助，不做判定）
+
+对包内每个 `.class` 文件做常量池字符串匹配。Java class 的常量池以明文存放引用的类名与
+方法名，因此无需反编译即可发现引用关系。命中项**不代表恶意**，只标记需要人工重点核对的位置。
+
+| 类别 | 匹配特征 | 关注原因 |
+|---|---|---|
+| 进程执行 | `java/lang/Runtime`、`ProcessBuilder` | 可执行任意本机命令 |
+| TLS 篡改 | `javax/net/ssl/X509TrustManager`、`SSLContext.init`、`setDefaultSSLSocketFactory` | JetBrains 事件的关键手法：关掉证书校验后明文外传 |
+| 网络 | `java/net/Socket`、`HttpURLConnection`、`java/net/http` | 与 `permissions` 是否声明 `network` 交叉验证 |
+| 文件 | `java/io/File`、`java/nio/file/Files` | 与 `file_read` / `file_write` 交叉验证 |
+| 反射突破 | `setAccessible`、`sun/misc/Unsafe`、`MethodHandles` | 绕过封装访问宿主内部状态 |
+| 宿主内部 | `com/checkba/`、`ApplicationContext`、`DataSource` | 直接摸 Spring 容器与数据库 |
+| 硬编码出口 | 形如 IPv4 字面量、`http://` 明文 URL | 固定 C2 地址的典型特征 |
+
+**交叉验证是这一步最有价值的产出**：`permissions` 自述与实际引用不符（例如未声明
+`network` 却引用了 `Socket`）应当直接驳回。这让 manifest 里的权限声明第一次具备实际
+约束力——它不再只是作者的自说自话，而是审核时的对照基准。
+
+## 5. 签名
+
+**算法**：Ed25519（Node `crypto` 与 JDK 15+ 均原生支持，无需第三方库与证书链）。
+
+**密钥**：平台持有一对密钥。私钥仅存在于官网服务器环境变量 `AWD_PLUGIN_SIGNING_KEY`
+（PKCS#8 PEM），公钥硬编码在桌面端 `ai.plugins.registry-public-key` 配置默认值中。
+私钥泄露的处置方式是换密钥 + 客户端随版本更新公钥 + 全量重签。
+
+**签名对象**：审核通过时对下面这个 canonical JSON（键按字典序、无多余空白）签名：
+
+```json
+{"files":{"manifest.json":"<sha256>","tool.jar":"<sha256>"},"id":"my-plugin","publishedAt":"2026-07-27T00:00:00Z","version":"1.0.0"}
+```
+
+签名覆盖**每个文件的 SHA-256**，而不只是 JAR——manifest 同样关键（它决定加载哪些 JAR、
+声明什么权限）。客户端安装时逐文件比对哈希，任一不符即中止。
+
+## 6. registry 接口契约
+
+桌面端 `PluginMarketService` 消费。字段勿随意改名/删除。
+
+### `GET /api/registry/plugins`
+
+返回 `approved` 状态的插件元数据数组（不含二进制）：
+
+```jsonc
+[{
+  "id": "dd-workbench",
+  "name": "尽调工作台",
+  "description": "...",
+  "version": "2.1.0",
+  "author": "legal-ops",            // 提交者 username
+  "authorDisplayName": "法务运营组",
+  "permissions": ["file_read"],      // manifest 自述，客户端安装前展示
+  "tools": [{"name": "dd_checklist", "description": "生成尽调清单"}],
+  "size": 1048576,                   // 包总字节数
+  "downloads": 0,
+  "publishedAt": "2026-07-27T00:00:00Z",
+  "homepage": "https://www.aiworkdeck.com/zh/plugins/dd-workbench"
+}]
+```
+
+### `GET /api/registry/plugins/{id}/bundle`
+
+返回安装所需的清单与签名，**不含二进制**：
+
+```jsonc
+{
+  "id": "dd-workbench",
+  "version": "2.1.0",
+  "publishedAt": "2026-07-27T00:00:00Z",
+  "files": { "manifest.json": "<sha256>", "tool.jar": "<sha256>" },
+  "signature": "<base64 Ed25519 签名>"
+}
+```
+
+### `GET /api/registry/plugins/{id}/file?path=<相对路径>`
+
+按 `files` 中的键逐个下载文件二进制。`path` 必须是 `files` 里出现过的键，否则 404
+（避免变成任意文件读取接口）。
+
+### `GET /api/registry/plugins/revoked`
+
+封禁列表，客户端启动时与每 24 小时拉取一次：
+
+```jsonc
+[{"id": "bad-plugin", "version": "1.0.0", "reason": "窃取凭据", "revokedAt": "..."}]
+```
+
+`version` 为 `"*"` 时表示该 id 的所有版本均被封禁。
+
+## 7. 客户端安装流程
+
+1. 拉 `/bundle`，用内置公钥验签——**失败即中止**，不落任何文件；
+2. 逐个下载 `files` 中的文件到临时目录，边下边算 SHA-256，与清单比对；
+3. 全部匹配后，原子移动到 `plugins/<id>/`（先写临时目录再 rename，避免半成品被扫描到）；
+4. 弹出信任确认，展示：插件名、作者、版本、**权限自述**、工具清单，以及一句
+   「安装插件等同于在本机安装一个应用程序，它能读写你的文件并访问网络」；
+5. 用户确认后 `rescan()` 生效；未确认则删除已落盘内容。
+
+**默认安装后处于禁用状态**，需用户在已安装列表手动启用——配合 PLUGIN_SPEC §5 的
+「禁用即不加载」，这意味着用户点确认之前，插件代码一行都不会执行。
+
+## 8. 封禁生效
+
+客户端拉到封禁列表后，对命中的已安装插件：写入禁用名单 → 记录审计日志 →
+在插件广场标红提示「该插件已被平台下架：<原因>，建议卸载」。
+
+不自动删除文件——留给用户处置，避免误封时数据丢失。但**禁用是强制的**，
+用户无法在广场里重新启用被封禁的插件。
+
+## 9. 分期
+
+- **Phase 1**（当前）：官网提交 + 人工审核 + 自动扫描报告 + 签名 + registry 四个接口。
+- **Phase 2**：桌面端安装（验签 + 逐文件哈希校验 + 信任确认）+ 封禁拉取与强制禁用。
+- **Phase 3**（未排期）：进程外插件形态（MCP server），为不需要独立 UI 的插件提供
+  真正的隔离边界；届时在线渠道优先推荐该形态，JAR 保留给必须有自己界面的插件。

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -111,7 +111,7 @@ Java 侧没有进程内沙箱可用（`SecurityManager` 已于 JEP 411 废弃、
 
 **安装一个 JAR 插件 = 信任它等同于信任一个本机应用程序。** 这一点对本地手放的插件
 无法通过技术手段缓解，只能靠分发链路（签名、审核、封禁）把不可信来源挡在外面——
-见 §8 与 docs/PLUGIN_DISTRIBUTION.md。
+见 [docs/PLUGIN_DISTRIBUTION.md](PLUGIN_DISTRIBUTION.md)。
 
 ## 4. 后端工具（backendJars）约定
 
@@ -183,7 +183,11 @@ plugins/
 - **v1（0.4.x）**：声明式 manifest + 启停持久化 + 插件广场展示。
 - **v2（Phase 3A）**：ToolRegistry 按启停过滤三处消费点 + `tools[].permissions`
   分发前权限校验（诚实声明模型）+ 启停缓存 TTL。
-- **v2.1（当前，Phase 3B）**：manifest 新增 `skills` 字段，插件可携带 Skill（见 §7 与
+- **v2.1（Phase 3B）**：manifest 新增 `skills` 字段，插件可携带 Skill（见 §7 与
   docs/SKILL_SPEC.md）。
-- 规划中（见 AI_ARCHITECTURE.md Phase 3 TODO）：进程级运行时沙箱（真正强制 file/network 隔离）、
-  frontendEntry 动态加载、插件签名与来源校验。
+- **v2.2（当前）**：加载期收口——禁用即不加载 JAR（§5）、`backendJars` 路径逃逸校验（§4）；
+  在线分发落地：平台 Ed25519 签名 + 人工审核 + 客户端验签 + 远程封禁，见
+  [docs/PLUGIN_DISTRIBUTION.md](PLUGIN_DISTRIBUTION.md)。
+- 规划中：进程外插件形态（MCP server）为不需要独立 UI 的插件提供真正的隔离边界；
+  frontendEntry 动态加载。**进程内沙箱不在规划中**——Java 侧无此能力（§3），
+  不要再把它列为待办。

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -15,6 +15,17 @@ plugins/
     └── hello-plugin-1.0.0.jar # 可选，后端工具 JAR（manifest.backendJars 声明）
 ```
 
+`ai.plugins.dir` 默认是相对路径 `plugins`，**实际落点由后端进程的工作目录决定**：
+
+| 形态 | 工作目录 | 插件目录 |
+|---|---|---|
+| 本地开发 | `<repo>/backend` | `backend/plugins/` |
+| 打包桌面版 | `~/.aiworkdeck` | `~/.aiworkdeck/plugins/` |
+
+桌面版这个位置在**用户家目录下且可写**——任何以该用户身份运行的本地进程都能往里丢
+插件，下次启动即被加载。这是威胁模型里必须记住的一条：`plugins/` 目录的写权限
+等价于在宿主 JVM 里执行任意代码。
+
 启动时自动扫描；也可在插件广场点击「重新扫描」或调用 `POST /api/plugins/rescan` 热发现新插件（注意：重扫只能发现新插件/新元数据，已加载进 JVM 的旧类不会被卸载，替换 JAR 需重启后端）。
 
 ## 2. manifest.json 字段
@@ -47,7 +58,7 @@ plugins/
 | `icon` | string | 否 | emoji（如 `🔌`）或图片 URL/绝对路径；缺省时前端显示 `🧩`。 |
 | `author` | string | 否 | 作者 / 组织名。 |
 | `homepage` | string | 否 | 主页或仓库 URL。 |
-| `permissions` | string[] | 否 | 声明插件**被授予**的能力，见 §3。缺省视为不需要任何敏感能力。 |
+| `permissions` | string[] | 否 | 插件**自行声明**会用到的能力，见 §3。缺省视为不需要任何敏感能力。注意这是作者的自述，不是运行时授权。 |
 | `tools` | object[] | 否 | 工具清单（`name` + 中文 `description` + 可选 `permissions`），用于插件广场展示、人工审查与 v2 权限校验。`name` 应与 JAR 中 `@Tool` 方法名一致；`permissions` 声明**该工具运行所需**的能力（v2 新增，见 §3）。 |
 | `frontendEntry` | string | 否 | 前端入口（预留，v1 不加载）。 |
 | `backendJars` | string[] | 否 | 相对插件目录的 JAR 文件名列表，启动/重扫时加载其中带 `@Tool` 注解的类。 |
@@ -55,7 +66,7 @@ plugins/
 
 未知字段被忽略（向前兼容）；`permissions` 中出现 v1 未定义的值仅记录 WARN，不拒绝加载。
 
-## 3. permissions 权限模型（v2）
+## 3. permissions 自述与一致性校验（v2）
 
 | 值 | 含义 |
 |---|---|
@@ -64,27 +75,52 @@ plugins/
 | `network` | 访问外部网络（HTTP 等出站请求） |
 | `editor` | 操作文档编辑器（LOWA/LibreOffice 相关原语） |
 
-### v2 执行语义（分发前校验）
+> **先读这一段，否则会高估它的作用。**
+>
+> 这不是权限模型，是 manifest 内部的一致性 lint。校验比较的两个集合——「工具所需」
+> 与「插件声明」——**都来自插件作者自己写的同一个 manifest.json**，作者改任意一边
+> 即可让校验恒过（顶层写满四个权限，或干脆不写 `tools[].permissions`）。
+>
+> 更重要的是，**声明与实际行为完全不挂钩**：声明了空权限的工具，方法体里照样可以
+> 读写任意文件、发任意网络请求。这四个字符串在后端只用于日志、上述集合比较和前端
+> 标签展示，没有任何 FileService / HTTP 客户端 / EditorBridge 会去查它们。
+>
+> 它的真实价值：帮**诚实的**作者暴露"忘了声明"的疏漏，以及给人工审查提供一份可读的
+> 能力自述。对恶意插件零防御力。
 
 两级声明 + 分发时校验（实现在 `PluginService.missingPermissionsForTool()` +
 `ToolRegistry.execute()`）：
 
-- **插件级 `permissions`**：插件被授予的能力全集，管理员在插件广场审查的对象。
-- **工具级 `tools[].permissions`**：单个工具运行所需的能力。
+- **插件级 `permissions`**：插件自述会用到的能力全集，人工审查的对象。
+- **工具级 `tools[].permissions`**：单个工具自述运行所需的能力。
 - **校验规则**：分发插件工具前检查「工具所需 ⊆ 插件声明」；有所需权限未在插件级
   `permissions` 声明时**拒绝执行**，返回
   `Error: permission denied — tool 'x' requires permission(s) [...] not declared in the plugin manifest "permissions"`。
 - **v1 兼容**：工具未列入 `tools[]` 或未写 `permissions` 视为无敏感能力需求，直接放行；
   内置工具（不属于任何插件）不参与校验。
 
-> 边界：v2 校验发生在分发层（诚实声明模型），插件代码本身仍与宿主同进程运行，
-> **进程级沙箱（真正阻止未声明的文件/网络访问）是后续项**，见 docs/AI_ARCHITECTURE.md Phase 3 TODO。
+### 真实的信任边界在哪里
+
+插件 JAR 与宿主**同一个 JVM、同一个 Spring 容器、同一份权限**。`URLClassLoader` 的
+父加载器就是宿主自己，所以插件可以直接 `import com.checkba.*` 拿到 `DataSource`、
+`SystemSettingService`（**AI 供应商 API Key 存在这里**）等任意 Bean，也能读写用户
+home 下的任意文件、起子进程、改 JVM 全局状态。
+
+Java 侧没有进程内沙箱可用（`SecurityManager` 已于 JEP 411 废弃、JEP 486 在 JDK 24
+永久禁用，OpenJDK 官方给出的替代方案就是进程外隔离）。因此：
+
+**安装一个 JAR 插件 = 信任它等同于信任一个本机应用程序。** 这一点对本地手放的插件
+无法通过技术手段缓解，只能靠分发链路（签名、审核、封禁）把不可信来源挡在外面——
+见 §8 与 docs/PLUGIN_DISTRIBUTION.md。
 
 ## 4. 后端工具（backendJars）约定
 
 - 工具类需有**无参构造函数**，工具方法用 langchain4j 的 `dev.langchain4j.agent.tool.@Tool` 注解（当前宿主版本 **0.36.0**，编译时以 `provided` 作用域依赖 `langchain4j-core`，运行时由宿主提供）。
 - 工具名 = 方法名，全局唯一；与内置工具或其他插件重名时后注册的覆盖先注册的（避免与内置工具重名）。
-- JAR 由独立 `URLClassLoader` 加载（父加载器为应用 ClassLoader），依赖冲突自行规避；无法解析的类会被跳过。
+- 每个 JAR 一个 `URLClassLoader` 实例，**父加载器是宿主的应用 ClassLoader**——这是标准双亲委派，
+  不是隔离：插件能看见宿主的全部类（Spring、项目自己的 `com.checkba.*` service/repository）。
+  依赖冲突自行规避；无法解析的类会被跳过。
+- `backendJars` 的路径必须落在插件目录内（含子目录），`../` 逃逸会被拒绝并记 ERROR。
 
 ## 5. 启用 / 禁用
 
@@ -93,6 +129,22 @@ plugins/
 - **v2 起 ToolRegistry 按启停过滤**（Phase 3A）：禁用插件后其工具在三处消费点全部不可见——
   LLM 拿不到工具规格（`getAllSpecifications`）、XML 协议解析不识别（`toolNamesLongestFirst`）、
   分发返回 not found（`resolve`）；重新启用即时恢复，内置工具不受影响。
+
+### 禁用到底停掉了什么
+
+| 时机 | 行为 |
+|---|---|
+| 启动 / rescan 时已处于禁用 | **JAR 不加载**：静态初始化块与构造器都不会执行，元数据仍登记以便管理页展示与启停 |
+| 运行中禁用一个已加载的插件 | 工具立即不可见、不可分发，但**类已在 JVM 中无法卸载**——若插件在构造器里起了线程或注册了全局钩子，这些不会因禁用而消失，**需重启后端才能彻底停掉** |
+| 运行中启用一个启动时被禁的插件 | 自动补加载其 JAR（`loadJarsIfAbsent`），工具随即可用 |
+
+> 结论：禁用可以阻止**尚未加载**的插件运行，但不能撤销**已加载**插件造成的影响。
+> 处置可疑插件的正确顺序是：禁用 → 重启后端 → 从 `plugins/` 目录移除。
+
+### rescan 的限制
+
+`rescan()` 清空元数据与工具映射后全量重扫，用于**发现新装插件**。已由旧 ClassLoader
+加载的类不会卸载；替换同名 JAR 的新版本必须重启后端才能生效，否则运行的仍是旧类。
 - 启停查询走内存缓存，TTL（配置 `ai.plugins.disabled-cache-ttl-ms`，默认 5000ms）过期后从
   `system_setting` 重读：同 JVM 内启停即时生效，外部直接改库在 TTL 内收敛，工具调用高频路径不打库。
 

--- a/frontend/src/pages/plugin-market/plugin-market.vue
+++ b/frontend/src/pages/plugin-market/plugin-market.vue
@@ -111,14 +111,64 @@
           </view>
         </template>
 
-        <!-- 插件在线分发属 Phase 2（JAR 签名/沙箱安全模型另议），先给占位与本地安装指引 -->
-        <view v-else class="empty">
-          <svg class="empty-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path v-for="(d, i) in ICONS.blocks" :key="i" :d="d" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-          <text class="empty-title">插件在线分发即将上线</text>
-          <text class="empty-hint">当前可本地安装：将插件目录（含 manifest.json）放入服务端 plugins/ 目录后，点击"重新扫描"，然后到"已安装"里启用</text>
-        </view>
+        <!-- 在线插件：经平台审核并签名，安装时验签，见 docs/PLUGIN_DISTRIBUTION.md -->
+        <template v-else>
+          <view v-if="marketPluginError" class="empty">
+            <svg class="empty-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path v-for="(d, i) in ICONS.offline" :key="i" :d="d" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <text class="empty-title">在线插件广场暂不可用（离线或网络受限）</text>
+            <text class="empty-hint">{{ marketPluginError }}</text>
+          </view>
+          <view v-else-if="marketPlugins.length === 0" class="empty">
+            <svg class="empty-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path v-for="(d, i) in ICONS.blocks" :key="i" :d="d" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <text class="empty-title">{{ marketPluginLoading ? '加载中...' : '暂无在线插件' }}</text>
+            <text v-if="!marketPluginLoading" class="empty-hint">也可本地安装：把插件目录放入服务端 plugins/ 后点「重新扫描」</text>
+          </view>
+          <view v-else class="card-grid">
+            <view v-for="m in marketPlugins" :key="m.id" class="plugin-card">
+              <view class="card-header">
+                <view class="plugin-icon-wrap">
+                  <svg class="svg-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path v-for="(d, i) in ICONS.blocks" :key="i" :d="d" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </view>
+                <view class="title-block">
+                  <view class="name-row">
+                    <text class="plugin-name">{{ m.name || m.id }}</text>
+                    <text class="plugin-version" v-if="m.version">v{{ m.version }}</text>
+                    <text v-if="m.installed" class="installed-tag">已安装</text>
+                  </view>
+                  <text class="plugin-meta">作者：{{ m.authorDisplayName || m.author || '未知' }} · {{ m.downloads || 0 }} 次安装 · {{ formatSize(m.size) }}</text>
+                </view>
+                <view class="market-actions">
+                  <button
+                    v-if="!m.installed || m.updatable"
+                    class="btn-primary btn-mini"
+                    :disabled="!!pluginBusyId"
+                    @tap="installPlugin(m)"
+                  >{{ pluginBusyId === m.id ? '安装中...' : (m.updatable ? '更新' : '安装') }}</button>
+                  <button v-if="m.installed" class="btn-uninstall btn-mini" :disabled="!!pluginBusyId" @tap="uninstallPlugin(m)">卸载</button>
+                </view>
+              </view>
+
+              <text class="plugin-desc">{{ m.description || '暂无描述' }}</text>
+
+              <view class="tag-row">
+                <text v-if="m.tools && m.tools.length" class="tool-count-tag">{{ m.tools.length }} 个工具</text>
+                <text v-for="perm in m.permissions" :key="perm" class="perm-tag">{{ permissionLabel(perm) }}</text>
+                <text v-if="!m.permissions || !m.permissions.length" class="perm-tag-none">未声明敏感能力</text>
+              </view>
+            </view>
+          </view>
+
+          <view class="market-note">
+            插件与本机应用同等权限，安装前请确认来源可信。所有在线插件都经过人工审核与平台签名，
+            桌面端安装时验签；安装后默认处于停用状态，需你在「已安装」里手动启用。
+          </view>
+        </template>
       </scroll-view>
 
       <!-- ============ 已安装 tab ============ -->
@@ -250,7 +300,7 @@
 </template>
 
 <script>
-import { getPlugins, setPluginEnabled, rescanPlugins, getSkills, setSkillActivation, rescanSkills, getSkillMarket, installMarketSkill, uninstallMarketSkill } from '@/services/api.js'
+import { getPlugins, setPluginEnabled, rescanPlugins, getSkills, setSkillActivation, rescanSkills, getSkillMarket, installMarketSkill, uninstallMarketSkill, getPluginMarket, installMarketPlugin, uninstallMarketPlugin } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
 
 const PERMISSION_LABELS = {
@@ -291,6 +341,10 @@ export default {
       marketLoading: false,
       marketError: '',
       marketBusyId: '',
+      marketPlugins: [],
+      marketPluginLoading: false,
+      marketPluginError: '',
+      pluginBusyId: '',
       loading: false,
       switching: false,
       rescanning: false,
@@ -324,10 +378,73 @@ export default {
     this.loadPlugins()
     this.loadSkills()
     this.loadMarket()
+    this.loadPluginMarket()
   },
   methods: {
     permissionLabel(perm) {
       return PERMISSION_LABELS[perm] || perm
+    },
+    formatSize(bytes) {
+      if (!bytes) return '未知大小'
+      if (bytes < 1024) return bytes + ' B'
+      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
+      return (bytes / 1024 / 1024).toFixed(2) + ' MB'
+    },
+    async loadPluginMarket() {
+      this.marketPluginLoading = true
+      this.marketPluginError = ''
+      try {
+        const res = await getPluginMarket()
+        this.marketPlugins = res?.plugins || []
+      } catch (e) {
+        // 注册表不可达只在区块内提示，不影响本地插件与 Skill
+        console.warn('在线插件广场不可用:', e)
+        this.marketPluginError = e?.message || '网络不可用'
+        this.marketPlugins = []
+      } finally {
+        this.marketPluginLoading = false
+      }
+    },
+    async installPlugin(plugin) {
+      const perms = (plugin.permissions || []).map(p => this.permissionLabel(p)).join('、') || '未声明敏感能力'
+      const ok = await new Promise(resolve => {
+        uni.showModal({
+          title: '确认安装插件',
+          content: `${plugin.name || plugin.id} v${plugin.version}\n作者：${plugin.authorDisplayName || plugin.author || '未知'}\n声明能力：${perms}\n\n插件与本机应用同等权限，能读写你的文件并访问网络。安装后默认停用，需你手动启用。`,
+          confirmText: '安装',
+          cancelText: '取消',
+          success: r => resolve(r.confirm),
+          fail: () => resolve(false)
+        })
+      })
+      if (!ok) return
+
+      this.pluginBusyId = plugin.id
+      try {
+        await installMarketPlugin(plugin.id)
+        uni.showToast({ title: '已安装，请在「已安装」中启用', icon: 'none' })
+        await this.loadPlugins()
+        await this.loadPluginMarket()
+      } catch (e) {
+        console.error('安装插件失败:', e)
+        uni.showToast({ title: e?.message || '安装失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.pluginBusyId = ''
+      }
+    },
+    async uninstallPlugin(plugin) {
+      this.pluginBusyId = plugin.id
+      try {
+        await uninstallMarketPlugin(plugin.id)
+        uni.showToast({ title: '已卸载', icon: 'none' })
+        await this.loadPlugins()
+        await this.loadPluginMarket()
+      } catch (e) {
+        console.error('卸载插件失败:', e)
+        uni.showToast({ title: e?.message || '卸载失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.pluginBusyId = ''
+      }
     },
     categoryLabel(id) {
       const c = SKILL_CATEGORIES.find(c => c.id === (id || 'other'))
@@ -460,6 +577,7 @@ export default {
         })
         await this.loadPlugins()
         await this.loadSkills()
+        await this.loadPluginMarket()
       } catch (e) {
         console.error('重新扫描失败:', e)
         uni.showToast({ title: e?.message || '扫描失败（需要管理员权限）', icon: 'none' })
@@ -982,6 +1100,26 @@ $border-color: #E9ECEF;
   border-radius: 999px;
   background: rgba(230, 162, 60, 0.12);
   color: #B47D2B;
+}
+
+.perm-tag-none {
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: #F1F3F5;
+  color: $text-secondary;
+}
+
+/* 在线插件区块底部的信任提示：插件与本机应用同权限，这句不能省 */
+.market-note {
+  font-size: 12px;
+  line-height: 1.7;
+  color: $text-secondary;
+  background: rgba(230, 162, 60, 0.08);
+  border: 1px solid rgba(230, 162, 60, 0.25);
+  border-radius: 10px;
+  padding: 12px 16px;
+  margin: 0 4px 32px;
 }
 
 .trigger-tag {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -420,6 +420,34 @@ export function setPluginEnabled(pluginId, enabled) {
   });
 }
 
+// 在线插件广场：拉取官网注册表列表（仅含已审核签名的插件）
+export function getPluginMarket() {
+  return request({
+    url: '/api/plugins/market/list',
+    method: 'GET'
+  });
+}
+
+// 安装 / 更新在线插件（仅管理员）。后端会验签 + 逐文件校验哈希，装后默认停用。
+export function installMarketPlugin(pluginId) {
+  return request({
+    url: '/api/plugins/market/install',
+    method: 'POST',
+    data: { id: pluginId },
+    header: { 'Content-Type': 'application/json' },
+  });
+}
+
+// 卸载在线安装的插件（仅管理员）
+export function uninstallMarketPlugin(pluginId) {
+  return request({
+    url: '/api/plugins/market/uninstall',
+    method: 'POST',
+    data: { id: pluginId },
+    header: { 'Content-Type': 'application/json' },
+  });
+}
+
 // 重新扫描 plugins/ 目录（仅管理员）
 export function rescanPlugins() {
   return request({


### PR DESCRIPTION
## 背景

上一轮讨论确定了方向：**学 VS Code 的路子，把安全前移到分发链路**。原因是运行时根本拦不住——插件 JAR 与宿主同 JVM 同权限，而 Java 的 `SecurityManager` 已于 [JEP 486](https://openjdk.org/jeps/486) 在 JDK 24 永久禁用，OpenJDK 官方给出的替代方案就是进程外隔离。VS Code 与 JetBrains 都明确不做运行时沙箱，靠的是签名 + 审核 + 封禁。

配套官网 PR：aiworkdeck_website `feat/plugin-distribution`（162a5d1 + e42949e）

设计文档：`docs/PLUGIN_DISTRIBUTION.md`

## 一、先补三个加载期漏洞（28e175ec）

这三个与在线分发无关，**本地手放插件的场景现在就会踩**：

1. **禁用的插件仍会被加载**。此前禁用只是把工具从 LLM 可见列表摘掉，JAR 早已 `loadClass`、静态初始化块与无参构造器都跑过了。管理员点「禁用」的预期是「别运行它」，必须在加载前拦住。现在元数据仍登记（管理页照常展示与启停），但不碰 JAR；运行中启用一个启动时被禁的插件会自动补加载。
2. **`backendJars` 路径逃逸**。manifest 由作者提供，`"../../evil.jar"` 能指到插件目录外。新增 `resolveBackendJar()` 用 canonical path 校验（同时挡符号链接）。
3. `pluginSkillDirs` 改 `CopyOnWriteArrayList`——同类集合都因 rescan clear+重填用了并发安全实现，这处是遗漏。

`PLUGIN_SPEC.md` 同步修正了会让读者高估安全性的措辞：`permissions` 从「被授予」改为「自行声明」并加显式警告，「独立 ClassLoader」点明父加载器是宿主，补充禁用语义表、rescan 限制、桌面版插件目录落在用户可写的 `~/.aiworkdeck/plugins/`。

## 二、在线安装与验签（b3d5e984）

`PluginMarketService` 按 `PLUGIN_DISTRIBUTION.md` §7：

- 先拉 bundle 用内置 Ed25519 公钥验签，**验签失败在下载任何文件之前中止**；
- 逐文件下载并比对 SHA-256，任一不符即中止；
- 全部通过后先写临时目录再原子移动，避免半成品被扫描到；
- 清单里的相对路径同样做逃逸校验（注册表本身也可能被攻陷）；
- 装完先 `markDisabledBeforeLoad` 再 rescan——**新插件默认禁用**，配合第一部分的「禁用即不加载」，用户点启用之前插件代码一行都不会执行。

`PluginRevocationService` 启动时与每 24 小时同步平台封禁列表，命中的已安装插件强制禁用。封禁不可撤销（`setEnabled` 拒绝启用被封禁插件，只允许卸载），但不自动删文件——避免误封导致用户数据丢失。

未配置 `ai.plugins.registry-public-key` 时拒绝一切在线安装（默认留空，需随版本发布填入平台公钥）。

## 三、广场插件分区（3779c6d2）

从占位换成真实列表，安装前弹确认框列出插件名、作者、声明能力，并写明「插件与本机应用同等权限，能读写你的文件并访问网络。安装后默认停用」。注册表不可达时只在本区块内降级提示。

## 关于扫描能力（在官网侧）

官网的静态扫描做 class 常量池字符串匹配，覆盖进程执行、TLS 篡改、反射突破、宿主内部访问、网络、文件、反序列化、原生库，另检出硬编码 IP 与明文 HTTP。

最有价值的是**交叉验证**：把实际引用与 manifest 的 `permissions` 自述比对，声明与行为不符（如未声明 `network` 却引用 `Socket`）会被标出。这让权限声明第一次具备约束力——它不再只是作者的自说自话，而是审核时的对照基准。

## 验证

- 后端全量 **301 tests** 通过；新增 14 个覆盖：路径逃逸拒绝、目录内 JAR 放行、禁用插件登记但不注册工具、验签正误、files 键序无关、未配公钥拒装、非法 id、哈希不符中止且不落盘、验签失败不下载、封禁强制禁用且不可重新启用、semver 比较。
- **跨语言签名对拍**：用官网 Node crypto 签发的签名，桌面端 JDK 验签通过。canonical JSON 差一个字节就会失败，这条必须实测而非推断；用例以 `-Dcrosscheck.file` 开关控制，CI 无该文件时自动跳过。
- 官网侧端到端：用 JDK 21 编译了两个测试插件（一个诚实、一个声明零权限却读文件并向硬编码 IP 明文外传），可疑那个命中三条规则 + 两条交叉验证；审核通过后公钥验签通过、篡改版本号验签失败；驳回与封禁的插件 bundle/file 均 404；路径白名单挡住 `../` 与编码绕过。
- `check:emits` 与 `build:h5` 通过；浏览器验证插件分区渲染、已安装/可更新标记、权限标签、注册表不可达的降级路径。

## 部署前须做

1. 生成 Ed25519 密钥对，私钥写入官网服务器 `AWD_PLUGIN_SIGNING_KEY`，公钥填入 `application.yml` 的 `ai.plugins.registry-public-key`（未配置时在线安装一律拒绝，属安全默认）。
2. 官网 PR 部署后 registry 才有 `/api/registry/plugins` 系列接口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)