### PR TITLE
perf(editor): 冷启动提速——固定端口+缓存头激活 WASM 编译缓存，CJK 字体并行下载

### DIFF
--- a/desktop/main/zetaoffice-server.js
+++ b/desktop/main/zetaoffice-server.js
@@ -28,6 +28,15 @@ const { app } = require('electron')
 
 const LOWA_CDN = 'https://cdn.zetaoffice.net/zetaoffice_latest/'
 
+// Chromium keys both the HTTP disk cache and the V8 WASM code cache on
+// origin+URL. A random port (listen(0)) changes the origin every app launch,
+// so the 150MB soffice.wasm was re-downloaded from disk AND recompiled on
+// every cold start. A fixed port keeps the origin stable across launches;
+// if it's taken (second app instance, dev + packaged side by side) we fall
+// back to a random port — everything still works, just without cross-launch
+// cache reuse.
+const FIXED_PORT = 47613
+
 const TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.js': 'text/javascript; charset=utf-8',
@@ -107,9 +116,21 @@ function startEditorServer() {
             try {
               const st = await stat(localPath)
               if (st.isFile()) {
+                // ETag + no-cache (NOT immutable: /lowa/soffice.wasm keeps the
+                // same URL across engine upgrades, so the browser must
+                // revalidate — a localhost 304 costs ~1ms and still lets
+                // Chromium reuse the cached body plus its WASM code cache).
+                const etag = '"' + st.size + '-' + Math.round(st.mtimeMs) + '"'
+                const cacheHeaders = { ETag: etag, 'Cache-Control': 'public, no-cache' }
+                if (req.headers['if-none-match'] === etag) {
+                  res.writeHead(304, cacheHeaders)
+                  res.end()
+                  return
+                }
                 const headers = {
                   'Content-Type': TYPES[path.extname(localPath)] || 'application/octet-stream',
                   'Content-Length': st.size,
+                  ...cacheHeaders,
                 }
                 // Replay the brotli encoding for files the CDN pre-compressed.
                 const enc = lowaEncodings[path.basename(localPath)]
@@ -133,11 +154,21 @@ function startEditorServer() {
         res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' }).end('not found')
       }
     })
-    s.on('error', (e) => { serverPromise = null; reject(e) })
-    s.listen(0, '127.0.0.1', () => {
+    let fellBack = false
+    s.on('listening', () => {
       const port = s.address().port
       resolve({ port, origin: 'http://127.0.0.1:' + port })
     })
+    s.on('error', (e) => {
+      if (!fellBack && e && e.code === 'EADDRINUSE') {
+        fellBack = true
+        s.listen(0, '127.0.0.1')
+        return
+      }
+      serverPromise = null
+      reject(e)
+    })
+    s.listen(FIXED_PORT, '127.0.0.1')
   })
   return serverPromise
 }

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -99,22 +99,26 @@ export function bootZetaOffice(options = {}) {
     const fontList = [].concat(fontUrls || [], fontUrl ? [fontUrl] : [])
       .map((f) => (typeof f === 'string' ? { url: f } : f))
     const availableByCategory = {} // category -> registered family name
-    for (let i = 0; i < fontList.length; i++) {
-      const f = fontList[i]
+    // Fetch in parallel (serial awaits added the fonts' download times up into
+    // boot); process results in fontList order so injections and the
+    // availableByCategory first-hit-wins semantics stay deterministic.
+    const fontFetches = await Promise.all(fontList.map(async (f, i) => {
       try {
         const r = await fetch(f.url)
-        if (r.ok) {
-          const bytes = new Uint8Array(await r.arrayBuffer())
-          const base = String(f.url).split('?')[0].split('/').pop() || ('font-' + i)
-          injections.push({ path: '/instdir/share/fonts/truetype/AAA-' + base, bytes })
-          if (f.category && f.family && !availableByCategory[f.category]) availableByCategory[f.category] = f.family
-          log('CJK font fetched: ' + base + ' (' + Math.round(bytes.length / 1024) + ' KB)')
-        } else {
-          log('CJK font not found at ' + f.url + ' (skipping)')
-        }
+        if (!r.ok) { log('CJK font not found at ' + f.url + ' (skipping)'); return null }
+        const bytes = new Uint8Array(await r.arrayBuffer())
+        const base = String(f.url).split('?')[0].split('/').pop() || ('font-' + i)
+        return { f, base, bytes }
       } catch (e) {
         log('CJK font fetch failed: ' + f.url + ' — ' + e + ' (skipping)')
+        return null
       }
+    }))
+    for (const hit of fontFetches) {
+      if (!hit) continue
+      injections.push({ path: '/instdir/share/fonts/truetype/AAA-' + hit.base, bytes: hit.bytes })
+      if (hit.f.category && hit.f.family && !availableByCategory[hit.f.category]) availableByCategory[hit.f.category] = hit.f.family
+      log('CJK font fetched: ' + hit.base + ' (' + Math.round(hit.bytes.length / 1024) + ' KB)')
     }
 
     // --- CJK font-name aliases (fontconfig conf.d) ---


### PR DESCRIPTION
## 背景

对标 OnlyOffice 打开速度的借鉴评估（分支 claude/onlyoffice-editor-evaluation）结论之一：不换引擎，先修自身冷启动的两处实现问题。

## 改动

1. **固定端口 47613**（原 listen(0) 随机端口）：Chromium 的 HTTP 磁盘缓存与 V8 WASM 代码缓存按 origin+URL 键控，随机端口使 origin 每次启动都变，150MB soffice.wasm 每次冷启动都重新读盘+重新编译。固定端口后第二次启动起直接复用已编译机器码。端口被占（双实例并跑）自动回退随机端口，仅损失缓存复用。
2. **/lowa/\* 加 ETag + no-cache 复验**：引擎文件 URL 跨引擎版本不变，不能用 immutable；no-cache+If-None-Match 304 在 localhost 约 1ms，正确性与缓存收益兼得。
3. **CJK 字体并行下载**：boot 期四款字体原为串行 await，改 Promise.all，注入顺序与类别映射首命中语义不变。

## 验证

- lowa-e2e 真引擎回归：42 passed / 0 failed
- server 冒烟（plain node 桩 electron）：固定端口、200 带 ETag、304 空体、坏 ETag 重发、EADDRINUSE 回退随机端口，全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)