### PR TITLE
feat: 插件广场付费项支持（商业化改造 PR-D）

### DIFF
--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -64,11 +64,22 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
   FeatureCatalog 常量）在同一个 entitlements 列表里但语义不同。只用
   `MarketPurchaseGate.skillFeature/pluginFeature` 构造，**绝不拿条目 id 直接当 feature 查**。
 - **降级三条**（都有单测钉住）：
-  1. registry 缺 `priceCents` → 归一为 0 = 免费（官网旧格式/旧 registry 上不能把免费项锁住）；
-  2. 安装前查元数据拿价格失败（列表不可达）→ 按免费继续，真付费项由官网 402 兜底；
-  3. 免费项**不带** Authorization、不多一次判定——免费流程一字不变是硬要求。
+  1. registry 的 `priceCents` 缺失 / 负数 / 超上限（¥100,000，`MarketPurchaseGate.normalizePrice`）
+     → 一律归一为 0 = 免费。旧 registry 上不能把免费项锁住；畸形值也不能展示成假价格，
+     真付费项由官网 402 兜底，不会因此白拿。前端 `marketPricing.priceCentsOf` 同口径再兜一次；
+  2. 安装前查元数据拿价格失败（列表不可达）→ 按免费继续（网络抖动不该连免费项都装不上），
+     但**本机有账户 Key 就照样附上 Bearer**（`bearerForUnknownPrice`）：这一步分不清「真免费」
+     与「付费但价格没查到」，不带 Key 的话后者官网必 402，一个真已购的用户会被反过来指控没付费；
+     免费项的 bundle/file 端点不看 Authorization，附上无副作用；
+  3. 免费项**不带** Authorization、不查账户——bundle/file 请求逐字节与改造前一致。
+     注意这不等于「不多一次往返」：`install()` 会先拉一次 registry 列表拿价格，**免费项也走这一步**。
 - **价格必须服务端自查**：`install()` 先拉一次 registry 列表定价，不信前端传来的 priceCents，
-  否则等于让客户端决定付费闸门何时生效。
+  否则等于让客户端决定付费闸门何时生效。这也是免费项唯一多出来的一次往返，别为了省它按前端值分流。
+- **错误文案红线**：付费闸门抛的中文里**不能出现「登录」「未授权」「请先」**——
+  `frontend/src/services/api.js` 对 `code:1` 的消息做子串匹配来识别掉线，命中就清本地会话，
+  浏览器端还会跳登录页。这是业务错误不是掉线。两个测试文件里的 `assertNotMistakenForLogout` 钉住了这条。
+- **402 ≠ 用户没买过**：本机未连账户时官网无从查购买记录，`paymentRequired` 在这种情况下
+  说的是「去连接账户」而不是「去购买」。
 - **前端**：`frontend/src/utils/marketPricing.js` 是价格展示与状态判定的唯一出口
   （`priceLabel` / `paidState` / `canInstall` / `purchaseUrl`），MarketSidebarPanel、MarketDetailPane、
   MarketPane 三处共用。四态：免费 / 已购（直接装）/ 未购已连账户（「购买」外链）/ 未连账户（「需连接账户」跳设置）。
@@ -77,6 +88,13 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
   购买链接一律用 `purchaseUrl(kind, id)`，且走 `openExternalUrl`（系统浏览器）——
   支付要用用户已登录的浏览器会话，内嵌 tab 里付不了。
 - 广场列表响应额外带 `accountConnected`，省得前端为一个布尔再打一次 `/api/account/status`。
+  代价是 `GET /market/list`（Skill 与插件两个）**要求登录**：`purchased` / `accountConnected`
+  是账户隐私，团队服务器部署下不能匿名可读（与 EntitlementController 同口径）。
+- **账户状态变了要广播**：设置页连接/断开账户后 `admin.vue` 发
+  `awd:market-changed` + `awd:market-changed-from-sidebar` 两个事件（两个订阅方：左栏
+  MarketSidebarPanel / 中栏 MarketDetailPane，整页 MarketPane 也订了前者）。
+  不发的话——设置页是 `navigateTo` 打开的、广场那页并不销毁——用户从「需连接账户」点进设置、
+  连完账户返回，广场还是旧数据，再点又回设置页，转不出去。
 
 ## 安装/卸载链路
 

--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -48,9 +48,35 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
 
 ## 官网 registry 契约
 
-- **列表**：`GET {registryUrl}` → skill 元数据 JSON 数组，字段对应 MarketSkillView：id/name/description/icon/version/author/authorDisplayName/triggers[]/allowedTools[]/downloads/updatedAt/homepage（`installed` 由本地判定）。
+- **列表**：`GET {registryUrl}` → skill 元数据 JSON 数组，字段对应 MarketSkillView：id/name/description/icon/version/author/authorDisplayName/triggers[]/allowedTools[]/downloads/updatedAt/homepage/**priceCents/pricingModel**（`installed`、`purchased` 由本地判定）。
 - **下载**：`GET {registryUrl}/{id}/bundle` → `{id, version, files:{"skill.yml":"…","prompt.md":"…"}}`；只认白名单键 skill.yml/prompt.md（BUNDLE_FILES），值必须字符串，缺任一安装失败。
-- HTTP：hutool，连接 5s/读 10s 超时；非 200 抛 IllegalStateException；`httpGet` 是可覆写测试 seam。
+- HTTP：hutool，连接 5s/读 10s 超时；`httpGet(url, bearer)` 是可覆写测试 seam，返回 `RegistryReply(status, bytes)`（状态码交调用方判，402 不在 seam 里抛）；无鉴权的 `httpGet(url)` 是它的薄包装。
+
+## 付费项（PR-D，2026-08）
+
+- **契约**：registry 列表含 `priceCents`（分，0=免费）与 `pricingModel`（当前只有 `once`）；付费项的
+  `bundle` / `file` 端点要求 `Authorization: Bearer awdk_` 且已购，否则 402
+  `{code:"payment_required", priceCents, itemName}`。已购清单来自官网 `GET /api/account/entitlements`。
+- **单一判定出口**：`backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java`。
+  Skill 与插件两条链路共用它做「免费判定 / 未连接账户拦截 / 402 翻译 / 分转元」四件事，
+  不要在各自 service 里再写一套文案。
+- **feature 命名空间**：`skill:<id>` / `plugin:<id>`，与本地 SKU 键（`clipboard.unlimited` 等
+  FeatureCatalog 常量）在同一个 entitlements 列表里但语义不同。只用
+  `MarketPurchaseGate.skillFeature/pluginFeature` 构造，**绝不拿条目 id 直接当 feature 查**。
+- **降级三条**（都有单测钉住）：
+  1. registry 缺 `priceCents` → 归一为 0 = 免费（官网旧格式/旧 registry 上不能把免费项锁住）；
+  2. 安装前查元数据拿价格失败（列表不可达）→ 按免费继续，真付费项由官网 402 兜底；
+  3. 免费项**不带** Authorization、不多一次判定——免费流程一字不变是硬要求。
+- **价格必须服务端自查**：`install()` 先拉一次 registry 列表定价，不信前端传来的 priceCents，
+  否则等于让客户端决定付费闸门何时生效。
+- **前端**：`frontend/src/utils/marketPricing.js` 是价格展示与状态判定的唯一出口
+  （`priceLabel` / `paidState` / `canInstall` / `purchaseUrl`），MarketSidebarPanel、MarketDetailPane、
+  MarketPane 三处共用。四态：免费 / 已购（直接装）/ 未购已连账户（「购买」外链）/ 未连账户（「需连接账户」跳设置）。
+- **购买外链地雷**：官网**没有** `/zh/plugins/{id}` 路由（只有 `/zh/plugins` 列表页带购买按钮），
+  registry 里插件 `homepage` 默认值指向的路径并不存在，拿它当购买入口会 404。
+  购买链接一律用 `purchaseUrl(kind, id)`，且走 `openExternalUrl`（系统浏览器）——
+  支付要用用户已登录的浏览器会话，内嵌 tab 里付不了。
+- 广场列表响应额外带 `accountConnected`，省得前端为一个布尔再打一次 `/api/account/status`。
 
 ## 安装/卸载链路
 

--- a/backend/src/main/java/com/checkba/controller/ai/PluginController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginController.java
@@ -92,9 +92,18 @@ public class PluginController {
         return ResponseEntity.ok(result);
     }
 
-    /** 在线广场列表；注册表不可达返回 {code:1, message}，不影响本地插件区块 */
+    /**
+     * 在线广场列表；注册表不可达返回 {code:1, message}，不影响本地插件区块。
+     *
+     * 要求登录：响应里带 purchased / accountConnected，属账户隐私，团队服务器部署下不能匿名可读
+     * （与 EntitlementController 同口径）。
+     */
     @GetMapping("/market/list")
