### PR TITLE
fix(desktop): 首启假死与 .drawio 死胡同两项修复

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -225,6 +225,16 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   就继续启动——**表根本没建出来，启动看着正常，第一次查询才炸**。
   `EntityIndexColumnNamingTest` 是这条的护栏：反射扫全部 `@Entity`，对着 H2 的
   INFORMATION_SCHEMA 逐条对账列名与索引，新实体写错驼峰会自动红。
+- **Electron 主进程禁用 `spawnSync`/任何同步阻塞调用**：v0.21.0 新机首启 10-30 秒无窗口、
+  Dock 弹强制退出的根因是 `pptx-service.js` 的 `prepare()` 用 `spawnSync` 跑 alembic 迁移——
+  这一步冻住的是**主进程**，Node 事件循环停摆等于整个 app 失去响应，系统据此判定"无响应"。
+  改成 `spawn` + Promise 等 `exit`（模式抄 `pysvc-runtime.js` 的 `extractTarOnce`），语义不变
+  （非零退出码报错、stderr 截断）。同理，首启解压进度窗（`main.js` 的 `ensurePysvcReady`）
+  不能在解压完就销毁——后面 `createServices→allocatePorts→startEager` 还要拉起 Java 后端等
+  本机服务，这段同样耗时且此前完全没有 UI；真正销毁要挪到 `createMainWindow()` 之后
+  （挂在主窗口 `ready-to-show`，避免双窗口叠加闪烁），窗口本身在这期间只切文案不重开。
+  `startEager` 逐个 `await` 也一样是白等：各服务端口已在 `allocatePorts` 统一分配好，
+  互相没有启动时序依赖，串行只是把首启时间累加，已改 `Promise.all` 且保留单服务失败互不影响。
 
 ## 验证（改本领域自身时）
 

--- a/.claude/agents/litigation-visual.md
+++ b/.claude/agents/litigation-visual.md
@@ -213,6 +213,16 @@ Python 下限 **3.11**（与打包运行时一致）。引擎原本要 3.12+，�
 - 上游 `doctor.py` 自称「Python ≥ 3.9」与实际不符（见 PATCHES.md PATCH 2）；
   `schemas/` 的 layout 枚举曾漏 `comparison_table`（PATCH 3）。**升级引擎后
   重跑 `litviz/tests/test_cli.py`，别信上游的自述。**
+- **`.drawio` 打不开不能只说「没有编辑器」就完事**：v0.21.0 摘除随包 drawio 资源后，
+  `checkba:drawio-editor`（`desktop/main/main.js`）在 `isAvailable()` 为假时除了
+  `available:false` 还要带上 `packId:'litigation-visual'`（`drawio-server.js` 导出的
+  `PACK_ID` 常量），`DrawioEditor.vue` 桌面态下才能在 unavailable 分支画出「安装图形
+  编辑器组件」主按钮——复用 `packInfo`/`packInstall`/`packStatus`（`services/api.js`）
+  与 `LitigationVisualPanel.vue` 同一套轮询模式，`state:'ready'` 后自动重新 `boot()`
+  挂载编辑器，不用用户再点一次。Web 部署没有这条路（`host.js` 的 Web 能力表 `getEditor()`
+  从不带 `packId`），仍是「下载文件」兜底。这条不是给 draw.io 专属加的特权——任何后续
+  「资源摘出安装包、改走 native pack」的功能点想做到「打不开时能当场装」，都是这个形状：
+  IPC/接口把 `packId` 带出来，前端拿它去连 packInstall/packStatus。
 
 ## 验证
 

--- a/desktop/main/drawio-server.js
+++ b/desktop/main/drawio-server.js
@@ -227,4 +227,4 @@ async function stopDrawioServer() {
   } catch (e) { /* 起都没起来，无需关闭 */ }
 }
 
