### PR TITLE
feat: per-user 平台 AI key（server 模式多租户计费隔离）

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -64,8 +64,11 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `backend/src/main/java/com/checkba/service/storage/StorageLocationService.java` + `controller/StorageLocationController.java` — 自选存储位置（需 `stage.unlimited`；GET 与 reset 不设权益闸）。
 
 **平台 AI 通道与计费（PR-B，编排侧见 ai-chat.md）**
-- `backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java` — 取 provisioned OpenRouter key，缓存 `~/.aiworkdeck/platform-ai-key.json`（0600），`keyFingerprint()` 供模型实例缓存失效。
-- `service/ai/PlatformUsageAccountant.java` — 平台通道真实扣费对账（`GET https://openrouter.ai/api/v1/key` 累计消费差分）。
+- `backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java` — **取 key 的唯一路由出口**。
+  机器级路径（缓存 `~/.aiworkdeck/platform-ai-key.json`，0600）与 per-user 路径在这里分叉，
+  `keyFingerprint()` 供模型实例缓存失效。
+- `service/ai/PlatformUsageAccountant.java` — 平台通道真实扣费对账（`GET https://openrouter.ai/api/v1/key` 累计消费差分），
+  基线按**密钥指纹**分桶、worker 按指纹分片；兼做吊销探测（401/403 即作废本地密钥）。
 - `service/ai/ChatModelFactory.java` — `Provider.AWD_CLOUD` 路由；`demotePlatformProvider()` 在断开账户时把供应商降级回落。
 - `model/entity/TokenUsage.java` 的 `costSource`：`platform`（真实扣费）/ `estimate`（BYOK 单价表估算）。
 - 前端选平台通道有**两个**入口，判据必须一致（已连接账户 + 已分配额度，缺哪个都展示但不可选并给下一步）：
@@ -79,9 +82,27 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 
 **server 模式加固（插件云后端，2026-08-06）**
 - `backend/src/main/java/com/checkba/service/AuthAbuseGuard.java` — 注册闸（`security.registration-mode: open|closed`，默认 open）+ 登录失败锁定（IP+用户名 5 次失败锁 10 分钟）+ 注册按 IP 限频（10/小时）。进程内内存计数，**多实例部署必须前置 nginx limit_req**；local-mode 全部旁路。
-- `backend/src/main/java/com/checkba/service/account/AwdkLoginService.java` — `POST /api/auth/awdk-login`（匿名端点，AuthController）：awdk_ Key 调官网 `/api/account/me` 实时校验 → `account_binding` 映射（键是官网稳定 `accountId`，**官网侧尚未实施该字段**，见本仓 `doc/desktop-contract.md`）→ 首登 `UserService.registerExternal` 建无密码用户（`awd_` 前缀）→ `DeviceTokenService.issue` 签发 awdt_。开关 `security.awdk-login-enabled` 默认 false。
+- `backend/src/main/java/com/checkba/service/account/AwdkLoginService.java` — `POST /api/auth/awdk-login`（匿名端点，AuthController）：awdk_ Key 调官网 `/api/account/me` 实时校验 → `account_binding` 映射（键是官网稳定 `accountId`，官网侧已实施并进了权威契约与 contract-check）→ 首登 `UserService.registerExternal` 建无密码用户（`awd_` 前缀）→ `DeviceTokenService.issue` 签发 awdt_ → **顺手为该用户取一把 per-user 平台 AI key**（`PlatformAiKeyService.tryProvision`，失败绝不拖垮桥接）。开关 `security.awdk-login-enabled` 默认 false。
 - `backend/src/main/java/com/checkba/service/account/MachineAccountGuard.java` — server 模式下 `AccountController` 全部端点与 `GET /api/entitlements` 仅 admin 可用（账户连接/权益缓存是机器级状态，普通租户 disconnect 一下全服平台 AI 通道就断）；local-mode 恒放行一字不动。
 - `model/entity/AccountBinding.java` + `repository/AccountBindingRepository.java` — 官网账户 → server 用户映射表；awdk_ 明文**不落库**（每次桥接重验官网）。
+
+**per-user 平台 AI key（2026-08-07，多租户计费隔离）**
+- 设计文档 `docs/superpowers/specs/2026-08-07-per-user-platform-ai-key.md`（含三方案的安全边界比较与已确认决策）。
+- `service/ai/PlatformAiKeyService.java` — **per-user 密钥的唯一出口**：`resolve/provision/tryProvision/refresh/evict/markVerified/status`。
+  `isBound()`（该用户有 `account_binding`）与 `multiTenant()`（本实例存在任一绑定）是两条路由判据。
+- `service/ai/PlatformAiKeyCipher.java` — AES-256-GCM 落库加密，密文形态 `v1:iv:tag:cipher`
+  与官网仓 `lib/openrouter-keys.ts` **逐字对齐**；构造器里带**启动强不变式**（见地雷 15）。
+- `model/entity/PlatformAiKey.java` + `repository/PlatformAiKeyRepository.java` — 每用户至多一行，
+  存密文 + 指纹 + limitUsd + fetchedAt/lastVerifiedAt。**刻意不挂在 `account_binding` 上**：
+  那张表是纯身份映射且每次桥接都要读，塞密文会改变它的安全等级。
+- `service/ai/PlatformAiUserScope.java` — 「这次调用花谁的额度」的线程作用域。
+  设置点共 8 处（编排器入口、标题生成 runAsync、AiChatService、MemoryPipelineService、
+  SubAgentService.dispatch、MatterClassifierService、AutoTaggingService、PPT 生成 runAsync），
+  **跨线程提交必须 `wrap`**。
+- `controller/PlatformAiKeyController.java` — `/api/platform-ai/key/{status,refresh}`，
+  **会话级不是机器级**（不走 `MachineAccountGuard`——那道闸管的是整台服务器的账户连接）。
+- 插件侧：`office-addin/taskpane/components/SettingsView.vue` 的「AI 额度」卡片
+  + `taskpane/lib/api.js` 的 `fetchPlatformAiStatus` / `refreshPlatformAiKey`。
 
 **登录二次验证的判定出口（2026-08-07）**
 - `backend/src/main/java/com/checkba/service/auth/SecondFactorService.java` — **`required(user)` 是唯一判定出口**，
@@ -132,6 +153,8 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `ai.account.base-url`（`application.yml:97-98`，默认 `https://www.aiworkdeck.com`；**强制 https**，回环 http 例外供本地联调）。
 - `security.license.dir`（默认 `${user.home}/.aiworkdeck`）——license/account/entitlements/platform-ai-key/storage-location 五个状态文件都落这里。
 - `security.registration-mode`（默认 open）与 `security.awdk-login-enabled`(默认 false)——两者都只影响 server 模式；官方托管的插件云后端应配 closed + true。
+- `security.platform-key-secret`（`AWD_PLATFORM_KEY_SECRET`，默认空）——per-user 平台密钥的落库加密密钥。
+  **`awdk-login-enabled=true` 时必配，缺失直接拒绝启动**（见地雷 15）。
 - `sms.enabled`（`SMS_AUTH_ENABLED`，默认 false）——大陆短信通道开关，仅 server 模式生效；官方托管的插件云后端应配 true + 注入 AK/SK 环境变量。
 - `sms.intl.enabled`（`SMS_INTL_ENABLED`，默认 false）+ `TWILIO_ACCOUNT_SID/AUTH_TOKEN/MESSAGING_SERVICE_SID`——境外短信通道。
   **认证器（TOTP）不需要任何配置**，server 模式恒可用，是国际用户的推荐路径。
@@ -311,6 +334,20 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
     时自动预选平台通道——用账户 Key 解锁的人买的就是这条通道，不该再被引导去配别家的 Key。
     向导提交前的空值拦截在 `handleSubmit`，后端 `WizardController` 也拒空 `activeProvider`（两道都在才算数）。
 
+15. **平台通道的 key 是「谁的额度」，多租户下缺身份必须报错而不是回落**。
+    OpenRouter 的额度上限是 per-key 的，一把机器级 key 就是一个共享额度池——回落等于拿别人的钱花，
+    且对账差分会把 A 的消费记到 B 头上。`PlatformAiChannel.resolveOrThrow` 的四分支要背下来：
+    local-mode 恒走机器级（**一字不动**）；server + 已桥接 → per-user；
+    server + **本实例存在任一绑定**（`multiTenant()`）时，未桥接用户与缺身份**一律拒绝**；
+    server + 一个绑定都没有的团队服务器 → 机器级路径与改动前逐字一致。
+    第三条用 `multiTenant()` 而不是「非 local-mode」来收口，是为了让没人桥接的团队服务器
+    不会因为某处漏传身份就被打断——严格判据只落在真正的多租户实例上。
+    身份靠 `PlatformAiUserScope`（ThreadLocal），**池线程不会自动继承**（继承的是创建者而非提交者），
+    每个跨线程提交点都要 `wrap`；漏一处的后果被设计成「那条路报错」而不是「那条路记错账」。
+    新增 AI 入口（新的 @Async / executor.submit / runAsync）时必须一并接上，否则多租户下那条路取不到 key。
+    另外 `security.platform-key-secret` 在 `awdk-login-enabled=true` 时**缺失即拒绝启动**
+    （`PlatformAiKeyCipher` 构造器）——明文降级是典型的潜伏逃生门，这里刻意不留。
+
 ## 验证
 
 - 后端：`cd backend && mvn test`（**JDK 21，系统默认 25 会 SIGBUS**）。本领域相关用例：
@@ -324,7 +361,10 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
   `config/LocalModeAccessFilterTest`、`config/LocalModeLoopbackGuardTest`；
   server 模式加固：`service/AuthAbuseGuardTest`、`service/account/AwdkLoginServiceTest`、
   `service/account/MachineAccountGuardTest`、`controller/AuthControllerHardeningTest`、
-  `controller/AccountControllerMachineScopeTest`、`service/UserServiceTest`（无密码账户分支）。
+  `controller/AccountControllerMachineScopeTest`、`service/UserServiceTest`（无密码账户分支）；
+  per-user 平台密钥：`service/ai/PlatformAiKeyCipherTest`、`service/ai/PlatformAiKeyServiceTest`、
+  `service/ai/PlatformAiChannelRoutingTest`（四种形态的取 key 路由）、
+  `service/ai/PlatformAiUserScopeTest`、`controller/PlatformAiKeyControllerTest`。
 - 前端：`cd frontend && npm run check:emits` + `npm run build:h5`。
 - 端到端（同样在 `frontend/` 下跑）：`cd frontend && npm run test:app-e2e`
   （**J1 就是首启解锁门旅程**，用试用码解锁；其余旅程 local-mode 免登直达）。

--- a/backend/src/main/java/com/checkba/controller/PlatformAiKeyController.java
+++ b/backend/src/main/java/com/checkba/controller/PlatformAiKeyController.java
@@ -1,0 +1,88 @@
+package com.checkba.controller;
+
+import com.checkba.service.account.AccountException;
+import com.checkba.service.ai.PlatformAiKeyService;
+import com.checkba.service.ai.PlatformUsageAccountant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 按用户的平台 AI 通道额度（server 模式多租户）。
+ *
+ * <ul>
+ *   <li>GET  /api/platform-ai/key/status   本账号的额度概览（上限/已用/剩余/最近验证）</li>
+ *   <li>POST /api/platform-ai/key/refresh  {"key":"awdk_..."} 重新取一把 runtime key</li>
+ * </ul>
+ *
+ * <p><b>会话级，不是机器级</b>：这里描述的是「我这个账号自己的额度」，
+ * 因此不走 {@code MachineAccountGuard} 的 admin 闸——那道闸管的是
+ * {@code account.json}/{@code entitlements.json} 这类整台服务器的连接状态。
+ *
+ * <p>刷新路径存在的理由：用户在官网分配额度或重发密钥之后，server 手里没有 awdk_ 可以重取
+ * （明文不落库）。不复用 awdk-login 做刷新是因为那条路每次都会多签发一枚 awdt_ 设备令牌。
+ *
+ * <p>密钥明文<b>不出后端</b>：status 只回掩码与数字。
+ * 失败文案不含「登录」「未授权」「请先」子串（前端据此判定掉线，licensing 领域地雷 1）。
+ */
+@RestController
+@RequestMapping("/api/platform-ai/key")
+@Slf4j
+public class PlatformAiKeyController {
+
+    private final PlatformAiKeyService platformAiKeyService;
+    private final PlatformUsageAccountant platformUsageAccountant;
+
+    public PlatformAiKeyController(PlatformAiKeyService platformAiKeyService,
+                                   PlatformUsageAccountant platformUsageAccountant) {
+        this.platformAiKeyService = platformAiKeyService;
+        this.platformUsageAccountant = platformUsageAccountant;
+    }
+
+    @GetMapping("/status")
+    public Map<String, Object> status(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        return ok(platformAiKeyService.status(userId, platformUsageAccountant));
+    }
+
+    @PostMapping("/refresh")
+    public Map<String, Object> refresh(
+            @RequestBody(required = false) Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        platformAiKeyService.refresh(userId, body == null ? null : body.get("key"));
+        // 换了 key 就等于换了额度池，旧指纹的对账基线必须作废
+        platformUsageAccountant.resetBaseline();
+        return ok(platformAiKeyService.status(userId, platformUsageAccountant));
+    }
+
+    private Long requireUser(String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            // 会话缺失是真的掉线，这里就该触发前端重新认证
+            throw new IllegalArgumentException("未登录");
+        }
+        return userId;
+    }
+
+    @ExceptionHandler(AccountException.class)
+    public ResponseEntity<Map<String, Object>> handleAccountException(AccountException e) {
+        log.warn("平台 AI 通道额度操作失败 [{}]: {}", e.getKind(), e.getMessage());
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("kind", e.getKind().name());
+        result.put("message", e.getMessage());
+        return ResponseEntity.ok(result);
+    }
+
+    private static Map<String, Object> ok(Object data) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        result.put("data", data);
+        return result;
+    }
+}

--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -253,20 +253,21 @@ public class AiAgentController {
         final Long effectiveUserId = userId;
         
         // Asynchronous execution via PptxTools (which handles background task creation internally)
-        java.util.concurrent.CompletableFuture.runAsync(() -> {
-            pptxTools.performPptGenerationWithProgress(
-                request.getTopic(),
-                request.getProjectId(),
-                request.getParentId(),
-                request.getFileName(),
-                request.getStyle(),
-                request.getLanguage(),
-                request.getModelId(),
-                request.getConversationId(),
-                effectiveUserId,
-                request.isExportEditable()
-            );
-        });
+        // 平台通道按用户计费：后台线程上显式建立身份作用域，否则多租户下取不到 key
+        java.util.concurrent.CompletableFuture.runAsync(() ->
+            com.checkba.service.ai.PlatformAiUserScope.run(effectiveUserId, () ->
+                pptxTools.performPptGenerationWithProgress(
+                    request.getTopic(),
+                    request.getProjectId(),
+                    request.getParentId(),
+                    request.getFileName(),
+                    request.getStyle(),
+                    request.getLanguage(),
+                    request.getModelId(),
+                    request.getConversationId(),
+                    effectiveUserId,
+                    request.isExportEditable()
+                )));
         
         return ResponseEntity.ok().body("{\"status\":\"ok\", \"message\":\"PPT generation started\"}");
     }

--- a/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiChatController.java
@@ -187,15 +187,19 @@ public class AiChatController {
      * Get public AI configuration (e.g. active provider) for all users
      */
     @GetMapping("/config")
-    public ResponseEntity<?> getAiConfig() {
+    public ResponseEntity<?> getAiConfig(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         String activeProvider = systemSettingService.get("ai.activeProvider",
                 aiModelProperties.getProvider() != null ? aiModelProperties.getProvider().name() : "OLLAMA");
 
         // Return a simple map or DTO
         Map<String, Object> config = new java.util.HashMap<>();
         config.put("activeProvider", activeProvider);
-        // 平台通道「AI Workdeck 云端」是否可选：未连接官网账户时前端不展示该供应商
-        config.put("platformAiAvailable", platformAiChannel.isAvailable());
+        // 平台通道「AI Workdeck 云端」是否可选：未连接官网账户时前端不展示该供应商。
+        // server 模式多租户下密钥是 per-user 的，判据也必须按人算——机器级的答案会
+        // 让没直连账户的租户看到一个选了就报错的供应商。
+        config.put("platformAiAvailable",
+                platformAiChannel.availableFor(AuthController.getUserIdFromSession(sessionId)));
         return ResponseEntity.ok(config);
     }
 

--- a/backend/src/main/java/com/checkba/model/entity/PlatformAiKey.java
+++ b/backend/src/main/java/com/checkba/model/entity/PlatformAiKey.java
@@ -1,0 +1,55 @@
+package com.checkba.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * 每用户一把的平台 AI 通道密钥（server 模式多租户）。
+ *
+ * <p>为什么不挂在 {@link AccountBinding} 上：那张表是纯身份映射、每次桥接登录都要读，
+ * 把密文塞进去会改变它的安全等级；分表还让「吊销即删行」不碰身份数据。
+ *
+ * <p>{@code keyEnc} 是 OpenRouter runtime key 明文的 AES-256-GCM 密文
+ * （{@link com.checkba.service.ai.PlatformAiKeyCipher}）。awdk_ 账户 Key 明文
+ * <b>永不落库</b>——本表存的是它换来的、额度受 OpenRouter 侧 limit 强制的 runtime key。
+ */
+@Entity
+@Table(name = "platform_ai_key",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"userId"}))
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class PlatformAiKey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 密文，格式 v1:<ivB64>:<tagB64>:<cipherB64>。 */
+    @Column(nullable = false, length = 1024)
+    private String keyEnc;
+
+    /** SHA-256(明文) 前 12 位十六进制：模型实例缓存键与对账 baseline 的分桶键。 */
+    @Column(nullable = false, length = 32)
+    private String keyFingerprint;
+
+    /** 官网返回的额度上限（美元），展示用；官网未给时为 null。 */
+    private Double limitUsd;
+
+    @Column(nullable = false)
+    private LocalDateTime fetchedAt;
+
+    /**
+     * 最近一次向 OpenRouter 验证成功的时间。超过 30 天未成功验证即判为过期
+     * （与 EntitlementService/LicenseService 的 OFFLINE_GRACE 同口径：
+     * 永久离线不能等于永久可用）。
+     */
+    @Column(nullable = false)
+    private LocalDateTime lastVerifiedAt;
+}

