### PR TITLE
插件会话不丢 + 插件临时项目 + 字符级最小修订（批次2+3）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ProjectController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectController.java
@@ -17,6 +17,9 @@ import java.util.Map;
 @RequestMapping("/api/projects")
 public class ProjectController {
 
+    /** 插件懒建项目的固定名称 */
+    private static final String ADDIN_DEFAULT_PROJECT_NAME = "插件临时项目";
+
     private final ProjectService projectService;
     private final ProjectMemberService projectMemberService;
     private final com.checkba.service.LocalProjectService localProjectService;
@@ -49,6 +52,43 @@ public class ProjectController {
             throw new IllegalArgumentException("请先登录");
         }
         return projectService.createProject(request, userId);
+    }
+
+    /**
+     * Office 插件用：没有任何项目的账号，懒建一个「插件临时项目」。
+     *
+     * 项目是租户隔离维度（chat/history 等接口都按 projectId 判权），不能放开 null；
+     * 但插件用户不该被逼着先去桌面端建项目才能说第一句话。语义：
+     * - 已有任一项目 → 不建，返回 {created:false, project:null}（由用户自己选）；
+     * - 一个都没有 → 建一个并返回 {created:true, project:{id,name}}。
+     *
+     * 幂等靠「先查后建」。同一用户从插件并发首发的窗口极小（任务窗格单实例、首启只发一次），
+     * 故不引锁；真撞上了最坏结果是多出一个空项目，用户可自行删除。
+     * local-mode 与 server 模式行为一致：都只要求有效会话，无特判。
+     */
+    @PostMapping("/ensure-addin-default")
+    public Map<String, Object> ensureAddinDefaultProject(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = getUserIdFromSession(sessionId);
+        if (userId == null) {
+            throw new IllegalArgumentException("请先登录");
+        }
+        Map<String, Object> result = new HashMap<>();
+        if (!projectService.getUserProjectCardDTOs(userId).isEmpty()) {
+            result.put("created", false);
+            result.put("project", null);
+            return result;
+        }
+        ProjectCreateRequest request = new ProjectCreateRequest();
+        request.setProjectType("BLANK");
+        request.setName(ADDIN_DEFAULT_PROJECT_NAME);
+        Project project = projectService.createProject(request, userId);
+        Map<String, Object> projectInfo = new HashMap<>();
+        projectInfo.put("id", project.getId());
+        projectInfo.put("name", project.getName());
+        result.put("created", true);
+        result.put("project", projectInfo);
+        return result;
     }
 
     /**

--- a/backend/src/test/java/com/checkba/controller/ProjectControllerAddinDefaultTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectControllerAddinDefaultTest.java
@@ -1,0 +1,124 @@
+package com.checkba.controller;
+
+import com.checkba.model.dto.ProjectCardDTO;
+import com.checkba.model.dto.ProjectCreateRequest;
+import com.checkba.model.entity.Project;
+import com.checkba.service.LocalProjectService;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.ProjectService;
+import com.checkba.storage.ProjectStorageResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * 锁定「插件临时项目」端点的幂等语义：
+ * 项目是租户隔离维度不能为空，但插件用户不该被逼着先建项目——
+ * 一个都没有时建一个，已有任一项目时绝不再建（否则每次开窗格都多一个空项目）。
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectControllerAddinDefaultTest {
+
+    @Mock
+    private ProjectService projectService;
+    @Mock
+    private ProjectMemberService projectMemberService;
+    @Mock
+    private LocalProjectService localProjectService;
+    @Mock
+    private ProjectStorageResolver storageResolver;
+
+    @InjectMocks
+    private ProjectController controller;
+
+    @Test
+    void createsOnlyOneProjectAcrossRepeatedCalls() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+
+            Project created = new Project();
+            created.setId(42L);
+            created.setName("插件临时项目");
+            when(projectService.createProject(any(ProjectCreateRequest.class), eq(1L))).thenReturn(created);
+
+            ProjectCardDTO card = new ProjectCardDTO();
+            card.setId(42L);
+            card.setName("插件临时项目");
+            // 第一次调用时账号还没有项目；建好之后列表里就有了
+            when(projectService.getUserProjectCardDTOs(1L)).thenReturn(List.of(), List.of(card));
+
+            Map<String, Object> first = controller.ensureAddinDefaultProject("sess");
+            assertEquals(true, first.get("created"));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> project = (Map<String, Object>) first.get("project");
+            assertEquals(42L, project.get("id"));
+            assertEquals("插件临时项目", project.get("name"));
+
+            Map<String, Object> second = controller.ensureAddinDefaultProject("sess");
+            assertEquals(false, second.get("created"));
+            assertNull(second.get("project"));
+
+            // 幂等：两次调用只建了一个项目，且是空白项目
+            ArgumentCaptor<ProjectCreateRequest> captor = ArgumentCaptor.forClass(ProjectCreateRequest.class);
+            verify(projectService, times(1)).createProject(captor.capture(), eq(1L));
+            assertEquals("BLANK", captor.getValue().getProjectType());
+            assertEquals("插件临时项目", captor.getValue().getName());
+        }
+    }
+
+    @Test
+    void existingProjectsAreNeverTouched() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            ProjectCardDTO mine = new ProjectCardDTO();
+            mine.setId(3L);
+            mine.setName("某并购项目");
+            when(projectService.getUserProjectCardDTOs(7L)).thenReturn(List.of(mine));
+
+            Map<String, Object> result = controller.ensureAddinDefaultProject("sess");
+
+            assertEquals(false, result.get("created"));
+            assertNull(result.get("project"));
+            verify(projectService, never()).createProject(any(), anyLong());
+        }
+    }
+
+    @Test
+    void requiresValidSession() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession(null)).thenReturn(null);
+
+            assertThrows(IllegalArgumentException.class, () -> controller.ensureAddinDefaultProject(null));
+            verify(projectService, never()).createProject(any(), anyLong());
+            verify(projectService, never()).getUserProjectCardDTOs(anyLong());
+        }
+    }
+
+    @Test
+    void resultKeysAreStable() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(9L);
+            when(projectService.getUserProjectCardDTOs(9L)).thenReturn(List.of(new ProjectCardDTO()));
+
+            Map<String, Object> result = controller.ensureAddinDefaultProject("sess");
+
+            assertTrue(result.containsKey("created"));
+            assertTrue(result.containsKey("project"));
+        }
+    }
+}

--- a/office-addin/taskpane/App.vue
+++ b/office-addin/taskpane/App.vue
@@ -2,8 +2,9 @@
   <div class="app-shell">
     <!-- Office 宿主已按 manifest 的 DisplayName 自绘一条标题，这里不再重复品牌名 -->
     <header class="app-header">
+      <!-- 只有一个项目（含懒建的「插件临时项目」）时没什么可选，直接不渲染下拉 -->
       <select
-        v-if="view === 'chat' && projects.length"
+        v-if="view === 'chat' && projects.length > 1"
         class="project-select"
         :value="projectId"
         @change="onProjectChange($event.target.value)"
@@ -40,7 +41,7 @@ import { computed, onMounted, reactive, ref } from 'vue'
 import SettingsView from './components/SettingsView.vue'
 import ChatView from './components/ChatView.vue'
 import { loadSettings, saveProjectId, isConfigured } from './lib/settings.js'
-import { fetchMyProjects } from './lib/api.js'
+import { fetchMyProjects, ensureAddinDefaultProject } from './lib/api.js'
 
 const settings = reactive(loadSettings())
 const configured = computed(() => isConfigured(settings))
@@ -48,14 +49,33 @@ const view = ref(configured.value ? 'chat' : 'settings')
 const projects = ref([])
 const projectId = ref(settings.projectId || '')
 
+/**
+ * 项目不是插件的必选项：
+ * - 有多个项目：照旧由用户在下拉里选；
+ * - 只有一个项目：直接选中它（没什么可选，下拉也不渲染）；
+ * - 一个都没有：让后端懒建「插件临时项目」并静默选中，用户无感。
+ *   旧后端没有该端点时降级为现状（空态提示去选项目），不报错。
+ */
 async function refreshProjects() {
   if (!configured.value) return
   try {
-    projects.value = await fetchMyProjects(settings)
+    const list = await fetchMyProjects(settings)
+    projects.value = list
     // 记住的项目已不存在时清空选择
-    if (projectId.value && !projects.value.some(p => String(p.id) === projectId.value)) {
+    if (projectId.value && !list.some(p => String(p.id) === projectId.value)) {
       projectId.value = ''
       saveProjectId('')
+    }
+    if (list.length === 1) {
+      onProjectChange(String(list[0].id))
+      return
+    }
+    if (list.length) return
+
+    const created = await ensureAddinDefaultProject(settings)
+    if (created) {
+      projects.value = [created]
+      onProjectChange(String(created.id))
     }
   } catch (e) {
     console.warn('[Addin] 项目列表拉取失败', e)

--- a/office-addin/taskpane/components/ChatView.vue
+++ b/office-addin/taskpane/components/ChatView.vue
@@ -49,18 +49,23 @@
         </div>
       </div>
       <p v-if="reconnecting" class="banner conn">连接中断，正在自动重连……</p>
+      <p v-else-if="notice" class="banner conn">{{ notice }}</p>
       <p v-if="banner" class="banner">{{ banner }}</p>
     </footer>
   </div>
 </template>
 
 <script setup>
-import { computed, nextTick, onBeforeUnmount, reactive, ref } from 'vue'
-import { postChat, postCancel, postOfficeResult, createConversation } from '../lib/api.js'
-import { createSseConnection, createTagStreamParser } from '../lib/sse.js'
-import { readActiveDocument, detectHost } from '../lib/wordDoc.js'
-import { executeOfficeCommand, commandDisplayName } from '../lib/officeExecutor.js'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import {
+  messages, input, streaming, reconnecting, banner, notice, includeDocument, scrollSignal,
+  activateSession, send as sendMessage, stop as stopRun, newConversation
+} from '../lib/chatSession.js'
 
+/**
+ * 纯渲染与交互层：会话态、SSE 连接与 office_command 执行链都在 lib/chatSession.js。
+ * 组件卸载（切到设置视图）不再关连接、不再丢消息——那正是「切一次页面就收不到回复」的根因。
+ */
 const props = defineProps({
   settings: { type: Object, required: true },
   projectId: { type: String, default: '' },
@@ -68,23 +73,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['need-settings'])
 
-const messages = ref([])
-const input = ref('')
-const streaming = ref(false)
-const includeDocument = ref(true)
-const banner = ref('')
 const listEl = ref(null)
-
-// 会话 ID 优先由服务端签发（POST /api/agent/conversations，契约与后端并行分支约定）；
-// 端点不存在或失败时静默回退客户端生成的 conv-<毫秒>（与主前端一致）。插件会话独立。
-let conversationId = null
-let connection = null
-let parser = null
-let currentAssistant = null
-// SSE 是否发生过断线重连：只有重连后的 run_state 才用于兜底解锁
-// （首连的 run_state 在 send 已置 streaming 之后到达，不能当终态看）
-let everReconnected = false
-const reconnecting = ref(false)
 
 const canSend = computed(() =>
   props.configured && props.projectId && input.value.trim().length > 0 && !streaming.value)
@@ -95,179 +84,27 @@ function scrollToBottom() {
   })
 }
 
-function finishStreaming() {
-  if (currentAssistant) currentAssistant.streaming = false
-  streaming.value = false
-}
+// 连接配置或项目变化时重新激活会话（同一身份是空操作，不打断进行中的对话）
+watch(
+  () => [props.settings.serverUrl, props.settings.token, props.projectId],
+  () => { activateSession({ settings: props.settings, projectId: props.projectId }) },
+  { immediate: true }
+)
 
-function handleEvent(evt, dataStr) {
-  if (evt === 'text_delta') {
-    let content = dataStr
-    try { content = JSON.parse(dataStr).content || '' } catch (e) { /* 按原文处理 */ }
-    if (parser) parser.feed(content)
-    scrollToBottom()
-  } else if (evt === 'bubble_end') {
-    if (parser) parser.flush()
-    finishStreaming()
-  } else if (evt === 'error') {
-    let msg = '执行出错'
-    try { msg = JSON.parse(dataStr).message || msg } catch (e) { /* ignore */ }
-    if (currentAssistant) currentAssistant.error = msg
-    finishStreaming()
-  } else if (evt === 'cancelled') {
-    if (currentAssistant && !currentAssistant.text) currentAssistant.text = '（已停止）'
-    finishStreaming()
-  } else if (evt === 'client_action') {
-    handleClientAction(dataStr)
-  } else if (evt === 'run_state') {
-    // 建连时后端推送当前运行状态。仅在断线重连后用作兜底：
-    // 断线期间漏掉了 bubble_end/error 等终态事件时，靠它解锁输入框
-    if (everReconnected && streaming.value) {
-      let status = null
-      try { status = JSON.parse(dataStr).status } catch (e) { /* ignore */ }
-      const stillRunning = status === 'RUNNING' || status === 'PAUSED' || status === 'AWAITING_APPROVAL'
-      if (!stillRunning) {
-        if (parser) parser.flush()
-        finishStreaming()
-      }
-    }
-  }
-  // connected/heartbeat/plan_update 等其余事件：先忽略
-}
+// store 不碰 DOM：由它发出滚动信号，视图负责滚
+watch(scrollSignal, scrollToBottom)
 
-/**
- * office_command 执行链（Phase C 工具桥）：
- * 后端 OfficeBridgeService 下发 {tool:'office_command', requestId, command, args}
- * → Office.js 执行 → POST /api/agent/office/result 回传。
- * 其余 client_action（editor_command 等 LOWA 契约）与本插件无关，忽略。
- */
-async function handleClientAction(dataStr) {
-  let action = null
-  try { action = JSON.parse(dataStr) } catch (e) { return }
-  if (!action || action.tool !== 'office_command' || !action.requestId) return
-
-  const chip = reactive({ label: commandDisplayName(action.command), status: 'running' })
-  if (currentAssistant) {
-    if (!currentAssistant.tools) currentAssistant.tools = []
-    currentAssistant.tools.push(chip)
-    scrollToBottom()
-  }
-
-  const result = await executeOfficeCommand(action.command, action.args)
-  chip.status = result.ok ? 'done' : 'failed'
-  await postOfficeResult(props.settings, {
-    requestId: action.requestId,
-    ok: result.ok,
-    data: result.ok ? result.data : null,
-    error: result.ok ? null : result.error
-  })
-}
-
-async function ensureConnection() {
-  if (connection) return
-  const conn = createSseConnection({
-    baseUrl: props.settings.serverUrl,
-    token: props.settings.token,
-    conversationId,
-    onEvent: handleEvent,
-    onStatus: (status) => {
-      if (connection !== conn) return
-      if (status === 'reconnecting') {
-        everReconnected = true
-        reconnecting.value = true
-      } else if (status === 'connected') {
-        reconnecting.value = false
-      }
-    },
-    onClose: () => {
-      if (connection === conn) connection = null
-      reconnecting.value = false
-      // 连接彻底关闭时不静默卡死输入框（断线重连由 sse.js 内部处理，不走这里）
-      if (streaming.value) finishStreaming()
-    }
-  })
-  connection = conn
-  try {
-    await conn.ready
-  } catch (e) {
-    if (connection === conn) connection = null
-    throw e
-  }
-}
+// 重新挂载（从设置视图切回来）时恢复到最新一条消息
+onMounted(scrollToBottom)
 
 async function send() {
-  banner.value = ''
-  if (!props.configured) { emit('need-settings'); return }
-  if (!props.projectId) { banner.value = '尚未选择项目：在顶部下拉中选一个项目'; return }
-  const prompt = input.value.trim()
-  if (!prompt || streaming.value) return
-
-  input.value = ''
-  messages.value.push({ role: 'user', text: prompt })
-
-  const assistant = reactive({ role: 'assistant', text: '', thinking: '', streaming: true, error: '', tools: [] })
-  messages.value.push(assistant)
-  currentAssistant = assistant
-  parser = createTagStreamParser({
-    onMainText: (t) => { assistant.text += t },
-    onThinkingText: (t) => { assistant.thinking += t }
-  })
-  streaming.value = true
-  scrollToBottom()
-
-  try {
-    // 首条消息前先请求服务端签发会话 ID；旧后端无该端点时静默回退客户端生成
-    if (!conversationId) {
-      conversationId = (await createConversation(props.settings, parseInt(props.projectId, 10)))
-        || `conv-${Date.now()}`
-    }
-    await ensureConnection()
-
-    // 当前文档内容以内联形式随请求上送（activeContext.inlineContent）
-    let activeContext = null
-    if (includeDocument.value) {
-      activeContext = await readActiveDocument()
-      if (!activeContext) banner.value = '未能读取文档内容，本条消息不附带文档内容'
-    }
-
-    await postChat(props.settings, {
-      projectId: parseInt(props.projectId, 10),
-      conversationId,
-      message: prompt,
-      mode: 'AGENT',
-      activeContext,
-      // 声明客户端能力（Phase C）：后端据此让本会话只见 office_* 工具、隐藏 doc_*；
-      // officeHost 再按宿主细分（word/excel/powerpoint），点名对应工具面
-      clientCapability: 'office',
-      officeHost: detectHost() || 'word'
-    })
-  } catch (e) {
-    assistant.error = e.message || '消息发送失败'
-    finishStreaming()
-  }
+  const result = await sendMessage()
+  if (result && result.needSettings) emit('need-settings')
 }
 
-async function stop() {
-  if (conversationId) await postCancel(props.settings, conversationId)
-  if (connection) { connection.close(); connection = null }
-  if (currentAssistant && !currentAssistant.text) currentAssistant.text = '（已停止）'
-  finishStreaming()
+function stop() {
+  stopRun()
 }
-
-function newConversation() {
-  if (connection) { connection.close(); connection = null }
-  conversationId = null
-  messages.value = []
-  currentAssistant = null
-  parser = null
-  banner.value = ''
-  reconnecting.value = false
-  everReconnected = false
-}
-
-onBeforeUnmount(() => {
-  if (connection) connection.close()
-})
 </script>
 
 <style scoped>

--- a/office-addin/taskpane/lib/api.js
+++ b/office-addin/taskpane/lib/api.js
@@ -33,6 +33,52 @@ export async function fetchMyProjects({ serverUrl, token }) {
 }
 
 /**
+ * 一个项目都没有的账号：让后端懒建「插件临时项目」（POST /api/projects/ensure-addin-default）。
+ * 项目是后端的租户隔离维度不能为空，但用户不该被逼着先去建项目。
+ * 已有项目时后端返回 {created:false, project:null}；本函数只关心拿不拿得到项目。
+ * 旧后端没有该端点（404）或任何失败时返回 null，由调用方降级为「请选择项目」的现状，不报错。
+ */
+export async function ensureAddinDefaultProject({ serverUrl, token }) {
+  const base = normalizeBaseUrl(serverUrl)
+  if (!base) return null
+  try {
+    const resp = await fetch(`${base}/api/projects/ensure-addin-default`, {
+      method: 'POST',
+      headers: headers(token)
+    })
+    if (!resp.ok) return null
+    const data = await resp.json()
+    if (data && data.project && data.project.id != null) {
+      return { id: data.project.id, name: data.project.name }
+    }
+  } catch (e) {
+    // 静默降级：由调用方走「请选择项目」的现状路径
+  }
+  return null
+}
+
+/**
+ * 拉某个会话的历史消息（GET /api/ai/history?conversationId=...）。
+ * 任务窗格重建后据此把上一场对话回灌到界面。
+ * 403/404/网络失败一律返回空数组静默降级——历史拿不到不该打断用户开新的对话。
+ */
+export async function fetchConversationHistory({ serverUrl, token }, conversationId) {
+  const base = normalizeBaseUrl(serverUrl)
+  if (!base || !conversationId) return []
+  try {
+    const resp = await fetch(
+      `${base}/api/ai/history?conversationId=${encodeURIComponent(conversationId)}`,
+      { headers: headers(token) })
+    if (!resp.ok) return []
+    const data = await resp.json()
+    return Array.isArray(data) ? data : []
+  } catch (e) {
+    // 静默降级：当作空会话
+  }
+  return []
+}
+
+/**
  * 用官网账户 Key（awdk_ 开头）换取本服务器的 awdt_ 设备令牌。
  * 匿名端点 POST /api/auth/awdk-login，body {key}；服务端开关未开时返回业务错误。
  * 成功返回 awdt_ 令牌字符串；一切失败以 Error 抛出（文案不含「登录/未授权/请先」，

--- a/office-addin/taskpane/lib/chatSession.js
+++ b/office-addin/taskpane/lib/chatSession.js
@@ -1,0 +1,375 @@
+import { reactive, ref } from 'vue'
+import {
+  postChat, postCancel, postOfficeResult, createConversation, fetchConversationHistory
+} from './api.js'
+import { createSseConnection, createTagStreamParser } from './sse.js'
+import { readActiveDocument, detectHost } from './wordDoc.js'
+import { executeOfficeCommand, commandDisplayName } from './officeExecutor.js'
+import { loadConversationId, saveConversationId, isConfigured } from './settings.js'
+
+/**
+ * 对话会话的模块级单例状态（import 即共享）。
+ *
+ * 为什么不放在 ChatView 内：任务窗格切到「设置」视图时 ChatView 被卸载，
+ * 组件内的 messages 与 SSE 连接随之销毁——切回来时系统消息与后续回复全收不到。
+ * 会话态与连接生命周期因此整体提到组件之外；视图只负责渲染与交互。
+ *
+ * 连接只在「新对话 / 停止 / 切换项目或账户」时主动关闭；切视图不关。
+ */
+
+// ==================== 对外状态 ====================
+
+export const messages = ref([])
+/** 输入框草稿：切到设置再切回来不该丢 */
+export const input = ref('')
+export const streaming = ref(false)
+export const reconnecting = ref(false)
+/** 错误类提示（红） */
+export const banner = ref('')
+/** 中性提示（灰），如「上一次的任务仍在进行中」 */
+export const notice = ref('')
+export const includeDocument = ref(true)
+/** 滚动到底部的信号：store 不碰 DOM，视图 watch 这个计数器 */
+export const scrollSignal = ref(0)
+
+// ==================== 内部状态 ====================
+
+let ctx = { settings: null, projectId: '' }
+// 会话身份 = 服务器 + 令牌 + 项目：任一变化都视为换了会话，重置状态
+let sessionKey = null
+// 并发保护：activate 期间（拉历史/建连）身份又变了，旧流程的结果一律丢弃
+let generation = 0
+
+// 会话 ID 优先由服务端签发（POST /api/agent/conversations）；
+// 端点不存在或失败时静默回退客户端生成的 conv-<毫秒>（与主前端一致）。插件会话独立。
+let conversationId = null
+let connection = null
+let parser = null
+let currentAssistant = null
+// SSE 是否发生过断线重连：只有重连后的 run_state 才用于兜底解锁
+// （首连的 run_state 在 send 已置 streaming 之后到达，不能当终态看）
+let everReconnected = false
+// 本次建连是否由「回灌」触发（任务窗格重建后恢复既有会话）。
+// 区分「谁触发的建连」是 run_state 的两种读法的分水岭：
+//   - send 触发：streaming 已由 send 置起，首个 run_state 不能当终态；
+//   - 回灌触发：首个 run_state 就是当前运行状态的权威答案，据它决定锁不锁输入框。
+let restorePending = false
+
+function bumpScroll() {
+  scrollSignal.value++
+}
+
+// ==================== 会话激活与恢复 ====================
+
+/**
+ * 绑定当前的连接配置与项目并恢复会话。视图挂载时、以及 settings/projectId 变化时调用。
+ * 身份未变时是空操作——切视图不会打断进行中的对话。
+ */
+export async function activateSession({ settings, projectId }) {
+  ctx.settings = settings
+  const pid = projectId || ''
+  const key = `${settings ? settings.serverUrl : ''}|${settings ? settings.token : ''}|${pid}`
+  if (key === sessionKey) return
+  sessionKey = key
+  ctx.projectId = pid
+  const gen = ++generation
+
+  // 换了项目或账户：旧会话的连接与消息一律丢弃
+  closeConnection()
+  messages.value = []
+  currentAssistant = null
+  parser = null
+  streaming.value = false
+  reconnecting.value = false
+  everReconnected = false
+  banner.value = ''
+  notice.value = ''
+  conversationId = null
+
+  if (!pid || !settings || !isConfigured(settings)) return
+
+  // 任务窗格重建（切文档、重开窗格）后：接着上次的会话，而不是从空白开始
+  const stored = loadConversationId(pid)
+  if (!stored) return
+  conversationId = stored
+
+  const history = await fetchConversationHistory(settings, stored)
+  if (gen !== generation) return
+  if (history.length) {
+    messages.value = history.map(toLocalMessage)
+    bumpScroll()
+  }
+
+  restorePending = true
+  try {
+    await ensureConnection()
+  } catch (e) {
+    // 回灌建连失败（后端不可达/令牌失效）不打断用户：下次发送时会再建一次并给出明确报错
+    restorePending = false
+    console.warn('[Addin] 会话恢复建连失败', e)
+  }
+}
+
+/**
+ * 后端 GET /api/ai/history 的一条记录 → 插件消息模型。
+ * 字段：role(USER|ASSISTANT) / content。ASSISTANT 的 content 是带标签的整段文本
+ * （<thinking>/<final>/<process>… 见 AgentStreamHandler 协议），用与流式渲染同一个
+ * 解析器拆成正文与思考，标签种类保持一致。
+ * 工具活动 chip 无法从落库正文还原（历史里没有 requestId/状态），故不回灌——宁缺毋假。
+ */
+function toLocalMessage(row) {
+  const content = row && row.content ? String(row.content) : ''
+  const role = row && row.role ? String(row.role).toUpperCase() : 'USER'
+  if (role === 'USER') return { role: 'user', text: content }
+  let text = ''
+  let thinking = ''
+  const p = createTagStreamParser({
+    onMainText: (t) => { text += t },
+    onThinkingText: (t) => { thinking += t }
+  })
+  p.feed(content)
+  p.flush()
+  return reactive({ role: 'assistant', text, thinking, streaming: false, error: '', tools: [] })
+}
+
+// ==================== SSE ====================
+
+function finishStreaming() {
+  if (currentAssistant) currentAssistant.streaming = false
+  streaming.value = false
+  notice.value = ''
+}
+
+/**
+ * 取当前正在生成的助手气泡；没有就新建一个。
+ * 回灌场景下（窗格重建时后端仍在跑）本地没有气泡，后续 text_delta 到达时才补建。
+ */
+function ensureAssistantBubble() {
+  if (currentAssistant) return currentAssistant
+  const assistant = reactive({ role: 'assistant', text: '', thinking: '', streaming: true, error: '', tools: [] })
+  messages.value.push(assistant)
+  currentAssistant = assistant
+  attachParser(assistant)
+  return assistant
+}
+
+function attachParser(assistant) {
+  parser = createTagStreamParser({
+    onMainText: (t) => { assistant.text += t },
+    onThinkingText: (t) => { assistant.thinking += t }
+  })
+}
+
+/**
+ * 回灌后发现后端还在跑：把历史里最后那条助手消息接着用（编排器按轮次增量落库，
+ * 那条正是本轮已生成的部分），后续 text_delta 续写同一个气泡，而不是另起一个。
+ */
+function adoptLastAssistantBubble() {
+  const last = messages.value[messages.value.length - 1]
+  if (!last || last.role !== 'assistant') return
+  last.streaming = true
+  currentAssistant = last
+  attachParser(last)
+}
+
+function handleEvent(evt, dataStr) {
+  if (evt === 'text_delta') {
+    let content = dataStr
+    try { content = JSON.parse(dataStr).content || '' } catch (e) { /* 按原文处理 */ }
+    ensureAssistantBubble()
+    if (parser) parser.feed(content)
+    bumpScroll()
+  } else if (evt === 'bubble_end') {
+    if (parser) parser.flush()
+    finishStreaming()
+  } else if (evt === 'error') {
+    let msg = '执行出错'
+    try { msg = JSON.parse(dataStr).message || msg } catch (e) { /* ignore */ }
+    if (currentAssistant) currentAssistant.error = msg
+    finishStreaming()
+  } else if (evt === 'cancelled') {
+    if (currentAssistant && !currentAssistant.text) currentAssistant.text = '（已停止）'
+    finishStreaming()
+  } else if (evt === 'client_action') {
+    handleClientAction(dataStr)
+  } else if (evt === 'run_state') {
+    handleRunState(dataStr)
+  }
+  // connected/heartbeat/plan_update 等其余事件：先忽略
+}
+
+/**
+ * 建连时后端推送当前运行状态。两种读法，取决于这条连接是谁建的：
+ *   - 回灌建连（restorePending）：窗格重建后本地没有 streaming 状态，这条就是权威答案。
+ *     仍在跑 → 锁输入并提示，等后续正文经 SSE 推来；否则保持空闲。
+ *   - send 建连：streaming 已经置起，首个 run_state 不能当终态看（后端可能还没标 RUNNING）。
+ *     只有断线重连之后（everReconnected）才用它兜底解锁——断线期间可能漏掉了 bubble_end。
+ */
+function handleRunState(dataStr) {
+  let status = null
+  try { status = JSON.parse(dataStr).status } catch (e) { /* ignore */ }
+  const stillRunning = status === 'RUNNING' || status === 'PAUSED' || status === 'AWAITING_APPROVAL'
+
+  if (restorePending) {
+    restorePending = false
+    if (stillRunning) {
+      streaming.value = true
+      notice.value = '上一次的任务仍在进行中，正在接收后续回复……'
+      adoptLastAssistantBubble()
+    }
+    return
+  }
+
+  if (everReconnected && streaming.value && !stillRunning) {
+    if (parser) parser.flush()
+    finishStreaming()
+  }
+}
+
+/**
+ * office_command 执行链（Phase C 工具桥）：
+ * 后端 OfficeBridgeService 下发 {tool:'office_command', requestId, command, args}
+ * → Office.js 执行 → POST /api/agent/office/result 回传。
+ * 其余 client_action（editor_command 等 LOWA 契约）与本插件无关，忽略。
+ */
+async function handleClientAction(dataStr) {
+  let action = null
+  try { action = JSON.parse(dataStr) } catch (e) { return }
+  if (!action || action.tool !== 'office_command' || !action.requestId) return
+
+  const chip = reactive({ label: commandDisplayName(action.command), status: 'running' })
+  const assistant = ensureAssistantBubble()
+  if (!assistant.tools) assistant.tools = []
+  assistant.tools.push(chip)
+  bumpScroll()
+
+  const result = await executeOfficeCommand(action.command, action.args)
+  chip.status = result.ok ? 'done' : 'failed'
+  await postOfficeResult(ctx.settings, {
+    requestId: action.requestId,
+    ok: result.ok,
+    data: result.ok ? result.data : null,
+    error: result.ok ? null : result.error
+  })
+}
+
+async function ensureConnection() {
+  if (connection) return
+  const conn = createSseConnection({
+    baseUrl: ctx.settings.serverUrl,
+    token: ctx.settings.token,
+    conversationId,
+    onEvent: handleEvent,
+    onStatus: (status) => {
+      if (connection !== conn) return
+      if (status === 'reconnecting') {
+        everReconnected = true
+        reconnecting.value = true
+      } else if (status === 'connected') {
+        reconnecting.value = false
+      }
+    },
+    onClose: () => {
+      if (connection === conn) connection = null
+      reconnecting.value = false
+      // 连接彻底关闭时不静默卡死输入框（断线重连由 sse.js 内部处理，不走这里）
+      if (streaming.value) finishStreaming()
+    }
+  })
+  connection = conn
+  try {
+    await conn.ready
+  } catch (e) {
+    if (connection === conn) connection = null
+    throw e
+  }
+}
+
+function closeConnection() {
+  restorePending = false
+  if (connection) {
+    connection.close()
+    connection = null
+  }
+}
+
+// ==================== 交互 ====================
+
+export async function send() {
+  banner.value = ''
+  if (!ctx.settings || !isConfigured(ctx.settings)) return { needSettings: true }
+  if (!ctx.projectId) {
+    banner.value = '尚未选择项目：在顶部下拉中选一个项目'
+    return { needSettings: false }
+  }
+  const prompt = input.value.trim()
+  if (!prompt || streaming.value) return { needSettings: false }
+
+  const settings = ctx.settings
+  const projectId = ctx.projectId
+  input.value = ''
+  messages.value.push({ role: 'user', text: prompt })
+
+  currentAssistant = null
+  parser = null
+  const assistant = ensureAssistantBubble()
+  // 本轮由 send 触发：run_state 回到「不能当终态」的读法（回灌建连若还没收到 run_state，到此作废）
+  restorePending = false
+  streaming.value = true
+  bumpScroll()
+
+  try {
+    // 首条消息前先请求服务端签发会话 ID；旧后端无该端点时静默回退客户端生成。
+    // 会话 ID 按项目落本机存储，任务窗格重建后据它接回同一场对话。
+    if (!conversationId) {
+      conversationId = (await createConversation(settings, parseInt(projectId, 10)))
+        || `conv-${Date.now()}`
+      saveConversationId(projectId, conversationId)
+    }
+    await ensureConnection()
+
+    // 当前文档内容以内联形式随请求上送（activeContext.inlineContent）
+    let activeContext = null
+    if (includeDocument.value) {
+      activeContext = await readActiveDocument()
+      if (!activeContext) banner.value = '未能读取文档内容，本条消息不附带文档内容'
+    }
+
+    await postChat(settings, {
+      projectId: parseInt(projectId, 10),
+      conversationId,
+      message: prompt,
+      mode: 'AGENT',
+      activeContext,
+      // 声明客户端能力（Phase C）：后端据此让本会话只见 office_* 工具、隐藏 doc_*；
+      // officeHost 再按宿主细分（word/excel/powerpoint），点名对应工具面
+      clientCapability: 'office',
+      officeHost: detectHost() || 'word'
+    })
+  } catch (e) {
+    assistant.error = e.message || '消息发送失败'
+    finishStreaming()
+  }
+  return { needSettings: false }
+}
+
+export async function stop() {
+  if (conversationId) await postCancel(ctx.settings, conversationId)
+  closeConnection()
+  if (currentAssistant && !currentAssistant.text) currentAssistant.text = '（已停止）'
+  finishStreaming()
+}
+
+export function newConversation() {
+  closeConnection()
+  if (ctx.projectId) saveConversationId(ctx.projectId, '')
+  conversationId = null
+  messages.value = []
+  currentAssistant = null
+  parser = null
+  banner.value = ''
+  notice.value = ''
+  reconnecting.value = false
+  everReconnected = false
+  streaming.value = false
+}

--- a/office-addin/taskpane/lib/minimalEdit.js
+++ b/office-addin/taskpane/lib/minimalEdit.js
@@ -1,0 +1,126 @@
+/**
+ * 字符级最小编辑差分（纯函数模块，不依赖 Office.js，便于单测）。
+ *
+ * 用途：Word 原生修订（TrackAll）下把整段 Range 直接 insertText(replace)
+ * 会记成「整段删除 + 整段插入」——「我爱你」改「我恨你」在修订面板里读作
+ * 删「我爱你」加「我恨你」。本模块算出字符级最小编辑段，调用方只对差异段
+ * 落笔，修订面板里就只剩删「爱」加「恨」。
+ *
+ * 口径与桌面端 LOWA 的 `frontend/src/zetaoffice/public/office_thread.js`
+ * 中的 minimalEdits 一致（PR#188）：公共前后缀先裁剪 → 中段有界 LCS
+ * （超界回退整段单编辑）→ 合并被单个巧合相同字符夹住的相邻编辑。
+ * **改一边要想到另一边**：两处算法口径必须保持一致，否则同一处修改在
+ * 桌面编辑器与 Office 插件里会呈现出不同颗粒度的修订。
+ *
+ * 与 LOWA 版的唯一差异是返回值形态：
+ *   - LOWA 版返回 `{start, delLen, insText}` 且**按 start 降序**（它在
+ *     UNO 里靠字符偏移走光标，降序即"从右到左"的应用顺序）；
+ *   - 本版返回 `{start, end, oldText, newText}` 且**按 start 升序**
+ *     （Office.js 没有按偏移切 Range 的 API，调用方要用 oldText 段当锚串
+ *     二次 search 定位，升序更便于携带上下文消歧；应用时自行倒序遍历）。
+ * 编辑段互不重叠。
+ */
+
+// 中段 LCS 的 DP 单元上限（500x500 字符，远超任何单条条款的改动量）；
+// 超过就退回"整个中段一次替换"——已经足够小，且不值得为它跑 DP。
+const LCS_CELL_LIMIT = 250000
+
+/**
+ * 计算把 oldStr 变成 newStr 的最小编辑段。
+ *
+ * @param {string} oldStr 原文
+ * @param {string} newStr 新文
+ * @returns {Array<{start:number, end:number, oldText:string, newText:string}>}
+ *   start/end 为 oldStr 内的字符偏移（左闭右开）；oldStr[start,end) 这一段被
+ *   newText 取代。纯插入时 start === end 且 oldText 为空；纯删除时 newText
+ *   为空。结果按 start 升序、互不重叠；两串相同时返回空数组。
+ */
+export function minimalEdits(oldStr, newStr) {
+  const o = oldStr == null ? '' : String(oldStr)
+  const n = newStr == null ? '' : String(newStr)
+  const oLen = o.length
+  const nLen = n.length
+
+  // 1) 裁掉公共前缀与公共后缀（两者不许重叠）
+  const maxP = Math.min(oLen, nLen)
+  let p = 0
+  while (p < maxP && o.charCodeAt(p) === n.charCodeAt(p)) p++
+  let s = 0
+  while (s < maxP - p && o.charCodeAt(oLen - 1 - s) === n.charCodeAt(nLen - 1 - s)) s++
+
+  const oMid = o.slice(p, oLen - s)
+  const nMid = n.slice(p, nLen - s)
+  if (!oMid && !nMid) return []
+
+  // 2) 纯插入 / 纯删除 / 中段过大：一条连续替换已经是最小可用形态
+  if (!oMid || !nMid || oMid.length * nMid.length > LCS_CELL_LIMIT) {
+    return [toEdit(o, p, oMid.length, nMid)]
+  }
+
+  // 3) 中段跑 LCS DP（长度 <= 500，Uint16 足够）
+  const m = oMid.length
+  const q = nMid.length
+  const W = q + 1
+  const dp = new Uint16Array((m + 1) * W)
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= q; j++) {
+      dp[i * W + j] = oMid.charCodeAt(i - 1) === nMid.charCodeAt(j - 1)
+        ? dp[(i - 1) * W + (j - 1)] + 1
+        : Math.max(dp[(i - 1) * W + j], dp[i * W + (j - 1)])
+    }
+  }
+
+  // 4) 从尾回溯，把相邻的删+插合并成一条替换。回溯天然产出降序 start。
+  const runs = []
+  let i = m
+  let j = q
+  let curDel = 0
+  let curIns = ''
+  const flush = (atOld) => {
+    if (curDel || curIns) {
+      runs.push({ start: p + atOld, delLen: curDel, insText: curIns })
+      curDel = 0
+      curIns = ''
+    }
+  }
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oMid.charCodeAt(i - 1) === nMid.charCodeAt(j - 1)) {
+      flush(i)
+      i--
+      j--
+    } else if (j > 0 && (i === 0 || dp[i * W + (j - 1)] >= dp[(i - 1) * W + j])) {
+      curIns = nMid.charAt(j - 1) + curIns
+      j--
+    } else {
+      curDel++
+      i--
+    }
+  }
+  flush(0)
+
+  // 5) 收尾：被"单个巧合相同字符"夹住的两条编辑合成一条（LCS 在中文里常
+  //    捞到"的/、"这类巧合字，拆开读起来是零碎又费解的修订）。
+  //    runs 是降序，[k+1] 是左邻。
+  for (let k = 0; k + 1 < runs.length;) {
+    const right = runs[k]
+    const left = runs[k + 1]
+    const gap = right.start - (left.start + left.delLen)
+    if (gap >= 0 && gap <= 1) {
+      left.insText = left.insText + o.slice(left.start + left.delLen, right.start) + right.insText
+      left.delLen = left.delLen + gap + right.delLen
+      runs.splice(k, 1)
+    } else k++
+  }
+
+  // 6) 转成升序的 {start, end, oldText, newText}
+  const edits = []
+  for (let k = runs.length - 1; k >= 0; k--) {
+    edits.push(toEdit(o, runs[k].start, runs[k].delLen, runs[k].insText))
+  }
+  return edits
+}
+
+function toEdit(o, start, delLen, insText) {
+  const end = start + delLen
+  return { start, end, oldText: o.slice(start, end), newText: insText }
+}

