### PR TITLE
fix(i18n): 会议录音在英文版真的能用——三处遗留清掉，顺带补上「按钮点了不出纪要」

### DIFF
--- a/backend/skills/meeting-recorder/prompt.en.md
+++ b/backend/skills/meeting-recorder/prompt.en.md
@@ -1,0 +1,46 @@
+# Meeting Minutes
+
+You are preparing meeting minutes for a lawyer. The input is a meeting transcript with speaker
+labels and timestamps (machine-transcribed, so expect typos, spoken-language fragments, and the
+occasional mis-attributed speaker). The output is a structured minutes docx that can be filed,
+sent to the client, or circulated to the team as it stands.
+
+## Workflow
+
+1. Call `meeting_get_transcript` (with the meetingId from the kick-off prompt) to read the full
+   transcript. Machine-generated summary material (chapters / summary / to-do leads) may be
+   appended at the end - treat it as a hint only; the transcript text is authoritative.
+2. Read the whole transcript and identify: the subject of the meeting, the participants and their
+   positions, the topics discussed, the conclusions and resolutions reached, the explicit action
+   items (who, what, by when), and anything disputed or uncertain.
+3. Use `write_docx` to produce "Minutes_<meeting title>.docx".
+
+## Structure (five fixed sections)
+
+1. **Meeting information**: title, date, duration, participants (use the speaker list from the
+   transcript; a name like "Speaker N" means the user never renamed that speaker, so carry it
+   over as is and do not invent an identity).
+2. **Topics and discussion points**: grouped by topic, not a line-by-line retelling. Under each
+   topic, summarize each side's main position and attribute significant statements to the
+   speaker who made them. Transcript timestamps may be used to mark key moments (for example
+   "[00:23:15] the parties agreed on the payment schedule"), but do not tag every line.
+3. **Resolutions**: the conclusions actually agreed on, numbered. Include only what the
+   transcript shows was genuinely agreed.
+4. **Action items**: a table or list of item / owner / deadline. Where no deadline was stated,
+   write "not specified" rather than guessing.
+5. **Risks and items to verify**: from a lawyer's perspective - legal risks surfaced in the
+   discussion, inconsistent positions, and places where a likely transcription error affects the
+   meaning (give the timestamp so the audio can be checked). Write "none" if there are none.
+
+## Red lines
+
+- Stay faithful to the source: write only what the transcript supports. Never invent a statement
+  or a conclusion.
+- Obvious transcription typos may be rewritten into readable prose, but where amounts, dates,
+  deadlines, or party names look doubtful in the original, put them in section 5 for
+  verification instead of deciding on the user's behalf.
+- Speaker separation sometimes splits one person into two labels or merges two people. When
+  crossed labels clearly affect attribution, flag it in section 5; do not silently reassign
+  statements.
+- Tone: written, restrained, the register of a lawyer's work product. No emoji, no exclamation
+  marks.

--- a/backend/skills/meeting-recorder/skill.yml
+++ b/backend/skills/meeting-recorder/skill.yml
@@ -19,6 +19,19 @@ enabled_by_default: false
 # 法律事项类别（匿名统计用，枚举见 MatterCategory）
 category: 其他法律事务
 
+# 可用语言：录音→转写→写纪要这条链路不绑任何法域（不像股东大会核查那样绑中国证券法），
+# 面板本身已双语，英文版可用。
+# **这不是一个可选声明**：缺省（空）= 只在 zh-CN 可用（SkillRegistry.supportsCurrentLanguage），
+# 而左栏入口读的是 /api/skills/list（不过语言过滤）——两处判据不同，缺这行的后果是
+# 英文版下面板照样出现、能录能转写，但「生成会议纪要」拼的 prompt 永远命不中本 skill，
+# 拿不到 prompt.en.md 与 meeting_get_transcript / write_docx 白名单，按钮形同虚设。
+# 英文侧文本：name_en / triggers_en / output_en 见下，英文 prompt 在 prompt.en.md。
+languages:
+  - zh-CN
+  - en-US
+
+name_en: Meeting Recording
+
 # 触发条件：用户输入包含任一关键词即命中（面板 kick-off prompt 以「会议纪要」开头）
 triggers:
   - 会议纪要
@@ -27,6 +40,17 @@ triggers:
   - 整理会议
   - 会议转写
   - 谈判纪要
+
+# 英文触发词（仅 en-US 应用语言下参与匹配；zh-CN 匹配行为不受影响）。
+# **第一条必须与 MeetingRecordingService.buildMinutesKickoffPrompt 的英文开头一致**
+# （"Meeting minutes generation task."），面板那个按钮就是靠它命中的。
+triggers_en:
+  - meeting minutes
+  - meeting recording
+  - generate minutes
+  - write up the meeting
+  - meeting transcript
+  - negotiation minutes
 
 # prompt 模板文件名（相对本目录）
 prompt: prompt.md
@@ -50,3 +74,10 @@ output: |
   「会议纪要_<会议标题>.docx」——结构化会议纪要（基本信息、议题与讨论要点、
   决议事项、待办事项、风险提示与待核实事项）。
   <final> 中简述：几项决议、几项待办、有无需要核实的事项。不要复述纪要全文。
+
+output_en: |
+  One Word deliverable, written into the project files with write_docx:
+  "Minutes_<meeting title>.docx" - structured meeting minutes (basic information, topics and
+  discussion points, resolutions, action items, risks and items to verify).
+  In <final>, state briefly: how many resolutions, how many action items, and whether anything
+  needs verifying. Do not restate the minutes.

--- a/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
+++ b/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
@@ -1,7 +1,6 @@
 package com.checkba.controller;
 
 import com.checkba.model.entity.MeetingRecording;
-import com.checkba.model.entity.ProjectFile;
 import com.checkba.service.LangText;
 import com.checkba.service.ProjectMemberService;
 import com.checkba.service.meeting.MeetingRecordingService;
@@ -121,9 +120,15 @@ public class MeetingRecordingController {
         return meeting;
     }
 
-    /** 导出转写稿 docx 到项目「会议录音」文件夹。 */
+    /**
+     * 导出转写稿 docx 到项目的录音文件夹。
+     *
+     * <p>回 {@code {file, folderName}} 而不是裸 ProjectFile：文件夹名按语言二选一、也可能是
+     * 存量安装里早就建好的那一个，界面上「见 X 文件夹」那句话只能用实际名字
+     * （见 MeetingRecordingService.FOLDER_NAME 的注释）。
+     */
     @PostMapping("/{meetingId}/export")
