### PR TITLE
登录换 Key 时上报设备名，官网设备列表按设备显示

### DIFF
--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -386,6 +386,7 @@ public class AccountService {
     }
 
     private Map<String, Object> exchangeAndConnect(Map<String, Object> credentials) {
+        credentials.put("deviceName", deviceName());
         Map<String, Object> payload = postLogin("/api/auth/exchange-key", credentials);
         String key = str(payload.get("key"));
         if (key == null || key.isBlank()) {
@@ -562,5 +563,20 @@ public class AccountService {
 
     private static String str(Object value) {
         return value == null ? null : String.valueOf(value);
+    }
+
+    /** 登录换 Key 时上报的设备名，官网账户页「已连接的设备」按它显示，形如「Zeweis-MacBook-Pro (Mac)」。 */
+    static String deviceName() {
+        String os = System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT);
+        String osLabel = os.contains("mac") ? "Mac" : os.contains("win") ? "Windows" : os.contains("linux") ? "Linux" : "Desktop";
+        String host = "";
+        try {
+            host = java.net.InetAddress.getLocalHost().getHostName();
+        } catch (Exception ignored) {
+        }
+        if (host == null) host = "";
+        host = host.replaceAll("\\.local$", "").trim();
+        String name = host.isEmpty() ? osLabel : host + " (" + osLabel + ")";
+        return name.length() > 64 ? name.substring(0, 64) : name;
     }
 }

--- a/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
+++ b/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
@@ -185,6 +185,9 @@ public class AwdkLoginService {
      */
     private BridgeSession exchangeAndBridge(Map<String, Object> credentials) {
         requireEnabled();
+        // 这条服务本身就是「Office 插件」的桥接口，设备名固定为插件口径（不像桌面端那样按主机名取）；
+        // 按 baseUrl 分站，因为国际站账户页文案是英文。
+        credentials.put("deviceName", baseUrl.contains("workdeck.ai") ? "Office Add-in" : "Office 插件");
         Map<String, Object> payload =
                 AccountLoginExchange.post(transport, objectMapper, baseUrl, "/api/auth/exchange-key", credentials);
         String key = str(payload.get("key"));

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -172,6 +172,27 @@ class AccountServiceTest {
     }
 
     @Test
+    @DisplayName("换 Key 请求带上设备名：官网账户页「已连接的设备」靠它显示")
+    void exchangeKeyRequestIncludesDeviceName() {
+        transport = new StubTransport()
+                .enqueue(200, "{\"key\":\"" + KEY + "\",\"isNewUser\":true}")
+                .enqueue(200, ME);
+        service().loginWithPhone("13800138000", "123456");
+        assertTrue(transport.bodies.get(0).contains("\"deviceName\""), transport.bodies.get(0));
+    }
+
+    @Test
+    @DisplayName("deviceName()：非空、不超 64 字符、带 os 标签")
+    void deviceNameIsWellFormed() {
+        String name = AccountService.deviceName();
+        assertNotNull(name);
+        assertFalse(name.isBlank());
+        assertTrue(name.length() <= 64, name);
+        assertTrue(name.contains("Mac") || name.contains("Windows") || name.contains("Linux") || name.contains("Desktop"),
+                name);
+    }
+
+    @Test
     @DisplayName("口令登录：国际站主路径，同样换 Key 并连接")
     void passwordLoginExchangesKey() {
         transport = new StubTransport()

--- a/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
@@ -322,6 +322,16 @@ class AwdkLoginServiceTest {
     }
 
     @Test
+    @DisplayName("换 Key 请求带上设备名，固定为「Office 插件」（默认站点 aiworkdeck.com）")
+    void exchangeKeyRequestIncludesFixedDeviceName() {
+        transport.enqueue(200, "{\"key\":\"" + KEY + "\",\"isNewUser\":true}").enqueue(200, ME_OK);
+
+        service(true).loginWithPhone("13800138000", "123456");
+
+        assertTrue(transport.bodies.get(0).contains("\"deviceName\":\"Office 插件\""), transport.bodies.get(0));
+    }
+
+    @Test
     @DisplayName("口令登录：国际站主路径，凭据形状不同但桥接结果一样")
     void passwordLoginExchangesKeyThenBridges() {
         transport.enqueue(200, "{\"key\":\"" + KEY + "\"}").enqueue(200, ME_OK);


### PR DESCRIPTION
官网账户页「已连接的设备」此前只能显示 Key 前缀，对用户没有信息量。本 PR 让桌面端/插件云后端在 `/api/auth/exchange-key` 换 Key 时随凭据带上 `deviceName`：

- `AccountService.exchangeAndConnect`：三条登录路（手机验证码/邮箱验证码/口令）的唯一汇聚点，上报「主机名 (Mac/Windows/Linux)」，截 64 字符
- `AwdkLoginService.exchangeAndBridge`：Office 插件桥接口，固定「Office 插件」（intl baseUrl 为「Office Add-in」）
- 官网侧接收与展示已随官网 PR#77 上线（`api_keys.label`，存量显示「未命名设备」）；字段可选，旧客户端不带时行为完全不变

测试：AccountServiceTest 37 通过（新增出站 body 断言与 deviceName() 形状断言）、AwdkLoginServiceTest 21 通过（新增固定设备名断言）。

注意：本 PR 只合并进 master，不发版——设备名随下次统一发版生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)