### PR TITLE
fix(jpa): @Table 索引/唯一约束改用 snake_case 物理列名，并加 INFORMATION_SCHEMA 护栏

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -95,6 +95,15 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   `RagAutoConfig`——删掉后自动配置自己造 `contentRetriever`，而本项目有两个
   `EmbeddingStore<TextSegment>`，全部 `@SpringBootTest` 一起 NoUniqueBeanDefinition 起不来
   （2026-08 清理孤儿类时踩过，16 个 context 加载失败）。`DesktopContextSmokeTest` 是这条的护栏。
+- **`@Table` 的 `indexes` / `uniqueConstraints` 里必须写 snake_case 物理列名**：这两处不参与
+  PhysicalNamingStrategy 的驼峰转换（本仓没配自定义策略，用 Spring Boot 默认的
+  CamelCaseToUnderscoresNamingStrategy，字段 `projectId` 落成列 `project_id`）。
+  Hibernate 6.4.4 会先把它当**逻辑名**查一次，所以写驼峰往往侥幸能解析、索引其实建对了；
+  但一旦查不到就把字符串原样塞进 DDL，而 `@UniqueConstraint` 是内联在 `create table` 里的，
+  整条建表语句失败、Hibernate 只打一行 WARN（`GenerationTarget encountered exception`）
+  就继续启动——**表根本没建出来，启动看着正常，第一次查询才炸**。
+  `EntityIndexColumnNamingTest` 是这条的护栏：反射扫全部 `@Entity`，对着 H2 的
+  INFORMATION_SCHEMA 逐条对账列名与索引，新实体写错驼峰会自动红。
 
 ## 验证（改本领域自身时）
 

--- a/backend/src/main/java/com/checkba/model/entity/AccountBinding.java
+++ b/backend/src/main/java/com/checkba/model/entity/AccountBinding.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "account_binding",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"externalAccountId"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"external_account_id"}))
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class AccountBinding {

--- a/backend/src/main/java/com/checkba/model/entity/DeviceToken.java
+++ b/backend/src/main/java/com/checkba/model/entity/DeviceToken.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 /** 云端协作的长期设备令牌。库里只存 SHA-256，明文只在发放时返回一次。 */
 @Entity
 @Table(name = "device_token",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"tokenHash"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"token_hash"}))
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class DeviceToken {

--- a/backend/src/main/java/com/checkba/model/entity/DocFileLink.java
+++ b/backend/src/main/java/com/checkba/model/entity/DocFileLink.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  */
 @Entity
 @Table(name = "doc_file_link", indexes = {
-        @Index(name = "idx_doc_file_link_project_key", columnList = "projectId,linkKey", unique = true)
+        @Index(name = "idx_doc_file_link_project_key", columnList = "project_id,link_key", unique = true)
 })
 public class DocFileLink {
     @Id

--- a/backend/src/main/java/com/checkba/model/entity/FileTag.java
+++ b/backend/src/main/java/com/checkba/model/entity/FileTag.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "project_file_tag", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"fileId", "tagId"})
+    @UniqueConstraint(columnNames = {"file_id", "tag_id"})
 })
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id：join 实体最易被放进 Set 去重，字段型 hashCode 在 save 前后会变

--- a/backend/src/main/java/com/checkba/model/entity/PlatformAiKey.java
+++ b/backend/src/main/java/com/checkba/model/entity/PlatformAiKey.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "platform_ai_key",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"userId"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id"}))
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class PlatformAiKey {

--- a/backend/src/main/java/com/checkba/model/entity/ProjectRemote.java
+++ b/backend/src/main/java/com/checkba/model/entity/ProjectRemote.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 /** 一个项目与云端仓库的绑定关系。projectId 唯一——一个项目至多接一个云端。 */
 @Entity
 @Table(name = "project_remote",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"projectId"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"project_id"}))
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class ProjectRemote {

--- a/backend/src/main/java/com/checkba/model/entity/Tag.java
+++ b/backend/src/main/java/com/checkba/model/entity/Tag.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @Table(name = "project_tag", uniqueConstraints = {
     // 同项目内标签名唯一：应用层 existsByProjectIdAndName 是"先查后插"，并发下仍可能重复；
     // DB 唯一约束兜底，避免重复标签导致 findByProjectIdAndName 抛 NonUniqueResultException。
-    @UniqueConstraint(columnNames = {"projectId", "name"})
+    @UniqueConstraint(columnNames = {"project_id", "name"})
 })
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true) // 仅用 id，与仓库其余实体一致，避免可变字段/未持久化时的 hashCode 陷阱

