### PR TITLE
fix(external): company_mirror 长文本字段改双方言安全映射，修云端 PG 读回炸（dev-board#73）

### DIFF
--- a/backend/src/main/java/com/checkba/model/entity/CompanyMirror.java
+++ b/backend/src/main/java/com/checkba/model/entity/CompanyMirror.java
@@ -5,8 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -94,23 +95,25 @@ public class CompanyMirror {
     private String equityStructureRemark;
 
     /**
-     * 前十大股东列表 JSON
+     * 前十大股东列表 JSON。
+     * 长文本不用 @Lob：PG 方言下 @Lob String 走 large-object（oid）读写会炸，
+     * LONGVARCHAR + TEXT 在 H2（MODE=PostgreSQL）与 PG 双方言通吃（下两个 JSON 字段同理）。
      */
-    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     @Column(columnDefinition = "TEXT")
     private String top10ShareholdersJson;
 
     /**
      * 董监高列表 JSON
      */
-    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     @Column(columnDefinition = "TEXT")
     private String executivesJson;
 
     /**
      * 股东列表 JSON（标的公司）
      */
-    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     @Column(columnDefinition = "TEXT")
     private String shareholdersJson;
 


### PR DESCRIPTION
## 问题

CompanyMirror 三个 JSON 字段（top10ShareholdersJson / executivesJson / shareholdersJson）用 `@Lob + columnDefinition=TEXT`。Hibernate 6.4 的 PostgreSQL 方言下 `@Lob String` 走 large-object（oid）读写路径，列实际是 text 时运行时读回抛 `Bad value for type long`。云后端（application-cloud.yml，PostgreSQL）在 PR#481 配好企查查凭证后，这条路径会被真实走到。

## 修法

同 PR#483（MeetingRecording，dev-board#72）：`@Lob` 换 `@JdbcTypeCode(SqlTypes.LONGVARCHAR)`，保留 `columnDefinition="TEXT"`，H2（MODE=PostgreSQL）与 PG 双方言通吃。

## 验证

`mvn clean test`（JDK 21）全量：2079 个测试，0 失败 0 错误 11 跳过。

关联 zeweihan/dev-board#73

🤖 Generated with [Claude Code](https://claude.com/claude-code)