### PR TITLE
fix(mobile-sync): 客户端认全站 4010 信封（冒烟发现的三处判定漏洞）

### DIFF
--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -135,11 +136,13 @@ public class MobileRelayClientService {
             if (hash.equals(lastPushedHash)) return;
 
             HttpResponse<String> resp = authed("PUT", "/api/mobile/projects", payload);
-            if (resp != null && resp.statusCode() >= 200 && resp.statusCode() < 300) {
+            if (okEnvelope(resp)) {
                 lastPushedHash = hash;
                 log.info("手机同步：项目目录已推送（{} 项）", arr.size());
             } else if (resp != null) {
-                log.warn("手机同步：目录推送失败 status={}", resp.statusCode());
+                log.warn("手机同步：目录推送失败 status={} body={}", resp.statusCode(),
+                        resp.body() != null && resp.body().length() > 200
+                                ? resp.body().substring(0, 200) : resp.body());
             }
         } catch (Exception e) {
             log.warn("手机同步：目录推送异常（下轮重试）", e);
@@ -202,8 +205,14 @@ public class MobileRelayClientService {
             HttpRequest req = request("/api/mobile/inbox/" + itemId + "/content")
                     .header("X-Session-Id", token).GET().build();
             HttpResponse<InputStream> content = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
-            if (content.statusCode() < 200 || content.statusCode() >= 300) {
-                log.warn("手机同步：影像 {} 内容下载失败 status={}", itemId, content.statusCode());
+            // 拒绝响应也是 HTTP 200（JSON 信封）——不验 Content-Type 就落盘，
+            // 会把 {"code":4010} 当成照片字节写进项目
+            String contentType = content.headers().firstValue("Content-Type").orElse("");
+            if (content.statusCode() < 200 || content.statusCode() >= 300
+                    || !contentType.startsWith("application/octet-stream")) {
+                try (InputStream in = content.body()) { in.transferTo(OutputStream.nullOutputStream()); }
+                log.warn("手机同步：影像 {} 内容下载失败 status={} contentType={}",
+                        itemId, content.statusCode(), contentType);
                 return;
             }
             ProjectFile record = projectFileService.createFile(
@@ -218,7 +227,7 @@ public class MobileRelayClientService {
                     itemId, projectId, "现场影像", dateStr, landedName);
         }
         HttpResponse<String> ack = authed("POST", "/api/mobile/inbox/" + itemId + "/ack", "{}");
-        if (ack == null || ack.statusCode() < 200 || ack.statusCode() >= 300) {
+        if (!okEnvelope(ack)) {
             log.warn("手机同步：影像 {} ACK 失败（已落盘，下轮按同名幂等补发）", itemId);
         }
     }
@@ -262,13 +271,13 @@ public class MobileRelayClientService {
         return enabled && localMode && accountService.currentKeyOrNull() != null;
     }
 
-    /** 带令牌出站；401 时作废令牌重新桥接并重试一次。 */
+    /** 带令牌出站；鉴权失败时作废令牌重新桥接并重试一次。 */
     private HttpResponse<String> authed(String method, String path, String jsonBody) {
         String token = currentToken();
         if (token == null) return null;
         try {
             HttpResponse<String> resp = send(method, path, jsonBody, token);
-            if (resp.statusCode() == 401) {
+            if (authRejected(resp)) {
                 invalidateToken();
                 token = currentToken();
                 if (token == null) return resp;
@@ -279,6 +288,35 @@ public class MobileRelayClientService {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
             log.warn("手机同步：出站失败 {} {}", method, path, e);
             return null;
+        }
+    }
+
+    /**
+     * 鉴权被拒的两种形态都要认：裸 401，以及全站惯例的「HTTP 200 + code 4010 信封」
+     * （GlobalExceptionHandler 对 UnauthorizedException 统一返回 200）。只看 401 的话，
+     * 令牌失效后目录推送会被当成功、永不重桥接——上线冒烟时抓到的真形态。
+     */
+    private boolean authRejected(HttpResponse<String> resp) {
+        if (resp.statusCode() == 401) return true;
+        String body = resp.body();
+        if (body == null || !body.startsWith("{")) return false;
+        try {
+            return mapper.readTree(body).path("code").asInt(0)
+                    == com.checkba.config.GlobalExceptionHandler.CODE_UNAUTHENTICATED;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** 业务成功 = HTTP 2xx 且（无信封 code 或 code==0）。4010 拒绝也是 200，光看状态码会误判。 */
+    private boolean okEnvelope(HttpResponse<String> resp) {
+        if (resp == null || resp.statusCode() < 200 || resp.statusCode() >= 300) return false;
+        String body = resp.body();
+        if (body == null || !body.startsWith("{")) return true;
+        try {
+            return mapper.readTree(body).path("code").asInt(0) == 0;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/backend/src/test/java/com/checkba/MobileRelayEndpointIntegrationTest.java
+++ b/backend/src/test/java/com/checkba/MobileRelayEndpointIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.checkba;
+
+import com.checkba.service.ai.tools.WebTools;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * /api/mobile/* 全组端点的运行时集成测试：真实走 HTTP → 控制器参数绑定 →
+ * MobileRelayStoreService → H2。重点锁两类只有真 MVC 才暴露的缝：
+ * multipart/RequestParam 字段名与 iOS 客户端约定一致、PUT 体的嵌套 DTO 绑定。
+ * 环境同 IdorAuthIntegrationTest（server 语义，local-mode 关）。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:mobile-relay-e2e;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.local-mode=false",
+        "storage.local.root-path=${java.io.tmpdir}/mobile-relay-e2e-store"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("desktop")
+class MobileRelayEndpointIntegrationTest {
+
+    private static final String MEDIA_ID = "0a1b2c3d-1111-4222-8333-444455556666";
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ObjectMapper om;
+
+    @MockBean
+    private WebTools webTools;
+
+    private String register(String username) throws Exception {
+        String body = om.writeValueAsString(Map.of(
+                "username", username, "password", "pw123456", "displayName", username));
+        MvcResult r = mvc.perform(post("/api/auth/register").contentType(APPLICATION_JSON).content(body))
+                .andExpect(status().isOk()).andReturn();
+        JsonNode json = om.readTree(r.getResponse().getContentAsString());
+        String sid = json.path("data").path("sessionId").asText();
+        assertFalse(sid.isEmpty(), "注册应返回 sessionId：" + r.getResponse().getContentAsString());
+        return sid;
+    }
+
+    @Test
+    void fullRelayRoundTrip() throws Exception {
+        String desktop = register("desktop_" + System.nanoTime());
+
+        // 未带凭据：全站 4010 信封（HTTP 200）——客户端按这个形态判鉴权失败
+        mvc.perform(get("/api/mobile/projects"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(4010));
+
+        // 1. 桌面推目录（嵌套 DTO 绑定）
+        String dir = """
+                {"deviceId":"dev-a","deviceName":"Mac","projects":[
+                  {"key":"42","name":"金冠纾困"},{"key":"43","name":"probe"}]}""";
+        mvc.perform(put("/api/mobile/projects").header("X-Session-Id", desktop)
+                        .contentType(APPLICATION_JSON).content(dir))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.count").value(2));
+
+        // 2. 手机读目录（同一账号）：裸数组
+        mvc.perform(get("/api/mobile/projects").header("X-Session-Id", desktop))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].deviceId").value("dev-a"));
+
+        // 3. 手机传影像：multipart 字段名与 iOS 约定一字不差
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "现场影像-20260820-092011-0a1b.jpg",
+                "application/octet-stream", "JPEG-BYTES".getBytes());
+        mvc.perform(multipart("/api/mobile/media").file(file)
+                        .param("deviceId", "dev-a")
+                        .param("projectKey", "42")
+                        .param("clientMediaId", MEDIA_ID)
+                        .param("fileName", "现场影像-20260820-092011-0a1b.jpg")
+                        .param("mediaType", "image")
+                        .param("capturedAt", "2026-08-20T09:20:11Z")
+                        .header("X-Session-Id", desktop))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.delivered").value(false));
+
+        // 4. 桌面取件
+        MvcResult inbox = mvc.perform(get("/api/mobile/inbox").param("deviceId", "dev-a")
+                        .header("X-Session-Id", desktop))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].projectKey").value("42"))
+                .andReturn();
+        long itemId = om.readTree(inbox.getResponse().getContentAsString()).get(0).path("id").asLong();
+
+        // 5. 内容字节 + Content-Type（客户端靠它区分字节与信封）
+        MvcResult content = mvc.perform(get("/api/mobile/inbox/" + itemId + "/content")
+                        .header("X-Session-Id", desktop))
+                .andExpect(status().isOk()).andReturn();
+        assertEquals("JPEG-BYTES", content.getResponse().getContentAsString());
+        assertTrue(content.getResponse().getContentType().startsWith("application/octet-stream"));
+
+        // 6. ACK 后：取件清空、status=已投递
+        mvc.perform(post("/api/mobile/inbox/" + itemId + "/ack").header("X-Session-Id", desktop))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.code").value(0));
+        mvc.perform(get("/api/mobile/inbox").param("deviceId", "dev-a").header("X-Session-Id", desktop))
+                .andExpect(jsonPath("$.length()").value(0));
+        mvc.perform(get("/api/mobile/media/status").param("clientMediaIds", MEDIA_ID)
+                        .header("X-Session-Id", desktop))
+                .andExpect(jsonPath("$[0].delivered").value(true));
+
+        // 7. 越权：另一个账号看不到、也 ACK 不了
+        String stranger = register("stranger_" + System.nanoTime());
+        mvc.perform(get("/api/mobile/projects").header("X-Session-Id", stranger))
+                .andExpect(jsonPath("$.length()").value(0));
+        mvc.perform(post("/api/mobile/inbox/" + itemId + "/ack").header("X-Session-Id", stranger))
+                .andExpect(jsonPath("$.code").value(org.hamcrest.Matchers.not(0)));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
@@ -81,6 +81,7 @@ class MobileRelayClientHttpTest {
         server.createContext("/api/mobile/inbox", ex -> {
             String path = ex.getRequestURI().getPath();
             if (path.endsWith("/content")) {
+                ex.getResponseHeaders().add("Content-Type", "application/octet-stream");
                 respond(ex, 200, "JPEG-BYTES");
             } else if (path.endsWith("/ack")) {
                 acked.add(path);
@@ -234,6 +235,67 @@ class MobileRelayClientHttpTest {
         service().pollInbox();
         assertTrue(acked.isEmpty());
         assertTrue(savedBytes.isEmpty());
+    }
+
+    @Test
+    @DisplayName("令牌失效（HTTP 200 + code 4010 信封）：作废重桥接并重试，不把拒绝当成功")
+    void staleTokenEnvelopeTriggersRebridge() throws Exception {
+        // 预置一个「旧令牌」state：桥接过、指纹一致，authed 会直接带它出站
+        java.nio.file.Files.writeString(stateDir.resolve("mobile-relay.json"),
+                "{\"deviceId\":\"dev-persisted\",\"token\":\"awdt_stale\",\"accountFingerprint\":\"fp-1234\"}");
+
+        // 目录端点：旧令牌回 4010 信封（HTTP 200），新令牌才收下
+        server.removeContext("/api/mobile/projects");
+        server.createContext("/api/mobile/projects", ex -> {
+            String sid = ex.getRequestHeaders().getFirst("X-Session-Id");
+            dirBodies.add(readBody(ex.getRequestBody()));
+            if ("awdt_stale".equals(sid)) {
+                respond(ex, 200, "{\"code\":4010,\"message\":\"请先登录\"}");
+            } else {
+                respond(ex, 200, "{\"code\":0}");
+            }
+        });
+
+        MobileRelayClientService svc = service();
+        svc.pushDirectory();
+
+        assertEquals(1, bridgeBodies.size(), "4010 信封必须触发重桥接");
+        assertEquals(2, dirBodies.size(), "重桥接后应重试一次");
+
+        // 重试也被拒的话绝不能记成「已推送」：下一轮必须再出站
+        server.removeContext("/api/mobile/projects");
+        server.createContext("/api/mobile/projects", ex -> {
+            dirBodies.add(readBody(ex.getRequestBody()));
+            respond(ex, 200, "{\"code\":4010,\"message\":\"请先登录\"}");
+        });
+        MobileRelayClientService svc2 = service();
+        svc2.pushDirectory();
+        int after = dirBodies.size();
+        svc2.pushDirectory();
+        assertTrue(dirBodies.size() > after, "被拒的推送不得被哈希去重当成功吞掉");
+    }
+
+    @Test
+    @DisplayName("内容下载拿到 JSON 信封（非 octet-stream）：不落盘不 ACK")
+    void contentEnvelopeIsNotWrittenAsMedia() {
+        server.removeContext("/api/mobile/inbox");
+        server.createContext("/api/mobile/inbox", ex -> {
+            String path = ex.getRequestURI().getPath();
+            if (path.endsWith("/content")) {
+                ex.getResponseHeaders().add("Content-Type", "application/json");
+                respond(ex, 200, "{\"code\":4010,\"message\":\"请先登录\"}");
+            } else if (path.endsWith("/ack")) {
+                acked.add(path);
+                respond(ex, 200, "{\"code\":0}");
+            } else {
+                respond(ex, 200, inboxJson);
+            }
+        });
+        inboxJson = "[{\"id\":9,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"IMG_0001.jpg\",\"mediaType\":\"image\",\"fileSize\":10}]";
+        service().pollInbox();
+        assertTrue(savedBytes.isEmpty(), "JSON 信封绝不能被当成照片字节落盘");
+        assertTrue(acked.isEmpty(), "没落盘就不许 ACK");
     }
 
     @Test


### PR DESCRIPTION
部署 #451 后冒烟发现：鉴权拒绝按全站惯例是 HTTP 200 + code 4010 信封，客户端按 401 判会踩空。修正 authed 重桥接触发、推送/ACK 成败判定、取件内容 Content-Type 守卫（否则 JSON 信封会被当照片字节落盘）。新增 2 个桩测（7/7 绿）。

仅桌面侧客户端代码，云端无需重新部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)