### PR TITLE
fix(browser): Web/H5 切走标签再切回来不再丢内容；顺带修掉从没跑起来过的注入脚本

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -31,6 +31,57 @@ title-updated，把同一条消息里的 url 扔了）。
 **前进/后退/刷新走 view 自己的历史**（`checkba:browser-history`）：组件里那份 `history` 数组
 只服务 H5 iframe 模式，桌面端从来没驱动过 BrowserView（三个按钮点了没反应），保活之后更没法当历史用。
 
+**Web/H5 的那一半（iframe + 后端代理，改这块之前必读）**：没有 BrowserView 时 BrowserPane
+渲染 `<iframe :src=代理地址>`，src 由 `GET /api/browser/proxy?url=…&token=…` 拼出。桌面端那两个病
+（切走再切回来丢内容 / 地址不跟随页内跳转）在这条链路上是各自独立的根因，**都要修**：
+- **保活**靠组件不卸载：`leftWebTabs`/`rightWebTabs` 是与 `leftLibreFiles` 同形制的池
+  （按标签建实例 + `v-show` 藏 + LRU `WEB_KEEPALIVE_MAX=5`）。`v-show` 的 `display:none`
+  **不会**丢掉 iframe 文档（滚动位置也在，实测过），换 `src` 才会。
+  **这个池只在 Web 开**（`webKeepAliveEnabled = !host.browser`）：桌面端一次挂 5 个
+  BrowserPane 就是 5 个 BrowserView 同时挂到窗口上，后台那几个会浮上来盖住界面
+  （即下面「无脑挂回全部」那条地雷），而桌面端的保活早由 detach 解决了。
+  上限存在的理由：摘下的 BrowserView 会被 Chromium 冻住，藏起来的 iframe **不会**——
+  它们跟前台页共用同一个渲染进程，定时器照跑。
+- **地址**靠代理注入脚本回报 `postMessage({type:'URL_CHANGED', url})`。iframe 是不透明源
+  （`sandbox` 不带 `allow-same-origin`，**绝不能加**：与 `allow-scripts` 同时出现时沙箱失效，
+  被访问站点就能读本应用 origin 下的会话凭证），父窗口读不到它的 location，只能等页面自己报。
+  postMessage 这条通道在不透明源下照常可用（`event.origin` 是 `"null"`，鉴别靠 token）。
+- **`currentUrl` 与 `iframeUrl` 必须分开记**：前者是地址栏/标签显示的地址，跟随页内跳转；
+  后者是「iframe 被要求加载的地址」。把跟随来的新地址回写进 src，等于每跳一次就把
+  刚打开的那一页重新加载一遍——保活白做。
+- **保活之后后台标签也会报事件**（站点自己 302、SPA 换路由），所以
+  `onBrowserUrlChange/onBrowserTitleChange` 收 `(pane, tabId, value)`，按 id 找标签；
+  按「当前激活的那个」收会把后台标签的地址写到用户正看着的标签上。activityTracker
+  只记激活标签。
+- 跨窗格双开在 Web 下是**两个独立 iframe**（`tabDragSplit.moveTabTo` 跨窗格复制了 tab 对象，
+  左右各有自己的 `tab.url`），与桌面端「一个 BrowserView、`wanted` 计数」不是一回事。
+
+**注入脚本的三条硬规则**（`BrowserProxyController.inject`，`BrowserProxyControllerTest` 钉住）：
+1. **整段拼成一行，里面绝不能出现 `//` 行注释**——它会把后面全部代码一起注释掉。
+   这个 bug 从写下那天一直活到 2026-08：页面上只留一句
+   `SyntaxError: Unexpected end of input`，`_blank`/`window.open` 拦截、同标签跳转、
+   `OPEN_NEW_TAB` 回传三件事**全部静默失效**（现象是「点了没反应」，极易误判成 CSP 拦截）。
+   要写注释只能用 `/* */`，且写成 Java 侧拼接之间的块注释（不进产物）。
+2. **`proxify` 必须拼绝对地址**：页面里有我们注入的 `<base href=真站点>`，
+   `location.href = '/api/browser/proxy?…'` 会按文档 base 解析到**被访问站点**头上
+   （实测跳成 `http://被访站/api/browser/proxy?url=…`，站点回 404）。
+   做法是拿当前文档地址换 query（`new URL(location.href)` + `u.search=…`），
+   这样不依赖后端知道前端的 origin/子路径。
+3. **塞进 JS 字面量的值要过 `escapeJsString`**：页面地址是被访问站点能控的（302 到任意 URL），
+   带 `</script>` 或单引号就能跳出脚本。反斜杠必须先转，`<` 转 `\x3C`。
+
+**代理回的 HTML 必须带 charset**：以前是「按 UTF-8 解码、回 `text/html` 不带 charset」，
+浏览器拿默认编码（windows-1252）去解 UTF-8 字节，**中文页面在面板里整页乱码**。
+现在按上游 Content-Type 的 charset 解码、统一以 `text/html;charset=utf-8` 回。
+没覆盖的一档：只在 `<meta charset>` 里声明、响应头不带的 GBK 页面。
+
+**SSRF 例外名单（`security.browser-proxy.e2e-allowed-hosts`，默认空）**：`SsrfGuard` 按解析后的
+IP 拦回环/内网，而 app-e2e 要用本机起的两页小站验这条链路（断言不能挂在外网可达性上）。
+名单默认空、**刻意不写进任何 application*.yml**，只有显式传
+`SECURITY_BROWSER_PROXY_E2E_ALLOWED_HOSTS` 的进程才放行，发行版拿不到；精确主机名匹配，
+不认通配。别为了省事填成通配——放行的是「服务端替你去抓这个地址」，
+local-mode 下本机后端把每个请求都当本机用户，等于把本机管理端口暴露给被访问的网页。
+
 **截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
 
 **剪贴板**：`ClipboardPanel.vue`；desktop main.js 轮询监听 clipboardWatchTimer ~:117-232（指纹去重 ~:110，首 tick 只记指纹）、推送 `checkba:clipboard-copied`；后端 `controller/ClipboardController.java`（/api/clipboard：GET /、POST /text、POST /file、GET /{id}/file、DELETE /{id}）。
@@ -133,6 +184,11 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 - **摘下窗口的 BrowserView 会被 Chromium 冻住渲染进程**（后台标签的正常待遇，页面状态照留）。
   自动化里往冻着的 target 里 evaluate 会一直挂到 CDP 的 protocolTimeout，最后只落一句
   「Runtime.callFunctionOn timed out」——desktop-e2e 那一段为此自带超时与「等它醒过来」轮询。
