### PR TITLE
feat: 应用语言设置基建（EN 版 PR1/6：zh-CN/en-US 底座 + LOWA/菜单切换）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AppLanguageController.java
+++ b/backend/src/main/java/com/checkba/controller/AppLanguageController.java
@@ -1,0 +1,45 @@
+package com.checkba.controller;
+
+import com.checkba.service.AppLanguageService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 应用语言设置。鉴权口径同 TelemetryController：GET 无鉴权（启动链在登录前就要读），
+ * POST 要求登录（桌面 local-mode 自动解析为本机用户，非 admin 也可改——语言是
+ * 每个用户都该能改的设置，刻意不走 /api/admin/config 的 requireAdmin 通道）。
+ */
+@RestController
+@RequestMapping("/api/app")
+@RequiredArgsConstructor
+public class AppLanguageController {
+
+    private final AppLanguageService appLanguage;
+
+    @GetMapping("/language")
+    public Map<String, Object> getLanguage() {
+        Map<String, Object> r = new HashMap<>();
+        r.put("code", 0);
+        r.put("language", appLanguage.language());
+        return r;
+    }
+
+    @PostMapping("/language")
+    public Map<String, Object> setLanguage(
+            @RequestBody LanguageRequest request,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) throw new IllegalArgumentException("未登录");
+        appLanguage.setLanguage(request == null ? null : request.getLanguage());
+        return getLanguage();
+    }
+
+    @Data
+    public static class LanguageRequest {
+        private String language;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/AppLanguageService.java
+++ b/backend/src/main/java/com/checkba/service/AppLanguageService.java
@@ -1,0 +1,41 @@
+package com.checkba.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+/**
+ * 应用语言（zh-CN / en-US）。单机产品是全局设置：前端语言设置写透到这里，
+ * 后端凡是产出用户可见文案 / 选择 system prompt 语言的地方统一从这里取值。
+ * 默认 zh-CN——存量安装升级后行为不变；英文默认值由前端首启猜测后写入。
+ */
+@Service
+@RequiredArgsConstructor
+public class AppLanguageService {
+
+    public static final String KEY = "app.language";
+    public static final String ZH_CN = "zh-CN";
+    public static final String EN_US = "en-US";
+    private static final Set<String> SUPPORTED = Set.of(ZH_CN, EN_US);
+
+    private final SystemSettingService settings;
+
+    public String language() {
+        String v = settings.get(KEY, ZH_CN);
+        // Set.of 的 contains(null) 会抛 NPE，先挡掉 null
+        return v != null && SUPPORTED.contains(v) ? v : ZH_CN;
+    }
+
+    public boolean isEnglish() {
+        return EN_US.equals(language());
+    }
+
+    /** 非法值静默忽略（保持现语言），返回生效值。 */
+    public String setLanguage(String lang) {
+        if (lang != null && SUPPORTED.contains(lang)) {
+            settings.set(KEY, lang);
+        }
+        return language();
+    }
+}

--- a/backend/src/test/java/com/checkba/service/AppLanguageServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/AppLanguageServiceTest.java
@@ -1,0 +1,47 @@
+package com.checkba.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class AppLanguageServiceTest {
+
+    private final SystemSettingService settings = mock(SystemSettingService.class);
+    private final AppLanguageService service = new AppLanguageService(settings);
+
+    @Test
+    void defaultsToChineseWhenUnset() {
+        when(settings.get(eq(AppLanguageService.KEY), eq(AppLanguageService.ZH_CN)))
+                .thenReturn(AppLanguageService.ZH_CN);
+        assertEquals("zh-CN", service.language());
+        assertFalse(service.isEnglish());
+    }
+
+    @Test
+    void invalidStoredValueFallsBackToChinese() {
+        when(settings.get(eq(AppLanguageService.KEY), eq(AppLanguageService.ZH_CN)))
+                .thenReturn("fr-FR");
+        assertEquals("zh-CN", service.language());
+    }
+
+    @Test
+    void setPersistsSupportedLanguage() {
+        when(settings.get(eq(AppLanguageService.KEY), eq(AppLanguageService.ZH_CN)))
+                .thenReturn(AppLanguageService.EN_US);
+        String effective = service.setLanguage("en-US");
+        verify(settings).set(AppLanguageService.KEY, "en-US");
+        assertEquals("en-US", effective);
+        assertTrue(service.isEnglish());
+    }
+
+    @Test
+    void setIgnoresUnsupportedLanguage() {
+        when(settings.get(eq(AppLanguageService.KEY), eq(AppLanguageService.ZH_CN)))
+                .thenReturn(AppLanguageService.ZH_CN);
+        service.setLanguage("ja-JP");
+        service.setLanguage(null);
+        verify(settings, never()).set(anyString(), anyString());
+    }
+}

--- a/desktop/main/app-language.js
+++ b/desktop/main/app-language.js
@@ -1,0 +1,63 @@
+// 应用语言（zh-CN / en-US）在主进程侧的持久化与订阅。
+// 权威源是渲染层的语言设置（uni storage + 后端 system_setting），这里只是主进程的
+// 本地镜像：菜单/系统通知/原生对话框在渲染层就绪之前就要用到语言，所以落一份
+// userData/app-language.json；渲染层启动或用户切换语言时经 'checkba:set-app-language'
+// 同步过来并触发订阅方（如应用菜单重建）。
+// 首启猜测只看 app.getLocale()（zh* → zh-CN，其余 en-US）——与渲染层
+// utils/appLanguage.js 的全新安装分支同一条规则，两侧猜测结果一致；
+// 存量安装的保护（有使用痕迹默认 zh-CN）由渲染层判定后立刻同步覆盖到这里。
+
+const { app } = require('electron')
+const fs = require('fs')
+const path = require('path')
+
+const SUPPORTED = ['zh-CN', 'en-US']
+
+let current = null
+const listeners = []
+
+function storeFile() {
+  return path.join(app.getPath('userData'), 'app-language.json')
+}
+
+function guessFromSystem() {
+  let loc = ''
+  try { loc = String(app.getLocale() || '') } catch (e) { /* before ready 会抛，按空处理 */ }
+  return loc.toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US'
+}
+
+function getAppLanguage() {
+  if (current) return current
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storeFile(), 'utf8'))
+    if (SUPPORTED.includes(parsed && parsed.language)) current = parsed.language
+  } catch (e) { /* 首启无文件 */ }
+  if (!current) current = guessFromSystem()
+  return current
+}
+
+function setAppLanguage(lang) {
+  if (!SUPPORTED.includes(lang)) return getAppLanguage()
+  const changed = lang !== current
+  current = lang
+  try {
+    fs.writeFileSync(storeFile(), JSON.stringify({ language: lang }), 'utf8')
+  } catch (e) { console.warn('[app-language] persist failed:', e && e.message) }
+  if (changed) {
+    for (const fn of listeners) {
+      try { fn(lang) } catch (e) { /* ignore */ }
+    }
+  }
+  return current
+}
+
+function onAppLanguageChange(fn) {
+  if (typeof fn === 'function') listeners.push(fn)
+}
+
+// 主进程文案取值：t({ zh: '…', en: '…' })
+function t(pair) {
+  return getAppLanguage() === 'en-US' ? pair.en : pair.zh
+}
+
+module.exports = { getAppLanguage, setAppLanguage, onAppLanguageChange, t, SUPPORTED }

