### PR TITLE
fix: #319 与 #317/#320 并行合并后的两处对账（pom 重复依赖 + 优化者邮件配置说明过期）

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,11 +25,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-        <!-- 优化者的邮件出口（spring.mail.host 未配时不会创建 JavaMailSender，等于整条出口关闭） -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-mail</artifactId>
-        </dependency>
         <!-- 仅密码哈希（BCrypt），不引入整套 security 过滤器链，避免改变现有接口鉴权行为 -->
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/deploy/optimizer/README.md
+++ b/deploy/optimizer/README.md
@@ -128,3 +128,28 @@ MAIL_GLOBAL_FROM=<send.aiworkdeck.com 下的发信地址>
 | 战报 note 写「取件失败」 | token 与收件箱不一致，或收件箱那边 `feedback.optimizer-token` 没配（没配 = 整组 403） |
 | 每条都走通知、从不开 PR | 编码 Agent 没登录 → diff 为空 → 按 NO_CHANGES 转通知。手动跑一次 `claude -p` 验登录 |
 | 战报里 `failed` 全是「通知出口不可用」 | 两条发信通道都没配**且** `optimizer.repo.path` 也没配（开 Issue 也要在仓库目录里跑 gh） |
+| 战报里 `failed` 写「邮件发送失败」 | 先分清是**认证**还是**投递**：日志里 `MailAuthenticationException` = 凭据不对，其它多半是发信域名/收件方拒收 |
+
+### 发信通道自检
+
+出问题时别猜，直接对 SMTP 认证探一次（不动代码、不发信）：
+
+```bash
+python3 - <<'EOF'
+import smtplib, ssl
+# 阿里云：用户名就是发信地址；Resend：用户名固定字面量 resend、密码是 re_ key
+for label, host, port, user, pwd in [
+    ("阿里云", "smtpdm.aliyun.com", 465, "<发信地址>", "<SMTP密码>"),
+    ("Resend", "smtp.resend.com", 465, "resend", "<re_ key>"),
+]:
+    try:
+        with smtplib.SMTP_SSL(host, port, timeout=15, context=ssl.create_default_context()) as s:
+            s.login(user, pwd); print(label, "认证通过")
+    except Exception as e:
+        print(label, "失败:", e)
+EOF
+```
+
+**只有一条通道能用时**：把另一条 `MAIL_*_ENABLED` 置 false 即可。`MailRouter` 找不到认领该
+收件域名的通道时，会兜给唯一启用的那条——这是它设计里就有的退路，不是将就。
+（实测：收件人是 Gmail、Resend 密钥失效时，关掉 global 后由阿里云那条正常送达。）

--- a/deploy/optimizer/README.md
+++ b/deploy/optimizer/README.md
@@ -98,25 +98,28 @@ OPTIMIZER_AGENT_COMMAND_6={prompt}
 「建议 / 拿不准」那条出口默认是 **`auto`**：配了邮件就发邮件，**没配就开一条 GitHub Issue**。
 开 Issue 复用的是优化者本来就有的 `gh` 登录，**不需要任何新凭据**，所以开箱即用。
 
-想改用邮件（或两个都要）：
+想改用邮件（或两个都要）：把 `OPTIMIZER_NOTIFY_CHANNEL` 改成 `mail`（或 `both`），
+再配一条发信通道。**发信不走 `spring.mail.*`**，走仓库自己的双通道（按收件域名分流，
+见 `application.yml` 的 `mail` 段）——只配一条也能工作：
 
 ```bash
-OPTIMIZER_NOTIFY_CHANNEL=mail      # 或 issue / both
-SPRING_MAIL_HOST=smtp.qq.com
-SPRING_MAIL_PORT=465
-SPRING_MAIL_USERNAME=你的邮箱
-SPRING_MAIL_PASSWORD=授权码        # 不是登录密码
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=true
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE=true   # 587 的 STARTTLS 改 ..._STARTTLS_ENABLE
-OPTIMIZER_MAIL_TO=收件人
-OPTIMIZER_MAIL_FROM=同 SPRING_MAIL_USERNAME
+OPTIMIZER_NOTIFY_CHANNEL=mail
+OPTIMIZER_MAIL_TO=你自己的收件邮箱
+
+# 收件人是国内邮箱（QQ/163/126/139…）→ 阿里云邮件推送
+MAIL_DOMESTIC_ENABLED=true
+MAIL_DOMESTIC_USERNAME=<发信地址本身>
+MAIL_DOMESTIC_PASSWORD=<控制台「发信地址 → 设置SMTP密码」设的那个，不是 AccessKey>
+MAIL_DOMESTIC_FROM=<同上发信地址>
+
+# 收件人是境外邮箱（Gmail/Outlook/自有域名…）→ Resend
+MAIL_GLOBAL_ENABLED=true
+MAIL_GLOBAL_PASSWORD=<re_ 开头的 API key>
+MAIL_GLOBAL_FROM=<send.aiworkdeck.com 下的发信地址>
 ```
 
