### PR TITLE
sheet_* 电子表格原语：AI 获得 xlsx 读写与格式化能力

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -50,6 +50,8 @@ description: AI↔文档编辑桥接领域。任务涉及 doc_* 编辑原语、E
 
 EDITOR_ACTIONS 全集在 `libreofficeExecutorClient.js:15-67`（含宿主自发的 load_document/export_document/insert_image/var_*/*_hyperlink 与诊断类 get_ui_lang/probe_modules/list_fonts/debug_revisions）。`ui_command` 是其中一个 action，worker 端再经 UI_COMMANDS 二级白名单映射 `.uno:` 槽（IME 快捷键用，非 AI 管线）。
 
+**电子表格（Calc / xlsx）sheet_\* 原语**：doc_\* 是 Writer 专属（`xModel.getText()` 在 Calc 文档上必然失败），xlsx 走 sheet_\* 七件：`sheet_get_overview / sheet_read_range / sheet_write_cells / sheet_select_range / sheet_format_cells / sheet_set_borders / sheet_set_row_col`（工具名=action 名，不做映射）。worker 端 `resolveSheet` 统一守卫文档类型（非 Calc 返回明确错误）并把命中的工作表切为活动表。Calc 没有 redline，写入即生效——安全网是 doc_undo 与文档检查点（写类工具都打了 `fileEffect="MODIFIED"`）。地雷：`VertJustify` 声明 long、个别引擎按 short 校验（失败退 shortAny）；写入时数字样式字符串落数值但**前导 0 的编号保持文本**；数字格式经 `getNumberFormats().queryKey/addNew`（非法格式码会抛）。
+
 ## 命名双轨现状（PR#192，下个发布周期摘旧名）
 
 仍活着的 wps_* 旧名：后端 `sendDualNamedAction`（doc_open_file/wps_open_file、doc_reload_file/wps_reload_file）、executeEditorCommand 双发 editor_command/wps_command、doc_open_file_sync↔wps_open_file_sync、doc_stream_data/wps_stream_data 双发、`/wps-result` 路由别名；前端 handleClientAction 显式识别全部旧名+latch 去重、toolDisplayNames 把 wps_* 归一为 doc_*。

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -859,6 +859,190 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
+    // ==================== 电子表格（Calc / xlsx）sheet_* 原语 ====================
+    // 打开的 xlsx 由同一 LibreOffice 引擎的 Calc 模块承载；doc_* 的 Writer 原语
+    // （getText 一族）在表格文档上必然失败，表格操作一律走本节 sheet_* 工具。
+    // Calc 没有修订（redline）机制，写入即生效；纠错用 doc_undo，
+    // 首次修改前的文档检查点（fileEffect=MODIFIED）仍是最后防线。
+
+    @Tool("【表格·看】查看当前打开的电子表格（xlsx）的工作表结构：每张工作表的名称、序号、已用区域和行列数。" +
+          "打开 xlsx 后先用本工具了解结构，再决定读哪个区域。Word 文档请用 doc_* 工具，本工具仅对表格文档有效。")
+    public String sheet_get_overview() {
+        log.info("Tool: sheet_get_overview called");
+        try {
+            return editorBridgeService.executeEditorCommand("sheet_get_overview", null);
+        } catch (Exception e) {
+            log.error("Failed to get sheet overview", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【表格·看】读取电子表格指定区域的单元格内容。返回二维数组 rows（文本为字符串、数值/公式结果为数字，日期是序列数）" +
+          "和公式清单 formulas。range 不传则读整个已用区域；区域过大会截断并提示分块读取。")
+    public String sheet_read_range(
+            @P("区域，如 'A1:D20' 或单个单元格 'B3'；不传则读整个已用区域") String range,
+            @P("工作表名称或序号（0 开始）；不传用当前活动工作表") String sheet
+    ) {
+        log.info("Tool: sheet_read_range called range={}, sheet={}", range, sheet);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            if (range != null && !range.isBlank()) params.put("range", range);
+            if (sheet != null && !sheet.isBlank()) params.put("sheet", sheet);
+            return editorBridgeService.executeEditorCommand("sheet_read_range", params);
+        } catch (Exception e) {
+            log.error("Failed to read sheet range", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "写入单元格", category = "document", fileEffect = "MODIFIED")
+    @Tool("【表格·写】从起始单元格开始按二维数组批量写入。rowsJson 是 JSON 二维数组，如 " +
+          "[[\"项目\",\"金额\"],[\"咨询费\",10000],[\"合计\",\"=SUM(B2:B2)\"]]：数字与数字样式字符串写为数值，" +
+          "'=' 开头写为公式，其余写为文本；null 跳过不动该格。写入即生效（无修订痕迹），返回实际写入区域和首行回读值供核对。")
+    public String sheet_write_cells(
+            @P("起始单元格，如 'A1'") String startCell,
+            @P("写入内容，JSON 二维数组") String rowsJson,
+            @P("工作表名称或序号（0 开始）；不传用当前活动工作表") String sheet
+    ) {
+        log.info("Tool: sheet_write_cells called startCell={}, json length={}", startCell, rowsJson != null ? rowsJson.length() : 0);
+        if (startCell == null || startCell.isBlank()) {
+            return "Error: 缺少 startCell 参数（如 'A1'）";
+        }
+        if (rowsJson == null || rowsJson.isBlank()) {
+            return "Error: 缺少 rowsJson 参数（JSON 二维数组）";
+        }
+        try {
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            java.util.List<java.util.List<Object>> rows = mapper.readValue(
+                    rowsJson, new com.fasterxml.jackson.core.type.TypeReference<java.util.List<java.util.List<Object>>>() {});
+            if (rows.isEmpty()) {
+                return "Error: rowsJson 不能为空";
+            }
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("startCell", startCell);
+            params.put("rows", rows);
+            if (sheet != null && !sheet.isBlank()) params.put("sheet", sheet);
+            return editorBridgeService.executeEditorCommand("sheet_write_cells", params);
+        } catch (com.fasterxml.jackson.core.JacksonException je) {
+            return "Error: rowsJson 不是合法的 JSON 二维数组: " + je.getOriginalMessage();
+        } catch (Exception e) {
+            log.error("Failed to write sheet cells", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @Tool("【表格·选】选中电子表格的一个区域（视图滚动到该处并高亮，用户能看到 AI 正在操作哪里）。" +
+          "选中后可接 sheet_format_cells / sheet_set_borders 等格式操作。")
+    public String sheet_select_range(
+            @P("区域，如 'A1:D20' 或单个单元格 'B3'") String range,
+            @P("工作表名称或序号（0 开始）；不传用当前活动工作表") String sheet
+    ) {
+        log.info("Tool: sheet_select_range called range={}, sheet={}", range, sheet);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("range", range != null ? range : "");
+            if (sheet != null && !sheet.isBlank()) params.put("sheet", sheet);
+            return editorBridgeService.executeEditorCommand("sheet_select_range", params);
+        } catch (Exception e) {
+            log.error("Failed to select sheet range", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "设置单元格格式", category = "document", fileEffect = "MODIFIED")
+    @Tool("【表格·格式】设置电子表格区域的格式，只传需要改的参数：加粗/斜体/下划线、字号、字体、字色、底色、" +
+          "水平对齐 hAlign(left/center/right/standard)、垂直对齐 vAlign(top/center/bottom/standard)、自动换行 wrap、" +
+          "数字格式 numberFormat（LibreOffice 格式码，如 '#,##0.00'、'0.00%'、'yyyy-mm-dd'、'@'=文本）。")
+    public String sheet_format_cells(
+            @P("区域，如 'A1:D1'") String range,
+            @P("加粗 true/false，不改则不传") Boolean bold,
+            @P("斜体 true/false，不改则不传") Boolean italic,
+            @P("下划线 true/false，不改则不传") Boolean underline,
+            @P("字号（磅），不改则不传") Double fontSize,
+            @P("字体名，不改则不传") String fontName,
+            @P("文字颜色：#RRGGBB 或 auto，不改则不传") String color,
+            @P("单元格底色：#RRGGBB 或 none，不改则不传") String background,
+            @P("水平对齐：left/center/right/standard，不改则不传") String hAlign,
+            @P("垂直对齐：top/center/bottom/standard，不改则不传") String vAlign,
+            @P("自动换行 true/false，不改则不传") Boolean wrap,
+            @P("数字格式码，如 '#,##0.00'、'0.00%'、'yyyy-mm-dd'，不改则不传") String numberFormat,
+            @P("工作表名称或序号（0 开始）；不传用当前活动工作表") String sheet
+    ) {
+        log.info("Tool: sheet_format_cells called range={}", range);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("range", range != null ? range : "");
+            if (bold != null) params.put("bold", bold);
+            if (italic != null) params.put("italic", italic);
+            if (underline != null) params.put("underline", underline);
+            if (fontSize != null) params.put("fontSize", fontSize);
+            if (fontName != null && !fontName.isBlank()) params.put("fontName", fontName);
+            if (color != null && !color.isBlank()) params.put("color", color);
+            if (background != null && !background.isBlank()) params.put("background", background);
+            if (hAlign != null && !hAlign.isBlank()) params.put("hAlign", hAlign);
+            if (vAlign != null && !vAlign.isBlank()) params.put("vAlign", vAlign);
+            if (wrap != null) params.put("wrap", wrap);
+            if (numberFormat != null && !numberFormat.isBlank()) params.put("numberFormat", numberFormat);
+            if (sheet != null && !sheet.isBlank()) params.put("sheet", sheet);
+            return editorBridgeService.executeEditorCommand("sheet_format_cells", params);
+        } catch (Exception e) {
+            log.error("Failed to format sheet cells", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "设置单元格边框", category = "document", fileEffect = "MODIFIED")
+    @Tool("【表格·格式】给电子表格区域设置边框。preset: all=内外全部框线 / outer=仅外框（内线清除）/ none=清除全部。" +
+          "widthPt 线宽磅数（默认 0.75），color 边框颜色（默认黑色）。")
+    public String sheet_set_borders(
+            @P("区域，如 'A1:D20'") String range,
+            @P("边框样式：all/outer/none，默认 all") String preset,
+            @P("线宽（磅，如 0.75、1.5），默认 0.75") Double widthPt,
+            @P("边框颜色 #RRGGBB，默认黑色") String color,
+            @P("工作表名称或序号（0 开始）；不传用当前活动工作表") String sheet
+    ) {
+        log.info("Tool: sheet_set_borders called range={}, preset={}", range, preset);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("range", range != null ? range : "");
+            if (preset != null && !preset.isBlank()) params.put("preset", preset);
+            if (widthPt != null) params.put("widthPt", widthPt);
+            if (color != null && !color.isBlank()) params.put("color", color);
+            if (sheet != null && !sheet.isBlank()) params.put("sheet", sheet);
+            return editorBridgeService.executeEditorCommand("sheet_set_borders", params);
+        } catch (Exception e) {
+            log.error("Failed to set sheet borders", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "设置行高列宽", category = "document", fileEffect = "MODIFIED")
+    @Tool("【表格·格式】设置电子表格的行高列宽，作用于 range 覆盖到的整行/整列。" +
+          "rowHeightPt/colWidthPt 按磅设定值；autoFitRows/autoFitCols=true 按内容自动适应（优先于定值）。只传需要改的参数。")
+    public String sheet_set_row_col(
+            @P("区域，如 'A1:D1'（其覆盖的整行/整列生效）") String range,
+            @P("行高（磅），不改则不传") Double rowHeightPt,
+            @P("列宽（磅），不改则不传") Double colWidthPt,
+            @P("行高自动适应内容 true，不改则不传") Boolean autoFitRows,
+            @P("列宽自动适应内容 true，不改则不传") Boolean autoFitCols,
+            @P("工作表名称或序号（0 开始）；不传用当前活动工作表") String sheet
+    ) {
+        log.info("Tool: sheet_set_row_col called range={}", range);
+        try {
+            java.util.Map<String, Object> params = new java.util.HashMap<>();
+            params.put("range", range != null ? range : "");
+            if (rowHeightPt != null) params.put("rowHeightPt", rowHeightPt);
+            if (colWidthPt != null) params.put("colWidthPt", colWidthPt);
+            if (autoFitRows != null) params.put("autoFitRows", autoFitRows);
+            if (autoFitCols != null) params.put("autoFitCols", autoFitCols);
+            if (sheet != null && !sheet.isBlank()) params.put("sheet", sheet);
+            return editorBridgeService.executeEditorCommand("sheet_set_row_col", params);
+        } catch (Exception e) {
+            log.error("Failed to set sheet row/col size", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
     // ==================== 调试工具 ====================
 
     @Tool("调试工具：获取文档中所有修订记录的详细信息，包括修订类型、位置、内容等。用于分析和诊断修订模式下的文本操作问题。")

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -474,6 +474,22 @@ for file_id in file_ids:
 |-----|------|
 | `doc_undo(steps)` / `doc_redo(steps)` | 撤销/重做最近的编辑 |
 
+**电子表格（xlsx）——用 sheet_*，不要用 doc_***
+
+打开的活跃文档是 xlsx 时，上面的 doc_* 正文原语（读段落/查找替换/段落格式等）不适用，表格操作一律走 sheet_* 工具：
+
+| 工具 | 用途 |
+|-----|------|
+| `sheet_get_overview()` | **首选**：工作表清单+每张表的已用区域行列数，打开 xlsx 后先看结构 |
+| `sheet_read_range(range, sheet)` | 读区域单元格值（文本为字符串、数值/公式结果为数字，公式串另列）；range 不传读整个已用区域 |
+| `sheet_write_cells(startCell, rowsJson, sheet)` | 从起始格按 JSON 二维数组批量写入；数字落数值、`"=SUM(B2:B5)"` 落公式、其余落文本 |
+| `sheet_select_range(range, sheet)` | 选中区域（视图滚动+高亮，用户看得见） |
+| `sheet_format_cells(range, bold, italic, underline, fontSize, fontName, color, background, hAlign, vAlign, wrap, numberFormat, sheet)` | 单元格格式：字体/字号/加粗/字色/底色/水平垂直对齐/自动换行/数字格式（如 `#,##0.00`、`0.00%`、`yyyy-mm-dd`） |
+| `sheet_set_borders(range, preset, widthPt, color, sheet)` | 边框：all（内外全部）/outer（仅外框）/none（清除） |
+| `sheet_set_row_col(range, rowHeightPt, colWidthPt, autoFitRows, autoFitCols, sheet)` | 行高列宽（磅）或自动适应 |
+
+表格操作要点：sheet 参数是工作表名或序号（0 开始），不传即当前活动工作表；区域一律用 `A1:D20` 形式；**xlsx 上没有修订模式，写入即生效**，改错用 `doc_undo` 撤销（系统在首次修改前已建文档快照，最后手段 `doc_restore_checkpoint()`）；写数据后再做格式（先 `sheet_write_cells`，同一轮接 `sheet_format_cells`/`sheet_set_borders`/`sheet_set_row_col`）。
+
 ### 使用规范
 
 1. **优先用当前活跃文档**：系统提示中若有 `<active_document>`（用户此刻在编辑器里打开的文档），用户说"修订一下""这个文档"或未指明对象时就是指它——所有 doc_* 工具已直接作用于它，**禁止**再调 `doc_list_project_files` / `doc_open_file` 去重新发现或打开。只有要编辑**其他**文档（无活跃文档、或用户明确指定了别的文件）时，才先用 `doc_open_file` 打开目标文档

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -73,6 +73,11 @@ export const EDITOR_ACTIONS = [
   // [流式标准格式] doc_start_stream 的落字端：markdown 剥离 + 标准格式写入。
   // stream_insert 攒行消费，stream_flush 收尾/复位（{discard:true} 换文档硬清）。
   'stream_insert', 'stream_flush',
+  // [Calc 电子表格] sheet_* 原语集：xlsx 的读写/选区/格式/边框/行高列宽。
+  // doc_* 是 Writer 专属（getText 一族在 Calc 上必然失败），表格操作走这组；
+  // worker 侧 resolveSheet 对非 Calc 文档返回明确错误。
+  'sheet_get_overview', 'sheet_read_range', 'sheet_write_cells', 'sheet_select_range',
+  'sheet_format_cells', 'sheet_set_borders', 'sheet_set_row_col',
 ]
 
 /**

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -80,6 +80,14 @@ const NAMES = {
   doc_add_comment: { zh: '添加批注', en: 'Add comment' },
   doc_debug_revisions: { zh: '检查修订记录', en: 'Inspect revisions' },
   doc_restore_checkpoint: { zh: '恢复文档快照', en: 'Restore snapshot' },
+  // 电子表格（Calc / xlsx）sheet_* 原语
+  sheet_get_overview: { zh: '查看工作表结构', en: 'Sheet overview' },
+  sheet_read_range: { zh: '读取单元格区域', en: 'Read cells' },
+  sheet_write_cells: { zh: '写入单元格', en: 'Write cells' },
+  sheet_select_range: { zh: '选中单元格区域', en: 'Select cells' },
+  sheet_format_cells: { zh: '设置单元格格式', en: 'Format cells' },
+  sheet_set_borders: { zh: '设置单元格边框', en: 'Set cell borders' },
+  sheet_set_row_col: { zh: '设置行高列宽', en: 'Set row/column size' },
   // PPT
   pptx_check_service: { zh: '检查PPT服务', en: 'Check PPT service' },
   pptx_generate: { zh: '生成PPT演示文稿', en: 'Generate slides' },

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -643,6 +643,78 @@ function cursorToParagraphAfterTable(table) {
   if (!placed) { try { vc.gotoEnd(false); } catch (e) {} }
 }
 
+// ---- Calc（电子表格 sheet_*）原语 helpers ------------------------------------
+// 引擎含 Calc 模块（probe_modules 实锤），xlsx 经 load_document 正常打开，但
+// doc_* 一族全走 xModel.getText()（Writer 专属），在 Calc 文档上必然失败——
+// sheet_* 是 Calc 文档的对等原语集。文档类型守卫集中在 resolveSheet。
+function isCalcDoc() {
+  try { return !!(xModel && xModel.supportsService && xModel.supportsService('com.sun.star.sheet.SpreadsheetDocument')); }
+  catch (e) { return false; }
+}
+const NOT_SPREADSHEET_MSG = '当前打开的不是电子表格文档：sheet_* 原语仅对 xlsx/xls 生效。Word 文档请用 doc_* 原语；要操作表格文件请先用 doc_open_file 打开它。';
+// 解析 sheet 参数（工作表名或 0 开始的序号；缺省 = 当前活动工作表）。
+// 返回 {sheet} 或 {error}。命中非活动工作表时切为活动（拟人：用户看得见操作在哪张表）。
+function resolveSheet(p) {
+  if (!isCalcDoc()) return { error: NOT_SPREADSHEET_MSG };
+  const sheets = xModel.getSheets();
+  let sheet = null;
+  const want = p && p.sheet != null && String(p.sheet).trim() !== '' ? String(p.sheet).trim() : null;
+  if (want == null) {
+    try { sheet = ctrl.getActiveSheet(); } catch (e) {}
+    if (!sheet) sheet = sheets.getByIndex(0);
+  } else if (/^\d+$/.test(want)) {
+    const i = Number(want);
+    if (i >= sheets.getCount()) return { error: '工作表序号越界: ' + i + '（共 ' + sheets.getCount() + ' 张，0 开始）' };
+    sheet = sheets.getByIndex(i);
+  } else {
+    if (!sheets.hasByName(want)) return { error: '工作表不存在: ' + want };
+    sheet = sheets.getByName(want);
+  }
+  try {
+    const active = ctrl.getActiveSheet();
+    if (!active || active.getName() !== sheet.getName()) ctrl.setActiveSheet(sheet);
+  } catch (e) {}
+  return { sheet: sheet };
+}
+function sheetRange(sheet, rangeStr) {
+  try { return sheet.getCellRangeByName(String(rangeStr)); } catch (e) { return null; }
+}
+function colLetterOf(n) { // 0 -> A, 25 -> Z, 26 -> AA
+  let s = '';
+  n = Number(n);
+  do { s = String.fromCharCode(65 + (n % 26)) + s; n = Math.floor(n / 26) - 1; } while (n >= 0);
+  return s;
+}
+function sheetRangeName(addr) {
+  const a = colLetterOf(addr.StartColumn) + (addr.StartRow + 1);
+  const b = colLetterOf(addr.EndColumn) + (addr.EndRow + 1);
+  return a === b ? a : a + ':' + b;
+}
+function usedRangeAddress(sheet) {
+  const cur = sheet.createCursor();
+  cur.gotoStartOfUsedArea(false);
+  cur.gotoEndOfUsedArea(true);
+  return cur.getRangeAddress();
+}
+// 单元格读值归一：空→''，数值→number，公式→数值结果给 number、文本结果给 string。
+// FormulaResultType 是 long 常量组（FormulaResult.VALUE=1），走 unoEnumVal 兜底。
+function readCellOut(cell) {
+  const T = css.table.CellContentType;
+  const t = cell.getType();
+  if (enumEq(t, T.EMPTY)) return '';
+  if (enumEq(t, T.VALUE)) return cell.getValue();
+  if (enumEq(t, T.FORMULA)) {
+    try {
+      const FR_VALUE = (css.sheet && css.sheet.FormulaResult && css.sheet.FormulaResult.VALUE != null) ? css.sheet.FormulaResult.VALUE : 1;
+      if (unoEnumVal(cell.getPropertyValue('FormulaResultType')) === unoEnumVal(FR_VALUE)) return cell.getValue();
+    } catch (e) {}
+  }
+  return cell.getString();
+}
+// 写入时把"长得像数字"的字符串落成数值（同 NUMERIC_CELL_RE 的 house 口径，但
+// 更严格：前导 0 的编号（如 '001'）保持文本，避免证照号/编号被吞前导零）。
+const SHEET_NUMERIC_RE = /^-?(0|[1-9]\d*)(\.\d+)?$/;
+
 // ---- 流式写入状态机：markdown 行级解析 → 标准格式落字 ------------------------
 // stream_insert 攒字节、按完整行消费；stream_flush 收尾（写掉尾行/尾表、复位）。
 // 状态在 worker 内（宿主只透传 token），文档换人/换流由宿主在 open_sync 时
@@ -2153,6 +2225,253 @@ const EXEC = {
         ctrl.getFrame(), '.uno:EditDoc', '', 0, []);
     } catch (e) {}
     return { success: true, redlineCount: count };
+  },
+  // ==================== Calc 电子表格原语（sheet_*） ====================
+  // 与 doc_* 平行的 xlsx 操作面。Calc 没有 Writer 的修订（redline）机制，写入
+  // 即生效；安全网是 undo（Calc 的 UndoManager 同样可用）与后端文档检查点。
+  // [表格·看] 工作表清单 + 每张表的已用区域。打开 xlsx 后的第一步。
+  sheet_get_overview() {
+    if (!isCalcDoc()) return { success: false, message: NOT_SPREADSHEET_MSG };
+    const sheets = xModel.getSheets();
+    let activeName = '';
+    try { activeName = ctrl.getActiveSheet().getName(); } catch (e) {}
+    const out = [];
+    const n = Math.min(sheets.getCount(), 50);
+    for (let i = 0; i < n; i++) {
+      const s = sheets.getByIndex(i);
+      const item = { index: i, name: s.getName(), active: s.getName() === activeName };
+      try {
+        const addr = usedRangeAddress(s);
+        item.usedRange = sheetRangeName(addr);
+        item.rows = addr.EndRow - addr.StartRow + 1;
+        item.cols = addr.EndColumn - addr.StartColumn + 1;
+      } catch (e) { item.usedRangeErr = errStr(e); }
+      out.push(item);
+    }
+    return { success: true, sheetCount: sheets.getCount(), activeSheet: activeName, sheets: out };
+  },
+  // [表格·看] 读取区域单元格值。数值/公式结果返回 number（日期是序列数），公式串
+  // 另列在 formulas。range 缺省 = 该表已用区域。超上限窗口化返回，提示分块读。
+  sheet_read_range(p) {
+    const r0 = resolveSheet(p);
+    if (r0.error) return { success: false, message: r0.error };
+    const sheet = r0.sheet;
+    let range;
+    if (p && p.range) {
+      range = sheetRange(sheet, p.range);
+      if (!range) return { success: false, message: '无效的区域: ' + p.range + '（应为 A1 或 A1:D20 形式）' };
+    } else {
+      try { range = sheet.getCellRangeByName(sheetRangeName(usedRangeAddress(sheet))); }
+      catch (e) { return { success: false, message: '读取已用区域失败: ' + errStr(e) }; }
+    }
+    const addr = range.getRangeAddress();
+    const nRows = addr.EndRow - addr.StartRow + 1;
+    const nCols = addr.EndColumn - addr.StartColumn + 1;
+    const MAX_CELLS = 2000;
+    const colCap = Math.min(nCols, 100);
+    const rowCap = Math.min(nRows, Math.max(1, Math.floor(MAX_CELLS / colCap)));
+    const rows = [];
+    const formulas = [];
+    for (let r = 0; r < rowCap; r++) {
+      const row = [];
+      for (let c = 0; c < colCap; c++) {
+        const cell = range.getCellByPosition(c, r);
+        row.push(readCellOut(cell));
+        try {
+          if (enumEq(cell.getType(), css.table.CellContentType.FORMULA) && formulas.length < 100) {
+            formulas.push({ cell: colLetterOf(addr.StartColumn + c) + (addr.StartRow + r + 1), formula: cell.getFormula() });
+          }
+        } catch (e) {}
+      }
+      rows.push(row);
+    }
+    const res = { success: true, sheet: sheet.getName(), range: sheetRangeName(addr), rows: rows };
+    if (formulas.length) res.formulas = formulas;
+    if (rowCap < nRows || colCap < nCols) {
+      res.truncated = true;
+      res.note = '区域超过上限（' + MAX_CELLS + ' 格），只返回前 ' + rowCap + ' 行 × ' + colCap + ' 列，请缩小 range 分块读取';
+    }
+    return res;
+  },
+  // [表格·写] 从 startCell 起按二维数组批量写入。number/数字样式字符串落数值，
+  // '=' 开头落公式，其余落文本；null 跳过不动，'' 清空该格。写完选中写过的区域
+  // 并回读首行做验证回路。
+  sheet_write_cells(p) {
+    const r0 = resolveSheet(p);
+    if (r0.error) return { success: false, message: r0.error };
+    const sheet = r0.sheet;
+    const rows = p && p.rows;
+    if (!Array.isArray(rows) || !rows.length) return { success: false, message: 'sheet_write_cells requires {rows: any[][]}' };
+    if (rows.length > 500) return { success: false, message: '一次最多写 500 行，请分批写入' };
+    const anchor = sheetRange(sheet, String(p.startCell || 'A1'));
+    if (!anchor) return { success: false, message: '无效的起始单元格: ' + p.startCell };
+    const a0 = anchor.getRangeAddress();
+    let nCols = 1;
+    for (let i = 0; i < rows.length; i++) if (Array.isArray(rows[i])) nCols = Math.max(nCols, rows[i].length);
+    if (nCols > 100) return { success: false, message: '一次最多写 100 列，请分批写入' };
+    let written = 0;
+    for (let r = 0; r < rows.length; r++) {
+      const line = Array.isArray(rows[r]) ? rows[r] : [rows[r]];
+      for (let c = 0; c < line.length; c++) {
+        const v = line[c];
+        if (v == null) continue;
+        const cell = sheet.getCellByPosition(a0.StartColumn + c, a0.StartRow + r);
+        if (typeof v === 'number') cell.setValue(v);
+        else if (typeof v === 'boolean') cell.setValue(v ? 1 : 0);
+        else {
+          const s = String(v);
+          if (s.charAt(0) === '=') cell.setFormula(s);
+          else if (SHEET_NUMERIC_RE.test(s.trim())) cell.setValue(Number(s.trim()));
+          else cell.setString(s);
+        }
+        written++;
+      }
+    }
+    const wrote = sheetRangeName({
+      StartColumn: a0.StartColumn, StartRow: a0.StartRow,
+      EndColumn: a0.StartColumn + nCols - 1, EndRow: a0.StartRow + rows.length - 1,
+    });
+    try { ctrl.select(sheet.getCellRangeByName(wrote)); } catch (e) {} // 拟人：用户看到写入落点
+    const firstRowAfterWrite = [];
+    try {
+      const vr = sheet.getCellRangeByName(wrote);
+      for (let c = 0; c < Math.min(nCols, 10); c++) firstRowAfterWrite.push(readCellOut(vr.getCellByPosition(c, 0)));
+    } catch (e) {}
+    return { success: true, sheet: sheet.getName(), range: wrote, cellsWritten: written, firstRowAfterWrite: firstRowAfterWrite };
+  },
+  // [表格·选] 选中一个区域（视图滚过去、选区亮出来——用户看得见 AI 在操作哪里）。
+  sheet_select_range(p) {
+    const r0 = resolveSheet(p);
+    if (r0.error) return { success: false, message: r0.error };
+    const range = sheetRange(r0.sheet, String(p.range || ''));
+    if (!range) return { success: false, message: '无效的区域: ' + (p.range || '(空)') };
+    try { ctrl.select(range); } catch (e) { return { success: false, message: '选中失败: ' + errStr(e) }; }
+    const addr = range.getRangeAddress();
+    return {
+      success: true, sheet: r0.sheet.getName(), range: sheetRangeName(addr),
+      topLeftText: String(range.getCellByPosition(0, 0).getString() || ''),
+    };
+  },
+  // [表格·格式] 区域格式：字体/字号/加粗/斜体/下划线/字色/底色/水平垂直对齐/
+  // 自动换行/数字格式。CJK 走 Asian/Complex 姊妹属性（setCharProp）。
+  sheet_format_cells(p) {
+    const r0 = resolveSheet(p);
+    if (r0.error) return { success: false, message: r0.error };
+    const range = sheetRange(r0.sheet, String(p.range || ''));
+    if (!range) return { success: false, message: '无效的区域: ' + (p.range || '(空)') };
+    const applied = {};
+    if (p.bold != null) { setCharProp(range, 'CharWeight', p.bold ? css.awt.FontWeight.BOLD : css.awt.FontWeight.NORMAL); applied.bold = !!p.bold; }
+    if (p.italic != null) { setCharProp(range, 'CharPosture', p.italic ? css.awt.FontSlant.ITALIC : css.awt.FontSlant.NONE); applied.italic = !!p.italic; }
+    if (p.underline != null) { range.setPropertyValue('CharUnderline', p.underline ? css.awt.FontUnderline.SINGLE : css.awt.FontUnderline.NONE); applied.underline = !!p.underline; }
+    if (p.fontSize != null) { setCharProp(range, 'CharHeight', Number(p.fontSize)); applied.fontSize = Number(p.fontSize); }
+    if (p.fontName != null && String(p.fontName) !== '') { setCharProp(range, 'CharFontName', String(p.fontName)); applied.fontName = String(p.fontName); }
+    if (p.color != null) {
+      const c = parseColor(p.color, { auto: -1 });
+      if (c == null) return { success: false, message: 'bad color: ' + p.color + ' (use #RRGGBB or auto)' };
+      range.setPropertyValue('CharColor', c); applied.color = String(p.color);
+    }
+    if (p.background != null) {
+      const c = parseColor(p.background, { none: -1 });
+      if (c == null) return { success: false, message: 'bad background: ' + p.background + ' (use #RRGGBB or none)' };
+      range.setPropertyValue('CellBackColor', c); applied.background = String(p.background);
+    }
+    if (p.hAlign != null) {
+      const m = { left: css.table.CellHoriJustify.LEFT, center: css.table.CellHoriJustify.CENTER, right: css.table.CellHoriJustify.RIGHT, standard: css.table.CellHoriJustify.STANDARD };
+      const v = m[String(p.hAlign).toLowerCase()];
+      if (v == null) return { success: false, message: 'bad hAlign: ' + p.hAlign + ' (left/center/right/standard)' };
+      range.setPropertyValue('HoriJustify', v); applied.hAlign = String(p.hAlign);
+    }
+    if (p.vAlign != null) {
+      // VertJustify 声明为 long（CellVertJustify2 常量 0..3）；个别引擎仍按
+      // short 校验，失败退 shortAny（PR#107 的 short 型属性教训）。
+      const m = { standard: 0, top: 1, center: 2, bottom: 3 };
+      const v = m[String(p.vAlign).toLowerCase()];
+      if (v == null) return { success: false, message: 'bad vAlign: ' + p.vAlign + ' (top/center/bottom/standard)' };
+      try { range.setPropertyValue('VertJustify', v); }
+      catch (e) { range.setPropertyValue('VertJustify', shortAny(v)); }
+      applied.vAlign = String(p.vAlign);
+    }
+    if (p.wrap != null) { range.setPropertyValue('IsTextWrapped', !!p.wrap); applied.wrap = !!p.wrap; }
+    if (p.numberFormat != null && String(p.numberFormat) !== '') {
+      const fmt = String(p.numberFormat);
+      try {
+        const formats = xModel.getNumberFormats();
+        const loc = new css.lang.Locale({ Language: '', Country: '', Variant: '' });
+        let key = formats.queryKey(fmt, loc, false);
+        if (key === -1) key = formats.addNew(fmt, loc);
+        range.setPropertyValue('NumberFormat', key);
+        applied.numberFormat = fmt;
+      } catch (e) { return { success: false, message: '数字格式无效: ' + fmt + ' — ' + errStr(e) }; }
+    }
+    if (Object.keys(applied).length === 0) return { success: false, message: 'no format params given' };
+    try { ctrl.select(range); } catch (e) {} // 拟人：让用户看到被格式化的区域
+    return { success: true, sheet: r0.sheet.getName(), range: sheetRangeName(range.getRangeAddress()), applied: applied };
+  },
+  // [表格·格式] 区域边框。preset: all（内外全部）/ outer（仅外框，内线清除）/
+  // none（全部清除）。同 Writer 表格走 TableBorder2（typedef 编组依赖 vendored
+  // zeta.js 的 TYPEDEF 分支，见 zetajs 编组硬规则）。
+  sheet_set_borders(p) {
+    const r0 = resolveSheet(p);
+    if (r0.error) return { success: false, message: r0.error };
+    const range = sheetRange(r0.sheet, String(p.range || ''));
+    if (!range) return { success: false, message: '无效的区域: ' + (p.range || '(空)') };
+    const preset = String(p.preset || 'all').toLowerCase();
+    if (['all', 'outer', 'none'].indexOf(preset) === -1) return { success: false, message: 'bad preset: ' + preset + ' (all/outer/none)' };
+    const widthPt = Number(p.widthPt) || 0.75;
+    const widthMm = ptToMm100(widthPt);
+    const color = p.color != null ? parseColor(p.color, { black: 0 }) : 0;
+    if (color == null) return { success: false, message: 'bad color: ' + p.color + ' (use #RRGGBB)' };
+    const solid = (css.table.BorderLineStyle && css.table.BorderLineStyle.SOLID != null) ? css.table.BorderLineStyle.SOLID : 0;
+    const mk = function (on) {
+      return new css.table.BorderLine2({
+        Color: color, InnerLineWidth: 0, OuterLineWidth: 0, LineDistance: 0,
+        LineStyle: solid, LineWidth: on ? widthMm : 0,
+      });
+    };
+    const outer = mk(preset !== 'none');
+    const inner = mk(preset === 'all');
+    const tb = new css.table.TableBorder2({
+      TopLine: outer, BottomLine: outer, LeftLine: outer, RightLine: outer,
+      HorizontalLine: inner, VerticalLine: inner,
+      IsTopLineValid: true, IsBottomLineValid: true, IsLeftLineValid: true,
+      IsRightLineValid: true, IsHorizontalLineValid: true, IsVerticalLineValid: true,
+      Distance: 0, IsDistanceValid: false,
+    });
+    try { range.setPropertyValue('TableBorder2', tb); } catch (e) { return { success: false, message: '边框设置失败: ' + errStr(e) }; }
+    return {
+      success: true, sheet: r0.sheet.getName(), range: sheetRangeName(range.getRangeAddress()),
+      preset: preset, widthPt: preset === 'none' ? 0 : widthPt,
+    };
+  },
+  // [表格·格式] 行高列宽：作用于 range 覆盖到的整行/整列。autoFit* 优先于定值。
+  sheet_set_row_col(p) {
+    const r0 = resolveSheet(p);
+    if (r0.error) return { success: false, message: r0.error };
+    const range = sheetRange(r0.sheet, String(p.range || ''));
+    if (!range) return { success: false, message: '无效的区域: ' + (p.range || '(空)') };
+    const applied = {};
+    try {
+      if (p.autoFitRows || p.rowHeightPt != null) {
+        const rows = range.getRows();
+        for (let i = 0; i < rows.getCount(); i++) {
+          const row = rows.getByIndex(i);
+          if (p.autoFitRows) row.setPropertyValue('OptimalHeight', true);
+          else { row.setPropertyValue('OptimalHeight', false); row.setPropertyValue('Height', ptToMm100(p.rowHeightPt)); }
+        }
+        if (p.autoFitRows) applied.autoFitRows = true; else applied.rowHeightPt = Number(p.rowHeightPt);
+      }
+      if (p.autoFitCols || p.colWidthPt != null) {
+        const cols = range.getColumns();
+        for (let i = 0; i < cols.getCount(); i++) {
+          const col = cols.getByIndex(i);
+          if (p.autoFitCols) col.setPropertyValue('OptimalWidth', true);
+          else col.setPropertyValue('Width', ptToMm100(p.colWidthPt));
+        }
+        if (p.autoFitCols) applied.autoFitCols = true; else applied.colWidthPt = Number(p.colWidthPt);
+      }
+    } catch (e) { return { success: false, message: '行高列宽设置失败: ' + errStr(e) }; }
+    if (Object.keys(applied).length === 0) return { success: false, message: 'no params given (rowHeightPt/colWidthPt/autoFitRows/autoFitCols)' };
+    return { success: true, sheet: r0.sheet.getName(), range: sheetRangeName(range.getRangeAddress()), applied: applied };
   },
   // housekeeping: drop the hidden anchor bookmarks.
   clear_anchors() {

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -110,6 +110,41 @@ const DEBUG_ACTIONS = `
     } catch (e) { out.b2Err = errStr(e); }
     return out;
   },
+  debug_fresh_calc() {
+    // 组 16 探针：换一份全新空白 Calc 文档（sheet_* 原语在真 Calc 模型上验证），
+    // 与 debug_fresh_document 同一条 private:factory 路径。
+    try {
+      const loaded = desktop.loadComponentFromURL('private:factory/scalc', '_blank', 0, [mkProp('Hidden', true)]);
+      if (!loaded) return { success: false, message: 'loadComponentFromURL returned null' };
+      xModel = loaded;
+      ctrl = loaded.getCurrentController();
+      return { success: true };
+    } catch (e) { return { success: false, message: errStr(e) }; }
+  },
+  debug_sheet_cell_info(p) {
+    // 组 16 探针：读单元格格式落点。枚举比较在 worker 侧做完返回布尔（enumEq，
+    // LO 对枚举属性可能读回裸 short）；VertJustify 是 long 常量组直接比数值。
+    try {
+      const sheet = ctrl.getActiveSheet();
+      const range = sheet.getCellRangeByName(String(p.cell || 'A1'));
+      const cell = range.getCellByPosition(0, 0);
+      const out = { success: true, text: cell.getString(), value: cell.getValue() };
+      try { out.bold = cell.getPropertyValue('CharWeight') > 100; } catch (e) {}
+      try { out.sizePt = cell.getPropertyValue('CharHeight'); } catch (e) {}
+      try { out.hCenter = enumEq(cell.getPropertyValue('HoriJustify'), css.table.CellHoriJustify.CENTER); } catch (e) {}
+      try { out.hRight = enumEq(cell.getPropertyValue('HoriJustify'), css.table.CellHoriJustify.RIGHT); } catch (e) {}
+      try { out.vCenter = unoEnumVal(cell.getPropertyValue('VertJustify')) === 2; } catch (e) {}
+      try { out.bg = cell.getPropertyValue('CellBackColor'); } catch (e) {}
+      try {
+        const key = cell.getPropertyValue('NumberFormat');
+        out.numberFormat = xModel.getNumberFormats().getByKey(key).getPropertyValue('FormatString');
+      } catch (e) {}
+      try { out.borderTopWidth = cell.getPropertyValue('TopBorder2').LineWidth; } catch (e) {}
+      try { out.rowHeightMm = range.getRows().getByIndex(0).getPropertyValue('Height'); } catch (e) {}
+      try { out.colWidthMm = range.getColumns().getByIndex(0).getPropertyValue('Width'); } catch (e) {}
+      return out;
+    } catch (e) { return { success: false, message: errStr(e) }; }
+  },
 `
 function patchServed(urlPath, content) {
   if (urlPath === '/office_thread.js') {
@@ -120,8 +155,8 @@ function patchServed(urlPath, content) {
   if (/^\/assets\/editor-.*\.js$/.test(urlPath)) {
     const s = content.toString('utf8')
     return Buffer.from(
-      s.replace("'get_hyperlink_at_cursor'", "'get_hyperlink_at_cursor','debug_set_record_changes','debug_char_prop','debug_list_comments','debug_fresh_document','debug_table_info'")
-        .replace('"get_hyperlink_at_cursor"', '"get_hyperlink_at_cursor","debug_set_record_changes","debug_char_prop","debug_list_comments","debug_fresh_document","debug_table_info"'),
+      s.replace("'get_hyperlink_at_cursor'", "'get_hyperlink_at_cursor','debug_set_record_changes','debug_char_prop','debug_list_comments','debug_fresh_document','debug_table_info','debug_fresh_calc','debug_sheet_cell_info'")
+        .replace('"get_hyperlink_at_cursor"', '"get_hyperlink_at_cursor","debug_set_record_changes","debug_char_prop","debug_list_comments","debug_fresh_document","debug_table_info","debug_fresh_calc","debug_sheet_cell_info"'),
       'utf8')
   }
   return content
@@ -491,6 +526,66 @@ try {
       const fm2 = await exec('get_formatting')
       check('小标题=正文字号但加粗', fm2.character.bold === true && Math.abs(fm2.character.sizePt - 12) < 0.2, JSON.stringify(fm2.character))
     }
+  }
+
+  // ---------- 组 16：Calc 电子表格原语（sheet_*）----------
+  console.log('\n[16] Calc sheet_* 原语：读写 / 选区 / 格式 / 边框 / 行高列宽')
+  {
+    // 文档类型守卫：Writer 文档上 sheet_* 应报"不是电子表格"，而不是抛 UNO 异常
+    const guard = await exec('sheet_get_overview')
+    check('Writer 文档上 sheet_* 被明确拒绝', guard.success === false && /电子表格/.test(guard.message || ''), JSON.stringify(guard))
+
+    const fresh = await exec('debug_fresh_calc')
+    check('换新 Calc 文档成功', fresh && fresh.success === true, JSON.stringify(fresh))
+
+    const ov = await exec('sheet_get_overview')
+    check('sheet_get_overview 列出工作表', ov.success === true && ov.sheetCount >= 1 && !!ov.activeSheet, JSON.stringify(ov))
+
+    const wr = await exec('sheet_write_cells', {
+      startCell: 'A1',
+      rows: [['项目', '金额'], ['咨询费', 10000], ['律师费', '2500.5'], ['合计', '=SUM(B2:B3)'], ['编号', '001']],
+    })
+    check('sheet_write_cells 写入 5×2', wr.success === true && wr.range === 'A1:B5' && wr.cellsWritten === 10, JSON.stringify(wr))
+    check('写入验证回路返回首行', Array.isArray(wr.firstRowAfterWrite) && wr.firstRowAfterWrite[0] === '项目', JSON.stringify(wr.firstRowAfterWrite))
+
+    const rd = await exec('sheet_read_range', { range: 'A1:B5' })
+    check('读回：文本/数值/数字串转数值/公式结果', rd.success === true
+      && rd.rows[0][0] === '项目' && rd.rows[1][1] === 10000 && rd.rows[2][1] === 2500.5 && rd.rows[3][1] === 12500.5,
+      JSON.stringify(rd.rows))
+    check('前导 0 编号保持文本', rd.rows[4][1] === '001', JSON.stringify(rd.rows[4]))
+    check('公式串可见', (rd.formulas || []).some((f) => f.cell === 'B4' && /SUM/i.test(f.formula)), JSON.stringify(rd.formulas))
+
+    const rdAll = await exec('sheet_read_range', {})
+    check('缺省读已用区域', rdAll.success === true && rdAll.range === 'A1:B5', JSON.stringify(rdAll.range))
+
+    const sel = await exec('sheet_select_range', { range: 'A1:B5' })
+    check('sheet_select_range 成功', sel.success === true && sel.range === 'A1:B5' && sel.topLeftText === '项目', JSON.stringify(sel))
+
+    const fc = await exec('sheet_format_cells', { range: 'A1:B1', bold: true, fontSize: 12, hAlign: 'center', vAlign: 'center', background: '#EEEEEE' })
+    check('表头格式设置成功', fc.success === true, JSON.stringify(fc))
+    const nf = await exec('sheet_format_cells', { range: 'B2:B4', numberFormat: '#,##0.00', hAlign: 'right' })
+    check('数字格式+右对齐设置成功', nf.success === true, JSON.stringify(nf))
+    let ci = await exec('debug_sheet_cell_info', { cell: 'A1' })
+    check('A1 加粗/水平垂直居中/12 号/底色', ci.bold === true && ci.hCenter === true && ci.vCenter === true
+      && Math.abs(ci.sizePt - 12) < 0.2 && ci.bg === 0xEEEEEE, JSON.stringify(ci))
+    ci = await exec('debug_sheet_cell_info', { cell: 'B2' })
+    check('B2 数字格式 #,##0.00 且右对齐', ci.numberFormat === '#,##0.00' && ci.hRight === true, JSON.stringify(ci))
+
+    const bd = await exec('sheet_set_borders', { range: 'A1:B5', preset: 'all', widthPt: 1.5 })
+    check('边框设置成功', bd.success === true, JSON.stringify(bd))
+    ci = await exec('debug_sheet_cell_info', { cell: 'A1' })
+    check('A1 上边框 1.5 磅（53/100mm）', Math.abs((ci.borderTopWidth || 0) - 53) <= 1, JSON.stringify(ci.borderTopWidth))
+
+    const rc = await exec('sheet_set_row_col', { range: 'A1:B1', rowHeightPt: 24, colWidthPt: 90 })
+    check('行高列宽设置成功', rc.success === true, JSON.stringify(rc))
+    ci = await exec('debug_sheet_cell_info', { cell: 'A1' })
+    check('行高 24 磅（≈847/100mm）', Math.abs((ci.rowHeightMm || 0) - 847) <= 5, JSON.stringify(ci.rowHeightMm))
+    check('列宽 90 磅（≈3175/100mm）', Math.abs((ci.colWidthMm || 0) - 3175) <= 10, JSON.stringify(ci.colWidthMm))
+
+    const bad = await exec('sheet_read_range', { range: 'not-a-range' })
+    check('非法区域被拒绝', bad.success === false, JSON.stringify(bad))
+    const badSheet = await exec('sheet_read_range', { sheet: '不存在的表' })
+    check('不存在的工作表被拒绝', badSheet.success === false && /工作表不存在/.test(badSheet.message || ''), JSON.stringify(badSheet))
   }
 
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')


### PR DESCRIPTION
## 背景

AI 文档编辑原语（office_thread.js EXEC 表 + DocumentEditTools）全部是 Writer 实现——`xModel.getText()` 在 Calc 文档上必然失败。引擎本身含 Calc 模块（probe_modules 实锤），xlsx 也能正常打开进编辑器，但 AI 对它零操作能力。

## 内容

与 doc_* 平行的 **sheet_* 七件原语**，四件套全链路接通（DocumentEditTools @Tool + EDITOR_ACTIONS 白名单 + office_thread.js worker 实现 + toolDisplayNames 中文名；工具名=action 名不做映射）：

| 原语 | 能力 |
|---|---|
| sheet_get_overview | 工作表清单+已用区域行列数 |
| sheet_read_range | 读区域：文本/数值/公式结果，公式串另列；缺省读已用区域，超 2000 格窗口化 |
| sheet_write_cells | 二维批量写：数字落数值、`=` 落公式、前导 0 编号保文本；返回首行回读做验证回路 |
| sheet_select_range | 可见选区（视图滚动+高亮） |
| sheet_format_cells | 字体/字号/加粗/斜体/下划线/字色/底色/水平垂直对齐/自动换行/数字格式 |
| sheet_set_borders | all/outer/none 边框（TableBorder2） |
| sheet_set_row_col | 行高列宽（磅）/自动适应 |

要点：
- worker 端 `resolveSheet` 统一守卫文档类型：Writer 文档上返回明确错误而非 UNO 异常；命中的非活动工作表切为活动表（拟人）
- Calc 无 redline，写入即生效：写类工具打 `fileEffect=MODIFIED` 沿用文档检查点安全网
- 编组硬规则遵守：VertJustify long 失败退 shortAny；CJK 走 Asian/Complex 姊妹属性；数字格式 queryKey/addNew
- system_prompt 增电子表格小节（xlsx 用 sheet_* 不用 doc_*）；ai-doc-bridge.md 领域文档同步

## 验证

- `cd backend && mvn test`（JDK 21）全绿
- `npm run check:emits` 通过
- `npm run test:lowa-e2e` 新增组 16（debug_fresh_calc / debug_sheet_cell_info 探针，21 项断言：类型守卫、数值/公式/前导零口径、格式与边框落点、行高列宽换算、非法区域/工作表拒绝），真引擎 **94 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)