### PR TITLE
fix(backend): 网页代理无体积/总时限闸；云同步端点缺字段直接 NPE；编辑器回传的鉴权键错配（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
+++ b/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
@@ -56,6 +56,26 @@ public class BrowserProxyController {
     @org.springframework.beans.factory.annotation.Value("${security.browser-proxy.e2e-allowed-hosts:}")
     private String e2eAllowedHosts;
 
+    /**
+     * 单次代理允许拉回的最大字节数。默认 50MB。
+     *
+     * <p>注入的点击拦截脚本把 iframe 里**所有**同标签页链接点击都改道这个端点，
+     * 其中包括普通的大文件下载链接。上游响应此前是 {@code ofByteArray()} 全量进堆，
+     * 没有任何体积闸——后端是所有用户共用的一个 JVM，一次几百 MB 的下载就能把堆顶起来。
+     */
+    @org.springframework.beans.factory.annotation.Value("${security.browser-proxy.max-bytes:52428800}")
+    private long maxBytes = 52428800L;
+
+    /**
+     * 一次代理请求（含全部重定向跳）的总时限，秒。
+     *
+     * <p>此前只有每跳 20 秒的单跳超时，5 跳串起来能让一个请求占住一条 Tomcat 工作线程
+     * 将近 150 秒。慢速目标站（或一串各自慢一点的重定向）几个并发就能把线程池吃干净，
+     * 整个后端跟着卡住——而调用方只是在网页面板里点了个链接。
+     */
+    @org.springframework.beans.factory.annotation.Value("${security.browser-proxy.deadline-seconds:30}")
+    private long deadlineSeconds = 30L;
+
     /** 主机是否在 e2e 例外名单里（精确、忽略大小写）。名单为空时恒为 false。 */
     private boolean isE2eAllowedHost(String host) {
         if (host == null || host.isBlank() || e2eAllowedHosts == null || e2eAllowedHosts.isBlank()) return false;
@@ -79,7 +99,8 @@ public class BrowserProxyController {
 
         try {
             URI uri = URI.create(u);
-            HttpResponse<byte[]> resp = null;
+            HttpResponse<java.io.InputStream> resp = null;
+            long deadlineAt = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(Math.max(1, deadlineSeconds));
             // 手动跟随重定向，每一跳都重新做 scheme 白名单 + SSRF 校验，避免自动跳转绕过 SsrfGuard
             for (int hop = 0; hop < 5; hop++) {
                 String scheme = uri.getScheme();
@@ -93,23 +114,48 @@ public class BrowserProxyController {
                         && com.checkba.util.SsrfGuard.rejectIfBlocked(uri.toString()) != null) {
                     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(LangText.of("目标地址不被允许（已禁止本地/内网地址）", "Target address is not allowed (local/internal addresses are blocked)"));
                 }
+                Duration budget = Duration.ofNanos(deadlineAt - System.nanoTime());
+                if (budget.isNegative() || budget.isZero()) {
+                    return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).body(LangText.of(
+                            "代理超时：目标站点响应过慢", "Proxy timed out: the target site is too slow"));
+                }
                 HttpRequest req = HttpRequest.newBuilder(uri)
                         .GET()
-                        .timeout(Duration.ofSeconds(20))
+                        // 单跳超时取「剩余总预算」与 20 秒的较小值：跳数再多也不会累加成分钟级占用
+                        .timeout(budget.compareTo(Duration.ofSeconds(20)) < 0 ? budget : Duration.ofSeconds(20))
                         .header("User-Agent", "checkba-browser/1.0")
                         .build();
-                resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofByteArray());
+                // 流式接收而不是 ofByteArray()：正文要不要收、收多少由下面的体积闸说了算
+                resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofInputStream());
                 int sc = resp.statusCode();
                 if (sc >= 300 && sc < 400) {
                     String loc = resp.headers().firstValue("location").orElse(null);
                     if (loc == null || loc.isBlank()) break;
+                    closeQuietly(resp.body()); // 这一跳的正文用不上，别把连接挂在那儿
+                    resp = null;
                     uri = uri.resolve(loc); // 支持相对 Location，下一轮重新校验
                     continue;
                 }
                 break;
             }
             if (resp == null) {
-                return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(LangText.of("代理失败: 无响应", "Proxy failed: no response"));
+                // 跳满 5 次仍在重定向。此前这里会把最后那个 3xx 的正文当内容原样回给前端，
+                // 换成明确报错更诚实。
+                return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(LangText.of("代理失败: 重定向次数过多", "Proxy failed: too many redirects"));
+            }
+
+            long declared = resp.headers().firstValueAsLong("content-length").orElse(-1L);
+            if (declared > maxBytes) {
+                closeQuietly(resp.body());
+                return tooLarge();
+            }
+            byte[] payload;
+            try (java.io.InputStream in = resp.body()) {
+                payload = readBounded(in, maxBytes);
+            }
+            if (payload == null) {
+                // 上游没声明长度（分块传输），读到超限就停手，堆里最多多出 maxBytes+1 字节
+                return tooLarge();
             }
 
             String contentType = resp.headers().firstValue("content-type").orElse("application/octet-stream");
@@ -119,7 +165,7 @@ public class BrowserProxyController {
                 // 以前是「按 UTF-8 解、回 text/html 不带 charset」：浏览器于是拿默认编码
                 // （windows-1252）去解我们发出去的 UTF-8 字节，中文页面整页乱码。
                 // 已知没覆盖的一档：只在 <meta charset> 里声明、响应头不带的 GBK 页面。
-                String html = new String(resp.body(), charsetOf(contentType));
+                String html = new String(payload, charsetOf(contentType));
                 String injected = inject(html, uri.toString(), token);
                 HttpHeaders headers = new HttpHeaders();
                 headers.setContentType(new MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8));
@@ -134,10 +180,38 @@ public class BrowserProxyController {
                 headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
             }
             headers.setCacheControl("no-store");
-            return new ResponseEntity<>(resp.body(), headers, HttpStatus.OK);
+            return new ResponseEntity<>(payload, headers, HttpStatus.OK);
         } catch (Exception e) {
             log.warn("BrowserProxy failed: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(LangText.of("代理失败: ", "Proxy failed: ") + e.getMessage());
+        }
+    }
+
+    private ResponseEntity<?> tooLarge() {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(LangText.of(
+                "目标文件超过代理上限（" + (maxBytes / 1024 / 1024) + "MB），请在系统浏览器中打开",
+                "The target exceeds the proxy limit (" + (maxBytes / 1024 / 1024) + "MB); open it in your system browser"));
+    }
+
+    /** 最多读 max 字节；超了立刻停手并返回 null（堆里最多多出 max+1 字节）。 */
+    private static byte[] readBounded(java.io.InputStream in, long max) throws java.io.IOException {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] buf = new byte[8192];
+        long total = 0;
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            total += n;
+            if (total > max) return null;
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+
+    private static void closeQuietly(java.io.InputStream in) {
+        try {
+            if (in != null) in.close();
+        } catch (Exception ignore) {
+            // 关不掉就算了，连接池会自己回收
         }
     }
 

--- a/backend/src/main/java/com/checkba/controller/CloudController.java
+++ b/backend/src/main/java/com/checkba/controller/CloudController.java
@@ -54,7 +54,8 @@ public class CloudController {
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = requireLogin(sessionId);
         CloudConnection conn = cloudSyncService.connect(
-                body.get("serverUrl"), body.get("username"), body.get("password"), body.get("deviceName"), userId);
+                requireText(body, "serverUrl"), requireText(body, "username"), requireText(body, "password"),
+                optionalText(body, "deviceName", LangText.of("本机", "This device")), userId);
         Map<String, Object> data = new HashMap<>();
         data.put("connectionId", conn.getId());
         data.put("username", conn.getUsername());
