### PR TITLE
fix(ai-chat): 三处「系统故障被写成空结果」——证据检索/文件搜索/OCR（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/tools/EvidenceTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/EvidenceTools.java
@@ -58,12 +58,18 @@ public class EvidenceTools implements AgentToolComponent {
 
         StringBuilder sb = new StringBuilder();
         int total = 0;
+        // 失败的来源要单独记：把「检索没跑成」说成「查无此据」是本工具最不能犯的错，
+        // 见下方 total==0 分支
+        List<String> failedSources = new java.util.ArrayList<>();
+        int sourceCount = 0;
         for (EvidenceRetriever retriever : evidenceRetrieverRegistry.all()) {
+            sourceCount++;
             List<EvidenceItem> items;
             try {
                 items = retriever.retrieve(evidenceQuery);
             } catch (Exception e) {
                 log.warn("retrieve_evidence: 来源 {} 检索失败: {}", retriever.sourceId(), e.getMessage());
+                failedSources.add(retriever.sourceId());
                 continue;
             }
             for (EvidenceItem item : items) {
@@ -87,9 +93,25 @@ public class EvidenceTools implements AgentToolComponent {
         }
 
         if (total == 0) {
-            return "未检索到相关证据。注意：查无此据不等于结论矛盾——请如实向用户说明缺少依据，不要将缺失改写为反证。";
+            // 一条都没查到、而且所有来源都失败了：这**不是**「查无此据」，是「根本没查成」。
+            // 契约红线（docs/EVIDENCE_CONTRACT.md「缺证据≠矛盾」）针对的是真的没有证据；
+            // 把系统故障也说成查无此据，模型会据此在法律文书里断言「无相应依据」——
+            // 比拿不到证据严重得多。
+            if (!failedSources.isEmpty() && failedSources.size() == sourceCount) {
+                return "错误：证据检索未能完成——" + failedSources.size() + " 个来源全部失败（"
+                        + String.join(", ", failedSources) + "）。"
+                        + "**这不代表查无此据**，不要据此断言缺少依据；请如实告知用户检索暂不可用，或稍后重试。";
+            }
+            String partial = failedSources.isEmpty() ? ""
+                    : "（注意：" + failedSources.size() + " 个来源检索失败："
+                            + String.join(", ", failedSources) + "，结果可能不完整）";
+            return "未检索到相关证据。" + partial
+                    + "注意：查无此据不等于结论矛盾——请如实向用户说明缺少依据，不要将缺失改写为反证。";
         }
-        return "检索到 " + total + " 条证据（引用时请带证据ID）:\n\n" + sb;
+        String partialNote = failedSources.isEmpty() ? ""
+                : "（注意：" + failedSources.size() + " 个来源检索失败：" + String.join(", ", failedSources)
+                        + "，以下结果可能不完整）\n";
+        return "检索到 " + total + " 条证据（引用时请带证据ID）:\n\n" + partialNote + sb;
     }
 
     private static String shortHash(String hash) {

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -116,6 +116,24 @@ public class FileTools implements AgentToolComponent {
                     }
                     return FileVisitResult.CONTINUE;
                 }
+
+                // 单个条目读不了就跳过，不许掀翻整次搜索。SimpleFileVisitor 的默认实现是
+                // **把异常重新抛出**，于是一个没权限的目录、一条断掉的符号链接、或者遍历途中
+                // 被删掉的文件，就能让整次搜索抛 IOException——已经找到的匹配全部丢弃，
+                // 模型只拿到一句 "Error searching files"，然后认定这些文件不存在。
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    log.debug("search_project_files: 跳过读不了的条目 {}: {}", file, exc.toString());
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+                    if (exc != null) {
+                        log.debug("search_project_files: 目录 {} 未能完整遍历: {}", dir, exc.toString());
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
             });
             
             if (matches.isEmpty()) return "No files found matching '" + fileNamePattern + "' in " + (dirPath != null ? dirPath : "root");

--- a/backend/src/main/java/com/checkba/service/ocr/AliyunOcrClient.java
+++ b/backend/src/main/java/com/checkba/service/ocr/AliyunOcrClient.java
@@ -46,8 +46,13 @@ public class AliyunOcrClient {
         runtime.setReadTimeout(30000);
         RecognizeAllTextResponse resp = client.recognizeAllTextWithOptions(req, runtime);
 
+        // 响应缺体/缺 data 是**调用失败**，不是「这张图没有文字」。返回空 OcrResult 会让
+        // 调用方（OcrService → 前端/AI 工具）把它当成识别成功但内容为空，用户于是认定
+        // 这份扫描件没有文字。上抛由 OcrService 统一包成「OCR 识别失败: …」。
         if (resp == null || resp.getBody() == null || resp.getBody().getData() == null) {
-            return new OcrResult("", "");
+            throw new IllegalStateException("阿里云 OCR 返回了空响应体（requestId="
+                    + (resp != null && resp.getBody() != null ? resp.getBody().getRequestId() : "-")
+                    + "），本次识别未完成");
         }
 
         // 提取全文本

--- a/backend/src/test/java/com/checkba/service/ai/tools/EmptyVersusErrorTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/EmptyVersusErrorTest.java
@@ -1,0 +1,136 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.service.ai.evidence.EvidenceItem;
+import com.checkba.service.ai.evidence.EvidenceQuery;
+import com.checkba.service.ai.evidence.EvidenceRetriever;
+import com.checkba.service.ai.evidence.EvidenceRetrieverRegistry;
+import com.checkba.storage.ProjectStorageResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+/**
+ * 「查不到」与「没查成」必须分得开。
+ *
+ * <p>这是本轮审计里最反复出现的一族病：系统故障被写成一个合法的空结果交给模型，
+ * 全程没有任何错误信号。对法律产品来说尤其危险——模型会据此在文书里断言「无相应依据」。
+ */
+class EmptyVersusErrorTest {
+
+    @AfterEach
+    void clear() {
+        ProjectContextHolder.clear();
+    }
+
+    private static boolean classifiedAsSuccess(String out) {
+        return new ToolRegistry.ToolResult(out, null, true).success();
+    }
+
+    // ==================== retrieve_evidence ====================
+
+    private static EvidenceRetriever retriever(String id, boolean explode) {
+        return new EvidenceRetriever() {
+            @Override
+            public String sourceId() {
+                return id;
+            }
+
+            @Override
+            public List<EvidenceItem> retrieve(EvidenceQuery query) {
+                if (explode) throw new IllegalStateException("upstream down");
+                return List.of();
+            }
+        };
+    }
+
+    private static EvidenceTools evidenceToolsWith(EvidenceRetriever... retrievers) {
+        EvidenceRetrieverRegistry registry = Mockito.mock(EvidenceRetrieverRegistry.class);
+        when(registry.all()).thenReturn(List.of(retrievers));
+        ProjectContextHolder.setProjectId("7");
+        return new EvidenceTools(registry);
+    }
+
+    @Test
+    @DisplayName("所有证据来源都失败：必须说「没查成」，绝不能说「查无此据」")
+    void allSourcesFailingIsNotAnAbsenceOfEvidence() {
+        String out = evidenceToolsWith(retriever("pkulaw", true), retriever("memory", true))
+                .retrieve_evidence("违约金上限", 10);
+
+        assertFalse(out.contains("未检索到相关证据"),
+                "把系统故障说成查无此据，模型会在法律文书里断言「无相应依据」。实际是：" + out);
+        assertTrue(out.contains("未能完成"), "要明说没查成，实际是：" + out);
+        assertTrue(out.contains("不代表查无此据"), "要主动否掉「无据」这个结论，实际是：" + out);
+        assertFalse(classifiedAsSuccess(out), "检索没跑成必须被判成工具失败");
+    }
+
+    @Test
+    @DisplayName("部分来源失败但确实没结果：仍是「查无此据」，但要标明结果可能不完整")
+    void partialFailureStillSaysNoEvidenceButFlagsIncompleteness() {
+        String out = evidenceToolsWith(retriever("pkulaw", true), retriever("memory", false))
+                .retrieve_evidence("违约金上限", 10);
+
+        assertTrue(out.contains("未检索到相关证据"), "还有来源跑通了，仍属查无此据，实际是：" + out);
+        assertTrue(out.contains("检索失败"), "要标明有来源失败、结果可能不完整，实际是：" + out);
+        assertTrue(out.contains("pkulaw"), "要点名是哪个来源失败，实际是：" + out);
+    }
+
+    @Test
+    @DisplayName("全部来源正常且确实没有证据：既有文案与既有判定一字不改")
+    void genuineAbsenceKeepsTheExistingWording() {
+        String out = evidenceToolsWith(retriever("memory", false)).retrieve_evidence("违约金上限", 10);
+
+        assertTrue(out.contains("未检索到相关证据"), "实际是：" + out);
+        assertTrue(out.contains("查无此据不等于结论矛盾"), "既有的契约提示不许丢，实际是：" + out);
+        assertFalse(out.contains("检索失败"), "没有来源失败就别加噪声，实际是：" + out);
+        assertTrue(classifiedAsSuccess(out), "真的查无此据是一次成功的检索");
+    }
+
+    // ==================== search_project_files ====================
+
+    @Test
+    @DisplayName("一个读不了的目录不许掀翻整次搜索——已经找到的匹配必须照常返回")
+    void oneUnreadableDirectoryDoesNotDiscardEveryMatch(@TempDir Path root) throws Exception {
+        Files.writeString(root.resolve("起诉状.docx"), "x", StandardCharsets.UTF_8);
+        Path locked = Files.createDirectory(root.resolve("锁住的目录"));
+        Files.writeString(locked.resolve("里面.docx"), "y", StandardCharsets.UTF_8);
+        // root 用户读得动任何目录，这条断言对它没意义
+        assumeTrue(!"root".equals(System.getProperty("user.name")));
+        assumeTrue(locked.toFile().setReadable(false, false), "本文件系统不支持去掉读权限");
+
+        try {
+            ProjectStorageResolver resolver = Mockito.mock(ProjectStorageResolver.class);
+            when(resolver.projectRoot(anyLong())).thenReturn(root);
+            // 走完目录树后还会查库补 fileId，这里给一个空索引即可
+            com.checkba.repository.ProjectFileRepository repo =
+                    Mockito.mock(com.checkba.repository.ProjectFileRepository.class);
+            when(repo.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(anyLong())).thenReturn(List.of());
+            FileTools tools = new FileTools(null, repo, null, null, resolver, null, null);
+            ProjectContextHolder.setProjectId("7");
+
+            String out = tools.search_project_files("*.docx", null);
+
+            assertFalse(out.startsWith("Error searching files"),
+                    "SimpleFileVisitor 默认会把 IOException 重新抛出，一个没权限的目录就能"
+                            + "让整次搜索报错、已找到的匹配全丢。实际是：" + out);
+            assertTrue(out.contains("起诉状.docx"), "可读的匹配必须照常返回，实际是：" + out);
+        } finally {
+            locked.toFile().setReadable(true, false);
+        }
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第十批。同一族病：**故障被写成一个合法的空结果交给模型，全程零错误信号**。对法律产品最危险的一种，因为模型会据此在文书里断言「无相应依据」。

## 一、retrieve_evidence 把「没查成」说成「查无此据」（最严重）

每个来源 `retrieve` 抛异常时只 `log.warn` 然后 `continue`。所有来源都失败时 `total==0`，于是返回既有的那句「未检索到相关证据。注意：查无此据不等于结论矛盾……」——这句话本身是对的，但它描述的是「真的没有证据」，而此刻的真相是「**根本没查成**」。

`docs/EVIDENCE_CONTRACT.md` 的「缺证据≠矛盾」不变式针对的是前者；把系统故障也塞进这条口径，等于诱导模型在法律文书里断言缺少依据。

改：记下失败的来源。

- **全部来源失败** → 「错误：证据检索未能完成…**这不代表查无此据**，不要据此断言缺少依据」（以「错误」开头，`ToolResult.success()` 判失败，进连续失败纠正回路）；
- **部分失败** → 保留既有文案，另加一句「N 个来源检索失败，结果可能不完整」并点名来源；
- **全部正常且确实没有** → 既有文案与既有判定**一字不改**。

## 二、search_project_files 一个读不了的条目就丢掉全部匹配

`SimpleFileVisitor` 的默认 `visitFileFailed` / `postVisitDirectory` 是**把 IOException 重新抛出**。于是一个没权限的目录、一条断掉的符号链接、或者遍历途中被删掉的文件，就能让整次 `walkFileTree` 抛异常——**已经找到的匹配全部丢弃**，模型只拿到一句 `Error searching files`，然后认定这些文件不存在。两个回调都改成 `CONTINUE`。

## 三、AliyunOcrClient 空响应体返回空识别结果

`resp`/`body`/`data` 任一为 null 时 `return new OcrResult("", "")`——调用方分不清「这张图没有文字」和「调用失败」，用户于是认定这份扫描件没有文字。改为抛出（方法本就 `throws Exception`），由 `OcrService` 既有的 catch 统一包成「OCR 识别失败: …」。

## 测试

新增 `EmptyVersusErrorTest`（4 例）：全部来源失败必须说「没查成」且被判成工具失败、部分失败仍属查无此据但要标明不完整并点名来源、真的无果时既有文案与判定一字不改、一个没权限的目录不许掀翻整次搜索（`chmod 000` 真目录，root 与不支持权限位的文件系统用 `assumeTrue` 跳过）。

把两处实现改回原样后 4 例中 2 例转红（空断言校验通过）。**全量 `mvn test` 2126 通过 0 失败**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)