-    public ProjectFile export(
+    public MeetingRecordingService.ExportResult export(
             @PathVariable Long meetingId,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = requireMemberByMeeting(sessionId, meetingId);

--- a/backend/src/main/java/com/checkba/service/ai/tools/MeetingTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/MeetingTools.java
@@ -1,6 +1,7 @@
 package com.checkba.service.ai.tools;
 
 import com.checkba.model.entity.MeetingRecording;
+import com.checkba.service.LangText;
 import com.checkba.service.meeting.MeetingRecordingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.P;
@@ -14,6 +15,10 @@ import java.util.Map;
 /**
  * 会议录音工具：给 AI 编排读会议转写稿与摘要素材（生成纪要的 skill 用）。
  * projectId 由 ToolRegistry 从 ToolContext 强制注入，LLM 报的值不生效。
+ *
+ * <p>返回文本双语（LangText）：这些串是喂给模型的脚手架，英文会话里塞中文小标题
+ * （「转写稿」「机器摘要素材」）等于要求模型跨语言理解自己的输入格式，也会漏进过程卡。
+ * 转写内容本身是用户数据，一律原样不动。
  */
 @Component
 @RequiredArgsConstructor
@@ -28,15 +33,20 @@ public class MeetingTools implements AgentToolComponent {
     public String meeting_list_recordings(@P("Project id (injected by runtime)") Long projectId) {
         List<MeetingRecording> meetings = meetingService.list(projectId);
         if (meetings.isEmpty()) {
-            return "本项目还没有会议录音。请用户先在左栏「会议录音」面板录制。";
+            return LangText.of(
+                    "本项目还没有会议录音。请用户先在左栏「会议录音」面板录制。",
+                    "This project has no meeting recordings yet. Ask the user to record one in the "
+                            + "Meeting Recording panel in the sidebar.");
         }
-        StringBuilder sb = new StringBuilder("本项目的会议录音：\n");
+        StringBuilder sb = new StringBuilder(LangText.of(
+                "本项目的会议录音：\n", "Meeting recordings in this project:\n"));
         for (MeetingRecording m : meetings) {
             sb.append("- meetingId=").append(m.getId())
                     .append(" | ").append(m.getTitle())
-                    .append(" | 时长 ").append(m.getDurationMs() != null
-                            ? MeetingRecordingService.formatMs(m.getDurationMs()) : "未知")
-                    .append(" | 状态 ").append(statusLabel(m.getStatus()))
+                    .append(LangText.of(" | 时长 ", " | duration ")).append(m.getDurationMs() != null
+                            ? MeetingRecordingService.formatMs(m.getDurationMs())
+                            : LangText.of("未知", "unknown"))
+                    .append(LangText.of(" | 状态 ", " | status ")).append(statusLabel(m.getStatus()))
                     .append('\n');
         }
         return sb.toString();
@@ -51,18 +61,26 @@ public class MeetingTools implements AgentToolComponent {
             @P("Meeting recording id") Long meetingId) {
         MeetingRecording meeting = meetingService.get(meetingId);
         if (!projectId.equals(meeting.getProjectId())) {
-            return "该会议不属于当前项目。";
+            return LangText.of("该会议不属于当前项目。",
+                    "That meeting does not belong to the current project.");
         }
         if (!MeetingRecording.STATUS_TRANSCRIBED.equals(meeting.getStatus())) {
-            return "该会议尚未完成转写（当前状态：" + statusLabel(meeting.getStatus())
-                    + "）。请用户在「会议录音」面板完成转写后再生成纪要。";
+            return LangText.of(
+                    "该会议尚未完成转写（当前状态：" + statusLabel(meeting.getStatus())
+                            + "）。请用户在「会议录音」面板完成转写后再生成纪要。",
+                    "That meeting has not finished transcription (current status: "
+                            + statusLabel(meeting.getStatus()) + "). Ask the user to finish "
+                            + "transcription in the Meeting Recording panel before generating minutes.");
         }
         StringBuilder sb = new StringBuilder();
-        sb.append("会议：").append(meeting.getTitle());
+        sb.append(LangText.of("会议：", "Meeting: ")).append(meeting.getTitle());
         if (meeting.getDurationMs() != null) {
-            sb.append("（时长 ").append(MeetingRecordingService.formatMs(meeting.getDurationMs())).append("）");
+            sb.append(LangText.of("（时长 ", " (duration "))
+                    .append(MeetingRecordingService.formatMs(meeting.getDurationMs()))
+                    .append(LangText.of("）", ")"));
         }
-        sb.append("\n\n=== 转写稿（[时间] 说话人：内容）===\n");
+        sb.append(LangText.of("\n\n=== 转写稿（[时间] 说话人：内容）===\n",
+                "\n\n=== Transcript ([time] speaker: text) ===\n"));
         sb.append(meetingService.renderTranscriptText(meeting));
         appendSummary(sb, meeting);
         return sb.toString();
@@ -73,38 +91,44 @@ public class MeetingTools implements AgentToolComponent {
         if (meeting.getSummaryJson() == null || meeting.getSummaryJson().isBlank()) return;
         try {
             Map<?, ?> summary = objectMapper.readValue(meeting.getSummaryJson(), Map.class);
-            sb.append("\n=== 机器摘要素材（仅供参考，以转写稿原文为准）===\n");
+            sb.append(LangText.of("\n=== 机器摘要素材（仅供参考，以转写稿原文为准）===\n",
+                    "\n=== Machine summary material (reference only; the transcript is authoritative) ===\n"));
+            String colon = LangText.of("：", ": ");
             Object chapters = summary.get("chapters");
             if (chapters instanceof List<?> list && !list.isEmpty()) {
-                sb.append("章节速览：\n");
+                sb.append(LangText.of("章节速览：\n", "Chapters:\n"));
                 for (Object c : list) {
                     if (c instanceof Map<?, ?> m) {
-                        sb.append("- ").append(m.get("title")).append("：").append(m.get("summary")).append('\n');
+                        sb.append("- ").append(m.get("title")).append(colon).append(m.get("summary")).append('\n');
                     }
                 }
             }
             if (summary.get("summary") instanceof String s && !s.isBlank()) {
-                sb.append("全文摘要：").append(s).append('\n');
+                sb.append(LangText.of("全文摘要：", "Overall summary: ")).append(s).append('\n');
             }
             if (summary.get("todos") instanceof List<?> todos && !todos.isEmpty()) {
-                sb.append("待办线索：\n");
+                sb.append(LangText.of("待办线索：\n", "To-do leads:\n"));
                 todos.forEach(t -> sb.append("- ").append(t).append('\n'));
             }
             if (summary.get("keywords") instanceof List<?> kw && !kw.isEmpty()) {
-                sb.append("关键词：").append(String.join("、", kw.stream().map(String::valueOf).toList())).append('\n');
+                sb.append(LangText.of("关键词：", "Keywords: "))
+                        .append(String.join(LangText.of("、", ", "),
+                                kw.stream().map(String::valueOf).toList()))
+                        .append('\n');
             }
         } catch (Exception ignored) {
             // 摘要素材损坏不影响转写稿主体
         }
     }
 
+    /** 与面板的 meeting.status* 同口径（那边是给人看的徽标，这里是给模型读的字面）。 */
     private String statusLabel(String status) {
         return switch (status) {
-            case MeetingRecording.STATUS_RECORDING -> "录音中";
-            case MeetingRecording.STATUS_RECORDED -> "已录音（未转写）";
-            case MeetingRecording.STATUS_TRANSCRIBING -> "转写中";
-            case MeetingRecording.STATUS_TRANSCRIBED -> "已转写";
-            case MeetingRecording.STATUS_FAILED -> "转写失败";
+            case MeetingRecording.STATUS_RECORDING -> LangText.of("录音中", "recording");
+            case MeetingRecording.STATUS_RECORDED -> LangText.of("已录音（未转写）", "recorded (not transcribed)");
+            case MeetingRecording.STATUS_TRANSCRIBING -> LangText.of("转写中", "transcribing");
+            case MeetingRecording.STATUS_TRANSCRIBED -> LangText.of("已转写", "transcribed");
+            case MeetingRecording.STATUS_FAILED -> LangText.of("转写失败", "transcription failed");
             default -> status;
         };
     }

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
@@ -4,6 +4,7 @@ import com.checkba.model.entity.MeetingRecording;
 import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.MeetingRecordingRepository;
 import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.LangText;
 import com.checkba.service.ProjectFileService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +34,20 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MeetingRecordingService {
 
+    /**
+     * 存放录音与转写稿的项目文件夹名。**两个名字都是「正名」**，不是新旧关系：
+     * 建档时按界面语言取一个（{@link #folderName()}），查找时两个都认（{@link #ensureFolder}）。
+     *
+     * <p>为什么不像其他文案那样只留一个中文常量：这是**落到文件树上、用户看得见的目录**。
+     * 只留中文，英文用户会被指到一个叫「会议录音」的目录；换成只留英文，存量中文安装里
+     * 已有的那个目录会变成孤儿、下次录音另建一个。所以名字按语言选，查找跨语言兜住，
+     * 一个项目里永远只有一个这样的目录。
+     *
+     * <p>常量本身必须是纯字面量：{@code static final} 上求值会在类加载期把语言冻死
+     * （见 LangText 的类注释），所以取值走 {@link #folderName()} 方法。
+     */
     public static final String FOLDER_NAME = "会议录音";
+    public static final String FOLDER_NAME_EN = "Meeting Recordings";
 
     private final MeetingRecordingRepository meetingRepository;
     private final ProjectFileRepository projectFileRepository;
@@ -47,7 +61,9 @@ public class MeetingRecordingService {
     @Transactional
     public MeetingRecording create(Long projectId, Long userId) {
         LocalDateTime now = LocalDateTime.now();
-        String title = "会议 " + now.format(DateTimeFormatter.ofPattern("MM-dd HH:mm"));
+        // 默认标题是**落库的用户数据**，按建档那一刻的界面语言定，事后切语言不改历史会议
+        String title = LangText.of("会议 ", "Meeting ")
+                + now.format(DateTimeFormatter.ofPattern("MM-dd HH:mm"));
 
         ProjectFile folder = ensureFolder(projectId, userId);
         String audioName = uniqueName(projectId, folder.getId(), title, ".webm");
@@ -69,7 +85,8 @@ public class MeetingRecordingService {
 
     public MeetingRecording get(Long meetingId) {
         return meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("会议不存在: " + meetingId));
+                .orElseThrow(() -> new IllegalArgumentException(
+                        LangText.of("会议不存在: ", "Meeting not found: ") + meetingId));
     }
 
     public Long getProjectId(Long meetingId) {
@@ -107,7 +124,8 @@ public class MeetingRecordingService {
         try {
             meeting.setSpeakerNames(names == null || names.isEmpty() ? null : objectMapper.writeValueAsString(names));
         } catch (Exception e) {
-            throw new IllegalArgumentException("说话人名称格式非法");
+            throw new IllegalArgumentException(LangText.of(
+                    "说话人名称格式非法", "Invalid speaker name format"));
         }
         return meetingRepository.save(meeting);
     }
@@ -141,10 +159,17 @@ public class MeetingRecordingService {
         return names;
     }
 
-    /** 展示名解析：改过名用改的，否则「说话人N」。 */
+    /**
+     * 展示名解析：改过名用改的，否则「说话人N」/「Speaker N」。
+     *
+     * <p>这个默认名不落库（只有用户改过的名字才进 speakerNames），所以按当前界面语言取值是安全的：
+     * 同一份转写稿在中文界面读作「说话人1」、英文界面读作「Speaker 1」，不会两种叫法混进同一份数据。
+     * 面板侧的对应文案是 meeting.speakerDefaultName，两边措辞要一致。
+     */
     public String displaySpeaker(Map<String, String> names, String speakerId) {
         String custom = names.get(speakerId);
-        return (custom == null || custom.isBlank()) ? "说话人" + speakerId : custom;
+        if (custom != null && !custom.isBlank()) return custom;
+        return LangText.of("说话人" + speakerId, "Speaker " + speakerId);
     }
 
     /** 转写稿渲染成纯文本（AI 工具与导出共用）。 */
@@ -152,10 +177,12 @@ public class MeetingRecordingService {
         List<MeetingTranscriptParser.Segment> segments = readSegments(meeting);
         if (segments.isEmpty()) return "";
         Map<String, String> names = speakerDisplayNames(meeting);
+        // 说话人与正文之间的分隔：中文用全角冒号，英文用半角加空格（全角冒号在英文行里很扎眼）
+        String colon = LangText.of("：", ": ");
         StringBuilder sb = new StringBuilder();
         for (MeetingTranscriptParser.Segment s : segments) {
             sb.append('[').append(formatMs(s.start())).append("] ")
-                    .append(displaySpeaker(names, s.speaker())).append('：')
+                    .append(displaySpeaker(names, s.speaker())).append(colon)
                     .append(s.text()).append('\n');
         }
         return sb.toString();
@@ -180,43 +207,69 @@ public class MeetingRecordingService {
         }
     }
 
-    /** 导出转写稿 docx 到「会议录音」文件夹，返回新文件。 */
+    /**
+     * 导出结果：新文件 + 它所在文件夹的**实际**名字。
+     *
+     * <p>文件夹名要回给前端，是因为它按语言二选一、还可能是存量安装里早就建好的那一个
+     * （见 {@link #FOLDER_NAME}）。界面上那句「见 X 文件夹」若照自己的语言硬拼，
+     * 就会把用户指向一个不存在的目录名。
+     */
+    public record ExportResult(ProjectFile file, String folderName) {
+    }
+
+    /** 导出转写稿 docx 到录音文件夹，返回新文件与文件夹名。 */
     @Transactional
-    public ProjectFile exportTranscript(Long meetingId, Long userId) {
+    public ExportResult exportTranscript(Long meetingId, Long userId) {
         MeetingRecording meeting = get(meetingId);
         String text = renderTranscriptText(meeting);
         if (text.isEmpty()) {
-            throw new IllegalArgumentException("暂无转写内容可导出");
+            throw new IllegalArgumentException(LangText.of(
+                    "暂无转写内容可导出", "There is no transcript to export yet"));
         }
         byte[] docx = buildTranscriptDocx(meeting.getTitle(), text);
         ProjectFile folder = ensureFolder(meeting.getProjectId(), userId);
         String name = uniqueName(meeting.getProjectId(), folder.getId(),
-                "转写稿_" + sanitize(meeting.getTitle()), ".docx");
+                LangText.of("转写稿_", "Transcript_") + sanitize(meeting.getTitle()), ".docx");
         ProjectFile file = projectFileService.createFile(meeting.getProjectId(), folder.getId(),
                 name, "docx", (long) docx.length, null, null, userId);
         storageServiceFactory.getStorageService().save(file.getFilePath(), new ByteArrayInputStream(docx));
-        return file;
+        return new ExportResult(file, folder.getName());
     }
 
     /**
-     * 「生成纪要」kick-off prompt。开头必须是 skill 触发词「会议纪要」——
-     * SkillRouter 靠 prompt 文本命中（pinnedSkillId 只裁工具不注入 prompt）。
+     * 「生成纪要」kick-off prompt。<b>开头必须是 skill 触发词</b>——SkillRouter 靠 prompt 文本命中
+     * （pinnedSkillId 只裁工具不注入 prompt）。
+     *
+     * <p>因此这段话的语言不是「顺手也翻一下」：英文界面下必须以 skill.yml 的 <b>triggers_en</b>
+     * 里的词开头（"meeting minutes"），否则英文用户点「生成会议纪要」拼出的 prompt 命不中本 skill，
+     * 既拿不到 prompt.en.md 的指引、也拿不到 meeting_get_transcript / write_docx 白名单——
+     * 按钮点了看着有反应，产出却不是纪要。改这里要同步 skill.yml 的 triggers_en。
      */
     public String buildMinutesKickoffPrompt(MeetingRecording meeting) {
         Map<String, String> names = speakerDisplayNames(meeting);
+        boolean en = LangText.isEnglish();
         StringBuilder sb = new StringBuilder();
-        sb.append("会议纪要生成任务。\n\n");
-        sb.append("会议：").append(meeting.getTitle()).append("（meetingId=").append(meeting.getId()).append("）\n");
+        sb.append(en ? "Meeting minutes generation task.\n\n" : "会议纪要生成任务。\n\n");
+        sb.append(en ? "Meeting: " : "会议：").append(meeting.getTitle())
+                .append(en ? " (meetingId=" : "（meetingId=").append(meeting.getId())
+                .append(en ? ")\n" : "）\n");
         if (meeting.getDurationMs() != null) {
-            sb.append("时长：").append(formatMs(meeting.getDurationMs())).append('\n');
+            sb.append(en ? "Duration: " : "时长：").append(formatMs(meeting.getDurationMs())).append('\n');
         }
         List<MeetingTranscriptParser.Segment> segments = readSegments(meeting);
         java.util.Set<String> speakerIds = new java.util.TreeSet<>();
         segments.forEach(s -> speakerIds.add(s.speaker()));
         if (!speakerIds.isEmpty()) {
-            sb.append("与会人（说话人分离结果）：");
-            sb.append(String.join("、", speakerIds.stream().map(id -> displaySpeaker(names, id)).toList()));
+            sb.append(en ? "Participants (from speaker separation): " : "与会人（说话人分离结果）：");
+            sb.append(String.join(en ? ", " : "、",
+                    speakerIds.stream().map(id -> displaySpeaker(names, id)).toList()));
             sb.append('\n');
+        }
+        if (en) {
+            sb.append("\nFirst call the meeting_get_transcript tool (meetingId=").append(meeting.getId())
+                    .append(") to read the full transcript and summary material, then produce the "
+                            + "meeting minutes docx as the skill specifies.");
+            return sb.toString();
         }
         sb.append("\n请先调用 meeting_get_transcript 工具（meetingId=").append(meeting.getId())
                 .append("）读取完整转写稿与摘要素材，再按 skill 约定生成会议纪要 docx。");
@@ -225,13 +278,29 @@ public class MeetingRecordingService {
 
     // ==================== 私有 ====================
 
+    /** 建档那一刻的界面语言决定新文件夹叫什么；已存在的一律沿用，不改名。 */
+    public static String folderName() {
+        return LangText.of(FOLDER_NAME, FOLDER_NAME_EN);
+    }
+
+    /**
+     * 找到（或建出）本项目的录音文件夹。
+     *
+     * <p><b>查找跨两个语言的名字</b>：先按当前语言找，再按另一个找。少了这一步，
+     * 中文安装里已有的「会议录音」在切到英文后会被当成不存在，于是另建一个
+     * 「Meeting Recordings」——同一个项目里两个同用途目录，旧录音留在旧目录里像丢了。
+     */
     private ProjectFile ensureFolder(Long projectId, Long userId) {
-        Optional<ProjectFile> existing = projectFileRepository
-                .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, null, FOLDER_NAME);
-        if (existing.isPresent() && Boolean.TRUE.equals(existing.get().getIsFolder())) {
-            return existing.get();
+        String preferred = folderName();
+        String other = preferred.equals(FOLDER_NAME) ? FOLDER_NAME_EN : FOLDER_NAME;
+        for (String candidate : List.of(preferred, other)) {
+            Optional<ProjectFile> existing = projectFileRepository
+                    .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, null, candidate);
+            if (existing.isPresent() && Boolean.TRUE.equals(existing.get().getIsFolder())) {
+                return existing.get();
+            }
         }
-        return projectFileService.createFolder(projectId, null, FOLDER_NAME, userId);
+        return projectFileService.createFolder(projectId, null, preferred, userId);
     }
 
     /** createFile 对同名文件抛异常，这里先探测再加 (2)/(3) 后缀。 */
@@ -261,7 +330,7 @@ public class MeetingRecordingService {
         try (XWPFDocument doc = new XWPFDocument(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             XWPFParagraph titleP = doc.createParagraph();
             XWPFRun titleRun = titleP.createRun();
-            titleRun.setText(title + " 转写稿");
+            titleRun.setText(title + LangText.of(" 转写稿", " - Transcript"));
             titleRun.setBold(true);
             titleRun.setFontSize(16);
             for (String line : text.split("\n")) {

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
@@ -289,14 +289,16 @@ public class MeetingTranscriptionService {
      */
     public MeetingRecording startTranscription(Long meetingId) {
         MeetingRecording meeting = meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("会议不存在: " + meetingId));
+                .orElseThrow(() -> new IllegalArgumentException(
+                        LangText.of("会议不存在: ", "Meeting not found: ") + meetingId));
         if (MeetingRecording.STATUS_TRANSCRIBING.equals(meeting.getStatus())
                 || MeetingRecording.STATUS_TRANSCRIBED.equals(meeting.getStatus())) {
             return meeting;
         }
         // IllegalArgumentException：GlobalExceptionHandler 只对它透传 message，其余异常一律「服务器内部错误」
         if (MeetingRecording.STATUS_RECORDING.equals(meeting.getStatus())) {
-            throw new IllegalArgumentException("录音尚未结束");
+            throw new IllegalArgumentException(LangText.of(
+                    "录音尚未结束", "The recording has not finished yet"));
         }
 
         ExternalServiceProvider tier = tier();
@@ -325,7 +327,10 @@ public class MeetingTranscriptionService {
             }
             case BYOK -> {
                 if (!settings.configured()) {
-                    throw new IllegalArgumentException("未配置转写服务凭证，请到 设置-会议转写 填写阿里云凭证");
+                    throw new IllegalArgumentException(LangText.of(
+                            "未配置转写服务凭证，请到 设置-会议转写 填写阿里云凭证",
+                            "No transcription credentials configured. Enter your Aliyun credentials "
+                                    + "under System settings - Platform Services."));
                 }
             }
         }

--- a/backend/src/test/java/com/checkba/service/ai/skill/BuiltinSkillsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/BuiltinSkillsTest.java
@@ -137,6 +137,18 @@ class BuiltinSkillsTest {
         assertFalse(s.getPromptTemplate().isBlank(), "prompt.md 应有内容");
         assertTrue(s.getPromptTemplate().contains("meeting_get_transcript"),
                 "prompt 必须交代先读转写稿再写纪要");
+
+        // 英文侧：面板已双语，skill 侧缺一项就是「按钮点了产出不是纪要」
+        assertTrue(s.getLanguages().contains("en-US"),
+                "会议录音不绑法域，必须声明 en-US；缺了英文版下 SkillRouter 永远命不中它");
+        assertTrue(s.getTriggersEn().contains("meeting minutes"),
+                "MeetingRecordingService.buildMinutesKickoffPrompt 的英文开头就是它，"
+                        + "两处必须一致：" + s.getTriggersEn());
+        assertTrue(s.getPromptTemplateEn() != null
+                        && s.getPromptTemplateEn().contains("meeting_get_transcript"),
+                "prompt.en.md 应被加载且同样交代先读转写稿");
+        assertFalse(s.getOutputEn() == null || s.getOutputEn().isBlank(),
+                "output_en 缺失会让英文模式注入中文产出约定");
     }
 
     @Test
@@ -189,6 +201,36 @@ class BuiltinSkillsTest {
         assertEquals("litigation-visual",
                 enRouter.match("Please draw a case timeline of the dispute").orElseThrow().getId(),
                 "英文触发词应命中诉讼可视化");
+    }
+
+    /**
+     * 英文模式下「生成会议纪要」按钮的整条链路。
+     *
+     * <p>这里用的字面量就是 {@code MeetingRecordingService.buildMinutesKickoffPrompt} 英文分支的
+     * 开头（那边有对应的单测断言 prompt 以它开头）。两端各锁一半：那边保证发出去的是这句话，
+     * 这边保证这句话能命中本 skill。缺任一半，按钮在英文版下就是「有反应、产出不对」。
+     */
+    @Test
+    @DisplayName("英文模式：会议录音可用，面板 kick-off prompt 的英文开头能命中它")
+    void englishModeKeepsMeetingRecorderReachable() {
+        com.checkba.service.AppLanguageService en =
+                org.mockito.Mockito.mock(com.checkba.service.AppLanguageService.class);
+        org.mockito.Mockito.when(en.language()).thenReturn(com.checkba.service.AppLanguageService.EN_US);
+        org.mockito.Mockito.when(en.isEnglish()).thenReturn(true);
+
+        SkillProperties props = new SkillProperties();
+        props.setDir(SKILLS_DIR.toString());
+        SkillRegistry enRegistry = new SkillRegistry(props, null, new PluginService(), en);
+        enRegistry.init();
+        enRegistry.setEnabled("meeting-recorder", true); // 默认不安装，这里只测语言过滤
+
+        assertTrue(enRegistry.isAvailable(enRegistry.getSkill("meeting-recorder").orElseThrow()),
+                "会议录音声明了 en-US，英文版应可用");
+
+        SkillRouter enRouter = new SkillRouter(enRegistry, props, null, en);
+        assertEquals("meeting-recorder",
+                enRouter.match("Meeting minutes generation task.").orElseThrow().getId(),
+                "面板拼出的英文 kick-off prompt 必须命中会议录音 skill");
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/tools/MeetingToolsLanguageTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/MeetingToolsLanguageTest.java
@@ -1,0 +1,111 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.MeetingRecording;
+import com.checkba.repository.MeetingRecordingRepository;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.meeting.MeetingRecordingService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * meeting_* 工具返回文本的语言：这些串是喂给模型的脚手架（小标题、状态词、空态指引），
+ * 英文会话里漏中文会让模型跨语言理解自己的输入格式，也会漏进过程卡。
+ * 转写内容本身是用户数据，必须原样保留——两条一起锁。
+ */
+class MeetingToolsLanguageTest {
+
+    private MeetingRecordingRepository meetingRepository;
+    private MeetingTools tools;
+
+    private static final String TRANSCRIPT_JSON = """
+            [{"speaker":"1","start":61000,"end":62000,"text":"我方认为价款应分期支付"}]
+            """;
+
+    @BeforeEach
+    void setUp() {
+        meetingRepository = mock(MeetingRecordingRepository.class);
+        when(meetingRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        MeetingRecordingService service = new MeetingRecordingService(
+                meetingRepository, mock(ProjectFileRepository.class),
+                mock(ProjectFileService.class), mock(StorageServiceFactory.class));
+        tools = new MeetingTools(service);
+    }
+
+    @AfterEach
+    void resetLanguage() {
+        LangText.reset();
+    }
+
+    private void switchToEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+    }
+
+    private MeetingRecording transcribed() {
+        MeetingRecording m = new MeetingRecording();
+        m.setId(9L);
+        m.setProjectId(1L);
+        m.setTitle("尽调访谈");
+        m.setStatus(MeetingRecording.STATUS_TRANSCRIBED);
+        m.setDurationMs(3600_000L);
+        m.setTranscriptJson(TRANSCRIPT_JSON);
+        when(meetingRepository.findById(9L)).thenReturn(Optional.of(m));
+        return m;
+    }
+
+    @Test
+    @DisplayName("英文下转写稿工具的脚手架是英文，转写内容与会议标题原样保留")
+    void transcriptToolScaffoldingIsEnglish() {
+        transcribed();
+        switchToEnglish();
+        String out = tools.meeting_get_transcript(1L, 9L);
+        assertTrue(out.startsWith("Meeting: 尽调访谈"), "标题是用户数据，不翻：" + out);
+        assertTrue(out.contains("=== Transcript ([time] speaker: text) ==="), out);
+        assertTrue(out.contains("Speaker 1: 我方认为价款应分期支付"), "转写内容原样：" + out);
+        assertFalse(out.contains("转写稿"), "脚手架不该残留中文：" + out);
+        assertFalse(out.contains("时长"), "脚手架不该残留中文：" + out);
+    }
+
+    @Test
+    @DisplayName("英文下未完成转写与空列表的指引也是英文")
+    void guidanceTextIsEnglish() {
+        MeetingRecording m = transcribed();
+        m.setStatus(MeetingRecording.STATUS_RECORDED);
+        switchToEnglish();
+
+        String notReady = tools.meeting_get_transcript(1L, 9L);
+        assertTrue(notReady.contains("recorded (not transcribed)"), notReady);
+        assertTrue(notReady.contains("Meeting Recording panel"), notReady);
+        assertFalse(notReady.contains("请用户"), notReady);
+
+        when(meetingRepository.findByProjectIdOrderByCreatedAtDesc(2L)).thenReturn(List.of());
+        String empty = tools.meeting_list_recordings(2L);
+        assertTrue(empty.startsWith("This project has no meeting recordings yet"), empty);
+    }
+
+    @Test
+    @DisplayName("中文（默认/未登记语言）下这些串逐字不变")
+    void chineseUnchanged() {
+        transcribed();
+        String out = tools.meeting_get_transcript(1L, 9L);
+        assertTrue(out.startsWith("会议：尽调访谈"), out);
+        assertTrue(out.contains("=== 转写稿（[时间] 说话人：内容）==="), out);
+        assertTrue(out.contains("说话人1：我方认为价款应分期支付"), out);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingFolderLanguageTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingFolderLanguageTest.java
@@ -1,0 +1,169 @@
+package com.checkba.service.meeting;
+
+import com.checkba.model.entity.MeetingRecording;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.MeetingRecordingRepository;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
+import com.checkba.service.ProjectFileService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 录音文件夹的跨语言复用。
+ *
+ * <p>「会议录音」与「Meeting Recordings」是同一个目录的两个正名：建档按界面语言取一个，
+ * <b>查找必须两个都认</b>。少了跨语言那一步，中文安装切到英文后会另建一个同用途目录，
+ * 旧录音留在旧目录里像丢了——这类事故不会报错、只会让用户以为文件没了，所以在这里锁死。
+ */
+class MeetingFolderLanguageTest {
+
+    private ProjectFileRepository projectFileRepository;
+    private ProjectFileService projectFileService;
+    private MeetingRecordingRepository meetingRepository;
+    private MeetingRecordingService service;
+
+    private static final String TRANSCRIPT_JSON = """
+            [{"speaker":"1","start":61000,"end":62000,"text":"我方认为价款应分期支付"}]
+            """;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        meetingRepository = mock(MeetingRecordingRepository.class);
+        projectFileRepository = mock(ProjectFileRepository.class);
+        projectFileService = mock(ProjectFileService.class);
+        StorageServiceFactory factory = mock(StorageServiceFactory.class);
+        StorageService storage = mock(StorageService.class);
+        when(factory.getStorageService()).thenReturn(storage);
+        when(storage.save(anyString(), any())).thenReturn("stored");
+
+        // 两个名字默认都查不到；具体用例再按需给其中一个塞值
+        when(projectFileRepository.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(
+                anyLong(), isNull(), anyString())).thenReturn(Optional.empty());
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                anyLong(), any(), anyString(), anyLong())).thenReturn(false);
+        when(projectFileService.createFolder(anyLong(), isNull(), anyString(), anyLong()))
+                .thenAnswer(inv -> folder(inv.getArgument(2)));
+        when(projectFileService.createFile(anyLong(), any(), anyString(), anyString(),
+                anyLong(), any(), any(), anyLong()))
+                .thenAnswer(inv -> file(inv.getArgument(2)));
+
+        service = new MeetingRecordingService(
+                meetingRepository, projectFileRepository, projectFileService, factory);
+    }
+
+    @AfterEach
+    void resetLanguage() {
+        LangText.reset();
+    }
+
+    private void switchToEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+    }
+
+    private static ProjectFile folder(String name) {
+        ProjectFile f = new ProjectFile();
+        f.setId(100L);
+        f.setName(name);
+        f.setIsFolder(true);
+        return f;
+    }
+
+    private static ProjectFile file(String name) {
+        ProjectFile f = new ProjectFile();
+        f.setId(200L);
+        f.setName(name);
+        f.setIsFolder(false);
+        f.setFilePath("p/" + name);
+        return f;
+    }
+
+    private void givenExistingFolder(String name) {
+        when(projectFileRepository.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(
+                eq(1L), isNull(), eq(name))).thenReturn(Optional.of(folder(name)));
+    }
+
+    private MeetingRecording transcribedMeeting() {
+        MeetingRecording m = new MeetingRecording();
+        m.setId(9L);
+        m.setProjectId(1L);
+        m.setTitle("尽调访谈");
+        m.setStatus(MeetingRecording.STATUS_TRANSCRIBED);
+        m.setTranscriptJson(TRANSCRIPT_JSON);
+        when(meetingRepository.findById(9L)).thenReturn(Optional.of(m));
+        return m;
+    }
+
+    @Test
+    @DisplayName("英文界面遇到存量中文文件夹：沿用它，绝不另建一个")
+    void englishReusesExistingChineseFolder() {
+        transcribedMeeting();
+        givenExistingFolder(MeetingRecordingService.FOLDER_NAME);
+        switchToEnglish();
+
+        MeetingRecordingService.ExportResult res = service.exportTranscript(9L, 10001L);
+
+        assertEquals(MeetingRecordingService.FOLDER_NAME, res.folderName(),
+                "回给界面的必须是实际目录名，否则「见 X 文件夹」会指错地方");
+        verify(projectFileService, never()).createFolder(anyLong(), isNull(), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("中文界面遇到英文安装留下的文件夹：同样沿用")
+    void chineseReusesExistingEnglishFolder() {
+        transcribedMeeting();
+        givenExistingFolder(MeetingRecordingService.FOLDER_NAME_EN);
+
+        MeetingRecordingService.ExportResult res = service.exportTranscript(9L, 10001L);
+
+        assertEquals(MeetingRecordingService.FOLDER_NAME_EN, res.folderName());
+        verify(projectFileService, never()).createFolder(anyLong(), isNull(), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("两个名字都没有：按当前语言新建，导出文件名也跟着语言")
+    void createsFolderInCurrentLanguage() {
+        transcribedMeeting();
+        switchToEnglish();
+
+        MeetingRecordingService.ExportResult res = service.exportTranscript(9L, 10001L);
+
+        assertEquals(MeetingRecordingService.FOLDER_NAME_EN, res.folderName());
+        verify(projectFileService).createFolder(eq(1L), isNull(),
+                eq(MeetingRecordingService.FOLDER_NAME_EN), eq(10001L));
+        assertTrue(res.file().getName().startsWith("Transcript_"),
+                "英文下导出文件名不该是「转写稿_」：" + res.file().getName());
+    }
+
+    @Test
+    @DisplayName("中文（默认）下新建与命名逐字不变")
+    void chineseDefaultUnchanged() {
+        transcribedMeeting();
+
+        MeetingRecordingService.ExportResult res = service.exportTranscript(9L, 10001L);
+
+        assertEquals(MeetingRecordingService.FOLDER_NAME, res.folderName());
+        assertTrue(res.file().getName().startsWith("转写稿_"), res.file().getName());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingRecordingServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingRecordingServiceTest.java
@@ -3,8 +3,11 @@ package com.checkba.service.meeting;
 import com.checkba.model.entity.MeetingRecording;
 import com.checkba.repository.MeetingRecordingRepository;
 import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
 import com.checkba.service.ProjectFileService;
 import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/** 会议服务的纯逻辑面：说话人改名映射、转写稿渲染、kick-off prompt 契约。 */
+/** 会议服务的纯逻辑面：说话人改名映射、转写稿渲染、kick-off prompt 契约（含英文侧）。 */
 class MeetingRecordingServiceTest {
 
     private MeetingRecordingRepository meetingRepository;
@@ -35,6 +38,18 @@ class MeetingRecordingServiceTest {
         service = new MeetingRecordingService(
                 meetingRepository, mock(ProjectFileRepository.class),
                 mock(ProjectFileService.class), mock(StorageServiceFactory.class));
+    }
+
+    /** LangText 是静态指针，登记过就必须清掉，否则污染后面的测试类。 */
+    @AfterEach
+    void resetLanguage() {
+        LangText.reset();
+    }
+
+    private void switchToEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
     }
 
     private MeetingRecording transcribedMeeting() {
@@ -107,5 +122,58 @@ class MeetingRecordingServiceTest {
         assertEquals("张律师", names.get("1"));
         assertEquals("张律师", service.displaySpeaker(names, "1"));
         assertEquals("说话人2", service.displaySpeaker(names, "2"));
+    }
+
+    // ==================== 英文应用语言 ====================
+    // 这几条是「英文版会议录音真的能用」的守卫。默认名与文件夹名不落库、按当前语言取，
+    // 所以只能在这里锁；漏了就会退回「面板双语了、导出与 AI 侧还是中文」。
+
+    @Test
+    @DisplayName("英文下转写稿渲染用 Speaker N 与半角冒号")
+    void renderInEnglish() {
+        switchToEnglish();
+        String text = service.renderTranscriptText(transcribedMeeting());
+        assertTrue(text.contains("[01:01] Speaker 1: 我方认为价款应分期支付"),
+                "说话人默认名与分隔符要跟界面语言走，转写内容本身是用户数据不动：" + text);
+        assertFalse(text.contains("说话人"));
+        assertFalse(text.contains("："), "英文行里不该出现全角冒号");
+    }
+
+    @Test
+    @DisplayName("英文下改过名的说话人仍用用户改的名字（改名是用户数据，不受语言影响）")
+    void renamedSpeakersSurviveEnglish() {
+        switchToEnglish();
+        MeetingRecording m = transcribedMeeting();
+        m.setSpeakerNames("{\"1\":\"张律师\"}");
+        Map<String, String> names = service.speakerDisplayNames(m);
+        assertEquals("张律师", service.displaySpeaker(names, "1"));
+        assertEquals("Speaker 2", service.displaySpeaker(names, "2"));
+    }
+
+    /**
+     * 最要紧的一条：kick-off prompt 的开头必须落在 skill.yml 的 triggers_en 里。
+     * 不成立的话英文用户点「生成会议纪要」命不中 skill——没有 prompt.en.md、
+     * 没有 meeting_get_transcript / write_docx 白名单，按钮形同虚设。
+     * triggers_en 第一条与这里的开头是同一个契约，改一处要改两处（BuiltinSkillsTest 从 yml 侧锁）。
+     */
+    @Test
+    @DisplayName("英文下 kick-off prompt 以英文触发词 meeting minutes 开头")
+    void minutesPromptCarriesEnglishTriggerWord() {
+        switchToEnglish();
+        String prompt = service.buildMinutesKickoffPrompt(transcribedMeeting());
+        assertTrue(prompt.toLowerCase().startsWith("meeting minutes"),
+                "英文触发词必须在 prompt 开头，否则 SkillRouter 命不中：" + prompt);
+        assertTrue(prompt.contains("meetingId=9"));
+        assertTrue(prompt.contains("meeting_get_transcript"));
+        assertTrue(prompt.contains("Speaker 1, Speaker 2"));
+        assertFalse(prompt.contains("请先"), "英文 prompt 不该混中文句子");
+    }
+
+    @Test
+    @DisplayName("录音文件夹名按语言二选一，两个名字都是正名")
+    void folderNameFollowsLanguage() {
+        assertEquals("会议录音", MeetingRecordingService.folderName());
+        switchToEnglish();
+        assertEquals("Meeting Recordings", MeetingRecordingService.folderName());
     }
 }

--- a/desktop/main/services/model-manager.js
+++ b/desktop/main/services/model-manager.js
@@ -35,6 +35,7 @@ function dirSize(root) {
 }
 
 const { pysvcPath } = require('./pysvc-runtime')
+const { t } = require('../app-language')
 
 function pyBin(resourcesPath) {
   return process.platform === 'win32'
@@ -43,13 +44,18 @@ function pyBin(resourcesPath) {
 }
 
 // 组件注册表：MinerU pipeline 模型 + Kokoro 语音模型 + 本地转写模型
+//
+// name 写成 { zh, en } 对，由 status() 用 app-language 的 t() 取值——**必须在 status() 里取，
+// 不能在这张表上取**：模块加载发生在渲染层把语言同步过来之前，那样会把语言冻死在首启猜测上。
+// 这个 name 一路出现在 admin「组件管理」列表、下载/删除确认文案里，英文界面下不能是中文。
+//
 // sizeHint 只写数值与单位、**不带任何语言**（不要写「约」）：它会被塞进
 // admin 的下载/删除确认文案与语音面板的按钮里，那些串是双语的，
 // 「约」写在这里就会原样出现在英文界面上。修饰词归各处的 i18n 串。
 const COMPONENTS = [
   {
     id: 'mineru-models',
-    name: '文档解析模型（MinerU）',
+    name: { zh: '文档解析模型（MinerU）', en: 'Document Parsing Model (MinerU)' },
     sizeHint: '3 GB',
     estBytes: 3.0 * 1024 * 1024 * 1024, // 整体进度分母（估计值，进度封顶 99% 直到进程成功退出）
     // 模型根目录（相对 dataDir）
@@ -77,7 +83,7 @@ const COMPONENTS = [
   },
   {
     id: 'kokoro-models',
-    name: '语音合成模型（Kokoro）',
+    name: { zh: '语音合成模型（Kokoro）', en: 'Speech Synthesis Model (Kokoro)' },
     sizeHint: '300 MB',
     estBytes: 300 * 1024 * 1024,
     dir: (ctx) => path.join(ctx.dataDir, 'models', 'kokoro'),
@@ -106,7 +112,7 @@ const COMPONENTS = [
   },
   {
     id: 'asr-models',
-    name: '本地转写模型（Whisper medium）',
+    name: { zh: '本地转写模型（Whisper medium）', en: 'On-device Transcription Model (Whisper medium)' },
     sizeHint: '1.5 GB',
     estBytes: 1.5 * 1024 * 1024 * 1024,
     dir: (ctx) => path.join(ctx.dataDir, 'models', 'asr'),
@@ -173,7 +179,8 @@ class ModelManager {
   status() {
     return COMPONENTS.map((c) => ({
       id: c.id,
-      name: c.name,
+      // 每次调用都重新取语言：切语言不重启主进程，缓存下来会一直报旧语言的名字
+      name: t(c.name),
       sizeHint: c.sizeHint,
       state: this.stateOf(c.id),
       message: this.errors.get(c.id) || null

--- a/frontend/src/components/MeetingRecordingPanel.vue
+++ b/frontend/src/components/MeetingRecordingPanel.vue
@@ -39,7 +39,7 @@
         </template>
         <template v-else>
           <view class="mr-btn primary" v-if="canDownloadModel" @tap="onDownloadAsrModel">
-            {{ $t('meeting.downloadModel', { size: modelSizeText }) }}
+            {{ $t('meeting.downloadModel', { size: modelSizeHint }) }}
           </view>
           <view class="mr-btn secondary" @tap="onRecheckLocalAsr">{{ $t('meeting.recheck') }}</view>
         </template>
@@ -343,9 +343,10 @@ export default {
       modelPercent: 0,
       // 桌面壳报的体积（model-manager 的 sizeHint，形如 '1.5 GB'——**不带语言**，
       // 「约 / about」归 meeting.downloadModel 这类双语串，别把它加回 descriptor 里去：
-      // 那个值同时喂给 admin 的下载/删除确认文案，中文修饰词会原样出现在英文界面上）；
-      // 空 = 还没问到，界面回落到 meeting.modelSizeDefault
-      modelSizeHint: '',
+      // 那个值同时喂给 admin 的下载/删除确认文案，中文修饰词会原样出现在英文界面上）。
+      // 初值就写死同一个中立字面量（与 EasyVoicePane 同形）：浏览器里没有 host.model
+      // 问不到值，而这个数不需要翻译，没必要为它建一个 locale 键。
+      modelSizeHint: '1.5 GB',
       // 用户点过「录音不出本机」但没成——下面那块引导只在这之后出现，
       // 平台档用户不该每次开面板都看见一块「模型没下载」
       localGateOpen: false,
@@ -404,9 +405,6 @@ export default {
     },
     modelDownloading() {
       return this.modelState === 'downloading'
-    },
-    modelSizeText() {
-      return this.modelSizeHint || this.$t('meeting.modelSizeDefault')
     },
     tierText() {
       if (this.asrProvider === 'local') return this.$t('meeting.tierLocal')
@@ -702,9 +700,12 @@ export default {
     },
     async onExport(m) {
       try {
-        const file = await exportMeetingTranscript(m.id)
-        const name = (file && file.name) || this.$t('meeting.transcriptFallbackName')
-        uni.showToast({ title: this.$t('meeting.exported', { name }), icon: 'none' })
+        // 回的是 {file, folderName}：文件夹名必须用后端给的实际名字，不能按当前语言自己拼——
+        // 它按建档时的语言二选一，存量项目里很可能是另一种（见后端 FOLDER_NAME 注释）
+        const res = await exportMeetingTranscript(m.id)
+        const name = (res && res.file && res.file.name) || this.$t('meeting.transcriptFallbackName')
+        const folder = (res && res.folderName) || ''
+        uni.showToast({ title: this.$t('meeting.exported', { name, folder }), icon: 'none' })
       } catch (e) {
         uni.showToast({ title: this.$t('meeting.exportFailed', { message: (e && e.message) || e }), icon: 'none' })
       }

--- a/frontend/src/locales/en-US/meeting.js
+++ b/frontend/src/locales/en-US/meeting.js
@@ -29,10 +29,9 @@ export default {
   // ---- On-device transcription model (downloadable in place) ----
   modelDownloading: 'Downloading model {percent}%',
   cancelDownload: 'Cancel Download',
-  downloadModel: 'Download Model ({size})',
-  // The desktop shell overrides this with the size the main process reports; browsers have no
-  // host.model, so this is the fallback.
-  modelSizeDefault: 'about 1.5GB',
+  // The "~" belongs here, not in {size}: {size} is model-manager's sizeHint (like "1.5 GB",
+  // language-neutral) and the same value also feeds the admin confirm copy.
+  downloadModel: 'Download Model (~{size})',
   recheck: 'Check Again',
   downloadStartFailed: 'Could not start the download. Try again later.',
 
@@ -99,10 +98,9 @@ export default {
   sendingToAi: 'Handing off to AI...',
   generateMinutesFailed: 'Could not generate minutes: {message}',
   exportTranscript: 'Export Transcript',
-  // The folder name stays Chinese on purpose: MeetingRecordingService.FOLDER_NAME is a fixed
-  // backend constant (localizing it would fork one folder into two and orphan existing files),
-  // so this is the name the user actually sees in Explorer. Do not "translate" it.
-  exported: 'Exported: {name} (see the "会议录音" folder in Explorer)',
+  // {folder} is the ACTUAL folder name reported by the backend - never hardcode it: the folder is
+  // named in whichever language created it, so a hardcoded name points somewhere wrong half the time
+  exported: 'Exported: {name} (see the "{folder}" folder in Explorer)',
   transcriptFallbackName: 'transcript',
   exportFailed: 'Could not export: {message}',
 

--- a/frontend/src/locales/zh-CN/meeting.js
+++ b/frontend/src/locales/zh-CN/meeting.js
@@ -33,9 +33,9 @@ export default {
   // ---- 本机转写模型（就地下载） ----
   modelDownloading: '正在下载模型 {percent}%',
   cancelDownload: '取消下载',
-  downloadModel: '下载模型（{size}）',
-  // 桌面壳会用主进程报的 sizeHint 覆盖这一句；浏览器里没有 host.model，用这个兜底
-  modelSizeDefault: '约 1.5GB',
+  // 「约」在这里、不在 {size} 里：{size} 是 model-manager 的 sizeHint（形如 '1.5 GB'，
+  // 语言中立），同一个值还要喂给 admin 的确认文案，修饰词写进那边会漏到英文界面上
+  downloadModel: '下载模型（约 {size}）',
   recheck: '重新检测',
   downloadStartFailed: '开始下载失败，稍后重试',
 
@@ -102,7 +102,9 @@ export default {
   sendingToAi: '正在交给 AI...',
   generateMinutesFailed: '生成纪要失败：{message}',
   exportTranscript: '导出转写稿',
-  exported: '已导出：{name}（见「会议录音」文件夹）',
+  // {folder} 是后端回的**实际**文件夹名，不要写死：那个文件夹按建档时的界面语言叫
+  // 「会议录音」或 Meeting Recordings，写死一个必然有一种语境下指错地方
+  exported: '已导出：{name}（见「{folder}」文件夹）',
   transcriptFallbackName: '转写稿',
   exportFailed: '导出失败：{message}',
 


### PR DESCRIPTION
接 #391 的三处遗留。上手核的时候发现一个更要紧的、不在那三条里的问题，一并修了。

## 先说那个更要紧的：英文版「生成会议纪要」按钮实际是坏的

`meeting-recorder/skill.yml` 没有 `languages` 字段，而**缺省（空）= 只在 zh-CN 可用**（`SkillRegistry.supportsCurrentLanguage`）。但左栏入口读的是 `/api/skills/list`，那条路**不过语言过滤**（`getSkills()` 裸返回）。两处判据不同，于是英文版下：

- 面板照样出现，能录音、能转写（所以 #391 不是白做）；
- 但 `SkillRouter.match` 永远命不中 `meeting-recorder`——拿不到 prompt、拿不到 `meeting_get_transcript` / `write_docx` 白名单。**按钮点下去看着有反应，产出不是纪要。**

修法照 `litigation-visual` 已经建好的形制（不新造机制）：`languages` 声明 `en-US` + `name_en` + `triggers_en` + `output_en` + 新增 `prompt.en.md`（与中文版同结构、同红线：忠于原文、可疑数字进「待核实」、不静默重分配说话人、禁 emoji）。

`buildMinutesKickoffPrompt` 也必须跟着翻——**它的开头就是触发词**。英文分支现在以 `"Meeting minutes generation task."` 开头，与 `triggers_en` 第一条是同一个契约，两端各有一条测试锁一半（服务侧断言 prompt 以它开头，skill 侧断言这句话能命中）。

## 原来那三处

**① 桌面壳组件名**（`desktop/main/services/model-manager.js`）
`name` 改成 `{ zh, en }`，由 `status()` 用 `app-language` 的 `t()` 取值。**必须在 `status()` 里取而不是在表上取**：模块加载早于渲染层同步语言，在表上取会把语言冻死在首启猜测上。这个 name 一路出现在 admin「组件管理」列表与下载/删除确认文案里。

`sizeHint` 已被 #396 改成语言中立（`1.5 GB`），本次把「约 / ~」挪进 `meeting.downloadModel`（对齐 `panels.evDownloadModel` 的既有写法），顺手删掉 `modelSizeDefault` 与 `modelSizeText`——一个中立数字不需要 locale 键，初值直接写 `'1.5 GB'`（与 EasyVoicePane 同形）。修之前这两处是不一致的：桌面上显示「下载模型（1.5 GB）」（漏了「约」），浏览器里显示「下载模型（约 1.5GB）」。

**② 导出与 AI 侧的中文**
说话人默认名（说话人N / Speaker N）、转写稿分隔符（全角 / 半角冒号）、导出文件名（`转写稿_` / `Transcript_`）、docx 标题、新建会议的默认标题，以及 `MeetingTools` 的全部返回文本——那些小标题、状态词、空态指引是**喂给模型的脚手架**，英文会话里塞中文等于让模型跨语言理解自己的输入格式，还会漏进过程卡。

转写内容、会议标题、用户改过的说话人名**一律原样不动**，那是用户数据（有测试锁）。

**③ 导出文件夹名**
不再在 en 文案里硬留中文名。「会议录音」与「Meeting Recordings」现在是同一个目录的**两个正名**：建档按界面语言取一个，**查找两个都认**。少了跨语言查找那一步，中文安装切到英文会另建一个同用途目录、旧录音像丢了——这类事故不报错，只让用户以为文件没了。

导出端点因此回 `{file, folderName}` 而不是裸 `ProjectFile`，界面用后端给的**实际**名字，不按自己的语言拼（只有一个调用方，contract 改动面很小）。

## 顺带

这条链路上其余用户可见的 `IllegalArgumentException` 也双语化了（会议不存在 / 录音尚未结束 / 说话人名称格式非法 / 未配置凭证）。controller 的 `"未登录"` **保持纯中文不动**——那是 4010 的 equals 契约，不是文案。

## 验证

| 项 | 结果 |
|---|---|
| `mvn test` 全量 | ✓ 1836 通过，0 失败 |
| `npm run check:locales` | ✓ 20 个命名空间 |
| `npm run check:emits` | ✓ 85 个 .vue |
| `npm run build:h5` | ✓ DONE |

新增测试覆盖（英文侧此前完全没有覆盖，全靠 LangText 未登记时回退中文才「看起来没事」）：
- 英文侧转写稿渲染、说话人默认名、改过名的不受语言影响；
- 英文 kick-off prompt 以英文触发词开头、且不混中文句子；
- skill 在 en-US 下 `isAvailable`，且 `SkillRouter` 能被那句开头命中；
- `MeetingTools` 三种返回态的语言（正常/未完成转写/空列表），并断言转写内容原样；
- **文件夹跨语言复用四种组合**：英文遇存量中文目录（沿用，`verify(never()).createFolder`）/ 中文遇英文目录 / 两者皆无按当前语言建 / 中文默认逐字不变。

两处不是「只看代码就算过」的：
- 桌面主进程用桩件（拦 `require('electron')`）**真调了一次 `status()`**，切 zh-CN/en-US 组件名跟着变，英文下 name/sizeHint 无中文残留。
- `meeting-e2e` 的两处断言（rail `title="会议录音"`、返回含「未配置转写服务凭证」）都落在 zh 侧字面量上，逐字未动，不会因本 PR 变红。

## 一处明知而未做

`@ToolMeta(displayName = "列出会议录音")` 这层仍是中文。过程卡上的工具名走前端 `toolDisplayNames.js`（那里已有双语映射），`@ToolMeta` 是后端侧标签；全仓所有工具的 displayName 都是中文，只改会议这两个会变成不一致。属于独立的全局约定问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)