### PR TITLE
fix(ai): 活跃文档提醒改挂用户消息末位——system prompt 里的声明被弱模型无视

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -58,6 +58,12 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 - 新增工具不要改编排器（Phase 1 五条不变式）：实现 AgentToolComponent + @Tool + @ToolMeta 即自动注册；显示名要同步 toolDisplayNames.js。
 - SubAgentTools 注入必须 @Lazy（启动死环）。
 - 30 秒覆盖启发式曾致历史丢回复，现为轮次级 upsert（PR#153）——改历史持久化先读该记录。
+- **只写进 system prompt 的行为约束会被弱模型稳定无视**：活跃文档声明（连正文一起注入）曾放在
+  system prompt，真机日志实证注入后 6 秒模型照样调 doc_list_project_files 重新发现文档（PR#187 加强
+  措辞无效）。现改为在**用户消息尾部**追加 `[系统提醒]`（ContextAssemblerService.activeDocumentReminder，
+  PR#208）——末位是注意力最高的位置。**新增"必须/禁止"类约束一律挂末位，不要只写 system prompt。**
+- 排障需要后端日志时注意：桌面端复用已在跑的后端进程时不会重建日志管道，`~/.aiworkdeck/logs/backend.log`
+  会停止更新（表现为日志停在几天前）。要拿新日志先彻底退出 app 让后端随之重启。
 - 防走神注入/todo_write 进度卡/文档检查点机制见 PR#161/162。
 - RunGuard 阈值改动影响回放评测断言。
 

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -366,11 +366,28 @@ public class ContextAssemblerService {
         messages.addAll(historyMessages);
 
         // 4. Add Current User Prompt
-        messages.add(dev.langchain4j.data.message.UserMessage.from(userPrompt));
+        // 活跃文档提醒挂在**用户消息尾部**而非只留在 system prompt：system prompt 里的同类
+        // 声明被弱模型（如 DeepSeek Flash）稳定无视——实测注入了正文仍先调 doc_list_project_files
+        // 重新发现文档。末位消息是注意力最高的位置，这里再说一次才真正生效。
+        messages.add(dev.langchain4j.data.message.UserMessage.from(
+                userPrompt + activeDocumentReminder(activeContext)));
 
         return messages;
     }
     
+    /**
+     * 活跃文档的末位提醒（拼在用户消息尾部）。无活跃文档时返回空串。
+     */
+    private String activeDocumentReminder(com.checkba.controller.ai.AiAgentController.ContextItem activeContext) {
+        if (activeContext == null || activeContext.getId() == null || activeContext.getId().isEmpty()) {
+            return "";
+        }
+        return "\n\n[系统提醒] 编辑器中当前已打开文档《" + activeContext.getName() + "》（id="
+                + activeContext.getId() + "），其正文见 system prompt 的 <active_document>。"
+                + "用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——"
+                + "直接调用 doc_* 工具操作，**禁止**再调 doc_list_project_files 或 doc_open_file 去重新发现或打开它。";
+    }
+
     /**
      * Determines the current phase based on plan and task list state.
      * - CHAT: No plan, no task list (simple conversation)

--- a/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -60,11 +61,20 @@ class ContextAssemblerServiceTest {
                 new AiContextProperties(), skillRouter, memoryManager, contextCompressor);
     }
 
-    private String assembleSystemText(AiAgentController.ContextItem activeContext) {
-        List<ChatMessage> messages = assembler.assemble(
+    private List<ChatMessage> assembleMessages(AiAgentController.ContextItem activeContext) {
+        return assembler.assemble(
                 "conv-1", "帮我修订一下", null, activeContext,
                 null, null, "88", AgentMode.AGENT, 1L, null);
-        return ((SystemMessage) messages.get(0)).text();
+    }
+
+    private String assembleSystemText(AiAgentController.ContextItem activeContext) {
+        return ((SystemMessage) assembleMessages(activeContext).get(0)).text();
+    }
+
+    /** 末位消息（用户消息）的文本——注意力最高的位置。 */
+    private String assembleLastUserText(AiAgentController.ContextItem activeContext) {
+        List<ChatMessage> messages = assembleMessages(activeContext);
+        return ((dev.langchain4j.data.message.UserMessage) messages.get(messages.size() - 1)).singleText();
     }
 
     private static AiAgentController.ContextItem activeDoc() {
@@ -108,5 +118,39 @@ class ContextAssemblerServiceTest {
 
         assertFalse(systemText.contains("<active_document id="), "无活跃文档不应出现注入段");
         assertFalse(systemText.contains("# Active Document"), "无活跃文档不应出现注入段标题");
+    }
+
+    // ==== 末位提醒 ====
+    // 真机日志实证：system prompt 里的活跃文档声明（连正文一起注入）会被弱模型稳定无视，
+    // 注入后 6 秒仍调 doc_list_project_files 重新发现文档。末位消息是注意力最高的位置。
+
+    @Test
+    @DisplayName("活跃文档提醒挂在用户消息尾部，且点名禁用 list/open 两个工具")
+    void activeDocumentReminderRidesOnLastUserMessage() {
+        when(legalTools.read_document("123")).thenReturn("第一条 合作范围……");
+
+        String lastUser = assembleLastUserText(activeDoc());
+
+        assertTrue(lastUser.startsWith("帮我修订一下"), "用户原话必须在前，提醒只作为尾部追加");
+        assertTrue(lastUser.contains("[系统提醒]"), "应沿用既有系统提醒惯例");
+        assertTrue(lastUser.contains("合作框架协议.docx"), "提醒里应点名当前文档");
+        assertTrue(lastUser.contains("doc_list_project_files"), "应点名禁用 doc_list_project_files");
+        assertTrue(lastUser.contains("doc_open_file"), "应点名禁用 doc_open_file");
+    }
+
+    @Test
+    @DisplayName("正文读取失败也要挂末位提醒——模型至少知道该操作哪个文档")
+    void reminderPresentEvenWhenContentUnreadable() {
+        when(legalTools.read_document("123")).thenReturn(null);
+
+        String lastUser = assembleLastUserText(activeDoc());
+
+        assertTrue(lastUser.contains("合作框架协议.docx"), "正文读不到也应保留提醒");
+    }
+
+    @Test
+    @DisplayName("无活跃文档时用户消息保持原样，不夹带提醒")
+    void noReminderWhenNoActiveContext() {
+        assertEquals("帮我修订一下", assembleLastUserText(null), "无活跃文档时用户消息不应被改写");
     }
 }


