### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
大版本（全量安装包）。本版主线是**登录链路真正闭环**——上一版把「必须账户登录」立了起来，这一版把账户登录本身补完整并接上防刷。

## 主线一：手机号强制登录不再是空壳（#411）

`auth.phone-login-required` 与 `auth.phone-binding-deadline` 此前全仓只有一个启动期断言在读，设成 `true` 密码登录照常、没人被强制——**比没有这个开关更危险**。

本版接上 spec §5 的三态：已绑号放行 / 期限内放行但回 `mustBindPhone` 强制补绑 / 期限后拒登（码 4006，**不是 4010**）。接在 `/login`、`/device-token`、`/mail-login/verify` **三条**会签发凭据的路径上，拒登落在 `issue()` 之前。

**开关默认仍为 false，2026-09-30 之前不要打开。**

## 主线二：Office 插件与桌面端都改成账户登录（#412、#416、#418）

插件用户不必再去官网生成 `awdk_` Key 手工搬运，手机号/邮箱直登，粘 Key 降权进高级设置。

其中 #418 修的是一个**已经上线的洞**：官网给国际站加了邮箱验证码注册（那种账号 `passwordHash` 是空串），同时关掉了口令注册，而桌面端国际站的唯一登录路是「账号+口令」——**新国际站用户在官网注册完就再也连不上桌面端**。本版加上邮箱验证码那条路，登录表单改成「验证码登录 / 口令登录」两支，存量口令账号仍可用。

## 主线三：验证码防刷（#416 的透传部分）

官网侧已上线两层：按 IP 限流 + 全局熔断（always-on），以及人机验证（国际站 Turnstile / 大陆站阿里云拼图，**默认未启用**）。

桌面端与插件把人机验证 token 一路透传到官网——**官网无法区分「客户端转发」与「攻击者直接 POST」，放过不带 token 的请求等于那条闸完全失效**，所以两条转发链都必须带上。

## 其余

| PR | 内容 |
|---|---|
| #415 | 顶栏整条点不动的根因（body 级拖拽条）+ 登出入口 + 项目列表两视图 |
| #417 | 项目档案五个字段接进列表 |
| #414 | 镜像同步保留上一版安装包，关掉官网下载按钮的 404 窗口 |
| #413 | 补 #412 漏掉的第 12 个构造器参数 |

## 验证

`mvn -B test`：1901 通过 / 0 失败。合并后打 `v0.19.0` tag 出四平台安装包（mac 只在 tag 上构建）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)