### PR TITLE
fix(backend): 空 body 上传截断已有文件、对账被一条坏条目整轮回滚、写盘失败留孤儿（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/FileController.java
+++ b/backend/src/main/java/com/checkba/controller/FileController.java
@@ -407,6 +407,26 @@ public class FileController {
                 }
                 inputStream = multipartFile.getInputStream();
             } else {
+                // 裸 octet-stream 分支（分片上传/桌面端三个真实调用点全走这条路）此前没有
+                // 任何空校验：客户端自己在 X-File-Total-Size 里声明了非零总大小却送来空
+                // body，是客户端自相矛盾，必须在写盘前拒绝——否则 save()/append() 的
+                // REPLACE_EXISTING 语义会把已有的非空文件截成 0 字节，还照常回 code:0。
+                // 头缺失或显式为 0 时不拦，保存一个空文件是合法场景。
+                String declaredTotalSizeStr = request.getHeader("X-File-Total-Size");
+                if (StringUtils.hasText(declaredTotalSizeStr)) {
+                    try {
+                        long declaredTotalSize = Long.parseLong(declaredTotalSizeStr);
+                        // 只认「显式声明为 0」。长度未知时是 -1（分块传输，例如反向代理
+                        // 关掉 proxy_request_buffering 后转发的请求），那种情况一律放行——
+                        // 把「不知道多长」当成「空」会误拒正常上传，比漏拦更糟。
+                        if (declaredTotalSize > 0 && request.getContentLengthLong() == 0) {
+                            return ResponseEntity.status(400).body(Map.of("code", -1, "message",
+                                    com.checkba.service.LangText.of("上传内容为空，与声明的文件大小不符", "Uploaded content is empty but a non-zero file size was declared")));
+                        }
+                    } catch (NumberFormatException ignored) {
+                        // 头解析不了不是这里要处理的问题，交给后续既有逻辑
+                    }
+                }
                 inputStream = request.getInputStream();
             }
 