### PR DESCRIPTION
## 真机实证：PR#187 的修复方向错了

用户在 v0.8.0（已确认安装包内的 backend.jar 和前端产物都含 PR#187 的代码）上复现：开着 newdocument.docx 问"这个写了什么？"，模型答"可能是指当前项目中的文件，我需要先查看项目中有哪些文件"，然后调 `doc_list_project_files`。

翻 `~/.aiworkdeck/logs/backend.log` 拿到决定性证据：

```
10:03:57  [Context] Injecting active document   <- activeContext 到了后端、注入了、连正文一起注入
10:04:04  Tool: doc_list_project_files          <- 6 秒后模型照样去列文件
```

所以**从来不是"识别不到上下文"**——上下文一直都在。是模型无视了 system prompt 里的文字约束。PR#187 把那段措辞写得更强硬，本质还是同一个办法，自然还是无效。

## 改法

把约束从 system prompt 深处移到**用户消息尾部**，沿用编排器既有的 `[系统提醒]` 惯例：

```
帮我修订一下

[系统提醒] 编辑器中当前已打开文档《合作框架协议.docx》（id=123），其正文见 system prompt
的 <active_document>。用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——
直接调用 doc_* 工具操作，**禁止**再调 doc_list_project_files 或 doc_open_file 去重新发现或打开它。
```

末位消息是注意力最高的位置。system prompt 里的 `<active_document>` 正文注入**保留不动**——那部分负责提供内容，末位提醒负责提供行为约束。

## 文档同步

`.claude/agents/ai-chat.md` 地雷清单加两条：
1. 新增"必须/禁止"类约束一律挂末位，不要只写 system prompt；
2. 桌面端复用已在跑的后端进程时不重建日志管道，`backend.log` 会停更（本次排障差点被这个坑挡住——日志停在 4 天前，一度以为后端没在跑）。

## 验证

后端全量 `mvn test`（JDK 21）：**306 tests, 0 failures**，新增 3 个断言覆盖末位提醒（用户原话在前、点名文档、点名禁用两个工具、无活跃文档时不改写用户消息）。

## 局限（重要）

**这仍是提示词层面的改进，只在单测层验证了消息结构，没有对真实模型做端到端验证。** 上一轮就是栽在"改完提示词就宣布修好"，这次明说：需要重新打包后在真机复测"开着文档问这个写了什么"才算数。如果末位提醒对 DeepSeek Flash 仍然无效，下一步就得上确定性手段（activeContext 存在时从工具清单里摘掉这两个工具，或拦截其调用直接返回重定向结果）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)