### PR TITLE
fix(browser): 切走标签再切回来不再退回默认地址、丢掉整页内容

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -9,7 +9,27 @@ description: 辅助小工具领域。任务涉及浏览器面板、截图/OCR、
 
 ## 分组清单（前端组件 / desktop 宿主 / 后端 API 三层）
 
-**浏览器**：`frontend/src/components/BrowserPane.vue`；desktop `desktop/main/main.js`（BrowserView 创建 ~:634、重复 add 先 remove 再 add 置顶 ~:771-810、window.open 拦截转工作区新 tab ~:290/:674 → 事件 `checkba:browser-open-new-tab`、全屏/黑屏兜底恢复 ~:336/:549/:887/:1189、IPC handlers ~:819-988）；后端 `controller/BrowserProxyController.java`（GET /api/browser/proxy）。
+**浏览器**：`frontend/src/components/BrowserPane.vue`；desktop `desktop/main/browser-views.js`（BrowserView 注册表）+ `desktop/main/main.js`（`makeBrowserView` 建 view 并接事件、window.open 拦截转工作区新 tab → 事件 `checkba:browser-open-new-tab`、全屏/黑屏兜底恢复、IPC handlers）；后端 `controller/BrowserProxyController.java`（GET /api/browser/proxy）。
+
+**BrowserView 生命周期（改这块之前必读）**：**面板卸载 = detach（保活），标签关闭 = destroy**。
+切标签会把 BrowserPane 整个卸载（project-overview 里是 `v-if` + `:key=tab.id`），如果卸载即销毁，
+用户翻到的那一页（页内跳转、滚动位置、填了一半的表单、页面里的登录态）就全没了，
+切回来只能按渲染层记的旧地址重新加载——默认标签那个地址是 `https://www.baidu.com`，
+现象就是「切走再切回来变成默认地址」。销毁的责任因此落在两处，**都不能漏**：
+`fileOpenTabs.js` 的 `closeFile`（另一侧还双开着同一标签时不销毁，见下）与 project-overview
+`beforeUnmount` 的 `destroyAllBrowserViews()`。
+注册表同时记 `wanted`（哪些面板正端着它，**计数**）与 `attached`（此刻真挂在窗口上）：
+- 全局隐藏（弹窗/蒙层、离开工作台、截图框选）走 `setAllVisible(false)`；恢复时**只挂回
+  wanted 的那些**。无脑挂回全部，后台保活的标签会一起浮到最上层盖住界面。
+- 计数而不是布尔，是因为跨窗格拖拽是「在另一侧也打开同一标签」（同 id 双开，见
+  `tabDragSplit.moveTabTo`）；关掉一侧不能把另一侧正看的网页摘走。
+- `browser-create` 对已存在的 view **不重新 loadURL**，并把 view 此刻的真实状态
+  （url/title/canGoBack/canGoForward/mobile）回给渲染层，由 `adoptViewState` 回填工具栏。
+**标签地址跟随页内跳转**靠主进程的 `did-navigate`/`did-navigate-in-page` → `checkba:browser-url-updated`；
+渲染层不订阅它的话，tab.url 会永远停在打开时那个地址（BrowserPane 此前只消费了
+title-updated，把同一条消息里的 url 扔了）。
+**前进/后退/刷新走 view 自己的历史**（`checkba:browser-history`）：组件里那份 `history` 数组
+只服务 H5 iframe 模式，桌面端从来没驱动过 BrowserView（三个按钮点了没反应），保活之后更没法当历史用。
 
 **截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
 
@@ -110,6 +130,9 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 ## 已知地雷
 
 - BrowserView 弹窗守卫模式与 window.open 消费者、截图假死根因见 v0.6.1 修复（desktop-interaction-bugfix 记录）；改 BrowserView 生命周期务必测全屏/黑屏恢复路径。