--- a/backend/src/main/java/com/checkba/model/entity/UserSession.java
+++ b/backend/src/main/java/com/checkba/model/entity/UserSession.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "user_session",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"tokenHash"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"token_hash"}))
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class UserSession {

--- a/backend/src/test/java/com/checkba/repository/EntityIndexColumnNamingTest.java
+++ b/backend/src/test/java/com/checkba/repository/EntityIndexColumnNamingTest.java
@@ -1,0 +1,234 @@
+package com.checkba.repository;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.test.context.TestPropertySource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 全实体的 @Index / @UniqueConstraint 物理列名对账（H2 侧，MODE=PostgreSQL）。
+ *
+ * 为什么需要这条：{@code @Table} 的 indexes/uniqueConstraints 里写的是**物理列名**，
+ * 不走 PhysicalNamingStrategy 的驼峰转换。本仓没配自定义命名策略，Spring Boot 默认的
+ * CamelCaseToUnderscoresNamingStrategy 会把字段 projectId 落成列 project_id；此处若写
+ * 驼峰 "projectId"，Hibernate 找不到同名物理列，只会在启动日志里留一行 warn 就跳过，
+ * 建表照常成功、索引却没建出来——线上表现是「悄悄变慢」，没有任何报错。
+ *
+ * 断言口径刻意不看索引名，只看列组合：H2 把 UNIQUE 约束的背书索引改名成
+ * {@code IDX_XXX_INDEX_B}，按名字对账会假红。
+ *
+ * 用反射扫全包而不是硬编码清单：新加实体写错驼峰时，这条会自动红，不需要有人记得回来补。
+ *
+ * H2 内存库配方照抄 WorkSessionRepositoryTest:19-28，只改库名——@TestPropertySource
+ * 参与 ApplicationContext 缓存键，换个库名就不会与其他 @DataJpaTest 互相污染。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:entity-index-naming-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class EntityIndexColumnNamingTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    /** 一条 @Index 或 @UniqueConstraint 声明。 */
+    private record DeclaredIndex(String entity, String table, String name, List<String> columns, boolean unique) {
+        String describe() {
+            return entity + " 的 " + (name.isBlank() ? "(未命名)" : name) + " " + columns;
+        }
+    }
+
+    /** INFORMATION_SCHEMA 里读到的一条真实索引。 */
+    private record ActualIndex(String name, List<String> columns, boolean unique) {
+    }
+
+    // ---------- 声明侧：反射扫全部 @Entity ----------
+
+    private static List<DeclaredIndex> declaredIndexes() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Entity.class));
+
+        List<DeclaredIndex> declared = new ArrayList<>();
+        for (var candidate : scanner.findCandidateComponents("com.checkba")) {
+            Class<?> type;
+            try {
+                type = Class.forName(candidate.getBeanClassName());
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("扫到实体但加载不了：" + candidate.getBeanClassName(), e);
+            }
+            Table table = type.getAnnotation(Table.class);
+            if (table == null || (table.indexes().length == 0 && table.uniqueConstraints().length == 0)) {
+                continue;
+            }
+            assertFalse(table.name().isBlank(),
+                    type.getSimpleName() + " 声明了索引/唯一约束，却没在 @Table 里写 name，无法对账物理表名");
+
+            for (Index index : table.indexes()) {
+                declared.add(new DeclaredIndex(type.getSimpleName(), table.name(), index.name(),
+                        splitColumnList(index.columnList()), index.unique()));
+            }
+            for (UniqueConstraint constraint : table.uniqueConstraints()) {
+                declared.add(new DeclaredIndex(type.getSimpleName(), table.name(), constraint.name(),
+                        List.of(constraint.columnNames()), true));
+            }
+        }
+        assertFalse(declared.isEmpty(), "一个声明索引的实体都没扫到，扫描包名或过滤器写错了");
+        return declared;
+    }
+
+    /** columnList 允许写成 "a, b DESC"，物理列名只取排序方向前的那一段。 */
+    private static List<String> splitColumnList(String columnList) {
+        List<String> columns = new ArrayList<>();
+        for (String raw : columnList.split(",")) {
+            String column = raw.trim();
+            if (column.isEmpty()) {
+                continue;
+            }
+            int space = column.indexOf(' ');
+            columns.add(space > 0 ? column.substring(0, space) : column);
+        }
+        return columns;
+    }
+
+    // ---------- 实际侧：读 INFORMATION_SCHEMA ----------
+
+    /** 表名 -> 列名集合，全部大写（H2 对未加引号的标识符一律折成大写，PostgreSQL 模式下也一样）。 */
+    private Map<String, Set<String>> physicalColumns() throws Exception {
+        Map<String, Set<String>> byTable = new LinkedHashMap<>();
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet rs = statement.executeQuery(
+                     "SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+                             + "WHERE TABLE_SCHEMA = 'PUBLIC'")) {
+            while (rs.next()) {
+                byTable.computeIfAbsent(upper(rs.getString(1)), k -> new LinkedHashSet<>())
+                        .add(upper(rs.getString(2)));
+            }
+        }
+        return byTable;
+    }
+
+    /** 表名 -> 索引列表，列按 ORDINAL_POSITION 排好序。 */
+    private Map<String, List<ActualIndex>> actualIndexes() throws Exception {
+        Map<String, Map<String, List<String>>> columnsByTableAndIndex = new LinkedHashMap<>();
+        Map<String, Map<String, Boolean>> uniqueByTableAndIndex = new LinkedHashMap<>();
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet rs = statement.executeQuery(
+                     "SELECT ic.TABLE_NAME, ic.INDEX_NAME, ic.COLUMN_NAME, i.INDEX_TYPE_NAME "
+                             + "FROM INFORMATION_SCHEMA.INDEX_COLUMNS ic "
+                             + "JOIN INFORMATION_SCHEMA.INDEXES i "
+                             + "  ON i.INDEX_SCHEMA = ic.INDEX_SCHEMA "
+                             + " AND i.TABLE_NAME = ic.TABLE_NAME "
+                             + " AND i.INDEX_NAME = ic.INDEX_NAME "
+                             + "WHERE ic.TABLE_SCHEMA = 'PUBLIC' "
+                             + "ORDER BY ic.TABLE_NAME, ic.INDEX_NAME, ic.ORDINAL_POSITION")) {
+            while (rs.next()) {
+                String table = upper(rs.getString(1));
+                String index = upper(rs.getString(2));
+                columnsByTableAndIndex
+                        .computeIfAbsent(table, k -> new LinkedHashMap<>())
+                        .computeIfAbsent(index, k -> new ArrayList<>())
+                        .add(upper(rs.getString(3)));
+                uniqueByTableAndIndex
+                        .computeIfAbsent(table, k -> new LinkedHashMap<>())
+                        .put(index, upper(rs.getString(4)).contains("UNIQUE"));
+            }
+        }
+
+        Map<String, List<ActualIndex>> byTable = new LinkedHashMap<>();
+        columnsByTableAndIndex.forEach((table, perIndex) -> {
+            List<ActualIndex> indexes = new ArrayList<>();
+            perIndex.forEach((index, columns) ->
+                    indexes.add(new ActualIndex(index, columns, uniqueByTableAndIndex.get(table).get(index))));
+            byTable.put(table, indexes);
+        });
+        return byTable;
+    }
+
+    private static String upper(String value) {
+        return value == null ? "" : value.toUpperCase(Locale.ROOT);
+    }
+
+    private static List<String> upper(List<String> values) {
+        return values.stream().map(EntityIndexColumnNamingTest::upper).toList();
+    }
+
+    // ---------- 断言 ----------
+
+    @Test
+    void 索引里声明的列名必须是真实存在的物理列() throws Exception {
+        Map<String, Set<String>> columns = physicalColumns();
+
+        List<String> problems = new ArrayList<>();
+        for (DeclaredIndex declared : declaredIndexes()) {
+            Set<String> actual = columns.get(upper(declared.table()));
+            if (actual == null) {
+                problems.add(declared.describe() + "：表 " + declared.table() + " 没建出来");
+                continue;
+            }
+            for (String column : declared.columns()) {
+                if (!actual.contains(upper(column))) {
+                    problems.add(declared.describe() + "：列 \"" + column + "\" 在表 " + declared.table()
+                            + " 里不存在（该表实际列 " + actual + "）"
+                            + "——@Table 的 indexes/uniqueConstraints 要写 snake_case 物理列名，不是 Java 驼峰字段名");
+                }
+            }
+        }
+        assertTrue(problems.isEmpty(), "以下索引声明引用了不存在的列：\n  " + String.join("\n  ", problems));
+    }
+
+    @Test
+    void 声明的索引与唯一约束在H2上真的建出来了() throws Exception {
+        Map<String, List<ActualIndex>> indexes = actualIndexes();
+
+        List<String> problems = new ArrayList<>();
+        for (DeclaredIndex declared : declaredIndexes()) {
+            List<ActualIndex> actual = indexes.getOrDefault(upper(declared.table()), List.of());
+            List<String> wanted = upper(declared.columns());
+
+            // 按列组合对账而不是按名字：H2 会把 UNIQUE 约束的背书索引改名成 XXX_INDEX_B。
+            ActualIndex hit = actual.stream()
+                    .filter(index -> index.columns().equals(wanted))
+                    .findFirst()
+                    .orElse(null);
+
+            if (hit == null) {
+                problems.add(declared.describe() + "：表 " + declared.table() + " 上没有覆盖 " + wanted
+                        + " 的索引（实际索引 " + actual.stream().map(ActualIndex::columns).toList() + "）");
+            } else if (declared.unique() && !hit.unique()) {
+                problems.add(declared.describe() + "：声明了 unique，实际索引 " + hit.name() + " 不是唯一索引");
+            }
+        }
+        assertTrue(problems.isEmpty(), "以下索引没有在 H2 上建出来：\n  " + String.join("\n  ", problems));
+    }
+}