--- a/backend/src/main/java/com/checkba/service/DdService.java
+++ b/backend/src/main/java/com/checkba/service/DdService.java
@@ -232,33 +232,67 @@ public class DdService {
         String fileName = System.currentTimeMillis() + "_" + rawName;
 
         String storagePath = "projects/" + projectId + "/client_uploads/" + fileName;
-        
+
+        // 展示名同样要落进 ProjectFile.name 的 256 字符列宽以内：此前这里直接用未清洗的
+        // originalFilename，客户端传一个超长文件名就在落库时炸出
+        // DataIntegrityViolationException——而这一步已经排在物理写盘之后，事务回滚也
+        // 救不回已经落盘的字节，孤儿对象永久留在存储里（存储 key 带时间戳，永不覆盖，
+        // 重试一次多漏一个）。
+        String displayName = truncateToColumnWidth(originalFilename, 256);
+
         // Physical Save
         storageServiceFactory.getStorageService().save(storagePath, file.getInputStream());
 
-        // 6. Create ProjectFile record in the target folder
-        ProjectFile projectFile = new ProjectFile();
-        projectFile.setProjectId(projectId);
-        projectFile.setParentId(targetFolder.getId());
-        projectFile.setIsFolder(false);
-        projectFile.setName(originalFilename); // Display name
-        projectFile.setFileType(extension);
-        projectFile.setFileSize(file.getSize());
-        projectFile.setFilePath(storagePath);
-        projectFile.setWpsFileId(generateWpsFileId(projectId));
-        projectFile.setSortOrder(0);
-        projectFile.setUserId(userId);
-        projectFile.setCreatedAt(LocalDateTime.now());
-        projectFile.setUpdatedAt(LocalDateTime.now());
-        projectFile = projectFileRepository.save(projectFile);
+        try {
+            // 6. Create ProjectFile record in the target folder
+            ProjectFile projectFile = new ProjectFile();
+            projectFile.setProjectId(projectId);
+            projectFile.setParentId(targetFolder.getId());
+            projectFile.setIsFolder(false);
+            projectFile.setName(displayName); // Display name
+            projectFile.setFileType(extension);
+            projectFile.setFileSize(file.getSize());
+            projectFile.setFilePath(storagePath);
+            projectFile.setWpsFileId(generateWpsFileId(projectId));
+            projectFile.setSortOrder(0);
+            projectFile.setUserId(userId);
+            projectFile.setCreatedAt(LocalDateTime.now());
+            projectFile.setUpdatedAt(LocalDateTime.now());
+            projectFile = projectFileRepository.save(projectFile);
 
-        // 7. Update DdItem
-        item.setUploadedFileId(projectFile.getId());
-        item.setUploadedAt(LocalDateTime.now());
-        item.setUploadedBy(userId);
-        item.setStatus("UPLOADED");
-        
-        return ddItemRepository.save(item);
+            // 7. Update DdItem
+            item.setUploadedFileId(projectFile.getId());
+            item.setUploadedAt(LocalDateTime.now());
+            item.setUploadedBy(userId);
+            item.setStatus("UPLOADED");
+
+            return ddItemRepository.save(item);
+        } catch (RuntimeException e) {
+            // 落库失败（列宽超限之外的原因也算，比如瞬时 DB 故障）：物理对象已经写盘，
+            // 必须补偿删除，否则每次重试都在存储里多留一个孤儿。
+            try {
+                storageServiceFactory.getStorageService().delete(storagePath);
+            } catch (Exception cleanupEx) {
+                log.warn("落库失败后清理孤儿存储对象也失败: path={}", storagePath, cleanupEx);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * 展示名截到列宽以内，尽量保留扩展名（用户认得文件类型的部分）。
+     */
+    private static String truncateToColumnWidth(String name, int maxLength) {
+        if (name == null || name.length() <= maxLength) {
+            return name;
+        }
+        int dot = name.lastIndexOf('.');
+        // 扩展名本身占了列宽的大部分（异常情况）就不特殊处理，直接截断
+        if (dot > 0 && name.length() - dot <= 32) {
+            String ext = name.substring(dot);
+            return name.substring(0, maxLength - ext.length()) + ext;
+        }
+        return name.substring(0, maxLength);
     }
 
     private ProjectFile ensureFolder(Long projectId, Long parentId, String name, Long userId) {

--- a/backend/src/main/java/com/checkba/service/LocalProjectService.java
+++ b/backend/src/main/java/com/checkba/service/LocalProjectService.java
@@ -48,6 +48,7 @@ public class LocalProjectService {
     private final ProjectStorageResolver storageResolver;
     private final org.springframework.context.ApplicationEventPublisher eventPublisher;
     private final com.checkba.service.telemetry.TelemetryService telemetryService;
+    private final org.springframework.transaction.support.TransactionTemplate transactionTemplate;
 
     public LocalProjectService(ProjectRepository projectRepository,
                                ProjectMemberRepository projectMemberRepository,
@@ -56,7 +57,8 @@ public class LocalProjectService {
                                ProjectMemberService projectMemberService,
                                ProjectStorageResolver storageResolver,
                                org.springframework.context.ApplicationEventPublisher eventPublisher,
-                               com.checkba.service.telemetry.TelemetryService telemetryService) {
+                               com.checkba.service.telemetry.TelemetryService telemetryService,
+                               org.springframework.transaction.PlatformTransactionManager transactionManager) {
         this.projectRepository = projectRepository;
         this.projectMemberRepository = projectMemberRepository;
         this.projectFileRepository = projectFileRepository;
@@ -65,6 +67,7 @@ public class LocalProjectService {
         this.storageResolver = storageResolver;
         this.eventPublisher = eventPublisher;
         this.telemetryService = telemetryService;
+        this.transactionTemplate = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
     }
 
     /** 本地文件夹项目被打开/创建（LocalRootWatchService 据此启动监听）。 */
@@ -73,7 +76,21 @@ public class LocalProjectService {
     public record OpenLocalResult(Project project, boolean reused, Long openFileId,
                                   int importedCount, boolean truncated) {}
 
-    @Transactional
+    /**
+     * 打开/复用本地文件夹项目。
+     *
+     * <p><b>刻意不带 @Transactional</b>，与 {@link #reconcileProject} 同理：方法里调的
+     * {@code importFolder} 会逐条调 ProjectFileService 那三个 @Transactional 方法
+     * （REQUIRED，会参与外层事务）。磁盘上出现与库中「活着」的文件同名的目录时
+     * （用户把某个文件换成了同名文件夹），createFolder 的同名检查抛异常，
+     * Spring 对参与型事务默认标 rollback-only；importFolder 的 catch 接住异常继续扫，
+     * 却撤不回这个标记——方法体正常返回后，代理提交时抛 UnexpectedRollbackException。
+     * 用户看到的是「打开失败」，而且**重开一次还是失败，项目从此打不开**。
+     *
+     * <p>项目行与成员行仍必须一起落（否则一次失败会留下没有成员的孤儿项目，
+     * 之后 findByLocalRoot 命中它、权限检查又不过，这个文件夹就谁都用不了了），
+     * 所以那一段单独用 TransactionTemplate 包起来，导入留在事务之外。
+     */
     public OpenLocalResult openLocalFolder(String localRootRaw, boolean createFolder,
                                            String name, String openFileName, Long userId) {
         if (userId == null) {
@@ -82,38 +99,9 @@ public class LocalProjectService {
         Path root = validateLocalRoot(localRootRaw, createFolder);
         String canonical = root.toString();
 
-        Optional<Project> existing = projectRepository.findByLocalRoot(canonical);
-        Project project;
-        boolean reused;
-        if (existing.isPresent()) {
-            project = existing.get();
-            if (!projectMemberService.hasReadPermission(project.getId(), userId)) {
-                throw new IllegalArgumentException(LangText.of("该文件夹已被其他账号的项目使用", "This folder is already in use by another account's project"));
-            }
-            reused = true;
-        } else {
-            rejectNestedRoot(root);
-            project = new Project();
-            project.setName(StringUtils.hasText(name) ? name.trim() : folderDisplayName(root));
-            project.setProjectType("BLANK");
-            project.setListedCompanyName("");
-            project.setTargetCompanyName("");
-            project.setUserId(userId);
-            project.setLocalRoot(canonical);
-            LocalDateTime now = LocalDateTime.now();
-            project.setCreatedAt(now);
-            project.setUpdatedAt(now);
-            project = projectRepository.save(project);
-
-            ProjectMember member = new ProjectMember();
-            member.setProjectId(project.getId());
-            member.setUserId(userId);
-            member.setRole("ADMIN");
-            projectMemberRepository.save(member);
-
-            storageResolver.invalidate(project.getId());
-            reused = false;
-        }
+        ProjectResolution resolution = transactionTemplate.execute(status -> resolveProject(canonical, root, name, userId));
+        Project project = resolution.project();
+        boolean reused = resolution.reused();
 
         ImportStats stats = importFolder(project.getId(), root, userId);
 
@@ -132,7 +120,42 @@ public class LocalProjectService {
         return new OpenLocalResult(project, reused, openFileId, stats.imported, stats.truncated);
     }
 
-    public record ReconcileResult(int changed, boolean rootMissing) {}
+    private record ProjectResolution(Project project, boolean reused) {}
+
+    /** 复用既有项目或新建一个（项目行 + 成员行必须同一个事务）。 */
+    private ProjectResolution resolveProject(String canonical, Path root, String name, Long userId) {
+        Optional<Project> existing = projectRepository.findByLocalRoot(canonical);
+        if (existing.isPresent()) {
+            Project project = existing.get();
+            if (!projectMemberService.hasReadPermission(project.getId(), userId)) {
+                throw new IllegalArgumentException(LangText.of("该文件夹已被其他账号的项目使用", "This folder is already in use by another account's project"));
+            }
+            return new ProjectResolution(project, true);
+        }
+        rejectNestedRoot(root);
+        Project project = new Project();
+        project.setName(StringUtils.hasText(name) ? name.trim() : folderDisplayName(root));
+        project.setProjectType("BLANK");
+        project.setListedCompanyName("");
+        project.setTargetCompanyName("");
+        project.setUserId(userId);
+        project.setLocalRoot(canonical);
+        LocalDateTime now = LocalDateTime.now();
+        project.setCreatedAt(now);
+        project.setUpdatedAt(now);
+        project = projectRepository.save(project);
+
+        ProjectMember member = new ProjectMember();
+        member.setProjectId(project.getId());
+        member.setUserId(userId);
+        member.setRole("ADMIN");
+        projectMemberRepository.save(member);
+
+        storageResolver.invalidate(project.getId());
+        return new ProjectResolution(project, false);
+    }
+
+    public record ReconcileResult(int changed, boolean rootMissing, boolean truncated) {}
 
     /**
      * 磁盘 ↔ 数据库文件树对账（watcher 触发；幂等，只写数据库、绝不写磁盘）：
@@ -140,22 +163,39 @@ public class LocalProjectService {
      * ② 磁盘上已消失的行软删除（进回收站语义，signalChange 由服务方法自带）。
      * 根目录整个不可达（外置盘拔出/文件夹被移走）时整体跳过——绝不把「暂时看不见」
      * 当成「都被删了」，否则一次误判就把整棵文件树扫进回收站。
+     *
+     * 本方法故意不带 @Transactional：它调的 ProjectFileService.createFolder /
+     * createOrUpdateFile / delete 各自都是独立 bean 上的 @Transactional（REQUIRED）方法。
+     * 如果这里也开一个外层事务，内层就会"参与"进来共享同一个事务——某一条目录/文件
+     * 因为同名冲突等原因抛异常时（比如磁盘上出现一个和库里"活着"的文件同名的目录，
+     * createFolder 内部的查重不看 isFolder 类型），Spring 对参与型事务抛异常默认标记
+     * rollback-only，下面的 catch 把异常本身接住继续扫下一条，但撤不回这个标记——
+     * 方法体正常 return 之后，AOP 代理 commit 时发现 rollback-only，转而抛
+     * UnexpectedRollbackException，把本轮已经处理完的其它条目一起回滚，而日志还已经
+     * 打过"对账完成"。不开外层事务后，每次对 createFolder/createOrUpdateFile/delete
+     * 的调用都各自独立成一个新事务、处理完就提交，一条坏条目只影响它自己那次调用，
+     * 与"跳过这条坏数据、把其余导完"的既有设计意图一致。
      */
-    @Transactional
     public ReconcileResult reconcileProject(Long projectId) {
         Project project = projectRepository.findById(projectId).orElse(null);
         if (project == null || !StringUtils.hasText(project.getLocalRoot())) {
-            return new ReconcileResult(0, false);
+            return new ReconcileResult(0, false, false);
         }
         Path root = Paths.get(project.getLocalRoot());
         if (!Files.isDirectory(root)) {
             log.warn("对账跳过：项目文件夹不可达 project={}, root={}", projectId, root);
-            return new ReconcileResult(0, true);
+            return new ReconcileResult(0, true, false);
         }
         Long ownerId = project.getUserId();
 
         ImportStats stats = importFolder(projectId, root, ownerId);
         int changed = stats.changed;
+        if (stats.truncated) {
+            // 此前 stats.truncated 只在 openLocalFolder 那侧被读取，watcher 触发的
+            // reconcileProject 从不读它——超出 MAX_IMPORT_ENTRIES 上限的文件永远静默
+            // 不进文件树，无日志无 API 信号。这里补上，与 openLocalFolder 的日志对齐。
+            log.warn("对账触发导入上限截断: project={}, root={}, 上限={}", projectId, root, MAX_IMPORT_ENTRIES);
+        }
 
         // 删除同步：行在库、物理不存在 → 软删除（文件按 filePath 解析，文件夹按父链拼相对路径）
         java.util.List<ProjectFile> rows = projectFileRepository.findByProjectId(projectId);
@@ -188,7 +228,7 @@ public class LocalProjectService {
         if (changed > 0) {
             log.info("对账完成: project={}, changed={}", projectId, changed);
         }
-        return new ReconcileResult(changed, false);
+        return new ReconcileResult(changed, false, stats.truncated);
     }
 
     private String relativeFolderPath(ProjectFile folder, Map<Long, ProjectFile> byId) {

--- a/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
+++ b/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
@@ -182,17 +182,38 @@ public class ShareholderMeetingService {
 
     /**
      * 把字节流保存为项目文件（幂等：同名同目录则覆盖更新）。
+     *
+     * createOrUpdateFile 自带 @Transactional，是独立于本类的一次提交；写字节失败时
+     * 行已经落库，不补偿就会在文件树里留一条有名有大小、内容不存在的僵尸文件。
+     * 只清理"这次新建的"行——如果 createOrUpdateFile 命中的是已有行（重复抓取覆盖
+     * 更新），那条行在写字节失败前还指向一份能打开的旧内容，删掉反而比"元数据先一步
+     * 被改成新值"更糟，所以只在确认是新建时才删除。
      */
     private ProjectFile saveBytesAsProjectFile(Long projectId, Long parentId, String fileName,
                                                String fileType, byte[] bytes, Long userId) {
+        String cleanName = sanitizeName(fileName);
+        boolean isNewFile = projectFileRepository
+                .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, parentId, cleanName)
+                .isEmpty();
         ProjectFile file = projectFileService.createOrUpdateFile(
-                projectId, parentId, sanitizeName(fileName), fileType, (long) bytes.length, null, null, userId);
-        String savedPath = storageServiceFactory.getStorageService()
-                .save(file.getFilePath(), new ByteArrayInputStream(bytes));
-        file.setFilePath(savedPath);
-        file.setFileSize((long) bytes.length);
-        file.setUpdatedAt(LocalDateTime.now());
-        return projectFileRepository.save(file);
+                projectId, parentId, cleanName, fileType, (long) bytes.length, null, null, userId);
+        try {
+            String savedPath = storageServiceFactory.getStorageService()
+                    .save(file.getFilePath(), new ByteArrayInputStream(bytes));
+            file.setFilePath(savedPath);
+            file.setFileSize((long) bytes.length);
+            file.setUpdatedAt(LocalDateTime.now());
+            return projectFileRepository.save(file);
+        } catch (RuntimeException e) {
+            if (isNewFile) {
+                try {
+                    projectFileRepository.deleteById(file.getId());
+                } catch (Exception cleanupEx) {
+                    log.warn("写盘失败后清理孤儿文件行也失败: fileId={}", file.getId(), cleanupEx);
+                }
+            }
+            throw e;
+        }
     }
 
     // ==================== 巨潮拉取 ====================

--- a/backend/src/test/java/com/checkba/controller/FileControllerEmptyBodyGuardTest.java
+++ b/backend/src/test/java/com/checkba/controller/FileControllerEmptyBodyGuardTest.java
@@ -1,0 +1,190 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.ai.AutoTaggingService;
+import com.checkba.service.ai.ProjectRagService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import com.checkba.version.WorkSessionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 裸 octet-stream 上传（分片上传/桌面端三个真实调用点全走这条路）空 body 的围栏。
+ *
+ * 客户端在 X-File-Total-Size 里自己声明了非零总大小，却送来空 body——这是客户端自相
+ * 矛盾。此前 else 分支（非 multipart）没有任何空校验，直接把空输入流交给
+ * storageService.save/append，REPLACE_EXISTING 语义会把已有的非空文件截成 0 字节，
+ * 还照常回 code:0 骗前端"上传成功"。必须在写盘之前（storageService.save/append 调用
+ * 之前）就拒绝，而不是事后补救。
+ *
+ * X-File-Total-Size 缺失或显式为 0 时不能拦——保存一个空 .txt 是合法场景。
+ */
+@ExtendWith(MockitoExtension.class)
+class FileControllerEmptyBodyGuardTest {
+
+    @Mock
+    private ProjectFileRepository projectFileRepository;
+    @Mock
+    private ProjectMemberService projectMemberService;
+    @Mock
+    private StorageServiceFactory storageServiceFactory;
+    @Mock
+    private ProjectRagService projectRagService;
+    @Mock
+    private AutoTaggingService autoTaggingService;
+    @Mock
+    private StorageService storageService;
+    @Mock
+    private WorkSessionService workSessionService;
+
+    @InjectMocks
+    private FileController controller;
+
+    private static final String WPS_FILE_ID = "project_4_doc_1784101301299_a5d5o6u";
+    private static final String FILE_PATH = "projects/4/big.docx";
+
+    private ProjectFile projectFile() {
+        ProjectFile pf = new ProjectFile();
+        pf.setId(16L);
+        pf.setProjectId(4L);
+        pf.setName("big.docx");
+        pf.setFileType("docx");
+        pf.setFilePath(FILE_PATH);
+        pf.setWpsFileId(WPS_FILE_ID);
+        return pf;
+    }
+
+    /**
+     * 核心回归：已有非空文件 + 客户端声明了非零总大小的空 body → 必须在写盘前拒绝，
+     * 不能截断已有文件，也不能回 code:0。
+     */
+    @Test
+    void emptyOctetStreamBodyWithDeclaredTotalSizeIsRejectedBeforeWrite() throws Exception {
+        when(projectFileRepository.findByWpsFileId(WPS_FILE_ID)).thenReturn(List.of(projectFile()));
+        when(projectFileRepository.sumSizeByProjectId(4L)).thenReturn(0L);
+        // 注意：不 stub getStorageService()——修复后的守卫必须在碰存储层之前就拒绝，
+        // 一旦实现改成先取存储服务再判断，这里会因为 UnnecessaryStubbing 之外的原因
+        // （NPE）失败，能防止守卫被误挪到写盘之后。
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/octet-stream");
+        request.setContent(new byte[0]); // 空 body，getContentLengthLong() == 0
+        request.addHeader("X-File-Total-Size", "1024"); // 客户端自己声明了非零总大小
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasWritePermission(4L, 7L)).thenReturn(true);
+
+            ResponseEntity<Map<String, Object>> resp =
+                    controller.uploadFile(WPS_FILE_ID, null, null, "sess", null, request);
+
+            assertEquals(400, resp.getStatusCode().value(), "自相矛盾的空 body 必须被拒绝，不能回 200");
+            assertNotEquals(0, resp.getBody().get("code"), "响应体不能是 code:0（骗前端上传成功）");
+        }
+
+        verify(storageService, never()).save(any(), any());
+        verify(storageService, never()).append(any(), any());
+        verify(projectFileRepository, never()).save(any());
+    }
+
+    /** X-File-Total-Size 缺失时，空 body 是合法场景（保存一个空文件），不能被新校验误伤。 */
+    @Test
+    void emptyBodyWithoutTotalSizeHeaderIsAllowed() throws Exception {
+        when(projectFileRepository.findByWpsFileId(WPS_FILE_ID)).thenReturn(List.of(projectFile()));
+        when(projectFileRepository.sumSizeByProjectId(4L)).thenReturn(0L);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+        when(storageService.save(any(), any())).thenReturn(FILE_PATH);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/octet-stream");
+        request.setContent(new byte[0]);
+        // 无 X-File-Total-Size 头
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasWritePermission(4L, 7L)).thenReturn(true);
+
+            ResponseEntity<Map<String, Object>> resp =
+                    controller.uploadFile(WPS_FILE_ID, null, null, "sess", null, request);
+
+            assertEquals(200, resp.getStatusCode().value());
+            assertEquals(0, resp.getBody().get("code"));
+        }
+
+        verify(storageService).save(eq(FILE_PATH), any(InputStream.class));
+    }
+
+    /** X-File-Total-Size 显式为 0 同样是合法的空文件声明，不能被拦。 */
+    @Test
+    void emptyBodyWithZeroTotalSizeHeaderIsAllowed() throws Exception {
+        when(projectFileRepository.findByWpsFileId(WPS_FILE_ID)).thenReturn(List.of(projectFile()));
+        when(projectFileRepository.sumSizeByProjectId(4L)).thenReturn(0L);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+        when(storageService.save(any(), any())).thenReturn(FILE_PATH);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/octet-stream");
+        request.setContent(new byte[0]);
+        request.addHeader("X-File-Total-Size", "0");
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasWritePermission(4L, 7L)).thenReturn(true);
+
+            ResponseEntity<Map<String, Object>> resp =
+                    controller.uploadFile(WPS_FILE_ID, null, null, "sess", null, request);
+
+            assertEquals(200, resp.getStatusCode().value());
+            assertEquals(0, resp.getBody().get("code"));
+        }
+
+        verify(storageService).save(eq(FILE_PATH), any(InputStream.class));
+    }
+
+    /** 非空 body 即便声明了总大小也必须正常放行，不能被新校验误伤真实分片。 */
+    @Test
+    void nonEmptyBodyWithDeclaredTotalSizeStillWorks() throws Exception {
+        when(projectFileRepository.findByWpsFileId(WPS_FILE_ID)).thenReturn(List.of(projectFile()));
+        when(projectFileRepository.sumSizeByProjectId(4L)).thenReturn(0L);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+        when(storageService.save(any(), any())).thenReturn(FILE_PATH);
+        when(storageService.getSize(FILE_PATH)).thenReturn(1024L);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/octet-stream");
+        request.setContent(new byte[]{1, 2, 3});
+        request.addHeader("X-File-Total-Size", "1024");
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            when(projectMemberService.hasWritePermission(4L, 7L)).thenReturn(true);
+
+            ResponseEntity<Map<String, Object>> resp =
+                    controller.uploadFile(WPS_FILE_ID, null, null, "sess", null, request);
+
+            assertEquals(200, resp.getStatusCode().value());
+            assertEquals(0, resp.getBody().get("code"));
+        }
+
+        verify(storageService).save(eq(FILE_PATH), any(InputStream.class));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/DdServiceUploadFileTest.java
+++ b/backend/src/test/java/com/checkba/service/DdServiceUploadFileTest.java
@@ -1,0 +1,147 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.DdItem;
+import com.checkba.model.entity.DdRequest;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.DdCommentRepository;
+import com.checkba.repository.DdItemRepository;
+import com.checkba.repository.DdRequestRepository;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * DdService.uploadFile 先写存储再落库（dev-board#74 稳定性审计条目 4）：
+ * 展示名用的是未清洗的原始文件名，超过 ProjectFile.name 的 256 字符列宽时落库炸出
+ * DataIntegrityViolationException，事务回滚，但物理对象已经先落盘——孤儿对象永久
+ * 留在存储里（存储 key 带时间戳，重试一次多漏一个）。
+ *
+ * 用真实 H2 库（而非纯 Mockito）承载 ProjectFileRepository，才能真正复现列宽超限
+ * 在数据库层的报错，而不是靠猜测 Hibernate/驱动的具体异常类型。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:dd-service-upload-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class DdServiceUploadFileTest {
+
+    @Autowired private ProjectFileRepository projectFileRepository;
+    @Autowired private DdRequestRepository ddRequestRepository;
+    @Autowired private DdItemRepository ddItemRepository;
+
+    private StorageService storageService;
+    private StorageServiceFactory storageServiceFactory;
+    private ProjectFileService projectFileService;
+
+    private DdRequest seedRequest(Long projectId) {
+        DdRequest req = new DdRequest();
+        req.setProjectId(projectId);
+        req.setName("尽调请求");
+        req.setCreatedBy(9L);
+        return ddRequestRepository.save(req);
+    }
+
+    private DdItem seedItem(Long requestId) {
+        DdItem item = new DdItem();
+        item.setDdRequestId(requestId);
+        item.setTitle("营业执照");
+        item.setSortOrder(0);
+        return ddItemRepository.save(item);
+    }
+
+    private void setUpCollaborators() {
+        storageService = mock(StorageService.class);
+        storageServiceFactory = mock(StorageServiceFactory.class);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+
+        // ensureFolder 找不到就建：给个自增 id 的假文件夹，不需要真实建文件夹的副作用
+        projectFileService = mock(ProjectFileService.class);
+        AtomicLong folderIdSeq = new AtomicLong(1000);
+        when(projectFileService.createFolder(anyLong(), any(), anyString(), anyLong())).thenAnswer(inv -> {
+            ProjectFile f = new ProjectFile();
+            f.setId(folderIdSeq.incrementAndGet());
+            f.setProjectId(inv.getArgument(0));
+            f.setParentId(inv.getArgument(1));
+            f.setName(inv.getArgument(2));
+            f.setIsFolder(true);
+            return f;
+        });
+    }
+
+    private DdService buildService(ProjectFileRepository repo) {
+        return new DdService(ddRequestRepository, ddItemRepository,
+                mock(DdCommentRepository.class), repo, projectFileService, storageServiceFactory);
+    }
+
+    @Test
+    void overlongOriginalFilenameDoesNotBlowUpTheColumnAndLeavesNoOrphan() throws Exception {
+        setUpCollaborators();
+        DdRequest req = seedRequest(1L);
+        DdItem item = seedItem(req.getId());
+        DdService ddService = buildService(projectFileRepository);
+
+        String longStem = "a".repeat(400);
+        String originalFilename = longStem + ".pdf";
+        MockMultipartFile file = new MockMultipartFile("file", originalFilename,
+                "application/pdf", new byte[]{1, 2, 3});
+
+        DdItem updated = assertDoesNotThrow(() -> ddService.uploadFile(item.getId(), file, 9L),
+                "超长文件名不该在落库时炸出 DataIntegrityViolationException");
+
+        ProjectFile saved = projectFileRepository.findById(updated.getUploadedFileId()).orElseThrow();
+        assertTrue(saved.getName().length() <= 256, "展示名必须截到列宽以内: len=" + saved.getName().length());
+        assertTrue(saved.getName().endsWith(".pdf"), "截断要尽量保留扩展名，否则用户认不出文件类型: " + saved.getName());
+        verify(storageService, never()).delete(anyString());
+    }
+
+    /**
+     * 落库失败（任何原因，未必是长文件名）时，物理对象已经写盘，必须补偿删除，
+     * 否则每次重试都在存储里留一个孤儿（存储 key 带时间戳，永不覆盖）。
+     *
+     * 这里改用纯 Mockito mock 顶替 ProjectFileRepository（不再是 Test A 用的真实 H2
+     * 库），只为了能可控地让 save() 在任意时刻抛出任意异常——不依赖列宽超限这个
+     * 具体触发条件，覆盖"任何落库失败都不该留孤儿"这个更通用的不变式。
+     */
+    @Test
+    void dbSaveFailureAfterStorageWriteCleansUpOrphan() throws Exception {
+        setUpCollaborators();
+        DdRequest req = seedRequest(1L);
+        DdItem item = seedItem(req.getId());
+
+        ProjectFileRepository failingRepo = mock(ProjectFileRepository.class);
+        when(failingRepo.findByProjectIdAndParentIdAndName(anyLong(), any(), anyString()))
+                .thenReturn(java.util.Optional.empty());
+        when(failingRepo.save(any(ProjectFile.class)))
+                .thenThrow(new DataIntegrityViolationException("模拟落库失败"));
+        DdService ddService = buildService(failingRepo);
+
+        MockMultipartFile file = new MockMultipartFile("file", "license.pdf",
+                "application/pdf", new byte[]{1, 2, 3});
+
+        assertThrows(DataIntegrityViolationException.class,
+                () -> ddService.uploadFile(item.getId(), file, 9L));
+
+        org.mockito.ArgumentCaptor<String> pathCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(storageService).save(pathCaptor.capture(), any());
+        verify(storageService).delete(pathCaptor.getValue());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/LocalProjectServiceReconcileTransactionTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalProjectServiceReconcileTransactionTest.java
@@ -1,0 +1,112 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.version.WorkSessionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 对账事务不能被一条坏条目整体拖垮（dev-board#74 稳定性审计条目 3）。
+ *
+ * 全上下文（真实 @Transactional 代理）而非 @DataJpaTest 手工 new：
+ * LocalProjectServiceTest 里的 svc/projectFileService 是手工 new 出来的 POJO，绕过了
+ * Spring AOP 代理，@Transactional 在那份测试里其实从未真正生效过——复现"内层参与事务
+ * 抛异常污染外层事务"这个 bug 必须要有真代理，所以这里改用 @SpringBootTest + @Autowired。
+ *
+ * 复现路径：reconcileProject / importFolder 带 @Transactional；它们调的
+ * ProjectFileService.createFolder 是另一个 bean 上的 @Transactional 方法（REQUIRED 传播，
+ * 参与同一事务）。磁盘上出现一个与库中"活着"的文件同名的目录时，createFolder 内部的
+ * existsByProjectIdAndParentIdAndNameAndIdNot 查重不看 isFolder，判定"同名已存在"抛出
+ * IllegalArgumentException。LocalProjectService 在 preVisitDirectory 里 catch 住继续扫，
+ * 但 Spring 对参与型事务抛异常默认 doSetRollbackOnly，catch 撤不回这个标记——
+ * reconcileProject 方法体本身正常 return，AOP 代理 commit 时发现 rollback-only，
+ * 转而回滚整个事务并抛 UnexpectedRollbackException，本轮已经处理完的其它条目
+ * （如同一次扫描里正常的新文件）跟着一起被吞。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:reconcile-tx-poison-test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.local-mode=false"})
+@ActiveProfiles("desktop")
+class LocalProjectServiceReconcileTransactionTest {
+
+    @Autowired
+    private LocalProjectService localProjectService;
+    @Autowired
+    private ProjectFileRepository projectFileRepository;
+
+    @MockBean
+    private WorkSessionService workSessionService;
+    // 全上下文会真的挂文件系统监听（onLocalProjectOpened 监听器）；不掐掉的话，
+    // 后台 watcher 会对着同一个临时目录并发触发它自己的 reconcile，跟本测试手动
+    // 调用的 reconcileProject 互相打架，测试变得不确定。
+    @MockBean
+    private LocalRootWatchService localRootWatchService;
+
+    @Test
+    void oneBadEntryDuringReconcileDoesNotDiscardTheRestOfTheBatch(@TempDir Path folder) throws Exception {
+        // "conflict" 起初是一个真文件，随项目一起导入（库里落一条"活着"的文件行）
+        Files.writeString(folder.resolve("conflict"), "was a file");
+        Files.writeString(folder.resolve("keep.txt"), "1");
+        Long projectId = localProjectService
+                .openLocalFolder(folder.toString(), false, null, null, 1L)
+                .project().getId();
+
+        // Finder 里：把 conflict 从文件换成同名目录（库里那行还是"文件"，类型冲突），
+        // 另外新增一个完全正常的文件
+        Files.delete(folder.resolve("conflict"));
+        Files.createDirectories(folder.resolve("conflict"));
+        Files.writeString(folder.resolve("new.txt"), "2");
+
+        LocalProjectService.ReconcileResult result = assertDoesNotThrow(
+                () -> localProjectService.reconcileProject(projectId),
+                "同名类型冲突（磁盘目录 vs 库中的文件行）触发的内层 IllegalArgumentException "
+                        + "不该把整轮对账拖成 UnexpectedRollbackException 抛给调用方");
+
+        assertFalse(result.rootMissing());
+        List<ProjectFile> rows = projectFileRepository.findByProjectId(projectId);
+        assertTrue(rows.stream().anyMatch(f -> "new.txt".equals(f.getName()) && !Boolean.TRUE.equals(f.getIsDeleted())),
+                "一条坏条目不能拖累同一轮扫描里其它条目的导入结果: " + rows);
+        assertTrue(rows.stream().anyMatch(f -> "keep.txt".equals(f.getName()) && !Boolean.TRUE.equals(f.getIsDeleted())),
+                "更早已提交的行不应受影响: " + rows);
+    }
+
+    /**
+     * 同样的形状也长在 openLocalFolder 上，而且后果更重：它是 @Transactional，
+     * 里面同样调 importFolder。重开一个已存在的本地文件夹项目时，若磁盘上出现
+     * 与库中「活着」的文件同名的目录，内层 IllegalArgumentException 会把外层事务
+     * 标成 rollback-only，提交时抛 UnexpectedRollbackException——用户看到的是
+     * 「打开失败」，而且重开一次还是失败，项目从此打不开。
+     */
+    @Test
+    void oneBadEntryDuringReopenDoesNotFailTheWholeOpen(@TempDir Path folder) throws Exception {
+        Files.writeString(folder.resolve("conflict"), "was a file");
+        Long projectId = localProjectService
+                .openLocalFolder(folder.toString(), false, null, null, 1L)
+                .project().getId();
+
+        Files.delete(folder.resolve("conflict"));
+        Files.createDirectories(folder.resolve("conflict"));
+        Files.writeString(folder.resolve("new.txt"), "2");
+
+        LocalProjectService.OpenLocalResult reopened = assertDoesNotThrow(
+                () -> localProjectService.openLocalFolder(folder.toString(), false, null, null, 1L),
+                "一条同名冲突条目不该让整个「打开本地文件夹」失败");
+        assertTrue(reopened.reused());
+        assertTrue(projectFileRepository.findByProjectId(projectId).stream()
+                        .anyMatch(f -> "new.txt".equals(f.getName()) && !Boolean.TRUE.equals(f.getIsDeleted())),
+                "同一次导入里正常的新文件仍应落库");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
@@ -47,6 +47,7 @@ class LocalProjectServiceTest {
     @Autowired private ProjectRepository projectRepository;
     @Autowired private ProjectMemberRepository projectMemberRepository;
     @Autowired private ProjectFileRepository projectFileRepository;
+    @Autowired private org.springframework.transaction.PlatformTransactionManager transactionManager;
 
     private LocalProjectService svc;
     private ProjectFileService projectFileService;
@@ -78,7 +79,8 @@ class LocalProjectServiceTest {
         svc = new LocalProjectService(projectRepository, projectMemberRepository,
                 projectFileRepository, projectFileService, memberService, resolver,
                 mock(org.springframework.context.ApplicationEventPublisher.class),
-                mock(com.checkba.service.telemetry.TelemetryService.class));
+                mock(com.checkba.service.telemetry.TelemetryService.class),
+                transactionManager);
     }
 
     private Path userFolder(@TempDir Path tmp) {
@@ -226,6 +228,28 @@ class LocalProjectServiceTest {
         assertTrue(r.rootMissing());
         ProjectFile a = projectFileRepository.findByProjectId(projectId).get(0);
         assertFalse(Boolean.TRUE.equals(a.getIsDeleted()), "根目录不可达时不得软删除任何行");
+    }
+
+    /**
+     * importFolder 在扫描条目数达到 MAX_IMPORT_ENTRIES 上限时会置位 ImportStats.truncated，
+     * 但 reconcileProject 此前只读 stats.changed，truncated 被整个丢弃——ReconcileResult
+     * 没有字段承载它，watcher 触发的后台对账因此全静默：超出上限的文件永远不进文件树，
+     * 无日志无 API 信号。openLocalFolder/OpenLocalResult 早就正确处理了同一个 stats.truncated
+     * （见 reconcileImportsNewAndSoftDeletesVanished 之外的 openLocalFolder 路径），
+     * 这里补上 reconcileProject 这一侧。
+     */
+    @Test
+    void reconcileReportsTruncationWhenImportHitsTheCap(@TempDir Path folder) throws Exception {
+        Long projectId = svc.openLocalFolder(folder.toString(), false, null, null, 1L).project().getId();
+
+        // 超过 MAX_IMPORT_ENTRIES（3000）上限，逼 importFolder 在扫描中途截断
+        int overCap = LocalProjectService.MAX_IMPORT_ENTRIES + 5;
+        for (int i = 0; i < overCap; i++) {
+            Files.writeString(folder.resolve("f" + i + ".txt"), "x");
+        }
+
+        LocalProjectService.ReconcileResult r = svc.reconcileProject(projectId);
+        assertTrue(r.truncated(), "扫描条目数超过上限时，对账结果必须报出截断，否则超限文件永远静默不进文件树");
     }
 
     /**

--- a/backend/src/test/java/com/checkba/service/ShareholderMeetingServiceCninfoOrphanTest.java
+++ b/backend/src/test/java/com/checkba/service/ShareholderMeetingServiceCninfoOrphanTest.java
@@ -1,0 +1,113 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.ShareholderMeetingCheck;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ShareholderMeetingCheckRepository;
+import com.checkba.storage.StorageException;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * cninfo 自动抓取写盘失败时的孤儿行清理（dev-board#74 稳定性审计条目 5）。
+ *
+ * saveBytesAsProjectFile 先 projectFileService.createOrUpdateFile 落库（该方法自带
+ * @Transactional，与本类无关，独立成一次提交），后 storageServiceFactory...save()
+ * 写字节。save() 抛出时行已经提交，上游 downloadAndAttach 的 catch 只把异常记进
+ * errors 就完，没有补偿删除——文件树里于是多出一条有名有大小、内容不存在、
+ * 谁也不认领的僵尸文件。
+ */
+@ExtendWith(MockitoExtension.class)
+class ShareholderMeetingServiceCninfoOrphanTest {
+
+    @Mock private ShareholderMeetingCheckRepository checkRepository;
+    @Mock private ProjectFileRepository projectFileRepository;
+    @Mock private ProjectFileService projectFileService;
+    @Mock private StorageServiceFactory storageServiceFactory;
+    @Mock private StorageService storageService;
+    @Mock private CninfoAnnouncementService cninfoService;
+
+    private ShareholderMeetingService svc;
+
+    @BeforeEach
+    void setUp() {
+        svc = new ShareholderMeetingService(checkRepository, projectFileRepository,
+                projectFileService, storageServiceFactory, cninfoService);
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+    }
+
+    private ShareholderMeetingCheck check() {
+        ShareholderMeetingCheck c = new ShareholderMeetingCheck();
+        c.setId(1L);
+        c.setProjectId(4L);
+        c.setCompanyName("测试公司");
+        c.setStockCode("000001");
+        c.setMeetingName("2026年第一次临时股东会");
+        c.setMeetingDate(LocalDate.of(2026, 6, 1));
+        return c;
+    }
+
+    @Test
+    void storageWriteFailureCleansUpTheJustCreatedRowInsteadOfLeavingAZombie() throws Exception {
+        ShareholderMeetingCheck check = check();
+        when(checkRepository.findById(1L)).thenReturn(Optional.of(check));
+        when(checkRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        CninfoAnnouncementService.FetchResult fetched = new CninfoAnnouncementService.FetchResult();
+        fetched.notice = new CninfoAnnouncementService.Announcement(
+                "股东大会通知公告", 1L, "ann1", "org1", "/finalpage/notice.pdf", "000001");
+        when(cninfoService.fetchForMeeting(anyString(), anyString(), any())).thenReturn(fetched);
+        when(cninfoService.downloadPdf(anyString())).thenReturn(new byte[]{1, 2, 3});
+
+        // 底稿夹全部文件夹都不存在，ensureFolder 统一走 createFolder 新建
+        when(projectFileRepository.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(any(), any(), any()))
+                .thenReturn(Optional.empty());
+        AtomicLong folderIdSeq = new AtomicLong(100);
+        when(projectFileService.createFolder(anyLong(), any(), anyString(), anyLong())).thenAnswer(inv -> {
+            ProjectFile f = new ProjectFile();
+            f.setId(folderIdSeq.incrementAndGet());
+            f.setProjectId(inv.getArgument(0));
+            f.setParentId(inv.getArgument(1));
+            f.setName(inv.getArgument(2));
+            f.setIsFolder(true);
+            return f;
+        });
+
+        // saveBytesAsProjectFile 第一步：createOrUpdateFile 落库成功，产出一条新行（id=555）
+        ProjectFile created = new ProjectFile();
+        created.setId(555L);
+        created.setProjectId(4L);
+        created.setIsFolder(false);
+        created.setName("股东大会通知公告.pdf");
+        created.setFileSize(3L);
+        created.setFilePath("projects/4/股东大会核查/xxx/01-会议通知/股东大会通知公告.pdf");
+        when(projectFileService.createOrUpdateFile(anyLong(), any(), anyString(), anyString(), anyLong(),
+                isNull(), isNull(), anyLong())).thenReturn(created);
+
+        // 第二步：写字节失败——存储服务抖动/磁盘写满
+        when(storageService.save(anyString(), any())).thenThrow(new StorageException("模拟磁盘写满"));
+
+        Map<String, Object> result = svc.fetchFromCninfo(1L, null, 9L);
+
+        @SuppressWarnings("unchecked")
+        List<String> errors = (List<String>) result.get("errors");
+        assertFalse(errors.isEmpty(), "下载/写盘失败必须体现在 errors 里");
+
+        verify(projectFileRepository).deleteById(555L);
+    }
+}


### PR DESCRIPTION
五条（子 agent 完成，审校时补了两处，见文末）。每条先写测试看它红、改实现看它绿、
再把实现还原确认测试真会红。

1. [HIGH] 空 body 的 octet-stream 上传把已有文件截成 0 字节，还报成功
   multipart 分支有两道 isEmpty 校验，裸 octet-stream 分支一道都没有——而前端三个
   真实调用点（ChatInterface / FileTree 分片上传 / meetingRecorder）全走这条。
   save() 的 REPLACE_EXISTING 把目标截成 0 字节后正常返回，接口回 code:0，
   还回写 updatedAt（fileSize 因为 size>0 才写而保持旧值，更具误导性）。
   修法：客户端自己在 X-File-Total-Size 里声明了非零总大小却送来空 body 是自相矛盾，
   在写盘前拒绝。头缺失或显式为 0 时不拦——保存一个空 .txt 是合法场景。

2. [HIGH] reconcileProject 丢掉 importFolder 的 truncated 标志
   超过 MAX_IMPORT_ENTRIES 上限时 importFolder 会置位并终止遍历，但 reconcileProject
   从不读它、ReconcileResult 也没有承载它的字段。对照 openLocalFolder 是打日志并随
   返回值上报的——于是只有 watcher 触发的后台对账这条路全静默：超出上限的文件永远
   不进文件树，无日志无 API 信号。补上字段与 WARN 日志，不动 3000 这个上限本身。

3. [HIGH] 内层 @Transactional 抛异常污染整轮，已完成的导入与软删除一起回滚
   reconcileProject 带 @Transactional，而它调的 ProjectFileService.createFolder /
   createOrUpdateFile / delete 是另一个 bean 上的 @Transactional（REQUIRED，会参与）。
   磁盘上出现与库中「活着」的文件同名的目录时（用户把文件换成了同名文件夹），
   createFolder 的同名检查抛异常，Spring 对参与型事务默认标 rollback-only；
   catch 接住异常继续扫却撤不回这个标记——方法体正常 return，代理提交时抛
   UnexpectedRollbackException，本轮已完成的全部导入与软删除一起回滚，
   而日志已经打过「对账完成: changed=N」。
   修法：reconcileProject 不再自带 @Transactional，内层三个方法各自独立成一次提交，
   一条坏条目只影响它自己那次调用。不用 REQUIRES_NEW，那会改变
   ProjectFileService 三个方法在**全部**调用方处的传播语义，改动面比问题本身大。

   审校补充（子 agent 只修了对账那条路）：**openLocalFolder 是同一形状且后果更重**。
   它也是 @Transactional 也调 importFolder；重开一个已存在的本地文件夹项目时撞上
   同名冲突，整个「打开」抛 UnexpectedRollbackException——用户看到「打开失败」，
   而且重开一次还是失败，项目从此打不开。实测已复现。
   修法：openLocalFolder 同样去掉 @Transactional，但「项目行 + 成员行」必须一起落
   （否则失败会留下没有成员的孤儿项目，之后 findByLocalRoot 命中它、权限又不过，
   这个文件夹谁都用不了了），所以那一段单独用 TransactionTemplate 包起来，
   导入留在事务之外。新增用例钉住这条。

4. [HIGH] DdService 先写存储再落库，超长文件名炸列宽后留下孤儿对象
   方法带 @Transactional，先 storageService.save 写物理对象，之后才建 ProjectFile 行，
   而那行的 name 用的是**未清洗的原始文件名**、列宽只有 256。客户端可控的超长
   filename → DataIntegrityViolation → 事务回滚，孤儿对象永久留在存储里，
   每重试一次多漏一个（存储 key 带时间戳，永不覆盖）。
   修法：写盘前先把名字截到列宽以内（尽量保留扩展名），并给失败路径加补偿删除。

5. [HIGH] 巨潮自动抓取留下孤儿空文件行
   saveBytesAsProjectFile 先 createOrUpdateFile（自带 @Transactional，返回即提交）
   再写字节；写字节失败时行已落库，上游 catch 只把它记进 errors 就完，没有补偿删除，
   而 attachMaterial 在写盘之后才调——文件树里于是多出一条有名有大小、内容不存在、
   谁也不认领的僵尸文件。
   修法：写盘失败时删掉这次**新建**的行；命中的是已有行（重复抓取覆盖更新）则不删，
   那条行在写字节失败前还指向一份能打开的旧内容。

审校时另一处收窄：第 1 条原实现用 `getContentLengthLong() <= 0` 判空，
会把「长度未知」（-1，分块传输，例如反向代理关掉 proxy_request_buffering 后转发的
请求）也当成空。改成只认「显式为 0」——把「不知道多长」当成「空」会误拒正常上传，
比漏拦更糟。

全量 mvn test：2187 通过 0 失败 11 跳过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)