### PR TITLE
refactor(shell): Phase 3c——OCR 采集与浮层生命周期外置（OCR 簇收官）

### DIFF
--- a/frontend/src/pages/project-overview/ocrCapture.js
+++ b/frontend/src/pages/project-overview/ocrCapture.js
@@ -1,0 +1,334 @@
+// project-overview.vue 的 OCR 采集入口与浮层生命周期：桌面走主进程 OverlayWindow、
+// 浏览器走 getDisplayMedia；浮层开关、ESC 热键、document 级 down/move/up 框选监听与解绑。
+// 这组持有跨方法的实例态（_ocrDoc* / _ocrGlobalBound / _ocrKeydownBound），改动需成对检查绑定与解绑。
+// 注意：本簇无法在 app-e2e 浏览器目标里驱动（getDisplayMedia 会关掉 target），见 run.mjs J6.6 注释。
+// 经展开进组件 methods（纯搬移，Phase 3c 外置），`this` 即 project-overview 页面实例。
+
+
+export const ocrCaptureMethods = {
+    async applyDesktopOcrSelection(payload) {
+      if (!payload || !payload.dataUrl || !payload.selection) return
+      // 选区完成后再隐藏 BrowserView：此时用户不需要看真实网页了
+      try {
+        if (window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
+          await window.checkbaDesktop.browser.setViewsVisible({ visible: false })
+        }
+      } catch (e) {
+        // ignore
+      }
+
+      this.ocrText = ''
+      this.ocrImageDataUrl = ''
+      this.ocrOverlaySelecting = false
+      this.ocrActionBar = { visible: false, x: 0, y: 0 }
+      this.showOcrOverlay = true
+      this.bindOcrHotkeys()
+      this.bindOcrGlobalListeners()
+
+      this.ocrSourceUrl = payload.url ? String(payload.url) : (this.ocrSourceUrl || '')
+      const b = payload.bounds || null
+      const hostRect = b ? { x: Number(b.x) || 0, y: Number(b.y) || 0, width: Number(b.width) || 0, height: Number(b.height) || 0 } : null
+      this.ocrHostRect = hostRect
+      await this.ocrSetFrameFromDataUrl(String(payload.dataUrl), hostRect)
+
+      const s = payload.selection
+      this.ocrSel = { x1: Number(s.x1) || 0, y1: Number(s.y1) || 0, x2: Number(s.x2) || 0, y2: Number(s.y2) || 0 }
+
+      try {
+        this.ocrImageDataUrl = this.cropOcrSelection()
+        const left = Math.min(this.ocrSel.x1, this.ocrSel.x2)
+    const right = Math.max(this.ocrSel.x1, this.ocrSel.x2)
+    const bottom = Math.max(this.ocrSel.y1, this.ocrSel.y2)
+    const centerX = (left + right) / 2
+    this.ocrActionBar = { visible: true, x: centerX, y: bottom + 12 }
+      } catch (e) {
+        console.error('截图裁剪失败:', e)
+      }
+    },
+    getOcrPoint(e) {
+      const te = e && (e.touches && e.touches[0])
+      const ce = e && (e.changedTouches && e.changedTouches[0])
+      const p = te || ce || e || {}
+      return { x: Number(p.clientX || p.pageX || 0), y: Number(p.clientY || p.pageY || 0) }
+    },
+    getOcrCanvasEl() {
+      // uniapp H5 下 ref 可能不是原生 canvas；兜底用 id 取真实 DOM
+      let c = this.$refs.ocrCanvas
+      if (c && c.$el) c = c.$el
+      if (c && typeof c.getContext === 'function') return c
+      // #ifdef H5
+      const dom = document.getElementById('ocr-overlay-canvas')
+      if (dom && typeof dom.getContext === 'function') return dom
+      // #endif
+      return null
+    },
+    ocrLog(...args) {
+      if (!this.ocrDebug) return
+      // eslint-disable-next-line no-console
+      console.log('[OCR]', ...args)
+    },
+    // uniapp H5 下：用 document capture 事件接管拖拽，避免 view 合成事件不触发
+    bindOcrGlobalListeners() {
+      // #ifdef H5
+      if (this._ocrGlobalBound) return
+      this._ocrGlobalBound = true
+      this._ocrMoveLogTs = 0
+
+      this._ocrDocDown = (ev) => {
+        if (!this.showOcrOverlay) return
+        const p0 = this.getOcrPoint(ev)
+        this.ocrLastPointer = p0
+        // 右键不处理
+        if (ev && ev.button !== undefined && ev.button !== 0) return
+        // actionbar 内点击不触发框选
+        if (ev && ev.target && ev.target.closest && ev.target.closest('.ocr-actionbar')) return
+        this.onOcrOverlayDown(ev)
+        if (ev && ev.cancelable) ev.preventDefault()
+      }
+      this._ocrDocMove = (ev) => {
+        if (!this.showOcrOverlay) return
+        const p0 = this.getOcrPoint(ev)
+        this.ocrLastPointer = p0
+        this.onOcrOverlayMove(ev)
+        const now = Date.now()
+        if (this.ocrDebug && now - this._ocrMoveLogTs > 250) {
+          const p = this.getOcrPoint(ev)
+          this.ocrLog('move', p.x, p.y, 'selecting=', this.ocrOverlaySelecting)
+          this._ocrMoveLogTs = now
+        }
+        if (ev && ev.cancelable) ev.preventDefault()
+      }
+      this._ocrDocUp = (ev) => {
+        if (!this.showOcrOverlay) return
+        const p0 = this.getOcrPoint(ev)
+        this.ocrLastPointer = p0
+        this.onOcrOverlayUp(ev)
+        if (ev && ev.cancelable) ev.preventDefault()
+      }
+
+      document.addEventListener('mousedown', this._ocrDocDown, true)
+      document.addEventListener('mousemove', this._ocrDocMove, true)
+      document.addEventListener('mouseup', this._ocrDocUp, true)
+      document.addEventListener('touchstart', this._ocrDocDown, { capture: true, passive: false })
+      document.addEventListener('touchmove', this._ocrDocMove, { capture: true, passive: false })
+      document.addEventListener('touchend', this._ocrDocUp, { capture: true, passive: false })
+      // #endif
+    },
+    unbindOcrGlobalListeners() {
+      // #ifdef H5
+      if (!this._ocrGlobalBound) return
+      document.removeEventListener('mousedown', this._ocrDocDown, true)
+      document.removeEventListener('mousemove', this._ocrDocMove, true)
+      document.removeEventListener('mouseup', this._ocrDocUp, true)
+      document.removeEventListener('touchstart', this._ocrDocDown, true)
+      document.removeEventListener('touchmove', this._ocrDocMove, true)
+      document.removeEventListener('touchend', this._ocrDocUp, true)
+      this._ocrDocDown = null
+      this._ocrDocMove = null
+      this._ocrDocUp = null
+      this._ocrGlobalBound = false
+      // #endif
+    },
+    bindOcrHotkeys() {
+      if (this._ocrKeydownBound) return
+      this._ocrKeydownBound = true
+      this._ocrKeydownHandler = (e) => {
+        if (!this.showOcrOverlay) return
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          this.closeOcrOverlay()
+        }
+      }
+      window.addEventListener('keydown', this._ocrKeydownHandler)
+    },
+    unbindOcrHotkeys() {
+      if (this._ocrKeydownHandler) {
+        window.removeEventListener('keydown', this._ocrKeydownHandler)
+      }
+      this._ocrKeydownHandler = null
+      this._ocrKeydownBound = false
+    },
+    closeOcrOverlay() {
+      // 关闭蒙层：H5 使用屏幕共享时可能涉及授权；Desktop 不需要授权
+      // Desktop：BrowserView 的恢复由 desktopOverlayActive watcher 统一处理
+      // （若此时还有其它弹窗打开，则保持隐藏，避免弹窗被网页遮挡）
+      this.showOcrOverlay = false
+      // #ifdef H5
+      this.unbindOcrGlobalListeners()
+      // #endif
+      this.ocrOverlaySelecting = false
+      this.ocrSel = { x1: 0, y1: 0, x2: 0, y2: 0 }
+      this.ocrActionBar = { visible: false, x: 0, y: 0 }
+      this.ocrText = ''
+      this.ocrImageDataUrl = ''
+      this.ocrFrameCanvas = null
+      this.ocrFrameView = null
+      if (this.ocrFrameUrl) {
+        try { URL.revokeObjectURL(this.ocrFrameUrl) } catch (e) { /* ignore */ }
+      }
+      this.ocrFrameUrl = ''
+      this.unbindOcrHotkeys()
+    },
+    async startOcrCapture() {
+      // #ifdef H5
+      try {
+        this.ocrLoading = false
+        this.ocrText = ''
+        this.ocrImageDataUrl = ''
+        this.ocrHostRect = null
+        this.ocrOverlaySelecting = false
+        this.ocrSel = { x1: 0, y1: 0, x2: 0, y2: 0 }
+        this.ocrFrameCanvas = null
+        this.ocrFrameView = null
+        this.ocrFrameLoading = false
+
+        // 尽量绑定当前浏览器 tab 的 URL（用于收藏）
+        const active = this.focusedPane === 'right' ? this.activeFileRight : this.activeFileLeft
+        this.ocrSourceUrl = active && active.tabType === 'web' ? (active.url || '') : ''
+
+        // Desktop：直接抓屏做底图，不需要浏览器授权
+        if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.ocr) {
+          // 桌面端（方案 B）：使用主进程 OverlayWindow 进行框选（选区期间不隐藏 BrowserView）
+          const activeWebTab = this.getActiveWebTab()
+          const viewId = activeWebTab && activeWebTab.id ? String(activeWebTab.id) : ''
+          if (!window.checkbaDesktop.ocr.startSelection) {
+            uni.showToast({ title: '桌面端截图能力不可用', icon: 'none' })
+            return
+          }
+          // 全局截图：无网页 tab 时走 window 模式（两边都是文档也能截图）
+          const resp = viewId
+            ? await window.checkbaDesktop.ocr.startSelection({ viewId })
+            : await window.checkbaDesktop.ocr.startSelection({ mode: 'window' })
+          if (!resp || resp.ok !== true) {
+            if (resp && resp.cancelled) return
+            uni.showToast({ title: (resp && resp.message) ? String(resp.message) : '截图失败', icon: 'none' })
+            return
+          }
+          if (resp && resp.payload) {
+            await this.applyDesktopOcrSelection(resp.payload)
+          } else {
+            // 兼容旧事件回调（但不再依赖）
+            uni.showToast({ title: '截图完成，但未收到结果', icon: 'none' })
+          }
+          return
+        }
+
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+          uni.showToast({ title: '当前浏览器不支持屏幕共享', icon: 'none' })
+          return
+        }
+
+        // 关键：授权一次后保持 stream，用户在全屏浮层上随时框选
+        if (!this.ocrStream) {
+          this.ocrStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false })
+        }
+
+        this.showOcrOverlay = true
+        this.ocrActionBar = { visible: false, x: 0, y: 0 }
+        this.bindOcrHotkeys()
+        this.bindOcrGlobalListeners()
+        // 用 offscreen video + canvas 实时渲染（避免出现“播放器三角/黑屏”）
+        if (!this.ocrVideo) {
+          this.ocrVideo = document.createElement('video')
+          this.ocrVideo.muted = true
+          this.ocrVideo.playsInline = true
+          this.ocrVideo.autoplay = true
+        }
+        this.ocrVideo.srcObject = this.ocrStream
+        await this.ocrVideo.play()
+
+        // 改为“冻结帧”模式：抓一帧作为底图，用户在底图上框选，裁剪/下载/识别都基于同一帧
+        await this.$nextTick()
+        await this.ocrRefreshFrame()
+      } catch (e) {
+        console.error('启动 OCR 截图失败:', e)
+        // 桌面端不需要浏览器授权：避免误导
+        const title = this.isDesktopApp ? (e.message || '截图失败') : '截图失败（请允许共享标签页/窗口）'
+        uni.showToast({ title, icon: 'none' })
+        // 失败时统一走 closeOcrOverlay 复位（BrowserView 恢复由 watcher 处理）
+        try {
+          this.closeOcrOverlay()
+        } catch (err) {
+          // ignore
+        }
+      }
+      // #endif
+      // #ifndef H5
+      uni.showToast({ title: '仅 H5 支持截图摘录', icon: 'none' })
+      // #endif
+    },
+
+    // OCR 不再使用弹窗
+
+    hideOcrOverlay() {
+      this.closeOcrOverlay()
+    },
+
+    stopOcrCapture() {
+      this.closeOcrOverlay()
+      try {
+        if (this.ocrStream) {
+          this.ocrStream.getTracks().forEach(t => t.stop())
+        }
+      } catch (e) {
+        // ignore
+      }
+      this.ocrStream = null
+      this.ocrVideo = null
+    },
+    onOcrOverlayDown(e) {
+      if (!this.showOcrOverlay) return
+      // 只处理左键
+      if (e && e.button !== 0) return
+      // 如果已经有 actionbar，重新开始框选
+      this.ocrActionBar.visible = false
+      this.ocrOverlaySelecting = true
+      const p = this.getOcrPoint(e)
+      this.ocrSel = { x1: p.x, y1: p.y, x2: p.x, y2: p.y }
+      this.ocrLog('down', p.x, p.y, 'type=', e && e.type)
+    },
+    onOcrOverlayMove(e) {
+      if (!this.ocrOverlaySelecting) return
+      const p = this.getOcrPoint(e)
+      this.ocrSel = { ...this.ocrSel, x2: p.x, y2: p.y }
+    },
+    async onOcrOverlayUp(e) {
+      if (!this.ocrOverlaySelecting) return
+      this.ocrOverlaySelecting = false
+      const p = this.getOcrPoint(e)
+      this.ocrLog('up', p.x, p.y, 'hasSelection=', this.ocrHasSelection)
+      // 单击（无明显拖动）直接退出蒙层
+      if (!this.ocrHasSelection) {
+        this.closeOcrOverlay()
+        return
+      }
+
+      // 框选结束：先裁剪生成图片，再显示快捷命令条（不自动识别）
+      // #ifdef H5
+      try {
+        this.ocrText = ''
+        await this.ensureOcrFrozenFrame()
+        this.ocrImageDataUrl = this.cropOcrSelection()
+        const left = Math.min(this.ocrSel.x1, this.ocrSel.x2)
+    const right = Math.max(this.ocrSel.x1, this.ocrSel.x2)
+    const bottom = Math.max(this.ocrSel.y1, this.ocrSel.y2)
+
+    // Center X: Use the midpoint
+    const centerX = (left + right) / 2
+
+    // Y: Below the selection
+    const topY = bottom + 12
+
+    // 命令条位置：居中显示在框选区域下方
+    this.ocrActionBar = {
+      visible: true,
+      x: centerX,
+      y: topY
+    }
+      } catch (e) {
+        console.error('截图裁剪失败:', e)
+        uni.showToast({ title: e.message || '截图失败', icon: 'none' })
+      }
+      // #endif
+    },
+}

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1311,6 +1311,7 @@ import { tabDragSplitMethods } from './tabDragSplit.js'
 import { fileOpenTabsMethods } from './fileOpenTabs.js'
 import { clipboardBridgeMethods } from './clipboardBridge.js'
 import { ocrActionMethods } from './ocrActions.js'
