### PR TITLE
fix(editor): 修订删除回退行内删除线，修复侧边显示与表格正文叠字

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -60,6 +60,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - 删除键/快捷键必须走 `.uno:` 调度（覆盖层吞键+修订模式手工删卡死教训，PR#164/166）。
 - `npm run build:zetaoffice` 会清空 dist 并删掉已 fetch 的引擎——本地反复跑 e2e 用 `LOWA_ENGINE_DIR` 规避，或从兄弟 worktree 复制引擎（CDN 挂时的配方）。
 - 修订作者：params 带 `__agent:true` → 署名 "AI Workdeck"。
+- **ShowChangesInMargin 禁用勿开**：引擎把页边删除文本画在锚点所在 frame 的左侧，表格内 frame=单元格，删除文本会叠画到左邻单元格正文上（法律文书大量用表格），JS 无法矫正绘制位置。修订删除一律行内删除线（office_thread.js `showDeletionsInline`，boot+retarget 双点设置）；批注侧栏不受影响。
 - webview/uni 存储格式坑与宿主侧 e2e 配方见 lowa-keepalive 记录（PR#159）。
 - **预热备胎是同一个 LibreOfficeEditor 组件（file=null）**：任何在组件树/DOM 里"找编辑器实例"的探针（如 desktop-e2e FIND_EDITOR）必须过滤 `file` 非空，否则命令打在隐藏空白备胎上、样样"成功"但真文档纹丝不动。备胎未激活用 visibility 隐藏（绝对定位占位），不能改 display:none——引擎要在有尺寸画布里 boot。
 

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -362,13 +362,16 @@ function setCharProp(ps, base, value) {
   }
 }
 
