### PR TITLE
feat(mobile-sync): 手机端项目目录镜像 + 现场影像云中转 + 桥接认领手机号（dev-board#30）

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -1,0 +1,59 @@
+---
+name: mobile-sync
+description: 手机端同步领域。任务涉及手机端项目目录镜像、现场影像云中转（/api/mobile/*）、桌面侧 MobileRelayClientService、桥接认领手机号、aiworkdeck_mobile 仓的 iOS/小程序客户端时，先读本文档再动代码。
+---
+
+# 手机端同步（项目目录镜像 + 现场影像云中转）
+
+手机端（独立仓 `1-3 aiworkdeck_mobile`：iOS Swift + 微信小程序）拍现场影像，归档到
+桌面端项目的「现场影像/YYYY-MM-DD/」。**桌面端是项目的唯一权威源**，云端只做两件事：
+目录镜像（手机「选择项目」的数据源）与影像中转区（ACK 即删 + 7 天 TTL 兜底）。
+权威 spec：`aiworkdeck_mobile/docs/specs/2026-08-20-project-sync-relay.md`（根因复盘见
+dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
+
+## 关键文件
+
+- `service/mobile/MobileRelayStoreService.java` — 云端（server 侧）：目录按 (userId,
+  deviceId) 整批替换、影像入库（幂等键 userId+clientMediaId）、ACK（置 deliveredAt +
+  **立即删 blob**、行保留供 status）、每日 TTL 清理。blob 落
+  `{storage.local.root-path}/mobile-relay/{userId}/{clientMediaId}`。
+- `controller/MobileRelayController.java` — `/api/mobile/*` 全组端点。鉴权一律
+  `X-Session-Id`：手机端带登录会话，桌面端带 awdt_ 设备令牌（`AuthController.
+  getUserIdFromSession` 两种都解析）。响应风格同 `/api/projects/my`（裸数组）。
+- `service/mobile/MobileRelayClientService.java` — 桌面侧（local-mode 专属）：
+  用本机 awdk_ 到云端换 awdt_（存 `~/.aiworkdeck/mobile-relay.json`，0600，含
+  deviceId 与账户指纹）、每 10 分钟推项目目录（清单哈希不变则跳过）、每 60 秒
+  轮询取件落盘 + ACK。
+- `model/entity/MobileProjectDir.java` / `MobileMediaInbox.java` + 对应 repository。
+- `service/UserService.claimPhoneFromWebsite` + `AwdkLoginService.login` 的认领调用 —
+  桥接时把官网账户的手机号认领到桥接用户名下（占用者转移、已有异号不覆盖、永不抛出），
+  使手机端 sms-login 的 `findOrCreateByPhone` 解析到同一账号。官网 `/api/account/me`
+  的 `phone` 字段随官网 PR#87 上线。
+
+## 核心契约
+
+- 目录条目 = `{deviceId, key, name}`；`key` 是**那台桌面机本地库的项目 id**，跨机同号
+  不同物，任何消费方必须连 deviceId 一起用。
+- 影像幂等键 = (userId, clientMediaId)，clientMediaId 只收 UUID 形态（路径穿越围栏）。
+- 删除由 ACK 触发，TTL 只是兜底——两个机制不能混。
+- 桌面落盘文件名 = 原名 + clientMediaId 前 8 位（`landedFileName`）：跨轮重试的幂等锚点，
+  「同名已在 → 只补 ACK」。
+- 客户端换账号守卫：state 里的账户指纹与 `AccountService.accountFingerprintOrNull()`
+  不一致即作废令牌重桥接（平台 AI key 在 PR#334 栽过同形状的坑）。
+
+## 已知地雷
+
+1. 目录整批替换在同一事务里 delete + insert 同键：`deleteByUserIdAndDeviceId` 后必须
+   `flush()`，否则 Hibernate 动作队列把 INSERT 排在 DELETE 前撞唯一约束。
+2. iOS v1（TestFlight 存量构建）用的还是 `/api/auth/sms-login` + `/api/projects/my` +
+   `/api/projects/{id}/files/file` 旧链路——认领上线后登录能落到正确账号，但项目列表
+   要等 iOS 切到 `/api/mobile/projects` 的新构建。
+3. 项目在桌面端被删后，指向它的中转件**留置不 ACK**（云端 TTL 兜底），不要改成 ACK——
+   那等于把用户拍的证据静默删掉。
+4. 云端/团队服务器绝不能跑客户端：双闸 = `security.local-mode` + 账户 Key 在场。
+
+## 验证
+
+- `mvn test -Dtest='MobileRelay*Test,AwdkLoginServiceTest'`（JDK 21）。
+- 云端冒烟：`curl https://addin.aiworkdeck.com/api/mobile/projects` 无凭据应 401。
+- iOS 侧改动跑 `aiworkdeck_mobile` 仓的构建 + TestFlight 通道（fastlane）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ AI WorkDeck（checkba_cloud）：面向法律行业的 AI 工作台。Java Sprin
 | 构建、发版、CI、测试体系、本地开发启动 | `.claude/agents/eng-infra.md` |
 | 版本记录、工作段、时间线、退回、Git 仓库 | `.claude/agents/version-control.md` |
 | 反馈浮窗、反馈落库、优化者（分诊/开 PR/发邮件）、后台反馈看板 | `.claude/agents/feedback-optimizer.md` |
+| 手机端同步：项目目录镜像、现场影像云中转（/api/mobile/*）、桥接认领手机号、iOS/小程序客户端 | `.claude/agents/mobile-sync.md` |
 
 这些文件同时是可派遣的 sub-agent 定义：需要并行探查或委托领域内工作时，可直接用对应 agent 类型派子任务。
 

--- a/backend/src/main/java/com/checkba/controller/MobileRelayController.java
+++ b/backend/src/main/java/com/checkba/controller/MobileRelayController.java
@@ -1,0 +1,186 @@
+package com.checkba.controller;
+
+import com.checkba.exception.UnauthorizedException;
+import com.checkba.model.entity.MobileMediaInbox;
+import com.checkba.service.LangText;
+import com.checkba.service.mobile.MobileRelayStoreService;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 手机端云中转（spec：aiworkdeck_mobile docs/specs/2026-08-20-project-sync-relay.md）。
+ *
+ * <p>鉴权一律 {@code X-Session-Id}：手机端带登录会话，桌面端带 awdt_ 设备令牌，
+ * {@link AuthController#getUserIdFromSession} 两种都解析。响应风格与
+ * {@code /api/projects/my} 一致（裸数组/裸对象，不带 code 信封）。
+ */
+@RestController
+@RequestMapping("/api/mobile")
+@Slf4j
+public class MobileRelayController {
+
+    private final MobileRelayStoreService store;
+
+    public MobileRelayController(MobileRelayStoreService store) {
+        this.store = store;
+    }
+
+    @Data
+    public static class DirectoryRequest {
+        private String deviceId;
+        private String deviceName;
+        private List<Entry> projects;
+
+        @Data
+        public static class Entry {
+            private String key;
+            private String name;
+        }
+    }
+
+    /** 桌面端：项目目录全量替换（按 userId + deviceId）。 */
+    @PutMapping("/projects")
+    public Map<String, Object> replaceDirectory(
+            @RequestBody DirectoryRequest request,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        List<MobileRelayStoreService.DirEntry> entries = new ArrayList<>();
+        if (request.getProjects() != null) {
+            for (DirectoryRequest.Entry e : request.getProjects()) {
+                if (e != null) entries.add(new MobileRelayStoreService.DirEntry(e.getKey(), e.getName()));
+            }
+        }
+        store.replaceDirectory(userId, request.getDeviceId(), request.getDeviceName(), entries);
+        return Map.of("code", 0, "count", entries.size());
+    }
+
+    /** 手机端：该账号全部设备的项目目录并集（裸数组）。 */
+    @GetMapping("/projects")
+    public List<Map<String, Object>> listDirectory(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        return store.listDirectory(requireUser(sessionId));
+    }
+
+    /** 手机端：上传一件现场影像到中转区（幂等键 clientMediaId）。 */
+    @PostMapping("/media")
+    public Map<String, Object> uploadMedia(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam("deviceId") String deviceId,
+            @RequestParam("projectKey") String projectKey,
+            @RequestParam("clientMediaId") String clientMediaId,
+            @RequestParam("fileName") String fileName,
+            @RequestParam("mediaType") String mediaType,
+            @RequestParam(value = "capturedAt", required = false) String capturedAt,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException(LangText.of("未找到文件", "No file provided"));
+        }
+        LocalDateTime captured = parseCapturedAt(capturedAt);
+        try (InputStream in = file.getInputStream()) {
+            MobileMediaInbox item = store.storeMedia(
+                    userId, deviceId, projectKey, clientMediaId, fileName, mediaType, captured, in);
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("code", 0);
+            out.put("id", item.getId());
+            out.put("clientMediaId", item.getClientMediaId());
+            out.put("delivered", item.getDeliveredAt() != null);
+            return out;
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("影像暂存失败", "Failed to store media"), e);
+        }
+    }
+
+    /** 手机端：查询影像投递状态（裸数组）。 */
+    @GetMapping("/media/status")
+    public List<Map<String, Object>> mediaStatus(
+            @RequestParam("clientMediaIds") String clientMediaIds,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        List<String> ids = new ArrayList<>();
+        for (String id : clientMediaIds.split(",")) {
+            if (!id.isBlank()) ids.add(id.trim());
+        }
+        return store.status(userId, ids);
+    }
+
+    /** 桌面端：本设备待取件（元数据，裸数组）。 */
+    @GetMapping("/inbox")
+    public List<Map<String, Object>> inbox(
+            @RequestParam("deviceId") String deviceId,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (MobileMediaInbox item : store.pendingForDevice(userId, deviceId)) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("id", item.getId());
+            m.put("projectKey", item.getProjectKey());
+            m.put("clientMediaId", item.getClientMediaId());
+            m.put("fileName", item.getFileName());
+            m.put("mediaType", item.getMediaType());
+            m.put("fileSize", item.getFileSize());
+            m.put("capturedAt", item.getCapturedAt() != null ? item.getCapturedAt().toString() : null);
+            m.put("createdAt", item.getCreatedAt().toString());
+            out.add(m);
+        }
+        return out;
+    }
+
+    /** 桌面端：取件字节流。 */
+    @GetMapping("/inbox/{id}/content")
+    public ResponseEntity<FileSystemResource> content(
+            @PathVariable("id") Long id,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        FileSystemResource resource = new FileSystemResource(store.contentPath(userId, id));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                .body(resource);
+    }
+
+    /** 桌面端：确认落盘。置 deliveredAt 并立即删除 blob。 */
+    @PostMapping("/inbox/{id}/ack")
+    public Map<String, Object> ack(
+            @PathVariable("id") Long id,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        store.ack(requireUser(sessionId), id);
+        return Map.of("code", 0);
+    }
+
+    private Long requireUser(String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            throw new UnauthorizedException("请先登录");
+        }
+        return userId;
+    }
+
+    private static LocalDateTime parseCapturedAt(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            // 手机端发 ISO-8601；带时区偏移的转成服务器本地时间，裸的按原样收
+            if (value.contains("+") || value.endsWith("Z")) {
+                return java.time.OffsetDateTime.parse(value)
+                        .atZoneSameInstant(java.time.ZoneId.systemDefault()).toLocalDateTime();
+            }
+            return LocalDateTime.parse(value);
+        } catch (DateTimeParseException e) {
+            return null; // 拍摄时间是元数据，格式不对不该挡住上传
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/model/entity/MobileMediaInbox.java
+++ b/backend/src/main/java/com/checkba/model/entity/MobileMediaInbox.java
@@ -1,0 +1,62 @@
+package com.checkba.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * 手机端现场影像中转区的一件待取件。
+ *
+ * <p>生命周期：手机上传（幂等键 user_id + client_media_id）→ 桌面端取件落盘后 ACK
+ * （置 deliveredAt + <b>立即删除 blob</b>，行保留供手机端查「已抵达」）→ 7 天清理任务删行。
+ * 删除由 ACK 触发、不由时间触发，TTL 只是兜底——两个机制不能混（spec 不变式 1）。
+ */
+@Entity
+@Table(name = "mobile_media_inbox",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "client_media_id"}))
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class MobileMediaInbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 目标桌面机（与 MobileProjectDir.deviceId 同源）。 */
+    @Column(nullable = false, length = 64)
+    private String deviceId;
+
+    @Column(nullable = false, length = 64)
+    private String projectKey;
+
+    /** 手机侧生成的 UUID，幂等键。 */
+    @Column(nullable = false, length = 64)
+    private String clientMediaId;
+
+    @Column(nullable = false, length = 512)
+    private String fileName;
+
+    /** image | video */
+    @Column(nullable = false, length = 16)
+    private String mediaType;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+    /** blob 的物理绝对路径；ACK 删 blob 后置空。 */
+    @Column(length = 1024)
+    private String storagePath;
+
+    private LocalDateTime capturedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deliveredAt;
+}

