### PR TITLE
fix(desktop): Mac 上应用名显示 Electron；iCloud 文件夹被监听器读穿全树

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -49,7 +49,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 - 一键：`./restart-all.sh`（Docker 服务 + 后端 + 前端 + 桌面）。
 - 后端：`cd backend && ./restart-backend.sh`（mvn package -DskipTests → kill 9696 → nohup java -jar，prod 配置，日志 backend/app.log）。
 - 前端：`cd frontend && npm run dev:h5`（5173；e2e 用 `npx uni --port 5174`）。**npm 不是 pnpm**。
-- 桌面：`cd desktop && npm run dev`（AIWORKDECK_DESKTOP_DEV=1 electron .；dev Electron 复用已跑的 9696 后端不另起 java）。`npm run clean` 清用户数据目录。
+- 桌面：`cd desktop && npm run dev`（AIWORKDECK_DESKTOP_DEV=1 electron .；dev Electron 复用已跑的 9696 后端不另起 java）。`npm run clean` 清用户数据目录。predev 钩子会跑 `scripts/brand-dev-electron.js` 把 node_modules 里的 Electron.app 改名（见下条）。
 - Docker 附属：`docker compose up`（mineru 8001、pptx 5001、easyvoice 9549 段已停用改 ElevenLabs）。
 
 ## 关键构建脚本（desktop/scripts/）
@@ -82,6 +82,20 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 - CI 签名→冒烟→打包顺序不可乱（PR#176）。
 - macOS CI 红要当真查（Apple 协议过期事件后恢复）；`--admin` 合并与 worktree 删分支技巧见 ci-macos 记录。
 - iCloud 驱逐会掏空本地文件（打包/测试环境两次踩）；EMFILE 用抬 ulimit 解。
+- **iCloud 上「读一下」不是免费的**：被驱逐的文件是 dataless 占位，`stat` 秒回真实大小但
+  `st_blocks=0`，**一 read 就同步触发下载**（本机实测 23KB 文件首次 read 耗 1.28 秒，延迟
+  决定、与大小无关）。所以凡是「扫用户文件夹」的代码只许 stat，绝不许顺手读内容——
+  `LocalRootWatchService.WATCH_FILE_HASHER` 就是为此把 DirectoryWatcher 的默认内容哈希
+  换成了 mtime 哈希（默认值会在建立监听时把整棵树逐字节读一遍，等于打开项目就把整个
+  文件夹从 iCloud 拉回来）。回归用例 `LocalRootWatchServiceTest`，拿命名管道当"未下载文件"。
+  已知仍会读穿全树的是版本记录的 `git add .`（JGit 必须读内容才能存 blob），但它被
+  `repoService.isInitialized` 挡着，只有开了版本记录的项目才走到。
+- **macOS 菜单栏左上角那个应用名只认 .app 包的 `CFBundleName`**，跟 `app.name`、跟菜单模板
+  第一项的 label 都无关（实测 `app.setName('AI Workdeck')` 之后菜单栏照旧写 Electron）。
+  打包版由 electron-builder 按 `build.productName` 写好；dev 跑的是 node_modules 里的
+  Electron.app，所以要靠 `scripts/brand-dev-electron.js` 就地改名（Electron 的 dist 包是
+  linker-signed adhoc，`Info.plist=not bound`，改它不破坏签名）。**做官网/README 截图前
+  务必确认这一步跑过**，否则截出来的图左上角是 Electron。
 - worktree 冷启动跑双 e2e 完整配方见 v0.7.7 发版实录；worktree merge 报 stash failed 用 cherry-pick 绕。
 - 坏 pnpm node_modules 遇到过——本项目一律 npm。
 - **worktree 的 node_modules 落后于新增依赖**（如 TOTP 带来的 `qrcode`）时，vite 会推一个盖满视口的 `vite-error-overlay`，坐标点击全被它吃掉，e2e 表现成"点了没反应"的超时而非编译错误。冷启动 worktree 跑 e2e 前先 `npm install`；desktop-e2e 的点击已加命中校验，会直接报出遮挡者和它的文案。

--- a/backend/src/main/java/com/checkba/service/LocalRootWatchService.java
+++ b/backend/src/main/java/com/checkba/service/LocalRootWatchService.java
@@ -3,6 +3,7 @@ package com.checkba.service;
 import com.checkba.model.entity.Project;
 import com.checkba.repository.ProjectRepository;
 import io.methvin.watcher.DirectoryWatcher;
