### PR TITLE
fix(ai): PythonTools 注入子进程的外部凭证改为库优先（既有缺陷）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -164,6 +164,13 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
   末位提醒仍是概率性的，确定性兜底在分发层：`dispatchTool` 短路"打开活跃文档本身"的 doc_open_file、
   给 doc_list_project_files 结果钉活跃文档提示（`activeDocOpenShortCircuit` / `appendActiveDocNotice`，
   PR#210）。**跨文档场景不拦截**——改这两个 helper 前先确认别把"对比另一份合同"之类的正常流程堵死。
+- **外部服务凭证有两个来源，工具侧只读一个就会静默失效**：企查查 / Tushare 的 Key 在设置页写进
+  `system_setting`（`external.qichacha.key` / `external.qichacha.secret` / `external.tushare.token`），
+  yml 只是兜底。`PythonTools` 注入 Python 子进程的那三个环境变量曾只读 `@Value`，于是用户填了 Key
+  脚本照样拿空值——还不报「未配置」，只是查不到数据，AI 据此回答「没有查到该公司的信息」。
+  取值统一走 `PythonTools.resolveExternalCredentials()`（库优先、yml 兜底、每次调用现取，
+  `PythonToolsCredentialSourceTest` 钉住）。platform 档下这三个变量刻意不注入是另一条口径
+  （设计文档 §5.5，随 P4 落地），别与本条混为一谈。
 - 排障需要后端日志时注意：桌面端复用已在跑的后端进程时不会重建日志管道，`~/.aiworkdeck/logs/backend.log`
   会停止更新（表现为日志停在几天前）。要拿新日志先彻底退出 app 让后端随之重启。
 - 防走神注入/todo_write 进度卡/文档检查点机制见 PR#161/162。

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -41,6 +41,7 @@ public class PythonTools implements AgentToolComponent {
 
     private final LegalTools legalTools;
     private final WebTools webTools;
+    private final com.checkba.service.SystemSettingService systemSettingService;
 
     private static final String DOCKER_IMAGE = "python:3.9-slim";
 
@@ -124,11 +125,14 @@ default_api = _ToolAPI()
             return "Error: code is required.";
         }
         log.info("Tool: run_python called. Code length={}", code.length());
-        
+
+        java.util.Map<String, String> credentials = resolveExternalCredentials();
         // Debug: Log API key status (masked for security)
         log.info("API Key Status - TUSHARE_TOKEN: {}, QICHACHA_KEY: {}, QICHACHA_SECRET: {}",
-            maskValue(tushareToken), maskValue(qichachaKey), maskValue(qichachaSecret));
-        
+            maskValue(credentials.get("TUSHARE_TOKEN")),
+            maskValue(credentials.get("QICHACHA_KEY")),
+            maskValue(credentials.get("QICHACHA_SECRET")));
+
         Path tempDir = null;
         Process process = null;
         try {
@@ -170,13 +174,11 @@ default_api = _ToolAPI()
             command.add("-w");
             command.add("/workspace");
             // Env Vars
-            command.add("-e");
-            command.add("TUSHARE_TOKEN=" + (tushareToken != null ? tushareToken : ""));
-            command.add("-e");
-            command.add("QICHACHA_KEY=" + (qichachaKey != null ? qichachaKey : ""));
-            command.add("-e");
-            command.add("QICHACHA_SECRET=" + (qichachaSecret != null ? qichachaSecret : ""));
-            
+            credentials.forEach((name, value) -> {
+                command.add("-e");
+                command.add(name + "=" + value);
+            });
+
             // Image & Command
             command.add(DOCKER_IMAGE);
             command.add("python");
@@ -291,6 +293,28 @@ default_api = _ToolAPI()
         }
     }
     
