### PR TITLE
fix(release): 镜像同步保留上一版安装包——关掉官网下载按钮的 404 窗口

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -73,6 +73,8 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   而页面缓存里还是旧文件名，用户点下载就是 404（2026-08-18 发 v0.18.0 实测到）；
   留一版也给「已经点了下载、1.4GB 正在传」的用户留余地。改动这段先跑
   `bash deploy/update-mirror-sync_prune_test.sh`（纯本地，不碰网络与真镜像目录）。
+  **服务器上跑的是一份副本**（`/www/wwwroot/update/desktop/update-mirror-sync.sh`，cron 每小时 :17），
+  合并 PR 不会让它生效，要 scp 覆盖过去。
 - **`deploy/publish-lowa-engine.sh` — 换 LOWA 引擎必须走它，别手工传**（issue #310）。
   `check-build <目录>` 只在本地验产物；`publish <目录> <版本号>` 发到两台机；`verify <版本号>` 切指针前必跑。
   它把三件必须同时做对的事绑在一起：按形态判定该压不该压、**两台机都同步**（新加坡是本地镜像直出、

--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -67,6 +67,12 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 
 - `deploy/web/` — Web 服务器版（瘦客户端 Phase A2/鸿蒙路线）：nginx.conf.example、能力探针 probe/、后端 prod 只听 127.0.0.1。
 - `deploy/cloud/` — 官方托管的插件云后端（addin.aiworkdeck.com）：nginx server 块、systemd unit、env 模板、部署实录。
+- `deploy/update-mirror-sync.sh` — 官网 ECS 上每小时一跑的镜像同步（补丁产物 + 安装包 + installers/latest.json）。
+  **安装包留最新两版，别改回「只留最新一版」**：官网 /start 的下载按钮是服务端渲染的，
+  数据源（官网仓 lib/latest-release.ts）对 latest.json 用了 `revalidate: 300`。旧包一删、
+  而页面缓存里还是旧文件名，用户点下载就是 404（2026-08-18 发 v0.18.0 实测到）；
+  留一版也给「已经点了下载、1.4GB 正在传」的用户留余地。改动这段先跑
+  `bash deploy/update-mirror-sync_prune_test.sh`（纯本地，不碰网络与真镜像目录）。
 - **`deploy/publish-lowa-engine.sh` — 换 LOWA 引擎必须走它，别手工传**（issue #310）。
   `check-build <目录>` 只在本地验产物；`publish <目录> <版本号>` 发到两台机；`verify <版本号>` 切指针前必跑。
   它把三件必须同时做对的事绑在一起：按形态判定该压不该压、**两台机都同步**（新加坡是本地镜像直出、
@@ -81,6 +87,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 ## 已知地雷
 
 - CI 签名→冒烟→打包顺序不可乱（PR#176）。
+- 发版有个跨仓的时间差：镜像脚本删旧包 vs 官网页面 ISR 缓存。两边任何一边改保留策略/缓存时长前，先看 `deploy/update-mirror-sync.sh` 里 prune_old_installers 的注释。
 - macOS CI 红要当真查（Apple 协议过期事件后恢复）；`--admin` 合并与 worktree 删分支技巧见 ci-macos 记录。
 - iCloud 驱逐会掏空本地文件（打包/测试环境两次踩）；EMFILE 用抬 ulimit 解。
 - **iCloud 上「读一下」不是免费的**：被驱逐的文件是 dataless 占位，`stat` 秒回真实大小但

--- a/deploy/update-mirror-sync.sh
+++ b/deploy/update-mirror-sync.sh
@@ -6,7 +6,8 @@
 # 同步两类产物：
 #   1. 补丁产物 patch-*.tar.gz + manifest.json(.sig) → $WEB_ROOT/assets/（应用内增量更新）
 #   2. 安装包 .dmg / .exe → $WEB_ROOT/installers/ + latest.json（官网下载直链，
-#      大陆用户打不开 GitHub，官网必须自己发包；只留最新一版，旧安装包同步后清掉）
+#      大陆用户打不开 GitHub，官网必须自己发包；留最新两版，更老的同步后清掉——
+#      为什么不是只留一版见 prune_old_installers 的注释）
 #
 #   bash deploy/update-mirror-sync.sh
 #
@@ -22,6 +23,49 @@ set -euo pipefail
 REPO="${REPO:-zeweihan/aiworkdeck}"
 WEB_ROOT="${WEB_ROOT:-/www/wwwroot/update/desktop}"
 API="https://api.github.com/repos/${REPO}/releases/latest"
