### PR TITLE
fix(test): project-home 静态测试随 i18n 迁移改看 locale 文案（修 master 红）

### DIFF
--- a/frontend/tests/project-home/_visible-text.mjs
+++ b/frontend/tests/project-home/_visible-text.mjs
@@ -1,0 +1,57 @@
+// i18n 迁移后，组件源码里只剩 $t('ns.key')，中文文案实体在 src/locales/zh-CN/<ns>.js。
+// 这些测试守的是「界面上有没有这句话」这条契约，不是「源码里有没有这个字符串」，
+// 所以断言要看组件**实际引用的那些键**解析出来的中文，而不是整份 locale 文件——
+// 整份拼进去会让禁字断言（"unavailable 不许是错误文案"之类）永远通不了红。
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const nsCache = new Map()
+
+function loadNs(ns) {
+  if (!nsCache.has(ns)) {
+    const p = resolve(HERE, '../../src/locales/zh-CN/' + ns + '.js')
+    let dict = {}
+    try {
+      // locale 是纯字面量对象的 ES 模块；这里不引 vue-i18n，直接抠出 default 导出求值
+      const src = readFileSync(p, 'utf8').replace(/^\s*export\s+default\s*/m, 'return ')
+      dict = new Function(src)() || {}
+    } catch (e) { /* 该 ns 还没建：按空字典处理，断言自然会红 */ }
+    nsCache.set(ns, dict)
+  }
+  return nsCache.get(ns)
+}
+
+const dig = (obj, path) => path.reduce((o, k) => (o == null ? o : o[k]), obj)
+
+/** 组件引用到的全部 zh 文案值（不含源码），换行拼接。 */
+export function localeValuesOf(src) {
+  const keys = [...src.matchAll(/\$t\(\s*['"]([\w.]+)['"]/g)].map((m) => m[1])
+  return keys
+    .map((k) => {
+      const [ns, ...rest] = k.split('.')
+      const v = dig(loadNs(ns), rest)
+      return typeof v === 'string' ? v : ''
+    })
+    .join('\n')
+}
+
+/**
+ * 组件源码 + 它引用到的 zh 文案，拼成「这个组件会显示的文字」。
+ * 断言 includes 某句中文时用它替代裸 SRC。
+ */
+export function visibleText(src) {
+  return src + '\n' + localeValuesOf(src)
+}
+
+/**
+ * 禁字断言专用：去注释的源码 + 引用到的 zh 文案。
+ * 迁移后文案不在源码里了，禁字断言只查源码等于失效——「不许是错误文案」这类
+ * 契约必须能看到 locale 里的实际值才拦得住。注释仍然排除（注释里要能写清楚
+ * 为什么不做某件事，不该判红）。
+ */
+export function visibleCode(src, stripComments) {
+  return stripComments(src) + '\n' + localeValuesOf(src)
+}

--- a/frontend/tests/project-home/activity-feed.test.mjs
+++ b/frontend/tests/project-home/activity-feed.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { visibleText, visibleCode } from './_visible-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/ActivityFeed.vue'),
@@ -12,7 +13,9 @@ const SRC = readFileSync(
 // 那些说明性文字不该把断言判红。
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-const CODE = stripComments(SRC)
+const CODE = visibleCode(SRC, stripComments)
+// 界面文案已外置到 zh locale：断言"显示了这句话"要看组件实际引用的键解析出的中文
+const TEXT = visibleText(SRC)
 
 test('e2e 锚点：根节点类名是 activity-feed', () => {
   assert.ok(SRC.includes('class="activity-feed"'))
@@ -27,13 +30,13 @@ test('四个 props 齐全且都有默认值', () => {
 
 test('unavailable 走中性引导态而不是错误态', () => {
   assert.match(SRC, /v-else-if="unavailable"/)
-  assert.ok(SRC.includes('这份案卷还没有版本记录'))
+  assert.ok(TEXT.includes('这份案卷还没有版本记录'))
   for (const bad of ['读取失败', '加载失败', '出错了', '请重试'])
     assert.ok(!CODE.includes(bad), 'unavailable 不许是错误文案: ' + bad)
 })
 
 test('空列表另有一条空态文案，与 unavailable 分开', () => {
-  assert.ok(SRC.includes('还没有动态'))
+  assert.ok(TEXT.includes('还没有动态'))
 })
 
 test('不标注 AI/人', () => {

--- a/frontend/tests/project-home/conversation-list.test.mjs
+++ b/frontend/tests/project-home/conversation-list.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { visibleCode } from './_visible-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/ConversationList.vue'),
@@ -12,7 +13,7 @@ const SRC = readFileSync(
 // 那些说明性文字不该把断言判红。
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-const CODE = stripComments(SRC)
+const CODE = visibleCode(SRC, stripComments)
 
 test('e2e 锚点：根节点类名是 conversation-list', () => {
   assert.ok(SRC.includes('class="conversation-list"'))

--- a/frontend/tests/project-home/page.test.mjs
+++ b/frontend/tests/project-home/page.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { visibleText, visibleCode } from './_visible-text.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../src')
 const SRC = readFileSync(resolve(ROOT, 'pages/project-home/project-home.vue'), 'utf8')
@@ -11,7 +12,9 @@ const SRC = readFileSync(resolve(ROOT, 'pages/project-home/project-home.vue'), '
 // 那些说明性文字不该把断言判红。
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-const CODE = stripComments(SRC)
+const CODE = visibleCode(SRC, stripComments)
+// 界面文案已外置到 zh locale：断言"显示了这句话"要看组件实际引用的键解析出的中文
+const TEXT = visibleText(SRC)
 
 // pages.json 不是纯 JSON（:2 行尾有 // 注释，注释里还带 https:// ），
 // 用逐字符扫描剥注释，别用 /\/\/.*$/ ——那会把字符串里的 URL 也砍掉。
@@ -57,7 +60,9 @@ test('App.vue 的路由埋点注释与 pages.json 的页面数一致', () => {
 test('e2e 锚点类名齐全', () => {
   for (const c of ['page-project-home', 'btn-project-list', 'btn-workbench', 'home-topbar-title'])
     assert.ok(SRC.includes(c), '缺 e2e 锚点: ' + c)
-  assert.ok(SRC.includes('>项目概览<'), 'e2e 用顶栏标题文案做 blur 触发点')
+  // 文案已外置到 locale，原来那个「>项目概览<」的尖括号写法是用来确认它在模板文本
+  // 节点里的，现在由上面的 home-topbar-title 类名断言承担；这里只保证文案还在。
+  assert.ok(TEXT.includes('项目概览'), 'e2e 用顶栏标题文案做 blur 触发点')
 })
 
 test('轮询纪律：不起定时器，不调 /version/status', () => {

--- a/frontend/tests/project-home/profile-header.test.mjs
+++ b/frontend/tests/project-home/profile-header.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { visibleText, visibleCode } from './_visible-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/ProfileHeader.vue'),
@@ -12,7 +13,9 @@ const SRC = readFileSync(
 // 那些说明性文字不该把断言判红。
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-const CODE = stripComments(SRC)
+const CODE = visibleCode(SRC, stripComments)
+// 界面文案已外置到 zh locale：断言"显示了这句话"要看组件实际引用的键解析出的中文
+const TEXT = visibleText(SRC)
 
 test('e2e 锚点：根类名 profile-header + 输入框类名 profile-field-input', () => {
   assert.ok(SRC.includes('class="profile-header"'))
@@ -66,7 +69,7 @@ test('ai / default 都弱化标记，走 profileFieldHint', () => {
 test('空态引导 + 事项类型下拉用 MATTER_TYPES', () => {
   assert.match(SRC, /import\s*\{\s*MATTER_TYPES\s*\}\s*from\s*'@\/config\/matterTypes\.js'/)
   assert.match(SRC, /isProfileEmpty/)
-  assert.ok(SRC.includes('这份案卷的档案还是空的'))
+  assert.ok(TEXT.includes('这份案卷的档案还是空的'))
 })
 
 test('禁 emoji + 浅色', () => {

--- a/frontend/tests/project-home/stats-bar.test.mjs
+++ b/frontend/tests/project-home/stats-bar.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { visibleText, visibleCode } from './_visible-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/OverviewStatsBar.vue'),
@@ -12,7 +13,9 @@ const SRC = readFileSync(
 // 那些说明性文字不该把断言判红。
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-const CODE = stripComments(SRC)
+const CODE = visibleCode(SRC, stripComments)
+// 界面文案已外置到 zh locale：断言"显示了这句话"要看组件实际引用的键解析出的中文
+const TEXT = visibleText(SRC)
 
 test('e2e 锚点：根节点类名是 overview-stats-bar', () => {
   assert.ok(SRC.includes('class="overview-stats-bar"'), 'e2e 靠这个类名等统计条渲染，不许改名')
@@ -34,9 +37,9 @@ test('不展示项目大小与最近修改（那两个数是假的）', () => {
 })
 
 test('四个统计格都在：文件 / 文件夹 / 参与人 / 后台任务', () => {
-  assert.ok(SRC.includes('个文件夹'))
-  assert.ok(SRC.includes('位参与人'))
-  assert.ok(SRC.includes('个后台任务'))
+  assert.ok(TEXT.includes('个文件夹'))
+  assert.ok(TEXT.includes('位参与人'))
+  assert.ok(TEXT.includes('个后台任务'))
   assert.match(SRC, /class="stat-tile"/)
 })
 

--- a/frontend/tests/project-home/task-schedule.test.mjs
+++ b/frontend/tests/project-home/task-schedule.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { visibleText, visibleCode } from './_visible-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/TaskSchedule.vue'),
@@ -12,7 +13,9 @@ const SRC = readFileSync(
 // 那些说明性文字不该把断言判红。
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-const CODE = stripComments(SRC)
+const CODE = visibleCode(SRC, stripComments)
+// 界面文案已外置到 zh locale：断言"显示了这句话"要看组件实际引用的键解析出的中文
+const TEXT = visibleText(SRC)
 
 test('e2e 锚点：根节点类名是 task-schedule', () => {
   assert.ok(SRC.includes('class="task-schedule"'))
@@ -24,7 +27,7 @@ test('props 契约', () => {
 })
 
 test('空态文案存在（A 期唯一会渲染的分支）', () => {
-  assert.ok(SRC.includes('还没有排任务'))
+  assert.ok(TEXT.includes('还没有排任务'))
 })
 
 test('列表分支已落地（B 期只换渲染分支，父页面与端点不改）', () => {


### PR DESCRIPTION
**master 自 PR#353 合并起 `test:project-home` 一直 6 红**，是我那次长尾 i18n 迁移造成的：文案抽到了 `src/locales/zh-CN/*.js`，而这组测试仍在组件源码里找中文串。

## 修法
不是放宽断言，而是让断言看到真正的文案。新增 `tests/project-home/_visible-text.mjs`：从组件源码解析出它实际引用的 `$t('ns.key')`，到对应 zh locale 取值，拼成「这个组件会显示的文字」。

- **正向断言**（显示了这句话）→ `visibleText(SRC)`
- **禁字断言**（"unavailable 不许是错误文案"、"不许复用工作台指针" 等）→ `visibleCode(SRC, stripComments)`。这条是关键：文案外置后只查源码等于护栏失效，有人把 locale 里那句改成「读取失败」也不会红。注释仍然排除（注释里要能写清楚为什么不做某件事）。

## 护栏有效性实测
把 zh locale 里「这份案卷还没有版本记录」改成「读取失败」→ 测试立刻红（not ok 3 unavailable 走中性引导态）；还原 → 绿。不是「改到不红」而已。

## 一处口径调整
`page.test` 的 `>项目概览<` 尖括号写法原本是用来确认文案在模板文本节点里的；文案外置后这层由同一测试里的 `home-topbar-title` 类名断言承担，这里只保证文案还在。

## 验证
`npm run test:project-home` **72/72**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)