### PR TITLE
fix(ai): 修复活跃文档兜底的三个缺陷——串名、坏 JSON、null 名

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -201,10 +201,29 @@ public class AgentOrchestrator {
         if (guard != null && "doc_open_file".equals(toolName)) {
             try {
                 String fid = extractArg(argsJson, "fileId");
-                if (fid != null && !fid.isEmpty()) guard.activeFileId = Long.parseLong(fid.trim());
+                if (fid != null && !fid.isEmpty()) {
+                    Long opened = Long.parseLong(fid.trim());
+                    guard.activeFileName = activeDocNameAfterOpen(guard.activeFileId, guard.activeFileName, opened);
+                    guard.activeFileId = opened;
+                }
             } catch (Exception ignore) { /* fileId 非数字时保持原值 */ }
         }
         return result;
+    }
+
+    /**
+     * 模型中途 doc_open_file 后，活跃文档名该保留还是作废。
+     *
+     * <p>切到别的文档时必须作废：否则后续短路反馈/列表加钉会拿**旧名配新 id**，等于主动喂给
+     * 模型一条错误信息。这一层拿不到新文档名，置 null 即回退为通称「当前文档」。
+     */
+    static String activeDocNameAfterOpen(Long previousId, String previousName, Long openedId) {
+        return openedId != null && openedId.equals(previousId) ? previousName : null;
+    }
+
+    /** 活跃文档的展示名：名字缺失（含模型中途切文档后作废的情况）时回退为通称，避免出现「《null》」。 */
+    private static String activeDocDisplayName(String activeFileName) {
+        return (activeFileName == null || activeFileName.isBlank()) ? "当前文档" : "《" + activeFileName + "》";
     }
 
     /**
@@ -224,10 +243,11 @@ public class AgentOrchestrator {
         } catch (NumberFormatException e) {
             return null;
         }
-        String name = (activeFileName == null || activeFileName.isBlank()) ? "该文档" : "《" + activeFileName + "》";
-        return "{\"status\":\"success\",\"alreadyOpen\":true,\"message\":\"" + name
-                + "（id=" + activeFileId + "）本来就在编辑器中打开着，无需打开。"
-                + "请直接调用 doc_* 工具对它操作，不要再调 doc_open_file 或 doc_list_project_files。\"}";
+        // 返回纯文本而非手拼 JSON：doc_open_file 本身返回的就是纯文本，格式保持一致；
+        // 手拼 JSON 遇到文件名里的引号/反斜杠（macOS 合法字符）会产出坏 JSON。
+        return activeDocDisplayName(activeFileName) + "（id=" + activeFileId
+                + "）本来就在编辑器中打开着，无需打开，可直接进行后续操作。"
+                + "请直接调用 doc_* 工具对它操作，不要再调 doc_open_file 或 doc_list_project_files。";
     }
 
     /**
@@ -237,9 +257,9 @@ public class AgentOrchestrator {
         if (activeFileId == null) {
             return listOutput;
         }
-        String name = (activeFileName == null || activeFileName.isBlank()) ? "当前文档" : "《" + activeFileName + "》";
         return (listOutput == null ? "" : listOutput)
-                + "\n\n[系统提醒] 用户此刻打开的是 " + name + "（id=" + activeFileId + "）。"
+                + "\n\n[系统提醒] 用户此刻打开的是 " + activeDocDisplayName(activeFileName)
+                + "（id=" + activeFileId + "）。"
                 + "若本次任务针对的就是它，直接用 doc_* 工具操作即可，不要再调 doc_open_file。";
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -375,6 +375,11 @@ public class ContextAssemblerService {
         return messages;
     }
     
+    /** 活跃文档展示名：名字缺失时回退为通称，避免给模型看到「《null》」。 */
+    private static String activeDocDisplayName(String name) {
+        return (name == null || name.isBlank()) ? "当前文档" : "《" + name + "》";
+    }
+
     /**
      * 活跃文档的末位提醒（拼在用户消息尾部）。无活跃文档时返回空串。
      */
