### PR TITLE
refactor(shell): Phase 3a——剪贴板捕获桥外置 + #ifdef 机制验证 + 剪贴板 e2e 冒烟

### DIFF
--- a/frontend/src/pages/project-overview/clipboardBridge.js
+++ b/frontend/src/pages/project-overview/clipboardBridge.js
@@ -1,0 +1,242 @@
+// project-overview.vue 的剪贴板捕获桥：桌面端走 Electron 主进程推送，H5 走
+// copy/paste/keydown 三路兜底监听；TEXT/IMAGE/FILE 三类载荷统一经 recordClipboardOnce 入库。
+// 去重状态挂 window 而非组件实例——本页经 navigateTo 反复进入时页面栈里存在多个实例，
+// 实例级去重挡不住"一次复制、多实例各入库一条"（见 PR#148/#151）。
+// 含 #ifdef H5 条件编译：uni 预处理器对 src/pages/**.js 同样生效（已实测验证）。
+// 经展开进组件 methods（纯搬移，Phase 3a 外置），`this` 即 project-overview 页面实例。
+
+import { saveClipboardText, saveClipboardFile } from '@/services/api.js'
+import { getCurrentUser } from '@/utils/auth.js'
+
+export const clipboardBridgeMethods = {
+    bindClipboardListener() {
+      // #ifdef H5
+      if (this._clipboardBound) return
+      const user = getCurrentUser()
+      if (!user) return
+      this._clipboardBound = true
+      // 统一的“写库 + 立即更新 UI”入口：避免 copy 事件多次触发导致重复入库
+      // 去重状态挂 window 而非组件实例：本页经 navigateTo 反复进入时页面栈里会存在
+      // 多个实例，每个实例都绑定过监听；实例级去重挡不住“一次复制、多实例各入库一条”
+      if (typeof window !== 'undefined' && !window.__checkbaClipLastText) {
+        window.__checkbaClipLastText = { ts: 0, text: '' }
+      }
+      const recordClipboardOnce = async (rawText, source = 'doc') => {
+        // 1. Electron Payload Object (IMAGE / FILE)
+        if (rawText && typeof rawText === 'object') {
+           const payload = rawText
+           // 同一事件（ts 相同）会被页面栈里每个实例的监听器各收到一次，只处理第一次；
+           // 图片/文件没有下方文本那样的内容去重，全靠这里挡住重复入库
+           const evKey = String(payload.type || '') + '_' + String(payload.ts || '')
+           if (typeof window !== 'undefined') {
+             if (window.__checkbaClipLastEventKey === evKey) return null
+             window.__checkbaClipLastEventKey = evKey
+           }
+           if (payload.type === 'TEXT') {
+             return await recordClipboardOnce(payload.text, source)
+           } else if (payload.type === 'IMAGE' && payload.data) {
+             try {
+               const arr = payload.data.split(',')
+               const match = arr[0].match(/:(.*?);/)
+               const mime = match ? match[1] : 'image/png'
+               // Decode base64
+               const bstr = atob(arr[1])
+               let n = bstr.length
+               const u8arr = new Uint8Array(n)
+               while (n--) { u8arr[n] = bstr.charCodeAt(n) }
+               const blob = new Blob([u8arr], { type: mime })
+
+               // Create File object
+               const f = new File([blob], `image_${Date.now()}.png`, { type: mime })
+
+               const res = await saveClipboardFile({ file: f }, 'IMAGE')
+               const saved = (res && res.data) ? res.data : res
+               this.onClipboardSaved(saved)
+               uni.showToast({ title: '已捕获图片', icon: 'success' })
+               return saved
+             } catch (e) {
+               console.error('Image upload failed', e)
+               return null
+             }
+           } else if (payload.type === 'FILE' && payload.filePath) {
+             try {
+               // Must verify API exists (Electron only)
+                // eslint-disable-next-line
+               if (window.checkbaDesktop && window.checkbaDesktop.utils && window.checkbaDesktop.utils.readFile) {
+                  // eslint-disable-next-line
+                  const resp = await window.checkbaDesktop.utils.readFile(payload.filePath)
+                  if (resp && resp.ok && resp.data) {
+                     // resp.data is usually Uint8Array or serialized Buffer
+                     const u8arr = new Uint8Array(resp.data)
+
+                     const name = payload.filePath.split(/[/\\]/).pop() || 'file'
+                     const blob = new Blob([u8arr])
+                     const f = new File([blob], name)
+
+
+                     const res = await saveClipboardFile({ file: f }, 'FILE')
+                     const saved = (res && res.data) ? res.data : res
+                     this.onClipboardSaved(saved)
+                     uni.showToast({ title: '已捕获文件', icon: 'success' })
+                     return saved
+                  }
+               }
+             } catch (e) {
+               console.error('File upload failed', e)
+             }
+             return null
+           }
+           return null
+        }
+
+        // 2. Normal Text Logic
+        let t = (rawText || '').trim()
+        if (
+          !t &&
+          typeof navigator !== 'undefined' &&
+          navigator.clipboard &&
+          typeof navigator.clipboard.readText === 'function'
+        ) {
+          try {
+            const latest = await navigator.clipboard.readText()
+            t = (latest || '').trim()
+          } catch (clipErr) {
+            // ignore permission errors
+          }
+        }
+        if (!t) return null
+
+        const now = Date.now()
+        // 仅用于防止同一次用户动作被多路监听重复触发（不是业务去重）
+        const lastText = (typeof window !== 'undefined' && window.__checkbaClipLastText) || { ts: 0, text: '' }
+        if (lastText.text === t && now - (lastText.ts || 0) < 600) {
+          return null
+        }
+        if (typeof window !== 'undefined') {
+          window.__checkbaClipLastText = { ts: now, text: t, source }
+        }
+
+        try {
+          const res = await saveClipboardText(t)
+          const saved = (res && res.data) ? res.data : res
+          this.onClipboardSaved(saved)
+          return saved
+        } catch (saveErr) {
+          console.error('记录剪贴板失败:', saveErr)
+          return null
+        }
+      }
+      this._recordClipboardOnce = recordClipboardOnce
+
+      // Desktop：由 Electron 主进程捕获 copy/cut，并直接推送剪贴板文本（更稳定，不依赖浏览器权限）
+      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.clipboard) {
+        try {
+          if (!this._desktopClipboardUnsub) {
+            this._desktopClipboardUnsub = window.checkbaDesktop.clipboard.onCopied(async (payload) => {
+              try {
+                // Pass full payload object to support IMAGE/FILE
+                await recordClipboardOnce(payload, 'desktop')
+              } catch (e) {
+                // ignore
+              }
+            })
+          }
+        } catch (e) {
+          // ignore
+        }
+        return
+      }
+
+      this._pasteHandler = async (e) => {
+        try {
+          const cd = e && e.clipboardData
+          const text = cd && typeof cd.getData === 'function' ? (cd.getData('text/plain') || '') : ''
+          await recordClipboardOnce(text, 'paste')
+        } catch (err) {
+          // ignore
+        }
+      }
+
+      this._copyHandler = async (e) => {
+        try {
+          let text = ''
+          const cd = e && e.clipboardData
+          if (cd && typeof cd.getData === 'function') {
+            text = cd.getData('text/plain') || ''
+          }
+          if (!text && typeof window !== 'undefined' && window.getSelection) {
+            const selection = window.getSelection()
+            text = selection ? selection.toString() : ''
+          }
+          await recordClipboardOnce(text, 'copy')
+        } catch (err) {
+          // ignore
+        }
+      }
+
+      // 键盘兜底：覆盖部分“网页内复制/iframe 内复制”导致外层收不到 copy 事件的场景（best-effort）
+      this._clipboardKeydownHandler = async (e) => {
+        try {
+          const key = e && (e.key || '')
+          const isCopy = (key === 'c' || key === 'C') && (e.metaKey || e.ctrlKey)
+          if (!isCopy) return
+          // 不从事件里取文本，直接尝试读剪贴板（权限失败则忽略）
+          await recordClipboardOnce('', 'keydown')
+        } catch (err) {
+          // ignore
+        }
+      }
+
+      document.addEventListener('paste', this._pasteHandler)
+      document.addEventListener('copy', this._copyHandler, true)
+      window.addEventListener('keydown', this._clipboardKeydownHandler, true)
+      // #endif
+    },
+    onClipboardSaved(item) {
+      // 1) 面板打开时：立即新增一张卡片（不等刷新）
+      if (this.$refs.clipboardPanel && typeof this.$refs.clipboardPanel.prependItem === 'function') {
+        this.$refs.clipboardPanel.prependItem(item, 80)
+      } else {
+        this.pendingClipboardRefresh = true
+      }
+      // 2) 兜底：如果面板当前可见，做一次 refresh 对齐服务端（避免时间/格式差异）
+      this.triggerClipboardRefresh()
+    },
+    triggerClipboardRefresh() {
+      if (!this.pendingClipboardRefresh) return
+      // 仅在剪贴板面板已渲染时刷新；否则保持 pending，等用户切到剪贴板再刷新
+      const panel = this.$refs.clipboardPanel
+      if (panel && typeof panel.refresh === 'function') {
+        this.pendingClipboardRefresh = false
+        try {
+          panel.refresh()
+        } catch (e) {
+          // ignore
+        }
+      }
+    },
+    unbindClipboardListener() {
+      // #ifdef H5
+      try {
+        if (this._desktopClipboardUnsub) this._desktopClipboardUnsub()
+      } catch (e) {
+        // ignore
+      }
+      this._desktopClipboardUnsub = null
+      if (this._pasteHandler) {
+        document.removeEventListener('paste', this._pasteHandler)
+      }
+      if (this._copyHandler) {
+        document.removeEventListener('copy', this._copyHandler, true)
+      }
+      if (this._clipboardKeydownHandler) {
+        window.removeEventListener('keydown', this._clipboardKeydownHandler, true)
+      }
+      this._pasteHandler = null
+      this._copyHandler = null
+      this._clipboardKeydownHandler = null
+      this._recordClipboardOnce = null
+      this._clipboardBound = false
+      // #endif
+    },
+}

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1268,7 +1268,6 @@ import {
   createDocFileLink,
   getDocFileLink,
   saveClipboardText,
-  saveClipboardFile,
   saveProjectVariable,
   getProjectVariables,
   getProjectFiles,
@@ -1313,6 +1312,7 @@ import { librePoolMethods } from './librePool.js'
 import { stagingAreaMethods } from './stagingArea.js'
 import { tabDragSplitMethods } from './tabDragSplit.js'
 import { fileOpenTabsMethods } from './fileOpenTabs.js'
+import { clipboardBridgeMethods } from './clipboardBridge.js'
 
 
 export default {
@@ -2298,6 +2298,8 @@ export default {
     ...stagingAreaMethods,
     ...tabDragSplitMethods,
     ...fileOpenTabsMethods,
+    // Phase 3a 外置的方法组
+    ...clipboardBridgeMethods,
     // EasyVoice Integration
     async handleEasyVoiceDocRequest(callback) {
       console.log('[EasyVoice] Requesting doc text...')
@@ -2932,236 +2934,7 @@ export default {
       this._ocrGlobalBound = false
       // #endif
     },
-    bindClipboardListener() {
-      // #ifdef H5
-      if (this._clipboardBound) return
-      const user = getCurrentUser()
-      if (!user) return
-      this._clipboardBound = true
-      // 统一的“写库 + 立即更新 UI”入口：避免 copy 事件多次触发导致重复入库
-      // 去重状态挂 window 而非组件实例：本页经 navigateTo 反复进入时页面栈里会存在
-      // 多个实例，每个实例都绑定过监听；实例级去重挡不住“一次复制、多实例各入库一条”
-      if (typeof window !== 'undefined' && !window.__checkbaClipLastText) {
-        window.__checkbaClipLastText = { ts: 0, text: '' }
-      }
-      const recordClipboardOnce = async (rawText, source = 'doc') => {
-        // 1. Electron Payload Object (IMAGE / FILE)
-        if (rawText && typeof rawText === 'object') {
-           const payload = rawText
-           // 同一事件（ts 相同）会被页面栈里每个实例的监听器各收到一次，只处理第一次；
-           // 图片/文件没有下方文本那样的内容去重，全靠这里挡住重复入库
-           const evKey = String(payload.type || '') + '_' + String(payload.ts || '')
-           if (typeof window !== 'undefined') {
-             if (window.__checkbaClipLastEventKey === evKey) return null
-             window.__checkbaClipLastEventKey = evKey
-           }
-           if (payload.type === 'TEXT') {
-             return await recordClipboardOnce(payload.text, source)
-           } else if (payload.type === 'IMAGE' && payload.data) {
-             try {
-               const arr = payload.data.split(',')
-               const match = arr[0].match(/:(.*?);/)
-               const mime = match ? match[1] : 'image/png'
-               // Decode base64
-               const bstr = atob(arr[1])
-               let n = bstr.length
-               const u8arr = new Uint8Array(n)
-               while (n--) { u8arr[n] = bstr.charCodeAt(n) }
-               const blob = new Blob([u8arr], { type: mime })
-
-               // Create File object
-               const f = new File([blob], `image_${Date.now()}.png`, { type: mime })
-
-               const res = await saveClipboardFile({ file: f }, 'IMAGE')
-               const saved = (res && res.data) ? res.data : res
-               this.onClipboardSaved(saved)
-               uni.showToast({ title: '已捕获图片', icon: 'success' })
-               return saved
-             } catch (e) {
-               console.error('Image upload failed', e)
-               return null
-             }
-           } else if (payload.type === 'FILE' && payload.filePath) {
-             try {
-               // Must verify API exists (Electron only)
-                // eslint-disable-next-line
-               if (window.checkbaDesktop && window.checkbaDesktop.utils && window.checkbaDesktop.utils.readFile) {
-                  // eslint-disable-next-line
-                  const resp = await window.checkbaDesktop.utils.readFile(payload.filePath)
-                  if (resp && resp.ok && resp.data) {
-                     // resp.data is usually Uint8Array or serialized Buffer
-                     const u8arr = new Uint8Array(resp.data)
-
-                     const name = payload.filePath.split(/[/\\]/).pop() || 'file'
-                     const blob = new Blob([u8arr])
-                     const f = new File([blob], name)
-
-
-                     const res = await saveClipboardFile({ file: f }, 'FILE')
-                     const saved = (res && res.data) ? res.data : res
-                     this.onClipboardSaved(saved)
-                     uni.showToast({ title: '已捕获文件', icon: 'success' })
-                     return saved
-                  }
-               }
-             } catch (e) {
-               console.error('File upload failed', e)
-             }
-             return null
-           }
-           return null
-        }
-
-        // 2. Normal Text Logic
-        let t = (rawText || '').trim()
-        if (
-          !t &&
-          typeof navigator !== 'undefined' &&
-          navigator.clipboard &&
-          typeof navigator.clipboard.readText === 'function'
-        ) {
-          try {
-            const latest = await navigator.clipboard.readText()
-            t = (latest || '').trim()
-          } catch (clipErr) {
-            // ignore permission errors
-          }
-        }
-        if (!t) return null
-
-        const now = Date.now()
-        // 仅用于防止同一次用户动作被多路监听重复触发（不是业务去重）
-        const lastText = (typeof window !== 'undefined' && window.__checkbaClipLastText) || { ts: 0, text: '' }
-        if (lastText.text === t && now - (lastText.ts || 0) < 600) {
-          return null
-        }
-        if (typeof window !== 'undefined') {
-          window.__checkbaClipLastText = { ts: now, text: t, source }
-        }
-
-        try {
-          const res = await saveClipboardText(t)
-          const saved = (res && res.data) ? res.data : res
-          this.onClipboardSaved(saved)
-          return saved
-        } catch (saveErr) {
-          console.error('记录剪贴板失败:', saveErr)
-          return null
-        }
-      }
-      this._recordClipboardOnce = recordClipboardOnce
-
-      // Desktop：由 Electron 主进程捕获 copy/cut，并直接推送剪贴板文本（更稳定，不依赖浏览器权限）
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.clipboard) {
-        try {
-          if (!this._desktopClipboardUnsub) {
-            this._desktopClipboardUnsub = window.checkbaDesktop.clipboard.onCopied(async (payload) => {
-              try {
-                // Pass full payload object to support IMAGE/FILE
-                await recordClipboardOnce(payload, 'desktop')
-              } catch (e) {
-                // ignore
-              }
-            })
-          }
-        } catch (e) {
-          // ignore
-        }
-        return
-      }
-
-      this._pasteHandler = async (e) => {
-        try {
-          const cd = e && e.clipboardData
-          const text = cd && typeof cd.getData === 'function' ? (cd.getData('text/plain') || '') : ''
-          await recordClipboardOnce(text, 'paste')
-        } catch (err) {
-          // ignore
-        }
-      }
-
-      this._copyHandler = async (e) => {
-        try {
-          let text = ''
-          const cd = e && e.clipboardData
-          if (cd && typeof cd.getData === 'function') {
-            text = cd.getData('text/plain') || ''
-          }
-          if (!text && typeof window !== 'undefined' && window.getSelection) {
-            const selection = window.getSelection()
-            text = selection ? selection.toString() : ''
-          }
-          await recordClipboardOnce(text, 'copy')
-        } catch (err) {
-          // ignore
-        }
-      }
-
-      // 键盘兜底：覆盖部分“网页内复制/iframe 内复制”导致外层收不到 copy 事件的场景（best-effort）
-      this._clipboardKeydownHandler = async (e) => {
-        try {
-          const key = e && (e.key || '')
-          const isCopy = (key === 'c' || key === 'C') && (e.metaKey || e.ctrlKey)
-          if (!isCopy) return
-          // 不从事件里取文本，直接尝试读剪贴板（权限失败则忽略）
-          await recordClipboardOnce('', 'keydown')
-        } catch (err) {
-          // ignore
-        }
-      }
-
-      document.addEventListener('paste', this._pasteHandler)
-      document.addEventListener('copy', this._copyHandler, true)
-      window.addEventListener('keydown', this._clipboardKeydownHandler, true)
-      // #endif
-    },
-    onClipboardSaved(item) {
-      // 1) 面板打开时：立即新增一张卡片（不等刷新）
-      if (this.$refs.clipboardPanel && typeof this.$refs.clipboardPanel.prependItem === 'function') {
-        this.$refs.clipboardPanel.prependItem(item, 80)
-      } else {
-        this.pendingClipboardRefresh = true
-      }
-      // 2) 兜底：如果面板当前可见，做一次 refresh 对齐服务端（避免时间/格式差异）
-      this.triggerClipboardRefresh()
-    },
-    triggerClipboardRefresh() {
-      if (!this.pendingClipboardRefresh) return
-      // 仅在剪贴板面板已渲染时刷新；否则保持 pending，等用户切到剪贴板再刷新
-      const panel = this.$refs.clipboardPanel
-      if (panel && typeof panel.refresh === 'function') {
-        this.pendingClipboardRefresh = false
-        try {
-          panel.refresh()
-        } catch (e) {
-          // ignore
-        }
-      }
-    },
-    unbindClipboardListener() {
-      // #ifdef H5
-      try {
-        if (this._desktopClipboardUnsub) this._desktopClipboardUnsub()
-      } catch (e) {
-        // ignore
-      }
-      this._desktopClipboardUnsub = null
-      if (this._pasteHandler) {
-        document.removeEventListener('paste', this._pasteHandler)
-      }
-      if (this._copyHandler) {
-        document.removeEventListener('copy', this._copyHandler, true)
-      }
-      if (this._clipboardKeydownHandler) {
-        window.removeEventListener('keydown', this._clipboardKeydownHandler, true)
-      }
-      this._pasteHandler = null
-      this._copyHandler = null
-      this._clipboardKeydownHandler = null
-      this._recordClipboardOnce = null
-      this._clipboardBound = false
-      // #endif
-    },
+    // 剪贴板捕获桥方法组已外置 → ./clipboardBridge.js（Phase 3a）
     bindOcrHotkeys() {
       if (this._ocrKeydownBound) return
       this._ocrKeydownBound = true

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -201,6 +201,26 @@ try {
   }
   await shot('j6-rails')
 
+  // ============ J6.6 剪贴板面板 ============
+  // 剪贴板簇长期没有端到端覆盖，而它重度依赖 document/window 全局监听
+  // （copy/paste/keydown 三路兜底）——正是"搬进 .js 模块后静态检查发现不了"的失效面。
+  //
+  // 注意：截图(OCR)簇**无法在浏览器目标里驱动**。浏览器路径走
+  // navigator.mediaDevices.getDisplayMedia（见 project-overview.vue 的
+  // startOcrCapture），headless Chrome 点下去直接 Target closed；桌面路径又依赖
+  // 主进程 OverlayWindow。同 LOWA 引擎，属于本套件的目标能力边界，
+  // 不要再往这里加 OCR 步骤（加了会整套崩，不是"抖动"）。
+  console.log('== J6.6 剪贴板面板 ==')
+  await step('剪贴板面板可打开', async () => {
+    await mouseClickSel('[title="常用工具"]')
+    await mouseClickText('剪贴板')
+    await page.waitForFunction(
+      () => [...document.querySelectorAll('.tab-indicator')].length > 0,
+      { timeout: 10000 }
+    )
+  })
+  await shot('j6.6-clipboard')
+
   // ============ J6.5 AI 对话（真 UI 打字发送；默认模型 deepseek-v4-flash，
   // $0.09/M tokens，一条消息成本可忽略；AI_E2E=0 跳过） ============
   if (process.env.AI_E2E !== '0') {


### PR DESCRIPTION
## 背景

Phase 2（#201）刻意跳过了剪贴板组，理由是它含 4 处 `#ifdef H5`，而当时 `.js` 模块里**没有条件编译先例**——不确定 uni 预处理器是否处理 `src/pages/**.js`。

这个不确定性很阴险：**H5 是唯一实际构建目标**，所以即使指令在 `.js` 里失效，行为也完全一致，`build` / `check:emits` / `e2e` **没有任何一项能发现**。属于静默隐患，必须先单独验证机制。

## 1. 先做的一次性探针（已回滚，不入库）

用 `#ifdef MP-WEIXIN` 包裹唯一标记字符串，构建后在产物里 grep：

| 标记 | 产物中 | 含义 |
|---|---|---|
| `.vue` 未包裹（对照） | 存在 | 方法本身有效 |
| `.vue` 包裹 | **消失** | 已知-good 基线：指令在 .vue 里生效 |
| `.js` 未包裹（对照） | 存在 | 排除被摇树/压缩吃掉的误判 |
| `.js` 包裹 | **消失** | **预处理器对 .js 同样生效** |

四格都可解释，结论明确：**`#ifdef` 在 `src/pages/**.js` 里正常工作**。这条结论同时解锁了后续 OCR 簇（含 16 处指令）的外置。

## 2. 搬移

`clipboardBridge.js`（230 行，4 个方法）：`bindClipboardListener` / `onClipboardSaved` / `triggerClipboardRefresh` / `unbindClipboardListener`。

`project-overview.vue` **5459 → 5230 行**。

顺带删掉本次改动造成的孤儿 import（`saveClipboardFile`；`saveClipboardText` 页面里另有调用，保留）。

## 3. 补 e2e 覆盖

新增 **J6.6「剪贴板面板可打开」**（常用工具 → 剪贴板 tab），套件 **29 → 30 步**。

剪贴板此前零端到端覆盖，而它重度依赖 `document`/`window` 全局监听——正是搬进 `.js` 模块后静态检查发现不了的失效面。剪贴板去重又恰好是历史地雷区（#148/#151 多实例重复订阅）。

同时在 J6.6 上方记下一条**能力边界**：**OCR 簇无法在浏览器目标里驱动**。浏览器路径走 `navigator.mediaDevices.getDisplayMedia`，headless Chrome 点下去整个 target 直接关闭（不是抖动，是全套崩）；桌面路径又依赖主进程 OverlayWindow。同 LOWA 引擎，属于本套件的目标边界——注释写在原地，防止后人再往这里加 OCR 步骤。

## 验证

- **反向验证**：搬移后 `#ifdef H5` 内的代码（`已捕获图片` / `已捕获文件` / `__checkbaClipLastText`）在 h5 产物中**均存在**，未被误剥离——这是对本次搬移真正要命的失败方向
- **逐行比对**：230 行**字节一致**（脚本化搬移）
- **方法名扫描**：七个模块 62 个方法与 `.vue` 剩余 152 个方法**零重名**
- `npm run build:h5` 通过；`npm run check:emits` 通过
- `npm run test:app-e2e` **30/30**（含新步骤，连续 2 次）