### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI Workdeck desktop shell (Electron)",
   "author": "AI Workdeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号单一来源 `desktop/package.json`：0.16.0 → 0.17.0。

**为什么是大版本**：#371 改了 `desktop/main/` 与 `desktop/preload/`，
`desktop/scripts/patch-gate.sh` 会拒绝这类改动走小版本补丁通道
（那条只允许 backend-app / frontend-h5 / zetaoffice-wrapper / pysvc-src
四个 overlay 组件），只能发全量安装包。

## 本版内容

**#371 桌面外壳无边框化 + 菜单栏重建**

- Electron 默认标题栏去掉，窗口控件并进已有的 `.project-header`
  （mac 交通灯精确摆位，Windows 原生控件覆盖右上）
- 菜单栏从 Electron 模板重建成九个菜单，新增 文档 / AI / 转到 / 工具 / 帮助
- 命令表收口为菜单、加速键、命令面板（`⌥⌘P`）三者的单一数据源
- Windows 自绘菜单栏（那边无边框后原生菜单栏会一并消失）
- 快捷键编辑器优先，本次零破坏性变更

同时带上此前已合并的 #367 #368 #369 #370。

## 合并打 tag 后要人工过一眼

- **全屏进出**：CSS 侧实测过，真实全屏触发不了（自动化点 `Toggle Full Screen`
  不生效，该 role 要求真实用户交互）
- **菜单加速键能否穿透 LOWA webview**
- **Windows 自绘菜单栏从没在真 Windows 上跑过**，只在 mac 上冒充 `is-win`
  验过样式与渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)