### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
大版本（全量安装包）。内容：#424（平台 UI 与功能一揽子优化：外壳重构 / 诉讼可视化稳定性 / AI 面板展示 / skill 可见性 / 登录页注册与推广位）+ #425（推广位放开国际站，金额按站点分流）。

配套服务器侧已就绪：网关 ASR 凭证五件套（听悟实测通）、OCR 独立凭证、两站注册赠金（cn ¥99.99 / intl $9.90，至 2026-09-30）。

合并后打 tag v0.20.0 触发 mac+win 双平台构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)