### PR TITLE
docs(legal): 商标声明补齐真实注册信息，区分已注册图形与未注册文字

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Commercial licensing is available for:
 
 See [LICENSE](legal/LICENSE) and [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md). For commercial licensing, contact [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com).
 
-**AI WorkDeck™** is a trademark of the project maintainers. Building on the kernel is welcome under the licenses above, but using the **AI WorkDeck** name or logo for a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
+**AI WorkDeck™** is our unregistered word mark; the AI WorkDeck logo is a registered trademark in China (Class 9, reg. no. 89857424). Building on the kernel is welcome under the licenses above, but using the **AI WorkDeck** name or logo for a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
 
 ## Background
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -318,7 +318,7 @@ AI WorkDeck 社区版基于 GNU Affero General Public License v3.0 发布。
 
 详见 [LICENSE](legal/LICENSE) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md)。商业许可请联系 [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com)。
 
-**AI WorkDeck™** 是我们的商标。欢迎在上述许可下基于内核构建产品，但将 **AI WorkDeck** 名称或标识用于商业产品需要品牌或认证协议——见 [TRADEMARKS.md](legal/TRADEMARKS.md) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md) 中的**品牌与认证计划**。
+**AI WorkDeck™** 是我们的未注册文字商标；AI WorkDeck 标识已在中国注册（第 9 类，注册号 89857424）。欢迎在上述许可下基于内核构建产品，但将 **AI WorkDeck** 名称或标识用于商业产品需要品牌或认证协议——见 [TRADEMARKS.md](legal/TRADEMARKS.md) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md) 中的**品牌与认证计划**。
 
 ## 背景
 

--- a/legal/COMMERCIAL-LICENSE.md
+++ b/legal/COMMERCIAL-LICENSE.md
@@ -26,7 +26,7 @@ Please contact our licensing team to discuss your specific use case and pricing:
 - **Website:** [www.aiworkdeck.com](https://www.aiworkdeck.com)
 
 ## Brand & Certification Programs
-**AI WorkDeck™** is our trademark (see [`TRADEMARKS.md`](TRADEMARKS.md)). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
+**AI WorkDeck™** is our word mark and the AI WorkDeck logo is a registered trademark (see [`TRADEMARKS.md`](TRADEMARKS.md) for the per-class status). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
 
 | Program | What you get |
 |---|---|

--- a/legal/TRADEMARKS.md
+++ b/legal/TRADEMARKS.md
@@ -3,8 +3,27 @@
 ## 1. Purpose
 The purpose of this policy is to balance the interests of the open-source community with the need to protect the **AI WorkDeck** brand and reputation. We want you to feel free to hack on the code, but we must prevent confusion in the marketplace.
 
-## 2. Product Name
-**AI WorkDeck™** and **AI WorkDeck Kernel™** are trademarks of the project maintainers, used in commerce to identify this software and the related services we provide. Unauthorized commercial use of these marks may infringe our trademark rights.
+## 2. The Marks and Their Status
+
+All marks below are held by 北京京微资易科技有限公司, the entity behind this project.
+
+### 2.1 The logo (device mark)
+
+The AI WorkDeck logo — the stylised "K" device — is filed with the China National Intellectual Property Administration in three classes, one of which has issued:
+
+| Class | Goods / services | Reg. or app. no. | Status |
+|---|---|---|---|
+| 9 | Computer software (downloadable software, file and database management software, OCR, chatbot software) | 89857424 | **Registered** 2026-07-27; exclusive right runs to 2036-07-26 |
+| 35 | Advertising and business services | 89857389 | Preliminarily approved and published 2026-05-27; **application pending** |
+| 42 | SaaS, PaaS, software design and hosting | 89857390 | Preliminarily approved and published 2026-05-27; **application pending** |
+
+The ® symbol is used with the device mark only for the Class 9 goods on which it is registered. The Class 35 and 42 applications have cleared examination but are not yet registered, and we do not mark them ®.
+
+### 2.2 The name (word mark)
+
+**AI WorkDeck™** and **AI WorkDeck Kernel™** are unregistered trademarks used in commerce to identify this software and the related services we provide. There is no word-mark registration, so we mark them ™ rather than ®.
+
+Unregistered marks are still protectable. Unauthorized commercial use that causes confusion as to the source of goods or services may infringe our rights under the Anti-Unfair Competition Law, independently of any registration.
 
 ## 3. Trade Dress & Look and Feel
 In addition to the name, the **distinctive visual appearance and user experience (UX/UI) flow** of the AI WorkDeck IDE constitutes our **Trade Dress**.


### PR DESCRIPTION
接 #388。维护者提供了企查查的商标检索结果，据此把商标声明改准。

## 真实状态

三件商标，申请人**北京京微资易科技有限公司**，均 2026-01-22 申请，**全部是图形商标（K 标识），没有任何文字商标**：

| 注册/申请号 | 类别 | 状态 |
|---|---|---|
| 89857424 | 9 类 计算机软件 | **已注册** 2026-07-27，专用权至 2036-07-26 |
| 89857389 | 35 类 广告销售 | 初审公告 2026-05-27，**尚未注册** |
| 89857390 | 42 类 SaaS / 设计研究 | 初审公告 2026-05-27，**尚未注册** |

## 修正了上一版的两处不准确

#388 里我按维护者口述写成「注册的是 K 图形商标」，比对登记数据后有两处要改：

1. **只有 9 类真的下证。** 35 类与 42 类还停在初审公告，处于异议期，不能称为已注册。
2. **权利人写错了。** 文档原文是 "trademarks of the project maintainers"，实际权利人是公司主体北京京微资易科技有限公司。法律文件里这个不能含糊。

## 改动

`legal/TRADEMARKS.md` 第 2 节拆成两小节：

- **2.1 图形商标** —— 表格逐类列注册/申请号与状态，并写明 **® 仅用于已注册的 9 类商品**，35/42 未下证不标 ®
- **2.2 文字商标** —— `AI WorkDeck™` / `AI WorkDeck Kernel™` 为未注册商标，标 ™ 不标 ®；保留「未经授权的商业使用若造成来源混淆，可依反不正当竞争法主张权利」

`README.md`、`README.zh-CN.md`、`legal/COMMERCIAL-LICENSE.md` 的一句话摘要同步为「文字未注册 + 标识已在 9 类注册（89857424）」，避免摘要与详版互相矛盾。

品牌许可、认证计划、禁止性条款、fork 改名要求一律未动。

## 复核

全仓已扫：`®` 只出现在 `TRADEMARKS.md` 中说明其适用范围的两句话里，**没有任何一处把 ® 用作未注册标识的角标**。

## 一个时间点

35 类与 42 类初审公告日 2026-05-27，异议期三个月，约 **2026-08-27** 届满。未被异议的话两件会转为注册，届时这张表要更新（把两行改成已注册并补注册公告日与专用权期限）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)