### PR TITLE
fix(meeting): meeting_recording 长文本字段改双方言安全映射，修云端 PG 建表失败（dev-board#72）

### DIFF
--- a/backend/src/main/java/com/checkba/model/entity/MeetingRecording.java
+++ b/backend/src/main/java/com/checkba/model/entity/MeetingRecording.java
@@ -3,7 +3,9 @@ package com.checkba.model.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 
@@ -71,9 +73,12 @@ public class MeetingRecording {
      * 转写结果（压缩后的段落 JSON 数组）：
      * [{"speaker":"1","start":毫秒,"end":毫秒,"text":"..."}]
      * speaker 是听悟的说话人编号字符串，展示名经 speakerNames 映射。
+     *
+     * <p>长文本不用 @Lob：PG 方言下 @Lob String 走 large-object（oid）读写会炸，
+     * LONGVARCHAR + TEXT 在 H2（MODE=PostgreSQL）与 PG 双方言通吃（summaryJson 同理）。
      */
-    @Lob
-    @Column(columnDefinition = "CLOB")
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(columnDefinition = "TEXT")
     private String transcriptJson;
 
     /** 说话人改名映射 JSON：{"1":"张律师","2":"对方代理人"}，未改名的用默认「说话人N」 */
@@ -84,8 +89,8 @@ public class MeetingRecording {
      * 听悟增值结果 JSON：{"chapters":[...],"summary":"...","todos":[...],"keywords":[...]}
      * 作为纪要生成的素材，缺失不影响主流程。
      */
-    @Lob
-    @Column(columnDefinition = "CLOB")
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(columnDefinition = "TEXT")
     private String summaryJson;
 
     /** 最近一次失败原因（FAILED 态展示与排障用） */


### PR DESCRIPTION
## 问题

云端插件后端（addin.aiworkdeck.com，PostgreSQL 14）每次启动 journal 报：

`Error executing DDL "create table meeting_recording (... summary_json CLOB ...)" — ERROR: type "clob" does not exist`

MeetingRecording 的 transcriptJson/summaryJson 硬编码了 `columnDefinition = "CLOB"`，PG 没有这个类型；桌面 H2 能过所以一直没暴露。

## 修法

两个字段改成 `@JdbcTypeCode(SqlTypes.LONGVARCHAR)` + `columnDefinition = "TEXT"`：
- DDL：TEXT 在 PG 原生合法，桌面 H2 连接串开着 `MODE=PostgreSQL` 同样合法（CompanyMirror 三个字段已是活证）；
- 运行时：不再用 @Lob——Hibernate 6.4 下 @Lob String 在 PG 方言走 large-object（oid）读写，即使列是 text 读回也会抛 "Bad value for type long"（代码库 ProjectProfileField 注释里已记过这颗雷）。LONGVARCHAR 在两种方言都走 setString/getString。

云端表因建表一直失败并不存在，ddl-auto=update 下个启动会用 TEXT 建出来；万一已存在也不会被 update 重建。

顺带发现 CompanyMirror 的三个 @Lob 字段有同样的 PG 运行时隐患，已另挂后台任务卡，不混进本 PR。

## 验证

- backend `mvn test`（JDK 21）全绿，meeting 相关测试（MeetingRecordingServiceTest 等）覆盖 H2 侧建表与读写。

dev-board: zeweihan/dev-board#72

🤖 Generated with [Claude Code](https://claude.com/claude-code)