### PR TITLE
feat(pack): 安装包摘除诉讼可视化重资源，改走 native pack（v0.21.0）

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -91,15 +91,6 @@ jobs:
           # first and falls back to the CDN only for anything not bundled.
           node desktop/scripts/fetch-lowa-assets.js
           ls -la frontend/dist/zetaoffice/lowa frontend/dist/zetaoffice/cjk.ttc
-      - name: Bake draw.io editor into the frontend bundle (offline)
-        shell: bash
-        run: |
-          # 诉讼可视化出的 .drawio 是唯一可继续编辑的版本；内嵌 draw.io 让它在应用内
-          # 直接打开，而不是变成必须装别的软件才能用的死文件。官方只发 draw.war
-          # （53 MB / 解开 151 MB），脚本裁到主编辑器 + 默认图形 + 中英文案，约
-          # 40 MB 落盘。运行期完全离线（stealth=1），案件材料不出网。
-          node desktop/scripts/fetch-drawio-assets.js
-          ls -la frontend/dist/drawio/index.html frontend/dist/drawio/js/app.min.js
       - name: Install desktop dependencies
         working-directory: desktop
         run: npm ci
@@ -183,15 +174,6 @@ jobs:
             --requirements asr-service/requirements.lock \
             --out desktop/bundled/mac-arm64
           du -sh desktop/bundled/mac-arm64/pysvc/asr-service/lib
