### PR TITLE
fix(editor): 修中文标点吞键/输入过程不可见/手势缩放/保存胶囊/逐字符修订

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -33,7 +33,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - Web 态部署布局见 `deploy/web/nginx.conf.example`（站点 root 下 `zetaoffice/`，全站 COOP/COEP）；`host.zetaoffice.isAvailable()` 在 Web 态 HEAD 探一次编辑器页，没部署就让宿主退回预览路径，而不是挂一个永远起不来的 iframe。
 
 **宿主 UI（保活/实例管理/自动保存）**
-- `frontend/src/components/ReviewPanel.vue` — 审阅面板（编辑器右栏）：修订/批注两栏清单，点击定位、逐条接受/拒绝、全部接受/拒绝、批注标记解决/删除。数据全走 worker 原语（list_revisions/goto_revision/resolve_revision/resolve_all_revisions、list_comments/goto_comment/set_comment_resolved/delete_comment），executor 由 LibreOfficeEditor 注入；处置后 emit changed → 走自动保存链路。**面板是修订的权威视图**（页边小字读不到作者/时间，且同行多格删除会在页边互叠）。
+- `frontend/src/components/ReviewPanel.vue` — 审阅面板（编辑器右栏）：修订/批注两栏清单，点击定位、逐条接受/拒绝、全部接受/拒绝、批注标记解决/删除。数据全走 worker 原语（list_revisions/goto_revision/resolve_revision/resolve_all_revisions、list_comments/goto_comment/set_comment_resolved/delete_comment），executor 由 LibreOfficeEditor 注入；处置后 emit changed → 走自动保存链路。**面板是修订的权威视图**（页边小字读不到作者/时间，且同行多格删除会在页边互叠）。**卡片是「组」不是「条」**：引擎按一次编辑操作记一条 redline，连按 Backspace 删一个词就是一字一条（页边模式下引擎不会自行合并，真机实证 5 次删除 = 5 条）；面板把 `contiguous`（worker 用区间比较给出的首尾相接判据）+ 同类型同作者同分钟的相邻条目并成一张卡，处置时**从高索引往低索引**逐条 resolve（index 是枚举序，处置一条后更大的索引会前移）。
 - `frontend/src/components/LibreOfficeEditor.vue` — 单文档编辑器组件：webview 创建、prefetch、load/export、autoSave、flushSave、reloadFromBackend。支持**备胎过继**（watch file 仅 null→文档；引擎已就绪走 finishDocLoad，未就绪由 onEndpointReady 接手）与**只读预览接力**（字节预取完成即 docx-preview 本地渲染，previewReady 后 overlay 变成可滚动阅读 + 顶部细进度条，ready 后整体消失）。
 - `frontend/src/pages/project-overview/librePool.js` — 保活池方法组（Phase 1 外置）：libreLruKeys/touchLibreLru/evictLibreInstance、syncLibreExecutor 活跃指针、`_libreRefs`/`_libreExecMap` 非响应式注册表、`LIBRE_KEEPALIVE_MAX = 3`、reloadActiveLibreInstances（版本退回/检查点恢复后就地重载）；**预热备胎**（PR#220）：libreSpares（{key, file}，file=null 是后台预 boot 的空白隐藏实例），onActiveOfficeFileChanged 里 maybeAdoptLibreSpare（须在 touchLibreLru 之前，靠"不在 lru 记账"识别无实例）过继给池外首开文档，过继后按 'left:fileId' 常规记账；补胎在过继 ready 后（scheduleLibreSpare，4s 延迟）。仅左窗格设备胎（webview 不能跨容器移动）；h5 无 checkbaDesktop 不建胎；常驻多一个空白实例内存（数百 MB）。
 
@@ -68,6 +68,15 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 
 守卫（防空文档覆盖，PR#194）：`docLoadFailed` 闸——load 失败或"元数据非空却下载 0 字节"（fileSize>0 而 bytes 空）时置位，此后 onDocModified 与 saveDocument 一律拒绝；fileSize==0 才当新建空白。**该编辑器存/取走整文件 XHR，不含分片上传**。
 
+## LO chrome 的取舍（自建工具栏路线，spike 已验证）
+
+维护者定调：**最终形态是自建工具栏**，LO 自己的 menubar/toolbar 退场（菜单栏末端那个 × 会把 webview 里的文档关掉）。分期方案见 `docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md`。
+
+- 入口：`ctrl.getFrame().getPropertyValue('LayoutManager')`；元素 URL 形如 `private:resource/menubar/menubar`、`private:resource/toolbar/standardbar`、`private:resource/toolbar/textobjectbar`、`private:resource/statusbar/statusbar`，外加 11 条 `singlemode-*` 上下文工具栏。
+- **`hideElement()` 的返回值恒为 false，不代表失败**——必须用 `isElementVisible()` 复核。`showElement()` 可逆（返回 true 且 visible 恢复）。
+- 标尺不归 LayoutManager 管，是 `ViewSettings.ShowHoriRuler/ShowVertRuler`。
+- 隐藏 chrome 后编辑、`.uno:` 派发、格式原语、缩放全部照常；引擎自带对话框仍画在 canvas 上，不受影响。
+
 ## 已知地雷
 
 - boot 三地雷勿回退（canvas 必须 id=qtcanvas 且禁 border/padding；COOP/COEP 缺失 SharedArrayBuffer 不可用；locale shim）。
@@ -77,6 +86,10 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - 引擎仅 Writer+Calc 实锤（PR#165），别承诺 Impress。
 - CJK 字体走类别映射别名（PR#157/158），**不能用 assign 硬替换**；tofu 排查用 list_fonts 诊断 action。
 - 删除键/快捷键必须走 `.uno:` 调度（覆盖层吞键+修订模式手工删卡死教训，PR#164/166）。
