### PR TITLE
fix: 补丁产物排除漏项 + 体积守门 + patch-gate 只拦进包路径

### DIFF
--- a/desktop/scripts/build-patch-assets.js
+++ b/desktop/scripts/build-patch-assets.js
@@ -31,8 +31,14 @@ const MIRROR_ASSET_BASE = 'https://www.aiworkdeck.com/update/desktop/assets/'
 const GH_RELEASE_BASE = 'https://github.com/zeweihan/aiworkdeck/releases/download/'
 const DOWNLOAD_PAGE = 'https://www.aiworkdeck.com'
 
-// 壳层组件排除项：LOWA 引擎与 CJK 字体只随大版本走（fetch-lowa-assets 烙入）
-const ZETA_EXCLUDE = new Set(['lowa', 'cjk.ttc'])
+// 壳层组件排除项：LOWA 引擎与全部 CJK 字体只随大版本走（fetch-lowa-assets 烙入）。
+// 字体必须按前缀排，不能只列 cjk.ttc——cjk-kai.ttf(23.6MB)/cjk-serif.otf(11.1MB)/
+// cjk-fangsong.ttf(8.4MB) 曾漏网，让 v0.11.0 的壳层补丁涨到 26.9MB（业务代码仅 0.3MB）。
+const zetaExcluded = (name) => name === 'lowa' || /^cjk[.-]/.test(name)
+
+// pysvc-src 排除项：字节码缓存（客户端 Python 会自行重建）与随服务烙入的字体
+// 资产（app/fonts/NotoSansSC-Regular.ttf 15.7MB）——同理只随大版本走。
+const PYSVC_SRC_EXCLUDE_DIRS = new Set(['__pycache__', 'fonts'])
 
 function parseArgs(argv) {
   const args = {}
@@ -161,7 +167,7 @@ async function main() {
   stage['zetaoffice-wrapper'] = path.join(work, 'zetaoffice-wrapper')
   fs.mkdirSync(stage['zetaoffice-wrapper'], { recursive: true })
   for (const en of fs.readdirSync(args.zeta, { withFileTypes: true })) {
-    if (ZETA_EXCLUDE.has(en.name)) continue
+    if (zetaExcluded(en.name)) continue
     fs.cpSync(path.join(args.zeta, en.name), path.join(stage['zetaoffice-wrapper'], en.name), { recursive: true })
   }
 
@@ -173,7 +179,10 @@ async function main() {
     for (const en of fs.readdirSync(args.pysvc, { withFileTypes: true })) {
       const appDir = path.join(args.pysvc, en.name, 'app')
       if (en.isDirectory() && fs.existsSync(appDir)) {
-        fs.cpSync(appDir, path.join(stage['pysvc-src'], en.name, 'app'), { recursive: true })
+        fs.cpSync(appDir, path.join(stage['pysvc-src'], en.name, 'app'), {
+          recursive: true,
+          filter: (src) => !PYSVC_SRC_EXCLUDE_DIRS.has(path.basename(src))
+        })
       }
     }
   }
@@ -210,6 +219,18 @@ async function main() {
       ]
     })
     console.log(`[build-patch-assets] ${name} -> ${assetName} (${(st.size / 1048576).toFixed(1)}MB)`)
+  }
+
+  // --- 体积自检 --------------------------------------------------------------
+  // 补丁的全部意义就是小。任何一次"大文件漏进排除规则"（v0.11.0 的 CJK 字体与
+  // pysvc 字体）都会静默把补丁涨成几十 MB，用户侧只会表现为"更新有点慢"而不会
+  // 报错——所以在产出时就炸，别等用户发现。
+  const MAX_COMPONENT_MB = 8
+  const oversized = components.filter((c) => c.size > MAX_COMPONENT_MB * 1048576)
+  if (oversized.length && !process.env.ALLOW_LARGE_PATCH) {
+    console.error('[build-patch-assets] 补丁组件体积异常（多半是大文件漏进了排除规则）：')
+    for (const c of oversized) console.error(`  ${c.name}: ${(c.size / 1048576).toFixed(1)}MB > ${MAX_COMPONENT_MB}MB`)
+    fail('确认体积合理后可用 ALLOW_LARGE_PATCH=1 放行')
   }
 
   // --- 生成并签名 manifest ---------------------------------------------------