--- a/backend/src/main/java/com/checkba/model/entity/MobileProjectDir.java
+++ b/backend/src/main/java/com/checkba/model/entity/MobileProjectDir.java
@@ -1,0 +1,47 @@
+package com.checkba.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * 手机端项目目录镜像（云中转，spec 见 aiworkdeck_mobile docs/specs/2026-08-20-project-sync-relay.md）。
+ *
+ * <p>桌面端是项目的唯一权威源：本表只是各台桌面机推上来的 {key, name} 清单，
+ * 供手机端「选择项目」页展示与影像中转寻址，<b>不是</b>云端 project 表的一部分——
+ * projectKey 是那台桌面机本地库的项目 id，跨机同号不同物，所以必须连着 deviceId 一起用。
+ */
+@Entity
+@Table(name = "mobile_project_dir",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "device_id", "project_key"}))
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class MobileProjectDir {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 推送方桌面机的安装标识（UUID）。 */
+    @Column(nullable = false, length = 64)
+    private String deviceId;
+
+    @Column(length = 128)
+    private String deviceName;
+
+    /** 那台桌面机本地库的项目 id（字符串形态，透传不解释）。 */
+    @Column(nullable = false, length = 64)
+    private String projectKey;
+
+    @Column(nullable = false, length = 512)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/checkba/repository/MobileMediaInboxRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MobileMediaInboxRepository.java
@@ -1,0 +1,22 @@
+package com.checkba.repository;
+
+import com.checkba.model.entity.MobileMediaInbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MobileMediaInboxRepository extends JpaRepository<MobileMediaInbox, Long> {
+
+    Optional<MobileMediaInbox> findByUserIdAndClientMediaId(Long userId, String clientMediaId);
+
+    List<MobileMediaInbox> findByUserIdAndDeviceIdAndDeliveredAtIsNullOrderByCreatedAtAsc(
+            Long userId, String deviceId);
+
+    List<MobileMediaInbox> findByUserIdAndClientMediaIdIn(Long userId, List<String> clientMediaIds);
+
+    List<MobileMediaInbox> findByCreatedAtBefore(LocalDateTime cutoff);
+}

--- a/backend/src/main/java/com/checkba/repository/MobileProjectDirRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MobileProjectDirRepository.java
@@ -1,0 +1,17 @@
+package com.checkba.repository;
+
+import com.checkba.model.entity.MobileProjectDir;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MobileProjectDirRepository extends JpaRepository<MobileProjectDir, Long> {
+
+    List<MobileProjectDir> findByUserIdOrderByUpdatedAtDesc(Long userId);
+
+    List<MobileProjectDir> findByUserIdAndDeviceId(Long userId, String deviceId);
+
+    void deleteByUserIdAndDeviceId(Long userId, String deviceId);
+}

--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -118,6 +118,47 @@ public class UserService {
 
     public record PhoneAccount(User user, boolean created) {}
 
+    private static final org.slf4j.Logger claimLog = org.slf4j.LoggerFactory.getLogger(UserService.class);
+
+    /**
+     * 桥接认领手机号（手机端账号归一，dev-board#30）：官网账户带着经短信验证的手机号
+     * 来桥接时，把该号写到桥接用户名下——此后手机端 sms-login 的
+     * {@link #findOrCreateByPhone} 自然解析到同一个账号，不再另建孤号。
+     *
+     * <p>号码正被别的用户占用时<b>转移</b>：占用方是经 sms-login 对同一手机号
+     * 验证过控制权的账号，与官网账户持有人是同一个人，归一正是本方法的目的。
+     * 桥接用户已绑了<b>另一个</b>号码时不覆盖（只记日志）——覆盖会悄悄改变
+     * 一个已工作的登录入口。
+     *
+     * <p>永不抛出：认领是桥接的顺手动作，失败不影响桥接本身。
+     */
+    @org.springframework.transaction.annotation.Transactional
+    public void claimPhoneFromWebsite(User user, String phone) {
+        try {
+            if (user == null || phone == null || !phone.matches("^1\\d{10}$")) return;
+            if (phone.equals(user.getPhone())) return;
+            if (StringUtils.hasText(user.getPhone())) {
+                claimLog.info("桥接用户 {} 已绑 {}，不用官网号码覆盖",
+                        user.getId(), com.checkba.service.sms.SmsAuthService.maskPhone(user.getPhone()));
+                return;
+            }
+            Optional<User> holder = userRepository.findByPhone(phone);
+            if (holder.isPresent() && !holder.get().getId().equals(user.getId())) {
+                User h = holder.get();
+                h.setPhone(null);
+                h.setUpdatedAt(LocalDateTime.now());
+                userRepository.save(h);
+                claimLog.info("手机号 {} 从用户 {} 转移到桥接用户 {}（账号归一）",
+                        com.checkba.service.sms.SmsAuthService.maskPhone(phone), h.getId(), user.getId());
+            }
+            user.setPhone(phone);
+            user.setUpdatedAt(LocalDateTime.now());
+            userRepository.save(user);
+        } catch (Exception e) {
+            claimLog.warn("桥接认领手机号失败（不影响桥接）: user={}", user == null ? null : user.getId(), e);
+        }
+    }
+
     /** 随机短用户名，撞了重试。10 次都撞说明随机源坏了，宁可报错也不静默降级。 */
     private String allocatePhoneUsername() {
         for (int i = 0; i < 10; i++) {

--- a/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
+++ b/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
@@ -112,6 +112,9 @@ public class AwdkLoginService {
         }
 
         User user = resolveUser(accountId, str(me.get("username")), str(me.get("displayName")));
+        // 手机端账号归一（dev-board#30）：官网账户带手机号时认领到桥接用户名下，
+        // 此后手机端 sms-login 解析到同一账号。方法自吞异常，不影响桥接。
+        userService.claimPhoneFromWebsite(user, str(me.get("phone")));
         // per-user 平台 AI key：此刻是 server 唯一合法持有该用户 awdk_ 的时机，顺手换一把
         // 属于他自己的 OpenRouter runtime key 存起来；awdk_ 本身用完即弃，仍然不落库。
         // 取不到（最常见是还没分配额度）绝不影响桥接——插件的绝大多数能力与 AI 额度无关。

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
@@ -1,0 +1,411 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.LocalIdentityService;
+import com.checkba.storage.StorageServiceFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 桌面侧手机同步客户端（spec：aiworkdeck_mobile docs/specs/2026-08-20-project-sync-relay.md）。
+ *
+ * <p>账户已连接（本机持有 awdk_）时自动工作，零配置：
+ * <ul>
+ *   <li>用 awdk_ 到云中转后端换 awdt_ 设备令牌（存 ~/.aiworkdeck/mobile-relay.json，0600）；</li>
+ *   <li>周期把本机项目清单 {key, name} 推到云端目录（手机端「选择项目」的数据源）；</li>
+ *   <li>轮询中转区取回现场影像，落到项目「现场影像/YYYY-MM-DD/」，落盘成功即 ACK
+ *       （云端 ACK 后立即删 blob——落地即删）。</li>
+ * </ul>
+ *
+ * <p>只在 {@code security.local-mode=true}（单机桌面版）活动：云后端与团队服务器
+ * 都没有 AccountService 凭据，天然不跑，这里再加一道显式闸。
+ *
+ * <p>换账号守卫：state 里记录账户指纹，与 {@link AccountService#accountFingerprintOrNull()}
+ * 不一致时作废缓存令牌重新桥接——平台 AI key 曾因漏掉这一步把额度记到前一个账号头上
+ * （PR#334 的根因），同一形状的坑不踩第二次。
+ */
+@Service
+@Slf4j
+public class MobileRelayClientService {
+
+    private final boolean enabled;
+    private final boolean localMode;
+    private final String baseUrl;
+    private final AccountService accountService;
+    private final LocalIdentityService localIdentityService;
+    private final ProjectRepository projectRepository;
+    private final ProjectFileService projectFileService;
+    private final StorageServiceFactory storageServiceFactory;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Path stateFile;
+    private final HttpClient http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10)).build();
+
+    /** 上次成功推送的目录哈希：清单没变就不重复出站。 */
+    private volatile String lastPushedHash;
+
+    private final Object stateLock = new Object();
+    private RelayState state;
+
+    /** 持久化结构：~/.aiworkdeck/mobile-relay.json */
+    public static class RelayState {
+        public String deviceId;
+        public String token;
+        public String accountFingerprint;
+    }
+
+    @Autowired
+    public MobileRelayClientService(
+            @Value("${mobile.relay.enabled:true}") boolean enabled,
+            @Value("${security.local-mode:false}") boolean localMode,
+            @Value("${mobile.relay.base-url:}") String configuredBaseUrl,
+            @Value("${ai.account.base-url:https://www.aiworkdeck.com}") String accountBaseUrl,
+            @Value("${security.license.dir:${user.home}/.aiworkdeck}") String stateDir,
+            AccountService accountService,
+            LocalIdentityService localIdentityService,
+            ProjectRepository projectRepository,
+            ProjectFileService projectFileService,
+            StorageServiceFactory storageServiceFactory) {
+        this.enabled = enabled;
+        this.localMode = localMode;
+        // 国际站账户连到国际中转，大陆站连大陆中转——跟着账户走，别让尽调影像跨境
+        this.baseUrl = configuredBaseUrl != null && !configuredBaseUrl.isBlank()
+                ? configuredBaseUrl.replaceAll("/+$", "")
+                : (accountBaseUrl != null && accountBaseUrl.contains("workdeck.ai")
+                        ? "https://addin.workdeck.ai" : "https://addin.aiworkdeck.com");
+        this.accountService = accountService;
+        this.localIdentityService = localIdentityService;
+        this.projectRepository = projectRepository;
+        this.projectFileService = projectFileService;
+        this.storageServiceFactory = storageServiceFactory;
+        this.stateFile = Path.of(stateDir, "mobile-relay.json");
+    }
+
+    // ==================== 周期任务 ====================
+
+    /** 项目目录推送：启动后 45 秒首推，此后每 10 分钟（清单无变化则跳过出站）。 */
+    @Scheduled(initialDelay = 45_000, fixedDelay = 600_000)
+    public void pushDirectory() {
+        if (!active()) return;
+        try {
+            Long userId = localIdentityService.localUserId();
+            List<Project> projects = projectRepository.findByUserIdOrderByCreatedAtDesc(userId);
+            ObjectNode body = mapper.createObjectNode();
+            body.put("deviceId", deviceId());
+            body.put("deviceName", deviceName());
+            ArrayNode arr = body.putArray("projects");
+            for (Project p : projects) {
+                if (p.getId() == null || p.getName() == null) continue;
+                ObjectNode e = arr.addObject();
+                e.put("key", String.valueOf(p.getId()));
+                e.put("name", p.getName());
+            }
+            String payload = mapper.writeValueAsString(body);
+            String hash = sha256(payload);
+            if (hash.equals(lastPushedHash)) return;
+
+            HttpResponse<String> resp = authed("PUT", "/api/mobile/projects", payload);
+            if (resp != null && resp.statusCode() >= 200 && resp.statusCode() < 300) {
+                lastPushedHash = hash;
+                log.info("手机同步：项目目录已推送（{} 项）", arr.size());
+            } else if (resp != null) {
+                log.warn("手机同步：目录推送失败 status={}", resp.statusCode());
+            }
+        } catch (Exception e) {
+            log.warn("手机同步：目录推送异常（下轮重试）", e);
+        }
+    }
+
+    /** 影像取件：每 60 秒轮询，逐件落盘 + ACK。任一件失败不影响其余。 */
+    @Scheduled(initialDelay = 60_000, fixedDelay = 60_000)
+    public void pollInbox() {
+        if (!active()) return;
+        try {
+            HttpResponse<String> resp = authed("GET", "/api/mobile/inbox?deviceId=" + deviceId(), null);
+            if (resp == null || resp.statusCode() < 200 || resp.statusCode() >= 300) return;
+            JsonNode items = mapper.readTree(resp.body());
+            if (!items.isArray() || items.isEmpty()) return;
+            for (JsonNode item : items) {
+                try {
+                    landAndAck(item);
+                } catch (Exception e) {
+                    log.warn("手机同步：影像 {} 落盘失败（留在中转区下轮重试）",
+                            item.path("id").asLong(), e);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("手机同步：取件轮询异常（下轮重试）", e);
+        }
+    }
+
+    // ==================== 落盘 ====================
+
+    private void landAndAck(JsonNode item) throws IOException, InterruptedException {
+        long itemId = item.path("id").asLong();
+        long projectId;
+        try {
+            projectId = Long.parseLong(item.path("projectKey").asText());
+        } catch (NumberFormatException e) {
+            log.warn("手机同步：影像 {} 的项目标识无法解析: {}", itemId, item.path("projectKey").asText());
+            return;
+        }
+        Long userId = localIdentityService.localUserId();
+        Optional<Project> project = projectRepository.findById(projectId);
+        if (project.isEmpty() || !userId.equals(project.get().getUserId())) {
+            // 项目已删或不属于本机用户：不 ACK（云端 7 天 TTL 兜底），只告警
+            log.warn("手机同步：影像 {} 指向的项目 {} 不存在或不属于本机用户，留置", itemId, projectId);
+            return;
+        }
+
+        String dateStr = captureDate(item);
+        ProjectFile root = ensureFolder(projectId, null, "现场影像", userId);
+        ProjectFile day = ensureFolder(projectId, root.getId(), dateStr, userId);
+
+        String landedName = landedFileName(item.path("fileName").asText(),
+                item.path("clientMediaId").asText());
+        // 幂等：同名已在（上轮落盘成功但 ACK 没发出去）→ 直接补 ACK
+        boolean already = projectFileService.getFilesByParent(projectId, day.getId()).stream()
+                .anyMatch(f -> !Boolean.TRUE.equals(f.getIsFolder()) && landedName.equals(f.getName()));
+        if (!already) {
+            String token = currentToken();
+            if (token == null) return;
+            HttpRequest req = request("/api/mobile/inbox/" + itemId + "/content")
+                    .header("X-Session-Id", token).GET().build();
+            HttpResponse<InputStream> content = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
+            if (content.statusCode() < 200 || content.statusCode() >= 300) {
+                log.warn("手机同步：影像 {} 内容下载失败 status={}", itemId, content.statusCode());
+                return;
+            }
+            ProjectFile record = projectFileService.createFile(
+                    projectId, day.getId(), landedName,
+                    item.path("mediaType").asText("image"),
+                    item.path("fileSize").asLong(0),
+                    null, null, userId);
+            try (InputStream in = content.body()) {
+                storageServiceFactory.getStorageService().save(record.getFilePath(), in);
+            }
+            log.info("手机同步：影像 {} 已落盘 项目={} 文件={}/{}/{}",
+                    itemId, projectId, "现场影像", dateStr, landedName);
+        }
+        HttpResponse<String> ack = authed("POST", "/api/mobile/inbox/" + itemId + "/ack", "{}");
+        if (ack == null || ack.statusCode() < 200 || ack.statusCode() >= 300) {
+            log.warn("手机同步：影像 {} ACK 失败（已落盘，下轮按同名幂等补发）", itemId);
+        }
+    }
+
+    private ProjectFile ensureFolder(Long projectId, Long parentId, String name, Long userId) {
+        Optional<ProjectFile> existing = projectFileService.getFilesByParent(projectId, parentId).stream()
+                .filter(f -> Boolean.TRUE.equals(f.getIsFolder()) && name.equals(f.getName()))
+                .findFirst();
+        return existing.orElseGet(() -> projectFileService.createFolder(projectId, parentId, name, userId));
+    }
+
+    /** 落盘文件名 = 原名 + clientMediaId 前 8 位：既可读，又是跨轮重试的幂等锚点。 */
+    static String landedFileName(String fileName, String clientMediaId) {
+        String n = fileName == null ? "" : fileName.replace('\\', '/');
+        n = n.substring(n.lastIndexOf('/') + 1).trim();
+        if (n.isEmpty()) n = "media";
+        String marker = clientMediaId == null || clientMediaId.length() < 8
+                ? "00000000" : clientMediaId.substring(0, 8).toLowerCase();
+        int dot = n.lastIndexOf('.');
+        return dot > 0 ? n.substring(0, dot) + "-" + marker + n.substring(dot) : n + "-" + marker;
+    }
+
+    /** 归档日期：优先拍摄时间，缺失用中转区入库时间，再缺用今天（桌面机本地时区）。 */
+    static String captureDate(JsonNode item) {
+        for (String field : new String[]{"capturedAt", "createdAt"}) {
+            String v = item.path(field).asText(null);
+            if (v != null && !v.isBlank()) {
+                try {
+                    return LocalDateTime.parse(v).toLocalDate().toString();
+                } catch (Exception ignored) {
+                    // 归档日期是尽力而为的元数据，解析不了就退下一级
+                }
+            }
+        }
+        return LocalDate.now().toString();
+    }
+
+    // ==================== 凭据与传输 ====================
+
+    private boolean active() {
+        return enabled && localMode && accountService.currentKeyOrNull() != null;
+    }
+
+    /** 带令牌出站；401 时作废令牌重新桥接并重试一次。 */
+    private HttpResponse<String> authed(String method, String path, String jsonBody) {
+        String token = currentToken();
+        if (token == null) return null;
+        try {
+            HttpResponse<String> resp = send(method, path, jsonBody, token);
+            if (resp.statusCode() == 401) {
+                invalidateToken();
+                token = currentToken();
+                if (token == null) return resp;
+                return send(method, path, jsonBody, token);
+            }
+            return resp;
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            log.warn("手机同步：出站失败 {} {}", method, path, e);
+            return null;
+        }
+    }
+
+    private HttpResponse<String> send(String method, String path, String jsonBody, String token)
+            throws IOException, InterruptedException {
+        HttpRequest.Builder b = request(path);
+        b.header("X-Session-Id", token);
+        if (jsonBody != null) {
+            b.header("Content-Type", "application/json");
+            b.method(method, HttpRequest.BodyPublishers.ofString(jsonBody, StandardCharsets.UTF_8));
+        } else {
+            b.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+        return http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpRequest.Builder request(String path) {
+        return HttpRequest.newBuilder(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(60));
+    }
+
+    /** 取当前令牌；没有或账户已换人则（重新）桥接。 */
+    private String currentToken() {
+        synchronized (stateLock) {
+            RelayState s = loadState();
+            String fingerprint = accountService.accountFingerprintOrNull();
+            if (s.token != null && fingerprint != null && fingerprint.equals(s.accountFingerprint)) {
+                return s.token;
+            }
+            return bridgeLocked(s, fingerprint);
+        }
+    }
+
+    private void invalidateToken() {
+        synchronized (stateLock) {
+            RelayState s = loadState();
+            s.token = null;
+            s.accountFingerprint = null;
+            saveState(s);
+        }
+    }
+
+    private String bridgeLocked(RelayState s, String fingerprint) {
+        String key = accountService.currentKeyOrNull();
+        if (key == null) return null;
+        try {
+            ObjectNode body = mapper.createObjectNode();
+            body.put("key", key);
+            HttpRequest req = HttpRequest.newBuilder(URI.create(baseUrl + "/api/auth/awdk-login"))
+                    .timeout(Duration.ofSeconds(20))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body), StandardCharsets.UTF_8))
+                    .build();
+            HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+            JsonNode json = mapper.readTree(resp.body());
+            if (resp.statusCode() >= 200 && resp.statusCode() < 300 && json.path("code").asInt(-1) == 0) {
+                s.token = json.path("data").path("token").asText(null);
+                s.accountFingerprint = fingerprint;
+                saveState(s);
+                log.info("手机同步：已桥接到 {}", baseUrl);
+                return s.token;
+            }
+            log.warn("手机同步：桥接失败 status={} message={}", resp.statusCode(),
+                    json.path("message").asText(""));
+            return null;
+        } catch (Exception e) {
+            log.warn("手机同步：桥接异常", e);
+            return null;
+        }
+    }
+
+    // ==================== 状态文件 ====================
+
+    String deviceId() {
+        synchronized (stateLock) {
+            return loadState().deviceId;
+        }
+    }
+
+    private String deviceName() {
+        String host = System.getenv().getOrDefault("HOSTNAME", "");
+        if (host.isBlank()) {
+            try {
+                host = java.net.InetAddress.getLocalHost().getHostName();
+            } catch (Exception ignored) {
+                host = "Desktop";
+            }
+        }
+        return host.length() > 128 ? host.substring(0, 128) : host;
+    }
+
+    private RelayState loadState() {
+        if (state != null) return state;
+        RelayState s = null;
+        try {
+            if (Files.exists(stateFile)) {
+                s = mapper.readValue(Files.readAllBytes(stateFile), RelayState.class);
+            }
+        } catch (Exception e) {
+            log.warn("手机同步：状态文件损坏，重建 {}", stateFile, e);
+        }
+        if (s == null) s = new RelayState();
+        if (s.deviceId == null || s.deviceId.isBlank()) {
+            s.deviceId = UUID.randomUUID().toString();
+            saveState(s);
+        }
+        state = s;
+        return s;
+    }
+
+    private void saveState(RelayState s) {
+        try {
+            Files.createDirectories(stateFile.getParent());
+            Files.write(stateFile, mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(s));
+            AccountService.restrictPermissions(stateFile);
+            state = s;
+        } catch (IOException e) {
+            log.warn("手机同步：状态文件写入失败 {}", stateFile, e);
+        }
+    }
+
+    private static String sha256(String value) {
+        try {
+            return HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 不可用", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayStoreService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayStoreService.java
@@ -1,0 +1,264 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.MobileMediaInbox;
+import com.checkba.model.entity.MobileProjectDir;
+import com.checkba.repository.MobileMediaInboxRepository;
+import com.checkba.repository.MobileProjectDirRepository;
+import com.checkba.service.LangText;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * 云中转区（server 侧）：手机端项目目录镜像 + 现场影像待取件。
+ *
+ * <p>spec：aiworkdeck_mobile docs/specs/2026-08-20-project-sync-relay.md。
+ * 对应桌面侧客户端 {@link MobileRelayClientService}。三条不变式：
+ * <ul>
+ *   <li>目录按 (userId, deviceId) 整批替换——projectKey 是那台桌面机本地库的项目 id，
+ *       跨机同号不同物；</li>
+ *   <li>影像幂等键 (userId, clientMediaId)，重传返回既有记录；</li>
+ *   <li>删除由桌面端 ACK 触发（删 blob 留行），7 天 TTL 只是兜底（行与残留 blob 一并删）。</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+public class MobileRelayStoreService {
+
+    /** clientMediaId 只收 UUID 形态——它会拼进物理路径，这里是路径穿越的唯一围栏。 */
+    private static final Pattern MEDIA_ID = Pattern.compile("^[A-Fa-f0-9-]{8,64}$");
+    /** 单设备目录上限：正常律师机器几十个项目，超出多半是调用方出错，不让它撑爆表。 */
+    private static final int MAX_DIR_ENTRIES = 1000;
+    private static final Duration TTL = Duration.ofDays(7);
+
+    private final MobileProjectDirRepository dirRepository;
+    private final MobileMediaInboxRepository inboxRepository;
+    private final Path relayRoot;
+
+    @Autowired
+    public MobileRelayStoreService(MobileProjectDirRepository dirRepository,
+                                   MobileMediaInboxRepository inboxRepository,
+                                   @Value("${storage.local.root-path:data}") String storageRoot) {
+        this.dirRepository = dirRepository;
+        this.inboxRepository = inboxRepository;
+        this.relayRoot = Path.of(storageRoot, "mobile-relay").toAbsolutePath().normalize();
+    }
+
+    public record DirEntry(String key, String name) {}
+
+    // ==================== 项目目录 ====================
+
+    @Transactional
+    public void replaceDirectory(Long userId, String deviceId, String deviceName, List<DirEntry> projects) {
+        requireDeviceId(deviceId);
+        if (projects == null) projects = List.of();
+        if (projects.size() > MAX_DIR_ENTRIES) {
+            throw new IllegalArgumentException(LangText.of("项目目录条数超限", "Too many directory entries"));
+        }
+        dirRepository.deleteByUserIdAndDeviceId(userId, deviceId);
+        // Hibernate 的动作队列把 INSERT 排在实体级 DELETE 之前，同键重推会先撞唯一约束——
+        // 删除必须先落库
+        dirRepository.flush();
+        LocalDateTime now = LocalDateTime.now();
+        for (DirEntry entry : projects) {
+            if (entry == null || entry.key() == null || entry.key().isBlank()
+                    || entry.name() == null || entry.name().isBlank()) {
+                continue;
+            }
+            MobileProjectDir row = new MobileProjectDir();
+            row.setUserId(userId);
+            row.setDeviceId(deviceId);
+            row.setDeviceName(truncate(deviceName, 128));
+            row.setProjectKey(truncate(entry.key().trim(), 64));
+            row.setName(truncate(entry.name().trim(), 512));
+            row.setUpdatedAt(now);
+            dirRepository.save(row);
+        }
+    }
+
+    /** 该账号全部设备的目录并集，按更新时间倒序（最近在线的桌面机排前面）。 */
+    public List<Map<String, Object>> listDirectory(Long userId) {
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (MobileProjectDir row : dirRepository.findByUserIdOrderByUpdatedAtDesc(userId)) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("deviceId", row.getDeviceId());
+            m.put("deviceName", row.getDeviceName());
+            m.put("key", row.getProjectKey());
+            m.put("name", row.getName());
+            out.add(m);
+        }
+        return out;
+    }
+
+    // ==================== 影像中转 ====================
+
+    @Transactional
+    public MobileMediaInbox storeMedia(Long userId, String deviceId, String projectKey,
+                                       String clientMediaId, String fileName, String mediaType,
+                                       LocalDateTime capturedAt, InputStream content) {
+        requireDeviceId(deviceId);
+        if (projectKey == null || projectKey.isBlank()) {
+            throw new IllegalArgumentException(LangText.of("缺少项目标识", "Missing project key"));
+        }
+        if (clientMediaId == null || !MEDIA_ID.matcher(clientMediaId).matches()) {
+            throw new IllegalArgumentException(LangText.of("影像标识格式不正确", "Invalid media id format"));
+        }
+        if (fileName == null || fileName.isBlank()) {
+            throw new IllegalArgumentException(LangText.of("缺少文件名", "Missing file name"));
+        }
+        if (!"image".equals(mediaType) && !"video".equals(mediaType)) {
+            throw new IllegalArgumentException(LangText.of("影像类型只能是 image 或 video", "Media type must be image or video"));
+        }
+
+        Optional<MobileMediaInbox> existing = inboxRepository.findByUserIdAndClientMediaId(userId, clientMediaId);
+        if (existing.isPresent()) {
+            // 幂等：弱网重传、进程被杀重启都不产生重复件（spec 不变式 2）
+            return existing.get();
+        }
+
+        Path blob = relayRoot.resolve(String.valueOf(userId)).resolve(clientMediaId);
+        long size;
+        try {
+            Files.createDirectories(blob.getParent());
+            size = Files.copy(content, blob, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new IllegalStateException(LangText.of("影像暂存失败", "Failed to store media"), e);
+        }
+
+        MobileMediaInbox row = new MobileMediaInbox();
+        row.setUserId(userId);
+        row.setDeviceId(deviceId);
+        row.setProjectKey(truncate(projectKey.trim(), 64));
+        row.setClientMediaId(clientMediaId);
+        row.setFileName(sanitizeFileName(fileName));
+        row.setMediaType(mediaType);
+        row.setFileSize(size);
+        row.setStoragePath(blob.toString());
+        row.setCapturedAt(capturedAt);
+        row.setCreatedAt(LocalDateTime.now());
+        return inboxRepository.save(row);
+    }
+
+    public List<MobileMediaInbox> pendingForDevice(Long userId, String deviceId) {
+        requireDeviceId(deviceId);
+        return inboxRepository.findByUserIdAndDeviceIdAndDeliveredAtIsNullOrderByCreatedAtAsc(userId, deviceId);
+    }
+
+    /** 取件内容：只有属主且尚未投递的能读。 */
+    public Path contentPath(Long userId, Long itemId) {
+        MobileMediaInbox item = owned(userId, itemId);
+        if (item.getDeliveredAt() != null || item.getStoragePath() == null) {
+            throw new IllegalArgumentException(LangText.of("该影像已投递", "This media item has already been delivered"));
+        }
+        Path p = Path.of(item.getStoragePath());
+        if (!Files.exists(p)) {
+            throw new IllegalArgumentException(LangText.of("影像内容不存在", "Media content not found"));
+        }
+        return p;
+    }
+
+    @Transactional
+    public void ack(Long userId, Long itemId) {
+        MobileMediaInbox item = owned(userId, itemId);
+        if (item.getStoragePath() != null) {
+            try {
+                Files.deleteIfExists(Path.of(item.getStoragePath()));
+            } catch (IOException e) {
+                // blob 删不掉不该挡住投递确认：行先标记，残留 blob 由 TTL 清理兜底
+                log.warn("ACK 删除 blob 失败，留给 TTL 清理: item={}, path={}", itemId, item.getStoragePath(), e);
+            }
+            item.setStoragePath(null);
+        }
+        if (item.getDeliveredAt() == null) {
+            item.setDeliveredAt(LocalDateTime.now());
+        }
+        inboxRepository.save(item);
+    }
+
+    public List<Map<String, Object>> status(Long userId, List<String> clientMediaIds) {
+        if (clientMediaIds == null || clientMediaIds.isEmpty()) return List.of();
+        List<Map<String, Object>> out = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+        for (MobileMediaInbox item : inboxRepository.findByUserIdAndClientMediaIdIn(userId, clientMediaIds)) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("clientMediaId", item.getClientMediaId());
+            m.put("delivered", item.getDeliveredAt() != null);
+            m.put("waitingSeconds", item.getDeliveredAt() != null ? 0L
+                    : Math.max(0L, Duration.between(item.getCreatedAt(), now).getSeconds()));
+            out.add(m);
+        }
+        return out;
+    }
+
+    // ==================== TTL 兜底 ====================
+
+    /** 每天一次：超过 7 天的行（含未投递的）删行 + 删残留 blob。ACK 才是主删除机制。 */
+    @Scheduled(initialDelay = 15 * 60 * 1000, fixedDelay = 24 * 60 * 60 * 1000)
+    @Transactional
+    public void cleanupExpired() {
+        List<MobileMediaInbox> expired = inboxRepository.findByCreatedAtBefore(LocalDateTime.now().minus(TTL));
+        for (MobileMediaInbox item : expired) {
+            if (item.getStoragePath() != null) {
+                try {
+                    Files.deleteIfExists(Path.of(item.getStoragePath()));
+                } catch (IOException e) {
+                    log.warn("TTL 清理 blob 失败: item={}, path={}", item.getId(), item.getStoragePath(), e);
+                }
+            }
+            inboxRepository.delete(item);
+        }
+        if (!expired.isEmpty()) {
+            log.info("影像中转区 TTL 清理 {} 件", expired.size());
+        }
+    }
+
+    // ==================== 内部 ====================
+
+    private MobileMediaInbox owned(Long userId, Long itemId) {
+        MobileMediaInbox item = inboxRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException(LangText.of("影像不存在", "Media item not found")));
+        if (!item.getUserId().equals(userId)) {
+            throw new IllegalArgumentException(LangText.of("无权访问该影像", "You do not have access to this media item"));
+        }
+        return item;
+    }
+
+    private static void requireDeviceId(String deviceId) {
+        if (deviceId == null || deviceId.isBlank() || deviceId.length() > 64) {
+            throw new IllegalArgumentException(LangText.of("缺少设备标识", "Missing device id"));
+        }
+    }
+
+    /** 文件名只留最后一段并去掉路径字符——它日后会成为桌面端项目里的文件名。 */
+    private static String sanitizeFileName(String name) {
+        String n = name.replace('\\', '/');
+        n = n.substring(n.lastIndexOf('/') + 1).trim();
+        if (n.isEmpty() || ".".equals(n) || "..".equals(n)) {
+            throw new IllegalArgumentException(LangText.of("文件名不合法", "Invalid file name"));
+        }
+        return truncate(n, 512);
+    }
+
+    private static String truncate(String value, int max) {
+        if (value == null) return null;
+        return value.length() <= max ? value : value.substring(0, max);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
@@ -106,6 +106,10 @@ class AwdkLoginServiceTest {
                 .thenAnswer(inv -> Optional.ofNullable(usersByName.get(inv.getArgument(0, String.class))));
         when(userRepository.findById(anyLong()))
                 .thenAnswer(inv -> Optional.ofNullable(usersById.get(inv.getArgument(0, Long.class))));
+        when(userRepository.findByPhone(anyString()))
+                .thenAnswer(inv -> usersById.values().stream()
+                        .filter(u -> inv.getArgument(0, String.class).equals(u.getPhone()))
+                        .findFirst());
         when(userRepository.save(any(User.class))).thenAnswer(inv -> {
             User u = inv.getArgument(0);
             if (u.getId() == null) u.setId(userSeq.getAndIncrement());
@@ -431,5 +435,56 @@ class AwdkLoginServiceTest {
         AccountException e = assertThrows(AccountException.class,
                 () -> service(true).sendLoginCode("13800138000", null));
         assertEquals(AccountException.Kind.NETWORK, e.getKind());
+    }
+
+    // ==================== 桥接认领手机号（手机端账号归一，dev-board#30） ====================
+
+    private static final String ME_WITH_PHONE =
+            "{\"accountId\":\"acc_9f3a\",\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\","
+                    + "\"phone\":\"18610211590\",\"balanceCents\":1980,\"plan\":\"paid\"}";
+
+    @Test
+    @DisplayName("认领：官网 me 带 phone 时写到桥接用户名下（sms-login 由此解析到同一账号）")
+    void bridgeClaimsWebsitePhone() {
+        transport.enqueue(200, ME_WITH_PHONE);
+        AwdkLoginService.BridgeSession session = service(true).login(KEY);
+        assertEquals("18610211590", usersById.get(session.userId()).getPhone());
+    }
+
+    @Test
+    @DisplayName("认领转移：号码正被手机号免密建号的孤立用户占用时，转移到桥接用户（同一个人）")
+    void bridgeClaimTransfersPhoneFromStandaloneUser() {
+        User orphan = userService.findOrCreateByPhone("18610211590").user();
+        assertEquals("18610211590", orphan.getPhone());
+
+        transport.enqueue(200, ME_WITH_PHONE);
+        AwdkLoginService.BridgeSession session = service(true).login(KEY);
+
+        assertEquals("18610211590", usersById.get(session.userId()).getPhone());
+        assertNull(usersById.get(orphan.getId()).getPhone(), "孤立用户的号码应被转移走");
+    }
+
+    @Test
+    @DisplayName("认领不覆盖：桥接用户已绑了另一个号码时保持不动")
+    void bridgeClaimNeverOverwritesDifferentPhone() {
+        transport.enqueue(200, ME_OK);
+        AwdkLoginService.BridgeSession first = service(true).login(KEY);
+        User bridged = usersById.get(first.userId());
+        bridged.setPhone("13900000000");
+
+        transport.enqueue(200, ME_WITH_PHONE);
+        service(true).login(KEY);
+        assertEquals("13900000000", usersById.get(first.userId()).getPhone());
+    }
+
+    @Test
+    @DisplayName("认领容错：me 无 phone / phone 形态不对都不影响桥接")
+    void bridgeClaimToleratesMissingOrMalformedPhone() {
+        transport.enqueue(200, ME_OK);
+        assertDoesNotThrow(() -> service(true).login(KEY));
+
+        transport.enqueue(200, ME_OK.replace("\"plan\":\"paid\"", "\"plan\":\"paid\",\"phone\":\"+86 186\""));
+        AwdkLoginService.BridgeSession session = service(true).login(KEY);
+        assertNull(usersById.get(session.userId()).getPhone());
     }
 }

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
@@ -1,0 +1,256 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.service.LocalIdentityService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.account.AccountService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 桌面侧客户端对着**真 HTTP 桩**跑完整编排（不 mock 传输层）：
+ * - 首次出站自动用 awdk_ 桥接换 awdt_ 并持久化；
+ * - 目录推送带 deviceId 与项目清单；同清单第二轮不重复出站；
+ * - 取件：下载内容 → 建「现场影像/日期」两级目录 → createFile + 写字节 → ACK；
+ * - 同名已落盘（上轮 ACK 丢失）时不重复建文件，直接补 ACK；
+ * - 项目不存在时留置（不 ACK，交给云端 TTL）。
+ */
+class MobileRelayClientHttpTest {
+
+    private static final String MEDIA_ID = "0a1b2c3d-1111-4222-8333-444455556666";
+
+    private HttpServer server;
+    private String baseUrl;
+
+    private AccountService accountService;
+    private LocalIdentityService localIdentityService;
+    private ProjectRepository projectRepository;
+    private ProjectFileService projectFileService;
+    private StorageServiceFactory storageServiceFactory;
+    private StorageService storageService;
+
+    @TempDir
+    Path stateDir;
+
+    private final List<String> bridgeBodies = new CopyOnWriteArrayList<>();
+    private final List<String> dirBodies = new CopyOnWriteArrayList<>();
+    private final List<String> acked = new CopyOnWriteArrayList<>();
+    private volatile String inboxJson = "[]";
+
+    // 假文件树：parentId+name → ProjectFile
+    private final List<ProjectFile> tree = new ArrayList<>();
+    private final AtomicLong fileSeq = new AtomicLong(100);
+    private final List<String> savedStorageKeys = new ArrayList<>();
+    private final List<byte[]> savedBytes = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/auth/awdk-login", ex -> {
+            bridgeBodies.add(readBody(ex.getRequestBody()));
+            respond(ex, 200, "{\"code\":0,\"data\":{\"token\":\"awdt_test_token\",\"userId\":3,\"username\":\"awd_x\"}}");
+        });
+        server.createContext("/api/mobile/projects", ex -> {
+            dirBodies.add(readBody(ex.getRequestBody()));
+            respond(ex, 200, "{\"code\":0}");
+        });
+        server.createContext("/api/mobile/inbox", ex -> {
+            String path = ex.getRequestURI().getPath();
+            if (path.endsWith("/content")) {
+                respond(ex, 200, "JPEG-BYTES");
+            } else if (path.endsWith("/ack")) {
+                acked.add(path);
+                respond(ex, 200, "{\"code\":0}");
+            } else {
+                respond(ex, 200, inboxJson);
+            }
+        });
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        accountService = mock(AccountService.class);
+        when(accountService.currentKeyOrNull()).thenReturn("awdk_test_key");
+        when(accountService.accountFingerprintOrNull()).thenReturn("fp-1234");
+
+        localIdentityService = mock(LocalIdentityService.class);
+        when(localIdentityService.localUserId()).thenReturn(7L);
+
+        projectRepository = mock(ProjectRepository.class);
+        Project p42 = new Project();
+        p42.setId(42L);
+        p42.setName("金冠纾困");
+        p42.setUserId(7L);
+        when(projectRepository.findByUserIdOrderByCreatedAtDesc(7L)).thenReturn(List.of(p42));
+        when(projectRepository.findById(42L)).thenReturn(Optional.of(p42));
+        when(projectRepository.findById(999L)).thenReturn(Optional.empty());
+
+        projectFileService = mock(ProjectFileService.class);
+        when(projectFileService.getFilesByParent(anyLong(), any()))
+                .thenAnswer(inv -> {
+                    Long parent = inv.getArgument(1);
+                    List<ProjectFile> out = new ArrayList<>();
+                    for (ProjectFile f : tree) {
+                        if (parent == null ? f.getParentId() == null : parent.equals(f.getParentId())) out.add(f);
+                    }
+                    return out;
+                });
+        when(projectFileService.createFolder(anyLong(), any(), anyString(), anyLong()))
+                .thenAnswer(inv -> addNode(inv.getArgument(1), inv.getArgument(2), true));
+        when(projectFileService.createFile(anyLong(), any(), anyString(), anyString(), anyLong(), any(), any(), anyLong()))
+                .thenAnswer(inv -> {
+                    ProjectFile f = addNode(inv.getArgument(1), inv.getArgument(2), false);
+                    f.setFilePath("projects/42/" + f.getName());
+                    return f;
+                });
+
+        storageService = mock(StorageService.class);
+        when(storageService.save(anyString(), any(InputStream.class))).thenAnswer(inv -> {
+            savedStorageKeys.add(inv.getArgument(0));
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            inv.getArgument(1, InputStream.class).transferTo(buf);
+            savedBytes.add(buf.toByteArray());
+            return inv.getArgument(0);
+        });
+        storageServiceFactory = mock(StorageServiceFactory.class);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    private ProjectFile addNode(Long parentId, String name, boolean folder) {
+        ProjectFile f = new ProjectFile();
+        f.setId(fileSeq.getAndIncrement());
+        f.setProjectId(42L);
+        f.setParentId(parentId);
+        f.setName(name);
+        f.setIsFolder(folder);
+        tree.add(f);
+        return f;
+    }
+
+    private MobileRelayClientService service() {
+        return new MobileRelayClientService(true, true, baseUrl,
+                "https://www.aiworkdeck.com", stateDir.toString(),
+                accountService, localIdentityService, projectRepository,
+                projectFileService, storageServiceFactory);
+    }
+
+    private static String readBody(InputStream in) throws java.io.IOException {
+        return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange ex, int status, String body) throws java.io.IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        ex.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(bytes);
+        }
+        ex.close();
+    }
+
+    @Test
+    @DisplayName("目录推送：首次出站先桥接，请求带 deviceId 与项目清单；同清单第二轮不重复出站")
+    void pushDirectoryBridgesAndDedupes() {
+        MobileRelayClientService svc = service();
+        svc.pushDirectory();
+
+        assertEquals(1, bridgeBodies.size(), "应自动桥接一次");
+        assertTrue(bridgeBodies.get(0).contains("awdk_test_key"));
+        assertEquals(1, dirBodies.size());
+        assertTrue(dirBodies.get(0).contains("\"key\":\"42\""));
+        assertTrue(dirBodies.get(0).contains("金冠纾困"));
+        assertTrue(dirBodies.get(0).contains(svc.deviceId()));
+
+        svc.pushDirectory();
+        assertEquals(1, dirBodies.size(), "清单没变不该重复出站");
+        assertEquals(1, bridgeBodies.size(), "令牌已持久化，不该重复桥接");
+    }
+
+    @Test
+    @DisplayName("取件全链路：下载→现场影像/日期两级目录→createFile+写字节→ACK")
+    void pollInboxLandsAndAcks() {
+        inboxJson = "[{\"id\":9,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"IMG_0001.jpg\",\"mediaType\":\"image\",\"fileSize\":10,"
+                + "\"capturedAt\":\"2026-08-19T21:00:00\",\"createdAt\":\"2026-08-20T09:00:00\"}]";
+        service().pollInbox();
+
+        assertTrue(tree.stream().anyMatch(f -> Boolean.TRUE.equals(f.getIsFolder()) && "现场影像".equals(f.getName())));
+        assertTrue(tree.stream().anyMatch(f -> Boolean.TRUE.equals(f.getIsFolder()) && "2026-08-19".equals(f.getName())));
+        assertTrue(tree.stream().anyMatch(f -> !Boolean.TRUE.equals(f.getIsFolder())
+                && "IMG_0001-0a1b2c3d.jpg".equals(f.getName())));
+        assertEquals(1, savedBytes.size());
+        assertEquals("JPEG-BYTES", new String(savedBytes.get(0), StandardCharsets.UTF_8));
+        assertEquals(List.of("/api/mobile/inbox/9/ack"), acked);
+    }
+
+    @Test
+    @DisplayName("幂等：同名已落盘（上轮 ACK 丢失）不重复建文件，直接补 ACK")
+    void pollInboxSkipsAlreadyLanded() {
+        ProjectFile root = addNode(null, "现场影像", true);
+        ProjectFile day = addNode(root.getId(), "2026-08-19", true);
+        addNode(day.getId(), "IMG_0001-0a1b2c3d.jpg", false);
+
+        inboxJson = "[{\"id\":9,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"IMG_0001.jpg\",\"mediaType\":\"image\",\"fileSize\":10,"
+                + "\"capturedAt\":\"2026-08-19T21:00:00\"}]";
+        service().pollInbox();
+
+        assertTrue(savedBytes.isEmpty(), "不该再写一份字节");
+        assertEquals(List.of("/api/mobile/inbox/9/ack"), acked, "但必须补 ACK");
+    }
+
+    @Test
+    @DisplayName("项目不存在：留置不 ACK（交给云端 7 天 TTL）")
+    void pollInboxLeavesOrphanItems() {
+        inboxJson = "[{\"id\":9,\"projectKey\":\"999\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"IMG_0001.jpg\",\"mediaType\":\"image\",\"fileSize\":10}]";
+        service().pollInbox();
+        assertTrue(acked.isEmpty());
+        assertTrue(savedBytes.isEmpty());
+    }
+
+    @Test
+    @DisplayName("账户未连接 / 非 local-mode：一条出站都不发")
+    void inactiveWhenNoAccountOrNotLocalMode() {
+        when(accountService.currentKeyOrNull()).thenReturn(null);
+        service().pushDirectory();
+        service().pollInbox();
+        assertTrue(bridgeBodies.isEmpty());
+        assertTrue(dirBodies.isEmpty());
+
+        when(accountService.currentKeyOrNull()).thenReturn("awdk_test_key");
+        MobileRelayClientService notLocal = new MobileRelayClientService(true, false, baseUrl,
+                "https://www.aiworkdeck.com", stateDir.toString(),
+                accountService, localIdentityService, projectRepository,
+                projectFileService, storageServiceFactory);
+        notLocal.pushDirectory();
+        assertTrue(dirBodies.isEmpty(), "非 local-mode（云端/团队服务器）绝不出站");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientServiceTest.java
@@ -1,0 +1,46 @@
+package com.checkba.service.mobile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 桌面侧手机同步客户端的纯函数契约：
+ * - 落盘文件名 = 原名 + clientMediaId 前 8 位（跨轮重试的幂等锚点，路径字符剥掉）；
+ * - 归档日期取值顺序 capturedAt → createdAt → 今天。
+ * HTTP 编排部分由本地双实例全链路验证（见 spec 验证一节），不在单测里桩。
+ */
+class MobileRelayClientServiceTest {
+
+    private static final String MEDIA_ID = "0a1b2c3d-1111-4222-8333-444455556666";
+
+    @Test
+    @DisplayName("落盘文件名：扩展名前插 clientMediaId 前 8 位；路径字符剥掉；无扩展名追加在尾")
+    void landedFileNameContract() {
+        assertEquals("IMG_0001-0a1b2c3d.jpg",
+                MobileRelayClientService.landedFileName("IMG_0001.jpg", MEDIA_ID));
+        assertEquals("passwd-0a1b2c3d",
+                MobileRelayClientService.landedFileName("../../etc/passwd", MEDIA_ID));
+        assertEquals("media-00000000",
+                MobileRelayClientService.landedFileName("", "x"));
+        // 同一件影像重试两轮生成同一个名字——幂等的根据
+        assertEquals(MobileRelayClientService.landedFileName("a.mov", MEDIA_ID),
+                MobileRelayClientService.landedFileName("a.mov", MEDIA_ID));
+    }
+
+    @Test
+    @DisplayName("归档日期：capturedAt 优先，缺了用 createdAt，都没有用今天")
+    void captureDateContract() throws Exception {
+        ObjectMapper m = new ObjectMapper();
+        assertEquals("2026-08-19", MobileRelayClientService.captureDate(
+                m.readTree("{\"capturedAt\":\"2026-08-19T21:02:03\",\"createdAt\":\"2026-08-20T01:00:00\"}")));
+        assertEquals("2026-08-20", MobileRelayClientService.captureDate(
+                m.readTree("{\"createdAt\":\"2026-08-20T01:00:00\"}")));
+        assertEquals(LocalDate.now().toString(), MobileRelayClientService.captureDate(
+                m.readTree("{\"capturedAt\":\"not-a-date\"}")));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceTest.java
@@ -1,0 +1,162 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.MobileMediaInbox;
+import com.checkba.repository.MobileMediaInboxRepository;
+import com.checkba.repository.MobileProjectDirRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 云中转区（spec：aiworkdeck_mobile docs/specs/2026-08-20-project-sync-relay.md）契约：
+ * - 目录按 (userId, deviceId) 整批替换，跨设备并集按更新时间倒序；
+ * - 影像入库幂等键 (userId, clientMediaId)，重复上传返回既有记录、不重写 blob；
+ * - clientMediaId 只收 UUID 形态（路径穿越围栏）；
+ * - ACK：置 deliveredAt + 立即删 blob，行保留供 status 查询；
+ * - status：delivered 与等待秒数；
+ * - 7 天 TTL 清理：删行 + 删残留 blob（ACK 是主机制，TTL 只是兜底）。
+ *
+ * 内存 H2（MODE=PostgreSQL）约定同 WorkSessionRepositoryTest。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:mobile-relay-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class MobileRelayStoreServiceTest {
+
+    @Autowired
+    private MobileProjectDirRepository dirRepository;
+    @Autowired
+    private MobileMediaInboxRepository inboxRepository;
+
+    @TempDir
+    Path blobRoot;
+
+    private MobileRelayStoreService service;
+
+    private static final String MEDIA_ID = "0a1b2c3d-1111-4222-8333-444455556666";
+
+    @BeforeEach
+    void setUp() {
+        service = new MobileRelayStoreService(dirRepository, inboxRepository, blobRoot.toString());
+    }
+
+    private MobileMediaInbox store(String clientMediaId, String content) {
+        return service.storeMedia(1L, "dev-a", "42", clientMediaId,
+                "IMG_0001.jpg", "image", null,
+                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    @DisplayName("目录整批替换：同设备重推覆盖，跨设备并集保留")
+    void directoryReplaceIsPerDevice() {
+        service.replaceDirectory(1L, "dev-a", "Mac", List.of(
+                new MobileRelayStoreService.DirEntry("42", "金冠纾困"),
+                new MobileRelayStoreService.DirEntry("43", "probe")));
+        service.replaceDirectory(1L, "dev-b", "Win", List.of(
+                new MobileRelayStoreService.DirEntry("42", "另一台机的 42")));
+        // dev-a 重推：43 没了，44 出现
+        service.replaceDirectory(1L, "dev-a", "Mac", List.of(
+                new MobileRelayStoreService.DirEntry("42", "金冠纾困"),
+                new MobileRelayStoreService.DirEntry("44", "新项目")));
+
+        List<Map<String, Object>> all = service.listDirectory(1L);
+        assertEquals(3, all.size());
+        assertTrue(all.stream().anyMatch(m -> "44".equals(m.get("key")) && "dev-a".equals(m.get("deviceId"))));
+        assertTrue(all.stream().anyMatch(m -> "42".equals(m.get("key")) && "dev-b".equals(m.get("deviceId"))));
+        assertFalse(all.stream().anyMatch(m -> "43".equals(m.get("key"))), "dev-a 重推后 43 应被替换掉");
+        // 别的用户看不到
+        assertTrue(service.listDirectory(2L).isEmpty());
+    }
+
+    @Test
+    @DisplayName("影像入库幂等：同 clientMediaId 重传返回既有记录，blob 不被改写")
+    void mediaStoreIsIdempotent() throws Exception {
+        MobileMediaInbox first = store(MEDIA_ID, "original-bytes");
+        MobileMediaInbox again = store(MEDIA_ID, "different-bytes");
+        assertEquals(first.getId(), again.getId());
+        assertEquals("original-bytes",
+                Files.readString(Path.of(first.getStoragePath()), StandardCharsets.UTF_8));
+        assertEquals(1, inboxRepository.count());
+    }
+
+    @Test
+    @DisplayName("clientMediaId 非 UUID 形态一律拒绝（路径穿越围栏）")
+    void mediaIdMustLookLikeUuid() {
+        assertThrows(IllegalArgumentException.class, () -> store("../../etc/passwd", "x"));
+        assertThrows(IllegalArgumentException.class, () -> store("", "x"));
+        assertThrows(IllegalArgumentException.class, () -> store("id with spaces", "x"));
+    }
+
+    @Test
+    @DisplayName("取件按 (userId, deviceId) 过滤且只给未投递的；ACK 置 deliveredAt 并立即删 blob")
+    void inboxAndAck() {
+        MobileMediaInbox item = store(MEDIA_ID, "payload");
+        assertEquals(1, service.pendingForDevice(1L, "dev-a").size());
+        assertTrue(service.pendingForDevice(1L, "dev-b").isEmpty());
+        assertTrue(service.pendingForDevice(2L, "dev-a").isEmpty());
+
+        Path blob = Path.of(item.getStoragePath());
+        assertTrue(Files.exists(blob));
+        service.ack(1L, item.getId());
+        assertFalse(Files.exists(blob), "ACK 必须立即删除 blob");
+        assertTrue(service.pendingForDevice(1L, "dev-a").isEmpty());
+
+        // 行保留，status 可查
+        List<Map<String, Object>> status = service.status(1L, List.of(MEDIA_ID));
+        assertEquals(1, status.size());
+        assertEquals(Boolean.TRUE, status.get(0).get("delivered"));
+    }
+
+    @Test
+    @DisplayName("ACK 只认属主：他人 id 拒绝")
+    void ackChecksOwnership() {
+        MobileMediaInbox item = store(MEDIA_ID, "payload");
+        assertThrows(IllegalArgumentException.class, () -> service.ack(2L, item.getId()));
+    }
+
+    @Test
+    @DisplayName("status：未投递的 delivered=false 且带等待秒数；未知 id 不出现")
+    void statusReportsWaiting() {
+        store(MEDIA_ID, "payload");
+        List<Map<String, Object>> status = service.status(1L, List.of(MEDIA_ID, "ffffffff-0000-4000-8000-000000000000"));
+        assertEquals(1, status.size());
+        assertEquals(Boolean.FALSE, status.get(0).get("delivered"));
+        assertTrue((long) status.get(0).get("waitingSeconds") >= 0);
+    }
+
+    @Test
+    @DisplayName("7 天 TTL 兜底：过期行删除，未投递的残留 blob 一并删")
+    void ttlCleanupRemovesRowsAndOrphanBlobs() {
+        MobileMediaInbox item = store(MEDIA_ID, "payload");
+        item.setCreatedAt(LocalDateTime.now().minusDays(8));
+        inboxRepository.save(item);
+        Path blob = Path.of(item.getStoragePath());
+        assertTrue(Files.exists(blob));
+
+        service.cleanupExpired();
+        assertFalse(Files.exists(blob));
+        assertEquals(0, inboxRepository.count());
+    }
+}


### PR DESCRIPTION
## 根因

手机端调 addin.aiworkdeck.com 的 /api/projects/my，但云端 project 表全库只有 1 行（08-07 插件默认项目）——桌面项目只存在本机库，没有任何机制上云；且 iOS 用 /api/auth/sms-login 建了孤立账号（user 4），与桌面/插件的桥接账号（user 3）互不相识。详见 dev-board#30 与 spec（aiworkdeck_mobile docs/specs/2026-08-20-project-sync-relay.md）。

## 改动

**云端（server 侧）** `/api/mobile/*`：目录整批替换 / 影像幂等入库 / 桌面 ACK 即删 blob / 7 天 TTL 兜底 / status 查询。鉴权 X-Session-Id（登录会话与 awdt_ 同门）。

**桌面侧** `MobileRelayClientService`（仅 local-mode + 账户已连接）：自动桥接（~/.aiworkdeck/mobile-relay.json，0600，含账户指纹防换账号串数据）、推项目目录（哈希去重）、取件落盘「现场影像/YYYY-MM-DD/」+ ACK（同名幂等锚点 = 原名+clientMediaId 前 8 位）。

**账号归一**：AwdkLoginService 桥接时认领官网 me.phone 到桥接用户（占用者转移、已有异号不覆盖、永不抛出）。配套官网 PR：aiworkdeck_website#87。

新领域文档 .claude/agents/mobile-sync.md + CLAUDE.md 路由行。

## 测试

18 个新用例全绿（store 7 / client-http 5 / client 纯函数 2 / 认领 4），DesktopContextSmokeTest 通过。

## 发布

- 云 jar 部署北京 addin.aiworkdeck.com（本会话随后执行）
- 桌面侧随下一个桌面发版上车
- iOS 切新端点另行 PR（aiworkdeck_mobile 仓）

🤖 Generated with [Claude Code](https://claude.com/claude-code)