### PR TITLE
perf(editor): 预热备胎实例+只读预览接力——首开文档从整链冷启动降为秒级

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -15,7 +15,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - `desktop/scripts/lowa-selfhost.md` — 自托管流程文档。
 
 **桌面壳服务**
-- `desktop/main/zetaoffice-server.js` — 同源本地 HTTP 服务（editor.html + /lowa/* 本地优先、CDN 兜底）；memoized `startEditorServer()`。
+- `desktop/main/zetaoffice-server.js` — 同源本地 HTTP 服务（editor.html + /lowa/* 本地优先、CDN 兜底）；memoized `startEditorServer()`。**固定端口 47613**（占用回退随机）+ /lowa/* ETag/304 复验（PR#220）：origin 稳定才能让 Chromium 跨启动复用 HTTP 缓存与 V8 WASM 代码缓存（150MB soffice.wasm 免重编译）；引擎 URL 跨版本不变所以是 no-cache 复验而非 immutable，别改成长缓存。
 - `desktop/main/zetaoffice-session.js` — persist:zetaoffice 分区注入 COOP/COEP/CORP（webview 跨源隔离，SharedArrayBuffer 可用，不污染主窗口）。
 - `desktop/main/zetaoffice-verify.js` — ⌘⇧L 验证窗口（?verify=1，零副作用验证引擎/中文/AI 命令）。
 - IPC：`checkba:zetaoffice-editor`（main.js ~:1373，返回 {url, preload, partition}）；`desktop/preload/zetaoffice-webview-preload.js` 暴露 `window.zetaHostBridge`（通道 lo-relay）。
@@ -27,8 +27,8 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - `frontend/vite.zetaoffice.config.js` — editor 页专用 Vite 构建（脱离 uni-app），产出 dist/zetaoffice/。
 
 **宿主 UI（保活/实例管理/自动保存）**
-- `frontend/src/components/LibreOfficeEditor.vue` — 单文档编辑器组件：webview 创建、prefetch、load/export、autoSave、flushSave。
-- `frontend/src/pages/project-overview/project-overview.vue` — 保活池宿主：leftLibreFiles/rightLibreFiles（v-show 常驻，~:1661）、libreLruKeys/touchLibreLru/evictLibreInstance（~:5886-5906）、syncLibreExecutor 活跃指针（~:5871）、`_libreRefs`/`_libreExecMap` 非响应式注册表；`LIBRE_KEEPALIVE_MAX = 3`（~:1286）。
+- `frontend/src/components/LibreOfficeEditor.vue` — 单文档编辑器组件：webview 创建、prefetch、load/export、autoSave、flushSave。支持**备胎过继**（watch file 仅 null→文档；引擎已就绪走 finishDocLoad，未就绪由 onEndpointReady 接手）与**只读预览接力**（字节预取完成即 docx-preview 本地渲染，previewReady 后 overlay 变成可滚动阅读 + 顶部细进度条，ready 后整体消失）。
+- `frontend/src/pages/project-overview/librePool.js` — 保活池方法组（Phase 1 外置）：libreLruKeys/touchLibreLru/evictLibreInstance、syncLibreExecutor 活跃指针、`_libreRefs`/`_libreExecMap` 非响应式注册表、`LIBRE_KEEPALIVE_MAX = 3`；**预热备胎**（PR#220）：libreSpares（{key, file}，file=null 是后台预 boot 的空白隐藏实例），onActiveOfficeFileChanged 里 maybeAdoptLibreSpare（须在 touchLibreLru 之前，靠"不在 lru 记账"识别无实例）过继给池外首开文档，过继后按 'left:fileId' 常规记账；补胎在过继 ready 后（scheduleLibreSpare，4s 延迟）。仅左窗格设备胎（webview 不能跨容器移动）；h5 无 checkbaDesktop 不建胎；常驻多一个空白实例内存（数百 MB）。
 
 ## 启动链路（打开 docx → 可编辑）
 
@@ -57,6 +57,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - `npm run build:zetaoffice` 会清空 dist 并删掉已 fetch 的引擎——本地反复跑 e2e 用 `LOWA_ENGINE_DIR` 规避，或从兄弟 worktree 复制引擎（CDN 挂时的配方）。
 - 修订作者：params 带 `__agent:true` → 署名 "AI Workdeck"。
 - webview/uni 存储格式坑与宿主侧 e2e 配方见 lowa-keepalive 记录（PR#159）。
+- **预热备胎是同一个 LibreOfficeEditor 组件（file=null）**：任何在组件树/DOM 里"找编辑器实例"的探针（如 desktop-e2e FIND_EDITOR）必须过滤 `file` 非空，否则命令打在隐藏空白备胎上、样样"成功"但真文档纹丝不动。备胎未激活用 visibility 隐藏（绝对定位占位），不能改 display:none——引擎要在有尺寸画布里 boot。
 
 ## 验证
 

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -17,7 +17,15 @@
     <!-- 加载进度面板：引擎启动 + 文档下载/打开是感知最慢的一段（尤其大文档），
          把过程阶段化展示出来（用户反馈：不能更快，也要看得见进展）。 -->
     <view v-if="loadingOverlayVisible" class="libre-loading">
-      <view class="libre-loading-card">
+      <!-- 只读预览接力：文档字节一到就先用 docx-preview 本地渲出可读内容，
+           引擎继续后台 boot；就绪后 overlay 整体消失、无缝换入可编辑视图。
+           渲染失败/非 Word/空文档保持原进度卡片。 -->
+      <view v-show="previewReady" class="libre-preview-strip">
+        <view class="libre-strip-track"><view class="libre-strip-fill" :style="{ width: bootPct + '%' }"></view></view>
+        <text class="libre-strip-text">{{ bootStage }} {{ Math.round(bootPct) }}% — 已可阅读，编辑器就绪后可直接编辑</text>
+      </view>
+      <view v-show="previewReady" ref="docxPreviewHost" class="libre-preview-host"></view>
+      <view v-if="!previewReady" class="libre-loading-card">
         <view class="libre-doc-icon">
           <view class="doc-fold"></view>
           <view class="doc-line l1"></view>
@@ -96,6 +104,10 @@ export default {
       bootStage: '正在启动文档引擎',
       dlLoaded: 0,
       dlTotal: 0,
+      // 只读预览接力：字节预取完成后 docx-preview 渲染成功置 previewReady，
+      // overlay 从进度卡片切换为可滚动阅读的文档 + 顶部细进度条。
+      previewReady: false,
+      previewFailed: false,
     }
   },
   computed: {
@@ -119,6 +131,24 @@ export default {
       return this.dlTotal > 0
         ? `文档内容 ${fmt(this.dlLoaded)} / ${fmt(this.dlTotal)}`
         : `已下载文档内容 ${fmt(this.dlLoaded)}`
+    },
+  },
+  watch: {
+    // 预热备胎过继（librePool.js）：宿主把 file 从 null 换成真实文档。引擎
+    // 可能已空白就绪（_endpointUp），也可能仍在 boot——后者只预取字节，
+    // onEndpointReady 会照常装载。file→file 换文档不支持（池按实例=文档）。
+    file(newFile, oldFile) {
+      if (!newFile || oldFile) return
+      this.prefetchBytes()
+      if (!this._endpointUp) return
+      this.ready = false
+      this.docLoadFailed = false
+      this.statusText = '加载文档中…'
+      this.bootPct = 75
+      this.bootCap = 95
+      this.bootStage = '正在打开文档'
+      this.startBootTrickle()
+      this.finishDocLoad()
     },
   },
   async mounted() {
@@ -255,6 +285,12 @@ export default {
     // starts routing AI commands to the (now correctly-targeted) editor.
     async onEndpointReady() {
       if (!this.executor) return // unmounted during boot
+      this._endpointUp = true
+      await this.finishDocLoad()
+    },
+    // 装载 + 发布就绪。两个入口：onEndpointReady（常规：mount 时就有 file，或
+    // 备胎空白 boot 完成），以及 file watcher（备胎在引擎就绪后被过继）。
+    async finishDocLoad() {
       if (this.file) {
         try {
           await this.loadDocument()
@@ -288,6 +324,37 @@ export default {
       })
         .then((buf) => { this.appendLog('文档字节预取完成 / prefetched ' + (buf ? buf.byteLength : 0) + ' bytes in ' + (Date.now() - t0) + 'ms'); return buf })
         .catch((e) => { this.appendLog('预取失败（加载时重试）/ prefetch failed: ' + (e && e.message ? e.message : e)); return null })
+      // 只读预览接力：不影响 _bytesPromise 本身（loadDocument 仍 await 它）
+      this._bytesPromise.then((buf) => this.tryDocxPreview(buf))
+    },
+    // 引擎 boot 期间先把预取到的 docx 渲成只读预览（docx-preview 本地解析，
+    // 同 FilePreview.renderDocx 的配置）。失败静默回落进度卡片。
+    async tryDocxPreview(buf) {
+      if (!buf || buf.byteLength === 0 || this.ready || this.previewReady || this.previewFailed) return
+      const t = String((this.file && this.file.fileType) || '').toLowerCase()
+      if (t !== 'docx' && t !== 'doc') return
+      try {
+        const { renderAsync } = await import('docx-preview')
+        await this.$nextTick() // 过继路径上 overlay 可能刚重新显示，等 ref 挂上
+        const ref = this.$refs.docxPreviewHost
+        const container = ref && (ref.$el || ref)
+        if (!container || this.ready) return
+        container.innerHTML = ''
+        await renderAsync(buf, container, null, {
+          className: 'docx',
+          inWrapper: true,
+          ignoreWidth: false,
+          ignoreHeight: false,
+          breakPages: true,
+          experimental: true,
+        })
+        if (this.ready) return
+        this.previewReady = true
+        this.appendLog('只读预览就绪（引擎继续后台启动）')
+      } catch (e) {
+        this.previewFailed = true
+        this.appendLog('docx 预览渲染失败（保留进度面板）: ' + (e && e.message ? e.message : e))
+      }
     },
     async loadDocument() {
       const f = this.file
@@ -501,4 +568,14 @@ export default {
 .libre-loading-pct { font-size: 12px; color: #1A5336; font-weight: 600; }
 .libre-loading-dl { font-size: 11px; color: #868E96; }
 .libre-loading-hint { font-size: 11px; color: #ADB5BD; margin-top: 6px; }
+/* ---- 只读预览接力 ---- */
+.libre-preview-strip { position: absolute; top: 0; left: 0; right: 0; z-index: 2; display: flex; flex-direction: column;
+  gap: 4px; padding: 6px 14px 8px; background: rgba(248, 249, 250, 0.95); border-bottom: 1px solid #E9ECEF;
+  backdrop-filter: blur(4px); }
+.libre-strip-track { width: 100%; height: 3px; background: #E9ECEF; border-radius: 999px; overflow: hidden; }
+.libre-strip-fill { height: 100%; background: #5BD197; border-radius: 999px; transition: width 0.5s ease; }
+.libre-strip-text { font-size: 11px; color: #868E96; }
+.libre-preview-host { position: absolute; inset: 0; top: 34px; overflow-y: auto; background: #F1F3F5; }
+/* docx-preview 生成的页面居中呈现（deep：内容是运行时注入的非 scoped DOM） */
+.libre-preview-host :deep(.docx-wrapper) { background: transparent; padding: 16px 0; }
 </style>

--- a/frontend/src/pages/project-overview/librePool.js
+++ b/frontend/src/pages/project-overview/librePool.js
@@ -43,9 +43,74 @@ export const librePoolMethods = {
         this.libreOfficeActive = !!exec
     },
     // 激活的标签变化：Office 文档记入保活 LRU（超上限触发淘汰），并同步指针。
+    // 池外文档先尝试过继给预热备胎（必须在 touchLibreLru 之前判断——touch 会
+    // 把 key 记入 libreLruKeys，adopt 以"不在 lru 记账"识别无实例）。
     onActiveOfficeFileChanged(pane, file) {
-        if (file && this.useLibreEditor(file)) this.touchLibreLru(pane, file.id)
+        if (file && this.useLibreEditor(file)) {
+            if (pane === 'left') this.maybeAdoptLibreSpare(file)
+            this.touchLibreLru(pane, file.id)
+        }
         this.syncLibreExecutor()
+    },
+
+    // ---- 预热备胎（spare）：首开文档免整链冷启动 ----
+    // 常驻一个后台 boot 到空白就绪的隐藏实例（借鉴 OnlyOffice"服务常驻热着"）。
+    // 激活一个池外 Office 文档时把文档过继给它（组件 watch file 触发装载），
+    // 省去 webview 创建 + 引擎 WASM 启动整段。过继后转正进常规记账（executor/
+    // ref 均按 'left:fileId' 键，LRU 淘汰与 closeFile flush 走既有链路）。
+    // 只在左窗格设备胎（webview 不能跨容器移动）；右窗格分屏冷开保持原状。
+    // 代价：常驻多一个空白实例的内存（数百 MB），换首开从整链 boot 降为仅
+    // load_document。
+    scheduleLibreSpare() {
+        // 延迟建胎：避开项目打开期（文件树/面板初始化）的资源竞争。
+        clearTimeout(this._libreSpareTimer)
+        this._libreSpareTimer = setTimeout(() => this.initLibreSpare(), 4000)
+    },
+    initLibreSpare() {
+        // 页面栈多实例守卫：只有活跃 overview 实例建备胎（PR#148/#151 模式）。
+        if (typeof this.isActiveOverviewInstance === 'function' && !this.isActiveOverviewInstance()) return
+        const api = typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.zetaoffice
+        if (!api) return // 非桌面版没有 LOWA
+        if (this.libreSpares.some(sp => !sp.file)) return // 已有空闲备胎
+        this._libreSpareSeq = (this._libreSpareSeq || 0) + 1
+        this.libreSpares.push({ key: this._libreSpareSeq, file: null })
+        console.log('[ProjectOverview] LibreOffice spare booting (#' + this._libreSpareSeq + ')')
+    },
+    maybeAdoptLibreSpare(file) {
+        if (!file || !this.useLibreEditor(file)) return
+        const id = String(file.id)
+        if (this.libreSpares.some(sp => sp.file && String(sp.file.id) === id)) return // 已是过继实例
+        if (this.libreLruKeys.includes('left:' + file.id)) return // 常规池里已有活实例
+        const spare = this.libreSpares.find(sp => !sp.file)
+        if (!spare) return
+        spare.file = file
+        console.log('[ProjectOverview] LibreOffice spare adopted → left:' + id)
+        // 新备胎等这次过继 ready 后再补（onLibreSpareReady），避免两个引擎
+        // 同时抢 CPU 拖慢文档装载。
+    },
+    setLibreSpareRef(sp, el) {
+        // 过继后按常规键注册，closeFile/evict 的 flushSave 走同一注册表；
+        // 空白备胎无人引用，不注册。
+        if (sp.file) this.setLibreRef('left', sp.file.id, el)
+    },
+    onLibreSpareReady(sp, executor) {
+        if (sp.file) {
+            this.onLibreReady(executor, 'left', sp.file.id)
+            this.scheduleLibreSpare() // 过继完成、引擎空闲——补一个新备胎
+        } else {
+            console.log('[ProjectOverview] LibreOffice spare warm (blank ready)')
+        }
+    },
+    // 过继实例渲染自 libreSpares，出池必须同步删条目组件才会卸载。
+    // key 形如 'left:fileId'（右窗格无备胎，非 left 键直接返回）。
+    pruneLibreSpare(key) {
+        if (!key.startsWith('left:')) return
+        const id = key.slice(5)
+        this.libreSpares = this.libreSpares.filter(sp => !(sp.file && String(sp.file.id) === id))
+    },
+    // 关闭 tab（closeFile 已 flush 过）后清掉文件已不在左列表的过继条目。
+    pruneClosedLibreSpares() {
+        this.libreSpares = this.libreSpares.filter(sp => !sp.file || this.isLibreKeyOpen('left:' + sp.file.id))
     },
     touchLibreLru(pane, fileId) {
         const key = pane + ':' + fileId
@@ -74,6 +139,7 @@ export const librePoolMethods = {
         if (idx === -1 || idx < LIBRE_KEEPALIVE_MAX) return
         if (key === 'left:' + this.activeFileIdLeft || key === 'right:' + this.activeFileIdRight) return
         this.libreLruKeys = this.libreLruKeys.filter(k => k !== key)
+        this.pruneLibreSpare(key)
         console.log('[ProjectOverview] LibreOffice keep-alive evicted (LRU):', key)
     },
 

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -1771,6 +1771,15 @@ $bg-white: #FFFFFF;
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.03);
 }
 
+/* 预热备胎实例（librePool.js）：未激活时脱离布局流隐形占位。不能用
+   display:none——引擎要在有尺寸的画布里 boot；visibility 保留布局尺寸。 */
+.pane-content.libre-spare-standby {
+  position: absolute;
+  inset: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .pane-empty, .empty-workspace {
   width: 100%;
   height: 100%;

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -735,6 +735,24 @@
                       @open-url="onLibreOpenUrl"
                     />
                   </view>
+                  <!-- 预热备胎实例（librePool.js）：file=null 时是后台预 boot 的
+                       空白引擎，首开 Office 文档时过继（file 换成文档）省去整链
+                       冷启动。未激活时用绝对定位 + visibility 隐藏而非 v-show：
+                       display:none 下 boot 引擎画布无尺寸，风险未验证。 -->
+                  <view
+                    v-for="sp in libreSpares"
+                    :key="'libre-spare-' + sp.key"
+                    class="pane-content"
+                    :class="{ 'libre-spare-standby': !(sp.file && activeFileLeft && activeFileLeft.id === sp.file.id) }"
+                  >
+                    <LibreOfficeEditor
+                      :ref="el => setLibreSpareRef(sp, el)"
+                      :file="sp.file"
+                      @ready="onLibreSpareReady(sp, $event)"
+                      @close="onLibreClose"
+                      @open-url="onLibreOpenUrl"
+                    />
+                  </view>
                   <view v-if="activeFileLeft && !useLibreEditor(activeFileLeft)" class="pane-content">
                     <BrowserPane
                       v-if="isBrowserTab(activeFileLeft)"
@@ -1526,6 +1544,9 @@ export default {
       // 内嵌编辑器保活 LRU：'pane:fileId'（left:123），最近激活在前。在池中的
       // Office 标签切走时实例不销毁（v-show 隐藏），切回免重 boot/重载。
       libreLruKeys: [],
+      // 预热备胎实例（librePool.js）：{key, file}。file=null 是后台预 boot 的
+      // 空白备胎；过继后 file 为真实文档、实例转正（渲染仍在此数组）。
+      libreSpares: [],
       // 后端 doc_stream_data（旧名 wps_stream_data）流式写入的本地缓冲（#79：LibreOffice 消费端）
       _docStreamBuffer: '',
       _docStreamTimer: null,
@@ -1696,6 +1717,7 @@ export default {
     // （出 leftFiles/rightFiles）时自然出池 → 组件卸载走现有 close 流程。
     leftLibreFiles() {
       return this.leftFiles.filter(f => this.useLibreEditor(f) &&
+        !this.libreSpares.some(sp => sp.file && sp.file.id === f.id) && // 过继实例渲染自备胎槽
         (f.id === this.activeFileIdLeft || this.libreLruKeys.includes('left:' + f.id)))
     },
     rightLibreFiles() {
@@ -1821,6 +1843,7 @@ export default {
     }
     // 后台任务状态轮询清理
     if (this.convStatusPollTimer) { clearInterval(this.convStatusPollTimer); this.convStatusPollTimer = null }
+    clearTimeout(this._libreSpareTimer)
     this.teardownResponsiveListener()
     // Epic #43: 解绑 ⌘⇧O 嵌入式编辑器监听
     // 清理轮询定时器
@@ -1972,6 +1995,8 @@ export default {
       window.__checkbaActiveOverviewVm = this
       if (this._wpsInternalLinkFn) window.__checkbaHandleInternalLink = this._wpsInternalLinkFn
     }
+    // 重新成为活跃实例后确保有预热备胎（mounted 时可能因非活跃被跳过）
+    this.scheduleLibreSpare()
 
     // Sync UI state
     this.isRecording = activityTracker.getRecordingState()
@@ -2027,6 +2052,8 @@ export default {
     // 处理，否则一次事件触发 N 份副作用（与 PR#148 剪贴板重复入库同源）
     if (typeof window !== 'undefined') window.__checkbaActiveOverviewVm = this
     this.setupResponsiveListener()
+    // 预热备胎：延迟建（避开项目打开期资源竞争），首开 Office 文档免冷启动
+    this.scheduleLibreSpare()
     // 后台任务状态轮询：AI 面板打开时每 15s 刷一次会话状态（驱动历史列表状态点
     // 与入口角标；quiet 模式不弹错误 toast、不动 loading 态）
     this.convStatusPollTimer = setInterval(() => {
@@ -2293,6 +2320,8 @@ export default {
     activeFileLeft(f) { this.onActiveOfficeFileChanged('left', f) },
     activeFileRight(f) { this.onActiveOfficeFileChanged('right', f) },
     focusedPane() { this.syncLibreExecutor() },
+    // 关闭 tab 后清掉文件已不在左列表的过继备胎条目（closeFile 已 flush）
+    'leftFiles.length'() { this.pruneClosedLibreSpares() },
   },
   methods: {
     // Phase 1 外置的方法组（纯搬移，this 即页面实例）

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -136,6 +136,9 @@ try {
   // 宿主侧编辑器组件（executor / statusText / saveDocument 所在）。
   // 注意：keepalive 池（PR#159）用 createElement 命令式建 webview，元素上没有
   // __vueParentComponent —— 必须从 Vue 组件树根 DFS 找 saveDocument 组件。
+  // 且必须要求 file 非空：预热备胎（librePool.js spare）也是同一组件，只是
+  // file=null 的隐藏空白实例——遍历顺序可能先碰到它，打在备胎上的插入/保存
+  // 全部"成功"但真文档纹丝不动（真实路由按活跃文件键控 executor，无此问题）。
   const FIND_EDITOR = `
     function findEditor() {
       let seed = null
@@ -145,7 +148,7 @@ try {
       const q = [root]
       while (q.length) {
         const c = q.shift()
-        if (c.proxy && typeof c.proxy.saveDocument === 'function') return c.proxy
+        if (c.proxy && typeof c.proxy.saveDocument === 'function' && c.proxy.file) return c.proxy
         const stack = [c.subTree]
         while (stack.length) {
           const v = stack.pop()


### PR DESCRIPTION
## 背景

OnlyOffice 评估结论的落地第二批（第一批 #219：固定端口+缓存头+字体并行）。借鉴其「服务常驻热着」与「渐进渲染」两个思路，不换引擎拿到同级打开体验。

## 改动

### 预热备胎实例（librePool.js + project-overview + LibreOfficeEditor）
- 进入工作台 4s 后，后台预 boot 一个空白隐藏编辑器实例（仅桌面版、仅活跃 overview 实例、仅左窗格——webview 不能跨容器移动）。
- 激活池外 Office 文档时过继给备胎（touchLibreLru 之前判定），组件 watch file（仅 null→文档）触发预取+装载，**省去 webview 创建 + 引擎 WASM 启动整段**。
- 过继后按 'left:fileId' 转正：executor/ref/LRU/flushSave 全走既有链路；淘汰与关 tab 同步清备胎条目；过继 ready 后补新备胎。
- 未激活备胎绝对定位 + visibility 隐藏（不能 display:none，引擎要在有尺寸画布里 boot）。
- 代价：常驻多一个空白实例内存（数百 MB），换首开秒级。

### 只读预览接力（LibreOfficeEditor）
- 文档字节预取完成即用 docx-preview 本地渲染只读预览（同 FilePreview 配置）；加载 overlay 变为可滚动阅读 + 顶部细进度条；引擎就绪后整体消失换入可编辑视图。失败/非 Word/空文档回落原进度卡片。

### desktop-e2e 探针修正
- FIND_EDITOR 要求 file 非空：备胎与文档编辑器是同一组件（file=null），反序遍历会先命中备胎——命令打在隐藏空白实例上样样成功但真文档不动。测试假设更新，产品路由（按活跃文件键控 executor）无此问题。

### 领域文档
- doc-editor.md 同步：备胎机制、探针地雷、#219 的端口/缓存契约。

## 验证（dev Electron + CDP 真机）

- desktop-e2e 保存链路全通（标记落盘命中）
- 专项脚本：spare adopted → left:418；previewReady @1ms，引擎就绪 @5014ms（冷启动对照约 1-2 分钟）；真实字节 load_document success；PR#194 空文档闸在过继路径正常拦截
- app-e2e 30 步通过（J9 版本记录 8 步失败=旧后端错配已知假警报，与本改动无关）
- check:emits 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)