### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号单一来源 `desktop/package.json`：0.17.0 → **0.18.0**。

## 为什么是大版本

`patch-gate` 的判据逐条核过：master 自 `v0.17.0` 起已改动 `desktop/main`、`desktop/preload`、`asr-service/requirements.lock`——这三类路径补丁通道明确拒收，只能随大版本走全量安装包。

## 本版主线

**官方桌面版必须账户登录**（#409）。解锁门不再受理试用码，只接受账户凭据（手机号/邮箱登录，或手工粘 `awdk_` Key）。

- 存量用试用码解锁的机器有到 **2026-09-30** 的过渡期，期内照常可用并在顶栏倒计时提醒，数据一条不丢。
- 离线不受影响：账户授权本就有 30 天离线宽限（每次联网启动成功复验即重置），本版新增剩 ≤7 天的预警与到期出路。
- 商业版 / 私有部署 / 自行构建改 `security.license.trial-code.enabled` 一行即完全恢复原行为。

## 发版前置（已核实）

- 官网手机号登录已上线，`AWD_SMS_*` 已注入北京服务器，**真实号码实测收到验证码**
- 桌面账户登录（#408）已在 master
- `mvn test` 1862/0、`app-e2e` 123/0（含 J11 云端协作）、`check:emits` / `check:locales` / `build:h5` 全绿

合并后打 `v0.18.0` tag 触发双平台构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)