### PR TITLE
插件广场重构为 VS Code 扩展栏形态（左栏列表 + 中栏详情 tab）

### DIFF
--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -9,10 +9,12 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
 
 ## 关键文件
 
-**前端**
-- `frontend/src/components/MarketPane.vue` — 插件广场**组件本体**（2026-08 从整页抽出）：扁平三 tab「Skill 广场 / 插件广场 / 已安装」。Skill 广场带七分类下划线导航（带计数、空分类不占位）与搜索；插件广场接在线注册表，安装前弹权限确认；已安装分插件区与 Skill 区，Skill 卡右上是生效方式三档下拉。prop `standalone`（默认 false）控制返回按钮渲染；根 `.market-pane` height:100% 内滚。**主入口是 workbench 内 tab**（rail 广场按钮 → openMarketTab()，`tabType:'market'`，见 sidebar-shell.md）。
-  **视觉规范以官网 `aiworkdeckweb/DESIGN.md` 为准**（深绿 hero + 眉标 + 衬线展示字 + 编辑式下划线页签 + 「引号」触发词 + 毛玻璃卡片），改这页先读那份，不要在本页自创风格。
-- `frontend/src/pages/plugin-market/plugin-market.vue` — 薄壳页（22 行）：`<MarketPane :standalone="true">`，保留给 admin 页跳转与直链。onLoad 语义已移入组件 mounted；tab 每次重挂会重拉四组数据（两个打在线 registry）。
+**前端（2026-08 二改：VS Code 扩展栏形态，主入口）**
+- `frontend/src/components/MarketSidebarPanel.vue` — **左栏列表面板**（rail 广场按钮 → `toggleLeftPane('market')` 打开）：顶部搜索（过滤全部分组）+ 三个折叠分组「已安装（含重扫按钮）/ Skill 广场 / 插件广场」的紧凑行（分类图标+名称+一行描述+版本·下载·分类，行内快捷安装钮）。点行 emit `open-detail`。
+- `frontend/src/components/MarketDetailPane.vue` — **中栏详情 tab**（overview `openMarketDetail(spec)` 打开，`tabType:'market-detail'`、id=`market-detail_{kind}_{id}`、单例、isTabVisible 常显）：头部图标+衬线标题+作者/版本/下载+动作区（Skill：安装/更新/卸载/生效方式三档；插件：安装带权限确认/启停 switch/卸载），正文触发词「」排版、能力、详细信息（标识/来源/主页，主页 emit open-url 走浏览器 tab）。
+- 两件通过 `uni.$emit('awd:market-changed')`（详情→列表）与 `'awd:market-changed-from-sidebar'`（列表→详情）互相刷新；组件卸载时 $off，不涉页面栈多实例地雷。
+- `frontend/src/components/MarketPane.vue` — 原整页版（深绿 hero 三 tab），现**仅存于 admin 独立页**：`frontend/src/pages/plugin-market/plugin-market.vue` 薄壳页 `<MarketPane :standalone="true">`，保留给 admin 页跳转与直链。
+  **视觉规范以官网 `aiworkdeckweb/DESIGN.md` 为准**；新两件是浅色工作台密度形态（VS Code 扩展栏/详情页结构 + 产品浅色绿系）。
 - `frontend/src/config/icons.js` — `catContract/catLitigation/catCompliance/catResearch/catCorporate/catOffice/catOther` 七枚分类图标，**与官网 `components/skills/CategoryIcon.tsx` 的映射一一对应**，改一边必须同步另一边，否则同一个 Skill 在官网与桌面端长相不同。
 - `frontend/src/services/api.js` :407-485 — plugins、skills、skills/market 三组 HTTP 封装。
 - 入口：`frontend/src/pages/admin/admin.vue` :584 系统管理侧边栏项 `{key:'plugins', label:'插件广场', route:'/pages/plugin-market/plugin-market'}`。**leftSidebarPlugins.js 不含市场入口**（那是 IDE 左栏业务插件位）。

--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -35,7 +35,7 @@ rail 点击 → toggleLeftPane(key)（:2988）：staging 单独分支 → 把当
 ## 左栏入口（frontend/src/config/leftSidebarPlugins.js，57 行）
 
 固定入口：files(资源管理器→FileTree)、dd-files(尽调文件)、shareholder-meeting(股东大会，**面板区无分支=占位**)、search、easyvoice、desensitize、version(版本记录→VersionPanel，见 `.claude/agents/version-control.md`)。辅助函数 getLeftSidebarPlugin(key)（找不到回退第一项）、getPluginsForUser(role)（CLIENT 只见尽调文件）。动态插件后端拉取后追加 rail 并用 PluginPane 渲染。rail 齿轮对所有人可见，admin 页/接口后端 requireAdmin（用户名 admin）。
-**插件广场入口（2026-08 起 VS Code 式）**：rail 广场按钮 goToPluginMarket → `openMarketTab()` 在 workbench 开单例 tab（`tabType:'market'`，isTabVisible 常显不随左栏模式隐藏，直接 push 进 leftFiles/rightFiles 绕过 isFileTypeSupported 白名单——与浏览器 tab 同法），渲染 `components/MarketPane.vue`；独立页面路由保留给 admin 入口与直链（薄壳页 + `<MarketPane :standalone="true">`）。
+**插件广场入口（2026-08 二改：VS Code 扩展栏形态）**：rail 广场按钮 goToPluginMarket → `toggleLeftPane('market')` 开左栏列表面板（`MarketSidebarPanel`，leftPaneKey='market'，leftPaneTitle 特判）；点列表行 → `openMarketDetail(spec)` 在中栏开详情 tab（`MarketDetailPane`，`tabType:'market-detail'`、单例、isTabVisible 常显、直接 push 进 leftFiles/rightFiles 绕过 isFileTypeSupported——与浏览器 tab 同法）。独立页面路由保留给 admin 入口与直链（薄壳页 + `<MarketPane :standalone="true">`）。详见 plugin-marketplace.md。
 
 ## 页面路由（frontend/src/pages.json，全部 navigationStyle: custom）
 

