### PR TITLE
test(app-e2e): J6.6 剪贴板断言改为面板真实挂载 + 消除开关竞态

### DIFF
--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -212,12 +212,12 @@ try {
   // 不要再往这里加 OCR 步骤（加了会整套崩，不是"抖动"）。
   console.log('== J6.6 剪贴板面板 ==')
   await step('剪贴板面板可打开', async () => {
-    await mouseClickSel('[title="常用工具"]')
+    // 「常用工具」是开关：面板已开时再点会把它关掉——先探测再决定是否点击
+    if (!(await page.$('.bottom-panel'))) await mouseClickSel('[title="常用工具"]')
+    await page.waitForSelector('.bottom-panel', { timeout: 10000 })
     await mouseClickText('剪贴板')
-    await page.waitForFunction(
-      () => [...document.querySelectorAll('.tab-indicator')].length > 0,
-      { timeout: 10000 }
-    )
+    // 断言 ClipboardPanel 组件真的挂载了（.tab-indicator 只说明有 tab 激活，面板挂载失败也存在）
+    await page.waitForSelector('.clip-panel', { timeout: 10000 })
   })
   await shot('j6.6-clipboard')
 


### PR DESCRIPTION
## 背景

对 #197–#213 九模块拆分做了一轮独立复查审计。拆分本体全部通过（详见下），唯一发现的两个实际问题都在 #211 顺手加的 e2e 步骤里，本 PR 修复。

## 修复

**1. 断言无效**：J6.6 原断言 `.tab-indicator` 存在——但工具面板一打开、默认 tab 激活时它就存在，与 `ClipboardPanel` 是否挂载无关。组件挂载失败该步骤也照样绿，等于没断言。改为等待 `ClipboardPanel` 根节点 `.clip-panel`。

**2. 开关竞态**：`[title="常用工具"]` 是 toggle（`showToolsPanel` 默认 `false`）。当前旅程顺序恰好没踩坑，但任何前序步骤先开过面板，这一步会把它关掉再神秘失败。改为先探测 `.bottom-panel`，不在才点击。

验证：`npm run test:app-e2e` **30/30**。强化后的断言实际验证了 ClipboardPanel 挂载，反向增强了 #211 剪贴板搬移的真实覆盖。

## 审计结论（拆分本体，全部通过）

- **方法集守恒**（新检查，此前从未做过）：对 #199/#201/#211/#212/#213 五个 commit 逐一验证「父 commit 的 .vue 方法集 = 拆分后 .vue ∪ 新模块」，五个 commit 全部守恒，零丢失、零凭空多出、零重复
- **自由标识符扫描**（新检查）：九个模块引用的所有「.vue 侧 import / script 顶层声明」均已在模块内自行 import，无潜在运行时 ReferenceError（Phase 1/2 的 import 是手工/硬编码候选清单确定的，这里补上了系统性验证）
- **模板绑定全量解析**：用花括号计数的正确边界收集 methods/computed/data + 九模块方法共 389 个实例成员，模板全部调用可解析
- **动态派发扫描**：`this[expr](` 零命中；四个 config 文件无字符串方法名——重名扫描的盲区不存在
- **标记注释**：14 处「已外置」标记全部指向真实存在的模块文件
- `GLYPHS` 模板链完好（computed 暴露）

## 顺带发现的既有问题（非拆分引入，未动）

- `beforeDestroy()` 声明在 `methods:{}` **内部**（L3368），Vue 永远不会调用；其清理逻辑在真正的 `beforeUnmount` 钩子里已有重复实现，无实际泄漏，属死代码
- L972 `@tap="$emit('toggle-history')"`——页面自身向不存在的父组件发事件，疑似死 UI
- `loadAssistants()` 结尾 `},` 是 2 空格误缩进：运行时无害，但会骗过一切用 `^  },$` 找 methods 块结尾的正则（本次审计改用花括号计数才发现之前的边界检测一直是错的——所幸此前扫描均为超集方向，结论不受影响）
- 4 个死 import（`saveProjectVariable`/`getProjectVariables`/`logActivity`/`inviteClient`）仍待单独清理