### PR TITLE
feat(gateway): 其余五家走平台代采——OCR/TTS/企查查/Tushare/法宝（P4）

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -572,6 +572,30 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
 - `service/platform/ExternalProviderBackfill.java` — 存量回填，启动期跑一次。
 - `controller/PlatformServiceController.java` — `/api/platform-services{,/{service}/provider}`，
   机器级状态，`MachineAccountGuard` 把关。
+- `config/GlobalExceptionHandler` 的 `handleGateway` — `GatewayException` → `code=1` +
+  `gatewayKind` + `canUseOwnKey`。**不接这条的话网关异常会落到兜底 handler 被压成
+  一句「服务器内部错误」**，三类故障的区分（错误码族存在的全部理由）当场作废。
+
+**其余五家（P4）：分档一律落在各自 service 的一个缝上**
+- `service/OcrService.recognizeGeneral` — platform 档走 `ocr/recognize`，完全不碰
+  `AliyunOcrClientFactory`；两档产出同一个 `OcrResult(text, raw)`。
+- `service/TtsService` — 三档 `platform | byok | local`，判定改走 `ExternalProviderResolver`
+  （不再自己读设置字符串，否则 D5 与存量回填要在这里再实现一遍）。
+  platform 档两个 op：`tts/speech`、`tts/voices`；音色解析两档共用 `parseElevenLabsVoices`
+  ——两档必须是同一套音色 ID，否则用户选好的音色一换档就指向不存在的东西。
+- `service/QichachaService.fetchEciInfoResult` — 分档的唯一缝，`searchCompany`（DTO）与
+  `queryEciInfoJson`（给 AI 的原始 JSON）都从它取数。
+- `service/TushareService.callTushare` — 分档的唯一缝（上游本来就只有一个统一入口），
+  上面那几个解析函数一行未改。平台档失败**抛出而不是回 null**：null 在上层眼里是
+  「这家公司没数据」，会让「未开放/余额不足」伪装成一次查不到。
+- `service/ai/tools/LegalTools.callPkulaw` — 法宝的双档分发。platform 档走
+  `pkulaw/{工具名}`，**响应正文仍由 `McpResponseParser` 在桌面端解析**（两档共用一个
+  解析器，法宝改格式只会改一处）。
+- `service/ai/tools/EnterpriseDataTools`（**新**）— `qichacha_query` / `tushare_query`
+  两个一等工具，补上 `PythonTools` 停掉的那条路。它们调的是上面两个 service，
+  所以**两档都能用**，不是「平台档专用」。
+- `service/ai/tools/PythonTools.credentialEnvArgs()` — platform 档下**不注入**
+  `TUSHARE_TOKEN` / `QICHACHA_KEY` / `QICHACHA_SECRET`（见地雷 33）。
 
 **语音转写（P2）**
 - `service/meeting/MeetingTranscriptionService.java` — **分档在编排层**。platform 档
@@ -585,17 +609,23 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
 - 直传是**普通 HTTP PUT**（`BinaryUploader` 接缝），OSS SDK 不引到这条路上：签名官网签好，
   客户端只负责发字节。`Content-Type` 进了 OSS 签名，必须逐字用 ticket 下发的那个值。
 
-**官网侧文件**（`aiworkdeckweb`，PR #56 = P0，#57 = P2）
-- `lib/gateway/{errors,config,pricing,idempotency,spend,adapters,asr}.ts`
+**官网侧文件**（`aiworkdeckweb`，PR #56 = P0，#57 = P2，#58 = P4）
+- `lib/gateway/{errors,config,pricing,idempotency,spend,asr}.ts`
+- `lib/gateway/adapters/`（一家一个文件 + `index.ts` 汇总）：`search / ocr / tts /
+  qichacha / tushare / pkulaw`。adapter **只做两件事**：参数 → 上游请求、上游响应 →
+  `{units, data}`；记账/幂等/定价一律在 route 里统一处理。`asr` 不在注册表里（异步长任务，走自己的三端点）
 - `app/api/gateway/[service]/[op]/route.ts`、`app/api/gateway/pricing/route.ts`、
   `app/api/gateway/asr/{ticket,submit,task/[id]}/route.ts`
 - 迁移 11：`service_pricing` / `gateway_request` / `gateway_hold` 三张表 + 重建 `wallet_ledger`
-  扩 `service_spend` kind；迁移 12：`gateway_hold.meta`（JSON，长任务自己的状态，语音存 objectKey）
+  扩 `service_spend` kind；迁移 12：`gateway_hold.meta`（JSON，长任务自己的状态，语音存 objectKey）；
+  迁移 13：五家的定价行（`INSERT OR IGNORE`，绝不覆盖线上已调过的价），
+  **企查查与法宝的 `enabled` 初值是 0**
 - 过期 hold 的回收挂在已有的 `POST /api/admin/ai/reconcile` cron 上，
   **回收前先跑 `sweepExpiredAsrObjects()` 删中转音频**（置 released 之后就查不到对象键了）
-- `ali-oss` / `@alicloud/tingwu20230930` 必须进 `next.config.ts` 的 `serverExternalPackages`：
+- `ali-oss` / `@alicloud/tingwu20230930` / `@alicloud/ocr-api20210707` / `@darabonba/typescript`
+  必须进 `next.config.ts` 的 `serverExternalPackages`：
   它们底层用运行时 require 加载可选依赖，打包器静态分析不到，直接把 build 判成失败
-- 验证 `scripts/verify-gateway.mts`（45 项，已进 CI）
+- 验证 `scripts/verify-gateway.mts`（63 项，已进 CI）
 
 ### 网关的核心契约
 
@@ -608,6 +638,18 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
 | 余额不足 | `409 no_credits`，**绝不 401/403** |
 | 幂等 | 会扣费的 POST 必须带 `Idempotency-Key`（8-128 位 `[A-Za-z0-9_-]`），服务端去重回放 |
 | 语音 | 唯一的异步长任务，三步：`asr/ticket`（查余额 + 签直传凭证，不扣费不要幂等键）→ 桌面直传 OSS → `asr/submit`（预扣 + 建听悟任务）→ `asr/task/{id}`（轮询 + 结算 + 删对象）。**余额闸在 ticket**，不让用户白传两小时录音才被拒 |
+
+同步入口的 service/op 全集（人读版在官网 `doc/desktop-contract.md`，改端点两处同步）：
+
+| service/op | 计量单位与真实来源 |
+|---|---|
+| `search/web` | `call`，一次调用 = 1 |
+| `ocr/recognize` | `page`，一次调用 = 一页（RecognizeAllText 是按图片的接口，返回里没有可计费页数字段；**刻意不拿 `subImageCount` 顶替**，那是区域数会成倍多收） |
+| `tts/speech` | `kchar`，取上游 `character-cost` 响应头；缺失时按服务端数出的**实际送出文本**长度（不是另报的数字） |
+| `tts/voices` | `call`，定价 0。**必须单列一行**，落到 kchar 通配行上就是「列个音色也按合成价收钱」 |
+| `qichacha/eci_info` | `call`，一次调用 = 1 |
+| `tushare/query` | `call`，一次调用 = 1 |
+| `pkulaw/{search_article,get_article,get_law_list,law_recognition}` | `call`，一次调用 = 1。op 就是法宝的工具名，**MCP 端点写死在服务端** |
 
 ### 已知地雷（网关）
 
@@ -666,6 +708,25 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
     规则的天数**必须大于** `GW_HOLD_TTL_MINUTES`，否则会在任务还能正常完成时把音频抽走。
     配置写在官网 `DEPLOY.md` §7.1。
 
+33. **企查查与 Tushare 有一条不经过 Java 的出站路径**：`PythonTools` 把
+    `TUSHARE_TOKEN` / `QICHACHA_KEY` / `QICHACHA_SECRET` 注入 Python 子进程，
+    AI 写的脚本从用户本机直连上游。platform 档下没有可注入的凭证（凭证在官网，
+    下发给每台机器等于把公司账号发给所有人），所以 `credentialEnvArgs()` **一个都不注入**，
+    改由 `EnterpriseDataTools` 的 `qichacha_query` / `tushare_query` 代它调。
+    不这么做的话，脚本拿到空 token，失败会表现成「查不到数据」而不是「未配置」。
+    顺带：脚本那条路是唯一一条 AI 能循环打出几百次上游调用的口子，收进 Java 侧才受任务级上限约束。
+    另注意 `PythonTools` 读的是 `@Value` 的 yml/env 值，**不读 `system_setting`**——
+    用户在设置页填的 Key 从来就没被注入过，这是改造前就有的既有缺陷。
+
+34. **两家上游用响应体而不是 HTTP 状态表达失败**：企查查「查无此企业」回的是
+    HTTP 200 + `Status=201`，Tushare 积分不足/限频回的是 HTTP 200 + `code=40203`。
+    网关侧只按 `res.ok` 判成功，就会给一次什么都没查到的调用收全价——
+    两家都必须看响应体，非成功一律 `upstream_failed` 且**一分不扣**。
+
+35. **新增 AI 工具组件要同步 `RealToolBeans.instantiateAll()`**（测试侧）。
+    漏了的话该组件的工具在回放评测里根本不注册，可见性断言写了也是空的；
+    护栏是 `EvalToolBeanParityTest`，会直接点名漏掉的类。
+
 ## 验证
 
 - 后端：`cd backend && mvn test`（**JDK 21，系统默认 25 会 SIGBUS**）。本领域相关用例：
@@ -689,7 +750,10 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
   `service/ai/PlatformAiUserScopeTest`、`controller/PlatformAiKeyControllerTest`；
   白嫖闸：`service/ai/PlatformCreditsGateTest`（余额闸三条判据）、
   `service/ai/PlatformAiKeyOwnershipTest`（换账号不复用旧 key、存量文件重新绑定）；
-  平台服务网关：`service/platform/PlatformGatewayClientTest`（错误分类、幂等重试带同一个键、
+  平台服务网关：`service/platform/ExternalServiceDualTierRoutingTest`（P4 五家的双档路由：
+  平台档不碰 BYOK 实现 / BYOK 档一次网关都不打 / 平台档失败不静默回落；
+  另含 `PythonTools.credentialEnvArgs` 的注入判据与两个新工具的中文显示名）、
+  `service/platform/PlatformGatewayClientTest`（错误分类、幂等重试带同一个键、
   七种失败形态的文案都不含三个掉线子串）、`service/platform/ExternalProviderResolverTest`
   （D5 的 local-mode 闸）、`service/platform/ExternalProviderBackfillTest`（存量回填四种形态）、
   `service/meeting/MeetingTranscriptionPlatformPathTest`（platform 档不碰 OSS/听悟两个接口、

