### PR TITLE
test+docs: 长尾诉求进回放评测（12 组）+ 目录读取工具口径收敛（#261 部分）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -86,6 +86,6 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 
 ## 验证
 
-- `cd backend && mvn test`（JDK 21！默认 25 SIGBUS）——含回放评测 OrchestratorReplayEvalTest（用例 `backend/src/test/resources/ai-eval/cases/cases-*.json`，10 组）+ DesktopContextSmokeTest。
+- `cd backend && mvn test`（JDK 21！默认 25 SIGBUS）——含回放评测 OrchestratorReplayEvalTest（用例 `backend/src/test/resources/ai-eval/cases/cases-*.json`，12 组）+ DesktopContextSmokeTest。新增 cases-file-tree（整理文件夹/重命名的 create_folder→move_project_file→rename_project_file 链）与 cases-harness-recovery（截断 tool_code 纠正回路 F-10、编辑器桥 `{"error"}` 判 FAILURE F-09）。`expect.promptContains` 断言编排器回喂的系统提醒确实进了下一轮上下文。
 - 只跑回放：`mvn test -Dtest=OrchestratorReplayEvalTest`；真实 LLM 冒烟：`OPENROUTER_API_KEY=… mvn test -Dtest=RealLlmSmokeTest`。
 - 前端：`npm run check:emits`；UI 链路 `npm run test:app-e2e`。

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -41,7 +41,10 @@ public class DocumentEditTools implements AgentToolComponent {
 
     // ==================== 文件管理工具 ====================
 
-    @Tool("列出项目中的所有可编辑文档文件（docx, doc, xlsx, xls, pptx, ppt）。返回文件ID、名称和类型的列表。")
+    @Tool("文件树里可编辑文档的权威清单，也是文件 ID 的主要来源：doc_open_file、extract_file_text 的 fileId，"
+            + "以及 rename_project_file / move_project_file / create_folder 的 fileId 与 parentFolderId 都从这里取。"
+            + "不含 PDF（用 pdf_list_files）与文件夹（用 list_project_folders）；只要物理路径不要 ID 才用 list_files。"
+            + "列出项目中的所有可编辑文档文件（docx, doc, xlsx, xls, pptx, ppt），返回文件ID、名称和类型的列表。")
     public String doc_list_project_files(
             @P("项目ID") Long projectId
     ) {

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -65,7 +65,9 @@ public class FileTools implements AgentToolComponent {
     }
 
     @ToolMeta(displayName = "搜索项目文件", category = "file")
-    @Tool("Search for files in the project. Can specify a sub-directory.")
+    @Tool("Locate a file by NAME PATTERN. Returns paths only, NO database fileId — once you know the name, "
+            + "get the fileId from doc_list_project_files (documents), pdf_list_files (PDF) or pptx_list_files (PPTX) "
+            + "before any open/edit/rename/move. Can specify a sub-directory.")
     public String search_project_files(
             @P("Filename pattern (e.g. '*Controller.java' or 'User*.java')") String fileNamePattern,
             @P("Optional: Sub-directory to search in, relative to the project folder. Default is the project root.") String dirPath
@@ -155,7 +157,10 @@ public class FileTools implements AgentToolComponent {
     }
 
     @ToolMeta(displayName = "列出文件", category = "file")
-    @Tool("List files and directories in a project's data folder. Note: This lists physical files, not database records. For database files, use doc_list_project_files or pptx_list_files.")
+    @Tool("PHYSICAL DISK view of the project folder: returns paths only, NO database fileId, so nothing here can be "
+            + "fed to open/edit/rename/move tools. Use doc_list_project_files (documents), pdf_list_files (PDF) or "
+            + "pptx_list_files (PPTX) whenever a later step needs a fileId. "
+            + "Lists files and directories under data/projects/{projectId}/.")
     public String list_files(
             @P("Project ID - files will be listed from data/projects/{projectId}/") Long projectId,
             @P("Optional: Subdirectory path within the project folder. Use '.' or empty for project root.") String subPath

--- a/backend/src/main/java/com/checkba/service/ai/tools/PdfTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PdfTools.java
@@ -50,7 +50,8 @@ public class PdfTools implements AgentToolComponent {
     // ==================== 读取 ====================
 
     @ToolMeta(displayName = "列出PDF文件", category = "pdf")
-    @Tool("列出项目中的所有 PDF 文件，返回文件 ID、名称和位置。所有 pdf_* 工具的 fileId 都从这里获取。")
+    @Tool("PDF 专用清单，也是 PDF 文件 ID 的唯一来源：doc_list_project_files 不列 PDF、search_project_files 不返回 ID，"
+            + "所有 pdf_* 工具的 fileId 只能从这里获取。列出项目中的所有 PDF 文件，返回文件 ID、名称和位置。")
     public String pdf_list_files(
             @P("项目 ID") Long projectId
     ) {

--- a/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
@@ -58,7 +58,9 @@ public class PptxTools implements AgentToolComponent {
 
     // ==================== 文件管理工具 ====================
 
-    @Tool("列出项目中的所有文件夹。返回文件夹 ID、名称和路径。仅当用户明确指定要保存到某个特定文件夹时才需要调用此工具。")
+    @Tool("只列文件夹、不列文件，是 folderId 的来源：write_docx 的 parentFolderId、move_project_file 的 targetFolderId "
+            + "都可从这里取（新建文件夹用 create_folder，文件的 fileId 用 doc_list_project_files）。"
+            + "返回文件夹 ID、名称和路径。仅当用户明确指定要保存到某个特定文件夹时才需要调用此工具。")
     public String list_project_folders(
             @P("项目 ID") Long projectId
     ) {
@@ -94,7 +96,9 @@ public class PptxTools implements AgentToolComponent {
         }
     }
 
-    @Tool("列出项目中的所有 PPTX 演示文稿文件。返回文件 ID、名称和位置信息。")
+    @Tool("PPTX 专用清单，也是 PPTX 文件 ID 的来源：所有 pptx_* 工具的 fileId 从这里或 pptx_search_files 获取"
+            + "（doc_list_project_files 也列 pptx，但 pptx_* 工具请以本清单为准）。"
+            + "列出项目中的所有 PPTX 演示文稿文件，返回文件 ID、名称和位置信息。")
     public String pptx_list_files(
             @P("项目 ID") Long projectId
     ) {

--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalCase.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalCase.java
@@ -82,6 +82,8 @@ public class EvalCase {
         public List<String> offeredToolsExclude = new ArrayList<>();
         /** 会话文件夹重命名（<title> 协议）应包含的子串（null = 不断言） */
         public String renamedTitleContains;
+        /** 应在某次 LLM 调用的上下文中出现的子串（断言编排器回喂了某条系统提醒；空 = 不断言） */
+        public List<String> promptContains = new ArrayList<>();
     }
 
     /** artifact 落盘断言 */

--- a/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/EvalHarness.java
@@ -63,6 +63,7 @@ public final class EvalHarness {
             List<String> folderRenames,
             List<Boolean> toolsOfferedPerLlmCall,
             List<List<String>> toolNamesOfferedPerLlmCall,
+            List<String> promptTexts,
             int remainingScriptTurns) {
 
         /** 最终保存的 ASSISTANT 消息（含 executionLog 前缀） */
@@ -177,7 +178,8 @@ public final class EvalHarness {
 
         return new RunResult(c, registry.dispatches(), List.copyOf(sseEvents), List.copyOf(savedMessages),
                 List.copyOf(artifactSaves), List.copyOf(folderRenames),
-                scripted.toolsOfferedPerCall(), scripted.toolNamesOfferedPerCall(), scripted.remainingTurns());
+                scripted.toolsOfferedPerCall(), scripted.toolNamesOfferedPerCall(),
+                scripted.promptTextPerCall(), scripted.remainingTurns());
     }
 
     /** 内置 skills 目录（与 EvalCase.casesDir 同思路：兼容从 backend/ 或仓库根目录跑测试） */

--- a/backend/src/test/java/com/checkba/service/ai/eval/OrchestratorReplayEvalTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/OrchestratorReplayEvalTest.java
@@ -112,6 +112,13 @@ class OrchestratorReplayEvalTest {
             }
         }
 
+        // 5.2 回喂断言：编排器主动追加的系统提醒应出现在某次 LLM 上下文里
+        for (String marker : c.expect.promptContains) {
+            assertTrue(r.promptTexts().stream().anyMatch(p -> p.contains(marker)),
+                    "期望某次 LLM 调用的上下文中包含 [" + marker + "]，但 " + r.promptTexts().size()
+                            + " 次调用里都没有出现");
+        }
+
         // 6. <title> 协议：会话文件夹重命名
         if (c.expect.renamedTitleContains != null) {
             assertTrue(r.folderRenames().stream().anyMatch(t -> t.contains(c.expect.renamedTitleContains)),

--- a/backend/src/test/java/com/checkba/service/ai/eval/ScriptedStreamingModel.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/ScriptedStreamingModel.java
@@ -31,6 +31,7 @@ public class ScriptedStreamingModel implements StreamingChatLanguageModel {
     private final Deque<EvalCase.Turn> remaining;
     private final List<Boolean> toolsOfferedPerCall = new ArrayList<>();
     private final List<List<String>> toolNamesOfferedPerCall = new ArrayList<>();
+    private final List<String> promptTextPerCall = new ArrayList<>();
 
     public ScriptedStreamingModel(List<EvalCase.Turn> turns) {
         this.remaining = new ArrayDeque<>(turns);
@@ -46,6 +47,11 @@ public class ScriptedStreamingModel implements StreamingChatLanguageModel {
         return List.copyOf(toolNamesOfferedPerCall);
     }
 
+    /** 每次 LLM 调用收到的完整上下文文本（供「回喂了某条提醒」类断言） */
+    public List<String> promptTextPerCall() {
+        return List.copyOf(promptTextPerCall);
+    }
+
     /** 剩余未消费的脚本轮数（用例结束后应为 0） */
     public int remainingTurns() {
         return remaining.size();
@@ -53,20 +59,22 @@ public class ScriptedStreamingModel implements StreamingChatLanguageModel {
 
     @Override
     public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
-        serve(false, List.of(), handler);
+        serve(messages, false, List.of(), handler);
     }
 
     @Override
     public void generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications,
                          StreamingResponseHandler<AiMessage> handler) {
-        serve(true, toolSpecifications == null ? List.of()
+        serve(messages, true, toolSpecifications == null ? List.of()
                 : toolSpecifications.stream().map(ToolSpecification::name).toList(), handler);
     }
 
-    private void serve(boolean toolsOffered, List<String> toolNames,
+    private void serve(List<ChatMessage> messages, boolean toolsOffered, List<String> toolNames,
                        StreamingResponseHandler<AiMessage> handler) {
         toolsOfferedPerCall.add(toolsOffered);
         toolNamesOfferedPerCall.add(List.copyOf(toolNames));
+        promptTextPerCall.add(messages == null ? ""
+                : messages.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining("\n")));
         EvalCase.Turn turn = remaining.poll();
         if (turn == null) {
             throw new IllegalStateException(

--- a/backend/src/test/resources/ai-eval/cases/cases-file-tree.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-file-tree.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "organize-files-into-new-folder-xml",
+    "title": "整理文件到新文件夹（create_folder → move_project_file 链）",
+    "category": "files",
+    "protocol": "xml",
+    "userInput": "帮我把这几个文件整理到一个新文件夹里",
+    "turns": [
+      {
+        "text": "<process name=\"列出项目文档\"><tool_code>doc_list_project_files(projectId=1)</tool_code></process>"
+      },
+      {
+        "text": "<process name=\"新建文件夹\"><tool_code>create_folder(folderName=\"尽调材料\", projectId=1)</tool_code></process>"
+      },
+      {
+        "text": "<process name=\"移动文件\"><tool_code>move_project_file(fileId=101, targetFolderId=77)</tool_code></process>"
+      },
+      {
+        "text": "<process name=\"移动文件\"><tool_code>move_project_file(fileId=102, targetFolderId=77)</tool_code></process>"
+      },
+      {
+        "text": "<final>已新建「尽调材料」文件夹，并把《股权结构说明》《历史沿革说明》两份文件移入其中。</final>"
+      }
+    ],
+    "toolStubs": {
+      "doc_list_project_files": "项目文件列表：\n- ID: 101, 名称: 股权结构说明.docx\n- ID: 102, 名称: 历史沿革说明.docx",
+      "create_folder": "Successfully created folder '尽调材料' (folderId=77).",
+      "move_project_file": "Successfully moved to folder 77."
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "doc_list_project_files" },
+        { "name": "create_folder", "argsContain": { "folderName": "尽调材料" } },
+        { "name": "move_project_file", "argsContain": { "fileId": "101", "targetFolderId": "77" } },
+        { "name": "move_project_file", "argsContain": { "fileId": "102", "targetFolderId": "77" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "rename-project-file-native",
+    "title": "重命名项目文件（fileId 取自 doc_list_project_files）",
+    "category": "files",
+    "protocol": "native",
+    "userInput": "把 会议纪要v3.docx 重命名为 股东会决议.docx",
+    "turns": [
+      {
+        "toolCalls": [
+          {
+            "name": "doc_list_project_files",
+            "arguments": { "projectId": 1 }
+          }
+        ]
+      },
+      {
+        "toolCalls": [
+          {
+            "name": "rename_project_file",
+            "arguments": { "fileId": 101, "newName": "股东会决议.docx" }
+          }
+        ]
+      },
+      {
+        "text": "<final>已把《会议纪要v3.docx》重命名为《股东会决议.docx》。</final>"
+      }
+    ],
+    "toolStubs": {
+      "doc_list_project_files": "项目文件列表：\n- ID: 101, 名称: 会议纪要v3.docx",
+      "rename_project_file": "Successfully renamed to '股东会决议.docx' (fileId=101)."
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "doc_list_project_files" },
+        { "name": "rename_project_file", "argsContain": { "fileId": "101", "newName": "股东会决议" } }
+      ],
+      "structureContains": ["<process", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]

--- a/backend/src/test/resources/ai-eval/cases/cases-harness-recovery.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-harness-recovery.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "truncated-tool-code-correction-xml",
+    "title": "截断的 tool_code 触发纠正回路而非静默收尾（F-10）",
+    "category": "files",
+    "protocol": "xml",
+    "userInput": "帮我建一个「尽调材料」文件夹",
+    "turns": [
+      {
+        "text": "<process name=\"新建文件夹\"><tool_code>create_folder(folderName=\"尽调材料\", projectId=1"
+      },
+      {
+        "text": "<process name=\"新建文件夹\"><tool_code>create_folder(folderName=\"尽调材料\", projectId=1)</tool_code></process>"
+      },
+      {
+        "text": "<final>已新建「尽调材料」文件夹。</final>"
+      }
+    ],
+    "toolStubs": {
+      "create_folder": "Successfully created folder '尽调材料' (folderId=77)."
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "create_folder", "argsContain": { "folderName": "尽调材料" } }
+      ],
+      "promptContains": ["标签未闭合"],
+      "structureContains": ["<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "editor-bridge-json-error-is-failure-xml",
+    "title": "编辑器桥 JSON 错误判为 FAILURE 而非 SUCCESS（F-09）",
+    "category": "revision",
+    "protocol": "xml",
+    "userInput": "把正文里的「甲方」全部替换成「委托方」",
+    "turns": [
+      {
+        "text": "<process name=\"查找替换\"><tool_code>doc_find_replace(findText=\"甲方\", replaceText=\"委托方\", replaceAll=true)</tool_code></process>"
+      },
+      {
+        "text": "<final>替换没有成功：编辑器 30 秒内没有回执。请确认文档已在编辑器中打开后再试一次。</final>"
+      }
+    ],
+    "toolStubs": {
+      "doc_find_replace": "{\"error\": \"操作超时：编辑器 30 秒内未返回回执\"}"
+    },
+    "expect": {
+      "toolCalls": [
+        { "name": "doc_find_replace", "argsContain": { "findText": "甲方", "replaceText": "委托方" } }
+      ],
+      "structureContains": ["<tool_output status=\"FAILURE\">", "<final>"],
+      "bubbleEndStatus": "finished"
+    }
+  }
+]


### PR DESCRIPTION
issue #261 的两个轻量子项（Opus subagent 实现，Fable 验收）：

**回放评测 10→12 组**：新增 cases-file-tree.json（整理文件夹/重命名，XML 与原生双协议）与 cases-harness-recovery.json（截断 tool_code 纠正回路、编辑器桥 {"error"} 判 FAILURE——v0.10.1 两个修复的防回归锁）。EvalHarness 新增 promptContains 断言维度（可观测"回喂了纠正消息"）。

**目录读取口径收敛（纯描述零行为）**：实际六套并存（含漏盘点的 pptx_list_files），每条描述开头一句讲清分工与"ID 从哪来"；描述语言随各文件现状（FileTools 英文、doc/pdf/pptx 中文）。

验证：mvn -B test 945 项全绿（回放评测 29→33 项）。

Closes 部分 #261（Word 表格原语在 harness2/doc-tables 单独出 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)