--- a/backend/src/main/java/com/checkba/repository/AccountBindingRepository.java
+++ b/backend/src/main/java/com/checkba/repository/AccountBindingRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface AccountBindingRepository extends JpaRepository<AccountBinding, Long> {
     Optional<AccountBinding> findByExternalAccountId(String externalAccountId);
+
+    Optional<AccountBinding> findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/checkba/repository/PlatformAiKeyRepository.java
+++ b/backend/src/main/java/com/checkba/repository/PlatformAiKeyRepository.java
@@ -1,0 +1,11 @@
+package com.checkba.repository;
+
+import com.checkba.model.entity.PlatformAiKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlatformAiKeyRepository extends JpaRepository<PlatformAiKey, Long> {
+
+    Optional<PlatformAiKey> findByUserId(Long userId);
+}

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -140,6 +140,16 @@ public class AccountService {
     }
 
     /**
+     * GET /api/account/me，用调用方给定的 awdk_（不是本机连接的那把）。
+     *
+     * 供 server 模式下「代表某个已桥接用户校验其 Key」使用：Key 由调用方短暂持有、用完即弃，
+     * <b>不会落到 account.json，也不会落库</b>。
+     */
+    public Map<String, Object> fetchProfileWith(String awdkKey) {
+        return getJson("/api/account/me", awdkKey);
+    }
+
+    /**
      * GET /api/account/entitlements。
      * 契约返回 {@code {"entitlements":[{feature, purchasedAt, orderId}]}}。
      */
@@ -180,7 +190,17 @@ public class AccountService {
      * @throws AccountException CONFLICT（409 no_allocation：还没从余额分配 AI 额度）
      */
     public Map<String, Object> fetchAiKey() {
-        String key = requireKey();
+        return fetchAiKeyWith(requireKey());
+    }
+
+    /**
+     * 同 {@link #fetchAiKey()}，但用调用方给定的 awdk_。
+     *
+     * server 模式的 per-user 平台通道走这条：桥接登录/显式刷新时短暂持有该用户的 Key，
+     * 换回属于他自己的 runtime key，Key 本身用完即弃（见 {@code PlatformAiKeyService}）。
+     */
+    public Map<String, Object> fetchAiKeyWith(String awdkKey) {
+        String key = awdkKey;
         AccountTransport.Reply reply = transport.send("POST", baseUrl + "/api/account/ai-key", key, "{}");
         if (reply.networkFailure()) {
             throw networkError();

--- a/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
+++ b/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
@@ -55,6 +55,7 @@ public class AwdkLoginService {
     private final AccountBindingRepository bindingRepository;
     private final UserService userService;
     private final DeviceTokenService deviceTokenService;
+    private final com.checkba.service.ai.PlatformAiKeyService platformAiKeyService;
     private final ObjectMapper objectMapper = AccountService.stateMapper();
 
     public AwdkLoginService(
@@ -63,7 +64,8 @@ public class AwdkLoginService {
             AccountTransport transport,
             AccountBindingRepository bindingRepository,
             UserService userService,
-            DeviceTokenService deviceTokenService) {
+            DeviceTokenService deviceTokenService,
+            com.checkba.service.ai.PlatformAiKeyService platformAiKeyService) {
         this.enabled = enabled;
         // 与 LicenseService / AccountService 共用同一条红线（https，回环 http 例外）
         this.baseUrl = AccountEndpoint.requireSecure(baseUrl);
@@ -71,6 +73,7 @@ public class AwdkLoginService {
         this.bindingRepository = bindingRepository;
         this.userService = userService;
         this.deviceTokenService = deviceTokenService;
+        this.platformAiKeyService = platformAiKeyService;
     }
 
     /** 桥接结果：awdt_ 设备令牌 + 映射到的 server 用户。 */
@@ -97,6 +100,10 @@ public class AwdkLoginService {
         }
 
         User user = resolveUser(accountId, str(me.get("username")), str(me.get("displayName")));
+        // per-user 平台 AI key：此刻是 server 唯一合法持有该用户 awdk_ 的时机，顺手换一把
+        // 属于他自己的 OpenRouter runtime key 存起来；awdk_ 本身用完即弃，仍然不落库。
+        // 取不到（最常见是还没分配额度）绝不影响桥接——插件的绝大多数能力与 AI 额度无关。
+        platformAiKeyService.tryProvision(user.getId(), key);
         DeviceTokenService.IssuedToken issued =
                 deviceTokenService.issue(user.getId(), "账户桥接");
         return new BridgeSession(issued.plaintext(), user.getId(), user.getUsername());

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -331,6 +331,13 @@ public class AgentOrchestrator {
      */
     @Async("taskExecutor") // Run in separate thread
     public void handleUserMessage(AiAgentController.AgentChatRequest request, Long userId) {
+        // 平台通道按用户计费（server 模式多租户）：整轮循环——含其中同步调用的上下文组装、
+        // 记忆检索、子 Agent、故障转移换模型——都在这个身份作用域内取 key。
+        // 本方法体里另有跨线程提交（标题生成），必须各自用 PlatformAiUserScope.wrap 重放。
+        PlatformAiUserScope.run(userId, () -> handleUserMessageInScope(request, userId));
+    }
+
+    private void handleUserMessageInScope(AiAgentController.AgentChatRequest request, Long userId) {
         String conversationId = request.getConversationId();
         String projectId = String.valueOf(request.getProjectId());
         AgentMode agentMode = request.getAgentMode(); // 获取 Agent 模式
@@ -365,7 +372,8 @@ public class AgentOrchestrator {
             if (existingMsgs.size() <= 1) { // Only the user message we just saved
                 final String convId = conversationId;
                 final String userMsg = request.getMessage();
-                CompletableFuture.runAsync(() -> {
+                // 跨线程提交：身份不会自动传递（池线程继承的是创建者而非提交者），显式重放
+                CompletableFuture.runAsync(PlatformAiUserScope.wrap(() -> {
                     try {
                         log.info("Generating conversation title for: {}", convId);
                         // Use a lightweight model for title generation
@@ -378,7 +386,7 @@ public class AgentOrchestrator {
                     } catch (Exception e) {
                         log.warn("Failed to generate conversation title for {}", convId, e);
                     }
-                });
+                }));
             }
             
             // 1.2 Skill 激活（Phase 3B）：用户钉选优先，否则触发词匹配；都未命中时行为与现状一致

--- a/backend/src/main/java/com/checkba/service/ai/AiChatService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AiChatService.java
@@ -71,6 +71,11 @@ public class AiChatService {
      * 处理一次同步 chat 请求（含多模态与上下文注入）。
      */
     public AiChatResponse chat(AiChatRequest request, Long userId) {
+        // 平台通道按用户计费：整条同步链路都在该身份作用域内取 key
+        return PlatformAiUserScope.call(userId, () -> chatInScope(request, userId));
+    }
+
+    private AiChatResponse chatInScope(AiChatRequest request, Long userId) {
         try {
             ProjectContextHolder.setProjectId(request.getProjectId());
 

--- a/backend/src/main/java/com/checkba/service/ai/AutoTaggingService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AutoTaggingService.java
@@ -34,6 +34,11 @@ public class AutoTaggingService {
      * Automatically generate and attach tags to a file based on its content.
      */
     public void autoTagFile(Long projectId, Long fileId, String storagePath, Long userId) {
+        // 平台通道按用户计费：这次 LLM 调用要落在上传者本人的额度上
+        PlatformAiUserScope.run(userId, () -> autoTagFileInScope(projectId, fileId, storagePath, userId));
+    }
+
+    private void autoTagFileInScope(Long projectId, Long fileId, String storagePath, Long userId) {
         log.info("Starting auto-tagging for fileId={}, path={}", fileId, storagePath);
         try {
             // 1. Extract text

--- a/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
+++ b/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
@@ -37,8 +37,24 @@ public class ChatModelFactory {
                 "streaming", streaming));
     }
 
-    // 缓存: key = provider + ":" + modelName
-    private final Map<String, ChatLanguageModel> modelCache = new ConcurrentHashMap<>();
+    /**
+     * 缓存上限。平台通道的缓存键含密钥指纹，per-user 化之后条目数从 O(模型数) 变成
+     * O(用户数×模型数)——多租户下无界 Map 就是内存泄漏，这里按访问顺序淘汰。
+     */
+    private static final int MODEL_CACHE_MAX = 64;
+
+    private static <V> Map<String, V> boundedCache() {
+        return java.util.Collections.synchronizedMap(
+                new java.util.LinkedHashMap<>(16, 0.75f, true) {
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<String, V> eldest) {
+                        return size() > MODEL_CACHE_MAX;
+                    }
+                });
+    }
+
+    // 缓存: key = provider + ":" + modelName（平台通道另含密钥指纹）
+    private final Map<String, ChatLanguageModel> modelCache = boundedCache();
 
     /**
      * 解析当前生效的供应商：优先读管理后台/向导写入 system_setting 的 ai.activeProvider，
@@ -171,17 +187,16 @@ public class ChatModelFactory {
     /**
      * 平台通道密钥由官网 provision，取不到时**不能**静默回退 BYOK：
      * 那会把用户自己的 key 花掉，也会掩盖「未分配额度」这类需要用户去官网处理的状态。
-     * 这里原样抛出 AccountException（中文文案，如「请先在官网账户页分配 AI 额度」）。
+     * 这里原样抛出 AccountException（中文文案）。
+     *
+     * <p>server 模式多租户下密钥是 per-user 的，身份取自 {@link PlatformAiUserScope}；
+     * 缺身份同样抛业务错误，**绝不回落机器级 key**（那等于拿别人的额度花钱）。
      */
     private String platformApiKey() {
-        if (!platformAiChannel.isAvailable()) {
-            throw new com.checkba.service.account.AccountException(
-                    com.checkba.service.account.AccountException.Kind.NOT_CONNECTED,
-                    "「AI Workdeck 云端」需要连接账户，请到设置页粘贴账户 Key");
-        }
+        Long userId = PlatformAiUserScope.current();
         String key = platformAiChannel.apiKey();
         // 请求发出前先把用量基线建起来，否则重启后第一条消息只够建基线、cost 永远留空
-        usageAccountant.ensureBaselineAsync();
+        usageAccountant.ensureBaselineAsync(userId);
         return key;
     }
 
@@ -196,6 +211,12 @@ public class ChatModelFactory {
         String active = systemSettingService.get("ai.activeProvider", null);
         if (active == null
                 || !AiModelProperties.Provider.AWD_CLOUD.name().equalsIgnoreCase(active.trim())) {
+            return null;
+        }
+        // server 模式多租户：ai.activeProvider 是全局设置，而平台通道的密钥是 per-user 的。
+        // 管理员断开机器级账户不该把还在正常用 per-user 密钥的租户一起打断。
+        if (platformAiChannel.hasPerUserKeys()) {
+            log.info("机器级账户已断开，但仍有按用户的平台通道密钥在用，保持 AWD_CLOUD 不降级");
             return null;
         }
         String next;
@@ -290,7 +311,7 @@ public class ChatModelFactory {
         });
     }
     // Streaming Cache
-    private final Map<String, dev.langchain4j.model.chat.StreamingChatLanguageModel> streamingModelCache = new ConcurrentHashMap<>();
+    private final Map<String, dev.langchain4j.model.chat.StreamingChatLanguageModel> streamingModelCache = boundedCache();
 
     public dev.langchain4j.model.chat.StreamingChatLanguageModel getStreamingChatModel(String modelId) {
         String targetModel = (modelId == null || modelId.isEmpty()) ? "default" : modelId;

--- a/backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformAiChannel.java
@@ -26,12 +26,23 @@ import java.util.Map;
  * 缓存只是省一次往返；官网撤销重发后本地 clearCache 即可重新拉取。
  *
  * 未连接账户时该通道不可用（{@link #isAvailable()} 为 false，前端据此不展示为可选供应商）。
+ *
+ * <h3>server 模式多租户（2026-08-07）</h3>
+ * 上面描述的是<b>机器级</b>路径，local-mode 与未桥接的团队服务器成员继续走它，行为逐字不变。
+ * server 模式下<b>已桥接</b>（存在 account_binding）的用户改走 per-user 库记录
+ * （{@link PlatformAiKeyService}）：OpenRouter 的额度上限是 per-key 的，一把机器级 key
+ * 等于一个共享额度池，A 能把 B 的额度花光，且对账差分会把 A 的消费记到 B 头上。
+ *
+ * <p>身份从 {@link PlatformAiUserScope} 取。多租户形态下缺身份一律拒绝，
+ * <b>绝不回落机器级 key</b>——错账是静默的，报错是能被测试抓到的。
  */
 @Service
 @Slf4j
 public class PlatformAiChannel {
 
     private final AccountService accountService;
+    private final PlatformAiKeyService perUser;
+    private final boolean localMode;
     private final Path keyFile;
     // 解析失败的异常 message 不许带原文——这个文件里是 provision 出来的 OpenRouter 明文密钥
     private final ObjectMapper objectMapper = AccountService.stateMapper();
@@ -40,8 +51,12 @@ public class PlatformAiChannel {
 
     public PlatformAiChannel(
             AccountService accountService,
+            PlatformAiKeyService perUser,
+            @Value("${security.local-mode:false}") boolean localMode,
             @Value("${security.license.dir:${user.home}/.aiworkdeck}") String stateDir) {
         this.accountService = accountService;
+        this.perUser = perUser;
+        this.localMode = localMode;
         this.keyFile = Path.of(stateDir, "platform-ai-key.json");
     }
 
@@ -53,23 +68,28 @@ public class PlatformAiChannel {
         public String fetchedAt;
     }
 
-    /** 账户已连接才可能有平台通道。不发网络请求。 */
+    /** 机器级通道是否可用（账户已连接）。不发网络请求。AccountController 的机器级视图用它。 */
     public boolean isAvailable() {
         return accountService.isConnected();
     }
 
-    /**
-     * 取平台通道密钥：内存缓存 → 磁盘缓存 → 向官网请求。
-     *
-     * @throws AccountException NOT_CONNECTED（未连接账户）/ CONFLICT（未分配 AI 额度）/ NETWORK
-     */
-    public String apiKey() {
-        Cached cached = current();
-        if (cached != null) return cached.openrouterKey;
-        return fetch().openrouterKey;
+    /** 指定用户视角下平台通道是否可用（前端「可选供应商」判据）。不发网络请求。 */
+    public boolean availableFor(Long userId) {
+        if (perUserApplies(userId)) return perUser.resolve(userId).isPresent();
+        if (strictMultiTenant()) return false;
+        return accountService.isConnected();
     }
 
-    /** 当前额度上限（美元）；未取到返回 null。不触发网络请求。 */
+    /**
+     * 取当前身份的平台通道密钥。
+     *
+     * @throws AccountException NOT_CONNECTED / CONFLICT（未分配额度、未直连、缺身份）/ NETWORK
+     */
+    public String apiKey() {
+        return resolveOrThrow(PlatformAiUserScope.current()).apiKey();
+    }
+
+    /** 当前额度上限（美元）；未取到返回 null。不触发网络请求。机器级视图专用。 */
     public Double limitUsd() {
         Cached cached = current();
         return cached == null ? null : cached.limitUsd;
@@ -77,9 +97,90 @@ public class PlatformAiChannel {
 
     /**
      * 模型实例缓存用的密钥指纹。key 换了指纹就变，
-     * {@link ChatModelFactory} 因此不会把旧 key 建的模型实例一直用到进程重启。
+     * {@link ChatModelFactory} 因此不会把旧 key 建的模型实例一直用到进程重启；
+     * per-user 化之后不同用户指纹不同，模型实例天然按用户分叉，不会串用。
      */
     public String keyFingerprint() {
+        Long userId = PlatformAiUserScope.current();
+        if (perUserApplies(userId)) {
+            String fingerprint = perUser.fingerprintOrNull(userId);
+            return fingerprint == null ? "none" : fingerprint;
+        }
+        return machineFingerprint();
+    }
+
+    /**
+     * 给定用户的密钥与指纹，不依赖线程作用域——对账 worker 在自己的线程上跑，用这个。
+     * 取不到返回 null（对账拿不到 key 只是跳过，不该抛）。
+     */
+    public PlatformAiKeyService.Resolved resolveFor(Long userId) {
+        try {
+            return resolveOrThrow(userId);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * OpenRouter 明确拒绝（401/403）：这把 key 已被官网侧吊销或重发，本地这份立刻作废。
+     * 与「官网明确拒绝 → 立刻清缓存、不吃宽限」同源；网络不可达绝不走这条。
+     */
+    public void onKeyRejected(Long userId) {
+        if (perUserApplies(userId)) {
+            perUser.evict(userId);
+            return;
+        }
+        clearCache();
+    }
+
+    /** 探针成功：刷新 30 天宽限的计时起点。 */
+    public void onKeyVerified(Long userId) {
+        if (perUserApplies(userId)) perUser.markVerified(userId);
+    }
+
+    /** 本实例上是否存在按用户的平台通道密钥（断开机器级账户时的降级判据）。 */
+    public boolean hasPerUserKeys() {
+        return !localMode && perUser.anyKeyExists();
+    }
+
+    // ==================== 路由 ====================
+
+    /** 已桥接的 server 用户走 per-user；local-mode 与未桥接成员走机器级。 */
+    private boolean perUserApplies(Long userId) {
+        return !localMode && userId != null && perUser.isBound(userId);
+    }
+
+    /** 多租户形态（本实例存在任一桥接绑定）下，机器级回落是禁止的。 */
+    private boolean strictMultiTenant() {
+        return !localMode && perUser.multiTenant();
+    }
+
+    private PlatformAiKeyService.Resolved resolveOrThrow(Long userId) {
+        if (perUserApplies(userId)) {
+            return perUser.resolve(userId).orElseThrow(() -> new AccountException(
+                    AccountException.Kind.CONFLICT,
+                    "本账号的「AI Workdeck 云端」额度尚未就绪，可在插件设置页用账户 Key 刷新额度"));
+        }
+        if (strictMultiTenant()) {
+            // 多租户实例上回落机器级 key = 拿别人的额度花钱，宁可报错
+            if (userId == null) {
+                throw new AccountException(AccountException.Kind.CONFLICT,
+                        "本次 AI 调用未携带用户身份，「AI Workdeck 云端」无法确定额度归属");
+            }
+            throw new AccountException(AccountException.Kind.CONFLICT,
+                    "本账号尚未通过账户 Key 完成直连，暂不能使用「AI Workdeck 云端」通道");
+        }
+        if (!accountService.isConnected()) {
+            throw new AccountException(AccountException.Kind.NOT_CONNECTED,
+                    "「AI Workdeck 云端」需要连接账户，请到设置页粘贴账户 Key");
+        }
+        Cached cached = current();
+        if (cached == null) cached = fetch();
+        return new PlatformAiKeyService.Resolved(
+                cached.openrouterKey, machineFingerprint(), cached.limitUsd);
+    }
+
+    private String machineFingerprint() {
         Cached cached = current();
         if (cached == null || cached.openrouterKey == null) return "none";
         try {

--- a/backend/src/main/java/com/checkba/service/ai/PlatformAiKeyCipher.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformAiKeyCipher.java
@@ -1,0 +1,124 @@
+package com.checkba.service.ai;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * per-user 平台 AI key 的落库加密（server 模式多租户）。
+ *
+ * <p>密文形态与官网仓 {@code lib/openrouter-keys.ts} <b>逐字对齐</b>：
+ * {@code v1:<ivB64>:<tagB64>:<cipherB64>}，AES-256-GCM，加密密钥 = SHA-256(secret)。
+ * 两侧同形态是刻意的——同一把 runtime key 在官网库与 server 库里长得一样，排查时不必换脑子。
+ *
+ * <p>GCM 的 tag 保证篡改即解密失败：DB 里被改过的密文不会解出一把「能用但不是你的」key。
+ *
+ * <p><b>启动强不变式</b>：{@code security.awdk-login-enabled=true}（官方托管的插件云后端形态）
+ * 时 secret 必须配置，否则拒绝启动。明文兜底属于「潜伏逃生门」——真出事时没人记得这里曾经
+ * 悄悄降级过。local-mode 与未开桥接的团队服务器不受影响：它们根本不走 per-user 路径。
+ */
+@Component
+public class PlatformAiKeyCipher {
+
+    private static final String VERSION = "v1";
+    private static final int IV_BYTES = 12;
+    private static final int TAG_BITS = 128;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final byte[] key;
+
+    public PlatformAiKeyCipher(
+            @Value("${security.platform-key-secret:}") String secret,
+            @Value("${security.awdk-login-enabled:false}") boolean awdkLoginEnabled) {
+        String trimmed = secret == null ? "" : secret.trim();
+        if (trimmed.isEmpty()) {
+            if (awdkLoginEnabled) {
+                throw new IllegalStateException(
+                        "开启账户桥接（security.awdk-login-enabled=true）时必须配置 "
+                                + "security.platform-key-secret（环境变量 AWD_PLATFORM_KEY_SECRET）："
+                                + "该密钥用于加密每个用户的平台 AI 通道密钥，缺失时拒绝以明文降级运行。");
+            }
+            this.key = null;
+            return;
+        }
+        this.key = sha256(trimmed);
+    }
+
+    /** 未配置 secret 时 per-user 存储整体不可用（调用方据此给业务错误，而不是明文降级）。 */
+    public boolean isConfigured() {
+        return key != null;
+    }
+
+    public String encrypt(String plaintext) {
+        requireConfigured();
+        try {
+            byte[] iv = new byte[IV_BYTES];
+            RANDOM.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(TAG_BITS, iv));
+            byte[] out = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+            // JCE 把 tag 附在密文尾部，这里拆开以对齐官网的三段式
+            int tagBytes = TAG_BITS / 8;
+            byte[] body = new byte[out.length - tagBytes];
+            byte[] tag = new byte[tagBytes];
+            System.arraycopy(out, 0, body, 0, body.length);
+            System.arraycopy(out, body.length, tag, 0, tagBytes);
+            Base64.Encoder b64 = Base64.getEncoder();
+            return String.join(":", VERSION, b64.encodeToString(iv), b64.encodeToString(tag), b64.encodeToString(body));
+        } catch (Exception e) {
+            // 异常 message 里绝不带明文（同 AccountService.stateMapper 的考虑）
+            throw new IllegalStateException("平台 AI 通道密钥加密失败");
+        }
+    }
+
+    /** 解密失败（密文损坏 / secret 换过 / 被篡改）一律抛错，调用方按「没有 key」降级。 */
+    public String decrypt(String encoded) {
+        requireConfigured();
+        String[] parts = encoded == null ? new String[0] : encoded.split(":");
+        if (parts.length != 4 || !VERSION.equals(parts[0])) {
+            throw new IllegalStateException("平台 AI 通道密钥密文格式不支持");
+        }
+        try {
+            Base64.Decoder b64 = Base64.getDecoder();
+            byte[] iv = b64.decode(parts[1]);
+            byte[] tag = b64.decode(parts[2]);
+            byte[] body = b64.decode(parts[3]);
+            byte[] joined = new byte[body.length + tag.length];
+            System.arraycopy(body, 0, joined, 0, body.length);
+            System.arraycopy(tag, 0, joined, body.length, tag.length);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(TAG_BITS, iv));
+            return new String(cipher.doFinal(joined), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("平台 AI 通道密钥解密失败");
+        }
+    }
+
+    /** 模型实例缓存与对账 baseline 的分桶键。key 换了指纹就变。 */
+    public static String fingerprint(String plaintextKey) {
+        byte[] digest = sha256(plaintextKey);
+        return java.util.HexFormat.of().formatHex(digest, 0, 6);
+    }
+
+    private void requireConfigured() {
+        if (key == null) {
+            throw new IllegalStateException("security.platform-key-secret 未配置");
+        }
+    }
+
+    private static byte[] sha256(String value) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 不可用", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PlatformAiKeyService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformAiKeyService.java
@@ -1,0 +1,243 @@
+package com.checkba.service.ai;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.PlatformAiKey;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.repository.PlatformAiKeyRepository;
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * per-user 平台 AI 通道密钥的取用与存储（server 模式多租户）。
+ *
+ * <h3>凭据模型</h3>
+ * awdk_ 账户 Key 明文<b>永不落库</b>。server 只在两个时刻短暂持有它——桥接登录、显式刷新——
+ * 用它向官网换一把该账户的 provisioned OpenRouter runtime key，加密存本表，awdk_ 用完即弃。
+ * 因此本库被拖走的后果被限定为「各 key 上的剩余额度」（额度由 OpenRouter 侧 limit 强制），
+ * 拿不到官网账户本身：读余额、同步权益、买广场付费项、签发新 key 全都要 awdk_。
+ *
+ * <h3>吊销与过期</h3>
+ * 用户在官网禁用/重发 runtime key → OpenRouter 侧立即失效 → 对账探针拿到 401/403 即
+ * {@link #evict} 删行（与「官网明确拒绝 → 立刻清缓存、不吃宽限」同源）。
+ * 网络不可达一律保留（服务器故障不等于凭据失效）。外层再由 {@link #OFFLINE_GRACE}
+ * 封顶：30 天没有一次成功验证即判过期，需走刷新——永久离线不能等于永久可用。
+ *
+ * <h3>生效范围</h3>
+ * 只有<b>已桥接</b>（存在 {@code account_binding}）的 server 用户走这条路。
+ * local-mode 与未桥接的团队服务器成员一律走 {@link PlatformAiChannel} 的机器级文件缓存，
+ * 行为与本次改动之前逐字一致。
+ */
+@Service
+@Slf4j
+public class PlatformAiKeyService {
+
+    /** 与 EntitlementService.OFFLINE_GRACE / LicenseService.OFFLINE_GRACE 同口径同值。 */
+    static final Duration OFFLINE_GRACE = Duration.ofDays(30);
+
+    private static final String KEY_PREFIX = "awdk_";
+
+    private final PlatformAiKeyRepository keyRepository;
+    private final AccountBindingRepository bindingRepository;
+    private final PlatformAiKeyCipher cipher;
+    private final AccountService accountService;
+
+    public PlatformAiKeyService(PlatformAiKeyRepository keyRepository,
+                                AccountBindingRepository bindingRepository,
+                                PlatformAiKeyCipher cipher,
+                                AccountService accountService) {
+        this.keyRepository = keyRepository;
+        this.bindingRepository = bindingRepository;
+        this.cipher = cipher;
+        this.accountService = accountService;
+    }
+
+    /** 解出来的可用密钥。 */
+    public record Resolved(String apiKey, String fingerprint, Double limitUsd) {}
+
+    // ==================== 判据 ====================
+
+    /** 该用户是否已通过账户 Key 完成桥接（有映射才可能有 per-user key）。 */
+    public boolean isBound(Long userId) {
+        return userId != null && bindingRepository.findByUserId(userId).isPresent();
+    }
+
+    /**
+     * 本实例是否是多租户形态（存在任一桥接绑定）。
+     *
+     * 用它把「缺身份即拒绝」的严格判据限定在真正的多租户部署上：一台谁都没桥接过的团队服务器
+     * 行为逐字不变，不会因为某处漏传身份就把机器级平台通道打断。
+     */
+    public boolean multiTenant() {
+        return bindingRepository.count() > 0;
+    }
+
+    /** 本实例上是否已经存在任一 per-user 密钥。 */
+    public boolean anyKeyExists() {
+        return keyRepository.count() > 0;
+    }
+
+    // ==================== 取用 ====================
+
+    /** 该用户当前可用的密钥；没有 / 解不开 / 已过期都返回空。不发网络请求。 */
+    public Optional<Resolved> resolve(Long userId) {
+        if (userId == null || !cipher.isConfigured()) return Optional.empty();
+        Optional<PlatformAiKey> row = keyRepository.findByUserId(userId);
+        if (row.isEmpty()) return Optional.empty();
+        PlatformAiKey entity = row.get();
+        if (isStale(entity)) return Optional.empty();
+        String plaintext;
+        try {
+            plaintext = cipher.decrypt(entity.getKeyEnc());
+        } catch (Exception e) {
+            // 不删行：secret 被换过/临时配错时删掉等于把全体用户的 key 静默清空，
+            // 而这类故障是可修复的（改回 secret 即恢复）。
+            log.warn("用户 {} 的平台 AI 通道密钥无法解密，按不可用处理: {}", userId, e.getMessage());
+            return Optional.empty();
+        }
+        return Optional.of(new Resolved(plaintext, entity.getKeyFingerprint(), entity.getLimitUsd()));
+    }
+
+    /** 仅取指纹（对账分桶用），不解密。过期同样视为没有。 */
+    public String fingerprintOrNull(Long userId) {
+        if (userId == null) return null;
+        return keyRepository.findByUserId(userId)
+                .filter(e -> !isStale(e))
+                .map(PlatformAiKey::getKeyFingerprint)
+                .orElse(null);
+    }
+
+    // ==================== 写入 ====================
+
+    /**
+     * 桥接登录时的「顺手取一把」：<b>任何失败都不得拖垮桥接</b>。
+     *
+     * 尤其 409 no_allocation 是常态（该账户还没从余额分配 AI 额度），
+     * 若据此拒绝桥接，用户会连插件都进不去——而插件绝大多数能力与 AI 额度无关。
+     */
+    public void tryProvision(Long userId, String awdkKey) {
+        try {
+            provision(userId, awdkKey);
+        } catch (AccountException e) {
+            log.info("桥接登录未能取得平台 AI 通道密钥（不影响桥接）userId={} kind={}: {}",
+                    userId, e.getKind(), e.getMessage());
+        } catch (Exception e) {
+            log.warn("桥接登录取平台 AI 通道密钥异常（不影响桥接）userId={}: {}", userId, e.getMessage());
+        }
+    }
+
+    /**
+     * 用 awdk_ 明文向官网换该账户的 runtime key 并加密入库（覆盖旧行）。
+     * awdk_ 用完即弃。
+     *
+     * @throws AccountException 官网侧的各类失败（NOT_CONNECTED 除外，此处必然带 Key）
+     */
+    public void provision(Long userId, String awdkKey) {
+        if (!cipher.isConfigured()) {
+            throw new AccountException(AccountException.Kind.CONFLICT,
+                    "本服务器未配置平台 AI 通道密钥的存储密钥，暂无法启用该通道");
+        }
+        Map<String, Object> body = accountService.fetchAiKeyWith(awdkKey);
+        String plaintext = String.valueOf(body.get("openrouterKey"));
+        Object limit = body.get("limitUsd");
+
+        PlatformAiKey entity = keyRepository.findByUserId(userId).orElseGet(PlatformAiKey::new);
+        entity.setUserId(userId);
+        entity.setKeyEnc(cipher.encrypt(plaintext));
+        entity.setKeyFingerprint(PlatformAiKeyCipher.fingerprint(plaintext));
+        entity.setLimitUsd(limit instanceof Number n ? n.doubleValue() : null);
+        LocalDateTime now = LocalDateTime.now();
+        entity.setFetchedAt(now);
+        entity.setLastVerifiedAt(now);
+        keyRepository.save(entity);
+        log.info("已为用户 {} 取得平台 AI 通道密钥（指纹 {}）", userId, entity.getKeyFingerprint());
+    }
+
+    /**
+     * 显式刷新：用户在官网分配额度/重发 key 之后，server 手里没有 awdk_ 可用来重取。
+     *
+     * <p>必须校验这枚 awdk_ 对应的官网 accountId 与当前会话用户的绑定一致——
+     * 否则 A 可以把 B 的 Key 贴进来，把 B 的额度装到自己名下用。
+     */
+    public void refresh(Long userId, String awdkKey) {
+        String key = awdkKey == null ? "" : awdkKey.trim();
+        if (key.isEmpty() || !key.startsWith(KEY_PREFIX)) {
+            throw new AccountException(AccountException.Kind.UNAUTHORIZED,
+                    "账户 Key 格式不正确，应以 awdk_ 开头（在官网账户页「桌面连接」生成）");
+        }
+        AccountBinding binding = bindingRepository.findByUserId(userId)
+                .orElseThrow(() -> new AccountException(AccountException.Kind.CONFLICT,
+                        "该账号尚未通过账户 Key 完成直连，无法刷新平台 AI 通道额度"));
+        Map<String, Object> me = accountService.fetchProfileWith(key);
+        Object accountId = me.get("accountId");
+        if (accountId == null || String.valueOf(accountId).isBlank()) {
+            throw new AccountException(AccountException.Kind.MALFORMED,
+                    "官网账户信息缺少 accountId 字段，本服务器暂无法完成额度刷新");
+        }
+        if (!binding.getExternalAccountId().equals(String.valueOf(accountId))) {
+            throw new AccountException(AccountException.Kind.CONFLICT,
+                    "这枚账户 Key 属于另一个 AI Workdeck 账户，与本账号的直连关系不一致");
+        }
+        provision(userId, key);
+    }
+
+    /** 官网明确拒绝（OpenRouter 401/403）时调用：密钥已被吊销或重发，本地这份立刻作废。 */
+    public void evict(Long userId) {
+        if (userId == null) return;
+        keyRepository.findByUserId(userId).ifPresent(entity -> {
+            keyRepository.delete(entity);
+            log.info("用户 {} 的平台 AI 通道密钥已被官网侧吊销，本地记录已清除", userId);
+        });
+    }
+
+    /** 探针成功即刷新验证时间（30 天宽限的计时起点）。 */
+    public void markVerified(Long userId) {
+        if (userId == null) return;
+        keyRepository.findByUserId(userId).ifPresent(entity -> {
+            entity.setLastVerifiedAt(LocalDateTime.now());
+            keyRepository.save(entity);
+        });
+    }
+
+    // ==================== 展示 ====================
+
+    /**
+     * 额度面板的数据源。密钥明文<b>不出后端</b>——只回掩码与数字。
+     * 用量取自 OpenRouter，由 server 代查；查不到时只降级用量这一段，不整块报错。
+     */
+    public Map<String, Object> status(Long userId, PlatformUsageAccountant accountant) {
+        Map<String, Object> result = new HashMap<>();
+        boolean bound = isBound(userId);
+        result.put("bound", bound);
+        result.put("configured", cipher.isConfigured());
+
+        Optional<PlatformAiKey> row = keyRepository.findByUserId(userId);
+        result.put("hasKey", row.isPresent());
+        result.put("stale", row.map(this::isStale).orElse(false));
+        result.put("limitUsd", row.map(PlatformAiKey::getLimitUsd).orElse(null));
+        result.put("lastVerifiedAt", row.map(e -> e.getLastVerifiedAt().toString()).orElse(null));
+        result.put("keyMasked", row.map(e -> "sk-or-****" + e.getKeyFingerprint()).orElse(null));
+
+        Optional<Resolved> resolved = resolve(userId);
+        result.put("available", resolved.isPresent());
+        Double usage = resolved.map(r -> accountant.probeUsageForDisplay(userId, r.apiKey())).orElse(null);
+        result.put("usageUsd", usage);
+        Double limit = row.map(PlatformAiKey::getLimitUsd).orElse(null);
+        result.put("remainingUsd", usage == null || limit == null ? null : Math.max(0d, limit - usage));
+        // 用量拿不到时前端显示「—」，绝不把 0 当成剩余额度（licensing 领域既有口径）
+        result.put("usageAvailable", usage != null);
+        return result;
+    }
+
+    boolean isStale(PlatformAiKey entity) {
+        LocalDateTime verified = entity.getLastVerifiedAt();
+        return verified == null || verified.isBefore(LocalDateTime.now().minus(OFFLINE_GRACE));
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PlatformAiUserScope.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformAiUserScope.java
@@ -1,0 +1,80 @@
+package com.checkba.service.ai;
+
+import java.util.concurrent.Callable;
+
+/**
+ * 「这次 AI 调用花的是谁的额度」——平台通道的身份作用域（server 模式多租户）。
+ *
+ * <h3>为什么不是把 userId 一路当参数传</h3>
+ * {@code ChatModelFactory.getChatModel} 在全仓有十余个调用点，其中
+ * MemCellExtractor / ConversationSummarizer / AgenticRetriever / AiAssistantService
+ * 的方法签名里根本没有 userId，穿参要改动整个 AI 编排领域的调用链。
+ * 这里改用显式作用域：在少数几个手边就有 userId 的入口设置，同线程的后续调用自动继承。
+ *
+ * <h3>红线</h3>
+ * ThreadLocal 不会跨线程池自动传递（池线程继承的是创建者而非提交者）。因此每一处
+ * <b>跨线程提交</b>都必须用 {@link #wrap(Runnable)} / {@link #wrap(Callable)} 显式重放。
+ * 漏掉一处的后果被设计成「那条路报业务错误」而不是「那条路记错账」——
+ * 见 {@link PlatformAiChannel#resolve}：多租户形态下缺身份一律拒绝，绝不回落机器级 key。
+ * 错账是静默的，报错是能被测试和冒烟抓到的。
+ */
+public final class PlatformAiUserScope {
+
+    private static final ThreadLocal<Long> CURRENT = new ThreadLocal<>();
+
+    private PlatformAiUserScope() {}
+
+    /** 当前线程的用户；未设置返回 null。 */
+    public static Long current() {
+        return CURRENT.get();
+    }
+
+    /** 在作用域内执行。嵌套安全：退出时恢复外层值而不是清空。 */
+    public static void run(Long userId, Runnable body) {
+        Long previous = CURRENT.get();
+        set(userId);
+        try {
+            body.run();
+        } finally {
+            set(previous);
+        }
+    }
+
+    public static <T> T call(Long userId, java.util.function.Supplier<T> body) {
+        Long previous = CURRENT.get();
+        set(userId);
+        try {
+            return body.get();
+        } finally {
+            set(previous);
+        }
+    }
+
+    /** 捕获当前身份，供跨线程提交时重放。 */
+    public static Runnable wrap(Runnable task) {
+        Long captured = CURRENT.get();
+        return () -> run(captured, task);
+    }
+
+    /** 捕获当前身份，供跨线程提交时重放（有返回值版本）。 */
+    public static <T> Callable<T> wrap(Callable<T> task) {
+        Long captured = CURRENT.get();
+        return () -> {
+            Long previous = CURRENT.get();
+            set(captured);
+            try {
+                return task.call();
+            } finally {
+                set(previous);
+            }
+        };
+    }
+
+    private static void set(Long userId) {
+        if (userId == null) {
+            CURRENT.remove();
+        } else {
+            CURRENT.set(userId);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
+++ b/backend/src/main/java/com/checkba/service/ai/PlatformUsageAccountant.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -29,10 +30,18 @@ import java.util.concurrent.Executors;
  * 该端点返回这把 key 的**累计**消费（美元）。相邻两次采样之差即这段时间的真实花费。
  * OpenRouter 记账有秒级延迟，所以采样会重试几次等数字变动。
  *
- * 取舍（已知且可接受）：并发轮次之间的归属可能串位，但**总额始终精确**（差分自洽）；
- * 权威结算数字本来也在官网/OpenRouter 侧，本地这份是给用户看明细的。
+ * <h3>按 key 指纹分桶（server 模式多租户，2026-08-07）</h3>
+ * baseline 从单个字段改成 {@code Map<指纹, 累计值>}，用<b>密钥指纹</b>而不是 userId 做键：
+ * key 轮换后指纹变化、baseline 自动重建，不会把两把 key 的累计值之差整个记到下一条消息上。
+ * worker 也从单线程改为按指纹分片的固定线程池——同一把 key 仍严格串行（差分正确性不变），
+ * 不同用户并行，否则多租户下「待结算」会被排队拖成分钟级。
  *
- * 单线程 worker 串行执行，既保证差分正确，也不占用流式回调线程（否则会拖住 bubble_end）。
+ * <p>取舍（已知且可接受）：同一把 key 的并发轮次之间归属可能串位，但**总额始终精确**
+ * （差分自洽）。per-user 化之后这个串位被收敛在用户自己的并发轮次内，不再跨租户。
+ *
+ * <h3>兼做吊销探测</h3>
+ * 探针拿到 401/403 = 这把 key 已在官网侧被禁用或重发，立刻让 {@link PlatformAiChannel}
+ * 作废本地这份（与「官网明确拒绝 → 立刻清缓存、不吃宽限」同源）；网络不可达一律保留。
  */
 @Component
 @Slf4j
@@ -45,6 +54,9 @@ public class PlatformUsageAccountant {
     /** OpenRouter 记账延迟：最多重采样这么多次。 */
     private static final int MAX_POLLS = 4;
 
+    /** 分片数。同一指纹恒落同一片，保证差分串行。 */
+    private static final int SHARDS = 4;
+
     /** 重采样间隔。单测会调小，生产不改。 */
     private long pollIntervalMs = 1500L;
 
@@ -54,14 +66,10 @@ public class PlatformUsageAccountant {
     private final String openRouterBaseUrl;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final ExecutorService worker = Executors.newSingleThreadExecutor(r -> {
-        Thread t = new Thread(r, "platform-usage-accountant");
-        t.setDaemon(true);
-        return t;
-    });
+    private final ExecutorService[] workers = new ExecutorService[SHARDS];
 
-    /** 上一次观测到的累计消费。null = 尚未建立基线。 */
-    private volatile BigDecimal baseline;
+    /** 上一次观测到的累计消费，按密钥指纹分桶。缺键 = 尚未建立基线。 */
+    private final Map<String, BigDecimal> baselines = new ConcurrentHashMap<>();
 
     public PlatformUsageAccountant(
             TokenUsageRepository tokenUsageRepository,
@@ -74,27 +82,44 @@ public class PlatformUsageAccountant {
         this.openRouterBaseUrl = openRouterBaseUrl.endsWith("/")
                 ? openRouterBaseUrl.substring(0, openRouterBaseUrl.length() - 1)
                 : openRouterBaseUrl;
+        for (int i = 0; i < SHARDS; i++) {
+            final int index = i;
+            workers[i] = Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "platform-usage-accountant-" + index);
+                t.setDaemon(true);
+                return t;
+            });
+        }
     }
 
     /** 排队对账某条 token_usage 记录。立即返回，不阻塞调用方。 */
-    public void reconcileAsync(Long tokenUsageId) {
+    public void reconcileAsync(Long tokenUsageId, Long userId) {
         if (tokenUsageId == null) return;
-        submit(() -> reconcile(tokenUsageId), "对账 id=" + tokenUsageId);
+        PlatformAiKeyService.Resolved resolved = platformAiChannel.resolveFor(userId);
+        if (resolved == null) {
+            log.debug("无可用平台密钥，跳过对账 id={}", tokenUsageId);
+            return;
+        }
+        submit(resolved.fingerprint(), () -> reconcile(tokenUsageId, userId, resolved),
+                "对账 id=" + tokenUsageId);
     }
 
     /**
      * 在平台通道**发起请求之前**建立基线。
      *
      * baseline 是内存字段，进程重启即丢；没有这一步，重启后第一条消息只够建基线，
-     * cost 永远留空、界面上永久显示「待结算」。这里排在同一个单线程 worker 上，
+     * cost 永远留空、界面上永久显示「待结算」。这里排在与后续对账同一个分片上，
      * 所以一定先于那条消息随后入队的对账任务跑完。已有基线时是内存判断，不发请求。
      */
-    public void ensureBaselineAsync() {
-        if (baseline != null) return;
-        submit(() -> {
-            if (baseline != null) return;
-            BigDecimal observed = probeCumulativeUsage();
-            if (observed != null) baseline = observed;
+    public void ensureBaselineAsync(Long userId) {
+        PlatformAiKeyService.Resolved resolved = platformAiChannel.resolveFor(userId);
+        if (resolved == null) return;
+        String fingerprint = resolved.fingerprint();
+        if (baselines.containsKey(fingerprint)) return;
+        submit(fingerprint, () -> {
+            if (baselines.containsKey(fingerprint)) return;
+            BigDecimal observed = probeCumulativeUsage(userId, resolved.apiKey());
+            if (observed != null) baselines.put(fingerprint, observed);
         }, "建立用量基线");
     }
 
@@ -103,36 +128,52 @@ public class PlatformUsageAccountant {
      * 留着会把两把 key 的累计值之差整个记到下一条消息头上。
      */
     public void resetBaseline() {
-        baseline = null;
+        baselines.clear();
     }
 
-    private void submit(Runnable task, String what) {
+    /** 某把 key 作废（吊销/轮换）时精确清除它的基线。 */
+    public void forget(String fingerprint) {
+        if (fingerprint != null) baselines.remove(fingerprint);
+    }
+
+    /**
+     * 额度面板用的同步查询：返回这把 key 的累计消费（美元），查不到返回 null。
+     * 401/403 同样触发作废——面板刷新时顺手把已吊销的密钥清掉。
+     */
+    public Double probeUsageForDisplay(Long userId, String apiKey) {
+        BigDecimal usage = probeCumulativeUsage(userId, apiKey);
+        return usage == null ? null : usage.doubleValue();
+    }
+
+    private void submit(String fingerprint, Runnable task, String what) {
+        int shard = Math.floorMod(String.valueOf(fingerprint).hashCode(), SHARDS);
         try {
-            worker.submit(task);
+            workers[shard].submit(task);
         } catch (java.util.concurrent.RejectedExecutionException e) {
             log.debug("平台用量对账已停止，跳过{}", what);
         }
     }
 
     /** 包可见供单测直接驱动。 */
-    void reconcile(Long tokenUsageId) {
+    void reconcile(Long tokenUsageId, Long userId, PlatformAiKeyService.Resolved resolved) {
+        String fingerprint = resolved.fingerprint();
         try {
-            BigDecimal observed = probeCumulativeUsage();
+            BigDecimal observed = probeCumulativeUsage(userId, resolved.apiKey());
             if (observed == null) return;
 
-            BigDecimal previous = baseline;
+            BigDecimal previous = baselines.get(fingerprint);
             if (previous == null) {
                 // 首次只建基线：这条记录之前的消费不属于它
-                baseline = observed;
+                baselines.put(fingerprint, observed);
                 return;
             }
             for (int i = 0; i < MAX_POLLS && observed.compareTo(previous) <= 0; i++) {
                 Thread.sleep(pollIntervalMs);
-                BigDecimal again = probeCumulativeUsage();
+                BigDecimal again = probeCumulativeUsage(userId, resolved.apiKey());
                 if (again == null) return;
                 observed = again;
             }
-            baseline = observed;
+            baselines.put(fingerprint, observed);
 
             BigDecimal delta = observed.subtract(previous);
             if (delta.signum() <= 0) {
@@ -151,16 +192,24 @@ public class PlatformUsageAccountant {
         }
     }
 
-    /** GET /api/v1/key → {"data":{"usage": 1.234, "limit": 10, ...}}；失败返回 null。 */
-    private BigDecimal probeCumulativeUsage() {
-        String key;
-        try {
-            key = platformAiChannel.apiKey();
-        } catch (Exception e) {
+    /**
+     * GET /api/v1/key → {"data":{"usage": 1.234, "limit": 10, ...}}；失败返回 null。
+     *
+     * 401/403 是**官网侧已吊销/重发**的确证，立刻作废本地密钥并清基线；
+     * 网络不可达与 5xx 一律保留（服务器故障不等于凭据失效）。
+     */
+    private BigDecimal probeCumulativeUsage(Long userId, String apiKey) {
+        if (apiKey == null) return null;
+        AccountTransport.Reply reply = transport.send("GET", openRouterBaseUrl + "/key", apiKey, null);
+        if (reply.networkFailure()) return null;
+        if (reply.status() == 401 || reply.status() == 403) {
+            String fingerprint = PlatformAiKeyCipher.fingerprint(apiKey);
+            log.info("平台通道密钥已被拒绝（HTTP {}），作废本地记录 userId={}", reply.status(), userId);
+            platformAiChannel.onKeyRejected(userId);
+            forget(fingerprint);
             return null;
         }
-        AccountTransport.Reply reply = transport.send("GET", openRouterBaseUrl + "/key", key, null);
-        if (reply.networkFailure() || reply.status() < 200 || reply.status() >= 300 || reply.body() == null) {
+        if (reply.status() < 200 || reply.status() >= 300 || reply.body() == null) {
             return null;
         }
         try {
@@ -168,15 +217,21 @@ public class PlatformUsageAccountant {
             Object data = parsed.get("data");
             if (!(data instanceof Map<?, ?> map)) return null;
             Object usage = map.get("usage");
-            return usage instanceof Number n ? new BigDecimal(n.toString()) : null;
+            if (!(usage instanceof Number n)) return null;
+            platformAiChannel.onKeyVerified(userId);
+            return new BigDecimal(n.toString());
         } catch (Exception e) {
             return null;
         }
     }
 
     /** 便于单测断言与复位。 */
-    void setBaselineForTest(BigDecimal value) {
-        this.baseline = value;
+    void setBaselineForTest(String fingerprint, BigDecimal value) {
+        baselines.put(fingerprint, value);
+    }
+
+    BigDecimal baselineForTest(String fingerprint) {
+        return baselines.get(fingerprint);
     }
 
     /** 单测把重采样间隔调小，避免为了等 OpenRouter 记账延迟白等几秒。 */
@@ -186,6 +241,8 @@ public class PlatformUsageAccountant {
 
     @PreDestroy
     void shutdown() {
-        worker.shutdownNow();
+        for (ExecutorService worker : workers) {
+            worker.shutdownNow();
+        }
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
+++ b/backend/src/main/java/com/checkba/service/ai/TokenUsageService.java
@@ -64,7 +64,8 @@ public class TokenUsageService {
 
             tokenUsageRepository.save(entity);
             if (platformChannel) {
-                scheduleReconcile(entity.getId());
+                // userId 决定这笔账查哪把 key 的累计消费（server 模式下密钥是 per-user 的）
+                scheduleReconcile(entity.getId(), userId);
             }
             log.debug("Recorded usage for model {}: {} tokens, source={}",
                     modelId, totalTokens, entity.getCostSource());
@@ -77,15 +78,15 @@ public class TokenUsageService {
      * 对账必须等事务提交后再入队：id 在 flush 时就有了，但对账 worker 是另一条连接，
      * 提交前 findById 查不到这条记录会静默 no-op，该条的 cost 永久留空。
      */
-    private void scheduleReconcile(Long tokenUsageId) {
+    private void scheduleReconcile(Long tokenUsageId, Long userId) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            platformUsageAccountant.reconcileAsync(tokenUsageId);
+            platformUsageAccountant.reconcileAsync(tokenUsageId, userId);
             return;
         }
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                platformUsageAccountant.reconcileAsync(tokenUsageId);
+                platformUsageAccountant.reconcileAsync(tokenUsageId, userId);
             }
         });
     }

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
@@ -47,6 +47,13 @@ public class MemoryPipelineService {
     @Async("memoryExecutor")
     public void onConversationTurnCompleted(String conversationId, String projectId,
                                             Long userId, List<ChatMessage> messages) {
+        // 独立线程池：平台通道按用户计费，摘要/抽取这几次 LLM 调用要落在本人的额度上
+        com.checkba.service.ai.PlatformAiUserScope.run(userId,
+                () -> runPipeline(conversationId, projectId, userId, messages));
+    }
+
+    private void runPipeline(String conversationId, String projectId,
+                             Long userId, List<ChatMessage> messages) {
         log.info("Memory pipeline triggered: conversationId={}, messageCount={}",
                 conversationId, messages.size());
 

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
@@ -112,14 +112,16 @@ public class SubAgentService {
         String subtaskId = "subtask-" + UUID.randomUUID().toString().substring(0, 8);
         sendProgress(parentCtx, subtaskId, "started", 0, "子任务开始：" + brief(taskDescription));
 
-        Future<SubAgentResult> future = executor.submit(() -> {
-            IN_SUB_AGENT.set(Boolean.TRUE);
-            try {
-                return runLoop(subtaskId, taskDescription, expectedOutput, toolScope, parentCtx);
-            } finally {
-                IN_SUB_AGENT.remove();
-            }
-        });
+        // 跨线程提交：子 Agent 的模型调用也按主会话身份计费（平台通道 per-user），显式重放
+        Future<SubAgentResult> future = executor.submit(
+                com.checkba.service.ai.PlatformAiUserScope.<SubAgentResult>wrap(() -> {
+                    IN_SUB_AGENT.set(Boolean.TRUE);
+                    try {
+                        return runLoop(subtaskId, taskDescription, expectedOutput, toolScope, parentCtx);
+                    } finally {
+                        IN_SUB_AGENT.remove();
+                    }
+                }));
 
         SubAgentResult result;
         try {

--- a/backend/src/main/java/com/checkba/service/telemetry/MatterClassifierService.java
+++ b/backend/src/main/java/com/checkba/service/telemetry/MatterClassifierService.java
@@ -68,7 +68,9 @@ public class MatterClassifierService {
             if (!classified.add(conversationId)) return;
             String snippet = firstUserMessage.length() > 500
                     ? firstUserMessage.substring(0, 500) : firstUserMessage;
-            executor.execute(() -> classify(conversationId, snippet));
+            // 跨线程提交：平台通道按用户计费，身份必须显式重放（不重放的话多租户下取不到 key）
+            executor.execute(com.checkba.service.ai.PlatformAiUserScope.wrap(
+                    () -> classify(conversationId, snippet)));
         } catch (Exception ignored) {
         }
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -288,6 +288,11 @@ security:
   # 客户端自造的 conv-<毫秒> ID 会被拒绝；已有消息的会话仍按 DB 归属判定。
   # 默认 false：桌面单机与既有前端自造 ID 流程行为完全不变。
   conversation-issuance-required: false
+  # per-user 平台 AI 通道密钥的落库加密密钥（AES-256-GCM，密钥 = SHA-256(本值)）。
+  # 开启账户桥接（security.awdk-login-enabled=true，即官方托管的插件云后端）时**必配**，
+  # 缺失直接拒绝启动——明文降级属于潜伏逃生门，不留。
+  # local-mode 与未开桥接的团队服务器不受影响：它们走机器级密钥文件，不碰这条路。
+  platform-key-secret: ${AWD_PLATFORM_KEY_SECRET:}
 
 # LangChain4j Ollama Configuration
 langchain4j:

--- a/backend/src/test/java/com/checkba/controller/PlatformAiKeyControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/PlatformAiKeyControllerTest.java
@@ -1,0 +1,126 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.DeviceToken;
+import com.checkba.repository.DeviceTokenRepository;
+import com.checkba.service.DeviceTokenService;
+import com.checkba.service.ai.PlatformAiKeyService;
+import com.checkba.service.ai.PlatformUsageAccountant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 按用户的平台 AI 额度端点。
+ *
+ * 与 AccountController 的关键区别：这是<b>会话级</b>的（我自己的额度），
+ * 不走 MachineAccountGuard 的 admin 闸——那道闸管的是整台服务器的账户连接。
+ */
+class PlatformAiKeyControllerTest {
+
+    private static final String AWDK = "awdk_" + "KeyMaterial0123456789abcdefghijklmnop";
+
+    private DeviceTokenService deviceTokenService;
+    private PlatformAiKeyService keyService;
+    private PlatformUsageAccountant accountant;
+    private PlatformAiKeyController controller;
+
+    private final Map<String, DeviceToken> tokensByHash = new HashMap<>();
+    private final AtomicLong seq = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        AuthController.registerLocalIdentityService(null);
+        tokensByHash.clear();
+
+        DeviceTokenRepository tokenRepository = mock(DeviceTokenRepository.class);
+        when(tokenRepository.save(any(DeviceToken.class))).thenAnswer(inv -> {
+            DeviceToken t = inv.getArgument(0);
+            if (t.getId() == null) t.setId(seq.getAndIncrement());
+            tokensByHash.put(t.getTokenHash(), t);
+            return t;
+        });
+        when(tokenRepository.findByTokenHash(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(tokensByHash.get(inv.getArgument(0, String.class))));
+        deviceTokenService = new DeviceTokenService(tokenRepository);
+
+        keyService = mock(PlatformAiKeyService.class);
+        accountant = mock(PlatformUsageAccountant.class);
+        controller = new PlatformAiKeyController(keyService, accountant);
+    }
+
+    private String tokenFor(long userId) {
+        return deviceTokenService.issue(userId, "test").plaintext();
+    }
+
+    @Test
+    @DisplayName("普通用户（非 admin）也能查自己的额度：这是会话级状态，不是机器级配置")
+    void anyAuthenticatedUserCanReadOwnQuota() {
+        when(keyService.status(eq(9L), any())).thenReturn(Map.of("available", true, "limitUsd", 10.0));
+
+        Map<String, Object> result = controller.status(tokenFor(9L));
+
+        assertEquals(0, result.get("code"));
+        verify(keyService).status(eq(9L), any());
+    }
+
+    @Test
+    @DisplayName("无会话：报「未登录」——这是真的掉线，本就该触发前端重新认证")
+    void missingSessionIsRejected() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> controller.status("awdt_not-a-real-token"));
+        assertEquals("未登录", e.getMessage());
+        verifyNoInteractions(keyService);
+    }
+
+    @Test
+    @DisplayName("刷新：按会话身份刷新，并作废旧指纹的对账基线")
+    void refreshUsesSessionIdentityAndResetsBaseline() {
+        when(keyService.status(eq(9L), any())).thenReturn(Map.of("available", true));
+
+        controller.refresh(Map.of("key", AWDK), tokenFor(9L));
+
+        verify(keyService).refresh(9L, AWDK);
+        verify(accountant).resetBaseline();
+    }
+
+    @Test
+    @DisplayName("刷新 body 缺失：交给服务层的格式校验，不 NPE")
+    void refreshWithoutBodyIsHandled() {
+        String token = tokenFor(9L);
+        assertDoesNotThrow(() -> {
+            try {
+                controller.refresh(null, token);
+            } catch (com.checkba.service.account.AccountException expected) {
+                // 服务层的格式拒绝是预期路径
+            }
+        });
+        verify(keyService).refresh(9L, null);
+    }
+
+    @Test
+    @DisplayName("业务错误回全站信封 code=1，且文案不被前端误判为掉线")
+    void accountExceptionBecomesBusinessEnvelope() {
+        var response = controller.handleAccountException(new com.checkba.service.account.AccountException(
+                com.checkba.service.account.AccountException.Kind.CONFLICT,
+                "这枚账户 Key 属于另一个 AI Workdeck 账户，与本账号的直连关系不一致"));
+
+        Map<String, Object> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(1, body.get("code"));
+        assertEquals("CONFLICT", body.get("kind"));
+        String message = String.valueOf(body.get("message"));
+        for (String forbidden : new String[]{"登录", "未授权", "请先"}) {
+            assertFalse(message.contains(forbidden), "文案不得含「" + forbidden + "」: " + message);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
@@ -76,6 +76,7 @@ class AwdkLoginServiceTest {
     private UserService userService;
     private DeviceTokenService deviceTokenService;
     private AccountBindingRepository bindingRepository;
+    private com.checkba.service.ai.PlatformAiKeyService platformAiKeyService;
 
     // 内存假库
     private final Map<String, User> usersByName = new HashMap<>();
@@ -118,6 +119,8 @@ class AwdkLoginServiceTest {
                 .thenAnswer(inv -> Optional.ofNullable(tokensByHash.get(inv.getArgument(0, String.class))));
         deviceTokenService = new DeviceTokenService(tokenRepository);
 
+        platformAiKeyService = mock(com.checkba.service.ai.PlatformAiKeyService.class);
+
         bindingRepository = mock(AccountBindingRepository.class);
         when(bindingRepository.findByExternalAccountId(anyString()))
                 .thenAnswer(inv -> Optional.ofNullable(bindingsByAccountId.get(inv.getArgument(0, String.class))));
@@ -131,7 +134,7 @@ class AwdkLoginServiceTest {
 
     private AwdkLoginService service(boolean enabled) {
         return new AwdkLoginService(enabled, "https://www.aiworkdeck.com",
-                transport, bindingRepository, userService, deviceTokenService);
+                transport, bindingRepository, userService, deviceTokenService, platformAiKeyService);
     }
 
     private static void assertNotMistakenForLogout(String message) {
@@ -265,5 +268,27 @@ class AwdkLoginServiceTest {
         AwdkLoginService.BridgeSession second = svc.login(KEY);
         assertNotEquals(first.userId(), second.userId());
         assertEquals(second.userId(), bindingsByAccountId.get("acc_9f3a").getUserId());
+    }
+
+    // ==================== per-user 平台 AI key（2026-08-07） ====================
+
+    @Test
+    @DisplayName("桥接成功即为该用户换一把平台 AI 密钥：awdk_ 只在这一刻被用到")
+    void bridgeProvisionsPerUserPlatformKey() {
+        transport.enqueue(200, ME_OK);
+        AwdkLoginService.BridgeSession session = service(true).login(KEY);
+
+        // 取 key 走的是「短暂持有的原始 awdk_」这一条路（不落库的前提下唯一可行的时机）
+        org.mockito.Mockito.verify(platformAiKeyService).tryProvision(session.userId(), KEY);
+    }
+
+    @Test
+    @DisplayName("Key 无效时不得去取平台密钥：官网都没认，更不该拿它换 runtime key")
+    void invalidKeyNeverProvisions() {
+        transport.enqueue(401, "{\"error\":\"unauthorized\"}");
+        assertThrows(AccountException.class, () -> service(true).login(KEY));
+
+        org.mockito.Mockito.verify(platformAiKeyService, org.mockito.Mockito.never())
+                .tryProvision(anyLong(), anyString());
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
@@ -159,7 +159,6 @@ class ChatModelFactoryTest {
     @DisplayName("AWD_CLOUD：即便是白名单模型也走平台密钥，不能落到 BYOK 的 OpenRouter key")
     void platformChannelTakesPrecedenceOverAllowlistShortcut() {
         setDbProvider("AWD_CLOUD");
-        when(platformAiChannel.isAvailable()).thenReturn(true);
         when(platformAiChannel.apiKey()).thenReturn("sk-or-provisioned");
         when(platformAiChannel.keyFingerprint()).thenReturn("abc123");
 
@@ -174,20 +173,22 @@ class ChatModelFactoryTest {
     @DisplayName("AWD_CLOUD 但未连接账户：明确报错，不静默回退 BYOK 花用户自己的 key")
     void platformChannelWithoutAccountFailsLoudly() {
         setDbProvider("AWD_CLOUD");
-        when(platformAiChannel.isAvailable()).thenReturn(false);
+        when(platformAiChannel.apiKey()).thenThrow(new com.checkba.service.account.AccountException(
+                com.checkba.service.account.AccountException.Kind.NOT_CONNECTED,
+                "「AI Workdeck 云端」需要连接账户，请到设置页粘贴账户 Key"));
 
         var e = assertThrows(com.checkba.service.account.AccountException.class,
                 () -> factory.getChatModel("deepseek/deepseek-v4-flash"));
         assertEquals(com.checkba.service.account.AccountException.Kind.NOT_CONNECTED, e.getKind());
         assertTrue(e.getMessage().contains("连接账户"), e.getMessage());
-        verify(platformAiChannel, never()).apiKey();
+        // 绝不回落 BYOK：用户自己的 key 一次都不该被读到
+        verify(systemSettingService, never()).get(eq("external.openrouter.apiKey"), any());
     }
 
     @Test
     @DisplayName("故障转移换模型不换通道：平台通道下备选模型仍走平台密钥，不碰 BYOK 的 key")
     void failoverCandidateStaysOnPlatformChannel() {
         setDbProvider("AWD_CLOUD");
-        when(platformAiChannel.isAvailable()).thenReturn(true);
         when(platformAiChannel.apiKey()).thenReturn("sk-or-provisioned");
         when(platformAiChannel.keyFingerprint()).thenReturn("abc123");
 
@@ -202,12 +203,11 @@ class ChatModelFactoryTest {
     @DisplayName("平台通道用之前先建用量基线：否则重启后第一条消息永远显示「待结算」")
     void platformChannelEstablishesUsageBaselineBeforeCall() {
         setDbProvider("AWD_CLOUD");
-        when(platformAiChannel.isAvailable()).thenReturn(true);
         when(platformAiChannel.apiKey()).thenReturn("sk-or-provisioned");
         when(platformAiChannel.keyFingerprint()).thenReturn("abc123");
 
         factory.getStreamingChatModel("openai/gpt-5.2");
-        verify(usageAccountant, atLeastOnce()).ensureBaselineAsync();
+        verify(usageAccountant, atLeastOnce()).ensureBaselineAsync(any());
     }
 
     @Test
@@ -238,5 +238,52 @@ class ChatModelFactoryTest {
 
         assertNull(factory.demotePlatformProvider());
         verify(systemSettingService, never()).set(eq("ai.activeProvider"), anyString());
+    }
+
+    @Test
+    @DisplayName("多租户：还有按用户的密钥在用时，断开机器级账户不降级（否则把租户一起打断）")
+    void demoteKeepsPlatformWhenPerUserKeysExist() {
+        setDbProvider("AWD_CLOUD");
+        when(platformAiChannel.hasPerUserKeys()).thenReturn(true);
+        when(systemSettingService.get(eq("external.openrouter.apiKey"), any())).thenReturn("sk-or-db-key");
+
+        assertNull(factory.demotePlatformProvider());
+        verify(systemSettingService, never()).set(eq("ai.activeProvider"), anyString());
+    }
+
+    // ==================== per-user 平台密钥（server 模式多租户） ====================
+
+    @Test
+    @DisplayName("按用户取密钥：身份来自作用域，两个用户拿到不同的模型实例")
+    void perUserScopeYieldsSeparateModelInstances() {
+        setDbProvider("AWD_CLOUD");
+        when(platformAiChannel.apiKey()).thenAnswer(inv ->
+                PlatformAiUserScope.current() == 1L ? "sk-or-alice" : "sk-or-bob");
+        when(platformAiChannel.keyFingerprint()).thenAnswer(inv ->
+                PlatformAiUserScope.current() == 1L ? "aaaaaa" : "bbbbbb");
+
+        ChatLanguageModel alice = PlatformAiUserScope.call(1L, () -> factory.getChatModel("openai/gpt-5.2"));
+        ChatLanguageModel bob = PlatformAiUserScope.call(2L, () -> factory.getChatModel("openai/gpt-5.2"));
+
+        assertNotSame(alice, bob, "不同用户的密钥指纹不同，模型实例必须分叉，绝不能串用额度");
+        assertSame(alice, PlatformAiUserScope.call(1L, () -> factory.getChatModel("openai/gpt-5.2")));
+    }
+
+    @Test
+    @DisplayName("多租户下缺身份：报业务错误，绝不回落 BYOK 或机器级密钥")
+    void missingScopeFailsLoudly() {
+        setDbProvider("AWD_CLOUD");
+        when(platformAiChannel.apiKey()).thenThrow(new com.checkba.service.account.AccountException(
+                com.checkba.service.account.AccountException.Kind.CONFLICT,
+                "本次 AI 调用未携带用户身份，「AI Workdeck 云端」无法确定额度归属"));
+
+        var e = assertThrows(com.checkba.service.account.AccountException.class,
+                () -> factory.getChatModel("openai/gpt-5.2"));
+        assertEquals(com.checkba.service.account.AccountException.Kind.CONFLICT, e.getKind());
+        verify(systemSettingService, never()).get(eq("external.openrouter.apiKey"), any());
+        for (String forbidden : new String[]{"登录", "未授权", "请先"}) {
+            assertFalse(e.getMessage().contains(forbidden),
+                    "业务错误文案不得含「" + forbidden + "」：前端据此判定掉线并清会话");
+        }
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/PlatformAiChannelRoutingTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformAiChannelRoutingTest.java
@@ -1,0 +1,172 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * 平台通道的取 key 路由。这条路由决定「花谁的额度」，四种形态各有硬约束：
+ *
+ * <ul>
+ *   <li>local-mode：一字不动，永远走机器级密钥文件；</li>
+ *   <li>server + 已桥接用户：走 per-user 密钥；</li>
+ *   <li>server + 多租户实例上的未桥接用户 / 缺身份：<b>报错</b>，绝不回落机器级
+ *       （回落等于拿别人的额度花钱）；</li>
+ *   <li>server + 一个绑定都没有的团队服务器：机器级路径与改动前逐字一致。</li>
+ * </ul>
+ */
+class PlatformAiChannelRoutingTest {
+
+    @TempDir
+    Path stateDir;
+
+    private AccountService accountService;
+    private PlatformAiKeyService perUser;
+
+    @BeforeEach
+    void setUp() {
+        accountService = mock(AccountService.class);
+        perUser = mock(PlatformAiKeyService.class);
+    }
+
+    private PlatformAiChannel channel(boolean localMode) {
+        return new PlatformAiChannel(accountService, perUser, localMode, stateDir.toString());
+    }
+
+    private void machineKeyAvailable() {
+        when(accountService.isConnected()).thenReturn(true);
+        when(accountService.fetchAiKey()).thenReturn(Map.of(
+                "openrouterKey", "sk-or-machine", "limitUsd", 10.0));
+    }
+
+    private void bound(long userId, String key) {
+        when(perUser.isBound(userId)).thenReturn(true);
+        when(perUser.multiTenant()).thenReturn(true);
+        when(perUser.resolve(userId)).thenReturn(Optional.of(
+                new PlatformAiKeyService.Resolved(key, "fp-" + userId, 5.0)));
+        when(perUser.fingerprintOrNull(userId)).thenReturn("fp-" + userId);
+    }
+
+    @Test
+    @DisplayName("local-mode：即便库里有绑定也走机器级文件，行为一字不动")
+    void localModeAlwaysUsesMachineKey() {
+        machineKeyAvailable();
+        bound(1L, "sk-or-alice");
+
+        PlatformAiChannel channel = channel(true);
+        assertEquals("sk-or-machine", PlatformAiUserScope.call(1L, channel::apiKey));
+        verify(perUser, never()).resolve(any());
+    }
+
+    @Test
+    @DisplayName("server + 已桥接：取本人的密钥")
+    void boundUserGetsOwnKey() {
+        machineKeyAvailable();
+        bound(1L, "sk-or-alice");
+
+        PlatformAiChannel channel = channel(false);
+        assertEquals("sk-or-alice", PlatformAiUserScope.call(1L, channel::apiKey));
+        assertEquals("fp-1", PlatformAiUserScope.call(1L, channel::keyFingerprint));
+        assertTrue(channel.availableFor(1L));
+        verify(accountService, never()).fetchAiKey();
+    }
+
+    @Test
+    @DisplayName("多租户实例上的未桥接用户：明确拒绝，绝不回落机器级密钥")
+    void unboundUserOnMultiTenantIsRefused() {
+        machineKeyAvailable();
+        when(perUser.multiTenant()).thenReturn(true);
+        when(perUser.isBound(2L)).thenReturn(false);
+
+        PlatformAiChannel channel = channel(false);
+        AccountException e = assertThrows(AccountException.class,
+                () -> PlatformAiUserScope.call(2L, channel::apiKey));
+        assertNotMistakenForLogout(e.getMessage());
+        assertFalse(channel.availableFor(2L));
+        verify(accountService, never()).fetchAiKey();
+    }
+
+    @Test
+    @DisplayName("多租户实例上缺身份：报错而不是记错账（漏传身份必须能被测试和冒烟抓到）")
+    void missingScopeOnMultiTenantIsRefused() {
+        machineKeyAvailable();
+        when(perUser.multiTenant()).thenReturn(true);
+
+        PlatformAiChannel channel = channel(false);
+        AccountException e = assertThrows(AccountException.class, channel::apiKey);
+        assertTrue(e.getMessage().contains("身份"), e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+        verify(accountService, never()).fetchAiKey();
+    }
+
+    @Test
+    @DisplayName("已桥接但密钥未就绪（没分配额度/已过期）：给可操作的引导，不回落")
+    void boundButNoKeyGivesActionableMessage() {
+        machineKeyAvailable();
+        when(perUser.isBound(1L)).thenReturn(true);
+        when(perUser.multiTenant()).thenReturn(true);
+        when(perUser.resolve(1L)).thenReturn(Optional.empty());
+
+        PlatformAiChannel channel = channel(false);
+        AccountException e = assertThrows(AccountException.class,
+                () -> PlatformAiUserScope.call(1L, channel::apiKey));
+        assertTrue(e.getMessage().contains("刷新额度"), e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+        verify(accountService, never()).fetchAiKey();
+    }
+
+    @Test
+    @DisplayName("团队服务器（没有任何绑定）：机器级路径与改动前一致，缺身份也照常可用")
+    void teamServerWithoutBindingsKeepsMachineBehaviour() {
+        machineKeyAvailable();
+        when(perUser.multiTenant()).thenReturn(false);
+
+        PlatformAiChannel channel = channel(false);
+        assertEquals("sk-or-machine", channel.apiKey());
+        assertTrue(channel.availableFor(42L));
+    }
+
+    @Test
+    @DisplayName("未连接账户的机器级路径：仍是原来那句「需要连接账户」")
+    void machinePathWithoutAccountKeepsOriginalMessage() {
+        when(accountService.isConnected()).thenReturn(false);
+        when(perUser.multiTenant()).thenReturn(false);
+
+        PlatformAiChannel channel = channel(false);
+        AccountException e = assertThrows(AccountException.class, channel::apiKey);
+        assertEquals(AccountException.Kind.NOT_CONNECTED, e.getKind());
+        assertTrue(e.getMessage().contains("连接账户"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("密钥被拒：per-user 走删行，机器级走清缓存")
+    void rejectionRoutesToTheRightStore() {
+        bound(1L, "sk-or-alice");
+        PlatformAiChannel channel = channel(false);
+
+        channel.onKeyRejected(1L);
+        verify(perUser).evict(1L);
+
+        when(perUser.isBound(3L)).thenReturn(false);
+        channel.onKeyRejected(3L);
+        verify(perUser, never()).evict(3L);
+    }
+
+    private static void assertNotMistakenForLogout(String message) {
+        assertNotNull(message);
+        for (String forbidden : new String[]{"登录", "未授权", "请先"}) {
+            assertFalse(message.contains(forbidden), "文案不得含「" + forbidden + "」: " + message);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PlatformAiKeyCipherTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformAiKeyCipherTest.java
@@ -1,0 +1,111 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * per-user 平台密钥的落库加密。密文形态与官网仓 lib/openrouter-keys.ts 对齐
+ * （v1:iv:tag:cipher，AES-256-GCM），GCM tag 保证篡改即解密失败。
+ */
+class PlatformAiKeyCipherTest {
+
+    private static final String KEY = "sk-or-v1-0123456789abcdef";
+
+    private PlatformAiKeyCipher cipher(String secret) {
+        return new PlatformAiKeyCipher(secret, false);
+    }
+
+    @Test
+    @DisplayName("加解密往返")
+    void roundTrip() {
+        PlatformAiKeyCipher cipher = cipher("s3cr3t");
+        String encoded = cipher.encrypt(KEY);
+        assertNotEquals(KEY, encoded);
+        assertFalse(encoded.contains(KEY), "密文里不得出现明文");
+        assertEquals(KEY, cipher.decrypt(encoded));
+    }
+
+    @Test
+    @DisplayName("密文形态：四段 v1:iv:tag:cipher（与官网侧同形态，两边排查不必换脑子）")
+    void cipherTextShape() {
+        String[] parts = cipher("s3cr3t").encrypt(KEY).split(":");
+        assertEquals(4, parts.length);
+        assertEquals("v1", parts[0]);
+    }
+
+    @Test
+    @DisplayName("同一明文两次加密的密文不同（IV 随机），但都能解回来")
+    void randomIv() {
+        PlatformAiKeyCipher cipher = cipher("s3cr3t");
+        String a = cipher.encrypt(KEY);
+        String b = cipher.encrypt(KEY);
+        assertNotEquals(a, b);
+        assertEquals(KEY, cipher.decrypt(a));
+        assertEquals(KEY, cipher.decrypt(b));
+    }
+
+    @Test
+    @DisplayName("密文被篡改：解密必失败，绝不解出一把「能用但不是你的」key")
+    void tamperedCipherTextFails() {
+        PlatformAiKeyCipher cipher = cipher("s3cr3t");
+        String encoded = cipher.encrypt(KEY);
+        String[] parts = encoded.split(":");
+        // 改掉密文体的最后一个字符
+        String body = parts[3];
+        char last = body.charAt(body.length() - 1);
+        parts[3] = body.substring(0, body.length() - 1) + (last == 'A' ? 'B' : 'A');
+        String tampered = String.join(":", parts);
+
+        assertThrows(IllegalStateException.class, () -> cipher.decrypt(tampered));
+    }
+
+    @Test
+    @DisplayName("换了 secret：旧密文解不开（不会静默返回垃圾）")
+    void secretRotationInvalidatesOldCipherText() {
+        String encoded = cipher("old-secret").encrypt(KEY);
+        assertThrows(IllegalStateException.class, () -> cipher("new-secret").decrypt(encoded));
+    }
+
+    @Test
+    @DisplayName("格式不认识：明确抛错")
+    void unsupportedFormat() {
+        PlatformAiKeyCipher cipher = cipher("s3cr3t");
+        assertThrows(IllegalStateException.class, () -> cipher.decrypt("v2:a:b:c"));
+        assertThrows(IllegalStateException.class, () -> cipher.decrypt("nonsense"));
+        assertThrows(IllegalStateException.class, () -> cipher.decrypt(null));
+    }
+
+    @Test
+    @DisplayName("未配置 secret：整块不可用，而不是明文降级")
+    void unconfiguredRefusesToWork() {
+        PlatformAiKeyCipher cipher = cipher("");
+        assertFalse(cipher.isConfigured());
+        assertThrows(IllegalStateException.class, () -> cipher.encrypt(KEY));
+    }
+
+    @Test
+    @DisplayName("启动强不变式：开启账户桥接却没配 secret 直接拒绝启动（不留明文逃生门）")
+    void bridgeWithoutSecretRefusesToStart() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> new PlatformAiKeyCipher("  ", true));
+        assertTrue(e.getMessage().contains("AWD_PLATFORM_KEY_SECRET"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("未开桥接（local-mode / 团队服务器）：缺 secret 照常启动，走机器级路径")
+    void nonBridgeDeploymentStartsWithoutSecret() {
+        assertDoesNotThrow(() -> new PlatformAiKeyCipher(null, false));
+    }
+
+    @Test
+    @DisplayName("指纹随 key 变化，长度稳定")
+    void fingerprintChangesWithKey() {
+        String a = PlatformAiKeyCipher.fingerprint(KEY);
+        String b = PlatformAiKeyCipher.fingerprint(KEY + "x");
+        assertEquals(12, a.length());
+        assertNotEquals(a, b);
+        assertEquals(a, PlatformAiKeyCipher.fingerprint(KEY));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PlatformAiKeyServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformAiKeyServiceTest.java
@@ -1,0 +1,311 @@
+package com.checkba.service.ai;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.PlatformAiKey;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.repository.PlatformAiKeyRepository;
+import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * per-user 平台 AI 密钥的取用与存储（server 模式多租户）。
+ *
+ * 守的几条：桥接取 key 失败绝不拖垮桥接；awdk_ 明文不落库；刷新必须校验 accountId 归属；
+ * 30 天未验证即过期；官网明确拒绝立刻清除；失败文案不被前端误判为掉线。
+ */
+class PlatformAiKeyServiceTest {
+
+    private static final String AWDK = "awdk_" + "KeyMaterial0123456789abcdefghijklmnop";
+    private static final String RUNTIME_KEY = "sk-or-v1-provisioned-alice";
+
+    private PlatformAiKeyRepository keyRepository;
+    private AccountBindingRepository bindingRepository;
+    private AccountService accountService;
+    private PlatformAiKeyService service;
+
+    private Map<Long, PlatformAiKey> rows;
+    private Map<Long, AccountBinding> bindings;
+
+    @BeforeEach
+    void setUp() {
+        rows = new HashMap<>();
+        bindings = new HashMap<>();
+        AtomicLong seq = new AtomicLong(1);
+
+        keyRepository = mock(PlatformAiKeyRepository.class);
+        when(keyRepository.findByUserId(any()))
+                .thenAnswer(inv -> Optional.ofNullable(rows.get(inv.getArgument(0, Long.class))));
+        when(keyRepository.save(any(PlatformAiKey.class))).thenAnswer(inv -> {
+            PlatformAiKey e = inv.getArgument(0);
+            if (e.getId() == null) e.setId(seq.getAndIncrement());
+            rows.put(e.getUserId(), e);
+            return e;
+        });
+        doAnswer(inv -> rows.remove(inv.getArgument(0, PlatformAiKey.class).getUserId()))
+                .when(keyRepository).delete(any(PlatformAiKey.class));
+        when(keyRepository.count()).thenAnswer(inv -> (long) rows.size());
+
+        bindingRepository = mock(AccountBindingRepository.class);
+        when(bindingRepository.findByUserId(any()))
+                .thenAnswer(inv -> Optional.ofNullable(bindings.get(inv.getArgument(0, Long.class))));
+        when(bindingRepository.count()).thenAnswer(inv -> (long) bindings.size());
+
+        accountService = mock(AccountService.class);
+        service = new PlatformAiKeyService(keyRepository, bindingRepository,
+                new PlatformAiKeyCipher("unit-test-secret", false), accountService);
+    }
+
+    private void bind(long userId, String accountId) {
+        AccountBinding b = new AccountBinding();
+        b.setUserId(userId);
+        b.setExternalAccountId(accountId);
+        bindings.put(userId, b);
+    }
+
+    private void websiteReturnsKey(String key, Double limit) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("openrouterKey", key);
+        body.put("limitUsd", limit);
+        when(accountService.fetchAiKeyWith(anyString())).thenReturn(body);
+    }
+
+    private static void assertNotMistakenForLogout(String message) {
+        assertNotNull(message);
+        for (String forbidden : new String[]{"登录", "未授权", "请先"}) {
+            assertFalse(message.contains(forbidden), "文案不得含「" + forbidden + "」: " + message);
+        }
+    }
+
+    // ==================== 取用 ====================
+
+    @Test
+    @DisplayName("取到即加密入库；解出来是同一把 key，且明文不出现在存储里")
+    void provisionStoresEncrypted() {
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+
+        PlatformAiKey stored = rows.get(1L);
+        assertNotNull(stored);
+        assertFalse(stored.getKeyEnc().contains(RUNTIME_KEY), "库里不得出现 runtime key 明文");
+        assertFalse(stored.getKeyEnc().contains(AWDK), "库里更不得出现 awdk_ 明文");
+        assertEquals(RUNTIME_KEY, service.resolve(1L).orElseThrow().apiKey());
+        assertEquals(10.0, stored.getLimitUsd());
+    }
+
+    @Test
+    @DisplayName("重复取：覆盖同一行（每用户至多一把）")
+    void provisionIsIdempotentPerUser() {
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+        websiteReturnsKey("sk-or-v1-rotated", 20.0);
+        service.provision(1L, AWDK);
+
+        assertEquals(1, rows.size());
+        assertEquals("sk-or-v1-rotated", service.resolve(1L).orElseThrow().apiKey());
+        assertEquals(20.0, rows.get(1L).getLimitUsd());
+    }
+
+    @Test
+    @DisplayName("两个用户各一把：指纹不同，互不可见")
+    void keysAreIsolatedPerUser() {
+        websiteReturnsKey("sk-or-alice", 10.0);
+        service.provision(1L, AWDK);
+        websiteReturnsKey("sk-or-bob", 10.0);
+        service.provision(2L, AWDK);
+
+        assertEquals("sk-or-alice", service.resolve(1L).orElseThrow().apiKey());
+        assertEquals("sk-or-bob", service.resolve(2L).orElseThrow().apiKey());
+        assertNotEquals(service.fingerprintOrNull(1L), service.fingerprintOrNull(2L));
+    }
+
+    @Test
+    @DisplayName("桥接取 key 失败（最常见是 409 还没分配额度）一律吞掉：不得拖垮桥接登录")
+    void tryProvisionSwallowsFailures() {
+        // doThrow 而不是 when().thenThrow()：已被 stub 成抛异常的 mock，在 when() 里再调一次会当场抛
+        doThrow(new AccountException(AccountException.Kind.CONFLICT,
+                "尚未分配 AI 额度，请到官网账户页从余额分配"))
+                .when(accountService).fetchAiKeyWith(anyString());
+        assertDoesNotThrow(() -> service.tryProvision(1L, AWDK));
+        assertTrue(rows.isEmpty());
+
+        doThrow(new AccountException(AccountException.Kind.NETWORK,
+                "无法连接 AI Workdeck 服务器，请检查网络后重试"))
+                .when(accountService).fetchAiKeyWith(anyString());
+        assertDoesNotThrow(() -> service.tryProvision(1L, AWDK));
+
+        doThrow(new RuntimeException("boom")).when(accountService).fetchAiKeyWith(anyString());
+        assertDoesNotThrow(() -> service.tryProvision(1L, AWDK));
+        assertTrue(rows.isEmpty(), "取不到就什么都不写");
+    }
+
+    @Test
+    @DisplayName("未配置存储密钥：明确的业务错误，不明文降级")
+    void provisionWithoutSecretIsRefused() {
+        PlatformAiKeyService noSecret = new PlatformAiKeyService(keyRepository, bindingRepository,
+                new PlatformAiKeyCipher("", false), accountService);
+        AccountException e = assertThrows(AccountException.class, () -> noSecret.provision(1L, AWDK));
+        assertNotMistakenForLogout(e.getMessage());
+        assertTrue(rows.isEmpty());
+    }
+
+    // ==================== 过期与吊销 ====================
+
+    @Test
+    @DisplayName("29 天前验证过：仍可用；31 天：判为过期（永久离线不等于永久可用）")
+    void offlineGraceIsThirtyDays() {
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+
+        rows.get(1L).setLastVerifiedAt(LocalDateTime.now().minusDays(29));
+        assertTrue(service.resolve(1L).isPresent());
+        assertNotNull(service.fingerprintOrNull(1L));
+
+        rows.get(1L).setLastVerifiedAt(LocalDateTime.now().minusDays(31));
+        assertTrue(service.resolve(1L).isEmpty(), "超 30 天未验证必须判过期");
+        assertNull(service.fingerprintOrNull(1L));
+    }
+
+    @Test
+    @DisplayName("探针成功刷新验证时间，过期的密钥随之复活")
+    void markVerifiedRefreshesGrace() {
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+        rows.get(1L).setLastVerifiedAt(LocalDateTime.now().minusDays(31));
+        assertTrue(service.resolve(1L).isEmpty());
+
+        service.markVerified(1L);
+        assertTrue(service.resolve(1L).isPresent());
+    }
+
+    @Test
+    @DisplayName("官网明确拒绝：立刻删行，不吃宽限")
+    void evictDeletesRow() {
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+        service.evict(1L);
+
+        assertTrue(rows.isEmpty());
+        assertTrue(service.resolve(1L).isEmpty());
+    }
+
+    @Test
+    @DisplayName("secret 被换过导致解不开：按不可用降级，但绝不删行（改回 secret 即恢复）")
+    void undecryptableRowIsNotDeleted() {
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+
+        PlatformAiKeyService rotated = new PlatformAiKeyService(keyRepository, bindingRepository,
+                new PlatformAiKeyCipher("another-secret", false), accountService);
+        assertTrue(rotated.resolve(1L).isEmpty());
+        assertFalse(rows.isEmpty(), "解不开不等于该丢——这类故障是可修复的");
+    }
+
+    // ==================== 刷新 ====================
+
+    @Test
+    @DisplayName("刷新：Key 归属本账号才放行")
+    void refreshRequiresMatchingAccount() {
+        bind(1L, "acc_alice");
+        when(accountService.fetchProfileWith(anyString()))
+                .thenReturn(Map.of("accountId", "acc_alice", "username", "alice"));
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+
+        service.refresh(1L, AWDK);
+        assertEquals(RUNTIME_KEY, service.resolve(1L).orElseThrow().apiKey());
+    }
+
+    @Test
+    @DisplayName("刷新：贴别人的 Key 必拒（否则等于把别人的额度装到自己名下用）")
+    void refreshRejectsForeignKey() {
+        bind(1L, "acc_alice");
+        when(accountService.fetchProfileWith(anyString()))
+                .thenReturn(Map.of("accountId", "acc_bob", "username", "bob"));
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+
+        AccountException e = assertThrows(AccountException.class, () -> service.refresh(1L, AWDK));
+        assertNotMistakenForLogout(e.getMessage());
+        assertTrue(rows.isEmpty(), "校验没过就不该有任何写入");
+        verify(accountService, never()).fetchAiKeyWith(anyString());
+    }
+
+    @Test
+    @DisplayName("刷新：官网响应缺 accountId 一律拒绝，不回落 username 做归属判据")
+    void refreshRejectsMissingAccountId() {
+        bind(1L, "acc_alice");
+        when(accountService.fetchProfileWith(anyString())).thenReturn(Map.of("username", "alice"));
+
+        AccountException e = assertThrows(AccountException.class, () -> service.refresh(1L, AWDK));
+        assertEquals(AccountException.Kind.MALFORMED, e.getKind());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("刷新：没桥接过的账号明确拒绝，且不向官网发请求")
+    void refreshRequiresBinding() {
+        AccountException e = assertThrows(AccountException.class, () -> service.refresh(1L, AWDK));
+        assertNotMistakenForLogout(e.getMessage());
+        verify(accountService, never()).fetchProfileWith(anyString());
+    }
+
+    @Test
+    @DisplayName("刷新：Key 格式不对当场拒绝，不浪费一次官网往返")
+    void refreshValidatesKeyShape() {
+        bind(1L, "acc_alice");
+        AccountException e = assertThrows(AccountException.class, () -> service.refresh(1L, "not-a-key"));
+        assertEquals(AccountException.Kind.UNAUTHORIZED, e.getKind());
+        verify(accountService, never()).fetchProfileWith(anyString());
+    }
+
+    // ==================== 判据与展示 ====================
+
+    @Test
+    @DisplayName("绑定判据：有映射才算已桥接；任一映射存在即为多租户形态")
+    void bindingPredicates() {
+        assertFalse(service.isBound(1L));
+        assertFalse(service.multiTenant());
+
+        bind(1L, "acc_alice");
+        assertTrue(service.isBound(1L));
+        assertTrue(service.multiTenant());
+        assertFalse(service.isBound(2L));
+        assertFalse(service.isBound(null));
+    }
+
+    @Test
+    @DisplayName("额度面板：密钥明文不出后端，用量拿不到时不把 0 当成剩余额度")
+    void statusNeverLeaksKeyAndDegradesUsage() {
+        bind(1L, "acc_alice");
+        websiteReturnsKey(RUNTIME_KEY, 10.0);
+        service.provision(1L, AWDK);
+
+        PlatformUsageAccountant accountant = mock(PlatformUsageAccountant.class);
+        when(accountant.probeUsageForDisplay(any(), anyString())).thenReturn(null);
+
+        Map<String, Object> status = service.status(1L, accountant);
+        assertEquals(Boolean.TRUE, status.get("available"));
+        assertEquals(10.0, status.get("limitUsd"));
+        assertNull(status.get("usageUsd"));
+        assertNull(status.get("remainingUsd"), "用量未知时剩余必须是 null，不能顶成 0");
+        assertEquals(Boolean.FALSE, status.get("usageAvailable"));
+        assertFalse(String.valueOf(status).contains(RUNTIME_KEY), "状态里绝不能出现密钥明文");
+
+        when(accountant.probeUsageForDisplay(any(), anyString())).thenReturn(2.5);
+        Map<String, Object> withUsage = service.status(1L, accountant);
+        assertEquals(2.5, withUsage.get("usageUsd"));
+        assertEquals(7.5, withUsage.get("remainingUsd"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PlatformAiUserScopeTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformAiUserScopeTest.java
@@ -1,0 +1,81 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 平台通道的身份作用域。这里守的是「这次 AI 调用花的是谁的额度」——
+ * 传丢了不会静默记错账（{@link PlatformAiChannel} 在多租户下会拒绝），但会让功能不可用，
+ * 所以嵌套与跨线程重放两条都要有护栏。
+ */
+class PlatformAiUserScopeTest {
+
+    @Test
+    @DisplayName("作用域内可见，退出后清空")
+    void setAndClear() {
+        assertNull(PlatformAiUserScope.current());
+        PlatformAiUserScope.run(7L, () -> assertEquals(7L, PlatformAiUserScope.current()));
+        assertNull(PlatformAiUserScope.current());
+    }
+
+    @Test
+    @DisplayName("嵌套：退出内层恢复外层，而不是清空")
+    void nestedRestoresOuter() {
+        PlatformAiUserScope.run(1L, () -> {
+            PlatformAiUserScope.run(2L, () -> assertEquals(2L, PlatformAiUserScope.current()));
+            assertEquals(1L, PlatformAiUserScope.current(), "内层退出后必须恢复外层身份");
+        });
+    }
+
+    @Test
+    @DisplayName("抛异常也要还原（否则线程池里的下一个任务会顶着别人的身份跑）")
+    void restoresOnException() {
+        assertThrows(RuntimeException.class, () -> PlatformAiUserScope.run(3L, () -> {
+            throw new RuntimeException("boom");
+        }));
+        assertNull(PlatformAiUserScope.current());
+    }
+
+    @Test
+    @DisplayName("跨线程不自动传递：不 wrap 就是 null（这正是每个异步点必须显式重放的原因）")
+    void notInheritedByPoolThreads() throws Exception {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            Long seen = PlatformAiUserScope.call(5L, () -> {
+                try {
+                    return pool.submit(PlatformAiUserScope::current).get();
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+            assertNull(seen);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("wrap 显式重放：池线程上拿到提交者的身份")
+    void wrapReplaysIdentity() throws Exception {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            Long seen = PlatformAiUserScope.call(5L, () -> {
+                try {
+                    return pool.submit(PlatformAiUserScope.wrap(PlatformAiUserScope::current)).get();
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+            assertEquals(5L, seen);
+            // 任务跑完后池线程不得残留身份
+            assertNull(pool.submit(PlatformAiUserScope::current).get());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PlatformUsageAccountantTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PlatformUsageAccountantTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,49 +21,70 @@ import static org.mockito.Mockito.*;
 /**
  * 平台通道真实花费对账：差分口径（相邻两次累计消费之差）。
  * 这里算的是真花的钱，写错就是账不平——首次只建基线、采不到就不写、非正差分不写。
+ *
+ * server 模式多租户之后另加一条硬约束：<b>基线按密钥指纹分桶</b>，
+ * 两个用户交替消费必须各算各的，否则就是把 A 的钱记在 B 头上。
  */
 class PlatformUsageAccountantTest {
 
+    private static final PlatformAiKeyService.Resolved KEY_A =
+            new PlatformAiKeyService.Resolved("sk-or-v1-alice", "aaaaaaaaaaaa", 10.0);
+    private static final PlatformAiKeyService.Resolved KEY_B =
+            new PlatformAiKeyService.Resolved("sk-or-v1-bob", "bbbbbbbbbbbb", 10.0);
+
     private TokenUsageRepository repository;
     private PlatformAiChannel channel;
-    private Deque<AccountTransport.Reply> replies;
+    /** 每把 key 各自的应答队列——多租户下两个用户的采样不能共用一条队列。 */
+    private Map<String, Deque<AccountTransport.Reply>> replies;
     private PlatformUsageAccountant accountant;
     private TokenUsage row;
+    private TokenUsage rowB;
 
     @BeforeEach
     void setUp() {
         repository = mock(TokenUsageRepository.class);
         channel = mock(PlatformAiChannel.class);
-        when(channel.apiKey()).thenReturn("sk-or-v1-provisioned");
+        when(channel.resolveFor(1L)).thenReturn(KEY_A);
+        when(channel.resolveFor(2L)).thenReturn(KEY_B);
 
         row = new TokenUsage();
         row.setId(7L);
         row.setCostSource("platform");
         when(repository.findById(7L)).thenReturn(Optional.of(row));
 
-        replies = new ArrayDeque<>();
+        rowB = new TokenUsage();
+        rowB.setId(8L);
+        rowB.setCostSource("platform");
+        when(repository.findById(8L)).thenReturn(Optional.of(rowB));
+
+        replies = new HashMap<>();
         AccountTransport transport = (method, url, bearer, body) -> {
             assertEquals("https://openrouter.ai/api/v1/key", url);
-            assertEquals("sk-or-v1-provisioned", bearer);
-            return replies.isEmpty()
+            Deque<AccountTransport.Reply> queue = replies.get(bearer);
+            return queue == null || queue.isEmpty()
                     ? new AccountTransport.Reply(AccountTransport.Reply.NETWORK_FAILURE, null)
-                    : replies.poll();
+                    : queue.poll();
         };
         accountant = new PlatformUsageAccountant(repository, channel, transport,
                 "https://openrouter.ai/api/v1");
         accountant.setPollIntervalMsForTest(1L);
     }
 
+    private void usage(PlatformAiKeyService.Resolved key, double cumulative) {
+        replies.computeIfAbsent(key.apiKey(), k -> new ArrayDeque<>())
+                .add(new AccountTransport.Reply(200,
+                        "{\"data\":{\"usage\":" + cumulative + ",\"limit\":10.0,\"limit_remaining\":9.0}}"));
+    }
+
     private void usage(double cumulative) {
-        replies.add(new AccountTransport.Reply(200,
-                "{\"data\":{\"usage\":" + cumulative + ",\"limit\":10.0,\"limit_remaining\":9.0}}"));
+        usage(KEY_A, cumulative);
     }
 
     @Test
     @DisplayName("首次对账只建基线：之前的消费不属于这条记录")
     void firstCallOnlyEstablishesBaseline() {
         usage(1.25);
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
         verify(repository, never()).save(any());
         assertNull(row.getCost());
     }
@@ -69,9 +92,9 @@ class PlatformUsageAccountantTest {
     @Test
     @DisplayName("第二次对账写入差分作为真实花费")
     void deltaBecomesCost() {
-        accountant.setBaselineForTest(new BigDecimal("1.250000"));
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.250000"));
         usage(1.28);
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
 
         verify(repository).save(row);
         assertEquals(0, new BigDecimal("0.03").compareTo(row.getCost()), "cost=" + row.getCost());
@@ -81,11 +104,11 @@ class PlatformUsageAccountantTest {
     @Test
     @DisplayName("OpenRouter 记账有延迟：重采样直到数字变动")
     void retriesUntilUsageMoves() {
-        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.00"));
         usage(1.00); // 还没记上
         usage(1.00);
         usage(1.02); // 记上了
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
 
         assertEquals(0, new BigDecimal("0.02").compareTo(row.getCost()));
     }
@@ -93,29 +116,28 @@ class PlatformUsageAccountantTest {
     @Test
     @DisplayName("采样一直不动：不写 cost（宁可留空也不写假数字）")
     void noMovementLeavesCostNull() {
-        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.00"));
         for (int i = 0; i < 6; i++) usage(1.00);
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
 
         verify(repository, never()).save(any());
         assertNull(row.getCost());
     }
 
     @Test
-    @DisplayName("采样失败（断网/被禁用）：静默跳过，绝不影响对话")
+    @DisplayName("采样失败（断网）：静默跳过，绝不影响对话")
     void probeFailureIsSilent() {
-        accountant.setBaselineForTest(new BigDecimal("1.00"));
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.00"));
         // replies 为空 → 桩返回 NETWORK_FAILURE
-        assertDoesNotThrow(() -> accountant.reconcile(7L));
+        assertDoesNotThrow(() -> accountant.reconcile(7L, 1L, KEY_A));
         verify(repository, never()).save(any());
     }
 
     @Test
-    @DisplayName("未连接账户（拿不到平台 key）：跳过，不发请求")
+    @DisplayName("拿不到平台 key：入队时就跳过，不发请求")
     void skipsWhenNoPlatformKey() {
-        when(channel.apiKey()).thenThrow(new IllegalStateException("not connected"));
-        accountant.setBaselineForTest(new BigDecimal("1.00"));
-        assertDoesNotThrow(() -> accountant.reconcile(7L));
+        when(channel.resolveFor(9L)).thenReturn(null);
+        assertDoesNotThrow(() -> accountant.reconcileAsync(7L, 9L));
         verify(repository, never()).save(any());
     }
 
@@ -123,17 +145,17 @@ class PlatformUsageAccountantTest {
     @DisplayName("换账户必须重置基线：否则两把 key 的累计差会整个记到下一条消息头上")
     void resetBaselineDropsPreviousKeysCumulative() {
         // 账户 A 的累计是 0.02，账户 B 的累计是 5.00
-        accountant.setBaselineForTest(new BigDecimal("0.02"));
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("0.02"));
         accountant.resetBaseline();
 
         usage(5.00);
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
         // 重置后第一次只重新建基线，不会把 4.98 写成这条消息的花费
         verify(repository, never()).save(any());
         assertNull(row.getCost());
 
         usage(5.01);
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
         assertEquals(0, new BigDecimal("0.01").compareTo(row.getCost()), "cost=" + row.getCost());
     }
 
@@ -141,12 +163,60 @@ class PlatformUsageAccountantTest {
     @DisplayName("请求前建基线：随后第一条消息就能算出差分，不再永久「待结算」")
     void ensureBaselineMakesFirstMessageBillable() throws Exception {
         usage(2.00); // ensureBaseline 采到的
-        accountant.ensureBaselineAsync();
-        // 单线程 worker：等基线任务跑完
-        for (int i = 0; i < 100 && !replies.isEmpty(); i++) Thread.sleep(10);
+        accountant.ensureBaselineAsync(1L);
+        // 分片 worker：等基线任务跑完
+        for (int i = 0; i < 100 && accountant.baselineForTest(KEY_A.fingerprint()) == null; i++) {
+            Thread.sleep(10);
+        }
 
         usage(2.05); // 这条消息之后的累计
-        accountant.reconcile(7L);
+        accountant.reconcile(7L, 1L, KEY_A);
         assertEquals(0, new BigDecimal("0.05").compareTo(row.getCost()), "cost=" + row.getCost());
+    }
+
+    @Test
+    @DisplayName("多租户核心回归：两个用户交替消费，各自差分独立，绝不串位")
+    void twoUsersAreAccountedSeparately() {
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.00"));
+        accountant.setBaselineForTest(KEY_B.fingerprint(), new BigDecimal("50.00"));
+
+        // A 花了 0.03，B 花了 2.00；若共用一个 baseline，B 这条会被记成 49 美元
+        usage(KEY_A, 1.03);
+        usage(KEY_B, 52.00);
+        accountant.reconcile(7L, 1L, KEY_A);
+        accountant.reconcile(8L, 2L, KEY_B);
+
+        assertEquals(0, new BigDecimal("0.03").compareTo(row.getCost()), "A cost=" + row.getCost());
+        assertEquals(0, new BigDecimal("2.00").compareTo(rowB.getCost()), "B cost=" + rowB.getCost());
+    }
+
+    @Test
+    @DisplayName("OpenRouter 401：密钥已在官网侧吊销，立刻作废本地记录并清基线")
+    void rejectedKeyIsEvictedImmediately() {
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.00"));
+        replies.computeIfAbsent(KEY_A.apiKey(), k -> new ArrayDeque<>())
+                .add(new AccountTransport.Reply(401, "{\"error\":\"unauthorized\"}"));
+
+        accountant.reconcile(7L, 1L, KEY_A);
+
+        verify(channel).onKeyRejected(1L);
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("网络不可达不等于凭据失效：绝不作废密钥")
+    void networkFailureNeverEvicts() {
+        accountant.setBaselineForTest(KEY_A.fingerprint(), new BigDecimal("1.00"));
+        accountant.reconcile(7L, 1L, KEY_A); // 队列为空 → NETWORK_FAILURE
+
+        verify(channel, never()).onKeyRejected(any());
+    }
+
+    @Test
+    @DisplayName("采样成功即刷新验证时间：30 天宽限的计时起点")
+    void successfulProbeMarksVerified() {
+        usage(1.00);
+        accountant.reconcile(7L, 1L, KEY_A);
+        verify(channel).onKeyVerified(1L);
     }
 }

--- a/doc/desktop-contract.md
+++ b/doc/desktop-contract.md
@@ -6,24 +6,36 @@
 
 ## 待官网侧实施
 
-### 1. `GET /api/account/me` 需增加稳定 `accountId` 字段（2026-08-06，插件云后端 awdk 桥）
+（当前无待办条目。）
 
-- 用途：server 模式桥接端点 `POST /api/auth/awdk-login`（本仓 `AwdkLoginService`）用 awdk_ Key
-  调 `GET /api/account/me` 校验通过后，以 `accountId` 作为 `account_binding.external_account_id`
-  的映射键——同一官网账户在 Key 轮换、username/displayName 改名后仍映射到同一个 server 用户。
-- 要求：字段对账户终身稳定（不随 username / displayName / Key 轮换变化），字符串形态，长度 <= 128。
-- 官网侧落地时须同步官网仓 `doc/desktop-contract.md` 与 `scripts/contract-check.mts`。
-- 未实施期间的桌面仓行为：awdk-login 对缺失 `accountId` 的响应按 MALFORMED 拒绝——**不猜、
-  不回落 username 做映射键**（username 可改名，以它为键会在改名后凭空生出第二个 server 用户）。
+## 已落地条目（留档，便于回溯当初的判断）
 
-### 2. per-user 平台 AI key（设计待办，未排期）
+### `GET /api/account/me` 的稳定 `accountId`（2026-08-06 提出，官网侧已实施）
 
-server 模式的平台 AI 通道目前仍是机器级（`~/.aiworkdeck/platform-ai-key.json` 一台机器一把 key），
-多租户下所有用户共享同一账户额度且 `PlatformUsageAccountant` 的差分对账会串位。按用户化的要点：
+官网已返回 `accountId`（`users.json` 的 uuid 主键），并已进入官网仓 `doc/desktop-contract.md`
+与 `scripts/contract-check.mts`。本仓 `AwdkLoginService` 以它作 `account_binding.external_account_id`
+的映射键；缺失时按 MALFORMED 拒绝，**不回落 username**（username 可改名，以它为键会在改名后
+凭空生出第二个 server 用户）。
 
-- 桌面/server 侧：`AccountService` / `PlatformAiChannel` 从机器级文件改 per-user DB 记录
-  （可挂在 `account_binding` 上），每用户一把 provisioned OpenRouter runtime key；
-- 官网侧：`POST /api/account/ai-key` 现成且幂等，per-user 化后由 server 后端代表每个绑定的
-  官网账户各自调用（每次桥接登录时已持有该用户的 awdk_，但明文不落库——需要设计
-  「何时用什么凭据取 key」：候选是桥接时即取即存 per-user key，或官网增加服务端-服务端凭据）；
-- 对账：OpenRouter `GET /api/v1/key` 的累计消费差分随 key 隔离到用户维度，串位问题随之消解。
+### per-user 平台 AI key（2026-08-07 实施，方案 a）
+
+server 模式的平台 AI 通道原为机器级（`~/.aiworkdeck/platform-ai-key.json` 一台机器一把 key），
+多租户下所有用户共享同一额度池，且 `PlatformUsageAccountant` 的差分对账会串位。现按用户化：
+
+- **官网侧零改动**：`POST /api/account/ai-key` 现成、幂等、已进契约与 contract-check，
+  server 实例在**桥接登录**（`POST /api/auth/awdk-login`）与**显式刷新**
+  （`POST /api/platform-ai/key/refresh`）这两个时刻短暂持有该用户的 awdk_，用它代表该用户调用；
+- awdk_ 明文仍然**不落库**，落库的是它换回的 OpenRouter runtime key（AES-256-GCM 密文，
+  密钥来自 `AWD_PLATFORM_KEY_SECRET`）；额度由 OpenRouter 侧的 per-key limit 强制；
+- 吊销：用户在官网禁用/重发 runtime key → OpenRouter 401/403 → server 侧探针立刻删本地行。
+
+**没有采纳「官网新增服务端-服务端凭据」**（server 注册为受信客户端、凭 accountId 换任意用户 key）：
+那把长期主凭据泄露即可拉取全站账户的 key，而要把半径收窄回来又必须再引入 per-account 授权记录，
+建立授权仍然要用户的 awdk_ 走一次桥接——安全上界与现方案相同，却多背一把主密钥。
+
+**触发重新评估的条件**：出现**第二方托管的 server 实例**（非我方运营的插件后端要接入官网账户体系）。
+届时「撤销某台 server 对我账户的授权」成为刚需，服务端-服务端凭据 + per-account 授权表值得单独立项。
+本仓侧的升级面被收敛在 `PlatformAiKeyService.provision/refresh` 这一个出口，
+上层（`PlatformAiChannel` 路由、`ChatModelFactory`、对账分桶、身份作用域）不需要改动。
+
+设计文档：`docs/superpowers/specs/2026-08-07-per-user-platform-ai-key.md`。

--- a/docs/superpowers/specs/2026-08-07-per-user-platform-ai-key.md
+++ b/docs/superpowers/specs/2026-08-07-per-user-platform-ai-key.md
@@ -1,0 +1,350 @@
+# per-user 平台 AI key 设计（server 模式多租户）
+
+- 日期：2026-08-07
+- 领域：licensing-billing（编排侧落点见 ai-chat）
+- 前置：`2026-08-06-office-addin-and-memory-sync.md` §「后续」第 4 条，本仓 `doc/desktop-contract.md` 待办 2
+- 状态：设计待确认 → 确认后实施
+
+## 1. 问题
+
+官方托管的 server 模式实例（插件云后端）里，平台 AI 通道（`Provider.AWD_CLOUD`）仍是**机器级**的：
+
+- `PlatformAiChannel` 把一把 provisioned OpenRouter runtime key 缓存在
+  `~/.aiworkdeck/platform-ai-key.json`，整台服务器所有租户共用；
+- OpenRouter 的额度上限是 **per-key** 的，一把 key 就是一个额度池——A 用户可以把 B 用户的额度花光；
+- `PlatformUsageAccountant` 用「同一把 key 的累计消费差分」记账，多租户下并发轮次的
+  cost 会记到别人的 `token_usage` 行上（现有注释里承认的「串位」在单用户下只是明细不准，
+  多租户下变成把 A 的钱记在 B 头上）。
+
+目标：每个（已桥接的）用户一把 provisioned key，按用户取、按用户缓存、按 key 隔离对账。
+
+## 2. 现状盘点（代码事实）
+
+| 事实 | 位置 |
+|---|---|
+| key 缓存是单文件、无用户维度 | `service/ai/PlatformAiChannel.java:45,106-139` |
+| 对账 baseline 是**单个** volatile 字段 | `service/ai/PlatformUsageAccountant.java:64` |
+| 对账探针用 `platformAiChannel.apiKey()` 拿「那把」key | 同上 `:155-175` |
+| 模型实例缓存 key 已含 `keyFingerprint()` | `service/ai/ChatModelFactory.java:224,244` |
+| 取不到 key 绝不回落 BYOK（红线） | 同上 `:171-186`、`AgentOrchestrator.java:963-980` |
+| `TokenUsageService.recordUsage` 手里**已有 userId** | `service/ai/TokenUsageService.java:36` |
+| awdk 桥每次重验官网，awdk_ 明文不落库 | `service/account/AwdkLoginService.java:22-43` |
+| 映射键是官网稳定 `accountId` | `model/entity/AccountBinding.java` |
+| 官网 `GET /api/account/me` **已返回** `accountId` | 官网仓 `app/api/account/me/route.ts:18`、`doc/desktop-contract.md:58`、`scripts/contract-check.mts:156-159` |
+| 官网 `POST /api/account/ai-key` 幂等、已进契约与 contract-check | 官网仓 `app/api/account/ai-key/route.ts`、`scripts/contract-check.mts:221-241` |
+| 官网侧 key 明文是 AES-256-GCM 加密入库（`v1:iv:tag:cipher`） | 官网仓 `lib/openrouter-keys.ts` |
+
+顺带发现（本设计的副产物）：本仓 `doc/desktop-contract.md` 的待办条目 1
+（「`/api/account/me` 需增加 accountId」）**官网侧已实施并进了权威契约**，按该文件自己的规则应当删除。
+
+## 3. 三个候选方案
+
+共同前提：server 实例不存 awdk_ 明文（PR#268 的既定决策，本设计不推翻）。
+差别在于「用什么凭据、在什么时机代表用户去官网取他的 platform key」。
+
+### a) 桥接时即取即存（server 库存 per-user OpenRouter key，awdk_ 仍不落库）
+
+awdk-login 成功的那一刻，server 手里短暂持有该用户的 awdk_，顺手调
+`POST /api/account/ai-key` 取到这把用户的 runtime key，加密落 server 库；awdk_ 用完即弃。
+
+- **泄露半径**：server 库里多了 N 把 OpenRouter runtime key。拿到它们能做的**只有**花掉各自
+  key 上剩余的额度（上限由 OpenRouter 侧 `limitUsd` 强制），**不能**读官网账户、不能动余额、
+  不能签发新 key、不能同步权益、不能买广场付费项——这些都要 awdk_，而 awdk_ 不在库里。
+- **吊销路径**：用户在官网账户页禁用/重发 key（`openrouter_keys.disabledAt`）→ 该 key 立即在
+  OpenRouter 侧失效 → server 侧的探针（见 §4.6）拿到 401 即删本地行。**不依赖 server 配合**，
+  这一点很关键：吊销的权力留在官网侧，被攻破的 server 无法阻止用户止损。
+- **离线/过期**：key 在库里，官网不可达也能继续用（与桌面端今天一致）。上界由「30 天未成功验证
+  即停用」封顶（§4.6），与 `EntitlementService.OFFLINE_GRACE` 同值同口径。
+- **两仓工作量**：官网侧 **零改动**（端点现成、幂等、已进 contract-check）。桌面/server 侧一份改动。
+- **弱点**：awdk_ 被吊销 ≠ platform key 被吊销，二者是官网侧两条独立的吊销开关。用户以为
+  「我把 Key 撤了就断干净了」但 AI 额度还在被那台 server 用。必须在官网账户页文案上说清，
+  或（更好）在官网侧把「吊销 awdk_」与「禁用该账户的 runtime key」做成可勾选的联动——
+  这属于官网侧后续优化，不阻塞本次。
+
+### b) 官网新增服务端-服务端凭据（server 注册为受信客户端，凭 accountId 换用户 key）
+
+server 实例持一把长期 `awds_` 服务器凭据（env 注入），调新端点
+`POST /api/account/ai-key/for-account {accountId}` 取任意账户的 key。
+
+- **泄露半径**：**最大**。一把 `awds_` 泄露 = 可拉取官网上**任何**账户的 runtime key，包括
+  从未用过这台 server 的账户。要收窄就必须再引入「per-account 授权记录」——而建立这条授权记录
+  本身仍然需要用户的 awdk_ 走一次桥接，于是安全上界回到与 (a) 相同，却多背了一把长期主密钥。
+- **吊销路径**：这是它唯一真正的优势——官网侧可以做「撤销某台 server 对我账户的授权」按钮，
+  一键切断，比 (a) 的「去禁用 runtime key」语义更贴用户心智。
+- **离线/过期**：server 不必存 key，可每次会话现取、只存内存——库被拖走时零密钥泄露。
+  代价是官网不可达时平台通道整体不可用（无宽限可言，除非再把取到的 key 缓存起来，
+  那就退化成 (a) 的存储形态）。
+- **两仓工作量**：官网侧新表（server 注册 + per-account 授权）、新端点、授权与撤销 UI、
+  契约文档 + contract-check 条目、`awds_` 的生成与轮换流程。是 (a) 的数倍。
+- **结论**：为「一台自营 server」引入一把可拉取全站密钥的主凭据，是拿更大的爆炸半径换一个
+  更好看的吊销按钮。**当出现第二方托管的 server 实例时**（别人部署的插件后端要接我们的账户体系），
+  它才成为必需——那时 per-account 授权与撤销是刚需，值得单独立项。
+
+### c) 插件端持 awdk_ 直连官网取 key，server 只透传使用
+
+- **泄露半径**：**把凭据挪到了最不可信的一层**。Office 任务窗格的持久化（localStorage /
+  roamingSettings）比 server 库更暴露：roamingSettings 会同步到微软云，任务窗格里一个 XSS
+  就能同时拿到 awdk_（不只是 runtime key）。而且 key 最终仍然要进 server 内存才能发请求，
+  server 的暴露面一点没减少，只是多了一层。
+- **与既有红线冲突**：等于把「account 级凭据不落客户端持久层」这条线在插件侧破了；
+  持有 awdk_ 的插件还能直接调官网的余额、权益、断开连接。
+- **致命的工程问题**：server 侧的 AI 调用有一半发生在**请求生命周期之外**——编排循环是
+  `@Async`、标题生成是 `runAsync`、记忆抽取是 `@Async("memoryExecutor")`、子 Agent 是独立
+  executor、PPT 生成是后台任务。「每请求透传」的 key 覆盖不到这些，要覆盖就必须在 server 侧缓存，
+  于是又退化成 (a)，只是取 key 的路径更差。
+- **结论**：不采纳。
+
+### 比较小结
+
+| | a 桥接即取即存 | b 服务端凭据 | c 插件直连 |
+|---|---|---|---|
+| server 被攻破的爆炸半径 | N 把 runtime key 的**剩余额度** | 同左（有授权表）/ **全站 key**（无授权表） | 同左，另加插件侧 awdk_ |
+| 凭据在最弱一层 | 否 | 否 | **是**（任务窗格存储） |
+| 吊销路径 | 官网禁用 runtime key（不依赖 server 配合） | 官网撤销 server 授权（更贴心智） | 官网吊销 awdk_ |
+| 离线可用 | 可用，30 天封顶 | 不可用（除非缓存 → 退化为 a） | 不可用 |
+| 与 30 天宽限一致 | 一致（复用同口径） | 无宽限概念 | 无 |
+| 官网侧工作量 | **零** | 新表 + 新端点 + 撤销 UI + 契约 | 中 |
+| 后台线程可用 | 是 | 是 | **否** |
+
+**推荐 (a)**，并在设计里把 (b) 的升级路径留出来：per-user key 的取用被收敛到一个
+`PlatformAiKeyService.keyFor(userId)` 出口，将来换成 (b) 只换这个出口的实现，
+上层（工厂、对账、身份作用域）一行不动。
+
+## 4. 详细设计（方案 a）
+
+### 4.1 生效范围：只有「已桥接用户」走 per-user，其余一字不动
+
+| 形态 | 平台通道取 key 的路径 |
+|---|---|
+| local-mode（桌面单机） | **完全不变**：`~/.aiworkdeck/platform-ai-key.json` |
+| server 模式 + 当前用户有 `account_binding` | per-user 库记录（本设计新增） |
+| server 模式 + 当前用户无 `account_binding`（团队服务器的普通成员） | **不变**：机器级文件 |
+
+不引入新开关：「有没有绑定」本身就是判据，天然是加法改动。团队服务器（没人桥接）行为逐字不变；
+官方云后端（注册关闭 + 桥接开启，人人都是桥接用户）自然全部走 per-user。
+
+### 4.2 数据模型
+
+新实体 `PlatformAiKey` → 表 `platform_ai_key`：
+
+| 列 | 说明 |
+|---|---|
+| `userId` | 唯一约束，指向 server 用户 |
+| `keyEnc` | runtime key 明文的 AES-256-GCM 密文，格式 `v1:<ivB64>:<tagB64>:<cipherB64>` |
+| `keyFingerprint` | SHA-256(明文) 前 12 位十六进制。模型缓存 key、对账 baseline 的键 |
+| `limitUsd` | 官网返回的额度上限，展示用 |
+| `fetchedAt` / `lastVerifiedAt` | 取得时间 / 最近一次向 OpenRouter 验证成功的时间 |
+
+不挂在 `account_binding` 上：那张表是纯身份映射、每次桥接登录都要读，
+把密文塞进去会改变它的安全等级；分表还让「吊销即删行」不碰身份数据。
+
+**加密**：新增 `service/ai/PlatformAiKeyCipher`，AES-256-GCM，密钥 = SHA-256(secret)，
+密文格式与官网 `lib/openrouter-keys.ts` **逐字对齐**（同一形态两侧都好排查）。
+secret 取自 `security.platform-key-secret`（env `AWD_PLATFORM_KEY_SECRET`）。
+
+secret 缺失时的行为见 §7 决策点 D1。
+
+### 4.3 取 key 的时机与刷新路径
+
+**主路径（桥接时）**：`AwdkLoginService.login()` 在解析出 user 之后、返回 awdt_ 之前，
+用同一枚 in-memory awdk_ 调 `POST /api/account/ai-key`，成功即加密入库（覆盖旧行）。
+
+**取 key 失败一律不拖垮桥接登录**：
+
+| 官网回应 | 处理 |
+|---|---|
+| 409 `no_allocation` | 正常态（该账户还没从余额分配 AI 额度）。不落库，桥接照常成功 |
+| 409 `key_missing` / 503 `not_configured` | 记 warn，不落库，桥接照常成功 |
+| 网络不可达 / 5xx | 记 warn，不落库，桥接照常成功 |
+| 2xx 但 `openrouterKey` 空 | 记 warn，不落库 |
+
+理由：否则「还没分配额度」的用户连插件都登不进去，而插件的绝大多数能力与 AI 额度无关。
+
+**刷新路径**：用户在官网分配额度/重发 key 之后，server 侧没有 awdk_ 可用来重取。
+新增两个**会话级**（不是机器级，不走 `MachineAccountGuard`）端点：
+
+- `GET /api/platform-ai/key/status` → `{available, limitUsd, keyMasked, lastVerifiedAt, stale, bound}`
+  —— 供插件/前端展示与引导；
+- `POST /api/platform-ai/key/refresh`，body `{accountKey: "awdk_..."}` ——
+  用它调官网 `/api/account/me`，**校验返回的 accountId 与当前会话用户的
+  `account_binding.external_account_id` 一致**（不一致直接拒绝：否则 A 能把 B 的 Key 贴进来，
+  把 B 的额度装到自己名下用），一致则取 key 覆盖入库。awdk_ 用完即弃，不落库。
+
+不复用 `awdk-login` 做刷新：那条路每次都会多签发一枚 awdt_ 设备令牌，令牌会越积越多。
+
+### 4.4 身份作用域：模型工厂怎么知道「这是谁的钱」
+
+`ChatModelFactory.getChatModel(modelId)` 在全仓有 ~12 个调用点，其中
+`MemCellExtractor` / `ConversationSummarizer` / `AgenticRetriever` / `AiAssistantService`
+的方法签名里根本没有 userId，把 userId 一路穿进去要改动整个 ai-chat 领域的调用链——
+与「外科手术式改动」冲突，也会把 AI 编排领域拖进这次计费改造。
+
+采用**显式作用域 + 缺身份即拒绝**：
+
+新增 `service/ai/PlatformAiUserScope`：`ThreadLocal<Long>` + `run(userId, Supplier)` +
+`capture()`（跨线程时显式重放）。设置点（每个都在手边就有 userId）：
+
+| 设置点 | userId 来源 |
+|---|---|
+| `AgentOrchestrator.handleUserMessage(request, userId)` | 方法参数，try/finally 包住整个方法体 |
+| 同方法内标题生成的 `CompletableFuture.runAsync`（:368） | 闭包捕获后显式重放 |
+| `AiChatService.chat(request, userId)` | 方法参数 |
+| `MemoryPipelineService.onConversationTurnCompleted(..., userId, ...)`（`@Async`） | 方法参数 |
+| `SubAgentService.dispatch` 的 `executor.submit`（:115） | `parentCtx.userId()`（工具上下文不变式 3） |
+| `MatterClassifierService.classifyAsync`（单线程 executor） | 新增 userId 参数，调用点在编排器内 |
+| `AutoTaggingService.autoTagFile(..., userId)` | 方法参数 |
+| `AiAgentController` PPT 生成的 `runAsync`（:256） | 已有的 `effectiveUserId` |
+
+其余调用点（`AgenticRetriever`、`ConversationSummarizer`、`MemCellExtractor`、
+`AiAssistantService`）都是被上面这些同步调用的，继承线程即可。
+
+**不变式（本设计最硬的一条）**：server 模式 + 当前 provider 是 `AWD_CLOUD` + 作用域为空
+→ 抛业务错误（中文文案，不含「登录/未授权/请先」三个子串），**绝不回落机器级 key、
+绝不回落 BYOK**。漏掉一个传播点的后果是「这条路报错」而不是「这条路记错账」——
+错账是静默的，报错是能被测试和冒烟抓到的。
+
+### 4.5 对账按 key 隔离
+
+- `PlatformUsageAccountant.baseline`（单字段）→ `Map<fingerprint, BigDecimal>`。
+  用 **key 指纹**而不是 userId 做键：key 轮换后指纹变化，baseline 自动重建，
+  不会把两把 key 的累计值之差整个记到下一条消息头上。
+- `reconcileAsync(tokenUsageId)` → `reconcileAsync(tokenUsageId, userId)`；
+  `TokenUsageService.recordUsage` 手里已经有 userId，调用点零成本。
+- `ensureBaselineAsync()` → `ensureBaselineAsync(userId)`；探针 `probeCumulativeUsage(apiKey)`
+  用该用户的 key。
+- 单线程 worker → **固定 4 线程池 + 按指纹分片**（`Math.floorMod(fingerprint.hashCode(), 4)`），
+  同一把 key 仍严格串行（差分正确性不变），不同用户并行。
+  现状单线程 + 每轮最多 4×1.5s 轮询，在多租户下会把「待结算」拖成分钟级。
+- `resetBaseline()` 保留为「全清」（机器级账户 connect/disconnect 时用），
+  新增 `forget(fingerprint)` 供吊销/轮换时精确清除。
+
+现有注释里那条「并发轮次归属可能串位、但总额精确」的取舍**保留**，但作用域从
+「整台机器」收敛到「同一个用户自己的并发轮次」——这正是本次要达成的目标。
+
+### 4.6 吊销与过期
+
+对账探针 `GET https://openrouter.ai/api/v1/key` 每轮都会跑，让它兼做验证：
+
+| 探针结果 | 处理 | 口径来源 |
+|---|---|---|
+| 2xx | 刷新 `lastVerifiedAt` | |
+| **401 / 403** | **立即删除该用户的 `platform_ai_key` 行** + `forget(fingerprint)` + 清模型缓存 | 与「官网明确拒绝 → 立刻清缓存、不吃宽限」同源 |
+| 网络不可达 / 5xx | 保留，什么都不做 | 与「服务器故障 ≠ 凭据失效」同源 |
+
+外层封顶：`lastVerifiedAt` 超过 **30 天** → 该用户的平台通道判为过期不可用，
+提示走刷新端点。常数与 `EntitlementService.OFFLINE_GRACE` / `LicenseService.OFFLINE_GRACE`
+同值（30 天），注释里互相指认。理由与权益缓存完全相同：永久离线不能等于永久可用。
+
+取 key 本身**不发网络请求**（沿用现状：库记录命中即用），验证只发生在探针里。
+
+### 4.7 模型实例缓存
+
+`getOrCreatePlatformModel` 的缓存键已经是 `awd_cloud:<fingerprint>:<modelId>`，
+per-user 之后指纹天然按用户分叉，**不存在串用风险**。但 `modelCache` / `streamingModelCache`
+是无界 `ConcurrentHashMap`，N 用户 × M 模型会无界增长——见 §7 决策点 D2。
+
+`demotePlatformProvider()` 目前在断开机器级账户时把 `ai.activeProvider` 摘下来。
+多租户下 `ai.activeProvider` 是全局设置，若还有 per-user key 在用，摘掉会把所有桥接用户一起打断。
+改为：**server 模式下存在任一有效 per-user key 时不降级**。
+
+### 4.8 契约与护栏
+
+方案 a 下**官网仓零代码改动**。契约侧要做的：
+
+- 本仓 `doc/desktop-contract.md`：删除待办条目 1（accountId 官网已实施并已进权威契约与
+  contract-check，按该文件自己的规则应当移除）；把条目 2 改写为「已实施，方案 a，官网无新增端点」
+  并说明 (b) 的触发条件（出现第二方托管 server 实例时）。
+- 官网仓 `doc/desktop-contract.md` 的 `POST /api/account/ai-key` 一节补一段**使用方说明**：
+  该端点除桌面端外，还被 server 模式实例在桥接登录时代表用户调用；
+  `scripts/contract-check.mts` 已覆盖字段与幂等性，无需新增断言。
+- 领域文档 `.claude/agents/licensing-billing.md` 同 PR 更新（关键文件地图 + 地雷）。
+
+## 5. 不变式清单（实施与后续改动都不许破）
+
+1. server 模式 + AWD_CLOUD + 无用户作用域 → 报业务错误，**绝不回落机器级 key 或 BYOK**。
+2. awdk_ 明文**永不落 server 库**，也永不回给前端/插件。
+3. local-mode 的取 key 路径**一字不动**（文件缓存、`isAvailable()` 语义、现有用例全部不改）。
+4. 无 `account_binding` 的 server 用户走机器级路径，与今天完全一致。
+5. 对账 baseline 只能按 **key 指纹**分桶；换 key 必须换桶。
+6. 所有新增用户可见文案不得含「登录」「未授权」「请先」子串。
+7. OpenRouter 401/403 立即清 key；网络不可达一律保留。
+8. 刷新端点必须校验 awdk_ 对应的 accountId 与会话用户的绑定一致。
+
+## 6. 测试计划（全量，本机 `mvn` 必须 JDK 21）
+
+新增：
+
+- `service/ai/PlatformAiKeyCipherTest`：加解密往返、密文篡改必失败、格式不符必抛、secret 换过必失败。
+- `service/ai/PlatformAiKeyServiceTest`：取 key 覆盖入库幂等；409 `no_allocation` / 网络失败
+  **不抛异常**；stale 判定（29 天可用 / 31 天不可用）；401 立即删行；文案护栏。
+- `service/account/AwdkLoginServiceTest` 增补：取 key 的四种失败都不影响桥接返回 awdt_。
+- `service/ai/PlatformUsageAccountantTest` 增补（**本次的核心回归**）：
+  两个用户交替消费，各自差分独立、互不串位；换 key 后 baseline 重建。
+- `service/ai/ChatModelFactoryTest` 增补：server 模式无作用域 → 抛业务错误且不落到 BYOK 分支；
+  两个用户拿到不同实例；有 per-user key 时 `demotePlatformProvider` 不降级。
+- `service/ai/PlatformAiUserScopeTest`：嵌套/清理/跨线程显式重放。
+- `controller/PlatformAiKeyControllerTest`：status/refresh 的会话鉴权；accountId 不一致必拒。
+
+回归（必须全绿，不得改断言）：`AccountServiceTest`、`EntitlementServiceTest`、
+`MachineAccountGuardTest`、`AccountControllerMachineScopeTest`、`LicenseServiceTest`、
+`LocalIdentity*`、`LocalModeAccessFilterTest`，以及编排侧 `EvalHarness` 相关用例
+（改 `ChatModelFactory`/`PlatformUsageAccountant` 构造器要同步 `EvalHarness`，这条已经踩过两次）。
+
+前端/端到端：`npm run check:emits`、`npm run build:h5`；
+若本次动到设置页展示（见 D3），补 `npm run test:app-e2e`。
+
+## 7. 已确认的决策（2026-08-07）
+
+**方案选型**：走 (a)。(b) 的触发条件（出现第二方托管的 server 实例）写进契约文档备查。
+
+**D1：`AWD_PLATFORM_KEY_SECRET` 缺失 → 启动即失败**，仅在
+`security.awdk-login-enabled=true`（即官方云后端形态）时生效，给出精确配置提示。
+明文兜底是典型的「潜伏逃生门」（`cors.allow-all` 那类），不留。
+local-mode 与未开桥接的团队服务器不受影响——它们根本不走 per-user 路径。
+
+**D2：模型实例缓存本次一并有界化**。access-order `LinkedHashMap`，上限 64 条。
+per-user 化正是把它从 O(模型数) 变成 O(用户数×模型数) 的那次改动。
+
+**D3：额度面板一起做**。后端 `status` / `refresh` 两个端点 + 插件设置页的「AI 额度」卡片
+（上限 / 已用 / 剩余 / 最近验证时间 / 刷新入口）。已用与剩余取自 OpenRouter
+`GET /api/v1/key`（server 侧代查，key 明文不出后端）。
+
+**D4：本仓 `doc/desktop-contract.md` 待办条目 1 本 PR 顺手删除**（accountId 官网已实施
+并已进权威契约与 contract-check）。
+
+## 8. 实施记录（2026-08-07）
+
+新增：`service/ai/PlatformAiKeyService`、`PlatformAiKeyCipher`、`PlatformAiUserScope`、
+`model/entity/PlatformAiKey` + repository、`controller/PlatformAiKeyController`；
+插件设置页「AI 额度」卡片 + `taskpane/lib/api.js` 两个函数。
+
+改动：`PlatformAiChannel`（四分支路由 + `availableFor/resolveFor/onKeyRejected/onKeyVerified/hasPerUserKeys`）、
+`PlatformUsageAccountant`（指纹分桶 + 4 分片 worker + 401 作废 + `probeUsageForDisplay`）、
+`ChatModelFactory`（作用域取 key、缓存有界化、降级守卫）、`TokenUsageService`（对账带 userId）、
+`AccountService`（`fetchProfileWith` / `fetchAiKeyWith` 两个显式给 Key 的重载）、
+`AwdkLoginService`（桥接后 `tryProvision`）、`AiChatController#getAiConfig`（可用性按人算）、
+以及 8 处身份作用域设置点。
+
+与设计的偏差：无。两处实现细节值得记：
+
+1. `provision/evict/markVerified` 上**没有** `@Transactional`——它们都是单仓储操作，
+   而 `tryProvision`/`refresh` 是同类自调用（代理不生效），标了反而给出假保证。
+2. 「多租户下缺身份即拒绝」的判据用 `multiTenant()`（本实例存在任一绑定）而不是「非 local-mode」。
+   后者会让一台谁都没桥接过的团队服务器因为某处漏传身份就被打断；前者把严格判据
+   只落在真正的多租户实例上，团队服务器的机器级路径逐字不变。
+
+验证：`mvn test` 1142 项全绿（新增 51 项）；官网仓 `contract-check` 26 项全绿（该侧仅文档改动）；
+`office-addin` 构建通过。`frontend/` 一行未改，故未跑该目录的 e2e。
+
+**部署动作（必做，否则官方云后端起不来）**：给插件云后端加环境变量
+`AWD_PLATFORM_KEY_SECRET`（任意高熵字符串，与官网的 `AWD_KEY_ENCRYPTION_SECRET` 是两把无关的密钥）。
+这是 D1 有意选择的启动强不变式：`security.awdk-login-enabled=true` 且缺该变量时拒绝启动。
+
+## 9. 明确不做
+
+- 不引入官网服务端-服务端凭据（方案 b）。触发条件写进契约文档：**出现第二方托管的 server 实例时**再立项。
+- 不改 `langchain4j` 版本、不改 `usage.cost` 的读取路径（对账口径沿用差分法）。
+- 不动 local-mode 的任何行为。
+- 不动 `MachineAccountGuard` 的 admin 口径：`account.json` / `entitlements.json` 仍是机器级状态，
+  本设计新增的是**并行**的一条 per-user 通道，不是替换。
+- 不做 per-user 的 entitlement（权益仍是机器级；插件云后端的付费闸门在官网侧）。

--- a/office-addin/taskpane/components/SettingsView.vue
+++ b/office-addin/taskpane/components/SettingsView.vue
@@ -62,12 +62,53 @@
 
       <p v-if="keyStatus" class="status" :class="keyStatusKind">{{ keyStatus }}</p>
     </section>
+
+    <section v-if="quota" class="card quota-card">
+      <h2>AI 额度</h2>
+      <p class="hint">
+        「AI Workdeck 云端」通道按账号计费，额度在官网账户页从余额分配。
+      </p>
+
+      <dl class="quota">
+        <div class="quota-row">
+          <dt>额度上限</dt>
+          <dd>{{ money(quota.limitUsd) }}</dd>
+        </div>
+        <div class="quota-row">
+          <dt>已用</dt>
+          <dd>{{ money(quota.usageUsd) }}</dd>
+        </div>
+        <div class="quota-row">
+          <dt>剩余</dt>
+          <dd>{{ money(quota.remainingUsd) }}</dd>
+        </div>
+        <div class="quota-row">
+          <dt>最近验证</dt>
+          <dd>{{ shortTime(quota.lastVerifiedAt) }}</dd>
+        </div>
+      </dl>
+
+      <p v-if="quotaNotice" class="status warn">{{ quotaNotice }}</p>
+
+      <div class="actions">
+        <button class="btn secondary" :disabled="refreshing" @click="refreshQuota">
+          {{ refreshing ? '刷新中...' : '用上方账户 Key 刷新额度' }}
+        </button>
+      </div>
+
+      <p v-if="quotaStatus" class="status" :class="quotaStatusKind">{{ quotaStatus }}</p>
+    </section>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { fetchMyProjects, postAwdkLogin } from '../lib/api.js'
+import { computed, onMounted, ref } from 'vue'
+import {
+  fetchMyProjects,
+  postAwdkLogin,
+  fetchPlatformAiStatus,
+  refreshPlatformAiKey
+} from '../lib/api.js'
 import { saveSettings, normalizeBaseUrl } from '../lib/settings.js'
 
 const props = defineProps({
@@ -85,6 +126,74 @@ const awdkKey = ref('')
 const connecting = ref(false)
 const keyStatus = ref('')
 const keyStatusKind = ref('ok')
+/** 平台 AI 通道额度；null = 该后端没有这条能力（旧版本/单机形态），整块不展示 */
+const quota = ref(null)
+const refreshing = ref(false)
+const quotaStatus = ref('')
+const quotaStatusKind = ref('ok')
+
+/** 金额与时间都可能是 null（用量拿不到时不许把 0 当成剩余额度），统一显示为「—」 */
+function money(value) {
+  return typeof value === 'number' ? `$${value.toFixed(2)}` : '—'
+}
+
+function shortTime(value) {
+  if (!value) return '—'
+  const at = new Date(value)
+  return Number.isNaN(at.getTime()) ? '—' : at.toLocaleString()
+}
+
+const quotaNotice = computed(() => {
+  const q = quota.value
+  if (!q) return ''
+  if (!q.bound) return '本账号尚未通过账户 Key 直连，暂不能使用云端通道。'
+  if (q.stale) return '密钥超过 30 天未验证，已暂停使用，刷新后恢复。'
+  if (!q.hasKey) return '尚未分配 AI 额度，可在官网账户页从余额分配后回来刷新。'
+  if (!q.usageAvailable) return '暂时取不到实时用量，已用与剩余显示为「—」。'
+  return ''
+})
+
+async function loadQuota() {
+  if (!serverUrl.value.trim() || !token.value.trim()) {
+    quota.value = null
+    return
+  }
+  quota.value = await fetchPlatformAiStatus({
+    serverUrl: serverUrl.value,
+    token: token.value.trim()
+  })
+}
+
+/**
+ * 服务端不保存账户 Key，所以「在官网分配额度之后」只能由用户再贴一次 Key 来重取。
+ * 复用上方的输入框，用完即清空。
+ */
+async function refreshQuota() {
+  quotaStatus.value = ''
+  const key = awdkKey.value.trim()
+  if (!key) {
+    quotaStatusKind.value = 'error'
+    quotaStatus.value = '刷新未开始：请在上方粘贴 awdk_ 账户 Key'
+    return
+  }
+  refreshing.value = true
+  try {
+    quota.value = await refreshPlatformAiKey(
+      { serverUrl: serverUrl.value, token: token.value.trim() },
+      key
+    )
+    awdkKey.value = ''
+    quotaStatusKind.value = 'ok'
+    quotaStatus.value = '额度已刷新'
+  } catch (e) {
+    quotaStatusKind.value = 'error'
+    quotaStatus.value = e.message || '额度刷新失败'
+  } finally {
+    refreshing.value = false
+  }
+}
+
+onMounted(loadQuota)
 
 async function testConnection() {
   status.value = ''
@@ -141,6 +250,8 @@ async function connectWithKey() {
     saveSettings({ serverUrl: serverUrl.value, token: awdtToken })
     keyStatusKind.value = 'ok'
     keyStatus.value = '连接成功：已换取设备令牌'
+    // 桥接同时会为本账号取一把平台 AI 密钥，这里顺手把额度显示出来
+    await loadQuota()
     emit('saved', { serverUrl: normalizeBaseUrl(serverUrl.value), token: awdtToken })
   } catch (e) {
     keyStatusKind.value = 'error'
@@ -165,6 +276,27 @@ async function connectWithKey() {
 }
 
 .key-card { margin-top: 12px; }
+.quota-card { margin-top: 12px; }
+
+.quota {
+  margin: 0 0 12px;
+  font-size: 12px;
+}
+
+.quota-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--awd-border);
+}
+
+.quota-row:last-child { border-bottom: none; }
+
+.quota dt { color: var(--awd-text-secondary); }
+.quota dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
 
 h2 {
   margin: 0 0 6px;
@@ -237,4 +369,5 @@ input:focus, textarea:focus {
 
 .status.ok { color: #1d7a3e; }
 .status.error { color: var(--awd-danger); }
+.status.warn { color: var(--awd-text-secondary); }
 </style>

--- a/office-addin/taskpane/lib/api.js
+++ b/office-addin/taskpane/lib/api.js
@@ -73,6 +73,57 @@ export async function postAwdkLogin({ serverUrl }, key) {
 }
 
 /**
+ * 取本账号的平台 AI 通道额度（GET /api/platform-ai/key/status）。
+ * 旧后端没有该端点（404）或任何失败时返回 null，由调用方隐藏额度卡片而不是报错——
+ * 额度是附加信息，拿不到不该妨碍对话。
+ */
+export async function fetchPlatformAiStatus({ serverUrl, token }) {
+  const base = normalizeBaseUrl(serverUrl)
+  if (!base || !token) return null
+  try {
+    const resp = await fetch(`${base}/api/platform-ai/key/status`, { headers: headers(token) })
+    if (!resp.ok) return null
+    const data = await resp.json()
+    if (data && data.code === 0 && data.data) return data.data
+  } catch (e) {
+    // 静默降级：额度未知
+  }
+  return null
+}
+
+/**
+ * 用官网账户 Key 重新取一把平台 AI 通道密钥（POST /api/platform-ai/key/refresh）。
+ * 用于「在官网分配额度/重发密钥之后」——服务端不保存账户 Key，只能由用户再贴一次。
+ * Key 用完即弃，不落本机存储。成功返回最新额度状态。
+ */
+export async function refreshPlatformAiKey({ serverUrl, token }, key) {
+  const base = normalizeBaseUrl(serverUrl)
+  if (!base) throw new Error('连接未就绪：后端地址为空')
+  let resp
+  try {
+    resp = await fetch(`${base}/api/platform-ai/key/refresh`, {
+      method: 'POST',
+      headers: headers(token),
+      body: JSON.stringify({ key: (key || '').trim() })
+    })
+  } catch (e) {
+    throw new Error('后端不可达：请检查地址、网络与 HTTPS/证书')
+  }
+  if (resp.status === 404) {
+    throw new Error('该服务器不支持按账号的 AI 额度刷新')
+  }
+  if (!resp.ok) throw new Error(`额度刷新失败（HTTP ${resp.status}）`)
+  let data
+  try {
+    data = await resp.json()
+  } catch (e) {
+    throw new Error('后端响应格式异常')
+  }
+  if (data && data.code === 0 && data.data) return data.data
+  throw new Error('额度刷新未通过：请确认这枚 Key 属于本账号且未过期')
+}
+
+/**
  * 请求后端签发会话 ID（POST /api/agent/conversations，body {projectId}）。
  * 契约与后端并行分支约定；旧后端没有该端点（404）或任何失败时返回 null，
  * 由调用方静默回退到客户端生成的 conv-<毫秒>。


### PR DESCRIPTION
## 问题

官方托管的插件云后端上，平台 AI 通道（`AWD_CLOUD`）是**机器级**的：一把 provisioned OpenRouter key 全服共用。OpenRouter 的额度上限是 per-key 的，于是 A 能把 B 的额度花光；`PlatformUsageAccountant` 的差分对账也会把 A 的消费记到 B 的 `token_usage` 行上。

## 方案：桥接时即取即存（官网侧零改动）

server 在 **awdk-login** 与**显式刷新**这两个时刻短暂持有用户的 `awdk_`，用它调官网现成且幂等的 `POST /api/account/ai-key` 换回该用户的 runtime key，加密落库；`awdk_` 用完即弃、**仍不落库**（PR#268 的既定决策未被推翻）。

三个候选的安全边界比较：

| | a 桥接即取即存（本 PR） | b 服务端凭据 | c 插件直连 |
|---|---|---|---|
| server 被攻破的爆炸半径 | N 把 runtime key 的**剩余额度**（读余额/同步权益/买付费项/签新 key 全要 awdk_，都拿不到） | 有授权表则同左；**无授权表则是全站账户的 key** | 同 a，另加任务窗格里的 awdk_ |
| 吊销是否依赖 server 配合 | 否（官网禁用 runtime key，OpenRouter 侧立即失效） | 否 | 否 |
| 离线行为 | 可用，30 天封顶（与 `EntitlementService.OFFLINE_GRACE` 同口径） | 不可用；要可用就得缓存 → 退化成 a | 不可用 |
| 官网侧工作量 | **零** | 新表 + 新端点 + 撤销 UI + 契约 | 中 |
| 后台线程（编排 `@Async`/记忆池/子 Agent/PPT）可用 | 是 | 是 | **否，致命** |

c 直接出局：把凭据挪到最不可信的一层（roamingSettings 会同步到微软云），且 server 侧一半的 AI 调用发生在请求生命周期之外，「每请求透传」覆盖不到，最后仍得在 server 缓存。b 的唯一优势是更贴心智的撤销按钮，但为一台自营 server 引入一把能拉取全站密钥的长期主凭据不划算——**触发重评的条件（出现第二方托管的 server 实例）已写进两仓契约文档**，届时只换 `PlatformAiKeyService` 这一个出口。

## 主要改动

- **`PlatformAiChannel` 成为取 key 的唯一路由出口**，四分支：local-mode 恒走机器级（**一字不动**）；server + 已桥接 → per-user；server + 本实例存在任一绑定时，未桥接用户与缺身份**一律拒绝，绝不回落机器级 key**；server + 零绑定的团队服务器 → 机器级路径逐字不变。第三条用「存在任一绑定」而非「非 local-mode」收口，是为了让没人桥接的团队服务器不会因为某处漏传身份就被打断。
- **`PlatformAiUserScope`** 承载「这次调用花谁的额度」。`getChatModel` 有十余个调用点，其中 4 个的签名里根本没有 userId，穿参要改动整个 ai-chat 领域的调用链；改用显式作用域 + 8 处入口设置，跨线程提交显式 `wrap`。**漏传的后果被设计成报错而非记错账**——错账是静默的，报错能被测试抓到。
- **对账按密钥指纹分桶**（不是 userId：key 轮换时指纹变、基线自动重建），worker 按指纹分片（同 key 仍严格串行，不同用户并行）。探针兼做吊销探测：OpenRouter 401/403 立刻删本地密钥，网络不可达一律保留；外层 30 天未验证即过期。
- 密钥 AES-256-GCM 落库，密文形态与官网 `lib/openrouter-keys.ts` 逐字对齐。`security.awdk-login-enabled=true` 时缺 `AWD_PLATFORM_KEY_SECRET` **拒绝启动**。
- 新增会话级端点 `/api/platform-ai/key/{status,refresh}`（不走 `MachineAccountGuard` 的 admin 闸——那道闸管的是整台服务器的账户连接）；插件设置页加「AI 额度」卡片。刷新必须校验 `awdk_` 对应的 accountId 与本账号绑定一致，否则等于把别人的额度装到自己名下用。
- 顺带：模型实例缓存有界化（per-user 化把它从 O(模型数) 变成 O(用户数×模型数)）；机器级账户断开时若仍有 per-user 密钥则不降级；`doc/desktop-contract.md` 的 accountId 待办条目已实施，按该文件自己的规则移除。

## 验证

- `mvn test` **1142 项全绿**（新增 51 项，含两用户交替消费的对账隔离回归、四种形态的取 key 路由、跨线程身份重放、密文篡改）
- 官网仓 `contract-check` 26 项全绿（该侧仅文档改动）
- `office-addin` 构建通过；`frontend/` 一行未改

## 部署动作（必做）

给插件云后端加环境变量 **`AWD_PLATFORM_KEY_SECRET`**（任意高熵字符串，与官网的 `AWD_KEY_ENCRYPTION_SECRET` 是两把无关的密钥）。缺它且开着账户桥接时服务拒绝启动——这是有意选择的启动强不变式，明文降级是典型的潜伏逃生门。

设计文档：`docs/superpowers/specs/2026-08-07-per-user-platform-ai-key.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)