+
+# 清理旧安装包：只删「比上一版更老的」，当前版与上一版都留着。
+#
+# 为什么不能一换 latest.json 就把旧包全删——2026-08-18 发 v0.18.0 时实测到的 404 窗口：
+# 官网 /start 的下载按钮是服务端渲染的，数据源 aiworkdeck_website 的 lib/latest-release.ts
+# 对本清单用了 `revalidate: 300`。latest.json 已指向新版、旧包已被删，而页面缓存里还是
+# 旧版文件名，用户点下载直接 404（stale-while-revalidate 还会让过期后的第一个访客继续
+# 拿到旧页面，真实窗口比 300 秒更长）。
+# 留一版旧包同时也照顾到「已经点了下载、正在传」的用户：安装包 1.4GB，大陆常要传很久，
+# 传到一半文件没了就是断流——这个比 404 更隐蔽。
+#
+# 入参：$1 = 本版版本号（如 0.18.0），$2 = 本版资产清单 tsv
+prune_old_installers() {
+  local cur_ver="$1" tsv="$2"
+  local prev_ver f base stem
+
+  # 上一版 = 盘上除本版外最高的那个版本号。版本号从文件名里取
+  #（AI.WorkDeck-0.18.0-arm64.dmg / AI.WorkDeck.Setup.0.18.0.exe），不认品牌大小写
+  # ——0.18.0 起 Workdeck 改成了 WorkDeck，按名字前缀比对会在改名那一版失手。
+  # 必须 sort -V：字典序会把 0.9.0 判得比 0.18.0 新。
+  prev_ver=$(find "$WEB_ROOT/installers" -maxdepth 1 -type f \( -name '*.dmg' -o -name '*.exe' \) \
+    | sed 's#.*/##' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -uV | grep -vFx "$cur_ver" | tail -1 || true)
+  [ -n "$prev_ver" ] && echo "[mirror-sync] keep previous installer: $prev_ver"
+
+  while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    stem="${base#.}"; stem="${stem%.part}"
+    # 本版的（含正在续传的半成品）：留
+    if grep -qF "$stem" "$tsv"; then continue; fi
+    # 上一版的成品安装包：留。半成品不留——`.part` 只对还在下的那一版有意义，
+    # 旧版的半成品没人会再续传，是纯占盘。
+    if [ -n "$prev_ver" ]; then
+      case "$base" in
+        *"$prev_ver"*.dmg|*"$prev_ver"*.exe) continue ;;
+      esac
+    fi
+    echo "[mirror-sync] prune old installer: $base"
+    rm -f "$f"
+  done < <(find "$WEB_ROOT/installers" -maxdepth 1 -type f \( -name '*.dmg' -o -name '*.exe' -o -name '.*.part' \) -print0)
+}
+
+# 测试只想拿上面的函数，不要跑同步本身（deploy/update-mirror-sync_prune_test.sh）
+[ "${MIRROR_SYNC_SOURCE_ONLY:-0}" = "1" ] && return 0
 
 # 全局互斥锁：安装包是 GB 级、大陆拉 GitHub 可能一跑数小时，cron 每小时一发，
 # 不加锁必然叠车——2026-08-14 实测三个并发实例互分带宽，每个只剩 ~15KB/s，
@@ -124,7 +168,7 @@ fi
 
 # ---- 安装包镜像（官网下载直链）----------------------------------------------
 # 全部就位才写 latest.json（原子替换，官网只信这份清单，绝不指向缺失文件）；
-# 写完再清理不属于本版的旧安装包（1.4GB 级别，只留最新一版省磁盘）。
+# 写完再清理更老的安装包（1.4GB 级别，留最新两版，更老的省磁盘）。
 # 任一下载失败则保留旧 latest.json 与旧安装包——官网继续发上一版，不发半套。
 INSTALLERS_FAILED=0
 if [ -s "$TMP/installers.tsv" ]; then
@@ -165,14 +209,7 @@ EOF
     echo "[mirror-sync] installers/latest.json updated -> $TAG"
 
     # 清理旧安装包与过期半成品（只删 .dmg/.exe/.part，不碰 latest.json）
-    while IFS= read -r -d '' f; do
-      base="$(basename "$f")"
-      stem="${base#.}"; stem="${stem%.part}"
-      if ! grep -qF "$stem" "$TMP/installers.tsv"; then
-        echo "[mirror-sync] prune old installer: $base"
-        rm -f "$f"
-      fi
-    done < <(find "$WEB_ROOT/installers" -maxdepth 1 -type f \( -name '*.dmg' -o -name '*.exe' -o -name '.*.part' \) -print0)
+    prune_old_installers "${TAG#v}" "$TMP/installers.tsv"
   else
     echo "[mirror-sync] 安装包未全部就位，latest.json 不更新（官网继续发上一版）；重跑本脚本可续传补齐" >&2
   fi