+- **IME 覆盖层的「吞掉尾随 input」闩不能无条件置位**（`zetaOfficeImeOverlay.js`）：`compositionend` 之后浏览器**不一定**补发 input 事件（中文态标点直接上屏、组合被取消都不发），闩挂着不解就会吃掉用户随后敲的第一个字符——真机现象是「中文标点要按两次才过去」。判据用 `inputType`（只吞 insertCompositionText/insertFromComposition），并且无论如何在下一个宏任务解闩，绝不让它跨事件循环存活。
+- **组合中的文字要用独立预览条显示**：覆盖层的 `<input>` 压在画布上，必须全透明（显字会与正文叠印），所以「输入过程」看不见。预览条不依赖光标映射，未点过画布 / 映射失败时照样可见。
+- **触控板捏合必须在 canvas 上 `preventDefault`**：Chromium 把捏合报成 `ctrl+wheel`，不拦就是浏览器缩放整个 webview 页面（工具栏跟着放大、画布发糊、IME 像素映射基准作废）。拦下来改派 `set_zoom`（`ViewSettings.ZoomValue`，先切 `ZoomType=BY_VALUE` 否则自动模式会把值算回去；两个属性都是 sal_Int16，必须 `shortAny()`）。
+- **保存状态胶囊只在「慢」和「失败」时出声**：成功保存不报「已保存」（维护者反馈：经常闪变、打扰）。浮层要钉在**画布**上而不是编辑器外层——审阅面板是并排挤宽的，钉外层会压住面板标题行。
 - `npm run build:zetaoffice` 会清空 dist 并删掉已 fetch 的引擎——本地反复跑 e2e 用 `LOWA_ENGINE_DIR` 规避，或从兄弟 worktree 复制引擎（CDN 挂时的配方）。
 - 修订作者：params 带 `__agent:true` → 署名 "AI Workdeck"。
 - **ShowChangesInMargin 依赖自建引擎 ≥24.2.8-zhcn-r3**：原生 LO 把页边删除文本画在锚点所在 frame 左侧，表格内 frame=单元格会叠画左邻格正文；r3 焙入 frmpaint.cxx 表格锚点补丁（`desktop/lowa-build/patches`，锚 FindTabFrame 整表左缘）后才能开。页边模式非纯视图设置：开=删除文本移入 redline 对象（getString 可取、正文不含），关=留正文流且 redline getString 抛异常——debug_revisions 已带 RedlineText/区间双路取回，两种模式都能读。已知残留局限：同一表格行多格删除会在页边同 Y 相互叠（上游按行画、无跨格协调）。批注侧栏与此设置无关。

--- a/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md
+++ b/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md
@@ -57,17 +57,29 @@ private:resource/statusbar/statusbar          状态栏
 4. **`set_chrome`**：一次性隐藏/显示 menubar / 两条工具栏 / 状态栏 / 标尺，
    每一步用 `isElementVisible` 复核后如实返回。
 
-### P1.5 — 选区变化事件（spike，卡住 P2 的唯一未知项）
+### P1.5 — 状态刷新机制（spike 已完成，2026-08-14）
 
-工具栏的激活态（B 是否高亮、当前字体字号、当前样式）必须跟着光标走。
-LO 不会主动把「选区变了」推给宿主。两条路：
+工具栏的激活态（B 是否高亮、当前字体字号、当前样式）必须跟着光标走。实测结论：
 
-- **首选**：worker 里装 `XSelectionChangeListener`（`ctrl.addSelectionChangeListener`），
-  变化时 post 给宿主。可行性有旁证——`installModifyListener`（XModifyListener）
-  已经在跑，说明 zetajs 建 UNO listener 这条路是通的。
-- **兜底**：编辑器获得焦点时按 250ms 轮询 `get_ui_state`，失焦停轮询。
+| 探测 | 结果 |
+|---|---|
+| `zetajs.unoObject([css.view.XSelectionChangeListener])` + `ctrl.addSelectionChangeListener` | ✅ 装得上、能触发 |
+| 扩选 / 全选 / 选中段落 | ✅ 每次都触发（一次一条） |
+| **纯光标移动（collapsed，无选区）** | ❌ **基本不触发**（连移 5 次只收到 1 条） |
+| 一次性回读全部工具栏状态的耗时 | **5.8ms/次**（20 次共 116ms） |
+| `xModel.getPropertyValue('UndoManager')` | ❌ UnknownPropertyException——**要改走 `XUndoManagerSupplier.getUndoManager()`**，P1 里重测；实在读不到就让撤销/重做常亮（LO 自己也这么干过一阵） |
+| 段落样式清单 | ✅ 126 条，但 `getElementNames()` 给的是**英文程序名**（Standard / Heading 1 / Text body）。下拉要显示中文，得读每个样式的 `DisplayName` |
 
-先 spike，通了走首选。
+**定案：事件 + 轮询混合。**光标移动这条路 listener 靠不住，但回读只要 5.8ms，
+按 400ms 轮询完全够廉价。刷新触发点：
+
+1. `XSelectionChangeListener` 事件（选区类变化，最及时）；
+2. 任何经 executor 发出的命令之后（工具栏自己的按钮、AI 命令）；
+3. 已有的 `modified` 信号（打字）；
+4. 编辑器聚焦时 400ms 安全轮询，失焦即停（兜住纯光标移动与画布点击）。
+
+注：方向键其实也会经 IME 覆盖层转成 `move_cursor` 命令，命中第 2 条；轮询主要
+兜的是画布点击定位和引擎内部的光标移动。
 
 ### P2 — 工具栏组件（宿主 DOM）
 