+- **摘下窗口的 BrowserView 会被 Chromium 冻住渲染进程**（后台标签的正常待遇，页面状态照留）。
+  自动化里往冻着的 target 里 evaluate 会一直挂到 CDP 的 protocolTimeout，最后只落一句
+  「Runtime.callFunctionOn timed out」——desktop-e2e 那一段为此自带超时与「等它醒过来」轮询。
 - 剪贴板去重靠指纹+window 级状态，改动监听逻辑先读 PR#148/#151 教训。
 - `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
 - Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。asr-models 的下载走同一条路，同样禁 xet。
@@ -132,6 +155,7 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 
 ## 验证
 
-- desktop 服务栈：`cd desktop && npm test`（service-manager/model-manager/pysvc-runtime）。
+- desktop 服务栈：`cd desktop && npm test`（service-manager/model-manager/pysvc-runtime/**browser-views**）。
+  `browser-views.test.js` 钉住的就是上面那套记账：复用不重载、detach 不销毁、隐藏恢复只挂回前台、双开计数。
 - 后端相关单测：TtsServiceTest、FileControllerChunkedUploadTest、ProjectFileService*Test 等；剪贴板/收藏/搜索/OCR/浏览器代理暂无专属测试。
 - UI 链路：`cd frontend && npm run test:app-e2e`。

--- a/desktop/main/browser-views.js
+++ b/desktop/main/browser-views.js
@@ -1,0 +1,158 @@
+'use strict'
+
+// 内嵌浏览器面板（BrowserPane）的 BrowserView 注册表。
+//
+// 从 main.js 抽出来不是分层洁癖：这里的记账正是「切走标签再切回来就变回默认地址」
+// 的病灶。原实现在渲染层组件卸载时直接 destroy 掉 BrowserView——切个标签就把整个
+// 网页（页内跳转、滚动位置、填了一半的表单、页面里的登录态）连根拔掉，切回来只能
+// 按渲染层记着的那个旧地址重新 loadURL。现在改成：
+//   面板卸载 = 摘下（detach，view 还活着）；标签关闭 = 销毁（destroy）。
+//
+// 因此注册表必须同时记两件事：
+//   wanted   —— 渲染层希望它出现在窗口上（= 这个标签正被某个窗格显示）
+//   attached —— 它此刻真的挂在窗口上
+// 分开记是因为「全局隐藏」（弹窗/蒙层、离开工作台、截图框选）会把所有 view 从窗口
+// 摘下，恢复时**只能把 wanted 的挂回去**。恢复时无脑挂回全部，后台保活着的标签就会
+// 一起浮到最上层盖住界面——保活改动最容易在这里翻车。
+//
+// 依赖注入（createView / getWindow）只为可测：单测喂假 view 与假窗口即可验证记账，
+// 不需要真的起 Electron。
+
+/**
+ * @param {{ createView: (id: string) => any, getWindow: () => any }} deps
+ */
+function createBrowserViewRegistry({ createView, getWindow }) {
+  /** @type {Map<string, any>} */
+  const views = new Map()
+  /** @type {Map<string, {x:number,y:number,width:number,height:number}>} */
+  const bounds = new Map()
+  // 渲染层希望可见的 view，按「有几个面板正端着它」计数。计数而不是布尔，是因为
+  // 同一个网页标签可以被拖成左右双开（tabDragSplit 跨窗格拖是复制、id 相同），
+  // 那时两个面板各挂一份 BrowserPane、各自 attach。布尔的话，关掉其中一个就把
+  // 另一个还在看的网页从窗口上摘走了。
+  /** @type {Map<string, number>} */
+  const wanted = new Map()
+  /** 此刻真的挂在窗口上的 view @type {Set<string>} */
+  const attached = new Set()
+  /** 全局可见性：弹窗/蒙层/离开工作台期间为 false */
+  let visible = true
+
+  function layoutAll() {
+    if (!getWindow()) return
+    for (const [id, view] of views.entries()) {
+      const b = bounds.get(id)
+      if (!b) continue
+      try {
+        view.setBounds(b)
+        view.setAutoResize({ width: false, height: false })
+      } catch (e) {
+        // ignore
+      }
+    }
+  }
+
+  function addToWindow(id) {
+    const win = getWindow()
+    const view = views.get(id)
+    if (!win || !view) return
+    // addBrowserView 重复 add 会抛错，因此先 remove 再 add 以确保置顶
+    try { win.removeBrowserView(view) } catch (e) { /* ignore */ }
+    try {
+      win.addBrowserView(view)
+      attached.add(id)
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  function removeFromWindow(id) {
+    const win = getWindow()
+    const view = views.get(id)
+    attached.delete(id)
+    if (!win || !view) return
+    try { win.removeBrowserView(view) } catch (e) { /* ignore */ }
+  }
+
+  return {
+    /** 取（必要时建）一个 view。created=false 说明是保活着的旧 view，调用方不要重新 loadURL。 */
+    ensure(id) {
+      if (views.has(id)) return { view: views.get(id), created: false }
+      const view = createView(id)
+      views.set(id, view)
+      return { view, created: true }
+    },
+
+    /** 面板挂载/激活：登记为期望可见，全局可见时立刻挂上窗口并置顶。 */
+    attach(id) {
+      if (!views.has(id)) return false
+      wanted.set(id, (wanted.get(id) || 0) + 1)
+      if (visible) addToWindow(id)
+      layoutAll()
+      return true
+    },
+
+    /** 面板卸载：还有别的面板端着它就只减计数；没人要了才从窗口摘下。view 始终活着。 */
+    detach(id) {
+      if (!views.has(id)) return false
+      const left = (wanted.get(id) || 0) - 1
+      if (left > 0) { wanted.set(id, left); return true }
+      wanted.delete(id)
+      removeFromWindow(id)
+      return true
+    },
+
+    /** 标签真正关闭：销毁 view。这是唯一会丢页面状态的入口。 */
+    destroy(id) {
+      const view = views.get(id)
+      if (!view) return false
+      removeFromWindow(id)
+      try { view.webContents.destroy() } catch (e) { /* ignore */ }
+      views.delete(id)
+      bounds.delete(id)
+      wanted.delete(id)
+      return true
+    },
+
+    /**
+     * 全局显示/隐藏。隐藏时把所有 view 从窗口摘下但保留 wanted；
+     * 恢复时只挂回 wanted 的那些（后台保活的标签不许跟着冒出来）。
+     */
+    setAllVisible(next) {
+      visible = next !== false
+      if (!visible) {
+        // 不依赖 attached：某些情况下它可能与真实状态不同步，导致 remove 不生效
+        for (const id of views.keys()) removeFromWindow(id)
+        return
+      }
+      for (const id of wanted.keys()) addToWindow(id)
+      layoutAll()
+    },
+
+    /** 窗口 show/focus 后的兜底重挂（沿用当前可见性）。 */
+    restoreVisibility() {
+      this.setAllVisible(visible)
+      layoutAll()
+    },
+
+    setBounds(id, b) {
+      if (!views.has(id)) return false
+      bounds.set(id, b)
+      // 仅更新 bounds，避免频繁 remove/add 导致导航被打断（ERR_ABORTED）
+      layoutAll()
+      return true
+    },
+
+    getBounds(id) { return bounds.get(id) || null },
+    get(id) { return views.get(id) || null },
+    has(id) { return views.has(id) },
+    ids() { return [...views.keys()] },
+    layoutAll,
+
+    // 仅供测试与排查
+    _state() {
+      return { visible, wanted: [...wanted.keys()], attached: [...attached] }
+    },
+  }
+}
+
+module.exports = { createBrowserViewRegistry }

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -8,6 +8,7 @@ const { createKokoroDescriptor } = require('./services/kokoro-service')
 const { createAsrDescriptor } = require('./services/asr-service')
 const { createModelManager } = require('./services/model-manager')
 const { initLocalFileService } = require('./file-service')
+const { createBrowserViewRegistry } = require('./browser-views')
 
 
 const DEV_SERVER_URL = process.env.CHECKBA_DEV_SERVER_URL || 'http://localhost:5173'
@@ -38,17 +39,15 @@ function overlayCtx() {
   }
 }
 
-/** @type {Map<string, BrowserView>} */
-const views = new Map()
+// 内嵌浏览器面板的 BrowserView 注册表（记账与生命周期见 ./browser-views.js）。
+// 面板卸载只是 detach，标签关闭才 destroy——切标签不再把网页连根拔掉。
+const views = createBrowserViewRegistry({
+  createView: (id) => makeBrowserView(id),
+  getWindow: () => mainWindow,
+})
 
-/** @type {Map<string, {x:number,y:number,width:number,height:number}>} */
-const viewBounds = new Map()
-
-/** @type {Set<string>} */
-const attachedViewIds = new Set()
-
-// 渲染层期望 BrowserView 是否可见（用于避免弹窗/全屏切换导致 onHide/onShow 未触发时“卡死黑屏”）
-let viewsVisibleDesired = true
+/** 每个 view 当前是否用移动端 UA（面板重新挂载时要照实回填工具栏按钮） @type {Map<string, boolean>} */
+const viewMobileUA = new Map()
 
 let clipboardWatchTimer = null
 let lastClipboardText = ''
@@ -123,12 +122,7 @@ function closeOcrSelectWin() {
 
 function restoreViewsVisibility() {
   try {
-    setAllViewsVisible(viewsVisibleDesired)
-  } catch (e) {
-    // ignore
-  }
-  try {
-    layoutAllViews()
+    views.restoreVisibility()
   } catch (e) {
     // ignore
   }
@@ -400,17 +394,17 @@ function createMainWindow() {
     mainWindow = null
   })
 
-  mainWindow.on('resize', () => layoutAllViews())
-  mainWindow.on('maximize', () => layoutAllViews())
-  mainWindow.on('unmaximize', () => layoutAllViews())
+  mainWindow.on('resize', () => views.layoutAll())
+  mainWindow.on('maximize', () => views.layoutAll())
+  mainWindow.on('unmaximize', () => views.layoutAll())
   // 全屏切换在 macOS 上不会总触发 resize/maximize：这里补齐，避免 BrowserView bounds 不同步
   mainWindow.on('enter-full-screen', () => {
-    layoutAllViews()
+    views.layoutAll()
     // OCR 覆盖窗跟随（全屏时 bounds 会变化）
     syncOcrSelectWinBounds()
   })
   mainWindow.on('leave-full-screen', () => {
-    layoutAllViews()
+    views.layoutAll()
     syncOcrSelectWinBounds()
   })
   // 某些情况下（弹窗/空间切换）会出现 BrowserView 未重新 attach 导致“黑屏”，focus 时兜底恢复
@@ -451,7 +445,7 @@ ipcMain.handle('checkba:ocr-start-selection', async (_evt, payload) => {
   const viewId = payload && payload.viewId ? String(payload.viewId) : ''
   const mode = payload && payload.mode ? String(payload.mode) : ''
   const useWindow = mode === 'window' || !viewId
-  const vb = !useWindow && viewId ? (viewBounds.get(viewId) || null) : null
+  const vb = !useWindow && viewId ? views.getBounds(viewId) : null
   const view = !useWindow && viewId ? views.get(viewId) : null
   // window 模式：允许在任意内容上框选（包括两边都是文档）
   if (!useWindow && (!viewId || !vb || !view)) return { ok: false, message: 'view not found' }
@@ -683,24 +677,9 @@ ipcMain.handle('checkba:ocr-start-selection', async (_evt, payload) => {
   }
 })
 
-function layoutAllViews() {
-  if (!mainWindow) return
-  for (const [id, view] of views.entries()) {
-    const b = viewBounds.get(id)
-    if (!b) continue
-    try {
-      view.setBounds(b)
-      view.setAutoResize({ width: false, height: false })
-    } catch (e) {
-      // ignore
-    }
-  }
-}
-
-function ensureView(id) {
-  if (!mainWindow) throw new Error('mainWindow not ready')
-  if (views.has(id)) return views.get(id)
-
+// 新建一个浏览器面板 view 并接好全部事件。只由注册表在「这个 id 还没有 view」时调用，
+// 复用旧 view 的那条路不会再进来（否则事件会重复绑定）。
+function makeBrowserView(id) {
   const view = new BrowserView({
     webPreferences: {
       contextIsolation: true,
@@ -740,6 +719,29 @@ function ensureView(id) {
       // ignore
     }
   })
+
+  // 页内跳转（点链接、搜索、SPA 换路由）后把当前地址回传渲染层。
+  // 没有这条，标签记的还是「当初打开时那个地址」——地址栏与前进/后退按钮全是过期的，
+  // 而且一旦 view 需要重建（关掉再开）就会退回默认首页，正是本次要修的丢内容现象。
+  const pushUrl = () => {
+    try {
+      if (!mainWindow) return
+      const wc = view.webContents
+      mainWindow.webContents.send('checkba:browser-url-updated', {
+        id,
+        url: wc.getURL ? String(wc.getURL() || '') : '',
+        // 标题一起带上：渲染层收到 url 变化会把标签名退成域名，纯页内跳转
+        // （hash / pushState）不会再来一条 page-title-updated 把名字补回去。
+        title: wc.getTitle ? String(wc.getTitle() || '') : '',
+        canGoBack: wc.canGoBack ? wc.canGoBack() : false,
+        canGoForward: wc.canGoForward ? wc.canGoForward() : false
+      })
+    } catch (e) {
+      // ignore
+    }
+  }
+  view.webContents.on('did-navigate', pushUrl)
+  view.webContents.on('did-navigate-in-page', pushUrl)
 
   // 关键：window.open / target=_blank => 交给工作区新 tab
   view.webContents.setWindowOpenHandler(({ url }) => {
@@ -799,7 +801,7 @@ function ensureView(id) {
       ])
       // BrowserView 的 x/y 是相对 view 的；popup 需要相对 BrowserWindow 内容区坐标
       try {
-        const b = viewBounds.get(id) || { x: 0, y: 0 }
+        const b = views.getBounds(id) || { x: 0, y: 0 }
         const x = Math.max(0, Math.floor((b.x || 0) + (params.x || 0)))
         const y = Math.max(0, Math.floor((b.y || 0) + (params.y || 0)))
         menu.popup({ window: mainWindow, x, y })
@@ -830,76 +832,50 @@ function ensureView(id) {
     }
   })
 
-  views.set(id, view)
   return view
 }
 
-function attachView(id) {
-  if (!mainWindow) return
+// 面板挂载时的工具栏状态：复用旧 view 时要照它此刻的真实情况回填（地址、标题、
+// 前进后退可用性、是否移动端 UA），不能让渲染层拿组件的初值去猜。
+function viewState(id) {
   const view = views.get(id)
-  if (!view) return
-  // addBrowserView 重复 add 会抛错，因此先 remove 再 add 以确保置顶
+  if (!view) return {}
+  const wc = view.webContents
   try {
-    mainWindow.removeBrowserView(view)
+    return {
+      url: wc.getURL ? String(wc.getURL() || '') : '',
+      title: wc.getTitle ? String(wc.getTitle() || '') : '',
+      canGoBack: wc.canGoBack ? wc.canGoBack() : false,
+      canGoForward: wc.canGoForward ? wc.canGoForward() : false,
+      mobile: !!viewMobileUA.get(id)
+    }
   } catch (e) {
-    // ignore
+    return {}
   }
-  try {
-    mainWindow.addBrowserView(view)
-    attachedViewIds.add(id)
-  } catch (e) {
-    // ignore
-  }
-  layoutAllViews()
-}
-
-function setAllViewsVisible(visible) {
-  if (!mainWindow) return
-  if (visible === false) {
-    // 不依赖 attachedViewIds：某些情况下 set 可能不同步，导致 remove 不生效
-    for (const [_id, view] of views.entries()) {
-      if (!view) continue
-      try {
-        mainWindow.removeBrowserView(view)
-      } catch (e) {
-        // ignore
-      }
-    }
-    attachedViewIds.clear()
-    return
-  }
-  // visible === true：把所有 view 重新 add 回来（按最后一次的 bounds）
-  // 先 remove 再 add：重复 add 已挂载的 view 会抛错，导致 attachedViewIds 不同步
-  for (const [id, view] of views.entries()) {
-    try {
-      mainWindow.removeBrowserView(view)
-    } catch (e) {
-      // ignore
-    }
-    try {
-      mainWindow.addBrowserView(view)
-      attachedViewIds.add(id)
-    } catch (e) {
-      // ignore
-    }
-  }
-  layoutAllViews()
 }
 
 ipcMain.handle('checkba:browser-create', async (_evt, payload) => {
+  if (!mainWindow) return { ok: false, message: 'mainWindow not ready' }
   const id = payload && payload.id ? String(payload.id) : `web_${Date.now()}`
   let url = payload && payload.url ? String(payload.url) : 'about:blank'
   // 仅允许 http(s)/about，禁止 file:// 等本地 scheme 经内嵌浏览器读取本地文件后回读
   if (!/^(https?:|about:)/i.test(url)) url = 'about:blank'
-  ensureView(id)
-  attachView(id)
+  const { view, created } = views.ensure(id)
+  views.attach(id)
+
+  // 保活着的旧 view 一律不重新加载——重新加载就等于把用户翻到的那一页丢掉，
+  // 这正是本次要修的 bug。只有新建的、或上一次压根没加载成功（停在空白）的才加载。
+  const loaded = created ? '' : (view.webContents.getURL ? String(view.webContents.getURL() || '') : '')
+  const needLoad = created || !loaded || loaded === 'about:blank'
+  if (!needLoad) return { id, ok: true, reused: true, ...viewState(id) }
+
   try {
-    await views.get(id).webContents.loadURL(url)
+    await view.webContents.loadURL(url)
   } catch (e) {
     // 避免 loadURL 的 ERR_ABORTED 等成为未处理 rejection（与 navigate 行为一致）
-    return { id, ok: false, code: e && e.code ? String(e.code) : '', message: e && e.message ? String(e.message) : String(e) }
+    return { id, ok: false, reused: !created, code: e && e.code ? String(e.code) : '', message: e && e.message ? String(e.message) : String(e) }
   }
-  return { id }
+  return { id, ok: true, reused: !created, ...viewState(id) }
 })
 
 ipcMain.handle('checkba:browser-navigate', async (_evt, payload) => {
@@ -925,71 +901,80 @@ ipcMain.handle('checkba:browser-navigate', async (_evt, payload) => {
 ipcMain.handle('checkba:browser-set-active', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : null
   if (!id) return { ok: false }
-  attachView(id)
+  views.attach(id)
   return { ok: true }
+})
+
+// 面板卸载（切到别的标签、离开工作台）：只从窗口摘下，view 继续活着。
+// 这一条与 destroy 的分工就是「切标签不丢内容」的全部要害，别改回卸载即销毁。
+ipcMain.handle('checkba:browser-detach', async (_evt, payload) => {
+  const id = payload && payload.id ? String(payload.id) : null
+  if (!id) return { ok: false }
+  return { ok: views.detach(id) }
 })
 
 ipcMain.handle('checkba:browser-set-bounds', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : null
   const bounds = payload && payload.bounds ? payload.bounds : null
   if (!id || !bounds) return { ok: false }
-  const view = views.get(id)
-  if (!view) return { ok: false }
   const b = {
     x: Math.max(0, Math.floor(bounds.x || 0)),
     y: Math.max(0, Math.floor(bounds.y || 0)),
     width: Math.max(0, Math.floor(bounds.width || 0)),
     height: Math.max(0, Math.floor(bounds.height || 0))
   }
-  viewBounds.set(id, b)
-  // 仅更新 bounds，避免频繁 remove/add 导致导航被打断（ERR_ABORTED）
-  layoutAllViews()
-  return { ok: true }
+  return { ok: views.setBounds(id, b) }
 })
 
+// 标签真正关闭时才销毁（渲染层 closeFile / 工作台页面卸载）。
 ipcMain.handle('checkba:browser-destroy', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : null
   if (!id) return { ok: false }
-  const view = views.get(id)
-  if (!view) return { ok: false }
-  if (mainWindow) {
-    try {
-      mainWindow.removeBrowserView(view)
-    } catch (e) {
-      // ignore
-    }
-  }
-  try {
-    view.webContents.destroy()
-  } catch (e) {
-    // ignore
-  }
-  views.delete(id)
-  viewBounds.delete(id)
-  attachedViewIds.delete(id)
-  return { ok: true }
+  viewMobileUA.delete(id)
+  return { ok: views.destroy(id) }
 })
 
 ipcMain.handle('checkba:browser-set-views-visible', async (_evt, payload) => {
   const visible = payload && typeof payload.visible === 'boolean' ? payload.visible : true
-  viewsVisibleDesired = visible
-  setAllViewsVisible(visible)
+  views.setAllVisible(visible)
   return { ok: true }
 })
 
 ipcMain.handle('checkba:browser-set-ua', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : null
   const ua = payload && payload.ua ? String(payload.ua) : null
+  const mobile = !!(payload && payload.mobile)
   if (!id) return { ok: false }
   const view = views.get(id)
   if (!view) return { ok: false }
   try {
     if (ua) view.webContents.setUserAgent(ua)
+    viewMobileUA.set(id, mobile)
     // 自动刷新以生效
     view.webContents.reload()
     return { ok: true }
   } catch (e) {
     return { ok: false }
+  }
+})
+
+// 前进/后退/刷新：走 view 自己的历史。渲染层那份 history 数组做不到这件事——
+// 面板一卸载它就没了，而且它从来没驱动过 BrowserView（三个按钮在桌面端一直是死的）。
+ipcMain.handle('checkba:browser-history', async (_evt, payload) => {
+  const id = payload && payload.id ? String(payload.id) : null
+  const action = payload && payload.action ? String(payload.action) : ''
+  if (!id) return { ok: false }
+  const view = views.get(id)
+  if (!view) return { ok: false }
+  const wc = view.webContents
+  try {
+    if (action === 'back') { if (!wc.canGoBack()) return { ok: false }; wc.goBack() }
+    else if (action === 'forward') { if (!wc.canGoForward()) return { ok: false }; wc.goForward() }
+    else if (action === 'reload') wc.reload()
+    else return { ok: false, message: 'unknown action' }
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, message: String(e && e.message ? e.message : e) }
   }
 })
 
@@ -1016,7 +1001,7 @@ ipcMain.handle('checkba:browser-get-snapshot', async (_evt, payload) => {
 ipcMain.handle('checkba:browser-get-bounds', async (_evt, payload) => {
   const id = payload && payload.id ? String(payload.id) : null
   if (!id) return { ok: false }
-  const b = viewBounds.get(id)
+  const b = views.getBounds(id)
   if (!b) return { ok: false }
   return { ok: true, bounds: b }
 })

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js"
+    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/preload/preload.js
+++ b/desktop/preload/preload.js
@@ -31,7 +31,10 @@ contextBridge.exposeInMainWorld('checkbaDesktop', {
     setActive: (payload) => ipcRenderer.invoke('checkba:browser-set-active', payload),
     setBounds: (payload) => ipcRenderer.invoke('checkba:browser-set-bounds', payload),
     setViewsVisible: (payload) => ipcRenderer.invoke('checkba:browser-set-views-visible', payload),
+    // detach = 面板卸载（切标签），view 保活；destroy = 标签真的关了
+    detach: (payload) => ipcRenderer.invoke('checkba:browser-detach', payload),
     destroy: (payload) => ipcRenderer.invoke('checkba:browser-destroy', payload),
+    history: (payload) => ipcRenderer.invoke('checkba:browser-history', payload),
     getBounds: (payload) => ipcRenderer.invoke('checkba:browser-get-bounds', payload),
     waitReady: (payload) => ipcRenderer.invoke('checkba:browser-wait-ready', payload),
     onOpenNewTab: (handler) => {
@@ -48,6 +51,12 @@ contextBridge.exposeInMainWorld('checkbaDesktop', {
       const listener = (_evt, data) => handler && handler(data)
       ipcRenderer.on('checkba:browser-title-updated', listener)
       return () => ipcRenderer.removeListener('checkba:browser-title-updated', listener)
+    },
+    // 页内跳转后的当前地址（点链接、搜索、SPA 换路由）——标签靠它才不会停在打开时那一页
+    onUrlUpdated: (handler) => {
+      const listener = (_evt, data) => handler && handler(data)
+      ipcRenderer.on('checkba:browser-url-updated', listener)
+      return () => ipcRenderer.removeListener('checkba:browser-url-updated', listener)
     },
     getSnapshot: (payload) => ipcRenderer.invoke('checkba:browser-get-snapshot', payload),
     setUA: (payload) => ipcRenderer.invoke('checkba:browser-set-ua', payload)

--- a/desktop/tests/browser-views.test.js
+++ b/desktop/tests/browser-views.test.js
@@ -1,0 +1,117 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const { createBrowserViewRegistry } = require('../main/browser-views')
+
+function harness() {
+  const onWindow = new Set()
+  const win = {
+    addBrowserView: (v) => { if (onWindow.has(v)) throw new Error('already added'); onWindow.add(v) },
+    removeBrowserView: (v) => { onWindow.delete(v) },
+  }
+  const made = []
+  const registry = createBrowserViewRegistry({
+    createView: (id) => {
+      const view = {
+        id,
+        destroyed: false,
+        bounds: null,
+        setBounds: (b) => { view.bounds = b },
+        setAutoResize: () => {},
+        webContents: { destroy: () => { view.destroyed = true } },
+      }
+      made.push(view)
+      return view
+    },
+    getWindow: () => win,
+  })
+  const shownIds = () => [...onWindow].map((v) => v.id).sort()
+  return { registry, made, shownIds }
+}
+
+test('同一个标签第二次 ensure 复用旧 view（切回来不重新加载页面）', () => {
+  const { registry, made } = harness()
+  const first = registry.ensure('tab1')
+  assert.strictEqual(first.created, true)
+  const again = registry.ensure('tab1')
+  assert.strictEqual(again.created, false)
+  assert.strictEqual(again.view, first.view)
+  assert.strictEqual(made.length, 1)
+})
+
+test('detach 只是从窗口摘下，view 还活着；destroy 才真的销毁', () => {
+  const { registry, shownIds } = harness()
+  const { view } = registry.ensure('tab1')
+  registry.attach('tab1')
+  assert.deepStrictEqual(shownIds(), ['tab1'])
+
+  registry.detach('tab1')
+  assert.deepStrictEqual(shownIds(), [])
+  assert.strictEqual(registry.has('tab1'), true, 'detach 不该把 view 从注册表里删掉')
+  assert.strictEqual(view.destroyed, false, 'detach 不该销毁 webContents——页面状态就靠它留着')
+  // 切回来：复用同一个 view
+  assert.strictEqual(registry.ensure('tab1').created, false)
+
+  registry.destroy('tab1')
+  assert.strictEqual(registry.has('tab1'), false)
+  assert.strictEqual(view.destroyed, true)
+})
+
+test('全局隐藏再恢复：只挂回正在显示的标签，后台保活的不许冒出来', () => {
+  const { registry, shownIds } = harness()
+  for (const id of ['front', 'background']) registry.ensure(id)
+  registry.attach('front')
+  registry.attach('background')
+  registry.detach('background') // 用户切到了 front 标签，background 保活但不显示
+  assert.deepStrictEqual(shownIds(), ['front'])
+
+  registry.setAllVisible(false) // 弹窗/截图框选/离开工作台
+  assert.deepStrictEqual(shownIds(), [])
+
+  registry.setAllVisible(true)
+  assert.deepStrictEqual(shownIds(), ['front'], '恢复后只该有 front，background 是保活的后台标签')
+})
+
+test('隐藏期间挂载的面板：当下不上窗口，恢复时补上', () => {
+  const { registry, shownIds } = harness()
+  registry.ensure('tab1')
+  registry.setAllVisible(false)
+  registry.attach('tab1')
+  assert.deepStrictEqual(shownIds(), [], '蒙层开着的时候不能把 view 挂上去')
+  registry.setAllVisible(true)
+  assert.deepStrictEqual(shownIds(), ['tab1'])
+})
+
+test('destroy 之后不再被恢复挂回（记账清干净，不留幽灵）', () => {
+  const { registry, shownIds } = harness()
+  registry.ensure('tab1')
+  registry.attach('tab1')
+  registry.destroy('tab1')
+  registry.setAllVisible(false)
+  registry.setAllVisible(true)
+  assert.deepStrictEqual(shownIds(), [])
+  assert.deepStrictEqual(registry._state().wanted, [])
+  assert.deepStrictEqual(registry._state().attached, [])
+})
+
+test('同一个标签被左右双开：关掉一侧不该把另一侧正看的网页摘走', () => {
+  const { registry, shownIds } = harness()
+  registry.ensure('tab1')
+  registry.attach('tab1') // 左窗格
+  registry.attach('tab1') // 右窗格（跨窗格拖拽是复制，id 相同）
+  registry.detach('tab1') // 关掉其中一侧
+  assert.deepStrictEqual(shownIds(), ['tab1'], '另一侧还端着它，不能从窗口摘下')
+  registry.detach('tab1') // 两侧都没了
+  assert.deepStrictEqual(shownIds(), [])
+  assert.strictEqual(registry.has('tab1'), true, '摘下不等于销毁')
+})
+
+test('bounds 只更新不重挂（避免打断导航），destroy 后清掉', () => {
+  const { registry } = harness()
+  const { view } = registry.ensure('tab1')
+  registry.attach('tab1')
+  registry.setBounds('tab1', { x: 1, y: 2, width: 3, height: 4 })
+  assert.deepStrictEqual(view.bounds, { x: 1, y: 2, width: 3, height: 4 })
+  assert.deepStrictEqual(registry.getBounds('tab1'), { x: 1, y: 2, width: 3, height: 4 })
+  registry.destroy('tab1')
+  assert.strictEqual(registry.getBounds('tab1'), null)
+})

--- a/frontend/src/components/BrowserPane.vue
+++ b/frontend/src/components/BrowserPane.vue
@@ -86,15 +86,23 @@ export default {
       _desktopUnsub: null,
       _desktopResizeObs: null,
       _desktopViewId: '',
+      // 桌面端：BrowserView 自己维护历史，前进/后退可用性由主进程推过来
+      _desktopReady: false,
+      viewCanGoBack: false,
+      viewCanGoForward: false,
       isMobileMode: false
     }
   },
   computed: {
     ICONS() { return ICONS },
     canGoBack() {
+      // 桌面端不看组件里那份 history：面板一卸载它就没了，而 BrowserView 是保活的，
+      // 真实历史只有主进程知道
+      if (this.isDesktopBrowser) return this.viewCanGoBack
       return this.index > 0
     },
     canGoForward() {
+      if (this.isDesktopBrowser) return this.viewCanGoForward
       return this.index >= 0 && this.index < this.history.length - 1
     },
     isDesktopBrowser() {
@@ -121,9 +129,16 @@ export default {
     url: {
       immediate: true,
       handler(val) {
-        if (val && val !== this.currentUrl) {
-          this.navigate(val, true)
+        if (!val || val === this.currentUrl) return
+        // 桌面端首帧只把初值抄进组件，不去驱动 BrowserView：切回一个保活着的标签时
+        // 重新 loadURL 就等于把用户翻到的那一页丢掉（本组件修的正是这个）。
+        // 真正的创建/复用在 setupDesktopBrowser 里，之后这个 watcher 才恢复导航职责。
+        if (this.isDesktopBrowser && !this._desktopReady) {
+          this.currentUrl = this.normalizeUrl(val)
+          this.inputUrl = this.currentUrl === 'about:blank' ? '' : this.currentUrl
+          return
         }
+        this.navigate(val, true)
       }
     }
   },
@@ -195,13 +210,23 @@ export default {
         }
       }) : null
 
-      // 创建/加载
+      // 监听页内跳转（点链接、搜索、SPA 换路由）：BrowserView 自己跳的，渲染层此前
+      // 完全不知情，标签因此一直记着「打开时那个地址」——重建时就退回了默认首页。
+      this._desktopUrlUnsub = api.onUrlUpdated ? api.onUrlUpdated((data) => {
+        if (!data) return
+        if (data.id && String(data.id) !== String(this._desktopViewId)) return
+        this.adoptViewState(data)
+      }) : null
+
+      // 创建（已有同 id 的保活 view 时是复用，主进程不会重新加载）
       try {
-        await api.create({ id: this._desktopViewId, url: this.normalizeUrl(this.currentUrl || this.url) })
+        const res = await api.create({ id: this._desktopViewId, url: this.normalizeUrl(this.currentUrl || this.url) })
+        this.adoptViewState(res)
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn('desktop browser create failed', e)
       }
+      this._desktopReady = true
 
       // 绑定尺寸变化：把 DOM 的 rect 传给主进程作为 BrowserView bounds
       const mountRef = this.$refs.desktopMount
@@ -246,14 +271,42 @@ export default {
         // ignore
       }
       this._desktopTitleUnsub = null
-
-      // MVP：组件卸载即销毁 view（后续可由“tab close”统一管理，避免丢历史）
       try {
-        const api = host.browser
-        if (api && this._desktopViewId) api.destroy({ id: this._desktopViewId })
+        if (this._desktopUrlUnsub) this._desktopUrlUnsub()
       } catch (e) {
         // ignore
       }
+      this._desktopUrlUnsub = null
+      this._desktopReady = false
+
+      // 只从窗口摘下，不销毁：切走再切回来时同一个 view 原样接着用，页内跳转、
+      // 滚动位置、填了一半的表单、页面里的登录态都还在。
+      // 真正的销毁在标签关闭时（project-overview 的 closeFile / 页面卸载）。
+      try {
+        const api = host.browser
+        if (api && this._desktopViewId) api.detach({ id: this._desktopViewId })
+      } catch (e) {
+        // ignore
+      }
+    },
+
+    // 把 BrowserView 此刻的真实状态抄回工具栏与标签（复用旧 view 时尤其重要：
+    // 组件是新的，它对这个网页一无所知，只能问主进程）
+    adoptViewState(state) {
+      if (!state) return
+      const url = state.url ? String(state.url) : ''
+      this.viewCanGoBack = !!state.canGoBack
+      this.viewCanGoForward = !!state.canGoForward
+      if (typeof state.mobile === 'boolean') this.isMobileMode = state.mobile
+      if (url && url !== 'about:blank' && url !== this.currentUrl) {
+        this.currentUrl = url
+        this.inputUrl = url
+        this.$emit('url-change', url)
+      }
+      // url-change 会把标签名退成域名（父级按 host 命名），标题随后补回来。
+      // 复用旧 view 不会重新加载，等不到 page-title-updated，所以这里要主动带上。
+      const title = state.title ? String(state.title) : ''
+      if (title) this.$emit('title-change', title)
     },
     syncDesktopBounds() {
       const api = host.browser
@@ -285,7 +338,8 @@ export default {
       this.currentUrl = next
       this.inputUrl = next === 'about:blank' ? '' : next
 
-      // Desktop：直接导航 BrowserView
+      // Desktop：直接导航 BrowserView。历史由 view 自己维护（见 goBack/goForward），
+      // 组件里那份 history 数组只服务 H5 的 iframe 模式。
       if (this.isDesktopBrowser) {
         try {
           const api = host.browser
@@ -296,6 +350,8 @@ export default {
         } catch (e) {
           // ignore
         }
+        this.$emit('url-change', next)
+        return
       }
 
       if (replace && this.index >= 0) {
@@ -311,8 +367,25 @@ export default {
 
       this.$emit('url-change', next)
     },
+    // 后退/前进/刷新：桌面端交给 BrowserView 自己的历史。
+    // 此前这三个按钮在桌面端只改了地址栏文字、从没驱动过 BrowserView（点了没反应）；
+    // 而且组件里的 history 数组会随面板卸载清空，保活之后更没法当历史用。
+    desktopHistory(action) {
+      try {
+        const api = host.browser
+        if (!api || !api.history || !this._desktopViewId) return false
+        Promise.resolve(api.history({ id: this._desktopViewId, action })).catch(() => {})
+        return true
+      } catch (e) {
+        return false
+      }
+    },
     reload() {
-      // 重新设置 src 触发刷新
+      if (this.isDesktopBrowser) {
+        this.desktopHistory('reload')
+        return
+      }
+      // H5：重新设置 src 触发刷新
       const u = this.currentUrl
       this.currentUrl = 'about:blank'
       this.$nextTick(() => {
@@ -321,6 +394,10 @@ export default {
     },
     goBack() {
       if (!this.canGoBack) return
+      if (this.isDesktopBrowser) {
+        this.desktopHistory('back')
+        return
+      }
       this.index -= 1
       this.currentUrl = this.history[this.index]
       this.inputUrl = this.currentUrl
@@ -328,6 +405,10 @@ export default {
     },
     goForward() {
       if (!this.canGoForward) return
+      if (this.isDesktopBrowser) {
+        this.desktopHistory('forward')
+        return
+      }
       this.index += 1
       this.currentUrl = this.history[this.index]
       this.inputUrl = this.currentUrl
@@ -350,9 +431,11 @@ export default {
       const desktopUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
       
       try {
+        // mobile 一并告诉主进程：view 是保活的，切回来时工具栏要照它的真实 UA 回填
         await api.setUA({
           id: this._desktopViewId,
-          ua: this.isMobileMode ? mobileUA : desktopUA
+          ua: this.isMobileMode ? mobileUA : desktopUA,
+          mobile: this.isMobileMode
         })
       } catch (e) {
         // ignore

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -229,6 +229,14 @@ export const fileOpenTabsMethods = {
         idx = list.findIndex(f => f.id === fileId)
         if (idx === -1) return
       }
+      // 浏览器标签：BrowserPane 卸载时只把 BrowserView 摘下（保活，为的是切标签
+      // 不丢网页内容），真正销毁只发生在标签关闭——也就是这里，以及页面卸载。
+      // 跨窗格拖拽是「在另一侧也打开同一个标签」（同 id 双开，见 tabDragSplit），
+      // 所以另一侧还开着的时候不能销毁——那是把人家正看着的网页拔掉。
+      if (this.isBrowserTab(file) && !this.isOpenInOtherPane(fileId, pane)) {
+        this.destroyBrowserView(file.id)
+      }
+
       const activeId = this[idProp]
 
       // If closing the active file/tab, the activityTracker.trackActivePage in activateTab or openFile will handle the switch.

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -2284,6 +2284,11 @@ export default {
     // Stop Activity Tracking
     this.stopActivityTracking()
 
+    // Desktop：本页的浏览器标签随页面一起消失，对应的 BrowserView 必须销毁。
+    // BrowserPane 卸载时只 detach（保活，切标签不丢内容），销毁的责任因此落在
+    // 「标签真的没了」的两处：closeFile 与这里。漏掉就是主进程里的 view 泄漏。
+    this.destroyAllBrowserViews()
+
     // Cleanup manual event listener removed
   },
   onLoad(query) {
@@ -3640,6 +3645,24 @@ export default {
     // OCR 采集与浮层生命周期方法组已外置（Phase 3c） → ./ocrCapture.js
     isBrowserTab(tab) {
       return !!tab && tab.tabType === 'web'
+    },
+    // 销毁某个浏览器标签对应的 BrowserView。BrowserPane 卸载只 detach（保活），
+    // 所以「标签关闭」必须显式销毁，否则主进程里的 view 一直留着。
+    destroyBrowserView(tabId) {
+      try {
+        const api = host.browser
+        if (api && api.destroy && tabId) {
+          Promise.resolve(api.destroy({ id: String(tabId) })).catch(() => {})
+        }
+      } catch (e) {
+        // ignore
+      }
+    },
+    destroyAllBrowserViews() {
+      const all = [...(this.leftFiles || []), ...(this.rightFiles || [])]
+      for (const t of all) {
+        if (this.isBrowserTab(t)) this.destroyBrowserView(t.id)
+      }
     },
     onBrowserUrlChange(pane, url) {
       const active = pane === 'left' ? this.activeFileLeft : this.activeFileRight

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 // 桌面宿主链路 e2e / desktop host-chain e2e (Electron + CDP).
 //
-// 覆盖浏览器目标够不到的两处：
+// 覆盖浏览器目标够不到的三处：
 //  ① 编辑器保存链路：新建 Word → 编辑器（<webview> 内真实 LOWA 引擎）boot → 宿主
 //     执行器插入文本 → 点保存按钮 → 后端落盘 → API 下载 docx 验证内容真的写进了文件。
 //  ② 需要真实桌面能力（window.checkbaDesktop.fs）才渲染的界面形态——目前是项目
 //     列表页那两张新建卡。app-e2e 的最小桌面桩不含 fs，那边只能验降级形态。
+//  ③ 浏览器面板的 BrowserView 生命周期：切走标签再切回来必须还是原来那一页（保活），
+//     关掉标签才销毁（不泄漏）。浏览器目标里根本没有 BrowserView，只有这里能验。
 //
 // 跑法（本机）：
 //   1) worktree/主仓库 frontend：`npx uni --port 5174`（dev:h5，VITE_API_BASE_URL
@@ -21,6 +23,7 @@
 // 端口会经 CHECKBA_BACKEND_PORT 传给 Electron 壳，渲染层因此跟测试用同一个后端）
 
 import { spawn, execSync } from 'node:child_process'
+import http from 'node:http'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
@@ -52,6 +55,11 @@ const portFree = (p) => {
 const pickCdpPort = () => {
   for (let p = 9333; p < 9373; p++) if (portFree(p)) return p
   throw new Error('9333-9372 全被占，挑不出空闲 CDP 端口')
+}
+// 同样的理由（维护者常年多开）：浏览器面板那一段自起的本机测试站也得现挑端口
+const pickFreePort = (from) => {
+  for (let p = from; p < from + 60; p++) if (portFree(p)) return p
+  throw new Error(from + '-' + (from + 59) + ' 全被占，挑不出空闲端口')
 }
 const CDP_PORT = Number(process.env.DESKTOP_E2E_CDP_PORT) || pickCdpPort()
 const MARKER = 'QA_SAVE_MARKER_' + Date.now()
@@ -354,6 +362,191 @@ try {
   })
   const pageErrs = []
   page.on('pageerror', (e) => pageErrs.push(String(e).slice(0, 160)))
+
+  // ---- 浏览器面板：切走标签再切回来必须还是原来那一页 ----
+  // 修复前的行为：BrowserPane 一卸载就 destroy 掉 BrowserView（切个标签就把整个网页
+  // 连根拔掉），而渲染层记的 tab.url 又从不跟随页内跳转（点链接/搜索主进程知道、
+  // 渲染层不知情）。两件事叠起来，切回来就是「退回打开时那个地址」——默认标签的
+  // 那个地址是 https://www.baidu.com，用户看到的现象正是「变成默认地址、内容没了」。
+  // 只有桌面目标能验：浏览器目标里压根没有 BrowserView。
+  // 用本机起的两页小站而不是真网站：断言不能挂在外网可达性上。
+  const SITE_PORT = pickFreePort(8811)
+  const SITE = 'http://127.0.0.1:' + SITE_PORT
+  let site = null
+  const clickTabAt = async (idx) => {
+    const box = await page.evaluate((check, i) => {
+      const el = document.querySelectorAll('.tabs-pane-left .tab-item')[i]
+      if (!el) return null
+      return eval(check + '; hitCheck(el)')
+    }, HIT_CHECK, idx)
+    await clickAt(box, '第 ' + (idx + 1) + ' 个标签')
+    await sleep(1200)
+  }
+  const webTabs = () => page.evaluate(() => {
+    const vm = window.__checkbaActiveOverviewVm
+    if (!vm) return null
+    return (vm.leftFiles || []).filter((f) => f && f.tabType === 'web').map((f) => ({ name: f.name, url: f.url }))
+  })
+  const sitePages = async () => {
+    const out = []
+    for (const t of browser.targets().filter((t) => t.url().startsWith(SITE))) {
+      const p = await t.page().catch(() => null)
+      if (p) out.push(p)
+    }
+    return out
+  }
+  // 从窗口摘下的 BrowserView，Chromium 会把它的渲染进程冻起来（后台标签的正常待遇，
+  // 页面状态照样留着）。往冻着的 target 里 evaluate 会一直挂着，最后只落一句
+  // 「Runtime.callFunctionOn timed out」——查不出是哪一步。所以对 view 的求值自带超时，
+  // 切回来之后先轮询到它重新应答为止。
+  const evalInView = (vp, fn, ms = 4000) => Promise.race([
+    vp.evaluate(fn),
+    new Promise((_, rej) => setTimeout(() => rej(new Error('view 求值超时(' + ms + 'ms)')), ms)),
+  ])
+  const evalInViewWhenAwake = async (vp, fn, tries = 12) => {
+    let last = null
+    for (let i = 0; i < tries; i++) {
+      try { return await evalInView(vp, fn) } catch (e) { last = e; await sleep(1000) }
+    }
+    throw new Error('view 一直没醒过来：' + String(last && last.message ? last.message : last))
+  }
+
+  await step('浏览器标签：切走再切回来仍是原来那一页（BrowserView 保活）', async () => {
+    site = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      if ((req.url || '/').startsWith('/b')) res.end('<html><head><title>QA-PAGE-B</title></head><body><h1>B</h1></body></html>')
+      else res.end('<html><head><title>QA-PAGE-A</title></head><body><h1>A</h1><a id="go" href="' + SITE + '/b">B</a></body></html>')
+    })
+    await new Promise((r) => site.listen(SITE_PORT, '127.0.0.1', r))
+
+    // 两个网页标签：第一个用来翻页，第二个只是「切走去别处」的落点。
+    // 顶栏图标很小、这前后界面还在重排，点空是常态（同「新建文档」那一步的教训）：
+    // 点了就验效果、不够就补点，别一次点完直接断言。
+    // 这个按钮是顶栏里 21×21 的小图标，而且它所在的 .project-header 是无边框窗口的
+    // 拖拽区（按钮自己是 no-drag）。点空是常态，所以点了就验效果、不够就补点。
+    // 失败时把「点击有没有真的落到按钮上」一起报出来——只报「标签没开出来」的话，
+    // 分不清是没点到还是点到了但处理器早退。
+    await page.evaluate(() => {
+      if (window.__awdBrowserBtnHits) return
+      window.__awdBrowserBtnHits = 0
+      document.addEventListener('click', (e) => {
+        const el = e.target && e.target.closest ? e.target.closest('[title="浏览器"]') : null
+        if (el) window.__awdBrowserBtnHits++
+      }, true)
+    })
+    let opened = []
+    for (let round = 0; round < 8 && opened.length < 2; round++) {
+      await mouseClickSel('[title="浏览器"]')
+      await sleep(1200)
+      opened = (await webTabs()) || []
+    }
+    if (opened.length < 2) {
+      const snap = await page.evaluate(() => {
+        const el = document.querySelector('[title="浏览器"]')
+        const r = el ? el.getBoundingClientRect() : null
+        return {
+          domTabs: document.querySelectorAll('.tabs-pane-left .tab-item').length,
+          btnRect: r ? [Math.round(r.x), Math.round(r.y), Math.round(r.width), Math.round(r.height)] : null,
+          clicksReachedBtn: window.__awdBrowserBtnHits,
+          vm: !!window.__checkbaActiveOverviewVm,
+          files: window.__checkbaActiveOverviewVm
+            ? (window.__checkbaActiveOverviewVm.leftFiles || []).map((f) => f.tabType + ':' + f.name) : null,
+        }
+      }).catch(() => null)
+      throw new Error('两个网页标签没开出来：' + JSON.stringify(snap) + '；页面错误=' + JSON.stringify(pageErrs.slice(-3)))
+    }
+    await clickTabAt(0)
+
+    // 地址栏真人输入 + 点「打开」（uni 的 <input> 外面套了一层 uni-input，要点里面那个）。
+    // 地址栏里本来就有当前地址，得先全选再打字——否则是接在后面续写，
+    // 实测会得到 "https://www.baidu.com/http://127.0.0.1:xxxx/a" 这种四不像。
+    // 全选用三连击而不是 ⌘A：CDP 打进来的 ⌘A 到不了原生菜单的 Select All role，
+    // 实测选不中，于是新地址被接在旧地址后面。三连击是纯渲染层行为，稳。
+    const addrBox = await page.evaluate((check) => {
+      const el = document.querySelector('.browser-toolbar .url-input input')
+      if (!el) return null
+      return eval(check + '; hitCheck(el)')
+    }, HIT_CHECK)
+    if (!addrBox || addrBox.blockedBy) throw new Error('地址栏点不到：' + JSON.stringify(addrBox))
+    await page.mouse.click(addrBox.x, addrBox.y, { clickCount: 3 })
+    await sleep(300)
+    await page.keyboard.type(SITE + '/a')
+    await sleep(300)
+    // 输进去没有当场就验：没验的话下面只会报「找不到 BrowserView」，
+    // 分不清是没输进去、没点开、还是保活链路坏了。
+    const typed = await page.evaluate(() => {
+      const el = document.querySelector('.browser-toolbar .url-input input')
+      return el ? { value: el.value, focused: document.activeElement === el } : null
+    })
+    if (!typed || !String(typed.value).endsWith('/a')) {
+      throw new Error('地址栏没吃到输入：' + JSON.stringify(typed))
+    }
+    await mouseClickSel('[title="打开"]')
+    let viewPages = []
+    for (let i = 0; i < 20 && !viewPages.length; i++) { await sleep(500); viewPages = await sitePages() }
+    if (!viewPages.length) {
+      const snap = await page.evaluate(() => {
+        const vm = window.__checkbaActiveOverviewVm
+        const el = document.querySelector('.browser-toolbar .url-input input')
+        return {
+          addr: el ? el.value : '(没有地址栏)',
+          tabs: vm ? (vm.leftFiles || []).map((f) => f.tabType + ':' + f.url) : '(没有实例指针)',
+        }
+      }).catch(() => null)
+      throw new Error('地址栏导航没生效：找不到指向测试站的 BrowserView；' + JSON.stringify(snap))
+    }
+
+    // 页内跳转（点页面里的链接）——这一步渲染层此前完全不知情
+    const vp = viewPages[0]
+    await vp.click('#go')
+    for (let i = 0; i < 20 && !vp.url().endsWith('/b'); i++) await sleep(300)
+    if (!vp.url().endsWith('/b')) throw new Error('页内跳转没成功：' + vp.url())
+    // 只活在这一个文档实例上的标记：重新 loadURL 会把它冲掉，据此判断"是不是同一页"
+    await evalInViewWhenAwake(vp, () => { window.__awdQaAlive = 'ALIVE'; return 'ok' })
+
+    await sleep(800)
+    const tracked = (await webTabs())[0]
+    if (!tracked || !String(tracked.url).endsWith('/b')) {
+      throw new Error('标签没跟上页内跳转（切回来就会退回旧地址）：' + JSON.stringify(tracked))
+    }
+
+    // 切到第二个标签，再切回来
+    await clickTabAt(1)
+    await clickTabAt(0)
+    await sleep(1500)
+
+    const back = await sitePages()
+    if (!back.length) throw new Error('切回来之后 BrowserView 没了（又变成卸载即销毁）')
+    const alive = await evalInViewWhenAwake(back[0], () => window.__awdQaAlive || '(页面被重新加载了)')
+      .catch((e) => '(读不到：' + String(e.message || e) + ')')
+    if (alive !== 'ALIVE') throw new Error('网页被重建了，不是原来那一页：' + alive + '；URL=' + back[0].url())
+    if (!back[0].url().endsWith('/b')) throw new Error('切回来地址变了：' + back[0].url())
+    const shown = await page.evaluate(() => {
+      const el = document.querySelector('.browser-toolbar .url-input input')
+      return el ? el.value : '(没有地址栏)'
+    })
+    if (!String(shown).endsWith('/b')) throw new Error('地址栏没跟上，显示的是 ' + shown)
+  })
+
+  await step('关闭网页标签才销毁 BrowserView（保活不等于泄漏）', async () => {
+    for (let i = 0; i < 6; i++) {
+      const n = await page.evaluate(() => document.querySelectorAll('.tabs-pane-left .tab-item').length)
+      if (!n) break
+      const box = await page.evaluate((check) => {
+        const el = document.querySelector('.tabs-pane-left .tab-item .tab-close')
+        if (!el) return null
+        return eval(check + '; hitCheck(el)')
+      }, HIT_CHECK)
+      if (!box) break
+      await clickAt(box, '标签的关闭按钮')
+      await sleep(800)
+    }
+    let left = await sitePages()
+    for (let i = 0; i < 10 && left.length; i++) { await sleep(500); left = await sitePages() }
+    if (left.length) throw new Error('标签关了但 BrowserView 还在（主进程里泄漏）：' + left.map((p) => p.url()).join(','))
+    try { site.close() } catch (e) { /* ignore */ }
+    site = null
+  })
 
   await step('新建 Word 文档并点击打开（编辑器 webview）', async () => {
     // 「新建文档」是个 18×16 的小图标，而顶栏（试用徽标/负责人行）在这前后还在
@@ -698,6 +891,7 @@ try {
     console.log('    docx ' + buf.length + ' 字节，标记命中')
   })
 } finally {
+  try { if (site) site.close() } catch {}
   try { await api('/api/projects/' + QA.projectId, { method: 'DELETE' }) } catch {}
   try { browser.disconnect() } catch {}
   killTree()


### PR DESCRIPTION
## 现象

开一个浏览器标签、在页面里翻到别处（搜索、点链接），切到别的标签再切回来，地址退回打开时那一个——默认标签就是 `https://www.baidu.com`——已经打开的内容全没了。

