### PR TITLE
fix(desktop): 离开工作台后菜单栏残留全亮，点了没反应

### DIFF
--- a/frontend/src/pages/project-overview/menuCommands.js
+++ b/frontend/src/pages/project-overview/menuCommands.js
@@ -89,10 +89,18 @@ export const menuCommandsMethods = {
     this.pushMenuState()
   },
 
+  /**
+   * 交出菜单。**必须连状态一起清掉**——只摘事件监听的话，桥里还留着
+   * page:'workbench' 和一整套 flags，用户去了项目列表/设置页，菜单依然全亮，
+   * 点下去却没有活跃实例来接 = 点了没反应。清成空页面后，所有
+   * when:['workbench'] 的条目自动置灰，「打开文件夹」这类无 when 的照常可用。
+   */
   unregisterMenuCommands() {
     if (!this._menuCmdHandler) return
     try { uni.$off(COMMAND_EVENT, this._menuCmdHandler) } catch (e) { /* ignore */ }
     this._menuCmdHandler = null
+    setMenuPage('', {})
+    this.menuBarRefreshKey++
   },
 
   // ---- 命令执行 ---------------------------------------------------------

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -2355,6 +2355,9 @@ export default {
     }
   },
   onHide() {
+    // 菜单栏：本页被盖住（去了个人中心/设置页）就交出去。实例还活着，
+    // onShow 会重新接管——但期间菜单不能继续亮着工作台那一堆条目。
+    this.unregisterMenuCommands()
     this.stopActivityTracking()
 
     // Desktop：离开工作区页面（如去个人中心）必须隐藏 BrowserView


### PR DESCRIPTION
#371 的后续修复，**建议在 v0.17.0 打 tag 前合并**。

## 问题

#371 只在工作台（project-overview）上报菜单状态，而 `unregisterMenuCommands`
只摘事件监听、不清桥里的状态快照。于是去了项目列表 / 个人中心 / 设置页之后，
`appMenuBridge` 里仍是 `page: 'workbench'` 加一整套 flags——**菜单照旧全亮，
点下去却没有活跃实例来接**，表现为「点了没反应」。

这正是本仓库文档反复警告的那类缺陷（`.claude/agents/sidebar-shell.md` 页面栈
多实例那一节）。

## 改法

`unregisterMenuCommands` 连状态一起清（`setMenuPage('', {})`），并在 `onHide`
也调一次——`navigateTo` 去设置页时实例还活着但已被盖住，菜单不能继续亮着工作台
那一堆条目。`onShow` 原有的 `registerMenuCommands` 负责回来时重新接管。

清成空页面后，所有 `when: ['workbench']` 的条目自动置灰，而「打开文件夹」
「新建项目」这类无 `when` 的照常可用——**离开工作台后菜单仍然有用，只是不再
提供它接不住的东西。**

## 真机验证

`osascript` 读真实 NSMenu 的 enabled 属性：

| 时机 | View 菜单 | Document 菜单 |
|---|---|---|
| 在工作台 | 业务项可用 | 开着 Word 文档时可用 |
| navigateTo 个人中心后 | 业务项**全灰**，只剩重新加载/开发者工具/缩放/全屏 | 全灰 |
| navigateBack 回工作台 | 重新点亮 | — |

回来后点 `View→Sidebar` 仍能真的翻转 `sidebarCollapsed`，接管没丢。

`check:emits` 与 `test:commands` 17/17 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)