### PR TITLE
docs(skill): 补记在线 Skill 广场的三个 market 端点与 registry 契约

### DIFF
--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -21,7 +21,7 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
 - `backend/src/main/java/com/checkba/controller/ai/PluginController.java` — /api/plugins：list、启停、rescan、market/list|install|uninstall、market/sync-revoked。
 - `backend/src/main/java/com/checkba/service/ai/PluginMarketService.java` — **在线插件安装与验签**（Ed25519 公钥内置，逐文件 SHA-256 校验，临时目录+原子移动，装后默认禁用）。
 - `backend/src/main/java/com/checkba/service/ai/PluginRevocationService.java` — 平台封禁列表同步（启动时 + 每 24h），命中强制禁用且不可重新启用。
-- `backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java` — 在线广场客户端（**市场契约的权威定义在此类 Javadoc**，SKILL_SPEC.md §8 未含 market 端点）。
+- `backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java` — 在线广场客户端。市场契约见 `docs/SKILL_SPEC.md` §8 / §8.1（端点表、registry 与 bundle 的字段契约、id 正则与卸载守卫），实现细节以此类 Javadoc 为准。
 - `backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java` — 本地扫描/启停/rescan。
 - `backend/src/main/java/com/checkba/service/ai/skill/SkillProperties.java` — ai.skills.*（dir/base-tools/registry-url/ttl）；registry-url 默认 `https://www.aiworkdeck.com/api/registry/skills`（application.yml ~:163）。
 

--- a/docs/SKILL_SPEC.md
+++ b/docs/SKILL_SPEC.md
@@ -130,8 +130,25 @@ ai:
 | POST | `/api/skills/{id}/disable` | admin | 禁用 skill |
 | POST | `/api/skills/{id}/activation` | admin | 设置生效方式，body `{"mode":"auto"\|"manual"\|"disabled"}` |
 | POST | `/api/skills/rescan` | admin | 重扫 skills/ 目录与插件携带的 skill，返回 `{ code, skillCount }` |
+| GET | `/api/skills/market/list` | 登录 | 在线 Skill 广场列表（官网 registry + 本地 `installed` 标记）；registry 不可达返回 `{code:1, message}` |
+| POST | `/api/skills/market/install` | admin | body `{id}`。下载 bundle 落盘 `skills/<id>/` 后 rescan，重装即更新 |
+| POST | `/api/skills/market/uninstall` | admin | body `{id}`。仅可卸载 `ai.skills.dir` 直属目录；插件携带的 skill 拒绝 |
 
-管理接口鉴权与 PluginController 一致：`X-Session-Id` 请求头 → session 用户名为 `admin`。
+管理接口鉴权与 PluginController 一致：`X-Session-Id` 请求头 → `AdminAccessService.isAdmin`
+（云端=用户名 admin；桌面单机 `security.admin.allow-all-users=true` 时全员管理员。
+PR#146 起 SkillController 走此唯一出口，PluginController 待对齐）。
+
+## 8.1 在线 Skill 广场（官网 registry，PR#146）
+
+官网（仓库 `zeweihan/aiworkdeck_website`）提供公开注册表，桌面端 `SkillMarketService` 消费，
+配置键 `ai.skills.registry-url`（默认 `https://www.aiworkdeck.com/api/registry/skills`）：
+
+- `GET {registry-url}`：数组，元素含 `id/name/description/icon/version/author/authorDisplayName/triggers/allowedTools/downloads/updatedAt/homepage`；
+- `GET {registry-url}/{id}/bundle`：`{ id, version, files: { "skill.yml": "...", "prompt.md": "..." } }`，
+  下载即计数。安装=两文件落盘 `skills/<id>/` + rescan；skill.yml 标量为 JSON 编码（YAML 1.2 子集，SnakeYAML 兼容）。
+
+安全：skill id 校验 `^[a-z0-9][a-z0-9-]{1,49}$`；bundle 只落盘 `skill.yml`/`prompt.md` 两个白名单文件名；
+卸载走 canonical path 守卫。官网侧用户体系与提交流程见该仓库 `lib/skills-store.ts`、`app/api/registry/`。
 
 ## 9. 内置 Skill
 


### PR DESCRIPTION
## 起因

同步本地 master 时发现工作区躺着一笔从未提交的 `docs/SKILL_SPEC.md` 改动。核对后确认：这是 **PR#146（在线 Skill 广场）当时该写进规范但漏掉的部分**——`docs/` 在 .gitignore 里，需要 `git add -f`，当时忘了，于是在工作区躺到现在。远端 master 里确实没有这段。

## 改了什么

`docs/SKILL_SPEC.md`：

- **§8 表补三行**：`GET /api/skills/market/list`（登录）、`POST /api/skills/market/install`、`POST /api/skills/market/uninstall`（admin）；
- **鉴权说明订正**：改为 `AdminAccessService.isAdmin` 唯一出口（云端 = 用户名 admin；桌面单机 `security.admin.allow-all-users=true` 时全员管理员）。原文写的是"session 用户名为 admin"，PR#146 起已不准确；
- **新增 §8.1「在线 Skill 广场」**：registry 列表与 bundle 两个端点的字段契约、安装 = 两个白名单文件（`skill.yml` / `prompt.md`）落盘 + rescan、id 正则 `^[a-z0-9][a-z0-9-]{1,49}$`、卸载走 canonical path 守卫。

`.claude/agents/plugin-marketplace.md`：原本写着"市场契约的权威定义在 SkillMarketService 的 Javadoc，SKILL_SPEC.md §8 未含 market 端点"——补齐后这句不再成立，改为指向 §8/§8.1，实现细节仍以 Javadoc 为准。

## 核对

内容与代码逐条对过：`SkillController`（端点与鉴权注解）、`SkillMarketService`（registry / bundle 契约、`BUNDLE_FILES` 白名单、`requireValidId` 正则、卸载守卫）、`SkillProperties`（`registry-url` 默认值）。纯文档，无代码改动。

同步 master 时这个文件与 #198/#186 对 §4/§7 的改动自动合并成功，无冲突标记，两侧内容均在。

🤖 Generated with [Claude Code](https://claude.com/claude-code)