+import { ocrCaptureMethods } from './ocrCapture.js'
 
 
 export default {
@@ -2300,6 +2301,8 @@ export default {
     ...clipboardBridgeMethods,
     // Phase 3b 外置的方法组
     ...ocrActionMethods,
+    // Phase 3c 外置的方法组
+    ...ocrCaptureMethods,
     // EasyVoice Integration
     async handleEasyVoiceDocRequest(callback) {
       console.log('[EasyVoice] Requesting doc text...')
@@ -2725,45 +2728,7 @@ export default {
         uni.showToast({ title: e.message || '打开失败', icon: 'none' })
       }
     },
-    async applyDesktopOcrSelection(payload) {
-      if (!payload || !payload.dataUrl || !payload.selection) return
-      // 选区完成后再隐藏 BrowserView：此时用户不需要看真实网页了
-      try {
-        if (window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-          await window.checkbaDesktop.browser.setViewsVisible({ visible: false })
-        }
-      } catch (e) {
-        // ignore
-      }
-
-      this.ocrText = ''
-      this.ocrImageDataUrl = ''
-      this.ocrOverlaySelecting = false
-      this.ocrActionBar = { visible: false, x: 0, y: 0 }
-      this.showOcrOverlay = true
-      this.bindOcrHotkeys()
-      this.bindOcrGlobalListeners()
-
-      this.ocrSourceUrl = payload.url ? String(payload.url) : (this.ocrSourceUrl || '')
-      const b = payload.bounds || null
-      const hostRect = b ? { x: Number(b.x) || 0, y: Number(b.y) || 0, width: Number(b.width) || 0, height: Number(b.height) || 0 } : null
-      this.ocrHostRect = hostRect
-      await this.ocrSetFrameFromDataUrl(String(payload.dataUrl), hostRect)
-
-      const s = payload.selection
-      this.ocrSel = { x1: Number(s.x1) || 0, y1: Number(s.y1) || 0, x2: Number(s.x2) || 0, y2: Number(s.y2) || 0 }
-
-      try {
-        this.ocrImageDataUrl = this.cropOcrSelection()
-        const left = Math.min(this.ocrSel.x1, this.ocrSel.x2)
-    const right = Math.max(this.ocrSel.x1, this.ocrSel.x2)
-    const bottom = Math.max(this.ocrSel.y1, this.ocrSel.y2)
-    const centerX = (left + right) / 2
-    this.ocrActionBar = { visible: true, x: centerX, y: bottom + 12 }
-      } catch (e) {
-        console.error('截图裁剪失败:', e)
-      }
-    },
+    // OCR 采集与浮层生命周期方法组已外置（Phase 3c） → ./ocrCapture.js
     getActiveWebTab() {
       // 优先取当前聚焦窗格的激活 tab
       const focused = this.focusedPane === 'right' ? this.activeFileRight : this.activeFileLeft
@@ -2850,131 +2815,9 @@ export default {
       // 按 Cursor 体验：不在窄屏时强行限制面板宽度（遮挡就遮挡），只切换样式密度
     },
     // 左栏面板切换方法组已外置 → ./panelSwitching.js（Phase 1）
-    getOcrPoint(e) {
-      const te = e && (e.touches && e.touches[0])
-      const ce = e && (e.changedTouches && e.changedTouches[0])
-      const p = te || ce || e || {}
-      return { x: Number(p.clientX || p.pageX || 0), y: Number(p.clientY || p.pageY || 0) }
-    },
-    getOcrCanvasEl() {
-      // uniapp H5 下 ref 可能不是原生 canvas；兜底用 id 取真实 DOM
-      let c = this.$refs.ocrCanvas
-      if (c && c.$el) c = c.$el
-      if (c && typeof c.getContext === 'function') return c
-      // #ifdef H5
-      const dom = document.getElementById('ocr-overlay-canvas')
-      if (dom && typeof dom.getContext === 'function') return dom
-      // #endif
-      return null
-    },
-    ocrLog(...args) {
-      if (!this.ocrDebug) return
-      // eslint-disable-next-line no-console
-      console.log('[OCR]', ...args)
-    },
-    // uniapp H5 下：用 document capture 事件接管拖拽，避免 view 合成事件不触发
-    bindOcrGlobalListeners() {
-      // #ifdef H5
-      if (this._ocrGlobalBound) return
-      this._ocrGlobalBound = true
-      this._ocrMoveLogTs = 0
-
-      this._ocrDocDown = (ev) => {
-        if (!this.showOcrOverlay) return
-        const p0 = this.getOcrPoint(ev)
-        this.ocrLastPointer = p0
-        // 右键不处理
-        if (ev && ev.button !== undefined && ev.button !== 0) return
-        // actionbar 内点击不触发框选
-        if (ev && ev.target && ev.target.closest && ev.target.closest('.ocr-actionbar')) return
-        this.onOcrOverlayDown(ev)
-        if (ev && ev.cancelable) ev.preventDefault()
-      }
-      this._ocrDocMove = (ev) => {
-        if (!this.showOcrOverlay) return
-        const p0 = this.getOcrPoint(ev)
-        this.ocrLastPointer = p0
-        this.onOcrOverlayMove(ev)
-        const now = Date.now()
-        if (this.ocrDebug && now - this._ocrMoveLogTs > 250) {
-          const p = this.getOcrPoint(ev)
-          this.ocrLog('move', p.x, p.y, 'selecting=', this.ocrOverlaySelecting)
-          this._ocrMoveLogTs = now
-        }
-        if (ev && ev.cancelable) ev.preventDefault()
-      }
-      this._ocrDocUp = (ev) => {
-        if (!this.showOcrOverlay) return
-        const p0 = this.getOcrPoint(ev)
-        this.ocrLastPointer = p0
-        this.onOcrOverlayUp(ev)
-        if (ev && ev.cancelable) ev.preventDefault()
-      }
-
-      document.addEventListener('mousedown', this._ocrDocDown, true)
-      document.addEventListener('mousemove', this._ocrDocMove, true)
-      document.addEventListener('mouseup', this._ocrDocUp, true)
-      document.addEventListener('touchstart', this._ocrDocDown, { capture: true, passive: false })
-      document.addEventListener('touchmove', this._ocrDocMove, { capture: true, passive: false })
-      document.addEventListener('touchend', this._ocrDocUp, { capture: true, passive: false })
-      // #endif
-    },
-    unbindOcrGlobalListeners() {
-      // #ifdef H5
-      if (!this._ocrGlobalBound) return
-      document.removeEventListener('mousedown', this._ocrDocDown, true)
-      document.removeEventListener('mousemove', this._ocrDocMove, true)
-      document.removeEventListener('mouseup', this._ocrDocUp, true)
-      document.removeEventListener('touchstart', this._ocrDocDown, true)
-      document.removeEventListener('touchmove', this._ocrDocMove, true)
-      document.removeEventListener('touchend', this._ocrDocUp, true)
-      this._ocrDocDown = null
-      this._ocrDocMove = null
-      this._ocrDocUp = null
-      this._ocrGlobalBound = false
-      // #endif
-    },
+    // OCR 采集与浮层生命周期方法组已外置（Phase 3c） → ./ocrCapture.js
     // 剪贴板捕获桥方法组已外置 → ./clipboardBridge.js（Phase 3a）
-    bindOcrHotkeys() {
-      if (this._ocrKeydownBound) return
-      this._ocrKeydownBound = true
-      this._ocrKeydownHandler = (e) => {
-        if (!this.showOcrOverlay) return
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          this.closeOcrOverlay()
-        }
-      }
-      window.addEventListener('keydown', this._ocrKeydownHandler)
-    },
-    unbindOcrHotkeys() {
-      if (this._ocrKeydownHandler) {
-        window.removeEventListener('keydown', this._ocrKeydownHandler)
-      }
-      this._ocrKeydownHandler = null
-      this._ocrKeydownBound = false
-    },
-    closeOcrOverlay() {
-      // 关闭蒙层：H5 使用屏幕共享时可能涉及授权；Desktop 不需要授权
-      // Desktop：BrowserView 的恢复由 desktopOverlayActive watcher 统一处理
-      // （若此时还有其它弹窗打开，则保持隐藏，避免弹窗被网页遮挡）
-      this.showOcrOverlay = false
-      // #ifdef H5
-      this.unbindOcrGlobalListeners()
-      // #endif
-      this.ocrOverlaySelecting = false
-      this.ocrSel = { x1: 0, y1: 0, x2: 0, y2: 0 }
-      this.ocrActionBar = { visible: false, x: 0, y: 0 }
-      this.ocrText = ''
-      this.ocrImageDataUrl = ''
-      this.ocrFrameCanvas = null
-      this.ocrFrameView = null
-      if (this.ocrFrameUrl) {
-        try { URL.revokeObjectURL(this.ocrFrameUrl) } catch (e) { /* ignore */ }
-      }
-      this.ocrFrameUrl = ''
-      this.unbindOcrHotkeys()
-    },
+    // OCR 采集与浮层生命周期方法组已外置（Phase 3c） → ./ocrCapture.js
     isBrowserTab(tab) {
       return !!tab && tab.tabType === 'web'
     },
@@ -3045,113 +2888,7 @@ export default {
     },
 
     // ===== OCR 摘录：屏幕共享抓帧 -> 框选 -> 后端 OCR（阿里云） =====
-    async startOcrCapture() {
-      // #ifdef H5
-      try {
-        this.ocrLoading = false
-        this.ocrText = ''
-        this.ocrImageDataUrl = ''
-        this.ocrHostRect = null
-        this.ocrOverlaySelecting = false
-        this.ocrSel = { x1: 0, y1: 0, x2: 0, y2: 0 }
-        this.ocrFrameCanvas = null
-        this.ocrFrameView = null
-        this.ocrFrameLoading = false
-
-        // 尽量绑定当前浏览器 tab 的 URL（用于收藏）
-        const active = this.focusedPane === 'right' ? this.activeFileRight : this.activeFileLeft
-        this.ocrSourceUrl = active && active.tabType === 'web' ? (active.url || '') : ''
-
-        // Desktop：直接抓屏做底图，不需要浏览器授权
-        if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.ocr) {
-          // 桌面端（方案 B）：使用主进程 OverlayWindow 进行框选（选区期间不隐藏 BrowserView）
-          const activeWebTab = this.getActiveWebTab()
-          const viewId = activeWebTab && activeWebTab.id ? String(activeWebTab.id) : ''
-          if (!window.checkbaDesktop.ocr.startSelection) {
-            uni.showToast({ title: '桌面端截图能力不可用', icon: 'none' })
-            return
-          }
-          // 全局截图：无网页 tab 时走 window 模式（两边都是文档也能截图）
-          const resp = viewId
-            ? await window.checkbaDesktop.ocr.startSelection({ viewId })
-            : await window.checkbaDesktop.ocr.startSelection({ mode: 'window' })
-          if (!resp || resp.ok !== true) {
-            if (resp && resp.cancelled) return
-            uni.showToast({ title: (resp && resp.message) ? String(resp.message) : '截图失败', icon: 'none' })
-            return
-          }
-          if (resp && resp.payload) {
-            await this.applyDesktopOcrSelection(resp.payload)
-          } else {
-            // 兼容旧事件回调（但不再依赖）
-            uni.showToast({ title: '截图完成，但未收到结果', icon: 'none' })
-          }
-          return
-        }
-
-        if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
-          uni.showToast({ title: '当前浏览器不支持屏幕共享', icon: 'none' })
-          return
-        }
-
-        // 关键：授权一次后保持 stream，用户在全屏浮层上随时框选
-        if (!this.ocrStream) {
-          this.ocrStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false })
-        }
-
-        this.showOcrOverlay = true
-        this.ocrActionBar = { visible: false, x: 0, y: 0 }
-        this.bindOcrHotkeys()
-        this.bindOcrGlobalListeners()
-        // 用 offscreen video + canvas 实时渲染（避免出现“播放器三角/黑屏”）
-        if (!this.ocrVideo) {
-          this.ocrVideo = document.createElement('video')
-          this.ocrVideo.muted = true
-          this.ocrVideo.playsInline = true
-          this.ocrVideo.autoplay = true
-        }
-        this.ocrVideo.srcObject = this.ocrStream
-        await this.ocrVideo.play()
-
-        // 改为“冻结帧”模式：抓一帧作为底图，用户在底图上框选，裁剪/下载/识别都基于同一帧
-        await this.$nextTick()
-        await this.ocrRefreshFrame()
-      } catch (e) {
-        console.error('启动 OCR 截图失败:', e)
-        // 桌面端不需要浏览器授权：避免误导
-        const title = this.isDesktopApp ? (e.message || '截图失败') : '截图失败（请允许共享标签页/窗口）'
-        uni.showToast({ title, icon: 'none' })
-        // 失败时统一走 closeOcrOverlay 复位（BrowserView 恢复由 watcher 处理）
-        try {
-          this.closeOcrOverlay()
-        } catch (err) {
-          // ignore
-        }
-      }
-      // #endif
-      // #ifndef H5
-      uni.showToast({ title: '仅 H5 支持截图摘录', icon: 'none' })
-      // #endif
-    },
-
-    // OCR 不再使用弹窗
-
-    hideOcrOverlay() {
-      this.closeOcrOverlay()
-    },
-
-    stopOcrCapture() {
-      this.closeOcrOverlay()
-      try {
-        if (this.ocrStream) {
-          this.ocrStream.getTracks().forEach(t => t.stop())
-        }
-      } catch (e) {
-        // ignore
-      }
-      this.ocrStream = null
-      this.ocrVideo = null
-    },
+    // OCR 采集与浮层生命周期方法组已外置（Phase 3c） → ./ocrCapture.js
 
     // OCR 帧处理与动作方法组已外置（Phase 3b） → ./ocrActions.js
     startActivityTracking() {
@@ -3200,61 +2937,7 @@ export default {
         }
     },
 
