### PR TITLE
feat: Entitlement 框架 + 账户连接 + 平台 AI 通道（商业化改造 PR-B）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -15,7 +15,9 @@ description: AI 对话编排领域。任务涉及编排器 AgentOrchestrator、T
 - `service/ai/AgentStreamHandler.java`（493 行）— StreamingResponseHandler：token 流→SSE；<bubble_type>/<artifact> 边界解析缓冲、编辑器流过滤、token 用量上报。每次 runLoop 新建实例。
 - `service/ai/AgentRunStateService.java` — 每会话运行状态登记簿（内存）：RUNNING/PAUSED/AWAITING_APPROVAL/FINISHED/ERROR/CANCELLED。**新增终止分支必打状态点**（PR#173 状态机契约）。
 - `service/ai/ContextAssemblerService.java`（507 行）— assemble()：prompts/system_prompt.md + enforcement 段 + 模式约束 + Skill 注入 + 记忆 + 文件上下文 + 历史栈。
-- `service/ai/ChatModelFactory.java` — 供应商路由（OpenRouter/Gemini/Ollama）；provider 优先 DB `ai.activeProvider` 再回退 yml（PR#144）。`AllowedModels.java` 白名单（含单价）。
+- `service/ai/ChatModelFactory.java` — 供应商路由（OpenRouter/Gemini/Ollama/**AWD_CLOUD**）；provider 优先 DB `ai.activeProvider` 再回退 yml（PR#144）。`AllowedModels.java` 白名单（含单价）。
+- **平台通道 AWD_CLOUD「AI Workdeck 云端」（商业化 PR-B）**：key 由官网 provision（`service/ai/PlatformAiChannel.java`，缓存 `~/.aiworkdeck/platform-ai-key.json` 0600），判定**先于白名单短路**，取不到 key **绝不静默回退 BYOK**（会花用户自己的钱）。`service/ai/PlatformUsageAccountant.java` 用 OpenRouter `GET /api/v1/key` 累计消费差分补 `TokenUsage.costSource=platform` 的真实扣费（langchain4j 0.36 拿不到响应里的 `usage.cost`）；BYOK 仍是单价表估算，标 `costSource=estimate`。两套数字**分开标注不得合并**（Spec §3）。账户连接在 `service/account/`，权益在 `service/entitlement/`。
+- **AccountException 不是内部错误**：AgentOrchestrator 与 AiChatService 单独 catch 它，把中文文案（如「请先在官网账户页分配 AI 额度」）原样透出，不加 `Internal Error:` / `Sorry, I encountered an error:` 前缀——这是用户可自行处理的状态，未分配额度时每条消息都会走到。
 - context/ 子包：ContextCompressor、ConversationSummarizer、FileContextLoader、LegalInfoProtector、ProjectContextHolder。
 
 **工具注册与执行**

--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -17,7 +17,8 @@ description: AI 对话编排领域。任务涉及编排器 AgentOrchestrator、T
 - `service/ai/ContextAssemblerService.java`（507 行）— assemble()：prompts/system_prompt.md + enforcement 段 + 模式约束 + Skill 注入 + 记忆 + 文件上下文 + 历史栈。
 - `service/ai/ChatModelFactory.java` — 供应商路由（OpenRouter/Gemini/Ollama/**AWD_CLOUD**）；provider 优先 DB `ai.activeProvider` 再回退 yml（PR#144）。`AllowedModels.java` 白名单（含单价）。
 - **平台通道 AWD_CLOUD「AI Workdeck 云端」（商业化 PR-B）**：key 由官网 provision（`service/ai/PlatformAiChannel.java`，缓存 `~/.aiworkdeck/platform-ai-key.json` 0600），判定**先于白名单短路**，取不到 key **绝不静默回退 BYOK**（会花用户自己的钱）。`service/ai/PlatformUsageAccountant.java` 用 OpenRouter `GET /api/v1/key` 累计消费差分补 `TokenUsage.costSource=platform` 的真实扣费（langchain4j 0.36 拿不到响应里的 `usage.cost`）；BYOK 仍是单价表估算，标 `costSource=estimate`。两套数字**分开标注不得合并**（Spec §3）。账户连接在 `service/account/`，权益在 `service/entitlement/`。
-- **AccountException 不是内部错误**：AgentOrchestrator 与 AiChatService 单独 catch 它，把中文文案（如「请先在官网账户页分配 AI 额度」）原样透出，不加 `Internal Error:` / `Sorry, I encountered an error:` 前缀——这是用户可自行处理的状态，未分配额度时每条消息都会走到。
+- **AccountException 不是内部错误**：AgentOrchestrator 与 AiChatService 单独 catch 它，把中文文案（如「尚未分配 AI 额度，请到官网账户页从余额分配」）原样透出，不加 `Internal Error:` / `Sorry, I encountered an error:` 前缀——这是用户可自行处理的状态，未分配额度时每条消息都会走到。**账户类文案里不许出现「登录」「未授权」「请先」**：`services/api.js` 用这三个子串判定未登录，会清会话（浏览器端还跳登录页），`AccountServiceTest.accountMessagesDoNotLookLikeAuthErrors` 守这条。
+- **平台通道的三个状态钩子**（改账户连接时容易漏）：① connect/disconnect 必须 `PlatformUsageAccountant.resetBaseline()`，否则两把 key 的累计消费之差会整个记到下一条消息头上；② 平台模型创建前调 `ensureBaselineAsync()`，否则进程重启后第一条消息永久显示「待结算」；③ disconnect 必须 `ChatModelFactory.demotePlatformProvider()` 把 `ai.activeProvider` 从 AWD_CLOUD 摘下来（返回落到的供应商，随 `/api/account/disconnect` 的 `aiProviderFallback` 下发给前端），否则设置页显示平台通道正常选中、每条消息却报未连接账户。
 - context/ 子包：ContextCompressor、ConversationSummarizer、FileContextLoader、LegalInfoProtector、ProjectContextHolder。
 
 **工具注册与执行**

--- a/backend/src/main/java/com/checkba/config/AiModelProperties.java
+++ b/backend/src/main/java/com/checkba/config/AiModelProperties.java
@@ -20,11 +20,14 @@ public class AiModelProperties {
      * - OLLAMA：本地 Ollama 服务
      * - GEMINI：Google Gemini 云端模型
      * - OPENROUTER: OpenRouter (OpenAI 兼容)
+     * - AWD_CLOUD：平台通道「AI Workdeck 云端」——密钥由官网按账户 provision，
+     *   仍走 OpenRouter，但用户不必自备 key（Spec §3）。未连接账户时不可选。
      */
     public enum Provider {
         OLLAMA,
         GEMINI,
-        OPENROUTER
+        OPENROUTER,
+        AWD_CLOUD
     }
 
     /**

--- a/backend/src/main/java/com/checkba/controller/AccountController.java
+++ b/backend/src/main/java/com/checkba/controller/AccountController.java
@@ -5,6 +5,7 @@ import com.checkba.repository.TokenUsageRepository;
 import com.checkba.service.account.AccountException;
 import com.checkba.service.account.AccountService;
 import com.checkba.service.ai.PlatformAiChannel;
+import com.checkba.service.ai.PlatformUsageAccountant;
 import com.checkba.service.entitlement.EntitlementService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.math.BigDecimal;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -105,6 +107,9 @@ public class AccountController {
 
     // ==================== 内部 ====================
 
+    /** 明细列表的条数上限：设置页只是「最近用量」，全量导出不是本端点的职责。 */
+    private static final int RECENT_LIMIT = 50;
+
     private Map<String, Object> localUsage(Long userId) {
         List<TokenUsage> records = userId == null ? List.of() : tokenUsageRepository.findByUserId(userId);
         long prompt = 0;
@@ -117,7 +122,7 @@ public class AccountController {
             completion += record.getCompletionTokens() == null ? 0 : record.getCompletionTokens();
             total += record.getTotalTokens() == null ? 0 : record.getTotalTokens();
             if (record.getCost() == null) continue;
-            if ("platform".equals(record.getCostSource())) {
+            if (PlatformUsageAccountant.SOURCE_PLATFORM.equals(record.getCostSource())) {
                 platformCost = platformCost.add(record.getCost());
             } else {
                 estimatedCost = estimatedCost.add(record.getCost());
@@ -132,7 +137,30 @@ public class AccountController {
         local.put("platformCostUsd", platformCost.toPlainString());
         // BYOK 的本地估算（美元），**不是账单**
         local.put("estimatedCostUsd", estimatedCost.toPlainString());
+        local.put("recent", recentRows(records));
         return local;
+    }
+
+    /**
+     * 明细行：只挑设置页要展示的字段，不直接序列化实体
+     * （实体里还有 userId/projectId/conversationId，与「最近用量」无关）。
+     * cost 为 null 原样保留——平台通道对账未完成时前端显示「待结算」，绝不能顶成 0。
+     */
+    private static List<Map<String, Object>> recentRows(List<TokenUsage> records) {
+        return records.stream()
+                .sorted(Comparator.comparing(TokenUsage::getCreatedAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(RECENT_LIMIT)
+                .map(record -> {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("model", record.getModel());
+                    row.put("createdAt", record.getCreatedAt());
+                    row.put("totalTokens", record.getTotalTokens());
+                    row.put("cost", record.getCost());
+                    row.put("costSource", record.getCostSource());
+                    return row;
+                })
+                .toList();
     }
 
     private Map<String, Object> platformUsage() {
@@ -149,14 +177,37 @@ public class AccountController {
             platform.put("allocations", accountService.fetchLedger().stream()
                     .filter(entry -> "ai_alloc".equals(entry.get("kind")))
                     .toList());
-            platform.put("limitUsd", platformAiChannel.limitUsd());
             platform.put("available", true);
         } catch (AccountException e) {
             // 官网不可达不该让整个用量面板报错——本地统计仍然有价值
             platform.put("available", false);
             platform.put("message", e.getMessage());
+            return platform;
         }
+        putAiQuota(platform);
         return platform;
+    }
+
+    /**
+     * AI 额度三个数（上限/已用/剩余）单独一段，失败只降级这一段：
+     * 余额与账本已经取到了，不该因为额度查询挂掉就一起隐藏。
+     * {@code quotaAvailable=false} 时前端显示「额度信息暂不可用」，不会把 0 当成真实剩余额度。
+     */
+    private void putAiQuota(Map<String, Object> platform) {
+        try {
+            Map<String, Object> quota = accountService.fetchAiUsage();
+            platform.put("quotaAvailable", true);
+            // hasKey=false 表示该账户还没从余额分配过 AI 额度——引导文案的判据
+            platform.put("hasAiQuota", Boolean.TRUE.equals(quota.get("hasKey")));
+            platform.put("limitUsd", quota.get("limitUsd"));
+            platform.put("usageUsd", quota.get("usageUsd"));
+            platform.put("remainingUsd", quota.get("remainingUsd"));
+        } catch (AccountException e) {
+            platform.put("quotaAvailable", false);
+            platform.put("quotaMessage", e.getMessage());
+            // 本地缓存的 limit 是 provision 当时的快照，只在实时口径拿不到时兜底展示
+            platform.put("limitUsd", platformAiChannel.limitUsd());
+        }
     }
 
     private static Map<String, Object> ok(Object data) {

--- a/backend/src/main/java/com/checkba/controller/AccountController.java
+++ b/backend/src/main/java/com/checkba/controller/AccountController.java
@@ -4,6 +4,7 @@ import com.checkba.model.entity.TokenUsage;
 import com.checkba.repository.TokenUsageRepository;
 import com.checkba.service.account.AccountException;
 import com.checkba.service.account.AccountService;
+import com.checkba.service.ai.ChatModelFactory;
 import com.checkba.service.ai.PlatformAiChannel;
 import com.checkba.service.ai.PlatformUsageAccountant;
 import com.checkba.service.entitlement.EntitlementService;
@@ -34,8 +35,14 @@ import java.util.Map;
  *   <li>GET  /api/account/usage      平台结算（官网）+ 本地统计（TokenUsage）两套口径</li>
  * </ul>
  *
- * local-mode 免登：这些端点不要求登录，但 POST 一律落在 PR-A 的
- * {@code LocalModeAccessFilter} 之内（跨站 Origin 硬拦截 + 回环校验 + 反代痕迹拒绝），
+ * 鉴权与全站同一条：先过 {@link AuthController#getUserIdFromSession}。local-mode 下它把
+ * 任何请求解析为本机用户（等于免登），server 模式（团队案件库）下无有效会话即拒绝——
+ * 后者不可省：{@code LocalModeAccessFilter} 在 local-mode=false 时整体短路，
+ * 而 {@code deploy/web/nginx.conf.example} 把 /api/ 整段反代出去，漏检等于把
+ * 账户状态与「断开连接」暴露给匿名请求。
+ *
+ * local-mode 下 POST 另外还落在 PR-A 的 {@code LocalModeAccessFilter} 之内
+ * （跨站 Origin 硬拦截 + 回环校验 + 反代痕迹拒绝），
  * 因此「任意网页悄悄把用户账户断开/换绑」这条路是关死的。
  *
  * 返回沿用全站信封 {@code {code:0,data:...}} / {@code {code:1,message:"中文"}}（HTTP 恒 200），
@@ -49,20 +56,38 @@ public class AccountController {
     private final AccountService accountService;
     private final EntitlementService entitlementService;
     private final PlatformAiChannel platformAiChannel;
+    private final PlatformUsageAccountant platformUsageAccountant;
+    private final ChatModelFactory chatModelFactory;
     private final TokenUsageRepository tokenUsageRepository;
 
     public AccountController(AccountService accountService,
                              EntitlementService entitlementService,
                              PlatformAiChannel platformAiChannel,
+                             PlatformUsageAccountant platformUsageAccountant,
+                             ChatModelFactory chatModelFactory,
                              TokenUsageRepository tokenUsageRepository) {
         this.accountService = accountService;
         this.entitlementService = entitlementService;
         this.platformAiChannel = platformAiChannel;
+        this.platformUsageAccountant = platformUsageAccountant;
+        this.chatModelFactory = chatModelFactory;
         this.tokenUsageRepository = tokenUsageRepository;
     }
 
+    /**
+     * 身份闸：local-mode 恒解析为本机用户（免登），server 模式无有效会话即拒绝。
+     * 「未登录」文案与全站一致，前端 api.js 据此清会话。
+     */
+    private static void requireUser(String sessionId) {
+        if (AuthController.getUserIdFromSession(sessionId) == null) {
+            throw new IllegalArgumentException("未登录");
+        }
+    }
+
     @GetMapping("/status")
-    public Map<String, Object> status() {
+    public Map<String, Object> status(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
         Map<String, Object> data = new LinkedHashMap<>(accountService.status());
         // 平台 AI 通道是否可选（未连接账户时前端不展示该供应商）
         data.put("platformAiAvailable", platformAiChannel.isAvailable());
@@ -70,22 +95,36 @@ public class AccountController {
     }
 
     @PostMapping("/connect")
-    public Map<String, Object> connect(@RequestBody(required = false) Map<String, String> body) {
+    public Map<String, Object> connect(
+            @RequestBody(required = false) Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
         String key = body == null ? null : body.get("key");
         Map<String, Object> status = accountService.connect(key);
-        // 换账户后旧账户的权益与平台密钥必须立刻作废，不能等下一次刷新
+        // 换账户后旧账户的权益、平台密钥与用量基线必须立刻作废，不能等下一次刷新
         entitlementService.clearAccountCache();
         platformAiChannel.clearCache();
+        platformUsageAccountant.resetBaseline();
         entitlementService.refreshAsync();
         return ok(status);
     }
 
     @PostMapping("/disconnect")
-    public Map<String, Object> disconnect() {
+    public Map<String, Object> disconnect(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
         Map<String, Object> status = accountService.disconnect();
         entitlementService.clearAccountCache();
         platformAiChannel.clearCache();
-        return ok(status);
+        platformUsageAccountant.resetBaseline();
+        Map<String, Object> data = new LinkedHashMap<>(status);
+        String fallback = chatModelFactory.demotePlatformProvider();
+        if (fallback != null) {
+            // 前端据此更新设置页的供应商单选并提示用户，避免「界面显示平台通道正常选中、
+            // 实际每条消息都报未连接账户」
+            data.put("aiProviderFallback", fallback);
+        }
+        return ok(data);
     }
 
     /**
@@ -98,6 +137,7 @@ public class AccountController {
     @GetMapping("/usage")
     public Map<String, Object> usage(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
         Long userId = AuthController.getUserIdFromSession(sessionId);
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("local", localUsage(userId));

--- a/backend/src/main/java/com/checkba/controller/AccountController.java
+++ b/backend/src/main/java/com/checkba/controller/AccountController.java
@@ -1,0 +1,182 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.TokenUsage;
+import com.checkba.repository.TokenUsageRepository;
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.ai.PlatformAiChannel;
+import com.checkba.service.entitlement.EntitlementService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 与官网账户的连接（商业化改造 PR-B）。
+ *
+ * <ul>
+ *   <li>GET  /api/account/status     当前连接状态（不含 Key 明文）</li>
+ *   <li>POST /api/account/connect    {"key":"awdk_..."} 校验并落盘</li>
+ *   <li>POST /api/account/disconnect 断开并清空权益缓存、平台 AI 密钥缓存</li>
+ *   <li>GET  /api/account/usage      平台结算（官网）+ 本地统计（TokenUsage）两套口径</li>
+ * </ul>
+ *
+ * local-mode 免登：这些端点不要求登录，但 POST 一律落在 PR-A 的
+ * {@code LocalModeAccessFilter} 之内（跨站 Origin 硬拦截 + 回环校验 + 反代痕迹拒绝），
+ * 因此「任意网页悄悄把用户账户断开/换绑」这条路是关死的。
+ *
+ * 返回沿用全站信封 {@code {code:0,data:...}} / {@code {code:1,message:"中文"}}（HTTP 恒 200），
+ * 与 frontend/src/services/api.js 的拦截约定一致。
+ */
+@RestController
+@RequestMapping("/api/account")
+@Slf4j
+public class AccountController {
+
+    private final AccountService accountService;
+    private final EntitlementService entitlementService;
+    private final PlatformAiChannel platformAiChannel;
+    private final TokenUsageRepository tokenUsageRepository;
+
+    public AccountController(AccountService accountService,
+                             EntitlementService entitlementService,
+                             PlatformAiChannel platformAiChannel,
+                             TokenUsageRepository tokenUsageRepository) {
+        this.accountService = accountService;
+        this.entitlementService = entitlementService;
+        this.platformAiChannel = platformAiChannel;
+        this.tokenUsageRepository = tokenUsageRepository;
+    }
+
+    @GetMapping("/status")
+    public Map<String, Object> status() {
+        Map<String, Object> data = new LinkedHashMap<>(accountService.status());
+        // 平台 AI 通道是否可选（未连接账户时前端不展示该供应商）
+        data.put("platformAiAvailable", platformAiChannel.isAvailable());
+        return ok(data);
+    }
+
+    @PostMapping("/connect")
+    public Map<String, Object> connect(@RequestBody(required = false) Map<String, String> body) {
+        String key = body == null ? null : body.get("key");
+        Map<String, Object> status = accountService.connect(key);
+        // 换账户后旧账户的权益与平台密钥必须立刻作废，不能等下一次刷新
+        entitlementService.clearAccountCache();
+        platformAiChannel.clearCache();
+        entitlementService.refreshAsync();
+        return ok(status);
+    }
+
+    @PostMapping("/disconnect")
+    public Map<String, Object> disconnect() {
+        Map<String, Object> status = accountService.disconnect();
+        entitlementService.clearAccountCache();
+        platformAiChannel.clearCache();
+        return ok(status);
+    }
+
+    /**
+     * 用量：两套数字**分开标注**，不做合并（Spec §3）。
+     * - local：本机 TokenUsage 汇总，BYOK 部分是按单价表估算的；
+     * - platform：官网账户余额与 AI 额度分配流水，是真实结算口径。
+     *
+     * 官网侧不可达时只降级 platform 段，本地统计照常返回。
+     */
+    @GetMapping("/usage")
+    public Map<String, Object> usage(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("local", localUsage(userId));
+        data.put("platform", platformUsage());
+        return ok(data);
+    }
+
+    // ==================== 内部 ====================
+
+    private Map<String, Object> localUsage(Long userId) {
+        List<TokenUsage> records = userId == null ? List.of() : tokenUsageRepository.findByUserId(userId);
+        long prompt = 0;
+        long completion = 0;
+        long total = 0;
+        BigDecimal platformCost = BigDecimal.ZERO;
+        BigDecimal estimatedCost = BigDecimal.ZERO;
+        for (TokenUsage record : records) {
+            prompt += record.getPromptTokens() == null ? 0 : record.getPromptTokens();
+            completion += record.getCompletionTokens() == null ? 0 : record.getCompletionTokens();
+            total += record.getTotalTokens() == null ? 0 : record.getTotalTokens();
+            if (record.getCost() == null) continue;
+            if ("platform".equals(record.getCostSource())) {
+                platformCost = platformCost.add(record.getCost());
+            } else {
+                estimatedCost = estimatedCost.add(record.getCost());
+            }
+        }
+        Map<String, Object> local = new LinkedHashMap<>();
+        local.put("records", records.size());
+        local.put("promptTokens", prompt);
+        local.put("completionTokens", completion);
+        local.put("totalTokens", total);
+        // 平台通道的实际扣费（美元），已完成对账的部分
+        local.put("platformCostUsd", platformCost.toPlainString());
+        // BYOK 的本地估算（美元），**不是账单**
+        local.put("estimatedCostUsd", estimatedCost.toPlainString());
+        return local;
+    }
+
+    private Map<String, Object> platformUsage() {
+        Map<String, Object> platform = new LinkedHashMap<>();
+        if (!accountService.isConnected()) {
+            platform.put("connected", false);
+            return platform;
+        }
+        platform.put("connected", true);
+        try {
+            Map<String, Object> profile = accountService.fetchProfile();
+            platform.put("balanceCents", profile.get("balanceCents"));
+            platform.put("plan", profile.get("plan"));
+            platform.put("allocations", accountService.fetchLedger().stream()
+                    .filter(entry -> "ai_alloc".equals(entry.get("kind")))
+                    .toList());
+            platform.put("limitUsd", platformAiChannel.limitUsd());
+            platform.put("available", true);
+        } catch (AccountException e) {
+            // 官网不可达不该让整个用量面板报错——本地统计仍然有价值
+            platform.put("available", false);
+            platform.put("message", e.getMessage());
+        }
+        return platform;
+    }
+
+    private static Map<String, Object> ok(Object data) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("data", data);
+        return result;
+    }
+
+    /**
+     * 账户类失败统一转成全站信封。HTTP 恒 200 + code=1，
+     * 前端 api.js 会 reject 并把 message 原样弹给用户（中文，且不含 Key 明文）。
+     */
+    @ExceptionHandler(AccountException.class)
+    public ResponseEntity<Map<String, Object>> handleAccountException(AccountException e) {
+        log.warn("账户操作失败 [{}]: {}", e.getKind(), e.getMessage());
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("kind", e.getKind().name());
+        result.put("message", e.getMessage());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/main/java/com/checkba/controller/EntitlementController.java
+++ b/backend/src/main/java/com/checkba/controller/EntitlementController.java
@@ -2,6 +2,8 @@ package com.checkba.controller;
 
 import com.checkba.service.entitlement.EntitlementService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
@@ -12,6 +14,9 @@ import java.util.Map;
  *
  * 前端 {@code useEntitlement(feature)} 的数据源：目录内每项是否已获得、来源（本地票据/账户同步）、
  * 以及缓存新鲜度（{@code stale=true} 表示超过 30 天未联网同步，账户型权益已回落为未拥有）。
+ *
+ * 鉴权同全站（local-mode 免登，server 模式要求会话）：已购权益属于账户隐私，
+ * 团队服务器部署下不能匿名可读。
  */
 @RestController
 public class EntitlementController {
@@ -22,8 +27,20 @@ public class EntitlementController {
         this.entitlementService = entitlementService;
     }
 
+    /**
+     * @param refresh 前端「刚连接账户 / 刚在官网买完回来」的显式刷新：先同步拉一次官网再出快照。
+     *                默认 false 走本地缓存，另有陈旧自动刷新兜底（见 EntitlementService.snapshot）。
+     */
     @GetMapping("/api/entitlements")
-    public Map<String, Object> list() {
+    public Map<String, Object> list(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
+            @RequestParam(value = "refresh", required = false, defaultValue = "false") boolean refresh) {
+        if (AuthController.getUserIdFromSession(sessionId) == null) {
+            throw new IllegalArgumentException("未登录");
+        }
+        if (refresh) {
+            entitlementService.refreshQuietly();
+        }
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
         result.put("data", entitlementService.snapshot());

--- a/backend/src/main/java/com/checkba/controller/EntitlementController.java
+++ b/backend/src/main/java/com/checkba/controller/EntitlementController.java
@@ -1,0 +1,32 @@
+package com.checkba.controller;
+
+import com.checkba.service.entitlement.EntitlementService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * GET /api/entitlements —— 功能权益快照（Spec §6）。
+ *
+ * 前端 {@code useEntitlement(feature)} 的数据源：目录内每项是否已获得、来源（本地票据/账户同步）、
+ * 以及缓存新鲜度（{@code stale=true} 表示超过 30 天未联网同步，账户型权益已回落为未拥有）。
+ */
+@RestController
+public class EntitlementController {
+
+    private final EntitlementService entitlementService;
+
+    public EntitlementController(EntitlementService entitlementService) {
+        this.entitlementService = entitlementService;
+    }
+
+    @GetMapping("/api/entitlements")
+    public Map<String, Object> list() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("data", entitlementService.snapshot());
+        return result;
+    }
+}

--- a/backend/src/main/java/com/checkba/controller/LicenseController.java
+++ b/backend/src/main/java/com/checkba/controller/LicenseController.java
@@ -1,6 +1,9 @@
 package com.checkba.controller;
 
 import com.checkba.service.LicenseService;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.entitlement.EntitlementService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,12 +24,19 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/license")
+@Slf4j
 public class LicenseController {
 
     private final LicenseService licenseService;
+    private final AccountService accountService;
+    private final EntitlementService entitlementService;
 
-    public LicenseController(LicenseService licenseService) {
+    public LicenseController(LicenseService licenseService,
+                             AccountService accountService,
+                             EntitlementService entitlementService) {
         this.licenseService = licenseService;
+        this.accountService = accountService;
+        this.entitlementService = entitlementService;
     }
 
     @GetMapping("/status")
@@ -36,13 +46,39 @@ public class LicenseController {
 
     @PostMapping("/activate")
     public ResponseEntity<Map<String, Object>> activate(@RequestBody Map<String, String> body) {
-        Map<String, Object> result = licenseService.activate(body == null ? null : body.get("code"));
+        String code = body == null ? null : body.get("code");
+        Map<String, Object> result = licenseService.activate(code);
         // 前端契约（api.js request 层）：激活失败必须走非 200 才能 reject 到 unlock 页内联报错；
         // 200 + unlocked:false 会被当成功 resolve（响应无 code 字段时直接放行）。
         if (!Boolean.TRUE.equals(result.get("unlocked"))) {
             return ResponseEntity.badRequest().body(result);
         }
+        connectAccountIfKey(code);
         return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 解锁门里粘 awdk_ Key = 连接账户一步到位（Spec §1）。
+     *
+     * 少了这一步，用户在解锁页粘完 Key 解锁为正式版之后账户仍是「未连接」：
+     * 顶栏没有账户 chip、平台 AI 通道不可选、官网已购功能一个都不生效，
+     * 必须再去设置页把同一把 Key 粘第二遍。
+     *
+     * 连接失败不回滚解锁：verify-key 已经确认这把 Key 有效，
+     * 此处多半只是 /api/account/me 这一跳的抖动，设置页里随时可以重连。
+     */
+    private void connectAccountIfKey(String code) {
+        // 团队服务器部署没有解锁门（activate 恒回「无需激活」），这条端点又是匿名的——
+        // 不加这道闸，任何人都能往团队服务器上绑一把自己的账户 Key
+        if (!licenseService.isLocalMode()) return;
+        String key = code == null ? "" : code.trim();
+        if (!key.startsWith("awdk_")) return;
+        try {
+            accountService.connect(key);
+            entitlementService.refreshAsync();
+        } catch (Exception e) {
+            log.warn("解锁成功但账户连接未完成（可在设置页重试）: {}", e.getMessage());
+        }
     }
 
     @PostMapping("/deactivate")

--- a/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
@@ -35,6 +35,7 @@ public class AiChatController {
     private final com.checkba.repository.TokenUsageRepository tokenUsageRepository;
     private final com.checkba.service.ai.AgentRunStateService agentRunStateService;
     private final com.checkba.service.ProjectMemberService projectMemberService;
+    private final com.checkba.service.ai.PlatformAiChannel platformAiChannel;
 
     public AiChatController(
             AiChatService aiChatService,
@@ -46,7 +47,8 @@ public class AiChatController {
             com.checkba.service.ai.ConversationFileChangeService conversationFileChangeService,
             com.checkba.repository.TokenUsageRepository tokenUsageRepository,
             com.checkba.service.ai.AgentRunStateService agentRunStateService,
-            com.checkba.service.ProjectMemberService projectMemberService) {
+            com.checkba.service.ProjectMemberService projectMemberService,
+            com.checkba.service.ai.PlatformAiChannel platformAiChannel) {
         this.aiChatService = aiChatService;
         this.aiAssistantService = aiAssistantService;
         this.projectAiMessageService = projectAiMessageService;
@@ -57,6 +59,7 @@ public class AiChatController {
         this.tokenUsageRepository = tokenUsageRepository;
         this.agentRunStateService = agentRunStateService;
         this.projectMemberService = projectMemberService;
+        this.platformAiChannel = platformAiChannel;
     }
 
     @PostMapping("/chat")
@@ -189,8 +192,10 @@ public class AiChatController {
                 aiModelProperties.getProvider() != null ? aiModelProperties.getProvider().name() : "OLLAMA");
 
         // Return a simple map or DTO
-        Map<String, String> config = new java.util.HashMap<>();
+        Map<String, Object> config = new java.util.HashMap<>();
         config.put("activeProvider", activeProvider);
+        // 平台通道「AI Workdeck 云端」是否可选：未连接官网账户时前端不展示该供应商
+        config.put("platformAiAvailable", platformAiChannel.isAvailable());
         return ResponseEntity.ok(config);
     }
 

--- a/backend/src/main/java/com/checkba/model/entity/TokenUsage.java
+++ b/backend/src/main/java/com/checkba/model/entity/TokenUsage.java
@@ -45,6 +45,17 @@ public class TokenUsage {
     @Column(precision = 19, scale = 6)
     private BigDecimal cost;
 
+    /**
+     * cost 的口径（Spec §3「本地统计 vs 平台结算」两套数字必须分开标注）：
+     * <ul>
+     *   <li>{@code estimate}：BYOK 通道，按 {@code AllowedModels} 的单价表本地估算，不是真实账单；</li>
+     *   <li>{@code platform}：平台通道，来自 OpenRouter 账户实际扣费，是真花的钱。</li>
+     * </ul>
+     * platform 行在对账完成前 cost 为 null——平台的钱不允许用估算值顶替。
+     */
+    @Column(length = 16)
+    private String costSource;
+
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
     
@@ -116,6 +127,14 @@ public class TokenUsage {
 
     public void setCost(BigDecimal cost) {
         this.cost = cost;
+    }
+
+    public String getCostSource() {
+        return costSource;
+    }
+
+    public void setCostSource(String costSource) {
+        this.costSource = costSource;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/backend/src/main/java/com/checkba/service/LicenseService.java
+++ b/backend/src/main/java/com/checkba/service/LicenseService.java
@@ -51,25 +51,9 @@ public class LicenseService {
             @Value("${ai.account.base-url:https://www.aiworkdeck.com}") String accountBaseUrl,
             @Value("${security.license.dir:${user.home}/.aiworkdeck}") String licenseDir) {
         this.localMode = localMode;
-        this.accountBaseUrl = requireHttps(accountBaseUrl.endsWith("/")
-                ? accountBaseUrl.substring(0, accountBaseUrl.length() - 1)
-                : accountBaseUrl);
+        // 授权服务器地址的协议校验与 AccountService 共用一份实现（https，回环 http 例外）
+        this.accountBaseUrl = com.checkba.service.account.AccountEndpoint.requireSecure(accountBaseUrl);
         this.licenseFile = Path.of(licenseDir, "license.json");
-    }
-
-    /**
-     * 授权服务器地址必须是 https：这条通道上跑的是明文 awdk_ 账户 Key，
-     * 配成 http 等于把 Key 交给同网段的任何人。默认值本就是 https，
-     * 只有显式覆盖成 http 才会走到这里，属明确的错误配置，直接拒绝启动。
-     */
-    private static String requireHttps(String baseUrl) {
-        if (baseUrl != null && baseUrl.toLowerCase(java.util.Locale.ROOT).startsWith("https://")) {
-            return baseUrl;
-        }
-        String message = "ai.account.base-url 必须是 https 地址（当前：" + baseUrl
-                + "）。账户 Key 是明文凭据，不允许走未加密通道。";
-        log.error(message);
-        throw new IllegalArgumentException(message);
     }
 
     /** 持久化结构：~/.aiworkdeck/license.json */

--- a/backend/src/main/java/com/checkba/service/LicenseService.java
+++ b/backend/src/main/java/com/checkba/service/LicenseService.java
@@ -42,7 +42,8 @@ public class LicenseService {
     private final boolean localMode;
     private final String accountBaseUrl;
     private final Path licenseFile;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    // 解析失败的异常 message 不许带原文——license.json 里存着明文 awdk_ 账户 Key
+    private final ObjectMapper objectMapper = com.checkba.service.account.AccountService.stateMapper();
 
     private volatile PublicKey trialPublicKey;
 
@@ -63,6 +64,11 @@ public class LicenseService {
         public String code;
         public String activatedAt;
         public String lastVerifiedAt;
+    }
+
+    /** 是否单机模式。解锁门只在单机模式下存在，调用方据此决定要不要做解锁的后续动作。 */
+    public boolean isLocalMode() {
+        return localMode;
     }
 
     /** account 模式启动时机会性复验（后台线程，不阻塞启动，失败静默）。 */

--- a/backend/src/main/java/com/checkba/service/account/AccountEndpoint.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountEndpoint.java
@@ -1,0 +1,61 @@
+package com.checkba.service.account;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 官网账户服务地址（{@code ai.account.base-url}）的规范化与传输安全校验。
+ *
+ * <p>这条通道上跑的是明文 {@code awdk_} 账户 Key，所以默认只允许 https：配成明文 http
+ * 等于把 Key 交给同网段的任何人。唯一的例外是**回环地址**——发往 127.0.0.1 / localhost / [::1]
+ * 的流量不出本机网卡，「同网段窃听」这个威胁本身不成立，这也是浏览器把 localhost
+ * 当作 secure context 的同一条理由。官网仓本地 {@code npm run dev} 联调必须走这条口子，
+ * 否则桌面端与官网只能拿生产环境对，改契约就没有安全的验证场地。
+ *
+ * <p>其余任何 http 地址一律在启动期拒绝（属明确的错误配置，不做降级）。
+ */
+public final class AccountEndpoint {
+
+    private static final Set<String> LOOPBACK_HOSTS = Set.of("localhost", "::1", "[::1]");
+
+    /** 127.0.0.0/8 的点分四段字面量。**不能**用 startsWith("127.") 判断——那会放行 127.0.0.1.evil.com。 */
+    private static final java.util.regex.Pattern IPV4_LOOPBACK =
+            java.util.regex.Pattern.compile("127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+
+    private AccountEndpoint() {
+    }
+
+    /**
+     * 去掉尾部斜杠并校验协议。
+     *
+     * @throws IllegalArgumentException 非 https 且非回环 http
+     */
+    public static String requireSecure(String baseUrl) {
+        String url = baseUrl == null ? null : (baseUrl.endsWith("/")
+                ? baseUrl.substring(0, baseUrl.length() - 1)
+                : baseUrl);
+        if (url != null) {
+            String lower = url.toLowerCase(Locale.ROOT);
+            if (lower.startsWith("https://")) {
+                return url;
+            }
+            if (lower.startsWith("http://") && isLoopback(url)) {
+                return url;
+            }
+        }
+        throw new IllegalArgumentException("ai.account.base-url 必须是 https 地址（当前：" + baseUrl
+                + "）。账户 Key 是明文凭据，不允许走未加密通道；本地联调可用 http://localhost。");
+    }
+
+    private static boolean isLoopback(String url) {
+        try {
+            String host = URI.create(url).getHost();
+            if (host == null) return false;
+            String normalized = host.toLowerCase(Locale.ROOT);
+            return LOOPBACK_HOSTS.contains(normalized) || IPV4_LOOPBACK.matcher(normalized).matches();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/account/AccountException.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountException.java
@@ -1,0 +1,37 @@
+package com.checkba.service.account;
+
+/**
+ * 与官网账户通信的失败分类。
+ *
+ * 分类的意义在调用侧：{@link Kind#NETWORK}（断网/超时/DNS）**不能**清除本地已存的连接，
+ * 否则用户一进地铁就被断开；{@link Kind#UNAUTHORIZED}（官网明确拒绝）才是真的失效。
+ * 这与 PR-A 的 {@code LicenseService} 4xx=INVALID / 5xx=UNREACHABLE 判定同源。
+ *
+ * message 一律中文且**不含 awdk_ Key 明文**——它会进日志、进前端 toast。
+ */
+public class AccountException extends RuntimeException {
+
+    public enum Kind {
+        /** 网络不可达：断网、超时、DNS 失败、5xx。保留本地连接。 */
+        NETWORK,
+        /** 鉴权失败：401/403，Key 无效或已被吊销。可清除本地连接。 */
+        UNAUTHORIZED,
+        /** 业务冲突：409（如未分配 AI 额度）。 */
+        CONFLICT,
+        /** 本地尚未连接账户，请求根本没发出去。 */
+        NOT_CONNECTED,
+        /** 官网返回了预期外的内容（字段缺失、非 JSON）。 */
+        MALFORMED
+    }
+
+    private final Kind kind;
+
+    public AccountException(Kind kind, String message) {
+        super(message);
+        this.kind = kind;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -1,0 +1,317 @@
+package com.checkba.service.account;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 桌面与官网账户的连接（商业化改造 PR-B）。
+ *
+ * 桌面端永远不需要登录（Spec §1）：与账户的唯一连接方式是在设置页粘贴一枚
+ * 官网账户页生成的 {@code awdk_} Key。连接后可以用平台 AI 通道、同步已购权益、看余额与流水。
+ *
+ * 落盘：{@code ~/.aiworkdeck/account.json}（权限 0600，与 PR-A 的 license.json 同目录同规格）。
+ * 出站请求一律 {@code Authorization: Bearer <key>}，5 秒超时，失败按
+ * {@link AccountException.Kind} 分类——网络不可达绝不清除本地连接。
+ *
+ * 契约以官网仓 {@code doc/desktop-contract.md} 为准（注意两处与总 Spec 字面的偏差：
+ * verify-key 的 plan 是 paid|free；ledger 返回 {@code {entries:[...]}} 而非裸数组）。
+ */
+@Service
+@Slf4j
+public class AccountService {
+
+    private static final String KEY_PREFIX = "awdk_";
+
+    private final String baseUrl;
+    private final Path accountFile;
+    private final AccountTransport transport;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AccountService(
+            @Value("${ai.account.base-url:https://www.aiworkdeck.com}") String baseUrl,
+            @Value("${security.license.dir:${user.home}/.aiworkdeck}") String accountDir,
+            AccountTransport transport) {
+        this.baseUrl = requireHttps(stripTrailingSlash(baseUrl));
+        this.accountFile = Path.of(accountDir, "account.json");
+        this.transport = transport;
+    }
+
+    /**
+     * 与 PR-A 的 LicenseService 同一条红线：这条通道上跑的是明文 awdk_ Key，
+     * 配成 http 等于把 Key 交给同网段的任何人。默认值本就是 https。
+     */
+    private static String requireHttps(String url) {
+        if (url != null && url.toLowerCase(Locale.ROOT).startsWith("https://")) {
+            return url;
+        }
+        String message = "ai.account.base-url 必须是 https 地址（当前：" + url
+                + "）。账户 Key 是明文凭据，不允许走未加密通道。";
+        log.error(message);
+        throw new IllegalArgumentException(message);
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url != null && url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /** 持久化结构：~/.aiworkdeck/account.json */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class State {
+        public String key;
+        public String username;
+        public String displayName;
+        public String connectedAt;
+        public String lastSyncAt;
+    }
+
+    // ==================== 连接生命周期 ====================
+
+    /**
+     * 连接账户：调 GET /api/account/me 校验 Key，通过才落盘。
+     *
+     * @throws AccountException 网络不可达 / Key 无效 / 官网返回异常内容
+     */
+    public synchronized Map<String, Object> connect(String awdkKey) {
+        String key = awdkKey == null ? "" : awdkKey.trim();
+        if (key.isEmpty()) {
+            throw new AccountException(AccountException.Kind.UNAUTHORIZED, "账户 Key 不能为空");
+        }
+        if (!key.startsWith(KEY_PREFIX)) {
+            throw new AccountException(AccountException.Kind.UNAUTHORIZED,
+                    "账户 Key 格式不正确，应以 awdk_ 开头（在官网账户页「桌面连接」生成）");
+        }
+        Map<String, Object> me = getJson("/api/account/me", key);
+
+        State state = new State();
+        state.key = key;
+        state.username = str(me.get("username"));
+        state.displayName = str(me.get("displayName"));
+        state.connectedAt = Instant.now().toString();
+        state.lastSyncAt = state.connectedAt;
+        saveState(state);
+        log.info("已连接 AI Workdeck 账户: {}", state.username);
+        return status();
+    }
+
+    /** 断开账户连接：删除本地凭据。调用方负责一并清掉权益缓存与平台 AI Key 缓存。 */
+    public synchronized Map<String, Object> disconnect() {
+        try {
+            Files.deleteIfExists(accountFile);
+        } catch (Exception e) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "断开连接失败：本地凭据文件无法删除");
+        }
+        return status();
+    }
+
+    /** GET /api/account/status 的数据源。**绝不返回 Key 明文**。 */
+    public synchronized Map<String, Object> status() {
+        State state = loadState();
+        Map<String, Object> result = new HashMap<>();
+        boolean connected = state.key != null && !state.key.isBlank();
+        result.put("connected", connected);
+        if (connected) {
+            result.put("username", state.username);
+            result.put("displayName", state.displayName);
+            result.put("connectedAt", state.connectedAt);
+            result.put("lastSyncAt", state.lastSyncAt);
+            result.put("keyMasked", mask(state.key));
+        }
+        return result;
+    }
+
+    public synchronized boolean isConnected() {
+        State state = loadState();
+        return state.key != null && !state.key.isBlank();
+    }
+
+    // ==================== 官网数据拉取 ====================
+
+    /** GET /api/account/me —— 余额与账户档案（余额单位是整数分）。 */
+    public Map<String, Object> fetchProfile() {
+        return getJson("/api/account/me", requireKey());
+    }
+
+    /**
+     * GET /api/account/entitlements。
+     * 契约返回 {@code {"entitlements":[{feature, purchasedAt, orderId}]}}。
+     */
+    public List<Map<String, Object>> fetchEntitlements() {
+        Map<String, Object> body = getJson("/api/account/entitlements", requireKey());
+        touchLastSync();
+        return listOf(body.get("entitlements"));
+    }
+
+    /**
+     * GET /api/account/ledger?limit=50。
+     * 契约返回 {@code {"entries":[...]}}（**不是**总 Spec 字面写的裸数组，以官网契约文档为准）。
+     */
+    public List<Map<String, Object>> fetchLedger() {
+        Map<String, Object> body = getJson("/api/account/ledger?limit=50", requireKey());
+        return listOf(body.get("entries"));
+    }
+
+    /**
+     * POST /api/account/ai-key —— 取该账户的 provisioned OpenRouter runtime key。
+     * 幂等：已有未禁用的 key 直接返回同一把。
+     *
+     * @throws AccountException CONFLICT（409 no_allocation：还没从余额分配 AI 额度）
+     */
+    public Map<String, Object> fetchAiKey() {
+        String key = requireKey();
+        AccountTransport.Reply reply = transport.send("POST", baseUrl + "/api/account/ai-key", key, "{}");
+        if (reply.networkFailure()) {
+            throw networkError();
+        }
+        if (reply.status() == 409) {
+            String code = str(parse(reply.body()).get("error"));
+            if ("no_allocation".equals(code)) {
+                throw new AccountException(AccountException.Kind.CONFLICT,
+                        "请先在官网账户页分配 AI 额度");
+            }
+            throw new AccountException(AccountException.Kind.CONFLICT,
+                    "官网 AI 额度状态异常（" + (code == null ? "未知" : code) + "），请到官网账户页查看");
+        }
+        if (reply.status() == 503) {
+            throw new AccountException(AccountException.Kind.NETWORK,
+                    "官网 AI 额度服务暂不可用，请稍后重试");
+        }
+        Map<String, Object> body = handle(reply);
+        if (str(body.get("openrouterKey")) == null) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网返回的 AI 通道密钥为空，请稍后重试");
+        }
+        return body;
+    }
+
+    // ==================== 内部 ====================
+
+    /** 已连接才有 Key，否则请求根本不该发出去。 */
+    private String requireKey() {
+        State state = loadState();
+        if (state.key == null || state.key.isBlank()) {
+            throw new AccountException(AccountException.Kind.NOT_CONNECTED,
+                    "尚未连接 AI Workdeck 账户，请先在设置页粘贴账户 Key");
+        }
+        return state.key;
+    }
+
+    private Map<String, Object> getJson(String path, String key) {
+        AccountTransport.Reply reply = transport.send("GET", baseUrl + path, key, null);
+        if (reply.networkFailure()) {
+            throw networkError();
+        }
+        return handle(reply);
+    }
+
+    /**
+     * 状态码分类。5xx 归入 NETWORK（服务器故障不等于凭据失效，不能据此清除本地连接），
+     * 401/403 才是明确的鉴权失败——与 PR-A LicenseService 的判定同源。
+     */
+    private Map<String, Object> handle(AccountTransport.Reply reply) {
+        int status = reply.status();
+        if (status == 401 || status == 403) {
+            throw new AccountException(AccountException.Kind.UNAUTHORIZED,
+                    "账户 Key 无效或已被撤销，请到官网账户页重新生成");
+        }
+        if (status >= 500) {
+            throw new AccountException(AccountException.Kind.NETWORK,
+                    "AI Workdeck 服务器暂时不可用，请稍后重试");
+        }
+        if (status < 200 || status >= 300) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网返回了预期外的状态（" + status + "），请稍后重试");
+        }
+        return parse(reply.body());
+    }
+
+    private static AccountException networkError() {
+        return new AccountException(AccountException.Kind.NETWORK,
+                "无法连接 AI Workdeck 服务器，请检查网络后重试");
+    }
+
+    private Map<String, Object> parse(String body) {
+        if (body == null || body.isBlank()) return Map.of();
+        try {
+            Map<String, Object> parsed = objectMapper.readValue(body, new TypeReference<>() {});
+            return parsed == null ? Map.of() : parsed;
+        } catch (Exception e) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网返回的内容无法解析，请稍后重试");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> listOf(Object raw) {
+        if (raw instanceof List<?> list) {
+            return (List<Map<String, Object>>) list;
+        }
+        return List.of();
+    }
+
+    /** 拉取成功后刷新最后同步时间，供设置页展示「最近同步于 …」。 */
+    private synchronized void touchLastSync() {
+        State state = loadState();
+        if (state.key == null) return;
+        state.lastSyncAt = Instant.now().toString();
+        saveState(state);
+    }
+
+    synchronized State loadState() {
+        try {
+            if (!Files.exists(accountFile)) return new State();
+            return objectMapper.readValue(Files.readAllBytes(accountFile), State.class);
+        } catch (Exception e) {
+            log.warn("account.json 读取失败，按未连接处理: {}", e.getMessage());
+            return new State();
+        }
+    }
+
+    private void saveState(State state) {
+        try {
+            Files.createDirectories(accountFile.getParent());
+            Files.write(accountFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(state));
+            restrictPermissions(accountFile);
+        } catch (Exception e) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "账户连接状态写入失败，请检查磁盘权限");
+        }
+    }
+
+    /**
+     * 存凭据的文件默认 umask 下会落成 0644（同机他人可读），收敛为 0600。
+     * 平台 AI 通道的 key 缓存文件也复用这条。
+     */
+    public static void restrictPermissions(Path file) {
+        try {
+            Files.setPosixFilePermissions(file,
+                    java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"));
+        } catch (UnsupportedOperationException e) {
+            // Windows：文件默认继承用户目录 ACL，无需处理
+        } catch (Exception e) {
+            log.warn("account.json 权限收敛失败（文件仍可用）: {}", e.getMessage());
+        }
+    }
+
+    /** 展示用掩码：只留前缀与末 4 位，够用户认出是哪把 Key，又不泄露。 */
+    private static String mask(String key) {
+        if (key.length() <= KEY_PREFIX.length() + 4) return KEY_PREFIX + "****";
+        return KEY_PREFIX + "****" + key.substring(key.length() - 4);
+    }
+
+    private static String str(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -43,27 +42,10 @@ public class AccountService {
             @Value("${ai.account.base-url:https://www.aiworkdeck.com}") String baseUrl,
             @Value("${security.license.dir:${user.home}/.aiworkdeck}") String accountDir,
             AccountTransport transport) {
-        this.baseUrl = requireHttps(stripTrailingSlash(baseUrl));
+        // 与 PR-A 的 LicenseService 共用同一条红线（https，回环 http 例外），见 AccountEndpoint
+        this.baseUrl = AccountEndpoint.requireSecure(baseUrl);
         this.accountFile = Path.of(accountDir, "account.json");
         this.transport = transport;
-    }
-
-    /**
-     * 与 PR-A 的 LicenseService 同一条红线：这条通道上跑的是明文 awdk_ Key，
-     * 配成 http 等于把 Key 交给同网段的任何人。默认值本就是 https。
-     */
-    private static String requireHttps(String url) {
-        if (url != null && url.toLowerCase(Locale.ROOT).startsWith("https://")) {
-            return url;
-        }
-        String message = "ai.account.base-url 必须是 https 地址（当前：" + url
-                + "）。账户 Key 是明文凭据，不允许走未加密通道。";
-        log.error(message);
-        throw new IllegalArgumentException(message);
-    }
-
-    private static String stripTrailingSlash(String url) {
-        return url != null && url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 
     /** 持久化结构：~/.aiworkdeck/account.json */
@@ -161,6 +143,21 @@ public class AccountService {
     public List<Map<String, Object>> fetchLedger() {
         Map<String, Object> body = getJson("/api/account/ledger?limit=50", requireKey());
         return listOf(body.get("entries"));
+    }
+
+    /**
+     * GET /api/account/ai-usage —— AI 额度的实时口径
+     * {@code {configured, hasKey, limitUsd, usageUsd, remainingUsd, keyMasked}}。
+     *
+     * <p>注意：这个端点在官网仓 master 上实现了，但**没有写进** {@code doc/desktop-contract.md}，
+     * 属于契约文档的缺口（已回报）。因此这里当成「可能不存在」处理：任何非 2xx 都由
+     * {@link #handle} 抛 AccountException，调用方降级成「额度未知」而不是整块报错。
+     *
+     * <p>不用 OpenRouter 的 {@code GET /api/v1/key} 代替：那条路要求本地已经 provision 过
+     * runtime key（未分配额度的账户根本没有），而这里恰恰要能回答「还没分配」。
+     */
+    public Map<String, Object> fetchAiUsage() {
+        return getJson("/api/account/ai-usage", requireKey());
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -36,7 +36,7 @@ public class AccountService {
     private final String baseUrl;
     private final Path accountFile;
     private final AccountTransport transport;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = stateMapper();
 
     public AccountService(
             @Value("${ai.account.base-url:https://www.aiworkdeck.com}") String baseUrl,
@@ -176,7 +176,7 @@ public class AccountService {
             String code = str(parse(reply.body()).get("error"));
             if ("no_allocation".equals(code)) {
                 throw new AccountException(AccountException.Kind.CONFLICT,
-                        "请先在官网账户页分配 AI 额度");
+                        "尚未分配 AI 额度，请到官网账户页从余额分配");
             }
             throw new AccountException(AccountException.Kind.CONFLICT,
                     "官网 AI 额度状态异常（" + (code == null ? "未知" : code) + "），请到官网账户页查看");
@@ -195,12 +195,17 @@ public class AccountService {
 
     // ==================== 内部 ====================
 
-    /** 已连接才有 Key，否则请求根本不该发出去。 */
+    /**
+     * 已连接才有 Key，否则请求根本不该发出去。
+     *
+     * 文案里刻意不写「请先」：前端 api.js 用「登录」「未授权」「请先」三个子串判定未登录，
+     * 命中会清会话（浏览器端还会跳登录页）。账户未连接与未登录是两回事。
+     */
     private String requireKey() {
         State state = loadState();
         if (state.key == null || state.key.isBlank()) {
             throw new AccountException(AccountException.Kind.NOT_CONNECTED,
-                    "尚未连接 AI Workdeck 账户，请先在设置页粘贴账户 Key");
+                    "尚未连接 AI Workdeck 账户，可在设置页「账户与用量」粘贴账户 Key");
         }
         return state.key;
     }
@@ -285,6 +290,21 @@ public class AccountService {
             throw new AccountException(AccountException.Kind.MALFORMED,
                     "账户连接状态写入失败，请检查磁盘权限");
         }
+    }
+
+    /**
+     * 凭据类 JSON 的共用 mapper。
+     *
+     * Jackson 默认开着 {@code INCLUDE_SOURCE_IN_LOCATION}：解析失败时异常 message 里会带上
+     * 原文片段（{@code at [Source: (byte[])"{\"key\":\"awdk_...\""}）。account.json /
+     * license.json / platform-ai-key.json 里存的都是明文密钥，而这些解析失败点普遍
+     * {@code log.warn(..., e.getMessage())}——一次半截写入（崩溃/磁盘满）就足以把 0600 的密钥
+     * 复制进 0644 的日志文件。关掉源文引用后 Jackson 打印 REDACTED，定位信息（行列、原因）不受影响。
+     */
+    public static ObjectMapper stateMapper() {
+        return com.fasterxml.jackson.databind.json.JsonMapper.builder()
+                .disable(com.fasterxml.jackson.core.StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+                .build();
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/account/AccountTransport.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountTransport.java
@@ -1,0 +1,27 @@
+package com.checkba.service.account;
+
+/**
+ * 出站 HTTP 缝（seam）：把「怎么发请求」从 {@link AccountService} 里剥出来，
+ * 单测可以打桩返回任意状态码/报文，不必真的起一个 HTTP 服务或依赖网络。
+ *
+ * 生产实现 {@link HttpAccountTransport} 用 JDK HttpClient，5 秒超时。
+ */
+public interface AccountTransport {
+
+    /** 出站响应。status &lt; 0 表示请求根本没发出去（连接失败/超时）。 */
+    record Reply(int status, String body) {
+        public static final int NETWORK_FAILURE = -1;
+
+        public boolean networkFailure() {
+            return status < 0;
+        }
+    }
+
+    /**
+     * @param method     GET / POST
+     * @param url        绝对地址
+     * @param bearerKey  awdk_ 账户 Key，null 表示不带 Authorization
+     * @param jsonBody   请求体，null 表示无体
+     */
+    Reply send(String method, String url, String bearerKey, String jsonBody);
+}

--- a/backend/src/main/java/com/checkba/service/account/HttpAccountTransport.java
+++ b/backend/src/main/java/com/checkba/service/account/HttpAccountTransport.java
@@ -1,0 +1,49 @@
+package com.checkba.service.account;
+
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/** {@link AccountTransport} 的生产实现：JDK HttpClient，连接与响应各 5 秒超时。 */
+@Component
+public class HttpAccountTransport implements AccountTransport {
+
+    static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    @Override
+    public Reply send(String method, String url, String bearerKey, String jsonBody) {
+        try {
+            HttpRequest.BodyPublisher body = jsonBody == null
+                    ? HttpRequest.BodyPublishers.noBody()
+                    : HttpRequest.BodyPublishers.ofString(jsonBody, StandardCharsets.UTF_8);
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(TIMEOUT)
+                    .method(method, body);
+            if (jsonBody != null) {
+                builder.header("Content-Type", "application/json");
+            }
+            if (bearerKey != null) {
+                builder.header("Authorization", "Bearer " + bearerKey);
+            }
+            HttpResponse<String> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            return new Reply(response.statusCode(), response.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new Reply(Reply.NETWORK_FAILURE, null);
+        } catch (Exception e) {
+            // 异常信息里可能夹带 URL，但绝不会有 Key（Key 只在 header 里），可安全丢弃
+            return new Reply(Reply.NETWORK_FAILURE, null);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/account/HttpAccountTransport.java
+++ b/backend/src/main/java/com/checkba/service/account/HttpAccountTransport.java
@@ -1,5 +1,6 @@
 package com.checkba.service.account;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -11,11 +12,19 @@ import java.time.Duration;
 
 /** {@link AccountTransport} 的生产实现：JDK HttpClient，连接与响应各 5 秒超时。 */
 @Component
+@Slf4j
 public class HttpAccountTransport implements AccountTransport {
 
     static final Duration TIMEOUT = Duration.ofSeconds(5);
 
+    /**
+     * 固定 HTTP/1.1。JDK HttpClient 默认 HTTP_2，对明文地址会先发 h2c 升级请求——
+     * Node/Next 的开发服务器收到后直接不回字节，客户端报「header parser received no bytes」，
+     * 在上层看只是一句「无法连接服务器」，排查成本极高（本地联调实测踩到）。
+     * 这里全是几 KB 的 JSON 往返，HTTP/2 没有任何收益，不值得为它留这个坑。
+     */
     private final HttpClient client = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
             .connectTimeout(TIMEOUT)
             .followRedirects(HttpClient.Redirect.NEVER)
             .build();
@@ -42,7 +51,9 @@ public class HttpAccountTransport implements AccountTransport {
             Thread.currentThread().interrupt();
             return new Reply(Reply.NETWORK_FAILURE, null);
         } catch (Exception e) {
-            // 异常信息里可能夹带 URL，但绝不会有 Key（Key 只在 header 里），可安全丢弃
+            // 上层只会给用户一句「无法连接服务器」，具体死因必须留在日志里，否则无从排查。
+            // URL 可以打，Key 只在 header 里，不会随异常信息泄露
+            log.debug("账户请求失败 {} {}: {}", method, url, e.toString());
             return new Reply(Reply.NETWORK_FAILURE, null);
         }
     }

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -382,6 +382,14 @@ public class AgentOrchestrator {
             }
             runLoop(model, messages, conversationId, projectId, userId, request.getModel(), 0, executionLog, agentMode, guard);
 
+        } catch (com.checkba.service.account.AccountException e) {
+            // 账户/额度类失败不是「内部错误」，而是用户可自行处理的状态
+            // （如「请先在官网账户页分配 AI 额度」）。原样透出中文文案，不加英文前缀，
+            // 也不打 ERROR 级日志——这条路径在未分配额度时每发一条消息都会走到
+            log.info("平台通道不可用 [{}]，会话 {}: {}", e.getKind(), conversationId, e.getMessage());
+            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
+            sseEmitterService.send(conversationId, "error", e.getMessage());
+            sseEmitterService.close(conversationId);
         } catch (Exception e) {
             log.error("Agent Loop Error for conversation: " + conversationId, e);
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);

--- a/backend/src/main/java/com/checkba/service/ai/AiChatService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AiChatService.java
@@ -135,6 +135,10 @@ public class AiChatService {
 
             return new AiChatResponse(response, conversationId);
 
+        } catch (com.checkba.service.account.AccountException e) {
+            // 账户/额度类失败是用户可自行处理的状态，中文文案原样透出（同 AgentOrchestrator）
+            log.info("平台通道不可用 [{}]: {}", e.getKind(), e.getMessage());
+            return new AiChatResponse(e.getMessage(), request.getConversationId());
         } catch (Exception e) {
             log.error("Error during AI chat", e);
             return new AiChatResponse("Sorry, I encountered an error: " + e.getMessage(), request.getConversationId());

--- a/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
+++ b/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
@@ -24,6 +24,7 @@ public class ChatModelFactory {
 
     private final AiModelProperties aiModelProperties;
     private final com.checkba.service.SystemSettingService systemSettingService;
+    private final PlatformAiChannel platformAiChannel;
 
     // 缓存: key = provider + ":" + modelName
     private final Map<String, ChatLanguageModel> modelCache = new ConcurrentHashMap<>();
@@ -32,7 +33,7 @@ public class ChatModelFactory {
      * 解析当前生效的供应商：优先读管理后台/向导写入 system_setting 的 ai.activeProvider，
      * 未配置或值非法时回退 application.yml 的静态配置。
      */
-    private AiModelProperties.Provider resolveProvider() {
+    public AiModelProperties.Provider resolveProvider() {
         String configured = systemSettingService.get("ai.activeProvider", null);
         if (configured != null && !configured.isBlank()) {
             try {
@@ -76,6 +77,12 @@ public class ChatModelFactory {
 
         if (targetModel == null || targetModel.isEmpty()) {
             targetModel = "default";
+        }
+
+        // 平台通道必须先于白名单短路判定：白名单模型走的是 BYOK 的 OpenRouter key，
+        // 而平台通道用的是官网 provision 的 key，两者不能混
+        if (provider == AiModelProperties.Provider.AWD_CLOUD) {
+            return getOrCreatePlatformModel(resolvePlatformModel(targetModel));
         }
 
         // Logic to switch provider based on modelId pattern if Provider is set to OPENROUTER or dynamic
@@ -136,6 +143,70 @@ public class ChatModelFactory {
         });
     }
 
+    // ==================== 平台通道「AI Workdeck 云端」 ====================
+
+    /** 平台通道仍是 OpenRouter 后端，模型口径与 BYOK 一致：非白名单一律回落默认模型。 */
+    private String resolvePlatformModel(String targetModel) {
+        if (AllowedModels.isAllowed(targetModel)) return targetModel;
+        String defaultModel = aiModelProperties.getOpenRouter().getDefaultModel();
+        if (!"default".equals(targetModel)) {
+            log.warn("Model '{}' is not in the allowed list, platform channel falls back to: {}",
+                    targetModel, defaultModel);
+        }
+        return defaultModel;
+    }
+
+    /**
+     * 平台通道密钥由官网 provision，取不到时**不能**静默回退 BYOK：
+     * 那会把用户自己的 key 花掉，也会掩盖「未分配额度」这类需要用户去官网处理的状态。
+     * 这里原样抛出 AccountException（中文文案，如「请先在官网账户页分配 AI 额度」）。
+     */
+    private String platformApiKey() {
+        if (!platformAiChannel.isAvailable()) {
+            throw new com.checkba.service.account.AccountException(
+                    com.checkba.service.account.AccountException.Kind.NOT_CONNECTED,
+                    "「AI Workdeck 云端」需要先连接账户，请到设置页粘贴账户 Key");
+        }
+        return platformAiChannel.apiKey();
+    }
+
+    /** 缓存 key 带密钥指纹：官网撤销重发后指纹变化，旧实例自然作废。 */
+    private ChatLanguageModel getOrCreatePlatformModel(String modelId) {
+        String apiKey = platformApiKey();
+        String cacheKey = "awd_cloud:" + platformAiChannel.keyFingerprint() + ":" + modelId;
+        return modelCache.computeIfAbsent(cacheKey, k -> {
+            log.info("Creating new AWD Cloud ChatModel instance for: {}", modelId);
+            AiModelProperties.OpenRouter config = aiModelProperties.getOpenRouter();
+            return OpenAiChatModel.builder()
+                    .apiKey(apiKey)
+                    // 平台通道的 baseUrl 只认 yml 配置，不读 DB：DB 那份是用户 BYOK 的自定义地址，
+                    // 把 provision 出来的 key 发到用户指定的地址等于把平台凭据交出去
+                    .baseUrl(config.getBaseUrl())
+                    .modelName(modelId)
+                    .timeout(config.getTimeout())
+                    .logRequests(true)
+                    .logResponses(true)
+                    .build();
+        });
+    }
+
+    private dev.langchain4j.model.chat.StreamingChatLanguageModel getOrCreatePlatformStreamingModel(String modelId) {
+        String apiKey = platformApiKey();
+        String cacheKey = "awd_cloud_stream:" + platformAiChannel.keyFingerprint() + ":" + modelId;
+        return streamingModelCache.computeIfAbsent(cacheKey, k -> {
+            log.info("Creating new AWD Cloud StreamingChatModel for: {}", modelId);
+            AiModelProperties.OpenRouter config = aiModelProperties.getOpenRouter();
+            return dev.langchain4j.model.openai.OpenAiStreamingChatModel.builder()
+                    .apiKey(apiKey)
+                    .baseUrl(config.getBaseUrl())
+                    .modelName(modelId)
+                    .timeout(config.getTimeout())
+                    .logRequests(true)
+                    .logResponses(true)
+                    .build();
+        });
+    }
+
     private ChatLanguageModel getOrCreateOllamaModel(String modelName) {
         String cacheKey = "ollama:" + modelName;
         return modelCache.computeIfAbsent(cacheKey, k -> {
@@ -172,13 +243,16 @@ public class ChatModelFactory {
 
     public dev.langchain4j.model.chat.StreamingChatLanguageModel getStreamingChatModel(String modelId) {
         String targetModel = (modelId == null || modelId.isEmpty()) ? "default" : modelId;
+        AiModelProperties.Provider provider = resolveProvider();
+
+        // 同 getChatModel：平台通道先于白名单短路
+        if (provider == AiModelProperties.Provider.AWD_CLOUD) {
+            return getOrCreatePlatformStreamingModel(resolvePlatformModel(targetModel));
+        }
 
         if (AllowedModels.isAllowed(targetModel)) {
             return getOrCreateOpenRouterStreamingModel(targetModel);
         }
-
-        // Fallback or Local
-        AiModelProperties.Provider provider = resolveProvider();
 
         // 同 getChatModel：OPENROUTER 供应商下不回退本地 Ollama
         if (provider == AiModelProperties.Provider.OPENROUTER) {

--- a/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
+++ b/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
@@ -25,6 +25,7 @@ public class ChatModelFactory {
     private final AiModelProperties aiModelProperties;
     private final com.checkba.service.SystemSettingService systemSettingService;
     private final PlatformAiChannel platformAiChannel;
+    private final PlatformUsageAccountant usageAccountant;
 
     // 缓存: key = provider + ":" + modelName
     private final Map<String, ChatLanguageModel> modelCache = new ConcurrentHashMap<>();
@@ -165,9 +166,44 @@ public class ChatModelFactory {
         if (!platformAiChannel.isAvailable()) {
             throw new com.checkba.service.account.AccountException(
                     com.checkba.service.account.AccountException.Kind.NOT_CONNECTED,
-                    "「AI Workdeck 云端」需要先连接账户，请到设置页粘贴账户 Key");
+                    "「AI Workdeck 云端」需要连接账户，请到设置页粘贴账户 Key");
         }
-        return platformAiChannel.apiKey();
+        String key = platformAiChannel.apiKey();
+        // 请求发出前先把用量基线建起来，否则重启后第一条消息只够建基线、cost 永远留空
+        usageAccountant.ensureBaselineAsync();
+        return key;
+    }
+
+    /**
+     * 断开账户后把 activeProvider 从平台通道摘下来，返回切换到的供应商（本来就不是平台通道时返回 null）。
+     *
+     * 不做这一步的话：platformAiChannel 不可用 → 每条消息都在 {@link #platformApiKey()} 抛
+     * NOT_CONNECTED，而设置页仍把「AI Workdeck 云端」渲染成正常选中（不可选标记刻意豁免当前选项），
+     * 用户看不出问题出在哪。落点按「哪个还能用」挑，避免一律摔回本地 Ollama（多数人没装）。
+     */
+    public String demotePlatformProvider() {
+        String active = systemSettingService.get("ai.activeProvider", null);
+        if (active == null
+                || !AiModelProperties.Provider.AWD_CLOUD.name().equalsIgnoreCase(active.trim())) {
+            return null;
+        }
+        String next;
+        if (hasSetting("external.openrouter.apiKey", aiModelProperties.getOpenRouter().getApiKey())) {
+            next = AiModelProperties.Provider.OPENROUTER.name();
+        } else if (hasSetting("external.google.apiKey", aiModelProperties.getGemini().getApiKey())) {
+            next = AiModelProperties.Provider.GEMINI.name();
+        } else {
+            next = AiModelProperties.Provider.OLLAMA.name();
+        }
+        systemSettingService.set("ai.activeProvider", next);
+        clearCache();
+        log.info("账户已断开，AI 供应商由平台通道切换为 {}", next);
+        return next;
+    }
+
+    private boolean hasSetting(String key, String staticFallback) {
+        String value = getSetting(key, staticFallback);
+        return value != null && !value.isBlank();
     }
 
     /** 缓存 key 带密钥指纹：官网撤销重发后指纹变化，旧实例自然作废。 */

--- a/backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java
@@ -33,7 +33,8 @@ public class PlatformAiChannel {
 
     private final AccountService accountService;
     private final Path keyFile;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    // 解析失败的异常 message 不许带原文——这个文件里是 provision 出来的 OpenRouter 明文密钥
+    private final ObjectMapper objectMapper = AccountService.stateMapper();
 
     private volatile Cached memory;
 

--- a/backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java
@@ -1,0 +1,139 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Map;
+
+/**
+ * 平台 AI 通道「AI Workdeck 云端」（Spec §3）。
+ *
+ * 用户不必自备 OpenRouter key：连接账户后由官网 provision 一把带额度上限的 runtime key
+ * （POST /api/account/ai-key），桌面端拿来直连 OpenRouter。额度强制在 OpenRouter 侧执行
+ * （key 自带 limit，超限 402），桌面端不做也做不了额度校验。
+ *
+ * key 缓存在 {@code ~/.aiworkdeck/platform-ai-key.json}（0600）。官网端点是幂等的，
+ * 缓存只是省一次往返；官网撤销重发后本地 clearCache 即可重新拉取。
+ *
+ * 未连接账户时该通道不可用（{@link #isAvailable()} 为 false，前端据此不展示为可选供应商）。
+ */
+@Service
+@Slf4j
+public class PlatformAiChannel {
+
+    private final AccountService accountService;
+    private final Path keyFile;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private volatile Cached memory;
+
+    public PlatformAiChannel(
+            AccountService accountService,
+            @Value("${security.license.dir:${user.home}/.aiworkdeck}") String stateDir) {
+        this.accountService = accountService;
+        this.keyFile = Path.of(stateDir, "platform-ai-key.json");
+    }
+
+    /** 持久化结构：~/.aiworkdeck/platform-ai-key.json */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Cached {
+        public String openrouterKey;
+        public Double limitUsd;
+        public String fetchedAt;
+    }
+
+    /** 账户已连接才可能有平台通道。不发网络请求。 */
+    public boolean isAvailable() {
+        return accountService.isConnected();
+    }
+
+    /**
+     * 取平台通道密钥：内存缓存 → 磁盘缓存 → 向官网请求。
+     *
+     * @throws AccountException NOT_CONNECTED（未连接账户）/ CONFLICT（未分配 AI 额度）/ NETWORK
+     */
+    public String apiKey() {
+        Cached cached = current();
+        if (cached != null) return cached.openrouterKey;
+        return fetch().openrouterKey;
+    }
+
+    /** 当前额度上限（美元）；未取到返回 null。不触发网络请求。 */
+    public Double limitUsd() {
+        Cached cached = current();
+        return cached == null ? null : cached.limitUsd;
+    }
+
+    /**
+     * 模型实例缓存用的密钥指纹。key 换了指纹就变，
+     * {@link ChatModelFactory} 因此不会把旧 key 建的模型实例一直用到进程重启。
+     */
+    public String keyFingerprint() {
+        Cached cached = current();
+        if (cached == null || cached.openrouterKey == null) return "none";
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(cached.openrouterKey.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest, 0, 6);
+        } catch (Exception e) {
+            return "none";
+        }
+    }
+
+    /** 断开账户或官网撤销重发后调用。 */
+    public synchronized void clearCache() {
+        memory = null;
+        try {
+            Files.deleteIfExists(keyFile);
+        } catch (Exception e) {
+            log.warn("平台 AI 通道密钥缓存清除失败: {}", e.getMessage());
+        }
+    }
+
+    // ==================== 内部 ====================
+
+    private synchronized Cached current() {
+        if (memory != null) return memory;
+        try {
+            if (Files.exists(keyFile)) {
+                Cached cached = objectMapper.readValue(Files.readAllBytes(keyFile), Cached.class);
+                if (cached != null && cached.openrouterKey != null && !cached.openrouterKey.isBlank()) {
+                    memory = cached;
+                    return memory;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("平台 AI 通道密钥缓存读取失败，将重新获取: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private synchronized Cached fetch() {
+        Map<String, Object> body = accountService.fetchAiKey();
+        Cached cached = new Cached();
+        cached.openrouterKey = String.valueOf(body.get("openrouterKey"));
+        Object limit = body.get("limitUsd");
+        cached.limitUsd = limit instanceof Number n ? n.doubleValue() : null;
+        cached.fetchedAt = Instant.now().toString();
+        try {
+            Files.createDirectories(keyFile.getParent());
+            Files.write(keyFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(cached));
+            AccountService.restrictPermissions(keyFile);
+        } catch (Exception e) {
+            // 落盘失败不致命：本次进程内仍可用，下次重启再拉一次
+            log.warn("平台 AI 通道密钥缓存写入失败: {}", e.getMessage());
+        }
+        memory = cached;
+        return cached;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
@@ -1,0 +1,162 @@
+package com.checkba.service.ai;
+
+import com.checkba.repository.TokenUsageRepository;
+import com.checkba.service.account.AccountTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 平台通道的真实花费对账（Spec §3）。
+ *
+ * <h3>为什么不是直接读响应体的 usage.cost</h3>
+ * Spec 写的是「桌面端单请求成本直接读响应 {@code usage.cost}（流式在最后一条 SSE）」，
+ * 但本仓固定在 langchain4j 0.36 / openai4j 0.23：{@code dev.ai4j.openai4j.shared.Usage}
+ * 只有 prompt/completion/total 三个字段，OpenRouter 多返回的 {@code cost} 在反序列化时被丢弃，
+ * 且拿不到原始响应；OpenRouter 还要求请求体里带 {@code usage:{include:true}} 才会返回 cost，
+ * 而这个 client 的请求 POJO 也不支持透传自定义字段。升 langchain4j 是另一个量级的改动
+ * （MCP 那次已知 1.0.0+ 不兼容 0.36）。
+ *
+ * <h3>改用的口径</h3>
+ * 每次记账后异步查一次 {@code GET https://openrouter.ai/api/v1/key}（用平台 runtime key 鉴权），
+ * 该端点返回这把 key 的**累计**消费（美元）。相邻两次采样之差即这段时间的真实花费。
+ * OpenRouter 记账有秒级延迟，所以采样会重试几次等数字变动。
+ *
+ * 取舍（已知且可接受）：并发轮次之间的归属可能串位，但**总额始终精确**（差分自洽）；
+ * 权威结算数字本来也在官网/OpenRouter 侧，本地这份是给用户看明细的。
+ *
+ * 单线程 worker 串行执行，既保证差分正确，也不占用流式回调线程（否则会拖住 bubble_end）。
+ */
+@Component
+@Slf4j
+public class PlatformUsageAccountant {
+
+    static final String SOURCE_PLATFORM = "platform";
+    static final String SOURCE_ESTIMATE = "estimate";
+
+    /** OpenRouter 记账延迟：最多重采样这么多次。 */
+    private static final int MAX_POLLS = 4;
+
+    /** 重采样间隔。单测会调小，生产不改。 */
+    private long pollIntervalMs = 1500L;
+
+    private final TokenUsageRepository tokenUsageRepository;
+    private final PlatformAiChannel platformAiChannel;
+    private final AccountTransport transport;
+    private final String openRouterBaseUrl;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final ExecutorService worker = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "platform-usage-accountant");
+        t.setDaemon(true);
+        return t;
+    });
+
+    /** 上一次观测到的累计消费。null = 尚未建立基线。 */
+    private volatile BigDecimal baseline;
+
+    public PlatformUsageAccountant(
+            TokenUsageRepository tokenUsageRepository,
+            PlatformAiChannel platformAiChannel,
+            AccountTransport transport,
+            @Value("${ai.model.open-router.base-url:https://openrouter.ai/api/v1}") String openRouterBaseUrl) {
+        this.tokenUsageRepository = tokenUsageRepository;
+        this.platformAiChannel = platformAiChannel;
+        this.transport = transport;
+        this.openRouterBaseUrl = openRouterBaseUrl.endsWith("/")
+                ? openRouterBaseUrl.substring(0, openRouterBaseUrl.length() - 1)
+                : openRouterBaseUrl;
+    }
+
+    /** 排队对账某条 token_usage 记录。立即返回，不阻塞调用方。 */
+    public void reconcileAsync(Long tokenUsageId) {
+        if (tokenUsageId == null) return;
+        try {
+            worker.submit(() -> reconcile(tokenUsageId));
+        } catch (java.util.concurrent.RejectedExecutionException e) {
+            log.debug("平台用量对账已停止，跳过 id={}", tokenUsageId);
+        }
+    }
+
+    /** 包可见供单测直接驱动。 */
+    void reconcile(Long tokenUsageId) {
+        try {
+            BigDecimal observed = probeCumulativeUsage();
+            if (observed == null) return;
+
+            BigDecimal previous = baseline;
+            if (previous == null) {
+                // 首次只建基线：这条记录之前的消费不属于它
+                baseline = observed;
+                return;
+            }
+            for (int i = 0; i < MAX_POLLS && observed.compareTo(previous) <= 0; i++) {
+                Thread.sleep(pollIntervalMs);
+                BigDecimal again = probeCumulativeUsage();
+                if (again == null) return;
+                observed = again;
+            }
+            baseline = observed;
+
+            BigDecimal delta = observed.subtract(previous);
+            if (delta.signum() <= 0) {
+                log.debug("平台用量未变动，跳过对账 id={}", tokenUsageId);
+                return;
+            }
+            tokenUsageRepository.findById(tokenUsageId).ifPresent(entity -> {
+                entity.setCost(delta);
+                entity.setCostSource(SOURCE_PLATFORM);
+                tokenUsageRepository.save(entity);
+            });
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.warn("平台用量对账失败（不影响对话）: {}", e.getMessage());
+        }
+    }
+
+    /** GET /api/v1/key → {"data":{"usage": 1.234, "limit": 10, ...}}；失败返回 null。 */
+    private BigDecimal probeCumulativeUsage() {
+        String key;
+        try {
+            key = platformAiChannel.apiKey();
+        } catch (Exception e) {
+            return null;
+        }
+        AccountTransport.Reply reply = transport.send("GET", openRouterBaseUrl + "/key", key, null);
+        if (reply.networkFailure() || reply.status() < 200 || reply.status() >= 300 || reply.body() == null) {
+            return null;
+        }
+        try {
+            Map<?, ?> parsed = objectMapper.readValue(reply.body(), Map.class);
+            Object data = parsed.get("data");
+            if (!(data instanceof Map<?, ?> map)) return null;
+            Object usage = map.get("usage");
+            return usage instanceof Number n ? new BigDecimal(n.toString()) : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** 便于单测断言与复位。 */
+    void setBaselineForTest(BigDecimal value) {
+        this.baseline = value;
+    }
+
+    /** 单测把重采样间隔调小，避免为了等 OpenRouter 记账延迟白等几秒。 */
+    void setPollIntervalMsForTest(long millis) {
+        this.pollIntervalMs = millis;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        worker.shutdownNow();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
@@ -38,8 +38,9 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class PlatformUsageAccountant {
 
-    static final String SOURCE_PLATFORM = "platform";
-    static final String SOURCE_ESTIMATE = "estimate";
+    /** {@code TokenUsage.costSource} 的两个取值，展示层也要按它分辨口径。 */
+    public static final String SOURCE_PLATFORM = "platform";
+    public static final String SOURCE_ESTIMATE = "estimate";
 
     /** OpenRouter 记账延迟：最多重采样这么多次。 */
     private static final int MAX_POLLS = 4;

--- a/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
@@ -79,10 +79,38 @@ public class PlatformUsageAccountant {
     /** 排队对账某条 token_usage 记录。立即返回，不阻塞调用方。 */
     public void reconcileAsync(Long tokenUsageId) {
         if (tokenUsageId == null) return;
+        submit(() -> reconcile(tokenUsageId), "对账 id=" + tokenUsageId);
+    }
+
+    /**
+     * 在平台通道**发起请求之前**建立基线。
+     *
+     * baseline 是内存字段，进程重启即丢；没有这一步，重启后第一条消息只够建基线，
+     * cost 永远留空、界面上永久显示「待结算」。这里排在同一个单线程 worker 上，
+     * 所以一定先于那条消息随后入队的对账任务跑完。已有基线时是内存判断，不发请求。
+     */
+    public void ensureBaselineAsync() {
+        if (baseline != null) return;
+        submit(() -> {
+            if (baseline != null) return;
+            BigDecimal observed = probeCumulativeUsage();
+            if (observed != null) baseline = observed;
+        }, "建立用量基线");
+    }
+
+    /**
+     * 换账户/断开连接：旧 key 的累计消费与新 key 毫无关系，
+     * 留着会把两把 key 的累计值之差整个记到下一条消息头上。
+     */
+    public void resetBaseline() {
+        baseline = null;
+    }
+
+    private void submit(Runnable task, String what) {
         try {
-            worker.submit(() -> reconcile(tokenUsageId));
+            worker.submit(task);
         } catch (java.util.concurrent.RejectedExecutionException e) {
-            log.debug("平台用量对账已停止，跳过 id={}", tokenUsageId);
+            log.debug("平台用量对账已停止，跳过{}", what);
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
+++ b/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -62,13 +64,30 @@ public class TokenUsageService {
 
             tokenUsageRepository.save(entity);
             if (platformChannel) {
-                platformUsageAccountant.reconcileAsync(entity.getId());
+                scheduleReconcile(entity.getId());
             }
             log.debug("Recorded usage for model {}: {} tokens, source={}",
                     modelId, totalTokens, entity.getCostSource());
         } catch (Exception e) {
             log.error("Failed to record token usage", e);
         }
+    }
+
+    /**
+     * 对账必须等事务提交后再入队：id 在 flush 时就有了，但对账 worker 是另一条连接，
+     * 提交前 findById 查不到这条记录会静默 no-op，该条的 cost 永久留空。
+     */
+    private void scheduleReconcile(Long tokenUsageId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            platformUsageAccountant.reconcileAsync(tokenUsageId);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                platformUsageAccountant.reconcileAsync(tokenUsageId);
+            }
+        });
     }
 
     /** 当前是否走平台通道。供应商解析失败按 BYOK 处理——记账问题不该拖垮对话。 */

--- a/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
+++ b/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
@@ -17,9 +17,18 @@ public class TokenUsageService {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TokenUsageService.class);
 
     private final TokenUsageRepository tokenUsageRepository;
+    private final ChatModelFactory chatModelFactory;
+    private final PlatformUsageAccountant platformUsageAccountant;
 
     /**
-     * 记录 Token 使用情况和成本
+     * 记录 Token 使用情况和成本。
+     *
+     * cost 分两套口径（Spec §3）：
+     * <ul>
+     *   <li>BYOK：按单价表本地估算，{@code costSource=estimate}——这是「本地统计」，不是账单；</li>
+     *   <li>平台通道：cost 先留空，由 {@link PlatformUsageAccountant} 异步用 OpenRouter 的
+     *       实际扣费补上，{@code costSource=platform}。平台的钱不允许用估算值顶替。</li>
+     * </ul>
      */
     @Transactional
     public void recordUsage(Long projectId, Long userId, String modelId, dev.langchain4j.model.output.TokenUsage usage, String conversationId) {
@@ -42,14 +51,33 @@ public class TokenUsageService {
             entity.setCompletionTokens(completionTokens);
             entity.setTotalTokens(totalTokens);
 
-            // Calculate Cost
-            BigDecimal cost = calculateCost(modelId, promptTokens, completionTokens);
-            entity.setCost(cost);
+            boolean platformChannel = isPlatformChannel();
+            if (platformChannel) {
+                entity.setCost(null);
+                entity.setCostSource(PlatformUsageAccountant.SOURCE_PLATFORM);
+            } else {
+                entity.setCost(calculateCost(modelId, promptTokens, completionTokens));
+                entity.setCostSource(PlatformUsageAccountant.SOURCE_ESTIMATE);
+            }
 
             tokenUsageRepository.save(entity);
-            log.debug("Recorded usage for model {}: {} tokens, ${}", modelId, totalTokens, cost);
+            if (platformChannel) {
+                platformUsageAccountant.reconcileAsync(entity.getId());
+            }
+            log.debug("Recorded usage for model {}: {} tokens, source={}",
+                    modelId, totalTokens, entity.getCostSource());
         } catch (Exception e) {
             log.error("Failed to record token usage", e);
+        }
+    }
+
+    /** 当前是否走平台通道。供应商解析失败按 BYOK 处理——记账问题不该拖垮对话。 */
+    private boolean isPlatformChannel() {
+        try {
+            return chatModelFactory.resolveProvider()
+                    == com.checkba.config.AiModelProperties.Provider.AWD_CLOUD;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/entitlement/EntitlementService.java
+++ b/backend/src/main/java/com/checkba/service/entitlement/EntitlementService.java
@@ -1,0 +1,234 @@
+package com.checkba.service.entitlement;
+
+import com.checkba.service.LicenseService;
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 功能权益的单一出口（Spec §6）。
+ *
+ * 来源合并（并集）：
+ * <ol>
+ *   <li><b>本地票据</b>：PR-A 的 {@link LicenseService} —— 试用码/账户 Key 解锁应用本体，
+ *       映射为 {@link FeatureCatalog#APP_UNLOCKED}；</li>
+ *   <li><b>账户同步</b>：GET /api/account/entitlements 的结果，落盘缓存
+ *       {@code ~/.aiworkdeck/entitlements.json}。</li>
+ * </ol>
+ *
+ * 断网宽限 30 天（与 license 同机制、同时长）：缓存里的 syncedAt 超过 30 天，
+ * 账户型权益整体回落为「未拥有」——不是「保持拥有」，否则一台永久离线的机器等于永久买断。
+ * 本地票据不受宽限影响（试用码是离线验签的，本就不需要联网）。
+ *
+ * 刷新时机：启动时 + 每次 connect 之后，均为异步且失败不阻塞启动。
+ */
+@Service
+@Slf4j
+public class EntitlementService {
+
+    /** 与 {@code LicenseService.OFFLINE_GRACE} 同口径。 */
+    static final Duration OFFLINE_GRACE = Duration.ofDays(30);
+
+    private final LicenseService licenseService;
+    private final AccountService accountService;
+    private final Path cacheFile;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public EntitlementService(
+            LicenseService licenseService,
+            AccountService accountService,
+            @Value("${security.license.dir:${user.home}/.aiworkdeck}") String stateDir) {
+        this.licenseService = licenseService;
+        this.accountService = accountService;
+        this.cacheFile = Path.of(stateDir, "entitlements.json");
+    }
+
+    /** 持久化结构：~/.aiworkdeck/entitlements.json */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Cache {
+        public String syncedAt;
+        public List<String> features = new ArrayList<>();
+    }
+
+    // ==================== 单一出口 ====================
+
+    /**
+     * 该 feature 是否已获得。业务侧一律走这个方法，不要自己拼来源。
+     *
+     * @param feature {@link FeatureCatalog} 常量，或动态的 {@code skill:<id>} / {@code plugin:<id>}
+     */
+    public boolean isEnabled(String feature) {
+        if (feature == null || feature.isBlank()) return false;
+        if (FeatureCatalog.APP_UNLOCKED.equals(feature) && localAppUnlocked()) {
+            return true;
+        }
+        return accountFeatures().contains(feature);
+    }
+
+    /**
+     * GET /api/entitlements 的数据源。
+     *
+     * 两个列表刻意分开，因为它们回答的是不同问题：
+     * <ul>
+     *   <li>{@code features}：**只含已拥有的**（目录内 + 动态的 skill:/plugin:）。
+     *       「出现在列表里 = 已拥有」是这个字段名唯一自然的读法，前端
+     *       {@code useEntitlement} 就是这么用的——如果这里塞进未拥有的条目，
+     *       调用方会把一切都判成已解锁，权益体系直接失效；</li>
+     *   <li>{@code catalog}：目录全集带 enabled 标志，给设置页「已有/去购买」列表用。</li>
+     * </ul>
+     */
+    public Map<String, Object> snapshot() {
+        Set<String> account = accountFeatures();
+        boolean appUnlocked = localAppUnlocked();
+
+        List<Map<String, Object>> owned = new ArrayList<>();
+        List<Map<String, Object>> catalog = new ArrayList<>();
+        for (String feature : FeatureCatalog.all()) {
+            Map<String, Object> item = describe(feature, account, appUnlocked);
+            catalog.add(item);
+            if (Boolean.TRUE.equals(item.get("enabled"))) {
+                owned.add(describe(feature, account, appUnlocked));
+            }
+        }
+        // 目录之外的动态权益（付费 Skill / 插件）：拿到就是已购，供插件广场判定
+        account.stream().filter(f -> !FeatureCatalog.isKnown(f)).sorted()
+                .forEach(f -> owned.add(describe(f, account, appUnlocked)));
+
+        Cache cache = loadCache();
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("features", owned);
+        result.put("catalog", catalog);
+        result.put("accountConnected", accountService.isConnected());
+        result.put("syncedAt", cache.syncedAt);
+        result.put("stale", cache.syncedAt != null && !withinGrace(cache));
+        return result;
+    }
+
+    private static Map<String, Object> describe(String feature, Set<String> account, boolean appUnlocked) {
+        boolean fromAccount = account.contains(feature);
+        boolean fromLocal = FeatureCatalog.APP_UNLOCKED.equals(feature) && appUnlocked;
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("feature", feature);
+        item.put("displayName", FeatureCatalog.displayName(feature));
+        item.put("enabled", fromAccount || fromLocal);
+        // 来源分开标注：本地票据（试用/离线）与账户同步是两套口径，前端文案不同
+        item.put("source", fromLocal ? "local" : (fromAccount ? "account" : "none"));
+        return item;
+    }
+
+    // ==================== 刷新 ====================
+
+    /** 启动时刷新一次：后台线程，失败静默，绝不阻塞启动。 */
+    @PostConstruct
+    void refreshOnStartup() {
+        refreshAsync();
+    }
+
+    /** 异步刷新账户型权益。connect 成功后也调这个。 */
+    public void refreshAsync() {
+        Thread thread = new Thread(this::refreshQuietly, "entitlement-refresh");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    /** 同步刷新，吞掉全部异常并返回是否成功。单测与刷新线程共用。 */
+    boolean refreshQuietly() {
+        if (!accountService.isConnected()) {
+            return false;
+        }
+        try {
+            List<Map<String, Object>> entitlements = accountService.fetchEntitlements();
+            Cache cache = new Cache();
+            cache.syncedAt = Instant.now().toString();
+            cache.features = new ArrayList<>(new LinkedHashSet<>(entitlements.stream()
+                    .map(e -> e.get("feature"))
+                    .filter(f -> f instanceof String s && !s.isBlank())
+                    .map(String::valueOf)
+                    .toList()));
+            saveCache(cache);
+            log.info("账户权益已同步，共 {} 项", cache.features.size());
+            return true;
+        } catch (AccountException e) {
+            // 网络不可达走宽限，鉴权失败也只是不刷新——清除连接是 connect/disconnect 的职责
+            log.debug("账户权益同步跳过（{}）: {}", e.getKind(), e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.warn("账户权益同步失败: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /** 断开账户连接时清空账户型权益缓存（本地票据不受影响）。 */
+    public synchronized void clearAccountCache() {
+        try {
+            Files.deleteIfExists(cacheFile);
+        } catch (Exception e) {
+            log.warn("权益缓存清除失败: {}", e.getMessage());
+        }
+    }
+
+    // ==================== 内部 ====================
+
+    private boolean localAppUnlocked() {
+        try {
+            return Boolean.TRUE.equals(licenseService.status().get("unlocked"));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** 账户型权益：超过 30 天未同步即整体失效。 */
+    private Set<String> accountFeatures() {
+        Cache cache = loadCache();
+        if (cache.features == null || cache.features.isEmpty()) return Set.of();
+        if (!withinGrace(cache)) {
+            return Set.of();
+        }
+        return new LinkedHashSet<>(cache.features);
+    }
+
+    private static boolean withinGrace(Cache cache) {
+        if (cache.syncedAt == null) return false;
+        try {
+            return Instant.parse(cache.syncedAt).plus(OFFLINE_GRACE).isAfter(Instant.now());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    synchronized Cache loadCache() {
+        try {
+            if (!Files.exists(cacheFile)) return new Cache();
+            Cache cache = objectMapper.readValue(Files.readAllBytes(cacheFile), Cache.class);
+            return cache == null ? new Cache() : cache;
+        } catch (Exception e) {
+            log.warn("entitlements.json 读取失败，按无账户权益处理: {}", e.getMessage());
+            return new Cache();
+        }
+    }
+
+    synchronized void saveCache(Cache cache) {
+        try {
+            Files.createDirectories(cacheFile.getParent());
+            Files.write(cacheFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(cache));
+        } catch (Exception e) {
+            log.warn("权益缓存写入失败（不影响本次判定）: {}", e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/entitlement/EntitlementService.java
+++ b/backend/src/main/java/com/checkba/service/entitlement/EntitlementService.java
@@ -35,8 +35,20 @@ import java.util.Set;
  * 断网宽限 30 天（与 license 同机制、同时长）：缓存里的 syncedAt 超过 30 天，
  * 账户型权益整体回落为「未拥有」——不是「保持拥有」，否则一台永久离线的机器等于永久买断。
  * 本地票据不受宽限影响（试用码是离线验签的，本就不需要联网）。
+ * 宽限只覆盖「联系不上官网」；官网**明确拒绝**（401/403 = Key 已吊销）时立即清缓存，
+ * 与 {@code LicenseService.reverifyOnStartup} 对 INVALID 的处理同口径。
  *
- * 刷新时机：启动时 + 每次 connect 之后，均为异步且失败不阻塞启动。
+ * 刷新时机：启动时 + 每次 connect 之后 + 快照发现缓存陈旧时（均为异步、失败静默），
+ * 另有 {@code GET /api/entitlements?refresh=true} 的显式同步刷新。
+ *
+ * <h3>已知边界：entitlements.json 未签名</h3>
+ * 总 Spec §5 写的是「本地 entitlements.json（签名票据集合）」，本轮实现是明文 JSON。
+ * 机器主人手改这个文件可以给自己开出 ¥19.9 档的本地 SKU——这是**有意接受**的：
+ * 这两个 SKU 的判定本就完全在本地执行（剪贴板裁剪、Stage 容量），没有任何服务端往返
+ * 能拦住改文件的人，签名只是抬高门槛。真正要钱的两条路都另有服务端闸门：
+ * 付费 Skill/插件的 bundle 下载由官网 402 把关（见官网契约 doc/desktop-contract.md），
+ * 平台 AI 额度由 OpenRouter 侧的 key limit 强制执行。
+ * 缓存只在账户已连接时生效（见 {@link #accountFeatures()}），删掉 account.json 就一起失效。
  */
 @Service
 @Slf4j
@@ -45,10 +57,23 @@ public class EntitlementService {
     /** 与 {@code LicenseService.OFFLINE_GRACE} 同口径。 */
     static final Duration OFFLINE_GRACE = Duration.ofDays(30);
 
+    /**
+     * 快照发现缓存比这个还旧就顺手异步刷一次。没有它，一台长期不重启的机器
+     * 会一直用启动那一刻的权益（官网上刚买的东西看不见），并且 syncedAt 永不推进，
+     * 到第 31 天当场把账户型权益整体判失效——尽管它一直在线。
+     */
+    private static final Duration REFRESH_INTERVAL = Duration.ofMinutes(10);
+
     private final LicenseService licenseService;
     private final AccountService accountService;
     private final Path cacheFile;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = AccountService.stateMapper();
+
+    /** 内存缓存：isEnabled 是热路径（PR-C 的剪贴板裁剪、Stage 容量检查每次都要问）。 */
+    private Cache memory;
+    /** 陈旧自动刷新的在途标记，避免每次快照都起一个线程。 */
+    private final java.util.concurrent.atomic.AtomicBoolean refreshing =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
 
     public EntitlementService(
             LicenseService licenseService,
@@ -94,6 +119,7 @@ public class EntitlementService {
      * </ul>
      */
     public Map<String, Object> snapshot() {
+        refreshIfStale();
         Set<String> account = accountFeatures();
         boolean appUnlocked = localAppUnlocked();
 
@@ -142,13 +168,28 @@ public class EntitlementService {
 
     /** 异步刷新账户型权益。connect 成功后也调这个。 */
     public void refreshAsync() {
-        Thread thread = new Thread(this::refreshQuietly, "entitlement-refresh");
+        if (!refreshing.compareAndSet(false, true)) return;
+        Thread thread = new Thread(() -> {
+            try {
+                refreshQuietly();
+            } finally {
+                refreshing.set(false);
+            }
+        }, "entitlement-refresh");
         thread.setDaemon(true);
         thread.start();
     }
 
-    /** 同步刷新，吞掉全部异常并返回是否成功。单测与刷新线程共用。 */
-    boolean refreshQuietly() {
+    /** 缓存陈旧（或压根没有）时顺手异步刷一次；已在刷新中则跳过。 */
+    private void refreshIfStale() {
+        if (!accountService.isConnected()) return;
+        Cache cache = loadCache();
+        if (cache.syncedAt != null && !olderThan(cache.syncedAt, REFRESH_INTERVAL)) return;
+        refreshAsync();
+    }
+
+    /** 同步刷新，吞掉全部异常并返回是否成功。控制器的显式刷新与刷新线程共用。 */
+    public boolean refreshQuietly() {
         if (!accountService.isConnected()) {
             return false;
         }
@@ -165,7 +206,16 @@ public class EntitlementService {
             log.info("账户权益已同步，共 {} 项", cache.features.size());
             return true;
         } catch (AccountException e) {
-            // 网络不可达走宽限，鉴权失败也只是不刷新——清除连接是 connect/disconnect 的职责
+            if (e.getKind() == AccountException.Kind.UNAUTHORIZED) {
+                // 官网**明确拒绝** = Key 已吊销。30 天宽限是给「联系不上官网」的，
+                // 拿它兜吊销等于用户止损后付费功能还能再用一个月。立刻清缓存。
+                // 本地连接状态不动：设置页仍显示已连接 + 明确的「Key 已失效」提示，
+                // 比凭据凭空消失更容易让用户找到下一步。
+                log.warn("账户 Key 已被拒绝（官网 401/403），账户型权益已清除");
+                clearAccountCache();
+                return false;
+            }
+            // 网络不可达（含 5xx）走宽限：服务器故障不等于凭据失效
             log.debug("账户权益同步跳过（{}）: {}", e.getKind(), e.getMessage());
             return false;
         } catch (Exception e) {
@@ -176,6 +226,7 @@ public class EntitlementService {
 
     /** 断开账户连接时清空账户型权益缓存（本地票据不受影响）。 */
     public synchronized void clearAccountCache() {
+        memory = new Cache();
         try {
             Files.deleteIfExists(cacheFile);
         } catch (Exception e) {
@@ -193,37 +244,52 @@ public class EntitlementService {
         }
     }
 
-    /** 账户型权益：超过 30 天未同步即整体失效。 */
+    /**
+     * 账户型权益：超过 30 天未同步即整体失效。
+     * 另外必须账户仍处于连接状态——缓存文件是账户同步的产物，
+     * 没有 account.json 却还认这份缓存，等于把「删掉凭据」和「手写一份缓存」都变成免费解锁。
+     */
     private Set<String> accountFeatures() {
+        if (!accountService.isConnected()) return Set.of();
         Cache cache = loadCache();
         if (cache.features == null || cache.features.isEmpty()) return Set.of();
-        if (!withinGrace(cache)) {
+        if (cache.syncedAt == null || olderThan(cache.syncedAt, OFFLINE_GRACE)) {
             return Set.of();
         }
         return new LinkedHashSet<>(cache.features);
     }
 
-    private static boolean withinGrace(Cache cache) {
-        if (cache.syncedAt == null) return false;
+    /** ISO 时间戳距今是否超过 duration；无法解析按「已超过」处理。 */
+    private static boolean olderThan(String isoTimestamp, Duration duration) {
         try {
-            return Instant.parse(cache.syncedAt).plus(OFFLINE_GRACE).isAfter(Instant.now());
+            return !Instant.parse(isoTimestamp).plus(duration).isAfter(Instant.now());
         } catch (Exception e) {
-            return false;
+            return true;
         }
+    }
+
+    private static boolean withinGrace(Cache cache) {
+        return cache.syncedAt != null && !olderThan(cache.syncedAt, OFFLINE_GRACE);
     }
 
     synchronized Cache loadCache() {
+        if (memory != null) return memory;
+        Cache cache;
         try {
-            if (!Files.exists(cacheFile)) return new Cache();
-            Cache cache = objectMapper.readValue(Files.readAllBytes(cacheFile), Cache.class);
-            return cache == null ? new Cache() : cache;
+            cache = Files.exists(cacheFile)
+                    ? objectMapper.readValue(Files.readAllBytes(cacheFile), Cache.class)
+                    : new Cache();
+            if (cache == null) cache = new Cache();
         } catch (Exception e) {
             log.warn("entitlements.json 读取失败，按无账户权益处理: {}", e.getMessage());
-            return new Cache();
+            cache = new Cache();
         }
+        memory = cache;
+        return cache;
     }
 
     synchronized void saveCache(Cache cache) {
+        memory = cache;
         try {
             Files.createDirectories(cacheFile.getParent());
             Files.write(cacheFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(cache));

--- a/backend/src/main/java/com/checkba/service/entitlement/FeatureCatalog.java
+++ b/backend/src/main/java/com/checkba/service/entitlement/FeatureCatalog.java
@@ -1,0 +1,61 @@
+package com.checkba.service.entitlement;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 中央功能目录（Spec §6）。
+ *
+ * 这里是桌面端**唯一**的 feature 名字来源：新增可解锁功能先在这里加常量，
+ * 再在业务处用 {@link EntitlementService#isEnabled(String)} 判定，禁止在各处硬写字符串。
+ *
+ * 命名必须与官网 {@code doc/desktop-contract.md}「权益命名」一节逐字一致——
+ * 官网生成兑换码时按同一张表做白名单校验，对不上就是发出去的码兑不了。
+ *
+ * 付费 Skill / 插件的权益名形如 {@code skill:<id>} / {@code plugin:<id>}，是动态的，
+ * 不在本目录里枚举；{@link EntitlementService#isEnabled(String)} 对任意字符串都可用。
+ */
+public final class FeatureCatalog {
+
+    /** 应用本体已解锁（试用码离线解锁或账户 Key 解锁）。 */
+    public static final String APP_UNLOCKED = "app.unlocked";
+
+    /** 无线剪贴板无限版：免费额度为最多回溯 20 条且保留 3 天。 */
+    public static final String CLIPBOARD_UNLIMITED = "clipboard.unlimited";
+
+    /** Stage 文件缓存区无限版：免费额度为最多 20 个文件、总量 500MB。 */
+    public static final String STAGE_UNLIMITED = "stage.unlimited";
+
+    /** 预留：整体 Pro 订阅。本轮不实现订阅状态机，仅占位以免后续改名。 */
+    public static final String PLAN_PRO = "plan.pro";
+
+    /** feature -> 面向用户的中文名。插入顺序即 GET /api/entitlements 的返回顺序。 */
+    private static final Map<String, String> DISPLAY_NAMES;
+
+    static {
+        Map<String, String> names = new LinkedHashMap<>();
+        names.put(APP_UNLOCKED, "应用解锁");
+        names.put(CLIPBOARD_UNLIMITED, "无线剪贴板无限版");
+        names.put(STAGE_UNLIMITED, "文件缓存区无限版");
+        names.put(PLAN_PRO, "Pro 订阅");
+        DISPLAY_NAMES = Collections.unmodifiableMap(names);
+    }
+
+    /** 目录内全部 feature。 */
+    public static Set<String> all() {
+        return DISPLAY_NAMES.keySet();
+    }
+
+    /** 面向用户的中文名；未知 feature 原样返回。 */
+    public static String displayName(String feature) {
+        return DISPLAY_NAMES.getOrDefault(feature, feature);
+    }
+
+    public static boolean isKnown(String feature) {
+        return DISPLAY_NAMES.containsKey(feature);
+    }
+
+    private FeatureCatalog() {}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -92,6 +92,10 @@ mcp:
 
 # AI 大模型配置（供应商可切换）
 ai:
+  # 官网账户服务地址（解锁门在线校验、账户连接、平台 AI 通道密钥）。
+  # 必须是 https：这条通道上跑的是明文 awdk_ 账户 Key，配成 http 会被启动期直接拒绝。
+  account:
+    base-url: https://www.aiworkdeck.com
   model:
     # 当前启用的提供商：ollama（本地）或 gemini（Google 云端）
     provider: open-router

--- a/backend/src/test/java/com/checkba/service/account/AccountEndpointTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountEndpointTest.java
@@ -1,0 +1,54 @@
+package com.checkba.service.account;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 锁定官网地址的传输安全红线：明文 awdk_ Key 只允许走 https 或回环 http。
+ * 这里最要紧的是**前缀不能当主机判据**——127.0.0.1.evil.com 这类域名会骗过 startsWith。
+ */
+class AccountEndpointTest {
+
+    @Test
+    @DisplayName("https 放行并去掉尾部斜杠")
+    void httpsAllowed() {
+        assertEquals("https://www.aiworkdeck.com", AccountEndpoint.requireSecure("https://www.aiworkdeck.com"));
+        assertEquals("https://www.aiworkdeck.com", AccountEndpoint.requireSecure("https://www.aiworkdeck.com/"));
+        assertEquals("https://WWW.AIWORKDECK.COM", AccountEndpoint.requireSecure("https://WWW.AIWORKDECK.COM"));
+    }
+
+    @Test
+    @DisplayName("回环 http 放行：本地起官网联调")
+    void loopbackHttpAllowed() {
+        assertEquals("http://localhost:3000", AccountEndpoint.requireSecure("http://localhost:3000"));
+        assertEquals("http://127.0.0.1:3000", AccountEndpoint.requireSecure("http://127.0.0.1:3000"));
+        assertEquals("http://127.0.0.53", AccountEndpoint.requireSecure("http://127.0.0.53"));
+        assertEquals("http://[::1]:3000", AccountEndpoint.requireSecure("http://[::1]:3000"));
+    }
+
+    @Test
+    @DisplayName("非回环 http 一律拒绝")
+    void remoteHttpRejected() {
+        assertThrows(IllegalArgumentException.class, () -> AccountEndpoint.requireSecure("http://www.aiworkdeck.com"));
+        assertThrows(IllegalArgumentException.class, () -> AccountEndpoint.requireSecure("http://192.168.1.10:3000"));
+    }
+
+    @Test
+    @DisplayName("伪装成回环的域名必须拒绝（前缀匹配会放行它们）")
+    void loopbackLookalikesRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AccountEndpoint.requireSecure("http://127.0.0.1.evil.example"));
+        assertThrows(IllegalArgumentException.class,
+                () -> AccountEndpoint.requireSecure("http://localhost.evil.example"));
+    }
+
+    @Test
+    @DisplayName("空值与非法 URL 拒绝")
+    void invalidRejected() {
+        assertThrows(IllegalArgumentException.class, () -> AccountEndpoint.requireSecure(null));
+        assertThrows(IllegalArgumentException.class, () -> AccountEndpoint.requireSecure(""));
+        assertThrows(IllegalArgumentException.class, () -> AccountEndpoint.requireSecure("www.aiworkdeck.com"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -1,0 +1,233 @@
+package com.checkba.service.account;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 锁定账户连接契约（商业化改造 PR-B）：
+ * - connect 校验通过才落盘，且文件权限 0600（存着明文 awdk_ Key）；
+ * - 失败分类：网络不可达 / 鉴权失败 / 业务冲突各走各的分支，5xx 归网络不能清连接；
+ * - 任何错误信息都是中文且**不含 Key 明文**；
+ * - 官网契约文档记录的两处偏差：ledger 是 {entries:[...]} 包裹，不是裸数组。
+ */
+class AccountServiceTest {
+
+    private static final String KEY = "awdk_" + "S3cretKeyMaterial0123456789abcdefghij";
+
+    @TempDir
+    Path tempDir;
+
+    /** 可编排的出站桩：按入队顺序返回，同时记录收到的请求。 */
+    static class StubTransport implements AccountTransport {
+        final Deque<Reply> replies = new ArrayDeque<>();
+        final List<String> calls = new ArrayList<>();
+        String lastBearer;
+
+        StubTransport enqueue(int status, String body) {
+            replies.add(new Reply(status, body));
+            return this;
+        }
+
+        StubTransport enqueueNetworkFailure() {
+            replies.add(new Reply(Reply.NETWORK_FAILURE, null));
+            return this;
+        }
+
+        @Override
+        public Reply send(String method, String url, String bearerKey, String jsonBody) {
+            calls.add(method + " " + url);
+            lastBearer = bearerKey;
+            if (replies.isEmpty()) {
+                throw new AssertionError("桩没有为 " + method + " " + url + " 准备响应");
+            }
+            return replies.poll();
+        }
+    }
+
+    private StubTransport transport;
+
+    private AccountService service() {
+        return new AccountService("https://www.aiworkdeck.com", tempDir.toString(), transport);
+    }
+
+    private AccountService connected() {
+        transport = new StubTransport().enqueue(200,
+                "{\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\",\"balanceCents\":1980,\"plan\":\"paid\"}");
+        AccountService service = service();
+        service.connect(KEY);
+        return service;
+    }
+
+    // ==================== connect ====================
+
+    @Test
+    @DisplayName("连接成功：落盘 + status 带用户名，且绝不返回 Key 明文")
+    void connectPersistsAndNeverExposesKey() {
+        AccountService service = connected();
+
+        assertEquals("GET https://www.aiworkdeck.com/api/account/me", transport.calls.get(0));
+        assertEquals(KEY, transport.lastBearer, "出站请求必须带 Bearer <key>");
+
+        Map<String, Object> status = service.status();
+        assertEquals(true, status.get("connected"));
+        assertEquals("hanzewei", status.get("username"));
+        assertEquals("韩泽伟", status.get("displayName"));
+        assertNotNull(status.get("connectedAt"));
+        assertFalse(status.toString().contains(KEY), "status 不允许出现 Key 明文: " + status);
+        assertTrue(String.valueOf(status.get("keyMasked")).startsWith("awdk_****"));
+
+        assertTrue(Files.exists(tempDir.resolve("account.json")));
+        // 新实例（模拟重启）从盘上恢复
+        transport = new StubTransport();
+        assertTrue(service().isConnected());
+    }
+
+    @Test
+    @DisplayName("account.json 存明文 Key，权限必须收敛为 0600")
+    void accountFileIsOwnerOnly() throws Exception {
+        connected();
+        Path file = tempDir.resolve("account.json");
+        Assumptions.assumeTrue(
+                Files.getFileAttributeView(file, PosixFileAttributeView.class) != null, "非 POSIX 文件系统跳过");
+        assertEquals("rw-------", PosixFilePermissions.toString(Files.getPosixFilePermissions(file)));
+    }
+
+    @Test
+    @DisplayName("401：分类为鉴权失败，中文提示，不落盘")
+    void unauthorizedIsClassifiedAndNotPersisted() {
+        transport = new StubTransport().enqueue(401, "{\"error\":\"unauthorized\"}");
+        AccountException e = assertThrows(AccountException.class, () -> service().connect(KEY));
+        assertEquals(AccountException.Kind.UNAUTHORIZED, e.getKind());
+        assertTrue(e.getMessage().contains("账户 Key 无效"), e.getMessage());
+        assertFalse(e.getMessage().contains(KEY), "错误信息不允许出现 Key 明文");
+        assertFalse(Files.exists(tempDir.resolve("account.json")));
+    }
+
+    @Test
+    @DisplayName("连接超时/断网：分类为网络不可达，中文提示")
+    void networkFailureIsClassified() {
+        transport = new StubTransport().enqueueNetworkFailure();
+        AccountException e = assertThrows(AccountException.class, () -> service().connect(KEY));
+        assertEquals(AccountException.Kind.NETWORK, e.getKind());
+        assertTrue(e.getMessage().contains("网络"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("5xx 归为网络不可达：服务器故障不等于凭据失效，不能据此清连接")
+    void serverErrorIsNetworkNotUnauthorized() {
+        AccountService service = connected();
+        transport.enqueue(503, "gateway down");
+        AccountException e = assertThrows(AccountException.class, service::fetchEntitlements);
+        assertEquals(AccountException.Kind.NETWORK, e.getKind());
+        assertTrue(service.isConnected(), "5xx 之后本地连接必须还在");
+    }
+
+    @Test
+    @DisplayName("Key 格式不对：本地直接拒绝，一个请求都不发")
+    void malformedKeyRejectedWithoutRequest() {
+        transport = new StubTransport();
+        AccountException e = assertThrows(AccountException.class, () -> service().connect("sk-not-an-awdk"));
+        assertEquals(AccountException.Kind.UNAUTHORIZED, e.getKind());
+        assertTrue(e.getMessage().contains("awdk_"), e.getMessage());
+        assertTrue(transport.calls.isEmpty(), "格式不对不该产生出站请求");
+    }
+
+    @Test
+    @DisplayName("未连接时拉数据：分类为 NOT_CONNECTED，请求不发出")
+    void notConnectedShortCircuits() {
+        transport = new StubTransport();
+        AccountException e = assertThrows(AccountException.class, () -> service().fetchLedger());
+        assertEquals(AccountException.Kind.NOT_CONNECTED, e.getKind());
+        assertTrue(transport.calls.isEmpty());
+    }
+
+    // ==================== disconnect ====================
+
+    @Test
+    @DisplayName("断开：清除本地凭据")
+    void disconnectClearsCredential() {
+        AccountService service = connected();
+        Map<String, Object> status = service.disconnect();
+        assertEquals(false, status.get("connected"));
+        assertFalse(service.isConnected());
+        assertFalse(Files.exists(tempDir.resolve("account.json")));
+    }
+
+    // ==================== 数据拉取 ====================
+
+    @Test
+    @DisplayName("ledger 按官网契约解 {entries:[...]}，不是裸数组")
+    void ledgerUnwrapsEntries() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"entries\":[{\"kind\":\"recharge\",\"amountCents\":1000},"
+                + "{\"kind\":\"ai_alloc\",\"amountCents\":-500}]}");
+        List<Map<String, Object>> entries = service.fetchLedger();
+        assertEquals(2, entries.size());
+        assertEquals("ai_alloc", entries.get(1).get("kind"));
+    }
+
+    @Test
+    @DisplayName("entitlements 解 {entitlements:[...]}，并刷新 lastSyncAt")
+    void entitlementsUnwrapAndTouchSync() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"entitlements\":[{\"feature\":\"clipboard.unlimited\","
+                + "\"purchasedAt\":\"2026-08-01T00:00:00Z\",\"orderId\":\"o1\"}]}");
+        List<Map<String, Object>> list = service.fetchEntitlements();
+        assertEquals(1, list.size());
+        assertEquals("clipboard.unlimited", list.get(0).get("feature"));
+        assertNotNull(service.status().get("lastSyncAt"));
+    }
+
+    @Test
+    @DisplayName("ai-key 409 no_allocation：给出「去官网分配额度」的中文引导")
+    void aiKeyNoAllocationGivesGuidance() {
+        AccountService service = connected();
+        transport.enqueue(409, "{\"error\":\"no_allocation\"}");
+        AccountException e = assertThrows(AccountException.class, service::fetchAiKey);
+        assertEquals(AccountException.Kind.CONFLICT, e.getKind());
+        assertEquals("请先在官网账户页分配 AI 额度", e.getMessage());
+    }
+
+    @Test
+    @DisplayName("ai-key 成功：返回 openrouterKey 与 limitUsd")
+    void aiKeySuccess() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"openrouterKey\":\"sk-or-v1-provisioned\",\"limitUsd\":5.0}");
+        Map<String, Object> body = service.fetchAiKey();
+        assertEquals("sk-or-v1-provisioned", body.get("openrouterKey"));
+        assertEquals(5.0, ((Number) body.get("limitUsd")).doubleValue(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("官网返回非 JSON：分类为 MALFORMED，不当成鉴权失败")
+    void malformedBodyIsClassified() {
+        AccountService service = connected();
+        transport.enqueue(200, "<html>502 bad gateway</html>");
+        AccountException e = assertThrows(AccountException.class, service::fetchLedger);
+        assertEquals(AccountException.Kind.MALFORMED, e.getKind());
+    }
+
+    // ==================== 配置红线 ====================
+
+    @Test
+    @DisplayName("base-url 配成 http 直接拒绝：明文 Key 不允许走未加密通道")
+    void httpBaseUrlRejected() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new AccountService("http://www.aiworkdeck.com", tempDir.toString(), new StubTransport()));
+        assertTrue(e.getMessage().contains("https"), e.getMessage());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -199,7 +199,27 @@ class AccountServiceTest {
         transport.enqueue(409, "{\"error\":\"no_allocation\"}");
         AccountException e = assertThrows(AccountException.class, service::fetchAiKey);
         assertEquals(AccountException.Kind.CONFLICT, e.getKind());
-        assertEquals("请先在官网账户页分配 AI 额度", e.getMessage());
+        assertEquals("尚未分配 AI 额度，请到官网账户页从余额分配", e.getMessage());
+    }
+
+    @Test
+    @DisplayName("账户类文案不许命中前端的「未登录」判据，否则会误清会话/跳登录页")
+    void accountMessagesDoNotLookLikeAuthErrors() {
+        // frontend/src/services/api.js 用这三个子串判定未登录（清 session，浏览器端还会 reLaunch 登录页）。
+        // 账户未连接、未分配额度都与登录无关，文案撞上就会把用户踢出去。
+        String[] loginMarkers = {"登录", "未授权", "请先"};
+
+        AccountService notConnected = service();
+        String notConnectedMsg = assertThrows(AccountException.class, notConnected::fetchProfile).getMessage();
+
+        AccountService service = connected();
+        transport.enqueue(409, "{\"error\":\"no_allocation\"}");
+        String noAllocationMsg = assertThrows(AccountException.class, service::fetchAiKey).getMessage();
+
+        for (String marker : loginMarkers) {
+            assertFalse(notConnectedMsg.contains(marker), notConnectedMsg + " 含 " + marker);
+            assertFalse(noAllocationMsg.contains(marker), noAllocationMsg + " 含 " + marker);
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -213,6 +213,28 @@ class AccountServiceTest {
     }
 
     @Test
+    @DisplayName("ai-usage：返回额度三个数，hasKey 区分「未分配额度」")
+    void aiUsageReturnsQuota() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"configured\":true,\"hasKey\":true,"
+                + "\"limitUsd\":5.0,\"usageUsd\":1.25,\"remainingUsd\":3.75}");
+        Map<String, Object> body = service.fetchAiUsage();
+        assertEquals("GET https://www.aiworkdeck.com/api/account/ai-usage",
+                transport.calls.get(transport.calls.size() - 1));
+        assertEquals(Boolean.TRUE, body.get("hasKey"));
+        assertEquals(3.75, ((Number) body.get("remainingUsd")).doubleValue(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("ai-usage 端点不存在（旧官网）：抛 MALFORMED 由调用方降级，不拖垮整个用量面板")
+    void aiUsageMissingEndpointIsRecoverable() {
+        AccountService service = connected();
+        transport.enqueue(404, "{}");
+        AccountException e = assertThrows(AccountException.class, service::fetchAiUsage);
+        assertEquals(AccountException.Kind.MALFORMED, e.getKind());
+    }
+
+    @Test
     @DisplayName("官网返回非 JSON：分类为 MALFORMED，不当成鉴权失败")
     void malformedBodyIsClassified() {
         AccountService service = connected();
@@ -229,5 +251,20 @@ class AccountServiceTest {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> new AccountService("http://www.aiworkdeck.com", tempDir.toString(), new StubTransport()));
         assertTrue(e.getMessage().contains("https"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("回环 http 放行：本地起官网联调用，流量不出本机网卡")
+    void loopbackHttpAllowed() {
+        assertDoesNotThrow(() -> new AccountService("http://localhost:3000", tempDir.toString(), new StubTransport()));
+        assertDoesNotThrow(() -> new AccountService("http://127.0.0.1:3000", tempDir.toString(), new StubTransport()));
+    }
+
+    @Test
+    @DisplayName("尾部斜杠归一化：不能拼出 //api/account/me")
+    void trailingSlashStripped() {
+        transport = new StubTransport().enqueue(200, "{\"username\":\"u\"}");
+        new AccountService("https://www.aiworkdeck.com/", tempDir.toString(), transport).connect(KEY);
+        assertEquals("GET https://www.aiworkdeck.com/api/account/me", transport.calls.get(0));
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
@@ -31,6 +31,7 @@ class ChatModelFactoryTest {
     private AiModelProperties properties;
     private SystemSettingService systemSettingService;
     private ChatModelFactory factory;
+    private PlatformAiChannel platformAiChannel;
 
     @BeforeEach
     void setUp() {
@@ -40,7 +41,8 @@ class ChatModelFactoryTest {
         // 默认：DB 无该配置时返回调用方给的默认值
         when(systemSettingService.get(anyString(), any()))
                 .thenAnswer(inv -> inv.getArgument(1));
-        factory = new ChatModelFactory(properties, systemSettingService);
+        platformAiChannel = mock(PlatformAiChannel.class);
+        factory = new ChatModelFactory(properties, systemSettingService, platformAiChannel);
     }
 
     private void setDbProvider(String provider) {
@@ -142,5 +144,35 @@ class ChatModelFactoryTest {
         for (String id : required) {
             assertTrue(AllowedModels.isAllowed(id), "白名单缺失: " + id);
         }
+    }
+
+    // ==================== 平台通道「AI Workdeck 云端」（PR-B） ====================
+
+    @Test
+    @DisplayName("AWD_CLOUD：即便是白名单模型也走平台密钥，不能落到 BYOK 的 OpenRouter key")
+    void platformChannelTakesPrecedenceOverAllowlistShortcut() {
+        setDbProvider("AWD_CLOUD");
+        when(platformAiChannel.isAvailable()).thenReturn(true);
+        when(platformAiChannel.apiKey()).thenReturn("sk-or-provisioned");
+        when(platformAiChannel.keyFingerprint()).thenReturn("abc123");
+
+        assertInstanceOf(OpenAiChatModel.class, factory.getChatModel("openai/gpt-5.2"));
+        assertInstanceOf(OpenAiStreamingChatModel.class, factory.getStreamingChatModel("openai/gpt-5.2"));
+        // 白名单短路分支绝不能先命中——那条路用的是 BYOK 的 key
+        verify(platformAiChannel, atLeastOnce()).apiKey();
+        verify(systemSettingService, never()).get(eq("external.openrouter.apiKey"), any());
+    }
+
+    @Test
+    @DisplayName("AWD_CLOUD 但未连接账户：明确报错，不静默回退 BYOK 花用户自己的 key")
+    void platformChannelWithoutAccountFailsLoudly() {
+        setDbProvider("AWD_CLOUD");
+        when(platformAiChannel.isAvailable()).thenReturn(false);
+
+        var e = assertThrows(com.checkba.service.account.AccountException.class,
+                () -> factory.getChatModel("deepseek/deepseek-v4-flash"));
+        assertEquals(com.checkba.service.account.AccountException.Kind.NOT_CONNECTED, e.getKind());
+        assertTrue(e.getMessage().contains("连接账户"), e.getMessage());
+        verify(platformAiChannel, never()).apiKey();
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
@@ -32,6 +32,7 @@ class ChatModelFactoryTest {
     private SystemSettingService systemSettingService;
     private ChatModelFactory factory;
     private PlatformAiChannel platformAiChannel;
+    private PlatformUsageAccountant usageAccountant;
 
     @BeforeEach
     void setUp() {
@@ -42,7 +43,8 @@ class ChatModelFactoryTest {
         when(systemSettingService.get(anyString(), any()))
                 .thenAnswer(inv -> inv.getArgument(1));
         platformAiChannel = mock(PlatformAiChannel.class);
-        factory = new ChatModelFactory(properties, systemSettingService, platformAiChannel);
+        usageAccountant = mock(PlatformUsageAccountant.class);
+        factory = new ChatModelFactory(properties, systemSettingService, platformAiChannel, usageAccountant);
     }
 
     private void setDbProvider(String provider) {
@@ -174,5 +176,47 @@ class ChatModelFactoryTest {
         assertEquals(com.checkba.service.account.AccountException.Kind.NOT_CONNECTED, e.getKind());
         assertTrue(e.getMessage().contains("连接账户"), e.getMessage());
         verify(platformAiChannel, never()).apiKey();
+    }
+
+    @Test
+    @DisplayName("平台通道用之前先建用量基线：否则重启后第一条消息永远显示「待结算」")
+    void platformChannelEstablishesUsageBaselineBeforeCall() {
+        setDbProvider("AWD_CLOUD");
+        when(platformAiChannel.isAvailable()).thenReturn(true);
+        when(platformAiChannel.apiKey()).thenReturn("sk-or-provisioned");
+        when(platformAiChannel.keyFingerprint()).thenReturn("abc123");
+
+        factory.getStreamingChatModel("openai/gpt-5.2");
+        verify(usageAccountant, atLeastOnce()).ensureBaselineAsync();
+    }
+
+    @Test
+    @DisplayName("断开账户：activeProvider 从平台通道切到还配着 key 的 OpenRouter")
+    void demoteFallsBackToConfiguredOpenRouter() {
+        setDbProvider("AWD_CLOUD");
+        when(systemSettingService.get(eq("external.openrouter.apiKey"), any())).thenReturn("sk-or-db-key");
+
+        assertEquals("OPENROUTER", factory.demotePlatformProvider());
+        verify(systemSettingService).set("ai.activeProvider", "OPENROUTER");
+    }
+
+    @Test
+    @DisplayName("断开账户且没有任何云端 key：落到本地 Ollama（而不是留在打不通的平台通道）")
+    void demoteFallsBackToOllamaWhenNothingConfigured() {
+        properties.getOpenRouter().setApiKey("");
+        properties.getGemini().setApiKey("");
+        setDbProvider("AWD_CLOUD");
+
+        assertEquals("OLLAMA", factory.demotePlatformProvider());
+        verify(systemSettingService).set("ai.activeProvider", "OLLAMA");
+    }
+
+    @Test
+    @DisplayName("当前供应商不是平台通道：断开账户不动用户的选择")
+    void demoteLeavesOtherProvidersAlone() {
+        setDbProvider("OPENROUTER");
+
+        assertNull(factory.demotePlatformProvider());
+        verify(systemSettingService, never()).set(eq("ai.activeProvider"), anyString());
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/PlatformUsageAccountantTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformUsageAccountantTest.java
@@ -1,0 +1,121 @@
+package com.checkba.service.ai;
+
+import com.checkba.model.entity.TokenUsage;
+import com.checkba.repository.TokenUsageRepository;
+import com.checkba.service.account.AccountTransport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * 平台通道真实花费对账：差分口径（相邻两次累计消费之差）。
+ * 这里算的是真花的钱，写错就是账不平——首次只建基线、采不到就不写、非正差分不写。
+ */
+class PlatformUsageAccountantTest {
+
+    private TokenUsageRepository repository;
+    private PlatformAiChannel channel;
+    private Deque<AccountTransport.Reply> replies;
+    private PlatformUsageAccountant accountant;
+    private TokenUsage row;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(TokenUsageRepository.class);
+        channel = mock(PlatformAiChannel.class);
+        when(channel.apiKey()).thenReturn("sk-or-v1-provisioned");
+
+        row = new TokenUsage();
+        row.setId(7L);
+        row.setCostSource("platform");
+        when(repository.findById(7L)).thenReturn(Optional.of(row));
+
+        replies = new ArrayDeque<>();
+        AccountTransport transport = (method, url, bearer, body) -> {
+            assertEquals("https://openrouter.ai/api/v1/key", url);
+            assertEquals("sk-or-v1-provisioned", bearer);
+            return replies.isEmpty()
+                    ? new AccountTransport.Reply(AccountTransport.Reply.NETWORK_FAILURE, null)
+                    : replies.poll();
+        };
+        accountant = new PlatformUsageAccountant(repository, channel, transport,
+                "https://openrouter.ai/api/v1");
+        accountant.setPollIntervalMsForTest(1L);
+    }
+
+    private void usage(double cumulative) {
+        replies.add(new AccountTransport.Reply(200,
+                "{\"data\":{\"usage\":" + cumulative + ",\"limit\":10.0,\"limit_remaining\":9.0}}"));
+    }
+
+    @Test
+    @DisplayName("首次对账只建基线：之前的消费不属于这条记录")
+    void firstCallOnlyEstablishesBaseline() {
+        usage(1.25);
+        accountant.reconcile(7L);
+        verify(repository, never()).save(any());
+        assertNull(row.getCost());
+    }
+
+    @Test
+    @DisplayName("第二次对账写入差分作为真实花费")
+    void deltaBecomesCost() {
+        accountant.setBaselineForTest(new BigDecimal("1.250000"));
+        usage(1.28);
+        accountant.reconcile(7L);
+
+        verify(repository).save(row);
+        assertEquals(0, new BigDecimal("0.03").compareTo(row.getCost()), "cost=" + row.getCost());
+        assertEquals("platform", row.getCostSource());
+    }
+
+    @Test
+    @DisplayName("OpenRouter 记账有延迟：重采样直到数字变动")
+    void retriesUntilUsageMoves() {
+        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        usage(1.00); // 还没记上
+        usage(1.00);
+        usage(1.02); // 记上了
+        accountant.reconcile(7L);
+
+        assertEquals(0, new BigDecimal("0.02").compareTo(row.getCost()));
+    }
+
+    @Test
+    @DisplayName("采样一直不动：不写 cost（宁可留空也不写假数字）")
+    void noMovementLeavesCostNull() {
+        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        for (int i = 0; i < 6; i++) usage(1.00);
+        accountant.reconcile(7L);
+
+        verify(repository, never()).save(any());
+        assertNull(row.getCost());
+    }
+
+    @Test
+    @DisplayName("采样失败（断网/被禁用）：静默跳过，绝不影响对话")
+    void probeFailureIsSilent() {
+        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        // replies 为空 → 桩返回 NETWORK_FAILURE
+        assertDoesNotThrow(() -> accountant.reconcile(7L));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("未连接账户（拿不到平台 key）：跳过，不发请求")
+    void skipsWhenNoPlatformKey() {
+        when(channel.apiKey()).thenThrow(new IllegalStateException("not connected"));
+        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        assertDoesNotThrow(() -> accountant.reconcile(7L));
+        verify(repository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PlatformUsageAccountantTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformUsageAccountantTest.java
@@ -118,4 +118,35 @@ class PlatformUsageAccountantTest {
         assertDoesNotThrow(() -> accountant.reconcile(7L));
         verify(repository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("换账户必须重置基线：否则两把 key 的累计差会整个记到下一条消息头上")
+    void resetBaselineDropsPreviousKeysCumulative() {
+        // 账户 A 的累计是 0.02，账户 B 的累计是 5.00
+        accountant.setBaselineForTest(new BigDecimal("0.02"));
+        accountant.resetBaseline();
+
+        usage(5.00);
+        accountant.reconcile(7L);
+        // 重置后第一次只重新建基线，不会把 4.98 写成这条消息的花费
+        verify(repository, never()).save(any());
+        assertNull(row.getCost());
+
+        usage(5.01);
+        accountant.reconcile(7L);
+        assertEquals(0, new BigDecimal("0.01").compareTo(row.getCost()), "cost=" + row.getCost());
+    }
+
+    @Test
+    @DisplayName("请求前建基线：随后第一条消息就能算出差分，不再永久「待结算」")
+    void ensureBaselineMakesFirstMessageBillable() throws Exception {
+        usage(2.00); // ensureBaseline 采到的
+        accountant.ensureBaselineAsync();
+        // 单线程 worker：等基线任务跑完
+        for (int i = 0; i < 100 && !replies.isEmpty(); i++) Thread.sleep(10);
+
+        usage(2.05); // 这条消息之后的累计
+        accountant.reconcile(7L);
+        assertEquals(0, new BigDecimal("0.05").compareTo(row.getCost()), "cost=" + row.getCost());
+    }
 }

--- a/backend/src/test/java/com/checkba/service/entitlement/EntitlementServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/entitlement/EntitlementServiceTest.java
@@ -1,0 +1,214 @@
+package com.checkba.service.entitlement;
+
+import com.checkba.service.LicenseService;
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定权益合并与宽限契约（Spec §6）：
+ * - 来源是并集：本地票据（试用码解锁 → app.unlocked）∪ 账户同步结果；
+ * - 账户型权益断网 30 天宽限，**超期回落为「未拥有」**（不是保持拥有，否则永久离线=永久买断）；
+ * - 本地票据不吃宽限（试用码离线验签，本就不需要联网）；
+ * - 刷新失败不抛异常（启动期异步刷新绝不能拖垮启动）。
+ */
+class EntitlementServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private LicenseService licenseService;
+    private AccountService accountService;
+
+    @BeforeEach
+    void setUp() {
+        licenseService = mock(LicenseService.class);
+        accountService = mock(AccountService.class);
+        when(licenseService.status()).thenReturn(Map.of("unlocked", false, "mode", "none"));
+        when(accountService.isConnected()).thenReturn(false);
+    }
+
+    private EntitlementService service() {
+        return new EntitlementService(licenseService, accountService, tempDir.toString());
+    }
+
+    private void writeCache(Instant syncedAt, String... features) throws Exception {
+        String list = String.join(",", java.util.Arrays.stream(features).map(f -> "\"" + f + "\"").toList());
+        Files.writeString(tempDir.resolve("entitlements.json"),
+                "{\"syncedAt\":\"" + syncedAt + "\",\"features\":[" + list + "]}", StandardCharsets.UTF_8);
+    }
+
+    // ==================== 合并 ====================
+
+    @Test
+    @DisplayName("全新安装：什么都没有")
+    void freshInstallHasNothing() {
+        EntitlementService svc = service();
+        assertFalse(svc.isEnabled(FeatureCatalog.APP_UNLOCKED));
+        assertFalse(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+        assertFalse(svc.isEnabled(null));
+        assertFalse(svc.isEnabled(""));
+    }
+
+    @Test
+    @DisplayName("本地票据：试用码解锁只给 app.unlocked，不给付费 SKU")
+    void localTicketOnlyUnlocksApp() {
+        when(licenseService.status()).thenReturn(Map.of("unlocked", true, "mode", "trial"));
+        EntitlementService svc = service();
+        assertTrue(svc.isEnabled(FeatureCatalog.APP_UNLOCKED));
+        // 试用版同样受免费额度约束（Spec §5）
+        assertFalse(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+        assertFalse(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
+    }
+
+    @Test
+    @DisplayName("并集：本地票据 ∪ 账户同步，两边各自生效")
+    void sourcesAreUnioned() throws Exception {
+        when(licenseService.status()).thenReturn(Map.of("unlocked", true, "mode", "trial"));
+        writeCache(Instant.now(), FeatureCatalog.CLIPBOARD_UNLIMITED, "skill:due-diligence");
+
+        EntitlementService svc = service();
+        assertTrue(svc.isEnabled(FeatureCatalog.APP_UNLOCKED), "来自本地票据");
+        assertTrue(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED), "来自账户同步");
+        assertTrue(svc.isEnabled("skill:due-diligence"), "动态权益（付费 Skill）也走同一出口");
+        assertFalse(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
+    }
+
+    @Test
+    @DisplayName("账户同步也能给 app.unlocked（账户 Key 即正式版）")
+    void accountCanGrantAppUnlocked() throws Exception {
+        writeCache(Instant.now(), FeatureCatalog.APP_UNLOCKED);
+        assertTrue(service().isEnabled(FeatureCatalog.APP_UNLOCKED));
+    }
+
+    // ==================== 宽限 ====================
+
+    @Test
+    @DisplayName("29 天未同步：账户型权益仍在宽限内")
+    void withinGraceStillOwned() throws Exception {
+        writeCache(Instant.now().minus(Duration.ofDays(29)), FeatureCatalog.STAGE_UNLIMITED);
+        EntitlementService svc = service();
+        assertTrue(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
+        assertEquals(false, svc.snapshot().get("stale"));
+    }
+
+    @Test
+    @DisplayName("31 天未同步：账户型权益整体回落为未拥有，本地票据不受影响")
+    void beyondGraceFallsBackToNotOwned() throws Exception {
+        when(licenseService.status()).thenReturn(Map.of("unlocked", true, "mode", "trial"));
+        writeCache(Instant.now().minus(Duration.ofDays(31)),
+                FeatureCatalog.STAGE_UNLIMITED, FeatureCatalog.CLIPBOARD_UNLIMITED);
+
+        EntitlementService svc = service();
+        assertFalse(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
+        assertFalse(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+        assertTrue(svc.isEnabled(FeatureCatalog.APP_UNLOCKED), "本地票据是离线验签的，不吃宽限");
+        assertEquals(true, svc.snapshot().get("stale"));
+    }
+
+    @Test
+    @DisplayName("缓存文件损坏：按无账户权益处理，不抛异常")
+    void corruptCacheTreatedAsEmpty() throws Exception {
+        Files.writeString(tempDir.resolve("entitlements.json"), "{not json", StandardCharsets.UTF_8);
+        assertFalse(service().isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+    }
+
+    // ==================== 刷新与快照 ====================
+
+    @Test
+    @DisplayName("刷新：写入缓存并即时生效")
+    void refreshWritesCache() {
+        when(accountService.isConnected()).thenReturn(true);
+        when(accountService.fetchEntitlements()).thenReturn(List.of(
+                Map.of("feature", FeatureCatalog.CLIPBOARD_UNLIMITED, "orderId", "o1"),
+                Map.of("feature", "plugin:shareholder-meeting", "orderId", "o2")));
+
+        EntitlementService svc = service();
+        assertTrue(svc.refreshQuietly());
+        assertTrue(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+        assertTrue(svc.isEnabled("plugin:shareholder-meeting"));
+    }
+
+    @Test
+    @DisplayName("刷新失败（断网）：吞掉异常并保留既有缓存，走宽限")
+    void refreshFailureKeepsCache() throws Exception {
+        writeCache(Instant.now().minus(Duration.ofDays(2)), FeatureCatalog.STAGE_UNLIMITED);
+        when(accountService.isConnected()).thenReturn(true);
+        when(accountService.fetchEntitlements())
+                .thenThrow(new AccountException(AccountException.Kind.NETWORK, "无法连接 AI Workdeck 服务器"));
+
+        EntitlementService svc = service();
+        assertFalse(svc.refreshQuietly());
+        assertTrue(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED), "断网不该把已购权益吃掉");
+    }
+
+    @Test
+    @DisplayName("未连接账户：刷新直接跳过，不发请求")
+    void refreshSkippedWhenNotConnected() {
+        assertFalse(service().refreshQuietly());
+        verify(accountService, never()).fetchEntitlements();
+    }
+
+    @Test
+    @DisplayName("断开连接：账户型权益立刻清空，本地票据保留")
+    void disconnectClearsAccountFeaturesOnly() throws Exception {
+        when(licenseService.status()).thenReturn(Map.of("unlocked", true, "mode", "trial"));
+        writeCache(Instant.now(), FeatureCatalog.CLIPBOARD_UNLIMITED);
+
+        EntitlementService svc = service();
+        svc.clearAccountCache();
+        assertFalse(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+        assertTrue(svc.isEnabled(FeatureCatalog.APP_UNLOCKED));
+    }
+
+    @Test
+    @DisplayName("快照 features 只含已拥有的：前端把「出现在列表里」当已拥有，混进未拥有项等于全解锁")
+    @SuppressWarnings("unchecked")
+    void snapshotFeaturesContainsOwnedOnly() throws Exception {
+        when(licenseService.status()).thenReturn(Map.of("unlocked", true, "mode", "trial"));
+        when(accountService.isConnected()).thenReturn(true);
+        writeCache(Instant.now(), FeatureCatalog.CLIPBOARD_UNLIMITED, "skill:due-diligence");
+
+        Map<String, Object> snapshot = service().snapshot();
+        List<Map<String, Object>> owned = (List<Map<String, Object>>) snapshot.get("features");
+
+        assertEquals(
+                List.of(FeatureCatalog.APP_UNLOCKED, FeatureCatalog.CLIPBOARD_UNLIMITED, "skill:due-diligence"),
+                owned.stream().map(f -> f.get("feature")).toList());
+        owned.forEach(f -> assertEquals(true, f.get("enabled"), f + " 出现在 features 里就必须是已拥有"));
+        assertEquals("local", owned.get(0).get("source"));
+        assertEquals("account", owned.get(1).get("source"));
+        assertEquals(true, snapshot.get("accountConnected"));
+    }
+
+    @Test
+    @DisplayName("快照 catalog 是目录全集带 enabled 标志（设置页「已有/去购买」用）")
+    @SuppressWarnings("unchecked")
+    void snapshotCatalogCoversWholeDirectory() throws Exception {
+        writeCache(Instant.now(), FeatureCatalog.CLIPBOARD_UNLIMITED);
+
+        List<Map<String, Object>> catalog =
+                (List<Map<String, Object>>) service().snapshot().get("catalog");
+        assertEquals(FeatureCatalog.all().size(), catalog.size());
+
+        Map<String, Object> pro = catalog.stream()
+                .filter(f -> FeatureCatalog.PLAN_PRO.equals(f.get("feature"))).findFirst().orElseThrow();
+        assertEquals(false, pro.get("enabled"));
+        assertEquals("none", pro.get("source"));
+        assertEquals("Pro 订阅", pro.get("displayName"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/entitlement/EntitlementServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/entitlement/EntitlementServiceTest.java
@@ -46,10 +46,18 @@ class EntitlementServiceTest {
         return new EntitlementService(licenseService, accountService, tempDir.toString());
     }
 
+    /** 账户型权益只在账户仍连接时生效，所以写缓存的用例都得先把连接立起来。 */
     private void writeCache(Instant syncedAt, String... features) throws Exception {
+        when(accountService.isConnected()).thenReturn(true);
         String list = String.join(",", java.util.Arrays.stream(features).map(f -> "\"" + f + "\"").toList());
         Files.writeString(tempDir.resolve("entitlements.json"),
                 "{\"syncedAt\":\"" + syncedAt + "\",\"features\":[" + list + "]}", StandardCharsets.UTF_8);
+    }
+
+    /** 缓存陈旧时快照会顺手起一次后台刷新；单测里让它确定性失败，免得干扰断言。 */
+    private void networkDown() {
+        when(accountService.fetchEntitlements())
+                .thenThrow(new AccountException(AccountException.Kind.NETWORK, "无法连接 AI Workdeck 服务器"));
     }
 
     // ==================== 合并 ====================
@@ -101,6 +109,7 @@ class EntitlementServiceTest {
     @DisplayName("29 天未同步：账户型权益仍在宽限内")
     void withinGraceStillOwned() throws Exception {
         writeCache(Instant.now().minus(Duration.ofDays(29)), FeatureCatalog.STAGE_UNLIMITED);
+        networkDown();
         EntitlementService svc = service();
         assertTrue(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
         assertEquals(false, svc.snapshot().get("stale"));
@@ -112,6 +121,7 @@ class EntitlementServiceTest {
         when(licenseService.status()).thenReturn(Map.of("unlocked", true, "mode", "trial"));
         writeCache(Instant.now().minus(Duration.ofDays(31)),
                 FeatureCatalog.STAGE_UNLIMITED, FeatureCatalog.CLIPBOARD_UNLIMITED);
+        networkDown();
 
         EntitlementService svc = service();
         assertFalse(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
@@ -123,6 +133,8 @@ class EntitlementServiceTest {
     @Test
     @DisplayName("缓存文件损坏：按无账户权益处理，不抛异常")
     void corruptCacheTreatedAsEmpty() throws Exception {
+        when(accountService.isConnected()).thenReturn(true);
+        networkDown();
         Files.writeString(tempDir.resolve("entitlements.json"), "{not json", StandardCharsets.UTF_8);
         assertFalse(service().isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
     }
@@ -147,13 +159,65 @@ class EntitlementServiceTest {
     @DisplayName("刷新失败（断网）：吞掉异常并保留既有缓存，走宽限")
     void refreshFailureKeepsCache() throws Exception {
         writeCache(Instant.now().minus(Duration.ofDays(2)), FeatureCatalog.STAGE_UNLIMITED);
-        when(accountService.isConnected()).thenReturn(true);
-        when(accountService.fetchEntitlements())
-                .thenThrow(new AccountException(AccountException.Kind.NETWORK, "无法连接 AI Workdeck 服务器"));
+        networkDown();
 
         EntitlementService svc = service();
         assertFalse(svc.refreshQuietly());
         assertTrue(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED), "断网不该把已购权益吃掉");
+    }
+
+    @Test
+    @DisplayName("官网明确拒绝（Key 已吊销）：立刻清缓存，不吃 30 天宽限")
+    void unauthorizedClearsCacheImmediately() throws Exception {
+        writeCache(Instant.now(), FeatureCatalog.CLIPBOARD_UNLIMITED, "skill:due-diligence");
+        when(accountService.fetchEntitlements()).thenThrow(
+                new AccountException(AccountException.Kind.UNAUTHORIZED, "账户 Key 无效或已被撤销"));
+
+        EntitlementService svc = service();
+        assertTrue(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED), "前提：吊销前是有的");
+        assertFalse(svc.refreshQuietly());
+        assertFalse(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED),
+                "吊销 Key 后付费功能不能再撑 30 天");
+        assertFalse(svc.isEnabled("skill:due-diligence"));
+    }
+
+    @Test
+    @DisplayName("未连接账户：即便本地有一份 entitlements.json 也不生效")
+    void cacheIgnoredWhenAccountNotConnected() throws Exception {
+        writeCache(Instant.now(), FeatureCatalog.CLIPBOARD_UNLIMITED, FeatureCatalog.STAGE_UNLIMITED);
+        when(accountService.isConnected()).thenReturn(false);
+
+        EntitlementService svc = service();
+        assertFalse(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED));
+        assertFalse(svc.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
+    }
+
+    @Test
+    @DisplayName("缓存陈旧：快照顺手起一次后台刷新（长期不重启的实例也能拿到新购权益）")
+    void staleSnapshotTriggersRefresh() throws Exception {
+        writeCache(Instant.now().minus(Duration.ofHours(2)), FeatureCatalog.STAGE_UNLIMITED);
+        when(accountService.fetchEntitlements()).thenReturn(List.of(
+                Map.of("feature", FeatureCatalog.STAGE_UNLIMITED),
+                Map.of("feature", FeatureCatalog.CLIPBOARD_UNLIMITED)));
+
+        EntitlementService svc = service();
+        svc.snapshot();
+        // 刷新是后台线程，给它一点时间落盘
+        for (int i = 0; i < 50 && !svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED); i++) {
+            Thread.sleep(20);
+        }
+        assertTrue(svc.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED),
+                "陈旧缓存应触发同步，官网上刚买的功能不该等到重启才生效");
+    }
+
+    @Test
+    @DisplayName("缓存新鲜：快照不发请求（避免设置页每次打开都打一次官网）")
+    void freshSnapshotDoesNotRefresh() throws Exception {
+        writeCache(Instant.now(), FeatureCatalog.STAGE_UNLIMITED);
+
+        service().snapshot();
+        Thread.sleep(50);
+        verify(accountService, never()).fetchEntitlements();
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/entitlement/FeatureCatalogTest.java
+++ b/backend/src/test/java/com/checkba/service/entitlement/FeatureCatalogTest.java
@@ -1,0 +1,45 @@
+package com.checkba.service.entitlement;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 功能目录是**跨仓契约**：官网 doc/desktop-contract.md「权益命名」一节按同一张表
+ * 校验兑换码白名单，名字对不上就是发出去的码兑不了、买了的权益桌面端不认。
+ * 改这里的字面量前先确认官网侧同步。
+ */
+class FeatureCatalogTest {
+
+    @Test
+    @DisplayName("feature 名字面量锁定（与官网契约逐字一致）")
+    void featureNamesAreFrozen() {
+        assertEquals("app.unlocked", FeatureCatalog.APP_UNLOCKED);
+        assertEquals("clipboard.unlimited", FeatureCatalog.CLIPBOARD_UNLIMITED);
+        assertEquals("stage.unlimited", FeatureCatalog.STAGE_UNLIMITED);
+        assertEquals("plan.pro", FeatureCatalog.PLAN_PRO);
+    }
+
+    @Test
+    @DisplayName("目录内容与顺序锁定")
+    void catalogContents() {
+        assertEquals(
+                List.of("app.unlocked", "clipboard.unlimited", "stage.unlimited", "plan.pro"),
+                List.copyOf(FeatureCatalog.all()));
+    }
+
+    @Test
+    @DisplayName("每项都有中文展示名；未知 feature 原样返回")
+    void displayNames() {
+        for (String feature : FeatureCatalog.all()) {
+            assertNotEquals(feature, FeatureCatalog.displayName(feature),
+                    feature + " 缺中文展示名");
+        }
+        // 付费 Skill / 插件是动态权益，不在目录里
+        assertFalse(FeatureCatalog.isKnown("skill:due-diligence"));
+        assertEquals("skill:due-diligence", FeatureCatalog.displayName("skill:due-diligence"));
+    }
+}

--- a/frontend/src/components/UnlockHint.vue
+++ b/frontend/src/components/UnlockHint.vue
@@ -1,0 +1,74 @@
+<template>
+  <view class="unlock-hint">
+    <text class="unlock-hint-text">{{ text }}</text>
+    <text class="unlock-hint-link" @tap.stop="onLearnMore">{{ linkText }}</text>
+  </view>
+</template>
+
+<script>
+// 「解锁」引导：功能触达免费额度上限时的统一行内提示。
+// 只提示与外链，不做拦截——是否拦、拦在哪由调用方自己判断（配合 useEntitlement）。
+// 语气克制：用户没做错事，只是碰到了额度边界。
+import { openExternalUrl } from '@/utils/externalLink.js'
+
+// 官网账户页：解锁 SKU 的购买入口都挂在这里
+const DEFAULT_LINK_URL = 'https://www.aiworkdeck.com/zh/account'
+
+export default {
+  name: 'UnlockHint',
+  props: {
+    // 提示正文，例如「免费版最多回溯 20 条剪贴记录」
+    text: {
+      type: String,
+      required: true,
+    },
+    linkText: {
+      type: String,
+      default: '了解详情',
+    },
+    // 外链地址；走系统浏览器（桌面端 window.open 会被主进程吞掉）
+    linkUrl: {
+      type: String,
+      default: DEFAULT_LINK_URL,
+    },
+  },
+  methods: {
+    onLearnMore() {
+      openExternalUrl(this.linkUrl)
+    },
+  },
+}
+</script>
+
+<style scoped>
+/* 浅色体系：与顶栏「试用版」chip 同一族暖色，避免做成刺眼的警告条 */
+.unlock-hint {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 10px;
+  background: #fdf7ec;
+  border: 1px solid #ecdfc3;
+  border-radius: 4px;
+}
+
+.unlock-hint-text {
+  font-size: 12px;
+  line-height: 18px;
+  color: #8a6d2f;
+}
+
+.unlock-hint-link {
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 500;
+  color: #1a5336;
+  cursor: pointer;
+}
+
+.unlock-hint-link:hover {
+  color: #2d7a52;
+  text-decoration: underline;
+}
+</style>

--- a/frontend/src/composables/useEntitlement.js
+++ b/frontend/src/composables/useEntitlement.js
@@ -49,15 +49,19 @@ export function refreshEntitlements(force = false) {
   }
   const p = (async () => {
     try {
-      const res = await getEntitlements()
+      // force 时让后端先同步一次官网：用户刚连接账户、或刚在官网买完回来，
+      // 只重读后端本地缓存是拿不到新权益的
+      const res = await getEntitlements(force)
       features.value = normalize(res && res.features)
+      // loaded 只在成功时置位。失败也置位会把「后端还没起来」那一次的空结果
+      // 变成整个进程生命周期的「没有任何付费功能」，只有显式 refresh(true) 能救
+      loaded.value = true
     } catch (e) {
       // 未连接账户、旧后端没有该端点、离线：一律视为无附加权益。
       // 这里不弹提示——权益缺失的引导由 UnlockHint 在具体功能处给，
       // 在这里报错会变成打开任意页面都弹窗。
       features.value = []
     } finally {
-      loaded.value = true
       if (inflight === p) inflight = null
     }
     return features.value

--- a/frontend/src/composables/useEntitlement.js
+++ b/frontend/src/composables/useEntitlement.js
@@ -1,0 +1,91 @@
+// 功能权益（entitlement）前端出口。
+//
+// 单一数据源是后端 GET /api/entitlements（本地票据 ∪ 账户同步结果，合并逻辑在后端
+// EntitlementService）。前端这层只做两件事：模块级缓存（整个应用只拉一次，多个组件
+// 共享同一份 ref 与同一个在途请求），以及一个稳定的 isEnabled(feature) 出口。
+//
+// 用法：
+//   import { useEntitlement, FEATURES } from '@/composables/useEntitlement.js'
+//   const { isEnabled, refresh } = useEntitlement()
+//   if (!isEnabled(FEATURES.CLIPBOARD_UNLIMITED)) { ...走免费额度... }
+// 也可以传功能名拿到该功能的响应式布尔：
+//   const { enabled } = useEntitlement(FEATURES.STAGE_UNLIMITED)
+//
+// 账户连接状态变化后（设置页连接/断开）必须调 refresh(true) 让缓存失效。
+import { computed, ref } from 'vue'
+import { getEntitlements } from '@/services/api.js'
+
+// 功能目录：与后端 FeatureCatalog、官网 entitlements.feature 命名一一对应。
+// 新增 SKU 时三处同步改（桌面后端 / 官网 / 这里），否则会出现只有一边认得的权益名。
+export const FEATURES = {
+  APP_UNLOCKED: 'app.unlocked',
+  CLIPBOARD_UNLIMITED: 'clipboard.unlimited',
+  STAGE_UNLIMITED: 'stage.unlimited',
+}
+
+// 模块级单例状态（跨组件共享，页面栈多实例也只有一份）
+const features = ref([])
+const loaded = ref(false)
+let inflight = null
+
+// 后端可能返回字符串数组，也可能返回 { feature, purchasedAt, ... } 对象数组
+// （官网侧 entitlements 就是对象形态），两种都归一成字符串数组。
+function normalize(list) {
+  if (!Array.isArray(list)) return []
+  return list
+    .map((it) => (typeof it === 'string' ? it : it && it.feature))
+    .filter(Boolean)
+}
+
+/**
+ * 拉取权益清单。默认命中缓存直接返回；force=true 强制重取。
+ * @param {boolean} force 是否绕过缓存
+ * @returns {Promise<string[]>}
+ */
+export function refreshEntitlements(force = false) {
+  if (!force) {
+    if (inflight) return inflight
+    if (loaded.value) return Promise.resolve(features.value)
+  }
+  const p = (async () => {
+    try {
+      const res = await getEntitlements()
+      features.value = normalize(res && res.features)
+    } catch (e) {
+      // 未连接账户、旧后端没有该端点、离线：一律视为无附加权益。
+      // 这里不弹提示——权益缺失的引导由 UnlockHint 在具体功能处给，
+      // 在这里报错会变成打开任意页面都弹窗。
+      features.value = []
+    } finally {
+      loaded.value = true
+      if (inflight === p) inflight = null
+    }
+    return features.value
+  })()
+  inflight = p
+  return p
+}
+
+/**
+ * 某项功能是否已解锁。读的是响应式 features，可直接用在 computed / 模板里。
+ * @param {string} feature FEATURES 中的功能名
+ * @returns {boolean}
+ */
+export function isEnabled(feature) {
+  return !!feature && features.value.includes(feature)
+}
+
+/**
+ * @param {string} [feature] 可选：传入后额外返回该功能的响应式布尔 enabled
+ */
+export function useEntitlement(feature) {
+  // 惰性首拉：第一个用到权益的组件触发，后续组件命中缓存
+  if (!loaded.value && !inflight) refreshEntitlements()
+  return {
+    features,
+    loaded,
+    isEnabled,
+    refresh: refreshEntitlements,
+    enabled: computed(() => isEnabled(feature)),
+  }
+}

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -317,11 +317,12 @@
                     v-for="opt in aiProviderOptions"
                     :key="opt.value"
                     class="radio-item"
-                    :class="{ checked: form.ai.activeProvider === opt.value }"
-                    @tap="form.ai.activeProvider = opt.value"
+                    :class="{ checked: form.ai.activeProvider === opt.value, unavailable: opt.unavailable }"
+                    @tap="onPickProvider(opt)"
                   >
                     <view class="radio-dot"></view>
                     <text class="radio-label">{{ opt.label }}</text>
+                    <text v-if="opt.unavailable" class="radio-hint">需先连接账户</text>
                   </view>
                 </view>
               </view>
@@ -396,6 +397,132 @@
               保存配置
             </button>
           </view>
+        </scroll-view>
+
+        <!-- 账户与用量（仅桌面端：连接 AI Workdeck 账户、余额与 AI 额度） -->
+        <scroll-view
+          v-else-if="activeNav === 'account'"
+          scroll-y
+          class="config-scroll"
+        >
+          <!-- 未连接：引导去官网取 Key -->
+          <view v-if="!account.connected" class="section-card">
+            <view class="section-header">
+              <text class="section-title">账户与用量</text>
+              <text class="section-subtitle">
+                连接 AI Workdeck 账户后，可以使用平台 AI 通道、查看余额与用量，并同步已购插件与功能解锁
+              </text>
+            </view>
+            <view class="section-body">
+              <view class="provider-card">
+                <text class="account-intro">
+                  桌面端不需要注册登录。在官网账户页生成一枚账户 Key（awdk_ 开头），粘贴到下面即可完成连接；Key 保存在本机，随时可以断开。
+                </text>
+                <view class="account-link-row">
+                  <button class="comp-btn" @tap="openAccountSite">前往官网获取 Key</button>
+                </view>
+                <view class="form-row">
+                  <text class="form-label">账户 Key</text>
+                  <input
+                    v-model="accountKeyInput"
+                    class="form-input"
+                    placeholder="粘贴 awdk_ 开头的账户 Key"
+                  />
+                </view>
+                <view class="account-connect-actions">
+                  <button class="btn-primary" :disabled="accountBusy" @tap="onConnectAccount">
+                    {{ accountBusy ? '连接中...' : '连接账户' }}
+                  </button>
+                </view>
+              </view>
+            </view>
+          </view>
+
+          <!-- 已连接：账户信息 + AI 额度 + 本地用量明细 -->
+          <template v-else>
+            <view class="section-card">
+              <view class="section-header">
+                <text class="section-title">账户</text>
+                <text class="section-subtitle">当前本机已连接的 AI Workdeck 账户</text>
+              </view>
+              <view class="section-body">
+                <view class="provider-card">
+                  <view class="provider-header account-header">
+                    <view class="account-identity">
+                      <text class="provider-name">{{ account.displayName || account.username || '账户' }}</text>
+                      <text class="account-sub">{{ account.username }}<text v-if="accountPlanLabel"> · {{ accountPlanLabel }}</text></text>
+                    </view>
+                    <button class="comp-btn danger" @tap="onDisconnectAccount">断开连接</button>
+                  </view>
+                  <!-- 官网不可达：只降级平台数字，本地统计照常 -->
+                  <text v-if="!accountPlatformReachable" class="account-note">
+                    {{ (accountPlatform && accountPlatform.message) || '暂时无法连接 AI Workdeck 服务器，余额与额度稍后再试。本机连接未受影响。' }}
+                  </text>
+                  <template v-else>
+                    <view class="account-metrics">
+                      <view class="account-metric">
+                        <text class="account-metric-label">钱包余额</text>
+                        <text class="account-metric-value">{{ accountBalanceYuan }} 元</text>
+                      </view>
+                      <view class="account-metric">
+                        <text class="account-metric-label">AI 额度已用</text>
+                        <text class="account-metric-value">{{ quotaText(accountPlatform && accountPlatform.usageUsd) }}</text>
+                      </view>
+                      <view class="account-metric">
+                        <text class="account-metric-label">AI 额度剩余</text>
+                        <text class="account-metric-value">{{ quotaText(accountPlatform && accountPlatform.remainingUsd) }}</text>
+                      </view>
+                      <view class="account-metric">
+                        <text class="account-metric-label">AI 额度上限</text>
+                        <text class="account-metric-value">{{ quotaText(accountPlatform && accountPlatform.limitUsd) }}</text>
+                      </view>
+                    </view>
+                    <!-- 已连账户但没分配过额度：平台 AI 通道此时不可用，给明确的下一步 -->
+                    <text v-if="accountNeedsAllocation" class="account-note">
+                      尚未分配 AI 额度，暂时不能使用「AI Workdeck 云端」通道。请到官网账户页从余额分配额度后再回来。
+                    </text>
+                    <text v-else-if="!accountQuotaAvailable" class="account-note">
+                      AI 额度信息暂时取不到，稍后重试。
+                    </text>
+                  </template>
+                  <text class="account-note">
+                    余额用于充值与购买；AI 额度是从余额分配到平台 AI 通道的部分，在官网账户页分配。
+                  </text>
+                </view>
+              </view>
+            </view>
+
+            <view class="section-card">
+              <view class="section-header">
+                <text class="section-title">最近用量</text>
+                <text class="section-subtitle">
+                  本机记录的调用明细。自带 Key 的通道费用为本地估算，平台通道以实际扣费为准
+                </text>
+              </view>
+              <view class="section-body">
+                <view v-if="!accountUsageRows.length" class="empty">
+                  <text class="empty-text">暂无用量记录</text>
+                </view>
+                <view
+                  v-for="(row, idx) in accountUsageRows"
+                  :key="'usage-' + idx"
+                  class="usage-row"
+                >
+                  <view class="usage-main">
+                    <text class="usage-model">{{ row.model || '未知模型' }}</text>
+                    <text class="usage-time">
+                      {{ formatUsageTime(row.createdAt) }}
+                      <text v-if="usageSourceLabel(row)"> · {{ usageSourceLabel(row) }}</text>
+                    </text>
+                  </view>
+                  <view class="usage-numbers">
+                    <text class="usage-tokens">{{ row.totalTokens || 0 }} tokens</text>
+                    <text class="usage-cost">{{ usageCostText(row) }}</text>
+                  </view>
+                </view>
+              </view>
+            </view>
+          </template>
         </scroll-view>
 
         <!-- 组件管理（仅桌面端：本地模型下载与服务启用） -->
@@ -584,8 +711,14 @@
 import {
   getAdminConfig, saveAdminConfig, resetWizard,
   cloudConnect, listCloudConnections, disconnectCloudConnection,
+  getAccountStatus, connectAccount, disconnectAccount, getAccountUsage,
 } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
+import { openExternalUrl } from '@/utils/externalLink.js'
+import { refreshEntitlements } from '@/composables/useEntitlement.js'
+
+// 官网账户页：生成账户 Key、充值、分配 AI 额度都在这里
+const ACCOUNT_SITE_URL = 'https://www.aiworkdeck.com/zh/account'
 
 export default {
   name: 'AdminPage',
@@ -597,6 +730,7 @@ export default {
       navItems: [
         { key: 'config', label: '系统配置' },
         { key: 'ai', label: 'AI 功能设置' },
+        { key: 'account', label: '账户与用量', desktopOnly: true },
         { key: 'components', label: '组件管理', desktopOnly: true },
         { key: 'cloud', label: '云端协作', desktopOnly: true },
         { key: 'plugins', label: '插件广场', route: '/pages/plugin-market/plugin-market' },
@@ -620,11 +754,8 @@ export default {
           assistants: [],
         },
       },
-      aiProviderOptions: [
-        { value: 'OLLAMA', label: '本地 Ollama' },
-        { value: 'GEMINI', label: 'Google Gemini' },
-        { value: 'OPENROUTER', label: 'OpenRouter' },
-      ],
+      // 平台 AI 通道是否可选（= 是否已连接账户），来自 /api/account/status
+      platformAiAvailable: false,
       // Helpers
       defaultAssistants: [
         { id: 'default', name: '默认助手', tools: [], systemPrompt: '你是一个专业的助手。', description: 'Generic Assistant' },
@@ -646,6 +777,12 @@ export default {
       cloudConnections: [],
       cloudForm: { serverUrl: '', username: '', password: '' },
       cloudBusy: false,
+      // 账户与用量（商业化 PR-B）
+      // status 是纯本地读盘（不含余额），余额与额度都在 usage 的 platform 段
+      account: { connected: false, username: '', displayName: '', keyMasked: '' },
+      accountUsage: null, // { local: {...}, platform: {...} }，形状见 api.js getAccountUsage
+      accountKeyInput: '',
+      accountBusy: false,
     }
   },
   computed: {
@@ -659,14 +796,72 @@ export default {
     cloudServerUrlIsHttp() {
       return /^http:\/\//i.test((this.cloudForm.serverUrl || '').trim())
     },
+    // 供应商单选项。「AI Workdeck 云端」是平台计费通道，未连接账户时展示但不可选——
+    // 隐藏它会让用户根本发现不了这个选项，直接可选又会在发消息时才报「未连接账户」
+    aiProviderOptions() {
+      const options = [
+        { value: 'OLLAMA', label: '本地 Ollama' },
+        { value: 'GEMINI', label: 'Google Gemini' },
+        { value: 'OPENROUTER', label: 'OpenRouter' },
+      ]
+      if (this.isDesktop) {
+        options.push({
+          value: 'AWD_CLOUD',
+          label: 'AI Workdeck 云端',
+          // 已经选中的供应商不标不可选，否则用户会看到一个自相矛盾的界面
+          unavailable: !this.platformAiAvailable && this.form.ai.activeProvider !== 'AWD_CLOUD',
+        })
+      }
+      return options
+    },
+    // 平台结算段：官网不可达时 available=false，其余字段不可信
+    accountPlatform() {
+      return (this.accountUsage && this.accountUsage.platform) || null
+    },
+    accountPlatformReachable() {
+      return !!(this.accountPlatform && this.accountPlatform.available)
+    },
+    // 余额后端以整数分下发，展示统一转元
+    accountBalanceYuan() {
+      const cents = this.accountPlatform && this.accountPlatform.balanceCents
+      return ((Number(cents) || 0) / 100).toFixed(2)
+    },
+    accountPlanLabel() {
+      const plan = this.accountPlatform && this.accountPlatform.plan
+      if (plan === 'paid') return '付费账户'
+      if (plan === 'free') return '免费账户'
+      return ''
+    },
+    // 额度三个数只在实时口径拿得到时才展示——拿不到时显示「暂不可用」，
+    // 而不是把 0 当成真实剩余额度让用户以为额度用光了
+    accountQuotaAvailable() {
+      return !!(this.accountPlatform && this.accountPlatform.quotaAvailable)
+    },
+    // 已连账户但从未分配过 AI 额度：面板要给出「去官网分配」的引导
+    accountNeedsAllocation() {
+      return this.accountQuotaAvailable && !this.accountPlatform.hasAiQuota
+    },
+    accountUsageRows() {
+      const rows = this.accountUsage && this.accountUsage.local && this.accountUsage.local.recent
+      return Array.isArray(rows) ? rows : []
+    },
   },
-  onLoad() {
+  onLoad(query) {
     const user = getCurrentUser()
     if (user) {
       this.userDisplayName = user.displayName || user.username || '用户'
     }
+    // 深链定位面板（顶栏「已连接账户」chip → ?nav=account）；
+    // 只认当前可见的本页面板，route 型导航项不在此列
+    const nav = query && query.nav
+    if (nav && this.visibleNavItems.some((n) => n.key === nav && !n.route)) {
+      this.onNavTap({ key: nav })
+    }
     this.loadConfig()
     if (this.isDesktop) {
+      // AI 面板的「AI Workdeck 云端」选项是否可选，取决于是否已连接账户。
+      // status 是后端纯本地读盘，不打官网，可以随页面加载
+      this.loadPlatformAiAvailability()
       this.loadComponents()
       // 订阅主进程模型下载进度；onUnload 退订
       this._modelProgressUnsub = window.checkbaDesktop.model.onProgress((evt) => {
@@ -787,6 +982,132 @@ export default {
       if (nav.key === 'cloud') {
         this.loadCloudConnections()
       }
+      if (nav.key === 'account') {
+        this.loadAccount()
+      }
+    },
+    async loadPlatformAiAvailability() {
+      try {
+        const s = await getAccountStatus()
+        this.platformAiAvailable = !!(s && s.platformAiAvailable)
+      } catch (e) {
+        this.platformAiAvailable = false
+      }
+    },
+    // 供应商单选：不可选项给出下一步，而不是静默不响应
+    onPickProvider(opt) {
+      if (opt.unavailable) {
+        uni.showToast({ title: '请先在「账户与用量」连接账户', icon: 'none' })
+        return
+      }
+      this.form.ai.activeProvider = opt.value
+    },
+    // ---------- 账户与用量 ----------
+    // 拉状态；已连接才继续拉用量（未连接时后端没有可查的账户）
+    async loadAccount() {
+      try {
+        const s = await getAccountStatus()
+        this.platformAiAvailable = !!(s && s.platformAiAvailable)
+        this.account = {
+          connected: !!(s && s.connected),
+          username: (s && s.username) || '',
+          displayName: (s && s.displayName) || '',
+          keyMasked: (s && s.keyMasked) || '',
+        }
+      } catch (e) {
+        // 旧后端没有该端点 / 请求失败：按未连接展示引导，不弹错打断
+        this.account = { connected: false, username: '', displayName: '', keyMasked: '' }
+        this.platformAiAvailable = false
+      }
+      if (this.account.connected) {
+        await this.loadAccountUsage()
+      } else {
+        this.accountUsage = null
+      }
+    },
+    async loadAccountUsage() {
+      try {
+        this.accountUsage = await getAccountUsage()
+      } catch (e) {
+        // 账户已连但尚未分配 AI 额度时后端会报错，此处按「无额度」展示
+        this.accountUsage = null
+      }
+    },
+    openAccountSite() {
+      openExternalUrl(ACCOUNT_SITE_URL)
+    },
+    async onConnectAccount() {
+      const key = (this.accountKeyInput || '').trim()
+      if (!key) {
+        uni.showToast({ title: '请先粘贴账户 Key', icon: 'none' })
+        return
+      }
+      this.accountBusy = true
+      try {
+        await connectAccount(key)
+        this.accountKeyInput = ''
+        await this.loadAccount()
+        // 已购功能解锁随账户走，连接后必须让权益缓存失效重取
+        await refreshEntitlements(true)
+        uni.showToast({ title: '已连接账户', icon: 'none' })
+      } catch (e) {
+        uni.showToast({ title: (e && e.message) || '连接失败', icon: 'none' })
+      } finally {
+        this.accountBusy = false
+      }
+    },
+    async onDisconnectAccount() {
+      const ok = await new Promise((r) => uni.showModal({
+        title: '断开账户连接',
+        content: '断开后本机将清除账户 Key：不再能使用平台 AI 通道，已购插件与功能解锁也会同步失效。本机数据不受影响，随时可以重新连接。',
+        confirmText: '断开',
+        success: (res) => r(res.confirm),
+      }))
+      if (!ok) return
+      try {
+        await disconnectAccount()
+        await this.loadAccount()
+        await refreshEntitlements(true)
+        uni.showToast({ title: '已断开连接', icon: 'none' })
+      } catch (e) {
+        uni.showToast({ title: (e && e.message) || '操作失败', icon: 'none' })
+      }
+    },
+    // 金额一律两位小数，缺值显示 $0.00 而不是 NaN
+    formatUsd(v) {
+      const n = Number(v)
+      return '$' + (Number.isFinite(n) ? n : 0).toFixed(2)
+    },
+    // 额度数字：实时口径拿不到时显示「—」。
+    // 这里不能沿用 formatUsd 的 0 兜底——$0.00 会被读成「额度已用光」
+    quotaText(v) {
+      if (!this.accountQuotaAvailable) return '—'
+      const n = Number(v)
+      return Number.isFinite(n) ? this.formatUsd(n) : '—'
+    },
+    // 费用口径标注（Spec §3：本地估算与平台结算两套数字必须分得开）
+    usageSourceLabel(row) {
+      const src = row && row.costSource
+      if (src === 'platform') return '平台结算'
+      if (src === 'estimate') return '本地估算'
+      return ''
+    },
+    // 平台通道在对账完成前 cost 为 null——显示「待结算」，
+    // 绝不能拿 $0.00 顶替，那会让用户以为这次调用不花钱
+    usageCostText(row) {
+      const cost = row && row.cost
+      if (cost === null || cost === undefined || cost === '') {
+        return row && row.costSource === 'platform' ? '待结算' : '—'
+      }
+      // 估算值加约等号，避免和真实账单混淆
+      const prefix = row && row.costSource === 'estimate' ? '≈' : ''
+      return prefix + this.formatUsd(cost)
+    },
+    // 后端 LocalDateTime 序列化成 "2026-08-05T12:34:56"，只取到分钟。
+    // 刻意不过 Date 解析：无时区后缀的串在不同实现下会被当本地/UTC，反而错位。
+    formatUsageTime(ts) {
+      if (!ts) return ''
+      return String(ts).replace('T', ' ').slice(0, 16)
     },
     async loadCloudConnections() {
       try {
@@ -1273,6 +1594,17 @@ $border-color: #E9ECEF; // Gray-Light
   background: $brand-mint-light;
 }
 
+// 未连接账户时的「AI Workdeck 云端」：可见但压低，点击给引导而不是静默失败
+.radio-item.unavailable {
+  opacity: 0.55;
+}
+
+.radio-hint {
+  margin-left: 8px;
+  font-size: 12px;
+  color: $text-secondary;
+}
+
 .radio-dot {
   width: 14px;
   height: 14px;
@@ -1661,5 +1993,127 @@ $border-color: #E9ECEF; // Gray-Light
 .btn-primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* 账户与用量 */
+.account-intro {
+  display: block;
+  margin-bottom: 14px;
+  font-size: 13px;
+  line-height: 21px;
+  color: $text-secondary;
+}
+
+.account-link-row {
+  display: flex;
+  margin-bottom: 16px;
+}
+
+.account-connect-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.account-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.account-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.account-sub {
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.account-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.account-metric {
+  flex: 1 1 130px;
+  min-width: 130px;
+  padding: 12px 14px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 6px;
+  background: $brand-bg;
+}
+
+.account-metric-label {
+  display: block;
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.account-metric-value {
+  display: block;
+  margin-top: 6px;
+  font-size: 18px;
+  font-weight: 600;
+  color: $brand-primary;
+}
+
+.account-note {
+  display: block;
+  margin-top: 14px;
+  font-size: 12px;
+  line-height: 18px;
+  color: $text-secondary;
+}
+
+.usage-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.usage-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.usage-model {
+  font-size: 13px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.usage-time {
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.usage-numbers {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-left: 16px;
+  flex-shrink: 0;
+}
+
+.usage-tokens {
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.usage-cost {
+  font-size: 13px;
+  font-weight: 600;
 }
 </style>

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -322,7 +322,7 @@
                   >
                     <view class="radio-dot"></view>
                     <text class="radio-label">{{ opt.label }}</text>
-                    <text v-if="opt.unavailable" class="radio-hint">需先连接账户</text>
+                    <text v-if="opt.hint" class="radio-hint">{{ opt.hint }}</text>
                   </view>
                 </view>
               </view>
@@ -796,8 +796,10 @@ export default {
     cloudServerUrlIsHttp() {
       return /^http:\/\//i.test((this.cloudForm.serverUrl || '').trim())
     },
-    // 供应商单选项。「AI Workdeck 云端」是平台计费通道，未连接账户时展示但不可选——
-    // 隐藏它会让用户根本发现不了这个选项，直接可选又会在发消息时才报「未连接账户」
+    // 供应商单选项。「AI Workdeck 云端」是平台计费通道，条件不满足时展示但不可选——
+    // 隐藏它会让用户根本发现不了这个选项，直接可选又会在发消息时才报错。
+    // 两个前置条件都要单独判：连接账户 → 在官网从余额分配 AI 额度。
+    // 缺后者时官网 /api/account/ai-key 返回 409 no_allocation，只在发消息那一刻才炸。
     aiProviderOptions() {
       const options = [
         { value: 'OLLAMA', label: '本地 Ollama' },
@@ -805,11 +807,14 @@ export default {
         { value: 'OPENROUTER', label: 'OpenRouter' },
       ]
       if (this.isDesktop) {
+        let hint = ''
+        if (!this.platformAiAvailable) hint = '需先连接账户'
+        else if (this.accountNeedsAllocation) hint = '需先在官网分配额度'
         options.push({
           value: 'AWD_CLOUD',
           label: 'AI Workdeck 云端',
-          // 已经选中的供应商不标不可选，否则用户会看到一个自相矛盾的界面
-          unavailable: !this.platformAiAvailable && this.form.ai.activeProvider !== 'AWD_CLOUD',
+          hint,
+          unavailable: !!hint,
         })
       }
       return options
@@ -993,11 +998,17 @@ export default {
       } catch (e) {
         this.platformAiAvailable = false
       }
+      // 「已连接但没分配额度」也会让平台通道打不通，判据在用量接口里（accountNeedsAllocation）。
+      // 设置页不是热路径，多这一次请求换来单选项如实标注，好过发消息时才报错。
+      if (this.platformAiAvailable) {
+        await this.loadAccountUsage()
+      }
     },
     // 供应商单选：不可选项给出下一步，而不是静默不响应
     onPickProvider(opt) {
+      if (opt.value === this.form.ai.activeProvider) return
       if (opt.unavailable) {
-        uni.showToast({ title: '请先在「账户与用量」连接账户', icon: 'none' })
+        uni.showToast({ title: opt.hint || '当前不可用', icon: 'none' })
         return
       }
       this.form.ai.activeProvider = opt.value
@@ -1065,10 +1076,23 @@ export default {
       }))
       if (!ok) return
       try {
-        await disconnectAccount()
+        const res = await disconnectAccount()
         await this.loadAccount()
         await refreshEntitlements(true)
-        uni.showToast({ title: '已断开连接', icon: 'none' })
+        // 后端会把 activeProvider 从平台通道摘下来（否则每条消息都报未连接账户，
+        // 而设置页仍显示平台通道正常选中）。这里同步表单并如实告知切到了哪一个。
+        const fallback = res && res.aiProviderFallback
+        if (fallback) {
+          this.form.ai.activeProvider = fallback
+          const label = (this.aiProviderOptions.find((o) => o.value === fallback) || {}).label || fallback
+          uni.showModal({
+            title: '已断开连接',
+            content: 'AI 供应商原本是「AI Workdeck 云端」，断开后已切换为「' + label + '」。可在「AI 服务配置」重新选择。',
+            showCancel: false,
+          })
+        } else {
+          uni.showToast({ title: '已断开连接', icon: 'none' })
+        }
       } catch (e) {
         uni.showToast({ title: (e && e.message) || '操作失败', icon: 'none' })
       }
@@ -1594,7 +1618,8 @@ $border-color: #E9ECEF; // Gray-Light
   background: $brand-mint-light;
 }
 
-// 未连接账户时的「AI Workdeck 云端」：可见但压低，点击给引导而不是静默失败
+// 前置条件未满足（未连接账户 / 未分配额度）的「AI Workdeck 云端」：
+// 可见但压低，点击给出下一步而不是静默失败
 .radio-item.unavailable {
   opacity: 0.55;
 }

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -292,6 +292,20 @@ $bg-white: #FFFFFF;
     font-weight: 500;
     color: #8a6d2f;
   }
+
+  // 已连接账户：同一形状换绿系，与「试用版」的暖色区分开
+  &.account-chip {
+    background: $color-accent-pale;
+    border-color: #c4ead8;
+
+    &:hover {
+      border-color: $color-accent;
+    }
+
+    .trial-chip-text {
+      color: $color-primary;
+    }
+  }
 }
 
 .project-meta {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -74,9 +74,18 @@
       </view>
 
       <view class="header-right">
-        <!-- 试用版标识（mode=trial 时显示，低调 chip，点击弹说明） -->
+        <!-- 授权标识（低调 chip）：已连接账户优先于试用版——
+             试用码解锁后再连账户的用户，此时该看到的是账户状态 -->
         <view
-          v-if="licenseMode === 'trial'"
+          v-if="accountConnected"
+          class="trial-chip account-chip"
+          @tap.stop="goToAccountPanel"
+          title="账户与用量"
+        >
+          <text class="trial-chip-text">已连接账户</text>
+        </view>
+        <view
+          v-else-if="licenseMode === 'trial'"
           class="trial-chip"
           @tap.stop="showTrialInfo = true"
           title="试用版说明"
@@ -1410,7 +1419,8 @@ import {
   getFileLocalPath,
   getMyProjects, // 最近项目切换器
   bindShareholderMeetingConversation, // 股东大会核查：会话绑定
-  getLicenseStatus // 试用版标识（商业化解锁门）
+  getLicenseStatus, // 试用版标识（商业化解锁门）
+  getAccountStatus // 账户连接标识（商业化 PR-B）
 } from '@/services/api.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
 import { getCurrentUser } from '@/utils/auth.js'
@@ -1496,6 +1506,8 @@ export default {
       // 授权状态（试用版标识，商业化解锁门）
       licenseMode: '',
       showTrialInfo: false,
+      // 账户连接状态（商业化 PR-B）：已连接时 chip 改显「已连接账户」
+      accountConnected: false,
 
       // 布局状态
       sidebarWidth: 260, // 侧边栏宽度
@@ -2129,6 +2141,9 @@ export default {
     // 重新成为活跃实例后确保有预热备胎（mounted 时可能因非活跃被跳过）
     this.scheduleLibreSpare()
 
+    // 从设置页返回时刷新授权/账户 chip（用户可能刚连接或断开账户）
+    this.loadLicenseMode()
+
     // Sync UI state
     this.isRecording = activityTracker.getRecordingState()
 
@@ -2494,7 +2509,8 @@ export default {
     'leftFiles.length'() { this.pruneClosedLibreSpares() },
   },
   methods: {
-    // 试用版标识：桌面端查授权模式（mode=trial 显示 chip；account/查询失败不显示）
+    // 授权标识：桌面端查授权模式与账户连接状态
+    // （已连接账户 → 「已连接账户」chip；否则 mode=trial → 「试用版」chip）
     async loadLicenseMode() {
       if (typeof window === 'undefined' || !window.checkbaDesktop) return
       try {
@@ -2503,6 +2519,17 @@ export default {
       } catch (e) {
         // 服务器模式/旧后端没有该端点：静默忽略
       }
+      try {
+        const account = await getAccountStatus()
+        this.accountConnected = !!(account && account.connected)
+      } catch (e) {
+        // 同上：查不到就按未连接处理，不影响试用版 chip
+        this.accountConnected = false
+      }
+    },
+    // chip 点击直达设置页「账户与用量」面板
+    goToAccountPanel() {
+      uni.navigateTo({ url: '/pages/admin/admin?nav=account' })
     },
     openUpgradeSite() {
       this.showTrialInfo = false

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -705,6 +705,78 @@ export function deactivateLicense() {
   });
 }
 
+// ===================== 账户与用量（商业化 PR-B）相关 API =====================
+//
+// 桌面后端把官网账户接口收敛成本机端点，前端一律只跟本机后端说话
+// （awdk_ Key 与 Bearer 鉴权都留在后端，不进渲染进程）。
+//
+// 信封说明：这批端点与解锁门同批，按 LicenseController 惯例返回裸 JSON；
+// 但本仓另有 { code, data } 信封惯例，这里统一剥一层，两种形状都能用。
+function unwrapEnvelope(res) {
+  if (res && typeof res === 'object' && 'code' in res && 'data' in res) return res.data;
+  return res;
+}
+
+// 账户连接状态：{ connected, username, displayName, connectedAt, lastSyncAt, keyMasked, platformAiAvailable }
+// 未连接时只有 { connected: false, platformAiAvailable: false }。
+// 刻意**不含余额与套餐**：这是纯本地读盘的轻端点（顶栏 chip 每次 onShow 都调），
+// 带上余额就意味着每次都要打一次官网。余额在 getAccountUsage() 的 platform 段。
+export function getAccountStatus() {
+  return request({
+    url: '/api/account/status',
+    method: 'GET',
+  }).then(unwrapEnvelope);
+}
+
+// 连接账户：粘贴官网账户页生成的 awdk_ Key
+export function connectAccount(key) {
+  return request({
+    url: '/api/account/connect',
+    method: 'POST',
+    data: { key },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  }).then(unwrapEnvelope);
+}
+
+// 断开账户连接：清除本机保存的账户 Key
+export function disconnectAccount() {
+  return request({
+    url: '/api/account/disconnect',
+    method: 'POST',
+  }).then(unwrapEnvelope);
+}
+
+// 用量：两套口径分开返回（Spec §3），前端不做合并。
+// {
+//   local:    { records, promptTokens, completionTokens, totalTokens,
+//               platformCostUsd, estimatedCostUsd,
+//               recent: [{ model, createdAt, totalTokens, cost, costSource }] },
+//   platform: { connected, available, message?,
+//               balanceCents, plan, allocations: [...],
+//               quotaAvailable, quotaMessage?, hasAiQuota, limitUsd, usageUsd, remainingUsd }
+// }
+// platform.available=false 表示官网不可达（本地统计仍然有效）；
+// quotaAvailable=false 表示额度实时口径拿不到——此时不要把 0 当成真实剩余额度。
+export function getAccountUsage() {
+  return request({
+    url: '/api/account/usage',
+    method: 'GET',
+  }).then(unwrapEnvelope);
+}
+
+// 功能权益：{ features: [...已拥有...], catalog: [...目录全集含 enabled...],
+//            accountConnected, syncedAt, stale }
+// features 只含已拥有项——「出现在 features 里 = 已拥有」，catalog 才是带 enabled 的全集。
+// 由 useEntitlement composable 统一消费，业务代码不要直接调这个。
+export function getEntitlements() {
+  return request({
+    url: '/api/entitlements',
+    method: 'GET',
+  }).then(unwrapEnvelope);
+}
+
 // ===================== 用户认证相关 API =====================
 
 // 用户注册

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -770,9 +770,11 @@ export function getAccountUsage() {
 //            accountConnected, syncedAt, stale }
 // features 只含已拥有项——「出现在 features 里 = 已拥有」，catalog 才是带 enabled 的全集。
 // 由 useEntitlement composable 统一消费，业务代码不要直接调这个。
-export function getEntitlements() {
+// refresh=true 让后端先同步一次官网再出快照（连接账户后 / 官网购买后回来时用），
+// 默认走后端本地缓存，避免每个页面打开都打一次官网。
+export function getEntitlements(refresh = false) {
   return request({
-    url: '/api/entitlements',
+    url: refresh ? '/api/entitlements?refresh=true' : '/api/entitlements',
     method: 'GET',
   }).then(unwrapEnvelope);
 }


### PR DESCRIPTION
# PR-B：Entitlement 框架 + 账户连接 + 平台 AI 通道

总 Spec：`docs/superpowers/specs/2026-08-05-commercialization-redesign.md` §1 §3 §5 §6 §9。
依赖 PR-A（#247，已在 master）。官网侧 W0-W4 已上线生产。

## 一、与官网契约的对接情况

权威契约是官网仓 `doc/desktop-contract.md`。**两处与总 Spec 字面不同的地方以契约文档为准，本 PR 按文档实现**：

| 端点 | 契约口径 | 桌面端实现 |
|---|---|---|
| `POST /api/license/verify-key` | `plan` 是 `paid`/`free`（不是 Spec 写的 `trial`/`paid`） | `LicenseService.callVerifyKey` 只看 `valid`，`plan` 不参与判定 |
| `GET /api/account/ledger` | 返回 `{entries:[...]}`（不是裸数组） | `AccountService.fetchLedger` 读 `entries` |
| `GET /api/account/me` | username/displayName/balanceCents/plan/createdAt | 连接时校验 + 用量面板读余额 |
| `GET /api/account/entitlements` | `{entitlements:[{feature,purchasedAt,orderId}]}` | 同步进 `~/.aiworkdeck/entitlements.json` |
| `POST /api/account/ai-key` | 幂等；409 `no_allocation` / 409 `key_missing` / 503 `not_configured` | 三种状态分别给中文引导，不静默回退 BYOK |
| 权益命名 | `clipboard.unlimited` / `stage.unlimited` / `skill:<id>` / `plugin:<id>` | `FeatureCatalog` 与之一一对应 |

状态码分类：4xx=INVALID（清授权）、5xx/超时=UNREACHABLE（保授权走 30 天宽限），与契约文档对 verify-key 的要求一致。

另有一个契约文档没写、但官网 master 上确实存在的端点 `GET /api/account/ai-usage`（额度实时口径），按「可能不存在」处理——任何非 2xx 都降级成「额度未知」而不是整块报错。**已回报官网侧补文档。**

## 二、五状态行为表

「授权状态 × 账户状态」的组合是这个 PR 最容易出错的地方，逐个钉死：

| # | 状态 | 应用本体 | 平台 AI 通道 | 账户型权益 | 设置页表现 |
|---|---|---|---|---|---|
| 1 | 未解锁 | 停在解锁门 | 不可用 | 无 | 进不到设置页 |
| 2 | 试用码解锁 | 可用（试用版标识） | 不可选，标「需先连接账户」 | 无（试用版同样受免费额度约束） | 引导粘 Key |
| 3 | 账户 Key 解锁 | 可用（正式版） | **一步到位可用**——解锁即连接账户 | 随账户同步 | 顶栏账户 chip + 用量面板 |
| 4 | 已连接但未分配 AI 额度 | 可用 | **不可选，标「需先在官网分配额度」** | 正常 | 账户卡片给「去官网分配」引导 |
| 5 | 连接后断网 | 可用 | 本次调用报错，连接不清 | 30 天宽限内仍生效 | 余额/额度显示「—」，本地统计照常 |

两条附加规则：
- **官网明确吊销 Key（401/403）不吃宽限**，立刻清账户型权益。宽限是给「联系不上官网」的，不是给止损场景的。
- **断开连接会把 `ai.activeProvider` 从 AWD_CLOUD 摘下来**，回落到还配着 key 的供应商，并在断开弹窗里如实告知切到了哪一个。

## 三、本轮修掉的对抗审查发现

安全五项：
1. `AccountController` / `EntitlementController` 原先**无任何鉴权**。`LocalModeAccessFilter` 在 `local-mode=false` 时整体短路，而 `deploy/web/nginx.conf.example` 把 `/api/` 整段反代出去——团队服务器部署下账户状态可匿名读、`POST /disconnect` 可匿名调（凭据真的会被删）。补 `getUserIdFromSession` 闸，local-mode 免登行为不变。
2. **明文 Key 会进日志**：Jackson 默认把原文片段拼进解析异常的 message，而 `account.json`/`license.json`/`platform-ai-key.json` 存的都是明文密钥，日志文件是 0644、凭据文件是 0600。一次半截写入（崩溃/磁盘满）+ 一次状态轮询就够把密钥复制进日志。统一走 `AccountService.stateMapper()`，关掉 `INCLUDE_SOURCE_IN_LOCATION`。
3. **吊销 Key 后付费功能还能再用 30 天**：`refreshQuietly` 原先对所有 `AccountException` 一视同仁。现在 UNAUTHORIZED 立即清缓存，NETWORK 才走宽限。
4. **`entitlements.json` 未签名且不看连接状态**：删掉 `account.json` 后手写一份缓存就能开出全部权益。现在缓存只在账户仍连接时生效。签名票据（Spec §5 字面）本轮**有意不做**，理由写在 `EntitlementService` 类注释里：本地 SKU 的判定完全在本地执行，没有服务端往返能拦住改文件的人，签名只是抬高门槛；真正要钱的两条路（付费 Skill/插件下载、AI 额度）都另有服务端闸门。这是记录在案的取舍，不是遗漏。
5. **`PlatformUsageAccountant.baseline` 不随换账户重置**：账户 A（累计 $0.02）换到账户 B（累计 $5.00），下一条消息会被记成花了 $4.98。

正确性四项：
6. **解锁门粘 `awdk_` Key 不连接账户**——Spec §1 写的是「等于连接账户一步到位」，原实现只写 `license.json`，用户必须再去设置页粘第二遍，否则平台通道不可用、官网已购功能全锁着。
7. **断开账户后 AI 整体死掉且界面不提示**（见上表附加规则）。
8. **「已连接但没分配额度」时平台通道仍可选**，是「选了才报错」而不是「不可选」。
9. **权益只在启动与 connect 时同步过**：桌面开着的时候在官网买东西，怎么刷都看不见，必须重启；且 `syncedAt` 永不推进，长期在线的实例会在第 31 天当场把权益判失效。现在快照发现陈旧会自动异步刷新，另加 `?refresh=true` 供前端显式刷新。

次要四项：`isEnabled` 加内存缓存（原先每次调用都读盘，PR-C 的剪贴板/Stage 是热路径）；对账任务改到事务提交后入队（原先可能先于提交跑，该条 cost 永久留空）；平台模型创建前先建用量基线（原先重启后第一条消息永久显示「待结算」）；`useEntitlement` 的 `loaded` 只在成功时置位；账户类文案避开前端 `api.js` 的「登录/未授权/请先」未登录判据（加了断言守着）。

## 四、验证结果

| 项 | 结果 |
|---|---|
| `mvn -B test`（JDK 21） | **781 通过 / 0 失败**（新增 9 个用例） |
| `npm run check:emits` | 通过（扫 63 个 .vue） |
| `npm run build:h5` | 通过 |
| `npm run test:app-e2e` | **76 步通过 / 0 失败**（J11 缺 `APP_E2E_JAR` 跳过，与本 PR 无关） |

联调用隔离实例（9797/9798/9800 + 独立 `user.home` + 独立 H2 + 本地官网桩 9799），**全程未启动也未触碰 9696**，收尾已全部停掉。

真机验证过的行为：
- 服务器模式（`local-mode=false`）下 `/api/account/status`、`/api/entitlements`、`/api/account/usage`、`POST /disconnect` 匿名请求一律 `{"code":1,"message":"未登录"}`；local-mode 下四者照常免登可用，跨站 POST 仍被 PR-A 的过滤器拦为「跨站请求已被拒绝」。
- 半截 `account.json` + 状态轮询后，日志里是 `at [Source: UNKNOWN; ...]`，`grep` 明文 Key 命中 **0** 次。
- 解锁门粘 `awdk_` Key（对本地官网桩）：一次操作同时拿到 `unlocked:true` + `connected:true` + 权益 `['app.unlocked','clipboard.unlimited']`。
- 官网改回 401 后显式刷新：`clipboard.unlimited` 当场消失，本地票据的 `app.unlocked` 保留。
- 设 `activeProvider=AWD_CLOUD` 后断开：响应带 `aiProviderFallback:"OPENROUTER"`，DB 里的 `activeProvider` 确实变成 `OPENROUTER`。

## 五、后续

- PR-C 消费本 PR 的 `EntitlementService.isEnabled`（剪贴板 20 条/3 天、Stage 20 个/500MB 免费额度）。
- PR-F 建「授权与计费」领域文档并补 CLAUDE.md 路由表；本 PR 只顺手更新了 `.claude/agents/ai-chat.md` 里被改到的契约与三个状态钩子。
- 官网侧待办：`GET /api/account/ai-usage` 补进 `doc/desktop-contract.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
