### PR TITLE
fix: 免登本机身份不再回落 admin，多账号有数据时交给用户选定

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -39,8 +39,10 @@ rail 点击 → toggleLeftPane(key)（:2988）：staging 单独分支 → 把当
 
 ## 页面路由（frontend/src/pages.json，全部 navigationStyle: custom）
 
-login（**启动页**）/ newproject / project-overview / variable-library / userprofile / admin / plugin-market / wizard。
-导航流：login reLaunch→wizard|project-overview|userprofile；overview navigateTo userprofile/admin；admin→plugin-market；newproject reLaunch→overview；退出 reLaunch login。
+launch（**启动页**）/ unlock / identity / login / newproject / project-overview / variable-library / userprofile / admin / plugin-market / wizard。
+导航流：launch reLaunch→login（非桌面）|unlock（未解锁）|identity（本机工作区待选定）|wizard（未初始化）|project-overview|userprofile；unlock/identity 完成后一律 reLaunch 回 launch 重跑分流，不自己跳工作区；overview navigateTo userprofile/admin；admin→plugin-market；newproject reLaunch→overview；退出 reLaunch login。
+**启动链只用 reLaunch，不用 navigateTo**——分流页不该留在页面栈里。
+**identity（本机工作区选择，2026-08-05）**：单机免登下所有请求解析为同一个「本机用户」，老安装的库里常有多个历史账号（admin 往往是空壳，真实数据在用户自己注册的账号名下）。后端 `LocalIdentityService` 按数据量解析，多个账号都有数据时不猜，`GET /api/local-identity/status` 回 needsSelection，launch 页据此分流到 identity 页；选定经 `POST /api/local-identity/select` 持久化到 SystemSetting，之后不再出现。补救入口在 admin 页「账户与用量」的「本机工作区」卡（候选 >1 才渲染）。
 **IDE 化体验对齐第二轮（2026-07-31，同分支）**：① 启动直达——login 页 `tryAutoResume()` 存储会话有效即 reLaunch 上次项目（`utils/recentProjects.js` 的 `checkba_last_project_id`），登录页只在会话失效时出现；② 桌面应用菜单 `desktop/main/app-menu.js`（文件→打开文件夹 Cmd+O/打开文件/新建项目文件夹/最近打开动态子菜单；编辑菜单是 editMenu role，删了它 mac 输入框 Cmd+C/V 全灭；窗口菜单刻意无 close role——Cmd+W 留给渲染层关标签），动作经 `checkba:menu-action` 到 App.vue 全局处理器（`utils/ideOpen.js` 共用流程）；③ overview 键位 Cmd+P（`QuickOpenPanel.vue` 快速打开，document 捕获段拦键：uni input 不透传 keydown）/Cmd+W 关活跃标签，焦点在 LOWA webview 内收不到属已知边界；④ 顶栏项目名旁最近项目切换器（`.project-switcher`/`.switcher-menu`）与工作状态点（`.work-status-chip`，复用 `checkAdoptConflict` 的 /status，working/onDraft 才渲染）；⑤ 窗口标题「文件 — 项目 — AI Workdeck」（watch activeFileIdLeft/project.name）；⑥ 拖文件夹到窗口（App.vue capture 段 drop，单目录才接管，`fs.getPathForFile` preload helper）与 macOS open-file 事件（main.js `dispatchOpenPath`，窗口未就绪先存后发）都走 open-local。文件树方向键导航有意缓做（全局拦方向键与编辑器输入冲突）。
 **newproject 已 IDE 化（2026-07-31）**：桌面态三动作「打开文件夹/新建项目文件夹/打开文件」走 `window.checkbaDesktop.fs.showOpenDialog` + `POST /api/projects/open-local`（同一 localRoot 重复打开复用项目并幂等重扫导入，见 `LocalProjectService`）；浏览器降级为托管空白项目（BLANK）；成功后 reLaunch 进 overview，单文件过渡版带 `openFileId` 查询参数（`fileOpenTabs.js` 的 `openPendingLocalFile`）。项目类型选择表单已删除（`config/projectTypes.js` 仅剩 `getProjectTypeLabel` 供存量项目卡片显示）。FileTree 右键新增「在访达中显示」（`reveal-file` → overview `onRevealFile` → `/local-path` 端点 + `fs.showItemInFolder` IPC）。
 