-      - name: Bundle graphviz (macOS arm64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
-        if: runner.os == 'macOS' && steps.cache-pybundle-mac.outputs.cache-hit != 'true'
-        run: |
-          # 诉讼可视化的流程图布局要 graphviz 的 dot（其余六种布局零原生依赖）。
-          # 只带布局引擎、不带任何渲染后端（我们只用 -Tplain），闭包约 4 MB。
-          brew install graphviz
-          # 不传 --from：脚本从 PATH 上找 dot 反推安装根，省得写死安装目录
-          node desktop/scripts/prepare-graphviz.js --out desktop/bundled/mac-arm64
       - name: Bundle backend (Windows x64)
         if: runner.os == 'Windows'
         shell: bash
@@ -270,26 +252,6 @@ jobs:
             --requirements asr-service/requirements.lock \
             --out desktop/bundled/win-x64
           du -sh desktop/bundled/win-x64/pysvc/asr-service/lib
-      - name: Bundle graphviz (Windows x64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
-        if: runner.os == 'Windows' && steps.cache-pybundle-win.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          # 同 macOS 那步。Windows 上 DLL 在 exe 同目录解析，不需要重定位，
-          # 整份 bin/ 拷走即可（约几 MB）。
-          # chocolatey 社区源对 CI runner 限流严重（v0.15.0 发版 PR 连续两次 503），
-          # 带退避重试，五次全 503 才算真挂。
-          for attempt in 1 2 3 4 5; do
-            choco install graphviz --no-progress -y && break
-            [ "$attempt" = "5" ] && { echo "choco 重试耗尽"; exit 1; }
-            echo "choco install 第 $attempt 次失败（多半是社区源 503），$((attempt * 30))s 后重试"
-            sleep $((attempt * 30))
-          done
-          # choco 装完不会刷新当前 shell 的 PATH，手动补上再让脚本从 PATH 找 dot。
-          # 不写 "/c/Program Files/..." 是因为这步跑在 bash 里，而脚本是 Node：
-          # Node 在 Windows 上不认 git-bash 风格路径，会解成 C:\c\Program Files\...
-          export PATH="/c/Program Files/Graphviz/bin:$PATH"
-          node desktop/scripts/prepare-graphviz.js --out desktop/bundled/win-x64
       - name: Sign bundled backend natives (macOS)
         if: runner.os == 'macOS'
         env:

--- a/deploy/publish-pack.sh
+++ b/deploy/publish-pack.sh
@@ -162,22 +162,22 @@ cmd_sign() {
 set -euo pipefail
 remote_tmp="$1"; env_file="$2"
 [ -f "$env_file" ] || { echo "官网 env 文件不存在：$env_file" >&2; exit 1; }
-key_line=$(grep -m1 '^AWD_PLUGIN_SIGNING_KEY=' "$env_file" || true)
-[ -n "$key_line" ] || { echo "$env_file 里没有 AWD_PLUGIN_SIGNING_KEY" >&2; exit 1; }
-key_value="${key_line#AWD_PLUGIN_SIGNING_KEY=}"
-# 去掉包裹的引号（Next.js env 文件常见写法）
-key_value="${key_value%\"}"; key_value="${key_value#\"}"
-key_value="${key_value%\'}"; key_value="${key_value#\'}"
+# 私钥绝不经过 shell 变量/argv（多行 PEM 会被拆参、还可能进 ps 输出）：
+# node 自己读 env 文件，跨行解析三种常见形态——双引号多行块 / 单引号多行块 /
+# 单行 \n 转义。北京官网机实测是「双引号 + 真换行 PEM」（2026-08-19）。
 node -e '
   const crypto = require("crypto");
   const fs = require("fs");
-  // 多行 PEM 若以 \n 转义存成单行，这里转回真换行；已是真换行的 PEM 不受影响。
-  const keyPem = process.argv[1].replace(/\\n/g, "\n");
+  const envText = fs.readFileSync(process.argv[1], "utf8");
+  const m = envText.match(/^AWD_PLUGIN_SIGNING_KEY=("([\s\S]*?)"|\x27([\s\S]*?)\x27|(.*))$/m);
+  if (!m) { console.error("env 文件里没有 AWD_PLUGIN_SIGNING_KEY"); process.exit(1); }
+  const raw = m[2] !== undefined ? m[2] : (m[3] !== undefined ? m[3] : m[4]);
+  const keyPem = raw.replace(/\\n/g, "\n").trim();
   const privateKey = crypto.createPrivateKey(keyPem);
   const bytes = fs.readFileSync(process.argv[2]);
   const sig = crypto.sign(null, bytes, privateKey);
   process.stdout.write(sig.toString("base64"));
-' "$key_value" "$remote_tmp/manifest.json"
+' "$env_file" "$remote_tmp/manifest.json"
 REMOTE
 )
   local rc=$?

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",
@@ -41,10 +41,6 @@
         "to": "frontend/dist/zetaoffice"
       },
       {
-        "from": "../frontend/dist/drawio",
-        "to": "frontend/dist/drawio"
-      },
-      {
         "from": "bundled/${os}-${arch}/backend",
         "to": "backend"
       },
@@ -65,24 +61,11 @@
         "to": "pysvc.meta.json"
       },
       {
-        "from": "bundled/${os}-${arch}/graphviz",
-        "to": "graphviz"
-      },
-      {
         "from": "../backend/skills",
         "to": "skills",
         "filter": [
           "**/*",
           "!**/__pycache__/**"
-        ]
-      },
-      {
-        "from": "../litviz",
-        "to": "litviz",
-        "filter": [
-          "**/*",
-          "!**/__pycache__/**",
-          "!**/*.pyc"
         ]
       }
     ],


### PR DESCRIPTION
## 前置已完成

pack **litigation-visual@1.0.0** 已上架北京+新加坡双镜像，`publish-pack.sh verify` 公网对账通过（manifest 签名用桌面端内置公钥本地验签 true）。master 从本 PR 起任一状态都能发出功能完整的版本：新装用户点「安装」即从镜像下载，老用户升级后自动补下载（PR#434 的 PackAutoInstaller）。

## 内容

- extraResources 删 `../litviz` / `graphviz` / `../frontend/dist/drawio` 三项（skills 与 python 保留：文本很小 / pysvc 还要用）
- desktop-build.yml 删 draw.io 烘焙 + 双平台 graphviz 打包三步（脚本本体保留，pack-release.yml 在用）
- 版本号 0.20.0 → **0.21.0**（desktop/ 改动只能随大版本，patch-gate 约束；**本轮不发版**，攒着一起发）
- 顺带载入 publish-pack.sh sign 修复（私钥经 node 直读 env，多行 PEM 不再被 grep 截断——上架 1.0.0 时实测踩到并修好）

## 测试

desktop npm test 49/49（含 drawio 多根与 build-pack）；瘦身量 mac 约 -45MB / win 约 -60MB（解压后口径，dmg/exe 压缩后略小）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)