### PR TITLE
fix(utility-tools): 浏览器视图创建失败可见可重试，截图 view 失踪降级窗口截图 (dev-board#44)

### DIFF
--- a/frontend/src/components/BrowserPane.vue
+++ b/frontend/src/components/BrowserPane.vue
@@ -33,6 +33,13 @@
     <view class="browser-body">
       <!-- Desktop(Electron): 使用 BrowserView（不在 DOM 内渲染，这里仅作为占位与计算 bounds） -->
       <view v-if="isDesktopBrowser" ref="desktopMount" class="browser-desktop-mount"></view>
+      <!-- BrowserView 创建失败时主进程没有对应 view（僵尸 tab）：面板会一直空白、
+           截图按 viewId 查表报 view not found。原生层不存在时这层 DOM 提示才可见 -->
+      <view v-if="isDesktopBrowser && desktopCreateError" class="browser-create-error">
+        <text class="bce-text">{{ $t('panels.bpCreateFailed') }}</text>
+        <text class="bce-detail">{{ desktopCreateError }}</text>
+        <view class="bce-retry" @tap="retryDesktopCreate"><text>{{ $t('panels.bpRetry') }}</text></view>
+      </view>
 
       <!-- H5: 使用 iframe 做最小可用网页展示 -->
       <!-- #ifdef H5 -->
@@ -98,7 +105,8 @@ export default {
       _desktopReady: false,
       viewCanGoBack: false,
       viewCanGoForward: false,
-      isMobileMode: false
+      isMobileMode: false,
+      desktopCreateError: ''
     }
   },
   computed: {
@@ -202,6 +210,28 @@ export default {
     this._messageBound = false
   },
   methods: {
+    // BrowserView 创建失败此前只 console.warn 一声：tab 留在前端列表里但主进程
+    // 注册表查无此 view（僵尸 tab）——面板空白、截图报 view not found，且当次
+    // 会话内无任何自愈手段（用户反馈14）。失败必须落成可见错误态并给重试。
+    async createDesktopView() {
+      const api = host.browser
+      if (!api) return
+      try {
+        const res = await api.create({ id: this._desktopViewId, url: this.normalizeUrl(this.currentUrl || this.url) })
+        this.adoptViewState(res)
+        this.desktopCreateError = ''
+      } catch (e) {
+        this.desktopCreateError = (e && e.message) ? String(e.message) : String(e || 'create failed')
+        // eslint-disable-next-line no-console
+        console.warn('desktop browser create failed', e)
+      }
+    },
+    async retryDesktopCreate() {
+      await this.createDesktopView()
+      if (!this.desktopCreateError) {
+        this.$nextTick(() => requestAnimationFrame(() => this.syncDesktopBounds()))
+      }
+    },
     async setupDesktopBrowser() {
       const api = host.browser
       if (!api) return
@@ -235,13 +265,7 @@ export default {
       }) : null
 
       // 创建（已有同 id 的保活 view 时是复用，主进程不会重新加载）
-      try {
-        const res = await api.create({ id: this._desktopViewId, url: this.normalizeUrl(this.currentUrl || this.url) })
-        this.adoptViewState(res)
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn('desktop browser create failed', e)
-      }
+      await this.createDesktopView()
       this._desktopReady = true
 
       // 绑定尺寸变化：把 DOM 的 rect 传给主进程作为 BrowserView bounds
@@ -558,6 +582,8 @@ export default {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  /* 供 .browser-create-error 绝对定位铺满 */
+  position: relative;
 }
 
 .browser-iframe {
@@ -577,6 +603,47 @@ export default {
 .browser-fallback {
   padding: 16px;
   color: #666666;
+}
+
+.browser-create-error {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: #f8fafc;
+  padding: 24px;
+  text-align: center;
+}
+
+.bce-text {
+  font-size: 14px;
+  color: #475569;
+}
+
+.bce-detail {
+  font-size: 12px;
+  color: #94a3b8;
+  word-break: break-all;
+  max-width: 420px;
+}
+
+.bce-retry {
+  margin-top: 4px;
+  padding: 7px 18px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1A5336;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.bce-retry:hover {
+  border-color: #1A5336;
+  background: #f0f7f3;
 }
 
 .btn-icon-svg {

--- a/frontend/src/locales/en-US/panels.js
+++ b/frontend/src/locales/en-US/panels.js
@@ -199,6 +199,8 @@ export default {
   bpSwitchToDesktop: 'Switch back to desktop view',
   bpSwitchToMobile: 'Switch to mobile view (fixes pages that are too wide)',
   bpUnsupportedPlatform: 'The browser control is not supported on this platform (H5 only)',
+  bpCreateFailed: 'Failed to create the browser view',
+  bpRetry: 'Retry',
 
   // ProjectFavoritesPanel.vue
   pfLoading: 'Loading…',

--- a/frontend/src/locales/zh-CN/panels.js
+++ b/frontend/src/locales/zh-CN/panels.js
@@ -199,6 +199,8 @@ export default {
   bpSwitchToDesktop: '切换回桌面版',
   bpSwitchToMobile: '切换移动版 (解决网页过宽)',
   bpUnsupportedPlatform: '当前平台暂不支持浏览器控件（仅 H5）',
+  bpCreateFailed: '浏览器视图创建失败',
+  bpRetry: '重试',
 
   // ProjectFavoritesPanel.vue
   pfLoading: '加载中...',

--- a/frontend/src/pages/project-overview/ocrCapture.js
+++ b/frontend/src/pages/project-overview/ocrCapture.js
@@ -198,9 +198,14 @@ export const ocrCaptureMethods = {
             return
           }
           // 全局截图：无网页 tab 时走 window 模式（两边都是文档也能截图）
-          const resp = viewId
+          let resp = viewId
             ? await host.ocr.startSelection({ viewId })
             : await host.ocr.startSelection({ mode: 'window' })
+          // viewId 查表失败（如 BrowserView 创建失败留下的僵尸 tab 报 view not
+          // found）不许成死路——降级为窗口截图照样能截。用户主动取消不降级。
+          if (viewId && (!resp || (resp.ok !== true && !resp.cancelled))) {
+            resp = await host.ocr.startSelection({ mode: 'window' })
+          }
           if (!resp || resp.ok !== true) {
             if (resp && resp.cancelled) return
             uni.showToast({ title: (resp && resp.message) ? String(resp.message) : this.$t('workbenchOps.captureFailed'), icon: 'none' })


### PR DESCRIPTION
## 背景（用户反馈14 / dev-board#44）

用户报「点截图提示 view not found、浏览器面板也打不开」。真机复现调查结论：

- 当前源码起 dev Electron 实跑，浏览器与截图两条链路均正常（BrowserView 正常创建、OCR 框选正常弹出）；
- PR#424/#446/#449/#450 及打包配置近两周改动均不触及该链路，desktop 单测 49/49 绿；
- 「view not found」唯一可达来源是 ocr-start-selection 按 viewId 查主进程注册表为空——与「面板空白」同根因：browser.create 在主进程运行时失败（最可能是环境瞬时因素，重启自愈），失败被 console.warn 吞掉，前端 tab 变僵尸。

## 修复（韧性缺口，非回归修复）

1. BrowserPane.vue：create 失败落成可见错误态（浅色、含错误详情）+ 重试按钮；成功后清错误态并同步 bounds。
2. ocrCapture.js：viewId 路径失败（且非用户取消）自动降级 `{mode:'window'}` 窗口截图，不再死路。
3. panels 词典补 bpCreateFailed/bpRetry（中英对拍）。

## 验证

- check-locale-parity（20 命名空间）/ check-emit-bindings（93 vue）/ check-navigation-contract 全绿。
- 再次出现时的诊断路径已记录在 dev-board#44（renderer console 的 desktop browser create failed 一行会带出底层异常）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)