### PR TITLE
fix(test): 本地转写用例的 TRANSCRIBING 断言不再拼调度运气

### DIFF
--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -105,6 +105,7 @@ manifest.json 要点：id（必需）/name/version/icon/author/permissions（fil
 - `RealToolBeans.instantiateAll()`（评测用的工具 bean 清单）与生产的 `AgentToolComponent` 实现集**不是自动同步的**：`TodoTools` 就不在里面，所以 `todo_write` 在回放评测里根本没注册，评测断言不到它的可见性。新增工具组件时要顺手补进去。
 - 插件启停语义只影响可见性，不拦截历史工具调用回放。
 - 改 AgentOrchestrator 构造器（如注入新服务）必须同步 EvalHarness（踩过两次）。
+- **「先落中间态再 `executor.submit`」的服务（会议转写就是），测试里断中间态必须先卡住后台线程**：`save` mock 成原样返回入参时，方法返回的对象与测试持有的是同一个可变实例，后台那个瞬间返回的 mock 会抢先把它改成终态，断言成败取决于 runner 调度（#394 修的就是这个间歇红）。用 `CountDownLatch` 卡住后台调用的那个 mock，断完中间态再 `countDown` 放行。
 - SubAgentTools 曾因循环依赖断启动，用 @Lazy 解决（PR#98），插件/工具类注入编排器时注意。
 
 ## 验证

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionLocalPathTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionLocalPathTest.java
@@ -130,10 +130,18 @@ class MeetingTranscriptionLocalPathTest {
     @Test
     @DisplayName("local 档转写：音频一个字节都不出本机，段落按秒→毫秒落库，speaker 恒为 1")
     void transcribesLocallyAndNeverLeavesTheMachine() throws Exception {
-        when(localAsr.transcribe(any(File.class))).thenReturn(LOCAL_JSON);
+        // save 原样返回入参，startTranscription 的返回值与 out 是同一个可变实例；
+        // 不卡住后台推理的话，它可能赶在下面读 status 之前就把这个实例改成 TRANSCRIBED，
+        // 断言的成败就成了 runner 的调度运气。断完 TRANSCRIBING 再放行。
+        java.util.concurrent.CountDownLatch hold = new java.util.concurrent.CountDownLatch(1);
+        when(localAsr.transcribe(any(File.class))).thenAnswer(inv -> {
+            hold.await(3, TimeUnit.SECONDS);
+            return LOCAL_JSON;
+        });
 
         MeetingRecording out = meeting(MeetingRecording.STATUS_RECORDED);
         assertEquals(MeetingRecording.STATUS_TRANSCRIBING, service().startTranscription(7L).getStatus());
+        hold.countDown();
         awaitUntil(() -> MeetingRecording.STATUS_TRANSCRIBED.equals(out.getStatus()));
 
         // 本批最重要的一条：录音不出本机 = 云端三条出站路径一次都不该被走到


### PR DESCRIPTION
## 现象

`MeetingTranscriptionLocalPathTest#transcribesLocallyAndNeverLeavesTheMachine` 间歇性红：

```
expected: <TRANSCRIBING> but was: <TRANSCRIBED>
```

首次在 master 的 #388 那次 push 上翻（run 32016566223），1780 个用例里就红这一个。此后 #392、#389 两次 push 都绿，所以 master 的 tip 现在是绿的——但这条抖动会继续随机翻。

## 根因（测试自身的竞态，不是产品缺陷）

- 测试把 `meetingRepository.save(any())` mock 成原样返回入参，且 `findById(7L)` 恒返回同一个 `MeetingRecording` 实例。于是 `startTranscription` 返回的 `saved` 与测试持有的 `out` 是**同一个可变对象**。
- `MeetingTranscriptionService.startTranscription` 先 `setStatus(TRANSCRIBING)` + `save`，紧接着 `executor.submit(() -> transcribeLocally(meetingId))`，**然后才** `return saved`。
- 后台线程里 `localAsr.transcribe()` 是 mock、瞬间返回，`storeSegments` 随即把这同一个实例改成 `TRANSCRIBED`。它和测试线程读 `status` 谁先谁后取决于 runner 调度 → 间歇红。

## 改法

用同文件既有的 latch 写法（`inFlightLocalTranscriptionIsNotMistakenForInterrupted` 已经这么干）卡住后台推理，断完 `TRANSCRIBING` 再 `countDown` 放行，之后照旧 `awaitUntil` 等 `TRANSCRIBED`。

**产品代码一行没动**，改动只有这一个测试方法。

## 顺带核对过的同形状用例

- `localFailureNeverFallsBackToCloud`：只等终态 `FAILED`，不断中间态，无竞态。
- `inFlightLocalTranscriptionIsNotMistakenForInterrupted`：本来就有 latch。
- `MeetingTranscriptionPlatformPathTest:172` 是同一形状，但 `submitViaPlatform` 成功路径只写 `gatewayTaskId`/`lastPolledAt`，全程不碰 `status`，那条断言翻不了，不动。
- 全 backend 扫了一遍「identity-returning save mock + 后台线程」的组合，只有这三个会议用例落在交集里。

## 验证

- 单类连跑 9 次全绿（每次 7 项）。
- 全量 `mvn -B test`：**1787 项，0 失败，11 跳过，BUILD SUCCESS**（JDK 21）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)