### PR TITLE
fix(mobile-sync): 手机号转移到归一账号时作废旧账号会话——手机端否则永远停在空项目列表（dev-board#75）

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -52,6 +52,29 @@ dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
    那等于把用户拍的证据静默删掉。
 4. 云端/团队服务器绝不能跑客户端：双闸 = `security.local-mode` + 账户 Key 在场。
 
+## 排查「手机端一个项目都读不到」的顺序（dev-board#75 实测路径）
+
+空数组是**合法响应**，没有报错也没有 4010，所以必须按下面的顺序把「哪一环是空的」逐段夹出来：
+
+1. 桌面端有没有桥接：`~/.aiworkdeck/mobile-relay.json` 在不在（不在 = `active()` 没过闸，
+   多半是没连账户，`enabled && local-mode && currentKeyOrNull() != null`）。
+2. 云端目录镜像有没有：拿那个文件里的 `awdt_` 打
+   `curl -H "X-Session-Id: awdt_…" https://addin.aiworkdeck.com/api/mobile/projects`。
+   **有数组** = 桌面端推送这一段是好的，问题在手机侧账号。
+3. 桥接账号是谁、有没有认领到手机号：同一个 `awdt_` 打 `/api/auth/me`，看 `phoneMasked`。
+4. 手机端登录的是不是同一个账号——**这一步是历史坑的高发区**，见下。
+
+## 已知地雷（续）
+
+5. **手机号转移不动会话**：`claimPhoneFromWebsite` 把号码从旧账号 A 转到桥接账号 B 时，
+   A 名下的登录会话**仍然有效**。手机 App 手里那张 A 的会话会继续用下去，而目录镜像挂在 B
+   名下，A 名下空空如也 → 返回合法空数组 → 用户看到「一个项目都读不到」，
+   **且反复重进也一样**（会话不到期就永远不会自愈）。
+   现在转移时会调 `UserSessionService.revokeAllForUser(A)` 逼手机端重新登录，
+   短信验证会把它落到归一后的 B 上。
+   **已经踩了的存量用户**（转移发生在这个修复之前）修不回来，只能在手机端手动退出登录再登一次。
+   回归用例 `PhoneClaimSessionRevocationTest`。
+
 ## 验证
 
 - `mvn test -Dtest='MobileRelay*Test,AwdkLoginServiceTest'`（JDK 21）。

--- a/backend/src/main/java/com/checkba/repository/UserSessionRepository.java
+++ b/backend/src/main/java/com/checkba/repository/UserSessionRepository.java
@@ -15,4 +15,8 @@ public interface UserSessionRepository extends JpaRepository<UserSession, Long> 
 
     @Transactional
     long deleteByLastUsedAtBefore(LocalDateTime cutoff);
+
+    /** 作废某个用户的全部登录会话（手机号被转移走时用，见 UserService.claimPhoneFromWebsite）。 */
+    @Transactional
+    long deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -15,6 +15,12 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    /**
+     * 手机号转移后要作废原持有者的会话。用 @Lazy 打断 UserSessionService ->
+     * AuthController.registerUserSessionService -> ... 这条启动期的相互引用。
+     */
+    @org.springframework.context.annotation.Lazy
+    private final UserSessionService userSessionService;
 
     /** BCrypt 无状态、线程安全，可静态复用。 */
     private static final BCryptPasswordEncoder PW_ENCODER = new BCryptPasswordEncoder();
@@ -150,6 +156,17 @@ public class UserService {
                 userRepository.save(h);
                 claimLog.info("手机号 {} 从用户 {} 转移到桥接用户 {}（账号归一）",
                         com.checkba.service.sms.SmsAuthService.maskPhone(phone), h.getId(), user.getId());
+                // 转移完必须把原持有者的会话一并作废。否则手机端手上那张老会话仍然有效，
+                // 它会继续以老账号的身份请求 /api/mobile/projects——而目录镜像挂在归一后的
+                // 账号名下，老账号名下空空如也，返回的是合法的空数组：**没有报错、没有提示，
+                // 用户看到的就是「一个项目都读不到」，而且怎么重进都一样**（会话不过期就永远不会自愈）。
+                // 作废后手机端被迫重新走短信登录，落到归一后的账号上。
+                // 同一个人：占用方本就是用这个号码验证过控制权的账号。
+                try {
+                    userSessionService.revokeAllForUser(h.getId());
+                } catch (Exception e) {
+                    claimLog.warn("作废原持有者 {} 的会话失败（手机号已转移，用户需手动重新登录）", h.getId(), e);
+                }
             }
             user.setPhone(phone);
             user.setUpdatedAt(LocalDateTime.now());

--- a/backend/src/main/java/com/checkba/service/UserSessionService.java
+++ b/backend/src/main/java/com/checkba/service/UserSessionService.java
@@ -99,6 +99,25 @@ public class UserSessionService {
         repository.deleteByTokenHash(sha256(plaintext));
     }
 
