### PR TITLE
fix: 首启路径去死路（向导内就地连接账户 + 全新安装不再跳过向导）+ 发布 v0.12.0

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -311,6 +311,21 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
     时自动预选平台通道——用账户 Key 解锁的人买的就是这条通道，不该再被引导去配别家的 Key。
     向导提交前的空值拦截在 `handleSubmit`，后端 `WizardController` 也拒空 `activeProvider`（两道都在才算数）。
 
+15. **向导里每一条「下一步」都必须能在向导里做完**。平台通道曾经在未连接账户时置灰 +
+    提示「进入产品后在系统管理粘贴 Key」——那是死路：试用码解锁的用户在向导里无论如何都点不亮它，
+    只能先随便选一家凑合。现在 `AWD_CLOUD` 恒可选，选中就地展开连接块（`handleConnectAccount` 调
+    `POST /api/account/connect`，与 admin 页 `onConnectAccount` 同链路：连接 → 重取状态 →
+    `refreshEntitlements(true)`），已连接但没分配额度时给「前往官网分配额度 + 重新检查」两个动作。
+    两个前置条件缺任一时 `handleSubmit` 拦住提交并指出下一步——**闸门从「不可选」挪到了「不可提交」，
+    不是取消了**。
+
+16. **全新安装必须先钉 `system.wizard.completed=false`**（`DataInitializer`，仅 admin 不存在时写）。
+    `WizardController.isInitialized()` 在标记不存在时退回存量兜底「system_setting 非空即已初始化」，
+    而首启链上 `LocalIdentityService.commit()` 解析本机身份就会写下 `local.identity.selectedUserId`
+    一行——launch 页查身份在查向导之前，于是**全新安装反而整个跳过首启向导**（真机复现过：
+    解锁后直接进个人中心，`ai.activeProvider` 一直空着，要到发第一条消息才发现）。
+    护栏 `config/DataInitializerTest`：全新装写标记、存量库一个字都不许改（改了等于把匿名提交窗口重开）。
+
 ## 验证
 
 - 后端：`cd backend && mvn test`（**JDK 21，系统默认 25 会 SIGBUS**）。本领域相关用例：

--- a/backend/src/main/java/com/checkba/config/DataInitializer.java
+++ b/backend/src/main/java/com/checkba/config/DataInitializer.java
@@ -1,7 +1,9 @@
 package com.checkba.config;
 
