### PR TITLE
feat(auth): 登录会话空闲有效期可配，桌面/团队默认改为一年常驻

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -126,8 +126,12 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `backend/src/main/java/com/checkba/service/account/MachineAccountGuard.java` — server 模式下 `AccountController` 全部端点与 `GET /api/entitlements` 仅 admin 可用（账户连接/权益缓存是机器级状态，普通租户 disconnect 一下全服平台 AI 通道就断）；local-mode 恒放行一字不动。
 - `model/entity/AccountBinding.java` + `repository/AccountBindingRepository.java` — 官网账户 → server 用户映射表；awdk_ 明文**不落库**（每次桥接重验官网）。
 - `service/UserSessionService.java` + `model/entity/UserSession.java` — 浏览器登录会话 DB 落库（2026-08-07，
-  替代 AuthController 进程内 SESSION_STORE）：哈希落库、7 天滑动过期、lastUsedAt 写回节流（1 分钟）、
+  替代 AuthController 进程内 SESSION_STORE）：哈希落库、滑动过期、lastUsedAt 写回节流（1 分钟）、
   每日定时清理；重启不掉线。awdt_ 设备令牌与 local-mode 免登不走这条路，行为一字未变。
+  滑动过期天数自 2026-08-19 起可配（`security.session-idle-days`）：**代码默认 365 天**（「常驻」语义——
+  短信/邮箱验证码登录每条有真实成本，7 天一断线逼用户反复走验证码），
+  **官方云后端在 `application-cloud.yml` 显式配 7**，已上线的「7 天滑动过期」契约逐字不变；
+  改默认值或动 cloud 配置前先看 `UserSessionServiceTest.cloudProfilePinsSevenDays`。
 
 **per-user 平台 AI key（2026-08-07，多租户计费隔离）**
 - 设计文档 `docs/superpowers/specs/2026-08-07-per-user-platform-ai-key.md`（含三方案的安全边界比较与已确认决策）。

