### PR TITLE
fix(overview): ocrActions 补 promptFeatureNotConfigured 导入

### DIFF
--- a/frontend/src/pages/project-overview/ocrActions.js
+++ b/frontend/src/pages/project-overview/ocrActions.js
@@ -4,7 +4,7 @@
 // 经展开进组件 methods（纯搬移，Phase 3b 外置），`this` 即 project-overview 页面实例。
 
 
-import { ocrRecognize, createProjectFavorite, getProjectFiles, createFile, getApiBaseUrl } from '@/services/api.js'
+import { ocrRecognize, createProjectFavorite, getProjectFiles, createFile, getApiBaseUrl, promptFeatureNotConfigured } from '@/services/api.js'
 import { getSessionId } from '@/utils/auth.js'
 import { host } from '@/services/host.js'
 


### PR DESCRIPTION
OCR 未配置分支（`e.featureNotConfigured`）命中时会 ReferenceError：`ocrActions.js` 是 Phase 3b 从 project-overview.vue 外置的 mixin 模块，页面里的 import 不进该模块作用域，模块内第 245 行裸调用 `promptFeatureNotConfigured`。

修复：模块顶部补 `promptFeatureNotConfigured` 到既有的 `@/services/api.js` 导入。已核对同文件其余标识符（均为已导入符号、`this.*` 方法或浏览器/uni 全局），无同类缺口；project-overview.vue 本身的多行 import 正常。

这是 EN 版 i18n 迁移审校时发现的既有缺口，非迁移引入。

验证：
- `npm run check:emits` 通过（77 个 .vue）
- `npm run build:h5` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)