### PR TITLE
fix(storage): 读不到文件就伪造一份空白模板——load 回归纯读，建文件走 createFromTemplate（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -254,12 +254,14 @@ public class ProjectFileService {
 
         ProjectFile savedFile = projectFileRepository.save(file);
         
-        // 尝试创建物理文件（从模板复制）
+        // 从模板物化物理文件。此前这里调的是 load()——靠「读不到就造一个」的副作用来建文件，
+        // 于是读路径也被迫保留那个副作用，任何一份正文丢失的文档都会被静默读成空白模板。
+        // 建与读拆开后，这里明确表达「创建」，load() 得以回归纯读（文件不存在就报错）。
         try {
-            storageServiceFactory.getStorageService().load(filePath);
+            storageServiceFactory.getStorageService().createFromTemplate(filePath);
             log.info("物理文件创建成功: {}", filePath);
         } catch (Exception e) {
-            log.warn("物理文件创建可能失败 (如果是第一次访问会自动创建): {}", filePath, e);
+            log.warn("物理文件创建失败（首次保存时会重新写入）: {}", filePath, e);
         }
 
         signalChange(projectId, userId);

--- a/backend/src/main/java/com/checkba/storage/LocalFileStorageService.java
+++ b/backend/src/main/java/com/checkba/storage/LocalFileStorageService.java
@@ -55,35 +55,48 @@ public class LocalFileStorageService implements StorageService {
         }
     }
 
