### PR TITLE
feat(tags): 标签类型维度——文件关联当事人/争议焦点（dev-board#63）

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -110,6 +110,20 @@ PDFParser 调 PDFBox2 已删除的 `PDDocument.load` 会抛 `NoSuchMethodError`�
 超过 24 个截断给「显示全部 N 个」，超过 12 个再加一个过滤框；**折叠态仍常驻显示已选标签**——
 否则「搜不到东西」的原因被藏起来了。根因不在这个面板，见下面的自动打标签条目。
 
+**标签类型维度（2026-08-20，dev-board#63）**：`Tag.type` = `NORMAL`/`PARTY`（当事人）/
+`ISSUE`（争议焦点），**可空且 null 视同 NORMAL**（存量行零迁移）——前端判断一律走
+`utils/tagTypes.js` 的 `normalizeTagType()`，别手写 `tag.type === 'PARTY'`；后端白名单校验在
+`TagService.validateType`，`updateTag` 收到 null type 是「不改型」不是清空（前端改型总是显式传值，
+含改回 NORMAL）。同名唯一约束不分型：`TagService.getOrCreateTag` 撞同名不同型时**复用不改型**
+（改型是用户在标签管理里的决定）。新建默认色按类型（PARTY `#B45309` / ISSUE `#9B1C31` /
+NORMAL `#3B82F6`，`tagTypes.js` 与 TagService 两处同值）。分组展示在 TagSelector（可选列表三组）
+与 SearchPanel（展开态三个 `.tag-subsec-head` 分组头，**只是 shownTags 的按型切片渲染**，
+过滤/截断/排序仍是那一份全局逻辑，别按组各写一套）。AI 工具 `service/ai/tools/TagTools.java`
+三件：`tag_list`（描述里强制先查再打、防同义词膨胀）/ `tag_file`（`ToolFileGuard` 校验归属，
+幂等）/ `tag_remove_from_file`（只解关联）；接线同步 `RealToolBeans` 与前端 `toolDisplayNames.js`。
+`AutoTaggingService` 刻意不产类型标签（当事人/争点判定不适合挂在每次自动保存的便宜档链路上）。
+测试：`TagServiceTest` / `TagToolsTest`。
+
 **下载**：`DownloadList.vue` 是**孤儿组件**（全仓库无引用、未挂载）；文件下载实际走 FileController `GET /api/files/{fileId}/download`。
 
 **语音 TTS**：`EasyVoicePane.vue`（api：getTtsVoices/generateTtsAudio）；desktop 本地 Kokoro 由 `desktop/main/services/kokoro-service.js` 管理；后端 `controller/TtsController.java`（/api/tts/voices、/generate）+ `service/TtsService.java`。**只有本机一档**：桌面捆绑 Kokoro，OpenAI 兼容 /v1，地址 `external.tts.local-base-url`（打包态由 Electron 注入动态端口），地址为空即「组件未就绪」。云端 ElevenLabs 那一档与 `external.tts.provider` 开关已整体移除。easyvoice Docker 段已停用。

--- a/backend/src/main/java/com/checkba/controller/TagController.java
+++ b/backend/src/main/java/com/checkba/controller/TagController.java
@@ -49,7 +49,7 @@ public class TagController {
             @RequestBody CreateTagRequest request,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireMember(sessionId, projectId);
-        return tagService.createTag(projectId, request.getName(), request.getColor(), request.getDescription());
+        return tagService.createTag(projectId, request.getName(), request.getColor(), request.getDescription(), request.getType());
     }
 
     /**
@@ -62,7 +62,7 @@ public class TagController {
             @RequestBody UpdateTagRequest request,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireMember(sessionId, projectId);
-        return tagService.updateTag(projectId, tagId, request.getName(), request.getColor(), request.getDescription());
+        return tagService.updateTag(projectId, tagId, request.getName(), request.getColor(), request.getDescription(), request.getType());
     }
 
     /**
@@ -82,6 +82,7 @@ public class TagController {
         private String name;
         private String color;
         private String description;
+        private String type;
     }
 
     @Data
@@ -89,5 +90,6 @@ public class TagController {
         private String name;
         private String color;
         private String description;
+        private String type;
     }
 }

--- a/backend/src/main/java/com/checkba/model/entity/Tag.java
+++ b/backend/src/main/java/com/checkba/model/entity/Tag.java
@@ -53,7 +53,13 @@ public class Tag {
      */
     @Column(nullable = false, columnDefinition = "boolean default false")
     private Boolean isSystem = false;
-    
+
+    /**
+     * 标签类型：NORMAL 普通 / PARTY 当事人 / ISSUE 争议焦点；null 视同 NORMAL（存量行零迁移）。
+     */
+    @Column(length = 16)
+    private String type;
+
     /**
      * 描述
      */

