### PR TITLE
refactor: 宿主能力层收口 + H5 编辑器 iframe 通道（Phase A1）

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -26,6 +26,12 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - composables：`zetaOfficeBoot.js`（emscripten Module、注入 CJK 字体+fontconfig 别名 conf、locale shim、resolve office-worker port）、`zetaOfficeEditorEndpoint.js`（boot+executor+serve 三件套）、`zetaOfficeRelay.js`（跨隔离命令中继：serveExecutor/createRelayExecutor/portTransport）、`libreofficeExecutorClient.js`（EDITOR_ACTIONS 白名单+请求应答）、`useLibreOfficeBridge.js`、`useZetaOfficeWebview.js`（webview 包成 executeCommand 契约）、`zetaOfficeImeOverlay.js`（canvas 透明 IME 层，中文输入+控制键转发）。
 - `frontend/vite.zetaoffice.config.js` — editor 页专用 Vite 构建（脱离 uni-app），产出 dist/zetaoffice/。
 
+**宿主能力层与编辑器容器（两种壳，一套 relay）**
+- `frontend/src/services/host.js` — **前端访问壳的唯一出口**。业务代码一律 `import { host } from '@/services/host.js'`，禁止再直接读 `window.checkbaDesktop`（那会把 Electron 焊回业务代码）。惰性 Proxy 解析（与原先逐次读 window 的语义一致，注入时机不影响调用点）；桌面态逐字段透传，Web 态只提供浏览器里真能实现的能力、其余字段缺席（调用点原有的 `if (host.x && ...)` 守卫因此原样成立）。`isDesktopHost()` 是「是不是桌面壳」的判据。
+- `host.zetaoffice.getEditor()` 返回**带 kind 的描述符**：桌面 `{kind:'webview', url, preload, partition}`、Web `{kind:'iframe', url}`。`host.zetaoffice` 在宿主没有这一项时必须缺席（app-e2e 给浏览器目标注入的最小桩只有 shell.openExternal）——无条件包一层会让调用点的 `typeof getEditor === 'function'` 守卫通过后再抛 TypeError。
+- `useZetaOfficeWebview.js` — 两个宿主侧传输适配器：`webviewTransport`（Electron webview IPC）与 `iframeTransport`（同源 postMessage，收发都钉死 `location.origin` 且校验 `e.source`）。差异只在这两个 `{send, subscribe}` 里，relay/executor/worker 一字不改。
+- Web 态部署布局见 `deploy/web/nginx.conf.example`（站点 root 下 `zetaoffice/`，全站 COOP/COEP）；`host.zetaoffice.isAvailable()` 在 Web 态 HEAD 探一次编辑器页，没部署就让宿主退回预览路径，而不是挂一个永远起不来的 iframe。
+
 **宿主 UI（保活/实例管理/自动保存）**
 - `frontend/src/components/ReviewPanel.vue` — 审阅面板（编辑器右栏）：修订/批注两栏清单，点击定位、逐条接受/拒绝、全部接受/拒绝、批注标记解决/删除。数据全走 worker 原语（list_revisions/goto_revision/resolve_revision/resolve_all_revisions、list_comments/goto_comment/set_comment_resolved/delete_comment），executor 由 LibreOfficeEditor 注入；处置后 emit changed → 走自动保存链路。**面板是修订的权威视图**（页边小字读不到作者/时间，且同行多格删除会在页边互叠）。
 - `frontend/src/components/LibreOfficeEditor.vue` — 单文档编辑器组件：webview 创建、prefetch、load/export、autoSave、flushSave、reloadFromBackend。支持**备胎过继**（watch file 仅 null→文档；引擎已就绪走 finishDocLoad，未就绪由 onEndpointReady 接手）与**只读预览接力**（字节预取完成即 docx-preview 本地渲染，previewReady 后 overlay 变成可滚动阅读 + 顶部细进度条，ready 后整体消失）。
@@ -65,6 +71,9 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 ## 已知地雷
 
 - boot 三地雷勿回退（canvas 必须 id=qtcanvas 且禁 border/padding；COOP/COEP 缺失 SharedArrayBuffer 不可用；locale shim）。
+- **宿主事件订阅必须在建元素时就挂，不能推迟到 dom-ready**（`LibreOfficeEditor.subscribeHostEvents`，与命令通道 `wireExecutor` 分开）：`boot-log` 从引擎启动第一刻就在发，`modified` 是自动保存的唯一触发信号——晚挂一步就丢开头的消息，丢 `modified` 等于用户的编辑不落盘。命令通道则相反，webview 必须等 dom-ready（此前 send 无处可去）。
+- **iframe 容器不能加 sandbox**：沙箱会掐掉 SharedArrayBuffer 与 Worker，引擎起不来；跨源隔离靠站点级 COOP/COEP，不是 iframe 属性。
+- iframe 传输的订阅挂在 `window` 上，不随元素移除消失——`beforeUnmount` 必须显式退订（`_eventUnsub`），否则关一个文档漏一个监听器，且已销毁实例的 `onDocModified` 还会被触发。
 - 引擎仅 Writer+Calc 实锤（PR#165），别承诺 Impress。
 - CJK 字体走类别映射别名（PR#157/158），**不能用 assign 硬替换**；tofu 排查用 list_fonts 诊断 action。
 - 删除键/快捷键必须走 `.uno:` 调度（覆盖层吞键+修订模式手工删卡死教训，PR#164/166）。

--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -64,6 +64,7 @@ launch（**启动页**）/ unlock / identity / login / newproject / project-over
 
 ## 相关文件
 
