### PR TITLE
fix(eng-infra): 镜像同步不再用 releases/latest——pack release 会顶掉应用版把同步打挂

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -86,6 +86,12 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   `bash deploy/update-mirror-sync_prune_test.sh`（纯本地，不碰网络与真镜像目录）。
   **服务器上跑的是一份副本**（`/www/wwwroot/update/desktop/update-mirror-sync.sh`，cron 每小时 :17），
   合并 PR 不会让它生效，要 scp 覆盖过去。
+  **选版不用 `releases/latest`**：那是仓库级「最新」，正式 pack release 也算数
+  （2026-08-19 实测顶掉应用版 2.5 小时，脚本连挂三轮、镜像停更）。脚本从
+  `/releases` 列表挑 tag 形如 `v<数字>` 的正式版；pack-release.yml 那边同时标
+  `prerelease: true` 双保险。latest.json 落地后会回调官网 `/api/revalidate-release`
+  （配置在服务器 `/etc/aiworkdeck/mirror-sync.env`，token 与官网 env 同值），
+  让 /start 下载链立即刷新；没配置/回调失败靠页面 `revalidate: 300` 兜底。
 - `deploy/publish-pack.sh` — 原生资源包（native pack）上架：check 本地验产物 /
   sign 在官网机上用 env 私钥签 manifest（私钥不落本机）/ publish 双机上架
   `/www/wwwroot/plugin-packs/` 暂存校验后换入、双机验证后才切 manifest 指针 /

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -141,6 +141,12 @@ jobs:
           tag_name: pack-${{ env.PACK_ID }}-v${{ inputs.version }}
           name: 'native pack: ${{ env.PACK_ID }} v${{ inputs.version }}'
           # 与应用的 v* tag 井水不犯河水（前缀不同），不会触发 desktop-build.yml。
+          # 必须标 prerelease：GitHub 的 releases/latest 是仓库级的，正式 release
+          # 一律算数。2026-08-19 实测 pack 上架后 releases/latest 返回本 release
+          # 达 2.5 小时，镜像同步脚本连挂三轮、两个官网的 fromGithub 也被污染。
+          # prerelease 不影响资产直链下载，pack 分发链路（mirror 优先 + GitHub
+          # 按 tag 直链兜底）完全不受影响。
+          prerelease: true
           body: |
             native pack `${{ env.PACK_ID }}` v${{ inputs.version }}（未签名产物）。
 

--- a/deploy/update-mirror-sync.sh
+++ b/deploy/update-mirror-sync.sh
@@ -22,7 +22,32 @@ set -euo pipefail
 
 REPO="${REPO:-zeweihan/aiworkdeck}"
 WEB_ROOT="${WEB_ROOT:-/www/wwwroot/update/desktop}"
-API="https://api.github.com/repos/${REPO}/releases/latest"
+# 不能用 releases/latest：它是仓库级「最新」，native pack 的 release
+# （tag pack-*-v*，见 pack-release.yml）也算数。2026-08-19 实测：pack 上架后到
+# 下一个应用版发布前的 2.5 小时里，releases/latest 一直返回 pack release，
+# 本脚本连挂三轮 cron（pack 带 manifest.json 却没有 .sig，mv 直接炸），
+# 镜像停更、官网 /start 发旧版。改为列出 releases 后只认 tag 形如 v<数字> 的
+# 正式应用版。per_page=15 足够：应用版最密一天三发，15 条怎么也罩得住。
+API="https://api.github.com/repos/${REPO}/releases?per_page=15"
+
+# 回调官网 revalidate 端点用的配置（AWD_REVALIDATE_URLS / AWD_REVALIDATE_TOKEN）。
+# 不能放 WEB_ROOT 下：nginx 那个 location 只 deny .sh/.py，其它文件名公网可下载。
+if [ -f /etc/aiworkdeck/mirror-sync.env ]; then . /etc/aiworkdeck/mirror-sync.env; fi
+
+# latest.json 落地后回调官网，立即作废 /start 下载链的 fetch 缓存
+# （官网仓 app/api/revalidate-release，tag 'latest-release'）。没配置就跳过；
+# 回调失败只记日志——官网自身 revalidate:300 兜底，最迟 5 分钟自愈。
+notify_website() {
+  [ -n "${AWD_REVALIDATE_URLS:-}" ] || return 0
+  local u
+  for u in $AWD_REVALIDATE_URLS; do
+    if curl -sf -m 10 -X POST -H "authorization: Bearer ${AWD_REVALIDATE_TOKEN:-}" "$u" >/dev/null; then
+      echo "[mirror-sync] revalidate 回调成功: $u"
+    else
+      echo "[mirror-sync] revalidate 回调失败（忽略，页面最迟 5 分钟自行刷新）: $u" >&2
+    fi
+  done
+}
 
 # 清理旧安装包：只删「比上一版更老的」，当前版与上一版都留着。
 #
@@ -77,8 +102,23 @@ mkdir -p "$WEB_ROOT/assets" "$WEB_ROOT/installers"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# cron 重定向进同一个日志文件，没有时间戳就没法做事后取证
+#（2026-08-19 复盘时全靠文件 mtime 反推时间线）
+echo "[mirror-sync] run at $(date '+%F %T')"
 echo "[mirror-sync] fetching latest release metadata: $REPO"
