### PR TITLE
fix: 反馈浮窗点空白处即关闭且丢失已输入内容（用户反馈 #1）

### DIFF
--- a/frontend/scripts/check-emit-bindings.mjs
+++ b/frontend/scripts/check-emit-bindings.mjs
@@ -42,6 +42,7 @@ function walk(dir, out = []) {
 }
 
 const vueFiles = walk(SRC)
+const feedbackWidgetFile = resolve(SRC, 'components/FeedbackWidget.vue')
 
 // 1) 每个 .vue 组件声明/使用的 emit 事件名（kebab 归一）
 const emitsByFile = new Map()   // absPath -> Set<kebab-name> | null(动态 emit，跳过)
@@ -93,8 +94,18 @@ for (const f of vueFiles) {
   }
 }
 
+// 回归护栏：反馈浮窗不允许“点遮罩空白处关闭”，否则用户误点会中断正在写的反馈。
+{
+  const code = readFileSync(feedbackWidgetFile, 'utf8')
+  const maskTag = code.match(/<div\b[^>]*class="awdfb-mask"[^>]*>/s)
+  if (maskTag && /@(mousedown|click)\.self\s*=\s*["']closePanel["']/.test(maskTag[0])) {
+    console.error('✗ FeedbackWidget: awdfb-mask 不应把空白点击绑定到 closePanel')
+    errors++
+  }
+}
+
 if (errors > 0) {
-  console.error(`\n共 ${errors} 处死绑定/事件名不匹配。子组件重构丢了 emit，或事件名拼错。`)
+  console.error(`\n共 ${errors} 处静态检查失败。`)
   process.exit(1)
 }
 console.log(`✓ emit/绑定契约检查通过（扫描 ${vueFiles.length} 个 .vue）`)

--- a/frontend/src/components/FeedbackWidget.vue
+++ b/frontend/src/components/FeedbackWidget.vue
@@ -37,7 +37,7 @@
       <span>反馈</span>
     </div>
 
-    <div v-if="open" class="awdfb-mask" @mousedown.self="closePanel">
+    <div v-if="open" class="awdfb-mask">
       <div
         class="awdfb-panel"
         :class="{ 'is-dragging': dragging }"


### PR DESCRIPTION
> 本 PR 由**优化者（Optimizer Agent）**根据一条用户反馈自动生成，**未经人工审阅**。
> 请先看「怎么复现」再看改动；不合适直接关掉即可，不要凭标题合并。

## 用户原话（反馈 #1）

> 在右下角反馈浮窗里打了一半字，手一滑点到旁边空白的地方，浮窗直接关了，刚写的东西全没了，只能重写一遍。能不能别点一下外面就关掉？


## 分诊结论

| 项 | 值 |
|---|---|
| 判定 | BUG |
| 置信度 | 0.91 |
| 严重度 | medium |
| 提交页面 | pages/project-overview/project-overview |
| 版本 / 平台 | dev / Mac OS X 27.0 (aarch64) |

用户在反馈浮窗里打了字，点到面板外面浮窗直接关闭，输入内容全部丢失。

## 本次改动的文件

```
frontend/scripts/check-emit-bindings.mjs
frontend/src/components/FeedbackWidget.vue
```

## 复核清单

- [ ] 这确实是一个缺陷，不是使用方式问题
- [ ] 改动范围最小，没有顺手重构
- [ ] 相关领域文档（`.claude/agents/`）无需同步更新
- [ ] 已在本机跑过对应验证命令
