### PR TITLE
fix(ai-chat): 工具空输出不再掀翻整轮，异常终止的轮次也落库（dev-board #28 / #27）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -156,6 +156,26 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 
 - **改 AgentOrchestrator 构造器必须同步 EvalHarness**（已踩三次；现构造器末三参是
   TelemetryService/TelemetryTurnTracker/MatterClassifierService）。
+- **工具返回空白会掀翻整轮**：`ToolExecutionResultMessage.from(req, text)` 的
+  `ensureNotBlank(text, "text")` 对空串直接抛异常，用户看到的是
+  「Callback Error: text cannot be null or blank」——一个返回空串的工具就能打掉整轮对话。
+  两条入栈点（`AgentOrchestrator` 原生分支、`SubAgentService.executeScoped`）现在都把空白归一成
+  `AgentOrchestrator.BLANK_TOOL_OUTPUT` 并**按 FAILURE 处理**（进连续失败纠正回路）。
+  **新增任何往 messages 里塞工具结果的路径都要带这条归一**；XML 兜底分支因为有模板包裹不受影响。
+  上游诱因是抽取层：`read_document`/`read_file` 对 **Office 格式**必须走
+  `DocumentTextService`（Tika/PDFBox，与 `extract_file_text` 同一套）——docx 既不在
+  `FileContentExtractorService.ALLOWED_TEXT_EXTENSIONS` 也不在 `ai.context.ocr-extensions`，
+  只按那两个白名单分支就恒返回空串。抽不出正文时**返回一句可行动的说明，绝不返回空白**。
+  `ContextAssemblerService` 注入文件正文的两处守卫（`<file>` 段与 `<active_document>` 段）
+  也一律**判空白而不只判 null**，否则模型看到一段空 CDATA 会转头自己再调一次读取工具。
+- **轮次异常终止必须落库**：`onComplete` 的 catch 走 `finishWithError(...)`（与
+  `handleStreamErrorTerminal` 共用），把 `executionLog` + 已流出的部分内容 + 「[生成出错，已中断]」
+  一并写进 ASSISTANT 消息。只发 SSE 不落库 = 那一轮在历史里一个字都没有（「历史对话吃消息」）。
+  同理**执行日志的 `executionLog.append` 必须排在 `ToolExecutionResultMessage.from` 入栈之前**：
+  入栈抛异常时排在后面的 append 不会执行，崩溃轮的过程卡整段丢失。
+  内部一致性错误的 SSE 载荷带 `LlmErrorClassifier.INTERNAL_ERROR_MARKER`（`AI_INTERNAL_ERROR`），
+  前端 `useAgentStream` 据此换成人话（`agentStream.internalErrorNotice`，两套 locale 成对）——
+  这个标记**不由 `classify()` 产出**，是编排器直接拼的，别往 `Kind` 枚举里加。
 - **埋点体系**（`com.checkba.service.telemetry`，设计 docs/ANALYTICS_TELEMETRY_DESIGN.md）：
   唯一采集入口 TelemetryService.record/recordConv，字段过 TelemetryAttrWhitelist 白名单
   （新事件/字段要同步白名单 + TelemetryServiceTest + 官网仓 lib/telemetry-store.ts 的 EVENT_WHITELIST）。
@@ -238,5 +258,8 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 - 只跑回放：`mvn test -Dtest=OrchestratorReplayEvalTest`；真实 LLM 冒烟：`OPENROUTER_API_KEY=… mvn test -Dtest=RealLlmSmokeTest`（默认模型已换成 deepseek/deepseek-v4-flash，境内可跑）。
 - 身份作用域与模型解析：`mvn test -Dtest=PlatformScopeCloudMultiTenantTest,AuxModelResolverTest,SubAgentServiceTest,AgentOrchestratorFailoverTest,AgentOrchestratorFailoverFlowTest`。
 - 状态持久化/启动回收：`mvn test -Dtest=AgentRunRecoveryServiceTest`（mark 写透、RUNNING→INTERRUPTED+补标记、幂等、续跑翻回 RUNNING）。
