### PR TITLE
feat: AI 链路 SSE 展示与落库文案双语（EN 版 PR4-A）

### DIFF
--- a/backend/src/main/java/com/checkba/service/AppLanguageService.java
+++ b/backend/src/main/java/com/checkba/service/AppLanguageService.java
@@ -1,5 +1,6 @@
 package com.checkba.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,15 @@ public class AppLanguageService {
     private static final Set<String> SUPPORTED = Set.of(ZH_CN, EN_US);
 
     private final SystemSettingService settings;
+
+    /**
+     * 登记 LangText 静态桥。刻意用 @PostConstruct 而不是构造器：只有 Spring 容器里的
+     * 这个实例才该成为全局指针，单测里 new 出来的实例不登记（否则跨测试类污染静态状态）。
+     */
+    @PostConstruct
+    void registerLangTextBridge() {
+        LangText.register(this);
+    }
 
     public String language() {
         String v = settings.get(KEY, ZH_CN);

--- a/backend/src/main/java/com/checkba/service/LangText.java
+++ b/backend/src/main/java/com/checkba/service/LangText.java
@@ -1,0 +1,44 @@
+package com.checkba.service;
+
+/**
+ * 静态语言文案桥：非 Spring 托管的产文案点（enum、new 出来的 handler、静态方法）
+ * 经它按应用语言二选一取用户可见文案，Spring bean 也可直接用它避免构造器扩散。
+ *
+ * <p>指针由 AppLanguageService 的 @PostConstruct 登记——只登记 Spring 容器里的那个实例，
+ * 单测里 new 出来的不登记，避免跨测试类污染静态状态。未登记（启动早期 / 纯单测）或取值
+ * 抛异常一律回退中文，与存量行为逐字节一致（v0.15.0 static 指针顺序的教训：静态指针必须
+ * null 安全回退，不搞全局监听器）。
+ */
+public final class LangText {
+
+    private static volatile AppLanguageService languageService;
+
+    private LangText() {
+    }
+
+    /** 由 AppLanguageService @PostConstruct 调用；测试可显式登记后在收尾 reset()。 */
+    public static void register(AppLanguageService service) {
+        languageService = service;
+    }
+
+    /** 测试收尾用：清掉登记，回到「未初始化=中文」的默认态。 */
+    public static void reset() {
+        languageService = null;
+    }
+
+    public static boolean isEnglish() {
+        AppLanguageService svc = languageService;
+        if (svc == null) return false;
+        try {
+            return svc.isEnglish();
+        } catch (Exception e) {
+            // 语言取不到时宁可回退中文，也不能让一条进度文案把整轮对话带崩
+            return false;
+        }
+    }
+
+    /** 按应用语言二选一：zh-CN（含未初始化/异常回退）取 zh，en-US 取 en。 */
+    public static String of(String zh, String en) {
+        return isEnglish() ? en : zh;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectAiMessageService.java
@@ -212,8 +212,9 @@ public class ProjectAiMessageService {
      * Clean conversation title by stripping common XML tags like <thinking>, <process>, etc.
      */
     private String cleanTitle(String rawTitle) {
+        // 读时兜底按当前应用语言渲染（存量库里也可能存着另一种语言的字面量，不迁移）
         if (rawTitle == null || rawTitle.isBlank()) {
-            return "新对话";
+            return LangText.of("新对话", "New chat");
         }
         // Remove common XML tags
         String cleaned = rawTitle
@@ -232,7 +233,7 @@ public class ProjectAiMessageService {
             cleaned = cleaned.substring(0, 100) + "...";
         }
         
-        return cleaned.isEmpty() ? "新对话" : cleaned;
+        return cleaned.isEmpty() ? LangText.of("新对话", "New chat") : cleaned;
     }
 
     /**
@@ -309,16 +310,23 @@ public class ProjectAiMessageService {
      * 调用 LLM 生成对话标题（基于用户第一条消息）
      */
     public String generateConversationTitle(String userMessage, dev.langchain4j.model.chat.ChatLanguageModel model) {
-        String prompt = "请为以下用户问题生成一个简短的对话标题（不超过15个字，不要标点符号，只输出标题本身）:\n" + userMessage;
+        // 英文模式换英文 prompt：否则英文界面会持续产生中文标题（标题是落库文案，跟应用语言走）
+        String prompt = LangText.of(
+                "请为以下用户问题生成一个简短的对话标题（不超过15个字，不要标点符号，只输出标题本身）:\n",
+                "Generate a short conversation title in English for the following user question "
+                        + "(no more than 8 words, no punctuation, output only the title itself):\n")
+                + userMessage;
         try {
             String title = model.generate(prompt);
             // Clean any XML tags or extra formatting the model might output
             title = title.replaceAll("<[^>]+>", "").replaceAll("```[a-z]*", "").trim();
             title = title.replaceAll("^[\"']+|[\"']+$", ""); // Remove quotes
-            if (title.length() > 30) title = title.substring(0, 30);
-            return title.isEmpty() ? "新对话" : title;
+            // 英文标题按词计数，30 字符会把词砍半：英文模式放宽到 60 字符（zh 行为不变）
+            int cap = LangText.isEnglish() ? 60 : 30;
+            if (title.length() > cap) title = title.substring(0, cap);
+            return title.isEmpty() ? LangText.of("新对话", "New chat") : title;
         } catch (Exception e) {
-            return "新对话";
+            return LangText.of("新对话", "New chat");
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -3,6 +3,7 @@ package com.checkba.service.ai;
 import com.checkba.controller.ai.AiAgentController;
 import com.checkba.model.ai.AgentMode;
 import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.service.LangText;
 import com.checkba.service.ProjectAiMessageService;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
@@ -35,6 +36,13 @@ public class AgentOrchestrator {
 
     // 循环步数预算：达到上限时优雅收尾（保存进度 + 告知用户可继续），而不是静默中断
     private static final int MAX_LOOP_DEPTH = 30;
+
+    /** 步数预算耗尽的用户提示（抽成方法便于按应用语言断言，见 AgentTextLanguageTest）。 */
+    static String maxDepthNotice() {
+        return LangText.of(
+                "\n\n> 本轮已达最大执行步数（" + MAX_LOOP_DEPTH + " 步），先暂停。已完成的修改均已生效，点击下方「继续」按钮可接着执行剩余任务。",
+                "\n\n> This run reached the maximum step budget (" + MAX_LOOP_DEPTH + " steps) and is paused. All completed changes have taken effect; click the Continue button below to carry on with the remaining work.");
+    }
     // 工具连续失败达到该次数后，向模型注入强提示要求收敛
     private static final int CONSECUTIVE_FAILURE_NUDGE = 3;
 
@@ -153,14 +161,15 @@ public class AgentOrchestrator {
         
         // 如果有部分内容，保存并标记为已中断
         if (!partialContent.isEmpty()) {
-            String contentToSave = partialContent + "\n\n[已中断]";
+            String contentToSave = partialContent + LangText.of("\n\n[已中断]", "\n\n[Interrupted]");
             saveAssistantMessage(conversationId, projectId, userId, contentToSave);
             log.info("Saved partial content ({} chars) for cancelled conversation: {}", partialContent.length(), conversationId);
         }
         
         agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.CANCELLED);
         // 发送取消事件
-        sseEmitterService.send(conversationId, "cancelled", "{\"message\":\"用户已停止生成\"}");
+        sseEmitterService.send(conversationId, "cancelled",
+                "{\"message\":\"" + LangText.of("用户已停止生成", "Generation stopped by the user") + "\"}");
         sseEmitterService.close(conversationId);
         
         // 清理状态
@@ -485,7 +494,7 @@ public class AgentOrchestrator {
         if (depth > MAX_LOOP_DEPTH) {
             // 步数预算耗尽：不是报错，而是"存档 + 请示"——保存进度、明确告知用户、干净收尾。
             log.warn("Agent loop reached max depth {} for conversation {}, stopping gracefully", MAX_LOOP_DEPTH, conversationId);
-            String notice = "\n\n> 本轮已达最大执行步数（" + MAX_LOOP_DEPTH + " 步），先暂停。已完成的修改均已生效，点击下方「继续」按钮可接着执行剩余任务。";
+            String notice = maxDepthNotice();
             sendTextDelta(conversationId, notice);
             String persisted = (executionLog.length() > 0 ? executionLog.toString() : "") + notice;
             saveAssistantMessage(conversationId, projectId, userId, persisted);
@@ -603,7 +612,9 @@ public class AgentOrchestrator {
                 }
                 // 纠正预算耗尽：按「存档 + 请示」暂停（同步数预算收尾的语义），绝不执行截断的调用
                 log.warn("LENGTH-truncated tool calls persisted after corrections for {}, pausing", conversationId);
-                String notice = "\n\n> 模型输出连续多次达到长度上限、工具调用无法完整发出，先暂停。点击下方「继续」按钮可接着执行。";
+                String notice = LangText.of(
+                        "\n\n> 模型输出连续多次达到长度上限、工具调用无法完整发出，先暂停。点击下方「继续」按钮可接着执行。",
+                        "\n\n> The model's output kept hitting the length limit and the tool call could not be emitted in full; pausing here. Click the Continue button below to resume.");
                 sendTextDelta(conversationId, notice);
                 String truncPersisted = (executionLog.length() > 0 ? executionLog.toString() : "")
                         + (aiMessage.text() != null ? aiMessage.text() : "") + notice;
@@ -796,7 +807,8 @@ public class AgentOrchestrator {
                     // 优先使用LLM选择的process name，否则用工具元数据里的中文显示名
                     String processNameForLog = (llmProcessName != null && !llmProcessName.isEmpty())
                         ? llmProcessName
-                        : (toolResult != null && toolResult.tool() != null ? toolResult.tool().displayName() : "工具执行");
+                        : (toolResult != null && toolResult.tool() != null ? toolResult.tool().displayName()
+                                : LangText.of("工具执行", "Tool execution"));
                     executionLog.append(String.format("<process name=\"%s\"><tool_code>%s</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
                         processNameForLog, AgentTagProtocol.escape(code), statusPrefix,
                         AgentTagProtocol.escape(result)));
@@ -969,7 +981,9 @@ public class AgentOrchestrator {
             // 刻意不触发记忆管线与版本落档——本轮没有真正结束，续写完成的那轮一并跑。
             if (response.finishReason() == dev.langchain4j.model.output.FinishReason.LENGTH) {
                 log.warn("Answer truncated by output length limit for {}, pausing for continuation", conversationId);
-                String notice = "\n\n> 回答达到单次输出长度上限被截断，点击下方「继续」按钮可接着生成。";
+                String notice = LangText.of(
+                        "\n\n> 回答达到单次输出长度上限被截断，点击下方「继续」按钮可接着生成。",
+                        "\n\n> The answer was cut off by the per-response output length limit. Click the Continue button below to keep generating.");
                 sendTextDelta(conversationId, notice);
                 String truncContent = (executionLog.length() > 0 ? executionLog.toString() + content : content) + notice;
                 saveAssistantMessage(conversationId, projectId, userId, truncContent);
@@ -1043,8 +1057,10 @@ public class AgentOrchestrator {
                 // 限流与故障文案分开：用户看到「服务不可用」而实际是限流排队，会误判成产品坏了
                 sendTextDelta(conversationId, String.format(
                         kind == LlmErrorClassifier.Kind.RATE_LIMITED
-                                ? "\n\n> 模型限流等待中，%d 秒后自动继续（第 %d/%d 次）…\n\n"
-                                : "\n\n> 模型服务暂时不可用，%d 秒后自动重试（第 %d/%d 次）…\n\n",
+                                ? LangText.of("\n\n> 模型限流等待中，%d 秒后自动继续（第 %d/%d 次）…\n\n",
+                                        "\n\n> The model is rate limited; continuing automatically in %d s (attempt %d/%d)…\n\n")
+                                : LangText.of("\n\n> 模型服务暂时不可用，%d 秒后自动重试（第 %d/%d 次）…\n\n",
+                                        "\n\n> The model service is temporarily unavailable; retrying in %d s (attempt %d/%d)…\n\n"),
                         delaySec, attempt, kind.maxRetries()));
                 // 定时器是自己的单线程池：身份同样要显式重放，否则重放的这一轮取不到平台密钥
                 LLM_RETRY_SCHEDULER.schedule(PlatformAiUserScope.wrap(() -> {
@@ -1070,8 +1086,9 @@ public class AgentOrchestrator {
                 if (forceCompactAfterOverflow(messages, conversationId, modelId)) {
                     log.warn("Context overflow for {} confirmed by provider, retrying after forced compaction",
                             conversationId);
-                    sendTextDelta(conversationId,
-                            "\n\n> 对话上下文超出模型窗口，已自动压缩较早的内容后重试…\n\n");
+                    sendTextDelta(conversationId, LangText.of(
+                            "\n\n> 对话上下文超出模型窗口，已自动压缩较早的内容后重试…\n\n",
+                            "\n\n> The conversation exceeded the model's context window; earlier content was compacted automatically, retrying…\n\n"));
                     try {
                         runLoop(model, messages, conversationId, projectId, userId, modelId,
                                 depth, executionLog, agentMode, guard);
@@ -1157,7 +1174,8 @@ public class AgentOrchestrator {
         // 换模型等于换了一条通道，重试预算重新计
         guard.llmRetries = 0;
         sendTextDelta(conversationId, String.format(
-                "\n\n> 模型「%s」%s，已自动切换到备用模型「%s」继续本轮任务。\n\n",
+                LangText.of("\n\n> 模型「%s」%s，已自动切换到备用模型「%s」继续本轮任务。\n\n",
+                        "\n\n> Model \"%s\" %s; automatically switched to fallback model \"%s\" to continue this round.\n\n"),
                 failedModelId, kind.userFacingReason(), nextModelId));
         try {
             runLoop(nextModel, messages, conversationId, projectId, userId, nextModelId,
@@ -1195,7 +1213,8 @@ public class AgentOrchestrator {
         StringBuilder sb = activeStreamContent.get(conversationId);
         String partialContent = sb != null ? sb.toString() : "";
         if (!partialContent.isEmpty()) {
-            saveAssistantMessage(conversationId, projectId, userId, partialContent + "\n\n[生成出错，已中断]");
+            saveAssistantMessage(conversationId, projectId, userId,
+                    partialContent + LangText.of("\n\n[生成出错，已中断]", "\n\n[Generation error, interrupted]"));
         }
         sseEmitterService.close(conversationId);
         clearCancelledState(conversationId);
@@ -1262,7 +1281,8 @@ public class AgentOrchestrator {
             log.warn("Empty LLM response for {} (attempt {}/{}), retrying in {}s",
                     conversationId, attempt, kind.maxRetries(), delaySec);
             sendTextDelta(conversationId, String.format(
-                    "\n\n> 模型返回了空响应，%d 秒后自动重试（第 %d/%d 次）…\n\n",
+                    LangText.of("\n\n> 模型返回了空响应，%d 秒后自动重试（第 %d/%d 次）…\n\n",
+                            "\n\n> The model returned an empty response; retrying in %d s (attempt %d/%d)…\n\n"),
                     delaySec, attempt, kind.maxRetries()));
             // 同 onError 的重试路径：定时器线程不继承平台通道身份，必须显式重建
             LLM_RETRY_SCHEDULER.schedule(PlatformAiUserScope.wrap(() -> {
@@ -1278,7 +1298,8 @@ public class AgentOrchestrator {
         }
         log.error("Empty LLM response persisted after retries for {}", conversationId);
         handleStreamErrorTerminal(conversationId, projectId, userId,
-                new IllegalStateException("模型连续返回空响应，请稍后重发这条消息"), kind);
+                new IllegalStateException(LangText.of("模型连续返回空响应，请稍后重发这条消息",
+                        "The model kept returning empty responses; please resend this message later")), kind);
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/AgentRunRecoveryService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentRunRecoveryService.java
@@ -27,9 +27,20 @@ public class AgentRunRecoveryService {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AgentRunRecoveryService.class);
 
-    /** 追加到半截回复末尾的中断说明；口径对齐取消路径的 [已中断]。 */
-    static final String INTERRUPT_NOTICE =
-            "\n\n> **[进程中断]** 任务执行中应用被关闭，点击下方「继续」按钮可接着执行。";
+    /** 追加到半截回复末尾的中断说明（中文标记）；口径对齐取消路径的 [已中断]。 */
+    static final String INTERRUPT_MARKER_ZH = "[进程中断]";
+    /** 英文标记。幂等检查必须两个标记都认（见 {@link #appendInterruptNotice}）。 */
+    static final String INTERRUPT_MARKER_EN = "[Process interrupted]";
+
+    static final String INTERRUPT_NOTICE_ZH =
+            "\n\n> **" + INTERRUPT_MARKER_ZH + "** 任务执行中应用被关闭，点击下方「继续」按钮可接着执行。";
+    static final String INTERRUPT_NOTICE_EN =
+            "\n\n> **" + INTERRUPT_MARKER_EN + "** The app was closed while this task was running. Click the Continue button below to resume.";
+
+    /** 按应用语言取本次要写入的中断说明。 */
+    static String interruptNotice() {
+        return com.checkba.service.LangText.of(INTERRUPT_NOTICE_ZH, INTERRUPT_NOTICE_EN);
+    }
 
     private final AgentRunRecordRepository recordRepository;
     private final ProjectAiMessageRepository messageRepository;
@@ -103,9 +114,10 @@ public class AgentRunRecoveryService {
         }
         if (last == null) return;
         String content = last.getContent() == null ? "" : last.getContent();
-        // 幂等：重复启动（或回收跑了两次）不该把说明叠加成一串
-        if (content.contains("[进程中断]")) return;
-        last.setContent(content + INTERRUPT_NOTICE);
+        // 幂等：重复启动（或回收跑了两次）不该把说明叠加成一串。
+        // 中英两个标记都要认——切换语言后重启（或升级后存量中文半截消息）不能被二次追加
+        if (content.contains(INTERRUPT_MARKER_ZH) || content.contains(INTERRUPT_MARKER_EN)) return;
+        last.setContent(content + interruptNotice());
         messageRepository.save(last);
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
@@ -66,7 +66,9 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
                 log.warn("Stream inactive for {}s (limit {}s) for {}, terminating round via watchdog",
                         idleSec, inactivitySeconds, conversationId);
                 onError(new java.util.concurrent.TimeoutException(
-                        "流式响应停滞超过 " + inactivitySeconds + " 秒"));
+                        com.checkba.service.LangText.of(
+                                "流式响应停滞超过 " + inactivitySeconds + " 秒",
+                                "Streaming response stalled for more than " + inactivitySeconds + " seconds")));
             }
         }, 15, 15, java.util.concurrent.TimeUnit.SECONDS);
     }

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -428,7 +428,7 @@ public class ContextAssemblerService {
             Optional<ProjectMemory> projectMemoryOpt = memoryManager.getProjectMemory(projectIdLong);
             if (projectMemoryOpt.isPresent()) {
                 ProjectMemory pm = projectMemoryOpt.get();
-                systemText.append("\n\n# 项目记忆（长期记忆）\n");
+                systemText.append(english ? "\n\n# Project Memory (long-term)\n" : "\n\n# 项目记忆（长期记忆）\n");
                 systemText.append(pm.toCoreContext());
             }
             
@@ -436,7 +436,7 @@ public class ContextAssemblerService {
             List<MemoryEntry> relevantMemories = memoryManager.retrieveMemories(
                     projectIdLong, userPrompt, null, 5);
             if (!relevantMemories.isEmpty()) {
-                systemText.append("\n\n# 相关记忆（证据账本）\n");
+                systemText.append(english ? "\n\n# Relevant Memories (evidence ledger)\n" : "\n\n# 相关记忆（证据账本）\n");
                 systemText.append(memoryManager.formatAsEvidenceLedger(relevantMemories));
             }
         }
@@ -445,8 +445,12 @@ public class ContextAssemblerService {
         if (userId != null) {
             List<MemoryEntry> userMemories = memoryManager.retrieveUserMemories(userId, 5);
             if (!userMemories.isEmpty()) {
-                systemText.append("\n\n# 用户偏好与习惯（跨项目记忆）\n");
-                systemText.append("以下是该用户长期积累的偏好与习惯，输出时应遵循：\n");
+                systemText.append(english
+                        ? "\n\n# User Preferences and Habits (cross-project memory)\n"
+                        : "\n\n# 用户偏好与习惯（跨项目记忆）\n");
+                systemText.append(english
+                        ? "The following are this user's long-standing preferences and habits; follow them in your output:\n"
+                        : "以下是该用户长期积累的偏好与习惯，输出时应遵循：\n");
                 for (MemoryEntry mem : userMemories) {
                     systemText.append("- ");
                     if (mem.getMemoryKey() != null) {

--- a/backend/src/main/java/com/checkba/service/ai/LlmErrorClassifier.java
+++ b/backend/src/main/java/com/checkba/service/ai/LlmErrorClassifier.java
@@ -99,16 +99,25 @@ public final class LlmErrorClassifier {
             return this == REGION_BLOCKED;
         }
 
-        /** 给用户看的一句话原因（中文，进 SSE 文本流）。 */
+        /**
+         * 给用户看的一句话原因（按应用语言二选一，进 SSE 文本流）。
+         * enum 不是 Spring bean，语言经 {@link com.checkba.service.LangText} 静态桥取。
+         * 英文措辞是谓语形态：拼进故障转移文案「Model "X" &lt;reason&gt;; …」要成句。
+         */
         public String userFacingReason() {
             return switch (this) {
-                case RATE_LIMITED -> "触发了限流";
-                case MODEL_UNAVAILABLE -> "当前不可用（可能已下线）";
-                case REGION_BLOCKED -> "在当前网络环境不可用（服务商按地域拒绝）";
-                case QUOTA_EXHAUSTED -> "账户额度不足";
-                case CONTEXT_OVERFLOW -> "上下文超出模型窗口";
-                case TRANSIENT -> "连续多次响应失败";
-                case FATAL -> "调用失败";
+                case RATE_LIMITED -> com.checkba.service.LangText.of("触发了限流", "hit a rate limit");
+                case MODEL_UNAVAILABLE -> com.checkba.service.LangText.of("当前不可用（可能已下线）",
+                        "is currently unavailable (possibly retired)");
+                case REGION_BLOCKED -> com.checkba.service.LangText.of("在当前网络环境不可用（服务商按地域拒绝）",
+                        "is unavailable on the current network (rejected by the provider for this region)");
+                case QUOTA_EXHAUSTED -> com.checkba.service.LangText.of("账户额度不足",
+                        "ran out of account credit");
+                case CONTEXT_OVERFLOW -> com.checkba.service.LangText.of("上下文超出模型窗口",
+                        "exceeded the model's context window");
+                case TRANSIENT -> com.checkba.service.LangText.of("连续多次响应失败",
+                        "failed to respond several times in a row");
+                case FATAL -> com.checkba.service.LangText.of("调用失败", "failed to be called");
             };
         }
     }

--- a/backend/src/main/java/com/checkba/service/ai/PptxServiceClient.java
+++ b/backend/src/main/java/com/checkba/service/ai/PptxServiceClient.java
@@ -5,6 +5,7 @@ import cn.hutool.http.HttpResponse;
 import cn.hutool.json.JSONArray;
 import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
+import com.checkba.service.LangText;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -572,33 +573,42 @@ public class PptxServiceClient {
         
         try {
             // 1. 创建项目 (2%)
-            reportProgress.accept(2, new String[]{"creating_project", "正在创建 PPT 项目..."});
+            reportProgress.accept(2, new String[]{"creating_project",
+                    LangText.of("正在创建 PPT 项目...", "Creating the PPT project...")});
             String projectId = createProject(topic);
             result.setProjectId(projectId);
             
             // 2. 生成大纲 (10%)
-            reportProgress.accept(5, new String[]{"generating_outline", "正在生成演示文稿大纲..."});
+            reportProgress.accept(5, new String[]{"generating_outline",
+                    LangText.of("正在生成演示文稿大纲...", "Generating the presentation outline...")});
             JSONArray pages = generateOutline(projectId, language, modelConfig);
             result.setPagesCount(pages.size());
-            reportProgress.accept(10, new String[]{"generating_outline", "大纲生成完成，共 " + pages.size() + " 页"});
+            reportProgress.accept(10, new String[]{"generating_outline",
+                    LangText.of("大纲生成完成，共 " + pages.size() + " 页",
+                            "Outline generated: " + pages.size() + " pages")});
             
             // 3. 生成描述 (10% -> 25%)
-            reportProgress.accept(12, new String[]{"generating_descriptions", "正在生成页面内容描述..."});
+            reportProgress.accept(12, new String[]{"generating_descriptions",
+                    LangText.of("正在生成页面内容描述...", "Generating page content descriptions...")});
             String descTaskId = startGenerateDescriptions(projectId, language, modelConfig);
             JSONObject descTaskResult = waitForTaskWithProgress(projectId, descTaskId, 10, 25, 
-                    "generating_descriptions", "正在生成页面描述", progressCallback);
+                    "generating_descriptions",
+                    LangText.of("正在生成页面描述", "Generating page descriptions"), progressCallback);
             if (descTaskResult == null) {
                 result.setSuccess(false);
                 result.setError("Description generation failed");
                 return result;
             }
-            reportProgress.accept(25, new String[]{"generating_descriptions", "页面描述生成完成"});
+            reportProgress.accept(25, new String[]{"generating_descriptions",
+                    LangText.of("页面描述生成完成", "Page descriptions generated")});
             
             // 4. 生成图片 (25% -> 70%)
-            reportProgress.accept(27, new String[]{"generating_images", "正在生成幻灯片图片..."});
+            reportProgress.accept(27, new String[]{"generating_images",
+                    LangText.of("正在生成幻灯片图片...", "Generating slide images...")});
             String imgTaskId = startGenerateImages(projectId, language, templateStyle, modelConfig);
             JSONObject imgTaskResult = waitForTaskWithProgress(projectId, imgTaskId, 25, 70, 
-                    "generating_images", "正在生成幻灯片图片", progressCallback);
+                    "generating_images",
+                    LangText.of("正在生成幻灯片图片", "Generating slide images"), progressCallback);
             if (imgTaskResult == null) {
                 result.setSuccess(false);
                 result.setError("Image generation failed");
@@ -615,19 +625,23 @@ public class PptxServiceClient {
                     }
                 }
             }
-            reportProgress.accept(70, new String[]{"generating_images", "幻灯片图片生成完成"});
+            reportProgress.accept(70, new String[]{"generating_images",
+                    LangText.of("幻灯片图片生成完成", "Slide images generated")});
             
             // 5. 导出 PPTX (70% -> 95%)
-            reportProgress.accept(72, new String[]{"exporting_pptx", "正在导出 PPTX 文件..."});
+            reportProgress.accept(72, new String[]{"exporting_pptx",
+                    LangText.of("正在导出 PPTX 文件...", "Exporting the PPTX file...")});
             String filename = "presentation_" + projectId + ".pptx";
             String downloadUrl;
             
             if (exportEditable) {
-                reportProgress.accept(75, new String[]{"exporting_pptx", "正在生成可编辑版本..."});
+                reportProgress.accept(75, new String[]{"exporting_pptx",
+                        LangText.of("正在生成可编辑版本...", "Generating the editable version...")});
                 try {
                     String editableTaskId = startExportEditable(projectId, filename, modelConfig);
                     JSONObject editableTaskResult = waitForTaskWithProgress(projectId, editableTaskId, 75, 95, 
-                            "exporting_pptx", "正在导出可编辑版本", progressCallback);
+                            "exporting_pptx",
+                            LangText.of("正在导出可编辑版本", "Exporting the editable version"), progressCallback);
                     
                     if (editableTaskResult != null) {
                         JSONObject editableProgress = editableTaskResult.getJSONObject("progress");
@@ -659,17 +673,20 @@ public class PptxServiceClient {
             }
             
             result.setDownloadUrl(downloadUrl);
-            reportProgress.accept(95, new String[]{"exporting_pptx", "PPTX 导出完成"});
+            reportProgress.accept(95, new String[]{"exporting_pptx",
+                    LangText.of("PPTX 导出完成", "PPTX export completed")});
             
             // 6. 下载到本地 (95% -> 100%)
             if (localSavePath != null && !localSavePath.isEmpty()) {
-                reportProgress.accept(97, new String[]{"downloading", "正在保存文件到本地..."});
+                reportProgress.accept(97, new String[]{"downloading",
+                        LangText.of("正在保存文件到本地...", "Saving the file locally...")});
                 String savedPath = downloadPptx(downloadUrl, localSavePath);
                 result.setLocalPath(savedPath);
             }
             
             result.setSuccess(true);
-            reportProgress.accept(100, new String[]{"completed", "PPTX 生成完成！"});
+            reportProgress.accept(100, new String[]{"completed",
+                    LangText.of("PPTX 生成完成！", "PPTX generation completed.")});
             log.info("PPTX generation with progress completed: {}, editable={}", result.getLocalPath(), result.isEditable());
             
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
@@ -142,7 +142,8 @@ public class SubAgentService {
         String subtaskId = "subtask-" + UUID.randomUUID().toString().substring(0, 8);
         // started/结束事件必须成对发出（前端的子任务卡按 taskId 配对渲染），
         // 所以模型校验失败那条路径也走"先 started 再 failed"，不能只发一个 failed
-        sendProgress(parentCtx, subtaskId, "started", 0, "子任务开始：" + brief(taskDescription));
+        sendProgress(parentCtx, subtaskId, "started", 0,
+                com.checkba.service.LangText.of("子任务开始：", "Subtask started: ") + brief(taskDescription));
 
         // 模型在提交线程解析，非白名单在起跑前就拒绝：ChatModelFactory 对非白名单的处置是
         // 静默回落默认模型——failover 链踩过的同一个坑（看着「配了便宜模型」，实际跑的是主模型，
@@ -151,12 +152,16 @@ public class SubAgentService {
         if (!AllowedModels.isAllowed(modelId)) {
             log.warn("子 Agent 模型 '{}' 不在可用模型清单内，子任务 {} 未派发", modelId, subtaskId);
             SubAgentResult rejected = SubAgentResult.failure(subtaskId,
-                    "子 Agent 模型「" + modelId + "」不在可用模型清单内，本次子任务没有执行。"
-                            + "到设置页的 AI 供应商里把子 Agent 模型换成清单内的模型，"
-                            + "或清空该项让它跟随辅助模型。",
+                    com.checkba.service.LangText.of(
+                            "子 Agent 模型「" + modelId + "」不在可用模型清单内，本次子任务没有执行。"
+                                    + "到设置页的 AI 供应商里把子 Agent 模型换成清单内的模型，"
+                                    + "或清空该项让它跟随辅助模型。",
+                            "Sub-agent model \"" + modelId + "\" is not in the allowed model list, so this subtask was not executed. "
+                                    + "In Settings > AI Provider, switch the sub-agent model to one from the list, "
+                                    + "or clear the field to follow the auxiliary model."),
                     List.of(), 0);
             sendProgress(parentCtx, subtaskId, "failed", 100,
-                    "子任务失败：" + brief(rejected.error()));
+                    com.checkba.service.LangText.of("子任务失败：", "Subtask failed: ") + brief(rejected.error()));
             return rejected;
         }
 
@@ -212,8 +217,9 @@ public class SubAgentService {
         // 新造一个 stage 值只会多一处待同步的字面量），区别体现在给用户看的文案上
         sendProgress(parentCtx, subtaskId,
                 result.success() ? "succeeded" : "failed", 100,
-                result.success() ? "子任务完成"
-                        : cancelledByUser ? "子任务已停止" : "子任务失败：" + brief(result.error()));
+                result.success() ? com.checkba.service.LangText.of("子任务完成", "Subtask completed")
+                        : cancelledByUser ? com.checkba.service.LangText.of("子任务已停止", "Subtask stopped")
+                        : com.checkba.service.LangText.of("子任务失败：", "Subtask failed: ") + brief(result.error()));
         return result;
     }
 

--- a/backend/src/test/java/com/checkba/service/LangTextTest.java
+++ b/backend/src/test/java/com/checkba/service/LangTextTest.java
@@ -1,0 +1,63 @@
+package com.checkba.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * LangText 静态语言桥的回退契约：未登记 / 取值抛异常一律回退中文
+ * （v0.15.0 static 指针顺序的教训——静态指针必须 null 安全，不能因初始化顺序把对话带崩）。
+ */
+class LangTextTest {
+
+    @AfterEach
+    void reset() {
+        LangText.reset();
+    }
+
+    @Test
+    void unregistered_fallsBackToChinese() {
+        LangText.reset();
+        assertFalse(LangText.isEnglish());
+        assertEquals("中文", LangText.of("中文", "English"));
+    }
+
+    @Test
+    void registeredEnglish_picksEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+        assertTrue(LangText.isEnglish());
+        assertEquals("English", LangText.of("中文", "English"));
+    }
+
+    @Test
+    void registeredChinese_picksChinese() {
+        AppLanguageService zh = mock(AppLanguageService.class);
+        when(zh.isEnglish()).thenReturn(false);
+        LangText.register(zh);
+        assertEquals("中文", LangText.of("中文", "English"));
+    }
+
+    @Test
+    void languageLookupFailure_fallsBackToChinese() {
+        AppLanguageService broken = mock(AppLanguageService.class);
+        when(broken.isEnglish()).thenThrow(new RuntimeException("db down"));
+        LangText.register(broken);
+        // 语言取不到时宁可回退中文，也不能让一条进度文案把整轮对话带崩
+        assertEquals("中文", LangText.of("中文", "English"));
+    }
+
+    @Test
+    void resetRestoresChineseDefault() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+        assertTrue(LangText.isEnglish());
+        LangText.reset();
+        assertFalse(LangText.isEnglish());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/AgentRunRecoveryServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentRunRecoveryServiceTest.java
@@ -4,6 +4,7 @@ import com.checkba.model.entity.AgentRunRecord;
 import com.checkba.model.entity.ProjectAiMessage;
 import com.checkba.repository.AgentRunRecordRepository;
 import com.checkba.repository.ProjectAiMessageRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -69,6 +70,19 @@ class AgentRunRecoveryServiceTest {
         turnTracker = Mockito.mock(com.checkba.service.telemetry.TelemetryTurnTracker.class);
         stateService = new AgentRunStateService(recordRepository, turnTracker);
         recoveryService = new AgentRunRecoveryService(recordRepository, messageRepository, stateService);
+    }
+
+    @AfterEach
+    void resetLangText() {
+        // 静态语言桥必须清干净，否则 en 模式的测试会污染同 fork 里的其他测试类
+        com.checkba.service.LangText.reset();
+    }
+
+    private void switchToEnglish() {
+        com.checkba.service.AppLanguageService en =
+                Mockito.mock(com.checkba.service.AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        com.checkba.service.LangText.register(en);
     }
 
     private ProjectAiMessage msg(String role, String content) {
@@ -242,6 +256,49 @@ class AgentRunRecoveryServiceTest {
 
         assertEquals("RUNNING", stateService.statusName(CONV));
         assertEquals("RUNNING", table.get(CONV).getStatus());
+    }
+
+    // ---- 中断说明的双语与幂等（EN 版 PR4-A）----
+
+    @Test
+    void recovery_englishMode_appendsEnglishNotice() {
+        switchToEnglish();
+        stateService.mark(CONV, AgentRunStateService.RunStatus.RUNNING, 42L, 7L);
+        ProjectAiMessage halfDone = msg("ASSISTANT", "half-finished reply");
+        messages.put(CONV, List.of(halfDone));
+
+        assertEquals(1, recoveryService.recoverInterruptedRuns());
+        assertTrue(halfDone.getContent().contains("[Process interrupted]"), "en 模式要补英文标记");
+        assertFalse(halfDone.getContent().contains("[进程中断]"), "en 模式不该出现中文标记");
+    }
+
+    @Test
+    void recovery_englishMode_skipsLegacyChineseMarker() {
+        // 升级场景：存量中文半截消息已带 [进程中断]，切到 en 后重启不能被二次追加英文说明
+        switchToEnglish();
+        stateService.mark(CONV, AgentRunStateService.RunStatus.RUNNING, 42L, 7L);
+        ProjectAiMessage halfDone = msg("ASSISTANT",
+                "半截内容" + AgentRunRecoveryService.INTERRUPT_NOTICE_ZH);
+        messages.put(CONV, List.of(halfDone));
+
+        assertEquals(1, recoveryService.recoverInterruptedRuns());
+        assertEquals(0, countOccurrences(halfDone.getContent(), "[Process interrupted]"),
+                "已带中文标记的消息不能再叠英文说明");
+        assertEquals(1, countOccurrences(halfDone.getContent(), "[进程中断]"));
+    }
+
+    @Test
+    void recovery_chineseMode_skipsEnglishMarker() {
+        // 反向切换：en 时期落库的英文标记，切回 zh 后重启同样不能叠中文说明
+        stateService.mark(CONV, AgentRunStateService.RunStatus.RUNNING, 42L, 7L);
+        ProjectAiMessage halfDone = msg("ASSISTANT",
+                "half-finished reply" + AgentRunRecoveryService.INTERRUPT_NOTICE_EN);
+        messages.put(CONV, List.of(halfDone));
+
+        assertEquals(1, recoveryService.recoverInterruptedRuns());
+        assertEquals(0, countOccurrences(halfDone.getContent(), "[进程中断]"),
+                "已带英文标记的消息不能再叠中文说明");
+        assertEquals(1, countOccurrences(halfDone.getContent(), "[Process interrupted]"));
     }
 
     private static int countOccurrences(String text, String needle) {

--- a/backend/src/test/java/com/checkba/service/ai/AgentTextLanguageTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentTextLanguageTest.java
@@ -1,0 +1,62 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * AI 链路用户可见文案的应用语言抽样断言（EN 版 PR4-A）：
+ * zh 默认（LangText 未登记）与今天逐字节一致，en 模式关键文案是英文。
+ */
+class AgentTextLanguageTest {
+
+    @AfterEach
+    void reset() {
+        LangText.reset();
+    }
+
+    private void switchToEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+    }
+
+    @Test
+    void maxDepthNotice_chineseByDefault() {
+        assertEquals(
+                "\n\n> 本轮已达最大执行步数（30 步），先暂停。已完成的修改均已生效，点击下方「继续」按钮可接着执行剩余任务。",
+                AgentOrchestrator.maxDepthNotice(),
+                "zh 模式步数暂停 notice 必须与存量逐字节一致");
+    }
+
+    @Test
+    void maxDepthNotice_englishInEnglishMode() {
+        switchToEnglish();
+        String notice = AgentOrchestrator.maxDepthNotice();
+        assertTrue(notice.contains("maximum step budget"), "en 模式步数暂停 notice 要是英文: " + notice);
+        assertTrue(notice.contains("30 steps"));
+        assertFalse(notice.contains("步数"), "en 模式不该混入中文");
+    }
+
+    @Test
+    void userFacingReason_followsAppLanguage() {
+        assertEquals("触发了限流", LlmErrorClassifier.Kind.RATE_LIMITED.userFacingReason());
+        assertEquals("账户额度不足", LlmErrorClassifier.Kind.QUOTA_EXHAUSTED.userFacingReason());
+
+        switchToEnglish();
+        assertEquals("hit a rate limit", LlmErrorClassifier.Kind.RATE_LIMITED.userFacingReason());
+        assertEquals("ran out of account credit", LlmErrorClassifier.Kind.QUOTA_EXHAUSTED.userFacingReason());
+    }
+
+    @Test
+    void interruptNotice_followsAppLanguage() {
+        assertEquals(AgentRunRecoveryService.INTERRUPT_NOTICE_ZH, AgentRunRecoveryService.interruptNotice());
+        switchToEnglish();
+        assertEquals(AgentRunRecoveryService.INTERRUPT_NOTICE_EN, AgentRunRecoveryService.interruptNotice());
+    }
+}


### PR DESCRIPTION
EN 版 PR4 第一批：用户在对话气泡里直接看到的后端文案 + 写进消息历史的标记，共 30+ 条。zh 逐字节零回归。

## 内容
- **LangText 静态语言桥**：`of(zh, en)`，AppLanguageService @PostConstruct 登记指针（刻意不用构造器登记，防单测 new 实例污染静态状态；未登记回退 zh，无全局监听器——绕开 v0.15.0 static 指针顺序炸弹一类的坑）。enum/record/new 出来的类与 Spring bean 统一走它，全 PR 零构造器签名变更（EvalHarness 零同步）。
- **SSE 展示（A 类）**：停止/步数暂停/限流与瞬时重试/故障转移/压缩重试/停滞看门狗/子任务五态/PPT 进度 15 条/「工具执行」兜底名/LlmErrorClassifier 七条 userFacingReason。模型侧文本（stuck nudge/system-reminder/tool_output）一律未动。
- **落库（D 类）**：「[已中断]」「[生成出错，已中断]」「[进程中断]」按语言写入；恢复服务幂等**中英双标记匹配**（升级后存量中文半截消息不会被二次追加，3 条测试钉住）；「新对话」写库与读时兜底双语；标题生成 prompt 英文模式产英文标题（≤8 词，截断上限 en 60 字符）。存量历史不迁移，中英混排可接受。
- 记忆区三个标题（项目记忆/证据账本/用户偏好）补 PR5 遗留。
- 前端零改动（grep 证实三个落库标记无任何前端 includes 判据，判据走 run_state）。

## 验证
mvn -B test：**1676 通过 / 0 失败**（新增 12 条：LangText 5 + 双语文案 4 + 幂等双匹配 3）；zh 步数 notice 有逐字节回归断言。

## 后续（PR4-B 范围）
- `...(截断)` 后缀是前端截断判据契约，本 PR 刻意未翻；EN 化需前后端同步双后缀匹配，归入 PR4-B。
- B 类 HTTP message（约 290 条 controller/service 文案）按域分片继续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)