### PR TITLE
docs(cloud): addin.aiworkdeck.com 退役 h5 客户端，根路径改跳官网

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -1,13 +1,17 @@
 # 插件云后端部署（addin.aiworkdeck.com）
 
-官方托管的后端实例：Office 插件经 awdk_ 桥接连接；同域名同时提供浏览器 Web 客户端
-（h5 + LOWA 编辑器）。部署形态与决策记录（2026-08-07，维护者拍板）：
+官方托管的后端实例：Office 插件经 awdk_ 桥接连接。**浏览器 Web 客户端（h5 + LOWA 编辑器）
+已于 2026-08-19 退役**（维护者拍板：裸露登录页令人困惑）——根路径 index.html 现在是一个
+跳转 aiworkdeck.com 的静态页（原件备份为 `index.html.h5-retired-20260819`），
+**更新部署时不要再铺 build:h5 / build:zetaoffice 产物**；`web/` 下的 assets/static/zetaoffice
+是退役残留，留在原地无害，不要顺手清理（清理与否待单独拍板）。
+部署形态与决策记录（2026-08-07，维护者拍板）：
 
 | 决策项 | 结论 |
 |---|---|
 | 机器/域名 | 北京 ECS 8.152.169.44 / addin.aiworkdeck.com（certbot 独立签，不进新加坡续期主控） |
 | 数据库 | 既有 PostgreSQL 14 新建独立库 aiworkdeck_cloud + 源码编译 pgvector |
-| 部署范围 | 后端 + h5 前端 + LOWA 编辑器；不带 Python 附属服务（pptx/mineru/kokoro 云端不可用） |
+| 部署范围 | 后端 + 插件任务窗格静态页；h5 前端与 LOWA 编辑器 2026-08-19 起不再部署；不带 Python 附属服务（pptx/mineru/kokoro 云端不可用） |
 | 进程管理 | systemd（aiworkdeck-cloud.service），专用系统账号 aiworkdeck |
 | 会话存储 | 已改 DB 落库（UserSession，7 天滑动过期），重启不掉线 |
 
@@ -24,8 +28,9 @@
   data/template.docx   <- 新建文档模板（repo docs/template.docx）
   home/                <- 服务账号 HOME（~/.aiworkdeck 状态文件落这里）
   acme/                <- certbot webroot
-  web/                 <- frontend/dist/build/h5/*
-  web/zetaoffice/      <- frontend/dist/zetaoffice/*（含 lowa/ 引擎与 CJK 字体）
+  web/                 <- index.html 为跳官网的静态重定向页（h5 已退役，见上）
+  web/office-addin/    <- Office 插件任务窗格（office-addin 构建产物，见 office-addin.md）
+  web/zetaoffice/      <- 退役残留（原 h5 的 LOWA 引擎载荷），留置不清理
 ```
 
 ## 首次部署步骤（2026-08-07 实录见 PR 描述）
@@ -33,8 +38,7 @@
 1. 本地构建（worktree 内，JDK 21）：
    ```bash
    cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -B -DskipTests package
-   cd frontend && npm run build:h5 && npm run build:zetaoffice
-   node desktop/scripts/fetch-lowa-assets.js
+   #（历史步骤，2026-08-19 起不再执行：build:h5 / build:zetaoffice / fetch-lowa-assets）
    ```
 2. 服务器准备（root）：
    - `useradd -r -m -d /opt/aiworkdeck/cloud/home aiworkdeck`
@@ -75,5 +79,6 @@
 - 日志：`journalctl -u aiworkdeck-cloud -f`
 - 更新后端：本地重新 package → scp 覆盖 backend.jar → `systemctl restart aiworkdeck-cloud`
   （会话已 DB 落库，重启不掉浏览器登录态）
-- 更新前端：重新 build:h5 / build:zetaoffice → rsync 覆盖 web/
+- 更新插件任务窗格：office-addin `npm run build:deploy -- --url https://addin.aiworkdeck.com/office-addin`
+  → 覆盖 web/office-addin/（**不要**动 web/ 根下的重定向 index.html，也不要再铺 h5）
 - DB 备份：`sudo -u postgres pg_dump aiworkdeck_cloud | gzip > /root/backup/...`（建议进 cron）


### PR DESCRIPTION
服务器侧改动已上线（仅换 web/index.html 为静态重定向页，nginx/后端/任务窗格均未动，已 curl 验收：根路径跳官网、/office-addin/taskpane.html 200、/api/ 反代正常）。本 PR 只同步 deploy/cloud/README.md 的部署口径，防止下次重铺前端把 h5 登录页带回来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)