### PR TITLE
feat: conversationId 服务端签发——关掉空会话抢占窗口（安全审计遗留 + Office 插件 Phase D 第 6 项）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -11,6 +11,7 @@ description: AI 对话编排领域。任务涉及编排器 AgentOrchestrator、T
 
 **编排核心**
 - `controller/ai/AiAgentController.java` — 主入口（/api/agent）：GET /connect/{cid}（建 SSE）、POST /chat（异步 200）、POST /cancel/{cid}、/history/rollback、/tasks/active、/ppt/generate。AiChatController 是已被取代的 v1，非主链路。
+- **conversationId 服务端签发**（安全审计遗留 + Office 插件 Phase D）：`controller/ai/ConversationIssuanceController.java` `POST /api/agent/conversations` body `{projectId}` → `{"conversationId":"conv-<毫秒>-<16位随机base64url>"}`（鉴权 + hasReadPermission）。登记簿 `service/ai/ConversationIssuanceService.java`（内存 Map，惰性 24h 过期）；`ProjectAiMessageService.canUseConversation` 开头先查登记——签发给谁就归谁，关掉「空会话首条消息落库前任何登录用户可抢占」的窗口。开关 `security.conversation-issuance-required`（默认 false）：true（官方云配）时**尚无消息**的未登记会话一律拒绝（已有消息仍按 DB 归属，进程重启丢登记不影响历史）；local-mode 恒不强制，桌面自造 conv-毫秒 ID 流程不变。
 - `service/ai/AgentOrchestrator.java`（862 行）— **编排器**：handleUserMessage（@Async("taskExecutor")）+ runLoop（递归）。RunGuard：重复调用熔断 MAX_IDENTICAL_TOOL_CALLS=3、连续失败提示=3、步数预算 MAX_LOOP_DEPTH=30。工具分发 dispatchTool（~:160）、artifact/<title> 处理、检查点触发。
 - `service/ai/AgentStreamHandler.java`（493 行）— StreamingResponseHandler：token 流→SSE；<bubble_type>/<artifact> 边界解析缓冲、编辑器流过滤、token 用量上报。每次 runLoop 新建实例。
 - `service/ai/AgentRunStateService.java` — 每会话运行状态登记簿（内存）：RUNNING/PAUSED/AWAITING_APPROVAL/FINISHED/ERROR/CANCELLED。**新增终止分支必打状态点**（PR#173 状态机契约）。

