### PR TITLE
fix(doc-editor): 迟到的 load_document 结果不再被静默丢弃

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,8 @@
     "test:meeting-e2e": "node tests/meeting-e2e/run.mjs",
     "test:project-home": "node --test tests/project-home/*.test.mjs",
     "test:auth-redirect": "node --test tests/auth-redirect/*.test.mjs",
-    "test:commands": "node --test tests/commands/commands.test.mjs"
+    "test:commands": "node --test tests/commands/commands.test.mjs",
+    "test:zeta-relay": "node --test tests/zeta-relay/*.test.mjs"
   },
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-4080420251103001",

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -470,6 +470,7 @@ export default {
           send: transport.send,
           subscribe: transport.subscribe,
           onReady: () => this.onEndpointReady(),
+          onLateResult: (action, result) => this.onLateLoadResult(action, result),
         })
         // 命令繁忙跟踪：AI 命令与用户输入都走这同一个 executor。autoSave 据此
         // 避开活跃期（export_document 会冻结 office 线程上的 Qt 事件循环）。
@@ -497,6 +498,25 @@ export default {
       this._endpointUp = true
       await this.finishDocLoad()
     },
+    // 迟到结果：load_document 的 180s relay 超时只是「host 端不再等」，worker 里
+    // 的 loadComponentFromURL 打不断，常常在超时之后仍然真的装载成功。旧行为
+    // 是静默丢弃这条迟到的成功消息——用户看到「文档加载失败」的红胶囊，画布上
+    // 其实已经换成了真文档；更严重的是 docLoadFailed 同时是自动保存闸，误判
+    // 期间的编辑会静默不落盘。
+    // 只在「当前仍显示着这次失败」且「没有更晚的装载尝试发生过」（世代号相符）
+    // 时才撤回失败态——世代号不符说明文档已切换/已重试/组件已卸载后订阅已断开
+    // （dispose() 会取消订阅，届时这个回调根本不会再被触发），这些情形一律
+    // 按兵不动，不能让一个作废的迟到结果去污染当前状态。
+    onLateLoadResult(action, result) {
+      if (action !== 'load_document') return
+      if (!this.docLoadFailed) return
+      if (this._loadGen !== this._loadGenAtFailure) return
+      if (result && result.success) {
+        this.docLoadFailed = false
+        this.statusKey = 'ready'
+        this.appendLog('迟到的 load_document 结果实际成功，撤回失败态 / late load_document result arrived successful, reverting loadFailed')
+      }
+    },
     // 装载 + 发布就绪。两个入口：onEndpointReady（常规：mount 时就有 file，或
     // 备胎空白 boot 完成），以及 file watcher（备胎在引擎就绪后被过继）。
     async finishDocLoad() {
@@ -510,6 +530,10 @@ export default {
           // 空白画布上的任何编辑都不得回传覆盖后端真文件。
           this.docLoadFailed = true
           this.statusKey = 'loadFailed'
+          // 记下这次失败时的世代号——迟到的 load_document 结果（见
+          // onLateLoadResult）只在世代仍相符（没有更晚的装载尝试发生过）时
+          // 才允许撤回这个失败态，防止串到后来的重试/换文档头上。
+          this._loadGenAtFailure = this._loadGen
           this.appendLog('load_document failed: ' + (e && e.message ? e.message : e))
         }
       }
