### PR TITLE
插件响应速度优化：埋点+预连+正文省传（批次5）

### DIFF
--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -23,7 +23,8 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 
 - **鉴权**：awdt_ 设备令牌放 `X-Session-Id` 请求头（后端 `getUserIdFromSession` 前缀解析）。连接测试 = `GET /api/projects/my`。桌面端生成 awdt_ 的界面在 userprofile「插件访问令牌」分组（走 `POST /api/auth/device-token/issue-local`，仅 local-mode，见 licensing-billing.md）。**awdk_ 一键连接**：`POST /api/auth/awdk-login`（body `{key}`，匿名端点，开关 `security.awdk-login-enabled` 默认关）→ `{code:0, data:{token}}` 换回 awdt_ 存本地，Key 本身用完即弃不落盘；开关未开/旧后端 404 → 提示「该服务器未开启账户直连，请改用设备令牌」。
 - **对话**：`POST /api/agent/chat` + `GET /api/agent/connect/{cid}` SSE（fetch + ReadableStream）。conversationId 优先服务端签发（`POST /api/agent/conversations`，body `{projectId}`，契约与后端并行分支约定），404/失败静默回退客户端 `conv-<毫秒>`。
-- **文档上下文**：按宿主读取（见 wordDoc.js），经 `activeContext.inlineContent` 内联上送（客户端 200k 截断）；activeContext.id 用合成值 `office-current-document`。后端侧 inlineContent 优先于 read_document（ContextAssemblerService，服务端同样 200k 上限）。
+- **文档上下文**：按宿主读取（见 wordDoc.js），经 `activeContext.inlineContent` 内联上送（客户端 200k 截断）；activeContext.id 用合成值 `office-current-document`。后端侧 inlineContent 优先于 read_document（ContextAssemblerService，服务端同样 200k 上限）。**正文省传**：同一会话内文档没变时客户端只上送 `activeContext.inlineContentHash`（SHA-256 十六进制，`wordDoc.js` 的 `hashContent`）、不带 inlineContent；后端 `InlineContentCache`（按会话，LRU 上限 32 条 ≈13MB）凭哈希取回上一轮正文，**哈希后端自算**（客户端上送值只当省传信号），未命中即按「无内联正文」现状处理不报错。
+- **发送路径（批次 5 性能）**：会话签发（`POST /api/agent/conversations`）与 SSE 建连提前到 `preconnect()`——进面板/切项目（activateSession）与「新对话」时就做完，send 只剩「读文档 ‖ 兜底 preconnect → POST /chat」两件并行事。每轮四段耗时经 `console.info('[AddinPerf]', {...})` 输出并存 `lastPerf`（docReadMs/docChars/docReused/connectMs/chatAcceptedMs/firstTokenMs/totalMs），不上报遥测。
 - **SSE 事件**：消费 text_delta/bubble_end/error/cancelled/run_state + `client_action`（仅 tool=office_command）。run_state 仅在断线重连后消费：漏掉终态事件时按状态（非 RUNNING/PAUSED/AWAITING_APPROVAL）兜底解锁输入框——首连的 run_state 不能当终态看（send 已先置 streaming）。
 - **工具桥（Phase C+宿主细分）**：chat 请求带 `clientCapability: "office"` + `officeHost: "word|excel|powerpoint"`（缺省 word）→ ClientCapabilityService 记录 → ToolRegistry 过滤：word 会话只见 Word 面 office_*（读写六个 + 格式六个）、excel 只见 office_excel_*、ppt 只见 office_ppt_*（前缀判定，`hostOfTool` 最长前缀优先）；doc_*/sheet_* 对 office 会话一律隐藏。ContextAssemblerService 的 office 分支文案按宿主点名对应工具集。命令链：SSE client_action `{tool:'office_command', requestId, command, args}` → officeExecutor 执行 → `POST /api/agent/office/result`。Word 修改类命令前置 `changeTrackingMode=TrackAll`、执行后恢复原值（WordApi 1.4 不支持时降级直改标 `tracked:false`）；**Excel/PPT 没有修订机制，写入直接生效**。
 
@@ -52,6 +53,8 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 - 修改类命令必须恢复用户原有的修订开关状态（withTracking 的 finally 恢复），别改成常开。
 - **PowerPoint 文本读写要 PowerPointApi 1.4**（TextFrame/TextRange；Microsoft 365 较新版本才有，2019/2021 永久版没有）——执行器 requirePptTextApi 前置报错，别绕开它直接调 API。Excel 查找是客户端扫已用区域（兼容旧宿主），别改成 ExcelApi 1.9 的 findAll。
 - SSE 重连语义：onClose 只在主动 close 触发；改 ChatView 的 streaming 解锁逻辑时记住三条路径（bubble_end/error/cancelled 正常终态、onClose 主动关、重连后 run_state 兜底）。
