### PR TITLE
feat: 插件云后端加固——注册闸/限速/账户端点封堵/awdk 登录桥(server 侧)

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -74,10 +74,17 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `service/market/RegistryReply.java` — `httpGet(url, bearer)` 缝的返回值（状态码交调用方判，402 不在缝里抛）。
 - 前端 `frontend/src/utils/marketPricing.js` — 价格展示与状态判定的唯一出口。
 
+**server 模式加固（插件云后端，2026-08-06）**
+- `backend/src/main/java/com/checkba/service/AuthAbuseGuard.java` — 注册闸（`security.registration-mode: open|closed`，默认 open）+ 登录失败锁定（IP+用户名 5 次失败锁 10 分钟）+ 注册按 IP 限频（10/小时）。进程内内存计数，**多实例部署必须前置 nginx limit_req**；local-mode 全部旁路。
+- `backend/src/main/java/com/checkba/service/account/AwdkLoginService.java` — `POST /api/auth/awdk-login`（匿名端点，AuthController）：awdk_ Key 调官网 `/api/account/me` 实时校验 → `account_binding` 映射（键是官网稳定 `accountId`，**官网侧尚未实施该字段**，见本仓 `doc/desktop-contract.md`）→ 首登 `UserService.registerExternal` 建无密码用户（`awd_` 前缀）→ `DeviceTokenService.issue` 签发 awdt_。开关 `security.awdk-login-enabled` 默认 false。
+- `backend/src/main/java/com/checkba/service/account/MachineAccountGuard.java` — server 模式下 `AccountController` 全部端点与 `GET /api/entitlements` 仅 admin 可用（账户连接/权益缓存是机器级状态，普通租户 disconnect 一下全服平台 AI 通道就断）；local-mode 恒放行一字不动。
+- `model/entity/AccountBinding.java` + `repository/AccountBindingRepository.java` — 官网账户 → server 用户映射表；awdk_ 明文**不落库**（每次桥接重验官网）。
+
 **配置**
 - `security.local-mode`（`application-desktop.yml:36` 为 true，默认 false = 团队服务器模式）。
 - `ai.account.base-url`（`application.yml:97-98`，默认 `https://www.aiworkdeck.com`；**强制 https**，回环 http 例外供本地联调）。
 - `security.license.dir`（默认 `${user.home}/.aiworkdeck`）——license/account/entitlements/platform-ai-key/storage-location 五个状态文件都落这里。
+- `security.registration-mode`（默认 open）与 `security.awdk-login-enabled`(默认 false)——两者都只影响 server 模式；官方托管的插件云后端应配 closed + true。
 
 ## 核心契约
 
@@ -234,6 +241,14 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
     价格没查到时本机有 Key 就照带 Bearer（分不清「真免费」与「付费但价格没查到」，不带的话后者官网必 402，
     真已购用户会被反过来指控没付费）。`normalizePrice` 有 ¥100,000 上限——官网写超 int 范围的值会被截断成
     1215752191，原样展示就是 ¥12,157,521.91 的假价。
+12. **awdk 桥的映射键只认官网稳定 `accountId`**，缺失时 MALFORMED 拒绝，**绝不回落 username**
+    （可改名，改名后会凭空生出第二个 server 用户），也**绝不把官网用户名绑到本服务器已有的
+    同名账号**（等于账户接管）——首登一律新建 `awd_` 前缀用户。桥接建的是无密码账户：
+    口令列存 `UserService.EXTERNAL_ACCOUNT_MARK` 哨兵 + 随机料，`login()` 见前缀直接拒绝；
+    动密码兼容逻辑时别把这个分支删了（删了哨兵检查后还有随机料兜底，但两道都在才算安全）。
+13. **锁定拒绝不计入失败计数**。AuthController 里锁定检查（`checkLoginAttempt`）与凭据校验
+    分属两个 try：锁定期内的轮询若也 `recordLoginFailure` 会把锁无限续期。同理 awdk-login
+    只有官网明确 401/403（UNAUTHORIZED）才计失败，网络不可达不消耗尝试次数。
 
 ## 验证
 
@@ -245,7 +260,10 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
   `service/quota/StageQuotaServiceTest`、`service/storage/StorageLocationServiceTest`、
   `service/ClipboardQuotaTest`、`service/ai/PlatformUsageAccountantTest`、`service/ai/ChatModelFactoryTest`、
   `service/ai/{PluginMarketServiceTest, skill/SkillMarketServiceTest}`、
-  `config/LocalModeAccessFilterTest`、`config/LocalModeLoopbackGuardTest`。
+  `config/LocalModeAccessFilterTest`、`config/LocalModeLoopbackGuardTest`；
+  server 模式加固：`service/AuthAbuseGuardTest`、`service/account/AwdkLoginServiceTest`、
+  `service/account/MachineAccountGuardTest`、`controller/AuthControllerHardeningTest`、
+  `controller/AccountControllerMachineScopeTest`、`service/UserServiceTest`（无密码账户分支）。
 - 前端：`cd frontend && npm run check:emits` + `npm run build:h5`。
 - 端到端（同样在 `frontend/` 下跑）：`cd frontend && npm run test:app-e2e`
   （**J1 就是首启解锁门旅程**，用试用码解锁；其余旅程 local-mode 免登直达）。

--- a/backend/src/main/java/com/checkba/controller/AccountController.java
+++ b/backend/src/main/java/com/checkba/controller/AccountController.java
@@ -4,6 +4,7 @@ import com.checkba.model.entity.TokenUsage;
 import com.checkba.repository.TokenUsageRepository;
 import com.checkba.service.account.AccountException;
 import com.checkba.service.account.AccountService;
+import com.checkba.service.account.MachineAccountGuard;
 import com.checkba.service.ai.ChatModelFactory;
 import com.checkba.service.ai.PlatformAiChannel;
 import com.checkba.service.ai.PlatformUsageAccountant;