## 根因（dev Electron 实测复现，两个叠在一起）

| 时刻 | BrowserView 实际地址 | 渲染层记的 `tab.url` | 页内状态 |
|---|---|---|---|
| 页内点链接后 | `/b` | `/a`（没跟上） | 在 |
| 切走再切回 | `/a`（重建） | `/a` | 没了 |

1. **BrowserPane 一卸载就 `destroy` 掉 BrowserView**（原代码自己标着「MVP：组件卸载即销毁 view」）。切标签会把面板整个卸载，于是整张网页——页内跳转、滚动位置、填了一半的表单、页面里的登录态——被连根拔掉。
2. **标签记的 `url` 从不跟随页内跳转**。主进程其实知道（`page-title-updated` 那条消息里就带着当前 url），但渲染层只取了 title、把 url 扔了。于是重建时用的是「当初打开时那个地址」。

## 改法

**面板卸载 = detach（view 保活），标签关闭才 destroy。**

- 新增 `desktop/main/browser-views.js` 收口 BrowserView 记账：`wanted`（哪些面板正端着它，**计数**）与 `attached`（此刻真挂在窗口上）分开记。全局隐藏（弹窗/蒙层、离开工作台、截图框选）恢复时**只挂回 wanted 的**——否则后台保活的标签会一起浮到最上层盖住界面。计数而非布尔是为了跨窗格双开（同 id 两个面板）关掉一侧时不把另一侧正看的网页摘走。
- `browser-create` 复用已有 view 时**不重新 loadURL**，并把 view 此刻的真实状态（url / title / 前进后退可用性 / 是否移动端 UA）回给渲染层回填工具栏。
- 新增 `did-navigate` / `did-navigate-in-page` → `checkba:browser-url-updated`，标签地址与地址栏跟着页内跳转走。
- 销毁责任落到「标签真的没了」两处：`closeFile` 与工作台页面卸载。

顺带修掉同一面板上三个一直是死的按钮：**后退 / 前进 / 刷新**此前只改了地址栏文字、从没驱动过 BrowserView（点了没反应），现在走 view 自己的历史。组件里那份 `history` 数组只剩 H5 iframe 模式在用。

## 验证

- `desktop/tests/browser-views.test.js` 钉住记账（复用不重载、detach 不销毁、隐藏恢复只挂回前台、双开计数、关闭才销毁）；`cd desktop && npm test` **44/44**。
- `desktop-e2e` 新增两步真人链路（切走切回来仍是**同一个文档实例**、关标签才销毁）——**在修复前的代码上会红在「标签没跟上页内跳转」**，修完全通，连跑 3 轮稳定。
- `app-e2e` 93/1；唯一失败的 EasyVoice 在未改动的基线上同样失败（本机没装 Kokoro 模型）。
- 领域文档 `.claude/agents/utility-tools.md` 已同步生命周期契约与地雷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)