### PR TITLE
fix(i18n): 工具名兜底串去掉冻结的中文；两侧对账立成护栏

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -1,5 +1,6 @@
 package com.checkba.service.ai;
 
+import com.checkba.service.LangText;
 import com.checkba.service.ai.context.ProjectContextHolder;
 import com.checkba.service.ai.tools.AgentToolComponent;
 import com.checkba.service.ai.tools.ToolContext;
@@ -82,11 +83,21 @@ public class ToolRegistry {
      */
     public record RegisteredTool(Object bean, Method method, ToolSpecification spec, ToolMeta meta, boolean fromPlugin) {
 
+        /**
+         * 兜底展示名。**用户实际看到的工具名不在这里**：过程卡按工具代号查前端的
+         * `utils/toolDisplayNames.js`（工具元数据不随 SSE 下发，前端自备一份，
+         * 完整性由 ToolDisplayNameCoverageTest 钉着）。这里的值只进 `<process name>`
+         * 写入历史，以及前端解析不出工具代号时的回退。
+         *
+         * <p>回退串走 LangText 而不是硬写中文：同一条链路下游的 AgentOrchestrator
+         * 早就是 {@code LangText.of("工具执行", "Tool execution")}，这里漏了就成了
+         * 英文会话里唯一冒中文的那一处。
+         */
         public String displayName() {
             if (meta != null && !meta.displayName().isEmpty()) {
                 return meta.displayName();
             }
-            return "工具执行";
+            return LangText.of("工具执行", "Tool execution");
         }
     }
 

--- a/backend/src/test/java/com/checkba/service/ai/ToolDisplayNameCoverageTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolDisplayNameCoverageTest.java
@@ -1,0 +1,167 @@
+package com.checkba.service.ai;
+
+import com.checkba.service.ai.tools.AgentToolComponent;
+import dev.langchain4j.agent.tool.Tool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * 工具人性化名称的两侧对账：后端每个已注册工具，前端 {@code utils/toolDisplayNames.js} 里
+ * 都得有一行。
+ *
+ * <p><b>为什么需要这条护栏</b>：用户在过程卡上看到的工具名<b>不是</b>后端
+ * {@code @ToolMeta(displayName)}——工具元数据不随 SSE 下发，前端只能自备一份 zh/en 映射，
+ * 按工具代号查。漏一行的后果不是报错，而是律师用户看到 {@code doc get outline} 这种
+ * snake_case 兜底串（前端 toolDisplayName 的降级路径）。而后端加工具是最日常的动作，
+ * 「记得去前端补一行」这种约定靠注释留不住——所以在这里钉死。
+ *
+ * <p>反向（前端有、后端没有）只告警不失败：后端下线一个工具时留几行死映射无害，
+ * 而失败会逼着下线工具的人顺手改前端，反倒制造无关改动。
+ *
+ * <p>注册口径与 {@link ToolRegistry} 一致：扫 {@link AgentToolComponent} 实现类里的
+ * {@code @Tool} 方法。插件工具（运行期从 jar 装）不在其内，也不该在其内——它们的名字
+ * 由插件自己带，前端走兜底展示。
+ */
+class ToolDisplayNameCoverageTest {
+
+    /** 从后端源码树定位前端那份映射：两侧在同一个仓库里，backend/ 的兄弟目录。 */
+    private static final Path FRONTEND_MAP =
+            Path.of("..", "frontend", "src", "utils", "toolDisplayNames.js");
+
+    /** NAMES 表的一行：`  tool_code: { zh: '…', en: '…' },` */
+    private static final Pattern MAP_ENTRY = Pattern.compile("^\\s{2}([a-z][a-z0-9_]*)\\s*:\\s*\\{", Pattern.MULTILINE);
+
+    @Test
+    @DisplayName("后端每个已注册工具在前端 toolDisplayNames.js 里都有名字")
+    void everyRegisteredToolHasAFrontendName() throws IOException {
+        // 单独跑 backend 模块（没有 frontend 目录）时跳过，而不是红：这条护栏是仓库级的
+        assumeTrue(Files.isRegularFile(FRONTEND_MAP),
+                "找不到 " + FRONTEND_MAP.toAbsolutePath().normalize() + "，跳过两侧对账");
+
+        Set<String> backend = registeredToolNames();
+        Set<String> frontend = frontendMappedNames();
+
+        assertFalse(backend.isEmpty(), "一个工具都没扫到，说明扫描口径坏了，不是真的没有工具");
+        assertFalse(frontend.isEmpty(), "前端映射一行都没解析出来，检查 MAP_ENTRY 正则是否跟文件形态脱节");
+
+        List<String> missing = backend.stream().filter(name -> !frontend.contains(name)).sorted().toList();
+        assertTrue(missing.isEmpty(),
+                "这些工具在 frontend/src/utils/toolDisplayNames.js 里没有名字，过程卡会显示 "
+                        + "snake_case 兜底串。补上 zh/en 两列即可：" + missing);
+    }
+
+    /**
+     * 每行都得有 zh 与 en 两列。{@code toolDisplayName} 是
+     * {@code isEnglish() ? entry.en : entry.zh}——缺一列不会报错，会把
+     * {@code undefined} 画到过程卡上。和 locale 键对拍是同一类防静默失败的检查。
+     */
+    @Test
+    @DisplayName("前端映射每行都有 zh 与 en 两列且都非空")
+    void everyFrontendEntryHasBothLanguages() throws IOException {
+        assumeTrue(Files.isRegularFile(FRONTEND_MAP), "找不到前端映射，跳过");
+
+        String src = Files.readString(FRONTEND_MAP, StandardCharsets.UTF_8);
+        Pattern row = Pattern.compile("^\\s{2}([a-z][a-z0-9_]*)\\s*:\\s*\\{([^}]*)}", Pattern.MULTILINE);
+        List<String> broken = new ArrayList<>();
+        Matcher m = row.matcher(src);
+        while (m.find()) {
+            String body = m.group(2);
+            boolean zh = Pattern.compile("\\bzh\\s*:\\s*['\"][^'\"]").matcher(body).find();
+            boolean en = Pattern.compile("\\ben\\s*:\\s*['\"][^'\"]").matcher(body).find();
+            if (!zh || !en) {
+                broken.add(m.group(1) + (zh ? "" : " 缺 zh") + (en ? "" : " 缺 en"));
+            }
+        }
+        assertTrue(broken.isEmpty(),
+                "这些行缺语言列，界面上会显示 undefined（toolDisplayName 直接取 entry.en/entry.zh）："
+                        + broken);
+    }
+
+    @Test
+    @DisplayName("前端映射里没有后端已不存在的死行（只告警，不失败）")
+    void reportsStaleFrontendEntries() throws IOException {
+        assumeTrue(Files.isRegularFile(FRONTEND_MAP), "找不到前端映射，跳过");
+
+        Set<String> backend = registeredToolNames();
+        Set<String> frontend = frontendMappedNames();
+        // 规模打进日志：护栏失败时能立刻分辨「漏补一行」和「扫描口径坏了」
+        System.out.println("[工具名对账] 后端已注册 " + backend.size()
+                + " 个工具，前端映射 " + frontend.size() + " 行");
+        List<String> stale = frontend.stream()
+                .filter(name -> !backend.contains(name)).sorted().toList();
+        if (!stale.isEmpty()) {
+            // 无害（死映射不会被查到），但攒多了会让人误以为这些工具还在
+            System.out.println("[提示] 前端映射里有 " + stale.size()
+                    + " 行对应的后端工具已不存在，可顺手清理：" + stale);
+        }
+    }
+
+    // ---------- 后端侧：按 ToolRegistry 的口径扫 ----------
+
+    private static Set<String> registeredToolNames() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AssignableTypeFilter(AgentToolComponent.class));
+
+        Set<String> names = new LinkedHashSet<>();
+        for (var candidate : scanner.findCandidateComponents("com.checkba")) {
+            Class<?> type;
+            try {
+                type = Class.forName(candidate.getBeanClassName());
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("扫到工具组件但加载不了：" + candidate.getBeanClassName(), e);
+            }
+            if (!isProductionClass(type)) continue;
+            for (Method method : type.getMethods()) {
+                if (method.isAnnotationPresent(Tool.class)) {
+                    names.add(method.getName());
+                }
+            }
+        }
+        return names;
+    }
+
+    /**
+     * 只认主源码编译出来的类。测试 classpath 上也有一批 {@link AgentToolComponent} 桩件
+     * （eval harness 与各种 *_probe / echo 工具），它们不是产品工具，前端当然没有名字——
+     * 不排掉的话这条护栏第一次跑就会拿桩件报一串假缺口。
+     */
+    private static boolean isProductionClass(Class<?> type) {
+        var source = type.getProtectionDomain().getCodeSource();
+        if (source == null || source.getLocation() == null) return true; // 取不到来源时宁可纳入
+        String location = source.getLocation().getPath();
+        return !location.contains("test-classes");
+    }
+
+    // ---------- 前端侧：解析 NAMES 表的键 ----------
+
+    private static Set<String> frontendMappedNames() throws IOException {
+        String src = Files.readString(FRONTEND_MAP, StandardCharsets.UTF_8);
+        Set<String> names = new LinkedHashSet<>();
+        Matcher m = MAP_ENTRY.matcher(src);
+        List<String> all = new ArrayList<>();
+        while (m.find()) {
+            all.add(m.group(1));
+        }
+        names.addAll(all);
+        return names;
+    }
+}


