### PR TITLE
ci: surefire fork 信道切 TCP，躲开 stdout 污染的假 BUILD FAILURE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
         # 零断言失败也算 BUILD FAILURE），2026-08-14 一天在 Linux runner 上撞了两次，
         # 两次都死在同一位置附近、重跑又过。TCP 信道对 stdout 污染免疫。
         run: mvn -B test -Dsurefire.forkNode.factory=org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory
+      - name: Dump surefire fork diagnostics on failure
+        if: failure()
+        working-directory: backend
+        # fork JVM 静默死亡（退出码 0、零断言失败）时，唯一的现场证据在 dumpstream：
+        # 里面有写进信道的原始脏字节与 fork 侧异常。不上传 artifact，直接打进日志。
+        run: |
+          for f in target/surefire-reports/*.dumpstream target/surefire-reports/*.dump; do
+            [ -f "$f" ] || continue
+            echo "===== $f ====="
+            head -c 20000 "$f" | LC_ALL=C tr -c '[:print:]\n\t' '.'
+            echo
+          done
 
   frontend:
     name: Frontend (build:h5)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
           cache: maven
       - name: Test
         working-directory: backend
-        run: mvn -B test
+        # forkNode 走 TCP 而不是默认的 stdout 管道：套件里有测试进程往 native stdout
+        # 吐脏字节（surefire 报 Corrupted channel），管道模式下 fork 信道被污染，
+        # surefire 误判 "VM terminated without properly saying goodbye"（退出码 0、
+        # 零断言失败也算 BUILD FAILURE），2026-08-14 一天在 Linux runner 上撞了两次，
+        # 两次都死在同一位置附近、重跑又过。TCP 信道对 stdout 污染免疫。
+        run: mvn -B test -Dsurefire.forkNode.factory=org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory
 
   frontend:
     name: Frontend (build:h5)


### PR DESCRIPTION
master 与 PR 的 Backend job 今天两次死于同款假失败：测试零断言失败、fork JVM 退出码 0，surefire 因 stdout 管道信道被 native 脏字节污染而误判 VM 失联。forkNode 切 TCP 后信道与 stdout 解耦。desktop-build 打包链全程 -DskipTests，不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)