### PR TITLE
fix: desktop-e2e 把 APP_E2E_BACKEND 端口传给 Electron 壳（渲染层原去了 9696）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -32,14 +32,14 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 | `npm run check:emits` | frontend/ | @event 绑定 vs $emit 声明静态护栏（scripts/check-emit-bindings.mjs） |
 | `npm run test:lowa-e2e` | frontend/ | LOWA 真引擎+键盘链路（tests/lowa-e2e/run.mjs，puppeteer-core 无头，基线 19 组 169 断言；不经应用页面，天然无登录前置） |
 | `npm run test:app-e2e` | frontend/ | 全应用真人模拟（tests/app-e2e/run.mjs；PR-A 去登录后 J1=首启解锁门（试用码），其余旅程 local-mode 免登直达，不再注册 qa_bot_*；需 dev:h5 **5174** + local-mode 后端（默认 9696，冷启动可用新 jar 9797 顶班 + 隔离 user.home/H2/cwd，APP_E2E_JAR 供 J11）。**发版前必跑** |
-| `npm run test:desktop-e2e` | frontend/ | 桌面保存链路（弹 dev Electron 窗口，webview 真 LOWA 插文本→保存→API 下载验内容；PR-A 后免登直达，provision 会自动用试用码解锁+置向导） |
+| `npm run test:desktop-e2e` | frontend/ | 桌面保存链路（弹 dev Electron 窗口，webview 真 LOWA 插文本→保存→API 下载验内容；PR-A 后免登直达，provision 会自动用试用码解锁+置向导）。`APP_E2E_BACKEND` 的端口会经 `CHECKBA_BACKEND_PORT` 传给 Electron 壳——渲染层的基址是壳注入的，只改 `VITE_API_BASE_URL` 对它无效 |
 
 每日全量 QA：`scripts/qa-nightly.sh`（crontab，跑在 ~/aiworkdeck-qa/repo 专用克隆，报告 ~/aiworkdeck-qa/reports/，失败 gh 开 issue 标签 qa-nightly，引擎取自已安装 app）。
 
 ## 端口体系（2026-08 起）
 
 - **打包态桌面后端：5269 → 5369 → 5169 → 随机**（`desktop/main/services/backend-service.js` allocateBackendPort：真实 bind 探测；被占时先探 `/api/admin/wizard` 验明是否自家后端——是则复用，否则降级下一个。service-manager 的 verifyReuse/reallocatePort 契约即为此加）。实际端口经 BrowserWindow additionalArguments → preload → `window.checkbaDesktop.apiBaseUrl` 注入渲染层，`frontend/src/services/api.js` 最优先读它。
-- **dev 态后端仍 9696**：restart-backend.sh / e2e / CI 全部不变；`CHECKBA_BACKEND_PORT` 可显式覆盖两种模式。
+- **dev 态后端仍 9696**：restart-backend.sh / e2e / CI 全部不变；`CHECKBA_BACKEND_PORT` 可显式覆盖两种模式。注入优先级高于 `VITE_API_BASE_URL`，所以**凡是走 Electron 壳的测试/脚本，要换后端必须改 `CHECKBA_BACKEND_PORT`**，只指 dev server 的环境变量不管用（desktop-e2e 曾因此整条链失败）。
 - pptx/mineru/kokoro 打包态是动态回环端口（由后端内部转发，前端不可见）；编辑器静态服务器 47613 因 COOP/COEP 跨源隔离必须独立源，勿并入。
 
 ## 本地开发启动
@@ -72,6 +72,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 - iCloud 驱逐会掏空本地文件（打包/测试环境两次踩）；EMFILE 用抬 ulimit 解。
 - worktree 冷启动跑双 e2e 完整配方见 v0.7.7 发版实录；worktree merge 报 stash failed 用 cherry-pick 绕。
 - 坏 pnpm node_modules 遇到过——本项目一律 npm。
+- **worktree 的 node_modules 落后于新增依赖**（如 TOTP 带来的 `qrcode`）时，vite 会推一个盖满视口的 `vite-error-overlay`，坐标点击全被它吃掉，e2e 表现成"点了没反应"的超时而非编译错误。冷启动 worktree 跑 e2e 前先 `npm install`；desktop-e2e 的点击已加命中校验，会直接报出遮挡者和它的文案。
 - 分支保护拦 gh pr merge 时权宜 = 用户网页点 Bypass rules and merge（白名单未配成）。
 - `docs/` 在 .gitignore，入库要 `git add -f`。
 

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -15,7 +15,8 @@
 // 注意：会在屏幕上弹出一个 dev Electron 窗口，跑完自动关闭。
 // PR-A 后无登录：local-mode 免登直达，不再注册 qa_desk 账号、不再注入会话。
 //