--- a/deploy/update-mirror-sync_prune_test.sh
+++ b/deploy/update-mirror-sync_prune_test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# update-mirror-sync.sh 的 prune 单元测试
+# ---------------------------------------------------------------------------
+# 只测 prune_old_installers 一个函数：造一个假的 installers 目录，跑一次，
+# 断言留下/删掉的正是该留该删的。不碰网络、不碰真镜像目录。
+#
+# 用法：bash deploy/update-mirror-sync_prune_test.sh
+# 退出码：0=全通过。
+#
+# 起因是 2026-08-18 发 v0.18.0 时官网下载按钮的 404 窗口：旧包一换 latest.json
+# 就被删，而 /start 页的下载直链带 ISR 缓存（lib/latest-release.ts revalidate 300），
+# 缓存里还是旧文件名。用例 1 就是这个回归。
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAIL=0
+
+ok()  { printf '\033[32m  PASS\033[0m %s\n' "$*"; }
+bad() { printf '\033[31m  FAIL\033[0m %s\n' "$*"; FAIL=1; }
+
+# 只取函数，不跑同步主体
+MIRROR_SYNC_SOURCE_ONLY=1 . "$HERE/update-mirror-sync.sh"
+
+ROOT=""
+cleanup() { [ -n "$ROOT" ] && rm -rf "$ROOT"; }
+trap cleanup EXIT
+
+# 造场景：$1=本版版本号，其余=盘上的文件名。设 WEB_ROOT/installers 与本版 tsv。
+setup() {
+  local cur="$1"; shift
+  ROOT="$(mktemp -d)"
+  WEB_ROOT="$ROOT"
+  mkdir -p "$WEB_ROOT/installers"
+  local f
+  for f in "$@"; do : > "$WEB_ROOT/installers/$f"; done
+  # latest.json 永远在，且永远不该被删
+  echo '{}' > "$WEB_ROOT/installers/latest.json"
+  # 本版资产清单，格式与主脚本的 installers.tsv 一致：name<TAB>size<TAB>url
+  TSV="$ROOT/installers.tsv"
+  : > "$TSV"
+  printf 'AI.WorkDeck-%s-arm64.dmg\t1\thttps://x\n' "$cur" >> "$TSV"
+  printf 'AI.WorkDeck.Setup.%s.exe\t1\thttps://x\n' "$cur" >> "$TSV"
+}
+
+# 断言盘上剩下的文件恰好是期望集合（排序后逐字比较）
+expect_left() {
+  local label="$1"; shift
+  local want got
+  want="$(printf '%s\n' "$@" | sort)"
+  got="$(find "$WEB_ROOT/installers" -maxdepth 1 -type f | sed 's#.*/##' | sort)"
+  if [ "$want" = "$got" ]; then
+    ok "$label"
+  else
+    bad "$label"
+    printf '    期望: %s\n' "$(echo "$want" | tr '\n' ' ')"
+    printf '    实际: %s\n' "$(echo "$got" | tr '\n' ' ')"
+  fi
+}
+
+printf '\033[1m[prune]\033[0m update-mirror-sync.sh prune_old_installers\n'
+
+# 1) 本次 404 的回归：换到 0.18.0 之后，上一版 0.17.0 必须还在（官网页面缓存里
+#    还是它的文件名），更老的 0.16.0 才删。
+setup 0.18.0 \
+  AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe \
+  AI.Workdeck-0.17.0-arm64.dmg AI.Workdeck.Setup.0.17.0.exe \
+  AI.Workdeck-0.16.0-arm64.dmg AI.Workdeck.Setup.0.16.0.exe
+prune_old_installers 0.18.0 "$TSV" >/dev/null
+expect_left "留本版 + 上一版，删更老的（含品牌大小写变更前的旧命名）" \
+  latest.json \
+  AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe \
+  AI.Workdeck-0.17.0-arm64.dmg AI.Workdeck.Setup.0.17.0.exe
+cleanup
+
+# 2) 盘上只有本版：什么都不该删
+setup 0.18.0 AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe
+prune_old_installers 0.18.0 "$TSV" >/dev/null
+expect_left "只有本版时不误删" \
+  latest.json AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe
+cleanup
+
+# 3) 半成品：本版的 .part 是正在续传的，要留；旧版的 .part 没人会再续，删。
+setup 0.18.0 \
+  AI.WorkDeck-0.18.0-arm64.dmg \
+  .AI.WorkDeck.Setup.0.18.0.exe.part \
+  AI.Workdeck-0.17.0-arm64.dmg \
+  .AI.Workdeck.Setup.0.17.0.exe.part \
+  .AI.Workdeck-0.16.0-arm64.dmg.part
+prune_old_installers 0.18.0 "$TSV" >/dev/null
+expect_left "留本版半成品，删旧版半成品（旧版成品仍留）" \
+  latest.json \
+  AI.WorkDeck-0.18.0-arm64.dmg \
+  .AI.WorkDeck.Setup.0.18.0.exe.part \
+  AI.Workdeck-0.17.0-arm64.dmg
+cleanup
+
+# 4) 连着发两版之后，只留最近两版
+setup 0.19.0 \
+  AI.WorkDeck-0.19.0-arm64.dmg AI.WorkDeck.Setup.0.19.0.exe \
+  AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe \
+  AI.Workdeck-0.17.0-arm64.dmg AI.Workdeck.Setup.0.17.0.exe
+prune_old_installers 0.19.0 "$TSV" >/dev/null
+expect_left "再发一版后窗口向前滚，只留最近两版" \
+  latest.json \
+  AI.WorkDeck-0.19.0-arm64.dmg AI.WorkDeck.Setup.0.19.0.exe \
+  AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe
+cleanup
+
+# 5) 版本号里有两位数段：0.9.0 比 0.18.0 老（字典序会判反，必须走 sort -V）
+setup 0.18.0 \
+  AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe \
+  AI.Workdeck-0.9.0-arm64.dmg AI.Workdeck-0.17.0-arm64.dmg
+prune_old_installers 0.18.0 "$TSV" >/dev/null
+expect_left "版本比较按数值而非字典序" \
+  latest.json \
+  AI.WorkDeck-0.18.0-arm64.dmg AI.WorkDeck.Setup.0.18.0.exe \
+  AI.Workdeck-0.17.0-arm64.dmg
+cleanup
+
+[ "$FAIL" = 0 ] && printf '\033[32m[prune] 全部通过\033[0m\n' || printf '\033[31m[prune] 有失败\033[0m\n'
+exit "$FAIL"


