### PR TITLE
feat(pack): 原生资源包分发——第四种分发形态（Phase A 机制层）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -76,6 +76,12 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   `bash deploy/update-mirror-sync_prune_test.sh`（纯本地，不碰网络与真镜像目录）。
   **服务器上跑的是一份副本**（`/www/wwwroot/update/desktop/update-mirror-sync.sh`，cron 每小时 :17），
   合并 PR 不会让它生效，要 scp 覆盖过去。
+- `deploy/publish-pack.sh` — 原生资源包（native pack）上架：check 本地验产物 /
+  sign 在官网机上用 env 私钥签 manifest（私钥不落本机）/ publish 双机上架
+  `/www/wwwroot/plugin-packs/` 暂存校验后换入、双机验证后才切 manifest 指针 /
+  verify 两站对账。产物来自 workflow `pack-release.yml`（workflow_dispatch，
+  tag `pack-<id>-v<ver>`，win 侧 graphviz 只能在 win runner 出）。规范
+  `docs/NATIVE_PACK_DISTRIBUTION.md`。
 - **`deploy/publish-lowa-engine.sh` — 换 LOWA 引擎必须走它，别手工传**（issue #310）。
   `check-build <目录>` 只在本地验产物；`publish <目录> <版本号>` 发到两台机；`verify <版本号>` 切指针前必跑。
   它把三件必须同时做对的事绑在一起：按形态判定该压不该压、**两台机都同步**（新加坡是本地镜像直出、

--- a/.claude/agents/litigation-visual.md
+++ b/.claude/agents/litigation-visual.md
@@ -64,11 +64,22 @@ JSON 对不对，不取决于模型对像素多聪明——这是上游的核心
 - `pages/project-overview/project-overview.vue` — 面板分支 + 三个 handler
   （`handleLitigationStart` / `handleLitigationOpenFile` / `handleLitigationScopeSelect`）。
 
-**打包**
-- `desktop/scripts/prepare-graphviz.js` — 烙最小 graphviz（约 4MB）。
-- `desktop/package.json` extraResources — `graphviz` / `skills` / `litviz` 三项。
-- `desktop/main/services/backend-service.js` — 打包态注入 `LITVIZ_DIR` /
-  `AWD_PYTHON_HOME` / `LITVIZ_GRAPHVIZ_DIR` / `AI_SKILLS_BUILTIN_DIR`。
+**打包与分发（2026-08 起转原生资源包，规范 docs/NATIVE_PACK_DISTRIBUTION.md）**
+- litviz / graphviz / drawio 三类重资源改走 native pack 运行时下载
+  （`~/.aiworkdeck/packs/litigation-visual/`），skill.yml 声明
+  `requires_pack: litigation-visual`。资源解析优先级：显式 env/config →
+  随包内置（若在场）→ dev 目录爬升 → pack current 目录；老版本随包资源优先，
+  不强迫重下。extraResources 摘除在 pack 上架双镜像验证后单独出 PR（随 v0.21.0）。
+- `desktop/scripts/prepare-graphviz.js` — 烙最小 graphviz（约 4MB）；现服务于
+  pack 构建（`desktop/scripts/build-pack.js`，workflow `pack-release.yml`）。
+- `desktop/package.json` extraResources — 摘除前仍含 `graphviz` / `skills` /
+  `litviz` 三项（`skills` 永久保留，文本很小）。
+- `desktop/main/services/backend-service.js` — 打包态注入 `LITVIZ_DIR`（有
+  existsSync 守卫，目录不在不注入）/ `AWD_PYTHON_HOME` / `LITVIZ_GRAPHVIZ_DIR` /
+  `AI_SKILLS_BUILTIN_DIR`。python 运行时不进 pack（pysvc 还要用，永远随包）。
+- `desktop/main/drawio-server.js` — 多根查找：env 覆盖 → 内置 Resources →
+  pack current（读 current.json，revoked / 无 .pack-complete 不参与），
+  装完即生效不重启。
 
 ## 核心契约
 

--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -49,6 +49,16 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
   `lib/plugin-signing.ts`（签名）、`lib/plugin-scan.ts`（常量池扫描 + permissions 交叉验证）、
   `app/[lang]/plugins/submit`（提交页）、`app/[lang]/admin/PluginReview.tsx`（审核台）。
 
+## 原生资源包（native pack）分发（2026-08）
+
+**规范：`docs/NATIVE_PACK_DISTRIBUTION.md`（第四种分发形态的权威定义）。**
+
+- 后端 `service/pack/NativePackService` + `controller/PackController`（/api/packs：list、{id}/status、{id}/info、{id}/install、{id}/uninstall）。签名沿用插件 registry 密钥对（`ai.plugins.registry-public-key`，未配置即拒装），但盖在 manifest **原始字节**上（旁挂 .sig），不走 canonical JSON。
+- 下载**不经官网应用层**：镜像静态直出 `https://{www.aiworkdeck.com|workdeck.ai}/plugin-packs/<id>/…`（`ai.packs.base-urls`），断点续传（.part + Range）+ 压缩包哈希 + 包内 `contents.sha256` 逐文件复核 + 原子指针切换。
+- 前端：MarketSidebarPanel / MarketDetailPane 对 `packId` 非空且 `packReady:false` 的面板 skill 显示「需下载资源包」与字节级进度；LitigationVisualPanel 顶部有下载状态条。
+- 三方 pack 提交/审核/签名在官网仓（`lib/packs-store.ts`、admin PackReview、`GET /api/registry/packs/revoked`），发布件出到 outbox 后由服务器侧脚本上架静态目录，新加坡镜像 SG 侧拉取。
+- pack 发布链：`.github/workflows/pack-release.yml`（tag `pack-<id>-v<ver>`）出未签名产物，`deploy/publish-pack.sh` 负责服务器侧签名（私钥不离开官网机）、双机上架与指针切换。
+
 ## 官网 registry 契约
 
 - **列表**：`GET {registryUrl}` → skill 元数据 JSON 数组，字段对应 MarketSkillView：id/name/description/icon/version/author/authorDisplayName/triggers[]/allowedTools[]/downloads/updatedAt/homepage/**priceCents/pricingModel**（`installed`、`purchased` 由本地判定）。

--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -7,13 +7,14 @@ description: 插件系统领域（具体插件实现）。任务涉及尽调/脱
 
 职责边界：各具体业务插件与插件/skill 运行机制。不含插件市场页与 registry 同步（plugin-marketplace 领域），不含左栏 UI 本身（sidebar-shell 领域）。
 
-## 三类插件形态
+## 四类插件形态
 
 1. **内置面板型**：前端组件直接内嵌 project-overview.vue 面板区，无启停开关，靠 `leftSidebarPlugins.js` 静态配置 + 角色过滤（`getPluginsForUser`，CLIENT 角色只见 dd-files）。
 2. **Skill 型**：后端 prompt 包（skill.yml + prompt.md），对话关键词触发。
 3. **动态 JAR 插件**：plugins/ 目录下 manifest.json + JAR，前端用 PluginPane iframe 承载。
+4. **原生资源包（native pack，2026-08 立项）**：重资源（脚本运行时/平台二进制/静态资产）的运行时下载分发，规范 `docs/NATIVE_PACK_DISTRIBUTION.md`。后端 `service/pack/NativePackService` + `/api/packs`；skill.yml 用 `requires_pack: <packId>` 声明依赖；落盘 `~/.aiworkdeck/packs/<id>/<version>/` + `current.json` 原子指针。首个对象是诉讼可视化（litviz+graphviz+drawio）。
 
-**「面板型插件在广场里启停」是体验对齐，不是真下载分发（2026-08-19）**：诉讼可视化、会议录音、脱敏这几个挂在左栏的面板，字节早已随安装包分发在本地（`backend/skills/<id>/`），广场里点「安装」实际做的是 `POST /api/skills/{id}/enable` 翻转 `SkillRegistry` 的启用位，立即可用，不联网、不下载任何东西。这是为了让用户心智上体验到「广场装插件」的交互一致性。**真正意义上的运行时下载分发**（不随安装包走、按需从网络拉取原生资源/可执行内容的插件形态）是独立的后续立项，目前只有「动态 JAR 插件」那条链路（见下文与 `docs/PLUGIN_DISTRIBUTION.md`）沾边，且仍要求人工审核 + 签名 + 装后默认禁用，二者不要混为一谈。
+**「面板型插件在广场里启停」的体验对齐（2026-08-19，PR#433）与真下载分发的关系**：诉讼可视化、会议录音、脱敏这几个左栏面板靠 `enabled_by_default:false` + `requiresSkill` 门控在广场呈现「安装/卸载」。资源随包在场时，「安装」仍只是 `POST /api/skills/{id}/enable` 翻启用位（不联网）；skill 声明了 `requires_pack` 且资源不在场（新版本已从安装包摘除、或老用户升级后资源随 .app 替换消失）时，「安装」会先走 `/api/packs/{id}/install` 下载资源包（字节级进度）再启用，后端启动时对「已启用但资源缺失」的 skill 自动补下载。随包资源优先于 pack（老用户不强迫重下）。
 
 ## 现有插件清单
 

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -1,0 +1,156 @@
+name: Pack Release
+
+# 构建「诉讼可视化」native pack（docs/NATIVE_PACK_DISTRIBUTION.md）并发布到
+# GitHub Release，供 deploy/publish-pack.sh 拉取、签名、推两台镜像。
+#
+# 与 desktop-build.yml 的 tag v* 触发**互不相干**（tag 前缀不同：pack-litigation-visual-v*
+# vs v*），不会互相触发对方的 workflow。
+#
+# 只手动触发（workflow_dispatch）：native pack 不随每次代码改动重发，只在
+# litviz/drawio/graphviz 三者之一真的需要出新版本时才手动跑一次。
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'pack 版本号（语义化版本，如 1.0.0；与应用版本号 desktop/package.json 无关）'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  PACK_ID: litigation-visual
+
+jobs:
+  # mac：litviz / drawio 是平台无关组件，随便挑一台机器产就行，图省事和
+  # desktop-build.yml 一样放在 macOS runner；graphviz(mac) 也在这台机产。
+  mac:
+    name: Build pack components (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Bake draw.io editor (offline, 裁剪版)
+        run: |
+          # 只需要这一步产出 frontend/dist/drawio 供 build-pack.js 打包；
+          # 不需要 build:h5 / build:zetaoffice——pack 不含前端应用本身。
+          node desktop/scripts/fetch-drawio-assets.js
+          ls -la frontend/dist/drawio/index.html frontend/dist/drawio/js/app.min.js
+      - name: Install graphviz (brew) and prepare mac-arm64 bundle
+        run: |
+          # 同 desktop-build.yml「Bundle graphviz (macOS arm64)」那一步：只要布局引擎，
+          # 不带任何渲染后端，闭包约 4 MB。不传 --from，脚本从 PATH 上找 dot 反推安装根。
+          brew install graphviz
+          node desktop/scripts/prepare-graphviz.js --out desktop/bundled/mac-arm64
+      - name: Build pack (litviz + drawio + graphviz-mac)
+        run: |
+          node desktop/scripts/build-pack.js \
+            --id "$PACK_ID" \
+            --version "${{ inputs.version }}" \
+            --out pack-out/mac \
+            --components litviz,drawio,graphviz
+          ls -la pack-out/mac
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pack-mac
+          path: pack-out/mac/*
+          if-no-files-found: error
+
+  # win：graphviz 的 Windows 闭包（19.7 MB，DLL 依赖算不出来）只能在 win 上出，
+  # 见 .claude/agents/litigation-visual.md「已知地雷」。这台机只产这一个组件。
+  win:
+    name: Build pack components (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install graphviz (choco) and prepare win-x64 bundle
+        shell: bash
+        run: |
+          # choco 社区源限流严重，带退避重试（同 desktop-build.yml 那一步）。
+          for attempt in 1 2 3 4 5; do
+            choco install graphviz --no-progress -y && break
+            [ "$attempt" = "5" ] && { echo "choco 重试耗尽"; exit 1; }
+            echo "choco install 第 $attempt 次失败（多半是社区源 503），$((attempt * 30))s 后重试"
+            sleep $((attempt * 30))
+          done
+          # choco 装完不刷新当前 shell 的 PATH；不写 git-bash 风格路径
+          # （Node 在 Windows 上不认，会解析成 C:\c\Program Files\...）。
+          export PATH="/c/Program Files/Graphviz/bin:$PATH"
+          node desktop/scripts/prepare-graphviz.js --out desktop/bundled/win-x64
+      - name: Build pack (graphviz-win only)
+        shell: bash
+        run: |
+          node desktop/scripts/build-pack.js \
+            --id "$PACK_ID" \
+            --version "${{ inputs.version }}" \
+            --out pack-out/win \
+            --components graphviz
+          ls -la pack-out/win
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pack-win
+          path: pack-out/win/*
+          if-no-files-found: error
+
+  # 汇总：合并 mac 与 win 两份半成品 manifest 成一份全量 manifest，连同全部产物
+  # 一起挂上 GitHub Release。manifest 在这里**不签名**——私钥只存在于官网服务器，
+  # 从不进 CI；签名在发布脚本 deploy/publish-pack.sh 的 sign 子命令里，在服务器
+  # 侧用 AWD_PLUGIN_SIGNING_KEY 完成。
+  release:
+    name: Merge manifest and publish GitHub Release
+    needs: [mac, win]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/download-artifact@v4
+        with:
+          name: pack-mac
+          path: pack-in/mac
+      - uses: actions/download-artifact@v4
+        with:
+          name: pack-win
+          path: pack-in/win
+      - name: Merge manifest + collect archives
+        run: |
+          mkdir -p pack-out/final
+          node desktop/scripts/build-pack.js \
+            --id "$PACK_ID" \
+            --version "${{ inputs.version }}" \
+            --out pack-out/final \
+            --merge pack-in/mac/manifest.json,pack-in/win/manifest.json
+          # 合并只产出 manifest.json；实际压缩包分散在 mac/win 两份产物里，
+          # 一并收进最终发布目录（manifest.json.sig 有意不在这里生成，见上方注释）。
+          cp pack-in/mac/*.tar.gz pack-out/final/
+          cp pack-in/win/*.tar.gz pack-out/final/
+          echo "=== 最终产物 ==="
+          ls -la pack-out/final
+          echo "=== manifest.json ==="
+          cat pack-out/final/manifest.json
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: pack-${{ env.PACK_ID }}-v${{ inputs.version }}
+          name: 'native pack: ${{ env.PACK_ID }} v${{ inputs.version }}'
+          # 与应用的 v* tag 井水不犯河水（前缀不同），不会触发 desktop-build.yml。
+          body: |
+            native pack `${{ env.PACK_ID }}` v${{ inputs.version }}（未签名产物）。
+
+            发布到镜像前必须先跑：
+            ```
+            bash deploy/publish-pack.sh check   <本地下载目录>
+            bash deploy/publish-pack.sh sign    <本地下载目录>
+            bash deploy/publish-pack.sh publish <本地下载目录> ${{ env.PACK_ID }} ${{ inputs.version }}
+            ```
+          files: |
+            pack-out/final/*.tar.gz
+            pack-out/final/manifest.json
+          generate_release_notes: false

--- a/backend/skills/litigation-visual/skill.yml
+++ b/backend/skills/litigation-visual/skill.yml
@@ -22,6 +22,10 @@ credits:
 # 用户在插件广场手动启用（= 安装），停用（= 卸载）不影响随包文件，见 SkillRegistry/SkillMarketService。
 enabled_by_default: false
 
+# 依赖的原生资源包（litviz 引擎 + graphviz + draw.io 静态资源，规范见
+# docs/NATIVE_PACK_DISTRIBUTION.md）。随包内置资源还在的老版本不会触发下载。
+requires_pack: litigation-visual
+
 # 法律事项类别（匿名统计用，枚举见 MatterCategory）
 category: 争议解决
 

--- a/backend/src/main/java/com/checkba/controller/PackController.java
+++ b/backend/src/main/java/com/checkba/controller/PackController.java
@@ -1,0 +1,180 @@
+package com.checkba.controller;
+
+import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
+import com.checkba.service.LangText;
+import com.checkba.service.ai.skill.SkillDefinition;
+import com.checkba.service.ai.skill.SkillRegistry;
+import com.checkba.service.pack.NativePackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * 原生资源包接口（规范见 docs/NATIVE_PACK_DISTRIBUTION.md §4.3）：
+ * - GET  /list              已知 pack 的状态（登录）
+ * - GET  /{id}/status       单个 pack 的状态（登录）
+ * - GET  /{id}/info         最新版本与本平台下载体积（登录，manifest 缓存 5 分钟）
+ * - POST /{id}/install      异步安装，幂等（admin）
+ * - POST /{id}/uninstall    卸载（admin）
+ *
+ * 鉴权模式与 SkillController 一致：X-Session-Id → userId → AdminAccessService
+ * （桌面单机全员管理员）。
+ */
+@RestController
+@RequestMapping("/api/packs")
+@RequiredArgsConstructor
+public class PackController {
+
+    private static final Pattern PACK_ID = Pattern.compile("^[a-z0-9][a-z0-9-]{1,49}$");
+
+    private final NativePackService packService;
+    private final SkillRegistry skillRegistry;
+    private final UserRepository userRepository;
+    private final AdminAccessService adminAccessService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Map<String, Object>> list(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isLoggedIn(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(LangText.of("未登录", "Not signed in")));
+        }
+        List<Map<String, Object>> packs = new ArrayList<>();
+        for (String id : knownPackIds()) {
+            packs.add(statusOf(id));
+        }
+        Map<String, Object> result = ok();
+        result.put("packs", packs);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/status")
+    public ResponseEntity<Map<String, Object>> status(
+            @PathVariable("id") String packId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isLoggedIn(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(LangText.of("未登录", "Not signed in")));
+        }
+        if (!PACK_ID.matcher(packId == null ? "" : packId).matches()) {
+            return ResponseEntity.ok(error(LangText.of("非法资源包 id: ", "Invalid pack ID: ") + packId));
+        }
+        Map<String, Object> result = ok();
+        result.put("status", statusOf(packId));
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/info")
+    public ResponseEntity<Map<String, Object>> info(
+            @PathVariable("id") String packId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isLoggedIn(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(LangText.of("未登录", "Not signed in")));
+        }
+        try {
+            NativePackService.PackInfo info = packService.info(packId);
+            Map<String, Object> result = ok();
+            result.put("latestVersion", info.latestVersion());
+            result.put("totalSize", info.totalSize());
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/{id}/install")
+    public ResponseEntity<Map<String, Object>> install(
+            @PathVariable("id") String packId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(error(LangText.of("仅管理员可操作", "Administrator permission required")));
+        }
+        try {
+            packService.installAsync(packId);
+            return ResponseEntity.ok(ok());
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/{id}/uninstall")
+    public ResponseEntity<Map<String, Object>> uninstall(
+            @PathVariable("id") String packId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (!isAdmin(sessionId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(error(LangText.of("仅管理员可操作", "Administrator permission required")));
+        }
+        try {
+            packService.uninstall(packId);
+            return ResponseEntity.ok(ok());
+        } catch (Exception e) {
+            return ResponseEntity.ok(error(e.getMessage()));
+        }
+    }
+
+    /** 已知 pack = 本地已装 ∪ 已注册 skill 声明的 requires_pack */
+    private Set<String> knownPackIds() {
+        Set<String> ids = new LinkedHashSet<>(packService.installedPackIds());
+        for (SkillDefinition skill : skillRegistry.getSkills()) {
+            String packId = skill.getRequiresPack();
+            if (packId != null && !packId.isBlank() && PACK_ID.matcher(packId).matches()) {
+                ids.add(packId);
+            }
+        }
+        return ids;
+    }
+
+    private Map<String, Object> statusOf(String packId) {
+        NativePackService.PackStatus st = packService.status(packId);
+        Map<String, Object> m = new HashMap<>();
+        m.put("id", packId);
+        m.put("state", st.getState());
+        m.put("installedVersion", st.getInstalledVersion());
+        m.put("bytesDownloaded", st.getBytesDownloaded());
+        m.put("bytesTotal", st.getBytesTotal());
+        m.put("error", st.getError());
+        return m;
+    }
+
+    private boolean isLoggedIn(String sessionId) {
+        return AuthController.getUserIdFromSession(sessionId) != null;
+    }
+
+    private boolean isAdmin(String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            return false;
+        }
+        return userRepository.findById(userId)
+                .map(adminAccessService::isAdmin)
+                .orElse(false);
+    }
+
+    private Map<String, Object> ok() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 0);
+        return result;
+    }
+
+    private Map<String, Object> error(String message) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("message", message);
+        return result;
+    }
+}

