### PR TITLE
fix(e2e): Electron 驱动三件套收进共享模块，并把 meeting-e2e 从整轮红修回全绿

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -107,7 +107,9 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   正解三件套（desktop-e2e 已落）：① `detached: true` 起进程组 + `process.kill(-pid)` 整组收（并挂 `process.on('exit'/'SIGINT')`）；
   ② 每轮现挑一个空闲端口（`DESKTOP_E2E_CDP_PORT` 可覆盖），别写死 9333——维护者常年多开，并行会话必撞；
   ③ 连之前用 `lsof` 核一遍持端口的 pid 在不在自己那棵树里，不是就当场报死。
-  **app-e2e / lowa-e2e / feedback-e2e / meeting-e2e 同样是 spawn npx + 写死端口，还没上这三件套。**
+  这三件套 + 输入加固已收进 **`frontend/tests/_lib/electron-cdp.mjs`**，desktop / feedback / meeting
+  三套共用（以前各抄一份，同一个坑要踩三次）。**app-e2e / lowa-e2e 不受影响**——它们用
+  `puppeteer.launch()` 自己起无头 Chrome，进程由 puppeteer 管，也自带下面那三个开关。
 - **"点了没反应"先分清是输入通道坏了还是界面坏了**：`page.mouse.click()` 之后在 `window` 捕获期录
   pointerdown/mousedown/mouseup/click，**一个都没有 = 输入通道的问题**，同坐标重试没有意义。
   这一档故障的特征很干净也很反直觉：**`mouseMoved` 照常送达，`mousePressed`/`mouseReleased`/`dispatchKeyEvent`
@@ -121,6 +123,21 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   恢复不了就报死并在错误里点明"是输入通道坏了不是界面问题"。
   **不要退回"页面内 `dispatchEvent` 伪造点击"兜底**（#390 曾这么干，已撤）——桌面端就这一条真实输入的覆盖，
   换成假的之后这一步就再也挡不住真的界面回归了。
+  另加了两层**对症但未经证伪的**加固（`_lib/electron-cdp.mjs`）：起 Electron 时带
+  `--disable-backgrounding-occluded-windows` / `--disable-renderer-backgrounding` /
+  `--disable-background-timer-throttling`（puppeteer.launch 自带，手动 spawn 再 connect 就没有），
+  连上页面后开 `Emulation.setFocusEmulationEnabled`（CDP 专为"自动化非前台页面"留的开关）。
+  选它们是因为**按下/按键跟焦点绑定、而 mouseMoved 不绑定**，正好对上故障特征；但本机无法按需
+  复现该故障，也没能造出遮挡来 A/B 验证开关是否真的改变了行为——**所以这两层是有依据的加固，不是已验证的修复**。
+- **meeting-e2e 曾在 master 上整轮红（10/10），四个坑叠在一起**（2026-08-17 修复）：
+  ① 用的还是"写 `checkba_last_project_id` → reload 直达工作台"的老配方，而 2026-08 起启动一律落
+  项目列表页，于是第一步就卡死——改成 desktop-e2e 同款"轮询到真进工作台为止，在列表上就点卡片"；
+  ② 拿「资源管理器」当工作台就绪判据，但**左栏面板是记住上次的**，上一轮把它切到「会议录音」之后
+  下一轮永远等不到这四个字——改用 `.page-project-overview` 这种与面板无关的根节点；
+  ③ rail 按钮是**开关**，面板已经开着时再点一下正好关上——改成"确保打开"而不是"点一下"；
+  ④ **没钉死界面语言**，Electron 常带 `--lang=en-GB`，rail 会变成 "Meeting Recording"，
+  中文选择器全失配（现象很像"skill 没启用"，极易误判）——补上 `awd_app_language=zh-CN`。
+  ②③是同一类：**上一轮留下的状态破坏下一轮**，写这类断言前先问"上一轮跑完留下了什么"。
 - 分支保护拦 gh pr merge 时权宜 = 用户网页点 Bypass rules and merge（白名单未配成）。
 - `docs/` 在 .gitignore，入库要 `git add -f`。
 - **改跨类 `public static final String` 常量的值必须 `mvn clean test`**：这类常量在编译期被内联进

