### PR TITLE
pptx 服务格式能力补齐：markdown 治理落字 + HOUSE 字体 + 存量文件格式操作端点

### DIFF
--- a/pptx-service/UPGRADE_CHECKBA.md
+++ b/pptx-service/UPGRADE_CHECKBA.md
@@ -13,6 +13,12 @@
 | `docker-compose.yml` / `docker-compose.prod.yml` | 宿主机端口默认 `5001:5000`（对齐 PptxServiceClient 默认 base-url） |
 | `requirements.lock` | 桌面打包/CI 用（`desktop/scripts/prepare-python-service.js`、`.github/workflows/desktop-build.yml`）。再生成：`uv export --no-dev --no-hashes --no-emit-project -o requirements.lock` |
 | `compat_smoke_test.sh` / 本文件 | checkba 侧新增，上游没有 |
+| `backend/utils/text_sanitizer.py` | **checkba 新增**：markdown 治理（行内标记转真格式、列表前缀转 bullet 语义、纯剥离），落字防线 |
+| `backend/utils/pptx_format_utils.py` | **checkba 新增**：run/段落格式读写（东亚字体 `<a:ea>`、删除线、高亮、buChar/buAutoNum 的 oxml 补齐；HOUSE 字体常量 楷体_GB2312/Arial，env `PPTX_HOUSE_EA_FONT`/`PPTX_HOUSE_LATIN_FONT` 可覆盖） |
+| `backend/utils/pptx_builder.py` | **checkba 改造**：`add_text_element`/`add_table_element` 落字走 sanitizer（markdown → 真格式）、写 HOUSE 字体、多行文本逐行成段修复只有首段吃到样式的缺陷、列表行写真实项目符号；`_set_core_properties` 去掉必抛的 `last_printed=None` |
+| `backend/services/pptx_format_service.py` + `backend/controllers/pptx_edit_controller.py` | **checkba 新增**：存量 pptx 格式识别与操作端点 `POST /api/pptx/inspect`、`POST /api/pptx/format`（六种 op：run 格式/段落格式/替换文本/整框重写/单元格文本/单元格格式），注册见 `app.py`、`controllers/__init__.py` 的 `[checkba]` 标记 |
+| `backend/services/prompts.py` | **checkba 改动**：大纲生成 prompt 增加禁 markdown 指令（`Do NOT use markdown formatting symbols ...`） |
+| `backend/tests/unit/test_text_sanitizer.py` / `test_pptx_formatting.py` | **checkba 新增**：上述能力的回归测试（re-vendor 后跑它们即可验证定制是否套全） |
 
 > 注：0.4.0 上游把「可编辑 PPTX 导出」改为 image_editability 混合抽取器（MinerU 云端 + 可选百度高精 OCR，
 > 见 `BAIDU_OCR_API_KEY`）。该链路的 FileParserService 未显式传 `mineru_local_url`，但由于缺省会
@@ -56,3 +62,14 @@
 
 > 其余较少用到的端点（`/pages/{id}/edit/image`、`/refine/outline`、`/files/screenshot`、
 > `/projects/edit-standalone-image`、`/projects/edit-pptx-slide`）如上游有改动，同样在 PptxServiceClient 里对齐即可。
+>
+> **已知缺口（2026-08-01 实测）**：`/api/files/screenshot`、`/api/projects/edit-standalone-image`、
+> `/api/projects/edit-pptx-slide` 三个端点在 0.4.0 re-vendor 后已不存在（上游删除，checkba 侧未重建），
+> 但 `PptxServiceClient.java` 仍在调用——对应 `pptx_get_page_screenshot`、`pptx_smart_modify`（图片编辑分支）
+> 工具实为死路径，恢复时需在服务侧重建这三个端点或改走新的 `/api/pptx/*` 能力。
+>
+> **checkba 自有端点（上游没有，re-vendor 时必须连同上表文件一起保留）**：
+> | 方法 | 路径 | 用途 |
+> |---|---|---|
+> | POST | /api/pptx/inspect | 存量 pptx 结构化格式全览（字体/字号/粗斜删下/高亮/颜色/对齐/行距/项目符号/表格） |
+> | POST | /api/pptx/format | 批量格式操作（set_run_format / set_paragraph_format / replace_text / set_shape_text / set_cell_text / set_cell_format），落字自动去 markdown |

--- a/pptx-service/backend/app.py
+++ b/pptx-service/backend/app.py
@@ -25,6 +25,8 @@ from controllers.material_controller import material_bp, material_global_bp
 from controllers.reference_file_controller import reference_file_bp
 from controllers.settings_controller import settings_bp
 from controllers import project_bp, page_bp, template_bp, user_template_bp, export_bp, file_bp
+# [checkba] 存量 pptx 格式识别与操作端点
+from controllers import pptx_edit_bp
 
 
 # Enable SQLite WAL mode for all connections
@@ -111,6 +113,8 @@ def create_app():
     app.register_blueprint(material_global_bp)
     app.register_blueprint(reference_file_bp, url_prefix='/api/reference-files')
     app.register_blueprint(settings_bp)
+    # [checkba] 存量 pptx 格式识别与操作
+    app.register_blueprint(pptx_edit_bp)
 
     with app.app_context():
         # Load settings from database and sync to app.config

--- a/pptx-service/backend/controllers/__init__.py
+++ b/pptx-service/backend/controllers/__init__.py
@@ -6,6 +6,8 @@ from .export_controller import export_bp
 from .file_controller import file_bp
 from .material_controller import material_bp
 from .settings_controller import settings_bp
+# [checkba] 存量 pptx 格式识别与操作端点
+from .pptx_edit_controller import pptx_edit_bp
 
-__all__ = ['project_bp', 'page_bp', 'template_bp', 'user_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
+__all__ = ['project_bp', 'page_bp', 'template_bp', 'user_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp', 'pptx_edit_bp']
 

--- a/pptx-service/backend/controllers/pptx_edit_controller.py
+++ b/pptx-service/backend/controllers/pptx_edit_controller.py
@@ -1,0 +1,42 @@
+"""
+[checkba] PPTX Edit Controller - 存量 pptx 文件的格式识别与操作端点。
+
+供主仓 backend PptxServiceClient 调用（本地桌面同机部署，传本地文件路径），
+给 AI 提供与 docx 同级的 PPT 格式能力：
+- POST /api/pptx/inspect  {pptx_path}                     -> 结构化格式全览
+- POST /api/pptx/format   {pptx_path, ops, [output_path]} -> 批量格式操作
+"""
+from flask import Blueprint, request
+
+from utils import success_response, error_response
+from services import pptx_format_service
+
+pptx_edit_bp = Blueprint('pptx_edit', __name__, url_prefix='/api/pptx')
+
+
+@pptx_edit_bp.route('/inspect', methods=['POST'])
+def inspect_pptx():
+    data = request.get_json(silent=True) or {}
+    pptx_path = data.get('pptx_path')
+    try:
+        return success_response(pptx_format_service.inspect(pptx_path))
+    except pptx_format_service.PptxFormatError as e:
+        return error_response('INVALID_REQUEST', str(e), 400)
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@pptx_edit_bp.route('/format', methods=['POST'])
+def format_pptx():
+    data = request.get_json(silent=True) or {}
+    pptx_path = data.get('pptx_path')
+    ops = data.get('ops')
+    if not isinstance(ops, list) or not ops:
+        return error_response('INVALID_REQUEST', 'ops 必须是非空数组', 400)
+    try:
+        result = pptx_format_service.apply_ops(pptx_path, ops, data.get('output_path'))
+        return success_response(result)
+    except pptx_format_service.PptxFormatError as e:
+        return error_response('INVALID_REQUEST', str(e), 400)
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)

