### PR TITLE
fix: 首启向导接入平台 AI 通道，去掉 Ollama 预选

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -68,6 +68,9 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `service/ai/PlatformUsageAccountant.java` — 平台通道真实扣费对账（`GET https://openrouter.ai/api/v1/key` 累计消费差分）。
 - `service/ai/ChatModelFactory.java` — `Provider.AWD_CLOUD` 路由；`demotePlatformProvider()` 在断开账户时把供应商降级回落。
 - `model/entity/TokenUsage.java` 的 `costSource`：`platform`（真实扣费）/ `estimate`（BYOK 单价表估算）。
+- 前端选平台通道有**两个**入口，判据必须一致（已连接账户 + 已分配额度，缺哪个都展示但不可选并给下一步）：
+  `pages/admin/admin.vue` 的 `aiProviderOptions`、`pages/wizard/wizard.vue` 的 `providerOptions`（首启向导，
+  条件齐备时自动预选平台通道；向导刻意不预选任何供应商，见下方地雷 14）。
 
 **广场付费项（PR-D，链路见 plugin-marketplace.md）**
 - `backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java` — Skill 与插件两条安装链路共用的付费判定单一出口。
@@ -275,6 +278,12 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
 13. **锁定拒绝不计入失败计数**。AuthController 里锁定检查（`checkLoginAttempt`）与凭据校验
     分属两个 try：锁定期内的轮询若也 `recordLoginFailure` 会把锁无限续期。同理 awdk-login
     只有官网明确 401/403（UNAUTHORIZED）才计失败，网络不可达不消耗尝试次数。
+
+14. **首启向导不预选 AI 供应商**。曾经预选「本地 Ollama」，没装 Ollama 的用户一路点「完成设置」，
+    要到发第一条消息才收到 Connection refused（`ChatModelFactory` 只在 OPENROUTER 下防回退 Ollama，
+    反向没有保护）。现在 `activeProvider` 初值是空串、由用户显式选，唯一的例外是「已连接账户且已分配额度」
+    时自动预选平台通道——用账户 Key 解锁的人买的就是这条通道，不该再被引导去配别家的 Key。
+    向导提交前的空值拦截在 `handleSubmit`，后端 `WizardController` 也拒空 `activeProvider`（两道都在才算数）。
 
 ## 验证
 

--- a/frontend/src/pages/wizard/wizard.vue
+++ b/frontend/src/pages/wizard/wizard.vue
@@ -24,8 +24,8 @@
             v-for="opt in providerOptions"
             :key="opt.value"
             class="provider-card"
-            :class="{ selected: form.ai.activeProvider === opt.value }"
-            @tap="form.ai.activeProvider = opt.value"
+            :class="{ selected: form.ai.activeProvider === opt.value, unavailable: opt.unavailable }"
+            @tap="pickProvider(opt)"
           >
             <view class="provider-head">
               <view class="radio-dot" :class="{ checked: form.ai.activeProvider === opt.value }"></view>
@@ -35,6 +35,7 @@
               </text>
             </view>
             <text class="provider-desc">{{ opt.desc }}</text>
+            <text v-if="opt.unavailable" class="provider-blocked">{{ opt.hint }}</text>
             <view v-if="form.ai.activeProvider === opt.value && opt.setupHint" class="provider-setup">
               <text class="setup-line">{{ opt.setupHint }}</text>
               <text class="setup-cmd" selectable>{{ opt.setupCmd }}</text>
@@ -125,7 +126,13 @@
 </template>
 
 <script>
