### PR TITLE
feat(editor): 自建引擎 r3 修复页边修订表格叠字，恢复修订页边显示

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -11,7 +11,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 
 **引擎构建与分发**
 - `desktop/lowa-build/`：README.md（为什么自建 zh-CN）、RECIPE.md（精确配方+产物 sha256）、mega-build.sh（裸机全自动构建，PHASE_1..7）、autogen.input、patches/（两阶段 zh-CN 焙入 + ZZZ-aiworkdeck-locale-zh-CN.xcd 默认 ooLocale）。
-- `desktop/scripts/fetch-lowa-assets.js` — 构建期下载 LOWA 运行时 + OFL CJK 字体到 `frontend/dist/zetaoffice/lowa/`，写 `.encodings.json`（brotli 侧车）；`LOWA_BASE_URL` 指自托管引擎（`https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r2/`）。
+- `desktop/scripts/fetch-lowa-assets.js` — 构建期下载 LOWA 运行时 + OFL CJK 字体到 `frontend/dist/zetaoffice/lowa/`，写 `.encodings.json`（brotli 侧车）；`LOWA_BASE_URL` 指自托管引擎（`https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r3/`）。
 - `desktop/scripts/lowa-selfhost.md` — 自托管流程文档。
 
 **桌面壳服务**
@@ -64,7 +64,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - 删除键/快捷键必须走 `.uno:` 调度（覆盖层吞键+修订模式手工删卡死教训，PR#164/166）。
 - `npm run build:zetaoffice` 会清空 dist 并删掉已 fetch 的引擎——本地反复跑 e2e 用 `LOWA_ENGINE_DIR` 规避，或从兄弟 worktree 复制引擎（CDN 挂时的配方）。
 - 修订作者：params 带 `__agent:true` → 署名 "AI Workdeck"。
-- **ShowChangesInMargin 禁用勿开**：引擎把页边删除文本画在锚点所在 frame 的左侧，表格内 frame=单元格，删除文本会叠画到左邻单元格正文上（法律文书大量用表格），JS 无法矫正绘制位置。修订删除一律行内删除线（office_thread.js `showDeletionsInline`，boot+retarget 双点设置）；批注侧栏不受影响。
+- **ShowChangesInMargin 依赖自建引擎 ≥24.2.8-zhcn-r3**：原生 LO 把页边删除文本画在锚点所在 frame 左侧，表格内 frame=单元格会叠画左邻格正文；r3 焙入 frmpaint.cxx 表格锚点补丁（`desktop/lowa-build/patches`，锚 FindTabFrame 整表左缘）后才能开。页边模式非纯视图设置：开=删除文本移入 redline 对象（getString 可取、正文不含），关=留正文流且 redline getString 抛异常——debug_revisions 已带 RedlineText/区间双路取回，两种模式都能读。已知残留局限：同一表格行多格删除会在页边同 Y 相互叠（上游按行画、无跨格协调）。批注侧栏与此设置无关。
 - webview/uni 存储格式坑与宿主侧 e2e 配方见 lowa-keepalive 记录（PR#159）。
 - **预热备胎是同一个 LibreOfficeEditor 组件（file=null）**：任何在组件树/DOM 里"找编辑器实例"的探针（如 desktop-e2e FIND_EDITOR）必须过滤 `file` 非空，否则命令打在隐藏空白备胎上、样样"成功"但真文档纹丝不动。备胎未激活用 visibility 隐藏（绝对定位占位），不能改 display:none——引擎要在有尺寸画布里 boot。
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -62,7 +62,7 @@ jobs:
           # tooltips + FS/callMain exports. Hosted on the project site (versioned,
           # immutable; wasm/data served brotli so the installer stays small).
           # Unset -> upstream CDN (English UI). Build recipe: desktop/lowa-build/.
-          LOWA_BASE_URL: https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r2/
+          LOWA_BASE_URL: https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r3/
         run: |
           # Track A (Epic #43): download the LibreOffice WASM runtime (soffice.*)
           # into dist/zetaoffice/lowa and an OFL-licensed CJK font (Noto Sans SC)