--- a/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md
+++ b/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md
@@ -1,0 +1,115 @@
+# 编辑器外壳自建化：用我们自己的工具栏替换 LibreOffice chrome
+
+2026-08-14 立项。触发：维护者体验反馈（右上角 × 会关掉文档、整体样式不够现代）。
+决策：**最终形态是自建工具栏**，前提是**体验不能退步**——LO 菜单栏/工具栏能做的，
+自建这套要么覆盖，要么留得住逃生口。
+
+领域：`doc-editor`（编辑器内核与宿主集成）。相关：`sidebar-shell`（外壳布局）。
+
+---
+
+## 1. 已验证的技术前提（真机 spike，2026-08-14）
+
+用 `tests/lowa-e2e` 的服务器 + 探针注入机制，在 24.2.8-zhcn-r4 真引擎上跑通：
+
+| 前提 | 结论 |
+|---|---|
+| frame 的 `LayoutManager` 属性可达 | ✅ `ctrl.getFrame().getPropertyValue('LayoutManager')` |
+| 能列出 UI 元素 | ✅ 见下方清单 |
+| 能隐藏 menubar / 工具栏 / 状态栏 | ✅ `isElementVisible` 由 true 变 false |
+| 可逆（能再显示回来） | ✅ `showElement` 返回 true 且 visible 恢复 |
+| 标尺能关 | ✅ `ViewSettings.ShowHoriRuler/ShowVertRuler` |
+| 隐藏 chrome 后仍能编辑 / 派发 `.uno:` / 缩放 | ✅ 写入、select_all、format_selection、set_zoom 全部照常 |
+
+**地雷：`hideElement()` 的返回值恒为 false，不代表失败。**必须用 `isElementVisible()`
+复核，别拿返回值当成功判据（真机实测：返回 false 但元素确实隐藏了）。
+
+引擎当前的 UI 元素全集（Writer 文档态）：
+
+```
+private:resource/toolbar/standardbar          标准工具栏
+private:resource/toolbar/textobjectbar        格式工具栏
+private:resource/toolbar/singlemode-{ole,draw,form,text,frame,media,
+                         table,graphic,drawtext,annotation,printpreview}
+                                              上下文工具栏（选中表格/图片时自动冒出）
+private:resource/menubar/menubar              菜单栏（右上角那个 × 就长在它末端）
+private:resource/statusbar/statusbar          状态栏
+```
+
+## 2. 分期
+
+### P0 — 缺陷修复（已完成）
+
+与工具栏无关、可独立发布的五条，见本次 PR：中文标点吞键、输入过程不可见、
+手势缩放、保存状态胶囊、审阅面板逐字符删除合并。
+
+### P1 — 命令层底座（worker 侧）
+
+自建工具栏的每个按钮最终都要落到 worker 的一个 action 上。四件事：
+
+1. **`ui_command` 白名单扩容**。现在只有 12 条（IME 快捷键用）。按菜单分组扩到
+   覆盖工具栏 + 菜单条所需的 `.uno:` 全集。白名单仍是硬约束——**不开放任意
+   `.uno:` 透传**，否则宿主 DOM 就成了引擎的任意命令通道。
+2. **`get_ui_state`**：一次调用返回工具栏要显示的全部状态。已有的
+   `get_formatting` 覆盖了字符/段落属性，但缺三样：撤销/重做是否可用、修订开关
+   当前状态、当前缩放。工具栏是高频回读，必须一次拿全、且廉价。
+3. **`list_styles`**：段落样式清单，喂样式下拉（`set_style` 已经有了）。
+4. **`set_chrome`**：一次性隐藏/显示 menubar / 两条工具栏 / 状态栏 / 标尺，
+   每一步用 `isElementVisible` 复核后如实返回。
+
+### P1.5 — 选区变化事件（spike，卡住 P2 的唯一未知项）
+
+工具栏的激活态（B 是否高亮、当前字体字号、当前样式）必须跟着光标走。
+LO 不会主动把「选区变了」推给宿主。两条路：
+
+- **首选**：worker 里装 `XSelectionChangeListener`（`ctrl.addSelectionChangeListener`），
+  变化时 post 给宿主。可行性有旁证——`installModifyListener`（XModifyListener）
+  已经在跑，说明 zetajs 建 UNO listener 这条路是通的。
+- **兜底**：编辑器获得焦点时按 250ms 轮询 `get_ui_state`，失焦停轮询。
+
+先 spike，通了走首选。
+
+### P2 — 工具栏组件（宿主 DOM）
+
+`frontend/src/components/EditorToolbar.vue`，挂在 `LibreOfficeEditor.vue` 的
+canvas 上方（占布局高度，不是浮层——浮层压在 webview 上不可靠，且会遮正文）。
+
+单行紧凑布局 + 溢出收进「更多」。分区：
+
+```
+撤销 重做 │ 段落样式▾ 字体▾ 字号▾ │ B I U S 字色 高亮 │ 对齐 列表 缩进
+         │ 插入（表格/图片/链接/批注/分页）│ 修订开关 审阅 │ 缩放 −100%+
+```
+
+- 每个按钮 = 一次 `executor.executeCommand`，走宿主已有的 executor（不新开通道）。
+- 激活态由 P1.5 的状态流驱动。
+- 视觉对齐官网 DESIGN.md 与既有面板（浅色、无 emoji）。
+
+### P3 — 菜单层
+
+`frontend/src/components/EditorMenus.vue`：文件/编辑/视图/插入/格式/表格/工具
+七个下拉，条目直接落到 `ui_command` 或已有原语。
+
+引擎自带的对话框（插入表格、查找替换、段落设置…）画在 canvas 上，**隐藏
+chrome 不影响它们弹出**，所以复杂对话框沿用引擎的，不重做。
+
+### P4 — 切换与逃生口
+
+- `set_chrome` 默认隐藏 LO chrome。
+- 设置里留「显示原生菜单栏」开关（`showElement` 已验证可逆）——自建这套万一
+  漏了什么，用户当场能拿回全部功能。这条是「体验不能退步」的兜底保证，
+  在自建覆盖度做到位之前不许摘。
+
+### P5 — 验证
+
+- `npm run test:lowa-e2e` 加工具栏组：逐个按钮点一次，断言文档/状态真的变了
+  （不是「点了没报错」）。
+- `npm run test:app-e2e` 全应用走查。
+- 人工走查清单：律师日常动作（改字号、套样式、插表格、接受修订、导出）在
+  自建工具栏上全跑一遍。
+
+## 3. 不做的事
+
+- **不动引擎画布配色**（深色化已被否决，见 doc-editor 领域文档）。
+- **不重做引擎对话框**。
+- **不开放任意 `.uno:` 透传**——白名单是安全边界。

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -4,20 +4,6 @@
          (user feedback). Status floats over the editor's top-right corner;
          the pill only appears while something is happening (saving/failure)
          and vanishes when ready. -->
-    <view class="libre-float">
-      <!-- No manual save button: edits auto-save (modify listener → debounced
-           saveDocument). The pill doubles as the autosave indicator
-           (保存中… / 已保存 / 保存失败). Boot/load 阶段由下方进度面板展示，
-           pill 只负责就绪后的保存状态。 -->
-      <view v-if="displayStatus && !loadingOverlayVisible" class="libre-pill" :class="{ error: isError }">
-        <view v-if="!isError && !ready" class="libre-spin"></view>
-        <text>{{ displayStatus }}</text>
-      </view>
-      <!-- 审阅面板开关：页边小字读不到作者/时间，面板才是修订的权威视图。
-           Calc/Impress 都没有修订（redline）机制，按 docKind 隐藏——不能只是点了没反应。 -->
-      <text v-if="ready && !loadingOverlayVisible && showsReview" class="libre-review-btn" :class="{ on: reviewOpen }"
-            @tap="reviewOpen = !reviewOpen">审阅</text>
-    </view>
     <!-- 加载进度面板：引擎启动 + 文档下载/打开是感知最慢的一段（尤其大文档），
          把过程阶段化展示出来（用户反馈：不能更快，也要看得见进展）。 -->
     <view v-if="loadingOverlayVisible" class="libre-loading">
@@ -55,7 +41,23 @@
          审阅面板与画布并排（挤宽而非浮层）——webview 是独立合成层，浮层压在
          上面的行为不可靠。 -->
     <view class="libre-body">