+- **浏览器面板的注入脚本是一行**：加代码时别顺手写 `//` 注释，整段会当场死掉且只在页面控制台
+  留一句 SyntaxError（详见上面「注入脚本的三条硬规则」）。app-e2e 的 J6.7 与
+  `BrowserProxyControllerTest` 都能拦住。
+- **给网页标签加保活池要分宿主**：Web 走组件池，桌面走 BrowserView detach；两边都开等于
+  桌面端把多个 BrowserView 同时挂上窗口。
 - 剪贴板去重靠指纹+window 级状态，改动监听逻辑先读 PR#148/#151 教训。
 - `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
 - Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。asr-models 的下载走同一条路，同样禁 xet。
@@ -157,5 +213,11 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 
 - desktop 服务栈：`cd desktop && npm test`（service-manager/model-manager/pysvc-runtime/**browser-views**）。
   `browser-views.test.js` 钉住的就是上面那套记账：复用不重载、detach 不销毁、隐藏恢复只挂回前台、双开计数。
-- 后端相关单测：TtsServiceTest、FileControllerChunkedUploadTest、ProjectFileService*Test 等；剪贴板/收藏/搜索/OCR/浏览器代理暂无专属测试。
-- UI 链路：`cd frontend && npm run test:app-e2e`。
+- 后端相关单测：TtsServiceTest、FileControllerChunkedUploadTest、ProjectFileService*Test、
+  **BrowserProxyControllerTest**（SSRF 例外名单默认关、注入脚本能解析、proxify 绝对地址 +
+  URL_CHANGED、JS 字面量转义、HTML 带 charset）等；剪贴板/收藏/搜索/OCR 暂无专属测试。
+- UI 链路：`cd frontend && npm run test:app-e2e`。其中 **J6.7 浏览器面板**覆盖 Web/H5 这条链路
+  （harness 自起两页小站 → 开两个网页标签 → 页内点链接跳第二页 → 切走再切回来断言仍是同一个
+  文档实例 + 地址正确）。跑它要给后端加
+  `SECURITY_BROWSER_PROXY_E2E_ALLOWED_HOSTS=127.0.0.1`，否则这一段会显式 skip（不假绿）。
+  桌面端（BrowserView）那一半在 `npm run test:desktop-e2e`。

--- a/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
+++ b/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
@@ -39,6 +39,32 @@ public class BrowserProxyController {
             .connectTimeout(Duration.ofSeconds(10))
             .build();
 
+    /**
+     * e2e 专用的 SSRF 例外名单（逗号分隔的主机名，精确匹配、不认通配）。
+     *
+     * <p>存在的唯一理由：app-e2e 要在本机起一个两页小站来验这条代理链路，而 {@link
+     * com.checkba.util.SsrfGuard} 按解析后的 IP 判断，127.0.0.1 与任何能在本机 bind 的地址
+     * （回环、RFC1918、CGNAT）全在拦截清单里——不开这个口子，浏览器面板这条链路就只能拿外网
+     * 站点当断言对象，等于把测试挂在网络可达性上。
+     *
+     * <p><b>默认空，且刻意不写进任何 application*.yml</b>：只有显式传
+     * {@code SECURITY_BROWSER_PROXY_E2E_ALLOWED_HOSTS} 的进程才会放行，发行版永远拿不到。
+     * 放行的是「服务端替你去抓这个地址」，本机后端在 local-mode 下把每个请求都当本机用户，
+     * 放行内网地址等于把本机的管理端口暴露给被访问的网页——所以这里只认精确主机名，
+     * 也绝不要为了省事填成通配。{@code BrowserProxyControllerTest} 钉住「不设 = 照样拦」。
+     */
+    @org.springframework.beans.factory.annotation.Value("${security.browser-proxy.e2e-allowed-hosts:}")
+    private String e2eAllowedHosts;
+
+    /** 主机是否在 e2e 例外名单里（精确、忽略大小写）。名单为空时恒为 false。 */
+    private boolean isE2eAllowedHost(String host) {
+        if (host == null || host.isBlank() || e2eAllowedHosts == null || e2eAllowedHosts.isBlank()) return false;
+        for (String allowed : e2eAllowedHosts.split(",")) {
+            if (host.equalsIgnoreCase(allowed.trim())) return true;
+        }
+        return false;
+    }
+
     @GetMapping("/proxy")
     public ResponseEntity<?> proxy(
             @RequestParam("url") String url,
@@ -62,7 +88,9 @@ public class BrowserProxyController {
                 }
                 // 网段清单统一由 SsrfGuard 维护：本控制器原先自己判断，漏了 100.64.0.0/10
                 // （阿里云实例元数据 100.100.100.200 就在其中，能换取实例 RAM 凭证）与 IPv6 ULA
-                if (com.checkba.util.SsrfGuard.rejectIfBlocked(uri.toString()) != null) {
+                // 例外名单默认空（见 e2eAllowedHosts），发行版走的永远是下面这条无条件校验
+                if (!isE2eAllowedHost(uri.getHost())
+                        && com.checkba.util.SsrfGuard.rejectIfBlocked(uri.toString()) != null) {
                     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(LangText.of("目标地址不被允许（已禁止本地/内网地址）", "Target address is not allowed (local/internal addresses are blocked)"));
                 }
                 HttpRequest req = HttpRequest.newBuilder(uri)
@@ -87,10 +115,14 @@ public class BrowserProxyController {
             String contentType = resp.headers().firstValue("content-type").orElse("application/octet-stream");
             // 只对 HTML 注入脚本，其它资源原样返回（图片/CSS/JS 等）
             if (contentType.toLowerCase().contains("text/html")) {
-                String html = new String(resp.body(), StandardCharsets.UTF_8);
+                // 按上游声明的字符集解码，回给浏览器时统一声明 UTF-8。
+                // 以前是「按 UTF-8 解、回 text/html 不带 charset」：浏览器于是拿默认编码
+                // （windows-1252）去解我们发出去的 UTF-8 字节，中文页面整页乱码。
+                // 已知没覆盖的一档：只在 <meta charset> 里声明、响应头不带的 GBK 页面。
+                String html = new String(resp.body(), charsetOf(contentType));
                 String injected = inject(html, uri.toString(), token);
                 HttpHeaders headers = new HttpHeaders();
-                headers.setContentType(MediaType.TEXT_HTML);
+                headers.setContentType(new MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8));
                 headers.setCacheControl("no-store");
                 return new ResponseEntity<>(injected, headers, HttpStatus.OK);
             }
@@ -109,11 +141,28 @@ public class BrowserProxyController {
         }
     }
 
+    /** 从响应头的 Content-Type 里取字符集；没写或者认不出就按 UTF-8。 */
+    private java.nio.charset.Charset charsetOf(String contentType) {
+        try {
+            for (String part : contentType.split(";")) {
+                String p = part.trim();
+                if (p.toLowerCase().startsWith("charset=")) {
+                    String name = p.substring("charset=".length()).trim().replace("\"", "");
+                    if (java.nio.charset.Charset.isSupported(name)) return java.nio.charset.Charset.forName(name);
+                }
+            }
+        } catch (Exception ignore) {
+            // 落到 UTF-8
+        }
+        return StandardCharsets.UTF_8;
+    }
+
     private String inject(String html, String baseUrl, String token) {
         String safeBase = escapeHtmlAttr(baseUrl);
-        // 反斜杠必须先转义：只替换单引号的话，token 末尾带 \ 会把我们补的转义符本身
-        // 变成被转义的反斜杠，随后的单引号照样闭合字符串，等于在注入脚本里执行任意 JS
-        String safeToken = token == null ? "" : token.replace("\\", "\\\\").replace("'", "\\'");
+        String safeToken = escapeJsString(token);
+        // 页面的真实地址（跟完重定向之后那个）。注入进去是因为 iframe 自己的
+        // location 是代理地址，页面无从知道“我到底在哪一页”，而渲染层要靠它更新标签地址。
+        String safePageUrl = escapeJsString(baseUrl);
 
         // 1) base：让相对路径资源能回到原站点加载
         String baseTag = "<base href=\"" + safeBase + "\">";
@@ -121,12 +170,29 @@ public class BrowserProxyController {
         // 0) 尽量移除页面自带的 CSP meta（否则可能禁用我们注入的 inline script，导致“点了没反应”）
         String cleaned = stripCspMeta(html);
 
-        // 2) 注入脚本：拦截 target=_blank / window.open
+        // 2) 注入脚本：拦截 target=_blank / window.open，并把真实地址回报给渲染层
+        //
+        // 整段脚本拼成**一行**，所以里面绝对不能出现 `//` 行注释——它会把后面的
+        // 全部代码一起注释掉，页面上只留一句 SyntaxError: Unexpected end of input，
+        // 拦截、跳转、postMessage 三件事一起静默失效（这个 bug 存活到 2026-08 才发现，
+        // 现象是“点了没反应”，很容易误判成 CSP 拦截）。要写注释只能用 /* */。
         String script = "<script>(function(){"
                 + "var TOKEN='" + safeToken + "';"
+                + "var PAGE_URL='" + safePageUrl + "';"
                 + "function post(type,url){try{window.parent && window.parent.postMessage({__checkbaBrowser:true,token:TOKEN,type:type,url:url},'*');}catch(e){}}"
                 + "function debug(msg){post('DEBUG',String(msg||''));}"