--- a/pptx-service/backend/services/pptx_format_service.py
+++ b/pptx-service/backend/services/pptx_format_service.py
@@ -1,0 +1,299 @@
+"""
+[checkba] PPTX 格式识别与操作服务（python-pptx 层）。
+
+给 AI 提供对存量 .pptx 文件与 docx 同级的格式能力：
+- inspect: 全量结构化读出（形状/段落/run 的字体、字号、粗斜下划线、
+  删除线、高亮、颜色、对齐、行距、项目符号；表格单元格）
+- apply_ops: 批量格式操作（run 级/段落级/文本替换/整框重写/单元格写入），
+  所有落字路径经过 text_sanitizer 去 markdown 化（标准格式落字）。
+
+定位约定：slide/shape/paragraph/run/row/col 一律 0 起（与 inspect 输出一致）。
+"""
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from pptx import Presentation
+
+from utils import pptx_format_utils as fmt
+from utils.text_sanitizer import parse_lines, strip_markdown
+
+logger = logging.getLogger(__name__)
+
+
+class PptxFormatError(Exception):
+    """格式操作错误（带上下文信息，控制器直接回给调用方）"""
+
+
+def _load(pptx_path: str) -> Presentation:
+    if not pptx_path or not os.path.exists(pptx_path):
+        raise PptxFormatError(f"文件不存在: {pptx_path}")
+    if not pptx_path.lower().endswith('.pptx'):
+        raise PptxFormatError(f"仅支持 .pptx 文件: {pptx_path}")
+    try:
+        return Presentation(pptx_path)
+    except Exception as e:
+        raise PptxFormatError(f"无法解析 PPTX: {e}")
+
+
+# ==================== inspect ====================
+
+def inspect(pptx_path: str) -> Dict[str, Any]:
+    prs = _load(pptx_path)
+    slides = []
+    for s_idx, slide in enumerate(prs.slides):
+        shapes = []
+        for sh_idx, shape in enumerate(slide.shapes):
+            info: Dict[str, Any] = {
+                'shape_index': sh_idx,
+                'name': shape.name,
+                'shape_type': str(shape.shape_type) if shape.shape_type is not None else None,
+                'has_text_frame': bool(getattr(shape, 'has_text_frame', False)),
+                'has_table': bool(getattr(shape, 'has_table', False)),
+            }
+            if info['has_text_frame']:
+                info['paragraphs'] = _read_text_frame(shape.text_frame)
+            if info['has_table']:
+                tbl = shape.table
+                info['table'] = {
+                    'rows': len(tbl.rows),
+                    'cols': len(tbl.columns),
+                    'cells': [
+                        {
+                            'row': r, 'col': c,
+                            'text': tbl.cell(r, c).text,
+                            'paragraphs': _read_text_frame(tbl.cell(r, c).text_frame),
+                        }
+                        for r in range(len(tbl.rows))
+                        for c in range(len(tbl.columns))
+                    ],
+                }
+            shapes.append(info)
+        slides.append({'slide_index': s_idx, 'shapes': shapes})
+    return {'slide_count': len(prs.slides), 'slides': slides}
+
+
+def _read_text_frame(tf) -> List[Dict[str, Any]]:
+    paragraphs = []
+    for p_idx, para in enumerate(tf.paragraphs):
+        p_info = fmt.read_paragraph_format(para)
+        p_info['paragraph_index'] = p_idx
+        p_info['text'] = para.text
+        p_info['runs'] = []
+        for r_idx, run in enumerate(para.runs):
+            r_info = fmt.read_run_format(run)
+            r_info['run_index'] = r_idx
+            p_info['runs'].append(r_info)
+        paragraphs.append(p_info)
+    return paragraphs
+
+
+# ==================== apply_ops ====================
+
+def apply_ops(pptx_path: str, ops: List[Dict[str, Any]],
+              output_path: Optional[str] = None) -> Dict[str, Any]:
+    """
+    支持的 op（action 字段区分）：
+    - set_run_format:      slide, shape, [paragraph], [run], format={run 级键}
+                           缺省 run -> 该段全部 run；缺省 paragraph -> 全部段落
+    - set_paragraph_format: slide, shape, [paragraph], format={段落级键}
+    - replace_text:        slide, shape, find, replace（替换文本经 strip_markdown）
+    - set_shape_text:      slide, shape, text（整框重写，markdown 转真格式，
+                           可选 format={run 级键} 作为基础样式）
+    - set_cell_text:       slide, shape, row, col, text（表格单元格，去 markdown）
+    - set_cell_format:     slide, shape, row, col, [paragraph], format={run 级键 + 段落级键}
+    返回每个 op 的执行结果。
+    """
+    prs = _load(pptx_path)
+    results = []
+    for i, op in enumerate(ops or []):
+        action = op.get('action')
+        try:
+            handler = _OP_HANDLERS.get(action)
+            if handler is None:
+                raise PptxFormatError(f"未知 action: {action}")
+            detail = handler(prs, op)
+            results.append({'index': i, 'action': action, 'ok': True, 'detail': detail})
+        except PptxFormatError as e:
+            results.append({'index': i, 'action': action, 'ok': False, 'error': str(e)})
+        except Exception as e:
+            logger.exception(f"op #{i} ({action}) failed")
+            results.append({'index': i, 'action': action, 'ok': False, 'error': str(e)})
+
+    out = output_path or pptx_path
+    prs.save(out)
+    return {'output_path': out, 'applied': sum(1 for r in results if r['ok']),
+            'failed': sum(1 for r in results if not r['ok']), 'results': results}
+
+
+def _get_slide(prs, op):
+    idx = op.get('slide')
+    if idx is None or not (0 <= idx < len(prs.slides)):
+        raise PptxFormatError(f"slide 越界: {idx}（共 {len(prs.slides)} 页）")
+    return prs.slides[idx]
+
+
+def _get_shape(prs, op):
+    slide = _get_slide(prs, op)
+    idx = op.get('shape')
+    shapes = list(slide.shapes)
+    if idx is None or not (0 <= idx < len(shapes)):
+        raise PptxFormatError(f"shape 越界: {idx}（该页共 {len(shapes)} 个形状）")
+    return shapes[idx]
+
+
+def _get_text_frame(prs, op):
+    shape = _get_shape(prs, op)
+    if not getattr(shape, 'has_text_frame', False):
+        raise PptxFormatError(f"shape {op.get('shape')} 没有文本框")
+    return shape.text_frame
+
+
+def _iter_paragraphs(tf, op):
+    p_idx = op.get('paragraph')
+    paras = list(tf.paragraphs)
+    if p_idx is None:
+        return paras
+    if not (0 <= p_idx < len(paras)):
+        raise PptxFormatError(f"paragraph 越界: {p_idx}（共 {len(paras)} 段）")
+    return [paras[p_idx]]
+
+
+def _op_set_run_format(prs, op):
+    tf = _get_text_frame(prs, op)
+    spec = op.get('format') or {}
+    r_idx = op.get('run')
+    count = 0
+    for para in _iter_paragraphs(tf, op):
+        runs = list(para.runs)
+        targets = runs if r_idx is None else (
+            [runs[r_idx]] if 0 <= r_idx < len(runs) else [])
+        if r_idx is not None and not targets:
+            raise PptxFormatError(f"run 越界: {r_idx}（该段共 {len(runs)} 个 run）")
+        for run in targets:
+            fmt.apply_run_format(run, spec)
+            count += 1
+    return {'runs_formatted': count}
+
+
+def _op_set_paragraph_format(prs, op):
+    tf = _get_text_frame(prs, op)
+    spec = op.get('format') or {}
+    count = 0
+    for para in _iter_paragraphs(tf, op):
+        fmt.apply_paragraph_format(para, spec)
+        count += 1
+    return {'paragraphs_formatted': count}
+
+
+def _op_replace_text(prs, op):
+    tf = _get_text_frame(prs, op)
+    find = op.get('find')
+    if not find:
+        raise PptxFormatError("replace_text 需要非空 find")
+    replace = strip_markdown(op.get('replace') or '')
+    count = 0
+    for para in tf.paragraphs:
+        for run in para.runs:
+            if find in run.text:
+                run.text = run.text.replace(find, replace)
+                count += 1
+    if count == 0:
+        raise PptxFormatError(f"未找到文本（run 级匹配）: {find}")
+    return {'runs_replaced': count}
+
+
+def _op_set_shape_text(prs, op):
+    tf = _get_text_frame(prs, op)
+    text = op.get('text')
+    if text is None:
+        raise PptxFormatError("set_shape_text 需要 text")
+    base_spec = dict(op.get('format') or {})
+    base_spec.setdefault('font_name', fmt.HOUSE_LATIN_FONT)
+    base_spec.setdefault('ea_font', fmt.HOUSE_EA_FONT)
+
+    tf.clear()
+    line_specs = parse_lines(text)
+    for idx, line in enumerate(line_specs):
+        para = tf.paragraphs[0] if idx == 0 else tf.add_paragraph()
+        p_fmt = {}
+        if line.bullet:
+            p_fmt['bullet'] = line.bullet
+            if line.number:
+                p_fmt['number_start'] = line.number
+        if p_fmt:
+            fmt.apply_paragraph_format(para, p_fmt)
+        for ir in line.runs:
+            run = para.add_run()
+            run.text = ir.text
+            spec = dict(base_spec)
+            if ir.bold or line.heading_level:
+                spec['bold'] = True
+            if ir.italic:
+                spec['italic'] = True
+            if ir.strike:
+                spec['strike'] = True
+            if ir.highlight:
+                spec['highlight'] = '#FFFF00'
+            if ir.code:
+                spec['code'] = True
+            fmt.apply_run_format(run, spec)
+    return {'paragraphs_written': len(line_specs)}
+
+
+def _get_cell(prs, op):
+    shape = _get_shape(prs, op)
+    if not getattr(shape, 'has_table', False):
+        raise PptxFormatError(f"shape {op.get('shape')} 不是表格")
+    tbl = shape.table
+    r, c = op.get('row'), op.get('col')
+    if r is None or not (0 <= r < len(tbl.rows)):
+        raise PptxFormatError(f"row 越界: {r}（共 {len(tbl.rows)} 行）")
+    if c is None or not (0 <= c < len(tbl.columns)):
+        raise PptxFormatError(f"col 越界: {c}（共 {len(tbl.columns)} 列）")
+    return tbl.cell(r, c)
+
+
+def _op_set_cell_text(prs, op):
+    cell = _get_cell(prs, op)
+    text = op.get('text')
+    if text is None:
+        raise PptxFormatError("set_cell_text 需要 text")
+    cell.text = strip_markdown(text)
+    for para in cell.text_frame.paragraphs:
+        for run in para.runs:
+            fmt.apply_run_format(run, {
+                'font_name': fmt.HOUSE_LATIN_FONT,
+                'ea_font': fmt.HOUSE_EA_FONT,
+            })
+    return {'text': cell.text}
+
+
+def _op_set_cell_format(prs, op):
+    cell = _get_cell(prs, op)
+    spec = op.get('format') or {}
+    run_keys = {'bold', 'italic', 'underline', 'strike', 'highlight',
+                'color', 'font_name', 'ea_font', 'size_pt', 'code'}
+    para_keys = {'align', 'line_spacing', 'space_before_pt', 'space_after_pt',
+                 'bullet', 'number_start'}
+    run_spec = {k: v for k, v in spec.items() if k in run_keys}
+    para_spec = {k: v for k, v in spec.items() if k in para_keys}
+    count = 0
+    for para in _iter_paragraphs(cell.text_frame, op):
+        if para_spec:
+            fmt.apply_paragraph_format(para, para_spec)
+        for run in para.runs:
+            if run_spec:
+                fmt.apply_run_format(run, run_spec)
+                count += 1
+    return {'runs_formatted': count}
+
+
+_OP_HANDLERS = {
+    'set_run_format': _op_set_run_format,
+    'set_paragraph_format': _op_set_paragraph_format,
+    'replace_text': _op_replace_text,
+    'set_shape_text': _op_set_shape_text,
+    'set_cell_text': _op_set_cell_text,
+    'set_cell_format': _op_set_cell_format,
+}

