### PR TITLE
fix(favorites): 右键收藏后可见反馈——toast 被 BrowserView 遮挡改为打开面板高亮卡片（dev-board#64）

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -88,6 +88,13 @@ local-mode 下本机后端把每个请求都当本机用户，等于把本机管
   **免费额度（PR-C）**：未拥有 `clipboard.unlimited` 时 GET / 只返回「最近 20 条 且 3 天内」，两条同时生效取更严者。**实现是查询侧过滤，绝不删除记录**——超出的行留在库里，解锁后原样可见。GET / 返回体从裸数组改为 `{items, limited, hiddenCount, maxItems, retentionDays}`（`ClipboardListResult`），hiddenCount 只算「因额度看不见」的（= 总数 − min(3天内条数, 20)），不含被分页 limit 挡住的。常量在 `ClipboardService.FREE_MAX_ITEMS/FREE_RETENTION_DAYS`。**额度只在 local-mode（桌面单机版）执行**：`EntitlementService` 是按本机的（无 userId 维度），团队案件库服务器上权益恒为空集，照执行会把每个接入成员截到 20 条且永远无法解锁。
 
 **收藏夹**：`ProjectFavoritesPanel.vue`；网页选中收藏经 `checkba:webmark`（preload ~:26）→ project-overview 订阅入库（~:2003）；后端 `controller/WebFavoriteController.java`（/api/favorites/my、/api/projects/{id}/favorites、DELETE、image）。
+  **收藏成功的反馈必须是「打开收藏面板 + focusFavorite 高亮新卡片」，不能只弹 toast**：
+  用户此刻正在浏览器标签里，toast 在 DOM 层、被原生 BrowserView 整个盖住（实测 toast
+  中心恒落在 view 区域内），只弹 toast 的现象就是「点了没反应」。右键收藏与 OCR 摘录收藏
+  （`ocrDoFavorite`）现在同用这个模式；失败提示同理走 `host.app.confirm`（原生弹窗，不被遮挡）。
+  卡片右下角的来源域名读的是 `meta.sourceHost`（`WebFavoriteListItem.from` 从 meta JSON 提取），
+  新增收藏入口时 meta 里不写 sourceHost 就永远空白。面板 `refresh(force)`：新增收藏后的刷新
+  要传 `force=true` 绕过 1.2s 节流，否则新卡片可能刷不出来、高亮落空。
 
 **搜索**：`SearchPanel.vue`；后端 `controller/SearchController.java`（POST /api/projects/{id}/search）。
 `ContentSearchService` 的全文抽取已改为复用 `DocumentTextService`（PDF 走 PDFBox3 原生

--- a/frontend/src/components/ProjectFavoritesPanel.vue
+++ b/frontend/src/components/ProjectFavoritesPanel.vue
@@ -173,10 +173,11 @@ export default {
         return String(v)
       }
     },
