### PR TITLE
chore(release): v0.19.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
补丁版（**overlay 增量包**，用户不用重下 1.4G）。

patch-gate 判据已核：自 `v0.19.0` 起**未改动** `desktop/main`、`desktop/preload`、`asr-service/requirements.lock` 三类路径，符合补丁号条件。

## 修 v0.19.0 真机走查发现的三个问题（#420）

**① 登录成功但页面不动**（最严重）

解锁状态的唯一数据源是 `LicenseService` 的**票据**，而账户登录走 `AccountService.connect()`——它只写账户状态、从不碰票据。于是 `status().unlocked` 仍为 false，`launch.vue` 把人原地弹回解锁页，表现为「弹了个已解锁的提示，然后什么都没发生」。

**自 PR#408 引入账户登录起就一直如此——桌面端账户登录从来没真正解锁过应用。**

**② 滑块第一次成功、之后每次失败**

阿里云的校验参数一次性，用过要 `refresh()`。桌面端写的是 `getInstance: () => {}`，把 SDK 实例直接丢了，第二次滑完拿到的还是上一枚已核销的参数（线上日志 `verifyCode=F015`）。

**③ 官方版去掉「账户 Key」页签**

Key 现在由登录自动签发。`trialCodeEnabled` 为真时整块保留——那是商业版 / 私有部署的试用码入口。

## 外加登录页三处观感

- 页签换行：`.unlock-tabs` 漏了 `width: 100%`（`.unlock-card` 是 `align-items:center`）
- 中文界面冒英文：人机验证文案改用本地双语，其余仍以官网 message 优先
- 「用账号密码登录」挪到登录按钮下方

## 验证

`mvn -B test` **1903 通过 / 0 失败**。新增用例直接断言 `connect()` 落了解锁票据——那是第 ① 条的回归哨兵。

🤖 Generated with [Claude Code](https://claude.com/claude-code)