### PR DESCRIPTION
收 #398 结尾那条「明知而未做」。**动手前先量了一遍，结论和我原来的判断不同**，所以做法也不同。

## 我原来的判断是错的

我在 #398 里写「`@ToolMeta(displayName)` 全仓 188 处都是中文，改了会不一致，属独立问题」。实测下来这个模型是错的：

用户在过程卡上看到的工具名**不是**后端 `@ToolMeta(displayName)`。工具元数据不随 SSE 下发，前端 `utils/toolDisplayNames.js` 自备一份 zh/en 映射按工具代号查；`ProcessCard` 在英文界面下还会主动越过后端标题优先用前端表（`ProcessCard.vue:166`）。

对账实测：**后端 239 个已注册工具，前端映射 239 行，零缺失、零死行，每行 zh/en 都齐。**

所以翻那些注解既不改变用户看到的东西，还会把同一份文案变成第三份副本。真正的问题是另外两个:

## 真正的两处问题

**① 冻结的中文字面量**
`ToolRegistry.RegisteredTool.displayName()` 的兜底串硬写 `"工具执行"`。同一条链路下游的 `AgentOrchestrator` 早就是 `LangText.of("工具执行", "Tool execution")`——这里漏了，成了英文会话里唯一冒中文的那一处（前端解析不出工具代号时会回退到它）。已改走 LangText。

