### PR TITLE
fix(unlock): 登录成功却不跳转、滑块只能用一次、官方版去掉 Key 登录

### DIFF
--- a/backend/src/main/java/com/checkba/service/LicenseService.java
+++ b/backend/src/main/java/com/checkba/service/LicenseService.java
@@ -222,6 +222,29 @@ public class LicenseService {
         return activateTrialCode(trimmed);
     }
 
+    /**
+     * 账户已在别处校验通过，只把解锁票据落下来（不再打一次官网）。
+     *
+     * <p><b>为什么必须有这条</b>：解锁状态的唯一数据源是 license 票据（{@link #statusOf}），
+     * 而桌面端的账户登录走的是 {@code AccountService}——它只写账户状态，从不碰票据。
+     * 结果是「登录成功」但 {@code status().unlocked} 仍为 false，launch 页把人原地弹回解锁页，
+     * 表现为「弹了个已解锁的提示，然后什么都没发生」。2026-08-18 真机踩到，
+     * 自 PR#408 引入账户登录起就一直如此。
+     *
+     * <p>与 {@link #activateAccountKey} 的区别只有一处：那条要自己打官网验 Key，
+     * 这条的调用方（{@code AccountService.connect}）已经拉过 {@code /api/account/me} 验过了，
+     * 再验一次既多一次往返，也会让「网络刚好抖一下」把一次成功的登录变成失败。
+     */
+    public synchronized void markAccountUnlocked(String key) {
+        if (!localMode || key == null || key.isBlank()) return;
+        State state = new State();
+        state.mode = "account";
+        state.code = key;
+        state.activatedAt = Instant.now().toString();
+        state.lastVerifiedAt = state.activatedAt;
+        saveState(state);
+    }
+
     /** POST /api/license/deactivate。 */
     public synchronized Map<String, Object> deactivate() {
         if (!localMode) {

--- a/backend/src/main/java/com/checkba/service/account/AccountLoginExchange.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountLoginExchange.java
@@ -64,7 +64,11 @@ final class AccountLoginExchange {
         }
         String message = str(parsed.get("message"));
         String code = str(parsed.get("error"));
-        if (message == null || message.isBlank()) {
+        // 官网的 message 优先——它常带本地判断不出来的具体信息（还要等几秒、地址被拒的原因）。
+        // **但人机验证那两条例外**：官网只有英文文案，原样显示会让中文界面上冒出
+        // 「Verification failed, please try again」（2026-08-18 真机踩到）。
+        // 这两个 code 语义固定，本地双语文案的信息量不比英文原文少。
+        if (message == null || message.isBlank() || LOCALIZED_OVER_UPSTREAM.contains(code)) {
             message = errorMessage(code);
         }
         // 403 phone_binding_required（过了补绑硬期限）/ captcha_failed（人机验证没过）、
@@ -80,6 +84,10 @@ final class AccountLoginExchange {
     }
 
     /** 官网没给 message 时的兜底文案（按 error code 分，别一律「操作失败」）。 */
+    /** 这几个 code 一律用本地双语文案，不用官网回的（那边是纯英文）。 */
+    private static final java.util.Set<String> LOCALIZED_OVER_UPSTREAM =
+            java.util.Set.of("captcha_failed", "too_many_requests");
+
     static String errorMessage(String code) {
         if (code == null) {
             return LangText.of("登录失败，请稍后重试", "Sign-in failed, please retry shortly");

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -37,17 +37,26 @@ public class AccountService {
     private final com.checkba.service.site.SiteProfileService siteProfileService;
     private final Path accountFile;
     private final AccountTransport transport;
+    /**
+     * 解锁票据的写入口。**用 @Lazy 注入**：LicenseService 那边为了复用 State 的 JSON 形状
+     * 引用了本类的静态 stateMapper()，直接注入会在启动期形成构造循环。
+     * 允许为 null——单测里构造本类时不关心解锁票据。
+     */
+    private final com.checkba.service.LicenseService licenseService;
     private final ObjectMapper objectMapper = stateMapper();
 
     public AccountService(
             com.checkba.service.site.SiteProfileService siteProfileService,
             @Value("${security.license.dir:${user.home}/.aiworkdeck}") String accountDir,
-            AccountTransport transport) {
+            AccountTransport transport,
+            @org.springframework.context.annotation.Lazy
+            com.checkba.service.LicenseService licenseService) {
         // 基址由站点决定；协议校验（https，回环 http 例外，见 AccountEndpoint）
         // 在 SiteProfileService 的构造器里对全部站点做过一遍，与 PR-A 的 LicenseService 同源
         this.siteProfileService = siteProfileService;
         this.accountFile = Path.of(accountDir, "account.json");
         this.transport = transport;
+        this.licenseService = licenseService;
     }
 
     /** 当前站点的账户服务基址。切站后当场改指向。 */
@@ -92,6 +101,14 @@ public class AccountService {
         state.connectedAt = Instant.now().toString();
         state.lastSyncAt = state.connectedAt;
         saveState(state);
+        // 账户连上了就要一并落解锁票据：解锁状态的唯一数据源是 LicenseService 的票据，
+        // 而这里只写账户状态。不落的话「登录成功」但 status().unlocked 仍为 false，
+        // launch 页会把人原地弹回解锁页——表现为「弹了个已解锁的提示，然后什么都没发生」。
+        // 放在 connect() 而不是各个调用方：账户登录与设置页粘 Key 都经过这里，
+        // 挂在调用方上迟早漏掉一条（2026-08-18 真机踩到的正是登录那条）。
+        if (licenseService != null) {
+            licenseService.markAccountUnlocked(key);
+        }
         log.info("已连接 AI WorkDeck 账户: {}", state.username);
         return status();
     }

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -65,7 +65,7 @@ class AccountServiceTest {
     private AccountService service() {
         return new AccountService(
                 com.checkba.service.site.SiteProfileService.pinnedTo("https://www.aiworkdeck.com"),
-                tempDir.toString(), transport);
+                tempDir.toString(), transport, null);
     }
 
     private AccountService connected() {
@@ -455,22 +455,39 @@ class AccountServiceTest {
     @DisplayName("base-url 配成 http 直接拒绝：明文 Key 不允许走未加密通道")
     void httpBaseUrlRejected() {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("http://www.aiworkdeck.com"), tempDir.toString(), new StubTransport()));
+                () -> new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("http://www.aiworkdeck.com"), tempDir.toString(), new StubTransport(), null));
         assertTrue(e.getMessage().contains("https"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("连上账户必须一并落解锁票据——不落的话「登录成功」但 launch 页会把人原地弹回解锁页")
+    void connectAlsoMarksLicenseUnlocked() {
+        java.util.concurrent.atomic.AtomicReference<String> marked = new java.util.concurrent.atomic.AtomicReference<>();
+        com.checkba.service.LicenseService license =
+                org.mockito.Mockito.mock(com.checkba.service.LicenseService.class);
+        org.mockito.Mockito.doAnswer(inv -> { marked.set(inv.getArgument(0)); return null; })
+                .when(license).markAccountUnlocked(org.mockito.ArgumentMatchers.anyString());
+
+        transport = new StubTransport().enqueue(200, "{\"username\":\"u\"}");
+        new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("https://www.aiworkdeck.com"),
+                tempDir.toString(), transport, license).connect(KEY);
+
+        assertEquals(KEY, marked.get(),
+                "解锁状态的唯一数据源是 license 票据；只写账户状态等于登录了却仍是未解锁");
     }
 
     @Test
     @DisplayName("回环 http 放行：本地起官网联调用，流量不出本机网卡")
     void loopbackHttpAllowed() {
-        assertDoesNotThrow(() -> new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("http://localhost:3000"), tempDir.toString(), new StubTransport()));
-        assertDoesNotThrow(() -> new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("http://127.0.0.1:3000"), tempDir.toString(), new StubTransport()));
+        assertDoesNotThrow(() -> new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("http://localhost:3000"), tempDir.toString(), new StubTransport(), null));
+        assertDoesNotThrow(() -> new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("http://127.0.0.1:3000"), tempDir.toString(), new StubTransport(), null));
     }
 
     @Test
     @DisplayName("尾部斜杠归一化：不能拼出 //api/account/me")
     void trailingSlashStripped() {
         transport = new StubTransport().enqueue(200, "{\"username\":\"u\"}");
-        new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("https://www.aiworkdeck.com/"), tempDir.toString(), transport).connect(KEY);
+        new AccountService(com.checkba.service.site.SiteProfileService.pinnedTo("https://www.aiworkdeck.com/"), tempDir.toString(), transport, null).connect(KEY);
         assertEquals("GET https://www.aiworkdeck.com/api/account/me", transport.calls.get(0));
     }
 }

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -122,6 +122,19 @@ class AccountServiceTest {
     }
 
     @Test
