### PR TITLE
fix(h5): 未登录访问网页版不再无限刷新

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -370,6 +370,13 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
    （浏览器端还跳登录页）。账户未连接、未分配额度、付费项未购买全是**业务错误不是掉线**，
    必须走 code=1 信封、绝不带 4010。
    护栏：`AccountServiceTest.accountMessagesDoNotLookLikeAuthErrors`、两个 market 测试里的 `assertNotMistakenForLogout`。
+   **「跳登录页」这条链自己会喂自己**（2026-08-17 现网事故，addin.aiworkdeck.com 打开即整页无限刷新）：
+   `App.vue` 的导航拦截器给**每一次跳转**补一条 `ui.nav` 埋点，而 `/api/telemetry/event` 同样需要会话——
+   4010 → reLaunch 登录页 → 埋点 → 又 4010 → 又跳，8 秒 100 次导航。两道闸缺一不可：
+   `utils/telemetryClient.js` 的 track 在**浏览器态未登录时一条都不发**（桌面 local-mode 免登录恒可发），
+   `services/api.js` 的 4010 分支在**已经停在登录页时只清会话不再跳**。
+   护栏 `frontend/tests/auth-redirect`。往登录前的页面（launch/login/wizard）新加任何需要会话的请求，
+   或给导航拦截器再挂 fire-and-forget 调用，都要回看这条。
 2. **local-mode 与团队服务器模式行为差异是一整套，不是一个开关**。`EntitlementService` 是**按本机**的
    （数据源是 `~/.aiworkdeck` 的 license/account 状态，没有 userId 维度），团队服务器上权益恒为空集。
    因此这些地方必须「非 local-mode 一律不限制 / 恒为正式版」：`LicenseService.status/activate/deactivate`、

--- a/deploy/cloud/nginx-addin.conf.example
+++ b/deploy/cloud/nginx-addin.conf.example
@@ -93,6 +93,18 @@ server {
         types { } default_type application/octet-stream;
     }
 
+    # ---- 入口文档永不缓存 ----
+    # assets 是 hash 名可以长缓存，index.html 一旦被浏览器缓存住，用户就会一直跑在
+    # 旧包上：2026-08-17 实测过一次——旧包的 bug 是「未登录整页无限刷新」，前端修好
+    # 并铺开之后，本地缓存里的老 index.html 仍把人钉在旧包上继续刷。
+    # 本 location 内出现 add_header 即丢弃继承的 COOP/COEP，必须原样补回，
+    # 否则 LOWA 编辑器要的 SharedArrayBuffer 会失效。
+    location = /index.html {
+        add_header Cross-Origin-Opener-Policy   same-origin  always;
+        add_header Cross-Origin-Embedder-Policy require-corp always;
+        add_header Cache-Control "no-cache" always;
+    }
+
     # ---- SPA 回退 ----
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "test:feedback-e2e": "node tests/feedback-e2e/run.mjs",
     "test:meeting-e2e": "node tests/meeting-e2e/run.mjs",
     "test:project-home": "node --test tests/project-home/*.test.mjs",
