### PR TITLE
feat: 邮箱验证码登录（二次验证 + 免密）与优化者改走双通道发信

### DIFF
--- a/.claude/agents/feedback-optimizer.md
+++ b/.claude/agents/feedback-optimizer.md
@@ -36,6 +36,10 @@ description: 用户反馈闭环领域。任务涉及右下角反馈浮窗、反�
   —— 优化者读本地库还是云端收件箱，上层无感
 - `FeedbackTriageService` — 分诊；`OptimizerCodeFixRunner` — worktree + 编码 Agent + PR；
   `OptimizerMailer` — 只发不收；`OptimizerAgentService` — 调度与分流；`ProcessRunner` — 子进程出口
+- **邮件出口走 `service/mail/MailRouter`（`mail.domestic.*` / `mail.global.*`），不是 `spring.mail.*`**
+  （2026-08-08 PR#320 改）。多收件人**逐个分别发**：他们可能分属不同通道（维护者的 Gmail 与同事的
+  QQ 邮箱走的不是同一条），塞进同一封信只能挑一条，另一半到达率白丢。**发件人由通道决定**，
+  `optimizer.mail.from` 已删——两条通道发信域名不同，硬写 from 会让 SPF 当场判失败。
 - `controller/OptimizerController` — `/api/optimizer/run|status`（管理员，run 是异步）
 - 维护者机器上的常驻配方：`deploy/optimizer/`（run 脚本 + launchd plist + 搬机器步骤）
 

--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -127,7 +127,8 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 
 **登录二次验证的判定出口（2026-08-07）**
 - `backend/src/main/java/com/checkba/service/auth/SecondFactorService.java` — **`required(user)` 是唯一判定出口**，
-  返回 `NONE / TOTP / SMS`。TOTP 优先于短信（零成本、无国界、不受运营商报备与 SIM 交换影响）。
+  返回 `NONE / TOTP / MAIL / SMS`。优先级 **TOTP > 邮箱 > 短信**：TOTP 零成本、无国界、不受运营商报备与
+  SIM 交换影响；**邮箱排在短信之前是成本决策**（短信按条计费，邮件几乎免费），短信降为未绑邮箱时的兜底。
   两条密码入口（`/login`、`/device-token`）都只接 `AuthController.secondFactorChallenge()` 这一个私有方法——
   **新增第三条密码入口时必须接它**，漏一条等于没设闸。
 - 同文件管认证器绑定：`startSetup`（生成密钥，尚未启用）→ `activate`（验一次码才启用）→
@@ -139,14 +140,17 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - 端点：`/api/auth/totp/{setup,activate,disable}`（需登录）、`/api/auth/totp/reset/{userId}`（仅 admin）。
 - 前端：`userprofile.vue` 设置页「账号安全」的认证器分区（二维码用 `qrcode` 懒加载渲染，
   **otpauth URI 含密钥，只在前端本地转二维码，不走任何图片服务**）；`login.vue` 按 4005 的
-  `data.method` 区分 totp/sms 两种步骤（totp 不发短信、不显示重发倒计时）。
+  `data.method` 区分 totp/mail/sms 三种步骤（totp 不发码、不显示重发倒计时；**mail 与 sms 的重发要打
+  各自的端点**，打错会被判成「未绑定手机号」）。
 
 **登录短信验证（2026-08-06，sms-auth-integration）**
 - `backend/src/main/java/com/checkba/service/sms/SmsService.java` — 阿里云 dysmsapi 发送，**刻意不引 SDK**
   （JDK HttpClient 直签 HMAC-SHA1，保补丁通道资格；签名算法有真机对拍向量护栏 `SmsServiceTest`）。
   阿里云原始错误 Message 只进日志不进用户文案。
-- `service/sms/SmsCodeStore.java` — 验证码生命周期：6 位数字、5 分钟 TTL、一次性核销、单码 5 次验错作废、
-  60 秒重发冷却、单手机号日上限 10 条；内存只存 SHA-256。发送失败调 `invalidate` 回滚冷却（日配额不回滚）。
+- `service/auth/VerificationCodeStore.java`（原 `service/sms/SmsCodeStore.java`，2026-08-08 更名）——
+  验证码生命周期，**短信与邮件共用一套**：6 位数字、5 分钟 TTL、一次性核销、单码 5 次验错作废、
+  60 秒重发冷却、单 target 日上限 10 条；内存只存 SHA-256。发送失败调 `invalidate` 回滚冷却（日配额不回滚）。
+  `target` 短信是规范化手机号、邮件是规范化邮箱，两者不会撞键（手机号里没有 `@`）。
 - `service/sms/SmsAuthService.java` — 流程编排：scene 隔离（login 码≠bind 码）、号码规范化与校验、
   绑定唯一性（发码与确认两处都查）。`active()` = server 模式 && 任一通道可用；local-mode 恒旁路。
 - **通道按号码归属地分流**（`SmsGateway` 接口，2026-08-07）：`SmsService` 收大陆号（阿里云），
@@ -160,9 +164,33 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
   **code 4005** + `{smsRequired, phoneMasked}`（与 4001/4003 同族，前端 api.js 据此切验证码步骤）；
   存量未绑定用户不拦。`POST /api/auth/sms/send-code`（scene=login 须带正确用户名密码且与 /login 共用
   失败锁定，**否则就是免锁定的密码试探口**；scene=bind 须已登录）、`POST /api/auth/sms/bind`。
-  IP 维度限频在 `AuthAbuseGuard.checkSmsSendRate`（20 条/小时）。
-- `/api/auth/me` 多回 `smsAuthEnabled` + `phoneMasked`（空串=未绑定，Map.of 不收 null）；
+  IP 维度限频在 `AuthAbuseGuard.checkCodeSendRate`（20 条/小时，**短信与邮件共用这一把闸**——
+  各开一把等于换个通道就能绕过限频）。
+- `/api/auth/me` 多回 `smsAuthEnabled` + `phoneMasked` + `mailAuthEnabled` + `emailMasked`
+  （空串=未绑定，Map 不收 null；该 Map 已 12 项，超过 `Map.of` 的 10 对上限，用的是 `Map.ofEntries`）；
   绑定 UI 在 `userprofile.vue` 设置 tab「账号安全」，登录验证码步骤在 `login.vue`。
