### PR TITLE
chore: 发布 v0.14.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiworkdeck-desktop",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiworkdeck-desktop",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
把 master 上 v0.13.0 之后的二十个 PR（#296、#311-#331）打成 0.14.0。版本号单一来源 `desktop/package.json`，本 PR 只改版本号本身。

0.14.0 是大版本（Y=0），走全量安装包，patch-gate 不设限。

## 本版内容

- 诉讼可视化上线：时间轴 / 流程图 / 当事人关系图，服务端出 PNG（Batik）直接插进正在写的文书（#324、#327）
- AI 面板交互能力对齐：结构化反问、工具输出可见、慢工具可取消、长任务可见性；工具载荷协议标签中和（#328、#330）
- AI 供应商体系改造：三档收敛、模型目录服务化、区域判定、子 Agent 省钱额度（#323）
- Impress 桥收官：slide_* 七原语 Phase 2 / Phase 3（#311、#312）
- 用户反馈自我迭代闭环 + 通知出口开 GitHub Issue（#314、#319）
- 邮箱验证码登录、邮件发信双通道、双主站架构桌面端站点缝、Credits 契约跟随（#320、#317、#322、#316、#321）
- 插件云后端生产化部署、LOWA 引擎发布脚本、JGit 收录行为探针（#296、#315、#326）
- 项目概览页设计与实施计划、iCloud 驱逐闸门 1 设计（#325、#329、#331）

## 发版前验证（本地，均在本 worktree 冷启动跑）

| 项 | 结果 |
|---|---|
| backend `mvn -B test`（JDK 21） | 1520 通过 / 0 失败 / 7 跳过 |
| frontend `npm run test:app-e2e` | 104 步通过 / 0 失败 / 异常信号 0 条 |
| desktop `npm test` | 34 通过 |
| frontend `check:emits` + `build:h5` | 通过 |
| LOWA 引擎 24.2.8-zhcn-r4 双机可达性 | 北京 / 新加坡 / 默认解析均 200 |

合并后打 tag `v0.14.0` 触发 desktop-build 双平台出 dmg + exe。

🤖 Generated with [Claude Code](https://claude.com/claude-code)