### PR TITLE
fix(backend): PDF 脱敏漏掉被拆开的敏感串、DOCX 脱敏从不扫页眉页脚（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/SensitiveService.java
+++ b/backend/src/main/java/com/checkba/service/SensitiveService.java
@@ -80,18 +80,57 @@ public class SensitiveService {
             }
 
             // 2. Tables
-            for (XWPFTable tbl : doc.getTables()) {
-                for (XWPFTableRow row : tbl.getRows()) {
-                    for (XWPFTableCell cell : row.getTableCells()) {
-                        for (XWPFParagraph p : cell.getParagraphs()) {
-                            replaceInParagraph(p, strategies);
-                        }
-                    }
+            replaceInTables(doc.getTables(), strategies);
+
+            // 3. 页眉 / 页脚：此前完全没扫描。律所文书的抬头、落款、联系方式恰恰常见于页眉页脚，
+            //    是高频泄露点。页眉页脚自身也可能用表格排版（如三栏落款），一并覆盖。
+            for (XWPFHeader header : doc.getHeaderList()) {
+                for (XWPFParagraph p : header.getParagraphs()) {
+                    replaceInParagraph(p, strategies);
                 }
+                replaceInTables(header.getTables(), strategies);
             }
+            for (XWPFFooter footer : doc.getFooterList()) {
+                for (XWPFParagraph p : footer.getParagraphs()) {
+                    replaceInParagraph(p, strategies);
+                }
+                replaceInTables(footer.getTables(), strategies);
+            }
+
+            // 4. 脚注 / 尾注：同样此前完全没扫描。
+            for (XWPFFootnote footnote : doc.getFootnotes()) {
+                for (XWPFParagraph p : footnote.getParagraphs()) {
+                    replaceInParagraph(p, strategies);
+                }
+                replaceInTables(footnote.getTables(), strategies);
+            }
+            for (XWPFEndnote endnote : doc.getEndnotes()) {
+                for (XWPFParagraph p : endnote.getParagraphs()) {
+                    replaceInParagraph(p, strategies);
+                }
+                replaceInTables(endnote.getTables(), strategies);
+            }
+
+            // 已知局限（未覆盖，如实注明）：文本框（w:txbxContent）里的文字不脱敏。
+            // POI 的 org.apache.poi.xwpf.usermodel 对象模型没有暴露 Word 文本框类型
+            // （只有 xslf/xssf 分别为 PPT/Excel 提供了 TextBox 类），paragraphs/tables 都取不到
+            // 文本框内容，需要手写 w:txbxContent 的原始 XML 遍历才能做，本次不做，如果文本框里
+            // 塞了敏感信息不会被脱敏，需要人工核查。
 
             try (FileOutputStream out = new FileOutputStream(dest)) {
                 doc.write(out);
+            }
+        }
+    }
+
+    private void replaceInTables(List<XWPFTable> tables, List<String> strategies) {
+        for (XWPFTable tbl : tables) {
+            for (XWPFTableRow row : tbl.getRows()) {
+                for (XWPFTableCell cell : row.getTableCells()) {
+                    for (XWPFParagraph p : cell.getParagraphs()) {
+                        replaceInParagraph(p, strategies);
+                    }
+                }
             }
         }
     }
