### PR TITLE
fix(desktop): npm run clean 清的是早已改名的旧目录

### DIFF
--- a/desktop/scripts/clean.js
+++ b/desktop/scripts/clean.js
@@ -20,7 +20,10 @@ function removeDir(dirPath) {
     }
 }
 
-const appName = 'checkba-desktop'; // Must match name in package.json or app.name
+// 必须跟 Electron 的 app.name 一致，而 app.name 取自 package.json：有顶层 productName
+// 就用它、没有才用 name。本项目刻意不设顶层 productName（补上会连带把 userData 目录改名、
+// 丢存量用户登录态，理由见 main/app-menu.js 顶部），所以读 name 就是对的。别写死，会漂。
+const appName = require('../package.json').name;
 let userDataPath;
 
 if (process.platform === 'darwin') {


### PR DESCRIPTION
## 问题

`desktop/scripts/clean.js` 里 appName 写死成 `checkba-desktop`，是项目更名前的残留。

Electron 实际的 userData 目录名取自 `desktop/package.json` 的 `name` 字段 = `aiworkdeck-desktop`。dev 与打包版都是这个值——本机从 `/Applications/AI Workdeck.app` 解出 `app.asar` 里的 `package.json` 核对过：`name = aiworkdeck-desktop`，且没有顶层 `productName`（`build.productName` 只影响 electron-builder 写 Info.plist，不改 `app.name`）。

于是 `npm run clean` 从来没清过真正在用的那个目录，走完还照打 `Clean complete.`，看着像成功了。`desktop/README.md` 与 `.claude/agents/eng-infra.md` 都把它当成「清用户数据目录」的正规手段。

## 改动

一行：`const appName = require('../package.json').name`，跟 `app.name` 同源，以后再改名不会漂。

顺带留了条交叉引用注释：**别为了「统一命名」给 package.json 补顶层 `productName`**——那会连带把 `app.getPath('userData')` 从 `aiworkdeck-desktop` 改名到 `AI Workdeck`，存量用户的 Local Storage（登录态、uni 存储）当场全丢。理由原本只写在 `desktop/main/app-menu.js` 顶部，现在 clean.js 这边也指了过去。

## 验证

- 把 `HOME` 指到临时目录跑真脚本（`os.homedir()` 在 POSIX 上优先读 `$HOME`），正确删掉 `aiworkdeck-desktop`（含嵌套子目录），没碰旁边预置的 `checkba-desktop`。没有在真 userData 上跑过。
- `cd desktop && npm test` → 37/37，与基线一致（该套件不覆盖 scripts/，只作旁证）。

## 一条现场发现

本机 `~/Library/Application Support/checkba-desktop` **是存在的**，里面是 2025-12 到 2026-03 的旧 Cookies/Local Storage，是更名前那阵子留下的。所以此前跑 `npm run clean` 的实际效果是「删掉这个死目录」而不是「什么都没删」，症状看起来一样。改完之后这个旧目录不会再被碰到，要清得手动删。