### PR TITLE
feat: office_* 工具桥 + 会话级客户端能力过滤（Phase C）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -52,6 +52,17 @@ EDITOR_ACTIONS 全集在 `libreofficeExecutorClient.js:15-67`（含宿主自发�
 
 **电子表格（Calc / xlsx）sheet_\* 原语**：doc_\* 是 Writer 专属（`xModel.getText()` 在 Calc 文档上必然失败），xlsx 走 sheet_\* 全集（工具名=action 名，不做映射）——单元格面：`sheet_get_overview / sheet_read_range / sheet_write_cells / sheet_select_range / sheet_format_cells / sheet_set_borders / sheet_set_row_col`；结构面：`sheet_manage_sheets`（工作表增删改名移动）/ `sheet_edit_rows_cols`（插删行列）/ `sheet_merge_cells` / `sheet_sort_range`（XSortable，SortFields 是纯 Array of TableSortField 值结构体）/ `sheet_set_autofilter`（经命名 DatabaseRanges，set 语义而非 .uno: toggle）/ `sheet_freeze_panes`（XViewFreezable）/ `sheet_conditional_format`（命中外观落自建 CellStyle `__awd_cf_N`，每次调用替换区域现有规则）；`sheet_create_file` 是纯后端工具（POI 建最小空白 xlsx + 注册 + sendOpenFileAction，无 worker action）。worker 端 `resolveSheet` 统一守卫文档类型（非 Calc 返回明确错误）并把命中的工作表切为活动表。Calc 没有 redline，写入即生效——安全网是 doc_undo 与文档检查点（写类工具都打了 `fileEffect="MODIFIED"`）。地雷：`VertJustify` 声明 long、个别引擎按 short 校验（失败退 shortAny）；写入时数字样式字符串落数值但**前导 0 的编号保持文本**；数字格式经 `getNumberFormats().queryKey/addNew`（非法格式码会抛）；**setFormula 走 API 文法**——参数分隔符必须分号（逗号 Err:508）、跨表引用必须 `Sheet.A1`（`Sheet!A1` 报 #NAME?），worker 的 `normalizeFormula` 在字符串字面量外做 `,`→`;`、`!`→`.` 归一（Excel 数组字面量与 Calc 交集操作符 `!` 被牺牲，AI 公式里趋近于零）；引擎 LO 24.2 **无 XLOOKUP**（24.8 才有），出错公式经 `sheet_write_cells` 返回值 `formulaErrors` 报给 AI 自纠，读回侧 `readCellOut` 先查 `getError()`（否则错误格伪装成 0）。
 
+## 第二条桥：office_* 工具桥（Word 插件，Phase C）
+
+与 LOWA 桥并存的独立桥，服务 `office-addin/`（Word 任务窗格插件）。**逐字同构但零共享**：不复用 EditorBridgeService、超时常量独立、单名契约（无双轨旧名）。
+
+- `backend/src/main/java/com/checkba/service/ai/OfficeBridgeService.java` — requestId + CompletableFuture + SSE `client_action`（tool 固定 `office_command`，payload `{requestId, command, args, conversationId}`）+ 30s 超时。失败一律 `{"error": ...}`（Jackson 序列化，非手拼），ToolResult.success() 靠该前缀防绿勾空转。
+- `backend/src/main/java/com/checkba/controller/ai/OfficeResultController.java` — `POST /api/agent/office/result`（body `{requestId, ok, data|error}`）。会话归属**不信任请求体**：以桥挂起表按 requestId 登记的 conversationId 为准，再过 canUseConversation。
+- `backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java` — office_* 工具集 v1（工具名 ≠ command 名）：office_get_text→get_text、office_get_selection→get_selection、office_search→search、office_replace_text→replace_text、office_insert_text→insert_text、office_add_comment→add_comment。conversationId 参数由 ToolRegistry 服务端注入（不走 EditorBridgeService 的 ThreadLocal）。
+- `office-addin/taskpane/lib/officeExecutor.js` — 插件端执行器（Office.js 实现全集 + COMMAND_DISPLAY_NAMES 中文名表）；ChatView 消费 client_action(tool=office_command) → 执行 → postOfficeResult 回传。修改类命令执行前置 `changeTrackingMode=TrackAll`（Word 原生修订）、执行后恢复原值；WordApi 1.4 不支持时降级直接修改并标 `tracked:false`。
+
+**会话级客户端能力过滤**：chat 请求可选 `clientCapability`（lowa/office/none，缺省 lowa）→ `ClientCapabilityService`（按 conversationId 内存登记）→ ToolRegistry 三消费点过滤（getAllSpecifications(conversationId)/execute/resolve(name, conversationId)）：office 会话隐藏 doc_* 与 sheet_*，lowa 会话隐藏 office_*，none 全隐藏。判定按工具名前缀（doc_/sheet_=LOWA 专属，office_=插件专属）。末位提醒与 <active_document> 段文案在 ContextAssemblerService 按能力三分支切换。
+
 ## 命名双轨现状（PR#192，下个发布周期摘旧名）
 
 仍活着的 wps_* 旧名：后端 `sendDualNamedAction`（doc_open_file/wps_open_file、doc_reload_file/wps_reload_file）、executeEditorCommand 双发 editor_command/wps_command、doc_open_file_sync↔wps_open_file_sync、doc_stream_data/wps_stream_data 双发、`/wps-result` 路由别名；前端 handleClientAction 显式识别全部旧名+latch 去重、toolDisplayNames 把 wps_* 归一为 doc_*。
@@ -70,6 +81,8 @@ EDITOR_ACTIONS 全集在 `libreofficeExecutorClient.js:15-67`（含宿主自发�
 - **`insert_at_cursor` 对带 markdown 标记的文本走剥离转换**（`MD_MARKER_RE` 判定，**→真粗体、行首 # 剥掉），纯文本原样插入；改插入路径要想到这两条分支。`insert_under_heading` 曾经后端一直派发但 worker 没实现+白名单没收录（静默失败年久失修），已补齐。
 - **改标准格式规范要改两处**：worker `HOUSE`（office_thread.js）+ 后端 `DocxStyleHelper`（编辑器流式 与 write_docx 两条路径各一份，规范必须一致）。
 - 流式中断（onError）也会发 doc_stream_end——新增流式相关终止分支时别忘了这个收尾信号，否则 worker 状态机残留半张表。
+- **新增 office_* 工具三件套**：OfficeEditTools 加 @Tool + officeExecutor.js 加 HANDLERS 实现 + COMMAND_DISPLAY_NAMES 加中文名（主前端 toolDisplayNames.js 兜底同步）。没有客户端实现的远端工具 = 30s 超时空转（与 doc_* 四件套同款地雷）。
+- **能力过滤靠工具名前缀**（doc_/sheet_/office_）：新增 LOWA 专属或插件专属工具必须沿用对应前缀，否则会漏到不该见它的会话里；ToolRegistry 构造器加了 ClientCapabilityService，改它要同步 RecordingToolRegistry（EvalHarness）与各测试构造点。
 
 ## 验证
 

--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -5,13 +5,14 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 
 # Office 插件 领域地图
 
-职责边界：`office-addin/` 目录下的 Office Add-in（任务窗格 UI、Office.js 文档访问、与后端的连接/对话链路）。总 spec 见 `docs/superpowers/specs/2026-08-06-office-addin-and-memory-sync.md`（Phase B 已落地脚手架；Phase C 工具桥、Phase D 云后端生产化未做）。SSE/编排契约本体属 ai-chat 领域。
+职责边界：`office-addin/` 目录下的 Office Add-in（任务窗格 UI、Office.js 文档访问、与后端的连接/对话链路、office_command 执行器）。总 spec 见 `docs/superpowers/specs/2026-08-06-office-addin-and-memory-sync.md`（Phase B 脚手架、Phase C 工具桥+会话能力过滤已落地；Phase D 云后端生产化未做）。SSE/编排契约本体属 ai-chat 领域；office_* 后端桥（OfficeBridgeService/OfficeEditTools/能力过滤）详见 ai-doc-bridge 领域文档「第二条桥」一节。
 
 ## 关键文件
 
 - `office-addin/manifest.xml` — XML add-in only 清单（不是 unified JSON）。Hosts 目前只有 Document（Word）；开发态 URL 全指 `https://localhost:3000`，部署时整体替换。改后跑 `npx office-addin-manifest validate manifest.xml`（Version 必须 >= 1.0，低了直接判非法）。
 - `office-addin/taskpane.html` — 入口页。**office.js 必须从微软官方 CDN 以 script 标签引入，绝不打包进 bundle**（微软明令禁止自托管/打包）。
-- `office-addin/taskpane/` — Vue3 源码：`App.vue`（视图切换+项目下拉）、`components/SettingsView.vue`（后端地址+awdt_ 令牌+连接测试）、`components/ChatView.vue`（对话）、`lib/`（settings/api/sse/wordDoc）。
+- `office-addin/taskpane/` — Vue3 源码：`App.vue`（视图切换+项目下拉）、`components/SettingsView.vue`（后端地址+awdt_ 令牌+连接测试）、`components/ChatView.vue`（对话+office_command 消费+工具活动 chip）、`lib/`（settings/api/sse/wordDoc/officeExecutor）。
+- `office-addin/taskpane/lib/officeExecutor.js` — **office_command 执行器**：HANDLERS 表（get_text/get_selection/search/replace_text/insert_text/add_comment 的 Office.js 实现）+ COMMAND_DISPLAY_NAMES 固定中文名。未知 command 回 `{ok:false, error:'unsupported command'}`。
 - `office-addin/vite.config.js` — 端口 3000；自动读 `~/.office-addin-dev-certs` 证书启 https；`publicDir: 'assets'`（图标构建时拷入 dist 根，URL 无 /assets 前缀）。
 
 ## 核心契约
@@ -19,7 +20,8 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 - **鉴权**：awdt_ 设备令牌放 `X-Session-Id` 请求头（后端 `getUserIdFromSession` 前缀解析）。连接测试 = `GET /api/projects/my`。
 - **对话**：`POST /api/agent/chat` + `GET /api/agent/connect/{cid}` SSE（fetch + ReadableStream，与主前端 useAgentStream 同一消费方式）。conversationId 客户端生成 `conv-<毫秒>`，插件会话独立。
 - **文档上下文**：Word.run 读 body.text，经 `activeContext.inlineContent` 内联上送（客户端 200k 截断）；activeContext.id 用合成值 `office-current-document`（后端不会拿它读库，但 id 非空是注入门槛）。后端侧 inlineContent 优先于 read_document，见 ContextAssemblerService.resolveActiveDocumentContent（服务端同样 200k 上限）。
-- **SSE 事件**：MVP 只消费 text_delta/bubble_end/error/cancelled；text_delta 内容按 XML 标签轻量分流（final+裸文本=主回复、thinking=折叠），`client_action` 等留给 Phase C。
+- **SSE 事件**：消费 text_delta/bubble_end/error/cancelled + `client_action`（仅 tool=office_command，其余 editor_command 等 LOWA 契约一律忽略）；text_delta 内容按 XML 标签轻量分流（final+裸文本=主回复、thinking=折叠）。
+- **工具桥（Phase C）**：chat 请求带 `clientCapability: "office"` → 后端本会话只见 office_* 工具（doc_*/sheet_* 隐藏，防 30s 超时死路径）。命令链：SSE client_action `{tool:'office_command', requestId, command, args}` → officeExecutor 执行 → `POST /api/agent/office/result`（body `{requestId, ok, data|error}`，X-Session-Id 令牌鉴权，后端按挂起表校验会话归属）。修改类命令（replace_text/insert_text）执行前置 `changeTrackingMode=TrackAll`、执行后恢复原值（Word 原生修订）；WordApi 1.4 不支持时降级直接修改并标 `tracked:false`，add_comment 则直接报错。
 
 ## 已知地雷
 
@@ -27,10 +29,12 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 - 全局禁 emoji；包管理 npm 不是 pnpm。
 - 部署期 CORS：插件正式 Origin 要进 `security.cors.allowed-origins`；local-mode 下 LocalModeAccessFilter 用同一份白名单硬拦非 GET 跨站请求。`security.cors.allow-all` 绝不能开。localhost/127.0.0.1 默认放行，开发态零配置。
 - Office 只加载 https 任务窗格：dev 证书 `npx office-addin-dev-certs install`，vite 配置自动拾取。
