### PR TITLE
fix(sidebar-shell): 工作台「记录工作」浅色化 toast + 活动日志结构化绑定项目

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ActivityLogController.java
+++ b/backend/src/main/java/com/checkba/controller/ActivityLogController.java
@@ -34,7 +34,8 @@ public class ActivityLogController {
                 request.getTargetId(),
                 request.getTargetName(),
                 request.getDuration(),
-                request.getMetaInfo()
+                request.getMetaInfo(),
+                request.getProjectId()
         );
 
         Map<String, Object> result = new HashMap<>();
@@ -66,6 +67,7 @@ public class ActivityLogController {
         private String targetName;
         private Long duration;
         private String metaInfo;
+        private Long projectId;
 
         public String getActionType() { return actionType; }
         public void setActionType(String actionType) { this.actionType = actionType; }
@@ -77,5 +79,7 @@ public class ActivityLogController {
         public void setDuration(Long duration) { this.duration = duration; }
         public String getMetaInfo() { return metaInfo; }
         public void setMetaInfo(String metaInfo) { this.metaInfo = metaInfo; }
+        public Long getProjectId() { return projectId; }
+        public void setProjectId(Long projectId) { this.projectId = projectId; }
     }
 }

--- a/backend/src/main/java/com/checkba/model/entity/UserActivityLog.java
+++ b/backend/src/main/java/com/checkba/model/entity/UserActivityLog.java
@@ -48,6 +48,18 @@ public class UserActivityLog {
     private String targetName;
 
     /**
+     * 结构化项目归属。可为空——老数据没有这一列，前端归类为「未关联项目」。
+     */
+    @Column(name = "project_id")
+    private Long projectId;
+
+    /**
+     * 项目名，按 projectId 批量查 Project 表回填，不落库。
+     */
+    @Transient
+    private String projectName;
+
+    /**
      * 发生时间
      */
     @CreationTimestamp
@@ -108,6 +120,22 @@ public class UserActivityLog {
 
     public void setTargetName(String targetName) {
         this.targetName = targetName;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
     }
 
     public LocalDateTime getTimestamp() {

--- a/backend/src/main/java/com/checkba/service/UserActivityLogService.java
+++ b/backend/src/main/java/com/checkba/service/UserActivityLogService.java
@@ -1,19 +1,24 @@
 package com.checkba.service;
 
+import com.checkba.model.entity.Project;
 import com.checkba.model.entity.UserActivityLog;
+import com.checkba.repository.ProjectRepository;
 import com.checkba.repository.UserActivityLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class UserActivityLogService {
 
     private final UserActivityLogRepository repository;
+    private final ProjectRepository projectRepository;
 
-    public void logActivity(Long userId, String actionType, Long targetId, String targetName, Long duration, String metaInfo) {
+    public void logActivity(Long userId, String actionType, Long targetId, String targetName, Long duration, String metaInfo, Long projectId) {
         UserActivityLog log = new UserActivityLog();
         log.setUserId(userId);
         log.setActionType(actionType);
@@ -21,10 +26,31 @@ public class UserActivityLogService {
         log.setTargetName(targetName);
         log.setDuration(duration);
         log.setMetaInfo(metaInfo);
+        log.setProjectId(projectId);
         repository.save(log);
     }
 
+    // 按 projectId 批量补 projectName（一次 IN 查询，不逐条查）；查不到的（项目已删除）
+    // 与老数据没有 projectId 的，projectName 都留空，前端归到「未关联项目」。
     public List<UserActivityLog> getUserLogs(Long userId) {
-        return repository.findTop500ByUserIdOrderByTimestampDesc(userId);
+        List<UserActivityLog> logs = repository.findTop500ByUserIdOrderByTimestampDesc(userId);
+
+        List<Long> projectIds = logs.stream()
+                .map(UserActivityLog::getProjectId)
+                .filter(id -> id != null)
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (!projectIds.isEmpty()) {
+            Map<Long, String> nameById = projectRepository.findAllById(projectIds).stream()
+                    .collect(Collectors.toMap(Project::getId, Project::getName));
+            logs.forEach(log -> {
+                if (log.getProjectId() != null) {
+                    log.setProjectName(nameById.get(log.getProjectId()));
+                }
+            });
+        }
+
+        return logs;
     }
 }

--- a/backend/src/test/java/com/checkba/service/UserActivityLogServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/UserActivityLogServiceTest.java
@@ -1,0 +1,109 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.UserActivityLog;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.UserActivityLogRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * logActivity 落库带 projectId；getUserLogs 按 projectId 批量补 projectName，
+ * 老数据（无 projectId）与项目已删除（IN 查不到）都不炸、都留空。
+ */
+@ExtendWith(MockitoExtension.class)
+class UserActivityLogServiceTest {
+
+    private static final Long USER = 1L;
+
+    @Mock private UserActivityLogRepository repository;
+    @Mock private ProjectRepository projectRepository;
+
+    @InjectMocks private UserActivityLogService service;
+
+    private Project project(long id, String name) {
+        Project p = new Project();
+        p.setId(id);
+        p.setName(name);
+        return p;
+    }
+
+    private UserActivityLog log(Long projectId) {
+        UserActivityLog l = new UserActivityLog();
+        l.setUserId(USER);
+        l.setProjectId(projectId);
+        return l;
+    }
+
+    @Test
+    void logActivityPersistsProjectId() {
+        service.logActivity(USER, "OPEN_FILE", 10L, "合同.docx", 5000L, "meta", 88L);
+
+        ArgumentCaptor<UserActivityLog> captor = ArgumentCaptor.forClass(UserActivityLog.class);
+        verify(repository).save(captor.capture());
+        assertEquals(88L, captor.getValue().getProjectId());
+    }
+
+    @Test
+    void logActivityAllowsNullProjectId() {
+        service.logActivity(USER, "OPEN_FILE", 10L, "合同.docx", 5000L, "meta", null);
+
+        ArgumentCaptor<UserActivityLog> captor = ArgumentCaptor.forClass(UserActivityLog.class);
+        verify(repository).save(captor.capture());
+        assertNull(captor.getValue().getProjectId());
+    }
+
+    @Test
+    void getUserLogsFillsProjectNameByBatchQuery() {
+        UserActivityLog withProject = log(5L);
+        when(repository.findTop500ByUserIdOrderByTimestampDesc(USER))
+                .thenReturn(Arrays.asList(withProject));
+        when(projectRepository.findAllById(anyList()))
+                .thenReturn(Arrays.asList(project(5L, "并购项目")));
+
+        List<UserActivityLog> logs = service.getUserLogs(USER);
+
+        assertEquals("并购项目", logs.get(0).getProjectName());
+    }
+
+    @Test
+    void getUserLogsLeavesNameNullWhenProjectIdMissingOrDeleted() {
+        UserActivityLog legacy = log(null); // 老数据，从未写过 projectId
+        UserActivityLog deletedProject = log(999L); // 项目已删除，IN 查不到
+
+        when(repository.findTop500ByUserIdOrderByTimestampDesc(USER))
+                .thenReturn(Arrays.asList(legacy, deletedProject));
+        when(projectRepository.findAllById(anyList()))
+                .thenReturn(Collections.emptyList());
+
+        List<UserActivityLog> logs = service.getUserLogs(USER);
+
+        assertNull(logs.get(0).getProjectName());
+        assertNull(logs.get(1).getProjectName());
+    }
+
+    @Test
+    void getUserLogsSkipsProjectQueryWhenNoProjectIds() {
+        when(repository.findTop500ByUserIdOrderByTimestampDesc(USER))
+                .thenReturn(Arrays.asList(log(null)));
+
+        service.getUserLogs(USER);
+
+        verify(projectRepository, org.mockito.Mockito.never()).findAllById(any());
+    }
+}

--- a/frontend/src/components/userprofile/PersonalWorkLogPanel.vue
+++ b/frontend/src/components/userprofile/PersonalWorkLogPanel.vue
@@ -11,7 +11,12 @@
   <view class="panel-work-log">
     <view class="log-filter-bar">
       <input class="filter-input" v-model="activityFilter.date" :placeholder="$t('account.filterDatePlaceholder')" />
-      <input class="filter-input" v-model="activityFilter.project" :placeholder="$t('account.projectNameLabel')" />
+      <AwdSelect
+        class="filter-project-select"
+        :range="projectFilterLabels"
+        :value="projectFilterIndex"
+        @change="onProjectFilterChange"
+      />
       <input class="filter-input" v-model="activityFilter.content" :placeholder="$t('account.filterContentPlaceholder')" />
       <button class="btn-export" @tap="exportLogsToExcel">{{ $t('account.exportExcelBtn') }}</button>
     </view>
@@ -30,7 +35,7 @@
       <view v-else-if="getFilteredLogs().length === 0" class="empty-row">{{ $t('account.noRecords') }}</view>
       <scroll-view v-else scroll-y class="log-table-body">
         <view v-for="log in getFilteredLogs()" :key="log.id" class="log-table-row">
-          <text class="td td-project" :title="getLogProject(log)">{{ getLogProject(log) }}</text>
+          <text class="td td-project" :title="getLogProject(log)"><text class="project-badge">{{ getLogProject(log) }}</text></text>
           <text class="td td-action">{{ log.actionType }}</text>
           <text class="td td-object" :title="getLogObject(log)">{{ getLogObject(log) }}</text>
           <text class="td td-start">{{ getLogStartTime(log) }}</text>
@@ -45,24 +50,60 @@
 
 <script>
 import { getUserActivityHistory } from '@/services/api.js'
+import AwdSelect from '@/components/AwdSelect.vue'
 
 export default {
   name: 'PersonalWorkLogPanel',
+  components: { AwdSelect },
   data() {
     return {
       activityLogs: [],
       activityLoading: false,
       activityFilter: {
         date: '',
-        project: '',
         content: '',
       },
+      // 'all' | 'unassociated' | 项目 id 的字符串形式
+      projectFilterKey: 'all',
     }
+  },
+  computed: {
+    // 从当前记录里去重出的项目筛选项：全部 + 各项目 + 未关联项目（只在存在时才出现）
+    projectFilterOptions() {
+      const options = [{ key: 'all', label: this.$t('account.allProjectsOption') }]
+      const seen = new Map()
+      let hasUnassociated = false
+      this.activityLogs.forEach(log => {
+        if (log.projectId) {
+          if (!seen.has(log.projectId)) {
+            seen.set(log.projectId, log.projectName || this.$t('account.unassociatedProjectOption'))
+          }
+        } else {
+          hasUnassociated = true
+        }
+      })
+      seen.forEach((label, id) => options.push({ key: String(id), label }))
+      if (hasUnassociated) {
+        options.push({ key: 'unassociated', label: this.$t('account.unassociatedProjectOption') })
+      }
+      return options
+    },
+    projectFilterLabels() {
+      return this.projectFilterOptions.map(o => o.label)
+    },
+    projectFilterIndex() {
+      const idx = this.projectFilterOptions.findIndex(o => o.key === this.projectFilterKey)
+      return idx >= 0 ? idx : 0
+    },
   },
   mounted() {
     this.loadActivityLogs()
   },
   methods: {
+    onProjectFilterChange(index) {
+      const option = this.projectFilterOptions[index]
+      this.projectFilterKey = option ? option.key : 'all'
+    },
     async loadActivityLogs() {
       this.activityLoading = true
       try {
@@ -77,18 +118,28 @@ export default {
     getFilteredLogs() {
       return this.activityLogs.filter(log => {
         const dateMatch = !this.activityFilter.date || this.formatTime(log.timestamp).includes(this.activityFilter.date)
-        const projectMatch = !this.activityFilter.project || (log.targetName && log.targetName.includes(this.activityFilter.project))
         const contentMatch = !this.activityFilter.content || (log.metaInfo && log.metaInfo.includes(this.activityFilter.content))
+        let projectMatch = true
+        if (this.projectFilterKey === 'unassociated') {
+          projectMatch = !log.projectId
+        } else if (this.projectFilterKey !== 'all') {
+          projectMatch = String(log.projectId) === this.projectFilterKey
+        }
         return dateMatch && projectMatch && contentMatch
       })
     },
     getLogProject(log) {
+      // 结构化项目归属优先；projectId 有值但查不到名字（项目已删除）归「未关联项目」
+      if (log.projectId) {
+        return log.projectName || this.$t('account.unassociatedProjectOption')
+      }
+      // 老数据没有 projectId，兼容旧的 metaInfo 自由文本 "Project: 名称"
       if (log.metaInfo && log.metaInfo.includes('Project:')) {
         const match = log.metaInfo.match(/Project:\s*([^,;]+)/)
         if (match) return match[1]
       }
-      if (log.actionType === 'WORK') return log.targetName
-      return '-'
+      if (log.actionType === 'WORK' && log.targetName) return log.targetName
+      return this.$t('account.unassociatedProjectOption')
     },
     getLogObject(log) {
       if (log.actionType === 'OPEN_FILE' || log.actionType === 'CLOSE_FILE') return log.targetName
@@ -216,6 +267,10 @@ $brand-dark: #212629;
   font-size: 13px;
 }
 
+.filter-project-select {
+  flex: 1;
+}
+
 .btn-export {
   height: 36px;
   line-height: 36px;
@@ -285,7 +340,21 @@ $brand-dark: #212629;
   white-space: nowrap;
 }
 
-.td-project { width: 120px; color: $brand-dark; font-weight: 500; }
+.td-project { width: 120px; }
+
+.project-badge {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: $brand-dark;
+  font-size: 12px;
+  font-weight: 500;
+}
 .td-action { width: 80px; font-weight: 500; }
 .td-object { width: 150px; color: #334155; }
 .td-start { width: 140px; color: #64748b; font-size: 12px; }

--- a/frontend/src/locales/en-US/account.js
+++ b/frontend/src/locales/en-US/account.js
@@ -31,6 +31,8 @@ export default {
   loadingEllipsis: 'Loading…',
   noRecords: 'No records',
   minutesSuffix: '{count} min',
+  allProjectsOption: 'All Projects',
+  unassociatedProjectOption: 'No Project',
 
   // ---- userprofile.vue: favorites / to-dos placeholder ----
   emptyFavoritesDesc: 'No favorites yet',

--- a/frontend/src/locales/zh-CN/account.js
+++ b/frontend/src/locales/zh-CN/account.js
@@ -30,6 +30,8 @@ export default {
   loadingEllipsis: '加载中...',
   noRecords: '无记录',
   minutesSuffix: '{count}分',
+  allProjectsOption: '全部项目',
+  unassociatedProjectOption: '未关联项目',
 
   // ---- userprofile.vue：我的收藏 / 我的代办占位 ----
   emptyFavoritesDesc: '暂无收藏内容',

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -121,7 +121,7 @@ export const fileOpenTabsMethods = {
 
       const meta = this.project && this.project.name ? `Project: ${this.project.name}` : ''
       // Start session tracking for this file
-      activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, meta)
+      activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, this.project && this.project.id, meta)
 
       // 1. 如果已经在某个 pane 打开，则聚焦该 pane
       const existingLeft = this.leftFiles.find(f => f.id === file.id)
@@ -204,10 +204,10 @@ export const fileOpenTabsMethods = {
           const url = file.url || ''
           const title = file.name || ''
           const fullMeta = meta + (title ? `. Title: ${title}` : '')
-          activityTracker.trackActivePage('OPEN_URL', 0, url, fullMeta)
+          activityTracker.trackActivePage('OPEN_URL', 0, url, this.project && this.project.id, fullMeta)
       } else {
           // File
-          activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, meta)
+          activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, this.project && this.project.id, meta)
       }
     },
 

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -4030,27 +4030,43 @@ $bg-white: #FFFFFF;
 /* Custom Recording Toast */
 .recording-toast {
   position: fixed;
-  top: 50%;
+  top: 60px;
   left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: rgba(44, 51, 56, 0.9); /* AI WorkDeck Gray-Dark with opacity */
-  color: #fff;
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-size: 16px;
+  transform: translate(-50%, -6px);
+  background-color: #fff;
+  color: #0f172a;
+  padding: 8px 16px;
+  border: 1px solid #E2E8F0;
+  border-radius: 12px;
+  font-size: 13px;
   font-weight: 500;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.25s ease, transform 0.25s ease;
   z-index: 9999;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 8px;
 
   &.visible {
     opacity: 1;
+    transform: translate(-50%, 0);
   }
+}
+
+.recording-toast-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #EF4444;
+  flex-shrink: 0;
+  animation: recording-toast-dot-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes recording-toast-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 /* AI Context Drag & Drop */
 .side-panel-ai.drag-over {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -414,6 +414,7 @@
 
     <!-- Custom Recording Toast -->
     <view class="recording-toast" :class="{ visible: showRecordingToast }">
+      <view v-if="isRecording" class="recording-toast-dot"></view>
       <text>{{ recordingToastMessage }}</text>
     </view>
 
@@ -3914,7 +3915,7 @@ export default {
       if (!this.isActiveBrowserTab(pane, tabId)) return
       // Track URL Session (flush previous, start new)
       const meta = this.project && this.project.name ? `Project: ${this.project.name}` : ''
-      activityTracker.trackActivePage('OPEN_URL', 0, url, meta)
+      activityTracker.trackActivePage('OPEN_URL', 0, url, this.project && this.project.id, meta)
     },
     onBrowserTitleChange(pane, tabId, title) {
       const active = this.findBrowserTab(pane, tabId)
@@ -3933,7 +3934,7 @@ export default {
       // 同 onBrowserUrlChange：后台标签换标题不算浏览行为
       if (url && this.isActiveBrowserTab(pane, tabId)) {
           // Restart session to capture title in the new segment
-          activityTracker.trackActivePage('OPEN_URL', 0, url, meta)
+          activityTracker.trackActivePage('OPEN_URL', 0, url, this.project && this.project.id, meta)
       }
 
       // 避免过长：保留前 18 字符
@@ -4020,9 +4021,9 @@ export default {
                      const url = file.url || ''
                      const title = file.name || ''
                      const fullMeta = meta + (title ? `. Title: ${title}` : '')
-                     activityTracker.trackActivePage('OPEN_URL', 0, url, fullMeta)
+                     activityTracker.trackActivePage('OPEN_URL', 0, url, this.project && this.project.id, fullMeta)
                  } else {
-                     activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, meta)
+                     activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, this.project && this.project.id, meta)
                  }
              }
         } else {

--- a/frontend/src/pages/project-overview/tabDragSplit.js
+++ b/frontend/src/pages/project-overview/tabDragSplit.js
@@ -294,9 +294,9 @@ export const tabDragSplitMethods = {
                    const url = file.url || ''
                    const title = file.name || ''
                    const fullMeta = meta + (title ? `. Title: ${title}` : '')
-                   activityTracker.trackActivePage('OPEN_URL', 0, url, fullMeta)
+                   activityTracker.trackActivePage('OPEN_URL', 0, url, this.project && this.project.id, fullMeta)
               } else {
-                   activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, meta)
+                   activityTracker.trackActivePage('OPEN_FILE', file.id, file.name, this.project && this.project.id, meta)
               }
           }
       }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2005,7 +2005,7 @@ export function deleteFileVariable(id) {
 }
 
 // ===================== 用户活动日志 =====================
-export function logActivity(actionType, targetId, targetName, duration, metaInfo) {
+export function logActivity(actionType, targetId, targetName, duration, metaInfo, projectId) {
   return request({
     url: '/api/activity/log',
     method: 'POST',
@@ -2014,7 +2014,8 @@ export function logActivity(actionType, targetId, targetName, duration, metaInfo
       targetId,
       targetName,
       duration,
-      metaInfo
+      metaInfo,
+      projectId
     },
     header: { 'Content-Type': 'application/json' }
   })

--- a/frontend/src/utils/activityTracker.js
+++ b/frontend/src/utils/activityTracker.js
@@ -47,38 +47,41 @@ class ActivityTracker {
     
     // Track a specific active item (File or URL) as a session
     // Replaces logAction for session-based tracking
-    trackActivePage(actionType, targetId, targetName, projectMeta = '') {
+    // projectId：结构化项目归属，供后端 /api/activity/history 按项目分类；
+    // projectMeta 是旧的 "Project: 名称" 自由文本，为老展示逻辑保留兼容
+    trackActivePage(actionType, targetId, targetName, projectId, projectMeta = '') {
         if (!this.isRecording) return
 
         // If switching to the same item, check if we need to do anything.
         // Usually switching means we came from somewhere else, or opened it.
         // Let's just flush previous and start new to be safe and accurate with segments.
-        
+
         this.flushActiveSession()
-        
+
         this.activeSession = {
             actionType,
             targetId,
             targetName,
             startTime: Date.now(),
+            projectId,
             projectMeta
         }
         console.log(`[ActivityTracker] Started session: ${targetName} (${actionType})`)
     }
-    
+
     flushActiveSession() {
         if (!this.activeSession) return
-        
-        const { actionType, targetId, targetName, startTime, projectMeta } = this.activeSession
+
+        const { actionType, targetId, targetName, startTime, projectId, projectMeta } = this.activeSession
         const endTime = Date.now()
         const duration = endTime - startTime
-        
+
         // Log even short durations if precise mode requested, or at least > 100ms to avoid noise
         if (duration > 100) {
-            logActivity(actionType, targetId, targetName, duration, projectMeta)
+            logActivity(actionType, targetId, targetName, duration, projectMeta, projectId)
                 .catch(e => console.error('[ActivityTracker] Log active session failed', e))
         }
-        
+
         this.activeSession = null
     }
 
@@ -149,8 +152,8 @@ class ActivityTracker {
         if (this.isRecording && this.lastPausedSession) {
             console.log('[ActivityTracker] Window focus: Resuming active session')
             // Resume tracking the same item
-            const { actionType, targetId, targetName, projectMeta } = this.lastPausedSession
-            this.trackActivePage(actionType, targetId, targetName, projectMeta)
+            const { actionType, targetId, targetName, projectId, projectMeta } = this.lastPausedSession
+            this.trackActivePage(actionType, targetId, targetName, projectId, projectMeta)
             this.lastPausedSession = null
         }
     }


### PR DESCRIPTION
## 真实功能定位

用户反馈 15（dev-board#45）实际指两件事，都在「记录工作」这条功能上：

1. 右上角录制开关的自定义提示（`.recording-toast`）是深灰居中大块，与外壳「保持浅色」的红线不符，视觉突兀。
2. 「工作记录」页只能靠 `activityTracker` 拼进 `metaInfo` 的自由文本 `"Project: 名称"` 猜测记录属于哪个项目——项目改名、重名项目、以及非 project-overview 的调用路径都会让这条文本失真或缺失，展示页因此无法可靠按项目分类。

## 改动

**Toast 重设计**（`project-overview.vue` / `.scss`）
- `.recording-toast`：从 `rgba(44,51,56,.9)` 深灰居中大块，改为浅色顶部小卡（白底 + 1px `#E2E8F0` 描边 + 12px 圆角 + 柔和阴影，`top: 60px`），文字 Slate `#0f172a` 13px。
- 录制中额外渲染一枚 6px 红点（`.recording-toast-dot`），带 1.5s 呼吸脉冲动画；停止态不渲染。

**活动日志结构化绑定项目**（后端 + 前端全链路）
- `UserActivityLog` 新增可空 `project_id` 列（`ddl-auto: update` 自动演进，未加迁移脚本，与仓内既有模式一致）；`projectName` 为 `@Transient` 展示字段。
- `POST /api/activity/log`：`LogRequest` / `UserActivityLogService.logActivity` 全链路加 `projectId` 参数。
- `GET /api/activity/history`：`UserActivityLogService.getUserLogs` 按 `distinct projectId` 一次批量查 `Project` 表补 `projectName`；查不到（项目已删除）与老数据（无 `projectId`）都留空，前端归类为「未关联项目」。
- 前端 `activityTracker.trackActivePage(actionType, targetId, targetName, projectId, projectMeta)` 显式接 `projectId`；`api.js` 的 `logActivity` 加 `projectId` 尾参；`project-overview.vue` / `fileOpenTabs.js` / `tabDragSplit.js` 全部调用点传 `this.project.id`。`projectMeta` 自由文本原样保留，供老展示兼容。
- 顺手修了 `activityTracker.js` 内部 `handleFocus()` 续传路径漏传 `projectId` 的问题（拿旧签名调用会把 `projectMeta` 误当成 `projectId`）。

**「工作记录」面板按项目分类**（`PersonalWorkLogPanel.vue`，被 `AdminPane` 与 `userprofile.vue` 薄壳页共用的唯一实现）
- 用 `AwdSelect` 加项目筛选下拉：全部 / 各项目（从当前记录去重生成）/ 未关联项目；替换掉原来那个语义模糊、实际按 `targetName` 匹配的自由文本 `project` 输入框。
- 列表项目列改为徽章样式（`.project-badge`，圆角 pill），优先显示结构化 `projectName`，缺失时兼容旧 `metaInfo` 文本解析。
- 新增 `account.allProjectsOption` / `account.unassociatedProjectOption` 双语文案。

## 验证

- 后端：`export JAVA_HOME=$(/usr/libexec/java_home -v 21)`，新增 `UserActivityLogServiceTest`（5 个用例：落 projectId / 允许 null / 批量补 projectName / 老数据与已删除项目都留空且不炸 / 无 projectId 时跳过批量查询），`mvn test -Dtest=UserActivityLogServiceTest,ProjectOverviewServiceTest` 通过；`mvn compile` 全量编译通过。
- 前端：`npm run check:emits`、`check:locales`（20 个命名空间对拍通过）、`check:nav`、`npm run build:h5` 全部通过。

关联 dev-board#45。

## 遗留

- 未跑全量 `mvn test`（257 个测试类），只跑了改动相关的 service 测试，符合任务要求的“相关模块”范围。
- `UserActivityLog.duration` 单位是毫秒（实体注释已有说明），本次改动未触碰这个既有语义。

🤖 Generated with [Claude Code](https://claude.com/claude-code)