### PR TITLE
fix(ai): 活跃文档确定性兜底——分发层拦截，不再指望模型自觉

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -61,7 +61,10 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 - **只写进 system prompt 的行为约束会被弱模型稳定无视**：活跃文档声明（连正文一起注入）曾放在
   system prompt，真机日志实证注入后 6 秒模型照样调 doc_list_project_files 重新发现文档（PR#187 加强
   措辞无效）。现改为在**用户消息尾部**追加 `[系统提醒]`（ContextAssemblerService.activeDocumentReminder，
-  PR#208）——末位是注意力最高的位置。**新增"必须/禁止"类约束一律挂末位，不要只写 system prompt。**
+  PR#209）——末位是注意力最高的位置。**新增"必须/禁止"类约束一律挂末位，不要只写 system prompt。**
+  末位提醒仍是概率性的，确定性兜底在分发层：`dispatchTool` 短路"打开活跃文档本身"的 doc_open_file、
+  给 doc_list_project_files 结果钉活跃文档提示（`activeDocOpenShortCircuit` / `appendActiveDocNotice`，
+  PR#210）。**跨文档场景不拦截**——改这两个 helper 前先确认别把"对比另一份合同"之类的正常流程堵死。
 - 排障需要后端日志时注意：桌面端复用已在跑的后端进程时不会重建日志管道，`~/.aiworkdeck/logs/backend.log`
   会停止更新（表现为日志停在几天前）。要拿新日志先彻底退出 app 让后端随之重启。
 - 防走神注入/todo_write 进度卡/文档检查点机制见 PR#161/162。

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -50,6 +50,8 @@ public class AgentOrchestrator {
         int consecutiveFailures;
         // 当前活跃文档 ID（来自 activeContext 或 doc_open_file），用于修改前自动创建检查点
         Long activeFileId;
+        // 活跃文档名（仅用于给模型的反馈文案）
+        String activeFileName;
     }
 
     // 取消状态管理：存储被取消的会话ID
@@ -170,10 +172,30 @@ public class AgentOrchestrator {
             }
         }
 
+        // 活跃文档确定性兜底：提示词层面的约束对弱模型不可靠（system prompt 声明与末位提醒
+        // 都被无视过），这里在分发层直接拦截，不再指望模型自觉。
+        if (guard != null && guard.activeFileId != null && "doc_open_file".equals(toolName)) {
+            String shortCircuit = activeDocOpenShortCircuit(
+                    guard.activeFileId, guard.activeFileName, extractArg(argsJson, "fileId"));
+            if (shortCircuit != null) {
+                log.info("[ActiveDoc] 短路 doc_open_file：目标就是已打开的活跃文档 id={}", guard.activeFileId);
+                return new ToolRegistry.ToolResult(
+                        shortCircuit, toolRegistry.resolve(toolName).orElse(null), true);
+            }
+        }
+
         com.checkba.service.ai.tools.ToolContext ctx =
                 new com.checkba.service.ai.tools.ToolContext(projectId, conversationId, userId, modelId);
         ToolRegistry.ToolResult result = toolRegistry.execute(toolName, argsJson, ctx);
         applyToolSideEffects(result, argsJson, conversationId);
+
+        // 模型仍去列文件时，把活跃文档钉在结果里，让它下一轮自己纠回来（不阻断跨文档场景）
+        if (guard != null && guard.activeFileId != null
+                && "doc_list_project_files".equals(toolName) && result.success()) {
+            result = new ToolRegistry.ToolResult(
+                    appendActiveDocNotice(result.output(), guard.activeFileId, guard.activeFileName),
+                    result.tool(), result.found());
+        }
 
         // 跟踪活跃文档：模型中途打开新文档时，后续检查点跟着切换
         if (guard != null && "doc_open_file".equals(toolName)) {
@@ -183,6 +205,42 @@ public class AgentOrchestrator {
             } catch (Exception ignore) { /* fileId 非数字时保持原值 */ }
         }
         return result;
