### PR TITLE
fix(meeting-recording): 麦克风选择/胶囊电平与几何/删除入口/告知卡片视觉四项修复

### DIFF
--- a/frontend/src/components/MeetingRecordingIndicator.vue
+++ b/frontend/src/components/MeetingRecordingIndicator.vue
@@ -10,6 +10,11 @@
     <button class="mri-btn stop" type="button" :disabled="state.status === 'stopping'" @click="stop">
       {{ state.status === 'stopping' ? '保存中' : '停止' }}
     </button>
+    <!-- 电平条：贴着胶囊底边的细条，靠 .mri-pill 的 overflow:hidden 借用胶囊自身的圆角裁边，
+         不占布局高度（反馈8，与面板里 mr-level-bar 同一份数据源 recorderState.level） -->
+    <span class="mri-level-track">
+      <span class="mri-level-fill" :style="{ width: Math.round(state.level * 100) + '%' }"></span>
+    </span>
   </div>
 </template>
 
@@ -50,8 +55,14 @@ export default {
 
 <style scoped>
 .mri-pill {
+  /* 几何约束是刻意的，别为了「居中好看」把 top 调大（反馈9）：
+     桌面端浏览器面板用 Electron 原生 BrowserView 渲染，独立合成层，不参与 DOM
+     z-index/点击命中——胶囊只要有一点落进顶部工具条下方的 BrowserView 区域，
+     那部分按钮点击就会被原生层吃掉，点了没反应。顶部工具条（.project-header）
+     高度 42px（compact 模式 48px），胶囊必须整体落在这条 DOM 安全带内：
+     top:4px + height:32px = 底边 36px，留出 ≥6px 余量，不贴边、不相交。 */
   position: fixed;
-  top: 10px;
+  top: 4px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 99997; /* 低于反馈浮窗（99998），互不遮挡（一个在顶部一个在右下） */
@@ -67,6 +78,29 @@ export default {
   font-family: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif;
   font-size: 12px;
   color: #333333;
+  overflow: hidden; /* 裁出电平条贴底边的那一小截，借用胶囊自身的圆角；
+                       position:fixed 本身即为绝对定位子元素（电平条）建立定位基准 */
+}
+
+.mri-level-track {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  background: transparent;
+}
+
+.mri-level-fill {
+  display: block;
+  height: 100%;
+  max-width: 100%;
+  background: #1A5336;
+  transition: width 0.15s linear;
+}
+
+.mri-pill.paused .mri-level-fill {
+  background: #B0B4BA;
 }
 
 .mri-dot {

--- a/frontend/src/components/MeetingRecordingPanel.vue
+++ b/frontend/src/components/MeetingRecordingPanel.vue
@@ -81,6 +81,10 @@
   <!-- 录音区：开会点一下就开录，录前零表单 -->
   <view class="mr-record-zone">
     <template v-if="!recordingActive">
+      <view class="mr-device-picker" v-if="audioDevices.length > 1">
+        <text class="mr-device-picker-label">{{ $t('meeting.micDeviceLabel') }}</text>
+        <AwdSelect :range="deviceLabels" :value="selectedDeviceIndex" @change="onDeviceChange" />
+      </view>
       <view class="mr-record-btn" @tap="onStartRecording">
         <view class="mr-record-dot"></view>
         <text class="mr-record-text">{{ $t('meeting.startRecording') }}</text>
@@ -141,6 +145,12 @@
           <text class="mr-item-meta">{{ metaLine(m) }}</text>
         </view>
         <text class="mr-status" :class="m.status.toLowerCase()">{{ statusText(m.status) }}</text>
+        <view class="mr-item-delete" :title="$t('meeting.delete')" @tap.stop="confirmDelete(m)">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="3 6 5 6 21 6" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </view>
       </view>
 
       <!-- 详情 -->
@@ -279,13 +289,17 @@ import {
 import { getAuthHeaders } from '@/utils/auth.js'
 import {
   recorderState, startRecording, stopRecording, pauseRecording, resumeRecording,
-  isRecordingActive, formatSeconds
+  isRecordingActive, formatSeconds, listAudioInputDevices
 } from '@/utils/meetingRecorder.js'
 import {
   localTierReady, localAsrProbeResult, refreshLocalAsrReadiness
 } from '@/config/platformServices.js'
 import { host } from '@/services/host.js'
 import AwdSwitch from '@/components/AwdSwitch.vue'
+import AwdSelect from '@/components/AwdSelect.vue'
+
+// 选中的麦克风设备持久化到本机，跨会议记住上次的选择
+const MIC_DEVICE_STORAGE_KEY = 'awd_meeting_mic_device_id'
 
 const POLL_INTERVAL_MS = 8000
 
@@ -313,7 +327,7 @@ const NOTICE_COPY = {
 
 export default {
   name: 'MeetingRecordingPanel',
-  components: { AwdSwitch },
+  components: { AwdSwitch, AwdSelect },
   props: {
     projectId: {
       type: [String, Number],
@@ -340,6 +354,10 @@ export default {
       showDeleteDialog: false,
       deletingMeeting: null,
       playingId: null,
+      // 麦克风选择（反馈8）。只有多于 1 个输入设备时下拉才出现——单设备的机器没有可选的意义。
+      audioDevices: [],
+      selectedDeviceIndex: 0,
+      _onDeviceChange: null,
       // 转写档位（GET /api/platform-services 的 asr 那一项）。
       // null = 还没读到 / 读不到（server 模式下非 admin 就会读不到），此时整块不渲染——
       // 摆一个「未知」比不摆更让人不安。
@@ -380,6 +398,9 @@ export default {
     },
     recordingHere() {
       return this.recordingActive && String(this.recState.projectId) === String(this.projectId)
+    },
+    deviceLabels() {
+      return this.audioDevices.map(d => d.label)
     },
     tierKnown() {
       return this.asrProvider !== null
@@ -456,6 +477,12 @@ export default {
     this.loadMeetings()
     this.loadAsrTier()
     this.loadAsrNotice()
+    this.loadAudioDevices()
+    // 设备插拔（外接麦克风/耳机）实时刷新列表；未授权时 label 也可能借这个事件补上
+    if (navigator.mediaDevices && navigator.mediaDevices.addEventListener) {
+      this._onDeviceChange = () => this.loadAudioDevices()
+      navigator.mediaDevices.addEventListener('devicechange', this._onDeviceChange)
+    }
     // 装载时就探一次：面板要在**按下录音键之前**说清这段录音会不会出本机（设计 §6.2.1）
     refreshLocalAsrReadiness()
     this.loadModelState()
@@ -482,6 +509,10 @@ export default {
   beforeUnmount() {
     if (this._pollTimer) clearInterval(this._pollTimer)
     try { if (this._onStopped) uni.$off('awd:meeting-recording-stopped', this._onStopped) } catch (e) { /* ignore */ }
+    if (this._onDeviceChange && navigator.mediaDevices && navigator.mediaDevices.removeEventListener) {
+      navigator.mediaDevices.removeEventListener('devicechange', this._onDeviceChange)
+    }
+    this._onDeviceChange = null
     if (this._modelProgressUnsub) {
       this._modelProgressUnsub()
       this._modelProgressUnsub = null
@@ -627,6 +658,27 @@ export default {
       }
     },
 
+    // ==================== 麦克风设备（反馈8） ====================
+    // 未授权过麦克风时浏览器把 device.label 恒置空字符串，只能用「麦克风 N」占位；
+    // startRecording 成功后（此时必然已拿到授权）会再调一次本方法把真实 label 换上来。
+    async loadAudioDevices() {
+      const list = await listAudioInputDevices()
+      const savedId = uni.getStorageSync(MIC_DEVICE_STORAGE_KEY)
+      this.audioDevices = list.map((d, i) => ({
+        deviceId: d.deviceId,
+        label: (d.label && d.label.trim())
+          ? d.label
+          : this.$t('meeting.micDeviceFallbackName', { n: i + 1 })
+      }))
+      const idx = savedId ? this.audioDevices.findIndex(d => d.deviceId === savedId) : -1
+      this.selectedDeviceIndex = idx >= 0 ? idx : 0
+    },
+    onDeviceChange(i) {
+      this.selectedDeviceIndex = i
+      const d = this.audioDevices[i]
+      if (d) uni.setStorageSync(MIC_DEVICE_STORAGE_KEY, d.deviceId)
+    },
+
     // ==================== 录音 ====================
     async onStartRecording() {
       // 告知没确认就不开录。**拦在这一刻是刻意的**：此时什么都还没发生，
@@ -637,8 +689,11 @@ export default {
         return
       }
       try {
-        await startRecording(this.projectId)
+        const device = this.audioDevices[this.selectedDeviceIndex]
+        await startRecording(this.projectId, device && device.deviceId)
         if (recorderState.configured !== null) this.configured = recorderState.configured
+        // 权限刚拿到手：重新枚举一次，把「麦克风 N」占位换成浏览器现在肯给的真实 label
+        await this.loadAudioDevices()
         await this.loadMeetings()
       } catch (e) {
         uni.showToast({ title: (e && e.message) || this.$t('meeting.cannotStartRecording'), icon: 'none' })
@@ -1009,15 +1064,15 @@ $mr-muted: #6B7280;
 }
 
 /* ---- 平台档转写的单独告知（录音开始之前）----
-   跟随 #389 定的面板密度令牌（与上面的 .mr-tier 同形），不自带一套 12px 的边距：
-   这块就摆在档位卡下面，两者用不同的节奏会让 260px 宽的左栏更挤。
-   唯一不跟的是正文行高——它是一段要读完的告知，不是一行状态。 */
+   视觉对齐 components/collab/CollabDialog.vue 的浅色语言（Slate 色阶、12px 圆角、
+   克制的边框底色）——原先的浅绿卡片与面板其余部分的中性灰不是一套语言（反馈15）。
+   横向节奏仍跟随 #389 定的面板密度令牌，只换配色与圆角，不动布局。 */
 .mr-notice {
   margin: var(--awd-panel-gap) var(--awd-panel-pad-x) 0;
-  padding: 8px;
-  border: 1px solid #D6E4DC;
-  border-radius: var(--awd-panel-radius);
-  background: #F4F9F6;
+  padding: 10px;
+  border: 1px solid #E2E8F0;
+  border-radius: 12px;
+  background: #F8F9FA;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -1026,12 +1081,12 @@ $mr-muted: #6B7280;
 .mr-notice-title {
   font-size: 12px;
   font-weight: 600;
-  color: #1F2328;
+  color: #0F172A;
 }
 
 .mr-notice-body {
   font-size: var(--awd-panel-fs-meta);
-  color: #4B5563;
+  color: #475569;
   line-height: 1.7;
 }
 
@@ -1047,7 +1102,7 @@ $mr-muted: #6B7280;
   width: 13px;
   height: 13px;
   flex: none;
-  border: 1px solid #9CA3AF;
+  border: 1px solid #CBD5E1;
   border-radius: 3px;
   background: #FFFFFF;
 
@@ -1059,7 +1114,7 @@ $mr-muted: #6B7280;
 
 .mr-notice-check-label {
   font-size: var(--awd-panel-fs-meta);
-  color: #374151;
+  color: #334155;
 }
 
 .mr-notice-actions {
@@ -1081,6 +1136,18 @@ $mr-muted: #6B7280;
   flex-direction: column;
   align-items: center;
   gap: 6px;
+}
+
+.mr-device-picker {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mr-device-picker-label {
+  font-size: 11px;
+  color: $mr-muted;
 }
 
 .mr-record-btn {
@@ -1287,6 +1354,34 @@ $mr-muted: #6B7280;
   &.transcribing { background: #EBF5FF; color: #1D6FC2; }
   &.transcribed { background: #EAF7F0; color: $mr-primary; }
   &.failed { background: #FDF2F2; color: $mr-danger; }
+}
+
+/* 收起行的删除入口（反馈10）：常驻显示会跟状态徽标抢视线，收起时只在 hover 时露出，
+   与 FileTree 的 .tree-item-actions 同一套显隐节奏 */
+.mr-item-delete {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  color: $mr-muted;
+  opacity: 0;
+  /* 不显示时不能吃点击：opacity 不影响命中测试，漏了这行的话，行右侧那块看不见的
+     区域仍会响应点击，弹出删除确认框却查不出缘由 */
+  pointer-events: none;
+  transition: opacity 0.15s;
+
+  &:hover {
+    background: #FDF2F2;
+    color: $mr-danger;
+  }
+}
+
+.mr-item-head:hover .mr-item-delete {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* ---- 详情 ---- */

--- a/frontend/src/locales/en-US/meeting.js
+++ b/frontend/src/locales/en-US/meeting.js
@@ -40,6 +40,9 @@ export default {
   notConfiguredByok: 'No transcription service configured: recordings are still saved to project files, but cannot be turned into text. An administrator can enter Alibaba Cloud Tingwu credentials under System settings - Platform Services - Meeting Transcription, or switch to platform-sourced.',
 
   // ---- Recording ----
+  micDeviceLabel: 'Microphone',
+  micDeviceFallbackName: 'Microphone {n}',
+  micDeviceFallback: 'The selected microphone is unavailable; switched to the default device',
   startRecording: 'Start Recording',
   startHint: 'Tap to start. Speakers are separated automatically, and transcription runs once you stop.',
   recording: 'Recording',

--- a/frontend/src/locales/zh-CN/meeting.js
+++ b/frontend/src/locales/zh-CN/meeting.js
@@ -44,6 +44,9 @@ export default {
   notConfiguredByok: '未配置转写服务：录音会保存到项目文件，但不能转文字。管理员可在「系统管理 - 平台服务 - 会议录音转写」里填阿里云听悟凭证，或改用平台代采。',
 
   // ---- 录音 ----
+  micDeviceLabel: '麦克风',
+  micDeviceFallbackName: '麦克风 {n}',
+  micDeviceFallback: '选中的麦克风不可用，已切换到默认设备',
   startRecording: '开始录音',
   startHint: '点击即开始，说话人自动区分，结束后自动转写',
   recording: '录音中',

--- a/frontend/src/utils/meetingRecorder.js
+++ b/frontend/src/utils/meetingRecorder.js
@@ -64,11 +64,41 @@ export function isRecordingActive() {
 }
 
 /**
+ * 枚举可用的麦克风输入设备。
+ * 未授权过麦克风时浏览器把 label 恒置空（隐私考量）——面板据此判断要不要显示
+ * 「麦克风 N」占位名，并在 startRecording 拿到一次授权后重新调用本函数刷新真实 label。
+ */
+export async function listAudioInputDevices() {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) return []
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    return devices.filter((d) => d.kind === 'audioinput')
+  } catch (e) {
+    return []
+  }
+}
+
+// 拿指定设备的麦克风流；deviceId 不可用时（多半是设备被拔了）回退默认设备重试一次，
+// 不让用户因为选中的设备消失而彻底开不了录。
+async function acquireMicStream(deviceId) {
+  if (!deviceId) return navigator.mediaDevices.getUserMedia({ audio: true })
+  try {
+    return await navigator.mediaDevices.getUserMedia({ audio: { deviceId: { exact: deviceId } } })
+  } catch (e) {
+    if (e && (e.name === 'NotAllowedError' || e.name === 'PermissionDeniedError')) throw e
+    recorderState.error = t('meeting.micDeviceFallback')
+    return navigator.mediaDevices.getUserMedia({ audio: true })
+  }
+}
+
+/**
  * 开始录音：建会议档 → 拿麦克风 → 开录。
  * 全局同一时刻只允许一场；重复调用直接抛。
+ * @param {string|number} projectId
+ * @param {string} [deviceId] 指定的麦克风 deviceId；不传则用浏览器默认设备
  * @returns {Promise<object>} 后端返回的 meeting
  */
-export async function startRecording(projectId) {
+export async function startRecording(projectId, deviceId) {
   if (isRecordingActive()) {
     throw new Error(t('meeting.alreadyRecording'))
   }
@@ -84,7 +114,7 @@ export async function startRecording(projectId) {
   recorderState.projectId = projectId
   try {
     // 先拿麦克风再建档：权限被拒时不留空会议记录
-    mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    mediaStream = await acquireMicStream(deviceId)
     const res = await createMeetingRecording(projectId)
     const meeting = res.meeting || res
     recorderState.meetingId = meeting.id


### PR DESCRIPTION
## 处置逐条对照（用户反馈 8/9/10/15，dev-board#38 #39 #40 #45）

### 反馈8：麦克风选择 + 胶囊电平反馈
- `frontend/src/utils/meetingRecorder.js` 新增 `listAudioInputDevices()`（`enumerateDevices` 过滤 `audioinput`），`startRecording(projectId, deviceId)` 增加可选 `deviceId` 参数。
- 指定设备的 `getUserMedia` 用 `{ deviceId: { exact } }`；若设备已被拔走导致失败，`acquireMicStream()` 回退默认设备重试一次，并把提示写入 `recorderState.error`（面板既有的报错展示通道）。
- `MeetingRecordingPanel.vue` 录音区「开始录制」按钮旁加设备下拉（复用现有的 `AwdSelect` 桌面形制下拉组件），仅在 `audioDevices.length > 1` 时显示；选择记入 `uni.setStorageSync('awd_meeting_mic_device_id', ...)`，跨次记住。
- 未授权麦克风时浏览器把 `device.label` 恒置空，用 `$t('meeting.micDeviceFallbackName', {n})` 占位（「麦克风 N」）；`startRecording` 成功拿到授权后重新枚举一次刷新真实 label；同时订阅 `devicechange` 实时刷新插拔。
- 顶部胶囊 `MeetingRecordingIndicator.vue` 补上一条 3px 电平条（`#1A5336` 系，暂停变灰），与面板 `mr-level-bar` 共用 `recorderState.level` 同一份数据源，靠胶囊自身 `overflow:hidden` + 圆角裁边，不占用胶囊本身 32px 的布局高度。

### 反馈9：顶部胶囊点击被 BrowserView 吃掉
根因：桌面端浏览器面板是 Electron 原生 BrowserView（独立合成层，不参与 DOM 层叠/点击命中）。原先胶囊 `top:10px` + `height:32px`，底边落在 42px，与顶部工具条（`.project-header`，高度 42px / compact 模式 48px）下边缘贴线甚至相交，落进 BrowserView 区域的那部分点击被原生层吃掉。

修复：`top` 改为 `4px`，胶囊总高仍是 `32px`，底边 `36px`，与工具条下边缘之间留出 ≥6px 安全带，胶囊整体落在顶部工具条这条纯 DOM 区域内。代码里补了长注释说明这条几何约束的来由，防止后人为了「居中好看」把 `top` 调大改回相交状态。未改动横向位置（仍 `left:50%` 居中，与 `.header-center`/项目名同一水平位置，不压右侧按钮群，这是既有布局）。

**几何推演**：`.project-header` 高度 42px（`.compact-mode` 下 48px）→ 胶囊 `top:4px + height:32px = 底边36px` → `36 < 42`（两种模式下都成立），余量 ≥6px，不贴边、不相交。

### 反馈10：删除入口只在展开详情后可见
`mr-item-head`（收起行）增加 hover 才显现的删除图标（复用 `FileTree.vue` 的线性垃圾桶 SVG，`stroke-width:2`），点击走既有 `confirmDelete(m)` 弹确认框，`@tap.stop` 避免同时触发展开。默认 `opacity:0` 且 `pointer-events:none`，避免不可见状态下仍吃点击（真正命中测试问题，之前没有这层会导致靠近右边缘的误触发确认框）。

### 反馈15（可控部分）：告知卡片视觉重做
`mr-notice`（转写告知卡片）配色/圆角对齐 `components/collab/CollabDialog.vue` 的 Slate 色阶（`#0F172A`/`#475569`/`#334155`/`#CBD5E1`/`#E2E8F0`/`#F8F9FA`）与 12px 圆角，原先的浅绿卡片与面板其余部分的中性灰不是一套语言。文案未改动。
（反馈15 里「按项目分类」不需要开发——录音本来就绑定 `projectId`；「录前弹窗」现状是零表单直接开录，不存在可重做的自制弹窗，故本次不动。）

## 验证
- `npm run check:emits` — 通过（扫描 90 个 .vue，emit/绑定契约无违例）
- `npm run check:locales` — 通过（20 个命名空间键对拍一致，新增的 `micDeviceLabel`/`micDeviceFallbackName`/`micDeviceFallback` 中英文均已补）
- `npm run build:h5` — 编译通过，唯一告警是既有 Sass legacy API 弃用提示（`VariablePanel.vue`/`PersonalWorkLogPanel.vue`），与本次改动无关
- 未改动后端，未跑 `mvn`

## 遗留
- 未做端到端真机走查（真实拔插外接麦克风、真实 BrowserView 点击命中）；建议下次发版前人工过一遍。
- `MeetingRecordingIndicator.vue` 挂在页面树之外、未接 i18n 插件，胶囊文案仍是既有的硬编码中文（本次未新增文案，未加剧此欠账）。

Closes dev-board#38, dev-board#39, dev-board#40, dev-board#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)