--- a/backend/src/main/java/com/checkba/controller/ai/SkillController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/SkillController.java
@@ -43,6 +43,7 @@ public class SkillController {
     private final UserRepository userRepository;
     private final AdminAccessService adminAccessService;
     private final com.checkba.service.telemetry.TelemetryService telemetryService;
+    private final com.checkba.service.pack.NativePackService nativePackService;
 
     @lombok.Data
     public static class SkillView {
@@ -71,6 +72,14 @@ public class SkillController {
          * 否则英文界面下用户能勾中一个 zh-only 的 skill，勾了却永远不生效，也没有任何提示。
          */
         private boolean available;
+        /** 依赖的原生资源包 id（skill.yml: requires_pack）；不依赖资源包时为 null */
+        private String packId;
+        /**
+         * 资源是否已就位。**无 requires_pack 时恒 true**；声明了的话 =
+         * 「pack 已装」或「随包内置资源在场」（老版本用户的随包资源仍在，不该被逼着重下）。
+         * 随列表一起给，省得前端为每行再打一次 /api/packs/{id}/status。
+         */
+        private boolean packReady = true;
     }
 
     @GetMapping("/list")
@@ -213,6 +222,11 @@ public class SkillController {
         view.setLicense(skill.getLicense());
         view.setCredits(skill.getCredits());
         view.setAvailable(skillRegistry.isAvailable(skill));
+        String packId = skill.getRequiresPack();
+        if (packId != null && !packId.isBlank()) {
+            view.setPackId(packId);
+            view.setPackReady(nativePackService.resourceReady(packId));
+        }
         return view;
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/LitigationVisualService.java
+++ b/backend/src/main/java/com/checkba/service/ai/LitigationVisualService.java
@@ -44,6 +44,16 @@ public class LitigationVisualService {
     /** 引擎最低可用的 Python。低于此版本 import 期就会 SyntaxError，不如提前说清楚。 */
     private static final int MIN_MINOR = 11;
 
+    /** 承载 litviz / graphviz / drawio 的原生资源包 id（docs/NATIVE_PACK_DISTRIBUTION.md） */
+    public static final String PACK_ID = "litigation-visual";
+
+    /**
+     * 原生资源包服务。**可选注入**：单测与评测直接 {@code new LitigationVisualService()}，
+     * 那些场景下资源解析链只走「显式配置 → 随包内置 → dev 目录爬升」三步。
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.pack.NativePackService packService;
+
     @Value("${litviz.dir:}")
     private String configuredDir;
 
@@ -85,8 +95,27 @@ public class LitigationVisualService {
         resolved = null;
     }
 
+    /**
+     * 向 pack 服务登记「随包内置资源在场」探针：广场的 packReady 与自动补下载
+     * 都靠它区分「资源真缺」与「老版本随包资源还在」。
+     */
+    @jakarta.annotation.PostConstruct
+    void registerPackProbe() {
+        if (packService != null) {
+            packService.registerBuiltinProbe(PACK_ID, this::isEngineAvailableWithoutPack);
+        }
+    }
+
+    /**
+     * 不借助资源包时引擎是否可用（显式配置 / 随包内置 / dev 目录爬升三步）。
+     * 供 packReady 判定复用——随包内置优先于 pack，老用户不该被逼着重下一遍。
+     */
+    public boolean isEngineAvailableWithoutPack() {
+        return resolveLitvizDir(false) != null;
+    }
+
     private Runtime resolveRuntime() {
-        Path dir = resolveLitvizDir();
+        Path dir = resolveLitvizDir(true);
         String python = resolvePython();
         String version = python == null ? "" : probeVersion(python);
         String gv = firstNonBlank(configuredGraphvizDir, System.getenv("LITVIZ_GRAPHVIZ_DIR"));
@@ -94,6 +123,12 @@ public class LitigationVisualService {
             // 打包态的约定位置：litviz 目录旁边的 graphviz/bin
             Path sibling = dir.resolveSibling("graphviz").resolve("bin");
             if (Files.isDirectory(sibling)) gv = sibling.toString();
+        }
+        if (gv == null && packService != null) {
+            // 末位：资源包里的 graphviz/bin
+            Path packBin = packService.componentDir(PACK_ID, "graphviz")
+                    .map(p -> p.resolve("bin")).filter(Files::isDirectory).orElse(null);
+            if (packBin != null) gv = packBin.toString();
         }
         log.info("litviz runtime: dir={} python={} ({}) graphviz={}", dir, python, version, gv);
         return new Runtime(dir, python, version, gv);
@@ -104,9 +139,11 @@ public class LitigationVisualService {
      *
      * <p>最后一条覆盖两种真实布局：dev 态后端 cwd 是 {@code backend/}，litviz 在
      * {@code ../litviz}；打包态 cwd 是用户数据目录，靠 Electron 注入 LITVIZ_DIR，
-     * 走不到这一条。
+     * 走不到这一条。**末位是原生资源包**（规范 §5 的优先级：随包内置优先于 pack）。
+     *
+     * @param includePack false = 跳过资源包这一步（isEngineAvailableWithoutPack 用）
      */
-    private Path resolveLitvizDir() {
+    private Path resolveLitvizDir(boolean includePack) {
         for (String candidate : new String[]{configuredDir, System.getenv("LITVIZ_DIR")}) {
             if (candidate != null && !candidate.isBlank()) {
                 Path p = Paths.get(candidate).toAbsolutePath().normalize();
@@ -119,6 +156,10 @@ public class LitigationVisualService {
             if (base == null) continue;
             Path p = base.resolve("litviz");
             if (Files.isRegularFile(p.resolve("cli.py"))) return p.normalize();
+        }
+        if (includePack && packService != null) {
+            Path packDir = packService.componentDir(PACK_ID, "litviz").orElse(null);
+            if (packDir != null && Files.isRegularFile(packDir.resolve("cli.py"))) return packDir;
         }
         return null;
     }

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillDefinition.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillDefinition.java
@@ -42,6 +42,15 @@ public class SkillDefinition {
     private String sourcePluginId;
 
     /**
+     * 依赖的原生资源包 id（skill.yml: requires_pack，可选）。
+     *
+     * <p>声明了它就意味着「功能要用的重资源不随安装包分发」，广场安装时先下 pack
+     * 再启用 skill；旧版本应用忽略未知字段，向前兼容。规范见
+     * docs/NATIVE_PACK_DISTRIBUTION.md §7.1。
+     */
+    private String requiresPack;
+
+    /**
      * 法律事项类别（可选，用于匿名统计的事项类型分布，枚举值见
      * com.checkba.service.telemetry.MatterCategory；缺省不参与事项统计）
      */
@@ -113,6 +122,8 @@ public class SkillDefinition {
     public void setRequires(List<String> requires) { this.requires = requires; }
     public String getSourcePluginId() { return sourcePluginId; }
     public void setSourcePluginId(String sourcePluginId) { this.sourcePluginId = sourcePluginId; }
+    public String getRequiresPack() { return requiresPack; }
+    public void setRequiresPack(String requiresPack) { this.requiresPack = requiresPack; }
     public String getCategory() { return category; }
     public void setCategory(String category) { this.category = category; }
     public boolean isEnabledByDefault() { return enabledByDefault; }

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
@@ -363,6 +363,8 @@ public class SkillRegistry {
         skill.setVersion(asString(raw.get("version")));
         skill.setLicense(asString(raw.get("license")));
         skill.setCredits(asStringList(raw.get("credits")));
+        // 依赖的原生资源包（规范 docs/NATIVE_PACK_DISTRIBUTION.md §7.1，可选）
+        skill.setRequiresPack(asString(raw.get("requires_pack")));
         // 应用语言相关的可选字段（EN 版 PR5）：缺省时全部为空，语义 = 只在 zh-CN 可用
         skill.setLanguages(asStringList(raw.get("languages")));
         skill.setNameEn(asString(raw.get("name_en")));

--- a/backend/src/main/java/com/checkba/service/pack/NativePackService.java
+++ b/backend/src/main/java/com/checkba/service/pack/NativePackService.java
@@ -1,0 +1,1080 @@
+package com.checkba.service.pack;
+
+import cn.hutool.core.io.FileUtil;
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import com.checkba.service.LangText;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
+
+/**
+ * 原生资源包（native pack）的安装器。规范：docs/NATIVE_PACK_DISTRIBUTION.md。
+ *
+ * <p>pack = 「被宿主代码按路径消费的重资源」（Python 引擎、平台原生二进制、静态资产），
+ * 不进 JVM。它的信任等级与 JAR 插件相同（包里有会被解释执行/spawn 的内容），
+ * 因此**沿用插件 registry 的同一对 Ed25519 密钥**验签，公钥未配置 = 拒绝一切安装。
+ *
+ * <p>与 {@code PluginMarketService} 的一个刻意差异：pack 的 manifest 是托管的静态文件，
+ * 签名直接盖在 <b>manifest 原始字节</b>上（旁挂 {@code manifest.json.sig}），
+ * 不走 canonical JSON 重建——从根上避开跨语言键序坑。
+ *
+ * <p>落盘布局（{@code ai.packs.dir} 之下）：
+ * <pre>
+ * .staging/&lt;id&gt;-&lt;version&gt;/     安装事务工作区（*.part 断点文件 + unpack/）
+ * &lt;id&gt;/current.json             原子指针 {version, activatedAt, revoked}
+ * &lt;id&gt;/&lt;version&gt;/.pack-complete 逐文件复核通过后才写的完成标记
+ * &lt;id&gt;/&lt;version&gt;/&lt;unpackDir&gt;/  各组件
+ * </pre>
+ * 资源解析<b>只认</b>「current.json 指向且带 .pack-complete」的目录，半成品对外不可见。
+ */
+@Service
+@Slf4j
+public class NativePackService {
+
+    /** 与 skill / 插件 id 同一套规则，兼防路径穿越 */
+    private static final Pattern PACK_ID = Pattern.compile("^[a-z0-9][a-z0-9-]{1,49}$");
+
+    /** 宿主认识的资源↔宿主机器契约版本；manifest 声明别的值即拒装 */
+    private static final int SUPPORTED_ENGINE_API = 1;
+
+    private static final int SUPPORTED_SCHEMA = 1;
+
+    /** 单个组件的下载重试次数，每次换下一个源 */
+    private static final int MAX_ATTEMPTS = 3;
+
+    /** 解压防护：单个压缩包的条目数与解压后总体积上限 */
+    private static final int MAX_ENTRIES = 5000;
+    private static final long MAX_UNPACKED_BYTES = 500L * 1024 * 1024;
+
+    /** manifest 查询缓存时长（/api/packs/{id}/info） */
+    private static final long MANIFEST_TTL_MS = 5 * 60 * 1000L;
+
+    private static final long DAY_MS = 24 * 60 * 60 * 1000L;
+
+    private static final String COMPLETE_MARKER = ".pack-complete";
+    private static final String CURRENT_JSON = "current.json";
+    private static final String CONTENTS_LIST = "contents.sha256";
+
+    // 状态机（规范 §4.3；state 值直接进 API 响应）
+    public static final String STATE_NOT_INSTALLED = "not_installed";
+    public static final String STATE_DOWNLOADING = "downloading";
+    public static final String STATE_VERIFYING = "verifying";
+    public static final String STATE_INSTALLING = "installing";
+    public static final String STATE_READY = "ready";
+    public static final String STATE_FAILED = "failed";
+    public static final String STATE_REVOKED = "revoked";
+
+    private final PackProperties props;
+    private final String publicKeyPem;
+    private final String appVersion;
+
+    /** 安装串行执行：同一 pack 去重，不同 pack 也排队（下载是 IO 密集，并发下没有收益） */
+    private final ExecutorService installer =
+            Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "native-pack-installer");
+                t.setDaemon(true);
+                return t;
+            });
+
+    private final Map<String, PackStatus> statuses = new ConcurrentHashMap<>();
+    private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+    private final Map<String, CachedManifest> manifestCache = new ConcurrentHashMap<>();
+
+    /**
+     * 「随包内置资源在场」探针：packId -> 判定函数，由资源消费方（如
+     * {@link com.checkba.service.ai.LitigationVisualService}）自行登记。
+     *
+     * <p>存在的理由：老版本用户的随包资源仍在，不该被逼着重下一遍 pack
+     * （规范 §5 的解析优先级「随包优先于 pack」）。
+     */
+    private final Map<String, BooleanSupplier> builtinProbes = new ConcurrentHashMap<>();
+
+    private volatile HttpClient httpClient;
+
+    public NativePackService(
+            PackProperties props,
+            @Value("${ai.plugins.registry-public-key:}") String publicKeyPem,
+            @Value("${telemetry.app-version:${AWD_APP_VERSION:dev}}") String appVersion) {
+        this.props = props;
+        this.publicKeyPem = publicKeyPem;
+        this.appVersion = appVersion;
+    }
+
+    // ==================== 对外数据结构 ====================
+
+    /** manifest 里的一个组件 */
+    public record Component(String name, List<String> platforms, String archive,
+                            long size, String sha256, String unpackDir, List<String> urls) {}
+
+    /** pack manifest（托管静态文件，签名盖在原始字节上） */
+    public record Manifest(int schema, String id, String version, String publishedAt,
+                           String minAppVersion, int engineApi, List<Component> components) {}
+
+    /** 封禁表条目 */
+    public record RevokedPack(String id, String version, String reason, String revokedAt) {}
+
+    /** {@code /api/packs/{id}/info} 的返回体 */
+    public record PackInfo(String latestVersion, long totalSize) {}
+
+    /** 安装进度（内存态；重启后按磁盘重建 ready / not_installed） */
+    public static class PackStatus {
+        private String id;
+        private String state = STATE_NOT_INSTALLED;
+        private String installedVersion;
+        private long bytesDownloaded;
+        private long bytesTotal;
+        private String error;
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+        public String getState() { return state; }
+        public void setState(String state) { this.state = state; }
+        public String getInstalledVersion() { return installedVersion; }
+        public void setInstalledVersion(String installedVersion) { this.installedVersion = installedVersion; }
+        public long getBytesDownloaded() { return bytesDownloaded; }
+        public void setBytesDownloaded(long bytesDownloaded) { this.bytesDownloaded = bytesDownloaded; }
+        public long getBytesTotal() { return bytesTotal; }
+        public void setBytesTotal(long bytesTotal) { this.bytesTotal = bytesTotal; }
+        public String getError() { return error; }
+        public void setError(String error) { this.error = error; }
+    }
+
+    private record CachedManifest(Manifest manifest, long fetchedAt) {}
+
+    // ==================== 查询 ====================
+
+    /** 装好且未被封禁（current.json 指向的版本目录带完成标记） */
+    public boolean isReady(String packId) {
+        return currentVersionDir(packId).isPresent();
+    }
+
+    /**
+     * 资源是否可用 = pack 已就绪 <b>或</b> 随包内置资源在场。
+     * 广场的 packReady、自动补下载的判据都用它。
+     */
+    public boolean resourceReady(String packId) {
+        if (isReady(packId)) return true;
+        BooleanSupplier probe = builtinProbes.get(packId);
+        try {
+            return probe != null && probe.getAsBoolean();
+        } catch (Exception e) {
+            log.debug("Builtin probe for pack {} failed: {}", packId, e.getMessage());
+            return false;
+        }
+    }
+
+    /** 登记「随包内置资源在场」探针（资源消费方在 @PostConstruct 里调） */
+    public void registerBuiltinProbe(String packId, BooleanSupplier probe) {
+        if (packId != null && probe != null) builtinProbes.put(packId, probe);
+    }
+
+    /**
+     * 取某个组件的解压目录。未安装 / 已封禁 / 目录不存在都返回 empty，
+     * 调用方据此走自己的降级分支。
+     */
+    public Optional<Path> componentDir(String packId, String unpackDir) {
+        if (unpackDir == null || !isSafeSegment(unpackDir)) return Optional.empty();
+        return currentVersionDir(packId)
+                .map(v -> v.resolve(unpackDir))
+                .filter(Files::isDirectory);
+    }
+
+    /** 本地已装（含被封禁的）pack id */
+    public Set<String> installedPackIds() {
+        Path root = packsRoot();
+        Set<String> ids = new LinkedHashSet<>();
+        if (!Files.isDirectory(root)) return ids;
+        try (var stream = Files.list(root)) {
+            stream.filter(Files::isDirectory)
+                    .filter(p -> Files.isRegularFile(p.resolve(CURRENT_JSON)))
+                    .map(p -> p.getFileName().toString())
+                    .filter(name -> PACK_ID.matcher(name).matches())
+                    .forEach(ids::add);
+        } catch (IOException e) {
+            log.warn("列举已装资源包失败: {}", e.getMessage());
+        }
+        return ids;
+    }
+
+    /** 当前状态。内存里没有记录时按磁盘判定（重启后的 ready / revoked / not_installed）。 */
+    public PackStatus status(String packId) {
+        PackStatus live = statuses.get(packId);
+        if (live != null) return live;
+        PackStatus st = new PackStatus();
+        st.setId(packId);
+        JSONObject current = readCurrent(packId);
+        if (current != null) {
+            st.setInstalledVersion(current.getStr("version"));
+            if (current.getBool("revoked", false)) {
+                st.setState(STATE_REVOKED);
+            } else if (isReady(packId)) {
+                st.setState(STATE_READY);
+            }
+        }
+        return st;
+    }
+
+    /**
+     * 拉一次 manifest 回答「最新版多大」（按本平台过滤后的压缩包字节和）。
+     * 命中 5 分钟缓存时不发请求。
+     */
+    public PackInfo info(String packId) {
+        requireValidId(packId);
+        Manifest m = cachedManifest(packId);
+        long total = 0;
+        for (Component c : componentsForPlatform(m)) {
+            total += c.size();
+        }
+        return new PackInfo(m.version(), total);
+    }
+
+    // ==================== 安装 ====================
+
+    /**
+     * 异步安装（幂等）：同一 pack 已在队列里就直接返回，前端轮询 status 看进度。
+     */
+    public void installAsync(String packId) {
+        requireValidId(packId);
+        requireEnabled();
+        if (!inFlight.add(packId)) {
+            log.info("Pack {} install already in flight, ignoring duplicate request", packId);
+            return;
+        }
+        PackStatus st = liveStatus(packId);
+        st.setState(STATE_DOWNLOADING);
+        st.setError(null);
+        installer.submit(() -> {
+            try {
+                install(packId);
+            } catch (Exception e) {
+                log.warn("Pack {} install failed: {}", packId, e.getMessage());
+            } finally {
+                inFlight.remove(packId);
+            }
+        });
+    }
+
+    /**
+     * 同步安装事务（规范 §4.2）：验签 → 版本/engineApi 校验 → 逐组件断点续传下载并比对
+     * sha256 → 解压（四重防护）→ 按包内 contents.sha256 逐文件复核 → 原子 rename
+     * → 写完成标记 → 切 current.json 指针 → 删旧版本。
+     *
+     * <p>失败处置：验签/哈希失败删产物；网络中断保留 {@code .part} 供下次续传。
+     *
+     * @return 安装的版本号
+     */
+    public synchronized String install(String packId) {
+        requireValidId(packId);
+        requireEnabled();
+        PackStatus st = liveStatus(packId);
+        try {
+            st.setState(STATE_DOWNLOADING);
+            st.setError(null);
+            String version = doInstall(packId, st);
+            st.setState(STATE_READY);
+            st.setInstalledVersion(version);
+            return version;
+        } catch (RuntimeException e) {
+            st.setState(STATE_FAILED);
+            st.setError(e.getMessage());
+            throw e;
+        }
+    }
+
+    private String doInstall(String packId, PackStatus st) {
+        Manifest m = fetchAndVerifyManifest(packId);
+        checkCompatibility(m);
+
+        List<Component> components = componentsForPlatform(m);
+        if (components.isEmpty()) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包 " + packId + " 没有适用于当前平台（" + platform() + "）的组件",
+                    "Pack " + packId + " has no component for this platform (" + platform() + ")"));
+        }
+
+        Path versionDir = packsRoot().resolve(packId).resolve(m.version());
+        if (Files.isRegularFile(versionDir.resolve(COMPLETE_MARKER))) {
+            // 幂等重装：目标版本已完整落盘，只重写指针（不下载任何字节）
+            writeCurrent(packId, m.version(), false);
+            pruneOtherVersions(packId, m.version());
+            st.setBytesTotal(totalSize(components));
+            st.setBytesDownloaded(totalSize(components));
+            log.info("Pack {} v{} already installed, pointer refreshed", packId, m.version());
+            return m.version();
+        }
+
+        Path staging = packsRoot().resolve(".staging").resolve(packId + "-" + m.version());
+        Path unpack = staging.resolve("unpack");
+        try {
+            Files.createDirectories(staging);
+            // .part 断点文件留着续传，半成品解压目录每次重来
+            FileUtil.del(unpack.toFile());
+            Files.createDirectories(unpack);
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("创建安装工作区失败: ", "Failed to create staging area: ") + e.getMessage());
+        }
+
+        st.setBytesTotal(totalSize(components));
+        long completed = 0;
+        List<Path> archives = new ArrayList<>();
+        for (Component c : components) {
+            Path part = staging.resolve(c.archive() + ".part");
+            downloadComponent(packId, m.version(), c, part, st, completed);
+            completed += c.size() > 0 ? c.size() : sizeOf(part);
+            st.setBytesDownloaded(completed);
+            archives.add(part);
+        }
+
+        st.setState(STATE_INSTALLING);
+        for (int i = 0; i < components.size(); i++) {
+            Component c = components.get(i);
+            Path target = unpack.resolve(c.unpackDir());
+            extract(archives.get(i), target);
+            verifyContents(target);
+        }
+
+        Path versionParent = versionDir.getParent();
+        try {
+            Files.createDirectories(versionParent);
+            FileUtil.del(versionDir.toFile());
+            try {
+                Files.move(unpack, versionDir, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicFailed) {
+                // 跨文件系统时原子移动不可用，退化为拷贝（staging 与目标默认同盘，这条极少走到）
+                FileUtil.copyContent(unpack.toFile(), versionDir.toFile(), true);
+                FileUtil.del(unpack.toFile());
+            }
+            Files.writeString(versionDir.resolve(COMPLETE_MARKER), m.version(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            FileUtil.del(versionDir.toFile());
+            throw new IllegalStateException(LangText.of("安装落盘失败: ", "Failed to finalize installation: ") + e.getMessage());
+        }
+
+        writeCurrent(packId, m.version(), false);
+        pruneOtherVersions(packId, m.version());
+        FileUtil.del(staging.toFile());
+        log.info("Installed native pack {} v{} ({} component(s))", packId, m.version(), components.size());
+        return m.version();
+    }
+
+    /** 卸载：删 packs/&lt;id&gt;/ 整目录（含 current.json）。canonical 守卫只许删正下方。 */
+    public synchronized void uninstall(String packId) {
+        requireValidId(packId);
+        Path root = packsRoot();
+        Path dir = root.resolve(packId);
+        try {
+            String canonicalRoot = root.toFile().getCanonicalPath();
+            String canonicalDir = dir.toFile().getCanonicalPath();
+            if (!canonicalDir.startsWith(canonicalRoot + java.io.File.separator)) {
+                throw new IllegalArgumentException(LangText.of("非法资源包目录: ", "Invalid pack directory: ") + packId);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("路径检查失败: ", "Path check failed: ") + e.getMessage());
+        }
+        if (!Files.isDirectory(dir)) {
+            throw new IllegalArgumentException(LangText.of("资源包未安装: ", "Pack not installed: ") + packId);
+        }
+        FileUtil.del(dir.toFile());
+        deleteStaging(packId);
+        statuses.remove(packId);
+        manifestCache.remove(packId);
+        log.info("Uninstalled native pack {}", packId);
+    }
+
+    // ==================== 下载 ====================
+
+    private void downloadComponent(String packId, String version, Component c,
+                                   Path part, PackStatus st, long baseBytes) {
+        List<String> sources = sourceUrls(packId, version, c);
+        if (sources.isEmpty()) {
+            throw new IllegalStateException(LangText.of("没有可用的下载源", "No download source configured"));
+        }
+        String lastError = null;
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            String url = sources.get(attempt % sources.size());
+            try {
+                fetchToFile(url, part, st, baseBytes);
+                st.setState(STATE_VERIFYING);
+                String actual = sha256Hex(part);
+                if (actual.equalsIgnoreCase(c.sha256())) {
+                    st.setState(STATE_DOWNLOADING);
+                    return;
+                }
+                // 内容与签名清单不符：产物不可信，删了换下一个源
+                log.warn("Pack {} component {} sha256 mismatch from {} (expected {}, got {})",
+                        packId, c.name(), url, c.sha256(), actual);
+                FileUtil.del(part.toFile());
+                lastError = LangText.of("下载内容与签名清单不符", "Downloaded content does not match the signed manifest");
+                st.setState(STATE_DOWNLOADING);
+            } catch (IOException | InterruptedException e) {
+                // 网络中断：保留 .part，下次续传
+                if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+                lastError = e.getMessage();
+                log.warn("Pack {} component {} download from {} failed: {}", packId, c.name(), url, e.getMessage());
+            }
+        }
+        throw new IllegalStateException(LangText.of("组件下载失败: ", "Component download failed: ")
+                + c.name() + " (" + lastError + ")");
+    }
+
+    /**
+     * 一次下载尝试，带 HTTP Range 断点续传：本地已有 N 字节就带 {@code Range: bytes=N-}；
+     * 服务器不回 206（不支持 Range，或返回了整体 200）则从头重写。
+     */
+    private void fetchToFile(String url, Path part, PackStatus st, long baseBytes)
+            throws IOException, InterruptedException {
+        long have = sizeOf(part);
+        HttpResponse<InputStream> resp = httpGetRange(url, have);
+        int status = resp.statusCode();
+        boolean append;
+        if (status == 206 && have > 0) {
+            append = true;
+        } else if (status == 200) {
+            append = false;
+            have = 0;
+        } else {
+            resp.body().close();
+            throw new IOException("HTTP " + status);
+        }
+
+        Files.createDirectories(part.getParent());
+        long written = have;
+        try (InputStream in = resp.body();
+             OutputStream out = append
+                     ? Files.newOutputStream(part, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+                     : Files.newOutputStream(part, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            byte[] buf = new byte[64 * 1024];
+            int n;
+            while ((n = in.read(buf)) > 0) {
+                out.write(buf, 0, n);
+                written += n;
+                st.setBytesDownloaded(baseBytes + written);
+            }
+        }
+    }
+
+    private List<String> sourceUrls(String packId, String version, Component c) {
+        List<String> urls = new ArrayList<>();
+        for (String base : props.getBaseUrls()) {
+            if (base == null || base.isBlank()) continue;
+            urls.add(trimSlash(base) + "/" + packId + "/" + version + "/" + c.archive());
+        }
+        if (c.urls() != null) {
+            for (String u : c.urls()) {
+                if (u != null && (u.startsWith("http://") || u.startsWith("https://"))) urls.add(u);
+            }
+        }
+        return urls;
+    }
+
+    // ==================== manifest 与验签 ====================
+
+    private Manifest cachedManifest(String packId) {
+        CachedManifest cached = manifestCache.get(packId);
+        if (cached != null && System.currentTimeMillis() - cached.fetchedAt() < MANIFEST_TTL_MS) {
+            return cached.manifest();
+        }
+        Manifest m = fetchAndVerifyManifest(packId);
+        manifestCache.put(packId, new CachedManifest(m, System.currentTimeMillis()));
+        return m;
+    }
+
+    /**
+     * 按序试各下载源拉 {@code manifest.json} + {@code manifest.json.sig} 并验签。
+     *
+     * <p>取不到就换下一个源；<b>验签失败直接中止</b>（不再试别的源）——签名不符
+     * 说明这条分发链路上有人动过手脚，换个镜像继续找是错的方向。
+     */
+    Manifest fetchAndVerifyManifest(String packId) {
+        if (publicKeyPem == null || publicKeyPem.isBlank()) {
+            throw new IllegalStateException(LangText.of(
+                    "未配置注册表公钥（ai.plugins.registry-public-key），拒绝安装资源包",
+                    "Registry public key not configured (ai.plugins.registry-public-key); pack installation refused"));
+        }
+        String lastError = null;
+        for (String base : props.getBaseUrls()) {
+            if (base == null || base.isBlank()) continue;
+            String manifestUrl = trimSlash(base) + "/" + packId + "/manifest.json";
+            byte[] raw;
+            byte[] sig;
+            try {
+                raw = httpGetBytes(manifestUrl);
+                sig = httpGetBytes(manifestUrl + ".sig");
+            } catch (Exception e) {
+                lastError = e.getMessage();
+                log.debug("Pack {} manifest not available at {}: {}", packId, manifestUrl, e.getMessage());
+                continue;
+            }
+            if (!verifySignature(raw, new String(sig, StandardCharsets.UTF_8))) {
+                throw new IllegalStateException(LangText.of(
+                        "资源包清单签名验证失败，已中止（来源可能被篡改）",
+                        "Pack manifest signature verification failed; aborted (the source may have been tampered with)"));
+            }
+            Manifest m = parseManifest(raw);
+            if (!packId.equals(m.id())) {
+                throw new IllegalStateException(LangText.of(
+                        "清单里的 id 与请求不符: ", "Manifest id does not match the request: ") + m.id());
+            }
+            return m;
+        }
+        throw new IllegalStateException(LangText.of("资源包清单不可达: ", "Pack manifest unreachable: ")
+                + packId + (lastError == null ? "" : " (" + lastError + ")"));
+    }
+
+    boolean verifySignature(byte[] manifestBytes, String signatureB64) {
+        try {
+            PublicKey key = parsePublicKey(publicKeyPem);
+            Signature verifier = Signature.getInstance("Ed25519");
+            verifier.initVerify(key);
+            verifier.update(manifestBytes);
+            return verifier.verify(Base64.getDecoder().decode(signatureB64.trim()));
+        } catch (Exception e) {
+            log.error("Pack manifest signature verification error: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    static Manifest parseManifest(byte[] raw) {
+        JSONObject j;
+        try {
+            j = JSONUtil.parseObj(new String(raw, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException(LangText.of("资源包清单无法解析: ", "Failed to parse pack manifest: ") + e.getMessage());
+        }
+        List<Component> components = new ArrayList<>();
+        JSONArray arr = j.getJSONArray("components");
+        if (arr != null) {
+            for (Object o : arr) {
+                JSONObject c = (JSONObject) o;
+                components.add(new Component(
+                        c.getStr("name"),
+                        strList(c.getJSONArray("platforms")),
+                        c.getStr("archive"),
+                        c.getLong("size", 0L),
+                        c.getStr("sha256"),
+                        c.getStr("unpackDir"),
+                        strList(c.getJSONArray("urls"))));
+            }
+        }
+        Manifest m = new Manifest(
+                j.getInt("schema", 0),
+                j.getStr("id"),
+                j.getStr("version"),
+                j.getStr("publishedAt"),
+                j.getStr("minAppVersion"),
+                j.getInt("engineApi", 0),
+                components);
+        if (m.id() == null || m.version() == null || components.isEmpty()) {
+            throw new IllegalStateException(LangText.of("资源包清单缺少必需字段", "Pack manifest is missing required fields"));
+        }
+        for (Component c : components) {
+            if (!isSafeSegment(c.archive()) || !isSafeSegment(c.unpackDir()) || c.sha256() == null) {
+                throw new IllegalStateException(LangText.of("资源包清单含非法组件: ", "Pack manifest contains an invalid component: ") + c.name());
+            }
+        }
+        return m;
+    }
+
+    /** schema / engineApi / minAppVersion 三道兼容闸 */
+    private void checkCompatibility(Manifest m) {
+        if (m.schema() != SUPPORTED_SCHEMA) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包清单版本不受支持（schema=" + m.schema() + "），请升级应用",
+                    "Unsupported pack manifest schema (" + m.schema() + "); please upgrade the app"));
+        }
+        if (m.engineApi() != SUPPORTED_ENGINE_API) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包引擎契约版本不受支持（engineApi=" + m.engineApi() + "），请升级应用",
+                    "Unsupported pack engine API (" + m.engineApi() + "); please upgrade the app"));
+        }
+        String min = m.minAppVersion();
+        if (min == null || min.isBlank()) return;
+        if (!isSemver(appVersion)) {
+            // dev 态 / 未注入 AWD_APP_VERSION：拿不到可比较的版本号就放行，
+            // 硬编码一个假版本只会让开发环境按错误的前提做判断
+            log.warn("应用版本号 '{}' 无法解析，跳过 minAppVersion({}) 校验", appVersion, min);
+            return;
+        }
+        if (compareSemver(appVersion, min) < 0) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包需要应用 " + min + " 及以上（当前 " + appVersion + "），请先升级应用",
+                    "This pack requires app version " + min + " or newer (current " + appVersion + "); please upgrade first"));
+        }
+    }
+
+    // ==================== 解压与复核 ====================
+
+    /**
+     * 解压 tar.gz 到目标目录。四重防护（规范 §2/§10）<b>逐条目在写入之前</b>检查：
+     * 拒绝 symlink / hardlink / 绝对路径 / 含 {@code ..} 的条目，条目数与解压总体积封顶。
+     * 恢复 POSIX exec 位（graphviz 的 dot 等）；非 posix 文件系统跳过。
+     */
+    void extract(Path archive, Path destDir) {
+        try {
+            Files.createDirectories(destDir);
+            Path canonicalDest = destDir.toRealPath();
+            int entries = 0;
+            long unpacked = 0;
+            try (TarArchiveInputStream tin = new TarArchiveInputStream(
+                    new GzipCompressorInputStream(Files.newInputStream(archive)))) {
+                TarArchiveEntry e;
+                while ((e = tin.getNextEntry()) != null) {
+                    if (++entries > MAX_ENTRIES) {
+                        throw new IllegalStateException(LangText.of(
+                                "压缩包条目数超过上限（" + MAX_ENTRIES + "）",
+                                "Archive exceeds the entry limit (" + MAX_ENTRIES + ")"));
+                    }
+                    if (e.isSymbolicLink() || e.isLink()) {
+                        throw new IllegalStateException(LangText.of(
+                                "压缩包含链接条目，拒绝解压: ", "Archive contains a link entry; extraction refused: ") + e.getName());
+                    }
+                    if (!e.isDirectory() && !e.isFile()) {
+                        throw new IllegalStateException(LangText.of(
+                                "压缩包含非常规条目，拒绝解压: ", "Archive contains a non-regular entry; extraction refused: ") + e.getName());
+                    }
+                    String name = e.getName();
+                    if (!isSafeRelPath(name)) {
+                        throw new IllegalStateException(LangText.of(
+                                "压缩包含非法路径，拒绝解压: ", "Archive contains an unsafe path; extraction refused: ") + name);
+                    }
+                    Path dest = canonicalDest.resolve(name).normalize();
+                    if (!dest.startsWith(canonicalDest)) {
+                        throw new IllegalStateException(LangText.of(
+                                "压缩包路径越界，拒绝解压: ", "Archive path escapes the target directory; extraction refused: ") + name);
+                    }
+                    if (e.isDirectory()) {
+                        Files.createDirectories(dest);
+                        continue;
+                    }
+                    unpacked += Math.max(e.getSize(), 0);
+                    if (unpacked > MAX_UNPACKED_BYTES) {
+                        throw new IllegalStateException(LangText.of(
+                                "解压后体积超过上限（500 MB）", "Unpacked size exceeds the 500 MB limit"));
+                    }
+                    Files.createDirectories(dest.getParent());
+                    try (OutputStream out = Files.newOutputStream(dest)) {
+                        tin.transferTo(out);
+                    }
+                    restoreExecBit(dest, e.getMode());
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("解压失败: ", "Extraction failed: ") + e.getMessage());
+        }
+    }
+
+    private static void restoreExecBit(Path file, int mode) {
+        if ((mode & 0111) == 0) return;
+        try {
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+            perms.add(PosixFilePermission.GROUP_EXECUTE);
+            perms.add(PosixFilePermission.OTHERS_EXECUTE);
+            Files.setPosixFilePermissions(file, perms);
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Windows 等非 POSIX 文件系统没有 exec 位的概念，跳过
+        }
+    }
+
+    /**
+     * 按包内 {@code contents.sha256}（每行 {@code <hex>  <相对路径>}）逐文件复核。
+     * 签名已经从密码学上覆盖了压缩包内容，这一步是落盘完整性的事后可审计凭据。
+     */
+    void verifyContents(Path dir) {
+        Path list = dir.resolve(CONTENTS_LIST);
+        if (!Files.isRegularFile(list)) {
+            throw new IllegalStateException(LangText.of(
+                    "组件缺少 contents.sha256 清单", "Component is missing the contents.sha256 list"));
+        }
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(list, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("读取 contents.sha256 失败: ", "Failed to read contents.sha256: ") + e.getMessage());
+        }
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) continue;
+            String[] parts = trimmed.split("\\s+", 2);
+            if (parts.length != 2) {
+                throw new IllegalStateException(LangText.of("contents.sha256 格式错误: ", "Malformed contents.sha256 line: ") + trimmed);
+            }
+            String expected = parts[0];
+            String rel = parts[1].trim();
+            if (!isSafeRelPath(rel)) {
+                throw new IllegalStateException(LangText.of("contents.sha256 含非法路径: ", "contents.sha256 contains an unsafe path: ") + rel);
+            }
+            Path file = dir.resolve(rel).normalize();
+            if (!file.startsWith(dir) || !Files.isRegularFile(file)) {
+                throw new IllegalStateException(LangText.of("清单里的文件不存在: ", "File listed in contents.sha256 is missing: ") + rel);
+            }
+            if (!sha256Hex(file).equalsIgnoreCase(expected)) {
+                throw new IllegalStateException(LangText.of("文件校验失败: ", "File verification failed: ") + rel);
+            }
+        }
+    }
+
+    // ==================== 封禁 ====================
+
+    @PostConstruct
+    public void onStartup() {
+        if (!props.isEnabled()) return;
+        Thread t = new Thread(this::syncRevoked, "native-pack-revocation-init");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    @Scheduled(fixedDelay = DAY_MS, initialDelay = DAY_MS)
+    public void scheduledSyncRevoked() {
+        if (props.isEnabled()) syncRevoked();
+    }
+
+    /**
+     * 拉封禁表并对已装 pack 打标（{@code current.json} 的 revoked 位）。
+     * 打标后资源解析链对它视而不见；<b>不删本地文件</b>（与插件封禁同理，防误封丢数据）。
+     *
+     * @return 本次新打上封禁标记的 pack id
+     */
+    public List<String> syncRevoked() {
+        List<RevokedPack> revoked;
+        try {
+            revoked = fetchRevoked();
+        } catch (Exception e) {
+            // 官网未部署该端点时 404，静默跳过，不刷错误日志
+            log.debug("Pack revocation sync skipped: {}", e.getMessage());
+            return List.of();
+        }
+        List<String> hit = new ArrayList<>();
+        for (RevokedPack r : revoked) {
+            if (r.id() == null) continue;
+            JSONObject current = readCurrent(r.id());
+            if (current == null) continue;
+            String installed = current.getStr("version");
+            boolean matches = "*".equals(r.version()) || r.version() == null || r.version().equals(installed);
+            if (!matches || current.getBool("revoked", false)) continue;
+            writeCurrent(r.id(), installed, true);
+            statuses.remove(r.id());
+            hit.add(r.id());
+            log.warn("Native pack {} v{} revoked by platform: {}", r.id(), installed, r.reason());
+        }
+        return hit;
+    }
+
+    List<RevokedPack> fetchRevoked() {
+        byte[] body;
+        try {
+            body = httpGetBytes(props.getRevokedUrl());
+        } catch (Exception e) {
+            throw new IllegalStateException("revocation list unreachable: " + e.getMessage());
+        }
+        List<RevokedPack> result = new ArrayList<>();
+        for (Object o : JSONUtil.parseArray(new String(body, StandardCharsets.UTF_8))) {
+            JSONObject j = (JSONObject) o;
+            result.add(new RevokedPack(j.getStr("id"), j.getStr("version"), j.getStr("reason"), j.getStr("revokedAt")));
+        }
+        return result;
+    }
+
+    // ==================== 落盘细节 ====================
+
+    Path packsRoot() {
+        return Paths.get(props.getDir()).toAbsolutePath().normalize();
+    }
+
+    /** current.json 指向的、带完成标记的、未被封禁的版本目录 */
+    private Optional<Path> currentVersionDir(String packId) {
+        if (packId == null || !PACK_ID.matcher(packId).matches()) return Optional.empty();
+        JSONObject current = readCurrent(packId);
+        if (current == null || current.getBool("revoked", false)) return Optional.empty();
+        String version = current.getStr("version");
+        if (version == null || version.isBlank() || !isSafeSegment(version)) return Optional.empty();
+        Path dir = packsRoot().resolve(packId).resolve(version);
+        return Files.isRegularFile(dir.resolve(COMPLETE_MARKER)) ? Optional.of(dir) : Optional.empty();
+    }
+
+    private JSONObject readCurrent(String packId) {
+        Path f = packsRoot().resolve(packId).resolve(CURRENT_JSON);
+        if (!Files.isRegularFile(f)) return null;
+        try {
+            return JSONUtil.parseObj(Files.readString(f, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.warn("资源包指针 {} 无法解析: {}", f, e.getMessage());
+            return null;
+        }
+    }
+
+    /** 指针原子写（tmp + rename，overlay.js 同款） */
+    private void writeCurrent(String packId, String version, boolean revoked) {
+        Path dir = packsRoot().resolve(packId);
+        Path target = dir.resolve(CURRENT_JSON);
+        Path tmp = dir.resolve(CURRENT_JSON + ".tmp");
+        JSONObject j = JSONUtil.createObj()
+                .set("version", version)
+                .set("activatedAt", Instant.now().toString())
+                .set("revoked", revoked);
+        try {
+            Files.createDirectories(dir);
+            Files.writeString(tmp, j.toString(), StandardCharsets.UTF_8);
+            try {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicFailed) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("写入资源包指针失败: ", "Failed to write the pack pointer: ") + e.getMessage());
+        }
+    }
+
+    /** 卸载时连带清掉这个 pack 的安装工作区（含未完成的 .part 断点文件） */
+    private void deleteStaging(String packId) {
+        Path staging = packsRoot().resolve(".staging");
+        if (!Files.isDirectory(staging)) return;
+        try (var stream = Files.list(staging)) {
+            stream.filter(p -> p.getFileName().toString().startsWith(packId + "-"))
+                    .forEach(p -> FileUtil.del(p.toFile()));
+        } catch (IOException e) {
+            log.warn("清理安装工作区失败: {}", e.getMessage());
+        }
+    }
+
+    /** 只保留 current 一版：draw.io 级别的体积不值得本地存两份（规范 §4.2-5） */
+    private void pruneOtherVersions(String packId, String keep) {
+        Path dir = packsRoot().resolve(packId);
+        if (!Files.isDirectory(dir)) return;
+        try (var stream = Files.list(dir)) {
+            stream.filter(Files::isDirectory)
+                    .filter(p -> !p.getFileName().toString().equals(keep))
+                    .sorted(Comparator.comparing(Path::toString))
+                    .forEach(p -> FileUtil.del(p.toFile()));
+        } catch (IOException e) {
+            log.warn("清理旧版本目录失败: {}", e.getMessage());
+        }
+    }
+
+    // ==================== 平台与工具函数 ====================
+
+    /** 当前平台键（与 desktop/bundled/${os}-${arch} 命名一致） */
+    protected String platform() {
+        String os = System.getProperty("os.name", "").toLowerCase();
+        String arch = System.getProperty("os.arch", "").toLowerCase();
+        String o = os.contains("mac") || os.contains("darwin") ? "mac"
+                : os.contains("win") ? "win" : "linux";
+        String a = arch.contains("aarch64") || arch.contains("arm64") ? "arm64" : "x64";
+        return o + "-" + a;
+    }
+
+    /** 「匹配自身平台 ∪ *」 */
+    List<Component> componentsForPlatform(Manifest m) {
+        String self = platform();
+        List<Component> out = new ArrayList<>();
+        for (Component c : m.components()) {
+            List<String> platforms = c.platforms();
+            if (platforms == null || platforms.isEmpty() || platforms.contains("*") || platforms.contains(self)) {
+                out.add(c);
+            }
+        }
+        return out;
+    }
+
+    private PackStatus liveStatus(String packId) {
+        return statuses.computeIfAbsent(packId, id -> {
+            PackStatus st = status(id);
+            st.setId(id);
+            return st;
+        });
+    }
+
+    private static long totalSize(List<Component> components) {
+        long total = 0;
+        for (Component c : components) total += Math.max(c.size(), 0);
+        return total;
+    }
+
+    private static long sizeOf(Path p) {
+        try {
+            return Files.isRegularFile(p) ? Files.size(p) : 0;
+        } catch (IOException e) {
+            return 0;
+        }
+    }
+
+    static String sha256Hex(Path file) {
+        try (InputStream in = Files.newInputStream(file)) {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] buf = new byte[64 * 1024];
+            int n;
+            while ((n = in.read(buf)) > 0) md.update(buf, 0, n);
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : md.digest()) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException(LangText.of("哈希计算失败: ", "Failed to compute hash: ") + e.getMessage());
+        }
+    }
+
+    private static PublicKey parsePublicKey(String pem) throws Exception {
+        String base64 = pem.replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] der = Base64.getDecoder().decode(base64);
+        return KeyFactory.getInstance("Ed25519").generatePublic(new X509EncodedKeySpec(der));
+    }
+
+    private static List<String> strList(JSONArray arr) {
+        List<String> out = new ArrayList<>();
+        if (arr != null) {
+            for (Object o : arr) if (o != null) out.add(String.valueOf(o));
+        }
+        return out;
+    }
+
+    /** 单个路径段：非空、无分隔符、无 .. */
+    static boolean isSafeSegment(String s) {
+        if (s == null || s.isBlank() || s.length() > 200) return false;
+        if (s.contains("/") || s.contains("\\") || s.equals(".") || s.equals("..")) return false;
+        return !s.startsWith(".");
+    }
+
+    /** 压缩包/清单里的相对路径 */
+    static boolean isSafeRelPath(String p) {
+        if (p == null || p.isBlank() || p.length() > 1024) return false;
+        if (p.startsWith("/") || p.contains("\\") || p.matches("^[a-zA-Z]:.*")) return false;
+        for (String seg : p.split("/")) {
+            if (seg.equals("..") || seg.isBlank()) return false;
+        }
+        return true;
+    }
+
+    static boolean isSemver(String v) {
+        return v != null && v.matches("^\\d+\\.\\d+(\\.\\d+)?.*$");
+    }
+
+    static int compareSemver(String a, String b) {
+        String[] pa = (a == null ? "0.0.0" : a).split("\\.");
+        String[] pb = (b == null ? "0.0.0" : b).split("\\.");
+        for (int i = 0; i < 3; i++) {
+            int va = i < pa.length ? parseIntSafe(pa[i]) : 0;
+            int vb = i < pb.length ? parseIntSafe(pb[i]) : 0;
+            if (va != vb) return Integer.compare(va, vb);
+        }
+        return 0;
+    }
+
+    private static int parseIntSafe(String s) {
+        try {
+            return Integer.parseInt(s.replaceAll("[^0-9].*$", ""));
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private static String trimSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private static void requireValidId(String id) {
+        if (id == null || !PACK_ID.matcher(id).matches()) {
+            throw new IllegalArgumentException(LangText.of("非法资源包 id: ", "Invalid pack ID: ") + id);
+        }
+    }
+
+    private void requireEnabled() {
+        if (!props.isEnabled()) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包分发已关闭（ai.packs.enabled=false）",
+                    "Native pack distribution is disabled (ai.packs.enabled=false)"));
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        installer.shutdownNow();
+    }
+
+    // ==================== HTTP seam（单测覆写；测试用本地 HTTP 桩） ====================
+
+    protected HttpClient httpClient() {
+        HttpClient c = httpClient;
+        if (c == null) {
+            synchronized (this) {
+                if (httpClient == null) {
+                    httpClient = HttpClient.newBuilder()
+                            .connectTimeout(Duration.ofSeconds(10))
+                            .followRedirects(HttpClient.Redirect.NORMAL)
+                            .build();
+                }
+                c = httpClient;
+            }
+        }
+        return c;
+    }
+
+    /** 小体量 GET（manifest / sig / 封禁表）；非 200 抛 IOException */
+    protected byte[] httpGetBytes(String url) throws IOException, InterruptedException {
+        HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(20))
+                .GET().build();
+        HttpResponse<byte[]> resp = httpClient().send(req, HttpResponse.BodyHandlers.ofByteArray());
+        if (resp.statusCode() != 200) {
+            throw new IOException("HTTP " + resp.statusCode() + " for " + url);
+        }
+        return resp.body();
+    }
+
+    /** 大文件 GET，{@code from > 0} 时带 Range 头请求断点续传 */
+    protected HttpResponse<InputStream> httpGetRange(String url, long from)
+            throws IOException, InterruptedException {
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofMinutes(10))
+                .GET();
+        if (from > 0) {
+            b.header("Range", "bytes=" + from + "-");
+        }
+        return httpClient().send(b.build(), HttpResponse.BodyHandlers.ofInputStream());
+    }
+}