-- Phase C 之前不要注册任何 office_* 远端执行工具（客户端还没有执行器，会是死路径——PptxEditTools 教训）。
+- **新增 office_* 工具三件套**：后端 OfficeEditTools 加 @Tool + officeExecutor.js 的 HANDLERS 加实现 + COMMAND_DISPLAY_NAMES 加中文名。没有客户端实现的远端工具 = 30s 超时空转（PptxEditTools 教训）。
+- Word 的 body.search 查找串上限 255 字符（后端工具已前置校验）；search/replace 的锚点必须与文档文本精确一致（matchCase）。
+- 修改类命令必须恢复用户原有的修订开关状态（withTracking 的 finally 恢复），别改成常开。
 
 ## 验证
 
 - `cd office-addin && npm install && npm run build`；manifest 校验见上。
-- sideload 手测清单与步骤全在 `office-addin/README.md`。
-- 后端 inlineContent 路径单测：`mvn test -Dtest=ContextAssemblerServiceTest`（JDK 21）。
+- sideload 手测清单与步骤全在 `office-addin/README.md`（含工具桥场景：AI 改文档要出现 Word 原生修订）。
+- 后端单测（JDK 21）：`mvn test -Dtest='ContextAssemblerServiceTest,OfficeBridgeServiceTest,OfficeResultControllerTest,ToolRegistryCapabilityFilterTest,OfficeEditToolsTest'`。