+    @DisplayName("人机验证的文案用本地双语，不用官网那句英文——否则中文界面上会冒出英文")
+    void captchaMessageIsLocalizedNotUpstreamEnglish() {
+        transport = new StubTransport().enqueue(403,
+                "{\"error\":\"captcha_failed\",\"message\":\"Verification failed, please try again\"}");
+        AccountException e = assertThrows(AccountException.class,
+                () -> service().sendLoginCode("13800138000", "bad"));
+        assertNotEquals("Verification failed, please try again", e.getMessage(),
+                "官网只有英文文案，原样透出去就是中文界面上的英文句子");
+        assertTrue(e.getMessage().contains("安全验证") || e.getMessage().contains("security"),
+                "应当是本地双语文案：" + e.getMessage());
+    }
+
+    @Test
     @DisplayName("官网拒绝人机验证时归为 CONFLICT，不是 UNAUTHORIZED——后者会让上层去清一个还不存在的连接")
     void captchaFailureIsConflictNotUnauthorized() {
         transport = new StubTransport().enqueue(403, "{\"error\":\"captcha_failed\",\"message\":\"nope\"}");

--- a/backend/src/test/java/com/checkba/service/site/SiteMismatchMessageTest.java
+++ b/backend/src/test/java/com/checkba/service/site/SiteMismatchMessageTest.java
@@ -123,7 +123,7 @@ class SiteMismatchMessageTest {
     @DisplayName("账户端点 401：多站形态下同样点名站点")
     void accountUnauthorizedNamesBothSites() {
         AccountService account = new AccountService(sites(true, CN), tempDir.toString(),
-                (method, url, bearer, body) -> new AccountTransport.Reply(401, "{}"));
+                (method, url, bearer, body) -> new AccountTransport.Reply(401, "{}"), null);
 
         String message = assertThrows(AccountException.class,
                 () -> account.connect("awdk_" + "x".repeat(43))).getMessage();
@@ -137,7 +137,7 @@ class SiteMismatchMessageTest {
     @DisplayName("账户端点 401：单站形态保持原样")
     void accountUnauthorizedSingleSite() {
         AccountService account = new AccountService(sites(false, CN), tempDir.toString(),
-                (method, url, bearer, body) -> new AccountTransport.Reply(401, "{}"));
+                (method, url, bearer, body) -> new AccountTransport.Reply(401, "{}"), null);
 
         String message = assertThrows(AccountException.class,
                 () -> account.connect("awdk_" + "x".repeat(43))).getMessage();
@@ -156,7 +156,7 @@ class SiteMismatchMessageTest {
                     seen.setLength(0);
                     seen.append(url);
                     return new AccountTransport.Reply(401, "{}");
-                });
+                }, null);
 
         assertThrows(AccountException.class, () -> account.connect("awdk_" + "x".repeat(43)));
         assertTrue(seen.toString().startsWith(CN), seen.toString());

