### PR TITLE
test(version): JGit add 收录行为探针，据实测改掉默认建仓的排除方案

### DIFF
--- a/backend/src/test/java/com/checkba/version/JGitAddBehaviorProbeTest.java
+++ b/backend/src/test/java/com/checkba/version/JGitAddBehaviorProbeTest.java
@@ -1,0 +1,259 @@
+package com.checkba.version;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JGit `add(".")` 在真实用户目录上的收录行为探针。
+ *
+ * 存在理由：把「项目 = Git 仓库」从 opt-in 改成默认开启之后，建仓会发生在律师自选的任意文件夹上
+ * （Project.localRoot）。而 ProjectRepoService.init 用的是无差别的 `git add "."`，
+ * 数据库导入侧那套 3000 条上限 / 20 层深度 / 跳过点开头目录的规则（LocalProjectService）
+ * 对它一概不生效。
+ *
+ * 本测试钉死三条决定「默认建仓会不会把用户整个文件夹原样吞进对象库」的行为：
+ *   1. 工作区自带的 .gitignore 是否被应用
+ *   2. 嵌套的 .git 目录是当 gitlink 跳过，还是展开其内容
+ *   3. 符号链接是存成 symlink blob，还是跟进目标把目标内容收进来
+ *
+ * 调用序列与 ProjectRepoService.init 完全一致（repo.create(true) + add(".") + commit），
+ * gitDir 与 workTree 分离也照搬，保证结论对生产路径成立。
+ */
+class JGitAddBehaviorProbeTest {
+
+    /** 把某次提交的完整树摊平成 path -> FileMode，含子目录递归。 */
+    private static Map<String, FileMode> flattenTree(Repository repo, ObjectId commitId) throws Exception {
+        Map<String, FileMode> out = new LinkedHashMap<>();
+        try (RevWalk walk = new RevWalk(repo)) {
+            RevCommit commit = walk.parseCommit(commitId);
+            try (TreeWalk tw = new TreeWalk(repo)) {
+                tw.addTree(commit.getTree());
+                tw.setRecursive(false);
+                while (tw.next()) {
+                    out.put(tw.getPathString(), tw.getFileMode(0));
+                    // gitlink（嵌套仓库）不可进入；普通目录才递归
+                    if (tw.isSubtree() && tw.getFileMode(0) != FileMode.GITLINK) {
+                        tw.enterSubtree();
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    @Test
+    void probeAddBehaviorOnARealisticUserFolder(@TempDir Path tmp) throws Exception {
+        Path workTree = tmp.resolve("lawyer-folder");
+        Path gitDir = tmp.resolve("repos").resolve("project-1.git");
+        Path outside = tmp.resolve("outside-target");   // 工作区之外，符号链接的目标
+        Files.createDirectories(workTree);
+        Files.createDirectories(gitDir.getParent());
+        Files.createDirectories(outside);
+
+        // --- 1. 普通文件（基准） ---
+        Files.writeString(workTree.resolve("股权转让协议.docx"), "content");
+
+        // --- 2. 用户自带的 .gitignore ---
+        Files.writeString(workTree.resolve(".gitignore"), "node_modules/\n*.log\n");
+        Files.writeString(workTree.resolve("app.log"), "should be ignored by *.log");
+        Path nodeModules = workTree.resolve("node_modules").resolve("pkg");
+        Files.createDirectories(nodeModules);
+        Files.writeString(nodeModules.resolve("index.js"), "should be ignored by node_modules/");
+
+        // --- 3. 点开头目录里的普通文件（数据库导入会跳过，git 呢？） ---
+        Path hidden = workTree.resolve(".venv").resolve("lib");
+        Files.createDirectories(hidden);
+        Files.writeString(hidden.resolve("site.py"), "hidden dir, plain file");
+        Files.writeString(workTree.resolve(".DS_Store"), "mac junk");
+
+        // --- 4. 嵌套的 git 仓库（律师文件夹里恰好有个别人的项目） ---
+        Path nested = workTree.resolve("nested-repo");
+        Files.createDirectories(nested);
+        Files.writeString(nested.resolve("inner.txt"), "inside a nested repo");
+        try (Git ng = Git.init().setDirectory(nested.toFile()).call()) {
+            ng.add().addFilepattern(".").call();
+            ng.commit().setMessage("nested init").setAuthor("t", "t@t").call();
+        }
+
+        // --- 5. 指向工作区外部的符号链接（目录 + 文件各一条） ---
+        Files.writeString(outside.resolve("big.bin"), "x".repeat(1024));
+        boolean symlinkSupported;
+        try {
+            Files.createSymbolicLink(workTree.resolve("link-to-dir"), outside);
+            Files.createSymbolicLink(workTree.resolve("link-to-file"), outside.resolve("big.bin"));
+            symlinkSupported = true;
+        } catch (UnsupportedOperationException | java.io.IOException e) {
+            symlinkSupported = false;
+        }
+
+        // ===== 完全照搬 ProjectRepoService.init 的调用序列 =====
+        Map<String, FileMode> tree;
+        try (Repository repo = new FileRepositoryBuilder()
+                .setGitDir(gitDir.toFile())
+                .setWorkTree(workTree.toFile())
+                .build()) {
+            repo.create(true);
+            try (Git git = new Git(repo)) {
+                git.add().addFilepattern(".").call();
+                RevCommit c = git.commit()
+                        .setMessage("初始版本\n\nX-AWD-Kind: session")
+                        .setAuthor("AI Workdeck", "ai@aiworkdeck.local")
+                        .setAllowEmpty(true)
+                        .call();
+                tree = flattenTree(repo, c.getId());
+            }
+        }
+
+        List<String> report = new ArrayList<>();
+        report.add("=== JGit " + org.eclipse.jgit.internal.JGitText.class.getPackage().getImplementationVersion()
+                + " add(\".\") 收录结果（" + tree.size() + " 条） ===");
+        tree.forEach((p, m) -> report.add(String.format("  %-30s %s", p, modeName(m))));
+        report.add("symlink 可创建: " + symlinkSupported);
+        System.out.println(String.join("\n", report));
+
+        // ---------- 结论 1：.gitignore 是否生效 ----------
+        boolean gitignoreApplied = !tree.containsKey("app.log") && !tree.containsKey("node_modules/pkg/index.js");
+        System.out.println("[结论1] 工作区自带 .gitignore 被应用 = " + gitignoreApplied
+                + "  (app.log 在树里=" + tree.containsKey("app.log")
+                + ", node_modules/pkg/index.js 在树里=" + tree.containsKey("node_modules/pkg/index.js") + ")");
+
+        // ---------- 结论 2：嵌套 .git ----------
+        FileMode nestedMode = tree.get("nested-repo");
+        boolean nestedIsGitlink = nestedMode == FileMode.GITLINK;
+        boolean nestedExpanded = tree.containsKey("nested-repo/inner.txt");
+        boolean nestedDotGitLeaked = tree.keySet().stream().anyMatch(p -> p.startsWith("nested-repo/.git"));
+        System.out.println("[结论2] 嵌套仓库 mode=" + modeName(nestedMode)
+                + "  gitlink=" + nestedIsGitlink + "  内容被展开=" + nestedExpanded
+                + "  .git 内部泄漏=" + nestedDotGitLeaked);
+
+        // ---------- 结论 3：符号链接 ----------
+        FileMode linkDirMode = tree.get("link-to-dir");
+        FileMode linkFileMode = tree.get("link-to-file");
+        boolean followedDir = tree.keySet().stream().anyMatch(p -> p.startsWith("link-to-dir/"));
+        System.out.println("[结论3] link-to-dir mode=" + modeName(linkDirMode)
+                + "  link-to-file mode=" + modeName(linkFileMode)
+                + "  目录链接被跟进=" + followedDir);
+
+        // ---------- 结论 4：点开头目录（对照 LocalProjectService 的导入规则） ----------
+        boolean hiddenDirCollected = tree.containsKey(".venv/lib/site.py");
+        System.out.println("[结论4] 点开头目录里的普通文件被 git 收下 = " + hiddenDirCollected
+                + "  (.DS_Store 在树里=" + tree.containsKey(".DS_Store") + ")");
+
+        // ===== 断言：钉死行为，任何一条变了都要重新论证默认建仓的闸门设计 =====
+        assertTrue(tree.containsKey("股权转让协议.docx"), "基准：普通文件必须被收录");
+
+        assertTrue(gitignoreApplied,
+                "JGit 应当应用工作区自带的 .gitignore —— 若此断言失败，默认建仓的 .gitignore 闸门整个失效，"
+                        + "必须改用显式路径集合替代 addFilepattern(\".\")");
+
+        assertSame(FileMode.GITLINK, nestedMode,
+                "嵌套 .git 应当被识别为 gitlink 而非展开");
+        assertFalse(nestedExpanded, "嵌套仓库的内容不应被展开进本仓");
+        assertFalse(nestedDotGitLeaked, "嵌套仓库的 .git 内部文件绝不应进入对象库");
+
+        if (symlinkSupported) {
+            assertSame(FileMode.SYMLINK, linkFileMode, "指向文件的符号链接应存成 symlink blob");
+            assertSame(FileMode.SYMLINK, linkDirMode, "指向目录的符号链接应存成 symlink blob，不跟进目标");
+            assertFalse(followedDir, "符号链接指向的目录内容不应被收进对象库");
+        }
+
+        assertTrue(hiddenDirCollected,
+                "点开头目录里的普通文件会被 git 收下（数据库导入侧会跳过）—— 这正是「文件树看不见但已被版本记录收录」"
+                        + "的来源。若此断言失败说明 JGit 行为变了，spec 的闸门 2 论证需要重写");
+    }
+
+    /**
+     * 排除规则能不能放进 gitDir 的 info/exclude，而不是往用户文件夹里写 .gitignore。
+     *
+     * 这条决定默认建仓要不要在律师自己的文件夹里留下一个他没写过的 .gitignore：
+     * gitDir 恒在 {globalRoot}/repos/project-{id}.git（工作区之外），
+     * 若 JGit 认 $GIT_DIR/info/exclude，就能做到零文件写进用户目录，
+     * 而且不会与用户自带的 .gitignore 互相覆盖。
+     */
+    @Test
+    void probeInfoExcludeInsteadOfWritingGitignoreIntoUserFolder(@TempDir Path tmp) throws Exception {
+        Path workTree = tmp.resolve("lawyer-folder");
+        Path gitDir = tmp.resolve("repos").resolve("project-2.git");
+        Files.createDirectories(workTree);
+        Files.createDirectories(gitDir.getParent());
+
+        Files.writeString(workTree.resolve("尽调报告.docx"), "keep me");
+        Path nm = workTree.resolve("node_modules").resolve("pkg");
+        Files.createDirectories(nm);
+        Files.writeString(nm.resolve("index.js"), "drop me");
+        Path venv = workTree.resolve(".venv").resolve("lib");
+        Files.createDirectories(venv);
+        Files.writeString(venv.resolve("site.py"), "drop me too");
+        // 用户自带的 .gitignore，规则与我们的互不相同 —— 验证两者叠加而非互相覆盖
+        Files.writeString(workTree.resolve(".gitignore"), "*.tmp\n");
+        Files.writeString(workTree.resolve("draft.tmp"), "user's own rule should still work");
+
+        Map<String, FileMode> tree;
+        try (Repository repo = new FileRepositoryBuilder()
+                .setGitDir(gitDir.toFile())
+                .setWorkTree(workTree.toFile())
+                .build()) {
+            repo.create(true);
+
+            // 关键动作：排除规则写进 gitDir，不碰用户文件夹
+            Path info = gitDir.resolve("info");
+            Files.createDirectories(info);
+            Files.writeString(info.resolve("exclude"), String.join("\n",
+                    "node_modules/", ".venv/", ".*/", "*.mp4", "") );
+
+            try (Git git = new Git(repo)) {
+                git.add().addFilepattern(".").call();
+                RevCommit c = git.commit()
+                        .setMessage("初始版本\n\nX-AWD-Kind: session")
+                        .setAuthor("AI Workdeck", "ai@aiworkdeck.local")
+                        .setAllowEmpty(true)
+                        .call();
+                tree = flattenTree(repo, c.getId());
+            }
+        }
+
+        System.out.println("=== info/exclude 生效验证（" + tree.size() + " 条） ===");
+        tree.forEach((p, m) -> System.out.printf("  %-30s %s%n", p, modeName(m)));
+        boolean ourRulesWork = !tree.containsKey("node_modules/pkg/index.js")
+                && !tree.containsKey(".venv/lib/site.py");
+        boolean userRuleStillWorks = !tree.containsKey("draft.tmp");
+        System.out.println("[结论5] gitDir/info/exclude 生效 = " + ourRulesWork
+                + "  用户自带 .gitignore 仍生效 = " + userRuleStillWorks
+                + "  用户文件夹里有没有被我们写入 .gitignore = "
+                + (Files.readString(workTree.resolve(".gitignore")).equals("*.tmp\n") ? "没有（原样未动）" : "有（被改写）"));
+
+        assertTrue(tree.containsKey("尽调报告.docx"), "基准：普通文件必须被收录");
+        assertTrue(ourRulesWork,
+                "JGit 应当读取 $GIT_DIR/info/exclude —— 若失败，排除规则只能写成用户文件夹里的 .gitignore");
+        assertTrue(userRuleStillWorks, "用户自带的 .gitignore 规则必须与 info/exclude 叠加生效，而不是被顶掉");
+        assertEquals("*.tmp\n", Files.readString(workTree.resolve(".gitignore")),
+                "我们不应该改写用户自己的 .gitignore");
+    }
+
+    private static String modeName(FileMode m) {
+        if (m == null) return "<不在树里>";
+        if (m == FileMode.GITLINK) return "GITLINK(160000)";
+        if (m == FileMode.SYMLINK) return "SYMLINK(120000)";
+        if (m == FileMode.TREE) return "TREE(040000)";
+        if (m == FileMode.REGULAR_FILE) return "FILE(100644)";
+        if (m == FileMode.EXECUTABLE_FILE) return "EXEC(100755)";
+        return m.toString();
+    }
+}

--- a/docs/superpowers/specs/2026-08-08-project-overview-design.md
+++ b/docs/superpowers/specs/2026-08-08-project-overview-design.md
@@ -83,13 +83,29 @@ opt-in：`enabled = repoService.isInitialized(projectId)`（`VersionController.j
 
 #### 闸门 2：收录范围与文件树同源
 
-数据库导入有 3000 条上限、20 层深度、跳过点开头目录（`LocalProjectService.java:285/290/291-294/325`），`git add "."`（`ProjectRepoService.java:127-128`）不受任何约束。确定成立的后果：**超出 3000 条的部分、`.venv`/`.idea`/`.DS_Store` 里的普通文件会被 git 收下而文件树里看不见**。
+数据库导入有 3000 条上限、20 层深度、跳过点开头目录（`LocalProjectService.java:285/290/291-294/325`），`git add "."`（`ProjectRepoService.java:127-128`）不受任何约束。
 
 注意：`ProjectStorageResolver.java:28-29` 那条「git 提交的内容 = 用户看到的文件」契约**在 localRoot 项目上今天就已经破了**，默认开启只是把破口推广到全部项目。
 
-建仓时写一份默认 `.gitignore`，规则与导入规则同源（至少覆盖点开头目录），补 `node_modules/ dist/ target/ .venv/ *.mp4`。**这份 .gitignore 会出现在律师文件夹里，spec 明确接受**（`.awd/` 同理）。新口径写进 `.claude/agents/version-control.md` 作为契约修订。
+**实测结论**（2026-08-08，JGit 6.9.0.202403050737-r，护栏测试 `backend/src/test/java/com/checkba/version/JGitAddBehaviorProbeTest.java`，2 个用例全绿）：
 
-> **未验证，实施前必须实测**：JGit 6.9.0（`backend/pom.xml:111-113`）的 `AddCommand` 对三件事的实际行为没有任何代码或测试确认——① 是否应用工作区自带的 `.gitignore`；② 嵌套 `.git` 是当 gitlink 跳过还是展开；③ 符号链接是存 symlink blob 还是跟进目标。**这三条直接决定闸门 2 是否成立。** 用一个真实目录（含 node_modules + 自带 .gitignore + 嵌套 git 仓 + 指向外部的符号链接）跑一次实测再定策略。
+| 行为 | 实测结果 | 对设计的影响 |
+|---|---|---|
+| 工作区自带 `.gitignore` | **生效**（`app.log`、`node_modules/pkg/index.js` 都没进树） | 排除规则可行，**不需要**把 `addFilepattern(".")` 改成显式路径集合 |
+| 嵌套 `.git` 目录 | **存成 `GITLINK(160000)`**，内容不展开，`.git` 内部不泄漏 | 风险远小于预期。但见下方语义说明 |
+| 符号链接（指向目录 / 指向文件） | **都存成 `SYMLINK(120000)`，不跟进目标** | 外置盘、网络盘、大目录不会被顺着链接吞进来 |
+| 点开头目录里的普通文件 | **被 git 收下**（`.venv/lib/site.py`、`.DS_Store` 都在树里） | 确认「文件树看不见但已被版本记录收录」成立，排除规则必须覆盖点开头目录 |
+| `$GIT_DIR/info/exclude` | **生效，且与用户自带 `.gitignore` 叠加**（不互相顶掉） | **决定了下面的方案** |
+
+**方案：排除规则写进 `{gitDir}/info/exclude`，不往律师的文件夹里写任何东西。**
+
+gitDir 恒在 `{globalRoot}/repos/project-{id}.git`（工作区之外），所以这条规则对律师完全不可见，也不会与他自己的 `.gitignore` 互相覆盖——实测两者叠加生效。这比原计划的「写一份 `.gitignore` 进用户文件夹」严格更好：既守住了「用户自己的文件夹里不冒出他没写过的文件」这条既有承诺，又避免了「用户已有 `.gitignore` 时该追加还是覆盖」这个没有好答案的问题。
+
+默认规则（与导入规则同源）：`.*/`（点开头目录，对齐 `LocalProjectService.java:290`）、`node_modules/`、`dist/`、`target/`、`.venv/`、`*.mp4` 等大二进制。
+
+> **一条要写进领域文档的语义**：嵌套的 git 仓库存成 gitlink，意味着律师放在案卷里的某个 git 项目，**其内容不会进入版本记录的历史**——退回版本时那个子目录不受保护。这不是 bug（吞进去反而更糟），但要在 `.claude/agents/version-control.md` 里写明，否则将来会被当成数据丢失来查。
+
+`.awd/` 目录仍会出现在用户文件夹里（清单必须与内容进同一笔提交），这一条不变，spec 明确接受。新口径写进 `.claude/agents/version-control.md` 作为契约修订。
 
 #### 闸门 3：修 `isInitialized` 的半残仓陷阱
 
@@ -504,7 +520,7 @@ project_task
 ## 9. 前置修复清单（不修就不能上）
 
 1. **`isInitialized` 半残仓陷阱**（§3.3 闸门 3）——不修则默认建仓失败的项目永久不可恢复
-2. **JGit `AddCommand` 三项行为实测**（§3.3 闸门 2）——不测则闸门 2 建立在猜测上
+2. ~~JGit `AddCommand` 三项行为实测~~ —— **已完成**（2026-08-08，`JGitAddBehaviorProbeTest`，结论见 §3.3 闸门 2）
 3. **默认建仓触发点移出 `@Transactional`**（§3.3 闸门 4）
 4. **`/timeline` 未开仓时的错误信封改成早退空列表**（§6.3）
 5. **`project_ai_message` 加索引**（§6.4）——现在线上只有主键索引
@@ -526,7 +542,8 @@ project_task
 - `cd backend && mvn test`（JDK 21，**系统默认 25 会 SIGBUS**）
 - `cd frontend && npm run check:emits`
 - `cd frontend && npm run test:app-e2e`——**J2/J3 两段旅程要重写、J9 两步断言要改**（§5.4），基线会变
-- 新增：默认建仓的三个针对性用例（含 node_modules 的目录、含指向外部的符号链接的目录、含用户自带 `.git`/`.gitignore` 的目录）
+- **已落地**：`JGitAddBehaviorProbeTest`（含 node_modules + 用户自带 `.gitignore` + 点开头目录 + 嵌套 git 仓 + 指向外部的符号链接的真实目录，两个用例分别钉死 `add(".")` 的收录行为与 `info/exclude` 的生效）。**改动 `ProjectRepoService.init`/`commitAll` 的收录方式时必跑这个。**
+- 待补：默认建仓在大 localRoot 目录上的耗时用例（缺真实样本，见 §11 Q1）
 - 新表在 H2 与 MySQL 两种库上各验一次建表（§8）
 - 领域文档更新（CLAUDE.md 维护规则）：`sidebar-shell.md`（两个新页面、导航流、术语表）、`version-control.md`（默认建仓、`.awd/profile.json`、`.gitignore` 新契约）、`ai-chat.md`（`project_memory` 表结构与契约——**全仓目前只有 `ai-chat.md:32` 一行提到 `ProjectMemoryExtractor`**）
 
@@ -579,4 +596,4 @@ project_task
 21. ❌「`GET /api/ai/conversations` 可零后端改动直接接成『本项目全部对话历史』」——是 user-scoped，且有鉴权缺口
 22. ❌「`project_memory` 是项目基本情况最合适的落点，不用新建表」——不进 Git 同步、无 uid
 
-**标为「未验证」、不可当事实引用的**：JGit 6.9.0 对 `.gitignore`/嵌套 `.git`/符号链接的实际行为；`enableVersionRecording` 在大项目上的耗时；默认开启后 `onChangeSignal` 早退翻转的性能影响；`MemCellExtractor` 的输出结构；`ProjectMemoryExtractor` 注释里自述的那次「生产事故」（无 issue/PR/日志佐证）；`findConversationSummaries` 在 userId=null 时返回空（SQL 语义推断，未实跑）；taiga-front 的许可。
+**标为「未验证」、不可当事实引用的**：~~JGit 6.9.0 对 `.gitignore`/嵌套 `.git`/符号链接的实际行为~~（**2026-08-08 已实测，见 §3.3 闸门 2**）；`enableVersionRecording` 在大项目上的耗时；默认开启后 `onChangeSignal` 早退翻转的性能影响；`MemCellExtractor` 的输出结构；`ProjectMemoryExtractor` 注释里自述的那次「生产事故」（无 issue/PR/日志佐证）；`findConversationSummaries` 在 userId=null 时返回空（SQL 语义推断，未实跑）；taiga-front 的许可。


### PR DESCRIPTION
承接 #325 的设计文档。那份 spec 里「默认建仓」的闸门 2 有三条标着**未验证**的 JGit 行为，直接决定「把用户整个文件夹原样吞进对象库」是不是真的会发生。这个 PR 把它们测掉了。

## 实测结果

用一个真实目录（node_modules + 用户自带 `.gitignore` + 点开头目录 + 嵌套 git 仓 + 指向工作区外的符号链接）跑，调用序列完全照搬 `ProjectRepoService.init`：

| 行为 | 结果 |
|---|---|
| 工作区自带 `.gitignore` | **生效** → 不需要把 `addFilepattern(".")` 改成显式路径集合 |
| 嵌套 `.git` | **`GITLINK(160000)`**，内容不展开、`.git` 内部不泄漏 |
| 符号链接（指向目录 / 文件） | **都是 `SYMLINK(120000)`，不跟进目标** → 外置盘不会被顺着吞进来 |
| 点开头目录里的普通文件 | **被 git 收下**（数据库导入侧会跳过）→ 确认「文件树看不见但已被版本记录收录」 |
| `$GIT_DIR/info/exclude` | **生效，且与用户自带 `.gitignore` 叠加**，不互相顶掉 |

## 这改了什么设计

最后一条是意外收获。gitDir 恒在 `{globalRoot}/repos/project-{id}.git`，**在用户文件夹之外**——所以排除规则放 `info/exclude` 就能做到：

- 默认建仓不再往律师的目录里写任何他没写过的 `.gitignore`
- 不用面对「用户已有 `.gitignore` 时该追加还是覆盖」这个没有好答案的问题
- 用户自己的规则照常生效

比 spec 原来写的「写一份 .gitignore 进用户文件夹，spec 明确接受」严格更好，已同步改掉。

## 一条要进领域文档的语义

嵌套 git 仓库存成 gitlink，意味着律师放在案卷里的某个 git 项目**其内容不进版本记录历史**，退回版本时那个子目录不受保护。不是 bug（吞进去反而更糟），但不写明将来会被当成数据丢失来查。

## 验证

`JGitAddBehaviorProbeTest` 两个用例全绿；改动 `ProjectRepoService` 的收录方式时必跑。无生产代码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)