--- a/desktop/scripts/patch-gate.sh
+++ b/desktop/scripts/patch-gate.sh
@@ -40,10 +40,14 @@ echo "[patch-gate] 对比 $PREV..$TAG"
 
 violations=()
 
-# 1) desktop/ 改动（豁免 package.json 的 version 行）
-desktop_changed=$(git diff --name-only "$PREV..$TAG" -- desktop/ | grep -v '^desktop/package.json$' || true)
+# 1) 进包的 Electron 壳改动。只看真正进 .app 的路径——package.json 的 files
+# 字段是 main/** 与 preload/**，加上 build/（entitlements 与图标，进签名与安装器）。
+# desktop/scripts/ 与 desktop/tests/ 是 CI 侧产物，不进包：改它们只影响下一个
+# 全量安装包的构建方式，对存量用户的 .app 是 no-op，故豁免（否则连"修补丁打包
+# 脚本"这种纯 CI 修复都会逼出一个大版本）。
+desktop_changed=$(git diff --name-only "$PREV..$TAG" -- desktop/main/ desktop/preload/ desktop/build/ || true)
 if [ -n "$desktop_changed" ]; then
-  violations+=("desktop/ 有改动（Electron 壳只能随大版本走）：$(echo "$desktop_changed" | head -5 | tr '\n' ' ')")
+  violations+=("进包的 Electron 壳有改动（mac 签名密封，补丁到不了用户手里）：$(echo "$desktop_changed" | head -5 | tr '\n' ' ')")
 fi
 pkg_diff=$(git diff "$PREV..$TAG" -- desktop/package.json | grep -E '^[+-]' | grep -vE '^\+\+\+|^---' | grep -v '"version"' || true)
 if [ -n "$pkg_diff" ]; then


### PR DESCRIPTION
v0.11.0 首次真跑补丁链暴露的问题，不影响已发布的全量安装包，但必须在第一个小版本（0.11.1）之前修好——否则用户第一次体验补丁是 44MB 而不是 5MB。

## 两处排除漏项

| 组件 | 修前 | 修后 | 漏掉的大文件 |
|---|---|---|---|
| zetaoffice-wrapper | 26.9MB | **0.1MB** | cjk-kai.ttf 23.6MB / cjk-serif.otf 11.1MB / cjk-fangsong.ttf 8.4MB |
| pysvc-src | 13.4MB | **0.0MB** | app/fonts/NotoSansSC-Regular.ttf 15.7MB + `__pycache__` |

字体与引擎同属 fetch-lowa-assets / 服务烙入资产，只随大版本走；字节码客户端 Python 自建。排除规则从字面量清单改为前缀/目录名匹配。

## 体积守门（新）

单组件超 8MB 直接失败且**不产出 manifest**。理由：补丁涨大在用户侧只表现为"更新有点慢"，不会报任何错——这类回归必须在产出时炸。实测：注入 20MB 文件 → exit 1、无 manifest 落地；`ALLOW_LARGE_PATCH=1` 可显式放行。

## patch-gate 规则收窄

原规则拦整个 `desktop/`，会把本 PR 这种纯 CI 脚本修复也判成"必须升大版本"。改为只看真正进 `.app` 的路径（`main/` `preload/` `build/`，即 package.json `files` 字段 + 签名相关）。`scripts/` 与 `tests/` 不进包，改它们只影响下一个全量包的构建方式，对存量用户的 `.app` 是 no-op。

五场景实测：

| 改动 | 期望 | 实际 |
|---|---|---|
| desktop/scripts/build-patch-assets.js | 放行 | exit 0 |
| desktop/tests/overlay.test.js | 放行 | exit 0 |
| frontend/src/pages/admin/admin.vue | 放行 | exit 0 |
| desktop/main/main.js | 拦 | exit 1 |
| desktop/preload/preload.js | 拦 | exit 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)