+- **建连有三种来源，run_state 三种读法**（chatSession.js 的 handleRunState）：回灌（restorePending=true，首个 run_state 是权威状态，RUNNING 则锁输入续写）、**预连**（无 restorePending 无 streaming，run_state 必须零副作用——两个分支都不进）、send 兜底（streaming 已置起，只有 everReconnected 后才用 run_state 解锁）。加预连类的新调用点时先确认它落在哪一种。
+- **省传只在上一轮 bubble_end 之后启用**：出过 error 的会话（含旧后端不认 inlineContentHash 的情况）整场退回恒传全文；`crypto.subtle` 取不到（非 secure context）时哈希为空串，同样恒传全文。改 docCache 的提交/失效时机要同时想「旧后端把只带哈希的请求当无正文」这条降级路径。
 - 世纪互联 CDN 替换只发生在 build-manifest.mjs 的输出目录——别把源 taskpane.html 的 office.js 地址改掉。
 
 ## 验证
@@ -59,4 +62,4 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 - `cd office-addin && npm install && npm run build`；manifest 校验（dev 与 dist-deploy 两份）见上。
 - `npm run build:deploy -- --url https://addin.example.com --china` 后检查 dist-deploy/manifest.xml 无 localhost URL、taskpane.html 用 partner.office365.cn CDN。
 - sideload 手测清单与步骤全在 `office-addin/README.md`（Word 工具桥场景 + Excel/PPT 场景 + 断线重连/awdk 连接场景）。
-- 后端单测（JDK 21）：`mvn test -Dtest='ContextAssemblerServiceTest,OfficeBridgeServiceTest,OfficeResultControllerTest,ToolRegistryCapabilityFilterTest,OfficeEditToolsTest'`。
+- 后端单测（JDK 21）：`mvn test -Dtest='ContextAssemblerServiceTest,InlineContentCacheTest,OfficeBridgeServiceTest,OfficeResultControllerTest,ToolRegistryCapabilityFilterTest,OfficeEditToolsTest'`。