+import io.methvin.watcher.hashing.FileHasher;
 import jakarta.annotation.PreDestroy;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -39,6 +40,25 @@ public class LocalRootWatchService {
 
     /** 防抖窗口：编辑器保存/Finder 拷贝往往是一串事件，合并成一次对账。 */
     static final long DEBOUNCE_MILLIS = 800;
+
+    /**
+     * 监听器给每个文件算的"指纹"——**只取 mtime，绝不能用默认的内容哈希**。
+     *
+     * DirectoryWatcher 用这个指纹去重 MODIFY 事件，默认的 {@code FileHasher.DEFAULT_FILE_HASHER}
+     * 是「完整读一遍文件算 murmur3」。它在 watchAsync 建立监听时（PathUtils.initWatcherState）
+     * 就会把整棵树的每个文件从头读到尾，而且不受 MAX_IMPORT_ENTRIES 那种上限约束。
+     *
+     * 在 iCloud「优化 Mac 储存空间」的文件夹上这是灾难：被驱逐的文件在磁盘上是
+     * dataless 占位（stat 能秒回真实大小，st_blocks=0），**一旦 read 就触发下载**。
+     * 于是"打开一个项目文件夹"等于"把整个文件夹从 iCloud 拉回本地"——本机实测单个
+     * 23KB 的已驱逐文件光首次 read 就要 1.28 秒（延迟决定，与大小无关），几百个文件
+     * 就是几分钟的后台狂拉，网络和磁盘全被占住。
+     *
+     * mtime 指纹只 stat，不读内容，因此不会把文件拽下来。代价是"内容变了但 mtime 没变"
+     * 的修改不会触发事件——真实编辑不存在这种情况；何况监听回调压根不看事件内容，
+     * 只是排一次幂等的全量对账（见 {@link #scheduleReconcile}）。
+     */
+    static final FileHasher WATCH_FILE_HASHER = FileHasher.LAST_MODIFIED_TIME;
 
     private final ProjectRepository projectRepository;
     private final LocalProjectService localProjectService;
@@ -90,6 +110,7 @@ public class LocalRootWatchService {
         try {
             DirectoryWatcher watcher = DirectoryWatcher.builder()
                     .path(root)
+                    .fileHasher(WATCH_FILE_HASHER)   // 见 WATCH_FILE_HASHER：默认值会读穿整个文件夹
                     .listener(event -> scheduleReconcile(projectId))
                     .build();
             DirectoryWatcher prev = watchers.putIfAbsent(projectId, watcher);

--- a/backend/src/test/java/com/checkba/service/LocalRootWatchServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalRootWatchServiceTest.java
@@ -1,0 +1,44 @@
+package com.checkba.service;
+
+import io.methvin.watcher.hashing.FileHash;
+import io.methvin.watcher.hashing.FileHasher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * 文件夹监听的性能契约：**建立监听时不许读文件内容**。
+ *
+ * 背景见 {@link LocalRootWatchService#WATCH_FILE_HASHER}——DirectoryWatcher 默认的内容哈希
+ * 会在 watchAsync 时把整棵树逐字节读一遍，在 iCloud「优化 Mac 储存空间」的文件夹上
+ * 等价于「打开项目 = 把整个文件夹拉回本地」。
+ *
+ * 测试用命名管道（FIFO）扮演「未下载的 iCloud 文件」：stat 秒回、read 会一直挂着，
+ * 正是 dataless 占位文件的行为放大版。换回内容哈希，本用例会直接超时。
+ */
+class LocalRootWatchServiceTest {
+
+    @Test
+    void watchFileHasherReadsMetadataOnlyAndNeverBlocksOnFileContent(@TempDir Path dir) throws Exception {
+        assumeTrue(!System.getProperty("os.name").toLowerCase().startsWith("win"), "命名管道是 POSIX 特性");
+        Path evicted = dir.resolve("evicted.docx");
+        assumeTrue(new ProcessBuilder("mkfifo", evicted.toString()).start().waitFor() == 0,
+                "mkfifo 不可用，跳过");
+
+        FileHash hash = assertTimeoutPreemptively(Duration.ofSeconds(5),
+                () -> LocalRootWatchService.WATCH_FILE_HASHER.hash(evicted),
+                "指纹算法读了文件内容——在 iCloud 文件夹上这会把每个文件都下载一遍");
+
+        // DirectoryWatcher 的 pathHashes 是 ConcurrentSkipListMap，塞 null 会 NPE 掀掉监听线程
+        assertNotNull(hash, "指纹不能为 null");
+        assertNotSame(FileHasher.DEFAULT_FILE_HASHER, LocalRootWatchService.WATCH_FILE_HASHER,
+                "默认哈希是「完整读一遍文件」，不能用在用户自己的文件夹上");
+    }
+}

--- a/desktop/main/app-menu.js
+++ b/desktop/main/app-menu.js
@@ -5,8 +5,18 @@
 // 不能让菜单加速器抢走它去关整个窗口。
 // 菜单文案随应用语言（app-language.js）双语；语言切换经 onAppLanguageChange 整体重建。
 
-const { app, Menu, ipcMain } = require('electron')
+const { Menu, ipcMain } = require('electron')
 const { t, onAppLanguageChange } = require('./app-language')
+
+// 菜单里的应用名写死，**不要用 app.name**：desktop/package.json 没有顶层 productName，
+// Electron 于是拿 name 字段当 app.name，菜单会显示「关于 aiworkdeck-desktop」。
+// 而补一个顶层 productName 会连带把 app.getPath('userData') 从
+// ~/Library/Application Support/aiworkdeck-desktop 改名到「AI Workdeck」，
+// 存量用户的 Local Storage（登录态、uni 存储）当场全丢——不值得为一个显示名冒这个险。
+// 注：macOS 菜单栏最左边那个粗体应用名不由这里决定，它取自运行中 .app 包的
+// CFBundleName（打包版=AI Workdeck；dev 跑 node_modules 里的 Electron.app，
+// 见 scripts/brand-dev-electron.js）。
+const APP_DISPLAY_NAME = 'AI Workdeck'
 
 let getWindow = () => null
 let recentProjects = []
@@ -27,15 +37,15 @@ function buildTemplate() {
 
   return [
     {
-      label: app.name,
+      label: APP_DISPLAY_NAME,
       submenu: [
-        { role: 'about', label: t({ zh: '关于 ', en: 'About ' }) + app.name },
+        { role: 'about', label: t({ zh: '关于 ', en: 'About ' }) + APP_DISPLAY_NAME },
         { type: 'separator' },
-        { role: 'hide', label: t({ zh: '隐藏 ', en: 'Hide ' }) + app.name },
+        { role: 'hide', label: t({ zh: '隐藏 ', en: 'Hide ' }) + APP_DISPLAY_NAME },
         { role: 'hideOthers', label: t({ zh: '隐藏其他', en: 'Hide Others' }) },
         { role: 'unhide', label: t({ zh: '全部显示', en: 'Show All' }) },
         { type: 'separator' },
-        { role: 'quit', label: t({ zh: '退出 ', en: 'Quit ' }) + app.name },
+        { role: 'quit', label: t({ zh: '退出 ', en: 'Quit ' }) + APP_DISPLAY_NAME },
       ],
     },
     {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,6 +7,7 @@
   "main": "main/main.js",
   "scripts": {
     "clean": "node scripts/clean.js",
+    "predev": "node scripts/brand-dev-electron.js",
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",

--- a/desktop/scripts/brand-dev-electron.js
+++ b/desktop/scripts/brand-dev-electron.js
@@ -1,0 +1,57 @@
+// dev 态品牌名：把 node_modules 里那个 Electron.app 就地改名成 AI Workdeck。
+//
+// 为什么必须改包而不是改代码：macOS 菜单栏最左边那个粗体应用名由 AppKit 从**当前运行的
+// .app 包**的 Info.plist:CFBundleName 里读，跟 app.name、跟菜单模板第一项的 label 都无关。
+// 实测（Electron 30 / macOS 26）：app.setName('AI Workdeck') + 模板 label 也写 'AI Workdeck'，
+// 菜单栏照旧显示 Electron；只把包里的 CFBundleName 改掉，菜单栏立刻变成 AI Workdeck。
+// 打包版没这个问题（electron-builder 按 build.productName 写 Info.plist），只有
+// `npm run dev` 跑的是 node_modules/electron/dist/Electron.app，于是左上角写着 Electron。
+//
+// 安全性：Electron 的 dist 包是 linker-signed adhoc 签名，`codesign -dv` 报
+// 「Info.plist=not bound」——Info.plist 不在签名覆盖范围内，改它不会让包启动不了（已实测）。
+//
+// 幂等；失败只警告不阻断（predev 钩子，绝不能因为改不了名字就让人跑不起 dev）。
+// npm install 重装 electron 后会被还原，下次 npm run dev 再改一次即可。
+
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const DISPLAY_NAME = 'AI Workdeck'
+const PLIST = path.join(__dirname, '..', 'node_modules', 'electron', 'dist',
+  'Electron.app', 'Contents', 'Info.plist')
+
+function plist(...args) {
+  return execFileSync('/usr/libexec/PlistBuddy', [...args, PLIST], { encoding: 'utf8' }).trim()
+}
+
+function setKey(key) {
+  let current = null
+  try {
+    current = plist('-c', `Print :${key}`)
+  } catch {
+    // 键不存在（CFBundleDisplayName 在某些版本里没有）——补一个
+    plist('-c', `Add :${key} string ${DISPLAY_NAME}`)
+    return true
+  }
+  if (current === DISPLAY_NAME) return false
+  plist('-c', `Set :${key} ${DISPLAY_NAME}`)
+  return true
+}
+
+if (process.platform !== 'darwin') {
+  process.exit(0)
+}
+if (!fs.existsSync(PLIST)) {
+  // 还没 npm install，或 electron 装在了别处——不是错误
+  process.exit(0)
+}
+
+try {
+  const changed = ['CFBundleName', 'CFBundleDisplayName'].map(setKey).some(Boolean)
+  if (changed) {
+    console.log(`[brand-dev-electron] dev 态应用名已改为「${DISPLAY_NAME}」`)
+  }
+} catch (e) {
+  console.warn(`[brand-dev-electron] 跳过（dev 菜单栏会显示 Electron）: ${e.message}`)
+}


### PR DESCRIPTION
在 Mac 上打开 aiworkdeck 时踩到的两件事。

## 1. 左上角写着 Electron

**根因**：macOS 菜单栏最左边那个粗体应用名由 AppKit 从**当前运行的 .app 包**的 `Info.plist:CFBundleName` 里读，跟 `app.name`、跟菜单模板第一项的 `label` 都无关。实测（Electron 30 / macOS 26）：`app.setName('AI Workdeck')` 且模板 label 也写 `AI Workdeck`，菜单栏照旧显示 Electron；只把包里的 `CFBundleName` 改掉，菜单栏立刻变成 AI Workdeck。

打包版没这个问题（electron-builder 按 `build.productName` 写好了）。但 `npm run dev` 跑的是 `node_modules/electron/dist/Electron.app`，于是左上角是 Electron —— 这也意味着此前用 dev Electron 拍的官网/README 截图都带着这个名字。

**改法**：新增 `desktop/scripts/brand-dev-electron.js`（`predev` 钩子，幂等、失败只警告不阻断），把本机 dev 用的那个 Electron.app 就地改名。Electron 的 dist 包是 linker-signed adhoc 签名且 Info.plist 不在签名覆盖内（`codesign -dv` 报 `Info.plist=not bound`），改它不破坏签名、不影响启动。

**顺带修另一半**：`desktop/package.json` 没有顶层 `productName`，Electron 于是拿 `name` 字段当 `app.name`，菜单里写的是「关于 aiworkdeck-desktop」（这个打包版也有）。这里**没有**补 `productName` —— 补了会连带把 `app.getPath('userData')` 从 `aiworkdeck-desktop` 改名到 `AI Workdeck`，存量用户的 Local Storage（登录态、uni 存储）当场全丢。改成写死显示名，理由写在注释里。

## 2. iCloud 文件夹打开得慢

**根因**：`DirectoryWatcher` 默认的 `FileHasher.DEFAULT_FILE_HASHER` 是「完整读一遍文件算 murmur3」。它在 `watchAsync` 建立监听时（`PathUtils.initWatcherState`）就把整棵树每个文件从头读到尾，而且不受 `MAX_IMPORT_ENTRIES` 那种上限约束。

在 iCloud「优化 Mac 储存空间」的文件夹上这是灾难：被驱逐的文件是 dataless 占位，`stat` 能秒回真实大小（`st_blocks=0`），**一旦 read 就同步触发下载**。于是「打开一个项目文件夹」等价于「把整个文件夹从 iCloud 拉回本地」。

本机实测（用户自己的 iCloud Drive）：

```
读前: size=23673 blocks=0
real 1.28
读后: size=23673 blocks=48
```

单个 23KB 的已驱逐文件光首次 read 就要 1.28 秒（延迟决定、与大小无关），几百个文件就是几分钟的后台狂拉，网络和磁盘全被占住。

**改法**：换成 `FileHasher.LAST_MODIFIED_TIME`，只 stat 不读内容。代价是「内容变了但 mtime 没变」的修改不触发事件——真实编辑不存在这种情况；何况监听回调压根不看事件内容，只是排一次幂等的全量对账。

导入那条路径本来就只 stat（`LocalProjectService.importFolder` 用 `BasicFileAttributes`），不用动。

## 测试

新增 `LocalRootWatchServiceTest`：拿命名管道（FIFO）扮演「未下载的 iCloud 文件」——stat 秒回、read 一直挂着。换回默认哈希这条用例直接超时，已实测：

```
AssertionFailedError: 指纹算法读了文件内容——在 iCloud 文件夹上这会把每个文件都下载一遍
  ==> execution timed out after 5000 ms
```

- 后端 `mvn test`：1703 / 0 failures（基线 1702 + 本 PR 新增 1）
- desktop `npm test`：37 / 37
- `brand-dev-electron.js` 四种情形手验过：首次改名 / 二次静默 / 缺 `CFBundleDisplayName` 走 Add / 没装 node_modules 静默退出

## 遗留（未在本 PR 处理）

- 版本记录的 `git add .`（JGit 必须读内容才能存 blob）仍会读穿全树，但被 `repoService.isInitialized` 挡着，只有开了版本记录的项目才走到。
- 打开单个已驱逐文档时那一次下载等待没法省，属于 iCloud 语义本身。

🤖 Generated with [Claude Code](https://claude.com/claude-code)