### PR DESCRIPTION
## 背景

`@Table` 的 `indexes` / `uniqueConstraints` 里写的是**物理列名**，不参与 PhysicalNamingStrategy 的驼峰转换。本仓没配自定义命名策略，用的是 Spring Boot 默认的 `CamelCaseToUnderscoresNamingStrategy`（字段 `projectId` 落成列 `project_id`），所以这两处必须写 snake_case。

全仓扫了一遍 `@Index(columnList=...)` 与 `@UniqueConstraint(columnNames=...)`，共 20 处声明，其中 8 处写成了 Java 驼峰字段名。

## 改了什么

| 实体 | 表 | 原 | 现 |
|---|---|---|---|
| `AccountBinding` | `account_binding` | `externalAccountId` | `external_account_id` |
| `DeviceToken` | `device_token` | `tokenHash` | `token_hash` |
| `DocFileLink` | `doc_file_link` | `projectId,linkKey` | `project_id,link_key` |
| `FileTag` | `project_file_tag` | `fileId, tagId` | `file_id, tag_id` |
| `PlatformAiKey` | `platform_ai_key` | `userId` | `user_id` |
| `ProjectRemote` | `project_remote` | `projectId` | `project_id` |
| `Tag` | `project_tag` | `projectId, name` | `project_id, name` |
| `UserSession` | `user_session` | `tokenHash` | `token_hash` |