@@ -95,8 +96,8 @@ public class CloudController {
             @RequestBody Map<String, Object> body,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = requireLogin(sessionId);
-        long connectionId = ((Number) body.get("connectionId")).longValue();
-        long remoteProjectId = ((Number) body.get("remoteProjectId")).longValue();
+        long connectionId = requireLong(body, "connectionId");
+        long remoteProjectId = requireLong(body, "remoteProjectId");
         Map<String, Object> cloned = cloudSyncService.cloneFromCloud(connectionId, remoteProjectId, userId);
         telemetryService.record("project.created",
                 Map.of("kind", "cloud", "reused", false, "importedCount", 0));
@@ -121,7 +122,7 @@ public class CloudController {
             @RequestBody Map<String, Object> body,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = requireWriteMember(projectId, sessionId);
-        long connectionId = ((Number) body.get("connectionId")).longValue();
+        long connectionId = requireLong(body, "connectionId");
         return ok(cloudSyncService.shareToCloud(projectId, connectionId, userId));
     }
 
@@ -198,8 +199,8 @@ public class CloudController {
             @RequestBody Map<String, String> body,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireWriteMember(projectId, sessionId);
-        String role = body == null || body.get("role") == null ? "PARTICIPANT" : body.get("role");
-        cloudSyncService.proxyMembers(projectId, body == null ? null : body.get("username"), role);
+        String role = optionalText(body, "role", "PARTICIPANT");
+        cloudSyncService.proxyMembers(projectId, requireText(body, "username"), role);
         return ok(Map.of());
     }
 
@@ -243,6 +244,43 @@ public class CloudController {
     }
 
     /** 只校验登录，不校验项目成员/角色——连接级端点用。 */
+    /**
+     * 请求体里的必填数字。
+     *
+     * <p>此前是 {@code ((Number) body.get(key)).longValue()}：缺字段就 NPE、传字符串就
+     * ClassCastException，两者都被兜成「服务器内部错误」——用户与调用方都不知道
+     * 真正的原因只是请求少写了一个字段。数字串也一并收下，客户端把 id 序列化成字符串很常见。
+     */
+    private static long requireLong(Map<String, Object> body, String key) {
+        Object v = body == null ? null : body.get(key);
+        if (v instanceof Number n) return n.longValue();
+        if (v instanceof String str && !str.isBlank()) {
+            try {
+                return Long.parseLong(str.trim());
+            } catch (NumberFormatException ignore) {
+                // 落到下面统一报错
+            }
+        }
+        throw new IllegalArgumentException(LangText.of(
+                "参数 " + key + " 缺失或不是数字", "Parameter " + key + " is missing or not a number"));
+    }
+
+    /** 请求体里的必填文本。空串与纯空白按缺失处理。 */
+    private static String requireText(Map<String, String> body, String key) {
+        String v = body == null ? null : body.get(key);
+        if (v == null || v.isBlank()) {
+            throw new IllegalArgumentException(LangText.of(
+                    "参数 " + key + " 不能为空", "Parameter " + key + " must not be empty"));
+        }
+        return v.trim();
+    }
+
+    /** 可选文本，缺失时用默认值（下游 Map.of 不收 null，给个默认比放行 null 安全）。 */
+    private static String optionalText(Map<String, String> body, String key, String fallback) {
+        String v = body == null ? null : body.get(key);
+        return v == null || v.isBlank() ? fallback : v.trim();
+    }
+
     private Long requireLogin(String sessionId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) throw new IllegalArgumentException("未登录");

--- a/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/EditorResultController.java
@@ -42,13 +42,16 @@ public class EditorResultController {
         log.info("Received editor result: requestId={}, success={}", payload.getRequestId(), payload.isSuccess());
         
         try {
-            editorBridgeService.completeEditorAction(
+            boolean accepted = editorBridgeService.completeEditorAction(
                     payload.getRequestId(),
+                    payload.getConversationId(),
                     payload.isSuccess(),
                     payload.getData(),
                     payload.getError()
             );
-            
+            if (!accepted) {
+                return new EditorResultResponse(false, "无效的 requestId 或不属于该会话");
+            }
             return new EditorResultResponse(true, "Result received");
             
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/repository/ProjectInvitationRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectInvitationRepository.java
@@ -4,11 +4,20 @@ import com.checkba.model.entity.ProjectInvitation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ProjectInvitationRepository extends JpaRepository<ProjectInvitation, Long> {
     Optional<ProjectInvitation> findByAccessCode(String accessCode);
-    Optional<ProjectInvitation> findByProjectIdAndType(Long projectId, String type);
+    /**
+     * 返回 List 而不是 Optional：(project_id, type) 上没有、也不该有唯一约束——
+     * CLIENT_NAMED 天然一个项目多行。而 inviteClient 是先查后建，两个并发的
+     * 「生成访问码」会各插一行 CLIENT_GENERIC；声明成 Optional 就走 getSingleResult，
+     * 之后每次查都抛 IncorrectResultSizeDataAccessException，这个项目的邀请链接功能
+     * 从此永久 500，没有重试也没有自愈，只能有人手工去库里删行。
+     * 调用方按 id 取最早的一行，重复时行为稳定。
+     */
+    List<ProjectInvitation> findByProjectIdAndType(Long projectId, String type);
     Optional<ProjectInvitation> findByProjectIdAndRelatedUserId(Long projectId, Long relatedUserId);
 }

--- a/backend/src/main/java/com/checkba/service/ClientInvitationService.java
+++ b/backend/src/main/java/com/checkba/service/ClientInvitationService.java
@@ -66,13 +66,13 @@ public class ClientInvitationService {
 
         // 3. Standard Shared Code Logic (Generic)
         // Check for new "CLIENT_GENERIC" type
-        Optional<ProjectInvitation> existingGeneric = invitationRepository.findByProjectIdAndType(projectId, "CLIENT_GENERIC");
+        Optional<ProjectInvitation> existingGeneric = earliest(projectId, "CLIENT_GENERIC");
         if (existingGeneric.isPresent()) {
             return ensureLongCode(existingGeneric.get());
         }
         
         // Check for legacy "CLIENT" type
-        Optional<ProjectInvitation> existingLegacy = invitationRepository.findByProjectIdAndType(projectId, "CLIENT");
+        Optional<ProjectInvitation> existingLegacy = earliest(projectId, "CLIENT");
         if (existingLegacy.isPresent()) {
              return ensureLongCode(existingLegacy.get());
         }
@@ -98,7 +98,36 @@ public class ClientInvitationService {
         invitation.setCreatedBy(requesterId);
         invitationRepository.save(invitation);
 
+        // 通用码此前只建影子用户与 invitation 行，从不建成员行；而客户登录恒走
+        // 「登录成 relatedUserId 这个影子用户」那一支（前端传 displayName=null），
+        // 同样不建成员行。项目访问权全靠 project_member（hasReadPermission 只认成员行
+        // 或项目所有者），于是律师把码发出去，客户登录提示成功、页面跳进工作台，
+        // 之后每个文件接口都回 403——「登录成功」与「什么都打不开」并存。
+        ensureClientMember(projectId, templateUser.getId());
+
         return code;
+    }
+
+    /** 把影子用户补成 CLIENT 成员；已经是成员就不动（重发访问码会走到这里）。 */
+    private void ensureClientMember(Long projectId, Long userId) {
+        if (projectMemberRepository.findByProjectIdAndUserId(projectId, userId).isPresent()) {
+            return;
+        }
+        ProjectMember member = new ProjectMember();
+        member.setProjectId(projectId);
+        member.setUserId(userId);
+        member.setRole("CLIENT");
+        projectMemberRepository.save(member);
+    }
+
+    /**
+     * 同项目同类型的最早一行。并发签发能插出两行通用码，取「最早」保证之后每次都命中同一行，
+     * 不会今天用 A 明天用 B。
+     */
+    private Optional<ProjectInvitation> earliest(Long projectId, String type) {
+        return invitationRepository.findByProjectIdAndType(projectId, type).stream()
+                .min(java.util.Comparator.comparing(ProjectInvitation::getId,
+                        java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())));
     }
 
     private String ensureLongCode(ProjectInvitation invitation) {
@@ -108,6 +137,8 @@ public class ClientInvitationService {
             invitation.setRevokedAt(null);
             invitationRepository.save(invitation);
         }
+        // 作废客户时成员行会被删掉，重新发码就得把它补回来，否则码能用但没有权限。
+        ensureClientMember(invitation.getProjectId(), invitation.getRelatedUserId());
         String existingCode = invitation.getAccessCode();
         if (existingCode.length() < 10) {
             String newCode = generateUniqueCode();

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -492,6 +492,11 @@ public class ProjectFileService {
 
         // 权限检查已移至 Controller 层，这里不再检查创建者身份
 
+        // 文件缓存区免费额度：单文件移入同样要过闸。此前额度只挂在 batchMove 上，
+        // 而这条路径也能把文件移进 __staging_area__——一次拖一个就能无限塞，
+        // 付费闸等于没有。目标不是缓存区时 checkAdmission 直接放行，其它移动不受影响。
+        stageQuotaService.checkAdmission(newParentId, java.util.List.of(fileId));
+
         // 检查不能移动到自己的子文件夹中
         if (file.getIsFolder() && newParentId != null) {
             if (isDescendant(fileId, newParentId)) {

--- a/backend/src/main/java/com/checkba/service/TtsService.java
+++ b/backend/src/main/java/com/checkba/service/TtsService.java
@@ -156,7 +156,15 @@ public class TtsService {
             logger.info("Saved local TTS audio to: {}", outputFile.getAbsolutePath());
             return outputFile;
         } catch (org.springframework.web.client.ResourceAccessException e) {
-            // 连接被拒/超时：组件未启动（未下载或被删除）
+            if (!isServiceUnreachable(e)) {
+                // 组件在跑，只是这次合成没在读超时内给出结果。报成「请去下载组件」
+                // 会把用户支到一个和故障完全无关的地方，而真正该做的是缩短文本或重试。
+                logger.warn("Local TTS timed out (component is running): {}", e.getMessage());
+                throw new RuntimeException(LangText.of(
+                        "本地语音合成超时：文本过长或组件繁忙，请缩短文本后重试",
+                        "Local speech synthesis timed out: shorten the text or try again."), e);
+            }
+            // 连不上：组件未启动（未下载或被删除）
             throw new FeatureNotConfiguredException("tts",
                     LangText.of("本地语音组件未就绪：请在「系统管理 → 组件管理」下载并启用语音组件",
                             "Local speech component is not running: download & enable it in Admin → Components."));
@@ -166,6 +174,27 @@ public class TtsService {
             logger.error("Failed to generate audio via local Kokoro", e);
             throw new RuntimeException("Failed to generate audio: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * {@code ResourceAccessException} 把「连不上」和「连上了但太慢」裹成同一个类型，
+     * 于是一次读超时会被报成「组件未下载」——用户被支去重装一个正在正常运行的组件。
+     * 这里按 cause 分开：只有确实连不上才算「未就绪」。
+     *
+     * <p>读超时归为「可达但失败」。本地回环连不上是立刻 ECONNREFUSED，不会走到
+     * socket 超时，所以把 SocketTimeoutException 一律当成「服务在跑但没按时回」是安全的。
+     * 认不出来的 cause 保持旧行为（多数确实是连不上）。
+     */
+    static boolean isServiceUnreachable(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof java.net.SocketTimeoutException) return false;
+            if (t instanceof java.net.ConnectException
+                    || t instanceof java.net.UnknownHostException
+                    || t instanceof java.net.NoRouteToHostException) {
+                return true;
+            }
+        }
+        return true;
     }
 
     // Response DTOs

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -349,7 +349,9 @@ public class AgentOrchestrator {
         if (meta.refreshFiles()) {
             sseEmitterService.send(conversationId, "client_action", "{\"action\":\"refresh_files\"}");
         }
-        if (!meta.fileEffect().isEmpty()) {
+        // 「执行成功」不等于「改过文件」：查找替换一次都没命中时照发 MODIFIED，
+        // 用户会被告知本轮改了这个文件，去找却找不到任何改动。
+        if (!meta.fileEffect().isEmpty() && result.fileChanged()) {
             String fileName = meta.fileArg().isEmpty() ? null : extractArg(argsJson, meta.fileArg());
             if (fileName == null || fileName.isEmpty()) {
                 fileName = "Current Document";

--- a/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
@@ -562,8 +562,36 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
         sseEmitterService.send(conversationId, "bubble_start", "{\"bubbleId\":\"" + currentBubbleId + "\", \"type\":\"" + type + "\"}");
     }
     
-    private String escapeJson(String raw) {
+    /**
+     * SSE 载荷是手工拼的 JSON 串，这里必须把 JSON 规范要求的字符全转义掉。
+     *
+     * <p>此前只处理了 {@code \ " \n \r}：模型正文里出现一个真制表符（写 Makefile /
+     * Go / 缩进代码块时是常态）就会拼出非法 JSON，前端 text_delta 解析失败后回落成
+     * 「把整段 {"content":"..."} 信封当正文渲染」，artifact 事件则被整条丢弃。
+     * U+0000..U+001F 全区间都要转义，规范如此。
+     */
+    static String escapeJson(String raw) {
         if (raw == null) return "";
-        return raw.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r");
+        StringBuilder sb = new StringBuilder(raw.length() + 16);
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"' -> sb.append("\\\"");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
@@ -42,8 +42,19 @@ public class EditorBridgeService {
     private final ObjectMapper objectMapper;
     private final com.checkba.service.telemetry.TelemetryService telemetryService;
 
-    // 请求 ID -> CompletableFuture 的映射
-    private final ConcurrentHashMap<String, CompletableFuture<EditorActionResult>> pendingRequests = new ConcurrentHashMap<>();
+    /**
+     * 请求 ID -> 在等的那一轮。
+     *
+     * <p>连会话一起记：结果回传的鉴权键必须是「这个 requestId 是给哪个会话发的」，
+     * 而不是调用方自己报的 conversationId。此前只存 future，控制器又只校验
+     * payload 里客户端自报的会话（是他自己的会话就放行）——两把钥匙不是同一把，
+     * 拿到别的会话的 requestId 就能把伪造内容作为工具结果塞进那一轮的 Agent 循环，
+     * 而那个结果会被当成可信的文档内容驱动后续改文档动作。
+     */
+    private final ConcurrentHashMap<String, PendingAction> pendingRequests = new ConcurrentHashMap<>();
+
+    /** 一次在途的编辑器命令：它属于哪个会话，以及谁在等它。 */
+    private record PendingAction(String conversationId, CompletableFuture<EditorActionResult> future) {}
     
     // 当前活跃的 conversationId（由 AgentOrchestrator 设置）
     private final ThreadLocal<String> currentConversationId = new ThreadLocal<>();
@@ -251,7 +262,7 @@ public class EditorBridgeService {
 
         String requestId = UUID.randomUUID().toString();
         CompletableFuture<EditorActionResult> future = new CompletableFuture<>();
-        pendingRequests.put(requestId, future);
+        pendingRequests.put(requestId, new PendingAction(conversationId, future));
         long bridgeStartMs = System.currentTimeMillis();
 
         try {
@@ -305,14 +316,20 @@ public class EditorBridgeService {
      * @param data 结果数据
      * @param error 错误信息
      */
-    public void completeEditorAction(String requestId, boolean success, Object data, String error) {
-        CompletableFuture<EditorActionResult> future = pendingRequests.get(requestId);
-        if (future != null) {
-            future.complete(new EditorActionResult(success, data, error));
-            log.info("Completed editor action: requestId={}, success={}", requestId, success);
-        } else {
+    public boolean completeEditorAction(String requestId, String conversationId,
+                                        boolean success, Object data, String error) {
+        PendingAction pending = pendingRequests.get(requestId);
+        if (pending == null) {
             log.warn("No pending request found for requestId={}", requestId);
+            return false;
         }
+        if (conversationId == null || !conversationId.equals(pending.conversationId())) {
+            log.warn("Rejected editor result: requestId={} belongs to another conversation", requestId);
+            return false;
+        }
+        pending.future().complete(new EditorActionResult(success, data, error));
+        log.info("Completed editor action: requestId={}, success={}", requestId, success);
+        return true;
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -106,6 +106,22 @@ public class ToolRegistry {
      */
     public record ToolResult(String output, RegisteredTool tool, boolean found) {
 
+        /**
+         * 声明了 {@code fileEffect} 的工具，用它做返回值前缀表达
+         * 「这一次执行成功，但什么都没改」。
+         *
+         * <p>{@code @ToolMeta.fileEffect} 是写死的常量，编排器只看 success()，
+         * 于是一次「没找到、文件未改动」的查找替换也会发 file_change(MODIFIED)、
+         * 写进会话的文件变更历史——用户被告知本轮改了这个文件，去找却找不到改动。
+         * 有了这个前缀，副作用层能把「成功」与「改过」分开。
+         */
+        public static final String UNCHANGED_PREFIX = "未改动：";
+
+        /** 本次执行是否真的动了文件。仅对声明了 fileEffect 的工具有意义。 */
+        public boolean fileChanged() {
+            return success() && !output.stripLeading().startsWith(UNCHANGED_PREFIX);
+        }
+
         public boolean success() {
             if (!found || output == null) return false;
             String trimmed = output.stripLeading();

--- a/backend/src/main/java/com/checkba/service/ai/XmlToolCallParser.java
+++ b/backend/src/main/java/com/checkba/service/ai/XmlToolCallParser.java
@@ -298,21 +298,38 @@ public class XmlToolCallParser {
     }
 
     /**
-     * JSON 风格调用：tool({...}) → 直接返回 {...}；不是该风格返回 null。
+     * JSON 风格调用：{@code tool({...})} → 直接返回 {@code {...}}；不是该风格返回 null。
+     *
+     * <p>必须锚定到「工具名紧跟左括号」「右花括号收在调用末尾」这个形状。此前用
+     * {@code indexOf("({")} / {@code lastIndexOf("})")} 在整段文本里找，参数值里
+     * 只要出现一对 {@code ({ ... })}——正文引用代码、字典字面量、一句
+     * 「helper({k: 1})」都算——就会被整体当成参数对象返回，真正的命名参数全部丢失。
+     * 而 hutool 的 JSON 解析对无引号键很宽容，所以连兜底 catch 都不会兜住，
+     * 工具拿着一组凭空捏造的参数照常执行，全程零报错。
      */
     private String tryExtractJsonObjectArgs(String code) {
-        int jsonStart = code.indexOf("({");
-        int jsonEnd = code.lastIndexOf("})");
-        if (jsonStart == -1 || jsonEnd == -1 || jsonEnd <= jsonStart) {
-            return null;
+        String trimmed = code.strip();
+        // 允许末尾的分号（模型偶尔按 JS 习惯加）
+        while (trimmed.endsWith(";")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1).strip();
         }
-        String jsonStr = code.substring(jsonStart + 1, jsonEnd + 1);
+        if (!trimmed.endsWith(")")) return null;
+        int paren = trimmed.indexOf('(');
+        if (paren <= 0) return null;
+        // 左括号之前必须整段都是工具名（允许 xx.yy 前缀），中间不许夹别的东西
+        String head = trimmed.substring(0, paren).strip();
+        if (!TOOL_NAME_HEAD.matcher(head).matches()) return null;
+        String inner = trimmed.substring(paren + 1, trimmed.length() - 1).strip();
+        if (!inner.startsWith("{") || !inner.endsWith("}")) return null;
         try {
-            return cn.hutool.json.JSONUtil.parseObj(jsonStr).toString();
+            return cn.hutool.json.JSONUtil.parseObj(inner).toString();
         } catch (Exception e) {
             return null;
         }
     }
+
+    private static final java.util.regex.Pattern TOOL_NAME_HEAD =
+            java.util.regex.Pattern.compile("[A-Za-z_][A-Za-z0-9_.]*");
 
     /**
      * 从代码文本中提取字符串参数值。

--- a/backend/src/main/java/com/checkba/service/ai/context/LegalInfoProtector.java
+++ b/backend/src/main/java/com/checkba/service/ai/context/LegalInfoProtector.java
@@ -182,13 +182,19 @@ public class LegalInfoProtector {
 
         // 按位置排序并去重
         segments.sort(Comparator.comparingInt(ProtectedSegment::getStart));
-        return mergeOverlappingSegments(segments);
+        return mergeOverlappingSegments(content, segments);
     }
 
     /**
-     * 合并重叠的片段
+     * 合并重叠的片段。
+     *
+     * <p>合并后的正文必须重新从原文按 [start, end) 取，不能沿用第一个片段的 content：
+     * 此前 end 取了并集、content 却留着前一段，于是 [content 长度, end) 那一截在
+     * {@link #safeCompress} 里被静默跳过——那里是 {@code append(content)} 后直接
+     * {@code lastEnd = end}。「人民币500万元」同时命中「人民币+数字」与「数字+万元」
+     * 两条模式，合并后只剩「人民币500」：一份合同里的金额从五百万变成五百，零报错。
      */
-    private List<ProtectedSegment> mergeOverlappingSegments(List<ProtectedSegment> segments) {
+    private List<ProtectedSegment> mergeOverlappingSegments(String source, List<ProtectedSegment> segments) {
         if (segments.size() <= 1) {
             return segments;
         }
@@ -203,10 +209,12 @@ public class LegalInfoProtector {
                 int newEnd = Math.max(current.getEnd(), next.getEnd());
                 ProtectionLevel higherLevel = current.getLevel().getScore() >= next.getLevel().getScore() 
                         ? current.getLevel() : next.getLevel();
+                int safeStart = Math.max(0, Math.min(current.getStart(), source.length()));
+                int safeEnd = Math.max(safeStart, Math.min(newEnd, source.length()));
                 current = new ProtectedSegment(
                         current.getStart(),
                         newEnd,
-                        current.getContent(),  // 保留第一个的内容
+                        source.substring(safeStart, safeEnd),  // 按并集重取，别吃掉中间的字
                         higherLevel,
                         current.getType()
                 );

--- a/backend/src/main/java/com/checkba/service/ai/tools/TextFileEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/TextFileEditTools.java
@@ -74,6 +74,17 @@ public class TextFileEditTools implements AgentToolComponent {
         }
     }
 
+    /**
+     * 「一次都没命中」的返回串。带 {@link ToolRegistry.ToolResult#UNCHANGED_PREFIX}
+     * 前缀，好让编排器的副作用层知道这一次不该发 file_change——本工具声明的
+     * {@code fileEffect="MODIFIED"} 是常量，不带这个前缀，一次没命中的查找也会被
+     * 记成「本轮修改了这个文件」。
+     */
+    public static String noHitMessage(String find, int length) {
+        return com.checkba.service.ai.ToolRegistry.ToolResult.UNCHANGED_PREFIX
+                + "未找到 \"" + abbreviate(find) + "\"（文件共 " + length + " 字符）。";
+    }
+
     @ToolMeta(displayName = "文本查找替换", category = "file", fileEffect = "MODIFIED")
     @Tool("在纯文本/代码文件（txt/md/json/js/html/css/yml 等）中做字面量查找替换（非正则）。"
             + "replaceAll=true 替换全部命中，false 只替换第一处；返回命中次数。"
@@ -95,7 +106,7 @@ public class TextFileEditTools implements AgentToolComponent {
             String text = readText(pf);
             int hits = countOccurrences(text, find);
             if (hits == 0) {
-                return "未找到 \"" + abbreviate(find) + "\"，文件未改动（共 " + text.length() + " 字符）。";
+                return noHitMessage(find, text.length());
             }
             String replacement = replace == null ? "" : replace;
             String updated = replaceAll

--- a/backend/src/main/java/com/checkba/service/auth/VerificationCodeStore.java
+++ b/backend/src/main/java/com/checkba/service/auth/VerificationCodeStore.java
@@ -58,60 +58,80 @@ public class VerificationCodeStore {
      * 回收，否则冷却期会挡住用户的立即重试。
      */
     public String issue(String scene, String target) {
-        long now = nowMillis.getAsLong();
-        purgeIfOversized(now);
-        String key = key(scene, target);
-        Entry existing = codes.get(key);
-        if (existing != null && now - existing.issuedAt < RESEND_COOLDOWN.toMillis()) {
-            throw new IllegalArgumentException("验证码发送过于频繁，请稍后再试");
-        }
-        WindowCounter counter = dailySends.get(target);
-        if (counter != null
-                && now - counter.windowStart <= DAY_WINDOW.toMillis()
-                && counter.count >= MAX_PER_TARGET_PER_DAY) {
-            throw new IllegalArgumentException("该账号今日验证码条数已达上限，请明天再试");
-        }
-
-        String code = String.valueOf(100000 + SECURE_RANDOM.nextInt(900000));
-        Entry entry = new Entry();
-        entry.codeHash = sha256(code);
-        entry.issuedAt = now;
-        entry.expiresAt = now + TTL.toMillis();
-        codes.put(key, entry);
-        dailySends.compute(target, (k, c) -> {
-            if (c == null || now - c.windowStart > DAY_WINDOW.toMillis()) {
-                c = new WindowCounter();
-                c.windowStart = now;
+        // 「查冷却/查日上限」与「写新码/记条数」必须在同一临界区里：拆开就是 check-then-act，
+        // 两个并发请求会一起看到「没码/没超」，于是同一秒发出两条码、日上限被一起越过。
+        // 借 ConcurrentHashMap.compute 对同一 key 的原子性做这道锁；lambda 里抛异常时
+        // 映射保持不变（冷却/超限被拒不会留下半条记录）。
+        String[] issued = new String[1];
+        codes.compute(key(scene, target), (k, existing) -> {
+            long now = nowMillis.getAsLong();
+            if (existing != null && now - existing.issuedAt < RESEND_COOLDOWN.toMillis()) {
+                throw new IllegalArgumentException("验证码发送过于频繁，请稍后再试");
             }
-            c.count++;
-            return c;
+            // 嵌套 compute 的是另一张表（dailySends），CHM 只禁止在 compute 里改「本表」；
+            // 全局只有这一处按 codes -> dailySends 的顺序取锁，不存在反向路径。
+            dailySends.compute(target, (t, c) -> {
+                if (c == null || now - c.windowStart > DAY_WINDOW.toMillis()) {
+                    c = new WindowCounter();
+                    c.windowStart = now;
+                }
+                if (c.count >= MAX_PER_TARGET_PER_DAY) {
+                    throw new IllegalArgumentException("该账号今日验证码条数已达上限，请明天再试");
+                }
+                c.count++;
+                return c;
+            });
+            String code = String.valueOf(100000 + SECURE_RANDOM.nextInt(900000));
+            issued[0] = code;
+            Entry entry = new Entry();
+            entry.codeHash = sha256(code);
+            entry.issuedAt = now;
+            entry.expiresAt = now + TTL.toMillis();
+            return entry;
         });
-        return code;
+        // 清理挪到临界区外：purge 会遍历改 codes 本表，放进 compute 里是 CHM 明令禁止的。
+        purgeIfOversized(nowMillis.getAsLong());
+        return issued[0];
     }
 
     /** 验证并核销：成功即销毁；连续验错超限作废。过期/不存在/错码一律 false。 */
     public boolean verify(String scene, String target, String code) {
         if (code == null || code.isBlank()) return false;
-        String key = key(scene, target);
-        Entry entry = codes.get(key);
-        long now = nowMillis.getAsLong();
-        if (entry == null || now > entry.expiresAt) {
-            codes.remove(key);
-            return false;
-        }
-        if (!constantTimeEquals(entry.codeHash, sha256(code.trim()))) {
-            if (++entry.attempts >= MAX_ATTEMPTS) {
-                codes.remove(key);
+        // 哈希放在临界区外算，锁只盖住「读计数-加一-写回/作废」。
+        byte[] guess = sha256(code.trim());
+        // 此前 ++entry.attempts 是裸的字段自增：并发验错会丢更新，5 次上限挡不住
+        // 真打过来的 5 次以上猜测。compute 对同一 key 原子，计数不会漏记。
+        boolean[] ok = new boolean[1];
+        codes.compute(key(scene, target), (k, entry) -> {
+            long now = nowMillis.getAsLong();
+            if (entry == null || now > entry.expiresAt) {
+                return null; // 过期/不存在：顺手清掉（返回 null 即移除映射）
             }
-            return false;
-        }
-        codes.remove(key);
-        return true;
+            if (!constantTimeEquals(entry.codeHash, guess)) {
+                entry.attempts++;
+                return entry.attempts >= MAX_ATTEMPTS ? null : entry;
+            }
+            ok[0] = true;
+            return null; // 一次性：成功即核销
+        });
+        return ok[0];
     }
 
     /** 回收一枚未消费的码（发送失败时回滚冷却，不回滚当日计数——网关受理即可能计费）。 */
     public void invalidate(String scene, String target) {
         codes.remove(key(scene, target));
+    }
+
+    /** 测试用：当前累计验错次数（不存在返回 -1）。 */
+    int attemptsForTest(String scene, String target) {
+        Entry e = codes.get(key(scene, target));
+        return e == null ? -1 : e.attempts;
+    }
+
+    /** 测试用：当日已签发条数。 */
+    int dailySendsForTest(String target) {
+        WindowCounter c = dailySends.get(target);
+        return c == null ? 0 : c.count;
     }
 
     private static String key(String scene, String target) {

--- a/backend/src/main/java/com/checkba/service/feedback/FeedbackUploadService.java
+++ b/backend/src/main/java/com/checkba/service/feedback/FeedbackUploadService.java
@@ -53,8 +53,11 @@ public class FeedbackUploadService {
 
     /** 可注入的传输层（测试替身用）。 */
     public interface Transport {
-        /** @return HTTP 状态码 */
-        int post(String url, String contentType, byte[] body) throws Exception;
+        /** @return 状态码与响应体。**响应体必须带回来**：收件端对业务失败也回 HTTP 200 + {"code":1}，
+         *  只看状态码就会把「云端拒收」读成「已收下」。 */
+        Response post(String url, String contentType, byte[] body) throws Exception;
+
+        record Response(int status, String body) {}
     }
 
     @Autowired
@@ -82,13 +85,16 @@ public class FeedbackUploadService {
 
     private static Transport defaultTransport() {
         HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
-        return (url, contentType, body) -> client.send(
-                HttpRequest.newBuilder(URI.create(url))
-                        .timeout(Duration.ofSeconds(60))
-                        .header("Content-Type", contentType)
-                        .POST(HttpRequest.BodyPublishers.ofByteArray(body))
-                        .build(),
-                HttpResponse.BodyHandlers.discarding()).statusCode();
+        return (url, contentType, body) -> {
+            HttpResponse<String> resp = client.send(
+                    HttpRequest.newBuilder(URI.create(url))
+                            .timeout(Duration.ofSeconds(60))
+                            .header("Content-Type", contentType)
+                            .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            return new Transport.Response(resp.statusCode(), resp.body());
+        };
     }
 
     public boolean isConfigured() {
@@ -152,20 +158,55 @@ public class FeedbackUploadService {
         writeField(out, boundary, "payload", mapper.writeValueAsString(payload));
         for (FeedbackAttachment a : feedbackService.attachmentsOf(fb.getId())) {
             Path p = feedbackService.attachmentPath(fb.getId(), a.getStoredName());
-            if (!Files.isRegularFile(p)) continue;
+            if (!Files.isRegularFile(p)) {
+                // 附件读不到就静默跳过，会让纯语音/纯截图那条反馈发出一个空 multipart，
+                // 云端按「空反馈」拒收。留一条 WARN，否则这条反馈为什么一直传不上去
+                // 在日志里查不到任何线索。
+                log.warn("反馈 #{} 的附件 {} 不在磁盘上，本次上传将不含它", fb.getId(), a.getStoredName());
+                continue;
+            }
             writeFile(out, boundary, "files", a.getStoredName(),
                     a.getContentType() == null ? "application/octet-stream" : a.getContentType(),
                     Files.readAllBytes(p));
         }
         out.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
 
-        int status = transport.post(uploadUrl, "multipart/form-data; boundary=" + boundary, out.toByteArray());
+        Transport.Response resp = transport.post(uploadUrl, "multipart/form-data; boundary=" + boundary, out.toByteArray());
+        int status = resp.status();
         if (status == 429) {
             // 配额挡下的：标成已上传只会让这条永远消失，宁可下轮再试
             log.debug("反馈 #{} 被云端限流，留待下轮", fb.getId());
             return false;
         }
-        return status >= 200 && status < 300;
+        if (status < 200 || status >= 300) {
+            return false;
+        }
+        // 收件端对业务失败也回 HTTP 200 + {"code":1}（controller 里多处
+        // ResponseEntity.ok(error(...))，例如附件读不到导致正文与附件全空时的「空反馈」）。
+        // 只看状态码就把「云端拒收」读成「已收下」，markUploaded 永久置位——
+        // 这条反馈既不会重传也进不了优化者队列，而用户的「我的反馈」显示已送达。
+        if (isRejectedEnvelope(resp.body())) {
+            log.debug("反馈 #{} 被云端拒收（信封 code 非 0），留待下轮: {}", fb.getId(), abbreviate(resp.body()));
+            return false;
+        }
+        return true;
+    }
+
+    /** 信封里 code 非 0 即视为未收下。解析不出来的按「收下了」处理，别让格式变化把正常上传卡死。 */
+    private boolean isRejectedEnvelope(String body) {
+        if (body == null || body.isBlank()) return false;
+        try {
+            com.fasterxml.jackson.databind.JsonNode node = mapper.readTree(body);
+            com.fasterxml.jackson.databind.JsonNode code = node.get("code");
+            return code != null && code.isNumber() && code.asInt() != 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String abbreviate(String s) {
+        if (s == null) return "";
+        return s.length() <= 200 ? s : s.substring(0, 200) + "...";
     }
 
     private static void writeField(ByteArrayOutputStream out, String boundary, String name, String value)

--- a/backend/src/main/java/com/checkba/service/pack/NativePackService.java
+++ b/backend/src/main/java/com/checkba/service/pack/NativePackService.java
@@ -330,7 +330,15 @@ public class NativePackService {
             st.setInstalledVersion(version);
             return version;
         } catch (RuntimeException e) {
-            st.setState(STATE_FAILED);
+            // 因封禁被拒不是「安装失败」：状态要如实停在 revoked，否则广场把平台封禁
+            // 显示成一次网络出错，用户只会一遍遍重试
+            JSONObject current = readCurrent(packId);
+            if (current != null && current.getBool("revoked", false)) {
+                st.setState(STATE_REVOKED);
+                st.setInstalledVersion(current.getStr("version"));
+            } else {
+                st.setState(STATE_FAILED);
+            }
             st.setError(e.getMessage());
             throw e;
         }
@@ -339,6 +347,7 @@ public class NativePackService {
     private String doInstall(String packId, PackStatus st) {
         Manifest m = fetchAndVerifyManifest(packId);
         checkCompatibility(m);
+        requireNotRevoked(packId, m.version());
 
         List<Component> components = componentsForPlatform(m);
         if (components.isEmpty()) {
@@ -410,6 +419,39 @@ public class NativePackService {
         FileUtil.del(staging.toFile());
         log.info("Installed native pack {} v{} ({} component(s))", packId, m.version(), components.size());
         return m.version();
+    }
+
+    /**
+     * 封禁位只有平台说了才算数：安装流程不得顺手把它抹掉。
+     *
+     * <p>病灶：封禁是「打标不删文件」（防误封丢数据），于是版本目录连同 {@code .pack-complete}
+     * 都还在。下一次 {@link #doInstall} 走幂等分支只重写指针，{@code revoked} 被写回 false——
+     * 一次字节都没重新校验，平台的封禁就无声失效了。触发它不需要用户做什么：pack 被封后
+     * {@code resourceReady()} 为假，{@code PackAutoInstaller} 每次后端启动都会再触发一次安装。
+     *
+     * <p>处置：本地标着封禁时，重新问一次封禁表。平台已撤销才放行（并让后续 writeCurrent
+     * 正常清位）；仍在封禁、或封禁表根本拉不到，一律拒装——宁可装不上也不无声复活。
+     */
+    private void requireNotRevoked(String packId, String version) {
+        JSONObject current = readCurrent(packId);
+        if (current == null || !current.getBool("revoked", false)) return;
+
+        List<RevokedPack> list;
+        try {
+            list = fetchRevoked();
+        } catch (Exception e) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包 " + packId + " 已被平台封禁，当前无法核对封禁表，暂不重新安装",
+                    "Pack " + packId + " is revoked and the revocation list is unreachable; install refused"));
+        }
+        boolean stillRevoked = list.stream().anyMatch(r -> packId.equals(r.id())
+                && ("*".equals(r.version()) || r.version() == null || r.version().equals(version)));
+        if (stillRevoked) {
+            throw new IllegalStateException(LangText.of(
+                    "资源包 " + packId + " v" + version + " 已被平台封禁，不能安装",
+                    "Pack " + packId + " v" + version + " is revoked by the platform"));
+        }
+        log.info("Pack {} is no longer on the revocation list; the local revoked flag will be cleared", packId);
     }
 
     /** 卸载：删 packs/&lt;id&gt;/ 整目录（含 current.json）。canonical 守卫只许删正下方。 */

--- a/backend/src/test/java/com/checkba/controller/BrowserProxyControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/BrowserProxyControllerTest.java
@@ -30,6 +30,9 @@ class BrowserProxyControllerTest {
 
     private HttpServer site;
     private String siteUrl;
+    private String bigUrl;
+    private String chunkedUrl;
+    private String slowUrl;
     private BrowserProxyController controller;
 
     @BeforeEach
@@ -43,8 +46,34 @@ class BrowserProxyControllerTest {
             exchange.getResponseBody().write(body);
             exchange.close();
         });
+        site.createContext("/big", exchange -> {
+            byte[] chunk = new byte[64 * 1024];
+            exchange.getResponseHeaders().add("Content-Type", "application/pdf");
+            exchange.sendResponseHeaders(200, 8L * chunk.length);
+            for (int i = 0; i < 8; i++) exchange.getResponseBody().write(chunk);
+            exchange.close();
+        });
+        site.createContext("/chunked", exchange -> {
+            byte[] chunk = new byte[64 * 1024];
+            exchange.getResponseHeaders().add("Content-Type", "application/pdf");
+            exchange.sendResponseHeaders(200, 0); // 0 = 分块传输，不声明长度
+            for (int i = 0; i < 8; i++) exchange.getResponseBody().write(chunk);
+            exchange.close();
+        });
+        site.createContext("/slow", exchange -> {
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+        });
         site.start();
         siteUrl = "http://127.0.0.1:" + site.getAddress().getPort() + "/a";
+        bigUrl = "http://127.0.0.1:" + site.getAddress().getPort() + "/big";
+        chunkedUrl = "http://127.0.0.1:" + site.getAddress().getPort() + "/chunked";
+        slowUrl = "http://127.0.0.1:" + site.getAddress().getPort() + "/slow";
         controller = new BrowserProxyController();
         ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "");
     }
@@ -52,6 +81,54 @@ class BrowserProxyControllerTest {
     @AfterEach
     void tearDown() {
         if (site != null) site.stop(0);
+    }
+
+    /**
+     * 注入的点击拦截脚本把 iframe 里所有同标签页链接点击都改道这个端点，
+     * 大文件下载链接也不例外；上游响应此前全量进堆（ofByteArray），没有任何体积闸。
+     * 后端是所有用户共用的一个 JVM，一次几百 MB 的下载就能把堆顶起来。
+     */
+    @Test
+    void oversizedResponseIsRejectedInsteadOfBuffered() {
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "127.0.0.1");
+        ReflectionTestUtils.setField(controller, "maxBytes", 64L * 1024);
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE,
+                controller.proxy(bigUrl, "tok").getStatusCode(),
+                "超过上限必须直接拒绝，而不是先全量读进内存");
+    }
+
+    /** 分块传输不声明 Content-Length，早退闸看不见它，只能靠边读边数。 */
+    @Test
+    void chunkedOversizedResponseIsAlsoRejected() {
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "127.0.0.1");
+        ReflectionTestUtils.setField(controller, "maxBytes", 64L * 1024);
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE,
+                controller.proxy(chunkedUrl, "tok").getStatusCode(),
+                "没有 Content-Length 也必须能停手");
+    }
+
+    /**
+     * 此前只有每跳 20 秒的超时，5 跳能让一个请求占住工作线程近 150 秒。
+     * 这里把总预算压到 1 秒，目标站睡 3 秒，断言在预算内就收手。
+     */
+    @Test
+    void slowTargetHitsTheOverallDeadline() {
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "127.0.0.1");
+        ReflectionTestUtils.setField(controller, "deadlineSeconds", 1L);
+        long started = System.nanoTime();
+        HttpStatus status = (HttpStatus) controller.proxy(slowUrl, "tok").getStatusCode();
+        long elapsedMs = (System.nanoTime() - started) / 1_000_000;
+        assertTrue(elapsedMs < 2500, "必须在总预算内收手，实际耗时 " + elapsedMs + "ms");
+        assertTrue(status == HttpStatus.GATEWAY_TIMEOUT || status == HttpStatus.BAD_GATEWAY,
+                "超时要如实报出来，实际是 " + status);
+    }
+
+    @Test
+    void normalSizedResponseStillPassesThrough() {
+        ReflectionTestUtils.setField(controller, "e2eAllowedHosts", "127.0.0.1");
+        ReflectionTestUtils.setField(controller, "maxBytes", 64L * 1024);
+        assertEquals(HttpStatus.OK, controller.proxy(siteUrl, "tok").getStatusCode(),
+                "护栏：别把正常页面一起拦掉");
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/controller/CloudControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/CloudControllerTest.java
@@ -391,4 +391,67 @@ class CloudControllerTest {
         assertEquals(1, response.getBody().get("code"));
         assertEquals("请先把这份案卷放进团队案件库", response.getBody().get("message"));
     }
+
+    // ---- 请求体缺字段：要报「参数不对」，不是 NPE / ClassCastException ----
+
+    /**
+     * 这几个端点直接把 body 里的值往下传或强转：
+     * connect 把 null 交给 {@code serverUrl.replaceAll(...)} 与 {@code Map.of(...)}（Map.of 不收 null），
+     * accept/share 是 {@code ((Number) body.get("connectionId")).longValue()}。
+     * 缺字段就 NPE、传字符串就 ClassCastException，用户看到的是「服务器内部错误」，
+     * 而真正的原因是请求少写了一个字段——两头都不知道该改什么。
+     */
+    @Test
+    void connectRejectsMissingFieldsWithUserFacingError() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(USER_ID);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.connect(Map.of("serverUrl", "https://x"), "s"),
+                    "缺 username/password 要明确报出来");
+            verify(cloudSyncService, never()).connect(any(), any(), any(), any(), any());
+        }
+    }
+
+    @Test
+    void acceptRejectsMissingOrNonNumericIds() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(USER_ID);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.accept(Map.of("remoteProjectId", 3), "s"), "缺 connectionId");
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.accept(Map.of("connectionId", "abc", "remoteProjectId", 3), "s"),
+                    "connectionId 不是数字");
+            verify(cloudSyncService, never()).cloneFromCloud(anyLong(), anyLong(), anyLong());
+        }
+    }
+
+    @Test
+    void shareRejectsMissingConnectionId() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(USER_ID);
+            when(projectMemberService.hasReadPermission(PROJECT_ID, USER_ID)).thenReturn(true);
+            when(projectMemberService.isClient(PROJECT_ID, USER_ID)).thenReturn(false);
+            when(projectMemberService.hasWritePermission(PROJECT_ID, USER_ID)).thenReturn(true);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.share(PROJECT_ID, Map.of(), "s"));
+            verify(cloudSyncService, never()).shareToCloud(anyLong(), anyLong(), anyLong());
+        }
+    }
+
+    @Test
+    void addMemberRejectsMissingUsername() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(USER_ID);
+            when(projectMemberService.hasReadPermission(PROJECT_ID, USER_ID)).thenReturn(true);
+            when(projectMemberService.isClient(PROJECT_ID, USER_ID)).thenReturn(false);
+            when(projectMemberService.hasWritePermission(PROJECT_ID, USER_ID)).thenReturn(true);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.addMember(PROJECT_ID, Map.of("role", "PARTICIPANT"), "s"));
+            verify(cloudSyncService, never()).proxyMembers(anyLong(), any(), any());
+        }
+    }
 }

--- a/backend/src/test/java/com/checkba/repository/ProjectInvitationLookupTest.java
+++ b/backend/src/test/java/com/checkba/repository/ProjectInvitationLookupTest.java
@@ -1,0 +1,73 @@
+package com.checkba.repository;
+
+import com.checkba.model.entity.ProjectInvitation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * 通用访问码的查找不能因为存在重复行而永久 500。
+ *
+ * <p>病灶：{@code inviteClient} 是先查后建（查空就新建一行 CLIENT_GENERIC），
+ * 而 (project_id, type) 上没有任何唯一约束——两个并发的「生成访问码」请求会各插一行。
+ * 之后每一次 findByProjectIdAndType 都走 getSingleResult，抛
+ * IncorrectResultSizeDataAccessException：这个项目的邀请链接功能从此永久 500，
+ * 没有重试也没有自愈，只能有人手工去库里删行。
+ *
+ * <p>注意 (project_id, type) 本身**不能**加唯一约束：CLIENT_NAMED 天然一个项目多行。
+ * 所以修法是让查找取「最早的那一行」而不是要求唯一。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:invitation-lookup-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class ProjectInvitationLookupTest {
+
+    @Autowired
+    private ProjectInvitationRepository repository;
+
+    private ProjectInvitation row(Long projectId, String type, String code, Long relatedUserId) {
+        ProjectInvitation i = new ProjectInvitation();
+        i.setProjectId(projectId);
+        i.setType(type);
+        i.setAccessCode(code);
+        i.setRelatedUserId(relatedUserId);
+        return i;
+    }
+
+    @Test
+    @DisplayName("同项目出现两行通用码时，查找取最早那一行而不是抛异常")
+    void duplicateGenericRowsDoNotBreakLookup() {
+        repository.saveAll(java.util.List.of(
+                row(1L, "CLIENT_GENERIC", "codeAAAAAAAAAAAAAAAA", 11L),
+                row(1L, "CLIENT_GENERIC", "codeBBBBBBBBBBBBBBBB", 12L)));
+        repository.flush();
+
+        // 今天这一句会抛 IncorrectResultSizeDataAccessException：
+        // 派生查询声明成 Optional 就走 getSingleResult，多于一行直接炸
+        assertDoesNotThrow(() -> repository.findByProjectIdAndType(1L, "CLIENT_GENERIC"),
+                "重复行不该让这个项目的邀请链接功能永久 500");
+    }
+
+    @Test
+    @DisplayName("具名邀请一个项目本来就可以有多行，不该被唯一约束挡住")
+    void namedInvitationsMayCoexist() {
+        assertDoesNotThrow(() -> {
+            repository.saveAll(java.util.List.of(
+                    row(2L, "CLIENT_NAMED", "codeCCCCCCCCCCCCCCCC", 21L),
+                    row(2L, "CLIENT_NAMED", "codeDDDDDDDDDDDDDDDD", 22L)));
+            repository.flush();
+        });
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ClientInvitationServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ClientInvitationServiceTest.java
@@ -1,0 +1,92 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectInvitation;
+import com.checkba.model.entity.ProjectMember;
+import com.checkba.model.entity.User;
+import com.checkba.repository.ProjectInvitationRepository;
+import com.checkba.repository.ProjectMemberRepository;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 客户访问码的两条路：具名邀请与通用码。
+ *
+ * <p>不变式：拿到访问码的人登录后必须真的能读到这个项目。项目访问权全靠
+ * project_member 行（{@code ProjectMemberService.hasReadPermission} 只认成员行或项目所有者），
+ * 所以签发访问码的那条路必须把影子用户加成成员，否则「登录成功」与「什么都打不开」并存。
+ */
+class ClientInvitationServiceTest {
+
+    private ProjectInvitationRepository invitationRepository;
+    private ProjectMemberRepository projectMemberRepository;
+    private UserRepository userRepository;
+    private ProjectMemberService projectMemberService;
+    private ClientInvitationService service;
+
+    private final AtomicLong userIds = new AtomicLong(100);
+
+    @BeforeEach
+    void setUp() {
+        invitationRepository = mock(ProjectInvitationRepository.class);
+        projectMemberRepository = mock(ProjectMemberRepository.class);
+        userRepository = mock(UserRepository.class);
+        projectMemberService = mock(ProjectMemberService.class);
+        when(projectMemberService.hasWritePermission(any(), any())).thenReturn(true);
+        when(invitationRepository.findByAccessCode(any())).thenReturn(Optional.empty());
+        when(invitationRepository.findByProjectIdAndType(any(), any())).thenReturn(List.of());
+        when(userRepository.save(any())).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            if (u.getId() == null) u.setId(userIds.incrementAndGet());
+            return u;
+        });
+        when(invitationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        service = new ClientInvitationService(invitationRepository, projectMemberRepository,
+                userRepository, projectMemberService);
+    }
+
+    private List<ProjectMember> savedMembers() {
+        ArgumentCaptor<ProjectMember> captor = ArgumentCaptor.forClass(ProjectMember.class);
+        verify(projectMemberRepository, atLeastOnce()).save(captor.capture());
+        return captor.getAllValues();
+    }
+
+    @Test
+    @DisplayName("具名邀请：影子用户当场加成 CLIENT 成员（既有行为，护栏）")
+    void namedInviteAddsMember() {
+        service.inviteClient(1L, 7L, "张三");
+        List<ProjectMember> members = savedMembers();
+        assertEquals(1, members.size());
+        assertEquals("CLIENT", members.get(0).getRole());
+        assertEquals(1L, members.get(0).getProjectId());
+    }
+
+    /**
+     * 通用码这条路只建了影子用户和 invitation 行，从没建过成员行；
+     * 而前端的客户登录恒传 displayName=null，走的正是「登录成 relatedUserId 那个影子用户」这一支，
+     * 也不建成员行。于是律师把码发出去，客户登录提示成功、页面跳进工作台，
+     * 之后每一个文件接口都回 403——「登录成功」与「什么都打不开」并存。
+     */
+    @Test
+    @DisplayName("通用码：影子用户同样要加成成员，否则持码人登录后什么都读不到")
+    void genericInviteAddsMemberToo() {
+        service.inviteClient(1L, 7L, null);
+        List<ProjectMember> members = savedMembers();
+        assertTrue(members.stream().anyMatch(m -> "CLIENT".equals(m.getRole()) && m.getProjectId() == 1L),
+                "通用码的影子用户没有成员行，持码人拿不到任何项目权限");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 /**
@@ -59,5 +62,24 @@ class ProjectFileServiceIdorTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> projectFileService.batchMove(1L, req, 1L));
+    }
+
+    /**
+     * 缓存区免费额度此前只挂在 batchMove 上，单文件 move 这条同样能移进缓存区的路径
+     * 一个字节都不查——免费用户一次拖一个就能无限往里塞，付费闸形同虚设。
+     */
+    @Test
+    void singleMoveIntoStagingIsQuotaChecked() {
+        ProjectFile own = new ProjectFile();
+        own.setId(42L);
+        own.setProjectId(1L);
+        own.setIsFolder(false);
+        own.setName("a.docx");
+        when(projectFileRepository.findById(42L)).thenReturn(Optional.of(own));
+        doThrow(new com.checkba.exception.StageQuotaExceededException("超额", 20, 0, 20, 1L))
+                .when(stageQuotaService).checkAdmission(eq(9L), anyList());
+
+        assertThrows(com.checkba.exception.StageQuotaExceededException.class,
+                () -> projectFileService.move(42L, 9L, null, 1L));
     }
 }

--- a/backend/src/test/java/com/checkba/service/TtsServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/TtsServiceTest.java
@@ -3,6 +3,8 @@ package com.checkba.service;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * TTS local provider（Phase 3）：rate → Kokoro speed 的容错解析。
@@ -38,5 +40,28 @@ class TtsServiceTest {
         assertEquals(1.0, TtsService.parseSpeed("+30%"), 1e-9);
         // 前端现在发的是倍率串，这才是会真正生效的那一种
         assertEquals(1.3, TtsService.parseSpeed("1.3"), 1e-9);
+    }
+
+    /**
+     * 读超时不是「组件没装」。RestTemplate 把连接被拒与读超时裹成同一个
+     * ResourceAccessException，此前一律报成「请去组件管理下载语音组件」——
+     * 组件明明在跑，用户被支去重装一个和故障无关的东西。
+     */
+    @Test
+    void readTimeoutIsNotMistakenForMissingComponent() {
+        org.springframework.web.client.ResourceAccessException readTimeout =
+                new org.springframework.web.client.ResourceAccessException(
+                        "I/O error", new java.net.SocketTimeoutException("Read timed out"));
+        assertFalse(TtsService.isServiceUnreachable(readTimeout), "读超时说明服务在跑，不该判成未就绪");
+
+        org.springframework.web.client.ResourceAccessException refused =
+                new org.springframework.web.client.ResourceAccessException(
+                        "I/O error", new java.net.ConnectException("Connection refused"));
+        assertTrue(TtsService.isServiceUnreachable(refused), "连接被拒才是组件没起");
+
+        // 认不出来的原因保持旧行为
+        assertTrue(TtsService.isServiceUnreachable(
+                new org.springframework.web.client.ResourceAccessException(
+                        "I/O error", new java.io.IOException("broken pipe"))));
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorNoOpFileChangeTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorNoOpFileChangeTest.java
@@ -1,0 +1,218 @@
+package com.checkba.service.ai;
+
+import com.checkba.config.AiContextProperties;
+import com.checkba.config.AiFailoverProperties;
+import com.checkba.controller.ai.AiAgentController;
+import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.service.ProjectAiMessageService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.RunLoopCompactor;
+import com.checkba.service.ai.memory.MemoryPipelineService;
+import com.checkba.service.ai.skill.SkillRouter;
+import com.checkba.service.ai.tools.ToolMeta;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 「工具执行成功」不等于「文件被改过」。
+ *
+ * <p>病灶：{@code @ToolMeta(fileEffect="MODIFIED")} 是写死的常量，编排器的
+ * applyToolSideEffects 只看 success()，于是 text_find_replace 一次都没命中、
+ * 明确返回「文件未改动」时，照样发一条 file_change(MODIFIED) 并写进会话的
+ * 文件变更历史——用户被告知「本轮改了这个文件」，去找却找不到任何改动。
+ */
+class AgentOrchestratorNoOpFileChangeTest {
+
+    private static final String MODEL = "qwen/qwen3.7-flash";
+
+    private ChatModelFactory chatModelFactory;
+    private SseEmitterService sse;
+    private AgentRunStateService runState;
+    private ProjectAiMessageService messageService;
+    private ToolRegistry toolRegistry;
+    private TodoListService todoListService;
+    private List<String> sseEvents;
+    private List<String> sseData;
+    private AgentOrchestrator orchestrator;
+
+    /** 按脚本逐轮吐内容的模型，同时留下最后一轮收到的完整消息栈 */
+    private static final class ScriptModel implements StreamingChatLanguageModel {
+        private final List<AiMessage> script;
+        final AtomicInteger calls = new AtomicInteger();
+        volatile List<ChatMessage> lastMessages = List.of();
+
+        ScriptModel(List<AiMessage> script) {
+            this.script = script;
+        }
+
+        @Override
+        public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+            lastMessages = new ArrayList<>(messages);
+            int idx = calls.getAndIncrement();
+            AiMessage msg = script.get(Math.min(idx, script.size() - 1));
+            if (msg.text() != null && !msg.text().isEmpty()) {
+                handler.onNext(msg.text());
+            }
+            handler.onComplete(Response.from(msg));
+        }
+
+        @Override
+        public void generate(List<ChatMessage> messages, List<ToolSpecification> tools,
+                             StreamingResponseHandler<AiMessage> handler) {
+            generate(messages, handler);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        chatModelFactory = mock(ChatModelFactory.class);
+        sseEvents = new CopyOnWriteArrayList<>();
+        sseData = new CopyOnWriteArrayList<>();
+        sse = mock(SseEmitterService.class);
+        doAnswer(inv -> {
+            sseEvents.add(inv.getArgument(1));
+            sseData.add(String.valueOf((Object) inv.getArgument(2)));
+            return null;
+        }).when(sse).send(any(), any(), any());
+
+        messageService = mock(ProjectAiMessageService.class);
+        when(messageService.listByConversationId(any()))
+                .thenReturn(List.of(mock(ProjectAiMessage.class), mock(ProjectAiMessage.class)));
+        when(messageService.upsertAssistantMessage(any(), any(), any(), any(), any())).thenReturn(1L);
+
+        ContextAssemblerService assembler = mock(ContextAssemblerService.class);
+        when(assembler.assemble(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenAnswer(inv -> new ArrayList<ChatMessage>(List.of(
+                        SystemMessage.from("system"), UserMessage.from("读一下这份合同"))));
+
+        toolRegistry = mock(ToolRegistry.class);
+        when(toolRegistry.getAllSpecifications(any())).thenReturn(List.of());
+        when(toolRegistry.resolve(anyString())).thenReturn(java.util.Optional.empty());
+
+        SkillRouter skillRouter = mock(SkillRouter.class);
+        when(skillRouter.visibleTools(any(), any())).thenAnswer(inv -> inv.getArgument(1));
+        when(skillRouter.activeSkill(any())).thenReturn(java.util.Optional.empty());
+        XmlToolCallParser parser = mock(XmlToolCallParser.class);
+        when(parser.containsToolCall(any())).thenReturn(false);
+
+        todoListService = mock(TodoListService.class);
+        AiContextProperties contextProperties = new AiContextProperties();
+        runState = new AgentRunStateService(
+                mock(com.checkba.repository.AgentRunRecordRepository.class),
+                mock(com.checkba.service.telemetry.TelemetryTurnTracker.class));
+        orchestrator = new AgentOrchestrator(
+                chatModelFactory, messageService, sse, mock(TokenUsageService.class), assembler,
+                toolRegistry, skillRouter, parser, mock(MemoryPipelineService.class),
+                mock(ProjectFileService.class), mock(EditorBridgeService.class),
+                mock(ConversationFileChangeService.class), todoListService,
+                mock(DocumentCheckpointService.class), runState,
+                mock(com.checkba.version.WorkSessionService.class), new AiFailoverProperties(),
+                new RunLoopCompactor(contextProperties, new ContextCompressor(null, null, contextProperties)),
+                mock(com.checkba.service.telemetry.TelemetryService.class),
+                mock(com.checkba.service.telemetry.TelemetryTurnTracker.class),
+                mock(com.checkba.service.telemetry.MatterClassifierService.class));
+    }
+
+    private ScriptModel run(String conversationId, AiMessage... script) {
+        ScriptModel model = new ScriptModel(List.of(script));
+        when(chatModelFactory.getStreamingChatModel(MODEL)).thenReturn(model);
+        AiAgentController.AgentChatRequest request = new AiAgentController.AgentChatRequest();
+        request.setProjectId(1L);
+        request.setConversationId(conversationId);
+        request.setMessage("读一下这份合同");
+        request.setModel(MODEL);
+        orchestrator.handleUserMessage(request, 7L);
+        return model;
+    }
+
+    private static AiMessage readDocumentCall() {
+        return AiMessage.from(List.of(ToolExecutionRequest.builder()
+                .id("t1").name("read_document").arguments("{\"fileId\":\"12\"}").build()));
+    }
+
+    private String bubbleEndData() {
+        for (int i = 0; i < sseEvents.size(); i++) {
+            if ("bubble_end".equals(sseEvents.get(i))) return sseData.get(i);
+        }
+        return null;
+    }
+
+    private String eventData(String event) {
+        for (int i = 0; i < sseEvents.size(); i++) {
+            if (event.equals(sseEvents.get(i))) return sseData.get(i);
+        }
+        return null;
+    }
+
+    @ToolMeta(displayName = "文本查找替换", category = "file", fileEffect = "MODIFIED")
+    public void fakeTextFindReplace() {
+    }
+
+    private ToolRegistry.RegisteredTool fileEffectTool() throws Exception {
+        java.lang.reflect.Method m = getClass().getDeclaredMethod("fakeTextFindReplace");
+        return new ToolRegistry.RegisteredTool(this, m,
+                ToolSpecification.builder().name("text_find_replace").build(),
+                m.getAnnotation(ToolMeta.class), false);
+    }
+
+    private static AiMessage findReplaceCall() {
+        return AiMessage.from(List.of(ToolExecutionRequest.builder()
+                .id("t1").name("text_find_replace")
+                .arguments("{\"fileId\":\"12\",\"find\":\"甲方\",\"replace\":\"乙方\"}").build()));
+    }
+
+    @Test
+    @DisplayName("一次都没命中：不许发 file_change 声称文件被改过")
+    void noOpReplaceMustNotClaimTheFileChanged() throws Exception {
+        when(toolRegistry.execute(any(), any(), any())).thenReturn(new ToolRegistry.ToolResult(
+                com.checkba.service.ai.tools.TextFileEditTools.noHitMessage("甲方", 1200),
+                fileEffectTool(), true));
+
+        run("conv-noop", findReplaceCall(), AiMessage.from("<final>没找到这段文字。</final>"));
+
+        assertFalse(sseEvents.contains("file_change"),
+                "什么都没改却报「已修改」，用户会去找一个不存在的改动：" + sseEvents);
+    }
+
+    @Test
+    @DisplayName("真的替换成功时 file_change 照发（护栏：别把正常通知一起关掉）")
+    void realReplaceStillNotifies() throws Exception {
+        when(toolRegistry.execute(any(), any(), any())).thenReturn(new ToolRegistry.ToolResult(
+                "已在 a.txt 中替换 3 处（命中 3 处）。改动已进入版本记录。",
+                fileEffectTool(), true));
+
+        run("conv-real", findReplaceCall(), AiMessage.from("<final>已替换。</final>"));
+
+        assertTrue(sseEvents.contains("file_change"), "真改了就得通知：" + sseEvents);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/AgentStreamJsonEscapeTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentStreamJsonEscapeTest.java
@@ -1,0 +1,55 @@
+package com.checkba.service.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * SSE 载荷是手工拼的 JSON 字符串，转义漏一个字符，整条事件就在浏览器里 JSON.parse 失败。
+ *
+ * <p>病灶：escapeJson 只处理 {@code \ " \n \r}，而 JSON 规范要求 U+0000..U+001F
+ * 全部转义。模型正文里带一个真制表符（写 Makefile / Go / 缩进代码块时是常态）就会
+ * 生成非法 JSON：前端 useAgentStream 的 text_delta 分支 parse 失败后回落
+ * {@code processTextStream(dataStr)}，把整段 {"content":"..."} 信封当正文渲染给用户看；
+ * artifact 分支则整条事件被丢弃（气泡永远卡在加载态）。
+ */
+class AgentStreamJsonEscapeTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private String envelope(String raw) {
+        return "{\"content\":\"" + AgentStreamHandler.escapeJson(raw) + "\"}";
+    }
+
+    @Test
+    @DisplayName("正文里的制表符必须转义，否则 text_delta 载荷不是合法 JSON")
+    void tabInModelOutputStaysParseable() throws Exception {
+        String raw = "func main() {\n\tprintln(1)\n}";
+        String payload = envelope(raw);
+        assertEquals(raw, mapper.readTree(payload).get("content").asText());
+    }
+
+    @Test
+    @DisplayName("U+0000..U+001F 全区间都要转义（JSON 规范要求）")
+    void allControlCharactersAreEscaped() {
+        for (char c = 0; c < 0x20; c++) {
+            String raw = "a" + c + "b";
+            String payload = envelope(raw);
+            final char probe = c;
+            assertDoesNotThrow(() -> {
+                assertEquals(raw, mapper.readTree(payload).get("content").asText(),
+                        "U+" + String.format("%04X", (int) probe) + " 未被正确转义");
+            }, "U+" + String.format("%04X", (int) probe) + " 让载荷变成非法 JSON: " + payload);
+        }
+    }
+
+    @Test
+    @DisplayName("既有的反斜杠/引号/换行转义不能被改坏")
+    void existingEscapesStillWork() throws Exception {
+        String raw = "他说\"C:\\tmp\"\r\n第二行";
+        assertEquals(raw, mapper.readTree(envelope(raw)).get("content").asText());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/EditorBridgeConversationBindingTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/EditorBridgeConversationBindingTest.java
@@ -1,0 +1,73 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+/**
+ * 编辑器结果回传的鉴权键必须是「这个 requestId 属于哪个会话」，
+ * 而不是调用方自己报的 conversationId。
+ *
+ * <p>病灶：pendingRequests 只按 requestId 存 future，完全不记会话；
+ * 而控制器校验的是 payload 里客户端自报的 conversationId（只要是他自己的会话就放行）。
+ * 两把钥匙不是同一把——拿到别的会话的 requestId 就能把伪造内容作为工具结果
+ * 塞进那一轮的 Agent 循环，而结果会被当成可信的文档内容驱动后续改文档动作。
+ */
+class EditorBridgeConversationBindingTest {
+
+    private EditorBridgeService bridge() {
+        return new EditorBridgeService(
+                mock(SseEmitterService.class),
+                new com.fasterxml.jackson.databind.ObjectMapper(),
+                mock(com.checkba.service.telemetry.TelemetryService.class));
+    }
+
+    /** 起一轮编辑器命令并把它的 requestId 捞出来（SSE 载荷里带着）。 */
+    private String startCommandAndCaptureRequestId(EditorBridgeService svc, String conversationId,
+                                                   SseEmitterService sse, ExecutorService pool) throws Exception {
+        java.util.concurrent.BlockingQueue<String> payloads = new java.util.concurrent.LinkedBlockingQueue<>();
+        org.mockito.Mockito.doAnswer(inv -> {
+            payloads.add(String.valueOf((Object) inv.getArgument(2)));
+            return null;
+        }).when(sse).send(any(), any(), any());
+
+        pool.submit(() -> {
+            svc.setCurrentConversationId(conversationId);
+            svc.executeEditorCommand("get_selection", Map.of());
+        });
+        String payload = payloads.poll(5, TimeUnit.SECONDS);
+        assertTrue(payload != null && payload.contains("requestId"), "没抓到 client_action 载荷: " + payload);
+        return new com.fasterxml.jackson.databind.ObjectMapper().readTree(payload).get("requestId").asText();
+    }
+
+    @Test
+    @DisplayName("别的会话回传同一个 requestId 必须被拒；本会话回传照常兑现")
+    void resultsAreBoundToTheIssuingConversation() throws Exception {
+        SseEmitterService sse = mock(SseEmitterService.class);
+        EditorBridgeService svc = new EditorBridgeService(sse,
+                new com.fasterxml.jackson.databind.ObjectMapper(),
+                mock(com.checkba.service.telemetry.TelemetryService.class));
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            String requestId = startCommandAndCaptureRequestId(svc, "conv-A", sse, pool);
+
+            assertFalse(svc.completeEditorAction(requestId, "conv-B", true, Map.of("text", "伪造"), null),
+                    "requestId 属于 conv-A，conv-B 不该能兑现它");
+            assertTrue(svc.completeEditorAction(requestId, "conv-A", true, Map.of("text", "真结果"), null),
+                    "本会话回传要照常生效");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/XmlToolCallParserTest.java
@@ -109,6 +109,25 @@ class XmlToolCallParserTest {
         assertEquals("乙方", args.getStr("replaceText"));
     }
 
+    /**
+     * 参数值里出现一对 {@code ({ ... })} 是常态（正文里引用代码、字典字面量、
+     * 甚至一句「helper({k: 1})」）。此前 tryExtractJsonObjectArgs 用
+     * indexOf("({") / lastIndexOf("})") 在整段文本里找，命中即把中间那段当成
+     * 整体参数对象返回，真正的命名参数全部丢失——工具拿到一组凭空捏造的参数
+     * 却照常执行，而且不报错。
+     */
+    @Test
+    @DisplayName("参数值里的 ({...}) 不得被当成 JSON 风格整体参数")
+    void codeLikeArgumentIsNotMistakenForJsonStyleCall() {
+        XmlToolCallParser.ParsedCall call = single(
+                "<tool_code>doc_find_replace(findText=\"甲方\", replaceText=\"见 helper({k: 1}) 的返回\")</tool_code>");
+        assertEquals("doc_find_replace", call.toolName());
+        cn.hutool.json.JSONObject args = cn.hutool.json.JSONUtil.parseObj(call.argsJson());
+        assertEquals("甲方", args.getStr("findText"), "真实参数不该被 ({...}) 顶掉: " + call.argsJson());
+        assertTrue(args.getStr("replaceText") != null && args.getStr("replaceText").contains("helper("),
+                "replaceText 应保留原文: " + call.argsJson());
+    }
+
     @Test
     @DisplayName("ctrl46 定界符 + 无括号写法（Gemini 兼容）")
     void parsesCtrl46Format() {

--- a/backend/src/test/java/com/checkba/service/ai/context/LegalInfoProtectorTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/context/LegalInfoProtectorTest.java
@@ -115,6 +115,34 @@ class LegalInfoProtectorTest {
                    result.getProtectedSegments().stream().anyMatch(s -> s.getContent().contains("《公司法》")));
     }
 
+    /**
+     * 重叠片段合并时 end 取了并集、content 却留着第一个片段的原文，于是
+     * [content 长度, end) 那一截在 safeCompress 里被静默跳过。
+     * 「人民币500万元」正好同时命中「人民币+数字」和「数字+万元」两条模式，
+     * 合并后剩下「人民币500」——一份法律文书里的金额从五百万变成五百，
+     * 全程没有任何报错。
+     */
+    @Test
+    @DisplayName("重叠片段合并后必须覆盖整段原文，不能吃掉中间的字")
+    void mergedSegmentsMustCoverTheWholeSpan() {
+        String content = "本次交易对价为人民币500万元，由甲方于交割日一次性支付。";
+        for (LegalInfoProtector.ProtectedSegment s : protector.markProtectedInfo(content)) {
+            assertEquals(content.substring(s.getStart(), s.getEnd()), s.getContent(),
+                    "片段 [" + s.getStart() + "," + s.getEnd() + ") 的正文与原文对不上");
+        }
+    }
+
+    @Test
+    @DisplayName("压缩不得把金额的单位吃掉（人民币500万元 -> 人民币500）")
+    void compressionKeepsTheAmountUnit() {
+        String filler = "以下为与本条无关的背景说明文字，用于把正文撑到需要压缩的长度。".repeat(20);
+        String content = "本次交易对价为人民币500万元，由甲方于交割日一次性支付。\n" + filler;
+        LegalInfoProtector.CompressedResult result =
+                protector.safeCompress(content, content.length() / 2);
+        assertTrue(result.getContent().contains("人民币500万元"),
+                "压缩后金额被截断：" + result.getContent());
+    }
+
     @Test
     @DisplayName("验证压缩结果应检测丢失的关键信息")
     void validateShouldDetectMissingCriticalInfo() {

--- a/backend/src/test/java/com/checkba/service/auth/VerificationCodeStoreTest.java
+++ b/backend/src/test/java/com/checkba/service/auth/VerificationCodeStoreTest.java
@@ -3,7 +3,16 @@ package com.checkba.service.auth;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -94,5 +103,87 @@ class VerificationCodeStoreTest {
         store.issue("login", "13800000000");
         assertFalse(store.verify("login", "13800000000", null));
         assertFalse(store.verify("login", "13800000000", "  "));
+    }
+
+    // ---- 并发：签发与核销必须对同一 key 互斥 ----
+
+    /**
+     * 可控时钟兼交会点：武装后，第一个读表的线程停在原地，别的线程照常拿到时间。
+     * 借它把「一个线程正停在临界区里」这件事做成确定性的，不靠 sleep 撞运气。
+     */
+    private static final class GateClock implements LongSupplier {
+        volatile boolean armed = false;
+        final CountDownLatch entered = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicInteger hits = new AtomicInteger();
+        private final long fixed = 1_000_000L;
+
+        @Override
+        public long getAsLong() {
+            if (armed && hits.incrementAndGet() == 1) {
+                entered.countDown();
+                try {
+                    release.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return fixed;
+        }
+    }
+
+    @Test
+    @DisplayName("并发核销互斥：一个线程在临界区里时另一个 verify 必须被挡住（否则 ++attempts 丢更新，5 次上限形同虚设）")
+    void verifyIsAtomicPerKey() throws Exception {
+        GateClock gate = new GateClock();
+        VerificationCodeStore s = new VerificationCodeStore(gate);
+        String code = s.issue("login", "13800000000");
+        gate.armed = true;
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> first = pool.submit(() -> s.verify("login", "13800000000", "000000"));
+            assertTrue(gate.entered.await(5, TimeUnit.SECONDS), "第一个 verify 应当进入临界区");
+
+            Future<Boolean> second = pool.submit(() -> s.verify("login", "13800000000", "111111"));
+            assertThrows(TimeoutException.class, () -> second.get(600, TimeUnit.MILLISECONDS),
+                    "同一 key 的 verify 必须互斥：读计数与写回计数之间放行第二个线程就会丢更新");
+
+            gate.release.countDown();
+            assertFalse(first.get(5, TimeUnit.SECONDS));
+            assertFalse(second.get(5, TimeUnit.SECONDS));
+            // 两次错都必须真的记上
+            assertNotEquals(code, "000000");
+            assertEquals(2, s.attemptsForTest("login", "13800000000"));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("并发签发互斥：同一 key 两个线程同时进来，第二个必须撞上冷却而不是也发一条")
+    void issueIsAtomicPerKey() throws Exception {
+        GateClock gate = new GateClock();
+        VerificationCodeStore s = new VerificationCodeStore(gate);
+        gate.armed = true;
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<String> first = pool.submit(() -> s.issue("login", "13800000000"));
+            assertTrue(gate.entered.await(5, TimeUnit.SECONDS), "第一个 issue 应当进入临界区");
+
+            Future<String> second = pool.submit(() -> s.issue("login", "13800000000"));
+            assertThrows(TimeoutException.class, () -> second.get(600, TimeUnit.MILLISECONDS),
+                    "同一 key 的签发必须互斥：查冷却与写新码之间放行第二个线程，两条码就会一起发出去");
+
+            gate.release.countDown();
+            assertNotNull(first.get(5, TimeUnit.SECONDS));
+            ExecutionException boom = assertThrows(ExecutionException.class, () -> second.get(5, TimeUnit.SECONDS));
+            assertTrue(boom.getCause().getMessage().contains("频繁"), "第二个线程应被冷却挡下");
+            // 冷却挡下的那次不该算进当日条数
+            assertEquals(1, s.dailySendsForTest("13800000000"));
+        } finally {
+            pool.shutdownNow();
+        }
     }
 }

--- a/backend/src/test/java/com/checkba/service/feedback/FeedbackCloudInboxTest.java
+++ b/backend/src/test/java/com/checkba/service/feedback/FeedbackCloudInboxTest.java
@@ -182,7 +182,7 @@ class FeedbackCloudInboxTest {
             assertEquals("https://cloud/api/feedback/ingest", url);
             assertTrue(ct.startsWith("multipart/form-data; boundary="));
             body.append(new String(bytes, StandardCharsets.UTF_8));
-            return 200;
+            return ok();
         }, true, "https://cloud/api/feedback/ingest");
 
         up.flush();
@@ -199,9 +199,26 @@ class FeedbackCloudInboxTest {
         UserFeedback row = localRow(9L, "x");
         when(repo.findByUploadedFalseAndSourceOrderByIdAsc(eqLocal(), any(Pageable.class)))
                 .thenReturn(List.of(row));
-        uploader((url, ct, bytes) -> 429, true, "https://cloud/api/feedback/ingest").flush();
+        uploader((url, ct, bytes) -> resp(429, ""), true, "https://cloud/api/feedback/ingest").flush();
         // 429 标成已上传等于这条永远消失
         assertFalse(row.isUploaded());
+    }
+
+    /**
+     * 收件端对业务失败也回 HTTP 200 + {"code":1}（controller 里好几处
+     * ResponseEntity.ok(error(...)) 都是这个形状，例如附件读不到导致正文与附件全空时的
+     * 「空反馈」）。上传侧只看状态码，于是把「云端拒收」读成「已收下」，
+     * markUploaded 永久置位——这条反馈既不会重传，也永远进不了优化者的待办队列，
+     * 而用户自己的「我的反馈」里显示已送达。
+     */
+    @Test
+    void businessErrorEnvelopeIsNotTreatedAsDelivered() {
+        UserFeedback row = localRow(9L, "x");
+        when(repo.findByUploadedFalseAndSourceOrderByIdAsc(eqLocal(), any(Pageable.class)))
+                .thenReturn(List.of(row));
+        uploader((url, ct, bytes) -> resp(200, "{\"code\":1,\"message\":\"空反馈\"}"),
+                true, "https://cloud/api/feedback/ingest").flush();
+        assertFalse(row.isUploaded(), "云端明说没收下，不能标成已上传");
     }
 
     @Test
@@ -209,7 +226,7 @@ class FeedbackCloudInboxTest {
         UserFeedback row = localRow(9L, "x");
         when(repo.findByUploadedFalseAndSourceOrderByIdAsc(eqLocal(), any(Pageable.class)))
                 .thenReturn(List.of(row));
-        uploader((url, ct, bytes) -> 500, true, "https://cloud/api/feedback/ingest").flush();
+        uploader((url, ct, bytes) -> resp(500, ""), true, "https://cloud/api/feedback/ingest").flush();
         assertFalse(row.isUploaded());
     }
 
@@ -229,7 +246,7 @@ class FeedbackCloudInboxTest {
     void uploadIsInertWithoutUrl() {
         FeedbackUploadService up = uploader((url, ct, bytes) -> {
             fail("没配地址不该发请求");
-            return 200;
+            return ok();
         }, true, "");
         assertFalse(up.isConfigured());
         assertDoesNotThrow(up::flush);
@@ -240,10 +257,19 @@ class FeedbackCloudInboxTest {
     void disabledUploadStaysLocal() {
         FeedbackUploadService up = uploader((url, ct, bytes) -> {
             fail("关掉了还发就是漏数据");
-            return 200;
+            return ok();
         }, false, "https://cloud/api/feedback/ingest");
         assertFalse(up.isConfigured());
         assertDoesNotThrow(up::flush);
+    }
+
+    private static FeedbackUploadService.Transport.Response resp(int status, String body) {
+        return new FeedbackUploadService.Transport.Response(status, body);
+    }
+
+    /** 收件端成功时的信封。 */
+    private static FeedbackUploadService.Transport.Response ok() {
+        return resp(200, "{\"code\":0,\"data\":{\"id\":1}}");
     }
 
     private static String eqLocal() {

--- a/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
@@ -369,6 +369,67 @@ class NativePackServiceTest {
     }
 
     @Test
+    @DisplayName("被封禁的 pack 重装时不得把封禁位抹掉——平台仍在封时拒装")
+    void reinstallDoesNotResurrectRevokedPack() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        primary.files.put("/revoked", ("[{\"id\":\"" + PACK_ID + "\",\"version\":\"*\",\"reason\":\"test\"}]")
+                .getBytes(StandardCharsets.UTF_8));
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        assertEquals(List.of(PACK_ID), svc.syncRevoked());
+        assertFalse(svc.isReady(PACK_ID));
+
+        // 重启后的自动补下载 / 用户再点一次「安装」都会走到这里：
+        // 目标版本已完整落盘，幂等分支只重写指针——绝不能顺手把 revoked 写回 false
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> svc.install(PACK_ID));
+        assertTrue(e.getMessage().contains("封禁") || e.getMessage().toLowerCase().contains("revoked"), e.getMessage());
+        assertFalse(svc.isReady(PACK_ID), "平台仍在封禁，重装后资源不该重新可见");
+        assertTrue(svc.componentDir(PACK_ID, "litviz").isEmpty());
+        // 拒装不是「安装失败」：状态要如实停在 revoked，否则用户只会一遍遍重试
+        assertEquals(NativePackService.STATE_REVOKED, svc.status(PACK_ID).getState());
+    }
+
+    @Test
+    @DisplayName("平台撤销封禁后，重装可正常复活")
+    void reinstallClearsRevokedFlagOncePlatformLiftsIt() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        primary.files.put("/revoked", ("[{\"id\":\"" + PACK_ID + "\",\"version\":\"*\",\"reason\":\"test\"}]")
+                .getBytes(StandardCharsets.UTF_8));
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        svc.syncRevoked();
+        assertFalse(svc.isReady(PACK_ID));
+
+        // 平台把它从封禁表里撤了
+        primary.files.put("/revoked", "[]".getBytes(StandardCharsets.UTF_8));
+        assertEquals(VERSION, svc.install(PACK_ID));
+        assertTrue(svc.isReady(PACK_ID));
+        assertEquals(NativePackService.STATE_READY, svc.status(PACK_ID).getState());
+    }
+
+    @Test
+    @DisplayName("封禁表拉不到时，被封禁的 pack 维持封禁（宁可装不上也不无声复活）")
+    void reinstallRefusesWhenRevocationListUnreachable() throws Exception {
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        primary.files.put("/revoked", ("[{\"id\":\"" + PACK_ID + "\",\"version\":\"*\",\"reason\":\"test\"}]")
+                .getBytes(StandardCharsets.UTF_8));
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID);
+        svc.syncRevoked();
+
+        // 端点没了（未部署 / 网络不通）
+        primary.files.remove("/revoked");
+        assertThrows(IllegalStateException.class, () -> svc.install(PACK_ID));
+        assertFalse(svc.isReady(PACK_ID));
+    }
+
+    @Test
     @DisplayName("封禁端点 404 时静默跳过，不影响已装 pack")
     void revocationEndpointMissingIsSilent() throws Exception {
         byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION
四条，每条先写测试看它红、改实现看它绿、再把实现还原确认测试真会红。

1. [HIGH] 网页代理把整个上游响应全量读进堆，没有任何体积上限
   BrowserProxyController 用 ofByteArray() 全量materialize，HTML 分支还要再复制成
   String 再拼接注入串。而注入的点击拦截脚本把 iframe 里**所有**同标签页链接点击
   都改道这个端点，普通的大文件下载链接也不例外——用户在网页面板里点一下几百 MB 的
   附件，就能把所有人共用的这个 JVM 的堆顶起来。
   改成流式接收：先看 Content-Length 早退，没声明长度（分块传输）就边读边数，
   超限即停手回 413，堆里最多多出 maxBytes+1 字节。上限走配置
   security.browser-proxy.max-bytes，默认 50MB。
   顺带修掉同文件的另一条：跳满 5 次重定向后，此前会把最后那个 3xx 的正文当内容
   原样回给前端，改成明确报「重定向次数过多」。

2. [MEDIUM] 同上，单次代理能占住一条工作线程近 150 秒
   此前只有每跳 20 秒的超时，5 跳串起来就是 150 秒。慢速目标站几个并发就能把
   Tomcat 线程池吃干净，整个后端跟着卡——而用户只是在面板里点了个链接。
   加一条总预算（security.browser-proxy.deadline-seconds，默认 30），
   单跳超时取「剩余预算」与 20 秒的较小值。
   测试把预算压到 1 秒、目标站睡 3 秒：修前实测 3013ms，修后在预算内收手。

3. [MEDIUM/LOW] /api/cloud/* 的请求体缺字段直接 NPE / ClassCastException
   connect 把 body 里的 null 交给 serverUrl.replaceAll(...) 与 Map.of(...)（Map.of 不收 null）；
   accept 与 share 是 ((Number) body.get("connectionId")).longValue()——缺字段就 NPE、
   传字符串就 ClassCastException；addMember 的 username 为空则一路传到下游。
   四处都被兜成「服务器内部错误」，而真正的原因只是请求少写了一个字段，
   调用方和用户都不知道该改什么。
   加 requireLong/requireText/optionalText 三个小校验（数字串也收下，客户端把 id
   序列化成字符串很常见），报「参数 X 缺失或不是数字」这类能据以行动的信息。

4. [HIGH，纵深] 编辑器结果回传的鉴权键不是「这个 requestId 属于谁」
   EditorBridgeService 的 pendingRequests 只按 requestId 存 future，完全不记会话；
   而 EditorResultController 校验的是 payload 里客户端**自报**的 conversationId
   （只要是他自己的会话就放行）。两把钥匙不是同一把——拿到别的会话的 requestId
   就能把伪造内容作为工具结果塞进那一轮的 Agent 循环，而结果会被当成可信的文档内容
   驱动后续改文档动作。
   把会话与 requestId 绑在一起，回传时核对；不匹配则拒绝并回 received=false。
   已确认前端两处回传（handleEditorCommand / handleEditorOpenFileSync）都是把
   SSE client_action 载荷里的 conversationId 原样回echo，改动不影响现有链路；
   Office 插件走的是另一个 OfficeResultController，不受影响。
   实际可达性存疑（requestId 是 UUID，只经该会话自己的 SSE 下发，30 秒内必回收），
   所以按纵深防护做，不夸大它的严重度。

刻意没做：
- MatterClassifierService 的「去重位在异步 AI 调用成功前就置上」：确认属实
  （classified.add 在 executor.execute 之前），但 classifyAsync 只在会话首轮被调用，
  移除去重位也拿不到第二次机会；而丢一条会话的事项类别是纯遥测，无用户可见影响。
  真正值得做的是给 classify() 加重试与给 classified 加上界，价值低于本轮其它条目，留给下轮。
- AuthController.getUsernameFromSession 吞掉所有异常返回 null：属实，但修法只是补一条日志，
  不改变任何用户可见行为，单独提没有意义，并入下轮。

全量 mvn test：2171 通过 0 失败 11 跳过。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)