### PR TITLE
test: 文案类禁字断言随 i18n 迁移改看 locale 值（补 #359 的缺口）

### DIFF
--- a/frontend/tests/project-home/_locale-text.mjs
+++ b/frontend/tests/project-home/_locale-text.mjs
@@ -1,0 +1,41 @@
+// 禁字断言专用：解析出「这个组件实际会显示的中文」。
+//
+// i18n 迁移后组件源码里只剩 $t('ns.key')，于是 !CODE.includes('读取失败') 这类
+// 护栏永远为真——把 locale 里的文案改成禁用词也拦不住。正向断言可以直接读整份
+// locale 文件（#359 的做法），但禁字断言不行：projects.js 里就有
+// loadFailedRetry: '加载失败，请稍后重试'，整份拼进去会让「unavailable 不许是
+// 错误文案」误红。所以这里精确到该组件引用的那些键。
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const nsCache = new Map()
+
+function loadNs(ns) {
+  if (!nsCache.has(ns)) {
+    let dict = {}
+    try {
+      // locale 是纯字面量对象的 ES 模块；不引 vue-i18n，直接抠出 default 导出求值
+      const src = readFileSync(resolve(HERE, '../../src/locales/zh-CN/' + ns + '.js'), 'utf8')
+        .replace(/^\s*export\s+default\s*/m, 'return ')
+      dict = new Function(src)() || {}
+    } catch (e) { /* ns 不存在：按空字典处理 */ }
+    nsCache.set(ns, dict)
+  }
+  return nsCache.get(ns)
+}
+
+const dig = (obj, path) => path.reduce((o, k) => (o == null ? o : o[k]), obj)
+
+/** 组件源码里 $t 引用到的全部 zh 文案值，换行拼接。 */
+export function localeValuesOf(src) {
+  return [...src.matchAll(/\$t\(\s*['"]([\w.]+)['"]/g)]
+    .map((m) => {
+      const [ns, ...rest] = m[1].split('.')
+      const v = dig(loadNs(ns), rest)
+      return typeof v === 'string' ? v : ''
+    })
+    .join('\n')
+}

--- a/frontend/tests/project-home/activity-feed.test.mjs
+++ b/frontend/tests/project-home/activity-feed.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { localeValuesOf } from './_locale-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/ActivityFeed.vue'),
@@ -14,6 +15,9 @@ const ZH = readFileSync(new URL('../../src/locales/zh-CN/projects.js', import.me
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
 const CODE = stripComments(SRC)
+// 文案类禁字断言要看组件实际引用的 locale 值——只查源码的话，
+// 迁移后把 locale 改成禁用词也拦不住（见 _locale-text.mjs）。
+const CODE_TEXT = CODE + '\n' + localeValuesOf(SRC)
 
 test('e2e 锚点：根节点类名是 activity-feed', () => {
   assert.ok(SRC.includes('class="activity-feed"'))
@@ -31,7 +35,7 @@ test('unavailable 走中性引导态而不是错误态', () => {
   assert.ok(ZH.includes('这份案卷还没有版本记录'), '文案已迁 locale')
   assert.ok(SRC.includes('noVersionHistoryTitle'), '组件要引用该 key')
   for (const bad of ['读取失败', '加载失败', '出错了', '请重试'])
-    assert.ok(!CODE.includes(bad), 'unavailable 不许是错误文案: ' + bad)
+    assert.ok(!CODE_TEXT.includes(bad), 'unavailable 不许是错误文案: ' + bad)
 })
 
 test('空列表另有一条空态文案，与 unavailable 分开', () => {

--- a/frontend/tests/project-home/task-schedule.test.mjs
+++ b/frontend/tests/project-home/task-schedule.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { localeValuesOf } from './_locale-text.mjs'
 
 const SRC = readFileSync(
   resolve(dirname(fileURLToPath(import.meta.url)), '../../src/components/project-home/TaskSchedule.vue'),
@@ -14,6 +15,9 @@ const ZH = readFileSync(new URL('../../src/locales/zh-CN/projects.js', import.me
 const stripComments = (s) =>
   s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
 const CODE = stripComments(SRC)
+// 文案类禁字断言要看组件实际引用的 locale 值——只查源码的话，
+// 迁移后把 locale 改成禁用词也拦不住（见 _locale-text.mjs）。
+const CODE_TEXT = CODE + '\n' + localeValuesOf(SRC)
 
 test('e2e 锚点：根节点类名是 task-schedule', () => {
   assert.ok(SRC.includes('class="task-schedule"'))
@@ -38,7 +42,7 @@ test('列表分支已落地（B 期只换渲染分支，父页面与端点不改
 })
 
 test('不混用 AI 步骤条的词', () => {
-  assert.ok(!CODE.includes('进度条'), '「进度」是 todo_write 的词，项目级里程碑一律叫「任务」')
+  assert.ok(!CODE_TEXT.includes('进度条'), '「进度」是 todo_write 的词，项目级里程碑一律叫「任务」')
 })
 
 test('禁 emoji + 浅色', () => {


### PR DESCRIPTION
#359 修好了 project-home 的**正向**断言（读 locale 文件 + 断言组件引用了 key），但两条**文案类禁字**断言仍只查组件源码——迁移后源码里只剩 `$t('ns.key')`，「unavailable 不许是错误文案」「不许混用 AI 步骤条的词」实际已经成了空断言。

## A/B 实测
场景：给 unavailable 态新增一句错误口吻文案（`{{ $t('projects.loadFailedRetry') }}`，原文案不动）。

| | 结果 |
|---|---|
| master 现状 | 72/72 全绿放行 |
| 本 PR | not ok 3 — unavailable 走中性引导态而不是错误态 |

（#359 的正向断言拦得住「把原文案改成禁用词」，但拦不住「另外加一句」。）

## 修法要精确到键
不能把整份 locale 拼进 CODE：`projects.js` 里就有 `loadFailedRetry: '加载失败，请稍后重试'`，整份拼会让「unavailable 不许出现加载失败」误红。新增 `_locale-text.mjs` 从组件源码解析 `$t` 键再取对应值，只在这两条断言上用 `CODE_TEXT`。

其余禁字断言查的是代码标识符（`authorName` / `substr` / `ChatInterface` / `loadHistoryChat` 等），不受 i18n 影响，保持 `CODE` 不变——没有为了统一而扩大改动面。

## 验证
`npm run test:project-home` **72/72**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)