### PR TITLE
fix(sidebar-shell): 离开工作台不落盘——切项目/返回列表/退出登录会静默丢掉刚敲的修改（dev-board#74）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -7,6 +7,25 @@ description: 侧边栏与工作台外壳领域。任务涉及左侧 rail/左栏�
 
 职责边界：工作台整体布局、左侧 rail 与左栏、面板切换状态机、页面路由。各面板内部逻辑归 utility-tools / plugin-system；右栏聊天内容归 ai-chat；编辑器归 doc-editor。
 
+## 离开工作台前必须落盘（已踩）
+
+自动保存是防抖的，用户敲完最后一个字到真正落盘之间有一段窗口。`closeFile`
+（fileOpenTabs.js）与 `evictLibreInstance`（librePool.js）都会先 `await inst.flushSave()`
+再拆实例，但**离开整个页面**的三条路——切项目 `switchToProject`、返回列表 `goAllProjects`、
+退出登录 `handleLogout`——走的是 `uni.reLaunch`，页面组件树直接销毁，一次 flush 都没有。
+`LibreOfficeEditor.beforeUnmount` 自己写着「export 需要活的 webview，从这里保存已经太晚」，
+所以 Office 文档那几秒的改动**静默丢失且无任何提示**（纯文本有 PlainTextEditor 自己的
+beforeUnmount 兜底，Office 没有）。
+
+现在离开工作台只有一个出口 `leaveWorkbench(url)`：先 `flushDirtyEditors`（纯函数，
+`pages/project-overview/flushDirtyEditors.js`，零依赖便于单测）再 `uni.reLaunch`。
+`handleLogout` 因为要在 `clearSession()` **之前**落盘（会话一清保存就是未授权），
+自己显式 flush 而不复用出口。
+
+**新增任何离开工作台的路径都要走 `leaveWorkbench`**；`npm run check:nav` 已把这条钉住
+（goAllProjects 允许直接 reLaunch 或走 leaveWorkbench，走出口时会连带校验出口里有
+flushDirtyEditors），单测见 `frontend/tests/project-home/flush-dirty-editors.test.mjs`。
+
 ## project-overview.vue 内部地图（4939 行，主战场）
 
 > **下面这份 :xxx 行号地图早于「project-overview 分阶段拆分」，多数已漂（实测：

--- a/frontend/scripts/check-navigation-contract.mjs
+++ b/frontend/scripts/check-navigation-contract.mjs
@@ -434,13 +434,29 @@ check('newproject 按钮文案与跳转目标一致（不许挂着"个人中心"
   return null
 })
 