--- a/backend/src/main/java/com/checkba/service/TagService.java
+++ b/backend/src/main/java/com/checkba/service/TagService.java
@@ -14,33 +14,84 @@ import java.util.List;
 public class TagService {
 
     private final TagRepository tagRepository;
-    
+
+    /** 标签类型默认色：当事人琥珀褐 / 争议焦点深红褐 / 普通蓝（与 AutoTaggingService 自动标签色一致） */
+    private static final String DEFAULT_COLOR_PARTY = "#B45309";
+    private static final String DEFAULT_COLOR_ISSUE = "#9B1C31";
+    private static final String DEFAULT_COLOR_NORMAL = "#3B82F6";
+
+    /**
+     * 校验标签类型白名单：null 或 NORMAL/PARTY/ISSUE；非法值抛异常。
+     */
+    private static void validateType(String type) {
+        if (type == null) {
+            return;
+        }
+        if (!"NORMAL".equals(type) && !"PARTY".equals(type) && !"ISSUE".equals(type)) {
+            throw new IllegalArgumentException("非法的标签类型：" + type);
+        }
+    }
+
     /**
      * 获取项目的所有标签
      */
     public List<Tag> getProjectTags(Long projectId) {
         return tagRepository.findByProjectId(projectId);
     }
-    
+
     /**
      * 创建标签
      */
     @Transactional
-    public Tag createTag(Long projectId, String name, String color, String description) {
+    public Tag createTag(Long projectId, String name, String color, String description, String type) {
+        validateType(type);
         if (tagRepository.existsByProjectIdAndName(projectId, name)) {
             throw new IllegalArgumentException("Tag with this name already exists in the project");
         }
-        
+
         Tag tag = new Tag();
         tag.setProjectId(projectId);
         tag.setName(name);
         tag.setColor(color);
         tag.setDescription(description);
         tag.setIsSystem(false);
+        tag.setType(type);
         tag.setCreatedAt(LocalDateTime.now());
         tag.setUpdatedAt(LocalDateTime.now());
-        
+
         return tagRepository.save(tag);
+    }
+
+    /**
+     * 获取或创建标签（供 AI 工具 tag_file 使用）：按 projectId+name 找，找到就原样返回——
+     * 同名不同型时复用既有标签、不改型，改型是用户在标签管理里的决定。
+     * 没有则创建，isSystem=false，默认色按类型（调用方传了 color 则用调用方的）。
+     */
+    @Transactional
+    public Tag getOrCreateTag(Long projectId, String name, String type, String color) {
+        validateType(type);
+        return tagRepository.findByProjectIdAndName(projectId, name)
+                .orElseGet(() -> {
+                    Tag tag = new Tag();
+                    tag.setProjectId(projectId);
+                    tag.setName(name);
+                    tag.setType(type);
+                    tag.setColor(color != null ? color : defaultColorForType(type));
+                    tag.setIsSystem(false);
+                    tag.setCreatedAt(LocalDateTime.now());
+                    tag.setUpdatedAt(LocalDateTime.now());
+                    return tagRepository.save(tag);
+                });
+    }
+
+    private static String defaultColorForType(String type) {
+        if ("PARTY".equals(type)) {
+            return DEFAULT_COLOR_PARTY;
+        }
+        if ("ISSUE".equals(type)) {
+            return DEFAULT_COLOR_ISSUE;
+        }
+        return DEFAULT_COLOR_NORMAL;
     }
     
     /**
@@ -66,7 +117,8 @@ public class TagService {
      * 更新标签
      */
     @Transactional
-    public Tag updateTag(Long projectId, Long tagId, String name, String color, String description) {
+    public Tag updateTag(Long projectId, Long tagId, String name, String color, String description, String type) {
+        validateType(type);
         Tag tag = tagRepository.findById(tagId)
                 .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
         // 归属校验：tagId 必须属于该 projectId，防止本项目成员改动其它项目的标签
@@ -84,8 +136,13 @@ public class TagService {
         tag.setName(name);
         tag.setColor(color);
         tag.setDescription(description);
+        // type 为 null 表示「不改型」而不是清空：前端改型时总是显式传值（含改回 NORMAL），
+        // 不带 type 的调用方不该把当事人/争点标签静默抹回普通
+        if (type != null) {
+            tag.setType(type);
+        }
         tag.setUpdatedAt(LocalDateTime.now());
-        
+
         return tagRepository.save(tag);
     }
     

--- a/backend/src/main/java/com/checkba/service/ai/tools/TagTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/TagTools.java
@@ -1,0 +1,182 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.Tag;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.FileTagService;
+import com.checkba.service.TagService;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 标签类型维度工具（dev-board #63，spec：
+ * docs/superpowers/specs/2026-08-20-file-party-issue-tags-design.md）。
+ *
+ * 标签类型是既有普通标签的一个维度扩展：PARTY（当事人）/ ISSUE（争议焦点）/ NORMAL（普通，
+ * 含存量 null）。文件-标签关联本身不新增概念，直接复用 {@link FileTagService}。
+ *
+ * projectId/userId 由 ToolRegistry 按服务端上下文强制注入（SERVER_CONTEXT_PARAMS），
+ * LLM 传入的同名值会被忽略；fileId 是 LLM 自由填写的业务 ID，用 {@link ToolFileGuard}
+ * 校验归属，防止越权访问其它项目的文件。
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TagTools implements AgentToolComponent {
+
+    private final TagService tagService;
+    private final FileTagService fileTagService;
+    private final ProjectFileRepository projectFileRepository;
+
+    @Tool("查看当前项目的标签清单，按类型分组（当事人/争议焦点/普通标签）。" +
+          "给文件打标签前必须先调用本工具查看已有标签，优先复用已有名字，不要为同一个人/" +
+          "同一个争点造出措辞不同的同义词标签。")
+    @ToolMeta(displayName = "查看项目标签", category = "file")
+    public String tag_list(Long projectId) {
+        log.info("Tool: tag_list project={}", projectId);
+        if (projectId == null) {
+            return "错误：无法获取当前项目ID，请在项目上下文中使用此工具。";
+        }
+
+        List<Tag> tags = tagService.getProjectTags(projectId);
+        if (tags.isEmpty()) {
+            return "当前项目暂无标签。";
+        }
+
+        StringBuilder parties = new StringBuilder();
+        StringBuilder issues = new StringBuilder();
+        StringBuilder normal = new StringBuilder();
+        for (Tag tag : tags) {
+            String type = tag.getType();
+            if ("PARTY".equals(type)) {
+                appendName(parties, tag.getName());
+            } else if ("ISSUE".equals(type)) {
+                appendName(issues, tag.getName());
+            } else {
+                appendName(normal, tag.getName());
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("当事人：").append(parties.length() > 0 ? parties : "（无）").append('\n');
+        sb.append("争议焦点：").append(issues.length() > 0 ? issues : "（无）").append('\n');
+        sb.append("普通标签：").append(normal.length() > 0 ? normal : "（无）");
+        return sb.toString();
+    }
+
+    private void appendName(StringBuilder sb, String name) {
+        if (sb.length() > 0) {
+            sb.append("、");
+        }
+        sb.append(name);
+    }
+
+    @Tool("给文件打标签，可指定类型（NORMAL 普通 / PARTY 当事人 / ISSUE 争议焦点，缺省 NORMAL）。" +
+          "按名字找已有标签，找不到才新建；已挂过同一标签会幂等返回成功。打标签前建议先用 " +
+          "tag_list 查看已有标签，避免造同义词。")
+    @ToolMeta(displayName = "给文件打标签", category = "file")
+    public String tag_file(
+            @P("要打标签的项目内文件ID，须来自 doc_list_project_files 等工具返回的 fileId") Long fileId,
+            @P("标签名称") String tagName,
+            @P(value = "标签类型：NORMAL/PARTY/ISSUE，缺省 NORMAL", required = false) String type,
+            Long projectId,
+            Long userId
+    ) {
+        log.info("Tool: tag_file fileId={} tagName='{}' type={} project={}", fileId, tagName, type, projectId);
+
+        if (projectId == null) {
+            return "错误：无法获取当前项目ID，请在项目上下文中使用此工具。";
+        }
+        if (fileId == null) {
+            return "错误：fileId 不能为空。";
+        }
+        if (tagName == null || tagName.isBlank()) {
+            return "错误：标签名称不能为空。";
+        }
+        String effectiveType = (type == null || type.isBlank()) ? "NORMAL" : type;
+
+        try {
+            Optional<ProjectFile> fileOpt = projectFileRepository.findById(fileId);
+            if (fileOpt.isEmpty()) {
+                return "错误：文件不存在：" + fileId;
+            }
+            String denied = ToolFileGuard.rejectIfOutsideProject(fileOpt.get());
+            if (denied != null) {
+                return denied;
+            }
+
+            Tag tag = tagService.getOrCreateTag(projectId, tagName, effectiveType, null);
+            fileTagService.addTagToFile(fileId, tag.getId(), userId);
+
+            String actualType = tag.getType() == null ? "NORMAL" : tag.getType();
+            StringBuilder sb = new StringBuilder("已给文件打上标签「").append(tag.getName()).append("」。");
+            if (!actualType.equals(effectiveType)) {
+                sb.append("该标签已存在，实际类型为 ").append(actualType).append("（未按本次请求改型）。");
+            }
+            return sb.toString();
+        } catch (IllegalArgumentException e) {
+            return "错误：" + e.getMessage();
+        } catch (Exception e) {
+            log.warn("tag_file failed", e);
+            return "错误：打标签失败，" + e.getMessage();
+        }
+    }
+
+    @Tool("移除文件上的某个标签（只解除文件与标签的关联，不删除标签本身）。")
+    @ToolMeta(displayName = "移除文件标签", category = "file")
+    public String tag_remove_from_file(
+            @P("文件ID，须来自 doc_list_project_files 等工具返回的 fileId") Long fileId,
+            @P("要移除的标签名称") String tagName,
+            Long projectId
+    ) {
+        log.info("Tool: tag_remove_from_file fileId={} tagName='{}' project={}", fileId, tagName, projectId);
+
+        if (projectId == null) {
+            return "错误：无法获取当前项目ID，请在项目上下文中使用此工具。";
+        }
+        if (fileId == null) {
+            return "错误：fileId 不能为空。";
+        }
+        if (tagName == null || tagName.isBlank()) {
+            return "错误：标签名称不能为空。";
+        }
+
+        try {
+            Optional<ProjectFile> fileOpt = projectFileRepository.findById(fileId);
+            if (fileOpt.isEmpty()) {
+                return "错误：文件不存在：" + fileId;
+            }
+            String denied = ToolFileGuard.rejectIfOutsideProject(fileOpt.get());
+            if (denied != null) {
+                return denied;
+            }
+
+            List<Tag> existingTags = tagService.getProjectTags(projectId);
+            Tag target = existingTags.stream()
+                    .filter(t -> tagName.equals(t.getName()))
+                    .findFirst()
+                    .orElse(null);
+            if (target == null) {
+                return "项目里没有名为「" + tagName + "」的标签，无需移除。";
+            }
+
+            List<Tag> fileTags = fileTagService.getTagsByFileId(fileId);
+            boolean attached = fileTags.stream().anyMatch(t -> t.getId().equals(target.getId()));
+            if (!attached) {
+                return "文件本来就没有挂「" + tagName + "」这个标签。";
+            }
+
+            fileTagService.removeTagFromFile(fileId, target.getId());
+            return "已移除标签「" + tagName + "」。";
+        } catch (Exception e) {
+            log.warn("tag_remove_from_file failed", e);
+            return "错误：移除标签失败，" + e.getMessage();
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/TagServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/TagServiceTest.java
@@ -1,0 +1,137 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.Tag;
+import com.checkba.repository.TagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 标签类型维度（dev-board #63）的服务层契约：type 白名单校验、getOrCreateTag 的
+ * 复用-不改型语义与按类型默认色。TagRepository 为 mock。
+ */
+class TagServiceTest {
+
+    private TagRepository tagRepository;
+    private TagService tagService;
+
+    @BeforeEach
+    void setUp() {
+        tagRepository = mock(TagRepository.class);
+        tagService = new TagService(tagRepository);
+    }
+
+    @Test
+    @DisplayName("createTag：type 为 null 或白名单内的值都放行")
+    void createTagAllowsNullOrWhitelistedType() {
+        when(tagRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Tag t1 = tagService.createTag(1L, "标签A", "#000000", "desc", null);
+        assertEquals(null, t1.getType());
+
+        when(tagRepository.existsByProjectIdAndName(1L, "标签B")).thenReturn(false);
+        Tag t2 = tagService.createTag(1L, "标签B", "#000000", "desc", "PARTY");
+        assertEquals("PARTY", t2.getType());
+    }
+
+    @Test
+    @DisplayName("createTag：非法 type 抛 IllegalArgumentException，不调用 repository")
+    void createTagRejectsIllegalType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> tagService.createTag(1L, "标签A", "#000000", "desc", "BOGUS"));
+        verify(tagRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateTag：非法 type 抛 IllegalArgumentException，不调用 repository.findById")
+    void updateTagRejectsIllegalType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> tagService.updateTag(1L, 5L, "标签A", "#000000", "desc", "BOGUS"));
+        verify(tagRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("updateTag：type 为 null 表示不改型，既有类型保持原样")
+    void updateTagKeepsTypeWhenNull() {
+        Tag existing = new Tag();
+        existing.setId(5L);
+        existing.setProjectId(1L);
+        existing.setName("张三");
+        existing.setType("PARTY");
+        when(tagRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(tagRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Tag result = tagService.updateTag(1L, 5L, "张三", "#000000", "desc", null);
+
+        assertEquals("PARTY", result.getType(), "不带 type 的更新不许把标签抹回普通");
+    }
+
+    @Test
+    @DisplayName("getOrCreateTag：已存在同名标签——原样返回，不改型、不调用 save")
+    void getOrCreateTagReusesExistingWithoutRetyping() {
+        Tag existing = new Tag();
+        existing.setId(9L);
+        existing.setProjectId(1L);
+        existing.setName("李四");
+        existing.setType("NORMAL");
+        existing.setColor("#3B82F6");
+        when(tagRepository.findByProjectIdAndName(1L, "李四")).thenReturn(Optional.of(existing));
+
+        Tag result = tagService.getOrCreateTag(1L, "李四", "PARTY", null);
+
+        assertSame(existing, result);
+        assertEquals("NORMAL", result.getType(), "撞名不同型时必须复用既有标签、不改型");
+        verify(tagRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("getOrCreateTag：不存在则新建，按类型套默认色")
+    void getOrCreateTagCreatesWithDefaultColorByType() {
+        when(tagRepository.findByProjectIdAndName(1L, "张三")).thenReturn(Optional.empty());
+        when(tagRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Tag party = tagService.getOrCreateTag(1L, "张三", "PARTY", null);
+        assertEquals("#B45309", party.getColor());
+        assertEquals("PARTY", party.getType());
+        assertFalse(party.getIsSystem());
+
+        when(tagRepository.findByProjectIdAndName(1L, "违约责任")).thenReturn(Optional.empty());
+        Tag issue = tagService.getOrCreateTag(1L, "违约责任", "ISSUE", null);
+        assertEquals("#9B1C31", issue.getColor());
+
+        when(tagRepository.findByProjectIdAndName(1L, "证据一")).thenReturn(Optional.empty());
+        Tag normal = tagService.getOrCreateTag(1L, "证据一", "NORMAL", null);
+        assertEquals("#3B82F6", normal.getColor());
+    }
+
+    @Test
+    @DisplayName("getOrCreateTag：调用方传了 color 则用调用方的，不套默认色")
+    void getOrCreateTagUsesCallerColorWhenProvided() {
+        when(tagRepository.findByProjectIdAndName(1L, "张三")).thenReturn(Optional.empty());
+        when(tagRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Tag result = tagService.getOrCreateTag(1L, "张三", "PARTY", "#FF0000");
+
+        assertEquals("#FF0000", result.getColor());
+    }
+
+    @Test
+    @DisplayName("getOrCreateTag：非法 type 抛 IllegalArgumentException")
+    void getOrCreateTagRejectsIllegalType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> tagService.getOrCreateTag(1L, "张三", "BOGUS", null));
+        verify(tagRepository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
+++ b/backend/src/test/java/com/checkba/service/ai/eval/RealToolBeans.java
@@ -15,6 +15,7 @@ import com.checkba.service.ai.tools.PluginDevTools;
 import com.checkba.service.ai.tools.PptxTools;
 import com.checkba.service.ai.tools.PythonTools;
 import com.checkba.service.ai.tools.SubAgentTools;
+import com.checkba.service.ai.tools.TagTools;
 import com.checkba.service.ai.tools.TaskTools;
 import com.checkba.service.ai.tools.TextFileEditTools;
 import com.checkba.service.ai.tools.TodoTools;
@@ -63,6 +64,7 @@ final class RealToolBeans {
                 // offeredToolsInclude 永远失败、offeredToolsExclude 永远通过）。
                 // 补进来后 skill-orchestration-tools-not-trimmed 才真正有意义。
                 TodoTools.class,
+                TagTools.class,
                 TaskTools.class,
                 WebTools.class);
         List<AgentToolComponent> beans = new ArrayList<>();

--- a/backend/src/test/java/com/checkba/service/ai/tools/TagToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/TagToolsTest.java
@@ -1,0 +1,256 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.Tag;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.FileTagService;
+import com.checkba.service.TagService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * tag_list / tag_file / tag_remove_from_file（dev-board #63）单测。
+ *
+ * TagService/FileTagService/ProjectFileRepository 均为 mock：本类只验证 TagTools 这一层的
+ * 契约——fileId 归属校验如何转成拒绝文案、白名单异常如何回喂、同名不同型时如何说明「未改型」、
+ * 幂等挂标签不因重复调用报错、tag_list 按类型分组渲染。TagService 内部的白名单校验与
+ * getOrCreateTag 复用-不改型行为由 TagServiceTest 覆盖。
+ *
+ * ToolFileGuard 依赖 ProjectContextHolder 这个 ThreadLocal（生产由 ToolRegistry 在分发前
+ * 设置），这里手动 set/clear 模拟。
+ */
+class TagToolsTest {
+
+    private TagService tagService;
+    private FileTagService fileTagService;
+    private ProjectFileRepository projectFileRepository;
+    private TagTools tools;
+
+    private static final Long PROJECT_ID = 1L;
+    private static final Long OTHER_PROJECT_ID = 2L;
+    private static final Long USER_ID = 10L;
+
+    @BeforeEach
+    void setUp() {
+        tagService = mock(TagService.class);
+        fileTagService = mock(FileTagService.class);
+        projectFileRepository = mock(ProjectFileRepository.class);
+        tools = new TagTools(tagService, fileTagService, projectFileRepository);
+        ProjectContextHolder.setProjectId(String.valueOf(PROJECT_ID));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ProjectContextHolder.clear();
+    }
+
+    private ProjectFile file(Long id, Long projectId) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(projectId);
+        return f;
+    }
+
+    private Tag tag(Long id, String name, String type, String color) {
+        Tag t = new Tag();
+        t.setId(id);
+        t.setName(name);
+        t.setType(type);
+        t.setColor(color);
+        return t;
+    }
+
+    @Test
+    @DisplayName("tag_file：新建标签（带 type 与默认色），挂到文件")
+    void tagFileCreatesNewTag() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        when(tagService.getOrCreateTag(PROJECT_ID, "张三", "PARTY", null))
+                .thenReturn(tag(5L, "张三", "PARTY", "#B45309"));
+
+        String out = tools.tag_file(100L, "张三", "PARTY", PROJECT_ID, USER_ID);
+
+        assertTrue(out.contains("张三"), out);
+        assertFalse(out.contains("实际类型"), out);
+        verify(fileTagService).addTagToFile(100L, 5L, USER_ID);
+    }
+
+    @Test
+    @DisplayName("tag_file：type 缺省时按 NORMAL 处理")
+    void tagFileDefaultsToNormal() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        when(tagService.getOrCreateTag(PROJECT_ID, "证据一", "NORMAL", null))
+                .thenReturn(tag(6L, "证据一", null, "#3B82F6"));
+
+        String out = tools.tag_file(100L, "证据一", null, PROJECT_ID, USER_ID);
+
+        assertTrue(out.contains("证据一"), out);
+        verify(tagService).getOrCreateTag(PROJECT_ID, "证据一", "NORMAL", null);
+    }
+
+    @Test
+    @DisplayName("tag_file：撞上同名不同型的既有标签——复用不改型，返回文本说明实际类型")
+    void tagFileReusesExistingTagWithDifferentType() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        // 请求 PARTY，但项目里"李四"已经是普通标签——service 层不改型，原样返回既有标签
+        when(tagService.getOrCreateTag(PROJECT_ID, "李四", "PARTY", null))
+                .thenReturn(tag(7L, "李四", "NORMAL", "#3B82F6"));
+
+        String out = tools.tag_file(100L, "李四", "PARTY", PROJECT_ID, USER_ID);
+
+        assertTrue(out.contains("李四"), out);
+        assertTrue(out.contains("实际类型"), out);
+        assertTrue(out.contains("NORMAL"), out);
+        verify(fileTagService).addTagToFile(100L, 7L, USER_ID);
+    }
+
+    @Test
+    @DisplayName("tag_file：重复挂同一标签——幂等，两次调用都返回成功文案")
+    void tagFileIsIdempotent() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        when(tagService.getOrCreateTag(PROJECT_ID, "张三", "PARTY", null))
+                .thenReturn(tag(5L, "张三", "PARTY", "#B45309"));
+
+        String first = tools.tag_file(100L, "张三", "PARTY", PROJECT_ID, USER_ID);
+        String second = tools.tag_file(100L, "张三", "PARTY", PROJECT_ID, USER_ID);
+
+        assertFalse(first.startsWith("错误"), first);
+        assertFalse(second.startsWith("错误"), second);
+        verify(fileTagService, times(2)).addTagToFile(100L, 5L, USER_ID);
+    }
+
+    @Test
+    @DisplayName("tag_file：非法 type——service 抛出的 IllegalArgumentException 转成可行动错误文案")
+    void tagFileRejectsIllegalType() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        when(tagService.getOrCreateTag(eq(PROJECT_ID), eq("张三"), eq("BOGUS"), any()))
+                .thenThrow(new IllegalArgumentException("非法的标签类型：BOGUS"));
+
+        String out = tools.tag_file(100L, "张三", "BOGUS", PROJECT_ID, USER_ID);
+
+        assertTrue(out.startsWith("错误"), out);
+        assertTrue(out.contains("非法的标签类型"), out);
+        verify(fileTagService, never()).addTagToFile(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("tag_file：文件不属于当前项目——拒绝，不调用 service")
+    void tagFileRejectsFileFromAnotherProject() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, OTHER_PROJECT_ID)));
+
+        String out = tools.tag_file(100L, "张三", "PARTY", PROJECT_ID, USER_ID);
+
+        assertFalse(out.isBlank());
+        verify(tagService, never()).getOrCreateTag(any(), any(), any(), any());
+        verify(fileTagService, never()).addTagToFile(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("tag_file：文件不存在——返回明确错误")
+    void tagFileRejectsMissingFile() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.empty());
+
+        String out = tools.tag_file(100L, "张三", "PARTY", PROJECT_ID, USER_ID);
+
+        assertTrue(out.startsWith("错误"), out);
+    }
+
+    @Test
+    @DisplayName("tag_remove_from_file：标签存在且已挂——移除成功")
+    void removeSucceeds() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        Tag t = tag(5L, "张三", "PARTY", "#B45309");
+        when(tagService.getProjectTags(PROJECT_ID)).thenReturn(List.of(t));
+        when(fileTagService.getTagsByFileId(100L)).thenReturn(List.of(t));
+
+        String out = tools.tag_remove_from_file(100L, "张三", PROJECT_ID);
+
+        assertTrue(out.contains("张三"), out);
+        verify(fileTagService).removeTagFromFile(100L, 5L);
+    }
+
+    @Test
+    @DisplayName("tag_remove_from_file：标签不存在——返回说明性文本，不抛错")
+    void removeMissingTagReturnsExplanation() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        when(tagService.getProjectTags(PROJECT_ID)).thenReturn(List.of());
+
+        String out = tools.tag_remove_from_file(100L, "不存在的标签", PROJECT_ID);
+
+        assertFalse(out.isBlank());
+        assertFalse(out.startsWith("错误"), out);
+        verify(fileTagService, never()).removeTagFromFile(any(), any());
+    }
+
+    @Test
+    @DisplayName("tag_remove_from_file：标签存在但文件本来没挂——返回说明性文本，不抛错")
+    void removeUnattachedTagReturnsExplanation() {
+        when(projectFileRepository.findById(100L)).thenReturn(Optional.of(file(100L, PROJECT_ID)));
+        Tag t = tag(5L, "张三", "PARTY", "#B45309");
+        when(tagService.getProjectTags(PROJECT_ID)).thenReturn(List.of(t));
+        when(fileTagService.getTagsByFileId(100L)).thenReturn(List.of());
+
+        String out = tools.tag_remove_from_file(100L, "张三", PROJECT_ID);
+
+        assertFalse(out.isBlank());
+        assertFalse(out.startsWith("错误"), out);
+        verify(fileTagService, never()).removeTagFromFile(any(), any());
+    }
+
+    @Test
+    @DisplayName("tag_list：按类型分组渲染当事人/争议焦点/普通标签三段")
+    void tagListGroupsByType() {
+        when(tagService.getProjectTags(PROJECT_ID)).thenReturn(List.of(
+                tag(1L, "张三", "PARTY", "#B45309"),
+                tag(2L, "李四", "PARTY", "#B45309"),
+                tag(3L, "违约责任", "ISSUE", "#9B1C31"),
+                tag(4L, "证据一", "NORMAL", "#3B82F6"),
+                tag(5L, "证据二", null, "#3B82F6")
+        ));
+
+        String out = tools.tag_list(PROJECT_ID);
+
+        assertTrue(out.contains("张三"), out);
+        assertTrue(out.contains("李四"), out);
+        assertTrue(out.contains("违约责任"), out);
+        assertTrue(out.contains("证据一"), out);
+        assertTrue(out.contains("证据二"), out);
+        assertTrue(out.contains("当事人"), out);
+        assertTrue(out.contains("争议焦点"), out);
+        assertTrue(out.contains("普通标签"), out);
+    }
+
+    @Test
+    @DisplayName("tag_list：空标签清单返回明确文案，不是空字符串")
+    void tagListEmptyReturnsExplicitText() {
+        when(tagService.getProjectTags(PROJECT_ID)).thenReturn(List.of());
+
+        String out = tools.tag_list(PROJECT_ID);
+
+        assertFalse(out.isBlank(), "空工具输出会掀翻整轮对话，必须给明确文案");
+    }
+
+    @Test
+    @DisplayName("tag_list：projectId 缺失时返回可行动错误，不调用 service")
+    void tagListRejectsMissingProjectId() {
+        String out = tools.tag_list(null);
+
+        assertTrue(out.startsWith("错误"), out);
+        verify(tagService, never()).getProjectTags(any());
+    }
+}

--- a/docs/superpowers/specs/2026-08-20-file-party-issue-tags-design.md
+++ b/docs/superpowers/specs/2026-08-20-file-party-issue-tags-design.md
@@ -1,0 +1,80 @@
+# 文件关联到当事人/争议焦点（标签类型维度）设计 spec
+
+日期：2026-08-20 ｜ 看板卡：dev-board#63 ｜ 状态：待维护者过目
+
+## 背景与目标
+
+发布视频立项（dev-board#61）时暴露的产品缺口：文件只能打普通标签，没有「这份证据属于哪个当事人 / 支撑哪个争议焦点」的归档维度。维护者口径：「要么接下来很快迭代上，要么用现在的 tag 系统」。视频脚本 v2 暂按现有标签体系写，此卡做真功能；若在视频录制周（约 2026-08-27）前落地，视频镜头随之升级。
+
+目标：律师（或 AI）能把文件标到具体当事人与争议焦点上，文件树与搜索面板能按这两个维度分组浏览/筛选。
+
+## 方案取舍
+
+**A. 给标签加「类型」维度（推荐，本 spec 采纳）**：`project_tag` 表加一列 `type`（`NORMAL` / `PARTY` / `ISSUE`），全部下游管线（文件-标签关联、去重、鉴权、搜索筛选、色条、chip 渲染）原样复用。当事人/争点就是两类特殊标签。
+
+**B. 独立实体（party 表 + issue 表 + 各自的文件关联表）**：结构化更强（可挂原告/被告角色），但要把标签管线的 CRUD、鉴权、UI、搜索整套复制两遍；且今天没有任何消费方需要结构——诉讼可视化的当事人是每张图的 semantic-map JSON 里的字符串（无 DB 实体），`project_memory.parties` 是喂 AI 的 JSON 列。为不存在的消费方建结构违反 YAGNI，一周也做不完。
+
+**裁决：A。** 与诉讼可视化/项目记忆的打通留一条不需要改 schema 的桥：将来谁要当事人清单，查 `type=PARTY` 的标签即得（一条查询，届时再做）。
+
+一个文件可以同时挂多个当事人/多个争点（一份合同涉及双方当事人是常态），多对多天然由现有 `project_file_tag` 承载——这也是 A 优于「文件加一列 partyId」的原因。
+
+## 数据模型
+
+`Tag` 实体加一列：
+
+```java
+/** 标签类型：NORMAL 普通 / PARTY 当事人 / ISSUE 争议焦点；null 视同 NORMAL（存量行） */
+@Column(length = 16)
+private String type;
+```
+
+- 可空、无 DB 默认值：存量行全部为 null，读侧（前端与 AI 工具）把 null 当 NORMAL，**零迁移**。
+- 白名单校验在 TagService（非法值抛 IllegalArgumentException），不做 JPA enum（存量 H2 列演进走 ddl-auto 加列，字符串最稳）。
+- 同名唯一约束不变（projectId+name 全局唯一，不分型）：同一个「张三」不该既是普通标签又是当事人，撞名时提示已存在，用户可去标签管理改型。
+
+## API（全部沿用现有端点，只加字段）
+
+- `GET /api/projects/{id}/tags` — Tag 实体直接序列化，自动带上 `type`，前端无需新端点。
+- `POST /api/projects/{id}/tags`、`PUT /tags/{tagId}` — 请求体加可选 `type`；`PUT` 允许改型（存量普通标签「张三」可升级成当事人）。
+- 文件挂标签/摘标签端点不动。
+
+## AI 工具（新建 `TagTools`，照 `TaskTools` 形制）
+
+| 工具 | 签名要点 | 说明 |
+|---|---|---|
+| `tag_list` | 无参 | 返回项目标签清单按类型分组。工具描述明确：打标签前**必须**先看清单、优先复用既有名字（AutoTagging 同义词膨胀到单文件 338 标签的教训写进描述） |
+| `tag_file` | fileId, tagName, type | get-or-create（复用 projectId+name 去重）后挂到文件，幂等（已挂即返回成功）。type 缺省 NORMAL |
+| `tag_remove_from_file` | fileId, tagName | 摘错了能改；只解关联不删标签 |
+
+- `tag_file` 撞上同名但类型不同的既有标签时：**复用既有标签、不改型**，工具返回文本里说明实际类型（改型是用户在标签管理里的决定，AI 不许静默改）。
+- projectId/userId 走 `SERVER_CONTEXT_PARAMS` 注入（防跨项目越权，同 TaskTools）。
+- 接线三处：自动注册（`@Component` + `AgentToolComponent`）之外，手工同步 `RealToolBeans.instantiateAll()`（漏了 `EvalToolBeanParityTest` 会红）+ `frontend/src/utils/toolDisplayNames.js`（中英显示名）。base 工具不进任何 skill.yml 的 allowed_tools（留空语义那颗雷与此无关，这三个是通用工具）。
+- 视频镜头由此成立：对话里说「把这批证据按当事人和争议焦点归档」→ AI `tag_list` → `extract_file_text` → `tag_file`。
+
+## 前端 UI
+
+1. **TagSelector.vue**（管理标签弹窗里的选择器）：可选标签按「当事人 / 争议焦点 / 标签」三组展示；新建入口加类型三段控件（默认普通）。
+2. **TagManager.vue**（全局标签管理）：列表显示类型、编辑可改型。
+3. **TagChip.vue / 文件树色条**：不动。类型的视觉表达靠**建型时的默认色系**：当事人默认 `#B45309`（琥珀褐）、争点默认 `#9B1C31`（深红褐）、普通仍默认蓝，颜色照旧可改。不加图标不加 emoji（全局红线）。
+4. **SearchPanel.vue**：标签筛选区展开后按「当事人 / 争议焦点 / 其他标签」三个分组头（沿用 `--awd-panel-*` 分组头形制）分块渲染，组内排序规则不变（已选优先 → 命中数 → 名称）；折叠态常驻已选行、24 个截断、过滤框等机制全部不动。
+5. **i18n**：zh + en 双份 locale（EN 版红线），涉及 `fileTree.*`、`files.*`、标签管理与工具显示名。
+
+## 非目标（本期不做）
+
+- **AutoTaggingService 不动**：自动打标签继续只产普通系统标签。当事人/争点判定需要通读案情，不适合挂在「每次自动保存跑一次」的便宜档链路上；按需归档走对话 AI 工具。
+- 不做当事人角色（原告/被告）、不做与诉讼可视化 semantic-map 的实体级打通、不做 `project_memory.parties` 回写——桥已留（`type=PARTY` 查询），消费方出现再接。
+
+## 实施清单与验证
+
+1. 后端：Tag 加列 + TagService 白名单/型参 + TagController 请求体 → `mvn test -Dtest='TagServiceTest,TagControllerTest'`（新增）
+2. 后端：TagTools 三工具 + RealToolBeans → `TagToolsTest`（新增，照 TaskToolsTest）+ `EvalToolBeanParityTest`
+3. 前端：四个组件 + i18n + toolDisplayNames → `npm run check:emits` + `npm run build:h5`
+4. 人工走查（dev H5 接 5269 后端配方）：建当事人标签 → 文件挂标 → 搜索面板分组筛选 → 对话让 AI 归档一批文件
+
+预估改动量：后端约 300 行、前端约 250 行，视频录制周前可完成。
+
+## 开放问题（默认答案，维护者可推翻）
+
+1. 类型档位就三档（普通/当事人/争点）够吗？「证据」等更多档位本期不加（YAGNI，加档位是加一个枚举值的事）。
+2. 默认色系（当事人琥珀褐 / 争点深红褐）接受吗？
+3. FileTree 文件树本体要不要也出「按当事人分组」的视图？本期不做（文件树是目录结构，分组浏览由搜索面板承担），说得动就加。

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -2827,14 +2827,15 @@ export default {
        }
     },
     async handleCreateNewTag(payload) {
-       // payload can be string (legacy) or { name, color } object
+       // payload can be string (legacy) or { name, color, type } object
        const tagName = typeof payload === 'string' ? payload : payload?.name
        const tagColor = typeof payload === 'object' ? payload?.color : '#5BD197'
+       const tagType = typeof payload === 'object' ? payload?.type : undefined
 
        if (!this.targetFileForTags || !tagName) return
        try {
          // 1. Create Tag
-         const res = await createTag(this.projectId, { name: tagName, color: tagColor })
+         const res = await createTag(this.projectId, { name: tagName, color: tagColor, type: tagType })
          const newTag = res.data || res
 
          // 2. Refresh available tags

--- a/frontend/src/components/SearchPanel.vue
+++ b/frontend/src/components/SearchPanel.vue
@@ -68,18 +68,25 @@
             :placeholder="$t('files.tagFilterPlaceholder')"
           />
         </view>
-        <view class="tags-container">
-          <view
-            v-for="tag in shownTags"
-            :key="tag.id"
-            class="tag-chip"
-            :class="{ selected: selectedTagIds.includes(tag.id) }"
-            :style="getTagStyle(tag)"
-            @tap="toggleTag(tag.id)"
-          >
-            <text class="tag-name">{{ tag.name }}</text>
+        <!-- 分组只是展示形式，过滤/截断/排序全部作用于 shownTags 这一份全量列表，
+             按组切片渲染，不另起一套逻辑（三个分组共用一份过滤与截断） -->
+        <template v-for="group in shownTagGroups" :key="group.type">
+          <view v-if="group.tags.length > 0" class="tag-subsec-head">
+            <text class="tag-subsec-title">{{ $t(group.labelKey) }}</text>
           </view>
-        </view>
+          <view v-if="group.tags.length > 0" class="tags-container">
+            <view
+              v-for="tag in group.tags"
+              :key="tag.id"
+              class="tag-chip"
+              :class="{ selected: selectedTagIds.includes(tag.id) }"
+              :style="getTagStyle(tag)"
+              @tap="toggleTag(tag.id)"
+            >
+              <text class="tag-name">{{ tag.name }}</text>
+            </view>
+          </view>
+        </template>
         <text
           class="tag-more"
           v-if="filteredTags.length > shownTags.length"
@@ -155,6 +162,7 @@
 <script>
 import { searchProjectContent, getProjectTags } from '@/services/api'
 import FileTypeIcon from '@/components/FileTypeIcon.vue'
+import { TAG_TYPE_PARTY, TAG_TYPE_ISSUE, TAG_TYPE_NORMAL, normalizeTagType } from '@/utils/tagTypes.js'
 
 // 标签超过这个数量才值得再给它一个过滤框
 const TAG_FILTER_THRESHOLD = 12
@@ -231,6 +239,16 @@ export default {
     shownTags() {
       if (this.tagsExpanded || this.tagFilter.trim()) return this.filteredTags
       return this.filteredTags.slice(0, TAG_MAX_COLLAPSED)
+    },
+    // 展开态按「当事人 / 争议焦点 / 其他标签」三组渲染；shownTags 已经算好过滤+截断，
+    // 这里只按类型切片，组内相对顺序原样保留（filteredTags 排好的序不受影响）
+    shownTagGroups() {
+      const list = this.shownTags
+      return [
+        { type: TAG_TYPE_PARTY, labelKey: 'files.tagGroupParty', tags: list.filter(t => normalizeTagType(t) === TAG_TYPE_PARTY) },
+        { type: TAG_TYPE_ISSUE, labelKey: 'files.tagGroupIssue', tags: list.filter(t => normalizeTagType(t) === TAG_TYPE_ISSUE) },
+        { type: TAG_TYPE_NORMAL, labelKey: 'files.tagGroupOther', tags: list.filter(t => normalizeTagType(t) === TAG_TYPE_NORMAL) }
+      ]
     }
   },
   mounted() {
@@ -543,6 +561,22 @@ $border-color: #E9ECEF;
   cursor: pointer;
 
   &:hover { text-decoration: underline; }
+}
+
+/* 展开态内的三段分组头（当事人/争议焦点/其他标签）：与 .tag-sec-head 同一套令牌，
+   不折叠、不带计数/清除按钮——判据类型已经写在标题里了 */
+.tag-subsec-head {
+  display: flex;
+  align-items: center;
+  height: var(--awd-panel-sec-h);
+  padding: 0 var(--awd-panel-pad-x);
+}
+
+.tag-subsec-title {
+  font-size: var(--awd-panel-fs-sec);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--awd-panel-text-2);
 }
 
 .tag-filter-box {

--- a/frontend/src/components/TagManager.vue
+++ b/frontend/src/components/TagManager.vue
@@ -11,20 +11,30 @@
     
     <view class="content">
       <view class="add-section">
-        <input 
-          v-model="newTagName" 
-          class="new-tag-input" 
+        <input
+          v-model="newTagName"
+          class="new-tag-input"
           :placeholder="$t('files.tagNamePlaceholder')"
           @confirm="handleAdd"
         />
-        <view 
+        <view
           class="color-picker"
           :style="{ backgroundColor: newTagColor }"
           @click="toggleColorPicker"
         ></view>
         <button class="add-btn" @click="handleAdd" :disabled="!newTagName">{{ $t('files.add') }}</button>
       </view>
-      
+
+      <view class="type-segment">
+        <view
+          v-for="opt in typeOptions"
+          :key="opt.type"
+          class="type-segment-option"
+          :class="{ selected: newTagType === opt.type }"
+          @click="selectNewTagType(opt.type)"
+        >{{ $t(opt.labelKey) }}</view>
+      </view>
+
       <view v-if="showColorPicker" class="color-options">
         <view 
           v-for="color in presetColors" 
@@ -46,18 +56,31 @@
           <view v-for="tag in tags" :key="tag.id" class="tag-row">
             <view class="tag-info">
               <view class="tag-dot" :style="{ backgroundColor: tag.color }"></view>
-              <input 
-                v-if="editingId === tag.id"
-                v-model="editName"
-                class="edit-input"
-                focus
-                @blur="saveEdit(tag)"
-                @confirm="saveEdit(tag)"
-              />
-              <text v-else class="tag-name-text" @click="startEdit(tag)">{{ tag.name }}</text>
-              <text v-if="tag.isSystem" class="system-badge">{{ $t('files.systemBadge') }}</text>
+              <view v-if="editingId === tag.id" class="edit-block">
+                <input
+                  v-model="editName"
+                  class="edit-input"
+                  focus
+                  @confirm="saveEdit(tag)"
+                />
+                <view class="type-segment edit-type-segment">
+                  <view
+                    v-for="opt in typeOptions"
+                    :key="opt.type"
+                    class="type-segment-option"
+                    :class="{ selected: editType === opt.type }"
+                    @click="editType = opt.type"
+                  >{{ $t(opt.labelKey) }}</view>
+                </view>
+                <view class="edit-save-btn" @click="saveEdit(tag)">{{ $t('common.confirm') }}</view>
+              </view>
+              <template v-else>
+                <text class="tag-name-text" @click="startEdit(tag)">{{ tag.name }}</text>
+                <text class="type-badge" :class="'type-' + normType(tag).toLowerCase()">{{ $t(tagTypeLabelKey(tag)) }}</text>
+                <text v-if="tag.isSystem" class="system-badge">{{ $t('files.systemBadge') }}</text>
+              </template>
             </view>
-            <view class="actions">
+            <view class="actions" v-if="editingId !== tag.id">
               <view class="action-btn edit" @click="startEdit(tag)">
                 <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" width="16" height="16">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -78,6 +101,14 @@
 
 <script>
 import api from '@/services/api.js'
+import {
+  TAG_TYPE_NORMAL,
+  TAG_TYPE_PARTY,
+  TAG_TYPE_ISSUE,
+  TAG_TYPE_DEFAULT_COLORS,
+  TAG_TYPE_I18N_KEYS,
+  normalizeTagType
+} from '@/utils/tagTypes.js'
 
 export default {
   props: {
@@ -90,14 +121,23 @@ export default {
     return {
       tags: [],
       newTagName: '',
-      newTagColor: '#3B82F6',
+      newTagType: TAG_TYPE_NORMAL,
+      newTagColor: TAG_TYPE_DEFAULT_COLORS[TAG_TYPE_NORMAL],
       showColorPicker: false,
       presetColors: [
-        '#EF4444', '#F97316', '#F59E0B', '#10B981', '#3B82F6', 
-        '#6366F1', '#8B5CF6', '#EC4899', '#6B7280', '#000000'
+        '#EF4444', '#F97316', '#F59E0B', '#10B981', '#3B82F6',
+        '#6366F1', '#8B5CF6', '#EC4899', '#6B7280', '#000000',
+        '#B45309', '#9B1C31'
+      ],
+      // 新建/编辑标签共用的类型三段控件
+      typeOptions: [
+        { type: TAG_TYPE_NORMAL, labelKey: 'files.tagTypeNormal' },
+        { type: TAG_TYPE_PARTY, labelKey: 'files.tagTypeParty' },
+        { type: TAG_TYPE_ISSUE, labelKey: 'files.tagTypeIssue' }
       ],
       editingId: null,
-      editName: ''
+      editName: '',
+      editType: TAG_TYPE_NORMAL
     }
   },
   mounted() {
@@ -122,14 +162,28 @@ export default {
       this.newTagColor = color;
       this.showColorPicker = false;
     },
+    selectNewTagType(type) {
+      this.newTagType = type;
+      // 换型时把颜色带到该型的默认色，色板里仍可手动改
+      this.newTagColor = TAG_TYPE_DEFAULT_COLORS[type];
+    },
+    normType(tag) {
+      return normalizeTagType(tag);
+    },
+    tagTypeLabelKey(tag) {
+      return TAG_TYPE_I18N_KEYS[normalizeTagType(tag)];
+    },
     async handleAdd() {
       if (!this.newTagName.trim()) return;
       try {
         await api.createTag(this.projectId, {
           name: this.newTagName.trim(),
-          color: this.newTagColor
+          color: this.newTagColor,
+          type: this.newTagType
         });
         this.newTagName = '';
+        this.newTagType = TAG_TYPE_NORMAL;
+        this.newTagColor = TAG_TYPE_DEFAULT_COLORS[TAG_TYPE_NORMAL];
         this.refreshTags();
       } catch (e) {
         uni.showToast({ title: 'Failed to create tag', icon: 'none' });
@@ -138,14 +192,19 @@ export default {
     startEdit(tag) {
       this.editingId = tag.id;
       this.editName = tag.name;
+      this.editType = normalizeTagType(tag);
     },
     async saveEdit(tag) {
       if (!this.editingId) return;
-      if (this.editName.trim() && this.editName !== tag.name) {
+      const trimmedName = this.editName.trim();
+      const nameChanged = trimmedName && trimmedName !== tag.name;
+      const typeChanged = this.editType !== normalizeTagType(tag);
+      if (nameChanged || typeChanged) {
         try {
           await api.updateTag(this.projectId, tag.id, {
-            name: this.editName.trim(),
-            color: tag.color // Keep color for now, or allow editing
+            name: nameChanged ? trimmedName : tag.name,
+            color: tag.color, // Keep color for now, or allow editing
+            type: this.editType
           });
           await this.refreshTags();
         } catch (e) {
@@ -257,6 +316,37 @@ export default {
   background: #ccc;
 }
 
+.type-segment {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.type-segment-option {
+  flex: 1;
+  text-align: center;
+  padding: 5px 0;
+  font-size: 12px;
+  color: #666;
+  background: #f3f4f6;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.type-segment-option:hover {
+  background: #e5e7eb;
+}
+
+.type-segment-option.selected {
+  background: #1A5336;
+  color: #fff;
+}
+
+.edit-type-segment {
+  margin: 6px 0 0;
+}
+
 .color-options {
   display: flex;
   flex-wrap: wrap;
@@ -318,6 +408,35 @@ export default {
   font-size: 14px;
   color: #333;
   cursor: pointer;
+}
+
+.type-badge {
+  font-size: 10px;
+  color: #6b7280;
+  background: #f3f4f6;
+  padding: 1px 4px;
+  border-radius: 4px;
+  margin-left: 8px;
+}
+
+.edit-block {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.edit-save-btn {
+  align-self: flex-end;
+  margin-top: 6px;
+  font-size: 12px;
+  color: #1A5336;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 2px 8px;
+}
+
+.edit-save-btn:hover {
+  text-decoration: underline;
 }
 
 .edit-input {

--- a/frontend/src/components/TagSelector.vue
+++ b/frontend/src/components/TagSelector.vue
@@ -22,6 +22,17 @@
           <text class="picker-title">{{ $t('files.createNewTag', { name: pendingTagName }) }}</text>
         </view>
 
+        <text class="picker-subtitle">{{ $t('files.tagTypeLabel') }}</text>
+        <view class="type-segment">
+          <view
+            v-for="opt in typeOptions"
+            :key="opt.type"
+            class="type-segment-option"
+            :class="{ selected: selectedType === opt.type }"
+            @click="selectType(opt.type)"
+          >{{ $t(opt.labelKey) }}</view>
+        </view>
+
         <text class="picker-subtitle">{{ $t('files.pickColor') }}</text>
         <scroll-view scroll-x class="color-scroll" :show-scrollbar="false">
             <view class="color-row">
@@ -51,15 +62,18 @@
       <!-- Normal Search/Select Mode -->
       <template v-else>
         <view v-if="filteredTags.length > 0" class="tag-list">
-          <view 
-            v-for="tag in filteredTags" 
-            :key="tag.id" 
-            class="tag-option"
-            @click="selectTag(tag)"
-          >
-            <view :style="{backgroundColor: tag.color}" class="color-dot"></view>
-            <text>{{ tag.name }}</text>
-          </view>
+          <template v-for="group in tagGroups" :key="group.type">
+            <text v-if="group.tags.length > 0" class="tag-group-head">{{ $t(group.labelKey) }}</text>
+            <view
+              v-for="tag in group.tags"
+              :key="tag.id"
+              class="tag-option"
+              @click="selectTag(tag)"
+            >
+              <view :style="{backgroundColor: tag.color}" class="color-dot"></view>
+              <text>{{ tag.name }}</text>
+            </view>
+          </template>
         </view>
         <view v-else-if="searchText" class="no-tags">
           <text>{{ $t('files.noTagsFound') }}</text>
@@ -86,6 +100,14 @@
 </template>
 
 <script>
+import {
+  TAG_TYPE_NORMAL,
+  TAG_TYPE_PARTY,
+  TAG_TYPE_ISSUE,
+  TAG_TYPE_DEFAULT_COLORS,
+  groupTagsByType
+} from '@/utils/tagTypes.js'
+
 export default {
   props: {
     availableTags: {
@@ -107,22 +129,39 @@ export default {
       showDropdown: false,
       isCreatingTag: false,
       pendingTagName: '',
-      selectedColor: '#5BD197', // Default to Mint Green
+      selectedType: TAG_TYPE_NORMAL,
+      selectedColor: TAG_TYPE_DEFAULT_COLORS[TAG_TYPE_NORMAL],
       presetColors: [
-        '#EF4444', '#F97316', '#F59E0B', '#84CC16', '#10B981', 
+        '#EF4444', '#F97316', '#F59E0B', '#84CC16', '#10B981',
         '#5BD197', '#14B8A6', '#06B6D4', '#3B82F6', '#6366F1',
-        '#8B5CF6', '#A855F7', '#EC4899', '#F43F5E', '#6B7280'
+        '#8B5CF6', '#A855F7', '#EC4899', '#F43F5E', '#6B7280',
+        '#B45309', '#9B1C31'
+      ],
+      // 新建标签弹层里的类型三段控件，顺序与分组顺序一致
+      typeOptions: [
+        { type: TAG_TYPE_NORMAL, labelKey: 'files.tagTypeNormal' },
+        { type: TAG_TYPE_PARTY, labelKey: 'files.tagTypeParty' },
+        { type: TAG_TYPE_ISSUE, labelKey: 'files.tagTypeIssue' }
       ]
     }
   },
   computed: {
     filteredTags() {
       const unassignedTags = this.availableTags.filter(t => !this.existingTagIds.includes(t.id));
-      
+
       if (!this.searchText) return unassignedTags;
-      
+
       const lower = this.searchText.toLowerCase();
       return unassignedTags.filter(t => t.name.toLowerCase().includes(lower));
+    },
+    // 可选标签按「当事人 / 争议焦点 / 标签」三组展示，空组不渲染组头（模板里判空）
+    tagGroups() {
+      const grouped = groupTagsByType(this.filteredTags);
+      return [
+        { type: TAG_TYPE_PARTY, labelKey: 'files.tagGroupParty', tags: grouped[TAG_TYPE_PARTY] },
+        { type: TAG_TYPE_ISSUE, labelKey: 'files.tagGroupIssue', tags: grouped[TAG_TYPE_ISSUE] },
+        { type: TAG_TYPE_NORMAL, labelKey: 'files.tagGroupNormal', tags: grouped[TAG_TYPE_NORMAL] }
+      ];
     }
   },
   methods: {
@@ -138,18 +177,25 @@ export default {
     selectColor(color) {
       this.selectedColor = color;
     },
+    selectType(type) {
+      this.selectedType = type;
+      // 换型时把颜色带到该型的默认色，选完仍可在下面色板里手动改
+      this.selectedColor = TAG_TYPE_DEFAULT_COLORS[type];
+    },
     cancelCreate() {
       this.isCreatingTag = false;
       this.pendingTagName = '';
-      this.selectedColor = '#5BD197';
+      this.selectedType = TAG_TYPE_NORMAL;
+      this.selectedColor = TAG_TYPE_DEFAULT_COLORS[TAG_TYPE_NORMAL];
     },
     confirmCreate() {
-      this.$emit('create', { name: this.pendingTagName, color: this.selectedColor });
+      this.$emit('create', { name: this.pendingTagName, color: this.selectedColor, type: this.selectedType });
       this.searchText = '';
       this.showDropdown = false;
       this.isCreatingTag = false;
       this.pendingTagName = '';
-      this.selectedColor = '#5BD197';
+      this.selectedType = TAG_TYPE_NORMAL;
+      this.selectedColor = TAG_TYPE_DEFAULT_COLORS[TAG_TYPE_NORMAL];
     },
     openManager() {
       this.$emit('manage');
@@ -231,7 +277,16 @@ export default {
   overflow-y: auto;
   flex: 1;
   /* Enforce max height for the scrolling part to keep footer visible */
-  max-height: 180px; 
+  max-height: 180px;
+}
+
+.tag-group-head {
+  display: block;
+  padding: 6px 12px 2px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #9ca3af;
 }
 /* Custom Scrollbar */
 .tag-list::-webkit-scrollbar {
@@ -328,6 +383,33 @@ export default {
     color: #666;
     margin-bottom: 6px;
     display: block;
+}
+
+.type-segment {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.type-segment-option {
+    flex: 1;
+    text-align: center;
+    padding: 5px 0;
+    font-size: 12px;
+    color: #666;
+    background: #f3f4f6;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.type-segment-option:hover {
+    background: #e5e7eb;
+}
+
+.type-segment-option.selected {
+    background: #1A5336;
+    color: #fff;
 }
 
 .color-scroll {

--- a/frontend/src/locales/en-US/files.js
+++ b/frontend/src/locales/en-US/files.js
@@ -108,6 +108,15 @@ export default {
   deleteTagTitle: 'Delete Tag',
   deleteTagConfirm: 'Delete tag "{name}"?',
   deleteFailed: 'Failed to delete',
+  // Tag type dimension (dev-board#63): shared by TagSelector/TagManager/SearchPanel
+  tagTypeNormal: 'General',
+  tagTypeParty: 'Party',
+  tagTypeIssue: 'Issue',
+  tagTypeLabel: 'Type',
+  tagGroupParty: 'Party',
+  tagGroupIssue: 'Issue',
+  tagGroupNormal: 'Tags',
+  tagGroupOther: 'Other Tags',
   // MarkdownPreview.vue
   loadingDots: 'Loading...',
   loadFailedWithReason: 'Failed to load: {reason}',

--- a/frontend/src/locales/zh-CN/files.js
+++ b/frontend/src/locales/zh-CN/files.js
@@ -108,6 +108,15 @@ export default {
   deleteTagTitle: '删除标签',
   deleteTagConfirm: '确定要删除标签 "{name}" 吗？',
   deleteFailed: '删除失败',
+  // 标签类型维度（dev-board#63）：TagSelector/TagManager/SearchPanel 共用
+  tagTypeNormal: '普通',
+  tagTypeParty: '当事人',
+  tagTypeIssue: '争议焦点',
+  tagTypeLabel: '类型',
+  tagGroupParty: '当事人',
+  tagGroupIssue: '争议焦点',
+  tagGroupNormal: '标签',
+  tagGroupOther: '其他标签',
   // MarkdownPreview.vue
   loadingDots: '正在加载...',
   loadFailedWithReason: '加载失败: {reason}',

--- a/frontend/src/utils/tagTypes.js
+++ b/frontend/src/utils/tagTypes.js
@@ -1,0 +1,44 @@
+// tagTypes.js — 标签类型维度共享 helper（dev-board#63，见
+// docs/superpowers/specs/2026-08-20-file-party-issue-tags-design.md）。
+//
+// 后端 Tag.type 是 "NORMAL"/"PARTY"/"ISSUE"，可空、无 DB 默认值：存量行全部为 null。
+// 前端所有类型判断一律走 normalizeTagType()，不要自己写 tag.type === 'PARTY'，
+// 否则漏判 null/undefined 会把存量标签算成「无类型」而不是「普通标签」。
+
+export const TAG_TYPE_NORMAL = 'NORMAL'
+export const TAG_TYPE_PARTY = 'PARTY'
+export const TAG_TYPE_ISSUE = 'ISSUE'
+
+// 展示顺序：当事人 / 争议焦点 / 普通标签——TagSelector、SearchPanel 的分组顺序都按此来
+export const TAG_TYPE_ORDER = [TAG_TYPE_PARTY, TAG_TYPE_ISSUE, TAG_TYPE_NORMAL]
+
+// null/undefined 视同 NORMAL（存量行口径，零迁移）
+export function normalizeTagType(tag) {
+  const type = tag && tag.type
+  return type === TAG_TYPE_PARTY || type === TAG_TYPE_ISSUE ? type : TAG_TYPE_NORMAL
+}
+
+// 建标签时的默认色系（spec 定案；颜色之后仍可在标签管理里改，这里只管新建默认值）
+export const TAG_TYPE_DEFAULT_COLORS = {
+  [TAG_TYPE_PARTY]: '#B45309',
+  [TAG_TYPE_ISSUE]: '#9B1C31',
+  [TAG_TYPE_NORMAL]: '#3B82F6'
+}
+
+// 类型名走 locale 文件（EN 版红线），这里只维护「类型 → i18n key」的映射，
+// 组件里用 $t(TAG_TYPE_I18N_KEYS[type]) 取当前语言下的显示名。
+export const TAG_TYPE_I18N_KEYS = {
+  [TAG_TYPE_PARTY]: 'files.tagTypeParty',
+  [TAG_TYPE_ISSUE]: 'files.tagTypeIssue',
+  [TAG_TYPE_NORMAL]: 'files.tagTypeNormal'
+}
+
+// 按类型分组，供 TagSelector/SearchPanel 的三段式分组渲染共用一份口径，
+// 组内不排序（排序规则各消费方不同：TagSelector 是原顺序，SearchPanel 另有命中数排序）。
+export function groupTagsByType(tags) {
+  const groups = { [TAG_TYPE_PARTY]: [], [TAG_TYPE_ISSUE]: [], [TAG_TYPE_NORMAL]: [] }
+  ;(tags || []).forEach(tag => {
+    groups[normalizeTagType(tag)].push(tag)
+  })
+  return groups
+}

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -53,6 +53,10 @@ const NAMES = {
   create_folder: { zh: '新建文件夹', en: 'Create folder' },
   rename_project_file: { zh: '重命名文件', en: 'Rename file' },
   move_project_file: { zh: '移动文件', en: 'Move file' },
+  // 标签（TagTools，标签类型维度 dev-board#63）
+  tag_list: { zh: '查看项目标签', en: 'List tags' },
+  tag_file: { zh: '给文件打标签', en: 'Tag file' },
+  tag_remove_from_file: { zh: '移除文件标签', en: 'Untag file' },
   // 记忆
   save_memory: { zh: '保存记忆', en: 'Save memory' },
   query_memory: { zh: '检索记忆', en: 'Query memory' },


### PR DESCRIPTION
发布视频立项时暴露的产品缺口：文件没有「属于哪个当事人 / 支撑哪个争议焦点」的归档维度。方案与裁决见随 PR 提交的 spec（docs/superpowers/specs/2026-08-20-file-party-issue-tags-design.md，维护者已过目批准，三个开放问题均按默认答案落地）。

## 改动

**后端**
- Tag 实体加 type 列（NORMAL/PARTY/ISSUE，可空，null 视同 NORMAL，存量零迁移）；同名唯一约束不分型
- TagService：类型白名单校验；getOrCreateTag 撞同名不同型时复用不改型；新建默认色按类型（当事人 #B45309 / 争点 #9B1C31 / 普通 #3B82F6）；updateTag 收 null type 表示不改型（防不带 type 的调用把标签静默抹回普通）
- 新建 TagTools 三工具：tag_list（描述强制先查再打、防同义词膨胀）/ tag_file（ToolFileGuard 归属校验、幂等挂标）/ tag_remove_from_file（只解关联不删标签）；RealToolBeans 接线
- AutoTaggingService 刻意不动

**前端**
- utils/tagTypes.js 共享 helper（normalizeTagType：null 视同 NORMAL 的唯一口径）
- TagSelector：可选标签按当事人/争议焦点/标签三组展示；新建加类型三段控件（换型带默认色）
- TagManager：行内类型徽章；编辑可改型（blur 自动保存改为显式确认按钮——加了类型控件后点类型会先触发 blur 存旧值）
- SearchPanel：展开态按三组渲染（纯展示切片，过滤/截断/排序仍是一份全局逻辑）
- FileTree 接住 create 的 type；zh+en 双语；toolDisplayNames 三条

**文档**：utility-tools.md 补标签类型维度一节（同 PR 更新领域文档规矩）

## 验证
- mvn test（JDK 21）：TagServiceTest 8 + TagToolsTest 13 + EvalToolBeanParityTest 2 + TaskToolsTest 6 = 29/29 绿
- npm run check:emits 过（97 个 .vue）；npm run build:h5 DONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)