### PR TITLE
fix(test): ChangeSignalWiringTest 换内存 H2，不再附着用户真实桌面库

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -111,6 +111,13 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 
 ## 已知地雷
 
+- **`@ActiveProfiles("desktop")` 的 `@SpringBootTest` 必须同时把 `spring.datasource.url` 覆盖成
+  `jdbc:h2:mem:`**（写法照 IdorAuthIntegrationTest / DesktopContextSmokeTest）：desktop profile
+  的默认数据源是 `~/.aiworkdeck/local` 文件库且带 `AUTO_SERVER=TRUE`，开发机上测试会直接附着到
+  **正在运行的桌面应用的真实数据库**读写。ChangeSignalWiringTest 曾漏掉这条——它在幽灵项目 7 里
+  建「新建文件夹*」再 permDelete，运行中途崩一次就永久残留垃圾行，此后同名检查让本机所有运行
+  deterministically 红，还查不出所以然（2026-08-20 实测，dev-board#57）。同病残留的清理配方：
+  H2 Shell 带同一 URL（AUTO_SERVER 允许附着活库）先只读核对 name/created_at/user_id 再删。
 - CI 签名→冒烟→打包顺序不可乱（PR#176）。
 - **Windows 上 node:test 的 teardown 删「被本进程 HTTP 服务读流碰过的」临时目录，必须用异步
   `fs.promises.rm(dir, {recursive, force, maxRetries, retryDelay})`，不能用 rmSync**（PR#436，

--- a/backend/src/test/java/com/checkba/version/ChangeSignalWiringTest.java
+++ b/backend/src/test/java/com/checkba/version/ChangeSignalWiringTest.java
@@ -16,9 +16,15 @@ import static org.mockito.Mockito.*;
 // desktop profile = 嵌入式 H2（与 IdorAuthIntegrationTest / DesktopContextSmokeTest 同一约定）。
 // 默认 profile 连 localhost:5432 的 PostgreSQL，本机恰好有库时测试是绿的，CI 上必挂——
 // 全上下文测试一律显式走 desktop profile，不得依赖开发机的外部服务。
+// 数据源必须同时覆盖成内存库：desktop profile 的默认 URL 是 ~/.aiworkdeck/local 文件库且
+// 带 AUTO_SERVER=TRUE，开发机上会直接附着到正在运行的桌面应用、读写用户的真实数据——
+// 本测试在 project 7 建「新建文件夹*」再 permDelete，中途崩溃一次就永久残留垃圾行，
+// 此后同名检查让 createFolder 必抛、本机所有运行 deterministically 红（2026-08-20 实测）。
 // security.local-mode=false：保持本测试写作时的登录会话语义，并避免 local-mode 的
 // LocalIdentityService 静态注册泄漏到同 JVM 后续测试（desktop profile 现默认开启 local-mode）。
-@SpringBootTest(properties = {"security.local-mode=false"})
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:change-signal-wiring;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.local-mode=false"})
 @ActiveProfiles("desktop")
 class ChangeSignalWiringTest {
 


### PR DESCRIPTION
## 问题

`ChangeSignalWiringTest` 以 `@SpringBootTest` + `@ActiveProfiles("desktop")` 运行，但没有覆盖数据源。desktop profile 的默认 URL 是 `jdbc:h2:file:~/.aiworkdeck/local` 且带 `AUTO_SERVER=TRUE`，于是开发机上测试直接附着到**正在运行的桌面应用的真实数据库**，在幽灵项目 7（project 表里不存在）中创建「新建文件夹/二/三」再 permDelete。

两个后果：
1. 测试对真库有写入污染；
2. 运行中途崩溃一次，垃圾行永久残留，此后 `createFolder` 的同名检查必抛，本机所有运行 deterministically 红。2026-08-20 实测：真库残留行「新建文件夹三」（id 1673，created_at 11:09:54，user_id=1 为测试硬编码值）使 `changeSignalFallsBackToGenericNameWhenUserLookupFails` 必红。

## 修复

- 照 IdorAuthIntegrationTest / DesktopContextSmokeTest 等同类测试的**既有约定**，给 `@SpringBootTest` 补 `jdbc:h2:mem:change-signal-wiring` 数据源覆盖（TDD：先实跑复现红——`A folder with this name already exists: 新建文件夹三`——改后 3/3 绿）。
- 逐一核查其余 8 个 `@ActiveProfiles("desktop")` 全上下文测试（Idor/DesktopContextSmoke/MobileRelay/ProjectConversations/ProjectProfileFieldConcurrentSave/GitHttpIngest/GitHttpProtocol/ShareCloneRoundTrip），**均已自带内存库覆盖**，本文件是唯一漏网。
- `.claude/agents/eng-infra.md` 已知地雷补一条：desktop-profile 的 @SpringBootTest 必须同时覆盖数据源。

## 真库清理（随手完成，不在 diff 里）

经 H2 Shell 附着活库三重核验（name=新建文件夹三 / created_at 落在测试运行时段 / user_id=1 非真实本机用户 2）后删除该行，剩余 0 行，无物理目录残留。project 7 下另有一行 7 月中旬的 `__staging_area__`（user_id=7，另一处硬编码痕迹），不在本次授权范围未动。

dev-board: zeweihan/dev-board#57

🤖 Generated with [Claude Code](https://claude.com/claude-code)