### PR TITLE
fix(ai-chat): MCP SSE 解析两处——event: 开头认不出、多事件被拼成非法 JSON 只剩进度通知（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/mcp/McpResponseParser.java
+++ b/backend/src/main/java/com/checkba/service/ai/mcp/McpResponseParser.java
@@ -27,26 +27,18 @@ public final class McpResponseParser {
     public static String parse(String responseBody) {
         String trimmedResponse = responseBody.trim();
 
-        // Case 1: SSE / StreamableHTTP (starts with "data:")
-        if (trimmedResponse.startsWith("data:")) {
+        // Case 1: SSE / StreamableHTTP
+        //
+        // 判据是「正文里有 data: 行」，不是「第一行以 data: 开头」——真实的
+        // StreamableHTTP 流第一行往往是 `event: message`，旧判据认不出来，
+        // 整段带 event:/空行的协议原文就顺着 Case 4 交给了模型。
+        if (looksLikeSse(trimmedResponse)) {
             log.debug("Detected SSE response format");
-            StringBuilder fullContent = new StringBuilder();
-            String[] lines = responseBody.split("\n");
-            for (String line : lines) {
-                line = line.trim();
-                if (line.startsWith("data:")) {
-                    String dataContent = line.substring(5).trim();
-                    if (!dataContent.isEmpty() && !"[DONE]".equals(dataContent)) {
-                        fullContent.append(dataContent);
-                    }
-                }
-            }
-            // 聚合后的 data 内容若是 JSON，继续走下方 JSON 解析；否则原样返回
-            String accumulated = fullContent.toString();
-            if (accumulated.startsWith("{") || accumulated.startsWith("[")) {
-                trimmedResponse = accumulated;
+            String payload = pickSsePayload(responseBody);
+            if (payload.startsWith("{") || payload.startsWith("[")) {
+                trimmedResponse = payload;
             } else {
-                return accumulated;
+                return payload;
             }
         }
 
@@ -102,5 +94,89 @@ public final class McpResponseParser {
         // Case 4: Unknown format
         log.warn("Unknown response format: {}", trimmedResponse);
         return trimmedResponse;
+    }
+
+    /** 正文里出现任意一行 data:（SSE 事件流的唯一必需字段）即按 SSE 处理。 */
+    private static boolean looksLikeSse(String body) {
+        for (String line : body.split("\n")) {
+            if (line.trim().startsWith("data:")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 从 SSE 事件流里挑出真正要交给模型的那一份 data。
+     *
+     * <p>旧实现把所有 data: 行**无分隔符地拼在一起**。一条正常的 MCP 流是
+     * 「若干条 notifications/progress + 一条真正的 result」，拼完就是
+     * {@code {...progress...}{...result...}} 这种非法 JSON；而 hutool 的
+     * {@code JSONUtil.parseObj} 对它**不报错**，只解析第一个对象、丢掉其余
+     * （已实测：{@code parseObj("{\"a\":1}{\"b\":2}")} 返回 {@code {"a":1}}）。
+     * 于是模型收到的是一条进度通知，正文一个字都没有，且全程零错误信号——
+     * 表现就是「查法条没返回」。
+     *
+     * <p>现在按 SSE 规范分帧：空行分事件，事件内多条 data: 用 \n 拼（规范如此，
+     * 也是多行 JSON 载荷唯一正确的拼法）。然后优先挑出 JSON-RPC 响应
+     * （带 result 或 error 的那条），挑不到才退回「最后一条非空事件」，
+     * 再退回旧的全量拼接以保住既有的纯文本用法。
+     */
+    private static String pickSsePayload(String responseBody) {
+        java.util.List<String> events = new java.util.ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        for (String rawLine : responseBody.split("\n")) {
+            String line = rawLine.trim();
+            if (line.isEmpty()) {
+                if (current.length() > 0) {
+                    events.add(current.toString());
+                    current.setLength(0);
+                }
+                continue;
+            }
+            if (!line.startsWith("data:")) {
+                continue; // event: / id: / retry: / 注释行都不是载荷
+            }
+            String dataContent = line.substring(5).trim();
+            if (dataContent.isEmpty() || "[DONE]".equals(dataContent)) {
+                continue;
+            }
+            if (current.length() > 0) {
+                current.append('\n'); // 同一事件的多条 data 行，规范要求用换行拼
+            }
+            current.append(dataContent);
+        }
+        if (current.length() > 0) {
+            events.add(current.toString());
+        }
+        if (events.isEmpty()) {
+            return "";
+        }
+
+        // 优先：真正的 JSON-RPC 响应（有 result 或 error），跳过 notifications/* 之类的中间事件
+        for (int i = events.size() - 1; i >= 0; i--) {
+            String e = events.get(i);
+            if (!e.startsWith("{")) {
+                continue;
+            }
+            try {
+                JSONObject obj = JSONUtil.parseObj(e);
+                if (obj.containsKey("result") || obj.containsKey("error")
+                        || (obj.containsKey("code") && obj.containsKey("data"))) {
+                    return e;
+                }
+            } catch (Exception ignore) {
+                // 不是合法 JSON 就不算候选，继续往前找
+            }
+        }
+
+        // 退路一：最后一条事件（单事件流与纯文本流都落在这里，行为与改造前一致）
+        String last = events.get(events.size() - 1);
+        if (events.size() == 1) {
+            return last;
+        }
+        // 退路二：多事件但没有一条像响应——保住旧的全量拼接语义（纯文本分片场景）
+        boolean anyJson = events.stream().anyMatch(e -> e.startsWith("{") || e.startsWith("["));
+        return anyJson ? last : String.join("", events);
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/mcp/McpSseMultiEventTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/mcp/McpSseMultiEventTest.java
@@ -1,0 +1,137 @@
+package com.checkba.service.ai.mcp;
+
+import cn.hutool.json.JSONUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 真实 StreamableHTTP 流（多事件、带 event: 行）必须解析出正文。
+ *
+ * <p>两处病灶都会让「查法条」拿不到内容且零错误信号：
+ *
+ * <p><b>一、判据认不出 SSE。</b>旧判据是「正文第一行以 data: 开头」，而真实的
+ * MCP StreamableHTTP 流第一行往往是 {@code event: message}，于是整段带
+ * {@code event:} / 空行的协议原文顺着「未知格式」分支原样交给模型。
+ *
+ * <p><b>二、多事件被无分隔符拼在一起。</b>一条正常的 MCP 流是「若干条
+ * notifications/progress + 一条真正的 result」，拼完是 <code>{...}{...}</code>
+ * 这种非法 JSON——而 hutool 的 {@code JSONUtil.parseObj} 对它**不报错**，
+ * 只解析第一个对象、丢掉其余（本用例把这条 hutool 行为也钉住了）。
+ * 模型于是收到一条进度通知当作工具结果。
+ */
+class McpSseMultiEventTest {
+
+    private static final String LAW_TEXT =
+            "《中华人民共和国民法典》第五百七十七条：当事人一方不履行合同义务或者履行合同义务不符合约定的，"
+                    + "应当承担继续履行、采取补救措施或者赔偿损失等违约责任。";
+
+    private static String resultEvent() {
+        return "data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"content\":"
+                + "[{\"type\":\"text\",\"text\":\"" + LAW_TEXT + "\"}]}}";
+    }
+
+    private static String progressEvent(int n) {
+        return "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\","
+                + "\"params\":{\"progress\":" + n + ",\"total\":3}}";
+    }
+
+    @Test
+    @DisplayName("以 event: 开头的流也要认出是 SSE，不能把协议原文丢给模型")
+    void streamStartingWithEventLineIsRecognised() {
+        String sse = String.join("\n",
+                "event: message",
+                resultEvent(),
+                "");
+
+        String out = McpResponseParser.parse(sse);
+
+        assertEquals(LAW_TEXT, out, "第一行是 event: 时旧判据认不出 SSE，整段协议原文会被当成答案");
+        assertFalse(out.contains("event:"), "协议行不许漏给模型：" + out);
+        assertFalse(out.contains("data:"), "协议行不许漏给模型：" + out);
+    }
+
+    @Test
+    @DisplayName("进度事件 + 结果事件：必须取结果，不能取到进度通知")
+    void progressEventsAreSkippedInFavourOfTheActualResult() {
+        String sse = String.join("\n",
+                "event: message",
+                progressEvent(1),
+                "",
+                "event: message",
+                progressEvent(2),
+                "",
+                "event: message",
+                resultEvent(),
+                "");
+
+        String out = McpResponseParser.parse(sse);
+
+        assertEquals(LAW_TEXT, out, "旧实现拼接后被 hutool 只认头一个对象，模型拿到的是进度通知");
+        assertFalse(out.contains("notifications/progress"), "进度事件不许当成结果：" + out);
+    }
+
+    @Test
+    @DisplayName("结果事件在前、进度事件在后，同样要取结果")
+    void resultIsFoundEvenWhenItIsNotTheLastEvent() {
+        String sse = String.join("\n",
+                "event: message",
+                resultEvent(),
+                "",
+                "event: message",
+                progressEvent(3),
+                "");
+
+        assertEquals(LAW_TEXT, McpResponseParser.parse(sse));
+    }
+
+    @Test
+    @DisplayName("JSON-RPC 错误事件要被识别成错误，不被进度通知盖过")
+    void errorEventIsSurfaced() {
+        String sse = String.join("\n",
+                "event: message",
+                progressEvent(1),
+                "",
+                "event: message",
+                "data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"error\":{\"code\":-32603,\"message\":\"upstream timeout\"}}",
+                "");
+
+        String out = McpResponseParser.parse(sse);
+
+        assertTrue(out.startsWith("Error from MCP server"), "实际是：" + out);
+        assertTrue(out.contains("upstream timeout"), "要带上真实原因，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("同一事件里的多条 data 行按规范用换行拼接（多行 JSON 载荷唯一正确的拼法）")
+    void multipleDataLinesWithinOneEventAreJoinedByNewline() {
+        String sse = String.join("\n",
+                "event: message",
+                "data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"content\":",
+                "data: [{\"type\":\"text\",\"text\":\"分两行发的正文\"}]}}",
+                "");
+
+        assertEquals("分两行发的正文", McpResponseParser.parse(sse));
+    }
+
+    @Test
+    @DisplayName("钉住 hutool 的宽松解析：拼接出来的非法 JSON 它不报错，只认头一个对象")
+    void hutoolSilentlyAcceptsConcatenatedObjects() {
+        // 这条不是在测我们的代码，而是把「为什么绝不能无分隔符拼 data 行」钉在用例里：
+        // 换掉 JSON 库或升级 hutool 后若这条变红，说明这个前提变了，值得重新审视上面的实现。
+        assertEquals(1, JSONUtil.parseObj("{\"a\":1}{\"b\":2}").getInt("a"));
+        assertFalse(JSONUtil.parseObj("{\"a\":1}{\"b\":2}").containsKey("b"),
+                "hutool 会静默丢掉后面的对象——正是它让拼接错误无声无息");
+    }
+
+    @Test
+    @DisplayName("单事件与纯文本流的既有行为不变")
+    void singleEventAndPlainTextBehaviourUnchanged() {
+        assertEquals(LAW_TEXT, McpResponseParser.parse(resultEvent()));
+        assertEquals("未识别到法律条文引用",
+                McpResponseParser.parse("data: 未识别到法律条文引用\ndata: [DONE]\n"));
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第七批。法宝（PKULaw）检索走的就是这条 MCP StreamableHTTP 通道，两处病灶都让「查法条」拿不到正文且**零错误信号**——与用户报的「查法条第一次没有返回」同族。

## 一、判据认不出 SSE

旧判据是「正文**第一行**以 `data:` 开头」。真实的 StreamableHTTP 流第一行往往是 `event: message`，于是整段带 `event:` / 空行的协议原文顺着「未知格式」分支**原样交给模型**。

改成「正文里出现任意一行 `data:`」——`data` 是 SSE 事件流唯一必需的字段。

## 二、多事件被无分隔符拼在一起

一条正常的 MCP 流是「若干条 `notifications/progress` + 一条真正的 `result`」。旧实现把所有 `data:` 行直接 append 到一个 StringBuilder，拼完是 `{...progress...}{...result...}` 这种非法 JSON——而 hutool 的 `JSONUtil.parseObj` 对它**不报错**，只解析第一个对象、丢掉其余（已实测：`parseObj("{\"a\":1}{\"b\":2}")` 返回 `{"a":1}`）。于是模型收到的是一条**进度通知**，正文一个字都没有。

改成按 SSE 规范分帧：空行分事件，事件内多条 `data:` 用 `\n` 拼（规范如此，也是多行 JSON 载荷唯一正确的拼法）。然后优先挑出真正的 JSON-RPC 响应（带 `result` / `error` / `code+data` 的那条，从后往前找），挑不到才退回「最后一条事件」，再退回旧的全量拼接以保住纯文本分片用法。

## 测试

新增 `McpSseMultiEventTest`（7 例）：`event:` 开头的流要认出、进度事件不许盖过结果、结果在前进度在后同样要取到结果、`error` 事件要浮出真实原因、同一事件多条 `data` 行按 `\n` 拼、单事件与纯文本流行为不变；外加一条**把 hutool 宽松解析本身钉住**的用例——换 JSON 库或升级 hutool 后它若变红，说明本实现赖以成立的前提变了。

把实现改回旧行为后 7 例中 5 例转红（另两例本就与改动无关），空断言校验通过。既有 `McpResponseParserTest` 10 例、`McpClientServiceTest` 6 例、`ExternalServiceDualTierRoutingTest` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)