### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号 bump。本版内容与验证见下。

## 本版包含
- **中英双语全链路**（EN 版八片）：界面、文档编辑器、AI 回复与工具过程全部跟随设置里的语言；单一安装包，运行时切换。
- **会议录音插件**：录音转写、说话人分离、AI 纪要。
- **编辑器自建工具栏 P1–P4**：常用命令直达，补齐表格/脚注尾注/页眉页脚，LO 原生 chrome 退场。
- **两处稳定性修复**：AI 流式传输层错误被吞导致的 180 秒无响应（#363）；自动保存死循环——整份 docx 每 3 秒重传一次（#364）。

## 发版验证
| 套件 | 结果 | 基线 |
|---|---|---|
| `mvn test` | 1702 / 0 失败 | 1702 |
| `app-e2e` | 121 / 121 | 121（含 J12 英文走查）|
| `lowa-e2e` | 391 / 391 | 391 |
| `desktop-e2e` | 保存链路全通 | 全通 |

LOWA 引擎 24.2.8-zhcn-r4 三处资产已验可达。

合并后打 tag `v0.16.0` 触发双平台构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)