@@ -382,7 +387,7 @@ public class ContextAssemblerService {
         if (activeContext == null || activeContext.getId() == null || activeContext.getId().isEmpty()) {
             return "";
         }
-        return "\n\n[系统提醒] 编辑器中当前已打开文档《" + activeContext.getName() + "》（id="
+        return "\n\n[系统提醒] 编辑器中当前已打开文档" + activeDocDisplayName(activeContext.getName()) + "（id="
                 + activeContext.getId() + "），其正文见 system prompt 的 <active_document>。"
                 + "用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——"
                 + "直接调用 doc_* 工具操作，**禁止**再调 doc_list_project_files 或 doc_open_file 去重新发现或打开它。";

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorActiveDocTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorActiveDocTest.java
@@ -25,8 +25,19 @@ class AgentOrchestratorActiveDocTest {
 
         assertNotNull(msg, "打自己应短路");
         assertTrue(msg.contains("合作框架协议.docx"), "反馈里应点名文档");
-        assertTrue(msg.contains("alreadyOpen"), "应给出结构化标记供模型识别");
+        assertTrue(msg.contains("本来就在编辑器中打开着"), "应说明无需打开");
         assertTrue(msg.contains("doc_list_project_files"), "应顺带堵住再去列文件的退路");
+    }
+
+    @Test
+    @DisplayName("文件名含引号/反斜杠也不产出坏结构——短路走纯文本，与工具自身返回格式一致")
+    void shortCircuitSurvivesQuotesInFileName() {
+        String msg = AgentOrchestrator.activeDocOpenShortCircuit(
+                123L, "他说\"你好\"\\备份.docx", "123");
+
+        assertNotNull(msg);
+        assertTrue(msg.contains("他说\"你好\"\\备份.docx"), "文件名应原样呈现，不被转义破坏");
+        assertTrue(!msg.trim().startsWith("{"), "不应手拼 JSON——doc_open_file 本身返回纯文本");
     }
 
     @Test
@@ -51,13 +62,15 @@ class AgentOrchestratorActiveDocTest {
     }
 
     @Test
-    @DisplayName("文档名缺失时短路反馈仍可用，不出现空书名号")
+    @DisplayName("文档名缺失时短路反馈仍可用，不出现《null》或空书名号")
     void shortCircuitToleratesMissingName() {
-        String msg = AgentOrchestrator.activeDocOpenShortCircuit(123L, null, "123");
+        for (String noName : new String[]{null, "", "  "}) {
+            String msg = AgentOrchestrator.activeDocOpenShortCircuit(123L, noName, "123");
 
-        assertNotNull(msg);
-        assertTrue(msg.contains("该文档"), "无名时应回退为通称");
-        assertTrue(!msg.contains("《》"), "不应出现空书名号");
+            assertNotNull(msg);
+            assertTrue(msg.contains("当前文档"), "无名时应回退为通称");
+            assertTrue(!msg.contains("《》") && !msg.contains("null"), "不应漏出 null 或空书名号");
+        }
     }
 
     // ==== doc_list_project_files 结果加钉 ====
@@ -80,5 +93,36 @@ class AgentOrchestratorActiveDocTest {
         String raw = "[{\"id\":1}]";
         org.junit.jupiter.api.Assertions.assertEquals(
                 raw, AgentOrchestrator.appendActiveDocNotice(raw, null, "x.docx"));
+    }
+
+    @Test
+    @DisplayName("列表加钉在文档名缺失时回退通称，不漏出 null")
+    void listNoticeToleratesMissingName() {
+        String out = AgentOrchestrator.appendActiveDocNotice("[]", 123L, null);
+
+        assertTrue(out.contains("当前文档"), "无名时应回退为通称");
+        assertTrue(!out.contains("null"), "不应把 null 漏给模型");
+    }
+
+    // ==== 模型中途切文档后的文档名归属 ====
+
+    @Test
+    @DisplayName("模型打开别的文档 → 旧文档名必须作废，不能拿旧名配新 id")
+    void invalidatesNameWhenModelOpensDifferentDocument() {
+        assertNull(AgentOrchestrator.activeDocNameAfterOpen(123L, "合作框架协议.docx", 456L),
+                "切文档后旧名必须作废，否则会喂给模型错误信息");
+    }
+
+    @Test
+    @DisplayName("模型重复打开同一文档 → 文档名保留")
+    void keepsNameWhenReopeningSameDocument() {
+        org.junit.jupiter.api.Assertions.assertEquals("合作框架协议.docx",
+                AgentOrchestrator.activeDocNameAfterOpen(123L, "合作框架协议.docx", 123L));
+    }
+
+    @Test
+    @DisplayName("此前无活跃文档时打开任意文档 → 名字仍未知")
+    void nameStaysUnknownWhenThereWasNoActiveDoc() {
+        assertNull(AgentOrchestrator.activeDocNameAfterOpen(null, null, 456L));
     }
 }


