### PR TITLE
feat: 邮件发信双通道（按收件域名分流国内/国外）

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,13 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
+        <!-- SMTP 发信（JavaMailSenderImpl + jakarta.mail）。注意：邮件通道不走 Spring Boot 的
+             spring.mail.* 自动装配——那套只能配出一个 JavaMailSender，而我们要国内/国外两条
+             并存，见 com.checkba.service.mail -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -255,7 +255,7 @@ public class AuthController {
      *       失败锁定与 /login 共用同一套计数。</li>
      *   <li>{@code scene=bind}：需已登录会话，发往待绑定的新手机号。</li>
      * </ul>
-     * IP 维度限频在 AuthAbuseGuard，手机号维度冷却/日上限在 SmsCodeStore。
+     * IP 维度限频在 AuthAbuseGuard，手机号维度冷却/日上限在 VerificationCodeStore。
      */
     @PostMapping("/sms/send-code")
     public Map<String, Object> sendSmsCode(@RequestBody SmsSendCodeRequest request,

--- a/backend/src/main/java/com/checkba/model/entity/User.java
+++ b/backend/src/main/java/com/checkba/model/entity/User.java
@@ -44,10 +44,21 @@ public class User {
     private String avatarUrl;
 
     /**
-     * 用户邮箱（可选）
+     * 用户邮箱（可选，资料字段）。**未经验证、不唯一**，仅用于展示与联络，
+     * 不能用来定位账号——历史数据里存在重复与空串。登录身份见 {@link #verifiedEmail}。
      */
     @Column(length = 256)
     private String email;
+
+    /**
+     * 已验证邮箱（可选，邮箱验证码登录用；唯一，未绑定为 null）。
+     *
+     * <p>刻意与上面的 {@link #email} 分开而不是给它加唯一约束：{@code email} 是历史自由填写
+     * 的资料字段，直接加约束会在既有脏数据上失败。本列只由「收到验证码并验过」这一条路径写入，
+     * 语义与 {@link #phone} 完全对齐——两者都是「验证过因而可当身份」的联系方式。
+     */
+    @Column(length = 256, unique = true)
+    private String verifiedEmail;
 
     /**
      * 绑定手机号（可选，登录短信验证用；唯一，未绑定为 null）。
@@ -148,6 +159,14 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getVerifiedEmail() {
+        return verifiedEmail;
+    }
+
+    public void setVerifiedEmail(String verifiedEmail) {
+        this.verifiedEmail = verifiedEmail;
     }
 
     public String getPhone() {

--- a/backend/src/main/java/com/checkba/repository/UserRepository.java
+++ b/backend/src/main/java/com/checkba/repository/UserRepository.java
@@ -9,5 +9,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByPhone(String phone);
+
+    /** 按已验证邮箱定位账号（登录身份）。资料字段 email 不唯一，不可用于此。 */
+    Optional<User> findByVerifiedEmail(String verifiedEmail);
 }
 

--- a/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
+++ b/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
@@ -149,7 +149,7 @@ public class AuthAbuseGuard {
         });
     }
 
