### PR TITLE
sheet 公式方言归一：Excel 习惯写法直通 Calc API 文法 + 出错公式上报

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -50,7 +50,7 @@ description: AI↔文档编辑桥接领域。任务涉及 doc_* 编辑原语、E
 
 EDITOR_ACTIONS 全集在 `libreofficeExecutorClient.js:15-67`（含宿主自发的 load_document/export_document/insert_image/var_*/*_hyperlink 与诊断类 get_ui_lang/probe_modules/list_fonts/debug_revisions）。`ui_command` 是其中一个 action，worker 端再经 UI_COMMANDS 二级白名单映射 `.uno:` 槽（IME 快捷键用，非 AI 管线）。
 
-**电子表格（Calc / xlsx）sheet_\* 原语**：doc_\* 是 Writer 专属（`xModel.getText()` 在 Calc 文档上必然失败），xlsx 走 sheet_\* 七件：`sheet_get_overview / sheet_read_range / sheet_write_cells / sheet_select_range / sheet_format_cells / sheet_set_borders / sheet_set_row_col`（工具名=action 名，不做映射）。worker 端 `resolveSheet` 统一守卫文档类型（非 Calc 返回明确错误）并把命中的工作表切为活动表。Calc 没有 redline，写入即生效——安全网是 doc_undo 与文档检查点（写类工具都打了 `fileEffect="MODIFIED"`）。地雷：`VertJustify` 声明 long、个别引擎按 short 校验（失败退 shortAny）；写入时数字样式字符串落数值但**前导 0 的编号保持文本**；数字格式经 `getNumberFormats().queryKey/addNew`（非法格式码会抛）。
+**电子表格（Calc / xlsx）sheet_\* 原语**：doc_\* 是 Writer 专属（`xModel.getText()` 在 Calc 文档上必然失败），xlsx 走 sheet_\* 七件：`sheet_get_overview / sheet_read_range / sheet_write_cells / sheet_select_range / sheet_format_cells / sheet_set_borders / sheet_set_row_col`（工具名=action 名，不做映射）。worker 端 `resolveSheet` 统一守卫文档类型（非 Calc 返回明确错误）并把命中的工作表切为活动表。Calc 没有 redline，写入即生效——安全网是 doc_undo 与文档检查点（写类工具都打了 `fileEffect="MODIFIED"`）。地雷：`VertJustify` 声明 long、个别引擎按 short 校验（失败退 shortAny）；写入时数字样式字符串落数值但**前导 0 的编号保持文本**；数字格式经 `getNumberFormats().queryKey/addNew`（非法格式码会抛）；**setFormula 走 API 文法**——参数分隔符必须分号（逗号 Err:508）、跨表引用必须 `Sheet.A1`（`Sheet!A1` 报 #NAME?），worker 的 `normalizeFormula` 在字符串字面量外做 `,`→`;`、`!`→`.` 归一（Excel 数组字面量与 Calc 交集操作符 `!` 被牺牲，AI 公式里趋近于零）；引擎 LO 24.2 **无 XLOOKUP**（24.8 才有），出错公式经 `sheet_write_cells` 返回值 `formulaErrors` 报给 AI 自纠，读回侧 `readCellOut` 先查 `getError()`（否则错误格伪装成 0）。
 
 ## 命名双轨现状（PR#192，下个发布周期摘旧名）
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -898,7 +898,11 @@ public class DocumentEditTools implements AgentToolComponent {
     @ToolMeta(displayName = "写入单元格", category = "document", fileEffect = "MODIFIED")
     @Tool("【表格·写】从起始单元格开始按二维数组批量写入。rowsJson 是 JSON 二维数组，如 " +
           "[[\"项目\",\"金额\"],[\"咨询费\",10000],[\"合计\",\"=SUM(B2:B2)\"]]：数字与数字样式字符串写为数值，" +
-          "'=' 开头写为公式，其余写为文本；null 跳过不动该格。写入即生效（无修订痕迹），返回实际写入区域和首行回读值供核对。")
+          "'=' 开头写为公式，其余写为文本；null 跳过不动该格。写入即生效（无修订痕迹），返回实际写入区域和首行回读值供核对。" +
+          "公式用英文函数名，按 Excel 习惯写即可（逗号分隔、跨表 Sheet!A1 会自动归一为引擎方言）；" +
+          "SUM/AVERAGE/IF/COUNT/VLOOKUP/SUMIF/COUNTIF/INDEX+MATCH/IFERROR/TEXT/日期函数等均可用，" +
+          "但引擎是 LibreOffice 24.2，**不支持 XLOOKUP 等新函数**（用 VLOOKUP 或 INDEX+MATCH 代替）。" +
+          "任何公式出错都会在返回值 formulaErrors 里列出（单元格/公式/错误码），看到后必须修正并重写该格。")
     public String sheet_write_cells(
             @P("起始单元格，如 'A1'") String startCell,
             @P("写入内容，JSON 二维数组") String rowsJson,

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -490,6 +490,8 @@ for file_id in file_ids:
 
 表格操作要点：sheet 参数是工作表名或序号（0 开始），不传即当前活动工作表；区域一律用 `A1:D20` 形式；**xlsx 上没有修订模式，写入即生效**，改错用 `doc_undo` 撤销（系统在首次修改前已建文档快照，最后手段 `doc_restore_checkpoint()`）；写数据后再做格式（先 `sheet_write_cells`，同一轮接 `sheet_format_cells`/`sheet_set_borders`/`sheet_set_row_col`）。
 
+公式要点：函数名用英文，按 Excel 习惯写即可（逗号分隔参数、跨表引用 `Sheet1!A1`，系统会自动转换成引擎方言）；SUM/AVERAGE/IF/COUNT(A)/VLOOKUP/SUMIF(S)/COUNTIF(S)/MAX/MIN/ROUND/IFERROR/INDEX+MATCH/TEXT/CONCATENATE/LEFT/RIGHT/MID/LEN/DATE/TODAY/SUMPRODUCT/TEXTJOIN 等常用函数全部可用，中文文本做查找键/条件没有问题；**引擎不支持 XLOOKUP 等 Excel 新函数，用 VLOOKUP 或 INDEX+MATCH 代替**。`sheet_write_cells` 的返回值若带 `formulaErrors`，说明对应公式出错（含单元格、原公式、错误码），必须修正后重写该格，不能无视。
+
 ### 使用规范
 
 1. **优先用当前活跃文档**：系统提示中若有 `<active_document>`（用户此刻在编辑器里打开的文档），用户说"修订一下""这个文档"或未指明对象时就是指它——所有 doc_* 工具已直接作用于它，**禁止**再调 `doc_list_project_files` / `doc_open_file` 去重新发现或打开。只有要编辑**其他**文档（无活跃文档、或用户明确指定了别的文件）时，才先用 `doc_open_file` 打开目标文档

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -704,6 +704,9 @@ function readCellOut(cell) {
   if (enumEq(t, T.EMPTY)) return '';
   if (enumEq(t, T.VALUE)) return cell.getValue();
   if (enumEq(t, T.FORMULA)) {
+    // 出错的公式格 getValue() 返回 0、结果类型也可能标 VALUE——先查错误码，
+    // 否则解析失败的公式在读回里伪装成 0，AI 无从发现（组 17 抽查实证）。
+    try { const err = cell.getError(); if (err) return cell.getString() || ('Err:' + err); } catch (e) {}
     try {
       const FR_VALUE = (css.sheet && css.sheet.FormulaResult && css.sheet.FormulaResult.VALUE != null) ? css.sheet.FormulaResult.VALUE : 1;
       if (unoEnumVal(cell.getPropertyValue('FormulaResultType')) === unoEnumVal(FR_VALUE)) return cell.getValue();
@@ -714,6 +717,24 @@ function readCellOut(cell) {
 // 写入时把"长得像数字"的字符串落成数值（同 NUMERIC_CELL_RE 的 house 口径，但
 // 更严格：前导 0 的编号（如 '001'）保持文本，避免证照号/编号被吞前导零）。
 const SHEET_NUMERIC_RE = /^-?(0|[1-9]\d*)(\.\d+)?$/;
+// Excel 习惯公式 → setFormula 的 API 文法（真机实证：组 17 抽查）：参数分隔符
+// 必须是分号（逗号 Err:508），跨表引用必须是 Sheet.A1（Sheet!A1 报 #NAME?
+// Err:525）。AI 与用户都按 Excel 习惯写逗号和 '!'，在此归一化——只动双引号
+// 字符串字面量之外的字符（Calc 转义引号是成对 ""，相邻翻转两次天然兼容）。
+// 代价：Excel 数组字面量的逗号列分隔与 Calc 交集操作符 '!' 会被误转，两者在
+// AI 生成的公式里出现率趋近于零，换取最高频的多参数函数全部可用。
+function normalizeFormula(f) {
+  let out = '';
+  let inStr = false;
+  for (let i = 0; i < f.length; i++) {
+    const ch = f.charAt(i);
+    if (ch === '"') { inStr = !inStr; out += ch; continue; }
+    if (!inStr && ch === ',') { out += ';'; continue; }
+    if (!inStr && ch === '!') { out += '.'; continue; }
+    out += ch;
+  }
+  return out;
+}
 
 // ---- 流式写入状态机：markdown 行级解析 → 标准格式落字 ------------------------
 // stream_insert 攒字节、按完整行消费；stream_flush 收尾（写掉尾行/尾表、复位）。
@@ -2310,6 +2331,7 @@ const EXEC = {
     for (let i = 0; i < rows.length; i++) if (Array.isArray(rows[i])) nCols = Math.max(nCols, rows[i].length);
     if (nCols > 100) return { success: false, message: '一次最多写 100 列，请分批写入' };
     let written = 0;
+    const formulaCells = []; // 写完统一验错：解析失败/求值出错的公式要报给 AI 自纠
     for (let r = 0; r < rows.length; r++) {
       const line = Array.isArray(rows[r]) ? rows[r] : [rows[r]];
       for (let c = 0; c < line.length; c++) {
@@ -2320,12 +2342,22 @@ const EXEC = {
         else if (typeof v === 'boolean') cell.setValue(v ? 1 : 0);
         else {
           const s = String(v);
-          if (s.charAt(0) === '=') cell.setFormula(s);
+          if (s.charAt(0) === '=') {
+            cell.setFormula(normalizeFormula(s));
+            formulaCells.push({ cell: cell, name: colLetterOf(a0.StartColumn + c) + (a0.StartRow + r + 1), input: s });
+          }
           else if (SHEET_NUMERIC_RE.test(s.trim())) cell.setValue(Number(s.trim()));
           else cell.setString(s);
         }
         written++;
       }
+    }
+    const formulaErrors = [];
+    for (let i = 0; i < formulaCells.length && formulaErrors.length < 20; i++) {
+      try {
+        const err = formulaCells[i].cell.getError();
+        if (err) formulaErrors.push({ cell: formulaCells[i].name, formula: formulaCells[i].input, errorCode: err, display: formulaCells[i].cell.getString() });
+      } catch (e) {}
     }
     const wrote = sheetRangeName({
       StartColumn: a0.StartColumn, StartRow: a0.StartRow,
@@ -2337,7 +2369,12 @@ const EXEC = {
       const vr = sheet.getCellRangeByName(wrote);
       for (let c = 0; c < Math.min(nCols, 10); c++) firstRowAfterWrite.push(readCellOut(vr.getCellByPosition(c, 0)));
     } catch (e) {}
-    return { success: true, sheet: sheet.getName(), range: wrote, cellsWritten: written, firstRowAfterWrite: firstRowAfterWrite };
+    const res = { success: true, sheet: sheet.getName(), range: wrote, cellsWritten: written, firstRowAfterWrite: firstRowAfterWrite };
+    if (formulaErrors.length) {
+      res.formulaErrors = formulaErrors;
+      res.note = formulaErrors.length + ' 个公式出错（引擎为 LibreOffice 24.2：不支持 XLOOKUP 等新函数，用 VLOOKUP 或 INDEX+MATCH 改写；函数名必须是英文）。请修正后用 sheet_write_cells 重写这些单元格。';
+    }
+    return res;
   },
   // [表格·选] 选中一个区域（视图滚过去、选区亮出来——用户看得见 AI 在操作哪里）。
   sheet_select_range(p) {

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -139,6 +139,8 @@ const DEBUG_ACTIONS = `
         const key = cell.getPropertyValue('NumberFormat');
         out.numberFormat = xModel.getNumberFormats().getByKey(key).getPropertyValue('FormatString');
       } catch (e) {}
+      try { out.error = cell.getError(); } catch (e) {}
+      try { out.formula = cell.getFormula(); } catch (e) {}
       try { out.borderTopWidth = cell.getPropertyValue('TopBorder2').LineWidth; } catch (e) {}
       try { out.rowHeightMm = range.getRows().getByIndex(0).getPropertyValue('Height'); } catch (e) {}
       try { out.colWidthMm = range.getColumns().getByIndex(0).getPropertyValue('Width'); } catch (e) {}
@@ -586,6 +588,84 @@ try {
     check('非法区域被拒绝', bad.success === false, JSON.stringify(bad))
     const badSheet = await exec('sheet_read_range', { sheet: '不存在的表' })
     check('不存在的工作表被拒绝', badSheet.success === false && /工作表不存在/.test(badSheet.message || ''), JSON.stringify(badSheet))
+  }
+
+  // ---------- 组 17：Calc 常用公式抽查（按使用频率排序）----------
+  console.log('\n[17] Calc 公式抽查：高频函数 / 中文参数 / 分隔符与跨表写法')
+  {
+    await exec('debug_fresh_calc')
+    const ov17 = await exec('sheet_get_overview')
+    const SHEET = ov17.activeSheet
+    // 数据区 A1:C5
+    await exec('sheet_write_cells', {
+      startCell: 'A1',
+      rows: [
+        ['项目', '金额', '类别'],
+        ['咨询费', 10000, '服务'],
+        ['律师费', 2500.5, '服务'],
+        ['差旅费', 800, '报销'],
+        ['印花税', 120, '税费'],
+      ],
+    })
+    // 公式区 E1:E22 —— 按常用频率排序的抽查清单（Excel 习惯写法：逗号分隔）
+    const FORMULAS = [
+      ['SUM', '=SUM(B2:B5)', 13420.5],
+      ['AVERAGE', '=AVERAGE(B2:B5)', 3355.125],
+      ['IF+中文+逗号', '=IF(B2>5000,"高","低")', '高'],
+      ['COUNT', '=COUNT(B2:B5)', 4],
+      ['COUNTA', '=COUNTA(A2:A5)', 4],
+      ['VLOOKUP+中文键', '=VLOOKUP("律师费",A2:B5,2,0)', 2500.5],
+      ['SUMIF+中文条件', '=SUMIF(C2:C5,"服务",B2:B5)', 12500.5],
+      ['COUNTIF+中文条件', '=COUNTIF(C2:C5,"服务")', 2],
+      ['MAX', '=MAX(B2:B5)', 10000],
+      ['MIN', '=MIN(B2:B5)', 120],
+      ['ROUND', '=ROUND(3.14159,2)', 3.14],
+      ['IFERROR', '=IFERROR(VLOOKUP("不存在",A2:B5,2,0),"未找到")', '未找到'],
+      ['INDEX+MATCH', '=INDEX(A2:A5,MATCH(120,B2:B5,0))', '印花税'],
+      ['TEXT 数字格式', '=TEXT(B2,"#,##0.00")', '10,000.00'],
+      ['& 拼接', '="共"&COUNT(B2:B5)&"项"', '共4项'],
+      ['CONCATENATE', '=CONCATENATE(A2,"-",C2)', '咨询费-服务'],
+      ['LEFT 取中文', '=LEFT(A2,2)', '咨询'],
+      ['LEN 中文计数', '=LEN(A2)', 3],
+      ['DATE/YEAR', '=YEAR(DATE(2026,8,1))', 2026],
+      ['TODAY 比较', '=IF(TODAY()>DATE(2026,1,1),"ok","bad")', 'ok'],
+      ['SUMPRODUCT', '=SUMPRODUCT(B2:B3,B2:B3)', 106252500.25],
+      ['TEXTJOIN', '=TEXTJOIN("、",1,A2:A4)', '咨询费、律师费、差旅费'],
+    ]
+    const wr17 = await exec('sheet_write_cells', { startCell: 'E1', rows: FORMULAS.map((f) => [f[1]]) })
+    check('公式批量写入成功', wr17.success === true && wr17.cellsWritten === FORMULAS.length, JSON.stringify(wr17))
+    const rd17 = await exec('sheet_read_range', { range: 'E1:E' + FORMULAS.length })
+    for (let i = 0; i < FORMULAS.length; i++) {
+      const got = rd17.rows[i][0]
+      const wantVal = FORMULAS[i][2]
+      const ok = typeof wantVal === 'number' ? Math.abs(Number(got) - wantVal) < 1e-9 : got === wantVal
+      check('公式 ' + FORMULAS[i][0] + ' = ' + JSON.stringify(wantVal), ok, FORMULAS[i][1] + ' -> ' + JSON.stringify(got))
+    }
+    // 公式方言归一契约（真机实证：API 文法要分号与 Sheet.A1；worker 把 Excel
+    // 习惯写法归一化，字符串字面量内不动）
+    const DIALECT = [
+      ['分号写法原样可用', '=IF(B2>5000;"高";"低")', '高'],
+      ['跨表 Excel 感叹号归一为点号', '=' + SHEET + '!B2', 10000],
+      ['跨表 Calc 点号原样可用', '=' + SHEET + '.B2', 10000],
+      ['字符串内逗号不受归一影响', '=IF(B2>5000,"高,优","低")', '高,优'],
+      ['字符串内中文标点不受归一影响', '=SUBSTITUTE("甲、乙","、","/")', '甲/乙'],
+    ]
+    const wrD = await exec('sheet_write_cells', { startCell: 'G1', rows: DIALECT.map((f) => [f[1]]) })
+    check('方言公式写入无报错', wrD.success === true && !wrD.formulaErrors, JSON.stringify(wrD))
+    const rdD = await exec('sheet_read_range', { range: 'G1:G' + DIALECT.length })
+    for (let i = 0; i < DIALECT.length; i++) {
+      const got = rdD.rows[i][0]
+      const want = DIALECT[i][2]
+      const ok = typeof want === 'number' ? Math.abs(Number(got) - want) < 1e-9 : got === want
+      check(DIALECT[i][0], ok, DIALECT[i][1] + ' -> ' + JSON.stringify(got))
+    }
+    // 不支持的新函数（引擎 LO 24.2 无 XLOOKUP）：写入结果必须把错误报给 AI 自纠
+    const wrX = await exec('sheet_write_cells', { startCell: 'H1', rows: [['=XLOOKUP("律师费",A2:A5,B2:B5)']] })
+    check('XLOOKUP 出错被上报（formulaErrors+note）',
+      wrX.success === true && Array.isArray(wrX.formulaErrors) && wrX.formulaErrors[0].cell === 'H1' && /XLOOKUP/i.test(wrX.note || ''),
+      JSON.stringify(wrX))
+    const rdX = await exec('sheet_read_range', { range: 'H1' })
+    check('出错公式读回不伪装成 0', rdX.rows[0][0] !== 0 && rdX.rows[0][0] !== '' && String(rdX.rows[0][0]).length > 0, JSON.stringify(rdX.rows))
   }
 
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')


### PR DESCRIPTION
## 背景（PR #231 的后续）

按常用频率对 22 个高频公式做真机抽查（新增 lowa-e2e 组 17），发现两个致命方言差异：

- `setFormula` 走 API 文法，**参数分隔符必须分号**——逗号直接 Err:508，所有多参数函数（IF/VLOOKUP/SUMIF/COUNTIF/ROUND/IFERROR/INDEX+MATCH/TEXT/CONCATENATE/LEFT/DATE/SUMPRODUCT/TEXTJOIN）全部中招；
- 跨表引用必须 `Sheet.A1`——Excel 习惯的 `Sheet!A1` 报 #NAME?（Err:525）。

AI 和用户恰恰都按 Excel 习惯写。另外引擎 LO 24.2 无 XLOOKUP（24.8 才加入），且出错公式此前读回伪装成 0，AI 无从发现。

## 修复

- worker `normalizeFormula`：字符串字面量外 `,`→`;`、`!`→`.`（成对转义引号天然兼容；牺牲 Excel 数组字面量与 Calc 交集操作符 `!`，两者在 AI 公式中出现率趋近于零）
- `sheet_write_cells` 写完回读公式错误码，`formulaErrors`+note 报给 AI 自纠（提示 XLOOKUP 用 VLOOKUP/INDEX+MATCH 改写）
- `readCellOut` 先查 `getError()`，出错公式读回不再伪装成 0
- @Tool 描述与 system_prompt 补公式指引；ai-doc-bridge.md 地雷同步

## 验证

lowa-e2e 组 17 共 31 项断言：22 个高频公式（含中文查找键/条件、TEXT 数字格式、日期族、SUMPRODUCT/TEXTJOIN）+ 分号原样可用/感叹号归一/字符串内逗号与中文标点不受归一影响/XLOOKUP 出错上报——真引擎 **125 passed / 0 failed**。后端 compile 通过（仅注解字符串与提示词变更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)