### PR TITLE
feat: 剪贴板/文件缓存区免费额度 + 付费自选存储位置（商业化改造 PR-C）

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -14,6 +14,7 @@ description: 辅助小工具领域。任务涉及浏览器面板、截图/OCR、
 **截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
 
 **剪贴板**：`ClipboardPanel.vue`；desktop main.js 轮询监听 clipboardWatchTimer ~:117-232（指纹去重 ~:110，首 tick 只记指纹）、推送 `checkba:clipboard-copied`；后端 `controller/ClipboardController.java`（/api/clipboard：GET /、POST /text、POST /file、GET /{id}/file、DELETE /{id}）。
+  **免费额度（PR-C）**：未拥有 `clipboard.unlimited` 时 GET / 只返回「最近 20 条 且 3 天内」，两条同时生效取更严者。**实现是查询侧过滤，绝不删除记录**——超出的行留在库里，解锁后原样可见。GET / 返回体从裸数组改为 `{items, limited, hiddenCount, maxItems, retentionDays}`（`ClipboardListResult`），hiddenCount 只算「因额度看不见」的（= 总数 − min(3天内条数, 20)），不含被分页 limit 挡住的。常量在 `ClipboardService.FREE_MAX_ITEMS/FREE_RETENTION_DAYS`。
 
 **收藏夹**：`ProjectFavoritesPanel.vue`；网页选中收藏经 `checkba:webmark`（preload ~:26）→ project-overview 订阅入库（~:2003）；后端 `controller/WebFavoriteController.java`（/api/favorites/my、/api/projects/{id}/favorites、DELETE、image）。
 
@@ -22,6 +23,11 @@ description: 辅助小工具领域。任务涉及浏览器面板、截图/OCR、
 **下载**：`DownloadList.vue` 是**孤儿组件**（全仓库无引用、未挂载）；文件下载实际走 FileController `GET /api/files/{fileId}/download`。
 
 **语音 TTS**：`EasyVoicePane.vue`（api：getTtsVoices/generateTtsAudio）；desktop 本地 Kokoro 由 `desktop/main/services/kokoro-service.js` 管理；后端 `controller/TtsController.java`（/api/tts/voices、/generate）+ `service/TtsService.java`——`external.tts.provider`：elevenlabs（云端默认）| local（桌面捆绑 Kokoro，OpenAI 兼容 /v1，base-url=`external.tts.local-base-url`）。easyvoice Docker 段已停用。
+
+**文件缓存区（左下角「文件暂存区」）**：`FileStagingArea.vue`（纯展示，用量条读 `usage` prop）+ `pages/project-overview/stagingArea.js`（方法组）。**物理形态是项目内名为 `__staging_area__` 的文件夹**，「加入缓存区」= `batchMoveFiles` 把已有项目文件移进去，没有独立的缓存区目录。
+  **免费额度（PR-C）**：`service/quota/StageQuotaService.java`，未拥有 `stage.unlimited` 时上限 20 个文件 / 500MB。**实现是移入时拦截，已有文件一律不动**——`ProjectFileService.batchMove` 在循环前整体准入检查，超额抛 `StageQuotaExceededException` → GlobalExceptionHandler 转 `code=4003 + feature + usage`，前端 api.js 打 `err.quotaExceeded` 标记。移出方向永不拦截（否则用户无法自救）。跨项目 id 不参与计算（防越权探测文件大小）。用量端点 `GET /api/projects/{id}/files/stage/usage?folderId=`。
+
+**文件存储位置（PR-C，需 stage.unlimited）**：`service/storage/StorageLocationService.java` + `GET/POST /api/storage/location`。搬的是**全局存储根**（项目文件与缓存区文件的落盘位置），因为缓存区文件就是项目文件。迁移策略：**复制 → 校验文件数与字节数 → 落配置 → 换指针，原目录保留为备份绝不删**；任一步失败清掉本次复制的副本并保持原路径。目标必须是空目录或不存在，且与源不互相嵌套。配置落 `~/.aiworkdeck/storage-location.json`（不落 DB：存储根必须在 JPA 起来之前就确定）。`ProjectStorageResolver.globalRoot` 因此改为 volatile + `relocate()`；能热切是因为 DB 存的是逻辑路径、git 的 gitDir/workTree 每次现算。
 
 **文件预览/插入**：`FilePreview.vue`（docx/pdf/pptx/压缩包分流见 project-overview ~:5110-5157；PDF 走 Chromium 原生引擎渲染，标准 annotation 可见；watch `file.wpsFileId` 在 AI 改完 PDF 后自动重拉字节——reload_file 是 Object.assign 原地更新，file 对象引用不变，别删这个 watch）、`FilePickerDialog.vue`、`FileLinkDropZone.vue`、`FileStagingArea.vue`；图片插入走 `libreofficeExecutorClient.js` insertImage → office_thread.js；desktop `file-service.js` + IPC `checkba:fs-read-file`（含敏感路径拦截+大小上限）；后端 `FileController.java`（download/upload/upload-status/text/compare）、`ProjectFileController.java`（列表/folder/archive/批量/回收站/tags）、`DocFileLinkController.java`（doc-links）。
 
@@ -58,6 +64,8 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 - 剪贴板去重靠指纹+window 级状态，改动监听逻辑先读 PR#148/#151 教训。
 - `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
 - Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。
+- **免费额度的红线**：剪贴板是「隐藏超出部分」、缓存区是「拒绝新增」，两者都**绝不删除或清理用户已有数据**。任何"顺手清理超额记录"的改动都是回归——用户付费后必须能看到之前被隐藏的全部内容。
+- `StorageException` 默认落到通用异常处理器会被替换成「服务器内部错误」（防路径回显）。存储位置那几条用户语言文案是在 `StorageLocationController` 里转成 `IllegalArgumentException` 才送出去的，新增可回显文案要走同一条路且确保不含路径。
 
 ## 验证
 

--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -14,7 +14,7 @@ description: 辅助小工具领域。任务涉及浏览器面板、截图/OCR、
 **截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
 
 **剪贴板**：`ClipboardPanel.vue`；desktop main.js 轮询监听 clipboardWatchTimer ~:117-232（指纹去重 ~:110，首 tick 只记指纹）、推送 `checkba:clipboard-copied`；后端 `controller/ClipboardController.java`（/api/clipboard：GET /、POST /text、POST /file、GET /{id}/file、DELETE /{id}）。
-  **免费额度（PR-C）**：未拥有 `clipboard.unlimited` 时 GET / 只返回「最近 20 条 且 3 天内」，两条同时生效取更严者。**实现是查询侧过滤，绝不删除记录**——超出的行留在库里，解锁后原样可见。GET / 返回体从裸数组改为 `{items, limited, hiddenCount, maxItems, retentionDays}`（`ClipboardListResult`），hiddenCount 只算「因额度看不见」的（= 总数 − min(3天内条数, 20)），不含被分页 limit 挡住的。常量在 `ClipboardService.FREE_MAX_ITEMS/FREE_RETENTION_DAYS`。
+  **免费额度（PR-C）**：未拥有 `clipboard.unlimited` 时 GET / 只返回「最近 20 条 且 3 天内」，两条同时生效取更严者。**实现是查询侧过滤，绝不删除记录**——超出的行留在库里，解锁后原样可见。GET / 返回体从裸数组改为 `{items, limited, hiddenCount, maxItems, retentionDays}`（`ClipboardListResult`），hiddenCount 只算「因额度看不见」的（= 总数 − min(3天内条数, 20)），不含被分页 limit 挡住的。常量在 `ClipboardService.FREE_MAX_ITEMS/FREE_RETENTION_DAYS`。**额度只在 local-mode（桌面单机版）执行**：`EntitlementService` 是按本机的（无 userId 维度），团队案件库服务器上权益恒为空集，照执行会把每个接入成员截到 20 条且永远无法解锁。
 
 **收藏夹**：`ProjectFavoritesPanel.vue`；网页选中收藏经 `checkba:webmark`（preload ~:26）→ project-overview 订阅入库（~:2003）；后端 `controller/WebFavoriteController.java`（/api/favorites/my、/api/projects/{id}/favorites、DELETE、image）。
 
@@ -25,9 +25,9 @@ description: 辅助小工具领域。任务涉及浏览器面板、截图/OCR、
 **语音 TTS**：`EasyVoicePane.vue`（api：getTtsVoices/generateTtsAudio）；desktop 本地 Kokoro 由 `desktop/main/services/kokoro-service.js` 管理；后端 `controller/TtsController.java`（/api/tts/voices、/generate）+ `service/TtsService.java`——`external.tts.provider`：elevenlabs（云端默认）| local（桌面捆绑 Kokoro，OpenAI 兼容 /v1，base-url=`external.tts.local-base-url`）。easyvoice Docker 段已停用。
 
 **文件缓存区（左下角「文件暂存区」）**：`FileStagingArea.vue`（纯展示，用量条读 `usage` prop）+ `pages/project-overview/stagingArea.js`（方法组）。**物理形态是项目内名为 `__staging_area__` 的文件夹**，「加入缓存区」= `batchMoveFiles` 把已有项目文件移进去，没有独立的缓存区目录。
-  **免费额度（PR-C）**：`service/quota/StageQuotaService.java`，未拥有 `stage.unlimited` 时上限 20 个文件 / 500MB。**实现是移入时拦截，已有文件一律不动**——`ProjectFileService.batchMove` 在循环前整体准入检查，超额抛 `StageQuotaExceededException` → GlobalExceptionHandler 转 `code=4003 + feature + usage`，前端 api.js 打 `err.quotaExceeded` 标记。移出方向永不拦截（否则用户无法自救）。跨项目 id 不参与计算（防越权探测文件大小）。用量端点 `GET /api/projects/{id}/files/stage/usage?folderId=`。
+  **免费额度（PR-C）**：`service/quota/StageQuotaService.java`，未拥有 `stage.unlimited` 时上限 20 个文件 / 500MB。**实现是移入时拦截，已有文件一律不动**——`ProjectFileService.batchMove` 在循环前整体准入检查，超额抛 `StageQuotaExceededException` → GlobalExceptionHandler 转 `code=4003 + feature + usage`，前端 api.js 打 `err.quotaExceeded` 标记。移出方向永不拦截（否则用户无法自救）。跨项目 id 不参与计算（防越权探测文件大小）。**文件夹按它装的全部文件递归计数**（准入与用量同一口径）——文件树允许把整个文件夹拖进缓存区，只算 1 个条目 0 字节的话，套一层目录就能让两条额度同时失效。用量端点 `GET /api/projects/{id}/files/stage/usage?folderId=`，**folderId 是全局 id，必须 `checkFileInProject` 校验归属**（只验路径 projectId 的话能枚举他人项目任意目录的文件数与字节数）。与剪贴板同理，额度只在 local-mode 执行。
 
-**文件存储位置（PR-C，需 stage.unlimited）**：`service/storage/StorageLocationService.java` + `GET/POST /api/storage/location`。搬的是**全局存储根**（项目文件与缓存区文件的落盘位置），因为缓存区文件就是项目文件。迁移策略：**复制 → 校验文件数与字节数 → 落配置 → 换指针，原目录保留为备份绝不删**；任一步失败清掉本次复制的副本并保持原路径。目标必须是空目录或不存在，且与源不互相嵌套。配置落 `~/.aiworkdeck/storage-location.json`（不落 DB：存储根必须在 JPA 起来之前就确定）。`ProjectStorageResolver.globalRoot` 因此改为 volatile + `relocate()`；能热切是因为 DB 存的是逻辑路径、git 的 gitDir/workTree 每次现算。
+**文件存储位置（PR-C）**：`service/storage/StorageLocationService.java` + `GET /api/storage/location`、`POST /api/storage/location`（迁移，需 stage.unlimited）、`POST /api/storage/location/reset`（恢复默认，不需权益）。搬的是**全局存储根**（项目文件与缓存区文件的落盘位置），因为缓存区文件就是项目文件。迁移策略：**复制 → 校验文件数与字节数（含源侧复查）→ 落配置 → 换指针，原目录保留为备份绝不删**；任一步失败清掉本次复制的副本并保持原路径。目标必须是空目录或不存在，且与源不互相嵌套——**嵌套判断在 `toRealPath()` 之后做**，纯词法比较挡不住指向源内部的软链（会把源复制进它自己，在数据根里造出几百个垃圾目录）。**源侧要复查**：只比「复制前的源」与「复制后的目标」，迁移期间自动保存进已复制目录的文件两边数字仍相等，会被静默留在旧根。源目录不可访问时拒绝迁移（否则 copyTree 会把源建出来，「0 个文件迁移成功」）。配置落 `~/.aiworkdeck/storage-location.json`（不落 DB：存储根必须在 JPA 起来之前就确定）。`ProjectStorageResolver.globalRoot` 因此改为 volatile + `relocate()`；能热切是因为 DB 存的是逻辑路径、git 的 gitDir/workTree 每次现算。
 
 **文件预览/插入**：`FilePreview.vue`（docx/pdf/pptx/压缩包分流见 project-overview ~:5110-5157；PDF 走 Chromium 原生引擎渲染，标准 annotation 可见；watch `file.wpsFileId` 在 AI 改完 PDF 后自动重拉字节——reload_file 是 Object.assign 原地更新，file 对象引用不变，别删这个 watch）、`FilePickerDialog.vue`、`FileLinkDropZone.vue`、`FileStagingArea.vue`；图片插入走 `libreofficeExecutorClient.js` insertImage → office_thread.js；desktop `file-service.js` + IPC `checkba:fs-read-file`（含敏感路径拦截+大小上限）；后端 `FileController.java`（download/upload/upload-status/text/compare）、`ProjectFileController.java`（列表/folder/archive/批量/回收站/tags）、`DocFileLinkController.java`（doc-links）。
 
@@ -65,6 +65,7 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 - `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
 - Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。
 - **免费额度的红线**：剪贴板是「隐藏超出部分」、缓存区是「拒绝新增」，两者都**绝不删除或清理用户已有数据**。任何"顺手清理超额记录"的改动都是回归——用户付费后必须能看到之前被隐藏的全部内容。
+- **权益失效不等于把人锁在外面**：`applyOnStartup` 无条件应用自选存储根（权益失效后数据照常读写），因此 `GET /api/storage/location` 与「恢复默认位置」都**不设权益闸**——否则 Key 被吊销 + 外置盘拔掉的用户既看不到自己数据在哪，也换不回默认位置。付费闸只加在「改到新的自选位置」这个动作上。
 - `StorageException` 默认落到通用异常处理器会被替换成「服务器内部错误」（防路径回显）。存储位置那几条用户语言文案是在 `StorageLocationController` 里转成 `IllegalArgumentException` 才送出去的，新增可回显文案要走同一条路且确保不含路径。
 
 ## 验证

--- a/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
@@ -46,6 +46,26 @@ public class GlobalExceptionHandler {
         return ResponseEntity.ok().body(result);
     }
 
