### PR TITLE
feat: 登录短信验证（server 模式二次验证 + 手机号绑定）

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -80,11 +80,32 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `backend/src/main/java/com/checkba/service/account/MachineAccountGuard.java` — server 模式下 `AccountController` 全部端点与 `GET /api/entitlements` 仅 admin 可用（账户连接/权益缓存是机器级状态，普通租户 disconnect 一下全服平台 AI 通道就断）；local-mode 恒放行一字不动。
 - `model/entity/AccountBinding.java` + `repository/AccountBindingRepository.java` — 官网账户 → server 用户映射表；awdk_ 明文**不落库**（每次桥接重验官网）。
 
+**登录短信验证（2026-08-06，sms-auth-integration）**
+- `backend/src/main/java/com/checkba/service/sms/SmsService.java` — 阿里云 dysmsapi 发送，**刻意不引 SDK**
+  （JDK HttpClient 直签 HMAC-SHA1，保补丁通道资格；签名算法有真机对拍向量护栏 `SmsServiceTest`）。
+  阿里云原始错误 Message 只进日志不进用户文案。
+- `service/sms/SmsCodeStore.java` — 验证码生命周期：6 位数字、5 分钟 TTL、一次性核销、单码 5 次验错作废、
+  60 秒重发冷却、单手机号日上限 10 条；内存只存 SHA-256。发送失败调 `invalidate` 回滚冷却（日配额不回滚）。
+- `service/sms/SmsAuthService.java` — 流程编排：scene 隔离（login 码≠bind 码）、大陆手机号校验、
+  绑定唯一性（发码与确认两处都查）。`active()` = server 模式 && sms 配置齐全；local-mode 恒旁路。
+- `User.phone`（unique 列）+ `UserRepository.findByPhone`。
+- AuthController：`/login` 与 `/device-token` 同一道闸——已绑手机号且启用时缺 `smsCode` 回
+  **code 4005** + `{smsRequired, phoneMasked}`（与 4001/4003 同族，前端 api.js 据此切验证码步骤）；
+  存量未绑定用户不拦。`POST /api/auth/sms/send-code`（scene=login 须带正确用户名密码且与 /login 共用
+  失败锁定，**否则就是免锁定的密码试探口**；scene=bind 须已登录）、`POST /api/auth/sms/bind`。
+  IP 维度限频在 `AuthAbuseGuard.checkSmsSendRate`（20 条/小时）。
+- `/api/auth/me` 多回 `smsAuthEnabled` + `phoneMasked`（空串=未绑定，Map.of 不收 null）；
+  绑定 UI 在 `userprofile.vue` 设置 tab「账号安全」，登录验证码步骤在 `login.vue`。
+- 配置 `sms.*`（application.yml）：`SMS_AUTH_ENABLED` 默认 false；AK/SK 走 `SMS_ACCESS_KEY_ID/SECRET`
+  环境变量（RAM 子用户仅授 AliyunDysmsFullAccess），签名/模板默认 `京微资易`/`SMS_483655011`。
+  **签名的运营商报备状态是外部前置条件**（2026-08 时点：报备卡「检测中」待推进，发送会 PORT_NOT_REGISTERED）。
+
 **配置**
 - `security.local-mode`（`application-desktop.yml:36` 为 true，默认 false = 团队服务器模式）。
 - `ai.account.base-url`（`application.yml:97-98`，默认 `https://www.aiworkdeck.com`；**强制 https**，回环 http 例外供本地联调）。
 - `security.license.dir`（默认 `${user.home}/.aiworkdeck`）——license/account/entitlements/platform-ai-key/storage-location 五个状态文件都落这里。
 - `security.registration-mode`（默认 open）与 `security.awdk-login-enabled`(默认 false)——两者都只影响 server 模式；官方托管的插件云后端应配 closed + true。
