### PR TITLE
fix(pack): build-pack 出包去掉多套的 unpackDir 顶层目录（dev-board#65）

### DIFF
--- a/desktop/scripts/build-pack.js
+++ b/desktop/scripts/build-pack.js
@@ -20,7 +20,6 @@
  * 不进 CI（NATIVE_PACK_DISTRIBUTION.md §1）。
  */
 const fs = require('fs')
-const os = require('os')
 const path = require('path')
 const crypto = require('crypto')
 const { execFileSync } = require('child_process')
@@ -96,30 +95,29 @@ function listFiles(dir, exclude) {
 // 判据，不会出现「哈希清单排除了 __pycache__，但 tar 整目录打包时忘了排除」
 // 这种两条平行逻辑对不上的漂移。
 //
-// 包内顶层目录名固定为 topName（= manifest 的 unpackDir），**不依赖 srcDir 自身
-// 的目录名**：现有三个组件恰好 srcDir 的 basename 就是组件名（litviz/drawio/
-// graphviz），但显式控制更稳妥，也让打包函数可以对着任意名字的临时目录测试。
-// 做法是建一个指向 srcDir、名字是 topName 的软链，清单里的路径写成
-// topName/<relFile>，tar -h 经软链解析到真实内容。
-function tarPack(srcDir, relFiles, archivePath, topName) {
-  const linkParent = fs.mkdtempSync(path.join(os.tmpdir(), 'aiworkdeck-pack-link-'))
-  const linkPath = path.join(linkParent, topName)
-  const listPath = path.join(linkParent, '.tar-filelist')
+// **包内条目是裸相对路径，不套顶层目录**：安装端会先建 <version>/<unpackDir>/
+// 再解压（NativePackService.doInstall），包里若再带一层目录就会落成
+// <unpackDir>/<unpackDir>/…，verifyContents 找不到 contents.sha256，
+// 安装必挂（dev-board#65 真机「组件缺少 contents.sha256 清单」的根因）。
+function tarPack(srcDir, relFiles, archivePath) {
+  // Windows 上（Git for Windows 的 GNU tar）带盘符的路径 D:\... 会被当成
+  // 远程主机（rsh 语法）报 "Cannot connect to D"。所以 cwd 钉在 srcDir、
+  // 全用相对路径出包，再把成品搬到目标位置（copy 而非 rename，兼容跨盘符）。
+  // 清单与临时包都落在 srcDir 里（与 contents.sha256 同款临时物，finally 清走），
+  // 二者都不在 relFiles 清单里，不会被打进包。
+  const listPath = path.join(srcDir, '.tar-filelist')
+  const tmpArchive = '.out.tar.gz'
   try {
-    fs.symlinkSync(srcDir, linkPath, 'dir')
     // 清单路径一律正斜杠：Windows 下 path.relative 产出反斜杠，tar 不认
-    fs.writeFileSync(listPath, relFiles.map((rel) => `${topName}/${rel.split(path.sep).join('/')}`).join('\n') + '\n')
+    fs.writeFileSync(listPath, relFiles.map((rel) => rel.split(path.sep).join('/')).join('\n') + '\n')
     const env = { ...process.env }
     if (process.platform === 'darwin') env.COPYFILE_DISABLE = '1' // 防 AppleDouble（._ 文件）
-    // Windows 上（Git for Windows 的 GNU tar）带盘符的路径 D:\... 会被当成
-    // 远程主机（rsh 语法）报 "Cannot connect to D"。所以 cwd 钉在 linkParent、
-    // 全用相对路径出包，再把成品搬到目标位置（copy 而非 rename，兼容跨盘符）。
-    const tmpArchive = '.out.tar.gz'
-    execFileSync('tar', ['-czhf', tmpArchive, '-T', '.tar-filelist'], { stdio: 'inherit', env, cwd: linkParent })
+    execFileSync('tar', ['-czhf', tmpArchive, '-T', '.tar-filelist'], { stdio: 'inherit', env, cwd: srcDir })
     fs.mkdirSync(path.dirname(archivePath), { recursive: true })
-    fs.copyFileSync(path.join(linkParent, tmpArchive), archivePath)
+    fs.copyFileSync(path.join(srcDir, tmpArchive), archivePath)
   } finally {
-    fs.rmSync(linkParent, { recursive: true, force: true })
+    fs.rmSync(listPath, { force: true })
+    fs.rmSync(path.join(srcDir, tmpArchive), { force: true })
   }
 }
 
@@ -136,7 +134,7 @@ function packComponent(ctx, { name, srcDir, exclude, archive, platforms, unpackD
   try {
     const archivePath = path.join(ctx.outDir, archive)
     console.log(`打包 ${name} -> ${archivePath}（${files.length} 个文件）`)
-    tarPack(srcDir, [...files, contentsRel], archivePath, topName)
+    tarPack(srcDir, [...files, contentsRel], archivePath)
     const st = fs.statSync(archivePath)
     return {
       name,

--- a/desktop/tests/build-pack.test.js
+++ b/desktop/tests/build-pack.test.js
@@ -65,24 +65,33 @@ test('打包一个自造小目录：manifest 的 size/sha256 与 contents.sha256
   // 这条防的是「git status 多出一个文件」）。
   assert.ok(!fs.existsSync(path.join(srcDir, 'contents.sha256')), '打包后源目录不该留下 contents.sha256')
 
+  // 包内条目必须是**裸相对路径**（不带 unpackDir 顶层目录）：安装端会先建
+  // <version>/<unpackDir>/ 再解压，包里若再套一层 litviz/，落盘就成了
+  // litviz/litviz/…，verifyContents 在外层找不到 contents.sha256，安装必挂
+  // （真机报「组件缺少 contents.sha256 清单」，dev-board#65）。
+  const entries = execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' }).trim().split('\n')
+  for (const entry of entries) {
+    assert.ok(!entry.startsWith('litviz/'), `包内条目不该带 unpackDir 顶层前缀：${entry}`)
+  }
+
   // 解开 tar，核对包内 contents.sha256 记的哈希与解出来的文件逐一一致，
   // 并且 __pycache__/*.pyc 确实被排除在外。
   const extractDir = path.join(workRoot, 'extract')
   fs.mkdirSync(extractDir, { recursive: true })
   execFileSync('tar', ['-xzf', archivePath, '-C', extractDir])
 
-  assert.ok(!fs.existsSync(path.join(extractDir, 'litviz', '__pycache__')), '__pycache__ 目录不该被打进包里')
-  assert.ok(!fs.existsSync(path.join(extractDir, 'litviz', 'engine', 'core.pyc')), '.pyc 文件不该被打进包里')
-  assert.ok(fs.existsSync(path.join(extractDir, 'litviz', 'cli.py')), '正常文件应当在包里')
+  assert.ok(!fs.existsSync(path.join(extractDir, '__pycache__')), '__pycache__ 目录不该被打进包里')
+  assert.ok(!fs.existsSync(path.join(extractDir, 'engine', 'core.pyc')), '.pyc 文件不该被打进包里')
+  assert.ok(fs.existsSync(path.join(extractDir, 'cli.py')), '正常文件应当在包里')
 
-  const contentsSha = fs.readFileSync(path.join(extractDir, 'litviz', 'contents.sha256'), 'utf8')
+  const contentsSha = fs.readFileSync(path.join(extractDir, 'contents.sha256'), 'utf8')
   const lines = contentsSha.trim().split('\n').filter(Boolean)
   // 只有 cli.py / engine/core.py 两个正常文件，contents.sha256 不列自身
   assert.strictEqual(lines.length, 2)
   for (const line of lines) {
     const [want, rel] = line.split('  ')
     assert.ok(!rel.includes('__pycache__') && !rel.endsWith('.pyc'), `contents.sha256 不该列出被排除的文件：${rel}`)
-    const got = sha256Of(path.join(extractDir, 'litviz', rel))
+    const got = sha256Of(path.join(extractDir, rel))
     assert.strictEqual(got, want, `contents.sha256 里 ${rel} 的哈希对不上解出来的文件`)
   }
 })

--- a/docs/NATIVE_PACK_DISTRIBUTION.md
+++ b/docs/NATIVE_PACK_DISTRIBUTION.md
@@ -112,6 +112,12 @@ manifest 原始字节上（旁挂 `.sig`，与增量更新的 `manifest.json.sig
   `desktop/bundled/${os}-${arch}` 的命名一致；当前就这两个发行目标）。客户端按
   自身平台过滤 components，取「匹配平台 ∪ `*`」；某平台缺必需组件时如实降级
   （graphviz 的降级语义沿用现状：缺了只报流程图布局不可用）。
+- **包内条目是裸相对路径，不套顶层目录**：安装端负责先建 `<version>/<unpackDir>/`
+  再解压，`contents.sha256` 必须位于压缩包根。包里若再带一层目录会落成
+  `<unpackDir>/<unpackDir>/…`，复核找不到清单、安装必挂（v1.0.0 发布件曾因
+  build-pack 多套一层 `topName/` 全网装不上，dev-board#65）。两侧测试都钉了这条：
+  `desktop/tests/build-pack.test.js` 断言包内无顶层前缀，
+  `NativePackServiceTest` 的夹具即裸路径包。
 - **逐文件哈希**：签名 manifest 只盖**压缩包级** sha256（密码学上已覆盖全部内容）；
   每个压缩包内自带 `contents.sha256`（包内逐文件哈希清单，构建期生成），
   安装端解压后**逐文件复核一遍**才写完成标记。这样 manifest 体积与文件数解耦


### PR DESCRIPTION
## 问题

真机 v0.22.0 安装诉讼可视化 native pack 报「组件缺少 contents.sha256 清单」，重试无效（dev-board#65）。

## 根因（镜像真实发布件实证）

`tar -tzf litviz-1.0.0.tar.gz` 显示所有条目带 `litviz/` 前缀（含 `litviz/contents.sha256`）。而安装端契约（规范 §4.2、NativePackServiceTest 夹具）是**包内裸相对路径**：doInstall 先建 `<version>/<unpackDir>/` 再解压，于是落盘成 `litviz/litviz/…`，verifyContents 在外层找不到清单，安装必挂。#434 起 build-pack 就多套了这层；desktop 侧测试当时把错误布局也断言了进去，形成两套平行契约，所以 CI 全绿。

现网从未产生过脏安装（verify 抛错即回滚不落盘），**重发 pack 即全量自愈，无需发桌面版**。

## 修复

- `tarPack` 不再经软链套 topName，cwd 钉 srcDir 直接出裸包（保留 #438 Windows 盘符规避与 `-h` 物化软链；`.tar-filelist`/`.out.tar.gz` 落 srcDir，finally 清走）
- `build-pack.test.js` 改为断言包内无顶层前缀（与后端夹具、规范对齐）
- 规范文档补「包内裸相对路径」显式条款

## 自验证

- `node --test desktop/tests/build-pack.test.js`：修前红（前缀断言拦住）→ 修后绿
- 真实 litviz 源目录冒烟出包：58 文件全裸路径、contents.sha256 在包根、源树 git status 干净
- 按安装端方式模拟解压到 `unpack/litviz/` 后 `shasum -a 256 -c contents.sha256` 58/58 OK

合并后重发 pack v1.0.1（pack-release.yml → 北京机 publish-pack.sh sign/publish/verify）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)