### PR TITLE
fix(editor): 自动保存死循环——export_document 自己把文档标成已修改

### DIFF
--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -1432,6 +1432,9 @@ function installKeyHandler() {
 }
 
 // ---- autosave: forward document modify events to the editor page ---------
+// 导出期间抑制 modified 上报：storeToURL 会把文档标成已修改，见 export_document。
+let exportInFlight = false;
+
 // XModifyBroadcaster fires `modified` on every document change regardless of
 // origin (canvas typing, IME overlay commit, AI agent command) — the one seam
 // that sees them all. The editor page throttles and relays the signal to the
@@ -1439,7 +1442,11 @@ function installKeyHandler() {
 // out the broadcast a later setModified(false) would emit.
 function installModifyListener(model) {
   const listener = zetajs.unoObject([css.util.XModifyListener], {
-    modified() { try { if (model.isModified()) post('modified'); } catch (e) { /* ignore */ } },
+    // exportInFlight：storeToURL 自己会把文档标成 modified（见 export_document）。
+    // 不挡掉的话每次自动保存都会引出一次 modified，宿主据此再排一次保存——
+    // 实测形成每 3 秒一轮的「保存→modified→保存」死循环，整份 docx 反复上传，
+    // 且 export 是全文档同步序列化，会周期性冻住 Qt 事件循环。
+    modified() { try { if (exportInFlight) return; if (model.isModified()) post('modified'); } catch (e) { /* ignore */ } },
     disposing() {},
   });
   model.addModifyListener(listener);
@@ -2385,7 +2392,19 @@ const EXEC = {
     if (filter) props.push(mkProp('FilterName', filter));
     // private:stream = "write to the OutputStream in the media descriptor" —
     // the standard LO idiom for exporting to memory (no filesystem involved).
-    xModel.storeToURL('private:stream', props);
+    // storeToURL 会把文档标成 modified（实测：导出完 isModified() 恒为 true）。
+    // 不复原的话宿主收到 modified 又排一次自动保存，形成保存死循环，所以这里
+    // 既要在导出期间闭掉上报，也要把标志恢复成导出前的值。
+    // 导出是同步的、跑在这条 office 线程上，期间不可能有用户编辑挤进来，
+    // 复原不会吃掉真实修改；宿主侧的 dirty 是另一套独立记账，也不受影响。
+    const wasModified = (() => { try { return !!xModel.isModified(); } catch (e) { return false; } })();
+    exportInFlight = true;
+    try {
+      xModel.storeToURL('private:stream', props);
+    } finally {
+      exportInFlight = false;
+      try { if (!!xModel.isModified() !== wasModified) xModel.setModified(wasModified); } catch (e) { /* 只读文档等场景可能拒绝，忽略 */ }
+    }
     saveSeq++;
     if (total === 0) return { success: false, message: 'export_document: store produced 0 bytes' };
     const u8 = new Uint8Array(total);

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -406,6 +406,9 @@ try {
     // 保留对「已保存」的识别只是为了兼容旧版本前端。
     for (let i = 0; i < 60; i++) {
       const st = await editorEval('return { status: ed.statusText, saving: ed.saving, dirty: ed.dirty }')
+      // editorEval 找不到组件时回 { err }，而 !st.dirty / !st.saving 对 undefined
+      // 恒为真——不挡住就会把「编辑器压根没挂上」判成「保存完成」（实测假绿过）
+      if (st.err) throw new Error('读不到编辑器实例: ' + st.err)
       if (/已保存/.test(st.status)) return
       if (i > 5 && !st.dirty && !st.saving && !/失败/.test(st.status)) return
       if (/失败/.test(st.status)) throw new Error('保存状态: ' + st.status)


### PR DESCRIPTION
**打开文档后，整份 docx 每约 3 秒往后端传一次，一直传到关闭。**

## 根因
`export_document` 用 `storeToURL('private:stream')` 导出 → LO 导出完 `isModified()` 仍为 true → worker 的 XModifyListener 上报 `modified` → 宿主 `onDocModified` 标脏 → 排下一次自动保存 → 又导出。

desktop-e2e 探针实测（每秒采样）：

| 时刻 | saves | mods | dirty |
|---|---|---|---|
| … | 12 | 16 | true |
| … | 15 | 19 | true |
| … | 18 | 22 | true |

保存次数与 modified 次数**严格一一对应**上涨——每保存一次就引出一次 modified。修复后：saves 停在 **1**、mods 停在 4（只有真实编辑）、dirty 保存后转 false。

## 代价不只是流量
`export_document` 是全文档同步序列化，跑在 office 线程上会周期性冻住 Qt 事件循环——与历史「假死」（PR#182）同一机理。

**一直没被发现**是因为功能表现完全正常：内容确实保存了，界面也不出声（PR#345 的「安静保存」策略下成功不显示任何东西）。唯一逮到它的是 desktop-e2e 的 `dirty` 断言，而那条红线此前被当作测试抖动搁置（#359 只给它加了诊断输出）。

## 修法
worker 侧模块级 `exportInFlight`：导出期间闭掉 modified 上报，导出结束把 `isModified` 恢复成导出前的值。

导出是同步的、跑在 office 线程上，期间不可能有用户编辑挤进来，所以复原不会吃掉真实修改；宿主侧的 `dirty` 是另一套独立记账，也不受影响（`autoSave` 里「edits arrived mid-save」那条分支照常成立）。

## 顺带修一处 e2e 假绿
`editorEval` 找不到组件时返回 `{ err }`，而 `!st.dirty` / `!st.saving` 对 `undefined` 恒为真 → 把「编辑器压根没挂上」判成「保存完成」。本次诊断途中它真的假绿过一次（前面步骤全红、这一步却打勾）。

## 验证
- `test:desktop-e2e` **全通**（修前 1 步失败）
- `test:lowa-e2e` **391/391**（改了 worker，按硬约束必跑，用 24.2.8-zhcn-r4 真引擎）
- `test:app-e2e` 121/121；`mvn test` 1702/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)