### PR TITLE
feat: Twilio 通道支持 API Key 认证

### DIFF
--- a/backend/src/main/java/com/checkba/service/sms/TwilioSmsGateway.java
+++ b/backend/src/main/java/com/checkba/service/sms/TwilioSmsGateway.java
@@ -33,6 +33,7 @@ public class TwilioSmsGateway implements SmsGateway {
     private final SmsTransport transport;
     private final boolean enabled;
     private final String accountSid;
+    private final String apiKeySid;
     private final String authToken;
     private final String messagingServiceSid;
     private final String template;
@@ -41,6 +42,7 @@ public class TwilioSmsGateway implements SmsGateway {
     public TwilioSmsGateway(SmsTransport transport,
                             @Value("${sms.intl.enabled:false}") boolean enabled,
                             @Value("${sms.intl.account-sid:}") String accountSid,
+                            @Value("${sms.intl.api-key-sid:}") String apiKeySid,
                             @Value("${sms.intl.auth-token:}") String authToken,
                             @Value("${sms.intl.messaging-service-sid:}") String messagingServiceSid,
                             @Value("${sms.intl.template:Your AI Workdeck verification code is {code}. It expires in 5 minutes.}")
@@ -48,9 +50,19 @@ public class TwilioSmsGateway implements SmsGateway {
         this.transport = transport;
         this.enabled = enabled;
         this.accountSid = accountSid;
+        this.apiKeySid = apiKeySid;
         this.authToken = authToken;
         this.messagingServiceSid = messagingServiceSid;
         this.template = template;
+    }
+
+    /**
+     * Basic 认证的用户名：配了 API Key（SK 开头）就用它，否则回落账号自身的 Auth Token 认证。
+     * **推荐配 API Key**——可单独吊销，泄露时不必换掉整个账号的 Auth Token。
+     * 无论哪种，URL 路径里的账号标识始终是 Account SID（AC 开头）。
+     */
+    private String basicUser() {
+        return StringUtils.hasText(apiKeySid) ? apiKeySid : accountSid;
     }
 
     @Override
@@ -77,7 +89,7 @@ public class TwilioSmsGateway implements SmsGateway {
                 + "&Body=" + enc(template.replace("{code}", code));
         String url = API_BASE + "/Accounts/" + enc(accountSid) + "/Messages.json";
         String basic = Base64.getEncoder().encodeToString(
-                (accountSid + ":" + authToken).getBytes(StandardCharsets.UTF_8));
+                (basicUser() + ":" + authToken).getBytes(StandardCharsets.UTF_8));
 
         SmsTransport.Reply reply = transport.postForm(url, body, "Basic " + basic);
         // Twilio 成功回 201；失败体形如 {"code":21211,"message":"Invalid 'To' Phone Number"}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -104,7 +104,12 @@ sms:
   # 里配置，代码只认 messaging-service-sid——加国家不需要改代码发版。
   intl:
     enabled: ${SMS_INTL_ENABLED:false}
+    # 账号标识（AC 开头），出现在 API 路径里
     account-sid: ${TWILIO_ACCOUNT_SID:}
+    # API Key（SK 开头，推荐）：可单独吊销，泄露时不必换整个账号的 Auth Token。
+    # 留空则用 account-sid 直接做 Basic 用户名（账号 Auth Token 认证）
+    api-key-sid: ${TWILIO_API_KEY_SID:}
+    # API Key 的 secret，或账号 Auth Token（取决于上一项是否配置）
     auth-token: ${TWILIO_AUTH_TOKEN:}
     messaging-service-sid: ${TWILIO_MESSAGING_SERVICE_SID:}
     template: ${TWILIO_SMS_TEMPLATE:Your AI Workdeck verification code is {code}. It expires in 5 minutes.}

--- a/backend/src/test/java/com/checkba/service/sms/TwilioSmsGatewayTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/TwilioSmsGatewayTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TwilioSmsGatewayTest {
 
     private static TwilioSmsGateway gateway(SmsTransport transport) {
-        return new TwilioSmsGateway(transport, true, "ACtest", "token123", "MGtest",
+        return new TwilioSmsGateway(transport, true, "ACtest", "", "token123", "MGtest",
                 "Your AI Workdeck verification code is {code}. It expires in 5 minutes.");
     }
 
@@ -30,11 +30,11 @@ class TwilioSmsGatewayTest {
     @Test
     @DisplayName("配置不齐即未启用（缺 SID/Token/MessagingServiceSid 任一）")
     void incompleteConfigMeansDisabled() {
-        assertFalse(new TwilioSmsGateway((u, b, a) -> null, true, "", "t", "MG", "x").enabled());
-        assertFalse(new TwilioSmsGateway((u, b, a) -> null, true, "AC", "", "MG", "x").enabled());
-        assertFalse(new TwilioSmsGateway((u, b, a) -> null, true, "AC", "t", "", "x").enabled());
-        assertFalse(new TwilioSmsGateway((u, b, a) -> null, false, "AC", "t", "MG", "x").enabled());
-        assertTrue(new TwilioSmsGateway((u, b, a) -> null, true, "AC", "t", "MG", "x").enabled());
+        assertFalse(new TwilioSmsGateway((u, b, a) -> null, true, "", "", "t", "MG", "x").enabled());
+        assertFalse(new TwilioSmsGateway((u, b, a) -> null, true, "AC", "", "", "MG", "x").enabled());
+        assertFalse(new TwilioSmsGateway((u, b, a) -> null, true, "AC", "", "t", "", "x").enabled());
+        assertFalse(new TwilioSmsGateway((u, b, a) -> null, false, "AC", "", "t", "MG", "x").enabled());
+        assertTrue(new TwilioSmsGateway((u, b, a) -> null, true, "AC", "", "t", "MG", "x").enabled());
     }
 
     @Test
@@ -59,6 +59,24 @@ class TwilioSmsGatewayTest {
         assertTrue(body.get().contains("MessagingServiceSid=MGtest"));
         assertTrue(body.get().contains("246810"), "模板占位应被替换为真码");
         assertFalse(body.get().contains("%7Bcode%7D"), "模板占位不得原样发出");
+    }
+
+    @Test
+    @DisplayName("配了 API Key 时用 SK 做 Basic 用户名，URL 路径仍是 Account SID")
+    void apiKeyAuthPrefersKeySid() {
+        AtomicReference<String> url = new AtomicReference<>();
+        AtomicReference<String> auth = new AtomicReference<>();
+        TwilioSmsGateway gw = new TwilioSmsGateway((u, b, a) -> {
+            url.set(u);
+            auth.set(a);
+            return new SmsTransport.Reply(201, "{\"sid\":\"SM1\"}");
+        }, true, "ACtest", "SKtest", "keysecret", "MGtest", "code {code}");
+
+        gw.sendVerificationCode("+14155552671", "123456");
+
+        assertTrue(url.get().contains("/Accounts/ACtest/"), url.get());
+        assertEquals("Basic " + Base64.getEncoder().encodeToString(
+                "SKtest:keysecret".getBytes(StandardCharsets.UTF_8)), auth.get());
     }
 
     @Test
@@ -87,7 +105,7 @@ class TwilioSmsGatewayTest {
     void failuresBecomeBusinessErrors() {
         TwilioSmsGateway down = gateway((u, b, a) -> new SmsTransport.Reply(-1, "timed out"));
         assertThrows(IllegalArgumentException.class, () -> down.sendVerificationCode("+14155552671", "1"));
-        TwilioSmsGateway off = new TwilioSmsGateway((u, b, a) -> null, false, "", "", "", "x");
+        TwilioSmsGateway off = new TwilioSmsGateway((u, b, a) -> null, false, "", "", "", "", "x");
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> off.sendVerificationCode("+14155552671", "1"));
         assertNoLogoutSubstring(e.getMessage());


### PR DESCRIPTION
用户提供的是 Twilio API Key（SK 开头）而非账号 Auth Token。API Key 可单独吊销、泄露时不必换整个账号凭据，是 Twilio 推荐做法，所以支持它作为 Basic 用户名，URL 路径里仍用 Account SID。留空则回落原有的账号 Auth Token 认证方式。

真机验证（2026-08-07）：
- 认证形态正确——读接口 Accounts.json / MessagingService / TrustHub 全部 200
- Messaging Service `aiworkdeck` 存在，含一个字母发送方（无电话号码）
- 发送被挡：`20003 Primary compliance profile is not approved`，需在 Trust Hub 完成 KYC。属账号侧外部前置条件，不阻塞合并

🤖 Generated with [Claude Code](https://claude.com/claude-code)