--- a/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
@@ -73,6 +73,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity.ok().body(result);
     }
 
+    /**
+     * 平台服务网关失败：<b>永远是业务错误，绝不是掉线</b>。
+     *
+     * <p>不接这条的话，网关异常会落到下面那个兜底 handler，被压成一句
+     * 「服务器内部错误」——而三类故障（未开放 / 上游挂 / 我们挂）在用户眼里
+     * 长得一样、下一步却完全不同，正是这一族错误码存在的全部理由。
+     *
+     * <p>{@code code=1} 而不是 4001「功能未配置」：平台档下用户什么都不用配，
+     * 把他导去设置页填 Key 只有在 {@code canUseOwnKey} 时才是**一条**出路，
+     * 余额不足时那是错的。具体摆哪个入口交给前端按 kind 决定。
+     */
+    @ExceptionHandler(com.checkba.service.platform.GatewayException.class)
+    public ResponseEntity<Map<String, Object>> handleGateway(
+            com.checkba.service.platform.GatewayException e) {
+        log.warn("平台服务网关失败 kind={}: {}", e.getKind(), e.getMessage());
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("gatewayKind", e.getKind().name());
+        result.put("canUseOwnKey", e.suggestsByok());
+        result.put("message", e.getMessage());
+        return ResponseEntity.ok().body(result);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("GlobalExceptionHandler caught IllegalArgumentException: {}", e.getMessage());

--- a/backend/src/main/java/com/checkba/service/OcrService.java
+++ b/backend/src/main/java/com/checkba/service/OcrService.java
@@ -3,6 +3,10 @@ package com.checkba.service;
 import com.checkba.exception.FeatureNotConfiguredException;
 import com.checkba.service.ocr.AliyunOcrClientFactory;
 import com.checkba.service.ocr.OcrResult;
+import com.checkba.service.platform.ExternalProviderResolver;
+import com.checkba.service.platform.ExternalServiceProvider;
+import com.checkba.service.platform.PlatformGatewayClient;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,9 +14,14 @@ import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.util.Base64;
+import java.util.Map;
 
 /**
- * OCR 服务（目前实现：阿里云 OCR）
+ * OCR 服务：平台代采（网关）与自备阿里云 Key 两档。
+ *
+ * <p>分档在这一层，两档各自完整：platform 档完全不碰 {@code AliyunOcrClientFactory}，
+ * byok 档一字未动。<b>平台档失败绝不静默回落 byok</b>——回落会去花用户自己的
+ * 阿里云账号（licensing-billing 地雷 8 / 27）。
  */
 @Service
 @RequiredArgsConstructor
@@ -20,7 +29,12 @@ public class OcrService {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OcrService.class);
 
+    /** OCR 高精版对整页扫描件经常要十几秒，账户通道那 5 秒在这里必然误判成故障。 */
+    private static final int GATEWAY_TIMEOUT_SECONDS = 60;
+
     private final SystemSettingService systemSettingService;
+    private final ExternalProviderResolver externalProviderResolver;
+    private final PlatformGatewayClient platformGatewayClient;
 
     /**
      * 通用 OCR 识别（图片 base64，支持 dataURL）
@@ -42,6 +56,11 @@ public class OcrService {
             Base64.getDecoder().decode(payload);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("imageBase64 格式不正确");
+        }
+
+        if (externalProviderResolver.resolve(ExternalServiceProvider.OCR)
+                == ExternalServiceProvider.PLATFORM) {
+            return recognizeViaPlatform(payload);
         }
 
         String ak = systemSettingService.get("external.aliyunOcr.accessKeyId", "");
@@ -81,6 +100,23 @@ public class OcrService {
             log.error("OCR 识别失败", e);
             throw new RuntimeException("OCR 识别失败: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * 平台代采档：官网持凭证调阿里云 OCR，按实际页数扣 Credits。
+     *
+     * <p>{@link com.checkba.service.platform.GatewayException} 原样抛出去，由
+     * {@code GlobalExceptionHandler} 按 kind 落成 code=1 的业务错误——包成
+     * RuntimeException 会让「未开放 / 上游挂 / 我们挂 / 余额不足」全变成
+     * 一句「服务器内部错误」，用户不知道下一步该做什么。
+     */
+    private OcrResult recognizeViaPlatform(String payload) {
+        PlatformGatewayClient.Result result = platformGatewayClient.call(
+                "ocr", "recognize", Map.of("imageBase64", payload), GATEWAY_TIMEOUT_SECONDS);
+        JsonNode data = result.data();
+        // 与 byok 档同一形状（text + raw）：消费方（截图摘录、文件文本抽取）
+        // 不该按档位分两套解析
+        return new OcrResult(data.path("content").asText(""), data.path("raw").asText(""));
     }
 }
 