另外 12 处（`MemoryEntry` 6 条、`MemoryRemote`、`TelemetryEvent`、`TelemetryDailyRollup`、`FileVariable`、`ProjectVariable`、`ProjectMember`、`UserVariable`）本来就是 snake_case，未改动。

## 一个需要更正的前提：这 8 处此前并没有把索引建错

立项时的判断是「写驼峰会建错索引或建不出来，只是悄悄变慢」。实测下来**不成立**，这里如实记录：

Hibernate 6.4.4 在 `InFlightMetadataCollectorImpl#buildUniqueKeyFromColumnNames` 里会先把 `columnList` / `columnNames` 的每一项**当逻辑名**查一次映射表。字段 `projectId` 的逻辑名恰好就是 `projectId`、物理名是 `project_id`，于是驼峰写法侥幸能解析成正确的物理列，索引其实一直是建对的。

改前改后各跑一次建表，抓 Hibernate 实际发出的 DDL 对比，**16 条语句逐字节一致**：

```
create table account_binding ... unique (external_account_id)
create table doc_file_link   ... unique (project_id, link_key)
create table project_tag     ... unique (project_id, name)
...
```

所以这是一处**声明写法错误 + 潜在风险**，不是正在发生的线上故障。仍然值得改，因为它依赖的是没有文档保证的逻辑名回退：一旦解析不到（Hibernate 升级改了这段、或者某个字段加了与字段名不同的 `@Column(name=...)`），Hibernate 会把字符串**原样**塞进 DDL。实测了这条失败路径（临时把 `Tag` 的约束列改成一个不存在的列名）：

