### PR TITLE
feat(editor): 自建工具栏 P1 命令层（状态回读 / .uno: 扩容 / chrome 开关）

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -72,10 +72,15 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 
 维护者定调：**最终形态是自建工具栏**，LO 自己的 menubar/toolbar 退场（菜单栏末端那个 × 会把 webview 里的文档关掉）。分期方案见 `docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md`。
 
-- 入口：`ctrl.getFrame().getPropertyValue('LayoutManager')`；元素 URL 形如 `private:resource/menubar/menubar`、`private:resource/toolbar/standardbar`、`private:resource/toolbar/textobjectbar`、`private:resource/statusbar/statusbar`，外加 11 条 `singlemode-*` 上下文工具栏。
-- **`hideElement()` 的返回值恒为 false，不代表失败**——必须用 `isElementVisible()` 复核。`showElement()` 可逆（返回 true 且 visible 恢复）。
+- 入口：`ctrl.getFrame().getPropertyValue('LayoutManager')`；元素 URL 形如 `private:resource/menubar/menubar`、`private:resource/toolbar/standardbar`、`private:resource/toolbar/textobjectbar`、`private:resource/statusbar/statusbar`，外加 11 条 `singlemode-*` 上下文工具栏（选中表格/图片时自动冒出，逐项关必须连它们一起关）。全集在 `office_thread.js` 的 `CHROME_URLS`。
+- **`hideElement()` 的返回值恒为 false，不代表失败**——必须用 `isElementVisible()` 复核。`showElement()` 可逆（返回 true 且 visible 恢复），这是「体验不能退步」的逃生口。`LayoutManager.setVisible(false)` 是关掉全部 chrome 最稳的一刀切。
 - 标尺不归 LayoutManager 管，是 `ViewSettings.ShowHoriRuler/ShowVertRuler`。
 - 隐藏 chrome 后编辑、`.uno:` 派发、格式原语、缩放全部照常；引擎自带对话框仍画在 canvas 上，不受影响。
+- **P1 命令层原语**（宿主发起，非 AI 管线）：`get_ui_state`（工具栏激活态一次拿全，实测 ~6ms）、`list_styles`（`name` 程序名 + `display` 显示名 + `inUse`）、`set_chrome`、`set_track_changes`（直接写 `RecordChanges`，比派发切换语义的 `.uno:TrackChanges` 可靠）。工具栏按钮统一走 `ui_command` 白名单，**不许改成任意 `.uno:` 透传**。
+- **`.uno:Grow` / `.uno:Shrink` 在本引擎是哑弹**（派发不报错，CharHeight 纹丝不动）。字号步进走 `get_ui_state` 读当前值 + `format_selection {fontSize}`。参数名不对称是既有契约：读回叫 `sizePt`，写入叫 `fontSize`，别改。
+- 撤销/重做可用性走 `xModel.getUndoManager()`（XUndoManagerSupplier 的**方法**）；`getPropertyValue('UndoManager')` 抛 UnknownPropertyException。
+- `XSelectionChangeListener` 装得上、选区变化每次触发，但**纯光标移动基本不触发**——工具栏状态刷新必须是「事件 + 聚焦时轮询」混合。
+- `format_selection` 拒绝空选区，工具栏「先设格式再打字」这条路目前是断的（P2 待补）。
 
 ## 已知地雷
 

--- a/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md
+++ b/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md
@@ -43,19 +43,32 @@ private:resource/statusbar/statusbar          状态栏
 与工具栏无关、可独立发布的五条，见本次 PR：中文标点吞键、输入过程不可见、
 手势缩放、保存状态胶囊、审阅面板逐字符删除合并。
 
-### P1 — 命令层底座（worker 侧）
+### P1 — 命令层底座（worker 侧，已完成）
 
-自建工具栏的每个按钮最终都要落到 worker 的一个 action 上。四件事：
+自建工具栏的每个按钮最终都要落到 worker 的一个 action 上。
 