**② 两侧同步没有任何护栏**
全靠 `toolDisplayNames.js` 顶上那句注释「后端新增工具时同步补一行」。今天恰好是齐的，但没有东西保证它继续齐——漏一行**不报错**，只是律师用户看到 `doc get outline` 这种 snake_case 兜底串。而后端加工具是最日常的动作。这才是该修的东西。

## 护栏

新增 `ToolDisplayNameCoverageTest`，按 `ToolRegistry` 的**同一口径**（扫 `AgentToolComponent` 实现类里的 `@Tool` 方法，不是正则啃 Java 源码）对账前端映射，三条断言：

| 断言 | 失败/告警 | 理由 |
|---|---|---|
| 后端每个工具在前端都有名字 | 失败，报出具体工具名 | 漏一行 = 用户看到原始代号 |
| 每行 zh/en 两列都非空 | 失败，报出缺哪列 | `toolDisplayName` 是 `isEnglish() ? entry.en : entry.zh`，缺一列把 `undefined` 画到卡上——静默失败，和 locale 键对拍同一类 |
| 前端有、后端没有的死行 | 只打印不失败 | 下线工具时留几行死映射无害；失败反而逼人制造无关改动 |

两处实现细节值得记着:
- **必须排掉 test-classes 里的 `AgentToolComponent` 桩件**（`echo` / `*_probe` 那一批）。不排的话护栏第一次跑就拿桩件报 13 个假缺口——我踩了这一下才收窄成「只认主源码产物」（按 code source 路径过滤）。
- 插件工具（运行期从 jar 装）**刻意不纳入**：名字由插件自带，前端走兜底展示。

## 护栏本身验过会咬人

不是写完看它绿就算数:
- 临时删掉 `search_web` 那一行 → 失败，并点名 `[search_web]`;
- 临时去掉它的 `en` 列 → 失败，并报 `[search_web 缺 en]`;
- 两次都还原干净（`git diff` 为空，`search_web:` 计数回到 1）。

## 验证

| 项 | 结果 |
|---|---|
| `mvn test` 全量 | ✓ 1839 通过，0 失败 |
| `npm run check:locales` | ✓ 20 个命名空间 |
| `npm run check:emits` | ✓ 85 个 .vue |

CI 日志里现在会有一行 `[工具名对账] 后端已注册 239 个工具，前端映射 239 行`——护栏将来失败时，能立刻分辨「漏补一行」和「扫描口径坏了」。

## 关于那 57 个没有 @ToolMeta 的工具

它们的后端展示名回落到兜底串，但用户看到的仍是前端表里的正确名字（ProcessCard 对 `工具执行` 这个标题也有专门的覆盖分支）。给它们补 displayName-only 的注解不改变任何用户可见行为，只会多出一份会漂移的副本。**这是一个设计结论，不是一件待办**——权威在前端表，现在有测试把这件事写下来了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)