+    "test:auth-redirect": "node --test tests/auth-redirect/*.test.mjs",
     "test:commands": "node --test tests/commands/commands.test.mjs"
   },
   "dependencies": {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -155,6 +155,21 @@ export function getApiBaseUrl() {
   return cachedApiBaseUrl;
 }
 
+// 当前是否已经停在登录页。4010 的兜底动作是 reLaunch 登录页，而 reLaunch 会重挂
+// 登录页 → onLoad 再打一轮请求；只要那一轮里还有需要会话的接口，就又是一次 4010，
+// 「跳登录页」本身成了产生 4010 的原因，浏览器端表现为整页无限刷新。
+// 已经在登录页时清掉会话就够了，不必再跳一次。
+function isOnLoginPage() {
+  try {
+    const pages = typeof getCurrentPages === 'function' ? getCurrentPages() : [];
+    const current = pages.length ? pages[pages.length - 1] : null;
+    const route = (current && (current.route || (current.$page && current.$page.route))) || '';
+    return route.indexOf('pages/login/login') !== -1;
+  } catch (e) {
+    return false;
+  }
+}
+
 function request(options) {
   const baseUrl = getApiBaseUrl();
   const url = options.url.startsWith('http')
@@ -287,6 +302,10 @@ function request(options) {
                   icon: 'none',
                   duration: 2000
                 });
+              } else if (isOnLoginPage()) {
+                // 已经在登录页：会话清掉即可，再 reLaunch 一次只会重挂本页并重跑
+                // onLoad 的请求，构成自激循环（见 isOnLoginPage 上方注释）
+                console.warn('未登录，且已在登录页，跳过跳转');
               } else {
                 console.warn('检测到未登录状态，准备跳转到登录页');
                 uni.reLaunch({

--- a/frontend/src/utils/telemetryClient.js
+++ b/frontend/src/utils/telemetryClient.js
@@ -1,4 +1,6 @@
 import { logTelemetryEvent } from '@/services/api.js'
+import { getSessionId } from '@/utils/auth.js'
+import { isDesktopHost } from '@/services/host.js'
 
 /**
  * 产品埋点前端入口（设计见 docs/ANALYTICS_TELEMETRY_DESIGN.md）。
@@ -9,6 +11,12 @@ import { logTelemetryEvent } from '@/services/api.js'
  */
 export function track(eventName, attrs) {
   try {
+    // 浏览器态未登录时一条都不发。/api/telemetry/event 本来就要会话，未登录必回
+    // 4010，而 request() 收到 4010 会 reLaunch 登录页，reLaunch 又被 App.vue 的
+    // 导航拦截器再记一条 ui.nav——「跳转 → 埋点 → 4010 → 跳转」自激成死循环，
+    // 浏览器端就是整页无限刷新（addin.aiworkdeck.com 实测）。桌面 local-mode
+    // 免登录，恒可发。
+    if (!isDesktopHost() && !getSessionId()) return
     logTelemetryEvent(eventName, attrs || {}).catch(() => {})
   } catch (e) {
     // 静默

--- a/frontend/tests/auth-redirect/no-login-loop.test.mjs
+++ b/frontend/tests/auth-redirect/no-login-loop.test.mjs
@@ -1,0 +1,34 @@
+// 「未登录 → 跳登录页」这条链在浏览器部署里曾自激成无限刷新（addin.aiworkdeck.com 实测：
+// 8 秒 100 次整页导航、196 次 API 请求）。环路是：
+//   任一需要会话的请求回 4010 → request() reLaunch 登录页
+//   → App.vue 的导航拦截器给每次跳转补一条 ui.nav 埋点
+//   → /api/telemetry/event 同样需要会话 → 又是 4010 → 又跳一次 …
+// 两道闸各堵一头，缺一头就还能转起来；services/api.js 与 utils/telemetryClient.js
+// 引用了 uni.* 与 @/ 别名、node 无法 import，只能做源码级契约断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const API = readFileSync(new URL('../../src/services/api.js', import.meta.url), 'utf8')
+const TELEMETRY = readFileSync(new URL('../../src/utils/telemetryClient.js', import.meta.url), 'utf8')
+const APP = readFileSync(new URL('../../src/App.vue', import.meta.url), 'utf8')
+
+test('闸一：浏览器态未登录不发埋点（埋点本身需要会话，会回 4010）', () => {
+  assert.match(TELEMETRY, /isDesktopHost/, 'track 要能识别桌面 local-mode')
+  assert.match(TELEMETRY, /getSessionId/, 'track 要能识别未登录')
+  assert.match(TELEMETRY, /if\s*\(!isDesktopHost\(\)\s*&&\s*!getSessionId\(\)\)\s*return/,
+    '未登录且非桌面时必须直接 return，不许发请求')
+})
+
+test('闸二：已经在登录页时 4010 不再 reLaunch 登录页', () => {
+  assert.match(API, /function isOnLoginPage\(/, '需要「当前是否已在登录页」的判定')
+  assert.match(API, /getCurrentPages/, '判定要读页面栈而不是猜')
+  // 跳登录页只许出现在 isOnLoginPage() 为假的那条分支里
+  assert.match(API,
+    /else if \(isOnLoginPage\(\)\) \{[\s\S]{0,600}?\} else \{[\s\S]{0,300}?uni\.reLaunch\(\{[\s\S]{0,80}?'\/pages\/login\/login'/,
+    'reLaunch 登录页必须落在 isOnLoginPage 为假的分支')
+})
+
+test('埋点仍挂在导航拦截器上（环路的另一半，改动时要一并回看本文件）', () => {
+  assert.match(APP, /track\('ui\.nav'/, 'ui.nav 埋点仍由导航拦截器发出')
+})


### PR DESCRIPTION
## 现象

浏览器打开 https://addin.aiworkdeck.com 后整页无限刷新，控制台刷屏 `业务错误 {code: 4010}`。

## 根因

「未登录 → 跳登录页」这条链自己喂自己，与向导状态、与具体页面都无关：

1. 任一需要会话的请求回 4010 → `services/api.js` 的 `request()` `reLaunch` 登录页；
2. `App.vue` 的导航拦截器给**每一次跳转**补一条 `ui.nav` 埋点；
3. `/api/telemetry/event` 同样需要会话 → 又是 4010 → 回到第 1 步。

本地用当前 master 构建 h5 + 反代线上后端复现：8 秒内 100 次整页导航、196 次 API 请求，不收敛。把服务端 `initialized` 顶成 true 也照样转——曾以为是「云端向导未初始化」引起，实测证伪。

## 改动

- `utils/telemetryClient.js`：浏览器态未登录直接 return。埋点本来就要会话，发出去只会换回一个 4010；桌面 local-mode 免登录，恒可发。
- `services/api.js`：4010 时若当前已停在登录页，只清会话不再跳。`reLaunch` 会重挂登录页并重跑 `onLoad` 的请求，是同一个环路的另一半。

## 验证

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 匿名打开 | 100 次导航 / 196 次请求，不停 | 5 次导航 / 3 次请求，静止 |
| 会话过期 | 同上 | 5 次导航 / 7 次请求，静止 |

回归测试 `frontend/tests/auth-redirect`（`npm run test:auth-redirect`），去掉任一道闸即判红。另跑通 check:nav / check:emits / check:locales / test:project-home。

## 未包含

线上 `addin.aiworkdeck.com` 跑的还是 8-07 那份构建产物，本 PR 不改变现网行为，需要单独重新部署 h5（后端 jar 同期）。云端 `system.wizard.completed` 仍是 `false`，匿名访客会落在首启向导页而不是登录页——那是另一条待办。

🤖 Generated with [Claude Code](https://claude.com/claude-code)