### PR TITLE
fix(ai-chat): browse_url 导航失败被当成「网页是空的」交给模型（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/WebTools.java
@@ -229,16 +229,29 @@ public class WebTools implements AgentToolComponent {
                 }
             });
 
+            // 导航失败与「等待加载状态超时」必须分开处理。旧代码把两者裹在同一个 catch 里
+            // 一律「continue, content might be partially loaded」，于是域名解析失败、连接被拒、
+            // 或被 SSRF 路由拦掉时，page.content() 拿到的是 about:blank 或 Chromium 自己的
+            // 错误页，照样拼成 "Page Title: …\n\nContent:…" 返回——模型以为自己读到了网页。
+            com.microsoft.playwright.Response navResponse;
             try {
-                page.navigate(url);
-                // Wait for network to be idle or dom content loaded. 'networkidle' is good for SPAs.
-                // Using a reasonable timeout
-                page.waitForLoadState(com.microsoft.playwright.options.LoadState.NETWORKIDLE, new com.microsoft.playwright.Page.WaitForLoadStateOptions().setTimeout(20000));
+                navResponse = page.navigate(url);
             } catch (Exception e) {
-                log.warn("Playwright navigation/wait warning: {}", e.getMessage());
-                // Continue, as content might be partially loaded
-                // Fallback to DOMCONTENTLOADED if network idle times out
-                // page.waitForLoadState(com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED);
+                log.warn("browse_url navigation failed for {}: {}", url, e.getMessage());
+                return "Error browsing URL: navigation failed (" + e.getMessage()
+                        + "). The page was NOT loaded — do not treat this as empty content.";
+            }
+            try {
+                // 网络空闲等待超时是可以容忍的：SPA 常年有长连接，此时页面正文其实已经在了
+                page.waitForLoadState(com.microsoft.playwright.options.LoadState.NETWORKIDLE,
+                        new com.microsoft.playwright.Page.WaitForLoadStateOptions().setTimeout(20000));
+            } catch (Exception e) {
+                log.warn("Playwright wait-for-networkidle timed out for {} (continuing with loaded content): {}",
+                        url, e.getMessage());
+            }
+            if (navResponse != null && navResponse.status() >= 400) {
+                return "Error browsing URL: the site returned HTTP " + navResponse.status()
+                        + ". The page was NOT loaded — do not treat this as empty content.";
             }
 
             // Get standard HTML
@@ -251,9 +264,9 @@ public class WebTools implements AgentToolComponent {
             // Basic extraction: remove script, style, nav, footer
             doc.select("script, style, nav, footer, header, aside, .ads, .advertisement, noscript, iframe").remove();
 
-            String bodyText = doc.body().text();
+            String bodyText = doc.body() == null ? "" : doc.body().text();
 
-            return "Page Title: " + title + "\n\nContent:\n" + bodyText;
+            return renderBrowseResult(url, title, bodyText);
 
         } catch (Exception e) {
              log.error("Failed to browse url {} with Playwright", url, e);
@@ -279,5 +292,28 @@ public class WebTools implements AgentToolComponent {
                 log.error("WebTools initialization warning: Failed to pre-warm Playwright. It will try again on first request.", e);
             }
         }).start();