+    /**
+     * 注入 Python 子进程的外部服务凭证（环境变量名 -> 值）。
+     *
+     * <p><b>库优先、yml 兜底</b>，与同一批凭证的 Java 侧调用方（{@code TushareService} /
+     * {@code QichachaService}）同源。早先这里只读 {@code @Value}，而用户在
+     * 「系统管理 → 外部服务」填的凭证写进的是 {@code system_setting}——脚本因此永远拿到空值，
+     * 且不会报「未配置」，只是查不到数据，AI 据此回答「没有查到该公司的信息」。
+     *
+     * <p>取值放在每次调用时而不是启动时：设置页改完即时生效，不用重启后端。
+     */
+    java.util.Map<String, String> resolveExternalCredentials() {
+        java.util.Map<String, String> env = new java.util.LinkedHashMap<>();
+        env.put("TUSHARE_TOKEN", orEmpty(systemSettingService.get("external.tushare.token", tushareToken)));
+        env.put("QICHACHA_KEY", orEmpty(systemSettingService.get("external.qichacha.key", qichachaKey)));
+        env.put("QICHACHA_SECRET", orEmpty(systemSettingService.get("external.qichacha.secret", qichachaSecret)));
+        return env;
+    }
+
+    private static String orEmpty(String value) {
+        return value != null ? value : "";
+    }
+
     /**
      * 后台守护线程持续读取进程输出流到缓冲，防止管道写阻塞导致子进程挂死。
      */

--- a/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsCredentialSourceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsCredentialSourceTest.java
@@ -1,0 +1,86 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.SystemSettingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 注入 Python 子进程的外部服务凭证必须<b>库优先、yml 兜底</b>，与同一批凭证的 Java 侧调用方
+ * （{@code TushareService} / {@code QichachaService}）同源。
+ *
+ * <p>护栏的由来：这里早先只读 {@code @Value}，而用户在「系统管理 → 外部服务」填的企查查 /
+ * Tushare 凭证写进的是 {@code system_setting}。两边不同源的后果很隐蔽——脚本拿到空值不会报
+ * 「未配置」，只是查不到数据，AI 据此回答「没有查到该公司的信息」，看起来像数据源没有。
+ *
+ * <p>只钉 BYOK 档。platform 档下这三个变量刻意不注入（改走 Java 侧一等工具经平台网关，
+ * 见设计文档 §5.5，随 P4 落地），那条口径由 P4 自己的测试守，这里不重复、也不预先冻结。
+ */
+class PythonToolsCredentialSourceTest {
+
+    /** 工具方法本身不碰 legalTools / webTools，与 {@code RealToolBeans} 一样传 null 即可。 */
+    private static PythonTools toolsWith(Map<String, String> rows,
+                                         String ymlTushareToken,
+                                         String ymlQichachaKey,
+                                         String ymlQichachaSecret) {
+        SystemSettingService settings = mock(SystemSettingService.class);
+        when(settings.get(anyString(), any())).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            return rows.containsKey(key) ? rows.get(key) : inv.getArgument(1);
+        });
+        PythonTools tools = new PythonTools(null, null, settings);
+        ReflectionTestUtils.setField(tools, "tushareToken", ymlTushareToken);
+        ReflectionTestUtils.setField(tools, "qichachaKey", ymlQichachaKey);
+        ReflectionTestUtils.setField(tools, "qichachaSecret", ymlQichachaSecret);
+        return tools;
+    }
+
+    @Test
+    @DisplayName("BYOK 档：设置页填过的凭证必须盖过 yml 默认值")
+    void databaseValuesWinOverYamlDefaults() {
+        Map<String, String> rows = new HashMap<>();
+        rows.put("external.qichacha.provider", "byok");
+        rows.put("external.tushare.provider", "byok");
+        rows.put("external.tushare.token", "db-tushare-token");
+        rows.put("external.qichacha.key", "db-qichacha-key");
+        rows.put("external.qichacha.secret", "db-qichacha-secret");
+
+        Map<String, String> env = toolsWith(rows, "yml-tushare-token", "yml-qichacha-key", "yml-qichacha-secret")
+                .resolveExternalCredentials();
+
+        assertEquals("db-tushare-token", env.get("TUSHARE_TOKEN"));
+        assertEquals("db-qichacha-key", env.get("QICHACHA_KEY"));
+        assertEquals("db-qichacha-secret", env.get("QICHACHA_SECRET"));
+    }
+
+    @Test
+    @DisplayName("库里没写过时回落 yml——靠配置文件供凭证的存量部署不能被打断")
+    void yamlDefaultsRemainTheFallback() {
+        Map<String, String> env =
+                toolsWith(new HashMap<>(), "yml-tushare-token", "yml-qichacha-key", "yml-qichacha-secret")
+                        .resolveExternalCredentials();
+
+        assertEquals("yml-tushare-token", env.get("TUSHARE_TOKEN"));
+        assertEquals("yml-qichacha-key", env.get("QICHACHA_KEY"));
+        assertEquals("yml-qichacha-secret", env.get("QICHACHA_SECRET"));
+    }
+
+    @Test
+    @DisplayName("哪儿都没配时是空串，不能把 \"null\" 当 token 传进容器")
+    void unconfiguredCredentialsBecomeEmptyStrings() {
+        Map<String, String> env = toolsWith(new HashMap<>(), null, null, null).resolveExternalCredentials();
+
+        assertEquals("", env.get("TUSHARE_TOKEN"));
+        assertEquals("", env.get("QICHACHA_KEY"));
+        assertEquals("", env.get("QICHACHA_SECRET"));
+    }
+}