-    onOcrOverlayDown(e) {
-      if (!this.showOcrOverlay) return
-      // 只处理左键
-      if (e && e.button !== 0) return
-      // 如果已经有 actionbar，重新开始框选
-      this.ocrActionBar.visible = false
-      this.ocrOverlaySelecting = true
-      const p = this.getOcrPoint(e)
-      this.ocrSel = { x1: p.x, y1: p.y, x2: p.x, y2: p.y }
-      this.ocrLog('down', p.x, p.y, 'type=', e && e.type)
-    },
-    onOcrOverlayMove(e) {
-      if (!this.ocrOverlaySelecting) return
-      const p = this.getOcrPoint(e)
-      this.ocrSel = { ...this.ocrSel, x2: p.x, y2: p.y }
-    },
-    async onOcrOverlayUp(e) {
-      if (!this.ocrOverlaySelecting) return
-      this.ocrOverlaySelecting = false
-      const p = this.getOcrPoint(e)
-      this.ocrLog('up', p.x, p.y, 'hasSelection=', this.ocrHasSelection)
-      // 单击（无明显拖动）直接退出蒙层
-      if (!this.ocrHasSelection) {
-        this.closeOcrOverlay()
-        return
-      }
-
-      // 框选结束：先裁剪生成图片，再显示快捷命令条（不自动识别）
-      // #ifdef H5
-      try {
-        this.ocrText = ''
-        await this.ensureOcrFrozenFrame()
-        this.ocrImageDataUrl = this.cropOcrSelection()
-        const left = Math.min(this.ocrSel.x1, this.ocrSel.x2)
-    const right = Math.max(this.ocrSel.x1, this.ocrSel.x2)
-    const bottom = Math.max(this.ocrSel.y1, this.ocrSel.y2)
-
-    // Center X: Use the midpoint
-    const centerX = (left + right) / 2
-
-    // Y: Below the selection
-    const topY = bottom + 12
-
-    // 命令条位置：居中显示在框选区域下方
-    this.ocrActionBar = {
-      visible: true,
-      x: centerX,
-      y: topY
-    }
-      } catch (e) {
-        console.error('截图裁剪失败:', e)
-        uni.showToast({ title: e.message || '截图失败', icon: 'none' })
-      }
-      // #endif
-    },
+    // OCR 采集与浮层生命周期方法组已外置（Phase 3c） → ./ocrCapture.js
 
     // OCR 帧处理与动作方法组已外置（Phase 3b） → ./ocrActions.js
     async insertClipboardAndCopy(text, options = {}) {


### PR DESCRIPTION
## 改动

`ocrCapture.js`（**325 行，15 个方法，5 段连续区间**）：采集入口（桌面走主进程 OverlayWindow、浏览器走 `getDisplayMedia`）、浮层开关、ESC 热键、document 级 down/move/up 框选监听与解绑。

`project-overview.vue` **4675 → 4357 行**。累计 **10639 → 4357（-59%）**。OCR 簇（33 个方法约 890 行）至此拆完。

## 这组为什么单独拆出来

风险最高：持有跨方法的实例态（`_ocrDoc*` / `_ocrGlobalBound` / `_ocrKeydownBound`），而且 **app-e2e 无法驱动 OCR**。所以在常规验证之外补了针对性检查：

**监听器对称**——模块内 `addEventListener` 的 7 类事件全部在同模块内有对应 `removeEventListener`：

| 事件 | add | remove |
|---|---|---|
| mousedown / mousemove / mouseup | ✓ | ✓ |
| touchstart / touchmove / touchend | ✓ | ✓ |
| keydown | ✓ | ✓ |

无跨模块悬挂（这正是"bind 搬走了、unbind 留在 .vue"会造成的泄漏）。

**实例态不跨界**——六个字段在 `.vue` 与其他八个模块中的引用数**均为 0**，全部收敛在本模块：

`_ocrGlobalBound` / `_ocrKeydownBound` / `_ocrDocDown` / `_ocrDocMove` / `_ocrDocUp` / `_ocrKeydownHandler`

**条件编译反向验证**——本模块含 **14 处 `#ifdef`**（九个模块里最多）。搬移后 `#ifdef H5` 内的文案（`当前浏览器不支持屏幕共享` / `桌面端截图能力不可用`）在 h5 产物中仍在，未被误剥离。

## 顺带修掉提取脚本的一个真缺陷

原先方法区间的 `end` 取「下一个方法起始行 - 1」，于是会把前几期留下的「已外置」**标记注释一并吞进新模块，同时从 `.vue` 里删掉**。

**而逐行比对发现不了**——因为 HEAD 在同一位置也有那行注释，字节比对照样"通过"。第一次跑 Phase 3c 就实际踩中了（3 行标记被吞）。

已改为：把 `end` 锚定到方法自身的闭合花括号，并加一道「区间内不得含标记行」的硬拦截（命中即 `exit 1`）。**已复查前八个模块均未中招**，各自 grep 标记数为 0，`.vue` 侧标记完整。

## 验证

- **逐行比对**：5 段区间共 **325 行字节一致**
- **方法名扫描**：九个模块 95 个方法与 `.vue` 剩余 119 个方法**零重名**
- `npm run build:h5` 通过；`npm run check:emits` 通过
- `npm run test:app-e2e`：3 次 **2 通过 1 失败**

关于那 1 次失败：是 J1 登录的**既有抖动**（issue #200，master 实测同样 2/3），不是本 PR 引入。已另用独立 puppeteer 探针确认本分支 UI 登录正常跳转 `#/pages/userprofile/userprofile`——没有靠"重跑到绿"下结论。

### 覆盖前提

同 #212：**OCR 链路无法在浏览器目标 e2e 里驱动**，本 PR 的信心来自静态等价证明 + 上述对称性/边界检查，不是端到端跑通。