@@ -578,6 +602,10 @@ export default {
       const f = this.file
       const fileId = f.wpsFileId || f.id
       if (!fileId) throw new Error('file has no id/wpsFileId')
+      // 每次真正尝试装载都记一个新世代号——onLateLoadResult 靠它辨认一个迟到的
+      // load_document 结果是否还对着「当前显示着的那次失败」，而不是被后来的
+      // 重试/换文档盖过之后依然生效。
+      this._loadGen = (this._loadGen || 0) + 1
       const url = getFileDownloadUrl(fileId)
       let buf = this._bytesPromise ? await this._bytesPromise : null
       if (!buf) {
@@ -680,6 +708,7 @@ export default {
         // 会用旧内容覆盖后端刚改好的文件。
         this.docLoadFailed = true
         this.statusKey = 'reloadFailed'
+        this._loadGenAtFailure = this._loadGen
         this.appendLog('reload failed: ' + (e && e.message ? e.message : e))
         return false
       } finally {

--- a/frontend/src/composables/zetaOfficeRelay.js
+++ b/frontend/src/composables/zetaOfficeRelay.js
@@ -64,18 +64,39 @@ export function serveExecutor({ executor, send, subscribe }) {
  *        it is booted and serving ({type:'ready'}). The host uses this to know
  *        when it may push commands that must not be dropped pre-boot (e.g. Track
  *        D's load_document — sent before this, serveExecutor isn't subscribed yet).
+ * @param {(action:string,result:any)=>void} [args.onLateResult] fired when a
+ *        'result' message arrives for a reqId that already timed out (see
+ *        below) — the caller decides whether the straggler is still relevant.
  * @returns {{executeCommand:(a:string,p?:object)=>Promise<any>, dispose:()=>void}}
  */
-export function createRelayExecutor({ send, subscribe, timeoutMs = 30000, onReady }) {
+export function createRelayExecutor({ send, subscribe, timeoutMs = 30000, onReady, onLateResult }) {
   let seq = 0
   let readyCb = onReady
   const pending = new Map() // reqId -> {resolve, timer}
+  // Timing out a command only stops US from waiting on it — the worker-side
+  // operation (e.g. loadComponentFromURL for load_document) is not abortable
+  // and often keeps running to completion after we've already resolved
+  // failure to the caller. Without this, that late 'result' message has
+  // nowhere to land (pending.get returns undefined) and used to be silently
+  // dropped — the exact bug this fixes: editor reports "load failed" while
+  // the document actually finishes loading a moment later.
+  // Bounded + self-pruning on match: a long-lived webview must not leak one
+  // entry per timeout forever.
+  const tombstones = new Map() // reqId -> action
+  const MAX_TOMBSTONES = 20
   const off = subscribe((msg) => {
     if (!msg || msg.__lo !== TAG) return
     if (msg.type === 'ready') { if (readyCb) { const cb = readyCb; readyCb = null; cb() } return }
     if (msg.type !== 'result') return
     const entry = pending.get(msg.reqId)
-    if (!entry) return
+    if (!entry) {
+      const lateAction = tombstones.get(msg.reqId)
+      if (lateAction) {
+        tombstones.delete(msg.reqId)
+        if (onLateResult) onLateResult(lateAction, msg.result)
+      }
+      return
+    }
     clearTimeout(entry.timer)
     pending.delete(msg.reqId)
     entry.resolve(msg.result)
@@ -93,6 +114,8 @@ export function createRelayExecutor({ send, subscribe, timeoutMs = 30000, onRead
       const timer = setTimeout(() => {
         if (pending.has(reqId)) {
           pending.delete(reqId)
+          tombstones.set(reqId, action)
+          if (tombstones.size > MAX_TOMBSTONES) tombstones.delete(tombstones.keys().next().value)
           resolve({ success: false, message: 'LibreOffice relay timeout: ' + action })
         }
       }, budget)

--- a/frontend/tests/zeta-relay/relay.test.mjs
+++ b/frontend/tests/zeta-relay/relay.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * zetaOfficeRelay.js 的迟到结果（late result）机制。零依赖，用 Node 自带的
+ * node:test 跑：
+ *   cd frontend && npm run test:zeta-relay
+ *
+ * 背景（用户反馈 6 / dev-board#36）：load_document/export_document 的 relay
+ * 超时预算是 180s，但 worker 侧的 loadComponentFromURL 打不断——超时后台
+ * host 端已经 resolve({success:false}) 并把 reqId 从 pending 里删掉，但
+ * worker 常常随后真的装载成功，迟到的 'result' 消息此前被静默丢弃。
+ *
+ * 这里只单测 zetaOfficeRelay.js 本身新增的「墓碑」机制（超时→登记→迟到
+ * result 命中→onLateResult 触发，且只触发一次）。世代号匹配/不匹配的裁决
+ * 逻辑在 LibreOfficeEditor.vue（Vue SFC，仓库里没有为 .vue 组件搭单测
+ * 框架）——那部分改用手工推演矩阵，见本 PR 正文。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRelayExecutor } from '../../src/composables/zetaOfficeRelay.js'
+
+/** 造一对可手动摆布的 {send, subscribe}：send 记下发出的消息，subscribe 的
+ * handler 存起来，测试代码直接调它模拟"对端回了一条消息"。 */
+function fakeTransport() {
+  const sent = []
+  let handler = null
+  return {
+    sent,
+    send: (msg) => sent.push(msg),
+    subscribe: (h) => { handler = h; return () => { handler = null } },
+    // 模拟 webview/iframe 对端发回一条消息
+    deliver: (msg) => handler && handler(msg),
+  }
+}
+
+test('超时后迟到的成功结果触发 onLateResult，而不是被静默丢弃', async () => {
+  const t = fakeTransport()
+  const lateCalls = []
+  // 用一个不是 load_document/export_document 的 action 名，绕开生产代码里
+  // 对这两个 action 强制 >=180000ms 的预算下限，让测试能用一个短超时快速
+  // 触发——墓碑机制本身与具体 action 名无关。
+  const relay = createRelayExecutor({
+    send: t.send,
+    subscribe: t.subscribe,
+    timeoutMs: 20,
+    onLateResult: (action, result) => lateCalls.push({ action, result }),
+  })
+
+  const p = relay.executeCommand('some_slow_action', { x: 1 })
+  const timedOut = await p
+  assert.equal(timedOut.success, false, '超时应先把失败结果 resolve 给调用方')
+
+  // worker 端"迟到"发回真正的结果——reqId 就是刚刚发送的那条消息里的 reqId。
+  const reqId = t.sent[0].reqId
+  t.deliver({ __lo: 'lo-relay', type: 'result', reqId, result: { success: true, kind: 'writer' } })
+
+  assert.equal(lateCalls.length, 1, 'onLateResult 应该被触发恰好一次')
+  assert.equal(lateCalls[0].action, 'some_slow_action')
+  assert.deepEqual(lateCalls[0].result, { success: true, kind: 'writer' })
+
+  // 同一个 reqId 不能重复触发（墓碑命中后必须摘除）。
+  t.deliver({ __lo: 'lo-relay', type: 'result', reqId, result: { success: true } })
+  assert.equal(lateCalls.length, 1, '墓碑命中一次后应摘除，重复的 result 不再触发')
+})
+
+test('正常在超时预算内返回的结果走 pending 路径，不经过 onLateResult', async () => {
+  const t = fakeTransport()
+  const lateCalls = []
+  const relay = createRelayExecutor({
+    send: t.send,
+    subscribe: t.subscribe,
+    timeoutMs: 5000,
+    onLateResult: (action, result) => lateCalls.push({ action, result }),
+  })
+
+  const p = relay.executeCommand('quick_action', {})
+  const reqId = t.sent[0].reqId
+  t.deliver({ __lo: 'lo-relay', type: 'result', reqId, result: { success: true } })
+
+  const res = await p
+  assert.equal(res.success, true)
+  assert.equal(lateCalls.length, 0, '未超时的正常结果不应触发 onLateResult')
+})
+
+test('未提供 onLateResult 时，迟到结果被安静丢弃，不抛异常', async () => {
+  const t = fakeTransport()
+  const relay = createRelayExecutor({ send: t.send, subscribe: t.subscribe, timeoutMs: 20 })
+
+  await relay.executeCommand('some_action', {})
+  const reqId = t.sent[0].reqId
+  assert.doesNotThrow(() => {
+    t.deliver({ __lo: 'lo-relay', type: 'result', reqId, result: { success: true } })
+  })
+})
+
+test('墓碑表有上限，超出后丢弃最旧的一条，不无限增长', async () => {
+  const t = fakeTransport()
+  const lateCalls = []
+  const relay = createRelayExecutor({
+    send: t.send,
+    subscribe: t.subscribe,
+    timeoutMs: 5,
+    onLateResult: (action, result) => lateCalls.push({ action, result }),
+  })
+
+  // 连续发起 25 次都超时（上限是 20），reqId 按顺序记录下来。
+  const reqIds = []
+  for (let i = 0; i < 25; i++) {
+    const p = relay.executeCommand('act_' + i, {})
+    reqIds.push(t.sent[t.sent.length - 1].reqId)
+    // eslint-disable-next-line no-await-in-loop
+    await p // 等这次超时 resolve 完再发下一条，保证顺序确定
+  }
+
+  // 最早的 5 条（超出 20 条上限的部分）应该已经被挤掉，迟到结果找不到对应
+  // 的墓碑，onLateResult 不会被调用。
+  t.deliver({ __lo: 'lo-relay', type: 'result', reqId: reqIds[0], result: { success: true } })
+  assert.equal(lateCalls.length, 0, '最旧的墓碑应已被挤出上限，迟到结果找不到归宿')
+
+  // 最近的一条（第 25 个）应该还在表里。
+  t.deliver({ __lo: 'lo-relay', type: 'result', reqId: reqIds[24], result: { success: true } })
+  assert.equal(lateCalls.length, 1, '仍在上限内的墓碑应正常命中')
+})


### PR DESCRIPTION
## 根因

`frontend/src/composables/zetaOfficeRelay.js` 的 `createRelayExecutor`：`load_document`/`export_document` 走 180s 预算，relay 超时后 `resolve({success:false})` 并把 `pending.delete(reqId)`——但 worker 侧 `loadComponentFromURL` 不会被打断，常常随后真的加载成功、渲染出来。迟到的 `result` 消息因 `pending` 里查不到条目被静默丢弃（旧代码 `if (!entry) return`）。

`LibreOfficeEditor.vue` 的 `finishDocLoad()` catch 里置 `docLoadFailed=true`、`statusKey='loadFailed'`（右上角红胶囊，无自动消失），但 `ready` 仍置 `true`，遮罩就掉了——用户看到的是「提示失败但文档其实已经打开」。

更严重的是 `docLoadFailed` 同时是自动保存闸（`onDocModified`/`saveDocument` 都会拦），这个闸本是防「空白种子文档覆盖真文件」（PR#194）设的，语义不能削弱——但误判发生时，用户在（其实已经装好的）文档上继续编辑会静默不落盘。

对应用户反馈 6 / dev-board#36。

## 修复

1. **`zetaOfficeRelay.js`**：`createRelayExecutor` 新增 `onLateResult(action, result)` 回调。超时时把 `reqId → action` 记入一张有上限（20 条）、自我修剪的「墓碑」表；之前的先失败-后成功 resolve 行为不变。后续对应的 `result` 消息到达时，若在 `pending` 里查不到但命中墓碑，就调用 `onLateResult` 并摘除墓碑条目，不再静默丢弃。
2. **`LibreOfficeEditor.vue`**：`wireExecutor()` 传入 `onLateResult`。新增 `_loadGen` 世代计数——每次 `loadDocument()` 真正尝试装载时 +1；`finishDocLoad`/`reloadFromBackend` 的失败分支记下 `_loadGenAtFailure = this._loadGen`。`onLateLoadResult(action, result)`：仅当 `action==='load_document'`、当前 `docLoadFailed===true`、且 `_loadGen === _loadGenAtFailure`（没有更晚的装载尝试发生过）时，若 `result.success` 就撤回 `docLoadFailed`/`statusKey`（`'ready'`），否则不动。

不改动：`fetchArrayBuffer` 60s 超时与下载重试一次的链路；`docLoadFailed` 闸本身拦截的内容；`finishDocLoad` 无论成败都置 `ready=true` 的既有设计。

## 四种情形推演

| 情形 | 世代号关系 | 行为 |
|---|---|---|
| 超时→迟到**成功** | `_loadGen === _loadGenAtFailure`（没有新尝试） | `onLateLoadResult` 命中，撤回 `docLoadFailed`/`statusKey='ready'`，自动保存闸解除 |
| 超时→迟到**失败** | 同上 | `result.success` 为假，`if (result && result.success)` 不成立，不动，仍保持失败态与保存闸 |
| 期间**文档已切换**（重试/换文档触发了新的 `loadDocument()`） | `_loadGen` 已递增，`_loadGen !== _loadGenAtFailure` | 直接 `return`，迟到结果被丢弃，不污染当前（更新的）装载状态 |
| 期间**组件已卸载** | N/A——`beforeUnmount` 里 `executor.dispose()`（即 relay 的 `off()`）已取消 transport 订阅 | relay 内部的 `subscribe` handler 不再被调用，`onLateResult` 根本不会触发，无需额外判空 |

## 测试

- 新增 `frontend/tests/zeta-relay/relay.test.mjs`（`node:test`，零依赖单测 `zetaOfficeRelay.js` 的墓碑机制）：
  - 超时后迟到的成功结果触发 `onLateResult`，且只触发一次（墓碑命中后摘除，重复 result 不再触发）
  - 未超时的正常结果走 `pending` 路径，不经过 `onLateResult`
  - 未提供 `onLateResult` 时安静丢弃，不抛异常
  - 墓碑表有上限（20 条），超出后挤掉最旧的一条
  - `npm run test:zeta-relay` — 4/4 通过
  - 世代号匹配/不匹配的裁决逻辑在 `LibreOfficeEditor.vue`（Vue SFC，仓库未搭 `.vue` 组件单测框架），已按上表手工推演，未额外补自动化用例
- `npm run check:emits` / `check:locales` / `check:nav` 均通过
- `lowa-e2e` 未跑（冷启动较重，本次改动不影响引擎/worker 侧契约，只影响 relay 超时后的收尾路径）

Closes dev-board#36

🤖 Generated with [Claude Code](https://claude.com/claude-code)