--- a/desktop/lowa-build/RECIPE.md
+++ b/desktop/lowa-build/RECIPE.md
@@ -1,10 +1,31 @@
 # zh-CN LOWA engine rebuild recipe (with tooltip-CJK fix) — issue #66
 
+## r3 (2026-08-02) — margin-redline table anchor fix
+
+Built on mainland VM 8.156.75.91 (8C/30GB + 48G swap, Ubuntu 22.04) with the SAME
+recipe below plus **source patch 4** (sw/source/core/text/frmpaint.cxx — anchor
+ShowChangesInMargin deleted text at the TABLE frame's left edge via FindTabFrame,
+so in-table deletions render in the true page margin instead of over the
+neighboring cell). soffice.js + metadata sha are byte-identical to r2 — the only
+behavioral delta is the wasm.
+Mainland network note: emsdk's storage.googleapis.com downloads crawl — pre-seed
+`emsdk/downloads/` (node via npmmirror; wasm-binaries relayed from an unrestricted
+network). git clones via GitHub mirror are fine. 8C timings: qt5 ~6 min,
+LO make ~5.8 h (swap carried the final link on 30G RAM).
+
+### r3 artifact sha256
+- soffice.js   ea337a9f4d9d2c74a8b0df9c8bf0c4b9c64f5fda770cd09e631dedd770e882e1  (== r2)
+- soffice.wasm 792b9cb03ddd3d0f0ee4191c7d2ad5401405d33256681346c307bb1879a837b1
+- soffice.data c4841c254079c686cf22a943cc911d5672d0e3b7f2a6049e7cf659abb0d95ddf
+- soffice.data.js.metadata 7c5d27a650d5f0a0b4f08b9c096fa03c51c3233ea6fe4d179d530efdbf383fa2  (== r2)
+
+## r2 (2026-06-26)
+
 Built 2026-06-26 on Singapore VM 47.84.13.121 (32C/123GB RAM, Ubuntu 22.04), from
 scratch. Reproduces the engine with: native zh-CN UI (--with-lang) + ooLocale=zh-CN
 default + **the QToolTip CJK fix** (this round's new change).
 
-## Artifact sha256 (this build)
+## Artifact sha256 (r2 build)
 - soffice.js   ea337a9f4d9d2c74a8b0df9c8bf0c4b9c64f5fda770cd09e631dedd770e882e1
 - soffice.wasm a186dd5082eb69ef58fb57d256294d07817c4acfb06e63fc5901e77d07612954
 - soffice.data e85af877e964f75f14b21b97f0a7103d104aea308ec8c687519412ace48deeb5

--- a/desktop/lowa-build/patches/apply-source-patches.py
+++ b/desktop/lowa-build/patches/apply-source-patches.py
@@ -86,4 +86,37 @@ patch(
     ': Qt::LeftToRight);\n' + cjk_block + '}\n',
     'QtInstance AfterAppInit CJK block',
 )
+
+# ---- Patch 3: margin-redline anchor inside tables (tdf#34355 follow-up) ------
+# ShowChangesInMargin paints the deleted text right-aligned at m_nX (the text
+# frame's left edge). Inside a table that frame is the CELL, so the deleted
+# text lands on top of the NEIGHBORING cell's content. The change bar (m_nRedX)
+# already anchors at the table frame via FindTabFrame() — do the same here so
+# in-table deletions render in the true page margin, left of the whole table.
+patch(
+    f'{CORE}/sw/source/core/text/frmpaint.cxx',
+    ('    Point aTmpPos( m_nX, nY );\n'
+     '    aTmpPos.AdjustY(nAsc );\n'
+     '    if ( pRedlineText )\n'
+     '    {\n'
+     '        Size aSize = pTmpFnt->GetTextSize_( aDrawInf );\n'
+     '        aTmpPos.AdjustX( -(aSize.Width()) - 200 );\n'
+     '    }\n'),
+    ('    Point aTmpPos( m_nX, nY );\n'
+     '    aTmpPos.AdjustY(nAsc );\n'
+     '    if ( pRedlineText )\n'
+     '    {\n'
+     '        Size aSize = pTmpFnt->GetTextSize_( aDrawInf );\n'
+     '        // AI Workdeck: inside a table m_nX is the CELL\'s left edge —\n'
+     '        // right-aligning the deleted text there paints it over the\n'
+     '        // neighboring cell\'s content. Anchor at the table frame\'s left\n'
+     '        // edge instead (the change bar m_nRedX already does this via\n'
+     '        // FindTabFrame in the SwExtraPainter ctor).\n'
+     '        const SwFrame* pTabAnchor = m_pTextFrame->FindTabFrame();\n'
+     '        if ( pTabAnchor )\n'
+     '            aTmpPos.setX( pTabAnchor->getFrameArea().Left() );\n'
+     '        aTmpPos.AdjustX( -(aSize.Width()) - 200 );\n'
+     '    }\n'),
+    'frmpaint margin-redline table anchor',
+)
 print('ALL_PATCHES_OK')

--- a/desktop/lowa-build/patches/source-patches.diff
+++ b/desktop/lowa-build/patches/source-patches.diff
@@ -95,3 +95,22 @@ index 8ac9d2bda..2bcba8b6c 100644
  }
  
  void QtInstance::localeChanged()
