### PR TITLE
feat(auth): 手机号强制登录不再是空壳——三态闸真正接进登录链路 (spec §5)

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -229,6 +229,27 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
   **签名的运营商报备状态是外部前置条件**：2026-08-07 实测联通已通（真机送达），移动/电信报备中，
   未通的运营商发送会 PORT_NOT_REGISTERED；报备状态用 `GetSmsSign` API 可查。
 
+**手机号强制登录与补绑期（2026-08-18）**
+- 设计 `docs/superpowers/specs/2026-08-17-phone-login-design.md` §5。官网侧同一口径的参照实现是
+  `aiworkdeck_website` 的 `lib/phone-policy.ts`（`gateForUser()`）+ `app/api/auth/login/route.ts`。
+- `config/PhoneLoginGuard.java` 一个类兼两职：**启动期**断言（开了强制但短信网关是暗的 → 拒绝启动，
+  不静默降级成谁都进不来）＋**运行期**三态闸 `gateFor(user)` → `OK` / `MUST_BIND` / `BLOCKED`。
+  `required = phone-login-required && !local-mode`——local-mode 免登没有登录环节，闸恒不生效。
+- 接线在 `AuthController` 的**三条**会签发凭据的路径：`/login`、`/device-token`、`/mail-login/verify`。
+  只护住 `/login` 是假闸——换个端点就绕过去了，而 `/device-token` 发的还是**长期**凭据。
+  `/awdk-login`（awdk_ 桥）刻意不管，它不走密码也不走手机号；`/sms-login/verify` 天然已绑号。
+- **拒登必须落在 `issue()` 之前**：先签发再拒等于已经把一个能用的凭据交出去了。用例
+  `AuthControllerPhoneGateTest` 用 `verify(sessions, never()).issue(...)` 钉住这条。
+- **拒登码是 4006，绝不能用 4010**：4010 是前端 `api.js:288` 认定的「会话失效」专用码，
+  回它会让客户端清掉本地会话并弹回登录页，文案也一起被冲掉，被锁的人就不知道该去发邮件。
+- 放行时回包带 `data.mustBindPhone`（`/login`、`/device-token`、`/mail-login/verify` 三处），
+  客户端据此弹**不可跳过**的强制补绑，走现成的 `POST /api/auth/sms/bind`。
+- 期限默认 `2026-09-30`，**与官网 `DEFAULT_BINDING_DEADLINE` 同值，改一边必须改另一边**，
+  否则会出现「官网说还能用到 X 日、后端 X-30 日就把人拒了」。当天仍算期限内；格式配错回落默认值。
+- **已知未闭合的边**：`/register` 没接这条闸。`security.registration-mode` 代码默认 `open`
+  （cloud profile 显式 `closed`），所以只有「开了强制手机号 + 又开着注册」的部署才踩得到：
+  期限后新注册仍会拿到一个能用的会话，直到下次登录才被拒。要不要一并关掉是待定的策略问题。
+
 **站点（双主站，2026-08-08）**
 - 设计文档 `docs/superpowers/specs/2026-08-08-dual-site-architecture.md`（含实施记录一节，与设计有出入以那节为准）。
 - 两个站分的是**商业与合规**：币种、支付通道、发票、适用法、ICP 备案、默认语言、

--- a/backend/src/main/java/com/checkba/config/PhoneLoginGuard.java
+++ b/backend/src/main/java/com/checkba/config/PhoneLoginGuard.java
@@ -1,29 +1,65 @@
 package com.checkba.config;
 