-// Env：DESKTOP_E2E_DEVURL（默认 http://localhost:5174）、APP_E2E_BACKEND（默认 9696）
+// Env：DESKTOP_E2E_DEVURL（默认 http://localhost:5174）、APP_E2E_BACKEND（默认 9696；
+// 端口会经 CHECKBA_BACKEND_PORT 传给 Electron 壳，渲染层因此跟测试用同一个后端）
 
 import { spawn, execSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -28,6 +29,13 @@ const frontendDir = path.resolve(here, '../..')
 const desktopDir = path.resolve(frontendDir, '../desktop')
 const DEVURL = process.env.DESKTOP_E2E_DEVURL || 'http://localhost:5174'
 const BACKEND = process.env.APP_E2E_BACKEND || 'http://127.0.0.1:9696'
+// 渲染层的后端地址由桌面壳注入（BrowserWindow additionalArguments → preload →
+// window.checkbaDesktop.apiBaseUrl），api.js 最优先读它——比 VITE_API_BASE_URL 还
+// 靠前。所以只把 dev server 指向 APP_E2E_BACKEND 不够：壳仍会注入 dev 默认 9696，
+// 页面便去了另一个后端，而这里 provision 的项目在 APP_E2E_BACKEND 上。
+// CHECKBA_BACKEND_PORT 是 backend-service.js 留的显式覆盖口，同时让壳复用这个已在
+// 跑的后端（verifyReuse 探 /api/admin/wizard）而不是另起一个 java。
+const BACKEND_PORT = new URL(BACKEND).port
 const CDP_PORT = 9333
 const MARKER = 'QA_SAVE_MARKER_' + Date.now()
 
@@ -76,7 +84,12 @@ async function api(ep, opts = {}) {
 console.log('启动 dev Electron（屏幕会出现窗口，结束自动关闭）...')
 const elec = spawn('npx', ['electron', '.', '--remote-debugging-port=' + CDP_PORT], {
   cwd: desktopDir,
-  env: { ...process.env, AIWORKDECK_DESKTOP_DEV: '1', CHECKBA_DEV_SERVER_URL: DEVURL },
+  env: {
+    ...process.env,
+    AIWORKDECK_DESKTOP_DEV: '1',
+    CHECKBA_DEV_SERVER_URL: DEVURL,
+    CHECKBA_BACKEND_PORT: BACKEND_PORT,
+  },
   stdio: ['ignore', 'pipe', 'pipe'],
 })
 const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'desktop-e2e-electron.log'))
@@ -106,15 +119,43 @@ try {
   }
   if (!page) throw new Error('找不到主渲染页')
 