-      <view :id="hostId" class="libre-host"></view>
+      <!-- 浮层必须钉在**画布**上而不是整个编辑器上：审阅面板是并排挤宽的，钉在
+           外层右上角会正好压住面板的「修订/批注」标题行（真机截图实证）。 -->
+      <view class="libre-canvas-wrap">
+        <view :id="hostId" class="libre-host"></view>
+        <view class="libre-float">
+          <!-- No manual save button: edits auto-save (modify listener → debounced
+               saveDocument). 保存状态只在「慢」和「失败」时出声——见 saveDocument。 -->
+          <view v-if="displayStatus && !loadingOverlayVisible" class="libre-pill" :class="{ error: isError }">
+            <view v-if="!isError && !ready" class="libre-spin"></view>
+            <text>{{ displayStatus }}</text>
+          </view>
+          <!-- 审阅面板开关：页边小字读不到作者/时间，面板才是修订的权威视图。
+               Calc/Impress 都没有修订（redline）机制，按 docKind 隐藏——不能只是点了没反应。 -->
+          <text v-if="ready && !loadingOverlayVisible && showsReview" class="libre-review-btn" :class="{ on: reviewOpen }"
+                @tap="reviewOpen = !reviewOpen">审阅</text>
+        </view>
+      </view>
       <ReviewPanel
         v-if="reviewOpen && ready && showsReview"
         :executor="executor"