-                + "function proxify(url){try{return '/api/browser/proxy?url='+encodeURIComponent(url)+'&token='+encodeURIComponent(TOKEN);}catch(e){return url;}}"
+                /* proxify：必须拼成绝对地址。iframe 里有我们注入的 <base href=真站点>，
+                   而 location.href 的赋值是按文档 base 解析的——给相对路径的话
+                   '/api/browser/proxy?...' 会解析到被访问站点自己头上（实测跳出
+                   http://被访站/api/browser/proxy?url=... 的四不像，站点回 404）。
+                   拿当前文档地址（就是代理端点本身）换 query 最稳：不依赖后端知道
+                   前端从哪个 origin/子路径来，也不怕应用部署在子路径下。 */
+                + "function proxify(url){var q='?url='+encodeURIComponent(url)+'&token='+encodeURIComponent(TOKEN);"
+                + "try{var u=new URL(location.href);u.search=q;return u.toString();}catch(e){return '/api/browser/proxy'+q;}}"
+                /* 每次文档加载都回报一次真实地址：页内点链接、站点自己 302、SPA 换页
+                   都会重新走一遍代理，渲染层据此让 tab.url 跟上。不报的话标签永远停在
+                   打开时那个地址，切走再切回来就退回默认首页。 */
+                + "post('URL_CHANGED',PAGE_URL);"
                 + "var _open=window.open;"
                 + "window.open=function(url){try{debug('window.open -> '+String(url||''));}catch(e){} if(url){post('OPEN_NEW_TAB',String(url));}return null;};"
                 + "document.addEventListener('click',function(e){"