-module.exports = { startDrawioServer, stopDrawioServer, drawioUrl, isAvailable }
+module.exports = { startDrawioServer, stopDrawioServer, drawioUrl, isAvailable, PACK_ID }

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -28,6 +28,10 @@ let mainWindow = null
 let services = null
 let modelManager = null
 let updateService = null
+// 首启 pysvc 解压完成后仍需保留的进度窗（见 ensurePysvcReady）：解压只是启动链的一段，
+// 后面 createServices→startEager 还要拉起 Java 后端等本机服务，期间没有它就是纯黑屏，
+// 系统会判定"无响应"。真正销毁挪到 createMainWindow 之后（ready-to-show 时机，见下）。
+let firstLaunchSplash = null
 
 // 增量更新（docs/INCREMENTAL_UPDATE_DESIGN.md）：overlay 上下文——三个 seam
 // （backend jar / h5 / zetaoffice 壳层）与 update-service 共用
@@ -1301,6 +1305,11 @@ function resolvePysvcRoot() {
 // 首启/升级后的 pysvc 解压（幂等）。带一个极简进度窗——mineru lib 解压要数十秒，
 // 无提示会被当成"点了没反应"。失败不阻塞主流程：弹框告知后照常开窗，
 // 相关 Python 服务会各自启动失败并落日志。
+//
+// 解压完成不等于启动完成：后面还要 createServices→allocatePorts→startEager 拉起
+// Java 后端等本机服务，这段同样耗时且此前完全没有 UI（系统据此判定"无响应"，Dock
+// 弹强制退出）。所以这里解压完不销毁窗口，只把文案切到不确定态；真正销毁交给调用方
+// 在 createMainWindow 之后做（见 firstLaunchSplash）。
 async function ensurePysvcReady() {
   const root = resolvePysvcRoot()
   if (!root) return
@@ -1327,14 +1336,28 @@ async function ensurePysvcReady() {
     const html = `<!doctype html><meta charset="utf-8">
       <body style="margin:0;font:14px -apple-system,'Segoe UI',sans-serif;background:#1e1f24;color:#e8e8ea;display:flex;align-items:center;justify-content:center;height:100vh;user-select:none">
         <div style="width:320px;text-align:center">
-          <div style="margin-bottom:6px">正在准备本地组件…</div>
-          <div style="font-size:12px;color:#9a9aa2;margin-bottom:14px">首次启动或版本更新后需解压，约一分钟</div>
+          <div id="title" style="margin-bottom:6px">正在准备本地组件…</div>
+          <div id="subtitle" style="font-size:12px;color:#9a9aa2;margin-bottom:14px">首次启动或版本更新后需解压，约一分钟</div>
           <div style="background:#33343c;border-radius:4px;height:8px;overflow:hidden">
             <div id="bar" style="background:#4f8cff;height:100%;width:0%;transition:width .4s"></div>
           </div>
           <div id="pct" style="font-size:12px;color:#9a9aa2;margin-top:8px">&nbsp;</div>
         </div>
-        <script>window.__setP=function(p){if(p>=0){document.getElementById('bar').style.width=p+'%';document.getElementById('pct').textContent=p+'%'}}</script>
+        <style>
+          @keyframes indet { 0% { margin-left:-40% } 100% { margin-left:100% } }
+          #bar.indet { width:40% !important; animation: indet 1.1s ease-in-out infinite; transition: none }
+        </style>
+        <script>
+          window.__setP=function(p){if(p>=0){document.getElementById('bar').style.width=p+'%';document.getElementById('pct').textContent=p+'%'}}
+          // 解压完成后进入"启动本地服务"阶段：耗时未知，切不确定态进度条
+          window.__setPhase=function(title, subtitle){
+            document.getElementById('title').textContent = title
+            document.getElementById('subtitle').textContent = subtitle
+            document.getElementById('pct').textContent = '\\u00a0'
+            var bar = document.getElementById('bar')
+            bar.classList.add('indet')
+          }
+        </script>
       </body>`
     splash.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html))
     splash.once('ready-to-show', () => { try { splash.show() } catch (e) { /* ignore */ } })
@@ -1348,8 +1371,8 @@ async function ensurePysvcReady() {
     versionDir,
     onProgress: ({ percent }) => setProgress(percent)
   })
