### PR TITLE
release v0.10.0：商业化改造全线

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
自 v0.9.4 起累计 12 个提交，本版是商业化改造的完整落地。

## 本版亮点

**去登录与解锁门**（#247）：桌面端不再有登录页，启动即工作区。首次启动用邀请码解锁（GitHub 公开试用码离线验签，或粘贴官网账户 Key 直达正式版）。团队服务器部署的登录流程原样保留。同时补上 CSRF 防护（去登录移除了自定义头这道事实防线，改为 Origin 硬校验 + 代理痕迹拒绝）。

**账户与平台 AI 计费**（#248）：设置页新增「账户与用量」，粘贴账户 Key 即连接。新增「AI Workdeck 云端」提供商，用官网签发的专属 OpenRouter key 直连，额度与用量在面板可见。BYOK 路径不受影响。

**本地小功能免费额度与解锁**（#249）：无线剪贴板免费回溯 20 条 / 3 天，文件缓存区免费 20 个文件 / 500MB。超额只隐藏或拦新增，绝不删除既有数据；付费解锁后可自选存储位置（迁移失败整体回滚）。

**本机身份选择**（#250）：多个历史账号都有数据时不再静默回落 admin，改为启动时列出候选（含项目数与文件数）由用户选定，选定后记住，设置页可切换。

**插件广场付费项**（#251）：列表与详情显示价格与已购状态，付费项引导至官网购买，已购后凭账户 Key 安装。免费项流程不变。

**协作 UX 律师化**（#252）：团队服务器改称团队案件库、共享项目改称共享案卷、上传下载改称交稿与取回最新稿、成员改称案件参与人。协作入口从设置页深处上浮到项目界面，常驻同步状态。冲突三选一改用律师语言说明后果（并修正了「仅冲突处」的错误表述——文档类合并的裁决粒度是整份文件）。

**文档**（#253 #255）：README 增加获取与解锁章节并公开试用码；新增授权与计费领域文档；Spec 补实现偏差记录。

## 发版前验证（本机全量）

| 套件 | 结果 |
|---|---|
| 后端 mvn test（JDK 21） | 858 通过 / 0 失败 / 2 跳过 |
| app-e2e | 104 步通过 / 0 失败 / 异常信号 0 条 |
| lowa-e2e | 169 断言通过 / 0 失败（19 组） |
| desktop-e2e | 保存链路全通（免登直达、引擎 boot、自动保存、下载验字节） |

隔离栈：9797 后端 + 独立 user.home/H2/cwd + 5174 dev server，用户常驻的 9696 全程未占用。

## 升级注意

- 老安装首次启动会出现工作区选择页，选择数据所在的账号即可，选定后不再询问。
- 桌面端不再需要账号密码；原有数据不迁移、不改归属。

Generated with Claude Code