@@ -127,30 +166,10 @@ public class SensitiveService {
     
     private void processPdf(File src, File dest, List<String> strategies) throws IOException {
         try (PDDocument document = org.apache.pdfbox.Loader.loadPDF(src)) {
-            // We need to find coordinates of sensitive text.
-            // Using a custom PDFTextStripper to intercept writing.
-            SensitiveTextStripper stripper = new SensitiveTextStripper(strategies);
-            stripper.setSortByPosition(true);
-            
-            // 1. Scan doc to find redaction areas
-            // Note: processing page by page to map coordinates to pages correctly.
-            int totalPages = document.getNumberOfPages();
-            
-            // Collect all redactions first
-            // Map<PageIndex, List<RedactionArea>>
-            // Actually, stripper runs on range. We can reset it per page or run globally if we track page index.
-            // PDFBox stripper is stateful. Best to process one page at a time.
-            
-            for (int i = 0; i < totalPages; i++) {
-                int pageIndex = i + 1; // 1-based for stripper
-                stripper.setStartPage(pageIndex);
-                stripper.setEndPage(pageIndex);
-                stripper.currentPdfPageIndex = i; 
-                stripper.getText(document); // This triggers writeString logic
-            }
-            
+            // 1. Scan doc to find redaction areas (page by page, so coordinates map to the right page)
+            List<RedactionArea> areas = computeRedactionAreas(document, strategies);
+
             // 2. Draw black rectangles
-            List<RedactionArea> areas = stripper.getRedactionAreas();
             for (RedactionArea area : areas) {
                 PDPage page = document.getPage(area.pageIndex);
                 try (PDPageContentStream contentStream = new PDPageContentStream(document, page, PDPageContentStream.AppendMode.APPEND, true, true)) {
@@ -191,8 +210,28 @@ public class SensitiveService {
         }
     }
 
+    /**
+     * 扫描 PDF 全文，返回命中敏感策略的黑框区域列表；按页处理，保证坐标落在正确的页。
+     * 包可见（而非 private）：测试需要直接断言命中了哪些区域——脱敏后文字层会被栅格化抹掉，
+     * 无法再靠"提取输出文本"这种黑盒方式验证是否真的画上了黑框（详见 SensitiveTextStripper 内的取舍说明）。
+     */
+    List<RedactionArea> computeRedactionAreas(PDDocument document, List<String> strategies) throws IOException {
+        SensitiveTextStripper stripper = new SensitiveTextStripper(strategies);
+        stripper.setSortByPosition(true);
+        int totalPages = document.getNumberOfPages();
+        for (int i = 0; i < totalPages; i++) {
+            int pageIndex = i + 1; // 1-based for stripper
+            stripper.setStartPage(pageIndex);
+            stripper.setEndPage(pageIndex);
+            stripper.currentPdfPageIndex = i;
+            stripper.getText(document); // This triggers writeString logic, accumulating into the page buffer
+            stripper.finishPage(); // 整页文本收集完毕，统一匹配、求黑框，并清空缓冲避免跨页串号
+        }
+        return stripper.getRedactionAreas();
+    }
+
     // Inner class for coordinate extraction
-    private static class RedactionArea {
+    static class RedactionArea {
         int pageIndex;
         float x, y, width, height;
 
@@ -210,6 +249,16 @@ public class SensitiveService {
         private final List<RedactionArea> redactionAreas = new ArrayList<>();
         public int currentPdfPageIndex = 0;
 
+        // 整页累积缓冲：PDFBox 按"词/行"把文字拆成多次 writeString 回调喂进来（同一视觉行也可能因换行、
+        // 分栏等原因被拆成多次回调，注释里举的 "138"/"0013" 就是这种片段）。若只在单次回调内做正则匹配，
+        // 被拆开的敏感串永远凑不齐、永远命中不了。这里不在 writeString 里匹配，只积累"整页文本 + 逐字符
+        // 位置"，等一页收完后在 finishPage() 里对整页文本统一匹配，再把命中区间映射回 TextPosition 求黑框。
+        /** 基线 Y 相差超过它就算换行了（单位与 TextPosition 一致，磅）。 */
+        private static final float LINE_TOLERANCE = 2.0f;
+
+        private final StringBuilder pageText = new StringBuilder();
+        private final List<TextPosition> pagePositions = new ArrayList<>();
+
         public SensitiveTextStripper(List<String> strategies) throws IOException {
             super();
             this.strategies = strategies;
@@ -221,124 +270,107 @@ public class SensitiveService {
 
         @Override
         protected void writeString(String text, List<TextPosition> textPositions) throws IOException {
-            // Check if text matches any strategy
-            // Problem: 'text' might be a fragment (e.g. "138", "0013"). Regex needs context.
-            // PDFTextStripper aggregates lines usually. 
-            // writeString is called with a "word" or "line". 
-            // If we match strictly regex on 'text', it might match.
-            
-            // To handle "fragmented" text, standard stripper aggregates words. 
-            // We'll simplisticly assume writeString gives us enough context or we match what we have.
-            
             if (StrUtil.isEmpty(text)) return;
-            
+
+            if (text.length() != textPositions.size()) {
+                // 极少数情况（连字/组合字符等）字符数与位置数对不上，没法为这个片段建立可靠的
+                // 字符->坐标映射。不静默丢弃：打日志留痕，并用 null 占位保持下标对齐——匹配阶段一旦
+                // 命中区间落在 null 占位上，就如实判定"这次命中没能画框"而不是瞎猜一个位置画错框。
+                log.warn("PDF脱敏：第{}页出现字符数({})与位置数({})不一致的文本片段，该片段可能无法精确定位黑框",
+                        currentPdfPageIndex + 1, text.length(), textPositions.size());
+                pageText.append(text);
+                for (int i = 0; i < text.length(); i++) {
+                    pagePositions.add(null);
+                }
+                return;
+            }
+
+            pageText.append(text);
+            pagePositions.addAll(textPositions);
+        }
+
+        /**
+         * 一页文字全部收集完毕后调用：在整页文本上做正则匹配，把命中区间映射回 TextPosition 求黑框，
+         * 然后清空缓冲，避免跨页串号。必须在每次 getText(document) 处理完一页后由调用方显式调用。
+         */
+        void finishPage() {
+            String text = pageText.toString();
             for (String strategyCode : strategies) {
                 SensitiveType type = SensitiveType.fromCode(strategyCode);
                 if (type == null) continue;
-                
+
                 Matcher matcher = type.getPattern().matcher(text);
                 while (matcher.find()) {
-                    // Match found! We need to map this match back to TextPositions.
-                    int start = matcher.start();
-                    int end = matcher.end();
-                    
-                    // Calculate bounding box for the matched range
-                    // textPositions should align with 'text' characters.
-                     if (start < textPositions.size() && end <= textPositions.size()) {
-                        float minX = Float.MAX_VALUE;
-                        float maxY = -1; // Top-most Y (in PDF bottom-up, Top is max? No, in standard PDF, Bottom is 0)
-                        // Wait, TextPosition getYDirAdj() is Top-Down (0 at top).
-                        // PDPageContentStream uses Bottom-Up (0 at bottom).
-                        // We need to convert.
-                        
-                        float minY_PDF = Float.MAX_VALUE;
-                        float maxY_PDF = -1;
-                        
-                        for (int k = start; k < end; k++) {
-                            TextPosition tp = textPositions.get(k);
-                            
-                            // X is standard
-                            if (tp.getXDirAdj() < minX) minX = tp.getXDirAdj();
-                            
-                            // Y: tp.getYDirAdj() is from Top. 
-                            // We need PDF Y (from bottom). 
-                            // Fortunately, TextPosition also has getPageHeight() maybe? No.
-                            // But tp.getY() is usually unadjusted? 
-                            // actually TextPosition textY, pageHeight are available?
-                            // Let's use getX() and getY() (unadjusted non-flipped) ??
-                            // Usually getXDirAdj() and getYDirAdj() are best for "visual" extraction.
-                            
-                            // Let's assume we want to draw exactly where the text is.
-                            // We can use the Matrix? 
-                            // Simpler: Use TextPosition.getX() and getY() (but check coordinate system).
-                            // 
-                            // Correct approach for redaction usually involves:
-                            // x = tp.getXDirAdj();
-                            // y = tp.getPageHeight() - tp.getYDirAdj(); (Flip back to bottom-up)
-                            // height = tp.getHeightDir();
-                            // width = tp.getWidthDirAdj();
-                            
-                            float pHeight = tp.getPageHeight();
-                            float pY = pHeight - tp.getYDirAdj(); // Bottom-up Y of the baseline approx
-                            // Adjust for font height to cover top of letters
-                            // The box should start at pY - descender? 
-                            // Simplified: 
-                            // Box Bottom Y = pHeight - tp.getYDirAdj() - (some descent);
-                            // Box Top Y = Box Bottom Y + tp.getHeightDir();
-                            
-                            // Let's use the provided bounding box logic from common PDFbox examples:
-                            // rect x = tp.getXDirAdj()
-                            // rect y = tp.getPageHeight() - tp.getYDirAdj() - tp.getHeightDir(); (Assuming yDirAdj is baseline?)
-                            // Actually getYDirAdj() is usually the "Baseline" Y from top.
-                            
-                            // Let's rely on getX(), getY(), getHeight(), getWidth().
-                            // tp.getY() -> This is usually bottom-up Y of baseline? 
-                            // No, PDFTextStripper normalizes to Top-Left 0,0.
-                            
-                            float x = tp.getXDirAdj();
-                            float yTop = tp.getYDirAdj(); // Y from top
-                            float h = tp.getHeightDir();
-                            float w = tp.getWidthDirAdj();
-                            
-                            // Convert to bottom-up for ContentStream
-                            float pageHeight = tp.getPageHeight();
-                            float yBottom = pageHeight - yTop; // This is the baseline Y in bottom-up
-                            
-                            // We want to cover from yBottom (descender?) to yBottom + h.
-                            // Actually 'h' from TextPosition is usually font height.
-                            // The rectangle should specify bottom-left corner (x, y) and w, h.
-                            // So: x = x, y = yBottom, w = w, h = h.
-                            // Note: PDF 'y' usually refers to baseline. Text goes up and down.
-                            // Let's add a small buffer?
-                            
-                            // Since we want to obliterate it, being slightly larger is better.
-                            // y = yBottom - 2 (descent buffer)
-                            // h = h + 2 + 2 
-                            
-                            float rectX = x;
-                            float rectY = yBottom; 
-                            float rectW = w;
-                            float rectH = h;
-                            
-                            
-                            if (rectY < minY_PDF) minY_PDF = rectY;
-                            if (rectY + rectH > maxY_PDF) maxY_PDF = rectY + rectH;
-                        }
-                        
-                         // Aggregate width for the whole word match
-                        float wordWidth = 0;
-                        for (int k = start; k < end; k++) {
-                             wordWidth += textPositions.get(k).getWidthDirAdj();
-                        }
-                        
-                        // We need a single rect for the whole match? 
-                        // Or individual rects? A single rect is cleaner visually.
-                        // Assuming horizontal text.
-                        
-                        redactionAreas.add(new RedactionArea(currentPdfPageIndex, minX, minY_PDF, wordWidth, maxY_PDF - minY_PDF));
-                     }
+                    addRedactionArea(type, matcher.start(), matcher.end());
                 }
             }
+            pageText.setLength(0);
+            pagePositions.clear();
+        }
+
+        private void addRedactionArea(SensitiveType type, int start, int end) {
+            if (start < 0 || end > pagePositions.size() || start >= end) {
+                log.warn("PDF脱敏：第{}页命中{}但匹配区间越界（start={}, end={}, size={}），跳过画框",
+                        currentPdfPageIndex + 1, type.getLabel(), start, end, pagePositions.size());
+                return;
+            }
+
+            // **按行分段画框**：命中区间可能跨行（整页累积匹配的代价），而一个横跨两行的
+            // 包围盒会把两行之间、左右两侧的全部内容一起涂黑——那是把无关正文毁掉，
+            // 比漏盖更糟。所以先按基线把命中字符切成若干段，每段各画一个框。
+            List<Integer> segmentStarts = new ArrayList<>();
+            List<Integer> segmentEnds = new ArrayList<>();
+            int segStart = start;
+            Float lineY = null;
+            for (int k = start; k < end; k++) {
+                TextPosition tp = pagePositions.get(k);
+                if (tp == null) {
+                    // 该字符缺少可靠坐标（字符数/位置数不一致的片段），不能猜一个位置去画框——
+                    // 如实记为"这次命中没能画框"，避免出现"看起来已脱敏、实则未覆盖"的假阳性。
+                    log.warn("PDF脱敏：第{}页命中{}但命中区间内存在无法映射坐标的字符，跳过画框（原文可能未被遮盖，请人工核查）",
+                            currentPdfPageIndex + 1, type.getLabel());
+                    return;
+                }
+                float y = tp.getYDirAdj();
+                if (lineY == null) {
+                    lineY = y;
+                } else if (Math.abs(y - lineY) > LINE_TOLERANCE) {
+                    segmentStarts.add(segStart);
+                    segmentEnds.add(k);
+                    segStart = k;
+                    lineY = y;
+                }
+            }
+            segmentStarts.add(segStart);
+            segmentEnds.add(end);
+
+            for (int s = 0; s < segmentStarts.size(); s++) {
+                addSingleLineArea(segmentStarts.get(s), segmentEnds.get(s));
+            }
+        }
+
+        /** 同一行内的一段命中字符 -> 一个黑框。 */
+        private void addSingleLineArea(int start, int end) {
+            // TextPosition.getYDirAdj() 是从页面顶部往下算的基线 Y，PDPageContentStream 画矩形要用
+            // PDF 用户空间（从底部往上）的坐标，所以要用 pageHeight 翻转过来。
+            float minX = Float.MAX_VALUE;
+            float maxX = -Float.MAX_VALUE;
+            float minY = Float.MAX_VALUE;
+            float maxY = -Float.MAX_VALUE;
+            for (int k = start; k < end; k++) {
+                TextPosition tp = pagePositions.get(k);
+                float x = tp.getXDirAdj();
+                float w = tp.getWidthDirAdj();
+                float yBottom = tp.getPageHeight() - tp.getYDirAdj(); // 翻转为 PDF 底部起算坐标
+                float h = tp.getHeightDir();
+                if (x < minX) minX = x;
+                if (x + w > maxX) maxX = x + w;
+                if (yBottom < minY) minY = yBottom;
+                if (yBottom + h > maxY) maxY = yBottom + h;
+            }
+            // 用真实的包围盒（minX~maxX）而不是"逐字宽度求和"：同一行内命中区间可能跨越词间距，
+            // 求和会得到与实际视觉跨度对不上的宽度，导致黑框覆盖不全。
+            redactionAreas.add(new RedactionArea(currentPdfPageIndex, minX, minY, maxX - minX, maxY - minY));
         }
     }
 

--- a/backend/src/test/java/com/checkba/service/SensitiveServiceRedactionTest.java
+++ b/backend/src/test/java/com/checkba/service/SensitiveServiceRedactionTest.java
@@ -7,7 +7,12 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.poi.wp.usermodel.HeaderFooterType;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFEndnote;
+import org.apache.poi.xwpf.usermodel.XWPFFooter;
+import org.apache.poi.xwpf.usermodel.XWPFFootnote;
+import org.apache.poi.xwpf.usermodel.XWPFHeader;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.junit.jupiter.api.Test;
 
@@ -17,12 +22,17 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 锁定脱敏的安全性质：
  * - PDF：脱敏后为图片型 PDF，底层文字被移除，敏感号码不可再被提取（此前仅画黑框、可复制还原）。
- * - DOCX：敏感串即使被排版拆到多个 run 也会被脱敏（跨 run 匹配）。
+ *        且黑框命中不能依赖敏感串恰好落在同一次 writeString 回调里——PDFBox 按行/按词把文字喂给
+ *        stripper，被拆成多段的敏感串也必须命中（dev-board#74 审计 B2-1）。
+ * - DOCX：敏感串即使被排版拆到多个 run 也会被脱敏（跨 run 匹配）；且页眉/页脚/脚注/尾注要与正文
+ *         同等处理，不能只扫正文段落与表格（dev-board#74 审计 B2-2）。
  */
 class SensitiveServiceRedactionTest {
 
@@ -69,6 +79,138 @@ class SensitiveServiceRedactionTest {
                     .map(XWPFParagraph::getText)
                     .collect(Collectors.joining());
             assertFalse(text.contains("13800001111"), "跨 run 的手机号必须被脱敏");
+        }
+    }
+
+    /**
+     * PDFBox 的 PDFTextStripper 按"行/词"把文字喂给 writeString 回调（同一视觉行也可能因换行、
+     * 分栏等原因被拆成多次回调）。若只在每次回调拿到的片段内做正则匹配，被拆开的敏感串永远凑不齐、
+     * 永远命中不了——但栅格化步骤仍然无条件执行，输出看起来"已脱敏"，实则敏感信息以图像形式完好保留。
+     * 用 computeRedactionAreas 直接断言命中区域列表，而不是提取输出文本：栅格化后底层文字必然被抹掉，
+     * 靠"文本提取不到"是无法区分"真的脱敏了"和"压根没匹配上、只是文字层被删了"这两种情况的。
+     */
+    @Test
+    void pdfRedactionCatchesPhoneNumberSplitAcrossFragments() throws Exception {
+        SensitiveService service = new SensitiveService();
+
+        // A：手机号一次性 showText 写完——基线场景，不应受本次改动影响。
+        try (PDDocument wholeDoc = new PDDocument()) {
+            PDPage page = new PDPage();
+            wholeDoc.addPage(page);
+            try (PDPageContentStream cs = new PDPageContentStream(wholeDoc, page)) {
+                cs.beginText();
+                cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                cs.newLineAtOffset(100, 700);
+                cs.showText("13800001111");
+                cs.endText();
+            }
+            List<SensitiveService.RedactionArea> areas = service.computeRedactionAreas(wholeDoc, List.of("PHONE"));
+            assertFalse(areas.isEmpty(), "完整写入同一片段的手机号必须命中");
+        }
+
+        // B：手机号被拆成 "1380000" + "1111" 两段、分两行写入，PDFBox 会用两次独立的 writeString
+        // 回调喂给 stripper（Y 坐标跳变，行内 overlap 判断会强制切行）。
+        try (PDDocument splitDoc = new PDDocument()) {
+            PDPage page = new PDPage();
+            splitDoc.addPage(page);
+            try (PDPageContentStream cs = new PDPageContentStream(splitDoc, page)) {
+                cs.beginText();
+                cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                cs.newLineAtOffset(100, 700);
+                cs.showText("1380000");
+                cs.endText();
+
+                cs.beginText();
+                cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                cs.newLineAtOffset(100, 660); // 换行，Y 坐标明显跳变
+                cs.showText("1111");
+                cs.endText();
+            }
+            List<SensitiveService.RedactionArea> areas = service.computeRedactionAreas(splitDoc, List.of("PHONE"));
+            assertFalse(areas.isEmpty(),
+                    "被拆成多个 writeString 片段（跨行）的手机号也必须命中，不能因为单次回调只看到片段就漏判");
+
+            // 跨行命中必须按行切成多个框。一个横跨两行的包围盒会把两行之间、左右两侧的
+            // 全部内容一起涂黑——那是把无关正文毁掉，比漏盖更糟。
+            assertTrue(areas.size() >= 2, "跨行命中要按行分段画框，实际只有 " + areas.size() + " 个区域");
+            float lineGap = 700 - 660;
+            for (SensitiveService.RedactionArea area : areas) {
+                assertTrue(area.height < lineGap,
+                        "单个黑框不该纵向跨越两行（高度 " + area.height + " >= 行距 " + lineGap + "）");
+            }
+        }
+    }
+
+    /**
+     * processDocx 此前只遍历 doc.getParagraphs() 与 doc.getTables()，页眉/页脚/脚注/尾注原样保留。
+     * 律所文书的抬头、落款、联系方式恰恰常见于页眉页脚——正文测不含手机号、只在页眉里放一个，
+     * 复现"页眉完全没被扫描"的缺陷。
+     */
+    @Test
+    void docxRedactionCoversHeader() throws Exception {
+        File src = File.createTempFile("redact-src-", ".docx");
+        try (XWPFDocument doc = new XWPFDocument()) {
+            XWPFHeader header = doc.createHeader(HeaderFooterType.DEFAULT);
+            header.createParagraph().createRun().setText("联系电话:13800001111");
+            doc.createParagraph().createRun().setText("正文不含手机号");
+            try (FileOutputStream out = new FileOutputStream(src)) {
+                doc.write(out);
+            }
+        }
+
+        String outPath = new SensitiveService().processFile(src.getAbsolutePath(), List.of("PHONE"));
+
+        try (XWPFDocument out = new XWPFDocument(Files.newInputStream(new File(outPath).toPath()))) {
+            String headerText = out.getHeaderList().stream()
+                    .map(XWPFHeader::getText)
+                    .collect(Collectors.joining());
+            assertTrue(headerText.contains("联系电话"), "页眉本身应该还在，只是号码要被脱敏（确认真的读到了页眉，不是空断言）");
+            assertFalse(headerText.contains("13800001111"), "页眉里的手机号必须被脱敏");
+        }
+    }
+
+    /**
+     * 与页眉同一根因，一并覆盖页脚、脚注、尾注三处——避免"只补了页眉，脚注/尾注还是漏的"这种半吊子修复。
+     */
+    @Test
+    void docxRedactionCoversFooterFootnoteAndEndnote() throws Exception {
+        File src = File.createTempFile("redact-src-", ".docx");
+        try (XWPFDocument doc = new XWPFDocument()) {
+            XWPFFooter footer = doc.createFooter(HeaderFooterType.DEFAULT);
+            footer.createParagraph().createRun().setText("footer:13800001112");
+
+            XWPFFootnote footnote = doc.createFootnote();
+            footnote.createParagraph().createRun().setText("footnote:13800001113");
+
+            XWPFEndnote endnote = doc.createEndnote();
+            endnote.createParagraph().createRun().setText("endnote:13800001114");
+
+            doc.createParagraph().createRun().setText("正文不含手机号");
+            try (FileOutputStream out = new FileOutputStream(src)) {
+                doc.write(out);
+            }
+        }
+
+        String outPath = new SensitiveService().processFile(src.getAbsolutePath(), List.of("PHONE"));
+
+        try (XWPFDocument out = new XWPFDocument(Files.newInputStream(new File(outPath).toPath()))) {
+            String footerText = out.getFooterList().stream()
+                    .map(XWPFFooter::getText)
+                    .collect(Collectors.joining());
+            String footnoteText = out.getFootnotes().stream()
+                    .map(f -> f.getParagraphs().stream().map(XWPFParagraph::getText).collect(Collectors.joining()))
+                    .collect(Collectors.joining());
+            String endnoteText = out.getEndnotes().stream()
+                    .map(e -> e.getParagraphs().stream().map(XWPFParagraph::getText).collect(Collectors.joining()))
+                    .collect(Collectors.joining());
+
+            // 用 assertAll：三处互不短路，任何一处漏改都会在同一次运行里独立报出来，
+            // 不会被排在前面的失败挡住看不见。
+            assertAll(
+                    () -> assertFalse(footerText.contains("13800001112"), "页脚里的手机号必须被脱敏"),
+                    () -> assertFalse(footnoteText.contains("13800001113"), "脚注里的手机号必须被脱敏"),
+                    () -> assertFalse(endnoteText.contains("13800001114"), "尾注里的手机号必须被脱敏")
+            );
         }
     }
 }


### PR DESCRIPTION
两条（子 agent 完成，审校时补了一处，见文末）。都先写测试看它红、改实现看它绿、
再把实现还原确认测试真会红。

1. [HIGH] PDF 脱敏是按片段匹配的，被拆开的敏感串永远打不上码，页面却照样被栅格化
   writeString 回调里只在这一次拿到的片段内做正则匹配，而 PDFBox 是按词/按行把片段
   喂进来的（代码自己的注释就写着 text 可能是 "138"/"0013" 这种片段）。
   跨片段的敏感串永远凑不齐、永远产生不了黑框；而「栅格化真删文字层」那一步是
   **无条件**对每一页做的，与该页有没有画上黑框无关——于是输出永远是一份
   「看起来已脱敏、文字层已抹掉」的 PDF，漏掉的个人信息以图像形式完好可见。
   另外旧代码里 `start < size && end <= size` 不成立时，匹配会被再静默丢一次。
   修法：writeString 只累积「整页文本 + 逐字符坐标」，一页收完后在 finishPage()
   里对整页统一匹配，再把命中区间映射回 TextPosition 求黑框。
   字符数与坐标数对不上（连字等）时用 null 占位并打日志，命中区间落在占位上就如实
   判定「这次没能画框、请人工核查」，而不是猜一个位置画错框——不让「没盖上」
   和「盖上了」长得一样。

   **审校补充**：子 agent 的实现对跨行命中会画出**一个横跨两行的包围盒**，
   把两行之间、左右两侧的全部内容一起涂黑——那是把无关正文毁掉，比漏盖更糟。
   改成按基线切段、每段各画一个框，并加断言钉住「单个黑框不得纵向跨越两行」
   （临时去掉切行逻辑实测该断言变红）。

   **留给维护者的取舍**：整页累积意味着相邻两个无关数字串会被拼成一个长数字串，
   变长数字模式（BANK_CARD 是 \d{16,19}）理论上可能因此误命中，把两处正常数字
   一起涂黑。这与 #498 清单里 CHINESE_NAME 那条「过度脱敏」属同一类产品口径问题，
   本次不擅自收紧规则——需要收紧的话，方向是给数字类模式加前后不接数字的断言。

2. [HIGH] DOCX 脱敏只扫正文段落与表格，页眉/页脚/脚注/尾注原样保留
   律所文书的抬头、落款、联系方式恰恰常见于页眉页脚，而接口照常 200 并登记一份
   「[已脱敏]」文件。把这四类容器一并纳入同一套替换逻辑（它们都暴露相同的
   getParagraphs()/getTables() 形状），表格排版的页眉页脚也覆盖到。
   **文本框（w:txbxContent）明确未覆盖**：POI 的 xwpf 对象模型没有暴露 Word 文本框
   类型，paragraphs/tables 都取不到，要手写原始 XML 遍历才能做。已在代码注释里
   如实写明——文本框里塞了敏感信息不会被脱敏，需要人工核查。不假装做了。

全量 mvn test：2183 通过 0 失败 11 跳过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)