--- a/backend/src/main/java/com/checkba/service/pack/PackAutoInstaller.java
+++ b/backend/src/main/java/com/checkba/service/pack/PackAutoInstaller.java
@@ -1,0 +1,81 @@
+package com.checkba.service.pack;
+
+import com.checkba.service.ai.skill.SkillDefinition;
+import com.checkba.service.ai.skill.SkillRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 升级后的资源缺口自动补下载（规范 docs/NATIVE_PACK_DISTRIBUTION.md §5 / §13-2）。
+ *
+ * <p>解决的是这个场景：老用户升级到「资源已从安装包里摘除」的大版本，Resources 里的
+ * 随包资源随 .app 替换消失，而本地还没有 pack——于是「skill 已启用」与「资源缺失」并存。
+ * 用户当初打开这个功能就是在表达要它，升级不该让它变哑。
+ *
+ * <p>判据是 {@link NativePackService#resourceReady}（pack 已装 <b>或</b> 随包内置在场），
+ * 所以随包资源还在的老版本一个字节都不会下。
+ */
+@Component
+@Slf4j
+public class PackAutoInstaller {
+
+    /** 启动后延迟多久开始检查：别和后端启动抢 CPU 与网络 */
+    private static final long DELAY_SECONDS = 10;
+
+    private final PackProperties props;
+    private final NativePackService packService;
+    private final SkillRegistry skillRegistry;
+
+    private final ScheduledExecutorService scheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "native-pack-auto-install");
+                t.setDaemon(true);
+                return t;
+            });
+
+    public PackAutoInstaller(PackProperties props, NativePackService packService, SkillRegistry skillRegistry) {
+        this.props = props;
+        this.packService = packService;
+        this.skillRegistry = skillRegistry;
+    }
+
+    @PostConstruct
+    public void scheduleCheck() {
+        if (!props.isEnabled()) return;
+        scheduler.schedule(this::checkAndInstall, DELAY_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /** 对每个「声明了 requires_pack 且已启用、但资源不在场」的 skill 触发一次安装。 */
+    public List<String> checkAndInstall() {
+        if (!props.isEnabled()) return List.of();
+        List<String> triggered = new ArrayList<>();
+        for (SkillDefinition skill : skillRegistry.getSkills()) {
+            String packId = skill.getRequiresPack();
+            if (packId == null || packId.isBlank()) continue;
+            if (!skillRegistry.isEnabled(skill.getId())) continue;
+            if (packService.resourceReady(packId)) continue;
+            try {
+                packService.installAsync(packId);
+                triggered.add(packId);
+                log.info("Skill '{}' is enabled but pack '{}' is missing; auto-install triggered",
+                        skill.getId(), packId);
+            } catch (Exception e) {
+                log.warn("资源包 {} 自动补下载未能启动: {}", packId, e.getMessage());
+            }
+        }
+        return triggered;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        scheduler.shutdownNow();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/pack/PackProperties.java
+++ b/backend/src/main/java/com/checkba/service/pack/PackProperties.java
@@ -1,0 +1,50 @@
+package com.checkba.service.pack;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 原生资源包（native pack）配置（规范见 docs/NATIVE_PACK_DISTRIBUTION.md §3.2）。
+ *
+ * 配置前缀：ai.packs
+ */
+@Component
+@ConfigurationProperties(prefix = "ai.packs")
+public class PackProperties {
+
+    /**
+     * 资源包落盘目录（相对服务端工作目录，惯例同 ai.plugins.dir）。
+     * 打包桌面版的后端 cwd 是用户数据目录，所以它落在 ~/.aiworkdeck/packs/。
+     */
+    private String dir = "packs";
+
+    /**
+     * 下载源，按序降级（镜像必须排在 GitHub 之前：境内直连 GitHub 实测 12 KB/s，
+     * 几十 MB 的包不能指望它当主源）。每个 base 拼 {@code /<id>/manifest.json} 与
+     * {@code /<id>/<version>/<archive>}。
+     */
+    private List<String> baseUrls = new ArrayList<>(List.of(
+            "https://www.aiworkdeck.com/plugin-packs",
+            "https://workdeck.ai/plugin-packs"));
+
+    /** 总开关。置 false 时安装、自动补下载、封禁同步全部旁路（离线部署形态用）。 */
+    private boolean enabled = true;
+
+    /**
+     * 平台封禁表地址（形制同插件封禁表，见规范 §8.4）。
+     * 端点 404 / 不可达时静默跳过——官网未部署时不该刷错误日志。
+     */
+    private String revokedUrl = "https://www.aiworkdeck.com/api/registry/packs/revoked";
+
+    public String getDir() { return dir; }
+    public void setDir(String dir) { this.dir = dir; }
+    public List<String> getBaseUrls() { return baseUrls; }
+    public void setBaseUrls(List<String> baseUrls) { this.baseUrls = baseUrls; }
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getRevokedUrl() { return revokedUrl; }
+    public void setRevokedUrl(String revokedUrl) { this.revokedUrl = revokedUrl; }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -305,6 +305,21 @@ ai:
       MCowBQYDK2VwAyEAjAbnyl44SiQF/CTyn59/uHAXCeRTEI0h0Bn5HEv7T4Y=
       -----END PUBLIC KEY-----
 
+  # 原生资源包（native pack）配置（对应 PackProperties，规范见 docs/NATIVE_PACK_DISTRIBUTION.md）
+  # 验签沿用上面 ai.plugins.registry-public-key 那把公钥（pack 与 JAR 插件同属
+  # 「广场分发的可执行内容」这一信任层级），公钥留空同样是拒绝一切安装。
+  packs:
+    # 资源包落盘目录（相对服务端工作目录，惯例同 ai.plugins.dir；打包态在 ~/.aiworkdeck/packs/）
+    dir: packs
+    # 下载源，按序降级。镜像必须排在 GitHub 之前：境内直连 GitHub 实测 12 KB/s。
+    base-urls:
+      - https://www.aiworkdeck.com/plugin-packs
+      - https://workdeck.ai/plugin-packs
+    # 总开关：false 时安装、自动补下载、封禁同步全部旁路（离线部署形态用）
+    enabled: true
+    # 平台封禁表（形制同插件封禁表）；端点不可达时静默跳过
+    revoked-url: https://www.aiworkdeck.com/api/registry/packs/revoked
+
   # Skill 体系配置（对应 SkillProperties，规范见 docs/SKILL_SPEC.md）
   skills:
     # 可写 skill 目录（相对服务端工作目录，做法同 ai.plugins.dir）。广场安装落这里。

--- a/backend/src/test/java/com/checkba/controller/ai/SkillControllerPackViewTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/SkillControllerPackViewTest.java
@@ -1,0 +1,87 @@
+package com.checkba.controller.ai;
+
+import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.skill.SkillProperties;
+import com.checkba.service.ai.skill.SkillRegistry;
+import com.checkba.service.pack.NativePackService;
+import com.checkba.service.pack.PackProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * /api/skills/list 的 packId / packReady 两个字段（规范 docs/NATIVE_PACK_DISTRIBUTION.md §7.1）。
+ *
+ * 前端靠它们区分「点安装就能用」与「要先下 45 MB」，判定必须包含
+ * 「随包内置资源在场」这一支——老版本用户的资源还在，不该被显示成未安装。
+ */
+class SkillControllerPackViewTest {
+
+    @TempDir
+    Path tempDir;
+
+    private void writeSkill(String id, String extra) throws IOException {
+        Path dir = tempDir.resolve("skills").resolve(id);
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("skill.yml"), """
+                id: %s
+                name: 测试技能
+                description: 描述
+                triggers:
+                  - 触发词
+                %s""".formatted(id, extra == null ? "" : extra));
+        Files.writeString(dir.resolve("prompt.md"), "指引");
+    }
+
+    private SkillController controller(NativePackService packService) {
+        SkillProperties props = new SkillProperties();
+        props.setDir(tempDir.resolve("skills").toString());
+        SkillRegistry registry = new SkillRegistry(props, null, new PluginService(), null);
+        registry.init();
+        return new SkillController(registry, null, null, null, null, packService);
+    }
+
+    private NativePackService packService() {
+        PackProperties props = new PackProperties();
+        props.setDir(tempDir.resolve("packs").toString());
+        props.setBaseUrls(List.of("https://example.invalid/plugin-packs"));
+        return new NativePackService(props, "", "0.21.0");
+    }
+
+    @Test
+    @DisplayName("无 requires_pack 的 skill：packId 为空、packReady 恒 true")
+    void skillWithoutPackIsAlwaysReady() throws IOException {
+        writeSkill("plain-skill", null);
+        List<SkillController.SkillView> views = controller(packService()).listSkills();
+
+        assertEquals(1, views.size());
+        assertNull(views.get(0).getPackId());
+        assertTrue(views.get(0).isPackReady());
+    }
+
+    @Test
+    @DisplayName("声明了 requires_pack：资源缺失 packReady=false，随包内置在场则 true")
+    void packReadyFollowsResourceAvailability() throws IOException {
+        writeSkill("packed-skill", "requires_pack: litigation-visual\n");
+        NativePackService packs = packService();
+
+        SkillController.SkillView missing = controller(packs).listSkills().get(0);
+        assertEquals("litigation-visual", missing.getPackId());
+        assertFalse(missing.isPackReady(), "pack 未装且随包资源不在场");
+
+        // 随包内置资源在场（老版本用户）——不该被逼着重下一遍
+        packs.registerBuiltinProbe("litigation-visual", () -> true);
+        SkillController.SkillView bundled = controller(packs).listSkills().get(0);
+        assertTrue(bundled.isPackReady());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/skill/BuiltinSkillsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/BuiltinSkillsTest.java
@@ -119,6 +119,8 @@ class BuiltinSkillsTest {
                 "出图三件套必须都在白名单里，缺一个模型就调不到：" + s.getAllowedTools());
         assertTrue(s.getAllowedTools().contains("extract_file_text"),
                 "抽取阶段要通读文件夹里的材料，缺了它就只能凭对话内容画");
+        assertEquals("litigation-visual", s.getRequiresPack(),
+                "出图资源（litviz/graphviz/drawio）走原生资源包分发，缺了这行广场就不会去下载");
         assertFalse(s.getPromptTemplate().isBlank(), "prompt.md 应有内容");
     }
 

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillRegistryTest.java
@@ -98,6 +98,17 @@ class SkillRegistryTest {
         assertFalse(registry.isEnabled("authored-skill"), "enabled_by_default:false 首次扫描即默认禁用");
     }
 
+    @Test
+    @DisplayName("解析 requires_pack（原生资源包依赖，可选字段）")
+    void parsesRequiresPack() throws IOException {
+        writeSkill(tempDir.resolve("packed-skill"), "packed-skill", "requires_pack: litigation-visual\n");
+        writeSkill(tempDir.resolve("plain-skill"), "plain-skill", null);
+        SkillRegistry registry = newRegistry(tempDir, new PluginService());
+
+        assertEquals("litigation-visual", registry.getSkill("packed-skill").orElseThrow().getRequiresPack());
+        assertNull(registry.getSkill("plain-skill").orElseThrow().getRequiresPack(), "缺省即不依赖资源包");
+    }
+
     /**
      * 极简内存版 SystemSettingService：只覆盖 get/set，用来验证禁用/种子名单能跨"重启"
      * （新的 SkillRegistry 实例、同一份存储）持久化。父类真正依赖的仓储用不到，传 null。

--- a/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
@@ -1,0 +1,602 @@
+package com.checkba.service.pack;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.Signature;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * NativePackService 单测（规范 docs/NATIVE_PACK_DISTRIBUTION.md §9）：
+ * manifest 验签正/负/未配公钥、平台过滤、HTTP Range 断点续传、哈希不符换源重试、
+ * 解压四重防护、contents.sha256 复核失败回滚、幂等重装、卸载守卫、封禁后资源不可见。
+ *
+ * 网络这一层用 com.sun.net.httpserver 起本地桩（支持 Range），不打真实网络。
+ */
+class NativePackServiceTest {
+
+    private static final String PACK_ID = "litigation-visual";
+    private static final String VERSION = "1.0.0";
+
+    @TempDir
+    Path tempDir;
+
+    private KeyPair keyPair;
+    private String publicKeyPem;
+    private StubMirror primary;
+    private StubMirror secondary;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("Ed25519");
+        keyPair = gen.generateKeyPair();
+        publicKeyPem = "-----BEGIN PUBLIC KEY-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.US_ASCII))
+                        .encodeToString(keyPair.getPublic().getEncoded())
+                + "\n-----END PUBLIC KEY-----\n";
+        primary = new StubMirror();
+        secondary = new StubMirror();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (primary != null) primary.stop();
+        if (secondary != null) secondary.stop();
+    }
+
+    // ==================== 验签 ====================
+
+    @Test
+    @DisplayName("签名正确时安装成功，资源目录可解析")
+    void installsWhenSignatureValid() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "print(1)".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        assertEquals(VERSION, svc.install(PACK_ID));
+
+        assertTrue(svc.isReady(PACK_ID));
+        Path dir = svc.componentDir(PACK_ID, "litviz").orElseThrow();
+        assertEquals("print(1)", Files.readString(dir.resolve("cli.py")));
+        assertEquals(NativePackService.STATE_READY, svc.status(PACK_ID).getState());
+        // 半成品工作区装完即清
+        assertFalse(Files.exists(packsRoot().resolve(".staging").resolve(PACK_ID + "-" + VERSION)));
+    }
+
+    @Test
+    @DisplayName("签名不符即中止，不落任何文件")
+    void refusesWhenSignatureInvalid() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "print(1)".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), false);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install(PACK_ID));
+        assertTrue(e.getMessage().contains("签名") || e.getMessage().contains("signature"), e.getMessage());
+        assertFalse(svc.isReady(PACK_ID));
+        assertFalse(Files.exists(packsRoot().resolve(PACK_ID)));
+        assertEquals(NativePackService.STATE_FAILED, svc.status(PACK_ID).getState());
+    }
+
+    @Test
+    @DisplayName("未配置公钥 = 拒绝一切安装（与 JAR 插件同语义）")
+    void refusesWhenPublicKeyMissing() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        NativePackService svc = service("", primary.baseUrl());
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install(PACK_ID));
+        assertTrue(e.getMessage().contains("registry-public-key"), e.getMessage());
+        // 一个字节都不该下
+        assertTrue(primary.requests.stream().noneMatch(r -> r.path().endsWith(".tar.gz")));
+    }
+
+    // ==================== 平台过滤 ====================
+
+    @Test
+    @DisplayName("只装「匹配自身平台 ∪ *」的组件")
+    void filtersComponentsByPlatform() throws Exception {
+        byte[] shared = tarGzWithContents(Map.of("cli.py", "shared".getBytes(StandardCharsets.UTF_8)));
+        byte[] mac = tarGzWithContents(Map.of("bin/dot", "mac".getBytes(StandardCharsets.UTF_8)));
+        byte[] win = tarGzWithContents(Map.of("bin/dot.exe", "win".getBytes(StandardCharsets.UTF_8)));
+
+        List<Map<String, Object>> components = List.of(
+                component("litviz", List.of("*"), "litviz.tar.gz", shared, "litviz"),
+                component("graphviz", List.of("mac-arm64"), "graphviz-mac.tar.gz", mac, "graphviz"),
+                component("graphviz", List.of("win-x64"), "graphviz-win.tar.gz", win, "graphviz"));
+        publishManifest(primary, components, true, "0.1.0", 1, 1);
+        primary.files.put("/" + PACK_ID + "/" + VERSION + "/litviz.tar.gz", shared);
+        primary.files.put("/" + PACK_ID + "/" + VERSION + "/graphviz-mac.tar.gz", mac);
+        primary.files.put("/" + PACK_ID + "/" + VERSION + "/graphviz-win.tar.gz", win);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+
+        assertEquals("mac", Files.readString(svc.componentDir(PACK_ID, "graphviz").orElseThrow().resolve("bin/dot")));
+        // win 组件不该被下载
+        assertTrue(primary.requests.stream().noneMatch(r -> r.path().endsWith("graphviz-win.tar.gz")));
+        // info 的体积也只算本平台
+        assertEquals(shared.length + mac.length, svc.info(PACK_ID).totalSize());
+    }
+
+    // ==================== 断点续传 ====================
+
+    @Test
+    @DisplayName("本地已有 .part 时带 Range 续传，最终 sha256 仍正确")
+    void resumesWithRangeHeader() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "0123456789".repeat(500).getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        // 预置一段真实前缀，模拟上次下到一半被网络掐断
+        int have = archive.length / 3;
+        Path part = packsRoot().resolve(".staging").resolve(PACK_ID + "-" + VERSION).resolve("litviz.tar.gz.part");
+        Files.createDirectories(part.getParent());
+        Files.write(part, java.util.Arrays.copyOf(archive, have));
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+
+        StubMirror.Request archiveReq = primary.requests.stream()
+                .filter(r -> r.path().endsWith(".tar.gz")).findFirst().orElseThrow();
+        assertEquals("bytes=" + have + "-", archiveReq.range());
+        assertEquals(1, primary.rangeServed.size());
+        assertEquals("0123456789".repeat(500),
+                Files.readString(svc.componentDir(PACK_ID, "litviz").orElseThrow().resolve("cli.py")));
+    }
+
+    // ==================== 哈希不符换源 ====================
+
+    @Test
+    @DisplayName("下载内容哈希不符时删产物、换下一个源重试")
+    void retriesOnNextSourceWhenHashMismatches() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "good".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        publish(secondary, archive, "litviz", List.of("*"), true);
+        // 主源的压缩包被掉包（manifest 与签名仍正确）
+        byte[] tampered = tarGzWithContents(Map.of("cli.py", "evil".getBytes(StandardCharsets.UTF_8)));
+        primary.files.put("/" + PACK_ID + "/" + VERSION + "/litviz.tar.gz", tampered);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl(), secondary.baseUrl());
+        svc.install(PACK_ID);
+
+        assertEquals("good", Files.readString(svc.componentDir(PACK_ID, "litviz").orElseThrow().resolve("cli.py")));
+        assertTrue(primary.requests.stream().anyMatch(r -> r.path().endsWith(".tar.gz")));
+        assertTrue(secondary.requests.stream().anyMatch(r -> r.path().endsWith(".tar.gz")));
+    }
+
+    // ==================== 解压防护 ====================
+
+    @Test
+    @DisplayName("解压拒绝软链条目")
+    void rejectsSymlinkEntry() throws Exception {
+        byte[] bad = tarGz(tar -> tar.symlink("evil", "/etc/passwd"));
+        assertExtractRejected(bad, "链接");
+    }
+
+    @Test
+    @DisplayName("解压拒绝绝对路径条目")
+    void rejectsAbsolutePathEntry() throws Exception {
+        byte[] bad = tarGz(tar -> tar.file("/etc/evil", "x".getBytes(StandardCharsets.UTF_8)));
+        assertExtractRejected(bad, "非法路径");
+    }
+
+    @Test
+    @DisplayName("解压拒绝含 .. 的条目（zip-slip）")
+    void rejectsParentTraversalEntry() throws Exception {
+        byte[] bad = tarGz(tar -> tar.file("../evil", "x".getBytes(StandardCharsets.UTF_8)));
+        assertExtractRejected(bad, "非法路径");
+    }
+
+    @Test
+    @DisplayName("解压拒绝条目数超限的压缩包")
+    void rejectsTooManyEntries() throws Exception {
+        byte[] bad = tarGz(tar -> {
+            for (int i = 0; i <= 5001; i++) {
+                tar.file("f" + i, new byte[]{1});
+            }
+        });
+        assertExtractRejected(bad, "条目数");
+    }
+
+    // ==================== contents.sha256 复核 ====================
+
+    @Test
+    @DisplayName("包内 contents.sha256 复核失败即回滚，不留版本目录与指针")
+    void rollsBackWhenContentsListMismatches() throws Exception {
+        Map<String, byte[]> files = new LinkedHashMap<>();
+        files.put("cli.py", "real".getBytes(StandardCharsets.UTF_8));
+        byte[] archive = tarGz(tar -> {
+            tar.file("cli.py", files.get("cli.py"));
+            // 清单里写的是另一份内容的哈希
+            String line = sha256Hex("tampered".getBytes(StandardCharsets.UTF_8)) + "  cli.py\n";
+            tar.file(CONTENTS, line.getBytes(StandardCharsets.UTF_8));
+        });
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install(PACK_ID));
+        assertTrue(e.getMessage().contains("文件校验失败") || e.getMessage().contains("File verification failed"), e.getMessage());
+        assertFalse(svc.isReady(PACK_ID));
+        assertFalse(Files.exists(packsRoot().resolve(PACK_ID).resolve(VERSION)));
+        assertFalse(Files.exists(packsRoot().resolve(PACK_ID).resolve("current.json")));
+    }
+
+    // ==================== 幂等 / 卸载 / 封禁 ====================
+
+    @Test
+    @DisplayName("已就绪的版本重装不再下载任何字节")
+    void reinstallIsIdempotent() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        long firstCount = primary.requests.stream().filter(r -> r.path().endsWith(".tar.gz")).count();
+        svc.install(PACK_ID);
+        long secondCount = primary.requests.stream().filter(r -> r.path().endsWith(".tar.gz")).count();
+
+        assertEquals(1, firstCount);
+        assertEquals(firstCount, secondCount);
+        assertTrue(svc.isReady(PACK_ID));
+    }
+
+    @Test
+    @DisplayName("卸载删掉整个 pack 目录；非法 id 被守卫挡下")
+    void uninstallRemovesPackAndGuardsId() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        assertThrows(IllegalArgumentException.class, () -> svc.uninstall("../evil"));
+        assertThrows(IllegalArgumentException.class, () -> svc.uninstall("/etc"));
+        assertTrue(svc.isReady(PACK_ID));
+
+        svc.uninstall(PACK_ID);
+        assertFalse(svc.isReady(PACK_ID));
+        assertFalse(Files.exists(packsRoot().resolve(PACK_ID)));
+        assertTrue(svc.componentDir(PACK_ID, "litviz").isEmpty());
+    }
+
+    @Test
+    @DisplayName("命中封禁表后资源解析视而不见，但本地文件不删")
+    void revokedPackBecomesInvisible() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        primary.files.put("/revoked", ("[{\"id\":\"" + PACK_ID + "\",\"version\":\"*\",\"reason\":\"test\"}]")
+                .getBytes(StandardCharsets.UTF_8));
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        assertTrue(svc.isReady(PACK_ID));
+
+        assertEquals(List.of(PACK_ID), svc.syncRevoked());
+        assertFalse(svc.isReady(PACK_ID));
+        assertTrue(svc.componentDir(PACK_ID, "litviz").isEmpty());
+        assertEquals(NativePackService.STATE_REVOKED, svc.status(PACK_ID).getState());
+        // 不自动删本地文件（防误封丢数据）
+        assertTrue(Files.exists(packsRoot().resolve(PACK_ID).resolve(VERSION).resolve("litviz").resolve("cli.py")));
+    }
+
+    @Test
+    @DisplayName("封禁端点 404 时静默跳过，不影响已装 pack")
+    void revocationEndpointMissingIsSilent() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        assertEquals(List.of(), svc.syncRevoked());
+        assertTrue(svc.isReady(PACK_ID));
+    }
+
+    @Test
+    @DisplayName("engineApi / minAppVersion 不满足时拒装")
+    void refusesIncompatibleManifest() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        List<Map<String, Object>> components = List.of(
+                component("litviz", List.of("*"), "litviz.tar.gz", archive, "litviz"));
+
+        publishManifest(primary, components, true, "0.1.0", 2, 1);
+        primary.files.put("/" + PACK_ID + "/" + VERSION + "/litviz.tar.gz", archive);
+        NativePackService unknownApi = service(publicKeyPem, primary.baseUrl());
+        assertTrue(assertThrows(IllegalStateException.class, () -> unknownApi.install(PACK_ID))
+                .getMessage().contains("engineApi"));
+
+        publishManifest(primary, components, true, "9.9.9", 1, 1);
+        NativePackService tooOld = service(publicKeyPem, primary.baseUrl());
+        assertTrue(assertThrows(IllegalStateException.class, () -> tooOld.install(PACK_ID))
+                .getMessage().contains("9.9.9"));
+    }
+
+    @Test
+    @DisplayName("ai.packs.enabled=false 时安装被旁路")
+    void disabledBypassesInstall() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+
+        PackProperties props = props(primary.baseUrl());
+        props.setEnabled(false);
+        NativePackService svc = new TestPackService(props, publicKeyPem, "0.21.0");
+        assertThrows(IllegalStateException.class, () -> svc.install(PACK_ID));
+        assertTrue(primary.requests.isEmpty());
+    }
+
+    // ==================== 脚手架 ====================
+
+    private static final String CONTENTS = "contents.sha256";
+
+    /** 平台固定为 mac-arm64，别让断言随构建机的 os.arch 变化 */
+    private static class TestPackService extends NativePackService {
+        TestPackService(PackProperties props, String pem, String appVersion) {
+            super(props, pem, appVersion);
+        }
+
+        @Override
+        protected String platform() {
+            return "mac-arm64";
+        }
+    }
+
+    private Path packsRoot() {
+        return tempDir.resolve("packs").toAbsolutePath().normalize();
+    }
+
+    private PackProperties props(String... baseUrls) {
+        PackProperties props = new PackProperties();
+        props.setDir(packsRoot().toString());
+        props.setBaseUrls(new ArrayList<>(List.of(baseUrls)));
+        props.setRevokedUrl(baseUrls[0].replaceAll("/plugin-packs$", "") + "/revoked");
+        return props;
+    }
+
+    private NativePackService service(String pem, String... baseUrls) {
+        return new TestPackService(props(baseUrls), pem, "0.21.0");
+    }
+
+    /** 单组件 pack 的一站式发布（manifest + sig + 压缩包） */
+    private void publish(StubMirror mirror, byte[] archive, String unpackDir,
+                         List<String> platforms, boolean validSignature) throws Exception {
+        List<Map<String, Object>> components = List.of(
+                component("litviz", platforms, "litviz.tar.gz", archive, unpackDir));
+        publishManifest(mirror, components, validSignature, "0.1.0", 1, 1);
+        mirror.files.put("/" + PACK_ID + "/" + VERSION + "/litviz.tar.gz", archive);
+    }
+
+    private Map<String, Object> component(String name, List<String> platforms, String archiveName,
+                                          byte[] archive, String unpackDir) {
+        Map<String, Object> c = new LinkedHashMap<>();
+        c.put("name", name);
+        c.put("platforms", platforms);
+        c.put("archive", archiveName);
+        c.put("size", archive.length);
+        c.put("sha256", sha256Hex(archive));
+        c.put("unpackDir", unpackDir);
+        return c;
+    }
+
+    private void publishManifest(StubMirror mirror, List<Map<String, Object>> components,
+                                 boolean validSignature, String minAppVersion,
+                                 int engineApi, int schema) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"schema\":").append(schema)
+                .append(",\"id\":\"").append(PACK_ID).append('"')
+                .append(",\"version\":\"").append(VERSION).append('"')
+                .append(",\"publishedAt\":\"2026-08-20T00:00:00Z\"")
+                .append(",\"minAppVersion\":\"").append(minAppVersion).append('"')
+                .append(",\"engineApi\":").append(engineApi)
+                .append(",\"components\":[");
+        for (int i = 0; i < components.size(); i++) {
+            Map<String, Object> c = components.get(i);
+            if (i > 0) sb.append(',');
+            sb.append("{\"name\":\"").append(c.get("name")).append('"')
+                    .append(",\"platforms\":[");
+            @SuppressWarnings("unchecked")
+            List<String> platforms = (List<String>) c.get("platforms");
+            for (int p = 0; p < platforms.size(); p++) {
+                if (p > 0) sb.append(',');
+                sb.append('"').append(platforms.get(p)).append('"');
+            }
+            sb.append("],\"archive\":\"").append(c.get("archive")).append('"')
+                    .append(",\"size\":").append(c.get("size"))
+                    .append(",\"sha256\":\"").append(c.get("sha256")).append('"')
+                    .append(",\"unpackDir\":\"").append(c.get("unpackDir")).append("\"}");
+        }
+        sb.append("]}");
+
+        byte[] manifest = sb.toString().getBytes(StandardCharsets.UTF_8);
+        Signature signer = Signature.getInstance("Ed25519");
+        signer.initSign(keyPair.getPrivate());
+        signer.update(validSignature ? manifest : "not-this-manifest".getBytes(StandardCharsets.UTF_8));
+        String sig = Base64.getEncoder().encodeToString(signer.sign());
+
+        mirror.files.put("/" + PACK_ID + "/manifest.json", manifest);
+        mirror.files.put("/" + PACK_ID + "/manifest.json.sig", sig.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void assertExtractRejected(byte[] archive, String expectedFragment) throws IOException {
+        Path file = tempDir.resolve("bad-" + System.nanoTime() + ".tar.gz");
+        Files.write(file, archive);
+        NativePackService svc = service(publicKeyPem, "https://example.invalid/plugin-packs");
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> svc.extract(file, tempDir.resolve("out-" + System.nanoTime())));
+        assertTrue(e.getMessage().contains(expectedFragment), e.getMessage());
+    }
+
+    // ---------- tar.gz 构造 ----------
+
+    private static byte[] tarGz(java.util.function.Consumer<TarBuilder> writer) throws IOException {
+        TarBuilder tar = new TarBuilder();
+        writer.accept(tar);
+        return tar.gzip();
+    }
+
+    /** 常规组件包：内容文件 + 自动生成的 contents.sha256 */
+    private static byte[] tarGzWithContents(Map<String, byte[]> files) throws IOException {
+        Map<String, byte[]> ordered = new LinkedHashMap<>(files);
+        return tarGz(tar -> {
+            StringBuilder list = new StringBuilder();
+            for (Map.Entry<String, byte[]> e : ordered.entrySet()) {
+                tar.file(e.getKey(), e.getValue());
+                list.append(sha256Hex(e.getValue())).append("  ").append(e.getKey()).append('\n');
+            }
+            tar.file(CONTENTS, list.toString().getBytes(StandardCharsets.UTF_8));
+        });
+    }
+
+    /**
+     * 极简 ustar 写入器。
+     *
+     * <p>不用 commons-compress 的 {@code TarArchiveOutputStream}：它的写入端依赖
+     * commons-lang3 3.14+（ArrayFill），而 Spring Boot BOM 把 lang3 锁在 3.13，
+     * 一写就 NoClassDefFoundError。读取端（被测代码走的那条路）不受影响，
+     * 所以只在测试里自己拼 512 字节头，别为了造测试数据去动生产依赖的版本。
+     */
+    private static class TarBuilder {
+        private final ByteArrayOutputStream raw = new ByteArrayOutputStream();
+
+        void file(String name, byte[] data) {
+            entry(name, data, '0', "", 0644);
+        }
+
+        void symlink(String name, String target) {
+            entry(name, new byte[0], '2', target, 0777);
+        }
+
+        private void entry(String name, byte[] data, char type, String linkName, int mode) {
+            byte[] h = new byte[512];
+            ascii(h, 0, name, 100);
+            octal(h, 100, 8, mode);
+            octal(h, 108, 8, 0);
+            octal(h, 116, 8, 0);
+            octal(h, 124, 12, data.length);
+            octal(h, 136, 12, 0);
+            for (int i = 148; i < 156; i++) h[i] = ' ';
+            h[156] = (byte) type;
+            ascii(h, 157, linkName, 100);
+            ascii(h, 257, "ustar", 6);
+            h[263] = '0';
+            h[264] = '0';
+            int sum = 0;
+            for (byte b : h) sum += b & 0xFF;
+            octal(h, 148, 7, sum);
+            h[154] = 0;
+            h[155] = ' ';
+            raw.writeBytes(h);
+            raw.writeBytes(data);
+            int pad = (512 - (data.length % 512)) % 512;
+            raw.writeBytes(new byte[pad]);
+        }
+
+        byte[] gzip() throws IOException {
+            raw.writeBytes(new byte[1024]);          // 两个空块 = 归档结束
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (java.util.zip.GZIPOutputStream gz = new java.util.zip.GZIPOutputStream(out)) {
+                gz.write(raw.toByteArray());
+            }
+            return out.toByteArray();
+        }
+
+        private static void ascii(byte[] h, int off, String s, int len) {
+            byte[] b = s.getBytes(StandardCharsets.UTF_8);
+            System.arraycopy(b, 0, h, off, Math.min(b.length, len - 1));
+        }
+
+        private static void octal(byte[] h, int off, int len, long value) {
+            String s = String.format("%0" + (len - 1) + "o", value);
+            System.arraycopy(s.getBytes(StandardCharsets.US_ASCII), 0, h, off, len - 1);
+        }
+    }
+
+    private static String sha256Hex(byte[] data) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    // ---------- 本地 HTTP 桩（支持 Range） ----------
+
+    private static class StubMirror {
+        record Request(String path, String range) {}
+
+        final Map<String, byte[]> files = new LinkedHashMap<>();
+        final List<Request> requests = new CopyOnWriteArrayList<>();
+        final List<String> rangeServed = new CopyOnWriteArrayList<>();
+        private final HttpServer server;
+
+        StubMirror() throws IOException {
+            server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            server.createContext("/", this::handle);
+            server.start();
+        }
+
+        String baseUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/plugin-packs";
+        }
+
+        void stop() {
+            server.stop(0);
+        }
+
+        private void handle(HttpExchange ex) throws IOException {
+            String path = ex.getRequestURI().getPath().replaceFirst("^/plugin-packs", "");
+            String range = ex.getRequestHeaders().getFirst("Range");
+            requests.add(new Request(path, range));
+            byte[] body = files.get(path);
+            if (body == null) {
+                ex.sendResponseHeaders(404, -1);
+                ex.close();
+                return;
+            }
+            int from = 0;
+            if (range != null && range.startsWith("bytes=")) {
+                from = Integer.parseInt(range.substring("bytes=".length()).replace("-", ""));
+                rangeServed.add(range);
+            }
+            byte[] slice = java.util.Arrays.copyOfRange(body, Math.min(from, body.length), body.length);
+            if (from > 0) {
+                ex.getResponseHeaders().add("Content-Range",
+                        "bytes " + from + "-" + (body.length - 1) + "/" + body.length);
+                ex.sendResponseHeaders(206, slice.length);
+            } else {
+                ex.sendResponseHeaders(200, slice.length);
+            }
+            try (OutputStream out = ex.getResponseBody()) {
+                out.write(slice);
+            }
+            ex.close();
+        }
+    }
+}

