### PR TITLE
fix(ai-chat): 工具失败判据听不见中文「错误：」——37 处失败返回被判成成功（dev-board#74）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -201,6 +201,17 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
   回归用例 `FolderContextOfficeFormatTest`。
   （同文件的 `extractFileText` / `collectFolderContent` 有同样的白名单缺陷，但**零生产调用方**，
   本次刻意没动——要用它们之前先照 `buildFolderContext` 改。）
+- **工具失败判据只认前缀，中英文各一个**：`ToolRegistry.ToolResult.success()` 认
+  `Error` 前缀、`错误` 前缀与 `{"error"` JSON 形态。中文前缀是补的——MemoryTools / TagTools /
+  TaskTools / EvidenceTools / PptxTools 共 37 处失败返回写的是「错误：…」，它们**自认为在报错**，
+  判据却只认英文，于是全被判成 SUCCESS：过程卡给失败调用打绿勾、`appendFailureNudge` 把
+  `consecutiveFailures` 清零（连续失败纠正回路对这些工具永不触发，模型能对着同一个错误
+  重试到步数上限）、埋点也记 `success=true`。
+  **新增失败返回必须以 `Error` 或「错误」开头**，别写成「XX 失败：…」——判据看不见。
+  反过来也别改成按包含匹配：合同正文里出现「失败」「违约」是家常便饭，误判成失败比漏判更糟
+  （回归用例 `ToolFailureClassificationTest` 把这条也钉住了）。
+  **`GatewayException` 的 `unavailable()` 文案刻意没加标记**：`Kind.BUDGET_EXCEEDED`
+  按设计「是可恢复的确认，不是失败」，一并标成失败会误伤它——要动先想清楚这一档。
 - **埋点体系**（`com.checkba.service.telemetry`，设计 docs/ANALYTICS_TELEMETRY_DESIGN.md）：
   唯一采集入口 TelemetryService.record/recordConv，字段过 TelemetryAttrWhitelist 白名单
   （新事件/字段要同步白名单 + TelemetryServiceTest + 官网仓 lib/telemetry-store.ts 的 EVENT_WHITELIST）。

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -110,6 +110,14 @@ public class ToolRegistry {
             if (!found || output == null) return false;
             String trimmed = output.stripLeading();
             if (trimmed.startsWith("Error")) return false;
+            // 中文失败前缀与英文同等对待：MemoryTools / TagTools / TaskTools /
+            // EvidenceTools / PptxTools 共 37 处失败返回写的是「错误：…」，它们**自认为在报错**，
+            // 判据却只认英文 "Error"，于是全被判成 SUCCESS——过程卡给失败的调用打绿勾、
+            // appendFailureNudge 把 consecutiveFailures 清零（连续失败纠正回路对这些工具
+            // 永不触发，模型能对着同一个错误重试到步数上限）、埋点也记成功。
+            // 只认**前缀**，不按包含匹配：合同正文里出现「失败」「错误」是家常便饭，
+            // 把正常结果误判成失败比漏判更糟。
+            if (trimmed.startsWith("错误")) return false;
             // 编辑器桥等工具的失败以 JSON 返回（如 {"error": "操作超时..."}）。
             // 此前只认 "Error" 前缀，这类失败被判成 SUCCESS：失败熔断计数被清零、
             // 前端显示绿勾、file_change 照发——模型一路"成功"空转到步数上限（F-09）。

--- a/backend/src/main/java/com/checkba/service/ai/tools/EnterpriseDataTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/EnterpriseDataTools.java
@@ -69,7 +69,9 @@ public class EnterpriseDataTools implements AgentToolComponent {
             return unavailable("企业工商信息查询", "企业数据", e);
         } catch (Exception e) {
             log.warn("企业工商信息查询失败: {}", e.toString());
-            return "企业工商信息查询失败：" + e.getMessage()
+            // 「错误：」前缀是本仓的失败标记（ToolResult.success 认前缀）——没有它，
+            // 这条真失败会被判成 SUCCESS：过程卡打绿勾、连续失败纠正回路不计数
+            return "错误：企业工商信息查询失败：" + e.getMessage()
                     + " 本次已跳过该查询，请基于已有信息继续完成任务。";
         }
     }
@@ -100,7 +102,8 @@ public class EnterpriseDataTools implements AgentToolComponent {
             return unavailable("金融数据查询", "金融数据", e);
         } catch (Exception e) {
             log.warn("金融数据查询失败: {}", e.toString());
-            return "金融数据查询失败：" + e.getMessage()
+            // 同上：失败标记不能少，否则判据听不见
+            return "错误：金融数据查询失败：" + e.getMessage()
                     + " 本次已跳过该查询，请基于已有信息继续完成任务。";
         }
     }