@@ -137,8 +203,8 @@ public class BrowserProxyController {
                 + "var abs=a.href||href;"
                 + "var t=(a.getAttribute('target')||'').toLowerCase();"
                 + "if(t==='_blank'){try{debug('click _blank -> '+String(abs));}catch(e){} e.preventDefault();e.stopPropagation();post('OPEN_NEW_TAB',String(abs));return;}"
-                + "// 同一标签页内导航也强制走 proxy，保证后续页面仍可拦截 _blank/window.open"
-                + "try{debug('click nav -> '+String(abs));}catch(e){};"
+                /* 同一标签页内导航也强制走 proxy，保证后续页面仍可拦截 _blank/window.open */
+                + "try{debug('click nav -> '+String(abs));}catch(e){}"
                 + "e.preventDefault();e.stopPropagation();window.location.href=proxify(String(abs));"
                 + "},true);"
                 + "})();</script>";
@@ -174,6 +240,25 @@ public class BrowserProxyController {
         out = out.replaceAll("(?is)<meta\\s+[^>]*name\\s*=\\s*['\\\"]?content-security-policy['\\\"]?[^>]*>", "");
         out = out.replaceAll("(?is)<meta\\s+[^>]*name\\s*=\\s*['\\\"]?csp['\\\"]?[^>]*>", "");
         return out;
+    }
+
+    /**
+     * 转义成能安全塞进单引号 JS 字面量的串。
+     *
+     * <p>反斜杠必须先转义：只替换单引号的话，末尾带 {@code \} 的值会把我们补的转义符本身
+     * 变成被转义的反斜杠，随后的单引号照样闭合字符串，等于在注入脚本里执行任意 JS。
+     * {@code <} 一并转成 {@code \x3C}，否则值里带 {@code </script>} 就能直接闭合 script 标签
+     * 跳出字面量——页面地址是被访问站点能控制的（302 到任意 URL），不是可信输入。
+     */
+    private String escapeJsString(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\")
+                .replace("'", "\\'")
+                .replace("<", "\\x3C")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n")
+                .replace("\u2028", "\\u2028")
+                .replace("\u2029", "\\u2029");
     }
 
     private String escapeHtmlAttr(String s) {

--- a/backend/src/test/java/com/checkba/controller/BrowserProxyControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/BrowserProxyControllerTest.java
@@ -1,0 +1,143 @@
+package com.checkba.controller;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 浏览器面板代理（Web/H5 那条链路）的契约。
+ *
+ * <p>钉三件事：
+ * <ol>
+ *   <li><b>SSRF 例外名单默认关</b>——不设就照样拦回环，e2e 那个口子不能悄悄留在发行版里；</li>
+ *   <li><b>注入脚本必须能解析</b>——整段拼成一行，字符串外出现 {@code //} 就会把后面全部
+ *       代码注释掉（这个 bug 让 _blank/window.open 拦截、同标签跳转、postMessage 三件事
+ *       静默失效了很久，页面上只留一句 SyntaxError: Unexpected end of input）；</li>
+ *   <li><b>同标签跳转拼绝对地址 + 回报真实地址</b>——相对路径会被注入的 {@code <base>}
+ *       解析到被访问站点头上，而 {@code URL_CHANGED} 是渲染层让 tab.url 跟随导航的唯一来源。</li>
+ * </ol>
+ */
+class BrowserProxyControllerTest {
+
+    private HttpServer site;
+    private String siteUrl;
+    private BrowserProxyController controller;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // 端口 0 = 内核分配，维护者常年多开并行会话，写死端口必撞
+        site = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        site.createContext("/", exchange -> {
+            byte[] body = "<html><head><title>T</title></head><body>去第二页</body></html>".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        site.start();
+        siteUrl = "http://127.0.0.1:" + site.getAddress().getPort() + "/a";
+        controller = new BrowserProxyController();
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (site != null) site.stop(0);
+    }
+
+    @Test
+    void loopbackBlockedWhenAllowListUnset() {
+        assertEquals(HttpStatus.FORBIDDEN, controller.proxy(siteUrl, "tok").getStatusCode(),
+                "例外名单为空时必须照常拦回环——这个默认值是发行版唯一会用到的那个");
+    }
+
+    @Test
+    void loopbackBlockedWhenAllowListNamesAnotherHost() {
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "example.invalid");
+        assertEquals(HttpStatus.FORBIDDEN, controller.proxy(siteUrl, "tok").getStatusCode(),
+                "名单是精确匹配，别的主机在名单里不等于放行本机");
+    }
+
+    @Test
+    void injectedScriptParsesAndCarriesNavigationContract() {
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "127.0.0.1");
+        ResponseEntity<?> resp = controller.proxy(siteUrl, "br_tok_1");
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        String script = extractInjectedScript(String.valueOf(resp.getBody()));
+
+        assertNoLineComment(script);
+
+        // 同标签跳转必须拼绝对地址：相对路径会被上面注入的 <base href=真站点> 解析到
+        // 被访问站点头上（实测跳成 http://被访站/api/browser/proxy?url=…，站点回 404）
+        assertTrue(script.contains("new URL(location.href)"),
+                "proxify 必须基于当前文档地址拼绝对 URL，否则会被 <base> 解析到被访问站点上");
+
+        // 渲染层靠它让 tab.url 跟随页内导航；报的必须是真实页面地址，不是代理地址
+        assertTrue(script.contains("post('URL_CHANGED',PAGE_URL)"), "每次文档加载都要回报真实地址");
+        assertTrue(script.contains("var PAGE_URL='" + siteUrl + "'"),
+                "PAGE_URL 应是跟完重定向之后的真实地址，实际脚本：" + script);
+    }
+
+    @Test
+    void htmlResponseDeclaresCharset() {
+        // 不声明 charset 的话浏览器拿默认编码（windows-1252）去解我们发出去的 UTF-8 字节，
+        // 中文页面在浏览器面板里整页乱码（"去第二页" → "åŽ»ç¬¬äºŒé¡µ"）
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "127.0.0.1");
+        ResponseEntity<?> resp = controller.proxy(siteUrl, "tok");
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals(StandardCharsets.UTF_8, resp.getHeaders().getContentType().getCharset(),
+                "回给浏览器的 HTML 必须声明 charset=utf-8");
+        assertTrue(String.valueOf(resp.getBody()).contains("去第二页"), "正文不该在服务端就被解坏");
+    }
+
+    @Test
+    void scriptStringEscapingSurvivesHostileUrl() {
+        // 被访问站点能 302 到任意地址，页面地址不是可信输入：带 </script> 或单引号
+        // 就能跳出 JS 字面量。构造真实的恶意重定向成本太高，这里直接验转义函数。
+        // 不要包一层 String.valueOf：invokeMethod 的返回类型靠目标推断，包起来会选中
+        // String.valueOf(char[]) 那个重载，运行时炸 ClassCastException
+        String escaped = ReflectionTestUtils.invokeMethod(
+                controller, "escapeJsString", "https://x/?a=</script><script>evil()&b='+alert(1)+'");
+        assertFalse(escaped.contains("<"), "< 一律转 \\x3C，否则能闭合 script 标签跳出脚本：" + escaped);
+        for (int i = 0; i < escaped.length(); i++) {
+            if (escaped.charAt(i) == '\'') {
+                assertTrue(i > 0 && escaped.charAt(i - 1) == '\\',
+                        "第 " + i + " 个字符上有没转义的单引号，能闭合字面量：" + escaped);
+            }
+        }
+    }
+
+    /** 扫一遍字符串字面量之外的 {@code //}。脚本里没有块注释也没有除法，所以这个扫描是精确的。 */
+    private void assertNoLineComment(String js) {
+        boolean inStr = false;
+        for (int i = 0; i < js.length() - 1; i++) {
+            char c = js.charAt(i);
+            if (inStr) {
+                if (c == '\\') i++;
+                else if (c == '\'') inStr = false;
+                continue;
+            }
+            if (c == '\'') { inStr = true; continue; }
+            if (c == '/' && js.charAt(i + 1) == '/') {
+                fail("注入脚本是单行拼接，字符串外出现 // 行注释会把后面全部代码一起注释掉。位置 "
+                        + i + "：" + js.substring(Math.max(0, i - 60), Math.min(js.length(), i + 60)));
+            }
+        }
+    }
+
+    private String extractInjectedScript(String html) {
+        int start = html.indexOf("<script>");
+        int end = html.indexOf("</script>", start);
+        assertTrue(start >= 0 && end > start, "没找到注入的脚本：" + html.substring(0, Math.min(300, html.length())));
+        return html.substring(start + "<script>".length(), end);
+    }
+}

--- a/frontend/src/components/BrowserPane.vue
+++ b/frontend/src/components/BrowserPane.vue
@@ -79,7 +79,15 @@ export default {
     return {
       history: [],
       index: -1,
+      // currentUrl = 地址栏/标签显示的地址；iframeUrl = iframe 真正被要求加载的地址。
+      // 两个必须分开：页内跳转之后 currentUrl 要跟着走（否则切回来退回打开时那个地址），
+      // 但 iframe 已经站在那一页上了，把新地址回写进 src 会让它整个重新加载一遍——
+      // 页面状态、滚动位置、填了一半的表单全没，正是这次要修的病。
       currentUrl: 'about:blank',
+      iframeUrl: 'about:blank',
+      // 这一次加载是我们自己发起的（地址栏/前进后退），用来区分「站点自己重定向」
+      // 和「用户点了链接」：前者该替换历史栈顶，后者该新增一条
+      _pendingNav: false,
       inputUrl: '',
       iframeToken: `br_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
       _messageHandler: null,
@@ -114,9 +122,11 @@ export default {
       }
     },
     iframeSrc() {
-      // iframe 永远加载 proxy 地址（保证可拦截 _blank / window.open，且导航保持在工作区内）
-      if (!this.currentUrl || this.currentUrl === 'about:blank') return 'about:blank'
-      const raw = String(this.currentUrl).trim()
+      // iframe 永远加载 proxy 地址（保证可拦截 _blank / window.open，且导航保持在工作区内）。
+      // 读 iframeUrl 而不是 currentUrl：页内跳转只动 currentUrl，这里不能跟着变，
+      // 否则每跳一次都会被 Vue 改一次 src、把刚打开的那一页重新加载掉。
+      if (!this.iframeUrl || this.iframeUrl === 'about:blank') return 'about:blank'
+      const raw = String(this.iframeUrl).trim()
       if (!raw || raw.startsWith('about:')) return 'about:blank'
       if (raw.startsWith('http://') || raw.startsWith('https://')) {
         const base = getApiBaseUrl().replace(/\/$/, '')
@@ -155,6 +165,12 @@ export default {
       if (data.token !== this.iframeToken) return
       if (data.type === 'OPEN_NEW_TAB' && data.url) {
         this.$emit('open-new-tab', String(data.url))
+      }
+      if (data.type === 'URL_CHANGED' && data.url) {
+        // 代理注入的脚本在每次文档加载时回报真实地址（页内点链接、站点自己 302）。
+        // 这是 Web/H5 下标签地址跟随导航的唯一来源——iframe 是不透明源，父窗口
+        // 读不到它的 location（sandbox 不带 allow-same-origin，也绝不能带）。
+        this.adoptPageUrl(String(data.url))
       }
       if (data.type === 'DEBUG' && data.url) {
         // 打点：用于排查“点了没反应”（例如 CSP 禁止注入 / 链接不是 <a target=_blank> / window.open 被覆盖）
@@ -308,6 +324,29 @@ export default {
       const title = state.title ? String(state.title) : ''
       if (title) this.$emit('title-change', title)
     },
+    // H5：iframe 里的文档换了一页（点链接 / 站点自己重定向）。只更新"显示与记账"那一侧，
+    // 绝不回写 iframeUrl —— 那会让已经站在新页上的 iframe 再加载一次。
+    // 与桌面端的 adoptViewState 是同一件事的两种实现（那边问主进程，这边等页面回报）。
+    adoptPageUrl(url) {
+      const next = String(url || '').trim()
+      if (!next || next === this.currentUrl) {
+        this._pendingNav = false
+        return
+      }
+      this.currentUrl = next
+      this.inputUrl = next
+      if (this._pendingNav && this.index >= 0) {
+        // 我们刚要求加载的那一页被站点重定向走了：替换栈顶而不是新增一条，
+        // 否则「后退」会回到那个只会再跳一次的地址，按钮看着能用其实在原地打转
+        this.history.splice(this.index, 1, next)
+      } else {
+        if (this.index < this.history.length - 1) this.history = this.history.slice(0, this.index + 1)
+        this.history.push(next)
+        this.index = this.history.length - 1
+      }
+      this._pendingNav = false
+      this.$emit('url-change', next)
+    },
     syncDesktopBounds() {
       const api = host.browser
       const mountRef = this.$refs.desktopMount
@@ -354,6 +393,10 @@ export default {
         return
       }
 
+      // H5：这一条才是真正让 iframe 去加载
+      this.iframeUrl = next
+      this._pendingNav = true
+
       if (replace && this.index >= 0) {
         this.history.splice(this.index, 1, next)
       } else {
@@ -385,11 +428,13 @@ export default {
         this.desktopHistory('reload')
         return
       }
-      // H5：重新设置 src 触发刷新
+      // H5：重新设置 src 触发刷新。刷的是 currentUrl（用户此刻看的这一页），
+      // 不是 iframe 当初被要求加载的那一页——页内跳转之后两者已经不是一回事了
       const u = this.currentUrl
-      this.currentUrl = 'about:blank'
+      this.iframeUrl = 'about:blank'
       this.$nextTick(() => {
-        this.currentUrl = u
+        this.iframeUrl = u
+        this._pendingNav = true
       })
     },
     goBack() {
@@ -399,9 +444,7 @@ export default {
         return
       }
       this.index -= 1
-      this.currentUrl = this.history[this.index]
-      this.inputUrl = this.currentUrl
-      this.$emit('url-change', this.currentUrl)
+      this.goToHistoryEntry()
     },
     goForward() {
       if (!this.canGoForward) return
@@ -410,8 +453,14 @@ export default {
         return
       }
       this.index += 1
+      this.goToHistoryEntry()
+    },
+    // H5 前进/后退：history 里那一条既要显示出来，也要真的让 iframe 去加载
+    goToHistoryEntry() {
       this.currentUrl = this.history[this.index]
       this.inputUrl = this.currentUrl
+      this.iframeUrl = this.currentUrl
+      this._pendingNav = true
       this.$emit('url-change', this.currentUrl)
     },
     openInAppNewTab() {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -836,18 +836,28 @@
                       @menu-state="pushMenuState"
                     />
                   </view>
-                  <view v-if="activeFileLeft && !useLibreEditor(activeFileLeft)" class="pane-content">
+                  <!-- 网页标签保活池（Web/H5）：与上面的编辑器保活池同形制——按标签建实例、
+                       v-show 藏。BrowserPane 在 Web 下渲染的是 <iframe>，组件一卸载文档就
+                       整个没了，切回来按 tab.url 重新加载（页内跳转、滚动位置、填了一半的
+                       表单全丢）。桌面端这个池只留当前激活的那一个，保活由 BrowserView
+                       detach 负责，见 webKeepAliveEnabled。 -->
+                  <view
+                    v-for="tab in leftWebTabs"
+                    :key="'web-left-' + tab.id"
+                    v-show="activeFileLeft && activeFileLeft.id === tab.id"
+                    class="pane-content"
+                  >
                     <BrowserPane
-                      v-if="isBrowserTab(activeFileLeft)"
-                      :key="activeFileLeft.id"
-                      :tab-id="activeFileLeft.id"
-                      :url="activeFileLeft.url"
-                      @url-change="onBrowserUrlChange('left', $event)"
-                      @title-change="onBrowserTitleChange('left', $event)"
+                      :tab-id="tab.id"
+                      :url="tab.url"
+                      @url-change="onBrowserUrlChange('left', tab.id, $event)"
+                      @title-change="onBrowserTitleChange('left', tab.id, $event)"
                       @open-new-tab="openBrowserTab($event)"
                     />
+                  </view>
+                  <view v-if="activeFileLeft && !useLibreEditor(activeFileLeft) && !isBrowserTab(activeFileLeft)" class="pane-content">
                     <MarkdownPreview
-                      v-else-if="isMarkdownTab(activeFileLeft)"
+                      v-if="isMarkdownTab(activeFileLeft)"
                       :content="activeFileLeft.content"
                       :file="activeFileLeft"
                     />
@@ -939,18 +949,26 @@
                       @menu-state="pushMenuState"
                     />
                   </view>
-                  <view v-if="activeFileRight && !useLibreEditor(activeFileRight)" class="pane-content">
+                  <!-- 网页标签保活池（见左窗格同名注释）。跨窗格拖拽是"在另一侧也打开同一
+                       标签"（同 id、但 tabDragSplit 复制了对象），所以左右各有自己的实例
+                       与自己的 tab.url，互不干扰。 -->
+                  <view
+                    v-for="tab in rightWebTabs"
+                    :key="'web-right-' + tab.id"
+                    v-show="activeFileRight && activeFileRight.id === tab.id"
+                    class="pane-content"
+                  >
                     <BrowserPane
-                      v-if="isBrowserTab(activeFileRight)"
-                      :key="activeFileRight.id"
-                      :tab-id="activeFileRight.id"
-                      :url="activeFileRight.url"
-                      @url-change="onBrowserUrlChange('right', $event)"
-                      @title-change="onBrowserTitleChange('right', $event)"
+                      :tab-id="tab.id"
+                      :url="tab.url"
+                      @url-change="onBrowserUrlChange('right', tab.id, $event)"
+                      @title-change="onBrowserTitleChange('right', tab.id, $event)"
                       @open-new-tab="openBrowserTab($event)"
                     />
+                  </view>
+                  <view v-if="activeFileRight && !useLibreEditor(activeFileRight) && !isBrowserTab(activeFileRight)" class="pane-content">
                     <MarkdownPreview
-                      v-else-if="isMarkdownTab(activeFileRight)"
+                      v-if="isMarkdownTab(activeFileRight)"
                       :content="activeFileRight.content"
                       :file="activeFileRight"
                     />
@@ -1596,6 +1614,12 @@ import { clipboardBridgeMethods } from './clipboardBridge.js'
 import { ocrActionMethods } from './ocrActions.js'
 import { ocrCaptureMethods } from './ocrCapture.js'
 
+// 网页标签保活上限（只在 Web/H5 生效，桌面端保活是 BrowserView 的活，见 leftWebTabs）。
+// 为什么要有上限、而桌面端可以不要：从窗口摘下的 BrowserView 会被 Chromium 冻住渲染进程，
+// 藏起来的 iframe 不会——它们跟前台页共用同一个渲染进程，定时器照跑、音视频照放。
+// 5 = 一件案子同时对着看的参考页大致就这么多；再往后的尾巴是冷的，被淘汰时重新加载
+// 也能回到正确的那一页（地址已经跟着导航走了），不会退回默认首页。
+const WEB_KEEPALIVE_MAX = 5
 
 export default {
   components: {
@@ -1848,6 +1872,9 @@ export default {
       // 预热备胎实例（librePool.js）：{key, file}。file=null 是后台预 boot 的
       // 空白备胎；过继后 file 为真实文档、实例转正（渲染仍在此数组）。
       libreSpares: [],
+      // 网页标签保活 LRU：'pane:tabId'，最近激活在前（同 libreLruKeys 的形制）。
+      // 只在 Web/H5 用得上——见 leftWebTabs 与 WEB_KEEPALIVE_MAX。
+      webKeepAliveKeys: [],
       // 后端 doc_stream_data（旧名 wps_stream_data）流式写入的本地缓冲（#79：LibreOffice 消费端）
       _docStreamBuffer: '',
       _docStreamTimer: null,
@@ -2056,6 +2083,37 @@ export default {
     rightLibreFiles() {
       return this.rightFiles.filter(f => this.useLibreEditor(f) &&
         (f.id === this.activeFileIdRight || this.libreLruKeys.includes('right:' + f.id)))
+    },
+    // 网页标签保活池只在没有 BrowserView 能力的宿主（Web/H5）里开。
+    // 桌面端**绝不能**开：那边 BrowserPane 挂载即 browser-create，一次挂 5 个
+    // 就是 5 个 BrowserView 同时挂到窗口上（后台那几个会浮到最上层盖住界面，
+    // 正是 utility-tools.md「无脑挂回全部」那条地雷），而桌面端的保活早已由
+    // BrowserView detach 解决了（PR#401），本来就不需要池。
+    webKeepAliveEnabled() {
+      try {
+        return !host.browser
+      } catch (e) {
+        return true
+      }
+    },
+    // 与 leftLibreFiles 同形制：当前激活的网页标签必进池，其余按 LRU 保活，
+    // 都用 v-show 藏而不是卸载——BrowserPane 在 Web 下是个 <iframe>，组件一卸载
+    // 文档就没了，切回来只能按 tab.url 重新加载（那正是「切走再切回来丢内容」）。
+    leftWebTabs() {
+      if (!this.webKeepAliveEnabled) {
+        const active = this.activeFileLeft
+        return (active && this.isBrowserTab(active)) ? [active] : []
+      }
+      return this.leftFiles.filter(f => this.isBrowserTab(f) &&
+        (f.id === this.activeFileIdLeft || this.webKeepAliveKeys.includes('left:' + f.id)))
+    },
+    rightWebTabs() {
+      if (!this.webKeepAliveEnabled) {
+        const active = this.activeFileRight
+        return (active && this.isBrowserTab(active)) ? [active] : []
+      }
+      return this.rightFiles.filter(f => this.isBrowserTab(f) &&
+        (f.id === this.activeFileIdRight || this.webKeepAliveKeys.includes('right:' + f.id)))
     },
     // NEW: Current active tab for AI context (prioritizes focused pane)
     currentActiveTab() {
@@ -2771,8 +2829,8 @@ export default {
     // 内嵌 LibreOffice 多实例保活：激活的 Office 标签记入 LRU（超上限触发
     // 淘汰），并把 AI 指令路由指针同步到当前活动实例（活跃实例指针，同
     // PR#151 WPS 编辑器模式）。
-    activeFileLeft(f) { this.onActiveOfficeFileChanged('left', f) },
-    activeFileRight(f) { this.onActiveOfficeFileChanged('right', f) },
+    activeFileLeft(f) { this.onActiveOfficeFileChanged('left', f); this.touchWebKeepAlive('left', f) },
+    activeFileRight(f) { this.onActiveOfficeFileChanged('right', f); this.touchWebKeepAlive('right', f) },
     focusedPane() { this.syncLibreExecutor() },
     // 关闭 tab 后清掉文件已不在左列表的过继备胎条目（closeFile 已 flush）
     'leftFiles.length'() { this.pruneClosedLibreSpares() },
@@ -3664,27 +3722,40 @@ export default {
         if (this.isBrowserTab(t)) this.destroyBrowserView(t.id)
       }
     },
-    onBrowserUrlChange(pane, url) {
-      const active = pane === 'left' ? this.activeFileLeft : this.activeFileRight
-      if (active && this.isBrowserTab(active)) {
-        active.url = url
-        // 标签名称：尽量短（host）
-        try {
-          const u = new URL(url)
-          active.name = u.host || url
-        } catch (e) {
-          active.name = url
-        }
-        this.$forceUpdate()
-
-        // Track URL Session (flush previous, start new)
-        const meta = this.project && this.project.name ? `Project: ${this.project.name}` : ''
-        activityTracker.trackActivePage('OPEN_URL', 0, url, meta)
-      }
+    // 网页标签保活之后，后台那些标签的 BrowserPane 也活着（站点自己 302、SPA 换路由
+    // 都会报上来），所以这两个回调必须认 tabId——按"当前激活的那个标签"收，会把
+    // 后台标签的地址写到用户正看着的标签上。
+    findBrowserTab(pane, tabId) {
+      const list = pane === 'left' ? this.leftFiles : this.rightFiles
+      const tab = (list || []).find(f => String(f.id) === String(tabId))
+      return (tab && this.isBrowserTab(tab)) ? tab : null
     },
-    onBrowserTitleChange(pane, title) {
-      const active = pane === 'left' ? this.activeFileLeft : this.activeFileRight
-      if (!active || !this.isBrowserTab(active)) return
+    isActiveBrowserTab(pane, tabId) {
+      const activeId = pane === 'left' ? this.activeFileIdLeft : this.activeFileIdRight
+      return String(activeId) === String(tabId)
+    },
+    onBrowserUrlChange(pane, tabId, url) {
+      const tab = this.findBrowserTab(pane, tabId)
+      if (!tab) return
+      tab.url = url
+      // 标签名称：尽量短（host）
+      try {
+        const u = new URL(url)
+        tab.name = u.host || url
+      } catch (e) {
+        tab.name = url
+      }
+      this.$forceUpdate()
+
+      // 工作记录只跟"用户正在看的那一页"：后台标签自己跳走不该被记成浏览行为
+      if (!this.isActiveBrowserTab(pane, tabId)) return
+      // Track URL Session (flush previous, start new)
+      const meta = this.project && this.project.name ? `Project: ${this.project.name}` : ''
+      activityTracker.trackActivePage('OPEN_URL', 0, url, meta)
+    },
+    onBrowserTitleChange(pane, tabId, title) {
+      const active = this.findBrowserTab(pane, tabId)
+      if (!active) return
       const t = String(title || '').trim()
       if (!t) return
 
@@ -3696,7 +3767,8 @@ export default {
 
       const url = active.url || ''
       const meta = (this.project && this.project.name ? `Project: ${this.project.name}. ` : '') + `Title: ${t}`
-      if (url) {
+      // 同 onBrowserUrlChange：后台标签换标题不算浏览行为
+      if (url && this.isActiveBrowserTab(pane, tabId)) {
           // Restart session to capture title in the new segment
           activityTracker.trackActivePage('OPEN_URL', 0, url, meta)
       }
@@ -3704,6 +3776,21 @@ export default {
       // 避免过长：保留前 18 字符
       active.name = t.length > 18 ? (t.slice(0, 18) + '…') : t
       this.$forceUpdate()
+    },
+    // 激活的网页标签变化：记进保活 LRU（超上限的尾巴直接出池 = 组件卸载 = iframe 收掉，
+    // 不像编辑器那样需要先落盘，网页没有我们负责保存的状态）。顺带清掉已关标签的残留记账。
+    touchWebKeepAlive(pane, file) {
+      if (!this.webKeepAliveEnabled || !file || !this.isBrowserTab(file)) return
+      const key = pane + ':' + file.id
+      const stillOpen = (k) => {
+        const sep = k.indexOf(':')
+        const list = k.slice(0, sep) === 'right' ? this.rightFiles : this.leftFiles
+        const id = k.slice(sep + 1)
+        return (list || []).some(f => this.isBrowserTab(f) && String(f.id) === id)
+      }
+      this.webKeepAliveKeys = [key]
+        .concat(this.webKeepAliveKeys.filter(k => k !== key && stillOpen(k)))
+        .slice(0, WEB_KEEPALIVE_MAX)
     },
     openBrowserTab(url = 'https://www.baidu.com', pane = null) {
       // 默认在当前聚焦窗格打开；未分屏则左侧

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -38,6 +38,7 @@
 // Env: APP_E2E_BASE / APP_E2E_BACKEND / PUPPETEER_EXECUTABLE_PATH
 
 import fs from 'node:fs'
+import http from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -598,6 +599,234 @@ try {
     await page.waitForSelector('.clip-panel', { timeout: 10000 })
   })
   await shot('j6.6-clipboard')
+
+  // ============ J6.7 浏览器面板：切走标签再切回来（Web/H5 iframe 链路） ============
+  // 桌面端（BrowserView）那一半由 desktop-e2e 覆盖（PR#401）。Web/H5 是另一条链路：
+  // BrowserPane 渲染 <iframe :src=后端代理地址>，切标签会把整个组件卸载，两个病与桌面端
+  // 同源——① 组件一卸载 iframe 就整个重载，用户翻到的那一页（页内跳转、滚动位置、填了
+  // 一半的表单）全没了；② tab.url 从不跟随 iframe 内的导航，切回来退回打开时那个地址
+  // （新建标签的默认地址是 https://www.baidu.com）。
+  //
+  // 用本机起的两页小站而不是真网站：断言不能挂在外网可达性上。代价是后端的 SsrfGuard
+  // 按解析后的 IP 拦回环/内网，必须给这台测试站开例外——见下面 siteReachable 的说明。
+  console.log('== J6.7 浏览器面板 ==')
+  let site = null
+  let SITE = ''
+  {
+    // 端口取 0 让内核分配：维护者常年多开并行会话，写死端口必撞。
+    site = http.createServer((req, res) => {
+      const p = (req.url || '/').split('?')[0]
+      if (p === '/a') {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end('<html><head><title>QA-WEB-A</title></head><body><h1>QA-WEB-A</h1>'
+          + '<a id="go" href="/b">去第二页</a></body></html>')
+      } else if (p === '/b') {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end('<html><head><title>QA-WEB-B</title></head><body><h1>QA-WEB-B</h1></body></html>')
+      } else {
+        // 其余路径一律 404：修复前注入脚本的同标签跳转会把地址解析到测试站自己头上
+        // （<base href> 的锅），落在这里才看得出「跳错地方了」，而不是碰巧还显示 A 页
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+        res.end('QA-WEB-404 ' + p)
+      }
+    })
+    await new Promise((r) => site.listen(0, '127.0.0.1', r))
+    SITE = 'http://127.0.0.1:' + site.address().port
+  }
+  // 后端能不能抓这台测试站：SsrfGuard 默认拦回环，需要后端带
+  // SECURITY_BROWSER_PROXY_E2E_ALLOWED_HOSTS=127.0.0.1 起。没开就显式 skip，不静默假绿。
+  const siteReachable = await (async () => {
+    try {
+      const r = await fetch(BACKEND + '/api/browser/proxy?url=' + encodeURIComponent(SITE + '/a') + '&token=probe')
+      return r.status === 200
+    } catch (e) { return false }
+  })()
+
+  if (!siteReachable) {
+    note('skip', 'J6.7 浏览器面板已跳过：后端未放行本机测试站，'
+      + '需以 SECURITY_BROWSER_PROXY_E2E_ALLOWED_HOSTS=127.0.0.1 起后端（默认空=照常拦内网）')
+  } else {
+    // 网页标签只在资源管理器模式下可见（isTabVisible），J6/J6.6 可能停在别处
+    await mouseClickSel('[title="资源管理器"]')
+
+    const webTabs = () => page.evaluate(() => {
+      const vm = window.__checkbaActiveOverviewVm
+      if (!vm) return null
+      return (vm.leftFiles || []).filter((f) => f && f.tabType === 'web').map((f) => ({ name: f.name, url: f.url }))
+    })
+    // 标签条是对 leftFiles 的 v-for，此刻里面还躺着前面旅程开的文件标签——
+    // 按「第 N 个 .tab-item」点会点到 qa-small.txt 上去（首版就这么写，红在了地址栏找不到）。
+    // 所以先问实例指针要网页标签在 leftFiles 里的下标。
+    const webTabIndices = () => page.evaluate(() => {
+      const vm = window.__checkbaActiveOverviewVm
+      if (!vm) return []
+      return (vm.leftFiles || []).map((f, i) => (f && f.tabType === 'web' ? i : -1)).filter((i) => i >= 0)
+    })
+    // 代理过的文档是不透明源（sandbox 不带 allow-same-origin，绝不能加），
+    // 但 CDP 照样能在里面求值——探针实测过，父页拿不到它的 location 不影响这里。
+    //
+    // 按「当前可见的那个 .browser-iframe」找，不按 URL 里有没有 /api/browser/proxy 找：
+    // 注入脚本坏掉时点链接是普通跳转（直接落到站点上、不经代理），按 URL 找会报
+    // 「没有代理 iframe」，把「跳转没走代理」说成「iframe 没了」。保活之后同时还会有
+    // 多个 .browser-iframe 挂着（隐藏的那些 boundingBox 为 null）。
+    const activeFrame = async () => {
+      for (const h of await page.$$('.browser-iframe')) {
+        const box = await h.boundingBox()
+        if (box && box.width > 0) return { frame: await h.contentFrame(), box }
+      }
+      return null
+    }
+    const frameText = async (f) => f.evaluate(() => document.body.innerText.trim().slice(0, 60)).catch((e) => '(读不到:' + e.message + ')')
+    const activeFrameText = async () => {
+      const cur = await activeFrame()
+      if (!cur || !cur.frame) return '(没有可见的浏览器 iframe)'
+      return (await frameText(cur.frame)) + ' @ ' + cur.frame.url().slice(0, 120)
+    }
+    const clickTabAt = async (idx) => {
+      const box = await page.evaluate((i) => {
+        const el = document.querySelectorAll('.tabs-pane-left .tab-item')[i]
+        if (!el) return null
+        const r = el.getBoundingClientRect()
+        if (!r.width || !r.height) return null
+        return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+      }, idx)
+      if (!box) throw new Error('点不到第 ' + idx + ' 号标签（不存在或被隐藏）')
+      await page.mouse.click(box.x, box.y)
+      await sleep(900)
+    }
+
+    await step('开两个网页标签并把第一个导航到测试站', async () => {
+      let opened = []
+      for (let round = 0; round < 6 && opened.length < 2; round++) {
+        await mouseClickSel('[title="浏览器"]')
+        await sleep(600)
+        opened = (await webTabs()) || []
+      }
+      if (opened.length < 2) throw new Error('两个网页标签没开出来：' + JSON.stringify(opened))
+      await clickTabAt((await webTabIndices())[0])
+
+      // 地址栏真人输入：uni 的 <input> 外面套了一层 uni-input，要点里面那个；
+      // 里面本来就有默认地址，先三连击全选再打字，否则是接在后面续写。
+      await mouseClickSel('.browser-toolbar .url-input input')
+      const addr = await page.evaluate(() => {
+        const el = document.querySelector('.browser-toolbar .url-input input')
+        const r = el.getBoundingClientRect()
+        return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+      })
+      // 打字要带 delay 并当场回读：uni 的 <input> 去抖会吃掉快速连打的字符
+      // （issue #200 登录密码被截断是同一个坑）。不回读的话下面只会报「A 页没渲染
+      // 出来」，分不清是没输进去、没点开、还是代理链路坏了——实测被截成过 "h"，
+      // 于是打开的是 https://h。
+      let typed = null
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await page.mouse.click(addr.x, addr.y, { clickCount: 3 })
+        await page.keyboard.type(SITE + '/a', { delay: 25 })
+        await sleep(300)
+        typed = await page.evaluate(() => {
+          const el = document.querySelector('.browser-toolbar .url-input input')
+          return el ? el.value : null
+        })
+        if (typed === SITE + '/a') break
+      }
+      if (typed !== SITE + '/a') throw new Error('地址栏没吃到完整输入，实际是：' + JSON.stringify(typed))
+      await mouseClickSel('[title="打开"]')
+      await page.waitForFunction(
+        () => [...document.querySelectorAll('iframe')].some((f) => (f.src || '').includes('%2Fa')),
+        { timeout: 15000 })
+      // 真的把 A 页渲染出来了才算导航成功（只看 src 会把 403/404 当成功）
+      for (let i = 0; i < 20; i++) {
+        if ((await activeFrameText()).includes('QA-WEB-A')) return
+        await sleep(500)
+      }
+      throw new Error('测试站 A 页没渲染出来：' + (await activeFrameText()))
+    })
+
+    await step('页内点链接跳到第二页，标签地址跟着走', async () => {
+      const cur = await activeFrame()
+      if (!cur || !cur.frame) throw new Error('找不到浏览器 iframe')
+      // 真实鼠标：iframe 元素在父页的位置 + 链接在 iframe 内的位置
+      const linkBox = await cur.frame.evaluate(() => {
+        const el = document.getElementById('go'); if (!el) return null
+        const r = el.getBoundingClientRect()
+        return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+      })
+      if (!linkBox) throw new Error('A 页里找不到链接，iframe 里是：' + (await activeFrameText()))
+      await page.mouse.click(cur.box.x + linkBox.x, cur.box.y + linkBox.y)
+
+      // 先确认 iframe 真的跳到了 B 页（跳错地方时这里就报出来，不会拖到下一步）
+      let landed = ''
+      for (let i = 0; i < 24; i++) {
+        landed = await activeFrameText()
+        if (landed.includes('QA-WEB-B')) break
+        await sleep(500)
+      }
+      if (!landed.includes('QA-WEB-B')) throw new Error('页内跳转没落到第二页：' + landed)
+      // 跳转必须仍走代理：直接落到站点上就等于跳出了工作区，后续页面再也拦不住
+      // _blank/window.open（注入脚本坏掉时正是这个形态）
+      if (!landed.includes('/api/browser/proxy')) throw new Error('页内跳转绕过了代理：' + landed)
+      // 标签必须跟上——不跟上就是「切回来退回打开时那个地址」的根因
+      let tracked = null
+      for (let i = 0; i < 20; i++) {
+        tracked = (await webTabs())[0]
+        if (tracked && String(tracked.url).endsWith('/b')) return
+        await sleep(400)
+      }
+      throw new Error('标签地址没跟上页内跳转：' + JSON.stringify(tracked))
+    })
+
+    await step('切走再切回来仍是同一个文档实例（没被重新加载）', async () => {
+      // 只活在这一个文档实例上的标记：iframe 一重载就没了，据此判断"是不是同一页"
+      const cur = await activeFrame()
+      if (!cur || !cur.frame) throw new Error('找不到浏览器 iframe')
+      await cur.frame.evaluate(() => { window.__awdQaAlive = 'ALIVE' })
+
+      const idxs = await webTabIndices()
+      await clickTabAt(idxs[1])
+      await sleep(600)
+      await clickTabAt(idxs[0])
+      await sleep(1200)
+
+      const back = await activeFrame()
+      if (!back || !back.frame) throw new Error('切回来之后浏览器 iframe 没了')
+      const alive = await back.frame.evaluate(() => window.__awdQaAlive || '(页面被重新加载了)')
+        .catch((e) => '(读不到：' + String(e.message || e) + ')')
+      if (alive !== 'ALIVE') {
+        throw new Error('网页被重建了，不是原来那一页：' + alive + '；' + (await activeFrameText()))
+      }
+      const text = await frameText(back.frame)
+      if (!text.includes('QA-WEB-B')) throw new Error('切回来内容变了：' + JSON.stringify(text))
+      const shown = await page.evaluate(() => {
+        const el = document.querySelector('.browser-toolbar .url-input input')
+        return el ? el.value : '(没有地址栏)'
+      })
+      if (!String(shown).endsWith('/b')) throw new Error('地址栏没跟上，显示的是 ' + shown)
+    })
+
+    await step('关掉两个网页标签收尾', async () => {
+      for (let i = 0; i < 6; i++) {
+        const idxs = await webTabIndices()
+        if (!idxs.length) break
+        const box = await page.evaluate((idx) => {
+          const tab = document.querySelectorAll('.tabs-pane-left .tab-item')[idx]
+          const el = tab && tab.querySelector('.tab-close')
+          if (!el) return null
+          const r = el.getBoundingClientRect()
+          if (!r.width || !r.height) return null
+          return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+        }, idxs[0])
+        if (!box) break
+        await page.mouse.click(box.x, box.y)
+        await sleep(500)
+      }
+      const left = (await webTabs()) || []
+      if (left.length) throw new Error('网页标签没关干净：' + JSON.stringify(left))
+    })
+    await shot('j6.7-browser')
+  }
+  // 后端的 HttpClient 会跟测试站保持 keep-alive 连接，光 close() 是"不再收新连接"，
+  // 老连接还挂着 —— Node 因此不肯退出，整套跑完停在最后一行不打报告（实测卡了 4 分钟才发现）
+  try { site.closeAllConnections() } catch (e) { /* Node < 18.2 没有这个方法 */ }
+  try { site.close() } catch (e) { /* ignore */ }
 
   // ============ J6.5 AI 对话（真 UI 打字发送；默认模型 deepseek-v4-flash，
   // $0.09/M tokens，一条消息成本可忽略；AI_E2E=0 跳过） ============


### PR DESCRIPTION
补掉 #401（PR #401 只修了桌面端 BrowserView）明确留下的 Web/H5 缺口。

## 现象与根因

Web/H5 下 BrowserPane 渲染 `<iframe :src=后端代理地址>`，工作台里它是 `v-if` + `:key=tab.id`，**切标签即卸载 → iframe 整个重新加载**。桌面端那两个病在这条链路上是各自独立的根因：

| | 桌面端（已修 #401） | Web/H5（本 PR） |
|---|---|---|
| 保活 | BrowserView 面板卸载 detach、标签关闭才 destroy | 组件不卸载：保活池 + `v-show` + LRU=5 |
| 地址跟随 | 主进程 `did-navigate` → `browser-url-updated` | 代理注入脚本 `postMessage({type:'URL_CHANGED'})` |

**① 保活池**：`leftWebTabs`/`rightWebTabs`，与 LOWA 编辑器保活池同形制。`v-show` 的 `display:none` **不会**丢掉 iframe 文档（滚动位置也在，实测过），换 `src` 才会。

**池只在 Web 开**（`webKeepAliveEnabled = !host.browser`）：桌面端一次挂 5 个 BrowserPane 就是 5 个 BrowserView 同时挂到窗口上，后台那几个会浮上来盖住界面（`utility-tools.md`「无脑挂回全部」那条地雷）。上限存在的理由：摘下的 BrowserView 会被 Chromium 冻住，藏起来的 iframe **不会**——它们跟前台页共用同一个渲染进程。

**② 地址跟随**：iframe 是不透明源（`sandbox` 不带 `allow-same-origin`，**绝不能加**），父窗口读不到它的 location，只能等页面自己报。postMessage 在不透明源下照常可用（`origin="null"`，鉴别靠 token）——**先写探针实测过再动的代码**。`currentUrl`（显示的地址）与 `iframeUrl`（iframe 被要求加载的地址）必须分开记：把跟随来的新地址回写进 `src`，等于每跳一次就把刚打开的那一页重新加载一遍，保活白做。

## 沿路挖出来的三个既有 bug

- **注入脚本从写下那天起就没跑起来过**。整段拼成一行，里面那句 `//` 中文注释把后面全部代码一起注释掉了。页面上只留一句 `SyntaxError: Unexpected end of input`，`_blank`/`window.open` 拦截、同标签跳转、`OPEN_NEW_TAB` 回传三件事**全部静默失效**（现象是「点了没反应」，很容易误判成 CSP 拦截）。
- **`proxify` 拼的是相对地址**。页面里有我们注入的 `<base href=真站点>`，`location.href='/api/browser/proxy?…'` 于是解析到被访问站点头上，实测跳出 `http://被访站/api/browser/proxy?url=…` 的四不像、站点回 404。改成拿当前文档地址换 query（也不怕应用部署在子路径下）。
- **代理回的 HTML 不带 charset**。按 UTF-8 解码却回 `text/html`（无 charset），浏览器拿 windows-1252 去解，**中文页面在面板里整页乱码**。改成按上游 charset 解码、统一以 `text/html;charset=utf-8` 回。

另：注入进 JS 字面量的页面地址是被访问站点能控的（302 到任意 URL），`escapeJsString` 统一处理反斜杠/单引号/`<`（`</script>` 跳出）。保活之后后台标签也会报事件，`onBrowserUrlChange/onBrowserTitleChange` 改收 `(pane, tabId, value)` 按 id 找标签——按「当前激活的那个」收会把后台标签的地址写到用户正看着的标签上。

## 验证（都是链路级，不是原语级）

`frontend/tests/app-e2e/run.mjs` 新增 **J6.7**：harness 自起两页小站 → 开两个网页标签 → 地址栏真人打字导航 → 页内点链接跳第二页 → 切走再切回来，断言**仍是同一个文档实例**（往页面里写 `window.__awdQaAlive`，重载会被冲掉）+ 地址正确。

**修复前实测红**（同一份测试代码、同一环境）：
```
[step-fail] 页内点链接跳到第二页，标签地址跟着走: 页内跳转绕过了代理：QA-WEB-B @ http://127.0.0.1:50828/b
[step-fail] 切走再切回来仍是同一个文档实例（没被重新加载）: 网页被重建了，不是原来那一页：(页面被重新加载了)；… proxy?url=…%2Fa
```
**修复后**：app-e2e **120 通过 / 0 失败**（基线 116/4，那 4 条正是这里的 3 条 + 下面那个旧串）。

- 新增 `BrowserProxyControllerTest`（5 条）：SSRF 例外名单默认关、注入脚本字符串外无 `//`、proxify 绝对地址 + URL_CHANGED、JS 字面量转义、HTML 带 charset。**旧注入逻辑下实测红**。
- `mvn test` **1845 通过 / 0 失败**；`check:emits` / `check:locales` / `check:nav:full` / `test:project-home`(72) / `test:commands`(17) / `build:h5` 全绿。

## 需要过目的一处取舍

`security.browser-proxy.e2e-allowed-hosts`（默认空）：`SsrfGuard` 按解析后的 IP 拦回环/内网，而「harness 自起本机小站」要求代理能抓 127.0.0.1。不开这个口子，这条链路就只能拿外网站点当断言对象，等于把测试挂在网络可达性上。

名单**默认空、刻意不写进任何 `application*.yml`**，只有显式传 `SECURITY_BROWSER_PROXY_E2E_ALLOWED_HOSTS` 的进程才放行；精确主机名匹配、不认通配；后端没开时 J6.7 显式 skip（不假绿）。`BrowserProxyControllerTest` 钉住「不设 = 照样拦」。如果你更希望这个口子完全不进产品代码，说一声，我把 J6.7 改成 skip-only 并把这段回退。

## 顺手修的两处测试欠账

- J6 的 `EasyVoice` 是改名前的旧串（rail 早已改叫「语音合成」，见 `leftSidebarPlugins.js` 注释），从那次改名起一直红着。
- 测试站 `close()` 不掐 keep-alive 连接，会让整套跑完卡住不打报告（实测卡 4 分钟）。

契约与地雷已同步 `.claude/agents/utility-tools.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)