+- `sms.enabled`（`SMS_AUTH_ENABLED`，默认 false）——登录短信验证开关，仅 server 模式生效；官方托管的插件云后端应配 true + 注入 AK/SK 环境变量。
 
 ## 核心契约
 

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -21,6 +21,13 @@ public class AuthController {
     private final com.checkba.service.DeviceTokenService deviceTokenService;
     private final com.checkba.service.AuthAbuseGuard authAbuseGuard;
     private final com.checkba.service.account.AwdkLoginService awdkLoginService;
+    private final com.checkba.service.sms.SmsAuthService smsAuthService;
+
+    /**
+     * 密码校验通过但还缺短信验证码时的响应 code（前端 api.js 据此弹验证码输入步骤，
+     * 与 4001 featureNotConfigured / 4003 quotaExceeded 同一族约定）。
+     */
+    static final int CODE_SMS_REQUIRED = 4005;
 
     /**
      * awdk 桥接限速的用户名维度占位：与真实用户名共用一套失败锁定，
@@ -51,13 +58,15 @@ public class AuthController {
                           com.checkba.service.AdminAccessService adminAccessService,
                           com.checkba.service.DeviceTokenService deviceTokenService,
                           com.checkba.service.AuthAbuseGuard authAbuseGuard,
-                          com.checkba.service.account.AwdkLoginService awdkLoginService) {
+                          com.checkba.service.account.AwdkLoginService awdkLoginService,
+                          com.checkba.service.sms.SmsAuthService smsAuthService) {
         this.userService = userService;
         this.clientInvitationService = clientInvitationService;
         this.adminAccessService = adminAccessService;
         this.deviceTokenService = deviceTokenService;
         this.authAbuseGuard = authAbuseGuard;
         this.awdkLoginService = awdkLoginService;
+        this.smsAuthService = smsAuthService;
         staticUserService = userService;
     }
 
@@ -123,6 +132,22 @@ public class AuthController {
         }
         try {
             User user = userService.login(request.getUsername(), request.getPassword());
+
+            // 短信二次验证（仅 server 模式且用户已绑定手机号时要求）：
+            // 缺码 → 4005 让前端进入验证码步骤（不发会话、不动失败计数——密码是对的）；
+            // 错码 → 落入下方 catch 计一次失败（叠加 SmsCodeStore 的单码尝试上限双重兜底）。
+            if (smsAuthService != null && smsAuthService.requiresCode(user)) {
+                if (request.getSmsCode() == null || request.getSmsCode().isBlank()) {
+                    Map<String, Object> result = new HashMap<>();
+                    result.put("code", CODE_SMS_REQUIRED);
+                    result.put("message", "本次操作需要短信验证");
+                    result.put("data", Map.of(
+                            "smsRequired", true,
+                            "phoneMasked", com.checkba.service.sms.SmsAuthService.maskPhone(user.getPhone())));
+                    return result;
+                }
+                smsAuthService.verifyLoginCode(user, request.getSmsCode());
+            }
             authAbuseGuard.recordLoginSuccess(ip, request.getUsername());
 
             String sessionId = generateSessionId();
@@ -186,6 +211,79 @@ public class AuthController {
             result.put("message", e.getMessage());
         } catch (IllegalArgumentException e) {
             // 开关关闭等业务态
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
+    }
+
+    /**
+     * 发送短信验证码。两个场景：
+     * <ul>
+     *   <li>{@code scene=login}：匿名但必须携带正确的用户名密码（否则该端点就是
+     *       给任意手机号发短信的水龙头 + 免锁定的密码试探口），发往该用户已绑定的手机号。
+     *       失败锁定与 /login 共用同一套计数。</li>
+     *   <li>{@code scene=bind}：需已登录会话，发往待绑定的新手机号。</li>
+     * </ul>
+     * IP 维度限频在 AuthAbuseGuard，手机号维度冷却/日上限在 SmsCodeStore。
+     */
+    @PostMapping("/sms/send-code")
+    public Map<String, Object> sendSmsCode(@RequestBody SmsSendCodeRequest request,
+                                           @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
+                                           jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        Map<String, Object> result = new HashMap<>();
+        try {
+            authAbuseGuard.checkSmsSendRate(ip);
+            String phoneMasked;
+            if ("bind".equals(request.getScene())) {
+                Long userId = getUserIdFromSession(sessionId);
+                if (userId == null) {
+                    result.put("code", 1);
+                    result.put("message", "未登录");
+                    return result;
+                }
+                phoneMasked = smsAuthService.sendBindCode(userId, request.getPhone());
+            } else {
+                // login 场景：先过锁定闸再校验凭据，语义与 /login 完全一致
+                authAbuseGuard.checkLoginAttempt(ip, request.getUsername());
+                User user;
+                try {
+                    user = userService.login(request.getUsername(), request.getPassword());
+                } catch (IllegalArgumentException e) {
+                    authAbuseGuard.recordLoginFailure(ip, request.getUsername());
+                    throw e;
+                }
+                phoneMasked = smsAuthService.sendLoginCode(user);
+            }
+            authAbuseGuard.recordSmsSend(ip);
+            result.put("code", 0);
+            result.put("message", "验证码已发送");
+            result.put("data", Map.of("phoneMasked", phoneMasked));
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
+    }
+
+    /** 绑定/更换手机号（需已登录；验证码走 scene=bind 的 send-code）。 */
+    @PostMapping("/sms/bind")
+    public Map<String, Object> bindPhone(@RequestBody SmsBindRequest request,
+                                         @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = getUserIdFromSession(sessionId);
+        Map<String, Object> result = new HashMap<>();
+        if (userId == null) {
+            result.put("code", 1);
+            result.put("message", "未登录");
+            return result;
+        }
+        try {
+            String phoneMasked = smsAuthService.confirmBind(userId, request.getPhone(), request.getCode());
+            result.put("code", 0);
+            result.put("message", "绑定成功");
+            result.put("data", Map.of("phoneMasked", phoneMasked));
+        } catch (IllegalArgumentException e) {
             result.put("code", 1);
             result.put("message", e.getMessage());
         }
@@ -270,7 +368,10 @@ public class AuthController {
                 "role", user.getRole(),
                 "subscriptionType", user.getSubscriptionType(),
                 // 系统管理权限（桌面单机=全员；云端=仅 admin 账号），前端据此显示「系统设置」入口
-                "isAdmin", adminAccessService.isAdmin(user)
+                "isAdmin", adminAccessService.isAdmin(user),
+                // 短信验证：绑定入口的显隐与当前绑定状态（Map.of 不收 null，空串=未绑定）
+                "smsAuthEnabled", smsAuthService != null && smsAuthService.active(),
+                "phoneMasked", com.checkba.service.sms.SmsAuthService.maskPhone(user.getPhone())
         ));
         return result;
     }
@@ -367,6 +468,19 @@ public class AuthController {
         }
         try {
             User user = userService.login(body.get("username"), body.get("password"));
+            // 与 /login 同一道短信闸：换令牌也是一次密码登录，留了旁路等于没设闸
+            if (smsAuthService != null && smsAuthService.requiresCode(user)) {
+                String smsCode = body.get("smsCode");
+                if (smsCode == null || smsCode.isBlank()) {
+                    result.put("code", CODE_SMS_REQUIRED);
+                    result.put("message", "本次操作需要短信验证");
+                    result.put("data", Map.of(
+                            "smsRequired", true,
+                            "phoneMasked", com.checkba.service.sms.SmsAuthService.maskPhone(user.getPhone())));
+                    return result;
+                }
+                smsAuthService.verifyLoginCode(user, smsCode);
+            }
             authAbuseGuard.recordLoginSuccess(ip, body.get("username"));
             var issued = deviceTokenService.issue(user.getId(), body.get("name"));
             result.put("code", 0);
@@ -428,11 +542,40 @@ public class AuthController {
     static class LoginRequest {
         private String username;
         private String password;
+        private String smsCode;
 
         public String getUsername() { return username; }
         public void setUsername(String username) { this.username = username; }
         public String getPassword() { return password; }
         public void setPassword(String password) { this.password = password; }
+        public String getSmsCode() { return smsCode; }
+        public void setSmsCode(String smsCode) { this.smsCode = smsCode; }
+    }
+
+    static class SmsSendCodeRequest {
+        private String scene;
+        private String username;
+        private String password;
+        private String phone;
+
+        public String getScene() { return scene; }
+        public void setScene(String scene) { this.scene = scene; }
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+        public String getPhone() { return phone; }
+        public void setPhone(String phone) { this.phone = phone; }
+    }
+
+    static class SmsBindRequest {
+        private String phone;
+        private String code;
+
+        public String getPhone() { return phone; }
+        public void setPhone(String phone) { this.phone = phone; }
+        public String getCode() { return code; }
+        public void setCode(String code) { this.code = code; }
     }
 
     static class ClientLoginRequest {

--- a/backend/src/main/java/com/checkba/model/entity/User.java
+++ b/backend/src/main/java/com/checkba/model/entity/User.java
@@ -50,6 +50,12 @@ public class User {
     private String email;
 
     /**
+     * 绑定手机号（可选，登录短信验证用；唯一，未绑定为 null）
+     */
+    @Column(length = 32, unique = true)
+    private String phone;
+
+    /**
      * 用户密码（加密存储）
      * 注意：实际生产环境应使用 BCrypt 等加密算法
      */
@@ -122,6 +128,14 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
     }
 
     public String getPassword() {

--- a/backend/src/main/java/com/checkba/repository/UserRepository.java
+++ b/backend/src/main/java/com/checkba/repository/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+
+    Optional<User> findByPhone(String phone);
 }
 

--- a/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
+++ b/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
@@ -50,6 +50,9 @@ public class AuthAbuseGuard {
     static final int MAX_REGISTRATIONS_PER_WINDOW = 10;
     static final Duration REGISTRATION_WINDOW = Duration.ofHours(1);
 
+    static final int MAX_SMS_SENDS_PER_WINDOW = 20;
+    static final Duration SMS_WINDOW = Duration.ofHours(1);
+
     /** 内存兜底：超过该条数触发一次过期清理，防止被海量伪造维度撑爆内存。 */
     private static final int PURGE_THRESHOLD = 10_000;
 
@@ -59,6 +62,7 @@ public class AuthAbuseGuard {
 
     private final Map<String, FailureState> loginFailures = new ConcurrentHashMap<>();
     private final Map<String, WindowCounter> registrations = new ConcurrentHashMap<>();
+    private final Map<String, WindowCounter> smsSends = new ConcurrentHashMap<>();
 
     @Autowired
     public AuthAbuseGuard(
@@ -145,6 +149,33 @@ public class AuthAbuseGuard {
         });
     }
 
+    // ==================== 短信发送限频（按 IP；手机号维度在 SmsCodeStore） ====================
+
+    public void checkSmsSendRate(String ip) {
+        if (localMode) return;
+        WindowCounter counter = smsSends.get(ip);
+        long now = nowMillis.getAsLong();
+        if (counter != null
+                && now - counter.windowStart <= SMS_WINDOW.toMillis()
+                && counter.count >= MAX_SMS_SENDS_PER_WINDOW) {
+            throw new IllegalArgumentException("验证码发送过于频繁，请稍后再试");
+        }
+    }
+
+    public void recordSmsSend(String ip) {
+        if (localMode) return;
+        purgeIfOversized();
+        long now = nowMillis.getAsLong();
+        smsSends.compute(ip, (k, counter) -> {
+            if (counter == null || now - counter.windowStart > SMS_WINDOW.toMillis()) {
+                counter = new WindowCounter();
+                counter.windowStart = now;
+            }
+            counter.count++;
+            return counter;
+        });
+    }
+
     // ==================== 内部 ====================
 
     private static String loginKey(String ip, String username) {
@@ -161,6 +192,10 @@ public class AuthAbuseGuard {
         if (registrations.size() > PURGE_THRESHOLD) {
             registrations.entrySet().removeIf(e ->
                     now - e.getValue().windowStart > REGISTRATION_WINDOW.toMillis());
+        }
+        if (smsSends.size() > PURGE_THRESHOLD) {
+            smsSends.entrySet().removeIf(e ->
+                    now - e.getValue().windowStart > SMS_WINDOW.toMillis());
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/sms/HttpSmsTransport.java
+++ b/backend/src/main/java/com/checkba/service/sms/HttpSmsTransport.java
@@ -1,0 +1,42 @@
+package com.checkba.service.sms;
+
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/** {@link SmsTransport} 的生产实现：JDK HttpClient（沿用 HttpAccountTransport 的 HTTP/1.1 立场）。 */
+@Component
+public class HttpSmsTransport implements SmsTransport {
+
+    static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    private final HttpClient client = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    @Override
+    public Reply postForm(String url, String formBody) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(TIMEOUT)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(formBody, StandardCharsets.UTF_8))
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return new Reply(response.statusCode(), response.body());
+        } catch (java.io.IOException e) {
+            return new Reply(-1, e.getMessage() == null ? "io error" : e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new Reply(-1, "interrupted");
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/sms/SmsAuthService.java
+++ b/backend/src/main/java/com/checkba/service/sms/SmsAuthService.java
@@ -1,0 +1,137 @@
+package com.checkba.service.sms;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * 登录短信验证的流程编排：手机号绑定、登录二次验证的发码与核销。
+ *
+ * <p>仅 server 模式生效——local-mode 是免登单机形态，没有登录环节，
+ * {@link #active()} 恒 false，所有端点自然退化为未启用。
+ *
+ * <p>场景常量即 {@link SmsCodeStore} 的 scene 维度：login 码只能用于登录、
+ * bind 码只能用于绑定，互不通用。
+ */
+@Service
+public class SmsAuthService {
+
+    static final String SCENE_LOGIN = "login";
+    static final String SCENE_BIND = "bind";
+
+    /** 大陆手机号；短信通道是国内签名+模板，境外号本就发不了。 */
+    private static final Pattern MAINLAND_PHONE = Pattern.compile("^1[3-9]\\d{9}$");
+
+    private final SmsService smsService;
+    private final SmsCodeStore codeStore;
+    private final UserRepository userRepository;
+    private final boolean localMode;
+
+    @Autowired
+    public SmsAuthService(SmsService smsService, SmsCodeStore codeStore, UserRepository userRepository,
+                          @Value("${security.local-mode:false}") boolean localMode) {
+        this.smsService = smsService;
+        this.codeStore = codeStore;
+        this.userRepository = userRepository;
+        this.localMode = localMode;
+    }
+
+    /** 短信验证在本部署形态下是否启用。 */
+    public boolean active() {
+        return !localMode && smsService.enabled();
+    }
+
+    /** 该用户本次登录是否需要短信验证码（启用且已绑定手机号；未绑定的存量用户不拦）。 */
+    public boolean requiresCode(User user) {
+        return active() && user != null && StringUtils.hasText(user.getPhone());
+    }
+
+    /** 给已绑定手机号的用户发登录验证码，返回脱敏手机号。调用方须先完成密码校验。 */
+    public String sendLoginCode(User user) {
+        if (!requiresCode(user)) {
+            throw new IllegalArgumentException("短信验证未启用");
+        }
+        sendWithRollback(SCENE_LOGIN, user.getPhone());
+        return maskPhone(user.getPhone());
+    }
+
+    /** 核销登录验证码；错码/过期抛业务错误（在线爆破由 SmsCodeStore 的尝试上限兜底）。 */
+    public void verifyLoginCode(User user, String code) {
+        if (!requiresCode(user)) {
+            return;
+        }
+        if (!codeStore.verify(SCENE_LOGIN, user.getPhone(), code)) {
+            throw new IllegalArgumentException("验证码错误或已过期");
+        }
+    }
+
+    /** 给待绑定的手机号发验证码（需已通过会话鉴权），返回脱敏手机号。 */
+    public String sendBindCode(Long userId, String phone) {
+        requireActive();
+        String normalized = normalizePhone(phone);
+        requireNotBoundByOther(userId, normalized);
+        sendWithRollback(SCENE_BIND, normalized);
+        return maskPhone(normalized);
+    }
+
+    /** 校验验证码并完成绑定（也用于更换手机号：直接绑新号覆盖）。 */
+    public String confirmBind(Long userId, String phone, String code) {
+        requireActive();
+        String normalized = normalizePhone(phone);
+        requireNotBoundByOther(userId, normalized);
+        if (!codeStore.verify(SCENE_BIND, normalized, code)) {
+            throw new IllegalArgumentException("验证码错误或已过期");
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在: " + userId));
+        user.setPhone(normalized);
+        user.setUpdatedAt(LocalDateTime.now());
+        userRepository.save(user);
+        return maskPhone(normalized);
+    }
+
+    /** 138****0070；空号回空串（Map.of 不收 null）。 */
+    public static String maskPhone(String phone) {
+        if (phone == null || phone.length() != 11) return "";
+        return phone.substring(0, 3) + "****" + phone.substring(7);
+    }
+
+    private void sendWithRollback(String scene, String phone) {
+        String code = codeStore.issue(scene, phone);
+        try {
+            smsService.sendVerificationCode(phone, code);
+        } catch (RuntimeException e) {
+            // 没发出去就不该占用户的冷却期（当日配额不回滚：网关受理即可能计费）
+            codeStore.invalidate(scene, phone);
+            throw e;
+        }
+    }
+
+    private void requireActive() {
+        if (!active()) {
+            throw new IllegalArgumentException("短信验证未启用");
+        }
+    }
+
+    private static String normalizePhone(String phone) {
+        String trimmed = phone == null ? "" : phone.replaceAll("\\s", "");
+        if (!MAINLAND_PHONE.matcher(trimmed).matches()) {
+            throw new IllegalArgumentException("手机号格式不正确");
+        }
+        return trimmed;
+    }
+
+    private void requireNotBoundByOther(Long userId, String phone) {
+        Optional<User> holder = userRepository.findByPhone(phone);
+        if (holder.isPresent() && !holder.get().getId().equals(userId)) {
+            throw new IllegalArgumentException("该手机号已绑定其他账号");
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/sms/SmsCodeStore.java
+++ b/backend/src/main/java/com/checkba/service/sms/SmsCodeStore.java
@@ -1,0 +1,148 @@
+package com.checkba.service.sms;
+
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * 短信验证码的签发与核销（进程内内存，与 AuthAbuseGuard 同一实现边界：
+ * 单实例基线，多实例部署需外置存储；短信验证仅在官方托管的插件云后端启用，当前恒单实例）。
+ *
+ * <ul>
+ *   <li>验证码 6 位数字，{@link #TTL 5 分钟}有效，验证成功即销毁（一次性）。</li>
+ *   <li>同一 scene+phone {@link #RESEND_COOLDOWN 60 秒}内不可重发。</li>
+ *   <li>连续 {@link #MAX_ATTEMPTS} 次验错即作废（防在线爆破 6 位码）。</li>
+ *   <li>单手机号每天最多 {@link #MAX_PER_PHONE_PER_DAY} 条（防短信轰炸的最后一道；IP 维度在 AuthAbuseGuard）。</li>
+ *   <li>内存只存 SHA-256，不存明文码。</li>
+ * </ul>
+ */
+@Service
+public class SmsCodeStore {
+
+    static final Duration TTL = Duration.ofMinutes(5);
+    static final Duration RESEND_COOLDOWN = Duration.ofSeconds(60);
+    static final int MAX_ATTEMPTS = 5;
+    static final int MAX_PER_PHONE_PER_DAY = 10;
+    private static final Duration DAY_WINDOW = Duration.ofHours(24);
+    private static final int PURGE_THRESHOLD = 10_000;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final LongSupplier nowMillis;
+    private final Map<String, Entry> codes = new ConcurrentHashMap<>();
+    private final Map<String, WindowCounter> dailySends = new ConcurrentHashMap<>();
+
+    public SmsCodeStore() {
+        this(System::currentTimeMillis);
+    }
+
+    /** 测试用：可控时钟。 */
+    SmsCodeStore(LongSupplier nowMillis) {
+        this.nowMillis = nowMillis;
+    }
+
+    /**
+     * 签发一枚验证码（冷却期内 / 当日超量则抛业务错误）。
+     * 调用方拿到返回值后负责真正把短信发出去；发送失败时应调 {@link #invalidate} 回收，
+     * 否则冷却期会挡住用户的立即重试。
+     */
+    public String issue(String scene, String phone) {
+        long now = nowMillis.getAsLong();
+        purgeIfOversized(now);
+        String key = key(scene, phone);
+        Entry existing = codes.get(key);
+        if (existing != null && now - existing.issuedAt < RESEND_COOLDOWN.toMillis()) {
+            throw new IllegalArgumentException("验证码发送过于频繁，请稍后再试");
+        }
+        WindowCounter counter = dailySends.get(phone);
+        if (counter != null
+                && now - counter.windowStart <= DAY_WINDOW.toMillis()
+                && counter.count >= MAX_PER_PHONE_PER_DAY) {
+            throw new IllegalArgumentException("该手机号今日验证码条数已达上限，请明天再试");
+        }
+
+        String code = String.valueOf(100000 + SECURE_RANDOM.nextInt(900000));
+        Entry entry = new Entry();
+        entry.codeHash = sha256(code);
+        entry.issuedAt = now;
+        entry.expiresAt = now + TTL.toMillis();
+        codes.put(key, entry);
+        dailySends.compute(phone, (k, c) -> {
+            if (c == null || now - c.windowStart > DAY_WINDOW.toMillis()) {
+                c = new WindowCounter();
+                c.windowStart = now;
+            }
+            c.count++;
+            return c;
+        });
+        return code;
+    }
+
+    /** 验证并核销：成功即销毁；连续验错超限作废。过期/不存在/错码一律 false。 */
+    public boolean verify(String scene, String phone, String code) {
+        if (code == null || code.isBlank()) return false;
+        String key = key(scene, phone);
+        Entry entry = codes.get(key);
+        long now = nowMillis.getAsLong();
+        if (entry == null || now > entry.expiresAt) {
+            codes.remove(key);
+            return false;
+        }
+        if (!constantTimeEquals(entry.codeHash, sha256(code.trim()))) {
+            if (++entry.attempts >= MAX_ATTEMPTS) {
+                codes.remove(key);
+            }
+            return false;
+        }
+        codes.remove(key);
+        return true;
+    }
+
+    /** 回收一枚未消费的码（发送失败时回滚冷却，不回滚当日计数——短信可能已产生费用）。 */
+    public void invalidate(String scene, String phone) {
+        codes.remove(key(scene, phone));
+    }
+
+    private static String key(String scene, String phone) {
+        return scene + "|" + phone;
+    }
+
+    private static byte[] sha256(String value) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 不可用", e);
+        }
+    }
+
+    private static boolean constantTimeEquals(byte[] a, byte[] b) {
+        return MessageDigest.isEqual(a, b);
+    }
+
+    private void purgeIfOversized(long now) {
+        if (codes.size() > PURGE_THRESHOLD) {
+            codes.entrySet().removeIf(e -> now > e.getValue().expiresAt);
+        }
+        if (dailySends.size() > PURGE_THRESHOLD) {
+            dailySends.entrySet().removeIf(e -> now - e.getValue().windowStart > DAY_WINDOW.toMillis());
+        }
+    }
+
+    private static final class Entry {
+        byte[] codeHash;
+        long issuedAt;
+        long expiresAt;
+        int attempts;
+    }
+
+    private static final class WindowCounter {
+        int count;
+        long windowStart;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/sms/SmsService.java
+++ b/backend/src/main/java/com/checkba/service/sms/SmsService.java
@@ -1,0 +1,164 @@
+package com.checkba.service.sms;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+/**
+ * 阿里云短信（dysmsapi）验证码发送。
+ *
+ * <p>刻意不引入阿里云 SDK：RPC 签名（HMAC-SHA1）几十行可覆盖，换依赖不值得
+ * 破坏补丁通道资格（patch-gate 见 pom 变更即拒，增量更新契约）。签名算法与
+ * 线上探测脚本对拍验证过（2026-08-06 真机发送成功受理）。
+ *
+ * <p>失败文案红线：不得含「登录」「未授权」「请先」子串（licensing 领域地雷 1，
+ * 前端 api.js 会把命中的 code=1 message 当掉线清会话）。阿里云返回的原始 Message
+ * 只进日志，不进给用户的文案。
+ */
+@Service
+@Slf4j
+public class SmsService {
+
+    static final String ENDPOINT = "https://dysmsapi.aliyuncs.com/";
+    static final String API_VERSION = "2017-05-25";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final DateTimeFormatter RPC_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+
+    private final SmsTransport transport;
+    private final boolean enabled;
+    private final String accessKeyId;
+    private final String accessKeySecret;
+    private final String signName;
+    private final String templateCode;
+
+    @Autowired
+    public SmsService(SmsTransport transport,
+                      @Value("${sms.enabled:false}") boolean enabled,
+                      @Value("${sms.access-key-id:}") String accessKeyId,
+                      @Value("${sms.access-key-secret:}") String accessKeySecret,
+                      @Value("${sms.sign-name:}") String signName,
+                      @Value("${sms.template-code:}") String templateCode) {
+        this.transport = transport;
+        this.enabled = enabled;
+        this.accessKeyId = accessKeyId;
+        this.accessKeySecret = accessKeySecret;
+        this.signName = signName;
+        this.templateCode = templateCode;
+    }
+
+    /** 配置齐全才算启用：开关 + AK/SK + 签名 + 模板缺一不可。 */
+    public boolean enabled() {
+        return enabled
+                && StringUtils.hasText(accessKeyId)
+                && StringUtils.hasText(accessKeySecret)
+                && StringUtils.hasText(signName)
+                && StringUtils.hasText(templateCode);
+    }
+
+    /** 发送验证码短信；网关或运营商拒绝时抛业务错误（文案见类注释红线）。 */
+    public void sendVerificationCode(String phone, String code) {
+        if (!enabled()) {
+            throw new IllegalArgumentException("短信服务未配置");
+        }
+        String templateParam;
+        try {
+            templateParam = MAPPER.writeValueAsString(Map.of("code", code));
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new IllegalStateException(e); // Map.of 序列化不会失败
+        }
+        Map<String, String> params = new TreeMap<>();
+        params.put("Action", "SendSms");
+        params.put("Version", API_VERSION);
+        params.put("Format", "JSON");
+        params.put("RegionId", "cn-hangzhou");
+        params.put("AccessKeyId", accessKeyId);
+        params.put("SignatureMethod", "HMAC-SHA1");
+        params.put("SignatureVersion", "1.0");
+        params.put("SignatureNonce", UUID.randomUUID().toString());
+        params.put("Timestamp", RPC_TIMESTAMP.format(Instant.now()));
+        params.put("PhoneNumbers", phone);
+        params.put("SignName", signName);
+        params.put("TemplateCode", templateCode);
+        params.put("TemplateParam", templateParam);
+
+        String body = signedForm(params, accessKeySecret);
+        SmsTransport.Reply reply = transport.postForm(ENDPOINT, body);
+        if (reply.status() != 200) {
+            log.warn("短信网关异常: status={} body={}", reply.status(), abbreviate(reply.body()));
+            throw new IllegalArgumentException("短信发送失败，请稍后重试");
+        }
+        String resultCode;
+        try {
+            JsonNode node = MAPPER.readTree(reply.body());
+            resultCode = node.path("Code").asText("");
+            if (!"OK".equals(resultCode)) {
+                log.warn("短信发送被拒: code={} message={}", resultCode, node.path("Message").asText(""));
+            }
+        } catch (Exception e) {
+            log.warn("短信响应解析失败: {}", abbreviate(reply.body()));
+            throw new IllegalArgumentException("短信发送失败，请稍后重试");
+        }
+        if ("OK".equals(resultCode)) {
+            return;
+        }
+        // 限流类给出可行动文案，其余一律通用文案（阿里云原始 Message 不外露）
+        if ("isv.BUSINESS_LIMIT_CONTROL".equals(resultCode)) {
+            throw new IllegalArgumentException("短信发送过于频繁，请稍后再试");
+        }
+        throw new IllegalArgumentException("短信发送失败，请稍后重试");
+    }
+
+    /**
+     * 按阿里云 RPC 风格签名并编码为表单体（POST）。纯函数，供单测对拍。
+     *
+     * @return {@code Signature=...&K1=V1&...}（键按字典序，RFC3986 百分号编码）
+     */
+    static String signedForm(Map<String, String> sortedParams, String secret) {
+        StringBuilder canonical = new StringBuilder();
+        for (Map.Entry<String, String> e : sortedParams.entrySet()) {
+            if (canonical.length() > 0) canonical.append('&');
+            canonical.append(pctEncode(e.getKey())).append('=').append(pctEncode(e.getValue()));
+        }
+        String toSign = "POST&%2F&" + pctEncode(canonical.toString());
+        String signature;
+        try {
+            Mac mac = Mac.getInstance("HmacSHA1");
+            mac.init(new SecretKeySpec((secret + "&").getBytes(StandardCharsets.UTF_8), "HmacSHA1"));
+            signature = Base64.getEncoder().encodeToString(mac.doFinal(toSign.getBytes(StandardCharsets.UTF_8)));
+        } catch (java.security.GeneralSecurityException e) {
+            throw new IllegalStateException("HmacSHA1 不可用", e);
+        }
+        return "Signature=" + pctEncode(signature) + "&" + canonical;
+    }
+
+    /** RFC3986 百分号编码（URLEncoder 是表单编码，三处差异必须修正，与阿里云签名规范一致）。 */
+    static String pctEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
+                .replace("+", "%20")
+                .replace("*", "%2A")
+                .replace("%7E", "~");
+    }
+
+    private static String abbreviate(String s) {
+        if (s == null) return "";
+        return s.length() > 300 ? s.substring(0, 300) + "..." : s;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/sms/SmsTransport.java
+++ b/backend/src/main/java/com/checkba/service/sms/SmsTransport.java
@@ -1,0 +1,13 @@
+package com.checkba.service.sms;
+
+/**
+ * 短信网关的出站 HTTP 缝：单测打桩不依赖网络（与 account 包的 AccountTransport 同一模式）。
+ */
+public interface SmsTransport {
+
+    /** 对 url 发送 application/x-www-form-urlencoded POST，返回状态码与响应体。 */
+    Reply postForm(String url, String formBody);
+
+    record Reply(int status, String body) {
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -90,6 +90,16 @@ mcp:
       timeout-seconds: 60
       enabled: true
 
+# 登录短信验证（阿里云 dysmsapi；仅 server 模式生效，local-mode 免登无登录环节）。
+# AK/SK 一律环境变量注入（与 OSS_ACCESS_KEY_* 同一模式），绝不写进任何入库文件。
+# 官方托管的插件云后端：SMS_AUTH_ENABLED=true + RAM 子用户密钥（仅 AliyunDysmsFullAccess）。
+sms:
+  enabled: ${SMS_AUTH_ENABLED:false}
+  access-key-id: ${SMS_ACCESS_KEY_ID:}
+  access-key-secret: ${SMS_ACCESS_KEY_SECRET:}
+  sign-name: ${SMS_SIGN_NAME:京微资易}
+  template-code: ${SMS_TEMPLATE_CODE:SMS_483655011}
+
 # AI 大模型配置（供应商可切换）
 ai:
   # 官网账户服务地址（解锁门在线校验、账户连接、平台 AI 通道密钥）。

--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -54,7 +54,7 @@ class AuthControllerHardeningTest {
     void closedRegistrationShortCircuits() {
         UserService userService = mock(UserService.class);
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("closed"), null);
+                userService, null, null, null, serverGuard("closed"), null, null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -70,7 +70,7 @@ class AuthControllerHardeningTest {
         when(userService.register(anyString(), anyString(), anyString()))
                 .thenReturn(user(1L, "alice"));
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("open"), null);
+                userService, null, null, null, serverGuard("open"), null, null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -85,7 +85,7 @@ class AuthControllerHardeningTest {
                 .thenReturn(user(1L, "alice"));
         AuthAbuseGuard localGuard = new AuthAbuseGuard(true, "closed");
         AuthController controller = new AuthController(
-                userService, null, null, null, localGuard, null);
+                userService, null, null, null, localGuard, null, null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -99,7 +99,7 @@ class AuthControllerHardeningTest {
         when(userService.login(anyString(), anyString()))
                 .thenThrow(new IllegalArgumentException("用户名或密码错误"));
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("open"), null);
+                userService, null, null, null, serverGuard("open"), null, null);
 
         AuthController.LoginRequest request = new AuthController.LoginRequest();
         request.setUsername("alice");
@@ -122,7 +122,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(anyString()))
                 .thenReturn(new AwdkLoginService.BridgeSession("awdt_x", 7L, "awd_hanzewei"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -141,7 +141,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(any()))
                 .thenThrow(new IllegalArgumentException("本服务器未开启账户桥接功能"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -160,7 +160,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(anyString())).thenThrow(new AccountException(
                 AccountException.Kind.UNAUTHORIZED, "账户 Key 无效或已被撤销，请到官网账户页重新生成"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null);
 
         for (int i = 0; i < 5; i++) {
             assertEquals(1, controller.awdkLogin(Map.of("key", "awdk_bad"), http()).get("code"));

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSessionIdTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSessionIdTest.java
@@ -26,7 +26,7 @@ class AuthControllerSessionIdTest {
 
     @Test
     void sessionIdIsUnpredictable() throws Exception {
-        AuthController controller = new AuthController(null, null, null, null, null, null);
+        AuthController controller = new AuthController(null, null, null, null, null, null, null);
 
         long before = System.currentTimeMillis();
         Set<String> seen = new HashSet<>();

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
@@ -1,0 +1,204 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.User;
+import com.checkba.service.AuthAbuseGuard;
+import com.checkba.service.UserService;
+import com.checkba.service.sms.SmsAuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 登录短信二次验证的 AuthController 接线：4005 信封、验证码核销挡在会话签发之前、
+ * send-code 的 login 场景不成为免锁定的密码试探口。服务层语义见 SmsAuthServiceTest。
+ */
+class AuthControllerSmsTest {
+
+    private static MockHttpServletRequest http() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("9.9.9.9");
+        return request;
+    }
+
+    private static User boundUser() {
+        User user = new User();
+        user.setId(7L);
+        user.setUsername("alice");
+        user.setDisplayName("Alice");
+        user.setRole("USER");
+        user.setSubscriptionType("FREE");
+        user.setPhone("13800000000");
+        return user;
+    }
+
+    private static AuthController.LoginRequest loginRequest(String smsCode) {
+        AuthController.LoginRequest request = new AuthController.LoginRequest();
+        request.setUsername("alice");
+        request.setPassword("pw123456");
+        request.setSmsCode(smsCode);
+        return request;
+    }
+
+    private static AuthController controller(UserService userService, AuthAbuseGuard guard,
+                                             SmsAuthService smsAuthService) {
+        return new AuthController(userService, null, null, null, guard, null, smsAuthService);
+    }
+
+    @Test
+    @DisplayName("需要短信验证且缺码：返回 4005 + 脱敏手机号，不签发会话")
+    void missingCodeReturns4005WithoutSession() {
+        UserService userService = mock(UserService.class);
+        when(userService.login("alice", "pw123456")).thenReturn(boundUser());
+        SmsAuthService sms = mock(SmsAuthService.class);
+        when(sms.requiresCode(any())).thenReturn(true);
+
+        AuthController controller = controller(userService, new AuthAbuseGuard(false, "open"), sms);
+        Map<String, Object> result = controller.login(loginRequest(null), http());
+
+        assertEquals(AuthController.CODE_SMS_REQUIRED, result.get("code"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+        assertEquals(true, data.get("smsRequired"));
+        assertEquals("138****0000", data.get("phoneMasked"));
+        assertFalse(data.containsKey("sessionId"), "缺码不得签发会话");
+        verify(sms, never()).verifyLoginCode(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("带正确验证码：核销通过后正常登录")
+    void correctCodeLogsIn() {
+        UserService userService = mock(UserService.class);
+        when(userService.login("alice", "pw123456")).thenReturn(boundUser());
+        SmsAuthService sms = mock(SmsAuthService.class);
+        when(sms.requiresCode(any())).thenReturn(true);
+
+        AuthController controller = controller(userService, new AuthAbuseGuard(false, "open"), sms);
+        Map<String, Object> result = controller.login(loginRequest("123456"), http());
+
+        assertEquals(0, result.get("code"));
+        verify(sms).verifyLoginCode(any(), eq("123456"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+        assertNotNull(data.get("sessionId"));
+    }
+
+    @Test
+    @DisplayName("错码：业务错误信封，不签发会话，且计入失败锁定")
+    void wrongCodeFailsAndCounts() {
+        UserService userService = mock(UserService.class);
+        when(userService.login("alice", "pw123456")).thenReturn(boundUser());
+        SmsAuthService sms = mock(SmsAuthService.class);
+        when(sms.requiresCode(any())).thenReturn(true);
+        doThrow(new IllegalArgumentException("验证码错误或已过期"))
+                .when(sms).verifyLoginCode(any(), eq("000000"));
+
+        AuthAbuseGuard guard = new AuthAbuseGuard(false, "open");
+        AuthController controller = controller(userService, guard, sms);
+        for (int i = 0; i < 5; i++) {
+            Map<String, Object> result = controller.login(loginRequest("000000"), http());
+            assertEquals(1, result.get("code"));
+        }
+        // 连续错码后触发同一套失败锁定：锁定文案（不再是错码文案）
+        Map<String, Object> locked = controller.login(loginRequest("000000"), http());
+        assertEquals(1, locked.get("code"));
+        assertTrue(String.valueOf(locked.get("message")).contains("锁定"));
+    }
+
+    @Test
+    @DisplayName("未启用/未绑定（requiresCode=false）：登录行为与从前一字不差")
+    void notRequiredKeepsLegacyBehavior() {
+        UserService userService = mock(UserService.class);
+        when(userService.login("alice", "pw123456")).thenReturn(boundUser());
+        SmsAuthService sms = mock(SmsAuthService.class);
+        when(sms.requiresCode(any())).thenReturn(false);
+
+        AuthController controller = controller(userService, new AuthAbuseGuard(false, "open"), sms);
+        Map<String, Object> result = controller.login(loginRequest(null), http());
+        assertEquals(0, result.get("code"));
+        verify(sms, never()).verifyLoginCode(any(), any());
+    }
+
+    @Test
+    @DisplayName("send-code login 场景：凭据错误计入失败锁定（不是免锁定的密码试探口）")
+    void sendCodeLoginSceneCountsCredentialFailures() {
+        UserService userService = mock(UserService.class);
+        when(userService.login(anyString(), anyString()))
+                .thenThrow(new IllegalArgumentException("用户名或密码错误"));
+        SmsAuthService sms = mock(SmsAuthService.class);
+
+        AuthAbuseGuard guard = new AuthAbuseGuard(false, "open");
+        AuthController controller = controller(userService, guard, sms);
+        AuthController.SmsSendCodeRequest request = new AuthController.SmsSendCodeRequest();
+        request.setScene("login");
+        request.setUsername("alice");
+        request.setPassword("wrong");
+
+        for (int i = 0; i < 5; i++) {
+            Map<String, Object> result = controller.sendSmsCode(request, null, http());
+            assertEquals(1, result.get("code"));
+        }
+        // 第 6 次：还没碰 UserService 就被锁定闸拦下
+        clearInvocations(userService);
+        Map<String, Object> locked = controller.sendSmsCode(request, null, http());
+        assertEquals(1, locked.get("code"));
+        assertTrue(String.valueOf(locked.get("message")).contains("锁定"));
+        verify(userService, never()).login(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("send-code login 场景：凭据正确即发码并返回脱敏手机号")
+    void sendCodeLoginSceneSends() {
+        UserService userService = mock(UserService.class);
+        when(userService.login("alice", "pw123456")).thenReturn(boundUser());
+        SmsAuthService sms = mock(SmsAuthService.class);
+        when(sms.sendLoginCode(any())).thenReturn("138****0000");
+
+        AuthController controller = controller(userService, new AuthAbuseGuard(false, "open"), sms);
+        AuthController.SmsSendCodeRequest request = new AuthController.SmsSendCodeRequest();
+        request.setScene("login");
+        request.setUsername("alice");
+        request.setPassword("pw123456");
+
+        Map<String, Object> result = controller.sendSmsCode(request, null, http());
+        assertEquals(0, result.get("code"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+        assertEquals("138****0000", data.get("phoneMasked"));
+    }
+
+    @Test
+    @DisplayName("send-code bind 场景：无会话即业务错误，不发短信")
+    void sendCodeBindSceneRequiresSession() {
+        SmsAuthService sms = mock(SmsAuthService.class);
+        AuthController controller = controller(mock(UserService.class),
+                new AuthAbuseGuard(false, "open"), sms);
+        AuthController.SmsSendCodeRequest request = new AuthController.SmsSendCodeRequest();
+        request.setScene("bind");
+        request.setPhone("13800000000");
+
+        Map<String, Object> result = controller.sendSmsCode(request, "session_not_exist", http());
+        assertEquals(1, result.get("code"));
+        verify(sms, never()).sendBindCode(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("device-token 与 /login 同一道短信闸：缺码 4005")
+    void deviceTokenGetsSameSmsGate() {
+        UserService userService = mock(UserService.class);
+        when(userService.login("alice", "pw123456")).thenReturn(boundUser());
+        SmsAuthService sms = mock(SmsAuthService.class);
+        when(sms.requiresCode(any())).thenReturn(true);
+
+        AuthController controller = controller(userService, new AuthAbuseGuard(false, "open"), sms);
+        Map<String, Object> result = controller.issueDeviceToken(
+                Map.of("username", "alice", "password", "pw123456"), http());
+        assertEquals(AuthController.CODE_SMS_REQUIRED, result.get("code"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/sms/SmsAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsAuthServiceTest.java
@@ -1,0 +1,159 @@
+package com.checkba.service.sms;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class SmsAuthServiceTest {
+
+    private static final SmsTransport OK_TRANSPORT =
+            (url, body) -> new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
+
+    private static SmsService enabledSms(SmsTransport transport) {
+        return new SmsService(transport, true, "ak", "sk", "sign", "tpl");
+    }
+
+    private static User user(long id, String phone) {
+        User u = new User();
+        u.setId(id);
+        u.setUsername("alice");
+        u.setPhone(phone);
+        return u;
+    }
+
+    @Test
+    @DisplayName("local-mode 恒未启用；server 模式看 SmsService 配置")
+    void activeGating() {
+        UserRepository repo = mock(UserRepository.class);
+        SmsCodeStore store = new SmsCodeStore();
+        assertFalse(new SmsAuthService(enabledSms(OK_TRANSPORT), store, repo, true).active(),
+                "local-mode 必须旁路");
+        assertTrue(new SmsAuthService(enabledSms(OK_TRANSPORT), store, repo, false).active());
+        SmsService disabled = new SmsService(OK_TRANSPORT, false, "ak", "sk", "sign", "tpl");
+        assertFalse(new SmsAuthService(disabled, store, repo, false).active());
+    }
+
+    @Test
+    @DisplayName("requiresCode：启用且已绑手机号才要求；存量未绑定用户不拦")
+    void requiresCodeOnlyWithPhone() {
+        SmsAuthService svc = new SmsAuthService(
+                enabledSms(OK_TRANSPORT), new SmsCodeStore(), mock(UserRepository.class), false);
+        assertTrue(svc.requiresCode(user(1, "13800000000")));
+        assertFalse(svc.requiresCode(user(1, null)));
+        assertFalse(svc.requiresCode(user(1, "")));
+        assertFalse(svc.requiresCode(null));
+    }
+
+    @Test
+    @DisplayName("登录码全流程：发码（脱敏返回）→ 核销放行；错码抛业务错误")
+    void loginCodeRoundTrip() {
+        AtomicReference<String> sentBody = new AtomicReference<>();
+        SmsCodeStore store = new SmsCodeStore();
+        SmsAuthService svc = new SmsAuthService(enabledSms((url, body) -> {
+            sentBody.set(body);
+            return new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
+        }), store, mock(UserRepository.class), false);
+
+        User alice = user(1, "13800000000");
+        assertEquals("138****0000", svc.sendLoginCode(alice));
+        assertNotNull(sentBody.get());
+
+        assertThrows(IllegalArgumentException.class, () -> svc.verifyLoginCode(alice, "000000"));
+        // 从请求体反解真码（6 位数字模板参数）
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile("%22code%22%3A%22(\\d{6})%22")
+                .matcher(sentBody.get());
+        assertTrue(m.find(), "请求体应含验证码模板参数: " + sentBody.get());
+        assertDoesNotThrow(() -> svc.verifyLoginCode(alice, m.group(1)));
+    }
+
+    @Test
+    @DisplayName("发送失败回滚冷却：网关拒绝后可立即重试")
+    void failedSendRollsBackCooldown() {
+        SmsCodeStore store = new SmsCodeStore();
+        AtomicReference<Boolean> fail = new AtomicReference<>(true);
+        SmsAuthService svc = new SmsAuthService(enabledSms((url, body) ->
+                fail.get() ? new SmsTransport.Reply(500, "boom")
+                           : new SmsTransport.Reply(200, "{\"Code\":\"OK\"}")),
+                store, mock(UserRepository.class), false);
+        User alice = user(1, "13800000000");
+        assertThrows(IllegalArgumentException.class, () -> svc.sendLoginCode(alice));
+        fail.set(false);
+        assertDoesNotThrow(() -> svc.sendLoginCode(alice), "失败的发送不该占用冷却期");
+    }
+
+    @Test
+    @DisplayName("绑定：手机号被他人占用即拒（发码与确认两处都查）")
+    void bindRejectsPhoneBoundByOther() {
+        UserRepository repo = mock(UserRepository.class);
+        when(repo.findByPhone("13800000000")).thenReturn(Optional.of(user(99, "13800000000")));
+        SmsAuthService svc = new SmsAuthService(enabledSms(OK_TRANSPORT), new SmsCodeStore(), repo, false);
+        assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "13800000000"));
+        assertThrows(IllegalArgumentException.class, () -> svc.confirmBind(1L, "13800000000", "123456"));
+    }
+
+    @Test
+    @DisplayName("绑定确认：正码落库并返回脱敏号；同一用户重绑自己的号不算冲突")
+    void confirmBindPersistsPhone() {
+        UserRepository repo = mock(UserRepository.class);
+        AtomicReference<String> sentBody = new AtomicReference<>();
+        User alice = user(1, null);
+        when(repo.findByPhone("13800000000")).thenReturn(Optional.of(alice)); // 自己占用自己：放行
+        when(repo.findById(1L)).thenReturn(Optional.of(alice));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        SmsAuthService svc = new SmsAuthService(enabledSms((url, body) -> {
+            sentBody.set(body);
+            return new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
+        }), new SmsCodeStore(), repo, false);
+
+        svc.sendBindCode(1L, "13800000000");
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile("%22code%22%3A%22(\\d{6})%22")
+                .matcher(sentBody.get());
+        assertTrue(m.find());
+        assertEquals("138****0000", svc.confirmBind(1L, "13800000000", m.group(1)));
+        assertEquals("13800000000", alice.getPhone());
+        verify(repo).save(alice);
+    }
+
+    @Test
+    @DisplayName("手机号格式：非大陆手机号拒绝；空白剥离后再校验")
+    void phoneFormatValidated() {
+        SmsAuthService svc = new SmsAuthService(
+                enabledSms(OK_TRANSPORT), new SmsCodeStore(), mock(UserRepository.class), false);
+        assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "12345"));
+        assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "23800000000"));
+        assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, null));
+        assertDoesNotThrow(() -> svc.sendBindCode(1L, " 138 0000 0000 "));
+    }
+
+    @Test
+    @DisplayName("未启用时绑定类操作一律业务错误，且文案不踩掉线三子串")
+    void inactiveRejectsBindOperations() {
+        SmsAuthService svc = new SmsAuthService(
+                enabledSms(OK_TRANSPORT), new SmsCodeStore(), mock(UserRepository.class), true);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> svc.sendBindCode(1L, "13800000000"));
+        assertFalse(e.getMessage().contains("登录"));
+        assertFalse(e.getMessage().contains("未授权"));
+        assertFalse(e.getMessage().contains("请先"));
+        // 未启用时登录核销直接放行（requiresCode=false 的对偶行为）
+        assertDoesNotThrow(() -> svc.verifyLoginCode(user(1, "13800000000"), null));
+    }
+
+    @Test
+    @DisplayName("maskPhone：标准脱敏；异常长度回空串（Map.of 不收 null）")
+    void maskPhoneShape() {
+        assertEquals("138****0000", SmsAuthService.maskPhone("13800000000"));
+        assertEquals("", SmsAuthService.maskPhone(null));
+        assertEquals("", SmsAuthService.maskPhone("123"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/sms/SmsCodeStoreTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsCodeStoreTest.java
@@ -1,0 +1,98 @@
+package com.checkba.service.sms;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SmsCodeStoreTest {
+
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+    private final SmsCodeStore store = new SmsCodeStore(clock::get);
+
+    @Test
+    @DisplayName("签发-验证-核销：验证成功后同码立即失效（一次性）")
+    void verifyConsumesCode() {
+        String code = store.issue("login", "13800000000");
+        assertEquals(6, code.length());
+        assertTrue(store.verify("login", "13800000000", code));
+        assertFalse(store.verify("login", "13800000000", code), "已核销的码不可复用");
+    }
+
+    @Test
+    @DisplayName("scene 隔离：login 码不能用于 bind")
+    void scenesAreIsolated() {
+        String code = store.issue("login", "13800000000");
+        assertFalse(store.verify("bind", "13800000000", code));
+        assertTrue(store.verify("login", "13800000000", code));
+    }
+
+    @Test
+    @DisplayName("过期即失效（5 分钟 TTL）")
+    void expiryInvalidates() {
+        String code = store.issue("login", "13800000000");
+        clock.addAndGet(SmsCodeStore.TTL.toMillis() + 1);
+        assertFalse(store.verify("login", "13800000000", code));
+    }
+
+    @Test
+    @DisplayName("冷却期内重发被拒；冷却期过后可重发且旧码作废")
+    void resendCooldown() {
+        String first = store.issue("login", "13800000000");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> store.issue("login", "13800000000"));
+        assertTrue(e.getMessage().contains("频繁"));
+
+        clock.addAndGet(SmsCodeStore.RESEND_COOLDOWN.toMillis() + 1);
+        String second = store.issue("login", "13800000000");
+        if (!first.equals(second)) {
+            assertFalse(store.verify("login", "13800000000", first), "重发后旧码应作废");
+        }
+        assertTrue(store.verify("login", "13800000000", second));
+    }
+
+    @Test
+    @DisplayName("连续验错 5 次作废，正确码也救不回来（防在线爆破）")
+    void attemptCapInvalidates() {
+        String code = store.issue("login", "13800000000");
+        for (int i = 0; i < SmsCodeStore.MAX_ATTEMPTS; i++) {
+            assertFalse(store.verify("login", "13800000000", "000000".equals(code) ? "111111" : "000000"));
+        }
+        assertFalse(store.verify("login", "13800000000", code));
+    }
+
+    @Test
+    @DisplayName("单手机号日上限：第 11 条被拒，跨天窗口滚动后恢复")
+    void dailyCapPerPhone() {
+        for (int i = 0; i < SmsCodeStore.MAX_PER_PHONE_PER_DAY; i++) {
+            store.issue("login", "13800000000");
+            clock.addAndGet(SmsCodeStore.RESEND_COOLDOWN.toMillis() + 1);
+        }
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> store.issue("login", "13800000000"));
+        assertTrue(e.getMessage().contains("上限"));
+        // 其他手机号不受影响
+        assertDoesNotThrow(() -> store.issue("login", "13900000000"));
+        // 24 小时后窗口滚动
+        clock.addAndGet(java.time.Duration.ofHours(24).toMillis() + 1);
+        assertDoesNotThrow(() -> store.issue("login", "13800000000"));
+    }
+
+    @Test
+    @DisplayName("发送失败回收：invalidate 后立即重发不吃冷却")
+    void invalidateClearsCooldown() {
+        store.issue("login", "13800000000");
+        store.invalidate("login", "13800000000");
+        assertDoesNotThrow(() -> store.issue("login", "13800000000"));
+    }
+
+    @Test
+    @DisplayName("空码/空白码一律 false")
+    void blankCodeRejected() {
+        store.issue("login", "13800000000");
+        assertFalse(store.verify("login", "13800000000", null));
+        assertFalse(store.verify("login", "13800000000", "  "));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/sms/SmsServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsServiceTest.java
@@ -1,0 +1,116 @@
+package com.checkba.service.sms;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SmsServiceTest {
+
+    private static SmsService service(SmsTransport transport) {
+        return new SmsService(transport, true, "testAk", "testSecret", "京微资易", "SMS_483655011");
+    }
+
+    @Test
+    @DisplayName("签名对拍：与线上实弹验证过的参考实现逐字节一致")
+    void signatureMatchesReferenceVector() {
+        Map<String, String> params = new TreeMap<>();
+        params.put("AccessKeyId", "testAk");
+        params.put("Action", "SendSms");
+        params.put("Format", "JSON");
+        params.put("PhoneNumbers", "13800000000");
+        params.put("RegionId", "cn-hangzhou");
+        params.put("SignName", "京微资易");
+        params.put("SignatureMethod", "HMAC-SHA1");
+        params.put("SignatureNonce", "fixed-nonce");
+        params.put("SignatureVersion", "1.0");
+        params.put("TemplateCode", "SMS_483655011");
+        params.put("TemplateParam", "{\"code\":\"123456\"}");
+        params.put("Timestamp", "2026-08-06T08:00:00Z");
+        params.put("Version", "2017-05-25");
+
+        String form = SmsService.signedForm(params, "testSecret");
+        // 参考签名由已在阿里云真机发送成功的探测脚本对同一输入计算得出
+        assertTrue(form.startsWith("Signature=" + SmsService.pctEncode("W4Fg6bZtlyxPvAMi3Leco/yBEBQ=") + "&"),
+                "签名不匹配: " + form.substring(0, Math.min(80, form.length())));
+        assertTrue(form.contains("PhoneNumbers=13800000000"));
+        assertTrue(form.contains("SignName=%E4%BA%AC%E5%BE%AE%E8%B5%84%E6%98%93"));
+    }
+
+    @Test
+    @DisplayName("百分号编码：修正 URLEncoder 的表单编码三处差异")
+    void pctEncodeIsRfc3986() {
+        assertEquals("a%20b", SmsService.pctEncode("a b"));
+        assertEquals("%2A", SmsService.pctEncode("*"));
+        assertEquals("~", SmsService.pctEncode("~"));
+        assertEquals("%3D%26", SmsService.pctEncode("=&"));
+    }
+
+    @Test
+    @DisplayName("网关 OK 正常返回；请求体带齐手机号与模板参数")
+    void sendsThroughTransport() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        SmsService svc = service((url, body) -> {
+            captured.set(body);
+            assertEquals(SmsService.ENDPOINT, url);
+            return new SmsTransport.Reply(200, "{\"Code\":\"OK\",\"BizId\":\"1\"}");
+        });
+        assertDoesNotThrow(() -> svc.sendVerificationCode("13800000000", "654321"));
+        assertTrue(captured.get().contains("PhoneNumbers=13800000000"));
+        assertTrue(captured.get().contains("Signature="));
+        assertTrue(captured.get().contains(SmsService.pctEncode("{\"code\":\"654321\"}")));
+    }
+
+    @Test
+    @DisplayName("运营商拒绝：文案通用且不外露阿里云原始 Message，也不含掉线三子串")
+    void carrierRejectionUsesSafeMessage() {
+        SmsService svc = service((url, body) ->
+                new SmsTransport.Reply(200, "{\"Code\":\"isv.MOBILE_NUMBER_ILLEGAL\",\"Message\":\"raw aliyun text\"}"));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> svc.sendVerificationCode("13800000000", "111111"));
+        assertFalse(e.getMessage().contains("raw aliyun"));
+        assertNoLogoutSubstring(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("限流码给出可行动文案")
+    void throttleCodeGetsActionableMessage() {
+        SmsService svc = service((url, body) ->
+                new SmsTransport.Reply(200, "{\"Code\":\"isv.BUSINESS_LIMIT_CONTROL\"}"));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> svc.sendVerificationCode("13800000000", "111111"));
+        assertTrue(e.getMessage().contains("频繁"));
+        assertNoLogoutSubstring(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("传输层失败（超时/断网）不炸栈，抛业务错误")
+    void transportFailureBecomesBusinessError() {
+        SmsService svc = service((url, body) -> new SmsTransport.Reply(-1, "timed out"));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> svc.sendVerificationCode("13800000000", "111111"));
+        assertNoLogoutSubstring(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("配置不齐即未启用（缺 AK/SK/签名/模板任一）")
+    void incompleteConfigMeansDisabled() {
+        assertFalse(new SmsService((u, b) -> null, true, "", "s", "sign", "tpl").enabled());
+        assertFalse(new SmsService((u, b) -> null, true, "ak", "", "sign", "tpl").enabled());
+        assertFalse(new SmsService((u, b) -> null, true, "ak", "s", "", "tpl").enabled());
+        assertFalse(new SmsService((u, b) -> null, true, "ak", "s", "sign", "").enabled());
+        assertFalse(new SmsService((u, b) -> null, false, "ak", "s", "sign", "tpl").enabled());
+        assertTrue(new SmsService((u, b) -> null, true, "ak", "s", "sign", "tpl").enabled());
+    }
+
+    /** licensing 领域地雷 1：这些子串会被前端当成掉线清会话。 */
+    private static void assertNoLogoutSubstring(String message) {
+        assertFalse(message.contains("登录"), message);
+        assertFalse(message.contains("未授权"), message);
+        assertFalse(message.contains("请先"), message);
+    }
+}

--- a/frontend/src/pages/login/login.vue
+++ b/frontend/src/pages/login/login.vue
@@ -110,7 +110,7 @@
           </view>
 
           <!-- Login Form -->
-          <view v-if="activeTab === 'login'" class="form-body swing-in">
+          <view v-if="activeTab === 'login' && !smsStep" class="form-body swing-in">
             <view class="input-group">
               <text class="label">用户名</text>
               <input class="glass-input" type="text" v-model="loginForm.username" placeholder="请输入用户名" placeholder-class="placeholder-style" />
@@ -127,6 +127,22 @@
                <text class="link-text">忘记密码?</text>
             </view>
             <button class="action-btn" :loading="loginLoading" @tap="handleLogin">登 录</button>
+          </view>
+
+          <!-- SMS Verification Step（登录二次验证） -->
+          <view v-else-if="activeTab === 'login' && smsStep" class="form-body swing-in">
+            <view class="input-group">
+              <text class="label">短信验证</text>
+              <text class="sms-hint">验证码已发送至 {{ smsPhoneMasked }}</text>
+              <input class="glass-input" type="number" maxlength="6" v-model="smsCodeInput" @confirm="handleSmsLogin" placeholder="请输入 6 位验证码" placeholder-class="placeholder-style" />
+            </view>
+            <view class="form-options">
+              <text class="link-text" @tap="backToPassword">返回</text>
+              <text class="link-text" :class="{ disabled: smsCountdown > 0 }" @tap="resendSmsCode">
+                {{ smsCountdown > 0 ? smsCountdown + 's 后可重发' : '重新发送' }}
+              </text>
+            </view>
+            <button class="action-btn" :loading="loginLoading" @tap="handleSmsLogin">验证并登录</button>
           </view>
 
           <!-- Register Form -->
@@ -169,7 +185,7 @@
 </template>
 
 <script>
-import { login, register, clientLogin, getWizardStatus, getMyProjects } from '@/services/api.js'
+import { login, register, clientLogin, getWizardStatus, getMyProjects, sendSmsCode } from '@/services/api.js'
 import { saveSession, getSessionId, getCurrentUser } from '@/utils/auth.js'
 import { syncRecentToMenu } from '@/utils/recentProjects.js'
 
@@ -211,8 +227,17 @@ export default {
       },
       loginLoading: false,
       registerLoading: false,
-      clientLoginLoading: false
+      clientLoginLoading: false,
+      // 登录短信二次验证步骤（后端返回 4005 时进入）
+      smsStep: false,
+      smsPhoneMasked: '',
+      smsCodeInput: '',
+      smsCountdown: 0,
+      smsCountdownTimer: null
     }
+  },
+  onUnload() {
+    if (this.smsCountdownTimer) clearInterval(this.smsCountdownTimer)
   },
   computed: {
     deviceTransform() {
@@ -281,6 +306,76 @@ export default {
       this.loginForm = { username: '', password: '' };
       this.registerForm = { username: '', displayName: '', password: '', passwordConfirm: '' };
       this.clientForm = { accessCode: '' };
+      this.resetSmsStep();
+    },
+    resetSmsStep() {
+      this.smsStep = false;
+      this.smsPhoneMasked = '';
+      this.smsCodeInput = '';
+      this.smsCountdown = 0;
+      if (this.smsCountdownTimer) {
+        clearInterval(this.smsCountdownTimer);
+        this.smsCountdownTimer = null;
+      }
+    },
+    backToPassword() {
+      this.resetSmsStep();
+    },
+    startSmsCountdown() {
+      this.smsCountdown = 60;
+      if (this.smsCountdownTimer) clearInterval(this.smsCountdownTimer);
+      this.smsCountdownTimer = setInterval(() => {
+        if (this.smsCountdown > 0) {
+          this.smsCountdown--;
+        } else {
+          clearInterval(this.smsCountdownTimer);
+          this.smsCountdownTimer = null;
+        }
+      }, 1000);
+    },
+    async resendSmsCode() {
+      if (this.smsCountdown > 0) return;
+      try {
+        const res = await sendSmsCode({
+          scene: 'login',
+          username: this.loginForm.username,
+          password: this.loginForm.password
+        });
+        if (res.data && res.data.phoneMasked) this.smsPhoneMasked = res.data.phoneMasked;
+        this.startSmsCountdown();
+        uni.showToast({ title: '验证码已发送', icon: 'none' });
+      } catch (e) {
+        uni.showToast({ title: e.message || '发送失败', icon: 'none' });
+      }
+    },
+    async handleSmsLogin() {
+      if (!this.smsCodeInput || this.smsCodeInput.length < 6) {
+        uni.showToast({ title: '请输入 6 位验证码', icon: 'none' });
+        return;
+      }
+      this.loginLoading = true;
+      try {
+        const res = await login(this.loginForm.username, this.loginForm.password, this.smsCodeInput);
+        if (res.code === 0 && res.data) {
+          this.resetSmsStep();
+          this.finishLogin(res);
+        } else {
+          uni.showToast({ title: res.message || '验证失败', icon: 'none' });
+        }
+      } catch (error) {
+        this.smsCodeInput = '';
+        uni.showToast({ title: error.message || '验证失败', icon: 'none' });
+      } finally {
+        this.loginLoading = false;
+      }
+    },
+    finishLogin(res) {
+      saveSession(res.data.sessionId, res.data.user);
+      if (!getSessionId()) throw new Error('Session Save Failed');
+      uni.showToast({ title: '登录成功', icon: 'success' });
+      setTimeout(() => {
+        uni.reLaunch({ url: '/pages/userprofile/userprofile' });
+      }, 300);
     },
     async handleClientLogin() {
       if (!this.clientForm.accessCode) {
@@ -315,18 +410,19 @@ export default {
       try {
         const res = await login(this.loginForm.username, this.loginForm.password);
         if (res.code === 0 && res.data) {
-          saveSession(res.data.sessionId, res.data.user);
-           // Verify session
-          if (!getSessionId()) throw new Error('Session Save Failed');
-          
-          uni.showToast({ title: '登录成功', icon: 'success' });
-          setTimeout(() => {
-            uni.reLaunch({ url: '/pages/userprofile/userprofile' });
-          }, 300);
+          this.finishLogin(res);
         } else {
           uni.showToast({ title: res.message || '登录失败', icon: 'none' });
         }
       } catch (error) {
+        if (error && error.smsRequired) {
+          // 密码已对，进入短信验证步骤并自动发一次码
+          this.smsStep = true;
+          this.smsPhoneMasked = (error.data && error.data.phoneMasked) || '';
+          this.smsCodeInput = '';
+          this.resendSmsCode();
+          return;
+        }
         console.error('Login Failed', error);
         uni.showToast({ title: error.message || '登录失败', icon: 'none' });
       } finally {
@@ -765,6 +861,18 @@ $glass-border: rgba(255, 255, 255, 0.5);
 .link-text {
   color: $color-primary;
   cursor: pointer;
+
+  &.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}
+
+.sms-hint {
+  display: block;
+  font-size: 12px;
+  color: $color-text-light;
+  margin-bottom: 6px;
 }
 
 .action-btn {

--- a/frontend/src/pages/userprofile/userprofile.vue
+++ b/frontend/src/pages/userprofile/userprofile.vue
@@ -310,6 +310,34 @@
                 </view>
               </view>
               
+              <!-- 账号安全（server 模式且登录短信验证启用时显示） -->
+              <view v-if="userInfo.smsAuthEnabled" class="form-group">
+                <text class="group-title">账号安全</text>
+                <view class="form-row">
+                  <text class="form-label">手机号</text>
+                  <text class="form-value">{{ userInfo.phoneMasked || '未绑定' }}</text>
+                  <text class="bind-link" @tap="showBindPhone = !showBindPhone">{{ userInfo.phoneMasked ? '更换' : '绑定' }}</text>
+                </view>
+                <view v-if="showBindPhone" class="bind-phone-form">
+                  <view class="form-row">
+                    <text class="form-label">新手机号</text>
+                    <input class="bind-input" type="number" maxlength="11" v-model="bindPhoneInput" placeholder="请输入大陆手机号" />
+                  </view>
+                  <view class="form-row">
+                    <text class="form-label">验证码</text>
+                    <input class="bind-input code" type="number" maxlength="6" v-model="bindCodeInput" placeholder="6 位验证码" />
+                    <button class="btn-send-code" :disabled="bindCountdown > 0" @tap="sendBindPhoneCode">
+                      {{ bindCountdown > 0 ? bindCountdown + 's' : '获取验证码' }}
+                    </button>
+                  </view>
+                  <view class="bind-actions">
+                    <button class="btn-bind-confirm" @tap="confirmBindPhone">确认绑定</button>
+                    <text class="bind-link" @tap="cancelBindPhone">取消</text>
+                  </view>
+                  <text class="bind-tip">绑定后，本账号在网页端与桌面端连接时的密码登录均需短信验证码</text>
+                </view>
+              </view>
+
               <!-- 授权（桌面端）：当前模式 / 激活时间 / 解除授权 -->
               <view v-if="isDesktop && licenseInfo.unlocked" class="form-group">
                 <text class="group-title">授权</text>
@@ -351,7 +379,7 @@
 </template>
 
 <script>
-import { getMyProjects, deleteProject, renameProject, getCurrentUser as getCurrentUserApi, getMyFavorites, deleteFavorite, getFavoriteImageUrl, getProjectMembers, addProjectMember, removeProjectMember, getUserActivityHistory, inviteClient, uploadAvatar, getLicenseStatus, deactivateLicense } from '@/services/api.js'
+import { getMyProjects, deleteProject, renameProject, getCurrentUser as getCurrentUserApi, getMyFavorites, deleteFavorite, getFavoriteImageUrl, getProjectMembers, addProjectMember, removeProjectMember, getUserActivityHistory, inviteClient, uploadAvatar, getLicenseStatus, deactivateLicense, sendSmsCode, bindPhone } from '@/services/api.js'
 import { getProjectTypeLabel } from '@/config/projectTypes.js'
  import { getCurrentUser, isLoggedIn, getSessionId, clearSession, setSessionUser } from '@/utils/auth.js'
 import InviteMemberDialog from '@/components/InviteMemberDialog.vue'
@@ -404,6 +432,13 @@ export default {
 
       // 授权状态（桌面端）：{ unlocked, mode, plan, activatedAt? }
       licenseInfo: {},
+
+      // 手机号绑定（登录短信验证，仅 server 模式且启用时显示）
+      showBindPhone: false,
+      bindPhoneInput: '',
+      bindCodeInput: '',
+      bindCountdown: 0,
+      bindCountdownTimer: null,
 
       // Activity Logs
       activityLogs: [],
@@ -674,17 +709,66 @@ export default {
       if (user) {
         this.userInfo = user
         this.checkAdminTab()
-      } else {
-        // 如果本地没有，尝试从服务器获取
-        try {
-          const res = await getCurrentUserApi()
-          if (res.code === 0 && res.data) {
-            this.userInfo = res.data
-            this.checkAdminTab()
-          }
-        } catch (error) {
-          console.error('获取用户信息失败:', error)
+      }
+      // 短信绑定状态（smsAuthEnabled/phoneMasked）只在 /api/auth/me 下发，
+      // 缓存的登录响应里没有——有缓存也拉一次合并
+      try {
+        const res = await getCurrentUserApi()
+        if (res.code === 0 && res.data) {
+          this.userInfo = { ...this.userInfo, ...res.data }
+          this.checkAdminTab()
         }
+      } catch (error) {
+        console.error('获取用户信息失败:', error)
+      }
+    },
+    async sendBindPhoneCode() {
+      if (this.bindCountdown > 0) return
+      if (!/^1[3-9]\d{9}$/.test(this.bindPhoneInput)) {
+        uni.showToast({ title: '请输入正确的手机号', icon: 'none' })
+        return
+      }
+      try {
+        await sendSmsCode({ scene: 'bind', phone: this.bindPhoneInput })
+        uni.showToast({ title: '验证码已发送', icon: 'none' })
+        this.bindCountdown = 60
+        if (this.bindCountdownTimer) clearInterval(this.bindCountdownTimer)
+        this.bindCountdownTimer = setInterval(() => {
+          if (this.bindCountdown > 0) {
+            this.bindCountdown--
+          } else {
+            clearInterval(this.bindCountdownTimer)
+            this.bindCountdownTimer = null
+          }
+        }, 1000)
+      } catch (e) {
+        uni.showToast({ title: e.message || '发送失败', icon: 'none' })
+      }
+    },
+    async confirmBindPhone() {
+      if (!this.bindCodeInput || this.bindCodeInput.length < 6) {
+        uni.showToast({ title: '请输入 6 位验证码', icon: 'none' })
+        return
+      }
+      try {
+        const res = await bindPhone(this.bindPhoneInput, this.bindCodeInput)
+        uni.showToast({ title: '绑定成功', icon: 'success' })
+        const phoneMasked = (res.data && res.data.phoneMasked) || ''
+        this.userInfo = { ...this.userInfo, phoneMasked }
+        setSessionUser(this.userInfo)
+        this.cancelBindPhone()
+      } catch (e) {
+        uni.showToast({ title: e.message || '绑定失败', icon: 'none' })
+      }
+    },
+    cancelBindPhone() {
+      this.showBindPhone = false
+      this.bindPhoneInput = ''
+      this.bindCodeInput = ''
+      this.bindCountdown = 0
+      if (this.bindCountdownTimer) {
+        clearInterval(this.bindCountdownTimer)
+        this.bindCountdownTimer = null
       }
     },
     checkAdminTab() {
@@ -1808,6 +1892,66 @@ $danger-color: #E74C3C;
         color: $text-main;
         background: #fafafa;
     }
+}
+
+/* 手机号绑定（登录短信验证） */
+.bind-link {
+    color: $brand-primary;
+    font-size: 13px;
+    margin-left: 12px;
+    cursor: pointer;
+}
+.bind-phone-form {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed $border-color;
+}
+.bind-input {
+    flex: 1;
+    height: 36px;
+    border: 1px solid $border-color;
+    border-radius: 6px;
+    padding: 0 10px;
+    font-size: 13px;
+    background: #fff;
+}
+.btn-send-code {
+    height: 36px;
+    line-height: 34px;
+    margin-left: 8px;
+    padding: 0 12px;
+    border: 1px solid $border-color;
+    border-radius: 6px;
+    background: #fff;
+    color: $text-main;
+    font-size: 13px;
+    cursor: pointer;
+
+    &[disabled] {
+        opacity: 0.5;
+        cursor: default;
+    }
+}
+.bind-actions {
+    display: flex;
+    align-items: center;
+    margin-top: 10px;
+}
+.btn-bind-confirm {
+    height: 36px;
+    line-height: 36px;
+    padding: 0 18px;
+    border-radius: 6px;
+    background: $brand-primary;
+    color: #fff;
+    font-size: 13px;
+    cursor: pointer;
+}
+.bind-tip {
+    display: block;
+    margin-top: 8px;
+    font-size: 12px;
+    color: $text-secondary;
 }
 
 /* Work Log Styles */

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -229,6 +229,13 @@ function request(options) {
           if (res.data.code === 0) {
             // 成功：code=0
             resolve(res.data);
+          } else if (res.data.code === 4005) {
+            // 密码已对但还差短信验证码（登录二次验证）：reject 时带 smsRequired 标记，
+            // 登录页据此切到验证码输入步骤。这不是错误态，不能落进通用报错。
+            const err = new Error(res.data.message || '本次操作需要短信验证');
+            err.smsRequired = true;
+            err.data = res.data.data || {};
+            reject(err);
           } else if (res.data.code === 4001) {
             // 功能未配置（#18 T7）：reject 时带 featureNotConfigured 标记，
             // 由调用方决定如何引导（弹"去设置" / 降级为只读），避免在拦截器
@@ -858,14 +865,40 @@ export function register(username, password, displayName) {
 }
 
 // 用户登录
-export function login(username, password) {
+export function login(username, password, smsCode) {
   return request({
     url: '/api/auth/login',
     method: 'POST',
     data: {
       username,
       password,
+      ...(smsCode ? { smsCode } : {}),
     },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+// 发送短信验证码。scene='login' 需带 username/password（发往已绑定手机号）；
+// scene='bind' 需已登录，带 phone（发往待绑定的新手机号）。
+export function sendSmsCode(payload) {
+  return request({
+    url: '/api/auth/sms/send-code',
+    method: 'POST',
+    data: payload,
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+// 绑定/更换手机号（验证码走 sendSmsCode 的 bind 场景）
+export function bindPhone(phone, code) {
+  return request({
+    url: '/api/auth/sms/bind',
+    method: 'POST',
+    data: { phone, code },
     header: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
## 概要

用户登录（server 模式/插件云后端）加短信验证码二次验证，并提供手机号绑定入口。阿里云 dysmsapi 直签调用（无新 Maven 依赖，保增量更新补丁通道资格）。

## 设计要点

- **默认关闭**：`SMS_AUTH_ENABLED=false`；仅 server 模式生效，local-mode（桌面免登）恒旁路
- **存量兼容**：未绑定手机号的用户登录不受影响；绑定后 `/login` 与 `/device-token` 同一道闸（缺码回 4005 信封）
- **防滥用四层**：send-code login 场景要求正确用户名密码且与登录共用失败锁定（堵免锁定密码试探口）；IP 维度 20 条/小时（AuthAbuseGuard）；单手机号 60s 冷却 + 日上限 10 条；单码 5 次验错作废
- **验证码**：6 位、5 分钟 TTL、一次性核销、内存只存 SHA-256；scene 隔离（login 码≠bind 码）
- **签名护栏**：HMAC-SHA1 直签与真机实弹验证过的参考实现逐字节对拍（SmsServiceTest）
- **文案红线**：全部错误文案避开「登录/未授权/请先」三子串（api.js 掉线启发式）

## 验证

- `mvn test` 全量 973 通过（JDK 21），新增 32 个用例（SmsService/SmsCodeStore/SmsAuthService/AuthControllerSms）
- `npm run check:emits` + `npm run build:h5` 通过

## 部署备注

- 服务器侧需注入 `SMS_AUTH_ENABLED=true` + `SMS_ACCESS_KEY_ID/SECRET`（RAM 子用户仅授 AliyunDysmsFullAccess）
- 短信实际可达依赖阿里云签名「京微资易」的运营商报备完成（当前卡「检测中」，已重新发起，属外部前置条件，不阻塞合并）

🤖 Generated with [Claude Code](https://claude.com/claude-code)