### PR TITLE
fix(sidebar-shell): 工作台接缝弧口与面板拖拽不跟手（dev-board#54/#55）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -321,6 +321,7 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
 - 全局覆盖：`frontend/src/App.vue`（:15-65 只覆盖 uni-modal/uni-toast）。
 - **awd-\* 类名约定**（King IDE 品牌清零后的通用弹窗/按钮样式，PR#171）：awd-dialog/-mask/-header/-title/-body/-footer、awd-btn/-primary/-secondary/-danger、awd-field/awd-input。**没有集中定义**——在 project-overview.vue（~:10180-10300）、ChatInterface.vue（~:2869 起）、FileTree.vue 各自 scoped 重复定义；改样式要多处同步。
 - 外壳布局类：.header-tools:6904、.rail-btn:7009、.sidebar-left:7403/7905、.workbench:7455、.bottom-panel:7283/7510、.compact-mode:7478、.is-resizing:7927。
+- **面板拖拽的跟手守卫是三件一套，删一件拖拽就会退化**（2026-08-20）：① `.is-resizing` 禁 transition；② `.is-resizing :deep(iframe)/:deep(webview)` 关 pointer-events——光标滑进嵌入文档父窗口就收不到 mousemove，拖拽会冻住；③ 桌面端浏览器 BrowserView 是原生层 CSS 管不到，靠 `desktopOverlayActive` 里那条 `resizing.active` 在拖拽期间隐藏。另外 `startResize/stopResize`（tabDragSplit.js）会锁/还原 body 的 cursor 与 user-select。编辑器窗格 `.editor-pane`/`.pane-content` 已拉平成方角（圆角卡片残留会在标签栏下沿与分栏缝露出底色弧口），别再给它们加 border-radius。
 - **编辑器标签（`.tab-item`）在 project-overview.scss 里只有一份定义了**。此前有两份：
   靠前那份是 VS Code 式贴合标签，被靠后那份整个覆盖成死代码，实际生效的是一排
   10px 全圆角 + 四面描边 + `min-width:100px` 的「筛选 chip」，与下方编辑器完全断开。

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -1266,6 +1266,15 @@ $bg-white: #FFFFFF;
   transition: none !important;
 }
 