-    public ResponseEntity<Map<String, Object>> listMarket() {
+    public ResponseEntity<Map<String, Object>> listMarket(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (AuthController.getUserIdFromSession(sessionId) == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("未登录"));
+        }
         try {
             Map<String, Object> result = ok();
             result.put("plugins", pluginMarketService.listMarket());

--- a/backend/src/main/java/com/checkba/controller/ai/PluginController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginController.java
@@ -98,6 +98,8 @@ public class PluginController {
         try {
             Map<String, Object> result = ok();
             result.put("plugins", pluginMarketService.listMarket());
+            // 付费项按钮形态取决于账户是否已连接（未连接显示「需连接账户」），随列表一起给
+            result.put("accountConnected", pluginMarketService.accountConnected());
             return ResponseEntity.ok(result);
         } catch (Exception e) {
             return ResponseEntity.ok(error(e.getMessage()));

--- a/backend/src/main/java/com/checkba/controller/ai/SkillController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/SkillController.java
@@ -108,9 +108,18 @@ public class SkillController {
         return ResponseEntity.ok(result);
     }
 
-    /** 在线广场列表；注册表不可达返回 {code:1, message}，不影响本地区块 */
+    /**
+     * 在线广场列表；注册表不可达返回 {code:1, message}，不影响本地区块。
+     *
+     * 要求登录：响应里带 purchased / accountConnected，属账户隐私，团队服务器部署下不能匿名可读
+     * （与 EntitlementController 同口径——同一份「买了什么」不能一边设防一边敞开）。
+     */
     @GetMapping("/market/list")
-    public ResponseEntity<Map<String, Object>> listMarket() {
+    public ResponseEntity<Map<String, Object>> listMarket(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (AuthController.getUserIdFromSession(sessionId) == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error("未登录"));
+        }
         try {
             Map<String, Object> result = ok();
             result.put("skills", skillMarketService.listMarket());

--- a/backend/src/main/java/com/checkba/controller/ai/SkillController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/SkillController.java
@@ -114,6 +114,9 @@ public class SkillController {
         try {
             Map<String, Object> result = ok();
             result.put("skills", skillMarketService.listMarket());
+            // 付费项按钮形态取决于账户是否已连接（未连接显示「需连接账户」），随列表一起给，
+            // 省得前端为一个布尔再打一次 /api/account/status
+            result.put("accountConnected", skillMarketService.accountConnected());
             return ResponseEntity.ok(result);
         } catch (Exception e) {
             return ResponseEntity.ok(error(e.getMessage()));

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -119,6 +119,19 @@ public class AccountService {
         return state.key != null && !state.key.isBlank();
     }
 
+    /**
+     * 已连接则返回账户 Key 明文，否则 null。
+     *
+     * 仅供**需要自行向官网发带鉴权请求**的服务使用（当前只有 PR-D 的广场付费项下载：
+     * registry bundle/file 端点要求 {@code Authorization: Bearer awdk_}）。
+     * 其余场景一律走本类的 fetchXxx 方法，不要把 Key 拿出去到处传；
+     * 尤其**不得**回给前端——{@link #status()} 只暴露掩码。
+     */
+    public synchronized String currentKeyOrNull() {
+        State state = loadState();
+        return state.key == null || state.key.isBlank() ? null : state.key;
+    }
+
     // ==================== 官网数据拉取 ====================
 
     /** GET /api/account/me —— 余额与账户档案（余额单位是整数分）。 */

--- a/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
@@ -5,6 +5,8 @@ import cn.hutool.http.HttpRequest;
 import cn.hutool.http.HttpResponse;
 import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
+import com.checkba.service.market.MarketPurchaseGate;
+import com.checkba.service.market.RegistryReply;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,12 @@ import java.util.regex.Pattern;
  *
  * 安装后插件默认处于禁用状态，需用户在广场手动启用。配合
  * PluginService「禁用即不加载 JAR」，这意味着用户确认之前插件代码一行都不会执行。
+ *
+ * <h3>付费项（PR-D）</h3>
+ * bundle 与 file 两个端点对 {@code priceCents > 0} 的插件都要求 {@code Authorization: Bearer awdk_}
+ * 且已购，否则 402。判定与文案统一在 {@link MarketPurchaseGate}；
+ * <b>付费与否不改变验签链路</b>——签名、逐文件 SHA-256 比对一步不少。
+ * 免费项（含官网旧格式缺 priceCents 字段）链路一字不变。
  */
 @Service
 @Slf4j
@@ -50,16 +58,19 @@ public class PluginMarketService {
     private final String publicKeyPem;
     private final String pluginsDir;
     private final PluginService pluginService;
+    private final MarketPurchaseGate purchaseGate;
 
     public PluginMarketService(
             @Value("${ai.plugins.registry-url:https://www.aiworkdeck.com/api/registry/plugins}") String registryUrl,
             @Value("${ai.plugins.registry-public-key:}") String publicKeyPem,
             @Value("${ai.plugins.dir:plugins}") String pluginsDir,
-            PluginService pluginService) {
+            PluginService pluginService,
+            MarketPurchaseGate purchaseGate) {
         this.registryUrl = registryUrl;
         this.publicKeyPem = publicKeyPem;
         this.pluginsDir = pluginsDir;
         this.pluginService = pluginService;
+        this.purchaseGate = purchaseGate;
     }
 
     /** 广场条目：注册表元数据 + 本地是否已安装 */
@@ -78,13 +89,22 @@ public class PluginMarketService {
         private Integer downloads;
         private String publishedAt;
         private String homepage;
+        /**
+         * 售价（分），0 = 免费。**官网旧格式没有这个字段 → 反序列化得 null → 归一为 0（免费）**，
+         * 绝不能因为字段缺失把免费项锁住。
+         */
+        private Integer priceCents;
+        /** 计价方式，当前只有 "once"（一次性买断）；缺失同样按 once 处理 */
+        private String pricingModel;
         private boolean installed;
         /** 已安装且本地版本低于注册表版本 */
         private boolean updatable;
+        /** 付费项且账户权益里有 plugin:{id}（免费项恒 false，前端按 priceCents 判免费） */
+        private boolean purchased;
     }
 
     /**
-     * 拉取在线插件列表并标注安装状态。
+     * 拉取在线插件列表并标注安装 / 已购状态。
      * @throws IllegalStateException 注册表不可达或返回无法解析（调用方转 {code:1}，不阻断本地功能）
      */
     public List<MarketPluginView> listMarket() {
@@ -96,6 +116,12 @@ public class PluginMarketService {
             throw new IllegalStateException("注册表返回内容无法解析: " + e.getMessage());
         }
         for (MarketPluginView view : list) {
+            view.setPriceCents(normalizePrice(view.getPriceCents()));
+            if (view.getPricingModel() == null || view.getPricingModel().isBlank()) {
+                view.setPricingModel("once");
+            }
+            view.setPurchased(view.getPriceCents() > 0 && view.getId() != null
+                    && purchaseGate.purchased(MarketPurchaseGate.pluginFeature(view.getId())));
             pluginService.getPlugins().stream()
                     .filter(p -> p.getId() != null && p.getId().equals(view.getId()))
                     .findFirst()
@@ -107,6 +133,16 @@ public class PluginMarketService {
         return list;
     }
 
+    /** 广场列表响应带回的账户连接状态：未连接时前端把付费项显示为「需连接账户」。 */
+    public boolean accountConnected() {
+        return purchaseGate.accountConnected();
+    }
+
+    /** 旧格式缺字段、负数、非法值一律按免费。 */
+    private static int normalizePrice(Integer raw) {
+        return raw == null || raw < 0 ? 0 : raw;
+    }
+
     /**
      * 安装（或更新）一个在线插件。
      *
@@ -115,7 +151,7 @@ public class PluginMarketService {
      *
      * @return 安装的插件 id
      * @throws IllegalArgumentException id 非法
-     * @throws IllegalStateException 未配置公钥 / 注册表不可达 / 验签失败 / 哈希不匹配 / 落盘失败
+     * @throws IllegalStateException 未配置公钥 / 注册表不可达 / 付费项未连接账户或未购买 / 验签失败 / 哈希不匹配 / 落盘失败
      */
     public synchronized String install(String id) {
         requireValidId(id);
@@ -123,9 +159,15 @@ public class PluginMarketService {
             throw new IllegalStateException("未配置插件注册表公钥（ai.plugins.registry-public-key），拒绝安装");
         }
 
+        MarketPluginView listing = findRegistryEntry(id);
+        int priceCents = listing == null ? 0 : normalizePrice(listing.getPriceCents());
+        String itemName = listing == null || listing.getName() == null ? id : listing.getName();
+        // 免费项 bearer 为 null：不带鉴权头，与改造前逐字节一致
+        String bearer = purchaseGate.bearerFor(priceCents, itemName);
+
         JSONObject bundle;
         try {
-            bundle = JSONUtil.parseObj(httpGet(registryUrl + "/" + id + "/bundle"));
+            bundle = JSONUtil.parseObj(readText(registryUrl + "/" + id + "/bundle", bearer, itemName, priceCents));
         } catch (IllegalStateException e) {
             throw e;
         } catch (Exception e) {
@@ -163,7 +205,8 @@ public class PluginMarketService {
                 if (!isSafeRelPath(relPath)) {
                     throw new IllegalStateException("清单包含非法路径: " + relPath);
                 }
-                byte[] data = httpGetBytes(registryUrl + "/" + id + "/file?path=" + urlEncode(relPath));
+                byte[] data = readBinary(registryUrl + "/" + id + "/file?path=" + urlEncode(relPath),
+                        bearer, itemName, priceCents);
                 String actual = sha256Hex(data);
                 if (!actual.equalsIgnoreCase(entry.getValue())) {
                     throw new IllegalStateException("文件校验失败: " + relPath + "（内容与签名清单不符）");
@@ -333,32 +376,48 @@ public class PluginMarketService {
         return java.net.URLEncoder.encode(s, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20");
     }
 
-    /** HTTP GET 文本（单测覆写此 seam 打桩） */
-    protected String httpGet(String url) {
-        HttpResponse resp;
+    /**
+     * 安装前查一次注册表元数据拿价格。
+     *
+     * 价格必须由服务端自己确认——前端传来的 priceCents 只是显示值，拿它决定「要不要带 Bearer」
+     * 就等于让客户端决定付费闸门什么时候生效。
+     *
+     * 列表不可达 / 条目已下架时返回 null，按免费继续尝试：真付费项官网仍会 402 兜底，
+     * 而在这里直接失败会把一次网络抖动变成免费项也装不上。
+     */
+    private MarketPluginView findRegistryEntry(String id) {
         try {
-            resp = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(15000).execute();
+            return listMarket().stream()
+                    .filter(v -> id.equals(v.getId()))
+                    .findFirst().orElse(null);
         } catch (Exception e) {
-            throw new IllegalStateException("注册表不可达: " + e.getMessage());
+            log.debug("安装前拉取注册表元数据失败，按免费项继续: {}", e.getMessage());
+            return null;
         }
-        if (resp.getStatus() != 200) {
-            throw new IllegalStateException("注册表请求失败 (HTTP " + resp.getStatus() + ")");
-        }
-        return resp.body();
     }
 
-    /** HTTP GET 二进制（单测覆写此 seam 打桩） */
-    protected byte[] httpGetBytes(String url) {
-        HttpResponse resp;
-        try {
-            resp = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(60000).execute();
-        } catch (Exception e) {
-            throw new IllegalStateException("下载失败: " + e.getMessage());
+    /** 带付费闸门的文本读取：402 翻成明确中文，其余非 200 沿用原有措辞。 */
+    private String readText(String url, String bearer, String itemName, int priceCents) {
+        RegistryReply reply = httpGet(url, bearer);
+        if (reply.status() == 402) {
+            throw purchaseGate.paymentRequired(reply.body(), itemName, priceCents);
         }
-        if (resp.getStatus() != 200) {
-            throw new IllegalStateException("下载失败 (HTTP " + resp.getStatus() + ")");
+        if (reply.status() != 200) {
+            throw new IllegalStateException("注册表请求失败 (HTTP " + reply.status() + ")");
         }
-        byte[] data = resp.bodyBytes();
+        return reply.body();
+    }
+
+    /** 带付费闸门的二进制读取（含 50 MB 上限，防恶意注册表打爆内存）。 */
+    private byte[] readBinary(String url, String bearer, String itemName, int priceCents) {
+        RegistryReply reply = httpGetBytes(url, bearer);
+        if (reply.status() == 402) {
+            throw purchaseGate.paymentRequired(reply.body(), itemName, priceCents);
+        }
+        if (reply.status() != 200) {
+            throw new IllegalStateException("下载失败 (HTTP " + reply.status() + ")");
+        }
+        byte[] data = reply.data();
         if (data == null) {
             throw new IllegalStateException("下载内容为空");
         }
@@ -366,5 +425,50 @@ public class PluginMarketService {
             throw new IllegalStateException("文件超过 50 MB 上限");
         }
         return data;
+    }
+
+    /** 无鉴权 HTTP GET 文本；非 200 直接抛（listMarket / fetchRevoked 用） */
+    protected String httpGet(String url) {
+        RegistryReply reply = httpGet(url, null);
+        if (reply.status() != 200) {
+            throw new IllegalStateException("注册表请求失败 (HTTP " + reply.status() + ")");
+        }
+        return reply.body();
+    }
+
+    /**
+     * HTTP GET 文本 seam（单测覆写此方法打桩）。
+     * @param bearer 非空时带 {@code Authorization: Bearer}；付费项 bundle 端点需要
+     */
+    protected RegistryReply httpGet(String url, String bearer) {
+        HttpResponse resp;
+        try {
+            HttpRequest req = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(15000);
+            if (bearer != null && !bearer.isBlank()) {
+                req.header("Authorization", "Bearer " + bearer);
+            }
+            resp = req.execute();
+        } catch (Exception e) {
+            throw new IllegalStateException("注册表不可达: " + e.getMessage());
+        }
+        return new RegistryReply(resp.getStatus(), resp.bodyBytes());
+    }
+
+    /**
+     * HTTP GET 二进制 seam（单测覆写此方法打桩）。
+     * @param bearer 非空时带 {@code Authorization: Bearer}；付费项 file 端点需要
+     */
+    protected RegistryReply httpGetBytes(String url, String bearer) {
+        HttpResponse resp;
+        try {
+            HttpRequest req = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(60000);
+            if (bearer != null && !bearer.isBlank()) {
+                req.header("Authorization", "Bearer " + bearer);
+            }
+            resp = req.execute();
+        } catch (Exception e) {
+            throw new IllegalStateException("下载失败: " + e.getMessage());
+        }
+        return new RegistryReply(resp.getStatus(), resp.bodyBytes());
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
@@ -43,7 +43,8 @@ import java.util.regex.Pattern;
  * bundle 与 file 两个端点对 {@code priceCents > 0} 的插件都要求 {@code Authorization: Bearer awdk_}
  * 且已购，否则 402。判定与文案统一在 {@link MarketPurchaseGate}；
  * <b>付费与否不改变验签链路</b>——签名、逐文件 SHA-256 比对一步不少。
- * 免费项（含官网旧格式缺 priceCents 字段）链路一字不变。
+ * 免费项（含官网旧格式缺 priceCents 字段）不查账户、不带鉴权头，下载请求逐字节与改造前一致；
+ * 唯一的增量是 {@link #install} 会先查一次注册表列表拿价格（价格必须服务端自证），免费项也走这一步。
  */
 @Service
 @Slf4j
@@ -116,7 +117,7 @@ public class PluginMarketService {
             throw new IllegalStateException("注册表返回内容无法解析: " + e.getMessage());
         }
         for (MarketPluginView view : list) {
-            view.setPriceCents(normalizePrice(view.getPriceCents()));
+            view.setPriceCents(MarketPurchaseGate.normalizePrice(view.getPriceCents()));
             if (view.getPricingModel() == null || view.getPricingModel().isBlank()) {
                 view.setPricingModel("once");
             }
@@ -138,11 +139,6 @@ public class PluginMarketService {
         return purchaseGate.accountConnected();
     }
 
-    /** 旧格式缺字段、负数、非法值一律按免费。 */
-    private static int normalizePrice(Integer raw) {
-        return raw == null || raw < 0 ? 0 : raw;
-    }
-
     /**
      * 安装（或更新）一个在线插件。
      *
@@ -160,10 +156,13 @@ public class PluginMarketService {
         }
 
         MarketPluginView listing = findRegistryEntry(id);
-        int priceCents = listing == null ? 0 : normalizePrice(listing.getPriceCents());
+        int priceCents = listing == null ? 0 : MarketPurchaseGate.normalizePrice(listing.getPriceCents());
         String itemName = listing == null || listing.getName() == null ? id : listing.getName();
-        // 免费项 bearer 为 null：不带鉴权头，与改造前逐字节一致
-        String bearer = purchaseGate.bearerFor(priceCents, itemName);
+        // 免费项 bearer 为 null：不带鉴权头，与改造前逐字节一致。
+        // listing == null 是「价格没查到」而不是「免费」：本机有 Key 就带上，见 bearerForUnknownPrice
+        String bearer = listing == null
+                ? purchaseGate.bearerForUnknownPrice()
+                : purchaseGate.bearerFor(priceCents, itemName);
 
         JSONObject bundle;
         try {

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java
@@ -30,7 +30,9 @@ import java.util.regex.Pattern;
  * <h3>付费项（PR-D）</h3>
  * 列表多出 {@code priceCents}（分，0=免费）/{@code pricingModel}，安装时 bundle 端点对付费项要求
  * {@code Authorization: Bearer awdk_} 且已购，否则 402。判定与文案统一在 {@link MarketPurchaseGate}。
- * <b>免费项（含官网旧格式缺 priceCents 字段）的链路一字不变</b>：不查账户、不带鉴权头、不多一次往返。
+ * <b>免费项（含官网旧格式缺 priceCents 字段）不查账户、不带鉴权头</b>，bundle 请求逐字节与改造前一致。
+ * 唯一的增量是 {@link #install} 会先查一次注册表列表拿价格（价格必须服务端自证，见 {@link #findRegistryEntry}），
+ * 免费项也走这一步——不能靠「是不是免费」来决定要不要查，那等于让客户端说了算。
  */
 @Service
 @Slf4j
@@ -96,7 +98,7 @@ public class SkillMarketService {
             throw new IllegalStateException("注册表返回内容无法解析: " + e.getMessage());
         }
         for (MarketSkillView view : list) {
-            view.setPriceCents(normalizePrice(view.getPriceCents()));
+            view.setPriceCents(MarketPurchaseGate.normalizePrice(view.getPriceCents()));
             if (view.getPricingModel() == null || view.getPricingModel().isBlank()) {
                 view.setPricingModel("once");
             }
@@ -112,11 +114,6 @@ public class SkillMarketService {
         return purchaseGate.accountConnected();
     }
 
-    /** 旧格式缺字段、负数、非法值一律按免费。 */
-    private static int normalizePrice(Integer raw) {
-        return raw == null || raw < 0 ? 0 : raw;
-    }
-
     /**
      * 安装（或重装 = 更新）一个在线 skill：下载 bundle 写入 {ai.skills.dir}/{id}/ 并 rescan。
      * @return 安装的 skill id
@@ -126,10 +123,13 @@ public class SkillMarketService {
     public synchronized String install(String id) {
         requireValidId(id);
         MarketSkillView entry = findRegistryEntry(id);
-        int priceCents = entry == null ? 0 : normalizePrice(entry.getPriceCents());
+        int priceCents = entry == null ? 0 : MarketPurchaseGate.normalizePrice(entry.getPriceCents());
         String itemName = entry == null || entry.getName() == null ? id : entry.getName();
-        // 免费项 bearer 为 null：不带鉴权头，与改造前逐字节一致
-        String bearer = purchaseGate.bearerFor(priceCents, itemName);
+        // 免费项 bearer 为 null：不带鉴权头，与改造前逐字节一致。
+        // entry == null 是「价格没查到」而不是「免费」：本机有 Key 就带上，见 bearerForUnknownPrice
+        String bearer = entry == null
+                ? purchaseGate.bearerForUnknownPrice()
+                : purchaseGate.bearerFor(priceCents, itemName);
 
         RegistryReply reply = httpGet(properties.getRegistryUrl() + "/" + id + "/bundle", bearer);
         if (reply.status() == 402) {

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillMarketService.java
@@ -5,6 +5,8 @@ import cn.hutool.http.HttpRequest;
 import cn.hutool.http.HttpResponse;
 import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
+import com.checkba.service.market.MarketPurchaseGate;
+import com.checkba.service.market.RegistryReply;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +26,11 @@ import java.util.regex.Pattern;
  *
  * 安装 = 把 bundle 中的两个已知文件写入 {ai.skills.dir}/{id}/ 后 rescan（重装即更新）；
  * 注册表不可达只影响广场功能本身，不影响本地 skill / 插件体系。
+ *
+ * <h3>付费项（PR-D）</h3>
+ * 列表多出 {@code priceCents}（分，0=免费）/{@code pricingModel}，安装时 bundle 端点对付费项要求
+ * {@code Authorization: Bearer awdk_} 且已购，否则 402。判定与文案统一在 {@link MarketPurchaseGate}。
+ * <b>免费项（含官网旧格式缺 priceCents 字段）的链路一字不变</b>：不查账户、不带鉴权头、不多一次往返。
  */
 @Service
 @Slf4j
@@ -37,10 +44,13 @@ public class SkillMarketService {
 
     private final SkillProperties properties;
     private final SkillRegistry skillRegistry;
+    private final MarketPurchaseGate purchaseGate;
 
-    public SkillMarketService(SkillProperties properties, SkillRegistry skillRegistry) {
+    public SkillMarketService(SkillProperties properties, SkillRegistry skillRegistry,
+                              MarketPurchaseGate purchaseGate) {
         this.properties = properties;
         this.skillRegistry = skillRegistry;
+        this.purchaseGate = purchaseGate;
     }
 
     /** 广场 skill 视图：注册表元数据 + 本地是否已安装 */
@@ -60,12 +70,21 @@ public class SkillMarketService {
         private Integer downloads;
         private String updatedAt;
         private String homepage;
+        /**
+         * 售价（分），0 = 免费。**官网旧格式没有这个字段 → 反序列化得 null → 归一为 0（免费）**，
+         * 绝不能因为字段缺失把免费项锁住。
+         */
+        private Integer priceCents;
+        /** 计价方式，当前只有 "once"（一次性买断）；缺失同样按 once 处理 */
+        private String pricingModel;
         /** 本地 SkillRegistry 中已存在同 id skill */
         private boolean installed;
+        /** 付费项且账户权益里有 skill:{id}（免费项恒 false，前端按 priceCents 判免费） */
+        private boolean purchased;
     }
 
     /**
-     * 拉取在线广场列表并标注安装状态。
+     * 拉取在线广场列表并标注安装 / 已购状态。
      * @throws IllegalStateException 注册表不可达或返回内容无法解析（调用方转 {code:1}，不阻断本地功能）
      */
     public List<MarketSkillView> listMarket() {
@@ -77,20 +96,49 @@ public class SkillMarketService {
             throw new IllegalStateException("注册表返回内容无法解析: " + e.getMessage());
         }
         for (MarketSkillView view : list) {
+            view.setPriceCents(normalizePrice(view.getPriceCents()));
+            if (view.getPricingModel() == null || view.getPricingModel().isBlank()) {
+                view.setPricingModel("once");
+            }
             view.setInstalled(view.getId() != null && skillRegistry.getSkill(view.getId()).isPresent());
+            view.setPurchased(view.getPriceCents() > 0 && view.getId() != null
+                    && purchaseGate.purchased(MarketPurchaseGate.skillFeature(view.getId())));
         }
         return list;
+    }
+
+    /** 广场列表响应带回的账户连接状态：未连接时前端把付费项显示为「需连接账户」。 */
+    public boolean accountConnected() {
+        return purchaseGate.accountConnected();
+    }
+
+    /** 旧格式缺字段、负数、非法值一律按免费。 */
+    private static int normalizePrice(Integer raw) {
+        return raw == null || raw < 0 ? 0 : raw;
     }
 
     /**
      * 安装（或重装 = 更新）一个在线 skill：下载 bundle 写入 {ai.skills.dir}/{id}/ 并 rescan。
      * @return 安装的 skill id
      * @throws IllegalArgumentException id 非法
-     * @throws IllegalStateException 注册表不可达 / bundle 缺必需文件 / 写盘失败
+     * @throws IllegalStateException 注册表不可达 / 付费项未连接账户或未购买 / bundle 缺必需文件 / 写盘失败
      */
     public synchronized String install(String id) {
         requireValidId(id);
-        String body = httpGet(properties.getRegistryUrl() + "/" + id + "/bundle");
+        MarketSkillView entry = findRegistryEntry(id);
+        int priceCents = entry == null ? 0 : normalizePrice(entry.getPriceCents());
+        String itemName = entry == null || entry.getName() == null ? id : entry.getName();
+        // 免费项 bearer 为 null：不带鉴权头，与改造前逐字节一致
+        String bearer = purchaseGate.bearerFor(priceCents, itemName);
+
+        RegistryReply reply = httpGet(properties.getRegistryUrl() + "/" + id + "/bundle", bearer);
+        if (reply.status() == 402) {
+            throw purchaseGate.paymentRequired(reply.body(), itemName, priceCents);
+        }
+        if (reply.status() != 200) {
+            throw new IllegalStateException("注册表请求失败 (HTTP " + reply.status() + ")");
+        }
+        String body = reply.body();
         JSONObject files;
         try {
             files = JSONUtil.parseObj(body).getJSONObject("files");
@@ -151,20 +199,54 @@ public class SkillMarketService {
         }
     }
 
-    /** HTTP GET（单测覆写此 seam 打桩）；非 200 或网络异常抛 IllegalStateException */
+    /**
+     * 安装前查一次注册表元数据拿价格。
+     *
+     * 价格必须由服务端自己确认——前端传来的 priceCents 只是显示值，拿它决定「要不要带 Bearer」
+     * 就等于让客户端决定付费闸门什么时候生效。
+     *
+     * 列表不可达 / 条目已下架时返回 null，按免费继续尝试：真付费项官网仍会 402 兜底，
+     * 而在这里直接失败会把一次网络抖动变成免费项也装不上。
+     */
+    private MarketSkillView findRegistryEntry(String id) {
+        try {
+            return listMarket().stream()
+                    .filter(v -> id.equals(v.getId()))
+                    .findFirst().orElse(null);
+        } catch (Exception e) {
+            log.debug("安装前拉取注册表元数据失败，按免费项继续: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /** 无鉴权 HTTP GET；非 200 或网络异常抛 IllegalStateException */
     protected String httpGet(String url) {
+        RegistryReply reply = httpGet(url, null);
+        if (reply.status() != 200) {
+            throw new IllegalStateException("注册表请求失败 (HTTP " + reply.status() + ")");
+        }
+        return reply.body();
+    }
+
+    /**
+     * HTTP GET seam（单测覆写此方法打桩，无鉴权的 {@link #httpGet(String)} 也走这里）。
+     *
+     * @param bearer 非空时带 {@code Authorization: Bearer}；付费项 bundle 端点需要
+     * @throws IllegalStateException 网络不可达（状态码交由调用方判断，402 不在这里抛）
+     */
+    protected RegistryReply httpGet(String url, String bearer) {
         HttpResponse resp;
         try {
-            resp = HttpRequest.get(url)
+            HttpRequest req = HttpRequest.get(url)
                     .setConnectionTimeout(5000)
-                    .setReadTimeout(10000)
-                    .execute();
+                    .setReadTimeout(10000);
+            if (bearer != null && !bearer.isBlank()) {
+                req.header("Authorization", "Bearer " + bearer);
+            }
+            resp = req.execute();
         } catch (Exception e) {
             throw new IllegalStateException("注册表不可达: " + e.getMessage());
         }
-        if (resp.getStatus() != 200) {
-            throw new IllegalStateException("注册表请求失败 (HTTP " + resp.getStatus() + ")");
-        }
-        return resp.body();
+        return new RegistryReply(resp.getStatus(), resp.bodyBytes());
     }
 }

--- a/backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java
+++ b/backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java
@@ -1,0 +1,104 @@
+package com.checkba.service.market;
+
+import cn.hutool.json.JSONUtil;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.entitlement.EntitlementService;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * 广场付费项的共用闸门（商业化改造 PR-D）。Skill 广场与插件广场两条安装链路逐字共用这一份判定，
+ * 避免两边的中文提示与 feature 命名各写一套。
+ *
+ * <h3>feature 命名空间</h3>
+ * 官网 {@code /api/account/entitlements} 返回的 feature 形如 {@code skill:<id>} / {@code plugin:<id>}，
+ * 与本地功能键（{@code clipboard.unlimited} 等 {@code FeatureCatalog} 常量）在同一个列表里但语义不同。
+ * 这里只用 {@link #skillFeature} / {@link #pluginFeature} 构造，**绝不**把广场条目 id 直接当 feature 查，
+ * 否则一个 id 叫 {@code clipboard.unlimited} 的 Skill 就能蹭到本地 SKU 的权益。
+ *
+ * <h3>三层判定</h3>
+ * <ol>
+ *   <li>免费项（priceCents &lt;= 0，含官网旧格式缺字段）：完全不参与本闸门，链路一字不变；</li>
+ *   <li>付费项 + 未连接账户：本地直接拒绝，不发无意义的请求（官网必 402）；</li>
+ *   <li>付费项 + 已连接：带 Bearer 发请求，官网返回 402 时由 {@link #paymentRequired} 翻成明确中文。</li>
+ * </ol>
+ * 本地权益缓存只用于 UI 标注（{@link #purchased}），**不作安装前置条件**——真正的闸门在官网侧，
+ * 缓存陈旧时按已购乐观放行、由 402 兜底，比在本地拦住一个真已购的用户更不容易出错。
+ */
+@Service
+public class MarketPurchaseGate {
+
+    private final AccountService accountService;
+    private final EntitlementService entitlementService;
+
+    public MarketPurchaseGate(AccountService accountService, EntitlementService entitlementService) {
+        this.accountService = accountService;
+        this.entitlementService = entitlementService;
+    }
+
+    public static String skillFeature(String id) {
+        return "skill:" + id;
+    }
+
+    public static String pluginFeature(String id) {
+        return "plugin:" + id;
+    }
+
+    /** 广场列表响应里带回前端：未连接时付费项显示「需连接账户」而不是「购买」。 */
+    public boolean accountConnected() {
+        return accountService.isConnected();
+    }
+
+    /** 该条目是否已购（账户权益缓存口径，仅用于列表/详情的标注）。 */
+    public boolean purchased(String feature) {
+        return entitlementService.isEnabled(feature);
+    }
+
+    /**
+     * 安装前置：返回本次请求要带的账户 Key。
+     *
+     * @param priceCents 广场元数据里的价格（分）；&lt;= 0 一律按免费处理
+     * @param itemName   用于错误文案的条目名
+     * @return 付费项返回账户 Key；**免费项返回 null**（不带鉴权头，行为与改造前一致）
+     * @throws IllegalStateException 付费项但本机尚未连接账户
+     */
+    public String bearerFor(int priceCents, String itemName) {
+        if (priceCents <= 0) {
+            return null;
+        }
+        String key = accountService.currentKeyOrNull();
+        if (key == null) {
+            throw new IllegalStateException("「" + itemName + "」是付费项目（" + yuan(priceCents)
+                    + "），请先在设置的「账户与用量」中连接 AI Workdeck 账户");
+        }
+        return key;
+    }
+
+    /**
+     * 把官网 402 {@code {code:"payment_required", priceCents, itemName}} 翻成明确的中文错误。
+     * 官网字段缺失或响应体不是 JSON 时退回调用方已知的名称与价格，不吞成通用失败。
+     */
+    public IllegalStateException paymentRequired(String responseBody, String fallbackName, int fallbackPriceCents) {
+        String name = fallbackName;
+        int cents = fallbackPriceCents;
+        try {
+            var json = JSONUtil.parseObj(responseBody);
+            String remoteName = json.getStr("itemName");
+            if (remoteName != null && !remoteName.isBlank()) name = remoteName;
+            Integer remotePrice = json.getInt("priceCents");
+            if (remotePrice != null && remotePrice > 0) cents = remotePrice;
+        } catch (Exception ignored) {
+            // 官网没按契约返回 JSON：用本地已知信息把话说清楚即可
+        }
+        String price = cents > 0 ? "（" + yuan(cents) + "）" : "";
+        return new IllegalStateException("「" + name + "」需购买后安装" + price
+                + "。请在官网完成购买，再点「我已购买，刷新」重试");
+    }
+
+    /** 分转元，两位小数。与官网 formatPriceYuan 同口径。 */
+    public static String yuan(int cents) {
+        return "¥" + BigDecimal.valueOf(cents).movePointLeft(2).setScale(2, RoundingMode.HALF_UP).toPlainString();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java
+++ b/backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java
@@ -46,6 +46,19 @@ public class MarketPurchaseGate {
         return "plugin:" + id;
     }
 
+    /** 售价上限（分）= ¥100,000。超过必是注册表畸形值（如 long 被截成 int），按未知处理而不是展示假价。 */
+    private static final int MAX_PRICE_CENTS = 100_000_00;
+
+    /**
+     * 注册表价格归一：旧格式缺字段、负数、明显畸形的值一律按免费。
+     *
+     * 「畸形按免费」不是白嫖口子——真付费项官网仍会 402 兜底；反过来「畸形按付费」会把
+     * 一个跑在旧 registry 上的免费项锁死，那才是真事故。
+     */
+    public static int normalizePrice(Integer raw) {
+        return raw == null || raw < 0 || raw > MAX_PRICE_CENTS ? 0 : raw;
+    }
+
     /** 广场列表响应里带回前端：未连接时付费项显示「需连接账户」而不是「购买」。 */
     public boolean accountConnected() {
         return accountService.isConnected();
@@ -70,15 +83,43 @@ public class MarketPurchaseGate {
         }
         String key = accountService.currentKeyOrNull();
         if (key == null) {
-            throw new IllegalStateException("「" + itemName + "」是付费项目（" + yuan(priceCents)
-                    + "），请先在设置的「账户与用量」中连接 AI Workdeck 账户");
+            throw new IllegalStateException(needAccountMessage(itemName, priceCents));
         }
         return key;
     }
 
     /**
+     * 价格未确认时（安装前那次注册表列表查询失败）本次请求要带的 Key。
+     *
+     * 这一步分不清「真免费」与「付费但价格没查到」。不带 Key 的话后者官网必 402，
+     * 一个真已购的用户会被反过来告知没付费；而免费项的 bundle/file 端点根本不看
+     * Authorization。所以本机有 Key 就一律附上：对免费项无副作用，对付费项救回一次误报。
+     *
+     * @return 已连接账户返回 Key，未连接返回 null（**不抛异常**——价格未知不该把免费项拦住）
+     */
+    public String bearerForUnknownPrice() {
+        return accountService.currentKeyOrNull();
+    }
+
+    /**
+     * 「付费项 + 本机未连账户」的统一文案。
+     *
+     * 措辞刻意避开「请先」「登录」「未授权」三个子串：前端 services/api.js 对 {@code code:1}
+     * 的消息做子串匹配来识别掉线，命中就会清本地会话、并在浏览器端跳登录页。
+     * 这是一条业务错误，不是掉线。
+     */
+    private static String needAccountMessage(String itemName, int priceCents) {
+        String price = priceCents > 0 ? "（" + yuan(priceCents) + "）" : "";
+        return "「" + itemName + "」是付费项目" + price
+                + "，需在设置的「账户与用量」中连接 AI Workdeck 账户后才能安装";
+    }
+
+    /**
      * 把官网 402 {@code {code:"payment_required", priceCents, itemName}} 翻成明确的中文错误。
      * 官网字段缺失或响应体不是 JSON 时退回调用方已知的名称与价格，不吞成通用失败。
+     *
+     * 本机未连账户时**不说「去购买」**：官网无从查这台机器的购买记录，402 只说明没带 Key，
+     * 不说明用户没买过。这条分支只有价格未知的降级路径能走到（价格已知时 {@link #bearerFor} 已本地拦下）。
      */
     public IllegalStateException paymentRequired(String responseBody, String fallbackName, int fallbackPriceCents) {
         String name = fallbackName;
@@ -91,6 +132,9 @@ public class MarketPurchaseGate {
             if (remotePrice != null && remotePrice > 0) cents = remotePrice;
         } catch (Exception ignored) {
             // 官网没按契约返回 JSON：用本地已知信息把话说清楚即可
+        }
+        if (!accountService.isConnected()) {
+            return new IllegalStateException(needAccountMessage(name, cents));
         }
         String price = cents > 0 ? "（" + yuan(cents) + "）" : "";
         return new IllegalStateException("「" + name + "」需购买后安装" + price

--- a/backend/src/main/java/com/checkba/service/market/RegistryReply.java
+++ b/backend/src/main/java/com/checkba/service/market/RegistryReply.java
@@ -1,0 +1,19 @@
+package com.checkba.service.market;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 官网注册表的一次 HTTP 响应（状态码 + 原始字节）。
+ *
+ * 为什么不直接返回 String：付费闸门要求调用方能区分 402（未购买）与其它非 200，
+ * 而 402 的响应体是 JSON、插件文件下载的响应体是二进制——两条链路共用一种载体最省事。
+ *
+ * @param status HTTP 状态码；0 表示请求根本没发出去（网络不可达）
+ * @param data   响应体原始字节，可能为 null
+ */
+public record RegistryReply(int status, byte[] data) {
+
+    public String body() {
+        return data == null ? "" : new String(data, StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/CrossLanguageSignatureTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/CrossLanguageSignatureTest.java
@@ -34,8 +34,9 @@ class CrossLanguageSignatureTest {
         for (String k : filesObj.keySet()) files.put(k, filesObj.getStr(k));
 
         String pubPem = Files.readString(f.getParent().resolve("test-pub.pem"));
+        // 验签不碰付费闸门，gate 传 null 即可（这条用例只对拍 canonical JSON）
         PluginMarketService svc = new PluginMarketService(
-                "http://x", pubPem, f.getParent().toString(), new PluginService());
+                "http://x", pubPem, f.getParent().toString(), new PluginService(), null);
 
         assertTrue(
                 svc.verifySignature(payload.getStr("id"), payload.getStr("version"),

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -378,7 +378,19 @@ class PluginMarketServiceTest {
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
         assertTrue(e.getMessage().contains("连接 AI Workdeck 账户"), e.getMessage());
         assertTrue(e.getMessage().contains("¥19.90"), "价格要写进引导文案: " + e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
         assertEquals(1, urls.size(), "只查了元数据，不该再打 bundle 端点");
+    }
+
+    /**
+     * 付费闸门的文案不能撞上前端的掉线启发式：services/api.js 对 {@code code:1} 的消息做子串匹配，
+     * 见到「登录」「未授权」「请先」就清本地会话，浏览器端还会跳登录页。这里是业务错误，不是掉线。
+     */
+    private static void assertNotMistakenForLogout(String message) {
+        for (String needle : java.util.List.of("登录", "未授权", "请先")) {
+            assertFalse(message.contains(needle),
+                    "文案含「" + needle + "」会被前端当成掉线清会话: " + message);
+        }
     }
 
     @Test
@@ -428,5 +440,71 @@ class PluginMarketServiceTest {
         };
         assertEquals("demo", svc.install("demo"));
         assertEquals(java.util.List.of("null", "null"), bearers, "已连接账户也不该给免费项带鉴权头");
+    }
+
+    @Test
+    @DisplayName("安装：价格没查到但本机已连账户时 bundle 与 file 两个端点都带 Bearer")
+    void unknownPriceStillSendsBearerWhenConnected() throws Exception {
+        byte[] manifestBytes = "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\"}".getBytes(StandardCharsets.UTF_8);
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", PluginMarketService.sha256Hex(manifestBytes));
+        String sig = sign(canonical("demo", "1.0.0", "2026-07-27T00:00:00Z", files));
+
+        java.util.List<String> bearers = new java.util.ArrayList<>();
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService,
+                gate("awdk_live", "plugin:demo")) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                // 列表端点直接失败 = 价格查不到；付费与否无从判断
+                if (url.endsWith("/plugins")) throw new IllegalStateException("注册表不可达: stub");
+                bearers.add(String.valueOf(bearer));
+                return reply(200, bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, sig));
+            }
+            @Override
+            protected RegistryReply httpGetBytes(String url, String bearer) {
+                bearers.add(String.valueOf(bearer));
+                return new RegistryReply(200, manifestBytes);
+            }
+        };
+        assertEquals("demo", svc.install("demo"));
+        assertEquals(java.util.List.of("awdk_live", "awdk_live"), bearers,
+                "价格未知时本机有 Key 就带上，免得已购用户被 402 反过来指控没付费");
+    }
+
+    @Test
+    @DisplayName("安装：价格未知 + 未连账户吃到 402 时说「去连接账户」，不说「去购买」")
+    void unknownPrice402WithoutAccountSuggestsConnecting() {
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService, gate) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                if (url.endsWith("/plugins")) throw new IllegalStateException("注册表不可达: stub");
+                return reply(402, "{\"code\":\"payment_required\",\"priceCents\":1990,\"itemName\":\"尽调助手\"}");
+            }
+        };
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
+        assertTrue(e.getMessage().contains("连接 AI Workdeck 账户"), e.getMessage());
+        assertFalse(e.getMessage().contains("需购买后安装"),
+                "本机没连账户，官网无从查购买记录：402 不等于用户没买过 —— " + e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("列表：priceCents 畸形（负数 / 超上限的截断值）按未知处理，不展示假价格")
+    void listNormalizesMalformedPrice() {
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService, gate) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                // 1215752191 = 官网写了个超 int 范围的值、反序列化被截断的实测结果（¥12,157,521.91）
+                return reply(200, """
+                        [{ "id": "neg", "name": "负价", "priceCents": -100 },
+                         { "id": "huge", "name": "溢出", "priceCents": 1215752191 }]""");
+            }
+        };
+        var list = svc.listMarket();
+        assertEquals(0, list.get(0).getPriceCents(), "负数按未知");
+        assertEquals(0, list.get(1).getPriceCents(), "超上限只可能是畸形值，不能当真价展示");
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -1,6 +1,10 @@
 package com.checkba.service.ai;
 
 import com.checkba.service.SystemSettingService;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.market.MarketPurchaseGate;
+import com.checkba.service.market.RegistryReply;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,9 +39,26 @@ class PluginMarketServiceTest {
     private String publicKeyPem;
     private final Map<String, String> settingStore = new HashMap<>();
     private PluginService pluginService;
+    /** 默认：未连接账户、无任何已购权益（免费项用例走这条，付费用例各自重建） */
+    private MarketPurchaseGate gate;
+
+    /**
+     * @param accountKey 账户 Key；null = 未连接
+     * @param ownedFeature 已购的 feature（skill:/plugin: 命名空间），null = 未购
+     */
+    private static MarketPurchaseGate gate(String accountKey, String ownedFeature) {
+        AccountService account = mock(AccountService.class);
+        when(account.currentKeyOrNull()).thenReturn(accountKey);
+        when(account.isConnected()).thenReturn(accountKey != null);
+        EntitlementService entitlements = mock(EntitlementService.class);
+        when(entitlements.isEnabled(anyString()))
+                .thenAnswer(inv -> ownedFeature != null && ownedFeature.equals(inv.getArgument(0)));
+        return new MarketPurchaseGate(account, entitlements);
+    }
 
     @BeforeEach
     void setUp() throws Exception {
+        gate = gate(null, null);
         keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
         publicKeyPem = "-----BEGIN PUBLIC KEY-----\n"
                 + Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(keyPair.getPublic().getEncoded())
@@ -69,7 +90,8 @@ class PluginMarketServiceTest {
     }
 
     private PluginMarketService service(String pubKey) {
-        return new PluginMarketService("http://registry.test/plugins", pubKey, pluginsDir.toString(), pluginService);
+        return new PluginMarketService("http://registry.test/plugins", pubKey, pluginsDir.toString(),
+                pluginService, gate);
     }
 
     @Test
@@ -182,15 +204,17 @@ class PluginMarketServiceTest {
 
         boolean[] downloaded = {false};
         PluginMarketService svc = new PluginMarketService(
-                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService) {
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService, gate) {
             @Override
-            protected String httpGet(String url) {
-                return bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, badSig);
+            protected RegistryReply httpGet(String url, String bearer) {
+                return reply(200, url.endsWith("/plugins")
+                        ? "[]"
+                        : bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, badSig));
             }
             @Override
-            protected byte[] httpGetBytes(String url) {
+            protected RegistryReply httpGetBytes(String url, String bearer) {
                 downloaded[0] = true;
-                return new byte[0];
+                return reply(200, "");
             }
         };
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
@@ -274,18 +298,135 @@ class PluginMarketServiceTest {
                 "ai.plugins.registry-public-key 为空会让所有在线插件安装被拒绝");
     }
 
-    /** 打桩 HTTP：bundle 返回给定清单，file 按路径返回对应内容 */
+    /** 打桩 HTTP：注册表列表返回空数组（= 免费项），bundle 返回给定清单，file 按路径返回对应内容 */
     private PluginMarketService stubbed(String pubKey, Map<String, String> files, String sig,
                                         byte[] manifestBytes, byte[] jarBytes) {
-        return new PluginMarketService("http://registry.test/plugins", pubKey, pluginsDir.toString(), pluginService) {
+        return new PluginMarketService("http://registry.test/plugins", pubKey, pluginsDir.toString(),
+                pluginService, gate) {
             @Override
-            protected String httpGet(String url) {
-                return bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, sig);
+            protected RegistryReply httpGet(String url, String bearer) {
+                return reply(200, url.endsWith("/plugins")
+                        ? "[]"
+                        : bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, sig));
             }
             @Override
-            protected byte[] httpGetBytes(String url) {
-                return url.contains("tool.jar") ? jarBytes : manifestBytes;
+            protected RegistryReply httpGetBytes(String url, String bearer) {
+                return new RegistryReply(200, url.contains("tool.jar") ? jarBytes : manifestBytes);
             }
         };
+    }
+
+    private static RegistryReply reply(int status, String body) {
+        return new RegistryReply(status, body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // ==================== 付费项（PR-D） ====================
+
+    /** 注册表列表：一个 ¥19.90 的付费插件 */
+    private static String paidRegistryJson() {
+        return """
+                [{ "id": "demo", "name": "尽调助手", "version": "1.0.0",
+                   "priceCents": 1990, "pricingModel": "once" }]""";
+    }
+
+    @Test
+    @DisplayName("列表：官网旧格式没有 priceCents 时按免费处理（向后兼容，不能把免费项锁住）")
+    void listTreatsMissingPriceAsFree() {
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService, gate) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                return reply(200, """
+                        [{ "id": "legacy", "name": "老插件", "version": "1.0.0" }]""");
+            }
+        };
+        PluginMarketService.MarketPluginView view = svc.listMarket().get(0);
+        assertEquals(0, view.getPriceCents(), "缺字段 = 免费");
+        assertEquals("once", view.getPricingModel(), "缺字段按一次性买断兜底");
+        assertFalse(view.isPurchased());
+    }
+
+    @Test
+    @DisplayName("列表：付费项已购时标 purchased（feature 命名空间 plugin:<id>）")
+    void listMarksPurchased() {
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService,
+                gate("awdk_live", "plugin:demo")) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                return reply(200, paidRegistryJson());
+            }
+        };
+        PluginMarketService.MarketPluginView view = svc.listMarket().get(0);
+        assertEquals(1990, view.getPriceCents());
+        assertTrue(view.isPurchased());
+        assertTrue(svc.accountConnected());
+    }
+
+    @Test
+    @DisplayName("安装：付费项未连接账户时本地拦下并给出连接引导，不发 bundle 请求")
+    void paidInstallWithoutAccountIsBlockedLocally() {
+        java.util.List<String> urls = new java.util.ArrayList<>();
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService, gate) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                urls.add(url);
+                return reply(200, paidRegistryJson());
+            }
+        };
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
+        assertTrue(e.getMessage().contains("连接 AI Workdeck 账户"), e.getMessage());
+        assertTrue(e.getMessage().contains("¥19.90"), "价格要写进引导文案: " + e.getMessage());
+        assertEquals(1, urls.size(), "只查了元数据，不该再打 bundle 端点");
+    }
+
+    @Test
+    @DisplayName("安装：官网 402 被翻成明确中文（含条目名与价格），不吞成通用失败")
+    void paidInstallSurfaces402() {
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService,
+                gate("awdk_live", null)) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                if (url.endsWith("/plugins")) return reply(200, paidRegistryJson());
+                assertEquals("awdk_live", bearer, "付费项 bundle 请求必须带账户 Bearer");
+                return reply(402, "{\"code\":\"payment_required\",\"priceCents\":1990,\"itemName\":\"尽调助手\"}");
+            }
+        };
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install("demo"));
+        assertTrue(e.getMessage().contains("尽调助手"), e.getMessage());
+        assertTrue(e.getMessage().contains("需购买后安装"), e.getMessage());
+        assertTrue(e.getMessage().contains("¥19.90"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("安装：免费项不带 Authorization（免费流程一字不变）")
+    void freeInstallSendsNoBearer() throws Exception {
+        byte[] manifestBytes = "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\"}".getBytes(StandardCharsets.UTF_8);
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", PluginMarketService.sha256Hex(manifestBytes));
+        String sig = sign(canonical("demo", "1.0.0", "2026-07-27T00:00:00Z", files));
+
+        java.util.List<String> bearers = new java.util.ArrayList<>();
+        PluginMarketService svc = new PluginMarketService(
+                "http://registry.test/plugins", publicKeyPem, pluginsDir.toString(), pluginService,
+                gate("awdk_live", null)) {
+            @Override
+            protected RegistryReply httpGet(String url, String bearer) {
+                if (url.endsWith("/plugins")) {
+                    return reply(200, "[{\"id\":\"demo\",\"name\":\"演示\",\"priceCents\":0}]");
+                }
+                bearers.add(String.valueOf(bearer));
+                return reply(200, bundleJson("demo", "1.0.0", "2026-07-27T00:00:00Z", files, sig));
+            }
+            @Override
+            protected RegistryReply httpGetBytes(String url, String bearer) {
+                bearers.add(String.valueOf(bearer));
+                return new RegistryReply(200, manifestBytes);
+            }
+        };
+        assertEquals("demo", svc.install("demo"));
+        assertEquals(java.util.List.of("null", "null"), bearers, "已连接账户也不该给免费项带鉴权头");
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillMarketServiceTest.java
@@ -1,11 +1,16 @@
 package com.checkba.service.ai.skill;
 
+import com.checkba.service.account.AccountService;
 import com.checkba.service.ai.PluginService;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.market.MarketPurchaseGate;
+import com.checkba.service.market.RegistryReply;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -17,10 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * SkillMarketService 单测：注册表列表解析与安装标注、id/文件名安全校验、
- * 安装写盘 + rescan 生效、卸载（含拒绝插件携带 skill）。httpGet seam 打桩，不走真实网络。
+ * 安装写盘 + rescan 生效、卸载（含拒绝插件携带 skill）、付费项闸门（PR-D）。
+ * httpGet seam 打桩，不走真实网络。
  */
 class SkillMarketServiceTest {
 
@@ -29,23 +38,41 @@ class SkillMarketServiceTest {
     @TempDir
     Path tempDir;
 
-    /** httpGet seam 打桩：url -> 响应体；未配置的 url 模拟网络失败 */
+    /**
+     * @param accountKey 账户 Key；null = 未连接
+     * @param ownedFeature 已购的 feature（skill:/plugin: 命名空间），null = 未购
+     */
+    private static MarketPurchaseGate gate(String accountKey, String ownedFeature) {
+        AccountService account = mock(AccountService.class);
+        when(account.currentKeyOrNull()).thenReturn(accountKey);
+        when(account.isConnected()).thenReturn(accountKey != null);
+        EntitlementService entitlements = mock(EntitlementService.class);
+        when(entitlements.isEnabled(anyString()))
+                .thenAnswer(inv -> ownedFeature != null && ownedFeature.equals(inv.getArgument(0)));
+        return new MarketPurchaseGate(account, entitlements);
+    }
+
+    /** httpGet seam 打桩：url -> 响应体；未配置的 url 模拟网络失败。记录每次请求带的 bearer。 */
     private static class StubMarketService extends SkillMarketService {
         final Map<String, String> responses = new HashMap<>();
+        /** url -> 状态码，缺省 200（402 用例在这里登记） */
+        final Map<String, Integer> statuses = new HashMap<>();
         final List<String> requestedUrls = new ArrayList<>();
+        final List<String> sentBearers = new ArrayList<>();
 
-        StubMarketService(SkillProperties properties, SkillRegistry registry) {
-            super(properties, registry);
+        StubMarketService(SkillProperties properties, SkillRegistry registry, MarketPurchaseGate gate) {
+            super(properties, registry, gate);
         }
 
         @Override
-        protected String httpGet(String url) {
+        protected RegistryReply httpGet(String url, String bearer) {
             requestedUrls.add(url);
+            sentBearers.add(String.valueOf(bearer));
             String body = responses.get(url);
             if (body == null) {
                 throw new IllegalStateException("注册表不可达: stub");
             }
-            return body;
+            return new RegistryReply(statuses.getOrDefault(url, 200), body.getBytes(StandardCharsets.UTF_8));
         }
     }
 
@@ -53,12 +80,16 @@ class SkillMarketServiceTest {
     private SkillRegistry registry;
 
     private StubMarketService newService(Path skillsDir, PluginService pluginService) {
+        return newService(skillsDir, pluginService, gate(null, null));
+    }
+
+    private StubMarketService newService(Path skillsDir, PluginService pluginService, MarketPurchaseGate gate) {
         props = new SkillProperties();
         props.setDir(skillsDir.toString());
         props.setRegistryUrl(REGISTRY_URL);
         registry = new SkillRegistry(props, null, pluginService);
         registry.init();
-        return new StubMarketService(props, registry);
+        return new StubMarketService(props, registry, gate);
     }
 
     private void writeLocalSkill(Path dir, String id) throws IOException {
@@ -199,5 +230,111 @@ class SkillMarketServiceTest {
 
         assertThrows(IllegalStateException.class, () -> service.uninstall("plugin-skill"));
         assertTrue(registry.getSkill("plugin-skill").isPresent(), "插件 skill 原样保留");
+    }
+
+    // ==================== 付费项（PR-D） ====================
+
+    /** 注册表列表：一个 ¥19.90 的付费 Skill */
+    private static final String PAID_REGISTRY = """
+            [{ "id": "due-diligence", "name": "尽调助手", "triggers": ["尽调"],
+               "priceCents": 1990, "pricingModel": "once" }]""";
+
+    @Test
+    @DisplayName("listMarket：官网旧格式没有 priceCents 时按免费处理（向后兼容，不能把免费项锁住）")
+    void listTreatsMissingPriceAsFree() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService());
+        service.responses.put(REGISTRY_URL, """
+                [{ "id": "legacy-skill", "name": "老技能", "triggers": ["老"] }]""");
+
+        SkillMarketService.MarketSkillView view = service.listMarket().get(0);
+        assertEquals(0, view.getPriceCents(), "缺字段 = 免费");
+        assertEquals("once", view.getPricingModel(), "缺字段按一次性买断兜底");
+        assertFalse(view.isPurchased());
+    }
+
+    @Test
+    @DisplayName("listMarket：付费项已购时标 purchased（feature 命名空间 skill:<id>，不与本地功能键混淆）")
+    void listMarksPurchased() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService(),
+                gate("awdk_live", "skill:due-diligence"));
+        service.responses.put(REGISTRY_URL, PAID_REGISTRY);
+
+        SkillMarketService.MarketSkillView view = service.listMarket().get(0);
+        assertEquals(1990, view.getPriceCents());
+        assertEquals("once", view.getPricingModel());
+        assertTrue(view.isPurchased());
+        assertTrue(service.accountConnected());
+
+        // 同一条目在未购账户下不得标已购
+        StubMarketService unpaid = newService(tempDir.resolve("skills2"), new PluginService(),
+                gate("awdk_live", "clipboard.unlimited"));
+        unpaid.responses.put(REGISTRY_URL, PAID_REGISTRY);
+        assertFalse(unpaid.listMarket().get(0).isPurchased(), "本地 SKU 的权益不能蹭成广场条目的已购");
+    }
+
+    @Test
+    @DisplayName("install：付费项未连接账户时本地拦下并给出连接引导，不发 bundle 请求")
+    void paidInstallWithoutAccountIsBlockedLocally() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService());
+        service.responses.put(REGISTRY_URL, PAID_REGISTRY);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> service.install("due-diligence"));
+        assertTrue(e.getMessage().contains("连接 AI Workdeck 账户"), e.getMessage());
+        assertTrue(e.getMessage().contains("¥19.90"), "价格要写进引导文案: " + e.getMessage());
+        assertEquals(List.of(REGISTRY_URL), service.requestedUrls, "只查了元数据，不该再打 bundle 端点");
+    }
+
+    @Test
+    @DisplayName("install：官网 402 被翻成明确中文（含条目名与价格），不吞成通用失败")
+    void paidInstallSurfaces402() {
+        Path skillsDir = tempDir.resolve("skills");
+        StubMarketService service = newService(skillsDir, new PluginService(), gate("awdk_live", null));
+        String bundleUrl = REGISTRY_URL + "/due-diligence/bundle";
+        service.responses.put(REGISTRY_URL, PAID_REGISTRY);
+        service.responses.put(bundleUrl, "{\"code\":\"payment_required\",\"priceCents\":1990,\"itemName\":\"尽调助手\"}");
+        service.statuses.put(bundleUrl, 402);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> service.install("due-diligence"));
+        assertTrue(e.getMessage().contains("尽调助手"), e.getMessage());
+        assertTrue(e.getMessage().contains("需购买后安装"), e.getMessage());
+        assertTrue(e.getMessage().contains("¥19.90"), e.getMessage());
+        assertEquals("awdk_live", service.sentBearers.get(1), "付费项 bundle 请求必须带账户 Bearer");
+        assertFalse(Files.exists(skillsDir.resolve("due-diligence")), "402 不得留下半成品");
+    }
+
+    @Test
+    @DisplayName("install：已购付费项带 Bearer 正常安装；免费项即使已连接账户也不带鉴权头")
+    void paidPurchasedInstallsAndFreeStaysAnonymous() {
+        Path skillsDir = tempDir.resolve("skills");
+        StubMarketService paid = newService(skillsDir, new PluginService(),
+                gate("awdk_live", "skill:due-diligence"));
+        paid.responses.put(REGISTRY_URL, PAID_REGISTRY);
+        paid.responses.put(REGISTRY_URL + "/due-diligence/bundle", bundleJson("due-diligence"));
+
+        assertEquals("due-diligence", paid.install("due-diligence"));
+        assertEquals("awdk_live", paid.sentBearers.get(1));
+
+        StubMarketService free = newService(tempDir.resolve("free"), new PluginService(),
+                gate("awdk_live", null));
+        free.responses.put(REGISTRY_URL, """
+                [{ "id": "contract-review", "name": "合同审查", "triggers": ["合同"], "priceCents": 0 }]""");
+        free.responses.put(REGISTRY_URL + "/contract-review/bundle", bundleJson("contract-review"));
+
+        assertEquals("contract-review", free.install("contract-review"));
+        assertEquals(List.of("null", "null"), free.sentBearers, "免费项链路一字不变：不带 Authorization");
+    }
+
+    @Test
+    @DisplayName("install：注册表列表不可达时按免费继续（网络抖动不该连免费项都装不上）")
+    void installFallsBackToFreeWhenRegistryListUnavailable() {
+        Path skillsDir = tempDir.resolve("skills");
+        StubMarketService service = newService(skillsDir, new PluginService());
+        // 只登记 bundle，列表 url 缺失 = stub 抛网络失败
+        service.responses.put(REGISTRY_URL + "/contract-review/bundle", bundleJson("contract-review"));
+
+        assertEquals("contract-review", service.install("contract-review"));
+        assertEquals("null", service.sentBearers.get(1), "价格未知按免费，不带鉴权头");
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillMarketServiceTest.java
@@ -239,6 +239,17 @@ class SkillMarketServiceTest {
             [{ "id": "due-diligence", "name": "尽调助手", "triggers": ["尽调"],
                "priceCents": 1990, "pricingModel": "once" }]""";
 
+    /**
+     * 付费闸门的文案不能撞上前端的掉线启发式：services/api.js 对 {@code code:1} 的消息做子串匹配，
+     * 见到「登录」「未授权」「请先」就清本地会话，浏览器端还会跳登录页。这里是业务错误，不是掉线。
+     */
+    private static void assertNotMistakenForLogout(String message) {
+        for (String needle : List.of("登录", "未授权", "请先")) {
+            assertFalse(message.contains(needle),
+                    "文案含「" + needle + "」会被前端当成掉线清会话: " + message);
+        }
+    }
+
     @Test
     @DisplayName("listMarket：官网旧格式没有 priceCents 时按免费处理（向后兼容，不能把免费项锁住）")
     void listTreatsMissingPriceAsFree() {
@@ -282,6 +293,7 @@ class SkillMarketServiceTest {
                 () -> service.install("due-diligence"));
         assertTrue(e.getMessage().contains("连接 AI Workdeck 账户"), e.getMessage());
         assertTrue(e.getMessage().contains("¥19.90"), "价格要写进引导文案: " + e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
         assertEquals(List.of(REGISTRY_URL), service.requestedUrls, "只查了元数据，不该再打 bundle 端点");
     }
 
@@ -335,6 +347,50 @@ class SkillMarketServiceTest {
         service.responses.put(REGISTRY_URL + "/contract-review/bundle", bundleJson("contract-review"));
 
         assertEquals("contract-review", service.install("contract-review"));
-        assertEquals("null", service.sentBearers.get(1), "价格未知按免费，不带鉴权头");
+        assertEquals("null", service.sentBearers.get(1), "未连账户就没得带，按免费继续");
+    }
+
+    @Test
+    @DisplayName("install：价格没查到但本机已连账户时照带 Bearer（已购用户不该被 402 反过来指控没付费）")
+    void unknownPriceStillSendsBearerWhenConnected() {
+        Path skillsDir = tempDir.resolve("skills");
+        StubMarketService service = newService(skillsDir, new PluginService(),
+                gate("awdk_live", "skill:due-diligence"));
+        // 列表 url 缺失 = 价格查不到；付费与否无从判断
+        service.responses.put(REGISTRY_URL + "/due-diligence/bundle", bundleJson("due-diligence"));
+
+        assertEquals("due-diligence", service.install("due-diligence"));
+        assertEquals("awdk_live", service.sentBearers.get(1),
+                "价格未知时本机有 Key 就带上——免费项的 bundle 端点不看 Authorization，附上无副作用");
+    }
+
+    @Test
+    @DisplayName("install：价格未知 + 未连账户吃到 402 时说「去连接账户」，不说「去购买」")
+    void unknownPrice402WithoutAccountSuggestsConnecting() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService());
+        String bundleUrl = REGISTRY_URL + "/due-diligence/bundle";
+        service.responses.put(bundleUrl, "{\"code\":\"payment_required\",\"priceCents\":1990,\"itemName\":\"尽调助手\"}");
+        service.statuses.put(bundleUrl, 402);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> service.install("due-diligence"));
+        assertTrue(e.getMessage().contains("连接 AI Workdeck 账户"), e.getMessage());
+        assertFalse(e.getMessage().contains("需购买后安装"),
+                "本机没连账户，官网无从查购买记录：402 不等于用户没买过 —— " + e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("listMarket：priceCents 畸形（负数 / 超上限的截断值）按未知处理，不展示假价格")
+    void listNormalizesMalformedPrice() {
+        StubMarketService service = newService(tempDir.resolve("skills"), new PluginService());
+        // 1215752191 = 官网写了个超 int 范围的值、反序列化时被截断的实测结果（¥12,157,521.91）
+        service.responses.put(REGISTRY_URL, """
+                [{ "id": "neg-price", "name": "负价", "priceCents": -100 },
+                 { "id": "huge-price", "name": "溢出", "priceCents": 1215752191 }]""");
+
+        List<SkillMarketService.MarketSkillView> list = service.listMarket();
+        assertEquals(0, list.get(0).getPriceCents(), "负数按未知");
+        assertEquals(0, list.get(1).getPriceCents(), "超上限只可能是畸形值，不能当真价展示");
     }
 }

--- a/frontend/src/components/MarketDetailPane.vue
+++ b/frontend/src/components/MarketDetailPane.vue
@@ -338,10 +338,14 @@ export default {
     async reload() {
       this.loading = true
       this.loadError = ''
+      // 广场不可达要如实说：本页没有市场数据时按钮区是空的，若再不给原因，
+      // 用户看到的就是「有标题、没价格、没按钮」的哑页面——尤其付费项本来也没有安装按钮
+      let marketError = null
+      const keepMarketError = (e) => { marketError = e; return null }
       try {
         if (this.spec.kind === 'skill') {
           const [mRes, iRes] = await Promise.all([
-            getSkillMarket().catch(() => null),
+            getSkillMarket().catch(keepMarketError),
             getSkills().catch(() => null),
           ])
           const marketList = mRes?.skills || []
@@ -351,7 +355,7 @@ export default {
           this.installedInfo = installedList.find(s => s.id === this.spec.id) || null
         } else {
           const [mRes, iRes] = await Promise.all([
-            getPluginMarket().catch(() => null),
+            getPluginMarket().catch(keepMarketError),
             getPlugins().catch(() => null),
           ])
           const marketList = mRes?.plugins || []
@@ -359,6 +363,10 @@ export default {
           if (typeof mRes?.accountConnected === 'boolean') this.accountConnected = mRes.accountConnected
           this.marketInfo = marketList.find(p => p.id === this.spec.id) || null
           this.installedInfo = installedList.find(p => p.id === this.spec.id) || null
+        }
+        // 本机已装的项即使广场挂了也照常展示（信息来自本地），不必报错打扰
+        if (!this.marketInfo && !this.installedInfo && marketError) {
+          this.loadError = marketError.message || '在线广场不可用'
         }
       } catch (e) {
         console.error('加载详情失败:', e)

--- a/frontend/src/components/MarketDetailPane.vue
+++ b/frontend/src/components/MarketDetailPane.vue
@@ -13,6 +13,7 @@
             <text class="mdp-title">{{ display.name }}</text>
             <text class="mdp-kind-badge">{{ spec.kind === 'plugin' ? '插件' : 'Skill' }}</text>
             <text v-if="installedInfo" class="mdp-installed-badge">已安装</text>
+            <text v-if="marketInfo" class="mdp-price-badge" :class="{ paid: isPaidItem }">{{ priceBadge }}</text>
           </view>
           <view class="mdp-byline">
             <text v-if="display.author" class="mdp-byline-item mdp-author">{{ display.author }}</text>
@@ -26,10 +27,23 @@
 
           <!-- 动作区 -->
           <view class="mdp-actions">
+            <!-- 付费未购（Skill 与插件同款）：先去官网买，本机不给安装按钮——点了也只会拿到 402 -->
+            <template v-if="marketInfo && !installedInfo && needsPurchase">
+              <view class="mdp-btn primary" @tap="openPurchase">
+                <text>购买 {{ priceText }}</text>
+              </view>
+              <view v-if="paidStateValue === 'need-account'" class="mdp-btn" @tap="goToAccountSettings">
+                <text>去连接账户</text>
+              </view>
+              <view v-else class="mdp-btn" :class="{ busy }" @tap="onPurchasedRefresh">
+                <text>{{ busy ? '刷新中…' : '我已购买，刷新' }}</text>
+              </view>
+            </template>
+
             <!-- Skill：安装 / 更新 / 卸载 + 生效方式三档 -->
             <template v-if="spec.kind === 'skill'">
               <view
-                v-if="marketInfo && !installedInfo"
+                v-if="marketInfo && !installedInfo && !needsPurchase"
                 class="mdp-btn primary"
                 :class="{ busy }"
                 @tap="doInstallSkill"
@@ -68,7 +82,7 @@
             <!-- 插件：安装（带权限确认）/ 启停 / 卸载 -->
             <template v-else>
               <view
-                v-if="marketInfo && !installedInfo"
+                v-if="marketInfo && !installedInfo && !needsPurchase"
                 class="mdp-btn primary"
                 :class="{ busy }"
                 @tap="doInstallPlugin"
@@ -89,6 +103,8 @@
               </view>
             </template>
           </view>
+
+          <text v-if="purchaseHint" class="mdp-purchase-hint">{{ purchaseHint }}</text>
         </view>
       </view>
 
@@ -126,6 +142,9 @@
             <view v-if="spec.kind === 'skill' && toolSummary" class="mdp-kv-row">
               <text class="mdp-k">工具权限</text><text class="mdp-v">{{ toolSummary }}</text>
             </view>
+            <view v-if="marketInfo" class="mdp-kv-row">
+              <text class="mdp-k">价格</text><text class="mdp-v">{{ priceDetailText }}</text>
+            </view>
             <view class="mdp-kv-row"><text class="mdp-k">标识</text><text class="mdp-v mono">{{ spec.id }}</text></view>
             <view v-if="display.version" class="mdp-kv-row"><text class="mdp-k">版本</text><text class="mdp-v">v{{ display.version }}</text></view>
             <view v-if="display.author" class="mdp-kv-row"><text class="mdp-k">作者</text><text class="mdp-v">{{ display.author }}</text></view>
@@ -148,6 +167,9 @@
 // 装/卸/启停后通过 uni.$emit('awd:market-changed') 通知左栏刷新。
 import { getPlugins, getSkills, getSkillMarket, getPluginMarket, installMarketSkill, uninstallMarketSkill, installMarketPlugin, uninstallMarketPlugin, setPluginEnabled, setSkillActivation } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
+import { formatPrice, isPaid, paidState, priceCentsOf, priceLabel, purchaseUrl } from '@/utils/marketPricing.js'
+import { openExternalUrl } from '@/utils/externalLink.js'
+import { refreshEntitlements } from '@/composables/useEntitlement.js'
 
 const CATEGORY_GLYPHS = {
   contract: ICONS.catContract,
@@ -195,11 +217,43 @@ export default {
       marketInfo: null,
       installedInfo: null,
       busy: false,
+      // 是否已连接官网账户；随广场列表响应下发（付费未购项据此在「购买」与「需连接账户」之间选）
+      accountConnected: false,
     }
   },
   computed: {
     ACTIVATION_LABELS() {
       return ACTIVATION_LABELS
+    },
+    isPaidItem() {
+      return isPaid(this.marketInfo)
+    },
+    /** 'free' | 'purchased' | 'buy' | 'need-account'；marketInfo 为空（本机项）按免费 */
+    paidStateValue() {
+      return paidState(this.marketInfo, this.accountConnected)
+    },
+    /** 付费且未购：动作区换成购买引导，不给安装按钮 */
+    needsPurchase() {
+      return this.paidStateValue === 'buy' || this.paidStateValue === 'need-account'
+    },
+    /** 标题行徽章：免费 / ¥xx.xx / 已购买 */
+    priceBadge() {
+      return priceLabel(this.marketInfo)
+    },
+    priceText() {
+      return formatPrice(priceCentsOf(this.marketInfo))
+    },
+    priceDetailText() {
+      if (!this.isPaidItem) return '免费'
+      const base = this.priceText + '（一次性买断）'
+      return this.marketInfo && this.marketInfo.purchased ? base + ' · 已购买' : base
+    },
+    purchaseHint() {
+      if (!this.needsPurchase) return ''
+      if (this.paidStateValue === 'need-account') {
+        return '这是付费项目。请先在设置的「账户与用量」中连接 AI Workdeck 账户，安装时才能校验购买记录。'
+      }
+      return '这是付费项目。购买在官网完成，付款后回到本页点「我已购买，刷新」即可安装。'
     },
     headGlyph() {
       if (this.spec.kind === 'plugin') return ICONS.blocks
@@ -292,6 +346,7 @@ export default {
           ])
           const marketList = mRes?.skills || []
           const installedList = Array.isArray(iRes) ? iRes : (iRes?.data || [])
+          if (typeof mRes?.accountConnected === 'boolean') this.accountConnected = mRes.accountConnected
           this.marketInfo = marketList.find(s => s.id === this.spec.id) || null
           this.installedInfo = installedList.find(s => s.id === this.spec.id) || null
         } else {
@@ -301,6 +356,7 @@ export default {
           ])
           const marketList = mRes?.plugins || []
           const installedList = Array.isArray(iRes) ? iRes : (iRes?.data || [])
+          if (typeof mRes?.accountConnected === 'boolean') this.accountConnected = mRes.accountConnected
           this.marketInfo = marketList.find(p => p.id === this.spec.id) || null
           this.installedInfo = installedList.find(p => p.id === this.spec.id) || null
         }
@@ -313,6 +369,35 @@ export default {
     },
     notifyChanged() {
       uni.$emit('awd:market-changed')
+    },
+    // 购买走系统浏览器：支付要用用户已登录的浏览器会话，内嵌 tab 里付不了
+    openPurchase() {
+      openExternalUrl(purchaseUrl(this.spec.kind, this.spec.id))
+    },
+    goToAccountSettings() {
+      uni.navigateTo({ url: '/pages/admin/admin?nav=account' })
+    },
+    /**
+     * 「我已购买，刷新」：先让后端同步一次官网权益（本地缓存不刷新是看不到刚买的东西的），
+     * 再重拉广场；确认已购就顺手把安装接上，省得用户再点一次。
+     */
+    async onPurchasedRefresh() {
+      if (this.busy) return
+      this.busy = true
+      try {
+        await refreshEntitlements(true)
+        await this.reload()
+        this.notifyChanged()
+      } finally {
+        this.busy = false
+      }
+      if (this.needsPurchase) {
+        uni.showToast({ title: '还没查到这一项的购买记录，请确认已在官网完成支付', icon: 'none' })
+        return
+      }
+      if (this.installedInfo) return
+      if (this.spec.kind === 'skill') await this.doInstallSkill()
+      else await this.doInstallPlugin()
     },
     async doInstallSkill() {
       if (this.busy) return
@@ -498,6 +583,29 @@ export default {
   background: #1A5336;
   border-radius: 4px;
   padding: 1px 6px;
+}
+
+/* 价格徽章：免费用中性灰，付费用暖色（与「试用版」chip 同族），不做成促销红 */
+.mdp-price-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: #868E96;
+  background: #F1F3F5;
+  border-radius: 4px;
+  padding: 1px 6px;
+
+  &.paid {
+    color: #8A6D2F;
+    background: #FDF7EC;
+  }
+}
+
+.mdp-purchase-hint {
+  display: block;
+  margin-top: 8px;
+  font-size: 11px;
+  line-height: 17px;
+  color: #8A6D2F;
 }
 
 .mdp-byline {

--- a/frontend/src/components/MarketPane.vue
+++ b/frontend/src/components/MarketPane.vue
@@ -119,12 +119,19 @@
                     </template>
                   </view>
                   <text class="card-title">{{ m.name || m.id }}</text>
-                  <text class="card-id">{{ m.id }} · v{{ m.version || '1.0.0' }}</text>
+                  <text class="card-id">{{ m.id }} · v{{ m.version || '1.0.0' }} · {{ priceTag(m) }}</text>
                 </view>
                 <view class="card-actions">
-                  <view class="act-primary" :class="{ 'is-busy': !!marketBusyId }" @tap="installSkill(m)">
+                  <view
+                    v-if="marketAction(m) === 'install'"
+                    class="act-primary"
+                    :class="{ 'is-busy': !!marketBusyId }"
+                    @tap="installSkill(m)"
+                  >
                     {{ marketBusyId === m.id ? '处理中' : (m.installed ? '更新' : '安装') }}
                   </view>
+                  <view v-else-if="marketAction(m) === 'buy'" class="act-primary" @tap="openPurchase('skill', m.id)">购买</view>
+                  <view v-else class="act-primary" @tap="goToAccountSettings">需连接账户</view>
                   <view v-if="m.installed" class="act-remove" @tap="uninstallSkill(m)">卸载</view>
                 </view>
               </view>
@@ -177,15 +184,17 @@
                     </template>
                   </view>
                   <text class="card-title">{{ m.name || m.id }}</text>
-                  <text class="card-id">{{ m.id }} · v{{ m.version || '1.0.0' }} · {{ formatSize(m.size) }}</text>
+                  <text class="card-id">{{ m.id }} · v{{ m.version || '1.0.0' }} · {{ formatSize(m.size) }} · {{ priceTag(m) }}</text>
                 </view>
                 <view class="card-actions">
                   <view
-                    v-if="!m.installed || m.updatable"
+                    v-if="marketAction(m) === 'install' && (!m.installed || m.updatable)"
                     class="act-primary"
                     :class="{ 'is-busy': !!pluginBusyId }"
                     @tap="installPlugin(m)"
                   >{{ pluginBusyId === m.id ? '安装中' : (m.updatable ? '更新' : '安装') }}</view>
+                  <view v-else-if="marketAction(m) === 'buy'" class="act-primary" @tap="openPurchase('plugin', m.id)">购买</view>
+                  <view v-else-if="marketAction(m) === 'need-account'" class="act-primary" @tap="goToAccountSettings">需连接账户</view>
                   <view v-if="m.installed" class="act-remove" @tap="uninstallPlugin(m)">卸载</view>
                 </view>
               </view>
@@ -327,6 +336,8 @@
 
 <script>
 import { getPlugins, setPluginEnabled, rescanPlugins, getSkills, setSkillActivation, rescanSkills, getSkillMarket, installMarketSkill, uninstallMarketSkill, getPluginMarket, installMarketPlugin, uninstallMarketPlugin } from '@/services/api.js'
+import { paidState, priceLabel, purchaseUrl } from '@/utils/marketPricing.js'
+import { openExternalUrl } from '@/utils/externalLink.js'
 import { ICONS } from '@/config/icons.js'
 
 const PERMISSION_LABELS = {
@@ -396,6 +407,8 @@ export default {
       marketPluginLoading: false,
       marketPluginError: '',
       pluginBusyId: '',
+      // 是否已连接官网账户；随广场列表响应下发（付费未购项据此在「购买」与「需连接账户」之间选）
+      accountConnected: false,
       loading: false,
       switching: false,
       rescanning: false,
@@ -472,6 +485,26 @@ export default {
     categoryGlyph(id) {
       return CATEGORY_GLYPHS[id] || CATEGORY_GLYPHS.other
     },
+    // 与导入的 priceLabel 重名会让人误以为递归，模板里统一叫 priceTag
+    priceTag(m) {
+      return priceLabel(m)
+    },
+    /**
+     * 卡片主按钮形态：'install'（免费 / 已购 / 已安装，行为不变）｜'buy'｜'need-account'。
+     * 已安装项一律走 install 分支，更新与卸载不受付费状态影响。
+     */
+    marketAction(m) {
+      if (m.installed) return 'install'
+      const state = paidState(m, this.accountConnected)
+      return state === 'buy' || state === 'need-account' ? state : 'install'
+    },
+    // 购买走系统浏览器：支付要用用户已登录的浏览器会话
+    openPurchase(kind, id) {
+      openExternalUrl(purchaseUrl(kind, id))
+    },
+    goToAccountSettings() {
+      uni.navigateTo({ url: '/pages/admin/admin?nav=account' })
+    },
     formatSize(bytes) {
       if (!bytes) return '未知大小'
       if (bytes < 1024) return bytes + ' B'
@@ -484,6 +517,7 @@ export default {
       try {
         const res = await getPluginMarket()
         this.marketPlugins = res?.plugins || []
+        if (typeof res?.accountConnected === 'boolean') this.accountConnected = res.accountConnected
       } catch (e) {
         // 注册表不可达只在区块内提示，不影响本地插件与 Skill
         console.warn('在线插件广场不可用:', e)
@@ -616,6 +650,7 @@ export default {
       try {
         const res = await getSkillMarket()
         this.marketSkills = res?.skills || []
+        if (typeof res?.accountConnected === 'boolean') this.accountConnected = res.accountConnected
       } catch (e) {
         // 注册表不可达只在区块内提示，不弹 toast、不影响本地插件 / Skill 区块
         console.warn('在线广场不可用:', e)

--- a/frontend/src/components/MarketPane.vue
+++ b/frontend/src/components/MarketPane.vue
@@ -452,12 +452,21 @@ export default {
   // 原页面在 onLoad 里拉取（无路由参数依赖）；组件化后等价迁到 mounted，
   // 嵌入态每次挂载（含 :key 变化触发的重挂）都会重新拉取四组数据
   mounted() {
-    this.loadPlugins()
-    this.loadSkills()
-    this.loadMarket()
-    this.loadPluginMarket()
+    this.reloadAll()
+    // 设置页连接/断开账户后广播回来：付费项的按钮形态跟着账户状态变，
+    // 而设置页是 navigateTo 打开的、本页并不销毁，不订阅就会停在旧状态转不出去
+    uni.$on('awd:market-changed', this.reloadAll)
+  },
+  beforeUnmount() {
+    uni.$off('awd:market-changed', this.reloadAll)
   },
   methods: {
+    reloadAll() {
+      this.loadPlugins()
+      this.loadSkills()
+      this.loadMarket()
+      this.loadPluginMarket()
+    },
     tabCount(key) {
       if (key === 'skill') return this.marketSkills.length
       if (key === 'plugin') return this.marketPlugins.length

--- a/frontend/src/components/MarketSidebarPanel.vue
+++ b/frontend/src/components/MarketSidebarPanel.vue
@@ -78,15 +78,21 @@
             <text v-if="row.desc" class="msb-row-desc">{{ row.desc }}</text>
             <text class="msb-row-meta">{{ row.meta }}</text>
           </view>
+          <view v-if="row.installed" class="msb-row-state ok"><text>已装</text></view>
           <view
-            v-if="!row.installed"
+            v-else-if="row.canInstall"
             class="msb-row-install"
             :class="{ busy: marketBusyId === row.id }"
             @tap.stop="installSkillRow(row)"
           >
             <text>{{ marketBusyId === row.id ? '…' : '安装' }}</text>
           </view>
-          <view v-else class="msb-row-state ok"><text>已装</text></view>
+          <view v-else-if="row.paidState === 'buy'" class="msb-row-install buy" @tap.stop="openPurchase(row)">
+            <text>购买</text>
+          </view>
+          <view v-else class="msb-row-state need" @tap.stop="goToAccountSettings">
+            <text>需连接账户</text>
+          </view>
         </view>
       </view>
 
@@ -120,15 +126,21 @@
             <text v-if="row.desc" class="msb-row-desc">{{ row.desc }}</text>
             <text class="msb-row-meta">{{ row.meta }}</text>
           </view>
+          <view v-if="row.installed" class="msb-row-state ok"><text>已装</text></view>
           <view
-            v-if="!row.installed"
+            v-else-if="row.canInstall"
             class="msb-row-install"
             :class="{ busy: pluginBusyId === row.id }"
             @tap.stop="installPluginRow(row)"
           >
             <text>{{ pluginBusyId === row.id ? '…' : '安装' }}</text>
           </view>
-          <view v-else class="msb-row-state ok"><text>已装</text></view>
+          <view v-else-if="row.paidState === 'buy'" class="msb-row-install buy" @tap.stop="openPurchase(row)">
+            <text>购买</text>
+          </view>
+          <view v-else class="msb-row-state need" @tap.stop="goToAccountSettings">
+            <text>需连接账户</text>
+          </view>
         </view>
       </view>
     </scroll-view>
@@ -141,6 +153,8 @@
 // 数据与安装链路复用 MarketPane 同一组 services/api.js 封装。
 import { getPlugins, getSkills, getSkillMarket, getPluginMarket, installMarketSkill, installMarketPlugin, rescanPlugins, rescanSkills } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
+import { canInstall, paidState, priceLabel, purchaseUrl } from '@/utils/marketPricing.js'
+import { openExternalUrl } from '@/utils/externalLink.js'
 
 const CATEGORY_GLYPHS = {
   contract: ICONS.catContract,
@@ -193,6 +207,8 @@ export default {
       marketBusyId: '',
       pluginBusyId: '',
       rescanning: false,
+      // 是否已连接官网账户；随广场列表响应一起下发（付费未购项据此显示「购买」还是「需连接账户」）
+      accountConnected: false,
     }
   },
   computed: {
@@ -240,6 +256,8 @@ export default {
         const dl = fmtDownloads(m.downloads)
         if (dl) metaParts.push(dl + ' 下载')
         metaParts.push(CATEGORY_LABELS[cat] || '其他')
+        metaParts.push(priceLabel(m))
+        const state = paidState(m, this.accountConnected)
         return {
           kind: 'skill',
           id: m.id,
@@ -248,6 +266,8 @@ export default {
           glyph: CATEGORY_GLYPHS[cat] || CATEGORY_GLYPHS.other,
           meta: metaParts.join(' · '),
           installed: !!m.installed,
+          paidState: state,
+          canInstall: canInstall(state),
           raw: m,
         }
       })
@@ -266,6 +286,8 @@ export default {
         if (m.version) metaParts.push('v' + m.version)
         const author = m.authorDisplayName || m.author
         if (author) metaParts.push(author)
+        metaParts.push(priceLabel(m))
+        const state = paidState(m, this.accountConnected)
         return {
           kind: 'plugin',
           id: m.id,
@@ -274,6 +296,8 @@ export default {
           glyph: ICONS.blocks,
           meta: metaParts.join(' · ') || '插件',
           installed: installedIds.has(m.id) || !!m.installed,
+          paidState: state,
+          canInstall: canInstall(state),
           raw: m,
         }
       })
@@ -295,6 +319,14 @@ export default {
     openDetail(row) {
       this.$emit('open-detail', { kind: row.kind, id: row.id, name: row.name })
     },
+    // 购买走系统浏览器：支付要用用户已登录的浏览器会话，内嵌 tab 里付不了
+    openPurchase(row) {
+      openExternalUrl(purchaseUrl(row.kind, row.id))
+      uni.showToast({ title: '已在浏览器打开商品页，购买后回到详情页点「我已购买，刷新」', icon: 'none' })
+    },
+    goToAccountSettings() {
+      uni.navigateTo({ url: '/pages/admin/admin?nav=account' })
+    },
     async reloadAll() {
       this.loadInstalled()
       this.loadMarketSkills()
@@ -315,6 +347,7 @@ export default {
       try {
         const res = await getSkillMarket()
         this.marketSkills = res?.skills || []
+        if (typeof res?.accountConnected === 'boolean') this.accountConnected = res.accountConnected
       } catch (e) {
         console.warn('在线 Skill 广场不可用:', e)
         this.marketError = e?.message || '网络不可用'
@@ -329,6 +362,7 @@ export default {
       try {
         const res = await getPluginMarket()
         this.marketPlugins = res?.plugins || []
+        if (typeof res?.accountConnected === 'boolean') this.accountConnected = res.accountConnected
       } catch (e) {
         console.warn('在线插件广场不可用:', e)
         this.marketPluginError = e?.message || '网络不可用'
@@ -651,6 +685,20 @@ export default {
     opacity: 0.6;
     pointer-events: none;
   }
+
+  /* 付费未购：描边而非实心，与「安装」区分开——点它去的是官网，不是本机动作 */
+  &.buy {
+    background: #fff;
+    border-color: #1A5336;
+
+    text {
+      color: #1A5336;
+    }
+
+    &:hover {
+      background: #E8F3ED;
+    }
+  }
 }
 
 .msb-row-state {
@@ -675,6 +723,21 @@ export default {
     text {
       color: #868E96;
       font-size: 10px;
+    }
+  }
+
+  /* 未连接账户：与顶栏「试用版」chip 同一族暖色，是引导不是报错 */
+  &.need {
+    background: #FDF7EC;
+    cursor: pointer;
+
+    text {
+      color: #8A6D2F;
+      font-size: 10px;
+    }
+
+    &:hover {
+      background: #F7EBD5;
     }
   }
 }

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -1331,6 +1331,7 @@ export default {
         await this.loadAccount()
         // 已购功能解锁随账户走，连接后必须让权益缓存失效重取
         await refreshEntitlements(true)
+        this.notifyMarketAccountChanged()
         uni.showToast({ title: '已连接账户', icon: 'none' })
       } catch (e) {
         uni.showToast({ title: (e && e.message) || '连接失败', icon: 'none' })
@@ -1350,6 +1351,7 @@ export default {
         const res = await disconnectAccount()
         await this.loadAccount()
         await refreshEntitlements(true)
+        this.notifyMarketAccountChanged()
         // 后端会把 activeProvider 从平台通道摘下来（否则每条消息都报未连接账户，
         // 而设置页仍显示平台通道正常选中）。这里同步表单并如实告知切到了哪一个。
         const fallback = res && res.aiProviderFallback
@@ -1367,6 +1369,17 @@ export default {
       } catch (e) {
         uni.showToast({ title: (e && e.message) || '操作失败', icon: 'none' })
       }
+    },
+    /**
+     * 账户连接状态变了 → 广场的付费项按钮形态跟着变（「需连接账户」↔「购买」/「安装」）。
+     *
+     * 设置页是 navigateTo 打开的，上一页并不销毁：不广播的话用户从「需连接账户」点进来、
+     * 连完账户返回，广场还是旧数据，再点又回到这里，转不出去。
+     * 两个事件名分属两个订阅方（左栏 MarketSidebarPanel / 中栏 MarketDetailPane），都要发。
+     */
+    notifyMarketAccountChanged() {
+      uni.$emit('awd:market-changed')
+      uni.$emit('awd:market-changed-from-sidebar')
     },
     // 金额一律两位小数，缺值显示 $0.00 而不是 NaN
     formatUsd(v) {

--- a/frontend/src/utils/marketPricing.js
+++ b/frontend/src/utils/marketPricing.js
@@ -7,10 +7,14 @@
 
 const SITE_BASE = 'https://www.aiworkdeck.com'
 
-/** 售价（分）。缺失、非数字、负数一律 0 = 免费。 */
+// 售价上限（分）= ¥100,000，与后端 MarketPurchaseGate.MAX_PRICE_CENTS 同口径。
+// 超上限必是注册表畸形值（如 long 被截成 int），按未知处理——展示一个假价格比展示「免费」更糟。
+const MAX_PRICE_CENTS = 100000 * 100
+
+/** 售价（分）。缺失、非数字、负数、超上限一律 0 = 免费。 */
 export function priceCentsOf(item) {
   const n = Number(item && item.priceCents)
-  return Number.isFinite(n) && n > 0 ? Math.round(n) : 0
+  return Number.isFinite(n) && n > 0 && n <= MAX_PRICE_CENTS ? Math.round(n) : 0
 }
 
 export function isPaid(item) {

--- a/frontend/src/utils/marketPricing.js
+++ b/frontend/src/utils/marketPricing.js
@@ -1,0 +1,62 @@
+// 广场付费项的展示口径（商业化改造 PR-D）。
+// 左栏列表 MarketSidebarPanel 与中栏详情 MarketDetailPane 两处共用，避免状态判定与文案各写一套。
+//
+// 契约：官网 registry 列表带 priceCents（分，0 = 免费）与 pricingModel。
+// 官网旧格式没有这两个字段——后端已归一为 0 / 'once'，这里再兜一次底：
+// **字段缺失一律按免费**，绝不能因为跑在旧后端/旧 registry 上就把免费项锁住。
+
+const SITE_BASE = 'https://www.aiworkdeck.com'
+
+/** 售价（分）。缺失、非数字、负数一律 0 = 免费。 */
+export function priceCentsOf(item) {
+  const n = Number(item && item.priceCents)
+  return Number.isFinite(n) && n > 0 ? Math.round(n) : 0
+}
+
+export function isPaid(item) {
+  return priceCentsOf(item) > 0
+}
+
+/** 分转元，两位小数。与官网 formatPriceYuan 同口径。 */
+export function formatPrice(cents) {
+  return '¥' + (Number(cents) / 100).toFixed(2)
+}
+
+/** 价格标签：免费项「免费」，已购项「已购买」，其余「¥xx.xx」。 */
+export function priceLabel(item) {
+  const cents = priceCentsOf(item)
+  if (!cents) return '免费'
+  if (item && item.purchased) return '已购买'
+  return formatPrice(cents)
+}
+
+/**
+ * 条目的付费状态，决定按钮形态：
+ * - 'free'         免费项 —— 安装流程一字不变，不多一步
+ * - 'purchased'    付费项已购 —— 与免费项同样直接安装
+ * - 'buy'          付费项未购、账户已连接 —— 去官网商品页购买
+ * - 'need-account' 付费项未购、账户未连接 —— 先去设置连接账户
+ */
+export function paidState(item, accountConnected) {
+  if (!isPaid(item)) return 'free'
+  if (item && item.purchased) return 'purchased'
+  return accountConnected ? 'buy' : 'need-account'
+}
+
+/** 该状态下能否直接走安装（免费 / 已购）。 */
+export function canInstall(state) {
+  return state === 'free' || state === 'purchased'
+}
+
+/**
+ * 官网商品页。
+ *
+ * Skill 有 /zh/skills/{id} 独立详情页（页内带购买按钮）；
+ * 插件官网只有列表页 /zh/plugins（购买按钮在卡片上），**没有 /zh/plugins/{id} 路由**——
+ * registry 里那个 homepage 默认值指向的路径并不存在，拿它当购买入口会打到 404。
+ */
+export function purchaseUrl(kind, id) {
+  return kind === 'plugin'
+    ? `${SITE_BASE}/zh/plugins`
+    : `${SITE_BASE}/zh/skills/${encodeURIComponent(id)}`
+}


### PR DESCRIPTION
对齐官网 PR-W3 的 registry 付费闸门契约（列表带 `priceCents`/`pricingModel`；付费项的 `bundle`/`file` 端点要求 `Authorization: Bearer awdk_` 且已购，否则 402 `{code:"payment_required", priceCents, itemName}`）。

## 后端

- 新增 `service/market/MarketPurchaseGate`：Skill 与插件两条安装链路共用的付费判定单一出口——免费判定、未连接账户拦截、402 翻中文、分转元。feature 命名空间固定 `skill:<id>` / `plugin:<id>`，不与本地 SKU 键（`clipboard.unlimited` 等）混淆。
- `SkillMarketService` / `PluginMarketService`：列表透传 `priceCents`/`pricingModel` 并标注 `purchased`；`install` 先服务端自查价格（不信前端传值），付费项带账户 Bearer，402 转成「需购买后安装（¥xx.xx）」，未连账户直接给连接引导且**不发无意义请求**。
- HTTP seam 改为 `httpGet(url, bearer)` → `RegistryReply(status, bytes)`，状态码交调用方判，402 不在 seam 里抛。
- `AccountService.currentKeyOrNull()`：仅供需自行向官网发鉴权请求的服务使用，不回给前端。
- 广场列表响应带 `accountConnected`，省得前端为一个布尔再打一次 `/api/account/status`。
- 付费与否不改变插件 Ed25519 验签链路，签名与逐文件 SHA-256 比对一步不少。

## 前端

- 新增 `utils/marketPricing.js` 作为价格展示与状态判定的唯一出口，`MarketSidebarPanel` / `MarketDetailPane` / `MarketPane`（admin 页）三处共用。
- 四态 UI：

| 状态 | 列表行 | 详情页 |
|---|---|---|
| 免费 | 元信息「免费」+「安装」（流程一字不变） | 徽章「免费」+「安装」 |
| 已购 | 元信息「已购买」+「安装」 | 徽章「已购买」+「安装」，价格行标「¥xx.xx（一次性买断）· 已购买」 |
| 未购·已连账户 | 「¥xx.xx」+ 描边「购买」（系统浏览器开商品页） | 「购买 ¥xx.xx」+「我已购买，刷新」+ 说明文字 |
| 未连账户 | 「¥xx.xx」+ 暖色「需连接账户」（点击跳设置） | 「购买 ¥xx.xx」+「去连接账户」+ 说明文字 |

- 「我已购买，刷新」：同步官网权益 → 重拉广场 → 确认已购则自动接上安装。
- 购买链接走 `openExternalUrl`（系统浏览器；支付要用已登录的浏览器会话），且**不用 registry 的 `homepage`**——官网没有 `/zh/plugins/{id}` 路由，那个默认值会 404。

## 降级与兼容

1. registry 缺 `priceCents` → 归一为 0 = 免费（旧格式/旧 registry 上不能把免费项锁住）；
2. 安装前查元数据失败（列表不可达）→ 按免费继续，真付费项由官网 402 兜底；
3. 免费项不带 `Authorization`、不多一次判定；
4. 官网不可达时广场沿用既有「在线广场不可用：{原因}」区块内提示，不空白、不影响本地已装项。

## 测试

- 新增 11 条单测：旧格式兼容（无 priceCents 视为免费）、`purchased` 标注与命名空间隔离、未连账户拦截且不发请求、402 翻译含条目名与价格、免费项不带鉴权头、列表不可达降级。
- `mvn test`（JDK 21）852 全绿，基线 841。
- 前端 `build:h5` + `check:emits` 通过。

同 PR 更新了 `.claude/agents/plugin-marketplace.md`（付费项契约、命名空间、降级三条、购买外链地雷）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)