### PR TITLE
release v0.9.4：版本号 + 修 #241 引入的新会话 403 回归

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -58,11 +58,9 @@ public class AiAgentController {
      * 猜到即可接管他人的 SSE 输出流（含文档正文与 editor 指令的 requestId）。
      */
     private boolean canUseConversation(String conversationId, Long userId) {
-        if (userId == null || conversationId == null) {
-            return false;
-        }
-        return messageService.isConversationOwnedBy(conversationId, userId)
-                || messageService.listByConversationId(conversationId).isEmpty();
+        // 口径收敛到 ProjectAiMessageService：此前这条规则只在本控制器有，
+        // AiChatController 取历史用的是严格归属，导致新会话一进项目就 403
+        return messageService.canUseConversation(conversationId, userId);
     }
 
     /**

--- a/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
@@ -100,7 +100,9 @@ public class AiChatController {
 
         // If conversationId is provided, return specific messages
         if (StringUtils.hasText(conversationId)) {
-             if (!projectAiMessageService.isConversationOwnedBy(conversationId, userId)) {
+             // 用「可用」而非「归属」：新会话还没有消息，前端一进项目就会来拉一次，
+             // 拿严格归属判会把每个新会话都挡成 403
+             if (!projectAiMessageService.canUseConversation(conversationId, userId)) {
                  return ResponseEntity.status(403).body("无权查看该会话");
              }
              return ResponseEntity.ok(projectAiMessageService.listByConversationId(conversationId));
@@ -138,7 +140,7 @@ public class AiChatController {
                                                      @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         // 归属校验：文件变动清单会暴露他人项目的文件名，此前此接口连 session 都不读
         Long userId = AuthController.getUserIdFromSession(sessionId);
-        if (userId == null || !projectAiMessageService.isConversationOwnedBy(conversationId, userId)) {
+        if (!projectAiMessageService.canUseConversation(conversationId, userId)) {
             return ResponseEntity.status(403).body("无权查看该会话");
         }
         try {

--- a/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
@@ -32,7 +32,9 @@ public class EditorResultController {
         // 归属校验：结果会以工具输出的身份进入模型上下文并驱动后续改文档动作，
         // 此前既不认人也不认会话，拿到 requestId 就能往别人的 Agent 循环里塞伪造内容
         Long userId = com.checkba.controller.AuthController.getUserIdFromSession(sessionId);
-        if (userId == null || !messageService.isConversationOwnedBy(payload.getConversationId(), userId)) {
+        // 用「可用」而非「归属」：工具结果可能早于首条消息落库，严格归属会误杀；
+        // 拦住「回传到别人的会话」这一点两者一致
+        if (!messageService.canUseConversation(payload.getConversationId(), userId)) {
             log.warn("Rejected editor result: requestId={}, conversationId={}", payload.getRequestId(), payload.getConversationId());
             return new EditorResultResponse(false, "无权回传该会话的结果");
         }

--- a/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
@@ -140,6 +140,21 @@ public class ProjectAiMessageService {
                 .orElse(false);
     }
 
+    /**
+     * 会话是否可被该用户使用：已归属于他，或还没有任何消息（新会话，尚无主）。
+     *
+     * 前端进入项目就先生成 conversationId 并拉历史/开流，此时一条消息都还没落库，
+     * 用 isConversationOwnedBy 判会得到 false——那是「归属判定」，不是「可用判定」，
+     * 两者混用会把每个新会话都挡成 403（实测：一进项目 AI 面板就报无权）。
+     * 读写类接口一律用本方法；只有明确的破坏性操作（如回滚他人会话）才用严格归属。
+     */
+    public boolean canUseConversation(String conversationId, Long userId) {
+        if (userId == null || conversationId == null) return false;
+        return repository.findFirstByConversationId(conversationId)
+                .map(m -> userId.equals(m.getUserId()))
+                .orElse(true);
+    }
+
     public List<java.util.Map<String, Object>> listConversations(Long projectId, Long userId) {
         List<Object[]> results = repository.findConversationSummaries(projectId, userId);
         return results.stream()

--- a/backend/src/test/java/com/checkba/service/ProjectAiMessageServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectAiMessageServiceTest.java
@@ -103,4 +103,36 @@ class ProjectAiMessageServiceTest {
         ArgumentCaptor<ProjectAiMessage> captor = ArgumentCaptor.forClass(ProjectAiMessage.class);
         verify(repository, never()).save(captor.capture());
     }
+
+    /**
+     * 回归：安全加固时把「会话可用」误用成「会话归属」，新会话（还没有任何消息）
+     * 被判为无主，用户一进项目、AI 面板拉历史就 403，连带整个页面初始化中断
+     * （app-e2e 表现为版本时间线不刷新，J10 整条链路失败）。
+     * 两个语义必须分开：读写用可用性，破坏性操作用严格归属。
+     */
+    @Test
+    void 新会话尚无消息时可用但不判定归属() {
+        when(repository.findFirstByConversationId("conv-new")).thenReturn(Optional.empty());
+
+        assertTrue(service.canUseConversation("conv-new", 7L), "新会话必须可用，否则每个新会话都被挡成 403");
+        assertFalse(service.isConversationOwnedBy("conv-new", 7L), "无消息的会话没有归属人");
+    }
+
+    @Test
+    void 已有消息的会话只有首条作者可用() {
+        ProjectAiMessage first = new ProjectAiMessage();
+        first.setUserId(7L);
+        when(repository.findFirstByConversationId("conv-owned")).thenReturn(Optional.of(first));
+
+        assertTrue(service.canUseConversation("conv-owned", 7L));
+        assertFalse(service.canUseConversation("conv-owned", 8L), "别人的会话不可用");
+        assertTrue(service.isConversationOwnedBy("conv-owned", 7L));
+        assertFalse(service.isConversationOwnedBy("conv-owned", 8L));
+    }
+
+    @Test
+    void 未登录一律不可用() {
+        assertFalse(service.canUseConversation("conv-new", null));
+        assertFalse(service.canUseConversation(null, 7L));
+    }
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
安全修复版发版。#241 已合入 master（39 项确认高危 + 12 项中低危，修复 42 项）。

本 PR 两件事：
1. `desktop/package.json` 提到 0.9.4（版本号唯一来源，合入后推 `v0.9.4` 触发桌面构建）
2. **修掉 #241 引入的一个回归**（见下）

## 回归：一进项目 AI 面板就 403

发版前按约定跑 app-e2e，结果 **79 过 / 21 失败**，失败全部集中在 J10
「退回 → 另起一稿 → 采纳」。用合并前的 `38fc6d2f` 跑同一套做对照：**100 过 / 0 失败**。
所以是 #241 引入的回归，不是既有问题。

根因：把「会话可用」当成「会话归属」用了。`isConversationOwnedBy` 依据首条消息的
`userId` 判定，而新会话此刻一条消息都没有，`orElse(false)` 直接判为无主。前端一进项目
就生成 conversationId 并拉历史，于是**每个新会话必 403**；`request()` 对非 200 一律
reject，`project-overview` 初始化链路被打断，版本时间线不再刷新——e2e 因此在 J10 首步
就失败，后面 20 步是连锁。

`AiAgentController` 当时自己写了「空会话视为无主」的 `canUseConversation`，
`AiChatController` 取历史却用严格归属，两处口径不一致是漏网原因。

修法：语义收敛到 `ProjectAiMessageService.canUseConversation`（已归属 或 尚无消息）。
读写类接口（取历史 / 会话元数据 / SSE 连接 / editor-result 回传）统一用它；
破坏性操作（`history/rollback` 截断消息）保留严格归属。

## 验证

- 实测：新会话取历史 403 → **200 空列表**；未登录仍 **401**；
  A 的会话有消息后 B 去读仍 **403**（越权防护未削弱）
- `mvn test` **680 项全通过**，新增三例锁定「可用 vs 归属」两套语义
- `npm run test:app-e2e` **100 步全过 / 0 失败**，与合并前基线一致

## 仍未覆盖

`test:lowa-e2e` 未跑（需 LOWA 引擎资源）。本次改动不涉及编辑器引擎，
但 #241 动过 editor-result 回传，发版后值得在真机上点一次 AI 改文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)