### PR TITLE
发布 v0.13.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiworkdeck-desktop",
-  "version": "0.6.3",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiworkdeck-desktop",
-      "version": "0.6.3",
+      "version": "0.13.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",
@@ -3426,7 +3426,7 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号单一来源 desktop/package.json 提到 0.13.0（package-lock 同步，它长期停在 0.6.3）。

## 本版内容（PR #297-#308）

**插件体验八条反馈全修**：设置单字段化（只填官网 API Key）、桌面端补设备令牌界面、标题栏去重、广场入口页内化、授权展示口径统一（修「连了账户仍显示试用版」）、会话不丢（切页面/重开窗格）、插件临时项目、字符级最小修订。

**文档能力大幅扩张**：插件三宿主 11 → 74 command；桌面端 doc_* 二期 16 原语（批注读回解决/修订接受拒绝/页眉页脚/分节/脚注/超链接/图片/样式）、sheet_* 二期 10 原语（批注/验证/图表/查找/命名/保护/分组/透视表）。

**Impress 实时编辑桥 Phase 1**：slide_* 七原语上线，桌面端首次支持 PPT 实时编辑（此前只有批量文件重写）。随附 **r4 引擎**（首个含 Impress/Draw/Math 的 LOWA 构建，已自托管，CI 指针已切；r3 留架回退）。

## 发版前验证（四套全绿，均在本 PR 的候选码上实跑）

| 套件 | 结果 |
|---|---|
| `mvn test` (JDK 21) | 1213 通过 / 0 失败 |
| `lowa-e2e`（真 r4 引擎） | 225 通过 / 0 失败 |
| `app-e2e` | 104 步通过 / 异常信号 0 |
| `desktop-e2e` | 保存链路全通（新建→编辑→自动保存→落盘校验） |

合并后打 tag `v0.13.0` 触发桌面构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)