### PR TITLE
test(app-e2e): 截图助手不再裸抛，偶发截图超时不再打死整套旅程

### DIFF
--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -202,7 +202,10 @@ try {
     else if (r.status() === 404 && !/favicon|hot-update/.test(r.url())) note('asset404', r.url().slice(0, 150))
   })
 
+  // 截图只是诊断产物，不是断言：Chrome 偶发 captureScreenshot 超时（2026-08-20
+  // 实跑撞过一次，裸 await 直接把整套旅程打死），这里必须吞掉并记 note。
   const shot = (n) => page.screenshot({ path: path.join(OUT, n + '.png') })
+    .catch((e) => note('shotFail', n + ': ' + String((e && e.message) || e).slice(0, 120)))
   const textOf = () => page.evaluate(() => document.body.innerText.replace(/\n{2,}/g, '\n'))
   const waitText = async (t, ms = 15000) => {
     await page.waitForFunction((x) => document.body.innerText.includes(x), { timeout: ms }, t)


### PR DESCRIPTION
## 背景
2026-08-20 在合并后的 master 上实跑全量 app-e2e（93 步全过）时，第一轮曾因 Chrome 偶发 `Page.captureScreenshot` 超时崩掉整个 Node 进程：`shot()` 助手在若干顶层调用点（如 j2-project-list）是裸 await，未捕获异常直接终止套件，整轮作废只能重跑。

## 修法
截图是诊断产物不是断言。`shot()` 内部 catch 截图异常并记 `shotFail` note（沿用既有 note 通道），旅程继续。

## 验证
- `node --check frontend/tests/app-e2e/run.mjs` 通过
- 该文件为测试台架自身，产品代码零改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)