### PR TITLE
fix(frontend): 输入法组合中的 Enter 提前发送、文件图标画两个、错误信封当正文显示（dev-board#74）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -212,6 +212,12 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
   （回归用例 `ToolFailureClassificationTest` 把这条也钉住了）。
   **`GatewayException` 的 `unavailable()` 文案刻意没加标记**：`Kind.BUDGET_EXCEEDED`
   按设计「是可恢复的确认，不是失败」，一并标成失败会误伤它——要动先想清楚这一档。
+- **聊天输入框的 Enter 必须先判输入法组合**：中文/日文/韩文输入时，按 Enter「上屏候选词」
+  同样会派发 keydown（`isComposing=true`，部分浏览器只给 `keyCode=229`）。
+  `ChatInterface.handleEnterKey` 不挡住的话，这一下会把**还没上屏的拼音**直接当消息发出去。
+  编辑器侧（`zetaOfficeImeOverlay` / `zetaoffice/editor-main.js`）早就为同一类问题做了
+  composing 闩，聊天输入框一直漏着。守卫必须排在 `handleSubmit` 之前。
+  回归用例 `frontend/tests/project-home/frontend-audit-batch.test.mjs`。
 - **埋点体系**（`com.checkba.service.telemetry`，设计 docs/ANALYTICS_TELEMETRY_DESIGN.md）：
   唯一采集入口 TelemetryService.record/recordConv，字段过 TelemetryAttrWhitelist 白名单
   （新事件/字段要同步白名单 + TelemetryServiceTest + 官网仓 lib/telemetry-store.ts 的 EVENT_WHITELIST）。

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -1823,6 +1823,12 @@ export default {
 
     // --- Handle Enter Key ---
     const handleEnterKey = (e) => {
+      // 输入法组合中按下的 Enter 是「上屏候选词」，不是「发送」。
+      // 中文/日文/韩文输入时浏览器照样派发 keydown（isComposing=true，部分浏览器 keyCode=229），
+      // 不挡住的话这一下会把还没上屏的拼音直接当成消息发出去——中文用户天天撞。
+      // 编辑器侧（zetaOfficeImeOverlay / editor-main）早就为同一类问题做了 composing 闩，
+      // 聊天输入框一直漏着。
+      if (e.isComposing || e.keyCode === 229) return
       if (!e.shiftKey) {
         // Plain Enter -> Send
         e.preventDefault()

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -542,6 +542,15 @@ export default {
           method: 'GET',
           header: getAuthHeaders()
         })
+        // uni.request 对 4xx/5xx 不会 reject，走的是 success 回调。不看 statusCode
+        // 就把 response.data 当正文，用户会在「文本预览」里读到后端的错误信封
+        // （{"code":4010,...} 之类），还以为那就是文件内容。
+        const status = Number(response.statusCode || 0)
+        if (status && (status < 200 || status >= 300)) {
+          console.warn('[FilePreview] 文本预览请求失败 status=', status)
+          this.textContent = this.$t('files.loadFailed')
+          return
+        }
         this.textContent = response.data || ''
       } catch (error) {
         console.error('加载文本内容失败:', error)

--- a/frontend/src/components/FileTypeIcon.vue
+++ b/frontend/src/components/FileTypeIcon.vue
@@ -14,8 +14,10 @@
            :fill="getPathColor(path.type)"
         />
     </svg>
-    <!-- Fallback for unknown types -->
-    <svg class="fallback-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- Fallback for unknown types。v-else 不能少：908cc7d3（全站清零 emoji）把
+         `<text v-else>📄</text>` 换成这个 svg 时把 v-else 一起丢了，于是已知类型
+         （docx/xlsx/pptx/pdf…）会在同一个 19x19 容器里同时画出真图标和兜底图标。 -->
+    <svg v-else class="fallback-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path v-for="(d, gi) in ICONS.doc" :key="gi" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   </view>

--- a/frontend/tests/project-home/frontend-audit-batch.test.mjs
+++ b/frontend/tests/project-home/frontend-audit-batch.test.mjs
@@ -1,0 +1,61 @@
+// 审计（dev-board#74）确认的三处前端问题的回归断言。
+// 都是「源码文本断言」——本仓既有 node:test 用例的一贯写法（组件带 @/ 别名，import 不进来）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const read = (rel) => readFileSync(new URL('../../src/' + rel, import.meta.url), 'utf8')
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+// ---------- 1. 文件类型图标：兜底图标必须带 v-else ----------
+//
+// 908cc7d3（全站清零 emoji）把 `<text v-else class="fallback-icon">📄</text>` 换成
+// 一个 svg 时，把 v-else 一起丢了。于是 docx/xlsx/pptx/pdf 这些**已知类型**会在同一个
+// 19x19 的 flex 容器里同时画出真图标和兜底图标（.fallback-icon 既没 v-else 也没
+// display:none），两个图标挤在一格里。FileTree / SearchPanel / ProcessCard 都在用。
+test('FileTypeIcon 的兜底图标带 v-else，不会和真图标同时渲染', () => {
+  const src = stripComments(read('components/FileTypeIcon.vue'))
+  const fallback = src.match(/<svg[^>]*class="fallback-icon"[^>]*>/)
+  assert.ok(fallback, '找不到 fallback-icon 的 svg')
+  assert.match(fallback[0], /v-else/,
+    '兜底图标必须 v-else，否则已知类型会同时画出两个图标（908cc7d3 的回归）')
+})
+
+test('FileTypeIcon 真图标仍然是 v-if 分支，两者构成互斥', () => {
+  const src = stripComments(read('components/FileTypeIcon.vue'))
+  assert.match(src, /<svg\s+[\s\S]{0,80}v-if="svgData"/,
+    '真图标要保持 v-if="svgData"，与兜底的 v-else 配对')
+})
+
+// ---------- 2. 聊天输入框：输入法组合中的 Enter 不是发送 ----------
+//
+// 中文/日文/韩文输入时，按 Enter 上屏候选词也会派发 keydown（isComposing=true，
+// 部分浏览器 keyCode=229）。不挡住就会把还没上屏的拼音直接当消息发出去。
+// 编辑器侧（zetaOfficeImeOverlay / editor-main）早就为同一类问题做了 composing 闩。
+test('handleEnterKey 在输入法组合期间直接返回，不发送', () => {
+  const src = stripComments(read('components/ChatInterface.vue'))
+  const start = src.indexOf('const handleEnterKey')
+  assert.ok(start > 0, '找不到 handleEnterKey')
+  const body = src.slice(start, start + 500)
+  assert.match(body, /isComposing/, 'Enter 处理必须判 isComposing')
+  assert.match(body, /229/, '还要兜住只给 keyCode=229 的浏览器')
+  // 守卫必须排在真正的发送分支之前，否则等于没加
+  assert.ok(body.indexOf('isComposing') < body.indexOf('handleSubmit'),
+    '组合守卫必须排在 handleSubmit 之前')
+})
+
+// ---------- 3. 文本预览：不能把错误信封当正文显示 ----------
+//
+// uni.request 对 4xx/5xx 不 reject，走的是 success 回调。不看 statusCode 就把
+// response.data 当正文，用户会在「文本预览」里读到 {"code":4010,...} 还以为那是文件内容。
+test('loadTextContent 检查 statusCode，非 2xx 不当正文显示', () => {
+  const src = stripComments(read('components/FilePreview.vue'))
+  const start = src.indexOf('async loadTextContent')
+  assert.ok(start > 0, '找不到 loadTextContent')
+  const body = src.slice(start, src.indexOf('async loadMediaResource'))
+  assert.match(body, /statusCode/, '必须检查 statusCode——uni.request 不会因 4xx/5xx reject')
+  assert.ok(body.indexOf('statusCode') < body.lastIndexOf('this.textContent = response.data'),
+    'statusCode 判断要排在把 data 当正文之前')
+  assert.match(body, /files\.loadFailed/, '失败要走既有的失败文案，不要新造一套')
+})


### PR DESCRIPTION
审计（dev-board#74）第九批，三处独立的前端问题，都能直接看见。

## 一、中文输入时 Enter 会把没上屏的拼音发出去

`ChatInterface.handleEnterKey` 不判输入法组合状态。中文/日文/韩文输入时，按 Enter「上屏候选词」同样会派发 keydown（`isComposing=true`，部分浏览器只给 `keyCode=229`），于是这一下被当成「发送」，把**还没上屏的拼音**直接发了出去。

编辑器侧（`zetaOfficeImeOverlay` / `zetaoffice/editor-main.js`）早就为同一类问题做了 composing 闩（注释里还记着「中文标点要按两次」的根因），聊天输入框一直漏着。守卫加在 `handleSubmit` 之前。

## 二、已知类型的文件图标被画了两个

`FileTypeIcon` 的兜底 svg 没有 `v-else`。**908cc7d3（全站清零 emoji）把 `<text v-else class="fallback-icon">📄</text>` 换成 svg 时把 `v-else` 一起丢了**，而 `.fallback-icon` 也没有 `display:none`——于是 docx/xlsx/pptx/pdf 这些已知类型，会在同一个 19x19 的 flex 容器里同时画出真图标和兜底图标。`FileTree` / `SearchPanel` / `ProcessCard` 都在用这个组件。

## 三、文本预览把后端错误信封当文件内容显示

`FilePreview.loadTextContent` 直接 `this.textContent = response.data`。`uni.request` 对 4xx/5xx **不 reject**，走的是 success 回调——所以文件不存在、无权限、会话过期时，用户会在「文本预览」里读到 `{"code":4010,...}` 这种信封，还以为那就是文件内容。补 `statusCode` 判断，非 2xx 走既有的 `files.loadFailed` 文案。

## 测试

新增 `frontend/tests/project-home/frontend-audit-batch.test.mjs`（4 例，本仓既有的源码文本断言写法）：兜底图标必须带 `v-else` 且与 `v-if` 构成互斥、Enter 处理必须判 `isComposing`/229 且守卫排在 `handleSubmit` 之前、`loadTextContent` 必须检查 `statusCode` 且判断排在把 data 当正文之前、失败走既有文案不新造一套。

去掉 `v-else` 后转红（空断言校验通过）。`check:emits` / `check:nav` / `check:locales` / `test:project-home` 全通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)