--- a/pptx-service/backend/services/prompts.py
+++ b/pptx-service/backend/services/prompts.py
@@ -148,6 +148,7 @@ You can organize the content in two ways:
 
 Choose the format that best fits the content. Use parts when the PPT has clear major sections.
 Unless otherwise specified, the first page should be kept simplest, containing only the title, subtitle, and presenter information.
+Do NOT use markdown formatting symbols (such as **, *, `, #, - list prefixes) inside titles or points; write plain text only.
 
 The user's request: {idea_prompt}. Now generate the outline, don't include any other text.
 {get_language_instruction(language)}

--- a/pptx-service/backend/tests/unit/test_pptx_formatting.py
+++ b/pptx-service/backend/tests/unit/test_pptx_formatting.py
@@ -1,0 +1,188 @@
+"""
+[checkba] PPTXBuilder 落字治理 + pptx_format_service 格式读写测试
+"""
+import os
+import re
+import zipfile
+
+import pytest
+from pptx import Presentation
+
+from utils.pptx_builder import PPTXBuilder
+from utils import pptx_format_utils as fmt
+from utils.text_sanitizer import has_markdown
+from services import pptx_format_service as pfs
+
+
+@pytest.fixture
+def built_pptx(tmp_path):
+    """用 builder 生成一份含 markdown 输入的 pptx，返回路径"""
+    b = PPTXBuilder()
+    b.create_presentation()
+    slide = b.add_blank_slide()
+    b.add_text_element(slide, "# 一、公司治理结构", [50, 30, 700, 80], text_level=1)
+    b.add_text_element(
+        slide, "**核心结论**：本次交易*不构成*重大资产重组，~~初稿口径~~已废弃。",
+        [50, 100, 700, 150])
+    b.add_text_element(slide, "- 第一项要点\n- 第二项要点\n1. 编号项", [50, 160, 700, 300])
+    b.add_table_element(
+        slide,
+        "<table><tr><th>股东</th><th>比例</th></tr><tr><td>**甲方**</td><td>51%</td></tr></table>",
+        [50, 320, 700, 450])
+    out = str(tmp_path / "built.pptx")
+    b.save(out)
+    return out
+
+
+class TestBuilderMarkdownHygiene:
+    def test_no_markdown_in_any_text(self, built_pptx):
+        prs = Presentation(built_pptx)
+        for slide in prs.slides:
+            for shape in slide.shapes:
+                if getattr(shape, 'has_text_frame', False):
+                    assert not has_markdown(shape.text_frame.text), shape.text_frame.text
+                if getattr(shape, 'has_table', False):
+                    for row in shape.table.rows:
+                        for cell in row.cells:
+                            assert "**" not in cell.text
+
+    def test_bold_converted_to_real_format(self, built_pptx):
+        prs = Presentation(built_pptx)
+        shape = list(prs.slides[0].shapes)[1]
+        runs = shape.text_frame.paragraphs[0].runs
+        bold_map = {r.text: r.font.bold for r in runs}
+        assert bold_map.get("核心结论") is True
+        italic_map = {r.text: r.font.italic for r in runs}
+        assert italic_map.get("不构成") is True
+        strike_runs = [r for r in runs if fmt.get_strike(r)]
+        assert [r.text for r in strike_runs] == ["初稿口径"]
+
+    def test_bullets_are_real_bullets(self, built_pptx):
+        prs = Presentation(built_pptx)
+        shape = list(prs.slides[0].shapes)[2]
+        paras = shape.text_frame.paragraphs
+        assert fmt.get_bullet(paras[0]) == "bullet"
+        assert fmt.get_bullet(paras[1]) == "bullet"
+        assert fmt.get_bullet(paras[2]) == "number"
+        assert paras[0].text == "第一项要点"
+
+    def test_house_fonts_written(self, built_pptx):
+        with zipfile.ZipFile(built_pptx) as z:
+            xml = z.read("ppt/slides/slide1.xml").decode("utf-8")
+        assert f'<a:latin typeface="{fmt.HOUSE_LATIN_FONT}"' in xml
+        assert f'<a:ea typeface="{fmt.HOUSE_EA_FONT}"' in xml
+
+    def test_all_paragraphs_styled(self, built_pptx):
+        """多行文本每一段都要有字号（原实现只有首段有）"""
+        prs = Presentation(built_pptx)
+        shape = list(prs.slides[0].shapes)[2]
+        for para in shape.text_frame.paragraphs:
+            for run in para.runs:
+                assert run.font.size is not None
+
+
+class TestFormatService:
+    def test_inspect_structure(self, built_pptx):
+        result = pfs.inspect(built_pptx)
+        assert result["slide_count"] == 1
+        shapes = result["slides"][0]["shapes"]
+        assert any(s["has_table"] for s in shapes)
+        text_shape = shapes[1]
+        first_run = text_shape["paragraphs"][0]["runs"][0]
+        assert first_run["font_name"] == fmt.HOUSE_LATIN_FONT
+        assert first_run["ea_font"] == fmt.HOUSE_EA_FONT
+        assert first_run["size_pt"] is not None
+
+    def test_apply_run_and_paragraph_ops(self, built_pptx):
+        ops = [
+            {"action": "set_run_format", "slide": 0, "shape": 0,
+             "format": {"strike": True, "highlight": "#FFFF00", "color": "#FF0000",
+                        "size_pt": 30, "font_name": "Times New Roman", "ea_font": "黑体"}},
+            {"action": "set_paragraph_format", "slide": 0, "shape": 0,
+             "format": {"align": "center", "line_spacing": 1.5, "bullet": "none",
+                        "space_after_pt": 6}},
+        ]
+        result = pfs.apply_ops(built_pptx, ops)
+        assert result["failed"] == 0
+
+        info = pfs.inspect(built_pptx)
+        para = info["slides"][0]["shapes"][0]["paragraphs"][0]
+        run = para["runs"][0]
+        assert run["strike"] is True
+        assert run["highlight"] == "#FFFF00"
+        assert run["color"] == "#FF0000"
+        assert run["size_pt"] == 30
+        assert run["font_name"] == "Times New Roman"
+        assert run["ea_font"] == "黑体"
+        assert para["align"] == "center"
+        assert para["line_spacing"] == 1.5
+        assert para["space_after_pt"] == 6
+
+    def test_replace_text_strips_markdown(self, built_pptx):
+        ops = [{"action": "replace_text", "slide": 0, "shape": 1,
+                "find": "核心结论", "replace": "**最终结论**"}]
+        result = pfs.apply_ops(built_pptx, ops)
+        assert result["failed"] == 0
+        info = pfs.inspect(built_pptx)
+        text = info["slides"][0]["shapes"][1]["paragraphs"][0]["text"]
+        assert "最终结论" in text and "**" not in text
+
+    def test_set_shape_text_converts_markdown(self, built_pptx):
+        ops = [{"action": "set_shape_text", "slide": 0, "shape": 0,
+                "text": "**重写标题**\n- 新要点甲\n- 新要点乙"}]
+        result = pfs.apply_ops(built_pptx, ops)
+        assert result["failed"] == 0
+        prs = Presentation(built_pptx)
+        tf = list(prs.slides[0].shapes)[0].text_frame
+        assert tf.paragraphs[0].runs[0].text == "重写标题"
+        assert tf.paragraphs[0].runs[0].font.bold is True
+        assert fmt.get_bullet(tf.paragraphs[1]) == "bullet"
+        assert tf.paragraphs[1].text == "新要点甲"
+
+    def test_cell_ops(self, built_pptx):
+        info = pfs.inspect(built_pptx)
+        table_shape_idx = next(s["shape_index"] for s in info["slides"][0]["shapes"]
+                               if s["has_table"])
+        ops = [
+            {"action": "set_cell_text", "slide": 0, "shape": table_shape_idx,
+             "row": 1, "col": 0, "text": "**乙方**"},
+            {"action": "set_cell_format", "slide": 0, "shape": table_shape_idx,
+             "row": 1, "col": 0, "format": {"bold": True, "align": "left"}},
+        ]
+        result = pfs.apply_ops(built_pptx, ops)
+        assert result["failed"] == 0
+        prs = Presentation(built_pptx)
+        table = next(s for s in prs.slides[0].shapes if getattr(s, 'has_table', False)).table
+        cell = table.cell(1, 0)
+        assert cell.text == "乙方"
+        assert cell.text_frame.paragraphs[0].runs[0].font.bold is True
+
+    def test_out_of_range_errors_reported(self, built_pptx):
+        ops = [{"action": "set_run_format", "slide": 9, "shape": 0, "format": {"bold": True}}]
+        result = pfs.apply_ops(built_pptx, ops)
+        assert result["failed"] == 1
+        assert "越界" in result["results"][0]["error"]
+
+    def test_missing_file_raises(self):
+        with pytest.raises(pfs.PptxFormatError):
+            pfs.inspect("/nonexistent/x.pptx")
+
+
+class TestApiEndpoints:
+    def test_inspect_and_format_via_http(self, client, built_pptx):
+        resp = client.post("/api/pptx/inspect", json={"pptx_path": built_pptx})
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert data["slide_count"] == 1
+
+        resp = client.post("/api/pptx/format", json={
+            "pptx_path": built_pptx,
+            "ops": [{"action": "set_run_format", "slide": 0, "shape": 0,
+                     "format": {"bold": True}}],
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["data"]["failed"] == 0
+
+    def test_invalid_requests(self, client, built_pptx):
+        assert client.post("/api/pptx/inspect", json={"pptx_path": "/no/x.pptx"}).status_code == 400
+        assert client.post("/api/pptx/format", json={"pptx_path": built_pptx, "ops": []}).status_code == 400

--- a/pptx-service/backend/tests/unit/test_text_sanitizer.py
+++ b/pptx-service/backend/tests/unit/test_text_sanitizer.py
@@ -1,0 +1,92 @@
+"""
+[checkba] text_sanitizer 单元测试：markdown 去除与真格式转换
+"""
+import pytest
+
+from utils.text_sanitizer import parse_inline, parse_lines, strip_markdown, has_markdown
+
+
+class TestParseInline:
+    def test_plain_text_untouched(self):
+        runs = parse_inline("普通文本 plain text")
+        assert len(runs) == 1
+        assert runs[0].text == "普通文本 plain text"
+        assert not runs[0].bold
+
+    def test_bold(self):
+        runs = parse_inline("前**加粗**后")
+        assert [r.text for r in runs] == ["前", "加粗", "后"]
+        assert [r.bold for r in runs] == [False, True, False]
+
+    def test_italic_strike_code_highlight(self):
+        runs = parse_inline("*斜* ~~删~~ `码` ==亮==")
+        styles = {r.text: r for r in runs}
+        assert styles["斜"].italic
+        assert styles["删"].strike
+        assert styles["码"].code
+        assert styles["亮"].highlight
+
+    def test_bold_italic_nested(self):
+        runs = parse_inline("***粗斜***")
+        assert runs[0].bold and runs[0].italic
+
+    def test_link_keeps_text_only(self):
+        runs = parse_inline("见[条款原文](https://example.com)。")
+        assert "".join(r.text for r in runs) == "见条款原文。"
+
+    def test_no_markdown_symbols_survive(self):
+        text = "# 标题 **粗** *斜* `码` ~~删~~ [链](http://x) ==亮=="
+        joined = "".join(r.text for r in parse_inline(text))
+        for symbol in ("**", "~~", "`", "==", "]("):
+            assert symbol not in joined
+
+
+class TestParseLines:
+    def test_bullet_lines(self):
+        specs = parse_lines("- 第一\n* 第二\n· 第三")
+        assert all(s.bullet == "bullet" for s in specs)
+        assert [s.text for s in specs] == ["第一", "第二", "第三"]
+
+    def test_numbered_lines(self):
+        specs = parse_lines("1. 甲\n2）乙\n（3）丙\n4、丁")
+        assert all(s.bullet == "number" for s in specs)
+        assert [s.number for s in specs] == [1, 2, 3, 4]
+
+    def test_heading_stripped_and_marked(self):
+        specs = parse_lines("## 二、核心条款")
+        assert specs[0].heading_level == 2
+        assert specs[0].text == "二、核心条款"
+
+    def test_horizontal_rule_dropped(self):
+        specs = parse_lines("上文\n---\n下文")
+        assert [s.text for s in specs] == ["上文", "下文"]
+
+    def test_table_pipes_cleaned(self):
+        specs = parse_lines("| 股东 | 比例 |\n| --- | --- |\n| 甲 | 51% |")
+        texts = [s.text for s in specs]
+        assert texts == ["股东  比例", "甲  51%"]
+
+    def test_plain_multiline(self):
+        specs = parse_lines("第一行\n第二行")
+        assert [s.bullet for s in specs] == [None, None]
+
+
+class TestStripMarkdown:
+    def test_strip_everything(self):
+        dirty = "# 标题\n**结论**：*不构成*重大重组\n- 要点`一`\n1. 编号~~废弃~~"
+        clean = strip_markdown(dirty)
+        assert not has_markdown(clean)
+        assert "结论" in clean and "不构成" in clean and "要点一" in clean
+
+    def test_empty_and_none_safe(self):
+        assert strip_markdown("") == ""
+        assert strip_markdown(None) is None
+
+    def test_has_markdown_detection(self):
+        assert has_markdown("**x**")
+        assert has_markdown("- 列表项")
+        assert not has_markdown("普通文字，包含 3*4=12 吗")  # 乘号不该误报
+
+    def test_snake_case_not_mangled(self):
+        # 下划线变量名不应被当作斜体
+        assert strip_markdown("file_name 与 wps_file_id") == "file_name 与 wps_file_id"

--- a/pptx-service/backend/utils/pptx_builder.py
+++ b/pptx-service/backend/utils/pptx_builder.py
@@ -14,6 +14,10 @@ from pptx.dml.color import RGBColor
 from PIL import Image, ImageFont, ImageDraw
 from html.parser import HTMLParser
 
+# [checkba] markdown 治理 + run/段落格式工具（HOUSE 字体、bullet、删除线、高亮）
+from utils.text_sanitizer import parse_lines, parse_inline, strip_markdown
+from utils import pptx_format_utils as fmt_utils
+
 logger = logging.getLogger(__name__)
 
 
@@ -163,7 +167,7 @@ class PPTXBuilder:
             core.last_modified_by = "banana-slides"
             core.created = now
             core.modified = now
-            core.last_printed = None
+            # [checkba] 不再写 last_printed=None：python-pptx 要求 datetime，传 None 必抛
         except Exception as e:
             logger.warning(f"Failed to set core properties: {e}")
     
@@ -409,21 +413,11 @@ class PPTXBuilder:
         text_frame.margin_top = Inches(0)
         text_frame.margin_bottom = Inches(0)
         
-        def replace_some_chars(text: str) -> str:
-            # replace logic
-            # replace · to • if starts with ·
-            text = text.replace('·', '•', 1) if text.lstrip().startswith('·') else text
-            return text
-        actual_text = replace_some_chars(actual_text)
-        
-        # Calculate font size
-        font_size = self.calculate_font_size(bbox, actual_text, text_level, dpi)
-        
         # Determine effective alignment - text_style优先，否则使用参数
         effective_align = align
         if text_style and hasattr(text_style, 'text_alignment') and text_style.text_alignment:
             effective_align = text_style.text_alignment
-        
+
         # Get style attributes
         is_bold = False
         is_italic = False
@@ -432,67 +426,95 @@ class PPTXBuilder:
             is_bold = getattr(text_style, 'is_bold', False)
             is_italic = getattr(text_style, 'is_italic', False)
             is_underline = getattr(text_style, 'is_underline', False)
-        
+
         # Make title text bold (legacy behavior)
         if text_level == 1 or text_level == 'title':
             is_bold = True
-        
-        # Render text with colors
+
+        # [checkba] 落字前的 markdown 治理：行内标记转真格式，列表前缀转真项目符号。
+        # 字号测量用消毒后的纯文本（标记符不再占宽度）。
+        def _run_spec(inline_run, color_hex=None):
+            """由 InlineRun + 基础样式合成 apply_run_format 规格"""
+            spec = {
+                'bold': is_bold or inline_run.bold,
+                'italic': is_italic or inline_run.italic,
+                'underline': is_underline,
+                'size_pt': font_size,
+                'font_name': fmt_utils.HOUSE_LATIN_FONT,
+                'ea_font': fmt_utils.HOUSE_EA_FONT,
+            }
+            if inline_run.strike:
+                spec['strike'] = True
+            if inline_run.highlight:
+                spec['highlight'] = '#FFFF00'
+            if inline_run.code:
+                spec['code'] = True
+            if color_hex:
+                spec['color'] = color_hex
+            return spec
+
         if has_colored_segments:
-            # Multi-color text: use runs for each segment
-            paragraph = text_frame.paragraphs[0]
-            paragraph.clear()
-            
+            # Multi-color text: use runs for each segment（保持单段落，段内多 run）
+            seg_runs = []
             latex_count = 0
             for seg in text_style.colored_segments:
-                run = paragraph.add_run()
-                run.text = replace_some_chars(seg.text)
-                run.font.size = Pt(font_size)
-                run.font.bold = is_bold
-                run.font.underline = is_underline
-                # Set segment-specific color
-                r, g, b = seg.color_rgb
-                run.font.color.rgb = RGBColor(r, g, b)
-                
-                # Handle LaTeX formula segments
-                if hasattr(seg, 'is_latex') and seg.is_latex:
-                    # For LaTeX formulas, use italic style as visual hint
-                    # TODO: In future, could render as actual equation using OMML
-                    run.font.italic = True
+                is_latex = bool(getattr(seg, 'is_latex', False))
+                if is_latex:
+                    # LaTeX 公式原样保留（不做 markdown 解析），斜体作视觉提示
                     latex_count += 1
-                    logger.debug(f"  LaTeX formula detected: '{seg.text}'")
+                    seg_runs.append((seg, [type('IR', (), {
+                        'text': seg.text, 'bold': False, 'italic': True,
+                        'strike': False, 'code': False, 'highlight': False})()]))
                 else:
-                    run.font.italic = is_italic
-            
+                    seg_runs.append((seg, parse_inline(seg.text)))
+
+            plain_text = ''.join(ir.text for _, irs in seg_runs for ir in irs)
+            font_size = self.calculate_font_size(bbox, plain_text, text_level, dpi)
+
+            paragraph = text_frame.paragraphs[0]
+            paragraph.clear()
+            for seg, inline_runs in seg_runs:
+                r, g, b = seg.color_rgb
+                color_hex = f'#{r:02X}{g:02X}{b:02X}'
+                for ir in inline_runs:
+                    run = paragraph.add_run()
+                    run.text = ir.text
+                    fmt_utils.apply_run_format(run, _run_spec(ir, color_hex))
+
+            fmt_utils.apply_paragraph_format(paragraph, {'align': effective_align})
             latex_info = f", {latex_count} latex" if latex_count > 0 else ""
             style_info = f" | multi-color: {len(text_style.colored_segments)} segments{latex_info}"
+            actual_text = plain_text
         else:
-            # Single color text: use simple text assignment
-            text_frame.text = actual_text
-            # IMPORTANT: Re-get paragraph after setting text_frame.text
-            # because setting text_frame.text creates a new paragraph object
-            paragraph = text_frame.paragraphs[0]
-            paragraph.font.size = Pt(font_size)
-            paragraph.font.bold = is_bold
-            paragraph.font.italic = is_italic
-            paragraph.font.underline = is_underline
-            
-            # Apply single font color if provided
+            # 单色文本：逐行成段（修复原实现只有首段吃到样式的缺陷），
+            # 列表行写真实 buChar/buAutoNum，标题行加粗。
+            line_specs = parse_lines(actual_text)
+            plain_text = '\n'.join(s.text for s in line_specs)
+            font_size = self.calculate_font_size(bbox, plain_text, text_level, dpi)
+
+            color_hex = None
             if text_style and hasattr(text_style, 'font_color_rgb') and text_style.font_color_rgb:
                 r, g, b = text_style.font_color_rgb
-                paragraph.font.color.rgb = RGBColor(r, g, b)
-            
+                color_hex = f'#{r:02X}{g:02X}{b:02X}'
+
+            for idx, spec_line in enumerate(line_specs):
+                paragraph = text_frame.paragraphs[0] if idx == 0 else text_frame.add_paragraph()
+                para_fmt = {'align': effective_align}
+                if spec_line.bullet:
+                    para_fmt['bullet'] = spec_line.bullet
+                    if spec_line.number:
+                        para_fmt['number_start'] = spec_line.number
+                fmt_utils.apply_paragraph_format(paragraph, para_fmt)
+                for ir in spec_line.runs:
+                    run = paragraph.add_run()
+                    run.text = ir.text
+                    run_fmt = _run_spec(ir, color_hex)
+                    if spec_line.heading_level:
+                        run_fmt['bold'] = True
+                    fmt_utils.apply_run_format(run, run_fmt)
+
             style_info = f" | color={text_style.font_color_rgb if text_style else 'default'}"
-        
-        # Apply alignment after paragraph is finalized
-        if effective_align == 'center':
-            paragraph.alignment = PP_ALIGN.CENTER
-        elif effective_align == 'right':
-            paragraph.alignment = PP_ALIGN.RIGHT
-        elif effective_align == 'justify':
-            paragraph.alignment = PP_ALIGN.JUSTIFY
-        else:
-            paragraph.alignment = PP_ALIGN.LEFT
+            actual_text = plain_text
         
         # Calculate bbox dimensions for logging
         bbox_width = bbox[2] - bbox[0]
@@ -620,27 +642,34 @@ class PPTXBuilder:
                 for col_idx, cell_text in enumerate(row_data):
                     if col_idx < cols:  # Safety check
                         cell = table.cell(row_idx, col_idx)
-                        cell.text = cell_text
-                        
+                        # [checkba] 单元格落字去 markdown
+                        cell.text = strip_markdown(cell_text)
+
                         # Style the cell
                         text_frame = cell.text_frame
                         text_frame.word_wrap = True
-                        
+
                         # Calculate font size for table cell
                         # Use a conservative size to fit in cell
                         cell_height_px = (bbox[3] - bbox[1]) / rows
                         cell_width_px = (bbox[2] - bbox[0]) / cols
-                        
+
                         # Estimate font size (smaller for tables)
                         font_size = min(18, max(8, cell_height_px * 0.3))
-                        
+
                         for paragraph in text_frame.paragraphs:
                             paragraph.font.size = Pt(font_size)
                             paragraph.alignment = PP_ALIGN.CENTER
-                            
+
                             # Header row (first row) should be bold
                             if row_idx == 0:
                                 paragraph.font.bold = True
+                            # [checkba] HOUSE 字体（西文/中文分设）
+                            for run in paragraph.runs:
+                                fmt_utils.apply_run_format(run, {
+                                    'font_name': fmt_utils.HOUSE_LATIN_FONT,
+                                    'ea_font': fmt_utils.HOUSE_EA_FONT,
+                                })
             
             logger.info(f"Added editable table: {rows}x{cols} at bbox {bbox}")
             

--- a/pptx-service/backend/utils/pptx_format_utils.py
+++ b/pptx-service/backend/utils/pptx_format_utils.py
@@ -1,0 +1,241 @@
+"""
+[checkba] python-pptx run/段落级格式读写工具。
+
+python-pptx 原生 API 覆盖不到的部分（东亚字体 <a:ea>、删除线 strike、
+高亮 <a:highlight>、项目符号 buChar/buAutoNum）在此用 oxml 层补齐。
+pptx_builder（生成落字）与 pptx_format_service（存量文件格式操作）共用。
+
+默认字体与 docx 侧律所 HOUSE 规范协调（DocxStyleHelper / office_thread.js）：
+西文 Arial、中文楷体_GB2312。可通过环境变量覆盖。
+"""
+import os
+import re
+from typing import Any, Dict, Optional
+
+from pptx.util import Pt
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.oxml.ns import qn
+
+# 与 backend/DocxStyleHelper.java 的 HOUSE_FONT_* 同源
+HOUSE_LATIN_FONT = os.getenv('PPTX_HOUSE_LATIN_FONT', 'Arial')
+HOUSE_EA_FONT = os.getenv('PPTX_HOUSE_EA_FONT', '楷体_GB2312')
+CODE_FONT = os.getenv('PPTX_CODE_FONT', 'Consolas')
+
+_ALIGN_MAP = {
+    'left': PP_ALIGN.LEFT,
+    'center': PP_ALIGN.CENTER,
+    'right': PP_ALIGN.RIGHT,
+    'justify': PP_ALIGN.JUSTIFY,
+}
+_ALIGN_NAME = {v: k for k, v in _ALIGN_MAP.items()}
+
+_HEX_COLOR_RE = re.compile(r'^#?([0-9a-fA-F]{6})$')
+
+
+def _parse_color(value: str) -> Optional[RGBColor]:
+    m = _HEX_COLOR_RE.match(value.strip()) if isinstance(value, str) else None
+    return RGBColor.from_string(m.group(1).upper()) if m else None
+
+
+# ==================== run 级：oxml 补齐 ====================
+
+def set_ea_font(run, ea_name: str):
+    """设置 run 的东亚字体 <a:ea typeface>（python-pptx 无原生 API）。"""
+    rPr = run._r.get_or_add_rPr()
+    ea = rPr.find(qn('a:ea'))
+    if ea is None:
+        ea = rPr.makeelement(qn('a:ea'), {})
+        rPr.insert_element_before(
+            ea, 'a:cs', 'a:sym', 'a:hlinkClick',
+            'a:hlinkMouseOver', 'a:rtl', 'a:extLst')
+    ea.set('typeface', ea_name)
+
+
+def get_ea_font(run) -> Optional[str]:
+    rPr = run._r.find(qn('a:rPr'))
+    if rPr is None:
+        return None
+    ea = rPr.find(qn('a:ea'))
+    return ea.get('typeface') if ea is not None else None
+
+
+def set_strike(run, strike: bool):
+    """删除线：rPr 的 strike 属性。"""
+    rPr = run._r.get_or_add_rPr()
+    if strike:
+        rPr.set('strike', 'sngStrike')
+    elif rPr.get('strike') is not None:
+        del rPr.attrib['strike']
+
+
+def get_strike(run) -> bool:
+    rPr = run._r.find(qn('a:rPr'))
+    return rPr is not None and rPr.get('strike') in ('sngStrike', 'dblStrike')
+
+
+def set_highlight(run, color_hex: Optional[str]):
+    """高亮 <a:highlight><a:srgbClr/></a:highlight>；color_hex=None 表示清除。"""
+    rPr = run._r.get_or_add_rPr()
+    old = rPr.find(qn('a:highlight'))
+    if old is not None:
+        rPr.remove(old)
+    if not color_hex:
+        return
+    color = _parse_color(color_hex)
+    if color is None:
+        return
+    hl = rPr.makeelement(qn('a:highlight'), {})
+    clr = rPr.makeelement(qn('a:srgbClr'), {'val': str(color)})
+    hl.append(clr)
+    rPr.insert_element_before(
+        hl, 'a:uLnTx', 'a:uLn', 'a:uFillTx', 'a:uFill',
+        'a:latin', 'a:ea', 'a:cs', 'a:sym',
+        'a:hlinkClick', 'a:hlinkMouseOver', 'a:rtl', 'a:extLst')
+
+
+def get_highlight(run) -> Optional[str]:
+    rPr = run._r.find(qn('a:rPr'))
+    if rPr is None:
+        return None
+    hl = rPr.find(qn('a:highlight'))
+    if hl is None:
+        return None
+    clr = hl.find(qn('a:srgbClr'))
+    return f"#{clr.get('val')}" if clr is not None and clr.get('val') else None
+
+
+# ==================== 段落级：项目符号 ====================
+
+def set_bullet(paragraph, bullet: Optional[str], number_start: int = 1):
+    """
+    设置段落项目符号语义。
+    bullet: None/'none' 清除；'bullet' 圆点；'number' 阿拉伯数字编号。
+    """
+    pPr = paragraph._p.get_or_add_pPr()
+    for tag in ('a:buNone', 'a:buChar', 'a:buAutoNum'):
+        el = pPr.find(qn(tag))
+        if el is not None:
+            pPr.remove(el)
+    if bullet in (None, 'none'):
+        # 文本框默认即无符号；显式写 buNone 保险
+        el = pPr.makeelement(qn('a:buNone'), {})
+    elif bullet == 'bullet':
+        el = pPr.makeelement(qn('a:buChar'), {'char': '•'})
+    elif bullet == 'number':
+        attrs = {'type': 'arabicPeriod'}
+        if number_start and number_start != 1:
+            attrs['startAt'] = str(number_start)
+        el = pPr.makeelement(qn('a:buAutoNum'), attrs)
+    else:
+        return
+    pPr.insert_element_before(el, 'a:tabLst', 'a:defRPr', 'a:extLst')
+
+
+def get_bullet(paragraph) -> Optional[str]:
+    pPr = paragraph._p.find(qn('a:pPr'))
+    if pPr is None:
+        return None
+    if pPr.find(qn('a:buChar')) is not None:
+        return 'bullet'
+    if pPr.find(qn('a:buAutoNum')) is not None:
+        return 'number'
+    return None
+
+
+# ==================== 规格化读写 ====================
+
+def apply_run_format(run, spec: Dict[str, Any]):
+    """
+    将格式规格应用到 run。支持键：
+    bold/italic/underline/strike: bool
+    highlight: '#RRGGBB' | None（清除）
+    color: '#RRGGBB'
+    font_name: 西文字体名；ea_font: 中文字体名；size_pt: 字号磅值
+    code: bool（等宽字体快捷键）
+    """
+    f = run.font
+    if 'bold' in spec:
+        f.bold = bool(spec['bold'])
+    if 'italic' in spec:
+        f.italic = bool(spec['italic'])
+    if 'underline' in spec:
+        f.underline = bool(spec['underline'])
+    if 'strike' in spec:
+        set_strike(run, bool(spec['strike']))
+    if 'highlight' in spec:
+        set_highlight(run, spec['highlight'])
+    if 'color' in spec and spec['color']:
+        color = _parse_color(spec['color'])
+        if color is not None:
+            f.color.rgb = color
+    if 'size_pt' in spec and spec['size_pt']:
+        f.size = Pt(float(spec['size_pt']))
+    if spec.get('code'):
+        f.name = CODE_FONT
+        set_ea_font(run, CODE_FONT)
+    else:
+        if 'font_name' in spec and spec['font_name']:
+            f.name = spec['font_name']
+        if 'ea_font' in spec and spec['ea_font']:
+            set_ea_font(run, spec['ea_font'])
+
+
+def read_run_format(run) -> Dict[str, Any]:
+    f = run.font
+    try:
+        # 主题色等非 RGB 类型访问 .rgb 会抛异常
+        color = f"#{f.color.rgb}" if f.color.type is not None else None
+    except (AttributeError, ValueError):
+        color = None
+    return {
+        'text': run.text,
+        'font_name': f.name,
+        'ea_font': get_ea_font(run),
+        'size_pt': (f.size.pt if f.size is not None else None),
+        'bold': f.bold,
+        'italic': f.italic,
+        'underline': f.underline,
+        'strike': get_strike(run),
+        'highlight': get_highlight(run),
+        'color': color,
+    }
+
+
+def apply_paragraph_format(paragraph, spec: Dict[str, Any]):
+    """
+    段落级格式。支持键：
+    align: left/center/right/justify
+    line_spacing: 倍数（如 1.5）或磅值字符串 '28pt'
+    space_before_pt / space_after_pt: 段前后距磅值
+    bullet: 'none' | 'bullet' | 'number'；number_start: 起始编号
+    """
+    if 'align' in spec and spec['align'] in _ALIGN_MAP:
+        paragraph.alignment = _ALIGN_MAP[spec['align']]
+    if 'line_spacing' in spec and spec['line_spacing'] is not None:
+        ls = spec['line_spacing']
+        if isinstance(ls, str) and ls.endswith('pt'):
+            paragraph.line_spacing = Pt(float(ls[:-2]))
+        else:
+            paragraph.line_spacing = float(ls)
+    if 'space_before_pt' in spec and spec['space_before_pt'] is not None:
+        paragraph.space_before = Pt(float(spec['space_before_pt']))
+    if 'space_after_pt' in spec and spec['space_after_pt'] is not None:
+        paragraph.space_after = Pt(float(spec['space_after_pt']))
+    if 'bullet' in spec:
+        set_bullet(paragraph, spec['bullet'], spec.get('number_start', 1))
+
+
+def read_paragraph_format(paragraph) -> Dict[str, Any]:
+    ls = paragraph.line_spacing
+    if hasattr(ls, 'pt'):
+        ls = f"{ls.pt}pt"
+    return {
+        'align': _ALIGN_NAME.get(paragraph.alignment),
+        'line_spacing': ls,
+        'space_before_pt': (paragraph.space_before.pt
+                            if paragraph.space_before is not None else None),
+        'space_after_pt': (paragraph.space_after.pt
+                           if paragraph.space_after is not None else None),
+        'bullet': get_bullet(paragraph),
+    }

--- a/pptx-service/backend/utils/text_sanitizer.py
+++ b/pptx-service/backend/utils/text_sanitizer.py
@@ -1,0 +1,164 @@
+"""
+[checkba] Markdown 治理工具：LLM/OCR 输出落入 PPTX 前的最后一道防线。
+
+设计与 docx 侧「写入去 markdown 化（标准格式落字）」同一哲学（主仓 PR#230）：
+不是简单剥离标记，而是把行内 markdown 语义转成真实格式（粗体/斜体/删除线/
+高亮/等宽），把行首列表标记转成真实项目符号/编号语义，剩余符号才剥离。
+
+纯标准库实现，无第三方依赖，可被 pptx_builder 与 pptx_format_service 复用。
+"""
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class InlineRun:
+    """一段带样式语义的行内文本"""
+    text: str
+    bold: bool = False
+    italic: bool = False
+    strike: bool = False
+    code: bool = False       # 行内代码 -> 等宽字体
+    highlight: bool = False  # ==xx== 扩展语法 -> 高亮
+
+
+@dataclass
+class LineSpec:
+    """一行文本的块级语义"""
+    runs: List[InlineRun] = field(default_factory=list)
+    bullet: Optional[str] = None    # None | 'bullet' | 'number'
+    number: Optional[int] = None    # bullet == 'number' 时的原始序号
+    heading_level: Optional[int] = None  # '# ' 前缀的级别（1-6），无则 None
+
+    @property
+    def text(self) -> str:
+        return ''.join(r.text for r in self.runs)
+
+
+# 行内语法。顺序即优先级：先长定界符再短定界符，避免 ** 被 * 误吃。
+_INLINE_RE = re.compile(
+    r'\*\*\*(?P<bi>.+?)\*\*\*'          # ***粗斜***
+    r'|\*\*(?P<b>.+?)\*\*'              # **粗体**
+    r'|__(?P<b2>.+?)__'                 # __粗体__
+    r'|~~(?P<s>.+?)~~'                  # ~~删除线~~
+    r'|==(?P<hl>.+?)=='                 # ==高亮==（扩展语法）
+    r'|`(?P<c>[^`\n]+?)`'               # `行内代码`
+    r'|\*(?P<i>[^*\n]+?)\*'             # *斜体*
+    r'|!?\[(?P<lk>[^\]\n]*)\]\([^)\n]*\)'  # 链接/图片 -> 只留文字
+)
+
+# 行首列表标记
+_BULLET_RE = re.compile(r'^\s*[-*+•·➤▪]\s+')
+# 中文标点（、） （3））后不要求空格；ASCII '1.'/'1)' 要求空格，避免误吃 3.14 之类
+_NUMBER_RE = re.compile(r'^\s*(?:(\d{1,3})[、）]|[（(](\d{1,3})[）)]|(\d{1,3})[.)]\s)\s*')
+_HEADING_RE = re.compile(r'^\s*(#{1,6})\s+')
+
+# 表格行 / 分隔线等纯结构行
+_HR_RE = re.compile(r'^\s*(?:[-*_]\s*){3,}$')
+_TABLE_SEP_RE = re.compile(r'^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$')
+
+
+def parse_inline(text: str,
+                 bold: bool = False,
+                 italic: bool = False,
+                 strike: bool = False,
+                 code: bool = False,
+                 highlight: bool = False) -> List[InlineRun]:
+    """把一行文本解析为带样式语义的 run 列表（支持一层嵌套递归）。"""
+    runs: List[InlineRun] = []
+    pos = 0
+    for m in _INLINE_RE.finditer(text):
+        if m.start() > pos:
+            runs.append(InlineRun(text[pos:m.start()], bold, italic, strike, code, highlight))
+        if m.group('bi') is not None:
+            runs.extend(parse_inline(m.group('bi'), True, True, strike, code, highlight))
+        elif m.group('b') is not None:
+            runs.extend(parse_inline(m.group('b'), True, italic, strike, code, highlight))
+        elif m.group('b2') is not None:
+            runs.extend(parse_inline(m.group('b2'), True, italic, strike, code, highlight))
+        elif m.group('s') is not None:
+            runs.extend(parse_inline(m.group('s'), bold, italic, True, code, highlight))
+        elif m.group('hl') is not None:
+            runs.extend(parse_inline(m.group('hl'), bold, italic, strike, code, True))
+        elif m.group('c') is not None:
+            # 代码片段内部不再递归解析
+            runs.append(InlineRun(m.group('c'), bold, italic, strike, True, highlight))
+        elif m.group('i') is not None:
+            runs.extend(parse_inline(m.group('i'), bold, True, strike, code, highlight))
+        elif m.group('lk') is not None:
+            runs.extend(parse_inline(m.group('lk'), bold, italic, strike, code, highlight))
+        pos = m.end()
+    if pos < len(text):
+        runs.append(InlineRun(text[pos:], bold, italic, strike, code, highlight))
+    return [r for r in runs if r.text]
+
+
+def parse_lines(text: str) -> List[LineSpec]:
+    """
+    把多行文本解析为 LineSpec 列表：
+    - 行首 '- ' / '* ' / '· ' 等 -> bullet 语义（前缀剥离）
+    - 行首 '1. ' / '1）' 等 -> number 语义（前缀剥离）
+    - 行首 '# ' -> heading 语义（前缀剥离）
+    - 纯分隔线/表格分隔行 -> 丢弃
+    - 行内 markdown -> InlineRun 样式
+    """
+    specs: List[LineSpec] = []
+    for raw_line in text.split('\n'):
+        if _HR_RE.match(raw_line) or _TABLE_SEP_RE.match(raw_line):
+            continue
+        line = raw_line
+        bullet = None
+        number = None
+        heading_level = None
+
+        hm = _HEADING_RE.match(line)
+        if hm:
+            heading_level = len(hm.group(1))
+            line = line[hm.end():]
+        else:
+            nm = _NUMBER_RE.match(line)
+            if nm:
+                bullet = 'number'
+                number = int(nm.group(1) or nm.group(2) or nm.group(3))
+                line = line[nm.end():]
+            else:
+                bm = _BULLET_RE.match(line)
+                if bm:
+                    bullet = 'bullet'
+                    line = line[bm.end():]
+
+        # markdown 表格行：去掉管道符，保留单元格文字
+        if line.count('|') >= 2:
+            stripped = line.strip()
+            if stripped.startswith('|') or stripped.endswith('|'):
+                line = '  '.join(c.strip() for c in stripped.strip('|').split('|') if c.strip())
+
+        specs.append(LineSpec(runs=parse_inline(line), bullet=bullet,
+                              number=number, heading_level=heading_level))
+    return specs
+
+
+def strip_markdown(text: str) -> str:
+    """
+    纯文本消毒：剥离所有 markdown 标记，只留内容文字。
+    用于表格单元格等无 run 级格式的落字场景。
+    """
+    if not text:
+        return text
+    lines = []
+    for spec in parse_lines(text):
+        lines.append(spec.text)
+    return '\n'.join(lines)
+
+
+def has_markdown(text: str) -> bool:
+    """快速判断文本是否含 markdown 标记（用于日志/测试断言）。"""
+    if not text:
+        return False
+    if _INLINE_RE.search(text):
+        return True
+    return any(
+        _HEADING_RE.match(line) or _BULLET_RE.match(line) or _NUMBER_RE.match(line)
+        for line in text.split('\n')
+    )


### PR DESCRIPTION
## 背景

LOWA 引擎不含 Impress，PPT 的 AI 操作全部走 pptx 附属服务（banana-slides）。目标：AI 对 PPT 具备与 docx 同级的格式识别与操作能力，且生成内容不残留 markdown 标记（对齐 docx 侧 PR #230 的「标准格式落字」哲学与 HOUSE 规范）。

## 实测审计结论（本 PR 的依据）

1. **markdown 全量残留**：PPTXBuilder 直测，`**粗体**`、`# 标题`、`- 列表`、`` `代码` `` 等原样落入文本框与表格单元格。
2. **字体失控**：latin/ea typeface 均未写入，渲染回退 Calibri/系统默认，与律所 HOUSE 规范（楷体_GB2312/Arial）脱节。
3. **格式能力缺失**：无项目符号语义（`- ` 只是字符）、无行距、无删除线、无高亮；多行文本只有首段吃到字号/对齐（实测坐实的 bug）。
4. **两条死路径**（与本 PR 并行的既有问题，本 PR 只记录不修复）：
   - PptxEditTools 全班 7 个工具走编辑器桥 `ppt_*` 命令，被 `libreofficeExecutorClient.js:142` 明确拒绝（引擎无 Impress）；
   - `pptx_smart_modify`/`pptx_get_page_screenshot` 调用的 `/api/projects/edit-pptx-slide`、`/api/projects/edit-standalone-image`、`/api/files/screenshot` 在 banana-slides 0.4 re-vendor 时丢失（服务起动实测 404/405）。

## 改动（全部在 pptx-service，python-pptx 层，均带 [checkba] 标记）

- **utils/text_sanitizer.py（新）**：行内 markdown 转真格式（粗/斜/删除线/==高亮==/等宽），列表前缀（`-`、`1.`、`1、`、`（3）`）转 bullet/编号语义，链接留文字，分隔线/表格分隔行丢弃；`strip_markdown` 纯剥离。
- **utils/pptx_format_utils.py（新）**：python-pptx 原生 API 缺口的 oxml 补齐——东亚字体 `<a:ea>`、删除线 `strike`、高亮 `<a:highlight>`、项目符号 `buChar`/`buAutoNum`；HOUSE 字体常量与 DocxStyleHelper 同源（env `PPTX_HOUSE_EA_FONT`/`PPTX_HOUSE_LATIN_FONT` 可覆盖）。
- **utils/pptx_builder.py（改）**：所有落字路径走 sanitizer；每个 run 写 HOUSE 字体（西文 Arial + 中文楷体_GB2312 分设）；多行文本逐行成段，修复只有首段有样式的缺陷；列表行写真实项目符号；表格单元格去 markdown；修 `last_printed=None` 必抛。
- **services/pptx_format_service.py + controllers/pptx_edit_controller.py（新）**：存量 pptx 的格式识别与操作端点：
  - `POST /api/pptx/inspect`：全量结构化读出（字体/ea 字体/字号/粗斜下划线/删除线/高亮/颜色/对齐/行距/段距/项目符号/表格单元格）
  - `POST /api/pptx/format`：批量操作（`set_run_format`/`set_paragraph_format`/`replace_text`/`set_shape_text`/`set_cell_text`/`set_cell_format`），所有落字自动去 markdown 化
- **services/prompts.py（改）**：大纲生成 prompt 增加禁 markdown 指令（源头防线）。
- **UPGRADE_CHECKBA.md**：定制清单补全 + 三个丢失端点缺口记录 + checkba 自有端点契约表。

## 验证

- 新增 31 项单测，`tests/unit` 全套 60 项通过
- `compat_smoke_test.sh` 契约冒烟全 PASS（PptxServiceClient 依赖端点无破坏）
- 服务真机起动，`/api/pptx/inspect`、`/api/pptx/format` HTTP 回环验证（删除线/高亮/楷体/行距/bullet 写入后读回一致）
- LibreOffice headless 转 PDF 渲染验证：加粗/斜体/真圆点/编号/删除线全部生效，零 markdown 符号

## 后续（不在本 PR）

- 主仓 Java 侧接线：PptxServiceClient 增加 inspect/format 方法 + 新增 pptx 格式工具注册（涉及工具名中文映射表与 EvalHarness 同步）
- PptxEditTools 死路径处置：改走新 /api/pptx/* 或下线
- 三个丢失的图像编辑端点恢复（需 AI 图像编辑链路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)