-check('工作台「全部项目」用 reLaunch 去项目列表页', () => {
+check('工作台「全部项目」用 reLaunch 去项目列表页，且离开前先落盘', () => {
   const src = readVue('src/pages/project-overview/project-overview.vue')
   const body = extractMethodBody(src, 'goAllProjects()')
   if (!body) return '找不到 goAllProjects'
   if (!body.includes('/pages/project-list/project-list')) return 'goAllProjects 没有指向项目列表页'
-  if (!body.includes('uni.reLaunch')) return '工作台参与的跳转一律 reLaunch，不能用 navigateTo'
   if (body.includes('uni.navigateTo')) return '工作台参与的跳转一律 reLaunch，检测到误用 navigateTo'
+
+  // 跳转本身可以直接 reLaunch，也可以走统一出口 leaveWorkbench()——后者在 reLaunch 之前
+  // 先 flush 未落盘的编辑器内容（自动保存是防抖的，reLaunch 直接销毁组件树，
+  // LibreOfficeEditor 的 beforeUnmount 已经来不及导出）。两种写法都算合规，
+  // 但走 leaveWorkbench 时必须确认那个出口自己是 reLaunch + 落盘。
+  if (!body.includes('uni.reLaunch')) {
+    if (!body.includes('this.leaveWorkbench(')) {
+      return '工作台参与的跳转一律 reLaunch，不能用 navigateTo'
+    }
+    const exit = extractMethodBody(src, 'async leaveWorkbench(url)')
+    if (!exit) return 'goAllProjects 走了 leaveWorkbench，但找不到这个统一出口'
+    if (!exit.includes('uni.reLaunch')) return 'leaveWorkbench 必须用 reLaunch（工作台参与的跳转一律 reLaunch）'
+    if (exit.includes('uni.navigateTo')) return 'leaveWorkbench 里检测到误用 navigateTo'
+    if (!exit.includes('flushDirtyEditors')) {
+      return '离开工作台前必须先落盘：否则自动保存防抖窗口内的改动会被 reLaunch 静默丢掉'
+    }
+  }
   return null
 })
 

--- a/frontend/src/pages/project-overview/flushDirtyEditors.js
+++ b/frontend/src/pages/project-overview/flushDirtyEditors.js
@@ -1,0 +1,54 @@
+// 离开工作台前把还没落盘的编辑器内容存下来。
+//
+// 病灶：自动保存是防抖的，用户敲完最后一个字到真正落盘之间有一段窗口。
+// closeFile / evictLibreInstance 都会先 await flushSave 再拆实例，但**离开整个页面**
+// 的三条路（切项目 / 返回项目列表 / 退出登录）走的是 uni.reLaunch，页面组件树直接销毁，
+// 一次 flush 都没有。LibreOfficeEditor 的 beforeUnmount 自己写着「export 需要活的
+// webview，从这里保存已经太晚」——所以 Office 文档那几秒的改动**静默丢失，且无任何提示**。
+//
+// 刻意做成零依赖的纯函数：既能被 project-overview.vue 直接用，也能在 node:test 里
+// 真跑一遍（本目录其余模块都 import 了 @/ 别名，测不动）。
+
+/**
+ * 逐个 flush 还脏的编辑器实例。
+ *
+ * 判据与 closeFile 保持一致：
+ * - Office 文档（LibreOfficeEditor）要求 ready 且非 isError——加载失败的实例画布是
+ *   空白原型，保存会拿空白覆盖真文件（同 evictLibreInstance 的取舍）；
+ * - 纯文本（PlainTextEditor）只要求有 file。
+ *
+ * 单个实例保存失败不许拖累其它实例：逐个 try/catch，全部尝试完才返回。
+ *
+ * @param {object} libreRefs      形如 { 'left:123': inst }，来自 project-overview 的 _libreRefs
+ * @param {object} plainTextRefs  形如 { left: inst, right: inst }，来自 _plainTextRefs
+ * @returns {Promise<{flushed: number, failed: number}>}
+ */
+export async function flushDirtyEditors(libreRefs, plainTextRefs) {
+  let flushed = 0
+  let failed = 0
+
+  const attempt = async (inst) => {
+    try {
+      await inst.flushSave()
+      flushed++
+    } catch (e) {
+      failed++
+      console.warn('[ProjectOverview] leave flush-save failed:', e)
+    }
+  }
+
+  for (const inst of Object.values(libreRefs || {})) {
+    if (inst && inst.ready && !inst.isError && inst.file && (inst.dirty || inst.saving)
+        && typeof inst.flushSave === 'function') {
+      await attempt(inst)
+    }
+  }
+
+  for (const inst of Object.values(plainTextRefs || {})) {
+    if (inst && inst.file && (inst.dirty || inst.saving) && typeof inst.flushSave === 'function') {
+      await attempt(inst)
+    }
+  }
+
+  return { flushed, failed }
+}

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1551,6 +1551,7 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
+import { flushDirtyEditors } from './flushDirtyEditors.js'
 import LibreOfficeEditor from '@/components/LibreOfficeEditor.vue'
 import { host, isDesktopHost } from '@/services/host.js'
 import BrowserPane from '@/components/BrowserPane.vue'
@@ -3115,8 +3116,7 @@ export default {
     switchToProject(p) {
       this.projectSwitcherOpen = false
       if (!p || Number(p.id) === Number(this.projectId)) return
-      // reLaunch：切项目不叠页面栈（多实例地雷）
-      uni.reLaunch({ url: `/pages/project-overview/project-overview?id=${p.id}` })
+      this.leaveWorkbench(`/pages/project-overview/project-overview?id=${p.id}`)
     },
     // 工作台里的「项目概览」= 打开左栏的 home 面板。
     // 顶栏切换器里那一项与 rail 第一个按钮是同一个动作。
@@ -3140,11 +3140,29 @@ export default {
         else setTimeout(() => this.loadHistoryChat({ conversationId }), 600)
       })
     },
+    // 离开工作台的唯一出口。
+    //
+    // 两件事必须在这里一起做，缺一件都出过问题：
+    // 1) **先把还没落盘的编辑器内容存下来**。自动保存是防抖的，敲完最后一个字到真正
+    //    落盘之间有一段窗口；reLaunch 直接销毁页面组件树，LibreOfficeEditor 的
+    //    beforeUnmount 自己写着「export 需要活的 webview，从这里保存已经太晚」——
+    //    于是那几秒的改动静默丢失，连个提示都没有。
+    // 2) 工作台参与的跳转一律 reLaunch：navigateTo 会把工作台留在页面栈里，
+    //    从列表页再进另一个项目就出现两个存活的工作台实例（全局监听多实例地雷）。
+    //
+    // 保存失败不阻断跳转（用户已经在走了），但会留一条日志；逐个实例 try/catch，
+    // 一个失败不拖累其它。
+    async leaveWorkbench(url) {
+      try {
+        await flushDirtyEditors(this._libreRefs, this._plainTextRefs)
+      } catch (e) {
+        console.warn('[project-overview] flush before leaving failed', e)
+      }
+      uni.reLaunch({ url })
+    },
     goAllProjects() {
       this.projectSwitcherOpen = false
-      // 工作台参与的跳转一律 reLaunch：navigateTo 会把工作台留在页面栈里，
-      // 从列表页再进另一个项目就出现两个存活的工作台实例（全局监听多实例地雷）
-      uni.reLaunch({ url: '/pages/project-list/project-list' })
+      this.leaveWorkbench('/pages/project-list/project-list')
     },
     // Cmd+P 快速打开面板选中文件
     onQuickOpenFile(file) {
@@ -3622,7 +3640,14 @@ export default {
     toggleFileMoreMenu() {
       this.showFileMoreMenu = !this.showFileMoreMenu
     },
-    handleLogout() {
+    async handleLogout() {
+      // 落盘必须排在 clearSession 之前：会话一清，保存请求就是未授权，
+      // 用户「退出登录」等于顺手丢掉最后几秒的修改。
+      try {
+        await flushDirtyEditors(this._libreRefs, this._plainTextRefs)
+      } catch (e) {
+        console.warn('[project-overview] flush before logout failed', e)
+      }
       try {
          clearSession()
       } catch (e) {}

--- a/frontend/tests/project-home/flush-dirty-editors.test.mjs
+++ b/frontend/tests/project-home/flush-dirty-editors.test.mjs
@@ -1,0 +1,89 @@
+// 离开工作台前必须落盘：否则自动保存防抖窗口内的改动静默丢失。
+//
+// 病灶：closeFile / evictLibreInstance 都会先 await flushSave 再拆实例，但**离开整个
+// 页面**的三条路（切项目 / 返回项目列表 / 退出登录）走的是 uni.reLaunch，页面组件树
+// 直接销毁，一次 flush 都没有。LibreOfficeEditor 的 beforeUnmount 自己写着
+// 「export 需要活的 webview，从这里保存已经太晚」——Office 文档那几秒的改动就这么没了，
+// 而且没有任何提示。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { flushDirtyEditors } from '../../src/pages/project-overview/flushDirtyEditors.js'
+
+const PAGE = readFileSync(
+  new URL('../../src/pages/project-overview/project-overview.vue', import.meta.url), 'utf8')
+
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+function libre({ dirty = false, saving = false, ready = true, isError = false, file = { id: 1 } } = {}) {
+  const inst = { dirty, saving, ready, isError, file, flushed: 0 }
+  inst.flushSave = async () => { inst.flushed++ }
+  return inst
+}
+
+test('脏的 Office 文档在离开前被落盘', async () => {
+  const a = libre({ dirty: true })
+  const b = libre({ saving: true })
+  const res = await flushDirtyEditors({ 'left:1': a, 'right:2': b }, {})
+  assert.equal(a.flushed, 1)
+  assert.equal(b.flushed, 1)
+  assert.equal(res.flushed, 2)
+})
+
+test('干净的实例不空存一次', async () => {
+  const clean = libre({ dirty: false, saving: false })
+  const res = await flushDirtyEditors({ 'left:1': clean }, {})
+  assert.equal(clean.flushed, 0)
+  assert.equal(res.flushed, 0)
+})
+
+test('加载失败/未就绪的实例绝不保存——画布是空白原型，存下去等于清空真文件', async () => {
+  const broken = libre({ dirty: true, isError: true })
+  const notReady = libre({ dirty: true, ready: false })
+  await flushDirtyEditors({ 'left:1': broken, 'left:2': notReady }, {})
+  assert.equal(broken.flushed, 0, '与 closeFile / evictLibreInstance 同一取舍')
+  assert.equal(notReady.flushed, 0)
+})
+
+test('纯文本编辑器同样落盘', async () => {
+  const text = libre({ dirty: true })
+  const res = await flushDirtyEditors({}, { left: text })
+  assert.equal(text.flushed, 1)
+  assert.equal(res.flushed, 1)
+})
+
+test('一个实例保存失败不许拖累其它实例', async () => {
+  const bad = libre({ dirty: true })
+  bad.flushSave = async () => { throw new Error('boom') }
+  const good = libre({ dirty: true })
+  const res = await flushDirtyEditors({ 'left:1': bad, 'left:2': good }, {})
+  assert.equal(good.flushed, 1, '前一个抛了，后一个还得存')
+  assert.equal(res.failed, 1)
+  assert.equal(res.flushed, 1)
+})
+
+test('空/缺失的注册表不炸', async () => {
+  await flushDirtyEditors(undefined, undefined)
+  await flushDirtyEditors({}, {})
+  await flushDirtyEditors({ 'left:1': null }, { left: undefined })
+})
+
+test('工作台离开路径只有一个出口：除 leaveWorkbench / handleLogout 外不许裸 reLaunch', () => {
+  const code = stripComments(PAGE)
+  const bare = [...code.matchAll(/uni\.reLaunch\(/g)]
+  assert.ok(bare.length <= 2,
+    `工作台的离开路径必须先落盘。裸 uni.reLaunch 出现 ${bare.length} 处，` +
+    '新增离开路径请走 leaveWorkbench()（或像 handleLogout 那样自己先 flush 再清会话）')
+  assert.ok(code.includes('async leaveWorkbench(url)'), 'leaveWorkbench 出口必须还在')
+  assert.ok(code.includes('flushDirtyEditors'), '离开前必须调用 flushDirtyEditors')
+})
+
+test('退出登录时落盘排在 clearSession 之前，否则保存请求已经没有会话', () => {
+  const code = stripComments(PAGE)
+  const logout = code.slice(code.indexOf('async handleLogout()'))
+  const flushAt = logout.indexOf('flushDirtyEditors')
+  const clearAt = logout.indexOf('clearSession()')
+  assert.ok(flushAt >= 0 && clearAt >= 0, 'handleLogout 里两者都应存在')
+  assert.ok(flushAt < clearAt, '会话一清，保存就是未授权——落盘必须排在前面')
+})


### PR DESCRIPTION
审计（dev-board#74）第五批，前端最严重的一处：**静默数据丢失**。

## 病灶

自动保存是防抖的，敲完最后一个字到真正落盘之间有一段窗口。`closeFile`（fileOpenTabs.js:251/262）与 `evictLibreInstance`（librePool.js:138）都会先 `await inst.flushSave()` 再拆实例——但**离开整个页面**的三条路根本不经过它们：

- `switchToProject`（切项目）
- `goAllProjects`（返回项目列表）
- `handleLogout`（退出登录）

三者都是直接 `uni.reLaunch`，页面组件树当场销毁。而 `LibreOfficeEditor.beforeUnmount` 自己写着「export 需要活的 webview，从这里保存已经太晚」——它确实什么都没存。于是 **Office 文档最后几秒的改动静默丢失：没有确认弹窗、没有 toast、没有任何痕迹**。纯文本还有 `PlainTextEditor` 自己的 `beforeUnmount` 兜底，Office 文档一点兜底都没有。

`App.vue` 的 `uni.addInterceptor` 只做埋点（navTrack）并无条件放行，也拦不住。

## 修法

离开工作台收成一个出口 `leaveWorkbench(url)`：先 `flushDirtyEditors` 再 `reLaunch`。

`handleLogout` 因为必须在 `clearSession()` **之前**落盘（会话一清，保存请求就是未授权，「退出登录」等于顺手丢掉最后几秒的修改），自己显式 flush 而不复用出口。

`flushDirtyEditors` 刻意做成**零依赖纯函数**（新文件），既能被页面用，也能在 `node:test` 里真跑一遍——本目录其余模块都 `import` 了 `@/` 别名，测不动。落盘判据与 `closeFile` 完全一致：Office 实例要求 `ready` 且非 `isError`（加载失败的画布是空白原型，存下去等于拿空白覆盖真文件，同 `evictLibreInstance` 的取舍）。单个实例保存失败逐个 try/catch，不拖累其它，也不阻断跳转。

## 顺带加固导航契约检查

`check:nav` 原来只认 `goAllProjects` 方法体里字面出现 `uni.reLaunch`，走出口就判红。改成：允许直接 `reLaunch` 或走 `leaveWorkbench`；**走出口时连带校验出口自己是 `reLaunch` 且含 `flushDirtyEditors`**——比原来更严，不是放宽。

## 测试

新增 `frontend/tests/project-home/flush-dirty-editors.test.mjs`（8 例，真 import 真跑）：脏实例落盘、干净实例不空存、加载失败/未就绪绝不保存、纯文本同样落盘、一个失败不拖累其它、空注册表不炸；外加两条契约断言——除出口外不许裸 `reLaunch`、退出登录时 flush 必须排在 `clearSession` 之前。

`check:emits` / `check:nav` / `check:nav:full` / `check:locales` / `test:project-home` 全通过。本 worktree 没装 frontend `node_modules`，`build:h5` 交由 CI 的 Frontend 作业验证；本地已用 `node --check` 解析 SFC 的 script 块与新模块，语法无误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)