@@ -207,6 +209,7 @@ export default {
     // by the closer (closeFile / evictLibreInstance await flushSave first) —
     // export needs the live webview, so saving from here is already too late.
     clearTimeout(this._saveTimer)
+    clearTimeout(this._slowSaveTimer)
     clearInterval(this._bootTimer)
     // Tell the host this editor (and its executor) is going away — so it can
     // stop routing AI commands to a disposed executor when the document tab is
@@ -632,8 +635,13 @@ export default {
       const fileId = f.wpsFileId || f.id
       if (!fileId) { this.appendLog('save: file has no id/wpsFileId'); return false }
       this.saving = true
-      const prevStatus = this.statusText
-      this.statusText = '保存中…'
+      // 保存状态别抢戏：绝大多数保存几百毫秒就完了，闪一下「保存中…→已保存」
+      // 纯粹是干扰（用户反馈：经常有变化，不好看且会打扰）。规则改成——慢到 2s
+      // 以上才提示「保存中…」，成功后安静收回、不报「已保存」，失败才常驻显示。
+      // 上一次的「保存失败」不能当成要恢复的状态，这次成功了就该回到就绪。
+      const prevStatus = this.statusText.indexOf('失败') !== -1 ? '就绪' : this.statusText
+      clearTimeout(this._slowSaveTimer)
+      this._slowSaveTimer = setTimeout(() => { if (this.saving) this.statusText = '保存中…' }, 2000)
       try {
         const name = f.name || (String(fileId) + '.' + String(f.fileType || 'docx'))
         this.appendLog('▶ export_document「' + name + '」…')
@@ -660,7 +668,6 @@ export default {
         }
         this.appendLog('  ← exported ' + u8.length + ' bytes, uploading…')
         await this.uploadBytes(getFileUploadUrl(fileId), u8, name)
-        this.statusText = '已保存'
         this.appendLog('  ← saved to backend (fileId=' + fileId + ')')
         return true
       } catch (e) {
@@ -669,8 +676,9 @@ export default {
         return false
       } finally {
         this.saving = false
-        // Let the badge linger, then settle back to ready (unless a failure is showing).
-        setTimeout(() => { if (this.statusText === '已保存') this.statusText = prevStatus }, 2500)
+        clearTimeout(this._slowSaveTimer)
+        // 只收回自己挂上去的「保存中…」；失败态是 catch 里刚设的，必须留着
+        if (this.statusText === '保存中…') this.statusText = prevStatus
       }
     },
     // Authed multipart POST — the upload twin of fetchArrayBuffer (backend
@@ -694,9 +702,9 @@ export default {
 
 <style scoped>
 .libre-editor-wrapper { position: relative; display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
-/* Floating status pill, pinned over the editor's top-right corner (LO's own
-   menubar leaves that region empty). No layout height is reserved — the
-   document canvas gets the full pane. */
+/* Floating status pill, pinned over the CANVAS's top-right corner (not the
+   wrapper's — the review panel sits to the right and would be covered). No
+   layout height is reserved — the document canvas gets the full pane. */
 .libre-float { position: absolute; top: 6px; right: 16px; z-index: 20; display: flex; align-items: center; gap: 8px; }
 .libre-pill { display: flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px;
   background: rgba(31, 41, 55, 0.78); color: #e5e7eb; font-size: 12px; backdrop-filter: blur(4px); }
@@ -705,7 +713,8 @@ export default {
   border-radius: 50%; animation: libre-rot 0.8s linear infinite; }
 @keyframes libre-rot { to { transform: rotate(360deg); } }
 .libre-body { flex: 1; min-height: 0; width: 100%; display: flex; flex-direction: row; }
-.libre-host { flex: 1; min-width: 0; min-height: 0; height: 100%; }
+.libre-canvas-wrap { position: relative; flex: 1; min-width: 0; min-height: 0; height: 100%; }
+.libre-host { width: 100%; height: 100%; }
 .libre-review-btn { padding: 3px 10px; border-radius: 999px; background: rgba(31, 41, 55, 0.78);
   color: #e5e7eb; font-size: 12px; backdrop-filter: blur(4px); }
 .libre-review-btn.on { background: #E6F9F0; color: #1A5336; }

--- a/frontend/src/components/ReviewPanel.vue
+++ b/frontend/src/components/ReviewPanel.vue
@@ -2,7 +2,7 @@
   <view class="rp">
     <view class="rp-head">
       <view class="rp-tabs">
-        <text class="rp-tab" :class="{ on: tab === 'rev' }" @tap="tab = 'rev'">修订 {{ revisions.length }}</text>
+        <text class="rp-tab" :class="{ on: tab === 'rev' }" @tap="tab = 'rev'">修订 {{ revisionGroups.length }}</text>
         <text class="rp-tab" :class="{ on: tab === 'cmt' }" @tap="tab = 'cmt'">批注 {{ comments.length }}</text>
       </view>
       <text class="rp-close" @tap="$emit('close')">收起</text>
@@ -22,18 +22,19 @@
           <text class="rp-empty-t">没有待处理的修订</text>
           <text class="rp-empty-s">对文档的改动会以修订形式出现在这里，可逐条接受或拒绝</text>
         </view>
-        <view v-for="r in revisions" :key="'r' + r.index" class="rp-card" @tap="goto(r)">
+        <view v-for="g in revisionGroups" :key="g.key" class="rp-card" @tap="goto(g)">
           <view class="rp-card-top">
-            <text class="rp-tag" :class="r.type === 'Delete' ? 'del' : 'ins'">{{ r.type === 'Delete' ? '删除' : '插入' }}</text>
-            <text v-if="r.inTable" class="rp-tag tbl">表格</text>
-            <text class="rp-author">{{ r.author || '未署名' }}</text>
-            <text class="rp-date">{{ r.date || '' }}</text>
+            <text class="rp-tag" :class="g.type === 'Delete' ? 'del' : 'ins'">{{ g.type === 'Delete' ? '删除' : '插入' }}</text>
+            <text v-if="g.inTable" class="rp-tag tbl">表格</text>
+            <text v-if="g.items.length > 1" class="rp-tag cnt">{{ g.items.length }} 处连续</text>
+            <text class="rp-author">{{ g.author || '未署名' }}</text>
+            <text class="rp-date">{{ g.date || '' }}</text>
           </view>
-          <text class="rp-text" :class="{ del: r.type === 'Delete' }">{{ r.text || '（空）' }}</text>
-          <text v-if="r.paragraph" class="rp-ctx">{{ r.paragraph }}</text>
+          <text class="rp-text" :class="{ del: g.type === 'Delete' }">{{ g.text || '（空）' }}</text>
+          <text v-if="g.paragraph" class="rp-ctx">{{ g.paragraph }}</text>
           <view class="rp-acts">
-            <text class="rp-act ok" @tap.stop="resolve(r, 'accept')">接受</text>
-            <text class="rp-act no" @tap.stop="resolve(r, 'reject')">拒绝</text>
+            <text class="rp-act ok" @tap.stop="resolveGroup(g, 'accept')">接受</text>
+            <text class="rp-act no" @tap.stop="resolveGroup(g, 'reject')">拒绝</text>
           </view>
         </view>
       </template>
@@ -86,6 +87,35 @@ export default {
   data() {
     return { tab: 'rev', revisions: [], comments: [], error: '' }
   },
+  computed: {
+    // 引擎按「一次编辑操作」记一条 redline：连按 Backspace 删掉一个词，就是一个字
+    // 一条（页边模式下每次删除还各自带走一段内容，引擎也不会替我们合并）。面板是
+    // 修订的权威视图，就得按人的理解呈现——把**位置上首尾相接、且同类型同作者同
+    // 分钟**的相邻条目并成一条卡片，接受/拒绝作用于整组。
+    // contiguous 由 worker 的 list_revisions 用区间比较给出（同段落里相隔很远的
+    // 两处删除不会被误并）；拿不到该字段的旧 worker 退化成不合并，行为与从前一致。
+    revisionGroups() {
+      const groups = []
+      for (const r of this.revisions) {
+        const last = groups[groups.length - 1]
+        const joins = last && r.contiguous
+          && last.type === r.type
+          && (last.author || '') === (r.author || '')
+          && (last.date || '') === (r.date || '')
+        if (joins) {
+          last.items.push(r)
+          last.text += (r.text || '')
+        } else {
+          groups.push({
+            key: 'g' + r.index, type: r.type, author: r.author, date: r.date,
+            inTable: r.inTable, paragraph: r.paragraph, text: r.text || '', items: [r],
+          })
+        }
+      }
+      for (const g of groups) if (g.text.length > 120) g.text = g.text.slice(0, 120) + '…'
+      return groups
+    },
+  },
   watch: {
     executor: { handler() { this.reload() }, immediate: true },
     refreshKey() { this.reload() },
@@ -109,11 +139,19 @@ export default {
       this.revisions = (rv && rv.revisions) || []
       this.comments = (cm && cm.comments) || []
     },
-    goto(r) { this.run('goto_revision', { index: r.index }) },
+    goto(g) { this.run('goto_revision', { index: g.items[0].index }) },
     gotoComment(c) { this.run('goto_comment', { index: c.index }) },
-    async resolve(r, action) {
-      const res = await this.run('resolve_revision', { index: r.index, action })
-      if (res) this.$emit('changed')
+    // 整组处置。**必须从高索引往低处理**：index 就是枚举序，处置掉一条之后比它
+    // 大的索引全部前移一位，而比它小的不受影响——倒着走，剩下的索引才一直有效。
+    async resolveGroup(g, action) {
+      const indices = g.items.map((r) => r.index).sort((a, b) => b - a)
+      let done = 0
+      for (const index of indices) {
+        if (await this.run('resolve_revision', { index, action })) done++
+      }
+      if (done) this.$emit('changed')
+      // 引擎没命中的如实说，别让用户以为整组都处理完了
+      if (done < indices.length) this.error = `本组 ${indices.length} 处中有 ${indices.length - done} 处未被引擎处置`
       await this.reload()
     },
     async resolveAll(action) {
@@ -154,6 +192,7 @@ export default {
 .rp-tag.ins { background: #E6F9F0; color: #1A5336; }
 .rp-tag.del { background: #FEF2F2; color: #991B1B; }
 .rp-tag.tbl { background: #EEF2FF; color: #3730A3; }
+.rp-tag.cnt { background: #F1F3F5; color: #495057; }
 .rp-tag.done { background: #F1F3F5; color: #868E96; }
 .rp-author { font-size: 12px; color: #495057; }
 .rp-date { font-size: 11px; color: #ADB5BD; margin-left: auto; }

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -33,6 +33,9 @@ export const EDITOR_ACTIONS = [
   // [overlay 快捷键] desktop-parity keys (Cmd/Ctrl+A/B/I/U, Home/End) — the
   // worker holds the .uno: allowlist (UI_COMMANDS in office_thread.js).
   'ui_command',
+  // [视图缩放] 触控板捏合 / Cmd+加减号；{value} 绝对百分比、{delta} 相对增量，
+  // 不带参数就是只读回当前缩放。宿主发起，不是 AI 管线。
+  'set_zoom',
   // [Track D] load the user's real document into the editor (host-initiated, not
   // an AI-agent command): {bytes, name} -> MEMFS + loadComponentFromURL + retarget.
   'load_document',

--- a/frontend/src/composables/zetaOfficeImeOverlay.js
+++ b/frontend/src/composables/zetaOfficeImeOverlay.js
@@ -11,13 +11,17 @@
 //     caller's `commit` callback — the SAME verified path as agent commands:
 //     executor.executeCommand('insert_at_cursor', {text}).
 //
-// PHASE A (default, no getCursorRaw): the overlay covers the whole canvas,
-// transparent — the IME candidate box pops at the canvas top-left.
+// PHASE A (default, no getCursorRaw): the overlay covers the whole canvas until
+// the first click, then follows the last click point — the IME candidate box
+// pops there instead of the canvas top-left.
 //
 // PHASE B (when getCursorRaw is supplied): the overlay anchors a small box at the
 // LO view cursor's pixel rect so the native candidate window appears AT the
-// cursor; composing text shows inline (color turned visible), then clears on
-// commit while LO renders the real text.
+// cursor.
+//
+// 组合中的文字（"输入过程"）由一个独立的不透明预览条显示，贴在光标框上方——
+// 输入框本身必须全透明（它压在画布上，显字会与正文叠印），而预览条不依赖光标
+// 映射，Phase A 下照样可见。
 //
 //   MAPPING — doc 1/100 mm -> canvas CSS px is affine: px = origin + scale*(doc - scroll).
 //   * scale is STABLE: 96/2540 CSS px per 1/100 mm at 100% zoom (CSS defines
@@ -127,6 +131,8 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
   const phaseB = typeof getCursorRaw === 'function'
   let mapOk = phaseB     // flips false (-> Phase A) if a raw read ever throws
   let anchor = null      // {x,y} live origin offset in host px, set on canvas click
+  let lastClick = null   // 最近一次画布点击（host 相对 px）——没有光标映射时的摆位依据
+  let lastBox = null     // 最近一次算出的光标框，组合预览条据此贴在光标上方
 
   const input = document.createElement('input')
   input.setAttribute('autocomplete', 'off')
@@ -146,8 +152,28 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
   if (getComputedStyle(host).position === 'static') host.style.position = 'relative'
   host.appendChild(input)
 
+  // 组合预览条。输入法的候选窗只显示候选，正在拼的那串字（"输入过程"）是画在
+  // 输入框里的——而这个框必须全透明（它压在画布上，显字会和正文叠在一起）。所以
+  // 单独挂一个不透明小条来显示组合中的文字：它独立于映射是否可用，未点过画布、
+  // 光标映射失败时照样看得见（真机反馈：看不到输入过程）。
+  const preview = document.createElement('div')
+  preview.setAttribute('aria-hidden', 'true')
+  Object.assign(preview.style, {
+    position: 'absolute', display: 'none', zIndex: '6',
+    maxWidth: '32em', padding: '2px 7px',
+    background: '#fff', border: '1px solid #C7CDD3', borderRadius: '5px',
+    boxShadow: '0 2px 8px rgba(15, 23, 42, 0.16)',
+    font: '14px/1.45 system-ui, -apple-system, "PingFang SC", sans-serif',
+    color: '#1F2937', whiteSpace: 'pre', overflow: 'hidden', textOverflow: 'ellipsis',
+    textDecoration: 'underline', textDecorationColor: '#9CA3AF',
+    pointerEvents: 'none',
+  })
+  host.appendChild(preview)
+
   function applyCover() {
     Object.assign(input.style, { left: '0', top: '0', width: '100%', height: '100%' })
+    lastBox = null
+    positionPreview()
   }
   function applyCursorBox(rect) {
     Object.assign(input.style, {
@@ -156,14 +182,29 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
       width: '16em',
       height: Math.round(rect.height) + 'px',
     })
+    lastBox = rect
+    positionPreview()
   }
-  applyCover()
 
-  function setPreviewVisible(on) {
-    const show = on && mapOk && anchor
-    input.style.color = show ? '#111' : 'transparent'
-    input.style.caretColor = show ? '#111' : 'transparent'
+  // 预览条贴在光标框**上方**：系统候选窗弹在输入框下方，两者错开才不会互相盖住。
+  // 顶到画布上边时翻到下方。没有光标框就退回最后点击处，再退回左上角。
+  function positionPreview() {
+    if (preview.style.display === 'none') return
+    const box = lastBox
+      || (lastClick ? { left: lastClick.x, top: Math.max(0, lastClick.y - 9), height: 18 } : { left: 8, top: 24, height: 18 })
+    const above = box.top - preview.offsetHeight - 4
+    preview.style.left = Math.max(4, Math.round(box.left)) + 'px'
+    preview.style.top = Math.round(above >= 2 ? above : box.top + box.height + 4) + 'px'
   }
+  function showPreview(text) {
+    if (!text) { preview.style.display = 'none'; return }
+    preview.textContent = text
+    preview.style.display = 'block'
+    positionPreview()
+  }
+  function hidePreview() { preview.style.display = 'none' }
+
+  applyCover()
 
   // Re-derive the live origin offset from a canvas click: clickPx (host-relative)
   // and the cursor's doc coords AT that click give offset = clickPx - scale*pos.
@@ -204,15 +245,33 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     } catch (e) { mapOk = false; return null }
   }
 
-  // Move the box to the current LO cursor. Cover (Phase A) until first click.
+  // Move the box to the current LO cursor. 拿不到光标映射时（没点过画布 / 映射
+  // 失败）退回**最后一次点击处**而不是全覆盖：系统候选窗跟着输入框走，落在用户
+  // 刚点的地方总比钉在画布左上角强。一次都没点过才全覆盖。
   async function reposition() {
     const rect = await computeRect()
-    if (rect) applyCursorBox(rect); else applyCover()
+    if (rect) applyCursorBox(rect)
+    else if (lastClick) applyCursorBox({ left: lastClick.x, top: Math.max(0, lastClick.y - 9), height: 18 })
+    else applyCover()
   }
 
   // Commit logic: identical to the verified toolbar bridge. dedup the input event
   // that trails compositionend so a committed phrase isn't inserted twice.
+  //
+  // 这个闩曾经是「中文标点要按两次」的根因：compositionend 后无条件置位，指望
+  // 紧跟着一定有一个 input 事件来把它消费掉。可**不是每次都有**——中文态下标点
+  // 直接上屏、组合被取消等情形都不补发，闩就一直挂着，把用户随后敲的第一个字符
+  // 吃掉，于是"按两次才过去"。两道保险：
+  //   1) 有 inputType 时只吞组合产物（insertCompositionText/insertFromComposition），
+  //      普通字符（直接上屏的标点走 insertText）一律照常上屏；
+  //   2) 无论如何都在下一个宏任务里自动解闩——尾随 input 与 compositionend 由浏览器
+  //      在同一个任务里连发，解闩排在它之后，闩绝不跨事件循环存活。
   let composing = false, skipNextInput = false
+  const armSkip = () => {
+    skipNextInput = true
+    setTimeout(() => { skipNextInput = false }, 0)
+  }
+  const isCompositionInput = (e) => e.inputType === 'insertCompositionText' || e.inputType === 'insertFromComposition'
   const doCommit = (t) => {
     input.value = ''
     if (!t) return
@@ -220,16 +279,21 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     try { Promise.resolve(commit(t)).catch((e) => log('overlay commit error: ' + (e && e.message || e))) }
     catch (e) { log('overlay commit error: ' + (e && e.message || e)) }
   }
-  input.addEventListener('compositionstart', () => { composing = true; setPreviewVisible(true) })
+  input.addEventListener('compositionstart', () => { composing = true })
+  input.addEventListener('compositionupdate', (e) => showPreview(e.data || ''))
   input.addEventListener('compositionend', (e) => {
-    composing = false; skipNextInput = true
-    setPreviewVisible(false)
+    composing = false; armSkip()
+    hidePreview()
     doCommit(e.data)
     reposition() // cursor advanced past the committed text
   })
   input.addEventListener('input', (e) => {
-    if (composing) return                                  // mid-composition: wait for end
-    if (skipNextInput) { skipNextInput = false; return }   // trailing event after compositionend
+    if (composing) { showPreview(input.value); return }    // mid-composition: wait for end
+    if (skipNextInput) {
+      skipNextInput = false
+      // 只吞组合产物；直接上屏的标点带 insertText，必须放行（见 armSkip 注释）
+      if (!e.inputType || isCompositionInput(e)) return
+    }
     doCommit(e.data != null ? e.data : input.value)
     reposition()
   })
@@ -380,6 +444,9 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     const cx = e.clientX, cy = e.clientY
     setTimeout(() => {
       try { input.focus() } catch (err) {}
+      // 光标映射不可用时就靠它摆输入框/预览条——所以每次点击都记，不看 phaseB。
+      const r = host.getBoundingClientRect()
+      lastClick = { x: cx - r.left, y: cy - r.top }
       anchorFromClick(cx, cy).then(reposition)
     }, 0)
   }
@@ -400,6 +467,7 @@ export function attachImeOverlay({ canvas, commit, getCursorRaw, onEnter, sendCo
     destroy() {
       canvas.removeEventListener('mouseup', onMouseUp)
       input.remove()
+      preview.remove()
     },
   }
 }

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -256,8 +256,9 @@ startEditorEndpoint({
   // in the document (Qt5-WASM gives the canvas no IME). Commits at the LO cursor
   // via the same verified path as agent commands. Attached in BOTH webview and
   // verify modes — local typing is a real-user need, not just a verification one.
+  let overlay = null
   try {
-    attachImeOverlay({
+    overlay = attachImeOverlay({
       canvas: document.getElementById('qtcanvas'),
       commit: (text) => endpoint.executor.executeCommand('insert_at_cursor', { text }),
       // Control keys: the overlay swallows keystrokes (it IS the focused input),
@@ -270,6 +271,43 @@ startEditorEndpoint({
       onLog: (m) => { console.log('[zeta-editor]', m); if (VERIFY) vlog(m) },
     })
   } catch (e) { console.error('[zeta-editor] IME overlay failed:', e); if (VERIFY) vlog('IME overlay failed: ' + (e && e.message || e)) }
+  // 触控板捏合缩放。Chromium 把捏合报成 ctrlKey + wheel；**不拦下来**浏览器就去
+  // 缩放整个 webview 页面——LO 自己的工具栏跟着一起放大、画布重采样发糊，而且
+  // IME 覆盖层的像素映射基准（CSS px per 1/100 mm）整个作废。拦下来改成缩放
+  // 文档视图（ViewSettings.ZoomValue），这才是用户要的那种缩放。
+  try {
+    const canvas = document.getElementById('qtcanvas')
+    let zoomPct = 100      // 本地镜像：捏合连发时以它为基准，引擎回值再校正
+    let zoomTarget = null
+    let zoomTimer = 0
+    // 起始缩放问一次引擎（无参 set_zoom = 只读回当前值）
+    endpoint.executor.executeCommand('set_zoom', {})
+      .then((r) => { if (r && r.success && r.zoom) zoomPct = r.zoom })
+      .catch(() => { /* 读不到就按 100% 起步 */ })
+    const flushZoom = () => {
+      zoomTimer = 0
+      const v = zoomTarget
+      zoomTarget = null
+      if (v == null) return
+      endpoint.executor.executeCommand('set_zoom', { value: v })
+        .then((r) => {
+          // 只有没有更新的目标在排队时才回写，否则会把连发中的中间值倒推回去
+          if (zoomTarget == null && r && r.success && r.zoom) zoomPct = r.zoom
+          if (overlay) overlay.reposition()   // 缩放后光标的像素位置变了
+        })
+        .catch((err) => console.warn('[zeta-editor] set_zoom failed:', err))
+    }
+    canvas.addEventListener('wheel', (ev) => {
+      if (!ev.ctrlKey) return                 // 普通两指滚动照旧交给 Qt
+      ev.preventDefault()
+      const next = Math.max(20, Math.min(600, Math.round(zoomPct * Math.exp(-ev.deltaY / 100))))
+      if (next === zoomPct) return
+      zoomPct = next
+      zoomTarget = next
+      // 一次捏合会连发几十个 wheel：合并到 ~60ms 一发，否则每一步都要等引擎重排版
+      if (!zoomTimer) zoomTimer = setTimeout(flushZoom, 60)
+    }, { passive: false })
+  } catch (e) { console.error('[zeta-editor] pinch-zoom wiring failed:', e) }
   if (VERIFY) {
     wireVerifyPanel(endpoint.executor)
     // Automation hook: lets a headless-browser test driver call the executor

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -205,6 +205,13 @@ function countRedlines() {
   try { const en = xModel.getRedlines().createEnumeration(); while (en.hasMoreElements()) { en.nextElement(); n++; } } catch (e) {}
   return n;
 }
+// 两个文本区间的起点是否重合——list_revisions 用它判断相邻修订是否首尾相接。
+// 跨 XText（正文 vs 表格单元格）比较时引擎抛 IllegalArgumentException：那本来
+// 也不算相接，吞掉当 false。
+function rangeStartsEqual(a, b) {
+  if (!a || !b) return false;
+  try { return a.getText().compareRegionStarts(a, b) === 0; } catch (e) { return false; }
+}
 // 把视图光标摆到 .uno:Accept/RejectTrackedChange 能命中的位置。**两种修订
 // 类型要求相反的摆法**（真机探针逐一试出来的，别凭直觉改）：
 //   - 插入型：文本在正文流里，光标必须**跨选**整个区间才命中；
@@ -398,6 +405,10 @@ function dispatchUno(url) {
 // ALLOWLIST map (name -> .uno: slot), deliberately NOT a raw dispatch
 // passthrough. Toggles (bold/italic/underline) are the engine's own, so
 // collapsed-cursor and mixed-selection semantics match the desktop app.
+// 缩放上下限。LO 自身允许 20%..600%，越界写进去引擎会自己夹，但夹之前会先按
+// 非法值重排一次版；在 JS 侧先夹住，捏合手势连发时不至于抖。
+const ZOOM_MIN = 20, ZOOM_MAX = 600;
+
 const UI_COMMANDS = {
   select_all: '.uno:SelectAll',
   bold: '.uno:Bold', italic: '.uno:Italic', underline: '.uno:Underline',
@@ -1841,6 +1852,29 @@ const EXEC = {
     dispatchUno(url);
     return { success: true, name: String(p.name) };
   },
+  // 视图缩放（触控板捏合 / Cmd+加减号 / 工具栏缩放控件）。
+  // {value} 给绝对百分比，{delta} 给相对增量；不传就只读回当前值。
+  // ZoomType 必须先切 BY_VALUE——停在「适合页宽」这类自动模式时，引擎会按窗口
+  // 重算 ZoomValue，写进去的数当场被覆盖。两个属性都是 sal_Int16，裸 number 会
+  // 编组成 long 被严格 setter 拒绝（且常被 try 吞掉），必须走 shortAny。
+  set_zoom(p) {
+    let vs = null;
+    try { vs = ctrl.getViewSettings(); } catch (e) { return { success: false, message: 'no view settings: ' + errStr(e) }; }
+    let cur = 100;
+    try { cur = Number(vs.getPropertyValue('ZoomValue')) || 100; } catch (e) {}
+    const hasValue = p && p.value != null;
+    const hasDelta = p && p.delta != null;
+    if (!hasValue && !hasDelta) return { success: true, zoom: cur };
+    let next = hasValue ? Number(p.value) : cur + Number(p.delta);
+    if (!isFinite(next)) return { success: false, message: 'set_zoom: value/delta 不是数字' };
+    next = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(next)));
+    try { vs.setPropertyValue('ZoomType', shortAny(css.view.DocumentZoomType.BY_VALUE)); } catch (e) {}
+    try { vs.setPropertyValue('ZoomValue', shortAny(next)); }
+    catch (e) { return { success: false, message: 'set_zoom 失败: ' + errStr(e) }; }
+    let applied = next;
+    try { applied = Number(vs.getPropertyValue('ZoomValue')) || next; } catch (e) {}
+    return { success: true, zoom: applied };
+  },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the
   // mm->px formula can be calibrated on the JS side without restarting LOWA.
@@ -3044,6 +3078,7 @@ const EXEC = {
   list_revisions(p) {
     const limit = Math.max(1, Math.min(500, Number(p && p.limit) || 200));
     const out = [];
+    let prevEnd = null;   // 上一条的 RedlineEnd，用来判「首尾相接」（见 contiguous）
     try {
       const en = xModel.getRedlines().createEnumeration();
       while (en.hasMoreElements() && out.length < limit) {
@@ -3059,9 +3094,16 @@ const EXEC = {
         // 删除型在页边模式下文本收进 redline 对象（getString 可取）；插入型的
         // 文本只在正文流里，要靠 RedlineStart/End 区间取。两路都试。
         try { if (typeof r.getString === 'function') it.text = String(r.getString() || ''); } catch (e) {}
+        let curEnd = null;
         try {
           const rs = r.getPropertyValue('RedlineStart'), re = r.getPropertyValue('RedlineEnd');
           if (rs && re) {
+            curEnd = re;
+            // 与上一条首尾相接？审阅面板据此把「连按 Backspace 产生的一串单字
+            // 删除」并成一条卡片（用户反馈：一个字一条记录很不科学）。页边模式下
+            // 删除文本被移出正文流，一串连续删除的区间会塌到同一个正文位置，正好
+            // 命中这个判据；同段落里相隔很远的两处删除则不会被误并。
+            it.contiguous = rangeStartsEqual(prevEnd, rs);
             if (!it.text) {
               const rc = rs.getText().createTextCursorByRange(rs);
               rc.gotoRange(re, true);
@@ -3073,6 +3115,7 @@ const EXEC = {
             try { it.inTable = !!rs.getPropertyValue('Cell'); } catch (e) { it.inTable = false; }
           }
         } catch (e) {}
+        prevEnd = curEnd;
         it.text = String(it.text || '').slice(0, 120);
         out.push(it);
       }


### PR DESCRIPTION
维护者真机反馈的五条缺陷，外加「自建工具栏」路线的技术前提验证。

## 修了什么

| 反馈 | 根因 | 修法 |
|---|---|---|
| 中文标点要按两次才过去 | IME 覆盖层的「吞掉尾随 input」闩在 `compositionend` 后无条件置位，指望后面一定跟一个 input 事件来消费。中文态标点直接上屏时并不补发，闩挂着不解，吃掉用户随后敲的第一个字符 | 按 `inputType` 只吞组合产物（insertCompositionText/insertFromComposition），并在下一个宏任务无条件解闩 |
| 看不到输入过程 | 覆盖层的 `<input>` 压在画布上必须全透明（显字会与正文叠印），组合中的文字因此完全不可见；没点过画布时输入框还全覆盖，候选窗钉在画布左上角 | 独立的不透明预览条显示组合文字（不依赖光标映射）；未锚定时输入框跟随最后一次点击 |
| 不支持手势缩放 | 没有缩放通道；Chromium 把捏合报成 `ctrl+wheel`，不拦就是浏览器缩放整个 webview（工具栏跟着放大、画布发糊、IME 像素映射基准作废） | 新增 `set_zoom` 原语（`ZoomType=BY_VALUE` + `ZoomValue`，均需 `shortAny`），canvas 上拦下 `ctrl+wheel` 改缩放文档视图 |
| 「已保存」经常变化、打扰 | 每次自动保存都走「保存中…→已保存→收回」三段 | 成功不出声，慢于 2s 才提示「保存中…」，失败常驻 |
| 浮层压住审阅面板标题 | `.libre-float` 钉在编辑器外层右上角，而审阅面板是并排挤宽的 | 浮层改钉在画布容器上 |
| 删除每个字符算一条记录 | 引擎按一次编辑操作记一条 redline，页边模式下不会自行合并（真机实证：连删 5 字 = 5 条） | worker 用区间比较给出 `contiguous`，面板把首尾相接的同类修订并成一张卡；整组处置从高索引往低索引走 |

## 右上角那个 ×

是 LibreOffice 菜单栏末端的「关闭文档」按钮，引擎画在 canvas 上。已定方向：
隐藏整条 LO 菜单栏，最终走自建工具栏。本 PR 只做了技术前提验证，不含 chrome 改动。

## 真机验证（24.2.8-zhcn-r4 引擎）

- `set_zoom`：只读 100 → 设 160 → delta -40 得 120 → 越界 5000 夹到 600
- `list_revisions`：连删 5 字得 5 条，`contiguous=[false,true,true,true,true]`，文本拼回「到底，久久」→ 面板并成一张卡
- LayoutManager：menubar/standardbar/textobjectbar/statusbar 均可隐藏且可逆；标尺走 `ViewSettings.ShowHoriRuler`；隐藏后编辑、`.uno:` 派发、格式原语、缩放全部照常
- **地雷**：`hideElement()` 返回值恒为 false，不代表失败，必须用 `isElementVisible()` 复核

`npm run test:lowa-e2e`：**324 passed / 0 failed**

## 后续

自建工具栏分期方案见 `docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md`（P1 命令层底座 → P1.5 选区事件 spike → P2 工具栏 → P3 菜单 → P4 逃生开关 → P5 验证）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)