+- `frontend/src/services/host.js` — **访问桌面壳能力的唯一出口**（浏览器面板/截图/剪贴板/组件下载/自动更新/本地文件对话框/应用菜单等）。业务代码一律 `import { host } from '@/services/host.js'`，**不要再写 `window.checkbaDesktop`**；「是不是桌面壳」用 `isDesktopHost()`。桌面态逐字段透传、Web 态缺席，所以既有的 `if (host.browser && ...)` 子对象守卫必须保留（守卫就是能力探测）。详见 doc-editor.md 的「宿主能力层与编辑器容器」。
 - `frontend/src/config/tools.js` — 底部工具面板 tab（WORKBENCH_TOOLS）；`fileActions.js` — 文件树批量操作；`workbenchActions.js` — OCR/内链 scheme 常量。
 - `frontend/src/components/FileTree.vue`（5195 行）— 左栏文件树。
 - 各页面：login.vue(777)、newproject/index.vue(660)、wizard.vue(593，重跑语义见 PR#134)、userprofile.vue(2158)、variable-library.vue(543)、admin.vue(1648+，含插件广场入口与「记忆同步」面板——nav key `memory`、desktopOnly，配置记忆 Git 远端，见 version-control.md)、plugin-market.vue(766)。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,6 +2,7 @@
 import { getSessionId } from '@/utils/auth.js'
 import { openFolderFlow, openFileFlow, openLocalRootPath, openLocalFilePath } from '@/utils/ideOpen.js'
 import { track } from '@/utils/telemetryClient.js'
+import { host } from '@/services/host.js'
 
 export default {
   onLaunch: function () {
@@ -22,9 +23,8 @@ export default {
     })
     // IDE 化应用菜单动作（桌面壳菜单栏 文件→打开文件夹/打开文件/新建/最近打开）。
     // App 级注册一次，天然避开 project-overview 的页面栈多实例问题。
-    if (typeof window !== 'undefined' && window.checkbaDesktop
-        && window.checkbaDesktop.menu && window.checkbaDesktop.menu.onAction) {
-      window.checkbaDesktop.menu.onAction(async (data) => {
+    if (host.menu && host.menu.onAction) {
+      host.menu.onAction(async (data) => {
         const action = data && data.action
         if (!action) return
         if (!getSessionId()) {
@@ -52,8 +52,7 @@ export default {
     }
     // IDE 化：拖一个文件夹到窗口任意位置 = 打开为项目（capture 段拦截，
     // 避免文件上传等既有 drop 区把「文件夹」误当文件收走；单个目录才接管）
-    if (typeof window !== 'undefined' && window.checkbaDesktop
-        && window.checkbaDesktop.fs && window.checkbaDesktop.fs.getPathForFile) {
+    if (host.fs && host.fs.getPathForFile) {
       window.addEventListener('dragover', (e) => { e.preventDefault() }, false)
       window.addEventListener('drop', (e) => {
         try {
@@ -63,7 +62,7 @@ export default {
           if (!entry || !entry.isDirectory) return
           e.preventDefault()
           e.stopPropagation()
-          const path = window.checkbaDesktop.fs.getPathForFile(e.dataTransfer.files[0])
+          const path = host.fs.getPathForFile(e.dataTransfer.files[0])
           if (!path) return
           if (!getSessionId()) {
             uni.showToast({ title: '请先登录', icon: 'none' })

--- a/frontend/src/components/BrowserPane.vue
+++ b/frontend/src/components/BrowserPane.vue
@@ -61,6 +61,7 @@
 <script>
 import { getApiBaseUrl } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
+import { host } from '@/services/host.js'
 
 export default {
   name: 'BrowserPane',
@@ -98,8 +99,8 @@ export default {
     },
     isDesktopBrowser() {
       try {
-        // 通过 preload 暴露的 checkbaDesktop 判断
-        return typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.browser
+        // 宿主是否具备 BrowserView 能力（Web 态该字段缺席）
+        return host.browser
       } catch (e) {
         return false
       }
@@ -171,7 +172,7 @@ export default {
   },
   methods: {
     async setupDesktopBrowser() {
-      const api = window.checkbaDesktop && window.checkbaDesktop.browser
+      const api = host.browser
       if (!api) return
 
       // 监听 window.open/_blank => 工作区新 tab
@@ -248,14 +249,14 @@ export default {
 
       // MVP：组件卸载即销毁 view（后续可由“tab close”统一管理，避免丢历史）
       try {
-        const api = window.checkbaDesktop && window.checkbaDesktop.browser
+        const api = host.browser
         if (api && this._desktopViewId) api.destroy({ id: this._desktopViewId })
       } catch (e) {
         // ignore
       }
     },
     syncDesktopBounds() {
-      const api = window.checkbaDesktop && window.checkbaDesktop.browser
+      const api = host.browser
       const mountRef = this.$refs.desktopMount
       const el = mountRef && mountRef.$el ? mountRef.$el : mountRef
       if (!api || !el || !this._desktopViewId) return
@@ -287,7 +288,7 @@ export default {
       // Desktop：直接导航 BrowserView
       if (this.isDesktopBrowser) {
         try {
-          const api = window.checkbaDesktop && window.checkbaDesktop.browser
+          const api = host.browser
           if (api && this._desktopViewId) {
             // 不让 invoke rejection 冒泡到控制台（主进程可能返回 ok=false / ERR_ABORTED）
             Promise.resolve(api.navigate({ id: this._desktopViewId, url: next })).catch(() => {})
@@ -342,7 +343,7 @@ export default {
     async toggleMobileMode() {
       if (!this.isDesktopBrowser) return
       this.isMobileMode = !this.isMobileMode
-      const api = window.checkbaDesktop && window.checkbaDesktop.browser
+      const api = host.browser
       if (!api || !this._desktopViewId) return
       
       const mobileUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1'

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -827,6 +827,7 @@
 <script>
 import { getProjectFiles, createFolder, createFile, renameFile, deleteFile, deleteFilePerm, restoreFile as restoreFileApi, getRecycleBinFiles, moveFile, batchDeleteFiles, batchMoveFiles, batchCopyFiles, getApiBaseUrl } from '@/services/api.js'
 import { getAuthHeaders, getSessionId } from '@/utils/auth.js'
+import { host } from '@/services/host.js'
 import CircularProgress from '@/components/CircularProgress.vue'
 import FileTypeIcon from '@/components/FileTypeIcon.vue'
 import TagChip from '@/components/TagChip.vue'
@@ -979,8 +980,7 @@ export default {
   computed: {
     ICONS() { return ICONS },
     isDesktopShell() {
-      return typeof window !== 'undefined' && !!(window.checkbaDesktop && window.checkbaDesktop.fs
-        && window.checkbaDesktop.fs.showItemInFolder)
+      return !!(host.fs && host.fs.showItemInFolder)
     },
     sortLabel() {
       const map = { name: '名称', date: '修改时间', type: '类型' }

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -78,10 +78,12 @@
 // by the project-overview keep-alive pool as the product inline document editor
 // （原 ⌘⇧O 实验覆盖层与探针工具栏已移除）.
 
-import { createWebviewEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
+import { webviewTransport, iframeTransport } from '@/composables/useZetaOfficeWebview.js'
+import { createRelayExecutor } from '@/composables/zetaOfficeRelay.js'
 import ReviewPanel from '@/components/ReviewPanel.vue'
 import { getFileDownloadUrl, getFileUploadUrl } from '@/services/api.js'
 import { getAuthHeaders, getCurrentUser } from '@/utils/auth.js'
+import { host } from '@/services/host.js'
 
 let seq = 0
 
@@ -172,9 +174,9 @@ export default {
   },
   async mounted() {
     try {
-      const api = typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.zetaoffice
+      const api = host.zetaoffice
       if (!api || typeof api.getEditor !== 'function') {
-        this.statusText = '仅桌面版可用'
+        this.statusText = '当前环境不支持文档编辑'
         return
       }
       // Prefetch the document bytes IN PARALLEL with the LOWA boot — the fetch
@@ -183,8 +185,9 @@ export default {
       // whole download to the perceived open time.
       if (this.file) this.prefetchBytes()
       this.startBootTrickle()
-      const info = await api.getEditor() // { url, preload, partition }
-      this.mountWebview(info)
+      // { kind:'webview', url, preload, partition } | { kind:'iframe', url }
+      const info = await api.getEditor()
+      this.mountEditor(info)
     } catch (e) {
       this.statusText = '初始化失败'
       this.appendLog('init failed: ' + (e && e.message ? e.message : e))
@@ -201,6 +204,10 @@ export default {
     // closed or switched. The executor ref lets the host ignore stale closes.
     try { this.$emit('close', this.executor) } catch (e) { /* ignore */ }
     try { if (this.executor && typeof this.executor.dispose === 'function') this.executor.dispose() } catch (e) { /* ignore */ }
+    // iframe 传输的订阅挂在 window 上，不随元素移除而消失——必须显式退订，
+    // 否则关一个文档漏一个监听器，且已销毁实例的 onDocModified 还会被触发。
+    try { if (this._eventUnsub) this._eventUnsub() } catch (e) { /* ignore */ }
+    this._eventUnsub = null
     try { if (this.webviewEl && this.webviewEl.remove) this.webviewEl.remove() } catch (e) { /* ignore */ }
     this.webviewEl = null
     this.executor = null
@@ -238,49 +245,80 @@ export default {
       console.log('[libre-editor]', m)
       this.log = (this.log + m + '\n').split('\n').slice(-200).join('\n')
     },
-    mountWebview(info) {
-      const host = document.getElementById(this.hostId)
-      if (!host) { this.appendLog('host element missing'); return }
+    // 按宿主给出的容器类型挂编辑器：桌面壳是 Electron <webview>（隔离分区 +
+    // preload），Web 服务器版是同源 <iframe>。两者之外的一切——relay 协议、
+    // executor 契约、worker、自动保存链路——完全共用。
+    mountEditor(info) {
+      const mountEl = document.getElementById(this.hostId)
+      if (!mountEl) { this.appendLog('host element missing'); return }
+      const el = info.kind === 'iframe' ? this.createIframe(info) : this.createWebview(info)
+      el.style.width = '100%'
+      el.style.height = '100%'
+      el.style.border = '0'
+      mountEl.appendChild(el)
+      this.webviewEl = el
+    },
+    createWebview(info) {
       const wv = document.createElement('webview')
       wv.setAttribute('partition', info.partition)
       if (info.preload) wv.setAttribute('preload', info.preload)
       // contextIsolation ON (the preload uses contextBridge), nodeIntegration OFF.
       wv.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no')
-      wv.style.width = '100%'
-      wv.style.height = '100%'
-      wv.style.border = '0'
-      wv.addEventListener('dom-ready', () => this.onDomReady(wv))
-      // (#79) document hyperlink clicks: the editor page forwards LO's
-      // window.open over lo-relay as {type:'open-url'} — surface it to the host
-      // (project-overview routes checkba:// internal links / http(s) tabs).
-      wv.addEventListener('ipc-message', (e) => {
-        if (e.channel !== 'lo-relay') return
-        const msg = e.args && e.args[0]
-        if (!msg || msg.__lo !== 'lo-relay') return
-        if (msg.type === 'open-url' && msg.url) {
-          this.$emit('open-url', String(msg.url))
-        } else if (msg.type === 'modified') {
-          // Worker modify signal (throttled in editor-main.js) → autosave.
-          this.onDocModified()
-        } else if (msg.type === 'boot-log') {
-          // 引擎启动里程碑 → 加载进度面板推进阶段
-          this.onBootLog(String(msg.msg || ''))
-        }
+      const transport = webviewTransport(wv)
+      // 事件订阅必须在建元素时就挂上，绝不能推迟到 dom-ready：boot-log 里程碑
+      // 从引擎启动第一刻就在发，modified 是自动保存的唯一触发信号——晚挂一步
+      // 就会丢掉开头那些消息（丢 modified = 用户的编辑不落盘）。
+      this.subscribeHostEvents(transport)
+      // dom-ready 只说明 webview 渲染进程起来了；命令通道在此接（此前 send 无处可去）。
+      wv.addEventListener('dom-ready', () => {
+        if (this.executor) return // dom-ready 可能因页内导航重复触发
+        this.wireExecutor(transport, 'webview dom-ready')
       })
       wv.addEventListener('did-fail-load', (e) => this.appendLog('did-fail-load: ' + (e.errorDescription || e.errorCode)))
       wv.addEventListener('console-message', (e) => { if (e.level >= 2) this.appendLog('[webview] ' + e.message) })
       wv.setAttribute('src', info.url)
-      host.appendChild(wv)
-      this.webviewEl = wv
+      return wv
     },
-    onDomReady(wv) {
-      if (this.executor) return // dom-ready can fire again on in-page navigation
+    createIframe(info) {
+      const fr = document.createElement('iframe')
+      // 同源 iframe：LOWA 要 SharedArrayBuffer，跨源隔离由站点级 COOP/COEP 提供
+      // （deploy/web/nginx.conf.example），不是靠 iframe 属性。这里不能加 sandbox
+      // ——沙箱会掐掉 SharedArrayBuffer 与 Worker，引擎起不来。
+      fr.setAttribute('allow', 'clipboard-read; clipboard-write')
+      // <iframe> 没有 dom-ready；订阅的是 window 的 message 事件，建元素时就能
+      // 全部挂上（比 webview 更早更稳），命令通道也不必等。
+      const transport = iframeTransport(fr)
+      this.subscribeHostEvents(transport)
+      this.wireExecutor(transport, 'iframe mounted')
+      fr.addEventListener('error', () => this.appendLog('iframe load error: ' + info.url))
+      fr.src = info.url
+      return fr
+    },
+    // 事件通道：与命令共用同一个传输，另挂一个订阅者。
+    // (#79) 文档超链接点击由页面侧转成 {type:'open-url'}；modified 驱动自动保存；
+    // boot-log 推进加载进度面板。
+    subscribeHostEvents(transport) {
+      this._eventUnsub = transport.subscribe((msg) => {
+        if (!msg || msg.__lo !== 'lo-relay') return
+        if (msg.type === 'open-url' && msg.url) {
+          this.$emit('open-url', String(msg.url))
+        } else if (msg.type === 'modified') {
+          this.onDocModified()
+        } else if (msg.type === 'boot-log') {
+          this.onBootLog(String(msg.msg || ''))
+        }
+      })
+    },
+    // 命令通道：把 {send, subscribe} 传输接成 executor。两种容器共用。
+    wireExecutor(transport, whence) {
       try {
-        // dom-ready means the webview's renderer is up — NOT that the office is
-        // booted. We wait for the endpoint-ready handshake (onReady) before
-        // marking ready / pushing the document, so load_document can't be dropped
-        // pre-boot.
-        this.executor = createWebviewEditorExecutor(wv, { onReady: () => this.onEndpointReady() })
+        // onReady 握手到达前不推 load_document，否则会被丢（页面侧 serveExecutor
+        // 还没订阅、office 也没 boot）。
+        this.executor = createRelayExecutor({
+          send: transport.send,
+          subscribe: transport.subscribe,
+          onReady: () => this.onEndpointReady(),
+        })
         // 命令繁忙跟踪：AI 命令与用户输入都走这同一个 executor。autoSave 据此
         // 避开活跃期（export_document 会冻结 office 线程上的 Qt 事件循环）。
         this._cmdBusy = 0
@@ -294,7 +332,7 @@ export default {
           finally { this._cmdBusy--; this._lastCmdAt = Date.now() }
         }
         this.statusText = this.file ? '加载文档中…' : '启动中…'
-        this.appendLog('webview dom-ready — executor wired, awaiting office endpoint')
+        this.appendLog(whence + ' — executor wired, awaiting office endpoint')
       } catch (e) {
         this.appendLog('executor wiring failed: ' + (e && e.message ? e.message : e))
       }

--- a/frontend/src/components/ProjectFavoritesPanel.vue
+++ b/frontend/src/components/ProjectFavoritesPanel.vue
@@ -66,6 +66,7 @@
 <script>
 import { getProjectFavorites, deleteFavorite, getFavoriteImageUrl } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
+import { isDesktopHost } from '@/services/host.js'
 
 export default {
 
@@ -131,7 +132,7 @@ export default {
       // #ifdef H5
       // 桌面端（Electron，同为 H5 构建）：window.open 会被主进程拦截后丢弃，
       // 必须走 emit 让工作区开网页 tab
-      if (typeof window !== 'undefined' && window.checkbaDesktop) {
+      if (isDesktopHost()) {
         this.$emit('open-url', url)
         return
       }

--- a/frontend/src/components/version/VersionCompareTab.vue
+++ b/frontend/src/components/version/VersionCompareTab.vue
@@ -29,8 +29,9 @@
 </template>
 
 <script>
-import { createWebviewEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
+import { createWebviewEditorExecutor, createIframeEditorExecutor } from '@/composables/useZetaOfficeWebview.js'
 import { fetchVersionFileBytes } from '@/services/api.js'
+import { host } from '@/services/host.js'
 
 let seq = 0
 
@@ -52,9 +53,9 @@ export default {
   },
   async mounted() {
     try {
-      const api = typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.zetaoffice
+      const api = host.zetaoffice
       if (!api || typeof api.getEditor !== 'function') {
-        this.statusText = '版本对比仅桌面版可用'
+        this.statusText = '当前环境不支持版本对比'
         return
       }
       const spec = this.compareSpec
@@ -68,8 +69,9 @@ export default {
         fetchVersionFileBytes(spec.projectId, spec.newRef, spec.path),
         fetchVersionFileBytes(spec.projectId, spec.oldRef, spec.path),
       ]).catch((e) => { bytesError = e || new Error('读取版本内容失败'); return null })
-      const info = await api.getEditor() // { url, preload, partition }
-      await this.mountWebview(info) // resolves once 引擎端点就绪（onReady 握手），此前不发命令
+      // { kind:'webview', url, preload, partition } | { kind:'iframe', url }
+      const info = await api.getEditor()
+      await this.mountEditor(info) // resolves once 引擎端点就绪（onReady 握手），此前不发命令
       const bytes = await bytesPromise
       if (bytesError) throw bytesError
       const [newBytes, oldBytes] = bytes || []
@@ -107,42 +109,59 @@ export default {
     // dom-ready 只说明 webview 渲染进程起来了，onReady 才说明 office 端点起来、
     // 命令不会被丢——真实签名见 useZetaOfficeWebview.js:54 起
     // （createWebviewEditorExecutor(el, {onReady}) ，没有 whenReady()）。
-    mountWebview(info) {
+    mountEditor(info) {
       return new Promise((resolve, reject) => {
-        const host = document.getElementById(this.hostId)
-        if (!host) { reject(new Error('host missing')); return }
+        const mountEl = document.getElementById(this.hostId)
+        if (!mountEl) { reject(new Error('host missing')); return }
         // 引擎启动超时：150秒（WASM 编译 + 排版引擎约 90秒，留余量）。
         // onReady / did-fail-load 先到时清除，防止引擎挂死时 Promise 永不 settle。
         this._bootTimeout = setTimeout(() => {
           reject(new Error('对比准备超时，请关闭后重试'))
         }, 150000)
-        const wv = document.createElement('webview')
-        wv.setAttribute('partition', info.partition)
-        if (info.preload) wv.setAttribute('preload', info.preload)
-        wv.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no')
-        wv.style.width = '100%'; wv.style.height = '100%'; wv.style.border = '0'
-        wv.addEventListener('dom-ready', () => {
-          if (this.executor) return // dom-ready 可能因页内导航重复触发
+        const onReady = () => {
+          clearTimeout(this._bootTimeout)
+          resolve()
+        }
+        let el
+        if (info.kind === 'iframe') {
+          // Web 服务器版：同源 iframe，跨源隔离靠站点级 COOP/COEP（不能加 sandbox）。
+          el = document.createElement('iframe')
           try {
-            // 只读宿主：不订阅 lo-relay 的 modified 信号（没有自动保存这回事）。
-            this.executor = createWebviewEditorExecutor(wv, {
-              onReady: () => {
-                clearTimeout(this._bootTimeout)
-                resolve()
-              }
-            })
+            // 只读宿主：不订阅 modified（没有自动保存这回事）。
+            this.executor = createIframeEditorExecutor(el, { onReady })
           } catch (e) {
             clearTimeout(this._bootTimeout)
             reject(e)
+            return
           }
-        })
-        wv.addEventListener('did-fail-load', (e) => {
-          clearTimeout(this._bootTimeout)
-          reject(new Error('did-fail-load: ' + (e.errorDescription || e.errorCode)))
-        })
-        wv.src = info.url
-        host.appendChild(wv)
-        this.webviewEl = wv
+          el.addEventListener('error', () => {
+            clearTimeout(this._bootTimeout)
+            reject(new Error('编辑器页面加载失败'))
+          })
+          el.src = info.url
+        } else {
+          el = document.createElement('webview')
+          el.setAttribute('partition', info.partition)
+          if (info.preload) el.setAttribute('preload', info.preload)
+          el.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no')
+          el.addEventListener('dom-ready', () => {
+            if (this.executor) return // dom-ready 可能因页内导航重复触发
+            try {
+              this.executor = createWebviewEditorExecutor(el, { onReady })
+            } catch (e) {
+              clearTimeout(this._bootTimeout)
+              reject(e)
+            }
+          })
+          el.addEventListener('did-fail-load', (e) => {
+            clearTimeout(this._bootTimeout)
+            reject(new Error('did-fail-load: ' + (e.errorDescription || e.errorCode)))
+          })
+          el.src = info.url
+        }
+        el.style.width = '100%'; el.style.height = '100%'; el.style.border = '0'
+        mountEl.appendChild(el)
+        this.webviewEl = el
       })
     },
   },

--- a/frontend/src/composables/useZetaOfficeWebview.js
+++ b/frontend/src/composables/useZetaOfficeWebview.js
@@ -19,7 +19,11 @@
 // the host as a 'ipc-message' event with {channel, args}. The page side needs a
 // preload exposing ipcRenderer (nodeIntegrationInSubFrames / a preload script).
 //
-// DORMANT until the host renders the <webview> and wires the executor.
+// 两种宿主容器，同一套 relay：
+// - Electron <webview>（桌面壳）：webviewTransport，走 webview IPC；
+// - <iframe>（Web 服务器版 / 鸿蒙浏览器，docs/HARMONYOS_PLAN.md Phase A）：
+//   iframeTransport，走 postMessage。
+// 差异只在这两个 {send, subscribe} 适配器里；relay、executor、worker 一字不改。
 
 import { createRelayExecutor } from './zetaOfficeRelay.js'
 
@@ -53,5 +57,48 @@ export function webviewTransport(webviewEl) {
  */
 export function createWebviewEditorExecutor(webviewEl, opts = {}) {
   const transport = webviewTransport(webviewEl)
+  return createRelayExecutor({ send: transport.send, subscribe: transport.subscribe, timeoutMs: opts.timeoutMs, onReady: opts.onReady })
+}
+
+/**
+ * Build a {send, subscribe} transport over an <iframe> (Web 服务器版).
+ *
+ * 同源部署是硬前提（deploy/web/nginx.conf.example：站点与 /zetaoffice/ 同一 origin，
+ * 全站 COOP/COEP）——所以 targetOrigin 收成 location.origin，收信也只认这个 origin，
+ * 且必须来自这个 iframe 自己的 contentWindow。用 '*' 会把编辑器指令广播给任何
+ * 恰好被嵌进来的第三方文档，同时也会让任何页面能伪造 lo-relay 结果。
+ *
+ * 与 webviewTransport 的差别仅此一处；relay 协议完全相同。
+ *
+ * @param {HTMLIFrameElement} iframeEl
+ */
+export function iframeTransport(iframeEl) {
+  const origin = (typeof window !== 'undefined' && window.location) ? window.location.origin : ''
+  return {
+    send: (m) => {
+      const w = iframeEl.contentWindow
+      if (w) w.postMessage(m, origin)
+    },
+    subscribe: (h) => {
+      const f = (e) => {
+        if (e.source !== iframeEl.contentWindow) return
+        if (e.origin !== origin) return
+        h(e.data)
+      }
+      window.addEventListener('message', f)
+      return () => window.removeEventListener('message', f)
+    },
+  }
+}
+
+/**
+ * Host-side LibreOffice executor driving the editor inside an <iframe>.
+ * 与 createWebviewEditorExecutor 同契约，供 Web 态使用。
+ *
+ * @param {HTMLIFrameElement} iframeEl
+ * @param {{timeoutMs?:number, onReady?:()=>void}} [opts]
+ */
+export function createIframeEditorExecutor(iframeEl, opts = {}) {
+  const transport = iframeTransport(iframeEl)
   return createRelayExecutor({ send: transport.send, subscribe: transport.subscribe, timeoutMs: opts.timeoutMs, onReady: opts.onReady })
 }

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -1095,6 +1095,7 @@ import {
 import { getCurrentUser } from '@/utils/auth.js'
 import { getLastProjectId } from '@/utils/recentProjects.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
+import { host } from '@/services/host.js'
 import { refreshEntitlements, isEnabled, FEATURES } from '@/composables/useEntitlement.js'
 import UnlockHint from '@/components/UnlockHint.vue'
 
@@ -1202,7 +1203,7 @@ export default {
   },
   computed: {
     isDesktop() {
-      return typeof window !== 'undefined' && !!(window.checkbaDesktop && window.checkbaDesktop.model)
+      return !!(host.model)
     },
     stageUnlimited() {
       return isEnabled(FEATURES.STAGE_UNLIMITED)
@@ -1295,7 +1296,7 @@ export default {
       this.loadPlatformAiAvailability()
       this.loadComponents()
       // 订阅主进程模型下载进度；onUnload 退订
-      this._modelProgressUnsub = window.checkbaDesktop.model.onProgress((evt) => {
+      this._modelProgressUnsub = host.model.onProgress((evt) => {
         const comp = this.components.find((c) => c.id === evt.id)
         if (!comp) return
         if (evt.phase === 'progress') {
@@ -1308,8 +1309,8 @@ export default {
       })
       // 软件更新：拉初始状态 + 订阅主进程推送（快照全量携带，直接覆盖本地态）
       this.loadUpdateStatus()
-      if (window.checkbaDesktop.update) {
-        this._updateEventUnsub = window.checkbaDesktop.update.onEvent((evt) => {
+      if (host.update) {
+        this._updateEventUnsub = host.update.onEvent((evt) => {
           if (evt && evt.state) this.update = { ...this.update, ...evt.state }
         })
       }
@@ -1379,9 +1380,9 @@ export default {
       }
     },
     async loadUpdateStatus() {
-      if (!this.isDesktop || !window.checkbaDesktop.update) return
+      if (!this.isDesktop || !host.update) return
       try {
-        const s = await window.checkbaDesktop.update.status()
+        const s = await host.update.status()
         if (s) this.update = { ...this.update, ...s }
       } catch (e) {
         console.error('loadUpdateStatus failed', e)
@@ -1389,7 +1390,7 @@ export default {
     },
     async handleUpdateCheck() {
       try {
-        const s = await window.checkbaDesktop.update.check()
+        const s = await host.update.check()
         if (s) this.update = { ...this.update, ...s }
       } catch (e) {
         uni.showToast({ title: '检查更新失败', icon: 'none' })
@@ -1400,13 +1401,13 @@ export default {
         title: '重启应用',
         content: `将重启 AI Workdeck 以完成更新到 ${this.update.available ? this.update.available.version : '新版本'}。未保存的编辑会先自动保存。是否继续？`,
         success: (r) => {
-          if (r.confirm) window.checkbaDesktop.update.restart()
+          if (r.confirm) host.update.restart()
         },
       })
     },
     handleUpdateOpenDownload() {
       const page = (this.update.majorAvailable && this.update.majorAvailable.page) || 'https://www.aiworkdeck.com'
-      window.checkbaDesktop.shell.openExternal(page)
+      host.shell.openExternal(page)
     },
     formatUpdateTime(iso) {
       try {
@@ -1420,7 +1421,7 @@ export default {
     async loadComponents() {
       if (!this.isDesktop) return
       try {
-        const res = await window.checkbaDesktop.model.status()
+        const res = await host.model.status()
         this.components = (res && res.components ? res.components : []).map((c) => ({ percent: null, ...c }))
       } catch (e) {
         console.error('loadComponents failed', e)
@@ -1433,7 +1434,7 @@ export default {
         success: async (r) => {
           if (!r.confirm) return
           try {
-            await window.checkbaDesktop.model.download(comp.id)
+            await host.model.download(comp.id)
             comp.state = 'downloading'
             comp.percent = 0
           } catch (e) {
@@ -1444,7 +1445,7 @@ export default {
     },
     async handleComponentCancel(comp) {
       try {
-        await window.checkbaDesktop.model.cancel(comp.id)
+        await host.model.cancel(comp.id)
       } finally {
         this.loadComponents()
       }
@@ -1456,7 +1457,7 @@ export default {
         success: async (r) => {
           if (!r.confirm) return
           try {
-            await window.checkbaDesktop.model.remove(comp.id)
+            await host.model.remove(comp.id)
           } finally {
             this.loadComponents()
           }
@@ -1468,7 +1469,7 @@ export default {
       if (!comp.serviceName) return
       uni.showLoading({ title: '启动中...' })
       try {
-        const res = await window.checkbaDesktop.services.ensure(comp.serviceName)
+        const res = await host.services.ensure(comp.serviceName)
         if (!res || !res.ok) {
           uni.showToast({ title: '启动失败：' + ((res && res.message) || '未知错误'), icon: 'none' })
         }
@@ -1838,8 +1839,8 @@ export default {
       }
     },
     async onChangeStorageLocation() {
-      const desktop = typeof window !== 'undefined' ? window.checkbaDesktop : null
-      if (!desktop || !desktop.fs || typeof desktop.fs.showOpenDialog !== 'function') {
+      const desktop = host.fs && typeof host.fs.showOpenDialog === 'function' ? host : null
+      if (!desktop) {
         uni.showToast({ title: '仅桌面版支持选择目录', icon: 'none' })
         return
       }

--- a/frontend/src/pages/launch/launch.vue
+++ b/frontend/src/pages/launch/launch.vue
@@ -23,6 +23,7 @@ import {
   getMyProjects,
 } from '@/services/api.js'
 import { syncRecentToMenu } from '@/utils/recentProjects.js'
+import { isDesktopHost } from '@/services/host.js'
 
 export default {
   name: 'LaunchPage',
@@ -38,7 +39,7 @@ export default {
   },
   methods: {
     isDesktop() {
-      return typeof window !== 'undefined' && !!window.checkbaDesktop
+      return isDesktopHost()
     },
     async boot() {
       this.failed = false

--- a/frontend/src/pages/newproject/index.vue
+++ b/frontend/src/pages/newproject/index.vue
@@ -133,6 +133,7 @@
 import { createProject } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
 import { openFolderFlow, openFileFlow, createFolderFlow } from '@/utils/ideOpen.js'
+import { host } from '@/services/host.js'
 
 export default {
   data() {
@@ -162,8 +163,8 @@ export default {
   },
   computed: {
     isDesktop() {
-      return typeof window !== 'undefined' && !!(window.checkbaDesktop && window.checkbaDesktop.fs
-        && window.checkbaDesktop.fs.showOpenDialog)
+      return !!(host.fs
+        && host.fs.showOpenDialog)
     },
     namingNameValid() {
       const n = (this.namingName || '').trim()
@@ -184,7 +185,7 @@ export default {
 
     async onCreateFolder() {
       if (this.busy) return
-      const res = await window.checkbaDesktop.fs.showOpenDialog({
+      const res = await host.fs.showOpenDialog({
         title: '选择存放位置',
         buttonLabel: '选择此处',
         properties: ['openDirectory', 'createDirectory'],

--- a/frontend/src/pages/project-overview/clipboardBridge.js
+++ b/frontend/src/pages/project-overview/clipboardBridge.js
@@ -7,6 +7,7 @@
 
 import { saveClipboardText, saveClipboardFile } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
+import { host } from '@/services/host.js'
 
 export const clipboardBridgeMethods = {
     bindClipboardListener() {
@@ -62,9 +63,9 @@ export const clipboardBridgeMethods = {
              try {
                // Must verify API exists (Electron only)
                 // eslint-disable-next-line
-               if (window.checkbaDesktop && window.checkbaDesktop.utils && window.checkbaDesktop.utils.readFile) {
+               if (host.utils && host.utils.readFile) {
                   // eslint-disable-next-line
-                  const resp = await window.checkbaDesktop.utils.readFile(payload.filePath)
+                  const resp = await host.utils.readFile(payload.filePath)
                   if (resp && resp.ok && resp.data) {
                      // resp.data is usually Uint8Array or serialized Buffer
                      const u8arr = new Uint8Array(resp.data)
@@ -129,10 +130,10 @@ export const clipboardBridgeMethods = {
       this._recordClipboardOnce = recordClipboardOnce
 
       // Desktop：由 Electron 主进程捕获 copy/cut，并直接推送剪贴板文本（更稳定，不依赖浏览器权限）
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.clipboard) {
+      if (this.isDesktopApp && host.clipboard) {
         try {
           if (!this._desktopClipboardUnsub) {
-            this._desktopClipboardUnsub = window.checkbaDesktop.clipboard.onCopied(async (payload) => {
+            this._desktopClipboardUnsub = host.clipboard.onCopied(async (payload) => {
               try {
                 // Pass full payload object to support IMAGE/FILE
                 await recordClipboardOnce(payload, 'desktop')

--- a/frontend/src/pages/project-overview/librePool.js
+++ b/frontend/src/pages/project-overview/librePool.js
@@ -2,6 +2,8 @@
 // 模式说明见 .claude/agents/sidebar-shell.md 与 PR#151/#159。
 // 经展开进组件 methods（纯搬移，Phase 1 外置），`this` 即 project-overview 页面实例。
 
+import { isDesktopHost } from '@/services/host.js'
+
 // 内嵌 LibreOffice 实例保活上限（每个 LOWA 实例数百 MB 内存）。超过后按
 // LRU 淘汰最久未激活的实例——淘汰前自动保存（见 evictLibreInstance）。
 const LIBRE_KEEPALIVE_MAX = 3
@@ -69,8 +71,9 @@ export const librePoolMethods = {
     initLibreSpare() {
         // 页面栈多实例守卫：只有活跃 overview 实例建备胎（PR#148/#151 模式）。
         if (typeof this.isActiveOverviewInstance === 'function' && !this.isActiveOverviewInstance()) return
-        const api = typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.zetaoffice
-        if (!api) return // 非桌面版没有 LOWA
+        // 备胎是常驻的空白 LOWA 实例（数百 MB 内存），只在桌面壳里预热：
+        // Web 态没有保活语境（页面刷新即丢），不值这个内存。
+        if (!isDesktopHost()) return
         if (this.libreSpares.some(sp => !sp.file)) return // 已有空闲备胎
         this._libreSpareSeq = (this._libreSpareSeq || 0) + 1
         this.libreSpares.push({ key: this._libreSpareSeq, file: null })

--- a/frontend/src/pages/project-overview/ocrActions.js
+++ b/frontend/src/pages/project-overview/ocrActions.js
@@ -6,6 +6,7 @@
 
 import { ocrRecognize, createProjectFavorite, getProjectFiles, createFile, getApiBaseUrl } from '@/services/api.js'
 import { getSessionId } from '@/utils/auth.js'
+import { host } from '@/services/host.js'
 
 export const ocrActionMethods = {
     async ensureOcrFrozenFrame() {
@@ -42,14 +43,14 @@ export const ocrActionMethods = {
     async ocrRefreshFrame() {
       // 抓一帧作为底图，并绘制到 overlay canvas（用户框选基于该底图）
       // #ifdef H5
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.ocr) {
+      if (this.isDesktopApp && host.ocr) {
         // 桌面端：抓“当前激活网页 Tab 的 BrowserView”（包含网页内容；不需要屏幕录制权限）
         const activeWebTab = this.getActiveWebTab()
         const viewId = activeWebTab && activeWebTab.id ? String(activeWebTab.id) : ''
 
         // 获取 BrowserView 的 bounds，用于把截图图像铺到网页区域，确保框选坐标正确
         try {
-          const api = window.checkbaDesktop && window.checkbaDesktop.browser
+          const api = host.browser
           const b = api && viewId ? await api.getBounds({ id: viewId }) : null
           if (b && b.ok && b.bounds) {
             this.ocrHostRect = {
@@ -67,8 +68,8 @@ export const ocrActionMethods = {
 
         // 若当前没有网页 tab，则回退抓当前窗口（此时 hostRect 为空，图片会铺满全屏）
         const resp = viewId
-          ? await window.checkbaDesktop.ocr.captureScreen({ viewId })
-          : await window.checkbaDesktop.ocr.captureScreen({ mode: 'window' })
+          ? await host.ocr.captureScreen({ viewId })
+          : await host.ocr.captureScreen({ mode: 'window' })
         if (!resp || resp.ok !== true || !resp.dataUrl) {
           const m = resp && resp.message ? String(resp.message) : ''
           throw new Error(m || '截图失败')
@@ -516,8 +517,8 @@ export const ocrActionMethods = {
         try {
           const active = this.focusedPane === 'right' ? this.activeFileRight : this.activeFileLeft
           const viewId = active && active.tabType === 'web' ? active.id : ''
-          if (this.isDesktopApp && viewId && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.getSnapshot) {
-            const snap = await window.checkbaDesktop.browser.getSnapshot({ id: viewId })
+          if (this.isDesktopApp && viewId && host.browser && host.browser.getSnapshot) {
+            const snap = await host.browser.getSnapshot({ id: viewId })
             if (snap && snap.ok) {
               metaObj.sourceUrl = snap.url || metaObj.sourceUrl
               metaObj.title = snap.title || ''

--- a/frontend/src/pages/project-overview/ocrCapture.js
+++ b/frontend/src/pages/project-overview/ocrCapture.js
@@ -5,13 +5,15 @@
 // 经展开进组件 methods（纯搬移，Phase 3c 外置），`this` 即 project-overview 页面实例。
 
 
+import { host } from '@/services/host.js'
+
 export const ocrCaptureMethods = {
     async applyDesktopOcrSelection(payload) {
       if (!payload || !payload.dataUrl || !payload.selection) return
       // 选区完成后再隐藏 BrowserView：此时用户不需要看真实网页了
       try {
-        if (window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-          await window.checkbaDesktop.browser.setViewsVisible({ visible: false })
+        if (host.browser && host.browser.setViewsVisible) {
+          await host.browser.setViewsVisible({ visible: false })
         }
       } catch (e) {
         // ignore
@@ -187,18 +189,18 @@ export const ocrCaptureMethods = {
         this.ocrSourceUrl = active && active.tabType === 'web' ? (active.url || '') : ''
 
         // Desktop：直接抓屏做底图，不需要浏览器授权
-        if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.ocr) {
+        if (this.isDesktopApp && host.ocr) {
           // 桌面端（方案 B）：使用主进程 OverlayWindow 进行框选（选区期间不隐藏 BrowserView）
           const activeWebTab = this.getActiveWebTab()
           const viewId = activeWebTab && activeWebTab.id ? String(activeWebTab.id) : ''
-          if (!window.checkbaDesktop.ocr.startSelection) {
+          if (!host.ocr.startSelection) {
             uni.showToast({ title: '桌面端截图能力不可用', icon: 'none' })
             return
           }
           // 全局截图：无网页 tab 时走 window 模式（两边都是文档也能截图）
           const resp = viewId
-            ? await window.checkbaDesktop.ocr.startSelection({ viewId })
-            : await window.checkbaDesktop.ocr.startSelection({ mode: 'window' })
+            ? await host.ocr.startSelection({ viewId })
+            : await host.ocr.startSelection({ mode: 'window' })
           if (!resp || resp.ok !== true) {
             if (resp && resp.cancelled) return
             uni.showToast({ title: (resp && resp.message) ? String(resp.message) : '截图失败', icon: 'none' })

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1398,6 +1398,7 @@
 
 <script>
 import LibreOfficeEditor from '@/components/LibreOfficeEditor.vue'
+import { host, isDesktopHost } from '@/services/host.js'
 import BrowserPane from '@/components/BrowserPane.vue'
 import FileTree from '@/components/FileTree.vue'
 import QuickOpenPanel from '@/components/QuickOpenPanel.vue'
@@ -2024,7 +2025,7 @@ export default {
     ,
     isDesktopApp() {
       try {
-        return typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.ocr
+        return host.ocr
       } catch (e) {
         return false
       }
@@ -2243,8 +2244,8 @@ export default {
     // Desktop：仅在工作区页面展示 BrowserView（否则会“飘”到其它页面）
     // 注意尊重弹窗状态：若返回页面时仍有全屏弹窗打开，保持隐藏
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-        window.checkbaDesktop.browser.setViewsVisible({ visible: !this.desktopOverlayActive }).catch(() => {})
+      if (this.isDesktopApp && host.browser && host.browser.setViewsVisible) {
+        host.browser.setViewsVisible({ visible: !this.desktopOverlayActive }).catch(() => {})
       }
     } catch (e) {
       // ignore
@@ -2255,8 +2256,8 @@ export default {
 
     // Desktop：离开工作区页面（如去个人中心）必须隐藏 BrowserView
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-        window.checkbaDesktop.browser.setViewsVisible({ visible: false }).catch(() => {})
+      if (this.isDesktopApp && host.browser && host.browser.setViewsVisible) {
+        host.browser.setViewsVisible({ visible: false }).catch(() => {})
       }
     } catch (e) {
       // ignore
@@ -2268,8 +2269,8 @@ export default {
 
     // 兜底：页面销毁也隐藏
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-        window.checkbaDesktop.browser.setViewsVisible({ visible: false }).catch(() => {})
+      if (this.isDesktopApp && host.browser && host.browser.setViewsVisible) {
+        host.browser.setViewsVisible({ visible: false }).catch(() => {})
       }
     } catch (e) {
       // ignore
@@ -2329,9 +2330,9 @@ export default {
     }, 15000)
     // Desktop：网页选中“加入网核收藏”（右键菜单触发）
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.onWebMark) {
+      if (this.isDesktopApp && host.browser && host.browser.onWebMark) {
         if (!this._desktopWebMarkUnsub) {
-          this._desktopWebMarkUnsub = window.checkbaDesktop.browser.onWebMark(async (payload) => {
+          this._desktopWebMarkUnsub = host.browser.onWebMark(async (payload) => {
             // 页面栈里每个实例都订阅了本事件：只让活跃实例入库，否则一次“加入网核收藏”
             // 会按实例数重复 POST，且旧实例还会把收藏写进它自己的 projectId
             if (!this.isActiveOverviewInstance()) return
@@ -2369,9 +2370,9 @@ export default {
     // checkba:browser-open-new-tab { id: 'renderer' }，此前无人消费，
     // 导致桌面端"文件下载/查看/收藏开网页"等 window.open 全部静默失效。
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.onOpenNewTab) {
+      if (this.isDesktopApp && host.browser && host.browser.onOpenNewTab) {
         if (!this._desktopRendererOpenUnsub) {
-          this._desktopRendererOpenUnsub = window.checkbaDesktop.browser.onOpenNewTab((data) => {
+          this._desktopRendererOpenUnsub = host.browser.onOpenNewTab((data) => {
             if (!this.isActiveOverviewInstance()) return
             try {
               if (!data || data.id !== 'renderer' || !data.url) return
@@ -2388,16 +2389,22 @@ export default {
 
     // Manual binding removed (reverted to native modifier)
 
-    // Epic #43 Track B / #79: when the desktop app exposes the embedded editor,
-    // make it THE editor for Office documents (inline, no ⌘⇧O needed) —
-    // install-and-use, zero config.
+    // Epic #43 Track B / #79: 宿主提供内嵌编辑器时，它就是 Office 文档的默认
+    // 编辑器（内联，零配置）。桌面壳恒为真；Web 服务器版取决于 /zetaoffice/
+    // 有没有随站点部署，所以要探一次——没部署就退回原来的预览路径，而不是
+    // 挂一个永远起不来的编辑器（dev server 与只部署了 h5 的站点都属此列）。
     try {
-      this.libreOfficePreferred = !!(
-        this.isDesktopApp &&
-        window.checkbaDesktop &&
-        window.checkbaDesktop.zetaoffice &&
-        typeof window.checkbaDesktop.zetaoffice.getEditor === 'function'
-      )
+      const zo = host.zetaoffice
+      if (!zo || typeof zo.getEditor !== 'function') {
+        this.libreOfficePreferred = false
+      } else if (isDesktopHost()) {
+        // 桌面壳：引擎随包分发，同步置位——mounted 里后续逻辑与自动打开的文件
+        // 都依赖它，异步落位会让首个文档按「无编辑器」渲染。
+        this.libreOfficePreferred = true
+      } else {
+        // Web 服务器版：探一次 /zetaoffice/ 是否真部署了，回来再置位。
+        zo.isAvailable().then((ok) => { this.libreOfficePreferred = !!ok }).catch(() => {})
+      }
     } catch (e) {
       this.libreOfficePreferred = false
     }
@@ -2407,9 +2414,9 @@ export default {
 
     // Desktop：拦截 WPS 中点击 “checkba://...” 的内部链接
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.app && window.checkbaDesktop.app.onOpenInternal) {
+      if (this.isDesktopApp && host.app && host.app.onOpenInternal) {
         if (!this._desktopOpenInternalUnsub) {
-          this._desktopOpenInternalUnsub = window.checkbaDesktop.app.onOpenInternal((payload) => {
+          this._desktopOpenInternalUnsub = host.app.onOpenInternal((payload) => {
             if (!this.isActiveOverviewInstance()) return
             try {
               const raw0 = payload && payload.url ? String(payload.url) : ''
@@ -2550,9 +2557,9 @@ export default {
 
     // Desktop：截图框选失败时给用户提示（避免“松手啥也没有”）
     try {
-      if (this.isDesktopApp && window.checkbaDesktop && window.checkbaDesktop.ocr && window.checkbaDesktop.ocr.onSelectionError) {
+      if (this.isDesktopApp && host.ocr && host.ocr.onSelectionError) {
         if (!this._desktopOcrSelectionErrUnsub) {
-          this._desktopOcrSelectionErrUnsub = window.checkbaDesktop.ocr.onSelectionError((data) => {
+          this._desktopOcrSelectionErrUnsub = host.ocr.onSelectionError((data) => {
             // 只让活跃实例弹一次 toast，避免页面栈里 N 个实例连弹 N 次
             if (!this.isActiveOverviewInstance()) return
             const msg = data && data.message ? String(data.message) : '截图失败'
@@ -2572,7 +2579,7 @@ export default {
     desktopOverlayActive(open) {
       if (!this.isDesktopApp) return
       try {
-        const api = window.checkbaDesktop && window.checkbaDesktop.browser
+        const api = host.browser
         if (!api || !api.setViewsVisible) return
         api.setViewsVisible({ visible: !open }).catch(() => {})
         if (!open) {
@@ -2596,7 +2603,7 @@ export default {
     // 授权标识：桌面端查授权模式与账户连接状态
     // （已连接账户 → 「已连接账户」chip；否则 mode=trial → 「试用版」chip）
     async loadLicenseMode() {
-      if (typeof window === 'undefined' || !window.checkbaDesktop) return
+      if (!isDesktopHost()) return
       try {
         const status = await getLicenseStatus()
         this.licenseMode = (status && status.mode) || ''
@@ -2685,8 +2692,7 @@ export default {
     // 文件树右键「在访达中显示」：后端解析物理路径（localRoot 感知），桌面壳高亮
     async onRevealFile(file) {
       if (!file) return
-      const shellApi = typeof window !== 'undefined' && window.checkbaDesktop
-        && window.checkbaDesktop.fs && window.checkbaDesktop.fs.showItemInFolder
+      const shellApi = host.fs && host.fs.showItemInFolder
       if (!shellApi) return
       try {
         let path = null
@@ -2702,7 +2708,7 @@ export default {
             return
           }
         }
-        if (path) await window.checkbaDesktop.fs.showItemInFolder(path)
+        if (path) await host.fs.showItemInFolder(path)
       } catch (e) {
         uni.showToast({ title: (e && e.message) || '无法在访达中显示', icon: 'none' })
       }

--- a/frontend/src/pages/userprofile/userprofile.vue
+++ b/frontend/src/pages/userprofile/userprofile.vue
@@ -353,6 +353,7 @@
 <script>
 import { getMyProjects, deleteProject, renameProject, getCurrentUser as getCurrentUserApi, getMyFavorites, deleteFavorite, getFavoriteImageUrl, getProjectMembers, addProjectMember, removeProjectMember, getUserActivityHistory, inviteClient, uploadAvatar, getLicenseStatus, deactivateLicense } from '@/services/api.js'
 import { getProjectTypeLabel } from '@/config/projectTypes.js'
+import { host, isDesktopHost } from '@/services/host.js'
  import { getCurrentUser, isLoggedIn, getSessionId, clearSession, setSessionUser } from '@/utils/auth.js'
 import InviteMemberDialog from '@/components/InviteMemberDialog.vue'
 import CloudAcceptDialog from '@/components/CloudAcceptDialog.vue'
@@ -365,7 +366,7 @@ export default {
     ICONS() { return ICONS },
 
     isDesktop() {
-      return typeof window !== 'undefined' && !!window.checkbaDesktop
+      return isDesktopHost()
     }
 
   },
@@ -418,14 +419,14 @@ export default {
   onLoad() {
     // Desktop：个人中心页必须隐藏 BrowserView（避免工作区网页残留覆盖）
     try {
-      if (typeof window !== 'undefined' && window.checkbaDesktop && window.checkbaDesktop.browser && window.checkbaDesktop.browser.setViewsVisible) {
-        window.checkbaDesktop.browser.setViewsVisible({ visible: false }).catch(() => {})
+      if (host.browser && host.browser.setViewsVisible) {
+        host.browser.setViewsVisible({ visible: false }).catch(() => {})
       }
     } catch (e) {
       // ignore
     }
     // 检查登录状态（桌面端 local-mode 免登录，跳过该检查）
-    const isDesktopEnv = typeof window !== 'undefined' && !!window.checkbaDesktop
+    const isDesktopEnv = isDesktopHost()
     if (!isDesktopEnv) {
       const sessionId = getSessionId()
       const user = getCurrentUser()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -5,6 +5,7 @@
 
 // 导入认证工具
 import { getAuthHeaders, getSessionId, clearSession } from '@/utils/auth.js'
+import { host, isDesktopHost } from '@/services/host.js'
 
 /**
  * 功能未配置时的统一引导（#18 T7）。
@@ -101,8 +102,7 @@ export function getApiBaseUrl() {
   // 桌面壳注入的后端地址最优先：端口是主进程启动时实际分配的
   // （打包态默认 5269，冲突自动降 5369/5169），不能再靠写死的常量猜
   try {
-    const injected = typeof window !== 'undefined'
-      && window.checkbaDesktop && window.checkbaDesktop.apiBaseUrl;
+    const injected = host.apiBaseUrl;
     if (injected) {
       cachedApiBaseUrl = injected;
       console.log('[API] 使用桌面壳注入的 API 地址:', cachedApiBaseUrl);
@@ -270,7 +270,7 @@ function request(options) {
               }
 
               // 桌面端（local-mode 免登录）没有登录页可去：只提示，不打断当前页面
-              const isDesktop = typeof window !== 'undefined' && !!window.checkbaDesktop;
+              const isDesktop = isDesktopHost();
               if (isDesktop) {
                 uni.showToast({
                   title: errorMessage,

--- a/frontend/src/services/host.js
+++ b/frontend/src/services/host.js
@@ -1,0 +1,97 @@
+// host.js — 宿主能力层：前端与「壳」之间的唯一接缝。
+//
+// 前端此前直接读 window.checkbaDesktop（Electron preload 经 contextBridge 暴露），
+// 93 处散落在 18 个文件里。那等于把 Electron 焊进了业务代码：换壳（鸿蒙 Electron /
+// Tauri / WebView2）或跑纯浏览器（Web 服务器版，docs/HARMONYOS_PLAN.md Phase A）
+// 都得再挨个找一遍。本模块把这层收口——业务代码一律 import { host }，壳的差异
+// 只在这里表达。
+//
+// 语义保持不变（这是刻意的，迁移必须是机械的）：
+// - 桌面态 host 就是 window.checkbaDesktop 的门面，字段与行为逐一透传；
+// - Web 态只提供「浏览器里真能实现」的能力，其余字段缺席（undefined）。
+//   调用点原有的 `if (host.browser && ...)` 守卫因此原样成立，不需要改判断。
+//
+// 唯一被规范化的是 zetaoffice.getEditor：它现在返回带 kind 的描述符，
+// 宿主据此挂 <webview>（桌面）或 <iframe>（Web）。见 LibreOfficeEditor.vue。
+
+/** 是否运行在桌面壳里。用于「仅桌面版可用」类的能力分支。 */
+export function isDesktopHost() {
+  return !!nativeHost()
+}
+
+function nativeHost() {
+  return (typeof window !== 'undefined' && window.checkbaDesktop) || null
+}
+
+// Web 态编辑器资源路径。与 deploy/web/nginx.conf.example 的部署布局一一对应
+// （站点 root 下 zetaoffice/ 放 build:zetaoffice 产物，其中 lowa/ 是引擎）。
+// 全站 COOP/COEP 由 nginx 下发——没有跨源隔离，LOWA 的 SharedArrayBuffer 用不了，
+// 引擎会在 bootZetaOffice 的校验里明确报错，不会静默降级。
+const WEB_EDITOR_BASE = '/zetaoffice/'
+
+function webEditorDescriptor() {
+  const q = new URLSearchParams()
+  q.set('lowa', WEB_EDITOR_BASE + 'lowa/')
+  return { kind: 'iframe', url: WEB_EDITOR_BASE + 'editor.html?' + q.toString() }
+}
+
+// Web 态编辑器是否真的部署了。桌面版引擎随包走、必然存在，Web 版却取决于运维
+// 有没有把 frontend/dist/zetaoffice 放到站点下（dev server 上就没有）。
+// 不探测的话，宿主会照常挂 iframe，然后停在「正在启动文档引擎」直到超时——
+// 用户看到的是卡死而不是「这里没有编辑器」。探一次、缓存结果。
+let webEditorProbe = null
+function probeWebEditor() {
+  if (!webEditorProbe) {
+    webEditorProbe = fetch(webEditorDescriptor().url, { method: 'HEAD' })
+      .then((r) => r.ok)
+      .catch(() => false)
+  }
+  return webEditorProbe
+}
+
+// Web 态能力表：只有编辑器一项。浏览器面板/截图/剪贴板/组件下载/自动更新/
+// 本地文件对话框等都依赖 Electron 主进程，浏览器里没有对等实现——缺席比假实现
+// 诚实，调用点的守卫会把对应入口收起来。
+const WEB_CAPABILITIES = {
+  zetaoffice: {
+    isAvailable: probeWebEditor,
+    getEditor: async () => webEditorDescriptor(),
+  },
+}
+
+// 桌面态的 zetaoffice：把 getEditor 的返回值补上 kind，其余透传。
+// 按 native 对象缓存，避免每次属性访问都新建。
+let zetaCache = null
+function desktopZetaoffice(native) {
+  if (!zetaCache || zetaCache.native !== native) {
+    zetaCache = {
+      native,
+      api: {
+        isAvailable: async () => true, // 引擎随包分发，必然在
+        getEditor: async () => {
+          const info = await native.zetaoffice.getEditor() // { url, preload, partition }
+          return { kind: 'webview', ...info }
+        },
+      },
+    }
+  }
+  return zetaCache.api
+}
+
+function resolve(prop) {
+  const native = nativeHost()
+  if (!native) return WEB_CAPABILITIES[prop]
+  // zetaoffice 要条件包装：宿主未必带这一项（app-e2e 给浏览器目标注入的最小桩
+  // 只有 shell.openExternal）。无条件包一层的话，调用点的 `typeof getEditor ===
+  // 'function'` 守卫会通过，然后在 native.zetaoffice.getEditor() 上抛 TypeError——
+  // 把原本优雅的「当前环境不支持文档编辑」变成崩溃。
+  if (prop === 'zetaoffice') return native.zetaoffice ? desktopZetaoffice(native) : undefined
+  return native[prop]
+}
+
+// 惰性解析（而非模块加载时取一次快照）：与被替换掉的 `window.checkbaDesktop.X`
+// 逐次读取语义完全一致。preload 注入、测试桩注入的时机差异因此不影响任何调用点。
+export const host = new Proxy({}, {
+  get: (_t, prop) => resolve(prop),
+  has: (_t, prop) => resolve(prop) !== undefined,
+})

--- a/frontend/src/utils/externalLink.js
+++ b/frontend/src/utils/externalLink.js
@@ -1,18 +1,18 @@
+import { host } from '@/services/host.js'
+
 // 打开外部链接（官网、GitHub 等站外页面）的统一出口。
-// - 桌面端（Electron）：走系统浏览器，checkbaDesktop.shell.openExternal（preload 暴露，
+// - 桌面端（Electron）：走系统浏览器，host.shell.openExternal（preload 暴露，
 //   主进程 checkba:shell-open-external 处理）。注意不能依赖 window.open 降级：
 //   主进程 setWindowOpenHandler 会把 http(s) 转成 checkba:browser-open-new-tab 事件，
 //   而该事件只有 project-overview 页消费，解锁页等场景会静默失效。
-// - 浏览器端：window.open 新标签页。
+// - 浏览器端：host.shell 缺席，走 window.open 新标签页。
 export function openExternalUrl(url) {
   if (!url || !/^https?:\/\//i.test(url)) return
   try {
-    if (typeof window !== 'undefined' && window.checkbaDesktop) {
-      const shell = window.checkbaDesktop.shell
-      if (shell && typeof shell.openExternal === 'function') {
-        shell.openExternal(url)
-        return
-      }
+    const shell = host.shell
+    if (shell && typeof shell.openExternal === 'function') {
+      shell.openExternal(url)
+      return
     }
     window.open(url, '_blank')
   } catch (e) {

--- a/frontend/src/utils/ideOpen.js
+++ b/frontend/src/utils/ideOpen.js
@@ -2,14 +2,10 @@
 // newproject 页与应用菜单（App.vue 的 menu-action 处理器）共用，两处只差 busy UI。
 
 import { openLocalProject } from '@/services/api.js'
+import { host } from '@/services/host.js'
 
 export function desktopFsApi() {
-  return (typeof window !== 'undefined'
-    && window.checkbaDesktop
-    && window.checkbaDesktop.fs
-    && window.checkbaDesktop.fs.showOpenDialog)
-    ? window.checkbaDesktop.fs
-    : null
+  return (host.fs && host.fs.showOpenDialog) ? host.fs : null
 }
 
 async function launchProject(payload) {

--- a/frontend/src/utils/recentProjects.js
+++ b/frontend/src/utils/recentProjects.js
@@ -1,6 +1,8 @@
 // IDE 化：最近项目记录（启动直达 + 顶栏最近项目切换器共用）。
 // 只存 id 与访问时间，名称一律从 getMyProjects 实时解析，避免改名后显示陈旧。
 
+import { host } from '@/services/host.js'
+
 const LAST_KEY = 'checkba_last_project_id'
 const RECENT_KEY = 'checkba_recent_projects'
 const MAX_RECENT = 8
@@ -37,8 +39,7 @@ export function getLastProjectId() {
 
 /** 用项目全量列表把最近 id 解析成 {id, name}（改名不陈旧），推给桌面壳「最近打开」子菜单。 */
 export function syncRecentToMenu(projects) {
-  if (!(typeof window !== 'undefined' && window.checkbaDesktop
-      && window.checkbaDesktop.menu && window.checkbaDesktop.menu.setRecentProjects)) {
+  if (!(host.menu && host.menu.setRecentProjects)) {
     return
   }
   const byId = new Map((projects || []).map((p) => [Number(p.id), p]))
@@ -46,7 +47,7 @@ export function syncRecentToMenu(projects) {
     .map((id) => byId.get(id))
     .filter(Boolean)
     .map((p) => ({ id: Number(p.id), name: p.name }))
-  window.checkbaDesktop.menu.setRecentProjects(list)
+  host.menu.setRecentProjects(list)
 }
 
 /** 自取项目列表版（project-overview 等没有现成列表的调用方用）。静默失败。 */

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -49,11 +49,20 @@ function pickTransport() {
       },
     }
   }
+  // <iframe> 路径（Web 服务器版 / 鸿蒙浏览器）。宿主与本页同源是部署硬前提
+  // （deploy/web/nginx.conf.example：站点与 /zetaoffice/ 同 origin + 全站 COOP/COEP），
+  // 所以收发都钉死在 location.origin：'*' 会把文档内容和编辑器指令暴露给任何把
+  // 本页嵌进去的第三方页面，也会让任何页面能伪造 lo-relay 指令改用户的文档。
   const target = window.parent && window.parent !== window ? window.parent : window
+  const origin = window.location.origin
   return {
-    send: (m) => target.postMessage(m, '*'),
+    send: (m) => target.postMessage(m, origin),
     subscribe: (h) => {
-      const f = (e) => h(e.data)
+      const f = (e) => {
+        if (e.source !== target) return
+        if (e.origin !== origin) return
+        h(e.data)
+      }
       window.addEventListener('message', f)
       return () => window.removeEventListener('message', f)
     },


### PR DESCRIPTION
把 Electron 从「架构」降级为「可替换的分发形态」，为 Web 服务器版 / 鸿蒙壳（`docs/HARMONYOS_PLAN.md` Phase A）铺路。**不改任何产品行为。**

## 1. 宿主能力层 `frontend/src/services/host.js`

前端此前在 18 个文件、93 处直接读 `window.checkbaDesktop`——等于把 Electron 焊进业务代码，换壳或跑纯浏览器都得再挨个找一遍。现全部改走 `host` 门面：

- 桌面态逐字段透传，Web 态只提供浏览器里真能实现的能力、其余字段缺席，所以调用点原有的 `if (host.browser && ...)` 子对象守卫原样成立（守卫本身就是能力探测）。
- 惰性 Proxy 解析，与被替换掉的逐次读 window 语义完全一致——preload 注入、测试桩注入的时机差异不影响任何调用点。
- `zetaoffice` 条件包装：宿主没有这一项时必须缺席（app-e2e 给浏览器目标注入的最小桩只有 `shell.openExternal`），否则调用点的 `typeof getEditor === 'function'` 守卫会通过、然后抛 TypeError。

## 2. H5 编辑器 iframe 通道（Phase A1）

- `getEditor()` 改回**带 kind 的描述符**：桌面 `{kind:'webview', url, preload, partition}`、Web `{kind:'iframe', url}`。
- 新增 `iframeTransport` / `createIframeEditorExecutor`：同源 postMessage，收发都钉死 `location.origin` 且校验 `e.source`。页面侧 `editor-main.js` 的传输也从 `'*'` 收紧到同源（`'*'` 会把文档内容与编辑器指令暴露给任何嵌入方，也让任何页面能伪造 lo-relay 指令改用户的文档）。
- `LibreOfficeEditor` / `VersionCompareTab` 按 kind 分支挂容器；**relay 协议、executor 契约、worker、自动保存链路完全共用**，差异只在两个 `{send, subscribe}` 适配器里。
- Web 态先 `HEAD` 探一次编辑器页是否真部署（dev server 与只部署 h5 的站点上没有），没部署就退回预览路径，而不是挂一个永远起不来的 iframe。

## 过程中修掉的两个自引入缺陷

- 宿主事件订阅一度被推迟到 `dom-ready`——`modified` 是自动保存的唯一触发信号，晚挂一步就是用户编辑不落盘。已拆成 `subscribeHostEvents`（建元素时挂）与 `wireExecutor`（命令通道，webview 等 dom-ready）。
- iframe 传输的订阅挂在 `window` 上，不随元素移除消失，`beforeUnmount` 必须显式退订。

地雷已写进 `.claude/agents/doc-editor.md` 与 `sidebar-shell.md`。

## 验证

| 项 | 结果 |
|---|---|
| `npm run check:emits` | 通过 |
| `npm run build:h5` / `build:zetaoffice` | 通过 |
| `npm run test:lowa-e2e` | 198 通过 0 失败 |
| `npm run test:app-e2e`（含 J11 云端协作） | 104 通过 0 失败 0 异常信号 |
| `npm run test:desktop-e2e` | 保存链路全通 |

desktop-e2e 备注：预热备胎处于热态时最后一步会落盘空白文档（13371 字节、正文为空）。已用 stash 在**未修改的 master 上复现同样失败**，并通过临时停用备胎复现全绿（9443、标记命中）——属既有备胎竞态，与本 PR 无关，另行处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)