### PR DESCRIPTION
## 问题

企查查 / Tushare 的 Key 在「系统管理 → 外部服务」填写后写进 `system_setting`
（`external.tushare.token` / `external.qichacha.key` / `external.qichacha.secret`，
见 `AdminConfigController`），而 `PythonTools` 把这三个变量注入 Python 子进程时读的是
`@Value` 注入的 yml/env 值，**从不读 `system_setting`**。两边不同源，用户填了 Key，
AI 写的 Python 分析脚本却一直拿到空值。

后果隐蔽：脚本不会报「未配置」，只会查不到数据然后返回空结果，AI 据此告诉用户
「没有查到该公司的信息」。用户以为是数据源没有，实际是我们没把他的 Key 传下去。

**不是 2026-08-17 网关改造（#376）引入的**，是既有缺陷。

## 改动

`PythonTools` 新增 `resolveExternalCredentials()`：`systemSettingService.get(key, ymlDefault)`，
即**库优先、yml 兜底**——与同一批凭证的 Java 侧调用方（`TushareService` / `QichachaService`）一致。
docker 的 `-e` 参数与那行掩码状态日志都改从这一处取值。

取值放在每次调用时而不是启动时：设置页改完即时生效，不用重启后端。

## 护栏测试

新增 `PythonToolsCredentialSourceTest`：

1. **byok 档 + `system_setting` 有值 → 注入的是 DB 值而不是 yml 默认值**（本次要求的那条）
2. 库里没写过时仍回落 yml——靠配置文件供凭证的存量部署不能被打断
3. 哪儿都没配时是空串，不能把 `"null"` 当 token 传进容器

第 1 条对着修复前的取值来源实跑过，红在
`expected: <db-tushare-token> but was: <yml-tushare-token>`，确认这条护栏真的抓得住。

## 关于 platform 档

设计文档 §5.5 的口径是「platform 档下 `PythonTools` 不注入这三个变量，改走 Java 侧一等工具
`qichacha_query` / `tushare_query` 经平台网关」。**这条目前还没落地**——`PythonTools` 从未引用
`ExternalProviderResolver`，那两个工具也还不存在，§5.5 仍挂在 P4。

所以本次没有加这道闸：现在加会在没有替代路径的情况下直接掐掉 Python 这条出口。
护栏测试只钉 BYOK 档，P4 补闸时不必改它。

## 顺带

- `.claude/agents/ai-chat.md` 已知地雷加一条「外部服务凭证有两个来源」。
- 排查过同类缺陷：其余只读 yml 的 `external.*` 只有 `PptxServiceClient`（pptx 服务地址）与
  `PdfEditService`（CJK 字体路径），两者都不在 admin 页可写键里，没有第二处。

## 验证

`cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -o test` → **Tests run: 1747, Failures: 0, Errors: 0, Skipped: 11**

🤖 Generated with [Claude Code](https://claude.com/claude-code)