### PR TITLE
fix(ai-chat): 编排器三处「静默失败」——XML 兜底谎报成功、文件夹上下文丢 Office 正文、超长工具结果压不动（dev-board#74）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -176,6 +176,31 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
   内部一致性错误的 SSE 载荷带 `LlmErrorClassifier.INTERNAL_ERROR_MARKER`（`AI_INTERNAL_ERROR`），
   前端 `useAgentStream` 据此换成人话（`agentStream.internalErrorNotice`，两套 locale 成对）——
   这个标记**不由 `classify()` 产出**，是编排器直接拼的，别往 `Kind` 枚举里加。
+- **XML 兜底路径的工具反馈不许谎报成功**：`<tool_code>` 分支回喂模型的
+  「[System Tool Execution Log]」文案里，"The tool executed successfully." 曾是**无条件**拼进去的，
+  与同一条消息里的 `Status: FAILURE` 直接打架，紧跟着还催「output `<final>` IMMEDIATELY」。
+  XML 兜底是弱模型的主路径，而末位/最强指令会赢（PR#209 实证）——工具失败时模型被引导去宣布任务完成，
+  用户看到的就是「AI 说做完了，其实什么都没发生」。现按 `xmlToolSuccess` 二选一：成功给原收敛指令，
+  失败给纠错指令。**同一分支还补了原生分支早就有的空输出归一**（空白 → `BLANK_TOOL_OUTPUT` + FAILURE）：
+  模板包裹让它不会像原生分支那样抛 `ensureNotBlank`，但「Output: 空 + 断言成功」照样把模型骗去收尾。
+  回归用例 `AgentOrchestratorXmlToolFeedbackTest`。
+- **读取类工具的正文必须有上限，单一来源是 `ToolFileGuard.capToolText`（80k）**：
+  `extract_file_text` 一直有这个上限，`read_file` / `read_document` 没有——一次读一份几 MB 的合同
+  就产生几十万字符的单条 `ToolExecutionResultMessage`，下一轮必然被服务商以上下文超限 400 挡回。
+  **而且救不回来**：这条超长结果落在 `RunLoopCompactor` 的 keepRecent **尾区**（尾部平时刻意不剪），
+  中段又往往不够 `minMiddleMessages` 条数，于是 `forceCompact` 恒返回原实例、编排器判「压不动」终态，
+  同一份文档每次重试都必然再撞同一个 400。两道防线都要在：工具侧截断 +
+  `forceCompact` 兜底剪尾（**只在 force 下**；非 force 的尾部豁免是刻意设计，别一起改掉）。
+  回归用例 `OversizedToolResultRecoveryTest`。
+- **文件夹上下文要走 `DocumentTextService`，不是 `FileContentExtractorService.extractText`**：
+  后者的白名单（java/js/md/txt/csv…）不含 docx/xlsx/pptx/doc/pdf，恒返回空串，
+  `buildFolderContext` 随后 `if (!text.isEmpty())` 把这些文件**静默跳过**——
+  上下文里「### Folder Document Contents」标题下一个字都没有。17ca80d7 修的是**单文件**路径
+  （`read_document` 改走 Tika）与 `<file>` 段守卫，**文件夹路径当时漏了**。
+  抽不出正文的文件现在会在 `[System Note: ...]` 里点名留痕，不再凭空消失。
+  回归用例 `FolderContextOfficeFormatTest`。
+  （同文件的 `extractFileText` / `collectFolderContent` 有同样的白名单缺陷，但**零生产调用方**，
+  本次刻意没动——要用它们之前先照 `buildFolderContext` 改。）
 - **埋点体系**（`com.checkba.service.telemetry`，设计 docs/ANALYTICS_TELEMETRY_DESIGN.md）：
   唯一采集入口 TelemetryService.record/recordConv，字段过 TelemetryAttrWhitelist 白名单
   （新事件/字段要同步白名单 + TelemetryServiceTest + 官网仓 lib/telemetry-store.ts 的 EVENT_WHITELIST）。

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -846,6 +846,13 @@ public class AgentOrchestrator {
                                 : "Unknown tool in custom parser: " + code;
                         xmlToolSuccess = toolResult.found() && toolResult.success();
                     }
+                    // 空输出归一（与原生分支同口径，见上）：XML 兜底路径不会因空白抛
+                    // ensureNotBlank（feedbackMsg 有模板包裹），但「Output: 空」配上下面那句
+                    // 成功断言，等于告诉模型「跑成功了、只是没输出」——模型转头就收尾。
+                    if (!org.springframework.util.StringUtils.hasText(result)) {
+                        result = BLANK_TOOL_OUTPUT;
+                        xmlToolSuccess = false;
+                    }
                     result = appendFailureNudge(guard, result, xmlToolSuccess);
 
                     // Add Result to History
@@ -857,9 +864,17 @@ public class AgentOrchestrator {
                          result += "\n\n(System Note: File operation completed successfully.)";
                     }
 
