### PR TITLE
feat(marketing): 方舟临时 API Key 自动换取（免手工新建）

### DIFF
--- a/docs/marketing/launch-video/broll/README.md
+++ b/docs/marketing/launch-video/broll/README.md
@@ -89,3 +89,26 @@ node generate.mjs --all               # 生成全部（自动跳过 D 组未填�
   会自动跳过空提示词的镜头。
 
 视觉母题统一为「纸与光」，呼应官网衬线、纸白的视觉体系。
+
+## 取 ARK_API_KEY（已自动化，无需手工新建）
+
+不必去方舟控制台点「创建 API Key」。账号级 AK/SK 可以直接签名换取**临时、限定资源**的 key：
+
+```bash
+python3 docs/marketing/launch-video/broll/get-ark-key.py
+```
+
+脚本从 `.agent/CREDENTIALS.md` 读账号 AK/SK（只读、不打印），调用 OpenAPI `GetApiKey`
+（host `open.volcengineapi.com`，service=ark，region=cn-beijing，ResourceType=presetendpoint、
+ProjectName=default、ResourceIds 为视频模型 id），换取最长 30 天的 key，写入
+`.agent/ark_api_key.env`（权限 600，`.agent/` 已 gitignore）。
+
+跑生成前先加载：
+
+```bash
+set -a; source "/Users/zewei/Documents/2024-2044/5-Tech/1-2 checkba_cloud/.agent/ark_api_key.env"; set +a
+```
+
+2026-08-20 已换取一把，到期 2026-09-19；过期重跑脚本即可。这把 key 只限视频模型、且会自动过期，
+比长期 key 更稳妥。鉴权自检（不产生费用）：拿一个不存在的任务 id 查询，返回 404 ResourceNotFound
+即为鉴权正常，返回 401/403 才是 key 有问题。

--- a/docs/marketing/launch-video/broll/get-ark-key.py
+++ b/docs/marketing/launch-video/broll/get-ark-key.py
@@ -1,0 +1,88 @@
+"""用账号 AK/SK 签名调用方舟 GetApiKey，换取临时 API Key。
+密钥只从本地凭据文件读取，不打印、不入库。"""
+import datetime, hashlib, hmac, json, re, sys, urllib.request, urllib.error
+
+CRED = "/Users/zewei/Documents/2024-2044/5-Tech/1-2 checkba_cloud/.agent/CREDENTIALS.md"
+HOST, REGION, SERVICE, VERSION = "open.volcengineapi.com", "cn-beijing", "ark", "2024-01-01"
+
+
+def load_ak_sk():
+    txt = open(CRED, encoding="utf-8").read()
+    i = txt.find("## 火山引擎")
+    if i < 0:
+        sys.exit("凭据文件里找不到火山引擎段落")
+    seg = txt[i:i + 1200]
+    ak = re.search(r"\|\s*AccessKey\s*\|\s*([A-Za-z0-9_\-=+/]+)\s*\|", seg)
+    sk = re.search(r"\|\s*SecretKey\s*\|\s*([A-Za-z0-9_\-=+/]+)\s*\|", seg)
+    if not (ak and sk):
+        sys.exit("解析 AK/SK 失败")
+    return ak.group(1), sk.group(1)
+
+
+def sign(key, msg):
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def call(action, body):
+    ak, sk = load_ak_sk()
+    payload = json.dumps(body)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    xdate = now.strftime("%Y%m%dT%H%M%SZ")
+    datestamp = xdate[:8]
+    body_hash = hashlib.sha256(payload.encode()).hexdigest()
+    query = f"Action={action}&Version={VERSION}"
+
+    canonical_headers = f"host:{HOST}\nx-content-sha256:{body_hash}\nx-date:{xdate}\n"
+    signed_headers = "host;x-content-sha256;x-date"
+    canonical_request = "\n".join(
+        ["POST", "/", query, canonical_headers, signed_headers, body_hash])
+    scope = f"{datestamp}/{REGION}/{SERVICE}/request"
+    string_to_sign = "\n".join(
+        ["HMAC-SHA256", xdate, scope, hashlib.sha256(canonical_request.encode()).hexdigest()])
+
+    k = sign(sk.encode(), datestamp)
+    k = sign(k, REGION)
+    k = sign(k, SERVICE)
+    k = sign(k, "request")
+    signature = hmac.new(k, string_to_sign.encode(), hashlib.sha256).hexdigest()
+
+    req = urllib.request.Request(
+        f"https://{HOST}/?{query}", data=payload.encode(), method="POST",
+        headers={
+            "Host": HOST,
+            "Content-Type": "application/json; charset=UTF-8",
+            "X-Date": xdate,
+            "X-Content-Sha256": body_hash,
+            "Authorization": (f"HMAC-SHA256 Credential={ak}/{scope}, "
+                              f"SignedHeaders={signed_headers}, Signature={signature}"),
+        })
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode() or "{}")
+
+
+if __name__ == "__main__":
+    attempts = [
+        {"DurationSeconds": 2592000, "ResourceType": "presetendpoint",
+         "ProjectName": "default", "ResourceIds": ["doubao-seedance-1-0-pro-fast-251015"]},
+        {"DurationSeconds": 2592000, "ResourceType": "endpoint",
+         "ResourceIds": ["doubao-seedance-1-0-pro-fast-251015"]},
+    ]
+    for i, body in enumerate(attempts, 1):
+        status, data = call("GetApiKey", body)
+        result = (data or {}).get("Result") or {}
+        key = result.get("ApiKey")
+        err = (data or {}).get("ResponseMetadata", {}).get("Error") or data.get("Error")
+        print(f"[尝试{i}] ResourceType={body['ResourceType']} HTTP {status} "
+              f"{'拿到 key' if key else ''} {json.dumps(err, ensure_ascii=False) if err else ''}")
+        if key:
+            out = "/Users/zewei/Documents/2024-2044/5-Tech/1-2 checkba_cloud/.agent/ark_api_key.env"
+            with open(out, "w", encoding="utf-8") as f:
+                f.write(f"# 方舟临时 API Key，GetApiKey 换取，过期时间 {result.get('ExpiredTime')}\n")
+                f.write(f"export ARK_API_KEY={key}\n")
+            import os
+            os.chmod(out, 0o600)
+            print(f"已写入 {out}（权限 600），过期时间 {result.get('ExpiredTime')}")
+            break


### PR DESCRIPTION
dev-board #59。用账号级 AK/SK 签名调 OpenAPI GetApiKey(ResourceType=presetendpoint)，换取最长 30 天、仅限视频模型的临时 API Key，免去在方舟控制台手工创建长期 key。

- get-ark-key.py：从 .agent/CREDENTIALS.md 读 AK/SK（只读不打印），V4 签名，key 写入 .agent/ark_api_key.env（600，.agent/ 已 gitignore）；脚本内无任何硬编码密钥；
- README 补取 key 步骤与零成本鉴权自检法（查不存在的任务 id：404 = 鉴权正常，401/403 = key 有问题）。

已实测：换取成功（到期 2026-09-19），对视频接口鉴权返回 404 ResourceNotFound 即通过。未创建任何生成任务、未产生费用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)