--- a/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
@@ -74,7 +74,7 @@ public class WebTools implements AgentToolComponent {
 
         String apiKey = systemSettingService.get("external.bocha.apiKey", bochaApiKey);
         if (apiKey == null || apiKey.isBlank()) {
-            return "网络搜索未配置：缺少博查（Bocha AI）搜索的 API Key。请管理员在「设置 → 外部服务」中填写博查 API Key"
+            return "错误：网络搜索未配置：缺少博查（Bocha AI）搜索的 API Key。请管理员在「设置 → 外部服务」中填写博查 API Key"
                     + "（可在 bochaai.com 申请），保存后重试。本次已跳过网络搜索，请基于已有信息继续完成任务。";
         }
         try {

--- a/backend/src/test/java/com/checkba/service/ai/ToolFailureClassificationTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolFailureClassificationTest.java
@@ -1,0 +1,74 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 工具失败判据：中文「错误：」前缀必须和英文 "Error" 同等对待。
+ *
+ * <p>病灶：{@code ToolResult.success()} 只认英文 {@code "Error"} 前缀与
+ * {@code {"error"} } JSON 形态，而 MemoryTools / TagTools / TaskTools /
+ * EvidenceTools / PptxTools 共 37 处失败返回用的是中文「错误：」。
+ * 这些工具**自认为在报错**，判据却听不见，于是：
+ * <ul>
+ *   <li>过程卡给失败的调用打绿勾（用户看到「查询企业工商信息 ✓」而内容是查不到）；</li>
+ *   <li>{@code appendFailureNudge} 把 {@code consecutiveFailures} 清零，
+ *       连续失败纠正回路（CONSECUTIVE_FAILURE_NUDGE）对这些工具**永远不触发**，
+ *       模型可以对着同一个错误一直重试到步数上限；</li>
+ *   <li>埋点 {@code ai.tool success=true}，外部服务全线失败时指标仍是健康的。</li>
+ * </ul>
+ *
+ * <p>判据只认<b>前缀</b>，不认「失败/不可用」这类词出现在正文任意位置——
+ * 合同正文里出现「违约」「失败」是家常便饭，按包含匹配会把正常结果误判成失败，
+ * 那比漏判更糟。
+ */
+class ToolFailureClassificationTest {
+
+    private static boolean success(String output) {
+        return new ToolRegistry.ToolResult(output, null, true).success();
+    }
+
+    @Test
+    @DisplayName("中文「错误：」前缀 = 失败（MemoryTools/TagTools/TaskTools 等 37 处在用）")
+    void chineseErrorPrefixIsAFailure() {
+        assertFalse(success("错误：无法获取当前项目ID，请在项目上下文中使用此工具。"));
+        assertFalse(success("错误：无法获取当前用户ID，无法保存用户级记忆。"));
+        assertFalse(success("错误：打标签失败，标签不存在"));
+        assertFalse(success("错误：PPTX 生成服务不可用。请先启动 Docker 服务"));
+    }
+
+    @Test
+    @DisplayName("前导空白不影响判定（与英文分支同口径）")
+    void leadingWhitespaceDoesNotHideTheMarker() {
+        assertFalse(success("\n  错误：无法获取当前项目ID。"));
+        assertFalse(success("\n  Error: file not found"));
+    }
+
+    @Test
+    @DisplayName("既有的英文与 JSON 失败形态不变")
+    void existingFailureShapesStillDetected() {
+        assertFalse(success("Error: File not found."));
+        assertFalse(success("{\"error\": \"操作超时\"}"));
+        assertFalse(success("{ \"error\" : \"editor not open\" }"));
+    }
+
+    @Test
+    @DisplayName("正文里出现「失败/错误」不算失败——判据只认前缀，绝不按包含匹配")
+    void wordsInsideTheBodyMustNotFlipTheVerdict() {
+        assertTrue(success("第三条 违约责任：一方未能履行的，视为违约，另一方有权解除合同。"),
+                "合同正文里出现失败/违约字样是家常便饭，误判成失败比漏判更糟");
+        assertTrue(success("检索到 3 条结果，其中 1 条记载该公司曾因申报错误被行政处罚。"));
+        assertTrue(success("[文件 起诉状.docx]\n原告诉称：被告交付失败，构成根本违约。"));
+    }
+
+    @Test
+    @DisplayName("正常结果与空白仍按既有规则")
+    void normalResultsUnchanged() {
+        assertTrue(success("合同正文……"));
+        assertFalse(new ToolRegistry.ToolResult(null, null, true).success());
+        assertFalse(new ToolRegistry.ToolResult("whatever", null, false).success());
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第二批，单点修复。

## 病灶

`ToolRegistry.ToolResult.success()` 只认英文 `Error` 前缀与 `{"error"` JSON 形态，而 `MemoryTools`(11) / `TagTools`(12) / `TaskTools`(9) / `PptxTools`(4) / `EvidenceTools`(1) 共 **37 处**失败返回写的是中文「错误：…」。这些工具**自认为在报错**，判据却听不见，于是一律被判成 SUCCESS：

- 过程卡给失败的调用**打绿勾**——用户看到「查询企业工商信息 ✓」而内容是查不到；
- `appendFailureNudge` 把 `consecutiveFailures` 清零，`CONSECUTIVE_FAILURE_NUDGE` 连续失败纠正回路对这些工具**永远不触发**，模型可以对着同一个错误一直重试到步数上限；
- 埋点 `ai.tool success=true`，外部服务全线失败时指标仍然是健康的。

## 修法

判据补一条中文前缀分支（与英文分支同口径，同样 `stripLeading` 后判前缀）。

**刻意不按包含匹配**：合同正文里出现「失败」「违约」是家常便饭，把正常结果误判成失败比漏判更糟——用例里专门钉了三条「正文含失败/错误仍须判成功」的反向断言。

另外两处真失败补上标记（它们走普通 `catch`，不是 `GatewayException`）：`EnterpriseDataTools` 的两个 `catch (Exception)`、`WebTools` 缺 Bocha API Key 的「网络搜索未配置」。

## 刻意没做

`GatewayException` 的 `unavailable()` 文案没动。`Kind.BUDGET_EXCEEDED` 按其 javadoc「**是可恢复的确认，不是失败**」（用户自己设的花费上限拦了自己，下一步是「继续」或调高上限），和其它网关失败一并标成失败会误伤这一档。这属于产品语义决定，留给维护者拍板，已在领域文档记下。

## 测试

新增 `ToolFailureClassificationTest`（5 例，含 3 条防过度纠正的反向断言）。还原病灶即转红（中文前缀两例）。`ToolRegistryTest` 16 例、`ExternalServiceDualTierRoutingTest`（断言用 `contains`，加前缀不影响）全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)