### PR TITLE
fix(ai-doc-bridge): doc_get_paragraph/doc_modify_paragraph 自称 1 基而编辑器是 0 基——AI 整体改错一段（dev-board#74）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -7,6 +7,25 @@ description: AI↔文档编辑桥接领域。任务涉及 doc_*/sheet_*/slide_* 
 
 职责边界：AI 侧发出编辑指令 → 编辑器执行 的整条链路。不含编辑器内核本身（那是 doc-editor 领域），不含对话编排（ai-chat 领域）。
 
+## 段落号基数：doc_* 全族 0 基（已踩）
+
+编辑器侧一律 0 基——`office_thread.js` 的 `get_paragraph` / `modify_paragraph` /
+`select_paragraph` 都是从 `i = 0` 起数、`i === idx` 命中，`get_document_text` 返回的也是
+`index: i`（0 起）。可 `doc_get_paragraph` 与 `doc_modify_paragraph` 的 `@P` 曾写
+「段落索引，从 1 开始」，而同族的 `doc_get_document_text`、`doc_select_paragraph` 写的是 0 开始。
+
+模型先用 `doc_get_document_text` 拿 0 基编号，再照「从 1 开始」的说明去调
+`doc_modify_paragraph`，就整体差一段——**在修订模式下改错条款**，用户还很可能直接接受。
+
+**新增任何段落定位参数，说明里必须写明 0 基**，并且缺参要在 Java 侧拦下：编辑器的
+`Number(p.index) || 0` 会把 null／非数字静默当成第 0 段，「没给段落号」于是变成「改第一段」。
+回归用例 `ParagraphIndexBaseTest`（反射扫 `@P`，写成 1 基即转红）。
+
+同类：`doc_goto` 的描述曾宣告 `paragraph/bookmark/line` 三种定位，而 `office_thread.js` 的
+`goto()` 只实现 `start/end`，其余一律返回 "goto type not supported yet"——
+**描述里挂着做不到的能力 = 模型反复往死路上撞、白烧步数预算**。已收窄成只宣告 start/end，
+并指向 `doc_select_paragraph` / `doc_select_anchor`。
+
 ## 关键文件
 
 **后端工具原语**

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -247,10 +247,14 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
-    @Tool("移动文档的光标到指定位置。")
+    // 只宣告编辑器真的实现了的两种：office_thread.js 的 goto() 只处理 start/end，
+    // paragraph/bookmark/line 一律返回 "goto type not supported yet"。
+    // 描述里挂着做不到的能力 = 模型反复往死路上撞、白烧步数预算。
+    @Tool("把光标移到文档开头或结尾。只支持 start/end；要定位到某一段用 doc_select_paragraph，"
+          + "要定位到某处文本用 doc_find_text 拿 anchorId 再 doc_select_anchor。")
     public String doc_goto(
-            @P("定位类型: paragraph(段落)/bookmark(书签)/start(文档开头)/end(文档结尾)/line(行号)") String type,
-            @P("目标值: 段落号、书签名、行号等。对于 start/end 类型可以为空。") String target
+            @P("定位类型：start(文档开头) 或 end(文档结尾)") String type,
+            @P("保留参数，start/end 用不到，传空即可") String target
     ) {
         log.info("Tool: doc_goto called type={}, target={}", type, target);
         try {
@@ -415,11 +419,36 @@ public class DocumentEditTools implements AgentToolComponent {
         }
     }
 
+    /**
+     * 段落号校验。
+     *
+     * <p><b>编辑器侧一律 0 基</b>：{@code office_thread.js} 的 get_paragraph /
+     * modify_paragraph / select_paragraph 都是从 {@code i = 0} 起数、{@code i === idx} 命中，
+     * {@code get_document_text} 返回的也是 {@code index: i}（0 起）。
+     * 而 doc_get_paragraph / doc_modify_paragraph 的参数说明曾写「从 1 开始」——
+     * 照着描述办事的模型会整体差一段，在修订模式下**改错条款**，用户还可能直接接受。
+     *
+     * <p>缺参同样不能放行：编辑器的 {@code Number(p.index) || 0} 会把 null／非数字
+     * 静默当成第 0 段，于是「没给段落号」变成「改第一段」，无人察觉。
+     */
+    private static String rejectBadParagraphIndex(Integer paragraphIndex) {
+        if (paragraphIndex == null) {
+            return "Error: paragraphIndex is required. It is 0-based — use the `index` values returned by "
+                    + "doc_get_document_text / doc_read_paragraphs.";
+        }
+        if (paragraphIndex < 0) {
+            return "Error: paragraphIndex must be >= 0 (0-based). Received: " + paragraphIndex;
+        }
+        return null;
+    }
+
     @Tool("获取文档中指定段落的文本内容。")
     public String doc_get_paragraph(
-            @P("段落索引，从 1 开始") Integer paragraphIndex
+            @P("段落号（0 开始，用 doc_get_document_text / doc_read_paragraphs 返回的 index）") Integer paragraphIndex
     ) {
         log.info("Tool: doc_get_paragraph called index={}", paragraphIndex);
+        String rejected = rejectBadParagraphIndex(paragraphIndex);
+        if (rejected != null) return rejected;
         try {
             return editorBridgeService.executeEditorCommand("get_paragraph", 
                     java.util.Map.of("index", paragraphIndex));
@@ -432,10 +461,16 @@ public class DocumentEditTools implements AgentToolComponent {
     @ToolMeta(displayName = "修改段落", category = "document", fileEffect = "MODIFIED")
     @Tool("修改文档中指定段落的文本内容。修改将以修订模式进行，用户可以审阅后接受或拒绝。")
     public String doc_modify_paragraph(
-            @P("段落索引，从 1 开始") Integer paragraphIndex,
+            @P("段落号（0 开始，用 doc_get_document_text / doc_read_paragraphs 返回的 index）") Integer paragraphIndex,
             @P("新的段落文本") String newText
     ) {
-        log.info("Tool: doc_modify_paragraph called index={}, new text length={}", paragraphIndex, newText.length());
+        log.info("Tool: doc_modify_paragraph called index={}, new text length={}",
+                paragraphIndex, newText == null ? -1 : newText.length());
+        String rejected = rejectBadParagraphIndex(paragraphIndex);
+        if (rejected != null) return rejected;
+        if (newText == null) {
+            return "Error: newText is required. To delete a paragraph's content pass an empty string explicitly.";
+        }
         try {
             return editorBridgeService.executeEditorCommand("modify_paragraph", 
                     java.util.Map.of("index", paragraphIndex, "newText", newText));

--- a/backend/src/test/java/com/checkba/service/ai/tools/ParagraphIndexBaseTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/ParagraphIndexBaseTest.java
@@ -1,0 +1,137 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.EditorBridgeService;
+import dev.langchain4j.agent.tool.P;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * doc_* 段落号的基数契约：**全族 0 基**，且缺参绝不放行。
+ *
+ * <p>病灶：编辑器侧一律 0 基——{@code office_thread.js} 的 get_paragraph /
+ * modify_paragraph / select_paragraph 都是从 {@code i = 0} 起数、{@code i === idx} 命中，
+ * {@code get_document_text} 返回的也是 {@code index: i}（0 起）。
+ * 可 {@code doc_get_paragraph} 与 {@code doc_modify_paragraph} 的参数说明写的是
+ * 「段落索引，从 1 开始」，而同族的 {@code doc_get_document_text}、
+ * {@code doc_select_paragraph} 写的是 0 开始。
+ *
+ * <p>模型先用 doc_get_document_text 拿到 0 基编号，再照着「从 1 开始」的说明去调
+ * doc_modify_paragraph，就会整体差一段——**在修订模式下改错条款**，而用户很可能直接接受。
+ * 对法律文书来说这是最不能有的一类错。
+ *
+ * <p>另一半是缺参：编辑器的 {@code Number(p.index) || 0} 把 null／非数字静默当成第 0 段，
+ * 于是「没给段落号」变成「改第一段」，同样无人察觉。
+ */
+class ParagraphIndexBaseTest {
+
+    private static DocumentEditTools toolsWithBridge(EditorBridgeService bridge) {
+        return new DocumentEditTools(null, null, bridge, null);
+    }
+
+    /** 收集所有 @P 说明里提到「段落」的参数 */
+    private static List<String> paragraphParamDocs() {
+        List<String> docs = new ArrayList<>();
+        for (Method m : DocumentEditTools.class.getDeclaredMethods()) {
+            for (Parameter param : m.getParameters()) {
+                P p = param.getAnnotation(P.class);
+                if (p == null) continue;
+                // 只看「段落号/段落索引」这类整数定位参数：段落数（计数）、段落文本（String）、
+                // doc_goto 的定位类型都不是基数问题
+                boolean isIndexParam = (param.getType() == Integer.class || param.getType() == int.class)
+                        && (p.value().contains("段落号") || p.value().contains("段落索引"));
+                if (isIndexParam) {
+                    docs.add(m.getName() + " / " + param.getName() + " -> " + p.value());
+                }
+            }
+        }
+        return docs;
+    }
+
+    @Test
+    @DisplayName("没有任何段落号参数敢自称「从 1 开始」——编辑器侧一律 0 基")
+    void noParagraphParameterClaimsOneBasedIndexing() {
+        List<String> docs = paragraphParamDocs();
+        assertFalse(docs.isEmpty(), "用例前提：应当能反射到段落号参数");
+
+        List<String> liars = docs.stream()
+                .filter(d -> d.contains("从 1 开始") || d.contains("1 开始") && !d.contains("0 开始"))
+                .toList();
+        assertTrue(liars.isEmpty(),
+                "编辑器 office_thread.js 的 get_paragraph/modify_paragraph/select_paragraph 都是 0 基，"
+                        + "get_document_text 返回的 index 也是 0 起；说明写成 1 基会让模型整体差一段、"
+                        + "在修订模式下改错条款。违规参数：" + liars);
+    }
+
+    @Test
+    @DisplayName("每个段落号参数都要点明 0 基，模型才不用猜")
+    void everyParagraphParameterStatesTheBaseExplicitly() {
+        for (String doc : paragraphParamDocs()) {
+            assertTrue(doc.contains("0 开始"), "段落号说明必须写明 0 基，实际是：" + doc);
+        }
+    }
+
+    @Test
+    @DisplayName("缺段落号：返回可行动错误，且绝不下发到编辑器（否则静默改第 0 段）")
+    void missingParagraphIndexIsRejectedBeforeDispatch() {
+        EditorBridgeService bridge = Mockito.mock(EditorBridgeService.class);
+        DocumentEditTools tools = toolsWithBridge(bridge);
+
+        String got = tools.doc_get_paragraph(null);
+        String modified = tools.doc_modify_paragraph(null, "新条款");
+
+        assertTrue(got.startsWith("Error"), "实际是：" + got);
+        assertTrue(got.contains("0-based"), "要告诉模型基数，实际是：" + got);
+        assertTrue(modified.startsWith("Error"), "实际是：" + modified);
+
+        verify(bridge, never()).executeEditorCommand(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("负段落号同样拦下")
+    void negativeParagraphIndexIsRejected() {
+        EditorBridgeService bridge = Mockito.mock(EditorBridgeService.class);
+        DocumentEditTools tools = toolsWithBridge(bridge);
+
+        assertTrue(tools.doc_get_paragraph(-1).startsWith("Error"));
+        assertTrue(tools.doc_modify_paragraph(-3, "x").startsWith("Error"));
+        verify(bridge, never()).executeEditorCommand(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("缺 newText 不许下发：编辑器会把它当成空串，等于清空该段")
+    void missingNewTextIsRejectedBeforeDispatch() {
+        EditorBridgeService bridge = Mockito.mock(EditorBridgeService.class);
+        DocumentEditTools tools = toolsWithBridge(bridge);
+
+        String out = tools.doc_modify_paragraph(0, null);
+
+        assertTrue(out.startsWith("Error"), "实际是：" + out);
+        verify(bridge, never()).executeEditorCommand(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("0 是合法段落号（首段），必须放行")
+    void zeroIsAValidParagraphIndex() {
+        EditorBridgeService bridge = Mockito.mock(EditorBridgeService.class);
+        Mockito.when(bridge.executeEditorCommand(anyString(), any())).thenReturn("{\"success\":true}");
+        DocumentEditTools tools = toolsWithBridge(bridge);
+
+        String out = tools.doc_get_paragraph(0);
+
+        assertFalse(out.startsWith("Error"), "0 基的第一段不能被当成缺参，实际是：" + out);
+        verify(bridge).executeEditorCommand(Mockito.eq("get_paragraph"), any());
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第四批。三处都是**工具描述对模型说了假话**。

## 一、段落号基数说反了（主症）

编辑器侧一律 **0 基**：`office_thread.js` 的 `get_paragraph` / `modify_paragraph` / `select_paragraph` 都是从 `i=0` 起数、`i===idx` 命中，`get_document_text` 返回的也是 `index: i`（0 起）。

可这两个工具的 `@P` 写的是「段落索引，**从 1 开始**」，而同族的 `doc_get_document_text`、`doc_select_paragraph` 写的是「0 开始」。

模型先用 `doc_get_document_text` 拿到 0 基编号，再照着「从 1 开始」的说明去调 `doc_modify_paragraph`，就会**整体差一段**——在修订模式下**改错条款**，而修订正是给用户审阅接受的，很可能就这么被接受了。对法律文书这是最不能有的一类错。

改：两处 `@P` 统一成「段落号（0 开始，用 doc_get_document_text / doc_read_paragraphs 返回的 index）」。

## 二、缺参会静默改第 0 段

编辑器的 `Number(p.index) || 0` 把 null／非数字静默当成第 0 段，于是「模型没给段落号」变成「改第一段」；Java 侧 `Map.of("index", null)` 还会先抛 NPE，只留一句没头没脑的 `Error executing tool: ...`。

现在 Java 侧前置校验：缺参/负数返回可行动错误（明说 0 基、明说去哪拿编号），**绝不下发到编辑器**。缺 `newText` 同样拦下——编辑器会把 null 当空串，等于清空该段。（`newText.length()` 原本还写在 `try` 之外，null 直接 NPE，一并修。）

## 三、doc_goto 宣告了三种做不到的定位

描述写 `paragraph/bookmark/start/end/line`，而 `office_thread.js` 的 `goto()` **只实现 start/end**，其余一律返回 `goto type not supported yet`。描述里挂着做不到的能力 = 模型反复往死路上撞、白烧步数预算。收窄成只宣告 start/end，并指向 `doc_select_paragraph` / `doc_select_anchor`。

## 测试

新增 `ParagraphIndexBaseTest`（6 例）：**反射扫全部 `@P`**，任何段落号参数自称 1 基即转红（这条会一直守着新增的定位参数）；缺参/负数/缺 `newText` 必须返回可行动错误且 `never` 下发编辑器；`0` 是合法段落号必须放行。

把 `@P` 改回「从 1 开始」即转红（空断言校验通过）。`DocumentReplaceIntentTest`、`OfficeEditToolsTest`、`ToolRegistryTest`、`OrchestratorReplayEvalTest`（41 例回放）等共 135 例全绿。

领域文档 `.claude/agents/ai-doc-bridge.md` 已记下这条地雷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)