+    /**
+     * 纯读。文件不存在就抛，<b>绝不就地造一个出来</b>。
+     *
+     * <p>此前这里会「文件不存在就从模板复制一份」并当成正常结果返回：一份正文丢失的合同
+     * （换存储位置、同步失败、只恢复了数据库、localRoot 项目里被外部删掉）被读成一份空白模板，
+     * 用户打开看到空文档、AI 读到模板内容，全程零报错；自动保存再把空白盖回去，原件就真没了。
+     * 而且这与接口契约、与 {@link OssStorageService#load} 的行为都不一致（那边一直是抛）。
+     * 新建文档的模板物化改由 {@link #createFromTemplate(String)} 明确表达。
+     */
     @Override
     public Resource load(String fileId) throws StorageException {
         Path filePath = resolveFilePath(fileId);
-        
-        // 如果文件不存在，尝试从模板创建
-        if (!Files.exists(filePath)) {
-            try {
-                // 确保父目录存在
-                Files.createDirectories(filePath.getParent());
-                if (Files.exists(templateDoc)) {
-                    Files.copy(templateDoc, filePath, StandardCopyOption.REPLACE_EXISTING);
-                    log.info("从模板创建新文件: fileId={}, path={}", fileId, filePath);
-                } else {
-                    log.warn("模板文件不存在: {}, 创建空文件", templateDoc);
-                    Files.createFile(filePath);
-                }
-            } catch (IOException e) {
-                log.error("创建文件失败: fileId={}, path={}", fileId, filePath, e);
-                throw new StorageException("创建文件失败: " + e.getMessage(), e);
-            }
-        }
-        
+
         FileSystemResource resource = new FileSystemResource(filePath);
         if (!resource.exists()) {
             log.error("文件不存在: fileId={}, path={}", fileId, filePath);
             throw new StorageException("文件不存在: " + fileId);
         }
-        
+
         return resource;
+    }
+
+    /** 新建文档时物化模板文件；已存在则原样不动（幂等）。 */
+    @Override
+    public void createFromTemplate(String fileId) throws StorageException {
+        Path filePath = resolveFilePath(fileId);
+        if (Files.exists(filePath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(filePath.getParent());
+            if (Files.exists(templateDoc)) {
+                Files.copy(templateDoc, filePath, StandardCopyOption.REPLACE_EXISTING);
+                log.info("从模板创建新文件: fileId={}, path={}", fileId, filePath);
+            } else {
+                log.warn("模板文件不存在: {}, 创建空文件", templateDoc);
+                Files.createFile(filePath);
+            }
+        } catch (IOException e) {
+            log.error("创建文件失败: fileId={}, path={}", fileId, filePath, e);
+            throw new StorageException("创建文件失败: " + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/backend/src/main/java/com/checkba/storage/StorageService.java
+++ b/backend/src/main/java/com/checkba/storage/StorageService.java
@@ -27,13 +27,30 @@ public interface StorageService {
     String save(String fileId, InputStream inputStream) throws StorageException;
 
     /**
-     * 读取文件
-     * 
+     * 读取文件。
+     *
+     * <p><b>纯读操作：文件不存在必须抛 {@link StorageException}，绝不允许就地造一个出来。</b>
+     * 本地实现曾在此处「文件不存在就从模板复制一份」，于是一份正文丢失的合同被读成一份
+     * 空白模板，用户打开看到的是空文档、AI 读到的是模板内容，全程没有任何报错；
+     * 自动保存再把这份空白盖回去，原件就真的没了。新建文档要物化模板请走
+     * {@link #createFromTemplate(String)}——建和读是两件事，别再合用一个方法。
+     *
      * @param fileId 文件ID
      * @return 文件资源
-     * @throws StorageException 存储异常
+     * @throws StorageException 文件不存在或读取失败
      */
     Resource load(String fileId) throws StorageException;
+
+    /**
+     * 新建文档时物化一个初始文件（本地实现从 docs/template.docx 复制，缺模板则建空文件）。
+     *
+     * <p>只有「创建」路径可以调用；已存在则原样不动（幂等）。
+     * 默认空实现：对象存储此前根本没有这条路（{@code load} 直接抛，调用方 catch 掉记一行日志），
+     * 保持这个既有行为，不在本次修复里给 OSS 新增一次上传。
+     */
+    default void createFromTemplate(String fileId) throws StorageException {
+        // no-op：见 javadoc
+    }
 
     /**
      * 删除文件

--- a/backend/src/test/java/com/checkba/storage/MissingFileIsNotFabricatedTest.java
+++ b/backend/src/test/java/com/checkba/storage/MissingFileIsNotFabricatedTest.java
@@ -1,0 +1,120 @@
+package com.checkba.storage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 读文件不许就地造一个出来。
+ *
+ * <p>病灶：{@code LocalFileStorageService.load(key)} 在文件不存在时会**从模板复制一份**
+ * 并当成正常结果返回。于是一份正文丢失的合同（换存储位置、同步失败、只恢复了数据库、
+ * localRoot 项目里被外部删掉）被读成一份空白模板：用户打开看到空文档、AI 读到的是模板内容，
+ * 全程零报错；自动保存再把这份空白盖回去，原件就真的没了。
+ *
+ * <p>而且它与接口契约（「读取文件」）以及 {@code OssStorageService.load}（一直是抛）都不一致——
+ * 同一份代码在桌面端伪造、在云端报错。
+ *
+ * <p>模板物化本身是新建文档需要的真实能力，所以不是删掉而是**拆开**：
+ * 建走 {@code createFromTemplate}，读走 {@code load}。
+ */
+class MissingFileIsNotFabricatedTest {
+
+    private LocalFileStorageService storageWithTemplate(Path root, Path template) {
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(root.toAbsolutePath().toString());
+        props.getLocal().setTemplatePath(template.toAbsolutePath().toString());
+        return new LocalFileStorageService(new ProjectStorageResolver(props, null));
+    }
+
+    @Test
+    @DisplayName("读一个不存在的文件：必须抛，且不许在磁盘上留下任何东西")
+    void loadOfMissingFileThrowsAndCreatesNothing(@TempDir Path dir) throws Exception {
+        Path template = dir.resolve("template.docx");
+        Files.writeString(template, "TEMPLATE-BODY", StandardCharsets.UTF_8);
+        Path root = Files.createDirectory(dir.resolve("root"));
+        LocalFileStorageService storage = storageWithTemplate(root, template);
+
+        assertThrows(StorageException.class, () -> storage.load("projects/1/合同.docx"),
+                "读不到就伪造一份模板 = 用户以为文档被清空了，而且自动保存会把空白盖回去");
+
+        assertFalse(Files.exists(root.resolve("projects/1/合同.docx")),
+                "读操作不许有副作用：磁盘上不该凭空多出一个文件");
+    }
+
+    @Test
+    @DisplayName("读到的必须是真正的原文，不是模板")
+    void loadReturnsTheRealBytes(@TempDir Path dir) throws Exception {
+        Path template = dir.resolve("template.docx");
+        Files.writeString(template, "TEMPLATE-BODY", StandardCharsets.UTF_8);
+        Path root = Files.createDirectory(dir.resolve("root"));
+        LocalFileStorageService storage = storageWithTemplate(root, template);
+
+        storage.save("projects/1/合同.docx",
+                new ByteArrayInputStream("REAL-CONTRACT".getBytes(StandardCharsets.UTF_8)));
+
+        try (var in = storage.load("projects/1/合同.docx").getInputStream()) {
+            assertEquals("REAL-CONTRACT", new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    @DisplayName("新建文档的模板物化仍然可用（能力没被删掉，只是换了入口）")
+    void createFromTemplateStillMaterialisesTheFile(@TempDir Path dir) throws Exception {
+        Path template = dir.resolve("template.docx");
+        Files.writeString(template, "TEMPLATE-BODY", StandardCharsets.UTF_8);
+        Path root = Files.createDirectory(dir.resolve("root"));
+        LocalFileStorageService storage = storageWithTemplate(root, template);
+
+        storage.createFromTemplate("projects/1/新建文档.docx");
+
+        Path made = root.resolve("projects/1/新建文档.docx");
+        assertTrue(Files.exists(made), "新建文档必须真的落一个物理文件");
+        assertEquals("TEMPLATE-BODY", Files.readString(made, StandardCharsets.UTF_8));
+
+        try (var in = storage.load("projects/1/新建文档.docx").getInputStream()) {
+            assertEquals("TEMPLATE-BODY", new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    @DisplayName("模板物化是幂等的，绝不覆盖已有正文")
+    void createFromTemplateNeverOverwritesExistingContent(@TempDir Path dir) throws Exception {
+        Path template = dir.resolve("template.docx");
+        Files.writeString(template, "TEMPLATE-BODY", StandardCharsets.UTF_8);
+        Path root = Files.createDirectory(dir.resolve("root"));
+        LocalFileStorageService storage = storageWithTemplate(root, template);
+
+        storage.save("projects/1/合同.docx",
+                new ByteArrayInputStream("REAL-CONTRACT".getBytes(StandardCharsets.UTF_8)));
+        storage.createFromTemplate("projects/1/合同.docx");
+
+        assertEquals("REAL-CONTRACT",
+                Files.readString(root.resolve("projects/1/合同.docx"), StandardCharsets.UTF_8),
+                "幂等：已经有正文了就别动它，否则新建路径会变成一把删除器");
+    }
+
+    @Test
+    @DisplayName("缺模板文件时物化成空文件，仍然不许把这个行为漏进 load")
+    void createFromTemplateFallsBackToAnEmptyFile(@TempDir Path dir) throws Exception {
+        Path template = dir.resolve("no-such-template.docx");
+        Path root = Files.createDirectory(dir.resolve("root"));
+        LocalFileStorageService storage = storageWithTemplate(root, template);
+
+        storage.createFromTemplate("projects/1/新建文档.docx");
+        assertTrue(Files.exists(root.resolve("projects/1/新建文档.docx")));
+
+        assertThrows(StorageException.class, () -> storage.load("projects/1/另一个.docx"));
+        assertFalse(Files.exists(root.resolve("projects/1/另一个.docx")));
+    }
+}

--- a/docs/STORAGE_CONFIG.md
+++ b/docs/STORAGE_CONFIG.md
@@ -17,6 +17,24 @@
 - 实际文件存储在文件系统或对象存储中
 - 通过统一的`StorageService`接口管理文件操作
 
+## StorageService 契约红线：读就是读，别在读路径造文件
+
+`StorageService.load(key)` 是**纯读**：文件不存在必须抛 `StorageException`。
+
+`LocalFileStorageService.load` 曾在文件不存在时**从 `docs/template.docx` 复制一份**并当成
+正常结果返回。于是一份正文丢失的文档（换存储位置、同步失败、只恢复了数据库、
+localRoot 项目里被外部删掉）会被读成一份**空白模板**：用户打开看到空文档、AI 读到的是
+模板内容、下载拿到的是模板，全程零报错；自动保存再把这份空白盖回去，原件就真的没了。
+同一行为在 `OssStorageService.load` 里从来没有（那边一直是抛），所以桌面端伪造、云端报错，
+同一份代码两种行为。
+
+新建文档确实需要物化一个初始文件，那是**另一件事**，走
+`StorageService.createFromTemplate(key)`（幂等，已存在则不动；对象存储侧默认空实现，
+保持其既有行为）。唯一调用方是 `ProjectFileService.createFile`。
+
+**新增存储实现或新增调用点时**：读路径一律 `load`，创建路径一律 `createFromTemplate`，
+不要再让读操作带副作用。回归用例 `MissingFileIsNotFabricatedTest`。
+
 ## 配置方式
 
 ### 1. 本地文件系统存储（默认）


### PR DESCRIPTION
审计（dev-board#74）第三批。这条是本轮目前**数据完整性影响最大**的一处。

## 病灶

`LocalFileStorageService.load(key)` 在文件不存在时**从 `docs/template.docx` 复制一份**并当成正常结果返回。于是一份正文丢失的文档——换存储位置、同步失败、只恢复了数据库、localRoot 项目里被外部删掉——会被读成一份**空白模板**：

- 用户在编辑器里打开，看到空文档（以为自己的合同被清空了）；
- AI 的 `read_document` / `extract_file_text` 读到的是模板内容或空正文；
- `/api/file/download` 下载下来的也是模板；
- **全程零报错**，随后自动保存把这份空白盖回去，原件就真的没了。

而且这与接口契约（javadoc 写的是「读取文件」）以及 `OssStorageService.load`（那边一直是文件不存在就抛）都不一致——同一份代码桌面端伪造、云端报错。

## 为什么不能直接删掉

模板物化是**新建文档真正需要的能力**：`ProjectFileService.createFile` 一直靠 `load()` 的这个副作用来建物理文件（注释写着「尝试创建物理文件（从模板复制）」）。直接删会把新建文档打挂——这也是这条 bug 一直活着的原因。

## 修法：把「建」和「读」拆开

- **新增** `StorageService.createFromTemplate(key)`：显式表达「新建文档时物化初始文件」。幂等（已存在则原样不动，**绝不覆盖已有正文**）。默认空实现——对象存储此前根本没有这条路（`load` 直接抛、调用方 catch 掉记一行日志），保持既有行为，不在本次修复里给 OSS 新增一次模板上传。
- `LocalFileStorageService.load`：去掉模板兜底，文件不存在即抛 `StorageException`，与接口契约和 OSS 实现对齐。
- `ProjectFileService.createFile`：改调 `createFromTemplate`，意图写在代码里而不是藏在另一个方法的副作用里。

读路径的调用方本来就准备好了：`FileController.downloadFile` 早有 `catch (StorageException) -> 404`，`DocumentTextService` 包成 `IOException`，其余沿调用链把错误如实报给用户/模型——这正是本次要的结果。

## 测试

新增 `MissingFileIsNotFabricatedTest`（5 例）：读不存在的文件必须抛且**磁盘上不许留下任何东西**（读操作不能有副作用）、读到的必须是真正的原文、模板物化仍可用、物化幂等不覆盖已有正文、缺模板时退化成空文件但这行为不许漏回 `load`。

既有 `LocalFileStorageServiceTest`（路径遍历围栏 4 例）、`ProjectStorageResolverTest` 全绿。这条改动横跨十余个 `load` 调用点，所以跑的是**全量 `mvn test`：2100 通过 0 失败**。

契约红线已写进 `docs/STORAGE_CONFIG.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)