### PR TITLE
feat(plugins): 三方 Web 插件运行时——frontendEntry 激活 + sandbox 桥 + SDK（Phase B 桌面侧）

### DIFF
--- a/.claude/agents/plugin-marketplace.md
+++ b/.claude/agents/plugin-marketplace.md
@@ -49,6 +49,22 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
   `lib/plugin-signing.ts`（签名）、`lib/plugin-scan.ts`（常量池扫描 + permissions 交叉验证）、
   `app/[lang]/plugins/submit`（提交页）、`app/[lang]/admin/PluginReview.tsx`（审核台）。
 
+### 三方 Web 插件（Phase B，2026-08-19）
+
+提交包新增 `web/` 目录，`manifest.frontendEntry` 指向其中（`web/index.html`）。
+**纯 web 插件可以没有 JAR**——不进 JVM，风险量级低一档；`web/` 下的文件与 JAR 一样进
+`files` 哈希表、被同一个签名覆盖。JS 没有常量池，自动扫描降级为「外联 URL 字面量提取 +
+权限交叉验证」，以人工审核为主。
+
+客户端侧：`controller/ai/PluginWebController`（`GET /api/plugin-web/{id}/**`，服务
+`plugins/<id>/web/`，只服务已启用插件，CSP 按 manifest `network` 权限放开
+`connect-src`）+ `PluginPane.vue` 的 sandbox iframe 与 postMessage 桥。
+形态、协议与 SDK 契约见 `docs/PLUGIN_SPEC.md` §8 与 `.claude/agents/plugin-system.md`。
+
+`manifest.packs: ["<packId>"]`：`PluginMarketService.install` 成功后逐个
+`NativePackService.installAsync`；**装不上不回滚插件只记 WARN**——pack 有自己的状态机与重试面，
+一次网络抖动不该吃掉刚装好的插件。三方插件要带重资源走这条路，不撑大 registry 的 20 MB 受理线。
+
 ## 原生资源包（native pack）分发（2026-08）
 
 **规范：`docs/NATIVE_PACK_DISTRIBUTION.md`（第四种分发形态的权威定义）。**
@@ -133,6 +149,7 @@ description: 插件市场领域。任务涉及插件广场页、在线 Skill 广
 - 分类筛选依赖后端 `MarketSkillView.category`，该字段 #198 才加。**跑在旧后端（≤ v0.8.0）上时分类会全归「其他」，这是后端版本旧，不是前端 bug**；排查前先 `curl /api/skills/market/list` 看响应里有没有 category。
 - 桌面端 9696 是真实后端端口，测试市场功能别 mock 错对象。
 - bundle files 白名单意味着官网新增文件类型（如图标文件）需要同时改 BUNDLE_FILES 和官网打包端。
+- **Web 插件的 SDK 有三份副本**：源头 `sdk/plugin-sdk/awd-plugin-sdk.js`、官网模板 `lib/plugin-template.ts` 的 `WEB_SDK_JS`、示例 `examples/hello-web-plugin/web/awd-plugin-sdk.js`，必须逐字节一致；桥协议还有第四处实现（`PluginPane.vue` 宿主端）。改协议是四处同批次的事，单改一处的表现是插件卡在「等待宿主握手」。
 - **本仓 `skills/<id>/skill.yml` 里的 `category` 字段，和这里说的 `MarketSkillView.category`（contract/litigation/compliance/… 七类 + icons.js/CategoryIcon.tsx 图标映射）是两套完全不同的东西，只是字段名撞了**：前者是 `SkillDefinition.category`，取值来自 `MatterCategory` 枚举的中文 display（如「合规监管」「争议解决」），只在命中触发词时喂 `matter.classified` 埋点用（见 `SkillRouter.java`），`SkillController.SkillView` 压根不把它序列化进 `/api/skills/list` 响应；后者是**在线 registry**（网站提交时选的 category）才有的字段，只出现在 `GET /api/skills/market/list` 的 `MarketSkillView` 里。随包本地内置的 skill（诉讼可视化、会议录音、脱敏这类，从未经过官网提交流程）在市场面板「已安装」列表里的图标走的是 `isPanelSkill` 判定出的 `ICONS.panelLeft`，根本不读 `category`——本地 skill.yml 的 `category` 值不需要、也不应该对着 icons.js 的七个英文 key 去选，对着 `MatterCategory.java` 的中文枚举值选就对了（2026-08-19 脱敏改造踩过这个概念混淆，核实后确认两者无关联）。
 
 ## 验证

--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -32,13 +32,32 @@ description: 插件系统领域（具体插件实现）。任务涉及尽调/脱
 
 **会议录音**：面板 + skill + 专用工具三层齐备（2026-08-14）。前端 `frontend/src/components/MeetingRecordingPanel.vue`（一键录音/列表/转写稿/说话人改名/生成纪要）+ **模块级录音单例** `frontend/src/utils/meetingRecorder.js`（MediaRecorder 5s 分片边录边追加上传，页面跳转不断录）+ 跨页面浮动指示器 `utils/recordingIndicator.js`→`MeetingRecordingIndicator.vue`（body 级挂载，feedbackWidget 同模式）；后端 `controller/MeetingRecordingController.java`（/api/meetings）+ `service/meeting/`（MeetingRecordingService 生命周期、MeetingTranscriptionService 转写编排：JavaCV 转码 mp3 → OSS 签名 URL → 通义听悟 CreateTask（说话人分离 SpeakerCount=0 + 章节/摘要/待办）→ **poll-on-read** 收结果、TingwuClient/MeetingOssClient 接口+SDK 实现、MeetingTranscriptParser 纯函数解析）；工具 `service/ai/tools/MeetingTools.java`（meeting_list_recordings/meeting_get_transcript）；skill `backend/skills/meeting-recorder/`（`enabled_by_default:false`，广场启停，触发词「会议纪要」）。凭证五件套（AK/SK/听悟 AppKey/OSS bucket/endpoint）存 system_setting `meeting.asr.*`/`meeting.oss.*`，admin 页「会议转写」卡片可改（AdminConfigController TingwuConfig）；未配置时录音存档可用、转写降级提示。转写三档（`external.asr.provider` = platform | byok | local，分档在 `MeetingTranscriptionService` 编排层）：platform 走网关、byok 用自己的听悟凭证、**local 走本机 `asr-service`（faster-whisper，音频零出网，没有说话人分离）**，档位与就绪判定见 `.claude/agents/licensing-billing.md` 地雷 36-39。**地雷**：听悟只收公网 URL（必须 OSS 中转，转写完即删）；kick-off prompt 以「会议纪要」开头；录音单例绝不能搬进页面组件（reLaunch 即断录）；local 档全程没有 taskId，「转写中」的自愈判据是进程内 `inFlight` 集合而不是 taskId。
 
-**动态 JAR**：前端 `frontend/src/components/PluginPane.vue`（纯 iframe 壳：props url/pluginId，url 空则报"未配置入口地址"；加载哪个插件由父页面按 leftPaneKey + dynamicPlugins[].frontendEntry 决定）；后端 `service/ai/PluginService.java` + `controller/ai/PluginController.java`（/api/plugins）。
+**动态 JAR / Web 插件**：前端 `frontend/src/components/PluginPane.vue`（props url/pluginId/permissions/projectId，url 空则报"未配置入口地址"；加载哪个插件由父页面按 leftPaneKey + dynamicPlugins[].frontendEntry 决定）；后端 `service/ai/PluginService.java` + `controller/ai/PluginController.java`（/api/plugins）+ `controller/ai/PluginWebController.java`（/api/plugin-web，见下）。
+
+### 三方 Web 插件（规范 v2.3，docs/PLUGIN_SPEC.md §8）
+
+`manifest.frontendEntry` 从「预留」激活。两种形态在 PluginPane 里**行为刻意不同**：
+
+- **`web/` 相对路径** = Web 插件。后端 `GET /api/plugin-web/{id}/**` 静态服务 `plugins/<id>/web/`；PluginPane 给 iframe 加 `sandbox="allow-scripts allow-forms"`，与插件只走 postMessage 桥。
+- **`http(s)://` 绝对 URL** = 旧形态。不加 sandbox、不发握手、不响应桥调用——改它只会打断存量插件。判据是 URL 里有没有 `/api/plugin-web/`（`PluginPane.isWebPlugin`）。
+
+**绝不给 sandbox 加 `allow-same-origin`。** 同源的 iframe 能读 localStorage 里的 `X-Session-Id` 并打全部 `/api/*`，等于白送宿主权限。
+
+桥协议（`PluginPane.vue` 宿主端 / `sdk/plugin-sdk/awd-plugin-sdk.js` 插件端 / 官网模板与宿主模拟器，**三处同一份契约**）：`init` 握手 → `call{seq,method,params}` → `result{seq,ok,result|error}`；双向来源校验（宿主认 `event.source === iframe.contentWindow`，插件认 `window.parent`），targetOrigin 只能 `'*'`（opaque origin）。v1 方法：`context.get` / `files.list` / `files.read` / `ui.toast` / `storage.get` / `storage.set`；错误码 `permission_denied` / `unknown_method` / `quota_exceeded` / `not_found`。
+
+**这是 manifest permissions 第一次成为真实边界**：缺 `file_read` 时 `files.*` 直接 `permission_denied`；`network` 决定 PluginWebController 下发的 CSP 是 `connect-src 'none'` 还是 `connect-src https:`。JAR 插件同 JVM 同权限，做不到这一点。
+
+插件级 KV 存宿主 `localStorage` 的 `awd_plugin_kv_<pluginId>`，总量 64 KB；`files.read` 文本上限 5 MB（超限截断且 `truncated:true`，不报错），扩展名不在可抽取文本白名单里的按二进制拒绝。
+
+`manifest.packs: ["<packId>"]`（v2.3）：在线安装成功后 `PluginMarketService` 逐个 `NativePackService.installAsync`，**装不上不回滚插件只记 WARN**。
+
+示例：`examples/hello-web-plugin/`；SDK 源头 `sdk/plugin-sdk/`（官网模板里那份是分发副本，必须逐字节一致）。
 
 ## 注册与加载链路
 
 1. 静态注册：`frontend/src/config/leftSidebarPlugins.js` 导出 LEFT_SIDEBAR_PLUGINS + `getPluginsForUser(role)`。
 2. project-overview.vue 计算属性（~:1581）合并静态列表与 dynamicPlugins。
-3. 动态插件：`loadDynamicPlugins()`（~:6261）调 `GET /api/plugins/list`，映射成 `{key:'plugin-<id>', label, icon, isDynamic, frontendEntry}`。
+3. 动态插件：`loadDynamicPlugins()`（~:6261）调 `GET /api/plugins/list`，映射成 `{key:'plugin-<id>', pluginId, label, icon, isDynamic, permissions, frontendEntry}`。`frontendEntry` 经 `api.js` 的 `resolvePluginEntryUrl(id, entry)`：相对路径 → `<apiBase>/api/plugin-web/<id>/<entry>`，绝对 URL 原样。**`key` 是 `plugin-<id>`，`pluginId` 才是原始 id**——桥的握手上下文与 KV 分区键用后者，混用会让插件存储串到别的键上。
 4. 面板分发（~:531-563）按 leftPaneKey：dd-files→DdFilesPanel、desensitize→DesensitizePane、easyvoice→EasyVoicePane、search→SearchPanel、files→文件树、动态→PluginPane、其余→占位符。
 5. 后端 PluginService：@PostConstruct 扫 `plugins/`（可配 `ai.plugins.dir`），读 manifest.json → PluginMetadata；有 backendJars 时独立 URLClassLoader 加载，扫 langchain4j @Tool 类注册进 ToolRegistry。`POST /api/plugins/rescan` 热重扫。
 
@@ -113,6 +132,8 @@ manifest.json 要点：id（必需）/name/version/icon/author/permissions（fil
 - skill 的 allowed_tools 写错工具名不会报错，只是白名单零命中回退不裁剪——排查工具可见性问题时先核对 ToolRegistry 真名。**部分**写错更阴险：剩下的名字还能命中，裁剪照常生效，写错的那个工具就静默消失了。
 - `RealToolBeans.instantiateAll()`（评测用的工具 bean 清单）与生产的 `AgentToolComponent` 实现集**不是自动同步的**：`TodoTools` 就不在里面，所以 `todo_write` 在回放评测里根本没注册，评测断言不到它的可见性。新增工具组件时要顺手补进去。
 - 插件启停语义只影响可见性，不拦截历史工具调用回放。