--- a/backend/src/main/java/com/checkba/controller/LocalIdentityController.java
+++ b/backend/src/main/java/com/checkba/controller/LocalIdentityController.java
@@ -1,0 +1,130 @@
+package com.checkba.controller;
+
+import com.checkba.service.LocalIdentityService;
+import com.checkba.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 本机工作区（免登身份）端点，local-mode 专属。
+ *
+ * <ul>
+ *   <li>GET  /api/local-identity/status     启动链在解锁后、进工作区前的分流依据（needsSelection）</li>
+ *   <li>GET  /api/local-identity/candidates 候选账号 + 数据量，供选择页与设置页展示</li>
+ *   <li>POST /api/local-identity/select     {"userId": 2} 选定并持久化</li>
+ * </ul>
+ *
+ * 与 {@code LicenseController} 同为匿名端点：这条链跑在「进入工作区之前」，
+ * 此时本来就还没有身份可言，要求登录是循环依赖。安全前提与免登模式的其余部分一致——
+ * {@code LocalModeLoopbackGuard}（只绑回环）+ {@code LocalModeAccessFilter}
+ * （逐请求校验回环来源、拒绝反代痕迹、非安全方法的 Origin 白名单）。
+ * select 是 POST，自动落在该过滤器的跨站硬拦截分支内。
+ *
+ * server（团队服务器）模式下这三条端点不做任何事：status 恒回 localMode=false，
+ * select 直接 400——否则任何人都能匿名改写团队服务器上的身份解析。
+ */
+@RestController
+@RequestMapping("/api/local-identity")
+@Slf4j
+public class LocalIdentityController {
+
+    private final LocalIdentityService localIdentityService;
+    private final UserService userService;
+
+    public LocalIdentityController(LocalIdentityService localIdentityService, UserService userService) {
+        this.localIdentityService = localIdentityService;
+        this.userService = userService;
+    }
+
+    @GetMapping("/status")
+    public Map<String, Object> status() {
+        Map<String, Object> result = new HashMap<>();
+        if (!localIdentityService.isLocalMode()) {
+            result.put("localMode", false);
+            result.put("needsSelection", false);
+            return result;
+        }
+        LocalIdentityService.Resolution resolution = localIdentityService.resolution();
+        result.put("localMode", true);
+        result.put("needsSelection", resolution.needsSelection());
+        result.put("userId", resolution.userId());
+        try {
+            var user = userService.getUserById(resolution.userId());
+            if (user != null) {
+                result.put("username", user.getUsername());
+                result.put("displayName", user.getDisplayName());
+            }
+        } catch (Exception e) {
+            log.debug("本机身份展示信息读取失败（忽略）: {}", e.getMessage());
+        }
+        return result;
+    }
+
+    @GetMapping("/candidates")
+    public Map<String, Object> candidates() {
+        Map<String, Object> result = new HashMap<>();
+        if (!localIdentityService.isLocalMode()) {
+            result.put("localMode", false);
+            result.put("candidates", List.of());
+            return result;
+        }
+        LocalIdentityService.Resolution resolution = localIdentityService.resolution();
+        List<Map<String, Object>> list = new ArrayList<>();
+        for (LocalIdentityService.Candidate c : localIdentityService.candidates()) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("userId", c.userId());
+            item.put("username", c.username());
+            item.put("displayName", c.displayName());
+            item.put("projectCount", c.projectCount());
+            item.put("fileCount", c.fileCount());
+            list.add(item);
+        }
+        result.put("localMode", true);
+        result.put("needsSelection", resolution.needsSelection());
+        // 待选定时 currentUserId 只是临时落点，前端不要把它渲染成「已选中」
+        result.put("currentUserId", resolution.needsSelection() ? null : resolution.userId());
+        result.put("candidates", list);
+        return result;
+    }
+
+    @PostMapping("/select")
+    public ResponseEntity<Map<String, Object>> select(@RequestBody(required = false) Map<String, Object> body) {
+        if (!localIdentityService.isLocalMode()) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("message", "团队服务器部署不支持切换本机工作区"));
+        }
+        Long userId = parseUserId(body == null ? null : body.get("userId"));
+        try {
+            LocalIdentityService.Resolution resolution = localIdentityService.select(userId);
+            Map<String, Object> result = new HashMap<>();
+            result.put("userId", resolution.userId());
+            result.put("needsSelection", false);
+            return ResponseEntity.ok(result);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    /** userId 可能是 Integer / Long / String（JSON 数字宽度与前端序列化都不受控）。 */
+    private static Long parseUserId(Object raw) {
+        if (raw instanceof Number n) return n.longValue();
+        if (raw instanceof String s && !s.isBlank()) {
+            try {
+                return Long.parseLong(s.trim());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
@@ -38,6 +38,11 @@ public interface ProjectFileRepository extends JpaRepository<ProjectFile, Long> 
     List<ProjectFile> findByProjectIdOrderBySortOrderAsc(Long projectId);
 
     /**
+     * 某用户名下未删除的文件数（本机身份候选的「数据量」信号之一，见 LocalIdentityService）
+     */
+    long countByUserIdAndIsDeletedFalse(Long userId);
+
+    /**
      * 根据父文件夹 ID 查询子文件数量（排除已删除）
      */
     long countByParentIdAndIsDeletedFalse(Long parentId);

--- a/backend/src/main/java/com/checkba/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectRepository.java
@@ -17,6 +17,11 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByUserIdIsNull();
 
     /**
+     * 某用户名下的项目数（本机身份候选的「数据量」信号之一，见 LocalIdentityService）
+     */
+    long countByUserId(Long userId);
+
+    /**
      * 按本地文件夹根目录查项目（IDE 化本地文件夹项目，路径存入前已 normalize）
      */
     java.util.Optional<Project> findByLocalRoot(String localRoot);

--- a/backend/src/main/java/com/checkba/service/LocalIdentityService.java
+++ b/backend/src/main/java/com/checkba/service/LocalIdentityService.java
@@ -1,28 +1,59 @@
 package com.checkba.service;
 
 import com.checkba.controller.AuthController;
+import com.checkba.model.entity.SystemSetting;
 import com.checkba.model.entity.User;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.SystemSettingRepository;
 import com.checkba.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 /**
- * 单机免登模式下的「本机用户」身份解析（商业化改造 PR-A）。
+ * 单机免登模式下的「本机用户」身份解析（商业化改造 PR-A，2026-08-05 修正）。
  *
- * local-mode 下桌面端不再有登录概念，所有请求统一解析为同一个本机用户。
- * 解析规则（老安装零迁移）：
- * - username=local 存在则永远用它——一旦某次启动创建过 local 用户（如首个请求赶在
- *   DataInitializer 建 admin 之前的竞态窗口），后续重启不能因 admin 出现而翻转到
- *   另一个 userId，否则 local 名下数据成孤儿。
- * - 否则复用已存在的 username=admin 用户——老安装的项目/文件/记忆全挂在它名下，
- *   userId 绝不能变；只把 displayName 改成「本机用户」，去掉管理员心智。
- * - 两者都不存在（理论上的全新库兜底）时，创建 username=local、displayName「本机用户」。
+ * <h3>为什么要改</h3>
+ * PR-A 的规则是「local 优先，否则回落 admin」，前提是「老安装的数据都挂在 admin 名下」。
+ * 这条前提是错的：真机（~/.aiworkdeck/local.mv.db）实测 admin 名下只有 1 个项目 0 个文件，
+ * 用户 6 个项目 21 个文件全在 username=hanzewei 名下。回落 admin 会让老用户解锁后
+ * 看到一个近乎空的工作区——数据没丢，但全部不可见。
  *
- * 与 AuthController 的连接沿用 DeviceTokenService 的静态注册模式：
- * 仅在 local-mode 开启时注册，server 模式下静态入口保持 null、行为一字不变。
+ * <h3>解析顺序</h3>
+ * <ol>
+ *   <li><b>已持久化的选择</b>（{@link #SELECTED_KEY}）：用户选过就不再问，跨重启稳定。</li>
+ *   <li><b>username=local</b>：一旦某次启动创建过 local 用户（如首个请求赶在 DataInitializer
+ *       建 admin 之前的竞态窗口），后续不能因 admin 出现而翻转 userId，否则 local 名下数据成孤儿。
+ *       命中后顺手持久化，把这条历史包袱固化成规则 1。</li>
+ *   <li><b>按数据量判定</b>：统计每个候选用户的项目数 + 未删除文件数。
+ *       <ul>
+ *         <li>恰好一个候选有数据 → 选它并持久化（老安装的典型形态，零迁移）；</li>
+ *         <li>多个候选有数据 → <b>不猜</b>，返回「待选定」交给前端引导（见 {@link Resolution}）；</li>
+ *         <li>没有任何候选有数据 → 复用已存在的空 admin（全新库的典型形态，零新增行、
+ *             与 PR-A 行为一致），admin 也不存在时才新建 username=local。</li>
+ *       </ul></li>
+ * </ol>
+ *
+ * <h3>「待选定」怎么表达</h3>
+ * {@link #localUserId()} 永远返回非 null——它是全后端 90 余处调用方的热路径，返回 null
+ * 等于全站 500。待选定时它临时落在「数据量最大的候选」上，但<b>不写持久化</b>，
+ * 所以用户在选择页做出的选择仍然说了算。真正的门在前端：
+ * {@code GET /api/local-identity/status} 暴露 needsSelection，launch 页解锁后据此
+ * 分流到选择页，选完才进工作区。
+ *
+ * <h3>持久化位置：SystemSetting 表（不是 ~/.aiworkdeck/identity.json）</h3>
+ * 存的值是一个指向 local.mv.db 内 user 表的外键。把指针放进它所指向的库里，
+ * 二者才能同生共死：用户还原一份旧的 local.mv.db、或重置工作区时，指针跟着一起回退，
+ * 不会出现「指针指向一个已经不存在或含义变了的 userId」。license.json / account.json
+ * 恰恰相反——它们描述的是「这台机器的授权」，本就该独立于库存在，所以不同规格是刻意的。
+ * 顺带省掉一套文件权限收敛与 JSON 解析容错，只为存一个 Long。
  */
 @Service
 @Slf4j
@@ -30,18 +61,60 @@ public class LocalIdentityService {
 
     public static final String LOCAL_DISPLAY_NAME = "本机用户";
 
+    /** 已选定本机身份的持久化键。 */
+    static final String SELECTED_KEY = "local.identity.selectedUserId";
+
+    /**
+     * 测试账号用户名前缀。刻意保守——只排除测试脚手架自己造的、名字里带明确标记的账号，
+     * 宁可多留一个候选让用户在选择页里自己排除，也绝不能误排真实账号
+     * （真机上就有 hanzewei / hanzewei1 / newuser 这类名字，一条都不许命中）。
+     */
+    private static final List<String> TEST_ACCOUNT_PREFIXES = List.of(
+            "qa_bot_",        // frontend/tests/app-e2e：qa_bot_<时间戳>
+            "claude-e2e",     // 早期人工/脚本走查账号
+            "e2e_keepalive"); // 保活探针账号
+
     private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectFileRepository projectFileRepository;
+    private final SystemSettingRepository systemSettingRepository;
     private final boolean localMode;
 
-    /** 解析一次后缓存——getUserIdFromSession 是全后端每请求热路径。 */
-    private volatile Long cachedUserId;
+    /** 解析一次后缓存——localUserId 是全后端每请求热路径。选定身份后由 {@link #select} 失效。 */
+    private volatile Resolution cached;
 
     public LocalIdentityService(UserRepository userRepository,
+                                ProjectRepository projectRepository,
+                                ProjectFileRepository projectFileRepository,
+                                SystemSettingRepository systemSettingRepository,
                                 @Value("${security.local-mode:false}") boolean localMode) {
         this.userRepository = userRepository;
+        this.projectRepository = projectRepository;
+        this.projectFileRepository = projectFileRepository;
+        this.systemSettingRepository = systemSettingRepository;
         this.localMode = localMode;
         if (localMode) {
             AuthController.registerLocalIdentityService(this);
+        }
+    }
+
+    /**
+     * 一次解析的结果。
+     *
+     * @param userId        本机用户 id，恒非 null；needsSelection 时是「数据量最大的候选」这个临时落点
+     * @param needsSelection 是否需要用户亲自选定（多个历史账号都有数据）
+     */
+    public record Resolution(Long userId, boolean needsSelection) {}
+
+    /** 候选账号及其数据量，供选择页与设置页展示。 */
+    public record Candidate(Long userId, String username, String displayName,
+                            long projectCount, long fileCount) {
+        public long dataScore() {
+            return projectCount + fileCount;
+        }
+
+        public boolean hasData() {
+            return dataScore() > 0;
         }
     }
 
@@ -49,33 +122,120 @@ public class LocalIdentityService {
         return localMode;
     }
 
-    /** 返回本机用户 id（懒解析 + 缓存）。 */
+    /** 返回本机用户 id（懒解析 + 缓存），恒非 null。 */
     public Long localUserId() {
-        Long id = cachedUserId;
-        if (id != null) return id;
+        return resolution().userId();
+    }
+
+    /** 是否处于「待选定」状态：本机有多个带数据的历史账号，且用户还没选过。 */
+    public boolean needsSelection() {
+        return resolution().needsSelection();
+    }
+
+    /** 当前解析结果（懒解析 + 缓存）。 */
+    public Resolution resolution() {
+        Resolution r = cached;
+        if (r != null) return r;
         synchronized (this) {
-            if (cachedUserId == null) {
-                cachedUserId = resolveLocalUser().getId();
+            if (cached == null) {
+                cached = resolve();
             }
-            return cachedUserId;
+            return cached;
         }
     }
 
-    private User resolveLocalUser() {
-        // local 优先：一旦存在（含竞态窗口内创建的），解析结果必须跨重启稳定，
-        // 不能因 DataInitializer 后来建出 admin 而翻转 userId。
-        return userRepository.findByUsername("local")
-                .orElseGet(() -> userRepository.findByUsername("admin")
-                        .map(admin -> {
-                            if (!LOCAL_DISPLAY_NAME.equals(admin.getDisplayName())) {
-                                admin.setDisplayName(LOCAL_DISPLAY_NAME);
-                                admin.setUpdatedAt(LocalDateTime.now());
-                                admin = userRepository.save(admin);
-                                log.info("单机模式：复用已有 admin 用户作为本机用户（id={}）", admin.getId());
-                            }
-                            return admin;
-                        })
-                        .orElseGet(this::createLocalUser));
+    /**
+     * 候选账号列表，按数据量降序（同分按 id 升序，保证顺序稳定）。
+     * 无论是否已选定都如实计算——设置页的「切换本机工作区」要靠它给出可改选的全集。
+     */
+    public List<Candidate> candidates() {
+        return userRepository.findAll().stream()
+                .filter(u -> u.getId() != null)
+                .filter(u -> !isTestAccount(u.getUsername()))
+                .map(u -> new Candidate(
+                        u.getId(),
+                        u.getUsername(),
+                        u.getDisplayName(),
+                        projectRepository.countByUserId(u.getId()),
+                        projectFileRepository.countByUserIdAndIsDeletedFalse(u.getId())))
+                .sorted(Comparator.comparingLong(Candidate::dataScore).reversed()
+                        .thenComparing(Candidate::userId))
+                .toList();
+    }
+
+    /**
+     * 选定本机身份并持久化。
+     *
+     * @throws IllegalArgumentException userId 为空、不存在或不在候选集内（测试账号不可选）
+     */
+    public synchronized Resolution select(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("缺少 userId");
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("该账号不存在"));
+        if (isTestAccount(user.getUsername())) {
+            throw new IllegalArgumentException("该账号不可作为本机工作区");
+        }
+        Resolution resolved = commit(user);
+        cached = resolved;
+        log.info("单机模式：已选定本机身份 userId={} username={}", user.getId(), user.getUsername());
+        return resolved;
+    }
+
+    // ==================== 解析 ====================
+
+    private Resolution resolve() {
+        // 1. 用户选过就不再问
+        Long selected = loadSelected();
+        if (selected != null && userRepository.existsById(selected)) {
+            return new Resolution(selected, false);
+        }
+        if (selected != null) {
+            log.warn("单机模式：已持久化的本机身份 userId={} 不存在（库被替换？），重新解析", selected);
+        }
+
+        // 2. 历史 local 用户永远优先
+        Optional<User> local = userRepository.findByUsername("local");
+        if (local.isPresent()) {
+            return commit(local.get());
+        }
+
+        // 3. 按数据量判定
+        List<Candidate> withData = candidates().stream().filter(Candidate::hasData).toList();
+        if (withData.size() == 1) {
+            Candidate only = withData.get(0);
+            log.info("单机模式：唯一有数据的账号 {}（id={}，{} 项目 / {} 文件）已选为本机工作区",
+                    only.username(), only.userId(), only.projectCount(), only.fileCount());
+            return commit(userRepository.findById(only.userId()).orElseThrow());
+        }
+        if (withData.size() > 1) {
+            Candidate top = withData.get(0);
+            log.warn("单机模式：检测到 {} 个有数据的历史账号，等待用户选定本机工作区；"
+                            + "选定前临时落在数据量最大的 {}（id={}）",
+                    withData.size(), top.username(), top.userId());
+            // 临时落点不写持久化——用户的选择才算数
+            return new Resolution(top.userId(), true);
+        }
+
+        // 4. 全空库：复用 DataInitializer 建出的空 admin（零新增行，与 PR-A 行为一致）
+        return commit(userRepository.findByUsername("admin").orElseGet(this::createLocalUser));
+    }
+
+    /** 落定一个身份：admin 改名去掉管理员心智 + 持久化 + 返回已确定的 Resolution。 */
+    private Resolution commit(User user) {
+        User target = user;
+        // 只对 username=admin 改名：那是 DataInitializer 播的系统默认账号，
+        // 「管理员」不是用户自己起的名字。真实账号（hanzewei 等）的 displayName 一个字都不能动。
+        if ("admin".equalsIgnoreCase(target.getUsername())
+                && !LOCAL_DISPLAY_NAME.equals(target.getDisplayName())) {
+            target.setDisplayName(LOCAL_DISPLAY_NAME);
+            target.setUpdatedAt(LocalDateTime.now());
+            target = userRepository.save(target);
+            log.info("单机模式：复用已有 admin 用户作为本机用户（id={}）", target.getId());
+        }
+        saveSelected(target.getId());
+        return new Resolution(target.getId(), false);
     }
 
     private User createLocalUser() {
@@ -89,6 +249,53 @@ public class LocalIdentityService {
         User saved = userRepository.save(user);
         log.info("单机模式：已创建本机用户（id={}）", saved.getId());
         return saved;
+    }
+
+    // ==================== 持久化 ====================
+
+    private Long loadSelected() {
+        try {
+            return systemSettingRepository.findByKey(SELECTED_KEY)
+                    .map(SystemSetting::getValue)
+                    .map(String::trim)
+                    .filter(v -> !v.isEmpty())
+                    .map(v -> {
+                        try {
+                            return Long.parseLong(v);
+                        } catch (NumberFormatException e) {
+                            log.warn("本机身份持久化值非法（{}），忽略", v);
+                            return null;
+                        }
+                    })
+                    .orElse(null);
+        } catch (Exception e) {
+            log.warn("读取本机身份持久化值失败，按未选定处理: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private void saveSelected(Long userId) {
+        try {
+            SystemSetting setting = systemSettingRepository.findByKey(SELECTED_KEY)
+                    .orElseGet(() -> {
+                        SystemSetting fresh = new SystemSetting();
+                        fresh.setKey(SELECTED_KEY);
+                        return fresh;
+                    });
+            setting.setValue(String.valueOf(userId));
+            systemSettingRepository.save(setting);
+        } catch (Exception e) {
+            // 写不进去不致命：下次启动按同样规则重算，结果一致（只是多一次统计）
+            log.warn("本机身份持久化写入失败（不影响本次运行）: {}", e.getMessage());
+        }
+    }
+
+    // ==================== 工具 ====================
+
+    static boolean isTestAccount(String username) {
+        if (username == null) return false;
+        String lower = username.toLowerCase(Locale.ROOT);
+        return TEST_ACCOUNT_PREFIXES.stream().anyMatch(lower::startsWith);
     }
 
     private static String randomPassword() {

--- a/backend/src/test/java/com/checkba/service/LocalIdentityRealShapeIntegrationTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalIdentityRealShapeIntegrationTest.java
@@ -1,0 +1,179 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.User;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.SystemSettingRepository;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 用真机 ~/.aiworkdeck/local.mv.db 的实测形态跑一遍解析，锁死这次 bug 的现场：
+ *
+ * <pre>
+ *   id=1 admin      1 个项目 / 0 个文件   ← PR-A 的规则会选中它（用户看到空工作区）
+ *   id=2 hanzewei   6 个项目 / 21 个文件  ← 用户的全部真实数据
+ *   id=3 hanzewei1  0 / 0
+ *   id=4 newuser    0 / 0
+ *   + 一批 qa_bot_* / claude-e2e / e2e_keepalive 测试账号（部分有数据）
+ * </pre>
+ *
+ * 断言：解析结果是「待选定」而不是任何一个静默选择，候选排序里 hanzewei 排第一。
+ *
+ * 数据源约定同 WorkSessionRepositoryTest（内存 H2 + MODE=PostgreSQL + NON_KEYWORDS=VALUE）。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:local-identity-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class LocalIdentityRealShapeIntegrationTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private ProjectFileRepository projectFileRepository;
+    @Autowired private SystemSettingRepository systemSettingRepository;
+
+    private Long adminId;
+    private Long hanzeweiId;
+
+    private LocalIdentityService service() {
+        // localMode=false：本测试只验解析规则，不想污染 AuthController 的静态注册点
+        return new LocalIdentityService(userRepository, projectRepository,
+                projectFileRepository, systemSettingRepository, false);
+    }
+
+    private Long createUser(String username, String displayName) {
+        User u = new User();
+        u.setUsername(username);
+        u.setDisplayName(displayName);
+        u.setPassword("x");
+        u.setCreatedAt(LocalDateTime.now());
+        u.setUpdatedAt(LocalDateTime.now());
+        return userRepository.save(u).getId();
+    }
+
+    private void createProjectsAndFiles(Long userId, int projectCount, int fileCount) {
+        Long firstProjectId = null;
+        for (int i = 0; i < projectCount; i++) {
+            Project p = new Project();
+            p.setName("项目" + i);
+            p.setProjectType("BLANK");
+            p.setListedCompanyName("-");
+            p.setTargetCompanyName("-");
+            p.setUserId(userId);
+            p.setCreatedAt(LocalDateTime.now());
+            p.setUpdatedAt(LocalDateTime.now());
+            Long id = projectRepository.save(p).getId();
+            if (firstProjectId == null) firstProjectId = id;
+        }
+        for (int i = 0; i < fileCount; i++) {
+            ProjectFile f = new ProjectFile();
+            f.setProjectId(firstProjectId == null ? 1L : firstProjectId);
+            f.setName("文件" + i + ".docx");
+            f.setIsFolder(false);
+            f.setSortOrder(i);
+            f.setUserId(userId);
+            f.setIsDeleted(false);
+            f.setCreatedAt(LocalDateTime.now());
+            f.setUpdatedAt(LocalDateTime.now());
+            projectFileRepository.save(f);
+        }
+    }
+
+    @BeforeEach
+    void seedRealShape() {
+        adminId = createUser("admin", "管理员");
+        hanzeweiId = createUser("hanzewei", "韩泽伟");
+        createUser("hanzewei1", "韩泽伟1");
+        createUser("newuser", "新用户");
+        createUser("qa_bot_1754300001", "QA 机器人");
+        createUser("claude-e2e", "E2E");
+        createUser("e2e_keepalive", "保活探针");
+
+        createProjectsAndFiles(adminId, 1, 0);
+        createProjectsAndFiles(hanzeweiId, 6, 21);
+        // 测试账号也留了数据——排除逻辑必须在数据量之前生效
+        createProjectsAndFiles(userRepository.findByUsername("qa_bot_1754300001").orElseThrow().getId(), 4, 12);
+    }
+
+    @Test
+    void realMachineShapeResolvesToPendingSelectionInsteadOfAdmin() {
+        LocalIdentityService svc = service();
+
+        assertTrue(svc.needsSelection(),
+                "admin 与 hanzewei 都有数据，必须待用户选定，不能像 PR-A 那样静默选 admin");
+        assertEquals(hanzeweiId, svc.localUserId(),
+                "待选定期间的临时落点应是数据量最大的 hanzewei，而不是空壳 admin");
+        assertTrue(systemSettingRepository.findByKey(LocalIdentityService.SELECTED_KEY).isEmpty(),
+                "待选定不得写持久化");
+    }
+
+    @Test
+    void candidatesAreRankedByDataAndExcludeTestAccounts() {
+        List<LocalIdentityService.Candidate> candidates = service().candidates();
+
+        assertEquals(List.of("hanzewei", "admin", "hanzewei1", "newuser"),
+                candidates.stream().map(LocalIdentityService.Candidate::username).toList(),
+                "按数据量降序；qa_bot_* / claude-e2e / e2e_keepalive 即便有数据也不进候选");
+
+        LocalIdentityService.Candidate top = candidates.get(0);
+        assertEquals(6L, top.projectCount());
+        assertEquals(21L, top.fileCount());
+
+        LocalIdentityService.Candidate admin = candidates.get(1);
+        assertEquals(1L, admin.projectCount());
+        assertEquals(0L, admin.fileCount());
+    }
+
+    @Test
+    void selectingHanzeweiPersistsAndSurvivesRestart() {
+        LocalIdentityService svc = service();
+        svc.select(hanzeweiId);
+
+        assertFalse(svc.needsSelection());
+        assertEquals(hanzeweiId, svc.localUserId());
+
+        // 「重启」：换一个新实例重新解析，必须直接命中持久化的选择
+        LocalIdentityService restarted = service();
+        assertFalse(restarted.needsSelection(), "选过一次就不该再问");
+        assertEquals(hanzeweiId, restarted.localUserId());
+    }
+
+    @Test
+    void deletedFilesDoNotCountAsData() {
+        // 回收站里的文件不代表「还在用这个工作区」
+        ProjectFile f = new ProjectFile();
+        f.setProjectId(projectRepository.findByUserIdOrderByCreatedAtDesc(adminId).get(0).getId());
+        f.setName("已删除.docx");
+        f.setIsFolder(false);
+        f.setSortOrder(0);
+        f.setUserId(userRepository.findByUsername("newuser").orElseThrow().getId());
+        f.setIsDeleted(true);
+        f.setCreatedAt(LocalDateTime.now());
+        f.setUpdatedAt(LocalDateTime.now());
+        projectFileRepository.save(f);
+
+        LocalIdentityService.Candidate newuser = service().candidates().stream()
+                .filter(c -> "newuser".equals(c.username())).findFirst().orElseThrow();
+        assertEquals(0L, newuser.fileCount());
+        assertFalse(newuser.hasData());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/LocalIdentityServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalIdentityServiceTest.java
@@ -1,26 +1,80 @@
 package com.checkba.service;
 
 import com.checkba.controller.AuthController;
+import com.checkba.model.entity.SystemSetting;
 import com.checkba.model.entity.User;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.SystemSettingRepository;
 import com.checkba.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 /**
- * 锁定本机用户解析规则（商业化改造 PR-A）：
- * - local 用户存在则永远优先（跨重启稳定，防止 DataInitializer 竞态后翻转 userId）；
- * - 老安装：复用 username=admin 的 userId（数据全挂在它名下，绝不能变），displayName 改「本机用户」；
- * - 全新库：创建 username=local、displayName「本机用户」；
- * - local-mode 下静态注册后，getUserIdFromSession 无论 header 是什么都返回本机用户 id。
+ * 锁定本机身份解析规则（PR-A + 2026-08-05「选错账号」修正）：
+ * <ol>
+ *   <li>已持久化的选择永远优先，跨重启稳定；</li>
+ *   <li>其次 username=local（历史竞态窗口的产物，不能翻转）；</li>
+ *   <li>再次按数据量：唯一有数据的候选直接选中；多个有数据 → needsSelection，绝不静默选择；
+ *       全空库复用空 admin；</li>
+ *   <li>测试账号（qa_bot_* / claude-e2e / e2e_keepalive）不进候选，真实账号一个都不许误排。</li>
+ * </ol>
  */
 class LocalIdentityServiceTest {
+
+    private UserRepository users;
+    private ProjectRepository projects;
+    private ProjectFileRepository files;
+    private SystemSettingRepository settings;
+    private final List<User> table = new ArrayList<>();
+    private SystemSetting storedSelection;
+
+    @BeforeEach
+    void setUp() {
+        users = mock(UserRepository.class);
+        projects = mock(ProjectRepository.class);
+        files = mock(ProjectFileRepository.class);
+        settings = mock(SystemSettingRepository.class);
+        table.clear();
+        storedSelection = null;
+
+        when(users.findAll()).thenAnswer(inv -> new ArrayList<>(table));
+        when(users.findByUsername(anyString())).thenAnswer(inv -> table.stream()
+                .filter(u -> inv.getArgument(0).equals(u.getUsername())).findFirst());
+        when(users.findById(anyLong())).thenAnswer(inv -> table.stream()
+                .filter(u -> inv.getArgument(0).equals(u.getId())).findFirst());
+        when(users.existsById(anyLong())).thenAnswer(inv -> table.stream()
+                .anyMatch(u -> inv.getArgument(0).equals(u.getId())));
+        when(users.save(any(User.class))).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            if (u.getId() == null) {
+                u.setId(99L);
+                table.add(u);
+            }
+            return u;
+        });
+        // 默认零数据；需要数据的用例逐个覆盖
+        when(projects.countByUserId(anyLong())).thenReturn(0L);
+        when(files.countByUserIdAndIsDeletedFalse(anyLong())).thenReturn(0L);
+
+        when(settings.findByKey(LocalIdentityService.SELECTED_KEY))
+                .thenAnswer(inv -> Optional.ofNullable(storedSelection));
+        when(settings.save(any(SystemSetting.class))).thenAnswer(inv -> {
+            storedSelection = inv.getArgument(0);
+            return storedSelection;
+        });
+    }
 
     @AfterEach
     void resetStatic() {
@@ -28,103 +82,249 @@ class LocalIdentityServiceTest {
         AuthController.registerLocalIdentityService(null);
     }
 
-    private static User user(Long id, String username, String displayName) {
+    private User user(Long id, String username, String displayName) {
         User u = new User();
         u.setId(id);
         u.setUsername(username);
         u.setDisplayName(displayName);
+        table.add(u);
         return u;
     }
 
-    @Test
-    void reusesExistingAdminAndRenamesDisplayName() {
-        UserRepository repo = mock(UserRepository.class);
-        User admin = user(7L, "admin", "管理员");
-        when(repo.findByUsername("local")).thenReturn(Optional.empty());
-        when(repo.findByUsername("admin")).thenReturn(Optional.of(admin));
-        when(repo.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    private void data(Long userId, long projectCount, long fileCount) {
+        when(projects.countByUserId(userId)).thenReturn(projectCount);
+        when(files.countByUserIdAndIsDeletedFalse(userId)).thenReturn(fileCount);
+    }
 
-        LocalIdentityService svc = new LocalIdentityService(repo, false);
-        assertEquals(7L, svc.localUserId(), "必须复用 admin 的 userId，老安装数据不能变更归属");
-        assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME, admin.getDisplayName());
-        verify(repo).save(admin);
+    private LocalIdentityService service(boolean localMode) {
+        return new LocalIdentityService(users, projects, files, settings, localMode);
+    }
+
+    private void persistSelection(long userId) {
+        SystemSetting s = new SystemSetting();
+        s.setKey(LocalIdentityService.SELECTED_KEY);
+        s.setValue(String.valueOf(userId));
+        storedSelection = s;
+    }
+
+    // ==================== 规则 1：已持久化的选择 ====================
+
+    @Test
+    void persistedSelectionWinsOverEverything() {
+        user(1L, "admin", "管理员");
+        User picked = user(2L, "hanzewei", "韩泽伟");
+        user(3L, "local", LocalIdentityService.LOCAL_DISPLAY_NAME);
+        data(2L, 6, 21);
+        persistSelection(picked.getId());
+
+        LocalIdentityService svc = service(false);
+        assertEquals(2L, svc.localUserId(), "已选定的身份必须优先于 local 用户与数据量判定");
+        assertFalse(svc.needsSelection());
+        verify(users, never()).findByUsername("local");
     }
 
     @Test
-    void existingLocalUserAlwaysWinsOverAdmin() {
+    void persistedSelectionPointingAtMissingUserIsReResolved() {
+        // 库被替换/回滚：指针悬空时必须回落到重新解析，而不是抱着一个不存在的 userId
+        User admin = user(1L, "admin", "管理员");
+        persistSelection(777L);
+
+        LocalIdentityService svc = service(false);
+        assertEquals(admin.getId(), svc.localUserId());
+        assertFalse(svc.needsSelection());
+        assertEquals("1", storedSelection.getValue(), "重新解析的结果要覆盖悬空指针");
+    }
+
+    // ==================== 规则 2：username=local ====================
+
+    @Test
+    void existingLocalUserWinsOverAdminAndIsPersisted() {
         // 竞态窗口内创建过 local 用户后，即使 admin 后来出现，解析结果也不能翻转
-        UserRepository repo = mock(UserRepository.class);
-        when(repo.findByUsername("local"))
-                .thenReturn(Optional.of(user(3L, "local", LocalIdentityService.LOCAL_DISPLAY_NAME)));
+        user(1L, "admin", "管理员");
+        user(3L, "local", LocalIdentityService.LOCAL_DISPLAY_NAME);
+        data(1L, 5, 10); // admin 就算有数据也不夺权
 
-        LocalIdentityService svc = new LocalIdentityService(repo, false);
+        LocalIdentityService svc = service(false);
         assertEquals(3L, svc.localUserId(), "local 用户存在时必须优先，跨重启不能换 userId");
-        verify(repo, never()).findByUsername("admin");
-        verify(repo, never()).save(any());
+        assertFalse(svc.needsSelection());
+        assertEquals("3", storedSelection.getValue(), "命中后要固化成持久化选择");
+    }
+
+    // ==================== 规则 3：数据量判定 ====================
+
+    @Test
+    void singleCandidateWithDataIsSelectedAndPersisted() {
+        // 老安装的典型形态：admin 是空壳，数据全在真实账号名下
+        user(1L, "admin", "管理员");
+        user(2L, "hanzewei", "韩泽伟");
+        user(4L, "newuser", "新用户");
+        data(2L, 6, 21);
+
+        LocalIdentityService svc = service(false);
+        assertEquals(2L, svc.localUserId(), "唯一有数据的账号就是本机工作区");
+        assertFalse(svc.needsSelection());
+        assertEquals("2", storedSelection.getValue());
     }
 
     @Test
-    void reusedAdminAlreadyRenamedIsNotRewritten() {
-        UserRepository repo = mock(UserRepository.class);
-        User admin = user(7L, "admin", LocalIdentityService.LOCAL_DISPLAY_NAME);
-        when(repo.findByUsername("admin")).thenReturn(Optional.of(admin));
+    void multipleCandidatesWithDataNeedSelectionAndAreNotPersisted() {
+        user(1L, "admin", "管理员");
+        user(2L, "hanzewei", "韩泽伟");
+        data(1L, 1, 0);
+        data(2L, 6, 21);
 
-        LocalIdentityService svc = new LocalIdentityService(repo, false);
-        assertEquals(7L, svc.localUserId());
-        verify(repo, never()).save(any());
+        LocalIdentityService svc = service(false);
+        assertTrue(svc.needsSelection(), "多个候选有数据时必须交给用户选，绝不静默挑一个");
+        assertEquals(2L, svc.localUserId(), "待选定期间临时落在数据量最大的候选，避免全站 500");
+        assertNull(storedSelection, "待选定不得写持久化——用户的选择才算数");
+        verify(users, never()).save(any(User.class));
     }
 
     @Test
-    void createsLocalUserWhenAdminAbsent() {
-        UserRepository repo = mock(UserRepository.class);
-        when(repo.findByUsername("admin")).thenReturn(Optional.empty());
-        when(repo.findByUsername("local")).thenReturn(Optional.empty());
-        when(repo.save(any(User.class))).thenAnswer(inv -> {
-            User u = inv.getArgument(0);
-            u.setId(42L);
-            return u;
-        });
+    void emptyDatabaseReusesExistingAdminAndRenamesDisplayName() {
+        User admin = user(1L, "admin", "管理员");
 
-        LocalIdentityService svc = new LocalIdentityService(repo, false);
-        assertEquals(42L, svc.localUserId());
+        LocalIdentityService svc = service(false);
+        assertEquals(1L, svc.localUserId(), "全空库复用 DataInitializer 播的 admin，不新增账号");
+        assertFalse(svc.needsSelection());
+        assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME, admin.getDisplayName());
+        assertEquals("1", storedSelection.getValue());
+    }
+
+    @Test
+    void createsLocalUserWhenNoUsersAtAll() {
+        LocalIdentityService svc = service(false);
+        assertEquals(99L, svc.localUserId());
+        assertFalse(svc.needsSelection());
 
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
-        verify(repo).save(captor.capture());
+        verify(users).save(captor.capture());
         User created = captor.getValue();
         assertEquals("local", created.getUsername());
         assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME, created.getDisplayName());
         assertNotNull(created.getPassword(), "密码列非空约束需要满足");
         assertFalse(created.getPassword().isBlank());
+        assertEquals("99", storedSelection.getValue());
     }
 
     @Test
-    void cachesResolvedId() {
-        UserRepository repo = mock(UserRepository.class);
-        when(repo.findByUsername("admin"))
-                .thenReturn(Optional.of(user(7L, "admin", LocalIdentityService.LOCAL_DISPLAY_NAME)));
+    void realAccountDisplayNameIsNeverRewritten() {
+        // 改名只针对系统默认的 admin；用户自己的账号名一个字都不能动
+        User real = user(2L, "hanzewei", "韩泽伟");
+        data(2L, 6, 21);
 
-        LocalIdentityService svc = new LocalIdentityService(repo, false);
-        assertEquals(7L, svc.localUserId());
-        assertEquals(7L, svc.localUserId());
-        verify(repo, times(1)).findByUsername("admin");
+        service(false).localUserId();
+        assertEquals("韩泽伟", real.getDisplayName());
+    }
+
+    // ==================== 测试账号排除 ====================
+
+    @Test
+    void testAccountsAreExcludedButRealAccountsAreNot() {
+        user(1L, "admin", "管理员");
+        user(2L, "hanzewei", "韩泽伟");
+        user(3L, "hanzewei1", "韩泽伟1");
+        user(4L, "newuser", "新用户");
+        user(5L, "qa_bot_1754300000", "QA");
+        user(6L, "claude-e2e", "E2E");
+        user(7L, "e2e_keepalive", "保活");
+        data(2L, 6, 21);
+        data(5L, 3, 9);
+        data(6L, 2, 4);
+        data(7L, 1, 1);
+
+        LocalIdentityService svc = service(false);
+        List<String> names = svc.candidates().stream()
+                .map(LocalIdentityService.Candidate::username).toList();
+        assertEquals(List.of("hanzewei", "admin", "hanzewei1", "newuser"), names,
+                "测试账号出局；名字像但不是测试脚手架造的（hanzewei1 / newuser）必须留在候选里");
+        assertFalse(svc.needsSelection(), "排除测试账号后只剩 hanzewei 有数据，可以直接选定");
+        assertEquals(2L, svc.localUserId());
+    }
+
+    @Test
+    void testAccountPrefixMatchIsCaseInsensitiveAndPrefixOnly() {
+        assertTrue(LocalIdentityService.isTestAccount("qa_bot_123"));
+        assertTrue(LocalIdentityService.isTestAccount("QA_BOT_123"));
+        assertTrue(LocalIdentityService.isTestAccount("claude-e2e-2"));
+        assertTrue(LocalIdentityService.isTestAccount("e2e_keepalive"));
+        // 只按前缀匹配，不做子串匹配——真实用户名里出现这些词不该被吃掉
+        assertFalse(LocalIdentityService.isTestAccount("qa_bot"), "少了下划线就不是脚手架格式");
+        assertFalse(LocalIdentityService.isTestAccount("my_qa_bot_helper"));
+        assertFalse(LocalIdentityService.isTestAccount("hanzewei"));
+        assertFalse(LocalIdentityService.isTestAccount(null));
+    }
+
+    // ==================== select ====================
+
+    @Test
+    void selectPersistsAndClearsPendingState() {
+        user(1L, "admin", "管理员");
+        user(2L, "hanzewei", "韩泽伟");
+        data(1L, 1, 0);
+        data(2L, 6, 21);
+
+        LocalIdentityService svc = service(false);
+        assertTrue(svc.needsSelection());
+
+        svc.select(1L);
+        assertFalse(svc.needsSelection(), "选定后缓存要失效并回到已确定状态");
+        assertEquals(1L, svc.localUserId());
+        assertEquals("1", storedSelection.getValue());
+    }
+
+    @Test
+    void selectRejectsUnknownNullAndTestAccounts() {
+        user(2L, "hanzewei", "韩泽伟");
+        user(5L, "qa_bot_1754300000", "QA");
+        data(2L, 6, 21);
+
+        LocalIdentityService svc = service(false);
+        assertThrows(IllegalArgumentException.class, () -> svc.select(null));
+        assertThrows(IllegalArgumentException.class, () -> svc.select(404L));
+        assertThrows(IllegalArgumentException.class, () -> svc.select(5L),
+                "测试账号不在候选集内，不能被选为本机工作区");
+    }
+
+    // ==================== 缓存与 AuthController 接线 ====================
+
+    @Test
+    void cachesResolvedId() {
+        user(1L, "admin", LocalIdentityService.LOCAL_DISPLAY_NAME);
+
+        LocalIdentityService svc = service(false);
+        assertEquals(1L, svc.localUserId());
+        assertEquals(1L, svc.localUserId());
+        // 只解析一次：候选统计是每用户 2 条 count 查询，热路径上不能每请求重跑
+        verify(users, times(1)).findByUsername("local");
+        verify(users, times(1)).findAll();
     }
 
     @Test
     void localModeHijacksSessionResolutionRegardlessOfHeader() {
-        UserRepository repo = mock(UserRepository.class);
-        when(repo.findByUsername("admin"))
-                .thenReturn(Optional.of(user(7L, "admin", LocalIdentityService.LOCAL_DISPLAY_NAME)));
+        user(1L, "admin", LocalIdentityService.LOCAL_DISPLAY_NAME);
 
-        // localMode=true 构造即静态注册
-        new LocalIdentityService(repo, true);
-        assertEquals(7L, AuthController.getUserIdFromSession(null), "无 header 也应解析为本机用户");
-        assertEquals(7L, AuthController.getUserIdFromSession("session_garbage"), "任意无效 session 也应解析为本机用户");
+        service(true); // localMode=true 构造即静态注册
+        assertEquals(1L, AuthController.getUserIdFromSession(null), "无 header 也应解析为本机用户");
+        assertEquals(1L, AuthController.getUserIdFromSession("session_garbage"),
+                "任意无效 session 也应解析为本机用户");
+    }
+
+    @Test
+    void pendingSelectionStillResolvesSessionsInsteadOf500() {
+        // 待选定不能让全站 500：getUserIdFromSession 仍然拿得到一个 userId
+        user(1L, "admin", "管理员");
+        user(2L, "hanzewei", "韩泽伟");
+        data(1L, 1, 0);
+        data(2L, 6, 21);
+
+        service(true);
+        assertEquals(2L, AuthController.getUserIdFromSession(null));
     }
 
     @Test
     void serverModeDoesNotRegister() {
-        UserRepository repo = mock(UserRepository.class);
-        new LocalIdentityService(repo, false);
+        service(false);
         // 非 local-mode 行为一字不变：无效 session 仍然是未登录
         assertNull(AuthController.getUserIdFromSession("session_garbage"));
         assertNull(AuthController.getUserIdFromSession(null));

--- a/frontend/src/pages.json
+++ b/frontend/src/pages.json
@@ -15,6 +15,13 @@
 			}
 		},
 		{
+			"path": "pages/identity/identity",
+			"style": {
+				"navigationBarTitleText": "选择本机工作区",
+				"navigationStyle": "custom"
+			}
+		},
+		{
 			"path": "pages/login/login",
 			"style": {
 				"navigationBarTitleText": "登录",

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -587,6 +587,44 @@
               </view>
             </view>
           </view>
+
+          <!-- 本机工作区（免登身份）。只在本机确实有一个以上账号时出现——
+               绝大多数安装只有一个，摆一张永远只有一行的卡片是噪音。
+               这里是选错工作区之后的补救入口：老安装的库里常有多个历史账号，
+               启动时的选择页只出现一次。 -->
+          <view v-if="identityCandidates.length > 1" class="section-card">
+            <view class="section-header">
+              <text class="section-title">本机工作区</text>
+              <text class="section-subtitle">
+                本机检测到多个历史账号，当前使用的是其中一个。切换后项目与文件会换成另一个账号名下的内容，数据不会移动
+              </text>
+            </view>
+            <view class="section-body">
+              <view
+                v-for="item in identityCandidates"
+                :key="item.userId"
+                class="comp-row"
+              >
+                <view class="comp-main">
+                  <text class="comp-name">{{ item.displayName || item.username }}</text>
+                  <text class="comp-sub">
+                    {{ item.username }} · {{ item.projectCount }} 个项目 · {{ item.fileCount }} 个文件
+                  </text>
+                </view>
+                <view class="comp-actions">
+                  <text v-if="item.userId === identityCurrentId" class="account-note">当前使用</text>
+                  <button
+                    v-else
+                    class="comp-btn"
+                    :disabled="identityBusy"
+                    @tap="onSwitchIdentity(item)"
+                  >
+                    切换
+                  </button>
+                </view>
+              </view>
+            </view>
+          </view>
         </scroll-view>
 
         <!-- 组件管理（仅桌面端：本地模型下载与服务启用） -->
@@ -777,6 +815,7 @@ import {
   cloudConnect, listCloudConnections, disconnectCloudConnection,
   getAccountStatus, connectAccount, disconnectAccount, getAccountUsage,
   getStorageLocation, moveStorageLocation, resetStorageLocation,
+  getLocalIdentityCandidates, selectLocalIdentity,
 } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
@@ -856,6 +895,10 @@ export default {
       // path 为空 = 后端没给（非单机模式/旧后端），整块不显示
       storageLocation: { path: '', defaultPath: '', custom: false, available: true, entitled: false },
       storageBusy: false,
+      // 本机工作区（免登身份）候选。长度 <= 1 时整块卡片不渲染
+      identityCandidates: [],
+      identityCurrentId: null,
+      identityBusy: false,
     }
   },
   computed: {
@@ -1074,7 +1117,40 @@ export default {
         this.loadAccount()
         // 权益决定「更改位置」按钮出不出现；当前位置本身无论有没有权益都要显示
         this.loadStorageLocation()
+        this.loadIdentityCandidates()
         refreshEntitlements()
+      }
+    },
+    async loadIdentityCandidates() {
+      try {
+        const res = await getLocalIdentityCandidates()
+        this.identityCandidates = (res && res.candidates) || []
+        this.identityCurrentId = (res && res.currentUserId) || null
+      } catch (e) {
+        // 团队服务器部署没有本机工作区概念，读不到就整块不显示
+        this.identityCandidates = []
+        this.identityCurrentId = null
+      }
+    },
+    async onSwitchIdentity(item) {
+      const ok = await new Promise((r) => uni.showModal({
+        title: '切换本机工作区',
+        content: `切换到「${item.displayName || item.username}」后，项目与文件会换成该账号名下的内容。`
+          + '当前账号的数据不会被删除或移动，随时可以切回来。切换后应用会重新启动。',
+        confirmText: '切换',
+        success: (res) => r(res.confirm),
+      }))
+      if (!ok) return
+      this.identityBusy = true
+      try {
+        await selectLocalIdentity(item.userId)
+        // 全站几乎每个页面都缓存着上一个身份的数据，就地刷新不干净——回启动链重走一遍
+        uni.removeStorageSync('checkba_last_project_id')
+        uni.reLaunch({ url: '/pages/launch/launch' })
+      } catch (e) {
+        uni.showToast({ title: (e && e.message) || '切换失败', icon: 'none' })
+      } finally {
+        this.identityBusy = false
       }
     },
     async loadPlatformAiAvailability() {

--- a/frontend/src/pages/identity/identity.vue
+++ b/frontend/src/pages/identity/identity.vue
@@ -1,0 +1,251 @@
+<template>
+  <!-- 本机工作区选择：仅当本机有多个都带数据的历史账号时出现一次，选完即持久化 -->
+  <view class="identity-page">
+    <view class="identity-card">
+      <image class="identity-logo" src="/static/logo_full_v2.png" mode="heightFix" />
+      <text class="identity-title">选择本机工作区</text>
+      <text class="identity-subtitle">
+        检测到本机有多个历史账号，请选择要继续使用的工作区。选定后不会再问，之后可在「设置 - 账户与用量」里更改。
+      </text>
+
+      <view v-if="loading" class="identity-hint">
+        <text class="identity-hint-text">正在读取本机账号</text>
+      </view>
+
+      <view v-else-if="errorMsg" class="identity-hint">
+        <text class="identity-error">{{ errorMsg }}</text>
+        <button class="identity-retry-btn" @tap="load">重试</button>
+      </view>
+
+      <view v-else class="identity-list">
+        <view
+          v-for="item in candidates"
+          :key="item.userId"
+          class="identity-item"
+          :class="{ 'is-active': selectedId === item.userId }"
+          @tap="selectedId = item.userId"
+        >
+          <view class="identity-item-main">
+            <text class="identity-name">{{ item.displayName || item.username }}</text>
+            <text class="identity-username">{{ item.username }}</text>
+          </view>
+          <text class="identity-meta">{{ item.projectCount }} 个项目 · {{ item.fileCount }} 个文件</text>
+        </view>
+      </view>
+
+      <button
+        v-if="!loading && !errorMsg"
+        class="identity-btn"
+        :disabled="!selectedId || submitting"
+        @tap="confirm"
+      >
+        {{ submitting ? '正在进入' : '进入工作区' }}
+      </button>
+      <text v-if="submitError" class="identity-error">{{ submitError }}</text>
+    </view>
+  </view>
+</template>
+
+<script>
+import { getLocalIdentityCandidates, selectLocalIdentity } from '@/services/api.js'
+
+export default {
+  name: 'IdentityPage',
+  data() {
+    return {
+      loading: true,
+      candidates: [],
+      // 默认预选数据量最大的那个（后端已按数据量降序），但仍要用户确认才算数
+      selectedId: null,
+      errorMsg: '',
+      submitError: '',
+      submitting: false,
+    }
+  },
+  onLoad() {
+    this.load()
+  },
+  methods: {
+    async load() {
+      this.loading = true
+      this.errorMsg = ''
+      try {
+        const res = await getLocalIdentityCandidates()
+        this.candidates = (res && res.candidates) || []
+        if (!this.candidates.length) {
+          // 理论上到不了这里（needsSelection 必然意味着至少两个候选）；
+          // 真到了就别把用户困在空页面上，直接回启动链重新分流
+          uni.reLaunch({ url: '/pages/launch/launch' })
+          return
+        }
+        this.selectedId = this.candidates[0].userId
+      } catch (e) {
+        this.errorMsg = (e && e.message) || '无法读取本机账号，请重试'
+      } finally {
+        this.loading = false
+      }
+    },
+    async confirm() {
+      if (!this.selectedId || this.submitting) return
+      this.submitError = ''
+      this.submitting = true
+      try {
+        await selectLocalIdentity(this.selectedId)
+        uni.reLaunch({ url: '/pages/launch/launch' })
+      } catch (e) {
+        this.submitError = (e && e.message) || '选择失败，请重试'
+        this.submitting = false
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.identity-page {
+  width: 100vw;
+  height: 100vh;
+  background: #f8f9fa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.identity-card {
+  width: 420px;
+  max-height: 84vh;
+  padding: 36px 32px 30px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.identity-logo {
+  height: 32px;
+  margin-bottom: 18px;
+}
+
+.identity-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.identity-subtitle {
+  margin-top: 10px;
+  font-size: 12px;
+  line-height: 19px;
+  color: #64748b;
+  text-align: center;
+}
+
+.identity-hint {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.identity-hint-text {
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.identity-list {
+  width: 100%;
+  margin-top: 22px;
+  max-height: 46vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.identity-item {
+  padding: 12px 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #ffffff;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #cbd5e1;
+    background: #f8fafc;
+  }
+
+  &.is-active {
+    border-color: #1a5336;
+    background: #f1f7f3;
+  }
+}
+
+.identity-item-main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.identity-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.identity-username {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.identity-meta {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.identity-btn {
+  width: 100%;
+  height: 38px;
+  line-height: 36px;
+  margin-top: 20px;
+  font-size: 13px;
+  color: #ffffff;
+  background: #1a5336;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover {
+    background: #14422b;
+  }
+
+  &[disabled] {
+    background: #cbd5e1;
+    cursor: default;
+  }
+}
+
+.identity-retry-btn {
+  height: 34px;
+  line-height: 32px;
+  padding: 0 24px;
+  font-size: 13px;
+  color: #1a5336;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.identity-error {
+  margin-top: 12px;
+  font-size: 12px;
+  line-height: 18px;
+  color: #dc2626;
+  text-align: center;
+}
+</style>

--- a/frontend/src/pages/launch/launch.vue
+++ b/frontend/src/pages/launch/launch.vue
@@ -16,7 +16,12 @@
 </template>
 
 <script>
-import { getLicenseStatus, getWizardStatus, getMyProjects } from '@/services/api.js'
+import {
+  getLicenseStatus,
+  getLocalIdentityStatus,
+  getWizardStatus,
+  getMyProjects,
+} from '@/services/api.js'
 import { syncRecentToMenu } from '@/utils/recentProjects.js'
 
 export default {
@@ -54,6 +59,19 @@ export default {
       if (!status.unlocked) {
         uni.reLaunch({ url: '/pages/unlock/unlock' })
         return
+      }
+
+      // 本机工作区待选定：老安装的库里可能有多个都带数据的历史账号，后端不猜，
+      // 在这里拦下来让用户自己选，选完才进工作区（选过一次就不会再走这条分支）。
+      try {
+        const identity = await getLocalIdentityStatus()
+        if (identity && identity.needsSelection) {
+          uni.reLaunch({ url: '/pages/identity/identity' })
+          return
+        }
+      } catch (e) {
+        // 查询失败不拦路：后端仍会落在数据量最大的候选上，工作区可用
+        console.warn('查询本机工作区状态失败（忽略）:', e && e.message)
       }
 
       // 已解锁：向导检查 + 直达上次项目（迁移自 login.vue tryAutoResume）

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -715,6 +715,42 @@ export function deactivateLicense() {
   });
 }
 
+// ===================== 本机工作区（免登身份）相关 API =====================
+//
+// 单机免登下所有请求都解析为「本机用户」。老安装的库里往往不止一个账号
+// （admin 是系统播的空壳，真实数据在用户自己注册的账号名下），后端不再靠猜，
+// 多个账号都有数据时返回 needsSelection，由 launch 页分流到选择页。
+// 与解锁门同批，返回裸 JSON。
+
+// { localMode, needsSelection, userId, username, displayName }
+export function getLocalIdentityStatus() {
+  return request({
+    url: '/api/local-identity/status',
+    method: 'GET',
+  });
+}
+
+// { localMode, needsSelection, currentUserId, candidates: [{ userId, username, displayName, projectCount, fileCount }] }
+// 候选按数据量降序；待选定时 currentUserId 为 null（临时落点不算「已选中」）。
+export function getLocalIdentityCandidates() {
+  return request({
+    url: '/api/local-identity/candidates',
+    method: 'GET',
+  });
+}
+
+// 选定本机工作区。成功 200 { userId }；非法 userId 走 400 { message }（request 层转 reject）
+export function selectLocalIdentity(userId) {
+  return request({
+    url: '/api/local-identity/select',
+    method: 'POST',
+    data: { userId },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
 // ===================== 账户与用量（商业化 PR-B）相关 API =====================
 //
 // 桌面后端把官网账户接口收敛成本机端点，前端一律只跟本机后端说话


### PR DESCRIPTION
## 问题

PR-A（桌面去登录 + 解锁门，#247）的免登身份解析规则是「优先 username=local，否则回落 admin」，前提写的是「老安装的数据都挂在 admin 名下」。**这条前提是错的。**

维护者真机数据库 `~/.aiworkdeck/local.mv.db` 实测（H2 只读副本查询）：

| userId | username | 项目 | 文件 |
|---|---|---|---|
| 1 | admin | 1 | 0 |
| 2 | hanzewei | **6** | **21** |
| 3 | hanzewei1 | 0 | 0 |
| 4 | newuser | 0 | 0 |
| … | qa_bot_* / claude-e2e / e2e_keepalive | 若干 | 若干 |

PR-A 的规则会选中 id=1 的 admin —— 用户解锁后进入一个近乎空的工作区，6 个项目全部不可见。数据没丢，只是挂在另一个 userId 名下。

## 新解析规则

`LocalIdentityService` 按顺序：

1. **已持久化的「已选定本机身份」** → 直接用（跨重启稳定，用户选过就不再问）。
2. **存在 username=local 的用户** → 用它并持久化（历史竞态窗口的产物，翻转会让 local 名下数据成孤儿）。
3. **按数据量判定**：统计每个候选的「项目数 + 未删除文件数」。
   - 恰好一个候选有数据 → 选它并持久化（老安装的典型形态，零迁移）；
   - **多个候选有数据 → 不猜**，进入待选定状态；
   - 没有任何候选有数据 → 复用 DataInitializer 播的空 admin（全新库的典型形态），admin 也不存在时才新建 local。
4. **测试账号排除**：`qa_bot_` / `claude-e2e` / `e2e_keepalive` 三个前缀，刻意保守——只排除测试脚手架自己造的、名字里带明确标记的账号。`hanzewei1`、`newuser` 这类「名字像但是真的」一条都不会被误排；宁可多留一个候选让用户在选择页里自己排除。

**数据量只算项目数 + 未删除文件数**：AI 会话/记忆等都挂在项目之下，有 AI 历史必然有项目，加进去只是重复计权；回收站里的文件不代表「还在用这个工作区」，所以排除 `is_deleted`。

### 与 PR-A 的两处行为差异

- **displayName 改名收窄**：只对 `username=admin` 改成「本机用户」（那是系统播的默认账号，「管理员」不是用户起的名字）。真实账号的 displayName 一个字都不动——否则用户在选择页里认不出自己的账号。
- **全空库复用 admin 而不是新建 local**：两者在空库上行为等价，但复用 admin 零新增行、保持 PR-A 的首启行为与 app-e2e 基线不变，也不会在新增的切换器里多出一个空账号。

## 持久化位置：SystemSetting 表（不是 ~/.aiworkdeck/identity.json）

存的值是一个**指向 local.mv.db 内 user 表的外键**。把指针放进它所指向的库里，二者才能同生共死：用户还原一份旧的 local.mv.db、或重置工作区时，指针跟着一起回退，不会出现「指针指向一个已经不存在或含义变了的 userId」。`license.json` / `account.json` 恰恰相反——它们描述的是「这台机器的授权」，本就该独立于库存在，所以规格不同是刻意的。顺带省掉一套文件权限收敛与 JSON 解析容错，只为存一个 Long。

悬空指针（库被换掉）有兜底：`existsById` 校验不过就重新解析并覆写。

## 「待选定」状态的设计权衡

`getUserIdFromSession` 有 90 余处调用方，返回 null 等于全站 500。所以：

- **`localUserId()` 永远返回非 null。** 待选定时它临时落在「数据量最大的候选」上——这是最可能正确的那个，且**不写持久化**，用户在选择页做出的选择仍然说了算。
- **真正的门在前端**：新增 `GET /api/local-identity/status` 暴露 `needsSelection`，launch 页在解锁后、进工作区前分流到选择页，选完才继续。

代价与取舍：待选定期间若有请求绕过前端分流（背景轮询、直连 REST）落到临时候选上，理论上可能在「数据量最大的那个账号」名下产生写入。选择这条路是因为另外两条更差——返回 null 会让整站 500，静默持久化临时落点则会重演本次 bug。用「读得到、但不落定」把损失面收敛到最小。

放在 `/api/local-identity/status` 而不是塞进 `/api/license/status`：解锁门与身份是两件事，license 端点在团队服务器部署下恒回「已解锁」，混在一起会让 server 模式也背上一个恒 false 的字段。

新端点匿名（同 `LicenseController`）：这条链跑在「进入工作区之前」，此时本来就没有身份可言。安全前提与免登模式其余部分一致，`POST /select` 已实测落在 PR-A 的 `LocalModeAccessFilter` 防护内：

```
跨站 Origin POST  → 403
带 X-Forwarded-For → 403
同源无 Origin      → 200（渲染进程形态）
非法 userId        → 400
```

server 模式下三条端点全部空转（status 恒回 localMode=false，select 直接 400），否则任何人都能匿名改写团队服务器的身份解析。

## 前端

- 新页 `pages/identity/identity.vue`：浅色卡片列出候选（账号名、username、项目数、文件数），一句中文说明「检测到本机有多个历史账号，请选择要继续使用的工作区」，默认预选数据量最大的那个但仍需用户确认。选定后 `reLaunch` 回 launch 重跑分流（沿用 unlock 页的形状，不自己跳工作区）。
- `launch.vue` 在解锁后、向导检查之前插入分流；查询失败不拦路（后端仍有临时落点，工作区可用）。
- 设置页「账户与用量」新增「本机工作区」卡（**候选 >1 才渲染**，绝大多数安装只有一个账号，摆一张永远只有一行的卡片是噪音），二次确认后切换并回 launch 重走启动链，顺手清掉 `checkba_last_project_id`。

## 验证

- **单测** `LocalIdentityServiceTest`（16 个）：已持久化选择优先 / 悬空指针重解析 / local 用户优先并持久化 / 单候选有数据 / **多候选有数据返回 needsSelection 且不写持久化不静默选择** / 空库复用 admin / 无用户新建 local / 真实账号 displayName 不被改写 / 测试账号排除但真实账号不误排（前缀匹配大小写不敏感、不做子串匹配）/ select 的三类拒绝 / 缓存只解析一次 / 待选定仍能解析 session 不 500 / server 模式不注册。
- **集成测试** `LocalIdentityRealShapeIntegrationTest`（@DataJpaTest + 真 H2）：用上表的真机形态建库，断言解析结果是 `needsSelection`（而不是静默选 admin）、临时落点是 hanzewei、候选排序 hanzewei 在前且计数为 6/21、qa_bot 即便有数据也不进候选、选定后「重启」新实例直接命中持久化、回收站文件不计入数据量。
- **JDK 21 全量 `mvn test`**：841 个测试全绿（0 失败 0 错误，2 skipped）。
- **前端**：`npm run build:h5` 通过、`npm run check:emits` 通过（64 个 .vue）。
- **app-e2e**：全量通过。e2e 是全新库，走「空库复用 admin」路径，`needsSelection=false`，不触发选择页——新分支对既有启动链零影响。用隔离后端跑（9797 + 独立 user.home/H2/cwd），**未占用 9696**。
- 端点实测（隔离后端）：全新库 `{"needsSelection":false,"userId":1,"username":"admin"}`，候选只有 admin 一条。

不含 emoji，浅色体系，中文文案。

### 真机形态整链实跑

另起一个隔离后端（9798 + 独立 user.home），用上表形态种子库（admin 1/0、hanzewei 6/21、qa_bot 4/0）真实跑完选择链路：

```
/api/local-identity/status
  {"needsSelection":true,"userId":2,"username":"hanzewei","displayName":"韩泽伟"}
/api/local-identity/candidates
  hanzewei 6/21 → admin 1/0 → hanzewei1 0/0 → newuser 0/0   （qa_bot 已排除，currentUserId=null）
```

浏览器实跑（Chrome headless）：
- launch 检测到多候选，分流到 identity 页
- 页面渲染四张候选卡片与中文说明，hanzewei 默认预选，qa_bot 不出现
- 选定后进入工作区，后端 needsSelection 转 false 且落在 hanzewei
- 重新访问不再询问，直达工作区
- 设置页「账户与用量」出现「本机工作区」卡，当前项标「当前使用」，其余可「切换」

全程未占用 9696（维护者真实桌面后端）。