+
+--- a/sw/source/core/text/frmpaint.cxx
++++ b/sw/source/core/text/frmpaint.cxx
+@@ SwExtraPainter::PaintExtra @@
+     Point aTmpPos( m_nX, nY );
+     aTmpPos.AdjustY(nAsc );
+     if ( pRedlineText )
+     {
+         Size aSize = pTmpFnt->GetTextSize_( aDrawInf );
++        // AI Workdeck: inside a table m_nX is the CELL's left edge —
++        // right-aligning the deleted text there paints it over the
++        // neighboring cell's content. Anchor at the table frame's left
++        // edge instead (the change bar m_nRedX already does this via
++        // FindTabFrame in the SwExtraPainter ctor).
++        const SwFrame* pTabAnchor = m_pTextFrame->FindTabFrame();
++        if ( pTabAnchor )
++            aTmpPos.setX( pTabAnchor->getFrameArea().Left() );
+         aTmpPos.AdjustX( -(aSize.Width()) - 200 );
+     }

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -807,16 +807,17 @@ function streamWriteLine(line) {
   streamParagraph(parseInlineRuns(trimmed), 'body', null);
 }
 
-// Tracked DELETIONS display inline with strikethrough (Word "All Markup").
-// ShowChangesInMargin (tdf#34355) is deliberately OFF: the engine paints the
-// margin text to the LEFT of the anchor's frame — for text inside a table cell
-// that frame is the CELL, so deleted text lands on top of the neighboring
-// cell's content (法律文书大量用表格，重叠不可读；无 JS 手段矫正绘制位置).
-// Comments are unaffected — they keep their own sidebar right of the page.
-// This is a VIEW setting on the controller, not the model, so it must be
-// re-applied whenever the controller changes (boot AND load_document retarget).
-function showDeletionsInline() {
-  try { ctrl.getViewSettings().setPropertyValue('ShowChangesInMargin', false); }
+// LO 7.1+ (tdf#34355): tracked DELETIONS render in the page margin next to the
+// changed-line mark instead of inline strikethrough — the body stays readable
+// (original text + colored insertions only). REQUIRES engine >= 24.2.8-zhcn-r3:
+// stock LO paints the margin text left of the anchor's frame, which inside a
+// table is the CELL — deleted text landed on the neighboring cell's content.
+// r3 carries our frmpaint.cxx patch anchoring at the table frame's left edge
+// (desktop/lowa-build/patches). This is a VIEW setting on the controller, not
+// the model, so it must be re-applied whenever the controller changes (boot
+// AND load_document retarget).
+function showDeletionsInMargin() {
+  try { ctrl.getViewSettings().setPropertyValue('ShowChangesInMargin', true); }
   catch (e) { log('ShowChangesInMargin 设置失败 / failed: ' + errStr(e)); }
 }
 
@@ -836,7 +837,7 @@ function bootDoc() {
   // change the lawyer can accept/reject. Set once here (and on retarget) instead
   // of per-command, so no edit path can slip through untracked.
   try { xModel.setPropertyValue('RecordChanges', true); } catch {}
-  showDeletionsInline();
+  showDeletionsInMargin();
 
   installKeyHandler();
   try { installModifyListener(xModel); } catch (e) { log('XModifyListener 安装失败 / install failed: ' + errStr(e)); }
@@ -1420,7 +1421,7 @@ const EXEC = {
       try { installModifyListener(xModel); } catch (e) { log('XModifyListener 安装失败 / install failed: ' + errStr(e)); }
       // Revisions default ON for the real document too (same as bootDoc).
       try { xModel.setPropertyValue('RecordChanges', true); } catch (e) {}
-      showDeletionsInline();
+      showDeletionsInMargin();
     };
 
     const errs = [];

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -229,23 +229,23 @@ try {
     await focus()
   }
 
-  // NOTE: ShowChangesInMargin (tdf#34355) is OFF again — the engine paints
-  // margin deletions over the neighboring TABLE CELL's content (法律文书大量
-  // 用表格，重叠不可读), so deletions are back to inline strikethrough. The
-  // struck-through originals therefore stay in the cursor context and the
-  // cursor steps OVER them.
+  // NOTE: ShowChangesInMargin (tdf#34355) is ON again — engine 24.2.8-zhcn-r3
+  // carries the frmpaint table-anchor patch, so in-table deletions render in
+  // the true page margin (stock LO painted them over the neighboring cell).
+  // Deletions leave the inline text, so the cursor context no longer contains
+  // the struck-through originals.
   console.log('== 1) Backspace over pre-existing text (revision-mode jam regression #164) ==')
   await reset('合同条款abc') // inserted with rc OFF -> "original" text; rc back ON
   for (let i = 0; i < 3; i++) await key('Backspace', 'Backspace', 8)
   let c = await cursor()
-  check('3×Backspace 光标逐字越过原文（划线留正文）', c.b === '合同条款' && c.a === 'abc', JSON.stringify(c))
+  check('3×Backspace 删除移入页边（正文不留）', c.b === '合同条款' && c.a === '', JSON.stringify(c))
 
   console.log('== 2) Delete key forward-deletes ==')
   await reset('合同条款abc')
   for (let i = 0; i < 3; i++) await key('ArrowLeft', 'ArrowLeft', 37)
   for (let i = 0; i < 2; i++) await key('Delete', 'Delete', 46)
   c = await cursor()
-  check('2×Delete 前删越过原文（划线留正文）', c.b === '合同条款ab' && c.a === 'c', JSON.stringify(c))
+  check('2×Delete 前删移入页边（正文不留）', c.b === '合同条款' && c.a === 'c', JSON.stringify(c))
 
   console.log('== 3) IME CJK commit + Backspace hard-deletes own insert ==')
   await reset('')
@@ -348,9 +348,8 @@ try {
 
   console.log('== 11) 修订颗粒度：一字之差只标一字，不整段删增 ==')
   // 口径说明：按 author 过滤只看本场景的修订（场景 10 已把作者设为"测试用户"），
-  // 防前面场景跨 reset 残留的删除记录混入。行内显示（ShowChangesInMargin=false）
-  // 下删除文本留在正文流：正文断言按「插入在前、划删原文在后」的行内形态核对，
-  // 这个形态本身就证明了颗粒度（整段删增会让整句成对出现）。
+  // 防前面场景跨 reset 残留的删除记录混入（页边模式下删除文本不在正文流、
+  // 不随 reset 硬清）；删除文本经 debug_revisions 的 RedlineText/区间双路取回。
   const mine = (rv2) => (rv2.redlines || []).filter((r) => r.author === '测试用户')
   const delTexts = (rv2) => mine(rv2).filter((r) => r.type === 'Delete').map((r) => r.text)
   await reset('我爱你', true)
@@ -359,14 +358,14 @@ try {
   check('find_replace 我爱你→我恨你 只删"爱"（非整句）',
     rv11.success && delTexts(rv11).includes('爱') && delTexts(rv11).every((t2) => (t2 || '').length === 1), JSON.stringify(rv11))
   check('插入也只落一处修订', mine(rv11).filter((r) => r.type === 'Insert').length === 1, JSON.stringify(mine(rv11)))
-  check('正文呈现插删并存（恨插入、爱划删留正文）', (await doc()) === '我恨爱你', await doc())
+  check('正文呈现新句', (await doc()) === '我恨你', await doc())
   await reset('甲方应于三十日内向乙方支付服务费。', true)
   await exec('modify_paragraph', { index: 0, newText: '甲方应于六十日内向乙方支付全部服务费。' })
   rv11 = await exec('debug_revisions')
   check('modify_paragraph 散点小改只删"三"（非整段重写）',
     rv11.success && delTexts(rv11).includes('三') && delTexts(rv11).every((t2) => (t2 || '').length === 1), JSON.stringify(rv11))
   check('两处插入各自成修订（六 / 全部）', mine(rv11).filter((r) => r.type === 'Insert').length === 2, JSON.stringify(mine(rv11)))
-  check('改后段落实文正确（划删"三"留正文）', (await doc()) === '甲方应于六三十日内向乙方支付全部服务费。', await doc())
+  check('改后段落实文正确', (await doc()) === '甲方应于六十日内向乙方支付全部服务费。', await doc())
 
   console.log('== 12) add_comment 批注：解释文字挂批注、不进正文 ==')
   await reset('本合同自签署之日起生效。', true)
@@ -425,7 +424,7 @@ try {
     // 方向断言：探针（第 0 期）已实证产出「旧→新」的删/插修订——删除侧应含"三"
     check('方向正确：redlines 含 Delete「三」',
       cmpRedlines.filter((r) => r.type === 'Delete').map((r) => r.text).includes('三'), JSON.stringify(cmpRedlines))
-    check('正文停在新版+行内划删原文', (await doc()) === '甲方应于六三十日内支付合同价款。', await doc())
+    check('正文停在新版可读文本', (await doc()) === '甲方应于六十日内支付合同价款。', await doc())
   }
 
   // ---------- 组 14：富格式原语（行距/段距/缩进/编号/建表/格式读取）----------


### PR DESCRIPTION
## 背景

PR #229 定位到 ShowChangesInMargin 的表格叠字是引擎绘制缺陷，当时在宿主层回退为行内删除线规避。本 PR 从引擎侧根治并恢复页边显示。

## 引擎 24.2.8-zhcn-r3

- 新增 source patch 4：`sw/source/core/text/frmpaint.cxx` PaintExtra 的 pRedlineText 分支锚点改走 `FindTabFrame()` 取整表左缘（与 change bar `m_nRedX` 同一先例）——表格内删除文本落真页边，不再叠画左邻单元格；正文段落行为不变
- 复现配方与 sha256 已入 RECIPE.md（大陆网络 emsdk 预埋缓存诀窍、8C 机型时序）；soffice.js/metadata 与 r2 逐字节一致，行为差异仅 wasm
- 已部署 `https://www.aiworkdeck.com/lowa-engine/24.2.8-zhcn-r3/`（wasm/data brotli 直存、nginx 通用配置直接生效）；用生产 URL 走 fetch-lowa-assets 全流程校验，解压后 sha 与构建产物逐字节一致

## 前端联动

- `showDeletionsInline` → `showDeletionsInMargin`（恢复页边模式，注释注明依赖引擎 ≥r3）
- `desktop-build.yml` LOWA_BASE_URL 切 r3
- lowa-e2e 组 1/2/11/13 断言切回页边口径；`debug_revisions` 的 RedlineText/区间双路取回保留，两种显示模式都能读修订文本
- doc-editor.md 地雷更新（含已知局限：同一表格行多格删除会在页边同 Y 互叠，上游按行绘制无跨格协调）

## 验证

- r3 真机复现脚本：表格删除文本渲染于整表左侧真页边、正文页边行为不变、zh-CN UI 完整（「默认段落样式」/状态栏中文/ooLocale=zh-CN）
- `npm run test:lowa-e2e` 94/94 全绿（含 #230/#231 隔夜新增的富格式与 sheet_* 步骤，r3 引擎全兼容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)