+    }
+
+    /**
+     * doc_open_file 打的就是当前已打开的活跃文档时，返回给模型的短路反馈；否则返回 null（正常执行）。
+     *
+     * <p>省掉一整轮「SSE 下发打开指令 → 等前端回执」的往返。跨文档场景（requestedFileId 指向别的
+     * 文档）不受影响，照常执行。
+     */
+    static String activeDocOpenShortCircuit(Long activeFileId, String activeFileName, String requestedFileId) {
+        if (activeFileId == null || requestedFileId == null || requestedFileId.isBlank()) {
+            return null;
+        }
+        try {
+            if (!activeFileId.equals(Long.parseLong(requestedFileId.trim()))) {
+                return null;
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        String name = (activeFileName == null || activeFileName.isBlank()) ? "该文档" : "《" + activeFileName + "》";
+        return "{\"status\":\"success\",\"alreadyOpen\":true,\"message\":\"" + name
+                + "（id=" + activeFileId + "）本来就在编辑器中打开着，无需打开。"
+                + "请直接调用 doc_* 工具对它操作，不要再调 doc_open_file 或 doc_list_project_files。\"}";
+    }
+
+    /**
+     * doc_list_project_files 的结果尾部钉上活跃文档提示，让走神的模型下一轮自己纠回来。
+     */
+    static String appendActiveDocNotice(String listOutput, Long activeFileId, String activeFileName) {
+        if (activeFileId == null) {
+            return listOutput;
+        }
+        String name = (activeFileName == null || activeFileName.isBlank()) ? "当前文档" : "《" + activeFileName + "》";
+        return (listOutput == null ? "" : listOutput)
+                + "\n\n[系统提醒] 用户此刻打开的是 " + name + "（id=" + activeFileId + "）。"
+                + "若本次任务针对的就是它，直接用 doc_* 工具操作即可，不要再调 doc_open_file。";
     }
 
     /**
@@ -298,6 +356,7 @@ public class AgentOrchestrator {
             if (request.getActiveContext() != null && request.getActiveContext().getId() != null) {
                 try {
                     guard.activeFileId = Long.parseLong(request.getActiveContext().getId().trim());
+                    guard.activeFileName = request.getActiveContext().getName();
                 } catch (NumberFormatException ignore) { /* 非数字 ID（如临时文件）不做检查点 */ }
             }
             runLoop(model, messages, conversationId, projectId, userId, request.getModel(), 0, executionLog, agentMode, guard);

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorActiveDocTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorActiveDocTest.java
@@ -1,0 +1,84 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 活跃文档的确定性兜底（分发层拦截）。
+ *
+ * <p>背景：提示词层面的约束对弱模型不可靠——system prompt 里的 &lt;active_document&gt; 声明
+ * （PR#187）和用户消息末位提醒（PR#209）都被无视过，真机日志实证注入后 6 秒仍调
+ * doc_list_project_files。这两个 helper 在工具分发层兜底，不依赖模型自觉。
+ */
+class AgentOrchestratorActiveDocTest {
+
+    // ==== doc_open_file 短路 ====
+
+    @Test
+    @DisplayName("打开的就是活跃文档本身 → 短路，省掉一轮前端往返")
+    void shortCircuitsOpeningTheAlreadyOpenDocument() {
+        String msg = AgentOrchestrator.activeDocOpenShortCircuit(123L, "合作框架协议.docx", "123");
+
+        assertNotNull(msg, "打自己应短路");
+        assertTrue(msg.contains("合作框架协议.docx"), "反馈里应点名文档");
+        assertTrue(msg.contains("alreadyOpen"), "应给出结构化标记供模型识别");
+        assertTrue(msg.contains("doc_list_project_files"), "应顺带堵住再去列文件的退路");
+    }
+
+    @Test
+    @DisplayName("打开的是别的文档 → 不短路，跨文档场景必须照常执行")
+    void doesNotShortCircuitOtherDocuments() {
+        assertNull(AgentOrchestrator.activeDocOpenShortCircuit(123L, "合作框架协议.docx", "456"),
+                "跨文档操作不能被拦截");
+    }
+
+    @Test
+    @DisplayName("无活跃文档或参数缺失 → 一律不短路")
+    void doesNotShortCircuitWithoutActiveDoc() {
+        assertNull(AgentOrchestrator.activeDocOpenShortCircuit(null, "x.docx", "123"));
+        assertNull(AgentOrchestrator.activeDocOpenShortCircuit(123L, "x.docx", null));
+        assertNull(AgentOrchestrator.activeDocOpenShortCircuit(123L, "x.docx", "  "));
+    }
+
+    @Test
+    @DisplayName("非数字 fileId（临时文件等）不短路，交由工具自己报错")
+    void doesNotShortCircuitNonNumericId() {
+        assertNull(AgentOrchestrator.activeDocOpenShortCircuit(123L, "x.docx", "tmp_abc"));
+    }
+
+    @Test
+    @DisplayName("文档名缺失时短路反馈仍可用，不出现空书名号")
+    void shortCircuitToleratesMissingName() {
+        String msg = AgentOrchestrator.activeDocOpenShortCircuit(123L, null, "123");
+
+        assertNotNull(msg);
+        assertTrue(msg.contains("该文档"), "无名时应回退为通称");
+        assertTrue(!msg.contains("《》"), "不应出现空书名号");
+    }
+
+    // ==== doc_list_project_files 结果加钉 ====
+
+    @Test
+    @DisplayName("列文件结果尾部钉上活跃文档，让走神的模型下一轮自纠")
+    void appendsActiveDocNoticeToListOutput() {
+        String out = AgentOrchestrator.appendActiveDocNotice(
+                "[{\"id\":1,\"name\":\"a.docx\"}]", 123L, "合作框架协议.docx");
+
+        assertTrue(out.startsWith("[{"), "原始列表必须保留在前");
+        assertTrue(out.contains("[系统提醒]"), "应沿用既有系统提醒惯例");
+        assertTrue(out.contains("合作框架协议.docx"), "应点名活跃文档");
+        assertTrue(out.contains("123"), "应带上 id");
+    }
+
+    @Test
+    @DisplayName("无活跃文档时列文件结果原样返回")
+    void leavesListOutputUntouchedWithoutActiveDoc() {
+        String raw = "[{\"id\":1}]";
+        org.junit.jupiter.api.Assertions.assertEquals(
+                raw, AgentOrchestrator.appendActiveDocNotice(raw, null, "x.docx"));
+    }
+}


