### PR TITLE
feat(doc-editor): txt/md 轻量文本编辑器（CodeMirror 6），不再进 LOWA + AI text_* 直改原语（dev-board#37）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -89,6 +89,18 @@ Impress **没有 redline**：`slide_write_notes`/`slide_set_shape_text`/`slide_r
 
 **Phase 1 未做、明确延后的项**（spec §5.2/§6 已标注理由，不是遗漏）：LRU 保活权重（Impress 实例记双倍权重）——spec 原话「具体阈值在 Phase 1 用真实 pptx 测了内存再定」，没有真机内存数据前不写死阈值；预热备胎过继到 Impress 文档的稳定性——架构上不需要改（池按 key 存实例，与文档类型无关），但"同一 Qt 窗口从 Writer view 换成 Impress view 是否稳定"必须真机验证，若不稳定的退化方案（pptx 不吃备胎）也留给真机验证后再决定要不要写。`layoutNameOf()` 的 `AutoLayout` 数值→名称映射是最佳努力（只覆盖几个常被引用的值，未逐值核对 idl），不影响原语契约，命中不了就回退 `null`。
 
+## 纯文本 text_* 原语（dev-board#37：后端直读直写，不走编辑器桥）
+
+txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue，见 doc-editor.md「纯文本分流」），doc_* 桥对它们不适用。AI 改这类文件走 `backend/.../tools/TextFileEditTools.java`：
+
+- `text_write_file`（整篇覆盖）、`text_find_replace`（字面量替换，replaceAll 可选，返回命中数）；读取复用 `extract_file_text`。均按扩展名校验（`PLAIN_TEXT_TYPES`，与前端 fileOpenTabs.js 的同名表对齐），docx 等一律拒绝并指回 doc_*。
+- 实现：StorageService 读写（存储键 filePath 优先、回退 wpsFileId，与 DocumentTextService 同口径；UTF-8 直读直写，**不走 Tika**）+ 回写 fileSize/updatedAt + `WorkSessionService.onChangeSignal`（与 FileController.uploadFile 同款版本信号）+ SSE 单向 `client_action {action:'text_reload_file', fileId}`（EditorBridgeService.sendTextReloadFileAction，单名无 wps_* 双轨）。
+- 前端消费：agentClientActions.js `handleTextReloadFile` → `reloadPlainTextInstances(fileId)` 就地重载打开中的文本标签（丢本地未保存态）；未打开不硬拉。
+- **能力过滤刻意不收 text_ 前缀**：这是纯后端执行工具（无客户端执行器依赖，SSE 刷新是 fire-and-forget），按 ClientCapabilityService 的既有语义对所有能力档位可见（与 extract_file_text 同口径）——不要把它加进 lowaOnly，那会让 office/none 会话白白失去纯文本编辑能力。
+- 上下文侧：ContextAssemblerService 的 `lowaDocKind` 新增 `"text"` 分支（txt/md/markdown），active-document 指引/末位提醒/readHint 三处（含英文版）都指向 extract_file_text + text_*，并禁止对其调 doc_*/sheet_*/slide_*；DocumentEditTools.doc_open_file 对纯文本返回指路错误。
+- 纯文本没有修订机制：安全网是版本记录（每次写入都发 onChangeSignal）。工具无 worker action、无 EDITOR_ACTIONS 白名单项——"四件套"清单对 text_* 只剩两件：@Tool + toolDisplayNames.js 中文名（ToolDisplayNameCoverageTest 钉着）。
+- 单测：`TextFileEditToolsTest`（命中/未命中/非文本拒绝/信号触发/跨项目拒绝）。
+
 ## 第二条桥：office_* 工具桥（Word 插件，Phase C）
 
 与 LOWA 桥并存的独立桥，服务 `office-addin/`（Word/Excel/PowerPoint 任务窗格插件）。**逐字同构但零共享**：不复用 EditorBridgeService、超时常量独立、单名契约（无双轨旧名）。

--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -37,6 +37,15 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - `frontend/src/components/LibreOfficeEditor.vue` — 单文档编辑器组件：webview 创建、prefetch、load/export、autoSave、flushSave、reloadFromBackend。支持**备胎过继**（watch file 仅 null→文档；引擎已就绪走 finishDocLoad，未就绪由 onEndpointReady 接手）与**只读预览接力**（字节预取完成即 docx-preview 本地渲染，previewReady 后 overlay 变成可滚动阅读 + 顶部细进度条，ready 后整体消失）。
 - `frontend/src/pages/project-overview/librePool.js` — 保活池方法组（Phase 1 外置）：libreLruKeys/touchLibreLru/evictLibreInstance、syncLibreExecutor 活跃指针、`_libreRefs`/`_libreExecMap` 非响应式注册表、`LIBRE_KEEPALIVE_MAX = 3`、reloadActiveLibreInstances（版本退回/检查点恢复后就地重载）；**预热备胎**（PR#220）：libreSpares（{key, file}，file=null 是后台预 boot 的空白隐藏实例），onActiveOfficeFileChanged 里 maybeAdoptLibreSpare（须在 touchLibreLru 之前，靠"不在 lru 记账"识别无实例）过继给池外首开文档，过继后按 'left:fileId' 常规记账；补胎在过继 ready 后（scheduleLibreSpare，4s 延迟）。仅左窗格设备胎（webview 不能跨容器移动）；h5 无 checkbaDesktop 不建胎；常驻多一个空白实例内存（数百 MB）。
 
+## 纯文本分流（dev-board#37，不进 LOWA）
+
+- `txt/md/markdown` 走 `frontend/src/components/PlainTextEditor.vue`（CodeMirror 6），**不进 LOWA**。分流表 `fileOpenTabs.js` 的 `PLAIN_TEXT_TYPES`（模块顶部常量）+ `isPlainTextFile()`；判定在 `isEditorOpenableFile` 的 wpsFileId 兜底**之前**——上传文件都被合成了 wpsFileId，不先拦就会被兜底判成"可编辑"送进引擎。当前刻意只收这三种扩展名，别顺手加 json/js。
+- 该组件是 **v-if 单实例**（每窗格至多一个，无保活池/LRU/备胎那一套）：切标签即销毁，未保存内容由 `beforeUnmount` 兜底落盘 + `closeFile` 的文本分支显式 `flushSave`。实例登记在 `_plainTextRefs`（`setPlainTextRef`，非响应式，对齐 `_libreRefs` 口径）。
+- 存取走与 LOWA 相同的通用字节接口（GET /download、POST /upload multipart）——upload 成功后端 `signalChange` 自动接版本记录，无需额外接线。保存闸：下载失败或"fileSize>0 却空下载"即禁编辑（`_loadOk`，PR#194 同款事故的朴素版预防）。
+- **版本退回/AI 直改后必须走 `reloadPlainTextInstances(fileId)`**（fileOpenTabs.js）：`onVersionReloadFiles` 与 `handleTextReloadFile`（SSE `text_reload_file`，AI text_* 工具后端直改后下发）都调用它，让正在显示的实例 `reloadFromBackend()` 就地重载并丢弃本地未保存态——不做的话画面不变、下次 autosave 把旧内容写回去。未激活的文本标签没有实例，下次挂载自然拉新内容。
+- 真 `.md` 文件自此可编辑（编辑/预览切换在组件内，markdown-it 渲染）；`isMarkdownTab` 已收窄为只认 `tabType==='markdown'` 的 AI 虚拟产物标签。
+- AI 侧对纯文本走后端直读直写（`text_write_file`/`text_find_replace`），不经编辑器桥——契约见 ai-doc-bridge.md。
+
 ## 启动链路（打开 docx → 可编辑）
 
 激活文档 → 渲染 LibreOfficeEditor → getEditor() IPC（装隔离+起服务）→ 建 webview（persist:zetaoffice）+ 并行 prefetch 文档字节 → editor.html/editor-main.js 选传输 → bootZetaOffice（校验 crossOriginIsolated、fetch CJK 字体、fontconfig conf、加载 soffice.js、uno_main resolve worker port）→ office_thread.js boot（Desktop.create → 空白 swriter、RecordChanges=true、installModifyListener → ui_ready）→ executor 握手 ready → loadDocument：`load_document {bytes}` 写 MEMFS + loadComponentFromURL 重定位 xModel → ready → onLibreReady 注册 executor + syncLibreExecutor。