+- 工具空输出与崩溃轮落库：`mvn test -Dtest=AgentOrchestratorBlankToolOutputTest,ReadDocumentOfficeFormatTest`
+  （空串工具不掀翻整轮 + 按 FAILURE 回喂；onComplete 异常路径把执行日志与错误摘要落库、error 载荷带
+  `AI_INTERNAL_ERROR`；read_document 对真实 docx fixture 返回非空正文、空文档给可行动说明）。
 - 前端：`npm run check:emits`；标签协议编解码 `npm run test:tag-protocol`（node:test，零依赖）；UI 链路 `npm run test:app-e2e`。
 - Office 插件的标签解析：`node --test office-addin/taskpane/lib/sse.test.js`（零依赖，未进 CI）。

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -46,6 +46,17 @@ public class AgentOrchestrator {
     // 工具连续失败达到该次数后，向模型注入强提示要求收敛
     private static final int CONSECUTIVE_FAILURE_NUDGE = 3;
 
+    /**
+     * 工具返回空白时替入上下文的占位说明。
+     *
+     * <p>不能原样把空串交给 {@code ToolExecutionResultMessage.from}：它的
+     * {@code ensureNotBlank(text, "text")} 会抛异常，一个返回空串的工具就掀翻整轮对话。
+     * 英文是给模型看的（与其它工具错误串同语种），不进用户可见文案。
+     */
+    public static final String BLANK_TOOL_OUTPUT =
+            "Error: the tool returned no output. Treat this as a failure: do not assume the operation "
+                    + "succeeded — verify with a read-only tool, or tell the user what is missing.";
+
     // LLM 失败自动重试：退避档位与次数上限按错误类型区分（见 LlmErrorClassifier.Kind），
     // 且仅在本轮尚未流出任何 token 时重放（对话状态未被污染，重放安全且用户无感知重复内容）；
     // 重试预算耗尽或模型下线时改走故障转移链（ai.failover），仍在同一计费通道内换模型
@@ -723,21 +734,33 @@ public class AgentOrchestrator {
                         result = toolResult.output();
                         success = toolResult.success();
                     }
+                    // 空输出归一：langchain4j 的 ToolExecutionResultMessage.from 对空白 text 抛
+                    // ensureNotBlank，一个返回空串的工具就能掀翻整轮对话（用户看到
+                    // 「Callback Error: text cannot be null or blank」）。任何工具返回空都不允许
+                    // 掀翻整轮——换成显式说明并按失败处理，走连续失败纠正回路让模型换个思路。
+                    if (!org.springframework.util.StringUtils.hasText(result)) {
+                        result = BLANK_TOOL_OUTPUT;
+                        success = false;
+                    }
                     result = appendFailureNudge(guard, result, success);
-                    messages.add(dev.langchain4j.data.message.ToolExecutionResultMessage.from(req, result));
 
                     // Determine status for history and display
                     String nativeToolStatus = success ? "SUCCESS" : "FAILURE";
+
+                    // Log for history persistence (include status attribute)
+                    // 先落执行日志再入栈：入栈那步一旦抛异常（历史上就是上面的 ensureNotBlank），
+                    // 排在它后面的 append 不会执行，崩溃轮的过程卡整段丢失、历史里无从回放
+                    executionLog.append(String.format("<process name=\"%s\"><tool_code>%s(%s)</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
+                        displayName.replace("\"", "'"), req.name(), AgentTagProtocol.escape(req.arguments()),
+                        nativeToolStatus, AgentTagProtocol.escape(result)));
+
                     // 载荷先截断再中和：截断口径按原文字数（与前端「...(截断)」提示一致），
                     // 中和只保证载荷不会顶掉外层标签（AgentTagProtocol，两侧契约）
                     sendTextDelta(conversationId, String.format("<tool_output status=\"%s\">%s</tool_output>",
                             nativeToolStatus,
                             AgentTagProtocol.escape(truncate(result, toolOutputDisplayLimit(req.name())))));
 
-                    // Log for history persistence (include status attribute)
-                    executionLog.append(String.format("<process name=\"%s\"><tool_code>%s(%s)</tool_code><tool_output status=\"%s\">%s</tool_output></process>\n",
-                        displayName.replace("\"", "'"), req.name(), AgentTagProtocol.escape(req.arguments()),
-                        nativeToolStatus, AgentTagProtocol.escape(result)));
+                    messages.add(dev.langchain4j.data.message.ToolExecutionResultMessage.from(req, result));
                 }
 
                 // 防走神注入（Claude Code system-reminder 模式）：每次工具执行后带上任务清单状态，