--- a/frontend/src/pages/unlock/unlock.vue
+++ b/frontend/src/pages/unlock/unlock.vue
@@ -7,7 +7,11 @@
       <text class="unlock-subtitle">{{ $t('onboarding.unlock.subtitle') }}</text>
 
       <!-- 账户登录是新的主路径；试用码 / 手工粘 Key 保留给离线试用、团队服务器与私有部署 -->
-      <view class="unlock-tabs">
+      <!-- 官方版只有账户登录这一条路：账户 Key 已经由登录自动签发，用户看不到也不需要粘。
+           **但 trialCodeEnabled 为真时整块要留着**——那是商业版 / 私有部署 / 自行构建的
+           试用码入口（application-desktop.yml 刻意留的开关），砍掉等于把那条路堵死。
+           只剩一个页签时不渲染整条 tab 栏：一个孤零零的页签不是选择，是噪音。 -->
+      <view v-if="trialCodeEnabled" class="unlock-tabs">
         <text class="unlock-tab" :class="{ 'is-active': mode === 'login' }" @tap="switchMode('login')">
           {{ $t('onboarding.unlock.loginTab') }}
         </text>
@@ -279,6 +283,9 @@ export default {
       try {
         const s = await getLicenseStatus()
         this.trialCodeEnabled = !(s && s.trialCodeEnabled === false)
+        // 页签整条被隐藏时，mode 必须回到 login——否则残留状态会把人卡在一个
+        // 已经没有入口可切回来的表单上
+        if (!this.trialCodeEnabled) this.mode = 'login'
       } catch (e) {
         console.warn('读取解锁门配置失败（按试用码可用渲染）:', e && e.message)
       }

--- a/frontend/src/pages/unlock/unlock.vue
+++ b/frontend/src/pages/unlock/unlock.vue
@@ -76,9 +76,6 @@
           />
         </template>
 
-        <text class="unlock-link unlock-login-switch" @tap="toggleLoginKind">
-          {{ loginKind === 'code' ? $t('onboarding.unlock.usePassword') : $t('onboarding.unlock.useCode') }}
-        </text>
         <text v-if="errorMsg" class="unlock-error">{{ errorMsg }}</text>
         <button
           class="unlock-btn"
@@ -88,6 +85,9 @@
         >
           {{ loggingIn ? $t('onboarding.unlock.loggingIn') : $t('onboarding.unlock.login') }}
         </button>
+        <text class="unlock-link unlock-login-switch" @tap="toggleLoginKind">
+          {{ loginKind === 'code' ? $t('onboarding.unlock.usePassword') : $t('onboarding.unlock.useCode') }}
+        </text>
       </view>
 
       <view v-else class="unlock-form">
@@ -544,6 +544,12 @@ export default {
 <style lang="scss" scoped>
 /* 触发元素必须存在且可被 click()，所以用 0 尺寸而不是 display:none——
    display:none 的元素 SDK 挂不上事件，控件永远弹不出来。 */
+.unlock-login-switch {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 12px;
+}
+
 .unlock-captcha-trigger {
   width: 0;
   height: 0;
@@ -600,6 +606,9 @@ export default {
 }
 
 .unlock-tabs {
+  /* .unlock-card 是 align-items:center，子元素默认收缩到内容宽度——不写这行，
+     页签会被挤窄到「账户登录」四个字都放不下而换行（.unlock-form 早就写了同一行补偿）。 */
+  width: 100%;
   display: flex;
   gap: 4px;
   margin-bottom: 16px;
@@ -611,6 +620,7 @@ export default {
 .unlock-tab {
   flex: 1;
   text-align: center;
+  white-space: nowrap;
   padding: 8px 0;
   font-size: 13px;
   color: #64748b;

--- a/frontend/src/utils/captcha.js
+++ b/frontend/src/utils/captcha.js
@@ -78,6 +78,7 @@ export async function setupCaptcha(config, holderId) {
   if (!window.initAliyunCaptcha) return null
 
   let pending = null
+  let instance = null
   window.initAliyunCaptcha({
     SceneId: config.sceneId,
     mode: 'popup',
@@ -90,7 +91,10 @@ export async function setupCaptcha(config, holderId) {
       return { captchaResult: true, bizResult: true }
     },
     onBizResultCallback: () => { /* 业务结果由发码流程处理 */ },
-    getInstance: () => {},
+    // **必须存下实例**：校验参数是一次性的，下一次取之前要 refresh() 换一枚。
+    // 丢掉实例就没法刷新，第二次滑完拿到的还是上一枚已用过的参数，
+    // 服务端会判重复提交（2026-08-18 真机：第一次成功、之后每次都失败）。
+    getInstance: (i) => { instance = i },
     slideStyle: { width: 320, height: 40 },
     language: 'cn',
     onError: (e) => console.warn('[captcha] 阿里云控件初始化失败:', e),
@@ -100,6 +104,8 @@ export async function setupCaptcha(config, holderId) {
     provider: 'aliyun',
     getToken: () => new Promise((resolve) => {
       pending = resolve
+      // 一次性参数：每次取之前先刷新，否则拿到的是上一枚已核销的
+      try { if (instance && instance.refresh) instance.refresh() } catch (e) { /* 未就绪时忽略 */ }
       const trigger = document.getElementById(holderId + '-trigger')
       if (!trigger) return resolve('')
       trigger.click()


### PR DESCRIPTION
v0.19.0 真机走查发现的三个问题 + 登录页三处观感修补。

## ① 登录成功但页面不动（最严重，v0.18.0 就埋着）

真机表现：验证码通过 → 弹「已登录，正式版已解锁」→ **然后什么都没发生**。

根因：解锁状态的唯一数据源是 `LicenseService` 的**票据**（`statusOf` 读 `state.mode`），而桌面端账户登录走 `AccountService.connect()`——**它只写账户状态，从不碰票据**。于是 `status().unlocked` 仍为 false，`launch.vue:60` 把人原地 `reLaunch` 回解锁页。

老路（设置页粘 Key）走 `LicenseService.activateAccountKey` 才落票据，所以一直没暴露。**自 PR#408 引入账户登录起，桌面端账户登录从来没真正解锁过应用。**

修法：新增 `LicenseService.markAccountUnlocked(key)`——已在别处验过、只落票据，**不再打一次官网**（`connect()` 刚拉过 `/api/account/me` 验过；再验一次既多一次往返，也会让网络抖一下把一次成功的登录变成失败）。挂在 `connect()` 里而不是各调用方：账户登录与粘 Key 都经过它，挂调用方上迟早漏一条。`@Lazy` 注入避开构造循环。

## ② 滑块第一次成功、之后每次失败

阿里云的校验参数是**一次性**的，用过要 `refresh()` 换一枚。桌面端 `utils/captcha.js` 写的是 `getInstance: () => {}`——**把实例直接丢了**，根本没法刷新，第二次滑完拿到的还是上一枚已核销的参数，服务端判重复提交（线上日志 `verifyCode=F015`）。Turnstile 那支写了 `reset()`，阿里云这支漏了。

官网组件是同一个毛病（存了实例但从不 refresh），在 [website#75](https://github.com/zeweihan/aiworkdeck_website/pull/75) 一起修。

## ③ 官方版不再显示「账户 Key」页签

Key 现在由登录自动签发，用户看不到也不需要粘。**但 `trialCodeEnabled` 为真时整块保留**——那是商业版 / 私有部署 / 自行构建的试用码入口（`application-desktop.yml` 刻意留的开关），砍掉等于把那条路堵死。只剩一个页签时不渲染整条 tab 栏；隐藏时把 `mode` 钉回 `login`，免得残留状态把人卡在一个没有入口可切回来的表单上。

## ④ 登录页三处观感

- **页签换行**：`.unlock-card` 是 `align-items:center`，子元素默认收缩到内容宽度。`.unlock-form` 早就写了 `width:100%` 补偿，`.unlock-tabs` 漏了——「账户登录」四个字都放不下、折成两行。（既有问题）
- **中文界面冒英文**：官网的人机验证文案只有英文，而 `AccountLoginExchange` 的规则是「官网给了 message 就用官网的」。改成 `captcha_failed` / `too_many_requests` 用本地双语；其余仍以官网优先（它常带本地判断不出来的具体信息，不能一刀切）。
- **「用账号密码登录」挪到登录按钮下方**：原先夹在验证码输入与错误提示之间，打断视线。

## 验证

`mvn -B test` **1903 通过 / 0 失败**；`build:h5` 通过。新增用例直接断言 `connect()` 落了解锁票据——那正是这次最严重那条的回归哨兵。

🤖 Generated with [Claude Code](https://claude.com/claude-code)