@@ -59,29 +60,31 @@ public class AccountController {
     private final PlatformUsageAccountant platformUsageAccountant;
     private final ChatModelFactory chatModelFactory;
     private final TokenUsageRepository tokenUsageRepository;
+    private final MachineAccountGuard machineAccountGuard;
 
     public AccountController(AccountService accountService,
                              EntitlementService entitlementService,
                              PlatformAiChannel platformAiChannel,
                              PlatformUsageAccountant platformUsageAccountant,
                              ChatModelFactory chatModelFactory,
-                             TokenUsageRepository tokenUsageRepository) {
+                             TokenUsageRepository tokenUsageRepository,
+                             MachineAccountGuard machineAccountGuard) {
         this.accountService = accountService;
         this.entitlementService = entitlementService;
         this.platformAiChannel = platformAiChannel;
         this.platformUsageAccountant = platformUsageAccountant;
         this.chatModelFactory = chatModelFactory;
         this.tokenUsageRepository = tokenUsageRepository;
+        this.machineAccountGuard = machineAccountGuard;
     }
 
     /**
-     * 身份闸：local-mode 恒解析为本机用户（免登），server 模式无有效会话即拒绝。
-     * 「未登录」文案与全站一致，前端 api.js 据此清会话。
+     * 身份闸（插件云后端加固后收严）：local-mode 恒放行（本机用户即机器主人）；
+     * server 模式下账户连接是<b>机器级</b>状态，仅 admin 可读可改——普通租户
+     * disconnect 一下全服的平台 AI 通道就断了。判定在 {@link MachineAccountGuard}。
      */
-    private static void requireUser(String sessionId) {
-        if (AuthController.getUserIdFromSession(sessionId) == null) {
-            throw new IllegalArgumentException("未登录");
-        }
+    private void requireUser(String sessionId) {
+        machineAccountGuard.requireMachineScope(sessionId);
     }
 
     @GetMapping("/status")

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -19,6 +19,14 @@ public class AuthController {
     private final ClientInvitationService clientInvitationService;
     private final com.checkba.service.AdminAccessService adminAccessService;
     private final com.checkba.service.DeviceTokenService deviceTokenService;
+    private final com.checkba.service.AuthAbuseGuard authAbuseGuard;
+    private final com.checkba.service.account.AwdkLoginService awdkLoginService;
+
+    /**
+     * awdk 桥接限速的用户名维度占位：与真实用户名共用一套失败锁定，
+     * 但键上带冒号（注册时用户名不可能撞上），不会误伤同名账号。
+     */
+    private static final String AWDK_BRIDGE_RATE_KEY = "::awdk-bridge";
 
     // 简单的 session 存储（内存中，实际生产环境应使用 Redis 或 JWT）
     // 并发安全：登录写入与每请求读取/移除高频并发，普通 HashMap 扩容会损坏桶结构
@@ -41,11 +49,15 @@ public class AuthController {
 
     public AuthController(UserService userService, ClientInvitationService clientInvitationService,
                           com.checkba.service.AdminAccessService adminAccessService,
-                          com.checkba.service.DeviceTokenService deviceTokenService) {
+                          com.checkba.service.DeviceTokenService deviceTokenService,
+                          com.checkba.service.AuthAbuseGuard authAbuseGuard,
+                          com.checkba.service.account.AwdkLoginService awdkLoginService) {
         this.userService = userService;
         this.clientInvitationService = clientInvitationService;
         this.adminAccessService = adminAccessService;
         this.deviceTokenService = deviceTokenService;
+        this.authAbuseGuard = authAbuseGuard;
+        this.awdkLoginService = awdkLoginService;
         staticUserService = userService;
     }
 
@@ -53,13 +65,18 @@ public class AuthController {
      * 用户注册
      */
     @PostMapping("/register")
-    public Map<String, Object> register(@RequestBody RegisterRequest request) {
+    public Map<String, Object> register(@RequestBody RegisterRequest request,
+                                        jakarta.servlet.http.HttpServletRequest http) {
         try {
+            // 注册闸 + 按 IP 限频（server 模式；local-mode 旁路）
+            authAbuseGuard.requireRegistrationOpen();
+            authAbuseGuard.checkRegistrationRate(http.getRemoteAddr());
             User user = userService.register(
                     request.getUsername(),
                     request.getPassword(),
                     request.getDisplayName()
             );
+            authAbuseGuard.recordRegistration(http.getRemoteAddr());
 
             // 注册成功后自动登录
             String sessionId = generateSessionId();
@@ -92,9 +109,21 @@ public class AuthController {
      * 用户登录
      */
     @PostMapping("/login")
-    public Map<String, Object> login(@RequestBody LoginRequest request) {
+    public Map<String, Object> login(@RequestBody LoginRequest request,
+                                     jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        // 锁定检查独立于凭据校验的 try：锁定拒绝不再计入失败（否则轮询会把锁无限续期）
+        try {
+            authAbuseGuard.checkLoginAttempt(ip, request.getUsername());
+        } catch (IllegalArgumentException e) {
+            Map<String, Object> result = new HashMap<>();
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+            return result;
+        }
         try {
             User user = userService.login(request.getUsername(), request.getPassword());
+            authAbuseGuard.recordLoginSuccess(ip, request.getUsername());
 
             String sessionId = generateSessionId();
             SESSION_STORE.put(sessionId, user.getId());
@@ -115,11 +144,52 @@ public class AuthController {
             ));
             return result;
         } catch (IllegalArgumentException e) {
+            authAbuseGuard.recordLoginFailure(ip, request.getUsername());
             Map<String, Object> result = new HashMap<>();
             result.put("code", 1);
             result.put("message", e.getMessage());
             return result;
         }
+    }
+
+    /**
+     * awdk_ → server 会话桥（插件云后端）：官网账户 Key 换本服务器的 awdt_ 设备令牌。
+     * 匿名端点；开关 security.awdk-login-enabled 默认 false。限速与密码登录共用一套
+     * 失败锁定（按 IP + 固定桥接维度）。
+     */
+    @PostMapping("/awdk-login")
+    public Map<String, Object> awdkLogin(@RequestBody(required = false) Map<String, String> body,
+                                         jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        Map<String, Object> result = new HashMap<>();
+        try {
+            authAbuseGuard.checkLoginAttempt(ip, AWDK_BRIDGE_RATE_KEY);
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+            return result;
+        }
+        try {
+            var session = awdkLoginService.login(body == null ? null : body.get("key"));
+            authAbuseGuard.recordLoginSuccess(ip, AWDK_BRIDGE_RATE_KEY);
+            result.put("code", 0);
+            result.put("data", Map.of(
+                    "token", session.token(),
+                    "userId", session.userId(),
+                    "username", session.username()));
+        } catch (com.checkba.service.account.AccountException e) {
+            // 只有官网明确拒绝（Key 无效）才计失败；网络不可达不该消耗尝试次数
+            if (e.getKind() == com.checkba.service.account.AccountException.Kind.UNAUTHORIZED) {
+                authAbuseGuard.recordLoginFailure(ip, AWDK_BRIDGE_RATE_KEY);
+            }
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            // 开关关闭等业务态
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
     }
 
     /**
@@ -283,10 +353,21 @@ public class AuthController {
 
     /** 用账号密码换长期设备令牌（桌面端连接团队服务器用）。明文只在这里出现一次。 */
     @PostMapping("/device-token")
-    public Map<String, Object> issueDeviceToken(@RequestBody Map<String, String> body) {
+    public Map<String, Object> issueDeviceToken(@RequestBody Map<String, String> body,
+                                                jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
         Map<String, Object> result = new HashMap<>();
+        // 这也是一次密码登录，与 /login 共用同一套失败锁定
+        try {
+            authAbuseGuard.checkLoginAttempt(ip, body.get("username"));
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+            return result;
+        }
         try {
             User user = userService.login(body.get("username"), body.get("password"));
+            authAbuseGuard.recordLoginSuccess(ip, body.get("username"));
             var issued = deviceTokenService.issue(user.getId(), body.get("name"));
             result.put("code", 0);
             result.put("data", Map.of(
@@ -296,6 +377,7 @@ public class AuthController {
                     "username", user.getUsername(),
                     "displayName", user.getDisplayName() == null ? user.getUsername() : user.getDisplayName()));
         } catch (Exception e) {
+            authAbuseGuard.recordLoginFailure(ip, body.get("username"));
             result.put("code", 1);
             result.put("message", e.getMessage());
         }

--- a/backend/src/main/java/com/checkba/controller/EntitlementController.java
+++ b/backend/src/main/java/com/checkba/controller/EntitlementController.java
@@ -1,5 +1,6 @@
 package com.checkba.controller;
 
+import com.checkba.service.account.MachineAccountGuard;
 import com.checkba.service.entitlement.EntitlementService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -22,9 +23,12 @@ import java.util.Map;
 public class EntitlementController {
 
     private final EntitlementService entitlementService;
+    private final MachineAccountGuard machineAccountGuard;
 
-    public EntitlementController(EntitlementService entitlementService) {
+    public EntitlementController(EntitlementService entitlementService,
+                                 MachineAccountGuard machineAccountGuard) {
         this.entitlementService = entitlementService;
+        this.machineAccountGuard = machineAccountGuard;
     }
 
     /**
@@ -35,9 +39,9 @@ public class EntitlementController {
     public Map<String, Object> list(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
             @RequestParam(value = "refresh", required = false, defaultValue = "false") boolean refresh) {
-        if (AuthController.getUserIdFromSession(sessionId) == null) {
-            throw new IllegalArgumentException("未登录");
-        }
+        // 插件云后端加固：server 模式下权益缓存是机器级状态（EntitlementService 无 userId 维度），
+        // 仅 admin 可读；local-mode 行为一字不动（恒放行）。
+        machineAccountGuard.requireMachineScope(sessionId);
         if (refresh) {
             entitlementService.refreshQuietly();
         }

--- a/backend/src/main/java/com/checkba/model/entity/AccountBinding.java
+++ b/backend/src/main/java/com/checkba/model/entity/AccountBinding.java
@@ -1,0 +1,39 @@
+package com.checkba.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * 官网账户 → server 用户的绑定（插件云后端 awdk 桥）。
+ *
+ * 映射键是官网返回的稳定 accountId（不是 username——username 可改名，也不是 Key 哈希——
+ * Key 可轮换；两者做键都会在变更后凭空生出第二个 server 用户）。
+ * awdk_ Key 明文**不落库**：每次 awdk-login 都实时向官网重验，本表只存映射关系。
+ */
+@Entity
+@Table(name = "account_binding",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"externalAccountId"}))
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class AccountBinding {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    /** 官网侧的稳定账户标识（契约待官网实施，见 doc/desktop-contract.md）。 */
+    @Column(nullable = false, length = 128)
+    private String externalAccountId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastLoginAt;
+}

--- a/backend/src/main/java/com/checkba/repository/AccountBindingRepository.java
+++ b/backend/src/main/java/com/checkba/repository/AccountBindingRepository.java
@@ -1,0 +1,10 @@
+package com.checkba.repository;
+
+import com.checkba.model.entity.AccountBinding;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccountBindingRepository extends JpaRepository<AccountBinding, Long> {
+    Optional<AccountBinding> findByExternalAccountId(String externalAccountId);
+}

--- a/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
+++ b/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
@@ -1,0 +1,177 @@
+package com.checkba.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * 注册闸 + 登录/注册防滥用（插件云后端加固）。
+ *
+ * <h3>背景</h3>
+ * server 模式此前是内网团队服务器假设：开放注册、无限流。官方要托管一个 server 实例
+ * 作为 Office 插件云后端，公网暴露后这两条都要闸住。
+ *
+ * <h3>三道闸，全部只在 server 模式生效（local-mode 一律旁路）</h3>
+ * <ul>
+ *   <li><b>注册闸</b>：{@code security.registration-mode: open|closed}，默认 open 保持
+ *       团队服务器现状；closed 时注册返回业务错误。</li>
+ *   <li><b>凭据失败锁定</b>：按 IP+用户名维度计失败次数，{@value #MAX_LOGIN_FAILURES} 次
+ *       失败锁 {@code LOCKOUT} 分钟。锁定期内的请求在校验凭据之前就被拒绝，不再计数
+ *       （否则轮询会把锁无限续期）。</li>
+ *   <li><b>注册限频</b>：按 IP 每小时最多 {@value #MAX_REGISTRATIONS_PER_WINDOW} 个新账号。</li>
+ * </ul>
+ *
+ * <h3>实现边界（刻意接受）</h3>
+ * <ul>
+ *   <li>进程内内存计数，无 Redis 依赖。<b>多实例部署时各实例独立计数，必须在前置
+ *       nginx 配 limit_req 作为真正的限流层</b>；本类只是单实例基线。</li>
+ *   <li>基线部署形态是 nginx 与后端同机反代，后端看到的 remoteAddr 恒为 127.0.0.1，
+ *       此时 IP 维度退化为全局维度——登录锁定仍按用户名生效（这正是防爆破要的），
+ *       注册限频则变成全服共享一个额度，公网生产姿态本就该 registration-mode=closed。</li>
+ *   <li>不看 X-Forwarded-For（不可信，与 LocalModeAccessFilter 同一立场）。</li>
+ * </ul>
+ *
+ * 失败文案红线：不得含「登录」「未授权」「请先」子串——前端 api.js 对 code=1 的 message
+ * 做子串匹配识别掉线，命中会清本地会话（licensing 领域地雷 1）。
+ */
+@Service
+public class AuthAbuseGuard {
+
+    static final int MAX_LOGIN_FAILURES = 5;
+    static final Duration LOCKOUT = Duration.ofMinutes(10);
+    /** 失败计数窗口：距上次失败超过该时长则计数归零重来。 */
+    static final Duration FAILURE_WINDOW = Duration.ofMinutes(10);
+
+    static final int MAX_REGISTRATIONS_PER_WINDOW = 10;
+    static final Duration REGISTRATION_WINDOW = Duration.ofHours(1);
+
+    /** 内存兜底：超过该条数触发一次过期清理，防止被海量伪造维度撑爆内存。 */
+    private static final int PURGE_THRESHOLD = 10_000;
+
+    private final boolean localMode;
+    private final String registrationMode;
+    private final LongSupplier nowMillis;
+
+    private final Map<String, FailureState> loginFailures = new ConcurrentHashMap<>();
+    private final Map<String, WindowCounter> registrations = new ConcurrentHashMap<>();
+
+    @Autowired
+    public AuthAbuseGuard(
+            @Value("${security.local-mode:false}") boolean localMode,
+            @Value("${security.registration-mode:open}") String registrationMode) {
+        this(localMode, registrationMode, System::currentTimeMillis);
+    }
+
+    /** 测试用：可控时钟。 */
+    AuthAbuseGuard(boolean localMode, String registrationMode, LongSupplier nowMillis) {
+        this.localMode = localMode;
+        this.registrationMode = registrationMode;
+        this.nowMillis = nowMillis;
+    }
+
+    // ==================== 注册闸 ====================
+
+    /** closed 时抛业务错误。local-mode 不受影响（单机产品的注册本就不对公网暴露）。 */
+    public void requireRegistrationOpen() {
+        if (localMode) return;
+        if (!"closed".equalsIgnoreCase(registrationMode)) return;
+        throw new IllegalArgumentException("本服务器未开放自助注册，请联系服务器管理员开通账号");
+    }
+
+    // ==================== 登录失败锁定 ====================
+
+    /** 锁定期内直接拒绝（在校验凭据之前调用）。 */
+    public void checkLoginAttempt(String ip, String username) {
+        if (localMode) return;
+        FailureState state = loginFailures.get(loginKey(ip, username));
+        if (state != null && state.lockedUntil > nowMillis.getAsLong()) {
+            throw new IllegalArgumentException(
+                    "尝试次数过多，该账号已临时锁定，" + LOCKOUT.toMinutes() + " 分钟后自动解除");
+        }
+    }
+
+    public void recordLoginFailure(String ip, String username) {
+        if (localMode) return;
+        purgeIfOversized();
+        long now = nowMillis.getAsLong();
+        loginFailures.compute(loginKey(ip, username), (k, state) -> {
+            if (state == null || now - state.lastFailureAt > FAILURE_WINDOW.toMillis()) {
+                state = new FailureState();
+            }
+            state.count++;
+            state.lastFailureAt = now;
+            if (state.count >= MAX_LOGIN_FAILURES) {
+                state.lockedUntil = now + LOCKOUT.toMillis();
+                state.count = 0; // 锁定期满后重新给满额尝试次数
+            }
+            return state;
+        });
+    }
+
+    public void recordLoginSuccess(String ip, String username) {
+        if (localMode) return;
+        loginFailures.remove(loginKey(ip, username));
+    }
+
+    // ==================== 注册限频 ====================
+
+    public void checkRegistrationRate(String ip) {
+        if (localMode) return;
+        WindowCounter counter = registrations.get(ip);
+        long now = nowMillis.getAsLong();
+        if (counter != null
+                && now - counter.windowStart <= REGISTRATION_WINDOW.toMillis()
+                && counter.count >= MAX_REGISTRATIONS_PER_WINDOW) {
+            throw new IllegalArgumentException("注册过于频繁，请稍后再试");
+        }
+    }
+
+    public void recordRegistration(String ip) {
+        if (localMode) return;
+        purgeIfOversized();
+        long now = nowMillis.getAsLong();
+        registrations.compute(ip, (k, counter) -> {
+            if (counter == null || now - counter.windowStart > REGISTRATION_WINDOW.toMillis()) {
+                counter = new WindowCounter();
+                counter.windowStart = now;
+            }
+            counter.count++;
+            return counter;
+        });
+    }
+
+    // ==================== 内部 ====================
+
+    private static String loginKey(String ip, String username) {
+        return (ip == null ? "-" : ip) + "|" + (username == null ? "-" : username);
+    }
+
+    private void purgeIfOversized() {
+        long now = nowMillis.getAsLong();
+        if (loginFailures.size() > PURGE_THRESHOLD) {
+            loginFailures.entrySet().removeIf(e ->
+                    e.getValue().lockedUntil < now
+                            && now - e.getValue().lastFailureAt > FAILURE_WINDOW.toMillis());
+        }
+        if (registrations.size() > PURGE_THRESHOLD) {
+            registrations.entrySet().removeIf(e ->
+                    now - e.getValue().windowStart > REGISTRATION_WINDOW.toMillis());
+        }
+    }
+
+    private static final class FailureState {
+        int count;
+        long lastFailureAt;
+        long lockedUntil;
+    }
+
+    private static final class WindowCounter {
+        int count;
+        long windowStart;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -19,6 +19,16 @@ public class UserService {
     /** BCrypt 无状态、线程安全，可静态复用。 */
     private static final BCryptPasswordEncoder PW_ENCODER = new BCryptPasswordEncoder();
 
+    /**
+     * 外部账户桥接（awdk-login）建的无密码账号的口令哨兵前缀。
+     * {@link #login} 见到该前缀直接按凭据错误拒绝——这类账号不存在「正确密码」这回事。
+     * 哨兵后面还拼了 32 字节随机料作兜底：即使前缀检查被误删，历史明文兼容分支的
+     * equals 比对也没有任何用户输入能命中它。
+     */
+    public static final String EXTERNAL_ACCOUNT_MARK = "{external-account}";
+
+    private static final java.security.SecureRandom SECURE_RANDOM = new java.security.SecureRandom();
+
     /** 判断存储的口令是否已是 BCrypt 哈希（$2a/$2b/$2y 前缀）。 */
     private static boolean isBcryptHash(String stored) {
         return stored != null && stored.startsWith("$2");
@@ -59,6 +69,29 @@ public class UserService {
     }
 
     /**
+     * 外部账户桥接建号（awdk-login 首登）：无密码账户，只能经桥接换取设备令牌，
+     * 不可用密码登录（见 {@link #EXTERNAL_ACCOUNT_MARK}）。
+     */
+    public User registerExternal(String username, String displayName) {
+        if (!StringUtils.hasText(username)) {
+            throw new IllegalArgumentException("用户名不能为空");
+        }
+        if (userRepository.findByUsername(username).isPresent()) {
+            throw new IllegalArgumentException("用户名已存在");
+        }
+        byte[] raw = new byte[32];
+        SECURE_RANDOM.nextBytes(raw);
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(EXTERNAL_ACCOUNT_MARK
+                + java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(raw));
+        user.setDisplayName(StringUtils.hasText(displayName) ? displayName : username);
+        user.setCreatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
+        return userRepository.save(user);
+    }
+
+    /**
      * 用户登录
      */
     public User login(String username, String password) {
@@ -76,6 +109,10 @@ public class UserService {
 
         User user = userOpt.get();
         String stored = user.getPassword();
+        // 外部账户桥接建的无密码账号：一律按凭据错误拒绝（文案与普通失败一致，不泄露账号类型）
+        if (stored != null && stored.startsWith(EXTERNAL_ACCOUNT_MARK)) {
+            throw new IllegalArgumentException("用户名或密码错误");
+        }
         boolean ok;
         if (isBcryptHash(stored)) {
             ok = PW_ENCODER.matches(password, stored);

--- a/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
+++ b/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
@@ -1,0 +1,212 @@
+package com.checkba.service.account;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.User;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.service.DeviceTokenService;
+import com.checkba.service.UserService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * awdk_ → server 会话桥（插件云后端，server 侧）。
+ *
+ * <p>Office 插件持官网账户 Key（awdk_）来换本服务器的长期设备令牌（awdt_）：
+ * 用 Key 调官网 {@code GET /api/account/me} 实时校验，通过后按官网返回的稳定
+ * {@code accountId} 查/建 {@code account_binding} 映射，首登自动建无密码用户，
+ * 最后经 {@link DeviceTokenService#issue} 签发 awdt_——插件端长期凭据形态与
+ * 既有的设备令牌完全一致。
+ *
+ * <p>红线：
+ * <ul>
+ *   <li>awdk_ 明文<b>不落库</b>——本期只换会话，每次 awdk-login 都重验官网；</li>
+ *   <li>映射键只认 {@code accountId}（官网侧尚未实施，见 doc/desktop-contract.md），
+ *       缺失时按 MALFORMED 拒绝，<b>不回落 username</b>——username 可改名，
+ *       以它为键会在改名后凭空生出第二个 server 用户；</li>
+ *   <li>绝不把官网用户名直接绑到本服务器已有的同名账号上（等于账户接管），
+ *       首登一律新建 {@code awd_} 前缀用户；</li>
+ *   <li>失败文案不含「登录」「未授权」「请先」子串（licensing 领域地雷 1）。</li>
+ * </ul>
+ *
+ * <p>配置开关 {@code security.awdk-login-enabled} 默认 false：团队服务器与桌面
+ * 单机形态都用不到这条桥，只有官方托管的插件云后端显式打开。
+ */
+@Service
+@Slf4j
+public class AwdkLoginService {
+
+    static final String KEY_PREFIX = "awdk_";
+    /** 首登自动建号的用户名前缀，与人工注册的账号空间隔离。 */
+    static final String USERNAME_PREFIX = "awd_";
+
+    private final boolean enabled;
+    private final String baseUrl;
+    private final AccountTransport transport;
+    private final AccountBindingRepository bindingRepository;
+    private final UserService userService;
+    private final DeviceTokenService deviceTokenService;
+    private final ObjectMapper objectMapper = AccountService.stateMapper();
+
+    public AwdkLoginService(
+            @Value("${security.awdk-login-enabled:false}") boolean enabled,
+            @Value("${ai.account.base-url:https://www.aiworkdeck.com}") String baseUrl,
+            AccountTransport transport,
+            AccountBindingRepository bindingRepository,
+            UserService userService,
+            DeviceTokenService deviceTokenService) {
+        this.enabled = enabled;
+        // 与 LicenseService / AccountService 共用同一条红线（https，回环 http 例外）
+        this.baseUrl = AccountEndpoint.requireSecure(baseUrl);
+        this.transport = transport;
+        this.bindingRepository = bindingRepository;
+        this.userService = userService;
+        this.deviceTokenService = deviceTokenService;
+    }
+
+    /** 桥接结果：awdt_ 设备令牌 + 映射到的 server 用户。 */
+    public record BridgeSession(String token, Long userId, String username) {}
+
+    /**
+     * @throws IllegalArgumentException 开关关闭（业务错误，非鉴权错误）
+     * @throws AccountException UNAUTHORIZED（Key 无效/格式错）/ NETWORK / MALFORMED（缺 accountId 等）
+     */
+    public synchronized BridgeSession login(String rawKey) {
+        if (!enabled) {
+            throw new IllegalArgumentException("本服务器未开启账户桥接功能");
+        }
+        String key = rawKey == null ? "" : rawKey.trim();
+        if (key.isEmpty() || !key.startsWith(KEY_PREFIX)) {
+            throw new AccountException(AccountException.Kind.UNAUTHORIZED,
+                    "账户 Key 格式不正确，应以 awdk_ 开头（在官网账户页「桌面连接」生成）");
+        }
+        Map<String, Object> me = fetchMe(key);
+        String accountId = str(me.get("accountId"));
+        if (accountId == null || accountId.isBlank()) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网账户信息缺少 accountId 字段，本服务器暂无法完成账户桥接");
+        }
+
+        User user = resolveUser(accountId, str(me.get("username")), str(me.get("displayName")));
+        DeviceTokenService.IssuedToken issued =
+                deviceTokenService.issue(user.getId(), "账户桥接");
+        return new BridgeSession(issued.plaintext(), user.getId(), user.getUsername());
+    }
+
+    // ==================== 内部 ====================
+
+    private Map<String, Object> fetchMe(String key) {
+        AccountTransport.Reply reply = transport.send("GET", baseUrl + "/api/account/me", key, null);
+        if (reply.networkFailure()) {
+            throw new AccountException(AccountException.Kind.NETWORK,
+                    "无法连接 AI Workdeck 服务器，请检查网络后重试");
+        }
+        int status = reply.status();
+        if (status == 401 || status == 403) {
+            throw new AccountException(AccountException.Kind.UNAUTHORIZED,
+                    "账户 Key 无效或已被撤销，请到官网账户页重新生成");
+        }
+        if (status >= 500) {
+            throw new AccountException(AccountException.Kind.NETWORK,
+                    "AI Workdeck 服务器暂时不可用，请稍后重试");
+        }
+        if (status < 200 || status >= 300) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网返回了预期外的状态（" + status + "），请稍后重试");
+        }
+        try {
+            Map<String, Object> parsed =
+                    objectMapper.readValue(reply.body(), new TypeReference<>() {});
+            return parsed == null ? Map.of() : parsed;
+        } catch (Exception e) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网返回的内容无法解析，请稍后重试");
+        }
+    }
+
+    private User resolveUser(String accountId, String externalUsername, String displayName) {
+        Optional<AccountBinding> existing = bindingRepository.findByExternalAccountId(accountId);
+        if (existing.isPresent()) {
+            AccountBinding binding = existing.get();
+            try {
+                User user = userService.getUserById(binding.getUserId());
+                binding.setLastLoginAt(LocalDateTime.now());
+                bindingRepository.save(binding);
+                return user;
+            } catch (IllegalArgumentException e) {
+                // 绑定指向的用户已被删除：按首登重建，绑定改指新用户
+                log.warn("account_binding {} 指向的用户 {} 不存在，重建", accountId, binding.getUserId());
+                User user = createExternalUser(accountId, externalUsername, displayName);
+                binding.setUserId(user.getId());
+                binding.setLastLoginAt(LocalDateTime.now());
+                bindingRepository.save(binding);
+                return user;
+            }
+        }
+        User user = createExternalUser(accountId, externalUsername, displayName);
+        AccountBinding binding = new AccountBinding();
+        binding.setExternalAccountId(accountId);
+        binding.setUserId(user.getId());
+        binding.setCreatedAt(LocalDateTime.now());
+        binding.setLastLoginAt(LocalDateTime.now());
+        bindingRepository.save(binding);
+        log.info("awdk 桥接首登建号: accountId={} -> userId={} username={}",
+                accountId, user.getId(), user.getUsername());
+        return user;
+    }
+
+    private User createExternalUser(String accountId, String externalUsername, String displayName) {
+        String username = allocateUsername(externalUsername, accountId);
+        String display = displayName != null && !displayName.isBlank() ? displayName
+                : (externalUsername != null && !externalUsername.isBlank() ? externalUsername : username);
+        return userService.registerExternal(username, display);
+    }
+
+    /**
+     * 用户名分配：awd_ 前缀 + 官网用户名（清洗后），撞名时追加 accountId 短哈希。
+     * 绝不复用已存在的账号——官网用户名与本服务器同名账号是两个世界的身份。
+     */
+    private String allocateUsername(String externalUsername, String accountId) {
+        String base = sanitize(externalUsername);
+        if (base.isEmpty()) base = "user";
+        String candidate = truncate(USERNAME_PREFIX + base);
+        if (userService.getUserByUsername(candidate).isEmpty()) return candidate;
+        candidate = truncate(USERNAME_PREFIX + base + "_" + shortHash(accountId));
+        if (userService.getUserByUsername(candidate).isEmpty()) return candidate;
+        throw new AccountException(AccountException.Kind.MALFORMED,
+                "无法为该账户分配用户名，请联系服务器管理员");
+    }
+
+    private static String sanitize(String name) {
+        if (name == null) return "";
+        return name.replaceAll("[^A-Za-z0-9_-]", "").toLowerCase();
+    }
+
+    /** User.username 列宽 64。 */
+    private static String truncate(String username) {
+        return username.length() <= 64 ? username : username.substring(0, 64);
+    }
+
+    private static String shortHash(String accountId) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(accountId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest).substring(0, 8);
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 不可用", e);
+        }
+    }
+
+    private static String str(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/account/MachineAccountGuard.java
+++ b/backend/src/main/java/com/checkba/service/account/MachineAccountGuard.java
@@ -1,0 +1,61 @@
+package com.checkba.service.account;
+
+import com.checkba.controller.AuthController;
+import com.checkba.model.entity.User;
+import com.checkba.service.AdminAccessService;
+import com.checkba.service.UserService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * server 模式下账户连接/权益的机器级操作闸（插件云后端加固）。
+ *
+ * <p>{@code account.json} / {@code entitlements.json} 是<b>按机器</b>的状态：server 模式下
+ * connect/disconnect/余额/权益快照描述的是整台服务器的官网连接，让任意注册用户可读可改
+ * 等于把服务器级配置暴露给全体租户（普通用户 disconnect 一下，全服的平台 AI 通道就断了）。
+ * 因此 server 模式下这些端点仅 admin 可用（判定复用 {@link AdminAccessService}）。
+ *
+ * <p><b>local-mode 一字不动</b>：单机产品本机用户就是机器的主人，直接放行。
+ *
+ * <p>非 admin 的拒绝是业务错误：文案不得含「登录」「未授权」「请先」子串
+ * （前端 api.js 据此清会话，licensing 领域地雷 1）。会话缺失仍报「未登录」——
+ * 那是真的掉线，本就该触发前端重新认证。
+ */
+@Service
+public class MachineAccountGuard {
+
+    private final boolean localMode;
+    private final AdminAccessService adminAccessService;
+    private final UserService userService;
+
+    public MachineAccountGuard(
+            @Value("${security.local-mode:false}") boolean localMode,
+            AdminAccessService adminAccessService,
+            UserService userService) {
+        this.localMode = localMode;
+        this.adminAccessService = adminAccessService;
+        this.userService = userService;
+    }
+
+    /**
+     * local-mode 直接放行；server 模式要求会话有效且为 admin。
+     *
+     * @throws IllegalArgumentException 会话无效（「未登录」）或非 admin（业务错误）
+     */
+    public void requireMachineScope(String sessionId) {
+        if (localMode) return;
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            throw new IllegalArgumentException("未登录");
+        }
+        User user;
+        try {
+            user = userService.getUserById(userId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("未登录");
+        }
+        if (!adminAccessService.isAdmin(user)) {
+            throw new IllegalArgumentException("账户连接与权益同步属于服务器级配置，仅管理员账号可操作");
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AccountControllerMachineScopeTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerMachineScopeTest.java
@@ -1,0 +1,122 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.DeviceToken;
+import com.checkba.model.entity.User;
+import com.checkba.repository.DeviceTokenRepository;
+import com.checkba.repository.TokenUsageRepository;
+import com.checkba.service.AdminAccessService;
+import com.checkba.service.DeviceTokenService;
+import com.checkba.service.UserService;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.account.MachineAccountGuard;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.PlatformAiChannel;
+import com.checkba.service.ai.PlatformUsageAccountant;
+import com.checkba.service.entitlement.EntitlementService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * server 模式下账户/权益端点的接线回归（插件云后端加固）：
+ * 普通用户读不到机器级账户状态、断不开连接、看不到权益快照；admin 一切照旧。
+ * local-mode 语义在 MachineAccountGuardTest 里单独锁定。
+ */
+class AccountControllerMachineScopeTest {
+
+    private DeviceTokenService deviceTokenService;
+    private AccountService accountService;
+    private EntitlementService entitlementService;
+    private AccountController accountController;
+    private EntitlementController entitlementController;
+
+    private final Map<Long, User> usersById = new HashMap<>();
+    private final Map<String, DeviceToken> tokensByHash = new HashMap<>();
+    private final AtomicLong seq = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        AuthController.registerLocalIdentityService(null);
+        usersById.clear();
+        tokensByHash.clear();
+
+        DeviceTokenRepository tokenRepository = mock(DeviceTokenRepository.class);
+        when(tokenRepository.save(any(DeviceToken.class))).thenAnswer(inv -> {
+            DeviceToken t = inv.getArgument(0);
+            if (t.getId() == null) t.setId(seq.getAndIncrement());
+            tokensByHash.put(t.getTokenHash(), t);
+            return t;
+        });
+        when(tokenRepository.findByTokenHash(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(tokensByHash.get(inv.getArgument(0, String.class))));
+        deviceTokenService = new DeviceTokenService(tokenRepository);
+
+        UserService userService = mock(UserService.class);
+        when(userService.getUserById(anyLong())).thenAnswer(inv -> {
+            User user = usersById.get(inv.getArgument(0, Long.class));
+            if (user == null) throw new IllegalArgumentException("用户不存在");
+            return user;
+        });
+
+        MachineAccountGuard guard =
+                new MachineAccountGuard(false, new AdminAccessService(), userService);
+
+        accountService = mock(AccountService.class);
+        entitlementService = mock(EntitlementService.class);
+        PlatformAiChannel platformAiChannel = mock(PlatformAiChannel.class);
+        accountController = new AccountController(accountService, entitlementService,
+                platformAiChannel, mock(PlatformUsageAccountant.class), mock(ChatModelFactory.class),
+                mock(TokenUsageRepository.class), guard);
+        entitlementController = new EntitlementController(entitlementService, guard);
+    }
+
+    private String sessionFor(String username) {
+        User user = new User();
+        user.setId(seq.getAndIncrement());
+        user.setUsername(username);
+        usersById.put(user.getId(), user);
+        return deviceTokenService.issue(user.getId(), "test").plaintext();
+    }
+
+    @Test
+    @DisplayName("普通用户：status/disconnect/entitlements 全被业务错误拒绝，服务层零触碰")
+    void nonAdminRejectedEverywhere() {
+        String session = sessionFor("alice");
+
+        assertThrows(IllegalArgumentException.class, () -> accountController.status(session));
+        assertThrows(IllegalArgumentException.class, () -> accountController.disconnect(session));
+        assertThrows(IllegalArgumentException.class, () -> accountController.connect(Map.of(), session));
+        assertThrows(IllegalArgumentException.class, () -> accountController.usage(session));
+        assertThrows(IllegalArgumentException.class, () -> entitlementController.list(session, false));
+
+        verifyNoInteractions(accountService);
+        verifyNoInteractions(entitlementService);
+    }
+
+    @Test
+    @DisplayName("admin：status 与 entitlements 照常返回")
+    void adminStillWorks() {
+        String session = sessionFor("admin");
+        when(accountService.status()).thenReturn(Map.of("connected", false));
+        when(entitlementService.snapshot()).thenReturn(Map.of());
+
+        Map<String, Object> status = accountController.status(session);
+        assertEquals(0, status.get("code"));
+
+        Map<String, Object> entitlements = entitlementController.list(session, false);
+        assertEquals(0, entitlements.get("code"));
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -1,0 +1,173 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.User;
+import com.checkba.service.AuthAbuseGuard;
+import com.checkba.service.UserService;
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AwdkLoginService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 端点级锁定注册闸 / 登录锁定 / awdk-login 信封（插件云后端加固）。
+ * 服务层语义各有专测（AuthAbuseGuardTest / AwdkLoginServiceTest），
+ * 这里只验 AuthController 的接线：闸在业务动作之前、失败正确计数、信封 code/message 正确。
+ */
+class AuthControllerHardeningTest {
+
+    private AuthAbuseGuard serverGuard(String registrationMode) {
+        return new AuthAbuseGuard(false, registrationMode);
+    }
+
+    private static MockHttpServletRequest http() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("9.9.9.9");
+        return request;
+    }
+
+    private static AuthController.RegisterRequest registerRequest() {
+        AuthController.RegisterRequest request = new AuthController.RegisterRequest();
+        request.setUsername("alice");
+        request.setPassword("pw123456");
+        request.setDisplayName("Alice");
+        return request;
+    }
+
+    private static User user(long id, String username) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setDisplayName(username);
+        return user;
+    }
+
+    @Test
+    @DisplayName("registration-mode=closed：注册返回业务错误，UserService 根本不被调用")
+    void closedRegistrationShortCircuits() {
+        UserService userService = mock(UserService.class);
+        AuthController controller = new AuthController(
+                userService, null, null, null, serverGuard("closed"), null);
+
+        Map<String, Object> result = controller.register(registerRequest(), http());
+
+        assertEquals(1, result.get("code"));
+        assertTrue(String.valueOf(result.get("message")).contains("未开放自助注册"));
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("registration-mode=open：注册照常成功")
+    void openRegistrationStillWorks() {
+        UserService userService = mock(UserService.class);
+        when(userService.register(anyString(), anyString(), anyString()))
+                .thenReturn(user(1L, "alice"));
+        AuthController controller = new AuthController(
+                userService, null, null, null, serverGuard("open"), null);
+
+        Map<String, Object> result = controller.register(registerRequest(), http());
+
+        assertEquals(0, result.get("code"));
+    }
+
+    @Test
+    @DisplayName("local-mode 回归：registration-mode=closed 也不影响注册")
+    void localModeUnaffectedByClosedGate() {
+        UserService userService = mock(UserService.class);
+        when(userService.register(anyString(), anyString(), anyString()))
+                .thenReturn(user(1L, "alice"));
+        AuthAbuseGuard localGuard = new AuthAbuseGuard(true, "closed");
+        AuthController controller = new AuthController(
+                userService, null, null, null, localGuard, null);
+
+        Map<String, Object> result = controller.register(registerRequest(), http());
+
+        assertEquals(0, result.get("code"));
+    }
+
+    @Test
+    @DisplayName("登录连续失败 5 次后锁定：第 6 次不再触碰凭据校验")
+    void loginLockoutAfterFiveFailures() {
+        UserService userService = mock(UserService.class);
+        when(userService.login(anyString(), anyString()))
+                .thenThrow(new IllegalArgumentException("用户名或密码错误"));
+        AuthController controller = new AuthController(
+                userService, null, null, null, serverGuard("open"), null);
+
+        AuthController.LoginRequest request = new AuthController.LoginRequest();
+        request.setUsername("alice");
+        request.setPassword("wrong");
+        for (int i = 0; i < 5; i++) {
+            Map<String, Object> result = controller.login(request, http());
+            assertEquals(1, result.get("code"));
+        }
+
+        Map<String, Object> locked = controller.login(request, http());
+        assertEquals(1, locked.get("code"));
+        assertTrue(String.valueOf(locked.get("message")).contains("临时锁定"));
+        verify(userService, times(5)).login(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("awdk-login 成功：返回 token/userId/username 信封")
+    void awdkLoginSuccessEnvelope() {
+        AwdkLoginService awdkLoginService = mock(AwdkLoginService.class);
+        when(awdkLoginService.login(anyString()))
+                .thenReturn(new AwdkLoginService.BridgeSession("awdt_x", 7L, "awd_hanzewei"));
+        AuthController controller = new AuthController(
+                null, null, null, null, serverGuard("open"), awdkLoginService);
+
+        Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
+
+        assertEquals(0, result.get("code"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+        assertEquals("awdt_x", data.get("token"));
+        assertEquals(7L, data.get("userId"));
+        assertEquals("awd_hanzewei", data.get("username"));
+    }
+
+    @Test
+    @DisplayName("awdk-login 开关关闭：业务错误信封，不像掉线")
+    void awdkLoginDisabledEnvelope() {
+        AwdkLoginService awdkLoginService = mock(AwdkLoginService.class);
+        when(awdkLoginService.login(any()))
+                .thenThrow(new IllegalArgumentException("本服务器未开启账户桥接功能"));
+        AuthController controller = new AuthController(
+                null, null, null, null, serverGuard("open"), awdkLoginService);
+
+        Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
+
+        assertEquals(1, result.get("code"));
+        String message = String.valueOf(result.get("message"));
+        assertTrue(message.contains("未开启账户桥接"));
+        assertFalse(message.contains("登录"));
+        assertFalse(message.contains("未授权"));
+        assertFalse(message.contains("请先"));
+    }
+
+    @Test
+    @DisplayName("awdk-login 无效 Key 连续 5 次后锁定：第 6 次不再出站")
+    void awdkLoginLockoutAfterRepeatedInvalidKeys() {
+        AwdkLoginService awdkLoginService = mock(AwdkLoginService.class);
+        when(awdkLoginService.login(anyString())).thenThrow(new AccountException(
+                AccountException.Kind.UNAUTHORIZED, "账户 Key 无效或已被撤销，请到官网账户页重新生成"));
+        AuthController controller = new AuthController(
+                null, null, null, null, serverGuard("open"), awdkLoginService);
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals(1, controller.awdkLogin(Map.of("key", "awdk_bad"), http()).get("code"));
+        }
+        Map<String, Object> locked = controller.awdkLogin(Map.of("key", "awdk_bad"), http());
+        assertEquals(1, locked.get("code"));
+        assertTrue(String.valueOf(locked.get("message")).contains("临时锁定"));
+        verify(awdkLoginService, times(5)).login(anyString());
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSessionIdTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSessionIdTest.java
@@ -26,7 +26,7 @@ class AuthControllerSessionIdTest {
 
     @Test
     void sessionIdIsUnpredictable() throws Exception {
-        AuthController controller = new AuthController(null, null, null, null);
+        AuthController controller = new AuthController(null, null, null, null, null, null);
 
         long before = System.currentTimeMillis();
         Set<String> seen = new HashSet<>();

--- a/backend/src/test/java/com/checkba/service/AuthAbuseGuardTest.java
+++ b/backend/src/test/java/com/checkba/service/AuthAbuseGuardTest.java
@@ -1,0 +1,150 @@
+package com.checkba.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 锁定注册闸与防滥用限速的契约（插件云后端加固）：
+ * - 注册闸 open/closed 两态，local-mode 旁路；
+ * - 5 次失败锁 10 分钟，到期自动解除，成功清零；
+ * - 注册按 IP 限频；
+ * - 所有失败文案不含「登录」「未授权」「请先」子串（前端 api.js 据此清会话）。
+ */
+class AuthAbuseGuardTest {
+
+    private final AtomicLong now = new AtomicLong(1_700_000_000_000L);
+
+    private AuthAbuseGuard serverGuard(String registrationMode) {
+        return new AuthAbuseGuard(false, registrationMode, now::get);
+    }
+
+    private void advance(Duration d) {
+        now.addAndGet(d.toMillis());
+    }
+
+    private static void assertNotMistakenForLogout(String message) {
+        assertNotNull(message);
+        assertFalse(message.contains("登录"), "文案不得含「登录」: " + message);
+        assertFalse(message.contains("未授权"), "文案不得含「未授权」: " + message);
+        assertFalse(message.contains("请先"), "文案不得含「请先」: " + message);
+    }
+
+    // ==================== 注册闸 ====================
+
+    @Test
+    @DisplayName("registration-mode=closed：注册被业务错误拒绝，文案不像掉线")
+    void closedRegistrationRejected() {
+        AuthAbuseGuard guard = serverGuard("closed");
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, guard::requireRegistrationOpen);
+        assertTrue(e.getMessage().contains("未开放自助注册"), e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("registration-mode=open（默认）：放行")
+    void openRegistrationAllowed() {
+        assertDoesNotThrow(serverGuard("open")::requireRegistrationOpen);
+    }
+
+    @Test
+    @DisplayName("local-mode：closed 也不影响（单机产品不受注册闸约束）")
+    void localModeBypassesRegistrationGate() {
+        AuthAbuseGuard guard = new AuthAbuseGuard(true, "closed", now::get);
+        assertDoesNotThrow(guard::requireRegistrationOpen);
+    }
+
+    // ==================== 登录失败锁定 ====================
+
+    @Test
+    @DisplayName("5 次失败后锁定，10 分钟后自动解除")
+    void fiveFailuresLockThenAutoUnlock() {
+        AuthAbuseGuard guard = serverGuard("open");
+        for (int i = 0; i < 4; i++) {
+            guard.recordLoginFailure("1.2.3.4", "alice");
+            assertDoesNotThrow(() -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+        }
+        guard.recordLoginFailure("1.2.3.4", "alice");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+        assertNotMistakenForLogout(e.getMessage());
+
+        advance(Duration.ofMinutes(10).plusMillis(1));
+        assertDoesNotThrow(() -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+    }
+
+    @Test
+    @DisplayName("锁定按 IP+用户名维度：其他用户名与其他 IP 不受影响")
+    void lockIsScopedToIpAndUsername() {
+        AuthAbuseGuard guard = serverGuard("open");
+        for (int i = 0; i < 5; i++) {
+            guard.recordLoginFailure("1.2.3.4", "alice");
+        }
+        assertThrows(IllegalArgumentException.class,
+                () -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+        assertDoesNotThrow(() -> guard.checkLoginAttempt("1.2.3.4", "bob"));
+        assertDoesNotThrow(() -> guard.checkLoginAttempt("5.6.7.8", "alice"));
+    }
+
+    @Test
+    @DisplayName("成功登录清空失败计数")
+    void successClearsFailureCounter() {
+        AuthAbuseGuard guard = serverGuard("open");
+        for (int i = 0; i < 4; i++) {
+            guard.recordLoginFailure("1.2.3.4", "alice");
+        }
+        guard.recordLoginSuccess("1.2.3.4", "alice");
+        // 清零后再来 4 次失败也不该锁
+        for (int i = 0; i < 4; i++) {
+            guard.recordLoginFailure("1.2.3.4", "alice");
+        }
+        assertDoesNotThrow(() -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+    }
+
+    @Test
+    @DisplayName("失败计数窗口：距上次失败超 10 分钟则归零重来")
+    void staleFailuresExpire() {
+        AuthAbuseGuard guard = serverGuard("open");
+        for (int i = 0; i < 4; i++) {
+            guard.recordLoginFailure("1.2.3.4", "alice");
+        }
+        advance(Duration.ofMinutes(11));
+        guard.recordLoginFailure("1.2.3.4", "alice"); // 窗口已过，这是新一轮的第 1 次
+        assertDoesNotThrow(() -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+    }
+
+    @Test
+    @DisplayName("local-mode：失败再多也不锁")
+    void localModeBypassesLockout() {
+        AuthAbuseGuard guard = new AuthAbuseGuard(true, "open", now::get);
+        for (int i = 0; i < 20; i++) {
+            guard.recordLoginFailure("1.2.3.4", "alice");
+        }
+        assertDoesNotThrow(() -> guard.checkLoginAttempt("1.2.3.4", "alice"));
+    }
+
+    // ==================== 注册限频 ====================
+
+    @Test
+    @DisplayName("同 IP 注册超限被拒，窗口过后恢复")
+    void registrationRateLimitPerIp() {
+        AuthAbuseGuard guard = serverGuard("open");
+        for (int i = 0; i < 10; i++) {
+            assertDoesNotThrow(() -> guard.checkRegistrationRate("1.2.3.4"));
+            guard.recordRegistration("1.2.3.4");
+        }
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> guard.checkRegistrationRate("1.2.3.4"));
+        assertNotMistakenForLogout(e.getMessage());
+        // 其他 IP 不受影响
+        assertDoesNotThrow(() -> guard.checkRegistrationRate("5.6.7.8"));
+
+        advance(Duration.ofHours(1).plusMillis(1));
+        assertDoesNotThrow(() -> guard.checkRegistrationRate("1.2.3.4"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/UserServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/UserServiceTest.java
@@ -73,4 +73,33 @@ class UserServiceTest {
 
         assertThrows(IllegalArgumentException.class, () -> userService.login("dave", "wrong"));
     }
+
+    // ==================== 外部账户桥接（awdk-login）建的无密码账号 ====================
+
+    @Test
+    void externalAccountStoresSentinelNotUsablePassword() {
+        when(userRepository.findByUsername("awd_hanzewei")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User u = userService.registerExternal("awd_hanzewei", "韩泽伟");
+
+        assertTrue(u.getPassword().startsWith(UserService.EXTERNAL_ACCOUNT_MARK));
+        assertEquals("韩泽伟", u.getDisplayName());
+    }
+
+    @Test
+    void externalAccountCannotPasswordLogin() {
+        when(userRepository.findByUsername("awd_hanzewei")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        User external = userService.registerExternal("awd_hanzewei", "韩泽伟");
+        when(userRepository.findByUsername("awd_hanzewei")).thenReturn(Optional.of(external));
+
+        // 无论输入什么都拒绝：哨兵字面量、存储值本身，全都不是「正确密码」
+        assertThrows(IllegalArgumentException.class,
+                () -> userService.login("awd_hanzewei", UserService.EXTERNAL_ACCOUNT_MARK));
+        assertThrows(IllegalArgumentException.class,
+                () -> userService.login("awd_hanzewei", external.getPassword()));
+        // 且绝不能触发「历史明文就地升级」——账号必须保持无密码
+        assertTrue(external.getPassword().startsWith(UserService.EXTERNAL_ACCOUNT_MARK));
+    }
 }

--- a/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
@@ -1,0 +1,269 @@
+package com.checkba.service.account;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.DeviceToken;
+import com.checkba.model.entity.User;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.repository.DeviceTokenRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.DeviceTokenService;
+import com.checkba.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 锁定 awdk_ → server 会话桥的契约（插件云后端，官网侧尚未实施 accountId，全程 mock 官网）：
+ * - 开关关闭：业务错误，出站请求根本不发；
+ * - 有效 Key 首登：建无密码用户 + account_binding 映射，签发 awdt_ 且能解析回该用户；
+ * - 同 accountId 再登：复用映射，不再建号；
+ * - 无效 Key（401）：UNAUTHORIZED 拒绝；
+ * - 官网响应缺 accountId：MALFORMED 拒绝（不回落 username 做映射键）;
+ * - awdk_ 明文不落库；
+ * - 所有失败文案不含「登录」「未授权」「请先」子串。
+ */
+class AwdkLoginServiceTest {
+
+    private static final String KEY = "awdk_" + "BridgeKeyMaterial0123456789abcdefghijkl";
+    private static final String ME_OK =
+            "{\"accountId\":\"acc_9f3a\",\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\","
+                    + "\"balanceCents\":1980,\"plan\":\"paid\"}";
+
+    /** 可编排的出站桩（与 AccountServiceTest 同款）。 */
+    static class StubTransport implements AccountTransport {
+        final Deque<Reply> replies = new ArrayDeque<>();
+        final List<String> calls = new ArrayList<>();
+        String lastBearer;
+
+        StubTransport enqueue(int status, String body) {
+            replies.add(new Reply(status, body));
+            return this;
+        }
+
+        StubTransport enqueueNetworkFailure() {
+            replies.add(new Reply(Reply.NETWORK_FAILURE, null));
+            return this;
+        }
+
+        @Override
+        public Reply send(String method, String url, String bearerKey, String jsonBody) {
+            calls.add(method + " " + url);
+            lastBearer = bearerKey;
+            if (replies.isEmpty()) {
+                throw new AssertionError("桩没有为 " + method + " " + url + " 准备响应");
+            }
+            return replies.poll();
+        }
+    }
+
+    private StubTransport transport;
+    private UserService userService;
+    private DeviceTokenService deviceTokenService;
+    private AccountBindingRepository bindingRepository;
+
+    // 内存假库
+    private final Map<String, User> usersByName = new HashMap<>();
+    private final Map<Long, User> usersById = new HashMap<>();
+    private final Map<String, AccountBinding> bindingsByAccountId = new HashMap<>();
+    private final Map<String, DeviceToken> tokensByHash = new HashMap<>();
+    private final AtomicLong userSeq = new AtomicLong(1);
+    private final AtomicLong seq = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        transport = new StubTransport();
+        usersByName.clear();
+        usersById.clear();
+        bindingsByAccountId.clear();
+        tokensByHash.clear();
+
+        UserRepository userRepository = mock(UserRepository.class);
+        when(userRepository.findByUsername(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(usersByName.get(inv.getArgument(0, String.class))));
+        when(userRepository.findById(anyLong()))
+                .thenAnswer(inv -> Optional.ofNullable(usersById.get(inv.getArgument(0, Long.class))));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            if (u.getId() == null) u.setId(userSeq.getAndIncrement());
+            usersByName.put(u.getUsername(), u);
+            usersById.put(u.getId(), u);
+            return u;
+        });
+        userService = new UserService(userRepository);
+
+        DeviceTokenRepository tokenRepository = mock(DeviceTokenRepository.class);
+        when(tokenRepository.save(any(DeviceToken.class))).thenAnswer(inv -> {
+            DeviceToken t = inv.getArgument(0);
+            if (t.getId() == null) t.setId(seq.getAndIncrement());
+            tokensByHash.put(t.getTokenHash(), t);
+            return t;
+        });
+        when(tokenRepository.findByTokenHash(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(tokensByHash.get(inv.getArgument(0, String.class))));
+        deviceTokenService = new DeviceTokenService(tokenRepository);
+
+        bindingRepository = mock(AccountBindingRepository.class);
+        when(bindingRepository.findByExternalAccountId(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(bindingsByAccountId.get(inv.getArgument(0, String.class))));
+        when(bindingRepository.save(any(AccountBinding.class))).thenAnswer(inv -> {
+            AccountBinding b = inv.getArgument(0);
+            if (b.getId() == null) b.setId(seq.getAndIncrement());
+            bindingsByAccountId.put(b.getExternalAccountId(), b);
+            return b;
+        });
+    }
+
+    private AwdkLoginService service(boolean enabled) {
+        return new AwdkLoginService(enabled, "https://www.aiworkdeck.com",
+                transport, bindingRepository, userService, deviceTokenService);
+    }
+
+    private static void assertNotMistakenForLogout(String message) {
+        assertNotNull(message);
+        assertFalse(message.contains("登录"), "文案不得含「登录」: " + message);
+        assertFalse(message.contains("未授权"), "文案不得含「未授权」: " + message);
+        assertFalse(message.contains("请先"), "文案不得含「请先」: " + message);
+    }
+
+    @Test
+    @DisplayName("开关关闭（默认）：业务错误，出站请求根本不发")
+    void disabledRejectsWithoutOutboundCall() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> service(false).login(KEY));
+        assertTrue(e.getMessage().contains("未开启账户桥接"), e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+        assertTrue(transport.calls.isEmpty(), "开关关闭时不得向官网发请求");
+    }
+
+    @Test
+    @DisplayName("有效 Key 首登：建无密码用户 + 绑定映射，awdt_ 令牌解析回该用户")
+    void firstLoginCreatesBindingAndPasswordlessUser() {
+        transport.enqueue(200, ME_OK);
+
+        AwdkLoginService.BridgeSession session = service(true).login(KEY);
+
+        assertEquals("GET https://www.aiworkdeck.com/api/account/me", transport.calls.get(0));
+        assertEquals(KEY, transport.lastBearer, "校验请求必须带 Bearer <key>");
+
+        // 令牌形态与既有设备令牌一致，且解析回新建用户
+        assertTrue(session.token().startsWith(DeviceTokenService.TOKEN_PREFIX));
+        assertEquals(session.userId(), deviceTokenService.resolveUserId(session.token()));
+
+        // 用户：awd_ 前缀、无密码（哨兵），密码登录被拒
+        assertEquals("awd_hanzewei", session.username());
+        User created = usersByName.get("awd_hanzewei");
+        assertTrue(created.getPassword().startsWith(UserService.EXTERNAL_ACCOUNT_MARK));
+        assertThrows(IllegalArgumentException.class,
+                () -> userService.login("awd_hanzewei", created.getPassword()));
+
+        // 绑定：键是 accountId；awdk_ 明文不落库
+        AccountBinding binding = bindingsByAccountId.get("acc_9f3a");
+        assertNotNull(binding);
+        assertEquals(session.userId(), binding.getUserId());
+        assertFalse(binding.toString().contains(KEY));
+    }
+
+    @Test
+    @DisplayName("同 accountId 再登：复用映射同一用户，不再建号")
+    void repeatLoginReusesBinding() {
+        transport.enqueue(200, ME_OK).enqueue(200, ME_OK);
+        AwdkLoginService svc = service(true);
+
+        AwdkLoginService.BridgeSession first = svc.login(KEY);
+        AwdkLoginService.BridgeSession second = svc.login(KEY);
+
+        assertEquals(first.userId(), second.userId());
+        assertEquals(1, usersByName.size(), "不得重复建号");
+        assertNotEquals(first.token(), second.token(), "每次桥接签发独立令牌");
+    }
+
+    @Test
+    @DisplayName("官网用户名与本服务器既有账号撞名：新建带哈希后缀的用户，绝不绑到既有账号")
+    void usernameCollisionNeverHijacksExistingAccount() {
+        // 本服务器已有一个人工注册的 awd_hanzewei
+        User incumbent = userService.register("awd_hanzewei", "pw123456", "本地同名用户");
+        transport.enqueue(200, ME_OK);
+
+        AwdkLoginService.BridgeSession session = service(true).login(KEY);
+
+        assertNotEquals(incumbent.getId(), session.userId(), "撞名绝不能接管既有账号");
+        assertTrue(session.username().startsWith("awd_hanzewei_"), session.username());
+    }
+
+    @Test
+    @DisplayName("无效 Key（401）：UNAUTHORIZED 拒绝，不建任何数据")
+    void invalidKeyRejected() {
+        transport.enqueue(401, "{\"error\":\"invalid_key\"}");
+
+        AccountException e = assertThrows(AccountException.class, () -> service(true).login(KEY));
+
+        assertEquals(AccountException.Kind.UNAUTHORIZED, e.getKind());
+        assertNotMistakenForLogout(e.getMessage());
+        assertFalse(e.getMessage().contains(KEY), "文案不得含 Key 明文");
+        assertTrue(usersByName.isEmpty());
+        assertTrue(bindingsByAccountId.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Key 前缀不对：不发出站请求直接拒绝")
+    void malformedKeyRejectedWithoutOutboundCall() {
+        AccountException e = assertThrows(AccountException.class,
+                () -> service(true).login("sk-or-v1-not-awdk"));
+        assertEquals(AccountException.Kind.UNAUTHORIZED, e.getKind());
+        assertTrue(transport.calls.isEmpty());
+    }
+
+    @Test
+    @DisplayName("官网响应缺 accountId（官网侧尚未实施）：MALFORMED 拒绝，不回落 username 做映射键")
+    void missingAccountIdRejected() {
+        transport.enqueue(200, "{\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\"}");
+
+        AccountException e = assertThrows(AccountException.class, () -> service(true).login(KEY));
+
+        assertEquals(AccountException.Kind.MALFORMED, e.getKind());
+        assertTrue(e.getMessage().contains("accountId"), e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+        assertTrue(usersByName.isEmpty(), "缺映射键时绝不能按 username 建号");
+    }
+
+    @Test
+    @DisplayName("网络不可达：NETWORK（调用方不计入失败锁定）")
+    void networkFailureIsNetworkKind() {
+        transport.enqueueNetworkFailure();
+        AccountException e = assertThrows(AccountException.class, () -> service(true).login(KEY));
+        assertEquals(AccountException.Kind.NETWORK, e.getKind());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("绑定指向的用户已被删除：按首登重建并改指新用户")
+    void deletedUserGetsRecreated() {
+        transport.enqueue(200, ME_OK).enqueue(200, ME_OK);
+        AwdkLoginService svc = service(true);
+        AwdkLoginService.BridgeSession first = svc.login(KEY);
+
+        // 管理员删掉了该用户
+        User gone = usersById.remove(first.userId());
+        usersByName.remove(gone.getUsername());
+
+        AwdkLoginService.BridgeSession second = svc.login(KEY);
+        assertNotEquals(first.userId(), second.userId());
+        assertEquals(second.userId(), bindingsByAccountId.get("acc_9f3a").getUserId());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/MachineAccountGuardTest.java
+++ b/backend/src/test/java/com/checkba/service/account/MachineAccountGuardTest.java
@@ -1,0 +1,116 @@
+package com.checkba.service.account;
+
+import com.checkba.controller.AuthController;
+import com.checkba.model.entity.DeviceToken;
+import com.checkba.model.entity.User;
+import com.checkba.repository.DeviceTokenRepository;
+import com.checkba.service.AdminAccessService;
+import com.checkba.service.DeviceTokenService;
+import com.checkba.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 锁定 server 模式下账户/权益端点的机器级操作闸（插件云后端加固）：
+ * - server 模式：非 admin 拒绝（业务错误，文案不像掉线），admin 放行，无会话报「未登录」；
+ * - local-mode：一字不动，恒放行。
+ */
+class MachineAccountGuardTest {
+
+    private DeviceTokenService deviceTokenService;
+    private UserService userService;
+    private AdminAccessService adminAccessService;
+
+    private final Map<Long, User> usersById = new HashMap<>();
+    private final Map<String, DeviceToken> tokensByHash = new HashMap<>();
+    private final AtomicLong seq = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        // 清掉其他测试可能泄漏进静态入口的 local-mode 身份（LocalIdentityService 构造时反向注册）
+        AuthController.registerLocalIdentityService(null);
+
+        usersById.clear();
+        tokensByHash.clear();
+
+        DeviceTokenRepository tokenRepository = mock(DeviceTokenRepository.class);
+        when(tokenRepository.save(any(DeviceToken.class))).thenAnswer(inv -> {
+            DeviceToken t = inv.getArgument(0);
+            if (t.getId() == null) t.setId(seq.getAndIncrement());
+            tokensByHash.put(t.getTokenHash(), t);
+            return t;
+        });
+        when(tokenRepository.findByTokenHash(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(tokensByHash.get(inv.getArgument(0, String.class))));
+        deviceTokenService = new DeviceTokenService(tokenRepository);
+
+        userService = mock(UserService.class);
+        when(userService.getUserById(anyLong())).thenAnswer(inv -> {
+            Long id = inv.getArgument(0, Long.class);
+            User user = usersById.get(id);
+            if (user == null) throw new IllegalArgumentException("用户不存在: " + id);
+            return user;
+        });
+
+        adminAccessService = new AdminAccessService(); // allow-all-users 默认 false = server 语义
+    }
+
+    private String sessionFor(String username) {
+        User user = new User();
+        user.setId(seq.getAndIncrement());
+        user.setUsername(username);
+        usersById.put(user.getId(), user);
+        return deviceTokenService.issue(user.getId(), "test").plaintext();
+    }
+
+    private MachineAccountGuard guard(boolean localMode) {
+        return new MachineAccountGuard(localMode, adminAccessService, userService);
+    }
+
+    @Test
+    @DisplayName("server 模式：普通用户被业务错误拒绝，文案不含「登录/未授权/请先」")
+    void serverModeRejectsNonAdmin() {
+        String session = sessionFor("alice");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> guard(false).requireMachineScope(session));
+        assertTrue(e.getMessage().contains("仅管理员账号可操作"), e.getMessage());
+        assertFalse(e.getMessage().contains("登录"), e.getMessage());
+        assertFalse(e.getMessage().contains("未授权"), e.getMessage());
+        assertFalse(e.getMessage().contains("请先"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("server 模式：admin 放行")
+    void serverModeAllowsAdmin() {
+        String session = sessionFor("admin");
+        assertDoesNotThrow(() -> guard(false).requireMachineScope(session));
+    }
+
+    @Test
+    @DisplayName("server 模式：无会话报「未登录」（真掉线，本就该触发前端重新认证）")
+    void serverModeRequiresSession() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> guard(false).requireMachineScope(null));
+        assertEquals("未登录", e.getMessage());
+    }
+
+    @Test
+    @DisplayName("local-mode 回归：不查会话不查身份，恒放行")
+    void localModeAlwaysPasses() {
+        assertDoesNotThrow(() -> guard(true).requireMachineScope(null));
+        assertDoesNotThrow(() -> guard(true).requireMachineScope("session_whatever"));
+    }
+}

--- a/doc/desktop-contract.md
+++ b/doc/desktop-contract.md
@@ -1,0 +1,29 @@
+# 桌面/插件 ↔ 官网契约：本仓侧待办条目
+
+**权威契约文档在官网仓** `doc/desktop-contract.md`（人读版）+ `scripts/contract-check.mts`
+（机器可执行版）。本文件只记录由本仓（桌面/server 后端）一侧先行提出、**官网侧尚未实施**的
+契约条目；官网侧落地后应把条目并入权威文档与 contract-check，并从此处删除。
+
+## 待官网侧实施
+
+### 1. `GET /api/account/me` 需增加稳定 `accountId` 字段（2026-08-06，插件云后端 awdk 桥）
+
+- 用途：server 模式桥接端点 `POST /api/auth/awdk-login`（本仓 `AwdkLoginService`）用 awdk_ Key
+  调 `GET /api/account/me` 校验通过后，以 `accountId` 作为 `account_binding.external_account_id`
+  的映射键——同一官网账户在 Key 轮换、username/displayName 改名后仍映射到同一个 server 用户。
+- 要求：字段对账户终身稳定（不随 username / displayName / Key 轮换变化），字符串形态，长度 <= 128。
+- 官网侧落地时须同步官网仓 `doc/desktop-contract.md` 与 `scripts/contract-check.mts`。
+- 未实施期间的桌面仓行为：awdk-login 对缺失 `accountId` 的响应按 MALFORMED 拒绝——**不猜、
+  不回落 username 做映射键**（username 可改名，以它为键会在改名后凭空生出第二个 server 用户）。
+
+### 2. per-user 平台 AI key（设计待办，未排期）
+
+server 模式的平台 AI 通道目前仍是机器级（`~/.aiworkdeck/platform-ai-key.json` 一台机器一把 key），
+多租户下所有用户共享同一账户额度且 `PlatformUsageAccountant` 的差分对账会串位。按用户化的要点：
+
+- 桌面/server 侧：`AccountService` / `PlatformAiChannel` 从机器级文件改 per-user DB 记录
+  （可挂在 `account_binding` 上），每用户一把 provisioned OpenRouter runtime key；
+- 官网侧：`POST /api/account/ai-key` 现成且幂等，per-user 化后由 server 后端代表每个绑定的
+  官网账户各自调用（每次桥接登录时已持有该用户的 awdk_，但明文不落库——需要设计
+  「何时用什么凭据取 key」：候选是桥接时即取即存 per-user key，或官网增加服务端-服务端凭据）；
+- 对账：OpenRouter `GET /api/v1/key` 的累计消费差分随 key 隔离到用户维度，串位问题随之消解。


### PR DESCRIPTION
## 背景

Office 插件将独立运行，官方托管一个 server 模式实例作为插件云后端。server 模式现状是内网团队服务器假设（开放注册、无限流、机器级账户语义），公网暴露前需要加固。本 PR 落地总 spec（`docs/superpowers/specs/2026-08-06-office-addin-and-memory-sync.md` 第六节 Phase D）中可在本仓完成的四项，明确不动 AiAgentController / per-user 平台 AI key / ToolRegistry / version 包 / office-addin。

## 四项改动

### 1. 注册闸
- 新配置 `security.registration-mode: open|closed`，默认 open 保持团队服务器现状。
- closed 时 `POST /api/auth/register` 返回业务错误「本服务器未开放自助注册，请联系服务器管理员开通账号」。
- local-mode 不受影响（旁路）。

### 2. 登录/注册防滥用（`AuthAbuseGuard`）
- 按 IP+用户名维度失败计数：5 次失败锁 10 分钟，到期自动解除，成功清零；锁定期内的拒绝**不再计数**（防轮询把锁无限续期）。
- 注册按 IP 限频：每小时 10 个。
- `/login`、`/device-token`（也是密码登录）、`/awdk-login` 三个入口全部接入。
- 进程内内存实现，无 Redis 依赖；**多实例部署需前置 nginx limit_req**（类注释已注明）。同机反代形态下 remoteAddr 恒为回环、IP 维度退化为全局维度的边界也写在注释里。local-mode 全部旁路。

### 3. server 模式账户端点封堵（`MachineAccountGuard`）
- `account.json`/权益缓存是**机器级**状态：server 模式下普通租户 disconnect 一下，全服的平台 AI 通道就断了。
- server 模式下 `AccountController` 全部端点（status/connect/disconnect/usage）与 `GET /api/entitlements` 仅 admin 可用（复用 `AdminAccessService` 判定），普通用户返回业务错误。
- local-mode 行为一字不动（恒放行）。

### 4. awdk_ → server 会话桥（server 侧）
- 新匿名端点 `POST /api/auth/awdk-login`，body `{key}`；开关 `security.awdk-login-enabled` 默认 false（关闭时业务错误）。
- 开启时：用 Key 调官网 `GET /api/account/me` 实时校验（复用既有 `AccountTransport`/`AccountEndpoint` 出站机制与 https 强制，单测用可注入 transport mock 官网）→ 按官网稳定 `accountId` 查/建 `account_binding` 映射 → 首登 `UserService.registerExternal` 自动建**无密码用户**（`awd_` 前缀；哨兵口令前缀 + `login()` 显式拒绝双保险，且绝不绑到本服务器既有同名账号）→ `DeviceTokenService.issue` 签发 awdt_ 返回 `{token, userId, username}`，插件端长期凭据形态与现状一致。
- awdk_ 明文**不落库**：每次 awdk-login 都重验官网。
- `accountId` 缺失按 MALFORMED 拒绝，不回落 username 做映射键（username 可改名，会凭空生出第二个 server 用户）。

## 契约待办（官网侧）

本仓没有 `doc/desktop-contract.md` 与 `scripts/contract-check.mts`（权威契约文档在官网仓），因此新建了本仓 `doc/desktop-contract.md` 专记「本仓先行提出、官网侧尚未实施」的条目：
1. **`GET /api/account/me` 增加稳定 `accountId` 字段**（字符串、终身稳定、<=128）；官网落地时同步官网仓的契约文档与 contract-check。
2. **per-user 平台 AI key 设计要点**（未排期）：机器级 platform-ai-key 文件改 per-user DB 记录（可挂 account_binding），官网 `POST /api/account/ai-key` 现成幂等，需设计服务端取 key 的凭据形态；对账串位随 key 隔离消解。

## 测试

`cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test` 全绿：**891 通过 / 0 失败 / 2 既有跳过**。

新增用例：
- `AuthAbuseGuardTest`（9）：闸开/关两态、5 次锁定与到期解除、维度隔离、成功清零、窗口过期、local-mode 旁路、注册限频。
- `AwdkLoginServiceTest`（9）：开关关闭不出站、首登建号+绑定+令牌可解析、复用映射、撞名不接管既有账号、401 拒绝、缺 accountId 拒绝、网络失败分类、被删用户重建、明文不落库。
- `MachineAccountGuardTest`（4）+ `AccountControllerMachineScopeTest`（2）：server 模式非 admin 全端点拒绝且服务层零触碰、admin 照常、local-mode 回归。
- `AuthControllerHardeningTest`（7）：端点级接线（闸在业务动作前、锁定不再触碰凭据校验/不再出站、信封正确）。
- `UserServiceTest` 新增 2 条：无密码账户哨兵、任何输入（含哨兵字面量与存储值本身）都不能密码登录。

所有失败文案逐条断言不含「登录/未授权/请先」子串（licensing 领域地雷 1）。`account_binding` 为标准 JPA 定义（IDENTITY 主键 + 唯一约束），H2/PG 双方言兼容。

领域文档 `.claude/agents/licensing-billing.md` 已同步（新开关、端点、地雷 12/13、验证清单）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)