@@ -1068,13 +1091,16 @@ public class AgentOrchestrator {
             clearCancelledState(conversationId);
             activeStreamContent.remove(conversationId); // CLEANUP
           } catch (Exception e) {
-            // 确保异常时也能正确结束 bubble，避免前端一直显示加载状态
+            // 确保异常时也能正确结束 bubble，避免前端一直显示加载状态。
+            //
+            // 走 finishWithError 而不是只发一个 SSE：原来这里不落库，于是异常终止的那一轮
+            // 在历史里一个字都没有——用户当时看到过工具在跑、看到过半截回复，刷新后全没了
+            // （「历史对话吃消息」）。对照 handleStreamErrorTerminal 与 handleCancellation：
+            // 两者都存了部分内容。executionLog 一并带上，崩溃轮的过程卡才能回放。
             log.error("Error in onComplete callback for conversation: " + conversationId, e);
-            agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
-            sseEmitterService.send(conversationId, "error", "Callback Error: " + e.getMessage());
-            sseEmitterService.close(conversationId);
-            clearCancelledState(conversationId);
-            activeStreamContent.remove(conversationId); // CLEANUP
+            finishWithError(conversationId, projectId, userId,
+                    LlmErrorClassifier.INTERNAL_ERROR_MARKER + ": Callback Error: " + e.getMessage(),
+                    executionLog);
           } finally {
             // 流式回调运行在可复用线程池线程上，用完清理 ThreadLocal，防止会话串号
             editorBridgeService.clearCurrentConversationId();
@@ -1246,7 +1272,24 @@ public class AgentOrchestrator {
         String message = kind == null
                 ? err.getMessage()
                 : LlmErrorClassifier.taggedErrorMessage(kind, err.getMessage());
-        sseEmitterService.send(conversationId, "error", "Stream Error: " + message);
+        finishWithError(conversationId, projectId, userId, "Stream Error: " + message, null);
+    }
+
+    /**
+     * 错误终态的统一收尾：发 error 事件、保存已生成内容、关流、复位状态。
+     *
+     * <p>{@link #handleStreamErrorTerminal}（流式传输出错）与 onComplete 的 catch
+     * （回调内部一致性错误）共用这一条路径——两处都必须落库，否则那一轮在历史里
+     * 一个字都没有。
+     *
+     * @param ssePayload 直接下发给前端的 error 载荷，标记（AI_REGION_BLOCKED /
+     *                   AI_INTERNAL_ERROR 等）由调用方拼好
+     * @param executionLog 本轮已产生的工具过程日志，可为 null；非空时一并落库，
+     *                     崩溃轮的过程卡才能在历史里回放
+     */
+    private void finishWithError(String conversationId, String projectId, Long userId,
+                                 String ssePayload, StringBuilder executionLog) {
+        sseEmitterService.send(conversationId, "error", ssePayload);
         agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
         boolean wasStreamingOnError = editorBridgeService.isStreamingMode(conversationId);
         editorBridgeService.setStreamingMode(conversationId, false);
@@ -1257,9 +1300,11 @@ public class AgentOrchestrator {
         // 保存已生成的部分内容，避免"当时看到了回复、历史里却没有"
         StringBuilder sb = activeStreamContent.get(conversationId);
         String partialContent = sb != null ? sb.toString() : "";
-        if (!partialContent.isEmpty()) {
+        String logText = executionLog != null ? executionLog.toString() : "";
+        if (!partialContent.isEmpty() || !logText.isEmpty()) {
             saveAssistantMessage(conversationId, projectId, userId,
-                    partialContent + LangText.of("\n\n[生成出错，已中断]", "\n\n[Generation error, interrupted]"));
+                    logText + partialContent
+                            + LangText.of("\n\n[生成出错，已中断]", "\n\n[Generation error, interrupted]"));
         }
         sseEmitterService.close(conversationId);
         clearCancelledState(conversationId);

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -265,7 +265,11 @@ public class ContextAssemblerService {
                     }
                     systemText.append("<file id=\"").append(item.getId())
                               .append("\" name=\"").append(attrSafe(item.getName())).append("\"><![CDATA[\n");
-                    systemText.append(content != null ? fenceSafe(content) : "[Empty or unreadable file]");
+                    // 判空白而不只判 null：抽不出正文时（扫描件、抽取失败）拿到的是空串，
+                    // 原来会往上下文里注入一段空 CDATA——模型看到「文件在这儿但里面什么都没有」，
+                    // 于是转头自己再调一次读取工具。可见地写明读不出来才有下一步。
+                    systemText.append(content != null && !content.isBlank()
+                            ? fenceSafe(content) : "[Empty or unreadable file]");
                     systemText.append("\n]]></file>\n");
                     totalFileCount++;
                 }
@@ -386,7 +390,9 @@ public class ContextAssemblerService {
             }
             } // end zh active-document guidance
 
-            if (content != null && !content.isEmpty()) {
+            // 同 <file> 段：空白正文等于没读到，走下面的 readHint 分支明说「内容暂不可读」，
+            // 别注入一段空 CDATA 让模型以为文档本身是空的
+            if (content != null && !content.isBlank()) {
                 // Truncate if too long
                 int maxCharsPerFile = contextProperties.getFiles().getMaxCharsPerFile();
                 if (content.length() > maxCharsPerFile) {

--- a/backend/src/main/java/com/checkba/service/ai/LlmErrorClassifier.java
+++ b/backend/src/main/java/com/checkba/service/ai/LlmErrorClassifier.java
@@ -31,6 +31,16 @@ public final class LlmErrorClassifier {
     /** 上下文超窗的稳定标记（契约同上；只在强制压缩重试也失败的终态才会出现在 error 载荷里）。 */
     public static final String CONTEXT_OVERFLOW_MARKER = "AI_CONTEXT_OVERFLOW";
 
+    /**
+     * 编排器内部一致性错误的稳定标记（契约同上）。
+     *
+     * <p>与上面三个不同，它不是 LLM 调用的错误分类——{@link #classify} 永远不会产出它，
+     * 由 AgentOrchestrator 在 onComplete 回调的 catch 里直接拼上。存在的理由是那条路径
+     * 原来把裸 Java 异常文本发给前端（「Callback Error: text cannot be null or blank」），
+     * 用户既看不懂也无从处理。
+     */
+    public static final String INTERNAL_ERROR_MARKER = "AI_INTERNAL_ERROR";
+
     private LlmErrorClassifier() {
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
@@ -372,7 +372,11 @@ public class SubAgentService {
         }
         toolsUsed.add(resolved);
         ToolRegistry.ToolResult result = toolRegistry.execute(rawName, argsJson, subCtx);
-        return result.output();
+        String output = result.output();
+        // 空输出归一（同主编排器）：ToolExecutionResultMessage.from 的 ensureNotBlank 会对空白
+        // 抛异常，一个返回空串的工具就能把整个子任务打成 LLM call failed。两条协议分支共用这里。
+        return output == null || output.isBlank()
+                ? com.checkba.service.ai.AgentOrchestrator.BLANK_TOOL_OUTPUT : output;
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -144,13 +144,25 @@ public class FileTools implements AgentToolComponent {
             if (Files.isDirectory(path)) return "Error: Path is a directory.";
             if (Files.size(path) > 10 * 1024 * 1024) return "Error: File too large (>10MB).";
             
-            // Use unified extractor
+            // Use unified extractor：图片/PDF 走 OCR，纯文本直读，其余（docx/xlsx/pptx 等
+            // Office 格式）走 Tika——第三条以前不存在，Office 文件恒返回空串，
+            // 而空串会被 ToolExecutionResultMessage 的 ensureNotBlank 抛出来掀翻整轮
             File file = path.toFile();
+            String content;
             if (fileContentExtractorService.isOcrSupported(file.getName())) {
-               return fileContentExtractorService.extractTextWithOcr(file);
+                content = fileContentExtractorService.extractTextWithOcr(file);
+            } else if (fileContentExtractorService.isTextFile(file.getName())) {
+                content = fileContentExtractorService.extractText(file);
             } else {
-               return fileContentExtractorService.extractText(file);
+                try (java.io.InputStream is = Files.newInputStream(path)) {
+                    content = documentTextService.parse(is);
+                }
             }
+            if (!StringUtils.hasText(content)) {
+                return "Warning: no text extracted from '" + file.getName() + "' — the file may be a scanned "
+                        + "image or empty; try extract_file_text with its database file ID.";
+            }
+            return content;
         } catch (Exception e) {
             return "Error reading file: " + e.getMessage();
         }

--- a/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
@@ -33,9 +33,29 @@ public class LegalTools implements AgentToolComponent {
     private final com.checkba.service.ai.context.FileContentExtractorService fileContentExtractorService;
     private final com.checkba.service.platform.ExternalProviderResolver externalProviderResolver;
     private final com.checkba.service.platform.PlatformGatewayClient platformGatewayClient;
+    private final com.checkba.service.DocumentTextService documentTextService;
 
     // --- File Operations ---
 
+    /**
+     * 读取项目文件正文。
+     *
+     * <p>三条抽取路径，缺一条就有一整类文件读不出来：
+     * <ul>
+     *   <li>图片 / PDF → OCR（{@code ai.context.ocr-extensions}）；</li>
+     *   <li>纯文本类（java/js/md/txt/csv…）→ 直接按字符集解码；</li>
+     *   <li>其余（<b>docx/xlsx/pptx/doc 等 Office 格式</b>）→ Tika（{@link com.checkba.service.DocumentTextService}，
+     *       与 extract_file_text 同一套）。</li>
+     * </ul>
+     *
+     * <p>第三条曾经不存在：docx 两个白名单都不在，恒定落进
+     * {@code FileContentExtractorService.extractText} 的 else 分支返回空串——
+     * 而空串会被 {@code ToolExecutionResultMessage.from} 的 ensureNotBlank 抛出来掀翻整轮
+     * （用户看到「Callback Error: text cannot be null or blank」），
+     * 同时 Active Document 注入的正文也恒为空，模型转头自己再调一次本工具。
+     *
+     * <p>抽不出正文时<b>绝不返回空白</b>，而是给一句可行动的说明（口径抄 extract_file_text）。
+     */
     @ToolMeta(displayName = "读取文档", category = "file")
     @Tool("Read document content. Use this to read files from the project. Provide fileId.")
     public String read_document(String fileId) {
@@ -50,22 +70,30 @@ public class LegalTools implements AgentToolComponent {
 
             byte[] bytes = projectFileService.getFileBytes(fId);
             if (bytes == null || bytes.length == 0) return "File is empty.";
-            
-            // Create temp file for extractor (needed for Tika/PDFBox/OCR)
-            String ext = file.getFileType() != null ? "." + file.getFileType() : ".tmp";
-            tempPath = java.nio.file.Files.createTempFile("checkba_legal_" + fId + "_", ext);
-            java.nio.file.Files.write(tempPath, bytes);
-            java.io.File tempFile = tempPath.toFile();
-            
+
+            String name = file.getName();
+            boolean ocr = fileContentExtractorService.isOcrSupported(name);
             String result;
-            if (fileContentExtractorService.isOcrSupported(file.getName())) {
-               result = fileContentExtractorService.extractTextWithOcr(tempFile);
+            if (ocr || fileContentExtractorService.isTextFile(name)) {
+                // Create temp file for extractor (needed for OCR / charset decoding)
+                String ext = file.getFileType() != null ? "." + file.getFileType() : ".tmp";
+                tempPath = java.nio.file.Files.createTempFile("checkba_legal_" + fId + "_", ext);
+                java.nio.file.Files.write(tempPath, bytes);
+                java.io.File tempFile = tempPath.toFile();
+                result = ocr
+                        ? fileContentExtractorService.extractTextWithOcr(tempFile)
+                        : fileContentExtractorService.extractText(tempFile);
             } else {
-               result = fileContentExtractorService.extractText(tempFile);
+                // Office 格式（docx/xlsx/pptx/doc…）：Tika，与 extract_file_text 同一条路
+                result = documentTextService.extractText(file);
             }
-            
+
+            if (!StringUtils.hasText(result)) {
+                return "Warning: no text extracted from '" + name + "' — the file may be a scanned image "
+                        + "or empty; try extract_file_text, or read_file with OCR for image PDFs.";
+            }
             return result;
-            
+
         } catch (Exception e) {
             log.error("Failed to read document {}", fileId, e);
             return "Error reading document: " + e.getMessage();

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorBlankToolOutputTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorBlankToolOutputTest.java
@@ -1,0 +1,233 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.config.AiFailoverProperties;
+import com.checkba.controller.ai.AiAgentController;
+import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.RunLoopCompactor;
+import com.checkba.service.ai.memory.MemoryPipelineService;
+import com.checkba.service.ai.skill.SkillRouter;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 工具空输出与 onComplete 异常路径的两条不变式。
+ *
+ * <p>病灶一：工具返回空串时 {@code ToolExecutionResultMessage.from} 的
+ * {@code ensureNotBlank(text, "text")} 直接抛异常，整轮对话被掀翻——用户看到的是
+ * 「Callback Error: text cannot be null or blank」。任何工具返回空都不允许掀翻整轮。
+ *
+ * <p>病灶二：onComplete 的 catch 只发 SSE、不落库，于是异常终止的那一轮在历史里
+ * 一个字都没有（工具跑过的过程也一起没了）——「历史对话吃消息」。
+ * 对照 handleStreamErrorTerminal 与 handleCancellation：两者都存了部分内容。
+ */
+class AgentOrchestratorBlankToolOutputTest {
+
+    private static final String MODEL = "qwen/qwen3.7-flash";
+
+    private ChatModelFactory chatModelFactory;
+    private SseEmitterService sse;
+    private AgentRunStateService runState;
+    private ProjectAiMessageService messageService;
+    private ToolRegistry toolRegistry;
+    private TodoListService todoListService;
+    private List<String> sseEvents;
+    private List<String> sseData;
+    private AgentOrchestrator orchestrator;
+
+    /** 按脚本逐轮吐内容的模型，同时留下最后一轮收到的完整消息栈 */
+    private static final class ScriptModel implements StreamingChatLanguageModel {
+        private final List<AiMessage> script;
+        final AtomicInteger calls = new AtomicInteger();
+        volatile List<ChatMessage> lastMessages = List.of();
+
+        ScriptModel(List<AiMessage> script) {
+            this.script = script;
+        }
+
+        @Override
+        public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+            lastMessages = new ArrayList<>(messages);
+            int idx = calls.getAndIncrement();
+            AiMessage msg = script.get(Math.min(idx, script.size() - 1));
+            if (msg.text() != null && !msg.text().isEmpty()) {
+                handler.onNext(msg.text());
+            }
+            handler.onComplete(Response.from(msg));
+        }
+
+        @Override
+        public void generate(List<ChatMessage> messages, List<ToolSpecification> tools,
+                             StreamingResponseHandler<AiMessage> handler) {
+            generate(messages, handler);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        chatModelFactory = mock(ChatModelFactory.class);
+        sseEvents = new CopyOnWriteArrayList<>();
+        sseData = new CopyOnWriteArrayList<>();
+        sse = mock(SseEmitterService.class);
+        doAnswer(inv -> {
+            sseEvents.add(inv.getArgument(1));
+            sseData.add(String.valueOf((Object) inv.getArgument(2)));
+            return null;
+        }).when(sse).send(any(), any(), any());
+
+        messageService = mock(ProjectAiMessageService.class);
+        when(messageService.listByConversationId(any()))
+                .thenReturn(List.of(mock(ProjectAiMessage.class), mock(ProjectAiMessage.class)));
+        when(messageService.upsertAssistantMessage(any(), any(), any(), any(), any())).thenReturn(1L);
+
+        ContextAssemblerService assembler = mock(ContextAssemblerService.class);
+        when(assembler.assemble(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenAnswer(inv -> new ArrayList<ChatMessage>(List.of(
+                        SystemMessage.from("system"), UserMessage.from("读一下这份合同"))));
+
+        toolRegistry = mock(ToolRegistry.class);
+        when(toolRegistry.getAllSpecifications(any())).thenReturn(List.of());
+        when(toolRegistry.resolve(anyString())).thenReturn(java.util.Optional.empty());
+
+        SkillRouter skillRouter = mock(SkillRouter.class);
+        when(skillRouter.visibleTools(any(), any())).thenAnswer(inv -> inv.getArgument(1));
+        when(skillRouter.activeSkill(any())).thenReturn(java.util.Optional.empty());
+        XmlToolCallParser parser = mock(XmlToolCallParser.class);
+        when(parser.containsToolCall(any())).thenReturn(false);
+
+        todoListService = mock(TodoListService.class);
+        AiContextProperties contextProperties = new AiContextProperties();
+        runState = new AgentRunStateService(
+                mock(com.checkba.repository.AgentRunRecordRepository.class),
+                mock(com.checkba.service.telemetry.TelemetryTurnTracker.class));
+        orchestrator = new AgentOrchestrator(
+                chatModelFactory, messageService, sse, mock(TokenUsageService.class), assembler,
+                toolRegistry, skillRouter, parser, mock(MemoryPipelineService.class),
+                mock(ProjectFileService.class), mock(EditorBridgeService.class),
+                mock(ConversationFileChangeService.class), todoListService,
+                mock(DocumentCheckpointService.class), runState,
+                mock(com.checkba.version.WorkSessionService.class), new AiFailoverProperties(),
+                new RunLoopCompactor(contextProperties, new ContextCompressor(null, null, contextProperties)),
+                mock(com.checkba.service.telemetry.TelemetryService.class),
+                mock(com.checkba.service.telemetry.TelemetryTurnTracker.class),
+                mock(com.checkba.service.telemetry.MatterClassifierService.class));
+    }
+
+    private ScriptModel run(String conversationId, AiMessage... script) {
+        ScriptModel model = new ScriptModel(List.of(script));
+        when(chatModelFactory.getStreamingChatModel(MODEL)).thenReturn(model);
+        AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
+        request.setProjectId(1L);
+        request.setConversationId(conversationId);
+        request.setMessage("读一下这份合同");
+        request.setModel(MODEL);
+        orchestrator.handleUserMessage(request, 7L);
+        return model;
+    }
+
+    private static AiMessage readDocumentCall() {
+        return AiMessage.from(List.of(ToolExecutionRequest.builder()
+                .id("t1").name("read_document").arguments("{\"fileId\":\"12\"}").build()));
+    }
+
+    private String bubbleEndData() {
+        for (int i = 0; i < sseEvents.size(); i++) {
+            if ("bubble_end".equals(sseEvents.get(i))) return sseData.get(i);
+        }
+        return null;
+    }
+
+    private String eventData(String event) {
+        for (int i = 0; i < sseEvents.size(); i++) {
+            if (event.equals(sseEvents.get(i))) return sseData.get(i);
+        }
+        return null;
+    }
+
+    @Test
+    @DisplayName("工具返回空串：不掀翻整轮，按 FAILURE 回喂模型，对话照常收尾")
+    void blankToolOutputDoesNotBreakTheTurn() {
+        when(toolRegistry.execute(any(), any(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("", null, true));
+
+        ScriptModel model = run("conv-blank", readDocumentCall(),
+                AiMessage.from("<final>这份文档读不出正文。</final>"));
+
+        assertFalse(sseEvents.contains("error"),
+                "空输出不许把整轮打掉（langchain4j 的 ensureNotBlank）：" + sseEvents);
+        assertEquals(2, model.calls.get(), "空结果也要回喂模型继续下一轮");
+        assertEquals("{\"status\":\"finished\"}", bubbleEndData());
+        assertEquals(AgentRunStateService.RunStatus.FINISHED, runState.get("conv-blank").status());
+
+        ToolExecutionResultMessage toolResult = model.lastMessages.stream()
+                .filter(ToolExecutionResultMessage.class::isInstance)
+                .map(ToolExecutionResultMessage.class::cast)
+                .findFirst().orElse(null);
+        assertNotNull(toolResult, "工具结果必须进上下文，否则 tool_calls 无配对结果会让通道 400");
+        assertFalse(toolResult.text().isBlank(), "空白正文正是 ensureNotBlank 抛异常的原因");
+        assertTrue(toolResult.text().contains("no output"),
+                "要给模型一句能据以行动的说明，实际是：" + toolResult.text());
+
+        assertTrue(sseData.stream().anyMatch(d -> d != null && d.contains("FAILURE")),
+                "空输出按失败处理，才能进连续失败纠正回路：" + sseData);
+    }
+
+    @Test
+    @DisplayName("onComplete 异常：执行日志与错误摘要必须落库，历史里看得见「执行中断」")
+    void onCompleteFailurePersistsExecutionLog() {
+        when(toolRegistry.execute(any(), any(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("合同正文…", null, true));
+        // 工具跑完之后、增量保存之前炸掉：模拟 onComplete 回调里的内部一致性错误
+        when(todoListService.reminder(any())).thenThrow(new IllegalStateException("boom"));
+
+        run("conv-crash", readDocumentCall(), AiMessage.from("<final>不会走到</final>"));
+
+        assertEquals(AgentRunStateService.RunStatus.ERROR, runState.get("conv-crash").status());
+
+        ArgumentCaptor<String> saved = ArgumentCaptor.forClass(String.class);
+        verify(messageService, atLeastOnce())
+                .upsertAssistantMessage(any(), any(), any(), any(), saved.capture());
+        String content = saved.getAllValues().get(saved.getAllValues().size() - 1);
+        assertTrue(content.contains("<tool_output"),
+                "崩溃轮的执行过程也要能回放，实际落库的是：" + content);
+        assertTrue(content.contains("[生成出错，已中断]"),
+                "历史里要看得出这一轮是断掉的，实际落库的是：" + content);
+
+        String err = eventData("error");
+        assertNotNull(err, "仍要给前端错误事件：" + sseEvents);
+        assertTrue(err.contains(LlmErrorClassifier.INTERNAL_ERROR_MARKER),
+                "内部错误要带机器可读标记，前端才能换成人话，实际是：" + err);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/tools/ReadDocumentOfficeFormatTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/ReadDocumentOfficeFormatTest.java
@@ -1,0 +1,107 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.DocumentTextService;
+import com.checkba.service.OcrService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.context.FileContentExtractorService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * read_document 对 Office 格式必须真的读得出正文。
+ *
+ * <p>病灶：docx 既不在 {@code FileContentExtractorService.ALLOWED_TEXT_EXTENSIONS}
+ * （只有 java/js/md/txt/csv/json 这类），也不在 {@code ai.context.ocr-extensions}
+ * （只有图片 + pdf），于是恒定落进 extractText 的 else 分支返回空串。空串再往下
+ * 就是 {@code ToolExecutionResultMessage.from} 的 ensureNotBlank 把整轮打掉，
+ * 而 Active Document 注入的正文同样恒为空——模型转头自己再调一次 read_document。
+ */
+class ReadDocumentOfficeFormatTest {
+
+    @AfterEach
+    void clearContext() {
+        ProjectContextHolder.clear();
+    }
+
+    private static Path writeDocx(Path dir, String fileName, String... paragraphs) throws IOException {
+        Path path = dir.resolve(fileName);
+        try (XWPFDocument doc = new XWPFDocument(); FileOutputStream out = new FileOutputStream(path.toFile())) {
+            for (String p : paragraphs) {
+                doc.createParagraph().createRun().setText(p);
+            }
+            doc.write(out);
+        }
+        return path;
+    }
+
+    private static ProjectFile docxRecord(Path path) {
+        ProjectFile f = new ProjectFile();
+        f.setId(12L);
+        f.setProjectId(7L);
+        f.setName(path.getFileName().toString());
+        f.setFileType("docx");
+        f.setFilePath(path.toString());
+        f.setIsFolder(false);
+        return f;
+    }
+
+    /** 真的 Tika + 真的 PDFBox，只把「文件从哪来」换成本地临时文件。 */
+    private static LegalTools toolsFor(ProjectFile record, Path onDisk) throws Exception {
+        ProjectFileService fileService = Mockito.mock(ProjectFileService.class);
+        Mockito.when(fileService.getFile(12L)).thenReturn(record);
+        Mockito.when(fileService.getFileBytes(12L)).thenReturn(Files.readAllBytes(onDisk));
+
+        StorageService storage = Mockito.mock(StorageService.class);
+        Mockito.when(storage.load(record.getFilePath())).thenReturn(new FileSystemResource(onDisk));
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        Mockito.when(factory.getStorageService()).thenReturn(storage);
+
+        FileContentExtractorService extractor = new FileContentExtractorService(
+                Mockito.mock(OcrService.class), new AiContextProperties());
+        return new LegalTools(fileService, null, extractor, null, null, new DocumentTextService(factory));
+    }
+
+    @Test
+    @DisplayName("docx 返回真实正文，不再是空串")
+    void readsDocxBody(@TempDir Path dir) throws Exception {
+        Path docx = writeDocx(dir, "股权转让协议.docx",
+                "第一条 转让标的", "甲方将其持有的目标公司 40% 股权转让给乙方。");
+        ProjectContextHolder.setProjectId("7");
+
+        String out = toolsFor(docxRecord(docx), docx).read_document("12");
+
+        assertFalse(out.isBlank(), "docx 恒返回空串正是整条崩溃链的起点");
+        assertTrue(out.contains("股权转让"), "要拿到真正的正文，实际是：" + out);
+        assertTrue(out.contains("40%"), "正文不能只剩标题，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("抽不出正文时给一句可行动的说明，绝不返回空白")
+    void neverReturnsBlankForEmptyDocument(@TempDir Path dir) throws Exception {
+        Path docx = writeDocx(dir, "空白.docx");
+        ProjectContextHolder.setProjectId("7");
+
+        String out = toolsFor(docxRecord(docx), docx).read_document("12");
+
+        assertFalse(out.isBlank(), "空白输出会被 langchain4j 的 ensureNotBlank 打掉整轮");
+        assertTrue(out.contains("extract_file_text"), "要给模型下一步，实际是：" + out);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/platform/ExternalServiceDualTierRoutingTest.java
+++ b/backend/src/test/java/com/checkba/service/platform/ExternalServiceDualTierRoutingTest.java
@@ -249,7 +249,7 @@ class ExternalServiceDualTierRoutingTest {
         private LegalTools tools(ExternalServiceProvider tier, PlatformGatewayClient gateway,
                                  McpClientService mcp) {
             return new LegalTools(null, mcp, null,
-                    resolverWith(ExternalServiceProvider.PKULAW, tier), gateway);
+                    resolverWith(ExternalServiceProvider.PKULAW, tier), gateway, null);
         }
 
         @Test

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -898,6 +898,12 @@ export function useAgentStream() {
                     // 走到这里说明后端强制压缩后仍装不下（或压不动）
                     currentAssistantBubble.value.content +=
                         '\n\n' + t('agentStream.contextOverflowNotice') + '\n'
+                } else if (errMsg.includes('AI_INTERNAL_ERROR')) {
+                    // 编排器内部一致性错误（后端 LlmErrorClassifier.INTERNAL_ERROR_MARKER）：
+                    // 载荷后面拼着裸 Java 异常文本（如 "text cannot be null or blank"），
+                    // 对用户毫无意义。已生成的部分内容与工具过程后端都落了库，刷新看得到。
+                    currentAssistantBubble.value.content +=
+                        '\n\n' + t('agentStream.internalErrorNotice') + '\n'
                 } else {
                     currentAssistantBubble.value.content += '\n\n' + t('agentStream.executionInterrupted', { message: errMsg }) + '\n'
                 }

--- a/frontend/src/locales/en-US/agentStream.js
+++ b/frontend/src/locales/en-US/agentStream.js
@@ -19,6 +19,7 @@ export default {
   regionBlockedNotice: '> **This model is not available in your current network region**: models hosted overseas are blocked by their providers when accessed from a Mainland China network. Switch to the AI WorkDeck Cloud channel in Settings, or choose a model marked as available in both regions and resend.',
   quotaExhaustedNotice: '> **AI service credits exhausted**: the balance or quota for the current channel has been used up. With your own key, top up with your provider (such as OpenRouter); with the AI WorkDeck Cloud channel, check your credit allocation on the account page.',
   contextOverflowNotice: '> **The conversation exceeds the model context window**: automatic compression was attempted but it still does not fit. Start a new conversation, or attach fewer or shorter files.',
+  internalErrorNotice: '> **This run was interrupted by an internal error**: the work already done and the tool execution log have been saved and remain visible in the history. Send another message to continue; if this keeps happening, use the feedback button in the bottom-right corner to send us this conversation.',
   // Subtask progress rows
   subtaskStarted: 'Subtask started',
   subtaskEnded: 'Subtask finished',

--- a/frontend/src/locales/zh-CN/agentStream.js
+++ b/frontend/src/locales/zh-CN/agentStream.js
@@ -18,6 +18,7 @@ export default {
   regionBlockedNotice: '> **该模型在当前网络环境不可用**：境外模型在境内网络会被服务商按地域拒绝。可在设置中改用 AI WorkDeck 云端通道，或换成标注「境内外均可用」的模型后重新发送。',
   quotaExhaustedNotice: '> **AI 服务额度不足**：当前通道的余额或配额已用完。使用自备 Key 时请到服务商（如 OpenRouter）充值；使用 AI WorkDeck 云端通道时请到官网账户页检查额度分配。',
   contextOverflowNotice: '> **对话上下文超出模型窗口**：已尝试自动压缩仍超限。建议开启新对话继续，或减少一次携带的文件数量与长度。',
+  internalErrorNotice: '> **本轮执行被内部错误中断**：已完成的操作与工具执行过程都已保存，可在历史里查看。请再发一次消息继续；如果反复出现，请通过右下角反馈把这段对话发给我们。',
   // 子任务进度行
   subtaskStarted: '子任务开始',
   subtaskEnded: '子任务结束',


### PR DESCRIPTION
修两个用户可见的病：AI 修订文件报「Callback Error: text cannot be null or blank」（dev-board #28），
历史对话重新打开丢消息（dev-board #27）。两者同源——异常终止的那一轮既掀翻了对话，又什么都没落库。

## Bug 1：AI 修订文件报 Callback Error

### 根因（确定性崩溃链）

1. `LegalTools.read_document` 对 docx 恒返回空串。docx 既不在
   `FileContentExtractorService.ALLOWED_TEXT_EXTENSIONS`（只有 java/js/md/txt/csv 这类），
   也不在 `ai.context.ocr-extensions`（只有图片 + pdf），于是落进 `extractText` 的 else 分支
   直接 `return ""`。`FileTools.read_file` 同坑。
2. `ToolRegistry` 把结果归一成 `""` 且标 `success=true`。
3. `AgentOrchestrator` 把空串裸传给 `ToolExecutionResultMessage.from(req, result)`，
   langchain4j 的 `ensureNotBlank(text, "text")` 抛异常，掀翻整轮——就是用户看到的那句报错。
   `SubAgentService.executeScoped` 是同款裸传。
4. `ContextAssemblerService` 的守卫只判 null 不判空串，于是 Active Document 注入的正文恒为空。
   模型看到「文件在这儿但里面什么都没有」，转头自己调 `read_document` ——这大概率就是它频繁
   撞上那条崩溃链的诱因。

### 修法（四层，缺一层都是治标）

| 层 | 改动 |
|---|---|
| 抽取 | `read_document` / `read_file` 对 Office 格式改走 `DocumentTextService`（Tika/PDFBox，`extract_file_text` 在用的同一套）。PDF 与图片仍走 OCR、纯文本仍直读，两条既有路径行为一字未变 |
| 工具契约 | 两个工具抄 `extract_file_text` 的空结果守卫，抽不出正文时返回一句可行动的英文说明，不再返回空串 |
| 编排器兜底 | 入栈前把空白归一成 `AgentOrchestrator.BLANK_TOOL_OUTPUT` 并**按 FAILURE 处理**（进连续失败纠正回路）。`SubAgentService` 同步。任何工具返回空都不再允许掀翻整轮 |
| 上下文 | `ContextAssemblerService` 注入文件正文的两处守卫（`<file>` 段与 `<active_document>` 段）改成判空白，读不出来时可见地写明 |

## Bug 2：历史对话吃消息

### 根因

`AgentOrchestrator` onComplete 的 catch 只 `mark(ERROR)` + 发一个 SSE，**没有落库**。
对照同一个类里的另外两条终止路径——`handleStreamErrorTerminal` 存了部分内容 +
「[生成出错，已中断]」，`handleCancellation` 存了部分内容 + 「[已中断]」——只有这一条没存。
用户当时看到过工具在跑、看到过半截回复，刷新之后整轮消失。

叠加一处：`executionLog.append` 排在 `ToolExecutionResultMessage.from` 之后，入栈一抛异常，
排在它后面的 append 就不执行了，崩溃轮的工具过程整段丢失。

### 修法

- onComplete 的 catch 改为与 `handleStreamErrorTerminal` 共用新提取的 `finishWithError(...)`，
  把 `executionLog` + 已流出的部分内容 + 「[生成出错，已中断]」一并写进 ASSISTANT 消息。
  `doc_stream_end` / `close` / 清 ThreadLocal 沿用既有收尾（onComplete 开头已关流式模式，
  不会重复发 `doc_stream_end`），不重复也不遗漏。
- `executionLog.append` 挪到入栈之前，崩溃轮的过程卡也能回放。

## 错误文案透传

onComplete 的 catch 原来把裸 Java 异常发给前端（「Callback Error: text cannot be null or blank」），
用户既看不懂也无从处理。沿用既有标记模式新增 `LlmErrorClassifier.INTERNAL_ERROR_MARKER`
（`AI_INTERNAL_ERROR`）——它**不由 `classify()` 产出、不进 `Kind` 枚举**，由编排器直接拼；
前端 `useAgentStream` 的 error 分支 includes 命中后映射成 `agentStream.internalErrorNotice`，
zh-CN / en-US 词典成对（`npm run check:locales` 通过）。`ChatInterface.vue` 未改动。

## 测试证据

TDD，两组用例都先确认转红再修绿：

- 新增 `AgentOrchestratorBlankToolOutputTest`（脚本化流式模型，参考 `AgentOrchestratorQuestionStopTest`）
  - 工具返回空串：不发 error、模型被回喂后正常跑第二轮、`bubble_end=finished`、状态 FINISHED；
    进上下文的 `ToolExecutionResultMessage` 正文非空白且带可行动说明；SSE 里工具状态是 FAILURE
  - onComplete 抛异常：状态 ERROR，落库内容同时含 `<tool_output` 与「[生成出错，已中断]」，
    error 载荷带 `AI_INTERNAL_ERROR`
- 新增 `ReadDocumentOfficeFormatTest`（POI 现建真实 docx fixture + 真 Tika + 真 PDFBox，
  只把「文件从哪来」换成本地临时文件）
  - docx 返回真实正文（标题与正文均命中），不再是空串
  - 空白 docx 返回可行动说明，绝不返回空白
- **红/绿对照**：把四处修复逐一还原后重跑，4 条用例全部转红（不是空断言）；恢复后全绿
- 全量回归 `mvn clean test`：**Tests run: 1981, Failures: 0, Errors: 0, Skipped: 11**（BUILD SUCCESS；
  skip 全是既有的 env 门控用例，本 PR 未新增 @Disabled）
- 前端 `npm run check:locales`（20 个命名空间对拍通过）、`npm run check:emits`（87 个 .vue 通过）

## 文档

按 CLAUDE.md 维护规则，`.claude/agents/ai-chat.md` 的「已知地雷」补两条（工具空输出会炸
`ToolExecutionResultMessage` 的历史与归一口径、轮次异常终止必须落库 + append 顺序 + 新标记契约），
「验证」补一行新测试命令。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