--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -31,6 +31,7 @@ public class AiAgentController {
     private final com.checkba.service.ai.TodoListService todoListService;
     private final com.checkba.service.ai.AgentRunStateService agentRunStateService;
     private final com.checkba.service.ProjectMemberService projectMemberService;
+    private final com.checkba.service.ai.ClientCapabilityService clientCapabilityService;
 
     @org.springframework.beans.factory.annotation.Autowired
     public AiAgentController(SseEmitterService sseEmitterService,
@@ -40,7 +41,8 @@ public class AiAgentController {
                             com.checkba.service.ai.tools.PptxTools pptxTools,
                             com.checkba.service.ai.TodoListService todoListService,
                             com.checkba.service.ai.AgentRunStateService agentRunStateService,
-                            com.checkba.service.ProjectMemberService projectMemberService) {
+                            com.checkba.service.ProjectMemberService projectMemberService,
+                            com.checkba.service.ai.ClientCapabilityService clientCapabilityService) {
         this.sseEmitterService = sseEmitterService;
         this.agentOrchestrator = agentOrchestrator;
         this.messageService = messageService;
@@ -49,6 +51,7 @@ public class AiAgentController {
         this.todoListService = todoListService;
         this.agentRunStateService = agentRunStateService;
         this.projectMemberService = projectMemberService;
+        this.clientCapabilityService = clientCapabilityService;
     }
 
     /**
@@ -143,8 +146,11 @@ public class AiAgentController {
             return ResponseEntity.status(403).body("{\"status\":\"error\", \"message\":\"无权操作该会话\"}");
         }
 
-        log.info("Received Agent Chat Request: project={}, conversation={}, mode={}, msg={}", 
+        log.info("Received Agent Chat Request: project={}, conversation={}, mode={}, msg={}",
                 request.getProjectId(), request.getConversationId(), request.getAgentMode(), request.getMessage());
+
+        // 会话级客户端能力登记（Phase C）：lowa（默认，主前端）/ office（Word 插件）/ none（纯对话）
+        clientCapabilityService.record(request.getConversationId(), request.getClientCapability());
 
         agentOrchestrator.handleUserMessage(request, userId);
         
@@ -297,6 +303,11 @@ public class AiAgentController {
         private java.util.List<ContextItem> contextItems; // New: Full context metadata
         private ContextItem activeContext; // NEW: Auto-detected active tab (current document)
         private String pinnedSkillId; // 用户在对话中钉选的 Skill；为空则走触发词自动匹配
+        /**
+         * 可选：客户端文档编辑能力（lowa / office / none，Phase C）。
+         * 缺省按 lowa 处理，兼容不发送该字段的存量主前端。
+         */
+        private String clientCapability;
 
         public Long getProjectId() { return projectId; }
         public void setProjectId(Long projectId) { this.projectId = projectId; }
@@ -321,6 +332,8 @@ public class AiAgentController {
         public void setActiveContext(ContextItem activeContext) { this.activeContext = activeContext; }
         public String getPinnedSkillId() { return pinnedSkillId; }
         public void setPinnedSkillId(String pinnedSkillId) { this.pinnedSkillId = pinnedSkillId; }
+        public String getClientCapability() { return clientCapability; }
+        public void setClientCapability(String clientCapability) { this.clientCapability = clientCapability; }
     }
     
     /**

--- a/backend/src/main/java/com/checkba/controller/ai/OfficeResultController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/OfficeResultController.java
@@ -1,0 +1,70 @@
+package com.checkba.controller.ai;
+
+import com.checkba.service.ai.OfficeBridgeService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Office 插件操作结果接收控制器（Phase C 工具桥）。
+ *
+ * Word 任务窗格插件执行完 office_command 后回传结果。
+ * 归属校验思路与 EditorResultController 相同，但会话 ID 不信任请求体——
+ * 以后端挂起表中 requestId 登记的 conversationId 为准（插件伪造不了归属）。
+ */
+@RestController
+@RequestMapping("/api/agent/office")
+@RequiredArgsConstructor
+@Slf4j
+public class OfficeResultController {
+
+    private final OfficeBridgeService officeBridgeService;
+    private final com.checkba.service.ProjectAiMessageService messageService;
+
+    @PostMapping("/result")
+    public OfficeResultResponse receiveOfficeResult(@RequestBody OfficeResultPayload payload,
+                                                    @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        // 归属校验：结果会以工具输出身份进入模型上下文并驱动后续动作，
+        // 拿到 requestId 不等于有权回传——必须是该会话的可用用户
+        Long userId = com.checkba.controller.AuthController.getUserIdFromSession(sessionId);
+        String conversationId = officeBridgeService.getPendingConversationId(payload.getRequestId());
+        if (conversationId == null) {
+            log.warn("Rejected office result: unknown or expired requestId={}", payload.getRequestId());
+            return new OfficeResultResponse(false, "请求不存在或已超时");
+        }
+        if (!messageService.canUseConversation(conversationId, userId)) {
+            log.warn("Rejected office result: requestId={}, conversationId={}", payload.getRequestId(), conversationId);
+            return new OfficeResultResponse(false, "无权回传该会话的结果");
+        }
+
+        log.info("Received office result: requestId={}, ok={}", payload.getRequestId(), payload.isOk());
+        try {
+            officeBridgeService.completeOfficeAction(
+                    payload.getRequestId(), payload.isOk(), payload.getData(), payload.getError());
+            return new OfficeResultResponse(true, "Result received");
+        } catch (Exception e) {
+            log.error("Failed to process office result", e);
+            return new OfficeResultResponse(false, e.getMessage());
+        }
+    }
+
+    /** 回传请求体：{requestId, ok, data|error} */
+    @Data
+    public static class OfficeResultPayload {
+        /** 请求 ID（与 SSE 下发的 requestId 对应） */
+        private String requestId;
+        /** 是否成功 */
+        private boolean ok;
+        /** 结果数据（成功时） */
+        private Object data;
+        /** 错误信息（失败时） */
+        private String error;
+    }
+
+    @Data
+    public static class OfficeResultResponse {
+        private final boolean received;
+        private final String message;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -863,8 +863,9 @@ public class AgentOrchestrator {
             model.generate(messages, handler);
         } else {
             // Agent 和 Plan 模式：传递工具规格（内置 + 插件，统一来自注册表）
+            // 会话客户端能力过滤（Phase C：office/lowa/none）在注册表内完成；
             // Skill 命中时由 SkillRouter 做可见性白名单裁剪（Phase 3B，未命中原样返回）
-            List<ToolSpecification> allTools = skillRouter.visibleTools(conversationId, toolRegistry.getAllSpecifications());
+            List<ToolSpecification> allTools = skillRouter.visibleTools(conversationId, toolRegistry.getAllSpecifications(conversationId));
             model.generate(messages, allTools, handler);
         }
     }

--- a/backend/src/main/java/com/checkba/service/ai/ClientCapabilityService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ClientCapabilityService.java
@@ -1,0 +1,97 @@
+package com.checkba.service.ai;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 会话级客户端能力登记（Phase C：office_* 工具桥）。
+ *
+ * 背景：同一个后端同时服务两类文档编辑客户端——
+ * 1. 主前端（嵌入式 LibreOffice 编辑器，LOWA）：执行 doc_* / sheet_* 远端指令；
+ * 2. Office 任务窗格插件（Word）：执行 office_* 远端指令。
+ * 远端执行类工具在客户端没有对应实现时就是死路径——模型调用后阻塞 30 秒
+ * 超时空转（PptxEditTools 教训）。因此按会话记录客户端能力，
+ * ToolRegistry 的三个消费点（getAllSpecifications / execute / resolve）据此过滤。
+ *
+ * 能力由 chat 请求的可选字段 clientCapability 声明（lowa / office / none），
+ * 缺省 lowa 保持现状兼容（存量主前端不发送该字段）。
+ *
+ * 生命周期与 EditorBridgeService 的 conversationId 语义一致：按会话记录、
+ * 进程内存态、不落库；条目极小（枚举值），不做主动清理。
+ */
+@Service
+@Slf4j
+public class ClientCapabilityService {
+
+    /** 客户端能力档位 */
+    public enum Capability {
+        /** 主前端：嵌入式 LibreOffice 编辑器（默认，兼容存量客户端） */
+        LOWA,
+        /** Office 任务窗格插件（Word，office_* 执行器） */
+        OFFICE,
+        /** 无文档编辑执行器（纯对话客户端） */
+        NONE
+    }
+
+    private final ConcurrentHashMap<String, Capability> byConversation = new ConcurrentHashMap<>();
+
+    /**
+     * 记录一次 chat 请求声明的客户端能力。
+     * raw 为空或无法识别时按 LOWA 处理（现状兼容）。
+     */
+    public void record(String conversationId, String raw) {
+        if (conversationId == null || conversationId.isBlank()) {
+            return;
+        }
+        Capability parsed = parse(raw);
+        Capability previous = byConversation.put(conversationId, parsed);
+        if (previous != null && previous != parsed) {
+            log.info("Client capability changed for conversation {}: {} -> {}", conversationId, previous, parsed);
+        }
+    }
+
+    /** 会话能力；未登记（含 conversationId 为 null）时默认 LOWA。 */
+    public Capability capabilityOf(String conversationId) {
+        if (conversationId == null) {
+            return Capability.LOWA;
+        }
+        return byConversation.getOrDefault(conversationId, Capability.LOWA);
+    }
+
+    /**
+     * 工具对该会话是否可见。
+     * doc_* / sheet_* 是 LOWA 专属远端执行工具（经 EditorBridgeService 等前端回执）；
+     * office_* 是 Office 插件专属（经 OfficeBridgeService 等插件回执）；
+     * 其余工具（纯后端执行）对所有能力档位可见。
+     */
+    public boolean isToolVisible(String toolName, String conversationId) {
+        if (toolName == null) {
+            return false;
+        }
+        boolean lowaOnly = toolName.startsWith("doc_") || toolName.startsWith("sheet_");
+        boolean officeOnly = toolName.startsWith("office_");
+        if (!lowaOnly && !officeOnly) {
+            return true;
+        }
+        return switch (capabilityOf(conversationId)) {
+            case LOWA -> lowaOnly;
+            case OFFICE -> officeOnly;
+            case NONE -> false;
+        };
+    }
+
+    private static Capability parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Capability.LOWA;
+        }
+        try {
+            return Capability.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown clientCapability '{}', falling back to LOWA", raw);
+            return Capability.LOWA;
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -41,6 +41,7 @@ public class ContextAssemblerService {
     private final FileContextLoader fileContextLoader;
     private final AiContextProperties contextProperties;
     private final com.checkba.service.ai.skill.SkillRouter skillRouter;
+    private final ClientCapabilityService clientCapabilityService;
 
     // 记忆系统组件（读侧：写侧见 MemoryPipelineService）
     private final MemoryManager memoryManager;
@@ -241,15 +242,30 @@ public class ContextAssemblerService {
                      activeContext.getInlineContent() != null && !activeContext.getInlineContent().isEmpty());
 
             String content = resolveActiveDocumentContent(activeContext);
+            ClientCapabilityService.Capability capability = clientCapabilityService.capabilityOf(conversationId);
 
             systemText.append("\n\n# Active Document (当前活跃文档)\n");
             systemText.append("该文档（id=").append(activeContext.getId())
                       .append(", name=").append(activeContext.getName())
                       .append("）**已在编辑器中打开**，就是用户此刻正在看的文档。");
             systemText.append("用户说\"修订一下\"\"这个文档\"\"当前文档\"或未指明对象时，默认就是指它。\n");
-            systemText.append("所有 doc_* 编辑/读取工具直接作用于该文档——**无需也不要**调用 ");
-            systemText.append("`doc_list_project_files` 或 `doc_open_file` 去重新发现/打开它；");
-            systemText.append("只有用户明确要操作**其他**文档时才需要那两个工具。\n\n");
+            switch (capability) {
+                case OFFICE -> {
+                    systemText.append("该文档在用户本机的 Microsoft Word 中打开，正文已随本请求内联注入下方。");
+                    systemText.append("读取/修改它一律使用 office_* 工具（office_get_text / office_search / ");
+                    systemText.append("office_replace_text / office_insert_text / office_add_comment 等），");
+                    systemText.append("修改会以 Word 原生修订形式呈现。本会话没有 doc_* 工具。\n\n");
+                }
+                case NONE -> {
+                    systemText.append("当前客户端没有文档编辑执行器：正文仅供阅读分析，");
+                    systemText.append("请以文字形式给出分析结论或修改建议，不要尝试调用文档编辑工具。\n\n");
+                }
+                default -> {
+                    systemText.append("所有 doc_* 编辑/读取工具直接作用于该文档——**无需也不要**调用 ");
+                    systemText.append("`doc_list_project_files` 或 `doc_open_file` 去重新发现/打开它；");
+                    systemText.append("只有用户明确要操作**其他**文档时才需要那两个工具。\n\n");
+                }
+            }
 
             if (content != null && !content.isEmpty()) {
                 // Truncate if too long
@@ -263,10 +279,15 @@ public class ContextAssemblerService {
                 systemText.append(fenceSafe(content));
                 systemText.append("\n]]></active_document>\n");
             } else {
-                // 正文暂时读不到也要保留文档标识，模型仍可用 doc_get_document_text 等工具直接读
+                // 正文暂时读不到也要保留文档标识，模型仍可用读取类工具（按会话能力）直接读
+                String readHint = switch (capability) {
+                    case OFFICE -> "[正文暂不可读，可用 office_get_text 直接读取]";
+                    case NONE -> "[正文暂不可读]";
+                    default -> "[正文暂不可读，可用 doc_get_document_text 直接分段读取]";
+                };
                 systemText.append("<active_document id=\"").append(activeContext.getId())
                           .append("\" name=\"").append(attrSafe(activeContext.getName()))
-                          .append("\">[正文暂不可读，可用 doc_get_document_text 直接分段读取]</active_document>\n");
+                          .append("\">").append(readHint).append("</active_document>\n");
             }
         }
 
@@ -371,7 +392,8 @@ public class ContextAssemblerService {
         // 声明被弱模型（如 DeepSeek Flash）稳定无视——实测注入了正文仍先调 doc_list_project_files
         // 重新发现文档。末位消息是注意力最高的位置，这里再说一次才真正生效。
         messages.add(dev.langchain4j.data.message.UserMessage.from(
-                userPrompt + activeDocumentReminder(activeContext)));
+                userPrompt + activeDocumentReminder(activeContext,
+                        clientCapabilityService.capabilityOf(conversationId))));
 
         return messages;
     }
@@ -398,16 +420,31 @@ public class ContextAssemblerService {
     }
 
     /**
-     * 活跃文档的末位提醒（拼在用户消息尾部）。无活跃文档时返回空串。
+     * 活跃文档的末位提醒（拼在用户消息尾部），文案按会话客户端能力切换（Phase C）：
+     * lowa=doc_* 口径（现状）；office=office_* 口径（正文已内联注入，改动经 office_* 落到 Word）；
+     * none=只读口径。无活跃文档时返回空串。
      */
-    private String activeDocumentReminder(com.checkba.controller.ai.AiAgentController.ContextItem activeContext) {
+    private String activeDocumentReminder(com.checkba.controller.ai.AiAgentController.ContextItem activeContext,
+                                          ClientCapabilityService.Capability capability) {
         if (activeContext == null || activeContext.getId() == null || activeContext.getId().isEmpty()) {
             return "";
         }
-        return "\n\n[系统提醒] 编辑器中当前已打开文档" + activeDocDisplayName(activeContext.getName()) + "（id="
-                + activeContext.getId() + "），其正文见 system prompt 的 <active_document>。"
-                + "用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——"
-                + "直接调用 doc_* 工具操作，**禁止**再调 doc_list_project_files 或 doc_open_file 去重新发现或打开它。";
+        String docLabel = activeDocDisplayName(activeContext.getName());
+        return switch (capability) {
+            case OFFICE -> "\n\n[系统提醒] 用户此刻在 Microsoft Word 中打开着文档" + docLabel + "，"
+                    + "其正文已内联注入 system prompt 的 <active_document>，可直接阅读分析。"
+                    + "用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——"
+                    + "需要修改文档时调用 office_* 工具（office_replace_text / office_insert_text / "
+                    + "office_add_comment 等）落到 Word，修改会以 Word 原生修订形式呈现。";
+            case NONE -> "\n\n[系统提醒] 用户当前查看的文档是" + docLabel + "，"
+                    + "其正文见 system prompt 的 <active_document>，仅供阅读分析。"
+                    + "本会话的客户端没有文档编辑执行器，请以文字形式给出结论或修改建议，"
+                    + "不要尝试调用文档编辑工具。";
+            default -> "\n\n[系统提醒] 编辑器中当前已打开文档" + docLabel + "（id="
+                    + activeContext.getId() + "），其正文见 system prompt 的 <active_document>。"
+                    + "用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——"
+                    + "直接调用 doc_* 工具操作，**禁止**再调 doc_list_project_files 或 doc_open_file 去重新发现或打开它。";
+        };
     }
 
     /** 内联正文防滥用上限：超出即截断（客户端可随请求直接携带正文，不能无限吃内存）。 */

--- a/backend/src/main/java/com/checkba/service/ai/OfficeBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/OfficeBridgeService.java
@@ -1,0 +1,141 @@
+package com.checkba.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Office 插件桥接服务（后端 ↔ Word 任务窗格插件）。
+ *
+ * 与 {@link EditorBridgeService}（LOWA 编辑器桥）逐字同构但完全独立：
+ * 不共享超时常量、不参与 doc_* 与 wps_* 双轨命名、契约从第一天起就是单名。
+ *
+ * 工作流程：
+ * 1. Agent 调用 office_* 工具 -> OfficeEditTools 调用 executeOfficeCommand
+ * 2. 生成 requestId，经 SSE client_action 下发（tool 固定为 "office_command"，
+ *    payload {requestId, command, args, conversationId}），创建 CompletableFuture 等待
+ * 3. 插件执行 Office.js 操作后 POST /api/agent/office/result 回传
+ *    （body {requestId, ok, data|error}，控制器做会话归属校验）
+ * 4. completeOfficeAction 解锁 CompletableFuture，工具拿到结果返回给模型
+ *
+ * 失败一律以 {"error": "..."} JSON 返回——ToolRegistry.ToolResult.success()
+ * 靠这个前缀识别失败，防止绿勾空转（F-09 教训）。
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OfficeBridgeService {
+
+    private final SseEmitterService sseEmitterService;
+    private final ObjectMapper objectMapper;
+
+    /** 挂起的请求：requestId -> (conversationId, future)。conversationId 供回传端点做归属校验。 */
+    private final ConcurrentHashMap<String, PendingRequest> pendingRequests = new ConcurrentHashMap<>();
+
+    /** Office 插件操作超时（秒）。独立常量，不与 LOWA 的 EDITOR_ACTION_TIMEOUT 共享。 */
+    private static final int OFFICE_ACTION_TIMEOUT_SECONDS = 30;
+
+    /** 实际生效的超时秒数（测试用包内可见 setter 覆盖，生产恒为常量值）。 */
+    private volatile int timeoutSeconds = OFFICE_ACTION_TIMEOUT_SECONDS;
+
+    void setTimeoutSecondsForTest(int seconds) {
+        this.timeoutSeconds = seconds;
+    }
+
+    private record PendingRequest(String conversationId, CompletableFuture<OfficeActionResult> future) {
+    }
+
+    /**
+     * 下发一条 Office 命令并阻塞等待插件回传结果。
+     *
+     * @param conversationId 会话 ID（office_* 工具经 ToolRegistry 服务端注入）
+     * @param command        命令名（get_text / get_selection / search / replace_text / insert_text / add_comment）
+     * @param args           命令参数
+     * @return 成功时为结果数据的 JSON；失败时为 {"error": "..."} JSON
+     */
+    public String executeOfficeCommand(String conversationId, String command, Map<String, Object> args) {
+        if (conversationId == null || conversationId.isBlank()) {
+            return errorJson("缺少会话上下文，无法下发 Office 命令。");
+        }
+
+        String requestId = UUID.randomUUID().toString();
+        CompletableFuture<OfficeActionResult> future = new CompletableFuture<>();
+        pendingRequests.put(requestId, new PendingRequest(conversationId, future));
+
+        try {
+            Map<String, Object> payload = new java.util.HashMap<>();
+            payload.put("tool", "office_command");
+            payload.put("requestId", requestId);
+            payload.put("command", command);
+            payload.put("args", args != null ? args : Map.of());
+            payload.put("conversationId", conversationId);
+            sseEmitterService.send(conversationId, "client_action", objectMapper.writeValueAsString(payload));
+            log.info("Sent office command: command={}, requestId={}", command, requestId);
+
+            OfficeActionResult result = future.get(timeoutSeconds, TimeUnit.SECONDS);
+            if (result.ok()) {
+                return objectMapper.writeValueAsString(result.data());
+            }
+            String error = result.error() != null && !result.error().isBlank()
+                    ? result.error() : "插件执行失败（未提供错误信息）";
+            return errorJson(error);
+
+        } catch (TimeoutException e) {
+            log.warn("Office command timed out: command={}, requestId={}", command, requestId);
+            return errorJson("操作超时：Office 插件未在 " + timeoutSeconds
+                    + " 秒内返回结果。请确认 Word 中的插件任务窗格处于打开状态。");
+        } catch (Exception e) {
+            log.error("Failed to execute office command: command={}", command, e);
+            return errorJson("Office 命令执行异常：" + e.getMessage());
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    /**
+     * 挂起请求所属的会话 ID；无此请求（未知 requestId 或已超时清理）返回 null。
+     * 供回传端点先校验会话归属、再解锁 future。
+     */
+    public String getPendingConversationId(String requestId) {
+        if (requestId == null) {
+            return null;
+        }
+        PendingRequest pending = pendingRequests.get(requestId);
+        return pending != null ? pending.conversationId() : null;
+    }
+
+    /**
+     * 完成一次 Office 操作（由 OfficeResultController 在归属校验通过后调用）。
+     */
+    public void completeOfficeAction(String requestId, boolean ok, Object data, String error) {
+        PendingRequest pending = pendingRequests.get(requestId);
+        if (pending == null) {
+            log.warn("No pending office request found for requestId={}", requestId);
+            return;
+        }
+        pending.future().complete(new OfficeActionResult(ok, data, error));
+        log.info("Completed office action: requestId={}, ok={}", requestId, ok);
+    }
+
+    /** 统一的失败 JSON（ToolResult.success() 依赖 {"error" 前缀识别失败）。 */
+    private String errorJson(String message) {
+        try {
+            return objectMapper.writeValueAsString(Map.of("error", message == null ? "未知错误" : message));
+        } catch (Exception e) {
+            // message 已经过 Jackson 失败才会走到这里，保底手拼一个无特殊字符的错误
+            return "{\"error\": \"Office 桥接序列化失败\"}";
+        }
+    }
+
+    /** 一次 Office 操作的结果 */
+    public record OfficeActionResult(boolean ok, Object data, String error) {
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -107,14 +107,17 @@ public class ToolRegistry {
 
     private final List<AgentToolComponent> toolComponents;
     private final PluginService pluginService;
+    private final ClientCapabilityService clientCapabilityService;
 
     private final Map<String, RegisteredTool> builtinTools = new ConcurrentHashMap<>();
     private final Map<String, RegisteredTool> pluginToolCache = new ConcurrentHashMap<>();
     private final List<ToolSpecification> builtinSpecifications = new ArrayList<>();
 
-    public ToolRegistry(List<AgentToolComponent> toolComponents, PluginService pluginService) {
+    public ToolRegistry(List<AgentToolComponent> toolComponents, PluginService pluginService,
+                        ClientCapabilityService clientCapabilityService) {
         this.toolComponents = toolComponents;
         this.pluginService = pluginService;
+        this.clientCapabilityService = clientCapabilityService;
     }
 
     @PostConstruct
@@ -165,6 +168,21 @@ public class ToolRegistry {
     }
 
     /**
+     * 按会话客户端能力过滤后的全部工具规格（Phase C）：
+     * office 会话隐藏 doc_* 与 sheet_*（LOWA 专属远端执行工具），LOWA 会话隐藏 office_*，
+     * none 会话两者都隐藏。conversationId 为 null 时按默认能力（LOWA）处理。
+     */
+    public List<ToolSpecification> getAllSpecifications(String conversationId) {
+        List<ToolSpecification> filtered = new ArrayList<>();
+        for (ToolSpecification spec : getAllSpecifications()) {
+            if (clientCapabilityService.isToolVisible(spec.name(), conversationId)) {
+                filtered.add(spec);
+            }
+        }
+        return filtered;
+    }
+
+    /**
      * 插件启停过滤：内置工具（不属于任何插件，pid == null）恒可见；
      * 插件工具仅在所属插件启用时可见。
      */
@@ -190,6 +208,17 @@ public class ToolRegistry {
         }
         names.sort(Comparator.comparingInt(String::length).reversed());
         return names;
+    }
+
+    /**
+     * 会话能力感知的 resolve（Phase C）：能力档位下不可见的工具视同不存在。
+     * 无会话语境的元数据查询（展示名等）仍可用单参 {@link #resolve(String)}。
+     */
+    public Optional<RegisteredTool> resolve(String name, String conversationId) {
+        if (name != null && !clientCapabilityService.isToolVisible(name, conversationId)) {
+            return Optional.empty();
+        }
+        return resolve(name);
     }
 
     public Optional<RegisteredTool> resolve(String name) {
@@ -237,7 +266,8 @@ public class ToolRegistry {
      */
     public ToolResult execute(String name, String argsJson, ToolContext ctx) {
         String resolvedName = TOOL_NAME_ALIASES.getOrDefault(name, name);
-        Optional<RegisteredTool> toolOpt = resolve(resolvedName);
+        // 会话能力过滤：能力档位下不可见的工具按"不存在"拒绝（模型收到与未知工具一致的反馈）
+        Optional<RegisteredTool> toolOpt = resolve(resolvedName, ctx != null ? ctx.conversationId() : null);
         if (toolOpt.isEmpty()) {
             return new ToolResult("Tool not found or arguments invalid.", null, false);
         }

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
@@ -150,8 +150,11 @@ public class SubAgentService {
      */
     SubAgentResult runLoop(String subtaskId, String taskDescription, String expectedOutput,
                            List<String> toolScope, ToolContext parentCtx) {
-        Set<String> allowed = resolveScope(toolScope);
-        List<ToolSpecification> specs = toolRegistry.getAllSpecifications().stream()
+        // 子 Agent 继承主会话的客户端能力（不变式 3 同款思路）：
+        // office 会话派生的子 Agent 同样不该看到 doc_*/sheet_* 死路径工具
+        String parentConversationId = parentCtx != null ? parentCtx.conversationId() : null;
+        Set<String> allowed = resolveScope(toolScope, parentConversationId);
+        List<ToolSpecification> specs = toolRegistry.getAllSpecifications(parentConversationId).stream()
                 .filter(s -> allowed.contains(s.name()))
                 .toList();
 
@@ -245,10 +248,10 @@ public class SubAgentService {
      * 解析 tool_scope 为别名解析后的可用工具名集合。
      * 空 scope = 全部已注册工具；dispatch_subtask 无条件排除（防递归第一道防线）。
      */
-    private Set<String> resolveScope(List<String> toolScope) {
+    private Set<String> resolveScope(List<String> toolScope, String conversationId) {
         Set<String> allowed = new LinkedHashSet<>();
         if (toolScope == null || toolScope.isEmpty()) {
-            for (ToolSpecification spec : toolRegistry.getAllSpecifications()) {
+            for (ToolSpecification spec : toolRegistry.getAllSpecifications(conversationId)) {
                 allowed.add(spec.name());
             }
         } else {

--- a/backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java
@@ -1,0 +1,147 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.OfficeBridgeService;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Office 插件文档工具集 v1（Word 任务窗格，Phase C 工具桥）。
+ *
+ * 每个工具 = 参数校验 + 调 OfficeBridgeService 下发 office_command + 透传结果。
+ * 命令由插件端 officeExecutor（Office.js）执行：修改类命令走 Word 原生修订
+ * （changeTrackingMode=TrackAll），修订以 Word 审阅面板原生形态呈现。
+ *
+ * 可见性：office_* 仅对 clientCapability=office 的会话可见
+ * （ClientCapabilityService + ToolRegistry 过滤），LOWA 会话看不到这些工具，
+ * 反之 office 会话看不到 doc_* 与 sheet_*——远端工具没有执行器就是 30 秒超时死路径。
+ *
+ * conversationId 参数由 ToolRegistry 从服务端上下文强制注入（SERVER_CONTEXT_PARAMS），
+ * 模型传入值一律被忽略。
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OfficeEditTools implements AgentToolComponent {
+
+    private final OfficeBridgeService officeBridgeService;
+
+    // ==================== 读取 ====================
+
+    @Tool("读取当前 Word 文档的全文纯文本。超长文档会被截断（约 20 万字符）。")
+    @ToolMeta(displayName = "读取文档", category = "office")
+    public String office_get_text(
+            @P("会话ID（系统自动注入）") String conversationId
+    ) {
+        log.info("Tool: office_get_text called");
+        return officeBridgeService.executeOfficeCommand(conversationId, "get_text", Map.of());
+    }
+
+    @Tool("读取用户当前在 Word 中选中的文本内容。未选中时返回空文本。")
+    @ToolMeta(displayName = "读取选区", category = "office")
+    public String office_get_selection(
+            @P("会话ID（系统自动注入）") String conversationId
+    ) {
+        log.info("Tool: office_get_selection called");
+        return officeBridgeService.executeOfficeCommand(conversationId, "get_selection", Map.of());
+    }
+
+    @Tool("在当前 Word 文档中查找文本，返回命中数量与每处命中所在段落的上下文。查找串最长 255 字符。")
+    @ToolMeta(displayName = "查找文本", category = "office")
+    public String office_search(
+            @P("会话ID（系统自动注入）") String conversationId,
+            @P("要查找的文本") String query
+    ) {
+        log.info("Tool: office_search called, query={}", query);
+        if (query == null || query.isBlank()) {
+            return "Error: 查找文本不能为空";
+        }
+        if (query.length() > 255) {
+            return "Error: 查找文本过长（Word 查找上限 255 字符），请缩短后重试";
+        }
+        return officeBridgeService.executeOfficeCommand(conversationId, "search", Map.of("query", query));
+    }
+
+    // ==================== 修改（Word 原生修订） ====================
+
+    @Tool("在当前 Word 文档中查找并替换文本，修改以 Word 原生修订（Track Changes）形式呈现。" +
+          "searchText 必须与文档中的文本精确一致；replaceAll=false 时只替换第一处。")
+    @ToolMeta(displayName = "替换文本（修订）", category = "office", fileEffect = "MODIFIED")
+    public String office_replace_text(
+            @P("会话ID（系统自动注入）") String conversationId,
+            @P("要查找的原文（须与文档精确一致）") String searchText,
+            @P("替换后的新文本") String replaceText,
+            @P("是否替换所有匹配（false=仅第一处）") Boolean replaceAll
+    ) {
+        log.info("Tool: office_replace_text called, search={}, replaceAll={}", searchText, replaceAll);
+        if (searchText == null || searchText.isBlank()) {
+            return "Error: 查找文本不能为空";
+        }
+        if (searchText.length() > 255) {
+            return "Error: 查找文本过长（Word 查找上限 255 字符）。可分段替换，或用 office_insert_text 配合较短锚点";
+        }
+        if (replaceText == null) {
+            return "Error: 替换文本不能为 null（删除文本请传空字符串）";
+        }
+        Map<String, Object> args = new HashMap<>();
+        args.put("searchText", searchText);
+        args.put("replaceText", replaceText);
+        args.put("replaceAll", replaceAll != null && replaceAll);
+        return officeBridgeService.executeOfficeCommand(conversationId, "replace_text", args);
+    }
+
+    @Tool("在当前 Word 文档中插入文本，插入以 Word 原生修订（Track Changes）形式呈现。" +
+          "提供 anchorText 时在该锚点前/后插入（锚点须与文档精确一致）；不提供时在用户当前光标/选区处插入。")
+    @ToolMeta(displayName = "插入文本（修订）", category = "office", fileEffect = "MODIFIED")
+    public String office_insert_text(
+            @P("会话ID（系统自动注入）") String conversationId,
+            @P("要插入的文本") String text,
+            @P("定位锚点文本（可选；为空则在当前光标/选区处插入）") String anchorText,
+            @P("相对锚点的位置：before 或 after（默认 after，仅提供锚点时有效）") String position
+    ) {
+        log.info("Tool: office_insert_text called, anchor={}, position={}", anchorText, position);
+        if (text == null || text.isEmpty()) {
+            return "Error: 插入文本不能为空";
+        }
+        if (anchorText != null && anchorText.length() > 255) {
+            return "Error: 锚点文本过长（Word 查找上限 255 字符），请改用更短的唯一锚点";
+        }
+        String pos = position == null || position.isBlank() ? "after" : position.trim().toLowerCase();
+        if (!"before".equals(pos) && !"after".equals(pos)) {
+            return "Error: position 只能是 before 或 after";
+        }
+        Map<String, Object> args = new HashMap<>();
+        args.put("text", text);
+        args.put("anchorText", anchorText == null ? "" : anchorText);
+        args.put("position", pos);
+        return officeBridgeService.executeOfficeCommand(conversationId, "insert_text", args);
+    }
+
+    @Tool("在当前 Word 文档中为指定文本添加批注（Word 原生批注）。anchorText 须与文档中的文本精确一致，批注挂在第一处匹配上。")
+    @ToolMeta(displayName = "插入批注", category = "office", fileEffect = "MODIFIED")
+    public String office_add_comment(
+            @P("会话ID（系统自动注入）") String conversationId,
+            @P("要批注的目标文本（须与文档精确一致）") String anchorText,
+            @P("批注内容") String comment
+    ) {
+        log.info("Tool: office_add_comment called, anchor={}", anchorText);
+        if (anchorText == null || anchorText.isBlank()) {
+            return "Error: 批注目标文本不能为空";
+        }
+        if (anchorText.length() > 255) {
+            return "Error: 批注目标文本过长（Word 查找上限 255 字符），请截取其中一段唯一文本作为目标";
+        }
+        if (comment == null || comment.isBlank()) {
+            return "Error: 批注内容不能为空";
+        }
+        Map<String, Object> args = new HashMap<>();
+        args.put("anchorText", anchorText);
+        args.put("comment", comment);
+        return officeBridgeService.executeOfficeCommand(conversationId, "add_comment", args);
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/ai/OfficeResultControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/OfficeResultControllerTest.java
@@ -1,0 +1,79 @@
+package com.checkba.controller.ai;
+
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ai.OfficeBridgeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Office 结果回传端点的会话归属校验：
+ * 结果会以工具输出身份进入模型上下文，requestId 不是回传凭证——
+ * 归属以后端挂起表登记的 conversationId 为准，且回传者必须可用该会话。
+ */
+class OfficeResultControllerTest {
+
+    private OfficeBridgeService bridge;
+    private ProjectAiMessageService messageService;
+    private OfficeResultController controller;
+
+    @BeforeEach
+    void setUp() {
+        bridge = mock(OfficeBridgeService.class);
+        messageService = mock(ProjectAiMessageService.class);
+        controller = new OfficeResultController(bridge, messageService);
+    }
+
+    private static OfficeResultController.OfficeResultPayload payload(String requestId, boolean ok) {
+        OfficeResultController.OfficeResultPayload p = new OfficeResultController.OfficeResultPayload();
+        p.setRequestId(requestId);
+        p.setOk(ok);
+        p.setData(java.util.Map.of("text", "hello"));
+        return p;
+    }
+
+    @Test
+    @DisplayName("归属校验通过：结果解锁挂起的 future")
+    void acceptedWhenConversationUsable() {
+        when(bridge.getPendingConversationId("req-1")).thenReturn("conv-1");
+        when(messageService.canUseConversation(eq("conv-1"), any())).thenReturn(true);
+
+        var resp = controller.receiveOfficeResult(payload("req-1", true), null);
+
+        assertTrue(resp.isReceived());
+        verify(bridge).completeOfficeAction(eq("req-1"), eq(true), any(), any());
+    }
+
+    @Test
+    @DisplayName("无权会话：拒绝回传，不触碰挂起表")
+    void rejectedWhenConversationNotUsable() {
+        when(bridge.getPendingConversationId("req-1")).thenReturn("conv-1");
+        when(messageService.canUseConversation(eq("conv-1"), any())).thenReturn(false);
+
+        var resp = controller.receiveOfficeResult(payload("req-1", true), null);
+
+        assertFalse(resp.isReceived());
+        verify(bridge, never()).completeOfficeAction(any(), org.mockito.ArgumentMatchers.anyBoolean(), any(), any());
+    }
+
+    @Test
+    @DisplayName("未知/过期 requestId：拒绝回传（会话归属无从谈起）")
+    void rejectedWhenRequestUnknown() {
+        when(bridge.getPendingConversationId("req-gone")).thenReturn(null);
+
+        var resp = controller.receiveOfficeResult(payload("req-gone", true), null);
+
+        assertFalse(resp.isReceived());
+        verify(bridge, never()).completeOfficeAction(any(), org.mockito.ArgumentMatchers.anyBoolean(), any(), any());
+        verify(messageService, never()).canUseConversation(any(), any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
@@ -39,6 +39,7 @@ class ContextAssemblerServiceTest {
 
     private LegalTools legalTools;
     private ContextAssemblerService assembler;
+    private ClientCapabilityService capabilityService;
 
     @BeforeEach
     void setUp() {
@@ -56,9 +57,10 @@ class ContextAssemblerServiceTest {
         ContextCompressor contextCompressor = mock(ContextCompressor.class);
         when(contextCompressor.needsCompression(any(), any())).thenReturn(false);
 
+        capabilityService = new ClientCapabilityService();
         assembler = new ContextAssemblerService(
                 legalTools, messageService, fileContextLoader,
-                new AiContextProperties(), skillRouter, memoryManager, contextCompressor);
+                new AiContextProperties(), skillRouter, capabilityService, memoryManager, contextCompressor);
     }
 
     private List<ChatMessage> assembleMessages(AiAgentController.ContextItem activeContext) {
@@ -195,7 +197,8 @@ class ContextAssemblerServiceTest {
         props.getFiles().setMaxCharsPerFile(500_000);
         ContextAssemblerService bigLimitAssembler = new ContextAssemblerService(
                 legalTools, mockedMessageService(), mock(FileContextLoader.class),
-                props, mockedSkillRouter(), mockedMemoryManager(), mockedCompressor());
+                props, mockedSkillRouter(), new ClientCapabilityService(),
+                mockedMemoryManager(), mockedCompressor());
 
         String huge = "甲".repeat(200_001);
         List<ChatMessage> messages = bigLimitAssembler.assemble(
@@ -216,6 +219,58 @@ class ContextAssemblerServiceTest {
         assertTrue(lastUser.contains("[系统提醒]"), "内联正文路径也应有末位提醒");
         assertTrue(lastUser.contains("劳动合同.docx"), "提醒里应点名当前文档");
         assertTrue(lastUser.contains("doc_list_project_files"), "应点名禁用 doc_list_project_files");
+    }
+
+    // ==== 末位提醒按会话客户端能力切换（Phase C）====
+    // office 会话的编辑工具是 office_*，提醒里再点名 doc_* 就是把模型往死路径上引。
+
+    @Test
+    @DisplayName("office 会话：末位提醒改用 office_* 口径，不再点名 doc_* 工具")
+    void reminderSwitchesToOfficeWordingForOfficeCapability() {
+        capabilityService.record("conv-1", "office");
+
+        String lastUser = assembleLastUserText(officeDoc("第一条 试用期为三个月……"));
+
+        assertTrue(lastUser.contains("[系统提醒]"), "office 会话也应有末位提醒");
+        assertTrue(lastUser.contains("office_replace_text"), "应指引用 office_* 工具修改文档");
+        assertTrue(lastUser.contains("修订"), "应说明修改以 Word 原生修订呈现");
+        assertFalse(lastUser.contains("doc_list_project_files"), "office 会话不应再点名 doc_* 工具");
+        assertFalse(lastUser.contains("doc_open_file"), "office 会话不应再点名 doc_* 工具");
+    }
+
+    @Test
+    @DisplayName("office 会话：system prompt 活跃文档段同样切换为 office_* 口径")
+    void systemPromptActiveDocSectionSwitchesForOfficeCapability() {
+        capabilityService.record("conv-1", "office");
+
+        String systemText = assembleSystemText(officeDoc("第一条 试用期为三个月……"));
+
+        assertTrue(systemText.contains("office_get_text"), "应指引用 office_* 工具读取");
+        // 基底 system_prompt.md 里仍有 doc_* 工具表（会话工具过滤才是硬闸门），
+        // 这里只断言活跃文档段自身的 LOWA 口径语句没有出现
+        assertFalse(systemText.contains("**无需也不要**调用"), "活跃文档段不应再是 doc_* 口径");
+    }
+
+    @Test
+    @DisplayName("none 会话：末位提醒为只读口径，不点名任何编辑工具")
+    void reminderReadOnlyForNoneCapability() {
+        capabilityService.record("conv-1", "none");
+
+        String lastUser = assembleLastUserText(officeDoc("第一条 试用期为三个月……"));
+
+        assertTrue(lastUser.contains("[系统提醒]"), "none 会话也应有末位提醒");
+        assertTrue(lastUser.contains("仅供阅读"), "应说明只读语义");
+        assertFalse(lastUser.contains("office_"), "none 会话不应点名 office_* 工具");
+        assertFalse(lastUser.contains("doc_list_project_files"), "none 会话不应点名 doc_* 工具");
+    }
+
+    @Test
+    @DisplayName("默认（未声明能力）会话：保持现状 doc_* 口径")
+    void reminderKeepsLowaWordingByDefault() {
+        String lastUser = assembleLastUserText(officeDoc("第一条 试用期为三个月……"));
+
+        assertTrue(lastUser.contains("doc_list_project_files"), "默认能力应保持 doc_* 口径");
+        assertFalse(lastUser.contains("office_replace_text"), "默认能力不应出现 office_* 口径");
     }
 
     // ---- 供自建 assembler 的 mock 工厂（与 setUp 同配方）----

--- a/backend/src/test/java/com/checkba/service/ai/OfficeBridgeServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/OfficeBridgeServiceTest.java
@@ -1,0 +1,137 @@
+package com.checkba.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * OfficeBridgeService（Office 插件桥）的请求-应答 / 超时 / 错误 JSON 行为测试。
+ *
+ * 桥与 EditorBridgeService 同构但完全独立：单名契约（tool=office_command）、
+ * 独立超时常量、失败一律 {"error": ...}（ToolResult.success() 依赖该前缀判失败，
+ * 防绿勾空转）。
+ */
+class OfficeBridgeServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SseEmitterService sse;
+    private OfficeBridgeService bridge;
+    private final List<String> sentPayloads = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        sse = mock(SseEmitterService.class);
+        bridge = new OfficeBridgeService(sse, objectMapper);
+        sentPayloads.clear();
+    }
+
+    /** 让 SSE 下发即刻被"插件"处理：从 payload 里取 requestId 并回传结果 */
+    private void autoRespond(boolean ok, Object data, String error) {
+        doAnswer(inv -> {
+            String payload = String.valueOf((Object) inv.getArgument(2));
+            sentPayloads.add(payload);
+            String requestId = objectMapper.readTree(payload).get("requestId").asText();
+            bridge.completeOfficeAction(requestId, ok, data, error);
+            return null;
+        }).when(sse).send(any(), eq("client_action"), any());
+    }
+
+    @Test
+    @DisplayName("请求-应答：下发 office_command 载荷，成功结果按数据 JSON 透传")
+    void roundTripSuccess() throws Exception {
+        autoRespond(true, Map.of("text", "第一条 合作范围"), null);
+
+        String result = bridge.executeOfficeCommand("conv-1", "get_text", Map.of());
+
+        assertEquals("第一条 合作范围", objectMapper.readTree(result).get("text").asText());
+        // 载荷契约：tool 固定 office_command，携带 requestId/command/args/conversationId
+        var payload = objectMapper.readTree(sentPayloads.get(0));
+        assertEquals("office_command", payload.get("tool").asText());
+        assertEquals("get_text", payload.get("command").asText());
+        assertEquals("conv-1", payload.get("conversationId").asText());
+        assertFalse(payload.get("requestId").asText().isBlank());
+        assertTrue(payload.has("args"));
+    }
+
+    @Test
+    @DisplayName("失败结果：返回 {\"error\": ...}，且被 ToolResult.success() 判为失败（防绿勾空转）")
+    void failureBecomesErrorJson() throws Exception {
+        autoRespond(false, null, "未找到目标文本 \"第三条\"");
+
+        String result = bridge.executeOfficeCommand("conv-1", "replace_text",
+                Map.of("searchText", "第三条", "replaceText", "第四条"));
+
+        // 含引号的错误信息也必须是合法 JSON（Jackson 序列化而非手拼）
+        assertEquals("未找到目标文本 \"第三条\"", objectMapper.readTree(result).get("error").asText());
+        assertFalse(new ToolRegistry.ToolResult(result, null, true).success(),
+                "错误 JSON 必须被 ToolResult 判为失败");
+    }
+
+    @Test
+    @DisplayName("超时：插件不回传时返回超时错误 JSON，挂起表清理")
+    void timeoutYieldsErrorJson() throws Exception {
+        bridge.setTimeoutSecondsForTest(1);
+        doAnswer(inv -> {
+            sentPayloads.add(String.valueOf((Object) inv.getArgument(2)));
+            return null; // 不回传
+        }).when(sse).send(any(), eq("client_action"), any());
+
+        String result = bridge.executeOfficeCommand("conv-1", "get_text", Map.of());
+
+        assertTrue(objectMapper.readTree(result).get("error").asText().contains("超时"));
+        String requestId = objectMapper.readTree(sentPayloads.get(0)).get("requestId").asText();
+        assertNull(bridge.getPendingConversationId(requestId), "超时后挂起请求应被清理");
+        assertFalse(new ToolRegistry.ToolResult(result, null, true).success());
+    }
+
+    @Test
+    @DisplayName("无会话上下文：直接返回错误 JSON，不下发任何指令")
+    void missingConversationRejectedUpfront() throws Exception {
+        String result = bridge.executeOfficeCommand(null, "get_text", Map.of());
+
+        assertTrue(objectMapper.readTree(result).has("error"));
+        org.mockito.Mockito.verifyNoInteractions(sse);
+    }
+
+    @Test
+    @DisplayName("归属查询：挂起期间可查到 conversationId，未知 requestId 返回 null")
+    void pendingConversationLookup() {
+        doAnswer(inv -> {
+            String payload = String.valueOf((Object) inv.getArgument(2));
+            String requestId = objectMapper.readTree(payload).get("requestId").asText();
+            assertEquals("conv-9", bridge.getPendingConversationId(requestId),
+                    "挂起期间应能按 requestId 查到会话归属");
+            bridge.completeOfficeAction(requestId, true, Map.of(), null);
+            return null;
+        }).when(sse).send(any(), eq("client_action"), any());
+
+        bridge.executeOfficeCommand("conv-9", "get_selection", Map.of());
+
+        assertNull(bridge.getPendingConversationId("no-such-request"));
+    }
+
+    @Test
+    @DisplayName("失败但插件未给错误信息时，兜底文案仍是错误 JSON")
+    void failureWithoutErrorMessageStillErrorJson() throws Exception {
+        autoRespond(false, null, null);
+
+        String result = bridge.executeOfficeCommand("conv-1", "search", Map.of("query", "试用期"));
+
+        assertTrue(objectMapper.readTree(result).has("error"));
+        assertFalse(new ToolRegistry.ToolResult(result, null, true).success());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/ToolRegistryCapabilityFilterTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolRegistryCapabilityFilterTest.java
@@ -1,0 +1,138 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.ai.tools.AgentToolComponent;
+import com.checkba.service.ai.tools.ToolContext;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 会话级客户端能力过滤（Phase C）：ToolRegistry 三个消费点
+ * （getAllSpecifications / execute / resolve）按会话能力过滤——
+ * office 会话不见 doc_* 与 sheet_*，LOWA 会话不见 office_*，none 两者都不见。
+ * 远端执行工具没有客户端执行器就是 30 秒超时死路径（PptxEditTools 教训）。
+ */
+class ToolRegistryCapabilityFilterTest {
+
+    /** 覆盖三类前缀 + 普通后端工具的假工具集（名称避开真实工具） */
+    static class CapFakeTools implements AgentToolComponent {
+        @Tool("lowa doc tool")
+        public String doc_cap_probe(@P("t") String t) { return "doc:" + t; }
+
+        @Tool("lowa sheet tool")
+        public String sheet_cap_probe(@P("t") String t) { return "sheet:" + t; }
+
+        @Tool("office tool")
+        public String office_cap_probe(@P("t") String t) { return "office:" + t; }
+
+        @Tool("plain backend tool")
+        public String plain_cap_probe(@P("t") String t) { return "plain:" + t; }
+    }
+
+    private ClientCapabilityService capabilities;
+    private ToolRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        capabilities = new ClientCapabilityService();
+        registry = new ToolRegistry(List.of(new CapFakeTools()), new PluginService(), capabilities);
+        registry.init();
+    }
+
+    private List<String> specNames(String conversationId) {
+        return registry.getAllSpecifications(conversationId).stream().map(ToolSpecification::name).toList();
+    }
+
+    private ToolContext ctx(String conversationId) {
+        return new ToolContext(1L, conversationId, 7L, "model-x");
+    }
+
+    @Test
+    @DisplayName("office 会话：spec 不含 doc_*/sheet_*，execute 拒绝，resolve 不命中；office_* 正常")
+    void officeSessionHidesLowaTools() {
+        capabilities.record("conv-office", "office");
+
+        List<String> names = specNames("conv-office");
+        assertFalse(names.contains("doc_cap_probe"));
+        assertFalse(names.contains("sheet_cap_probe"));
+        assertTrue(names.contains("office_cap_probe"));
+        assertTrue(names.contains("plain_cap_probe"));
+
+        assertTrue(registry.resolve("doc_cap_probe", "conv-office").isEmpty());
+        assertTrue(registry.resolve("sheet_cap_probe", "conv-office").isEmpty());
+        assertTrue(registry.resolve("office_cap_probe", "conv-office").isPresent());
+
+        ToolRegistry.ToolResult denied = registry.execute("doc_cap_probe", "{\"t\":\"x\"}", ctx("conv-office"));
+        assertFalse(denied.found(), "office 会话 execute doc_* 应按未知工具拒绝");
+        ToolRegistry.ToolResult ok = registry.execute("office_cap_probe", "{\"t\":\"x\"}", ctx("conv-office"));
+        assertTrue(ok.found());
+        assertTrue(ok.output().contains("office:x"));
+    }
+
+    @Test
+    @DisplayName("lowa 会话：spec 不含 office_*，execute 拒绝，resolve 不命中；doc_*/sheet_* 正常")
+    void lowaSessionHidesOfficeTools() {
+        capabilities.record("conv-lowa", "lowa");
+
+        List<String> names = specNames("conv-lowa");
+        assertTrue(names.contains("doc_cap_probe"));
+        assertTrue(names.contains("sheet_cap_probe"));
+        assertFalse(names.contains("office_cap_probe"));
+
+        assertTrue(registry.resolve("office_cap_probe", "conv-lowa").isEmpty());
+        assertTrue(registry.resolve("doc_cap_probe", "conv-lowa").isPresent());
+
+        ToolRegistry.ToolResult denied = registry.execute("office_cap_probe", "{\"t\":\"x\"}", ctx("conv-lowa"));
+        assertFalse(denied.found());
+        ToolRegistry.ToolResult ok = registry.execute("doc_cap_probe", "{\"t\":\"x\"}", ctx("conv-lowa"));
+        assertTrue(ok.found());
+    }
+
+    @Test
+    @DisplayName("none 会话：doc_*/sheet_*/office_* 全部隐藏，普通后端工具不受影响")
+    void noneSessionHidesAllEditorTools() {
+        capabilities.record("conv-none", "none");
+
+        List<String> names = specNames("conv-none");
+        assertFalse(names.contains("doc_cap_probe"));
+        assertFalse(names.contains("sheet_cap_probe"));
+        assertFalse(names.contains("office_cap_probe"));
+        assertTrue(names.contains("plain_cap_probe"));
+
+        assertFalse(registry.execute("doc_cap_probe", "{}", ctx("conv-none")).found());
+        assertFalse(registry.execute("office_cap_probe", "{}", ctx("conv-none")).found());
+        assertTrue(registry.execute("plain_cap_probe", "{\"t\":\"x\"}", ctx("conv-none")).found());
+    }
+
+    @Test
+    @DisplayName("默认兼容现状：未声明能力（含 conversationId 为 null）按 lowa 处理")
+    void unrecordedConversationDefaultsToLowa() {
+        List<String> names = specNames("conv-never-recorded");
+        assertTrue(names.contains("doc_cap_probe"), "未登记会话应保持现状（doc_* 可见）");
+        assertFalse(names.contains("office_cap_probe"), "未登记会话不应看到 office_*");
+
+        assertTrue(registry.resolve("doc_cap_probe", null).isPresent());
+        assertTrue(registry.execute("doc_cap_probe", "{\"t\":\"x\"}", ctx(null)).found());
+        assertFalse(registry.execute("office_cap_probe", "{}", ctx(null)).found());
+
+        // 非法能力值按 lowa 兜底
+        capabilities.record("conv-weird", "quantum");
+        assertTrue(specNames("conv-weird").contains("doc_cap_probe"));
+    }
+
+    @Test
+    @DisplayName("单参 resolve（无会话语境的元数据查询）不受能力过滤影响")
+    void singleArgResolveUnfiltered() {
+        capabilities.record("conv-office", "office");
+        assertTrue(registry.resolve("doc_cap_probe").isPresent(),
+                "无会话语境的 resolve 仍应命中（供展示名等元数据查询）");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
@@ -67,7 +67,7 @@ class ToolRegistryTest {
 
     @BeforeEach
     void setUp() {
-        registry = new ToolRegistry(List.of(new FakeTools()), new PluginService());
+        registry = new ToolRegistry(List.of(new FakeTools()), new PluginService(), new ClientCapabilityService());
         registry.init();
     }
 
@@ -204,7 +204,7 @@ class ToolRegistryTest {
     @DisplayName("启停：禁用插件后规格/名单/分发全部不可见，重新启用即恢复，内置工具不受影响")
     void disabledPluginToolsAreHidden() {
         PluginService ps = pluginServiceWith("my-plugin", List.of("network"), null);
-        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps);
+        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps, new ClientCapabilityService());
         reg.init();
 
         // 启用态：插件工具可见可分发
@@ -235,7 +235,7 @@ class ToolRegistryTest {
     @DisplayName("权限：工具所需权限未在 manifest permissions 声明时分发被拒绝")
     void undeclaredPermissionIsRejected() {
         PluginService ps = pluginServiceWith("my-plugin", List.of("file_read"), List.of("network"));
-        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps);
+        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps, new ClientCapabilityService());
         reg.init();
 
         ToolRegistry.ToolResult r = reg.execute("plugin_echo", "{\"text\":\"hi\"}", ctx);
@@ -249,12 +249,12 @@ class ToolRegistryTest {
     @DisplayName("权限：所需权限已声明时正常执行；未声明所需权限的工具（v1 兼容）不受影响")
     void declaredPermissionAllowsExecution() {
         PluginService declared = pluginServiceWith("p1", List.of("network"), List.of("network"));
-        ToolRegistry reg1 = new ToolRegistry(List.of(new FakeTools()), declared);
+        ToolRegistry reg1 = new ToolRegistry(List.of(new FakeTools()), declared, new ClientCapabilityService());
         reg1.init();
         assertEquals("plugin:ok", reg1.execute("plugin_echo", "{\"text\":\"ok\"}", ctx).output());
 
         PluginService legacy = pluginServiceWith("p2", null, null);
-        ToolRegistry reg2 = new ToolRegistry(List.of(new FakeTools()), legacy);
+        ToolRegistry reg2 = new ToolRegistry(List.of(new FakeTools()), legacy, new ClientCapabilityService());
         reg2.init();
         assertEquals("plugin:ok", reg2.execute("plugin_echo", "{\"text\":\"ok\"}", ctx).output());
     }

--- a/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
@@ -56,7 +56,7 @@ class XmlToolCallParserTest {
 
     @BeforeEach
     void setUp() {
-        ToolRegistry registry = new ToolRegistry(List.of(new ProtocolFakeTools()), new PluginService());
+        ToolRegistry registry = new ToolRegistry(List.of(new ProtocolFakeTools()), new PluginService(), new ClientCapabilityService());
         registry.init();
         parser = new XmlToolCallParser(registry);
     }

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -6,6 +6,7 @@ import com.checkba.service.ai.tools.EvidenceTools;
 import com.checkba.service.ai.tools.FileTools;
 import com.checkba.service.ai.tools.LegalTools;
 import com.checkba.service.ai.tools.MemoryTools;
+import com.checkba.service.ai.tools.OfficeEditTools;
 import com.checkba.service.ai.tools.PdfTools;
 import com.checkba.service.ai.tools.PptxTools;
 import com.checkba.service.ai.tools.PythonTools;
@@ -40,6 +41,7 @@ final class RealToolBeans {
                 FileTools.class,
                 LegalTools.class,
                 MemoryTools.class,
+                OfficeEditTools.class,
                 PdfTools.class,
                 PptxTools.class,
                 PythonTools.class,

--- a/backend/src/test/java/com/checkba/service/ai/eval/RecordingToolRegistry.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RecordingToolRegistry.java
@@ -27,7 +27,8 @@ public class RecordingToolRegistry extends ToolRegistry {
     private Map<String, String> stubs = Map.of();
 
     public RecordingToolRegistry(List<AgentToolComponent> components, PluginService pluginService) {
-        super(components, pluginService);
+        // 评测里不声明 clientCapability：默认 LOWA 能力（与存量主前端一致），office_* 不下发
+        super(components, pluginService, new com.checkba.service.ai.ClientCapabilityService());
     }
 
     /** 设置工具桩输出（key = 别名解析后的工具名） */

--- a/backend/src/test/java/com/checkba/service/ai/subagent/SubAgentServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/subagent/SubAgentServiceTest.java
@@ -51,7 +51,8 @@ class SubAgentServiceTest {
     @BeforeEach
     void setUp() {
         registry = mock(ToolRegistry.class);
-        when(registry.getAllSpecifications()).thenReturn(List.of(
+        // 子 Agent 走会话能力感知的 getAllSpecifications(conversationId)（Phase C）
+        when(registry.getAllSpecifications(any())).thenReturn(List.of(
                 ToolSpecification.builder().name("search_web").description("web search").build(),
                 ToolSpecification.builder().name("read_document").description("read file").build(),
                 ToolSpecification.builder().name("dispatch_subtask").description("delegate").build()));

--- a/backend/src/test/java/com/checkba/service/ai/tools/OfficeEditToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/OfficeEditToolsTest.java
@@ -1,0 +1,80 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.OfficeBridgeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * office_* 工具集：参数校验 + 桥调用透传。
+ * 校验失败必须在后端拦下（不下发指令），错误以 "Error:" 前缀返回供模型自纠。
+ */
+class OfficeEditToolsTest {
+
+    private OfficeBridgeService bridge;
+    private OfficeEditTools tools;
+
+    @BeforeEach
+    void setUp() {
+        bridge = mock(OfficeBridgeService.class);
+        tools = new OfficeEditTools(bridge);
+    }
+
+    @Test
+    @DisplayName("office_replace_text：参数齐备时下发 replace_text，结果透传")
+    void replaceTextDispatches() {
+        when(bridge.executeOfficeCommand(eq("conv-1"), eq("replace_text"), anyMap()))
+                .thenReturn("{\"replaced\":1,\"tracked\":true}");
+
+        String result = tools.office_replace_text("conv-1", "甲方", "买受人", false);
+
+        assertEquals("{\"replaced\":1,\"tracked\":true}", result);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> args = ArgumentCaptor.forClass(Map.class);
+        verify(bridge).executeOfficeCommand(eq("conv-1"), eq("replace_text"), args.capture());
+        assertEquals("甲方", args.getValue().get("searchText"));
+        assertEquals("买受人", args.getValue().get("replaceText"));
+        assertEquals(false, args.getValue().get("replaceAll"));
+    }
+
+    @Test
+    @DisplayName("参数校验失败：返回 Error 前缀且不触碰桥（不产生 30 秒空等）")
+    void validationFailuresDoNotTouchBridge() {
+        assertTrue(tools.office_search("conv-1", " ").startsWith("Error"));
+        assertTrue(tools.office_search("conv-1", "长".repeat(256)).startsWith("Error"));
+        assertTrue(tools.office_replace_text("conv-1", "", "x", true).startsWith("Error"));
+        assertTrue(tools.office_replace_text("conv-1", "找我", null, true).startsWith("Error"));
+        assertTrue(tools.office_insert_text("conv-1", "", null, null).startsWith("Error"));
+        assertTrue(tools.office_insert_text("conv-1", "文本", "锚点", "middle").startsWith("Error"));
+        assertTrue(tools.office_add_comment("conv-1", "", "批注").startsWith("Error"));
+        assertTrue(tools.office_add_comment("conv-1", "目标", " ").startsWith("Error"));
+        verifyNoInteractions(bridge);
+    }
+
+    @Test
+    @DisplayName("office_insert_text：position 缺省归一为 after，锚点缺省传空串")
+    void insertTextDefaults() {
+        when(bridge.executeOfficeCommand(any(), eq("insert_text"), anyMap())).thenReturn("{}");
+
+        tools.office_insert_text("conv-1", "新增条款", null, null);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> args = ArgumentCaptor.forClass(Map.class);
+        verify(bridge).executeOfficeCommand(eq("conv-1"), eq("insert_text"), args.capture());
+        assertEquals("after", args.getValue().get("position"));
+        assertEquals("", args.getValue().get("anchorText"));
+    }
+}

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -99,6 +99,14 @@ const NAMES = {
   sheet_set_autofilter: { zh: '设置自动筛选', en: 'Set autofilter' },
   sheet_freeze_panes: { zh: '冻结窗格', en: 'Freeze panes' },
   sheet_conditional_format: { zh: '设置条件格式', en: 'Conditional format' },
+  // Office 插件（Word 任务窗格）office_* 工具桥
+  // 正常情况下主前端（lowa 会话）看不到这些工具（会话能力过滤），收录仅作兜底
+  office_get_text: { zh: '读取文档', en: 'Read document' },
+  office_get_selection: { zh: '读取选区', en: 'Read selection' },
+  office_search: { zh: '查找文本', en: 'Find in document' },
+  office_replace_text: { zh: '替换文本（修订）', en: 'Replace text (tracked)' },
+  office_insert_text: { zh: '插入文本（修订）', en: 'Insert text (tracked)' },
+  office_add_comment: { zh: '插入批注', en: 'Add comment' },
   // PPT
   pptx_check_service: { zh: '检查PPT服务', en: 'Check PPT service' },
   pptx_generate: { zh: '生成PPT演示文稿', en: 'Generate slides' },

--- a/office-addin/README.md
+++ b/office-addin/README.md
@@ -96,10 +96,29 @@ npx office-addin-manifest validate manifest.xml
 8. 断网/停后端再发消息 → 出现「后端不可达」类错误提示，输入框不卡死。
 9. 关闭再重开任务窗格 → 设置与项目选择仍在（localStorage 持久化）。
 
-## 已知边界（MVP）
+### 工具桥场景（Phase C：office_* 工具）
 
-- 只消费 `text_delta`/`bubble_end`/`error`/`cancelled` 四类 SSE 事件，
-  `client_action`（工具桥，Phase C）、`plan_update` 等先忽略。
+10. 打开一份合同文档，让 AI「把甲方全部改成买受人」→ 对话流出现「替换文本（修订）」chip，
+    文档中的修改以 **Word 原生修订**（审阅 → 修订）形式出现，可逐条接受/拒绝；
+    执行前后用户自己的「修订」开关状态不变（执行完恢复原值）。
+11. 让 AI「在第一条后面插入一段不可抗力条款」→ 出现「插入文本（修订）」chip，
+    插入内容同样是修订形态。
+12. 让 AI「给违约金条款加个批注说明风险」→ 出现「插入批注」chip，
+    Word 批注面板出现批注（作者为当前 Word 登录用户）。
+13. 让 AI「找找文中有几处试用期」→ 出现「查找文本」chip，回复引用命中段落上下文。
+14. 观察整轮对话：AI 不应尝试调用 doc_* 工具（会话能力过滤，
+    插件 chat 请求带 `clientCapability: "office"`）；主前端（LOWA）会话反之不见 office_*。
+15. 任务窗格关闭时让主前端会话正常改文档（回归确认 LOWA 链路不受影响）。
+
+## 已知边界
+
+- 消费 `text_delta`/`bubble_end`/`error`/`cancelled` 与 `client_action`（tool=office_command）
+  五类 SSE 事件，`plan_update` 等先忽略。
+- office_* 工具桥命令集 v1：get_text / get_selection / search / replace_text /
+  insert_text / add_comment；结果回传 `POST /api/agent/office/result`
+  （body `{requestId, ok, data|error}`，后端按挂起表做会话归属校验）。
+- 修订与批注依赖 WordApi 1.4（Word 2019+/Microsoft 365）；不支持时替换/插入降级为
+  直接修改（结果携带 `tracked:false`），批注返回明确错误。
 - 流式文本按 XML 标签轻量分流：`<final>` 与标签外文本为主回复、`<thinking>` 折叠展示，
   `<process>`/`<artifact>` 等暂不渲染。
 - awdt_ 令牌手工粘贴是 MVP 形态，Phase D 用 awdk_ 桥替换。

--- a/office-addin/taskpane/components/ChatView.vue
+++ b/office-addin/taskpane/components/ChatView.vue
@@ -16,6 +16,11 @@
             <summary>思考过程</summary>
             <div class="thinking-body">{{ msg.thinking }}</div>
           </details>
+          <div v-if="msg.tools && msg.tools.length" class="tool-chips">
+            <span v-for="(tool, ti) in msg.tools" :key="ti" class="tool-chip" :class="tool.status">
+              {{ tool.label }}<span v-if="tool.status === 'running'">…</span><span v-else-if="tool.status === 'failed'">（失败）</span>
+            </span>
+          </div>
           <div class="bubble assistant-bubble">
             <span>{{ msg.text }}</span>
             <span v-if="msg.streaming" class="cursor"></span>
@@ -50,9 +55,10 @@
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, reactive, ref } from 'vue'
-import { postChat, postCancel } from '../lib/api.js'
+import { postChat, postCancel, postOfficeResult } from '../lib/api.js'
 import { createSseConnection, createTagStreamParser } from '../lib/sse.js'
 import { readActiveDocument } from '../lib/wordDoc.js'
+import { executeOfficeCommand, commandDisplayName } from '../lib/officeExecutor.js'
 
 const props = defineProps({
   settings: { type: Object, required: true },
@@ -105,8 +111,38 @@ function handleEvent(evt, dataStr) {
   } else if (evt === 'cancelled') {
     if (currentAssistant && !currentAssistant.text) currentAssistant.text = '（已停止）'
     finishStreaming()
+  } else if (evt === 'client_action') {
+    handleClientAction(dataStr)
   }
-  // connected/heartbeat/client_action/plan_update 等其余事件：MVP 先忽略
+  // connected/heartbeat/plan_update 等其余事件：先忽略
+}
+
+/**
+ * office_command 执行链（Phase C 工具桥）：
+ * 后端 OfficeBridgeService 下发 {tool:'office_command', requestId, command, args}
+ * → Office.js 执行 → POST /api/agent/office/result 回传。
+ * 其余 client_action（editor_command 等 LOWA 契约）与本插件无关，忽略。
+ */
+async function handleClientAction(dataStr) {
+  let action = null
+  try { action = JSON.parse(dataStr) } catch (e) { return }
+  if (!action || action.tool !== 'office_command' || !action.requestId) return
+
+  const chip = reactive({ label: commandDisplayName(action.command), status: 'running' })
+  if (currentAssistant) {
+    if (!currentAssistant.tools) currentAssistant.tools = []
+    currentAssistant.tools.push(chip)
+    scrollToBottom()
+  }
+
+  const result = await executeOfficeCommand(action.command, action.args)
+  chip.status = result.ok ? 'done' : 'failed'
+  await postOfficeResult(props.settings, {
+    requestId: action.requestId,
+    ok: result.ok,
+    data: result.ok ? result.data : null,
+    error: result.ok ? null : result.error
+  })
 }
 
 async function ensureConnection() {
@@ -141,7 +177,7 @@ async function send() {
   input.value = ''
   messages.value.push({ role: 'user', text: prompt })
 
-  const assistant = reactive({ role: 'assistant', text: '', thinking: '', streaming: true, error: '' })
+  const assistant = reactive({ role: 'assistant', text: '', thinking: '', streaming: true, error: '', tools: [] })
   messages.value.push(assistant)
   currentAssistant = assistant
   parser = createTagStreamParser({
@@ -166,7 +202,9 @@ async function send() {
       conversationId,
       message: prompt,
       mode: 'AGENT',
-      activeContext
+      activeContext,
+      // 声明客户端能力（Phase C）：后端据此让本会话只见 office_* 工具、隐藏 doc_*
+      clientCapability: 'office'
     })
   } catch (e) {
     assistant.error = e.message || '消息发送失败'
@@ -242,6 +280,26 @@ onBeforeUnmount(() => {
   background: var(--awd-surface);
   border: 1px solid var(--awd-border);
 }
+
+.tool-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.tool-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--awd-border);
+  background: var(--awd-surface);
+  color: var(--awd-text-secondary);
+  font-size: 11px;
+}
+
+.tool-chip.done { color: var(--awd-text-secondary); }
+.tool-chip.failed { color: var(--awd-danger); border-color: var(--awd-danger); }
 
 .thinking {
   margin-bottom: 6px;

--- a/office-addin/taskpane/lib/api.js
+++ b/office-addin/taskpane/lib/api.js
@@ -51,6 +51,25 @@ export async function postChat({ serverUrl, token }, payload) {
 }
 
 /**
+ * 回传一条 office_command 的执行结果（Phase C 工具桥）。
+ * payload: {requestId, ok, data|error}；后端按挂起表校验会话归属。
+ * 回传失败时后端工具会在超时后拿到明确错误，这里只记录不重试。
+ */
+export async function postOfficeResult({ serverUrl, token }, payload) {
+  const base = normalizeBaseUrl(serverUrl)
+  try {
+    const resp = await fetch(`${base}/api/agent/office/result`, {
+      method: 'POST',
+      headers: headers(token),
+      body: JSON.stringify(payload)
+    })
+    if (!resp.ok) console.warn('[Addin] office 结果回传被拒绝', resp.status)
+  } catch (e) {
+    console.warn('[Addin] office 结果回传失败', e)
+  }
+}
+
+/**
  * 请求后端停止当前会话的执行。
  */
 export async function postCancel({ serverUrl, token }, conversationId) {

--- a/office-addin/taskpane/lib/officeExecutor.js
+++ b/office-addin/taskpane/lib/officeExecutor.js
@@ -1,0 +1,212 @@
+/**
+ * office_command 执行器（Phase C 工具桥）：
+ * 后端 OfficeBridgeService 经 SSE client_action 下发 {tool:'office_command',
+ * requestId, command, args, conversationId}，本模块按 command 分发到 Office.js
+ * 实现并返回 {ok, data|error}，由调用方 POST /api/agent/office/result 回传。
+ *
+ * 硬规则：后端注册的每个 office_* 工具都必须在这里有对应实现——
+ * 没有客户端实现的远端工具 = 30 秒超时空转（PptxEditTools 死路径教训）。
+ * 未知 command 立即回 {ok:false, error:'unsupported command'}，绝不静默吞掉。
+ *
+ * 修改类命令（replace_text / insert_text）执行前把 document.changeTrackingMode
+ * 设为 TrackAll（Word 原生修订），执行后恢复原值；宿主不支持 WordApi 1.4 时
+ * 降级为直接修改并在结果里标注 tracked:false。
+ */
+
+import { officeAvailable } from './wordDoc.js'
+
+// 与后端 ContextAssemblerService.MAX_INLINE_CONTENT_CHARS 一致的截断上限
+const MAX_TEXT_CHARS = 200_000
+// search 命中上下文的最大条数（防超长工具输出撑爆模型上下文）
+const MAX_SEARCH_HITS = 20
+
+function trackingSupported() {
+  try {
+    return Office.context.requirements.isSetSupported('WordApi', '1.4')
+  } catch (e) {
+    return false
+  }
+}
+
+function truncate(text) {
+  const s = text || ''
+  return s.length > MAX_TEXT_CHARS
+    ? { text: s.slice(0, MAX_TEXT_CHARS), truncated: true, totalChars: s.length }
+    : { text: s, truncated: false, totalChars: s.length }
+}
+
+/**
+ * 在开启 Word 原生修订（TrackAll）的前提下执行 fn，结束后恢复原模式。
+ * 返回 fn 的结果并附 tracked 标记。
+ */
+async function withTracking(context, fn) {
+  if (!trackingSupported()) {
+    const data = await fn()
+    return { ...data, tracked: false }
+  }
+  const doc = context.document
+  doc.load('changeTrackingMode')
+  await context.sync()
+  const previousMode = doc.changeTrackingMode
+  doc.changeTrackingMode = Word.ChangeTrackingMode.trackAll
+  await context.sync()
+  try {
+    const data = await fn()
+    return { ...data, tracked: true }
+  } finally {
+    doc.changeTrackingMode = previousMode
+    await context.sync()
+  }
+}
+
+/** body.search 定位锚点，返回命中 Range 数组（未命中返回空数组） */
+async function searchRanges(context, needle, matchCase) {
+  const results = context.document.body.search(needle, { matchCase: !!matchCase })
+  results.load('items')
+  await context.sync()
+  return results.items
+}
+
+const HANDLERS = {
+  async get_text() {
+    return Word.run(async (context) => {
+      const body = context.document.body
+      body.load('text')
+      await context.sync()
+      return truncate(body.text)
+    })
+  },
+
+  async get_selection() {
+    return Word.run(async (context) => {
+      const selection = context.document.getSelection()
+      selection.load('text')
+      await context.sync()
+      return truncate(selection.text)
+    })
+  },
+
+  async search(args) {
+    const query = String(args.query || '')
+    if (!query) throw new Error('查找文本不能为空')
+    return Word.run(async (context) => {
+      const items = await searchRanges(context, query, false)
+      const hits = items.slice(0, MAX_SEARCH_HITS)
+      // 命中上下文 = 命中所在段落的完整文本
+      const paragraphs = hits.map((range) => {
+        const p = range.paragraphs.getFirst()
+        p.load('text')
+        return p
+      })
+      await context.sync()
+      return {
+        count: items.length,
+        shown: hits.length,
+        matches: hits.map((range, i) => ({
+          index: i + 1,
+          context: (paragraphs[i].text || '').slice(0, 500)
+        }))
+      }
+    })
+  },
+
+  async replace_text(args) {
+    const searchText = String(args.searchText || '')
+    const replaceText = args.replaceText == null ? '' : String(args.replaceText)
+    const replaceAll = !!args.replaceAll
+    if (!searchText) throw new Error('查找文本不能为空')
+    return Word.run(async (context) => {
+      return withTracking(context, async () => {
+        const items = await searchRanges(context, searchText, true)
+        if (!items.length) {
+          throw new Error('未找到目标文本，请确认 searchText 与文档内容精确一致（可先用 search 命令核对）')
+        }
+        const targets = replaceAll ? items : [items[0]]
+        for (const range of targets) {
+          range.insertText(replaceText, Word.InsertLocation.replace)
+        }
+        await context.sync()
+        return { replaced: targets.length, totalMatches: items.length }
+      })
+    })
+  },
+
+  async insert_text(args) {
+    const text = String(args.text || '')
+    const anchorText = String(args.anchorText || '')
+    const position = args.position === 'before' ? 'before' : 'after'
+    if (!text) throw new Error('插入文本不能为空')
+    return Word.run(async (context) => {
+      return withTracking(context, async () => {
+        if (anchorText) {
+          const items = await searchRanges(context, anchorText, true)
+          if (!items.length) {
+            throw new Error('未找到锚点文本，请确认 anchorText 与文档内容精确一致')
+          }
+          const location = position === 'before' ? Word.InsertLocation.before : Word.InsertLocation.after
+          items[0].insertText(text, location)
+        } else {
+          // 无锚点：落在用户当前光标/选区处（选区被替换，与光标插入语义一致）
+          context.document.getSelection().insertText(text, Word.InsertLocation.replace)
+        }
+        await context.sync()
+        return { inserted: true, anchored: !!anchorText, position: anchorText ? position : 'selection' }
+      })
+    })
+  },
+
+  async add_comment(args) {
+    const anchorText = String(args.anchorText || '')
+    const comment = String(args.comment || '')
+    if (!anchorText) throw new Error('批注目标文本不能为空')
+    if (!comment) throw new Error('批注内容不能为空')
+    if (!trackingSupported()) {
+      // insertComment 同属 WordApi 1.4
+      throw new Error('当前 Word 版本不支持插入批注（需要 WordApi 1.4）')
+    }
+    return Word.run(async (context) => {
+      const items = await searchRanges(context, anchorText, true)
+      if (!items.length) {
+        throw new Error('未找到批注目标文本，请确认 anchorText 与文档内容精确一致')
+      }
+      items[0].insertComment(comment)
+      await context.sync()
+      return { commented: true }
+    })
+  }
+}
+
+/** 每个 command 的固定中文名（对话流中的工具活动 chip；与后端 @ToolMeta displayName 对齐） */
+export const COMMAND_DISPLAY_NAMES = {
+  get_text: '读取文档',
+  get_selection: '读取选区',
+  search: '查找文本',
+  replace_text: '替换文本（修订）',
+  insert_text: '插入文本（修订）',
+  add_comment: '插入批注'
+}
+
+export function commandDisplayName(command) {
+  return COMMAND_DISPLAY_NAMES[command] || `文档操作（${command}）`
+}
+
+/**
+ * 执行一条 office_command。永不 throw：一律返回 {ok:true, data} 或 {ok:false, error}。
+ */
+export async function executeOfficeCommand(command, args) {
+  if (!officeAvailable()) {
+    return { ok: false, error: 'Word 环境不可用：请在 Word 任务窗格中使用本插件' }
+  }
+  const handler = HANDLERS[command]
+  if (!handler) {
+    return { ok: false, error: `unsupported command: ${command}` }
+  }
+  try {
+    const data = await handler(args || {})
+    return { ok: true, data: data == null ? {} : data }
+  } catch (e) {
+    const message = (e && e.message) || String(e)
+    console.warn('[Addin] office_command 执行失败', command, e)
+    return { ok: false, error: message }
+  }
+}


### PR DESCRIPTION
总 spec Phase C 实施（`docs/superpowers/specs/2026-08-06-office-addin-and-memory-sync.md` 第五节）。**依赖 #265**（base 即其分支 `claude/office-addin-scaffold`，请先合 #265 再合本 PR）。

## 做了什么

### 后端：第二条桥 + office_* 工具集

- **OfficeBridgeService**（新）：与 EditorBridgeService 逐字同构但完全独立——requestId + CompletableFuture 挂起表 + SSE `client_action` 下发（tool 固定 `office_command`，payload `{requestId, command, args, conversationId}`）+ 独立 30s 超时常量（不共享 LOWA 的）。失败一律 Jackson 序列化的 `{"error": ...}`，`ToolResult.success()` 可识别，防绿勾空转（F-09 教训）。
- **OfficeResultController**（新）：`POST /api/agent/office/result`，body `{requestId, ok, data|error}`。会话归属**不信任请求体**——以桥挂起表按 requestId 登记的 conversationId 为准，再过 `canUseConversation`。
- **OfficeEditTools**（新）：office_* 工具集 v1，AgentToolComponent + @Tool + @ToolMeta 自动注册，**未改编排器**。工具名 -> command：office_get_text→get_text、office_get_selection→get_selection、office_search→search、office_replace_text→replace_text、office_insert_text→insert_text、office_add_comment→add_comment。conversationId 由 ToolRegistry 服务端注入（SERVER_CONTEXT_PARAMS 既有机制）。

### 会话级客户端能力过滤

- chat 请求新增可选 `clientCapability`（lowa/office/none，**缺省 lowa 兼容存量主前端**），`ClientCapabilityService` 按 conversationId 内存登记。
- ToolRegistry 三消费点过滤：`getAllSpecifications(conversationId)` / `execute`（按未知工具拒绝）/ `resolve(name, conversationId)`。office 会话隐藏 doc_* 与 sheet_*，lowa 会话隐藏 office_*，none 全隐藏；判定按工具名前缀。单参 `resolve(name)` 保留给无会话语境的元数据查询。
- 子 Agent（SubAgentService）继承主会话能力，同样不见死路径工具。
- **末位提醒三分支**（ContextAssemblerService）：lowa 保持现状 doc_* 口径；office 换 office_* 口径（正文已内联注入，改动经 office_* 落到 Word、呈现为原生修订）；none 只读口径。`<active_document>` 段与正文不可读兜底提示同步切换。

### 插件端（office-addin/）

- **officeExecutor.js**（新）：后端注册的每个 office_* 工具都有对应 Office.js 实现（PptxEditTools 死路径教训）；未知 command 回 `{ok:false, error:'unsupported command'}`。修改类命令（replace_text/insert_text）执行前把 `document.changeTrackingMode` 设为 TrackAll、执行后恢复原值（**Word 原生修订**）；WordApi 1.4 不支持时降级直接修改并标 `tracked:false`。
- ChatView 消费 `client_action`（tool=office_command）→ 执行 → `POST /api/agent/office/result` 回传；工具活动 chip 显示固定中文名（读取文档 / 替换文本（修订）/ 插入批注等）；chat 请求带 `clientCapability: "office"`。
- README 手测清单补工具桥场景（AI 改文档出现 Word 原生修订、office 会话不再调 doc_*）。
- 主前端 toolDisplayNames.js 兜底收录 office_* 中文名。

### 领域文档同步

- `.claude/agents/ai-doc-bridge.md`：新增「第二条桥：office_* 工具桥」一节 + 两条新地雷（office_* 三件套、能力过滤靠前缀/ToolRegistry 构造器同步点）。
- `.claude/agents/office-addin.md`：Phase C 契约、执行器文件、地雷与验证命令更新。

## 测试证据

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test`：**Tests run: 883, Failures: 0, Errors: 0, Skipped: 2（存量跳过），BUILD SUCCESS**（含 EvalHarness 回放评测）。
- 新增单测：OfficeBridgeServiceTest（请求-应答/超时/错误 JSON/含引号错误仍是合法 JSON/归属查询/挂起表清理，6 项）、OfficeResultControllerTest（归属三分支，3 项）、ToolRegistryCapabilityFilterTest（三消费点 x 三能力档 + 默认兼容 + 单参 resolve 不受影响，5 项）、OfficeEditToolsTest（校验失败不触桥，3 项）、ContextAssemblerServiceTest 新增提醒三分支（4 项）。
- `cd office-addin && npm run build`：通过（vite 6，21 modules）。

## 同步点说明

- 未改 AgentOrchestrator 构造器；改的是 ToolRegistry 构造器（+ClientCapabilityService），已同步 RecordingToolRegistry（EvalHarness）、RealToolBeans（收录 OfficeEditTools）、ToolRegistryTest/XmlToolCallParserTest/SubAgentServiceTest 构造与打桩点。
- 未动 EditorBridgeService / EDITOR_ACTIONS 白名单 / LOWA 双轨契约 / SseEmitterService 单连接契约。

## 遗留

- office_* v1 只覆盖 Word 文本面；Excel/PPT 语义按 spec 留给后续版本。
- 真机 sideload 手测（README 场景 10-15）待有 Word 环境时过一遍——修订开关恢复与 add_comment 在旧版 Word（无 WordApi 1.4）上的降级路径只有代码级防护。
- ClientCapabilityService 为进程内存态：后端重启后会话回落默认 lowa，插件下一条消息即重新登记。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
