### PR TITLE
fix(backend): 子进程超时形同虚设、尽调清单能被拖成环（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/DdService.java
+++ b/backend/src/main/java/com/checkba/service/DdService.java
@@ -23,6 +23,9 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DdService {
 
+    /** 尽调清单的父子链深度上限：既是环检测的步数保护，也挡住异常深的层级。 */
+    private static final int MAX_DD_TREE_DEPTH = 100;
+
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DdService.class);
 
     private final DdRequestRepository ddRequestRepository;
@@ -352,8 +355,12 @@ public class DdService {
         if (newParentId != null) {
             // Check loop
             if (itemId.equals(newParentId)) throw new IllegalArgumentException("不能移动到自己下面");
-            // TODO: check deeper loops if needed
-            
+            // 深层环检测（原来是一句 TODO）：只挡「移到自己身上」挡不住「移到自己的子孙身上」。
+            // 一旦成环（A.parent=B 且 B 在 A 的子树里），凡是顺着父子关系走的代码都会打转——
+            // deleteItem 的递归删子项会直接 StackOverflowError，前端建树也拼不出来，
+            // 而且这条坏数据**存进库里就再也移不回来**（每次操作都先撞上死循环）。
+            rejectIfDescendant(itemId, newParentId);
+
             DdItem newParent = ddItemRepository.findById(newParentId).orElseThrow(() -> new IllegalArgumentException("父项不存在"));
             item.setParentId(newParentId);
             item.setLevel(newParent.getLevel() + 1);
@@ -365,6 +372,28 @@ public class DdService {
         return ddItemRepository.save(item);
     }
 
+
+    /**
+     * 目标父节点是不是自己的子孙——是就拒绝，否则会在树里成环。
+     *
+     * <p>从目标父节点顺着 parentId 往上爬到根：路上遇到 itemId 说明它在 itemId 的子树里。
+     * 同时带一个步数上限，万一库里已经有历史坏数据（成环），这里也不会跟着一起打转。
+     */
+    private void rejectIfDescendant(Long itemId, Long newParentId) {
+        Long cursor = newParentId;
+        int guard = 0;
+        while (cursor != null && guard++ < MAX_DD_TREE_DEPTH) {
+            if (cursor.equals(itemId)) {
+                throw new IllegalArgumentException("不能移动到自己的子项下面");
+            }
+            DdItem node = ddItemRepository.findById(cursor).orElse(null);
+            if (node == null) break;
+            cursor = node.getParentId();
+        }
+        if (guard >= MAX_DD_TREE_DEPTH) {
+            throw new IllegalArgumentException("清单层级异常（疑似已有循环引用），请刷新后重试");
+        }
+    }
 
     /**
      * 删除项

--- a/backend/src/main/java/com/checkba/service/optimizer/ProcessRunner.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/ProcessRunner.java
@@ -42,18 +42,47 @@ public interface ProcessRunner {
                 // 两条流合一：只读 stdout 再 waitFor 的写法，会在 stderr 缓冲区写满时死锁
                 pb.redirectErrorStream(true);
                 Process p = pb.start();
-                String out = read(p.getInputStream());
+                // 输出必须在**另一条线程**上读。原来是先 read(...) 读到 EOF、再 waitFor(timeout)：
+                // readAllBytes 只有在进程退出（或自己关掉 stdout）时才返回，于是「卡住但没退出」
+                // 的进程会把调用线程永久阻塞在 read 里，waitFor 的超时根本没机会执行——
+                // 而这正是超时存在的唯一理由（进程正常退出时 waitFor 本来就立刻返回）。
+                java.util.concurrent.CompletableFuture<String> reader =
+                        java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                            try {
+                                return read(p.getInputStream());
+                            } catch (Exception e) {
+                                return "";
+                            }
+                        }, OUTPUT_READERS);
                 boolean done = p.waitFor(Math.max(1, timeoutSeconds), TimeUnit.SECONDS);
                 if (!done) {
                     p.destroyForcibly();
-                    return new Result(-1, out, "[超时 " + timeoutSeconds + "s，已终止]");
+                    // 强杀后管道关闭，reader 随即返回已读到的部分输出；再等一小会儿就够
+                    return new Result(-1, partial(reader), "[超时 " + timeoutSeconds + "s，已终止]");
                 }
-                return new Result(p.exitValue(), out, "");
+                return new Result(p.exitValue(), partial(reader), "");
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return new Result(-1, "", "被中断: " + e);
             } catch (Exception e) {
                 return new Result(-1, "", String.valueOf(e));
+            }
+        }
+
+        /** 读子进程输出的守护线程池：绝不能是非守护线程，否则卡住的读会拖住 JVM 退出。 */
+        private static final java.util.concurrent.ExecutorService OUTPUT_READERS =
+                java.util.concurrent.Executors.newCachedThreadPool(r -> {
+                    Thread t = new Thread(r, "proc-output-reader");
+                    t.setDaemon(true);
+                    return t;
+                });
+
+        /** 取已读到的输出；读线程若还卡着就返回空串，绝不把调用方再拖进去。 */
+        private static String partial(java.util.concurrent.CompletableFuture<String> reader) {
+            try {
+                return reader.get(5, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                return "";
             }
         }
 

--- a/backend/src/test/java/com/checkba/service/DdMoveItemCycleTest.java
+++ b/backend/src/test/java/com/checkba/service/DdMoveItemCycleTest.java
@@ -1,0 +1,124 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.DdItem;
+import com.checkba.repository.DdItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+/**
+ * 尽调清单的移动必须挡住「移到自己的子孙下面」。
+ *
+ * <p>病灶：{@code moveItem} 只判了 {@code itemId.equals(newParentId)}（移到自己身上），
+ * 旁边留着一句 {@code // TODO: check deeper loops if needed}。把 A 拖到 A 的某个子孙 B 下面，
+ * 就成了环（A.parent=B，而 B 在 A 的子树里）。
+ *
+ * <p>成环之后凡是顺着父子关系走的代码都会打转：{@code deleteItem} 的递归删子项直接
+ * StackOverflowError，前端建树也拼不出来。更糟的是这条坏数据**存进库里就再也移不回来**——
+ * 每次修复操作都先撞上死循环。而「把父节点拖到自己的子节点上」是用户拖拽时最容易误操作的一种。
+ */
+class DdMoveItemCycleTest {
+
+    private DdItemRepository items;
+    private DdService service;
+    private final Map<Long, DdItem> store = new HashMap<>();
+
+    private DdItem item(long id, Long parentId, int level) {
+        DdItem i = new DdItem();
+        i.setId(id);
+        i.setParentId(parentId);
+        i.setLevel(level);
+        store.put(id, i);
+        return i;
+    }
+
+    @BeforeEach
+    void setUp() {
+        store.clear();
+        items = Mockito.mock(DdItemRepository.class);
+        when(items.findById(anyLong())).thenAnswer(inv -> Optional.ofNullable(store.get(inv.getArgument(0, Long.class))));
+        when(items.save(any(DdItem.class))).thenAnswer(inv -> inv.getArgument(0));
+        service = new DdService(null, items, null, null, null, null);
+    }
+
+    @Test
+    @DisplayName("把父节点移到自己的子节点下面：必须拒绝（原来只挡直接自指）")
+    void movingOntoADirectChildIsRejected() {
+        item(1L, null, 0);          // A
+        item(2L, 1L, 1);            // B，A 的子节点
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> service.moveItem(1L, 2L));
+        assertTrue(e.getMessage().contains("子项"), "实际是：" + e.getMessage());
+        assertNull(store.get(1L).getParentId(), "拒绝之后不许把 parentId 改坏");
+    }
+
+    @Test
+    @DisplayName("移到更深一层的子孙下面同样拒绝——TODO 说的就是这一种")
+    void movingOntoADeepDescendantIsRejected() {
+        item(1L, null, 0);          // A
+        item(2L, 1L, 1);            // B
+        item(3L, 2L, 2);            // C
+        item(4L, 3L, 3);            // D，A 的曾孙
+
+        assertThrows(IllegalArgumentException.class, () -> service.moveItem(1L, 4L));
+    }
+
+    @Test
+    @DisplayName("移到自己身上：既有判断保持不变")
+    void movingOntoItselfStillRejected() {
+        item(1L, null, 0);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> service.moveItem(1L, 1L));
+        assertTrue(e.getMessage().contains("自己"), "实际是：" + e.getMessage());
+    }
+
+    @Test
+    @DisplayName("移到无关分支：正常放行，层级跟着新父节点走")
+    void movingToAnUnrelatedBranchStillWorks() {
+        item(1L, null, 0);          // A
+        item(2L, 1L, 1);            // B（A 的子节点）
+        item(9L, null, 0);          // X，另一棵树
+
+        DdItem moved = service.moveItem(2L, 9L);
+
+        assertEquals(9L, moved.getParentId());
+        assertEquals(1, moved.getLevel(), "层级要按新父节点重算");
+    }
+
+    @Test
+    @DisplayName("移到根：正常放行")
+    void movingToRootStillWorks() {
+        item(1L, null, 0);
+        item(2L, 1L, 1);
+
+        DdItem moved = service.moveItem(2L, null);
+
+        assertNull(moved.getParentId());
+        assertEquals(0, moved.getLevel());
+    }
+
+    @Test
+    @DisplayName("库里已有历史环数据：环检测自己不许跟着打转，要给出可读错误")
+    void preExistingCycleDoesNotHangTheCheck() {
+        // 历史坏数据：1 <-> 2 互为父子
+        item(1L, 2L, 1);
+        item(2L, 1L, 1);
+        item(3L, null, 0);
+
+        assertThrows(IllegalArgumentException.class, () -> service.moveItem(3L, 2L));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/optimizer/ProcessRunnerTimeoutTest.java
+++ b/backend/src/test/java/com/checkba/service/optimizer/ProcessRunnerTimeoutTest.java
@@ -1,0 +1,87 @@
+package com.checkba.service.optimizer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * 子进程超时必须真的会触发。
+ *
+ * <p>病灶：原实现是 <b>先</b> {@code read(p.getInputStream())} 读到 EOF、<b>再</b>
+ * {@code p.waitFor(timeout)}。而 {@code readAllBytes} 只有在进程退出（或自己关掉 stdout）
+ * 时才返回——于是「卡住但没退出」的进程会把调用线程永久阻塞在 read 里，
+ * {@code waitFor} 的超时根本没机会执行。
+ *
+ * <p>而这正是超时存在的唯一理由：进程正常退出时 waitFor 本来就立刻返回，
+ * 需要超时兜底的恰恰是「不退出」这一种。优化者跑的是编码 Agent CLI，
+ * 卡住就意味着那条线程再也回不来。
+ */
+class ProcessRunnerTimeoutTest {
+
+    private static final boolean WINDOWS =
+            System.getProperty("os.name", "").toLowerCase().contains("win");
+
+    private final ProcessRunner runner = new ProcessRunner.Default();
+
+    @Test
+    @DisplayName("进程卡住不退出：必须在超时后返回，而不是永久阻塞")
+    void hungProcessHitsTheTimeout() {
+        assumeFalse(WINDOWS, "用例用 sh 造一个不退出的进程");
+
+        long start = System.currentTimeMillis();
+        // sleep 不会关掉继承来的 stdout，管道一直开着——这正是原实现卡死的形状
+        ProcessRunner.Result r = runner.run(List.of("sh", "-c", "sleep 60"), null, 2);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertFalse(r.ok(), "超时必须算失败");
+        assertEquals(-1, r.exitCode());
+        assertTrue(r.stderr().contains("超时"), "要说明是超时终止的，实际是：" + r.stderr());
+        assertTrue(elapsed < 30_000,
+                "超时没生效——调用线程被 read 卡住了（原病灶）。实际耗时 " + elapsed + "ms");
+    }
+
+    @Test
+    @DisplayName("进程有输出但迟迟不退出：同样要按超时收场，不许被输出流吊住")
+    void processThatPrintsThenHangsStillTimesOut() {
+        assumeFalse(WINDOWS, "用例用 sh 造一个不退出的进程");
+
+        long start = System.currentTimeMillis();
+        ProcessRunner.Result r = runner.run(
+                List.of("sh", "-c", "echo hello; sleep 60"), null, 2);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertFalse(r.ok());
+        assertTrue(elapsed < 30_000, "实际耗时 " + elapsed + "ms");
+    }
+
+    @Test
+    @DisplayName("正常退出的进程：输出完整、退出码正确（既有行为不变）")
+    void normalProcessStillReturnsItsOutput() {
+        assumeFalse(WINDOWS, "用例用 sh");
+
+        ProcessRunner.Result r = runner.run(List.of("sh", "-c", "echo 合同已生成"), null, 10);
+
+        assertTrue(r.ok(), "实际 exit=" + r.exitCode() + " stderr=" + r.stderr());
+        assertEquals(0, r.exitCode());
+        assertTrue(r.stdout().contains("合同已生成"), "输出不能丢，实际是：" + r.stdout());
+    }
+
+    @Test
+    @DisplayName("非零退出码原样带回（失败原因要看得见）")
+    void nonZeroExitIsReported() {
+        assumeFalse(WINDOWS, "用例用 sh");
+
+        ProcessRunner.Result r = runner.run(List.of("sh", "-c", "echo boom >&2; exit 3"), null, 10);
+
+        assertFalse(r.ok());
+        assertEquals(3, r.exitCode());
+        // redirectErrorStream(true)：stderr 并进 stdout
+        assertTrue(r.stdout().contains("boom"), "实际是：" + r.stdout());
+    }
+}


### PR DESCRIPTION
审计（dev-board#74）第十一批，两处 critical。

## 一、ProcessRunner 的超时永远不会触发

写法是**先** `read(p.getInputStream())` 读到 EOF、**再** `p.waitFor(timeout)`。而 `readAllBytes` 只有在进程退出（或自己关掉 stdout）时才返回——于是「卡住但没退出」的进程把调用线程**永久阻塞在 read 里**，`waitFor` 的超时根本没机会执行。

而这正是超时存在的唯一理由：进程正常退出时 `waitFor` 本来就立刻返回，需要兜底的恰恰是「不退出」这一种。优化者跑的是编码 Agent CLI，卡住就意味着那条线程再也回不来。（文件里已经为 stderr 缓冲区死锁做过处理，这个顺序问题漏了。）

改：输出改在**守护线程**上读（绝不能用非守护线程，否则卡住的读会拖住 JVM 退出），`waitFor` 的超时于是真的能到期；超时后 `destroyForcibly` 关闭管道，再取一次已读到的部分输出带回。

**量化验证**：还原成旧写法后该用例类耗时 **120.1 秒**（两个挂起用例各卡满 60 秒）且转红；修好后 **4.0 秒**全绿。

## 二、尽调清单 moveItem 只挡直接自指，挡不住子孙

`if (itemId.equals(newParentId))` 之后跟着一句 `// TODO: check deeper loops if needed`。把 A 拖到 A 的某个子孙 B 下面就成环（`A.parent=B`，而 B 在 A 的子树里）。

成环之后凡是顺着父子关系走的代码都会打转：`deleteItem` 的递归删子项直接 StackOverflowError，前端建树也拼不出来。更糟的是这条坏数据**存进库里就再也移不回来**——每次修复操作都先撞上死循环。而「把父节点拖到自己的子节点上」正是拖拽时最容易的误操作。

改：从目标父节点顺着 `parentId` 爬到根，路上遇到 `itemId` 即拒绝；带 100 步上限，万一库里已经有历史环数据，检测自己也不会跟着打转。

## 测试

新增 `ProcessRunnerTimeoutTest`（4 例）与 `DdMoveItemCycleTest`（6 例）。两处实现改回原样后 10 例中 5 例转红（空断言校验通过）。**全量 `mvn test` 2138 通过 0 失败**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)