### PR TITLE
docs(eng-infra): 补记 DMG 安装窗口视觉的坐标契约与背景图源

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -19,6 +19,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 2. `git tag v<ver> && git push origin v<ver>` → 触发 desktop-build 双平台。auto 模式下 tag 推送不被分支保护拦；可用 Monitor 等 PR 合并后自动打 tag（v0.8.0 配方）。
 3. 产物：mac 仅 dmg（**arm64 only**，已放弃 Intel）；win 仅 nsis exe（x64）。electron-builder 配置在 desktop/package.json "build" 字段（appId com.aiworkdeck.desktop、extraResources 打入 frontend/dist、backend.jar、jre、python、pysvc.tar.gz+meta；notarize teamId X9B97KVA84；entitlements desktop/build/entitlements.mac.plist）。
 4. 签名抖动：Apple 时间戳抖动 = rerun 即可（连挂两次也 rerun）；公证轮询抖动排查见 ci-macos 记录。
+5. DMG 安装窗口视觉（PR#204）：`build.dmg` 里的 `contents` 坐标是**图标中心、原点在窗口内容区左上角（不含标题栏）**；窗口尺寸由背景图 1x 像素尺寸决定（660x420），所以没写 `window`。背景图 `desktop/build/background.png` + `background@2x.png` 由 electron-builder 自动合成 hidpi TIFF，源文件是 `desktop/build/dmg-background.html`（顶部注释有 headless Chrome 重新生成命令）。改图标落位必须同步改 HTML 里的光晕/箭头位置，否则错位。
 
 ## 测试命令总表
 


### PR DESCRIPTION
按 CLAUDE.md 的维护规则补 #204 漏掉的领域文档更新：`.claude/agents/eng-infra.md` 的发版章节加一条，写明 `build.dmg.contents` 的坐标语义（图标中心 / 原点在窗口内容区左上角、不含标题栏）、窗口尺寸由背景图 1x 像素尺寸决定、`background@2x.png` 由 electron-builder 自动合成 hidpi TIFF，以及背景图源文件 `desktop/build/dmg-background.html` 的位置和"改落位要同步改 HTML"这个地雷。

纯文档改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)