-    // ==================== 短信发送限频（按 IP；手机号维度在 SmsCodeStore） ====================
+    // ==================== 短信发送限频（按 IP；手机号维度在 VerificationCodeStore） ====================
 
     public void checkSmsSendRate(String ip) {
         if (localMode) return;

--- a/backend/src/main/java/com/checkba/service/auth/SecondFactorService.java
+++ b/backend/src/main/java/com/checkba/service/auth/SecondFactorService.java
@@ -2,6 +2,7 @@ package com.checkba.service.auth;
 
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.mail.MailAuthService;
 import com.checkba.service.sms.SmsAuthService;
 import com.checkba.service.totp.TotpService;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,9 @@ import java.time.LocalDateTime;
  * 任何一条漏了都等于没设闸。新增第三条密码入口时也只接这一个服务。
  *
  * <h3>方式选择</h3>
- * TOTP 优先于短信：零成本、无国界、不受运营商报备与 SIM 交换影响。短信是大陆用户的
- * 习惯路径与未装认证器时的兜底。两者都没有则不拦（存量用户不受影响）。
+ * TOTP &gt; 邮箱 &gt; 短信。TOTP 零成本、无国界、不受运营商报备与 SIM 交换影响，因此最优先。
+ * **邮箱排在短信之前是成本决策**：短信按条计费，邮件几乎免费，绑了邮箱的用户没理由再走短信。
+ * 短信降为未绑邮箱时的兜底与大陆用户的习惯路径。三者都没有则不拦（存量用户不受影响）。
  */
 @Service
 @RequiredArgsConstructor
@@ -29,11 +31,14 @@ public class SecondFactorService {
         NONE,
         /** 认证器 App（RFC 6238）。 */
         TOTP,
+        /** 邮箱验证码。 */
+        MAIL,
         /** 短信验证码。 */
         SMS
     }
 
     private final TotpService totpService;
+    private final MailAuthService mailAuthService;
     private final SmsAuthService smsAuthService;
     private final UserRepository userRepository;
 
@@ -43,15 +48,22 @@ public class SecondFactorService {
         if (user.isTotpEnabled() && StringUtils.hasText(user.getTotpSecret())) {
             return Method.TOTP;
         }
+        if (mailAuthService.requiresCode(user)) {
+            return Method.MAIL;
+        }
         if (smsAuthService.requiresCode(user)) {
             return Method.SMS;
         }
         return Method.NONE;
     }
 
-    /** 提示前端往哪儿看：短信回脱敏号码，TOTP 回空串（码在用户手机的 App 里）。 */
+    /** 提示前端往哪儿看：短信/邮箱回脱敏后的目标，TOTP 回空串（码在用户手机的 App 里）。 */
     public String target(User user) {
-        return required(user) == Method.SMS ? SmsAuthService.maskPhone(user.getPhone()) : "";
+        return switch (required(user)) {
+            case SMS -> SmsAuthService.maskPhone(user.getPhone());
+            case MAIL -> MailAuthService.maskEmail(user.getVerifiedEmail());
+            default -> "";
+        };
     }
 
     /**
@@ -63,6 +75,7 @@ public class SecondFactorService {
     public void verify(User user, String code) {
         switch (required(user)) {
             case TOTP -> verifyTotp(user, code);
+            case MAIL -> mailAuthService.verifyLoginCode(user, code);
             case SMS -> smsAuthService.verifyLoginCode(user, code);
             case NONE -> {
             }

--- a/backend/src/main/java/com/checkba/service/auth/VerificationCodeStore.java
+++ b/backend/src/main/java/com/checkba/service/auth/VerificationCodeStore.java
@@ -1,4 +1,4 @@
-package com.checkba.service.sms;
+package com.checkba.service.auth;
 
 import org.springframework.stereotype.Service;
 
@@ -11,24 +11,29 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongSupplier;
 
 /**
- * 短信验证码的签发与核销（进程内内存，与 AuthAbuseGuard 同一实现边界：
- * 单实例基线，多实例部署需外置存储；短信验证仅在官方托管的插件云后端启用，当前恒单实例）。
+ * 验证码的签发与核销，**短信与邮件共用一套生命周期**（进程内内存，与 AuthAbuseGuard
+ * 同一实现边界：单实例基线，多实例部署需外置存储；验证码登录仅在官方托管的插件云后端
+ * 启用，当前恒单实例）。
+ *
+ * <p>target 是「发给谁」的标识：短信是规范化手机号，邮件是规范化邮箱地址。两者不会撞键——
+ * 手机号里没有 {@code @}。共用一套的好处是防轰炸、爆破上限、一次性语义只有一份实现，
+ * 不必为新增通道再维护一条平行的验证码路径。
  *
  * <ul>
  *   <li>验证码 6 位数字，{@link #TTL 5 分钟}有效，验证成功即销毁（一次性）。</li>
- *   <li>同一 scene+phone {@link #RESEND_COOLDOWN 60 秒}内不可重发。</li>
+ *   <li>同一 scene+target {@link #RESEND_COOLDOWN 60 秒}内不可重发。</li>
  *   <li>连续 {@link #MAX_ATTEMPTS} 次验错即作废（防在线爆破 6 位码）。</li>
- *   <li>单手机号每天最多 {@link #MAX_PER_PHONE_PER_DAY} 条（防短信轰炸的最后一道；IP 维度在 AuthAbuseGuard）。</li>
+ *   <li>单 target 每天最多 {@link #MAX_PER_TARGET_PER_DAY} 条（防轰炸的最后一道；IP 维度在 AuthAbuseGuard）。</li>
  *   <li>内存只存 SHA-256，不存明文码。</li>
  * </ul>
  */
 @Service
-public class SmsCodeStore {
+public class VerificationCodeStore {
 
     static final Duration TTL = Duration.ofMinutes(5);
     static final Duration RESEND_COOLDOWN = Duration.ofSeconds(60);
     static final int MAX_ATTEMPTS = 5;
-    static final int MAX_PER_PHONE_PER_DAY = 10;
+    static final int MAX_PER_TARGET_PER_DAY = 10;
     private static final Duration DAY_WINDOW = Duration.ofHours(24);
     private static final int PURGE_THRESHOLD = 10_000;
 
@@ -38,33 +43,33 @@ public class SmsCodeStore {
     private final Map<String, Entry> codes = new ConcurrentHashMap<>();
     private final Map<String, WindowCounter> dailySends = new ConcurrentHashMap<>();
 
-    public SmsCodeStore() {
+    public VerificationCodeStore() {
         this(System::currentTimeMillis);
     }
 
     /** 测试用：可控时钟。 */
-    SmsCodeStore(LongSupplier nowMillis) {
+    VerificationCodeStore(LongSupplier nowMillis) {
         this.nowMillis = nowMillis;
     }
 
     /**
      * 签发一枚验证码（冷却期内 / 当日超量则抛业务错误）。
-     * 调用方拿到返回值后负责真正把短信发出去；发送失败时应调 {@link #invalidate} 回收，
-     * 否则冷却期会挡住用户的立即重试。
+     * 调用方拿到返回值后负责真正把码发出去（短信或邮件）；发送失败时应调 {@link #invalidate}
+     * 回收，否则冷却期会挡住用户的立即重试。
      */
-    public String issue(String scene, String phone) {
+    public String issue(String scene, String target) {
         long now = nowMillis.getAsLong();
         purgeIfOversized(now);
-        String key = key(scene, phone);
+        String key = key(scene, target);
         Entry existing = codes.get(key);
         if (existing != null && now - existing.issuedAt < RESEND_COOLDOWN.toMillis()) {
             throw new IllegalArgumentException("验证码发送过于频繁，请稍后再试");
         }
-        WindowCounter counter = dailySends.get(phone);
+        WindowCounter counter = dailySends.get(target);
         if (counter != null
                 && now - counter.windowStart <= DAY_WINDOW.toMillis()
-                && counter.count >= MAX_PER_PHONE_PER_DAY) {
-            throw new IllegalArgumentException("该手机号今日验证码条数已达上限，请明天再试");
+                && counter.count >= MAX_PER_TARGET_PER_DAY) {
+            throw new IllegalArgumentException("该账号今日验证码条数已达上限，请明天再试");
         }
 
         String code = String.valueOf(100000 + SECURE_RANDOM.nextInt(900000));
@@ -73,7 +78,7 @@ public class SmsCodeStore {
         entry.issuedAt = now;
         entry.expiresAt = now + TTL.toMillis();
         codes.put(key, entry);
-        dailySends.compute(phone, (k, c) -> {
+        dailySends.compute(target, (k, c) -> {
             if (c == null || now - c.windowStart > DAY_WINDOW.toMillis()) {
                 c = new WindowCounter();
                 c.windowStart = now;
@@ -85,9 +90,9 @@ public class SmsCodeStore {
     }
 
     /** 验证并核销：成功即销毁；连续验错超限作废。过期/不存在/错码一律 false。 */
-    public boolean verify(String scene, String phone, String code) {
+    public boolean verify(String scene, String target, String code) {
         if (code == null || code.isBlank()) return false;
-        String key = key(scene, phone);
+        String key = key(scene, target);
         Entry entry = codes.get(key);
         long now = nowMillis.getAsLong();
         if (entry == null || now > entry.expiresAt) {
@@ -104,13 +109,13 @@ public class SmsCodeStore {
         return true;
     }
 
-    /** 回收一枚未消费的码（发送失败时回滚冷却，不回滚当日计数——短信可能已产生费用）。 */
-    public void invalidate(String scene, String phone) {
-        codes.remove(key(scene, phone));
+    /** 回收一枚未消费的码（发送失败时回滚冷却，不回滚当日计数——网关受理即可能计费）。 */
+    public void invalidate(String scene, String target) {
+        codes.remove(key(scene, target));
     }
 
-    private static String key(String scene, String phone) {
-        return scene + "|" + phone;
+    private static String key(String scene, String target) {
+        return scene + "|" + target;
     }
 
     private static byte[] sha256(String value) {

--- a/backend/src/main/java/com/checkba/service/mail/DomesticMailGateway.java
+++ b/backend/src/main/java/com/checkba/service/mail/DomesticMailGateway.java
@@ -1,0 +1,53 @@
+package com.checkba.service.mail;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+/**
+ * 国内邮箱通道：阿里云邮件推送（DirectMail），发信域名 {@code dm.aiworkdeck.com}。
+ *
+ * <p>只认下面这份主流国内邮箱域名清单。国内用户用企业自建域名（腾讯企业邮 / 阿里企业邮
+ * 托管的公司域名）时不会命中，会落到 {@link GlobalMailGateway}——那是有意的取舍：
+ * 域名归属地无法从字符串判断，与其猜错不如让兜底通道发，Resend 发企业域名并不差。
+ *
+ * <p>{@code @Order} 决定 {@link MailRouter} 的匹配顺序：本通道必须排在兜底通道之前。
+ */
+@Service
+@Order(10)
+public class DomesticMailGateway extends SmtpMailGateway {
+
+    /** 主流国内邮箱域名（含各家的会员域名别名）。 */
+    static final Set<String> DOMAINS = Set.of(
+            "qq.com", "vip.qq.com", "foxmail.com",
+            "163.com", "126.com", "yeah.net", "188.com", "vip.163.com", "vip.126.com",
+            "sina.com", "sina.cn", "vip.sina.com", "sohu.com",
+            "139.com", "189.cn", "wo.cn",
+            "aliyun.com", "tom.com", "21cn.com", "263.net", "china.com"
+    );
+
+    @Autowired
+    public DomesticMailGateway(
+            @Value("${mail.domestic.enabled:false}") boolean enabled,
+            @Value("${mail.domestic.host:smtpdm.aliyun.com}") String host,
+            @Value("${mail.domestic.port:465}") int port,
+            @Value("${mail.domestic.username:}") String username,
+            @Value("${mail.domestic.password:}") String password,
+            @Value("${mail.domestic.from:}") String from,
+            @Value("${mail.from-name:AI Workdeck}") String fromName) {
+        super(enabled, host, port, username, password, from, fromName);
+    }
+
+    @Override
+    public String name() {
+        return "aliyun-directmail";
+    }
+
+    @Override
+    public boolean supports(String email) {
+        return email != null && DOMAINS.contains(MailRouter.domainOf(email));
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mail/GlobalMailGateway.java
+++ b/backend/src/main/java/com/checkba/service/mail/GlobalMailGateway.java
@@ -1,0 +1,42 @@
+package com.checkba.service.mail;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Service;
+
+/**
+ * 其余邮箱通道：Resend，发信域名 {@code send.aiworkdeck.com}。
+ *
+ * <p>{@link #supports} 恒为 true——它是兜底通道，接住所有没被 {@link DomesticMailGateway}
+ * 认领的地址。因此 {@code @Order} 必须排在国内通道之后，否则会把 QQ/163 也吃掉。
+ *
+ * <p>Resend 的 SMTP 用户名固定是字面量 {@code resend}，密码填 API key——不是账号邮箱。
+ */
+@Service
+@Order(20)
+public class GlobalMailGateway extends SmtpMailGateway {
+
+    @Autowired
+    public GlobalMailGateway(
+            @Value("${mail.global.enabled:false}") boolean enabled,
+            @Value("${mail.global.host:smtp.resend.com}") String host,
+            @Value("${mail.global.port:465}") int port,
+            @Value("${mail.global.username:resend}") String username,
+            @Value("${mail.global.password:}") String password,
+            @Value("${mail.global.from:}") String from,
+            @Value("${mail.from-name:AI Workdeck}") String fromName) {
+        super(enabled, host, port, username, password, from, fromName);
+    }
+
+    @Override
+    public String name() {
+        return "resend";
+    }
+
+    /** 兜底通道：不认领具体域名，谁没人要就归它。 */
+    @Override
+    public boolean supports(String email) {
+        return true;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
+++ b/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
@@ -1,0 +1,197 @@
+package com.checkba.service.mail;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.auth.VerificationCodeStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 邮箱验证码的流程编排：绑定、登录二次验证、免密登录的发码与核销。
+ *
+ * <p>与 {@code SmsAuthService} 同构，验证码生命周期共用 {@link VerificationCodeStore}
+ * （冷却、日上限、爆破上限、一次性只有一份实现）。存在的意义是成本：短信按条计费，
+ * 邮件几乎免费，所以绑了邮箱的用户二次验证优先走邮件（判定在 {@code SecondFactorService}）。
+ *
+ * <p>仅 server 模式生效——local-mode 是免登单机形态，{@link #active()} 恒 false。
+ *
+ * <h3>三个场景互不通用</h3>
+ * bind 码只能用于绑定、login 码只能用于登录二次验证、signin 码只能用于免密登录。
+ * 这是 {@link VerificationCodeStore} 的 scene 维度保证的：拿绑定码去免密登录会直接失败。
+ * 混用的后果很实际——bind 码是已登录态下发的，若能用于 signin，等于把一个低权限操作
+ * 兑换成了完整登录。
+ */
+@Service
+public class MailAuthService {
+
+    static final String SCENE_LOGIN = "mail-login";
+    static final String SCENE_BIND = "mail-bind";
+    static final String SCENE_SIGNIN = "mail-signin";
+
+    /** 与短信共用一个 store，scene 前缀已带 mail- 以免和手机号场景撞键。 */
+    private final VerificationCodeStore codeStore;
+    private final MailRouter mailRouter;
+    private final UserRepository userRepository;
+    private final boolean localMode;
+    private final boolean passwordlessEnabled;
+
+    @Autowired
+    public MailAuthService(VerificationCodeStore codeStore, MailRouter mailRouter,
+                           UserRepository userRepository,
+                           @Value("${security.local-mode:false}") boolean localMode,
+                           @Value("${mail.passwordless-login-enabled:false}") boolean passwordlessEnabled) {
+        this.codeStore = codeStore;
+        this.mailRouter = mailRouter;
+        this.userRepository = userRepository;
+        this.localMode = localMode;
+        this.passwordlessEnabled = passwordlessEnabled;
+    }
+
+    /** 邮箱验证在本部署形态下是否启用（非 local-mode 且至少一条发信通道配齐）。 */
+    public boolean active() {
+        return !localMode && mailRouter.active();
+    }
+
+    /** 免密登录是否开放。独立开关：它是一条新的匿名登录入口，默认关。 */
+    public boolean passwordlessActive() {
+        return active() && passwordlessEnabled;
+    }
+
+    /** 该用户本次登录是否可以用邮箱做二次验证（启用且已绑定已验证邮箱）。 */
+    public boolean requiresCode(User user) {
+        return active() && user != null && StringUtils.hasText(user.getVerifiedEmail());
+    }
+
+    // ==================== 登录二次验证 ====================
+
+    /** 给已绑定邮箱的用户发登录验证码，返回脱敏地址。调用方须先完成密码校验。 */
+    public String sendLoginCode(User user) {
+        if (!requiresCode(user)) {
+            throw new IllegalArgumentException("邮箱验证未启用");
+        }
+        sendWithRollback(SCENE_LOGIN, user.getVerifiedEmail(), "登录验证码");
+        return maskEmail(user.getVerifiedEmail());
+    }
+
+    /** 核销登录验证码；错码/过期抛业务错误（在线爆破由 VerificationCodeStore 的尝试上限兜底）。 */
+    public void verifyLoginCode(User user, String code) {
+        if (!requiresCode(user)) {
+            return;
+        }
+        if (!codeStore.verify(SCENE_LOGIN, user.getVerifiedEmail(), code)) {
+            throw new IllegalArgumentException("验证码错误或已过期");
+        }
+    }
+
+    // ==================== 绑定 ====================
+
+    /** 给待绑定的邮箱发验证码（需已通过会话鉴权），返回脱敏地址。 */
+    public String sendBindCode(Long userId, String email) {
+        requireActive();
+        String normalized = MailRouter.normalize(email);
+        requireNotBoundByOther(userId, normalized);
+        sendWithRollback(SCENE_BIND, normalized, "邮箱绑定验证码");
+        return maskEmail(normalized);
+    }
+
+    /** 校验验证码并完成绑定（也用于更换邮箱：直接绑新地址覆盖）。 */
+    public String confirmBind(Long userId, String email, String code) {
+        requireActive();
+        String normalized = MailRouter.normalize(email);
+        requireNotBoundByOther(userId, normalized);
+        if (!codeStore.verify(SCENE_BIND, normalized, code)) {
+            throw new IllegalArgumentException("验证码错误或已过期");
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("用户不存在: " + userId));
+        user.setVerifiedEmail(normalized);
+        // 资料邮箱为空时顺手补上，已填的不覆盖——那是用户自己写的
+        if (!StringUtils.hasText(user.getEmail())) {
+            user.setEmail(normalized);
+        }
+        user.setUpdatedAt(LocalDateTime.now());
+        userRepository.save(user);
+        return maskEmail(normalized);
+    }
+
+    // ==================== 免密登录 ====================
+
+    /**
+     * 免密登录发码。
+     *
+     * <p>**邮箱未绑定任何账号时，不发信但照常返回**——回包对「已注册」和「未注册」必须
+     * 完全一致，否则这个匿名端点就成了账号枚举器，谁都能拿它批量探测某人是不是用户。
+     * IP 维度的限频在 AuthAbuseGuard，邮箱维度的冷却与日上限在 VerificationCodeStore。
+     */
+    public void sendSigninCode(String email) {
+        if (!passwordlessActive()) {
+            throw new IllegalArgumentException("邮箱登录未启用");
+        }
+        String normalized = MailRouter.normalize(email);
+        if (userRepository.findByVerifiedEmail(normalized).isEmpty()) {
+            return;
+        }
+        sendWithRollback(SCENE_SIGNIN, normalized, "登录验证码");
+    }
+
+    /**
+     * 核销免密登录码并返回对应账号。错码/过期/无此账号一律同一句话——
+     * 同样是为了不泄露该邮箱是否注册过。
+     */
+    public User verifySigninCode(String email, String code) {
+        if (!passwordlessActive()) {
+            throw new IllegalArgumentException("邮箱登录未启用");
+        }
+        String normalized = MailRouter.normalize(email);
+        if (!codeStore.verify(SCENE_SIGNIN, normalized, code)) {
+            throw new IllegalArgumentException("验证码错误或已过期");
+        }
+        return userRepository.findByVerifiedEmail(normalized)
+                .orElseThrow(() -> new IllegalArgumentException("验证码错误或已过期"));
+    }
+
+    // ==================== 内部 ====================
+
+    /** h***@gmail.com；太短或空地址回空串（Map.of 不收 null）。 */
+    public static String maskEmail(String email) {
+        if (email == null) return "";
+        int at = email.indexOf('@');
+        if (at < 0) return "";
+        return (at <= 1 ? "***" : email.charAt(0) + "***") + email.substring(at);
+    }
+
+    private void sendWithRollback(String scene, String email, String purpose) {
+        // 先确认有通道可用，避免白占一次冷却
+        mailRouter.gatewayFor(email);
+        String code = codeStore.issue(scene, email);
+        try {
+            mailRouter.send(email, "AI Workdeck " + purpose,
+                    "你的验证码是：" + code + "\n\n"
+                            + "5 分钟内有效，请勿转发给任何人。\n"
+                            + "如果这不是你本人操作，忽略本邮件即可。\n\n"
+                            + "回信不会被系统读取。");
+        } catch (RuntimeException e) {
+            // 没发出去就不该占用户的冷却期（当日配额不回滚：网关受理即可能计费）
+            codeStore.invalidate(scene, email);
+            throw e;
+        }
+    }
+
+    private void requireActive() {
+        if (!active()) {
+            throw new IllegalArgumentException("邮箱验证未启用");
+        }
+    }
+
+    private void requireNotBoundByOther(Long userId, String email) {
+        Optional<User> holder = userRepository.findByVerifiedEmail(email);
+        if (holder.isPresent() && !holder.get().getId().equals(userId)) {
+            throw new IllegalArgumentException("该邮箱已绑定其他账号");
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mail/MailGateway.java
+++ b/backend/src/main/java/com/checkba/service/mail/MailGateway.java
@@ -1,0 +1,27 @@
+package com.checkba.service.mail;
+
+/**
+ * 邮件发信通道。按**收件域名**分流：国内主流邮箱走阿里云邮件推送
+ * （{@link DomesticMailGateway}），其余走 Resend（{@link GlobalMailGateway}）。
+ *
+ * <p>分流不是优化而是刚需：QQ/163/126 对境外 IP 发来的信过滤很凶，验证码进垃圾箱
+ * 甚至被拒收都很常见；反过来 Gmail 收阿里云的信到达率也一般。用错通道的后果是
+ * 用户收不到码 = 登不上，所以宁可多一条通道也不合并。
+ *
+ * <p>与 {@code SmsGateway} 同构（那边按号码归属地分流），两条路各自独立开关：
+ * 只配了一条的部署照常工作，{@link MailRouter} 会把不属于它的收件人也兜给它。
+ */
+public interface MailGateway {
+
+    /** 通道名，仅用于日志与诊断。 */
+    String name();
+
+    /** 配置齐全且开关打开。 */
+    boolean enabled();
+
+    /** 该通道是否负责这个收件地址（入参是 {@link MailRouter#normalize} 规范化后的地址）。 */
+    boolean supports(String email);
+
+    /** 发送纯文本邮件；失败抛 {@link IllegalArgumentException}（文案不得含「登录/未授权/请先」）。 */
+    void send(String to, String subject, String text);
+}

--- a/backend/src/main/java/com/checkba/service/mail/MailRouter.java
+++ b/backend/src/main/java/com/checkba/service/mail/MailRouter.java
@@ -1,0 +1,80 @@
+package com.checkba.service.mail;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * 按收件域名把邮件分派到对应通道。所有发信都应经由这里，不要直接拿 {@link MailGateway}。
+ *
+ * <p>选路规则两步走：
+ * <ol>
+ *   <li>找**已启用且认领该域名**的通道（国内邮箱 → 阿里云，其余 → Resend）；</li>
+ *   <li>没有则退回**任一已启用**的通道。</li>
+ * </ol>
+ * 第二步是有意的：只配了国内一条通道的部署，给 Gmail 发通知也得发得出去——
+ * 用次优通道送达，好过因为「没人认领」而整条路不通。
+ */
+@Service
+@Slf4j
+public class MailRouter {
+
+    /** 够用即可的地址形状校验：本地部分 + @ + 至少一级点分域名。 */
+    private static final Pattern EMAIL = Pattern.compile("^[^\\s@]+@[^\\s@.]+(\\.[^\\s@.]+)+$");
+
+    private final List<MailGateway> gateways;
+
+    @Autowired
+    public MailRouter(List<MailGateway> gateways) {
+        this.gateways = gateways;
+    }
+
+    /** 邮件功能在本部署形态下是否可用（任一通道配齐即算可用）。 */
+    public boolean active() {
+        return gateways.stream().anyMatch(MailGateway::enabled);
+    }
+
+    /** 选中负责该地址的通道。 */
+    public MailGateway gatewayFor(String email) {
+        List<MailGateway> on = gateways.stream().filter(MailGateway::enabled).toList();
+        if (on.isEmpty()) {
+            throw new IllegalArgumentException("邮件通道未配置");
+        }
+        return on.stream()
+                .filter(g -> g.supports(email))
+                .findFirst()
+                .orElseGet(() -> on.get(0));
+    }
+
+    /** 发一封纯文本邮件（收件地址会先规范化）。 */
+    public void send(String to, String subject, String text) {
+        String normalized = normalize(to);
+        MailGateway gateway = gatewayFor(normalized);
+        gateway.send(normalized, subject, text);
+        log.info("[mail] 已发送 to={} via={}", SmtpMailGateway.mask(normalized), gateway.name());
+    }
+
+    /**
+     * 规范化到存储/比较形态：去空白、整体小写。
+     *
+     * <p>大小写敏感性按域名其实各家不同，但主流邮箱一律不区分；统一小写才能让
+     * 「同一个邮箱」在唯一性检查里是同一条记录，否则 Foo@qq.com 和 foo@qq.com 会绑到两个账号。
+     */
+    public static String normalize(String email) {
+        String trimmed = email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
+        if (!EMAIL.matcher(trimmed).matches()) {
+            throw new IllegalArgumentException("邮箱格式不正确");
+        }
+        return trimmed;
+    }
+
+    /** 取 @ 之后的域名部分；入参须已规范化。 */
+    static String domainOf(String email) {
+        int at = email == null ? -1 : email.indexOf('@');
+        return at < 0 ? "" : email.substring(at + 1);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mail/SmtpMailGateway.java
+++ b/backend/src/main/java/com/checkba/service/mail/SmtpMailGateway.java
@@ -1,0 +1,104 @@
+package com.checkba.service.mail;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.util.StringUtils;
+
+import jakarta.mail.internet.MimeMessage;
+import java.util.Properties;
+
+/**
+ * 两条通道共用的 SMTP 发信实现——它们只在「凭据」和「负责哪些收件域名」上不同，
+ * 发信动作完全一样，所以放在基类里，子类只声明身份。
+ *
+ * <p>每个网关自己持有一个 {@link JavaMailSenderImpl}，不共用 Spring Boot 的
+ * {@code spring.mail.*} 单例：那套只能装配出一个 sender，而国内/国外必须并存。
+ *
+ * <p>用 MimeMessage 而不是 SimpleMailMessage，是因为要给发件人带显示名、
+ * 并把主题按 UTF-8 编码——中文主题走 SimpleMailMessage 在部分接收方会乱码。
+ */
+@Slf4j
+abstract class SmtpMailGateway implements MailGateway {
+
+    /** SMTP 各阶段超时。发信在登录/通知的请求线程上，卡住的连接会拖垮调用方。 */
+    private static final String TIMEOUT_MS = "10000";
+
+    private final boolean enabled;
+    private final String username;
+    private final String password;
+    private final String from;
+    private final String fromName;
+    private final JavaMailSenderImpl sender;
+
+    SmtpMailGateway(boolean enabled, String host, int port, String username, String password,
+                    String from, String fromName) {
+        this.enabled = enabled;
+        this.username = username;
+        this.password = password;
+        this.from = StringUtils.hasText(from) ? from : username;
+        this.fromName = fromName;
+
+        // 构造不建立连接，纯属性对象，因此无需惰性化
+        this.sender = new JavaMailSenderImpl();
+        this.sender.setHost(host);
+        this.sender.setPort(port);
+        this.sender.setUsername(username);
+        this.sender.setPassword(password);
+        this.sender.setDefaultEncoding("UTF-8");
+
+        Properties props = this.sender.getJavaMailProperties();
+        props.put("mail.smtp.auth", "true");
+        // 465 是隐式 SSL，587 是先明文连上再 STARTTLS 升级；两者不能混用
+        if (port == 465) {
+            props.put("mail.smtp.ssl.enable", "true");
+        } else {
+            props.put("mail.smtp.starttls.enable", "true");
+            props.put("mail.smtp.starttls.required", "true");
+        }
+        props.put("mail.smtp.connectiontimeout", TIMEOUT_MS);
+        props.put("mail.smtp.timeout", TIMEOUT_MS);
+        props.put("mail.smtp.writetimeout", TIMEOUT_MS);
+    }
+
+    /**
+     * 发件地址必须是真地址：Resend 的 SMTP 用户名是字面量 {@code resend}，
+     * 回落到 username 会拼出个非法 From，只有到发信那一刻才炸。宁可在这里判成未配置。
+     */
+    @Override
+    public boolean enabled() {
+        return enabled
+                && StringUtils.hasText(sender.getHost())
+                && StringUtils.hasText(username)
+                && StringUtils.hasText(password)
+                && from.contains("@");
+    }
+
+    @Override
+    public void send(String to, String subject, String text) {
+        if (!enabled()) {
+            throw new IllegalArgumentException("邮件通道未配置");
+        }
+        try {
+            MimeMessage message = sender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setFrom(from, fromName);
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(text, false);
+            sender.send(message);
+        } catch (Exception e) {
+            // 服务商原始文案（含主机名、账号、限流细节）不外露给调用方
+            log.warn("[mail] {} 发信失败 to={} err={}", name(), mask(to), e.toString());
+            throw new IllegalArgumentException("邮件发送失败，请稍后重试");
+        }
+    }
+
+    /** a***@example.com；日志里不留完整地址。 */
+    static String mask(String email) {
+        if (email == null) return "";
+        int at = email.indexOf('@');
+        if (at <= 1) return "***" + (at < 0 ? "" : email.substring(at));
+        return email.charAt(0) + "***" + email.substring(at);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/sms/SmsAuthService.java
+++ b/backend/src/main/java/com/checkba/service/sms/SmsAuthService.java
@@ -2,6 +2,7 @@ package com.checkba.service.sms;
 
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.auth.VerificationCodeStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -18,7 +19,7 @@ import java.util.regex.Pattern;
  * <p>仅 server 模式生效——local-mode 是免登单机形态，没有登录环节，
  * {@link #active()} 恒 false，所有端点自然退化为未启用。
  *
- * <p>场景常量即 {@link SmsCodeStore} 的 scene 维度：login 码只能用于登录、
+ * <p>场景常量即 {@link VerificationCodeStore} 的 scene 维度：login 码只能用于登录、
  * bind 码只能用于绑定，互不通用。
  */
 @Service
@@ -33,12 +34,12 @@ public class SmsAuthService {
     private static final Pattern E164_PHONE = Pattern.compile("^\\+[1-9]\\d{6,14}$");
 
     private final List<SmsGateway> gateways;
-    private final SmsCodeStore codeStore;
+    private final VerificationCodeStore codeStore;
     private final UserRepository userRepository;
     private final boolean localMode;
 
     @Autowired
-    public SmsAuthService(List<SmsGateway> gateways, SmsCodeStore codeStore, UserRepository userRepository,
+    public SmsAuthService(List<SmsGateway> gateways, VerificationCodeStore codeStore, UserRepository userRepository,
                           @Value("${security.local-mode:false}") boolean localMode) {
         this.gateways = gateways;
         this.codeStore = codeStore;
@@ -74,7 +75,7 @@ public class SmsAuthService {
         return maskPhone(user.getPhone());
     }
 
-    /** 核销登录验证码；错码/过期抛业务错误（在线爆破由 SmsCodeStore 的尝试上限兜底）。 */
+    /** 核销登录验证码；错码/过期抛业务错误（在线爆破由 VerificationCodeStore 的尝试上限兜底）。 */
     public void verifyLoginCode(User user, String code) {
         if (!requiresCode(user)) {
             return;

--- a/backend/src/main/java/com/checkba/service/sms/TwilioSmsGateway.java
+++ b/backend/src/main/java/com/checkba/service/sms/TwilioSmsGateway.java
@@ -15,7 +15,8 @@ import java.util.Base64;
 /**
  * 境外号码的短信通道：Twilio Messages API（不引 SDK，同 {@link SmsService} 的立场）。
  *
- * <p>只负责非大陆号码。发送内容由本服务拼装（验证码仍由 {@link SmsCodeStore} 统一签发与核销），
+ * <p>只负责非大陆号码。发送内容由本服务拼装（验证码仍由
+ * {@link com.checkba.service.auth.VerificationCodeStore} 统一签发与核销），
  * 这样国内外只有一套验证码生命周期，不必为 Twilio Verify 再维护一条远端校验路径。
  *
  * <p>合规（各国 Sender ID / 美国 10DLC / 印度 DLT）在 Twilio 控制台的 Messaging Service

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -121,6 +121,10 @@ sms:
 mail:
   # 发件人显示名，两条通道共用
   from-name: ${MAIL_FROM_NAME:AI Workdeck}
+  # 邮箱免密登录（输邮箱→收码→直接登录，不过密码）。**独立开关且默认关**：
+  # 它是一条新的匿名登录入口，攻击面与密码登录不同——邮箱被盗即账号被盗。
+  # 关闭时邮箱仍可作为登录二次验证使用（那条不需要这个开关）。
+  passwordless-login-enabled: ${MAIL_PASSWORDLESS_LOGIN_ENABLED:false}
   # 国内主流邮箱（QQ/163/126/139…）走这条：阿里云邮件推送，发信域名 dm.aiworkdeck.com。
   # 用户名就是发信地址本身；密码是控制台「发信地址 → 设置SMTP密码」设的那个，不是 AccessKey。
   domestic:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -114,6 +114,32 @@ sms:
     messaging-service-sid: ${TWILIO_MESSAGING_SERVICE_SID:}
     template: ${TWILIO_SMS_TEMPLATE:Your AI Workdeck verification code is {code}. It expires in 5 minutes.}
 
+# 邮件发信（按收件域名分流的两条 SMTP 通道，见 com.checkba.service.mail）。
+# 密码一律环境变量注入，与 SMS_ACCESS_KEY_* 同一模式，绝不写进任何入库文件。
+# 刻意不用 Spring Boot 的 spring.mail.*：那套只装配得出一个 JavaMailSender，
+# 而国内/国外必须并存——两条各自独立开关，只配一条的部署照常工作。
+mail:
+  # 发件人显示名，两条通道共用
+  from-name: ${MAIL_FROM_NAME:AI Workdeck}
+  # 国内主流邮箱（QQ/163/126/139…）走这条：阿里云邮件推送，发信域名 dm.aiworkdeck.com。
+  # 用户名就是发信地址本身；密码是控制台「发信地址 → 设置SMTP密码」设的那个，不是 AccessKey。
+  domestic:
+    enabled: ${MAIL_DOMESTIC_ENABLED:false}
+    host: ${MAIL_DOMESTIC_HOST:smtpdm.aliyun.com}
+    port: ${MAIL_DOMESTIC_PORT:465}
+    username: ${MAIL_DOMESTIC_USERNAME:}
+    password: ${MAIL_DOMESTIC_PASSWORD:}
+    from: ${MAIL_DOMESTIC_FROM:}
+  # 其余邮箱（Gmail/Outlook/企业自有域名…）走这条：Resend，发信域名 send.aiworkdeck.com。
+  # 用户名固定字面量 resend，密码填 API key（re_ 开头），不是账号邮箱。
+  global:
+    enabled: ${MAIL_GLOBAL_ENABLED:false}
+    host: ${MAIL_GLOBAL_HOST:smtp.resend.com}
+    port: ${MAIL_GLOBAL_PORT:465}
+    username: ${MAIL_GLOBAL_USERNAME:resend}
+    password: ${MAIL_GLOBAL_PASSWORD:}
+    from: ${MAIL_GLOBAL_FROM:}
+
 # AI 大模型配置（供应商可切换）
 ai:
   # 官网账户服务地址（解锁门在线校验、账户连接、平台 AI 通道密钥）。

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
@@ -51,9 +51,10 @@ class AuthControllerSmsTest {
 
     private static AuthController controller(UserService userService, AuthAbuseGuard guard,
                                              SmsAuthService smsAuthService) {
-        // 短信分支的接线测试：二次验证协调层用真实实现（TOTP 未启用 → 判定落到短信）
+        // 短信分支的接线测试：二次验证协调层用真实实现（TOTP 未启用、邮箱未绑 → 判定落到短信）
         SecondFactorService secondFactor = new SecondFactorService(
-                new TotpService(), smsAuthService, mock(UserRepository.class));
+                new TotpService(), mock(com.checkba.service.mail.MailAuthService.class),
+                smsAuthService, mock(UserRepository.class));
         // DB 会话服务（repository 打桩）：登录成功路径要经它签发 sessionId
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
                 mock(com.checkba.repository.UserSessionRepository.class));

--- a/backend/src/test/java/com/checkba/service/auth/SecondFactorServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/auth/SecondFactorServiceTest.java
@@ -20,6 +20,7 @@ class SecondFactorServiceTest {
 
     private UserRepository repo;
     private SmsAuthService sms;
+    private com.checkba.service.mail.MailAuthService mail;
     private TotpService totp;
     private SecondFactorService service;
 
@@ -27,8 +28,9 @@ class SecondFactorServiceTest {
     void setUp() {
         repo = mock(UserRepository.class);
         sms = mock(SmsAuthService.class);
+        mail = mock(com.checkba.service.mail.MailAuthService.class);
         totp = new TotpService();
-        service = new SecondFactorService(totp, sms, repo);
+        service = new SecondFactorService(totp, mail, sms, repo);
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
     }
 
@@ -60,6 +62,38 @@ class SecondFactorServiceTest {
                 "同时具备时必须选零成本无国界的 TOTP");
 
         assertEquals(SecondFactorService.Method.NONE, service.required(null));
+    }
+
+    @Test
+    @DisplayName("邮箱优先于短信——这是成本决策：绑了邮箱就别再花钱发短信")
+    void mailOutranksSms() {
+        User u = user(1);
+        when(sms.requiresCode(u)).thenReturn(true);
+        when(mail.requiresCode(u)).thenReturn(true);
+        assertEquals(SecondFactorService.Method.MAIL, service.required(u),
+                "两者都可用时必须走邮箱，否则这个功能不省钱");
+
+        when(mail.requiresCode(u)).thenReturn(false);
+        assertEquals(SecondFactorService.Method.SMS, service.required(u), "没绑邮箱才回落短信");
+
+        // TOTP 仍然压过两者
+        when(mail.requiresCode(u)).thenReturn(true);
+        u.setTotpEnabled(true);
+        u.setTotpSecret(totp.newSecret());
+        assertEquals(SecondFactorService.Method.TOTP, service.required(u));
+    }
+
+    @Test
+    @DisplayName("邮箱分支的校验落到 MailAuthService，且提示目标是脱敏邮箱")
+    void mailBranchDelegatesAndMasks() {
+        User u = user(1);
+        u.setVerifiedEmail("alice@gmail.com");
+        when(mail.requiresCode(u)).thenReturn(true);
+
+        assertEquals("a***@gmail.com", service.target(u));
+        service.verify(u, "123456");
+        verify(mail).verifyLoginCode(u, "123456");
+        verify(sms, never()).verifyLoginCode(any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/auth/VerificationCodeStoreTest.java
+++ b/backend/src/test/java/com/checkba/service/auth/VerificationCodeStoreTest.java
@@ -1,4 +1,4 @@
-package com.checkba.service.sms;
+package com.checkba.service.auth;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,10 +7,10 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class SmsCodeStoreTest {
+class VerificationCodeStoreTest {
 
     private final AtomicLong clock = new AtomicLong(1_000_000L);
-    private final SmsCodeStore store = new SmsCodeStore(clock::get);
+    private final VerificationCodeStore store = new VerificationCodeStore(clock::get);
 
     @Test
     @DisplayName("签发-验证-核销：验证成功后同码立即失效（一次性）")
@@ -33,7 +33,7 @@ class SmsCodeStoreTest {
     @DisplayName("过期即失效（5 分钟 TTL）")
     void expiryInvalidates() {
         String code = store.issue("login", "13800000000");
-        clock.addAndGet(SmsCodeStore.TTL.toMillis() + 1);
+        clock.addAndGet(VerificationCodeStore.TTL.toMillis() + 1);
         assertFalse(store.verify("login", "13800000000", code));
     }
 
@@ -45,7 +45,7 @@ class SmsCodeStoreTest {
                 () -> store.issue("login", "13800000000"));
         assertTrue(e.getMessage().contains("频繁"));
 
-        clock.addAndGet(SmsCodeStore.RESEND_COOLDOWN.toMillis() + 1);
+        clock.addAndGet(VerificationCodeStore.RESEND_COOLDOWN.toMillis() + 1);
         String second = store.issue("login", "13800000000");
         if (!first.equals(second)) {
             assertFalse(store.verify("login", "13800000000", first), "重发后旧码应作废");
@@ -57,7 +57,7 @@ class SmsCodeStoreTest {
     @DisplayName("连续验错 5 次作废，正确码也救不回来（防在线爆破）")
     void attemptCapInvalidates() {
         String code = store.issue("login", "13800000000");
-        for (int i = 0; i < SmsCodeStore.MAX_ATTEMPTS; i++) {
+        for (int i = 0; i < VerificationCodeStore.MAX_ATTEMPTS; i++) {
             assertFalse(store.verify("login", "13800000000", "000000".equals(code) ? "111111" : "000000"));
         }
         assertFalse(store.verify("login", "13800000000", code));
@@ -66,9 +66,9 @@ class SmsCodeStoreTest {
     @Test
     @DisplayName("单手机号日上限：第 11 条被拒，跨天窗口滚动后恢复")
     void dailyCapPerPhone() {
-        for (int i = 0; i < SmsCodeStore.MAX_PER_PHONE_PER_DAY; i++) {
+        for (int i = 0; i < VerificationCodeStore.MAX_PER_TARGET_PER_DAY; i++) {
             store.issue("login", "13800000000");
-            clock.addAndGet(SmsCodeStore.RESEND_COOLDOWN.toMillis() + 1);
+            clock.addAndGet(VerificationCodeStore.RESEND_COOLDOWN.toMillis() + 1);
         }
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> store.issue("login", "13800000000"));

--- a/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
@@ -1,0 +1,219 @@
+package com.checkba.service.mail;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.auth.VerificationCodeStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class MailAuthServiceTest {
+
+    /** 记录发信而不真发；同时充当「已配置的通道」。 */
+    private static final class RecordingGateway implements MailGateway {
+        final List<String[]> sent = new ArrayList<>();
+        boolean fail;
+
+        @Override public String name() { return "recording"; }
+        @Override public boolean enabled() { return true; }
+        @Override public boolean supports(String email) { return true; }
+
+        @Override public void send(String to, String subject, String text) {
+            if (fail) throw new IllegalArgumentException("邮件发送失败，请稍后重试");
+            sent.add(new String[]{to, subject, text});
+        }
+
+        /** 从最近一封信里抠出 6 位验证码。 */
+        String lastCode() {
+            String body = sent.get(sent.size() - 1)[2];
+            return body.replaceAll("(?s).*验证码是：(\\d{6}).*", "$1");
+        }
+    }
+
+    private static User user(long id, String verifiedEmail) {
+        User u = new User();
+        u.setId(id);
+        u.setUsername("alice");
+        u.setVerifiedEmail(verifiedEmail);
+        return u;
+    }
+
+    private record Fixture(MailAuthService svc, RecordingGateway gw, UserRepository repo) {
+    }
+
+    private static Fixture fixture(boolean localMode, boolean passwordless) {
+        RecordingGateway gw = new RecordingGateway();
+        UserRepository repo = mock(UserRepository.class);
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        MailAuthService svc = new MailAuthService(
+                new VerificationCodeStore(), new MailRouter(List.of(gw)), repo, localMode, passwordless);
+        return new Fixture(svc, gw, repo);
+    }
+
+    private static Fixture fixture() {
+        return fixture(false, true);
+    }
+
+    @Test
+    @DisplayName("local-mode 恒未启用；无可用通道时也未启用")
+    void activeGating() {
+        assertFalse(fixture(true, true).svc().active(), "local-mode 必须旁路");
+        assertTrue(fixture().svc().active());
+
+        MailRouter empty = new MailRouter(List.of());
+        assertFalse(new MailAuthService(new VerificationCodeStore(), empty,
+                mock(UserRepository.class), false, true).active(), "没有通道就不算启用");
+    }
+
+    @Test
+    @DisplayName("免密登录是独立开关，关掉后二次验证仍可用")
+    void passwordlessHasItsOwnSwitch() {
+        Fixture f = fixture(false, false);
+        assertTrue(f.svc().active());
+        assertFalse(f.svc().passwordlessActive());
+        assertThrows(IllegalArgumentException.class, () -> f.svc().sendSigninCode("a@qq.com"));
+        // 二次验证不受影响
+        assertTrue(f.svc().requiresCode(user(1, "a@qq.com")));
+    }
+
+    @Test
+    @DisplayName("只有绑过已验证邮箱的用户才走邮箱二次验证")
+    void requiresCodeOnlyWhenVerifiedEmailBound() {
+        MailAuthService svc = fixture().svc();
+        assertTrue(svc.requiresCode(user(1, "a@qq.com")));
+        assertFalse(svc.requiresCode(user(1, null)));
+        assertFalse(svc.requiresCode(user(1, "")));
+        assertFalse(svc.requiresCode(null));
+    }
+
+    @Test
+    @DisplayName("登录验证码：发出后错码被拒、对码通过且一次性")
+    void loginCodeLifecycle() {
+        Fixture f = fixture();
+        User u = user(1, "alice@gmail.com");
+
+        assertEquals("a***@gmail.com", f.svc().sendLoginCode(u));
+        assertEquals(1, f.gw().sent.size());
+        assertEquals("alice@gmail.com", f.gw().sent.get(0)[0]);
+
+        String code = f.gw().lastCode();
+        assertThrows(IllegalArgumentException.class, () -> f.svc().verifyLoginCode(u, "000000"));
+        assertDoesNotThrow(() -> f.svc().verifyLoginCode(u, code));
+        assertThrows(IllegalArgumentException.class, () -> f.svc().verifyLoginCode(u, code),
+                "验证成功即销毁，同一枚码不能用第二次");
+    }
+
+    @Test
+    @DisplayName("发信失败要回收验证码，否则冷却期挡住用户立即重试")
+    void rollsBackCodeWhenSendFails() {
+        Fixture f = fixture();
+        User u = user(1, "alice@gmail.com");
+        f.gw().fail = true;
+        assertThrows(IllegalArgumentException.class, () -> f.svc().sendLoginCode(u));
+
+        // 冷却已回滚：可以立刻再发
+        f.gw().fail = false;
+        assertDoesNotThrow(() -> f.svc().sendLoginCode(u));
+    }
+
+    @Test
+    @DisplayName("绑定：写入 verifiedEmail；资料邮箱为空才补，已填的不覆盖")
+    void confirmBindWritesVerifiedEmailWithoutClobberingProfile() {
+        Fixture f = fixture();
+        User u = user(7, null);
+        when(f.repo().findById(7L)).thenReturn(Optional.of(u));
+        when(f.repo().findByVerifiedEmail(any())).thenReturn(Optional.empty());
+
+        f.svc().sendBindCode(7L, "  Bob@QQ.com ");
+        assertEquals("bob@qq.com", f.gw().sent.get(0)[0], "收件地址应已规范化");
+
+        assertEquals("b***@qq.com", f.svc().confirmBind(7L, "bob@qq.com", f.gw().lastCode()));
+        assertEquals("bob@qq.com", u.getVerifiedEmail());
+        assertEquals("bob@qq.com", u.getEmail(), "资料邮箱原本为空，应顺手补上");
+
+        // 换绑到新地址时不动已有的资料邮箱
+        User u2 = user(8, null);
+        u2.setEmail("self-written@example.com");
+        when(f.repo().findById(8L)).thenReturn(Optional.of(u2));
+        f.svc().sendBindCode(8L, "carol@163.com");
+        f.svc().confirmBind(8L, "carol@163.com", f.gw().lastCode());
+        assertEquals("carol@163.com", u2.getVerifiedEmail());
+        assertEquals("self-written@example.com", u2.getEmail(), "用户自己填的资料邮箱不许被覆盖");
+    }
+
+    @Test
+    @DisplayName("同一邮箱不能绑到两个账号")
+    void rejectsEmailBoundByAnotherAccount() {
+        Fixture f = fixture();
+        when(f.repo().findByVerifiedEmail("taken@qq.com")).thenReturn(Optional.of(user(99, "taken@qq.com")));
+        assertThrows(IllegalArgumentException.class, () -> f.svc().sendBindCode(7L, "taken@qq.com"));
+        assertTrue(f.gw().sent.isEmpty(), "被占用就不该发出任何信");
+    }
+
+    @Test
+    @DisplayName("免密登录：未注册的邮箱不发信但照常返回，不泄露该邮箱是否是用户")
+    void signinDoesNotLeakRegistrationStatus() {
+        Fixture f = fixture();
+        when(f.repo().findByVerifiedEmail("stranger@gmail.com")).thenReturn(Optional.empty());
+
+        assertDoesNotThrow(() -> f.svc().sendSigninCode("stranger@gmail.com"));
+        assertTrue(f.gw().sent.isEmpty(), "未注册就不该真发信");
+
+        // 错码与查无此人给同一句话
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> f.svc().verifySigninCode("stranger@gmail.com", "123456"));
+        assertEquals("验证码错误或已过期", e.getMessage());
+    }
+
+    @Test
+    @DisplayName("免密登录：已注册邮箱走通并换回账号")
+    void signinReturnsAccountOnCorrectCode() {
+        Fixture f = fixture();
+        User u = user(5, "dave@gmail.com");
+        when(f.repo().findByVerifiedEmail("dave@gmail.com")).thenReturn(Optional.of(u));
+
+        f.svc().sendSigninCode("dave@gmail.com");
+        assertEquals(1, f.gw().sent.size());
+        assertSame(u, f.svc().verifySigninCode("dave@gmail.com", f.gw().lastCode()));
+    }
+
+    @Test
+    @DisplayName("场景隔离：绑定码不能拿去免密登录（否则低权限操作可兑换成完整登录）")
+    void scenesAreNotInterchangeable() {
+        Fixture f = fixture();
+        User u = user(5, "dave@gmail.com");
+        when(f.repo().findById(5L)).thenReturn(Optional.of(u));
+        when(f.repo().findByVerifiedEmail("dave@gmail.com")).thenReturn(Optional.of(u));
+
+        f.svc().sendBindCode(5L, "dave@gmail.com");
+        String bindCode = f.gw().lastCode();
+        assertThrows(IllegalArgumentException.class,
+                () -> f.svc().verifySigninCode("dave@gmail.com", bindCode));
+    }
+
+    @Test
+    @DisplayName("邮箱格式不合法直接拒，不占用配额")
+    void rejectsMalformedAddress() {
+        Fixture f = fixture();
+        for (String bad : List.of("", "foo", "foo@", "@qq.com", "foo@qq")) {
+            assertThrows(IllegalArgumentException.class, () -> f.svc().sendSigninCode(bad), "应拒绝: [" + bad + "]");
+        }
+        assertTrue(f.gw().sent.isEmpty());
+    }
+
+    @Test
+    @DisplayName("脱敏：单字符本地部分不泄露原字符")
+    void masksEmail() {
+        assertEquals("h***@gmail.com", MailAuthService.maskEmail("hanzewei@gmail.com"));
+        assertEquals("***@qq.com", MailAuthService.maskEmail("a@qq.com"));
+        assertEquals("", MailAuthService.maskEmail(null));
+        assertEquals("", MailAuthService.maskEmail("no-at-sign"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mail/MailRouterTest.java
+++ b/backend/src/test/java/com/checkba/service/mail/MailRouterTest.java
@@ -1,0 +1,105 @@
+package com.checkba.service.mail;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.Order;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MailRouterTest {
+
+    /** 用真网关而不是桩：选路谓词本身就是被测对象。构造 JavaMailSenderImpl 不建连接。 */
+    private static DomesticMailGateway domestic(boolean enabled) {
+        return new DomesticMailGateway(enabled, "smtpdm.aliyun.com", 465,
+                "optimizer@dm.aiworkdeck.com", "pw", "", "AI Workdeck");
+    }
+
+    private static GlobalMailGateway global(boolean enabled) {
+        return new GlobalMailGateway(enabled, "smtp.resend.com", 465,
+                "resend", "re_x", "optimizer@send.aiworkdeck.com", "AI Workdeck");
+    }
+
+    private static MailRouter router(MailGateway... gateways) {
+        return new MailRouter(List.of(gateways));
+    }
+
+    @Test
+    @DisplayName("国内主流邮箱走阿里云，其余走 Resend")
+    void routesByRecipientDomain() {
+        MailRouter r = router(domestic(true), global(true));
+        for (String cn : List.of("a@qq.com", "b@163.com", "c@126.com", "d@139.com",
+                "e@foxmail.com", "f@sina.com", "g@189.cn")) {
+            assertEquals("aliyun-directmail", r.gatewayFor(cn).name(), cn + " 应走国内通道");
+        }
+        for (String intl : List.of("a@gmail.com", "b@outlook.com", "c@example.org",
+                "d@aiworkdeck.com")) {
+            assertEquals("resend", r.gatewayFor(intl).name(), intl + " 应走兜底通道");
+        }
+    }
+
+    @Test
+    @DisplayName("域名匹配不受大小写影响（规范化后再判）")
+    void domainMatchIsCaseInsensitive() {
+        MailRouter r = router(domestic(true), global(true));
+        assertEquals("aliyun-directmail", r.gatewayFor(MailRouter.normalize(" Foo@QQ.com ")).name());
+    }
+
+    @Test
+    @DisplayName("只开一条通道时，不属于它的收件人也兜给它——宁可次优通道也要送达")
+    void fallsBackToAnyEnabledGateway() {
+        assertEquals("aliyun-directmail", router(domestic(true), global(false))
+                .gatewayFor("a@gmail.com").name());
+        assertEquals("resend", router(domestic(false), global(true))
+                .gatewayFor("a@qq.com").name());
+    }
+
+    @Test
+    @DisplayName("一条都没配则整体不可用，选路直接抛业务错误")
+    void inactiveWhenNothingConfigured() {
+        MailRouter r = router(domestic(false), global(false));
+        assertFalse(r.active());
+        assertThrows(IllegalArgumentException.class, () -> r.gatewayFor("a@qq.com"));
+    }
+
+    @Test
+    @DisplayName("Resend 未配 from 判为未配置：用户名是字面量 resend，回落会拼出非法发件人")
+    void globalGatewayRequiresRealFromAddress() {
+        assertFalse(new GlobalMailGateway(true, "smtp.resend.com", 465, "resend", "re_x", "", "AI Workdeck")
+                .enabled());
+        assertTrue(global(true).enabled());
+    }
+
+    @Test
+    @DisplayName("阿里云通道的 from 可留空——用户名本身就是发信地址")
+    void domesticGatewayFallsBackFromToUsername() {
+        assertTrue(domestic(true).enabled());
+    }
+
+    @Test
+    @DisplayName("国内通道必须排在兜底通道之前，否则 Resend 会把 QQ/163 全吃掉")
+    void gatewayOrderIsPinned() {
+        int cn = DomesticMailGateway.class.getAnnotation(Order.class).value();
+        int fallback = GlobalMailGateway.class.getAnnotation(Order.class).value();
+        assertTrue(cn < fallback, "DomesticMailGateway 的 @Order 必须小于 GlobalMailGateway");
+    }
+
+    @Test
+    @DisplayName("规范化：去空白、转小写；非法格式抛业务错误")
+    void normalizeTrimsAndLowercases() {
+        assertEquals("foo@qq.com", MailRouter.normalize("  Foo@QQ.Com "));
+        for (String bad : List.of("", "  ", "foo", "foo@", "@qq.com", "foo@qq", "a b@qq.com", "foo@@qq.com")) {
+            assertThrows(IllegalArgumentException.class, () -> MailRouter.normalize(bad), "应拒绝: [" + bad + "]");
+        }
+        assertThrows(IllegalArgumentException.class, () -> MailRouter.normalize(null));
+    }
+
+    @Test
+    @DisplayName("日志脱敏不泄露完整地址")
+    void masksAddressForLogging() {
+        assertEquals("h***@gmail.com", SmtpMailGateway.mask("hanzewei@gmail.com"));
+        assertEquals("***@qq.com", SmtpMailGateway.mask("a@qq.com"));
+        assertEquals("", SmtpMailGateway.mask(null));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/sms/SmsAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsAuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.checkba.service.sms;
 
 import com.checkba.model.entity.User;
+import com.checkba.service.auth.VerificationCodeStore;
 import com.checkba.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ class SmsAuthServiceTest {
     @DisplayName("local-mode 恒未启用；server 模式看 SmsService 配置")
     void activeGating() {
         UserRepository repo = mock(UserRepository.class);
-        SmsCodeStore store = new SmsCodeStore();
+        VerificationCodeStore store = new VerificationCodeStore();
         assertFalse(new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), store, repo, true).active(),
                 "local-mode 必须旁路");
         assertTrue(new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), store, repo, false).active());
@@ -47,7 +48,7 @@ class SmsAuthServiceTest {
     @DisplayName("requiresCode：启用且已绑手机号才要求；存量未绑定用户不拦")
     void requiresCodeOnlyWithPhone() {
         SmsAuthService svc = new SmsAuthService(
-                List.of(enabledSms(OK_TRANSPORT)), new SmsCodeStore(), mock(UserRepository.class), false);
+                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), false);
         assertTrue(svc.requiresCode(user(1, "13800000000")));
         assertFalse(svc.requiresCode(user(1, null)));
         assertFalse(svc.requiresCode(user(1, "")));
@@ -58,7 +59,7 @@ class SmsAuthServiceTest {
     @DisplayName("登录码全流程：发码（脱敏返回）→ 核销放行；错码抛业务错误")
     void loginCodeRoundTrip() {
         AtomicReference<String> sentBody = new AtomicReference<>();
-        SmsCodeStore store = new SmsCodeStore();
+        VerificationCodeStore store = new VerificationCodeStore();
         SmsAuthService svc = new SmsAuthService(List.of(enabledSms((url, body, auth) -> {
             sentBody.set(body);
             return new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
@@ -79,7 +80,7 @@ class SmsAuthServiceTest {
     @Test
     @DisplayName("发送失败回滚冷却：网关拒绝后可立即重试")
     void failedSendRollsBackCooldown() {
-        SmsCodeStore store = new SmsCodeStore();
+        VerificationCodeStore store = new VerificationCodeStore();
         AtomicReference<Boolean> fail = new AtomicReference<>(true);
         SmsAuthService svc = new SmsAuthService(List.of(enabledSms((url, body, auth) ->
                 fail.get() ? new SmsTransport.Reply(500, "boom")
@@ -95,7 +96,7 @@ class SmsAuthServiceTest {
     void bindRejectsPhoneBoundByOther() {
         UserRepository repo = mock(UserRepository.class);
         when(repo.findByPhone("13800000000")).thenReturn(Optional.of(user(99, "13800000000")));
-        SmsAuthService svc = new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), new SmsCodeStore(), repo, false);
+        SmsAuthService svc = new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), repo, false);
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "13800000000"));
         assertThrows(IllegalArgumentException.class, () -> svc.confirmBind(1L, "13800000000", "123456"));
     }
@@ -113,7 +114,7 @@ class SmsAuthServiceTest {
         SmsAuthService svc = new SmsAuthService(List.of(enabledSms((url, body, auth) -> {
             sentBody.set(body);
             return new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
-        })), new SmsCodeStore(), repo, false);
+        })), new VerificationCodeStore(), repo, false);
 
         svc.sendBindCode(1L, "13800000000");
         java.util.regex.Matcher m = java.util.regex.Pattern.compile("%22code%22%3A%22(\\d{6})%22")
@@ -128,7 +129,7 @@ class SmsAuthServiceTest {
     @DisplayName("手机号格式：非大陆手机号拒绝；空白剥离后再校验")
     void phoneFormatValidated() {
         SmsAuthService svc = new SmsAuthService(
-                List.of(enabledSms(OK_TRANSPORT)), new SmsCodeStore(), mock(UserRepository.class), false);
+                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), false);
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "12345"));
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "23800000000"));
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, null));
@@ -139,7 +140,7 @@ class SmsAuthServiceTest {
     @DisplayName("未启用时绑定类操作一律业务错误，且文案不踩掉线三子串")
     void inactiveRejectsBindOperations() {
         SmsAuthService svc = new SmsAuthService(
-                List.of(enabledSms(OK_TRANSPORT)), new SmsCodeStore(), mock(UserRepository.class), true);
+                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), true);
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> svc.sendBindCode(1L, "13800000000"));
         assertFalse(e.getMessage().contains("登录"));


### PR DESCRIPTION
## 背景

优化者 Agent 要给维护者发通知，后续还要用邮箱验证码替代部分短信（短信单价高）。本 PR 只做**发信能力**，不含验证码登录流程。

## 做了什么

两条 SMTP 通道并存，按收件人域名选路：

| 收件域名 | 通道 | 发信域名 |
|---|---|---|
| QQ / 163 / 126 / 139 / foxmail / sina / 189 等国内主流邮箱 | 阿里云邮件推送 | `dm.aiworkdeck.com` |
| 其余（Gmail / Outlook / 企业自有域名） | Resend | `send.aiworkdeck.com` |

分流不是优化而是刚需：国内邮箱对境外 IP 发来的信过滤很凶，验证码进垃圾箱等于用户登不上；反过来 Gmail 收阿里云的信到达率也一般。

## 几个设计取舍

- **不用 `spring.mail.*` 自动装配**：那套只装配得出一个 `JavaMailSender`，两条通道必须并存。每个网关自持凭据，形状与既有 `SmsGateway`（大陆走阿里云、境外走 Twilio）一致。
- **只配一条也能工作**：`MailRouter` 找不到认领该域名的通道时，兜给任一已启用的通道——用次优通道送达，好过因「没人认领」而整条路不通。
- **`@Order` 钉死顺序**：兜底通道 `supports()` 恒 true，排错了会把 QQ/163 全吃掉。已加测试锁死。
- **`from` 必须含 `@`**：Resend 的 SMTP 用户名是字面量 `resend`，回落会拼出非法发件人，只在发信那一刻才炸——宁可在 `enabled()` 判成未配置。
- SMTP 三段超时都设了 10s：发信跑在登录/通知的请求线程上。

## DNS

两个域名的 SPF / DKIM / DMARC / MX 已在 `aiworkdeck.com` 下配好并验证通过（Resend 三条、DirectMail 六条）。**根域的 QQ 企业邮箱 MX/SPF 未做任何改动**——根域动了当场收不到信。

## 验证

- `MailRouterTest` 9 项：域名选路、大小写、单通道兜底、全未配、`from` 不合法判未启用、`@Order` 顺序、规范化、日志脱敏
- 全量 `mvn test`：**1231 passed, 0 failed**

## 顺带

`backend/` 下有 3 个 iCloud 同步产生的 ` 2.java` 副本文件（`DataInitializer 2.java` 等），未被 git 跟踪但会让 javac 报重复类、整个编译挂掉。本 PR 未包含它们的删除（不在改动范围），已移出工作树。另有 `desktop/package 2.json` 和 `frontend/src/pages/wizard/wizard 2.vue` 同类残留待清。

## 未做

- 优化者接线：PR #314 的 `OptimizerMailer` 目前用 `spring.mail.*` + 单个 `JavaMailSender`，合并后应改走 `MailRouter`
- 邮箱验证码登录：需要先定产品形态（二次验证 vs 免密登录）
- 服务器凭据下发

🤖 Generated with [Claude Code](https://claude.com/claude-code)