### PR TITLE
feat(plugin): 配置生产签名公钥，在线插件安装链路启用

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -162,7 +162,14 @@ ai:
     # 平台签名公钥（Ed25519 SPKI PEM）。安装在线插件时用它验签，
     # 留空则拒绝一切在线安装。私钥仅存在于官网服务器的 AWD_PLUGIN_SIGNING_KEY。
     # 换密钥需同步更新此处并随版本发布，见 docs/PLUGIN_DISTRIBUTION.md §5。
-    registry-public-key: ""
+    #
+    # 公钥是公开信息，硬编码在客户端是标准做法（等同 CA 根证书内置）：
+    # 客户端必须在离线、未登录、注册表被劫持的情况下也能独立判断签名真伪，
+    # 所以它不能从网络获取。密钥对生成于 2026-07-27。
+    registry-public-key: |
+      -----BEGIN PUBLIC KEY-----
+      MCowBQYDK2VwAyEAjAbnyl44SiQF/CTyn59/uHAXCeRTEI0h0Bn5HEv7T4Y=
+      -----END PUBLIC KEY-----
 
   # Skill 体系配置（对应 SkillProperties，规范见 docs/SKILL_SPEC.md）
   skills:

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -233,6 +233,47 @@ class PluginMarketServiceTest {
         return o.toString();
     }
 
+    // ==== 生产公钥回归 ====
+
+    /**
+     * application.yml 里配置的生产公钥，与官网服务器 AWD_PLUGIN_SIGNING_KEY 成对。
+     * 上面那些用例用临时密钥对验的是算法与 canonical 形式；这一条钉的是
+     * "线上这把公钥确实能验开线上私钥签出来的名"——配错或轮换失误时直接红。
+     */
+    private static final String PROD_PUBLIC_KEY = """
+            -----BEGIN PUBLIC KEY-----
+            MCowBQYDK2VwAyEAjAbnyl44SiQF/CTyn59/uHAXCeRTEI0h0Bn5HEv7T4Y=
+            -----END PUBLIC KEY-----
+            """;
+
+    /** 由配对私钥用 Node 的 crypto.sign 对下方载荷签出，固化在此做跨语言对拍 */
+    private static final String PROD_SIGNATURE =
+            "XXoQuS5ogi3F/uhnSZtB0gPgiWCAjFmgqAVRSgyr+0GONi825hoo+8d2fPzBl0OSOdqAF2mGzDJhLnOryg3SCg==";
+
+    @Test
+    @DisplayName("生产公钥能验开官网私钥签出的真实签名（跨语言对拍）")
+    void productionKeyVerifiesRealSignature() throws Exception {
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", "a".repeat(64));
+        files.put("tool.jar", "b".repeat(64));
+
+        PluginMarketService svc = service(PROD_PUBLIC_KEY);
+        assertTrue(
+                svc.verifySignature("demo-plugin", "1.0.0", "2026-07-27T00:00:00.000Z", files, PROD_SIGNATURE),
+                "application.yml 的公钥与官网签名私钥不配对——检查是否漏配或轮换未同步");
+
+        // 同一把公钥必须拒绝被篡改的载荷，排除"恒真"式的假通过
+        assertFalse(svc.verifySignature("evil-plugin", "1.0.0", "2026-07-27T00:00:00.000Z", files, PROD_SIGNATURE));
+    }
+
+    @Test
+    @DisplayName("application.yml 中确实配置了公钥（防止合并时被清空）")
+    void applicationYmlHasPublicKeyConfigured() throws Exception {
+        String yml = Files.readString(Path.of("src/main/resources/application.yml"), StandardCharsets.UTF_8);
+        assertTrue(yml.contains("BEGIN PUBLIC KEY"),
+                "ai.plugins.registry-public-key 为空会让所有在线插件安装被拒绝");
+    }
+
     /** 打桩 HTTP：bundle 返回给定清单，file 按路径返回对应内容 */
     private PluginMarketService stubbed(String pubKey, Map<String, String> files, String sig,
                                         byte[] manifestBytes, byte[] jarBytes) {


### PR DESCRIPTION
## 改动

把 2026-07-27 生成的 Ed25519 公钥填进 `ai.plugins.registry-public-key`，与官网服务器的 `AWD_PLUGIN_SIGNING_KEY` 成对。此前留空是安全默认（客户端拒绝一切在线安装），配上之后 #202 建立的分发链路才真正通。

**公钥硬编码在客户端是标准做法**，等同 CA 根证书内置：客户端必须在离线、未登录、注册表被劫持的情况下也能独立判断签名真伪，所以它不能从网络获取。公钥本身是公开信息，泄露不构成风险——能签名的只有私钥。

## 两个回归

- **跨语言对拍**：用这把生产公钥验证一条由配对私钥（Node `crypto.sign`）签出的真实签名。公钥配错或将来密钥轮换没同步，CI 会直接红。同时断言它拒绝被篡改的载荷，排除「恒真」式的假通过。
- **防清空**：断言 `application.yml` 里公钥非空。这个值被合并冲突清回空串的话，所有在线安装会静默失败且不容易发现。

## 验证

`PluginMarketServiceTest` 12 tests 全过（新增 2 个）。

## 上线还需

官网侧要把配对私钥写进服务器 `.env.local` 的 `AWD_PLUGIN_SIGNING_KEY` 并重新部署（`npm install` + `pm2 restart --update-env`），后台的「通过并签名」才可用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)