-  try { if (splash && !splash.isDestroyed()) splash.destroy() } catch (e) { /* ignore */ }
   if (!result.ok) {
+    try { if (splash && !splash.isDestroyed()) splash.destroy() } catch (e) { /* ignore */ }
     console.error('[pysvc] extract failed:', result.message)
     try {
       const { dialog } = require('electron')
@@ -1361,6 +1384,31 @@ async function ensurePysvcReady() {
         })
       )
     } catch (e) { /* ignore */ }
+    return
+  }
+  // 成功：不销毁，切文案继续等后端等服务起来；调用方在 createMainWindow 后收尾
+  try {
+    if (splash && !splash.isDestroyed()) {
+      splash.webContents.executeJavaScript(
+        `window.__setPhase && window.__setPhase(${JSON.stringify('正在启动本地服务…')}, ${JSON.stringify('首次启动准备就绪，即将打开窗口')})`
+      ).catch(() => {})
+    }
+  } catch (e) { /* ignore */ }
+  firstLaunchSplash = splash
+}
+
+// firstLaunchSplash 收尾：绑到主窗口 ready-to-show，避免解压进度窗与主窗口两个
+// 窗口叠加闪烁；兜个超时兜底，防止极端情况下 ready-to-show 迟迟不来把它卡住。
+function retireFirstLaunchSplash() {
+  const splash = firstLaunchSplash
+  firstLaunchSplash = null
+  if (!splash || splash.isDestroyed()) return
+  const destroy = () => { try { if (!splash.isDestroyed()) splash.destroy() } catch (e) { /* ignore */ } }
+  if (mainWindow) {
+    mainWindow.once('ready-to-show', destroy)
+    setTimeout(destroy, 5000)
+  } else {
+    destroy()
   }
 }
 