-    async refresh() {
+    async refresh(force = false) {
       const now = Date.now()
-      // query 变化时绕过时间节流（否则搜索框改了结果却不刷新、停留在旧关键字）；仅对相同 query 的高频刷新节流
-      if (this._lastRefreshAt && now - this._lastRefreshAt < 1200 && this.query === this._lastRefreshQuery) return
+      // query 变化时绕过时间节流（否则搜索框改了结果却不刷新、停留在旧关键字）；仅对相同 query 的高频刷新节流。
+      // force：刚新增了收藏、必须立刻把新卡片刷出来（高亮定位依赖它在列表里）
+      if (!force && this._lastRefreshAt && now - this._lastRefreshAt < 1200 && this.query === this._lastRefreshQuery) return
       this._lastRefreshAt = now
       this._lastRefreshQuery = this.query
       this.loading = true

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -2708,20 +2708,40 @@ export default {
               const imageBase64 = payload && payload.imageDataUrl ? String(payload.imageDataUrl) : ''
               if (!text || !this.projectId) return
               const pid = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
-              await createProjectFavorite(pid, {
-                title: title || (url ? (() => { try { return new URL(url).host } catch (e) { return this.$t('workbench.webMark') } })() : this.$t('workbench.webMark')),
+              const host2 = (() => { try { return url ? new URL(url).host : '' } catch (e) { return '' } })()
+              const created = await createProjectFavorite(pid, {
+                title: title || host2 || this.$t('workbench.webMark'),
                 sourceUrl: url,
                 content: text,
-                imageBase64: imageBase64 || ''
+                imageBase64: imageBase64 || '',
+                // 卡片右下角的来源域名读的是 meta.sourceHost（与 OCR 摘录路径同口径），不写就永远空白
+                meta: JSON.stringify({ kind: 'webmark', capturedAt: new Date().toISOString(), sourceUrl: url, title, sourceHost: host2 })
               })
-              // 立即刷新网核中心面板（如果可见）
-              if (this.$refs.favoritesPanel && typeof this.$refs.favoritesPanel.refresh === 'function') {
-                this.$refs.favoritesPanel.refresh()
-              }
+              // 可见反馈不能只靠 toast：用户此刻正在浏览器标签里，toast 弹在 DOM 层、
+              // 被原生 BrowserView 整个盖住（实测 toast 中心恒落在 view 区域内），看起来
+              // 就是「点了没反应」。照 OCR 摘录收藏（ocrDoFavorite）的模式：打开收藏面板
+              // 并高亮新卡片——面板参与布局，BrowserView 会让位，反馈真实可见。
+              const favId = created && created.id ? created.id : (created && created.data && created.data.id ? created.data.id : null)
+              this.showToolsPanel = true
+              this.activeToolKey = 'favorites'
+              this.$nextTick(async () => {
+                try {
+                  const panel = this.$refs.favoritesPanel
+                  if (panel && typeof panel.refresh === 'function') await panel.refresh(true)
+                  if (favId && panel && typeof panel.focusFavorite === 'function') panel.focusFavorite(Number(favId))
+                } catch (e) {
+                  // ignore
+                }
+              })
               uni.showToast({ title: this.$t('workbench.webMarkFavAdded'), icon: 'success' })
             } catch (e) {
               console.error('保存网核收藏失败:', e)
-              uni.showToast({ title: e.message || this.$t('workbench.saveFailed'), icon: 'none' })
+              // 失败也一样被 BrowserView 盖住 = 静默失败；桌面端走不被遮挡的原生确认弹窗
+              if (host.app && host.app.confirm) {
+                host.app.confirm({ title: this.$t('workbench.saveFailed'), content: e.message || '' }).catch(() => {})
+              } else {
+                uni.showToast({ title: e.message || this.$t('workbench.saveFailed'), icon: 'none' })
+              }
             }
           })
         }


### PR DESCRIPTION
## 背景

维护者反馈「收藏功能恐怕有些问题」；产品发布视频（dev-board#59）幕三要拍该功能。台账：zeweihan/dev-board#64。

## 排查结论（dev Electron + CDP + osascript 原生右键菜单真机走查）

链路本体全通：右键菜单→主进程 capturePage→IPC→POST /favorites→落库→面板卡片→截图加载→插入落文档→打开来源回跳，逐环实测无断点。真问题有二：

1. **收藏后界面无反馈（主因）**：成功/失败 toast 弹在 DOM 层，被原生 BrowserView 盖住（几何实测 toast 中心恒落在 view 区域 (312,121)-(1400,873) 内）。用户在浏览器标签里右键收藏，看起来点了没反应。
2. **卡片不显示来源域名**：右键收藏不写 meta，`meta.sourceHost`（卡片右下角来源域名的唯一数据源）永远空白——只有 OCR 摘录路径在写。

## 修法

- 成功后打开底部收藏面板 + `focusFavorite` 高亮新卡片，对齐 OCR 摘录收藏（`ocrDoFavorite`）的既有模式——面板参与布局、BrowserView 让位，反馈真实可见；失败走 `host.app.confirm`（专为不被 BrowserView 遮挡而建的原生弹窗）。
- 补写 meta（kind/capturedAt/sourceUrl/title/sourceHost），与 OCR 路径同口径。
- `ProjectFavoritesPanel.refresh(force)`：新增收藏后的刷新绕过 1.2s 节流，否则新卡片可能刷不出来、高亮落空。
- 同 PR 更新 `.claude/agents/utility-tools.md`（收藏夹条目 + toast 遮挡地雷）。

## 自验证

- 真机终验（右键→原生菜单→落库→面板自动打开→收藏 tab 激活→卡片高亮→来源域名显示）全通。
- 插入落进文档（含「网页标签切回文档标签再插入」的真实用户序列）经引擎 get_document_text 验证。
- `check:emits` / `check:locales` / `check:nav` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)