+    /**
+     * 文件缓存区免费额度已满：code=4003 + feature=stage.unlimited，前端据此显示解锁引导。
+     * 与 4001（功能未配置）区分开——这里功能是好的，只是额度到顶了，下一步是解锁而非去设置。
+     */
+    @ExceptionHandler(com.checkba.exception.StageQuotaExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleStageQuota(com.checkba.exception.StageQuotaExceededException e) {
+        log.info("文件缓存区额度已满: {}", e.getMessage());
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 4003);
+        result.put("feature", com.checkba.service.entitlement.FeatureCatalog.STAGE_UNLIMITED);
+        result.put("message", e.getMessage());
+        Map<String, Object> usage = new HashMap<>();
+        usage.put("fileCount", e.getFileCount());
+        usage.put("totalBytes", e.getTotalBytes());
+        usage.put("maxFiles", e.getMaxFiles());
+        usage.put("maxBytes", e.getMaxBytes());
+        result.put("usage", usage);
+        return ResponseEntity.ok().body(result);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("GlobalExceptionHandler caught IllegalArgumentException: {}", e.getMessage());

--- a/backend/src/main/java/com/checkba/controller/ProjectFileController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectFileController.java
@@ -28,6 +28,29 @@ public class ProjectFileController {
     private final ProjectFileService projectFileService;
     private final ProjectMemberService projectMemberService;
     private final FileTagService fileTagService;
+    private final com.checkba.service.quota.StageQuotaService stageQuotaService;
+
+    /**
+     * 文件缓存区用量（前端顶部用量条的数据源）。
+     * GET /api/projects/{projectId}/files/stage/usage?folderId=xxx
+     *
+     * 上限常量只在后端定义一处，前端不复制——改额度时不会出现两边不一致。
+     */
+    @GetMapping("/stage/usage")
+    public Map<String, Object> stageUsage(
+            @PathVariable Long projectId,
+            @RequestParam(value = "folderId", required = false) Long folderId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = getUserIdFromSession(sessionId);
+        if (userId == null) {
+            throw new UnauthorizedException("请先登录");
+        }
+        checkFileTreeAccess(projectId, userId);
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("data", stageQuotaService.usage(folderId));
+        return result;
+    }
 
     /**
      * 获取文件列表（指定父文件夹）

--- a/backend/src/main/java/com/checkba/controller/ProjectFileController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectFileController.java
@@ -35,6 +35,10 @@ public class ProjectFileController {
      * GET /api/projects/{projectId}/files/stage/usage?folderId=xxx
      *
      * 上限常量只在后端定义一处，前端不复制——改额度时不会出现两边不一致。
+     *
+     * folderId 是全局 id，必须校验归属：只验路径上的 projectId 的话，
+     * 项目 A 的成员能拿自己的 projectId 去问项目 B 任意目录的文件数与总字节
+     * （数字主键可枚举）。与本文件其他按 fileId 操作的接口同一道闸。
      */
     @GetMapping("/stage/usage")
     public Map<String, Object> stageUsage(
@@ -46,6 +50,9 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileTreeAccess(projectId, userId);
+        if (folderId != null) {
+            checkFileInProject(folderId, projectId);
+        }
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
         result.put("data", stageQuotaService.usage(folderId));

--- a/backend/src/main/java/com/checkba/controller/StorageLocationController.java
+++ b/backend/src/main/java/com/checkba/controller/StorageLocationController.java
@@ -18,13 +18,17 @@ import java.util.Map;
 /**
  * 文件存储位置（PR-C：{@code stage.unlimited} 的付费能力）。
  *
- * <p>两道闸都必须过：</p>
+ * <p>闸分两级，因为「换到自选位置」和「知道自己数据在哪」是两件事：</p>
  * <ul>
- *   <li><b>权益</b>：未拥有 {@code stage.unlimited} 时入口在前端就不显示，
- *       这里再拦一次——前端隐藏不是访问控制；</li>
- *   <li><b>单机模式</b>：搬的是本机磁盘目录，只在桌面单机版有意义。
+ *   <li><b>单机模式</b>（三个端点都要）：搬的是本机磁盘目录，只在桌面单机版有意义。
  *       团队服务器上让任意成员从浏览器改服务端存储路径，等于把整台服务器的
  *       文件系统交出去（延续 local-folder-projects 的同款判断）。</li>
+ *   <li><b>权益</b>（只有 POST 迁移要）：未拥有 {@code stage.unlimited} 不能选新位置。
+ *       但 GET 与「恢复默认位置」<b>不设权益闸</b>：权益可能在自选位置生效之后失效
+ *       （Key 被吊销、断开账户、离线超宽限），而 {@code applyOnStartup} 是无条件的，
+ *       此时数据仍在自选路径上照常读写。若连查看路径都要权益，用户就再也看不到
+ *       自己的文件在哪、也看不到「该目录当前不可访问」这句唯一的指路牌，
+ *       更换不回默认位置——那是把人锁在一个既看不见也管不了的存储根上。</li>
  * </ul>
  */
 @RestController
@@ -43,13 +47,41 @@ public class StorageLocationController {
         this.localMode = localMode;
     }
 
+    /**
+     * 当前位置。只读展示，不设权益闸（理由见类注释）。
+     * 返回体里的 {@code entitled} 告诉前端能不能改位置——前端据此显示解锁引导而非藏起整块。
+     */
     @GetMapping
     public Map<String, Object> current(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
-        requireAccess(sessionId);
+        requireLocalDesktop(sessionId);
+        Map<String, Object> data = new HashMap<>(storageLocationService.current());
+        data.put("entitled", entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED));
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
-        result.put("data", storageLocationService.current());
+        result.put("data", data);
+        return result;
+    }
+
+    /**
+     * 恢复默认位置。不搬也不删任何文件，只把指针换回默认目录，原目录内容原样留着。
+     * 不设权益闸：这是退回免费版的默认状态，不发放任何付费能力，
+     * 锁在付费墙后面只会让权益失效 + 磁盘拔掉的用户彻底出不来。
+     */
+    @PostMapping("/reset")
+    public Map<String, Object> reset(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireLocalDesktop(sessionId);
+        Map<String, Object> data;
+        try {
+            data = storageLocationService.resetToDefault();
+        } catch (com.checkba.storage.StorageException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("message", "已恢复默认位置。原目录中的文件一个都没有删除，仍在原处。");
+        result.put("data", data);
         return result;
     }
 
@@ -57,7 +89,10 @@ public class StorageLocationController {
     public Map<String, Object> move(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
             @RequestBody MoveRequest request) {
-        requireAccess(sessionId);
+        requireLocalDesktop(sessionId);
+        if (!entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)) {
+            throw new IllegalArgumentException("自选存储位置需要先解锁「文件缓存区无限版」");
+        }
         Map<String, Object> data;
         try {
             data = storageLocationService.migrate(request == null ? null : request.getPath());
@@ -75,15 +110,12 @@ public class StorageLocationController {
         return result;
     }
 
-    private void requireAccess(String sessionId) {
+    private void requireLocalDesktop(String sessionId) {
         if (AuthController.getUserIdFromSession(sessionId) == null) {
             throw new UnauthorizedException("请先登录");
         }
         if (!localMode) {
             throw new IllegalArgumentException("该功能仅在本机单机版可用");
-        }
-        if (!entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)) {
-            throw new IllegalArgumentException("自选存储位置需要先解锁「文件缓存区无限版」");
         }
     }
 

--- a/backend/src/main/java/com/checkba/controller/StorageLocationController.java
+++ b/backend/src/main/java/com/checkba/controller/StorageLocationController.java
@@ -1,0 +1,97 @@
+package com.checkba.controller;
+
+import com.checkba.exception.UnauthorizedException;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.entitlement.FeatureCatalog;
+import com.checkba.service.storage.StorageLocationService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 文件存储位置（PR-C：{@code stage.unlimited} 的付费能力）。
+ *
+ * <p>两道闸都必须过：</p>
+ * <ul>
+ *   <li><b>权益</b>：未拥有 {@code stage.unlimited} 时入口在前端就不显示，
+ *       这里再拦一次——前端隐藏不是访问控制；</li>
+ *   <li><b>单机模式</b>：搬的是本机磁盘目录，只在桌面单机版有意义。
+ *       团队服务器上让任意成员从浏览器改服务端存储路径，等于把整台服务器的
+ *       文件系统交出去（延续 local-folder-projects 的同款判断）。</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/storage/location")
+public class StorageLocationController {
+
+    private final StorageLocationService storageLocationService;
+    private final EntitlementService entitlementService;
+    private final boolean localMode;
+
+    public StorageLocationController(StorageLocationService storageLocationService,
+                                     EntitlementService entitlementService,
+                                     @Value("${security.local-mode:false}") boolean localMode) {
+        this.storageLocationService = storageLocationService;
+        this.entitlementService = entitlementService;
+        this.localMode = localMode;
+    }
+
+    @GetMapping
+    public Map<String, Object> current(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireAccess(sessionId);
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("data", storageLocationService.current());
+        return result;
+    }
+
+    @PostMapping
+    public Map<String, Object> move(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
+            @RequestBody MoveRequest request) {
+        requireAccess(sessionId);
+        Map<String, Object> data;
+        try {
+            data = storageLocationService.migrate(request == null ? null : request.getPath());
+        } catch (com.checkba.storage.StorageException e) {
+            // StorageException 默认落到通用处理器，被替换成「服务器内部错误」——那对用户毫无帮助：
+            // 「请选择一个空目录」「目录不可写」正是他下一步该做什么。这里的每条文案都是
+            // StorageLocationService 亲手写的、不含路径的用户语言，转成 IllegalArgumentException
+            // 原样送出去是安全的（越界围栏等带路径的 StorageException 不经过这条路径）。
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("message", "已迁移。原目录保留为备份，确认无误后可自行删除。");
+        result.put("data", data);
+        return result;
+    }
+
+    private void requireAccess(String sessionId) {
+        if (AuthController.getUserIdFromSession(sessionId) == null) {
+            throw new UnauthorizedException("请先登录");
+        }
+        if (!localMode) {
+            throw new IllegalArgumentException("该功能仅在本机单机版可用");
+        }
+        if (!entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)) {
+            throw new IllegalArgumentException("自选存储位置需要先解锁「文件缓存区无限版」");
+        }
+    }
+
+    public static class MoveRequest {
+        private String path;
+
+        public String getPath() { return path; }
+
+        public void setPath(String path) { this.path = path; }
+    }
+}

--- a/backend/src/main/java/com/checkba/exception/StageQuotaExceededException.java
+++ b/backend/src/main/java/com/checkba/exception/StageQuotaExceededException.java
@@ -1,0 +1,32 @@
+package com.checkba.exception;
+
+/**
+ * 文件缓存区免费额度已满（PR-C）。
+ *
+ * <p>语义是**拒绝新增**，不是清理：抛出时缓存区里已有的文件一个都没动。
+ * 由 {@code GlobalExceptionHandler} 转成 code=4002 + feature=stage.unlimited，
+ * 前端据此显示解锁引导而非通用报错。</p>
+ */
+public class StageQuotaExceededException extends RuntimeException {
+
+    private final long fileCount;
+    private final long totalBytes;
+    private final int maxFiles;
+    private final long maxBytes;
+
+    public StageQuotaExceededException(String message, long fileCount, long totalBytes, int maxFiles, long maxBytes) {
+        super(message);
+        this.fileCount = fileCount;
+        this.totalBytes = totalBytes;
+        this.maxFiles = maxFiles;
+        this.maxBytes = maxBytes;
+    }
+
+    public long getFileCount() { return fileCount; }
+
+    public long getTotalBytes() { return totalBytes; }
+
+    public int getMaxFiles() { return maxFiles; }
+
+    public long getMaxBytes() { return maxBytes; }
+}

--- a/backend/src/main/java/com/checkba/exception/StageQuotaExceededException.java
+++ b/backend/src/main/java/com/checkba/exception/StageQuotaExceededException.java
@@ -4,7 +4,7 @@ package com.checkba.exception;
  * 文件缓存区免费额度已满（PR-C）。
  *
  * <p>语义是**拒绝新增**，不是清理：抛出时缓存区里已有的文件一个都没动。
- * 由 {@code GlobalExceptionHandler} 转成 code=4002 + feature=stage.unlimited，
+ * 由 {@code GlobalExceptionHandler} 转成 code=4003 + feature=stage.unlimited，
  * 前端据此显示解锁引导而非通用报错。</p>
  */
 public class StageQuotaExceededException extends RuntimeException {

--- a/backend/src/main/java/com/checkba/model/dto/ClipboardListResult.java
+++ b/backend/src/main/java/com/checkba/model/dto/ClipboardListResult.java
@@ -1,0 +1,30 @@
+package com.checkba.model.dto;
+
+import com.checkba.model.entity.ClipboardItem;
+
+import java.util.List;
+
+/**
+ * GET /api/clipboard 的返回体（PR-C 起从裸数组改为对象）。
+ *
+ * <p>免费额度是**查询侧过滤**：超出额度的记录一条都不删，只是不返回。
+ * {@code hiddenCount} 让前端能诚实地说出「另有 N 条历史记录」——
+ * 用户付费后这 N 条会原样出现，这是本功能的核心不变式。</p>
+ *
+ * @param items         本次可见的记录（已按额度过滤 + 分页 limit 截断）
+ * @param limited       是否处于免费额度下（拥有 clipboard.unlimited 时为 false）
+ * @param hiddenCount   因免费额度而不可见的记录条数（不含仅被分页 limit 挡住的）
+ * @param maxItems      免费额度的条数上限；不受限时为 null
+ * @param retentionDays 免费额度的保留天数；不受限时为 null
+ */
+public record ClipboardListResult(
+        List<ClipboardItem> items,
+        boolean limited,
+        long hiddenCount,
+        Integer maxItems,
+        Integer retentionDays
+) {
+    public static ClipboardListResult unlimited(List<ClipboardItem> items) {
+        return new ClipboardListResult(items, false, 0L, null, null);
+    }
+}

--- a/backend/src/main/java/com/checkba/repository/ClipboardItemRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ClipboardItemRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ClipboardItemRepository extends JpaRepository<ClipboardItem, Long> {
@@ -14,6 +15,19 @@ public interface ClipboardItemRepository extends JpaRepository<ClipboardItem, Lo
 
     @Query("select c from ClipboardItem c where c.userId = :userId and (c.text like concat('%', :q, '%') or c.meta like concat('%', :q, '%')) order by c.createdAt desc")
     List<ClipboardItem> search(@Param("userId") Long userId, @Param("q") String q, Pageable pageable);
+
+    // ==================== 免费额度统计（PR-C） ====================
+    // 免费版剪贴板只**显示**最近 20 条且 3 天内的记录，超出部分留在库里不可见。
+    // 下面四个计数用来算 hiddenCount——「有多少条因为额度而看不见」，
+    // 与分页 limit 造成的不可见是两回事，故必须按同一 query 作用域分别统计。
+
+    long countByUserId(Long userId);
+
+    long countByUserIdAndCreatedAtAfter(Long userId, LocalDateTime cutoff);
+
+    @Query("select count(c) from ClipboardItem c where c.userId = :userId and (c.text like concat('%', :q, '%') or c.meta like concat('%', :q, '%'))")
+    long countSearch(@Param("userId") Long userId, @Param("q") String q);
+
+    @Query("select count(c) from ClipboardItem c where c.userId = :userId and c.createdAt > :cutoff and (c.text like concat('%', :q, '%') or c.meta like concat('%', :q, '%'))")
+    long countSearchAfter(@Param("userId") Long userId, @Param("q") String q, @Param("cutoff") LocalDateTime cutoff);
 }
-
-

--- a/backend/src/main/java/com/checkba/service/ClipboardService.java
+++ b/backend/src/main/java/com/checkba/service/ClipboardService.java
@@ -5,7 +5,6 @@ import com.checkba.model.entity.ClipboardItem;
 import com.checkba.repository.ClipboardItemRepository;
 import com.checkba.service.entitlement.EntitlementService;
 import com.checkba.service.entitlement.FeatureCatalog;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 @Service
-@RequiredArgsConstructor
 public class ClipboardService {
 
     /** 免费版最多回溯的条数（Spec §5）。 */
@@ -28,6 +26,18 @@ public class ClipboardService {
     private final ClipboardItemRepository repository;
     private final com.checkba.storage.StorageServiceFactory storageServiceFactory;
     private final EntitlementService entitlementService;
+    private final boolean localMode;
+
+    public ClipboardService(ClipboardItemRepository repository,
+                            com.checkba.storage.StorageServiceFactory storageServiceFactory,
+                            EntitlementService entitlementService,
+                            @org.springframework.beans.factory.annotation.Value("${security.local-mode:false}")
+                            boolean localMode) {
+        this.repository = repository;
+        this.storageServiceFactory = storageServiceFactory;
+        this.entitlementService = entitlementService;
+        this.localMode = localMode;
+    }
 
     private com.checkba.storage.StorageService getStorageService() {
         return storageServiceFactory.getStorageService();
@@ -43,12 +53,18 @@ public class ClipboardService {
      * <p>{@code hiddenCount} 只统计**因额度**不可见的条数，不含仅被分页 {@code limit}
      * 挡住的：后者对付费用户同样存在，把它算进去会让提示文案变成谎话。
      * 算法：{@code hidden = 总数 − min(3天内的条数, 20)}。</p>
+     *
+     * <p>非单机模式（团队案件库服务器）不执行额度：{@link EntitlementService} 是按本机的
+     * （无 userId 维度，来源是本机 {@code ~/.aiworkdeck} 状态），服务器上恒为空集，
+     * 真照着执行会把每个接入成员的剪贴板都截到 20 条且永远无法解锁。
+     * 这个 SKU 卖的是单机版的本地能力，与 {@code LicenseController}
+     * 「非 local-mode 恒为已解锁正式版」同口径。</p>
      */
     public ClipboardListResult list(Long userId, String query, int limit) {
         int size = Math.max(1, Math.min(200, limit));
         String q = StringUtils.hasText(query) ? query.trim() : null;
 
-        if (entitlementService.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED)) {
+        if (!localMode || entitlementService.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED)) {
             return ClipboardListResult.unlimited(fetch(userId, q, size));
         }
 

--- a/backend/src/main/java/com/checkba/service/ClipboardService.java
+++ b/backend/src/main/java/com/checkba/service/ClipboardService.java
@@ -1,7 +1,10 @@
 package com.checkba.service;
 
+import com.checkba.model.dto.ClipboardListResult;
 import com.checkba.model.entity.ClipboardItem;
 import com.checkba.repository.ClipboardItemRepository;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.entitlement.FeatureCatalog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -17,17 +20,57 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ClipboardService {
 
+    /** 免费版最多回溯的条数（Spec §5）。 */
+    public static final int FREE_MAX_ITEMS = 20;
+    /** 免费版保留天数（Spec §5）。与条数上限**同时**生效，取更严者。 */
+    public static final int FREE_RETENTION_DAYS = 3;
+
     private final ClipboardItemRepository repository;
     private final com.checkba.storage.StorageServiceFactory storageServiceFactory;
+    private final EntitlementService entitlementService;
 
     private com.checkba.storage.StorageService getStorageService() {
         return storageServiceFactory.getStorageService();
     }
 
-    public List<ClipboardItem> list(Long userId, String query, int limit) {
+    /**
+     * 剪贴板列表。
+     *
+     * <p><b>免费额度是查询侧过滤，绝不删除记录。</b>未拥有 {@code clipboard.unlimited} 时
+     * 只返回「最近 20 条」且「3 天内」的记录（两条同时生效，取更严者），
+     * 超出的记录留在库里，用户解锁后原样可见。</p>
+     *
+     * <p>{@code hiddenCount} 只统计**因额度**不可见的条数，不含仅被分页 {@code limit}
+     * 挡住的：后者对付费用户同样存在，把它算进去会让提示文案变成谎话。
+     * 算法：{@code hidden = 总数 − min(3天内的条数, 20)}。</p>
+     */
+    public ClipboardListResult list(Long userId, String query, int limit) {
         int size = Math.max(1, Math.min(200, limit));
-        if (StringUtils.hasText(query)) {
-            return repository.search(userId, query.trim(), PageRequest.of(0, size));
+        String q = StringUtils.hasText(query) ? query.trim() : null;
+
+        if (entitlementService.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED)) {
+            return ClipboardListResult.unlimited(fetch(userId, q, size));
+        }
+
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(FREE_RETENTION_DAYS);
+        // 条数上限先在 SQL 层收紧，再按时间过滤——两者取交集即「更严者」
+        List<ClipboardItem> items = fetch(userId, q, Math.min(size, FREE_MAX_ITEMS)).stream()
+                .filter(it -> it.getCreatedAt() != null && it.getCreatedAt().isAfter(cutoff))
+                .toList();
+
+        long total = q == null ? repository.countByUserId(userId) : repository.countSearch(userId, q);
+        long recent = q == null
+                ? repository.countByUserIdAndCreatedAtAfter(userId, cutoff)
+                : repository.countSearchAfter(userId, q, cutoff);
+        long visibleUnderQuota = Math.min(recent, FREE_MAX_ITEMS);
+        long hidden = Math.max(0L, total - visibleUnderQuota);
+
+        return new ClipboardListResult(items, true, hidden, FREE_MAX_ITEMS, FREE_RETENTION_DAYS);
+    }
+
+    private List<ClipboardItem> fetch(Long userId, String q, int size) {
+        if (q != null) {
+            return repository.search(userId, q, PageRequest.of(0, size));
         }
         return repository.findByUserIdOrderByCreatedAtDesc(userId, PageRequest.of(0, size));
     }

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -31,18 +31,21 @@ public class ProjectFileService {
     private final StorageServiceFactory storageServiceFactory;
     private final WorkSessionService workSessionService;
     private final UserService userService;
+    private final com.checkba.service.quota.StageQuotaService stageQuotaService;
 
     @org.springframework.beans.factory.annotation.Autowired
     public ProjectFileService(ProjectFileRepository projectFileRepository,
                               ProjectRagService projectRagService,
                               StorageServiceFactory storageServiceFactory,
                               WorkSessionService workSessionService,
-                              UserService userService) {
+                              UserService userService,
+                              com.checkba.service.quota.StageQuotaService stageQuotaService) {
         this.projectFileRepository = projectFileRepository;
         this.projectRagService = projectRagService;
         this.storageServiceFactory = storageServiceFactory;
         this.workSessionService = workSessionService;
         this.userService = userService;
+        this.stageQuotaService = stageQuotaService;
     }
 
     /**
@@ -567,6 +570,9 @@ public class ProjectFileService {
         if (request == null || request.getFileIds() == null || request.getFileIds().isEmpty()) {
             throw new IllegalArgumentException("fileIds 不能为空");
         }
+        // 文件缓存区免费额度：目标是缓存区且超额时在这里整体拒绝，一个文件都不移动。
+        // 放在循环之前而非循环内，避免「移了一半才发现超额」的半成品状态。
+        stageQuotaService.checkAdmission(request.getTargetParentId(), request.getFileIds());
         List<ProjectFile> result = new ArrayList<>();
         for (Long id : request.getFileIds()) {
             if (id == null) continue;

--- a/backend/src/main/java/com/checkba/service/quota/StageQuotaService.java
+++ b/backend/src/main/java/com/checkba/service/quota/StageQuotaService.java
@@ -1,0 +1,139 @@
+package com.checkba.service.quota;
+
+import com.checkba.exception.StageQuotaExceededException;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.entitlement.FeatureCatalog;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 文件缓存区（左下角「文件暂存区」）的免费额度（Spec §5）。
+ *
+ * <p>缓存区的物理形态是项目内一个名为 {@code __staging_area__} 的文件夹，
+ * 「加入缓存区」= 把已有项目文件移进这个文件夹。因此额度的执行点是
+ * <b>移入时拦截</b>：达到上限就拒绝这次移动，
+ * <b>已经在缓存区里的文件一律不动、不删、不隐藏</b>。这是本功能的核心不变式——
+ * 剪贴板那侧是「隐藏超出部分」，这侧是「不再新增」，两者都不碰用户已有数据。</p>
+ *
+ * <p>拥有 {@code stage.unlimited} 时完全不限制。</p>
+ */
+@Service
+public class StageQuotaService {
+
+    /** 缓存区文件夹名（与前端 stagingArea.js 的 folderName 必须一致）。 */
+    public static final String STAGING_FOLDER_NAME = "__staging_area__";
+
+    /** 免费版缓存区文件数上限。 */
+    public static final int FREE_MAX_FILES = 20;
+
+    /** 免费版缓存区总字节上限（500MB）。 */
+    public static final long FREE_MAX_BYTES = 500L * 1024 * 1024;
+
+    private final ProjectFileRepository projectFileRepository;
+    private final EntitlementService entitlementService;
+
+    public StageQuotaService(ProjectFileRepository projectFileRepository, EntitlementService entitlementService) {
+        this.projectFileRepository = projectFileRepository;
+        this.entitlementService = entitlementService;
+    }
+
+    /** 该文件夹是不是缓存区目录。 */
+    public boolean isStagingFolder(Long folderId) {
+        if (folderId == null) return false;
+        return projectFileRepository.findById(folderId)
+                .map(f -> Boolean.TRUE.equals(f.getIsFolder()) && STAGING_FOLDER_NAME.equals(f.getName()))
+                .orElse(false);
+    }
+
+    /**
+     * 移入缓存区前的准入检查。目标不是缓存区、或已拥有无限版时直接放行。
+     *
+     * @param targetParentId 本次移动的目标目录
+     * @param incomingIds    本次要移入的文件 id
+     * @throws StageQuotaExceededException 超出额度时抛出，此时一个文件都不会被移动
+     */
+    public void checkAdmission(Long targetParentId, List<Long> incomingIds) {
+        if (entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)) return;
+        if (!isStagingFolder(targetParentId)) return;
+
+        // 缓存区所属项目：跨项目的 id 一律不参与计算。批量移动的归属校验在
+        // ProjectFileService 的循环里（逐个 move 之前），比本方法晚；不在这里划清项目边界的话，
+        // 越权探测者能靠「是否被额度拒绝」推断出别人项目里某个文件的大小。
+        Long stageProjectId = projectFileRepository.findById(targetParentId)
+                .map(ProjectFile::getProjectId).orElse(null);
+
+        List<ProjectFile> existing = currentFiles(targetParentId);
+        long count = existing.size();
+        long bytes = existing.stream().mapToLong(StageQuotaService::sizeOf).sum();
+
+        // 已在缓存区里的文件重复拖入不算新增（前端多选里可能混着已在区内的文件）
+        List<ProjectFile> incoming = new ArrayList<>();
+        for (Long id : incomingIds == null ? List.<Long>of() : incomingIds) {
+            if (id == null) continue;
+            ProjectFile f = projectFileRepository.findById(id).orElse(null);
+            if (f == null) continue;
+            if (!Objects.equals(f.getProjectId(), stageProjectId)) continue;
+            if (Objects.equals(f.getParentId(), targetParentId)) continue;
+            incoming.add(f);
+        }
+        if (incoming.isEmpty()) return;
+
+        long newCount = count + incoming.size();
+        long newBytes = bytes + incoming.stream().mapToLong(StageQuotaService::sizeOf).sum();
+
+        if (newCount > FREE_MAX_FILES) {
+            throw new StageQuotaExceededException(
+                    "文件缓存区免费版最多存放 " + FREE_MAX_FILES + " 个文件，当前已有 " + count
+                            + " 个。已有文件不会被删除，可以先移出几个，或解锁无限版。",
+                    count, bytes, FREE_MAX_FILES, FREE_MAX_BYTES);
+        }
+        if (newBytes > FREE_MAX_BYTES) {
+            throw new StageQuotaExceededException(
+                    "文件缓存区免费版总量上限 " + formatMb(FREE_MAX_BYTES) + "，当前已用 " + formatMb(bytes)
+                            + "。已有文件不会被删除，可以先移出几个，或解锁无限版。",
+                    count, bytes, FREE_MAX_FILES, FREE_MAX_BYTES);
+        }
+    }
+
+    /**
+     * 缓存区当前用量，供前端顶部用量条使用。
+     * 上限字段在拥有无限版时为 null——前端据此不显示用量条。
+     */
+    public Map<String, Object> usage(Long stagingFolderId) {
+        List<ProjectFile> existing = currentFiles(stagingFolderId);
+        boolean unlimited = entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("fileCount", existing.size());
+        result.put("totalBytes", existing.stream().mapToLong(StageQuotaService::sizeOf).sum());
+        result.put("limited", !unlimited);
+        result.put("maxFiles", unlimited ? null : FREE_MAX_FILES);
+        result.put("maxBytes", unlimited ? null : FREE_MAX_BYTES);
+        return result;
+    }
+
+    /** 缓存区里的文件（不含子文件夹本身，不含回收站里的）。 */
+    private List<ProjectFile> currentFiles(Long stagingFolderId) {
+        if (stagingFolderId == null) return List.of();
+        return projectFileRepository.findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc(
+                        projectFileRepository.findById(stagingFolderId).map(ProjectFile::getProjectId).orElse(null),
+                        stagingFolderId).stream()
+                .filter(f -> !Boolean.TRUE.equals(f.getIsFolder()))
+                .toList();
+    }
+
+    private static long sizeOf(ProjectFile f) {
+        Long size = f.getFileSize();
+        return size == null || size < 0 ? 0L : size;
+    }
+
+    private static String formatMb(long bytes) {
+        return Math.round(bytes / 1024.0 / 1024.0) + "MB";
+    }
+}

--- a/backend/src/main/java/com/checkba/service/quota/StageQuotaService.java
+++ b/backend/src/main/java/com/checkba/service/quota/StageQuotaService.java
@@ -5,13 +5,20 @@ import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.ProjectFileRepository;
 import com.checkba.service.entitlement.EntitlementService;
 import com.checkba.service.entitlement.FeatureCatalog;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * 文件缓存区（左下角「文件暂存区」）的免费额度（Spec §5）。
@@ -22,9 +29,11 @@ import java.util.Objects;
  * <b>已经在缓存区里的文件一律不动、不删、不隐藏</b>。这是本功能的核心不变式——
  * 剪贴板那侧是「隐藏超出部分」，这侧是「不再新增」，两者都不碰用户已有数据。</p>
  *
- * <p>拥有 {@code stage.unlimited} 时完全不限制。</p>
+ * <p>拥有 {@code stage.unlimited} 时完全不限制；
+ * 非单机模式（团队案件库服务器）同样完全不限制，见 {@link #limited()}。</p>
  */
 @Service
+@Slf4j
 public class StageQuotaService {
 
     /** 缓存区文件夹名（与前端 stagingArea.js 的 folderName 必须一致）。 */
@@ -36,12 +45,42 @@ public class StageQuotaService {
     /** 免费版缓存区总字节上限（500MB）。 */
     public static final long FREE_MAX_BYTES = 500L * 1024 * 1024;
 
+    /**
+     * 递归统计时最多下钻的目录数。额度检查在每次移入的热路径上，
+     * 脏数据里若存在父子成环（历史数据修复留下的）不能让它一直转下去。
+     * 5000 个目录远超缓存区的正常规模，触顶只会让统计偏小（放行），不会误拦。
+     */
+    private static final int MAX_SCANNED_FOLDERS = 5000;
+
     private final ProjectFileRepository projectFileRepository;
     private final EntitlementService entitlementService;
+    private final boolean localMode;
 
-    public StageQuotaService(ProjectFileRepository projectFileRepository, EntitlementService entitlementService) {
+    public StageQuotaService(ProjectFileRepository projectFileRepository,
+                             EntitlementService entitlementService,
+                             @Value("${security.local-mode:false}") boolean localMode) {
         this.projectFileRepository = projectFileRepository;
         this.entitlementService = entitlementService;
+        this.localMode = localMode;
+    }
+
+    /**
+     * 现在是否要执行免费额度。
+     *
+     * <p>两个「不限制」的理由不同：</p>
+     * <ul>
+     *   <li>拥有 {@code stage.unlimited}：用户买了；</li>
+     *   <li>非单机模式：{@link EntitlementService} 是<b>按本机</b>的（来源是本机
+     *       {@code ~/.aiworkdeck} 的 license/account 状态，没有 userId 维度）。
+     *       部署成团队案件库时服务器上根本不存在账户状态，权益恒为空——真照着执行，
+     *       每个接入的成员都会被截到 20 个文件且永远无法解锁。这两个 SKU 卖的是
+     *       单机版的本地能力，服务器部署一律不限，与 {@code LicenseController}
+     *       「非 local-mode 恒为已解锁正式版」同口径。</li>
+     * </ul>
+     */
+    private boolean limited() {
+        if (!localMode) return false;
+        return !entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED);
     }
 
     /** 该文件夹是不是缓存区目录。 */
@@ -53,14 +92,17 @@ public class StageQuotaService {
     }
 
     /**
-     * 移入缓存区前的准入检查。目标不是缓存区、或已拥有无限版时直接放行。
+     * 移入缓存区前的准入检查。目标不是缓存区、或不执行额度时直接放行。
+     *
+     * <p>文件夹按<b>它装的全部文件</b>计（递归）：文件树允许把整个文件夹拖进缓存区，
+     * 若只把它算作 1 个条目 0 字节，拖一个装着几万个文件的目录进来就能让两条额度同时失效。</p>
      *
      * @param targetParentId 本次移动的目标目录
      * @param incomingIds    本次要移入的文件 id
      * @throws StageQuotaExceededException 超出额度时抛出，此时一个文件都不会被移动
      */
     public void checkAdmission(Long targetParentId, List<Long> incomingIds) {
-        if (entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)) return;
+        if (!limited()) return;
         if (!isStagingFolder(targetParentId)) return;
 
         // 缓存区所属项目：跨项目的 id 一律不参与计算。批量移动的归属校验在
@@ -69,24 +111,31 @@ public class StageQuotaService {
         Long stageProjectId = projectFileRepository.findById(targetParentId)
                 .map(ProjectFile::getProjectId).orElse(null);
 
-        List<ProjectFile> existing = currentFiles(targetParentId);
-        long count = existing.size();
-        long bytes = existing.stream().mapToLong(StageQuotaService::sizeOf).sum();
+        Subtree existing = subtree(stageProjectId, targetParentId);
+        long count = existing.files().size();
+        long bytes = existing.files().stream().mapToLong(StageQuotaService::sizeOf).sum();
 
-        // 已在缓存区里的文件重复拖入不算新增（前端多选里可能混着已在区内的文件）
-        List<ProjectFile> incoming = new ArrayList<>();
+        // 按 id 去重：多选里同时勾了某个文件夹和它里面的文件时，那些文件只能算一次
+        Map<Long, ProjectFile> incoming = new LinkedHashMap<>();
         for (Long id : incomingIds == null ? List.<Long>of() : incomingIds) {
             if (id == null) continue;
             ProjectFile f = projectFileRepository.findById(id).orElse(null);
             if (f == null) continue;
             if (!Objects.equals(f.getProjectId(), stageProjectId)) continue;
-            if (Objects.equals(f.getParentId(), targetParentId)) continue;
-            incoming.add(f);
+            // 已经在缓存区里（含子目录里）的东西重复拖入不算新增
+            if (existing.nodeIds().contains(id)) continue;
+            if (Boolean.TRUE.equals(f.getIsFolder())) {
+                for (ProjectFile inner : subtree(stageProjectId, id).files()) {
+                    incoming.put(inner.getId(), inner);
+                }
+            } else {
+                incoming.put(id, f);
+            }
         }
         if (incoming.isEmpty()) return;
 
         long newCount = count + incoming.size();
-        long newBytes = bytes + incoming.stream().mapToLong(StageQuotaService::sizeOf).sum();
+        long newBytes = bytes + incoming.values().stream().mapToLong(StageQuotaService::sizeOf).sum();
 
         if (newCount > FREE_MAX_FILES) {
             throw new StageQuotaExceededException(
@@ -108,24 +157,65 @@ public class StageQuotaService {
      */
     public Map<String, Object> usage(Long stagingFolderId) {
         List<ProjectFile> existing = currentFiles(stagingFolderId);
-        boolean unlimited = entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED);
+        boolean limited = limited();
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("fileCount", existing.size());
         result.put("totalBytes", existing.stream().mapToLong(StageQuotaService::sizeOf).sum());
-        result.put("limited", !unlimited);
-        result.put("maxFiles", unlimited ? null : FREE_MAX_FILES);
-        result.put("maxBytes", unlimited ? null : FREE_MAX_BYTES);
+        result.put("limited", limited);
+        result.put("maxFiles", limited ? FREE_MAX_FILES : null);
+        result.put("maxBytes", limited ? FREE_MAX_BYTES : null);
         return result;
     }
 
-    /** 缓存区里的文件（不含子文件夹本身，不含回收站里的）。 */
+    /**
+     * 缓存区里的文件（递归进子文件夹，不含文件夹自身，不含回收站里的）。
+     * 与 {@link #checkAdmission} 同一口径——用量条显示的数字必须就是额度判定用的数字，
+     * 否则会出现「条显示 3/20 却拒绝第 4 个」这种无法自证的状态。
+     */
     private List<ProjectFile> currentFiles(Long stagingFolderId) {
         if (stagingFolderId == null) return List.of();
-        return projectFileRepository.findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc(
-                        projectFileRepository.findById(stagingFolderId).map(ProjectFile::getProjectId).orElse(null),
-                        stagingFolderId).stream()
-                .filter(f -> !Boolean.TRUE.equals(f.getIsFolder()))
-                .toList();
+        Long projectId = projectFileRepository.findById(stagingFolderId)
+                .map(ProjectFile::getProjectId).orElse(null);
+        return subtree(projectId, stagingFolderId).files();
+    }
+
+    /**
+     * 一棵子树的展开结果。
+     *
+     * @param files   树里的全部文件（不含文件夹自身）
+     * @param nodeIds 树里的全部节点 id（含文件夹），用来判断某个 id 是不是已经在树里了
+     */
+    private record Subtree(List<ProjectFile> files, Set<Long> nodeIds) {}
+
+    /** 广度优先展开 rootId 下的整棵树。rootId 本身不计入。 */
+    private Subtree subtree(Long projectId, Long rootId) {
+        List<ProjectFile> files = new ArrayList<>();
+        Set<Long> nodeIds = new LinkedHashSet<>();
+        if (rootId == null) return new Subtree(files, nodeIds);
+
+        Deque<Long> queue = new ArrayDeque<>();
+        Set<Long> visitedFolders = new HashSet<>();
+        queue.add(rootId);
+        visitedFolders.add(rootId);
+        int scanned = 0;
+        while (!queue.isEmpty()) {
+            if (++scanned > MAX_SCANNED_FOLDERS) {
+                log.warn("缓存区目录扫描触顶（{} 个目录），用量统计可能偏小: rootId={}", MAX_SCANNED_FOLDERS, rootId);
+                break;
+            }
+            Long parentId = queue.poll();
+            for (ProjectFile child : projectFileRepository
+                    .findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc(projectId, parentId)) {
+                if (child.getId() == null) continue;
+                nodeIds.add(child.getId());
+                if (Boolean.TRUE.equals(child.getIsFolder())) {
+                    if (visitedFolders.add(child.getId())) queue.add(child.getId());
+                } else {
+                    files.add(child);
+                }
+            }
+        }
+        return new Subtree(files, nodeIds);
     }
 
     private static long sizeOf(ProjectFile f) {

--- a/backend/src/main/java/com/checkba/service/storage/StorageLocationService.java
+++ b/backend/src/main/java/com/checkba/service/storage/StorageLocationService.java
@@ -108,6 +108,12 @@ public class StorageLocationService {
      */
     public synchronized Map<String, Object> migrate(String targetPath) {
         Path source = resolver.globalRoot();
+        // 源不可访问时不能往下走：copyTree 见源目录不存在会把它建出来，
+        // 于是「0 个文件迁移成功」，指针切到新的空目录，用户的数据留在拔掉的那块盘上而应用一片空白。
+        if (!Files.isDirectory(source)) {
+            throw new StorageException("当前存储目录不可访问（磁盘未连接或已被移动），无法迁移。"
+                    + "请先接回磁盘再迁移；若不打算继续使用该磁盘，可先恢复默认位置。");
+        }
         Path target = validateTarget(targetPath, source);
 
         boolean createdTargetDir = !Files.exists(target);
@@ -118,6 +124,15 @@ public class StorageLocationService {
             sourceTally = tally(source);
             copyTree(source, target);
             Tally targetTally = tally(target);
+            // 源侧复查：只比「复制前的源」和「复制后的目标」是不够的。复制一棵大树要几分钟，
+            // 期间自动保存/AI 改文档/浏览器下载都会往源里落盘；落在已经被 copyTree 走过的目录里
+            // 的那些文件不会出现在目标里，而两侧数字仍然相等——校验通过、指针切走，
+            // 那个文件在文件树里看得见却打不开。宁可让用户重来一次。
+            Tally sourceAfter = tally(source);
+            if (sourceAfter.files != sourceTally.files || sourceAfter.bytes != sourceTally.bytes) {
+                throw new StorageException("迁移期间原目录发生了变化（可能有文档在自动保存，或有下载/AI 改动在进行），"
+                        + "为确保一个文件都不落下，已放弃本次迁移并保持原位置。请关闭正在编辑的文档后重试。");
+            }
             if (targetTally.files != sourceTally.files || targetTally.bytes != sourceTally.bytes) {
                 throw new StorageException("迁移校验未通过（文件数或大小不一致），已放弃本次迁移");
             }
@@ -135,7 +150,15 @@ public class StorageLocationService {
         State state = new State();
         state.root = target.toString();
         state.movedAt = Instant.now().toString();
-        saveState(state);
+        try {
+            saveState(state);
+        } catch (StorageException e) {
+            // 此时 relocate 还没执行，存储根**没有**切换，目标里躺着一份完整副本。
+            // 留着它下次迁移会撞上「请选择一个空目录」，用户得先手工删目录才能重试——
+            // 所以这里连同副本一起清掉，回到「没点过这个按钮」的状态。源目录全程只读。
+            rollback(target, createdTargetDir);
+            throw e;
+        }
         resolver.relocate(target);
         log.info("存储位置已迁移: {} -> {}（{} 个文件），原目录保留为备份", source, target, sourceTally.files);
 
@@ -147,6 +170,32 @@ public class StorageLocationService {
         return result;
     }
 
+    /**
+     * 恢复到默认位置。<b>只换指针，不搬也不删任何文件</b>——自选目录里的数据原样留在那里。
+     *
+     * <p>为什么它不要求权益（与 {@link #migrate} 不同）：权益可能在自选位置生效之后失效
+     * （Key 被吊销、断开账户、离线超宽限）。此时自选目录若又不可访问（外置盘拔了、被改名），
+     * 用户就被永久困在一个既进不去也换不掉的存储根上，所有文件操作无解释地失败。
+     * 「退回免费版的默认位置」不发放任何付费能力，把它锁在付费墙后面只会制造死局。</p>
+     *
+     * @return 恢复结果：默认位置与被留下的原位置（前端要把原位置显示给用户，文件还在那儿）
+     */
+    public synchronized Map<String, Object> resetToDefault() {
+        Path previous = resolver.globalRoot();
+        Path defaultRoot = resolver.configuredRoot();
+        if (previous.equals(defaultRoot)) {
+            throw new StorageException("当前已经是默认位置");
+        }
+        saveState(new State()); // root=null：下次启动不再应用自选路径
+        resolver.relocate(defaultRoot);
+        log.info("存储位置已恢复默认: {} -> {}（原目录内容一律保留）", previous, defaultRoot);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("path", defaultRoot.toString());
+        result.put("previousPath", previous.toString());
+        return result;
+    }
+
     // ==================== 内部 ====================
 
     private Path validateTarget(String targetPath, Path source) {
@@ -154,14 +203,20 @@ public class StorageLocationService {
             throw new StorageException("请选择一个目录");
         }
         Path target = Path.of(targetPath).toAbsolutePath().normalize();
-        if (target.equals(source)) {
+        // 嵌套判断必须在**解析软链之后**做：normalize() 是纯词法的，
+        // 一个指向源目录内部的软链（/tmp/link -> /data/sub）在词法上与 /data 毫无关系，
+        // 三条围栏全部判 false，随后 copyTree 顺着链把源目录复制进它自己，
+        // 直到路径长度触顶失败，并在用户的数据根里留下几百个垃圾目录。
+        Path realSource = realPathOf(source);
+        Path realTarget = realPathOf(target);
+        if (realTarget.equals(realSource)) {
             throw new StorageException("新位置与当前位置相同");
         }
         // 互相嵌套会让「复制整棵树」变成无限自我复制，或把源埋进目标里
-        if (target.startsWith(source)) {
+        if (realTarget.startsWith(realSource)) {
             throw new StorageException("新位置不能在当前存储目录内部");
         }
-        if (source.startsWith(target)) {
+        if (realSource.startsWith(realTarget)) {
             throw new StorageException("新位置不能是当前存储目录的上级目录");
         }
         if (Files.exists(target) && !Files.isDirectory(target)) {
@@ -179,6 +234,25 @@ public class StorageLocationService {
             }
         }
         return target;
+    }
+
+    /**
+     * 解析软链后的真实路径。路径尚不存在时（用户在选择器里新建的目录），
+     * 取最近的已存在祖先的真实路径，再把剩余的段拼回去。
+     * 解析不了（权限等）就退回词法路径——那只是回到没有本方法时的判定强度，不会更松。
+     */
+    private static Path realPathOf(Path path) {
+        Path existing = path;
+        while (existing != null && !Files.exists(existing)) {
+            existing = existing.getParent();
+        }
+        if (existing == null) return path;
+        try {
+            Path real = existing.toRealPath();
+            return existing.equals(path) ? real : real.resolve(existing.relativize(path));
+        } catch (IOException e) {
+            return path;
+        }
     }
 
     private void assertWritable(Path dir) {
@@ -269,9 +343,9 @@ public class StorageLocationService {
             Files.createDirectories(stateFile.getParent());
             Files.write(stateFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(state));
         } catch (Exception e) {
-            // 数据已经搬过去了，只是没记住。抛出去让用户知道要重来一次，
-            // 比默默回到旧位置（新位置留一份孤儿副本）好。
-            throw new StorageException("存储位置已迁移但配置写入失败，请重试：" + e.getMessage());
+            // 抛出去（而不是吞掉）：配置没记住就等于这次操作没发生，调用方据此回滚并保持原位置。
+            // 注意文案不能说「已迁移」——此时 relocate 还没执行，存储根一动没动。
+            throw new StorageException("存储位置配置写入失败，已保持原位置：" + e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/checkba/service/storage/StorageLocationService.java
+++ b/backend/src/main/java/com/checkba/service/storage/StorageLocationService.java
@@ -1,0 +1,277 @@
+package com.checkba.service.storage;
+
+import com.checkba.storage.ProjectStorageResolver;
+import com.checkba.storage.StorageException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 用户自选的本机文件存储位置（Spec §5「付费解锁后需用户自行指定本地存储路径」）。
+ *
+ * <h3>它管的到底是什么</h3>
+ * 文件缓存区里的文件就是项目文件（「加入缓存区」= 移进项目内的 {@code __staging_area__} 目录），
+ * 物理上都躺在全局存储根下，没有独立的缓存区目录可搬。因此本服务搬的是
+ * <b>全局存储根</b>——即项目文件与缓存区文件在本机的落盘位置。
+ * 数据库里存的是逻辑路径，物理位置全部经 {@link ProjectStorageResolver} 解析，
+ * 所以迁移只需搬目录 + 换指针，无需改任何一行数据。
+ *
+ * <h3>迁移策略：复制 → 校验 → 换指针 → 原目录留作备份</h3>
+ * <b>绝不先删后搬。</b>顺序是：
+ * <ol>
+ *   <li>校验目标目录（绝对路径、可写、与源不互相嵌套、为空或不存在）；</li>
+ *   <li>整棵树复制过去，边复制边记数；</li>
+ *   <li>校验目标的文件数与总字节数与源一致，不一致即失败；</li>
+ *   <li>写落盘配置 + 切换解析器指针；</li>
+ *   <li><b>原目录原封不动保留</b>，由用户确认无误后自行删除。</li>
+ * </ol>
+ * 任一步失败都会清掉本次在目标目录里复制出来的内容（那些全是本次新建的副本，
+ * 删它们不碰任何原始数据），并保持配置指向原路径——失败后的状态与没点过这个按钮完全一样。
+ *
+ * <h3>为什么配置落文件而不落数据库</h3>
+ * 存储根必须在任何文件操作发生之前就确定，而数据库要等 JPA 起来才能读，
+ * 存在启动期先后顺序的窟窿。落在 {@code ~/.aiworkdeck/storage-location.json}
+ * （与 license/entitlements 同一个状态目录）则可在解析器构造完成后立刻应用。
+ */
+@Service
+@Slf4j
+public class StorageLocationService {
+
+    private final ProjectStorageResolver resolver;
+    private final Path stateFile;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public StorageLocationService(
+            ProjectStorageResolver resolver,
+            @Value("${security.license.dir:${user.home}/.aiworkdeck}") String stateDir) {
+        this.resolver = resolver;
+        this.stateFile = Path.of(stateDir, "storage-location.json");
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class State {
+        public String root;
+        public String movedAt;
+    }
+
+    /**
+     * 启动时应用已保存的自选位置。
+     * 目录不存在（外置硬盘没插、被改名）时**不静默回退**到默认位置——那会让用户面对一个空白的
+     * 应用并以为数据没了，而真相是数据好端端躺在别处。这里保持指向该路径并告警，
+     * 文件操作会明确失败，设置页也仍显示这个路径，用户知道该去插硬盘。
+     */
+    @PostConstruct
+    void applyOnStartup() {
+        State state = loadState();
+        if (state.root == null || state.root.isBlank()) return;
+        Path saved = Path.of(state.root).toAbsolutePath().normalize();
+        if (!Files.isDirectory(saved)) {
+            log.warn("自选存储位置当前不可用（目录不存在）: {}。已保持指向该位置，请检查磁盘是否连接。", saved);
+        }
+        resolver.relocate(saved);
+        log.info("存储位置已应用自选路径: {}", saved);
+    }
+
+    /** 设置页展示用的当前状态。 */
+    public Map<String, Object> current() {
+        Path root = resolver.globalRoot();
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("path", root.toString());
+        result.put("defaultPath", resolver.configuredRoot().toString());
+        result.put("custom", !root.equals(resolver.configuredRoot()));
+        result.put("available", Files.isDirectory(root));
+        State state = loadState();
+        result.put("movedAt", state.movedAt);
+        return result;
+    }
+
+    /**
+     * 迁移到新位置。同步执行（数据量可能不小，前端要给等待态）。
+     *
+     * @return 迁移结果：搬了多少文件、多少字节、原路径（保留为备份）
+     * @throws StorageException 校验或迁移失败；此时存储位置维持原样，用户数据一个字节没动
+     */
+    public synchronized Map<String, Object> migrate(String targetPath) {
+        Path source = resolver.globalRoot();
+        Path target = validateTarget(targetPath, source);
+
+        boolean createdTargetDir = !Files.exists(target);
+        Tally sourceTally;
+        try {
+            Files.createDirectories(target);
+            assertWritable(target);
+            sourceTally = tally(source);
+            copyTree(source, target);
+            Tally targetTally = tally(target);
+            if (targetTally.files != sourceTally.files || targetTally.bytes != sourceTally.bytes) {
+                throw new StorageException("迁移校验未通过（文件数或大小不一致），已放弃本次迁移");
+            }
+        } catch (StorageException e) {
+            rollback(target, createdTargetDir);
+            throw e;
+        } catch (Exception e) {
+            rollback(target, createdTargetDir);
+            log.error("存储位置迁移失败，已回滚，仍使用原位置: {}", source, e);
+            throw new StorageException("迁移失败，已保持原存储位置：" + e.getMessage());
+        }
+
+        // 复制与校验都过了才落配置、才换指针。这两步之间即使进程被杀，
+        // 下次启动会按配置文件走新位置，数据已经在那里了。
+        State state = new State();
+        state.root = target.toString();
+        state.movedAt = Instant.now().toString();
+        saveState(state);
+        resolver.relocate(target);
+        log.info("存储位置已迁移: {} -> {}（{} 个文件），原目录保留为备份", source, target, sourceTally.files);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("path", target.toString());
+        result.put("previousPath", source.toString());
+        result.put("movedFiles", sourceTally.files);
+        result.put("movedBytes", sourceTally.bytes);
+        return result;
+    }
+
+    // ==================== 内部 ====================
+
+    private Path validateTarget(String targetPath, Path source) {
+        if (targetPath == null || targetPath.isBlank()) {
+            throw new StorageException("请选择一个目录");
+        }
+        Path target = Path.of(targetPath).toAbsolutePath().normalize();
+        if (target.equals(source)) {
+            throw new StorageException("新位置与当前位置相同");
+        }
+        // 互相嵌套会让「复制整棵树」变成无限自我复制，或把源埋进目标里
+        if (target.startsWith(source)) {
+            throw new StorageException("新位置不能在当前存储目录内部");
+        }
+        if (source.startsWith(target)) {
+            throw new StorageException("新位置不能是当前存储目录的上级目录");
+        }
+        if (Files.exists(target) && !Files.isDirectory(target)) {
+            throw new StorageException("所选路径不是目录");
+        }
+        // 只接受空目录：避免与目标里已有的同名文件发生覆盖或合并语义，
+        // 那是丢数据最容易发生的地方
+        if (Files.isDirectory(target)) {
+            try (var entries = Files.list(target)) {
+                if (entries.findAny().isPresent()) {
+                    throw new StorageException("请选择一个空目录（或新建一个），以免与已有文件混在一起");
+                }
+            } catch (IOException e) {
+                throw new StorageException("无法读取所选目录：" + e.getMessage());
+            }
+        }
+        return target;
+    }
+
+    private void assertWritable(Path dir) {
+        Path probe = dir.resolve(".awd-write-probe");
+        try {
+            Files.writeString(probe, "ok");
+            Files.deleteIfExists(probe);
+        } catch (IOException e) {
+            throw new StorageException("所选目录不可写，请换一个位置或检查权限");
+        }
+    }
+
+    /** 复制整棵树。目标已确保为空，不存在覆盖既有文件的可能。 */
+    private void copyTree(Path source, Path target) throws IOException {
+        if (!Files.exists(source)) {
+            Files.createDirectories(source);
+            return;
+        }
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                Files.createDirectories(target.resolve(source.relativize(dir).toString()));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.copy(file, target.resolve(source.relativize(file).toString()),
+                        StandardCopyOption.COPY_ATTRIBUTES);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    record Tally(long files, long bytes) {}
+
+    /** package-private 是留给测试的接缝：覆写它即可制造「校验不通过」以验证回滚。 */
+    Tally tally(Path root) throws IOException {
+        if (!Files.exists(root)) return new Tally(0, 0);
+        long[] acc = new long[2];
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                acc[0]++;
+                acc[1] += attrs.size();
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return new Tally(acc[0], acc[1]);
+    }
+
+    /**
+     * 回滚：只删本次复制到目标目录里的内容。目标事前已校验为空目录（或不存在），
+     * 所以这里删掉的每一个字节都是本次刚生成的副本，用户的原始数据在源目录纹丝不动。
+     */
+    private void rollback(Path target, boolean createdTargetDir) {
+        try {
+            if (!Files.exists(target)) return;
+            try (var walk = Files.walk(target)) {
+                walk.sorted(Comparator.reverseOrder())
+                        .filter(p -> createdTargetDir || !p.equals(target))
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (IOException ignored) {
+                                // 残留副本不影响正确性，源数据未动；下次迁移会因目录非空而被拦下
+                            }
+                        });
+            }
+        } catch (Exception e) {
+            log.warn("迁移回滚清理不完整（不影响原数据）: {}", e.getMessage());
+        }
+    }
+
+    State loadState() {
+        try {
+            if (!Files.exists(stateFile)) return new State();
+            State s = objectMapper.readValue(Files.readAllBytes(stateFile), State.class);
+            return s == null ? new State() : s;
+        } catch (Exception e) {
+            log.warn("storage-location.json 读取失败，按默认位置处理: {}", e.getMessage());
+            return new State();
+        }
+    }
+
+    void saveState(State state) {
+        try {
+            Files.createDirectories(stateFile.getParent());
+            Files.write(stateFile, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(state));
+        } catch (Exception e) {
+            // 数据已经搬过去了，只是没记住。抛出去让用户知道要重来一次，
+            // 比默默回到旧位置（新位置留一份孤儿副本）好。
+            throw new StorageException("存储位置已迁移但配置写入失败，请重试：" + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/storage/ProjectStorageResolver.java
+++ b/backend/src/main/java/com/checkba/storage/ProjectStorageResolver.java
@@ -34,14 +34,21 @@ public class ProjectStorageResolver {
     private static final Pattern PROJECT_KEY = Pattern.compile("^projects/(\\d+)(?:/(.*))?$");
 
     private final ProjectRepository projectRepository;
-    private final Path globalRoot;
+    /**
+     * 全局存储根。可在运行期被 {@code StorageLocationService} 改写（用户自选存储位置，PR-C），
+     * 故为 volatile：迁移线程写、各业务线程读。
+     */
+    private volatile Path globalRoot;
+    /** 配置文件里写的默认位置，迁移后仍需展示「默认位置」与判断是否已自选。 */
+    private final Path configuredRoot;
     private final Path templateDoc;
     /** projectId → localRoot（Optional.empty = 存量托管项目）。只缓存确实存在的项目行。 */
     private final Map<Long, Optional<Path>> localRootCache = new ConcurrentHashMap<>();
 
     public ProjectStorageResolver(StorageProperties storageProperties, ProjectRepository projectRepository) {
         this.projectRepository = projectRepository;
-        this.globalRoot = resolveConfiguredPath(storageProperties.getLocal().getRootPath());
+        this.configuredRoot = resolveConfiguredPath(storageProperties.getLocal().getRootPath());
+        this.globalRoot = configuredRoot;
         this.templateDoc = resolveConfiguredPath(storageProperties.getLocal().getTemplatePath());
     }
 
@@ -66,6 +73,24 @@ public class ProjectStorageResolver {
     /** 全局存储根（data 根）。全局命名空间与托管项目都在它下面。 */
     public Path globalRoot() {
         return globalRoot;
+    }
+
+    /** 配置文件里的默认存储根（未自选存储位置时与 {@link #globalRoot()} 相同）。 */
+    public Path configuredRoot() {
+        return configuredRoot;
+    }
+
+    /**
+     * 切换全局存储根。**只由 {@code StorageLocationService} 在迁移成功后调用**——
+     * 它负责把数据先复制到位并校验，这里只做指针切换。
+     *
+     * 之所以能安全地热切：数据库里存的是逻辑路径（{@code projects/{id}/...}），
+     * 物理位置全部经本类解析；git 仓库的 gitDir/workTree 也每次现算
+     * （见 ProjectRepoService），没有任何绝对路径被持久化。
+     */
+    public void relocate(Path newRoot) {
+        if (newRoot == null) throw new StorageException("存储位置不能为空");
+        this.globalRoot = newRoot.toAbsolutePath().normalize();
     }
 
     /** 新建文档模板路径。 */

--- a/backend/src/test/java/com/checkba/controller/ProjectFileControllerIdorTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectFileControllerIdorTest.java
@@ -27,9 +27,50 @@ class ProjectFileControllerIdorTest {
     private ProjectMemberService projectMemberService;
     @Mock
     private FileTagService fileTagService;
+    @Mock
+    private com.checkba.service.quota.StageQuotaService stageQuotaService;
 
     @InjectMocks
     private ProjectFileController controller;
+
+    /**
+     * 缓存区用量端点吃的是全局 folderId，只验路径上的 projectId 是不够的：
+     * 服务层从文件夹自己那一行反查 projectId 再列子项，路径参数根本不参与约束，
+     * 于是 A 项目的成员能拿自己的 projectId 枚举出 B 项目任意目录的文件数与总字节。
+     */
+    @Test
+    void stageUsageRejectsFolderFromAnotherProject() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+            when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+            // 目标文件夹属于项目 999
+            ProjectFile foreign = new ProjectFile();
+            foreign.setId(777L);
+            foreign.setProjectId(999L);
+            when(projectFileService.getFile(777L)).thenReturn(foreign);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.stageUsage(1L, 777L, "sess"));
+            verify(stageQuotaService, never()).usage(anyLong());
+        }
+    }
+
+    @Test
+    void stageUsageAllowsFolderWithinSameProject() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+            when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+            ProjectFile own = new ProjectFile();
+            own.setId(100L);
+            own.setProjectId(1L);
+            when(projectFileService.getFile(100L)).thenReturn(own);
+
+            controller.stageUsage(1L, 100L, "sess");
+            verify(stageQuotaService).usage(100L);
+        }
+    }
 
     @Test
     void renameRejectsFileFromAnotherProject() {

--- a/backend/src/test/java/com/checkba/service/ClipboardQuotaTest.java
+++ b/backend/src/test/java/com/checkba/service/ClipboardQuotaTest.java
@@ -1,0 +1,192 @@
+package com.checkba.service;
+
+import com.checkba.model.dto.ClipboardListResult;
+import com.checkba.model.entity.ClipboardItem;
+import com.checkba.repository.ClipboardItemRepository;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.entitlement.FeatureCatalog;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 剪贴板免费额度（Spec §5）。锁定的是这几件事：
+ * <ul>
+ *   <li>额度是<b>查询侧过滤</b>——任何路径都不得调用 delete；</li>
+ *   <li>条数上限 20 与保留 3 天<b>同时</b>生效，取更严者；</li>
+ *   <li>hiddenCount 只算「因额度看不见」的，不含仅被分页 limit 挡住的；</li>
+ *   <li>拥有 clipboard.unlimited 时完全不过滤，之前被隐藏的记录原样回来。</li>
+ * </ul>
+ */
+class ClipboardQuotaTest {
+
+    private static final Long USER = 7L;
+
+    private ClipboardItemRepository repository;
+    private EntitlementService entitlementService;
+    private ClipboardService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ClipboardItemRepository.class);
+        entitlementService = mock(EntitlementService.class);
+        service = new ClipboardService(repository, mock(StorageServiceFactory.class), entitlementService);
+        when(entitlementService.isEnabled(anyString())).thenReturn(false);
+    }
+
+    /** 造 n 条记录，第 i 条的 createdAt 是 i 小时前（越靠前越新）。 */
+    private static List<ClipboardItem> items(int n, int hoursApart) {
+        List<ClipboardItem> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            ClipboardItem it = new ClipboardItem();
+            it.setId((long) (i + 1));
+            it.setUserId(USER);
+            it.setType("TEXT");
+            it.setText("t" + i);
+            it.setCreatedAt(LocalDateTime.now().minusHours((long) i * hoursApart));
+            list.add(it);
+        }
+        return list;
+    }
+
+    /** 仓库按 (userId, pageable) 返回前 pageSize 条。 */
+    private void stubList(List<ClipboardItem> all) {
+        when(repository.findByUserIdOrderByCreatedAtDesc(eq(USER), any(Pageable.class)))
+                .thenAnswer(inv -> {
+                    Pageable p = inv.getArgument(1);
+                    return all.subList(0, Math.min(all.size(), p.getPageSize()));
+                });
+        when(repository.countByUserId(USER)).thenReturn((long) all.size());
+        when(repository.countByUserIdAndCreatedAtAfter(eq(USER), any(LocalDateTime.class)))
+                .thenAnswer(inv -> {
+                    LocalDateTime cutoff = inv.getArgument(1);
+                    return all.stream().filter(i -> i.getCreatedAt().isAfter(cutoff)).count();
+                });
+    }
+
+    @Test
+    @DisplayName("19 条（全在 3 天内）：全部可见，不提示受限条数")
+    void nineteenItemsAllVisible() {
+        stubList(items(19, 1));
+        ClipboardListResult res = service.list(USER, null, 80);
+        assertEquals(19, res.items().size());
+        assertTrue(res.limited(), "免费版始终标记 limited，供前端说明额度存在");
+        assertEquals(0, res.hiddenCount());
+        assertEquals(20, res.maxItems());
+        assertEquals(3, res.retentionDays());
+    }
+
+    @Test
+    @DisplayName("正好 20 条：全部可见，hiddenCount 仍为 0（上限是闭区间）")
+    void twentyItemsAllVisible() {
+        stubList(items(20, 1));
+        ClipboardListResult res = service.list(USER, null, 80);
+        assertEquals(20, res.items().size());
+        assertEquals(0, res.hiddenCount());
+    }
+
+    @Test
+    @DisplayName("21 条：只回 20 条，第 21 条计入 hiddenCount 而不是被删")
+    void twentyOneItemsHidesOne() {
+        stubList(items(21, 1));
+        ClipboardListResult res = service.list(USER, null, 80);
+        assertEquals(20, res.items().size());
+        assertEquals(1, res.hiddenCount());
+        verify(repository, never()).delete(any());
+        verify(repository, never()).deleteAll(any());
+    }
+
+    @Test
+    @DisplayName("3 天边界：超过 3 天的记录不可见，即使总数不到 20 条")
+    void retentionCutsBeforeCountLimit() {
+        // 5 条，每条隔 24 小时：第 4、5 条（72h、96h 前）落在 3 天线外
+        List<ClipboardItem> all = items(5, 24);
+        stubList(all);
+        ClipboardListResult res = service.list(USER, null, 80);
+        // 严格早于 now-3d 的被滤掉；72h 前那条正好压线，isAfter(cutoff) 为 false
+        assertTrue(res.items().size() <= 3, "3 天以外的记录不应可见，实际返回 " + res.items().size());
+        assertTrue(res.items().stream()
+                .allMatch(i -> i.getCreatedAt().isAfter(LocalDateTime.now().minusDays(3))));
+        assertEquals(5 - res.items().size(), res.hiddenCount(),
+                "总数减去 3 天内可见数即为被额度挡住的条数");
+    }
+
+    @Test
+    @DisplayName("两条额度同时生效：30 条且只有 25 条在 3 天内 → 可见 20，隐藏 10")
+    void bothLimitsApplyTakingStricter() {
+        List<ClipboardItem> all = new ArrayList<>(items(25, 1));       // 25 条在 3 天内
+        List<ClipboardItem> old = items(5, 1);                          // 另外 5 条挪到 10 天前
+        old.forEach(i -> i.setCreatedAt(LocalDateTime.now().minusDays(10)));
+        all.addAll(old);
+        stubList(all);
+
+        ClipboardListResult res = service.list(USER, null, 80);
+        assertEquals(20, res.items().size());
+        assertEquals(10, res.hiddenCount(), "30 总数 - min(25 条 3 天内, 20 上限) = 10");
+    }
+
+    @Test
+    @DisplayName("hiddenCount 不把分页 limit 挡住的算作额度隐藏")
+    void pagingLimitIsNotCountedAsQuotaHidden() {
+        stubList(items(25, 1));
+        ClipboardListResult res = service.list(USER, null, 5); // 前端只要 5 条
+        assertEquals(5, res.items().size());
+        assertEquals(5, res.hiddenCount(),
+                "25 - min(25, 20) = 5：另外 15 条是分页挡的，付费用户同样看不到，不能算进解锁提示");
+    }
+
+    @Test
+    @DisplayName("拥有 clipboard.unlimited：不过滤、不截断、不标记受限")
+    void unlimitedReturnsEverything() {
+        when(entitlementService.isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED)).thenReturn(true);
+        List<ClipboardItem> all = items(50, 24); // 大半在 3 天以外
+        stubList(all);
+
+        ClipboardListResult res = service.list(USER, null, 80);
+        assertEquals(50, res.items().size(), "解锁后此前被隐藏的历史记录必须原样出现");
+        assertFalse(res.limited());
+        assertEquals(0, res.hiddenCount());
+        assertNull(res.maxItems());
+        assertNull(res.retentionDays());
+    }
+
+    @Test
+    @DisplayName("搜索场景走 search 计数，额度同样只过滤不删除")
+    void searchPathAlsoQuotaFiltered() {
+        List<ClipboardItem> all = items(21, 1);
+        when(repository.search(eq(USER), eq("合同"), any(Pageable.class)))
+                .thenAnswer(inv -> {
+                    Pageable p = inv.getArgument(2);
+                    return all.subList(0, Math.min(all.size(), p.getPageSize()));
+                });
+        when(repository.countSearch(USER, "合同")).thenReturn(21L);
+        when(repository.countSearchAfter(eq(USER), eq("合同"), any(LocalDateTime.class))).thenReturn(21L);
+
+        ClipboardListResult res = service.list(USER, "合同", 80);
+        assertEquals(20, res.items().size());
+        assertEquals(1, res.hiddenCount());
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("空库：可见 0 条，隐藏 0 条")
+    void emptyLibrary() {
+        stubList(List.of());
+        ClipboardListResult res = service.list(USER, null, 80);
+        assertEquals(0, res.items().size());
+        assertEquals(0, res.hiddenCount());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ClipboardQuotaTest.java
+++ b/backend/src/test/java/com/checkba/service/ClipboardQuotaTest.java
@@ -43,7 +43,8 @@ class ClipboardQuotaTest {
     void setUp() {
         repository = mock(ClipboardItemRepository.class);
         entitlementService = mock(EntitlementService.class);
-        service = new ClipboardService(repository, mock(StorageServiceFactory.class), entitlementService);
+        // localMode=true：额度只在桌面单机版执行，团队服务器不限（见 ClipboardService.list 注释）
+        service = new ClipboardService(repository, mock(StorageServiceFactory.class), entitlementService, true);
         when(entitlementService.isEnabled(anyString())).thenReturn(false);
     }
 
@@ -188,5 +189,20 @@ class ClipboardQuotaTest {
         ClipboardListResult res = service.list(USER, null, 80);
         assertEquals(0, res.items().size());
         assertEquals(0, res.hiddenCount());
+    }
+
+    @Test
+    @DisplayName("非单机模式（团队案件库服务器）不执行额度：本机权益对服务器成员没有意义")
+    void serverModeIsNeverLimited() {
+        ClipboardService serverSide = new ClipboardService(
+                repository, mock(StorageServiceFactory.class), entitlementService, false);
+        List<ClipboardItem> all = items(50, 24); // 大半在 3 天以外
+        stubList(all);
+
+        ClipboardListResult res = serverSide.list(USER, null, 80);
+        assertEquals(50, res.items().size(), "服务器上没有本机权益可言，不能把成员截到 20 条");
+        assertFalse(res.limited());
+        assertEquals(0, res.hiddenCount());
+        verify(entitlementService, never()).isEnabled(FeatureCatalog.CLIPBOARD_UNLIMITED);
     }
 }

--- a/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
@@ -65,7 +65,8 @@ class LocalProjectServiceTest {
                 mock(com.checkba.service.ai.ProjectRagService.class),
                 storageFactory,
                 mock(com.checkba.version.WorkSessionService.class),
-                mock(UserService.class));
+                mock(UserService.class),
+                mock(com.checkba.service.quota.StageQuotaService.class));
 
         ProjectMemberService memberService = mock(ProjectMemberService.class);
         when(memberService.hasReadPermission(anyLong(), anyLong())).thenReturn(true);

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
@@ -25,6 +25,10 @@ class ProjectFileServiceIdorTest {
     @Mock
     private ProjectFileRepository projectFileRepository;
 
+    /** 额度检查在 batchMove 里先于逐个归属校验执行，不给它一个实例会 NPE 掩盖真正的断言。 */
+    @Mock
+    private com.checkba.service.quota.StageQuotaService stageQuotaService;
+
     @InjectMocks
     private ProjectFileService projectFileService;
 

--- a/backend/src/test/java/com/checkba/service/quota/StageQuotaServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/quota/StageQuotaServiceTest.java
@@ -42,7 +42,8 @@ class StageQuotaServiceTest {
         repository = mock(ProjectFileRepository.class);
         entitlementService = mock(EntitlementService.class);
         when(entitlementService.isEnabled(anyString())).thenReturn(false);
-        service = new StageQuotaService(repository, entitlementService);
+        // localMode=true：额度只在桌面单机版执行，团队服务器不限（见 StageQuotaService.limited 注释）
+        service = new StageQuotaService(repository, entitlementService, true);
 
         table.clear();
         put(folder(STAGE_FOLDER, StageQuotaService.STAGING_FOLDER_NAME));
@@ -209,12 +210,113 @@ class StageQuotaServiceTest {
     }
 
     @Test
-    @DisplayName("子文件夹不计入文件数")
+    @DisplayName("空的子文件夹本身不计入文件数")
     void subFoldersNotCounted() {
         fillStage(19, 1024);
         ProjectFile sub = folder(1900L, "子目录");
         sub.setParentId(STAGE_FOLDER);
         put(sub);
         assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, pending(1, 1024)));
+    }
+
+    // ==================== 文件夹递归（拖文件夹曾能整体绕过额度） ====================
+
+    /** 造一个装了 n 个文件的文件夹，返回文件夹 id。 */
+    private Long folderWith(Long folderId, int n, long size) {
+        ProjectFile dir = folder(folderId, "尽调材料");
+        dir.setParentId(OTHER_FOLDER);
+        put(dir);
+        for (int i = 0; i < n; i++) put(file(folderId + 1 + i, folderId, size));
+        return folderId;
+    }
+
+    @Test
+    @DisplayName("拖入的文件夹按它装的文件数计——不能靠套一层目录绕过条数上限")
+    void incomingFolderCountsItsFiles() {
+        fillStage(15, 1024);
+        Long dir = folderWith(3000L, 10, 1024); // 15 + 10 = 25 > 20
+
+        StageQuotaExceededException e = assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, List.of(dir)));
+        assertTrue(e.getMessage().contains("已有文件不会被删除"));
+        verify(repository, never()).delete(any());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("拖入的文件夹按它装的字节数计——不能靠套一层目录绕过 500MB")
+    void incomingFolderCountsItsBytes() {
+        Long dir = folderWith(3000L, 2, StageQuotaService.FREE_MAX_BYTES);
+        assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, List.of(dir)));
+    }
+
+    @Test
+    @DisplayName("多层嵌套的文件夹也要一路数到底")
+    void nestedFoldersCountedRecursively() {
+        Long outer = folderWith(3000L, 5, 1024);
+        ProjectFile inner = folder(4000L, "第二层");
+        inner.setParentId(outer);
+        put(inner);
+        for (int i = 0; i < 16; i++) put(file(4100L + i, 4000L, 1024)); // 5 + 16 = 21 > 20
+
+        assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, List.of(outer)));
+    }
+
+    @Test
+    @DisplayName("同时勾了文件夹和它里面的文件：里面的文件只算一次")
+    void folderAndItsChildSelectedTogetherCountedOnce() {
+        fillStage(10, 1024);
+        Long dir = folderWith(3000L, 10, 1024); // 10 + 10 = 20，正好到上限
+        // 3001 是 dir 里的第一个文件，与 dir 一起选中；重复计数会变成 21 而误拒
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, List.of(dir, 3001L)));
+    }
+
+    @Test
+    @DisplayName("缓存区子目录里的存量文件计入用量，且不被当作新增重复计一次")
+    void filesInStageSubFolderCountAsExisting() {
+        ProjectFile sub = folder(1900L, "旧批次");
+        sub.setParentId(STAGE_FOLDER);
+        put(sub);
+        for (int i = 0; i < 20; i++) put(file(1910L + i, 1900L, 1024));
+
+        // 用量条要看得见它们（否则显示 0/20 却拒绝新文件，用户无法自证）
+        Map<String, Object> usage = service.usage(STAGE_FOLDER);
+        assertEquals(20, usage.get("fileCount"));
+
+        // 已经在区内的文件重复拖入不算新增
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, List.of(1910L, 1911L)));
+        // 但真正的新增会被拒
+        assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, pending(1, 1024)));
+    }
+
+    @Test
+    @DisplayName("自己是自己父目录的脏数据不会让递归转不出来")
+    void selfParentedFolderDoesNotHang() {
+        // 历史数据修复留下的自环：缓存区目录的 parentId 指向它自己，
+        // 于是「列出子项」把它自己也列进来。visitedFolders 必须挡住这一跳。
+        table.get(STAGE_FOLDER).setParentId(STAGE_FOLDER);
+        fillStage(3, 1024);
+
+        assertTimeoutPreemptively(java.time.Duration.ofSeconds(5), () -> {
+            Map<String, Object> usage = service.usage(STAGE_FOLDER);
+            assertEquals(3, usage.get("fileCount"));
+        });
+    }
+
+    // ==================== 团队服务器模式 ====================
+
+    @Test
+    @DisplayName("非单机模式（团队案件库服务器）不执行额度：本机权益对服务器成员没有意义")
+    void serverModeIsNeverLimited() {
+        StageQuotaService serverSide = new StageQuotaService(repository, entitlementService, false);
+        fillStage(100, StageQuotaService.FREE_MAX_BYTES);
+
+        assertDoesNotThrow(() -> serverSide.checkAdmission(STAGE_FOLDER, pending(50, 1024)));
+        Map<String, Object> usage = serverSide.usage(STAGE_FOLDER);
+        assertEquals(false, usage.get("limited"));
+        assertNull(usage.get("maxFiles"));
     }
 }

--- a/backend/src/test/java/com/checkba/service/quota/StageQuotaServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/quota/StageQuotaServiceTest.java
@@ -1,0 +1,220 @@
+package com.checkba.service.quota;
+
+import com.checkba.exception.StageQuotaExceededException;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.entitlement.FeatureCatalog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 文件缓存区免费额度（Spec §5）。核心不变式：<b>拦新增，不动存量</b>。
+ * 超额时抛异常拒绝这次移入，缓存区里已有的文件一个都不许被删/被隐藏。
+ */
+class StageQuotaServiceTest {
+
+    private static final Long PROJECT = 1L;
+    private static final Long STAGE_FOLDER = 100L;
+    private static final Long OTHER_FOLDER = 200L;
+
+    private ProjectFileRepository repository;
+    private EntitlementService entitlementService;
+    private StageQuotaService service;
+
+    /** id -> 文件，模拟一张最小的文件表。 */
+    private final Map<Long, ProjectFile> table = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ProjectFileRepository.class);
+        entitlementService = mock(EntitlementService.class);
+        when(entitlementService.isEnabled(anyString())).thenReturn(false);
+        service = new StageQuotaService(repository, entitlementService);
+
+        table.clear();
+        put(folder(STAGE_FOLDER, StageQuotaService.STAGING_FOLDER_NAME));
+        put(folder(OTHER_FOLDER, "合同"));
+
+        when(repository.findById(any())).thenAnswer(inv -> Optional.ofNullable(table.get(inv.getArgument(0))));
+        when(repository.findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc(any(), any()))
+                .thenAnswer(inv -> {
+                    Long parent = inv.getArgument(1);
+                    return table.values().stream()
+                            .filter(f -> parent != null && parent.equals(f.getParentId()))
+                            .toList();
+                });
+    }
+
+    private void put(ProjectFile f) {
+        table.put(f.getId(), f);
+    }
+
+    private static ProjectFile folder(Long id, String name) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(PROJECT);
+        f.setName(name);
+        f.setIsFolder(true);
+        f.setIsDeleted(false);
+        return f;
+    }
+
+    private static ProjectFile file(Long id, Long parentId, long size) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(PROJECT);
+        f.setParentId(parentId);
+        f.setName("f" + id + ".docx");
+        f.setIsFolder(false);
+        f.setIsDeleted(false);
+        f.setFileSize(size);
+        return f;
+    }
+
+    /** 往缓存区放 n 个文件，每个 size 字节。 */
+    private void fillStage(int n, long size) {
+        for (int i = 0; i < n; i++) put(file(1000L + i, STAGE_FOLDER, size));
+    }
+
+    /** 在缓存区外准备 n 个待移入的文件，返回它们的 id。 */
+    private List<Long> pending(int n, long size) {
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            ProjectFile f = file(2000L + i, OTHER_FOLDER, size);
+            put(f);
+            ids.add(f.getId());
+        }
+        return ids;
+    }
+
+    @Test
+    @DisplayName("缓存区已有 19 个，再放第 20 个：放行（上限是闭区间）")
+    void twentiethFileAllowed() {
+        fillStage(19, 1024);
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, pending(1, 1024)));
+    }
+
+    @Test
+    @DisplayName("缓存区已有 20 个，再放第 21 个：拒绝，且不碰任何已有文件")
+    void twentyFirstFileRejected() {
+        fillStage(20, 1024);
+        List<Long> incoming = pending(1, 1024);
+
+        StageQuotaExceededException e = assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, incoming));
+        assertTrue(e.getMessage().contains("20"));
+        assertTrue(e.getMessage().contains("已有文件不会被删除"), "提示必须让用户确信数据安全");
+        assertEquals(20, e.getFileCount());
+        verify(repository, never()).delete(any());
+        verify(repository, never()).deleteAll(any());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("一次批量移入导致越界：整批拒绝（不做部分放行）")
+    void batchThatOverflowsIsRejectedWholesale() {
+        fillStage(18, 1024);
+        assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, pending(5, 1024)));
+    }
+
+    @Test
+    @DisplayName("字节数边界：正好 500MB 放行，超 1 字节拒绝")
+    void byteLimitBoundary() {
+        long half = StageQuotaService.FREE_MAX_BYTES / 2;
+        fillStage(1, half);
+        // 已用 half，再放 half → 正好 500MB
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, pending(1, half)));
+
+        table.remove(2000L);
+        assertThrows(StageQuotaExceededException.class,
+                () -> service.checkAdmission(STAGE_FOLDER, pending(1, half + 1)));
+    }
+
+    @Test
+    @DisplayName("已在缓存区里的文件重复拖入不算新增")
+    void alreadyStagedFilesDoNotCountAsNew() {
+        fillStage(20, 1024);
+        List<Long> alreadyInside = List.of(1000L, 1001L);
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, alreadyInside));
+    }
+
+    @Test
+    @DisplayName("目标不是缓存区：额度完全不介入（普通移动不受影响）")
+    void nonStagingTargetUnaffected() {
+        fillStage(50, StageQuotaService.FREE_MAX_BYTES);
+        assertDoesNotThrow(() -> service.checkAdmission(OTHER_FOLDER, pending(30, 1024)));
+        assertDoesNotThrow(() -> service.checkAdmission(null, pending(30, 1024)));
+    }
+
+    @Test
+    @DisplayName("拥有 stage.unlimited：条数与字节都不再限制")
+    void unlimitedBypassesBothLimits() {
+        when(entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)).thenReturn(true);
+        fillStage(100, StageQuotaService.FREE_MAX_BYTES);
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, pending(50, StageQuotaService.FREE_MAX_BYTES)));
+    }
+
+    @Test
+    @DisplayName("fileSize 为 null 的历史文件按 0 计，不因脏数据误拦")
+    void nullFileSizeTreatedAsZero() {
+        ProjectFile legacy = file(1500L, STAGE_FOLDER, 0);
+        legacy.setFileSize(null);
+        put(legacy);
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, pending(1, 1024)));
+    }
+
+    @Test
+    @DisplayName("usage 报当前用量与上限；解锁后上限为 null")
+    void usageReportsCountsAndLimits() {
+        fillStage(3, 1024);
+        Map<String, Object> free = service.usage(STAGE_FOLDER);
+        assertEquals(3, free.get("fileCount"));
+        assertEquals(3L * 1024, free.get("totalBytes"));
+        assertEquals(true, free.get("limited"));
+        assertEquals(StageQuotaService.FREE_MAX_FILES, free.get("maxFiles"));
+        assertEquals(StageQuotaService.FREE_MAX_BYTES, free.get("maxBytes"));
+
+        when(entitlementService.isEnabled(FeatureCatalog.STAGE_UNLIMITED)).thenReturn(true);
+        Map<String, Object> paid = service.usage(STAGE_FOLDER);
+        assertEquals(false, paid.get("limited"));
+        assertNull(paid.get("maxFiles"));
+        assertNull(paid.get("maxBytes"));
+        assertEquals(3, paid.get("fileCount"), "解锁前后看到的文件数一致——存量不受额度影响");
+    }
+
+    @Test
+    @DisplayName("跨项目的文件 id 不参与额度计算（否则能靠拒绝与否探测他人文件大小）")
+    void crossProjectIdsIgnored() {
+        fillStage(19, 1024);
+        ProjectFile foreign = file(9000L, 8888L, StageQuotaService.FREE_MAX_BYTES);
+        foreign.setProjectId(999L); // 别人的项目
+        put(foreign);
+
+        // 这个文件足够大，若参与计算必然触发字节上限；正确行为是被整个忽略
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, List.of(9000L)));
+    }
+
+    @Test
+    @DisplayName("子文件夹不计入文件数")
+    void subFoldersNotCounted() {
+        fillStage(19, 1024);
+        ProjectFile sub = folder(1900L, "子目录");
+        sub.setParentId(STAGE_FOLDER);
+        put(sub);
+        assertDoesNotThrow(() -> service.checkAdmission(STAGE_FOLDER, pending(1, 1024)));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/storage/StorageLocationServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/storage/StorageLocationServiceTest.java
@@ -167,17 +167,16 @@ class StorageLocationServiceTest {
     void verificationFailureRollsBackCopiedFiles() throws IOException {
         Path target = tempDir.resolve("校验会失败");
 
-        // 复制照常发生（真的把 3 个文件写过去了），只是事后校验被做成必定不一致
+        // 复制照常发生（真的把 3 个文件写过去了），只是事后对**目标侧**的统计被做成必定不一致。
+        // 只谎报目标：源侧要照实统计，否则会先撞上「迁移期间原目录发生了变化」那道闸。
+        Path targetReal = target.toAbsolutePath().normalize();
         StorageLocationService svc = new StorageLocationService(resolver, stateDir.toString()) {
-            private boolean firstCall = true;
-
             @Override
             Tally tally(Path root) throws IOException {
-                if (firstCall) {          // 源侧照实统计
-                    firstCall = false;
-                    return super.tally(root);
+                if (root.toAbsolutePath().normalize().equals(targetReal)) {
+                    return new Tally(999, 999);
                 }
-                return new Tally(999, 999); // 目标侧谎报，触发校验失败
+                return super.tally(root);
             }
         };
 
@@ -264,6 +263,139 @@ class StorageLocationServiceTest {
         assertEquals(true, after.get("custom"));
         assertEquals(true, after.get("available"));
         assertNotNull(after.get("movedAt"));
+    }
+
+    @Test
+    @DisplayName("迁移期间源目录被写入：整体放弃，不留下「在树里看得见却打不开」的文件")
+    void concurrentWriteDuringCopyAbortsMigration() throws IOException {
+        Path target = tempDir.resolve("外置硬盘/awd");
+        Path targetReal = target.toAbsolutePath().normalize();
+
+        // 时序模拟：copyTree 走完之后（即对目标那次统计时）往源里落一个新文件，
+        // 模拟迁移期间的自动保存 / 下载 / AI 改动。它没有被复制过去，
+        // 而「复制前的源」与「复制后的目标」两个数字仍然相等——正是旧实现漏掉的那个缝。
+        StorageLocationService svc = new StorageLocationService(resolver, stateDir.toString()) {
+            @Override
+            Tally tally(Path root) throws IOException {
+                Tally t = super.tally(root);
+                if (root.toAbsolutePath().normalize().equals(targetReal)) {
+                    Files.writeString(source.resolve("projects/1/迁移期间自动保存.docx"), "新内容");
+                }
+                return t;
+            }
+        };
+
+        StorageException e = assertThrows(StorageException.class, () -> svc.migrate(target.toString()));
+        assertTrue(e.getMessage().contains("迁移期间"), "文案要说清原因，用户才知道下一步是关掉正在编辑的文档");
+
+        // 指针留在原位，两处数据都在：新写入的文件仍在源目录里，能被正常打开
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals("新内容", Files.readString(source.resolve("projects/1/迁移期间自动保存.docx")));
+        assertEquals(4L, countFiles(source));
+        assertFalse(Files.exists(stateDir.resolve("storage-location.json")), "放弃的迁移不得落配置");
+    }
+
+    @Test
+    @DisplayName("目标是指向源目录内部的软链：按真实路径判定并拒绝，不污染源数据根")
+    void symlinkTargetPointingIntoSourceRejected() throws IOException {
+        Path link = tempDir.resolve("看起来无关的目录");
+        try {
+            Files.createSymbolicLink(link, source.resolve("projects"));
+        } catch (UnsupportedOperationException | IOException e) {
+            org.junit.jupiter.api.Assumptions.assumeTrue(false, "当前环境不支持创建软链，跳过");
+        }
+
+        StorageException e = assertThrows(StorageException.class, () -> service().migrate(link.toString()));
+        assertTrue(e.getMessage().contains("内部"));
+
+        // 源数据根里不得多出任何东西（旧实现会在这里递归造出几百个垃圾目录）
+        assertEquals(3L, countFiles(source));
+        // source 自身 + projects + projects/1 + clipboard + clipboard/1
+        try (var walk = Files.walk(source)) {
+            assertEquals(5L, walk.filter(Files::isDirectory).count(), "源里的目录数不得变化");
+        }
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+    }
+
+    @Test
+    @DisplayName("配置写入失败：副本被清理、指针不动、文案不谎称已迁移")
+    void stateWriteFailureRollsBackAndKeepsOldLocation() throws IOException {
+        Path target = tempDir.resolve("新家");
+        StorageLocationService svc = new StorageLocationService(resolver, stateDir.toString()) {
+            @Override
+            void saveState(State state) {
+                throw new StorageException("存储位置配置写入失败，已保持原位置：磁盘只读");
+            }
+        };
+
+        StorageException e = assertThrows(StorageException.class, () -> svc.migrate(target.toString()));
+        assertFalse(e.getMessage().contains("已迁移"), "指针根本没切，不能说已迁移");
+
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals(3L, countFiles(source));
+        // 副本要清掉：留着的话下次重试会撞上「请选择一个空目录」，用户得先手工删目录
+        assertFalse(Files.exists(target), "失败后目标目录不该留下副本挡住重试");
+    }
+
+    @Test
+    @DisplayName("当前存储目录不可访问时拒绝迁移，不把 0 个文件当成迁移成功")
+    void migrationRefusedWhenSourceMissing() throws IOException {
+        Path target = tempDir.resolve("新家");
+        Path gone = tempDir.resolve("已拔掉的移动硬盘/awd");
+        resolver.relocate(gone); // 模拟外置盘被拔
+
+        StorageException e = assertThrows(StorageException.class, () -> service().migrate(target.toString()));
+        assertTrue(e.getMessage().contains("不可访问"));
+        assertEquals(gone.toAbsolutePath().normalize(), resolver.globalRoot(), "失败不改变指针");
+        assertFalse(Files.exists(target), "不得建出一个假装迁移成功的空目录");
+    }
+
+    @Test
+    @DisplayName("恢复默认位置：只换指针，自选目录里的文件一个都不删")
+    void resetToDefaultKeepsFilesWhereTheyAre() throws IOException {
+        Path target = tempDir.resolve("外置硬盘/awd");
+        StorageLocationService svc = service();
+        svc.migrate(target.toString());
+        assertEquals(target.toAbsolutePath().normalize(), resolver.globalRoot());
+
+        Map<String, Object> res = svc.resetToDefault();
+
+        assertEquals(source.toAbsolutePath().normalize().toString(), res.get("path"));
+        assertEquals(target.toAbsolutePath().normalize().toString(), res.get("previousPath"),
+                "要把原位置告诉用户——文件还在那儿");
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals(3L, countFiles(target), "自选目录里的文件一个都不许删");
+        assertEquals(3L, countFiles(source));
+
+        // 重启后不再回到自选位置
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(source.toAbsolutePath().toString());
+        ProjectStorageResolver fresh = new ProjectStorageResolver(props, null);
+        StorageLocationService restarted = new StorageLocationService(fresh, stateDir.toString());
+        restarted.applyOnStartup();
+        assertEquals(source.toAbsolutePath().normalize(), fresh.globalRoot());
+        assertEquals(false, restarted.current().get("custom"));
+    }
+
+    @Test
+    @DisplayName("自选目录已不可访问时也能恢复默认位置（权益失效 + 拔盘的死局出口）")
+    void resetWorksWhenCustomRootIsGone() throws IOException {
+        Path gone = tempDir.resolve("已拔掉的移动硬盘/awd");
+        resolver.relocate(gone);
+
+        StorageLocationService svc = service();
+        assertEquals(false, svc.current().get("available"));
+
+        assertDoesNotThrow(svc::resetToDefault);
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals(3L, countFiles(source));
+    }
+
+    @Test
+    @DisplayName("已经在默认位置时恢复默认是明确的错误，不是静默无操作")
+    void resetOnDefaultLocationRejected() {
+        StorageException e = assertThrows(StorageException.class, () -> service().resetToDefault());
+        assertTrue(e.getMessage().contains("默认位置"));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/storage/StorageLocationServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/storage/StorageLocationServiceTest.java
@@ -1,0 +1,281 @@
+package com.checkba.service.storage;
+
+import com.checkba.storage.ProjectStorageResolver;
+import com.checkba.storage.StorageException;
+import com.checkba.storage.StorageProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 自选存储位置的迁移契约（Spec §5）。这组测试守的是一句话：
+ * <b>无论成功还是失败，用户的原始文件一个字节都不能少。</b>
+ *
+ * <ul>
+ *   <li>成功：数据复制到新位置并校验通过，指针切换，<b>原目录原样保留为备份</b>；</li>
+ *   <li>失败：清掉本次复制出来的副本，指针不动，原目录纹丝不动；</li>
+ *   <li>非法目标（同路径/互相嵌套/非空/不可写）一律在动手之前就被拦下。</li>
+ * </ul>
+ */
+class StorageLocationServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path source;
+    private Path stateDir;
+    private ProjectStorageResolver resolver;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        source = tempDir.resolve("data");
+        stateDir = tempDir.resolve("state");
+        Files.createDirectories(stateDir);
+        seed(source);
+
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(source.toAbsolutePath().toString());
+        resolver = new ProjectStorageResolver(props, null);
+    }
+
+    /** 造一棵有嵌套目录的小树，模拟 projects/ 与 clipboard/ 命名空间。 */
+    private void seed(Path root) throws IOException {
+        Files.createDirectories(root.resolve("projects/1"));
+        Files.createDirectories(root.resolve("clipboard/1"));
+        Files.writeString(root.resolve("projects/1/合同.docx"), "甲方乙方");
+        Files.writeString(root.resolve("projects/1/附件.pdf"), "pdf-bytes");
+        Files.writeString(root.resolve("clipboard/1/剪贴.png"), "png-bytes");
+    }
+
+    private StorageLocationService service() {
+        return new StorageLocationService(resolver, stateDir.toString());
+    }
+
+    private static long countFiles(Path root) throws IOException {
+        try (var walk = Files.walk(root)) {
+            return walk.filter(Files::isRegularFile).count();
+        }
+    }
+
+    @Test
+    @DisplayName("迁移成功：新位置数据齐全、指针已切、原目录完整保留为备份")
+    void migrateSucceedsAndKeepsSourceAsBackup() throws IOException {
+        Path target = tempDir.resolve("外置硬盘/awd");
+        Map<String, Object> res = service().migrate(target.toString());
+
+        assertEquals(3L, res.get("movedFiles"));
+        assertEquals(target.toAbsolutePath().normalize().toString(), res.get("path"));
+        assertEquals(source.toAbsolutePath().normalize().toString(), res.get("previousPath"));
+
+        // 新位置内容逐字一致
+        assertEquals("甲方乙方", Files.readString(target.resolve("projects/1/合同.docx")));
+        assertEquals("png-bytes", Files.readString(target.resolve("clipboard/1/剪贴.png")));
+
+        // 解析器已指向新位置
+        assertEquals(target.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals(target.resolve("projects/1/合同.docx"), resolver.resolve("projects/1/合同.docx"));
+
+        // 原目录一个文件都没少——这是「绝不删用户数据」的落点
+        assertEquals(3L, countFiles(source));
+        assertEquals("甲方乙方", Files.readString(source.resolve("projects/1/合同.docx")));
+    }
+
+    @Test
+    @DisplayName("重启后按落盘配置恢复自选位置")
+    void savedLocationIsAppliedOnStartup() {
+        Path target = tempDir.resolve("外置硬盘/awd");
+        service().migrate(target.toString());
+
+        // 新进程：全新的 resolver + service，只靠 storage-location.json 恢复
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(source.toAbsolutePath().toString());
+        ProjectStorageResolver fresh = new ProjectStorageResolver(props, null);
+        StorageLocationService restarted = new StorageLocationService(fresh, stateDir.toString());
+        restarted.applyOnStartup();
+
+        assertEquals(target.toAbsolutePath().normalize(), fresh.globalRoot());
+        assertEquals(true, restarted.current().get("custom"));
+    }
+
+    @Test
+    @DisplayName("迁移中途失败：回滚删掉副本、指针不动、原数据完好")
+    void migrationFailureRollsBackAndKeepsOriginal() throws IOException {
+        Path target = tempDir.resolve("坏盘");
+        Files.createDirectories(target);
+
+        // 造一个必失败的场景：目标里预置一个与源同名的**只读目录占位**，
+        // 让复制到 projects/1 时抛 IOException
+        Path blocker = target.resolve("projects");
+        Files.writeString(blocker, "我是文件不是目录"); // 复制时 createDirectories 会失败
+
+        StorageLocationService svc = service();
+        // 目标非空会先被前置校验拦下，这正是期望的第一道闸
+        StorageException e = assertThrows(StorageException.class, () -> svc.migrate(target.toString()));
+        assertTrue(e.getMessage().contains("空目录"));
+
+        // 指针没动，源数据完好
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals(3L, countFiles(source));
+        // 目标里的东西也没被我们碰过
+        assertEquals("我是文件不是目录", Files.readString(blocker));
+    }
+
+    @Test
+    @DisplayName("复制过程中出错：本次复制出来的副本被清理，配置未写入")
+    void copyErrorCleansUpPartialCopy() throws IOException {
+        Path target = tempDir.resolve("半路失败");
+
+        // 让 tally 与 copy 之间产生不一致：源里放一个复制后会被判定为大小不符的场景不好造，
+        // 改用「目标父目录不可写」触发真实 IOException
+        Files.createDirectories(target.getParent());
+        Path readOnlyParent = tempDir.resolve("只读父目录");
+        Files.createDirectories(readOnlyParent);
+        assumeWritableToggle(readOnlyParent);
+
+        Path unwritableTarget = readOnlyParent.resolve("awd");
+        StorageLocationService svc = service();
+        assertThrows(StorageException.class, () -> svc.migrate(unwritableTarget.toString()));
+
+        // 指针不动、源完好、配置未落盘
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals(3L, countFiles(source));
+        assertFalse(Files.exists(stateDir.resolve("storage-location.json")),
+                "失败的迁移不得留下配置，否则重启会指向一个空目录");
+
+        readOnlyParent.toFile().setWritable(true);
+    }
+
+    private void assumeWritableToggle(Path dir) {
+        // 在 root 身份或某些文件系统上 setWritable(false) 无效，此时该用例退化为普通成功路径，
+        // 断言仍然成立（下面只断言"源数据完好"，不断言一定抛异常）——故这里直接跳过更诚实
+        boolean ok = dir.toFile().setWritable(false);
+        org.junit.jupiter.api.Assumptions.assumeTrue(ok && !Files.isWritable(dir),
+                "当前环境无法制造不可写目录，跳过");
+    }
+
+    @Test
+    @DisplayName("校验不通过：已复制的副本被彻底清理，原数据完好，配置未写入")
+    void verificationFailureRollsBackCopiedFiles() throws IOException {
+        Path target = tempDir.resolve("校验会失败");
+
+        // 复制照常发生（真的把 3 个文件写过去了），只是事后校验被做成必定不一致
+        StorageLocationService svc = new StorageLocationService(resolver, stateDir.toString()) {
+            private boolean firstCall = true;
+
+            @Override
+            Tally tally(Path root) throws IOException {
+                if (firstCall) {          // 源侧照实统计
+                    firstCall = false;
+                    return super.tally(root);
+                }
+                return new Tally(999, 999); // 目标侧谎报，触发校验失败
+            }
+        };
+
+        StorageException e = assertThrows(StorageException.class, () -> svc.migrate(target.toString()));
+        assertTrue(e.getMessage().contains("校验"));
+
+        // 目标目录连同本次复制出来的副本被整个清掉——它们全是本次新建的，删掉不碰原数据
+        assertFalse(Files.exists(target), "回滚后不该留下半成品目录");
+
+        // 三条核心不变式
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot(), "指针必须留在原位");
+        assertEquals(3L, countFiles(source), "原目录一个文件都不能少");
+        assertEquals("甲方乙方", Files.readString(source.resolve("projects/1/合同.docx")));
+        assertFalse(Files.exists(stateDir.resolve("storage-location.json")), "失败的迁移不得落配置");
+    }
+
+    @Test
+    @DisplayName("非法目标一律在动手前拦下")
+    void invalidTargetsRejectedUpFront() throws IOException {
+        StorageLocationService svc = service();
+
+        assertThrows(StorageException.class, () -> svc.migrate(null));
+        assertThrows(StorageException.class, () -> svc.migrate("  "));
+
+        // 同一个位置
+        StorageException same = assertThrows(StorageException.class, () -> svc.migrate(source.toString()));
+        assertTrue(same.getMessage().contains("相同"));
+
+        // 目标在源内部（会无限自我复制）
+        StorageException inside = assertThrows(StorageException.class,
+                () -> svc.migrate(source.resolve("projects/新位置").toString()));
+        assertTrue(inside.getMessage().contains("内部"));
+
+        // 目标是源的上级（会把源埋进自己里）
+        StorageException parent = assertThrows(StorageException.class,
+                () -> svc.migrate(source.getParent().toString()));
+        assertTrue(parent.getMessage().contains("上级"));
+
+        // 目标是个已存在的文件
+        Path aFile = tempDir.resolve("一个文件.txt");
+        Files.writeString(aFile, "x");
+        assertThrows(StorageException.class, () -> svc.migrate(aFile.toString()));
+
+        // 全程一次都没动过源
+        assertEquals(3L, countFiles(source));
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+    }
+
+    @Test
+    @DisplayName("非空目标被拒：避免与已有文件混合产生覆盖语义")
+    void nonEmptyTargetRejected() throws IOException {
+        Path target = tempDir.resolve("有东西的目录");
+        Files.createDirectories(target);
+        Files.writeString(target.resolve("别人的文件.txt"), "重要");
+
+        StorageException e = assertThrows(StorageException.class, () -> service().migrate(target.toString()));
+        assertTrue(e.getMessage().contains("空目录"));
+        assertEquals("重要", Files.readString(target.resolve("别人的文件.txt")));
+    }
+
+    @Test
+    @DisplayName("空的已存在目录可以作为目标")
+    void emptyExistingTargetAccepted() throws IOException {
+        Path target = tempDir.resolve("空目录");
+        Files.createDirectories(target);
+        assertDoesNotThrow(() -> service().migrate(target.toString()));
+        assertEquals(3L, countFiles(target));
+    }
+
+    @Test
+    @DisplayName("current() 未迁移时报默认位置，迁移后报自选位置")
+    void currentReflectsState() {
+        Map<String, Object> before = service().current();
+        assertEquals(source.toAbsolutePath().normalize().toString(), before.get("path"));
+        assertEquals(false, before.get("custom"));
+        assertNull(before.get("movedAt"));
+
+        Path target = tempDir.resolve("新家");
+        StorageLocationService svc = service();
+        svc.migrate(target.toString());
+
+        Map<String, Object> after = svc.current();
+        assertEquals(target.toAbsolutePath().normalize().toString(), after.get("path"));
+        assertEquals(true, after.get("custom"));
+        assertEquals(true, after.get("available"));
+        assertNotNull(after.get("movedAt"));
+    }
+
+    @Test
+    @DisplayName("迁移不改数据库里的逻辑路径，解析结果自动跟着走")
+    void logicalPathsSurviveMigration() {
+        List<String> keys = List.of("projects/1/合同.docx", "clipboard/1/剪贴.png");
+        Path target = tempDir.resolve("新家");
+        service().migrate(target.toString());
+
+        for (String key : keys) {
+            assertEquals(target.resolve(key), resolver.resolve(key));
+            assertTrue(Files.exists(resolver.resolve(key)), key + " 迁移后应能解析到实际文件");
+        }
+    }
+}

--- a/frontend/src/components/ClipboardPanel.vue
+++ b/frontend/src/components/ClipboardPanel.vue
@@ -1,5 +1,11 @@
 <template>
   <view class="clip-panel">
+    <!-- 免费额度提示：只在确实有记录被挡住时出现。没超额时一个字都不显示，不打扰。 -->
+    <UnlockHint
+      v-if="hiddenCount > 0"
+      class="clip-unlock-hint"
+      :text="`另有 ${hiddenCount} 条历史记录，解锁无限版后可查看`"
+    />
     <scroll-view class="clip-body" :scroll-y="false" :scroll-x="true" show-scrollbar="false">
       <view v-if="loading" class="loading">加载中...</view>
       <view v-else-if="items.length === 0" class="empty">暂无记录</view>
@@ -68,9 +74,11 @@ import { listClipboard, deleteClipboardItem, getApiBaseUrl } from '@/services/ap
 import { getClipboardTypeMeta } from '@/config/clipboard.js'
 import { getSessionId } from '@/utils/auth.js'
 import { ICONS } from '@/config/icons.js'
+import UnlockHint from '@/components/UnlockHint.vue'
 
 export default {
 
+  components: { UnlockHint },
   computed: {
 
     ICONS() { return ICONS }
@@ -88,6 +96,8 @@ export default {
     return {
       loading: false,
       items: [],
+      // 免费额度下被隐藏（注意：不是被删除）的历史记录条数。解锁后这些记录会原样回来。
+      hiddenCount: 0,
       confirmDeleteId: null
     }
   },
@@ -109,8 +119,16 @@ export default {
     async refresh() {
       this.loading = true
       try {
-        const list = await listClipboard(this.query, 80)
-        this.items = Array.isArray(list) ? list : (list?.data || [])
+        const res = await listClipboard(this.query, 80)
+        // PR-C 起后端返回 { items, limited, hiddenCount, ... }；
+        // 数组分支保留给旧后端（桌面壳可能连着未升级的 backend），此时按无额度处理。
+        if (Array.isArray(res)) {
+          this.items = res
+          this.hiddenCount = 0
+        } else {
+          this.items = res?.items || res?.data || []
+          this.hiddenCount = res?.limited ? (res.hiddenCount || 0) : 0
+        }
       } catch (e) {
         console.error('加载剪贴板失败:', e)
         uni.showToast({ title: '加载剪贴板失败', icon: 'none' })
@@ -254,6 +272,12 @@ $bg-white: #FFFFFF;
   flex-direction: column;
   min-height: 0;
   background: $bg-pale;
+}
+
+/* 额度提示贴在列表上方，不占据滚动区，避免翻到底才看到 */
+.clip-unlock-hint {
+  margin: 12px 16px 0;
+  flex-shrink: 0;
 }
 
 .clip-body {

--- a/frontend/src/components/FileStagingArea.vue
+++ b/frontend/src/components/FileStagingArea.vue
@@ -24,6 +24,20 @@
       </view>
     </view>
 
+    <!-- 免费额度用量条：平时是一条极淡的细线 + 灰字，只有接近上限才转为暖色。
+         没解锁但用量很低时不该有存在感——这是常驻面板，不是提醒栏。 -->
+    <view v-if="quotaVisible" class="staging-quota" :class="{ 'is-tight': quotaTight }">
+      <view class="quota-bar">
+        <view class="quota-fill" :style="{ width: quotaPercent + '%' }"></view>
+      </view>
+      <text class="quota-text">{{ quotaText }}</text>
+    </view>
+    <UnlockHint
+      v-if="quotaTight"
+      class="staging-unlock-hint"
+      text="缓存区快满了，解锁无限版可不限文件数与容量"
+    />
+
     <!-- Contrast Button (Visible when exactly 2 DOC/DOCX files are selected) -->
     <view v-if="canCompare" class="compare-btn-wrapper">
        <button class="btn-compare" @tap.stop="handleCompare">
@@ -93,8 +107,10 @@
 
 <script>
 import { ICONS } from '@/config/icons.js'
+import UnlockHint from '@/components/UnlockHint.vue'
 export default {
   name: 'FileStagingArea',
+  components: { UnlockHint },
   props: {
     visible: {
       type: Boolean,
@@ -103,6 +119,13 @@ export default {
     files: {
       type: Array,
       default: () => []
+    },
+    // 免费额度用量：{ fileCount, totalBytes, limited, maxFiles, maxBytes }
+    // 由 project-overview 从后端拉取；上限只有后端一处定义。
+    // limited 为 false（已解锁）或对象为空时整条用量条都不出现。
+    usage: {
+      type: Object,
+      default: null
     }
   },
   data() {
@@ -116,6 +139,28 @@ export default {
   },
   computed: {
     ICONS() { return ICONS },
+    // 只有「受免费额度约束且上限已知」时才显示用量条
+    quotaVisible() {
+      const u = this.usage
+      return !!(u && u.limited && u.maxFiles && u.maxBytes)
+    },
+    // 两条额度取更满的那条来画进度——用户关心的是「还能放多少」，而不是两个数字
+    quotaPercent() {
+      if (!this.quotaVisible) return 0
+      const u = this.usage
+      const byCount = (u.fileCount || 0) / u.maxFiles
+      const byBytes = (u.totalBytes || 0) / u.maxBytes
+      return Math.min(100, Math.round(Math.max(byCount, byBytes) * 100))
+    },
+    // 80% 以上才转为醒目色并给出解锁提示，平时保持安静
+    quotaTight() {
+      return this.quotaVisible && this.quotaPercent >= 80
+    },
+    quotaText() {
+      if (!this.quotaVisible) return ''
+      const u = this.usage
+      return `${u.fileCount || 0}/${u.maxFiles} 个文件 · ${this.formatSize(u.totalBytes || 0)}/${this.formatSize(u.maxBytes)}`
+    },
     canCompare() {
       if (this.selectedIds.length !== 2) return false
       const selectedFiles = this.files.filter(f => this.selectedIds.includes(f.id))
@@ -130,6 +175,13 @@ export default {
       // Marquee listeners removed
   },
   methods: {
+    formatSize(bytes) {
+      const n = Number(bytes) || 0
+      if (n >= 1024 * 1024 * 1024) return (n / 1024 / 1024 / 1024).toFixed(1) + 'GB'
+      if (n >= 1024 * 1024) return Math.round(n / 1024 / 1024) + 'MB'
+      if (n >= 1024) return Math.round(n / 1024) + 'KB'
+      return n + 'B'
+    },
     getFileIcon(file) {
       if (!file) return '/static/file.png'
       const name = file.name.toLowerCase()
@@ -365,6 +417,49 @@ export default {
 }
 .clear-btn:hover {
     color: #ef4444;
+}
+
+/* 用量条：常态是灰细线，克制到几乎看不见；接近上限才转暖色 */
+.staging-quota {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: #fff;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.quota-bar {
+    flex: 1;
+    height: 3px;
+    border-radius: 2px;
+    background: #e2e8f0;
+    overflow: hidden;
+}
+
+.quota-fill {
+    height: 100%;
+    background: #cbd5e1;
+    border-radius: 2px;
+    transition: width 0.2s ease, background 0.2s ease;
+}
+
+.quota-text {
+    font-size: 11px;
+    color: #94a3b8;
+    flex-shrink: 0;
+}
+
+.staging-quota.is-tight .quota-fill {
+    background: #d9a441;
+}
+
+.staging-quota.is-tight .quota-text {
+    color: #8a6d2f;
+}
+
+.staging-unlock-hint {
+    margin: 8px 12px 0;
 }
 
 .staging-empty {

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -530,9 +530,13 @@
             </view>
           </template>
 
-          <!-- 文件缓存区存储位置：仅在已解锁「文件缓存区无限版」时出现。
-               未解锁时整块入口不显示——没买的功能不该在设置页里当广告位。 -->
-          <view v-if="stageUnlimited" class="section-card">
+          <!-- 文件缓存区存储位置。
+               「当前位置」永远显示，不按权益隐藏：权益可能在自选位置生效之后失效
+               （Key 被吊销、断开账户、离线超宽限），数据仍在自选路径上照常读写。
+               此时若把整块藏起来，用户就看不到自己的文件在哪，也看不到下面那句
+               「该目录当前不可访问」——而那是文件突然打不开时唯一的指路牌。
+               未解锁时藏的是「更改位置」这个付费动作，不是信息本身。 -->
+          <view v-if="storageLocation.path" class="section-card">
             <view class="section-header">
               <text class="section-title">文件缓存区存储位置</text>
               <text class="section-subtitle">
@@ -543,22 +547,42 @@
               <view class="provider-card">
                 <view class="form-row">
                   <text class="form-label">当前位置</text>
-                  <text class="storage-path">{{ storageLocation.path || '读取中...' }}</text>
+                  <text class="storage-path">{{ storageLocation.path }}</text>
                 </view>
-                <text v-if="storageLocation.path && !storageLocation.available" class="storage-warn">
-                  该目录当前不可访问（磁盘未连接或已被移动）。文件操作会失败，请接回磁盘或改选其他位置。
+                <text v-if="!storageLocation.available" class="storage-warn">
+                  该目录当前不可访问（磁盘未连接或已被移动）。文件操作会失败，请接回磁盘，或恢复默认位置。
                 </text>
                 <text v-else-if="!storageLocation.custom" class="account-note">
                   当前使用默认位置。
                 </text>
+                <UnlockHint
+                  v-if="!storageCanMove"
+                  text="更改存储位置属于「文件缓存区无限版」。已有文件不受影响，仍在上面这个目录里。"
+                />
                 <view class="account-connect-actions">
-                  <button class="comp-btn" :disabled="storageBusy" @tap="onChangeStorageLocation">
+                  <button
+                    v-if="storageCanMove"
+                    class="comp-btn"
+                    :disabled="storageBusy"
+                    @tap="onChangeStorageLocation"
+                  >
                     {{ storageBusy ? '迁移中...' : '更改位置' }}
                   </button>
+                  <!-- 恢复默认不设权益闸：这是退回免费版的默认状态，不发放任何付费能力。
+                       锁在付费墙后面会让「权益失效 + 外置盘拔掉」的用户彻底出不来。 -->
+                  <button
+                    v-if="storageLocation.custom"
+                    class="comp-btn"
+                    :disabled="storageBusy"
+                    @tap="onResetStorageLocation"
+                  >
+                    恢复默认位置
+                  </button>
                 </view>
-                <text class="account-note">
+                <text v-if="storageCanMove" class="account-note">
                   迁移会把现有文件<text class="storage-emph">复制</text>到新目录并逐一校验，成功后才切换。
-                  原目录会完整保留为备份，确认无误后可自行删除。迁移期间请不要编辑文档。
+                  原目录会完整保留为备份，确认无误后可自行删除。迁移期间请不要编辑文档，
+                  若期间有文档自动保存，本次迁移会整体放弃并保持原位置。
                 </text>
               </view>
             </view>
@@ -752,17 +776,19 @@ import {
   getAdminConfig, saveAdminConfig, resetWizard,
   cloudConnect, listCloudConnections, disconnectCloudConnection,
   getAccountStatus, connectAccount, disconnectAccount, getAccountUsage,
-  getStorageLocation, moveStorageLocation,
+  getStorageLocation, moveStorageLocation, resetStorageLocation,
 } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
 import { refreshEntitlements, isEnabled, FEATURES } from '@/composables/useEntitlement.js'
+import UnlockHint from '@/components/UnlockHint.vue'
 
 // 官网账户页：生成账户 Key、充值、分配 AI 额度都在这里
 const ACCOUNT_SITE_URL = 'https://www.aiworkdeck.com/zh/account'
 
 export default {
   name: 'AdminPage',
+  components: { UnlockHint },
   data() {
     return {
       userDisplayName: '用户',
@@ -825,9 +851,10 @@ export default {
       accountKeyInput: '',
       accountBusy: false,
       entitlementBusy: false,
-      // 文件缓存区存储位置（PR-C，需 stage.unlimited）
-      // { path, defaultPath, custom, available, movedAt }
-      storageLocation: { path: '', defaultPath: '', custom: false, available: true },
+      // 文件缓存区存储位置（PR-C）
+      // { path, defaultPath, custom, available, movedAt, entitled }
+      // path 为空 = 后端没给（非单机模式/旧后端），整块不显示
+      storageLocation: { path: '', defaultPath: '', custom: false, available: true, entitled: false },
       storageBusy: false,
     }
   },
@@ -835,9 +862,15 @@ export default {
     isDesktop() {
       return typeof window !== 'undefined' && !!(window.checkbaDesktop && window.checkbaDesktop.model)
     },
-    // 自选存储位置是「文件缓存区无限版」的付费能力，未解锁时入口整块不显示
     stageUnlimited() {
       return isEnabled(FEATURES.STAGE_UNLIMITED)
+    },
+    // 能不能改到自选位置。以后端返回的 entitled 为准（它才是执行者）；
+    // 老后端不返回这个字段时退回本地权益缓存判断。
+    // 注意这只管「更改位置」这个付费动作——查看当前位置与恢复默认位置都不受它约束。
+    storageCanMove() {
+      const entitled = this.storageLocation.entitled
+      return entitled === undefined || entitled === null ? this.stageUnlimited : !!entitled
     },
     visibleNavItems() {
       return this.navItems.filter((n) => !n.desktopOnly || this.isDesktop)
@@ -1039,10 +1072,9 @@ export default {
       }
       if (nav.key === 'account') {
         this.loadAccount()
-        // 权益决定「存储位置」入口是否出现；拉一次缓存即可（模块级共享，不会重复请求）
-        refreshEntitlements().then(() => {
-          if (this.stageUnlimited) this.loadStorageLocation()
-        })
+        // 权益决定「更改位置」按钮出不出现；当前位置本身无论有没有权益都要显示
+        this.loadStorageLocation()
+        refreshEntitlements()
       }
     },
     async loadPlatformAiAvailability() {
@@ -1107,7 +1139,7 @@ export default {
       this.entitlementBusy = true
       try {
         await refreshEntitlements(true)
-        if (this.stageUnlimited) await this.loadStorageLocation()
+        await this.loadStorageLocation()
         uni.showToast({
           title: this.stageUnlimited ? '权益已更新' : '已刷新，未发现新的解锁',
           icon: 'none',
@@ -1124,7 +1156,40 @@ export default {
         const loc = await getStorageLocation()
         if (loc && typeof loc === 'object') this.storageLocation = loc
       } catch (e) {
-        // 未解锁 / 旧后端 / 非单机模式：入口本就不显示，静默即可
+        // 旧后端 / 非单机模式：拿不到 path，整块不显示，静默即可
+      }
+    },
+    // 恢复默认位置：只换指针，不搬也不删文件。自选目录里的东西原样留在那里，
+    // 所以弹窗必须把原路径念给用户听——否则会以为「数据没了」。
+    async onResetStorageLocation() {
+      const previous = this.storageLocation.path
+      const ok = await new Promise((r) => uni.showModal({
+        title: '恢复默认位置',
+        content: '应用将改用默认目录：\n' + (this.storageLocation.defaultPath || '')
+          + '\n\n当前目录中的文件不会被删除，仍完整保留在：\n' + previous
+          + '\n\n恢复后这些文件在应用里将不再出现（数据仍在磁盘上），可稍后自行拷回或重新迁移。',
+        confirmText: '恢复默认',
+        success: (res) => r(res.confirm),
+      }))
+      if (!ok) return
+
+      this.storageBusy = true
+      try {
+        await resetStorageLocation()
+        await this.loadStorageLocation()
+        uni.showModal({
+          title: '已恢复默认位置',
+          content: '原目录中的文件一个都没有删除，仍在：\n' + previous,
+          showCancel: false,
+        })
+      } catch (e) {
+        uni.showModal({
+          title: '恢复未完成',
+          content: (e && e.message) || '恢复失败，存储位置维持不变。',
+          showCancel: false,
+        })
+      } finally {
+        this.storageBusy = false
       }
     },
     async onChangeStorageLocation() {

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -488,6 +488,12 @@
                   <text class="account-note">
                     余额用于充值与购买；AI 额度是从余额分配到平台 AI 通道的部分，在官网账户页分配。
                   </text>
+                  <!-- 购买在官网完成，桌面端拉一次即可看到新解锁的功能 -->
+                  <view class="account-refresh-row">
+                    <button class="comp-btn" :disabled="entitlementBusy" @tap="onRefreshEntitlements">
+                      {{ entitlementBusy ? '刷新中...' : '我已购买，刷新权益' }}
+                    </button>
+                  </view>
                 </view>
               </view>
             </view>
@@ -523,6 +529,40 @@
               </view>
             </view>
           </template>
+
+          <!-- 文件缓存区存储位置：仅在已解锁「文件缓存区无限版」时出现。
+               未解锁时整块入口不显示——没买的功能不该在设置页里当广告位。 -->
+          <view v-if="stageUnlimited" class="section-card">
+            <view class="section-header">
+              <text class="section-title">文件缓存区存储位置</text>
+              <text class="section-subtitle">
+                文件缓存区与项目文件在本机的存放目录。解锁无限版后不再有容量限制，建议放到空间充裕的磁盘
+              </text>
+            </view>
+            <view class="section-body">
+              <view class="provider-card">
+                <view class="form-row">
+                  <text class="form-label">当前位置</text>
+                  <text class="storage-path">{{ storageLocation.path || '读取中...' }}</text>
+                </view>
+                <text v-if="storageLocation.path && !storageLocation.available" class="storage-warn">
+                  该目录当前不可访问（磁盘未连接或已被移动）。文件操作会失败，请接回磁盘或改选其他位置。
+                </text>
+                <text v-else-if="!storageLocation.custom" class="account-note">
+                  当前使用默认位置。
+                </text>
+                <view class="account-connect-actions">
+                  <button class="comp-btn" :disabled="storageBusy" @tap="onChangeStorageLocation">
+                    {{ storageBusy ? '迁移中...' : '更改位置' }}
+                  </button>
+                </view>
+                <text class="account-note">
+                  迁移会把现有文件<text class="storage-emph">复制</text>到新目录并逐一校验，成功后才切换。
+                  原目录会完整保留为备份，确认无误后可自行删除。迁移期间请不要编辑文档。
+                </text>
+              </view>
+            </view>
+          </view>
         </scroll-view>
 
         <!-- 组件管理（仅桌面端：本地模型下载与服务启用） -->
@@ -712,10 +752,11 @@ import {
   getAdminConfig, saveAdminConfig, resetWizard,
   cloudConnect, listCloudConnections, disconnectCloudConnection,
   getAccountStatus, connectAccount, disconnectAccount, getAccountUsage,
+  getStorageLocation, moveStorageLocation,
 } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
-import { refreshEntitlements } from '@/composables/useEntitlement.js'
+import { refreshEntitlements, isEnabled, FEATURES } from '@/composables/useEntitlement.js'
 
 // 官网账户页：生成账户 Key、充值、分配 AI 额度都在这里
 const ACCOUNT_SITE_URL = 'https://www.aiworkdeck.com/zh/account'
@@ -783,11 +824,20 @@ export default {
       accountUsage: null, // { local: {...}, platform: {...} }，形状见 api.js getAccountUsage
       accountKeyInput: '',
       accountBusy: false,
+      entitlementBusy: false,
+      // 文件缓存区存储位置（PR-C，需 stage.unlimited）
+      // { path, defaultPath, custom, available, movedAt }
+      storageLocation: { path: '', defaultPath: '', custom: false, available: true },
+      storageBusy: false,
     }
   },
   computed: {
     isDesktop() {
       return typeof window !== 'undefined' && !!(window.checkbaDesktop && window.checkbaDesktop.model)
+    },
+    // 自选存储位置是「文件缓存区无限版」的付费能力，未解锁时入口整块不显示
+    stageUnlimited() {
+      return isEnabled(FEATURES.STAGE_UNLIMITED)
     },
     visibleNavItems() {
       return this.navItems.filter((n) => !n.desktopOnly || this.isDesktop)
@@ -989,6 +1039,10 @@ export default {
       }
       if (nav.key === 'account') {
         this.loadAccount()
+        // 权益决定「存储位置」入口是否出现；拉一次缓存即可（模块级共享，不会重复请求）
+        refreshEntitlements().then(() => {
+          if (this.stageUnlimited) this.loadStorageLocation()
+        })
       }
     },
     async loadPlatformAiAvailability() {
@@ -1046,6 +1100,82 @@ export default {
     },
     openAccountSite() {
       openExternalUrl(ACCOUNT_SITE_URL)
+    },
+    // 购买在官网完成。这里强制重取一次权益（refresh=true 会让后端先同步官网），
+    // 让刚买完回到桌面的用户不用重启就看到解锁结果。
+    async onRefreshEntitlements() {
+      this.entitlementBusy = true
+      try {
+        await refreshEntitlements(true)
+        if (this.stageUnlimited) await this.loadStorageLocation()
+        uni.showToast({
+          title: this.stageUnlimited ? '权益已更新' : '已刷新，未发现新的解锁',
+          icon: 'none',
+        })
+      } catch (e) {
+        uni.showToast({ title: '刷新失败，请稍后重试', icon: 'none' })
+      } finally {
+        this.entitlementBusy = false
+      }
+    },
+    // ---------- 文件缓存区存储位置 ----------
+    async loadStorageLocation() {
+      try {
+        const loc = await getStorageLocation()
+        if (loc && typeof loc === 'object') this.storageLocation = loc
+      } catch (e) {
+        // 未解锁 / 旧后端 / 非单机模式：入口本就不显示，静默即可
+      }
+    },
+    async onChangeStorageLocation() {
+      const desktop = typeof window !== 'undefined' ? window.checkbaDesktop : null
+      if (!desktop || !desktop.fs || typeof desktop.fs.showOpenDialog !== 'function') {
+        uni.showToast({ title: '仅桌面版支持选择目录', icon: 'none' })
+        return
+      }
+      let picked
+      try {
+        const res = await desktop.fs.showOpenDialog({
+          title: '选择文件缓存区存储位置',
+          properties: ['openDirectory', 'createDirectory'],
+        })
+        if (!res || res.canceled || !res.filePaths || !res.filePaths.length) return
+        picked = res.filePaths[0]
+      } catch (e) {
+        uni.showToast({ title: '打开目录选择器失败', icon: 'none' })
+        return
+      }
+
+      const ok = await new Promise((r) => uni.showModal({
+        title: '迁移到新位置',
+        content: '将把现有文件复制到：\n' + picked
+          + '\n\n复制并校验通过后才会切换，原目录会完整保留为备份。迁移期间请不要编辑文档。',
+        confirmText: '开始迁移',
+        success: (res) => r(res.confirm),
+      }))
+      if (!ok) return
+
+      this.storageBusy = true
+      try {
+        const res = await moveStorageLocation(picked)
+        await this.loadStorageLocation()
+        const data = (res && res.data) || {}
+        uni.showModal({
+          title: '迁移完成',
+          content: '已迁移 ' + (data.movedFiles || 0) + ' 个文件到新位置。\n\n原目录仍保留在：\n'
+            + (data.previousPath || '') + '\n\n确认一切正常后，可自行删除原目录。',
+          showCancel: false,
+        })
+      } catch (e) {
+        // 失败即回滚：存储位置维持原样，用户数据一个字节没动
+        uni.showModal({
+          title: '迁移未完成',
+          content: (e && e.message) || '迁移失败。存储位置维持不变，文件未受影响。',
+          showCancel: false,
+        })
+      } finally {
+        this.storageBusy = false
+      }
     },
     async onConnectAccount() {
       const key = (this.accountKeyInput || '').trim()
@@ -2094,6 +2224,39 @@ $border-color: #E9ECEF; // Gray-Light
   font-size: 12px;
   line-height: 18px;
   color: $text-secondary;
+}
+
+.account-refresh-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+/* 存储位置：路径要能整段看清，故等宽字体 + 允许换行 */
+.storage-path {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 18px;
+  color: $text-main;
+  word-break: break-all;
+}
+
+.storage-warn {
+  display: block;
+  margin-top: 10px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: #fdf7ec;
+  border: 1px solid #ecdfc3;
+  font-size: 12px;
+  line-height: 18px;
+  color: #8a6d2f;
+}
+
+.storage-emph {
+  font-weight: 600;
+  color: $text-main;
 }
 
 .usage-row {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -594,6 +594,7 @@
           <FileStagingArea
             :visible="showStagingArea"
             :files="stagingFiles"
+            :usage="stagingUsage"
             @drop="onStagingDrop"
             @clear="handleStagingClear"
             @remove="handleStagingRemove"
@@ -1651,6 +1652,9 @@ export default {
       desensitizeFileSelectCallback: null,
 
       stagingFiles: [], // 文件暂存区列表
+      // 免费额度用量 { fileCount, totalBytes, limited, maxFiles, maxBytes }；
+      // null = 不限制或取不到（旧后端），此时不显示用量条
+      stagingUsage: null,
       stagingOriginalParents: {}, // 记录文件进入暂存区前的原始 parentId: { fileId: originalParentId }
       splitMode: false,
       quickOpenVisible: false, // IDE 化 Cmd+P 快速打开

--- a/frontend/src/pages/project-overview/stagingArea.js
+++ b/frontend/src/pages/project-overview/stagingArea.js
@@ -2,9 +2,21 @@
 // （移出按 stagingOriginalParents 回原目录，原目录已删则退回根目录）、清空与折叠。
 // 经展开进组件 methods（纯搬移，Phase 2 外置），`this` 即 project-overview 页面实例。
 
-import { getProjectFiles, createFolder, batchMoveFiles } from '@/services/api.js'
+import { getProjectFiles, createFolder, batchMoveFiles, getStageUsage } from '@/services/api.js'
+import { openExternalUrl } from '@/utils/externalLink.js'
 
 export const stagingAreaMethods = {
+    // 免费额度用量（顶部用量条的数据源）。取不到就当作「不限制」处理——
+    // 旧后端没有该端点，不能因此让用量条显示成一堆 0/0。
+    async loadStagingUsage() {
+      if (!this.stagingFolderId) return
+      try {
+        const usage = await getStageUsage(this.projectId, this.stagingFolderId)
+        this.stagingUsage = usage && typeof usage === 'object' ? usage : null
+      } catch (e) {
+        this.stagingUsage = null
+      }
+    },
     async ensureStagingFolder() {
       if (this.stagingFolderId) return
       try {
@@ -64,6 +76,7 @@ export const stagingAreaMethods = {
         if (files.length > 0) {
           console.log('LoadStaging: Files:', files.map(f => f.name).join(', '))
         }
+        this.loadStagingUsage()
       } catch (e) {
         console.error('Failed to load staging files:', e)
         uni.showToast({ title: '加载暂存区文件失败', icon: 'none' })
@@ -120,6 +133,22 @@ export const stagingAreaMethods = {
         this.stagingPinned = true
         uni.showToast({ title: '已加入暂存区', icon: 'success' })
       } catch (e) {
+        if (e && e.quotaExceeded) {
+          // 免费额度拦截：后端一个文件都没移动，缓存区里的存量原样保留。
+          // 用 modal 而不是 toast——这条提示要说清「已有文件不会被删除」，toast 放不下。
+          this.stagingPinned = true
+          this.loadStagingUsage()
+          uni.showModal({
+            title: '文件缓存区已满',
+            content: e.message,
+            confirmText: '了解详情',
+            cancelText: '知道了',
+            success: (r) => {
+              if (r.confirm) openExternalUrl('https://www.aiworkdeck.com/zh/account')
+            }
+          })
+          return
+        }
         console.error('Failed to move files to staging:', e)
         uni.showToast({ title: '加入暂存区失败', icon: 'none' })
       }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -225,6 +225,16 @@ function request(options) {
             err.featureNotConfigured = true;
             err.feature = res.data.feature || '';
             reject(err);
+          } else if (res.data.code === 4003) {
+            // 免费额度已满（PR-C）：功能本身是好的，只是到顶了，下一步是解锁而非去设置。
+            // 打上 quotaExceeded 标记让调用方能显示解锁引导而不是通用报错。
+            // 注意：这条路径**只拒绝新增**，用户已有的数据一条都没动。
+            const msg = res.data.message || '免费额度已满';
+            const err = new Error(msg);
+            err.quotaExceeded = true;
+            err.feature = res.data.feature || '';
+            err.usage = res.data.usage || null;
+            reject(err);
           } else {
             // 业务失败：code=1 或其他非0值
             const errorMessage = res.data.message || '服务异常，请稍后重试'
@@ -1246,6 +1256,35 @@ export function listClipboard(q, limit = 50) {
   return request({
     url: `/api/clipboard${queryString}`,
     method: 'GET',
+  })
+}
+
+// 文件缓存区用量：{ fileCount, totalBytes, limited, maxFiles, maxBytes }
+// 上限常量只在后端定义一处，前端不复制，避免改额度时两边不一致。
+export function getStageUsage(projectId, folderId) {
+  const qs = folderId ? `?folderId=${encodeURIComponent(folderId)}` : ''
+  return request({
+    url: `/api/projects/${projectId}/files/stage/usage${qs}`,
+    method: 'GET',
+  }).then(unwrapEnvelope)
+}
+
+// 本机文件存储位置（需 stage.unlimited）：{ path, defaultPath, custom, available, movedAt }
+export function getStorageLocation() {
+  return request({
+    url: '/api/storage/location',
+    method: 'GET',
+  }).then(unwrapEnvelope)
+}
+
+// 迁移存储位置。后端先复制再校验再切指针，原目录保留为备份；失败会回滚且保持原位置。
+// 返回整个响应体（含 message），调用方要区分 code=0 与失败文案。
+export function moveStorageLocation(path) {
+  return request({
+    url: '/api/storage/location',
+    method: 'POST',
+    data: { path },
+    header: { 'Content-Type': 'application/json' },
   })
 }
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1269,7 +1269,8 @@ export function getStageUsage(projectId, folderId) {
   }).then(unwrapEnvelope)
 }
 
-// 本机文件存储位置（需 stage.unlimited）：{ path, defaultPath, custom, available, movedAt }
+// 本机文件存储位置：{ path, defaultPath, custom, available, movedAt, entitled }
+// 只读展示不要求权益——权益失效后用户仍须看得到自己的数据在哪（entitled 告诉前端能不能改）
 export function getStorageLocation() {
   return request({
     url: '/api/storage/location',
@@ -1284,6 +1285,16 @@ export function moveStorageLocation(path) {
     url: '/api/storage/location',
     method: 'POST',
     data: { path },
+    header: { 'Content-Type': 'application/json' },
+  })
+}
+
+// 恢复默认存储位置。只换指针，不搬也不删任何文件——自选目录里的数据原样留在原处。
+// 不要求权益：权益失效 + 自选目录不可访问时，这是用户唯一的出口。
+export function resetStorageLocation() {
+  return request({
+    url: '/api/storage/location/reset',
+    method: 'POST',
     header: { 'Content-Type': 'application/json' },
   })
 }


### PR DESCRIPTION
Spec §5/§6 的第三条计费支柱（`docs/superpowers/specs/2026-08-05-commercialization-redesign.md`）。依赖已合并的 PR-A（去登录 + 解锁门）与 PR-B（EntitlementService + 账户连接）。

**这个 PR 最重要的一条不变式：免费额度是「不再新增」或「隐藏超出部分」，绝不是「删除历史数据」。用户付费后必须能看到之前被隐藏的全部内容。** 全 diff 里没有任何 delete/purge/清理路径由额度逻辑触发。

## 两处额度规则

**剪贴板：查询侧过滤，一条记录都不删**

未拥有 `clipboard.unlimited` 时 `GET /api/clipboard` 只返回「最近 20 条 **且** 3 天内」，两条同时生效取更严者。超出的行原封不动留在库里，解锁后原样可见。返回体从裸数组改为 `{items, limited, hiddenCount, maxItems, retentionDays}`；`hiddenCount` 只算「因额度看不见」的（总数 − min(3 天内条数, 20)），不含被分页 limit 挡住的——把后者算进去会让「另有 N 条」这句提示变成谎话。

**文件缓存区：移入时拦截，区内存量一个不动**

缓存区的物理形态是项目内 `__staging_area__` 目录，「加入缓存区」= 移动已有项目文件，所以额度只能拦新增：未拥有 `stage.unlimited` 时上限 20 个文件 / 500MB，超额**整批拒绝**（准入检查放在 `batchMove` 的循环之前，抛出时一个文件都没动）。**移出方向永不拦截**，否则用户超额后无法自救。

文件夹按它装的全部文件递归计数，准入与用量条同一口径——文件树允许把整个文件夹拖进来，只算 1 个条目 0 字节的话套一层目录就能让两条额度同时失效。

超额抛 `StageQuotaExceededException` → `code=4003 + feature + usage`，前端 `api.js` 打 `err.quotaExceeded` 标记，据此弹解锁引导而非通用报错。

两处额度都**只在 local-mode（桌面单机版）执行**：`EntitlementService` 是按本机的（无 userId 维度），团队案件库服务器上权益恒为空集，照执行会把每个接入成员截到 20 条且永远无法解锁。与 `LicenseController`「非 local-mode 恒为已解锁正式版」同口径。

## 不删数据是怎么实现的

- 剪贴板：`saveText`/`saveFile` 写入路径一字未动，超额照常写入；额度只作用在 `list()` 的查询与计数上。`ClipboardListResult.unlimited()` 返回全量，解锁后被隐藏的记录原样回来。
- 缓存区：`checkAdmission` 只会 `throw`，没有任何写/删；异常抛出时 `batchMove` 的循环还没开始。
- 存储位置迁移：**复制 → 校验 → 落配置 → 换指针，原目录完整保留为备份**，绝不先删后搬。任一步失败只清掉本次复制出来的副本（全是新建的，删它们不碰原始数据）并维持原路径，失败后的状态与没点过这个按钮完全一样。

## 自选存储路径迁移策略

缓存区文件就是项目文件，没有独立目录可搬，所以迁的是**全局存储根**。DB 存的是逻辑路径、git 的 gitDir/workTree 每次现算，所以只需搬目录 + 换指针（`ProjectStorageResolver.globalRoot` 改 volatile + `relocate()`），不改任何一行数据。

配置落 `~/.aiworkdeck/storage-location.json` 而非 DB：存储根必须在任何文件操作之前确定，读 DB 要等 JPA 起来，存在启动期顺序窟窿。

几处刻意的选择：

- 目标必须是空目录或不存在，且与源不互相嵌套；嵌套判断在 `toRealPath()` 之后做——纯词法比较挡不住指向源内部的软链，那会把源复制进它自己。
- 复制后**源侧要复查**：只比「复制前的源」和「复制后的目标」是不够的，迁移期间自动保存进已复制目录的文件在两边数字上仍然相等，会被静默留在旧根（DB 有行、文件树看得见、打不开）。不一致即整体放弃。
- 源目录不可访问（外置盘拔了）时拒绝迁移，否则 `copyTree` 会把源建出来，变成「0 个文件迁移成功」。
- 启动时目录不存在**不静默回退**到默认位置——那会让用户面对空白应用并以为数据没了，真相是数据好端端躺在别处。保持指向该路径并在设置页显式告警。

**权益失效不等于把人锁在外面**：`applyOnStartup` 是无条件的（Key 被吊销/断开账户/离线超宽限后，自选路径上的数据照常读写），因此 `GET /api/storage/location` 与「恢复默认位置」（`POST /reset`，只换指针不搬不删）都不设权益闸。付费闸只加在「改到新的自选位置」这个动作上。否则「权益失效 + 外置盘拔掉」的用户既看不到自己数据在哪，也换不回默认位置。

控制器另有 local-mode 闸：团队服务器上让任意成员从浏览器改服务端存储路径，等于把整台机器的文件系统交出去。

## 其他

- 目录选择器复用既有 `fs:showOpenDialog`（`properties: openDirectory`），不新增 IPC。
- 设置页加「我已购买，刷新权益」（`GET /api/entitlements?refresh=true`）。
- 用量端点 `GET /api/projects/{id}/files/stage/usage?folderId=` 走 `checkFileInProject` 校验 folderId 归属（全局数字主键可枚举，只验路径 projectId 拦不住跨项目探测）。

## 验证结果

- `mvn test` **828 通过 / 0 失败**（PR-B 基线 781 → 本 PR 828，新增 47 条：剪贴板额度 10、缓存区额度 18、存储位置 17、controller 越权 2）。
- 前端 `npm run build:h5` 与 `npm run check:emits` 通过。
- `npm run test:app-e2e`：**104 步全过，异常信号 0 条**（9797 隔离实例，未占用 9696）。
- 9797 隔离实例真机复验：
  - 20/25 条剪贴记录被隐藏、解锁后 25 条全回，H2 里 25 行始终在；
  - 含 25 个文件的文件夹拖入被 4003 拒绝，源目录 25 个文件一个不少；
  - 含 5 个文件的文件夹仍可正常移入，用量条数得到子目录里的文件（5 / 10240 字节）；
  - 跨项目 folderId 被「文件不属于该项目」拒绝；
  - 无权益时 GET 返回 `entitled=false` 且路径可见，POST 迁移仍被拒；
  - 迁移后新旧两处文件逐字一致，原目录完整保留。

领域文档 `.claude/agents/utility-tools.md` 已同步更新（额度口径、越权闸、迁移地雷、权益失效不锁人）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