+import com.checkba.model.entity.User;
 import com.checkba.service.sms.SmsAuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
 /**
- * 强制手机号登录的启动期不变式。
+ * 强制手机号登录的策略与启动期不变式。
  *
- * 这条闸存在的唯一理由：**开了强制手机号登录、而短信网关是暗的，等于所有人都登不进来。**
+ * <p><b>启动期</b>：**开了强制手机号登录、而短信网关是暗的，等于所有人都登不进来。**
  * 那种情况下静默启动是最坏的选择——服务看起来是健康的，用户全被挡在门外，
  * 排查方向会跑到前端和网络上去。宁可拒绝启动，让部署的人当场看见。
- *
  * 参照 {@code PlatformAiKeyCipher} 缺密钥即拒启的同一口径。
+ *
+ * <p><b>运行期</b>：{@link #gateFor} 是存量账号补绑手机号的三态闸（spec §5）。
+ * 口径与官网 {@code lib/phone-policy.ts} 的 {@code gateForUser()} 一一对应，两边别漂。
+ * 接线在 {@code AuthController} 的三条会签发凭据的登录路径上。
+ *
+ * <p>设计见 {@code docs/superpowers/specs/2026-08-17-phone-login-design.md}。
  */
 @Component
 public class PhoneLoginGuard {
 
+    private static final Logger log = LoggerFactory.getLogger(PhoneLoginGuard.class);
+
+    /**
+     * 默认硬期限。改这个值要同步官网 {@code lib/phone-policy.ts} 的
+     * {@code DEFAULT_BINDING_DEADLINE}——两边漂了就会出现「官网说还能用到 X 日、
+     * 后端 X-30 日就把人拒了」。
+     */
+    static final String DEFAULT_BINDING_DEADLINE = "2026-09-30";
+
+    /** 人工通道。被锁在门外的用户只看得到这一个出口，改之前先确认有人值守。 */
+    public static final String SUPPORT_EMAIL = "hi@aiworkdeck.com";
+
+    /** 本次登录该怎么处理这个账号。 */
+    public enum PhoneGate {
+        /** 放行（没开强制、或已绑号）。 */
+        OK,
+        /** 放行，但客户端要立刻弹不可跳过的强制补绑（期限内、未绑号）。 */
+        MUST_BIND,
+        /** 拒登（期限后、未绑号）。 */
+        BLOCKED
+    }
+
     private final boolean required;
+    private final LocalDate bindingDeadline;
 
     public PhoneLoginGuard(
             SmsAuthService smsAuthService,
             @Value("${auth.phone-login-required:false}") boolean required,
-            @Value("${security.local-mode:false}") boolean localMode) {
+            @Value("${security.local-mode:false}") boolean localMode,
+            @Value("${auth.phone-binding-deadline:" + DEFAULT_BINDING_DEADLINE + "}") String bindingDeadline) {
 
         this.required = required && !localMode;
+        this.bindingDeadline = parseDeadline(bindingDeadline);
 
         // local-mode（桌面端单机免登）根本没有登录环节，这条闸不适用
         if (!this.required) {
@@ -38,8 +74,39 @@ public class PhoneLoginGuard {
         }
     }
 
-    /** 供登录链路判断是否关闭密码登录。 */
+    /**
+     * 期限格式非法时**回落默认值而不是放行**——把 deadline 配错就无限期延期，
+     * 那是最容易被忽略的静默失效。
+     */
+    private static LocalDate parseDeadline(String raw) {
+        try {
+            return LocalDate.parse(raw == null ? DEFAULT_BINDING_DEADLINE : raw.trim());
+        } catch (DateTimeParseException e) {
+            log.warn("auth.phone-binding-deadline 格式非法（{}），回落默认值 {}", raw, DEFAULT_BINDING_DEADLINE);
+            return LocalDate.parse(DEFAULT_BINDING_DEADLINE);
+        }
+    }
+
+    /** 供登录链路判断是否启用手机号闸（local-mode 恒为 false）。 */
     public boolean isRequired() {
         return required;
+    }
+
+    /** 补绑期截止日；当天仍算期限内。 */
+    public LocalDate bindingDeadline() {
+        return bindingDeadline;
+    }
+
+    /** 存量账号在本次登录时该怎么处理。 */
+    public PhoneGate gateFor(User user) {
+        return gateFor(user, LocalDate.now());
+    }
+
+    /** 同上，注入「今天」便于按期限前后取值测试，不依赖机器当前日期。 */
+    PhoneGate gateFor(User user, LocalDate today) {
+        if (!required) return PhoneGate.OK;
+        String phone = user == null ? null : user.getPhone();
+        if (phone != null && !phone.isBlank()) return PhoneGate.OK;
+        return today.isAfter(bindingDeadline) ? PhoneGate.BLOCKED : PhoneGate.MUST_BIND;
     }
 }

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.checkba.controller;
 
 import com.checkba.config.GlobalExceptionHandler;
+import com.checkba.config.PhoneLoginGuard;
 import com.checkba.model.entity.ProjectInvitation;
 import com.checkba.model.entity.User;
 import com.checkba.service.ClientInvitationService;
@@ -29,6 +30,8 @@ public class AuthController {
     private final com.checkba.service.UserSessionService userSessionService;
     /** 单机免登模式。设备令牌的会话签发路径只在这一模式下存在（见 issueLocalDeviceToken）。 */
     private final boolean localMode;
+    /** 存量账号补绑手机号的三态闸；未接线的调用方传 null 表示不设闸。 */
+    private final PhoneLoginGuard phoneLoginGuard;
 
     /**
      * 密码校验通过但还缺二次验证码时的响应 code（前端 api.js 据此弹验证码输入步骤，
@@ -36,6 +39,15 @@ public class AuthController {
      * data 里的 {@code method} 区分 totp / sms。
      */
     static final int CODE_SMS_REQUIRED = 4005;
+
+    /**
+     * 补绑期已过、账号仍未绑手机号时的拒登 code。
+     *
+     * <p><b>刻意不用 4010</b>：那是前端 {@code api.js} 认定的「会话失效」专用码，
+     * 收到它会清掉本地会话并弹回登录页。这里的语义是「账号缺一次补绑」而不是「你掉线了」，
+     * 回 4010 会让客户端把用户的会话一起清掉，还会把文案冲掉，人就不知道该去发邮件了。
+     */
+    static final int CODE_PHONE_BINDING_REQUIRED = 4006;
 
     /** 认证器 App 里显示的服务名。 */
     private static final String TOTP_ISSUER = "AI WorkDeck";
@@ -76,7 +88,8 @@ public class AuthController {
                           com.checkba.service.auth.SecondFactorService secondFactorService,
                           com.checkba.service.UserSessionService userSessionService,
                           @org.springframework.beans.factory.annotation.Value("${security.local-mode:false}")
-                          boolean localMode) {
+                          boolean localMode,
+                          PhoneLoginGuard phoneLoginGuard) {
         this.userService = userService;
         this.clientInvitationService = clientInvitationService;
         this.adminAccessService = adminAccessService;
@@ -88,7 +101,35 @@ public class AuthController {
         this.secondFactorService = secondFactorService;
         this.userSessionService = userSessionService;
         this.localMode = localMode;
+        this.phoneLoginGuard = phoneLoginGuard;
         staticUserService = userService;
+    }
+
+    /** 本次登录的手机号闸判定；未接线（null）一律放行，不把既有链路连坐。 */
+    private PhoneLoginGuard.PhoneGate phoneGate(User user) {
+        return phoneLoginGuard == null ? PhoneLoginGuard.PhoneGate.OK : phoneLoginGuard.gateFor(user);
+    }
+
+    /**
+     * 补绑期已过、账号仍未绑手机号时的拒登信封（spec §5）。
+     *
+     * <p>调用点必须落在**签发会话/设备令牌之前**——先签发再拒等于已经给出了一个能用的凭据，
+     * 客户端存下来照样能用。文案指向 {@code hi@aiworkdeck.com}：被锁在门外的人只剩这一个出口。
+     *
+     * @return 需要拒登时返回 4006 信封；返回 null 表示放行，调用方据
+     *         {@link PhoneLoginGuard.PhoneGate#MUST_BIND} 决定是否让客户端弹强制补绑。
+     */
+    private Map<String, Object> phoneBindingRefusal(PhoneLoginGuard.PhoneGate gate) {
+        if (gate != PhoneLoginGuard.PhoneGate.BLOCKED) return null;
+        String deadline = phoneLoginGuard.bindingDeadline().toString();
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", CODE_PHONE_BINDING_REQUIRED);
+        result.put("message", LangText.of(
+                "该账号未绑定手机号，补绑期已于 " + deadline + " 结束。"
+                        + "请发邮件到 " + PhoneLoginGuard.SUPPORT_EMAIL + " 申请人工代绑。",
+                "This account has no phone number linked, and the grace period ended on " + deadline
+                        + ". Please email " + PhoneLoginGuard.SUPPORT_EMAIL + " to have it linked manually."));
+        return result;
     }
 
     /**
@@ -186,6 +227,14 @@ public class AuthController {
             }
             authAbuseGuard.recordLoginSuccess(ip, request.getUsername());
 
+            // 手机号补绑闸：期限后未绑号拒在这里——**必须早于下面的 issue()**，
+            // 先签发再拒等于已经把一个能用的会话交出去了。凭据是对的，因此不计失败。
+            PhoneLoginGuard.PhoneGate gate = phoneGate(user);
+            Map<String, Object> refusal = phoneBindingRefusal(gate);
+            if (refusal != null) {
+                return refusal;
+            }
+
             String sessionId = userSessionService.issue(user.getId());
 
             Map<String, Object> result = new HashMap<>();
@@ -193,6 +242,8 @@ public class AuthController {
             result.put("message", LangText.of("登录成功", "Signed in successfully"));
             result.put("data", Map.of(
                     "sessionId", sessionId,
+                    // 期限内未绑号：放行但让客户端立刻弹不可跳过的强制补绑（走现成的 /sms/bind）
+                    "mustBindPhone", gate == PhoneLoginGuard.PhoneGate.MUST_BIND,
                     "user", Map.of(
                             "id", user.getId(),
                             "username", user.getUsername(),
@@ -511,11 +562,19 @@ public class AuthController {
         try {
             User user = mailAuthService.verifySigninCode(request.getEmail(), request.getCode());
             authAbuseGuard.recordLoginSuccess(ip, lockKey);
+            // 同 /login 的手机号补绑闸：这条也是一次给未绑号账号发会话的入口，
+            // 只护住密码那条等于换个端点就绕过去了。
+            PhoneLoginGuard.PhoneGate gate = phoneGate(user);
+            Map<String, Object> refusal = phoneBindingRefusal(gate);
+            if (refusal != null) {
+                return refusal;
+            }
             String newSessionId = userSessionService.issue(user.getId());
             result.put("code", 0);
             result.put("message", LangText.of("登录成功", "Signed in successfully"));
             result.put("data", Map.of(
                     "sessionId", newSessionId,
+                    "mustBindPhone", gate == PhoneLoginGuard.PhoneGate.MUST_BIND,
                     "user", Map.of(
                             "id", user.getId(),
                             "username", user.getUsername(),
@@ -776,11 +835,19 @@ public class AuthController {
                 return challenge;
             }
             authAbuseGuard.recordLoginSuccess(ip, body.get("username"));
+            // 同 /login 的手机号补绑闸：换令牌也是一次密码登录，而且发出去的是**长期**凭据，
+            // 留了旁路等于补绑期一到就有条比会话还好用的后门。
+            PhoneLoginGuard.PhoneGate gate = phoneGate(user);
+            Map<String, Object> refusal = phoneBindingRefusal(gate);
+            if (refusal != null) {
+                return refusal;
+            }
             var issued = deviceTokenService.issue(user.getId(), body.get("name"));
             result.put("code", 0);
             result.put("data", Map.of(
                     "tokenId", issued.id(),
                     "token", issued.plaintext(),
+                    "mustBindPhone", gate == PhoneLoginGuard.PhoneGate.MUST_BIND,
                     "userId", user.getId(),
                     "username", user.getUsername(),
                     "displayName", user.getDisplayName() == null ? user.getUsername() : user.getDisplayName()));

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -95,9 +95,16 @@ mcp:
 # 开启前提是短信网关可用，否则 PhoneLoginGuard 会拒绝启动而不是静默降级。
 # 设计见 docs/superpowers/specs/2026-08-17-phone-login-design.md
 auth:
+  # 打开＝启用 PhoneLoginGuard 的三态闸（spec §5），**不是**「关掉密码登录」：
+  # 已绑号放行 / 期限内未绑号放行但回 mustBindPhone 让客户端强制补绑 /
+  # 期限后未绑号在签发会话之前拒登（code 4006）。接线在 AuthController 的
+  # /login、/device-token、/mail-login/verify 三条会签发凭据的路径上。
+  # awdk_ 桥（/awdk-login）不受这条闸管——它不走密码也不走手机号。
   phone-login-required: ${AUTH_PHONE_LOGIN_REQUIRED:false}
   # 存量用户补绑手机号的硬期限；过期未绑一律拒登，文案指向 hi@aiworkdeck.com。
-  # 写成配置而不是硬编码，要延期改这里即可。
+  # 写成配置而不是硬编码，要延期改这里即可。当天仍算期限内（次日 0 点起才拒）。
+  # 格式非法会回落默认值而不是无限期放行——配错就静默延期是最难发现的失效。
+  # **与官网 lib/phone-policy.ts 的 DEFAULT_BINDING_DEADLINE 同值，改一边就要改另一边。**
   phone-binding-deadline: ${AUTH_PHONE_BINDING_DEADLINE:2026-09-30}
 
 sms:

--- a/backend/src/test/java/com/checkba/config/PhoneBindingGateTest.java
+++ b/backend/src/test/java/com/checkba/config/PhoneBindingGateTest.java
@@ -1,0 +1,110 @@
+package com.checkba.config;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.auth.VerificationCodeStore;
+import com.checkba.service.sms.SmsAuthService;
+import com.checkba.service.sms.SmsService;
+import com.checkba.service.sms.SmsTransport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * 存量账号补绑手机号的三态闸（spec §5）。
+ *
+ * 口径与官网 {@code lib/phone-policy.ts} 的 {@code gateForUser()} 一一对应，两边别漂：
+ * {@code OK} 放行 / {@code MUST_BIND} 放行但要立刻强制补绑 / {@code BLOCKED} 拒登。
+ */
+class PhoneBindingGateTest {
+
+    private static final SmsTransport OK_TRANSPORT =
+            (url, body, auth) -> new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
+
+    private static final LocalDate DEADLINE = LocalDate.parse("2026-09-30");
+
+    /** 网关点亮的 SmsAuthService——否则 PhoneLoginGuard 在强制模式下拒绝构造。 */
+    private static SmsAuthService activeSms() {
+        return new SmsAuthService(
+                List.of(new SmsService(OK_TRANSPORT, true, "ak", "sk", "sign", "tpl")),
+                new VerificationCodeStore(), mock(UserRepository.class), false);
+    }
+
+    private static PhoneLoginGuard guard(boolean required, String deadline) {
+        return new PhoneLoginGuard(activeSms(), required, false, deadline);
+    }
+
+    private static User withPhone(String phone) {
+        User user = new User();
+        user.setId(7L);
+        user.setUsername("alice");
+        user.setPhone(phone);
+        return user;
+    }
+
+    @Test
+    @DisplayName("没开强制：未绑号也一律放行——这条闸对团队服务器/私有部署默认不生效")
+    void disabledLetsEveryoneThrough() {
+        PhoneLoginGuard g = guard(false, "2026-09-30");
+        assertEquals(PhoneLoginGuard.PhoneGate.OK, g.gateFor(withPhone(null), DEADLINE.plusYears(5)));
+    }
+
+    @Test
+    @DisplayName("已绑号：期限前后都放行")
+    void boundUserIsNeverGated() {
+        PhoneLoginGuard g = guard(true, "2026-09-30");
+        assertEquals(PhoneLoginGuard.PhoneGate.OK, g.gateFor(withPhone("13800000000"), DEADLINE.minusDays(1)));
+        assertEquals(PhoneLoginGuard.PhoneGate.OK, g.gateFor(withPhone("13800000000"), DEADLINE.plusYears(5)));
+    }
+
+    @Test
+    @DisplayName("期限内未绑号：放行但必须回 MUST_BIND——直接拒掉等于把存量用户当场锁死")
+    void unboundBeforeDeadlineMustBind() {
+        PhoneLoginGuard g = guard(true, "2026-09-30");
+        assertEquals(PhoneLoginGuard.PhoneGate.MUST_BIND, g.gateFor(withPhone(null), DEADLINE.minusMonths(1)));
+        assertEquals(PhoneLoginGuard.PhoneGate.MUST_BIND, g.gateFor(withPhone("   "), DEADLINE.minusMonths(1)),
+                "空白串不算绑过号");
+    }
+
+    @Test
+    @DisplayName("期限当天仍算期限内——按 23:59:59 收口，不是当天零点就锁人")
+    void deadlineDayIsStillInside() {
+        PhoneLoginGuard g = guard(true, "2026-09-30");
+        assertEquals(PhoneLoginGuard.PhoneGate.MUST_BIND, g.gateFor(withPhone(null), DEADLINE));
+    }
+
+    @Test
+    @DisplayName("期限次日起未绑号拒登")
+    void unboundAfterDeadlineIsBlocked() {
+        PhoneLoginGuard g = guard(true, "2026-09-30");
+        assertEquals(PhoneLoginGuard.PhoneGate.BLOCKED, g.gateFor(withPhone(null), DEADLINE.plusDays(1)));
+    }
+
+    @Test
+    @DisplayName("期限配错格式回落默认值，而不是静默变成无限期延期")
+    void malformedDeadlineFallsBackToDefault() {
+        PhoneLoginGuard g = guard(true, "not-a-date");
+        assertEquals(LocalDate.parse(PhoneLoginGuard.DEFAULT_BINDING_DEADLINE), g.bindingDeadline());
+        assertEquals(PhoneLoginGuard.PhoneGate.BLOCKED,
+                g.gateFor(withPhone(null), LocalDate.parse(PhoneLoginGuard.DEFAULT_BINDING_DEADLINE).plusDays(1)));
+    }
+
+    @Test
+    @DisplayName("local-mode 免登没有登录环节，这条闸不适用")
+    void localModeIsExempt() {
+        PhoneLoginGuard g = new PhoneLoginGuard(activeSms(), true, true, "2026-09-30");
+        assertFalse(g.isRequired());
+        assertEquals(PhoneLoginGuard.PhoneGate.OK, g.gateFor(withPhone(null), DEADLINE.plusYears(5)));
+    }
+
+    @Test
+    @DisplayName("期限默认值与官网 lib/phone-policy.ts 的 DEFAULT_BINDING_DEADLINE 同值")
+    void defaultDeadlineMatchesWebsite() {
+        assertEquals("2026-09-30", PhoneLoginGuard.DEFAULT_BINDING_DEADLINE);
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -60,7 +60,7 @@ class AuthControllerHardeningTest {
     void closedRegistrationShortCircuits() {
         UserService userService = mock(UserService.class);
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("closed"), null, null, null, null, sessions(), false);
+                userService, null, null, null, serverGuard("closed"), null, null, null, null, sessions(), false, null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -76,7 +76,7 @@ class AuthControllerHardeningTest {
         when(userService.register(anyString(), anyString(), anyString()))
                 .thenReturn(user(1L, "alice"));
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false);
+                userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false, null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -91,7 +91,7 @@ class AuthControllerHardeningTest {
                 .thenReturn(user(1L, "alice"));
         AuthAbuseGuard localGuard = new AuthAbuseGuard(true, "closed");
         AuthController controller = new AuthController(
-                userService, null, null, null, localGuard, null, null, null, null, sessions(), false);
+                userService, null, null, null, localGuard, null, null, null, null, sessions(), false, null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -105,7 +105,7 @@ class AuthControllerHardeningTest {
         when(userService.login(anyString(), anyString()))
                 .thenThrow(new IllegalArgumentException("用户名或密码错误"));
         AuthController controller = new AuthController(
-                userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false);
+                userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false, null);
 
         AuthController.LoginRequest request = new AuthController.LoginRequest();
         request.setUsername("alice");
@@ -128,7 +128,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(anyString()))
                 .thenReturn(new AwdkLoginService.BridgeSession("awdt_x", 7L, "awd_hanzewei"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -147,7 +147,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(any()))
                 .thenThrow(new IllegalArgumentException("本服务器未开启账户桥接功能"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -166,7 +166,7 @@ class AuthControllerHardeningTest {
         when(awdkLoginService.login(anyString())).thenThrow(new AccountException(
                 AccountException.Kind.UNAUTHORIZED, "账户 Key 无效或已被撤销，请到官网账户页重新生成"));
         AuthController controller = new AuthController(
-                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false);
+                null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null);
 
         for (int i = 0; i < 5; i++) {
             assertEquals(1, controller.awdkLogin(Map.of("key", "awdk_bad"), http()).get("code"));

--- a/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
@@ -51,7 +51,7 @@ class AuthControllerLocalDeviceTokenTest {
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
                 org.mockito.Mockito.mock(com.checkba.repository.UserSessionRepository.class));
         return new AuthController(userService, null, null, deviceTokenService,
-                null, null, null, null, null, sessions, localMode);
+                null, null, null, null, null, sessions, localMode, null);
     }
 
     private static User user(long id, String username, String displayName) {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
@@ -47,7 +47,7 @@ class AuthControllerMailTest {
     private static AuthController controller(UserService userService, AuthAbuseGuard guard,
                                              MailAuthService mailAuthService) {
         return new AuthController(userService, null, null, null, guard, null, null,
-                mailAuthService, null, sessions(), false);
+                mailAuthService, null, sessions(), false, null);
     }
 
     private static AuthController.MailSendCodeRequest sendCodeRequest(String scene, String email) {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerPhoneGateTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerPhoneGateTest.java
@@ -1,0 +1,235 @@
+package com.checkba.controller;
+
+import com.checkba.config.PhoneLoginGuard;
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.AuthAbuseGuard;
+import com.checkba.service.DeviceTokenService;
+import com.checkba.service.UserService;
+import com.checkba.service.UserSessionService;
+import com.checkba.service.auth.VerificationCodeStore;
+import com.checkba.service.mail.MailAuthService;
+import com.checkba.service.sms.SmsAuthService;
+import com.checkba.service.sms.SmsService;
+import com.checkba.service.sms.SmsTransport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * 手机号补绑闸接进登录链路（spec §5）。
+ *
+ * 这里钉的是**接线**，不是策略语义（那在 PhoneBindingGateTest）。三条不变式：
+ * 期限内未绑号照常登录但带 mustBindPhone 信号；期限后未绑号拒登且**一个凭据都不签发**；
+ * 拒登码不能是 4010——那是前端 api.js 认定的「会话失效」专用码，回它会让客户端清掉会话。
+ */
+class AuthControllerPhoneGateTest {
+
+    private static final SmsTransport OK_TRANSPORT =
+            (url, body, auth) -> new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
+
+    /** 补绑期内 / 期限后：靠配进 guard 的期限值切换，不依赖机器当前日期。 */
+    private static final String LONG_PAST = "2000-01-01";
+    private static final String FAR_FUTURE = "2099-12-31";
+
+    private static MockHttpServletRequest http() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("9.9.9.9");
+        return request;
+    }
+
+    private static User user(String phone) {
+        User user = new User();
+        user.setId(7L);
+        user.setUsername("alice");
+        user.setDisplayName("Alice");
+        user.setRole("USER");
+        user.setSubscriptionType("FREE");
+        user.setPhone(phone);
+        return user;
+    }
+
+    private static PhoneLoginGuard guard(boolean required, String deadline) {
+        SmsAuthService sms = new SmsAuthService(
+                List.of(new SmsService(OK_TRANSPORT, true, "ak", "sk", "sign", "tpl")),
+                new VerificationCodeStore(), mock(UserRepository.class), false);
+        return new PhoneLoginGuard(sms, required, false, deadline);
+    }
+
+    private static AuthController controller(UserService userService, UserSessionService sessions,
+                                             PhoneLoginGuard phoneLoginGuard) {
+        return controller(userService, sessions, phoneLoginGuard, null, null);
+    }
+
+    private static AuthController controller(UserService userService, UserSessionService sessions,
+                                             PhoneLoginGuard phoneLoginGuard,
+                                             DeviceTokenService deviceTokenService,
+                                             MailAuthService mailAuthService) {
+        return new AuthController(userService, null, null, deviceTokenService,
+                mock(AuthAbuseGuard.class), null, null, mailAuthService, null, sessions,
+                false, phoneLoginGuard);
+    }
+
+    private static UserSessionService sessions() {
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(sessions.issue(anyLong())).thenReturn("session_stub");
+        return sessions;
+    }
+
+    private static AuthController.LoginRequest loginRequest() {
+        AuthController.LoginRequest r = new AuthController.LoginRequest();
+        r.setUsername("alice");
+        r.setPassword("pw123456");
+        return r;
+    }
+
+    private static UserService loginReturning(User user) {
+        UserService userService = mock(UserService.class);
+        when(userService.login(anyString(), anyString())).thenReturn(user);
+        return userService;
+    }
+
+    // ==================== /login ====================
+
+    @Test
+    @DisplayName("期限内未绑号：照常登录、照常发会话，但要带 mustBindPhone 让客户端立刻弹强制补绑")
+    void beforeDeadlineUnboundSignsInWithMustBindSignal() {
+        UserSessionService sessions = sessions();
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions, guard(true, FAR_FUTURE))
+                .login(loginRequest(), http());
+
+        assertEquals(0, result.get("code"));
+        Map<?, ?> data = (Map<?, ?>) result.get("data");
+        assertEquals("session_stub", data.get("sessionId"));
+        assertEquals(true, data.get("mustBindPhone"), "期限内未绑号必须带补绑信号，否则客户端无从知道要弹窗");
+        verify(sessions).issue(7L);
+    }
+
+    @Test
+    @DisplayName("期限后未绑号：拒登，且**一个会话都不许签发**——先建会话再拒等于给了个能用的凭据")
+    void afterDeadlineUnboundIsRefusedBeforeAnySessionIsIssued() {
+        UserSessionService sessions = sessions();
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions, guard(true, LONG_PAST))
+                .login(loginRequest(), http());
+
+        assertNotEquals(0, result.get("code"));
+        assertNull(result.get("data"), "拒登不得带回任何 data，更不许夹带 sessionId");
+        verify(sessions, never()).issue(anyLong());
+    }
+
+    @Test
+    @DisplayName("拒登码不能是 4010——那是「会话失效」专用码，回它会让前端把会话清掉")
+    void refusalCodeIsNotTheSessionExpiredCode() {
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions(), guard(true, LONG_PAST))
+                .login(loginRequest(), http());
+
+        assertNotEquals(4010, result.get("code"));
+        assertEquals(AuthController.CODE_PHONE_BINDING_REQUIRED, result.get("code"));
+    }
+
+    @Test
+    @DisplayName("被锁在门外的用户看得到人工通道，否则他就是真的进不来了")
+    void refusalPointsAtTheSupportMailbox() {
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions(), guard(true, LONG_PAST))
+                .login(loginRequest(), http());
+
+        assertTrue(String.valueOf(result.get("message")).contains("hi@aiworkdeck.com"),
+                "拒登文案必须指向 hi@aiworkdeck.com：实际是 " + result.get("message"));
+    }
+
+    @Test
+    @DisplayName("已绑号不受影响：期限过了也照常登录，且不带补绑信号")
+    void boundUserIsUnaffected() {
+        UserSessionService sessions = sessions();
+        Map<String, Object> result = controller(loginReturning(user("13800000000")), sessions, guard(true, LONG_PAST))
+                .login(loginRequest(), http());
+
+        assertEquals(0, result.get("code"));
+        assertEquals(false, ((Map<?, ?>) result.get("data")).get("mustBindPhone"));
+        verify(sessions).issue(7L);
+    }
+
+    @Test
+    @DisplayName("没开强制时未绑号照常登录——这条闸默认对团队服务器/私有部署不生效")
+    void notRequiredMeansNoGate() {
+        UserSessionService sessions = sessions();
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions, guard(false, LONG_PAST))
+                .login(loginRequest(), http());
+
+        assertEquals(0, result.get("code"));
+        assertEquals(false, ((Map<?, ?>) result.get("data")).get("mustBindPhone"));
+        verify(sessions).issue(7L);
+    }
+
+    // ==================== /device-token ====================
+
+    @Test
+    @DisplayName("换设备令牌也是一次密码登录：期限后未绑号必须同样拒，否则换个端点就绕过去了")
+    void deviceTokenPathIsGatedToo() {
+        DeviceTokenService tokens = mock(DeviceTokenService.class);
+        when(tokens.issue(anyLong(), any())).thenReturn(new DeviceTokenService.IssuedToken(1L, "awdt_x"));
+
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions(),
+                guard(true, LONG_PAST), tokens, null)
+                .issueDeviceToken(Map.of("username", "alice", "password", "pw123456"), http());
+
+        assertEquals(AuthController.CODE_PHONE_BINDING_REQUIRED, result.get("code"));
+        verify(tokens, never()).issue(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("期限内未绑号仍能换令牌，同样带补绑信号")
+    void deviceTokenBeforeDeadlineCarriesMustBind() {
+        DeviceTokenService tokens = mock(DeviceTokenService.class);
+        when(tokens.issue(anyLong(), any())).thenReturn(new DeviceTokenService.IssuedToken(1L, "awdt_x"));
+
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions(),
+                guard(true, FAR_FUTURE), tokens, null)
+                .issueDeviceToken(Map.of("username", "alice", "password", "pw123456"), http());
+
+        assertEquals(0, result.get("code"));
+        assertEquals(true, ((Map<?, ?>) result.get("data")).get("mustBindPhone"));
+    }
+
+    // ==================== /mail-login/verify ====================
+
+    @Test
+    @DisplayName("邮箱免密登录同样过闸——留着它等于给未绑号用户开了条并行入口")
+    void mailLoginPathIsGatedToo() {
+        MailAuthService mail = mock(MailAuthService.class);
+        when(mail.verifySigninCode(anyString(), anyString())).thenReturn(user(null));
+        UserSessionService sessions = sessions();
+
+        AuthController.MailLoginRequest r = new AuthController.MailLoginRequest();
+        r.setEmail("alice@gmail.com");
+        r.setCode("123456");
+
+        Map<String, Object> result = controller(mock(UserService.class), sessions,
+                guard(true, LONG_PAST), null, mail).mailLoginVerify(r, http());
+
+        assertEquals(AuthController.CODE_PHONE_BINDING_REQUIRED, result.get("code"));
+        verify(sessions, never()).issue(anyLong());
+    }
+
+    // ==================== awdk 桥不受影响 ====================
+
+    @Test
+    @DisplayName("guard 为 null（未接线的调用方）时一律放行，不把既有链路连坐")
+    void nullGuardIsInert() {
+        UserSessionService sessions = sessions();
+        Map<String, Object> result = controller(loginReturning(user(null)), sessions, null)
+                .login(loginRequest(), http());
+
+        assertEquals(0, result.get("code"));
+        verify(sessions).issue(7L);
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
@@ -59,7 +59,7 @@ class AuthControllerSmsTest {
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
                 mock(com.checkba.repository.UserSessionRepository.class));
         return new AuthController(userService, null, null, null, guard, null, smsAuthService,
-                mock(com.checkba.service.mail.MailAuthService.class), secondFactor, sessions, false);
+                mock(com.checkba.service.mail.MailAuthService.class), secondFactor, sessions, false, null);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/sms/SmsSigninTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsSigninTest.java
@@ -100,7 +100,7 @@ class SmsSigninTest {
         assertFalse(inactive.active());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> new PhoneLoginGuard(inactive, true, false));
+                () -> new PhoneLoginGuard(inactive, true, false, "2026-09-30"));
         assertTrue(e.getMessage().contains("短信网关必须可用"),
                 "报错要说清楚是网关的问题，别让人去查前端");
     }
@@ -109,15 +109,15 @@ class SmsSigninTest {
     @DisplayName("网关可用时正常启动；local-mode 与未开启时这条闸不适用")
     void guardPassesWhenSane() {
         SmsAuthService active = svc(OK);
-        assertDoesNotThrow(() -> new PhoneLoginGuard(active, true, false));
+        assertDoesNotThrow(() -> new PhoneLoginGuard(active, true, false, "2026-09-30"));
 
         SmsService dark = new SmsService(OK, false, "", "", "sign", "tpl");
         SmsAuthService inactive = new SmsAuthService(List.of(dark), new VerificationCodeStore(),
                 mock(UserRepository.class), false);
         // 没开强制：网关暗着也该正常启动
-        assertDoesNotThrow(() -> new PhoneLoginGuard(inactive, false, false));
+        assertDoesNotThrow(() -> new PhoneLoginGuard(inactive, false, false, "2026-09-30"));
         // local-mode 根本没有登录环节
-        assertDoesNotThrow(() -> new PhoneLoginGuard(inactive, true, true));
-        assertFalse(new PhoneLoginGuard(inactive, true, true).isRequired());
+        assertDoesNotThrow(() -> new PhoneLoginGuard(inactive, true, true, "2026-09-30"));
+        assertFalse(new PhoneLoginGuard(inactive, true, true, "2026-09-30").isRequired());
     }
 }


### PR DESCRIPTION
## 问题

`auth.phone-login-required` 与 `auth.phone-binding-deadline` 两个配置项**从来没接上执行逻辑**（2026-08-18 逐条查证）：

- `phone-login-required` 全仓只有 `config/PhoneLoginGuard.java` 一个消费者，而它是**纯启动期断言**——只做「开了强制但短信网关是暗的就拒绝启动」。
- `PhoneLoginGuard.isRequired()` 的注释写着「供登录链路判断是否关闭密码登录」，但 `PhoneLoginGuard` 在全仓**没有任何其他引用**，这个方法是死代码。
- `phone-binding-deadline` 运行期**没有任何人读它**，只在 yml 里声明。

也就是说：把 `AUTH_PHONE_LOGIN_REQUIRED=true` 注入服务器，密码登录照常可用、没人被强制，唯一变化是缺短信配置时服务起不来。**它会让人误以为强制已开，比没有这个开关更危险。**

## 改动

把 spec §5 的三态真正接进登录链路，而不是简单拒掉密码登录：

| 账号状态 | 行为 |
|---|---|
| 已绑手机号 | 放行 |
| 期限内（默认到 2026-09-30）未绑号 | 放行，回包带 `mustBindPhone` 让客户端立刻弹强制补绑（走现成的 `POST /api/auth/sms/bind`） |
| 期限后未绑号 | 拒登，文案指向 `hi@aiworkdeck.com` |

口径照官网 PR#66 的 `lib/phone-policy.ts`（`gateForUser()`）做，两边别漂。期限默认值两边同为 `2026-09-30`，**改一边必须改另一边**；格式配错回落默认值而不是无限期放行。

`PhoneLoginGuard` 一个类兼两职：启动期断言（不动）＋ 运行期三态闸 `gateFor(user)`。`required && !localMode` 这条保留——local-mode 没有登录环节。

## 三条硬约束

- **拒登落在 `issue()` 之前**。先签发再拒等于已经把一个能用的凭据交出去了。用例用 `verify(sessions, never()).issue(...)` 钉住。
- **接线是三条路径不是一条**：`/login`、`/device-token`、`/mail-login/verify`。只护住 `/login` 是假闸——换个端点就绕过去了，而 `/device-token` 发的还是**长期**凭据。`/awdk-login`（awdk_ 桥）刻意不管，它不走密码也不走手机号，**Office 插件不受影响**。
- **拒登码 4006，绝不用 4010**。4010 是前端 `api.js:288` 认定的「会话失效」专用码，回它会让客户端清掉会话、把文案一起冲掉，被锁的人就不知道该去发邮件。4006 全仓无冲突。

## 时间点

开关默认仍为 `false`，本次**不改任何部署的行为**。**不要在 2026-09-30 之前打开**——提前开会把所有还没绑号的云端账号当场锁死，正是 §5 迁移设计要防的事。合理节奏是先让「期限内强制补绑」跑起来给存量用户绑号时间，到期后靠 deadline 自动生效（不需要人为改开关）。

## 已知未闭合的边

`/register` 没接这条闸。`security.registration-mode` 代码默认 `open`（cloud profile 显式 `closed`），所以只有「开了强制手机号 + 又开着注册」的部署才踩得到：期限后新注册仍会拿到一个能用的会话，直到下次登录才被拒。要不要一并关掉是待定的策略问题，已记在 `.claude/agents/licensing-billing.md`。

## 验证

`mvn -B test`（JDK 21）：**1880 passed / 0 failed / 7 skipped**。

新增用例钉住的不变式：

- `PhoneBindingGateTest`（策略层，8 例）：三态取值、期限当天仍算期限内、空白串不算绑过号、格式非法回落默认值、local-mode 豁免、默认期限与官网同值。
- `AuthControllerPhoneGateTest`（接线层，10 例）：期限内未绑号仍能登录且带 `must_bind` 信号、期限后未绑号拒登且 `verify(never()).issue(...)` 证明**没有签发会话**、已绑号不受影响、错误码不是 4010、拒登文案含 `hi@aiworkdeck.com`、`/device-token` 与 `/mail-login/verify` 同样过闸、guard 为 null 时完全惰性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)