+    }
+
+    /**
+     * 把抓到的标题/正文拼成给模型的结果；**抓不到正文时绝不伪装成成功**。
+     *
+     * <p>抽成静态纯函数是为了能单测：browse_url 本身要拉起 Playwright + Chromium，
+     * 单元测试里跑不动，而这里正是判「有没有真读到东西」的地方。
+     *
+     * <p>为什么空正文必须报错：旧实现无论如何都返回 "Page Title: …\n\nContent:\n…"，
+     * 即使正文是空的。这个串**非空**，所以既不会被编排器的空输出归一拦住，
+     * 也不会被 ToolResult.success() 判成失败——模型收到一个「成功但什么都没有」的结果，
+     * 转头就当这个网页确实没内容。
+     */
+    static String renderBrowseResult(String url, String title, String bodyText) {
+        String body = bodyText == null ? "" : bodyText.trim();
+        if (body.isEmpty()) {
+            String t = title == null ? "" : title.trim();
+            return "Error browsing URL: loaded " + url + " but extracted no readable text"
+                    + (t.isEmpty() ? "" : " (page title: " + t + ")")
+                    + ". The page may be JS-gated, login-walled, or a PDF/binary — "
+                    + "do not treat this as 'the page is empty'.";
+        }
+        return "Page Title: " + (title == null ? "" : title) + "\n\nContent:\n" + body;
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/tools/BrowseResultRenderingTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/BrowseResultRenderingTest.java
@@ -1,0 +1,80 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.ToolRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * browse_url 抓不到正文时不许伪装成成功。
+ *
+ * <p>病灶：无论抓到什么，旧实现都返回 {@code "Page Title: …\n\nContent:\n…"}。
+ * 导航失败（域名解析不了、连接被拒、被 SSRF 路由拦掉）时 {@code page.content()}
+ * 拿到的是 about:blank 或 Chromium 自己的错误页，照样拼成这个格式返回。
+ *
+ * <p>这个串**非空**，所以：
+ * <ul>
+ *   <li>编排器的空输出归一（BLANK_TOOL_OUTPUT）拦不住它；</li>
+ *   <li>{@code ToolResult.success()} 判它成功（不以 Error/错误 开头）；</li>
+ * </ul>
+ * 模型于是收到一个「成功但什么都没有」的结果，转头就认定这个网页确实没内容。
+ *
+ * <p>判「有没有真读到东西」的那段抽成了静态纯函数，才测得动——browse_url 本体要
+ * 拉起 Playwright + Chromium，单测里跑不动。
+ */
+class BrowseResultRenderingTest {
+
+    private static boolean classifiedAsSuccess(String toolOutput) {
+        return new ToolRegistry.ToolResult(toolOutput, null, true).success();
+    }
+
+    @Test
+    @DisplayName("正文为空：必须报错，且要被判成工具失败")
+    void emptyBodyIsAnError() {
+        String out = WebTools.renderBrowseResult("https://example.com", "", "");
+
+        assertTrue(out.startsWith("Error browsing URL"), "实际是：" + out);
+        assertFalse(classifiedAsSuccess(out),
+                "空正文必须被 ToolResult.success() 判成失败，否则过程卡打绿勾、失败回路不计数");
+    }
+
+    @Test
+    @DisplayName("只有空白字符的正文同样算抓不到")
+    void whitespaceOnlyBodyIsAnError() {
+        String out = WebTools.renderBrowseResult("https://example.com", "标题", "   \n\t  ");
+
+        assertTrue(out.startsWith("Error browsing URL"), "实际是：" + out);
+        assertFalse(classifiedAsSuccess(out));
+    }
+
+    @Test
+    @DisplayName("报错要带上可行动的原因，别让模型以为「这网页就是空的」")
+    void errorMessageIsActionable() {
+        String out = WebTools.renderBrowseResult("https://example.com/doc.pdf", "登录", "");
+
+        assertTrue(out.contains("do not treat this as"), "要明确否掉「页面为空」这个结论，实际是：" + out);
+        assertTrue(out.contains("登录"), "已知的标题要带上，便于模型判断是不是登录墙，实际是：" + out);
+        assertTrue(out.contains("example.com/doc.pdf"), "要带上 URL，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("正常抓到正文时格式与既有完全一致")
+    void normalResultKeepsTheExistingShape() {
+        String out = WebTools.renderBrowseResult("https://example.com", "民法典全文", "第五百七十七条 …");
+
+        assertTrue(out.startsWith("Page Title: 民法典全文"), "实际是：" + out);
+        assertTrue(out.contains("\n\nContent:\n第五百七十七条 …"), "实际是：" + out);
+        assertTrue(classifiedAsSuccess(out), "正常结果必须仍判成功");
+    }
+
+    @Test
+    @DisplayName("标题缺失但有正文：仍算成功，不因为没有标题就报错")
+    void missingTitleWithBodyIsStillSuccess() {
+        String out = WebTools.renderBrowseResult("https://example.com", null, "有正文");
+
+        assertTrue(out.contains("有正文"), "实际是：" + out);
+        assertTrue(classifiedAsSuccess(out));
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第八批。

## 病灶

`browse_url` 把 `page.navigate(url)` 和 `page.waitForLoadState(NETWORKIDLE)` 裹在**同一个 catch** 里，注释写「continue, as content might be partially loaded」——对超时来说这是对的（SPA 常年有长连接，此时正文其实已经在了），但对**导航本身失败**就完全不对：域名解析不了、连接被拒、被 SSRF 路由拦掉时，`page.content()` 拿到的是 `about:blank` 或 Chromium 自己的错误页，照样拼成 `Page Title: …\n\nContent:…` 返回。

这个串**非空**，于是两道既有防线都拦不住它：

- 编排器的空输出归一（`BLANK_TOOL_OUTPUT`）只认空白；
- `ToolResult.success()` 只认 `Error`/`错误` 前缀。

模型收到一个「成功但什么都没有」的结果，转头就认定这个网页确实没内容——又一例「静默地什么都没做，却报成功」。

## 修法

- 导航失败与等待超时**拆成两个 catch**：前者直接返回可行动错误并明说「页面根本没加载，别当成内容为空」；后者保持原来的容忍（只记日志继续）。
- 补 HTTP 状态判断：`navigate` 返回 4xx/5xx 同样按失败处理。
- 抓到的正文为空/全空白时不再伪装成成功，返回带 URL、已知标题和可能原因（JS 渲染 / 登录墙 / PDF 二进制）的错误串。
- `doc.body()` 补空判（非 HTML 响应时 Jsoup 的 body 可能为 null）。

判「有没有真读到东西」的那段抽成静态纯函数 `renderBrowseResult`——`browse_url` 本体要拉起 Playwright + Chromium，单测里跑不动，而这里正是病灶所在。

## 测试

新增 `BrowseResultRenderingTest`（5 例）：空正文/纯空白正文必须报错**并且被 `ToolResult.success()` 判成失败**（否则过程卡照样打绿勾、连续失败回路照样不计数）、错误文案要带 URL 与已知标题且明确否掉「页面为空」这个结论、正常结果格式与既有完全一致且仍判成功、缺标题但有正文仍算成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)