### PR TITLE
fix(meeting): 听悟 INVALID 也算终态失败，别把会议永远挂在转写中

### DIFF
--- a/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
@@ -477,8 +477,7 @@ public class MeetingTranscriptionService {
             }
             if (info.failed()) {
                 meeting.setStatus(MeetingRecording.STATUS_FAILED);
-                meeting.setError("听悟转写失败: "
-                        + (info.errorMessage() == null ? "未知原因" : info.errorMessage()));
+                meeting.setError(tingwuFailureText(info));
                 cleanupOss(meeting, settings);
                 return meetingRepository.save(meeting);
             }
@@ -488,6 +487,19 @@ public class MeetingTranscriptionService {
             log.warn("听悟任务查询失败: meetingId={}, {}", meeting.getId(), e.toString());
             return meeting;
         }
+    }
+
+    /**
+     * 终态失败的文案。INVALID 与 FAILED 分开说：前者是听悟没受理（音频取不到、格式不支持、参数非法），
+     * 用户该去换音频或查凭证；后者是任务跑起来了但失败。都写成「转写失败」的话，
+     * 用户只会以为是我们这边卡住了，然后反复重试同一份必然被拒的音频。
+     */
+    private static String tingwuFailureText(TingwuClient.TaskInfo info) {
+        String reason = info.errorMessage() == null || info.errorMessage().isBlank()
+                ? "未知原因" : info.errorMessage();
+        return info.invalid()
+                ? "听悟未受理该任务（INVALID）: " + reason
+                : "听悟转写失败: " + reason;
     }
 
     private MeetingRecording completeMeeting(MeetingRecording meeting, MeetingAsrSettings settings,

--- a/backend/src/main/java/com/checkba/service/meeting/TingwuClient.java
+++ b/backend/src/main/java/com/checkba/service/meeting/TingwuClient.java
@@ -13,7 +13,7 @@ public interface TingwuClient {
     TaskInfo getTask(MeetingAsrSettings settings, String taskId) throws Exception;
 
     /**
-     * 听悟任务快照。status 取值 ONGOING / COMPLETED / FAILED（听悟原文）。
+     * 听悟任务快照。status 取值 ONGOING / COMPLETED / FAILED / INVALID（听悟原文，<b>是四个不是三个</b>）。
      * 结果 URL 是听悟侧的临时下载地址（有效期 30 天），拿到后立即下载落库，不持久化 URL 本身。
      */
     record TaskInfo(
@@ -28,8 +28,18 @@ public interface TingwuClient {
             return "COMPLETED".equalsIgnoreCase(status);
         }
 
+        /**
+         * 终态失败。<b>INVALID 必须算在内</b>：它既不是 COMPLETED 也不是 FAILED，
+         * 漏判就会被当成「还在跑」，会议永远停在转写中——用户既拿不到稿也看不到错误，
+         * 挂在失败路径上的 OSS 中转对象清理也永远不会执行。
+         */
         public boolean failed() {
-            return "FAILED".equalsIgnoreCase(status);
+            return "FAILED".equalsIgnoreCase(status) || invalid();
+        }
+
+        /** INVALID = 听悟压根没受理这个任务（音频取不到/格式不支持/参数非法），与「跑起来失败了」的成因不同，文案要分得开。 */
+        public boolean invalid() {
+            return "INVALID".equalsIgnoreCase(status);
         }
     }
 }

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionServiceTest.java
@@ -132,6 +132,24 @@ class MeetingTranscriptionServiceTest {
     }
 
     @Test
+    @DisplayName("poll-on-read：听悟 INVALID 也是终态失败（不能一路当成还在跑），并清中转对象")
+    void refreshInvalidIsTerminalFailure() throws Exception {
+        MeetingRecording m = meeting(MeetingRecording.STATUS_TRANSCRIBING);
+        m.setTingwuTaskId("task-1");
+        when(tingwu.getTask(any(), eq("task-1"))).thenReturn(new TingwuClient.TaskInfo(
+                "INVALID", "音频地址无法访问", null, null, null, null));
+
+        MeetingRecording out = service(true).refreshIfNeeded(m);
+
+        assertEquals(MeetingRecording.STATUS_FAILED, out.getStatus());
+        // 文案要能看出是上游拒收，不是我们卡住了
+        assertTrue(out.getError().contains("未受理"), "实际文案: " + out.getError());
+        assertTrue(out.getError().contains("音频地址无法访问"));
+        // 清理只挂在完成/失败两条路径上，漏判终态就会把中转音频永远留在 OSS 里
+        verify(oss, atLeastOnce()).deleteQuietly(any(), anyString());
+    }
+
+    @Test
     @DisplayName("poll-on-read：查询网络异常不落 FAILED（任务还在听悟侧跑）")
     void refreshQueryErrorKeepsTranscribing() throws Exception {
         MeetingRecording m = meeting(MeetingRecording.STATUS_TRANSCRIBING);


### PR DESCRIPTION
## 问题（既有缺陷，非本次改动引入）

通义听悟 `GetTaskInfo` 的 `taskStatus` 有**四个**取值：ONGOING / COMPLETED / FAILED / **INVALID**，
而 `TingwuClient.TaskInfo.failed()` 只判了 `FAILED`。

后果：一个 INVALID 的任务既不满足 `completed()` 也不满足 `failed()`，`MeetingTranscriptionService.refreshViaTingwu`
会一直把它当成 ONGOING——

- 会议永远停在 `STATUS_TRANSCRIBING`，用户既拿不到转写结果，也看不到任何错误；
- OSS 中转对象也不会被清理（清理只挂在完成/失败两条路径上）。

这条地雷 `.claude/agents/licensing-billing.md` 第 31 条早就记了「两侧的终态判定都要带上它」，byok 这一侧一直没落实。

## 改法

- `TaskInfo.failed()` 覆盖 INVALID；另给 `invalid()` 供文案分流。
- 失败文案分开说：INVALID 写「听悟未受理该任务（INVALID）: 原因」，FAILED 维持「听悟转写失败: 原因」。
  两者成因不同、用户下一步也不同（前者该换音频/查凭证，后者可重试），都写成「转写失败」用户只会以为是我们卡住了，
  然后反复重试同一份必然被拒的音频。
- 失败路径已经在调 `cleanupOss`，本次把 INVALID 接进这条路径后中转对象随之被清（测试里断言了）。

**platform 档（走网关那条，2026-08-17 的 P2 新增）一字未动**——官网侧已按四个状态处理。
`MeetingTranscriptionPlatformPathTest` 9 项照常全绿。

## 护栏测试

`MeetingTranscriptionServiceTest.refreshInvalidIsTerminalFailure`：INVALID → `STATUS_FAILED` + 文案含「未受理」与上游原因 + `oss.deleteQuietly` 被调用。

先写测试看它红（`expected: <FAILED> but was: <TRANSCRIBING>`，正是本缺陷的现象），再改实现转绿。

## 验证

`cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -o test`
→ **Tests run: 1745, Failures: 0, Errors: 0, Skipped: 11, BUILD SUCCESS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)