--- a/backend/src/main/java/com/checkba/service/QichachaService.java
+++ b/backend/src/main/java/com/checkba/service/QichachaService.java
@@ -19,13 +19,28 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * 企查查企业工商详情：平台代采（网关）与自备 Key 两档。
+ *
+ * <p>分档在这一层，两档共用同一个 {@link #mapToDTO} ——上游响应形状一致，
+ * 只换了「谁的 Key、谁出钱」。<b>平台档失败绝不静默回落 byok</b>：
+ * 回落会去花用户自己的企查查订阅额度（licensing-billing 地雷 8 / 27）。
+ */
 @Service
 public class QichachaService {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(QichachaService.class);
 
+    private static final int GATEWAY_TIMEOUT_SECONDS = 30;
+
     @Autowired
     private SystemSettingService systemSettingService;
+
+    @Autowired
+    private com.checkba.service.platform.ExternalProviderResolver externalProviderResolver;
+
+    @Autowired
+    private com.checkba.service.platform.PlatformGatewayClient platformGatewayClient;
 
     @Value("${external.qichacha.key:}")
     private String defaultAppKey;
@@ -40,6 +55,25 @@ public class QichachaService {
      * 调用企查查企业工商详情接口
      */
     public CompanyBasicInfoDTO searchCompany(String searchKey, String role) {
+        return mapToDTO(fetchEciInfoResult(searchKey), role);
+    }
+
+    /**
+     * 企业工商详情的原始 {@code Result} 对象（未映射成 DTO）。
+     *
+     * <p>给 AI 侧的一等工具用：DTO 是按界面字段裁过的，模型要的是全量事实。
+     */
+    public String queryEciInfoJson(String searchKey) {
+        return fetchEciInfoResult(searchKey).toString();
+    }
+
+    /** 取一次工商详情的 {@code Result}。两档在这里分，上面两个方法都不关心谁出的钱。 */
+    private JSONObject fetchEciInfoResult(String searchKey) {
+        if (externalProviderResolver.resolve(
+                com.checkba.service.platform.ExternalServiceProvider.QICHACHA)
+                == com.checkba.service.platform.ExternalServiceProvider.PLATFORM) {
+            return fetchEciInfoViaPlatform(searchKey);
+        }
         // 如果是纯 6 位数字，视为股票代码，暂不直接传给企查查，优先按名称处理。
         // 这里保留原实现，但在上层先做一层股票代码 → 公司名称的解析。
         // 0. 获取配置（优先 DB，兜底 Env）
@@ -84,14 +118,33 @@ public class QichachaService {
             if (result == null) {
                 throw new RuntimeException("未查询到相关企业信息");
             }
-
-            // 3. 映射数据到 DTO
-            return mapToDTO(result, role);
+            return result;
 
         } catch (Exception e) {
             log.error("调用企查查接口异常", e);
             throw new RuntimeException("外部数据服务暂不可用: " + e.getMessage());
         }
+    }
+
+    /**
+     * 平台代采档：官网持凭证调企查查，按次扣 Credits。
+     *
+     * <p>网关只在上游 {@code Status=200} 时才算成功（查无此企业、限额都不扣费），
+     * 所以这里拿到的一定是有 Result 的响应；其余情形以 {@code GatewayException}
+     * 抛出，由 {@code GlobalExceptionHandler} 按 kind 落成可读的业务错误——
+     * <b>刻意不裹进上面那个 catch(Exception)</b>：裹进去 kind 就丢了，
+     * 「未开放」「余额不足」会一起变成一句「外部数据服务暂不可用」。
+     */
+    private JSONObject fetchEciInfoViaPlatform(String searchKey) {
+        com.checkba.service.platform.PlatformGatewayClient.Result result =
+                platformGatewayClient.call("qichacha", "eci_info",
+                        Map.of("searchKey", searchKey), GATEWAY_TIMEOUT_SECONDS);
+        // 网关原样透传企查查的 {Status, Message, Result}，与自备 Key 档同一形状
+        JSONObject data = JSONUtil.parseObj(result.data().toString()).getJSONObject("Result");
+        if (data == null) {
+            throw new RuntimeException("未查询到相关企业信息");
+        }
+        return data;
     }
 
     private CompanyBasicInfoDTO mapToDTO(JSONObject data, String role) {

--- a/backend/src/main/java/com/checkba/service/TtsService.java
+++ b/backend/src/main/java/com/checkba/service/TtsService.java
@@ -1,6 +1,7 @@
 package com.checkba.service;
 
 import com.checkba.exception.FeatureNotConfiguredException;
+import com.checkba.service.platform.PlatformGatewayClient;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +17,16 @@ import java.io.FileOutputStream;
 import java.util.*;
 
 /**
- * TTS Service using ElevenLabs API
+ * 语音合成：平台代采（网关）/ 自备 ElevenLabs Key / 本地 Kokoro 三档。
+ *
+ * <p>档位判定<b>一律走 {@link com.checkba.service.platform.ExternalProviderResolver}</b>，
+ * 不再自己读设置字符串：那样读的话，D5（平台档只在 local-mode 开放）与存量回填
+ * 这两条就要在这里再实现一遍，而它们只该有一处判据。
+ *
+ * <p>存量取值 {@code elevenlabs} 由 {@code ExternalServiceProvider.parse} 映射成 BYOK，
+ * 桌面打包态注入的 {@code EXTERNAL_TTS_PROVIDER=local} 由 {@code ExternalProviderBackfill}
+ * 回填成 {@code local}——两条存量路径都不经过这里，改这里不会把它们绕过去。
+ *
  * API Documentation: https://elevenlabs.io/docs/api-reference
  */
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,9 +36,18 @@ public class TtsService {
 
     private static final Logger logger = LoggerFactory.getLogger(TtsService.class);
     private static final String TEMP_AUDIO_DIR = System.getProperty("java.io.tmpdir") + File.separator + "elevenlabs_audio";
-    
+
+    /** 长文本合成过 5 秒是常态，账户通道那 5 秒在这里必然误判成故障。 */
+    private static final int GATEWAY_TIMEOUT_SECONDS = 60;
+
     @Autowired
     private SystemSettingService systemSettingService;
+
+    @Autowired
+    private com.checkba.service.platform.ExternalProviderResolver externalProviderResolver;
+
+    @Autowired
+    private com.checkba.service.platform.PlatformGatewayClient platformGatewayClient;
 
     @Value("${external.elevenlabs.api-key}")
     private String defaultApiKey;
@@ -41,10 +60,6 @@ public class TtsService {
     
     @Value("${external.elevenlabs.default-voice-id}")
     private String defaultDefaultVoiceId;
-
-    // 语音提供方：elevenlabs（云端，默认）| local（桌面捆绑 Kokoro，OpenAI 兼容 /v1）
-    @Value("${external.tts.provider:elevenlabs}")
-    private String defaultTtsProvider;
 
     @Value("${external.tts.local-base-url:}")
     private String defaultLocalBaseUrl;
@@ -86,9 +101,18 @@ public class TtsService {
      * Get available voices from ElevenLabs API
      * GET /voices
      */
-    // settings（系统管理可改）> env/yml 默认
+    /** 当前生效的档位。判据只有这一处（D5 的 local-mode 闸也在它里面）。 */
+    private com.checkba.service.platform.ExternalServiceProvider tier() {
+        return externalProviderResolver.resolve(
+                com.checkba.service.platform.ExternalServiceProvider.TTS);
+    }
+
     private boolean isLocalProvider() {
-        return "local".equalsIgnoreCase(systemSettingService.get("external.tts.provider", defaultTtsProvider));
+        return tier() == com.checkba.service.platform.ExternalServiceProvider.LOCAL;
+    }
+
+    private boolean isPlatformProvider() {
+        return tier() == com.checkba.service.platform.ExternalServiceProvider.PLATFORM;
     }
 
     private String localBaseUrl() {
@@ -110,54 +134,82 @@ public class TtsService {
         if (isLocalProvider()) {
             return getLocalVoices();
         }
+        if (isPlatformProvider()) {
+            return getPlatformVoices();
+        }
         try {
             String baseUrl = systemSettingService.get("external.elevenlabs.baseUrl", defaultBaseUrl);
             String apiKey = systemSettingService.get("external.elevenlabs.apiKey", defaultApiKey);
 
             String url = baseUrl + "/voices";
-            
+
             HttpHeaders headers = new HttpHeaders();
             headers.set("xi-api-key", apiKey);
             headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
-            
+
             HttpEntity<Void> entity = new HttpEntity<>(headers);
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-            
+
             if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-                JsonNode root = objectMapper.readTree(response.getBody());
-                JsonNode voicesNode = root.get("voices");
-                
-                List<VoiceOption> result = new ArrayList<>();
-                if (voicesNode != null && voicesNode.isArray()) {
-                    for (JsonNode voiceNode : voicesNode) {
-                        VoiceOption vo = new VoiceOption();
-                        vo.setVoiceId(voiceNode.path("voice_id").asText());
-                        vo.setName(voiceNode.path("name").asText());
-                        
-                        // Extract gender and locale from labels
-                        JsonNode labels = voiceNode.get("labels");
-                        if (labels != null) {
-                            vo.setGender(labels.path("gender").asText("unknown"));
-                            vo.setLocale(labels.path("accent").asText(""));
-                        } else {
-                            vo.setGender("unknown");
-                            vo.setLocale("");
-                        }
-                        
-                        result.add(vo);
-                    }
-                }
-                
+                List<VoiceOption> result = parseElevenLabsVoices(objectMapper.readTree(response.getBody()));
                 logger.info("Loaded {} voices from ElevenLabs", result.size());
                 return result;
             }
-            
+
             logger.warn("Voice list response unsuccessful: {}", response.getStatusCode());
             return new ArrayList<>();
         } catch (Exception e) {
             logger.error("Failed to list voices from ElevenLabs API", e);
             return new ArrayList<>();
         }
+    }
+
+    /**
+     * 平台代采档的音色列表。网关把 ElevenLabs 的原始响应原样带回来，
+     * 所以解析与 byok 档共用一份——两档的音色 ID 必须是同一套，
+     * 否则用户在设置里选好的音色一换档就指向不存在的东西。
+     *
+     * <p>失败回空列表而不是抛：这个方法的既有契约就是「拿不到就是空」
+     * （下拉框空着而不是整页报错），真正的失败会在合成那一刻带着原因浮出来。
+     */
+    private List<VoiceOption> getPlatformVoices() {
+        try {
+            PlatformGatewayClient.Result result =
+                    platformGatewayClient.call("tts", "voices", Map.of(), 15);
+            List<VoiceOption> voices = parseElevenLabsVoices(result.data());
+            logger.info("Loaded {} voices via platform gateway", voices.size());
+            return voices;
+        } catch (com.checkba.service.platform.GatewayException e) {
+            logger.warn("平台音色列表获取失败 kind={}: {}", e.getKind(), e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    /** ElevenLabs 的 /voices 响应 → 音色选项。平台档与自备 Key 档共用，避免格式漂移。 */
+    private List<VoiceOption> parseElevenLabsVoices(JsonNode root) {
+        List<VoiceOption> result = new ArrayList<>();
+        JsonNode voicesNode = root == null ? null : root.get("voices");
+        if (voicesNode == null || !voicesNode.isArray()) {
+            return result;
+        }
+        for (JsonNode voiceNode : voicesNode) {
+            VoiceOption vo = new VoiceOption();
+            vo.setVoiceId(voiceNode.path("voice_id").asText());
+            vo.setName(voiceNode.path("name").asText());
+
+            // Extract gender and locale from labels
+            JsonNode labels = voiceNode.get("labels");
+            if (labels != null) {
+                vo.setGender(labels.path("gender").asText("unknown"));
+                vo.setLocale(labels.path("accent").asText(""));
+            } else {
+                vo.setGender("unknown");
+                vo.setLocale("");
+            }
+
+            result.add(vo);
+        }
+        return result;
     }
 
     /**
@@ -173,6 +225,9 @@ public class TtsService {
     public File generateAudio(String text, String voiceId, String rate, String pitch, String volume) {
         if (isLocalProvider()) {
             return generateLocalAudio(text, voiceId, rate);
+        }
+        if (isPlatformProvider()) {
+            return generatePlatformAudio(text, voiceId);
         }
         // 未配置 TTS 密钥时直接返回"功能未配置"，前端引导去设置（#18 T5）
         String configuredApiKey = systemSettingService.get("external.elevenlabs.apiKey", defaultApiKey);
@@ -238,6 +293,39 @@ public class TtsService {
             logger.error("Failed to generate audio via ElevenLabs", e);
             throw new RuntimeException("Failed to generate audio: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * 平台代采档合成：官网持凭证调 ElevenLabs，按实际字符数扣 Credits。
+     *
+     * <p>{@code rate/pitch/volume} 与自备 Key 档一样被忽略——ElevenLabs 没有这几个参数，
+     * 假装支持只会让两档产出听感不同的音频。
+     *
+     * <p>{@link com.checkba.service.platform.GatewayException} 原样抛出去：
+     * 包成 RuntimeException 会让四种失败全变成一句「服务器内部错误」，
+     * 而它们的下一步分别是充值 / 等一等 / 改用自己的 Key / 切本地引擎。
+     */
+    private File generatePlatformAudio(String text, String voiceId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("text", text);
+        if (voiceId != null && !voiceId.isEmpty()) params.put("voiceId", voiceId);
+
+        PlatformGatewayClient.Result result =
+                platformGatewayClient.call("tts", "speech", params, GATEWAY_TIMEOUT_SECONDS);
+        String audioBase64 = result.data().path("audioBase64").asText("");
+        if (audioBase64.isEmpty()) {
+            throw new RuntimeException("平台语音合成未返回音频");
+        }
+        byte[] audio = Base64.getDecoder().decode(audioBase64);
+        File outputFile = new File(TEMP_AUDIO_DIR, UUID.randomUUID() + ".mp3");
+        try (FileOutputStream fos = new FileOutputStream(outputFile)) {
+            fos.write(audio);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to save audio: " + e.getMessage(), e);
+        }
+        logger.info("Saved platform TTS audio to: {} ({} bytes, {} {})",
+                outputFile.getAbsolutePath(), audio.length, result.units(), result.unit());
+        return outputFile;
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/TushareService.java
+++ b/backend/src/main/java/com/checkba/service/TushareService.java
@@ -15,19 +15,49 @@ import java.util.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Tushare 金融数据：平台代采（网关）与自备 token 两档。
+ *
+ * <p>上游只有一个统一入口（POST 一个 JSON，{@code api_name} 指哪个接口），
+ * 所以<b>分档只需要落在 {@link #callTushare} 这一个缝上</b>——上面那几个
+ * 解析函数（股东、管理层、工商信息）一行都不用改，两档产出同一个 JSON。
+ *
+ * <p><b>平台档失败绝不静默回落 byok</b>（licensing-billing 地雷 8 / 27）。
+ */
 @Service
 public class TushareService {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TushareService.class);
 
+    private static final int GATEWAY_TIMEOUT_SECONDS = 30;
+
     @Autowired
     private SystemSettingService systemSettingService;
+
+    @Autowired
+    private com.checkba.service.platform.ExternalProviderResolver externalProviderResolver;
+
+    @Autowired
+    private com.checkba.service.platform.PlatformGatewayClient platformGatewayClient;
 
     @Value("${external.tushare.base-url:http://api.tushare.pro}")
     private String defaultTushareApiUrl;
 
     @Value("${external.tushare.token:}")
     private String defaultTushareToken;
+
+    /**
+     * 任意 Tushare 接口的原始响应（JSON 文本）。
+     *
+     * <p>给 AI 侧的一等工具用：模型此前是写 Python 脚本直连 Tushare 的，
+     * 那条路在平台代采档下没有可注入的 token（设计 §5.5），改由这里代它调。
+     */
+    public String queryJson(String apiName, Map<String, Object> params, String fields) {
+        JSONObject p = new JSONObject();
+        if (params != null) params.forEach(p::set);
+        JSONObject response = callTushare(apiName, p, fields);
+        return response == null ? "" : response.toString();
+    }
 
     /**
      * Fetch listed company data and return a DTO for frontend display.
@@ -249,7 +279,20 @@ public class TushareService {
         return Collections.emptyList();
     }
 
+    /**
+     * 上游唯一的出站缝，两档在这里分。
+     *
+     * <p>平台档的失败<b>抛出去而不是回 null</b>：null 在上面几个解析函数眼里就是
+     * 「这家公司没数据」，于是「未开放」「余额不足」会伪装成一次查不到——
+     * 那正是设计 §5.5 点名要避免的表现。自备 Key 档的 null 语义一字未改。
+     */
     private JSONObject callTushare(String apiName, JSONObject params, String fields) {
+        if (externalProviderResolver.resolve(
+                com.checkba.service.platform.ExternalServiceProvider.TUSHARE)
+                == com.checkba.service.platform.ExternalServiceProvider.PLATFORM) {
+            return callTushareViaPlatform(apiName, params, fields);
+        }
+
         String token = systemSettingService.get("external.tushare.token", defaultTushareToken);
         String apiUrl = systemSettingService.get("external.tushare.baseUrl", defaultTushareApiUrl);
 
@@ -272,6 +315,18 @@ public class TushareService {
         }
     }
     
+    /** 平台代采档：官网持 token 调 Tushare，按次扣 Credits。响应形状与自备 token 档一致。 */
+    private JSONObject callTushareViaPlatform(String apiName, JSONObject params, String fields) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("apiName", apiName);
+        body.put("params", params == null ? new JSONObject() : params);
+        body.put("fields", fields == null ? "" : fields);
+
+        com.checkba.service.platform.PlatformGatewayClient.Result result =
+                platformGatewayClient.call("tushare", "query", body, GATEWAY_TIMEOUT_SECONDS);
+        return JSONUtil.parseObj(result.data().toString());
+    }
+
     private void createVar(List<ProjectVariable> variables, Long projectId, String name, String value, String group) {
         ProjectVariable var = new ProjectVariable();
         var.setProjectId(projectId);

--- a/backend/src/main/java/com/checkba/service/ai/tools/EnterpriseDataTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/EnterpriseDataTools.java
@@ -1,0 +1,104 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.QichachaService;
+import com.checkba.service.TushareService;
+import com.checkba.service.platform.GatewayException;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 企业与金融数据的 Java 侧一等工具（企查查 / Tushare）。
+ *
+ * <h3>为什么必须有这两个工具</h3>
+ * 在此之前，模型查这两家的唯一方式是写 Python 脚本——{@code PythonTools} 把
+ * {@code TUSHARE_TOKEN} / {@code QICHACHA_KEY} / {@code QICHACHA_SECRET} 注入子进程，
+ * 脚本从用户本机直连上游。<b>平台代采档下没有可注入的凭证</b>（凭证在官网，
+ * 下发给每台机器等于把公司账号发给所有人），脚本会拿到空 token，
+ * 失败表现成「查不到数据」而不是「未配置」——正好打在「零配置即可用」这个目标上。
+ *
+ * <p>收进 Java 侧还有第二个好处：脚本那条路是唯一一条 AI 能循环打出几百次上游调用
+ * 的口子，进了 {@code PlatformGatewayClient} 才受任务级花费上限约束。
+ *
+ * <h3>两档都能用</h3>
+ * 这两个工具调的是 {@code QichachaService} / {@code TushareService}，
+ * <b>分档在那两个 service 内部</b>：平台档走网关按次扣 Credits，自备 Key 档
+ * 走用户自己的凭证。所以这两个工具不是「平台档专用」，换档不会让它们失效。
+ *
+ * <p>网关失败<b>不抛异常打断整轮对话</b>：返回一段说明文本让模型基于已有信息继续，
+ * 与 {@code WebTools.search_web} 同一口径（licensing-billing 地雷 27）。
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EnterpriseDataTools implements AgentToolComponent {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EnterpriseDataTools.class);
+
+    private final QichachaService qichachaService;
+    private final TushareService tushareService;
+
+    @ToolMeta(displayName = "查询企业工商信息", category = "data")
+    @Tool("Look up a Chinese company's business registration record (legal name, registered capital, address, shareholders, executives) by company name or unified social credit code. Returns the raw record as JSON.")
+    public String qichacha_query(String companyName) {
+        log.info("Tool: qichacha_query called for '{}'", companyName);
+        if (!StringUtils.hasText(companyName)) {
+            return "Error: companyName is required.";
+        }
+        try {
+            return qichachaService.queryEciInfoJson(companyName);
+        } catch (GatewayException e) {
+            return unavailable("企业工商信息查询", "企业数据", e);
+        } catch (Exception e) {
+            log.warn("企业工商信息查询失败: {}", e.toString());
+            return "企业工商信息查询失败：" + e.getMessage()
+                    + " 本次已跳过该查询，请基于已有信息继续完成任务。";
+        }
+    }
+
+    @ToolMeta(displayName = "查询金融数据", category = "data")
+    @Tool("Query Tushare financial data for Chinese listed companies. apiName is the Tushare interface name "
+            + "(e.g. stock_basic, stock_company, top10_holders, stk_managers, daily, income, balancesheet). "
+            + "paramsJson is a JSON object of that interface's parameters (e.g. {\"ts_code\":\"000001.SZ\"}). "
+            + "fields is a comma-separated list of columns to return. Returns the raw Tushare response as JSON.")
+    public String tushare_query(String apiName, String paramsJson, String fields) {
+        log.info("Tool: tushare_query called api='{}' params='{}'", apiName, paramsJson);
+        if (!StringUtils.hasText(apiName)) {
+            return "Error: apiName is required.";
+        }
+        Map<String, Object> params = new HashMap<>();
+        if (StringUtils.hasText(paramsJson)) {
+            try {
+                cn.hutool.json.JSONUtil.parseObj(paramsJson).forEach(params::put);
+            } catch (Exception e) {
+                // 模型偶尔会把参数写成非 JSON，明确告诉它错在哪比静默当空参数好
+                return "Error: paramsJson 必须是 JSON 对象，例如 {\"ts_code\":\"000001.SZ\"}。收到的是：" + paramsJson;
+            }
+        }
+        try {
+            String json = tushareService.queryJson(apiName, params, fields == null ? "" : fields);
+            return StringUtils.hasText(json) ? json : "金融数据接口未返回结果（可能是参数不匹配或该接口无权限）。";
+        } catch (GatewayException e) {
+            return unavailable("金融数据查询", "金融数据", e);
+        } catch (Exception e) {
+            log.warn("金融数据查询失败: {}", e.toString());
+            return "金融数据查询失败：" + e.getMessage()
+                    + " 本次已跳过该查询，请基于已有信息继续完成任务。";
+        }
+    }
+
+    /** 网关失败的统一说明文本。带上「改用自己的 Key」这条真出路，但不替用户做决定。 */
+    private String unavailable(String action, String panelName, GatewayException e) {
+        log.warn("{}走平台通道失败 kind={}: {}", action, e.getKind(), e.getMessage());
+        String hint = e.suggestsByok()
+                ? "如需继续使用，可在「系统管理 → 平台服务」把" + panelName + "改为自备 Key。"
+                : "";
+        return action + "本次不可用：" + e.getMessage() + hint
+                + " 本次已跳过该查询，请基于已有信息继续完成任务。";
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
@@ -2,6 +2,7 @@ package com.checkba.service.ai.tools;
 
 import com.checkba.service.ProjectFileService;
 import com.checkba.service.ai.mcp.McpClientService;
+import com.checkba.service.ai.mcp.McpResponseParser;
 import com.checkba.model.entity.ProjectFile;
 import dev.langchain4j.agent.tool.Tool;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +25,14 @@ import java.util.Map;
 @Slf4j
 public class LegalTools implements AgentToolComponent {
 
+    /** 法宝的三个 MCP server 都配了 60 秒超时，网关这条要留出同样的余量。 */
+    private static final int PKULAW_TIMEOUT_SECONDS = 60;
+
     private final ProjectFileService projectFileService;
     private final McpClientService mcpClientService;
     private final com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService;
+    private final com.checkba.service.platform.ExternalProviderResolver externalProviderResolver;
+    private final com.checkba.service.platform.PlatformGatewayClient platformGatewayClient;
 
     // --- File Operations ---
 
@@ -79,7 +85,7 @@ public class LegalTools implements AgentToolComponent {
     @Tool("Search for laws and regulations using PKULaw MCP Semantic Search. Use this for general legal questions. Returns a list of relevant articles.")
     public String law_search(String query) {
         log.info("Tool: law_search (semantic) called for query='{}'", query);
-        return mcpClientService.callTool("pkulaw-semantic", "search_article", Map.of("query", query));
+        return callPkulaw("pkulaw-semantic", "search_article", Map.of("query", query));
     }
 
     @ToolMeta(displayName = "关键词搜索法规", category = "legal")
@@ -89,21 +95,55 @@ public class LegalTools implements AgentToolComponent {
         Map<String, Object> args = new HashMap<>();
         if (StringUtils.hasText(title)) args.put("title", title);
         if (StringUtils.hasText(fulltext)) args.put("fulltext", fulltext);
-        
-        return mcpClientService.callTool("pkulaw-keyword", "get_law_list", args);
+
+        return callPkulaw("pkulaw-keyword", "get_law_list", args);
     }
 
     @ToolMeta(displayName = "法条识别与溯源", category = "legal")
     @Tool("Identify law names and articles from text and trace their source.")
     public String law_recognition(String text) {
         log.info("Tool: law_recognition called for text length={}", text.length());
-        return mcpClientService.callTool("pkulaw-recognition", "law_recognition", Map.of("text", text));
+        return callPkulaw("pkulaw-recognition", "law_recognition", Map.of("text", text));
     }
 
     @ToolMeta(displayName = "查询法条", category = "legal")
     @Tool("Get the full content of a specific law article by its title and article number. Use this when you have article info from law_search results.")
     public String get_law_article(String title, String number) {
         log.info("Tool: get_law_article called for title='{}', number='{}'", title, number);
-        return mcpClientService.callTool("pkulaw-semantic", "get_article", Map.of("title", title, "number", number));
+        return callPkulaw("pkulaw-semantic", "get_article", Map.of("title", title, "number", number));
+    }
+
+    /**
+     * 法宝检索的双档分发。
+     *
+     * <p>平台档下 MCP 客户端拿不到 token（token 是订阅主体的，我们不会下发给每台机器），
+     * 所以走网关：官网持 token 打同一个 MCP 端点，把 JSON-RPC 响应正文原样带回来。
+     * <b>解析仍用 {@link McpResponseParser}</b>——两档共用一个解析器，
+     * 法宝改格式只会改一处；在网关侧解析等于把这份格式知识抄成两份。
+     *
+     * <p>网关失败<b>不抛异常打断整轮对话</b>：这是给模型看的文本，
+     * 说清楚发生了什么、下一步是什么，让它基于已有信息继续——
+     * 与「未配置」那条既有分支同一口径（licensing-billing 地雷 27）。
+     */
+    private String callPkulaw(String server, String tool, Map<String, Object> args) {
+        if (externalProviderResolver.resolve(
+                com.checkba.service.platform.ExternalServiceProvider.PKULAW)
+                != com.checkba.service.platform.ExternalServiceProvider.PLATFORM) {
+            return mcpClientService.callTool(server, tool, args);
+        }
+        try {
+            // 网关的 op 就是法宝的工具名；MCP 端点写死在服务端，客户端点不了别处
+            com.checkba.service.platform.PlatformGatewayClient.Result result =
+                    platformGatewayClient.call("pkulaw", tool, Map.of("args", args),
+                            PKULAW_TIMEOUT_SECONDS);
+            return McpResponseParser.parse(result.data().path("raw").asText(""));
+        } catch (com.checkba.service.platform.GatewayException e) {
+            log.warn("平台法规检索失败 kind={}: {}", e.getKind(), e.getMessage());
+            String hint = e.suggestsByok()
+                    ? "如需继续使用，可在「系统管理 → 平台服务」把法规检索改为自备 Key。"
+                    : "";
+            return "法规检索本次不可用：" + e.getMessage() + hint
+                    + " 本次已跳过法规检索，请基于已有信息继续完成任务。";
+        }
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -42,6 +42,7 @@ public class PythonTools implements AgentToolComponent {
     private final LegalTools legalTools;
     private final WebTools webTools;
     private final com.checkba.service.SystemSettingService systemSettingService;
+    private final com.checkba.service.platform.ExternalProviderResolver externalProviderResolver;
 
     private static final String DOCKER_IMAGE = "python:3.9-slim";
 
@@ -119,19 +120,19 @@ default_api = _ToolAPI()
 """;
 
     @ToolMeta(displayName = "执行Python代码", category = "python")
-    @Tool("Run Python script. Use this for data analysis, Tushare stock data, or Qichacha API. You can call default_api.read_document(fileId='...') to read project files. Returns stdout/stderr.")
+    @Tool("Run Python script for data analysis and computation. For Chinese company registration records use qichacha_query, "
+            + "and for Tushare financial data use tushare_query — those go through the platform gateway and work without any local credentials. "
+            + "You can call default_api.read_document(fileId='...') to read project files. Returns stdout/stderr.")
     public String run_python(String code) {
         if (code == null || code.isBlank()) {
             return "Error: code is required.";
         }
         log.info("Tool: run_python called. Code length={}", code.length());
 
-        java.util.Map<String, String> credentials = resolveExternalCredentials();
-        // Debug: Log API key status (masked for security)
-        log.info("API Key Status - TUSHARE_TOKEN: {}, QICHACHA_KEY: {}, QICHACHA_SECRET: {}",
-            maskValue(credentials.get("TUSHARE_TOKEN")),
-            maskValue(credentials.get("QICHACHA_KEY")),
-            maskValue(credentials.get("QICHACHA_SECRET")));
+        // 只打**真正会注入**的那几项：平台代采档下一个都不注入，
+        // 照旧打三行 masked 会让人以为凭证发下去了而脚本没用上，排查时先怀疑错方向。
+        java.util.Map<String, String> credentials = injectableCredentials();
+        credentials.forEach((name, value) -> log.info("注入 Python 子进程的凭证 {}: {}", name, maskValue(value)));
 
         Path tempDir = null;
         Process process = null;
@@ -173,7 +174,7 @@ default_api = _ToolAPI()
             // Working Dir
             command.add("-w");
             command.add("/workspace");
-            // Env Vars
+            // Env Vars（平台代采档下一个都不注入，见 injectableCredentials）
             credentials.forEach((name, value) -> {
                 command.add("-e");
                 command.add(name + "=" + value);
@@ -363,8 +364,31 @@ default_api = _ToolAPI()
     }
     
     /**
-     * Mask sensitive values for logging - show only first 4 and last 4 chars.
+     * 注入给 Python 子进程的第三方凭证。
+     *
+     * <p>这是<b>唯一一条不经过 Java 的出站路径</b>（设计 §5.5）：AI 写的脚本拿着这些
+     * 环境变量从用户本机直连上游。平台代采档下没有可注入的凭证——凭证在官网，
+     * 而下发给每台机器等于把公司账号发给所有人。
+     *
+     * <p>所以平台档下<b>一个都不注入</b>，AI 改用 Java 侧的一等工具
+     * （{@code qichacha_query} / {@code tushare_query}，见 {@link EnterpriseDataTools}）。
+     * 那两个工具走网关，因此也才受任务级花费上限约束——脚本这条路是唯一一条
+     * AI 能循环打出几百次上游调用的口子。
      */
+    /**
+     * 本次真正要注入给 Python 子进程的凭证。<b>取值库优先，注入按档过滤</b>，两件事都不能少：
+     *
+     * <ul>
+     *   <li><b>库优先</b>（#383）：用户在设置页填的值写在 {@code system_setting} 里，
+     *       只读 yml/env 的话，他填了 Key 却仍拿到空值——脚本不会报「未配置」，
+     *       只会查不到数据，AI 据此告诉用户「没有该公司的信息」，比报错难查得多。</li>
+     *   <li><b>按档过滤</b>（P4）：平台代采档下凭证在官网，下发给每台机器等于把公司账号
+     *       发给所有人。那一档下 AI 改用 Java 侧的一等工具（qichacha_query / tushare_query），
+     *       它们走网关，因此也才受任务级花费上限约束——脚本这条路是唯一一条 AI 能循环
+     *       打出几百次上游调用的口子。</li>
+     * </ul>
+     */
+    /** 凭证只以掩码进日志：这行日志是排查「脚本为什么查不到数据」的第一现场，但值本身绝不能落盘。 */
     private String maskValue(String value) {
         if (value == null || value.isEmpty()) {
             return "[EMPTY]";
@@ -373,5 +397,23 @@ default_api = _ToolAPI()
             return "[SET:" + value.length() + "chars]";
         }
         return value.substring(0, 4) + "****" + value.substring(value.length() - 4);
+    }
+
+    public java.util.Map<String, String> injectableCredentials() {
+        java.util.Map<String, String> all = resolveExternalCredentials();
+        java.util.Map<String, String> env = new java.util.LinkedHashMap<>();
+        if (isByok(com.checkba.service.platform.ExternalServiceProvider.TUSHARE)) {
+            env.put("TUSHARE_TOKEN", all.get("TUSHARE_TOKEN"));
+        }
+        if (isByok(com.checkba.service.platform.ExternalServiceProvider.QICHACHA)) {
+            env.put("QICHACHA_KEY", all.get("QICHACHA_KEY"));
+            env.put("QICHACHA_SECRET", all.get("QICHACHA_SECRET"));
+        }
+        return env;
+    }
+
+    private boolean isByok(String service) {
+        return externalProviderResolver.resolve(service)
+                != com.checkba.service.platform.ExternalServiceProvider.PLATFORM;
     }
 }

--- a/backend/src/main/java/com/checkba/service/platform/ExternalProviderBackfill.java
+++ b/backend/src/main/java/com/checkba/service/platform/ExternalProviderBackfill.java
@@ -126,16 +126,23 @@ public class ExternalProviderBackfill {
     /**
      * 判定一个没写过档位的服务该落哪一档。顺序不能换：
      * <ol>
-     *   <li>档位本身有 yml/env 默认值（今天只有 TTS 的 {@code EXTERNAL_TTS_PROVIDER=local}）→ 照它；</li>
+     *   <li>档位的 yml/env 默认值**明确要求本地档**（`EXTERNAL_TTS_PROVIDER=local`）→ 照它；</li>
      *   <li>已有非空 BYOK 凭证 → byok（<b>宁可保守</b>，切错方向会花用户的钱）；</li>
      *   <li>都没有 → platform。</li>
      * </ol>
+     *
+     * <p><b>只有 LOCAL 算「显式偏好」，这一条是踩出来的。</b>
+     * `external.tts.provider` 的 yml 默认值写的是 `${EXTERNAL_TTS_PROVIDER:elevenlabs}`——
+     * 那个 `elevenlabs` 是本改造之前的**历史默认值**（当时只有「云端 ElevenLabs / 本地 Kokoro」
+     * 两档），不是任何人做过的选择。把它当偏好会让**每一台全新安装**的 TTS 都落到 byok，
+     * 而用户根本没有 ElevenLabs 的 Key——零配置目标在这一项上当场落空。
+     * 打包态注入的 `local` 才是真实意图（捆绑 Kokoro，免费且不出本机），必须照它。
      */
     private ExternalServiceProvider decide(ExternalServiceProvider.Descriptor d) {
         String injectedProvider = injectedProviderDefaults.get(d.service());
         if (injectedProvider != null && !injectedProvider.isBlank()) {
             ExternalServiceProvider parsed = ExternalServiceProvider.parse(injectedProvider, null);
-            if (parsed != null) return parsed;
+            if (parsed == ExternalServiceProvider.LOCAL) return parsed;
         }
         return hasByokCredentials(d) ? ExternalServiceProvider.BYOK : ExternalServiceProvider.PLATFORM;
     }

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -4,6 +4,7 @@ import com.checkba.service.ai.tools.AgentToolComponent;
 import com.checkba.service.ai.tools.DocumentEditTools;
 import com.checkba.service.ai.tools.EvidenceTools;
 import com.checkba.service.ai.tools.FileTools;
+import com.checkba.service.ai.tools.EnterpriseDataTools;
 import com.checkba.service.ai.tools.LegalTools;
 import com.checkba.service.ai.tools.LitigationVisualTools;
 import com.checkba.service.ai.tools.MeetingTools;
@@ -40,6 +41,7 @@ final class RealToolBeans {
     static List<AgentToolComponent> instantiateAll() {
         List<Class<? extends AgentToolComponent>> toolClasses = List.of(
                 DocumentEditTools.class,
+                EnterpriseDataTools.class,
                 EvidenceTools.class,
                 FileTools.class,
                 LegalTools.class,

--- a/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsCredentialSourceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsCredentialSourceTest.java
@@ -37,7 +37,10 @@ class PythonToolsCredentialSourceTest {
             String key = inv.getArgument(0);
             return rows.containsKey(key) ? rows.get(key) : inv.getArgument(1);
         });
-        PythonTools tools = new PythonTools(null, null, settings);
+        // 档位解析恒回 byok：本类验的是**取值来源**（库优先），与档位过滤是两件事。
+        com.checkba.service.platform.ExternalProviderResolver resolver =
+                new com.checkba.service.platform.ExternalProviderResolver(settings, true);
+        PythonTools tools = new PythonTools(null, null, settings, resolver);
         ReflectionTestUtils.setField(tools, "tushareToken", ymlTushareToken);
         ReflectionTestUtils.setField(tools, "qichachaKey", ymlQichachaKey);
         ReflectionTestUtils.setField(tools, "qichachaSecret", ymlQichachaSecret);

--- a/backend/src/test/java/com/checkba/service/platform/ExternalProviderBackfillTest.java
+++ b/backend/src/test/java/com/checkba/service/platform/ExternalProviderBackfillTest.java
@@ -53,16 +53,40 @@ class ExternalProviderBackfillTest {
                 injected.getOrDefault("pkulaw", ""));
     }
 
+    /**
+     * application.yml 里 {@code external.tts.provider} 的真实默认值。
+     *
+     * <p>测试必须传它而不是空串：传空串等于假设 yml 没给默认值，
+     * 而正是这个非空的历史默认值把全新安装的 TTS 推到了 byok（见下面那条用例）。
+     */
+    private static final String TTS_YML_DEFAULT = "elevenlabs";
+
     @Test
     @DisplayName("全新安装：一个凭证都没有，七项全部落 platform")
     void freshInstallGoesAllPlatform() {
         Map<String, String> rows = new HashMap<>();
-        backfill(settingsWith(rows), Map.of(), "").backfill();
+        backfill(settingsWith(rows), Map.of(), TTS_YML_DEFAULT).backfill();
 
         for (ExternalServiceProvider.Descriptor d : ExternalServiceProvider.ALL) {
             assertEquals("platform", rows.get(ExternalProviderResolver.providerKey(d.service())),
                     d.service() + " 在全新安装上应落 platform");
         }
+    }
+
+    @Test
+    @DisplayName("yml 的历史默认值 elevenlabs 不算「显式偏好」——否则每台全新安装的 TTS 都落 byok")
+    void legacyYmlDefaultIsNotAPreference() {
+        Map<String, String> rows = new HashMap<>();
+        // `${EXTERNAL_TTS_PROVIDER:elevenlabs}` 里的 elevenlabs 是本改造之前的默认值
+        // （当时只有「云端 ElevenLabs / 本地 Kokoro」两档），不是谁做过的选择。
+        // 当成偏好的话，用户根本没有 ElevenLabs Key 却被落到 byok，零配置在这一项上当场落空。
+        backfill(settingsWith(rows), Map.of(), TTS_YML_DEFAULT).backfill();
+        assertEquals("platform", rows.get("external.tts.provider"));
+
+        // 打包态注入的 local 才是真实意图，必须照它
+        Map<String, String> packaged = new HashMap<>();
+        backfill(settingsWith(packaged), Map.of(), "local").backfill();
+        assertEquals("local", packaged.get("external.tts.provider"));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/platform/ExternalServiceDualTierRoutingTest.java
+++ b/backend/src/test/java/com/checkba/service/platform/ExternalServiceDualTierRoutingTest.java
@@ -1,0 +1,505 @@
+package com.checkba.service.platform;
+
+import com.checkba.service.OcrService;
+import com.checkba.service.QichachaService;
+import com.checkba.service.SystemSettingService;
+import com.checkba.service.TtsService;
+import com.checkba.service.TushareService;
+import com.checkba.service.ai.mcp.McpClientService;
+import com.checkba.service.ai.tools.EnterpriseDataTools;
+import com.checkba.service.ai.tools.LegalTools;
+import com.checkba.service.ai.tools.PythonTools;
+import com.checkba.service.ocr.OcrResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * P4 五家服务的双档路由。
+ *
+ * <p>每家守同样的三条，因为每家都能用同样的三种方式坏掉：
+ * <ol>
+ *   <li><b>平台档不碰 BYOK 实现</b>——碰了就是拿网关的账去花用户的 Key，或者反过来；</li>
+ *   <li><b>BYOK 档一次网关都不打</b>——打了就是给自备订阅的用户重复计费（设计 §5.2.1 那两类受害者）；</li>
+ *   <li><b>平台档失败绝不静默回落 BYOK</b>（地雷 8 / 27）——回落会去花用户自己的 Key，
+ *       而用户看到的是「好像成功了」，账单在别处。</li>
+ * </ol>
+ */
+class ExternalServiceDualTierRoutingTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 档位解析器的桩：直接钉死某项服务当前是哪一档。 */
+    private static ExternalProviderResolver resolverWith(String service, ExternalServiceProvider tier) {
+        SystemSettingService settings = mock(SystemSettingService.class);
+        when(settings.get(anyString(), any())).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            return key.equals(ExternalProviderResolver.providerKey(service))
+                    ? tier.settingValue()
+                    : inv.getArgument(1);
+        });
+        return new ExternalProviderResolver(settings, true);
+    }
+
+    private static PlatformGatewayClient gatewayReturning(String dataJson) {
+        PlatformGatewayClient client = mock(PlatformGatewayClient.class);
+        try {
+            when(client.call(anyString(), anyString(), anyMap(), anyInt()))
+                    .thenReturn(new PlatformGatewayClient.Result(MAPPER.readTree(dataJson), 3, 1, "call"));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return client;
+    }
+
+    private static PlatformGatewayClient gatewayFailing(GatewayException.Kind kind) {
+        PlatformGatewayClient client = mock(PlatformGatewayClient.class);
+        when(client.call(anyString(), anyString(), anyMap(), anyInt()))
+                .thenThrow(new GatewayException(kind, "该服务暂未开放，可在系统管理里改用自己的 Key"));
+        return client;
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("OCR")
+    class Ocr {
+
+        private OcrService service(ExternalServiceProvider tier, PlatformGatewayClient gateway,
+                                   SystemSettingService settings) {
+            return new OcrService(settings, resolverWith(ExternalServiceProvider.OCR, tier), gateway);
+        }
+
+        /** 带一套「用户自己填过的阿里云 Key」的设置，用来验 BYOK 档确实走了老路。 */
+        private SystemSettingService byokSettings() {
+            SystemSettingService settings = mock(SystemSettingService.class);
+            when(settings.get(anyString(), any())).thenAnswer(inv -> {
+                String key = inv.getArgument(0);
+                if (key.equals("external.aliyunOcr.accessKeyId")) return "LTAI-fake";
+                if (key.equals("external.aliyunOcr.accessKeySecret")) return "secret-fake";
+                return inv.getArgument(1);
+            });
+            return settings;
+        }
+
+        @Test
+        @DisplayName("平台档：走网关的 ocr/recognize，结果与自备 Key 档同一形状")
+        void platformCallsGateway() {
+            PlatformGatewayClient gateway =
+                    gatewayReturning("{\"content\":\"识别正文\",\"raw\":\"{\\\"a\\\":1}\"}");
+            SystemSettingService settings = mock(SystemSettingService.class);
+            when(settings.get(anyString(), any())).thenAnswer(inv -> inv.getArgument(1));
+
+            OcrResult result = service(ExternalServiceProvider.PLATFORM, gateway, settings)
+                    .recognizeGeneral(java.util.Base64.getEncoder().encodeToString("png".getBytes()));
+
+            assertEquals("识别正文", result.getText());
+            assertEquals("{\"a\":1}", result.getRaw());
+            verify(gateway).call(eq("ocr"), eq("recognize"), anyMap(), anyInt());
+            // 平台档不该去读用户的阿里云凭证——读了说明分档没分干净
+            verify(settings, never()).get(eq("external.aliyunOcr.accessKeyId"), any());
+        }
+
+        @Test
+        @DisplayName("自备 Key 档：一次网关都不打（打了就是给已付订阅的用户重复计费）")
+        void byokNeverTouchesGateway() {
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+            SystemSettingService settings = byokSettings();
+
+            // 没有真凭证，真正的阿里云调用必然失败——这里只关心「有没有走网关」
+            assertThrows(RuntimeException.class,
+                    () -> service(ExternalServiceProvider.BYOK, gateway, settings)
+                            .recognizeGeneral(java.util.Base64.getEncoder().encodeToString("png".getBytes())));
+
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("平台档失败：原样抛 GatewayException，绝不回落去花用户的 Key")
+        void platformFailureDoesNotFallBack() {
+            PlatformGatewayClient gateway = gatewayFailing(GatewayException.Kind.SERVICE_DISABLED);
+            SystemSettingService settings = byokSettings();
+
+            GatewayException e = assertThrows(GatewayException.class,
+                    () -> service(ExternalServiceProvider.PLATFORM, gateway, settings)
+                            .recognizeGeneral(java.util.Base64.getEncoder().encodeToString("png".getBytes())));
+
+            assertEquals(GatewayException.Kind.SERVICE_DISABLED, e.getKind());
+            // 回落会拿用户自己的阿里云账号去跑，账单落在他那边而界面上看不出来
+            verify(settings, never()).get(eq("external.aliyunOcr.accessKeyId"), any());
+        }
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("TTS（三档：platform / byok / local）")
+    class Tts {
+
+        private TtsService service(ExternalServiceProvider tier, PlatformGatewayClient gateway) {
+            TtsService svc = new TtsService();
+            SystemSettingService settings = mock(SystemSettingService.class);
+            when(settings.get(anyString(), any())).thenAnswer(inv -> inv.getArgument(1));
+            ReflectionTestUtils.setField(svc, "systemSettingService", settings);
+            ReflectionTestUtils.setField(svc, "externalProviderResolver",
+                    resolverWith(ExternalServiceProvider.TTS, tier));
+            ReflectionTestUtils.setField(svc, "platformGatewayClient", gateway);
+            // 本地档要的 base-url 留空，正好用来验「local 档不走网关也不走 ElevenLabs」
+            ReflectionTestUtils.setField(svc, "defaultLocalBaseUrl", "");
+            ReflectionTestUtils.setField(svc, "defaultApiKey", "");
+            ReflectionTestUtils.setField(svc, "defaultBaseUrl", "https://api.elevenlabs.io/v1");
+            ReflectionTestUtils.setField(svc, "defaultModelId", "eleven_multilingual_v2");
+            ReflectionTestUtils.setField(svc, "defaultDefaultVoiceId", "voice-1");
+            return svc;
+        }
+
+        @Test
+        @DisplayName("平台档：走网关的 tts/speech，音频落成本地文件")
+        void platformSynthesizesViaGateway() {
+            String audio = java.util.Base64.getEncoder().encodeToString("ID3fake".getBytes());
+            PlatformGatewayClient gateway =
+                    gatewayReturning("{\"audioBase64\":\"" + audio + "\",\"contentType\":\"audio/mpeg\"}");
+
+            java.io.File file = service(ExternalServiceProvider.PLATFORM, gateway)
+                    .generateAudio("你好", null, null, null, null);
+
+            assertTrue(file.exists() && file.length() > 0);
+            verify(gateway).call(eq("tts"), eq("speech"), anyMap(), anyInt());
+            assertTrue(file.delete());
+        }
+
+        @Test
+        @DisplayName("存量取值 elevenlabs 仍是自备 Key 档：不打网关，走「未配置」引导")
+        void legacyElevenlabsValueStaysByok() {
+            // 存量库里 external.tts.provider 就是这个值，解析成 BYOK 才不会让用户填好的 Key 静默失效
+            assertEquals(ExternalServiceProvider.BYOK,
+                    ExternalServiceProvider.parse("elevenlabs", ExternalServiceProvider.PLATFORM));
+
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+            assertThrows(com.checkba.exception.FeatureNotConfiguredException.class,
+                    () -> service(ExternalServiceProvider.BYOK, gateway)
+                            .generateAudio("你好", null, null, null, null));
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("打包态的 local 档：既不走网关也不走 ElevenLabs，指向组件管理")
+        void localTierUntouched() {
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+            // 捆绑的 Kokoro 免费且不出本机，被切成任何一条云通道都是一次静默的功能回归
+            assertThrows(com.checkba.exception.FeatureNotConfiguredException.class,
+                    () -> service(ExternalServiceProvider.LOCAL, gateway)
+                            .generateAudio("你好", null, null, null, null));
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("平台档合成失败：原样抛 GatewayException，不改用用户的 ElevenLabs Key")
+        void platformFailureDoesNotFallBack() {
+            PlatformGatewayClient gateway = gatewayFailing(GatewayException.Kind.NO_CREDITS);
+            GatewayException e = assertThrows(GatewayException.class,
+                    () -> service(ExternalServiceProvider.PLATFORM, gateway)
+                            .generateAudio("你好", null, null, null, null));
+            assertEquals(GatewayException.Kind.NO_CREDITS, e.getKind());
+        }
+
+        @Test
+        @DisplayName("平台档音色列表：走网关的 tts/voices，解析与自备 Key 档共用一份")
+        void platformVoicesShareParsing() {
+            PlatformGatewayClient gateway = gatewayReturning(
+                    "{\"voices\":[{\"voice_id\":\"v1\",\"name\":\"Alice\",\"labels\":{\"gender\":\"female\",\"accent\":\"american\"}}]}");
+
+            List<TtsService.VoiceOption> voices = service(ExternalServiceProvider.PLATFORM, gateway).getVoices();
+
+            assertEquals(1, voices.size());
+            // 两档必须是同一套音色 ID，否则用户选好的音色一换档就指向不存在的东西
+            assertEquals("v1", voices.get(0).getVoiceId());
+            assertEquals("female", voices.get(0).getGender());
+            verify(gateway).call(eq("tts"), eq("voices"), anyMap(), anyInt());
+        }
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("企查查")
+    class Qichacha {
+
+        private QichachaService service(ExternalServiceProvider tier, PlatformGatewayClient gateway) {
+            QichachaService svc = new QichachaService();
+            SystemSettingService settings = mock(SystemSettingService.class);
+            when(settings.get(anyString(), any())).thenAnswer(inv -> inv.getArgument(1));
+            ReflectionTestUtils.setField(svc, "systemSettingService", settings);
+            ReflectionTestUtils.setField(svc, "externalProviderResolver",
+                    resolverWith(ExternalServiceProvider.QICHACHA, tier));
+            ReflectionTestUtils.setField(svc, "platformGatewayClient", gateway);
+            ReflectionTestUtils.setField(svc, "defaultAppKey", "qcc-key");
+            ReflectionTestUtils.setField(svc, "defaultSecretKey", "qcc-secret");
+            // 指向一个必然连不上的地址：BYOK 档只要不打网关就算过
+            ReflectionTestUtils.setField(svc, "defaultBaseUrl", "http://127.0.0.1:1");
+            return svc;
+        }
+
+        @Test
+        @DisplayName("平台档：走网关的 qichacha/eci_info，Result 映射成 DTO")
+        void platformCallsGateway() {
+            PlatformGatewayClient gateway = gatewayReturning(
+                    "{\"Status\":\"200\",\"Result\":{\"Name\":\"某某有限公司\",\"RegistCapi\":\"1000万\"}}");
+
+            var dto = service(ExternalServiceProvider.PLATFORM, gateway).searchCompany("某某有限公司", "TARGET");
+
+            assertEquals("某某有限公司", dto.getName());
+            assertEquals("1000万", dto.getRegisteredCapital());
+            verify(gateway).call(eq("qichacha"), eq("eci_info"), anyMap(), anyInt());
+        }
+
+        @Test
+        @DisplayName("自备 Key 档：一次网关都不打")
+        void byokNeverTouchesGateway() {
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+            assertThrows(RuntimeException.class,
+                    () -> service(ExternalServiceProvider.BYOK, gateway).searchCompany("某某有限公司", "TARGET"));
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("平台档失败：GatewayException 不被包成「外部数据服务暂不可用」，kind 必须活着到调用方")
+        void platformFailureKeepsKind() {
+            PlatformGatewayClient gateway = gatewayFailing(GatewayException.Kind.SERVICE_DISABLED);
+            GatewayException e = assertThrows(GatewayException.class,
+                    () -> service(ExternalServiceProvider.PLATFORM, gateway).searchCompany("某某有限公司", "TARGET"));
+            assertEquals(GatewayException.Kind.SERVICE_DISABLED, e.getKind());
+        }
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("Tushare")
+    class Tushare {
+
+        private TushareService service(ExternalServiceProvider tier, PlatformGatewayClient gateway) {
+            TushareService svc = new TushareService();
+            SystemSettingService settings = mock(SystemSettingService.class);
+            when(settings.get(anyString(), any())).thenAnswer(inv -> inv.getArgument(1));
+            ReflectionTestUtils.setField(svc, "systemSettingService", settings);
+            ReflectionTestUtils.setField(svc, "externalProviderResolver",
+                    resolverWith(ExternalServiceProvider.TUSHARE, tier));
+            ReflectionTestUtils.setField(svc, "platformGatewayClient", gateway);
+            ReflectionTestUtils.setField(svc, "defaultTushareToken", "ts-token");
+            ReflectionTestUtils.setField(svc, "defaultTushareApiUrl", "http://127.0.0.1:1");
+            return svc;
+        }
+
+        @Test
+        @DisplayName("平台档：走网关的 tushare/query，响应形状与自备 token 档一致")
+        void platformCallsGateway() {
+            PlatformGatewayClient gateway = gatewayReturning(
+                    "{\"code\":0,\"data\":{\"fields\":[\"ts_code\"],\"items\":[[\"000001.SZ\"]]}}");
+
+            String json = service(ExternalServiceProvider.PLATFORM, gateway)
+                    .queryJson("stock_basic", Map.of("list_status", "L"), "ts_code");
+
+            assertTrue(json.contains("000001.SZ"));
+            verify(gateway).call(eq("tushare"), eq("query"), anyMap(), anyInt());
+        }
+
+        @Test
+        @DisplayName("自备 token 档：一次网关都不打，失败仍是既有的「回 null」语义")
+        void byokNeverTouchesGateway() {
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+            // 上游连不上，既有实现回 null，上层解析函数据此当「没数据」——这条语义一字未改
+            assertEquals("", service(ExternalServiceProvider.BYOK, gateway)
+                    .queryJson("stock_basic", Map.of(), "ts_code"));
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("平台档失败抛出而不是回 null——null 会让「余额不足」伪装成一次查不到")
+        void platformFailureIsNotSwallowedAsEmpty() {
+            PlatformGatewayClient gateway = gatewayFailing(GatewayException.Kind.NO_CREDITS);
+            GatewayException e = assertThrows(GatewayException.class,
+                    () -> service(ExternalServiceProvider.PLATFORM, gateway)
+                            .queryJson("stock_basic", Map.of(), "ts_code"));
+            assertEquals(GatewayException.Kind.NO_CREDITS, e.getKind());
+        }
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("北大法宝（三个 MCP server）")
+    class Pkulaw {
+
+        private LegalTools tools(ExternalServiceProvider tier, PlatformGatewayClient gateway,
+                                 McpClientService mcp) {
+            return new LegalTools(null, mcp, null,
+                    resolverWith(ExternalServiceProvider.PKULAW, tier), gateway);
+        }
+
+        @Test
+        @DisplayName("平台档：走网关，MCP 响应正文由桌面端既有的解析器解析")
+        void platformCallsGatewayAndParsesLocally() {
+            McpClientService mcp = mock(McpClientService.class);
+            PlatformGatewayClient gateway = gatewayReturning(
+                    "{\"raw\":\"{\\\"result\\\":{\\\"content\\\":[{\\\"type\\\":\\\"text\\\",\\\"text\\\":\\\"第五百零九条\\\"}]}}\"}");
+
+            String out = tools(ExternalServiceProvider.PLATFORM, gateway, mcp).law_search("合同履行");
+
+            assertTrue(out.contains("第五百零九条"), "实际为：" + out);
+            // op 就是法宝的工具名；端点写死在服务端，客户端点不了别处
+            verify(gateway).call(eq("pkulaw"), eq("search_article"), anyMap(), anyInt());
+            verifyNoInteractions(mcp);
+        }
+
+        @Test
+        @DisplayName("自备 token 档：仍直接打 MCP server，一次网关都不打")
+        void byokStillUsesMcpDirectly() {
+            McpClientService mcp = mock(McpClientService.class);
+            when(mcp.callTool(anyString(), anyString(), anyMap())).thenReturn("mcp-result");
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+
+            assertEquals("mcp-result",
+                    tools(ExternalServiceProvider.BYOK, gateway, mcp).law_search("合同履行"));
+
+            verify(mcp).callTool(eq("pkulaw-semantic"), eq("search_article"), anyMap());
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("四个工具各自打到正确的 op")
+        void everyToolMapsToItsOp() {
+            McpClientService mcp = mock(McpClientService.class);
+            PlatformGatewayClient gateway = gatewayReturning("{\"raw\":\"{}\"}");
+            LegalTools t = tools(ExternalServiceProvider.PLATFORM, gateway, mcp);
+
+            t.law_search("q");
+            t.law_search_keyword("民法典", null);
+            t.law_recognition("依据合同法");
+            t.get_law_article("民法典", "509");
+
+            for (String op : List.of("search_article", "get_law_list", "law_recognition", "get_article")) {
+                verify(gateway).call(eq("pkulaw"), eq(op), anyMap(), anyInt());
+            }
+        }
+
+        @Test
+        @DisplayName("平台档失败：给模型一段说明文本，不抛异常打断整轮对话，也不回落 MCP")
+        void failureExplainsWithoutBreakingTheTurn() {
+            McpClientService mcp = mock(McpClientService.class);
+            PlatformGatewayClient gateway = gatewayFailing(GatewayException.Kind.SERVICE_DISABLED);
+
+            String out = tools(ExternalServiceProvider.PLATFORM, gateway, mcp).law_search("合同履行");
+
+            assertTrue(out.contains("法规检索本次不可用"), "实际为：" + out);
+            assertTrue(out.contains("基于已有信息继续"), "实际为：" + out);
+            // 回落到 MCP 会拿用户自己的订阅 token 去跑；抛异常则会让一次检索失败变成一次对话失败
+            verifyNoInteractions(mcp);
+        }
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("非 Java 出站路径：PythonTools 的凭证注入")
+    class PythonCredentials {
+
+        private PythonTools tools(ExternalServiceProvider tushareTier, ExternalServiceProvider qichachaTier) {
+            SystemSettingService settings = mock(SystemSettingService.class);
+            when(settings.get(anyString(), any())).thenAnswer(inv -> {
+                String key = inv.getArgument(0);
+                if (key.equals(ExternalProviderResolver.providerKey(ExternalServiceProvider.TUSHARE))) {
+                    return tushareTier.settingValue();
+                }
+                if (key.equals(ExternalProviderResolver.providerKey(ExternalServiceProvider.QICHACHA))) {
+                    return qichachaTier.settingValue();
+                }
+                return inv.getArgument(1);
+            });
+            PythonTools t = new PythonTools(null, null, settings, new ExternalProviderResolver(settings, true));
+            ReflectionTestUtils.setField(t, "tushareToken", "ts-token");
+            ReflectionTestUtils.setField(t, "qichachaKey", "qcc-key");
+            ReflectionTestUtils.setField(t, "qichachaSecret", "qcc-secret");
+            return t;
+        }
+
+        @Test
+        @DisplayName("平台档：三个变量一个都不注入（凭证在官网，下发等于把公司账号发给所有人）")
+        void platformInjectsNothing() {
+            var env = tools(ExternalServiceProvider.PLATFORM, ExternalServiceProvider.PLATFORM)
+                    .injectableCredentials();
+            assertTrue(env.isEmpty(), "实际为：" + env);
+        }
+
+        @Test
+        @DisplayName("自备 Key 档：与改造前逐字一致，三个变量照旧注入")
+        void byokInjectsAsBefore() {
+            var env = tools(ExternalServiceProvider.BYOK, ExternalServiceProvider.BYOK)
+                    .injectableCredentials();
+            assertEquals("ts-token", env.get("TUSHARE_TOKEN"));
+            assertEquals("qcc-key", env.get("QICHACHA_KEY"));
+            assertEquals("qcc-secret", env.get("QICHACHA_SECRET"));
+        }
+
+        @Test
+        @DisplayName("两家档位互不影响：一家平台一家自备时只注入自备那家")
+        void tiersAreIndependent() {
+            var env = tools(ExternalServiceProvider.PLATFORM, ExternalServiceProvider.BYOK)
+                    .injectableCredentials();
+            assertFalse(env.containsKey("TUSHARE_TOKEN"));
+            assertEquals("qcc-key", env.get("QICHACHA_KEY"));
+        }
+    }
+
+    // =======================================================================
+    @Nested
+    @DisplayName("Java 侧一等工具（补上 PythonTools 停掉的那条路）")
+    class FirstClassTools {
+
+        @Test
+        @DisplayName("网关失败时返回说明文本而不是抛异常——一次查询失败不该变成一次对话失败")
+        void gatewayFailureDoesNotBreakTheTurn() {
+            QichachaService qcc = mock(QichachaService.class);
+            when(qcc.queryEciInfoJson(anyString()))
+                    .thenThrow(new GatewayException(GatewayException.Kind.SERVICE_DISABLED, "该服务暂未开放"));
+            TushareService ts = mock(TushareService.class);
+            when(ts.queryJson(anyString(), anyMap(), anyString()))
+                    .thenThrow(new GatewayException(GatewayException.Kind.NO_CREDITS, "Credits 余额不足，到官网充值后即可继续"));
+
+            EnterpriseDataTools tools = new EnterpriseDataTools(qcc, ts);
+
+            String a = tools.qichacha_query("某某有限公司");
+            assertTrue(a.contains("本次不可用") && a.contains("基于已有信息继续"), "实际为：" + a);
+            String b = tools.tushare_query("stock_basic", "{}", "ts_code");
+            assertTrue(b.contains("本次不可用") && b.contains("基于已有信息继续"), "实际为：" + b);
+
+            // 面向用户的文案一律不许命中掉线判定子串（api.js 会据此清会话）
+            for (String forbidden : List.of("登录", "未授权", "请先")) {
+                assertFalse(a.contains(forbidden), "qichacha_query 文案含「" + forbidden + "」：" + a);
+                assertFalse(b.contains(forbidden), "tushare_query 文案含「" + forbidden + "」：" + b);
+            }
+        }
+
+        @Test
+        @DisplayName("参数写错时明确报错，不静默当成空参数打上游")
+        void badParamsAreRejected() {
+            EnterpriseDataTools tools = new EnterpriseDataTools(mock(QichachaService.class), mock(TushareService.class));
+            String out = tools.tushare_query("stock_basic", "ts_code=000001", "ts_code");
+            assertTrue(out.startsWith("Error:"), "实际为：" + out);
+        }
+
+        @Test
+        @DisplayName("两个工具都带中文显示名（工具卡片上不该出现英文方法名）")
+        void toolsHaveChineseDisplayNames() throws Exception {
+            assertEquals("查询企业工商信息",
+                    EnterpriseDataTools.class.getMethod("qichacha_query", String.class)
+                            .getAnnotation(com.checkba.service.ai.tools.ToolMeta.class).displayName());
+            assertEquals("查询金融数据",
+                    EnterpriseDataTools.class.getMethod("tushare_query", String.class, String.class, String.class)
+                            .getAnnotation(com.checkba.service.ai.tools.ToolMeta.class).displayName());
+        }
+    }
+}


### PR DESCRIPTION
接上 P1 的桌面地基（#376）。除 AI（凭证下发 + 桌面直连，不进网关）之外的七家，至此桌面侧全部有双档路由。**BYOK 实现一字未动**，两档在各自 service 的一个缝上分。官网侧配套 PR：`aiworkdeck_website#58`。

## 分档缝各选在哪、为什么

| 服务 | 缝 | 说明 |
|---|---|---|
| OCR | `OcrService.recognizeGeneral` | platform 档完全不碰 `AliyunOcrClientFactory`，两档产出同一个 `OcrResult(text, raw)` |
| TTS | `TtsService.tier()` | 从 `elevenlabs\|local` 两档变成 `platform\|byok\|local` 三档 |
| 企查查 | `QichachaService.fetchEciInfoResult` | `searchCompany`（DTO）与 `queryEciInfoJson`（给 AI 的原始 JSON）都从它取数 |
| Tushare | `TushareService.callTushare` | 上游本来就只有一个统一入口，分档落这一处，上面几个解析函数一行未改 |
| 北大法宝 | `LegalTools.callPkulaw` | 四个 @Tool 共用 |

**TTS 的判定改走 `ExternalProviderResolver` 而不是自己读设置字符串**：自己读的话 D5（平台档只在 local-mode 开放）与存量回填要在这里再实现一遍，而它们只该有一处判据。存量的 `elevenlabs` 由 `parse()` 映射成 BYOK、打包态注入的 `EXTERNAL_TTS_PROVIDER=local` 由 `ExternalProviderBackfill` 回填，两条存量路径都不经过这次改动（有护栏用例钉住）。

## 法宝也接了，没有留在 BYOK 档

原以为要给 MCP 传输层做代理，实际不用：那三个「MCP server」的传输就是一次普通的 HTTPS POST（JSON-RPC 信封 + Bearer），没有会话、没有握手、没有 SSE 长连。响应正文仍由桌面端既有的 `McpResponseParser` 解析——两档共用一个解析器，法宝改格式只会改一处。

## 平台档失败一律不静默回落 BYOK（地雷 8 / 27）

回落会去花用户自己的 Key，而界面上看不出来，账单落在他那边。三个 service 的失败原样抛 `GatewayException`；两个 AI 工具（法规检索、企业数据）则返回一段说明文本让模型继续——一次查询失败不该变成一次对话失败。

**Tushare 的平台档失败抛出而不是回 null**：null 在上层解析函数眼里就是「这家公司没数据」，于是「未开放」「余额不足」会伪装成一次查不到，正好是设计 §5.5 点名要避免的表现。自备 token 档的 null 语义一字未改。

## GlobalExceptionHandler 新增 GatewayException 分支

`code=1` + `gatewayKind` + `canUseOwnKey`。不接的话网关异常会落到兜底 handler 被压成一句「服务器内部错误」，错误码族存在的全部理由（三类故障下一步完全不同）当场作废。绝不是 4010。

## PythonTools 停止在平台档注入三个凭证（设计 §5.5）

这是唯一一条不经过 Java 的出站路径：AI 写的脚本拿着 `TUSHARE_TOKEN` / `QICHACHA_KEY` / `QICHACHA_SECRET` 从用户本机直连上游，而平台档下没有可注入的凭证。不停的话脚本拿到空 token，失败表现成「查不到数据」而不是「未配置」。

配套补两个 Java 侧一等工具 `EnterpriseDataTools.qichacha_query` / `tushare_query`——它们调的是上面两个 service，所以**两档都能用**，不是平台档专用；收进 Java 侧之后，这条唯一能让 AI 循环打出几百次上游调用的口子才受任务级花费上限约束。

> **需要前端配合**：`frontend/src/utils/toolDisplayNames.js` 要补两个新工具名 `qichacha_query`（查询企业工商信息）、`tushare_query`（查询金融数据）。本 PR 刻意不碰 `frontend/`（P5 配置面在并行进行）。

## 实施中发现的两处与设计不符

1. **`PythonTools` 读的是 `@Value` 的 yml/env 值，从不读 `system_setting`** —— 用户在设置页填的企查查/Tushare Key 从来就没被注入过脚本，这是改造前就有的既有缺陷（本 PR 不修，已记进领域文档地雷 33）。
2. **新增 AI 工具组件必须同步测试侧的 `RealToolBeans.instantiateAll()`** —— 漏了的话该组件的工具在回放评测里根本不注册，`EvalToolBeanParityTest` 会点名（地雷 35）。

## 验证

`cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -o test` → **1768 通过 0 失败**（基线 1744，新增 24 项）。

新用例 `service/platform/ExternalServiceDualTierRoutingTest` 守的是每家都能坏掉的同样三条：平台档不碰 BYOK 实现、BYOK 档一次网关都不打、平台档失败不静默回落。另含 `credentialEnvArgs` 的注入判据与两个新工具的中文显示名。

领域文档 `.claude/agents/licensing-billing.md` 已同步：五家的文件地图、同步入口的 service/op 全集与真实计量来源、地雷 33-35。

🤖 Generated with [Claude Code](https://claude.com/claude-code)