### PR TITLE
test: 两套 e2e 跟上新的启动落点（app-e2e 断言目标写错 / desktop-e2e 赌壳启动时序）

### DIFF
--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -431,12 +431,19 @@ try {
     }
   })
 
-  await step('列表页自带两个新建入口，且没有「打开文件」', async () => {
+  await step('列表页下方有新建入口，且没有「打开文件」', async () => {
     await page.goto(BASE + '/#/pages/project-list/project-list', { waitUntil: 'networkidle2' })
-    await page.waitForSelector('.create-card', { timeout: 15000 })
+    await page.waitForSelector('.create-section', { timeout: 15000 })
     const t = await textOf()
-    if (!t.includes('打开文件夹')) throw new Error('列表下方缺「打开文件夹」')
-    if (!t.includes('新建项目文件夹')) throw new Error('列表下方缺「新建项目文件夹」')
+    // 浏览器目标注入的是最小桌面桩（只有 shell.openExternal，没有 fs），列表页的
+    // isDesktop 判据正是「有没有系统文件夹对话框」，所以这里必然走浏览器降级分支：
+    // 只渲染一张「新建项目」卡，点进去是 newproject 页的托管空白项目表单。
+    // 桌面版那两张（打开文件夹 / 新建项目文件夹）在这个目标下渲染不出来，
+    // 由 check-navigation-contract 的静态断言守（校验 openFolderFlow /
+    // createFolderFlow / 命名弹窗真的接在页面上），别在这里断言它们。
+    const cards = await page.evaluate(() => document.querySelectorAll('.create-card').length)
+    if (cards !== 1) throw new Error('浏览器降级下新建卡应当恰好 1 张，实际 ' + cards)
+    if (!t.includes('新建项目')) throw new Error('列表下方缺新建入口')
     if (t.includes('打开文件…')) throw new Error('「单独打开文件」应当已从新建入口去掉')
     await mouseClickSel('.project-item-card')
     await page.waitForFunction(

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -52,7 +52,7 @@ for (const [what, ok] of [
 ]) { if (!ok) { console.error('前置缺失: ' + what); process.exit(2) } }
 
 // ---- provision（local-mode 免登：任何请求都解析为本机用户） ----
-const QA = { sid: null }
+const QA = { sid: null, project: '', projectId: null }
 async function api(ep, opts = {}) {
   const r = await fetch(BACKEND + ep, {
     method: opts.method || 'GET',
@@ -76,7 +76,9 @@ async function api(ep, opts = {}) {
     // 三档收敛后 gemini 会被枚举校验打成 400（见 AdminConfigController.toSettingsUpdates）
     await api('/api/admin/wizard', { method: 'POST', body: { ai: { activeProvider: 'OPENROUTER' } } })
   }
-  const proj = await api('/api/projects', { method: 'POST', body: { name: '桌面链路QA_' + Date.now(), projectType: 'BLANK' } })
+  // 名字记进 QA：启动落项目列表之后要靠它从卡片里认出这一轮的项目
+  QA.project = '桌面链路QA_' + Date.now()
+  const proj = await api('/api/projects', { method: 'POST', body: { name: QA.project, projectType: 'BLANK' } })
   QA.projectId = proj.id
   console.log('本机用户（免登）/ 项目 #' + QA.projectId)
 }
@@ -178,11 +180,38 @@ try {
   // 语言落了盘，随后跳工作台只是改 hash（同文档导航），钩子根本不触发。
   await page.evaluate(() => { try { localStorage.setItem('awd_app_language', 'zh-CN') } catch (e) { /* ignore */ } })
 
-  await step('免登直达进入项目（PR-A 去登录：不注会话）', async () => {
+  await step('免登进入项目（启动落项目列表 → 点卡片进工作台）', async () => {
     await page.goto(DEVURL + '/#/pages/project-overview/project-overview?id=' + QA.projectId, { waitUntil: 'networkidle2' })
     // 同上：跳工作台若只是改 hash，uni 路由会把它弹回项目列表（工作台参与的跳转
     // 本该走 reLaunch）。整页重载一次，直接以工作台路由、以中文重新 boot。
     await page.reload({ waitUntil: 'networkidle2' })
+    // 2026-08 起**启动一律落项目列表页**（launch.vue 不再读 checkba_last_project_id
+    // 直达上次项目）。而壳自己的 loadURL(DEV_SERVER_URL) 是不带 hash 的，它随时可能
+    // 在上面这次导航之后才完成，把页面又带回列表——**点一次是不够的**：实测有一轮
+    // 点完之后壳的启动导航才落地，页面被拽回列表，整套 8 步全红。
+    // 所以这里轮询到真进了工作台为止：在列表上就按真人走法点卡片，已经在工作台
+    // 就直接出去。点卡片主体、避开标题行（标题绑 @tap.stop=startRename）与卡片
+    // 底部那排成员头像/加人按钮（各自也有 @tap.stop）。
+    const deadline = Date.now() + 60000
+    while (Date.now() < deadline) {
+      const where = await page.evaluate(() => ({
+        list: location.hash.includes('pages/project-list/project-list'),
+        wb: location.hash.includes('pages/project-overview/project-overview'),
+        ready: document.body.innerText.includes('资源管理器'),
+      })).catch(() => null)
+      if (where && where.wb && where.ready) break
+      if (where && where.list) {
+        const box = await page.evaluate((name) => {
+          const cards = [...document.querySelectorAll('.project-item-card')]
+          const card = cards.find((c) => (c.innerText || '').includes(name)) || cards[0]
+          if (!card) return null
+          const r = card.getBoundingClientRect()
+          return { x: r.x + r.width / 2, y: r.y + r.height * 0.55 }
+        }, QA.project).catch(() => null)
+        if (box) await page.mouse.click(box.x, box.y).catch(() => {})
+      }
+      await new Promise((r) => setTimeout(r, 1500))
+    }
     try {
       await page.waitForFunction(() => document.body.innerText.includes('资源管理器'), { timeout: 30000 })
     } catch (e) {


### PR DESCRIPTION
真跑了三套 e2e 才发现的两处测试问题。**产品代码没有回归**，改的都是测试自己。

## 1. app-e2e：新建入口断言写错了目标

#377 新加的断言去找「打开文件夹 / 新建项目文件夹」两张卡，但 app-e2e 的浏览器目标
只注入最小桌面桩（`shell.openExternal`，没有 `fs`），而项目列表页的 `isDesktop` 判据
正是「有没有系统文件夹对话框」——那里**必然**走浏览器降级分支，只渲染一张
「新建项目」卡。第一轮 87/3，三条全在 J3 且是同一个根因（这条在「点卡片进工作台」
之前就抛，后面两步还停在列表页）。

改成按目标断言；桌面版那两张由 `check-navigation-contract` 的静态断言守。

## 2. desktop-e2e：第一步赌「壳启动直达工作台」

启动落点改成项目列表页之后，它 goto 工作台 hash，但壳自己的
`mainWindow.loadURL(DEV_SERVER_URL)` 不带 hash，一旦在那次导航之后才完成，页面就
被带回列表，后面 8 步全塌。改成轮询到真进工作台为止——**点一次不够**，实测有一轮
点完之后壳的启动导航才落地，又把页面拽回列表。

归因用对照组做的：把 `frontend/src` 退回 `c07d6d30`（#377 之前）重编、同一套测试
再跑，失败集合与改动后完全一致 → 只有这一步是本次导航改动造成的。

## 三套结果（本机，隔离后端 9797 + 独立 H2，没碰常驻的 9696）

| 套件 | 结果 |
|---|---|
| app-e2e | **90 / 0**（J11 缺 `APP_E2E_JAR`、AI 段 `AI_E2E=0`，按既有基线跳过） |
| lowa-e2e | **391 / 0**（与基线一致） |
| desktop-e2e | **8 / 8**，桌面保存链路全通（docx 5255 字节、标记命中） |

### 跑法里踩到的两个环境坑（记给下次）

- 起隔离后端覆盖 `spring.datasource.url` 时，**H2 参数必须照抄 desktop profile 那一串**；
  少了 `NON_KEYWORDS=VALUE`，建表就死在 `value` 是保留字上。
- 从别的 worktree 借 LOWA 引擎时，`cp .../lowa/*` 会漏掉 **`.encodings.json`**（点文件）。
  引擎的 wasm/data 存的是 brotli 字节，靠这个旁车文件告诉 `zetaoffice-server.js` 回放
  `Content-Encoding`；漏了它壳就把 brotli 当原始文件发，引擎半死——表现是工具栏不渲染、
  `insert_at_cursor` relay 超时、保存出 0 字节 docx，看着像保存链路坏了。
  （lowa-e2e 不受影响：它的 `LOWA_ENGINE_DIR` 指向原目录，点文件还在。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)