--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -360,6 +360,12 @@ public class AiAgentController {
          * 后端没有对应 fileId 可读）。非空时上下文组装直接采用它，不再走 read_document。
          */
         private String inlineContent;
+        /**
+         * 可选：inlineContent 的 SHA-256 十六进制（Office 插件的「正文省传」）。
+         * 同一会话内文档没变时客户端只上送本字段、不再重传整篇正文，
+         * 后端凭它从 InlineContentCache 取回上一轮的正文；未命中即按「无内联正文」处理。
+         */
+        private String inlineContentHash;
 
         public String getId() { return id; }
         public void setId(String id) { this.id = id; }
@@ -372,5 +378,7 @@ public class AiAgentController {
         public void setFileType(String fileType) { this.fileType = fileType; }
         public String getInlineContent() { return inlineContent; }
         public void setInlineContent(String inlineContent) { this.inlineContent = inlineContent; }
+        public String getInlineContentHash() { return inlineContentHash; }
+        public void setInlineContentHash(String inlineContentHash) { this.inlineContentHash = inlineContentHash; }
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -42,6 +42,7 @@ public class ContextAssemblerService {
     private final AiContextProperties contextProperties;
     private final com.checkba.service.ai.skill.SkillRouter skillRouter;
     private final ClientCapabilityService clientCapabilityService;
+    private final InlineContentCache inlineContentCache;
 
     // 记忆系统组件（读侧：写侧见 MemoryPipelineService）
     private final MemoryManager memoryManager;
@@ -241,7 +242,7 @@ public class ContextAssemblerService {
                      activeContext.getId(), activeContext.getName(),
                      activeContext.getInlineContent() != null && !activeContext.getInlineContent().isEmpty());
 
-            String content = resolveActiveDocumentContent(activeContext);
+            String content = resolveActiveDocumentContent(activeContext, conversationId);
             ClientCapabilityService.Capability capability = clientCapabilityService.capabilityOf(conversationId);
 
             systemText.append("\n\n# Active Document (当前活跃文档)\n");
@@ -495,20 +496,36 @@ public class ContextAssemblerService {
     private static final int MAX_INLINE_CONTENT_CHARS = 200_000;
 
     /**
-     * 活跃文档正文来源二选一：
-     * 1) 请求随带的内联正文（Office 插件等场景——文档在客户端本地，后端没有可读的 fileId）优先；
-     * 2) 否则走既有 read_document(fileId) 路径。
-     * 两条路径产出同格式正文，后续统一由调用方做 CDATA 包裹与 maxCharsPerFile 截断。
+     * 活跃文档正文来源三选一：
+     * 1) 请求随带的内联正文（Office 插件等场景——文档在客户端本地，后端没有可读的 fileId）优先，
+     *    同时按会话存入 InlineContentCache 供后续「省传」轮次取用；
+     * 2) 只带内联正文哈希（文档自上一轮起没变，客户端省掉了整篇正文的上行）：凭哈希查缓存，
+     *    命中即复用；未命中（缓存已被 LRU 驱逐、或哈希对不上说明文档已改）返回 null，
+     *    由调用方按「正文暂不可读」现状处理——模型可改用读取类工具，不报错；
+     * 3) 两者都没有时走既有 read_document(fileId) 路径。
+     * 三条路径产出同格式正文，后续统一由调用方做 CDATA 包裹与 maxCharsPerFile 截断。
      */
     private String resolveActiveDocumentContent(
-            com.checkba.controller.ai.AiAgentController.ContextItem activeContext) {
+            com.checkba.controller.ai.AiAgentController.ContextItem activeContext,
+            String conversationId) {
         String inline = activeContext.getInlineContent();
         if (inline != null && !inline.isEmpty()) {
             if (inline.length() > MAX_INLINE_CONTENT_CHARS) {
-                inline = inline.substring(0, MAX_INLINE_CONTENT_CHARS)
+                // 超限正文不入缓存：缓存的内存上界按每条 200k 字符估算
+                return inline.substring(0, MAX_INLINE_CONTENT_CHARS)
                         + "\n... [TRUNCATED - Inline content too long]";
             }
+            inlineContentCache.put(conversationId, inline);
             return inline;
+        }
+        String hash = activeContext.getInlineContentHash();
+        if (hash != null && !hash.isBlank()) {
+            String cached = inlineContentCache.get(conversationId, hash);
+            if (cached == null) {
+                log.info("[Context] Inline content hash miss for conversation {}, falling back to no inline body",
+                        conversationId);
+            }
+            return cached;
         }
         return legalTools.read_document(activeContext.getId());
     }

--- a/backend/src/main/java/com/checkba/service/ai/InlineContentCache.java
+++ b/backend/src/main/java/com/checkba/service/ai/InlineContentCache.java
@@ -1,0 +1,91 @@
+package com.checkba.service.ai;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 会话级内联正文缓存（Office 插件的「正文省传」）。
+ *
+ * 背景：插件里的文档在用户本机，后端没有可读的 fileId，正文只能随每条 /chat 请求内联上送。
+ * 一篇合同上限 20 万字符，同一场对话里聊十轮就重传十遍——云后端场景下这段上行是
+ * 「插件响应慢」的可测量组成部分。因此客户端在正文没变时改为只上送内容哈希，
+ * 后端凭哈希从本缓存取回上一次的正文。
+ *
+ * 契约要点：
+ * - 哈希一律由**后端**对收到的正文自算（SHA-256），客户端上送的哈希只当作「省传」信号，
+ *   不作为缓存键的可信来源——否则客户端可以拿任意哈希取走别人的正文。
+ * - 未命中不报错：调用方按「本轮没有内联正文」处理（提示词里已有对应文案，
+ *   模型可改用 office_get_text 等读取类工具）。
+ * - 进程内存态、不落库、不做主动清理；生命周期与 ClientCapabilityService 同款（按会话）。
+ *
+ * 内存上界：单条正文 ≤ 200k 字符（ContextAssemblerService 的 MAX_INLINE_CONTENT_CHARS，
+ * 超限的不入缓存），条目上限 32，即 32 × 200k char ≈ 13MB（Java char 双字节）。
+ * 超出后按访问顺序 LRU 驱逐最久未用的会话。
+ */
+@Service
+@Slf4j
+public class InlineContentCache {
+
+    /** 条目上限：32 × 200k 字符 ≈ 13MB */
+    static final int MAX_ENTRIES = 32;
+
+    private record CachedBody(String hash, String content) { }
+
+    /** accessOrder=true 的 LinkedHashMap 即 LRU；并发访问全部走 synchronized 包装 */
+    private final Map<String, CachedBody> byConversation = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, CachedBody> eldest) {
+                    return size() > MAX_ENTRIES;
+                }
+            });
+
+    /**
+     * 记下本会话这一轮实际使用的内联正文。哈希由本方法自算，不接受外部传入。
+     */
+    public void put(String conversationId, String content) {
+        if (conversationId == null || conversationId.isBlank() || content == null || content.isEmpty()) {
+            return;
+        }
+        byConversation.put(conversationId, new CachedBody(sha256Hex(content), content));
+    }
+
+    /**
+     * 按客户端上送的哈希取回本会话上一次的正文。
+     * 会话没有缓存、或哈希与缓存内容不一致（文档已被改动）时返回 null——
+     * 调用方按「没有内联正文」处理，不报错。
+     */
+    public String get(String conversationId, String hash) {
+        if (conversationId == null || conversationId.isBlank() || hash == null || hash.isBlank()) {
+            return null;
+        }
+        CachedBody entry = byConversation.get(conversationId);
+        if (entry == null) {
+            return null;
+        }
+        return entry.hash().equalsIgnoreCase(hash.trim()) ? entry.content() : null;
+    }
+
+    /** SHA-256 十六进制小写，口径与插件端 crypto.subtle.digest('SHA-256') 一致。 */
+    static String sha256Hex(String text) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(text.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 是 JDK 必备算法，走不到这里
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
@@ -40,6 +40,7 @@ class ContextAssemblerServiceTest {
     private LegalTools legalTools;
     private ContextAssemblerService assembler;
     private ClientCapabilityService capabilityService;
+    private InlineContentCache inlineContentCache;
 
     @BeforeEach
     void setUp() {
@@ -58,9 +59,11 @@ class ContextAssemblerServiceTest {
         when(contextCompressor.needsCompression(any(), any())).thenReturn(false);
 
         capabilityService = new ClientCapabilityService();
+        inlineContentCache = new InlineContentCache();
         assembler = new ContextAssemblerService(
                 legalTools, messageService, fileContextLoader,
-                new AiContextProperties(), skillRouter, capabilityService, memoryManager, contextCompressor);
+                new AiContextProperties(), skillRouter, capabilityService, inlineContentCache,
+                memoryManager, contextCompressor);
     }
 
     private List<ChatMessage> assembleMessages(AiAgentController.ContextItem activeContext) {
@@ -197,7 +200,7 @@ class ContextAssemblerServiceTest {
         props.getFiles().setMaxCharsPerFile(500_000);
         ContextAssemblerService bigLimitAssembler = new ContextAssemblerService(
                 legalTools, mockedMessageService(), mock(FileContextLoader.class),
-                props, mockedSkillRouter(), new ClientCapabilityService(),
+                props, mockedSkillRouter(), new ClientCapabilityService(), new InlineContentCache(),
                 mockedMemoryManager(), mockedCompressor());
 
         String huge = "甲".repeat(200_001);
@@ -219,6 +222,57 @@ class ContextAssemblerServiceTest {
         assertTrue(lastUser.contains("[系统提醒]"), "内联正文路径也应有末位提醒");
         assertTrue(lastUser.contains("劳动合同.docx"), "提醒里应点名当前文档");
         assertTrue(lastUser.contains("doc_list_project_files"), "应点名禁用 doc_list_project_files");
+    }
+
+    // ==== 正文省传（inlineContentHash + InlineContentCache）====
+    // 同一会话里文档没变时，插件只上送内容哈希，不再重传整篇正文（20 万字符上限）。
+
+    private static AiAgentController.ContextItem officeDocByHash(String hash) {
+        AiAgentController.ContextItem item = new AiAgentController.ContextItem();
+        item.setId("office-current-document");
+        item.setName("劳动合同.docx");
+        item.setFileType("docx");
+        item.setInlineContentHash(hash);
+        return item;
+    }
+
+    @Test
+    @DisplayName("带正文的请求：正常注入，并按会话落入内联正文缓存")
+    void inlineContentIsCachedForLaterHashOnlyRequests() {
+        String body = "第一条 试用期为三个月……";
+
+        String systemText = assembleSystemText(officeDoc(body));
+
+        assertTrue(systemText.contains(body), "本轮正文应正常注入");
+        assertEquals(body, inlineContentCache.get("conv-1", InlineContentCache.sha256Hex(body)),
+                "正文应按会话落缓存，哈希由后端自算");
+    }
+
+    @Test
+    @DisplayName("只带哈希且命中缓存：复用上一轮正文，不回落 read_document")
+    void hashOnlyRequestReusesCachedContent() {
+        String body = "第一条 试用期为三个月……";
+        assembleSystemText(officeDoc(body));
+
+        String systemText = assembleSystemText(officeDocByHash(InlineContentCache.sha256Hex(body)));
+
+        assertTrue(systemText.contains(body), "命中缓存应复用上一轮正文");
+        org.mockito.Mockito.verify(legalTools, org.mockito.Mockito.never()).read_document(anyString());
+    }
+
+    @Test
+    @DisplayName("只带哈希但未命中（文档已改/缓存已驱逐）：降级为无正文，不报错也不回落 read_document")
+    void hashMissDegradesToNoInlineBody() {
+        capabilityService.record("conv-1", "office");
+        String body = "第一条 试用期为三个月……";
+        assembleSystemText(officeDoc(body));
+
+        String systemText = assembleSystemText(officeDocByHash(InlineContentCache.sha256Hex("文档已被改动")));
+
+        assertFalse(systemText.contains(body), "哈希对不上不应复用旧正文");
+        assertTrue(systemText.contains("[正文暂不可读，可用 office_get_text 直接读取]"),
+                "未命中应走既有「正文暂不可读」文案，模型改用读取类工具");
+        org.mockito.Mockito.verify(legalTools, org.mockito.Mockito.never()).read_document(anyString());
     }
 
     // ==== 末位提醒按会话客户端能力切换（Phase C）====

--- a/backend/src/test/java/com/checkba/service/ai/InlineContentCacheTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/InlineContentCacheTest.java
@@ -1,0 +1,55 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 内联正文缓存（Office 插件「正文省传」的后端半边）。
+ */
+class InlineContentCacheTest {
+
+    @Test
+    @DisplayName("存取按会话隔离：哈希一致才取得到，跨会话取不到")
+    void getRequiresMatchingHashAndConversation() {
+        InlineContentCache cache = new InlineContentCache();
+        cache.put("conv-a", "甲方乙方");
+
+        String hash = InlineContentCache.sha256Hex("甲方乙方");
+        assertEquals("甲方乙方", cache.get("conv-a", hash), "同会话同哈希应命中");
+        assertNull(cache.get("conv-b", hash), "别的会话不该取到本会话的正文");
+        assertNull(cache.get("conv-a", InlineContentCache.sha256Hex("改过的正文")), "哈希对不上应未命中");
+        assertNull(cache.get("conv-a", null), "无哈希即无省传信号");
+    }
+
+    @Test
+    @DisplayName("同一会话再次 put 覆盖旧正文：文档改动后旧哈希立即失效")
+    void putOverwritesPreviousContent() {
+        InlineContentCache cache = new InlineContentCache();
+        cache.put("conv-a", "第一版");
+        cache.put("conv-a", "第二版");
+
+        assertNull(cache.get("conv-a", InlineContentCache.sha256Hex("第一版")), "旧哈希应失效");
+        assertEquals("第二版", cache.get("conv-a", InlineContentCache.sha256Hex("第二版")), "新哈希应命中");
+    }
+
+    @Test
+    @DisplayName("超过条目上限按 LRU 驱逐最久未用的会话（内存上界 32 × 200k 字符）")
+    void evictsLeastRecentlyUsedBeyondLimit() {
+        InlineContentCache cache = new InlineContentCache();
+        for (int i = 0; i < InlineContentCache.MAX_ENTRIES; i++) {
+            cache.put("conv-" + i, "正文" + i);
+        }
+        // 触碰最早的一条，使其成为最近使用
+        assertEquals("正文0", cache.get("conv-0", InlineContentCache.sha256Hex("正文0")));
+
+        cache.put("conv-new", "新会话正文");
+
+        assertEquals("正文0", cache.get("conv-0", InlineContentCache.sha256Hex("正文0")),
+                "刚被访问过的会话不该被驱逐");
+        assertNull(cache.get("conv-1", InlineContentCache.sha256Hex("正文1")),
+                "最久未用的会话应被驱逐，未命中即降级为无正文");
+    }
+}

--- a/office-addin/taskpane/lib/chatSession.js
+++ b/office-addin/taskpane/lib/chatSession.js
@@ -3,7 +3,7 @@ import {
   postChat, postCancel, postOfficeResult, createConversation, fetchConversationHistory
 } from './api.js'
 import { createSseConnection, createTagStreamParser } from './sse.js'
-import { readActiveDocument, detectHost } from './wordDoc.js'
+import { readActiveDocument, detectHost, hashContent } from './wordDoc.js'
 import { executeOfficeCommand, commandDisplayName } from './officeExecutor.js'
 import { loadConversationId, saveConversationId, isConfigured } from './settings.js'
 
@@ -31,6 +31,12 @@ export const notice = ref('')
 export const includeDocument = ref(true)
 /** 滚动到底部的信号：store 不碰 DOM，视图 watch 这个计数器 */
 export const scrollSignal = ref(0)
+/**
+ * 最近一轮的耗时切片（毫秒整数）。界面暂不展示，控制台每轮打一条 [AddinPerf]。
+ * 「响应慢」得先能被测量：这里把一次发送拆成读文档 / 建连 / 请求受理 / 首字 / 全程五段，
+ * 优化前后各跑一遍就能说清快在哪一段。不上报遥测。
+ */
+export const lastPerf = ref(null)
 
 // ==================== 内部状态 ====================
 
@@ -50,13 +56,66 @@ let currentAssistant = null
 // （首连的 run_state 在 send 已置 streaming 之后到达，不能当终态看）
 let everReconnected = false
 // 本次建连是否由「回灌」触发（任务窗格重建后恢复既有会话）。
-// 区分「谁触发的建连」是 run_state 的两种读法的分水岭：
-//   - send 触发：streaming 已由 send 置起，首个 run_state 不能当终态；
-//   - 回灌触发：首个 run_state 就是当前运行状态的权威答案，据它决定锁不锁输入框。
+// 建连有三种来源，run_state 的读法各不相同（详见 handleRunState）：
+//   - 回灌触发（本标记位为 true）：首个 run_state 就是当前运行状态的权威答案；
+//   - 预连触发（进面板/新对话时提前建连）：本地没有进行中的轮次，run_state 无副作用；
+//   - send 触发（兜底重试）：streaming 已由 send 置起，首个 run_state 不能当终态。
 let restorePending = false
+
+/**
+ * 正文省传（内容哈希去重）的会话内状态。
+ * 文档没变时只上送哈希，后端按会话从 InlineContentCache 取回上一轮正文。
+ * - confirmed：上一轮正常收尾（bubble_end）过——只有这时才敢省传，
+ *   因为「后端确实收下并用了这份正文」只有轮次跑完才算数；
+ * - disabled：本会话出过 error（也覆盖旧后端不认 inlineContentHash 的情况），
+ *   之后整场退回恒传全文，宁可多传也不让模型看不到正文。
+ */
+let docCache = { conversationId: null, hash: '', confirmed: false, disabled: false }
+/** 本轮上送的正文哈希（轮次成功收尾时才提交进 docCache） */
+let pendingDocHash = ''
+
+function resetDocCache() {
+  docCache = { conversationId: null, hash: '', confirmed: false, disabled: false }
+  pendingDocHash = ''
+}
 
 function bumpScroll() {
   scrollSignal.value++
+}
+
+// ==================== 耗时埋点 ====================
+
+let perfRound = null
+
+function nowMs() {
+  return typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now()
+}
+
+/** 从用户点「发送」的那一刻起表 */
+function perfStart() {
+  perfRound = {
+    t0: nowMs(),
+    docReadMs: 0,      // 读当前文档正文 + 算哈希
+    docChars: 0,       // 本轮实际上送的正文字符数（省传时为 0）
+    docReused: false,  // 本轮是否命中省传（只上送哈希）
+    connectMs: 0,      // 本次发送触发的 SSE 建连（预连已就绪时为 0）
+    chatAcceptedMs: 0, // POST /chat 返回 200（相对起表）
+    firstTokenMs: 0,   // 本轮第一个 text_delta 到达（相对起表）
+    totalMs: 0         // 终态事件到达（相对起表）
+  }
+}
+
+function perfSince() {
+  return perfRound ? Math.round(nowMs() - perfRound.t0) : 0
+}
+
+function perfEnd() {
+  if (!perfRound) return
+  const { t0, ...fields } = perfRound
+  perfRound = null
+  const out = { ...fields, totalMs: Math.round(nowMs() - t0) }
+  lastPerf.value = out
+  console.info('[AddinPerf]', out)
 }
 
 // ==================== 会话激活与恢复 ====================
@@ -85,29 +144,52 @@ export async function activateSession({ settings, projectId }) {
   banner.value = ''
   notice.value = ''
   conversationId = null
+  resetDocCache()
 
   if (!pid || !settings || !isConfigured(settings)) return
 
   // 任务窗格重建（切文档、重开窗格）后：接着上次的会话，而不是从空白开始
   const stored = loadConversationId(pid)
-  if (!stored) return
-  conversationId = stored
-
-  const history = await fetchConversationHistory(settings, stored)
-  if (gen !== generation) return
-  if (history.length) {
-    messages.value = history.map(toLocalMessage)
-    bumpScroll()
+  if (stored) {
+    conversationId = stored
+    const history = await fetchConversationHistory(settings, stored)
+    if (gen !== generation) return
+    if (history.length) {
+      messages.value = history.map(toLocalMessage)
+      bumpScroll()
+    }
+    // 本次建连属于「回灌」，首个 run_state 是权威状态（见 handleRunState）
+    restorePending = true
   }
 
-  restorePending = true
+  // 有既有会话就只建连（回灌），没有就先签发再建连（预连）——同一条链，不存在两条并行建连
   try {
-    await ensureConnection()
+    await preconnect()
   } catch (e) {
-    // 回灌建连失败（后端不可达/令牌失效）不打断用户：下次发送时会再建一次并给出明确报错
+    // 建连失败（后端不可达/令牌失效）不打断用户：下次发送时会再建一次并给出明确报错
     restorePending = false
-    console.warn('[Addin] 会话恢复建连失败', e)
+    console.warn('[Addin] 会话预连失败', e)
   }
+}
+
+/**
+ * 备好会话 ID 与 SSE 连接。签发一个往返、建连一个往返，两个都从「发消息」的
+ * 关键路径上挪到这里——进面板/切项目时、以及新对话后就做完。
+ * 三处调用：activateSession（回灌或预连）、newConversation（新会话预连）、
+ * send（兜底重试：前两处失败或还没跑完时）。都已就位时是空操作。
+ */
+async function preconnect() {
+  if (!ctx.projectId || !ctx.settings || !isConfigured(ctx.settings)) return
+  if (!conversationId) {
+    // 会话 ID 优先服务端签发；旧后端无该端点时静默回退客户端生成。
+    // 按项目落本机存储，任务窗格重建后据它接回同一场对话。
+    const gen = generation
+    const issued = await createConversation(ctx.settings, parseInt(ctx.projectId, 10))
+    if (gen !== generation) return
+    conversationId = issued || `conv-${Date.now()}`
+    saveConversationId(ctx.projectId, conversationId)
+  }
+  await ensureConnection()
 }
 
 /**
@@ -138,6 +220,25 @@ function finishStreaming() {
   if (currentAssistant) currentAssistant.streaming = false
   streaming.value = false
   notice.value = ''
+  perfEnd()
+}
+
+/** 轮次正常收尾：本轮上送的正文哈希可以作为下一轮省传的依据了 */
+function commitDocHash() {
+  if (!pendingDocHash) return
+  docCache = {
+    conversationId,
+    hash: pendingDocHash,
+    confirmed: true,
+    disabled: docCache.disabled
+  }
+  pendingDocHash = ''
+}
+
+/** 轮次出错：本会话整场退回恒传全文（也覆盖旧后端不认 inlineContentHash 的情况） */
+function disableDocDedup() {
+  docCache = { conversationId: null, hash: '', confirmed: false, disabled: true }
+  pendingDocHash = ''
 }
 
 /**
@@ -176,16 +277,19 @@ function handleEvent(evt, dataStr) {
   if (evt === 'text_delta') {
     let content = dataStr
     try { content = JSON.parse(dataStr).content || '' } catch (e) { /* 按原文处理 */ }
+    if (perfRound && !perfRound.firstTokenMs) perfRound.firstTokenMs = perfSince()
     ensureAssistantBubble()
     if (parser) parser.feed(content)
     bumpScroll()
   } else if (evt === 'bubble_end') {
     if (parser) parser.flush()
+    commitDocHash()
     finishStreaming()
   } else if (evt === 'error') {
     let msg = '执行出错'
     try { msg = JSON.parse(dataStr).message || msg } catch (e) { /* ignore */ }
     if (currentAssistant) currentAssistant.error = msg
+    disableDocDedup()
     finishStreaming()
   } else if (evt === 'cancelled') {
     if (currentAssistant && !currentAssistant.text) currentAssistant.text = '（已停止）'
@@ -199,11 +303,15 @@ function handleEvent(evt, dataStr) {
 }
 
 /**
- * 建连时后端推送当前运行状态。两种读法，取决于这条连接是谁建的：
- *   - 回灌建连（restorePending）：窗格重建后本地没有 streaming 状态，这条就是权威答案。
- *     仍在跑 → 锁输入并提示，等后续正文经 SSE 推来；否则保持空闲。
- *   - send 建连：streaming 已经置起，首个 run_state 不能当终态看（后端可能还没标 RUNNING）。
- *     只有断线重连之后（everReconnected）才用它兜底解锁——断线期间可能漏掉了 bubble_end。
+ * 建连时后端推送当前运行状态。读法取决于这条连接是谁建的，共三种来源：
+ *   1. 回灌建连（restorePending=true）：窗格重建后本地没有 streaming 状态，这条就是权威答案。
+ *      仍在跑 → 锁输入并提示，等后续正文经 SSE 推来；否则保持空闲。
+ *   2. 预连建连（restorePending=false 且 streaming=false）：进面板/新对话时提前建的连，
+ *      本地没有进行中的轮次，这条 run_state 不该产生任何副作用——两个 if 都不进，
+ *      正是这里要的「无副作用」：既不锁输入（没人在发消息），也不解锁（本来就没锁）。
+ *   3. send 建连（兜底重试，streaming=true）：streaming 已由 send 置起，
+ *      首个 run_state 不能当终态看（后端可能还没标 RUNNING）。只有断线重连之后
+ *      （everReconnected）才用它兜底解锁——断线期间可能漏掉了 bubble_end。
  */
 function handleRunState(dataStr) {
   let status = null
@@ -255,6 +363,7 @@ async function handleClientAction(dataStr) {
 
 async function ensureConnection() {
   if (connection) return
+  const startedAt = nowMs()
   const conn = createSseConnection({
     baseUrl: ctx.settings.serverUrl,
     token: ctx.settings.token,
@@ -283,6 +392,8 @@ async function ensureConnection() {
     if (connection === conn) connection = null
     throw e
   }
+  // 只有「本次发送触发了建连」才记时——预连时没有轮次在跑，perfRound 为空
+  if (perfRound) perfRound.connectMs = Math.round(nowMs() - startedAt)
 }
 
 function closeConnection() {
@@ -294,6 +405,35 @@ function closeConnection() {
 }
 
 // ==================== 交互 ====================
+
+/**
+ * 读当前文档正文并算内容哈希。与「确保连接」并行跑——它是发送路径上唯一的长活儿
+ * （整篇正文最多 20 万字符），不该排在建连后面等。
+ */
+async function readDocumentForSend() {
+  const startedAt = nowMs()
+  const doc = await readActiveDocument()
+  const hash = doc ? await hashContent(doc.inlineContent) : ''
+  if (perfRound) perfRound.docReadMs = Math.round(nowMs() - startedAt)
+  return { doc, hash }
+}
+
+/**
+ * 组装 activeContext：正文没变（哈希相同）且上一轮正常收尾过，就只上送哈希，
+ * 让后端从会话缓存取回正文，省掉整篇正文的上行；否则全文与哈希一起上送。
+ * 哈希算不出（crypto.subtle 不可用）时恒传全文。
+ */
+function buildActiveContext(doc, hash) {
+  pendingDocHash = hash
+  const reusable = Boolean(hash) && docCache.confirmed && !docCache.disabled
+    && docCache.conversationId === conversationId && docCache.hash === hash
+  if (reusable) {
+    if (perfRound) perfRound.docReused = true
+    return { id: doc.id, name: doc.name, fileType: doc.fileType, inlineContentHash: hash }
+  }
+  if (perfRound) perfRound.docChars = (doc.inlineContent || '').length
+  return hash ? { ...doc, inlineContentHash: hash } : { ...doc }
+}
 
 export async function send() {
   banner.value = ''
@@ -312,27 +452,28 @@ export async function send() {
 
   currentAssistant = null
   parser = null
+  perfStart()
   const assistant = ensureAssistantBubble()
   // 本轮由 send 触发：run_state 回到「不能当终态」的读法（回灌建连若还没收到 run_state，到此作废）
   restorePending = false
+  // 上一轮若被中途停止，它的待提交哈希就此作废——本轮带不带正文由本轮说了算
+  pendingDocHash = ''
   streaming.value = true
   bumpScroll()
 
   try {
-    // 首条消息前先请求服务端签发会话 ID；旧后端无该端点时静默回退客户端生成。
-    // 会话 ID 按项目落本机存储，任务窗格重建后据它接回同一场对话。
-    if (!conversationId) {
-      conversationId = (await createConversation(settings, parseInt(projectId, 10)))
-        || `conv-${Date.now()}`
-      saveConversationId(projectId, conversationId)
-    }
-    await ensureConnection()
+    // 会话 ID 与 SSE 连接正常情况下已由预连备好，这里的 preconnect 只是兜底重试；
+    // 读文档与它并行——两件事互不依赖，串起来就是白等一个往返。
+    const [read] = await Promise.all([
+      includeDocument.value ? readDocumentForSend() : Promise.resolve(null),
+      preconnect()
+    ])
 
-    // 当前文档内容以内联形式随请求上送（activeContext.inlineContent）
+    // 当前文档内容以内联形式随请求上送（activeContext.inlineContent / inlineContentHash）
     let activeContext = null
-    if (includeDocument.value) {
-      activeContext = await readActiveDocument()
-      if (!activeContext) banner.value = '未能读取文档内容，本条消息不附带文档内容'
+    if (read) {
+      if (read.doc) activeContext = buildActiveContext(read.doc, read.hash)
+      else banner.value = '未能读取文档内容，本条消息不附带文档内容'
     }
 
     await postChat(settings, {
@@ -346,8 +487,10 @@ export async function send() {
       clientCapability: 'office',
       officeHost: detectHost() || 'word'
     })
+    if (perfRound) perfRound.chatAcceptedMs = perfSince()
   } catch (e) {
     assistant.error = e.message || '消息发送失败'
+    disableDocDedup()
     finishStreaming()
   }
   return { needSettings: false }
@@ -372,4 +515,8 @@ export function newConversation() {
   reconnecting.value = false
   everReconnected = false
   streaming.value = false
+  resetDocCache()
+  // 立刻预连新会话（签发新 ID + 建 SSE），让下一条消息零建连成本；
+  // 这条连接没有轮次在跑，其 run_state 不产生任何副作用（见 handleRunState 第 2 种来源）
+  preconnect().catch((e) => console.warn('[Addin] 新会话预连失败', e))
 }

--- a/office-addin/taskpane/lib/wordDoc.js
+++ b/office-addin/taskpane/lib/wordDoc.js
@@ -117,6 +117,27 @@ async function readPptSlides() {
   return { text, name: documentDisplayName('当前 PowerPoint 演示文稿'), fileType: 'pptx' }
 }
 
+/**
+ * 正文内容哈希（SHA-256 十六进制小写），用于「文档没变就不重传正文」的省传判定。
+ * 口径与后端 InlineContentCache.sha256Hex 一致（UTF-8 字节）。
+ *
+ * crypto.subtle 只在 secure context 可用——任务窗格是 https，常态都有；
+ * 取不到或算失败时返回空串，调用方据此降级为恒传全文（永远不会因此丢正文）。
+ */
+export async function hashContent(text) {
+  try {
+    const subtle = globalThis.crypto && globalThis.crypto.subtle
+    if (!subtle) return ''
+    const bytes = new TextEncoder().encode(text || '')
+    const digest = await subtle.digest('SHA-256', bytes)
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+  } catch (e) {
+    return ''
+  }
+}
+
 export async function readActiveDocument() {
   if (!officeAvailable()) return null
   try {


### PR DESCRIPTION
维护者反馈第 6 条（插件响应慢）。原则：先埋点后优化，优化项可被埋点验证。

## 内容

1. **埋点**：每轮输出 `[AddinPerf] {docReadMs, docChars, docReused, connectMs, chatAcceptedMs, firstTokenMs, totalMs}`，三条终态路径都收表；`lastPerf` 导出留给将来界面展示。
2. **预连**：签发会话 ID + 建 SSE 从「第一条 send 的关键路径」挪到进面板/新对话时；建连三来源（回灌/预连/send 兜底）收敛为一个 preconnect()，run_state 语义各自钉死（预连到达的 run_state 零副作用），sse.js 重连语义一行未动。send 内读文档与连接兜底 Promise.all 并行。
3. **正文省传**：同会话文档未变时只传 SHA-256 哈希不传 20 万字符正文。后端 InlineContentCache（会话级 LRU 32 条 ≈13MB，自算哈希不信客户端），未命中降级为无内联正文（模型可用 office_get_text 补读），不报错。保守启用条件：上一轮 bubble_end 正常收尾；出过 error 整场恒传；crypto.subtle 不可用恒传。

## 验证

- mvn test 定向 51 用例全绿（新增 InlineContentCacheTest 3 + ContextAssembler 省传 3 例）
- office-addin build 零报错；frontend check:emits 通过
- 提速实测数据待真机 sideload 后从 [AddinPerf] 读取对比

🤖 Generated with [Claude Code](https://claude.com/claude-code)