+
+**登录邮箱验证（2026-08-08，PR#320）**
+- `backend/src/main/java/com/checkba/service/mail/MailAuthService.java` — 流程编排，与 `SmsAuthService` 同构。
+  三个场景 `mail-bind / mail-login / mail-signin` **互不通用**：绑定码是已登录态下发的，
+  若能用于免密登录，等于把低权限操作兑换成完整登录。
+- `service/mail/`（`MailGateway` / `SmtpMailGateway` / `DomesticMailGateway` / `GlobalMailGateway` / `MailRouter`）——
+  `MailRouter` 按**收件域名**选路，国内主流邮箱走阿里云 DirectMail（`dm.aiworkdeck.com`），
+  其余走 Resend（`send.aiworkdeck.com`，兜底通道）。**刻意不用 Spring Boot 的 `spring.mail.*`**——
+  那套只装配得出一个 `JavaMailSender`，两条必须并存。`@Order` 钉死顺序，兜底通道排错会把 QQ/163 全吃掉。
+- `User.verifiedEmail`（**新增的 unique 列**）+ `UserRepository.findByVerifiedEmail`。
+  **不要给资料字段 `User.email` 加唯一约束**：它是历史自由填写的，有重复与空串，
+  `ddl-auto: update` 加约束会在脏数据上失败。`verifiedEmail` 只由「收到码并验过」写入。
+- 端点：`POST /api/auth/mail/send-code`（scene=login/bind，与短信同构）、`POST /api/auth/mail/bind`、
+  `POST /api/auth/mail-login/send-code` + `/verify`（免密登录两步）。
+- **免密登录的三条红线**：① 独立开关 `mail.passwordless-login-enabled` 且**默认关**——它是一条新的匿名
+  登录入口，邮箱被盗即账号被盗；② 未注册邮箱**不发信但照常返回**，回包对「已注册/未注册」完全一致，
+  否则这个端点就是账号枚举器；③ 验码失败**必须计入登录锁定**（锁定键=规范化后的邮箱）——单枚码的
+  尝试上限只管那一枚，换一枚重来不受限，不接锁定就是个 6 位码爆破口。
+- 配置 `mail.*`（application.yml）：两条通道各自 `enabled/host/port/username/password/from`，
+  默认全关。Resend 的 SMTP 用户名是**字面量 `resend`**、密码填 API key；`from` 必须含 `@`
+  （回落到 username 会拼出非法发件人，只在发信那一刻才炸，所以 `enabled()` 里就判掉）。
+  阿里云那条的密码是控制台「发信地址 → 设置SMTP密码」设的，**不是 AccessKey**。
 - 配置 `sms.*`（application.yml）：`SMS_AUTH_ENABLED` 默认 false；AK/SK 走 `SMS_ACCESS_KEY_ID/SECRET`
   环境变量（RAM 子用户仅授 AliyunDysmsFullAccess），签名/模板默认 `京微资易科技`/`SMS_483655011`
   （旧签名 `京微资易` 已在阿里云控制台删除，2026-08-06 重建为新签名）。

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -22,6 +22,7 @@ public class AuthController {
     private final com.checkba.service.AuthAbuseGuard authAbuseGuard;
     private final com.checkba.service.account.AwdkLoginService awdkLoginService;
     private final com.checkba.service.sms.SmsAuthService smsAuthService;
+    private final com.checkba.service.mail.MailAuthService mailAuthService;
     private final com.checkba.service.auth.SecondFactorService secondFactorService;
     private final com.checkba.service.UserSessionService userSessionService;
     /** 单机免登模式。设备令牌的会话签发路径只在这一模式下存在（见 issueLocalDeviceToken）。 */
@@ -69,6 +70,7 @@ public class AuthController {
                           com.checkba.service.AuthAbuseGuard authAbuseGuard,
                           com.checkba.service.account.AwdkLoginService awdkLoginService,
                           com.checkba.service.sms.SmsAuthService smsAuthService,
+                          com.checkba.service.mail.MailAuthService mailAuthService,
                           com.checkba.service.auth.SecondFactorService secondFactorService,
                           com.checkba.service.UserSessionService userSessionService,
                           @org.springframework.beans.factory.annotation.Value("${security.local-mode:false}")
@@ -80,6 +82,7 @@ public class AuthController {
         this.authAbuseGuard = authAbuseGuard;
         this.awdkLoginService = awdkLoginService;
         this.smsAuthService = smsAuthService;
+        this.mailAuthService = mailAuthService;
         this.secondFactorService = secondFactorService;
         this.userSessionService = userSessionService;
         this.localMode = localMode;
@@ -264,7 +267,7 @@ public class AuthController {
         String ip = http.getRemoteAddr();
         Map<String, Object> result = new HashMap<>();
         try {
-            authAbuseGuard.checkSmsSendRate(ip);
+            authAbuseGuard.checkCodeSendRate(ip);
             String phoneMasked;
             if ("bind".equals(request.getScene())) {
                 Long userId = getUserIdFromSession(sessionId);
@@ -286,7 +289,7 @@ public class AuthController {
                 }
                 phoneMasked = smsAuthService.sendLoginCode(user);
             }
-            authAbuseGuard.recordSmsSend(ip);
+            authAbuseGuard.recordCodeSend(ip);
             result.put("code", 0);
             result.put("message", "验证码已发送");
             result.put("data", Map.of("phoneMasked", phoneMasked));
@@ -388,6 +391,147 @@ public class AuthController {
     }
 
     /**
+     * 发送邮箱验证码。两个场景，与 {@code /sms/send-code} 完全对称：
+     * <ul>
+     *   <li>{@code scene=login}：匿名但必须携带正确的用户名密码，发往该用户已绑定的邮箱。
+     *       失败锁定与 /login 共用同一套计数。</li>
+     *   <li>{@code scene=bind}：需已登录会话，发往待绑定的新邮箱。</li>
+     * </ul>
+     * IP 维度限频与短信共用 AuthAbuseGuard 那把闸——否则换个通道就能绕过限频。
+     */
+    @PostMapping("/mail/send-code")
+    public Map<String, Object> sendMailCode(@RequestBody MailSendCodeRequest request,
+                                            @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
+                                            jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        Map<String, Object> result = new HashMap<>();
+        try {
+            authAbuseGuard.checkCodeSendRate(ip);
+            String emailMasked;
+            if ("bind".equals(request.getScene())) {
+                Long userId = getUserIdFromSession(sessionId);
+                if (userId == null) {
+                    result.put("code", 1);
+                    result.put("message", "未登录");
+                    return result;
+                }
+                emailMasked = mailAuthService.sendBindCode(userId, request.getEmail());
+            } else {
+                // login 场景：先过锁定闸再校验凭据，语义与 /login 完全一致
+                authAbuseGuard.checkLoginAttempt(ip, request.getUsername());
+                User user;
+                try {
+                    user = userService.login(request.getUsername(), request.getPassword());
+                } catch (IllegalArgumentException e) {
+                    authAbuseGuard.recordLoginFailure(ip, request.getUsername());
+                    throw e;
+                }
+                emailMasked = mailAuthService.sendLoginCode(user);
+            }
+            authAbuseGuard.recordCodeSend(ip);
+            result.put("code", 0);
+            result.put("message", "验证码已发送");
+            result.put("data", Map.of("emailMasked", emailMasked));
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
+    }
+
+    /** 校验验证码并绑定邮箱（需已登录）。也用于换绑：直接绑新地址覆盖。 */
+    @PostMapping("/mail/bind")
+    public Map<String, Object> bindEmail(@RequestBody MailBindRequest request,
+                                         @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = getUserIdFromSession(sessionId);
+        Map<String, Object> result = new HashMap<>();
+        if (userId == null) {
+            result.put("code", 1);
+            result.put("message", "未登录");
+            return result;
+        }
+        try {
+            String emailMasked = mailAuthService.confirmBind(userId, request.getEmail(), request.getCode());
+            result.put("code", 0);
+            result.put("message", "绑定成功");
+            result.put("data", Map.of("emailMasked", emailMasked));
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
+    }
+
+    /**
+     * 邮箱免密登录第一步：发码。
+     *
+     * <p>这是一条**匿名登录入口**，默认关（mail.passwordless-login-enabled）。
+     * 回包对「已注册」和「未注册」完全一致——未注册时 MailAuthService 不发信但照常返回，
+     * 否则这个端点就是账号枚举器。IP 维度限频与短信/绑定共用同一把闸。
+     */
+    @PostMapping("/mail-login/send-code")
+    public Map<String, Object> mailLoginSendCode(@RequestBody MailLoginRequest request,
+                                                 jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        Map<String, Object> result = new HashMap<>();
+        try {
+            authAbuseGuard.checkCodeSendRate(ip);
+            mailAuthService.sendSigninCode(request.getEmail());
+            authAbuseGuard.recordCodeSend(ip);
+            result.put("code", 0);
+            result.put("message", "验证码已发送");
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
+    }
+
+    /**
+     * 邮箱免密登录第二步：验码换会话。
+     *
+     * <p>走与密码登录同一套失败锁定，锁定键用邮箱本身——否则这条路就是一个不计失败次数的
+     * 6 位码爆破口（单枚码的尝试上限只管那一枚，换一枚重来不受限）。
+     */
+    @PostMapping("/mail-login/verify")
+    public Map<String, Object> mailLoginVerify(@RequestBody MailLoginRequest request,
+                                               jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        Map<String, Object> result = new HashMap<>();
+        String lockKey = request.getEmail() == null ? "" : request.getEmail().trim().toLowerCase();
+        try {
+            authAbuseGuard.checkLoginAttempt(ip, lockKey);
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+            return result;
+        }
+        try {
+            User user = mailAuthService.verifySigninCode(request.getEmail(), request.getCode());
+            authAbuseGuard.recordLoginSuccess(ip, lockKey);
+            String newSessionId = userSessionService.issue(user.getId());
+            result.put("code", 0);
+            result.put("message", "登录成功");
+            result.put("data", Map.of(
+                    "sessionId", newSessionId,
+                    "user", Map.of(
+                            "id", user.getId(),
+                            "username", user.getUsername(),
+                            "displayName", user.getDisplayName(),
+                            "avatarUrl", user.getAvatarUrl() != null ? user.getAvatarUrl() : "",
+                            "role", user.getRole(),
+                            "subscriptionType", user.getSubscriptionType()
+                    )
+            ));
+        } catch (IllegalArgumentException e) {
+            authAbuseGuard.recordLoginFailure(ip, lockKey);
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+        }
+        return result;
+    }
+
+    /**
      * 客户登录（使用访问码）
      */
     @PostMapping("/client-login")
@@ -456,19 +600,22 @@ public class AuthController {
 
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
-        result.put("data", Map.of(
-                "id", user.getId(),
-                "username", user.getUsername(),
-                "displayName", user.getDisplayName(),
-                "avatarUrl", user.getAvatarUrl() != null ? user.getAvatarUrl() : "",
-                "role", user.getRole(),
-                "subscriptionType", user.getSubscriptionType(),
+        // Map.of 最多 10 对，这里已经 12 项——用 ofEntries，加字段时不会突然编译不过
+        result.put("data", Map.ofEntries(
+                Map.entry("id", user.getId()),
+                Map.entry("username", user.getUsername()),
+                Map.entry("displayName", user.getDisplayName()),
+                Map.entry("avatarUrl", user.getAvatarUrl() != null ? user.getAvatarUrl() : ""),
+                Map.entry("role", user.getRole()),
+                Map.entry("subscriptionType", user.getSubscriptionType()),
                 // 系统管理权限（桌面单机=全员；云端=仅 admin 账号），前端据此显示「系统设置」入口
-                "isAdmin", adminAccessService.isAdmin(user),
-                // 二次验证：入口显隐与当前绑定状态（Map.of 不收 null，空串=未绑定）
-                "smsAuthEnabled", smsAuthService != null && smsAuthService.active(),
-                "phoneMasked", com.checkba.service.sms.SmsAuthService.maskPhone(user.getPhone()),
-                "totpEnabled", user.isTotpEnabled()
+                Map.entry("isAdmin", adminAccessService.isAdmin(user)),
+                // 二次验证：入口显隐与当前绑定状态（Map.entry 不收 null，空串=未绑定）
+                Map.entry("smsAuthEnabled", smsAuthService != null && smsAuthService.active()),
+                Map.entry("phoneMasked", com.checkba.service.sms.SmsAuthService.maskPhone(user.getPhone())),
+                Map.entry("mailAuthEnabled", mailAuthService != null && mailAuthService.active()),
+                Map.entry("emailMasked", com.checkba.service.mail.MailAuthService.maskEmail(user.getVerifiedEmail())),
+                Map.entry("totpEnabled", user.isTotpEnabled())
         ));
         return result;
     }
@@ -675,6 +822,43 @@ public class AuthController {
         public void setPassword(String password) { this.password = password; }
         public String getSmsCode() { return smsCode; }
         public void setSmsCode(String smsCode) { this.smsCode = smsCode; }
+    }
+
+    static class MailSendCodeRequest {
+        private String scene;
+        private String username;
+        private String password;
+        private String email;
+
+        public String getScene() { return scene; }
+        public void setScene(String scene) { this.scene = scene; }
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+    }
+
+    static class MailBindRequest {
+        private String email;
+        private String code;
+
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getCode() { return code; }
+        public void setCode(String code) { this.code = code; }
+    }
+
+    /** 免密登录两步共用：第一步只填 email，第二步再带 code。 */
+    static class MailLoginRequest {
+        private String email;
+        private String code;
+
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getCode() { return code; }
+        public void setCode(String code) { this.code = code; }
     }
 
     static class SmsSendCodeRequest {

--- a/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
+++ b/backend/src/main/java/com/checkba/service/AuthAbuseGuard.java
@@ -50,8 +50,8 @@ public class AuthAbuseGuard {
     static final int MAX_REGISTRATIONS_PER_WINDOW = 10;
     static final Duration REGISTRATION_WINDOW = Duration.ofHours(1);
 
-    static final int MAX_SMS_SENDS_PER_WINDOW = 20;
-    static final Duration SMS_WINDOW = Duration.ofHours(1);
+    static final int MAX_CODE_SENDS_PER_WINDOW = 20;
+    static final Duration CODE_WINDOW = Duration.ofHours(1);
 
     /** 内存兜底：超过该条数触发一次过期清理，防止被海量伪造维度撑爆内存。 */
     private static final int PURGE_THRESHOLD = 10_000;
@@ -62,7 +62,7 @@ public class AuthAbuseGuard {
 
     private final Map<String, FailureState> loginFailures = new ConcurrentHashMap<>();
     private final Map<String, WindowCounter> registrations = new ConcurrentHashMap<>();
-    private final Map<String, WindowCounter> smsSends = new ConcurrentHashMap<>();
+    private final Map<String, WindowCounter> codeSends = new ConcurrentHashMap<>();
 
     @Autowired
     public AuthAbuseGuard(
@@ -149,25 +149,25 @@ public class AuthAbuseGuard {
         });
     }
 
-    // ==================== 短信发送限频（按 IP；手机号维度在 VerificationCodeStore） ====================
+    // ==================== 验证码发送限频（按 IP，短信与邮件共用；手机号/邮箱维度在 VerificationCodeStore） ====================
 
-    public void checkSmsSendRate(String ip) {
+    public void checkCodeSendRate(String ip) {
         if (localMode) return;
-        WindowCounter counter = smsSends.get(ip);
+        WindowCounter counter = codeSends.get(ip);
         long now = nowMillis.getAsLong();
         if (counter != null
-                && now - counter.windowStart <= SMS_WINDOW.toMillis()
-                && counter.count >= MAX_SMS_SENDS_PER_WINDOW) {
+                && now - counter.windowStart <= CODE_WINDOW.toMillis()
+                && counter.count >= MAX_CODE_SENDS_PER_WINDOW) {
             throw new IllegalArgumentException("验证码发送过于频繁，请稍后再试");
         }
     }
 
-    public void recordSmsSend(String ip) {
+    public void recordCodeSend(String ip) {
         if (localMode) return;
         purgeIfOversized();
         long now = nowMillis.getAsLong();
-        smsSends.compute(ip, (k, counter) -> {
-            if (counter == null || now - counter.windowStart > SMS_WINDOW.toMillis()) {
+        codeSends.compute(ip, (k, counter) -> {
+            if (counter == null || now - counter.windowStart > CODE_WINDOW.toMillis()) {
                 counter = new WindowCounter();
                 counter.windowStart = now;
             }
@@ -193,9 +193,9 @@ public class AuthAbuseGuard {
             registrations.entrySet().removeIf(e ->
                     now - e.getValue().windowStart > REGISTRATION_WINDOW.toMillis());
         }
-        if (smsSends.size() > PURGE_THRESHOLD) {
-            smsSends.entrySet().removeIf(e ->
-                    now - e.getValue().windowStart > SMS_WINDOW.toMillis());
+        if (codeSends.size() > PURGE_THRESHOLD) {
+            codeSends.entrySet().removeIf(e ->
+                    now - e.getValue().windowStart > CODE_WINDOW.toMillis());
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerMailer.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerMailer.java
@@ -2,10 +2,8 @@ package com.checkba.service.optimizer;
 
 import com.checkba.model.entity.FeedbackAttachment;
 import com.checkba.model.entity.UserFeedback;
+import com.checkba.service.mail.MailRouter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,19 +15,21 @@ import java.util.List;
  * 都会把一个每天跑一次的批处理变成一个常驻服务；维护者读完信直接去改代码
  * 或在库里改状态更省事。信里因此写清「回信不会被系统读取」。
  *
- * <p>邮件通道用 Spring 的 {@code spring.mail.*}：配了 host 才有 JavaMailSender bean，
- * 没配就整条出口不可用（会记 FAILED 等人配置），不静默丢反馈。
+ * <p>发信走 {@link MailRouter}（{@code mail.domestic.*} / {@code mail.global.*}）：
+ * 一条通道都没配就整条出口不可用（会记 FAILED 等人配置），不静默丢反馈。
+ * 发件人由通道决定，本类不指定——两条通道的发信域名不同，硬写 from 会和实际发信域名对不上，
+ * SPF 当场判失败。
  */
 @Slf4j
 @Service
 public class OptimizerMailer implements OptimizerNotifier {
 
     private final OptimizerProperties props;
-    private final ObjectProvider<JavaMailSender> mailSenderProvider;
+    private final MailRouter mailRouter;
 
-    public OptimizerMailer(OptimizerProperties props, ObjectProvider<JavaMailSender> mailSenderProvider) {
+    public OptimizerMailer(OptimizerProperties props, MailRouter mailRouter) {
         this.props = props;
-        this.mailSenderProvider = mailSenderProvider;
+        this.mailRouter = mailRouter;
     }
 
     @Override
@@ -37,18 +37,18 @@ public class OptimizerMailer implements OptimizerNotifier {
         return "邮件";
     }
 
-    /** 邮件出口是否可用：要有 JavaMailSender（配了 spring.mail.host）且填了收件人。 */
+    /** 邮件出口是否可用：至少一条发信通道配齐且填了收件人。 */
     @Override
     public boolean isAvailable() {
         return props.getMail().isEnabled()
-                && mailSenderProvider.getIfAvailable() != null
+                && mailRouter.active()
                 && !props.getMail().getTo().isBlank();
     }
 
     @Override
     public String unavailableReason() {
         if (!props.getMail().isEnabled()) return "optimizer.mail.enabled=false";
-        if (mailSenderProvider.getIfAvailable() == null) return "未配置 spring.mail.host（没有 JavaMailSender）";
+        if (!mailRouter.active()) return "未配置发信通道（mail.domestic.* 或 mail.global.*）";
         if (props.getMail().getTo().isBlank()) return "未配置 optimizer.mail.to（收件人）";
         return "";
     }
@@ -63,15 +63,18 @@ public class OptimizerMailer implements OptimizerNotifier {
 
     public void send(UserFeedback fb, FeedbackTriageService.TriageResult triage,
                      List<FeedbackAttachment> attachments, OptimizerFeedbackSource source, String extraNote) {
-        JavaMailSender sender = mailSenderProvider.getIfAvailable();
-        if (sender == null) throw new IllegalStateException(unavailableReason());
+        if (!mailRouter.active()) throw new IllegalStateException(unavailableReason());
 
-        SimpleMailMessage msg = new SimpleMailMessage();
-        msg.setTo(props.getMail().getTo().split(","));
-        if (!props.getMail().getFrom().isBlank()) msg.setFrom(props.getMail().getFrom());
-        msg.setSubject(subject(fb, triage));
-        msg.setText(body(fb, triage, attachments, source, extraNote));
-        sender.send(msg);
+        String subject = subject(fb, triage);
+        String body = body(fb, triage, attachments, source, extraNote);
+        // 逐个收件人分别发：多个收件人可能分属不同通道（维护者的 Gmail 与同事的 QQ 邮箱
+        // 走的不是同一条），塞进同一封信就只能挑一条通道发，另一半到达率白丢。
+        for (String to : props.getMail().getTo().split(",")) {
+            String trimmed = to.trim();
+            if (!trimmed.isEmpty()) {
+                mailRouter.send(trimmed, subject, body);
+            }
+        }
         log.info("[optimizer] 已发送反馈 #{} 的邮件到 {}", fb.getId(), props.getMail().getTo());
     }
 

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerProperties.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerProperties.java
@@ -104,9 +104,8 @@ public class OptimizerProperties {
     @Setter
     public static class Mail {
         private boolean enabled = true;
-        /** 收件人（维护者）。留空 = 邮件出口不可用，会退化成只写库并记 FAILED。 */
+        /** 收件人（维护者），逗号分隔。留空 = 邮件出口不可用，会退化成只写库并记 FAILED。 */
         private String to = "";
-        private String from = "";
         private String subjectPrefix = "[AI Workdeck 优化者]";
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -29,15 +29,6 @@ spring:
         types:
           print:
             banner: false
-  # 邮件通道（只被「优化者」用来给维护者发信，产品功能不发任何邮件）。
-  # 刻意整段留空：配了 spring.mail.host 才会有 JavaMailSender bean，没配等于这条出口关闭。
-  # 维护者启用时用环境变量注入，别把授权码写进入库文件：
-  #   SPRING_MAIL_HOST=smtp.qq.com SPRING_MAIL_PORT=465
-  #   SPRING_MAIL_USERNAME=you@qq.com SPRING_MAIL_PASSWORD=<授权码>
-  #   SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=true
-  #   SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE=true   # 465 直连 SSL
-  #   （587 的 STARTTLS 改用 ..._MAIL_SMTP_STARTTLS_ENABLE=true）
-  #   OPTIMIZER_MAIL_TO=you@example.com OPTIMIZER_MAIL_FROM=you@qq.com
   servlet:
     multipart:
       enabled: true
@@ -360,10 +351,10 @@ optimizer:
     issue-labels: [ user-feedback ]
   mail:
     enabled: true
-    # 收件人（维护者）。邮件通道本身用 spring.mail.*（见下），没配 host 就没有
-    # JavaMailSender，这条出口会报「不可用」并由 notify.channel=auto 落到开 Issue。
+    # 收件人（维护者），逗号分隔可多个。发信通道本身是上面的 mail.domestic/global，
+    # 一条都没配时这条出口会报「不可用」并由 notify.channel=auto 落到开 Issue。
+    # 发件人由通道决定，此处不设——两条通道发信域名不同，硬写 from 会让 SPF 判失败。
     to: ${OPTIMIZER_MAIL_TO:}
-    from: ${OPTIMIZER_MAIL_FROM:}
     subject-prefix: "[AI Workdeck 优化者]"
 
 # 文件存储配置

--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -60,7 +60,7 @@ class AuthControllerHardeningTest {
     void closedRegistrationShortCircuits() {
         UserService userService = mock(UserService.class);
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("closed"), null, null, null, sessions(), false);
+                userService, null, null, null, serverGuard("closed"), null, null, null, null, sessions(), false);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -76,7 +76,7 @@ class AuthControllerHardeningTest {
         when(userService.register(anyString(), anyString(), anyString()))
                 .thenReturn(user(1L, "alice"));
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("open"), null, null, null, sessions(), false);
+                userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -91,7 +91,7 @@ class AuthControllerHardeningTest {
                 .thenReturn(user(1L, "alice"));
         AuthAbuseGuard localGuard = new AuthAbuseGuard(true, "closed");
         AuthController controller = new AuthController(
-                userService, null, null, null, localGuard, null, null, null, sessions(), false);
+                userService, null, null, null, localGuard, null, null, null, null, sessions(), false);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -105,7 +105,7 @@ class AuthControllerHardeningTest {
         when(userService.login(anyString(), anyString()))
                 .thenThrow(new IllegalArgumentException("用户名或密码错误"));
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("open"), null, null, null, sessions(), false);
+                userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false);
 
         AuthController.LoginRequest request = new AuthController.LoginRequest();
         request.setUsername("alice");
@@ -128,7 +128,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(anyString()))
                 .thenReturn(new AwdkLoginService.BridgeSession("awdt_x", 7L, "awd_hanzewei"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, sessions(), false);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -147,7 +147,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(any()))
                 .thenThrow(new IllegalArgumentException("本服务器未开启账户桥接功能"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, sessions(), false);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -166,7 +166,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(anyString())).thenThrow(new AccountException(
                 AccountException.Kind.UNAUTHORIZED, "账户 Key 无效或已被撤销，请到官网账户页重新生成"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, sessions(), false);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false);
 
         for (int i = 0; i < 5; i++) {
             assertEquals(1, controller.awdkLogin(Map.of("key", "awdk_bad"), http()).get("code"));

--- a/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
@@ -51,7 +51,7 @@ class AuthControllerLocalDeviceTokenTest {
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
                 org.mockito.Mockito.mock(com.checkba.repository.UserSessionRepository.class));
         return new AuthController(userService, null, null, deviceTokenService,
-                null, null, null, null, sessions, localMode);
+                null, null, null, null, null, sessions, localMode);
     }
 
     private static User user(long id, String username, String displayName) {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
@@ -1,0 +1,198 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserSessionRepository;
+import com.checkba.service.AuthAbuseGuard;
+import com.checkba.service.UserService;
+import com.checkba.service.UserSessionService;
+import com.checkba.service.mail.MailAuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 邮箱验证码端点的 AuthController 接线：限频闸与短信共用、login 场景不成为免锁定的
+ * 密码试探口、免密登录必须计入失败锁定。服务层语义见 MailAuthServiceTest。
+ */
+class AuthControllerMailTest {
+
+    private static MockHttpServletRequest http() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("9.9.9.9");
+        return request;
+    }
+
+    private static User boundUser() {
+        User user = new User();
+        user.setId(7L);
+        user.setUsername("alice");
+        user.setDisplayName("Alice");
+        user.setRole("USER");
+        user.setSubscriptionType("FREE");
+        user.setVerifiedEmail("alice@gmail.com");
+        return user;
+    }
+
+    private static UserSessionService sessions() {
+        return new UserSessionService(mock(UserSessionRepository.class));
+    }
+
+    private static AuthController controller(UserService userService, AuthAbuseGuard guard,
+                                             MailAuthService mailAuthService) {
+        return new AuthController(userService, null, null, null, guard, null, null,
+                mailAuthService, null, sessions(), false);
+    }
+
+    private static AuthController.MailSendCodeRequest sendCodeRequest(String scene, String email) {
+        AuthController.MailSendCodeRequest r = new AuthController.MailSendCodeRequest();
+        r.setScene(scene);
+        r.setUsername("alice");
+        r.setPassword("pw123456");
+        r.setEmail(email);
+        return r;
+    }
+
+    private static AuthController.MailLoginRequest loginRequest(String email, String code) {
+        AuthController.MailLoginRequest r = new AuthController.MailLoginRequest();
+        r.setEmail(email);
+        r.setCode(code);
+        return r;
+    }
+
+    @Test
+    @DisplayName("login 场景先过锁定闸再校验凭据，密码错要计一次失败——否则这是个免锁定的试探口")
+    void loginSceneCountsPasswordFailures() {
+        UserService userService = mock(UserService.class);
+        when(userService.login(anyString(), anyString())).thenThrow(new IllegalArgumentException("用户名或密码错误"));
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        MailAuthService mail = mock(MailAuthService.class);
+
+        Map<String, Object> result = controller(userService, guard, mail)
+                .sendMailCode(sendCodeRequest("login", null), null, http());
+
+        assertEquals(1, result.get("code"));
+        verify(guard).checkCodeSendRate("9.9.9.9");
+        verify(guard).checkLoginAttempt("9.9.9.9", "alice");
+        verify(guard).recordLoginFailure("9.9.9.9", "alice");
+        verify(guard, never()).recordCodeSend(anyString());
+        verify(mail, never()).sendLoginCode(any());
+    }
+
+    @Test
+    @DisplayName("login 场景密码对则发码，并记一次发送用于 IP 限频")
+    void loginSceneSendsOnCorrectPassword() {
+        UserService userService = mock(UserService.class);
+        when(userService.login(anyString(), anyString())).thenReturn(boundUser());
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        MailAuthService mail = mock(MailAuthService.class);
+        when(mail.sendLoginCode(any())).thenReturn("a***@gmail.com");
+
+        Map<String, Object> result = controller(userService, guard, mail)
+                .sendMailCode(sendCodeRequest("login", null), null, http());
+
+        assertEquals(0, result.get("code"));
+        assertEquals("a***@gmail.com", ((Map<?, ?>) result.get("data")).get("emailMasked"));
+        verify(guard).recordCodeSend("9.9.9.9");
+    }
+
+    @Test
+    @DisplayName("bind 场景没有会话就拒，不碰发信也不占限频额度")
+    void bindSceneRequiresSession() {
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        MailAuthService mail = mock(MailAuthService.class);
+
+        Map<String, Object> result = controller(mock(UserService.class), guard, mail)
+                .sendMailCode(sendCodeRequest("bind", "new@qq.com"), null, http());
+
+        assertEquals(1, result.get("code"));
+        assertEquals("未登录", result.get("message"));
+        verify(mail, never()).sendBindCode(any(), anyString());
+        verify(guard, never()).recordCodeSend(anyString());
+    }
+
+    @Test
+    @DisplayName("绑定端点没有会话就拒")
+    void bindEndpointRequiresSession() {
+        MailAuthService mail = mock(MailAuthService.class);
+        AuthController.MailBindRequest r = new AuthController.MailBindRequest();
+        r.setEmail("new@qq.com");
+        r.setCode("123456");
+
+        Map<String, Object> result = controller(mock(UserService.class), mock(AuthAbuseGuard.class), mail)
+                .bindEmail(r, null);
+
+        assertEquals(1, result.get("code"));
+        verify(mail, never()).confirmBind(any(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("免密登录发码走同一把 IP 限频闸——否则换个端点就能绕过限频")
+    void passwordlessSendSharesRateLimiter() {
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        MailAuthService mail = mock(MailAuthService.class);
+
+        Map<String, Object> result = controller(mock(UserService.class), guard, mail)
+                .mailLoginSendCode(loginRequest("alice@gmail.com", null), http());
+
+        assertEquals(0, result.get("code"));
+        verify(guard).checkCodeSendRate("9.9.9.9");
+        verify(guard).recordCodeSend("9.9.9.9");
+        verify(mail).sendSigninCode("alice@gmail.com");
+    }
+
+    @Test
+    @DisplayName("免密登录验码失败必须计入锁定——单枚码的尝试上限管不住换码重来")
+    void passwordlessFailureCountsTowardLockout() {
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        MailAuthService mail = mock(MailAuthService.class);
+        when(mail.verifySigninCode(anyString(), anyString()))
+                .thenThrow(new IllegalArgumentException("验证码错误或已过期"));
+
+        Map<String, Object> result = controller(mock(UserService.class), guard, mail)
+                .mailLoginVerify(loginRequest("Alice@Gmail.com", "000000"), http());
+
+        assertEquals(1, result.get("code"));
+        // 锁定键用规范化后的邮箱，否则改个大小写就是一个新的计数桶
+        verify(guard).checkLoginAttempt("9.9.9.9", "alice@gmail.com");
+        verify(guard).recordLoginFailure("9.9.9.9", "alice@gmail.com");
+    }
+
+    @Test
+    @DisplayName("已被锁定时直接拒，不消费验证码")
+    void passwordlessRespectsLockout() {
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        doThrow(new IllegalArgumentException("尝试过于频繁，请稍后再试"))
+                .when(guard).checkLoginAttempt(anyString(), anyString());
+        MailAuthService mail = mock(MailAuthService.class);
+
+        Map<String, Object> result = controller(mock(UserService.class), guard, mail)
+                .mailLoginVerify(loginRequest("alice@gmail.com", "123456"), http());
+
+        assertEquals(1, result.get("code"));
+        verify(mail, never()).verifySigninCode(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("免密登录成功才签发会话，且回包结构与密码登录一致")
+    void passwordlessIssuesSessionOnSuccess() {
+        AuthAbuseGuard guard = mock(AuthAbuseGuard.class);
+        MailAuthService mail = mock(MailAuthService.class);
+        when(mail.verifySigninCode(anyString(), anyString())).thenReturn(boundUser());
+
+        Map<String, Object> result = controller(mock(UserService.class), guard, mail)
+                .mailLoginVerify(loginRequest("alice@gmail.com", "123456"), http());
+
+        assertEquals(0, result.get("code"));
+        Map<?, ?> data = (Map<?, ?>) result.get("data");
+        assertNotNull(data.get("sessionId"));
+        assertEquals("alice", ((Map<?, ?>) data.get("user")).get("username"));
+        verify(guard).recordLoginSuccess("9.9.9.9", "alice@gmail.com");
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
@@ -58,7 +58,8 @@ class AuthControllerSmsTest {
         // DB 会话服务（repository 打桩）：登录成功路径要经它签发 sessionId
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
                 mock(com.checkba.repository.UserSessionRepository.class));
-        return new AuthController(userService, null, null, null, guard, null, smsAuthService, secondFactor, sessions, false);
+        return new AuthController(userService, null, null, null, guard, null, smsAuthService,
+                mock(com.checkba.service.mail.MailAuthService.class), secondFactor, sessions, false);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/optimizer/OptimizerMailerTest.java
+++ b/backend/src/test/java/com/checkba/service/optimizer/OptimizerMailerTest.java
@@ -2,41 +2,34 @@ package com.checkba.service.optimizer;
 
 import com.checkba.model.entity.FeedbackAttachment;
 import com.checkba.model.entity.UserFeedback;
+import com.checkba.service.mail.MailRouter;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /** 邮件出口：可用性判定的每条理由都要说得出口，正文要带够维护者直接动手的信息。 */
 class OptimizerMailerTest {
 
     OptimizerProperties props;
-    JavaMailSender sender;
+    MailRouter router;
     OptimizerMailer mailer;
-
-    @SuppressWarnings("unchecked")
-    private static ObjectProvider<JavaMailSender> providerOf(JavaMailSender s) {
-        ObjectProvider<JavaMailSender> p = mock(ObjectProvider.class);
-        when(p.getIfAvailable()).thenReturn(s);
-        return p;
-    }
 
     @BeforeEach
     void setup() {
         props = new OptimizerProperties();
         props.getMail().setTo("me@example.com");
-        props.getMail().setFrom("bot@example.com");
-        sender = mock(JavaMailSender.class);
-        mailer = new OptimizerMailer(props, providerOf(sender));
+        router = mock(MailRouter.class);
+        when(router.active()).thenReturn(true);
+        mailer = new OptimizerMailer(props, router);
     }
 
     /** 附件地址的形态由来源决定（本地磁盘路径 / 云端 URL），邮件只负责原样贴出来。 */
@@ -63,11 +56,26 @@ class OptimizerMailerTest {
                 "用户希望一次导出多个文件", "low", "属于新功能", "{}");
     }
 
+    /** 抓最近一次发信的正文。 */
+    private String capturedBody() {
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(router, atLeastOnce()).send(any(), any(), body.capture());
+        return body.getValue();
+    }
+
+    private String capturedSubject() {
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        verify(router, atLeastOnce()).send(any(), subject.capture(), any());
+        return subject.getValue();
+    }
+
     @Test
-    void unavailableWhenNoMailSender() {
-        OptimizerMailer none = new OptimizerMailer(props, providerOf(null));
-        assertFalse(none.isAvailable());
-        assertTrue(none.unavailableReason().contains("spring.mail.host"));
+    @DisplayName("一条发信通道都没配时不可用，理由要指到具体配置项")
+    void unavailableWhenNoMailChannel() {
+        when(router.active()).thenReturn(false);
+        assertFalse(mailer.isAvailable());
+        assertTrue(mailer.unavailableReason().contains("mail.domestic"),
+                "理由要说清缺哪一项：" + mailer.unavailableReason());
     }
 
     @Test
@@ -87,16 +95,11 @@ class OptimizerMailerTest {
         mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_SUGGESTION),
                 List.of(a), sourceRef("/data/feedback/12/voice-1.webm  (API: /api/feedback/12/attachment/3)"), "");
 
-        ArgumentCaptor<SimpleMailMessage> cap = ArgumentCaptor.forClass(SimpleMailMessage.class);
-        verify(sender).send(cap.capture());
-        SimpleMailMessage msg = cap.getValue();
+        verify(router).send(eq("me@example.com"), any(), any());
+        assertTrue(capturedSubject().startsWith("[AI Workdeck 优化者]"));
+        assertTrue(capturedSubject().contains("优化建议待定夺"));
 
-        assertArrayEquals(new String[]{"me@example.com"}, msg.getTo());
-        assertEquals("bot@example.com", msg.getFrom());
-        assertTrue(msg.getSubject().startsWith("[AI Workdeck 优化者]"));
-        assertTrue(msg.getSubject().contains("优化建议待定夺"));
-
-        String body = msg.getText();
+        String body = capturedBody();
         assertTrue(body.contains("希望批量导出"));
         assertTrue(body.contains("0.13.0"));
         assertTrue(body.contains("/data/feedback/12/voice-1.webm"));
@@ -112,20 +115,27 @@ class OptimizerMailerTest {
         mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_UNCLEAR),
                 List.of(), sourceRef(""), "改不出来");
 
-        ArgumentCaptor<SimpleMailMessage> cap = ArgumentCaptor.forClass(SimpleMailMessage.class);
-        verify(sender).send(cap.capture());
-        assertTrue(cap.getValue().getSubject().contains("需要你拍板"));
-        assertTrue(cap.getValue().getText().contains("为什么没直接开 PR"));
-        assertTrue(cap.getValue().getText().contains("改不出来"));
+        assertTrue(capturedSubject().contains("需要你拍板"));
+        assertTrue(capturedBody().contains("为什么没直接开 PR"));
+        assertTrue(capturedBody().contains("改不出来"));
     }
 
     @Test
-    void multipleRecipientsAreSplit() {
-        props.getMail().setTo("a@example.com,b@example.com");
+    @DisplayName("多收件人逐个分别发——他们可能分属不同通道，塞一封信只能挑一条")
+    void multipleRecipientsAreSentIndividually() {
+        props.getMail().setTo("a@qq.com, b@gmail.com");
         mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_SUGGESTION), List.of(), sourceRef(""), "");
 
-        ArgumentCaptor<SimpleMailMessage> cap = ArgumentCaptor.forClass(SimpleMailMessage.class);
-        verify(sender).send(cap.capture());
-        assertArrayEquals(new String[]{"a@example.com", "b@example.com"}, cap.getValue().getTo());
+        verify(router).send(eq("a@qq.com"), any(), any());
+        verify(router).send(eq("b@gmail.com"), any(), any());
+        verify(router, times(2)).send(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("收件人串里的空项被跳过，不会发出一封没有收件人的信")
+    void skipsBlankRecipients() {
+        props.getMail().setTo("a@qq.com,, ,b@gmail.com");
+        mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_SUGGESTION), List.of(), sourceRef(""), "");
+        verify(router, times(2)).send(any(), any(), any());
     }
 }

--- a/frontend/src/pages/login/login.vue
+++ b/frontend/src/pages/login/login.vue
@@ -129,10 +129,10 @@
             <button class="action-btn" :loading="loginLoading" @tap="handleLogin">登 录</button>
           </view>
 
-          <!-- Second Factor Step（登录二次验证：认证器或短信） -->
+          <!-- Second Factor Step（登录二次验证：认证器 / 邮箱 / 短信） -->
           <view v-else-if="activeTab === 'login' && smsStep" class="form-body swing-in">
             <view class="input-group">
-              <text class="label">{{ smsMethod === 'totp' ? '认证器验证' : '短信验证' }}</text>
+              <text class="label">{{ secondFactorLabel }}</text>
               <text class="sms-hint">
                 {{ smsMethod === 'totp' ? '请输入认证器 App 上当前显示的 6 位验证码' : '验证码已发送至 ' + smsPhoneMasked }}
               </text>
@@ -187,7 +187,7 @@
 </template>
 
 <script>
-import { login, register, clientLogin, getWizardStatus, getMyProjects, sendSmsCode } from '@/services/api.js'
+import { login, register, clientLogin, getWizardStatus, getMyProjects, sendSmsCode, sendMailCode } from '@/services/api.js'
 import { saveSession, getSessionId, getCurrentUser } from '@/utils/auth.js'
 import { syncRecentToMenu } from '@/utils/recentProjects.js'
 
@@ -243,6 +243,12 @@ export default {
     if (this.smsCountdownTimer) clearInterval(this.smsCountdownTimer)
   },
   computed: {
+    // 二次验证的方式由后端定（TOTP > 邮箱 > 短信），前端只负责说人话
+    secondFactorLabel() {
+      if (this.smsMethod === 'totp') return '认证器验证';
+      if (this.smsMethod === 'mail') return '邮箱验证';
+      return '短信验证';
+    },
     deviceTransform() {
       // Logic:
       // When mouse is at left (low %), device is tilted: rotateY(25deg) rotateX(5deg) scale(0.9)
@@ -340,12 +346,17 @@ export default {
     async resendSmsCode() {
       if (this.smsCountdown > 0) return;
       try {
-        const res = await sendSmsCode({
+        // 二次验证走哪条通道由后端 4005 信封里的 method 决定，发码就得打对应端点——
+        // 邮箱用户打短信端点会被判成「未绑定手机号」
+        const payload = {
           scene: 'login',
           username: this.loginForm.username,
           password: this.loginForm.password
-        });
-        if (res.data && res.data.phoneMasked) this.smsPhoneMasked = res.data.phoneMasked;
+        };
+        const res = this.smsMethod === 'mail' ? await sendMailCode(payload) : await sendSmsCode(payload);
+        // 邮箱通道回 emailMasked，短信回 phoneMasked；两者都填进同一个展示位
+        const masked = res.data && (res.data.emailMasked || res.data.phoneMasked);
+        if (masked) this.smsPhoneMasked = masked;
         this.startSmsCountdown();
         uni.showToast({ title: '验证码已发送', icon: 'none' });
       } catch (e) {

--- a/frontend/src/pages/userprofile/userprofile.vue
+++ b/frontend/src/pages/userprofile/userprofile.vue
@@ -373,6 +373,30 @@
                   </view>
                   <text class="bind-tip">绑定后，本账号在网页端与桌面端连接时的密码登录均需短信验证码</text>
                 </view>
+
+                <view v-if="userInfo.mailAuthEnabled" class="form-row">
+                  <text class="form-label">邮箱</text>
+                  <text class="form-value">{{ userInfo.emailMasked || '未绑定' }}</text>
+                  <text class="bind-link" @tap="showBindEmail = !showBindEmail">{{ userInfo.emailMasked ? '更换' : '绑定' }}</text>
+                </view>
+                <view v-if="showBindEmail" class="bind-phone-form">
+                  <view class="form-row">
+                    <text class="form-label">新邮箱</text>
+                    <input class="bind-input" v-model="bindEmailInput" placeholder="请输入邮箱地址" />
+                  </view>
+                  <view class="form-row">
+                    <text class="form-label">验证码</text>
+                    <input class="bind-input code" type="number" maxlength="6" v-model="bindEmailCodeInput" placeholder="6 位验证码" />
+                    <button class="btn-send-code" :disabled="bindEmailCountdown > 0" @tap="sendBindEmailCode">
+                      {{ bindEmailCountdown > 0 ? bindEmailCountdown + 's' : '获取验证码' }}
+                    </button>
+                  </view>
+                  <view class="bind-actions">
+                    <button class="btn-bind-confirm" @tap="confirmBindEmail">确认绑定</button>
+                    <text class="bind-link" @tap="cancelBindEmail">取消</text>
+                  </view>
+                  <text class="bind-tip">绑定邮箱后，登录二次验证优先走邮件而不再发短信</text>
+                </view>
               </view>
 
               <!-- 授权（桌面端）：当前模式 / 激活时间 / 解除授权 -->
@@ -439,7 +463,7 @@
 </template>
 
 <script>
-import { getMyProjects, deleteProject, renameProject, getCurrentUser as getCurrentUserApi, getMyFavorites, deleteFavorite, getFavoriteImageUrl, getProjectMembers, addProjectMember, removeProjectMember, getUserActivityHistory, inviteClient, uploadAvatar, getLicenseStatus, deactivateLicense, sendSmsCode, bindPhone, totpSetup, totpActivate, totpDisable, issueLocalDeviceToken, listDeviceTokens, revokeDeviceToken } from '@/services/api.js'
+import { getMyProjects, deleteProject, renameProject, getCurrentUser as getCurrentUserApi, getMyFavorites, deleteFavorite, getFavoriteImageUrl, getProjectMembers, addProjectMember, removeProjectMember, getUserActivityHistory, inviteClient, uploadAvatar, getLicenseStatus, deactivateLicense, sendSmsCode, bindPhone, sendMailCode, bindEmail, totpSetup, totpActivate, totpDisable, issueLocalDeviceToken, listDeviceTokens, revokeDeviceToken } from '@/services/api.js'
 import { getProjectTypeLabel } from '@/config/projectTypes.js'
 import { host, isDesktopHost } from '@/services/host.js'
  import { getCurrentUser, isLoggedIn, getSessionId, clearSession, setSessionUser } from '@/utils/auth.js'
@@ -511,6 +535,13 @@ export default {
       bindCodeInput: '',
       bindCountdown: 0,
       bindCountdownTimer: null,
+
+      // 邮箱绑定（与手机号并列的二次验证方式；绑了之后优先走邮件，省短信费）
+      showBindEmail: false,
+      bindEmailInput: '',
+      bindEmailCodeInput: '',
+      bindEmailCountdown: 0,
+      bindEmailCountdownTimer: null,
 
       // Activity Logs
       activityLogs: [],
@@ -954,6 +985,56 @@ export default {
       if (this.bindCountdownTimer) {
         clearInterval(this.bindCountdownTimer)
         this.bindCountdownTimer = null
+      }
+    },
+    async sendBindEmailCode() {
+      if (this.bindEmailCountdown > 0) return
+      // 只挡明显不是邮箱的输入；真正的规范化与判定在后端，前端不复刻一套正则
+      if (!/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test((this.bindEmailInput || '').trim())) {
+        uni.showToast({ title: '请输入正确的邮箱地址', icon: 'none' })
+        return
+      }
+      try {
+        await sendMailCode({ scene: 'bind', email: this.bindEmailInput.trim() })
+        uni.showToast({ title: '验证码已发送', icon: 'none' })
+        this.bindEmailCountdown = 60
+        if (this.bindEmailCountdownTimer) clearInterval(this.bindEmailCountdownTimer)
+        this.bindEmailCountdownTimer = setInterval(() => {
+          if (this.bindEmailCountdown > 0) {
+            this.bindEmailCountdown--
+          } else {
+            clearInterval(this.bindEmailCountdownTimer)
+            this.bindEmailCountdownTimer = null
+          }
+        }, 1000)
+      } catch (e) {
+        uni.showToast({ title: e.message || '发送失败', icon: 'none' })
+      }
+    },
+    async confirmBindEmail() {
+      if (!this.bindEmailCodeInput || this.bindEmailCodeInput.length < 6) {
+        uni.showToast({ title: '请输入 6 位验证码', icon: 'none' })
+        return
+      }
+      try {
+        const res = await bindEmail(this.bindEmailInput.trim(), this.bindEmailCodeInput)
+        uni.showToast({ title: '绑定成功', icon: 'success' })
+        const emailMasked = (res.data && res.data.emailMasked) || ''
+        this.userInfo = { ...this.userInfo, emailMasked }
+        setSessionUser(this.userInfo)
+        this.cancelBindEmail()
+      } catch (e) {
+        uni.showToast({ title: e.message || '绑定失败', icon: 'none' })
+      }
+    },
+    cancelBindEmail() {
+      this.showBindEmail = false
+      this.bindEmailInput = ''
+      this.bindEmailCodeInput = ''
+      this.bindEmailCountdown = 0
+      if (this.bindEmailCountdownTimer) {
+        clearInterval(this.bindEmailCountdownTimer)
+        this.bindEmailCountdownTimer = null
       }
     },
     checkAdminTab() {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -943,6 +943,56 @@ export function bindPhone(phone, code) {
   });
 }
 
+// 发送邮箱验证码。与 sendSmsCode 逐一对称：scene='login' 需带 username/password
+// （发往已绑定邮箱）；scene='bind' 需已登录，带 email（发往待绑定的新邮箱）。
+export function sendMailCode(payload) {
+  return request({
+    url: '/api/auth/mail/send-code',
+    method: 'POST',
+    data: payload,
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+// 绑定/更换邮箱（验证码走 sendMailCode 的 bind 场景）
+export function bindEmail(email, code) {
+  return request({
+    url: '/api/auth/mail/bind',
+    method: 'POST',
+    data: { email, code },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+// 邮箱免密登录第一步：发码。后端对「已注册」和「未注册」回同一个结果
+// （防账号枚举），所以这里成功也不代表该邮箱有账号。
+export function mailLoginSendCode(email) {
+  return request({
+    url: '/api/auth/mail-login/send-code',
+    method: 'POST',
+    data: { email },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+// 邮箱免密登录第二步：验码换会话，回包结构与密码登录一致
+export function mailLoginVerify(email, code) {
+  return request({
+    url: '/api/auth/mail-login/verify',
+    method: 'POST',
+    data: { email, code },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
 // 认证器（TOTP）：开始绑定，返回 { secret, provisioningUri }。此时尚未生效
 export function totpSetup() {
   return request({ url: '/api/auth/totp/setup', method: 'POST' });


### PR DESCRIPTION
接 #317。短信按条计费，邮件几乎免费——本 PR 让绑了邮箱的用户不再走短信。

## 二次验证优先级改为 TOTP > 邮箱 > 短信

`SecondFactorService` 是二次验证的唯一判定出口，加一个 MAIL 分支，两条密码入口（`/login`、`/device-token`）自动同时生效。邮箱排在短信之前是成本决策；短信降为未绑邮箱时的兜底。

## 端点（与 `/sms/*` 逐一对称）

| 端点 | 说明 |
|---|---|
| `POST /auth/mail/send-code` | `scene=login`（匿名但要密码）/ `scene=bind`（要会话） |
| `POST /auth/mail/bind` | 验码并绑定，也用于换绑 |
| `POST /auth/mail-login/send-code` + `/verify` | 免密登录两步，**默认关** |

## 几个安全判断

- **IP 限频与短信共用一把闸**，否则换个通道就能绕过。为此把 `checkSmsSendRate`/`recordSmsSend` 更名为 `checkCodeSendRate`/`recordCodeSend`。
- **免密登录的验码失败必须计入登录锁定**：单枚码的尝试上限只管那一枚，换一枚重来不受限，不接锁定就是个 6 位码爆破口。锁定键用规范化后的邮箱，否则改个大小写就是新的计数桶。
- **未注册邮箱不发信但照常返回**，回包对「已注册」「未注册」完全一致——否则这个匿名端点就是账号枚举器。
- **三个场景互不通用**：绑定码是已登录态下发的，若能用于免密登录，等于把低权限操作兑换成完整登录。
- 免密登录**独立开关且默认关**：它是一条新的匿名登录入口，邮箱被盗即账号被盗。

## 一个 schema 判断

新增 `User.verifiedEmail`（唯一、可空），**没有**给现有 `email` 加唯一约束——`email` 是历史自由填写的资料字段，有重复与空串，`ddl-auto: update` 加约束会在脏数据上失败。新列只由「收到码并验过」写入，语义与 `phone` 对齐。资料邮箱为空时顺手补上，已填的不覆盖。

`SmsCodeStore` 更名 `service.auth.VerificationCodeStore`：短信与邮件共用一套验证码生命周期（冷却/日上限/爆破上限/一次性只有一份实现），target 既可是手机号也可是邮箱，两者不会撞键（手机号里没有 `@`）。

## 优化者

`OptimizerMailer` 从 `spring.mail.*` 改走 `MailRouter`。多收件人逐个分别发——他们可能分属不同通道，塞进同一封信只能挑一条，另一半到达率白丢。发件人不再由 `optimizer.mail.from` 指定：两条通道发信域名不同，硬写会让 SPF 判失败。

## 前端

登录页二次验证按 `method` 分流发码端点（原来那句 `method !== 'totp' 就发短信` 会让邮箱用户打错端点）；设置页邮箱绑定与手机号并列。免密登录的 API 客户端已就位但未放入口——后端默认关，开了再上界面。

## 验证

- 后端全量 `mvn test`：**1329 passed**（新增 84 项）
- 前端 `npm run check:emits` 通过（67 个 .vue）、`npm run build:h5` 构建成功
- 未跑 app-e2e（需要打包 jar + LOWA 引擎的冷启动环境）

🤖 Generated with [Claude Code](https://claude.com/claude-code)