--- a/frontend/tests/_lib/electron-cdp.mjs
+++ b/frontend/tests/_lib/electron-cdp.mjs
@@ -1,0 +1,108 @@
+// 起一个带 CDP 的 dev Electron，再用 puppeteer 连上去 —— desktop / feedback / meeting
+// 三套 e2e 都要这一段。以前三个文件各抄一份，于是同一个坑得踩三次：2026-08-17
+// desktop-e2e「新建 Word 文档」间歇性红查了大半天，根因就在这段里（详见
+// .claude/agents/eng-infra.md 的两条）。收在这里，改一次三套都受益。
+//
+// 这段解决四件事，缺一件就会以"点了没反应"的形态间歇性红：
+//   ① 端口现挑——写死会撞上并行会话，也会撞上自己上一轮没死透的残留；
+//   ② 整棵进程树一起收——spawn 的是 npx，Electron 是**孙子进程**，kill(npx) 打不到它；
+//   ③ 连之前核身份——确认应答端口的就是自己刚起的那棵树，不是别人的窗口；
+//   ④ 连上之后钉稳输入通道——见 INPUT_FLAGS 与 hardenPageInput 的注释。
+
+import { spawn, execSync } from 'node:child_process'
+
+// 驱动一个"不在最前面"的窗口时，必须关掉 Chromium 的后台降级。被遮挡/非活动的
+// 窗口一旦被降级，**跟焦点绑定的输入**（mousePressed / mouseReleased / keyDown）
+// 会被静默丢弃，而按命中测试投递的 mouseMoved 不受影响——现象就是"鼠标移动送得到、
+// 点击和按键送不到，页面其余一切正常"。puppeteer.launch() 自带这三个开关（所以
+// app-e2e / lowa-e2e 那种自己 launch 无头 Chrome 的套件天然没这问题），而我们是手动
+// spawn Electron 再 connect，不显式加就没有。
+export const INPUT_FLAGS = [
+  '--disable-backgrounding-occluded-windows',
+  '--disable-renderer-backgrounding',
+  '--disable-background-timer-throttling',
+]
+
+export const portFree = (p) => {
+  try { execSync('lsof -nP -iTCP:' + p + ' -sTCP:LISTEN -t', { stdio: 'pipe' }); return false }
+  catch (e) { return true } // lsof 非零退出 = 没人在听
+}
+
+// 从 from 起找第一个空闲端口。envName 给一个显式覆盖口，方便手动错开。
+export const pickCdpPort = (envName, from) => {
+  const forced = Number(process.env[envName])
+  if (forced) return forced
+  for (let p = from; p < from + 40; p++) if (portFree(p)) return p
+  throw new Error('CDP 端口 ' + from + '-' + (from + 39) + ' 全被占，挑不出空闲的')
+}
+
+// detached 让它自成进程组，收尾时 kill(-pid) 能把 npx→node→Electron 整棵树带走。
+// 测试进程自己被 Ctrl-C / 异常退出时也要收，否则下一轮又撞上一个占着端口的孤儿。
+export const spawnElectron = ({ desktopDir, cdpPort, env, extraArgs = [] }) => {
+  const elec = spawn('npx', ['electron', '.', '--remote-debugging-port=' + cdpPort, ...INPUT_FLAGS, ...extraArgs], {
+    cwd: desktopDir,
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  const killTree = () => {
+    for (const sig of ['SIGTERM', 'SIGKILL']) {
+      try { process.kill(-elec.pid, sig) } catch (e) { /* 组没了就算了 */ }
+    }
+  }
+  process.on('exit', killTree)
+  process.on('SIGINT', () => { killTree(); process.exit(130) })
+  return { elec, killTree }
+}
+
+export const waitForCdpWs = async (cdpPort, tries = 60) => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  for (let i = 0; i < tries; i++) {
+    await sleep(1000)
+    const ws = await fetch('http://127.0.0.1:' + cdpPort + '/json/version')
+      .then((r) => r.json()).then((j) => j.webSocketDebuggerUrl).catch(() => null)
+    if (ws) return ws
+  }
+  return null
+}
+
+// 应答这个端口的，必须是我们刚起的那棵进程树。撞上别人就当场报死——总比默默驱动
+// 别人的窗口、最后以"点了没反应"的形态红在某一步强。
+export const cdpOwnershipError = (cdpPort, elec) => {
+  const kids = (root) => {
+    const out = []
+    const walk = (p) => {
+      let cs = ''
+      try { cs = execSync('pgrep -P ' + p + ' 2>/dev/null || true').toString() } catch (e) { cs = '' }
+      for (const c of cs.split('\n').map((s) => s.trim()).filter(Boolean)) { out.push(c); walk(c) }
+    }
+    walk(root)
+    return out
+  }
+  let holder = ''
+  try {
+    holder = execSync('lsof -nP -iTCP:' + cdpPort + ' -sTCP:LISTEN -t 2>/dev/null || true')
+      .toString().trim().split('\n')[0]
+  } catch (e) { holder = '' }
+  const ours = [String(elec.pid), ...kids(elec.pid)]
+  if (holder && !ours.includes(holder)) {
+    return 'CDP 端口 ' + cdpPort + ' 上应答的是 pid=' + holder + '，不是本轮起的 Electron('
+      + ours.join(',') + ')——多半有别的会话在跑同一套 e2e'
+  }
+  return null
+}
+
+// 光有命令行开关还不够：窗口不是"活动窗口"时，渲染器仍可能把这一页当成非活动页，
+// 于是 mousePressed / keyDown 被丢。CDP 专门为"自动化一个不在前台的页面"留了这个
+// 开关，让渲染器一直把它当成有焦点且活动的页面。失败了不致命（老版本可能没有），
+// 但要把话说出来，别让人以为加了就一定生效。
+export const hardenPageInput = async (page) => {
+  try {
+    const cdp = await page.target().createCDPSession()
+    await cdp.send('Emulation.setFocusEmulationEnabled', { enabled: true })
+    return true
+  } catch (e) {
+    console.log('  ! 焦点仿真没开成（' + String(e.message || e).slice(0, 60) + '），输入通道少一层保险')
+    return false
+  }
+}

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -22,12 +22,13 @@
 // Env：DESKTOP_E2E_DEVURL（默认 http://localhost:5174）、APP_E2E_BACKEND（默认 9696；
 // 端口会经 CHECKBA_BACKEND_PORT 传给 Electron 壳，渲染层因此跟测试用同一个后端）
 
-import { spawn, execSync } from 'node:child_process'
+import { execSync } from 'node:child_process'
 import http from 'node:http'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { fileURLToPath } from 'node:url'
+import { pickCdpPort, portFree, spawnElectron, waitForCdpWs, cdpOwnershipError, hardenPageInput } from '../_lib/electron-cdp.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const frontendDir = path.resolve(here, '../..')
@@ -41,27 +42,14 @@ const BACKEND = process.env.APP_E2E_BACKEND || 'http://127.0.0.1:9696'
 // CHECKBA_BACKEND_PORT 是 backend-service.js 留的显式覆盖口，同时让壳复用这个已在
 // 跑的后端（verifyReuse 探 /api/admin/wizard）而不是另起一个 java。
 const BACKEND_PORT = new URL(BACKEND).port
-// CDP 端口不能写死。9333 会被两种东西占住：① 同一台机器上并行的另一个会话
-// （维护者常年多开，5174/5175 早就被别的会话占着）；② 上一轮自己没死透的 Electron
-// ——本套件原来 spawn 的是 `npx`，`elec.kill()` 只打得到 npx，真正的 Electron 是孙子
-// 进程，收不到信号就活下来继续占着端口（实测跑完一轮之后它还在 LISTEN）。
-// 占住之后有两种死法，都真实发生过：残留还应答 CDP → 我们连上去驱动的是**别人的
-// 窗口**；残留只占端口不应答 → 我们干等 60 秒报「CDP 端点未就绪」。
-// 每轮现挑一个空闲端口，这两种都不成立。
-const portFree = (p) => {
-  try { execSync('lsof -nP -iTCP:' + p + ' -sTCP:LISTEN -t', { stdio: 'pipe' }); return false }
-  catch (e) { return true } // lsof 非零退出 = 没人在听
-}
-const pickCdpPort = () => {
-  for (let p = 9333; p < 9373; p++) if (portFree(p)) return p
-  throw new Error('9333-9372 全被占，挑不出空闲 CDP 端口')
-}
+// CDP 端口现挑、进程树整棵收、连前核身份、输入通道加固，统一在 tests/_lib/electron-cdp.mjs
+// （三套 e2e 共用；这些坑的来龙去脉见 .claude/agents/eng-infra.md）
+const CDP_PORT = pickCdpPort('DESKTOP_E2E_CDP_PORT', 9333)
 // 同样的理由（维护者常年多开）：浏览器面板那一段自起的本机测试站也得现挑端口
 const pickFreePort = (from) => {
   for (let p = from; p < from + 60; p++) if (portFree(p)) return p
   throw new Error(from + '-' + (from + 59) + ' 全被占，挑不出空闲端口')
 }
-const CDP_PORT = Number(process.env.DESKTOP_E2E_CDP_PORT) || pickCdpPort()
 const MARKER = 'QA_SAVE_MARKER_' + Date.now()
 
 let puppeteer
@@ -110,61 +98,21 @@ async function api(ep, opts = {}) {
 
 // ---- launch dev Electron with CDP ----
 console.log('启动 dev Electron（屏幕会出现窗口，结束自动关闭）...')
-// detached：让它自成进程组，收尾时能把 npx→node→Electron 整棵树一起杀掉。
-// 只 kill(elec.pid) 杀的是 npx，Electron 是孙子进程，会活下来占着 CDP 端口。
-const elec = spawn('npx', ['electron', '.', '--remote-debugging-port=' + CDP_PORT], {
-  cwd: desktopDir,
-  env: {
-    ...process.env,
-    AIWORKDECK_DESKTOP_DEV: '1',
-    CHECKBA_DEV_SERVER_URL: DEVURL,
-    CHECKBA_BACKEND_PORT: BACKEND_PORT,
-  },
-  stdio: ['ignore', 'pipe', 'pipe'],
-  detached: true,
+const { elec, killTree } = spawnElectron({
+  desktopDir,
+  cdpPort: CDP_PORT,
+  env: { AIWORKDECK_DESKTOP_DEV: '1', CHECKBA_DEV_SERVER_URL: DEVURL, CHECKBA_BACKEND_PORT: BACKEND_PORT },
 })
-// 整棵树一起收：先客气后强硬。测试进程自己被 Ctrl-C / 异常退出时也要收，
-// 否则下一轮又会撞上一个占着端口的孤儿。
-const killTree = () => {
-  for (const sig of ['SIGTERM', 'SIGKILL']) {
-    try { process.kill(-elec.pid, sig) } catch (e) { /* 组没了就算了 */ }
-  }
-}
-process.on('exit', killTree)
-process.on('SIGINT', () => { killTree(); process.exit(130) })
 const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'desktop-e2e-electron.log'))
 elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-let ws = null
-for (let i = 0; i < 60 && !ws; i++) {
-  await sleep(1000)
-  ws = await fetch('http://127.0.0.1:' + CDP_PORT + '/json/version').then((r) => r.json()).then((j) => j.webSocketDebuggerUrl).catch(() => null)
-}
+const ws = await waitForCdpWs(CDP_PORT)
 if (!ws) { console.error('CDP 端点未就绪（端口 ' + CDP_PORT + '）'); killTree(); process.exit(1) }
 
-// 连上去之前先确认：应答这个端口的，就是我们刚起的那棵进程树。
-// 万一还是撞上了别人（并行会话同时挑中同一个端口），当场报死——总比默默驱动
-// 别人的窗口、最后以"点了没反应"的形态红在某一步强。
 {
-  const kids = (root) => {
-    const out = []
-    const walk = (p) => {
-      let cs = ''
-      try { cs = execSync('pgrep -P ' + p + ' 2>/dev/null || true').toString() } catch (e) { cs = '' }
-      for (const c of cs.split('\n').map((s) => s.trim()).filter(Boolean)) { out.push(c); walk(c) }
-    }
-    walk(root)
-    return out
-  }
-  let holder = ''
-  try { holder = execSync('lsof -nP -iTCP:' + CDP_PORT + ' -sTCP:LISTEN -t 2>/dev/null || true').toString().trim().split('\n')[0] } catch (e) { holder = '?' }
-  const ours = [String(elec.pid), ...kids(elec.pid)]
-  if (holder && !ours.includes(holder)) {
-    console.error('CDP 端口 ' + CDP_PORT + ' 上应答的是 pid=' + holder + '，不是本轮起的 Electron('
-      + ours.join(',') + ')——多半有别的会话在跑同一套 e2e。换个端口重跑：DESKTOP_E2E_CDP_PORT=9400')
-    killTree(); process.exit(1)
-  }
+  const bad = cdpOwnershipError(CDP_PORT, elec)
+  if (bad) { console.error(bad + '。换个端口重跑：DESKTOP_E2E_CDP_PORT=9400'); killTree(); process.exit(1) }
 }
 
 let failed = 0
@@ -184,6 +132,7 @@ try {
     page = (await browser.pages()).find((p) => p.url().startsWith(DEVURL))
   }
   if (!page) throw new Error('找不到主渲染页')
+  await hardenPageInput(page)
 
   // 壳注入的基址若和 provision 用的后端不是同一个，后面每一步都会以"点了没反应"
   // 的形态超时（文件建在别的库里/根本建不出来）。这里当场报死，别让人去查 UI。

--- a/frontend/tests/feedback-e2e/run.mjs
+++ b/frontend/tests/feedback-e2e/run.mjs
@@ -20,6 +20,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { fileURLToPath } from 'node:url'
+import { pickCdpPort, spawnElectron, waitForCdpWs, cdpOwnershipError, hardenPageInput } from '../_lib/electron-cdp.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const frontendDir = path.resolve(here, '../..')
@@ -27,7 +28,8 @@ const desktopDir = path.resolve(frontendDir, '../desktop')
 const DEVURL = process.env.FEEDBACK_E2E_DEVURL || 'http://localhost:5174'
 const BACKEND = process.env.APP_E2E_BACKEND || 'http://127.0.0.1:9696'
 const BACKEND_PORT = new URL(BACKEND).port
-const CDP_PORT = 9334
+// 端口现挑 + 进程树整棵收 + 连前核身份 + 输入加固，见 tests/_lib/electron-cdp.mjs
+const CDP_PORT = pickCdpPort('FEEDBACK_E2E_CDP_PORT', 9334)
 const MARKER = 'QA_FEEDBACK_' + Date.now()
 
 let puppeteer
@@ -71,30 +73,23 @@ async function api(ep, opts = {}) {
 // --use-fake-device-for-media-stream 让 getUserMedia({audio}) 返回一路合成音轨，
 // --use-fake-ui-for-media-stream 免掉权限询问。没有它们这条用例只能靠人对着电脑说话。
 console.log('启动 dev Electron（屏幕会出现窗口，结束自动关闭）...')
-const elec = spawn('npx', ['electron', '.',
-  '--remote-debugging-port=' + CDP_PORT,
-  '--use-fake-device-for-media-stream',
-  '--use-fake-ui-for-media-stream',
-], {
-  cwd: desktopDir,
-  env: {
-    ...process.env,
-    AIWORKDECK_DESKTOP_DEV: '1',
-    CHECKBA_DEV_SERVER_URL: DEVURL,
-    CHECKBA_BACKEND_PORT: BACKEND_PORT,
-  },
-  stdio: ['ignore', 'pipe', 'pipe'],
+const { elec, killTree } = spawnElectron({
+  desktopDir,
+  cdpPort: CDP_PORT,
+  env: { AIWORKDECK_DESKTOP_DEV: '1', CHECKBA_DEV_SERVER_URL: DEVURL, CHECKBA_BACKEND_PORT: BACKEND_PORT },
+  // 假麦克风：getUserMedia({audio}) 返回一路合成音轨，并免掉权限询问
+  extraArgs: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'],
 })
 const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'feedback-e2e-electron.log'))
 elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-let ws = null
-for (let i = 0; i < 60 && !ws; i++) {
-  await sleep(1000)
-  ws = await fetch('http://127.0.0.1:' + CDP_PORT + '/json/version').then((r) => r.json()).then((j) => j.webSocketDebuggerUrl).catch(() => null)
+const ws = await waitForCdpWs(CDP_PORT)
+if (!ws) { console.error('CDP 端点未就绪（端口 ' + CDP_PORT + '）'); killTree(); process.exit(1) }
+{
+  const bad = cdpOwnershipError(CDP_PORT, elec)
+  if (bad) { console.error(bad + '。换个端口重跑：FEEDBACK_E2E_CDP_PORT=9401'); killTree(); process.exit(1) }
 }
-if (!ws) { console.error('CDP 端点未就绪'); elec.kill(); process.exit(1) }
 
 let failed = 0
 const step = async (name, fn) => {
@@ -116,6 +111,7 @@ try {
     page = (await browser.pages()).find((p) => p.url().startsWith(DEVURL))
   }
   if (!page) throw new Error('找不到主渲染页')
+  await hardenPageInput(page)
 
   {
     const injected = await page.evaluate(() => (window.checkbaDesktop || {}).apiBaseUrl || null)
@@ -269,7 +265,7 @@ try {
 } finally {
   try { await api('/api/projects/' + QA.projectId, { method: 'DELETE' }) } catch { /* 清不掉不影响结论 */ }
   try { browser.disconnect() } catch { /* ignore */ }
-  elec.kill('SIGTERM')
+  killTree()
   await sleep(1500)
   try { elec.kill('SIGKILL') } catch { /* ignore */ }
 }

--- a/frontend/tests/meeting-e2e/run.mjs
+++ b/frontend/tests/meeting-e2e/run.mjs
@@ -17,6 +17,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { fileURLToPath } from 'node:url'
+import { pickCdpPort, spawnElectron, waitForCdpWs, cdpOwnershipError, hardenPageInput } from '../_lib/electron-cdp.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const frontendDir = path.resolve(here, '../..')
@@ -25,7 +26,8 @@ const desktopDir = path.resolve(frontendDir, '../desktop')
 const DEVURL = process.env.MEETING_E2E_DEVURL || 'http://localhost:5174'
 const BACKEND_PORT = 9899
 const BACKEND = 'http://127.0.0.1:' + BACKEND_PORT
-const CDP_PORT = 9337
+// 端口现挑 + 进程树整棵收 + 连前核身份 + 输入加固，见 tests/_lib/electron-cdp.mjs
+const CDP_PORT = pickCdpPort('MEETING_E2E_CDP_PORT', 9337)
 const ts = Date.now()
 
 let puppeteer
@@ -75,7 +77,7 @@ for (let i = 0; i < 150 && !backendUp; i++) {
 }
 if (!backendUp) die('后端 150s 未就绪')
 
-const QA = { sid: null }
+const QA = { sid: null, project: '' }
 async function api(ep, opts = {}) {
   const r = await fetch(BACKEND + ep, {
     method: opts.method || 'GET',
@@ -101,7 +103,8 @@ async function api(ep, opts = {}) {
     const init = await api('/api/admin/wizard', { method: 'POST', body: { ai: { activeProvider: 'OLLAMA' } } })
     if (!init || init.code !== 0) die('向导初始化失败: ' + JSON.stringify(init))
   }
-  const proj = await api('/api/projects', { method: 'POST', body: { name: '会议QA_' + ts, projectType: 'BLANK' } })
+  QA.project = '会议QA_' + ts
+  const proj = await api('/api/projects', { method: 'POST', body: { name: QA.project, projectType: 'BLANK' } })
   QA.projectId = proj.id
   // 广场启停语义：enabled_by_default:false 的 skill 启用即安装，左栏 requiresSkill 过滤据此放行
   const en = await api('/api/skills/meeting-recorder/enable', { method: 'POST' })
@@ -117,31 +120,24 @@ async function api(ep, opts = {}) {
 
 // ---- dev Electron + 假麦克风 ----
 console.log('启动 dev Electron（屏幕会出现窗口，结束自动关闭）...')
-const elec = spawn('npx', ['electron', '.',
-  '--remote-debugging-port=' + CDP_PORT,
-  '--use-fake-device-for-media-stream',
-  '--use-fake-ui-for-media-stream',
-], {
-  cwd: desktopDir,
-  env: {
-    ...process.env,
-    AIWORKDECK_DESKTOP_DEV: '1',
-    CHECKBA_DEV_SERVER_URL: DEVURL,
-    CHECKBA_BACKEND_PORT: String(BACKEND_PORT),
-  },
-  stdio: ['ignore', 'pipe', 'pipe'],
+const { elec, killTree } = spawnElectron({
+  desktopDir,
+  cdpPort: CDP_PORT,
+  env: { AIWORKDECK_DESKTOP_DEV: '1', CHECKBA_DEV_SERVER_URL: DEVURL, CHECKBA_BACKEND_PORT: String(BACKEND_PORT) },
+  // 假麦克风：getUserMedia({audio}) 返回一路合成音轨，并免掉权限询问
+  extraArgs: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'],
 })
 {
   const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'meeting-e2e-electron.log'))
   elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
 }
 
-let ws = null
-for (let i = 0; i < 60 && !ws; i++) {
-  await sleep(1000)
-  ws = await fetch('http://127.0.0.1:' + CDP_PORT + '/json/version').then(r => r.json()).then(j => j.webSocketDebuggerUrl).catch(() => null)
+const ws = await waitForCdpWs(CDP_PORT)
+if (!ws) { killTree(); die('CDP 端点未就绪（端口 ' + CDP_PORT + '）') }
+{
+  const bad = cdpOwnershipError(CDP_PORT, elec)
+  if (bad) { killTree(); die(bad + '。换个端口重跑：MEETING_E2E_CDP_PORT=9402') }
 }
-if (!ws) { try { elec.kill() } catch (e) { /* ignore */ } die('CDP 端点未就绪') }
 
 let failed = 0
 const step = async (name, fn) => {
@@ -158,6 +154,14 @@ try {
     page = (await browser.pages()).find(p => p.url().startsWith(DEVURL))
   }
   if (!page) throw new Error('找不到主渲染页')
+  await hardenPageInput(page)
+
+  // 语言必须钉死中文：本套断言全是中文字面量（rail 的 title="会议录音"、面板文案…），
+  // 而 appLanguage 对全新安装是按 navigator.language 猜的——Electron 常带 --lang=en-GB，
+  // 猜成英文之后 rail 会变成 "Meeting Recording"，所有选择器一起失配（实测就这么红过一轮，
+  // 现象是"左栏没有会议录音入口"，很容易被误当成 skill 没启用）。下面那步的 goto+reload
+  // 会让它生效；不能用 evaluateOnNewDocument——壳启动时页面已经引导过一次了。
+  await page.evaluate(() => { try { localStorage.setItem('awd_app_language', 'zh-CN') } catch (e) { /* ignore */ } })
 
   {
     const injected = await page.evaluate(() => (window.checkbaDesktop || {}).apiBaseUrl || null)
@@ -186,25 +190,65 @@ try {
   page.on('console', (m) => { if (m.type() === 'error') console.log('    [console.error] ' + m.text().slice(0, 200)) })
 
   await step('进入工作台，左栏 rail 出现「会议录音」（skill 启用 → requiresSkill 放行）', async () => {
-    // 启动直达配方（app-e2e 同款）：写最近项目 → 回根路由 reload → launch 流程送进工作台。
-    // 直接 hash 跳 project-overview 会被启动逻辑弹回项目列表。
-    await page.goto(DEVURL + '/', { waitUntil: 'domcontentloaded', timeout: 120000 })
-    await page.evaluate((id) => localStorage.setItem('checkba_last_project_id', String(id)), QA.projectId)
+    // 2026-08 起**启动一律落项目列表页**：launch.vue 不再读 checkba_last_project_id
+    // 直达上次项目，所以老的"写最近项目 → reload 直达工作台"配方已经失效（本套件
+    // 因此在 master 上整轮红，10 步全挂，第一条就是这里）。改成 desktop-e2e 同款：
+    // 轮询到真进了工作台为止——在列表上就按真人走法点卡片，已经在工作台就直接出去。
+    // 点卡片主体、避开标题行（@tap.stop=startRename）与底部那排成员头像。
+    await page.goto(DEVURL + '/#/pages/project-overview/project-overview?id=' + QA.projectId,
+      { waitUntil: 'domcontentloaded', timeout: 120000 })
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 120000 })
+    const deadline = Date.now() + 90000
+    while (Date.now() < deadline) {
+      const where = await page.evaluate(() => ({
+        list: location.hash.includes('pages/project-list/project-list'),
+        wb: location.hash.includes('pages/project-overview/project-overview'),
+        // 别拿「资源管理器」当就绪判据：左栏面板是**记住上次**的，上一轮把它切到
+        // 「会议录音」之后，下一轮进来就永远等不到这四个字（本套件正是这样一轮好
+        // 一轮坏地交替）。工作台根节点与面板无关，才是稳的判据。
+        ready: !!document.querySelector('.page-project-overview'),
+      })).catch(() => null)
+      if (where && where.wb && where.ready) break
+      if (where && where.list) {
+        const box = await page.evaluate((name) => {
+          const cards = [...document.querySelectorAll('.project-item-card')]
+          const card = cards.find((c) => (c.innerText || '').includes(name)) || cards[0]
+          if (!card) return null
+          const r = card.getBoundingClientRect()
+          return { x: r.x + r.width / 2, y: r.y + r.height * 0.55 }
+        }, QA.project).catch(() => null)
+        if (box) await page.mouse.click(box.x, box.y).catch(() => {})
+      }
+      await new Promise((r) => setTimeout(r, 1500))
+    }
     try {
       await page.waitForFunction(
         () => location.hash.includes('pages/project-overview/project-overview'), POLL(60000))
-      await page.waitForFunction(() => document.body.innerText.includes('资源管理器'), POLL(120000))
+      await page.waitForFunction(() => !!document.querySelector('.page-project-overview'), POLL(120000))
     } catch (e) {
       const url = page.url()
       const text = await page.evaluate(() => document.body.innerText.slice(0, 400)).catch(() => '(取不到)')
       throw new Error('工作台未渲染。url=' + url + ' body=' + JSON.stringify(text))
     }
-    await page.waitForSelector('.rail-btn[title="会议录音"]', { timeout: 30000 })
+    // 等不到就把左栏 rail 现在到底有哪些入口、以及后端认不认这个 skill 一并报出来，
+    // 别只丢一句选择器超时（这一步就是靠 requiresSkill 放行的，缺什么要一眼看见）。
+    try {
+      await page.waitForSelector('.rail-btn[title="会议录音"]', { timeout: 30000 })
+    } catch (e) {
+      const rail = await page.evaluate(() => [...document.querySelectorAll('.rail-btn')]
+        .map((b) => b.getAttribute('title') || b.innerText.trim().slice(0, 8))).catch(() => null)
+      const skills = await api('/api/skills/list').catch(() => null)
+      const mine = Array.isArray(skills) ? skills.filter((k) => /meeting/i.test(JSON.stringify(k))) : skills
+      throw new Error('左栏没出现「会议录音」入口。当前 rail=' + JSON.stringify(rail)
+        + ' 后端 skill=' + JSON.stringify(mine).slice(0, 300))
+    }
   })
 
   await step('打开面板：录音区与降级提示（未配听悟凭证）在场', async () => {
-    await clickSel('.rail-btn[title="会议录音"]')
+    // rail 按钮是**开关**，而左栏面板是记住上次的：上一轮跑完把「会议录音」留在打开
+    // 状态，这一轮再点一下正好把它关上，于是 .mr-record-zone 永远等不到（本套件因此
+    // 一轮好一轮坏地交替）。改成"确保打开"而不是"点一下"。
+    if (!(await page.$('.mr-record-zone'))) await clickSel('.rail-btn[title="会议录音"]')
     await page.waitForSelector('.mr-record-zone', { timeout: 15000 })
     await page.waitForSelector('.mr-config-hint', { timeout: 10000 })
   })
@@ -289,15 +333,26 @@ try {
 
   await step('无凭证提交转写给出可读错误（降级路径）', async () => {
     const res = await api('/api/meetings/' + meetingId + '/transcribe', { method: 'POST' })
-    const msg = JSON.stringify(res || {})
-    if (!msg.includes('未配置转写服务凭证')) throw new Error('返回=' + msg.slice(0, 200))
+    const msg = String((res && res.message) || JSON.stringify(res || {}))
+    // 没凭证有两条合法分支，取决于当前转写档位（MeetingTranscriptionService）：
+    //   PLATFORM → 「平台转写需要连接 AI WorkDeck 账户…」
+    //   BYOK     → 「未配置转写服务凭证，请到 设置-会议转写 填写阿里云凭证」
+    // 原来只认死 BYOK 那句，档位默认走平台之后这步就一直红。这里认"说清了缺什么、
+    // 下一步去哪"，别再钉死某一句文案。
+    const readable = /凭证|账户/.test(msg) && !/服务器内部错误/.test(msg)
+    if (!readable) throw new Error('没给出可读的降级提示，返回=' + msg.slice(0, 200))
+    // 后端那边有明确约束：这句话不能含「登录」「未授权」「请先」——api.js 拿这三个
+    // 子串判定掉线并清会话，误伤了会把用户直接踢出去。属于契约，一并守住。
+    for (const bad of ['登录', '未授权', '请先']) {
+      if (msg.includes(bad)) throw new Error('降级提示里出现了会被 api.js 判成掉线的词「' + bad + '」：' + msg.slice(0, 200))
+    }
   })
 } catch (e) {
   failed++
   console.error('致命: ' + (e.message || e))
 } finally {
   try { await browser.disconnect() } catch (e) { /* ignore */ }
-  try { elec.kill() } catch (e) { /* ignore */ }
+  killTree()
   try { backendChild.kill() } catch (e) { /* ignore */ }
 }
 


### PR DESCRIPTION
接 #397 的两件事：**① 顺手扫**、**② 想办法修那个残留**。顺带发现 meeting-e2e 本来就是整轮红。

## ① 扫的结果：影响面比 #397 里写的窄，但漏掉的两套是真中招

#397 说「另外四套还没上三件套」，扫完发现**说宽了，这里更正**：

| 套件 | 起浏览器的方式 | 是否中招 |
|---|---|---|
| app-e2e / lowa-e2e | `puppeteer.launch()` 自己起无头 Chrome | **否**——进程由 puppeteer 管，且自带后台节流开关 |
| feedback-e2e (9334) / meeting-e2e (9337) | `spawn('npx', ['electron'…])` + 写死端口 + `elec.kill()` | **是**，和 desktop-e2e 一模一样 |

三件套（端口现挑 / `detached` 进程组整棵收 / 连前用 `lsof` 核身份）连同下面的输入加固，收进 **`frontend/tests/_lib/electron-cdp.mjs`**，三套共用。以前各抄一份，所以同一个坑得踩三次；净减 100+ 行重复。

## ② 想办法修：对症加固，但**没能证伪，不敢叫修复**

残留故障的特征是「`mouseMoved` 送得到、`mousePressed`/`keyDown` 被丢」——**按下与按键跟焦点绑定，鼠标移动不绑定**。据此加两层：

- 起 Electron 带 `--disable-backgrounding-occluded-windows` / `--disable-renderer-backgrounding` / `--disable-background-timer-throttling`（`puppeteer.launch` 自带，手动 spawn 再 connect 就没有）
- 连上页面后开 `Emulation.setFocusEmulationEnabled`（CDP 专为「自动化非前台页面」留的开关）

**丑话说前面**：本机无法按需复现该故障，也没能造出遮挡来 A/B 验证这两个开关真的改变了行为（试了 Cmd+H、最小化、激活 Edge/WeChat/Word/Mail/Finder，都没能让它转成被降级状态）。所以这是**有依据的加固，不是已验证的修复**。

数据：加固后连跑 **90 轮（三路并行）零输入通道故障**。但按「修完进程泄漏后 1/61」的基线，90 轮里本来也有 **约 23%** 的概率一次都不出——**这 90 轮只能说不矛盾，不构成证明**。所以检测 + 诚实恢复 + 响亮报错那条链原样保留，没有因为「看起来好了」就撤掉。

## ③ 捎带修好：meeting-e2e 在 master 上本来就是整轮红（10/10）

**不是本次改动引入的**——先用 master 原版跑了一遍复现确认。四个坑叠在一起：

1. 还在用「写 `checkba_last_project_id` → reload 直达工作台」的老配方，而 2026-08 起启动一律落项目列表页 → 第一步就卡死；改成 desktop-e2e 同款轮询点卡片
2. 拿「资源管理器」当工作台就绪判据，但左栏面板是**记住上次**的，上一轮切到「会议录音」之后下一轮永远等不到 → 改用 `.page-project-overview` 这种与面板无关的根节点
3. rail 按钮是**开关**，面板已开着时再点正好关上 → 改成「确保打开」而不是「点一下」
4. **没钉死界面语言**，Electron 常带 `--lang=en-GB`，rail 变成 `Meeting Recording`，中文选择器全失配——现象酷似「skill 没启用」，极易误判（我就先按这个方向查了一轮，是补上的诊断把真相打出来的）→ 补 `awd_app_language=zh-CN`

2 和 3 是同一类：**上一轮留下的状态破坏下一轮**。

另把「无凭证降级提示」那条死钉某句文案的断言改成认语义（平台档/BYOK 两条合法分支），并顺带守住后端注释里写明的契约：提示里不能出现「登录」「未授权」「请先」——`api.js` 拿这三个子串判掉线清会话，误伤会把用户直接踢出去。

## 验证

- **desktop-e2e**：完整 9 步绿；精简版三路并行 **90 轮零失败、零残留进程**
- **feedback-e2e**：全链路绿（截图 + 语音 + 落库 + 附件回读）
- **meeting-e2e**：master 原版 10/10 红 → 本版**连跑 4 轮全绿**

🤖 Generated with [Claude Code](https://claude.com/claude-code)