### PR TITLE
fix(ai-chat): 用户气泡与助手气泡同毫秒创建撞 ID，Vue 复用错节点（dev-board#74）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -218,6 +218,13 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
   编辑器侧（`zetaOfficeImeOverlay` / `zetaoffice/editor-main.js`）早就为同一类问题做了
   composing 闩，聊天输入框一直漏着。守卫必须排在 `handleSubmit` 之前。
   回归用例 `frontend/tests/project-home/frontend-audit-batch.test.mjs`。
+- **聊天气泡 ID 必须走 `nextBubbleId()`，不许用裸 `Date.now()`**：用户气泡与助手气泡是在
+  **同一个同步块**里先后创建的（`useAgentStream` 里 `push(createUserBubble(...))` 紧接着
+  `createAssistantBubble()`），同一毫秒 = 同一个 ID。而 `ChatInterface` 的列表是
+  `:key="msg.id || index"`——key 撞了之后 Vue 的 diff 会**复用错节点**：一条消息的正文
+  渲染进另一条气泡、用户/助手样式串位、旧内容残留，也就是「历史对话记录杂乱无序」的一种成因。
+  新增任何气泡创建点都要用 `composables/bubbleId.js` 的 `nextBubbleId()`（单调序号 + 时间戳）。
+  回归用例 `frontend/tests/project-home/bubble-id.test.mjs`。
 - **埋点体系**（`com.checkba.service.telemetry`，设计 docs/ANALYTICS_TELEMETRY_DESIGN.md）：
   唯一采集入口 TelemetryService.record/recordConv，字段过 TelemetryAttrWhitelist 白名单
   （新事件/字段要同步白名单 + TelemetryServiceTest + 官网仓 lib/telemetry-store.ts 的 EVENT_WHITELIST）。

--- a/frontend/src/composables/bubbleId.js
+++ b/frontend/src/composables/bubbleId.js
@@ -1,0 +1,23 @@
+// 聊天气泡的唯一 ID。
+//
+// 病灶：原来两处都是 `msg-${Date.now()}`，而用户气泡与助手气泡是在**同一个同步块**里
+// 先后创建的（useAgentStream 里 push(createUserBubble(...)) 紧接着 createAssistantBubble()），
+// 同一毫秒 = 同一个 ID。ChatInterface 的列表是 `:key="msg.id || index"`——
+// key 撞了之后 Vue 的 diff 会复用错节点：一条消息的正文渲染进另一条气泡、
+// 用户/助手样式串位、旧内容残留。用户看到的就是「历史对话记录杂乱无序」。
+//
+// 单调递增序号保证同一页面会话内绝不重复；仍带上时间戳，便于按 ID 排查日志。
+// 历史消息由后端带自己的 ID，不走这里。
+
+let seq = 0
+
+/** 生成一个页面会话内唯一的气泡 ID。 */
+export function nextBubbleId() {
+  seq += 1
+  return `msg-${Date.now()}-${seq}`
+}
+
+/** 仅供测试：重置序号。 */
+export function __resetBubbleIdSeqForTest() {
+  seq = 0
+}

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -3,6 +3,7 @@ import { getApiBaseUrl, getConversationMetadata } from '@/services/api.js'
 import { getSessionId } from '@/utils/auth.js'
 import { createProtocolTagRegex, decodeProtocolTags } from '@/composables/agentTagProtocol.mjs'
 import { t } from '@/i18n'
+import { nextBubbleId } from './bubbleId.js'
 
 // 网络恢复/页面回前台时触发重连的激活实例指针（模块级单例）。
 // 页面栈会多次实例化本 composable（PR#148 重复订阅地雷），window 监听只挂一次，