@@ -1500,8 +1548,10 @@ ipcMain.handle('checkba:zetaoffice-editor', async () => {
 // 资源没烙进这次构建时返回 { available:false }，渲染层据此退回「下载后用其他程序打开」，
 // 而不是挂一个永远转圈的 iframe。
 ipcMain.handle('checkba:drawio-editor', async () => {
-  const { startDrawioServer, drawioUrl, isAvailable } = require('./drawio-server')
-  if (!(await isAvailable())) return { available: false }
+  const { startDrawioServer, drawioUrl, isAvailable, PACK_ID } = require('./drawio-server')
+  // packId 供渲染层在 unavailable 分支引导安装原生资源包（广场「litigation-visual」）；
+  // 不改变 available:false 本身的既有语义，desktop/tests/drawio-server.test.js 钉着它。
+  if (!(await isAvailable())) return { available: false, packId: PACK_ID }
   const { origin } = await startDrawioServer()
   return { available: true, kind: 'iframe', origin, url: drawioUrl(origin) }
 })
@@ -1596,6 +1646,7 @@ app.whenReady().then(() => {
         }
       } catch (e) { console.error('[overlay]', e) }
       createMainWindow()
+      retireFirstLaunchSplash()
       // 应用内更新检查（P1）：启动 2 分钟后静默首查，之后每 6 小时一次
       try {
         const { createUpdateService } = require('./services/update-service')
@@ -1659,6 +1710,7 @@ app.whenReady().then(() => {
       // 端口分配/启动链失败也要建出主窗口并提示，避免 app 起来却无窗口无提示（静默失败）
       console.error('[startup] service init failed', err)
       try { createMainWindow() } catch (e) { /* ignore */ }
+      retireFirstLaunchSplash()
       try {
         if (mainWindow) mainWindow.webContents.send('checkba:backend-status', { ok: false, message: String(err && err.message ? err.message : err) })
       } catch (e) { /* ignore */ }

--- a/desktop/main/services/pptx-service.js
+++ b/desktop/main/services/pptx-service.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const fs = require('fs')
-const { spawnSync } = require('child_process')
+const { spawn } = require('child_process')
 const { findFreePort } = require('./service-manager')
 const { pysvcPath } = require('./pysvc-runtime')
 
@@ -46,6 +46,26 @@ function spawnEnv(ctx) {
   return env
 }
 
+// alembic 迁移异步跑：spawnSync 会冻住 Electron 主进程（macOS 上系统据此判定应用
+// 无响应，首启弹「强制退出」），改成 spawn + Promise 等 exit，语义不变
+// （status!=0 报错、stderr 截断到 2000 字符）
+function runAlembicUpgrade(ctx) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(pyBin(ctx), ['-m', 'alembic', '-c', path.join(appDir(ctx), 'alembic.ini'), 'upgrade', 'head'], {
+      cwd: appDir(ctx),
+      env: spawnEnv(ctx),
+      stdio: ['ignore', 'ignore', 'pipe']
+    })
+    let stderr = ''
+    proc.stderr.on('data', (d) => { stderr = (stderr + d.toString()).slice(-2000) })
+    proc.once('error', reject)
+    proc.once('exit', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(`pptx alembic migration failed: ${stderr}`))
+    })
+  })
+}
+
 function createPptxDescriptor() {
   return {
     name: 'pptx-service',
@@ -64,15 +84,7 @@ function createPptxDescriptor() {
       fs.mkdirSync(dataDir(ctx), { recursive: true })
       // SQLite schema 迁移（alembic.ini/migrations 随 app 源码打包；env.py 经 create_app
       // 读 PPTX_DATA_DIR，迁移与运行落同一个库）
-      const r = spawnSync(pyBin(ctx), ['-m', 'alembic', '-c', path.join(appDir(ctx), 'alembic.ini'), 'upgrade', 'head'], {
-        cwd: appDir(ctx),
-        env: spawnEnv(ctx),
-        stdio: 'pipe',
-        encoding: 'utf8'
-      })
-      if (r.status !== 0) {
-        throw new Error(`pptx alembic migration failed: ${(r.stderr || '').slice(-2000)}`)
-      }
+      await runAlembicUpgrade(ctx)
     },
     commands: (ctx) => {
       if (!ctx.packaged) return [] // dev 态只做复用检测，不自行 spawn

--- a/desktop/main/services/service-manager.js
+++ b/desktop/main/services/service-manager.js
@@ -189,17 +189,20 @@ class ServiceManager {
     })
   }
 
+  // 并行拉起所有 eager 服务。端口已在 allocatePorts 统一分配好，服务之间没有
+  // "谁先监听"的启动时序依赖（pptx 只是把 mineru 端口写进环境变量，不要求 mineru
+  // 已经监听），逐个 await 纯粹是白白把首启时间叠加起来。单个服务失败互不影响，
+  // 语义与原来串行版本一致：results 里每个 name 各自 {ok, error}。
   async startEager() {
     const results = {}
-    for (const d of this.descriptors.values()) {
-      if (!d.eager) continue
+    const eagerNames = [...this.descriptors.values()].filter((d) => d.eager).map((d) => d.name)
+    await Promise.all(eagerNames.map(async (name) => {
       try {
-        // eslint-disable-next-line no-await-in-loop
-        results[d.name] = await this.start(d.name)
+        results[name] = await this.start(name)
       } catch (e) {
-        results[d.name] = { ok: false, error: String(e && e.message ? e.message : e) }
+        results[name] = { ok: false, error: String(e && e.message ? e.message : e) }
       }
-    }
+    }))
     return results
   }
 

--- a/frontend/src/components/DrawioEditor.vue
+++ b/frontend/src/components/DrawioEditor.vue
@@ -4,15 +4,23 @@
       <text class="drawio-status-text">{{ $t('editor.drawio.opening') }}</text>
     </view>
 
-    <!-- 这次构建没烙 draw.io 资源（Web 部署未放 dist/drawio、壳层版本旧），
-         或者资源在但那个 origin 探不通。说清楚比挂一个永远转圈的 iframe、
-         或者让浏览器的 404 页占满整个编辑区诚实。 -->
+    <!-- 这次构建没烙 draw.io 资源，或者资源在但那个 origin 探不通。说清楚比挂一个
+         永远转圈的 iframe、或者让浏览器的 404 页占满整个编辑区诚实。
+         桌面态且探明是"资源包没装"（packId 有值）时给一条能当场解决的路——
+         v0.21.0 起 draw.io 摘出安装包改走 native pack，见 litigation-visual.md。 -->
     <view v-else-if="phase === 'unavailable'" class="drawio-status">
       <text class="drawio-status-text">{{ $t('editor.drawio.unavailable') }}</text>
       <text class="drawio-status-hint">
-        {{ $t('editor.drawio.downloadHint', { name: (file && file.name) || '' }) }}
+        {{ showInstallAction ? $t('editor.drawio.installHint') : $t('editor.drawio.downloadHint', { name: (file && file.name) || '' }) }}
       </text>
       <view class="drawio-actions">
+        <view
+          v-if="showInstallAction"
+          class="drawio-btn primary"
+          :class="{ disabled: installButtonDisabled }"
+          role="button"
+          @tap="installPack"
+        >{{ installButtonText }}</view>
         <view class="drawio-btn" role="button" @tap="download">{{ $t('editor.drawio.downloadFile') }}</view>
         <view class="drawio-btn" role="button" @tap="boot">{{ $t('editor.drawio.retry') }}</view>
       </view>
@@ -61,9 +69,9 @@
 // LitigationVisualPanelService.saveDrawio。**PNG 不用 draw.io 自己导的位图**——
 // 随包中文字体的注册与字体栈兜底都在服务端 Batik 那条路上，绕过它标题在干净的
 // Windows 上会变成方块（记在案的地雷）。
-import { getFileDownloadUrl, saveDrawioDiagram } from '@/services/api.js'
+import { getFileDownloadUrl, saveDrawioDiagram, packStatus, packInstall } from '@/services/api.js'
 import { getAuthHeaders } from '@/utils/auth.js'
-import { host } from '@/services/host.js'
+import { host, isDesktopHost } from '@/services/host.js'
 
 export default {
   name: 'DrawioEditor',
@@ -80,7 +88,36 @@ export default {
       xml: '',
       dirty: false,
       savedTip: '',
-      pendingExport: null     // 保存链路里等 SVG 的那个 resolve
+      pendingExport: null,    // 保存链路里等 SVG 的那个 resolve
+      // 桌面态资源包引导安装：packId 只在 getEditor() 明确回答"资源不在场"时才有值，
+      // 见 boot() 里的判定。与 LitigationVisualPanel.vue 的 native pack 状态条同一套
+      // 契约（packStatus/packInstall + 轮询），docs/NATIVE_PACK_DISTRIBUTION.md §5/§7.1。
+      packId: null,
+      packState: null,        // packStatus() 结果 {state, bytesDownloaded, bytesTotal, error}
+      packInstalling: false,
+      packTimer: null
+    }
+  },
+  computed: {
+    showInstallAction() {
+      return this.phase === 'unavailable' && !!this.packId && isDesktopHost()
+    },
+    installButtonDisabled() {
+      const s = this.packState
+      return this.packInstalling || !!(s && (s.state === 'downloading' || s.state === 'installing' || s.state === 'verifying'))
+    },
+    installButtonText() {
+      const s = this.packState
+      if (!s || s.state === 'not_installed') return this.$t('editor.drawio.installPack')
+      if (s.state === 'failed') return this.$t('editor.drawio.installPackRetry')
+      const total = s.bytesTotal || 0
+      if (total > 0) {
+        return this.$t('editor.drawio.installPackProgress', {
+          downloaded: ((s.bytesDownloaded || 0) / (1024 * 1024)).toFixed(1),
+          total: (total / (1024 * 1024)).toFixed(1)
+        })
+      }
+      return this.$t('editor.drawio.installPackDownloading')
     }
   },
   mounted() {
@@ -89,6 +126,7 @@ export default {
   },
   beforeUnmount() {
     window.removeEventListener('message', this.onMessage)
+    this.stopPackPoll()
   },
   watch: {
     'file.id'() {
@@ -101,6 +139,8 @@ export default {
     async boot() {
       this.phase = 'loading'
       this.errorText = ''
+      this.packId = null
+      this.stopPackPoll()
       try {
         const api = host.drawio
         if (!api || typeof api.getEditor !== 'function') {
@@ -109,7 +149,11 @@ export default {
         }
         const info = await api.getEditor()
         if (!info || !info.available || !info.url) {
+          // packId 只有 main.js 的 checkba:drawio-editor 明确判过资源不在场才带（见
+          // desktop/main/main.js），标志着"装个 pack 就能解决"而不是别的什么坏了
+          this.packId = (info && info.packId) || null
           this.phase = 'unavailable'
+          if (this.packId && isDesktopHost()) this.refreshPackStatus()
           return
         }
         // 先探一下这个 URL 真的能取到再挂 iframe。宿主只回答了"资源目录里有
@@ -273,6 +317,50 @@ export default {
         return
       }
       window.open(getFileDownloadUrl(id), '_blank')
+    },
+
+    // ---- 图形编辑器组件（native pack）引导安装 ----
+    async refreshPackStatus() {
+      if (!this.packId) return
+      try {
+        const res = await packStatus(this.packId)
+        this.packState = (res && res.status) || null
+      } catch (e) {
+        // 拉不到状态：旧后端没有这个端点——按「不可知」处理，用户仍可点「下载文件」兜底
+        this.packState = null
+        this.stopPackPoll()
+        return
+      }
+      const state = this.packState && this.packState.state
+      if (state === 'ready') {
+        this.stopPackPoll()
+        this.boot() // 装好了，自动重新挂编辑器，不用用户再点一次
+        return
+      }
+      if (state === 'failed') {
+        this.stopPackPoll()
+        return
+      }
+      if (state && !this.packTimer) this.startPackPoll()
+    },
+    startPackPoll() {
+      this.stopPackPoll()
+      this.packTimer = setInterval(() => { this.refreshPackStatus() }, 1000)
+    },
+    stopPackPoll() {
+      if (this.packTimer) { clearInterval(this.packTimer); this.packTimer = null }
+    },
+    async installPack() {
+      if (!this.packId || this.installButtonDisabled) return
+      this.packInstalling = true
+      try {
+        await packInstall(this.packId)
+        await this.refreshPackStatus()
+      } catch (e) {
+        uni.showToast({ title: (e && e.message) || this.$t('editor.drawio.installPackFailed'), icon: 'none' })
+      } finally {
+        this.packInstalling = false
+      }
     }
   }
 }
@@ -329,4 +417,11 @@ export default {
   user-select: none;
 }
 .drawio-btn:hover { border-color: #c9ced6; background: #fafbfc; }
+.drawio-btn.primary {
+  border-color: #3a7afe;
+  background: #3a7afe;
+  color: #fff;
+}
+.drawio-btn.primary:hover { border-color: #2f68e0; background: #2f68e0; }
+.drawio-btn.disabled { opacity: .6; pointer-events: none; }
 </style>

--- a/frontend/src/locales/en-US/editor.js
+++ b/frontend/src/locales/en-US/editor.js
@@ -134,6 +134,12 @@ export default {
     readFailed: 'Failed to read the file ({status})',
     fileEmpty: 'The file is empty',
     saveFailed: 'Failed to save',
+    installHint: 'The diagram editor component isn\'t installed yet. Install it to keep editing this diagram.',
+    installPack: 'Install Diagram Editor Component',
+    installPackDownloading: 'Installing…',
+    installPackProgress: 'Downloading… {downloaded} / {total} MB',
+    installPackRetry: 'Install failed, retry',
+    installPackFailed: 'Installation failed',
   },
   // Self-built toolbar (EditorToolbar.vue): tooltips, dropdowns and the find bar.
   toolbar: {

--- a/frontend/src/locales/zh-CN/editor.js
+++ b/frontend/src/locales/zh-CN/editor.js
@@ -134,6 +134,12 @@ export default {
     readFailed: '读取文件失败（{status}）',
     fileEmpty: '文件是空的',
     saveFailed: '保存失败',
+    installHint: '图形编辑器组件还没装，装好后可以继续编辑这份图。',
+    installPack: '安装图形编辑器组件',
+    installPackDownloading: '正在安装…',
+    installPackProgress: '正在下载… {downloaded} / {total} MB',
+    installPackRetry: '安装失败，重试',
+    installPackFailed: '安装失败',
   },
   // 自建工具栏（EditorToolbar.vue）。工具提示、下拉与查找替换条的全部可见文案。
   toolbar: {


### PR DESCRIPTION
## Summary

两个独立问题，各一个 commit：

**问题 1：v0.21.0 新机首启 10-30 秒无窗口、Dock 提示强制退出**
- `desktop/main/services/pptx-service.js`：`prepare()` 用 `spawnSync` 跑 alembic 迁移，冻住 Electron 主进程本身——事件循环停摆即"无响应"。改成 `spawn` + Promise 等 exit，语义不变（非零退出码报错、stderr 截断），模式抄 `pysvc-runtime.js` 的 `extractTarOnce`。
- `desktop/main/main.js`：首启解压进度窗一解压完就 `destroy`，而主窗口要等 `createServices→allocatePorts→startEager` 全部跑完才创建，中间完全没有 UI。改成解压完不销毁、切文案为"正在启动本地服务…"（不确定态进度条），真正销毁挪到 `createMainWindow` 之后、挂在主窗口 `ready-to-show`，避免两个窗口叠加闪烁。
- `desktop/main/services/service-manager.js`：`startEager` 改 `Promise.all` 并行拉起 eager 服务（各服务端口已在 `allocatePorts` 统一分配，互相没有启动时序依赖），单服务失败互不影响的语义不变。

**问题 2：打开 .drawio 显示"当前环境没有内置图形编辑器"死胡同**
- `checkba:drawio-editor` IPC 在 `available:false` 时附带 `packId:'litigation-visual'`，不改变既有语义。
- `DrawioEditor.vue` 桌面态下探明是"资源包没装"时，unavailable 分支增加主按钮"安装图形编辑器组件"，复用 `packInfo`/`packInstall`/`packStatus` 与 `LitigationVisualPanel.vue` 同一套轮询模式显示下载进度，`state:ready` 后自动重新 `boot()` 挂载编辑器。Web 部署（无 packId）保持现有"下载文件"文案。
- 中英文案成对补齐。

两个领域文档（`eng-infra.md` / `litigation-visual.md`）同步补了对应地雷记录。

## Test plan

- [x] `cd desktop && npm test` —— 49/49 通过（含 `drawio-server.test.js` 7/7，`drawioRoots()`/`isAvailable()` 既有语义未动）
- [x] `cd frontend && npm run check:emits` —— 通过
- [x] `cd frontend && npm run check:locales` —— 通过（新增 i18n 键中英文成对）
- [x] `cd frontend && npm run check:nav:full` —— 通过
- [x] `node -c` 语法检查全部改动的 .js 文件
- 未跑全量 e2e（按任务要求）；未发版

🤖 Generated with [Claude Code](https://claude.com/claude-code)