-                    // Explicitly tell the model to EVALUATE - with strict anti-over-execution instructions
-                    String feedbackMsg = String.format("[System Tool Execution Log]\nTool: %s\nStatus: %s\nOutput: %s\n\n(CRITICAL INSTRUCTION: The tool executed successfully. Now compare with the ORIGINAL user request. If the SPECIFIC task the user asked for is complete, output `<final>` IMMEDIATELY. DO NOT perform additional operations unless the user EXPLICITLY requested them. For example, if user asked to 'delete the 3rd z' and you deleted it, you are DONE - do not delete other z's.)",
-                        code, statusPrefix, result);
+                    // Explicitly tell the model to EVALUATE - with strict anti-over-execution instructions.
+                    // 收敛指令**只在成功时**给：这段文案里的 "The tool executed successfully" 原来是
+                    // 无条件拼进去的，与同一条消息里的 Status: FAILURE 直接打架，紧跟着还催
+                    // 「output <final> IMMEDIATELY」。XML 兜底是弱模型的主路径，而末位/最强指令
+                    // 会赢（PR#209 实证）——工具失败时模型被引导去宣布任务完成，用户看到的就是
+                    // 「AI 说做完了，其实什么都没发生」。失败时改成纠错指令，与原生分支语义一致。
+                    String instruction = xmlToolSuccess
+                            ? "(CRITICAL INSTRUCTION: The tool executed successfully. Now compare with the ORIGINAL user request. If the SPECIFIC task the user asked for is complete, output `<final>` IMMEDIATELY. DO NOT perform additional operations unless the user EXPLICITLY requested them. For example, if user asked to 'delete the 3rd z' and you deleted it, you are DONE - do not delete other z's.)"
+                            : "(CRITICAL INSTRUCTION: The tool FAILED - the operation did NOT take effect. Do NOT claim the task is done. Read the Output above, then either fix the call (correct arguments, or verify state with a read-only tool) or use `<final>` to tell the user plainly what failed and why. Never report success for a failed tool.)";
+                    String feedbackMsg = String.format("[System Tool Execution Log]\nTool: %s\nStatus: %s\nOutput: %s\n\n%s",
+                        code, statusPrefix, result, instruction);
 
                     // 防走神注入：任务清单状态随工具反馈一起带回（刚更新清单的轮次不注入）
                     if (!"todo_write".equals(call.toolName())) {

--- a/backend/src/main/java/com/checkba/service/ai/context/FileContextLoader.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/FileContextLoader.java
@@ -33,20 +33,50 @@ public class FileContextLoader {
     private static final int CHAT_FOLDER_MAX_DEPTH = 20;
     /** 文件夹递归的深度保护（Agent 上下文组装场景，行为沿用原实现） */
     private static final int ASSEMBLER_FOLDER_MAX_DEPTH = 5;
+    /** 「读不出正文」提示里最多点名几个文件（其余用省略号，防大文件夹刷屏） */
+    private static final int UNREADABLE_NAMES_SHOWN = 10;
 
     private final ProjectFileService projectFileService;
     private final FileContentExtractorService fileContentExtractorService;
     private final AiContextProperties contextProperties;
     private final com.checkba.storage.ProjectStorageResolver storageResolver;
+    /** Office/PDF 正文抽取（Tika + PDFBox），与 read_document / extract_file_text 同一套 */
+    private final com.checkba.service.DocumentTextService documentTextService;
 
     public FileContextLoader(ProjectFileService projectFileService,
                              FileContentExtractorService fileContentExtractorService,
                              AiContextProperties contextProperties,
-                             com.checkba.storage.ProjectStorageResolver storageResolver) {
+                             com.checkba.storage.ProjectStorageResolver storageResolver,
+                             com.checkba.service.DocumentTextService documentTextService) {
         this.projectFileService = projectFileService;
         this.fileContentExtractorService = fileContentExtractorService;
         this.contextProperties = contextProperties;
         this.storageResolver = storageResolver;
+        this.documentTextService = documentTextService;
+    }
+
+    /**
+     * 文件夹上下文里单个文件的正文抽取。
+     *
+     * <p>纯文本类（java/js/md/txt/csv…）直读；<b>其余（docx/xlsx/pptx/doc/pdf）走
+     * {@link com.checkba.service.DocumentTextService}</b>——与 {@code read_document} /
+     * {@code extract_file_text} 同一套 Tika+PDFBox。
+     *
+     * <p>此前这里只有 {@code FileContentExtractorService.extractText} 一条路，而它的
+     * 白名单不含 Office 格式，恒返回空串，于是「文件夹里的 Word/PDF」在上下文里
+     * 一个字都没有——单文件路径在 17ca80d7 已修（走 read_document），文件夹路径漏了。
+     * 图片仍不在此处做 OCR：文件夹扫描是批量路径，逐张走 OCR 的代价不在本次修复范围内。
+     */
+    private String extractForFolder(ProjectFile f, java.io.File physicalFile) {
+        if (fileContentExtractorService.isTextFile(f.getName())) {
+            return fileContentExtractorService.extractText(physicalFile);
+        }
+        try {
+            return documentTextService.extractText(f);
+        } catch (Exception e) {
+            log.warn("Folder context: failed to extract text from {}: {}", f.getName(), e.getMessage());
+            return "";
+        }
     }
 
     /**
@@ -171,6 +201,9 @@ public class FileContextLoader {
 
             long maxFileSize = contextProperties.getFiles().getMaxFileSizeBytes();
             int maxChars = contextProperties.getFiles().getFolderFileMaxChars();
+            // 读不出正文的文件要在上下文里留痕：静默跳过时模型看到的是
+            // 「Folder Document Contents」标题下空空如也，只能当这些文件不存在或去猜内容。
+            List<String> unreadable = new ArrayList<>();
             for (ProjectFile f : allFiles) {
                 if (reads >= maxReads) break;
                 if (Boolean.TRUE.equals(f.getIsFolder())) continue;
@@ -180,18 +213,30 @@ public class FileContextLoader {
                     // 改走 resolver 才真正读到文件（localRoot 感知）
                     java.io.File physicalFile = storageResolver.resolve(f.getFilePath()).toFile();
                     if (physicalFile.exists() && physicalFile.length() < maxFileSize) {
-                        String text = fileContentExtractorService.extractText(physicalFile);
-                        if (text != null && !text.isEmpty()) {
+                        String text = extractForFolder(f, physicalFile);
+                        if (text != null && !text.isBlank()) {
                             if (text.length() > maxChars) text = text.substring(0, maxChars) + "...[Truncated]";
 
                             sb.append("\n#### File: ").append(f.getName()).append("\n");
                             sb.append("```\n").append(text).append("\n```\n");
                             reads++;
+                        } else {
+                            unreadable.add(f.getName());
                         }
+                    } else {
+                        unreadable.add(f.getName());
                     }
                 } catch (Exception e) {
-                    // Ignore read errors for individual files
+                    unreadable.add(f.getName());
                 }
+            }
+            if (!unreadable.isEmpty()) {
+                int shown = Math.min(unreadable.size(), UNREADABLE_NAMES_SHOWN);
+                sb.append("\n[System Note: ").append(unreadable.size())
+                  .append(" file(s) in this folder have no extractable text (scanned image, unsupported type, or too large): ")
+                  .append(String.join(", ", unreadable.subList(0, shown)));
+                if (unreadable.size() > shown) sb.append(", ...");
+                sb.append(". Use extract_file_text or read_file with OCR if you need their content.]\n");
             }
 
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/service/ai/context/RunLoopCompactor.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/RunLoopCompactor.java
@@ -93,6 +93,34 @@ public class RunLoopCompactor {
         if (!cfg.isEnabled() || messages == null || messages.isEmpty()) {
             return messages;
         }
+        List<ChatMessage> outcome = compactCore(messages, modelId, force);
+        if (!force || outcome != messages) {
+            return outcome;
+        }
+        // 兜底：强制压缩（服务商已用 400 证实装不下）走到这里说明中段无可折、无可剪——
+        // 剩下的大头只可能在**尾部**。尾部平时刻意不剪（模型正在引用最近的结果），
+        // 但此刻的选择不是「剪不剪」而是「剪一刀还是整轮直接死」：一次
+        // read_document 读一份几 MB 的合同就能把单条工具结果顶到几十万字符，
+        // 它落在 keepRecent 尾区，中段又不够条数，于是 forceCompact 恒返回原实例、
+        // 编排器判定「压不动」终态——同一份文档每次重试都必然再撞同一个 400。
+        // 只剪正文、id/toolName 原样保留，工具配对不受影响；剪枝标记会告诉模型
+        // 中段没了、要全文就重新调用该工具。
+        try {
+            int headEnd = headEnd(messages);
+            List<ChatMessage> lastResort = pruneMiddleToolResults(messages, headEnd, messages.size());
+            if (lastResort != messages) {
+                log.warn("Context compaction last resort: pruned oversized tool result(s) in the keepRecent tail, "
+                        + "{} -> {} tokens", estimateTokens(messages), estimateTokens(lastResort));
+                return lastResort;
+            }
+        } catch (Exception e) {
+            log.warn("Last-resort tail pruning failed, keeping the original message stack", e);
+        }
+        return messages;
+    }
+
+    private List<ChatMessage> compactCore(List<ChatMessage> messages, String modelId, boolean force) {
+        AiContextProperties.Compaction cfg = properties.getCompaction();
         try {
             int tokens = estimateTokens(messages);
             int threshold = triggerThreshold(modelId);

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -162,7 +162,9 @@ public class FileTools implements AgentToolComponent {
                 return "Warning: no text extracted from '" + file.getName() + "' — the file may be a scanned "
                         + "image or empty; try extract_file_text with its database file ID.";
             }
-            return content;
+            // 同 extract_file_text 的上限（单一来源见 ToolFileGuard）：超长单条工具结果
+            // 会把整轮顶进上下文超限，而且落在 compactor 尾区剪不掉
+            return ToolFileGuard.capToolText(file.getName(), content);
         } catch (Exception e) {
             return "Error reading file: " + e.getMessage();
         }
@@ -267,12 +269,9 @@ public class FileTools implements AgentToolComponent {
             if (text == null || text.isBlank()) {
                 return "Warning: No text extracted from '" + pf.getName() + "'. The file may be a scanned image; try read_file with OCR for image PDFs.";
             }
-            final int maxChars = 80_000;
-            if (text.length() > maxChars) {
-                return "[文件 " + pf.getName() + "，全文 " + text.length() + " 字符，已截断至前 " + maxChars + " 字符]\n"
-                        + text.substring(0, maxChars);
-            }
-            return "[文件 " + pf.getName() + "]\n" + text;
+            String capped = ToolFileGuard.capToolText(pf.getName(), text);
+            // 未截断时保留原有的「[文件 X]」抬头（模型据此知道正文属于哪个文件）
+            return capped.length() == text.length() ? "[文件 " + pf.getName() + "]\n" + text : capped;
         } catch (Exception e) {
             log.warn("extract_file_text failed for fileId={}", fileId, e);
             return "Error extracting text: " + e.getMessage();

--- a/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
@@ -92,7 +92,9 @@ public class LegalTools implements AgentToolComponent {
                 return "Warning: no text extracted from '" + name + "' — the file may be a scanned image "
                         + "or empty; try extract_file_text, or read_file with OCR for image PDFs.";
             }
-            return result;
+            // 上限与 extract_file_text 同源：不截断的话，一份几 MB 的合同会变成一条几十万
+            // 字符的工具结果，下一轮必然上下文超限，且它落在 compactor 尾区剪不掉 = 整轮死
+            return ToolFileGuard.capToolText(name, result);
 
         } catch (Exception e) {
             log.error("Failed to read document {}", fileId, e);

--- a/backend/src/main/java/com/checkba/service/ai/tools/ToolFileGuard.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/ToolFileGuard.java
@@ -36,4 +36,35 @@ public final class ToolFileGuard {
         }
         return null;
     }
+
+    /**
+     * 单次读取类工具交给模型的正文字符上限。
+     *
+     * <p>口径与 {@code extract_file_text} 既有的 80k 一致——本方法就是把那处硬编码
+     * 收成单一来源，让三个读取工具（extract_file_text / read_file / read_document）
+     * 不再各说各话。
+     */
+    public static final int MAX_TOOL_TEXT_CHARS = 80_000;
+
+    /**
+     * 按 {@link #MAX_TOOL_TEXT_CHARS} 截断读取类工具的正文，并**显式告诉模型被截断了**。
+     *
+     * <p>为什么必须截断：工具结果原样进 {@code ToolExecutionResultMessage} 入栈，没有任何
+     * 上限。一次 {@code read_document} 读一份几 MB 的合同就能产生几十万字符的单条消息，
+     * 下一次 generate 必然被服务商以上下文超限 400 挡回。而这条超长结果落在
+     * {@code RunLoopCompactor} 的 keepRecent 尾区（尾部平时刻意不剪）、中段又往往不够
+     * 折叠条数，于是强制压缩缩不动、编排器判定「压不动」直接终态——同一份文档每次重试
+     * 都必然再撞同一个 400，用户侧表现为「这份文件永远读不了」。
+     *
+     * <p>截断说明写成模型能据以行动的一句话：告诉它还有多少、以及用哪个工具分段读。
+     */
+    public static String capToolText(String fileName, String text) {
+        if (text == null || text.length() <= MAX_TOOL_TEXT_CHARS) {
+            return text;
+        }
+        return "[文件 " + fileName + "，全文 " + text.length() + " 字符，已截断至前 "
+                + MAX_TOOL_TEXT_CHARS + " 字符。需要后续内容请用 doc_read_paragraphs 分段读取，"
+                + "或先检索定位再读该段。]\n"
+                + text.substring(0, MAX_TOOL_TEXT_CHARS);
+    }
 }

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorXmlToolFeedbackTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorXmlToolFeedbackTest.java
@@ -1,0 +1,228 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.config.AiFailoverProperties;
+import com.checkba.controller.ai.AiAgentController;
+import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.RunLoopCompactor;
+import com.checkba.service.ai.memory.MemoryPipelineService;
+import com.checkba.service.ai.skill.SkillRouter;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * XML 兜底路径（{@code <tool_code>}）回喂给模型的「工具执行日志」不许谎报成功。
+ *
+ * <p>病灶：那条 feedback 文案里 “The tool executed successfully.” 是**无条件**拼进去的，
+ * 与同一条消息里的 {@code Status: FAILURE} 直接打架，紧跟着还有一句
+ * “output {@code <final>} IMMEDIATELY”。XML 兜底是弱模型的主路径，而本仓的既有实证
+ * （PR#209）是「末位/最强指令赢」——于是工具失败时模型被引导去宣布任务完成，
+ * 用户看到的就是「AI 说做完了，其实什么都没发生」。
+ *
+ * <p>原生 function-calling 分支没有这个问题：它回喂的是纯 ToolExecutionResultMessage，
+ * 不附带任何成功断言。两条路径的语义必须一致。
+ */
+class AgentOrchestratorXmlToolFeedbackTest {
+
+    private static final String MODEL = "qwen/qwen3.7-flash";
+
+    private ChatModelFactory chatModelFactory;
+    private ToolRegistry toolRegistry;
+    private XmlToolCallParser parser;
+    private List<String> sseEvents;
+    private List<String> sseData;
+    private AgentOrchestrator orchestrator;
+
+    /** 按脚本逐轮吐内容的模型，同时留下最后一轮收到的完整消息栈 */
+    private static final class ScriptModel implements StreamingChatLanguageModel {
+        private final List<AiMessage> script;
+        final AtomicInteger calls = new AtomicInteger();
+        volatile List<ChatMessage> lastMessages = List.of();
+
+        ScriptModel(List<AiMessage> script) {
+            this.script = script;
+        }
+
+        @Override
+        public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+            lastMessages = new ArrayList<>(messages);
+            int idx = calls.getAndIncrement();
+            AiMessage msg = script.get(Math.min(idx, script.size() - 1));
+            if (msg.text() != null && !msg.text().isEmpty()) {
+                handler.onNext(msg.text());
+            }
+            handler.onComplete(Response.from(msg));
+        }
+
+        @Override
+        public void generate(List<ChatMessage> messages, List<ToolSpecification> tools,
+                             StreamingResponseHandler<AiMessage> handler) {
+            generate(messages, handler);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        chatModelFactory = mock(ChatModelFactory.class);
+        sseEvents = new CopyOnWriteArrayList<>();
+        sseData = new CopyOnWriteArrayList<>();
+        SseEmitterService sse = mock(SseEmitterService.class);
+        doAnswer(inv -> {
+            sseEvents.add(inv.getArgument(1));
+            sseData.add(String.valueOf((Object) inv.getArgument(2)));
+            return null;
+        }).when(sse).send(any(), any(), any());
+
+        ProjectAiMessageService messageService = mock(ProjectAiMessageService.class);
+        when(messageService.listByConversationId(any()))
+                .thenReturn(List.of(mock(ProjectAiMessage.class), mock(ProjectAiMessage.class)));
+        when(messageService.upsertAssistantMessage(any(), any(), any(), any(), any())).thenReturn(1L);
+
+        ContextAssemblerService assembler = mock(ContextAssemblerService.class);
+        when(assembler.assemble(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenAnswer(inv -> new ArrayList<ChatMessage>(List.of(
+                        SystemMessage.from("system"), UserMessage.from("读一下这份合同"))));
+
+        toolRegistry = mock(ToolRegistry.class);
+        when(toolRegistry.getAllSpecifications(any())).thenReturn(List.of());
+        when(toolRegistry.resolve(anyString())).thenReturn(java.util.Optional.empty());
+
+        SkillRouter skillRouter = mock(SkillRouter.class);
+        when(skillRouter.visibleTools(any(), any())).thenAnswer(inv -> inv.getArgument(1));
+        when(skillRouter.activeSkill(any())).thenReturn(java.util.Optional.empty());
+
+        // XML 兜底路径：解析器交出一次 read_document 调用
+        parser = mock(XmlToolCallParser.class);
+        when(parser.containsToolCall(anyString()))
+                .thenAnswer(inv -> String.valueOf((Object) inv.getArgument(0)).contains("<tool_code>"));
+        when(parser.extractProcessName(anyString())).thenReturn(java.util.Optional.of("读取文档"));
+        when(parser.parse(anyString())).thenAnswer(inv ->
+                String.valueOf((Object) inv.getArgument(0)).contains("<tool_code>")
+                        ? List.of(new XmlToolCallParser.ParsedCall(
+                                "read_document", "{\"fileId\":\"12\"}", "read_document(fileId=\"12\")"))
+                        : List.of());
+
+        TodoListService todoListService = mock(TodoListService.class);
+        AiContextProperties contextProperties = new AiContextProperties();
+        AgentRunStateService runState = new AgentRunStateService(
+                mock(com.checkba.repository.AgentRunRecordRepository.class),
+                mock(com.checkba.service.telemetry.TelemetryTurnTracker.class));
+        orchestrator = new AgentOrchestrator(
+                chatModelFactory, messageService, sse, mock(TokenUsageService.class), assembler,
+                toolRegistry, skillRouter, parser, mock(MemoryPipelineService.class),
+                mock(ProjectFileService.class), mock(EditorBridgeService.class),
+                mock(ConversationFileChangeService.class), todoListService,
+                mock(DocumentCheckpointService.class), runState,
+                mock(com.checkba.version.WorkSessionService.class), new AiFailoverProperties(),
+                new RunLoopCompactor(contextProperties, new ContextCompressor(null, null, contextProperties)),
+                mock(com.checkba.service.telemetry.TelemetryService.class),
+                mock(com.checkba.service.telemetry.TelemetryTurnTracker.class),
+                mock(com.checkba.service.telemetry.MatterClassifierService.class));
+    }
+
+    private ScriptModel run(String conversationId, AiMessage... script) {
+        ScriptModel model = new ScriptModel(List.of(script));
+        when(chatModelFactory.getStreamingChatModel(MODEL)).thenReturn(model);
+        AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
+        request.setProjectId(1L);
+        request.setConversationId(conversationId);
+        request.setMessage("读一下这份合同");
+        request.setModel(MODEL);
+        orchestrator.handleUserMessage(request, 7L);
+        return model;
+    }
+
+    /** 取回喂给模型的那条「工具执行日志」用户消息 */
+    private String toolFeedback(ScriptModel model) {
+        for (ChatMessage m : model.lastMessages) {
+            if (m instanceof UserMessage um) {
+                String text = um.singleText();
+                if (text != null && text.contains("[System Tool Execution Log]")) {
+                    return text;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Test
+    @DisplayName("XML 兜底：工具失败时回喂文案不许断言成功、不许催 <final>")
+    void failedXmlToolMustNotBeReportedAsSuccess() {
+        when(toolRegistry.execute(any(), any(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("Error: 文件不存在（fileId=12）", null, true));
+
+        ScriptModel model = run("conv-xml-fail",
+                AiMessage.from("<process name=\"读取文档\"><tool_code>read_document(fileId=\"12\")</tool_code></process>"),
+                AiMessage.from("<final>没找到这份文件。</final>"));
+
+        String feedback = toolFeedback(model);
+        assertNotNull(feedback, "工具反馈必须回喂模型，实际消息栈：" + model.lastMessages);
+        assertTrue(feedback.contains("Status: FAILURE"),
+                "失败的工具必须标 FAILURE，实际是：" + feedback);
+        assertFalse(feedback.contains("The tool executed successfully"),
+                "工具失败时不许告诉模型它成功了——这正是「AI 说做完了其实没做」的成因，实际是：" + feedback);
+        assertFalse(feedback.contains("output `<final>` IMMEDIATELY"),
+                "工具失败时不许催模型立刻收尾，应让它纠错或如实告知用户，实际是：" + feedback);
+    }
+
+    @Test
+    @DisplayName("XML 兜底：工具成功时保留原有的收敛指令，不改变既有行为")
+    void successfulXmlToolKeepsTheConvergenceInstruction() {
+        when(toolRegistry.execute(any(), any(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("合同正文……", null, true));
+
+        ScriptModel model = run("conv-xml-ok",
+                AiMessage.from("<process name=\"读取文档\"><tool_code>read_document(fileId=\"12\")</tool_code></process>"),
+                AiMessage.from("<final>读好了。</final>"));
+
+        String feedback = toolFeedback(model);
+        assertNotNull(feedback, "工具反馈必须回喂模型，实际消息栈：" + model.lastMessages);
+        assertTrue(feedback.contains("Status: SUCCESS"), "成功的工具标 SUCCESS，实际是：" + feedback);
+        assertTrue(feedback.contains("The tool executed successfully"),
+                "成功路径的既有文案保持不变（防过度改动），实际是：" + feedback);
+    }
+
+    @Test
+    @DisplayName("XML 兜底：工具返回空白按失败处理，与原生分支同口径")
+    void blankXmlToolOutputIsTreatedAsFailure() {
+        when(toolRegistry.execute(any(), any(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("   ", null, true));
+
+        ScriptModel model = run("conv-xml-blank",
+                AiMessage.from("<process name=\"读取文档\"><tool_code>read_document(fileId=\"12\")</tool_code></process>"),
+                AiMessage.from("<final>读不出来。</final>"));
+
+        String feedback = toolFeedback(model);
+        assertNotNull(feedback, "工具反馈必须回喂模型，实际消息栈：" + model.lastMessages);
+        assertTrue(feedback.contains("Status: FAILURE"),
+                "空白输出与原生分支同口径按 FAILURE 处理，实际是：" + feedback);
+        assertFalse(feedback.contains("The tool executed successfully"),
+                "空白输出不许被断言为成功，实际是：" + feedback);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/context/FileContextLoaderTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/context/FileContextLoaderTest.java
@@ -32,7 +32,8 @@ class FileContextLoaderTest {
         extractor = mock(FileContentExtractorService.class);
         props = new AiContextProperties();
         loader = new FileContextLoader(projectFileService, extractor, props,
-                new com.checkba.storage.ProjectStorageResolver(new com.checkba.storage.StorageProperties(), null));
+                new com.checkba.storage.ProjectStorageResolver(new com.checkba.storage.StorageProperties(), null),
+                mock(com.checkba.service.DocumentTextService.class));
     }
 
     private static ProjectFile file(Long id, String name, boolean isFolder) {

--- a/backend/src/test/java/com/checkba/service/ai/context/FolderContextOfficeFormatTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/context/FolderContextOfficeFormatTest.java
@@ -1,0 +1,136 @@
+package com.checkba.service.ai.context;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.DocumentTextService;
+import com.checkba.service.OcrService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.storage.ProjectStorageResolver;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 文件夹上下文必须真的读得出 Office/PDF 正文。
+ *
+ * <p>病灶：{@code buildFolderContext} 只走
+ * {@link FileContentExtractorService#extractText}，而它的白名单
+ * （java/js/md/txt/csv…）不含 docx/xlsx/pptx/pdf，恒返回空串，随后
+ * {@code if (text != null && !text.isEmpty())} 把这些文件<b>静默跳过</b>——
+ * 上下文里「### Folder Document Contents」标题下一个字都没有，模型只能当
+ * 这些文件不存在或自己去猜。
+ *
+ * <p>这是 17ca80d7（docx 恒返回空串）的漏网分支：那次修的是单文件路径
+ * （{@code read_document} 改走 {@link DocumentTextService}）与 {@code <file>} 段守卫，
+ * 文件夹路径没跟上。对法律工作台来说「一个案子 = 一个文件夹的 Word/PDF」是主用法。
+ */
+class FolderContextOfficeFormatTest {
+
+    private static final long PROJECT_ID = 7L;
+    private static final long FOLDER_ID = 100L;
+
+    private static Path writeDocx(Path dir, String fileName, String... paragraphs) throws IOException {
+        Path path = dir.resolve(fileName);
+        try (XWPFDocument doc = new XWPFDocument(); FileOutputStream out = new FileOutputStream(path.toFile())) {
+            for (String p : paragraphs) {
+                doc.createParagraph().createRun().setText(p);
+            }
+            doc.write(out);
+        }
+        return path;
+    }
+
+    private static ProjectFile record(long id, String name, String type, Path onDisk) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(PROJECT_ID);
+        f.setName(name);
+        f.setFileType(type);
+        f.setFilePath(onDisk.toString());
+        f.setIsFolder(false);
+        return f;
+    }
+
+    /** 真的 Tika、真的提取器，只把「文件从哪来」换成本地临时文件。 */
+    private static FileContextLoader loaderFor(List<ProjectFile> children) {
+        ProjectFileService fileService = Mockito.mock(ProjectFileService.class);
+        Mockito.when(fileService.getFilesByParent(PROJECT_ID, FOLDER_ID)).thenReturn(children);
+
+        StorageService storage = Mockito.mock(StorageService.class);
+        for (ProjectFile f : children) {
+            Mockito.when(storage.load(f.getFilePath()))
+                    .thenReturn(new FileSystemResource(Path.of(f.getFilePath())));
+        }
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        Mockito.when(factory.getStorageService()).thenReturn(storage);
+
+        ProjectStorageResolver resolver = Mockito.mock(ProjectStorageResolver.class);
+        Mockito.when(resolver.resolve(Mockito.anyString()))
+                .thenAnswer(inv -> Path.of(inv.getArgument(0, String.class)));
+
+        return new FileContextLoader(
+                fileService,
+                new FileContentExtractorService(Mockito.mock(OcrService.class), new AiContextProperties()),
+                new AiContextProperties(),
+                resolver,
+                new DocumentTextService(factory));
+    }
+
+    @Test
+    @DisplayName("文件夹里的 docx 正文必须进上下文，不能被静默跳过")
+    void folderContextIncludesDocxBody(@TempDir Path dir) throws Exception {
+        Path docx = writeDocx(dir, "股权转让协议.docx",
+                "第一条 转让标的", "甲方将其持有的目标公司 40% 股权转让给乙方。");
+
+        String out = loaderFor(List.of(record(11L, "股权转让协议.docx", "docx", docx)))
+                .buildFolderContext(String.valueOf(FOLDER_ID), String.valueOf(PROJECT_ID), 0);
+
+        assertTrue(out.contains("股权转让协议.docx"), "目录结构里要有这个文件，实际是：" + out);
+        assertTrue(out.contains("甲方将其持有的目标公司"),
+                "docx 正文必须真的进上下文——恒空正是「拖进来等于没拖」的成因，实际是：" + out);
+        assertTrue(out.contains("40%"), "正文不能只剩标题，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("纯文本文件的既有行为不变")
+    void folderContextStillReadsPlainText(@TempDir Path dir) throws Exception {
+        Path txt = dir.resolve("笔记.txt");
+        Files.writeString(txt, "开庭时间 2026-09-01", StandardCharsets.UTF_8);
+
+        String out = loaderFor(List.of(record(12L, "笔记.txt", "txt", txt)))
+                .buildFolderContext(String.valueOf(FOLDER_ID), String.valueOf(PROJECT_ID), 0);
+
+        assertTrue(out.contains("开庭时间 2026-09-01"), "纯文本路径不许被改坏，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("抽不出正文的文件要留痕，不能让模型以为文件夹是空的")
+    void unreadableFilesAreDisclosed(@TempDir Path dir) throws Exception {
+        // 扩展名不在文本白名单，Tika 也抽不出正文的二进制文件
+        Path bin = dir.resolve("扫描件.jpg");
+        Files.write(bin, new byte[]{0x11, 0x22, 0x33, 0x44});
+
+        String out = loaderFor(List.of(record(13L, "扫描件.jpg", "jpg", bin)))
+                .buildFolderContext(String.valueOf(FOLDER_ID), String.valueOf(PROJECT_ID), 0);
+
+        assertTrue(out.contains("扫描件.jpg"), "文件名要出现，实际是：" + out);
+        assertTrue(out.contains("no extractable text"),
+                "读不出来要明说，静默跳过等于骗模型，实际是：" + out);
+        assertFalse(out.contains("```"), "没有正文就不该出现空的代码块，实际是：" + out);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/context/OversizedToolResultRecoveryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/context/OversizedToolResultRecoveryTest.java
@@ -1,0 +1,132 @@
+package com.checkba.service.ai.context;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.service.ai.tools.ToolFileGuard;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 「一条超长工具结果就让整轮无法恢复」的两道防线。
+ *
+ * <p>病灶链：读取类工具的正文<b>没有上限</b>（extract_file_text 有 80k，read_file /
+ * read_document 没有），一次 read_document 读一份几 MB 的合同就能产生几十万字符的单条
+ * {@code ToolExecutionResultMessage}。下一次 generate 被服务商以上下文超限 400 挡回，
+ * 编排器走被动恢复通道调 {@code forceCompact}——可这条超长结果落在 keepRecent
+ * <b>尾区</b>（尾部平时刻意不剪），中段又不够 minMiddleMessages 条数，于是
+ * forceCompact 恒返回原实例，编排器判定「压不动」直接终态。
+ * 同一份文档每次重试都必然再撞同一个 400 = 这份文件永远读不了。
+ *
+ * <p>两道防线：① 工具侧截断（不让它长出来）；② forceCompact 兜底剪尾（长出来了也能救回来）。
+ */
+class OversizedToolResultRecoveryTest {
+
+    private AiContextProperties properties;
+    private RunLoopCompactor compactor;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AiContextProperties();
+        ContextCompressor compressor = mock(ContextCompressor.class);
+        when(compressor.getAvailableTokensForHistory(any())).thenReturn(1000);
+        compactor = new RunLoopCompactor(properties, compressor);
+    }
+
+    private static String filler(int chars) {
+        return "合同条款".repeat(chars / 4);
+    }
+
+    /** 刚读完一份大文档的消息栈：中段为空，全部落在 keepRecent 尾区 */
+    private static List<ChatMessage> justReadHugeDocument(int resultChars) {
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(SystemMessage.from("system prompt"));
+        messages.add(UserMessage.from("看看这份股权转让协议有什么风险"));
+        messages.add(AiMessage.from(ToolExecutionRequest.builder()
+                .id("c0").name("read_document").arguments("{\"fileId\":\"12\"}").build()));
+        messages.add(ToolExecutionResultMessage.from("c0", "read_document", filler(resultChars)));
+        return messages;
+    }
+
+    @Test
+    @DisplayName("防线二：尾部超长工具结果——强制压缩必须救得回来，不能判死")
+    void forceCompactRecoversFromAnOversizedTailToolResult() {
+        List<ChatMessage> messages = justReadHugeDocument(400_000);
+        int before = compactor.estimateTokens(messages);
+
+        List<ChatMessage> result = compactor.forceCompact(messages, null);
+
+        assertNotSame(messages, result,
+                "返回原实例 = 编排器判定「压不动」直接终态，这份文档就永远读不了了");
+        assertTrue(compactor.estimateTokens(result) < before,
+                "强压后 token 必须真的下降，否则重发再撞同一个 400");
+        assertEquals(messages.size(), result.size(), "只剪正文，不许丢消息");
+
+        ToolExecutionResultMessage pruned = (ToolExecutionResultMessage) result.get(3);
+        assertEquals("c0", pruned.id(), "id 必须原样保留，否则工具调用与结果配对断裂 -> 通道 400");
+        assertEquals("read_document", pruned.toolName(), "toolName 同样必须原样保留");
+        assertTrue(pruned.text().contains("工具结果中段已省略"),
+                "要留剪枝标记告诉模型中段没了，实际是：" + pruned.text().substring(0, 200));
+    }
+
+    @Test
+    @DisplayName("普通压缩仍然不剪尾部：模型正在引用最近结果，既有取舍不变")
+    void normalCompactionStillNeverPrunesTheTail() {
+        List<ChatMessage> messages = justReadHugeDocument(400_000);
+        ChatMessage hugeTail = messages.get(3);
+
+        List<ChatMessage> result = compactor.compact(messages, null);
+
+        assertSame(hugeTail, result.get(result.size() - 1),
+                "非强制路径的尾部豁免是刻意设计，不许被这次修复带偏");
+    }
+
+    @Test
+    @DisplayName("没有可剪的工具结果时，强制压缩仍然如实承认压不动")
+    void forceCompactStillAdmitsDefeatWhenNothingIsPrunable() {
+        List<ChatMessage> messages = new ArrayList<>(List.of(
+                SystemMessage.from("system prompt"),
+                UserMessage.from("你好"),
+                AiMessage.from("你好，有什么可以帮你的？")));
+
+        assertSame(messages, compactor.forceCompact(messages, null),
+                "压不动就得返回原实例，调用方据此放弃重试而不是无限重发");
+    }
+
+    @Test
+    @DisplayName("防线一：读取类工具的正文上限是单一来源，超长时明确告知模型如何分段读")
+    void toolTextIsCappedWithAnActionableNotice() {
+        String huge = filler(400_000);
+        String capped = ToolFileGuard.capToolText("股权转让协议.docx", huge);
+
+        assertTrue(capped.length() < huge.length(), "必须真的截断");
+        assertTrue(capped.contains("已截断"), "要告诉模型被截断了，实际开头是：" + capped.substring(0, 120));
+        assertTrue(capped.contains("doc_read_paragraphs"),
+                "要给模型下一步（分段读），否则它只会原地重试，实际开头是：" + capped.substring(0, 120));
+        assertTrue(capped.length() <= ToolFileGuard.MAX_TOOL_TEXT_CHARS + 300,
+                "截断后长度应贴近上限，实际 " + capped.length());
+    }
+
+    @Test
+    @DisplayName("未超上限的正文原样返回，不加任何噪声")
+    void shortToolTextIsUntouched() {
+        String small = "第一条 转让标的";
+        assertSame(small, ToolFileGuard.capToolText("a.docx", small));
+    }
+}


### PR DESCRIPTION
全量代码稳定性审计（dev-board#74）第一批。三处都属同一病症族：**失败/读不出来被当成成功或空**，用户侧表现为「AI 说做完了其实什么都没发生」。三处都做了复现 + 空断言校验后才动代码。

## 一、XML 兜底路径把每一次工具调用都说成成功

`AgentOrchestrator:861` 回喂模型的「[System Tool Execution Log]」里 `The tool executed successfully.` 是**无条件**拼进去的，与同一条消息里的 `Status: FAILURE` 直接打架，紧跟着还催 `output <final> IMMEDIATELY`。XML 兜底是弱模型的主路径，而末位/最强指令会赢（PR#209 实证）——工具失败时模型被引导去宣布任务完成。文案出自 aaffd1e9（1 月），当时这条路大概只在成功时走到。

现按 `xmlToolSuccess` 二选一：成功保持原收敛指令（既有行为一字不动），失败改成纠错指令。同一分支补上原生分支早就有的**空输出归一**——模板包裹让它不像原生分支那样抛 `ensureNotBlank`，所以 #448 判断它「不受影响」；崩溃确实不会发生，但「Output: 空 + 断言成功」照样把模型骗去收尾。

## 二、文件夹上下文里的 Word/Excel/PPT/PDF 一个字都进不去

`FileContextLoader.buildFolderContext` 只走 `FileContentExtractorService.extractText`，其白名单（java/js/md/txt/csv…）不含 Office 格式，恒返回空串，随后 `if (!text.isEmpty())` 把这些文件**静默跳过**——上下文里「### Folder Document Contents」标题下空空如也。

#448 修的是**单文件**路径（`read_document` 改走 Tika）与 `<file>` 段守卫，**文件夹路径当时漏了**；而「一个案子 = 一个文件夹的 Word/PDF」正是本产品主用法。改为同一套 `DocumentTextService`；抽不出正文的文件不再凭空消失，在 `[System Note: …]` 里点名留痕（点名数封顶防刷屏）。

图片仍不在此处做 OCR：文件夹扫描是批量路径，逐张 OCR 的代价不属本次修复范围。同文件的 `extractFileText` / `collectFolderContent` 有同样缺陷但**零生产调用方**，刻意没动，已在领域文档记下。

## 三、一条超长工具结果让整轮无法恢复

`extract_file_text` 一直有 80k 上限，`read_file` / `read_document` **没有**。一次读一份几 MB 的合同就是几十万字符的单条 `ToolExecutionResultMessage`，下一轮必被服务商以上下文超限 400 挡回。**而且救不回来**：它落在 `RunLoopCompactor` 的 keepRecent 尾区（尾部平时刻意不剪），中段又往往不够 `minMiddleMessages` 条数，于是 `forceCompact` 恒返回原实例、编排器判「压不动」直接终态——同一份文档每次重试都必然再撞同一个 400。

两道防线：
- 工具侧截断，上限收成单一来源 `ToolFileGuard.capToolText`（80k，口径沿用 `extract_file_text`；那处硬编码一并改为调用它，三个读取工具不会再各说各话），截断说明告诉模型用 `doc_read_paragraphs` 分段读；
- `forceCompact` 兜底剪尾：**只在 force 下**（服务商已用 400 证实装不下）。非 force 的尾部豁免是刻意设计，原样保留并加回归用例钉住。只剪正文，`id`/`toolName` 原样带过去，工具配对不受影响。

## 测试

新增 `AgentOrchestratorXmlToolFeedbackTest`（3）、`FolderContextOfficeFormatTest`（3，真 POI 写的 docx + 真 Tika）、`OversizedToolResultRecoveryTest`（5）。三组都做过**「还原病灶即转红」**校验：分别把 instruction 拼回无条件、把 `extractForFolder` 换回 `extractText`、把兜底剪尾短路，对应用例即转红。

既有 `RunLoopCompactorTest` 12 例、`FileContextLoaderTest`、`ContextAssemblerServiceTest` 全绿。全量 `mvn test` 2090 通过，唯一失败是 `LocalProjectServiceTest.watcherPicksUpExternalChanges`（本机 mac FSEvents 已知抖动，单独重跑即过，与本 PR 涉及文件无关）。

领域文档 `.claude/agents/ai-chat.md` 已同步三条地雷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)