-import { getWizardStatus, submitWizard } from '@/services/api.js'
+import {
+  getWizardStatus,
+  submitWizard,
+  getAccountStatus,
+  getAccountUsage,
+} from '@/services/api.js'
+import { isDesktopHost } from '@/services/host.js'
 
 export default {
   name: 'FirstRunWizard',
@@ -133,12 +140,17 @@ export default {
     return {
       submitting: false,
       showAdvanced: false,
+      isDesktop: isDesktopHost(),
+      // 平台通道「AI Workdeck 云端」的两个前置条件，与 admin 页同一判据：
+      // 已连接账户（本地读盘）+ 已在官网从余额分配 AI 额度（用量接口）。
+      platformAiAvailable: false,
+      platformNeedsAllocation: false,
       // 各云端提供商的 key 暂存：切换选项不丢已填内容，提交时只带选中者
       apiKeys: {
         OPENROUTER: '',
         GEMINI: '',
       },
-      providerOptions: [
+      byokOptions: [
         {
           value: 'OLLAMA',
           label: '本地 Ollama',
@@ -171,7 +183,9 @@ export default {
       ],
       form: {
         ai: {
-          activeProvider: 'OLLAMA',
+          // 刻意不预选：预选 OLLAMA 时，没装 Ollama 的用户一路点「完成设置」，
+          // 会到发第一条消息才收到 Connection refused。必须让用户显式选一个。
+          activeProvider: '',
         },
         external: {
           aliyunOcr: { accessKeyId: '', accessKeySecret: '' },
@@ -183,10 +197,68 @@ export default {
       },
     }
   },
+  computed: {
+    // 「AI Workdeck 云端」置顶：用账户 Key 解锁的用户买的就是这条通道，
+    // 不列出来他会被引导去再配一家别的 Key。前置条件不满足时展示但不可选并给出下一步
+    // （隐藏会让人发现不了，直接可选又会拖到发消息那一刻才报错）。
+    providerOptions() {
+      if (!this.isDesktop) return this.byokOptions
+      let hint = ''
+      // 试用码解锁的用户走到这里账户是未连接的，引导指向进入产品后可用的入口
+      if (!this.platformAiAvailable) hint = '需先连接账户：进入产品后在「系统管理 → 账户与用量」粘贴官网账户 Key'
+      else if (this.platformNeedsAllocation) hint = '需先在官网账户页从余额分配 AI 额度'
+      return [
+        {
+          value: 'AWD_CLOUD',
+          label: 'AI Workdeck 云端',
+          local: false,
+          desc: '用账户余额直接调用平台模型，无需自备 Key。按实际扣费结算，用量在「系统管理 → 账户与用量」可查。',
+          keyField: null,
+          hint,
+          unavailable: !!hint,
+        },
+        ...this.byokOptions,
+      ]
+    },
+  },
   onLoad() {
     this.checkStatus()
+    if (this.isDesktop) {
+      this.loadPlatformAi()
+    }
   },
   methods: {
+    // 平台通道可用性：status 是后端本地读盘（不打官网），可用时再补一次用量接口判额度。
+    // 两个条件都满足才替用户预选它——解锁时粘的就是账户 Key 的人不该再被问一遍。
+    async loadPlatformAi() {
+      try {
+        const s = await getAccountStatus()
+        this.platformAiAvailable = !!(s && s.platformAiAvailable)
+      } catch (e) {
+        this.platformAiAvailable = false
+        return
+      }
+      if (!this.platformAiAvailable) return
+      try {
+        const usage = await getAccountUsage()
+        const platform = (usage && usage.platform) || null
+        // quotaAvailable=false 表示实时口径拿不到，此时不当作「没额度」拦人
+        this.platformNeedsAllocation = !!(platform && platform.quotaAvailable && !platform.hasAiQuota)
+      } catch (e) {
+        this.platformNeedsAllocation = false
+      }
+      if (!this.platformNeedsAllocation && !this.form.ai.activeProvider) {
+        this.form.ai.activeProvider = 'AWD_CLOUD'
+      }
+    },
+    // 不可选项给出下一步，而不是静默不响应（与 admin 页 onPickProvider 同口径）
+    pickProvider(opt) {
+      if (opt.unavailable) {
+        uni.showToast({ title: opt.hint || '当前不可用', icon: 'none' })
+        return
+      }
+      this.form.ai.activeProvider = opt.value
+    },
     async checkStatus() {
       try {
         const res = await getWizardStatus()
@@ -415,6 +487,19 @@ export default {
 .provider-card.selected {
   border-color: #2563eb;
   background: rgba(37, 99, 235, 0.04);
+}
+
+.provider-card.unavailable {
+  opacity: 0.62;
+  background: #f8fafc;
+}
+
+.provider-blocked {
+  display: block;
+  font-size: 12px;
+  color: #b45309;
+  margin-top: 6px;
+  line-height: 1.6;
 }
 
 .provider-head {


### PR DESCRIPTION
## 背景

商业化改造后，桌面首启链路是：解锁门 → 本机工作区 → 首次运行向导 → 工作区。但向导（`frontend/src/pages/wizard/wizard.vue`）没有跟上改造：它只列三条 BYOK 通道（本地 Ollama / OpenRouter / Google Gemini），**唯独没有平台通道「AI Workdeck 云端」**（`AWD_CLOUD`）。

后果是付费路径断的：用户在官网充值、拿 `awdk_` Key、在解锁门粘贴（`LicenseController` 会顺带 `AccountService.connect()`），账户与额度都已就绪，下一屏却被要求在「装 Ollama / 填 OpenRouter Key / 填 Gemini Key」里三选一，得先随便选一个过掉向导，再自己摸到「系统管理 → AI 功能设置」把供应商改回来。

另一个坑：向导默认预选 `OLLAMA`。不改直接点「完成设置」的用户，要到发第一条消息才收到 Connection refused（`ChatModelFactory` 只在 OPENROUTER 供应商下刻意不回退 Ollama，反方向没有保护）。

## 改动

- `providerOptions` 改为 computed，桌面端置顶 `AWD_CLOUD`。可用性判据与 admin 页 `aiProviderOptions` 完全一致：已连接账户（`/api/account/status`，后端本地读盘不打官网）+ 已在官网从余额分配 AI 额度（`/api/account/usage` 的 `quotaAvailable && hasAiQuota`）。缺任一条件时**展示但不可选**并给出下一步（隐藏会让人发现不了，直接可选会拖到发消息才报错——沿用既有口径）；两条都满足时自动预选。
- `form.ai.activeProvider` 初值由 `'OLLAMA'` 改为空串，强制显式选择。提交前的空值拦截 `handleSubmit` 里本来就有，后端 `WizardController` 也拒空 `activeProvider`。
- 同步 `.claude/agents/licensing-billing.md`：记下平台通道有两个前端入口（判据必须一致），并补地雷 14。

后端零改动——`WizardController` 直接复用 `AdminConfigController.toSettingsUpdates`，`activeProvider=AWD_CLOUD` 本来就存得下。

## 验证

- `npm run check:emits` 通过（扫描 65 个 .vue）
- `npm run build:h5` 通过
- H5 产物 + 桩 XHR 走完 UI 链路，四种状态逐个确认：
  - 未连接账户 → 云端项不可选，提示「需先连接账户…」，点击不改变选中态
  - 已连接但未分配额度 → 不可选，提示「需先在官网账户页从余额分配 AI 额度」
  - 已连接且有额度 → 云端项自动预选
  - 未选任何供应商点「完成设置」→ 被拦，toast「请选择 AI 提供商」，不发请求
- e2e 不受影响：`app-e2e` 与 `desktop-e2e` 都直接 POST `/api/admin/wizard` 铺状态，不走向导 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)