```
WARN o.h.t.s.i.ExceptionHandlerLoggedImpl : GenerationTarget encountered exception accepting command :
  Error executing DDL "create table project_tag (... unique (totally_bogus_column, name))" via JDBC
  [Column "TOTALLY_BOGUS_COLUMN" not found;]
```

注意后果比「少一个索引」严重得多：`@UniqueConstraint` 是**内联在 `create table` 里**的，整条建表语句失败，而 Hibernate 只打一行 WARN 就继续启动——**表根本没建出来，应用启动看着完全正常，第一次查询才炸**。（独立的 `@Index` 走单独的 `create index`，失败才只是少个索引、悄悄变慢。）

## 存量库的影响

`ddl-auto: update` **只加不删**：它既不会删除已存在的索引，也不会去纠正建歪的索引。所以：

- **本 PR 涉及的这 8 处：预期无残留**。上面已实测改前改后 DDL 完全一致，说明历史上各环境建出来的就是 `unique (project_id, link_key)` 这类正确形态，本 PR 不改变任何一条建表语句，也不会产生新旧两份索引。
- **但这条不能只靠推断**。DDL 一致是在 Hibernate 6.4.4 / H2 上验的；本项目历史上跨过多个 Spring Boot 版本，prod 是 MySQL8、default/cloud 是 PostgreSQL、桌面打包态是 H2，早期版本在哪个库上留下过什么，代码里看不出来。上线前建议在 prod 的 MySQL8 和 cloud 的 PostgreSQL 上各查一次，确认没有以驼峰列名或重复列组合存在的残留索引：

MySQL8：

```sql
SELECT TABLE_NAME, INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS COLS, NON_UNIQUE
FROM INFORMATION_SCHEMA.STATISTICS
WHERE TABLE_SCHEMA = DATABASE()
  AND TABLE_NAME IN ('account_binding','device_token','doc_file_link','project_file_tag',
                     'platform_ai_key','project_remote','project_tag','user_session')
GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE
ORDER BY TABLE_NAME, INDEX_NAME;
```

PostgreSQL：

```sql
SELECT tablename, indexname, indexdef
FROM pg_indexes
WHERE schemaname = 'public'
  AND tablename IN ('account_binding','device_token','doc_file_link','project_file_tag',
                    'platform_ai_key','project_remote','project_tag','user_session')
ORDER BY tablename, indexname;
```

判读口径：每张表对同一列组合应当只有一条唯一索引。若查到列名带驼峰（如 `projectId`）或同一列组合有两条索引，就是历史残留，需要手工 `DROP INDEX`——`ddl-auto: update` 不会替你清理。

## 测试

新增 `backend/src/test/java/com/checkba/repository/EntityIndexColumnNamingTest.java`（H2 内存库，`MODE=PostgreSQL`，配方照抄 `WorkSessionRepositoryTest`）。两条断言：

1. `索引里声明的列名必须是真实存在的物理列` —— 对着 `INFORMATION_SCHEMA.COLUMNS` 查每一个声明的列名。
2. `声明的索引与唯一约束在H2上真的建出来了` —— 对着 `INFORMATION_SCHEMA.INDEX_COLUMNS` + `INDEXES` 查索引是否真的覆盖了那组列，声明 `unique` 的还要真是唯一索引。

两个设计取舍：

- **反射扫全部 `@Entity`，不硬编码清单**：将来新加实体写错驼峰会自动红，不需要有人记得回来补这张表。
- **按列组合对账，不按索引名**：H2 会把 UNIQUE 约束的背书索引改名成 `IDX_XXX_INDEX_B`，按名字对账会假红。

先在未修复的代码上跑过（RED），两条断言都红并逐条点名 8 处问题；修复后转绿。

## 验证

- `mvn test`：**1559 通过 / 0 失败 / 3 跳过**，BUILD SUCCESS（JDK 21）。
- 同一 PR 内按 CLAUDE.md 的维护规则，把这条地雷补进了 `.claude/agents/eng-infra.md`。
