### PR TITLE
fix(ai-chat): write_file 声称会登记进项目库，实际一行都没写——文件树里永远看不见（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -312,14 +312,19 @@ public class FileTools implements AgentToolComponent {
         return sb.toString();
     }
 
-    @ToolMeta(displayName = "写入文件", category = "file", fileEffect = "ADDED", fileArg = "fileName")
-    @Tool("Write content to a text file. Registers the file in the project database for editor access.")
+    @ToolMeta(displayName = "写入文件", category = "file", fileEffect = "ADDED", fileArg = "fileName", refreshFiles = true)
+    @Tool("Write content to a text file at the project root and register it in the project database so it "
+            + "appears in the file tree and can be opened in the editor. Returns the db_id. "
+            + "For a file inside a subfolder, write it and then call scan_files to register it.")
     public String write_file(
-            @P("Target filename (e.g. 'notes.txt')") String fileName, 
+            @P("Target filename at the project root (e.g. 'notes.txt')") String fileName, 
             @P("File content") String content,
             @P("Project ID (Required for DB registration)") Long projectId
     ) {
         log.info("Tool: write_file called for {}", fileName);
+        if (fileName == null || fileName.isBlank()) {
+            return "Error: fileName is required.";
+        }
         try {
              Path path = resolvePath(fileName);
              if (!Files.exists(path.getParent())) {
@@ -327,11 +332,39 @@ public class FileTools implements AgentToolComponent {
              }
              
              Files.writeString(path, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-             
-             // Register in DB so Agent "owns" it. 
-             // Note: We attempt to register. If it fails (e.g. file exists in DB owned by User), we continue 
-             // but Agent won't be able to delete it if it didn't create it.
-             return "Successfully wrote to " + path.toAbsolutePath();
+
+             // 落库。此前这里只有一段「Register in DB so Agent "owns" it」的注释，
+             // 底下一行代码都没有——而工具描述与参数说明都白纸黑字写着会注册。
+             // 后果：文件躺在项目目录里但没有 project_file 行，文件树看不见、编辑器打不开、
+             // 后续工具也拿不到 fileId，模型却已经向用户报告「文件已创建」。
+             // 注册方式与 write_docx 完全一致（createOrUpdateFile 幂等：同名已存在就更新）。
+             if (projectId == null) {
+                 return "File written to " + path.toAbsolutePath()
+                         + " but NOT registered in the project (no projectId): it will not appear in the file "
+                         + "tree. Call scan_files to register it.";
+             }
+             // 带子目录的名字不在这里登记：parentId 只能填 null，会让文件树把它显示在根目录，
+             // 与它实际所在的子文件夹对不上。如实告知并指向 scan_files（那条路会按目录结构登记）。
+             String normalizedName = fileName.replace('\\', '/');
+             if (normalizedName.contains("/")) {
+                 editorBridgeService.sendRefreshFilesAction();
+                 return "File written to " + path.toAbsolutePath()
+                         + ". It is in a subfolder, so it was NOT registered here — call scan_files("
+                         + projectId + ") to register it into the file tree.";
+             }
+             try {
+                 ProjectFile pf = projectFileService.createOrUpdateFile(
+                         projectId, null, fileName, getFileType(fileName), Files.size(path),
+                         "projects/" + projectId + "/" + fileName, null, AGENT_USER_ID);
+                 editorBridgeService.sendRefreshFilesAction();
+                 return String.format("{\"status\":\"success\", \"db_id\":%d, \"file_path\":\"%s\"}",
+                         pf.getId(), path.toAbsolutePath().toString().replace("\\", "\\\\"));
+             } catch (Exception e) {
+                 log.warn("write_file DB register failed for {}", fileName, e);
+                 return "File written to " + path.toAbsolutePath()
+                         + " but DB registration failed (it will not appear in the file tree): "
+                         + e.getMessage() + " — call scan_files to retry registration.";
+             }
         } catch (Exception e) {
             return "Error writing file: " + e.getMessage();
         }

--- a/backend/src/test/java/com/checkba/service/ai/tools/WriteFileRegistrationTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/WriteFileRegistrationTest.java
@@ -1,0 +1,129 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.storage.ProjectStorageResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * write_file 必须真的把文件登记进项目库。
+ *
+ * <p>病灶：工具描述写着 "Registers the file in the project database for editor access"、
+ * 参数说明写着 "Project ID (Required for DB registration)"，方法体里却只有一段
+ * 「Register in DB so Agent "owns" it」的**注释**，一行注册代码都没有。
+ *
+ * <p>后果：文件躺在项目目录里但没有 project_file 行——文件树看不见、编辑器打不开、
+ * 后续工具拿不到 fileId，而模型已经照着返回值向用户报告「文件已创建」。
+ * 用户看到的是「AI 说建好了，文件树里没有」。
+ */
+class WriteFileRegistrationTest {
+
+    private static final long PROJECT_ID = 7L;
+
+    @AfterEach
+    void clearContext() {
+        ProjectContextHolder.clear();
+    }
+
+    private record Harness(FileTools tools, ProjectFileService fileService,
+                           EditorBridgeService bridge, Path projectRoot) {}
+
+    private static Harness harness(Path root) {
+        ProjectFileService fileService = Mockito.mock(ProjectFileService.class);
+        EditorBridgeService bridge = Mockito.mock(EditorBridgeService.class);
+        ProjectStorageResolver resolver = Mockito.mock(ProjectStorageResolver.class);
+        when(resolver.projectRoot(anyLong())).thenReturn(root);
+
+        ProjectFile saved = new ProjectFile();
+        saved.setId(4242L);
+        when(fileService.createOrUpdateFile(anyLong(), any(), anyString(), anyString(),
+                anyLong(), anyString(), any(), anyLong())).thenReturn(saved);
+
+        FileTools tools = new FileTools(fileService, null, bridge, null, resolver, null, null);
+        ProjectContextHolder.setProjectId(String.valueOf(PROJECT_ID));
+        return new Harness(tools, fileService, bridge, root);
+    }
+
+    @Test
+    @DisplayName("根目录写文件：落盘之外必须落库，并把 db_id 交回模型")
+    void writeFileRegistersInProjectDatabase(@TempDir Path dir) throws Exception {
+        Harness h = harness(dir);
+
+        String out = h.tools().write_file("会议纪要.txt", "2026-09-01 开庭", PROJECT_ID);
+
+        assertTrue(Files.exists(dir.resolve("会议纪要.txt")), "物理文件要写出来");
+        assertEquals("2026-09-01 开庭",
+                Files.readString(dir.resolve("会议纪要.txt"), StandardCharsets.UTF_8));
+
+        ArgumentCaptor<String> name = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> storagePath = ArgumentCaptor.forClass(String.class);
+        verify(h.fileService()).createOrUpdateFile(eq(PROJECT_ID), eq(null), name.capture(),
+                anyString(), anyLong(), storagePath.capture(), any(), anyLong());
+        assertEquals("会议纪要.txt", name.getValue());
+        assertEquals("projects/7/会议纪要.txt", storagePath.getValue(),
+                "存储 key 口径要与 write_docx 一致，否则读回时解析不到");
+
+        assertTrue(out.contains("\"db_id\":4242"), "要把 db_id 交回模型，实际是：" + out);
+        verify(h.bridge()).sendRefreshFilesAction();
+    }
+
+    @Test
+    @DisplayName("子目录里的文件如实说明没登记，并指向 scan_files——不许假装已登记")
+    void nestedFileIsHonestAboutNotBeingRegistered(@TempDir Path dir) throws Exception {
+        Harness h = harness(dir);
+
+        String out = h.tools().write_file("卷宗/证据清单.txt", "证据一", PROJECT_ID);
+
+        assertTrue(Files.exists(dir.resolve("卷宗/证据清单.txt")), "物理文件仍要写出来");
+        verify(h.fileService(), never()).createOrUpdateFile(anyLong(), any(), anyString(), anyString(),
+                anyLong(), anyString(), any(), anyLong());
+        assertTrue(out.contains("NOT registered"), "要明说没登记，实际是：" + out);
+        assertTrue(out.contains("scan_files"), "要给模型下一步，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("登记失败要如实报告，不许当成完全成功")
+    void registrationFailureIsReported(@TempDir Path dir) throws Exception {
+        Harness h = harness(dir);
+        when(h.fileService().createOrUpdateFile(anyLong(), any(), anyString(), anyString(),
+                anyLong(), anyString(), any(), anyLong()))
+                .thenThrow(new IllegalStateException("db down"));
+
+        String out = h.tools().write_file("笔记.txt", "x", PROJECT_ID);
+
+        assertTrue(Files.exists(dir.resolve("笔记.txt")));
+        assertTrue(out.contains("DB registration failed"), "实际是：" + out);
+        assertTrue(out.contains("scan_files"), "要给模型补救路径，实际是：" + out);
+        assertFalse(out.contains("\"status\":\"success\""), "登记失败不能报成完全成功，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("缺文件名直接拒绝")
+    void blankFileNameRejected(@TempDir Path dir) {
+        Harness h = harness(dir);
+        assertTrue(h.tools().write_file("  ", "x", PROJECT_ID).startsWith("Error"));
+        assertTrue(h.tools().write_file(null, "x", PROJECT_ID).startsWith("Error"));
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第六批。

## 病灶

工具描述写着 `Registers the file in the project database for editor access`，参数说明写着 `Project ID (Required for DB registration)`，方法体里却只有一段「Register in DB so Agent "owns" it」的**注释**——一行注册代码都没有，写完盘直接 `return "Successfully wrote to ..."`。

后果：文件躺在项目目录里但没有 `project_file` 行——

- 文件树看不见；
- 编辑器打不开；
- 后续工具拿不到 `fileId`（`doc_open_file` / `extract_file_text` 都以它为入口）；
- `fileEffect = "ADDED"` 还会为这个没登记的文件发一次文件变更通知。

而模型照着返回值向用户报告「文件已创建」。用户看到的是**「AI 说建好了，文件树里没有」**。

## 修法

按 `write_docx` 已经跑通的同一套登记（`projectFileService.createOrUpdateFile` + `sendRefreshFilesAction`，`createOrUpdateFile` 幂等：同名已存在就更新）：

- 根目录文件：真的登记，把 `db_id` 交回模型；
- **带子目录的文件名不在这里登记**：`parentId` 只能填 `null`，会让文件树把它显示在根目录、与实际所在文件夹对不上。如实告知没登记并指向 `scan_files`（那条路按目录结构登记）；
- `projectId` 缺失、或登记抛异常：都如实说明「没进文件树」并给出 `scan_files` 补救，不再报成完全成功；
- 顺带补 `fileName` 空值校验与 `refreshFiles=true`。

## 测试

新增 `WriteFileRegistrationTest`（4 例）：根目录写入必须落库并交回 `db_id`、存储 key 口径与 `write_docx` 一致（`projects/{id}/{name}`，否则读回时解析不到）、子目录文件如实说明未登记并指向 `scan_files`、登记失败如实报告且不含 `status:success`、空文件名直接拒绝。

用例断言的是「`createOrUpdateFile` 这次调用确实发生」——旧代码从不调用它，因此该断言在病灶下必然为红。

全量 `mvn test` 2110 通过，唯一失败是 `LocalProjectServiceTest.watcherPicksUpExternalChanges`（本机 mac FSEvents 已知抖动，本轮机器负载高；单独重跑即过，与本 PR 涉及文件无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)