### PR TITLE
fix(auth): 补上 #412 测试助手漏掉的第 12 个构造器参数——master 编译不过

### DIFF
--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -179,9 +179,10 @@ class AuthControllerHardeningTest {
 
     // ==================== 账户登录（手机号/邮箱，匿名端点） ====================
 
+    /** phoneLoginGuard 传 null：手机号补绑闸只管密码/邮箱那三条入口，账户登录不走它。 */
     private static AuthController controller(AwdkLoginService awdkLoginService, AuthAbuseGuard guard) {
         return new AuthController(
-                null, null, null, null, guard, awdkLoginService, null, null, null, sessions(), false);
+                null, null, null, null, guard, awdkLoginService, null, null, null, sessions(), false, null);
     }
 
     @Test


### PR DESCRIPTION
**master 现在编译不过，这条是修它的。**

## 怎么坏的

[#411](https://github.com/zeweihan/aiworkdeck/pull/411) 给 `AuthController` 加了第 12 个构造器参数 `PhoneLoginGuard`，并把全部 8 处构造点各补了一个 `null`。
[#412](https://github.com/zeweihan/aiworkdeck/pull/412) 在同一个测试文件里**新增**了一个测试助手，按当时的 11 个参数构造。

两边改的是同一文件的不同行，git 判定无冲突直接合上；两条分支各自的 CI 也都是绿的——因为**谁都没同时见过对方的改动**。合并后的 master 才是第一次两处并存的地方，`javac` 当场断在 `AuthControllerHardeningTest`。#412 合并时 #411 已经在 master 上了，责任在后合的那条。

## 修法

```java
null, null, null, null, guard, awdkLoginService, null, null, null, sessions(), false, null
//                                                                                    ^^^^ 补这个
```

`phoneLoginGuard` 传 `null`（不设闸）是**正确语义**，不是为了让它编过：#411 明确写了闸只接 `/login`、`/device-token`、`/mail-login/verify` 三条，`/awdk-login` 刻意不管。账户登录这条同理——它根本不碰 `userService.login`，凭据由官网校验，补绑期判定也在官网（官网 PR#66 的 `gateForUser`）。官网回 `phone_binding_required` 时 `AccountLoginExchange` 已经把它归成 `CONFLICT`，端点据此拒登且不计入失败锁定。这台服务器再判一次，既拿不到判据（它不知道该账号在官网绑没绑），也不该判。

## 验证

`mvn -o test`：**1896 passed / 0 failed**（JDK 21），即 #411 的 1880 + #412 的 15 + 本条 1。

## 给下次的教训

分支各自绿 ≠ 合并后绿。两条 PR 同时在改一个构造器/一份签名时，后合的那条 merge 前应当先 rebase 到最新 master 跑一次，而不是只信自己分支上那次 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)