-1. **`ui_command` 白名单扩容**。现在只有 12 条（IME 快捷键用）。按菜单分组扩到
-   覆盖工具栏 + 菜单条所需的 `.uno:` 全集。白名单仍是硬约束——**不开放任意
+1. **`ui_command` 白名单扩容**：加了删除线/上下标/清除格式/大小写/四种对齐/
+   增减缩进/项目符号/编号/分页/格式标记。白名单是硬约束——**不开放任意
    `.uno:` 透传**，否则宿主 DOM 就成了引擎的任意命令通道。
-2. **`get_ui_state`**：一次调用返回工具栏要显示的全部状态。已有的
-   `get_formatting` 覆盖了字符/段落属性，但缺三样：撤销/重做是否可用、修订开关
-   当前状态、当前缩放。工具栏是高频回读，必须一次拿全、且廉价。
-3. **`list_styles`**：段落样式清单，喂样式下拉（`set_style` 已经有了）。
-4. **`set_chrome`**：一次性隐藏/显示 menubar / 两条工具栏 / 状态栏 / 标尺，
-   每一步用 `isElementVisible` 复核后如实返回。
+2. **`get_ui_state`**：一次拿全字符/段落/视图/选区/撤销可用性。实测 ~6ms。
+3. **`list_styles`**：段落样式清单（`name` 程序名 + `display` 显示名 + `inUse`）。
+4. **`set_chrome`**：逐项或 `{all:false}` 一刀切隐藏 LO chrome，每一步用
+   `isElementVisible` 复核后如实返回。
+5. **`set_track_changes`**：修订开关。直接写 `RecordChanges` 属性而不是派发
+   `.uno:TrackChanges`——后者是切换语义，宿主要设成确定状态还得先读再判。
+
+**真机实测得到的三条硬结论：**
+
+- **`.uno:Grow` / `.uno:Shrink` 在本引擎是哑弹**：派发不报错，`CharHeight`
+  纹丝不动（12→12）。已从白名单剔除。字号步进改由宿主做：`get_ui_state` 读到
+  当前字号 → `format_selection {sizePt}`（这条路已验证）。**宁可不给按钮，
+  也不给点了没反应的按钮。**
+- **撤销/重做可用性走 `xModel.getUndoManager()`**（XUndoManagerSupplier 的方法），
+  不是属性——`getPropertyValue('UndoManager')` 抛 UnknownPropertyException。
+  实测能读出 `canUndo/canRedo`。读不到时宿主让两个按钮常亮，不许灰掉能用的功能。
+- **`LayoutManager.setVisible(false)` 可用**，是关掉全部 chrome 最稳的一刀切；
+  逐项关的时候必须把 11 条 `singlemode-*` 上下文工具栏一起关，否则一选中表格
+  就又钻出一条老气的工具栏。
 
 ### P1.5 — 状态刷新机制（spike 已完成，2026-08-14）
 
@@ -80,6 +93,21 @@ private:resource/statusbar/statusbar          状态栏
 
 注：方向键其实也会经 IME 覆盖层转成 `move_cursor` 命令，命中第 2 条；轮询主要
 兜的是画布点击定位和引擎内部的光标移动。