-// LO 7.1+ (tdf#34355): tracked DELETIONS render in the page margin next to the
-// changed-line mark instead of inline strikethrough — the body stays readable
-// (original text + colored insertions only). This is a VIEW setting on the
-// controller, not the model, so it must be re-applied whenever the controller
-// changes (boot AND load_document retarget).
-function showDeletionsInMargin() {
-  try { ctrl.getViewSettings().setPropertyValue('ShowChangesInMargin', true); }
+// Tracked DELETIONS display inline with strikethrough (Word "All Markup").
+// ShowChangesInMargin (tdf#34355) is deliberately OFF: the engine paints the
+// margin text to the LEFT of the anchor's frame — for text inside a table cell
+// that frame is the CELL, so deleted text lands on top of the neighboring
+// cell's content (法律文书大量用表格，重叠不可读；无 JS 手段矫正绘制位置).
+// Comments are unaffected — they keep their own sidebar right of the page.
+// This is a VIEW setting on the controller, not the model, so it must be
+// re-applied whenever the controller changes (boot AND load_document retarget).
+function showDeletionsInline() {
+  try { ctrl.getViewSettings().setPropertyValue('ShowChangesInMargin', false); }
   catch (e) { log('ShowChangesInMargin 设置失败 / failed: ' + errStr(e)); }
 }
 
@@ -388,7 +391,7 @@ function bootDoc() {
   // change the lawyer can accept/reject. Set once here (and on retarget) instead
   // of per-command, so no edit path can slip through untracked.
   try { xModel.setPropertyValue('RecordChanges', true); } catch {}
-  showDeletionsInMargin();
+  showDeletionsInline();
 
   installKeyHandler();
   try { installModifyListener(xModel); } catch (e) { log('XModifyListener 安装失败 / install failed: ' + errStr(e)); }
@@ -968,7 +971,7 @@ const EXEC = {
       try { installModifyListener(xModel); } catch (e) { log('XModifyListener 安装失败 / install failed: ' + errStr(e)); }
       // Revisions default ON for the real document too (same as bootDoc).
       try { xModel.setPropertyValue('RecordChanges', true); } catch (e) {}
-      showDeletionsInMargin();
+      showDeletionsInline();
     };
 
     const errs = [];
@@ -1440,6 +1443,19 @@ const EXEC = {
         try { item.author = r.getPropertyValue('RedlineAuthor'); } catch (e) {}
         try { item.comment = r.getPropertyValue('RedlineComment'); } catch (e) {}
         try { if (typeof r.getString === 'function') item.text = String(r.getString() || '').slice(0, 80); } catch (e) {}
+        // 行内显示（ShowChangesInMargin=false）下删除文本留在正文流里，redline
+        // 自身 getString() 抛 RuntimeException（页边模式才把文本收进 redline）——
+        // 回退用 RedlineStart/End 区间从正文取；Insert 型两种模式都走这条。
+        if (item.text == null) {
+          try {
+            const rs = r.getPropertyValue('RedlineStart'), re = r.getPropertyValue('RedlineEnd');
+            if (rs && re) {
+              const rcur = rs.getText().createTextCursorByRange(rs);
+              rcur.gotoRange(re, true);
+              item.text = String(rcur.getString() || '').slice(0, 80);
+            }
+          } catch (e) {}
+        }
         out.push(item);
       }
     } catch (e) { return { success: false, message: errStr(e) }; }

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -167,22 +167,23 @@ try {
     await focus()
   }
 
-  // NOTE: ShowChangesInMargin (tdf#34355) is ON since the margin-redlines change —
-  // tracked DELETIONS leave the inline text (they render in the page margin), so
-  // the cursor context no longer contains the struck-through originals. The old
-  // expectations (deleted chars still inline) date from inline-strikethrough mode.
+  // NOTE: ShowChangesInMargin (tdf#34355) is OFF again — the engine paints
+  // margin deletions over the neighboring TABLE CELL's content (法律文书大量
+  // 用表格，重叠不可读), so deletions are back to inline strikethrough. The
+  // struck-through originals therefore stay in the cursor context and the
+  // cursor steps OVER them.
   console.log('== 1) Backspace over pre-existing text (revision-mode jam regression #164) ==')
   await reset('合同条款abc') // inserted with rc OFF -> "original" text; rc back ON
   for (let i = 0; i < 3; i++) await key('Backspace', 'Backspace', 8)
   let c = await cursor()
-  check('3×Backspace 删除移入页边（正文不留）', c.b === '合同条款' && c.a === '', JSON.stringify(c))
+  check('3×Backspace 光标逐字越过原文（划线留正文）', c.b === '合同条款' && c.a === 'abc', JSON.stringify(c))
 
   console.log('== 2) Delete key forward-deletes ==')
   await reset('合同条款abc')
   for (let i = 0; i < 3; i++) await key('ArrowLeft', 'ArrowLeft', 37)
   for (let i = 0; i < 2; i++) await key('Delete', 'Delete', 46)
   c = await cursor()
-  check('2×Delete 前删移入页边（正文不留）', c.b === '合同条款' && c.a === 'c', JSON.stringify(c))
+  check('2×Delete 前删越过原文（划线留正文）', c.b === '合同条款ab' && c.a === 'c', JSON.stringify(c))
 
   console.log('== 3) IME CJK commit + Backspace hard-deletes own insert ==')
   await reset('')
@@ -284,9 +285,10 @@ try {
   check('用户修订署用户名', authors.includes('测试用户'), JSON.stringify(authors))
 
   console.log('== 11) 修订颗粒度：一字之差只标一字，不整段删增 ==')
-  // 口径说明：删除型修订的文本已移入页边、不随 reset 硬清（前面场景的删除记录
-  // 会残留），所以按 author 过滤只看本场景（场景 10 已把作者设为"测试用户"）；
-  // Insert 型修订对象 getString() 拿不到插入文本，插入内容靠正文核对。
+  // 口径说明：按 author 过滤只看本场景的修订（场景 10 已把作者设为"测试用户"），
+  // 防前面场景跨 reset 残留的删除记录混入。行内显示（ShowChangesInMargin=false）
+  // 下删除文本留在正文流：正文断言按「插入在前、划删原文在后」的行内形态核对，
+  // 这个形态本身就证明了颗粒度（整段删增会让整句成对出现）。
   const mine = (rv2) => (rv2.redlines || []).filter((r) => r.author === '测试用户')
   const delTexts = (rv2) => mine(rv2).filter((r) => r.type === 'Delete').map((r) => r.text)
   await reset('我爱你', true)
@@ -295,14 +297,14 @@ try {
   check('find_replace 我爱你→我恨你 只删"爱"（非整句）',
     rv11.success && delTexts(rv11).includes('爱') && delTexts(rv11).every((t2) => (t2 || '').length === 1), JSON.stringify(rv11))
   check('插入也只落一处修订', mine(rv11).filter((r) => r.type === 'Insert').length === 1, JSON.stringify(mine(rv11)))
-  check('正文呈现新句', (await doc()).includes('我恨你'), await doc())
+  check('正文呈现插删并存（恨插入、爱划删留正文）', (await doc()) === '我恨爱你', await doc())
   await reset('甲方应于三十日内向乙方支付服务费。', true)
   await exec('modify_paragraph', { index: 0, newText: '甲方应于六十日内向乙方支付全部服务费。' })
   rv11 = await exec('debug_revisions')
   check('modify_paragraph 散点小改只删"三"（非整段重写）',
     rv11.success && delTexts(rv11).includes('三') && delTexts(rv11).every((t2) => (t2 || '').length === 1), JSON.stringify(rv11))
   check('两处插入各自成修订（六 / 全部）', mine(rv11).filter((r) => r.type === 'Insert').length === 2, JSON.stringify(mine(rv11)))
-  check('改后段落实文正确', (await doc()) === '甲方应于六十日内向乙方支付全部服务费。', await doc())
+  check('改后段落实文正确（划删"三"留正文）', (await doc()) === '甲方应于六三十日内向乙方支付全部服务费。', await doc())
 
   console.log('== 12) add_comment 批注：解释文字挂批注、不进正文 ==')
   await reset('本合同自签署之日起生效。', true)
@@ -361,7 +363,7 @@ try {
     // 方向断言：探针（第 0 期）已实证产出「旧→新」的删/插修订——删除侧应含"三"
     check('方向正确：redlines 含 Delete「三」',
       cmpRedlines.filter((r) => r.type === 'Delete').map((r) => r.text).includes('三'), JSON.stringify(cmpRedlines))
-    check('正文停在新版可读文本', (await doc()).includes('六十日'), await doc())
+    check('正文停在新版+行内划删原文', (await doc()) === '甲方应于六三十日内支付合同价款。', await doc())
   }
 
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')


### PR DESCRIPTION
## 问题

用户设置了批注和修订在侧面显示后，侧面内容与文档正文重叠，表格文档（处罚案例汇总表）里删除文本直接盖在相邻单元格文字上，无法阅读。

## 根因（真机复现实证）

LO 的 ShowChangesInMargin（tdf#34355）把页边删除文本画在**锚点所在 frame 的左侧**：

- 正文段落：frame = 页面文本区，删除文本画进左页边（正常）
- 表格单元格：frame = 单元格，删除文本叠画到**左邻单元格**的正文上（复现截图与用户截图形态一致）

绘制位置由引擎内部决定，宿主 JS 无法矫正。法律文书大量用表格，页边模式不可用。批注侧栏是独立机制（页面右侧专列），无重叠问题，保持不变。

另一发现：该设置并非纯视图设置——开启时删除文本物理移入 redline 对象（getString 可取、正文不含），关闭后留在正文流、redline getString 抛 RuntimeException。不处理的话 AI 侧 doc_debug_revisions 拿不到修订文本。

## 修复

- `office_thread.js`：showDeletionsInMargin → showDeletionsInline，显式关闭 ShowChangesInMargin（boot + retarget 双点）；修订删除回到 Word「所有标记」式行内删除线，任何位置不再叠字
- `debug_revisions` 补 RedlineStart/End 区间回退取文本（行内模式下 getString 不可用；顺带 Insert 型修订文本也能取到了）
- lowa-e2e 组 1/2/11/13 断言从页边口径改回行内口径
- doc-editor.md 记地雷：ShowChangesInMargin 禁用勿开

## 验证

- 无头真机复现：修复前删除文本叠画邻格 → 修复后行内删除线呈现在本格内
- `npm run test:lowa-e2e` 44/44 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)