--- a/backend/src/main/java/com/checkba/service/UserSessionService.java
+++ b/backend/src/main/java/com/checkba/service/UserSessionService.java
@@ -5,6 +5,7 @@ import com.checkba.model.entity.UserSession;
 import com.checkba.repository.UserSessionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -28,8 +29,15 @@ public class UserSessionService {
 
     public static final String SESSION_PREFIX = "session_";
 
-    /** 滑动过期：距最后一次使用超过该时长即失效。 */
-    static final Duration IDLE_TTL = Duration.ofDays(7);
+    /**
+     * 滑动过期天数的代码默认值：一年，即「常驻」语义（桌面端与团队服务器用）。
+     * 官方云后端 addin.aiworkdeck.com 的「7 天滑动过期」是已上线契约，
+     * 由 application-cloud.yml 显式配 security.session-idle-days: 7 钉住，绝不跟默认值漂移。
+     */
+    static final long DEFAULT_IDLE_DAYS = 365;
+
+    /** 滑动过期：距最后一次使用超过该时长即失效。天数来自 security.session-idle-days。 */
+    private final Duration idleTtl;
 
     /** lastUsedAt 写回节流：一分钟内的重复请求不再落盘（每请求一写没有意义）。 */
     static final Duration TOUCH_INTERVAL = Duration.ofMinutes(1);
@@ -43,8 +51,10 @@ public class UserSessionService {
 
     private final UserSessionRepository repository;
 
-    public UserSessionService(UserSessionRepository repository) {
+    public UserSessionService(UserSessionRepository repository,
+                              @Value("${security.session-idle-days:365}") long sessionIdleDays) {
         this.repository = repository;
+        this.idleTtl = Duration.ofDays(sessionIdleDays);
         AuthController.registerUserSessionService(this);
     }
 
@@ -70,7 +80,7 @@ public class UserSessionService {
         return repository.findByTokenHash(sha256(plaintext))
                 .map(s -> {
                     LocalDateTime now = LocalDateTime.now();
-                    if (s.getLastUsedAt().plus(IDLE_TTL).isBefore(now)) {
+                    if (s.getLastUsedAt().plus(idleTtl).isBefore(now)) {
                         repository.delete(s);
                         return null;
                     }
@@ -92,7 +102,7 @@ public class UserSessionService {
     /** 每日清理过期会话（滑动过期在读路径已兜住，这里只是让表不积灰）。 */
     @Scheduled(fixedDelay = 24 * 60 * 60 * 1000, initialDelay = 10 * 60 * 1000)
     public void purgeExpired() {
-        long removed = repository.deleteByLastUsedAtBefore(LocalDateTime.now().minus(IDLE_TTL));
+        long removed = repository.deleteByLastUsedAtBefore(LocalDateTime.now().minus(idleTtl));
         if (removed > 0) {
             log.info("清理过期登录会话 {} 条", removed);
         }

--- a/backend/src/main/resources/application-cloud.yml
+++ b/backend/src/main/resources/application-cloud.yml
@@ -34,6 +34,9 @@ spring:
 security:
   # server 模式（多租户）：local-mode 的免登/回环闸整套不生效
   local-mode: false
+  # 浏览器登录会话滑动过期保持 7 天（已上线契约，见 deploy/cloud/README.md）。
+  # 代码默认值已改为 365（桌面「常驻」语义），这里显式钉住 7，绝不跟默认值漂移。
+  session-idle-days: 7
   # 公网生产姿态：关闭自助注册，账号只经 awdk_ 桥接建立
   registration-mode: closed
   # 官网账户 Key（awdk_）一键桥接开关——插件云后端的核心登录方式

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -448,6 +448,12 @@ storage:
     cdn-domain:
 
 security:
+  # 登录会话空闲有效期（天，滑动过期：距最后一次使用超过该天数即失效）。
+  # 代码默认 365 = 「常驻」语义（滑动窗口一年，等效不掉线），给桌面端与团队服务器用——
+  # 短信/邮箱验证码登录每次都有真实成本，7 天一断线会逼用户反复走验证码。
+  # 官方云后端（application-cloud.yml）显式配 7，保持已上线的「7 天滑动过期」契约逐字不变。
+  # local-mode 免登与 awdt_ 设备令牌不走登录会话，不受本项影响。
+  session-idle-days: 365
   # conversationId 服务端签发强制开关（公网多租户/官方云置 true）：
   # 开启后（且非 local-mode），尚无消息的会话必须先经 POST /api/agent/conversations 签发，
   # 客户端自造的 conv-<毫秒> ID 会被拒绝；已有消息的会话仍按 DB 归属判定。

--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -30,7 +30,7 @@ class AuthControllerHardeningTest {
     /** DB 会话服务（repository 打桩）：注册/登录成功路径要经它签发 sessionId。 */
     private static com.checkba.service.UserSessionService sessions() {
         return new com.checkba.service.UserSessionService(
-                mock(com.checkba.repository.UserSessionRepository.class));
+                mock(com.checkba.repository.UserSessionRepository.class), 365);
     }
 
     private static MockHttpServletRequest http() {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
@@ -49,7 +49,7 @@ class AuthControllerLocalDeviceTokenTest {
                                              boolean localMode) {
         // 会话服务（repository 打桩）：本端点走 local-mode 身份解析不碰它，构造器补位而已
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
-                org.mockito.Mockito.mock(com.checkba.repository.UserSessionRepository.class));
+                org.mockito.Mockito.mock(com.checkba.repository.UserSessionRepository.class), 365);
         return new AuthController(userService, null, null, deviceTokenService,
                 null, null, null, null, null, sessions, localMode, null);
     }

--- a/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
@@ -41,7 +41,7 @@ class AuthControllerMailTest {
     }
 
     private static UserSessionService sessions() {
-        return new UserSessionService(mock(UserSessionRepository.class));
+        return new UserSessionService(mock(UserSessionRepository.class), 365);
     }
 
     private static AuthController controller(UserService userService, AuthAbuseGuard guard,

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSessionIdTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSessionIdTest.java
@@ -22,7 +22,7 @@ class AuthControllerSessionIdTest {
 
     @Test
     void sessionIdIsUnpredictable() {
-        UserSessionService service = new UserSessionService(mock(UserSessionRepository.class));
+        UserSessionService service = new UserSessionService(mock(UserSessionRepository.class), 365);
 
         long before = System.currentTimeMillis();
         Set<String> seen = new HashSet<>();

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
@@ -57,7 +57,7 @@ class AuthControllerSmsTest {
                 smsAuthService, mock(UserRepository.class));
         // DB 会话服务（repository 打桩）：登录成功路径要经它签发 sessionId
         com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
-                mock(com.checkba.repository.UserSessionRepository.class));
+                mock(com.checkba.repository.UserSessionRepository.class), 365);
         return new AuthController(userService, null, null, null, guard, null, smsAuthService,
                 mock(com.checkba.service.mail.MailAuthService.class), secondFactor, sessions, false, null);
     }

--- a/backend/src/test/java/com/checkba/service/UserSessionServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/UserSessionServiceTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.*;
 /**
  * DB 落库会话的服务层语义：哈希落库（明文不进库）、滑动过期、lastUsedAt 写回节流、
  * 登出删行。AuthController 的接线由 AuthControllerHardeningTest/SmsTest 顺带覆盖。
+ * 滑动过期天数自 security.session-idle-days 可配：代码默认 365（桌面「常驻」），
+ * 云端 application-cloud.yml 显式配 7 保持已上线契约。
  */
 class UserSessionServiceTest {
 
@@ -34,7 +36,7 @@ class UserSessionServiceTest {
     @DisplayName("签发：库里存的是 64 位十六进制哈希，不是明文")
     void issueStoresHashNotPlaintext() {
         UserSessionRepository repo = mock(UserSessionRepository.class);
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, UserSessionService.DEFAULT_IDLE_DAYS);
 
         String plaintext = service.issue(7L);
 
@@ -54,18 +56,18 @@ class UserSessionServiceTest {
         UserSessionRepository repo = mock(UserSessionRepository.class);
         when(repo.findByTokenHash(anyString()))
                 .thenReturn(Optional.of(row(7L, LocalDateTime.now())));
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, UserSessionService.DEFAULT_IDLE_DAYS);
 
         assertEquals(7L, service.resolveUserId("session_abc"));
     }
 
     @Test
-    @DisplayName("滑动过期：超过 7 天未使用的会话解析为 null 并被删除")
+    @DisplayName("滑动过期：按配置天数（云端配 7）闲置超过 7 天的会话解析为 null 并被删除")
     void expiredSessionIsDeleted() {
         UserSessionRepository repo = mock(UserSessionRepository.class);
         UserSession stale = row(7L, LocalDateTime.now().minusDays(8));
         when(repo.findByTokenHash(anyString())).thenReturn(Optional.of(stale));
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, 7);
 
         assertNull(service.resolveUserId("session_abc"));
         verify(repo).delete(stale);
@@ -73,10 +75,52 @@ class UserSessionServiceTest {
     }
 
     @Test
+    @DisplayName("桌面默认 365 天：闲置 8 天照常有效（常驻语义），闲置超过一年才过期")
+    void desktopDefaultKeepsSessionForAYear() {
+        UserSessionRepository repo = mock(UserSessionRepository.class);
+        UserSessionService service = new UserSessionService(repo, UserSessionService.DEFAULT_IDLE_DAYS);
+
+        // 云端契约下必掉线的「闲置 8 天」，在默认 365 天下必须仍然有效
+        when(repo.findByTokenHash(anyString()))
+                .thenReturn(Optional.of(row(7L, LocalDateTime.now().minusDays(8))));
+        assertEquals(7L, service.resolveUserId("session_abc"));
+        verify(repo, never()).delete(any(UserSession.class));
+
+        // 超过一年才失效（常驻不等于永久：被盗凭据仍有终点）
+        UserSession ancient = row(7L, LocalDateTime.now().minusDays(366));
+        when(repo.findByTokenHash(anyString())).thenReturn(Optional.of(ancient));
+        assertNull(service.resolveUserId("session_abc"));
+        verify(repo).delete(ancient);
+    }
+
+    @Test
+    @DisplayName("代码默认值钉在 365：@Value 注解默认值与 DEFAULT_IDLE_DAYS 一致")
+    void codeDefaultIsPinnedTo365() throws Exception {
+        assertEquals(365, UserSessionService.DEFAULT_IDLE_DAYS);
+        var ctor = UserSessionService.class.getConstructor(
+                com.checkba.repository.UserSessionRepository.class, long.class);
+        var value = ctor.getParameters()[1]
+                .getAnnotation(org.springframework.beans.factory.annotation.Value.class);
+        assertNotNull(value, "空闲天数参数必须带 @Value，否则配置接不进来");
+        assertEquals("${security.session-idle-days:365}", value.value());
+    }
+
+    @Test
+    @DisplayName("云端契约：application-cloud.yml 显式钉住 session-idle-days: 7，不跟默认值漂移")
+    void cloudProfilePinsSevenDays() throws Exception {
+        try (var in = UserSessionServiceTest.class.getResourceAsStream("/application-cloud.yml")) {
+            assertNotNull(in, "application-cloud.yml 必须在 classpath 上");
+            String yml = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            assertTrue(yml.contains("session-idle-days: 7"),
+                    "云端「7 天滑动过期」是已上线契约：默认值改成 365 后必须在 cloud profile 显式配 7");
+        }
+    }
+
+    @Test
     @DisplayName("lastUsedAt 节流：一分钟内的重复请求不写库，超过则写回")
     void touchIsThrottled() {
         UserSessionRepository repo = mock(UserSessionRepository.class);
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, UserSessionService.DEFAULT_IDLE_DAYS);
 
         when(repo.findByTokenHash(anyString()))
                 .thenReturn(Optional.of(row(7L, LocalDateTime.now().minusSeconds(10))));
@@ -93,7 +137,7 @@ class UserSessionServiceTest {
     @DisplayName("非 session_ 前缀（如 awdt_ 设备令牌）不触库直接返回 null")
     void foreignPrefixShortCircuits() {
         UserSessionRepository repo = mock(UserSessionRepository.class);
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, UserSessionService.DEFAULT_IDLE_DAYS);
 
         assertNull(service.resolveUserId("awdt_xyz"));
         assertNull(service.resolveUserId(null));
@@ -104,7 +148,7 @@ class UserSessionServiceTest {
     @DisplayName("登出：按哈希删行；未知 ID 静默")
     void revokeDeletesRow() {
         UserSessionRepository repo = mock(UserSessionRepository.class);
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, UserSessionService.DEFAULT_IDLE_DAYS);
 
         service.revoke("session_abc");
         verify(repo).deleteByTokenHash(anyString());
@@ -115,11 +159,11 @@ class UserSessionServiceTest {
     }
 
     @Test
-    @DisplayName("定时清理：按 lastUsedAt 截止时间批量删除")
+    @DisplayName("定时清理：按配置的空闲天数推截止时间批量删除")
     void purgeDeletesByCutoff() {
         UserSessionRepository repo = mock(UserSessionRepository.class);
         when(repo.deleteByLastUsedAtBefore(any())).thenReturn(3L);
-        UserSessionService service = new UserSessionService(repo);
+        UserSessionService service = new UserSessionService(repo, 7);
 
         service.purgeExpired();
 


### PR DESCRIPTION
## 背景

短信/邮箱验证码登录每次都有真实成本（dysmsapi 按条计费），而登录会话写死 7 天滑动过期，超过 7 天不用就被迫重走验证码。维护者结论：桌面端不加「记住我」选框，会话直接做成长效常驻。

## 真实根因查证（前端 sessionId 持久化情况）

按任务要求先查了「频繁要验证码」是不是前端把会话弄丢了，结论是**前端持久化没有问题，根因就是 7 天滑动 TTL 本身**：

- sessionId/user 经 `frontend/src/utils/auth.js` 的 `uni.setStorageSync` 落盘（H5 是 localStorage；桌面打包态 Electron `loadFile` 的 file:// origin，localStorage 落在 userData，重启不丢）。
- 清除只有两个入口：后端回 code=4010（api.js 统一处理）与显式退出（signOut.js / clearSession），没有启动期清库、没有 `clearStorageData` 之类的路径。
- 另查明：桌面端 local-mode 下 API 鉴权根本不走 `UserSessionService`（免登恒解析为本机用户），桌面的账户登录是解锁门的机器级状态（account.json/license.json，持久 + 30 天离线宽限）。所以 7 天滑动 TTL 真正打到的是**浏览器形态的登录会话**（团队服务器、云后端 h5 直访）——间歇使用超过 7 天就掉线重走验证码。本次前端零改动。

## 改动

- `UserSessionService`：写死的 `IDLE_TTL = 7 天` 抽成构造器注入 `security.session-idle-days`，**代码默认 365 天**（滑动窗口一年，等效常驻；常驻不等于永久，被盗凭据仍有终点）。读路径过期判定与每日清理 job（`deleteByLastUsedAtBefore`）用同一份配置。
- `application.yml`：显式写 `session-idle-days: 365` 并注释语义。
- `application-cloud.yml`：**显式钉住 7**，addin.aiworkdeck.com 已上线的「7 天滑动过期」契约逐字不变。
- 单测（`UserSessionServiceTest`）：新增「默认 365 常驻语义（闲置 8 天仍有效 / 超一年过期）」「@Value 注解默认值钉 365」「cloud profile 必须显式配 7」三条；存量 7 天过期与清理用例改为显式传 7。五个构造 `UserSessionService` 的既有测试补第二个参数。
- 领域文档 `.claude/agents/licensing-billing.md` 同步会话有效期段落。

## 红线自查

- 无新增 code=4010 路径（只动 TTL 数值来源，错误信封一字未改）。
- `/awdk-login` 桥、awdt_ 设备令牌（本就无 TTL）、registration-mode、手机号强制闸（PhoneLoginGuard）均未触碰。

## 测试

- `mvn test` 全量：Tests run: 1930, Failures: 0, Errors: 0（JDK 21）。
- 前端零改动，无需前端门禁。

🤖 Generated with [Claude Code](https://claude.com/claude-code)