### PR TITLE
AI harness 可靠性加固 + 桌面后端单端口 5269（冲突自动降级）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -24,7 +24,7 @@ description: AI 对话编排领域。任务涉及编排器 AgentOrchestrator、T
 **工具注册与执行**
 - `service/ai/ToolRegistry.java`（428 行）— @PostConstruct 扫 AgentToolComponent 的 @Tool；getAllSpecifications / execute（反射+服务端强注入 projectId/conversationId/userId+容错类型转换）/ resolve；别名表 TOOL_NAME_ALIASES/ARG_ALIASES/LEGACY_DEFAULTS。**插件启停过滤也在这三处消费点**。
 - `service/ai/XmlToolCallParser.java` — XML <tool_code> 协议兜底（位置参数按签名映射为命名参数，PR#193）。
-- tools/：FileTools(9，含 extract_file_text——Tika/PDFBox 全文抽取，Word/Excel/PDF 均可读；write_docx 支持可选 parentFolderId 落指定文件夹)、LegalTools(5)、WebTools(2)、PythonTools(1)、TodoTools(1)、SubAgentTools(1，**@Lazy 防启动死环** PR#98)、EvidenceTools(1)、MemoryTools(8)、DocumentEditTools(32)、CheckpointTools(1)、PptxTools(13，含 pptx_inspect_format/pptx_apply_format 走 pptx-service 自有端点 /api/pptx/*)、PdfTools(7，PDFBox 层：pdf_list_files/pdf_inspect/pdf_highlight/pdf_annotate/pdf_redact/pdf_replace_text/pdf_to_word，实现在 PdfEditService；定位类限文本型未加密 PDF、靠引用原文，fileId 必须从 pdf_list_files 拿——doc_list_project_files 不列 PDF、search_project_files 不带 ID。pdf_to_word 三路由：文本型走 pptx-service /api/pdf/to-docx 版式级(pdf2docx)→失败回退 Java 结构级提取；扫描件走 /api/pdf/ocr-markdown 本地 MinerU OCR，不用第三方云 OCR)。PptxEditTools 已删（7 个工具全走编辑器桥 ppt_* 命令，前端明确拒绝，死路径；pptx_smart_modify/pptx_get_page_screenshot 同因服务端点不存在下线）。
+- tools/：FileTools(12，含 create_folder/rename_project_file/move_project_file 三个 DB 感知文件树原语——直通 ProjectFileService，与前端右键菜单同路径；move_file 已停用只回错误引导；含 extract_file_text——Tika/PDFBox 全文抽取，Word/Excel/PDF 均可读；write_docx 支持可选 parentFolderId 落指定文件夹)、LegalTools(5)、WebTools(2)、PythonTools(1)、TodoTools(1)、SubAgentTools(1，**@Lazy 防启动死环** PR#98)、EvidenceTools(1)、MemoryTools(8)、DocumentEditTools(32)、CheckpointTools(1)、PptxTools(13，含 pptx_inspect_format/pptx_apply_format 走 pptx-service 自有端点 /api/pptx/*)、PdfTools(7，PDFBox 层：pdf_list_files/pdf_inspect/pdf_highlight/pdf_annotate/pdf_redact/pdf_replace_text/pdf_to_word，实现在 PdfEditService；定位类限文本型未加密 PDF、靠引用原文，fileId 必须从 pdf_list_files 拿——doc_list_project_files 不列 PDF、search_project_files 不带 ID。pdf_to_word 三路由：文本型走 pptx-service /api/pdf/to-docx 版式级(pdf2docx)→失败回退 Java 结构级提取；扫描件走 /api/pdf/ocr-markdown 本地 MinerU OCR，不用第三方云 OCR)。PptxEditTools 已删（7 个工具全走编辑器桥 ppt_* 命令，前端明确拒绝，死路径；pptx_smart_modify/pptx_get_page_screenshot 同因服务端点不存在下线）。
 
 **记忆/证据/MCP/子 Agent**
 - memory/：MemoryPipelineService（轮次结束异步触发写侧管线）、MemoryManager（检索）、AgenticRetriever、MemCellExtractor、ProjectMemoryExtractor、MemoryEvidenceFormatter（证据账本：时间锚点/来源/更新信号，PR#155）。记忆五作用域 + 拟人化排序（重要性×衰减×随机）。
@@ -33,7 +33,17 @@ description: AI 对话编排领域。任务涉及编排器 AgentOrchestrator、T
 - subagent/：SubAgentService（dispatch_subtask，发 subtask_progress）。
 
 **SSE**
-- `service/ai/SseEmitterService.java` — 连接池（cid→SseEmitter，超时 30 分钟，建连发 connected）。**所有事件唯一出口**。生产者：Orchestrator、StreamHandler、Controller、TodoListService(plan_update)、BackgroundTaskService(background_task_*/heartbeat/task_progress)、SubAgentService、EditorBridgeService。
+- `service/ai/SseEmitterService.java` — 连接池（cid→SseEmitter，超时 30 分钟，建连发 connected）。**所有事件唯一出口**。生产者：Orchestrator、StreamHandler、Controller、TodoListService(plan_update)、BackgroundTaskService(background_task_*/heartbeat/task_progress)、SubAgentService、EditorBridgeService。**15s 心跳广播**（@PostConstruct 调度器，穿透代理空闲回收 + 前端判活依据）；同 ID 重连会 complete 旧 emitter，回调移除一律用两参 remove(id, emitter) 防摘掉新连接。
+
+**可靠性层（2026-08 harness 加固，治"跑一半停了"）**
+- LLM timeout 600s（application.yml open-router.timeout；0.36 的单值=OkHttp callTimeout 整通墙钟上限，不是空闲超时）。
+- `AgentStreamHandler`：终态幂等（AtomicBoolean terminated）+ **无活动看门狗** armInactivityWatchdog(180s)——流停滞主动走 onError。
+- `AgentOrchestrator.setOnError`：瞬时错误（429/5xx/超时/断连，见 isTransientLlmError）且**零 token 已流出**时按 8/16/32s 指数退避重放本轮（RunGuard.llmRetries，成功轮清零）；否则 handleStreamErrorTerminal。
+- 截断 `<tool_code>`（有开无闭）不再静默正常收尾：回喂纠正提示重试，最多 2 轮（RunGuard.malformedToolRounds）。
+- `ToolResult.success()` 除 "Error" 前缀外还识别 `{"error"...}` JSON 形态（编辑器桥超时曾被判 SUCCESS 致绿勾空转 30 步）；工具参数 JSON 解析失败返回可行动错误回喂模型，不再静默空参硬跑。
+- connect 端点：run_state=RUNNING 时**无条件**发 state_recovery（哪怕快照为空）——前端靠它重建气泡指针，否则终态事件被守卫吞掉、isStreaming 永久锁死。
+- 前端 `useAgentStream`：心跳 45s 无字节判死 + 指数退避自动重连（1s→30s 封顶）+ online/visibilitychange 钩子（模块级单例，防页面栈多实例重复订阅）；bubble_end/error/cancelled 在气泡指针为 null 时也解锁 isStreaming；sendMessage 防重入有 toast 提示。
+- 线程池：`config/AsyncExecutorConfig.java` 显式 taskExecutor(16/32/队列200) + memoryExecutor(2/4)——MemoryPipelineService 的同步 LLM 调用已隔离，别再挂回 taskExecutor。
 
 **前端消费**
 - `frontend/src/composables/useAgentStream.js`（1233 行）— SSE 核心：connectSSE（fetch+ReadableStream，非 EventSource）、sendMessage、abort、handleEvent（~:352 分派）、handleTag/processTextDelta（XML 标签驱动气泡组装）、handleStateRecovery。

--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -35,6 +35,12 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 
 每日全量 QA：`scripts/qa-nightly.sh`（crontab，跑在 ~/aiworkdeck-qa/repo 专用克隆，报告 ~/aiworkdeck-qa/reports/，失败 gh 开 issue 标签 qa-nightly，引擎取自已安装 app）。
 
+## 端口体系（2026-08 起）
+
+- **打包态桌面后端：5269 → 5369 → 5169 → 随机**（`desktop/main/services/backend-service.js` allocateBackendPort：真实 bind 探测；被占时先探 `/api/admin/wizard` 验明是否自家后端——是则复用，否则降级下一个。service-manager 的 verifyReuse/reallocatePort 契约即为此加）。实际端口经 BrowserWindow additionalArguments → preload → `window.checkbaDesktop.apiBaseUrl` 注入渲染层，`frontend/src/services/api.js` 最优先读它。
+- **dev 态后端仍 9696**：restart-backend.sh / e2e / CI 全部不变；`CHECKBA_BACKEND_PORT` 可显式覆盖两种模式。
+- pptx/mineru/kokoro 打包态是动态回环端口（由后端内部转发，前端不可见）；编辑器静态服务器 47613 因 COOP/COEP 跨源隔离必须独立源，勿并入。
+
 ## 本地开发启动
 
 - 一键：`./restart-all.sh`（Docker 服务 + 后端 + 前端 + 桌面）。

--- a/backend/src/main/java/com/checkba/config/AsyncExecutorConfig.java
+++ b/backend/src/main/java/com/checkba/config/AsyncExecutorConfig.java
@@ -1,0 +1,53 @@
+package com.checkba.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * 显式异步线程池配置（2026-08 harness 加固 F-08）。
+ *
+ * 背景：此前全仓库没有任何 Executor 配置，@Async("taskExecutor") 落到 Spring Boot
+ * 默认池——核心 8 / 队列无界。无界队列意味着 max-size 永不生效、拒绝策略永不触发：
+ * 编排循环、记忆管线（同步阻塞 LLM 调用，一次可占几十秒）、云同步三方共用 8 个线程，
+ * 8 个会话同时收尾即打满，之后的新消息在队列里无限期排队且用户毫无提示
+ * （表现为"点了发送、HTTP 200、SSE 上什么都不来"）。
+ *
+ * 现拆两个池：
+ * - taskExecutor：编排循环 + 云同步等交互路径，核心 16 / 最大 32 / 有界队列 200。
+ *   队列打满走默认 AbortPolicy——异常会传回调用方而不是静默排队（单用户桌面场景
+ *   基本不可能触顶，触顶说明有泄漏，宁可炸出来）。
+ * - memoryExecutor：记忆写侧管线专用，慢且非交互，隔离出去防止拖垮交互路径。
+ *
+ * 注意：自定义任何 Executor bean 都会让 Boot 的 TaskExecutionAutoConfiguration 退避，
+ * 所以 taskExecutor 必须在这里显式声明（同时挂 applicationTaskExecutor 别名，
+ * 供 Spring MVC 异步请求等框架内部使用方解析）。
+ */
+@Configuration
+public class AsyncExecutorConfig {
+
+    @Bean(name = {"taskExecutor", "applicationTaskExecutor"})
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(16);
+        executor.setMaxPoolSize(32);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("awd-async-");
+        executor.setWaitForTasksToCompleteOnShutdown(false);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean("memoryExecutor")
+    public ThreadPoolTaskExecutor memoryExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("awd-memory-");
+        // 记忆管线丢一两条不致命，进程退出不等它
+        executor.setWaitForTasksToCompleteOnShutdown(false);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -90,6 +90,14 @@ public class AiAgentController {
         
         // Check for active stream recovery
         String snapshot = agentOrchestrator.getRecoverySnapshot(conversationId);
+        // RUNNING 但快照为空（上下文组装中/首 token 未到/纯 function-calling 轮）也必须发
+        // state_recovery：前端靠它重建气泡指针，否则后续 text_delta 乃至 bubble_end 全被
+        // 空指针守卫丢弃，isStreaming 永久锁死（F-06 确定性 hang）
+        if (snapshot == null
+                && com.checkba.service.ai.AgentRunStateService.RunStatus.RUNNING.name()
+                        .equals(agentRunStateService.statusName(conversationId))) {
+            snapshot = "";
+        }
         if (snapshot != null) {
             log.info("Recovering active stream for conversation: {} ({} chars)", conversationId, snapshot.length());
             // Send recovery event immediately after connection established

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -40,6 +40,19 @@ public class AgentOrchestrator {
     // 工具连续失败达到该次数后，向模型注入强提示要求收敛
     private static final int CONSECUTIVE_FAILURE_NUDGE = 3;
 
+    // LLM 瞬时错误（429/5xx/超时/断连）自动重试：指数退避 8/16/32s，仅在本轮
+    // 尚未流出任何 token 时重放（对话状态未被污染，重放安全且用户无感知重复内容）
+    private static final int MAX_LLM_RETRIES = 3;
+    private static final int LLM_RETRY_BASE_SECONDS = 8;
+    // 流无活动看门狗：超过该秒数没有任何 token 到达即判定本轮停滞（配合 timeout 调大后的兜底）
+    private static final int STREAM_INACTIVITY_TIMEOUT_SECONDS = 180;
+    private static final java.util.concurrent.ScheduledExecutorService LLM_RETRY_SCHEDULER =
+            java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "llm-retry-scheduler");
+                t.setDaemon(true);
+                return t;
+            });
+
     /**
      * 单次 Agent 运行的循环守卫状态（随递归传递）：
      * 重复调用检测 + 连续失败计数，防止模型原地打转耗尽步数预算。
@@ -48,6 +61,10 @@ public class AgentOrchestrator {
         String lastCallSignature;
         int repeatCount;
         int consecutiveFailures;
+        // 本轮 LLM 调用的瞬时错误重试次数（每个成功完成的轮次清零）
+        int llmRetries;
+        // 截断/未闭合 <tool_code> 的纠正轮次数（防纠正本身进入死循环）
+        int malformedToolRounds;
         // 当前活跃文档 ID（来自 activeContext 或 doc_open_file），用于修改前自动创建检查点
         Long activeFileId;
         // 活跃文档名（仅用于给模型的反馈文案）
@@ -468,6 +485,8 @@ public class AgentOrchestrator {
         // Callback for Loop
         handler.setOnComplete(response -> {
           try {
+            // 本轮成功完成：清零瞬时错误重试预算（重试额度按轮计，不跨轮累积）
+            guard.llmRetries = 0;
             // Unconditionally turn off streaming mode when generation ends
             boolean wasStreaming = editorBridgeService.isStreamingMode(conversationId);
             editorBridgeService.setStreamingMode(conversationId, false);
@@ -645,6 +664,26 @@ public class AgentOrchestrator {
                 }
             }
 
+            // 2.5 截断的工具调用（F-10）：输出里有 <tool_code> 却没有闭合标签——多为
+            // max_tokens/上游截断，解析器提不出任何调用。此前会落到"正常收尾"静默结束，
+            // 任务做一半、无错误提示、无继续按钮。这里回喂提示让模型重发，最多纠正 2 轮。
+            if (agentMode != AgentMode.ASK
+                    && content.contains("<tool_code>") && !content.contains("</tool_code>")) {
+                if (guard.malformedToolRounds < 2) {
+                    guard.malformedToolRounds++;
+                    log.warn("Truncated tool_code detected for {} (correction round {}), asking model to re-emit",
+                            conversationId, guard.malformedToolRounds);
+                    messages.add(dev.langchain4j.data.message.UserMessage.from(
+                            "[系统提醒] 你上一条输出中的 <tool_code> 标签未闭合（内容可能被截断），"
+                            + "该工具调用没有被执行。请重新、完整地输出这次工具调用；"
+                            + "若任务其实已完成，请直接输出最终总结。"));
+                    runLoop(model, messages, conversationId, projectId, userId, modelId,
+                            depth + 1, executionLog, agentMode, guard);
+                    return;
+                }
+                log.warn("Truncated tool_code persisted after corrections for {}, finishing normally", conversationId);
+            }
+
             // 3. Check for Artifacts
             // - Task List: Do NOT stop loop anymore (User Requirement). Backend maintains it or just logs it.
             // - Implementation Plan: STOP LOOP for approval.
@@ -784,25 +823,38 @@ public class AgentOrchestrator {
           }
         });
 
-        // 流式出错时的清理：关闭 emitter + 复位状态，避免 SSE 连接挂到超时、前端永久加载
+        // 流式出错处置：瞬时错误且零 token 已流出 → 指数退避自动重试本轮；
+        // 否则终态清理（关 emitter + 复位状态，避免 SSE 挂到超时、前端永久加载）
         handler.setOnError(err -> {
-            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
-            boolean wasStreamingOnError = editorBridgeService.isStreamingMode(conversationId);
-            editorBridgeService.setStreamingMode(conversationId, false);
-            // 出错也要让 worker 收尾（否则 markdown 状态机残留半行/半张表），须在 close 之前发
-            if (wasStreamingOnError) {
-                sseEmitterService.send(conversationId, "doc_stream_end", java.util.Map.of("status", "error"));
+            boolean retryable = !handler.hasStreamedTokens()
+                    && guard.llmRetries < MAX_LLM_RETRIES
+                    && isTransientLlmError(err)
+                    && !isCancelled(conversationId);
+            if (retryable) {
+                int attempt = ++guard.llmRetries;
+                long delaySec = (long) LLM_RETRY_BASE_SECONDS << (attempt - 1); // 8/16/32s
+                log.warn("Transient LLM error for {} (attempt {}/{}), retrying in {}s: {}",
+                        conversationId, attempt, MAX_LLM_RETRIES, delaySec, String.valueOf(err));
+                sendTextDelta(conversationId, String.format(
+                        "\n\n> 模型服务暂时不可用，%d 秒后自动重试（第 %d/%d 次）…\n\n",
+                        delaySec, attempt, MAX_LLM_RETRIES));
+                LLM_RETRY_SCHEDULER.schedule(() -> {
+                    try {
+                        // 同 depth 重放本轮：messages 只在 onComplete 里被追加，失败轮未污染上下文
+                        runLoop(model, messages, conversationId, projectId, userId, modelId,
+                                depth, executionLog, agentMode, guard);
+                    } catch (Exception retryEx) {
+                        log.error("Retry runLoop failed for {}", conversationId, retryEx);
+                        handleStreamErrorTerminal(conversationId, projectId, userId, retryEx);
+                    }
+                }, delaySec, java.util.concurrent.TimeUnit.SECONDS);
+                return;
             }
-            // 保存已生成的部分内容，避免"当时看到了回复、历史里却没有"
-            StringBuilder sb = activeStreamContent.get(conversationId);
-            String partialContent = sb != null ? sb.toString() : "";
-            if (!partialContent.isEmpty()) {
-                saveAssistantMessage(conversationId, projectId, userId, partialContent + "\n\n[生成出错，已中断]");
-            }
-            sseEmitterService.close(conversationId);
-            clearCancelledState(conversationId);
-            editorBridgeService.clearCurrentConversationId();
+            handleStreamErrorTerminal(conversationId, projectId, userId, err);
         });
+
+        // 无活动看门狗：timeout 调大后，"流悄悄停了但不回调"的场景由它兜底终止本轮
+        handler.armInactivityWatchdog(STREAM_INACTIVITY_TIMEOUT_SECONDS);
 
         // Execute Generation with Tools
         // Ask 模式：不传递工具，禁止工具调用
@@ -815,6 +867,63 @@ public class AgentOrchestrator {
             List<ToolSpecification> allTools = skillRouter.visibleTools(conversationId, toolRegistry.getAllSpecifications());
             model.generate(messages, allTools, handler);
         }
+    }
+
+    /**
+     * 流式错误的终态处置（重试预算耗尽 / 不可重试错误 / 已流出部分内容）：
+     * 发 error 事件、保存部分内容、关流、复位状态。原 setOnError 内联逻辑提取而来。
+     */
+    private void handleStreamErrorTerminal(String conversationId, String projectId, Long userId, Throwable err) {
+        sseEmitterService.send(conversationId, "error", "Stream Error: " + err.getMessage());
+        agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
+        boolean wasStreamingOnError = editorBridgeService.isStreamingMode(conversationId);
+        editorBridgeService.setStreamingMode(conversationId, false);
+        // 出错也要让 worker 收尾（否则 markdown 状态机残留半行/半张表），须在 close 之前发
+        if (wasStreamingOnError) {
+            sseEmitterService.send(conversationId, "doc_stream_end", java.util.Map.of("status", "error"));
+        }
+        // 保存已生成的部分内容，避免"当时看到了回复、历史里却没有"
+        StringBuilder sb = activeStreamContent.get(conversationId);
+        String partialContent = sb != null ? sb.toString() : "";
+        if (!partialContent.isEmpty()) {
+            saveAssistantMessage(conversationId, projectId, userId, partialContent + "\n\n[生成出错，已中断]");
+        }
+        sseEmitterService.close(conversationId);
+        clearCancelledState(conversationId);
+        editorBridgeService.clearCurrentConversationId();
+    }
+
+    /**
+     * 瞬时错误分类（对标 OpenHands RetryMixin）：限流/服务端错误/超时/断连可重试，
+     * 4xx 参数与鉴权类错误不可重试（重放也不会好，且可能重复扣费探测）。
+     */
+    static boolean isTransientLlmError(Throwable err) {
+        for (Throwable t = err; t != null; t = (t.getCause() == t ? null : t.getCause())) {
+            if (t instanceof java.net.SocketTimeoutException
+                    || t instanceof java.util.concurrent.TimeoutException
+                    || t instanceof java.net.ConnectException
+                    || t instanceof java.io.InterruptedIOException
+                    || t instanceof java.io.IOException) {
+                return true;
+            }
+            String msg = t.getMessage();
+            if (msg != null) {
+                String m = msg.toLowerCase(java.util.Locale.ROOT);
+                // 明确不可重试：客户端参数/鉴权错误
+                if (m.contains("status code: 400") || m.contains("status code: 401")
+                        || m.contains("status code: 403") || m.contains("status code: 404")) {
+                    return false;
+                }
+                if (m.contains("status code: 429") || m.contains("status code: 5")
+                        || m.contains("rate limit") || m.contains("overloaded")
+                        || m.contains("timeout") || m.contains("timed out")
+                        || m.contains("connection reset") || m.contains("stream was reset")
+                        || m.contains("unexpected end of stream") || m.contains("canceled")) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     // =================================================================================

--- a/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
@@ -29,6 +29,53 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
 
     private static final int MAX_BUFFER_SIZE = 50; // Buffer for XML tag detection
 
+    // ==================== 终态幂等 + 无活动看门狗（治"跑一半停了"F-01/F-03） ====================
+    // 终态只允许进入一次：看门狗超时与真实回调可能竞争，double-terminal 会重复关流/重复清理
+    private final java.util.concurrent.atomic.AtomicBoolean terminated =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+    // 是否已有 token 流出（重试决策依据：零 token 的失败轮可安全重放，不会给用户看重复内容）
+    private volatile boolean streamedAnyToken = false;
+    // 最近一次流活动时间（onNext 刷新），看门狗据此判定"流停滞"
+    private volatile long lastActivityNanos = System.nanoTime();
+    private volatile java.util.concurrent.ScheduledFuture<?> watchdogFuture;
+
+    // 守护线程调度器：进程退出不被它拖住；全局单线程足够（只做轻量检查）
+    private static final java.util.concurrent.ScheduledExecutorService WATCHDOG =
+            java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "llm-stream-watchdog");
+                t.setDaemon(true);
+                return t;
+            });
+
+    public boolean hasStreamedTokens() {
+        return streamedAnyToken;
+    }
+
+    /**
+     * 启动无活动看门狗：连续 inactivitySeconds 无任何 token 到达则主动以超时错误终止本轮
+     * （走 onError 路径，可被编排器的瞬时错误重试接住）。
+     * 背景：langchain4j 0.36 的单一 timeout 是整通调用墙钟上限；把它调大之后，
+     * "流悄悄断了但既不 onComplete 也不 onError"的场景需要这层兜底，否则会话永久 RUNNING。
+     */
+    public void armInactivityWatchdog(int inactivitySeconds) {
+        lastActivityNanos = System.nanoTime();
+        watchdogFuture = WATCHDOG.scheduleWithFixedDelay(() -> {
+            if (terminated.get()) return;
+            long idleSec = (System.nanoTime() - lastActivityNanos) / 1_000_000_000L;
+            if (idleSec >= inactivitySeconds) {
+                log.warn("Stream inactive for {}s (limit {}s) for {}, terminating round via watchdog",
+                        idleSec, inactivitySeconds, conversationId);
+                onError(new java.util.concurrent.TimeoutException(
+                        "流式响应停滞超过 " + inactivitySeconds + " 秒"));
+            }
+        }, 15, 15, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    private void cancelWatchdog() {
+        java.util.concurrent.ScheduledFuture<?> f = watchdogFuture;
+        if (f != null) f.cancel(false);
+    }
+
     public AgentStreamHandler(SseEmitterService sseEmitterService, String conversationId, TokenUsageService tokenUsageService, String projectId, Long userId, String modelId) {
         this.sseEmitterService = sseEmitterService;
         this.conversationId = conversationId;
@@ -53,6 +100,10 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
     @Override
     public void onNext(String token) {
         log.trace("Token for {}: [{}]", conversationId, token);
+        // 终态后到达的迟到 token 丢弃（看门狗已终止本轮时，底层流可能还在吐）
+        if (terminated.get()) return;
+        lastActivityNanos = System.nanoTime();
+        if (token != null && !token.isEmpty()) streamedAnyToken = true;
         if (token != null) {
             // Notify token callback for real-time state tracking
             if (onToken != null) {
@@ -407,6 +458,9 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
 
     @Override
     public void onComplete(Response<AiMessage> response) {
+        // 终态幂等：看门狗可能已抢先终止本轮
+        if (!terminated.compareAndSet(false, true)) return;
+        cancelWatchdog();
         // Flush remaining buffer
         if (buffer.length() > 0) {
             emitText(buffer.toString());
@@ -468,13 +522,18 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
 
     @Override
     public void onError(Throwable error) {
+        // 终态幂等：真实回调与看门狗超时可能竞争，只允许第一个进入
+        if (!terminated.compareAndSet(false, true)) return;
+        cancelWatchdog();
         log.error("Stream error for {}", conversationId, error);
-        sseEmitterService.send(conversationId, "error", "Stream Error: " + error.getMessage());
-        // 关键：出错时必须关闭 emitter 并清理编排器状态，否则 SSE 连接会一直挂到 30 分钟超时，
-        // 且 activeStreamContent / cancelledConversations 条目永不清理、前端永久显示加载态。
+        // 有编排器回调时把错误处置完全交给它：瞬时错误可能走自动重试，
+        // 此时不能先发 error 事件（前端会渲染"执行中断"），是否发由回调决定。
         if (onErrorCallback != null) {
             onErrorCallback.accept(error);
         } else {
+            // 无回调（单次响应）：保持旧行为——发 error 并关流，
+            // 否则 SSE 连接会挂到 30 分钟超时、前端永久显示加载态。
+            sseEmitterService.send(conversationId, "error", "Stream Error: " + error.getMessage());
             sseEmitterService.close(conversationId);
         }
     }

--- a/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
+++ b/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
@@ -20,6 +20,31 @@ public class SseEmitterService {
     // Key: conversationId (or sessionId) -> SseEmitter
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
+    // 心跳广播：15s 一次，双重作用——(a) 长工具执行期间通道零字节流动，企业网关/
+    // 代理的空闲回收窗口（常见 60~120s）会静默掐连接，心跳保活穿透；
+    // (b) 前端据 lastHeartbeat 判定连接死活，超时触发自动重连（F-04/F-05）。
+    private static final long HEARTBEAT_INTERVAL_SECONDS = 15;
+    private final java.util.concurrent.ScheduledExecutorService heartbeatScheduler =
+            java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "sse-heartbeat");
+                t.setDaemon(true);
+                return t;
+            });
+
+    @jakarta.annotation.PostConstruct
+    void startHeartbeat() {
+        heartbeatScheduler.scheduleWithFixedDelay(() -> {
+            for (String id : emitters.keySet()) {
+                send(id, "heartbeat", "{\"ts\":" + System.currentTimeMillis() + "}");
+            }
+        }, HEARTBEAT_INTERVAL_SECONDS, HEARTBEAT_INTERVAL_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    @jakarta.annotation.PreDestroy
+    void stopHeartbeat() {
+        heartbeatScheduler.shutdownNow();
+    }
+
     /**
      * 创建连接
      * @param connectionId 会话ID或用户ID
@@ -30,22 +55,29 @@ public class SseEmitterService {
         // Spring Boot 默认可能是 30s，这里设为 30分钟
         SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
 
+        // 两参 remove：只在映射仍指向本 emitter 时移除。同 ID 重连时旧 emitter 的
+        // complete 回调不能把刚放进去的新 emitter 一并摘掉
         emitter.onCompletion(() -> {
-            emitters.remove(connectionId);
+            emitters.remove(connectionId, emitter);
             log.debug("SSE connection completed: {}", connectionId);
         });
 
         emitter.onTimeout(() -> {
-            emitters.remove(connectionId);
+            emitters.remove(connectionId, emitter);
             log.debug("SSE connection timed out: {}", connectionId);
         });
 
         emitter.onError((e) -> {
-            emitters.remove(connectionId);
+            emitters.remove(connectionId, emitter);
             log.warn("SSE connection error: {}", connectionId, e);
         });
 
-        emitters.put(connectionId, emitter);
+        // 同 ID 重复建连（断线重连）：先 complete 旧 emitter 释放其 Tomcat 异步上下文，
+        // 否则旧连接悬空挂到 30 分钟超时才释放（F-12）
+        SseEmitter previous = emitters.put(connectionId, emitter);
+        if (previous != null) {
+            try { previous.complete(); } catch (Exception e) { /* 已失效，忽略 */ }
+        }
         log.info("SSE connection established: {}", connectionId);
         
         // Send immediate initial event to confirm connection
@@ -69,7 +101,7 @@ public class SseEmitterService {
                 // IOException：客户端断开；IllegalStateException：emitter 已 complete（与 close() 竞态）。
                 // 两种情况该 emitter 都已失效，一并丢弃，避免异常逃逸打断推事件的调用线程。
                 log.warn("Failed to send SSE event to {} ({}), removing emitter.", connectionId, e.getClass().getSimpleName());
-                emitters.remove(connectionId);
+                emitters.remove(connectionId, emitter);
             }
         } else {
             log.trace("Skipping SSE send. No emitter for {}", connectionId);

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -94,7 +94,14 @@ public class ToolRegistry {
     public record ToolResult(String output, RegisteredTool tool, boolean found) {
 
         public boolean success() {
-            return found && output != null && !output.startsWith("Error");
+            if (!found || output == null) return false;
+            String trimmed = output.stripLeading();
+            if (trimmed.startsWith("Error")) return false;
+            // 编辑器桥等工具的失败以 JSON 返回（如 {"error": "操作超时..."}）。
+            // 此前只认 "Error" 前缀，这类失败被判成 SUCCESS：失败熔断计数被清零、
+            // 前端显示绿勾、file_change 照发——模型一路"成功"空转到步数上限（F-09）。
+            String compact = trimmed.replace(" ", "").replace("\t", "");
+            return !compact.startsWith("{\"error\"");
         }
     }
 
@@ -262,7 +269,17 @@ public class ToolRegistry {
         }
 
         try {
-            cn.hutool.json.JSONObject args = parseArgs(argsJson);
+            cn.hutool.json.JSONObject args;
+            try {
+                args = parseArgs(argsJson);
+            } catch (IllegalArgumentException badArgs) {
+                // 参数 JSON 解析失败不能静默降级成空参执行（F-16）：工具会拿着一堆
+                // null/默认值跑出无意义结果甚至误改文档。返回可行动错误让模型自纠。
+                return new ToolResult("Error: tool arguments are not valid JSON. "
+                        + "Please re-emit the call to '" + resolvedName
+                        + "' with a well-formed JSON object of named arguments. Parse error: "
+                        + badArgs.getMessage(), tool, true);
+            }
             Object[] boundArgs = bindArguments(resolvedName, tool.method(), args, ctx);
             Object result = tool.method().invoke(tool.bean(), boundArgs);
             return new ToolResult(result != null ? result.toString() : "", tool, true);
@@ -288,9 +305,10 @@ public class ToolRegistry {
         try {
             return cn.hutool.json.JSONUtil.parseObj(argsJson);
         } catch (Exception e) {
-            log.warn("Failed to parse tool args as JSON, using empty args: {}",
+            log.warn("Failed to parse tool args as JSON: {}",
                     argsJson.length() > 200 ? argsJson.substring(0, 200) + "..." : argsJson);
-            return new cn.hutool.json.JSONObject();
+            // 交给 execute() 转成可行动的工具错误回喂模型，而不是空参硬跑（F-16）
+            throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
@@ -40,8 +40,10 @@ public class MemoryPipelineService {
 
     /**
      * 一轮对话（Agent 循环）完成后的记忆更新。异步执行，失败不影响对话主流程。
+     * 独立池：本方法同步阻塞调 LLM（摘要/MemCell 提取），一次可占几十秒，
+     * 放 taskExecutor 会与编排循环抢线程（F-08），故隔离到 memoryExecutor。
      */
-    @Async("taskExecutor")
+    @Async("memoryExecutor")
     public void onConversationTurnCompleted(String conversationId, String projectId,
                                             Long userId, List<ChatMessage> messages) {
         log.info("Memory pipeline triggered: conversationId={}, messageCount={}",

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -398,7 +398,8 @@ public class FileTools implements AgentToolComponent {
             
             return report.toString();
         } catch (Exception e) {
-             return "Scan failed: " + e.getMessage();
+             // "Error" 前缀是 ToolResult.success() 的失败判据，不能丢
+             return "Error: Scan failed: " + e.getMessage();
         }
     }
 
@@ -416,20 +417,74 @@ public class FileTools implements AgentToolComponent {
             @P("Source path") String sourcePath,
             @P("Destination path (new name or location)") String destPath
     ) {
-         log.info("Tool: move_file called {} -> {}", sourcePath, destPath);
-         try {
-             Path source = resolvePath(sourcePath);
-             Path dest = resolvePath(destPath);
-             
-             if (!Files.exists(source)) return "Error: Source not found.";
-             if (Files.exists(dest)) return "Error: Destination already exists.";
-             
-             Files.createDirectories(dest.getParent());
-             Files.move(source, dest, StandardCopyOption.ATOMIC_MOVE);
-             return "Successfully moved/renamed to: " + destPath;
-         } catch (Exception e) {
-             return "Error moving file: " + e.getMessage();
-         }
+         // 已停用（2026-08 harness 加固）：本工具只做物理 Files.move、不更新 project_file 表，
+         // 移动已注册文件后文件树仍显示旧位置、doc_open_file 会指向不存在的路径（净负资产）。
+         log.info("Tool: move_file called {} -> {} - DENIED (physical-only move is disabled)", sourcePath, destPath);
+         return "Error: move_file is disabled because it desyncs the project file tree. "
+                 + "Use move_project_file / rename_project_file instead "
+                 + "(look up fileId via doc_list_project_files).";
+    }
+
+    // ==================== 文件树管理原语（DB 感知：文件树/物理文件同步更新） ====================
+    // 治理"整理文件夹/重命名/移动"类诉求：此前没有任何 DB 感知的目录管理工具，
+    // 模型只能用物理 move_file 把文件树搞脱节。三个原语直通 ProjectFileService，
+    // 与前端文件树右键菜单同一条代码路径（同名校验/环检测/物理文件搬迁全部继承）。
+
+    /** 工具执行线程的真实用户；拿不到时退回 Agent 专户（与 write_docx 的口径一致）。 */
+    private Long toolUserId() {
+        Long uid = com.checkba.service.ai.context.ProjectContextHolder.getUserId();
+        return uid != null ? uid : AGENT_USER_ID;
+    }
+
+    @ToolMeta(displayName = "新建文件夹", category = "file", refreshFiles = true)
+    @Tool("Create a new folder in the project file tree. Returns the new folderId. " +
+            "Use parentFolderId to nest inside an existing folder (IDs from doc_list_project_files); omit for project root.")
+    public String create_folder(
+            @P("Folder name") String folderName,
+            @P("Project ID") Long projectId,
+            @P(value = "Parent folder ID (optional; omit for project root)", required = false) Long parentFolderId
+    ) {
+        log.info("Tool: create_folder '{}' parent={} project={}", folderName, parentFolderId, projectId);
+        try {
+            ProjectFile folder = projectFileService.createFolder(projectId, parentFolderId, folderName, toolUserId());
+            return "Successfully created folder '" + folder.getName() + "' (folderId=" + folder.getId() + ").";
+        } catch (Exception e) {
+            return "Error creating folder: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "重命名文件", category = "file", refreshFiles = true)
+    @Tool("Rename a project file or folder (file tree and storage stay in sync). " +
+            "Get the fileId from doc_list_project_files. For files, the original extension is preserved automatically.")
+    public String rename_project_file(
+            @P("File or folder ID") Long fileId,
+            @P("New name") String newName
+    ) {
+        log.info("Tool: rename_project_file {} -> '{}'", fileId, newName);
+        try {
+            ProjectFile renamed = projectFileService.rename(fileId, newName, toolUserId());
+            return "Successfully renamed to '" + renamed.getName() + "' (fileId=" + renamed.getId() + ").";
+        } catch (Exception e) {
+            return "Error renaming: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "移动文件", category = "file", refreshFiles = true)
+    @Tool("Move a project file or folder into another folder (file tree and storage stay in sync). " +
+            "targetFolderId comes from doc_list_project_files or create_folder; omit to move to project root. " +
+            "Moving a folder moves all its contents.")
+    public String move_project_file(
+            @P("File or folder ID to move") Long fileId,
+            @P(value = "Target folder ID (optional; omit for project root)", required = false) Long targetFolderId
+    ) {
+        log.info("Tool: move_project_file {} -> folder {}", fileId, targetFolderId);
+        try {
+            ProjectFile moved = projectFileService.move(fileId, targetFolderId, null, toolUserId());
+            return "Successfully moved '" + moved.getName() + "' to "
+                    + (targetFolderId == null ? "project root" : "folder " + targetFolderId) + ".";
+        } catch (Exception e) {
+            return "Error moving: " + e.getMessage();
+        }
     }
 
     // --- Helpers ---

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -46,7 +46,9 @@ ai:
       api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
       default-model: deepseek/deepseek-v4-flash
-      timeout: 120s
+      # 与 application.yml 同步：120s 的 OkHttp callTimeout 会掐断长流式轮次，
+      # 停滞检测由编排层看门狗负责
+      timeout: 600s
     ollama:
       base-url: ${OLLAMA_BASE_URL:http://localhost:11434}
       model-name: ${OLLAMA_MODEL_NAME:qwen3-vl:8b}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -117,7 +117,10 @@ ai:
       api-key: ${OPENROUTER_API_KEY:}
       base-url: https://openrouter.ai/api/v1
       default-model: deepseek/deepseek-v4-flash
-      timeout: 120s
+      # langchain4j 0.36 把这一个值同时灌进 OkHttp 的 callTimeout（整通调用墙钟上限，
+      # 含完整流式响应体）。120s 会把仍在稳定吐 token 的长轮次拦腰掐断（跑一半断的头号根因），
+      # 调大到 600s；"流真停了"的场景由 AgentStreamHandler 的无活动看门狗（180s）兜底。
+      timeout: 600s
   # AI 上下文与压缩配置（对应 AiContextProperties，以下均为默认值，可按需覆盖）
   context:
     # 上下文总 token 预算

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -274,12 +274,18 @@ function attachCopyListener(webContents, sourceLabel) {
 }
 
 function createMainWindow() {
+  // 后端实际端口（打包态默认 5269，冲突自动降级，见 backend-service.js 端口链）。
+  // 经 additionalArguments 同步注入 preload → window.checkbaDesktop.apiBaseUrl，
+  // 渲染层 api.js 优先读它，取代原先写死的 9696。
+  const backendPort = (services && services.ports && services.ports.backend)
+    || Number(process.env.CHECKBA_BACKEND_PORT || (app.isPackaged ? 5269 : 9696))
   mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
     icon: path.join(__dirname, '../../frontend/src/static/icon.png'),
     webPreferences: {
       preload: path.join(__dirname, '../preload/preload.js'),
+      additionalArguments: ['--checkba-api-base=http://127.0.0.1:' + backendPort],
       contextIsolation: true,
       nodeIntegration: false,
       // 允许跨域 Cookie（历史：为第三方在线编辑器 SameSite Cookie 而设；行为保留以兼容其它跨域资源）

--- a/desktop/main/services/backend-service.js
+++ b/desktop/main/services/backend-service.js
@@ -1,6 +1,63 @@
 const path = require('path')
 const fs = require('fs')
+const net = require('net')
+const http = require('http')
 const { spawn, execFileSync } = require('child_process')
+const { isPortOpen } = require('./service-manager')
+
+// 打包态后端端口链：默认 5269，被占则依次降级（5269 是 IANA 注册的 XMPP
+// 服务器互联口，桌面软件几乎不用；5369/5169 未注册）。dev 态保持 9696，
+// 与 restart-backend.sh / e2e / CI 的既有工作流一致。
+const DESKTOP_PORT_CHAIN = [5269, 5369, 5169]
+
+// 端口上监听的是不是我们自己的后端：探 GET /api/admin/wizard，
+// 该端点免鉴权、回环放行，返回体带 "initialized" 特征字段。
+// 用于防止把陌生进程（恰好占了链上端口）误当后端复用。
+function isOurBackend(port, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    const req = http.get(
+      { host: '127.0.0.1', port, path: '/api/admin/wizard', timeout: timeoutMs },
+      (res) => {
+        let body = ''
+        res.on('data', (c) => { if (body.length < 4096) body += c })
+        res.on('end', () => resolve(res.statusCode === 200 && body.includes('"initialized"')))
+      }
+    )
+    req.on('timeout', () => { req.destroy(); resolve(false) })
+    req.on('error', () => resolve(false))
+  })
+}
+
+// 能否真实绑定该端口（listen 后立刻释放；比 isPortOpen 的 connect 探测可靠——
+// 有些占用是 bind 而不 accept）。释放到 spawn 之间存在被抢窗口，与 findFreePort 同级，可接受。
+function canBind(port) {
+  return new Promise((resolve) => {
+    const s = net.createServer()
+    s.once('error', () => resolve(false))
+    s.listen(port, '127.0.0.1', () => s.close(() => resolve(true)))
+  })
+}
+
+async function allocateBackendPort(ctx) {
+  // 显式覆盖优先（e2e/脚本用）
+  if (process.env.CHECKBA_BACKEND_PORT) return Number(process.env.CHECKBA_BACKEND_PORT)
+  // dev 态维持 9696：复用 restart-backend.sh 起的后端，脚本/CI 不受影响
+  if (!ctx.packaged) return 9696
+  for (const cand of DESKTOP_PORT_CHAIN) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await isPortOpen(cand)) {
+      // 有人在听：是自己的后端（上次残留/多开实例）则复用，陌生进程则跳过
+      // eslint-disable-next-line no-await-in-loop
+      if (await isOurBackend(cand)) return cand
+      continue
+    }
+    // eslint-disable-next-line no-await-in-loop
+    if (await canBind(cand)) return cand
+  }
+  // 链上全被占：退随机空闲端口，保证应用仍能启动（渲染层经注入拿到实际端口）
+  const { findFreePort } = require('./service-manager')
+  return findFreePort()
+}
 
 function jarPath(ctx) {
   return ctx.packaged
@@ -79,7 +136,11 @@ function createBackendDescriptor() {
     name: 'backend',
     eager: true,
     logName: 'backend',
-    port: () => Number(process.env.CHECKBA_BACKEND_PORT || 9696),
+    port: (ctx) => allocateBackendPort(ctx),
+    // 占用端口的监听者必须验明正身才可复用（防"粘"到陌生进程）
+    verifyReuse: (ctx, port) => isOurBackend(port),
+    // 复用校验失败（分配后被抢）时重新走一遍分配链
+    reallocatePort: (ctx) => allocateBackendPort(ctx),
     startTimeoutMs: (ctx) => (ctx.packaged ? 60000 : 15000),
     prepare: async (ctx) => {
       if (fs.existsSync(jarPath(ctx))) return

--- a/desktop/main/services/service-manager.js
+++ b/desktop/main/services/service-manager.js
@@ -46,6 +46,8 @@ function findFreePort() {
  *   logName: string                    // 打包态日志文件名（<dataDir>/logs/<logName>.log）
  *   enabled?: (ctx) => boolean         // 缺省 true；false 则 start() 返回 {ok:false, disabled:true}
  *   port: (ctx) => number|Promise<number>   // 分配端口（可读 env、可 findFreePort）
+ *   verifyReuse?: (ctx, port) => Promise<boolean>  // 端口已被监听时验明是否自家服务；缺省视为是（旧语义）
+ *   reallocatePort?: (ctx) => Promise<number>      // verifyReuse 失败（端口被陌生进程占）时重新分配
  *   startTimeoutMs: (ctx) => number
  *   prepare?: (ctx) => Promise<void>   // spawn 前置（dev 构建 jar / 打包态跑 DB 迁移）
  *   commands: (ctx) => [{cmd, args, env, cwd}]           // 候选命令，按序轮试
@@ -94,13 +96,28 @@ class ServiceManager {
     const d = this.descriptors.get(name)
     if (!d) throw new Error(`unknown service: ${name}`)
     if (d.enabled && !d.enabled(this.ctx)) return { ok: false, disabled: true }
-    const port = this.ports[name]
+    let port = this.ports[name]
 
-    // 已有实例在跑：直接复用（与原 BackendManager 语义一致）
-    if (await isPortOpen(port)) return { ok: true, reused: true }
+    // 已有实例在跑：验明正身后复用（无 verifyReuse 的服务保持旧语义直接复用）
+    // 'reuse' = 自家服务在听 | 'foreign' = 陌生进程占用 | 'free' = 无人监听
+    const probe = async () => {
+      if (!(await isPortOpen(port))) return 'free'
+      if (!d.verifyReuse || (await d.verifyReuse(this.ctx, port))) return 'reuse'
+      return 'foreign'
+    }
+    let state = await probe()
+    if (state === 'foreign' && d.reallocatePort) {
+      port = await d.reallocatePort(this.ctx)
+      this.ports[name] = port
+      state = await probe()
+    }
+    if (state === 'reuse') return { ok: true, reused: true }
+    if (state === 'foreign') throw new Error(`${name} port ${port} 被未知进程占用`)
 
     if (d.prepare) await d.prepare(this.ctx)
-    if (await isPortOpen(port)) return { ok: true, reused: true }
+    const postPrepare = await probe()
+    if (postPrepare === 'reuse') return { ok: true, reused: true }
+    if (postPrepare === 'foreign') throw new Error(`${name} port ${port} 被未知进程占用`)
     if (this.procs.get(name)) await this.stop(name)
 
     const timeoutMs = d.startTimeoutMs(this.ctx)

--- a/desktop/preload/preload.js
+++ b/desktop/preload/preload.js
@@ -1,6 +1,12 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
+// 主进程经 additionalArguments 注入的后端地址（端口是启动时实际分配的，
+// 打包态默认 5269，冲突自动降级）。同步可读，供渲染层 api.js 首选。
+const apiBaseArg = process.argv.find((a) => a.startsWith('--checkba-api-base='))
+const apiBaseUrl = apiBaseArg ? apiBaseArg.slice('--checkba-api-base='.length) : null
+
 contextBridge.exposeInMainWorld('checkbaDesktop', {
+  apiBaseUrl,
   app: {
     onOpenInternal: (handler) => {
       const listener = (_evt, data) => handler && handler(data)

--- a/desktop/tests/service-manager.test.js
+++ b/desktop/tests/service-manager.test.js
@@ -69,6 +69,70 @@ test('reuses already-open port without spawning', async () => {
   }
 })
 
+test('verifyReuse=false triggers reallocatePort instead of reusing foreign process', async () => {
+  const http = require('http')
+  // 陌生进程占着首选端口
+  const foreign = http.createServer((req, res) => res.end('not ours'))
+  const occupied = await findFreePort()
+  await new Promise((r) => foreign.listen(occupied, '127.0.0.1', r))
+  try {
+    const mgr = makeManager()
+    mgr.register(fakeDescriptor({
+      port: async () => occupied,
+      verifyReuse: async () => false,
+      reallocatePort: async () => findFreePort()
+    }))
+    await mgr.allocatePorts()
+    const res = await mgr.start('fake')
+    assert.strictEqual(res.ok, true)
+    assert.strictEqual(res.reused, false)
+    assert.notStrictEqual(mgr.ports.fake, occupied)
+    await mgr.stopAll()
+  } finally {
+    foreign.close()
+  }
+})
+
+test('verifyReuse=true keeps old reuse semantics', async () => {
+  const http = require('http')
+  const server = http.createServer((req, res) => res.end('ok'))
+  const port = await findFreePort()
+  await new Promise((r) => server.listen(port, '127.0.0.1', r))
+  try {
+    const mgr = makeManager()
+    mgr.register(fakeDescriptor({ port: async () => port, verifyReuse: async () => true }))
+    await mgr.allocatePorts()
+    const res = await mgr.start('fake')
+    assert.strictEqual(res.reused, true)
+  } finally {
+    server.close()
+  }
+})
+
+test('backend allocator walks the 5269/5369/5169 chain past a foreign listener', async () => {
+  // 直接驱动 allocateBackendPort 的探测逻辑：占住 5269（若本机空闲），期望分配落到 5369
+  const net = require('net')
+  const { createBackendDescriptor } = require('../main/services/backend-service')
+  const d = createBackendDescriptor()
+  const holder = net.createServer()
+  const first = await new Promise((resolve) => {
+    holder.once('error', () => resolve(null)) // 5269 本机已被真实占用：跳过该断言前提
+    holder.listen(5269, '127.0.0.1', () => resolve(5269))
+  })
+  try {
+    const port = await d.port({ packaged: true })
+    if (first) {
+      // 5269 被占且不是我们的后端（无 /api/admin/wizard 响应）→ 应降级到 5369（或更后）
+      assert.notStrictEqual(port, 5269)
+      assert.ok([5369, 5169].includes(port) || port > 1024)
+    } else {
+      assert.ok([5269, 5369, 5169].includes(port) || port > 1024)
+    }
+  } finally {
+    holder.close()
+  }
+})
+
 test('falls through failed candidate to next command', async () => {
   const mgr = makeManager()
   mgr.register(fakeDescriptor({

--- a/docs/AI_HARNESS_GAP_ANALYSIS.md
+++ b/docs/AI_HARNESS_GAP_ANALYSIS.md
@@ -1,0 +1,46 @@
+# AI Harness 差距分析与加固记录（2026-08）
+
+对标对象：Nous Research hermes-agent、OpenHands（原 OpenDevin）、Claude Code / Agent SDK、LangGraph（durable execution）、smolagents。
+触发背景：用户反馈 AI 功能不稳定——"经常断了，或者跑一半就不跑了"；多样化诉求（整理文件夹/重命名/移动/做表格）覆盖不稳。
+
+## 一、"跑一半停了"的实证根因（按概率排序）
+
+代码审计在本仓库找到 16 个失败模式（F-01~F-16），与开源 harness 对标后确认四大根因：
+
+| # | 根因 | 证据 | 本轮修复 |
+|---|---|---|---|
+| 1 | **LLM 单轮 120s 硬超时**：langchain4j 0.36 把一个 timeout 灌进 OkHttp callTimeout（整通调用墙钟上限），长轮次即使 token 稳定在吐也会被第 120 秒掐断 | ChatModelFactory + application.yml `open-router.timeout` | 已修：timeout 600s + 流无活动看门狗 180s（AgentStreamHandler.armInactivityWatchdog） |
+| 2 | **流式调用零重试**：0.36 的流式模型结构上不支持 maxRetries，一次 429/5xx/断连整轮报废 | AgentOrchestrator onError 直接终局 | 已修：零 token 轮次的瞬时错误按 8/16/32s 指数退避重放本轮（对标 OpenHands RetryMixin），4xx 不重试 |
+| 3 | **编辑器桥失败被判成功**：`{"error":...}` 不匹配 "Error" 前缀启发式，编辑器超时/未打开时模型一路"绿勾"空转 30 步后 PAUSED | ToolRegistry.ToolResult.success() | 已修：success() 识别 JSON error 形态；scan_files 补 Error 前缀 |
+| 4 | **断线无自愈**：心跳生产者是死代码、前端零自动重连、重连窗口期快照缺失导致 isStreaming 永久锁死 | SseEmitterService / useAgentStream | 已修：SSE 层 15s 心跳广播 + 前端心跳超时判活/指数退避重连/online+visibilitychange 钩子 + RUNNING 无条件发 state_recovery + 终态事件穿透气泡守卫 |
+
+其余已修：截断的 `<tool_code>` 不再静默正常收尾（回喂纠正，最多 2 轮）；工具参数 JSON 解析失败不再静默空参硬跑；@Async 线程池显式配置（16/32/队列 200）+ 记忆管线隔离到独立池（此前默认池核心 8 + 无界队列，记忆管线的同步 LLM 调用可把交互路径整个堵死）；SSE 同 ID 重连不再悬空旧 emitter。
+
+## 二、工具覆盖缺口（"整理文件夹/重命名/移动/做表格"）
+
+行业结论（Claude Code Read/Write/Edit/Glob/Grep + OpenHands str_replace_editor+bash 殊途同归）：**十个以内的通用文件原语 + 兜底，胜过大量专用工具**。
+
+本轮补齐：
+- `create_folder` / `rename_project_file` / `move_project_file` —— DB 感知（直通 ProjectFileService，与文件树右键菜单同一条代码路径：同名校验/环检测/物理文件搬迁全部继承）。
+- 原 `move_file` 已停用：它只做物理 Files.move、不更新 project_file 表，移动已注册文件后文件树脱节（净负资产）。
+
+仍存在的缺口（后续排期）：
+- **Word 表格只有整表原语**（doc_insert_table/doc_format_table），改一格只能重建整张表；需要单元格级原语（读表/增删行列/改单元格/合并）。
+- 目录读取口径分散：list_files（物理）/doc_list_project_files（DB）/search_project_files（无 ID）/pdf_list_files 四五套，模型容易选错，宜合并或在描述里写清分工。
+
+## 三、与开源 harness 的剩余差距（按投入/收益排序的路线图）
+
+1. **run 事件溯源持久化 + 崩溃恢复**（中投入）——OpenHands 的核心设计：一切皆事件、append-only 日志、崩溃后按序重放即恢复。我们的 AgentRunStateService 是纯内存态，进程重启后半截 ASSISTANT 消息无"已中断"标记也无"继续"按钮。落点：SSE 事件同步 append 到 H2 + 重启后按日志重建。硬约束：续跑会重放最后一步，有副作用的工具需幂等标记。
+2. **provider 故障转移链**（低投入）——hermes-agent runtime_provider 模式：主通道连续失败自动切备选 (provider, model)；限流单列状态（OpenHands 把 RATE_LIMITED 与 ERROR 分开）。
+3. **上下文超限触发 compaction**（中投入）——长任务后半段 400/质量塌方的隐性根因。ContextCompressor 已存在，需要接上"超阈值自动摘要中段轮次"的触发器（对标 hermes context_compressor / Claude SDK auto-compaction）。
+4. **StuckDetector 先干预后熔断**——重复 action-observation 模式第一次注入提示打破循环，第二次才熔断；现有单槽 lastCallSignature 对 A/B 交替重复无感。
+5. **工具分组暴露**——hermes 按 28 个 toolset 场景裁剪；我们 80+ 工具全量暴露，选错率与上下文占用都受影响（SkillRouter 白名单是雏形，可推广到场景预设）。
+6. **长尾诉求进回放评测**——把"整理文件夹/批量重命名/做表格"失败案例固化进 ai-eval/cases，改工具描述跑评测（Anthropic 实证：微调描述即可显著提升）。
+7. **XML 兜底协议对齐 Hermes function-calling 格式**（`<tool_call>` JSON 体）——提高开源模型兼容性。
+8. **读 finishReason**——全链路目前不读 LENGTH/STOP，截断检测靠标签启发式；langchain4j 升级后应改为读结构化 finishReason。
+
+## 四、桌面端端口整合（同批落地）
+
+- 现状盘点：桌面端共 4 个受管服务（Java 后端、pptx、mineru、kokoro）+ 编辑器静态服务器。**前端只调后端一个端口**；三个 Python 服务打包态本就是动态回环端口、由后端内部转发，用户不可见——无需也不值得并端口（并入要新写 Spring 转发层 + SsrfGuard 豁免，零用户可见收益）。编辑器静态服务器因 COOP/COEP 跨源隔离（SharedArrayBuffer）必须独立源，不可合并。
+- 落地：打包态后端端口链 **5269 → 5369 → 5169 → 随机**（5269 是 IANA 注册的 XMPP 服务器互联口，桌面软件几乎不占；5369/5169 未注册；三个端口本机实测空闲）。真实 bind 探测 + 复用前身份验证（探 `/api/admin/wizard` 特征响应，防"粘"到陌生进程——旧逻辑端口有人听就直接当自己人）。实际端口经 additionalArguments → preload → `window.checkbaDesktop.apiBaseUrl` 注入渲染层，api.js 最优先读它。
+- dev 态维持 9696：restart-backend.sh / e2e / CI 工作流零改动；`CHECKBA_BACKEND_PORT` 环境变量仍可显式覆盖。

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -2,6 +2,24 @@ import { ref, reactive, nextTick } from 'vue'
 import { getApiBaseUrl, getConversationMetadata } from '@/services/api.js'
 import { getSessionId } from '@/utils/auth.js'
 
+// 网络恢复/页面回前台时触发重连的激活实例指针（模块级单例）。
+// 页面栈会多次实例化本 composable（PR#148 重复订阅地雷），window 监听只挂一次，
+// 回调经该指针分发到最近建连的实例。
+let activeNetworkRecoveryHook = null
+if (typeof window !== 'undefined' && !window.__awdSseNetworkHooks) {
+    window.__awdSseNetworkHooks = true
+    window.addEventListener('online', () => {
+        if (activeNetworkRecoveryHook) activeNetworkRecoveryHook('network-online')
+    })
+    if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible' && activeNetworkRecoveryHook) {
+                activeNetworkRecoveryHook('page-visible')
+            }
+        })
+    }
+}
+
 export function useAgentStream() {
     // STATE: List of all bubbles (history + active)
     const bubbles = ref([])
@@ -36,6 +54,49 @@ export function useAgentStream() {
     // Abort Controllers
     let sseAbortController = null
     let messageAbortController = null
+
+    // --- 断线自动重连状态（F-05）---
+    let reconnectAttempts = 0
+    let reconnectTimer = null
+    let heartbeatMonitor = null
+    let lastSseActivityAt = 0 // 任何 SSE 字节到达都刷新（后端心跳 15s 一跳兜底保活）
+    const HEARTBEAT_STALE_MS = 45000 // 连续 3 个心跳周期无任何字节判定连接已死
+
+    const stopHeartbeatMonitor = () => {
+        if (heartbeatMonitor) { clearInterval(heartbeatMonitor); heartbeatMonitor = null }
+    }
+
+    const startHeartbeatMonitor = () => {
+        stopHeartbeatMonitor()
+        heartbeatMonitor = setInterval(() => {
+            if (!isConnected.value) return
+            if (Date.now() - lastSseActivityAt > HEARTBEAT_STALE_MS) {
+                console.warn('[AgentStream] SSE 心跳超时，判定连接已死，强制断开并自动重连')
+                stopHeartbeatMonitor()
+                try { if (sseAbortController) sseAbortController.abort() } catch (e) { /* ignore */ }
+                scheduleReconnect('heartbeat-stale')
+            }
+        }, 10000)
+    }
+
+    // 指数退避自动重连：1s/2s/4s…封顶 30s；建连成功即清零。
+    // 重连后由后端 connect 端点推 run_state（+RUNNING 时的 state_recovery）恢复 UI 态。
+    const scheduleReconnect = (reason) => {
+        if (reconnectTimer) return
+        if (!currentConversationId.value) return
+        const delay = Math.min(30000, 1000 * Math.pow(2, reconnectAttempts))
+        reconnectAttempts++
+        console.warn(`[AgentStream] SSE 断开（${reason}），${delay}ms 后自动重连（第 ${reconnectAttempts} 次）`)
+        reconnectTimer = setTimeout(async () => {
+            reconnectTimer = null
+            if (isConnected.value || !currentConversationId.value) return
+            try {
+                await connectSSE(currentConversationId.value)
+            } catch (e) {
+                scheduleReconnect('retry-failed')
+            }
+        }, delay)
+    }
 
     // Parser State (Local to the current stream)
     let parserBuffer = ''
@@ -155,6 +216,13 @@ export function useAgentStream() {
                 if (!response.ok) throw new Error(`SSE Connection Failed: ${response.status}`)
 
                 isConnected.value = true
+                reconnectAttempts = 0
+                lastSseActivityAt = Date.now()
+                startHeartbeatMonitor()
+                // 网络恢复/回前台时经模块级单例回调触发本实例重连
+                activeNetworkRecoveryHook = (reason) => {
+                    if (!isConnected.value && currentConversationId.value) scheduleReconnect(reason)
+                }
                 resolve()
 
                 const reader = response.body.getReader()
@@ -168,6 +236,7 @@ export function useAgentStream() {
                     const chunk = decoder.decode(value, { stream: true })
                     // 调试日志：显示接收到的 chunk 时间戳
                     console.log('[SSE] Chunk received at:', new Date().toISOString(), 'size:', chunk.length)
+                    lastSseActivityAt = Date.now()
                     buffer += chunk
 
                     const lines = buffer.split(/\r?\n/)
@@ -202,12 +271,15 @@ export function useAgentStream() {
                 if (sseAbortController === myController) {
                     sseAbortController = null
                     isConnected.value = false
+                    stopHeartbeatMonitor()
                     // SSE 连接结束时（包括正常结束），确保状态正确
-                    if (isStreaming.value && currentAssistantBubble.value) {
-                        // 如果仍在流式状态但连接已结束，说明可能是意外断开
-                        console.warn('[AgentStream] SSE connection ended while still streaming')
-                        currentAssistantBubble.value.isStreaming = false
+                    if (isStreaming.value) {
+                        // 仍在流式状态但连接已结束 = 意外断开。后台 @Async 循环并不依赖
+                        // SSE，多半还在跑——自动重连续流（run_state/state_recovery 恢复气泡）。
+                        console.warn('[AgentStream] SSE connection ended while still streaming, scheduling reconnect')
+                        if (currentAssistantBubble.value) currentAssistantBubble.value.isStreaming = false
                         isStreaming.value = false
+                        scheduleReconnect('stream-ended')
                     }
                 }
             }
@@ -215,9 +287,15 @@ export function useAgentStream() {
     }
 
     const sendMessage = async ({ prompt, contentHtml = '', fileList = [], projectId, modelId = 'default', assistantId, mode = 'AGENT', activeContext = null, pinnedSkillId = '', _userImages = [], _userContextFiles = [] }) => {
-        // 防重入：流式进行中再触发发送（回车/连点）会产生重复气泡和并发请求
+        // 防重入：流式进行中再触发发送（回车/连点）会产生重复气泡和并发请求。
+        // 必须给用户可见反馈——静默吞掉就是"点了发送什么都没发生"（F-07）
         if (isStreaming.value) {
             console.warn('[AgentStream] sendMessage ignored: already streaming')
+            try {
+                if (typeof uni !== 'undefined' && uni.showToast) {
+                    uni.showToast({ title: 'AI 正在执行中，请等待完成或点击停止', icon: 'none' })
+                }
+            } catch (e) { /* ignore */ }
             return
         }
         // Clear file changes for new turn
@@ -398,7 +476,44 @@ export function useAgentStream() {
             return
         }
 
-        if (!currentAssistantBubble.value) return
+        // 心跳：与气泡无关（重连判活依据），必须在气泡守卫之前处理
+        if (evt === 'heartbeat') {
+            try {
+                const d = JSON.parse(dataStr)
+                lastHeartbeat.value = {
+                    source: d.source,
+                    conversationId: d.conversationId,
+                    taskId: d.taskId,
+                    currentOperation: d.currentOperation,
+                    timestamp: d.timestamp || d.ts || Date.now()
+                }
+            } catch (e) {
+                lastHeartbeat.value = { timestamp: Date.now() }
+            }
+            return
+        }
+
+        if (!currentAssistantBubble.value) {
+            // 终态事件不能因气泡指针缺失而丢弃：重连落在"RUNNING 但快照未建"窗口时
+            // 若把 bubble_end/error/cancelled 一并吞掉，isStreaming 永久锁死、输入框
+            // 永久禁用（F-06/F-07 确定性 hang）。这里至少要解锁全局状态。
+            if (evt === 'bubble_end' || evt === 'error' || evt === 'cancelled') {
+                isStreaming.value = false
+                try {
+                    const d = JSON.parse(dataStr || '{}')
+                    agentPaused.value = (evt === 'bubble_end' && d.status === 'paused')
+                        ? { reason: d.reason || '' } : null
+                    agentRunStatus.value = evt === 'error' ? 'ERROR'
+                        : evt === 'cancelled' ? 'CANCELLED'
+                        : d.status === 'paused' ? 'PAUSED'
+                        : d.status === 'awaiting_approval' ? 'AWAITING_APPROVAL' : 'FINISHED'
+                } catch (e) {
+                    agentPaused.value = null
+                    agentRunStatus.value = evt === 'error' ? 'ERROR' : 'FINISHED'
+                }
+            }
+            return
+        }
 
         if (evt === 'text_delta') {
             try {
@@ -606,21 +721,7 @@ export function useAgentStream() {
             }
         }
 
-        // Handle heartbeat
-        if (evt === 'heartbeat') {
-            try {
-                const d = JSON.parse(dataStr)
-                lastHeartbeat.value = {
-                    source: d.source, // 'LLM_LOOP' or 'PPTX_SERVICE'
-                    conversationId: d.conversationId,
-                    taskId: d.taskId,
-                    currentOperation: d.currentOperation,
-                    timestamp: d.timestamp || Date.now()
-                }
-            } catch (e) {
-                console.error('Failed to parse heartbeat', e)
-            }
-        }
+        // heartbeat 已在气泡守卫之前处理（见上）
 
         // Handle File Changes (Added/Modified)
         if (evt === 'file_change') {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -98,6 +98,20 @@ export function getApiBaseUrl() {
     return cachedApiBaseUrl;
   }
 
+  // 桌面壳注入的后端地址最优先：端口是主进程启动时实际分配的
+  // （打包态默认 5269，冲突自动降 5369/5169），不能再靠写死的常量猜
+  try {
+    const injected = typeof window !== 'undefined'
+      && window.checkbaDesktop && window.checkbaDesktop.apiBaseUrl;
+    if (injected) {
+      cachedApiBaseUrl = injected;
+      console.log('[API] 使用桌面壳注入的 API 地址:', cachedApiBaseUrl);
+      return cachedApiBaseUrl;
+    }
+  } catch (e) {
+    // ignore
+  }
+
   // 优先使用环境变量配置
   try {
     // eslint-disable-next-line no-undef

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -33,6 +33,9 @@ const NAMES = {
   scan_files: { zh: '扫描项目文件', en: 'Scan files' },
   delete_file: { zh: '删除文件', en: 'Delete file' },
   move_file: { zh: '移动文件', en: 'Move file' },
+  create_folder: { zh: '新建文件夹', en: 'Create folder' },
+  rename_project_file: { zh: '重命名文件', en: 'Rename file' },
+  move_project_file: { zh: '移动文件', en: 'Move file' },
   // 记忆
   save_memory: { zh: '保存记忆', en: 'Save memory' },
   query_memory: { zh: '检索记忆', en: 'Query memory' },


### PR DESCRIPTION
## 背景

用户反馈两件事：(1) AI 功能不稳定——经常断、跑一半停；(2) 桌面端后台服务太多、希望收敛到一个可预期端口（5269，冲突自动降 5369/5169）。

对标 hermes-agent（Nous Research）/ OpenHands / Claude Agent SDK / LangGraph 做了差距分析（全文见 `docs/AI_HARNESS_GAP_ANALYSIS.md`，含后续路线图），本 PR 落地全部低投入高收益项。

## "跑一半停了"的四大实证根因与修复

| 根因 | 修复 |
|---|---|
| LLM 单轮 120s 硬超时（langchain4j 0.36 单值=OkHttp callTimeout 整通墙钟上限，token 还在吐照样掐） | timeout 600s + AgentStreamHandler 180s 无活动看门狗兜底（终态幂等，看门狗与真实回调竞争安全） |
| 流式调用零重试，一次 429/5xx/断连整轮报废 | 零 token 轮次按 8/16/32s 指数退避重放本轮（对标 OpenHands RetryMixin），4xx 不重试，成功轮清零预算 |
| 编辑器桥超时 `{"error"}` 被判 SUCCESS——绿勾空转 30 步 | ToolResult.success() 识别 JSON error 形态；参数解析失败回喂可行动错误（不再空参硬跑）；截断 `<tool_code>` 回喂纠正（最多 2 轮）而非静默正常收尾 |
| 断线无自愈：心跳是死代码、前端零自动重连、重连窗口快照缺失致 isStreaming 永久锁死 | SSE 15s 心跳广播；前端 45s 判死+指数退避重连+online/visibilitychange 钩子（模块级单例防 PR#148 重复订阅地雷）；RUNNING 无条件发 state_recovery；终态事件穿透气泡守卫；防重入加 toast |

另修：@Async 默认池（核心 8+无界队列）曾致记忆管线阻塞把交互路径整个堵死——显式 taskExecutor(16/32/200) + memoryExecutor 隔离；SSE 同 ID 重连悬空旧 emitter（两参 remove 防摘新连接）。

## 工具覆盖（整理文件夹/重命名/移动）

新增 DB 感知原语 `create_folder` / `rename_project_file` / `move_project_file`（直通 ProjectFileService，与文件树右键菜单同路径，继承同名校验/环检测/物理搬迁）；停用净负资产 `move_file`（只动物理文件不更新 project_file 表，移动后文件树脱节）。显示名已同步 toolDisplayNames.js。

## 端口整合

- 盘点结论：前端只调后端一个端口；pptx/mineru/kokoro 打包态本就是动态回环端口（后端内部转发，用户不可见），无需并入；编辑器 47613 因 COOP/COEP 跨源隔离必须独立源。
- 打包态后端：**5269 → 5369 → 5169 → 随机**（5269 为 IANA XMPP s2s 注册口、桌面软件几乎不占；三口本机实测空闲）。真实 bind 探测；被占先探 `/api/admin/wizard` 验身——自家后端复用，陌生进程降级（旧逻辑"有人听就当自己人"一并修掉）。
- 端口经 additionalArguments→preload→`window.checkbaDesktop.apiBaseUrl` 注入，api.js 最优先读取。
- **dev 态维持 9696**：restart 脚本/e2e/CI 零改动；`CHECKBA_BACKEND_PORT` 仍可覆盖。

## 验证

- backend `mvn -B test`（JDK 21）：858 过 0 挂（含 OrchestratorReplayEvalTest 回放评测 + DesktopContextSmokeTest）
- desktop `npm test`：17 过 0 挂（新增 verifyReuse/端口链 3 个用例）
- frontend `npm run check:emits` 过；build:h5 由本 PR CI 验证
- 领域文档已同步：`.claude/agents/ai-chat.md`（可靠性层）、`.claude/agents/eng-infra.md`（端口体系）

🤖 Generated with [Claude Code](https://claude.com/claude-code)