--- a/desktop/main/app-menu.js
+++ b/desktop/main/app-menu.js
@@ -3,8 +3,10 @@
 // 「最近打开」子菜单由渲染层经 'checkba:recent-projects' 推送后整体重建。
 // 注意：窗口子菜单刻意不含 close 角色——Cmd+W 留给渲染层「关闭当前标签」（IDE 语义），
 // 不能让菜单加速器抢走它去关整个窗口。
+// 菜单文案随应用语言（app-language.js）双语；语言切换经 onAppLanguageChange 整体重建。
 
 const { app, Menu, ipcMain } = require('electron')
+const { t, onAppLanguageChange } = require('./app-language')
 
 let getWindow = () => null
 let recentProjects = []
@@ -18,56 +20,56 @@ function send(action, payload) {
 function buildTemplate() {
   const recentSubmenu = recentProjects.length
     ? recentProjects.map((r) => ({
-        label: String(r.name || ('项目 ' + r.id)),
+        label: String(r.name || (t({ zh: '项目 ', en: 'Project ' }) + r.id)),
         click: () => send('open-recent', { projectId: r.id }),
       }))
-    : [{ label: '暂无最近项目', enabled: false }]
+    : [{ label: t({ zh: '暂无最近项目', en: 'No Recent Projects' }), enabled: false }]
 
   return [
     {
       label: app.name,
       submenu: [
-        { role: 'about', label: '关于 ' + app.name },
+        { role: 'about', label: t({ zh: '关于 ', en: 'About ' }) + app.name },
         { type: 'separator' },
-        { role: 'hide', label: '隐藏 ' + app.name },
-        { role: 'hideOthers', label: '隐藏其他' },
-        { role: 'unhide', label: '全部显示' },
+        { role: 'hide', label: t({ zh: '隐藏 ', en: 'Hide ' }) + app.name },
+        { role: 'hideOthers', label: t({ zh: '隐藏其他', en: 'Hide Others' }) },
+        { role: 'unhide', label: t({ zh: '全部显示', en: 'Show All' }) },
         { type: 'separator' },
-        { role: 'quit', label: '退出 ' + app.name },
+        { role: 'quit', label: t({ zh: '退出 ', en: 'Quit ' }) + app.name },
       ],
     },
     {
-      label: '文件',
+      label: t({ zh: '文件', en: 'File' }),
       submenu: [
-        { label: '打开文件夹…', accelerator: 'CmdOrCtrl+O', click: () => send('open-folder') },
-        { label: '打开文件…', accelerator: 'CmdOrCtrl+Shift+O', click: () => send('open-file') },
-        { label: '新建项目文件夹…', accelerator: 'CmdOrCtrl+Shift+N', click: () => send('create-folder') },
+        { label: t({ zh: '打开文件夹…', en: 'Open Folder…' }), accelerator: 'CmdOrCtrl+O', click: () => send('open-folder') },
+        { label: t({ zh: '打开文件…', en: 'Open File…' }), accelerator: 'CmdOrCtrl+Shift+O', click: () => send('open-file') },
+        { label: t({ zh: '新建项目文件夹…', en: 'New Project Folder…' }), accelerator: 'CmdOrCtrl+Shift+N', click: () => send('create-folder') },
         { type: 'separator' },
-        { label: '最近打开', submenu: recentSubmenu },
+        { label: t({ zh: '最近打开', en: 'Open Recent' }), submenu: recentSubmenu },
       ],
     },
     // 标准编辑角色：mac 上没有它，所有输入框的 Cmd+C/V/X/Z 全部失灵
-    { label: '编辑', role: 'editMenu' },
+    { label: t({ zh: '编辑', en: 'Edit' }), role: 'editMenu' },
     {
-      label: '视图',
+      label: t({ zh: '视图', en: 'View' }),
       submenu: [
-        { role: 'reload', label: '重新加载' },
-        { role: 'toggleDevTools', label: '开发者工具' },
+        { role: 'reload', label: t({ zh: '重新加载', en: 'Reload' }) },
+        { role: 'toggleDevTools', label: t({ zh: '开发者工具', en: 'Developer Tools' }) },
         { type: 'separator' },
-        { role: 'resetZoom', label: '实际大小' },
-        { role: 'zoomIn', label: '放大' },
-        { role: 'zoomOut', label: '缩小' },
+        { role: 'resetZoom', label: t({ zh: '实际大小', en: 'Actual Size' }) },
+        { role: 'zoomIn', label: t({ zh: '放大', en: 'Zoom In' }) },
+        { role: 'zoomOut', label: t({ zh: '缩小', en: 'Zoom Out' }) },
         { type: 'separator' },
-        { role: 'togglefullscreen', label: '全屏' },
+        { role: 'togglefullscreen', label: t({ zh: '全屏', en: 'Toggle Full Screen' }) },
       ],
     },
     {
-      label: '窗口',
+      label: t({ zh: '窗口', en: 'Window' }),
       submenu: [
-        { role: 'minimize', label: '最小化' },
-        { role: 'zoom', label: '缩放' },
+        { role: 'minimize', label: t({ zh: '最小化', en: 'Minimize' }) },
+        { role: 'zoom', label: t({ zh: '缩放', en: 'Zoom' }) },
         { type: 'separator' },
-        { role: 'front', label: '前置全部窗口' },
+        { role: 'front', label: t({ zh: '前置全部窗口', en: 'Bring All to Front' }) },
       ],
     },
   ]
@@ -80,6 +82,7 @@ function rebuild() {
 function initAppMenu(mainWindowGetter) {
   getWindow = mainWindowGetter
   rebuild()
+  onAppLanguageChange(() => rebuild())
   ipcMain.on('checkba:recent-projects', (event, list) => {
     recentProjects = Array.isArray(list)
       ? list.filter((r) => r && r.id).slice(0, 8)

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -397,7 +397,7 @@ function createMainWindow() {
   mainWindow.webContents.session.on('will-download', (event, item, webContents) => {
     // Set options for the save dialog
     item.setSaveDialogOptions({
-      title: '保存文件',
+      title: require('./app-language').t({ zh: '保存文件', en: 'Save File' }),
       defaultPath: item.getFilename() // Use the default filename suggestion
     })
     // Note: If item.setSavePath() is NOT called, Electron implicitly shows the dialog 
@@ -740,7 +740,7 @@ function ensureView(id) {
 
       const menu = Menu.buildFromTemplate([
         {
-          label: '加入网核收藏',
+          label: require('./app-language').t({ zh: '加入网核收藏', en: 'Save to Web Research Favorites' }),
           click: async () => {
             try {
               const url = params.pageURL ? String(params.pageURL) : ''
@@ -1154,10 +1154,11 @@ ipcMain.handle('checkba:shell-open-external', async (_evt, payload) => {
 // 桌面端：统一的“应用内确认弹窗”（不依赖 uni.showModal，且不会被 BrowserView/iframe 遮挡）
 ipcMain.handle('checkba:ui-confirm', async (_evt, payload) => {
   if (!mainWindow) return { ok: false, confirmed: false, message: 'window not ready' }
-  const title = payload && payload.title ? String(payload.title) : '确认'
+  const { t: tL } = require('./app-language')
+  const title = payload && payload.title ? String(payload.title) : tL({ zh: '确认', en: 'Confirm' })
   const content = payload && payload.content ? String(payload.content) : ''
-  const okText = payload && payload.okText ? String(payload.okText) : '确定'
-  const cancelText = payload && payload.cancelText ? String(payload.cancelText) : '取消'
+  const okText = payload && payload.okText ? String(payload.okText) : tL({ zh: '确定', en: 'OK' })
+  const cancelText = payload && payload.cancelText ? String(payload.cancelText) : tL({ zh: '取消', en: 'Cancel' })
 
   const reqId = `confirm_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
   const resultChannel = `checkba:ui-confirm-result:${reqId}`
@@ -1336,7 +1337,13 @@ async function ensurePysvcReady() {
     console.error('[pysvc] extract failed:', result.message)
     try {
       const { dialog } = require('electron')
-      dialog.showErrorBox('本地组件解压失败', `部分本地功能（文档解析/PPT/语音）将不可用：\n${result.message || ''}`)
+      dialog.showErrorBox(
+        require('./app-language').t({ zh: '本地组件解压失败', en: 'Local Component Extraction Failed' }),
+        require('./app-language').t({
+          zh: `部分本地功能（文档解析/PPT/语音）将不可用：\n${result.message || ''}`,
+          en: `Some local features (document parsing/slides/voice) will be unavailable:\n${result.message || ''}`,
+        })
+      )
     } catch (e) { /* ignore */ }
   }
 }
@@ -1450,7 +1457,9 @@ ipcMain.handle('checkba:zetaoffice-editor', async () => {
   installZetaOfficeIsolation(ZETAOFFICE_PARTITION)
   const { origin } = await startEditorServer()
   return {
-    url: editorUrl(origin),
+    // LO 画布 UI 语言跟随应用语言；只影响新建的编辑器实例（保活池里已 boot 的
+    // 实例保持原语言，重启应用后全量生效）。
+    url: editorUrl(origin, { uilang: require('./app-language').getAppLanguage() }),
     preload: require('url').pathToFileURL(path.join(__dirname, '../preload/zetaoffice-webview-preload.js')).href,
     partition: ZETAOFFICE_PARTITION,
   }
@@ -1465,6 +1474,12 @@ ipcMain.handle('checkba:drawio-editor', async () => {
   if (!(await isAvailable())) return { available: false }
   const { origin } = await startDrawioServer()
   return { available: true, kind: 'iframe', origin, url: drawioUrl(origin) }
+})
+
+// 应用语言：渲染层是权威源（uni storage + 后端 system_setting），启动与切换时
+// send 过来；app-language.js 持久化并通知订阅方（应用菜单重建等）。
+ipcMain.on('checkba:app-language', (_evt, lang) => {
+  try { require('./app-language').setAppLanguage(String(lang || '')) } catch (e) { /* ignore */ }
 })
 
 // IDE 化：Finder「打开方式」/ 拖到 Dock 图标进来的路径（macOS open-file 事件，
@@ -1562,15 +1577,22 @@ app.whenReady().then(() => {
             // 非模态系统通知：补丁就绪 / 新大版本（设置页没开着也能看到）
             try {
               const { Notification } = require('electron')
+              const { t: tL } = require('./app-language')
               if (evt.type === 'ready' && Notification.isSupported()) {
                 new Notification({
-                  title: 'AI Workdeck 更新已就绪',
-                  body: `新版本 ${evt.version} 已下载完成，重启应用后生效。`
+                  title: tL({ zh: 'AI Workdeck 更新已就绪', en: 'AI Workdeck Update Ready' }),
+                  body: tL({
+                    zh: `新版本 ${evt.version} 已下载完成，重启应用后生效。`,
+                    en: `Version ${evt.version} has been downloaded. Restart the app to apply it.`,
+                  })
                 }).show()
               } else if (evt.type === 'major-available' && Notification.isSupported()) {
                 new Notification({
-                  title: 'AI Workdeck 新版本发布',
-                  body: `大版本 ${evt.major} 已发布，请前往官网下载完整安装包。`
+                  title: tL({ zh: 'AI Workdeck 新版本发布', en: 'New AI Workdeck Release' }),
+                  body: tL({
+                    zh: `大版本 ${evt.major} 已发布，请前往官网下载完整安装包。`,
+                    en: `Major version ${evt.major} is available. Download the full installer from the website.`,
+                  })
                 }).show()
               }
             } catch (e) { /* ignore */ }

--- a/desktop/main/zetaoffice-server.js
+++ b/desktop/main/zetaoffice-server.js
@@ -208,11 +208,14 @@ function startEditorServer() {
  * same-origin proxy (?lowa=); zeta.js / office_thread.js / cjk.ttc resolve to
  * their relative defaults served next to the page.
  * @param {string} origin e.g. http://127.0.0.1:54321
- * @param {{verify?:boolean}} [opts] verify=1 shows the standalone test panel.
+ * @param {{verify?:boolean, uilang?:string}} [opts] verify=1 shows the standalone
+ *   test panel; uilang 走 editor-main.js 的既有 ?uilang= 契约（LO 画布 UI 语言，
+ *   引擎双语资源已随包，缺省时 editor-main.js 落回 zh-CN）。
  */
 function editorUrl(origin, opts = {}) {
   const q = new URLSearchParams()
   if (opts.verify) q.set('verify', '1')
+  if (opts.uilang) q.set('uilang', opts.uilang)
   q.set('lowa', origin + '/lowa/')
   return origin + '/editor.html?' + q.toString()
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -100,7 +100,7 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false,
       "extendInfo": {
-        "NSMicrophoneUsageDescription": "反馈浮窗里的“说一段”需要用麦克风录下你的语音说明，录音只随这条反馈提交，不会在后台采集。"
+        "NSMicrophoneUsageDescription": "反馈浮窗里的“说一段”需要用麦克风录下你的语音说明，录音只随这条反馈提交，不会在后台采集。 The in-app feedback voice note uses the microphone to record your message; audio is only sent with that feedback and never captured in the background."
       },
       "notarize": {
         "teamId": "X9B97KVA84"

--- a/desktop/preload/preload.js
+++ b/desktop/preload/preload.js
@@ -162,6 +162,11 @@ contextBridge.exposeInMainWorld('checkbaDesktop', {
     },
     setRecentProjects: (list) => ipcRenderer.send('checkba:recent-projects', list)
   },
+  // 应用语言（zh-CN/en-US）：渲染层是权威源，启动与切换时推给主进程
+  // （菜单/原生对话框文案随之重建，见 desktop/main/app-language.js）。
+  appLanguage: {
+    set: (lang) => ipcRenderer.send('checkba:app-language', lang)
+  },
   // Epic #43: embedded LibreOffice editor <webview> wiring. getEditor() returns
   // { url, preload, partition } for the host to mount the webview.
   // （onOpenEmbed / ⌘⇧O 覆盖层已移除：内联编辑器就是产品默认。）

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,12 +2,28 @@
 import { getSessionId } from '@/utils/auth.js'
 import { openFolderFlow, openFileFlow, openLocalRootPath, openLocalFilePath } from '@/utils/ideOpen.js'
 import { track } from '@/utils/telemetryClient.js'
-import { host } from '@/services/host.js'
+import { host, isDesktopHost } from '@/services/host.js'
 import { mountFeedbackWidget } from '@/utils/feedbackWidget.js'
+import { getAppLanguage, APP_LANGUAGE_EVENT } from '@/utils/appLanguage.js'
+import { saveAppLanguageRemote } from '@/services/api.js'
 
 export default {
   onLaunch: function () {
     console.log('App Launch')
+    // 应用语言：最早读一次（首启在此完成猜测并持久化），并把镜像写透到
+    // 桌面主进程（菜单等原生文案）与后端 system_setting（prompt/文案语言）。
+    // 之后语言切换（设置页 setAppLanguage）经 APP_LANGUAGE_EVENT 走同一条同步链。
+    const syncLanguageMirrors = (lang) => {
+      try { if (host.appLanguage && host.appLanguage.set) host.appLanguage.set(lang) } catch (e) { /* ignore */ }
+      // fire-and-forget：后端没起来也不能拦启动，下次切换/启动会再补。
+      // 浏览器态未登录时不发——POST 会回「未登录」，request 包装器据此清会话
+      // 并 reLaunch 登录页，启动链会被这条后台同步搅乱；桌面 local-mode 恒可发。
+      if (isDesktopHost() || getSessionId()) {
+        try { saveAppLanguageRemote(lang).catch(() => {}) } catch (e) { /* ignore */ }
+      }
+    }
+    syncLanguageMirrors(getAppLanguage())
+    try { uni.$on(APP_LANGUAGE_EVENT, syncLanguageMirrors) } catch (e) { /* ignore */ }
     // 常驻反馈浮窗：挂在页面树之外，全应用一个实例（见 utils/feedbackWidget.js）
     mountFeedbackWidget()
     // 埋点：页面路由唯一收口（全仓 50 处 navigateTo/reLaunch 直调，拦截器一处全覆盖）；

--- a/frontend/src/locales/CONVENTIONS.md
+++ b/frontend/src/locales/CONVENTIONS.md
@@ -1,0 +1,45 @@
+# 前端 i18n 迁移约定（翻译/抽取工作的执行基准）
+
+与 glossary.md 配套：glossary 管「译成什么」，本文管「怎么抽、怎么接线」。
+
+## 架构
+
+- vue-i18n 9（legacy 模式）在 `src/i18n/index.js` 创建，`main.js` 里 `app.use(i18n)`。
+- locale 文件按命名空间分文件：`src/locales/zh-CN/<ns>.js` 与 `src/locales/en-US/<ns>.js`，
+  各自 `export default { key: '...' }`；`src/locales/zh-CN/index.js` 聚合。
+  **两种语言的同名文件键集合必须完全一致**（校验脚本会对拍）。
+- 组件内：模板 `{{ $t('ns.key') }}`、属性 `:placeholder="$t('ns.key')"`、脚本 `this.$t('ns.key')`。
+- 非组件 JS（utils/composables/config/services）：`import { t } from '@/i18n'`。
+- 语言切换 = 整页 reload（admin.vue 语言项触发）。因此模块加载期取值（config 里的
+  label 数组等）是安全的，可以直接在模块顶层调 `t()`。
+- 语言判定唯一来源 `utils/appLanguage.js`；**禁止** uni.getLocale()/navigator.language。
+
+## 抽取范围（什么算用户可见）
+
+要抽：模板文本节点、placeholder/title/confirmText 等属性、uni.showToast/showModal 文案、
+错误提示、状态文案、config 的 label/description、Date 格式里的中文（「今天/昨天」等）。
+
+不抽（保持原样）：
+- console.log / console.warn / console.error 与注释（注释保持中文）。
+- 埋点事件名与属性值、API 字段值、storage 键、CSS 类名、e2e 锚点类名。
+- 后端返回的动态 message（透传显示，后端侧另行处理）。
+- 用户数据（文件名、项目名、文档内容）。
+- `glossary.md` 里标注「不译」的品牌名。
+
+## 键名
+
+- `<ns>.<camelCaseKey>`，ns 与文件对应（如 `fileTree.deleteConfirm`）。
+- 完整句子一个键，不拼接碎片。变量用具名插值：`{ count }`、`{ name }`。
+  - zh: `已选中 {count} 个文件` / en: `{count} files selected`
+- vue-i18n 消息语法转义：文案里的字面量 `@` `|` `{` `}` 要写成 `{'@'}` 形式。
+
+## 翻译
+
+- 一律以 `glossary.md` 为准；未收录术语先补 glossary 再用。
+- Title Case 用于短标签（按钮/菜单/栏目），sentence case 用于句子提示。
+- 禁 emoji。en 文案不得出现中文标点（，。：「」）。
+
+## 验证
+
+每片改完必须：`npm run check:emits` 通过；改动文件无漏抽的用户可见中文
+（grep 中文后逐条核对是否属于「不抽」清单）；键对拍脚本通过。

--- a/frontend/src/locales/glossary.md
+++ b/frontend/src/locales/glossary.md
@@ -1,0 +1,151 @@
+# AI Workdeck 法律领域 zh→en 术语表（翻译唯一基准）
+
+所有 UI/文案/prompt 的中英翻译以本表为准。新增术语先加进本表再用。
+维护规则：改动产品名词的英文叫法 = 契约变更，PR 里同步更新本表与受影响的 locale 键。
+
+## 全局风格约定
+
+- 语体：American English。界面短标签（菜单/按钮/栏目名）用 Title Case；句子式提示、toast、错误信息用 sentence case。
+- 禁 emoji（全局红线）。
+- 法域口径：英文版是 jurisdiction-neutral 的国际商事/通用法律助手，不预设中国大陆法条；"法条" 一律译 statutory provision / legal provision，不写 "PRC law" 除非内容本身如此。
+- 品牌名不译：AI Workdeck。"AI Workdeck 云端" → AI Workdeck Cloud。
+
+## 产品结构名词
+
+| 中文 | English | 备注 |
+|---|---|---|
+| 工作台 | Workbench | 四列干活界面（路由 project-overview） |
+| 项目概览页 | Project Overview | 路由 project-home |
+| 项目列表页 | Projects | 路由 project-list；"全部项目" → All Projects |
+| 项目 | Project | |
+| 案卷 | Case File | 协作语境；单份工作文档集 |
+| 团队案件库 | Team Case Library | |
+| 案件参与人 | Case Members | |
+| 暂存区 | Staging Area | |
+| 左栏/侧边栏 | Sidebar | |
+| 底部工具抽屉 | Tools Panel | |
+| AI 面板 | AI Panel | |
+| 资源管理器（文件树） | Explorer | 对齐 VS Code 惯例 |
+| 变量库 | Variable Library | |
+| 收藏夹 | Favorites | |
+| 剪贴板 | Clipboard | |
+| 浏览器面板 | Browser | |
+| 插件广场 | Plugin Marketplace | |
+| 插件 | Plugin | |
+| 技能 | Skill | |
+| 组件管理 | Components | 模型/组件下载 |
+| 系统设置 | Settings | admin 页 |
+| 个人中心 | Profile | |
+| 工作记录 | Activity Log | |
+| 代办/待办 | To-dos | |
+| 向导 | Setup Wizard | |
+| 解锁 | Unlock | |
+| 试用码 | Trial Code | |
+| 额度 | Credits | 站内唯一计价单位，不译成 quota |
+| 平台通道（AI Workdeck 云端） | AI Workdeck Cloud | |
+| 自备 Key | Your Own Key (BYOK) | |
+| 网络区域 | Network Region | 境内 → Mainland China；国际 → International |
+
+## 文档编辑
+
+| 中文 | English | 备注 |
+|---|---|---|
+| 修订 | Tracked Changes | LO/Word 语义；单条修订 → a tracked change / revision |
+| 修订模式 | Track Changes | |
+| 页边修订 | Changes in Margin | |
+| 批注 | Comment | |
+| 审阅面板 | Review Panel | |
+| 接受/拒绝（修订） | Accept / Reject | 全部接受 → Accept All |
+| 标记解决（批注） | Resolve | |
+| 检查点 | Checkpoint | AI 改文档前的还原点 |
+| 自动保存 | Autosave | |
+| 只读预览 | Read-only Preview | |
+| 版本记录 | Version History | |
+| 工作段 | Work Session | |
+| 时间线 | Timeline | |
+| 退回（版本） | Revert | |
+| 丢弃工作 | Discard Changes | |
+| 另起一稿 | New Draft | |
+| 采纳（稿） | Adopt | 采纳-放弃-冲突三选一：Adopt / Discard / Resolve Conflict |
+| 交稿 | Submit Draft | 协作 |
+| 取回最新稿 | Pull Latest | 协作 |
+| 脱敏 | Redaction | 动词 redact |
+| 套红/公文格式 | House Style Formatting | |
+| 书签 | Bookmark | |
+| 正文 | Body Text | |
+
+## 法律业务
+
+| 中文 | English | 备注 |
+|---|---|---|
+| 尽调 | Due Diligence | 尽调文件 → Due Diligence Files |
+| 股东大会核查 | Shareholder Meeting Verification | 英文版隐藏该技能（中国法深度绑定） |
+| 合同审查 | Contract Review | |
+| 律师函 | Demand Letter | 泛指也可 Legal Letter |
+| 法律意见书 | Legal Opinion | |
+| 尽调报告 | Due Diligence Report | |
+| 庭审 | Hearing | 泛指；正式庭审 trial |
+| 诉讼 | Litigation | |
+| 诉讼可视化 | Litigation Visualization | |
+| 时间轴（诉讼） | Timeline | |
+| 流程图 | Flowchart | |
+| 当事人关系图 | Party Relationship Map | |
+| 当事人 | Party | 复数 parties |
+| 委托人/客户 | Client | |
+| 客户视图 | Client View | |
+| 甲方/乙方 | Party A / Party B | 合同变量场景保留原文语义 |
+| 标的公司 | Target Company | |
+| 上市公司 | Listed Company | |
+| 交易结构 | Transaction Structure | |
+| 法条/法律依据 | Legal Provision / Legal Basis | 不预设法域 |
+| 证据 | Evidence | |
+| 案由 | Cause of Action | |
+| 卷宗 | Case Bundle | |
+
+## AI 对话与编排
+
+| 中文 | English | 备注 |
+|---|---|---|
+| 对话 | Conversation | 新对话 → New Conversation |
+| 助手 | Assistant | |
+| 模式（问答/计划/代理） | Mode: Ask / Plan / Agent | |
+| 计划审批 | Plan Approval | 按此推进 → Proceed；修订（计划） → Revise |
+| 反问/追问 | Clarifying Question | 状态"待回答" → Awaiting Your Reply |
+| 待审批 | Awaiting Approval | |
+| 子任务 | Subtask | |
+| 后台任务 | Background Task | |
+| 过程卡/执行过程 | Steps | 折叠组标题；单条工具行显示工具名 |
+| 思考 | Thinking | |
+| 继续 | Resume | 中断恢复按钮 |
+| 停止 | Stop | |
+| 限流等待中 | Rate limited, waiting to retry | |
+| 记忆 | Memory | |
+| 上下文 | Context | |
+| 活跃文档 | Active Document | |
+| 进程中断 | Process Interrupted | |
+| 长上下文单价更高 | Higher rates for long context | 模型下拉提示 |
+| 需国际网络 | Requires international network | |
+
+## 通用 UI 动词/状态
+
+| 中文 | English | 中文 | English |
+|---|---|---|---|
+| 保存 | Save | 另存为 | Save As |
+| 打开 | Open | 新建 | New |
+| 重命名 | Rename | 删除 | Delete |
+| 移动 | Move | 上传 | Upload |
+| 下载 | Download | 导出 | Export |
+| 导入 | Import | 搜索 | Search |
+| 复制 | Copy | 粘贴 | Paste |
+| 撤销 | Undo | 重做 | Redo |
+| 确认 | Confirm | 取消 | Cancel |
+| 关闭 | Close | 重试 | Retry |
+| 刷新 | Refresh | 设置 | Settings |
+| 展开 | Expand | 收起 | Collapse |
+| 启用 | Enable | 停用 | Disable |
+| 安装 | Install | 卸载 | Uninstall |
+| 发送 | Send | 编辑 | Edit |
+| 加载中… | Loading… | 保存中… | Saving… |
+| 已保存 | Saved | 已完成 | Done |
+| 失败 | Failed | 已取消 | Canceled |
+| 暂无数据 | No data yet | 敬请期待 | Coming soon |

--- a/frontend/src/pages/admin/admin.vue
+++ b/frontend/src/pages/admin/admin.vue
@@ -44,6 +44,36 @@
           scroll-y
           class="config-scroll"
         >
+          <!-- 应用语言：立即生效、独立保存链（setAppLanguage 直写，不走 handleSave
+               的 /api/admin/config——那条要求 admin 权限，语言是人人可改的设置）。 -->
+          <view class="section-card">
+            <view class="section-header">
+              <text class="section-title">{{ appLanguage === 'en-US' ? 'Language' : '语言 / Language' }}</text>
+              <text class="section-subtitle">
+                {{ appLanguage === 'en-US'
+                  ? 'Applies to the interface, document editor, and AI replies. Newly opened editors use the new language; restart the app for full effect.'
+                  : '作用于界面、文档编辑器与 AI 回复。新打开的编辑器使用新语言，重启应用后完全生效。' }}
+              </text>
+            </view>
+            <view class="section-body">
+              <view class="form-row">
+                <text class="form-label">{{ appLanguage === 'en-US' ? 'Language' : '界面语言' }}</text>
+                <view class="provider-radio-group">
+                  <view
+                    v-for="opt in appLanguageOptions"
+                    :key="opt.value"
+                    class="radio-item"
+                    :class="{ checked: appLanguage === opt.value }"
+                    @tap="onAppLanguagePick(opt.value)"
+                  >
+                    <view class="radio-dot"></view>
+                    <text class="radio-label">{{ opt.label }}</text>
+                  </view>
+                </view>
+              </view>
+            </view>
+          </view>
+
           <!-- 外部服务 -->
           <view class="section-card">
             <view class="section-header">
@@ -1342,6 +1372,7 @@ import { openExternalUrl } from '@/utils/externalLink.js'
 import { accountPageUrl, siteBaseUrl, loadSiteLinks, resetSiteLinks } from '@/utils/siteLinks.js'
 import { host } from '@/services/host.js'
 import { refreshEntitlements, isEnabled, FEATURES } from '@/composables/useEntitlement.js'
+import { getAppLanguage, setAppLanguage } from '@/utils/appLanguage.js'
 import UnlockHint from '@/components/UnlockHint.vue'
 import MarketPane from '@/components/MarketPane.vue'
 
@@ -1352,6 +1383,13 @@ export default {
     return {
       userDisplayName: '用户',
       activeNav: 'config',
+      // 应用语言：读写走 utils/appLanguage.js（storage 权威源 + App.vue 镜像同步），
+      // 与 form/handleSave 无关。选项标签用各自母语，刻意不随语言翻译。
+      appLanguage: getAppLanguage(),
+      appLanguageOptions: [
+        { value: 'zh-CN', label: '简体中文' },
+        { value: 'en-US', label: 'English' },
+      ],
       /** 服务端记录的同意时间戳；空 = 未同意或告知文本已改版需重新征求 */
       crossBorderConsentAt: '',
       navItems: [
@@ -1837,6 +1875,14 @@ export default {
             uni.showToast({ title: (e && e.message) || '重置失败', icon: 'none' })
           }
         },
+      })
+    },
+    onAppLanguagePick(value) {
+      if (value === this.appLanguage) return
+      this.appLanguage = setAppLanguage(value)
+      uni.showToast({
+        title: this.appLanguage === 'en-US' ? 'Language switched' : '已切换为简体中文',
+        icon: 'none',
       })
     },
     onNavTap(nav) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1811,6 +1811,24 @@ export function logTelemetryEvent(eventName, attrs) {
   })
 }
 
+// 应用语言（zh-CN / en-US）。权威源在前端 utils/appLanguage.js，这两个函数只负责
+// 把值镜像到后端 system_setting（后端据此选 system prompt 语言与文案语言）。
+export function getAppLanguageRemote() {
+  return request({
+    url: '/api/app/language',
+    method: 'GET'
+  })
+}
+
+export function saveAppLanguageRemote(language) {
+  return request({
+    url: '/api/app/language',
+    method: 'POST',
+    data: { language },
+    header: { 'Content-Type': 'application/json' }
+  })
+}
+
 export function getTelemetrySettings() {
   return request({
     url: '/api/telemetry/settings',

--- a/frontend/src/services/host.js
+++ b/frontend/src/services/host.js
@@ -14,6 +14,8 @@
 // 唯一被规范化的是 zetaoffice.getEditor：它现在返回带 kind 的描述符，
 // 宿主据此挂 <webview>（桌面）或 <iframe>（Web）。见 LibreOfficeEditor.vue。
 
+import { getAppLanguage } from '@/utils/appLanguage.js'
+
 /** 是否运行在桌面壳里。用于「仅桌面版可用」类的能力分支。 */
 export function isDesktopHost() {
   return !!nativeHost()
@@ -32,6 +34,9 @@ const WEB_EDITOR_BASE = '/zetaoffice/'
 function webEditorDescriptor() {
   const q = new URLSearchParams()
   q.set('lowa', WEB_EDITOR_BASE + 'lowa/')
+  // LO 画布 UI 语言跟随应用语言（editor-main.js 的既有 ?uilang= 契约；引擎双语
+  // 资源已随包）。桌面态的对应注入点在 desktop/main/zetaoffice-server.js editorUrl。
+  q.set('uilang', getAppLanguage())
   return { kind: 'iframe', url: WEB_EDITOR_BASE + 'editor.html?' + q.toString() }
 }
 

--- a/frontend/src/utils/appLanguage.js
+++ b/frontend/src/utils/appLanguage.js
@@ -1,0 +1,76 @@
+// 应用语言（zh-CN / en-US）。权威源是这里的 uni storage 值；后端 system_setting
+// 与桌面主进程（菜单/原生对话框）只是镜像，由 App.vue 监听 EVENT 统一写透。
+//
+// 首启猜测规则（只猜一次，之后以用户显式设置为准）：
+// 1. 存量安装保护：storage 里已有使用痕迹（最近项目/会话）→ zh-CN。
+//    既有用户全部来自中文版，绝不能因为系统 locale 是 en-* 就把他们翻成英文
+//    （Electron 下系统 locale 报 en-* 的教训见 utils/toolDisplayNames.js）。
+// 2. 全新安装：navigator.language 以 zh 开头 → zh-CN，其余 → en-US。
+//    与桌面主进程 desktop/main/app-language.js 的 app.getLocale() 规则一致。
+//
+// 本模块刻意零依赖（host.js / api.js 都不引），否则 host.js 取语言会形成
+// host → appLanguage → api → host 的循环引用。
+
+export const APP_LANGUAGE_KEY = 'awd_app_language'
+export const APP_LANGUAGE_EVENT = 'awd-language-changed'
+export const SUPPORTED_LANGUAGES = ['zh-CN', 'en-US']
+
+let cached = ''
+
+function readStorage(key) {
+  try {
+    const v = uni.getStorageSync(key)
+    return typeof v === 'string' ? v.trim() : ''
+  } catch (e) {
+    return ''
+  }
+}
+
+function hasExistingFootprint() {
+  // 与 utils/recentProjects.js（checkba_last_project_id）、utils/auth.js（checkba_session_id）
+  // 的存储键对齐；任一存在即视为存量用户。
+  return !!(readStorage('checkba_last_project_id') || readStorage('checkba_session_id'))
+}
+
+function guessLanguage() {
+  if (hasExistingFootprint()) return 'zh-CN'
+  let loc = ''
+  try { loc = String((typeof navigator !== 'undefined' && navigator.language) || '') } catch (e) { /* ignore */ }
+  return loc.toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US'
+}
+
+export function getAppLanguage() {
+  if (cached) return cached
+  const stored = readStorage(APP_LANGUAGE_KEY)
+  if (SUPPORTED_LANGUAGES.includes(stored)) {
+    cached = stored
+    return cached
+  }
+  cached = guessLanguage()
+  try { uni.setStorageSync(APP_LANGUAGE_KEY, cached) } catch (e) { /* ignore */ }
+  return cached
+}
+
+export function isEnglish() {
+  return getAppLanguage() === 'en-US'
+}
+
+/**
+ * 设置语言并广播。镜像写透（后端 system_setting、桌面主进程）由 App.vue
+ * 的 APP_LANGUAGE_EVENT 监听器完成，调用方不需要关心。
+ */
+export function setAppLanguage(lang) {
+  if (!SUPPORTED_LANGUAGES.includes(lang)) return getAppLanguage()
+  const changed = lang !== getAppLanguage()
+  cached = lang
+  try { uni.setStorageSync(APP_LANGUAGE_KEY, lang) } catch (e) { console.warn('[appLanguage] persist failed:', e) }
+  if (changed) {
+    try { uni.$emit(APP_LANGUAGE_EVENT, lang) } catch (e) { /* ignore */ }
+  }
+  return cached
+}
+
+/** 双语文案就地取值：tr({ zh: '…', en: '…' })。i18n 框架接线前的轻量通道。 */
+export function tr(pair) {
+  return isEnglish() ? pair.en : pair.zh
+}

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -5,6 +5,8 @@
 // 后端新增工具时同步补一行；未收录的代号按 snake_case → 空格分词兜底展示。
 // wps_* 是 doc_* 的灰度别名（PR#87），查表前先归一化。
 
+import { isEnglish } from '@/utils/appLanguage.js'
+
 const NAMES = {
   // 计划 / 项目
   todo_write: { zh: '更新任务清单', en: 'Update plan' },
@@ -265,15 +267,16 @@ const NAMES = {
 }
 
 // code 可以是纯工具名，也可以是 <tool_code> 里的 `tool_name({...})` 完整调用串。
-// 产品是中文优先：显示名一律取 zh（此前按 uni.getLocale() 取语言，Electron 常
-// 返回 en-*，导致面板里中英文混杂——用户反馈统一为中文）。en 列保留给未来 i18n。
+// 语言判定只走应用自己的语言设置（utils/appLanguage.js），不信系统 locale：
+// 此前按 uni.getLocale() 取语言，Electron 常返回 en-*，导致面板里中英文混杂
+//（用户反馈后曾统一写死 zh）。现在 zh/en 两列都在用，随语言设置切换。
 export function toolDisplayName(code) {
   if (!code) return ''
   const m = String(code).match(/^\s*([\w.]+)\s*\(/)
   let name = m ? m[1] : String(code).trim()
   if (name.startsWith('wps_')) name = 'doc_' + name.slice(4) // 灰度别名归一
   const entry = NAMES[name]
-  if (entry) return entry.zh
+  if (entry) return isEnglish() ? entry.en : entry.zh
   // 兜底：未收录的代号按 snake_case 分词，至少可读
   return name.replace(/_/g, ' ')
 }


### PR DESCRIPTION
EN 版系列第 1/6 片。单一安装包 + 运行时语言切换的底座，中文行为零回归（默认值与存量保护见下）。

## 内容
- **语言设置**：`utils/appLanguage.js`（uni storage 权威源）；首启猜测规则——存量安装（storage 有 `checkba_last_project_id`/session 痕迹）默认 zh-CN，全新安装按系统 locale（zh\* → zh-CN，其余 en-US）；之后以用户显式设置为准。设置入口在系统设置「系统配置」面板顶部，立即生效、独立保存链（不走 requireAdmin 的 /api/admin/config）。
- **后端镜像**：`app.language` system_setting（AppLanguageService/Controller，照 TelemetryController 鉴权先例），供后续 PR4/PR5 选文案与 system prompt 语言。
- **LOWA**：编辑器 URL 追加既有 `?uilang=` 契约（桌面 zetaoffice-server.js editorUrl / Web host.js 两个构造点，同时覆盖 LibreOfficeEditor 与 VersionCompareTab 挂载点）。引擎 en-US 资源已随包（mega-build --with-lang），不重烧引擎。只影响新 boot 的实例；保活池存量实例重启后生效。
- **桌面壳**：`main/app-language.js`（userData 镜像 + 订阅）；应用菜单全量双语并随切换即时重建；将 Notification/showErrorBox/保存对话框/右键「加入网核收藏」/ui-confirm 默认按钮双语；NSMicrophoneUsageDescription 双语。
- **过程气泡工具行**：toolDisplayNames.js 按语言设置取 zh/en 列（修掉「en 列保留给未来 i18n」的欠账；卡片标题的后端 displayName 策略在 PR2 处理）。
- **术语表先行**：`frontend/src/locales/glossary.md`（法律领域 zh→en 唯一基准）+ `CONVENTIONS.md`（后续批量迁移的执行约定）。

## 验证
- backend：`mvn test -Dtest=AppLanguageServiceTest` 4/4（JDK 21）
- frontend：`npm run check:emits` 通过（77 .vue）、`npm run build:h5` 成功
- desktop：`npm test` 37/37

## 已知边界（后续片处理）
- 浏览器态未登录时启动不向后端推语言（request 包装器会把「未登录」响应当会话失效处理），登录后下次启动/切换补上。
- 界面文案本体仍中文，PR2/PR3 接 vue-i18n 批量迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)