+import com.checkba.controller.WizardController;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.SystemSettingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -19,6 +21,7 @@ import java.time.LocalDateTime;
 public class DataInitializer implements CommandLineRunner {
 
     private final UserRepository userRepository;
+    private final SystemSettingService systemSettingService;
 
     /**
      * 首启 admin 初始口令。桌面 profile 在 application-desktop.yml 里显式设为 "123"
@@ -38,8 +41,10 @@ public class DataInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
+        java.util.Optional<User> existingAdmin = userRepository.findByUsername("admin");
+        boolean freshInstall = existingAdmin.isEmpty();
         // 创建默认用户 admin（若不存在）。不再打印明文口令到日志。
-        userRepository.findByUsername("admin")
+        existingAdmin
                 .orElseGet(() -> {
                     User user = new User();
                     user.setUsername("admin");
@@ -62,6 +67,16 @@ public class DataInitializer implements CommandLineRunner {
                 });
         // 注意：此前每次启动会把所有项目强行归到 admin 名下——在多用户场景会"抢走"其他用户的项目，
         // 与 ProjectMemberService 等多用户能力冲突，已移除该逻辑。
+
+        // 全新安装：在任何人往 system_setting 写第一行之前，先把向导标记钉成 "false"。
+        // 不钉的话 WizardController.isInitialized() 会走"标记不存在 → 表非空即已初始化"
+        // 的存量兜底，而首启链上 LocalIdentityService 解析本机身份时就会写下
+        // local.identity.selectedUserId 这一行（launch 页查身份在查向导之前），
+        // 结果是全新安装反而跳过首启向导：用户没选过 AI 提供商，要到发第一条消息才发现。
+        if (freshInstall && systemSettingService.get(WizardController.KEY_WIZARD_COMPLETED, null) == null) {
+            systemSettingService.set(WizardController.KEY_WIZARD_COMPLETED, "false");
+            log.info("全新安装：已标记首启向导待运行");
+        }
     }
 
     private static String generateInitialPassword() {

--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -30,7 +30,8 @@ import java.util.Map;
 @RequestMapping("/api/admin/wizard")
 public class WizardController {
 
-    static final String KEY_WIZARD_COMPLETED = "system.wizard.completed";
+    /** 全新安装时由 {@code DataInitializer} 先落一份 "false"，见那里的注释。 */
+    public static final String KEY_WIZARD_COMPLETED = "system.wizard.completed";
 
     private final SystemSettingService systemSettingService;
     private final SystemSettingRepository systemSettingRepository;

--- a/backend/src/test/java/com/checkba/config/DataInitializerTest.java
+++ b/backend/src/test/java/com/checkba/config/DataInitializerTest.java
@@ -1,0 +1,60 @@
+package com.checkba.config;
+
+import com.checkba.controller.WizardController;
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.SystemSettingService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定「全新安装必须走首启向导」这条不变式。
+ *
+ * <p>没有这枚显式标记时，{@code WizardController.isInitialized()} 会退回存量兜底
+ * 「system_setting 非空即已初始化」，而首启链上 LocalIdentityService 解析本机身份
+ * 会先写下一行 selectedUserId——全新安装反而跳过向导，用户没选过 AI 提供商，
+ * 要到发第一条消息才发现。
+ */
+@ExtendWith(MockitoExtension.class)
+class DataInitializerTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private SystemSettingService systemSettingService;
+
+    private DataInitializer newInitializer() {
+        return new DataInitializer(userRepository, systemSettingService);
+    }
+
+    @Test
+    void freshInstallPinsWizardPending() {
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(systemSettingService.get(WizardController.KEY_WIZARD_COMPLETED, null)).thenReturn(null);
+
+        newInitializer().run();
+
+        verify(systemSettingService).set(WizardController.KEY_WIZARD_COMPLETED, "false");
+    }
+
+    @Test
+    void existingInstallIsNotReopened() {
+        // 已有 admin = 存量库：绝不能把向导标记重置成 "false"（等于把匿名提交窗口重新打开）
+        User admin = new User();
+        admin.setUsername("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+
+        newInitializer().run();
+
+        verify(systemSettingService, never()).set(anyString(), anyString());
+    }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",

--- a/frontend/src/pages/wizard/wizard.vue
+++ b/frontend/src/pages/wizard/wizard.vue
@@ -24,7 +24,7 @@
             v-for="opt in providerOptions"
             :key="opt.value"
             class="provider-card"
-            :class="{ selected: form.ai.activeProvider === opt.value, unavailable: opt.unavailable }"
+            :class="{ selected: form.ai.activeProvider === opt.value }"
             @tap="pickProvider(opt)"
           >
             <view class="provider-head">
@@ -35,7 +35,6 @@
               </text>
             </view>
             <text class="provider-desc">{{ opt.desc }}</text>
-            <text v-if="opt.unavailable" class="provider-blocked">{{ opt.hint }}</text>
             <view v-if="form.ai.activeProvider === opt.value && opt.setupHint" class="provider-setup">
               <text class="setup-line">{{ opt.setupHint }}</text>
               <text class="setup-cmd" selectable>{{ opt.setupCmd }}</text>
@@ -47,6 +46,44 @@
                 v-model="apiKeys[opt.value]"
                 :placeholder="opt.keyPlaceholder"
               />
+            </view>
+            <!-- 平台通道的连接就地完成：把「进入产品后再去系统管理粘贴 Key」的死路收回向导内 -->
+            <view v-if="form.ai.activeProvider === opt.value && opt.accountField" class="provider-account">
+              <template v-if="!platformAiAvailable">
+                <text class="account-line">
+                  桌面端无需注册登录：在官网账户页生成一枚账户 Key（awdk_ 开头），粘贴到下面直接连接。Key 只保存在本机，随时可以断开。
+                </text>
+                <view class="account-actions">
+                  <text class="account-link" @tap="openAccountSite">前往官网获取 Key</text>
+                </view>
+                <input
+                  class="text-input"
+                  v-model="accountKey"
+                  placeholder="粘贴 awdk_ 开头的账户 Key"
+                />
+                <button
+                  class="account-btn"
+                  :disabled="connectingAccount"
+                  @tap="handleConnectAccount"
+                >
+                  {{ connectingAccount ? '正在连接…' : '连接账户' }}
+                </button>
+              </template>
+              <template v-else-if="platformNeedsAllocation">
+                <text class="account-line">
+                  账户已连接{{ accountLabel }}。还差一步：到官网账户页从余额分配 AI 额度，分配完点「重新检查」。
+                </text>
+                <view class="account-actions">
+                  <text class="account-link" @tap="openAccountSite">前往官网分配额度</text>
+                  <text class="account-link" @tap="handleRecheckAccount">
+                    {{ recheckingAccount ? '检查中…' : '重新检查' }}
+                  </text>
+                </view>
+              </template>
+              <template v-else>
+                <text class="account-line account-ok">账户已连接{{ accountLabel }}，可以直接开始使用。</text>
+              </template>
+              <text v-if="accountError" class="account-error">{{ accountError }}</text>
             </view>
           </view>
         </view>
@@ -131,8 +168,14 @@ import {
   submitWizard,
   getAccountStatus,
   getAccountUsage,
+  connectAccount,
 } from '@/services/api.js'
+import { refreshEntitlements } from '@/composables/useEntitlement.js'
 import { isDesktopHost } from '@/services/host.js'
+import { openExternalUrl } from '@/utils/externalLink.js'
+
+// 官网账户页：生成账户 Key、充值、分配 AI 额度都在这里（与 admin 页同一地址）
+const ACCOUNT_SITE_URL = 'https://www.aiworkdeck.com/zh/account'
 
 export default {
   name: 'FirstRunWizard',
@@ -145,6 +188,11 @@ export default {
       // 已连接账户（本地读盘）+ 已在官网从余额分配 AI 额度（用量接口）。
       platformAiAvailable: false,
       platformNeedsAllocation: false,
+      accountName: '',
+      accountKey: '',
+      accountError: '',
+      connectingAccount: false,
+      recheckingAccount: false,
       // 各云端提供商的 key 暂存：切换选项不丢已填内容，提交时只带选中者
       apiKeys: {
         OPENROUTER: '',
@@ -199,14 +247,11 @@ export default {
   },
   computed: {
     // 「AI Workdeck 云端」置顶：用账户 Key 解锁的用户买的就是这条通道，
-    // 不列出来他会被引导去再配一家别的 Key。前置条件不满足时展示但不可选并给出下一步
-    // （隐藏会让人发现不了，直接可选又会拖到发消息那一刻才报错）。
+    // 不列出来他会被引导去再配一家别的 Key。选中即就地展开连接块——
+    // 前置条件不满足时**不能只给一句「进入产品后再去设置里连」**，那是死路：
+    // 用户在向导里没有任何办法把它变成可用，只能先选一家别的凑合。
     providerOptions() {
       if (!this.isDesktop) return this.byokOptions
-      let hint = ''
-      // 试用码解锁的用户走到这里账户是未连接的，引导指向进入产品后可用的入口
-      if (!this.platformAiAvailable) hint = '需先连接账户：进入产品后在「系统管理 → 账户与用量」粘贴官网账户 Key'
-      else if (this.platformNeedsAllocation) hint = '需先在官网账户页从余额分配 AI 额度'
       return [
         {
           value: 'AWD_CLOUD',
@@ -214,11 +259,13 @@ export default {
           local: false,
           desc: '用账户余额直接调用平台模型，无需自备 Key。按实际扣费结算，用量在「系统管理 → 账户与用量」可查。',
           keyField: null,
-          hint,
-          unavailable: !!hint,
+          accountField: true,
         },
         ...this.byokOptions,
       ]
+    },
+    accountLabel() {
+      return this.accountName ? `（${this.accountName}）` : ''
     },
   },
   onLoad() {
@@ -234,6 +281,7 @@ export default {
       try {
         const s = await getAccountStatus()
         this.platformAiAvailable = !!(s && s.platformAiAvailable)
+        this.accountName = (s && (s.displayName || s.username)) || ''
       } catch (e) {
         this.platformAiAvailable = false
         return
@@ -251,13 +299,47 @@ export default {
         this.form.ai.activeProvider = 'AWD_CLOUD'
       }
     },
-    // 不可选项给出下一步，而不是静默不响应（与 admin 页 onPickProvider 同口径）
     pickProvider(opt) {
-      if (opt.unavailable) {
-        uni.showToast({ title: opt.hint || '当前不可用', icon: 'none' })
+      this.form.ai.activeProvider = opt.value
+    },
+    openAccountSite() {
+      openExternalUrl(ACCOUNT_SITE_URL)
+    },
+    // 就地连接账户：与 admin 页 onConnectAccount 同一条链路（连接 → 重取状态 → 权益缓存失效）
+    async handleConnectAccount() {
+      const key = (this.accountKey || '').replace(/\s+/g, '')
+      if (!key) {
+        this.accountError = '请先粘贴账户 Key'
         return
       }
-      this.form.ai.activeProvider = opt.value
+      this.accountError = ''
+      this.connectingAccount = true
+      try {
+        await connectAccount(key)
+        this.accountKey = ''
+        await this.loadPlatformAi()
+        // 已购功能解锁随账户走，连接后必须让权益缓存失效重取
+        await refreshEntitlements(true)
+        uni.showToast({ title: '已连接账户', icon: 'none' })
+      } catch (e) {
+        this.accountError = (e && e.message) || '连接失败，请检查 Key 后重试'
+      } finally {
+        this.connectingAccount = false
+      }
+    },
+    // 用户到官网分配完额度回到向导：不必重启应用，重查一次即可
+    async handleRecheckAccount() {
+      if (this.recheckingAccount) return
+      this.accountError = ''
+      this.recheckingAccount = true
+      try {
+        await this.loadPlatformAi()
+        if (this.platformNeedsAllocation) {
+          this.accountError = '还没查到已分配的 AI 额度，稍等片刻再试'
+        }
+      } finally {
+        this.recheckingAccount = false
+      }
     },
     async checkStatus() {
       try {
@@ -318,6 +400,15 @@ export default {
       }
       if (provider === 'GEMINI' && !this.apiKeys.GEMINI.trim()) {
         uni.showToast({ title: '请填写 Gemini API Key', icon: 'none' })
+        return
+      }
+      // 平台通道两个前置条件缺一都会在发第一条消息时才报错，拦在这里并指出下一步
+      if (provider === 'AWD_CLOUD' && !this.platformAiAvailable) {
+        uni.showToast({ title: '请先在上方连接账户', icon: 'none' })
+        return
+      }
+      if (provider === 'AWD_CLOUD' && this.platformNeedsAllocation) {
+        uni.showToast({ title: '请先在官网账户页分配 AI 额度', icon: 'none' })
         return
       }
 
@@ -489,19 +580,6 @@ export default {
   background: rgba(37, 99, 235, 0.04);
 }
 
-.provider-card.unavailable {
-  opacity: 0.62;
-  background: #f8fafc;
-}
-
-.provider-blocked {
-  display: block;
-  font-size: 12px;
-  color: #b45309;
-  margin-top: 6px;
-  line-height: 1.6;
-}
-
 .provider-head {
   display: flex;
   align-items: center;
@@ -555,6 +633,63 @@ export default {
 
 .provider-key {
   margin-top: 10px;
+}
+
+.provider-account {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 10px;
+  background: #f8fafc;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.account-line {
+  font-size: 12px;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.account-ok {
+  color: #166534;
+}
+
+.account-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.account-link {
+  font-size: 12px;
+  color: #1d4ed8;
+  cursor: pointer;
+}
+
+.account-link:hover {
+  text-decoration: underline;
+}
+
+.account-btn {
+  height: 36px;
+  line-height: 36px;
+  border-radius: 8px;
+  background: #1e293b;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.account-btn[disabled] {
+  opacity: 0.6;
+}
+
+.account-error {
+  font-size: 12px;
+  color: #dc2626;
+  line-height: 1.6;
 }
 
 .provider-setup {


### PR DESCRIPTION
## 问题

首启向导里「AI Workdeck 云端」置灰，提示「需先连接账户：进入产品后在「系统管理 → 账户与用量」粘贴官网账户 Key」。

这是一条**死路**：用试用码解锁的用户在向导里无论如何都点不亮它，只能先随便选一家凑合，进产品后再回设置页改一遍。

排查时又发现一条更严重的：**全新安装会整个跳过首启向导**。

## 修复

### 1. 向导里的平台通道恒可选，选中就地展开连接块

`frontend/src/pages/wizard/wizard.vue`

- 「前往官网获取 Key」+ Key 输入框 + 「连接账户」，与 admin 页 `onConnectAccount` 同一条链路（`POST /api/account/connect` → 重取状态 → `refreshEntitlements(true)`）
- 已连接但未分配 AI 额度：给「前往官网分配额度」+「重新检查」，不必重启应用
- 两个前置条件缺任一时 `handleSubmit` 拦住提交并指出下一步——**闸门从「不可选」挪到了「不可提交」，不是取消了**（仍然不会拖到发第一条消息才报错，地雷 14 的口径不变）

### 2. 全新安装不再跳过首启向导

`backend/.../config/DataInitializer.java`

- 根因：`WizardController.isInitialized()` 在 `system.wizard.completed` 标记不存在时退回存量兜底「system_setting 非空即已初始化」，而首启链上 `LocalIdentityService.commit()` 解析本机身份就会写下 `local.identity.selectedUserId` 一行——launch 页**查身份在查向导之前**
- 真机复现：全新库解锁后直接进个人中心，`ai.activeProvider` 一直空着，要到发第一条消息才发现
- 修法：`DataInitializer` 在创建默认 admin（= 全新库）时先把标记钉成 `"false"`；**存量库一个字不改**（改了等于把匿名提交窗口重开）
- 护栏：新增 `config/DataInitializerTest` 两例

领域文档 `.claude/agents/licensing-billing.md` 已补两条地雷（15/16）。

## 版本

`desktop/package.json` 0.11.1 → **0.12.0**。大版本，走全量安装包，不吃补丁通道。

## 验证

| 项 | 结果 |
|---|---|
| backend `mvn test` | 1088 通过（含新增 2 例） |
| desktop `npm test` | 34 通过 |
| frontend `check:emits` + `build:h5` | 通过 |
| `npm run test:app-e2e` | 104 步全通过（与基线一致） |
| 首启链真人模拟（launch → 解锁门 → 向导） | 7 步全通过 |

首启链真人模拟覆盖：全新库解锁后**确实进了向导**、平台通道可点选、空 Key 内联提示、坏 Key 走后端内联报错且不跳登录页、未连接时提交被拦并指出下一步、改选 Ollama 可完成设置。

**已知（非本次回归）**：`test:desktop-e2e` 在本 worktree 的「新建 Word 文档」一步失败；stash 掉本次改动后在同一环境复现同样失败，浏览器目标下同一按钮建档正常——判定为该套件在 Electron 目标下的环境/驱动问题，另行跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)