### PR DESCRIPTION
## 问题

发 v0.18.0 时实测到：官网 /start 的下载按钮最长有 5 分钟点下去是 404。

`deploy/update-mirror-sync.sh` 写完 `installers/latest.json` 之后立刻把不属于本版的安装包全删了；而官网 /start 的下载直链是服务端渲染的，数据源（官网仓 `lib/latest-release.ts`）对这份 latest.json 用了 `revalidate: 300`。latest.json 已指向新版、旧包已被删，而页面缓存里还是旧文件名：

```
curl -sI https://www.aiworkdeck.com/update/desktop/installers/AI.Workdeck-0.17.0-arm64.dmg
-> HTTP/2 404
```

服务器实测：`installers/` 里只剩 0.18.0 两个文件，0.17.0 已被 prune 掉。stale-while-revalidate 还会让过期后的第一个访客继续拿到旧页面，真实窗口比 300 秒更长。

## 改动

保留最近两版：当前版与上一版都留着，只清理更老的。

选这条而不是把页面缓存改短，是因为它顺带解决一个更隐蔽的问题——安装包 1.4GB，大陆用户常要传很久，**正在传的时候文件被删掉就是断流**，缩短缓存时长对这类用户没有任何帮助。

- 上一版按文件名里的版本号识别（`sort -V`，不认品牌大小写——0.18.0 起 `Workdeck` 改成了 `WorkDeck`，按名字前缀比对会在改名那一版失手）
- 旧版的 `.part` 半成品仍然清掉：它只对还在下的那一版有意义
- prune 抽成 `prune_old_installers` 以便单测；抽出来时**先原样搬、跑测试确认复现了这个 404，再改**

## 验证

新增 `deploy/update-mirror-sync_prune_test.sh`（纯本地，不碰网络与真镜像目录）：

```
bash deploy/update-mirror-sync_prune_test.sh
```

五条用例：本次 404 的回归 / 只有本版时不误删 / 半成品的留删 / 连发两版窗口向前滚 / 版本比较按数值而非字典序。改前跑是 4 红 1 绿，改后全绿。

## 磁盘

安装包目录 ~2.9G → ~6.2G 稳态，同步新版的瞬时峰值 ~9.3G。官网 ECS 当前可用 15G。

## 部署

脚本在服务器上是一份副本（`/www/wwwroot/update/desktop/update-mirror-sync.sh`，cron 每小时 :17 跑），合并后要覆盖过去，不会自动生效。

## 配套

登录/注册在发版窗口里的报错在官网仓另开一条 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