+/* 拖拽期间让 iframe/webview 放行鼠标事件：mousemove 一进嵌入文档，父窗口就
+   收不到了，光标滑过编辑器时拖拽会整个冻住——「不跟手」的根因。桌面端的
+   浏览器面板是原生 BrowserView，CSS 管不到，由 desktopOverlayActive 在拖拽
+   期间隐藏兜底。 */
+.page-project-overview.is-resizing :deep(iframe),
+.page-project-overview.is-resizing :deep(webview) {
+  pointer-events: none !important;
+}
+
 .sidebar-header {
   display: flex;
   flex-direction: row;
@@ -1862,10 +1871,12 @@ $bg-white: #FFFFFF;
   min-width: 0; /* 防止内容撑大 */
   transition: all 0.2s ease-in-out; /* 更好的过渡 */
   overflow: hidden;
-  border-radius: 18px;
-  border: 1px solid rgba(15, 23, 42, 0.05);
-  background: rgba(249, 250, 255, 0.82);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.6);
+  /* 方角贴合外壳其余区块（.workbench/.content-area/.side-panel 都已拉平）：
+     圆角卡片残留会在标签栏下沿与分栏缝两侧露出底色小弧口 */
+  border-radius: 0;
+  border: none;
+  background: #ffffff;
+  box-shadow: none;
 
   &.focused {
     /* 聚焦时的高亮提示 */
@@ -1896,9 +1907,9 @@ $bg-white: #FFFFFF;
   width: 100%;
   height: 100%;
   overflow: hidden; /* 确保内部组件不溢出 */
-  border-radius: 16px;
+  border-radius: 0;
   background: #fff;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.03);
+  box-shadow: none;
 }
 
 /* 预热备胎实例（librePool.js）：未激活时脱离布局流隐形占位。不能用

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -2041,6 +2041,9 @@ export default {
         // 页面树之外的浮层（反馈浮窗）也要能压住 BrowserView：它自己不调
         // setViewsVisible，只置这个全局 ref，避免和下面这一处 watcher 互相打架
         globalOverlayActive.value ||
+        // 面板拖拽期间也要藏：BrowserView 是原生层，光标滑进去父窗口就收不到
+        // mousemove，拖拽会冻住（iframe/webview 由 is-resizing 的 CSS 放行）
+        (this.resizing && this.resizing.active) ||
         this.showOcrOverlay ||
         this.showScreenshotSaveDialog ||
         this.showExportDialog ||

--- a/frontend/src/pages/project-overview/tabDragSplit.js
+++ b/frontend/src/pages/project-overview/tabDragSplit.js
@@ -143,6 +143,14 @@ export const tabDragSplitMethods = {
         evt.preventDefault()
       }
 
+      // 拖拽期间锁全局光标与选区：不锁的话光标滑过文本/按钮会闪回默认形状，
+      // 且快速拖动会顺手拖出一片文本选区
+      if (typeof document !== 'undefined' && document.body) {
+        document.body.style.cursor = target === 'bottom' ? 'row-resize' : 'col-resize'
+        document.body.style.userSelect = 'none'
+        document.body.style.webkitUserSelect = 'none'
+      }
+
       if (typeof window !== 'undefined') {
         if (!this.boundResizeMove) this.boundResizeMove = (e2) => this.onResizeMove(e2)
         if (!this.boundStopResize) this.boundStopResize = () => this.stopResize()
@@ -173,6 +181,16 @@ export const tabDragSplitMethods = {
       if (this._resizeRaf) return
       this._resizeRaf = requestAnimationFrame(() => {
         this._resizeRaf = null
+        this.applyResizeFrame()
+      })
+    },
+
+    // rAF 帧体：把 pending 的光标位置落到面板尺寸上。单独成方法是因为 stopResize
+    // 也要调它——mouseup 常常赶在 rAF 回调前到达，不冲刷这最后一拍，快速拖动
+    // 松手时最后一段位移会被整个丢掉（表现就是「不跟手、松手回弹一截」）。
+    applyResizeFrame() {
+      if (!this.resizing.target) return
+      {
         const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
         const vh = typeof window !== 'undefined' ? window.innerHeight : 800
 
@@ -217,11 +235,18 @@ export const tabDragSplitMethods = {
           }
            this.resizing.currentValue = finalValue
         }
-      })
+      }
     },
 
     stopResize() {
       if (!this.resizing.active) return
+
+      // 冲刷最后一拍：mouseup 赶在 rAF 前到时，pending 位移还没落上去
+      if (this._resizeRaf) {
+        cancelAnimationFrame(this._resizeRaf)
+        this._resizeRaf = null
+        this.applyResizeFrame()
+      }
 
       // Save target and currentValue BEFORE nullifying
       const target = this.resizing.target
@@ -232,9 +257,10 @@ export const tabDragSplitMethods = {
       this.resizing.element = null
       this.resizing.currentValue = null
 
-      if (this._resizeRaf) {
-        cancelAnimationFrame(this._resizeRaf)
-        this._resizeRaf = null
+      if (typeof document !== 'undefined' && document.body) {
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        document.body.style.webkitUserSelect = ''
       }
 
       if (typeof window !== 'undefined') {


### PR DESCRIPTION
## 问题（用户 2026-08-20 截图反馈）

1. 列分隔处小接缝不好看：标签栏下沿、分栏缝两侧有小弧形缺口。
2. 面板宽窄拖拽不跟手。

## 根因与修复

**接缝**：`.editor-pane` 靠后那份定义残留圆角卡片样式（`border-radius:18px` + 半透明底 + 描边），方角 IDE 布局下每个编辑窗格顶角露出底色弧口；`.pane-content` 的 16px 圆角同罪。全部拉平成方角，对齐 `.workbench`/`.content-area` 既有形制。

**拖拽不跟手**（三个根因）：
- is-resizing 期间 iframe/webview 照常吃鼠标事件，光标滑进编辑器嵌入文档后父窗口收不到 mousemove，拖拽冻住 → `:deep(iframe)/:deep(webview) pointer-events:none`；
- 桌面端浏览器 BrowserView 是原生层 CSS 管不到 → `desktopOverlayActive` 纳入 `resizing.active`，拖拽期间隐藏；
- `stopResize` 在 mouseup 抢先于 rAF 时丢掉 pending 的最后一段位移（快速拖动松手回弹）→ rAF 帧体抽成 `applyResizeFrame`，stopResize 先冲刷再收尾。
- 另：拖拽期间锁 body cursor/user-select。

## 验证

- H5 dev + 隔离后端（本树 jar、隔离 user.home/H2、trial 票据）真机走查：向导 → 建项目 → 开 docx（LOWA iframe 正常 boot）→ 分栏；computed `borderRadius=0`，分栏缝与左栏交界无弧口。
- 真实输入拖拽：探针实证 is-resizing 期间穿过 iframe 的 mousemove 抵达 window；快速拖拽 260→654px 与光标终点差 ≤1px（冲刷生效）；松手后 is-resizing/cursor/user-select 全部还原。
- check:emits / check:nav / build:h5 全过。
- sidebar-shell.md 补记「跟手守卫三件一套」地雷。

关联卡：zeweihan/dev-board#54、zeweihan/dev-board#55

🤖 Generated with [Claude Code](https://claude.com/claude-code)