-**授权码只能你自己生成**（要登录邮箱后台，这一步没法代劳）：
-QQ 邮箱 → 设置 → 账号 → POP3/SMTP 开启后拿到的那串 16 位；
-163 → 设置 → POP3/SMTP/IMAP → 客户端授权密码；
-Gmail → 开两步验证后在「应用专用密码」里生成，host `smtp.gmail.com`。
-填完重启进程，`/api/optimizer/status` 的 `notifyChannel` 会显示成「邮件」。
+**发件人由通道决定，优化者不指定**：两条通道的发信域名不同，硬写 from 会和实际发信域名
+对不上、SPF 当场判失败。填完重启进程，`/api/optimizer/status` 的 `notifyChannel` 会显示成「邮件」。
 
 ## 出问题先看这三处
 
@@ -124,4 +127,4 @@ Gmail → 开两步验证后在「应用专用密码」里生成，host `smtp.gm
 |---|---|
 | 战报 note 写「取件失败」 | token 与收件箱不一致，或收件箱那边 `feedback.optimizer-token` 没配（没配 = 整组 403） |
 | 每条都走通知、从不开 PR | 编码 Agent 没登录 → diff 为空 → 按 NO_CHANGES 转通知。手动跑一次 `claude -p` 验登录 |
-| 战报里 `failed` 全是「通知出口不可用」 | 邮件没配全**且** `optimizer.repo.path` 也没配（开 Issue 也要在仓库目录里跑 gh） |
+| 战报里 `failed` 全是「通知出口不可用」 | 两条发信通道都没配**且** `optimizer.repo.path` 也没配（开 Issue 也要在仓库目录里跑 gh） |

--- a/deploy/optimizer/optimizer.env.example
+++ b/deploy/optimizer/optimizer.env.example
@@ -18,19 +18,23 @@ OPTIMIZER_REPO_PATH=/Users/zewei/aiworkdeck-optimizer
 OPTIMIZER_BASE_BRANCH=master
 
 # ---- 通知出口（建议/拿不准走这条）----
-# auto（默认）：配了邮件走邮件，没配就开 GitHub Issue（复用 gh 登录，零新增凭据）
+# auto（默认）：配了发信通道就发邮件，没配就开 GitHub Issue（复用 gh 登录，零新增凭据）
 # 也可显式指定 mail / issue / both
 OPTIMIZER_NOTIFY_CHANNEL=auto
 
-# 邮件是可选的：SMTP 授权码只能你自己去邮箱后台生成，配了才生效
-SPRING_MAIL_HOST=smtp.qq.com
-SPRING_MAIL_PORT=465
-SPRING_MAIL_USERNAME=
-SPRING_MAIL_PASSWORD=
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=true
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE=true
+# 邮件是可选的。发信不走 spring.mail.*，走仓库自己的双通道（国内/国外按收件域名分流，
+# 见 backend .../service/mail 与 application.yml 的 mail 段）——只配一条也能工作：
+#   国内收件人（QQ/163/126/139…）→ 阿里云邮件推送
+# MAIL_DOMESTIC_ENABLED=true
+# MAIL_DOMESTIC_USERNAME=<发信地址本身>
+# MAIL_DOMESTIC_PASSWORD=<控制台「发信地址→设置SMTP密码」设的那个，不是 AccessKey>
+# MAIL_DOMESTIC_FROM=<同上发信地址>
+#   其余收件人（Gmail/Outlook/自有域名…）→ Resend
+# MAIL_GLOBAL_ENABLED=true
+# MAIL_GLOBAL_PASSWORD=<re_ 开头的 API key；用户名固定字面量 resend>
+# MAIL_GLOBAL_FROM=<send.aiworkdeck.com 下的发信地址>
+# 收件人（你自己）：
 OPTIMIZER_MAIL_TO=
-OPTIMIZER_MAIL_FROM=
 
 # ---- 编码 Agent（默认 claude -p）----
 # 换成别的把整条命令按下标覆盖（Spring 的列表环境变量绑定），例如 codex：

--- a/docs/FEEDBACK_OPTIMIZER_DESIGN.md
+++ b/docs/FEEDBACK_OPTIMIZER_DESIGN.md
@@ -127,6 +127,8 @@ uni-h5 没导出 `Audio`；uni 的 `Input` 不支持 `type="file"`）。所以�
   只调 `gh issue create`，不碰工作区、不建 worktree、不产生提交。
 - **发邮件**（`OptimizerMailer`）：只发不收。收信要么轮 IMAP 要么架 webhook，
   都会把一个每天跑一次的批处理变成常驻服务；信里因此明说「回信不会被系统读取」。
+  发信走 `MailRouter` 的国内/国外双通道（`mail.domestic.*` / `mail.global.*`），
+  **发件人由通道决定、本类不指定**——两条通道发信域名不同，硬写 from 会让 SPF 当场判失败。
 
 `auto` 的含义是「有邮件用邮件，没有就开 Issue」。**这样默认是刻意的**：邮件要维护者亲自去
 邮箱后台生成 SMTP 授权码才能用，而「反馈没人管」这件事不该取决于有没有腾出时间去配它。
@@ -189,15 +191,15 @@ OPTIMIZER_BASE_BRANCH=master
 # 拿不到你终端里的交互式登录态。没登录的表现是 Agent 秒退、diff 为空、
 # 本条反馈按 NO_CHANGES 转成邮件出口（不会假装修好）。
 
-# 邮件出口：配了 spring.mail.host 才会有 JavaMailSender，没配这条出口明确报「不可用」
-SPRING_MAIL_HOST=smtp.qq.com
-SPRING_MAIL_PORT=465
-SPRING_MAIL_USERNAME=you@qq.com
-SPRING_MAIL_PASSWORD=<授权码>          # 一律环境变量，别写进入库文件
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=true
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE=true   # 587 的 STARTTLS 改 ..._STARTTLS_ENABLE
+# 通知出口：默认 auto（配了发信通道就发邮件，没配就开 GitHub Issue，后者零新增凭据）
+OPTIMIZER_NOTIFY_CHANNEL=auto
 OPTIMIZER_MAIL_TO=you@example.com
-OPTIMIZER_MAIL_FROM=you@qq.com
+# 发信不走 spring.mail.*，走仓库自己的双通道（按收件域名分流，见 application.yml 的 mail 段）
+MAIL_DOMESTIC_ENABLED=true            # 国内收件人走阿里云邮件推送
+MAIL_DOMESTIC_USERNAME=<发信地址>      # 密码是「发信地址→设置SMTP密码」，不是 AccessKey
+MAIL_DOMESTIC_PASSWORD=<SMTP 密码>
+MAIL_DOMESTIC_FROM=<同上发信地址>
+# MAIL_GLOBAL_*                       # 境外收件人走 Resend，用户名固定 resend、密码是 re_ key
 
 # 语音转写（可选）
 FEEDBACK_ASR_ENABLED=true


### PR DESCRIPTION
两个 PR 各自在 master 上都是对的，撞在一起留了两处不一致。

## 1. `backend/pom.xml` 重复声明 `spring-boot-starter-mail`

#314 加过一次、#317 又加了一次，Maven 会告 duplicate declaration。去掉先落的那条，**保留 #317 那条**——它的注释解释了「为什么不用 `spring.mail.*` 自动装配」，正是后来人会问的问题。

## 2. 优化者的邮件配置说明整体过期（影响更实际）

#320 把优化者发信从 `spring.mail.*` 换成了 `MailRouter` 的国内/国外双通道，`OptimizerProperties.Mail` 同时删掉了 `from`（发件人由通道决定，硬写会和实际发信域名对不上、SPF 当场判失败）。

但 #319 留下的三处文档还在教人配 `SPRING_MAIL_HOST` / `OPTIMIZER_MAIL_FROM`：

- `deploy/optimizer/optimizer.env.example`
- `deploy/optimizer/README.md`
- `docs/FEEDBACK_OPTIMIZER_DESIGN.md` §5

**照着配一行都不会生效，而且不报错**——只是永远不发信，很难反查。三处一并换成 `MAIL_DOMESTIC_*` / `MAIL_GLOBAL_*`，并写清发件人为什么不由优化者指定。

通知出口的默认行为不变：`auto` 在没配发信通道时仍落到开 GitHub Issue。

## 验证

- `mvn test` **1337 项全绿**
- 维护者机器上的常驻优化者已按新 env 重启，`/api/optimizer/status` 回显 `notifyChannel=GitHub Issue`、`source=云端收件箱`，空跑一轮取件正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)