### PR TITLE
chore: 发布 v0.11.1（小版本补丁）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
把 v0.11.0 之后已合并到 master 的全部改动打成一个小版本补丁，让存量 0.11.0 用户走应用内增量更新升上来。

## 打包内容（v0.11.0..master 共 6 个 PR）

| PR | 内容 |
|---|---|
| #281 | 补丁产物排除漏项（CJK 字体/字节码）+ 8MB 体积守门 + patch-gate 只拦进包路径 |
| #282 | 登录短信验证（server 模式二次验证 + 手机号绑定，阿里云 dysmsapi 无 SDK 直签） |
| #283 | mirror-sync 默认路径对齐线上部署 |
| #284 | 镜像同步加重试与续传，任一产物缺失就不换 manifest |
| #285 | 宿主能力层收口 + H5 编辑器 iframe 通道（Phase A1） |
| #286 | 首启向导接入平台 AI 通道，去掉 Ollama 预选 |

## 为什么可以走小版本

按 docs/INCREMENTAL_UPDATE_DESIGN.md §2.2 逐条核对：

- desktop/main、desktop/preload、desktop/build 零改动（只动了 desktop/scripts/，patch-gate 已豁免 CI 侧脚本）
- backend/pom.xml 零改动，依赖 lib/ 不变
- LOWA 引擎来源（LOWA_BASE_URL / fetch-lowa-assets.js）零改动
- requirements.lock 零改动
- 唯一 schema 变化是 User 加 phone 列（可空 + unique），属向后兼容加列

#285 新增的 frontend/src/services/host.js 只是把既有的 window.checkbaDesktop 调用收口成门面，未依赖任何新 preload API——所以打进 frontend-h5 补丁后跑在 0.11.0 的旧壳上没有断面。

## 验证

- backend `mvn -B test`（JDK 21）：1063 通过 / 0 失败
- desktop `npm test`：34 通过（含 overlay 与 update-service 全链路）
- frontend `npm run check:emits`：65 个 .vue 契约通过
- frontend `npm run build:h5`：构建通过

合并后打 tag v0.11.1 触发 desktop-build，产出补丁产物 + 签名 manifest，镜像同步后 0.11.0 客户端启动 2 分钟内即可收到更新。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)