### PR TITLE
fix(external): 企查查/Tushare 未配置可读提示 + 云端 env 模板补键（dev-board#69）

### DIFF
--- a/backend/src/main/java/com/checkba/service/QichachaService.java
+++ b/backend/src/main/java/com/checkba/service/QichachaService.java
@@ -81,7 +81,13 @@ public class QichachaService {
         String secretKey = systemSettingService.get("external.qichacha.secret", defaultSecretKey);
         String baseUrl = systemSettingService.get("external.qichacha.baseUrl", defaultBaseUrl);
 
-
+        // 未配置时给出与 search_web 同款的可读提示（dev-board#69）：此前空 key 会
+        // 直接打真实接口，失败后被包成泛泛的「外部数据服务暂不可用」，用户和模型
+        // 都猜不到是没配凭证。
+        if (appKey == null || appKey.isBlank() || secretKey == null || secretKey.isBlank()) {
+            throw new IllegalStateException(
+                    "企业工商信息查询未配置：缺少企查查凭证（管理页「外部服务」或环境变量 QICHACHA_KEY/QICHACHA_SECRET）。请基于已有信息继续完成任务。");
+        }
 
         // 1. 准备请求参数
         String timeSpan = String.valueOf(System.currentTimeMillis() / 1000);

--- a/backend/src/main/java/com/checkba/service/TushareService.java
+++ b/backend/src/main/java/com/checkba/service/TushareService.java
@@ -296,6 +296,13 @@ public class TushareService {
         String token = systemSettingService.get("external.tushare.token", defaultTushareToken);
         String apiUrl = systemSettingService.get("external.tushare.baseUrl", defaultTushareApiUrl);
 
+        // 未配置时给出可读提示（dev-board#69，与 search_web/企查查同口径）：
+        // 空 token 打上游只会换来一条看不出原因的失败。
+        if (token == null || token.isBlank()) {
+            throw new IllegalStateException(
+                    "金融数据查询未配置：缺少 Tushare token（管理页「外部服务」或环境变量 TUSHARE_TOKEN）。请基于已有信息继续完成任务。");
+        }
+
         JSONObject body = new JSONObject();
         body.put("api_name", apiName);
         body.put("token", token);

--- a/deploy/cloud/env.example
+++ b/deploy/cloud/env.example
@@ -23,3 +23,13 @@ HOME=/opt/aiworkdeck/cloud/home
 # TWILIO_API_KEY_SID=
 # TWILIO_AUTH_TOKEN=
 # TWILIO_MESSAGING_SERVICE_SID=
+
+# 外部数据服务凭证（dev-board#69）。云端 profile 恒 BYOK（ExternalProviderResolver
+# 设计决策 D5，平台网关档在非 local-mode 下不可达），这些键不配，网络搜索/企业
+# 工商查询/金融数据/法条检索四类工具在云端就永远「未配置」。键名与 backend/.env
+# 一致（application.yml 的 ${VAR:} 绑定；BOCHA_API_KEY 走 bocha.api.key 宽松绑定）。
+# BOCHA_API_KEY=
+# QICHACHA_KEY=
+# QICHACHA_SECRET=
+# TUSHARE_TOKEN=
+# PKULAW_TOKEN=


### PR DESCRIPTION
插件端「企业工商信息查询和网络搜索因平台未配置凭证不可用」的收尾 PR。

## 根因
云端 profile 恒 BYOK（ExternalProviderResolver 设计决策 D5，非 local-mode 强制降级），而 `deploy/cloud/env.example` 从未包含外部数据服务的键——addin 云后端因此必然处于「BYOK 档且无 key」状态。

## 已做的运维动作（本 PR 之外）
北京(8.152.169.44)与新加坡(8.219.94.204)两台云后端 `/opt/aiworkdeck/cloud/env` 已注入 BOCHA/QICHACHA(key+secret)/TUSHARE/PKULAW 五键并重启（先备份，进程 environ 已验证）；从北京机实测企查查 ECIInfoVerify/GetInfo Status=200（真查到公司）、博查 web-search HTTP 200。**网络搜索与企业工商查询在插件端已即时可用。**

## 本 PR
- env.example 补五个键位与注释（防未来部署复发）
- QichachaService/TushareService 空 key 前置抛可读「未配置」提示，与 search_web 同口径（此前空 key 直接打上游、报泛泛的失败）。所有非工具调用点（ExternalController 泛捕、ProjectService try/catch、工具层 catch）异常路径已核对安全。

## 自验证
mvn -Dtest='*Tushare*,*Qichacha*,*External*,WebToolsTest' 35/35 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)