-curl -sfL "$API" -o "$TMP/release.json"
+curl -sfL "$API" -o "$TMP/releases.json"
+# 列表按 created_at 倒序；挑第一个非草稿、非预发布、tag 形如 v<数字> 的应用版
+python3 - "$TMP/releases.json" <<'EOF' > "$TMP/release.json"
+import json, re, sys
+for r in json.load(open(sys.argv[1])):
+    if r.get('draft') or r.get('prerelease'):
+        continue
+    if re.match(r'^v\d', r.get('tag_name', '')):
+        json.dump(r, sys.stdout)
+        break
+else:
+    sys.exit('[mirror-sync] 列表里没有 tag 形如 v<数字> 的应用 release，放弃本次同步')
+EOF
 TAG=$(python3 -c "import json;print(json.load(open('$TMP/release.json'))['tag_name'])")
 echo "[mirror-sync] latest release: $TAG"
 
@@ -159,8 +199,11 @@ if [ "$FAILED" = "1" ]; then
 fi
 
 # assets 全部就位后再原子换 manifest（+签名，先 sig 后 manifest 也无妨，
-# 客户端总是成对拉取并验签）
-if [ "$FAILED" = "0" ] && [ "$MANIFEST_READY" = "1" ]; then
+# 客户端总是成对拉取并验签）。两个文件必须都在才动手——2026-08-19 pack release
+# 恰好带一个（pack 契约的）manifest.json 而没有 .sig，单腿落地会把桌面端
+# 更新通道的 manifest 换成 pack 的；当时全靠 mv sig 在前先炸救了一命。
+if [ "$FAILED" = "0" ] && [ "$MANIFEST_READY" = "1" ] \
+   && [ -f "$TMP/manifest.json" ] && [ -f "$TMP/manifest.json.sig" ]; then
   mv "$TMP/manifest.json.sig" "$WEB_ROOT/manifest.json.sig"
   mv "$TMP/manifest.json" "$WEB_ROOT/manifest.json"
   echo "[mirror-sync] manifest updated"
@@ -207,6 +250,7 @@ json.dump(out, sys.stdout, ensure_ascii=False)
 EOF
     mv "$TMP/latest.json" "$WEB_ROOT/installers/latest.json"
     echo "[mirror-sync] installers/latest.json updated -> $TAG"
+    notify_website
 
     # 清理旧安装包与过期半成品（只删 .dmg/.exe/.part，不碰 latest.json）
     prune_old_installers "${TAG#v}" "$TMP/installers.tsv"

--- a/docs/NATIVE_PACK_DISTRIBUTION.md
+++ b/docs/NATIVE_PACK_DISTRIBUTION.md
@@ -295,6 +295,9 @@ models/ 已验证过这一点），pack 同享此保障。
   litviz/drawio 平台无关组件单 runner 产出；汇总 job 生成 manifest、
   用 CI secret 里的签名私钥出 `.sig`、把全部产物挂上 GitHub Release
   （tag `pack-<id>-v<version>`，与应用 `v*` tag 井水不犯河水，不触发 desktop-build）。
+  **release 必须标 prerelease**：GitHub `releases/latest` 是仓库级的，正式 pack
+  release 会顶掉应用版——2026-08-19 实测污染镜像同步脚本与官网 fromGithub 达
+  2.5 小时（镜像停更、/start 发旧版）。prerelease 不影响资产直链下载。
 - 发布脚本 `deploy/publish-pack.sh`（照 `publish-lowa-engine.sh` 的骨架）：
   从 GitHub Release 拉产物（或本机中转）→ 验签验哈希 → 推北京 + 新加坡两台
   `/www/wwwroot/plugin-packs/<id>/<version>/` → 终验（两站各 curl 首尾字节 +


### PR DESCRIPTION
## 根因（2026-08-19 v0.21.0 发版事故复盘）

pack-litigation-visual-v1.0.0（18:06 +0800）上架后到 v0.21.0（20:33）发布前，GitHub `releases/latest` 一直返回 pack release（它是仓库级「最新」，正式 release 一律算数）。镜像同步 cron 在 18:17/19:17/20:17 连挂三轮：pack 资产里有 pack 契约的 `manifest.json` 却没有 `.sig`，`mv` 在 set -e 下直接炸。`installers/latest.json` 停在 v0.20.0，官网 /start 发旧版 47 分钟，叠加页面 revalidate:300 的正常窗口，被误判成「Next fetch 缓存 SWR 坏了」。

本地最小复现（Next 16.1.3 + next start + force-dynamic + `AbortSignal.timeout(4000)` + `revalidate:300`）证明 SWR 完全正常：改 JSON 后 5.5 分钟页面自动刷新，带不带 signal 无差别。官网缓存无罪。

另一条命保住纯属侥幸：脚本先 `mv manifest.json.sig` 后 `mv manifest.json`，缺 .sig 先炸，否则桌面端更新通道的 manifest 会被 pack 的 manifest 覆盖。

## 改动

- `deploy/update-mirror-sync.sh`：从 `/releases` 列表挑 tag 形如 `v<数字>` 的正式应用版；manifest 落地必须 `.json`+`.sig` 双全；日志加时间戳（这次取证全靠文件 mtime 反推时间线）；latest.json 落地后回调官网 revalidate 端点（`/etc/aiworkdeck/mirror-sync.env` 配置，缺省跳过，失败靠页面 revalidate:300 兜底）
- `.github/workflows/pack-release.yml`：pack release 标 `prerelease: true` 双保险（不影响资产直链下载；存量 pack-litigation-visual-v1.0.0 已用 API 补标完成）
- `docs/NATIVE_PACK_DISTRIBUTION.md` / `.claude/agents/eng-infra.md` 同步补地雷

配套官网仓 PR：revalidate 回调端点 + fetch 挂 'latest-release' tag。

## 验证

- `bash -n` 通过；`deploy/update-mirror-sync_prune_test.sh` 全绿
- revalidateTag 端点与 300s SWR 均在 Next 16.1.3 复现环境实测通过
- 服务器 scp 副本 + env 配置随合并后执行并实测端到端

🤖 Generated with [Claude Code](https://claude.com/claude-code)