--- a/office-addin/taskpane/lib/officeExecutor.js
+++ b/office-addin/taskpane/lib/officeExecutor.js
@@ -17,14 +17,20 @@
  * 设为 TrackAll（Word 原生修订），执行后恢复原值；宿主不支持 WordApi 1.4 时
  * 降级为直接修改并在结果里标注 tracked:false。Excel/PowerPoint 没有修订机制，
  * 写入直接生效。
+ *
+ * replace_text 走字符级最小修订（见下方 applyMinimalRedline）：只对新旧文的
+ * 差异段落笔，避免修订面板里出现「整段删 + 整段插」。
  */
 
 import { officeAvailable, detectHost } from './wordDoc.js'
+import { minimalEdits } from './minimalEdit.js'
 
 // 与后端 ContextAssemblerService.MAX_INLINE_CONTENT_CHARS 一致的截断上限
 const MAX_TEXT_CHARS = 200_000
 // search 命中上下文的最大条数（防超长工具输出撑爆模型上下文）
 const MAX_SEARCH_HITS = 20
+// Word 的查找串上限（超了直接判非法）
+const WORD_SEARCH_MAX_CHARS = 255
 
 function trackingSupported() {
   try {
@@ -71,6 +77,146 @@ async function searchRanges(context, needle, matchCase) {
   results.load('items')
   await context.sync()
   return results.items
+}
+
+/* ==================== Word 最小修订（minimal redline） ====================
+ * TrackAll 下对整个命中 Range 直接 insertText(replace) 会记成「整段删除 +
+ * 整段插入」——「我爱你」改「我恨你」在修订面板里读作删「我爱你」加
+ * 「我恨你」。这里先用 minimalEdits 算出字符级差异段，再只对差异段落笔，
+ * 修订面板里就只剩删「爱」加「恨」（与桌面端 LOWA 的 applyMinimalRedline
+ * 同口径，PR#188）。
+ *
+ * Office.js 没有按字符偏移切 Range 的 API，差异段只能靠在命中 Range 内二次
+ * search 锚串来定位——所以「定位是否唯一」是整条路径的安全阀：任何一段定位
+ * 不到唯一结果，整个 Range 放弃最小修订、回退原来的整段替换。全部定位都在
+ * 任何写入之前完成，绝不会出现「改了一半又回退」的双重编辑。
+ */
+
+/** needle 在 hay 中的非重叠出现次数 */
+function countOccurrences(hay, needle) {
+  if (!needle) return 0
+  let n = 0
+  let i = hay.indexOf(needle)
+  while (i !== -1) {
+    n++
+    i = hay.indexOf(needle, i + needle.length)
+  }
+  return n
+}
+
+/** 含孤立代理项的串（差分按 UTF-16 码元切，可能劈开 emoji）不能拿去 search */
+function hasLoneSurrogate(s) {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = s.charCodeAt(i + 1)
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true
+      i++
+    } else if (c >= 0xdc00 && c <= 0xdfff) return true
+  }
+  return false
+}
+
+/** Word 的 search 能安全吃下的查找串：非空、不超 255、不含特殊码前缀 ^、码元完整 */
+function searchable(s) {
+  return !!s && s.length <= WORD_SEARCH_MAX_CHARS && !s.includes('^') && !hasLoneSurrogate(s)
+}
+
+/**
+ * 为一段编辑构造在命中 Range 内的定位方案，返回 null 表示无法安全定位。
+ * 消歧策略：
+ *  - 替换/删除段（oldText 非空）：差异段在 Range 文本中唯一 → 直接 search
+ *    （mode 'direct'）。不唯一 → 以差异段为中心向两侧对称扩上下文窗口，直到
+ *    「窗口在 Range 内唯一」且「差异段在窗口内唯一」→ 先 search 窗口、再在
+ *    窗口内 search 差异段（mode 'window'）；扩到整段仍不满足就放弃。
+ *  - 纯插入段（oldText 为空）：以插入点左侧的一段文本为锚，锚唯一即
+ *    insertText(..., After)；左侧不可用（插入点在最左/左锚不唯一）时改用
+ *    右侧文本 + Before。
+ */
+function buildLocator(rangeText, edit) {
+  const seg = edit.oldText
+  const len = rangeText.length
+  if (seg) {
+    if (!searchable(seg)) return null
+    if (countOccurrences(rangeText, seg) === 1) return { mode: 'direct', needle: seg }
+    for (let pad = 1; ; pad++) {
+      const lo = Math.max(0, edit.start - pad)
+      const hi = Math.min(len, edit.end + pad)
+      const win = rangeText.slice(lo, hi)
+      if (!searchable(win)) return null
+      if (countOccurrences(rangeText, win) === 1 && countOccurrences(win, seg) === 1) {
+        return { mode: 'window', window: win, needle: seg }
+      }
+      if (lo === 0 && hi === len) return null
+    }
+  }
+  for (let pad = 1; pad <= edit.start; pad++) {
+    const anchor = rangeText.slice(edit.start - pad, edit.start)
+    if (!searchable(anchor)) break
+    if (countOccurrences(rangeText, anchor) === 1) return { mode: 'insertAfter', needle: anchor }
+  }
+  for (let pad = 1; edit.end + pad <= len; pad++) {
+    const anchor = rangeText.slice(edit.end, edit.end + pad)
+    if (!searchable(anchor)) break
+    if (countOccurrences(rangeText, anchor) === 1) return { mode: 'insertBefore', needle: anchor }
+  }
+  return null
+}
+
+/**
+ * 把 newText 以字符级最小修订写入命中 Range。
+ * @returns {Promise<number|null>} 实际落笔的编辑段数（0 = 新旧文一致，不留痕迹）；
+ *   null = 无法最小化，调用方回退整段 insertText(replace)。返回 null 时保证
+ *   一个字都还没写。
+ */
+async function applyMinimalRedline(context, range, rangeText, newText) {
+  const edits = minimalEdits(rangeText, newText)
+  if (!edits.length) return 0
+  // 差异覆盖整段：没有比整段替换更细的写法了
+  if (edits.length === 1 && edits[0].start === 0 && edits[0].end === rangeText.length) return null
+
+  const plans = []
+  for (const edit of edits) {
+    const loc = buildLocator(rangeText, edit)
+    if (!loc) return null
+    plans.push({ edit, loc })
+  }
+
+  // 第一轮定位：direct/纯插入的锚串，window 模式的外层窗口
+  for (const plan of plans) {
+    plan.primary = range.search(plan.loc.mode === 'window' ? plan.loc.window : plan.loc.needle, { matchCase: true })
+    plan.primary.load('items')
+  }
+  await context.sync()
+  for (const plan of plans) {
+    if (plan.primary.items.length !== 1) return null
+    plan.target = plan.primary.items[0]
+  }
+
+  // 第二轮定位：window 模式在唯一窗口内再切出差异段
+  const windowed = plans.filter((plan) => plan.loc.mode === 'window')
+  if (windowed.length) {
+    for (const plan of windowed) {
+      plan.inner = plan.target.search(plan.loc.needle, { matchCase: true })
+      plan.inner.load('items')
+    }
+    await context.sync()
+    for (const plan of windowed) {
+      if (plan.inner.items.length !== 1) return null
+      plan.target = plan.inner.items[0]
+    }
+  }
+
+  // 应用：从右到左。左侧编辑的定位不会被右侧的写入推移（与 LOWA 同理由）。
+  for (let i = plans.length - 1; i >= 0; i--) {
+    const { edit, loc, target } = plans[i]
+    if (loc.mode === 'insertAfter') target.insertText(edit.newText, Word.InsertLocation.after)
+    else if (loc.mode === 'insertBefore') target.insertText(edit.newText, Word.InsertLocation.before)
+    else if (edit.newText) target.insertText(edit.newText, Word.InsertLocation.replace)
+    else target.delete()
+  }
+  await context.sync()
+  return edits.length
 }
 
 const HANDLERS = {
@@ -128,11 +274,38 @@ const HANDLERS = {
           throw new Error('未找到目标文本，请确认 searchText 与文档内容精确一致（可先用 search 命令核对）')
         }
         const targets = replaceAll ? items : [items[0]]
-        for (const range of targets) {
-          range.insertText(replaceText, Word.InsertLocation.replace)
-        }
+        for (const range of targets) range.load('text')
         await context.sync()
-        return { replaced: targets.length, totalMatches: items.length }
+        // 跨段（\r/\n）交给整段替换：段落结构不该被字符级差分拆着改
+        const multiline = /[\r\n]/.test(searchText) || /[\r\n]/.test(replaceText)
+        let minimal = 0
+        let fallbacks = 0
+        let editSegments = 0
+        // 多个命中同样从右到左处理：前一处的写入不会推移后面命中的定位
+        for (let i = targets.length - 1; i >= 0; i--) {
+          const range = targets[i]
+          const rangeText = range.text == null ? '' : String(range.text)
+          const applied = multiline || !rangeText
+            ? null
+            : await applyMinimalRedline(context, range, rangeText, replaceText)
+          if (applied == null) {
+            range.insertText(replaceText, Word.InsertLocation.replace)
+            await context.sync()
+            fallbacks++
+          } else {
+            minimal++
+            editSegments += applied
+          }
+        }
+        const result = {
+          replaced: targets.length,
+          totalMatches: items.length,
+          via: fallbacks === 0 ? 'minimalRedline' : (minimal === 0 ? 'fullReplace' : 'mixed'),
+          edits: editSegments
+        }
+        if (fallbacks) result.fallbacks = fallbacks
+        if (!editSegments && !fallbacks) result.note = '新旧文本一致，未产生修订'
+        return result
       })
     })
   },