--- a/backend/src/main/java/com/checkba/controller/ai/ConversationIssuanceController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/ConversationIssuanceController.java
@@ -1,0 +1,55 @@
+package com.checkba.controller.ai;
+
+import com.checkba.controller.AuthController;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.ai.ConversationIssuanceService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * conversationId 服务端签发端点（安全审计遗留 + Office 插件 Phase D）。
+ *
+ * 契约（与插件端并行开发约定，勿改形状）：
+ *   POST /api/agent/conversations  body {"projectId": 123}
+ *   → 200 {"conversationId": "conv-<毫秒>-<16位随机base64url>"}
+ *
+ * 独立于 AiAgentController 成文件，避免与并行分支冲突。
+ * 桌面前端现有「客户端自造 conv-毫秒 ID」流程在默认配置下不受影响；
+ * 官方云开启 security.conversation-issuance-required 后，空会话必须先经此端点签发。
+ */
+@RestController
+@RequestMapping("/api/agent/conversations")
+@RequiredArgsConstructor
+public class ConversationIssuanceController {
+
+    private final ConversationIssuanceService conversationIssuanceService;
+    private final ProjectMemberService projectMemberService;
+
+    @PostMapping
+    public ResponseEntity<Map<String, String>> issue(@RequestBody IssueRequest request,
+                                                     @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            return ResponseEntity.status(403).body(Map.of("error", "会话身份无效"));
+        }
+        Long projectId = request == null ? null : request.getProjectId();
+        if (projectId == null || !projectMemberService.hasReadPermission(projectId, userId)) {
+            return ResponseEntity.status(403).body(Map.of("error", "无权访问该项目"));
+        }
+        String conversationId = conversationIssuanceService.issue(userId, projectId);
+        return ResponseEntity.ok(Map.of("conversationId", conversationId));
+    }
+
+    @Data
+    public static class IssueRequest {
+        private Long projectId;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class ProjectAiMessageService {
 
     private final ProjectAiMessageRepository repository;
+    private final com.checkba.service.ai.ConversationIssuanceService conversationIssuanceService;
 
     public void saveUserAndAssistantMessage(String projectIdStr, Long userId, String conversationId, String userContent, String assistantContent) {
         if (projectIdStr == null) {
@@ -150,9 +151,16 @@ public class ProjectAiMessageService {
      */
     public boolean canUseConversation(String conversationId, Long userId) {
         if (userId == null || conversationId == null) return false;
+        // 服务端签发登记优先于「空会话任何人可用」：签发给谁就归谁，
+        // 首条消息落库前的抢占窗口由此关闭（2026-08 安全审计遗留项）。
+        Long registeredOwner = conversationIssuanceService.ownerOf(conversationId);
+        if (registeredOwner != null && !registeredOwner.equals(userId)) return false;
         return repository.findFirstByConversationId(conversationId)
                 .map(m -> userId.equals(m.getUserId()))
-                .orElse(true);
+                // 无消息的新会话：已登记（归属相符）放行；未登记时看强制开关——
+                // 官方云（conversation-issuance-required=true 且非 local-mode）必须先签发，
+                // 默认配置/桌面单机维持现状（客户端自造 ID 仍可用）。
+                .orElseGet(() -> registeredOwner != null || !conversationIssuanceService.enforceIssuance());
     }
 
     public List<java.util.Map<String, Object>> listConversations(Long projectId, Long userId) {

--- a/backend/src/main/java/com/checkba/service/ai/ConversationIssuanceService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ConversationIssuanceService.java
@@ -1,0 +1,111 @@
+package com.checkba.service.ai;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.util.Base64;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * conversationId 服务端签发登记簿（2026-08 安全审计遗留项）。
+ *
+ * 背景：conversationId 历史上由客户端自造（conv-毫秒时间戳），可猜；
+ * 空会话在首条消息落库前，任何登录用户都能抢占（canUseConversation 对无消息会话放行）。
+ * 本服务把「谁签发的会话归谁」登记在内存里，在首条消息落库前就锁定归属，关掉抢占窗口。
+ *
+ * 与 AgentRunStateService / SseEmitterService 一样是进程内单实例假设（ConcurrentHashMap），
+ * 与现状部署形态一致；多实例部署时需要外置存储，届时一并改。
+ *
+ * 登记项惰性 24 小时过期：首条消息落库后归属判定落到 DB（ProjectAiMessageService），
+ * 登记项即失去作用，过期清理只为防 Map 无限涨。
+ */
+@Service
+public class ConversationIssuanceService {
+
+    /** 登记项存活时长：24 小时（首条消息落库后 DB 接管归属，登记项过期无害）。 */
+    static final long TTL_MILLIS = 24L * 60 * 60 * 1000;
+
+    private final boolean issuanceRequired;
+    private final boolean localMode;
+    private final Clock clock;
+    private final SecureRandom random = new SecureRandom();
+    private final ConcurrentHashMap<String, Registration> registrations = new ConcurrentHashMap<>();
+
+    record Registration(Long ownerUserId, Long projectId, long issuedAtMillis) {}
+
+    @Autowired
+    public ConversationIssuanceService(
+            @Value("${security.conversation-issuance-required:false}") boolean issuanceRequired,
+            @Value("${security.local-mode:false}") boolean localMode) {
+        this(issuanceRequired, localMode, Clock.systemUTC());
+    }
+
+    ConversationIssuanceService(boolean issuanceRequired, boolean localMode, Clock clock) {
+        this.issuanceRequired = issuanceRequired;
+        this.localMode = localMode;
+        this.clock = clock;
+    }
+
+    /**
+     * 签发一个新会话 ID 并登记归属。
+     * 格式 conv-&lt;毫秒&gt;-&lt;16位随机base64url&gt;：保留 conv- 前缀兼容既有格式约定，
+     * 随机段 12 字节（96 bit）不可猜。
+     */
+    public String issue(Long userId, Long projectId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("签发会话必须有归属用户");
+        }
+        purgeExpired();
+        byte[] bytes = new byte[12];
+        random.nextBytes(bytes);
+        String conversationId = "conv-" + clock.millis() + "-"
+                + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        registrations.put(conversationId, new Registration(userId, projectId, clock.millis()));
+        return conversationId;
+    }
+
+    /** 登记的归属用户；未登记或登记已过期返回 null。 */
+    public Long ownerOf(String conversationId) {
+        Registration reg = liveRegistration(conversationId);
+        return reg == null ? null : reg.ownerUserId();
+    }
+
+    /** 该会话是否有未过期的登记。 */
+    public boolean isRegistered(String conversationId) {
+        return liveRegistration(conversationId) != null;
+    }
+
+    /**
+     * 是否强制「空会话必须先经服务端签发」：
+     * security.conversation-issuance-required=true（官方云配）时开启；
+     * local-mode（单机免登，回环监听）恒不强制——桌面端自造 ID 流程不受影响。
+     * 只约束尚无消息的会话；已有消息的会话归属由 DB 判定，不受本开关影响
+     * （否则进程重启丢登记后所有历史会话都会被挡）。
+     */
+    public boolean enforceIssuance() {
+        return issuanceRequired && !localMode;
+    }
+
+    private Registration liveRegistration(String conversationId) {
+        if (conversationId == null) return null;
+        Registration reg = registrations.get(conversationId);
+        if (reg == null) return null;
+        if (clock.millis() - reg.issuedAtMillis() > TTL_MILLIS) {
+            registrations.remove(conversationId, reg);
+            return null;
+        }
+        return reg;
+    }
+
+    private void purgeExpired() {
+        long now = clock.millis();
+        registrations.entrySet().removeIf(e -> now - e.getValue().issuedAtMillis() > TTL_MILLIS);
+    }
+
+    int registrationCount() {
+        return registrations.size();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -229,6 +229,13 @@ storage:
     # CDN域名（可选，用于加速访问）
     cdn-domain:
 
+security:
+  # conversationId 服务端签发强制开关（公网多租户/官方云置 true）：
+  # 开启后（且非 local-mode），尚无消息的会话必须先经 POST /api/agent/conversations 签发，
+  # 客户端自造的 conv-<毫秒> ID 会被拒绝；已有消息的会话仍按 DB 归属判定。
+  # 默认 false：桌面单机与既有前端自造 ID 流程行为完全不变。
+  conversation-issuance-required: false
+
 # LangChain4j Ollama Configuration
 langchain4j:
   ollama:

--- a/backend/src/test/java/com/checkba/controller/ai/ConversationIssuanceControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/ConversationIssuanceControllerTest.java
@@ -1,0 +1,95 @@
+package com.checkba.controller.ai;
+
+import com.checkba.controller.AuthController;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.ai.ConversationIssuanceService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * conversationId 签发端点：身份 + 项目读权限双闸，通过后才签发。
+ * 端点契约（与 Office 插件端并行开发约定）：POST /api/agent/conversations
+ * body {projectId} → {"conversationId": "..."}。
+ */
+@ExtendWith(MockitoExtension.class)
+class ConversationIssuanceControllerTest {
+
+    @Mock
+    private ConversationIssuanceService issuanceService;
+    @Mock
+    private ProjectMemberService projectMemberService;
+
+    @InjectMocks
+    private ConversationIssuanceController controller;
+
+    private static ConversationIssuanceController.IssueRequest request(Long projectId) {
+        ConversationIssuanceController.IssueRequest r = new ConversationIssuanceController.IssueRequest();
+        r.setProjectId(projectId);
+        return r;
+    }
+
+    @Test
+    void 项目成员可签发_返回约定形状() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasReadPermission(42L, 7L)).thenReturn(true);
+            when(issuanceService.issue(7L, 42L)).thenReturn("conv-1754400000000-abcdefghijklmnop");
+
+            ResponseEntity<Map<String, String>> resp = controller.issue(request(42L), "sess");
+
+            assertEquals(200, resp.getStatusCode().value());
+            assertEquals("conv-1754400000000-abcdefghijklmnop", resp.getBody().get("conversationId"));
+        }
+    }
+
+    @Test
+    void 身份无效时拒绝_且文案不含认证类字眼() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession(null)).thenReturn(null);
+
+            ResponseEntity<Map<String, String>> resp = controller.issue(request(42L), null);
+
+            assertEquals(403, resp.getStatusCode().value());
+            String error = resp.getBody().get("error");
+            // services/api.js 用「登录/未授权/请先」子串判定未登录并清会话，误触会连坐整个前端会话
+            assertFalse(error.contains("登录") || error.contains("未授权") || error.contains("请先"),
+                    "失败文案不得含认证类字眼，实际：" + error);
+            verify(issuanceService, never()).issue(any(), any());
+        }
+    }
+
+    @Test
+    void 非项目成员不可签发() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasReadPermission(42L, 7L)).thenReturn(false);
+
+            ResponseEntity<Map<String, String>> resp = controller.issue(request(42L), "sess");
+
+            assertEquals(403, resp.getStatusCode().value());
+            verify(issuanceService, never()).issue(any(), any());
+        }
+    }
+
+    @Test
+    void 缺projectId直接拒绝() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+
+            ResponseEntity<Map<String, String>> resp = controller.issue(request(null), "sess");
+
+            assertEquals(403, resp.getStatusCode().value());
+            verify(issuanceService, never()).issue(any(), any());
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectAiMessageServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectAiMessageServiceTest.java
@@ -30,10 +30,14 @@ class ProjectAiMessageServiceTest {
     /** 模拟 JPA：save 时给新实体分配自增 ID，并记录所有落库实体 */
     private final List<ProjectAiMessage> savedRows = new ArrayList<>();
 
+    private com.checkba.service.ai.ConversationIssuanceService issuanceService;
+
     @BeforeEach
     void setUp() {
         repository = mock(ProjectAiMessageRepository.class);
-        service = new ProjectAiMessageService(repository);
+        // 默认配置：不强制签发、非 local-mode（与 application.yml 默认一致）
+        issuanceService = new com.checkba.service.ai.ConversationIssuanceService(false, false);
+        service = new ProjectAiMessageService(repository, issuanceService);
         savedRows.clear();
         AtomicLong idGen = new AtomicLong(0);
         when(repository.save(any(ProjectAiMessage.class))).thenAnswer(inv -> {
@@ -134,5 +138,55 @@ class ProjectAiMessageServiceTest {
     void 未登录一律不可用() {
         assertFalse(service.canUseConversation("conv-new", null));
         assertFalse(service.canUseConversation(null, 7L));
+    }
+
+    // ===== conversationId 服务端签发登记（2026-08 安全审计遗留：关掉空会话抢占窗口） =====
+
+    @Test
+    void 已签发的空会话只有签发对象可用_登记优先于空会话任何人可用() {
+        String issued = issuanceService.issue(7L, 1L);
+        when(repository.findFirstByConversationId(issued)).thenReturn(Optional.empty());
+
+        assertTrue(service.canUseConversation(issued, 7L), "签发给谁就归谁");
+        assertFalse(service.canUseConversation(issued, 8L),
+                "首条消息落库前，其他登录用户不得再抢占已签发的会话");
+    }
+
+    @Test
+    void 强制签发开启时_未登记的空会话被拒_已签发的可用() {
+        com.checkba.service.ai.ConversationIssuanceService issuance =
+                new com.checkba.service.ai.ConversationIssuanceService(true, false);
+        ProjectAiMessageService enforcing = new ProjectAiMessageService(repository, issuance);
+
+        when(repository.findFirstByConversationId("conv-1754400000000")).thenReturn(Optional.empty());
+        assertFalse(enforcing.canUseConversation("conv-1754400000000", 7L),
+                "官方云配下客户端自造 ID 必须被拒，强制走签发端点");
+
+        String issued = issuance.issue(7L, 1L);
+        when(repository.findFirstByConversationId(issued)).thenReturn(Optional.empty());
+        assertTrue(enforcing.canUseConversation(issued, 7L), "经签发的会话可用");
+    }
+
+    @Test
+    void 强制签发开启时_已有消息的会话仍按DB归属判定_进程重启丢登记不影响历史() {
+        ProjectAiMessageService enforcing = new ProjectAiMessageService(
+                repository, new com.checkba.service.ai.ConversationIssuanceService(true, false));
+        ProjectAiMessage first = new ProjectAiMessage();
+        first.setUserId(7L);
+        when(repository.findFirstByConversationId("conv-old")).thenReturn(Optional.of(first));
+
+        assertTrue(enforcing.canUseConversation("conv-old", 7L),
+                "历史会话（登记已随进程重启丢失）必须仍可被归属者使用");
+        assertFalse(enforcing.canUseConversation("conv-old", 8L));
+    }
+
+    @Test
+    void localMode下恒不强制签发_桌面自造ID流程不变() {
+        ProjectAiMessageService localMode = new ProjectAiMessageService(
+                repository, new com.checkba.service.ai.ConversationIssuanceService(true, true));
+        when(repository.findFirstByConversationId("conv-1754400000000")).thenReturn(Optional.empty());
+
+        assertTrue(localMode.canUseConversation("conv-1754400000000", 7L),
+                "local-mode（单机免登、回环监听）不强制签发，前端自造 ID 照常可用");
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/ConversationIssuanceServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ConversationIssuanceServiceTest.java
@@ -1,0 +1,114 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * conversationId 服务端签发登记簿：格式、归属登记、TTL 清理与强制开关语义。
+ * 背景见 ConversationIssuanceService 类注释（2026-08 安全审计遗留项）。
+ */
+class ConversationIssuanceServiceTest {
+
+    /** 可手动拨动的时钟，用于 TTL 测试。 */
+    private static class MutableClock extends Clock {
+        private Instant now;
+
+        MutableClock(Instant start) {
+            this.now = start;
+        }
+
+        void advanceMillis(long millis) {
+            now = now.plusMillis(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+    }
+
+    @Test
+    void 签发的ID符合格式且完成归属登记() {
+        ConversationIssuanceService service = new ConversationIssuanceService(false, false);
+        String id = service.issue(7L, 42L);
+
+        assertTrue(id.matches("conv-\\d+-[A-Za-z0-9_-]{16}"),
+                "格式必须为 conv-<毫秒>-<16位随机base64url>，实际：" + id);
+        assertTrue(service.isRegistered(id));
+        assertEquals(7L, service.ownerOf(id));
+    }
+
+    @Test
+    void 两次签发的ID互不相同() {
+        ConversationIssuanceService service = new ConversationIssuanceService(false, false);
+        assertNotEquals(service.issue(7L, 42L), service.issue(7L, 42L));
+    }
+
+    @Test
+    void 未登记的ID查不到归属() {
+        ConversationIssuanceService service = new ConversationIssuanceService(false, false);
+        assertNull(service.ownerOf("conv-1754400000000"));
+        assertFalse(service.isRegistered("conv-1754400000000"));
+        assertNull(service.ownerOf(null));
+    }
+
+    @Test
+    void 无归属用户不允许签发() {
+        ConversationIssuanceService service = new ConversationIssuanceService(false, false);
+        assertThrows(IllegalArgumentException.class, () -> service.issue(null, 42L));
+    }
+
+    @Test
+    void 登记项24小时后惰性过期() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-06T00:00:00Z"));
+        ConversationIssuanceService service = new ConversationIssuanceService(false, false, clock);
+        String id = service.issue(7L, 42L);
+
+        clock.advanceMillis(ConversationIssuanceService.TTL_MILLIS);
+        assertEquals(7L, service.ownerOf(id), "恰到期限仍有效");
+
+        clock.advanceMillis(1);
+        assertNull(service.ownerOf(id), "超过 24 小时后登记失效");
+        assertFalse(service.isRegistered(id));
+        assertEquals(0, service.registrationCount(), "惰性过期应把条目摘掉");
+    }
+
+    @Test
+    void 签发时顺手清理过期条目_防Map无限涨() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-06T00:00:00Z"));
+        ConversationIssuanceService service = new ConversationIssuanceService(false, false, clock);
+        service.issue(7L, 42L);
+        service.issue(8L, 42L);
+
+        clock.advanceMillis(ConversationIssuanceService.TTL_MILLIS + 1);
+        String fresh = service.issue(9L, 42L);
+
+        assertEquals(1, service.registrationCount(), "过期条目应在签发时被清走");
+        assertEquals(9L, service.ownerOf(fresh));
+    }
+
+    @Test
+    void 强制开关语义_localMode恒不强制() {
+        assertFalse(new ConversationIssuanceService(false, false).enforceIssuance(), "默认不强制");
+        assertTrue(new ConversationIssuanceService(true, false).enforceIssuance(), "官方云配强制");
+        assertFalse(new ConversationIssuanceService(true, true).enforceIssuance(),
+                "local-mode（单机免登）即使开关误开也不强制");
+        assertFalse(new ConversationIssuanceService(false, true).enforceIssuance());
+    }
+}


### PR DESCRIPTION
## 背景

conversationId 目前由客户端自造（conv-毫秒时间戳），可猜；空会话在首条消息落库前，任何登录用户都能抢占（canUseConversation 对无消息会话放行）。公网多租户下这是 2026-08 安全审计的遗留窗口，也是 Office 插件 spec Phase D 第 6 项。

## 改动

- **ConversationIssuanceService**（新）：进程内 ConcurrentHashMap 登记簿（单实例假设与 AgentRunStateService/SseEmitterService 一致，类注释已注明）。issue(userId, projectId) 生成 `conv-<毫秒>-<16位随机base64url>`（12 字节 SecureRandom，96 bit 不可猜；保留 conv- 前缀兼容既有格式约定）。登记项惰性 24h 过期 + 签发时顺手清理，防 Map 无限涨（首条消息落库后归属判定落到 DB，登记过期无害）。
- **POST /api/agent/conversations**（新控制器 ConversationIssuanceController，不动 AiAgentController，避免与并行分支冲突）：body `{projectId}`，X-Session-Id 鉴权 + hasReadPermission 后返回 `{"conversationId": "..."}`。接口形状是与插件端并行开发约好的契约。
- **归属闸**：ProjectAiMessageService.canUseConversation 开头先查登记——登记过且 owner 不符直接 false（登记 owner 优先于「空会话任何人可用」的现状规则）。
- **开关** `security.conversation-issuance-required`（默认 false，application.yml 有注释）：官方云置 true 后，**尚无消息**的未登记会话一律 false（强制走签发）；已有消息的会话仍按 DB 归属判定——否则进程重启丢内存登记后所有历史会话都会被挡。local-mode 恒不强制（enforceIssuance = required && !localMode），桌面前端自造 ID 流程在默认配置下行为完全不变。

## 测试

- 新增 15 个单测：签发格式与登记、两次签发互异、TTL 惰性过期与签发时清理、开关矩阵（含 local-mode 豁免）、他人抢占被拒（登记优先）、强制开启时未登记空会话被拒/已签发可用/历史会话按 DB 归属（重启存活）、默认配置回归（自造 ID 仍可用）、端点 403 文案不含「登录/未授权/请先」（services/api.js 子串判定地雷）。
- 全量 `mvn test`（JDK 21）：**956 通过 0 失败 2 跳过**（基线 941+2，新增 15 全绿）。

## 遗留

- 多实例部署时登记簿需外置存储（现状全站均为进程内单实例假设，届时一并改）。
- 官方云 profile 尚未置 `conversation-issuance-required: true`——等插件端接上签发端点后再开。
- 前端/插件端改用签发端点由并行分支负责，本 PR 只提供服务端契约。

🤖 Generated with [Claude Code](https://claude.com/claude-code)