+    /**
+     * 作废某个用户的全部登录会话。
+     *
+     * <p>用在「手机号被转移到另一个账号」之后：老账号已经不再拥有这个号码，可它手上的
+     * 会话仍然有效，手机端会继续以老账号的身份请求——而老账号名下什么都没有，
+     * 于是项目列表恒为空且没有任何提示（用户看到的就是「一个项目都读不到」）。
+     * 作废之后手机端被迫重新登录，短信验证会把它落到归一后的账号上。
+     *
+     * @return 实际作废的会话条数
+     */
+    public long revokeAllForUser(Long userId) {
+        if (userId == null) return 0;
+        long removed = repository.deleteByUserId(userId);
+        if (removed > 0) {
+            log.info("作废用户 {} 的全部登录会话 {} 条（手机号已转移到其它账号）", userId, removed);
+        }
+        return removed;
+    }
+
     /** 每日清理过期会话（滑动过期在读路径已兜住，这里只是让表不积灰）。 */
     @Scheduled(fixedDelay = 24 * 60 * 60 * 1000, initialDelay = 10 * 60 * 1000)
     public void purgeExpired() {

--- a/backend/src/test/java/com/checkba/service/PhoneClaimSessionRevocationTest.java
+++ b/backend/src/test/java/com/checkba/service/PhoneClaimSessionRevocationTest.java
@@ -1,0 +1,137 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 手机号被转移到归一账号之后，原持有者的登录会话必须一并作废。
+ *
+ * <p>病灶（dev-board#75「手机端一个项目都读不到」的真因）：
+ * <ol>
+ *   <li>用户先在手机上用手机号短信登录云后端 → 云端建了账号 A，手机 App 存下 A 的会话；</li>
+ *   <li>之后桌面端用 awdk_ 桥接 → 云端解析出账号 B（官网账户），
+ *       {@code claimPhoneFromWebsite} 把手机号从 A <b>转移</b>到 B（A.phone 置空）；</li>
+ *   <li>桌面端把项目目录镜像推到云端，镜像挂在 <b>B</b> 名下；</li>
+ *   <li>可手机 App 手里那张 <b>A 的会话仍然有效</b>（转移不动会话），
+ *       它继续以 A 的身份请求 {@code /api/mobile/projects}。</li>
+ * </ol>
+ *
+ * <p>A 名下什么都没有，于是返回一个**合法的空数组**——没有报错、没有 4010、没有任何提示。
+ * 用户看到的就是「一个项目都读不到」，而且反复重进也一样：会话不到期就永远不会自愈。
+ *
+ * <p>作废之后手机端被迫重新走短信登录，验证码会把它落到归一后的账号 B 上。
+ * 安全上没有放松：占用方本来就是用同一个号码验证过控制权的账号，是同一个人。
+ */
+class PhoneClaimSessionRevocationTest {
+
+    private static final String PHONE = "18600001590";
+
+    private UserRepository userRepository;
+    private UserSessionService sessionService;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        sessionService = mock(UserSessionService.class);
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        userService = new UserService(userRepository, sessionService);
+    }
+
+    private static User user(long id, String phone) {
+        User u = new User();
+        u.setId(id);
+        u.setPhone(phone);
+        return u;
+    }
+
+    @Test
+    @DisplayName("号码从旧账号转移到桥接账号：旧账号的会话必须作废，否则手机端永远停在空列表")
+    void transferRevokesPreviousHolderSessions() {
+        User oldHolder = user(7L, PHONE);
+        User bridged = user(3L, null);
+        when(userRepository.findByPhone(PHONE)).thenReturn(Optional.of(oldHolder));
+
+        userService.claimPhoneFromWebsite(bridged, PHONE);
+
+        assertNull(oldHolder.getPhone(), "号码要从旧账号摘掉");
+        assertEquals(PHONE, bridged.getPhone(), "号码要落到桥接账号上");
+        verify(sessionService).revokeAllForUser(7L);
+    }
+
+    @Test
+    @DisplayName("没有旧持有者时不作废任何人的会话")
+    void noHolderMeansNoRevocation() {
+        User bridged = user(3L, null);
+        when(userRepository.findByPhone(PHONE)).thenReturn(Optional.empty());
+
+        userService.claimPhoneFromWebsite(bridged, PHONE);
+
+        assertEquals(PHONE, bridged.getPhone());
+        verify(sessionService, never()).revokeAllForUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("号码本来就在桥接账号上：什么都不做，绝不把自己的会话踢掉")
+    void selfHeldPhoneIsANoOp() {
+        User bridged = user(3L, PHONE);
+        when(userRepository.findByPhone(PHONE)).thenReturn(Optional.of(bridged));
+
+        userService.claimPhoneFromWebsite(bridged, PHONE);
+
+        assertEquals(PHONE, bridged.getPhone());
+        verify(sessionService, never()).revokeAllForUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("桥接账号已绑另一个号码：既有「不覆盖」取舍不变，也不动任何会话")
+    void existingDifferentPhoneIsNotOverwritten() {
+        User bridged = user(3L, "13900000000");
+
+        userService.claimPhoneFromWebsite(bridged, PHONE);
+
+        assertEquals("13900000000", bridged.getPhone(), "不许悄悄改掉一个已在工作的登录入口");
+        verify(sessionService, never()).revokeAllForUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("作废会话抛异常不影响认领本身——认领是桥接的顺手动作，永不抛出")
+    void revocationFailureNeverBreaksTheClaim() {
+        User oldHolder = user(7L, PHONE);
+        User bridged = user(3L, null);
+        when(userRepository.findByPhone(PHONE)).thenReturn(Optional.of(oldHolder));
+        when(sessionService.revokeAllForUser(anyLong())).thenThrow(new IllegalStateException("db down"));
+
+        userService.claimPhoneFromWebsite(bridged, PHONE);
+
+        assertEquals(PHONE, bridged.getPhone(), "号码仍要认领成功");
+    }
+
+    @Test
+    @DisplayName("非法号码直接忽略，不触发任何写入")
+    void malformedPhoneIsIgnored() {
+        User bridged = user(3L, null);
+
+        userService.claimPhoneFromWebsite(bridged, "not-a-phone");
+        userService.claimPhoneFromWebsite(bridged, null);
+
+        assertNull(bridged.getPhone());
+        verify(userRepository, never()).findByPhone(anyString());
+        verify(sessionService, never()).revokeAllForUser(anyLong());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
@@ -81,6 +81,7 @@ class AwdkLoginServiceTest {
 
     private StubTransport transport;
     private UserService userService;
+    private com.checkba.service.UserSessionService sessionService;
     private DeviceTokenService deviceTokenService;
     private AccountBindingRepository bindingRepository;
     private com.checkba.service.ai.PlatformAiKeyService platformAiKeyService;
@@ -117,7 +118,8 @@ class AwdkLoginServiceTest {
             usersById.put(u.getId(), u);
             return u;
         });
-        userService = new UserService(userRepository);
+        sessionService = mock(com.checkba.service.UserSessionService.class);
+        userService = new UserService(userRepository, sessionService);
 
         DeviceTokenRepository tokenRepository = mock(DeviceTokenRepository.class);
         when(tokenRepository.save(any(DeviceToken.class))).thenAnswer(inv -> {


### PR DESCRIPTION
用户报「手机端还是一个项目都读不到」。按目录文档的排查顺序逐段夹，**前三段都是好的**：

1. 桌面端已桥接：`~/.aiworkdeck/mobile-relay.json` 在（deviceId + awdt_ + 账户指纹齐全）；
2. 云端目录镜像**有数据**：拿该 `awdt_` 打 `GET /api/mobile/projects` 返回 5+ 条真实项目；
3. 桥接账号已认领手机号：同一 `awdt_` 打 `/api/auth/me` → `id=3` / `awd_hanzewei` / `phoneMasked=186****1590`，`claimPhoneFromWebsite` 确实生效过。

问题出在第四段：**手机端拿的是被转移前那个账号的会话**。

## 病灶

时序：

- 用户先在手机上短信登录云后端 → 云端建账号 **A**，手机 App 存下 A 的会话；
- 之后桌面端 `awdk_` 桥接 → 解析出官网账号 **B**，`claimPhoneFromWebsite` 把手机号从 A **转移**到 B（`A.phone` 置空）；
- 桌面端把目录镜像推到云端，镜像挂在 **B** 名下；
- 但 **A 的会话没有被作废**，手机 App 继续以 A 的身份请求 `/api/mobile/projects`。

A 名下什么都没有，于是返回一个**合法的空数组**——没有报错、没有 4010、没有任何提示。用户看到的就是「一个项目都读不到」，而且**反复重进也一样**：滑动过期不到期（云端 7 天）就永远不会自愈。

## 修法

转移号码时一并作废原持有者的全部会话：`UserSessionRepository.deleteByUserId` → `UserSessionService.revokeAllForUser` → `claimPhoneFromWebsite` 在转移分支里调用（包 try/catch，认领是桥接的顺手动作，永不抛出）。

作废后手机端被迫重新走短信登录，验证码把它落到归一后的账号 B 上。安全上没有放松：占用方本来就是用同一个号码验证过控制权的账号，是同一个人。

`UserService` 注入 `UserSessionService` 用 `@Lazy`，避开 `UserSessionService` 构造器里 `AuthController.registerUserSessionService` 那条启动期相互引用。

## 存量用户（重要）

这个修复只覆盖**今后**的转移。**已经踩了的账号（包括本次报障的这个）云端修不回来**，需要在手机端手动退出登录再登一次。已写进领域文档。

## 测试

新增 `PhoneClaimSessionRevocationTest`（6 例）：转移必须作废旧账号会话、无旧持有者不作废、号码本来就在自己名下时什么都不做（绝不把自己的会话踢掉）、已绑另一号码时既有「不覆盖」取舍不变且不动会话、作废抛异常不影响认领本身、非法号码直接忽略不触发任何写入。

去掉 `revokeAllForUser` 调用后第一例转红（空断言校验通过）。`AwdkLoginServiceTest` 25 例、`UserSessionServiceTest` 10 例、`MobileRelay*Test`、`MobileRelayEndpointIntegrationTest` 全绿；**全量 `mvn test` 2128 通过 0 失败**。

排查顺序与这条地雷已写进 `.claude/agents/mobile-sync.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)