+- **Web 插件的 `frontendEntry` 校验失败是静默降级**：指到 `web/` 之外或文件不存在时 `PluginService` 把它置空并记 WARN，前端表现为「未配置入口地址」的空面板——面板空白先查后端日志的这条 WARN，别去前端找。
+- **`/api/plugin-web` 不要加登录闸**：iframe 是 opaque origin，带不出凭据，加了只会让面板白屏；那里也没有用户数据。禁用/未安装/被封禁一律 404（不是 403，不泄露 id 存在性）。
 - 改 AgentOrchestrator 构造器（如注入新服务）必须同步 EvalHarness（踩过两次）。
 - **「先落中间态再 `executor.submit`」的服务（会议转写就是），测试里断中间态必须先卡住后台线程**：`save` mock 成原样返回入参时，方法返回的对象与测试持有的是同一个可变实例，后台那个瞬间返回的 mock 会抢先把它改成终态，断言成败取决于 runner 调度（#394 修的就是这个间歇红）。用 `CountDownLatch` 卡住后台调用的那个 mock，断完中间态再 `countDown` 放行。
 - SubAgentTools 曾因循环依赖断启动，用 @Lazy 解决（PR#98），插件/工具类注入编排器时注意。

--- a/backend/src/main/java/com/checkba/controller/ai/PluginWebController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginWebController.java
@@ -1,0 +1,175 @@
+package com.checkba.controller.ai;
+
+import com.checkba.service.ai.PluginService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Web 插件静态资源服务（规范 v2.3，见 docs/PLUGIN_SPEC.md §9 与
+ * docs/NATIVE_PACK_DISTRIBUTION.md §11）。
+ *
+ * <p>把 {@code plugins/<id>/web/} 下的纯静态文件服务出来，供工作台的
+ * {@code PluginPane.vue} 用 sandbox iframe 承载。
+ *
+ * <h3>为什么不要登录态</h3>
+ * 这里只有插件包自带的静态资产，没有任何用户数据；而承载它的 iframe 带
+ * {@code sandbox="allow-scripts allow-forms"}（**无** allow-same-origin），
+ * 是 opaque origin，本来也带不出任何凭据。要登录既没有安全收益，还会让
+ * iframe 直接白屏。插件想碰用户数据只有 postMessage 桥一条路，权限在宿主端裁剪。
+ *
+ * <h3>四道守卫</h3>
+ * <ol>
+ *   <li>id 必须过 {@link #PLUGIN_ID} 正则；</li>
+ *   <li>目标文件的 canonical path 必须落在 {@code <pluginDir>/web/} 之下
+ *       （{@link PluginService#resolveWebFile}，同时挡 {@code ../} 与符号链接）；</li>
+ *   <li>只服务**已启用**插件：未安装 / 已禁用 / 被平台封禁一律 404，
+ *       与「禁用即不加载 JAR」同一口径——禁用了就不该还能跑它的代码；</li>
+ *   <li>响应带严格 CSP + {@code nosniff}：默认 {@code connect-src 'none'}，
+ *       只有 manifest 声明了 {@code network} 权限的插件才放开到 {@code https:}。</li>
+ * </ol>
+ *
+ * <p>一律 404 而不是 403：不向调用方泄露「这个 id 存在但被禁用了」。
+ */
+@RestController
+@RequestMapping("/api/plugin-web")
+@RequiredArgsConstructor
+@Slf4j
+public class PluginWebController {
+
+    /** 与 PluginMarketService / NativePackService 同一套 id 规则 */
+    private static final Pattern PLUGIN_ID = Pattern.compile("^[a-z0-9][a-z0-9-]{1,49}$");
+
+    private static final String PREFIX = "/api/plugin-web/";
+
+    /** 常见静态资产的 Content-Type；其余一律 octet-stream（配合 nosniff 就是「不执行」） */
+    private static final Map<String, String> CONTENT_TYPES = Map.ofEntries(
+            Map.entry("html", "text/html; charset=utf-8"),
+            Map.entry("htm", "text/html; charset=utf-8"),
+            Map.entry("js", "text/javascript; charset=utf-8"),
+            Map.entry("mjs", "text/javascript; charset=utf-8"),
+            Map.entry("css", "text/css; charset=utf-8"),
+            Map.entry("json", "application/json; charset=utf-8"),
+            Map.entry("txt", "text/plain; charset=utf-8"),
+            Map.entry("map", "application/json; charset=utf-8"),
+            Map.entry("svg", "image/svg+xml"),
+            Map.entry("png", "image/png"),
+            Map.entry("jpg", "image/jpeg"),
+            Map.entry("jpeg", "image/jpeg"),
+            Map.entry("gif", "image/gif"),
+            Map.entry("webp", "image/webp"),
+            Map.entry("ico", "image/x-icon"),
+            Map.entry("woff", "font/woff"),
+            Map.entry("woff2", "font/woff2"),
+            Map.entry("ttf", "font/ttf"),
+            Map.entry("otf", "font/otf"));
+
+    /** 不声明 network 权限时的 CSP：插件出不了网，只能走 postMessage 桥 */
+    static final String CSP_BASE =
+            "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "
+                    + "img-src 'self' data:; font-src 'self' data:; connect-src ";
+
+    private final PluginService pluginService;
+
+    @GetMapping("/{id}/**")
+    public ResponseEntity<byte[]> serve(@PathVariable("id") String id, HttpServletRequest request) {
+        if (id == null || !PLUGIN_ID.matcher(id).matches()) {
+            return ResponseEntity.notFound().build();
+        }
+        PluginService.PluginMetadata meta = pluginService.getPlugin(id);
+        if (meta == null || !pluginService.isEnabled(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        String subPath = subPathOf(request, id);
+        if (subPath == null || subPath.isBlank()) {
+            return ResponseEntity.notFound().build();
+        }
+        File file = pluginService.resolveWebFile(pluginService.getPluginDir(id), subPath);
+        if (file == null) {
+            return ResponseEntity.notFound().build();
+        }
+        byte[] body;
+        try {
+            body = Files.readAllBytes(file.toPath());
+        } catch (Exception e) {
+            log.warn("Failed to read plugin web asset {}/{}: {}", id, subPath, e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, contentTypeOf(subPath))
+                .header("Content-Security-Policy", cspFor(meta))
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.CACHE_CONTROL, "no-cache")
+                .body(body);
+    }
+
+    /**
+     * 取出 {@code /api/plugin-web/<id>/} 之后的子路径。
+     *
+     * <p>从原始 URI 自己切而不用 {@code **} 通配变量：Spring 对通配段的解码时机随
+     * PathPattern 配置而变，这里统一「先切后解码」，解码结果里的 {@code ..} 由
+     * {@link PluginService#resolveWebFile} 的 canonical 校验兜底。
+     */
+    static String subPathOf(HttpServletRequest request, String id) {
+        String uri = request.getRequestURI();
+        if (uri == null) {
+            return null;
+        }
+        int at = uri.indexOf(PREFIX);
+        if (at < 0) {
+            return null;
+        }
+        String rest = uri.substring(at + PREFIX.length());
+        if (!rest.startsWith(id)) {
+            return null;
+        }
+        rest = rest.substring(id.length());
+        if (!rest.startsWith("/")) {
+            return null;
+        }
+        rest = rest.substring(1);
+        int query = rest.indexOf('?');
+        if (query >= 0) {
+            rest = rest.substring(0, query);
+        }
+        try {
+            return URLDecoder.decode(rest, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * CSP：声明了 {@code network} 权限的插件放开 {@code connect-src https:}，否则 {@code 'none'}。
+     * 这是 manifest 权限第一次成为**运行时的真实边界**——JAR 插件做不到，这里由浏览器执行。
+     */
+    static String cspFor(PluginService.PluginMetadata meta) {
+        List<String> permissions = meta.getPermissions();
+        boolean network = permissions != null && permissions.contains("network");
+        return CSP_BASE + (network ? "https:" : "'none'");
+    }
+
+    static String contentTypeOf(String subPath) {
+        int dot = subPath.lastIndexOf('.');
+        if (dot < 0 || dot == subPath.length() - 1) {
+            return "application/octet-stream";
+        }
+        String ext = subPath.substring(dot + 1).toLowerCase(Locale.ROOT);
+        return CONTENT_TYPES.getOrDefault(ext, "application/octet-stream");
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
@@ -62,6 +62,18 @@ public class PluginMarketService {
     private final PluginService pluginService;
     private final MarketPurchaseGate purchaseGate;
 
+    /**
+     * 插件 manifest 声明的 pack 依赖由它去装。setter 注入而非构造器参数：
+     * pack 联动是安装后的可选副作用，缺了它安装链路必须照常工作（既有单测直接
+     * {@code new PluginMarketService(...)}，不该被迫编造一个 pack 服务）。
+     */
+    private com.checkba.service.pack.NativePackService nativePackService;
+
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    public void setNativePackService(com.checkba.service.pack.NativePackService nativePackService) {
+        this.nativePackService = nativePackService;
+    }
+
     public PluginMarketService(
             @Value("${ai.plugins.registry-url:https://www.aiworkdeck.com/api/registry/plugins}") String registryUrl,
             @Value("${ai.plugins.registry-public-key:}") String publicKeyPem,
@@ -247,7 +259,36 @@ public class PluginMarketService {
         pluginService.markDisabledBeforeLoad(id);
         pluginService.rescan();
         log.info("Installed market plugin '{}' v{} (disabled until user confirms)", id, version);
+        installDeclaredPacks(id);
         return id;
+    }
+
+    /**
+     * 装完插件后补装它声明的原生资源包（manifest.packs，见
+     * docs/NATIVE_PACK_DISTRIBUTION.md §11.4）。
+     *
+     * <p>刻意**不回滚插件**：pack 是独立分发物，有自己的状态机、进度条与重试面
+     * （{@code /api/packs/{id}/status}）。这里下不动网就把插件也删掉，等于让一次
+     * 网络抖动吃掉用户刚装好的插件——记 WARN，把重试留给 pack 自己那套。
+     */
+    private void installDeclaredPacks(String pluginId) {
+        if (nativePackService == null) {
+            return;
+        }
+        PluginService.PluginMetadata meta = pluginService.getPlugin(pluginId);
+        List<String> packs = meta == null ? null : meta.getPacks();
+        if (packs == null || packs.isEmpty()) {
+            return;
+        }
+        for (String packId : packs) {
+            try {
+                nativePackService.installAsync(packId);
+                log.info("Plugin {} declares pack '{}', install queued", pluginId, packId);
+            } catch (Exception e) {
+                log.warn("Plugin {} declares pack '{}' but queuing its install failed: {}",
+                        pluginId, packId, e.getMessage());
+            }
+        }
     }
 
     /** 卸载：删除 plugins/<id>/ 并 rescan */

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -37,6 +37,10 @@ public class PluginService {
     private static final Set<String> KNOWN_PERMISSIONS =
             Set.of("file_read", "file_write", "network", "editor");
 
+    /** manifest.packs 里的 pack id 规则，与 NativePackService / PluginMarketService 同一套 */
+    private static final java.util.regex.Pattern PACK_ID =
+            java.util.regex.Pattern.compile("^[a-z0-9][a-z0-9-]{1,49}$");
+
     // 并发安全：rescan() 会 clear()+重填这些集合，而 ToolRegistry 在高频请求线程上无同步地遍历读取，
     // 普通 ArrayList/HashMap 会抛 ConcurrentModificationException / 读到半空状态。
     @Getter
@@ -97,8 +101,21 @@ public class PluginService {
         private String icon;
         private String author;
         private String homepage;
+        /**
+         * 前端入口（规范 v2.3 激活）：
+         * <ul>
+         *   <li>{@code web/index.html} 这样的相对路径 = Web 插件，由 PluginWebController 静态服务；
+         *       扫描时校验必须落在插件目录的 {@code web/} 之下且文件存在，否则置空并记 WARN。</li>
+         *   <li>{@code http(s)://} 绝对 URL = 旧形态，原样透传给前端 iframe（不校验、不改行为）。</li>
+         * </ul>
+         */
         private String frontendEntry;
         private List<String> backendJars;
+        /**
+         * 依赖的原生资源包 id 列表（规范 v2.3，见 docs/NATIVE_PACK_DISTRIBUTION.md §11.4）。
+         * 在线安装该插件成功后逐个异步安装；pack 自己有状态与重试面，装失败不回滚插件。
+         */
+        private List<String> packs;
         /** 声明需要的能力：file_read / file_write / network / editor */
         private List<String> permissions;
         /** 插件提供的工具清单（名称 + 中文描述） */
@@ -307,6 +324,98 @@ public class PluginService {
         return toolToPluginId.get(toolName);
     }
 
+    /** 已加载的插件元数据；未知 id 返回 null */
+    public PluginMetadata getPlugin(String pluginId) {
+        return plugins.stream()
+                .filter(p -> Objects.equals(p.getId(), pluginId))
+                .findFirst().orElse(null);
+    }
+
+    /** 插件所在目录；未知 id 返回 null（供 PluginWebController 定位 web/ 静态资源） */
+    public File getPluginDir(String pluginId) {
+        return pluginDirById.get(pluginId);
+    }
+
+    /**
+     * 该插件是否带 Web 前端（frontendEntry 为校验通过的 {@code web/} 内相对路径）。
+     * 绝对 URL 形态返回 false——那种插件不经 PluginWebController，也不走 postMessage 桥。
+     */
+    public boolean hasWebEntry(String pluginId) {
+        PluginMetadata meta = getPlugin(pluginId);
+        return meta != null && meta.getFrontendEntry() != null && !isAbsoluteUrl(meta.getFrontendEntry());
+    }
+
+    private static boolean isAbsoluteUrl(String entry) {
+        String lower = entry.toLowerCase(Locale.ROOT);
+        return lower.startsWith("http://") || lower.startsWith("https://");
+    }
+
+    /**
+     * 校验 manifest.frontendEntry（规范 v2.3）。
+     *
+     * <p>绝对 http(s) URL 原样保留（旧形态，宿主直接 iframe 打开，本服务不介入）。
+     * 相对路径必须落在插件目录的 {@code web/} 之下且文件存在——否则**置空并记 WARN**，
+     * 当作没有前端入口：宁可这个插件在左栏显示空面板，也不能让一个指到
+     * {@code ../../} 的入口把插件目录之外的文件静态服务出去。
+     */
+    void validateFrontendEntry(File pluginDir, PluginMetadata meta) {
+        String entry = meta.getFrontendEntry();
+        if (entry == null || entry.isBlank()) {
+            meta.setFrontendEntry(null);
+            return;
+        }
+        entry = entry.trim();
+        if (isAbsoluteUrl(entry)) {
+            meta.setFrontendEntry(entry);
+            return;
+        }
+        String normalized = entry.replace('\\', '/');
+        while (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        }
+        if (!normalized.startsWith("web/")) {
+            log.warn("Plugin {} declares frontendEntry '{}' outside web/, treated as no web entry",
+                    meta.getId(), entry);
+            meta.setFrontendEntry(null);
+            return;
+        }
+        File target = resolveWebFile(pluginDir, normalized.substring("web/".length()));
+        if (target == null) {
+            log.warn("Plugin {} declares frontendEntry '{}' but the file is missing or escapes web/, "
+                    + "treated as no web entry", meta.getId(), entry);
+            meta.setFrontendEntry(null);
+            return;
+        }
+        meta.setFrontendEntry(normalized);
+    }
+
+    /**
+     * 把 {@code web/} 之下的相对子路径解析成真实文件。
+     *
+     * <p>用 canonical path 判定目标必须位于 {@code <pluginDir>/web/} 正下方——同时挡掉
+     * {@code ../} 穿越与符号链接绕行。这是 Web 插件静态服务的唯一定位入口。
+     *
+     * @param subPath 相对 {@code web/} 的路径，如 {@code index.html}、{@code assets/app.js}
+     * @return 校验通过且存在的普通文件；非法 / 不存在 / 是目录时返回 null
+     */
+    public File resolveWebFile(File pluginDir, String subPath) {
+        if (pluginDir == null || subPath == null || subPath.isBlank()) {
+            return null;
+        }
+        try {
+            File webRoot = new File(pluginDir, "web");
+            File target = new File(webRoot, subPath);
+            String base = webRoot.getCanonicalPath() + File.separator;
+            if (!target.getCanonicalPath().startsWith(base)) {
+                return null;
+            }
+            return target.isFile() ? target : null;
+        } catch (IOException e) {
+            log.warn("Plugin web path check failed for '{}': {}", subPath, e.getMessage());
+            return null;
+        }
+    }
+
     private void loadDisabledState() {
         disabledPluginIds.clear();
         if (systemSettingService == null) {
@@ -355,6 +464,7 @@ public class PluginService {
                     log.warn("Duplicate plugin id '{}', skip plugin dir: {}", meta.getId(), pluginDir.getName());
                     continue;
                 }
+                validateFrontendEntry(pluginDir, meta);
                 plugins.add(meta);
                 pluginDirById.put(meta.getId(), pluginDir);
 
@@ -441,6 +551,19 @@ public class PluginService {
                             meta.getId(), p, KNOWN_PERMISSIONS);
                 }
             }
+        }
+        // packs（规范 v2.3）：id 必须过与 pack / 插件同一套正则，非法项丢弃并告警——
+        // 这串字符会被拼进注册表 URL 与磁盘路径，不能放行任意输入。
+        if (meta.getPacks() != null) {
+            List<String> valid = new ArrayList<>();
+            for (String packId : meta.getPacks()) {
+                if (packId != null && PACK_ID.matcher(packId).matches()) {
+                    valid.add(packId);
+                } else {
+                    log.warn("Plugin {} declares invalid pack id '{}', ignored", meta.getId(), packId);
+                }
+            }
+            meta.setPacks(valid);
         }
         return meta;
     }

--- a/backend/src/test/java/com/checkba/controller/ai/PluginWebControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/PluginWebControllerTest.java
@@ -1,0 +1,182 @@
+package com.checkba.controller.ai;
+
+import com.checkba.service.SystemSettingService;
+import com.checkba.service.ai.PluginService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * PluginWebController 测试：路径穿越 / 禁用插件 404 / CSP 随 network 权限变化 / Content-Type。
+ *
+ * 用真的 PluginService（临时插件目录）而不是 mock：被测的核心是「哪些请求能拿到字节」，
+ * 而那条判定链一半在 PluginService.resolveWebFile 的 canonical 校验里，mock 掉就等于
+ * 把被测对象换成了测试自己的假设。
+ */
+class PluginWebControllerTest {
+
+    @TempDir
+    Path pluginsDir;
+
+    private final Map<String, String> settingStore = new HashMap<>();
+    private PluginService pluginService;
+    private PluginWebController controller;
+
+    @BeforeEach
+    void setUp() {
+        SystemSettingService settings = mock(SystemSettingService.class);
+        when(settings.get(anyString(), anyString())).thenAnswer(inv ->
+                settingStore.getOrDefault(inv.getArgument(0), inv.getArgument(1)));
+        doAnswer(inv -> settingStore.put(inv.getArgument(0), inv.getArgument(1)))
+                .when(settings).set(anyString(), anyString());
+        pluginService = new PluginService(settings, pluginsDir.toString());
+        controller = new PluginWebController(pluginService);
+    }
+
+    /** 写一个带 web/ 的插件；permissions 直接拼进 manifest */
+    private void writeWebPlugin(String id, String permissionsJson) throws IOException {
+        Path dir = pluginsDir.resolve(id);
+        Files.createDirectories(dir.resolve("web").resolve("assets"));
+        Files.writeString(dir.resolve("manifest.json"), """
+                {
+                  "id": "%s",
+                  "name": "Web 插件",
+                  "version": "1.0.0",
+                  "permissions": %s,
+                  "frontendEntry": "web/index.html"
+                }
+                """.formatted(id, permissionsJson), StandardCharsets.UTF_8);
+        Files.writeString(dir.resolve("web").resolve("index.html"), "<h1>hi</h1>", StandardCharsets.UTF_8);
+        Files.writeString(dir.resolve("web").resolve("assets").resolve("app.js"), "console.log(1)", StandardCharsets.UTF_8);
+        Files.write(dir.resolve("web").resolve("logo.png"), new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+        // 插件目录里、但在 web/ 之外的东西：不许被服务出去
+        Files.writeString(dir.resolve("secret.txt"), "隐私", StandardCharsets.UTF_8);
+    }
+
+    private ResponseEntity<byte[]> get(String id, String subPath) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/plugin-web/" + id + "/" + subPath);
+        request.setRequestURI("/api/plugin-web/" + id + "/" + subPath);
+        return controller.serve(id, request);
+    }
+
+    // ==== 正常服务 ====
+
+    @Test
+    @DisplayName("启用插件的 web/ 文件正常返回，带 CSP / nosniff / no-cache")
+    void servesEnabledPluginAssets() throws IOException {
+        writeWebPlugin("web-plugin", "[]");
+        pluginService.init();
+
+        ResponseEntity<byte[]> res = get("web-plugin", "index.html");
+        assertEquals(200, res.getStatusCode().value());
+        assertEquals("<h1>hi</h1>", new String(res.getBody(), StandardCharsets.UTF_8));
+        assertEquals("text/html; charset=utf-8", res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals("nosniff", res.getHeaders().getFirst("X-Content-Type-Options"));
+        assertEquals("no-cache", res.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL));
+        assertNotNull(res.getHeaders().getFirst("Content-Security-Policy"));
+
+        assertEquals(200, get("web-plugin", "assets/app.js").getStatusCode().value(), "子目录资产应可服务");
+    }
+
+    @Test
+    @DisplayName("Content-Type 按扩展名给；未知扩展名退 octet-stream")
+    void contentTypeByExtension() throws IOException {
+        writeWebPlugin("web-plugin", "[]");
+        pluginService.init();
+
+        assertEquals("text/javascript; charset=utf-8",
+                get("web-plugin", "assets/app.js").getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals("image/png",
+                get("web-plugin", "logo.png").getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals("application/octet-stream", PluginWebController.contentTypeOf("data.bin"));
+        assertEquals("application/octet-stream", PluginWebController.contentTypeOf("noext"));
+        assertEquals("font/woff2", PluginWebController.contentTypeOf("f.woff2"));
+        assertEquals("image/svg+xml", PluginWebController.contentTypeOf("i.SVG"), "扩展名大小写不敏感");
+    }
+
+    // ==== CSP 随 network 权限变化 ====
+
+    @Test
+    @DisplayName("未声明 network 的插件 connect-src 'none'；声明了才放开 https:")
+    void cspFollowsNetworkPermission() throws IOException {
+        writeWebPlugin("offline-plugin", "[]");
+        writeWebPlugin("online-plugin", "[\"network\"]");
+        pluginService.init();
+
+        String offline = get("offline-plugin", "index.html").getHeaders().getFirst("Content-Security-Policy");
+        assertTrue(offline.contains("default-src 'none'"), offline);
+        assertTrue(offline.endsWith("connect-src 'none'"), offline);
+
+        String online = get("online-plugin", "index.html").getHeaders().getFirst("Content-Security-Policy");
+        assertTrue(online.endsWith("connect-src https:"), online);
+        assertTrue(online.contains("img-src 'self' data:"), online);
+    }
+
+    // ==== 路径穿越 ====
+
+    @Test
+    @DisplayName("路径穿越一律 404：../ 出 web/、出插件目录、编码后的 ..")
+    void pathTraversalIsRejected() throws IOException {
+        writeWebPlugin("web-plugin", "[]");
+        pluginService.init();
+
+        assertEquals(404, get("web-plugin", "../secret.txt").getStatusCode().value(),
+                "web/ 之外的插件文件不许服务");
+        assertEquals(404, get("web-plugin", "../manifest.json").getStatusCode().value());
+        assertEquals(404, get("web-plugin", "../../../etc/passwd").getStatusCode().value());
+        assertEquals(404, get("web-plugin", "%2e%2e/secret.txt").getStatusCode().value(),
+                "百分号编码的 .. 解码后同样要被 canonical 校验挡住");
+        assertEquals(404, get("web-plugin", "assets/../../secret.txt").getStatusCode().value());
+        assertEquals(404, get("web-plugin", "missing.html").getStatusCode().value());
+        assertEquals(404, get("web-plugin", "assets").getStatusCode().value(), "目录不是文件");
+    }
+
+    @Test
+    @DisplayName("非法插件 id 一律 404，不落到文件系统")
+    void invalidPluginIdIsRejected() throws IOException {
+        writeWebPlugin("web-plugin", "[]");
+        pluginService.init();
+
+        assertEquals(404, get("../web-plugin", "index.html").getStatusCode().value());
+        assertEquals(404, get("Web-Plugin", "index.html").getStatusCode().value(), "大写不合规则");
+        assertEquals(404, get("a", "index.html").getStatusCode().value(), "长度不足");
+        assertEquals(404, get("web-plugin", "").getStatusCode().value(), "空子路径");
+    }
+
+    // ==== 启停与未安装 ====
+
+    @Test
+    @DisplayName("禁用的插件 404（与「禁用即不加载」同口径），重新启用后恢复")
+    void disabledPluginIsNotServed() throws IOException {
+        writeWebPlugin("web-plugin", "[]");
+        settingStore.put(PluginService.DISABLED_KEY, "[\"web-plugin\"]");
+        pluginService.init();
+
+        assertEquals(404, get("web-plugin", "index.html").getStatusCode().value());
+
+        pluginService.setEnabled("web-plugin", true);
+        assertEquals(200, get("web-plugin", "index.html").getStatusCode().value());
+    }
+
+    @Test
+    @DisplayName("未安装的插件 404")
+    void unknownPluginIsNotServed() {
+        pluginService.init();
+        assertEquals(404, get("ghost-plugin", "index.html").getStatusCode().value());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -222,6 +222,71 @@ class PluginMarketServiceTest {
         assertFalse(downloaded[0], "验签失败必须在下载任何文件之前中止");
     }
 
+    // ==== manifest.packs 联动（规范 v2.3 / NATIVE_PACK_DISTRIBUTION §11.4） ====
+
+    /** 装一个 manifest 声明了 packs 的插件，返回打桩过的 service（pack 服务由调用方注入） */
+    private PluginMarketService stubbedWithManifest(String manifest) throws Exception {
+        byte[] manifestBytes = manifest.getBytes(StandardCharsets.UTF_8);
+        Map<String, String> files = new TreeMap<>();
+        files.put("manifest.json", PluginMarketService.sha256Hex(manifestBytes));
+        String sig = sign(canonical("demo", "1.0.0", "2026-07-27T00:00:00Z", files));
+        return stubbed(publicKeyPem, files, sig, manifestBytes, null);
+    }
+
+    @Test
+    @DisplayName("安装成功后按 manifest.packs 逐个异步安装依赖的资源包")
+    void installQueuesDeclaredPacks() throws Exception {
+        PluginMarketService svc = stubbedWithManifest(
+                "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\","
+                        + "\"packs\":[\"litviz-fonts\",\"demo-pack\"]}");
+        com.checkba.service.pack.NativePackService packs =
+                mock(com.checkba.service.pack.NativePackService.class);
+        svc.setNativePackService(packs);
+
+        assertEquals("demo", svc.install("demo"));
+
+        verify(packs).installAsync("litviz-fonts");
+        verify(packs).installAsync("demo-pack");
+        verifyNoMoreInteractions(packs);
+    }
+
+    @Test
+    @DisplayName("pack 排队失败不回滚插件——pack 有自己的状态机与重试面")
+    void packInstallFailureDoesNotRollbackPlugin() throws Exception {
+        PluginMarketService svc = stubbedWithManifest(
+                "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\",\"packs\":[\"demo-pack\"]}");
+        com.checkba.service.pack.NativePackService packs =
+                mock(com.checkba.service.pack.NativePackService.class);
+        doThrow(new IllegalStateException("注册表不可达")).when(packs).installAsync(anyString());
+        svc.setNativePackService(packs);
+
+        assertEquals("demo", svc.install("demo"), "pack 装不上不该让插件安装失败");
+        assertTrue(Files.exists(pluginsDir.resolve("demo").resolve("manifest.json")));
+    }
+
+    @Test
+    @DisplayName("未声明 packs 的插件不触碰 pack 服务")
+    void installWithoutPacksDoesNotTouchPackService() throws Exception {
+        PluginMarketService svc = stubbedWithManifest(
+                "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\"}");
+        com.checkba.service.pack.NativePackService packs =
+                mock(com.checkba.service.pack.NativePackService.class);
+        svc.setNativePackService(packs);
+
+        assertEquals("demo", svc.install("demo"));
+        verifyNoInteractions(packs);
+    }
+
+    @Test
+    @DisplayName("未注入 pack 服务时安装链路照常工作（单机/单测形态）")
+    void installWorksWithoutPackService() throws Exception {
+        PluginMarketService svc = stubbedWithManifest(
+                "{\"id\":\"demo\",\"name\":\"演示\",\"version\":\"1.0.0\",\"packs\":[\"demo-pack\"]}");
+
+        assertEquals("demo", svc.install("demo"));
+        assertTrue(Files.exists(pluginsDir.resolve("demo").resolve("manifest.json")));
+    }
+
     @Test
     @DisplayName("封禁的插件不允许被重新启用")
     void revokedPluginCannotBeEnabled() throws Exception {

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -311,6 +311,122 @@ class PluginServiceTest {
 
     // ==== 禁用插件不加载 ====
 
+    // ==== 规范 v2.3：frontendEntry 校验 ====
+
+    /** 写一个带 web/index.html 的插件目录，frontendEntry 由调用方指定（null = 不写该字段） */
+    private void writeWebPlugin(String id, String frontendEntry) throws IOException {
+        Path dir = pluginsDir.resolve(id);
+        Files.createDirectories(dir.resolve("web"));
+        Files.writeString(dir.resolve("web").resolve("index.html"), "<h1>hi</h1>", StandardCharsets.UTF_8);
+        Files.writeString(dir.resolve("outside.html"), "<h1>out</h1>", StandardCharsets.UTF_8);
+        String entryJson = frontendEntry == null ? "null" : "\"" + frontendEntry + "\"";
+        writeManifest(id, "{\"id\": \"" + id + "\", \"name\": \"W\", \"frontendEntry\": " + entryJson + "}");
+    }
+
+    @Test
+    @DisplayName("frontendEntry 指向 web/ 内真实文件时保留，并识别为 Web 插件")
+    void validFrontendEntryIsKept() throws IOException {
+        writeWebPlugin("web-plugin", "web/index.html");
+        service.init();
+
+        assertEquals("web/index.html", service.getPlugins().get(0).getFrontendEntry());
+        assertTrue(service.hasWebEntry("web-plugin"));
+        assertNotNull(service.getPluginDir("web-plugin"));
+    }
+
+    @Test
+    @DisplayName("frontendEntry 指向 web/ 之外、或文件不存在时置空并当作无前端入口")
+    void invalidFrontendEntryIsDropped() throws IOException {
+        writeWebPlugin("escape-plugin", "../outside.html");
+        writeWebPlugin("outside-web", "outside.html");
+        writeWebPlugin("missing-file", "web/missing.html");
+        writeWebPlugin("escape-inside-web", "web/../outside.html");
+        service.init();
+
+        for (String id : List.of("escape-plugin", "outside-web", "missing-file", "escape-inside-web")) {
+            assertNull(service.getPlugin(id).getFrontendEntry(), id + " 的非法入口应被置空");
+            assertFalse(service.hasWebEntry(id), id);
+        }
+    }
+
+    @Test
+    @DisplayName("frontendEntry 是绝对 http(s) URL 时原样保留，且不算 Web 插件（旧形态不变）")
+    void absoluteUrlFrontendEntryIsPassedThrough() throws IOException {
+        writeManifest("legacy", "{\"id\": \"legacy\", \"name\": \"L\", "
+                + "\"frontendEntry\": \"https://example.com/panel\"}");
+        service.init();
+
+        assertEquals("https://example.com/panel", service.getPlugin("legacy").getFrontendEntry());
+        assertFalse(service.hasWebEntry("legacy"), "绝对 URL 不经 PluginWebController，也不走桥");
+    }
+
+    @Test
+    @DisplayName("resolveWebFile：web/ 内放行，穿越与目录一律 null")
+    void resolveWebFileGuards() throws IOException {
+        writeWebPlugin("web-plugin", "web/index.html");
+        service.init();
+        java.io.File dir = service.getPluginDir("web-plugin");
+
+        assertNotNull(service.resolveWebFile(dir, "index.html"));
+        assertNull(service.resolveWebFile(dir, "../outside.html"));
+        assertNull(service.resolveWebFile(dir, "../../"));
+        assertNull(service.resolveWebFile(dir, "missing.html"));
+        assertNull(service.resolveWebFile(dir, ""));
+        assertNull(service.resolveWebFile(dir, null));
+        assertNull(service.resolveWebFile(null, "index.html"));
+    }
+
+    // ==== 规范 v2.3：packs ====
+
+    @Test
+    @DisplayName("examples/hello-web-plugin 是一个能真正加载起来的 Web 插件")
+    void bundledWebPluginExampleIsValid() throws IOException {
+        // 示例插件是三方作者照抄的样板，坏了没人会发现——扫描口径变化时这条先红
+        Path example = Path.of("..", "examples", "hello-web-plugin");
+        assertTrue(Files.isDirectory(example), "示例插件目录不存在：" + example.toAbsolutePath());
+        Path dest = pluginsDir.resolve("hello-web-plugin");
+        try (var walk = Files.walk(example)) {
+            for (Path src : walk.toList()) {
+                Path target = dest.resolve(example.relativize(src).toString());
+                if (Files.isDirectory(src)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(src, target);
+                }
+            }
+        }
+        service.init();
+
+        PluginService.PluginMetadata meta = service.getPlugin("hello-web-plugin");
+        assertNotNull(meta, "示例插件应被扫描到");
+        assertEquals("web/index.html", meta.getFrontendEntry(),
+                "frontendEntry 被置空说明 web/index.html 缺失或路径写错");
+        assertTrue(service.hasWebEntry("hello-web-plugin"));
+        assertEquals(List.of("file_read"), meta.getPermissions());
+        assertNotNull(service.resolveWebFile(service.getPluginDir("hello-web-plugin"), "awd-plugin-sdk.js"),
+                "index.html 同步引入的 SDK 副本必须在包内");
+    }
+
+    @Test
+    @DisplayName("packs 字段解析；非法 id 被丢弃（会被拼进注册表 URL 与磁盘路径）")
+    void parsesPacksAndDropsInvalidIds() throws IOException {
+        writeManifest("with-packs", "{\"id\": \"with-packs\", \"name\": \"P\", "
+                + "\"packs\": [\"litviz-fonts\", \"BAD-ID\", \"../escape\", \"\", \"ok2\"]}");
+        service.init();
+
+        assertEquals(List.of("litviz-fonts", "ok2"), service.getPlugin("with-packs").getPacks());
+    }
+
+    @Test
+    @DisplayName("未声明 packs 时为 null（v1/v2 兼容）")
+    void packsAbsentStaysNull() throws IOException {
+        writeManifest("no-packs", "{\"id\": \"no-packs\", \"name\": \"P\"}");
+        service.init();
+
+        assertNull(service.getPlugin("no-packs").getPacks());
+    }
+
     @Test
     @DisplayName("启动时被禁用的插件仍登记元数据，但不加载其 JAR")
     void disabledPluginIsRegisteredButJarNotLoaded() throws IOException {

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -51,11 +51,22 @@ AI provider 的 API key 后窃取、装 JVM 全局 TrustManager 关掉 TLS 校�
 ```
 （zip 根）
 ├── manifest.json          必需，规范见 PLUGIN_SPEC.md §2
-├── <name>.jar             manifest.backendJars 声明的 JAR
+├── <name>.jar             可选，manifest.backendJars 声明的 JAR
+├── web/                   可选，Web 插件的静态资源（frontendEntry 指向其中）
+│   ├── index.html
+│   └── awd-plugin-sdk.js
 └── <skill-dir>/           可选，manifest.skills 声明的 Skill 目录
     ├── skill.yml
     └── prompt.md
 ```
+
+**纯 Web 插件可以完全没有 JAR。** 只带 `web/` 的插件不进 JVM，跑在 opaque origin 的
+sandbox iframe 里、能力经 postMessage 桥按 manifest 权限裁剪——风险量级比 JAR 低一整档
+（形态与桥协议见 [PLUGIN_SPEC.md](PLUGIN_SPEC.md) §8）。`web/` 下的文件与 JAR 一样进
+`files` 哈希表、被同一个签名覆盖。
+
+审核上的差别：JS 没有常量池可扫，§4 的自动扫描对 `web/` 降级为「外联 URL 字面量提取 +
+权限交叉验证」，以人工审核为主；运行时的真实兜底是 sandbox 与 CSP，不是扫描。
 
 服务端受理时的硬性检查（任一不过直接拒收，不进审核队列）：
 
@@ -69,6 +80,7 @@ AI provider 的 API key 后窃取、装 JVM 全局 TrustManager 关掉 TLS 校�
 | id 归属 | 新 id 归提交者；已存在的 id 只有原作者能提交新版本 |
 | version | 必须严格大于该 id 已有的最高版本 |
 | backendJars | 声明的每个文件都必须在包内且落在包根之下 |
+| frontendEntry | 非空且非 `http(s)://` 时必须是 `web/` 之下的相对路径且文件在包内 |
 
 ## 4. 自动扫描（审核辅助，不做判定）
 

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -1,8 +1,13 @@
-# 插件规范 v2.1（Plugin Spec v2.1）
+# 插件规范 v2.3（Plugin Spec v2.3）
 
-> 适用版本：v1 自 0.4.x；v2（权限执行 + 启停过滤）自 Phase 3A；v2.1（插件携带 Skill）自 Phase 3B。示例插件见 [examples/hello-plugin/](../examples/hello-plugin/)。
-> 后端实现：`PluginService`（扫描/解析/启停）、`PluginController`（HTTP API）；
-> 前端管理页：`frontend/src/pages/plugin-market/plugin-market.vue`（插件广场，入口在系统管理侧边栏）。
+> 适用版本：v1 自 0.4.x；v2（权限执行 + 启停过滤）自 Phase 3A；v2.1（插件携带 Skill）自 Phase 3B；
+> v2.3（Web 插件 + `packs` 依赖）自 native pack Phase B。
+> 示例插件：[examples/hello-plugin/](../examples/hello-plugin/)（JAR 工具）、
+> [examples/hello-web-plugin/](../examples/hello-web-plugin/)（纯前端）。
+> 后端实现：`PluginService`（扫描/解析/启停）、`PluginController`（HTTP API）、
+> `PluginWebController`（Web 插件静态服务）；
+> 前端管理页：`frontend/src/pages/plugin-market/plugin-market.vue`（插件广场，入口在系统管理侧边栏）；
+> Web 插件宿主桥：`frontend/src/components/PluginPane.vue`；SDK 源头：[sdk/plugin-sdk/](../sdk/plugin-sdk/)。
 
 ## 1. 目录结构
 
@@ -12,7 +17,9 @@
 plugins/
 └── hello-plugin/
     ├── manifest.json          # 必需，插件元数据（本规范核心）
-    └── hello-plugin-1.0.0.jar # 可选，后端工具 JAR（manifest.backendJars 声明）
+    ├── hello-plugin-1.0.0.jar # 可选，后端工具 JAR（manifest.backendJars 声明）
+    └── web/                   # 可选，Web 插件的静态资源（frontendEntry 指向其中，见 §8）
+        └── index.html
 ```
 
 `ai.plugins.dir` 默认是相对路径 `plugins`，**实际落点由后端进程的工作目录决定**：
@@ -60,9 +67,10 @@ plugins/
 | `homepage` | string | 否 | 主页或仓库 URL。 |
 | `permissions` | string[] | 否 | 插件**自行声明**会用到的能力，见 §3。缺省视为不需要任何敏感能力。注意这是作者的自述，不是运行时授权。 |
 | `tools` | object[] | 否 | 工具清单（`name` + 中文 `description` + 可选 `permissions`），用于插件广场展示、人工审查与 v2 权限校验。`name` 应与 JAR 中 `@Tool` 方法名一致；`permissions` 声明**该工具运行所需**的能力（v2 新增，见 §3）。 |
-| `frontendEntry` | string | 否 | 前端入口（预留，v1 不加载）。 |
+| `frontendEntry` | string | 否 | **v2.3 起激活**：`web/index.html` 这样的相对路径 = Web 插件（见 §8）；`http(s)://` 绝对 URL = 旧形态，宿主直接 iframe 打开外部页面。 |
 | `backendJars` | string[] | 否 | 相对插件目录的 JAR 文件名列表，启动/重扫时加载其中带 `@Tool` 注解的类。 |
 | `skills` | string[] | 否 | **v2.1 新增**：插件携带的 Skill 子目录名列表（相对插件目录），见 §7。 |
+| `packs` | string[] | 否 | **v2.3 新增**：依赖的原生资源包 id 列表，见 §9 与 [NATIVE_PACK_DISTRIBUTION.md](NATIVE_PACK_DISTRIBUTION.md)。 |
 
 未知字段被忽略（向前兼容）；`permissions` 中出现 v1 未定义的值仅记录 WARN，不拒绝加载。
 
@@ -87,6 +95,12 @@ plugins/
 >
 > 它的真实价值：帮**诚实的**作者暴露"忘了声明"的疏漏，以及给人工审查提供一份可读的
 > 能力自述。对恶意插件零防御力。
+
+> **Web 插件（§8）是例外，也是这套声明第一次真正落地的地方。** 那类插件不进 JVM，
+> 跑在 opaque origin 的 sandbox iframe 里，唯一的出口是 postMessage 桥；桥的宿主端
+> 逐调用比对 `permissions`（缺 `file_read` 时 `files.*` 直接返回 `permission_denied`），
+> `network` 还会改写静态响应的 CSP `connect-src`。同一串字符串，在 JAR 插件上是自述，
+> 在 Web 插件上是**由浏览器与宿主共同执行的边界**。
 
 两级声明 + 分发时校验（实现在 `PluginService.missingPermissionsForTool()` +
 `ToolRegistry.execute()`）：
@@ -156,6 +170,7 @@ Java 侧没有进程内沙箱可用（`SecurityManager` 已于 JEP 411 废弃、
 | POST | `/api/plugins/{id}/enable` | admin | 启用插件 |
 | POST | `/api/plugins/{id}/disable` | admin | 禁用插件 |
 | POST | `/api/plugins/rescan` | admin | 重新扫描 plugins/ 目录，返回 `{ code, pluginCount, toolCount }` |
+| GET | `/api/plugin-web/{id}/**` | 无 | Web 插件静态资源（`plugins/<id>/web/` 之下），见 §8.2 |
 
 管理接口鉴权与 AdminConfigController 一致：`X-Session-Id` 请求头 → session 用户名为 `admin`。
 
@@ -178,16 +193,153 @@ plugins/
 - **插件被禁用时，其携带的 skill 不参与触发匹配**（管理页仍可见）；插件重新启用即恢复。
 - skill 自身的启停独立持久化（`ai.skills.disabled`），与插件启停叠加生效。
 
-## 8. 版本演进
+## 8. Web 插件（v2.3）
+
+`frontendEntry` 从「预留，v1 不加载」正式激活。一个只会写 HTML/JS 的开发者由此能造出
+看得见的东西——不需要 Java，不需要编译，`web/index.html` 就是全部。
+
+```
+plugins/
+└── my-web-plugin/
+    ├── manifest.json        # "frontendEntry": "web/index.html", "permissions": ["file_read"]
+    └── web/
+        ├── index.html
+        └── awd-plugin-sdk.js
+```
+
+纯 Web 插件**可以没有任何 JAR**（`backendJars` 留空或不写）：这类插件不进 JVM，
+风险量级比 JAR 低一整档。
+
+### 8.1 frontendEntry 的两种形态
+
+| 形态 | 例子 | 行为 |
+|---|---|---|
+| `web/` 之下的相对路径 | `web/index.html` | Web 插件：后端静态服务 + sandbox iframe + postMessage 桥 |
+| `http(s)://` 绝对 URL | `https://example.com/panel` | 旧形态：iframe 直接打开外部页面，不加 sandbox、不握手、不响应桥调用 |
+
+扫描时校验相对路径：必须以 `web/` 开头、canonical path 落在 `<pluginDir>/web/` 之下、
+且文件存在。任一不满足则**置空并记 WARN**，当作没有前端入口——宁可这个插件在左栏显示
+空面板，也不能让一个指到 `../../` 的入口把插件目录之外的文件服务出去。
+
+### 8.2 静态服务与 CSP
+
+`PluginWebController`（`GET /api/plugin-web/{id}/**`）把 `plugins/<id>/web/` 服务出来。
+
+**不需要登录态**：这里只有插件包自带的静态资产，没有任何用户数据；而承载它的 iframe
+是 opaque origin，本来也带不出任何凭据。要登录既没有安全收益，还会让 iframe 直接白屏。
+
+四道守卫：
+
+1. id 必须过 `^[a-z0-9][a-z0-9-]{1,49}$`；
+2. 目标文件 canonical path 必须落在 `<pluginDir>/web/` 之下（同时挡 `../` 与符号链接）；
+3. 只服务**已启用**插件——未安装 / 已禁用 / 被平台封禁一律 404（不是 403：不泄露
+   「这个 id 存在但被禁用了」），与「禁用即不加载 JAR」同一口径；
+4. 响应头：
+
+| 头 | 值 |
+|---|---|
+| `Content-Security-Policy` | `default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'none'` |
+| 同上，manifest 声明了 `network` 时 | 末段换成 `connect-src https:` |
+| `X-Content-Type-Options` | `nosniff` |
+| `Cache-Control` | `no-cache` |
+| `Content-Type` | 按扩展名（html/js/css/json/svg/png/jpg/gif/webp/ico/woff/woff2/ttf/otf/txt/map），其余 `application/octet-stream` |
+
+### 8.3 sandbox 与桥
+
+宿主端在 `PluginPane.vue`：iframe 带 `sandbox="allow-scripts allow-forms"`，
+**绝不含 `allow-same-origin`**。
+
+> 这一条是整个模型的地基。iframe 一旦与应用同源，插件脚本就能读到 localStorage 里的
+> `X-Session-Id` 并打全部 `/api/*`，等于把宿主的全部权限白送出去。没有它，iframe 是
+> opaque origin，除了 postMessage 桥没有第二条路。
+
+协议（宿主端、SDK、官网模板与宿主模拟器共用同一份契约，任何一方单独改动都会让插件跑不起来）：
+
+```
+握手  宿主 -> 插件   { awd: 1, type: "init", context: { pluginId, projectId, language, theme } }
+请求  插件 -> 宿主   { awd: 1, type: "call", seq, method, params }
+响应  宿主 -> 插件   { awd: 1, type: "result", seq, ok, result | error: { code, message } }
+```
+
+来源校验是双向的：宿主校验 `event.source === iframe.contentWindow`，插件校验
+`event.source === window.parent`。两侧 `postMessage` 的 targetOrigin 都只能是 `'*'`——
+opaque origin 使然，不能靠 `event.origin` 判断。
+
+握手时机：宿主在 iframe `load` 之后立刻发 `init`。**SDK 必须用同步 `<script>` 引入且
+排在业务脚本之前**，晚注册监听会错过握手，`ready()` 将永远挂起。
+
+### 8.4 v1 方法表
+
+| 方法 | 参数 | 返回 | 权限 |
+|---|---|---|---|
+| `context.get` | `{}` | context 对象本身（不包层） | — |
+| `files.list` | `{}` | `{ files: [{ path, name, size }] }`，`path` 是项目内相对路径 | `file_read` |
+| `files.read` | `{ path }` | `{ path, content, truncated }`，文本上限 5 MB，超限截断且 `truncated: true`（不报错） | `file_read` |
+| `ui.toast` | `{ message }` | `{}` | — |
+| `storage.get` | `{ key }` | `{ key, value }`，不存在时 `value: null` | — |
+| `storage.set` | `{ key, value }` | `{}` | — |
+
+错误码：`permission_denied`（manifest 未声明所需权限，或读的不是可抽取文本的格式）、
+`unknown_method`、`quota_exceeded`（插件级 KV 超 64 KB）、`not_found`（文件不存在）。
+
+插件级 KV 存在宿主的 `localStorage`，键为 `awd_plugin_kv_<pluginId>`，
+每个插件总量上限 64 KB。
+
+### 8.5 SDK 表面
+
+源头在 [sdk/plugin-sdk/awd-plugin-sdk.js](../sdk/plugin-sdk/awd-plugin-sdk.js)；
+官网插件模板 zip 里的那份是**逐字节一致的分发副本**。
+
+```html
+<script src="awd-plugin-sdk.js"></script>
+<script>
+  const ctx = await awd.ready();      // resolve 值即 awd.context
+  const files = await awd.files.list();   // 糖衣：直接是数组
+  const doc = await awd.files.read(files[0].path);  // 原始 result
+  const n = await awd.storage.get('clicks');        // 糖衣：直接是值
+  await awd.storage.set('clicks', (n || 0) + 1);
+  await awd.ui.toast('你好');
+</script>
+```
+
+`awd.call(method, params)` 原样调用任意 v1 方法并返回宿主的 `result`；
+只有 `files.list()` 与 `storage.get()` 做了解包糖衣，`files.read()` 与 `call()` 返回原始 result。
+
+### 8.6 开发工作流
+
+官网插件模板 zip 带一份 `dev/host-simulator.html`——一个假扮宿主桥的静态页，
+起个本地静态服务就能在浏览器里开发调试，不必装桌面端。模拟器的 sandbox 属性与桌面端
+一致（同样没有 `allow-same-origin`）：调试时为了方便加上它，装进桌面端会立刻失败。
+
+## 9. 插件依赖原生资源包（packs，v2.3）
+
+```json
+{ "id": "my-plugin", "packs": ["litviz-fonts"] }
+```
+
+- 每项必须过与插件 id 同一套正则，非法项在解析时丢弃并记 WARN——这串字符会被拼进
+  注册表 URL 与磁盘路径。
+- **在线安装该插件成功后**，`PluginMarketService` 对每个 packId 调
+  `NativePackService.installAsync()`。
+- **装不上不回滚插件，只记 WARN**：pack 是独立分发物，有自己的状态机、进度条与重试面
+  （`/api/packs/{id}/status`）。一次网络抖动不该吃掉用户刚装好的插件。
+
+用途见 [NATIVE_PACK_DISTRIBUTION.md](NATIVE_PACK_DISTRIBUTION.md) §11.4：三方插件要带重资源时
+声明 pack 依赖，不把 registry 的 20 MB 受理线撑大。
+
+## 10. 版本演进
 
 - **v1（0.4.x）**：声明式 manifest + 启停持久化 + 插件广场展示。
 - **v2（Phase 3A）**：ToolRegistry 按启停过滤三处消费点 + `tools[].permissions`
   分发前权限校验（诚实声明模型）+ 启停缓存 TTL。
 - **v2.1（Phase 3B）**：manifest 新增 `skills` 字段，插件可携带 Skill（见 §7 与
   docs/SKILL_SPEC.md）。
-- **v2.2（当前）**：加载期收口——禁用即不加载 JAR（§5）、`backendJars` 路径逃逸校验（§4）；
+- **v2.2**：加载期收口——禁用即不加载 JAR（§5）、`backendJars` 路径逃逸校验（§4）；
   在线分发落地：平台 Ed25519 签名 + 人工审核 + 客户端验签 + 远程封禁，见
   [docs/PLUGIN_DISTRIBUTION.md](PLUGIN_DISTRIBUTION.md)。
-- 规划中：进程外插件形态（MCP server）为不需要独立 UI 的插件提供真正的隔离边界；
-  frontendEntry 动态加载。**进程内沙箱不在规划中**——Java 侧无此能力（§3），
-  不要再把它列为待办。
+- **v2.3（当前）**：`frontendEntry` 从「预留」激活为 Web 插件形态（§8）——`web/` 静态服务、
+  sandbox iframe、postMessage 桥、CSP；**permissions 在 Web 插件上第一次成为真实的执行边界**。
+  manifest 新增 `packs` 字段（§9）。
+- 规划中：进程外插件形态（MCP server）为不需要独立 UI 的插件提供真正的隔离边界。
+  **进程内沙箱不在规划中**——Java 侧无此能力（§3），不要再把它列为待办；
+  Web 插件那条路已经用「不同源 + 桥」拿到了同等效果，代价是能力必须逐个显式开放。

--- a/examples/hello-web-plugin/README.md
+++ b/examples/hello-web-plugin/README.md
@@ -1,0 +1,45 @@
+# hello-web-plugin
+
+纯前端插件的最小示例：没有 Java、没有构建步骤，`web/index.html` 就是全部。
+
+```
+hello-web-plugin/
+├── manifest.json            frontendEntry 指向 web/index.html，permissions 声明 file_read
+└── web/
+    ├── index.html           面板本体
+    └── awd-plugin-sdk.js    SDK 副本（源头在 sdk/plugin-sdk/，逐字节一致）
+```
+
+## 本地试跑
+
+把整个目录拷进插件目录，重启或在插件广场点「重新扫描」，然后在广场里启用它，
+左栏就会多出一个入口：
+
+| 形态 | 插件目录 |
+|---|---|
+| 本地开发 | `backend/plugins/` |
+| 打包桌面版 | `~/.aiworkdeck/plugins/` |
+
+```bash
+cp -R examples/hello-web-plugin backend/plugins/
+```
+
+装完是**禁用**状态（在线安装的插件同理），在插件广场点「启用」后才会出现在左栏。
+
+## 它演示了什么
+
+- `awd.ready()` 拿握手上下文（`pluginId` / `projectId` / `language` / `theme`）
+- `awd.files.list()` / `awd.files.read(path)`——需要 manifest 声明 `file_read`，
+  把 manifest 里的 `permissions` 改成 `[]` 再重扫，就能看到 `permission_denied` 分支
+- `awd.ui.toast(message)`
+- `awd.storage.get/set`——插件级 KV，宿主代存，总量上限 64 KB
+
+## 边界
+
+面板跑在 `sandbox="allow-scripts allow-forms"`（**无** `allow-same-origin`）的
+iframe 里，静态资源由后端 `/api/plugin-web/hello-web-plugin/...` 服务并带严格 CSP：
+不声明 `network` 权限就 `connect-src 'none'`，插件自己发不出任何请求，
+一切能力只能经 postMessage 桥、按 manifest 权限裁剪后取得。
+
+规范见 [docs/PLUGIN_SPEC.md](../../docs/PLUGIN_SPEC.md) §9，SDK 见
+[sdk/plugin-sdk/](../../sdk/plugin-sdk/)。

--- a/examples/hello-web-plugin/manifest.json
+++ b/examples/hello-web-plugin/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "hello-web-plugin",
+  "name": "Hello Web 插件",
+  "version": "1.0.0",
+  "description": "纯前端插件的最小示例：握手上下文、项目文件、toast、插件级存储各演示一次。",
+  "author": "AI WorkDeck",
+  "homepage": "https://github.com/zeweihan/checkba_cloud",
+  "permissions": ["file_read"],
+  "frontendEntry": "web/index.html",
+  "tools": [],
+  "backendJars": []
+}

--- a/examples/hello-web-plugin/web/awd-plugin-sdk.js
+++ b/examples/hello-web-plugin/web/awd-plugin-sdk.js
@@ -1,0 +1,104 @@
+/**
+ * AI WorkDeck 插件 SDK v1 —— postMessage 桥。
+ *
+ * 源头在桌面仓 sdk/plugin-sdk/，此为随模板分发的副本。
+ * 契约（桌面端宿主按同一份实现，勿单方面改动）：
+ *
+ *   握手  宿主 -> 插件   { awd: 1, type: "init", context: {...} }
+ *   请求  插件 -> 宿主   { awd: 1, type: "call", seq, method, params }
+ *   响应  宿主 -> 插件   { awd: 1, type: "result", seq, ok, result | error: { code, message } }
+ *
+ * v1 方法：
+ *   context.get   {}                  -> { pluginId, projectId, language, theme }
+ *   files.list    {}                  -> { files: [{ path, name, size }] }   需 file_read
+ *   files.read    { path }            -> { path, content, truncated }        需 file_read，文本上限 5 MB
+ *   ui.toast      { message }         -> {}
+ *   storage.get   { key }             -> { key, value }    插件级 KV，value 为 null 表示不存在
+ *   storage.set   { key, value }      -> {}                插件级 KV，总量上限 64 KB
+ *
+ * 错误码：permission_denied（manifest 未声明所需权限）、unknown_method（宿主不认识的方法）。
+ *
+ * 重要：本文件必须用普通同步 <script> 引入，且排在业务脚本之前——
+ * 宿主在 iframe load 后立刻发 init，晚注册监听会错过握手，ready() 将永远挂起。
+ */
+(function (global) {
+  'use strict';
+
+  var PROTOCOL = 1;
+  var seq = 0;
+  var pending = {};
+  var resolveReady;
+  var readyPromise = new Promise(function (resolve) { resolveReady = resolve; });
+
+  function post(msg) {
+    // 插件运行在 opaque origin 的 sandbox iframe 里，拿不到宿主的真实 origin，
+    // 只能用 '*'；反向的来源校验由宿主端（校验 event.source 是本 iframe）负责。
+    global.parent.postMessage(msg, '*');
+  }
+
+  global.addEventListener('message', function (event) {
+    if (event.source !== global.parent) return;
+    var msg = event.data;
+    if (!msg || msg.awd !== PROTOCOL) return;
+
+    if (msg.type === 'init') {
+      awd.context = msg.context || {};
+      resolveReady(awd.context);
+      return;
+    }
+
+    if (msg.type === 'result') {
+      var entry = pending[msg.seq];
+      if (!entry) return;
+      delete pending[msg.seq];
+      if (msg.ok) {
+        entry.resolve(msg.result);
+      } else {
+        var err = new Error((msg.error && msg.error.message) || '调用失败');
+        err.code = (msg.error && msg.error.code) || 'unknown_error';
+        entry.reject(err);
+      }
+    }
+  });
+
+  function call(method, params) {
+    return new Promise(function (resolve, reject) {
+      var id = ++seq;
+      pending[id] = { resolve: resolve, reject: reject };
+      post({ awd: PROTOCOL, type: 'call', seq: id, method: method, params: params || {} });
+    });
+  }
+
+  var awd = {
+    /** SDK 版本，与桥协议版本无关 */
+    version: '1.0.0',
+    /** 握手拿到的上下文；ready() 之前为 null */
+    context: null,
+    /** 等待宿主握手，resolve 值即 awd.context */
+    ready: function () { return readyPromise; },
+    /** 原样调用任意 v1 方法，返回宿主的 result */
+    call: call,
+    files: {
+      /** -> Array<{ path, name, size }> */
+      list: function () {
+        return call('files.list', {}).then(function (r) { return (r && r.files) || []; });
+      },
+      /** -> { path, content, truncated } */
+      read: function (path) { return call('files.read', { path: path }); }
+    },
+    ui: {
+      toast: function (message) { return call('ui.toast', { message: message }); }
+    },
+    storage: {
+      /** -> 存过的值，没有则 null */
+      get: function (key) {
+        return call('storage.get', { key: key }).then(function (r) {
+          return r && r.value !== undefined ? r.value : null;
+        });
+      },
+      set: function (key, value) { return call('storage.set', { key: key, value: value }); }
+    }
+  };
+
+  global.awd = awd;
+})(window);

--- a/examples/hello-web-plugin/web/index.html
+++ b/examples/hello-web-plugin/web/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hello Web 插件</title>
+<style>
+  :root { color-scheme: light; }
+  body {
+    margin: 0; padding: 20px;
+    font: 14px/1.7 system-ui, -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+    color: #1f2421; background: #fff;
+  }
+  h1 { margin: 0 0 4px; font-size: 16px; font-weight: 600; }
+  p.sub { margin: 0 0 18px; color: #6b7280; font-size: 12px; }
+  section { margin-bottom: 18px; }
+  h2 { margin: 0 0 8px; font-size: 12px; font-weight: 600; letter-spacing: .06em; color: #6b7280; }
+  dl { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 0; }
+  dt { color: #6b7280; }
+  dd { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+  ul { margin: 0; padding: 0; list-style: none; }
+  li { padding: 6px 0; border-bottom: 1px solid #eef0ef; display: flex; gap: 10px; }
+  li:last-child { border-bottom: 0; }
+  li .name { flex: 1; cursor: pointer; text-decoration: underline; text-underline-offset: 3px; }
+  li .size { color: #9ca3af; font-variant-numeric: tabular-nums; }
+  button {
+    font: inherit; padding: 6px 14px; border-radius: 6px;
+    border: 1px solid #d3d8d5; background: #fff; color: #1f2421; cursor: pointer;
+  }
+  button:hover { border-color: #1f4c3a; color: #1f4c3a; }
+  pre {
+    margin: 10px 0 0; padding: 10px; max-height: 180px; overflow: auto;
+    background: #f6f7f7; border-radius: 6px; font-size: 12px; white-space: pre-wrap;
+  }
+  .empty { color: #9ca3af; }
+</style>
+</head>
+<body>
+  <h1>Hello Web 插件</h1>
+  <p class="sub">最小面板：握手上下文、项目文件、toast、插件级存储各演示一次。</p>
+
+  <section>
+    <h2>上下文</h2>
+    <dl id="ctx"><dd class="empty">等待宿主握手…</dd></dl>
+  </section>
+
+  <section>
+    <h2>项目文件</h2>
+    <ul id="files"><li class="empty">等待宿主握手…</li></ul>
+    <pre id="preview" hidden></pre>
+  </section>
+
+  <section>
+    <h2>动作</h2>
+    <button id="toast">发一条 toast</button>
+    <button id="count">记一次点击（storage）</button>
+  </section>
+
+  <!-- SDK 必须同步引入且排在业务脚本之前：宿主在 iframe load 后立刻发 init，
+       晚注册监听会错过握手，ready() 将永远挂起。 -->
+  <script src="awd-plugin-sdk.js"></script>
+  <script>
+    (async function () {
+      var ctxEl = document.getElementById('ctx');
+      var filesEl = document.getElementById('files');
+      var previewEl = document.getElementById('preview');
+
+      var ctx = await awd.ready();
+
+      ctxEl.innerHTML = '';
+      Object.keys(ctx).forEach(function (k) {
+        var dt = document.createElement('dt'); dt.textContent = k;
+        var dd = document.createElement('dd'); dd.textContent = String(ctx[k]);
+        ctxEl.appendChild(dt); ctxEl.appendChild(dd);
+      });
+
+      // files.* 需要 manifest.permissions 含 file_read，未声明会抛 permission_denied
+      try {
+        var files = await awd.files.list();
+        filesEl.innerHTML = '';
+        if (!files.length) {
+          filesEl.innerHTML = '<li class="empty">项目里还没有文件</li>';
+        }
+        files.forEach(function (f) {
+          var li = document.createElement('li');
+          var name = document.createElement('span');
+          name.className = 'name';
+          name.textContent = f.name || f.path;
+          name.onclick = async function () {
+            try {
+              var doc = await awd.files.read(f.path);
+              previewEl.hidden = false;
+              previewEl.textContent = doc.content.slice(0, 2000) + (doc.truncated ? '\n…（已截断）' : '');
+            } catch (e) {
+              previewEl.hidden = false;
+              previewEl.textContent = '读取失败：' + (e.code || '') + ' ' + e.message;
+            }
+          };
+          var size = document.createElement('span');
+          size.className = 'size';
+          size.textContent = ((f.size || 0) / 1024).toFixed(1) + ' KB';
+          li.appendChild(name); li.appendChild(size);
+          filesEl.appendChild(li);
+        });
+      } catch (e) {
+        filesEl.innerHTML = '<li class="empty">读取文件失败：' + (e.code || '') + ' ' + e.message + '</li>';
+      }
+
+      document.getElementById('toast').onclick = function () {
+        awd.ui.toast('来自 ' + (ctx.pluginId || '插件') + ' 的问候');
+      };
+
+      document.getElementById('count').onclick = async function () {
+        var n = (await awd.storage.get('clicks')) || 0;
+        n = Number(n) + 1;
+        await awd.storage.set('clicks', n);
+        await awd.ui.toast('累计点击 ' + n + ' 次');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/frontend/src/components/PluginPane.vue
+++ b/frontend/src/components/PluginPane.vue
@@ -4,6 +4,7 @@
       v-if="url"
       ref="pluginFrame"
       :src="url"
+      :sandbox="sandboxAttr"
       class="plugin-iframe"
       frameborder="0"
       @load="onFrameLoad"
@@ -15,6 +16,52 @@
 </template>
 
 <script>
+// 插件面板：承载 manifest.frontendEntry 指向的页面。两种形态，行为刻意不同。
+//
+// 1) 绝对 http(s) URL（旧形态）：iframe 直接打开，不加 sandbox、不发握手、不响应桥调用。
+//    这类插件从来就是"内嵌一个外部网页"，改动它只会打断存量插件。
+// 2) web/ 相对路径（规范 v2.3 的 Web 插件）：后端 /api/plugin-web/ 静态服务，
+//    iframe 带 sandbox="allow-scripts allow-forms"，与宿主只通过 postMessage 桥通信。
+//
+// **sandbox 绝不能加 allow-same-origin。** iframe 一旦与应用同源，插件脚本就能读到
+// localStorage 里的 X-Session-Id 并打全部 /api/*，等于把宿主的全部权限白送给插件；
+// 没有它，iframe 是 opaque origin，除了这座桥没有第二条路。桥上每个方法都按
+// manifest.permissions 逐调用校验——权限声明在这里第一次成为真实的执行边界
+// （JAR 插件同 JVM 同权限，做不到这一点）。
+//
+// 桥协议（与 sdk/plugin-sdk/awd-plugin-sdk.js 及官网模板/宿主模拟器同一份契约，
+// 三处任何一处单独改动都会让插件跑不起来）：
+//   握手  宿主 -> 插件   { awd: 1, type: 'init', context: { pluginId, projectId, language, theme } }
+//   请求  插件 -> 宿主   { awd: 1, type: 'call', seq, method, params }
+//   响应  宿主 -> 插件   { awd: 1, type: 'result', seq, ok, result | error: { code, message } }
+import { getProjectFiles, getFileText } from '@/services/api.js'
+import { getAppLanguage } from '@/utils/appLanguage.js'
+
+/** 桥协议版本 */
+const PROTOCOL = 1
+
+/** files.read 的文本上限，与 SDK 契约/官网宿主模拟器一致 */
+const READ_LIMIT = 5 * 1024 * 1024
+
+/** 插件级 KV 的总量上限（序列化后字节数近似），与 SDK 契约一致 */
+const STORAGE_LIMIT = 64 * 1024
+
+/** 插件级 KV 在宿主 localStorage 里的键前缀 */
+const STORAGE_PREFIX = 'awd_plugin_kv_'
+
+// files.read 允许读取的扩展名。后端 /api/files/{id}/text 会对 docx/pdf 这类做文本抽取，
+// 所以白名单不止纯文本；名单之外一律当二进制拒绝，避免把一份 zip 的字节当"内容"塞回插件。
+const READABLE_EXTS = new Set([
+  'txt', 'md', 'markdown', 'json', 'csv', 'tsv', 'log', 'xml', 'html', 'htm',
+  'yml', 'yaml', 'js', 'ts', 'css', 'sql', 'ini', 'conf', 'properties',
+  'doc', 'docx', 'rtf', 'pdf', 'ppt', 'pptx', 'xls', 'xlsx'
+])
+
+function extOf(name) {
+  const dot = String(name || '').lastIndexOf('.')
+  return dot < 0 ? '' : String(name).slice(dot + 1).toLowerCase()
+}
+
 export default {
   name: 'PluginPane',
   props: {
@@ -22,15 +69,216 @@ export default {
       type: String,
       default: ''
     },
+    /** 插件 id（不是左栏的 plugin-<id> 面板 key）：进握手上下文，也是 KV 的分区键 */
     pluginId: {
       type: String,
       default: ''
+    },
+    /** manifest.permissions，桥按它逐调用裁剪能力 */
+    permissions: {
+      type: Array,
+      default: () => []
+    },
+    /** 当前项目 id：files.* 的作用域，同时进握手上下文 */
+    projectId: {
+      type: [String, Number],
+      default: ''
     }
+  },
+  computed: {
+    // 只有走 /api/plugin-web/ 的 Web 插件才 sandbox + 握手。
+    // 绑定 null 会让 Vue 移除该属性，绝对 URL 形态因此与改造前逐字节一致。
+    isWebPlugin() {
+      return String(this.url || '').indexOf('/api/plugin-web/') >= 0
+    },
+    sandboxAttr() {
+      return this.isWebPlugin ? 'allow-scripts allow-forms' : null
+    }
+  },
+  mounted() {
+    window.addEventListener('message', this.onMessage)
+  },
+  beforeUnmount() {
+    window.removeEventListener('message', this.onMessage)
   },
   methods: {
     onFrameLoad() {
-      console.log(`Plugin ${this.pluginId} loaded from ${this.url}`);
-      // Here we could inject some bridge or send initialization data
+      if (!this.isWebPlugin) return
+      const frame = this.$refs.pluginFrame
+      if (!frame || !frame.contentWindow) return
+      // 时序：load 之后才握手。插件侧 SDK 是同步 <script>，此刻监听已就位。
+      frame.contentWindow.postMessage(
+        { awd: PROTOCOL, type: 'init', context: this.buildContext() },
+        '*'
+      )
+    },
+
+    buildContext() {
+      return {
+        pluginId: this.pluginId || '',
+        projectId: this.projectId == null ? '' : String(this.projectId),
+        language: getAppLanguage(),
+        // 外壳恒为浅色（配色红线），字段保留是为了插件侧不必分支处理
+        theme: 'light'
+      }
+    },
+
+    async onMessage(event) {
+      if (!this.isWebPlugin) return
+      const frame = this.$refs.pluginFrame
+      // 唯一的来源校验：只认本 iframe 的窗口。插件侧发的 targetOrigin 是 '*'
+      // （opaque origin 拿不到宿主 origin），所以不能靠 event.origin 判断。
+      if (!frame || !frame.contentWindow || event.source !== frame.contentWindow) return
+      const msg = event.data
+      if (!msg || msg.awd !== PROTOCOL || msg.type !== 'call') return
+
+      let out
+      try {
+        out = await this.handleCall(String(msg.method || ''), msg.params || {})
+      } catch (e) {
+        out = { ok: false, error: { code: 'internal_error', message: (e && e.message) || '调用失败' } }
+      }
+      this.reply(msg.seq, out)
+    },
+
+    reply(seq, out) {
+      const frame = this.$refs.pluginFrame
+      if (!frame || !frame.contentWindow) return
+      const msg = { awd: PROTOCOL, type: 'result', seq, ok: !!out.ok }
+      if (out.ok) msg.result = out.result
+      else msg.error = out.error
+      frame.contentWindow.postMessage(msg, '*')
+    },
+
+    hasPermission(name) {
+      return Array.isArray(this.permissions) && this.permissions.indexOf(name) >= 0
+    },
+
+    denied(permission) {
+      return {
+        ok: false,
+        error: { code: 'permission_denied', message: 'manifest.permissions 未声明 ' + permission }
+      }
+    },
+
+    async handleCall(method, params) {
+      switch (method) {
+        case 'context.get':
+          return { ok: true, result: this.buildContext() }
+
+        case 'files.list':
+          if (!this.hasPermission('file_read')) return this.denied('file_read')
+          return { ok: true, result: { files: (await this.listProjectFiles()).map(f => ({
+            path: f.path, name: f.name, size: f.size
+          })) } }
+
+        case 'files.read':
+          if (!this.hasPermission('file_read')) return this.denied('file_read')
+          return await this.readProjectFile(String(params.path || ''))
+
+        case 'ui.toast':
+          uni.showToast({
+            title: String(params.message == null ? '' : params.message),
+            icon: 'none'
+          })
+          return { ok: true, result: {} }
+
+        case 'storage.get': {
+          const store = this.readStore()
+          const key = String(params.key == null ? '' : params.key)
+          return { ok: true, result: { key, value: store[key] === undefined ? null : store[key] } }
+        }
+
+        case 'storage.set': {
+          const store = this.readStore()
+          const next = Object.assign({}, store)
+          next[String(params.key == null ? '' : params.key)] = params.value
+          const serialized = JSON.stringify(next)
+          if (serialized.length > STORAGE_LIMIT) {
+            return { ok: false, error: { code: 'quota_exceeded', message: '插件存储超过 64 KB 上限' } }
+          }
+          this.writeStore(serialized)
+          return { ok: true, result: {} }
+        }
+
+        default:
+          return { ok: false, error: { code: 'unknown_method', message: '未知方法：' + method } }
+      }
+    },
+
+    // ==== 项目文件 ====
+
+    // 后端返回的是一份扁平全树（每条带 parentId），这里就地拼出项目内相对路径——
+    // 插件拿到的 path 必须是人看得懂、且能原样喂回 files.read 的东西，不是数据库 id。
+    async listProjectFiles() {
+      if (!this.projectId) return []
+      const res = await getProjectFiles(this.projectId, null, true)
+      const rows = Array.isArray(res) ? res : (res && res.data) || []
+      const byId = new Map()
+      rows.forEach(r => byId.set(r.id, r))
+      const pathOf = (row) => {
+        const parts = []
+        let cur = row
+        let guard = 0
+        while (cur && guard++ < 64) {
+          parts.unshift(cur.name || String(cur.id))
+          cur = cur.parentId ? byId.get(cur.parentId) : null
+        }
+        return parts.join('/')
+      }
+      return rows
+        .filter(r => r && !r.isFolder)
+        .map(r => ({ id: r.id, path: pathOf(r), name: r.name || '', size: r.fileSize || 0 }))
+    },
+
+    async readProjectFile(path) {
+      if (!path) {
+        return { ok: false, error: { code: 'not_found', message: '文件不存在：' + path } }
+      }
+      const hit = (await this.listProjectFiles()).find(f => f.path === path)
+      if (!hit) {
+        return { ok: false, error: { code: 'not_found', message: '文件不存在：' + path } }
+      }
+      if (!READABLE_EXTS.has(extOf(hit.name))) {
+        return {
+          ok: false,
+          error: {
+            code: 'permission_denied',
+            message: '不是可读取的文本格式，files.read 只支持文本与可抽取文本的文档：' + hit.name
+          }
+        }
+      }
+      const res = await getFileText(hit.id)
+      const raw = res && res.data != null ? String(res.data) : ''
+      const truncated = raw.length > READ_LIMIT
+      return {
+        ok: true,
+        result: { path: hit.path, content: truncated ? raw.slice(0, READ_LIMIT) : raw, truncated }
+      }
+    },
+
+    // ==== 插件级 KV ====
+
+    storageKey() {
+      return STORAGE_PREFIX + (this.pluginId || 'unknown')
+    },
+
+    readStore() {
+      try {
+        const raw = window.localStorage.getItem(this.storageKey())
+        const parsed = raw ? JSON.parse(raw) : null
+        return parsed && typeof parsed === 'object' ? parsed : {}
+      } catch (e) {
+        return {}
+      }
+    },
+
+    writeStore(serialized) {
+      try {
+        window.localStorage.setItem(this.storageKey(), serialized)
+      } catch (e) {
+        console.warn('[PluginPane] 写入插件存储失败:', e)
+      }
     }
   }
 }

--- a/frontend/src/pages/project-overview/panelSwitching.js
+++ b/frontend/src/pages/project-overview/panelSwitching.js
@@ -47,10 +47,14 @@ export const panelSwitchingMethods = {
         // Check if it's a dynamic plugin and open its tab
         const plugin = this.dynamicPlugins.find(p => p.key === key)
         if (plugin) {
+          // pluginId / permissions 随标签一起带过去：PluginPane 的 postMessage 桥
+          // 要用原始插件 id（标签 id 是 plugin-<id> 的面板 key）与 manifest 权限声明
           this.openFile({
             id: plugin.key,
             name: plugin.label,
             fileType: 'plugin',
+            pluginId: plugin.pluginId,
+            permissions: plugin.permissions || [],
             frontendEntry: plugin.frontendEntry
           })
         }

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -662,7 +662,9 @@
           <PluginPane
             v-else-if="leftPaneKey && dynamicPlugins.some(p => p.key === leftPaneKey)"
             :url="dynamicPlugins.find(p => p.key === leftPaneKey)?.frontendEntry"
-            :plugin-id="leftPaneKey"
+            :plugin-id="dynamicPlugins.find(p => p.key === leftPaneKey)?.pluginId || ''"
+            :permissions="dynamicPlugins.find(p => p.key === leftPaneKey)?.permissions || []"
+            :project-id="projectId"
           />
           <view v-else class="sidebar-plugin-placeholder">
             <text class="placeholder-title">{{ leftPaneTitle }}</text>
@@ -918,7 +920,9 @@
                     <PluginPane
                       v-else-if="activeFileLeft.fileType === 'plugin'"
                       :url="activeFileLeft.frontendEntry"
-                      :plugin-id="activeFileLeft.id"
+                      :plugin-id="activeFileLeft.pluginId || ''"
+                      :permissions="activeFileLeft.permissions || []"
+                      :project-id="projectId"
                     />
                     <!-- .drawio：诉讼可视化四份产物里唯一的可继续编辑版，走内嵌
                          draw.io。没有这条分支它会落进 FilePreview 的「暂不支持
@@ -1033,7 +1037,9 @@
                     <PluginPane
                       v-else-if="activeFileRight.fileType === 'plugin'"
                       :url="activeFileRight.frontendEntry"
-                      :plugin-id="activeFileRight.id"
+                      :plugin-id="activeFileRight.pluginId || ''"
+                      :permissions="activeFileRight.permissions || []"
+                      :project-id="projectId"
                     />
                     <DrawioEditor
                       v-else-if="isDrawioFile(activeFileRight)"
@@ -1586,6 +1592,7 @@ import {
 
   getAiConversations,
   getPlugins, // Added
+  resolvePluginEntryUrl,
   getSkills,
   getFileText,
   getVersionStatus, // 版本面板之外也要知道「有没有采纳等待处理」
@@ -5025,11 +5032,17 @@ export default {
           // Map backend PluginMetadata to frontend plugin structure
           this.dynamicPlugins = res.data.map(p => ({
             key: `plugin-${p.id}`,
+            // 左栏面板 key 是 plugin-<id>，桥要的是原始 id（握手上下文 + KV 分区键），
+            // 两者别混用
+            pluginId: p.id,
             label: p.name,
             icon: p.icon || '/static/plugin_default.png',
             activeIcon: p.icon || '/static/plugin_default.png',
             isDynamic: true,
-            frontendEntry: p.frontendEntry
+            // manifest.permissions：PluginPane 的桥按它逐调用裁剪能力
+            permissions: p.permissions || [],
+            // web/ 相对路径映射成后端静态服务地址；绝对 URL 原样保留（旧形态）
+            frontendEntry: resolvePluginEntryUrl(p.id, p.frontendEntry)
           }))
           console.log('Dynamic plugins loaded:', this.dynamicPlugins)
         }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1624,6 +1624,20 @@ export function getFileUploadUrl(fileId) {
   return `${baseUrl}/api/files/${fileId}/upload`
 }
 
+// Web 插件面板入口 URL（插件规范 v2.3）。
+// - 绝对 http(s) URL：旧形态，原样返回，宿主 iframe 直接打开外部页面（行为不变）
+// - web/ 之下的相对路径：映射到后端静态服务 <apiBase>/api/plugin-web/<id>/<entry>
+// apiBase 走 getApiBaseUrl()（桌面壳注入优先），生产同源时它是空串，返回相对路径同样可用。
+export function resolvePluginEntryUrl(pluginId, entry) {
+  if (!entry) return ''
+  const raw = String(entry)
+  if (/^https?:\/\//i.test(raw)) return raw
+  const baseUrl = getApiBaseUrl() || ''
+  const rel = raw.replace(/^\/+/, '').split('/').filter(Boolean).map(encodeURIComponent).join('/')
+  if (!rel) return ''
+  return `${baseUrl.replace(/\/$/, '')}/api/plugin-web/${encodeURIComponent(pluginId)}/${rel}`
+}
+
 // 获取文件文本内容
 export function getFileText(fileId) {
   return request({

--- a/sdk/plugin-sdk/README.md
+++ b/sdk/plugin-sdk/README.md
@@ -1,0 +1,62 @@
+# AI WorkDeck 插件 SDK（`awd-plugin-sdk.js`）
+
+Web 插件与宿主之间那座 postMessage 桥的插件侧实现。单文件、无依赖、无构建步骤，
+用普通同步 `<script>` 引入即可。
+
+**这里是源头。** 官网插件模板 zip 里的 `web/awd-plugin-sdk.js`
+（官网仓 `lib/plugin-template.ts` 的 `WEB_SDK_JS` 常量）与
+本仓 `examples/hello-web-plugin/web/awd-plugin-sdk.js` 都是**分发副本**，
+必须与本文件逐字节一致。改动顺序：先改这里，再同步两份副本。
+
+对应的宿主端实现在 `frontend/src/components/PluginPane.vue`。
+桥协议是双方共同的契约，任何一方单独改动都会让另一方的插件跑不起来——
+改协议要同一批次改三处：本文件、PluginPane.vue、官网模板与宿主模拟器。
+
+## 引入
+
+```html
+<script src="awd-plugin-sdk.js"></script>
+<script>
+  (async function () {
+    const ctx = await awd.ready();   // 等宿主握手，resolve 值即 awd.context
+    await awd.ui.toast('你好，' + ctx.pluginId);
+  })();
+</script>
+```
+
+SDK 必须排在业务脚本**之前**且用同步 `<script>`：宿主在 iframe `load`
+之后立刻发 `init`，晚注册监听会错过握手，`ready()` 将永远挂起。
+
+## 表面
+
+| 成员 | 说明 |
+|---|---|
+| `awd.version` | SDK 版本（与桥协议版本无关） |
+| `awd.ready()` | Promise，resolve 值即 `awd.context` |
+| `awd.context` | `{ pluginId, projectId, language, theme }`；`ready()` 之前为 `null` |
+| `awd.call(method, params)` | 原样调用任意 v1 方法，返回宿主的 `result` |
+| `awd.files.list()` | 糖衣：直接返回数组 `[{ path, name, size }]` |
+| `awd.files.read(path)` | 返回原始 result `{ path, content, truncated }` |
+| `awd.ui.toast(message)` | 宿主弹一条提示 |
+| `awd.storage.get(key)` | 糖衣：直接返回存过的值，没有则 `null` |
+| `awd.storage.set(key, value)` | 插件级 KV，总量上限 64 KB |
+
+失败时 Promise reject 出一个 `Error`，`err.code` 是错误码：
+`permission_denied`（manifest 未声明所需权限）、`unknown_method`、
+`quota_exceeded`（storage 超 64 KB）、`not_found`（文件不存在）。
+
+## 协议
+
+```
+握手  宿主 -> 插件   { awd: 1, type: "init", context: {...} }
+请求  插件 -> 宿主   { awd: 1, type: "call", seq, method, params }
+响应  宿主 -> 插件   { awd: 1, type: "result", seq, ok, result | error: { code, message } }
+```
+
+插件侧 `postMessage` 的 targetOrigin 只能是 `'*'`：插件跑在
+`sandbox="allow-scripts allow-forms"`（**无** `allow-same-origin`）的
+iframe 里，是 opaque origin，拿不到宿主的真实 origin。来源校验因此是双向的——
+插件校验 `event.source === window.parent`，宿主校验 `event.source === iframe.contentWindow`。
+
+完整规范见 [docs/PLUGIN_SPEC.md](../../docs/PLUGIN_SPEC.md) §9，
+最小可跑示例见 [examples/hello-web-plugin/](../../examples/hello-web-plugin/)。

--- a/sdk/plugin-sdk/awd-plugin-sdk.js
+++ b/sdk/plugin-sdk/awd-plugin-sdk.js
@@ -1,0 +1,104 @@
+/**
+ * AI WorkDeck 插件 SDK v1 —— postMessage 桥。
+ *
+ * 源头在桌面仓 sdk/plugin-sdk/，此为随模板分发的副本。
+ * 契约（桌面端宿主按同一份实现，勿单方面改动）：
+ *
+ *   握手  宿主 -> 插件   { awd: 1, type: "init", context: {...} }
+ *   请求  插件 -> 宿主   { awd: 1, type: "call", seq, method, params }
+ *   响应  宿主 -> 插件   { awd: 1, type: "result", seq, ok, result | error: { code, message } }
+ *
+ * v1 方法：
+ *   context.get   {}                  -> { pluginId, projectId, language, theme }
+ *   files.list    {}                  -> { files: [{ path, name, size }] }   需 file_read
+ *   files.read    { path }            -> { path, content, truncated }        需 file_read，文本上限 5 MB
+ *   ui.toast      { message }         -> {}
+ *   storage.get   { key }             -> { key, value }    插件级 KV，value 为 null 表示不存在
+ *   storage.set   { key, value }      -> {}                插件级 KV，总量上限 64 KB
+ *
+ * 错误码：permission_denied（manifest 未声明所需权限）、unknown_method（宿主不认识的方法）。
+ *
+ * 重要：本文件必须用普通同步 <script> 引入，且排在业务脚本之前——
+ * 宿主在 iframe load 后立刻发 init，晚注册监听会错过握手，ready() 将永远挂起。
+ */
+(function (global) {
+  'use strict';
+
+  var PROTOCOL = 1;
+  var seq = 0;
+  var pending = {};
+  var resolveReady;
+  var readyPromise = new Promise(function (resolve) { resolveReady = resolve; });
+
+  function post(msg) {
+    // 插件运行在 opaque origin 的 sandbox iframe 里，拿不到宿主的真实 origin，
+    // 只能用 '*'；反向的来源校验由宿主端（校验 event.source 是本 iframe）负责。
+    global.parent.postMessage(msg, '*');
+  }
+
+  global.addEventListener('message', function (event) {
+    if (event.source !== global.parent) return;
+    var msg = event.data;
+    if (!msg || msg.awd !== PROTOCOL) return;
+
+    if (msg.type === 'init') {
+      awd.context = msg.context || {};
+      resolveReady(awd.context);
+      return;
+    }
+
+    if (msg.type === 'result') {
+      var entry = pending[msg.seq];
+      if (!entry) return;
+      delete pending[msg.seq];
+      if (msg.ok) {
+        entry.resolve(msg.result);
+      } else {
+        var err = new Error((msg.error && msg.error.message) || '调用失败');
+        err.code = (msg.error && msg.error.code) || 'unknown_error';
+        entry.reject(err);
+      }
+    }
+  });
+
+  function call(method, params) {
+    return new Promise(function (resolve, reject) {
+      var id = ++seq;
+      pending[id] = { resolve: resolve, reject: reject };
+      post({ awd: PROTOCOL, type: 'call', seq: id, method: method, params: params || {} });
+    });
+  }
+
+  var awd = {
+    /** SDK 版本，与桥协议版本无关 */
+    version: '1.0.0',
+    /** 握手拿到的上下文；ready() 之前为 null */
+    context: null,
+    /** 等待宿主握手，resolve 值即 awd.context */
+    ready: function () { return readyPromise; },
+    /** 原样调用任意 v1 方法，返回宿主的 result */
+    call: call,
+    files: {
+      /** -> Array<{ path, name, size }> */
+      list: function () {
+        return call('files.list', {}).then(function (r) { return (r && r.files) || []; });
+      },
+      /** -> { path, content, truncated } */
+      read: function (path) { return call('files.read', { path: path }); }
+    },
+    ui: {
+      toast: function (message) { return call('ui.toast', { message: message }); }
+    },
+    storage: {
+      /** -> 存过的值，没有则 null */
+      get: function (key) {
+        return call('storage.get', { key: key }).then(function (r) {
+          return r && r.value !== undefined ? r.value : null;
+        });
+      },
+      set: function (key, value) { return call('storage.set', { key: key, value: value }); }
+    }
+  };
+
+  global.awd = awd;
+})(window);


### PR DESCRIPTION
## 概要

Web coding 方式开发的三方插件在桌面/应用侧的承载：manifest.frontendEntry 从「预留」激活，PluginPane 以无同源 sandbox iframe + postMessage 桥承载，权限声明在 Web 插件上第一次成为真实执行边界。配套官网侧已合并（[PR#84](https://github.com/zeweihan/aiworkdeck_website/pull/84)：受理/扫描/SDK 模板/开发指南）。规范 docs/NATIVE_PACK_DISTRIBUTION.md §11。

## 内容

- **PluginWebController** `/api/plugin-web/{id}/**`：canonical 限 web/ 之下、仅启用插件（404 不漏存在性）、CSP（network 权限决定 connect-src）+nosniff
- **PluginPane 桥**：sandbox="allow-scripts allow-forms"（无 allow-same-origin，插件拿不到会话与 localStorage）；init 握手 + v1 方法（context/files.list/files.read/ui.toast/storage）+ 方法级权限校验 + event.source 校验；**绝对 URL 旧形态不加 sandbox 不发握手，行为不变**
- **packs 联动**：manifest `packs:[]`，插件装后异步装依赖资源包（失败不回滚插件）
- **SDK**：sdk/plugin-sdk/ 源头文件（与官网模板逐字节一致）+ examples/hello-web-plugin
- **文档**：PLUGIN_SPEC v2.3、PLUGIN_DISTRIBUTION §3、两份领域文档

## 测试

- backend mvn 1976 全绿（PluginWebController 守卫/CSP、frontendEntry 校验、packs 联动 mock 用例）
- frontend 三检绿；无头 Chrome 真跑桥往返（sandbox 下 origin=null 实证无同源）

🤖 Generated with [Claude Code](https://claude.com/claude-code)