### PR TITLE
fix: 镜像同步加重试与续传，产物缺失时不换 manifest

### DIFF
--- a/deploy/update-mirror-sync.sh
+++ b/deploy/update-mirror-sync.sh
@@ -42,11 +42,36 @@ if ! [ -s "$TMP/assets.tsv" ]; then
   exit 0
 fi
 
+# 大陆机器直连 GitHub 拉几十 MB 常中断：带重试与续传，并对下载结果验字节数。
+# 首次部署 v0.11.0 时 28MB 的壳层补丁就是这么半路断掉的（set -e 让整次同步
+# 前功尽弃，manifest 没落地——所幸客户端有 GitHub 兜底通道，用户无感）。
+fetch_with_retry() {
+  local url="$1" out="$2" want="$3" name="$4"
+  local attempt
+  for attempt in 1 2 3 4; do
+    # -C - 续传（配合 --retry 让长文件能接着上次的字节走）
+    if curl -fL --retry 3 --retry-delay 5 --retry-all-errors \
+            --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
+            -C - -o "$out" "$url" 2>/dev/null || [ -f "$out" ]; then
+      local got
+      got=$(stat -c %s "$out" 2>/dev/null || stat -f %z "$out" 2>/dev/null || echo 0)
+      [ "$got" = "$want" ] && return 0
+      echo "[mirror-sync]   第 $attempt 次不完整（$got/$want），重试" >&2
+    else
+      echo "[mirror-sync]   第 $attempt 次失败，重试" >&2
+    fi
+    sleep $((attempt * 5))
+  done
+  return 1
+}
+
 MANIFEST_READY=0
+FAILED=0
 while IFS=$'\t' read -r name size url; do
   case "$name" in
     manifest.json|manifest.json.sig)
-      curl -sfL "$url" -o "$TMP/$name"
+      # manifest 很小，失败即整次放弃（不能让 assets 换了而清单还是旧的）
+      curl -sfL --retry 3 --retry-delay 3 --retry-all-errors "$url" -o "$TMP/$name" || { FAILED=1; break; }
       MANIFEST_READY=1
       ;;
     *)
@@ -55,12 +80,23 @@ while IFS=$'\t' read -r name size url; do
         echo "[mirror-sync] skip (exists): $name"
       else
         echo "[mirror-sync] download: $name (${size} bytes)"
-        curl -sfL "$url" -o "$TMP/$name"
-        mv "$TMP/$name" "$dest"
+        if fetch_with_retry "$url" "$TMP/$name" "$size" "$name"; then
+          mv "$TMP/$name" "$dest"
+        else
+          echo "[mirror-sync] 放弃: $name（重试耗尽）" >&2
+          FAILED=1
+        fi
       fi
       ;;
   esac
 done < "$TMP/assets.tsv"
+
+# 任一 asset 没就位就绝不换 manifest——否则客户端会拿到指向缺失文件的清单，
+# 每次检查更新都下到一半失败。宁可镜像停在旧版本（客户端自动走 GitHub 兜底）。
+if [ "$FAILED" = "1" ]; then
+  echo "[mirror-sync] 有产物未就位，本次不更新 manifest（客户端继续走 GitHub 兜底）；重跑本脚本可续传补齐" >&2
+  exit 1
+fi
 
 # assets 全部就位后再原子换 manifest（+签名，先 sig 后 manifest 也无妨，
 # 客户端总是成对拉取并验签）


### PR DESCRIPTION
首次部署 v0.11.0 镜像时暴露的真实缺陷。

## 现象与根因

大陆 ECS 直连 GitHub 拉 28MB 的 `patch-zetaoffice-wrapper` 半路断掉 → `set -e` 让脚本在循环中途退出 → 已下的 3 个 asset 留在磁盘上，但 manifest 没落地（trap 清了临时区）。

我最初以为脚本跑完了——因为调用时写了 `bash sync.sh | tail -15`，**管道把脚本退出码掩盖了**，读到的 exit 0 其实是后面 `ls` 的。

## 修复

- 大文件走 `fetch_with_retry`：`--retry-all-errors` + 续传 `-C -` + 低速超时（`--speed-limit 1024 --speed-time 60`，卡死不会挂住），四轮重试，**每轮用 Release 元数据里的 size 验字节数**，不完整就重来
- 任一 asset 未就位 → 显式 `exit 1` 且**不换 manifest**。这条是关键：宁可镜像停在旧版本（客户端自动走 GitHub 兜底、用户无感），也不能让客户端拿到指向缺失文件的清单，否则每次检查更新都会下到一半失败
- 重跑即续传补齐，幂等不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)