### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
自 v0.10.1 起合并 17 个 PR，按增量更新规则（0.X.Y）这批改动动了 Electron 壳与运行时布局，必须走大版本。

## 主线内容

- **增量更新 P1-P3**（#266）：小版本应用内补丁（overlay 覆盖层）、大版本全量引导、CI patch-gate 守门。**本版本是第一个带更新器的版本**——0.11.x 起的小版本用户不用再下 1.3GB。
- **Office 插件**（#265/#270/#271/#273）：Word/Excel/PPT 任务窗格、office_* 工具桥、SSE 断线重连、awdk 一键连接
- **AI harness 二期**（#275/#277）：run 状态持久化续跑、LLM 错误四分类与模型故障转移链、运行中上下文压缩、StuckDetector
- **记忆 Git 同步**（#267/#272）：独立记忆仓库 + LWW 自动合并 + 桌面设置面板
- **编辑器**（#276）：Word 表格单元格级原语 doc_table_*
- **其它**：产品埋点体系（#278）、conversationId 服务端签发（#271）、插件云后端加固（#268）、文件整理三线优化（#264）

## 发版前验证

- backend `mvn test`：**1031 通过**（0 失败，基线 858）
- app-e2e / lowa-e2e / desktop-e2e：本地跑（结果补充在评论）
- master 验证构建 run 31085673056（mac+win）：签名脚本修复后重跑

🤖 Generated with [Claude Code](https://claude.com/claude-code)