@@ -134,7 +135,7 @@ export function useAgentStream() {
 
     // --- HELPER: Create a new Assistant Bubble Structure ---
     const createAssistantBubble = () => ({
-        id: `msg-${Date.now()}`,
+        id: nextBubbleId(),
         role: 'ASSISTANT',
         thinking: { status: 'idle', content: '', duration: 0, startTime: 0, endTime: 0 },
         title: '',
@@ -158,7 +159,7 @@ export function useAgentStream() {
     // displayContent 为空则回退 content。渲染侧一律 displayContent || content，
     // 与 GET /api/ai/history 返回体的同名字段口径一致（否则刷新页面文案会变）。
     const createUserBubble = (content, images = [], contextFiles = [], contentHtml = '', displayContent = '') => ({
-        id: `msg-${Date.now()}`,
+        id: nextBubbleId(),
         role: 'USER',
         content: content,
         displayContent: displayContent || '',

--- a/frontend/tests/project-home/bubble-id.test.mjs
+++ b/frontend/tests/project-home/bubble-id.test.mjs
@@ -1,0 +1,40 @@
+// 聊天气泡 ID 必须唯一——撞 key 会让 Vue 复用错节点，正文渲染进别人的气泡。
+//
+// 病灶：用户气泡与助手气泡是在**同一个同步块**里先后创建的
+// （useAgentStream: push(createUserBubble(...)) 紧接着 createAssistantBubble()），
+// 两处 ID 都是 `msg-${Date.now()}` —— 同一毫秒 = 同一个 ID，几乎必撞。
+// ChatInterface 的列表是 `:key="msg.id || index"`，key 撞了之后 Vue 的 diff 会复用错节点：
+// 一条消息的正文渲染进另一条气泡、用户/助手样式串位、旧内容残留。
+// 用户看到的就是「AI 历史对话记录里信息杂乱无序」。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { nextBubbleId, __resetBubbleIdSeqForTest } from '../../src/composables/bubbleId.js'
+
+test('同一毫秒内连续生成的 ID 互不相同（这正是撞 key 的场景）', () => {
+  __resetBubbleIdSeqForTest()
+  // 同一个同步块里连出两个，就是真实代码里用户气泡 + 助手气泡的形状
+  const a = nextBubbleId()
+  const b = nextBubbleId()
+  assert.notEqual(a, b, '用户气泡与助手气泡同毫秒创建，ID 不能相同')
+})
+
+test('一千个连续 ID 全部唯一', () => {
+  __resetBubbleIdSeqForTest()
+  const ids = new Set()
+  for (let i = 0; i < 1000; i++) ids.add(nextBubbleId())
+  assert.equal(ids.size, 1000, '存在重复 ID')
+})
+
+test('ID 仍带时间戳前缀，便于按 ID 排日志', () => {
+  __resetBubbleIdSeqForTest()
+  assert.match(nextBubbleId(), /^msg-\d+-\d+$/)
+})
+
+test('useAgentStream 不再用裸 Date.now() 当气泡 ID', () => {
+  const src = readFileSync(new URL('../../src/composables/useAgentStream.js', import.meta.url), 'utf8')
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+  assert.ok(!/id:\s*`msg-\$\{Date\.now\(\)\}`/.test(code),
+    '裸 Date.now() 当 ID 会让同毫秒创建的气泡撞 key')
+  assert.match(code, /nextBubbleId\(\)/, '应改用 nextBubbleId()')
+})


### PR DESCRIPTION
审计（dev-board#74）第十二批。这条直接对应用户报的「**AI 历史对话记录里信息杂乱无序**」。

## 病灶

`createUserBubble` 与 `createAssistantBubble` 的 ID 都是 `msg-${Date.now()}`，而这两个气泡是在**同一个同步块**里先后创建的：

```js
bubbles.value.push(createUserBubble(prompt, ...))   // useAgentStream:419
const newBubble = createAssistantBubble()           // useAgentStream:422
```

同一毫秒 = 同一个 ID，**几乎必撞，不是偶发竞态**。而 `ChatInterface` 的消息列表是 `:key="msg.id || index"`——key 撞了之后 Vue 的 diff 会**复用错节点**：一条消息的正文渲染进另一条气泡、用户/助手样式串位、旧内容残留。多气泡轮次（`useAgentStream:947` 再建助手气泡）同样会撞。

## 修法

抽出 `composables/bubbleId.js` 的 `nextBubbleId()`：单调递增序号 + 时间戳，同一页面会话内绝不重复，仍保留时间戳前缀便于按 ID 排日志。两处创建点改用它。历史消息由后端带自己的 ID，不走这条路。

刻意做成独立小模块而不是内联一个计数器：`useAgentStream` 里全是 `@/` 别名，`node:test` 里 import 不进来；抽出来才能真的跑一遍「一千个 ID 全唯一」。

## 测试

新增 `frontend/tests/project-home/bubble-id.test.mjs`（4 例，真 import 真跑）：同一同步块连出两个 ID 必须不同（正是撞 key 的那个场景）、一千个连续 ID 全部唯一、ID 仍带时间戳前缀、`useAgentStream` 里不再有裸 `msg-${Date.now()}`。

把实现改回裸 `Date.now()` 后 4 例中 3 例转红（空断言校验通过）。`check:emits` / `check:nav` / `check:locales` / `test:project-home` 全通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)