### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
自 v0.8.0 累积 19 个 PR（#196–#216），版本号单一来源 `desktop/package.json` 提到 0.9.0。

## 为什么是 minor 而不是 patch

- #202/#203：在线插件分发的安全模型落地 + 配置生产签名公钥，**在线插件安装链路本版首次真正可用**
- #198：插件广场提级到 Railway 左栏 + Skill 生效方式三档 + 全站清零 emoji

均为新增用户可见能力，与 v0.8.0 同量级。

## 本批主要内容

- 插件分发：#202 安全模型（签名/审核/封禁 + 三个加载期漏洞）、#203 生产公钥、#206 广场按官网 DESIGN.md 重做
- 桌面：#204 macOS DMG 安装窗口视觉重做
- AI：#209/#210/#215 活跃文档确定性兜底（约束挂消息末位 + 分发层拦截 + 三个缺陷修复）
- 外壳重构：#197/#199/#201/#211/#212/#213 project-overview.vue 分阶段拆分收官（10639→4357，九模块）
- 文档：#196 8 份领域 sub-agent 文档 + CLAUDE.md 路由表、#205/#207/#208
- 测试：#216 app-e2e J6.6 剪贴板断言改为面板真实挂载

## 发版前回归（本 worktree 冷启动全跑）

| 检查 | 结果 |
|---|---|
| backend `mvn -B test`（JDK 21） | 318 通过 / 0 失败 / 2 跳过 |
| desktop `npm test` | 14/14 |
| frontend `check:emits` | 通过（45 个 .vue） |
| `test:app-e2e` | 30/30（基线 29，#216 新增一步） |
| `test:lowa-e2e` | 38/38（持平 v0.8.0 基线） |

app-e2e 报的一条 console 异常信号已查清：新前端打**打包版 v0.8.0 常驻后端**时 `/api/plugins/market/list` 返回 code:1；用本分支后端复验为 `{"code":0,"plugins":[]}`，属旧后端契约产物，非回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)