### PR TITLE
chore(release): bump version to 0.9.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
0.9.1 发版：自 v0.9.0 以来累计 #214 #219 #220 #218 #222 #223（编辑器打开提速 + 版本记录 v2 云端协作全量 + 复活语义收紧）。

双 e2e 发版门（lowa-e2e 基线 44 + app-e2e J1-J11 100 步）正在跑，绿灯确认后我会在合并后打 tag v0.9.1 触发构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)