### PR DESCRIPTION
复查 PR#209 / #210 的实现，发现三个问题，均已修复并补测试。

## 1. 文档名会串（真缺陷，会主动误导模型）

`dispatchTool` 底部的跟踪逻辑在模型中途打开别的文档时更新了 `guard.activeFileId`，**却没动 `guard.activeFileName`**：

```java
// 修复前
if (fid != null && !fid.isEmpty()) guard.activeFileId = Long.parseLong(fid.trim());
// activeFileName 保持不变 → 旧名配新 id
```

后果：模型打开文档 B 之后，短路反馈和列表加钉会输出「《A的名字》（id=B）」。这不是显示瑕疵——它是在往模型上下文里塞一条**错误事实**，而这两个函数的存在意义恰恰是纠正模型的认知。

修复：抽出 `activeDocNameAfterOpen(previousId, previousName, openedId)`，切文档即作废旧名（分发层拿不到新文档名），回退为通称「当前文档」。抽成纯函数也让这个分支可以被单测覆盖。

## 2. 手拼 JSON 未转义

短路返回值是字符串拼接的 JSON：

```java
return "{\"status\":\"success\",...,\"message\":\"" + name + "...\"}";
```

文件名含半角引号或反斜杠（macOS 上完全合法，例如 `他说"你好"\\备份.docx`）就会产出坏 JSON。

修复：改为**纯文本**。`doc_open_file` 本身返回的就是纯文本（"已发送打开文件指令。文件名: %s..."），短路返回纯文本反而格式一致，同时从根上消除这一类问题——不是补转义，是不再需要转义。

## 3. null 文档名漏给模型

`ContextAssemblerService` 的末位提醒直接插值 `getName()`，name 为空时模型会看到「《null》」。两处各加 `activeDocDisplayName` 兜底。

## 核查确认无问题的部分（不改动）

| 检查项 | 结论 |
|---|---|
| 末位提醒是否污染历史 | 否——持久化的是 `request.getMessage()` 原文（:287），提醒只进 LLM 消息栈 |
| 短路跳过 `applyToolSideEffects` 是否有副作用丢失 | 否——`doc_open_file` 无 `@ToolMeta` |
| 短路传入的 tool 可能为 null | 无 NPE——两处消费点（:270 :607）均已 null 判断 |
| 是否只对一种协议生效 | 否——原生 function calling(:505) 与 XML(:571) 都走 `dispatchTool` |
| 是否影响检查点 | 否——检查点在短路之前执行，且 `doc_open_file` 非 MODIFIED 类 |

## 验证

后端全量 `mvn test`（JDK 21）：**318 tests, 0 failures**（+5）。新增覆盖：切文档作废旧名、重开同一文档保留名、此前无活跃文档、引号/反斜杠文件名、列表加钉空名回退。

🤖 Generated with [Claude Code](https://claude.com/claude-code)