### PR TITLE
docs(example): 示例插件移除 emoji，补官网提交流程指引

### DIFF
--- a/examples/hello-plugin/README.md
+++ b/examples/hello-plugin/README.md
@@ -48,3 +48,14 @@ cp manifest.json target/hello-plugin-1.0.0.jar <后端工作目录>/plugins/hell
 2. 在 `permissions` 中如实声明需要的能力（`file_read` / `file_write` / `network` / `editor`）；
 3. 修改/新增带 `@Tool` 注解的工具类（无参构造、方法名唯一）；
 4. `pom.xml` 的 `artifactId/version` 与 `manifest.json` 的 `backendJars` 文件名保持一致。
+
+## 发布到插件广场
+
+本示例是仓库内的最小参考。要把插件发到线上供他人安装，走官网的提交与审核流程：
+
+- 开发指南（含打包、审核标准、驳回情形）：<https://www.aiworkdeck.com/zh/plugins/develop>
+- 模板工程下载：<https://www.aiworkdeck.com/api/plugins/template>
+- 提交入口：<https://www.aiworkdeck.com/zh/plugins/submit>
+
+官网那份模板与本目录同源，内容有出入时以 `aiworkdeckweb/lib/plugin-template.ts` 为准
+（外部开发者拿不到本私有仓库，只能看到官网那份）。

--- a/examples/hello-plugin/manifest.json
+++ b/examples/hello-plugin/manifest.json
@@ -3,13 +3,20 @@
   "name": "Hello 示例插件",
   "version": "1.0.0",
   "description": "演示插件规范 v1 的最小示例：提供文本回显与字数统计两个 AI 工具。",
-  "icon": "🔌",
   "author": "AI Workdeck",
   "homepage": "https://github.com/zeweihan/checkba_cloud",
   "permissions": [],
   "tools": [
-    { "name": "helloEcho", "description": "原样回显输入文本，用于验证插件链路" },
-    { "name": "helloWordCount", "description": "统计输入文本的字符数与词数" }
+    {
+      "name": "helloEcho",
+      "description": "原样回显输入文本，用于验证插件链路"
+    },
+    {
+      "name": "helloWordCount",
+      "description": "统计输入文本的字符数与词数"
+    }
   ],
-  "backendJars": ["hello-plugin-1.0.0.jar"]
+  "backendJars": [
+    "hello-plugin-1.0.0.jar"
+  ]
 }


### PR DESCRIPTION
配合官网新增的插件开发指南（aiworkdeck_website#9）。

- `manifest.json` 的 `icon` 用了 emoji，与全站禁 emoji 的约定冲突。该字段可选，直接删掉（前端已有线性图标兜底）。
- README 补上官网开发指南、模板下载与提交入口，并说明外部开发者只能看到官网那份模板，两边有出入时以 `aiworkdeckweb/lib/plugin-template.ts` 为准——本仓库是私有的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)