--- a/backend/src/main/java/com/checkba/service/ai/ClientCapabilityService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ClientCapabilityService.java
@@ -103,7 +103,8 @@ public class ClientCapabilityService {
      * office_* 是 Office 插件专属（经 OfficeBridgeService 等插件回执），且按宿主再细分——
      * office_excel_* 只对 Excel 会话可见、office_ppt_* 只对 PowerPoint 会话可见、
      * 其余 office_*（Word 面）只对 Word 会话可见；
-     * 其余工具（纯后端执行）对所有能力档位可见。
+     * 其余工具（纯后端执行）对所有能力档位可见——包括 text_*（纯文本直读直写，
+     * 后端 StorageService 落盘、无客户端执行器依赖，dev-board#37），刻意不过滤。
      */
     public boolean isToolVisible(String toolName, String conversationId) {
         if (toolName == null) {

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -380,6 +380,12 @@ public class ContextAssemblerService {
                                     "形状填充边框透明度用 slide_format_shape；表格建改用 slide_add_table / slide_table_read / " +
                                     "slide_table_set_cell / slide_table_set_style；超链接用 slide_set_hyperlink。\n\n");
                         }
+                        case "text" -> {
+                            systemText.append("这是一份纯文本文件（txt/md），在轻量文本编辑器中打开，没有修订机制。" +
+                                    "读取用 extract_file_text，修改用 text_write_file（整篇覆盖）或 " +
+                                    "text_find_replace（字面量查找替换），改动直接生效、自动进入版本记录并同步刷新" +
+                                    "用户打开的文本标签——**无需也不要**对它调用 doc_* / sheet_* / slide_* 工具。\n\n");
+                        }
                         default -> {
                             systemText.append("所有 doc_* 编辑/读取工具直接作用于该文档——**无需也不要**调用 ");
                             systemText.append("`doc_list_project_files` 或 `doc_open_file` 去重新发现/打开它；");
@@ -415,6 +421,7 @@ public class ContextAssemblerService {
                     default -> switch (lowaDocKind(activeContext)) {
                         case "sheet" -> "[内容暂不可读，可用 sheet_get_overview / sheet_read_range 直接读取]";
                         case "slide" -> "[内容暂不可读，可用 slide_get_overview / slide_get_page 直接读取]";
+                        case "text" -> "[内容暂不可读，可用 extract_file_text 直接读取]";
                         default -> "[正文暂不可读，可用 doc_get_document_text 直接分段读取]";
                     };
                 };
@@ -637,6 +644,11 @@ public class ContextAssemblerService {
                         + "表格用 slide_add_table / slide_table_read / slide_table_set_cell / slide_table_set_style，"
                         + "超链接用 slide_set_hyperlink，"
                         + "**禁止**再调 doc_list_project_files 或 doc_open_file 去重新发现或打开它。";
+                case "text" -> "\n\n[系统提醒] 用户此刻打开的是纯文本文件" + docLabel + "（id="
+                        + activeContext.getId() + "），其内容见 system prompt 的 <active_document>。"
+                        + "用户未指明别的文件时，「这个」「当前文件」「改一下」等都指它——"
+                        + "读取用 extract_file_text，修改用 text_write_file / text_find_replace"
+                        + "（写入直接生效并进入版本记录），**禁止**对它调用 doc_* / sheet_* / slide_* 工具。";
                 default -> "\n\n[系统提醒] 编辑器中当前已打开文档" + docLabel + "（id="
                         + activeContext.getId() + "），其正文见 system prompt 的 <active_document>。"
                         + "用户未指明别的文档时，「这个」「当前文档」「修订一下」等都指它——"
@@ -660,6 +672,8 @@ public class ContextAssemblerService {
         ext = ext.toLowerCase(java.util.Locale.ROOT);
         if (ext.startsWith("xls") || ext.startsWith("et") || "csv".equals(ext)) return "sheet";
         if (ext.startsWith("ppt") || "odp".equals(ext) || "potx".equals(ext)) return "slide";
+        // 纯文本（dev-board#37 起走轻量文本编辑器，不进 LOWA）：text_* 后端直改口径
+        if ("txt".equals(ext) || "md".equals(ext) || "markdown".equals(ext)) return "text";
         return "doc";
     }
 
@@ -1034,6 +1048,11 @@ This is a spreadsheet. Read and modify it exclusively with the sheet_* tools (sh
 
 """;
 
+    private static final String EN_GUIDE_LOWA_TEXT = """
+This is a plain-text file (txt/md), open in the lightweight text editor; it has no track-changes mechanism. Read it with extract_file_text; modify it with text_write_file (whole-file overwrite) or text_find_replace (literal find and replace). Changes take effect immediately, enter the version history automatically, and refresh the user's open text tab. You need NOT - and must NOT - call doc_* / sheet_* / slide_* tools on it.
+
+""";
+
     private static final String EN_GUIDE_LOWA_SLIDE = """
 This is a presentation. Read and modify it exclusively with the slide_* tools (slide_get_overview first for the deck overview, slide_get_page for one slide's details, slide_set_shape_text / slide_replace_text to change text, slide_write_notes to change speaker notes); writes take effect immediately (presentations have no track-changes mechanism; roll back mistakes with doc_restore_checkpoint). You need NOT - and must NOT - call `doc_list_project_files` or `doc_open_file` to rediscover or reopen it; those two tools are needed only when the user explicitly wants to work on a DIFFERENT document. This session has no doc_* tools.
 Slide and shape structure: slide_add_page / slide_delete_page / slide_move_page / slide_set_layout to add, delete, move slides and set layouts; slide_add_text_box / slide_add_shape to insert text boxes and shapes; slide_delete_shape / slide_set_shape_geometry to delete shapes and adjust position and size.
@@ -1070,6 +1089,7 @@ All doc_* editing and reading tools act directly on this document. You need NOT 
                 switch (lowaDocKind(activeContext)) {
                     case "sheet" -> sb.append(EN_GUIDE_LOWA_SHEET);
                     case "slide" -> sb.append(EN_GUIDE_LOWA_SLIDE);
+                    case "text" -> sb.append(EN_GUIDE_LOWA_TEXT);
                     default -> sb.append(EN_GUIDE_LOWA_DOC);
                 }
             }
@@ -1091,6 +1111,7 @@ All doc_* editing and reading tools act directly on this document. You need NOT 
             default -> switch (lowaDocKind(activeContext)) {
                 case "sheet" -> "[Content temporarily unreadable - read it directly with sheet_get_overview / sheet_read_range]";
                 case "slide" -> "[Content temporarily unreadable - read it directly with slide_get_overview / slide_get_page]";
+                case "text" -> "[Content temporarily unreadable - read it directly with extract_file_text]";
                 default -> "[Body temporarily unreadable - read it in chunks with doc_get_document_text]";
             };
         };
@@ -1183,6 +1204,12 @@ All doc_* editing and reading tools act directly on this document. You need NOT 
                         + "slide_table_read / slide_table_set_cell / slide_table_set_style; hyperlinks use "
                         + "slide_set_hyperlink. "
                         + "Calling doc_list_project_files or doc_open_file to rediscover or reopen it is **FORBIDDEN**.";
+                case "text" -> "\n\n[System reminder] The user currently has the plain-text file " + docLabel
+                        + " (id=" + activeContext.getId() + ") open; its content is in the system prompt's "
+                        + "<active_document>. Unless the user names another file, \"this\", \"the current file\", "
+                        + "\"change it\", and the like refer to it - read it with extract_file_text and modify it with "
+                        + "text_write_file / text_find_replace (writes take effect immediately and enter the version "
+                        + "history). Calling doc_* / sheet_* / slide_* tools on it is **FORBIDDEN**.";
                 default -> "\n\n[System reminder] The editor currently has the document " + docLabel
                         + " (id=" + activeContext.getId() + ") open; its body text is in the system prompt's "
                         + "<active_document>. Unless the user names another document, \"this\", \"the current document\", "

--- a/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
@@ -144,6 +144,30 @@ public class EditorBridgeService {
     }
 
     /**
+     * 通知前端重载纯文本标签（text_write_file / text_find_replace 后端直改之后）。
+     * 单向、单名（dev-board#37 新增，没有 wps_* 时代的旧名要背）；前端只对
+     * 「该文件正开着的文本标签」就地重载，没开着就什么都不做。
+     */
+    public void sendTextReloadFileAction(ProjectFile file) {
+        String conversationId = currentConversationId.get();
+        if (conversationId == null) {
+            log.warn("No conversation ID set, cannot send text reload file action");
+            return;
+        }
+        try {
+            String payload = objectMapper.writeValueAsString(Map.of(
+                    "action", "text_reload_file",
+                    "fileId", file.getId(),
+                    "fileName", file.getName()
+            ));
+            sseEmitterService.send(conversationId, "client_action", payload);
+            log.info("Sent text_reload_file action for file: {} (id={})", file.getName(), file.getId());
+        } catch (Exception e) {
+            log.error("Failed to send text reload file action", e);
+        }
+    }
+
+    /**
      * 双轨迁移期的单向 client_action 发送：同一份载荷按"新名在前、旧名在后"各发一次。
      * 顺序是契约的一部分——前端凭"先见新名"判定新后端并丢弃随后的旧名事件去重。
      */

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -89,6 +89,12 @@ public class DocumentEditTools implements AgentToolComponent {
             if (denied != null) return denied;
 
             if (!isEditableDocument(file.getName())) {
+                // 纯文本不进文档编辑器（dev-board#37 起走轻量文本编辑器），给模型指对路
+                if (TextFileEditTools.isPlainText(file)) {
+                    return "Error: " + file.getName() + " 是纯文本文件，不在文档编辑器中打开。"
+                            + "读取用 extract_file_text，修改用 text_write_file / text_find_replace"
+                            + "（改动会自动同步到用户已打开的文本标签）。";
+                }
                 return "Error: 该文件不是可编辑的文档格式: " + file.getName();
             }
             

--- a/backend/src/main/java/com/checkba/service/ai/tools/TextFileEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/TextFileEditTools.java
@@ -1,0 +1,232 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.storage.StorageServiceFactory;
+import com.checkba.version.WorkSessionService;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 纯文本文件（txt/md/markdown）的直读直写原语。
+ *
+ * <p>背景：这类文件自 dev-board#37 起不再进 LOWA 编辑器（前端改走 CodeMirror 轻量
+ * 文本编辑器），doc_* 那条「SSE 下发 → 编辑器执行 → 回执」的桥对它们不再适用。
+ * 这里走后端直改：StorageService 读写字节 + WorkSessionService.onChangeSignal 接上
+ * 版本记录（与 FileController.uploadFile 同一信号），改完发单向 SSE
+ * {@code text_reload_file} 让前端已打开的文本标签就地重载。
+ *
+ * <p>纯后端执行、无客户端执行器依赖，因此不参与 ClientCapabilityService 的
+ * 能力过滤（与 extract_file_text 同口径）；text_ 前缀仅作命名区隔。
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TextFileEditTools implements AgentToolComponent {
+
+    private final ProjectFileRepository projectFileRepository;
+    private final StorageServiceFactory storageServiceFactory;
+    private final WorkSessionService workSessionService;
+    private final EditorBridgeService editorBridgeService;
+    private final com.checkba.service.UserService userService;
+
+    /** 与前端 fileOpenTabs.js 的 plainTextTypes 对齐：只有这几种进轻量文本编辑器。 */
+    static final Set<String> PLAIN_TEXT_TYPES = Set.of("txt", "md", "markdown");
+
+    /** 大文件熔断：纯文本超过这个尺寸基本是日志/导出物，整篇改写没有意义还吃内存。 */
+    private static final long MAX_TEXT_BYTES = 5L * 1024 * 1024;
+
+    @ToolMeta(displayName = "写入文本文件", category = "file", fileEffect = "MODIFIED")
+    @Tool("整篇覆盖写入一个纯文本文件（仅限 .txt / .md / .markdown，UTF-8）。docx/xlsx/pptx 等 Office 文档"
+            + "禁止用本工具，那些走 doc_* / sheet_* / slide_* 编辑原语。读取纯文本用 extract_file_text。"
+            + "写入即生效（纯文本没有修订机制），并自动进入版本记录、同步刷新用户已打开的文本标签。")
+    public String text_write_file(
+            @P("项目文件数据库 ID（从 list_files / extract_file_text 等处获取）") Long fileId,
+            @P("新的完整文件内容（整篇覆盖）") String content
+    ) {
+        log.info("Tool: text_write_file called for fileId={}", fileId);
+        Resolved r = resolveTextFile(fileId);
+        if (r.error != null) return r.error;
+        ProjectFile pf = r.file;
+        String text = content == null ? "" : content;
+        try {
+            writeBack(pf, text);
+            return "已写入 " + pf.getName() + "（" + text.length() + " 字符）。改动已进入版本记录。";
+        } catch (Exception e) {
+            log.warn("text_write_file failed for fileId={}", fileId, e);
+            return "Error: 写入失败: " + e.getMessage();
+        }
+    }
+
+    @ToolMeta(displayName = "文本查找替换", category = "file", fileEffect = "MODIFIED")
+    @Tool("在纯文本文件（仅限 .txt / .md / .markdown）中做字面量查找替换（非正则）。"
+            + "replaceAll=true 替换全部命中，false 只替换第一处；返回命中次数。"
+            + "docx 等 Office 文档禁止用本工具（用 doc_find_replace）。改动直接生效并进入版本记录。")
+    public String text_find_replace(
+            @P("项目文件数据库 ID") Long fileId,
+            @P("要查找的文本（字面量，区分大小写）") String find,
+            @P("替换为的文本") String replace,
+            @P("是否替换全部命中（false 只替换第一处）") boolean replaceAll
+    ) {
+        log.info("Tool: text_find_replace called for fileId={}", fileId);
+        if (find == null || find.isEmpty()) {
+            return "Error: find 不能为空。";
+        }
+        Resolved r = resolveTextFile(fileId);
+        if (r.error != null) return r.error;
+        ProjectFile pf = r.file;
+        try {
+            String text = readText(pf);
+            int hits = countOccurrences(text, find);
+            if (hits == 0) {
+                return "未找到 \"" + abbreviate(find) + "\"，文件未改动（共 " + text.length() + " 字符）。";
+            }
+            String replacement = replace == null ? "" : replace;
+            String updated = replaceAll
+                    ? text.replace(find, replacement)
+                    : text.replaceFirst(java.util.regex.Pattern.quote(find),
+                            java.util.regex.Matcher.quoteReplacement(replacement));
+            int applied = replaceAll ? hits : 1;
+            writeBack(pf, updated);
+            return "已在 " + pf.getName() + " 中替换 " + applied + " 处（命中 " + hits + " 处）。改动已进入版本记录。";
+        } catch (Exception e) {
+            log.warn("text_find_replace failed for fileId={}", fileId, e);
+            return "Error: 替换失败: " + e.getMessage();
+        }
+    }
+
+    // ==================== 内部实现 ====================
+
+    /** 定位结果：file 与 error 恰有其一（工具是单例 Bean，不能把失败原因存实例字段）。 */
+    private record Resolved(ProjectFile file, String error) {}
+
+    /** 定位并校验目标：存在、同项目、确为纯文本扩展名。 */
+    private Resolved resolveTextFile(Long fileId) {
+        if (fileId == null) return new Resolved(null, "Error: fileId is required.");
+        Optional<ProjectFile> opt = projectFileRepository.findById(fileId);
+        if (opt.isEmpty()) {
+            return new Resolved(null, "Error: 文件不存在，ID=" + fileId);
+        }
+        ProjectFile pf = opt.get();
+        String denied = ToolFileGuard.rejectIfOutsideProject(pf);
+        if (denied != null) return new Resolved(null, denied);
+        if (Boolean.TRUE.equals(pf.getIsFolder())) {
+            return new Resolved(null, "Error: ID=" + fileId + " 是文件夹，不是文本文件。");
+        }
+        if (!isPlainText(pf)) {
+            return new Resolved(null, "Error: " + pf.getName() + " 不是纯文本文件。本工具仅限 .txt/.md/.markdown；"
+                    + "Word/Excel/PPT 请分别用 doc_* / sheet_* / slide_* 编辑原语。");
+        }
+        return new Resolved(pf, null);
+    }
+
+    static boolean isPlainText(ProjectFile pf) {
+        String ext = pf.getFileType();
+        if (ext == null || ext.isBlank()) {
+            String name = pf.getName();
+            int dot = name == null ? -1 : name.lastIndexOf('.');
+            ext = (dot >= 0 && dot < name.length() - 1) ? name.substring(dot + 1) : "";
+        }
+        return PLAIN_TEXT_TYPES.contains(ext.toLowerCase(Locale.ROOT));
+    }
+
+    /** 存储键与 DocumentTextService.extractText 同口径：filePath 优先，回退 wpsFileId。 */
+    private String storageKey(ProjectFile pf) {
+        String path = pf.getFilePath();
+        if (path == null || path.isBlank()) path = pf.getWpsFileId();
+        if (path == null || path.isBlank()) {
+            throw new IllegalStateException("文件没有存储路径: " + pf.getId());
+        }
+        return path;
+    }
+
+    /** 原始字节按 UTF-8 直读——不能走 Tika 抽取，改写回去要的是逐字节可逆的原文。 */
+    private String readText(ProjectFile pf) throws Exception {
+        Resource resource = storageServiceFactory.getStorageService().load(storageKey(pf));
+        try (InputStream is = resource.getInputStream()) {
+            byte[] bytes = is.readAllBytes();
+            if (bytes.length > MAX_TEXT_BYTES) {
+                throw new IllegalStateException("文件过大（>" + (MAX_TEXT_BYTES / 1024 / 1024) + "MB），拒绝整篇改写。");
+            }
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * 落盘 + 元数据 + 版本信号 + 前端刷新。
+     * 与 FileController.uploadFile 的收尾同构：字节写成功后元数据/信号失败只记日志，
+     * 不把已生效的写入报成失败。
+     */
+    private void writeBack(ProjectFile pf, String text) throws Exception {
+        byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_TEXT_BYTES) {
+            throw new IllegalStateException("内容过大（>" + (MAX_TEXT_BYTES / 1024 / 1024) + "MB），拒绝写入。");
+        }
+        storageServiceFactory.getStorageService().save(storageKey(pf), new ByteArrayInputStream(bytes));
+        try {
+            pf.setFileSize((long) bytes.length);
+            pf.setUpdatedAt(LocalDateTime.now());
+            projectFileRepository.save(pf);
+        } catch (Exception e) {
+            log.warn("text write: 回写文件元数据失败 fileId={}", pf.getId(), e);
+        }
+        signalChange(pf);
+        try {
+            editorBridgeService.sendTextReloadFileAction(pf);
+        } catch (Exception e) {
+            log.warn("text write: 发送 text_reload_file 失败 fileId={}", pf.getId(), e);
+        }
+    }
+
+    /** 版本记录信号，与 FileController.uploadFile / ProjectFileService 同口径：失败只记日志。 */
+    private void signalChange(ProjectFile pf) {
+        try {
+            Long userId = ProjectContextHolder.getUserId();
+            workSessionService.onChangeSignal(pf.getProjectId(), userId, resolveUserName(userId));
+        } catch (Exception e) {
+            log.warn("发送版本变更信号失败: project={}", pf.getProjectId(), e);
+        }
+    }
+
+    private String resolveUserName(Long userId) {
+        if (userId != null) {
+            try {
+                var u = userService.getUserById(userId);
+                if (u != null && u.getUsername() != null) return u.getUsername();
+            } catch (Exception e) {
+                log.warn("解析用户名失败: userId={}", userId, e);
+            }
+        }
+        // 拿不到会话用户就署 AI：这条路只有 AI 工具会走，比泛称「用户」更如实
+        return "AI WorkDeck";
+    }
+
+    static int countOccurrences(String text, String find) {
+        if (text == null || find == null || find.isEmpty()) return 0;
+        int count = 0;
+        int idx = 0;
+        while ((idx = text.indexOf(find, idx)) >= 0) {
+            count++;
+            idx += find.length();
+        }
+        return count;
+    }
+
+    private static String abbreviate(String s) {
+        return s.length() > 60 ? s.substring(0, 60) + "…" : s;
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -14,6 +14,7 @@ import com.checkba.service.ai.tools.PdfTools;
 import com.checkba.service.ai.tools.PptxTools;
 import com.checkba.service.ai.tools.PythonTools;
 import com.checkba.service.ai.tools.SubAgentTools;
+import com.checkba.service.ai.tools.TextFileEditTools;
 import com.checkba.service.ai.tools.TodoTools;
 import com.checkba.service.ai.tools.WebTools;
 
@@ -53,6 +54,7 @@ final class RealToolBeans {
                 PptxTools.class,
                 PythonTools.class,
                 SubAgentTools.class,
+                TextFileEditTools.class,
                 // TodoTools 长期漏列：todo_write 在整个回放评测里根本没注册，
                 // 于是「skill 命中时清单工具是否可见」这类断言写了也是空的（工具名不存在，
                 // offeredToolsInclude 永远失败、offeredToolsExclude 永远通过）。

--- a/backend/src/test/java/com/checkba/service/ai/tools/TextFileEditToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/TextFileEditToolsTest.java
@@ -1,0 +1,169 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import com.checkba.version.WorkSessionService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 纯文本直读直写原语（dev-board#37）：txt/md 不再进 LOWA，AI 改这类文件走
+ * text_write_file / text_find_replace（后端 StorageService 读写 + 版本信号 + 前端刷新）。
+ * 这组用例钉住四件事：命中替换真的落盘、未命中不动文件、非文本格式必须拒绝、
+ * 写入成功后版本信号（onChangeSignal）与前端刷新（text_reload_file）必须触发。
+ */
+class TextFileEditToolsTest {
+
+    private ProjectFileRepository repo;
+    private StorageService storage;
+    private WorkSessionService workSessions;
+    private EditorBridgeService bridge;
+    private TextFileEditTools tools;
+
+    @BeforeEach
+    void setUp() {
+        ProjectContextHolder.setProjectId("7");
+        repo = Mockito.mock(ProjectFileRepository.class);
+        storage = Mockito.mock(StorageService.class);
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        when(factory.getStorageService()).thenReturn(storage);
+        workSessions = Mockito.mock(WorkSessionService.class);
+        bridge = Mockito.mock(EditorBridgeService.class);
+        tools = new TextFileEditTools(repo, factory, workSessions, bridge, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ProjectContextHolder.clear();
+    }
+
+    private ProjectFile textFile(long id, String name, String type) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(7L);
+        f.setName(name);
+        f.setFileType(type);
+        f.setIsFolder(false);
+        f.setFilePath("projects/7/" + name);
+        return f;
+    }
+
+    private void stubContent(ProjectFile pf, String content) throws Exception {
+        when(storage.load(pf.getFilePath()))
+                .thenReturn(new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private String savedContent(ProjectFile pf) throws Exception {
+        ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
+        verify(storage).save(eq(pf.getFilePath()), captor.capture());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        captor.getValue().transferTo(out);
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @DisplayName("find_replace 命中：替换全部并落盘，触发版本信号与前端刷新")
+    void findReplaceHitWritesBackAndSignals() throws Exception {
+        ProjectFile pf = textFile(11L, "备忘.txt", "txt");
+        when(repo.findById(11L)).thenReturn(Optional.of(pf));
+        stubContent(pf, "甲方是A公司，甲方负责付款。");
+
+        String out = tools.text_find_replace(11L, "甲方", "乙方", true);
+
+        assertFalse(out.startsWith("Error"), out);
+        assertTrue(out.contains("2"), "要报出命中次数：" + out);
+        assertEquals("乙方是A公司，乙方负责付款。", savedContent(pf));
+        verify(workSessions).onChangeSignal(eq(7L), any(), anyString());
+        verify(bridge).sendTextReloadFileAction(pf);
+    }
+
+    @Test
+    @DisplayName("find_replace replaceAll=false 只替换第一处")
+    void findReplaceFirstOnly() throws Exception {
+        ProjectFile pf = textFile(12L, "notes.md", "md");
+        when(repo.findById(12L)).thenReturn(Optional.of(pf));
+        stubContent(pf, "todo one, todo two");
+
+        String out = tools.text_find_replace(12L, "todo", "done", false);
+
+        assertFalse(out.startsWith("Error"), out);
+        assertEquals("done one, todo two", savedContent(pf));
+    }
+
+    @Test
+    @DisplayName("find_replace 未命中：不写盘、不发信号，说清楚没找到")
+    void findReplaceMissTouchesNothing() throws Exception {
+        ProjectFile pf = textFile(13L, "备忘.txt", "txt");
+        when(repo.findById(13L)).thenReturn(Optional.of(pf));
+        stubContent(pf, "没有目标词的内容");
+
+        String out = tools.text_find_replace(13L, "丙方", "丁方", true);
+
+        assertTrue(out.contains("未找到"), out);
+        verify(storage, never()).save(anyString(), any());
+        verify(workSessions, never()).onChangeSignal(anyLong(), any(), anyString());
+        verify(bridge, never()).sendTextReloadFileAction(any());
+    }
+
+    @Test
+    @DisplayName("非纯文本格式（docx）必须拒绝并指对路")
+    void rejectsNonTextFile() {
+        ProjectFile pf = textFile(14L, "合同.docx", "docx");
+        when(repo.findById(14L)).thenReturn(Optional.of(pf));
+
+        String w = tools.text_write_file(14L, "x");
+        String r = tools.text_find_replace(14L, "a", "b", true);
+
+        assertTrue(w.startsWith("Error"), w);
+        assertTrue(w.contains("doc_"), "拒绝时要把 doc_* 的正路指出来：" + w);
+        assertTrue(r.startsWith("Error"), r);
+        verifyNoInteractions(storage);
+    }
+
+    @Test
+    @DisplayName("text_write_file 整篇覆盖：落盘 + 回写大小 + 信号 + 刷新")
+    void writeFileOverwritesAndSignals() throws Exception {
+        ProjectFile pf = textFile(15L, "README.md", "md");
+        when(repo.findById(15L)).thenReturn(Optional.of(pf));
+
+        String out = tools.text_write_file(15L, "# 新内容\n正文");
+
+        assertFalse(out.startsWith("Error"), out);
+        assertEquals("# 新内容\n正文", savedContent(pf));
+        assertEquals("# 新内容\n正文".getBytes(StandardCharsets.UTF_8).length, pf.getFileSize());
+        verify(repo).save(pf);
+        verify(workSessions).onChangeSignal(eq(7L), any(), anyString());
+        verify(bridge).sendTextReloadFileAction(pf);
+    }
+
+    @Test
+    @DisplayName("跨项目文件被项目边界挡住")
+    void rejectsFileFromAnotherProject() {
+        ProjectFile pf = textFile(16L, "别人的.txt", "txt");
+        pf.setProjectId(999L);
+        when(repo.findById(16L)).thenReturn(Optional.of(pf));
+
+        String out = tools.text_write_file(16L, "x");
+
+        assertTrue(out.startsWith("Error"), out);
+        verifyNoInteractions(storage);
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,11 @@
       "name": "uni-preset-vue",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/commands": "^6.11.0",
+        "@codemirror/lang-markdown": "^6.5.2",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.9",
         "@dcloudio/uni-app": "3.0.0-4080420251103001",
         "@dcloudio/uni-app-harmony": "3.0.0-4080420251103001",
         "@dcloudio/uni-app-plus": "3.0.0-4080420251103001",
@@ -2106,6 +2111,136 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.12.tgz",
+      "integrity": "sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.2.tgz",
+      "integrity": "sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.9.tgz",
+      "integrity": "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@dcloudio/types": {
       "version": "3.4.19",
@@ -4582,6 +4717,79 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.6.tgz",
+      "integrity": "sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.7.2.tgz",
+      "integrity": "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7185,6 +7393,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -13727,6 +13941,12 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -14610,6 +14830,12 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,11 @@
     "test:zeta-relay": "node --test tests/zeta-relay/*.test.mjs"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/lang-markdown": "^6.5.2",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.9",
     "@dcloudio/uni-app": "3.0.0-4080420251103001",
     "@dcloudio/uni-app-harmony": "3.0.0-4080420251103001",
     "@dcloudio/uni-app-plus": "3.0.0-4080420251103001",

--- a/frontend/src/components/PlainTextEditor.vue
+++ b/frontend/src/components/PlainTextEditor.vue
@@ -1,0 +1,458 @@
+<template>
+  <view class="ptx-editor">
+    <view v-if="phase === 'loading'" class="ptx-status">
+      <text class="ptx-status-text">{{ $t('editor.plainText.opening') }}</text>
+    </view>
+
+    <view v-else-if="phase === 'error'" class="ptx-status">
+      <text class="ptx-status-text">{{ errorText || $t('editor.plainText.loadFailed') }}</text>
+      <view class="ptx-btn" role="button" @tap="boot">{{ $t('editor.plainText.retry') }}</view>
+    </view>
+
+    <template v-else>
+      <view class="ptx-bar">
+        <text class="ptx-name">{{ file && file.name }}</text>
+        <view v-if="isMarkdown" class="ptx-toggle">
+          <view class="ptx-toggle-btn" :class="{ active: !previewMode }" role="button" @tap="setPreview(false)">
+            {{ $t('editor.plainText.edit') }}
+          </view>
+          <view class="ptx-toggle-btn" :class="{ active: previewMode }" role="button" @tap="setPreview(true)">
+            {{ $t('editor.plainText.preview') }}
+          </view>
+        </view>
+        <view class="ptx-bar-right">
+          <!-- 保存状态：成功不出声（同 LOWA 口径，成功提示只会闪变打扰）；
+               「未保存」小字常显、失败醒目并给当场重试。 -->
+          <view v-if="saveFailed" class="ptx-save-failed" role="button" @tap="save">
+            {{ $t('editor.plainText.saveFailedRetry') }}
+          </view>
+          <text v-else-if="dirty || saving" class="ptx-dirty">{{ $t('editor.plainText.unsaved') }}</text>
+        </view>
+      </view>
+      <!-- CodeMirror 挂载点必须是真实 DOM（div 而非 uni view），预览时 v-show 藏住
+           而不销毁——切回编辑要保留光标/滚动/撤销栈 -->
+      <div v-show="!previewMode" ref="cmHost" class="ptx-cm-host"></div>
+      <view v-if="previewMode" class="ptx-preview">
+        <view class="markdown-body" v-html="previewHtml"></view>
+      </view>
+    </template>
+  </view>
+</template>
+
+<script>
+// 纯文本轻量编辑器（dev-board#37）：txt / md / markdown 不再进 LOWA WASM 引擎
+// （150MB 引擎 boot 十几秒、Writer 语义对纯文本毫无意义），改走 CodeMirror 6。
+//
+// 契约与 LOWA 编辑器（LibreOfficeEditor.vue）对齐的三件事：
+// 1. 存取走同一套通用字节接口（GET /download、POST /upload multipart）——上传成功
+//    后端 signalChange 自动接上版本记录，这里不需要任何额外接线；
+// 2. 下载失败/可疑空下载即封保存（朴素版 docLoadFailed 闸，PR#194 同款事故的预防）；
+// 3. reloadFromBackend()：版本退回/AI text_* 直改后，宿主命令就地重载，丢弃本地
+//    未保存态（版本操作以后端为准），否则下一次自动保存会把旧内容写回去。
+import { EditorState } from '@codemirror/state'
+import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } from '@codemirror/view'
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
+import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language'
+import { markdown } from '@codemirror/lang-markdown'
+import MarkdownIt from 'markdown-it'
+import { getFileDownloadUrl, getFileUploadUrl } from '@/services/api.js'
+import { getAuthHeaders } from '@/utils/auth.js'
+
+const AUTOSAVE_DELAY = 3000
+const RETRY_DELAY = 15000
+
+export default {
+  name: 'PlainTextEditor',
+  props: {
+    file: { type: Object, default: null },
+    projectId: { type: [String, Number], default: null }
+  },
+  data() {
+    return {
+      phase: 'loading',      // loading | ready | error
+      errorText: '',
+      dirty: false,
+      saving: false,
+      saveFailed: false,
+      previewMode: false,
+      previewHtml: ''
+    }
+  },
+  computed: {
+    isMarkdown() {
+      const t = this.file && this.file.fileType ? String(this.file.fileType).toLowerCase() : ''
+      return t === 'md' || t === 'markdown'
+    }
+  },
+  mounted() {
+    // 非响应式内部状态（EditorView 进响应式代理会被 Proxy 拖垮且无意义）
+    this._view = null
+    this._seq = 0              // 每次用户编辑 +1；保存完成时对账判定期间有没有新输入
+    this._saveTimer = null
+    this._retryTimer = null
+    this._applyingRemote = false
+    this._loadOk = false
+    this._md = null
+    this.boot()
+  },
+  beforeUnmount() {
+    clearTimeout(this._saveTimer)
+    clearTimeout(this._retryTimer)
+    // 标签切走/关闭时的最后防线：同步取走内容，异步发出去（组件销毁不影响 XHR）。
+    // closeFile 的显式 flushSave 分支是主路径，这里兜住"切到别的标签"这种不经
+    // closeFile 的卸载——v-if 单实例意味着切标签就是销毁。
+    if (this.dirty && !this.saving && this._loadOk && this._view) {
+      const content = this._view.state.doc.toString()
+      this.uploadContent(content).catch((e) => {
+        console.warn('[PlainTextEditor] unmount flush-save failed:', e)
+      })
+    }
+    if (this._view) { this._view.destroy(); this._view = null }
+  },
+  methods: {
+    fileRef() {
+      const f = this.file
+      if (!f) return null
+      // 数字主键优先：wpsFileId 是自由字段，撞号时后端 findFirst 会取错文件（同 DrawioEditor）
+      return f.id != null ? f.id : (f.wpsFileId || null)
+    },
+
+    async boot() {
+      this.phase = 'loading'
+      this.errorText = ''
+      this.dirty = false
+      this.saveFailed = false
+      this._loadOk = false
+      clearTimeout(this._saveTimer)
+      clearTimeout(this._retryTimer)
+      if (this._view) { this._view.destroy(); this._view = null }
+      try {
+        const text = await this.download()
+        this._loadOk = true
+        this.phase = 'ready'
+        await this.$nextTick()
+        this.mountEditor(text)
+        if (this.previewMode) this.renderPreview()
+      } catch (e) {
+        this.errorText = (e && e.message) || this.$t('editor.plainText.loadFailed')
+        this.phase = 'error'
+      }
+    },
+
+    async download() {
+      const id = this.fileRef()
+      if (!id) throw new Error(this.$t('editor.plainText.fileMissing'))
+      const res = await fetch(getFileDownloadUrl(id), { headers: getAuthHeaders() || {} })
+      if (!res.ok) throw new Error(this.$t('editor.plainText.readFailed', { status: res.status }))
+      const text = await res.text()
+      // 空下载闸（PR#194 同款）：元数据说有内容、下载却是空的——多半是网络/存储
+      // 异常，此时装载空白再自动保存等于把真文件清空。宁可报错也不冒这个险。
+      const meta = this.file && this.file.fileSize
+      if (meta > 0 && text.length === 0) {
+        throw new Error(this.$t('editor.plainText.emptyDownload'))
+      }
+      return text
+    },
+
+    mountEditor(text) {
+      const host = this.$refs.cmHost
+      if (!host) return
+      const extensions = [
+        lineNumbers(),
+        highlightActiveLine(),
+        highlightActiveLineGutter(),
+        history(),
+        keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+        EditorView.lineWrapping,
+        syntaxHighlighting(defaultHighlightStyle),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged && !this._applyingRemote) this.onUserEdit()
+        }),
+        EditorView.theme({
+          '&': { height: '100%', fontSize: '13px', backgroundColor: '#ffffff' },
+          '.cm-scroller': {
+            fontFamily: "'SF Mono', Menlo, Consolas, 'PingFang SC', 'Microsoft YaHei', monospace",
+            lineHeight: '1.7'
+          },
+          '.cm-content': { padding: '12px 0', caretColor: '#1a5336' },
+          '.cm-gutters': { backgroundColor: '#fafbfc', color: '#9aa0a8', border: 'none', borderRight: '1px solid #f0f1f3' },
+          '.cm-activeLine': { backgroundColor: 'rgba(26, 83, 54, 0.04)' },
+          '.cm-activeLineGutter': { backgroundColor: 'rgba(26, 83, 54, 0.06)' },
+          '&.cm-focused': { outline: 'none' }
+        })
+      ]
+      if (this.isMarkdown) extensions.push(markdown())
+      this._view = new EditorView({
+        state: EditorState.create({ doc: text, extensions }),
+        parent: host
+      })
+    },
+
+    onUserEdit() {
+      this._seq++
+      this.dirty = true
+      this.saveFailed = false
+      this.scheduleSave()
+    },
+
+    scheduleSave() {
+      clearTimeout(this._saveTimer)
+      this._saveTimer = setTimeout(() => { this._saveTimer = null; this.save() }, AUTOSAVE_DELAY)
+    },
+
+    getText() {
+      return this._view ? this._view.state.doc.toString() : ''
+    },
+
+    getSelectionText() {
+      if (!this._view) return ''
+      const sel = this._view.state.selection.main
+      return sel.empty ? '' : this._view.state.sliceDoc(sel.from, sel.to)
+    },
+
+    async save() {
+      if (!this._loadOk || this.phase !== 'ready' || !this._view) return false
+      if (this.saving) { this.scheduleSave(); return false }
+      const seq = this._seq
+      const content = this._view.state.doc.toString()
+      this.saving = true
+      try {
+        await this.uploadContent(content)
+        this.saveFailed = false
+        // 保存期间又有输入的话保持脏、让防抖继续跑；没有才清脏
+        if (this._seq === seq) this.dirty = false
+        else this.scheduleSave()
+        return true
+      } catch (e) {
+        console.warn('[PlainTextEditor] save failed:', e)
+        this.saveFailed = true
+        clearTimeout(this._retryTimer)
+        this._retryTimer = setTimeout(() => { this._retryTimer = null; if (this.dirty) this.save() }, RETRY_DELAY)
+        return false
+      } finally {
+        this.saving = false
+      }
+    },
+
+    uploadContent(content) {
+      const id = this.fileRef()
+      if (!id) return Promise.reject(new Error('no file id'))
+      const mime = this.isMarkdown ? 'text/markdown' : 'text/plain'
+      const blob = new Blob([content], { type: mime + ';charset=utf-8' })
+      return new Promise((resolve, reject) => {
+        const headers = getAuthHeaders() || {}
+        const form = new FormData()
+        form.append('file', blob, (this.file && this.file.name) || 'untitled.txt')
+        const xhr = new XMLHttpRequest()
+        xhr.open('POST', getFileUploadUrl(id), true)
+        xhr.timeout = 60000
+        Object.keys(headers).forEach((k) => { if (k.toLowerCase() !== 'content-type') xhr.setRequestHeader(k, headers[k]) })
+        xhr.onload = () => (xhr.status >= 200 && xhr.status < 300 ? resolve(xhr.response) : reject(new Error('HTTP ' + xhr.status)))
+        xhr.onerror = () => reject(new Error('network error'))
+        xhr.ontimeout = () => reject(new Error('timeout'))
+        xhr.send(form)
+      })
+    },
+
+    /** 关闭前落盘（closeFile 的文本分支调用）：取消防抖、等在途保存、脏则立即存。 */
+    async flushSave() {
+      clearTimeout(this._saveTimer)
+      this._saveTimer = null
+      for (let i = 0; i < 100 && this.saving; i++) {
+        await new Promise((r) => setTimeout(r, 100))
+      }
+      if (this.dirty) await this.save()
+    },
+
+    /**
+     * 后端就地改了文件之后的重载（版本退回 / 检查点恢复 / AI text_* 直改）。
+     * 丢弃本地未保存态——这条链上的动作以后端为准，保留本地脏内容等于让下一次
+     * 自动保存把操作结果冲掉（LOWA reloadFromBackend 的同款数据事故，PR#218）。
+     * 失败则转入 error 相位封死保存（画布内容已不可信），用户可点重试。
+     */
+    async reloadFromBackend() {
+      clearTimeout(this._saveTimer)
+      this._saveTimer = null
+      clearTimeout(this._retryTimer)
+      this._retryTimer = null
+      this.dirty = false
+      this.saveFailed = false
+      for (let i = 0; i < 100 && this.saving; i++) {
+        await new Promise((r) => setTimeout(r, 100))
+      }
+      try {
+        const text = await this.download()
+        if (this._view) {
+          this._applyingRemote = true
+          try {
+            this._view.dispatch({ changes: { from: 0, to: this._view.state.doc.length, insert: text } })
+          } finally {
+            this._applyingRemote = false
+          }
+        } else if (this.phase !== 'ready') {
+          // 之前就没加载成功：这次全量重走 boot
+          await this.boot()
+          return this.phase === 'ready'
+        }
+        this._seq++
+        this.dirty = false
+        if (this.previewMode) this.renderPreview()
+        return true
+      } catch (e) {
+        console.warn('[PlainTextEditor] reload failed:', e)
+        this._loadOk = false
+        this.errorText = (e && e.message) || this.$t('editor.plainText.loadFailed')
+        this.phase = 'error'
+        return false
+      }
+    },
+
+    setPreview(on) {
+      if (this.previewMode === !!on) return
+      this.previewMode = !!on
+      if (on) this.renderPreview()
+    },
+
+    renderPreview() {
+      if (!this._md) {
+        // html:false —— 渲染结果直接进 v-html，放行原始 HTML 等于存储型 XSS（同 MarkdownPreview）
+        this._md = new MarkdownIt({ html: false, linkify: true, typographer: true })
+      }
+      this.previewHtml = this._md.render(this.getText())
+    }
+  }
+}
+</script>
+
+<style scoped>
+.ptx-editor {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+}
+
+.ptx-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid #ebedf0;
+  flex-shrink: 0;
+}
+.ptx-name {
+  font-size: 12px;
+  color: #1f2329;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ptx-bar-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+.ptx-dirty { font-size: 11px; color: #8a5a2b; }
+.ptx-save-failed {
+  font-size: 11px;
+  color: #b42318;
+  border: 1px solid #f0c4bf;
+  background: #fdf3f2;
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ptx-toggle { display: flex; border: 1px solid #e3e6ea; border-radius: 5px; overflow: hidden; }
+.ptx-toggle-btn {
+  font-size: 11px;
+  padding: 3px 10px;
+  color: #4a5058;
+  background: #fff;
+  cursor: pointer;
+  user-select: none;
+}
+.ptx-toggle-btn + .ptx-toggle-btn { border-left: 1px solid #e3e6ea; }
+.ptx-toggle-btn.active { background: #e6f9f0; color: #1a5336; }
+
+.ptx-cm-host {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+/* CodeMirror 根元素在 scoped 之外（运行时插入），穿透设置高度 */
+.ptx-cm-host :deep(.cm-editor) { height: 100%; }
+
+.ptx-preview {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.ptx-status {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 40px;
+}
+.ptx-status-text { font-size: 13px; color: #4a5058; text-align: center; }
+.ptx-btn {
+  padding: 6px 16px;
+  font-size: 12px;
+  border-radius: 5px;
+  border: 1px solid #e3e6ea;
+  color: #4a5058;
+  background: #fff;
+  cursor: pointer;
+  user-select: none;
+}
+.ptx-btn:hover { border-color: #c9ced6; background: #fafbfc; }
+
+/* Markdown 预览排版：与 MarkdownPreview.vue 同一视觉词汇 */
+.markdown-body {
+  font-size: 14px;
+  line-height: 1.7;
+  color: #2c2c2c;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  user-select: text;
+  -webkit-user-select: text;
+}
+.markdown-body :deep(h1),
+.markdown-body :deep(h2),
+.markdown-body :deep(h3) {
+  margin-top: 16px;
+  margin-bottom: 8px;
+  font-weight: 600;
+  color: #1a5336;
+}
+.markdown-body :deep(h1) { font-size: 20px; border-bottom: 1px solid #e9ecef; padding-bottom: 8px; }
+.markdown-body :deep(h2) { font-size: 17px; }
+.markdown-body :deep(h3) { font-size: 15px; }
+.markdown-body :deep(p) { margin: 8px 0; }
+.markdown-body :deep(ul),
+.markdown-body :deep(ol) { padding-left: 20px; }
+.markdown-body :deep(li) { margin: 4px 0; }
+.markdown-body :deep(code) {
+  background: #f5f5f5;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: 'Menlo', 'Monaco', monospace;
+  font-size: 13px;
+}
+.markdown-body :deep(pre) { background: #f9f9f9; padding: 12px; border-radius: 6px; overflow-x: auto; margin: 12px 0; }
+.markdown-body :deep(pre code) { background: none; padding: 0; }
+.markdown-body :deep(blockquote) {
+  border-left: 3px solid #1a5336;
+  padding-left: 12px;
+  margin: 12px 0;
+  color: #666;
+  font-style: italic;
+}
+.markdown-body :deep(table) { width: 100%; border-collapse: collapse; margin: 12px 0; }
+.markdown-body :deep(th),
+.markdown-body :deep(td) { border: 1px solid #e9ecef; padding: 8px 12px; text-align: left; }
+.markdown-body :deep(th) { background: #f5f5f5; font-weight: 600; }
+</style>

--- a/frontend/src/locales/en-US/editor.js
+++ b/frontend/src/locales/en-US/editor.js
@@ -142,6 +142,19 @@ export default {
     installPackRetry: 'Install failed, retry',
     installPackFailed: 'Installation failed',
   },
+  // Lightweight plain-text editor (PlainTextEditor.vue, dev-board#37)
+  plainText: {
+    opening: 'Opening the text editor…',
+    loadFailed: 'Failed to read the file',
+    readFailed: 'Failed to read the file ({status})',
+    fileMissing: 'File not found',
+    emptyDownload: 'Downloaded content is empty; editing is disabled to protect the real file. Please retry.',
+    retry: 'Retry',
+    edit: 'Edit',
+    preview: 'Preview',
+    unsaved: 'Unsaved',
+    saveFailedRetry: 'Save failed - tap to retry',
+  },
   // Self-built toolbar (EditorToolbar.vue): tooltips, dropdowns and the find bar.
   toolbar: {
     undo: 'Undo (Cmd/Ctrl+Z)',

--- a/frontend/src/locales/zh-CN/editor.js
+++ b/frontend/src/locales/zh-CN/editor.js
@@ -142,6 +142,19 @@ export default {
     installPackRetry: '安装失败，重试',
     installPackFailed: '安装失败',
   },
+  // 纯文本轻量编辑器（PlainTextEditor.vue，dev-board#37）
+  plainText: {
+    opening: '正在打开文本编辑器…',
+    loadFailed: '读取文件失败',
+    readFailed: '读取文件失败（{status}）',
+    fileMissing: '文件不存在',
+    emptyDownload: '文件内容下载为空，为防覆盖真实内容已禁止编辑，请重试',
+    retry: '重试',
+    edit: '编辑',
+    preview: '预览',
+    unsaved: '未保存',
+    saveFailedRetry: '保存失败，点击重试',
+  },
   // 自建工具栏（EditorToolbar.vue）。工具提示、下拉与查找替换条的全部可见文案。
   toolbar: {
     undo: '撤销 (Cmd/Ctrl+Z)',

--- a/frontend/src/pages/project-overview/agentClientActions.js
+++ b/frontend/src/pages/project-overview/agentClientActions.js
@@ -32,6 +32,11 @@ export const agentClientActionMethods = {
         else if (action.action === 'doc_reload_file' || action.action === 'wps_reload_file') {
             this.handleEditorReloadFile(action)
         }
+        // AI 后端直改了纯文本文件（text_write_file / text_find_replace，dev-board#37）：
+        // 刷新打开中的文本标签。单名新契约，无 wps_* 旧名双轨。
+        else if (action.action === 'text_reload_file') {
+            this.handleTextReloadFile(action)
+        }
         // AI Agent 请求执行编辑器命令
         else if (action.tool === 'editor_command' || action.tool === 'wps_command') {
             // 特殊处理同步打开命令（新建文件流式写入）
@@ -333,6 +338,27 @@ export const agentClientActionMethods = {
             console.error('[ProjectOverview] handleEditorReloadFile error:', e)
             uni.showToast({ title: this.$t('workbenchOps.refreshFileFailed'), icon: 'none' })
             return false
+        }
+    },
+
+    /**
+     * AI text_* 工具后端直改纯文本文件后的前端刷新（text_reload_file）。
+     * 与 handleEditorReloadFile 的分工：那条链服务 LOWA 保活池（逐 LRU、强刷活动
+     * 实例），文本编辑器是 v-if 单实例——只有"正激活显示"的标签有组件，就地重载
+     * 它（丢弃本地未保存态，AI 刚写进后端的才是权威版本）；未打开/未激活的什么都
+     * 不做（下次挂载自然拉新内容），也不把文件硬拉出来打开。
+     */
+    async handleTextReloadFile(action) {
+        try {
+            const fileId = action.fileId
+            if (!fileId) return
+            await this.reloadPlainTextInstances(fileId)
+            // 文件大小/修改时间变了，树上的元数据跟着刷
+            if (this.$refs.fileTree && this.$refs.fileTree.loadFiles) {
+                this.$refs.fileTree.loadFiles()
+            }
+        } catch (e) {
+            console.warn('[ProjectOverview] handleTextReloadFile error:', e)
         }
     },
 

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -6,6 +6,11 @@ import { getProjectFiles } from '@/services/api.js'
 import { activityTracker } from '@/utils/activityTracker.js'
 import { ICONS as GLYPHS, fileGlyph } from '@/config/icons.js'
 
+// 轻量文本编辑器（PlainTextEditor.vue）承接的扩展名（dev-board#37）。
+// 写成表便于日后扩展 json/js 等；当前刻意只收 txt/md/markdown——其它文本类
+// 扩展名仍走 FilePreview，不要顺手加。
+const PLAIN_TEXT_TYPES = ['txt', 'md', 'markdown']
+
 export const fileOpenTabsMethods = {
     handleFileTreeSelect(file) {
       if (!file || file.isFolder) return
@@ -249,6 +254,16 @@ export const fileOpenTabsMethods = {
         idx = list.findIndex(f => f.id === fileId)
         if (idx === -1) return
       }
+      // 文本标签（PlainTextEditor）的平行分支：v-if 单实例，只有"正激活显示"的
+      // 标签才有组件实例；非激活标签在切走时已由组件 beforeUnmount 兜底落盘。
+      else if (file && this.isPlainTextFile(file)) {
+        const inst = (this._plainTextRefs || {})[pane]
+        if (inst && inst.file && inst.file.id === fileId && (inst.dirty || inst.saving)) {
+          try { await inst.flushSave() } catch (e) { console.warn('[ProjectOverview] close flush-save (text) failed:', e) }
+        }
+        idx = list.findIndex(f => f.id === fileId)
+        if (idx === -1) return
+      }
       // 浏览器标签：BrowserPane 卸载时只把 BrowserView 摘下（保活，为的是切标签
       // 不丢网页内容），真正销毁只发生在标签关闭——也就是这里，以及页面卸载。
       // 跨窗格拖拽是「在另一侧也打开同一个标签」（同 id 双开，见 tabDragSplit），
@@ -347,8 +362,10 @@ export const fileOpenTabsMethods = {
       const externalSourceTypes = ['drawio', 'vsdx', 'vsd']
       if (externalSourceTypes.includes(type)) return false
 
-      // 2. 排除 Markdown 文件，使用专门的 Markdown 预览组件
-      if (type === 'md' || type === 'markdown') return false
+      // 2. 纯文本走轻量文本编辑器（PlainTextEditor.vue，dev-board#37），不进 LOWA。
+      // 必须排在下面 wpsFileId 兜底之前——上传的 txt 都被 FileTree 合成了 wpsFileId，
+      // 不拦就会被兜底分支判成"可编辑"送进 150MB 的 WASM 引擎。
+      if (PLAIN_TEXT_TYPES.includes(type)) return false
 
       // 3. Office 文档格式 —— 仅限自建 LOWA 引擎真正编入的模块（probe_modules
       // 实测：r3 起仅 Writer + Calc；Impress/Draw 随 r4 引擎补齐——见
@@ -367,8 +384,8 @@ export const fileOpenTabsMethods = {
           'pptx', 'ppt', 'pptm', 'potx', 'odp'
       ]
 
-      // Office 类型或带文件 ID（非媒体/markdown）即视为文档编辑器可打开
-      return wpsFormats.includes(type) || (file.wpsFileId && !mediaTypes.includes(type) && type !== 'md' && type !== 'markdown')
+      // Office 类型或带文件 ID（非媒体，纯文本已在上面拦下）即视为文档编辑器可打开
+      return wpsFormats.includes(type) || (file.wpsFileId && !mediaTypes.includes(type))
     },
 
     // Epic #43 Track B / #79: should this Office file open in the embedded
@@ -379,6 +396,43 @@ export const fileOpenTabsMethods = {
       return this.libreOfficePreferred && this.isEditorOpenableFile(file)
     },
 
+    // 纯文本文件（txt/md/markdown）走轻量文本编辑器（PlainTextEditor.vue，dev-board#37）。
+    // tabType 有值的都是虚拟标签（web/markdown/diff…），不归这里。
+    isPlainTextFile(file) {
+      if (!file || file.tabType || file.isFolder || !file.fileType) return false
+      return PLAIN_TEXT_TYPES.includes(file.fileType.toLowerCase())
+    },
+
+    // PlainTextEditor 实例登记（v-if 单实例，每窗格至多一个；对齐 _libreRefs 的
+    // 非响应式口径）。closeFile 落盘、版本重载、AI text_reload_file 都从这里取实例。
+    setPlainTextRef(pane, el) {
+      if (!this._plainTextRefs) this._plainTextRefs = {}
+      if (el) this._plainTextRefs[pane] = el
+      else delete this._plainTextRefs[pane]
+    },
+
+    /**
+     * 让正在显示 fileId 的文本编辑器实例就地重载（版本退回 / AI text_* 直改后调用）。
+     * 未激活的文本标签没有组件实例（v-if 单实例，切走即销毁），下次激活时挂载
+     * 自然拉取新内容，无需处理。返回是否全部成功（没有命中的实例也算成功）。
+     */
+    async reloadPlainTextInstances(fileId) {
+      let ok = true
+      for (const pane of ['left', 'right']) {
+        const inst = (this._plainTextRefs || {})[pane]
+        if (inst && inst.file && inst.file.id === fileId) {
+          try {
+            const r = await inst.reloadFromBackend()
+            if (!r) ok = false
+          } catch (e) {
+            console.warn('[ProjectOverview] plain text reload failed:', e)
+            ok = false
+          }
+        }
+      }
+      return ok
+    },
+
     // .drawio 走内嵌 draw.io 编辑器（DrawioEditor.vue）。诉讼可视化出的四份产物里
     // 它是唯一的「可继续编辑版」——没有这条分支它就会落进 FilePreview 的
     // 「暂不支持预览」兜底，等于这个格式白出了。
@@ -387,14 +441,10 @@ export const fileOpenTabsMethods = {
       return file.fileType.toLowerCase() === 'drawio'
     },
 
-    // Check if file is a markdown tab (for AI artifacts or real .md files)
+    // AI 虚拟 markdown 产物标签（tabType='markdown'，无真实 fileId）才走只读
+    // MarkdownPreview；真正的 .md 文件自 dev-board#37 起走 PlainTextEditor（可编辑）。
     isMarkdownTab(file) {
-      if (!file) return false
-      // 1. AI 创建的虚拟 markdown 标签
-      if (file.tabType === 'markdown') return true
-      // 2. 真正的 .md 文件（从文件树打开）
-      if (file.fileType && (file.fileType.toLowerCase() === 'md' || file.fileType.toLowerCase() === 'markdown')) return true
-      return false
+      return !!(file && file.tabType === 'markdown')
     },
 
     isDiffTab(file) {
@@ -552,6 +602,15 @@ export const fileOpenTabsMethods = {
       // 失败的那几份各自已经报过（静音只吞成功提示），这里只汇报成功的份数。
       if (many && ok) {
         uni.showToast({ title: this.$t('workbenchOps.updatedOpenFiles', { count: ok }), icon: 'success' })
+      }
+
+      // 文本标签（PlainTextEditor）的平行分支：正在显示的实例必须就地重载并丢弃
+      // 本地未保存态（版本操作以后端为准），否则画面不变、下一次自动保存还会把
+      // 退回前的旧内容写回去——与上面 forceActive 是同一类数据事故。未激活的文本
+      // 标签没有实例（v-if 单实例），下次激活挂载即拉新内容。失败时组件自己转入
+      // 错误相位并封死保存，这里不再叠加提示。
+      for (const fileId of idSet) {
+        await this.reloadPlainTextInstances(fileId)
       }
     },
 }

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -869,6 +869,15 @@
                       :content="activeFileLeft.content"
                       :file="activeFileLeft"
                     />
+                    <!-- 纯文本（txt/md/markdown）：轻量文本编辑器，不进 LOWA
+                         （dev-board#37）。v-if 单实例，切标签销毁重建，无保活池。 -->
+                    <PlainTextEditor
+                      v-else-if="isPlainTextFile(activeFileLeft)"
+                      :key="'ptx-left-' + activeFileLeft.id"
+                      :ref="el => setPlainTextRef('left', el)"
+                      :file="activeFileLeft"
+                      :project-id="projectId"
+                    />
                     <DocDiffViewer
                       v-else-if="isDiffTab(activeFileLeft)"
                       :source-id="activeFileLeft.diffSource.id"
@@ -981,6 +990,14 @@
                       v-if="isMarkdownTab(activeFileRight)"
                       :content="activeFileRight.content"
                       :file="activeFileRight"
+                    />
+                    <!-- 纯文本轻量编辑器：见左窗格同名注释 -->
+                    <PlainTextEditor
+                      v-else-if="isPlainTextFile(activeFileRight)"
+                      :key="'ptx-right-' + activeFileRight.id"
+                      :ref="el => setPlainTextRef('right', el)"
+                      :file="activeFileRight"
+                      :project-id="projectId"
                     />
                     <DocDiffViewer
                       v-else-if="isDiffTab(activeFileRight)"
@@ -1534,6 +1551,7 @@ import FileLinkDropZone from '@/components/FileLinkDropZone.vue'
 import FileStagingArea from '@/components/FileStagingArea.vue'
 import PluginPane from '@/components/PluginPane.vue' // Added
 import DrawioEditor from '@/components/DrawioEditor.vue'
+import PlainTextEditor from '@/components/PlainTextEditor.vue'
 // 插件广场 VS Code 形态：左栏列表面板 + 中栏详情 tab（整页 MarketPane 仅存于 admin 独立页）
 import MarketSidebarPanel from '@/components/MarketSidebarPanel.vue'
 import MarketDetailPane from '@/components/MarketDetailPane.vue'
@@ -1660,6 +1678,7 @@ export default {
     MarkdownPreview,
     PluginPane, // Added
     DrawioEditor,
+    PlainTextEditor,
     MarketSidebarPanel,
     MarketDetailPane,
     ProjectHomePane,
@@ -4538,6 +4557,12 @@ export default {
         candidate = this.activeFileLeft || this.activeFileRight || null
       }
       if (!candidate) return null
+      // 纯文本标签（PlainTextEditor）也是合法的 AI 目标：后端按 fileType 走
+      // text_* 工具口径（dev-board#37）。不放行的话，用户盯着一份 txt 问 AI，
+      // 上下文里却没有这份文件。
+      if (typeof this.isPlainTextFile === 'function' && this.isPlainTextFile(candidate)) {
+        return candidate
+      }
       if (typeof this.isEditorOpenableFile === 'function' && !this.isEditorOpenableFile(candidate)) {
         return null
       }
@@ -4634,7 +4659,20 @@ export default {
              }
         }
 
-        if (useEditor && this.libreOfficeActive && this.libreOfficeExecutor) {
+        // 纯文本标签：正文/选区直接从 CodeMirror 实例取（拿到的是含未保存输入的
+        // 活内容）。不能落进下面的 LOWA 分支——executor 指着的是别的文档，会把
+        // 那份 docx 的正文错标成这份 txt 的内容。
+        if (useEditor && this.isPlainTextFile(file)) {
+            for (const pane of ['left', 'right']) {
+                const inst = (this._plainTextRefs || {})[pane]
+                if (inst && inst.file && inst.file.id === (file.id || file.fileId)) {
+                    context.selectionText = this.normalizeContextText(inst.getSelectionText(), 1500)
+                    context.documentText = this.normalizeContextText(inst.getText(), 8000)
+                    break
+                }
+            }
+        }
+        else if (useEditor && this.useLibreEditor(file) && this.libreOfficeActive && this.libreOfficeExecutor) {
             try {
                  const sel = await this.libreOfficeExecutor.executeCommand('get_selection', {})
                  context.selectionText = this.normalizeContextText((sel && sel.text) || '', 1500)

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -37,6 +37,9 @@ const NAMES = {
   list_files: { zh: '列出文件', en: 'List files' },
   write_file: { zh: '写入文件', en: 'Write file' },
   write_docx: { zh: '生成Word文档', en: 'Create Word doc' },
+  // 纯文本直读直写（TextFileEditTools，dev-board#37）
+  text_write_file: { zh: '写入文本文件', en: 'Write text file' },
+  text_find_replace: { zh: '文本查找替换', en: 'Text find and replace' },
   scan_files: { zh: '扫描项目文件', en: 'Scan files' },
   delete_file: { zh: '删除文件', en: 'Delete file' },
   move_file: { zh: '移动文件', en: 'Move file' },


### PR DESCRIPTION
关联 dev-board#37（用户反馈 7）：txt/md 用 LibreOffice WASM 打开是杀鸡用牛刀——150MB 引擎冷启动十几秒，Writer 语义对纯文本毫无意义。本 PR 让 txt/md/markdown 走 CodeMirror 6 轻量文本编辑器，秒开可编辑，并补齐 AI 侧改纯文本的能力（此前 md 本来就改不了，txt 移出 LOWA 后也会回退）。

## 方案摘要

**前端编辑器**
- 新组件 `PlainTextEditor.vue`（CodeMirror 6，@codemirror/state|view|commands|language|lang-markdown）：行号、自动换行、浅色主题；md 启用语法高亮 + 「编辑/预览」切换（markdown-it 渲染，html:false 防 XSS）；3s 防抖自动保存，走通用 `GET /download` / `POST /upload`（multipart）——upload 成功后端 signalChange 自动接上版本记录，零额外接线；下载失败或「fileSize>0 却空下载」即封保存（PR#194 同款事故的朴素预防）；保存失败红字提示 + 点击重试 + 15s 自动重试。
- 分流：`fileOpenTabs.js` 新增 `PLAIN_TEXT_TYPES = ['txt','md','markdown']` 排除表 + `isPlainTextFile()`，判定排在 wpsFileId 兜底**之前**（txt 误入 LOWA 的根因就是这条兜底）。本次刻意只切这三种扩展名，json/js 等留扩展位不动。
- 生命周期：v-if 单实例（无保活池），切标签由 `beforeUnmount` 兜底落盘，`closeFile` 加文本 flush 平行分支；`onVersionReloadFiles` 加文本重载分支——版本退回后正显示的实例就地 `reloadFromBackend()` 丢弃本地未保存态，否则画面不变、下次 autosave 把退回冲掉（数据事故预防，与 LOWA forceActive 同口径）。
- `isMarkdownTab` 收窄为只认 AI 虚拟 markdown 产物（tabType==='markdown'）；真 `.md` 文件从只读预览升级为可编辑。

**AI 兼容（后端直读直写，绕开编辑器桥）**
- 新工具 `TextFileEditTools`：`text_write_file`（整篇覆盖）、`text_find_replace`（字面量替换，replaceAll 可选，返回命中数）。StorageService 读写（UTF-8 直读直写，不走 Tika）+ 回写 fileSize/updatedAt + `WorkSessionService.onChangeSignal`（与 FileController.uploadFile 同款版本信号）+ 单向 SSE `text_reload_file`（单名，无 wps_* 双轨）。按扩展名校验，docx/xlsx/pptx 拒绝并指回 doc_*/sheet_*/slide_*；跨项目被 ToolFileGuard 挡住；>5MB 熔断。
- 前端 `agentClientActions.js` 加 `text_reload_file` 分支：正开着的文本标签就地重载，没开不硬拉。
- `ContextAssemblerService.lowaDocKind` 新增 `"text"` 分支：active-document 指引、末位提醒、readHint 三处（中英文各一套）指向 extract_file_text + text_*，禁止对纯文本调 doc_*；`doc_open_file` 对纯文本返回指路错误。
- AI 上下文：纯文本标签成为合法 AI 目标（`getActiveAiTargetFile`），正文/选区直接取自 CodeMirror 活内容——顺带修了一个串台隐患：此前 txt 聚焦时若 LOWA executor 指着别的 docx，会把那份文档的正文错标成 txt 的内容。
- 能力过滤**刻意不收** text_ 前缀：纯后端执行工具（无客户端执行器依赖，SSE 刷新 fire-and-forget），按 ClientCapabilityService 既有语义对所有能力档位可见（与 extract_file_text 同口径）；已在 javadoc 与 ai-doc-bridge.md 记录该决策。

**文档**：`.claude/agents/doc-editor.md` 新增「纯文本分流」节、`ai-doc-bridge.md` 新增「text_* 原语」节。

## 测试结果

- 后端：新增 `TextFileEditToolsTest` 6 用例（命中替换落盘/只替第一处/未命中不写盘/非文本拒绝并指路/写入触发版本信号与刷新/跨项目拒绝）全绿；`mvn test` 全量 **2007 用例 1 失败→修复后全绿**（失败是 EvalToolBeanParityTest 抓到 TextFileEditTools 漏进 RealToolBeans，已补——这条护栏工作正常）；ContextAssemblerServiceTest 26、ToolDisplayNameCoverageTest（241 工具对账）、ToolRegistryCapabilityFilterTest 全绿。
- 前端：`check:emits`（91 个 .vue）/ `check:locales`（20 命名空间）/ `check:nav` 全过；`npm run build:h5` 完整构建通过（CodeMirror 引入无告警）。
- LOWA 回归：`npm run test:lowa-e2e` 真引擎（LOWA_ENGINE_DIR 借本机既有 r4 引擎，glue 用本树构建产物）**391 步全绿**——docx/xlsx/pptx 既有链路不受分流改动影响。

## 手工验证矩阵（发版前走查）

| 场景 | 预期 |
|---|---|
| 文件树打开 .txt | 秒开 CodeMirror（不再是 LOWA 加载卡） |
| 编辑后停 3s | 自动保存；版本面板出现变更记录 |
| 关闭有未保存修改的文本标签 | 关闭前落盘，重开内容在 |
| 打开 .md | 语法高亮；「编辑/预览」切换正常 |
| 版本退回（文本文件开着） | 画面就地刷新为退回后内容，随后不被 autosave 冲掉 |
| AI「把这份 txt 里的 X 改成 Y」 | 走 text_find_replace，打开中的标签自动刷新 |
| docx 打开/编辑/自动保存 | LOWA 行为不变（e2e 391 步已锁） |
| .drawio / .vsdx | 分流不回归（drawio 编辑器 / 下载兜底） |
| 断网时编辑 txt | 「保存失败，点击重试」出现，恢复后重试成功 |

## 风险与边界

- AI 直改与用户正在输入同时发生时，text_reload_file 会丢弃用户未保存的几秒输入（后端为权威）；版本记录兜底可找回。
- 纯文本无修订机制：安全网是版本记录（每次写入发 onChangeSignal）+ 检查点。
- 只切 txt/md/markdown；json/js/py 等仍走 FilePreview（刻意，留扩展位）。
- h5（Web 态）同样生效：txt/md 从 FilePreview/只读预览升级为可编辑，无桌面依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