--- a/frontend/src/components/MarketDetailPane.vue
+++ b/frontend/src/components/MarketDetailPane.vue
@@ -1,0 +1,659 @@
+<template>
+  <scroll-view scroll-y class="mdp">
+    <view class="mdp-inner">
+      <!-- 头部：图标 + 名称 + 元信息 + 动作（VS Code 扩展详情页结构） -->
+      <view class="mdp-head">
+        <view class="mdp-glyph">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path v-for="(d, gi) in headGlyph" :key="gi" :d="d" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </view>
+        <view class="mdp-head-main">
+          <view class="mdp-title-row">
+            <text class="mdp-title">{{ display.name }}</text>
+            <text class="mdp-kind-badge">{{ spec.kind === 'plugin' ? '插件' : 'Skill' }}</text>
+            <text v-if="installedInfo" class="mdp-installed-badge">已安装</text>
+          </view>
+          <view class="mdp-byline">
+            <text v-if="display.author" class="mdp-byline-item mdp-author">{{ display.author }}</text>
+            <text v-if="display.version" class="mdp-byline-item">v{{ display.version }}</text>
+            <text v-if="display.downloads" class="mdp-byline-item">{{ display.downloads }} 下载</text>
+            <text v-if="display.categoryLabel" class="mdp-byline-item">{{ display.categoryLabel }}</text>
+          </view>
+          <text v-if="display.description" class="mdp-summary">{{ display.description }}</text>
+
+          <!-- 动作区 -->
+          <view class="mdp-actions">
+            <!-- Skill：安装 / 更新 / 卸载 + 生效方式三档 -->
+            <template v-if="spec.kind === 'skill'">
+              <view
+                v-if="marketInfo && !installedInfo"
+                class="mdp-btn primary"
+                :class="{ busy }"
+                @tap="doInstallSkill"
+              >
+                <text>{{ busy ? '安装中…' : '安装' }}</text>
+              </view>
+              <view
+                v-else-if="marketInfo && installedInfo"
+                class="mdp-btn"
+                :class="{ busy }"
+                @tap="doInstallSkill"
+              >
+                <text>{{ busy ? '处理中…' : '重新安装 / 更新' }}</text>
+              </view>
+              <picker
+                v-if="installedInfo && !installedInfo.sourcePluginId"
+                :range="ACTIVATION_LABELS"
+                :value="activationIndex"
+                @change="onActivationChange"
+              >
+                <view class="mdp-btn">
+                  <text>生效方式：{{ ACTIVATION_LABELS[activationIndex] }} ▾</text>
+                </view>
+              </picker>
+              <text v-if="installedInfo && installedInfo.sourcePluginId" class="mdp-action-hint">随插件启停，不可单独设置</text>
+              <view
+                v-if="installedInfo && marketInfo && !installedInfo.sourcePluginId"
+                class="mdp-btn danger"
+                :class="{ busy }"
+                @tap="doUninstallSkill"
+              >
+                <text>卸载</text>
+              </view>
+            </template>
+
+            <!-- 插件：安装（带权限确认）/ 启停 / 卸载 -->
+            <template v-else>
+              <view
+                v-if="marketInfo && !installedInfo"
+                class="mdp-btn primary"
+                :class="{ busy }"
+                @tap="doInstallPlugin"
+              >
+                <text>{{ busy ? '安装中…' : '安装' }}</text>
+              </view>
+              <view v-if="installedInfo" class="mdp-switch-row">
+                <text class="mdp-switch-label">{{ installedInfo.enabled ? '已启用' : '已停用' }}</text>
+                <switch :checked="!!installedInfo.enabled" color="#1A5336" style="transform: scale(0.7);" @change="onPluginToggle" />
+              </view>
+              <view
+                v-if="installedInfo && marketInfo"
+                class="mdp-btn danger"
+                :class="{ busy }"
+                @tap="doUninstallPlugin"
+              >
+                <text>卸载</text>
+              </view>
+            </template>
+          </view>
+        </view>
+      </view>
+
+      <view class="mdp-divider"></view>
+
+      <view v-if="loading" class="mdp-loading"><text>加载中…</text></view>
+      <view v-else-if="!marketInfo && !installedInfo" class="mdp-loading">
+        <text>{{ loadError ? '加载失败：' + loadError : '没有找到这一项（可能已从广场下架或本机已卸载）' }}</text>
+      </view>
+
+      <template v-else>
+        <!-- 触发词（Skill） -->
+        <view v-if="spec.kind === 'skill' && triggerList.length" class="mdp-section">
+          <text class="mdp-sec-title">触发词</text>
+          <view class="mdp-triggers">
+            <text v-for="(t, i) in triggerList" :key="i" class="mdp-trigger">「{{ t }}」</text>
+          </view>
+          <text class="mdp-sec-note">对话命中触发词时自动生效；也可在输入框用 / 手动选用。</text>
+        </view>
+
+        <!-- 能力与权限 -->
+        <view class="mdp-section">
+          <text class="mdp-sec-title">{{ spec.kind === 'plugin' ? '声明能力' : '能力' }}</text>
+          <text class="mdp-sec-body">{{ capabilityText }}</text>
+          <text v-if="spec.kind === 'plugin'" class="mdp-sec-note">插件与本机应用同等权限。平台已人工审核并签名，安装后默认停用，启用前不会执行任何插件代码。</text>
+        </view>
+
+        <!-- 详细信息 -->
+        <view class="mdp-section">
+          <text class="mdp-sec-title">详细信息</text>
+          <view class="mdp-kv">
+            <view class="mdp-kv-row"><text class="mdp-k">标识</text><text class="mdp-v mono">{{ spec.id }}</text></view>
+            <view v-if="display.version" class="mdp-kv-row"><text class="mdp-k">版本</text><text class="mdp-v">v{{ display.version }}</text></view>
+            <view v-if="display.author" class="mdp-kv-row"><text class="mdp-k">作者</text><text class="mdp-v">{{ display.author }}</text></view>
+            <view v-if="display.updatedAt" class="mdp-kv-row"><text class="mdp-k">更新于</text><text class="mdp-v">{{ display.updatedAt }}</text></view>
+            <view class="mdp-kv-row"><text class="mdp-k">来源</text><text class="mdp-v">{{ sourceText }}</text></view>
+            <view v-if="display.homepage" class="mdp-kv-row">
+              <text class="mdp-k">主页</text>
+              <text class="mdp-v mdp-link" @tap="$emit('open-url', display.homepage)">{{ display.homepage }}</text>
+            </view>
+          </view>
+        </view>
+      </template>
+    </view>
+  </scroll-view>
+</template>
+
+<script>
+// 插件广场详情 tab（VS Code 扩展详情页形态）。spec = { kind: 'skill'|'plugin', id, name }
+// 由左栏 MarketSidebarPanel 点行打开。自行拉取市场与已安装两份数据合成视图，
+// 装/卸/启停后通过 uni.$emit('awd:market-changed') 通知左栏刷新。
+import { getPlugins, getSkills, getSkillMarket, getPluginMarket, installMarketSkill, uninstallMarketSkill, installMarketPlugin, uninstallMarketPlugin, setPluginEnabled, setSkillActivation } from '@/services/api.js'
+import { ICONS } from '@/config/icons.js'
+
+const CATEGORY_GLYPHS = {
+  contract: ICONS.catContract,
+  litigation: ICONS.catLitigation,
+  compliance: ICONS.catCompliance,
+  research: ICONS.catResearch,
+  corporate: ICONS.catCorporate,
+  office: ICONS.catOffice,
+  other: ICONS.catOther,
+}
+
+const CATEGORY_LABELS = {
+  contract: '合同',
+  litigation: '诉讼与争议',
+  compliance: '合规风控',
+  research: '法律研究',
+  corporate: '公司与投融资',
+  office: '办公效率',
+  other: '其他',
+}
+
+const PERMISSION_LABELS = {
+  file_read: '读取文件',
+  file_write: '写入文件',
+  network: '网络访问',
+  editor: '编辑器',
+}
+
+const ACTIVATION_MODES = ['auto', 'manual', 'disabled']
+const ACTIVATION_LABELS = ['自动触发', '仅手动', '停用']
+
+export default {
+  name: 'MarketDetailPane',
+  props: {
+    spec: {
+      type: Object,
+      required: true,
+    },
+  },
+  emits: ['open-url'],
+  data() {
+    return {
+      loading: true,
+      loadError: '',
+      marketInfo: null,
+      installedInfo: null,
+      busy: false,
+    }
+  },
+  computed: {
+    ACTIVATION_LABELS() {
+      return ACTIVATION_LABELS
+    },
+    headGlyph() {
+      if (this.spec.kind === 'plugin') return ICONS.blocks
+      const cat = (this.marketInfo?.category || this.installedInfo?.category) || 'other'
+      return CATEGORY_GLYPHS[cat] || CATEGORY_GLYPHS.other
+    },
+    display() {
+      const m = this.marketInfo || {}
+      const i = this.installedInfo || {}
+      const downloads = m.downloads
+      const cat = m.category || i.category
+      return {
+        name: m.name || i.name || this.spec.name || this.spec.id,
+        description: m.description || i.description || '',
+        author: m.authorDisplayName || m.author || i.author || '',
+        version: m.version || i.version || '',
+        downloads: downloads ? (downloads >= 10000 ? (downloads / 10000).toFixed(1) + 'w' : downloads >= 1000 ? (downloads / 1000).toFixed(1) + 'k' : String(downloads)) : '',
+        categoryLabel: this.spec.kind === 'skill' && cat ? (CATEGORY_LABELS[cat] || '其他') : '',
+        updatedAt: m.updatedAt ? String(m.updatedAt).slice(0, 10) : '',
+        homepage: m.homepage || '',
+      }
+    },
+    triggerList() {
+      return this.marketInfo?.triggers || this.installedInfo?.triggers || []
+    },
+    capabilityText() {
+      const item = this.marketInfo || this.installedInfo || {}
+      const parts = []
+      const toolCount = item.toolCount != null ? item.toolCount : (item.tools || []).length
+      if (toolCount) parts.push(`${toolCount} 个工具`)
+      if (this.spec.kind === 'skill' && (item.allowedTools || []).length) {
+        parts.push(`可用工具：${item.allowedTools.join('、')}`)
+      }
+      const perms = (item.permissions || []).map(p => PERMISSION_LABELS[p] || p)
+      parts.push(perms.length ? `需要 ${perms.join('、')}` : '未声明敏感能力')
+      return parts.join(' · ')
+    },
+    activationIndex() {
+      const s = this.installedInfo
+      if (!s) return 0
+      const mode = s.activationMode || (s.enabled ? 'auto' : 'disabled')
+      const idx = ACTIVATION_MODES.indexOf(mode)
+      return idx >= 0 ? idx : 0
+    },
+    sourceText() {
+      if (this.installedInfo?.sourcePluginId) return `插件内置（${this.installedInfo.sourcePluginId}）`
+      if (this.marketInfo) return '官网广场（平台签名分发）'
+      return '本机'
+    },
+  },
+  mounted() {
+    this.reload()
+    uni.$on('awd:market-changed-from-sidebar', this.reload)
+  },
+  beforeUnmount() {
+    uni.$off('awd:market-changed-from-sidebar', this.reload)
+  },
+  methods: {
+    async reload() {
+      this.loading = true
+      this.loadError = ''
+      try {
+        if (this.spec.kind === 'skill') {
+          const [mRes, iRes] = await Promise.all([
+            getSkillMarket().catch(() => null),
+            getSkills().catch(() => null),
+          ])
+          const marketList = mRes?.skills || []
+          const installedList = Array.isArray(iRes) ? iRes : (iRes?.data || [])
+          this.marketInfo = marketList.find(s => s.id === this.spec.id) || null
+          this.installedInfo = installedList.find(s => s.id === this.spec.id) || null
+        } else {
+          const [mRes, iRes] = await Promise.all([
+            getPluginMarket().catch(() => null),
+            getPlugins().catch(() => null),
+          ])
+          const marketList = mRes?.plugins || []
+          const installedList = Array.isArray(iRes) ? iRes : (iRes?.data || [])
+          this.marketInfo = marketList.find(p => p.id === this.spec.id) || null
+          this.installedInfo = installedList.find(p => p.id === this.spec.id) || null
+        }
+      } catch (e) {
+        console.error('加载详情失败:', e)
+        this.loadError = e?.message || '网络不可用'
+      } finally {
+        this.loading = false
+      }
+    },
+    notifyChanged() {
+      uni.$emit('awd:market-changed')
+    },
+    async doInstallSkill() {
+      if (this.busy) return
+      this.busy = true
+      try {
+        await installMarketSkill(this.spec.id)
+        uni.showToast({ title: this.installedInfo ? '已更新' : '已安装', icon: 'none' })
+        await this.reload()
+        this.notifyChanged()
+      } catch (e) {
+        console.error('安装 Skill 失败:', e)
+        uni.showToast({ title: e?.message || '安装失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.busy = false
+      }
+    },
+    async doUninstallSkill() {
+      if (this.busy) return
+      this.busy = true
+      try {
+        await uninstallMarketSkill(this.spec.id)
+        uni.showToast({ title: '已卸载', icon: 'none' })
+        await this.reload()
+        this.notifyChanged()
+      } catch (e) {
+        console.error('卸载 Skill 失败:', e)
+        uni.showToast({ title: e?.message || '卸载失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.busy = false
+      }
+    },
+    async doInstallPlugin() {
+      if (this.busy) return
+      const m = this.marketInfo || {}
+      const perms = (m.permissions || []).map(p => PERMISSION_LABELS[p] || p).join('、') || '未声明敏感能力'
+      const ok = await new Promise(resolve => {
+        uni.showModal({
+          title: '确认安装插件',
+          content: `${m.name || this.spec.id} v${m.version}\n作者：${m.authorDisplayName || m.author || '未知'}\n声明能力：${perms}\n\n插件与本机应用同等权限，能读写你的文件并访问网络。安装后默认停用，需你手动启用。`,
+          confirmText: '安装',
+          cancelText: '取消',
+          success: r => resolve(r.confirm),
+          fail: () => resolve(false),
+        })
+      })
+      if (!ok) return
+      this.busy = true
+      try {
+        await installMarketPlugin(this.spec.id)
+        uni.showToast({ title: '已安装，请启用后使用', icon: 'none' })
+        await this.reload()
+        this.notifyChanged()
+      } catch (e) {
+        console.error('安装插件失败:', e)
+        uni.showToast({ title: e?.message || '安装失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.busy = false
+      }
+    },
+    async doUninstallPlugin() {
+      if (this.busy) return
+      this.busy = true
+      try {
+        await uninstallMarketPlugin(this.spec.id)
+        uni.showToast({ title: '已卸载', icon: 'none' })
+        await this.reload()
+        this.notifyChanged()
+      } catch (e) {
+        console.error('卸载插件失败:', e)
+        uni.showToast({ title: e?.message || '卸载失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.busy = false
+      }
+    },
+    async onPluginToggle(event) {
+      const enabled = !!(event?.detail?.value)
+      try {
+        await setPluginEnabled(this.spec.id, enabled)
+        if (this.installedInfo) this.installedInfo.enabled = enabled
+        uni.showToast({ title: enabled ? '已启用' : '已禁用', icon: 'none' })
+        this.notifyChanged()
+      } catch (e) {
+        console.error('切换插件状态失败:', e)
+        uni.showToast({ title: e?.message || '操作失败（需要管理员权限）', icon: 'none' })
+        await this.reload()
+      }
+    },
+    async onActivationChange(event) {
+      const idx = Number(event?.detail?.value)
+      const mode = ACTIVATION_MODES[idx]
+      if (!mode || !this.installedInfo || mode === ACTIVATION_MODES[this.activationIndex]) return
+      try {
+        await setSkillActivation(this.spec.id, mode)
+        this.installedInfo.activationMode = mode
+        this.installedInfo.enabled = mode !== 'disabled'
+        uni.showToast({ title: `已设为「${ACTIVATION_LABELS[idx]}」`, icon: 'none' })
+        this.notifyChanged()
+      } catch (e) {
+        console.error('设置生效方式失败:', e)
+        uni.showToast({ title: e?.message || '操作失败（需要管理员权限）', icon: 'none' })
+        await this.reload()
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+/* VS Code 扩展详情页结构 + 产品浅色编辑排版（衬线标题按官网 DESIGN.md 只用于展示位） */
+.mdp {
+  width: 100%;
+  height: 100%;
+  background: #fff;
+}
+
+.mdp-inner {
+  max-width: 760px;
+  padding: 28px 36px 48px;
+}
+
+.mdp-head {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.mdp-glyph {
+  width: 72px;
+  height: 72px;
+  flex-shrink: 0;
+  border-radius: 14px;
+  background: #E8F3ED;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1A5336;
+
+  svg {
+    width: 34px;
+    height: 34px;
+  }
+}
+
+.mdp-head-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.mdp-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.mdp-title {
+  font-family: 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC', 'STSong', serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: #123A26;
+  line-height: 1.25;
+}
+
+.mdp-kind-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: #1A5336;
+  background: #E8F3ED;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.mdp-installed-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: #fff;
+  background: #1A5336;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.mdp-byline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.mdp-byline-item {
+  font-size: 12px;
+  color: #6C757D;
+
+  & + .mdp-byline-item::before {
+    content: '·';
+    margin-right: 6px;
+    color: #CED4DA;
+  }
+}
+
+.mdp-author {
+  color: #1A5336;
+  font-weight: 600;
+}
+
+.mdp-summary {
+  display: block;
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 20px;
+  color: #2C3338;
+}
+
+.mdp-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.mdp-btn {
+  height: 28px;
+  line-height: 26px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: 1px solid #CED4DA;
+  background: #fff;
+  cursor: pointer;
+
+  text {
+    font-size: 12px;
+    font-weight: 600;
+    color: #2C3338;
+  }
+
+  &:hover {
+    border-color: #1A5336;
+
+    text {
+      color: #1A5336;
+    }
+  }
+
+  &.primary {
+    background: #1A5336;
+    border-color: #1A5336;
+
+    text {
+      color: #fff;
+    }
+
+    &:hover {
+      background: #123A26;
+
+      text {
+        color: #fff;
+      }
+    }
+  }
+
+  &.danger:hover {
+    border-color: #C0392B;
+
+    text {
+      color: #C0392B;
+    }
+  }
+
+  &.busy {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+}
+
+.mdp-switch-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.mdp-switch-label {
+  font-size: 12px;
+  color: #6C757D;
+}
+
+.mdp-action-hint {
+  font-size: 11px;
+  color: #ADB5BD;
+}
+
+.mdp-divider {
+  height: 1px;
+  background: #E9ECEF;
+  margin: 22px 0 18px;
+}
+
+.mdp-loading {
+  padding: 24px 0;
+  font-size: 13px;
+  color: #868E96;
+}
+
+.mdp-section {
+  margin-bottom: 22px;
+}
+
+.mdp-sec-title {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: #123A26;
+  margin-bottom: 8px;
+}
+
+.mdp-sec-body {
+  display: block;
+  font-size: 13px;
+  line-height: 20px;
+  color: #2C3338;
+}
+
+.mdp-sec-note {
+  display: block;
+  margin-top: 6px;
+  font-size: 11px;
+  line-height: 17px;
+  color: #ADB5BD;
+}
+
+.mdp-triggers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+}
+
+.mdp-trigger {
+  font-size: 13px;
+  color: #1A5336;
+}
+
+.mdp-kv {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mdp-kv-row {
+  display: flex;
+  gap: 12px;
+}
+
+.mdp-k {
+  width: 56px;
+  flex-shrink: 0;
+  font-size: 12px;
+  color: #868E96;
+}
+
+.mdp-v {
+  font-size: 12px;
+  color: #2C3338;
+  word-break: break-all;
+
+  &.mono {
+    font-family: 'JetBrains Mono', Menlo, Consolas, monospace;
+  }
+}
+
+.mdp-link {
+  color: #1A5336;
+  text-decoration: underline;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/MarketSidebarPanel.vue
+++ b/frontend/src/components/MarketSidebarPanel.vue
@@ -1,0 +1,675 @@
+<template>
+  <view class="msb">
+    <!-- 搜索：过滤全部分组（VS Code 扩展栏语义） -->
+    <view class="msb-search">
+      <svg class="msb-search-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path v-for="(d, gi) in ICONS.search" :key="gi" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+      <input class="msb-search-input" v-model="searchText" placeholder="搜索 Skill 与插件" />
+      <view v-if="searchText" class="msb-search-clear" @tap="searchText = ''">×</view>
+    </view>
+
+    <scroll-view scroll-y class="msb-body">
+      <!-- ===== 已安装 ===== -->
+      <view class="msb-sec-head" @tap="toggleSection('installed')">
+        <text class="msb-sec-chevron" :class="{ open: sections.installed }">›</text>
+        <text class="msb-sec-title">已安装</text>
+        <text class="msb-sec-count">{{ installedRows.length }}</text>
+        <view class="msb-sec-spacer"></view>
+        <view class="msb-sec-action" title="重新扫描本机 Skill 与插件" @tap.stop="rescan">
+          <svg class="msb-sec-action-icon" :class="{ spinning: rescanning }" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path v-for="(d, gi) in ICONS.refresh" :key="gi" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </view>
+      </view>
+      <view v-if="sections.installed">
+        <view v-if="!installedRows.length" class="msb-empty">
+          <text>{{ searchText ? '没有匹配的已安装项' : '还没有安装任何 Skill 或插件' }}</text>
+        </view>
+        <view
+          v-for="row in installedRows"
+          :key="'ins-' + row.kind + '-' + row.id"
+          class="msb-row"
+          @tap="openDetail(row)"
+        >
+          <view class="msb-row-glyph">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path v-for="(d, gi) in row.glyph" :key="gi" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </view>
+          <view class="msb-row-main">
+            <text class="msb-row-name">{{ row.name }}</text>
+            <text v-if="row.desc" class="msb-row-desc">{{ row.desc }}</text>
+            <text class="msb-row-meta">{{ row.meta }}</text>
+          </view>
+          <view class="msb-row-state" :class="row.stateClass">
+            <text>{{ row.stateLabel }}</text>
+          </view>
+        </view>
+      </view>
+
+      <!-- ===== Skill 广场 ===== -->
+      <view class="msb-sec-head" @tap="toggleSection('skill')">
+        <text class="msb-sec-chevron" :class="{ open: sections.skill }">›</text>
+        <text class="msb-sec-title">Skill 广场</text>
+        <text class="msb-sec-count">{{ skillRows.length }}</text>
+      </view>
+      <view v-if="sections.skill">
+        <view v-if="marketLoading" class="msb-empty"><text>加载中…</text></view>
+        <view v-else-if="marketError" class="msb-empty msb-error">
+          <text>在线广场不可用：{{ marketError }}</text>
+        </view>
+        <view v-else-if="!skillRows.length" class="msb-empty">
+          <text>{{ searchText ? '没有匹配的 Skill' : '广场暂无 Skill' }}</text>
+        </view>
+        <view
+          v-for="row in skillRows"
+          :key="'mkt-s-' + row.id"
+          class="msb-row"
+          @tap="openDetail(row)"
+        >
+          <view class="msb-row-glyph">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path v-for="(d, gi) in row.glyph" :key="gi" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </view>
+          <view class="msb-row-main">
+            <text class="msb-row-name">{{ row.name }}</text>
+            <text v-if="row.desc" class="msb-row-desc">{{ row.desc }}</text>
+            <text class="msb-row-meta">{{ row.meta }}</text>
+          </view>
+          <view
+            v-if="!row.installed"
+            class="msb-row-install"
+            :class="{ busy: marketBusyId === row.id }"
+            @tap.stop="installSkillRow(row)"
+          >
+            <text>{{ marketBusyId === row.id ? '…' : '安装' }}</text>
+          </view>
+          <view v-else class="msb-row-state ok"><text>已装</text></view>
+        </view>
+      </view>
+
+      <!-- ===== 插件广场 ===== -->
+      <view class="msb-sec-head" @tap="toggleSection('plugin')">
+        <text class="msb-sec-chevron" :class="{ open: sections.plugin }">›</text>
+        <text class="msb-sec-title">插件广场</text>
+        <text class="msb-sec-count">{{ pluginRows.length }}</text>
+      </view>
+      <view v-if="sections.plugin">
+        <view v-if="marketPluginLoading" class="msb-empty"><text>加载中…</text></view>
+        <view v-else-if="marketPluginError" class="msb-empty msb-error">
+          <text>在线广场不可用：{{ marketPluginError }}</text>
+        </view>
+        <view v-else-if="!pluginRows.length" class="msb-empty">
+          <text>{{ searchText ? '没有匹配的插件' : '广场暂无插件' }}</text>
+        </view>
+        <view
+          v-for="row in pluginRows"
+          :key="'mkt-p-' + row.id"
+          class="msb-row"
+          @tap="openDetail(row)"
+        >
+          <view class="msb-row-glyph">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path v-for="(d, gi) in row.glyph" :key="gi" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </view>
+          <view class="msb-row-main">
+            <text class="msb-row-name">{{ row.name }}</text>
+            <text v-if="row.desc" class="msb-row-desc">{{ row.desc }}</text>
+            <text class="msb-row-meta">{{ row.meta }}</text>
+          </view>
+          <view
+            v-if="!row.installed"
+            class="msb-row-install"
+            :class="{ busy: pluginBusyId === row.id }"
+            @tap.stop="installPluginRow(row)"
+          >
+            <text>{{ pluginBusyId === row.id ? '…' : '安装' }}</text>
+          </view>
+          <view v-else class="msb-row-state ok"><text>已装</text></view>
+        </view>
+      </view>
+    </scroll-view>
+  </view>
+</template>
+
+<script>
+// 插件广场左栏面板（VS Code 扩展栏形态）：搜索 + 已安装/Skill 广场/插件广场
+// 三个折叠分组的紧凑列表；点行在中栏开详情 tab（emit open-detail），行内快捷安装。
+// 数据与安装链路复用 MarketPane 同一组 services/api.js 封装。
+import { getPlugins, getSkills, getSkillMarket, getPluginMarket, installMarketSkill, installMarketPlugin, rescanPlugins, rescanSkills } from '@/services/api.js'
+import { ICONS } from '@/config/icons.js'
+
+const CATEGORY_GLYPHS = {
+  contract: ICONS.catContract,
+  litigation: ICONS.catLitigation,
+  compliance: ICONS.catCompliance,
+  research: ICONS.catResearch,
+  corporate: ICONS.catCorporate,
+  office: ICONS.catOffice,
+  other: ICONS.catOther,
+}
+
+const CATEGORY_LABELS = {
+  contract: '合同',
+  litigation: '诉讼与争议',
+  compliance: '合规风控',
+  research: '法律研究',
+  corporate: '公司与投融资',
+  office: '办公效率',
+  other: '其他',
+}
+
+const ACTIVATION_STATE = {
+  auto: '自动',
+  manual: '手动',
+  disabled: '停用',
+}
+
+function fmtDownloads(n) {
+  if (!n) return ''
+  if (n >= 10000) return (n / 10000).toFixed(1) + 'w'
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'k'
+  return String(n)
+}
+
+export default {
+  name: 'MarketSidebarPanel',
+  emits: ['open-detail'],
+  data() {
+    return {
+      searchText: '',
+      sections: { installed: true, skill: true, plugin: true },
+      plugins: [],
+      skills: [],
+      marketSkills: [],
+      marketPlugins: [],
+      marketLoading: false,
+      marketError: '',
+      marketPluginLoading: false,
+      marketPluginError: '',
+      marketBusyId: '',
+      pluginBusyId: '',
+      rescanning: false,
+    }
+  },
+  computed: {
+    ICONS() {
+      return ICONS
+    },
+    installedRows() {
+      const kw = this.searchText.trim().toLowerCase()
+      const rows = []
+      for (const s of this.skills) {
+        const mode = s.activationMode || (s.enabled ? 'auto' : 'disabled')
+        rows.push({
+          kind: 'skill',
+          id: s.id,
+          name: s.name || s.id,
+          desc: s.description || '',
+          glyph: CATEGORY_GLYPHS[s.category] || ICONS.skill,
+          meta: 'Skill' + (s.sourcePluginId ? ' · 来自插件' : ''),
+          stateLabel: ACTIVATION_STATE[mode] || '自动',
+          stateClass: mode === 'disabled' ? 'off' : 'ok',
+          raw: s,
+        })
+      }
+      for (const p of this.plugins) {
+        rows.push({
+          kind: 'plugin',
+          id: p.id,
+          name: p.name || p.id,
+          desc: p.description || '',
+          glyph: ICONS.blocks,
+          meta: '插件' + (p.version ? ' · v' + p.version : ''),
+          stateLabel: p.enabled ? '已启用' : '已停用',
+          stateClass: p.enabled ? 'ok' : 'off',
+          raw: p,
+        })
+      }
+      return kw ? rows.filter(r => (r.name + ' ' + r.id + ' ' + r.desc).toLowerCase().includes(kw)) : rows
+    },
+    skillRows() {
+      const kw = this.searchText.trim().toLowerCase()
+      const rows = this.marketSkills.map(m => {
+        const cat = m.category || 'other'
+        const metaParts = []
+        if (m.version) metaParts.push('v' + m.version)
+        const dl = fmtDownloads(m.downloads)
+        if (dl) metaParts.push(dl + ' 下载')
+        metaParts.push(CATEGORY_LABELS[cat] || '其他')
+        return {
+          kind: 'skill',
+          id: m.id,
+          name: m.name || m.id,
+          desc: m.description || '',
+          glyph: CATEGORY_GLYPHS[cat] || CATEGORY_GLYPHS.other,
+          meta: metaParts.join(' · '),
+          installed: !!m.installed,
+          raw: m,
+        }
+      })
+      return kw
+        ? rows.filter(r => {
+            const hay = [r.name, r.id, r.desc, ...((r.raw.triggers) || [])].filter(Boolean).join(' ').toLowerCase()
+            return hay.includes(kw)
+          })
+        : rows
+    },
+    pluginRows() {
+      const kw = this.searchText.trim().toLowerCase()
+      const installedIds = new Set(this.plugins.map(p => p.id))
+      const rows = this.marketPlugins.map(m => {
+        const metaParts = []
+        if (m.version) metaParts.push('v' + m.version)
+        const author = m.authorDisplayName || m.author
+        if (author) metaParts.push(author)
+        return {
+          kind: 'plugin',
+          id: m.id,
+          name: m.name || m.id,
+          desc: m.description || '',
+          glyph: ICONS.blocks,
+          meta: metaParts.join(' · ') || '插件',
+          installed: installedIds.has(m.id) || !!m.installed,
+          raw: m,
+        }
+      })
+      return kw ? rows.filter(r => (r.name + ' ' + r.id + ' ' + r.desc).toLowerCase().includes(kw)) : rows
+    },
+  },
+  mounted() {
+    this.reloadAll()
+    // 详情 tab 里装/卸/启停后广播回来刷新列表（组件级订阅，卸载即清理）
+    uni.$on('awd:market-changed', this.reloadAll)
+  },
+  beforeUnmount() {
+    uni.$off('awd:market-changed', this.reloadAll)
+  },
+  methods: {
+    toggleSection(key) {
+      this.sections[key] = !this.sections[key]
+    },
+    openDetail(row) {
+      this.$emit('open-detail', { kind: row.kind, id: row.id, name: row.name })
+    },
+    async reloadAll() {
+      this.loadInstalled()
+      this.loadMarketSkills()
+      this.loadMarketPlugins()
+    },
+    async loadInstalled() {
+      try {
+        const [pRes, sRes] = await Promise.all([getPlugins(), getSkills()])
+        this.plugins = Array.isArray(pRes) ? pRes : (pRes?.data || [])
+        this.skills = Array.isArray(sRes) ? sRes : (sRes?.data || [])
+      } catch (e) {
+        console.error('加载已安装列表失败:', e)
+      }
+    },
+    async loadMarketSkills() {
+      this.marketLoading = true
+      this.marketError = ''
+      try {
+        const res = await getSkillMarket()
+        this.marketSkills = res?.skills || []
+      } catch (e) {
+        console.warn('在线 Skill 广场不可用:', e)
+        this.marketError = e?.message || '网络不可用'
+        this.marketSkills = []
+      } finally {
+        this.marketLoading = false
+      }
+    },
+    async loadMarketPlugins() {
+      this.marketPluginLoading = true
+      this.marketPluginError = ''
+      try {
+        const res = await getPluginMarket()
+        this.marketPlugins = res?.plugins || []
+      } catch (e) {
+        console.warn('在线插件广场不可用:', e)
+        this.marketPluginError = e?.message || '网络不可用'
+        this.marketPlugins = []
+      } finally {
+        this.marketPluginLoading = false
+      }
+    },
+    async installSkillRow(row) {
+      if (this.marketBusyId) return
+      this.marketBusyId = row.id
+      try {
+        await installMarketSkill(row.id)
+        uni.showToast({ title: '已安装', icon: 'none' })
+        await this.reloadAll()
+        uni.$emit('awd:market-changed-from-sidebar')
+      } catch (e) {
+        console.error('安装 Skill 失败:', e)
+        uni.showToast({ title: e?.message || '安装失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.marketBusyId = ''
+      }
+    },
+    async installPluginRow(row) {
+      if (this.pluginBusyId) return
+      const m = row.raw
+      const perms = (m.permissions || []).join('、') || '未声明敏感能力'
+      const ok = await new Promise(resolve => {
+        uni.showModal({
+          title: '确认安装插件',
+          content: `${m.name || m.id} v${m.version}\n作者：${m.authorDisplayName || m.author || '未知'}\n声明能力：${perms}\n\n插件与本机应用同等权限，能读写你的文件并访问网络。安装后默认停用，需你手动启用。`,
+          confirmText: '安装',
+          cancelText: '取消',
+          success: r => resolve(r.confirm),
+          fail: () => resolve(false),
+        })
+      })
+      if (!ok) return
+      this.pluginBusyId = row.id
+      try {
+        await installMarketPlugin(row.id)
+        uni.showToast({ title: '已安装，启用前不会执行任何插件代码', icon: 'none' })
+        await this.reloadAll()
+        uni.$emit('awd:market-changed-from-sidebar')
+      } catch (e) {
+        console.error('安装插件失败:', e)
+        uni.showToast({ title: e?.message || '安装失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.pluginBusyId = ''
+      }
+    },
+    async rescan() {
+      if (this.rescanning) return
+      this.rescanning = true
+      try {
+        const res = await rescanPlugins()
+        const skillRes = await rescanSkills().catch(() => null)
+        uni.showToast({
+          title: `扫描完成：${res?.pluginCount ?? 0} 个插件、${skillRes?.skillCount ?? 0} 个 Skill`,
+          icon: 'none',
+        })
+        await this.reloadAll()
+      } catch (e) {
+        console.error('重新扫描失败:', e)
+        uni.showToast({ title: e?.message || '扫描失败（需要管理员权限）', icon: 'none' })
+      } finally {
+        this.rescanning = false
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+/* VS Code 扩展栏密度 + 产品浅色体系（森林绿 #1A5336 / mint #5BD197 点缀） */
+.msb {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: transparent;
+}
+
+.msb-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 10px 6px;
+  height: 28px;
+  padding: 0 8px;
+  background: #fff;
+  border: 1px solid #E9ECEF;
+  border-radius: 6px;
+
+  &:focus-within {
+    border-color: #5BD197;
+    box-shadow: 0 0 0 2px rgba(91, 209, 151, 0.15);
+  }
+}
+
+.msb-search-icon {
+  width: 13px;
+  height: 13px;
+  color: #ADB5BD;
+  flex-shrink: 0;
+}
+
+.msb-search-input {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: #2C3338;
+  background: transparent;
+  border: none;
+  outline: none;
+  height: 26px;
+  line-height: 26px;
+}
+
+.msb-search-clear {
+  width: 16px;
+  height: 16px;
+  line-height: 15px;
+  text-align: center;
+  border-radius: 4px;
+  color: #ADB5BD;
+  font-size: 13px;
+  cursor: pointer;
+
+  &:hover {
+    background: #F1F3F5;
+    color: #2C3338;
+  }
+}
+
+.msb-body {
+  flex: 1;
+  min-height: 0;
+}
+
+/* 分组头：VS Code 式全大写小字 + 计数 */
+.msb-sec-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 26px;
+  padding: 0 10px 0 6px;
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background: rgba(26, 83, 54, 0.04);
+  }
+}
+
+.msb-sec-chevron {
+  width: 12px;
+  font-size: 12px;
+  color: #868E96;
+  transition: transform 0.12s ease;
+  transform-origin: center;
+
+  &.open {
+    transform: rotate(90deg);
+  }
+}
+
+.msb-sec-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #495057;
+}
+
+.msb-sec-count {
+  font-size: 10px;
+  color: #868E96;
+  background: #F1F3F5;
+  border-radius: 999px;
+  padding: 0 6px;
+  line-height: 14px;
+  margin-left: 2px;
+}
+
+.msb-sec-spacer {
+  flex: 1;
+}
+
+.msb-sec-action {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #868E96;
+  cursor: pointer;
+
+  &:hover {
+    background: #E8F3ED;
+    color: #1A5336;
+  }
+}
+
+.msb-sec-action-icon {
+  width: 12px;
+  height: 12px;
+
+  &.spinning {
+    animation: msb-spin 0.9s linear infinite;
+  }
+}
+
+@keyframes msb-spin {
+  to { transform: rotate(360deg); }
+}
+
+.msb-empty {
+  padding: 8px 12px 10px 22px;
+  font-size: 11px;
+  color: #ADB5BD;
+
+  &.msb-error {
+    color: #B4552D;
+  }
+}
+
+/* 列表行：紧凑三行（名称/描述/元信息），hover 出安装钮 */
+.msb-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 10px 6px 12px;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(26, 83, 54, 0.05);
+  }
+}
+
+.msb-row-glyph {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  border-radius: 6px;
+  background: #E8F3ED;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1A5336;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.msb-row-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.msb-row-name {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #2C3338;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.msb-row-desc {
+  font-size: 11px;
+  line-height: 15px;
+  color: #6C757D;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.msb-row-meta {
+  font-size: 10px;
+  color: #ADB5BD;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.msb-row-install {
+  flex-shrink: 0;
+  align-self: center;
+  height: 20px;
+  line-height: 18px;
+  padding: 0 8px;
+  border-radius: 4px;
+  background: #1A5336;
+  border: 1px solid #1A5336;
+  cursor: pointer;
+
+  text {
+    font-size: 10px;
+    font-weight: 600;
+    color: #fff;
+  }
+
+  &:hover {
+    background: #123A26;
+  }
+
+  &.busy {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+}
+
+.msb-row-state {
+  flex-shrink: 0;
+  align-self: center;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+
+  &.ok {
+    background: #E8F3ED;
+
+    text {
+      color: #1A5336;
+      font-size: 10px;
+    }
+  }
+
+  &.off {
+    background: #F1F3F5;
+
+    text {
+      color: #868E96;
+      font-size: 10px;
+    }
+  }
+}
+</style>

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -255,7 +255,7 @@ export const fileOpenTabsMethods = {
     /** 标签页图标的 SVG path 集合（界面禁用 emoji，图标一律 stroke 线性 SVG） */
     getFileIconPaths(type, tabType) {
       if (tabType === 'web') return GLYPHS.web
-      if (tabType === 'market') return GLYPHS.blocks
+      if (tabType === 'market-detail') return GLYPHS.blocks
       return fileGlyph(type)
     },
     isFileTypeSupported(file) {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -223,7 +223,12 @@
         </view>
 
         <!-- 插件广场：IDE 扩展市场式直达入口（浏览/安装不该藏在系统设置两跳之下） -->
-        <view class="rail-btn" title="插件广场" @tap="goToPluginMarket">
+        <view
+          class="rail-btn"
+          :class="{ active: leftPaneKey === 'market' && !sidebarCollapsed }"
+          title="插件广场"
+          @tap="goToPluginMarket"
+        >
           <view class="rail-icon-wrapper">
             <svg class="rail-icon-svg" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M4 4h7v7H4z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="rail-icon-path" />
@@ -541,6 +546,10 @@
             @reload-files="onVersionReloadFiles"
             @adopt-conflict="adoptConflictPending = $event"
           />
+          <MarketSidebarPanel
+            v-else-if="leftPaneKey === 'market'"
+            @open-detail="openMarketDetail"
+          />
           <PluginPane
             v-else-if="leftPaneKey && dynamicPlugins.some(p => p.key === leftPaneKey)"
             :url="dynamicPlugins.find(p => p.key === leftPaneKey)?.frontendEntry"
@@ -762,9 +771,11 @@
                       v-else-if="isDdRequest(activeFileLeft)"
                       :request-id="activeFileLeft.requestId"
                     />
-                    <MarketPane
-                      v-else-if="activeFileLeft.tabType === 'market'"
+                    <MarketDetailPane
+                      v-else-if="activeFileLeft.tabType === 'market-detail'"
                       :key="activeFileLeft.id"
+                      :spec="activeFileLeft.marketSpec"
+                      @open-url="openBrowserTab($event)"
                     />
                     <PluginPane
                       v-else-if="activeFileLeft.fileType === 'plugin'"
@@ -843,9 +854,11 @@
                       v-else-if="isDdRequest(activeFileRight)"
                       :request-id="activeFileRight.requestId"
                     />
-                    <MarketPane
-                      v-else-if="activeFileRight.tabType === 'market'"
+                    <MarketDetailPane
+                      v-else-if="activeFileRight.tabType === 'market-detail'"
                       :key="activeFileRight.id"
+                      :spec="activeFileRight.marketSpec"
+                      @open-url="openBrowserTab($event)"
                     />
                     <PluginPane
                       v-else-if="activeFileRight.fileType === 'plugin'"
@@ -1325,7 +1338,9 @@ import ProjectFavoritesPanel from '@/components/ProjectFavoritesPanel.vue'
 import FileLinkDropZone from '@/components/FileLinkDropZone.vue'
 import FileStagingArea from '@/components/FileStagingArea.vue'
 import PluginPane from '@/components/PluginPane.vue' // Added
-import MarketPane from '@/components/MarketPane.vue' // 插件广场 workbench 内嵌 tab
+// 插件广场 VS Code 形态：左栏列表面板 + 中栏详情 tab（整页 MarketPane 仅存于 admin 独立页）
+import MarketSidebarPanel from '@/components/MarketSidebarPanel.vue'
+import MarketDetailPane from '@/components/MarketDetailPane.vue'
 import EasyVoicePane from '@/components/EasyVoicePane.vue'
 import DesensitizePane from '@/components/DesensitizePane.vue'
 import ClipboardPanel from '@/components/ClipboardPanel.vue'
@@ -1420,7 +1435,8 @@ export default {
     ChatInterface,
     MarkdownPreview,
     PluginPane, // Added
-    MarketPane,
+    MarketSidebarPanel,
+    MarketDetailPane,
     CompareDocDialog,
     DocDiffViewer,
     VersionCompareTab,
@@ -1739,6 +1755,7 @@ export default {
       return user && user.role !== 'CLIENT'
     },
     leftPaneTitle() {
+      if (this.leftPaneKey === 'market') return '插件广场'
       try {
         return getLeftSidebarPlugin(this.leftPaneKey)?.label || '文件树'
       } catch (e) {
@@ -2775,8 +2792,8 @@ export default {
       if (file.tabType === 'version-compare' || file.tabType === 'version-text-diff') {
         return this.leftPaneKey === 'version' || this.leftPaneKey === 'files'
       }
-      // 插件广场 tab：与左栏模式无关，常显（VS Code 扩展页语义）
-      if (file.tabType === 'market') {
+      // 插件广场详情 tab：与左栏模式无关，常显（VS Code 扩展详情页语义）
+      if (file.tabType === 'market-detail') {
         return true
       }
       // 普通文件在资源管理器、搜索或EasyVoice模式下都可见
@@ -3464,15 +3481,16 @@ export default {
       uni.navigateTo({ url: '/pages/admin/admin' })
     },
     goToPluginMarket() {
-      // VS Code 式：插件广场在 workbench 里以 tab 打开，保留左栏与标签页，
-      // 不再整页跳转（独立页面路由仍保留给 admin 入口与直链兜底）。
-      this.openMarketTab()
+      // VS Code 扩展栏形态：rail 按钮开左栏列表面板（保留标签页与编辑区），
+      // 点列表项再在中栏开详情 tab。独立页面路由仍保留给 admin 入口与直链兜底。
+      this.toggleLeftPane('market')
     },
-    openMarketTab() {
-      // 单例 tab：任一窗格已开则激活之
+    // 左栏列表点行 → 中栏开该项详情 tab（同 id 单例，任一窗格已开则激活）
+    openMarketDetail(spec) {
+      const tabId = `market-detail_${spec.kind}_${spec.id}`
       for (const pane of ['left', 'right']) {
         const list = pane === 'left' ? this.leftFiles : this.rightFiles
-        const existing = list.find(f => f.tabType === 'market')
+        const existing = list.find(f => f.id === tabId)
         if (existing) {
           const idProp = pane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'
           this[idProp] = existing.id
@@ -3484,13 +3502,13 @@ export default {
       const targetPane = this.splitMode ? this.focusedPane : 'left'
       const list = targetPane === 'left' ? this.leftFiles : this.rightFiles
       const idProp = targetPane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'
-      const id = `market_${Date.now()}`
       list.push({
-        id,
-        tabType: 'market',
-        name: '插件广场'
+        id: tabId,
+        tabType: 'market-detail',
+        name: spec.name || spec.id,
+        marketSpec: spec
       })
-      this[idProp] = id
+      this[idProp] = tabId
       this.focusedPane = targetPane
       this.$nextTick(() => this.triggerWorkbenchResize())
     },


### PR DESCRIPTION
## 背景

维护者对比 VS Code Extensions 后指出：插件广场整页 hero 形态信息密度低、不像 IDE 工具。本 PR 把广场重构为 VS Code 扩展栏的信息架构，配色维持浅色体系。

## 改动

- **MarketSidebarPanel（左栏列表）**：rail 广场按钮 → 左栏面板（toggleLeftPane('market')）。顶部搜索过滤全部分组；「已安装（带重扫）/ Skill 广场 / 插件广场」三个折叠分组；紧凑行 = 分类图标 + 名称 + 一行描述 + 版本·下载·分类 + 行内安装钮/状态徽记。
- **MarketDetailPane（中栏详情 tab）**：点列表行打开，tab 常显、同项单例。头部 = 图标 + 衬线标题 + 作者/版本/下载 + 动作区（Skill：安装/更新/卸载/生效方式三档；插件：带权限确认的安装/启停/卸载）；正文 = 触发词「」排版、能力清单、详细信息（标识/来源/主页，主页在浏览器 tab 打开）。
- 装/卸/启停后两件通过 uni.$emit 互相刷新；原整页 MarketPane 保留给 admin 独立页与直链。
- 同步更新 sidebar-shell / plugin-marketplace 领域文档。

## 验证

check:emits ✓、build:h5 ✓、app-e2e 全旅程 0 步失败、真机截图目检（列表/详情 tab/搜索过滤「合同」→9 条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)