-  const mouseClickSel = async (sel) => {
-    await page.waitForSelector(sel, { timeout: 15000 })
-    const box = await page.evaluate((s) => {
-      const el = document.querySelector(s); if (!el) return null
+  // 壳注入的基址若和 provision 用的后端不是同一个，后面每一步都会以"点了没反应"
+  // 的形态超时（文件建在别的库里/根本建不出来）。这里当场报死，别让人去查 UI。
+  {
+    const injected = await page.evaluate(() => (window.checkbaDesktop || {}).apiBaseUrl || null)
+    if (!injected || new URL(injected).port !== BACKEND_PORT) {
+      throw new Error('渲染层后端(' + injected + ') 与测试后端(' + BACKEND + ') 不一致')
+    }
+  }
+
+  // 坐标点击的通病：任何全屏浮层都会把点吃掉，而现象只是"点了没反应"——真正的
+  // 报错落在下一个 waitFor 上，十几秒后一句没头没尾的超时。dev 的 vite-error-overlay
+  // 就这么骗过一次（node_modules 落后于新增依赖，vite 推编译错误盖满视口）。
+  // 命中校验把它当场变成可读的错误。
+  const HIT_CHECK = `
+    function hitCheck(el) {
       const r = el.getBoundingClientRect()
-      return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
-    }, sel)
+      const x = r.x + r.width / 2, y = r.y + r.height / 2
+      const hit = document.elementFromPoint(x, y)
+      if (hit && el.contains(hit)) return { x, y }
+      let who = hit ? hit.tagName.toLowerCase() : '(空白)'
+      try { if (hit && hit.shadowRoot) who += ': ' + hit.shadowRoot.textContent.replace(/\\s+/g, ' ').trim().slice(0, 200) } catch (e) {}
+      return { x, y, blockedBy: who }
+    }`
+  const clickAt = async (box, what) => {
+    if (!box) throw new Error('找不到可点元素: ' + what)
+    if (box.blockedBy) throw new Error('点击被遮挡[' + box.blockedBy + ']: ' + what)
     await page.mouse.click(box.x, box.y)
     await sleep(700)
+  }
+
+  const mouseClickSel = async (sel) => {
+    await page.waitForSelector(sel, { timeout: 15000 })
+    const box = await page.evaluate((check, s) => {
+      const el = document.querySelector(s); if (!el) return null
+      return eval(check + '; hitCheck(el)')
+    }, HIT_CHECK, sel)
+    await clickAt(box, sel)
   }
 
   await step('免登直达进入项目（PR-A 去登录：不注会话）', async () => {
@@ -123,16 +164,13 @@ try {
   })
 
   const mouseClickText = async (label) => {
-    const box = await page.evaluate((lbl) => {
+    const box = await page.evaluate((check, lbl) => {
       const els = [...document.querySelectorAll('*')].filter((el) =>
         el.children.length === 0 && el.innerText && el.offsetParent !== null && el.innerText.trim().includes(lbl))
       const el = els[0]; if (!el) return null
-      const r = el.getBoundingClientRect()
-      return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
-    }, label)
-    if (!box) throw new Error('找不到文本: ' + label)
-    await page.mouse.click(box.x, box.y)
-    await sleep(700)
+      return eval(check + '; hitCheck(el)')
+    }, HIT_CHECK, label)
+    await clickAt(box, '文本 ' + label)
   }
 
   await step('新建 Word 文档并点击打开（编辑器 webview）', async () => {


### PR DESCRIPTION
## 问题

`frontend/tests/desktop-e2e/run.mjs` 的「新建 Word 文档并点击打开（编辑器 webview）」一步失败：`Waiting failed: 15000ms exceeded`（等 `body.innerText` 出现 `newdocument` 超时），后端项目文件列表为空。同一按钮在浏览器目标（dev:h5 5174 + 后端 9797）下正常。

结论：**两层互相掩盖的测试驱动问题，产品代码没有缺陷**（`leftPaneKey` 是 `files`、`$refs.fileTree` 在、直接调 `onFileTreeQuickAction('newFile')` 立刻建出文件）。

## 根因一：渲染层去了另一个后端

渲染层的 API 基址由桌面壳注入（`desktop/main/main.js` `additionalArguments` → `desktop/preload/preload.js` → `window.checkbaDesktop.apiBaseUrl`），而 [`frontend/src/services/api.js:105`](frontend/src/services/api.js#L105) 读它的优先级**高于** `VITE_API_BASE_URL`。

驱动只把 dev server 指向 `APP_E2E_BACKEND`，壳仍按 dev 默认注入 `http://127.0.0.1:9696`（实测确认）。于是 provision 建在 9797 的项目在页面里根本不存在 → `createFile` 失败 → 文件树永远等不到 `newdocument` → 9797 的文件列表自然是空的。默认 9696 时两者恰好重合，所以过去一直没暴露。

修法：把端口经 `CHECKBA_BACKEND_PORT`（`backend-service.js:43` 专为脚本/e2e 留的显式覆盖口）一并传给壳。壳因此也会 `verifyReuse` 复用这个已在跑的后端，而不是另起一个 java。另加一道启动即校验的守卫，不一致当场报死。

## 根因二：坐标点击被全屏浮层吃掉

worktree 的 `node_modules` 落后于 TOTP 引入的 `qrcode` 依赖时，vite 推 `vite-error-overlay` 盖满视口，`page.mouse.click` 落在浮层上而不是按钮上。现象只是"点了没反应"，真正的报错变成下一个 `waitFor` 的无信息超时——第一层修完后正是它继续挡路。

修法：给两个点击助手加 `elementFromPoint` 命中校验，当场报出遮挡者标签及其 shadowRoot 文案。（`node_modules` 本身 `npm install` 即可，非代码问题；已在 eng-infra 地雷区记一笔。）

## 验证

本机 dev:h5 5174 + 隔离 `user.home`/H2 的 desktop profile 后端 9797：

- `APP_E2E_BACKEND=http://127.0.0.1:9797 npm run test:desktop-e2e` 连续两次**五步全通**（docx 落盘 9443 字节、标记命中）。
- 修复前同环境稳定复现 4 步失败。
- 守卫的失败路径单独验过：注入端口不符会报错；人造全屏浮层会报出 `blockedBy` 及其文案。

## 文档

按维护规则同步更新 `.claude/agents/eng-infra.md`：测试命令表、端口体系、已知地雷各一处。

🤖 Generated with [Claude Code](https://claude.com/claude-code)