--- a/office-addin/taskpane/lib/settings.js
+++ b/office-addin/taskpane/lib/settings.js
@@ -6,6 +6,9 @@
 const KEY_SERVER = 'awd_addin_server_url'
 const KEY_TOKEN = 'awd_addin_token'
 const KEY_PROJECT = 'awd_addin_project_id'
+// 会话 ID 按项目分别存：切文档/重开任务窗格会整个重建 webview，
+// 会话 ID 只活在内存里就等于每次都从空白开始
+const KEY_CONVERSATION_PREFIX = 'awd_addin_conv_'
 
 /**
  * 构建期注入的默认后端地址（见 vite.config.js 的 define）。
@@ -34,6 +37,24 @@ export function saveSettings({ serverUrl, token }) {
 
 export function saveProjectId(projectId) {
   localStorage.setItem(KEY_PROJECT, projectId == null ? '' : String(projectId))
+}
+
+/**
+ * 取该项目上次的会话 ID（无则空串）。
+ */
+export function loadConversationId(projectId) {
+  if (!projectId) return ''
+  return localStorage.getItem(KEY_CONVERSATION_PREFIX + projectId) || ''
+}
+
+/**
+ * 记住该项目的会话 ID；传空值即清除（「新对话」）。
+ */
+export function saveConversationId(projectId, conversationId) {
+  if (!projectId) return
+  const key = KEY_CONVERSATION_PREFIX + projectId
+  if (conversationId) localStorage.setItem(key, String(conversationId))
+  else localStorage.removeItem(key)
 }
 
 export function isConfigured(settings) {


### PR DESCRIPTION
维护者反馈八条问题中的第 3、9 条（消息丢失/项目必选）与第 7 条（最小修订），计划见 docs/superpowers/specs/2026-08-07-addin-desktop-ux-fixes.md。

## 批次2：会话不丢 + 插件临时项目

- **根因一**（切视图丢会话）：App.vue v-if 切换卸载 ChatView、onBeforeUnmount 关 SSE。修法：新增 `chatSession.js` 模块级 store，全部会话态（messages/conversationId/SSE/streaming/草稿）移出组件，ChatView 瘦成渲染层（script 214→50 行）。
- **根因二**（窗格重建丢会话）：conversationId 只在闭包里。修法：按项目落 localStorage + 重建时 `GET /api/ai/history` 回灌（用与流式同一个 tag parser 拆 thinking/final；工具 chip 落库无 requestId 不回灌，宁缺毋假）+ 回灌建连时 run_state 作权威状态（仍在跑则锁输入接续写）。
- **项目非必选**：`POST /api/projects/ensure-addin-default` 幂等懒建「插件临时项目」（已有任一项目不建）；插件端无项目静默直连，单项目不渲染下拉。

## 批次3：字符级最小修订

「我爱你→我恨你」在 Word 修订面板里现在只记删「爱」插「恨」，不再整句删+整句插。

- `minimalEdit.js`：前后缀裁剪+有界 LCS（DP 超 250000 单元回退整段），口径与 LOWA `minimalEdits` 一致（PR#188），3000 例随机对拍通过。
- `replace_text`：Office.js 无按偏移切 Range 的 API，差异段靠命中 Range 内二次 search 定位，歧义时对称扩上下文窗口消歧；**全部定位在任何写入之前完成**，任一段不唯一即整段回退（绝无改一半再回退的双重编辑）；多命中与段内编辑均从右到左应用。返回值新增 `via`（minimalRedline/fullReplace/mixed）与 `edits`。

## 验证

- office-addin `npm run build` 零报错（23 modules）
- 后端定向测试全绿：ProjectControllerAddinDefaultTest(4，幂等钉住)、ProjectControllerOpenLocalGateTest(2)、LicenseControllerEditionTest(8)、AuthControllerLocalDeviceTokenTest(3)
- minimalEdit 纯函数自测：单字替换/纯插入/纯删除/多段差异/超界回退/随机对拍全过
- 红线扫描零残留
- 真机 sideload 验证待办：Word 里「我爱你→我恨你」应只见两条修订（删「爱」插「恨」）

🤖 Generated with [Claude Code](https://claude.com/claude-code)