### PR TITLE
fix(version-control): 结束工作时合并抛异常，之后每一次自动存档都直接落进主线（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/version/WorkSessionService.java
+++ b/backend/src/main/java/com/checkba/version/WorkSessionService.java
@@ -312,6 +312,33 @@ public class WorkSessionService {
      * 工作会一直挂着「工作中」。已存在 ACTIVE 段时直接复用，不重新武装——
      * 那种情况下定时器该不该动由调用方自己的重排逻辑负责（见 onChangeSignal）。
      */
+    /**
+     * 合并抛异常时把律师放回他自己的工作段。endSession 是**先 checkout 主线、再合并**的，
+     * 合并「返回值失败」（冲突）那两条路径本来就会切回工作分支，唯独「直接抛异常」那条
+     * 没人管——mergeCore 会把任何 IO/JGit 故障（磁盘写满、.git/index.lock 被并发的 GC 或
+     * push 接收端占着、Windows 上 LOWA 还攥着文件句柄）包成 VersionException 抛出，异常
+     * 一路逃逸出 endSession，留下「段还挂着 ACTIVE、HEAD 却已经停在主线」的残局。
+     *
+     * 那个残局是要命的：之后每一次自动存档都会经 ensureSession 复用这个段（它只看有没有
+     * ACTIVE 段，不看 HEAD 在哪儿），再 commitAll 到当前 HEAD——也就是把律师后续的每一笔
+     * 修改直接提交进主线，绕开整个工作段隔离模型。历史永不重写，落进去就永久污染。
+     *
+     * 尽力而为：还原本身再失败也不能盖掉原始异常，挂到 suppressed 上一起交出去。
+     * abortMerge 在非 MERGING 态是真 no-op、可以盲调（v2 路径抛异常时可能停在 MERGING）。
+     */
+    private void restoreSessionCheckout(long projectId, WorkSession s, RuntimeException cause) {
+        try {
+            repoService.abortMerge(projectId);
+            if (!s.getBranchName().equals(repoService.currentBranch(projectId))) {
+                repoService.checkoutBranch(projectId, s.getBranchName());
+            }
+        } catch (Exception restoreFailure) {
+            cause.addSuppressed(restoreFailure);
+            log.error("合并失败后没能把工作段切回来: project={}, branch={}",
+                    projectId, s.getBranchName(), restoreFailure);
+        }
+    }
+
     private WorkSession ensureSession(long projectId, Long userId, String userName) {
         Optional<WorkSession> existing = activeSession(projectId);
         if (existing.isPresent()) return existing.get();
@@ -584,8 +611,14 @@ public class WorkSessionService {
             if (!mainAdvanced) {
                 // v1 原路径一字不改：单人场景主线没动过，merge() 的 NO_FF 语义与
                 // 既有护栏（ProjectRepoBranchTest）全部照旧。
-                MergeOutcome outcome = repoService.merge(
-                        projectId, s.getBranchName(), finalTitle, userName, email(userName));
+                MergeOutcome outcome;
+                try {
+                    outcome = repoService.merge(
+                            projectId, s.getBranchName(), finalTitle, userName, email(userName));
+                } catch (RuntimeException e) {
+                    restoreSessionCheckout(projectId, s, e);
+                    throw e;
+                }
                 if (!outcome.success()) {
                     // 合并没成，把用户放回他的工作段，改动一个都不能丢
                     repoService.checkoutBranch(projectId, s.getBranchName());
@@ -606,8 +639,14 @@ public class WorkSessionService {
             // 干净也不自动提交——清单要按数据库重算后与内容进同一个双亲提交（地雷 #21）。
             s.setTitle(finalTitle);
             sessionRepository.save(s);
-            MergeOutcome outcome = repoService.mergeNoCommit(
-                    projectId, s.getBranchName(), finalTitle, userName, email(userName));
+            MergeOutcome outcome;
+            try {
+                outcome = repoService.mergeNoCommit(
+                        projectId, s.getBranchName(), finalTitle, userName, email(userName));
+            } catch (RuntimeException e) {
+                restoreSessionCheckout(projectId, s, e);
+                throw e;
+            }
             if (outcome.mergeSha() != null) {
                 // ALREADY_UP_TO_DATE：理论不可达（空段已在上面筛掉），防御性收尾
                 return closeMergedSession(projectId, s, outcome.mergeSha());

--- a/backend/src/test/java/com/checkba/version/SessionEndMergeFailureResidueTest.java
+++ b/backend/src/test/java/com/checkba/version/SessionEndMergeFailureResidueTest.java
@@ -1,0 +1,161 @@
+package com.checkba.version;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.storage.StorageProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * endSession 先 checkout 主线、再让合并异常直接逃逸出去，留下一个残局：
+ * WorkSession 还是 ACTIVE，但 HEAD 已经在主线上。discardSession 早就为这个残局
+ * 加过显式的切回分支护栏（见它自己的注释），但 ensureSession——onChangeSignal /
+ * commitNow / revertTo 全部隐式开段的唯一收口——复用已存在的 ACTIVE 段时不做这个
+ * 检查，于是残局之后的每一次自动存档都直接落在主线上，绕开整个工作段隔离模型。
+ *
+ * fixture 照 SessionEndConflictTest（真实 Git 仓库 + HashMap 假仓储），另外把
+ * ProjectRepoService 包一层 spy，用来把合并期的 I/O 故障（mergeCore 会把任何
+ * IOException/JGit 异常包成 VersionException 抛出）注进去。
+ */
+class SessionEndMergeFailureResidueTest {
+
+    private Path root;
+    private ProjectRepoService repo;
+    private WorkSessionService svc;
+    private Map<Long, WorkSession> sessions;
+    private long nextSessionId;
+    private Map<Long, ProjectFile> db;
+    private long nextFileId;
+
+    @BeforeEach
+    void setUp(@TempDir Path tmp) throws Exception {
+        root = tmp;
+        Files.createDirectories(root.resolve("projects/7"));
+        Files.writeString(root.resolve("projects/7/合同.txt"), "初稿");
+
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(root.toAbsolutePath().toString());
+        ProjectRepoService real = new ProjectRepoService(
+                new com.checkba.storage.ProjectStorageResolver(props, null));
+        real.init(7L, "韩泽伟", "hzw@example.com");
+        repo = spy(real);
+
+        db = new HashMap<>();
+        nextFileId = 100L;
+        ProjectFileRepository fileRepo = mock(ProjectFileRepository.class);
+        when(fileRepo.findByProjectId(any())).thenAnswer(i -> {
+            Long pid = i.getArgument(0);
+            List<ProjectFile> out = new ArrayList<>();
+            for (ProjectFile f : db.values()) if (f.getProjectId().equals(pid)) out.add(f);
+            return out;
+        });
+        when(fileRepo.save(any(ProjectFile.class))).thenAnswer(i -> {
+            ProjectFile p = i.getArgument(0);
+            if (p.getId() == null) p.setId(nextFileId++);
+            db.put(p.getId(), p);
+            return p;
+        });
+        ProjectTreeManifestService manifestSvc = new ProjectTreeManifestService(
+                fileRepo, repo, new ObjectMapper(),
+                mock(UserRepository.class), mock(ProjectRepository.class));
+
+        sessions = new HashMap<>();
+        nextSessionId = 1L;
+        WorkSessionRepository sessionRepo = mock(WorkSessionRepository.class);
+        when(sessionRepo.save(any(WorkSession.class))).thenAnswer(i -> {
+            WorkSession s = i.getArgument(0);
+            if (s.getId() == null) s.setId(nextSessionId++);
+            sessions.put(s.getId(), s);
+            return s;
+        });
+        when(sessionRepo.findFirstByProjectIdAndStatusAndSessionType(any(), any(), any())).thenAnswer(i ->
+                sessions.values().stream()
+                        .filter(s -> s.getProjectId().equals(i.getArgument(0))
+                                && s.getStatus() == i.getArgument(1)
+                                && s.getSessionType() == i.getArgument(2))
+                        .findFirst());
+        when(sessionRepo.findByProjectIdAndStatusAndSessionTypeOrderByStartedAtDesc(any(), any(), any()))
+                .thenAnswer(i -> sessions.values().stream()
+                        .filter(s -> s.getProjectId().equals(i.getArgument(0))
+                                && s.getStatus() == i.getArgument(1)
+                                && s.getSessionType() == i.getArgument(2))
+                        .sorted(Comparator.comparing(WorkSession::getStartedAt).reversed())
+                        .toList());
+        when(sessionRepo.findById(any())).thenAnswer(i -> Optional.ofNullable(sessions.get(i.getArgument(0))));
+
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.initialize();
+
+        svc = new WorkSessionService(repo, manifestSvc, sessionRepo, scheduler, fileRepo, event -> {});
+        svc.setDebounceMillis(60_000); // 测试里不让防抖自己触发，全部手动落版
+    }
+
+    private void write(String relPath, String content) throws Exception {
+        Files.writeString(root.resolve("projects/7").resolve(relPath), content);
+    }
+
+    private WorkSession activeSession() {
+        return sessions.values().stream()
+                .filter(s -> s.getStatus() == WorkSession.Status.ACTIVE)
+                .findFirst().orElseThrow();
+    }
+
+    @Test
+    void autosaveAfterFailedEndSessionMustNotLandOnMainline() throws Exception {
+        svc.enableVersionRecording(7L, "韩泽伟", "hzw@example.com");
+        svc.onChangeSignal(7L, 1L, "韩泽伟");
+        write("合同.txt", "工作段里的修改");
+        svc.commitNow(7L, 1L, "韩泽伟", null);
+
+        WorkSession active = activeSession();
+        String sessionBranch = active.getBranchName();
+        String mainTipBefore = repo.resolveRef(7L, repo.mainBranch());
+
+        // 合并期真实故障：mergeCore 把任何 IO/JGit 异常包成 VersionException 抛出。
+        doThrow(new VersionException("模拟合并期 I/O 故障"))
+                .when(repo).merge(anyLong(), anyString(), anyString(), anyString(), anyString());
+
+        assertThrows(VersionException.class,
+                () -> svc.endSession(7L, 1L, "韩泽伟", "这段工作"));
+
+        // 段没结成，仍然 ACTIVE——这条本来就该如此，不是病灶。
+        assertEquals(WorkSession.Status.ACTIVE, sessions.get(active.getId()).getStatus(),
+                "前提不成立：合并没成，这段工作就该还挂着");
+
+        // 病灶正身：合并「返回值失败」两条路径都会切回工作分支，唯独「抛异常」那条
+        // 让异常直接逃逸，把 HEAD 丢在主线上，段与 HEAD 就此脱节。
+        assertEquals(sessionBranch, repo.currentBranch(7L),
+                "合并抛异常后 HEAD 被丢在主线上：工作段与 HEAD 脱节");
+
+        // 用户可见后果：脱节之后律师继续敲字，自动存档会顺着当前 HEAD 直接落进主线，
+        // 绕开整个工作段隔离（历史永不重写，落进去就永久污染）。
+        write("合同.txt", "残局之后又敲了一段");
+        svc.onChangeSignal(7L, 1L, "韩泽伟");
+        svc.commitNow(7L, 1L, "韩泽伟", null);
+
+        assertEquals(mainTipBefore, repo.resolveRef(7L, repo.mainBranch()),
+                "残局之后的自动存档直接落在主线上：工作段隔离被绕开了");
+        assertEquals(sessionBranch, repo.currentBranch(7L),
+                "自动存档没有把 HEAD 切回这段工作自己的分支");
+    }
+}


### PR DESCRIPTION
## 病灶

`endSession` 是「先 checkout 主线、再合并」的顺序。合并**返回值失败**（冲突）的两条路径都会把律师切回他自己的工作分支，唯独**抛异常**那条没人管——`mergeCore` 会把任何 IO/JGit 故障（磁盘写满、`.git/index.lock` 被并发的 GC 或 push 接收端占着、Windows 上 LOWA 还攥着文件句柄）包成 `VersionException` 抛出，异常一路逃逸出 `endSession`，留下「工作段还挂着 ACTIVE、HEAD 却已经停在主线」的残局。

残局之后是要命的：`ensureSession` 是 `onChangeSignal` / `commitNow` / `commitAiRound` 三个隐式开段入口的唯一收口，它**只看有没有 ACTIVE 段、不看 HEAD 在哪儿**，于是复用这个脱节的段之后，`commitAll` 顺着当前 HEAD 把律师后续的每一笔修改直接提交进主线，绕开整个工作段隔离模型。历史永不重写，落进去就永久污染。

`discardSession` 早就为同一个残局加过显式护栏（见它自己的注释），但那是在下游堵，残局本身照样会形成。

## 修法

在 `endSession` 的两条合并路径外面各包一层 try/catch，抛异常时先把律师放回工作分支再把原异常抛出去（`restoreSessionCheckout`）。还原是尽力而为的——还原本身再失败也不能盖掉原始异常，挂到 `suppressed` 上一起交出去；`abortMerge` 在非 MERGING 态是真 no-op、可以盲调，用来收拾 v2 路径抛异常时可能停在 MERGING 的现场。

## 刻意没做

没有在 `ensureSession` 里加「HEAD 跟段对不上就切回去」的兜底。**试过，不行**——残局形成后律师往往已经又改了文件，工作区是脏的，那里的 checkout 会被 JGit 直接拒（`CheckoutConflictException`），等于把自动存档整条路打断，比原病灶更糟。在源头堵住残局才是对的层次；崩溃/强杀留下的同类残局仍由 `discardSession` 那道护栏兜。

## 验证

`SessionEndMergeFailureResidueTest` 用 spy 把合并期 I/O 故障注进去，断言 (1) 抛异常后 HEAD 回到工作分支，(2) 之后的自动存档不改变主线 tip。

- 红：`expected: <work/1787272997671> but was: <master>`
- 绿：加上修复后通过
- **还原改动再变红**（确认断言真咬住病灶，不是空断言）
- `com.checkba.version` 全包 **309 个测试通过，0 失败**

## 来源

2026-08-20 全量稳定性审计补扫（dev-board#74）中，经两名独立「默认反驳」验证者复核后存活的 critical 结论，由我本人复现确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)