--- a/deploy/publish-pack.sh
+++ b/deploy/publish-pack.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# publish-pack.sh — 校验、签名、发布 native pack 到两台官网镜像
+# （docs/NATIVE_PACK_DISTRIBUTION.md §3/§7.3）。骨架照抄 publish-lowa-engine.sh。
+#
+# 在**本机**运行（不是服务器上）：
+#
+#   bash deploy/publish-pack.sh check   <本地产物目录>
+#     只在本地验产物，不碰网络：manifest.json 字段完整、每个组件的实物 sha256/size
+#     与 manifest 声明一致、tar 可解、条目防护抽查（无绝对路径/../条目、无符号链接
+#     残留——build-pack.js 打包时已 -h 物化过软链，出现说明产物不对劲）。
+#
+#   bash deploy/publish-pack.sh sign <本地产物目录>
+#     ssh 到北京官网机，在服务器上用官网应用 env 里的 AWD_PLUGIN_SIGNING_KEY 对
+#     manifest.json 的原始字节做 Ed25519 签名，取回 manifest.json.sig 写进本地
+#     产物目录。私钥全程只在服务器内存里过一次：不落本机、不进任何本地/远端日志、
+#     远端临时文件签完即删。
+#
+#   bash deploy/publish-pack.sh publish <本地产物目录> <id> <版本号>
+#     先 check，要求 manifest.json.sig 已经存在（没有就提示先跑 sign）。
+#     传北京 /www/wwwroot/plugin-packs/<id>/<版本号>/（先落 /root/pack-staging 暂存，
+#     逐组件复核 sha256/size 通过才 rename 换入 —— 半截产物不会出现在对外目录）→
+#     新加坡用它自己的 sg_to_bj 密钥从北京拉取同步、同样暂存校验后换入 →
+#     两台机各自 curl 公网镜像逐组件核对 sha256/size（终验）→ 全部通过才把
+#     manifest.json + manifest.json.sig 复制为 <id>/manifest.json（+.sig）—— 这是
+#     客户端实际读取的「最新版」指针，指针切换发生在两台机都验证通过之后，
+#     且两台机都要切（lowa r4 只传北京、CI 从新加坡拉到 404 的教训，见
+#     publish-lowa-engine.sh 顶部注释）。
+#
+#   bash deploy/publish-pack.sh verify <id> <版本号>
+#     独立验证：分别 curl 北京（www.aiworkdeck.com）与新加坡（workdeck.ai）两个公网
+#     镜像的 manifest 与各组件 archive，逐一核对 sha256/size。publish 内部也会跑
+#     这一步；单独调用用于事后复核或排障。
+#
+# 例：
+#   bash deploy/publish-pack.sh check ~/Downloads/pack-litigation-visual-v1.0.0
+#   bash deploy/publish-pack.sh sign ~/Downloads/pack-litigation-visual-v1.0.0
+#   bash deploy/publish-pack.sh publish ~/Downloads/pack-litigation-visual-v1.0.0 litigation-visual 1.0.0
+#   bash deploy/publish-pack.sh verify litigation-visual 1.0.0
+
+set -euo pipefail
+
+BJ_HOST="${BJ_HOST:-root@8.152.169.44}"
+SG_HOST="${SG_HOST:-root@8.219.94.204}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
+SG_TO_BJ_KEY="${SG_TO_BJ_KEY:-/root/.ssh/sg_to_bj}"      # 存放在**新加坡**机器上
+PACKS_ROOT="${PACKS_ROOT:-/www/wwwroot/plugin-packs}"
+STAGE_ROOT="${STAGE_ROOT:-/root/pack-staging}"           # web root 之外
+# 官网 Next.js 应用的 env 文件（AWD_PLUGIN_SIGNING_KEY 就存在这里，见
+# .agent/ACCOUNTS.md「官网服务器密钥」与 OPERATIONS.md 的官网部署路径）。
+WEBSITE_ENV_FILE="${WEBSITE_ENV_FILE:-/www/wwwroot/www.aiworkdeck.com/new/.env.local}"
+SYNC_TIMEOUT="${SYNC_TIMEOUT:-600}"
+
+BJ_BASE_URL="${BJ_BASE_URL:-https://www.aiworkdeck.com}"
+SG_BASE_URL="${SG_BASE_URL:-https://workdeck.ai}"
+
+SSH="ssh -i $SSH_KEY -o IdentitiesOnly=yes -o ConnectTimeout=20"
+
+die() { echo "错误：$*" >&2; exit 1; }
+step() { echo; echo "== $*"; }
+
+# macOS 没有 sha256sum（只有 shasum）
+if command -v sha256sum >/dev/null 2>&1; then sha256() { sha256sum; }
+else sha256() { shasum -a 256; }; fi
+sha256_of() { sha256 < "$1" | cut -d' ' -f1; }
+filesize() { stat -f%z "$1" 2>/dev/null || stat -c%s "$1"; }
+
+valid_id() {
+  [[ "$1" =~ ^[a-z0-9][a-z0-9-]{1,49}$ ]] || die "id 不合法（须匹配 ^[a-z0-9][a-z0-9-]{1,49}\$）：$1"
+}
+valid_version() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] || die "版本号只允许 [A-Za-z0-9._-]，收到：$1"
+}
+
+usage() {
+  cat >&2 <<'EOF'
+用法：
+  publish-pack.sh check   <本地产物目录>                本地验产物，不碰网络
+  publish-pack.sh sign    <本地产物目录>                服务器侧签名，取回 .sig
+  publish-pack.sh publish <本地产物目录> <id> <版本号>   推两台镜像并验证、切指针
+  publish-pack.sh verify  <id> <版本号>                 只验证两台镜像上的产物
+EOF
+  exit 2
+}
+
+# ---------------------------------------------------------------- check
+# manifest 里读出 "<name>\t<archive>\t<size>\t<sha256>"，每行一个组件。
+manifest_components_tsv() {
+  local manifest="$1"
+  # 用 %-格式化而非 f-string：这段 python 源码整体嵌在 bash 单引号字符串里，
+  # f-string 表达式里的 c["key"] 会与外层引号打架，%-格式化没有这个问题。
+  python3 -c '
+import json, sys
+m = json.load(open(sys.argv[1]))
+for c in m["components"]:
+    print("%s\t%s\t%s\t%s" % (c["name"], c["archive"], c["size"], c["sha256"]))
+' "$manifest"
+}
+
+cmd_check() {
+  local dir="$1"
+  [ -d "$dir" ] || die "目录不存在：$dir"
+  local manifest="$dir/manifest.json"
+  [ -f "$manifest" ] || die "缺 manifest.json：$manifest"
+
+  step "manifest.json 字段完整性"
+  python3 - "$manifest" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1]))
+required = ["schema", "id", "version", "publishedAt", "minAppVersion", "engineApi", "components"]
+missing = [k for k in required if k not in m]
+if missing:
+    print("缺字段:", missing); sys.exit(1)
+if not isinstance(m["components"], list) or not m["components"]:
+    print("components 为空"); sys.exit(1)
+for c in m["components"]:
+    for k in ("name", "platforms", "archive", "size", "sha256", "unpackDir"):
+        if k not in c:
+            print("组件缺字段:", c.get("name"), k); sys.exit(1)
+print(f"OK，{len(m['components'])} 个组件")
+PY
+
+  step "逐组件对账实物（size / sha256）+ tar 完整性 + 条目防护抽查"
+  local name archive want_size want_sha archpath got_size got_sha entries
+  while IFS=$'\t' read -r name archive want_size want_sha; do
+    [ -n "$name" ] || continue
+    archpath="$dir/$archive"
+    [ -f "$archpath" ] || die "组件 $name 的产物缺失：$archpath"
+
+    got_size=$(filesize "$archpath")
+    [ "$got_size" = "$want_size" ] || die "组件 $name 体积不符：manifest=$want_size 实物=$got_size"
+    got_sha=$(sha256_of "$archpath")
+    [ "$got_sha" = "$want_sha" ] || die "组件 $name sha256 不符：manifest=$want_sha 实物=$got_sha"
+
+    entries=$(tar tzf "$archpath" 2>/dev/null) || die "组件 $name 的 tar 无法解出条目列表：$archive"
+    if grep -qE '^/|(^|/)\.\./' <<< "$entries"; then
+      die "组件 $name 的 tar 里有绝对路径或 .. 条目，疑似 zip-slip：$archive"
+    fi
+    if tar tvzf "$archpath" 2>/dev/null | awk '{print substr($1,1,1)}' | grep -q '^l$'; then
+      die "组件 $name 的 tar 里有符号链接条目（build-pack.js 打包时应已 -h 物化）：$archive"
+    fi
+    echo "  $name  $archive  ${got_size} bytes  sha256 OK  tar 条目 $(wc -l <<< "$entries" | tr -d ' ') 个"
+  done < <(manifest_components_tsv "$manifest")
+
+  echo; echo "本地校验通过：$dir"
+}
+
+# ---------------------------------------------------------------- sign
+cmd_sign() {
+  local dir="$1"
+  local manifest="$dir/manifest.json"
+  [ -f "$manifest" ] || die "缺 manifest.json：$manifest"
+
+  local remote_tmp="/root/pack-sign-$$"
+  step "上传 manifest.json 到服务器临时目录（不进 web root）"
+  $SSH "$BJ_HOST" "mkdir -p '$remote_tmp'"
+  scp -i "$SSH_KEY" -o IdentitiesOnly=yes -q "$manifest" "$BJ_HOST:$remote_tmp/manifest.json"
+
+  step "服务器侧 Ed25519 签名（私钥只在服务器内存里过一次，不落本机、不进日志）"
+  local sig
+  set +e
+  sig=$($SSH "$BJ_HOST" "bash -s -- '$remote_tmp' '$WEBSITE_ENV_FILE'" <<'REMOTE'
+set -euo pipefail
+remote_tmp="$1"; env_file="$2"
+[ -f "$env_file" ] || { echo "官网 env 文件不存在：$env_file" >&2; exit 1; }
+key_line=$(grep -m1 '^AWD_PLUGIN_SIGNING_KEY=' "$env_file" || true)
+[ -n "$key_line" ] || { echo "$env_file 里没有 AWD_PLUGIN_SIGNING_KEY" >&2; exit 1; }
+key_value="${key_line#AWD_PLUGIN_SIGNING_KEY=}"
+# 去掉包裹的引号（Next.js env 文件常见写法）
+key_value="${key_value%\"}"; key_value="${key_value#\"}"
+key_value="${key_value%\'}"; key_value="${key_value#\'}"
+node -e '
+  const crypto = require("crypto");
+  const fs = require("fs");
+  // 多行 PEM 若以 \n 转义存成单行，这里转回真换行；已是真换行的 PEM 不受影响。
+  const keyPem = process.argv[1].replace(/\\n/g, "\n");
+  const privateKey = crypto.createPrivateKey(keyPem);
+  const bytes = fs.readFileSync(process.argv[2]);
+  const sig = crypto.sign(null, bytes, privateKey);
+  process.stdout.write(sig.toString("base64"));
+' "$key_value" "$remote_tmp/manifest.json"
+REMOTE
+)
+  local rc=$?
+  set -e
+  # 无论成败都先清掉远端临时文件（manifest 本身不是秘密，但不该留垃圾）
+  $SSH "$BJ_HOST" "rm -rf '$remote_tmp'" || true
+  [ $rc -eq 0 ] || die "服务器侧签名失败（见上方远端报错）"
+  [ -n "$sig" ] || die "签名结果为空"
+
+  printf '%s' "$sig" > "$dir/manifest.json.sig"
+  echo "已写入：$dir/manifest.json.sig"
+}
+
+# ---------------------------------------------------------------- publish
+# 换入前在暂存区逐组件复核 size/sha256，通过才把 staging 目录 rename 进正式
+# 版本目录（同文件系统，原子）；旧同名版本目录 rename 进 .replaced.<ts> 备份，
+# 不直接覆盖（可回滚）。
+swap_in_pack() {
+  local ssh_target="$1" id="$2" version="$3"
+  $SSH "$ssh_target" "bash -s -- '$id' '$version' '$PACKS_ROOT' '$STAGE_ROOT'" <<'REMOTE'
+set -euo pipefail
+id="$1"; version="$2"; packs_root="$3"; stage_root="$4"
+src="${stage_root}/${id}/${version}"
+dst="${packs_root}/${id}/${version}"
+[ -d "$src" ] || { echo "暂存目录不存在：$src" >&2; exit 1; }
+[ -f "$src/manifest.json" ] || { echo "暂存目录缺 manifest.json：$src" >&2; exit 1; }
+python3 - "$src" <<'PY'
+import hashlib, json, os, sys
+src = sys.argv[1]
+m = json.load(open(os.path.join(src, "manifest.json")))
+for c in m["components"]:
+    p = os.path.join(src, c["archive"])
+    if not os.path.isfile(p):
+        print("缺产物:", c["archive"]); sys.exit(1)
+    if os.path.getsize(p) != c["size"]:
+        print("体积不符:", c["archive"]); sys.exit(1)
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    if h.hexdigest() != c["sha256"]:
+        print("sha256 不符:", c["archive"]); sys.exit(1)
+print("暂存区校验通过，共", len(m["components"]), "个组件")
+PY
+mkdir -p "$(dirname "$dst")"
+if [ -d "$dst" ]; then
+  mv "$dst" "${dst}.replaced.$(date +%Y%m%d-%H%M%S)"
+fi
+mv "$src" "$dst"
+chmod 755 "$dst"
+find "$dst" -maxdepth 1 -type f -exec chmod 644 {} +
+echo "已换入：$dst"
+REMOTE
+}
+
+# 新加坡侧：用它自己的 sg_to_bj 密钥从北京（此时已换入正式目录）拉取，带重试。
+sg_pull_pack() {
+  local id="$1" version="$2"
+  $SSH "$SG_HOST" "bash -s -- '$id' '$version' '$BJ_HOST' '$SG_TO_BJ_KEY' '$PACKS_ROOT' '$STAGE_ROOT' '$SYNC_TIMEOUT'" <<'REMOTE'
+set -euo pipefail
+id="$1"; version="$2"; bj_host="$3"; key="$4"; packs_root="$5"; stage_root="$6"; timeout="$7"
+dst_stage="${stage_root}/${id}/${version}"
+rm -rf "$dst_stage"
+mkdir -p "$dst_stage"
+rc=1
+for i in 1 2 3; do
+  if rsync -a --partial --timeout="$timeout" \
+      -e "ssh -i ${key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ServerAliveInterval=15" \
+      "${bj_host}:${packs_root}/${id}/${version}/" "${dst_stage}/"; then
+    rc=0; break
+  fi
+  echo "第 $i 次 rsync 失败，10 秒后重试" >&2
+  sleep 10
+done
+[ $rc -eq 0 ] || { echo "新加坡拉取北京失败" >&2; exit 1; }
+REMOTE
+  swap_in_pack "$SG_HOST" "$id" "$version"
+}
+
+# 单个镜像的公网终验：curl manifest，逐组件核对远端 Content-Length 与内容 sha256。
+verify_mirror() {
+  local base="$1" id="$2" version="$3"
+  local manifest_url="$base/plugin-packs/$id/$version/manifest.json"
+  local body
+  body=$(curl -sf "$manifest_url") || { echo "  manifest 不可达：$manifest_url"; return 1; }
+  local lines
+  lines=$(python3 -c '
+import json, sys
+m = json.loads(sys.argv[1])
+for c in m["components"]:
+    print("%s\t%s\t%s" % (c["archive"], c["size"], c["sha256"]))
+' "$body") || { echo "  manifest 不是合法 JSON：$manifest_url"; return 1; }
+
+  local ok=0 archive size sha url got_size got_sha
+  while IFS=$'\t' read -r archive size sha; do
+    [ -n "$archive" ] || continue
+    url="$base/plugin-packs/$id/$version/$archive"
+    got_size=$(curl -sI "$url" | tr -d '\r' | awk -F': ' 'tolower($1)=="content-length"{print $2}' | tail -1)
+    if [ "$got_size" != "$size" ]; then
+      echo "  $archive 体积不符：manifest=$size 实得=$got_size"
+      ok=1
+      continue
+    fi
+    got_sha=$(curl -s "$url" | sha256 | cut -d' ' -f1)
+    if [ "$got_sha" != "$sha" ]; then
+      echo "  $archive sha256 不符"
+      ok=1
+      continue
+    fi
+    echo "  $archive OK（${got_size} bytes，sha256 ${got_sha:0:16}…）"
+  done <<< "$lines"
+  return $ok
+}
+
+cmd_verify() {
+  local id="$1" version="$2"
+  valid_id "$id"; valid_version "$version"
+  local rc=0
+  step "验证北京（$BJ_BASE_URL）"
+  verify_mirror "$BJ_BASE_URL" "$id" "$version" || rc=1
+  step "验证新加坡（$SG_BASE_URL）"
+  verify_mirror "$SG_BASE_URL" "$id" "$version" || rc=1
+  echo
+  if [ $rc -eq 0 ]; then
+    echo "两站校验通过：$id@$version"
+  else
+    echo "校验未通过：$id@$version" >&2
+  fi
+  return $rc
+}
+
+# 指针切换：把版本目录里的 manifest.json(+.sig) 原子复制为 <id>/manifest.json(.sig)，
+# 客户端与安装脚本读的正是这个「最新版」指针（no-cache，见 nginx 配置）。
+switch_pointer() {
+  local ssh_target="$1" id="$2" version="$3"
+  $SSH "$ssh_target" "bash -s -- '$id' '$version' '$PACKS_ROOT'" <<'REMOTE'
+set -euo pipefail
+id="$1"; version="$2"; packs_root="$3"
+src="${packs_root}/${id}/${version}"
+for f in manifest.json manifest.json.sig; do
+  [ -f "$src/$f" ] || { echo "版本目录缺 $f，无法切指针：$src" >&2; exit 1; }
+  tmp="${packs_root}/${id}/.${f}.tmp"
+  cp "$src/$f" "$tmp"
+  mv "$tmp" "${packs_root}/${id}/${f}"
+done
+chmod 644 "${packs_root}/${id}"/manifest.json "${packs_root}/${id}"/manifest.json.sig
+echo "指针已切换到 ${version}：${packs_root}/${id}/manifest.json"
+REMOTE
+}
+
+cmd_publish() {
+  local dir="$1" id="$2" version="$3"
+  valid_id "$id"; valid_version "$version"
+
+  cmd_check "$dir"
+  [ -f "$dir/manifest.json.sig" ] || die "缺 manifest.json.sig，先跑：bash $0 sign $dir"
+
+  step "上传到北京暂存区 ${STAGE_ROOT}/${id}/${version}/（web root 之外）"
+  $SSH "$BJ_HOST" "mkdir -p '$STAGE_ROOT/$id/$version'"
+  rsync -a --partial --partial-dir=/root/.pack-partial --timeout="$SYNC_TIMEOUT" -e "$SSH" \
+    "$dir"/ "$BJ_HOST:$STAGE_ROOT/$id/$version/"
+
+  step "北京：校验暂存区并换入正式版本目录（immutable）"
+  swap_in_pack "$BJ_HOST" "$id" "$version"
+
+  step "新加坡：用 sg_to_bj 拉取同步并换入"
+  sg_pull_pack "$id" "$version"
+
+  step "双机公网终验（manifest + 各组件 sha256）"
+  local rc=0
+  verify_mirror "$BJ_BASE_URL" "$id" "$version" || rc=1
+  verify_mirror "$SG_BASE_URL" "$id" "$version" || rc=1
+  [ $rc -eq 0 ] || die "双机终验未通过，不切换 <id>/manifest.json 指针（版本目录已就位，可重试 verify 排障）"
+
+  step "切指针：两台机都把该版本设为 <id>/manifest.json（no-cache）"
+  switch_pointer "$BJ_HOST" "$id" "$version"
+  switch_pointer "$SG_HOST" "$id" "$version"
+
+  echo; echo "发布完成：$id@$version"
+}
+
+# ---------------------------------------------------------------- main
+[ $# -ge 1 ] || usage
+case "${1:-}" in
+  check)   [ $# -eq 2 ] || usage; cmd_check "$2";;
+  sign)    [ $# -eq 2 ] || usage; cmd_sign "$2";;
+  publish) [ $# -eq 4 ] || usage; cmd_publish "$2" "$3" "$4";;
+  verify)  [ $# -eq 3 ] || usage; cmd_verify "$2" "$3";;
+  *) usage;;
+esac

--- a/desktop/main/drawio-server.js
+++ b/desktop/main/drawio-server.js
@@ -16,7 +16,9 @@
 // 实例 / dev 与打包版并存）就退回随机端口，功能不受影响，只是少了跨启动的缓存复用。
 
 const path = require('path')
+const os = require('node:os')
 const http = require('node:http')
+const fs = require('node:fs')
 const { stat } = require('node:fs/promises')
 const { createReadStream } = require('node:fs')
 
@@ -27,6 +29,38 @@ const FIXED_PORT = 47614 // zetaoffice 用 47613，挨着放便于排查
 function electronApp() {
   try {
     return require('electron').app
+  } catch (e) {
+    return null
+  }
+}
+
+// native pack（docs/NATIVE_PACK_DISTRIBUTION.md）：诉讼可视化的 draw.io 资源摘出
+// 安装包之后，广场下载安装到 <home>/.aiworkdeck/packs/litigation-visual/<version>/drawio。
+const PACK_ID = 'litigation-visual'
+const PACK_COMPONENT = 'drawio'
+
+// packs 根目录：AIWORKDECK_PACKS_DIR 覆盖仅供单测/开发指向临时目录，
+// 与 AIWORKDECK_DRAWIO_DIR 是同一套「显式覆盖」思路，正常运行时走
+// <home>/.aiworkdeck/packs（与 overlay.js 的 dataDir 同一个 home 惯例）。
+function packsBaseDir() {
+  if (process.env.AIWORKDECK_PACKS_DIR) return process.env.AIWORKDECK_PACKS_DIR
+  const app = electronApp()
+  const home = (app && app.getPath('home')) || os.homedir()
+  return path.join(home, '.aiworkdeck', 'packs')
+}
+
+// pack 根惰性解析：每次调用都现读 current.json，装完即生效、Electron 不需要重启
+// （NATIVE_PACK_DISTRIBUTION.md §4.4）。fs 开销可忽略，不做任何缓存。
+// 三种情况判定该根不参与：current.json 缺失/不是合法 JSON、revoked:true、
+// 指向的版本目录没有 .pack-complete 完成标记。
+function packRoot() {
+  try {
+    const packDir = path.join(packsBaseDir(), PACK_ID)
+    const cur = JSON.parse(fs.readFileSync(path.join(packDir, 'current.json'), 'utf8'))
+    if (!cur || typeof cur.version !== 'string' || cur.revoked === true) return null
+    const versionDir = path.join(packDir, cur.version)
+    if (!fs.existsSync(path.join(versionDir, '.pack-complete'))) return null
+    return path.join(versionDir, PACK_COMPONENT)
   } catch (e) {
     return null
   }
@@ -52,9 +86,11 @@ const TYPES = {
 
 let serverPromise = null
 
-// AIWORKDECK_DRAWIO_DIR 覆盖资源目录：dev 时指向自己解出来的 draw.io，
-// 单测里指向临时目录。与后端那侧注入 LITVIZ_DIR / AWD_PYTHON_HOME 同一套思路。
-function drawioRoot() {
+// 单根解析（内置资源）：AIWORKDECK_DRAWIO_DIR 覆盖优先——dev 时指向自己解出来的
+// draw.io，单测里指向临时目录（与后端那侧注入 LITVIZ_DIR / AWD_PYTHON_HOME 同一套
+// 思路）；否则打包态取 Resources/frontend/dist/drawio，dev 态取源树里的
+// frontend/dist/drawio（跑过 fetch-drawio-assets.js 才有）。
+function builtinRoot() {
   if (process.env.AIWORKDECK_DRAWIO_DIR) return process.env.AIWORKDECK_DRAWIO_DIR
   const app = electronApp()
   return app && app.isPackaged
@@ -62,14 +98,30 @@ function drawioRoot() {
     : path.join(__dirname, '../../frontend/dist/drawio')
 }
 
-/** draw.io 资源是否已烙进本次构建。dev 树上没跑过 fetch 脚本时为 false。 */
+// 请求时按序命中的根列表（NATIVE_PACK_DISTRIBUTION.md §4.4，照抄
+// zetaoffice-server.js editorRoots() 的双根手法，这里是两根）：
+//   1. 内置根（builtinRoot，含 AIWORKDECK_DRAWIO_DIR 覆盖）——只有目录里真的有
+//      index.html 才算一根，不存在就跳过（老版本随包资源仍在时优先用它，
+//      不强迫改吃 pack）。
+//   2. pack 当前版本目录——惰性解析，见 packRoot()。
+function drawioRoots() {
+  const roots = []
+  const builtin = builtinRoot()
+  if (fs.existsSync(path.join(builtin, 'index.html'))) roots.push(builtin)
+  const pr = packRoot()
+  if (pr) roots.push(pr)
+  return roots
+}
+
+/** draw.io 资源是否在任一根就位（内置或 pack 皆可）。 */
 async function isAvailable() {
-  try {
-    const st = await stat(path.join(drawioRoot(), 'index.html'))
-    return st.isFile()
-  } catch (e) {
-    return false
+  for (const root of drawioRoots()) {
+    try {
+      const st = await stat(path.join(root, 'index.html'))
+      if (st.isFile()) return true
+    } catch (e) { /* 该根没有，试下一根 */ }
   }
+  return false
 }
 
 /**
@@ -78,20 +130,28 @@ async function isAvailable() {
  */
 function startDrawioServer() {
   if (serverPromise) return serverPromise
-  const root = drawioRoot()
   serverPromise = new Promise((resolve, reject) => {
     const s = http.createServer(async (req, res) => {
       try {
         let urlPath = decodeURIComponent((req.url || '/').split('?')[0])
         if (urlPath === '/') urlPath = '/index.html'
-        const filePath = path.normalize(path.join(root, urlPath))
-        // 路径穿越防护：URL 是不可信输入，normalize 之后必须仍在根下。
-        if (filePath !== root && !filePath.startsWith(root + path.sep)) {
-          res.writeHead(403).end('forbidden')
-          return
+        // 根列表每次请求现读（pack 装完即生效，不用重启 Electron）。
+        const roots = drawioRoots()
+        let hit = null
+        for (const root of roots) {
+          const filePath = path.normalize(path.join(root, urlPath))
+          // 路径穿越防护：URL 是不可信输入，normalize 之后必须仍在根下。
+          if (filePath !== root && !filePath.startsWith(root + path.sep)) {
+            res.writeHead(403).end('forbidden')
+            return
+          }
+          try {
+            const st = await stat(filePath)
+            if (st.isFile()) { hit = { filePath, st }; break }
+          } catch (e) { /* 该根没有此文件，试下一根 */ }
         }
-        const st = await stat(filePath)
-        if (!st.isFile()) throw new Error('not a file')
+        if (!hit) throw new Error('not found in any root')
+        const { filePath, st } = hit
         // ETag + no-cache：draw.io 升级后文件名多数不变（app.min.js 等），
         // 必须让浏览器回源校验；本地 304 只要 1ms，命中后仍复用已缓存的正文。
         const etag = '"' + st.size + '-' + Math.round(st.mtimeMs) + '"'
@@ -153,7 +213,17 @@ async function stopDrawioServer() {
   serverPromise = null
   try {
     const s = await p.then((r) => r.server)
-    if (s) await new Promise((resolve) => s.close(resolve))
+    if (s) {
+      // server.close() 只停止接受新连接，已建立的 keep-alive 连接（哪怕已经
+      // 处理完上一个请求、正闲置着）不会被它主动断开——callback 会等这些连接
+      // 自然结束才触发。单测里连续起停多个服务、且客户端复用了 keep-alive 连接时，
+      // 这条空档会让「close() 已 resolve」与「端口真的空出来」脱节：下一个服务
+      // 一样绑同一个 FIXED_PORT，客户端的连接池却仍拿着指向旧 server 的那个
+      // socket，一复用就是 ECONNRESET/socket hang up。closeAllConnections()
+      // 强制切断，保证 stop 完成时端口与连接都真正清干净。
+      if (typeof s.closeAllConnections === 'function') s.closeAllConnections()
+      await new Promise((resolve) => s.close(resolve))
+    }
   } catch (e) { /* 起都没起来，无需关闭 */ }
 }
 

--- a/desktop/main/services/backend-service.js
+++ b/desktop/main/services/backend-service.js
@@ -151,7 +151,11 @@ function spawnEnv(ctx) {
     }
     // 诉讼可视化引擎（litviz）与它要用的解释器。引擎是纯 stdlib，
     // 直接复用已经为 pysvc 打进来的那个 Python 3.11，不额外带运行时。
-    if (!env.LITVIZ_DIR) env.LITVIZ_DIR = path.join(res, 'litviz')
+    // litviz 摘出安装包后（native pack，见 docs/NATIVE_PACK_DISTRIBUTION.md）
+    // Resources/litviz 不一定存在，加 existsSync 守卫与 graphviz 那条对齐——
+    // 目录不存在就不注入，让后端走自己的解析链（pack 目录等）。
+    const litvizDir = path.join(res, 'litviz')
+    if (!env.LITVIZ_DIR && fs.existsSync(litvizDir)) env.LITVIZ_DIR = litvizDir
     if (!env.AWD_PYTHON_HOME) env.AWD_PYTHON_HOME = path.join(res, 'python')
     // graphviz 只有流程图布局要用；没打进来时留空，后端会如实降级报缺。
     const gvBin = path.join(res, 'graphviz', 'bin')

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiworkdeck-desktop",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiworkdeck-desktop",
-      "version": "0.17.0",
+      "version": "0.20.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js"
+    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/build-pack.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/scripts/build-pack.js
+++ b/desktop/scripts/build-pack.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/*
+ * build-pack.js — 把一个 native pack 的组件打成 tar.gz + 产出未签名 manifest.json
+ * （规范见 docs/NATIVE_PACK_DISTRIBUTION.md §2/§7.3）。
+ *
+ * 用法：
+ *   node desktop/scripts/build-pack.js --id litigation-visual --version 1.0.0 \
+ *     --out pack-out/mac --components litviz,drawio,graphviz
+ *
+ *   # 汇总 job：不在本机构建任何组件，只把别的平台产出的 manifest 合并进来
+ *   node desktop/scripts/build-pack.js --id litigation-visual --version 1.0.0 \
+ *     --out pack-out/final --merge pack-mac/manifest.json,pack-win/manifest.json
+ *
+ * 三个组件与其源目录（相对本仓库根，见 desktop/package.json 现有 extraResources）：
+ *   litviz    <repo>/litviz                             平台无关
+ *   drawio    <repo>/frontend/dist/drawio                平台无关，前置：fetch-drawio-assets.js
+ *   graphviz  desktop/bundled/<os>-<arch>/graphviz        平台相关，前置：prepare-graphviz.js
+ *
+ * manifest 在这里**不签名**——签名私钥只在服务器侧（deploy/publish-pack.sh sign），
+ * 不进 CI（NATIVE_PACK_DISTRIBUTION.md §1）。
+ */
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const crypto = require('crypto')
+const { execFileSync } = require('child_process')
+
+const REPO_ROOT = path.join(__dirname, '..', '..')
+const DESKTOP_ROOT = path.join(__dirname, '..')
+
+const MIN_APP_VERSION = '0.21.0'
+const ENGINE_API = 1
+
+function parseArgs() {
+  const out = {}
+  const argv = process.argv.slice(2)
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--') && i + 1 < argv.length) out[argv[i].slice(2)] = argv[++i]
+  }
+  for (const k of ['id', 'version', 'out']) {
+    if (!out[k]) {
+      console.error(`缺少 --${k}`)
+      process.exit(1)
+    }
+  }
+  return out
+}
+
+// 当前跑这个脚本的平台标签。native pack 目前只发两个目标，与
+// desktop/bundled/${os}-${arch} 的命名一致（见 desktop/package.json extraResources）。
+function platformTag() {
+  if (process.platform === 'darwin' && process.arch === 'arm64') return 'mac-arm64'
+  if (process.platform === 'win32' && process.arch === 'x64') return 'win-x64'
+  throw new Error(`不支持的平台：${process.platform}-${process.arch}（native pack 目前只发 mac-arm64 / win-x64）`)
+}
+
+// ---------------------------------------------------------------------------
+// 文件树遍历 + 哈希（用 stat 而非 lstat：跟随符号链接，与打包时 tar -h
+// 物化软链的语义保持一致——两边算出来的应当是同一份「解析后」的内容）。
+// ---------------------------------------------------------------------------
+
+function sha256File(filePath) {
+  const h = crypto.createHash('sha256')
+  h.update(fs.readFileSync(filePath))
+  return h.digest('hex')
+}
+
+// exclude: Array<(relPath, name, stat) => boolean>，命中任一条即跳过（目录命中则整棵子树跳过）
+function listFiles(dir, exclude) {
+  const out = []
+  function walk(d, rel) {
+    for (const name of fs.readdirSync(d).sort()) {
+      const relPath = rel ? rel + '/' + name : name
+      const abs = path.join(d, name)
+      let st
+      try {
+        st = fs.statSync(abs) // 跟随符号链接；断链直接跳过
+      } catch (e) {
+        continue
+      }
+      if (exclude.some((fn) => fn(relPath, name, st))) continue
+      if (st.isDirectory()) walk(abs, relPath)
+      else if (st.isFile()) out.push(relPath)
+    }
+  }
+  walk(dir, '')
+  return out
+}
+
+// tar czh：-h 在归档时物化软链（写入被指向的真实内容），与 contents.sha256
+// 用 fs.statSync/readFileSync（同样跟随符号链接）算出来的哈希对得上。
+// 用系统 tar：win runner 自带 bsdtar 支持同一组短选项。
+//
+// **-T <文件清单> 而不是整目录打包**：清单来自 listFiles(srcDir, exclude)，
+// 与 contents.sha256 用的是同一份文件列表——这样「哪些文件被排除」只有一处
+// 判据，不会出现「哈希清单排除了 __pycache__，但 tar 整目录打包时忘了排除」
+// 这种两条平行逻辑对不上的漂移。
+//
+// 包内顶层目录名固定为 topName（= manifest 的 unpackDir），**不依赖 srcDir 自身
+// 的目录名**：现有三个组件恰好 srcDir 的 basename 就是组件名（litviz/drawio/
+// graphviz），但显式控制更稳妥，也让打包函数可以对着任意名字的临时目录测试。
+// 做法是建一个指向 srcDir、名字是 topName 的软链，清单里的路径写成
+// topName/<relFile>，tar -h 经软链解析到真实内容。
+function tarPack(srcDir, relFiles, archivePath, topName) {
+  const linkParent = fs.mkdtempSync(path.join(os.tmpdir(), 'aiworkdeck-pack-link-'))
+  const linkPath = path.join(linkParent, topName)
+  const listPath = path.join(linkParent, '.tar-filelist')
+  try {
+    fs.symlinkSync(srcDir, linkPath, 'dir')
+    fs.writeFileSync(listPath, relFiles.map((rel) => `${topName}/${rel}`).join('\n') + '\n')
+    const env = { ...process.env }
+    if (process.platform === 'darwin') env.COPYFILE_DISABLE = '1' // 防 AppleDouble（._ 文件）
+    execFileSync('tar', ['-czhf', archivePath, '-C', linkParent, '-T', listPath], { stdio: 'inherit', env })
+  } finally {
+    fs.rmSync(linkParent, { recursive: true, force: true })
+  }
+}
+
+function packComponent(ctx, { name, srcDir, exclude, archive, platforms, unpackDir }) {
+  if (!fs.existsSync(srcDir)) throw new Error(`组件 ${name} 的源目录不存在：${srcDir}`)
+  const topName = unpackDir || name
+  const contentsRel = 'contents.sha256'
+  const contentsPath = path.join(srcDir, contentsRel)
+  fs.rmSync(contentsPath, { force: true }) // 防止上一次构建的残留干扰本次遍历/哈希
+
+  const files = listFiles(srcDir, exclude)
+  const lines = files.map((rel) => `${sha256File(path.join(srcDir, rel))}  ${rel}`)
+  fs.writeFileSync(contentsPath, lines.join('\n') + '\n')
+  try {
+    const archivePath = path.join(ctx.outDir, archive)
+    console.log(`打包 ${name} -> ${archivePath}（${files.length} 个文件）`)
+    tarPack(srcDir, [...files, contentsRel], archivePath, topName)
+    const st = fs.statSync(archivePath)
+    return {
+      name,
+      platforms,
+      archive,
+      size: st.size,
+      sha256: sha256File(archivePath),
+      unpackDir: topName,
+    }
+  } finally {
+    // 源树（尤其 litviz，是仓库里跟踪的源码目录）打包后必须恢复干净，不留生成物。
+    fs.rmSync(contentsPath, { force: true })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 各组件
+// ---------------------------------------------------------------------------
+
+function buildLitviz(ctx) {
+  const srcDir = path.join(REPO_ROOT, 'litviz')
+  const exclude = [
+    (relPath, name, st) => st.isDirectory() && name === '__pycache__',
+    (relPath, name, st) => st.isFile() && name.endsWith('.pyc'),
+  ]
+  return packComponent(ctx, {
+    name: 'litviz',
+    srcDir,
+    exclude,
+    archive: `litviz-${ctx.version}.tar.gz`,
+    platforms: ['*'],
+  })
+}
+
+function buildDrawio(ctx) {
+  const srcDir = path.join(REPO_ROOT, 'frontend', 'dist', 'drawio')
+  if (!fs.existsSync(path.join(srcDir, 'index.html'))) {
+    throw new Error(
+      `draw.io 资源未就位（${srcDir}）。先跑：node desktop/scripts/fetch-drawio-assets.js`
+    )
+  }
+  return packComponent(ctx, {
+    name: 'drawio',
+    srcDir,
+    exclude: [],
+    archive: `drawio-${ctx.version}.tar.gz`,
+    platforms: ['*'],
+  })
+}
+
+function buildGraphviz(ctx) {
+  const plat = platformTag()
+  const srcDir = path.join(DESKTOP_ROOT, 'bundled', plat, 'graphviz')
+  if (!fs.existsSync(srcDir)) {
+    throw new Error(
+      `graphviz 未打包（${srcDir}）。先跑：node desktop/scripts/prepare-graphviz.js --out desktop/bundled/${plat}`
+    )
+  }
+  return packComponent(ctx, {
+    name: 'graphviz',
+    srcDir,
+    exclude: [],
+    archive: `graphviz-${ctx.version}-${plat}.tar.gz`,
+    platforms: [plat],
+  })
+}
+
+const COMPONENT_BUILDERS = { litviz: buildLitviz, drawio: buildDrawio, graphviz: buildGraphviz }
+
+// ---------------------------------------------------------------------------
+// manifest 合并（汇总 job：mac 产的 litviz/drawio/graphviz-mac 与 win 产的
+// graphviz-win 各自半成品 manifest 合并成一份全量 manifest）。
+// ---------------------------------------------------------------------------
+
+function componentKey(c) {
+  return `${c.name}:${[...c.platforms].sort().join(',')}`
+}
+
+function mergeManifest(manifest, mergePath) {
+  const raw = fs.readFileSync(mergePath, 'utf8')
+  let other
+  try {
+    other = JSON.parse(raw)
+  } catch (e) {
+    throw new Error(`--merge 指向的文件不是合法 JSON：${mergePath}`)
+  }
+  if (other.id !== manifest.id || other.version !== manifest.version) {
+    throw new Error(
+      `--merge 的 manifest（${other.id}@${other.version}）与本次构建（${manifest.id}@${manifest.version}）不匹配：${mergePath}`
+    )
+  }
+  const seen = new Set(manifest.components.map(componentKey))
+  for (const c of other.components || []) {
+    const key = componentKey(c)
+    if (seen.has(key)) {
+      console.warn(`  跳过重复组件 ${key}（已存在于当前 manifest，来自 ${mergePath}）`)
+      continue
+    }
+    manifest.components.push(c)
+    seen.add(key)
+  }
+  return manifest
+}
+
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs()
+  const outDir = path.resolve(args.out)
+  fs.mkdirSync(outDir, { recursive: true })
+  const ctx = { id: args.id, version: args.version, outDir }
+
+  const componentNames = (args.components || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  const components = []
+  for (const name of componentNames) {
+    const builder = COMPONENT_BUILDERS[name]
+    if (!builder) throw new Error(`未知组件：${name}（可选 ${Object.keys(COMPONENT_BUILDERS).join('/')}）`)
+    components.push(builder(ctx))
+  }
+
+  let manifest = {
+    schema: 1,
+    id: ctx.id,
+    version: ctx.version,
+    publishedAt: new Date().toISOString(),
+    minAppVersion: MIN_APP_VERSION,
+    engineApi: ENGINE_API,
+    components,
+  }
+
+  if (args.merge) {
+    for (const mergePath of args.merge.split(',').map((s) => s.trim()).filter(Boolean)) {
+      console.log(`合并 manifest：${mergePath}`)
+      manifest = mergeManifest(manifest, mergePath)
+    }
+  }
+
+  if (manifest.components.length === 0) {
+    throw new Error('manifest 没有任何组件：既没有 --components 构建任何东西，--merge 也没带来组件')
+  }
+
+  const manifestPath = path.join(outDir, 'manifest.json')
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
+  console.log(`manifest（未签名）写入：${manifestPath}`)
+  for (const c of manifest.components) {
+    console.log(
+      `  - ${c.name} [${c.platforms.join(',')}] ${c.archive}  ${(c.size / 1024 / 1024).toFixed(2)} MB  sha256=${c.sha256.slice(0, 12)}…`
+    )
+  }
+}
+
+// CLI 入口只在直接执行本文件时跑；被 require() 当模块用时（单测）只取函数，
+// 不触发任何文件系统写入或子进程调用。
+if (require.main === module) {
+  try {
+    main()
+  } catch (e) {
+    console.error('build-pack 失败:', e.message)
+    process.exit(1)
+  }
+}
+
+module.exports = { packComponent, sha256File, listFiles, mergeManifest, componentKey, platformTag }

--- a/desktop/tests/build-pack.test.js
+++ b/desktop/tests/build-pack.test.js
@@ -1,0 +1,88 @@
+// build-pack.js 的最小单测：打一个小的自造目录，断言 manifest 的 sha256/size
+// 与包内 contents.sha256 都算对了，且排除规则（__pycache__/*.pyc）真的生效、
+// 源目录打包后不留 contents.sha256 残留（它若是仓库里跟踪的源码目录，残留会
+// 污染 git 状态——litviz 组件正是这种情况）。
+//
+// 直接 require 脚本导出的 packComponent()，不经 CLI 子进程、不碰真实的
+// litviz/frontend/dist/drawio/desktop/bundled 目录，全程只操作临时目录。
+
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const crypto = require('crypto')
+const { execFileSync } = require('child_process')
+
+const { packComponent } = require('../scripts/build-pack')
+
+function sha256Of(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+test('打包一个自造小目录：manifest 的 size/sha256 与 contents.sha256 都对，排除规则生效', (t) => {
+  const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'build-pack-'))
+  t.after(() => fs.rmSync(workRoot, { recursive: true, force: true }))
+
+  // 一份小的自造「组件源」：两个正常文件 + 一个该被排除的 __pycache__ 目录
+  // 和一个散落的 .pyc，验证 litviz 组件真实使用的排除谓词。
+  const srcDir = path.join(workRoot, 'fake-litviz')
+  fs.mkdirSync(path.join(srcDir, 'engine'), { recursive: true })
+  fs.writeFileSync(path.join(srcDir, 'cli.py'), 'print(1)\n')
+  fs.writeFileSync(path.join(srcDir, 'engine', 'core.py'), 'x = 1\n')
+  fs.mkdirSync(path.join(srcDir, '__pycache__'), { recursive: true })
+  fs.writeFileSync(path.join(srcDir, '__pycache__', 'cli.cpython-311.pyc'), 'binary-junk')
+  fs.writeFileSync(path.join(srcDir, 'engine', 'core.pyc'), 'binary-junk')
+
+  const exclude = [
+    (relPath, name, st) => st.isDirectory() && name === '__pycache__',
+    (relPath, name, st) => st.isFile() && name.endsWith('.pyc'),
+  ]
+
+  const outDir = path.join(workRoot, 'out')
+  fs.mkdirSync(outDir, { recursive: true })
+  const ctx = { id: 'litigation-visual', version: '0.0.1-test', outDir }
+
+  const comp = packComponent(ctx, {
+    name: 'litviz',
+    srcDir,
+    exclude,
+    archive: 'litviz-0.0.1-test.tar.gz',
+    platforms: ['*'],
+  })
+
+  assert.strictEqual(comp.name, 'litviz')
+  assert.strictEqual(comp.unpackDir, 'litviz')
+  assert.deepStrictEqual(comp.platforms, ['*'])
+  assert.strictEqual(comp.archive, 'litviz-0.0.1-test.tar.gz')
+
+  const archivePath = path.join(outDir, comp.archive)
+  assert.ok(fs.existsSync(archivePath), '声明的 archive 文件应当存在')
+  assert.strictEqual(fs.statSync(archivePath).size, comp.size, 'manifest 组件的 size 必须等于实际文件大小')
+  assert.strictEqual(sha256Of(archivePath), comp.sha256, 'manifest 组件的 sha256 必须等于实际文件哈希')
+
+  // 源目录打包后不该留下 contents.sha256 残留（对着仓库里跟踪的源码目录跑时，
+  // 这条防的是「git status 多出一个文件」）。
+  assert.ok(!fs.existsSync(path.join(srcDir, 'contents.sha256')), '打包后源目录不该留下 contents.sha256')
+
+  // 解开 tar，核对包内 contents.sha256 记的哈希与解出来的文件逐一一致，
+  // 并且 __pycache__/*.pyc 确实被排除在外。
+  const extractDir = path.join(workRoot, 'extract')
+  fs.mkdirSync(extractDir, { recursive: true })
+  execFileSync('tar', ['-xzf', archivePath, '-C', extractDir])
+
+  assert.ok(!fs.existsSync(path.join(extractDir, 'litviz', '__pycache__')), '__pycache__ 目录不该被打进包里')
+  assert.ok(!fs.existsSync(path.join(extractDir, 'litviz', 'engine', 'core.pyc')), '.pyc 文件不该被打进包里')
+  assert.ok(fs.existsSync(path.join(extractDir, 'litviz', 'cli.py')), '正常文件应当在包里')
+
+  const contentsSha = fs.readFileSync(path.join(extractDir, 'litviz', 'contents.sha256'), 'utf8')
+  const lines = contentsSha.trim().split('\n').filter(Boolean)
+  // 只有 cli.py / engine/core.py 两个正常文件，contents.sha256 不列自身
+  assert.strictEqual(lines.length, 2)
+  for (const line of lines) {
+    const [want, rel] = line.split('  ')
+    assert.ok(!rel.includes('__pycache__') && !rel.endsWith('.pyc'), `contents.sha256 不该列出被排除的文件：${rel}`)
+    const got = sha256Of(path.join(extractDir, 'litviz', rel))
+    assert.strictEqual(got, want, `contents.sha256 里 ${rel} 的哈希对不上解出来的文件`)
+  }
+})

--- a/desktop/tests/drawio-server.test.js
+++ b/desktop/tests/drawio-server.test.js
@@ -1,9 +1,11 @@
 // 内嵌 draw.io 静态服务的回归测试。
 //
-// 守两件真出过事故的东西：
+// 守几件真出过事故 / 明确设计契约的东西：
 // 1. URL 参数里的 stealth=1 —— 它是「案件材料不出网」这条红线在 draw.io 侧的落点。
 //    删掉之后功能完全正常，只是编辑器会开始往外发请求，没有测试就没人会发现。
 // 2. 路径穿越 —— URL 是不可信输入，静态服务把根目录之外的文件读出来是经典事故。
+// 3. native pack 多根查找（NATIVE_PACK_DISTRIBUTION.md §4.4）：内置根优先，
+//    pack 根惰性解析（revoked / 无完成标记的版本不参与）。
 
 const test = require('node:test')
 const assert = require('node:assert')
@@ -14,12 +16,37 @@ const http = require('http')
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-'))
 process.env.AIWORKDECK_DRAWIO_DIR = root
+// packs 根同样隔离到临时目录：不设的话会落到真实 <home>/.aiworkdeck/packs，
+// 在装过 native pack 的机器上会让下面「没资源」的用例变得不确定。
+const packsBase = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-packs-base-'))
+process.env.AIWORKDECK_PACKS_DIR = packsBase
 const { startDrawioServer, stopDrawioServer, drawioUrl, isAvailable } = require('../main/drawio-server')
+
+// 在给定 packs 根目录下造一份「装好的 pack」布局：
+//   <packsDir>/litigation-visual/current.json
+//   <packsDir>/litigation-visual/<version>/.pack-complete（除非 opts.noComplete）
+//   <packsDir>/litigation-visual/<version>/drawio/index.html
+function seedPack(packsDir, opts = {}) {
+  const version = opts.version || '1.0.0'
+  const versionDir = path.join(packsDir, 'litigation-visual', version)
+  fs.mkdirSync(path.join(versionDir, 'drawio'), { recursive: true })
+  fs.writeFileSync(path.join(versionDir, 'drawio', 'index.html'), opts.html || '<html>PACK-DRAWIO</html>')
+  if (!opts.noComplete) fs.writeFileSync(path.join(versionDir, '.pack-complete'), '')
+  const current = { version, activatedAt: new Date().toISOString() }
+  if (opts.revoked) current.revoked = true
+  fs.writeFileSync(path.join(packsDir, 'litigation-visual', 'current.json'), JSON.stringify(current))
+}
 
 function get(origin, urlPath) {
   return new Promise((resolve, reject) => {
     http
-      .get(origin + urlPath, (res) => {
+      // agent:false —— 这个文件里同一个 FIXED_PORT 会先后起停好几个不同的
+      // server 实例（每个用例各自的 pack/内置根）。默认全局 agent 会在请求间
+      // 复用 keep-alive socket；旧 server 关闭后，那个被复用的 socket 有一定
+      // 概率还没被 agent 摘出空闲池就被派给新请求，新 server 那头看到的是一个
+      // 半死的连接，直接 ECONNRESET（"socket hang up"）。禁用 agent 逼每次
+      // 请求都开新连接，端口复用测试才稳定。
+      .get(origin + urlPath, { agent: false }, (res) => {
         const chunks = []
         res.on('data', (c) => chunks.push(c))
         res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }))
@@ -71,4 +98,75 @@ test('烙好之后能起、能取文件、挡得住路径穿越', async (t) => {
 
   const missing = await get(origin, '/nope.js')
   assert.strictEqual(missing.status, 404)
+})
+
+test('pack 根命中：内置资源缺失时从 pack 提供文件', async (t) => {
+  const emptyBuiltin = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-builtin-empty-'))
+  const packsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-packs-'))
+  seedPack(packsDir)
+
+  process.env.AIWORKDECK_DRAWIO_DIR = emptyBuiltin
+  process.env.AIWORKDECK_PACKS_DIR = packsDir
+  t.after(async () => {
+    await stopDrawioServer()
+    fs.rmSync(emptyBuiltin, { recursive: true, force: true })
+    fs.rmSync(packsDir, { recursive: true, force: true })
+  })
+
+  assert.strictEqual(await isAvailable(), true, '内置根没有 index.html，应当落到 pack 根')
+  const { origin } = await startDrawioServer()
+  const res = await get(origin, '/')
+  assert.strictEqual(res.status, 200)
+  assert.match(res.body, /PACK-DRAWIO/)
+})
+
+test('revoked:true 的 pack 版本不参与解析', async (t) => {
+  const emptyBuiltin = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-builtin-empty-'))
+  const packsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-packs-'))
+  seedPack(packsDir, { revoked: true })
+
+  process.env.AIWORKDECK_DRAWIO_DIR = emptyBuiltin
+  process.env.AIWORKDECK_PACKS_DIR = packsDir
+  t.after(() => {
+    fs.rmSync(emptyBuiltin, { recursive: true, force: true })
+    fs.rmSync(packsDir, { recursive: true, force: true })
+  })
+
+  assert.strictEqual(await isAvailable(), false, 'current.json 标了 revoked，pack 根不该被当成可用')
+})
+
+test('版本目录缺 .pack-complete 时不参与解析', async (t) => {
+  const emptyBuiltin = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-builtin-empty-'))
+  const packsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-packs-'))
+  seedPack(packsDir, { noComplete: true })
+
+  process.env.AIWORKDECK_DRAWIO_DIR = emptyBuiltin
+  process.env.AIWORKDECK_PACKS_DIR = packsDir
+  t.after(() => {
+    fs.rmSync(emptyBuiltin, { recursive: true, force: true })
+    fs.rmSync(packsDir, { recursive: true, force: true })
+  })
+
+  assert.strictEqual(await isAvailable(), false, '没有 .pack-complete 说明安装事务未完成，不该被当成可用')
+})
+
+test('内置根优先于 pack 根', async (t) => {
+  const builtinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-builtin-'))
+  fs.writeFileSync(path.join(builtinDir, 'index.html'), '<html>BUILTIN-DRAWIO</html>')
+  const packsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-packs-'))
+  seedPack(packsDir)
+
+  process.env.AIWORKDECK_DRAWIO_DIR = builtinDir
+  process.env.AIWORKDECK_PACKS_DIR = packsDir
+  t.after(async () => {
+    await stopDrawioServer()
+    fs.rmSync(builtinDir, { recursive: true, force: true })
+    fs.rmSync(packsDir, { recursive: true, force: true })
+  })
+
+  const { origin } = await startDrawioServer()
+  const res = await get(origin, '/')
+  assert.strictEqual(res.status, 200)
+  assert.match(res.body, /BUILTIN-DRAWIO/)
+  assert.doesNotMatch(res.body, /PACK-DRAWIO/)
 })

--- a/docs/NATIVE_PACK_DISTRIBUTION.md
+++ b/docs/NATIVE_PACK_DISTRIBUTION.md
@@ -1,0 +1,443 @@
+# 原生资源包分发规范（Native Pack：格式 · 托管 · 安装 · 卸载）
+
+> 状态：**已拍板定稿（2026-08-19）**。四项决议见 §13：签名沿用插件 registry 密钥对；
+> 升级资源缺口自动补下载；Phase A 与 Phase B 同轮实施；**v1 即开放第三方提交 pack**（§8）。
+> 适用范围：第四种分发形态「原生资源包（native pack）」——重资源功能的运行时下载分发。
+> 首个落地对象：诉讼可视化（litviz + graphviz + draw.io，约 45–65 MB）。
+> 相邻规范：[PLUGIN_SPEC.md](PLUGIN_SPEC.md)（JAR 插件）、[PLUGIN_DISTRIBUTION.md](PLUGIN_DISTRIBUTION.md)
+> （JAR 在线分发）、[SKILL_SPEC.md](SKILL_SPEC.md)（Skill）。
+
+## 0. 为什么需要第四种形态
+
+现有三种插件形态（内置面板型 / Skill 型 / 动态 JAR）没有一种能承载「重资源」：
+
+- Skill 广场只收 `skill.yml` + `prompt.md` 两个文本文件（`BUNDLE_FILES` 白名单）；
+- JAR 插件广场只装后端 Java 字节码，官网受理上限 20 MB，且下载端点
+  （`GET /api/registry/plugins/{id}/file`）是 Next.js 应用层 `readFileSync` 整读进内存——
+  生产机 1.8 GB 内存跑四个站点，几十 MB 级的包走这条路是 OOM 风险，也没有断点续传；
+- 内置面板型只能随安装包走。
+
+于是 2026-08-19（PR#433）诉讼可视化、脱敏做的「广场安装」只是**体验对齐**：
+`enabled_by_default:false` + `requiresSkill` 门控，点「安装」= 翻启用位，
+字节早已全部随安装包分发。代价直接压在安装包上：
+
+| 资源 | mac | win | 消费方 |
+|---|---|---|---|
+| draw.io 裁剪静态资源 | ~40 MB | ~40 MB | Electron `drawio-server.js`（静态服务） |
+| graphviz 平台二进制 | 4.3 MB | 19.7 MB | litviz `cli.py` 子进程（仅流程图布局） |
+| litviz Python 引擎 | 1.1 MB | 1.1 MB | 后端 `LitigationVisualService` 子进程 |
+
+本规范定义的 native pack 让这类资源**从插件广场真下载安装**：
+安装包瘦身约 45 MB（mac）/ 60 MB（win），用户体验与今天完全一致
+（广场点「安装」→（多一步：下载进度）→ 左栏出现入口）。
+
+### 什么资源该走 pack（判据）
+
+**进程外消费的重资源**：子进程运行时（Python 脚本引擎）、平台原生二进制（graphviz）、
+静态资产（draw.io）。共同点是宿主代码通过**路径**消费它们，不进 JVM。
+
+**什么不走**：宿主 Java 代码一律随包。脱敏（`SensitiveService`）编译在 backend
+app.jar 里、纯 Java、无外部重资源，把它拆出来是后端模块化工程而不是分发问题，
+收益为零——脱敏维持现状（随包 + skill 门控启停）。
+
+### 与 PLUGIN_DISTRIBUTION.md §9 分期表的关系
+
+原 Phase 3「进程外插件形态（MCP server）」解决的是**隔离执行**（不可信代码不进宿主
+JVM），本规范解决的是**资源分发**（可信资源不进安装包），相邻但不同问题，互不取代。
+落地时在 §9 表中为 native pack 加行、指向本文，MCP 形态保留原位（仍未排期）。
+
+## 1. 概念与信任模型
+
+**原生资源包（native pack）= 内置功能的可拆卸资源载荷。**
+它不含进 JVM 的字节码（区别于 JAR 插件）、不含 prompt（区别于 Skill）；
+消费它的代码（面板组件、后端 service、@Tool）仍然内置在应用里。
+
+| 形态 | 载荷 | 进 JVM | 分发 | 审核 |
+|---|---|---|---|---|
+| 内置面板型 | 前端组件 + 宿主 Java | 是（随应用） | 随安装包 | 即应用发布流程 |
+| Skill | 纯文本 prompt 包 | 否 | 官网 registry，登录即发布 | 无 |
+| 动态 JAR | Java 字节码 | **是** | 官网审核 + 签名 + registry | 人工，无自动通过 |
+| **native pack** | 脚本运行时 / 原生二进制 / 静态资产 | 否 | 静态镜像 + 签名 manifest | 第一方直发；**三方人工审核 + 签名**（§8） |
+
+**信任等级与 JAR 插件相同**：pack 里有可执行内容（Python 脚本会被解释执行、
+graphviz 是原生二进制会被 spawn），一旦被替换等同任意代码执行。因此：
+
+- Ed25519 签名沿用**现有插件 registry 密钥对**（私钥 = 官网 env
+  `AWD_PLUGIN_SIGNING_KEY`，公钥 = 桌面端 `ai.plugins.registry-public-key`，
+  默认留空即拒绝一切 pack 安装）——pack 与 JAR 插件同属「广场分发的可执行内容」
+  这一信任层级，共用一对密钥，轮换处置同一套（见 [[plugin-distribution-security]]）
+  【已拍板】；
+- 第三方提交 pack **v1 即开放**【已拍板】，但审核比 JAR 更重：平台二进制没有
+  class 常量池那样的可扫描面，自动扫描只能给出条目级线索（§8.2），人工审核
+  没有任何自动通过路径，且发布节奏完全由平台控制（审核通过 ≠ 立即上架，
+  上架动作是平台侧的发布脚本）。
+
+与 JAR 插件的一个刻意差异：pack 的 manifest 是**托管的静态文件**，签名直接盖在
+manifest 原始字节上（旁挂 `.sig`，与增量更新的 `manifest.json.sig` 同型），
+不走 canonical JSON 重建——没有「两端各自组装再对拍」的问题，从根上避开跨语言
+键序坑。`PluginMarketService` 的 canonical JSON 流程不动。
+
+## 2. pack manifest 格式
+
+每个 pack 一份 `manifest.json`（UTF-8，无 BOM）+ 同目录 `manifest.json.sig`
+（对 manifest 原始字节的 Ed25519 签名，base64）：
+
+```jsonc
+{
+  "schema": 1,
+  "id": "litigation-visual",          // ^[a-z0-9][a-z0-9-]{1,49}$，与 skill id 同规则
+  "version": "1.0.0",                  // 语义化版本，独立于应用版本号
+  "publishedAt": "2026-08-20T00:00:00Z",
+  "minAppVersion": "0.21.0",           // 低于此版本的应用拒绝安装（资源↔宿主契约由应用侧保证）
+  "engineApi": 1,                      // 资源与宿主的机器契约版本（litviz 即 cli.py 契约），宿主不认识则拒装
+  "components": [
+    {
+      "name": "litviz",
+      "platforms": ["*"],              // 平台无关
+      "archive": "litviz-1.0.0.tar.gz",
+      "size": 1153433,                 // 压缩包字节数（进度条与续传校验用）
+      "sha256": "…",                   // 压缩包哈希（签名经 manifest 覆盖到它）
+      "unpackDir": "litviz"            // 解压到 <packRoot>/<version>/litviz/
+    },
+    { "name": "graphviz", "platforms": ["mac-arm64"], "archive": "graphviz-1.0.0-mac-arm64.tar.gz",  "size": 0, "sha256": "…", "unpackDir": "graphviz" },
+    { "name": "graphviz", "platforms": ["win-x64"],   "archive": "graphviz-1.0.0-win-x64.tar.gz",    "size": 0, "sha256": "…", "unpackDir": "graphviz" },
+    { "name": "drawio",   "platforms": ["*"],         "archive": "drawio-1.0.0.tar.gz",              "size": 0, "sha256": "…", "unpackDir": "drawio" }
+  ]
+}
+```
+
+要点：
+
+- **平台/架构矩阵**：`platforms` 取值 `*`、`mac-arm64`、`win-x64`（与
+  `desktop/bundled/${os}-${arch}` 的命名一致；当前就这两个发行目标）。客户端按
+  自身平台过滤 components，取「匹配平台 ∪ `*`」；某平台缺必需组件时如实降级
+  （graphviz 的降级语义沿用现状：缺了只报流程图布局不可用）。
+- **逐文件哈希**：签名 manifest 只盖**压缩包级** sha256（密码学上已覆盖全部内容）；
+  每个压缩包内自带 `contents.sha256`（包内逐文件哈希清单，构建期生成），
+  安装端解压后**逐文件复核一遍**才写完成标记。这样 manifest 体积与文件数解耦
+  （draw.io 有数百个文件），事后完整性审计也有据可查。
+- **压缩格式**：统一 tar.gz 原始字节。**不做 brotli、不复用 `/lowa-engine/` 的
+  location**——那个 location 会给 wasm/data 强加 `Content-Encoding: br`
+  （见 [[lowa-engine-hosting-convention]] 的事故记录），pack 走自己的 location
+  并显式 `gzip off`，杜绝「客户端把压缩字节再解一层」这类编码事故。
+- **符号链接**：构建期打 tar 时 `--dereference` 物化所有软链；安装端解压器
+  **拒绝** symlink / hardlink / 绝对路径 / `..` 条目（zip-slip 同款防护），
+  并限制条目数（≤ 5000）与解压后总体积（≤ 500 MB）。
+- **可执行位**：tar 保留 POSIX 权限；Java 解压端恢复 exec bit（graphviz 的
+  `dot` 等）。mac 二进制在构建期已由 `prepare-graphviz.js` 做过
+  install_name_tool 重定位 + ad-hoc 重签，pack 原样收录（签名在文件字节里，
+  下载不破坏）；Java HTTP 下载不写 quarantine xattr，spawn 不过 Gatekeeper 门。
+
+## 3. 托管与下载源
+
+### 3.1 目录布局（镜像上）
+
+```
+/www/wwwroot/plugin-packs/
+└── litigation-visual/
+    ├── manifest.json          # 最新版指针（no-cache）
+    ├── manifest.json.sig
+    └── 1.0.0/                 # 版本目录，内容不可变（immutable）
+        ├── manifest.json      # 该版本的 manifest 快照 + .sig（回退安装用）
+        ├── manifest.json.sig
+        ├── litviz-1.0.0.tar.gz
+        ├── graphviz-1.0.0-mac-arm64.tar.gz
+        ├── graphviz-1.0.0-win-x64.tar.gz
+        └── drawio-1.0.0.tar.gz
+```
+
+nginx 新增 `location ^~ /plugin-packs/`，照抄 `/update/desktop/` 与
+`/lowa-engine/` 的成熟做法：`root /www/wwwroot`、静态直出**不经 Node 应用层**、
+manifest `no-cache`、版本目录 `immutable`、`gzip off`（防对 tar.gz 二次编码）、
+支持 Range（nginx 静态默认支持，断点续传靠它）。北京（宝塔配置）与新加坡
+（`doc/nginx-workdeck-ai.conf` 入库）各配一份。
+
+### 3.2 多源降级与境内速度
+
+客户端按序尝试（与 `update-service.js` 的 `urls[]` 降级同型）：
+
+1. `https://www.aiworkdeck.com/plugin-packs/…`（北京主镜像，境内首选）
+2. `https://workdeck.ai/plugin-packs/…`（新加坡镜像，境外/EN 版首选；两站顺序按
+   应用语言或 `site` 判定对调）
+3. GitHub Release 资产（兜底源）
+
+**镜像必须排在 GitHub 之前**：境内 ECS/用户直连 GitHub 实测 12 KB/s
+（[[release-mirror-sync-github-throttle]]），几十 MB 的包不能指望它当主源。
+官网两站 `data/` 互不相通不影响本方案——pack 走独立静态目录，不进
+`data/plugin-files/`，由发布脚本负责双机同步（§7.3）。
+
+配置：`ai.packs.base-urls`（列表，application.yml 给默认值），
+`ai.packs.dir`（默认相对 cwd 的 `packs`，同 `ai.plugins.dir` 惯例）。
+
+## 4. 客户端安装（后端负责）
+
+安装器放在**后端 Java**（新 `NativePackService` + `PackController /api/packs`），
+不放 Electron：广场 UI 本来就打后端 API；`~/.aiworkdeck` 是后端 cwd；
+deploy/web 服务器形态没有 Electron 也能用同一条链路。
+
+### 4.1 落盘布局（DMG 升级不丢）
+
+```
+~/.aiworkdeck/packs/                     # ai.packs.dir，打包态后端 cwd 之下
+├── .staging/litigation-visual-1.0.0/    # 安装事务工作区（含 *.part 断点文件）
+└── litigation-visual/
+    ├── current.json                     # 原子指针 {version, activatedAt}（tmp+rename，overlay.js 同款）
+    └── 1.0.0/
+        ├── .pack-complete               # 逐文件复核通过后才写的完成标记
+        ├── litviz/  graphviz/  drawio/
+```
+
+`~/.aiworkdeck` 在 DMG 覆盖安装/大版本升级时不被触碰（license.json、plugins/、
+models/ 已验证过这一点），pack 同享此保障。
+
+### 4.2 安装事务（幂等、可续传、失败回滚）
+
+1. 拉 `manifest.json` + `.sig`，内置公钥验签，**失败即中止**（不落任何文件）；
+   公钥未配置 = 拒绝一切安装（与 JAR 插件同语义）。
+2. 校验 `minAppVersion`（不满足则提示升级应用）与 `engineApi`（宿主不认识则拒装）。
+3. 按平台过滤 components，逐个下载到 `.staging/<id>-<version>/<archive>.part`：
+   HTTP Range 断点续传（本地已有 `.part` 时带 `Range: bytes=<len>-`，服务器不支持
+   206 则重头下）；边下边算 sha256；完成后与 manifest 比对，不符**删除重下**
+   （最多 3 次，每次换下一个源）。
+4. 解压到 staging（zip-slip/软链/条目数/总体积防护，见 §2）；按包内
+   `contents.sha256` 逐文件复核；恢复 exec bit。
+5. 全部组件就绪后：`rename(staging → <id>/<version>/)`（同文件系统，原子）→
+   写 `.pack-complete` → `current.json` 指针原子切换 → 删除旧版本目录（只保留
+   current 一版：draw.io 级别的体积不值得本地存两份，回退 = 按旧版本目录的
+   manifest 快照重装，镜像上旧版本常年在架）。
+6. 失败处置：验签/哈希失败删除对应产物；**网络中断保留 `.part`**（下次续传）；
+   staging 里的半成品不会被任何扫描路径看到（资源解析只认 `current.json` 指的、
+   带 `.pack-complete` 的版本目录）。
+7. 幂等重装：目标版本目录已存在且带完成标记 → 跳过下载，只重写指针。
+
+### 4.3 进度与 API
+
+| 方法 | 路径 | 权限 | 说明 |
+|---|---|---|---|
+| GET | `/api/packs/list` | 登录 | 各 pack 的 `{id, state, installedVersion, latestVersion, totalSize}` |
+| GET | `/api/packs/{id}/status` | 登录 | `{state: idle\|downloading\|verifying\|installing\|ready\|failed, bytesDownloaded, bytesTotal, error}` |
+| POST | `/api/packs/{id}/install` | admin | 异步启动安装（已在装则幂等返回当前进度） |
+| POST | `/api/packs/{id}/uninstall` | admin | 见 §6 |
+
+下载在后端单线程执行器里跑（同一 pack 串行、去重），前端**轮询 status**
+展示字节级进度（先例：组件管理的模型下载）。鉴权与市场写操作一致
+（`X-Session-Id` → admin，桌面单机全员 admin）。
+
+### 4.4 生效不重启
+
+- **后端侧**：`LitigationVisualService.resolveRuntime()` 本就是每次调用现算的
+  链式回退（config → env → dev 目录爬升），末位追加 pack 查询
+  （`NativePackService.currentDir(id, component)`）。装完即用，无需重启。
+- **Electron 侧（draw.io 静态服务）**：`drawio-server.js` 从单根改多根
+  （`zetaoffice-server.js` 的 `editorRoots()` 双根同款）：请求时按
+  `[AIWORKDECK_DRAWIO_DIR 覆盖, 内置 Resources（若存在）, ~/.aiworkdeck/packs/litigation-visual/<current>/drawio]`
+  顺序找文件。根列表每次请求惰性解析（读 `current.json`，fs 开销可忽略），
+  装完即生效，Electron 不重启。
+
+## 5. 资源解析优先级（老版本兼容）
+
+对 litviz / graphviz / drawio 三类资源，统一优先级：
+
+1. **显式覆盖**（config `litviz.*` / env `LITVIZ_DIR` 等）——dev 与测试用；
+2. **随包内置**（extraResources；打包态由 backend-service.js 注入 env，摘除后
+   注入逻辑改为 `fs.existsSync` 判定，目录不存在不注入）——**老版本已装用户
+   的随包资源仍在就优先用，不强迫重下**；
+3. dev 目录爬升（现状，仅 dev 态命中）;
+4. **pack current 目录**。
+
+**大版本升级的资源缺口**：老用户升级到摘除后的大版本，Resources 里的随包资源
+随 .app 替换消失，而本地还没有 pack——此时「skill 已启用」与「资源缺失」并存。
+处置（已拍板，§13-2）：后端启动时与面板打开时检测
+「skill enabled && 资源全链缺失」→ **自动触发 pack 安装**（用户已用启用状态表达过
+要这个功能，升级不该让它变哑），左栏面板顶部显示下载进度条；
+`litigation_render` 等工具在资源就绪前如实返回「资源包下载中/未安装」的引导文本。
+
+## 6. 卸载语义
+
+- 广场「卸载」一个带 pack 的面板型 skill = 停用 skill（rail 入口消失，现状语义）
+  **+ 删除 `packs/<id>/` 整目录**（前端确认框注明可释放体积）。
+- 随包内置形态下（老版本）「卸载」维持只停用——Resources 删不掉，也不该删。
+- 重装 = 重下（镜像常年在架）。卸载应用不清 `~/.aiworkdeck`（现状一致）。
+- `ai.skills.seeded` 的种子化语义不变：pack 卸载不重置用户的启停记忆。
+
+## 7. 与现有体系的接线
+
+### 7.1 skill 门控（体验不变）
+
+- `skill.yml` 新增可选字段 `requires_pack: <packId>`（旧版本应用忽略未知字段，
+  向前兼容）。litigation-visual 的 skill.yml 加上它；`requiresSkill` 显隐机制
+  一个字节不动。
+- 市场前端（MarketSidebarPanel / MarketDetailPane）对带 `requires_pack` 的面板
+  skill 扩展状态机：未安装（显示「需下载 ~45 MB」）→ 下载中（进度）→ 已安装。
+  「安装」按钮编排：`POST /api/packs/{id}/install` 轮询到 ready → 
+  `POST /api/skills/{id}/enable`。资源已就绪（随包或已装 pack）时跳过下载步，
+  与今天的体验逐像素一致。
+- `/api/skills/list` 的 SkillView 增加 `packId` / `packReady` 两个字段，
+  省得前端为每行再打一次 `/api/packs/status`。
+
+### 7.2 desktop 打包摘除
+
+- `desktop/package.json` extraResources 删三项：`../litviz`、
+  `bundled/${os}-${arch}/graphviz`、`../frontend/dist/drawio`。
+  `skills`（文本）与 `python`（pysvc 还要用）**保留**。
+- `backend-service.js`：`LITVIZ_DIR` / `LITVIZ_GRAPHVIZ_DIR` 注入加
+  `fs.existsSync` 守卫（drawio 侧 §4.4）；`AWD_PYTHON_HOME`、
+  `AI_SKILLS_BUILTIN_DIR` 不动。
+- CI `desktop-build.yml`：安装包链路里的 `prepare-graphviz` 与
+  `fetch-drawio-assets` 步骤移除（转入 pack 构建链，§7.3）。
+- **patch-gate 约束**：以上全是 desktop/ 改动，只能随大版本走——本项整体落
+  **v0.21.0**。
+
+### 7.3 pack 构建与发布链
+
+- 新 workflow `pack-release.yml`（workflow_dispatch，输入 packId+version）：
+  mac/win 双 runner 各产 graphviz 组件（win 的 19.7 MB DLL 闭包只能在 win 上出），
+  litviz/drawio 平台无关组件单 runner 产出；汇总 job 生成 manifest、
+  用 CI secret 里的签名私钥出 `.sig`、把全部产物挂上 GitHub Release
+  （tag `pack-<id>-v<version>`，与应用 `v*` tag 井水不犯河水，不触发 desktop-build）。
+- 发布脚本 `deploy/publish-pack.sh`（照 `publish-lowa-engine.sh` 的骨架）：
+  从 GitHub Release 拉产物（或本机中转）→ 验签验哈希 → 推北京 + 新加坡两台
+  `/www/wwwroot/plugin-packs/<id>/<version>/` → 终验（两站各 curl 首尾字节 +
+  sha256 对账）→ 最后才切 `<id>/manifest.json` 指针。**双机都传完才切指针**
+  （lowa r4 只传北京、CI 从新加坡拉到 404 的教训）。
+- 私钥沿用 `AWD_PLUGIN_SIGNING_KEY` 对应的那把（§1）；进 CI secret 之前先按
+  `.agent/ACCOUNTS.md` 核对本机备份位置（已拍板沿用此密钥对，§13-1）。
+
+### 7.4 官网仓改动（很小）
+
+pack 不进 registry API、不进 `data/plugin-files/`（那条路是为 ≤20 MB 的审核件
+设计的）。官网仓 v1 只需：
+
+- `doc/nginx-workdeck-ai.conf` 加 `^~ /plugin-packs/` location（北京侧宝塔同步改）；
+- `/zh/plugins` 页与桌面广场对面板型 skill 的展示口径不变（它们本来就不在
+  官网 registry 里）。
+
+## 8. 三方 pack 提交与审核（v1 即开放，已拍板）
+
+三方 pack 的意义：pack 本体是「被代码消费的资源」，单独一个 pack 什么都不做。
+三方 pack 的消费方是**三方插件**——JAR 或 Web 插件在 manifest 里声明
+`packs: ["<packId>"]`（PLUGIN_SPEC 新增字段），插件安装时联动安装其依赖的 pack；
+JAR 插件代码经 Spring 容器取 `NativePackService.currentDir(packId)` 拿到资源路径。
+第一方 pack（litigation-visual）由内置 skill 的 `requires_pack` 消费，不经此流程。
+
+### 8.1 提交与受理（官网）
+
+- 提交物 = 单个 zip：未签名的 `manifest.json` 草案（无 `publishedAt`/签名）+
+  manifest 里声明的全部 `*.tar.gz` 组件。
+- **上传不走 `formData()`**（Next 会把整包缓冲进内存）：新端点以 octet-stream
+  流式落盘 `data/pack-submissions/<id>/<version>/`，nginx 对该路由单独放大
+  `client_max_body_size`（其余路由维持原值）。
+- 受理硬检查（任一不过直接拒收）：id 正则 `^[a-z0-9][a-z0-9-]{1,49}$` 且
+  **不得撞第一方保留名单**（litigation-visual 等）；id 归属同插件规则
+  （新 id 归提交者，老 id 只有原作者能提新版本）；version 严格递增；
+  每个 tar.gz 可解且逐条目过 §2 的四重防护；manifest 里的 sha256/size 与实物
+  一致；平台键合法；总体积 ≤ 300 MB。
+
+### 8.2 审核（人工，无自动通过）
+
+审核台展示：manifest 全文、组件清单、解包条目列表（路径 + 大小 + exec 位 +
+文件类型嗅探）、二进制字符串提取出的 URL/IP 字面量、作者的用途自述。
+原生二进制无法像 class 常量池那样交叉验证，**审核结论主要依赖来源可信度**
+（作者是否提供可复现构建脚本/上游开源地址），拿不准就驳回。
+
+### 8.3 签名与发布
+
+审核通过后由平台侧完成（提交者无法触发）：补 `publishedAt` → 用
+`AWD_PLUGIN_SIGNING_KEY` 对 manifest 字节签名 → 产物移入
+`/www/wwwroot/plugin-packs/<id>/<version>/` → 同步新加坡镜像（SG 侧
+`sg_to_bj` 密钥拉取，同 lowa-engine 惯例）→ **双机都验证过才切**
+`<id>/manifest.json` 指针。
+
+### 8.4 封禁
+
+官网新增 `GET /api/registry/packs/revoked`（形制同插件封禁表）。客户端沿
+`PluginRevocationService` 的节奏（启动 + 每 24h）拉取，命中的已装 pack：
+在 `current.json` 写入 revoked 标记 → 资源解析链对它视而不见（消费入口全部
+如实报「资源包已被平台下架」）→ 广场标红建议卸载。镜像同时删档 + 指针回退，
+阻止新装。不自动删本地文件（与插件封禁同理，防误封丢数据）。
+
+## 9. 测试与验收
+
+- 后端单测：manifest 验签（正/负/未配公钥）、平台过滤、断点续传（本地 HTTP 桩，
+  update-service.test.js 同款手法）、zip-slip/软链拒绝、哈希不符重试换源、
+  幂等重装、指针原子性、卸载守卫（只删 packs 正下方目录，canonical 校验）。
+- 资源解析矩阵：env 覆盖 / 随包在场 / 仅 pack / 全缺四态 ×（litviz、graphviz、
+  drawio）——「随包优先于 pack」必须有断言钉住。
+- e2e：app-e2e 加旅程「广场安装诉讼可视化 →（桩 pack 源）下载 → rail 出现 →
+  出一张 numbered_point_timeline」；desktop `npm test` 盖 drawio-server 多根。
+- 发布链：`publish-pack.sh` 带 `check` 子命令本地验产物（不碰网络），
+  正反自检同 prepare-graphviz 惯例。
+
+## 10. 安全边界备忘
+
+- `~/.aiworkdeck/packs/` 与 `plugins/` 同级同威胁模型：本机同用户进程可写 =
+  可注入可执行内容。这不是 pack 引入的新敞口（PLUGIN_SPEC §1 已声明），
+  验签保护的是**分发链路**（下载途中与源站被篡改），不是本机落盘后。
+- 安装端对压缩包的四重防护（路径、软链、条目数、总体积）必须在解压**每个条目前**
+  检查，不是解完再看。
+- pack 安装不执行任何包内代码：litviz 只在用户触发出图时才被 spawn，
+  与「JAR 插件装后默认禁用」的精神一致（安装动作本身零执行）。
+
+## 11. 三方 Web 插件与 SDK（Track B）
+
+> 本章回答「三方上传插件 + 用 Web coding 方式开发」的路线。已拍板与 Phase A 同轮实施。
+
+### 11.1 现状缺口
+
+第三方今天已经能提交两种东西：Skill（官网表单，纯文本，登录即发布）与 JAR 插件
+（官网提交 → 人工审核 → 签名上架）。缺口是**带界面的插件**：`manifest.frontendEntry`
+一直是「预留，v1 不加载」，提交包格式也不收前端资源——一个只会写 Web 的开发者
+在这个生态里造不出任何看得见的东西。
+
+### 11.2 形态：web bundle 插件
+
+- 提交包新增 `web/` 目录（纯静态 HTML/JS/CSS，入口 `web/index.html`），
+  `frontendEntry` 激活为指向它。可以**不带任何 JAR**——纯前端插件是合法形态，
+  这类插件不进 JVM，风险量级低于 JAR 一档。
+- 承载：现成的 `PluginPane.vue` iframe 壳。后端把 `plugins/<id>/web/` 静态
+  服务出来。
+- **安全关键——绝不同源**：iframe 若与应用同源，插件脚本直接拿到
+  `X-Session-Id` 打全部 `/api/*`，等于白给宿主权限。方案：
+  `sandbox="allow-scripts allow-forms"`（**不含** allow-same-origin，opaque
+  origin），插件与宿主只通过 postMessage 桥通信；静态服务响应带严格 CSP
+  （`default-src 'self'`，声明了 `network` 权限的插件才按 manifest 放开
+  `connect-src`）。
+- 能力经桥、按 manifest `permissions` 裁剪：桥的宿主端在 PluginPane 里实现，
+  逐调用校验来源 iframe 与权限声明，转发到既有 api.js——权限声明从「自述 lint」
+  第一次变成 Web 插件上的**真实执行边界**（JAR 侧做不到的，这里做得到）。
+
+### 11.3 SDK（`@aiworkdeck/plugin-sdk`）
+
+- 单文件 JS（npm 包 + 官网可下模板内联），封装 postMessage 桥与握手：
+  `awd.ready()`、`awd.context()`（项目 id/语言/主题令牌）、
+  `awd.files.list/read`（按 file_read 权限）、`awd.tools.call(name, args)`
+  （按 manifest tools 白名单）、`awd.ui.toast/confirm`、`awd.storage`
+  （插件级 KV，宿主代存）。
+- 开发工作流：官网插件模板 zip（已有 Java 模板先例 `lib/plugin-template.ts`）
+  加一份 web 模板——vite 骨架 + SDK + **宿主模拟器**（一个静态页假扮宿主桥，
+  `npm run dev` 在浏览器里就能开发调试，不需要装桌面端）。
+- 审核：沿用 PLUGIN_DISTRIBUTION 状态机与签名（web 文件同样进 `files` 哈希表
+  签名覆盖）。JS 没有常量池可扫，自动扫描降级为「外联 URL 字面量提取 +
+  权限交叉验证」，人工审核为主；sandbox + CSP 是运行时的真实兜底。
+
+### 11.4 与 pack 的关系
+
+Web 插件包仍走官网 20 MB 受理线与 registry `file` 端点（体积小，应用层扛得住）。
+三方插件要带重资源时，在 manifest 声明 `packs: [...]` 依赖（§8），
+不把 registry 端点撑大。
+
+## 12. 分期
+
+| 期 | 内容 | 仓库 |
+|---|---|---|
+| **Phase A** | native pack 机制全量（§2–§10）+ 诉讼可视化 pack 化；安装包摘除**在 pack 上架双镜像并验证后**单独出 PR（保证 master 任一状态都能发出功能完整的版本），随 v0.21.0 大版本生效 | 本仓为主；官网仓 nginx conf + §8 提交审核链 |
+| **Phase B** | 三方 Web 插件：提交包收 `web/`、frontendEntry 激活、sandbox 桥、SDK + 模板 + 宿主模拟器（§11） | 双仓 |
+| **Phase C（未排期）** | 进程外 MCP 插件形态（原 PLUGIN_DISTRIBUTION §9 Phase 3，保留原位） | 双仓 |
+
+## 13. 拍板记录（2026-08-19）
+
+1. **签名密钥**：沿用插件 registry 密钥对（`AWD_PLUGIN_SIGNING_KEY` /
+   `ai.plugins.registry-public-key`）。
+2. **老用户升级后的资源缺口**：自动补下载 + 面板进度条（§5）。
+3. **Phase 顺序**：A、B 同轮实施。
+4. **三方 pack**：v1 即开放提交（§8），人工审核无自动通过。

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -182,7 +182,12 @@ AI provider 的 API key 后窃取、装 JVM 全局 TrustManager 关掉 TLS 校�
 
 ## 9. 分期
 
-- **Phase 1**（当前）：官网提交 + 人工审核 + 自动扫描报告 + 签名 + registry 四个接口。
-- **Phase 2**：桌面端安装（验签 + 逐文件哈希校验 + 信任确认）+ 封禁拉取与强制禁用。
+- **Phase 1**：官网提交 + 人工审核 + 自动扫描报告 + 签名 + registry 四个接口。（已落地）
+- **Phase 2**：桌面端安装（验签 + 逐文件哈希校验 + 信任确认）+ 封禁拉取与强制禁用。（已落地）
+- **Phase 2.5（2026-08 立项）**：第四种分发形态「原生资源包（native pack）」——
+  重资源（脚本运行时 / 平台二进制 / 静态资产）不随安装包、不进 registry 应用层，
+  走签名 manifest + 静态镜像的运行时下载；含三方 pack 提交审核与三方 Web 插件 SDK。
+  规范整体在 [NATIVE_PACK_DISTRIBUTION.md](NATIVE_PACK_DISTRIBUTION.md)，本文的
+  状态机 / 签名密钥 / 封禁语义被它沿用。
 - **Phase 3**（未排期）：进程外插件形态（MCP server），为不需要独立 UI 的插件提供
   真正的隔离边界；届时在线渠道优先推荐该形态，JAR 保留给必须有自己界面的插件。

--- a/docs/SKILL_SPEC.md
+++ b/docs/SKILL_SPEC.md
@@ -72,6 +72,7 @@ output: |
 | `version` | string | 否 | 展示用版本号，自由格式；不参与 id 覆盖判断（覆盖键始终是 `id`）。 |
 | `license` | string | 否 | 许可证标识，如 `MIT`。 |
 | `credits` | string[] | 否 | 随 skill 分发的第三方内容署名（如 vendor 引擎），用于满足 MIT 等许可证的版权声明保留要求；每条一行自由文本，前端原样展示在「详细信息」区。 |
+| `requires_pack` | string | 否 | 该 skill 依赖的原生资源包 id（见 [NATIVE_PACK_DISTRIBUTION.md](NATIVE_PACK_DISTRIBUTION.md)）。声明后 `/api/skills/list` 附带 `packId` 与 `packReady`；广场「安装」会先下载资源包再启用。旧版本应用忽略此字段（未知字段向前兼容），随包内置资源在场时视同就绪、不触发下载。 |
 
 未知字段被忽略（向前兼容）。
 

--- a/frontend/src/components/LitigationVisualPanel.vue
+++ b/frontend/src/components/LitigationVisualPanel.vue
@@ -3,6 +3,21 @@
 
   <!-- 面板标题由外壳的 sidebar-header 统一出，这里不再自画一份（重复两次的老毛病） -->
 
+  <!-- 原生资源包（native pack）状态条：skill 已启用（面板打得开=已启用）但资源
+       还没就绪时显示；ready 或没有 packId（旧后端/自检失败）都不渲染一个字节。
+       见 docs/NATIVE_PACK_DISTRIBUTION.md §5/§7.1。 -->
+  <view class="lv-pack-bar" :class="{ failed: litPackStatus && litPackStatus.state === 'failed' }" v-if="showPackBar">
+    <text class="lv-pack-text">{{ packBarText }}</text>
+    <view
+      v-if="litPackStatus && litPackStatus.state === 'failed'"
+      class="lv-pack-retry"
+      :class="{ disabled: litPackRetrying }"
+      @tap="retryPackInstall"
+    >
+      <text>{{ litPackRetrying ? $t('panels.litPackRetrying') : $t('common.retry') }}</text>
+    </view>
+  </view>
+
   <!-- 环境降级提示。graphviz 缺失只挡流程图一种布局，不能说成整体不可用 -->
   <view class="lv-notice" v-if="status && !status.available">
     <text class="lv-notice-text">{{ status.reason }}</text>
@@ -102,9 +117,14 @@ import {
   getLitigationVisualStatus,
   getLitigationDiagrams,
   restyleLitigationDiagram,
-  getLitigationKickoffPrompt
+  getLitigationKickoffPrompt,
+  packStatus,
+  packInstall
 } from '@/services/api.js'
 import { t } from '@/i18n'
+
+// 这个面板只服务诉讼可视化一个功能，资源包 id 与 skill id 同名，见 skill.yml 的 requires_pack
+const PACK_ID = 'litigation-visual'
 
 // 与引擎的三种视觉模式一一对应（litviz/engine/references/visual-style.md）
 const MODES = ['奇川风', '歸藏风', '白描']
@@ -148,12 +168,32 @@ export default {
       starting: false,
       restylingId: null,
       diagramHint: '',
-      scope: null            // { label, description } —— 由父页面的文件选择器回填
+      scope: null,            // { label, description } —— 由父页面的文件选择器回填
+      // 原生资源包状态条：见 docs/NATIVE_PACK_DISTRIBUTION.md §5/§7.1
+      litPackStatus: null,   // packStatus() 结果 {state, bytesDownloaded, bytesTotal, error}；null=未知/无 pack
+      litPackTimer: null,
+      litPackRetrying: false
     }
   },
   computed: {
     scopeLabel() {
       return this.scope ? this.scope.label : ''
+    },
+    showPackBar() {
+      return !!this.litPackStatus && this.litPackStatus.state !== 'ready'
+    },
+    packBarText() {
+      const s = this.litPackStatus
+      if (!s) return ''
+      if (s.state === 'failed') return s.error || this.$t('panels.litPackFailedText')
+      const total = s.bytesTotal || 0
+      if (total > 0) {
+        return this.$t('panels.litPackDownloadingProgress', {
+          downloaded: ((s.bytesDownloaded || 0) / (1024 * 1024)).toFixed(1),
+          total: (total / (1024 * 1024)).toFixed(1)
+        })
+      }
+      return this.$t('panels.litPackDownloading')
     }
   },
   watch: {
@@ -162,7 +202,50 @@ export default {
       handler() { this.reload() }
     }
   },
+  mounted() {
+    this.refreshPackStatus()
+  },
+  beforeUnmount() {
+    this.stopPackPoll()
+  },
   methods: {
+    // ---- 原生资源包（native pack）状态条 ----
+    async refreshPackStatus() {
+      try {
+        const res = await packStatus(PACK_ID)
+        this.litPackStatus = (res && res.status) || null
+      } catch (e) {
+        // 拉不到状态：旧后端没有这个端点，或本机压根没有这个 pack——按「不渲染」处理
+        this.litPackStatus = null
+        this.stopPackPoll()
+        return
+      }
+      const state = this.litPackStatus && this.litPackStatus.state
+      if (state === 'ready' || state === 'failed') {
+        this.stopPackPoll()
+      } else if (state && !this.litPackTimer) {
+        this.startPackPoll()
+      }
+    },
+    startPackPoll() {
+      this.stopPackPoll()
+      this.litPackTimer = setInterval(() => { this.refreshPackStatus() }, 1000)
+    },
+    stopPackPoll() {
+      if (this.litPackTimer) { clearInterval(this.litPackTimer); this.litPackTimer = null }
+    },
+    async retryPackInstall() {
+      if (this.litPackRetrying) return
+      this.litPackRetrying = true
+      try {
+        await packInstall(PACK_ID)
+        await this.refreshPackStatus()
+      } catch (e) {
+        uni.showToast({ title: (e && e.message) || this.$t('panels.litPackRetryFailedFallback'), icon: 'none' })
+      } finally {
+        this.litPackRetrying = false
+      }
+    },
     layoutLabel(layout) {
       const key = LAYOUT_LABEL_KEYS[layout]
       return key ? this.$t(`panels.${key}`) : this.$t('panels.litLayoutFallback')
@@ -278,6 +361,34 @@ export default {
 }
 .lv-notice.subtle { background: #F7F8FA; border-color: #E8EAED; }
 .lv-notice-text { font-size: var(--awd-panel-fs-meta); line-height: 1.55; color: #6B6560; }
+
+/* 原生资源包状态条：常态是中性下载提示，失败态借用 .lv-notice 同一套暖红 */
+.lv-pack-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px var(--awd-panel-pad-x);
+  background: var(--awd-panel-hover);
+  border-bottom: 1px solid var(--awd-panel-border);
+}
+.lv-pack-bar.failed { background: #FDF3F2; border-color: #F3D9D6; }
+.lv-pack-text {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--awd-panel-fs-meta);
+  color: var(--awd-panel-text-2);
+  line-height: 1.5;
+}
+.lv-pack-bar.failed .lv-pack-text { color: #6B6560; }
+.lv-pack-retry {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: var(--awd-panel-radius);
+  background: var(--awd-panel-accent);
+  cursor: pointer;
+}
+.lv-pack-retry text { font-size: 10px; color: #fff; font-weight: 600; }
+.lv-pack-retry.disabled { opacity: .5; pointer-events: none; }
 
 /* 分组头：与插件广场同形（26px / 11px-700 / 计数徽章 / 右侧动作） */
 .lv-sec-head {

--- a/frontend/src/components/MarketDetailPane.vue
+++ b/frontend/src/components/MarketDetailPane.vue
@@ -60,11 +60,28 @@
               </view>
               <!-- 面板型 skill（背后挂着左栏面板）按插件呈现：只有启用/停用。
                    「生效方式三档」是对话型 skill 的概念，对面板讲不通——设成 manual
-                   会让面板里的 kick-off 按钮点了没反应。判据见 leftSidebarPlugins.js。 -->
-              <view v-if="installedInfo && !installedInfo.sourcePluginId && isPanel" class="mdp-switch-row">
-                <text class="mdp-switch-label">{{ installedInfo.enabled ? $t('market.enabledTag') : $t('market.disabledTag') }}</text>
-                <AwdSwitch :checked="!!installedInfo.enabled" @change="onPanelSkillToggle" />
-              </view>
+                   会让面板里的 kick-off 按钮点了没反应。判据见 leftSidebarPlugins.js。
+                   挂着原生资源包（packId 非空）的再加一层：包没就绪前不给开关，
+                   见 docs/NATIVE_PACK_DISTRIBUTION.md §4.3/§7.1。 -->
+              <template v-if="installedInfo && !installedInfo.sourcePluginId && isPanel">
+                <text v-if="packRevokedState" class="mdp-pack-revoked">{{ $t('market.packRevokedNotice') }}</text>
+                <view v-else-if="packId && packDownloading" class="mdp-pack-progress">
+                  <text>{{ packProgressText }}</text>
+                </view>
+                <template v-else-if="packId && packFailed">
+                  <text class="mdp-pack-error">{{ (packStatusInfo && packStatusInfo.error) || $t('market.packInstallFailedShort') }}</text>
+                  <view class="mdp-btn" :class="{ busy: packBusy }" @tap="doInstallPack">
+                    <text>{{ $t('common.retry') }}</text>
+                  </view>
+                </template>
+                <view v-else-if="packId && !packReady" class="mdp-btn primary" :class="{ busy: packBusy }" @tap="doInstallPack">
+                  <text>{{ packBusy ? $t('market.installingEllipsis') : packInstallLabel }}</text>
+                </view>
+                <view v-else class="mdp-switch-row">
+                  <text class="mdp-switch-label">{{ installedInfo.enabled ? $t('market.enabledTag') : $t('market.disabledTag') }}</text>
+                  <AwdSwitch :checked="!!installedInfo.enabled" @change="onPanelSkillToggle" />
+                </view>
+              </template>
               <AwdSelect
                 v-else-if="installedInfo && !installedInfo.sourcePluginId"
                 :range="ACTIVATION_LABELS"
@@ -81,6 +98,14 @@
                 class="mdp-btn danger"
                 :class="{ busy }"
                 @tap="doUninstallSkill"
+              >
+                <text>{{ $t('market.uninstallBtn') }}</text>
+              </view>
+              <view
+                v-else-if="installedInfo && packId && !installedInfo.sourcePluginId"
+                class="mdp-btn danger"
+                :class="{ busy }"
+                @tap="doUninstallPack"
               >
                 <text>{{ $t('market.uninstallBtn') }}</text>
               </view>
@@ -177,7 +202,7 @@
 // 插件广场详情 tab（VS Code 扩展详情页形态）。spec = { kind: 'skill'|'plugin', id, name }
 // 由左栏 MarketSidebarPanel 点行打开。自行拉取市场与已安装两份数据合成视图，
 // 装/卸/启停后通过 uni.$emit('awd:market-changed') 通知左栏刷新。
-import { getPlugins, getSkills, getSkillMarket, getPluginMarket, installMarketSkill, uninstallMarketSkill, installMarketPlugin, uninstallMarketPlugin, setPluginEnabled, setSkillActivation } from '@/services/api.js'
+import { getPlugins, getSkills, getSkillMarket, getPluginMarket, installMarketSkill, uninstallMarketSkill, installMarketPlugin, uninstallMarketPlugin, setPluginEnabled, setSkillActivation, packStatus, packInfo, packInstall, packUninstall } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
 import { isPanelSkill } from '@/config/leftSidebarPlugins.js'
 import { formatPrice, isPaid, paidState, priceCentsOf, priceLabel, purchaseUrl } from '@/utils/marketPricing.js'
@@ -236,6 +261,11 @@ export default {
       busy: false,
       // 是否已连接官网账户；随广场列表响应下发（付费未购项据此在「购买」与「需连接账户」之间选）
       accountConnected: false,
+      // 原生资源包（native pack）状态，见 docs/NATIVE_PACK_DISTRIBUTION.md §4.3
+      packMeta: null,       // packInfo() 结果 {latestVersion, totalSize}，懒加载
+      packStatusInfo: null, // packStatus() 结果 {state, bytesDownloaded, bytesTotal, error}
+      packBusy: false,
+      packTimer: null,
     }
   },
   computed: {
@@ -346,6 +376,51 @@ export default {
     isPanel() {
       return this.spec && this.spec.kind === 'skill' && isPanelSkill(this.spec.id)
     },
+    /** 该 skill 挂着的原生资源包 id；来自 /api/skills/list 的 packId 字段，没有就是普通 skill */
+    packId() {
+      return (this.installedInfo && this.installedInfo.packId) || (this.marketInfo && this.marketInfo.packId) || null
+    },
+    packReady() {
+      return !!(this.installedInfo && this.installedInfo.packReady)
+    },
+    packDownloading() {
+      const state = this.packStatusInfo && this.packStatusInfo.state
+      return state === 'downloading' || state === 'verifying' || state === 'installing'
+    },
+    packFailed() {
+      return !!this.packStatusInfo && this.packStatusInfo.state === 'failed'
+    },
+    packRevokedState() {
+      return !!this.packStatusInfo && this.packStatusInfo.state === 'revoked'
+    },
+    /** 资源包体积（MB，一位小数），来自懒加载的 packInfo 或已有的 status 快照；两边都没有就留空 */
+    packSizeMB() {
+      const bytes = (this.packMeta && this.packMeta.totalSize) || (this.packStatusInfo && this.packStatusInfo.bytesTotal) || 0
+      if (!bytes) return ''
+      return (bytes / (1024 * 1024)).toFixed(1)
+    },
+    packInstallLabel() {
+      return this.packSizeMB
+        ? this.$t('market.installNeedsPackSized', { size: this.packSizeMB })
+        : this.$t('market.installNeedsPackNoSize')
+    },
+    packProgressText() {
+      const s = this.packStatusInfo
+      if (!s) return ''
+      const total = s.bytesTotal || 0
+      if (total > 0) {
+        return this.$t('market.packDownloadingProgress', {
+          downloaded: ((s.bytesDownloaded || 0) / (1024 * 1024)).toFixed(1),
+          total: (total / (1024 * 1024)).toFixed(1),
+        })
+      }
+      return this.$t('market.packDownloadingEllipsis')
+    },
+    uninstallPackHint() {
+      return this.packSizeMB
+        ? this.$t('market.uninstallPackConfirmSized', { size: this.packSizeMB })
+        : this.$t('market.uninstallPackConfirmPlain')
+    },
     sourceText() {
       if (this.installedInfo?.sourcePluginId) return this.$t('market.sourceBuiltinPlugin', { id: this.installedInfo.sourcePluginId })
       if (this.marketInfo) return this.$t('market.sourceOfficialMarket')
@@ -358,6 +433,7 @@ export default {
   },
   beforeUnmount() {
     uni.$off('awd:market-changed-from-sidebar', this.reload)
+    this.stopPackPoll()
   },
   methods: {
     async reload() {
@@ -399,9 +475,109 @@ export default {
       } finally {
         this.loading = false
       }
+      // 挂着资源包的面板型 skill：拉一次现状——可能是用户上次没装完，也可能是
+      // 老版本升级后端自动补下载中，两种都要接着轮询而不是回到「安装」按钮
+      if (this.packId) {
+        await this.refreshPackStatus()
+        const state = this.packStatusInfo && this.packStatusInfo.state
+        if (state === 'downloading' || state === 'verifying' || state === 'installing') {
+          this.packBusy = true
+          this.startPackPoll()
+        } else if (!this.packReady && state !== 'revoked' && !this.packMeta) {
+          this.loadPackMetaLazy()
+        }
+      } else {
+        this.stopPackPoll()
+      }
     },
     notifyChanged() {
       uni.$emit('awd:market-changed')
+    },
+    // ---- 原生资源包（native pack）：见 docs/NATIVE_PACK_DISTRIBUTION.md §4.3 ----
+    async loadPackMetaLazy() {
+      if (this.packMeta || !this.packId) return
+      try {
+        const res = await packInfo(this.packId)
+        if (res) this.packMeta = res
+      } catch (e) {
+        // 静默失败：安装按钮文案退化为不带大小的版本
+      }
+    },
+    async refreshPackStatus() {
+      if (!this.packId) return
+      try {
+        const res = await packStatus(this.packId)
+        this.packStatusInfo = (res && res.status) || null
+      } catch (e) {
+        // 轮询途中网络抖动很常见，不中止——下一拍再试
+        return
+      }
+      const state = this.packStatusInfo && this.packStatusInfo.state
+      if (state === 'ready') {
+        this.stopPackPoll()
+        this.packBusy = false
+        if (this.installedInfo) this.installedInfo.packReady = true
+        // 到 ready 才走现有 enable 流程；已经启用（如老版本升级自动补下载）则不重复调用
+        if (this.installedInfo && !this.installedInfo.enabled) {
+          await this.onPanelSkillToggle(true)
+        }
+      } else if (state === 'failed' || state === 'revoked') {
+        this.stopPackPoll()
+        this.packBusy = false
+      }
+    },
+    startPackPoll() {
+      this.stopPackPoll()
+      this.packTimer = setInterval(() => { this.refreshPackStatus() }, 1000)
+    },
+    stopPackPoll() {
+      if (this.packTimer) { clearInterval(this.packTimer); this.packTimer = null }
+    },
+    async doInstallPack() {
+      if (this.packBusy || !this.packId) return
+      this.packBusy = true
+      this.packStatusInfo = null
+      try {
+        await packInstall(this.packId)
+        await this.refreshPackStatus()
+        const state = this.packStatusInfo && this.packStatusInfo.state
+        if (state && state !== 'ready' && state !== 'failed') this.startPackPoll()
+      } catch (e) {
+        this.packBusy = false
+        console.error('安装资源包失败:', e)
+        uni.showToast({ title: e?.message || this.$t('market.installFailedNeedAdmin'), icon: 'none' })
+      }
+    },
+    async doUninstallPack() {
+      if (this.busy || !this.packId) return
+      if (!this.packMeta) await this.loadPackMetaLazy()
+      const ok = await new Promise(resolve => {
+        uni.showModal({
+          title: this.$t('market.confirmUninstallPackTitle'),
+          content: this.uninstallPackHint,
+          confirmText: this.$t('market.uninstallBtn'),
+          cancelText: this.$t('market.cancelBtn'),
+          success: r => resolve(r.confirm),
+          fail: () => resolve(false),
+        })
+      })
+      if (!ok) return
+      this.busy = true
+      try {
+        // 先走现有停用流程，再删资源包目录（§6：卸载 = 停用 + 删 packs/<id>/）
+        await setSkillActivation(this.spec.id, 'disabled')
+        await packUninstall(this.packId)
+        this.stopPackPoll()
+        this.packStatusInfo = null
+        uni.showToast({ title: this.$t('market.uninstalledToast'), icon: 'none' })
+        await this.reload()
+        this.notifyChanged()
+      } catch (e) {
+        console.error('卸载资源包失败:', e)
+        uni.showToast({ title: e?.message || this.$t('market.uninstallFailedNeedAdmin'), icon: 'none' })
+      } finally {
+        this.busy = false
+      }
     },
     // 购买走系统浏览器：支付要用用户已登录的浏览器会话，内嵌 tab 里付不了
     openPurchase() {
@@ -789,6 +965,28 @@ export default {
 .mdp-action-hint {
   font-size: 11px;
   color: #ADB5BD;
+}
+
+/* 原生资源包状态：下架标红、下载中用中性进度条、失败态错误文案 + 重试按钮 */
+.mdp-pack-revoked {
+  font-size: 12px;
+  font-weight: 600;
+  color: #C0392B;
+}
+
+.mdp-pack-progress {
+  height: 28px;
+  line-height: 28px;
+  padding: 0 12px;
+  border-radius: 6px;
+  background: #F1F3F5;
+  font-size: 12px;
+  color: #495057;
+}
+
+.mdp-pack-error {
+  font-size: 12px;
+  color: #C0392B;
 }
 
 .mdp-divider {

--- a/frontend/src/components/MarketSidebarPanel.vue
+++ b/frontend/src/components/MarketSidebarPanel.vue
@@ -229,6 +229,11 @@ export default {
         if (s.version) metaParts.push('v' + s.version)
         if (s.author) metaParts.push(s.author)
         if (s.sourcePluginId) metaParts.push(this.$t('market.fromPluginTag'))
+        // 挂着原生资源包的面板型 skill：已启用但包还没就绪（老版本升级后端自动
+        // 补下载的过渡态，见 docs/NATIVE_PACK_DISTRIBUTION.md §5）——如实标「下载中」，
+        // 不能显示「已启用」误导用户以为功能已经能用。装未装的初始态不受影响，
+        // 那条走 MarketDetailPane 的安装按钮，本行列表不加轮询。
+        const packPending = panel && s.packId && s.enabled && s.packReady === false
         rows.push({
           kind: 'skill',
           id: s.id,
@@ -236,10 +241,12 @@ export default {
           desc: s.description || '',
           glyph: panel ? ICONS.panelLeft : (CATEGORY_GLYPHS[s.category] || ICONS.skill),
           meta: metaParts.join(' · '),
-          stateLabel: panel
-            ? (s.enabled ? this.$t('market.enabledTag') : this.$t('market.disabledTag'))
-            : (ACTIVATION_STATE[mode] || this.$t('market.activationStateAuto')),
-          stateClass: mode === 'disabled' ? 'off' : 'ok',
+          stateLabel: packPending
+            ? this.$t('market.packDownloadingShort')
+            : panel
+              ? (s.enabled ? this.$t('market.enabledTag') : this.$t('market.disabledTag'))
+              : (ACTIVATION_STATE[mode] || this.$t('market.activationStateAuto')),
+          stateClass: packPending ? 'downloading' : (mode === 'disabled' ? 'off' : 'ok'),
           raw: s,
         })
       }
@@ -754,6 +761,16 @@ export default {
 
     &:hover {
       background: #F7EBD5;
+    }
+  }
+
+  /* 资源包下载中：与 .need 同一族暖色（都是「还没就绪」），不可点 */
+  &.downloading {
+    background: #FDF7EC;
+
+    text {
+      color: #8A6D2F;
+      font-size: 10px;
     }
   }
 }

--- a/frontend/src/locales/en-US/market.js
+++ b/frontend/src/locales/en-US/market.js
@@ -196,4 +196,16 @@ export default {
   purchased: 'Purchased',
   onetimePurchase: ' (one-time purchase)',
   purchasedSuffix: ' · Purchased',
+
+  // ---- Native pack, see docs/NATIVE_PACK_DISTRIBUTION.md §4.3/§7.1 ----
+  installNeedsPackSized: 'Install (downloads a {size} MB resource pack)',
+  installNeedsPackNoSize: 'Install (downloads a resource pack)',
+  packDownloadingProgress: 'Downloading {downloaded} / {total} MB',
+  packDownloadingEllipsis: 'Downloading…',
+  packDownloadingShort: 'Downloading',
+  packInstallFailedShort: 'Resource pack download failed',
+  packRevokedNotice: 'This resource pack has been delisted by the platform',
+  confirmUninstallPackTitle: 'Confirm Uninstall',
+  uninstallPackConfirmSized: 'This will disable the feature and delete the downloaded resource pack (about {size} MB). Continue?',
+  uninstallPackConfirmPlain: 'This will disable the feature and delete the downloaded resource pack. Continue?',
 }

--- a/frontend/src/locales/en-US/panels.js
+++ b/frontend/src/locales/en-US/panels.js
@@ -40,6 +40,12 @@ export default {
   litLayoutTree: 'Hierarchy Tree',
   litLayoutComparison: 'Comparison Table',
   litLayoutFallback: 'Diagram',
+  // Native pack status bar, see docs/NATIVE_PACK_DISTRIBUTION.md §5
+  litPackDownloading: 'Downloading the litigation visualization resource pack…',
+  litPackDownloadingProgress: 'Downloading the litigation visualization resource pack…{downloaded} / {total} MB',
+  litPackFailedText: 'Resource pack download failed',
+  litPackRetrying: 'Retrying…',
+  litPackRetryFailedFallback: 'Retry failed',
 
   // ShareholderMeetingPanel.vue
   smListLabel: 'Verifications',

--- a/frontend/src/locales/zh-CN/market.js
+++ b/frontend/src/locales/zh-CN/market.js
@@ -196,4 +196,16 @@ export default {
   purchased: '已购买',
   onetimePurchase: '（一次性买断）',
   purchasedSuffix: ' · 已购买',
+
+  // ---- 原生资源包（native pack），见 docs/NATIVE_PACK_DISTRIBUTION.md §4.3/§7.1 ----
+  installNeedsPackSized: '安装（需下载资源包 {size} MB）',
+  installNeedsPackNoSize: '安装（需下载资源包）',
+  packDownloadingProgress: '下载中 {downloaded} / {total} MB',
+  packDownloadingEllipsis: '下载中…',
+  packDownloadingShort: '下载中',
+  packInstallFailedShort: '资源包下载失败',
+  packRevokedNotice: '该资源包已被平台下架',
+  confirmUninstallPackTitle: '确认卸载',
+  uninstallPackConfirmSized: '停用后将删除已下载的资源包（约 {size} MB）。继续吗？',
+  uninstallPackConfirmPlain: '停用后将删除已下载的资源包。继续吗？',
 }

--- a/frontend/src/locales/zh-CN/panels.js
+++ b/frontend/src/locales/zh-CN/panels.js
@@ -40,6 +40,12 @@ export default {
   litLayoutTree: '层级结构树',
   litLayoutComparison: '对比表',
   litLayoutFallback: '图',
+  // 原生资源包状态条，见 docs/NATIVE_PACK_DISTRIBUTION.md §5
+  litPackDownloading: '正在下载诉讼可视化资源包…',
+  litPackDownloadingProgress: '正在下载诉讼可视化资源包…{downloaded} / {total} MB',
+  litPackFailedText: '资源包下载失败',
+  litPackRetrying: '重试中…',
+  litPackRetryFailedFallback: '重试失败',
 
   // ShareholderMeetingPanel.vue
   smListLabel: '核查任务',

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -664,6 +664,40 @@ export function uninstallMarketSkill(skillId) {
   });
 }
 
+// 原生资源包（native pack）：重资源功能的运行时下载安装，规范见 docs/NATIVE_PACK_DISTRIBUTION.md §4.3
+
+// 查询安装状态（登录即可）：{state, installedVersion, bytesDownloaded, bytesTotal, error}
+export function packStatus(packId) {
+  return request({
+    url: `/api/packs/${encodeURIComponent(packId)}/status`,
+    method: 'GET'
+  });
+}
+
+// 查询最新版本与总体积（登录即可）：{latestVersion, totalSize}，装前的大小提示用
+export function packInfo(packId) {
+  return request({
+    url: `/api/packs/${encodeURIComponent(packId)}/info`,
+    method: 'GET'
+  });
+}
+
+// 安装（仅管理员）：后端异步启动下载，已在装则幂等返回当前进度，前端轮询 packStatus 展示
+export function packInstall(packId) {
+  return request({
+    url: `/api/packs/${encodeURIComponent(packId)}/install`,
+    method: 'POST'
+  });
+}
+
+// 卸载（仅管理员）：删除本机已下载的资源包目录
+export function packUninstall(packId) {
+  return request({
+    url: `/api/packs/${encodeURIComponent(packId)}/uninstall`,
+    method: 'POST'
+  });
+}
+
 /**
  * 将一段 AI 文本（markdown）导出为 Word 文档并落地到项目文件树中（后端生成 docx）
  * payload: { projectId, parentId, fileName, markdown | content }


### PR DESCRIPTION
## 概要

按已拍板的 docs/NATIVE_PACK_DISTRIBUTION.md 落地 native pack 机制层：重资源（litviz/graphviz/drawio）改为签名 manifest + 静态镜像的运行时下载分发，广场体验不变（安装=下载+启用）。

## 内容

- **后端** `service/pack/`：NativePackService（验签/断点续传/tar 四重防护/逐文件复核/原子指针/封禁）+ PackController `/api/packs` + PackAutoInstaller（已启用但资源缺失自动补下载）；skill.yml 新字段 `requires_pack`
- **前端**：广场两件套 pack 状态机（体积提示/字节级进度/失败重试/下架标红）+ 诉讼可视化面板下载状态条 + 双语文案
- **桌面**：drawio-server 多根（内置优先、pack 兜底、逐请求解析装完不重启）；LITVIZ_DIR 注入 existsSync 守卫
- **构建发布链**：build-pack.js + pack-release.yml（tag `pack-<id>-v*`）+ publish-pack.sh（签名在官网机上做，私钥不进 CI 不落本机；双机上架验证后才切指针）
- **文档**：NATIVE_PACK_DISTRIBUTION.md（规范）、PLUGIN_DISTRIBUTION §9、SKILL_SPEC、plugin-system/plugin-marketplace/litigation-visual/eng-infra 四份领域文档

## 刻意不做

extraResources 摘除不在本 PR——待 pack v1.0.0 上架双镜像并验证后单独出 PR，保证 master 任一状态都能发出功能完整的版本。摘除属 desktop/ 改动，随 v0.21.0 大版本生效（patch-gate 约束）。

## 测试

- backend `mvn -B test`：1958 全绿（新增 NativePackServiceTest 17 条 + SkillControllerPackViewTest 2 条 + SkillRegistry/BuiltinSkills 各 1）
- desktop `npm test`：49/49（drawio 多根 4 条 + build-pack 对账）
- frontend `check:emits` / `check:locales` / `build:h5` 全绿

配套官网仓 PR（pack 提交/审核/签名/封禁链）随后提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)