### PR TITLE
docs: 向导闸门形态修正 + 云后端首次上线必配项清单

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -71,9 +71,12 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
   基线按**密钥指纹**分桶、worker 按指纹分片；兼做吊销探测（401/403 即作废本地密钥）。
 - `service/ai/ChatModelFactory.java` — `Provider.AWD_CLOUD` 路由；`demotePlatformProvider()` 在断开账户时把供应商降级回落。
 - `model/entity/TokenUsage.java` 的 `costSource`：`platform`（真实扣费）/ `estimate`（BYOK 单价表估算）。
-- 前端选平台通道有**两个**入口，判据必须一致（已连接账户 + 已分配额度，缺哪个都展示但不可选并给下一步）：
-  `pages/admin/admin.vue` 的 `aiProviderOptions`、`pages/wizard/wizard.vue` 的 `providerOptions`（首启向导，
-  条件齐备时自动预选平台通道；向导刻意不预选任何供应商，见下方地雷 14）。
+- 前端选平台通道有**两个**入口，前置条件相同（已连接账户 + 已分配额度）但**闸门形态不同**，别照抄：
+  - `pages/admin/admin.vue` 的 `aiProviderOptions`——缺条件时展示但 `unavailable`，`hint` 指出下一步
+    （「需先连接账户」/「需先在官网分配额度」）；
+  - `pages/wizard/wizard.vue` 的 `providerOptions`——`AWD_CLOUD` **恒可选**，选中就地展开连接块把条件补齐，
+    闸门挪到 `handleSubmit`（见下方地雷 15：向导里的每一条「下一步」都必须能在向导里做完）。
+    向导刻意不预选任何供应商，见下方地雷 14。
 
 **广场付费项（PR-D，链路见 plugin-marketplace.md）**
 - `backend/src/main/java/com/checkba/service/market/MarketPurchaseGate.java` — Skill 与插件两条安装链路共用的付费判定单一出口。

--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -32,6 +32,13 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 - 错误文案不得含「登录/未授权/请先」子串（主前端以此判定未登录清会话；licensing 领域红线）。统一说「连接未就绪/令牌无效/账户直连失败」。awdk 失败**不透传服务端原文**（服务端文案不受该红线约束）。
 - 全局禁 emoji；包管理 npm 不是 pnpm。
 - 部署期 CORS：插件正式 Origin 要进 `security.cors.allowed-origins`；local-mode 下 LocalModeAccessFilter 用同一份白名单硬拦非 GET 跨站请求。`security.cors.allow-all` 绝不能开。localhost/127.0.0.1 默认放行，开发态零配置。
+- **云后端首次上线的必配项清单**（Phase D 生产化尚未做，站起来之前照这张单子过一遍；截至 2026-08-07 两台 ECS 上都还没有这个后端实例）：
+  `security.local-mode=false`（默认）、`security.registration-mode=closed`、`security.awdk-login-enabled=true`、
+  `security.conversation-issuance-required=true`、`security.cors.allowed-origins` 填插件正式 Origin，
+  以及环境变量 **`AWD_PLATFORM_KEY_SECRET`**（per-user 平台 AI 密钥的落库加密密钥，任意高熵串，
+  例如 `openssl rand -base64 32`）。**最后这条是启动强不变式**：`awdk-login-enabled=true` 而它缺失时
+  服务直接拒绝启动（`PlatformAiKeyCipher` 构造器，licensing 领域地雷 17），刻意不做明文降级。
+  它与官网侧的 `AWD_KEY_ENCRYPTION_SECRET` 是两把互不相干的密钥，别复用同一个值。
 - Office 只加载 https 任务窗格：dev 证书 `npx office-addin-dev-certs install`，vite 配置自动拾取。
 - **新增 office_* 工具三件套**：后端 OfficeEditTools 加 @Tool + officeExecutor.js 的 HANDLERS 加实现 + COMMAND_DISPLAY_NAMES 加中文名，**并在 COMMAND_HOSTS 标宿主**。没有客户端实现的远端工具 = 30s 超时空转（PptxEditTools 教训）。**工具名前缀决定宿主可见性**：Excel 面必须 office_excel_*、PPT 面必须 office_ppt_*，其余 office_* 归 Word——起错前缀会漏进错误宿主的会话（死路径）。
 - Word 的 body.search 查找串上限 255 字符（后端工具已前置校验）；search/replace 的锚点必须与文档文本精确一致（matchCase）。


### PR DESCRIPTION
两条纯文档修正，无代码改动。

## 1. 平台通道两个入口的闸门形态（`licensing-billing.md`）

文件地图里仍写着两个入口「判据必须一致（缺哪个都展示但**不可选**并给下一步）」，而 [#292](https://github.com/zeweihan/aiworkdeck/pull/292) 已经把向导侧改成 `AWD_CLOUD` **恒可选**、选中就地展开连接块、闸门挪到 `handleSubmit`——与它自己新增的地雷 15（「向导里每一条『下一步』都必须能在向导里做完」）直接打架。照这行去改代码，会把 #292 刚拆掉的死路重新装回去。

现在两侧分开写：`admin.vue` 是「展示但 `unavailable` + `hint` 指下一步」，`wizard.vue` 是「恒可选 + 就地补齐条件 + 不可提交」。前置条件（已连接账户 + 已分配额度）两侧仍然相同，改的只是「不满足时怎么拦」。

## 2. 云后端首次上线的必配项清单（`office-addin.md`）

[#293](https://github.com/zeweihan/aiworkdeck/pull/293) 带来一条启动强不变式：`security.awdk-login-enabled=true` 而 `AWD_PLATFORM_KEY_SECRET` 缺失时服务**拒绝启动**（刻意不做明文降级）。

这条要求落在「云后端第一次站起来」的那一刻，而 Phase D 生产化还没做——2026-08-07 逐台实测，北京 ECS 与新加坡 ECS 上**都没有这个后端实例**（无 JVM / jar / systemd unit / 监听端口）。所以现在没有可改的运行环境，只能把它钉进接手时会读的文档里，顺带把散在各处的 server 模式必配项收成一张单子：`local-mode` / `registration-mode` / `awdk-login-enabled` / `conversation-issuance-required` / CORS 白名单 + 这个环境变量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)