### PR DESCRIPTION
## 为什么还要第三个 PR

提示词路线已经失败两次：

| PR | 做法 | 结果 |
|---|---|---|
| #187 | 加强 system prompt 里的 `<active_document>` 措辞 | 无效，真机日志实证注入后 6 秒仍调 `doc_list_project_files` |
| #209 | 改挂用户消息末位 `[系统提醒]` | 位置更好，但**仍是概率性的** |

不该再等第三次真机复测才上确定性手段。本 PR 在工具分发层兜底。

## 改法

`AgentOrchestrator.dispatchTool` 两处拦截：

**1. `doc_open_file` 打的就是活跃文档本身 → 短路**

直接返回 `{"status":"success","alreadyOpen":true,...}`，不执行。省掉一整轮「SSE 下发打开指令 → 等前端回执」的往返。

**2. `doc_list_project_files` 结果尾部钉上活跃文档**

```
[{...原始列表...}]

[系统提醒] 用户此刻打开的是《合作框架协议.docx》（id=123）。若本次任务针对的就是它，
直接用 doc_* 工具操作即可，不要再调 doc_open_file。
```

让走神的模型下一轮自己纠回来。

## 边界：跨文档场景不拦截

- `doc_open_file` 指向**别的**文档时照常执行；
- `doc_list_project_files` 本身**从不阻断**，只在结果上加钉。

「对比项目里另一份合同」这类正常流程完全不受影响。这是刻意的——把工具从清单里摘掉会更"彻底"，但会直接堵死跨文档任务。

## 实现与测试

抽成两个纯函数 helper（`activeDocOpenShortCircuit` / `appendActiveDocNotice`），可脱离编排器单测。**未改 `AgentOrchestrator` 构造器，EvalHarness 无需同步**（该地雷已踩过两次）。

后端全量 `mvn test`（JDK 21）：**313 tests, 0 failures**，新增 7 个断言覆盖短路命中、跨文档放行、参数缺失、非数字 id、无名回退、列表加钉、无活跃文档原样返回。

## 附：撤回一个误判

上一轮我把 `project-overview.vue` 的 `isTabVisible` 说成"潜在断点"，查证后**不成立**：标签本来就按左栏模式分组（`lastActiveIdsByMode` + `activeTabsByMode` 存储），该函数返回 false 时编辑区由同一个 `activeFileLeft` 驱动、本身就是空白，文档并不可见——此时不发 activeContext 是正确行为。不做改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)