+
+**P1 留给 P2 的两个已知缺口：**
+
+- **空选区下改不了格式**。`format_selection` 要求非空选区（`nothing selected —
+  select first, then format`）。但工具栏的常见用法是「先设好字号再开始打字」，
+  这条路现在是断的。P2 要么扩原语支持塌陷光标（写 CharHeight 到 view cursor 上，
+  LO 本身支持「后续输入用此格式」），要么在没有选区时把按钮置灰并说明原因——
+  但**不许点了没反应**。
+  （注意参数名：`get_ui_state` 回的是 `sizePt`，`format_selection` 收的是
+  `fontSize`；这是既有的 AI 工具契约，别为了对称去改名。）
+- **样式显示名的语言存疑**。spike 环境里 `get_ui_lang` 回 `ooLocale: en-US`，
+  于是 `DisplayName` 拿到的是英文（Default Paragraph Style / Body Text）；而真机
+  截图里 LO 自己的样式下拉显示的是中文（默认段落样式）。两者对不上，说明 spike
+  的 boot 没走到 zh-CN。P2 的做法：优先用 `display`，同时自备一张常用样式
+  （正文/标题 1-6/引用/列表…）的中文名映射兜底，**两条路都在，语言就不会翻车**。
 
 ### P2 — 工具栏组件（宿主 DOM）
 

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -36,6 +36,9 @@ export const EDITOR_ACTIONS = [
   // [视图缩放] 触控板捏合 / Cmd+加减号；{value} 绝对百分比、{delta} 相对增量，
   // 不带参数就是只读回当前缩放。宿主发起，不是 AI 管线。
   'set_zoom',
+  // [自建工具栏 P1] 工具栏状态一次性回读、样式下拉数据、LO chrome 开关、修订开关。
+  // 全部宿主发起（EditorToolbar → executor），不是 AI 管线。
+  'get_ui_state', 'list_styles', 'set_chrome', 'set_track_changes',
   // [Track D] load the user's real document into the editor (host-initiated, not
   // an AI-agent command): {bytes, name} -> MEMFS + loadComponentFromURL + retarget.
   'load_document',

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -401,14 +401,42 @@ function dispatchUno(url) {
   css.frame.DispatchHelper.create(context).executeDispatch(ctrl.getFrame(), url, '', 0, []);
 }
 
-// Desktop-keyboard parity set for the IME overlay's ui_command action — an
-// ALLOWLIST map (name -> .uno: slot), deliberately NOT a raw dispatch
-// passthrough. Toggles (bold/italic/underline) are the engine's own, so
-// collapsed-cursor and mixed-selection semantics match the desktop app.
 // 缩放上下限。LO 自身允许 20%..600%，越界写进去引擎会自己夹，但夹之前会先按
 // 非法值重排一次版；在 JS 侧先夹住，捏合手势连发时不至于抖。
 const ZOOM_MIN = 20, ZOOM_MAX = 600;
 
+// LO 自己的 chrome（自建工具栏要关掉的那些）。singlemode-* 是选中表格/图片时
+// 自动冒出来的上下文工具栏——逐项关的时候必须连它们一起关，否则一选中表格就
+// 又钻出一条老气的工具栏。真机枚举所得（LayoutManager.getElements）。
+const CHROME_URLS = {
+  menubar: 'private:resource/menubar/menubar',
+  statusbar: 'private:resource/statusbar/statusbar',
+  toolbars: [
+    'private:resource/toolbar/standardbar',
+    'private:resource/toolbar/textobjectbar',
+    'private:resource/toolbar/findbar',
+    'private:resource/toolbar/singlemode-ole',
+    'private:resource/toolbar/singlemode-draw',
+    'private:resource/toolbar/singlemode-form',
+    'private:resource/toolbar/singlemode-text',
+    'private:resource/toolbar/singlemode-frame',
+    'private:resource/toolbar/singlemode-media',
+    'private:resource/toolbar/singlemode-table',
+    'private:resource/toolbar/singlemode-graphic',
+    'private:resource/toolbar/singlemode-drawtext',
+    'private:resource/toolbar/singlemode-annotation',
+    'private:resource/toolbar/singlemode-printpreview',
+  ],
+};
+
+// Desktop-keyboard parity set for the IME overlay's ui_command action — an
+// ALLOWLIST map (name -> .uno: slot), deliberately NOT a raw dispatch
+// passthrough. Toggles (bold/italic/underline) are the engine's own, so
+// collapsed-cursor and mixed-selection semantics match the desktop app.
+//
+// 自建工具栏（见 docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md）
+// 的按钮同样走这张表。**白名单是安全边界，不许改成任意 .uno: 透传**——那等于把
+// 宿主 DOM 变成引擎的任意命令通道。新增按钮就在这里加一行。
 const UI_COMMANDS = {
   select_all: '.uno:SelectAll',
   bold: '.uno:Bold', italic: '.uno:Italic', underline: '.uno:Underline',
@@ -420,6 +448,22 @@ const UI_COMMANDS = {
   line_start_sel: '.uno:StartOfLineSel', line_end_sel: '.uno:EndOfLineSel',
   escape: '.uno:Escape',                                  // 取消选区
   page_up: '.uno:PageUp', page_down: '.uno:PageDown',
+  // ---- [P1 自建工具栏] 字符格式 ----
+  strikeout: '.uno:Strikeout',
+  superscript: '.uno:SuperScript', subscript: '.uno:SubScript',
+  // 字号增大/减小**不走 .uno:Grow/.uno:Shrink**——本引擎上这两个槽是哑弹，
+  // 派发不报错也不改 CharHeight（真机实证 12→12）。宿主用 get_ui_state 读到
+  // 当前字号再调 format_selection{sizePt} 自己步进，别留成点了没反应的按钮。
+  clear_formatting: '.uno:ResetAttributes',               // 清除直接格式
+  case_upper: '.uno:ChangeCaseToUpper', case_lower: '.uno:ChangeCaseToLower',
+  // ---- [P1 自建工具栏] 段落格式 ----
+  align_left: '.uno:LeftPara', align_center: '.uno:CenterPara',
+  align_right: '.uno:RightPara', align_justify: '.uno:JustifyPara',
+  indent_more: '.uno:IncrementIndent', indent_less: '.uno:DecrementIndent',
+  bullet_list: '.uno:DefaultBullet', number_list: '.uno:DefaultNumbering',
+  // ---- [P1 自建工具栏] 插入 / 视图 ----
+  page_break: '.uno:InsertPagebreak',
+  formatting_marks: '.uno:ControlCodes',                  // 显示/隐藏格式标记
 };
 
 // Shared verification snapshot returned by mutating commands: where the cursor
@@ -1874,6 +1918,152 @@ const EXEC = {
     let applied = next;
     try { applied = Number(vs.getPropertyValue('ZoomValue')) || next; } catch (e) {}
     return { success: true, zoom: applied };
+  },
+  // ---- [P1 自建工具栏] 状态回读 / 样式清单 / chrome 开关 -------------------
+  // 工具栏的激活态（B 是否高亮、当前字体字号样式对齐、能不能撤销）一次拿全。
+  // 高频调用（选区事件 + 400ms 聚焦轮询），实测整套读一遍约 6ms——每个字段各自
+  // try/catch，缺一个不影响其余，绝不因为某个属性在当前上下文不存在就整体失败。
+  get_ui_state() {
+    const out = { success: true };
+    let vc = null;
+    try { vc = ctrl.getViewCursor(); } catch (e) { return { success: false, message: errStr(e) }; }
+    const ch = {};
+    try { ch.bold = vc.getPropertyValue('CharWeight') > 100; } catch (e) {}
+    try { ch.italic = !enumEq(vc.getPropertyValue('CharPosture'), css.awt.FontSlant.NONE); } catch (e) {}
+    try { ch.underline = !enumEq(vc.getPropertyValue('CharUnderline'), css.awt.FontUnderline.NONE); } catch (e) {}
+    try { ch.strikeout = !enumEq(vc.getPropertyValue('CharStrikeout'), css.awt.FontStrikeout.NONE); } catch (e) {}
+    try {
+      const esc = Number(vc.getPropertyValue('CharEscapement')) || 0;
+      ch.superscript = esc > 0; ch.subscript = esc < 0;
+    } catch (e) {}
+    try { ch.font = vc.getPropertyValue('CharFontName'); } catch (e) {}
+    try { ch.fontAsian = vc.getPropertyValue('CharFontNameAsian'); } catch (e) {}
+    try { ch.sizePt = vc.getPropertyValue('CharHeight'); } catch (e) {}
+    try { const c = vc.getPropertyValue('CharColor'); ch.color = c === -1 ? 'auto' : '#' + ('000000' + (c >>> 0).toString(16)).slice(-6); } catch (e) {}
+    try { const h = vc.getPropertyValue('CharHighlight'); ch.highlight = h === -1 ? 'none' : '#' + ('000000' + (h >>> 0).toString(16)).slice(-6); } catch (e) {}
+    out.character = ch;
+    const pa = {};
+    try { pa.styleName = vc.getPropertyValue('ParaStyleName'); } catch (e) {}
+    try {
+      const a = vc.getPropertyValue('ParaAdjust');
+      const A = css.style.ParagraphAdjust;
+      pa.alignment = enumEq(a, A.CENTER) ? 'center' : enumEq(a, A.RIGHT) ? 'right'
+        : (enumEq(a, A.BLOCK) || enumEq(a, A.STRETCH)) ? 'justify' : 'left';
+    } catch (e) {}
+    try { pa.outlineLevel = vc.getPropertyValue('OutlineLevel') || 0; } catch (e) {}
+    // 列表种类：工具栏要分别高亮「项目符号」和「编号」两个按钮。NumberingIsNumber
+    // 只说明在不在列表里，具体是符号还是数字要看规则第 0 级的 NumberingType。
+    try {
+      pa.inList = !!vc.getPropertyValue('NumberingIsNumber');
+      if (pa.inList) {
+        pa.listKind = 'list';   // 读不出细分时的保守取值
+        const rules = vc.getPropertyValue('NumberingRules');
+        if (rules && rules.getCount && rules.getCount() > 0) {
+          const lvl = rules.getByIndex(0);
+          let nt = null;
+          for (let i = 0; i < (lvl.length || 0); i++) if (lvl[i].Name === 'NumberingType') nt = Number(lvl[i].Value);
+          const NT = css.style.NumberingType;
+          if (nt != null) pa.listKind = (nt === NT.CHAR_SPECIAL || nt === NT.BITMAP) ? 'bullet' : 'number';
+        }
+      } else pa.listKind = 'none';
+    } catch (e) {}
+    out.paragraph = pa;
+    const view = {};
+    try { view.zoom = ctrl.getViewSettings().getPropertyValue('ZoomValue'); } catch (e) {}
+    try { view.recordChanges = !!xModel.getPropertyValue('RecordChanges'); } catch (e) {}
+    out.view = view;
+    const sel = {};
+    try { sel.collapsed = (vc.getString() || '').length === 0; } catch (e) {}
+    try { sel.inTable = !!vc.getPropertyValue('Cell'); } catch (e) { sel.inTable = false; }
+    out.selection = sel;
+    // 撤销/重做可用性。UndoManager 不是属性（getPropertyValue 抛
+    // UnknownPropertyException，真机验过），要走 XUndoManagerSupplier 的方法。
+    // 实在拿不到就不给字段——宿主据此让两个按钮常亮，宁可多点一下也别灰掉能用的功能。
+    try {
+      const um = xModel.getUndoManager();
+      const u = {};
+      try { u.canUndo = !!um.isUndoPossible(); } catch (e) {}
+      try { u.canRedo = !!um.isRedoPossible(); } catch (e) {}
+      if (u.canUndo != null || u.canRedo != null) out.undo = u;
+    } catch (e) { out.undoErr = errStr(e); }
+    return out;
+  },
+  // 段落样式清单（样式下拉）。getElementNames() 给的是**英文程序名**
+  // （Standard / Heading 1），中文界面要显示的是 DisplayName——两者都带回，
+  // set_style 认的仍是程序名。
+  list_styles(p) {
+    if (!isWriterDoc()) return tableFail(NOT_TEXT_DOC_MSG);
+    const kind = String((p && p.kind) || 'paragraph').toLowerCase();
+    const familyName = kind === 'character' ? 'CharacterStyles' : 'ParagraphStyles';
+    try {
+      const fam = xModel.getStyleFamilies().getByName(familyName);
+      const names = fam.getElementNames();
+      const out = [];
+      for (let i = 0; i < (names.length || 0); i++) {
+        const it = { name: String(names[i]) };
+        try {
+          const st = fam.getByName(names[i]);
+          try { it.display = String(st.getPropertyValue('DisplayName') || it.name); } catch (e) { it.display = it.name; }
+          try { it.inUse = !!st.isInUse(); } catch (e) {}
+        } catch (e) { it.display = it.name; }
+        out.push(it);
+      }
+      return { success: true, kind: kind, count: out.length, styles: out };
+    } catch (e) { return tableFail('读取样式库失败: ' + errStr(e)); }
+  },
+  // LO 自己的 chrome 开关（自建工具栏上线后默认全关，设置里留逃生开关）。
+  // {all:false} 走 LayoutManager.setVisible(false) 一刀切——这样上下文工具栏
+  // （选中表格/图片时自动冒出来的 singlemode-*）也不会再钻出来；逐项开关用
+  // {menubar/toolbars/statusbar/rulers}。
+  // **hideElement() 的返回值恒为 false，不代表失败**（真机实证），一律用
+  // isElementVisible() 复核后如实回报。
+  set_chrome(p) {
+    const req = p || {};
+    const out = { success: true, applied: {} };
+    let lm = null;
+    try { lm = ctrl.getFrame().getPropertyValue('LayoutManager'); }
+    catch (e) { return { success: false, message: 'LayoutManager 不可达: ' + errStr(e) }; }
+    if (!lm) return { success: false, message: 'LayoutManager 为空' };
+    const setOne = (url, on) => {
+      try { if (on) lm.showElement(url); else lm.hideElement(url); } catch (e) {}
+      try { return !!lm.isElementVisible(url); } catch (e) { return null; }
+    };
+    if (req.all != null) {
+      try { lm.setVisible(!!req.all); } catch (e) { out.allErr = errStr(e); }
+      try { out.applied.all = !!lm.isVisible(); } catch (e) {}
+    }
+    if (req.menubar != null) out.applied.menubar = setOne(CHROME_URLS.menubar, !!req.menubar);
+    if (req.statusbar != null) out.applied.statusbar = setOne(CHROME_URLS.statusbar, !!req.statusbar);
+    if (req.toolbars != null) {
+      const states = {};
+      for (let i = 0; i < CHROME_URLS.toolbars.length; i++) {
+        const u = CHROME_URLS.toolbars[i];
+        states[u.slice(u.lastIndexOf('/') + 1)] = setOne(u, !!req.toolbars);
+      }
+      out.applied.toolbars = states;
+    }
+    if (req.rulers != null) {
+      const vs = ctrl.getViewSettings();
+      const r = {};
+      for (const k of ['ShowHoriRuler', 'ShowVertRuler']) {
+        try { vs.setPropertyValue(k, !!req.rulers); } catch (e) {}
+        try { r[k] = !!vs.getPropertyValue(k); } catch (e) {}
+      }
+      out.applied.rulers = r;
+    }
+    return out;
+  },
+  // 修订开关（工具栏的「修订」按钮）。RecordChanges 是文档属性，直接写比派发
+  // .uno:TrackChanges 可靠——后者是切换语义，宿主想设成确定状态就得先读再判。
+  set_track_changes(p) {
+    if (!isWriterDoc()) return tableFail(NOT_TEXT_DOC_MSG);
+    if (p && p.on != null) {
+      try { xModel.setPropertyValue('RecordChanges', !!p.on); }
+      catch (e) { return tableFail('设置修订开关失败: ' + errStr(e)); }
+    }
+    let on = null;
+    try { on = !!xModel.getPropertyValue('RecordChanges'); } catch (e) {}
+    return { success: true, recordChanges: on };
   },
   // [spike] Phase B: raw measurements for mapping the view cursor to canvas
   // pixels. We DELIBERATELY return primitives (not a final px rect) so the

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -1418,6 +1418,86 @@ try {
     check('Writer 文档上 slide_add_table 被明确拒绝', guardTable.success === false && /演示文稿/.test(guardTable.message || ''), JSON.stringify(guardTable))
   }
 
+  // ---------- 组 24：自建工具栏命令层（P1）----------
+  // 每条都断言**可观察效果**，不是「派发没报错」——工具栏上一个点了没反应的
+  // 按钮就是体验退步。`.uno:Grow/Shrink` 正是因为这条规矩被剔出白名单的
+  // （本引擎上派发成功但 CharHeight 纹丝不动）。
+  console.log('\n[24] 自建工具栏命令层：状态回读 / 扩展 .uno: / 样式清单 / chrome 开关')
+  {
+    await exec('debug_fresh_document')
+    await exec('debug_set_record_changes', { on: false })
+    await exec('ui_command', { name: 'select_all' })
+    await exec('replace_selection', { text: '工具栏命令层回归段落。' })
+    await exec('select_paragraph', {})
+
+    const st = await exec('get_ui_state')
+    check('get_ui_state 成功', st.success === true, JSON.stringify(st).slice(0, 200))
+    check('回读字符状态', typeof st.character.bold === 'boolean' && st.character.sizePt > 0, JSON.stringify(st.character))
+    check('回读段落样式与对齐', !!st.paragraph.styleName && !!st.paragraph.alignment, JSON.stringify(st.paragraph))
+    check('回读缩放与修订开关', st.view.zoom > 0 && st.view.recordChanges === false, JSON.stringify(st.view))
+    check('回读选区状态', st.selection.collapsed === false, JSON.stringify(st.selection))
+    // 撤销可用性走 XUndoManagerSupplier 的方法（属性读法会抛 UnknownPropertyException）
+    check('回读撤销/重做可用性', st.undo && typeof st.undo.canUndo === 'boolean', JSON.stringify(st.undo || st.undoErr))
+
+    await exec('ui_command', { name: 'strikeout' })
+    check('strikeout 生效', (await exec('get_ui_state')).character.strikeout === true)
+    await exec('ui_command', { name: 'strikeout' })
+    await exec('ui_command', { name: 'superscript' })
+    check('superscript 生效', (await exec('get_ui_state')).character.superscript === true)
+    await exec('ui_command', { name: 'superscript' })
+    await exec('ui_command', { name: 'align_center' })
+    check('align_center 生效', (await exec('get_ui_state')).paragraph.alignment === 'center')
+    await exec('ui_command', { name: 'align_justify' })
+    check('align_justify 生效', (await exec('get_ui_state')).paragraph.alignment === 'justify')
+    await exec('ui_command', { name: 'align_left' })
+    check('align_left 生效', (await exec('get_ui_state')).paragraph.alignment === 'left')
+    await exec('ui_command', { name: 'bullet_list' })
+    const bl = (await exec('get_ui_state')).paragraph
+    check('bullet_list 识别为项目符号', bl.inList === true && bl.listKind === 'bullet', JSON.stringify(bl))
+    await exec('ui_command', { name: 'bullet_list' })
+    await exec('ui_command', { name: 'number_list' })
+    check('number_list 识别为编号', (await exec('get_ui_state')).paragraph.listKind === 'number')
+    await exec('ui_command', { name: 'number_list' })
+    await exec('ui_command', { name: 'bold' })
+    await exec('ui_command', { name: 'clear_formatting' })
+    check('clear_formatting 清掉直接格式', (await exec('get_ui_state')).character.bold === false)
+    check('白名单外的名字被拒绝', (await exec('ui_command', { name: 'font_grow' })).success === false)
+
+    // 字号步进的宿主实现路线（.uno:Grow 是哑弹，工具栏靠这条）
+    const sz0 = (await exec('get_ui_state')).character.sizePt
+    await exec('format_selection', { fontSize: sz0 + 2 })
+    check('字号步进（读回 sizePt → 写 fontSize）生效', (await exec('get_ui_state')).character.sizePt === sz0 + 2)
+    await exec('format_selection', { fontSize: sz0 })
+
+    check('set_track_changes 开', (await exec('set_track_changes', { on: true })).recordChanges === true)
+    check('set_track_changes 关', (await exec('set_track_changes', { on: false })).recordChanges === false)
+    check('set_track_changes 只读回读', (await exec('set_track_changes')).recordChanges === false)
+
+    const ls = await exec('list_styles')
+    check('list_styles 返回样式清单', ls.success === true && ls.count > 50, String(ls.count))
+    const std = (ls.styles || []).find((s) => s.name === 'Standard')
+    check('样式带显示名与在用标记', !!(std && std.display) && std.inUse === true, JSON.stringify(std))
+
+    const hidden = await exec('set_chrome', { menubar: false, statusbar: false, toolbars: false, rulers: false })
+    check('menubar 已隐藏', hidden.applied.menubar === false, JSON.stringify(hidden.applied.menubar))
+    check('statusbar 已隐藏', hidden.applied.statusbar === false)
+    check('两条主工具栏已隐藏',
+      hidden.applied.toolbars.standardbar === false && hidden.applied.toolbars.textobjectbar === false,
+      JSON.stringify(hidden.applied.toolbars))
+    check('上下文工具栏也一并隐藏（否则选中表格就冒出来）',
+      hidden.applied.toolbars['singlemode-table'] === false, JSON.stringify(hidden.applied.toolbars))
+    check('标尺已关', hidden.applied.rulers.ShowHoriRuler === false, JSON.stringify(hidden.applied.rulers))
+    // chrome 全隐藏之后功能不许退步
+    await exec('ui_command', { name: 'select_all' })
+    await exec('replace_selection', { text: 'chrome 隐藏后仍可编辑' })
+    check('隐藏后仍可编辑', (await doc()).indexOf('仍可编辑') >= 0, await doc())
+    check('隐藏后状态回读仍可用', (await exec('get_ui_state')).success === true)
+    check('隐藏后缩放仍可用', (await exec('set_zoom', { value: 130 })).zoom === 130)
+    check('menubar 可恢复（逃生开关）', (await exec('set_chrome', { menubar: true })).applied.menubar === true)
+    await exec('set_zoom', { value: 100 })
+    await exec('set_chrome', { statusbar: true, toolbars: true, rulers: true })
+  }
+
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
 } finally {
   await browser.close()


### PR DESCRIPTION
[自建工具栏方案](../blob/master/docs/superpowers/specs/2026-08-14-editor-chrome-self-built-toolbar.md)的 P1：worker 侧命令层底座。工具栏每个按钮最终都落到这一层的一个 action 上。本 PR **不含任何 UI 改动**，LO chrome 仍照常显示。

## 新增

| action | 用途 |
|---|---|
| `get_ui_state` | 工具栏激活态一次拿全（字符/段落/视图/选区/撤销可用性），实测 ~6ms |
| `list_styles` | 样式下拉数据（程序名 + DisplayName + isInUse） |
| `set_chrome` | 逐项或 `{all:false}` 隐藏 LO chrome，每步 `isElementVisible` 复核 |
| `set_track_changes` | 修订开关（直接写 `RecordChanges`，比切换语义的 `.uno:TrackChanges` 可靠） |

`ui_command` 白名单扩了 16 条：删除线、上下标、清除格式、大小写、四种对齐、增减缩进、项目符号、编号、分页、格式标记。**白名单是安全边界，不开放任意 `.uno:` 透传。**

## 真机实测挖出来的三条

- **`.uno:Grow` / `.uno:Shrink` 是哑弹**：派发不报错，`CharHeight` 纹丝不动（12→12）。已剔出白名单，字号步进改由宿主做（读回 `sizePt` → 写 `format_selection {fontSize}`）。**宁可不给按钮，也不给点了没反应的按钮**——这条已写成回归断言，以后加白名单必须断言可观察效果。
- **撤销/重做可用性走 `xModel.getUndoManager()`**（XUndoManagerSupplier 的方法），`getPropertyValue('UndoManager')` 抛 UnknownPropertyException。读不到时宿主让按钮常亮，不许灰掉能用的功能。
- **逐项关 chrome 必须连 11 条 `singlemode-*` 上下文工具栏一起关**，否则一选中表格就又冒出一条老气的工具栏。

## 「体验不能退步」的两条保证（已入回归）

- chrome 全隐藏后：编辑、`.uno:` 派发、格式原语、缩放、状态回读**全部照常**
- `menubar` 可通过 `showElement` 恢复 —— 逃生开关成立

## 验证

`npm run test:lowa-e2e`：**354 passed / 0 failed**（原 324 + 新增组 24 的 30 条）

## 留给 P2 的两个已知缺口（已记进 spec）

1. `format_selection` 拒绝空选区，「先设好字号再打字」这条路是断的
2. 样式显示名的语言存疑：spike 环境 `ooLocale=en-US` 拿到英文名，真机 LO 下拉是中文。P2 优先用 `display` + 自备常用样式中文名映射兜底

🤖 Generated with [Claude Code](https://claude.com/claude-code)