### PR TITLE
fix: 补扫清单 40 条一揽子修复（dev-board#74）

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -110,7 +110,7 @@ jobs:
       # ──────────────────────────────────────────────────────────────
       # Python 运行时 / 各 pysvc / graphviz 的缓存。
       #
-      # 这几样只由 requirements.lock 与打包脚本决定，与本次提交的代码无关，
+      # 这几样只由 requirements.lock、各服务源码与打包脚本决定，
       # 但过去每个 PR 都从零重装一遍（实测 Windows 上 mineru 111s + kokoro 98s +
       # pptx 60s + asr 22s + graphviz 43s ≈ 5.6 分钟纯浪费）。
       #
@@ -119,6 +119,11 @@ jobs:
       # 放在它之前恢复的缓存会被当场抹掉。
       #
       # key 里带打包脚本自身的哈希：脚本改了（比如换 Python 版本）就该重装。
+      # **也必须带各服务的源码哈希**（dev-board#74）：prepare-python-service.js 的
+      # --src 会把源码 cpSync 进这里被缓存的 pysvc/。少了它，只改
+      # pptx-service/backend、kokoro-service、asr-service 而不动 lock 时 key 不变，
+      # 缓存命中就把下面的打包步骤整步跳过，装机包里带的还是旧源码——构建全绿、
+      # 冒烟也过（跑的是旧代码），tag 构建会把缺了这笔改动的安装包直接发出去。
       # 开头的 v1 是人工盐——graphviz 来自 choco/brew，上游版本不体现在任何文件哈希里，
       # 想强制取新版就把它 +1。
       # ──────────────────────────────────────────────────────────────
@@ -131,10 +136,10 @@ jobs:
             desktop/bundled/mac-arm64/python
             desktop/bundled/mac-arm64/pysvc
             desktop/bundled/mac-arm64/graphviz
-          key: v1-mac-arm64-pybundle-${{ hashFiles('*/requirements.lock', 'desktop/scripts/prepare-python-service.js', 'desktop/scripts/prepare-graphviz.js') }}
+          key: v1-mac-arm64-pybundle-${{ hashFiles('*/requirements.lock', 'desktop/scripts/prepare-python-service.js', 'desktop/scripts/prepare-graphviz.js', 'pptx-service/backend/**', 'kokoro-service/**', 'asr-service/**') }}
 
       - name: Bundle pptx-service (macOS arm64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'macOS' && steps.cache-pybundle-mac.outputs.cache-hit != 'true'
         run: |
           node desktop/scripts/prepare-python-service.js \
@@ -143,7 +148,7 @@ jobs:
             --requirements pptx-service/requirements.lock \
             --out desktop/bundled/mac-arm64
       - name: Bundle mineru-service (macOS arm64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'macOS' && steps.cache-pybundle-mac.outputs.cache-hit != 'true'
         run: |
           # 纯 pip 包服务（无 --src）；模型不进包，首启在「组件管理」下载
@@ -153,7 +158,7 @@ jobs:
             --out desktop/bundled/mac-arm64
           du -sh desktop/bundled/mac-arm64/pysvc/mineru-service/lib
       - name: Bundle kokoro-service (macOS arm64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'macOS' && steps.cache-pybundle-mac.outputs.cache-hit != 'true'
         run: |
           # 本地 TTS 包装层（Phase 3）：模型不进包，首启在「组件管理」下载
@@ -164,7 +169,7 @@ jobs:
             --out desktop/bundled/mac-arm64
           du -sh desktop/bundled/mac-arm64/pysvc/kokoro-service/lib
       - name: Bundle asr-service (macOS arm64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'macOS' && steps.cache-pybundle-mac.outputs.cache-hit != 'true'
         run: |
           # 本地 ASR 包装层（P3）：模型不进包（1.5GB），首启在「组件管理」下载
@@ -187,7 +192,7 @@ jobs:
       # ──────────────────────────────────────────────────────────────
       # Python 运行时 / 各 pysvc / graphviz 的缓存。
       #
-      # 这几样只由 requirements.lock 与打包脚本决定，与本次提交的代码无关，
+      # 这几样只由 requirements.lock、各服务源码与打包脚本决定，
       # 但过去每个 PR 都从零重装一遍（实测 Windows 上 mineru 111s + kokoro 98s +
       # pptx 60s + asr 22s + graphviz 43s ≈ 5.6 分钟纯浪费）。
       #
@@ -196,6 +201,11 @@ jobs:
       # 放在它之前恢复的缓存会被当场抹掉。
       #
       # key 里带打包脚本自身的哈希：脚本改了（比如换 Python 版本）就该重装。
+      # **也必须带各服务的源码哈希**（dev-board#74）：prepare-python-service.js 的
+      # --src 会把源码 cpSync 进这里被缓存的 pysvc/。少了它，只改
+      # pptx-service/backend、kokoro-service、asr-service 而不动 lock 时 key 不变，
+      # 缓存命中就把下面的打包步骤整步跳过，装机包里带的还是旧源码——构建全绿、
+      # 冒烟也过（跑的是旧代码），tag 构建会把缺了这笔改动的安装包直接发出去。
       # 开头的 v1 是人工盐——graphviz 来自 choco/brew，上游版本不体现在任何文件哈希里，
       # 想强制取新版就把它 +1。
       # ──────────────────────────────────────────────────────────────
@@ -208,10 +218,10 @@ jobs:
             desktop/bundled/win-x64/python
             desktop/bundled/win-x64/pysvc
             desktop/bundled/win-x64/graphviz
-          key: v1-win-x64-pybundle-${{ hashFiles('*/requirements.lock', 'desktop/scripts/prepare-python-service.js', 'desktop/scripts/prepare-graphviz.js') }}
+          key: v1-win-x64-pybundle-${{ hashFiles('*/requirements.lock', 'desktop/scripts/prepare-python-service.js', 'desktop/scripts/prepare-graphviz.js', 'pptx-service/backend/**', 'kokoro-service/**', 'asr-service/**') }}
 
       - name: Bundle pptx-service (Windows x64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'Windows' && steps.cache-pybundle-win.outputs.cache-hit != 'true'
         shell: bash
         run: |
@@ -221,7 +231,7 @@ jobs:
             --requirements pptx-service/requirements.lock \
             --out desktop/bundled/win-x64
       - name: Bundle mineru-service (Windows x64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'Windows' && steps.cache-pybundle-win.outputs.cache-hit != 'true'
         shell: bash
         run: |
@@ -231,7 +241,7 @@ jobs:
             --out desktop/bundled/win-x64
           du -sh desktop/bundled/win-x64/pysvc/mineru-service/lib
       - name: Bundle kokoro-service (Windows x64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'Windows' && steps.cache-pybundle-win.outputs.cache-hit != 'true'
         shell: bash
         run: |
@@ -242,7 +252,7 @@ jobs:
             --out desktop/bundled/win-x64
           du -sh desktop/bundled/win-x64/pysvc/kokoro-service/lib
       - name: Bundle asr-service (Windows x64)
-        # 缓存命中就整步跳过——产物只由 requirements.lock / 打包脚本决定，见上面那条 cache
+        # 缓存命中就整步跳过——产物只由 requirements.lock / 服务源码 / 打包脚本决定，见上面那条 cache
         if: runner.os == 'Windows' && steps.cache-pybundle-win.outputs.cache-hit != 'true'
         shell: bash
         run: |

--- a/backend/src/main/java/com/checkba/controller/ProjectFileController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectFileController.java
@@ -129,6 +129,26 @@ public class ProjectFileController {
     }
 
     /**
+     * 校验创建/移动时指定的父目录：必须是本项目内未删除的文件夹（parentId 为空表示根目录）。
+     * 此前 parentId 完全不校验：前端对话框/拖拽目标缓存的目录 id 若在提交前被另一端软删除，
+     * 新节点仍会以 isDeleted=false 挂到已删除的父目录下，接口返回 200 看着成功，
+     * 但 getFileTree/getFilesByParent 只取 isDeleted=false 的行，永远拼不出它的路径，
+     * 节点在所有树视图里凭空消失。跨项目 parentId 同理。
+     */
+    private void checkParentFolder(Long parentId, Long projectId) {
+        if (parentId == null) {
+            return;
+        }
+        ProjectFile parent = projectFileService.getFile(parentId); // 不存在会抛异常
+        if (!projectId.equals(parent.getProjectId())
+                || !Boolean.TRUE.equals(parent.getIsFolder())
+                || Boolean.TRUE.equals(parent.getIsDeleted())) {
+            throw new IllegalArgumentException(com.checkba.service.LangText.of(
+                    "目标文件夹不存在或已被删除", "The target folder does not exist or has been deleted"));
+        }
+    }
+
+    /**
      * 创建文件夹
      * POST /api/projects/{projectId}/files/folder
      */
@@ -142,6 +162,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileWriteAccess(projectId, userId);
+        checkParentFolder(request.getParentId(), projectId);
         return projectFileService.createFolder(projectId, request.getParentId(), request.getName(), userId);
     }
 
@@ -203,6 +224,7 @@ public class ProjectFileController {
             throw new UnauthorizedException("请先登录");
         }
         checkFileWriteAccess(projectId, userId);
+        checkParentFolder(request.getParentId(), projectId);
         // 存储键一律由服务端按 projectId + 目录结构生成：请求体里的 filePath 曾被原样落库，
         // 可指向他人项目的文件，再借这条记录下载/覆盖对方的文档
         return projectFileService.createFile(
@@ -344,6 +366,7 @@ public class ProjectFileController {
         }
         checkFileWriteAccess(projectId, userId);
         checkFileInProject(fileId, projectId);
+        checkParentFolder(request.getParentId(), projectId);
         return projectFileService.move(fileId, request.getParentId(), request.getSortOrder(), userId);
     }
 

--- a/backend/src/main/java/com/checkba/controller/WebFavoriteController.java
+++ b/backend/src/main/java/com/checkba/controller/WebFavoriteController.java
@@ -30,14 +30,22 @@ public class WebFavoriteController {
     private final UserRepository userRepository;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    /** 我的收藏返回条数上限：个人中心那一栏没有搜索框，比项目内收藏的 80 放宽一些 */
+    private static final int MY_FAVORITES_DEFAULT_LIMIT = 200;
+    private static final int MY_FAVORITES_MAX_LIMIT = 500;
+
     @GetMapping("/api/favorites/my")
-    public ResponseEntity<?> myFavorites(@RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+    public ResponseEntity<?> myFavorites(
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error(com.checkba.service.LangText.of("请先登录", "Please sign in first")));
         }
+        // 性能关键：与项目内收藏同口径——限量 + 返回轻量列表（meta 可能包含 html 快照，体积巨大）
+        int lim = (limit == null ? MY_FAVORITES_DEFAULT_LIMIT : Math.max(1, Math.min(MY_FAVORITES_MAX_LIMIT, limit)));
         List<WebFavorite> list = webFavoriteService.listMyFavorites(userId);
-        return ResponseEntity.ok(list);
+        return ResponseEntity.ok(list.stream().limit(lim).map(WebFavoriteListItem::from).toList());
     }
 
     @GetMapping("/api/projects/{projectId}/favorites")

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -286,12 +286,6 @@ public class ProjectFileService {
 
         // 权限检查已移至 Controller 层，这里不再检查创建者身份
 
-        // 检查同名文件是否存在
-        if (projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
-                file.getProjectId(), file.getParentId(), newName.trim(), fileId)) {
-            throw new IllegalArgumentException(LangText.of("该文件夹下已存在同名文件/文件夹: ", "A file or folder with this name already exists: ") + newName);
-        }
-
         String oldName = file.getName();
         String oldFilePath = file.getFilePath();
         
@@ -315,7 +309,14 @@ public class ProjectFileService {
                 finalNewName = finalNewName + "." + file.getFileType();
             }
         }
-        
+
+        // 检查同名文件是否存在。必须用补完后缀的最终名字来查——用户只填主名时后缀会被自动补回，
+        // 拿裸名字查重会放过与既有同后缀文件的碰撞，物理路径又由名字派生，会覆盖掉对方的内容。
+        if (projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                file.getProjectId(), file.getParentId(), finalNewName, fileId)) {
+            throw new IllegalArgumentException(LangText.of("该文件夹下已存在同名文件/文件夹: ", "A file or folder with this name already exists: ") + finalNewName);
+        }
+
         // 更新文件名
         file.setName(finalNewName);
         file.setUpdatedAt(LocalDateTime.now());

--- a/backend/src/main/java/com/checkba/service/ProjectService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectService.java
@@ -16,7 +16,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +40,26 @@ public class ProjectService {
     private final TushareService tushareService;
     private final ProjectVariableService projectVariableService;
     private final com.checkba.service.telemetry.TelemetryService telemetryService;
+    private final com.checkba.storage.ProjectStorageResolver storageResolver;
+    private final com.checkba.version.ProjectRepoService projectRepoService;
+
+    @jakarta.persistence.PersistenceContext
+    private jakarta.persistence.EntityManager entityManager;
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ProjectService.class);
+
+    /**
+     * 删项目时必须一并清掉的项目级实体。
+     *
+     * 这些表全部只存一个裸 Long 的 projectId（没有 JPA 关联），而各 profile 都是
+     * hibernate ddl-auto=update——裸 Long 列不会生成外键，数据库层也就没有
+     * ON DELETE CASCADE。级联只能在这里手写，漏一张表就是一批永久孤儿行。
+     * 新增项目级实体时同步往这里加一条。
+     */
+    private static final List<String> PROJECT_SCOPED_ENTITIES = List.of(
+            "ProjectMember", "ProjectFile", "ProjectVariable", "ProjectProfileField",
+            "ProjectMemory", "ProjectInvitation", "ProjectRemote", "ProjectTask",
+            "ProjectAiMessage");
 
     @Transactional
     public Project createProject(ProjectCreateRequest request, Long userId) {
@@ -230,12 +254,51 @@ public class ProjectService {
     }
 
     /**
-     * 删除项目
+     * 删除项目：连带清掉项目级的库行与磁盘目录。
+     *
+     * 「删除项目」对律师意味着这个项目的材料不再留存，所以文档目录与版本记录仓库
+     * 都要一并抹掉，不能只删 project 行。
      */
+    @Transactional
     public void deleteProject(Long id) {
         if (!projectRepository.existsById(id)) {
             throw new IllegalArgumentException(LangText.of("项目不存在: ", "Project not found: ") + id);
         }
+
+        // 物理路径必须在删行之前算：localRoot 存在 Project 行上，行没了就解析不出来。
+        // IDE 化本地文件夹项目的目录是用户自己的文件夹，只解绑不删。
+        Path projectDir = storageResolver.hasLocalRoot(id) ? null : storageResolver.projectRoot(id);
+        Path gitDir = projectRepoService.gitDir(id);
+
+        for (String entity : PROJECT_SCOPED_ENTITIES) {
+            entityManager.createQuery("delete from " + entity + " e where e.projectId = :pid")
+                    .setParameter("pid", id)
+                    .executeUpdate();
+        }
         projectRepository.deleteById(id);
+        storageResolver.invalidate(id);
+
+        // 磁盘清理失败不回滚：库里已经删干净了，剩下的目录是可再清的垃圾，
+        // 为它报错反而会让用户以为项目没删掉。
+        deleteDirectoryQuietly(projectDir);
+        deleteDirectoryQuietly(gitDir);
+    }
+
+    /** 递归删目录，失败只记日志。 */
+    private void deleteDirectoryQuietly(Path dir) {
+        if (dir == null || !Files.isDirectory(dir)) {
+            return;
+        }
+        try (java.util.stream.Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    log.warn("删除项目文件失败: {}", p, e);
+                }
+            });
+        } catch (IOException e) {
+            log.warn("删除项目目录失败: {}", dir, e);
+        }
     }
 }

--- a/backend/src/main/java/com/checkba/service/TushareService.java
+++ b/backend/src/main/java/com/checkba/service/TushareService.java
@@ -136,8 +136,14 @@ public class TushareService {
             Set<String> executives = new LinkedHashSet<>();
 
             for (Map<String, String> mgr : managers) {
-                String name = mgr.get("name");
-                String title = mgr.get("job"); // mapped to 'job' in helper
+                // 上游 stk_managers 允许 name/title 缺失（原始公告没披露职务是常态）。
+                // 这里不做兜底的话，一行坏数据 NPE 出去，上层 catch 会把这次已经采到的
+                // 基本信息、股东、管理层三组变量一起丢掉，用户还看不到任何报错。
+                String name = StrUtil.nullToEmpty(mgr.get("name"));
+                String title = StrUtil.nullToEmpty(mgr.get("job")); // mapped to 'job' in helper
+                if (StrUtil.isBlank(name)) {
+                    continue;
+                }
                 if (title.contains("独立董事")) {
                     directors.add(name + "(独董)");
                 } else if (title.contains("董事")) {

--- a/backend/src/main/java/com/checkba/service/WebFavoriteService.java
+++ b/backend/src/main/java/com/checkba/service/WebFavoriteService.java
@@ -71,7 +71,13 @@ public class WebFavoriteService {
                 storageServiceFactory.getStorageService().save(path, new ByteArrayInputStream(bytes));
                 fav.setImagePath(path);
             } catch (Exception e) {
-                log.warn("保存收藏截图失败，忽略继续: userId={}", userId, e);
+                log.warn("保存收藏截图失败: userId={}", userId, e);
+                // 截图是唯一载荷时（网核关联、OCR 摘录收藏都传 content=""），存储一挂就什么都没剩下，
+                // 再吞掉就是落一条空收藏还回 200——用户以为证据存下了，其实根本不存在。
+                // 这时抛出让事务回滚并把失败回给前端；还有正文兜底的才允许降级为「丢截图、留文字」。
+                if (!StringUtils.hasText(content)) {
+                    throw new IllegalArgumentException(LangText.of("截图保存失败，请重试", "Failed to save the screenshot, please try again"));
+                }
             }
         }
 

--- a/backend/src/main/java/com/checkba/service/WizardStateService.java
+++ b/backend/src/main/java/com/checkba/service/WizardStateService.java
@@ -21,6 +21,13 @@ public class WizardStateService {
     /** 全新安装时由 {@code DataInitializer} 先落一份 "false"，见那里的注释。 */
     public static final String KEY_WIZARD_COMPLETED = "system.wizard.completed";
 
+    /**
+     * 「有没有人真的配过 AI」这一行——向导提交与管理后台保存 AI 配置都必写它，
+     * 用来区分标记 "false" 的两个来源（全新安装钉的 vs 管理员 reset 打开的）。
+     * 与 {@code AdminConfigController.KEY_AI_ACTIVE_PROVIDER} 同一个键。
+     */
+    private static final String KEY_AI_ACTIVE_PROVIDER = "ai.activeProvider";
+
     private final SystemSettingService systemSettingService;
     private final SystemSettingRepository systemSettingRepository;
 
@@ -43,14 +50,28 @@ public class WizardStateService {
     }
 
     /**
-     * 是否处于「全新安装的匿名向导窗口」内：标记从未写过且库里没有任何配置。
+     * 是否处于「全新安装的匿名向导窗口」内。
      *
      * <p>与 {@link #isInitialized()} 不是简单取反——管理员 reset 打开的窗口
      * （标记 = "false"）里 {@code isInitialized()} 也是 false，但那个窗口
      * **必须带管理员会话**，不属于匿名窗口。
+     *
+     * <p>判据不能写成「标记从未写过」：全新安装（非单机模式）启动时
+     * {@code DataInitializer} 就把标记钉成了 "false"，标记从此再也不是 null，
+     * 于是每一台全新机器上向导里的本地 Ollama / 本地 ASR 探测都会 401
+     * ——正好是本类注释说要防的那种死法。真正的分界是**有没有人配过 AI**：
+     * 向导提交与管理后台保存都会写 {@code ai.activeProvider}，
+     * 所以 reset 打开的窗口里这一行必然在，全新安装则必然没有。
      */
     public boolean inAnonymousSetupWindow() {
-        return systemSettingService.get(KEY_WIZARD_COMPLETED, null) == null
-                && systemSettingRepository.count() == 0;
+        String completed = systemSettingService.get(KEY_WIZARD_COMPLETED, null);
+        if (completed == null) {
+            // 存量部署：标记从未写过，只有空库才认全新安装（沿用原兜底，防匿名滥用）
+            return systemSettingRepository.count() == 0;
+        }
+        if (Boolean.parseBoolean(completed)) {
+            return false;
+        }
+        return systemSettingService.get(KEY_AI_ACTIVE_PROVIDER, null) == null;
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -1447,9 +1447,39 @@ public class AgentOrchestrator {
         sseEmitterService.send(conversationId, "text_delta", "{\"content\":\"" + esc + "\"}");
     }
 
-    private String truncate(String s, int max) {
+    static String truncate(String s, int max) {
         if (s == null) return "";
-        return s.length() <= max ? s : s.substring(0, max) + LangText.of("...(截断)", "...(truncated)");
+        return s.length() <= max ? s
+                : s.substring(0, tagSafeCut(s, max)) + LangText.of("...(截断)", "...(truncated)");
+    }
+
+    /**
+     * 截断点回退：不许把切口留在一个还没闭合的协议标签形状中间。
+     *
+     * <p>截断先于 {@link AgentTagProtocol#escape} 发生（截断口径按原文字数，与前端
+     * 「...(截断)」提示一致）。切口若落在 {@code <tool_output status="SUC} 这种半截标签里，
+     * 它没有 {@code >}，中和认不出、原样放行；紧随其后的是截断后缀和外层自己的
+     * {@code </tool_output>}，前端 tagRegex 的 {@code [^>]*} 属性段会一路吃到那个闭合标签的
+     * {@code >}——真正的闭合被当成属性吞掉，本轮剩下的正文全被塞进折叠区、工具行一直转圈。
+     *
+     * <p>只回退「还能长成已知标签」的形状：合同里的 {@code <甲方}、比较符 {@code a < b}
+     * 不是标签形状，照旧按字数切，展示内容不凭空少一截。
+     */
+    private static int tagSafeCut(String s, int max) {
+        int lt = s.lastIndexOf('<', max - 1);
+        if (lt < 0) return max;
+        // 切口之前已经闭合过，这个 '<' 不是半截标签
+        if (s.lastIndexOf('>', max - 1) > lt) return max;
+        boolean closing = lt + 1 < max && s.charAt(lt + 1) == '/';
+        String body = s.substring(closing ? lt + 2 : lt + 1, max);
+        for (String tag : AgentTagProtocol.TAGS) {
+            // 标签名还没写全，或标签名已写全、后面正在写属性
+            if (tag.startsWith(body)
+                    || (body.startsWith(tag) && Character.isWhitespace(body.charAt(tag.length())))) {
+                return lt;
+            }
+        }
+        return max;
     }
 
     /** 工具输出在面板上的默认展示上限（历史落库存的是全文，这里只是 SSE 载荷） */

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
@@ -66,14 +66,21 @@ public class SkillRegistry {
     /** id -> skill（保持扫描顺序，内置目录优先于插件） */
     private final Map<String, SkillDefinition> skills = new LinkedHashMap<>();
 
-    /** 被禁用 skill id 集合（内存缓存，与 system_setting 同步） */
-    private final Set<String> disabledSkillIds = ConcurrentHashMap.newKeySet();
+    /**
+     * 被禁用 skill id 集合（内存缓存，与 system_setting 同步）。
+     *
+     * volatile 而非 final：重载（{@link #loadDisabledState}）走"读完新名单再整体换引用"，
+     * 不在原集合上先 clear 再 addAll——{@link #isEnabled} 在 TTL 未到期时是无锁读，
+     * 会在重载的 DB 往返期间读到空名单，把管理员明确停用的 skill 短暂判成启用。
+     * 三个集合的所有写入（增删与换引用）都在 this monitor 下，读方看到的永远是完整的一版。
+     */
+    private volatile Set<String> disabledSkillIds = ConcurrentHashMap.newKeySet();
 
     /** "仅手动"skill id 集合：不参与触发词自动匹配，只能由用户在对话中钉选生效 */
-    private final Set<String> manualSkillIds = ConcurrentHashMap.newKeySet();
+    private volatile Set<String> manualSkillIds = ConcurrentHashMap.newKeySet();
 
     /** 已做过默认启停初始化的 skill id 集合（见 {@link #SEEDED_KEY}） */
-    private final Set<String> seededSkillIds = ConcurrentHashMap.newKeySet();
+    private volatile Set<String> seededSkillIds = ConcurrentHashMap.newKeySet();
 
     private volatile long disabledStateRefreshedAt = 0L;
 
@@ -473,21 +480,35 @@ public class SkillRegistry {
     }
 
     private void loadDisabledState() {
-        disabledSkillIds.clear();
-        manualSkillIds.clear();
-        seededSkillIds.clear();
         if (systemSettingService == null) {
+            disabledSkillIds = ConcurrentHashMap.newKeySet();
+            manualSkillIds = ConcurrentHashMap.newKeySet();
+            seededSkillIds = ConcurrentHashMap.newKeySet();
             return;
         }
         try {
-            disabledSkillIds.addAll(readIdSet(DISABLED_KEY));
-            manualSkillIds.addAll(readIdSet(MANUAL_KEY));
-            seededSkillIds.addAll(readIdSet(SEEDED_KEY));
+            // 三份名单全部读回来之后再换引用：中间隔着几次 DB 往返，
+            // 先 clear 的写法会让并发的无锁读方（isEnabled/isManual）在这段窗口里读到空名单。
+            Set<String> disabled = newIdSet(readIdSet(DISABLED_KEY));
+            Set<String> manual = newIdSet(readIdSet(MANUAL_KEY));
+            Set<String> seeded = newIdSet(readIdSet(SEEDED_KEY));
+            disabledSkillIds = disabled;
+            manualSkillIds = manual;
+            seededSkillIds = seeded;
         } catch (Exception e) {
             log.error("Failed to load skill activation state, default to all auto", e);
+            disabledSkillIds = ConcurrentHashMap.newKeySet();
+            manualSkillIds = ConcurrentHashMap.newKeySet();
+            seededSkillIds = ConcurrentHashMap.newKeySet();
         } finally {
             disabledStateRefreshedAt = System.currentTimeMillis();
         }
+    }
+
+    private static Set<String> newIdSet(List<String> ids) {
+        Set<String> set = ConcurrentHashMap.newKeySet();
+        set.addAll(ids);
+        return set;
     }
 
     private List<String> readIdSet(String key) {

--- a/backend/src/main/java/com/checkba/version/CloudSyncService.java
+++ b/backend/src/main/java/com/checkba/version/CloudSyncService.java
@@ -77,8 +77,19 @@ public class CloudSyncService {
 
     public enum UpdateStatus { UP_TO_DATE, UPDATED, CONFLICT, OFFLINE, NOT_LINKED }
 
+    /**
+     * landedOnCloud：这次整合的结果是不是已经到了云端。真合并路径要看
+     * {@link #completeCloudMerge} 的重推有没有落地；快进/已最新两条路径压根不用推
+     * （本地本就是云端的祖先），天然为真——所以缺省构造器给 true，别拿
+     * ProjectRemote.pendingUpload 的历史值反推，会把本就同步的项目误判成失败。
+     */
     public record UpdateResult(UpdateStatus status, List<Long> affectedFileIds,
-                               Map<String, Object> conflict) {}
+                               Map<String, Object> conflict, boolean landedOnCloud) {
+        public UpdateResult(UpdateStatus status, List<Long> affectedFileIds,
+                            Map<String, Object> conflict) {
+            this(status, affectedFileIds, conflict, true);
+        }
+    }
 
     private static final String ORIGIN_MASTER = "refs/remotes/origin/master";
     private static String cloudMergeTitle() {
@@ -408,6 +419,16 @@ public class CloudSyncService {
                     UpdateResult integrated = integrateFromCloud(projectId, conn, null, authorName);
                     if (integrated.status() == UpdateStatus.UPDATED
                             || integrated.status() == UpdateStatus.UP_TO_DATE) {
+                        if (!integrated.landedOnCloud()) {
+                            // 合并在本地落地了，回传却没到云端（重推又被拒/网络断）：报
+                            // UPLOADED 就是把真失败说成成功——界面显示「已交稿」，而同事
+                            // 永远看不到这份合并。黄灯已由 completeCloudMerge 置上，这里
+                            // 只说实话；affectedFileIds 照常带回，整合改写过的磁盘仍要走
+                            // 重载链。
+                            return new UploadResult(UploadStatus.OFFLINE_PENDING,
+                                    LangText.of("这次没能交稿，改动已经记下，稍后还可以再交", "This submission didn't go through — your changes are saved and you can submit again later"),
+                                    integrated.affectedFileIds());
+                        }
                         return new UploadResult(UploadStatus.UPLOADED, null,
                                 integrated.affectedFileIds());
                     }
@@ -695,7 +716,8 @@ public class CloudSyncService {
      * {@link ProjectTreeManifestService#unionApply(long, TreeManifest, TreeManifest)}——
      * 基线是合并前本地 tip 与云端 tip 的合并基线，只有云端那一侧相对基线真的做过复活
      * 动作才会复活本方亲手软删的文件）→ 提交 → 自动重推。
-     * 重推失败（网络问题）不回滚——合并已经落地，只是回传没成，转入待上传，绝不丢改动。
+     * 重推失败（网络问题）不回滚——合并已经落地，只是回传没成，转入待上传，绝不丢改动；
+     * 落没落地随 {@link UpdateResult#landedOnCloud()} 回给调用方（上传路径据此不报成功交稿）。
      */
     private UpdateResult completeCloudMerge(long projectId, String tipBefore, String cloudTip,
                                             CloudConnection conn, Long userId, String userName) {
@@ -706,12 +728,14 @@ public class CloudSyncService {
         manifestService.writeToWorkTree(projectId, manifestService.capture(projectId));
         repoService.commitMergeResolution(projectId, cloudMergeTitle(),
                 userName, authorEmail(userId, userName));
+        boolean landed = false;
         try {
             // 重推被拒是返回值不是异常（裁决窗口期间远端又被同事推进了一版）：不接住的话
             // 会绿灯假同步——pendingUpload=false + lastSyncSha=本地 sha，界面显示「已与云端
             // 同步」而云端根本没有这份裁决结果（v2 终审 I1）。
             ProjectRepoService.PushOutcome out = repoService.pushMainlineToOrigin(
                     projectId, conn.getUsername(), conn.getDeviceToken());
+            landed = out.pushed();
             remoteRepository.findByProjectId(projectId).ifPresent(remote -> {
                 if (out.pushed()) {
                     remote.setPendingUpload(false);
@@ -730,7 +754,7 @@ public class CloudSyncService {
                 remoteRepository.save(remote);
             });
         }
-        return new UpdateResult(UpdateStatus.UPDATED, affectedSince(projectId, tipBefore), null);
+        return new UpdateResult(UpdateStatus.UPDATED, affectedSince(projectId, tipBefore), null, landed);
     }
 
     /** 受影响文件 id：口径同 revertTo，动作前后的 HEAD 差异反向传给 diffNameStatus。 */

--- a/backend/src/test/java/com/checkba/controller/ProjectFileControllerParentValidationTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectFileControllerParentValidationTest.java
@@ -1,0 +1,169 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.FileTagService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ProjectMemberService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 锁定创建/移动时的父目录校验：parentId 必须是当前项目内未删除的文件夹。
+ * 缺这道闸时接口返回 200，但新节点挂在已删除（或他人项目的）父目录下，
+ * getFileTree/getFilesByParent 永远拼不出它的路径，节点在所有树视图里凭空消失。
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectFileControllerParentValidationTest {
+
+    @Mock
+    private ProjectFileService projectFileService;
+    @Mock
+    private ProjectMemberService projectMemberService;
+    @Mock
+    private FileTagService fileTagService;
+    @Mock
+    private com.checkba.service.quota.StageQuotaService stageQuotaService;
+
+    @InjectMocks
+    private ProjectFileController controller;
+
+    private void allowWrite() {
+        when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+        when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+        when(projectMemberService.hasWritePermission(1L, 1L)).thenReturn(true);
+    }
+
+    private ProjectFile folder(Long id, Long projectId, boolean deleted) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(projectId);
+        f.setIsFolder(true);
+        f.setIsDeleted(deleted);
+        return f;
+    }
+
+    /** 对话框打开后父目录被另一端软删除：这是真实可达的触发路径 */
+    @Test
+    void createFolderRejectsSoftDeletedParent() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowWrite();
+            when(projectFileService.getFile(100L)).thenReturn(folder(100L, 1L, true));
+
+            ProjectFileController.CreateFolderRequest req = new ProjectFileController.CreateFolderRequest();
+            req.setParentId(100L);
+            req.setName("x");
+
+            assertThrows(IllegalArgumentException.class, () -> controller.createFolder(1L, req, "sess"));
+            verify(projectFileService, never()).createFolder(anyLong(), any(), anyString(), anyLong());
+        }
+    }
+
+    /** 父目录属于别的项目：新节点在本项目树里永远拼不出路径 */
+    @Test
+    void createFolderRejectsParentFromAnotherProject() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowWrite();
+            when(projectFileService.getFile(200L)).thenReturn(folder(200L, 999L, false));
+
+            ProjectFileController.CreateFolderRequest req = new ProjectFileController.CreateFolderRequest();
+            req.setParentId(200L);
+            req.setName("x");
+
+            assertThrows(IllegalArgumentException.class, () -> controller.createFolder(1L, req, "sess"));
+            verify(projectFileService, never()).createFolder(anyLong(), any(), anyString(), anyLong());
+        }
+    }
+
+    @Test
+    void createFileRejectsSoftDeletedParent() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowWrite();
+            when(projectFileService.getFile(100L)).thenReturn(folder(100L, 1L, true));
+
+            ProjectFileController.CreateFileRequest req = new ProjectFileController.CreateFileRequest();
+            req.setParentId(100L);
+            req.setName("a.docx");
+
+            assertThrows(IllegalArgumentException.class, () -> controller.createFile(1L, req, "sess"));
+            verify(projectFileService, never()).createFile(
+                    anyLong(), any(), anyString(), any(), any(), any(), any(), anyLong());
+        }
+    }
+
+    /** 拖拽目标在提交前被删除 */
+    @Test
+    void moveRejectsSoftDeletedParent() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowWrite();
+            ProjectFile self = new ProjectFile();
+            self.setId(50L);
+            self.setProjectId(1L);
+            self.setIsFolder(false);
+            when(projectFileService.getFile(50L)).thenReturn(self);
+            when(projectFileService.getFile(100L)).thenReturn(folder(100L, 1L, true));
+
+            ProjectFileController.MoveRequest req = new ProjectFileController.MoveRequest();
+            req.setParentId(100L);
+
+            assertThrows(IllegalArgumentException.class, () -> controller.move(1L, 50L, req, "sess"));
+            verify(projectFileService, never()).move(anyLong(), any(), any(), anyLong());
+        }
+    }
+
+    /** 父目录是个文件而不是文件夹，同样拼不出路径 */
+    @Test
+    void createFolderRejectsNonFolderParent() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowWrite();
+            ProjectFile notFolder = folder(300L, 1L, false);
+            notFolder.setIsFolder(false);
+            when(projectFileService.getFile(300L)).thenReturn(notFolder);
+
+            ProjectFileController.CreateFolderRequest req = new ProjectFileController.CreateFolderRequest();
+            req.setParentId(300L);
+            req.setName("x");
+
+            assertThrows(IllegalArgumentException.class, () -> controller.createFolder(1L, req, "sess"));
+            verify(projectFileService, never()).createFolder(anyLong(), any(), anyString(), anyLong());
+        }
+    }
+
+    /** 根目录（parentId 为 null）与正常父目录不受影响 */
+    @Test
+    void createFolderAllowsRootAndLiveParent() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowWrite();
+            when(projectFileService.getFile(100L)).thenReturn(folder(100L, 1L, false));
+
+            ProjectFileController.CreateFolderRequest root = new ProjectFileController.CreateFolderRequest();
+            root.setName("root-child");
+            controller.createFolder(1L, root, "sess");
+            verify(projectFileService).createFolder(1L, null, "root-child", 1L);
+
+            ProjectFileController.CreateFolderRequest nested = new ProjectFileController.CreateFolderRequest();
+            nested.setParentId(100L);
+            nested.setName("nested");
+            controller.createFolder(1L, nested, "sess");
+            verify(projectFileService).createFolder(1L, 100L, "nested", 1L);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/WebFavoriteControllerMyFavoritesTest.java
+++ b/backend/src/test/java/com/checkba/controller/WebFavoriteControllerMyFavoritesTest.java
@@ -1,0 +1,101 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.WebFavorite;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.WebFavoriteService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code GET /api/favorites/my}：跟项目内收藏同口径——限量 + 只回轻量列表。
+ * meta 里可能压着整页 html 快照（网核证据），直接序列化实体会把它整包发给前端，
+ * 而「我的收藏」那一栏一个字段都不用它。
+ */
+@ExtendWith(MockitoExtension.class)
+class WebFavoriteControllerMyFavoritesTest {
+
+    @Mock
+    private WebFavoriteService webFavoriteService;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private WebFavoriteController controller;
+
+    private static WebFavorite row(long id, String meta) {
+        WebFavorite fav = new WebFavorite();
+        fav.setId(id);
+        fav.setUserId(7L);
+        fav.setTitle("某工商登记页");
+        fav.setSourceUrl("https://example.com/" + id);
+        fav.setContent("摘录文本");
+        fav.setMeta(meta);
+        fav.setCreatedAt(LocalDateTime.of(2026, 8, 20, 9, 0));
+        return fav;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<WebFavoriteController.WebFavoriteListItem> items(ResponseEntity<?> resp) {
+        return (List<WebFavoriteController.WebFavoriteListItem>) resp.getBody();
+    }
+
+    @Test
+    void dropsHugeMetaAndKeepsDisplayFields() {
+        String html = "<html>" + "x".repeat(200_000) + "</html>";
+        String meta = "{\"sourceHost\":\"example.com\",\"html\":\"" + html + "\"}";
+        when(webFavoriteService.listMyFavorites(7L)).thenReturn(List.of(row(1L, meta)));
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(7L);
+            ResponseEntity<?> resp = controller.myFavorites(null, "s");
+
+            List<WebFavoriteController.WebFavoriteListItem> body = items(resp);
+            assertEquals(1, body.size());
+            // 轻量投影：没有 meta 这个字段，html 快照走不出去
+            assertEquals(1L, body.get(0).getId());
+            assertEquals("example.com", body.get(0).getSourceHost());
+            assertEquals("摘录文本", body.get(0).getContent());
+            assertFalse(hasField(body.get(0), "meta"), "轻量列表项不该带 meta");
+        }
+    }
+
+    @Test
+    void capsRowCount() {
+        List<WebFavorite> many = new ArrayList<>();
+        for (int i = 0; i < 600; i++) many.add(row(i, "{}"));
+        when(webFavoriteService.listMyFavorites(7L)).thenReturn(many);
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(7L);
+
+            // 默认上限 200
+            assertEquals(200, items(controller.myFavorites(null, "s")).size());
+            // 显式 limit 生效，且被夹在 [1, 500]
+            assertEquals(10, items(controller.myFavorites(10, "s")).size());
+            assertEquals(500, items(controller.myFavorites(9999, "s")).size());
+            assertEquals(1, items(controller.myFavorites(0, "s")).size());
+        }
+    }
+
+    private static boolean hasField(Object o, String name) {
+        try {
+            o.getClass().getDeclaredField(name);
+            return true;
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectDeleteCascadeTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectDeleteCascadeTest.java
@@ -1,0 +1,200 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.ProjectAiMessage;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.ProjectInvitation;
+import com.checkba.model.entity.ProjectMember;
+import com.checkba.model.entity.ProjectMemory;
+import com.checkba.model.entity.ProjectProfileField;
+import com.checkba.model.entity.ProjectRemote;
+import com.checkba.model.entity.ProjectTask;
+import com.checkba.model.entity.ProjectVariable;
+import com.checkba.repository.ProjectAiMessageRepository;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectInvitationRepository;
+import com.checkba.repository.ProjectMemberRepository;
+import com.checkba.repository.ProjectMemoryRepository;
+import com.checkba.repository.ProjectProfileFieldRepository;
+import com.checkba.repository.ProjectRemoteRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.ProjectTaskRepository;
+import com.checkba.repository.ProjectVariableRepository;
+import com.checkba.storage.ProjectStorageResolver;
+import com.checkba.version.ProjectRepoService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 删项目必须连带清掉项目级的库行与磁盘目录。
+ *
+ * 这些表全是裸 Long 的 projectId（没有 JPA 关联），ddl-auto=update 也不会生成外键，
+ * 数据库层没有 ON DELETE CASCADE——级联全靠 ProjectService.deleteProject 手写，
+ * 所以只能在这一层守。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:project-delete-cascade;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "storage.local.root-path=target/test-storage-delete-cascade"
+})
+@ActiveProfiles("desktop")
+class ProjectDeleteCascadeTest {
+
+    @Autowired private ProjectService projectService;
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private ProjectMemberRepository memberRepository;
+    @Autowired private ProjectFileRepository fileRepository;
+    @Autowired private ProjectVariableRepository variableRepository;
+    @Autowired private ProjectProfileFieldRepository profileFieldRepository;
+    @Autowired private ProjectMemoryRepository memoryRepository;
+    @Autowired private ProjectInvitationRepository invitationRepository;
+    @Autowired private ProjectRemoteRepository remoteRepository;
+    @Autowired private ProjectTaskRepository taskRepository;
+    @Autowired private ProjectAiMessageRepository aiMessageRepository;
+    @Autowired private ProjectStorageResolver storageResolver;
+    @Autowired private ProjectRepoService projectRepoService;
+
+    @Test
+    void deleteProject_clearsEveryProjectScopedTableAndOnDiskDirectory() throws IOException {
+        Long projectId = seedProject();
+
+        Path projectDir = storageResolver.projectRoot(projectId);
+        Path gitDir = projectRepoService.gitDir(projectId);
+        Files.createDirectories(projectDir.resolve("客户上传"));
+        Files.writeString(projectDir.resolve("客户上传").resolve("尽调材料.txt"), "机密");
+        Files.createDirectories(gitDir.resolve("objects"));
+
+        projectService.deleteProject(projectId);
+
+        assertFalse(projectRepository.existsById(projectId), "project 行应被删除");
+        assertTrue(memberRepository.findByProjectId(projectId).isEmpty(), "project_member 残留孤儿行");
+        assertTrue(fileRepository.findByProjectId(projectId).isEmpty(), "project_file 残留孤儿行");
+        assertTrue(variableRepository.findByProjectId(projectId).isEmpty(), "project_variables 残留孤儿行");
+        assertTrue(profileFieldRepository.findByProjectId(projectId).isEmpty(), "project_profile_field 残留孤儿行");
+        assertTrue(memoryRepository.findByProjectId(projectId).isEmpty(), "project_memory 残留孤儿行");
+        assertTrue(invitationRepository.findByProjectIdAndType(projectId, "CLIENT").isEmpty(), "project_invitation 残留孤儿行");
+        assertTrue(remoteRepository.findByProjectId(projectId).isEmpty(), "project_remote 残留孤儿行");
+        assertTrue(taskRepository.findAll().stream().noneMatch(t -> projectId.equals(t.getProjectId())), "project_task 残留孤儿行");
+        assertTrue(aiMessageRepository.findByProjectIdOrderByCreatedAtAsc(projectId).isEmpty(), "project_ai_message 残留孤儿行");
+
+        assertFalse(Files.exists(projectDir), "项目目录仍留在磁盘上: " + projectDir);
+        assertFalse(Files.exists(gitDir), "版本记录仓库仍留在磁盘上: " + gitDir);
+    }
+
+    /** localRoot 非空的 IDE 化项目，目录是用户自己的文件夹，只能解绑不能删。 */
+    @Test
+    void deleteProject_keepsUserOwnedLocalRootDirectory() throws IOException {
+        Path userFolder = Path.of("target", "test-local-root-delete-cascade").toAbsolutePath();
+        Files.createDirectories(userFolder);
+        Files.writeString(userFolder.resolve("用户自己的文件.txt"), "别删我");
+
+        Project project = new Project();
+        project.setName("本地文件夹项目");
+        project.setProjectType("BLANK");
+        project.setListedCompanyName("");
+        project.setTargetCompanyName("");
+        project.setUserId(9001L);
+        project.setLocalRoot(userFolder.toString());
+        project.setCreatedAt(LocalDateTime.now());
+        project.setUpdatedAt(LocalDateTime.now());
+        Long projectId = projectRepository.save(project).getId();
+
+        projectService.deleteProject(projectId);
+
+        assertFalse(projectRepository.existsById(projectId));
+        assertTrue(Files.exists(userFolder.resolve("用户自己的文件.txt")), "用户自己的文件夹被误删");
+    }
+
+    private Long seedProject() {
+        Project project = new Project();
+        project.setName("待删项目");
+        project.setProjectType("BLANK");
+        project.setListedCompanyName("");
+        project.setTargetCompanyName("");
+        project.setUserId(9000L);
+        project.setCreatedAt(LocalDateTime.now());
+        project.setUpdatedAt(LocalDateTime.now());
+        Long projectId = projectRepository.save(project).getId();
+
+        ProjectMember member = new ProjectMember();
+        member.setProjectId(projectId);
+        member.setUserId(9000L);
+        member.setRole("ADMIN");
+        memberRepository.save(member);
+
+        ProjectFile file = new ProjectFile();
+        file.setProjectId(projectId);
+        file.setIsFolder(false);
+        file.setName("尽调材料.txt");
+        file.setSortOrder(0);
+        file.setUserId(9000L);
+        file.setIsDeleted(false);
+        file.setFilePath("projects/" + projectId + "/客户上传/尽调材料.txt");
+        fileRepository.save(file);
+
+        ProjectVariable variable = new ProjectVariable();
+        variable.setProjectId(projectId);
+        variable.setName("公司名");
+        variable.setValue("某某有限公司");
+        variable.setType("TEXT");
+        variableRepository.save(variable);
+
+        ProjectProfileField field = new ProjectProfileField();
+        field.setProjectId(projectId);
+        field.setFieldKey("client");
+        field.setFieldValue("某某");
+        field.setSource("user");
+        field.setUid(UUID.randomUUID().toString());
+        profileFieldRepository.save(field);
+
+        ProjectMemory memory = new ProjectMemory();
+        memory.setProjectId(projectId);
+        memory.setProjectName("待删项目");
+        memoryRepository.save(memory);
+
+        ProjectInvitation invitation = new ProjectInvitation();
+        invitation.setProjectId(projectId);
+        invitation.setAccessCode("CODE" + projectId);
+        invitation.setType("CLIENT");
+        invitation.setRelatedUserId(9002L);
+        invitationRepository.save(invitation);
+
+        ProjectRemote remote = new ProjectRemote();
+        remote.setProjectId(projectId);
+        remote.setConnectionId(1L);
+        remote.setPendingUpload(false);
+        remote.setCreatedAt(LocalDateTime.now());
+        remoteRepository.save(remote);
+
+        ProjectTask task = new ProjectTask();
+        task.setUid(UUID.randomUUID().toString());
+        task.setProjectId(projectId);
+        task.setTitle("开庭");
+        task.setDueDate(LocalDate.now());
+        task.setStatus("OPEN");
+        task.setSource("user");
+        task.setUserId(9000L);
+        taskRepository.save(task);
+
+        ProjectAiMessage message = new ProjectAiMessage();
+        message.setProjectId(projectId);
+        message.setUserId(9000L);
+        message.setRole("USER");
+        message.setContent("你好");
+        message.setCreatedAt(LocalDateTime.now());
+        aiMessageRepository.save(message);
+
+        return projectId;
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceRenameTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceRenameTest.java
@@ -1,0 +1,80 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * 重命名的同名校验必须按「补完后缀之后的最终名字」来查重：
+ * 用户只填主名（"summary"）时后缀会被自动补回（"summary.pdf"），
+ * 若查重仍拿裸名字去查，就会放过与既有 "summary.pdf" 的碰撞——
+ * 两条同名记录不说，物理路径也由名字派生，会把别人的文件内容覆盖掉。
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectFileServiceRenameTest {
+
+    @Mock
+    private ProjectFileRepository projectFileRepository;
+    @Mock
+    private com.checkba.service.ai.ProjectRagService projectRagService;
+    @Mock
+    private com.checkba.storage.StorageServiceFactory storageServiceFactory;
+    @Mock
+    private com.checkba.service.telemetry.TelemetryService telemetryService;
+
+    @InjectMocks
+    private ProjectFileService projectFileService;
+
+    private static final long PROJECT_ID = 1L;
+    private static final long PARENT_ID = 5L;
+    private static final long FILE_A = 100L;
+
+    private ProjectFile fileA() {
+        ProjectFile f = new ProjectFile();
+        f.setId(FILE_A);
+        f.setProjectId(PROJECT_ID);
+        f.setParentId(PARENT_ID);
+        f.setIsFolder(false);
+        f.setName("report.pdf");
+        f.setFileType("pdf");
+        return f;
+    }
+
+    @Test
+    void 补后缀后与既有文件同名应当报错() {
+        when(projectFileRepository.findById(FILE_A)).thenReturn(Optional.of(fileA()));
+        // 同目录下已存在另一份 summary.pdf
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                PROJECT_ID, PARENT_ID, "summary.pdf", FILE_A)).thenReturn(true);
+        when(projectFileRepository.save(any(ProjectFile.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.rename(FILE_A, "summary", 1L));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("summary"));
+    }
+
+    @Test
+    void 不与他人碰撞时补后缀重命名仍应成功() {
+        when(projectFileRepository.findById(FILE_A)).thenReturn(Optional.of(fileA()));
+        when(projectFileRepository.save(any(ProjectFile.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        ProjectFile renamed = projectFileService.rename(FILE_A, "summary", 1L);
+        assertEquals("summary.pdf", renamed.getName());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/TushareServiceManagerTitleTest.java
+++ b/backend/src/test/java/com/checkba/service/TushareServiceManagerTitleTest.java
@@ -1,0 +1,108 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectVariable;
+import com.checkba.service.platform.ExternalProviderResolver;
+import com.checkba.service.platform.ExternalServiceProvider;
+import com.checkba.service.platform.PlatformGatewayClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tushare 管理层字段缺失时不能把整批变量一起赔掉。
+ *
+ * <p>stk_managers 的 title 在真实数据里会缺（原始公告没披露职务）。以前那一行
+ * {@code title.contains(...)} 直接 NPE，而 ProjectService.createProject 把整个
+ * fetchAndCreateVariables 包在 catch 里——一行坏数据 = 基本信息、前十大股东、
+ * 管理层三组全丢，用户还看不到任何报错。
+ */
+class TushareServiceManagerTitleTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 平台档网关桩：按 apiName 分发假响应。 */
+    private static TushareService serviceWith(Map<String, String> responsesByApi) {
+        PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+        try {
+            when(gateway.call(anyString(), anyString(), anyMap(), anyInt())).thenAnswer(inv -> {
+                Map<String, Object> body = inv.getArgument(2);
+                String apiName = String.valueOf(body.get("apiName"));
+                String json = responsesByApi.getOrDefault(apiName, "{\"code\":0}");
+                return new PlatformGatewayClient.Result(MAPPER.readTree(json), 3, 1, "call");
+            });
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+        SystemSettingService settings = mock(SystemSettingService.class);
+        when(settings.get(anyString(), any())).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            return key.equals(ExternalProviderResolver.providerKey(ExternalServiceProvider.TUSHARE))
+                    ? ExternalServiceProvider.PLATFORM.settingValue()
+                    : inv.getArgument(1);
+        });
+
+        TushareService svc = new TushareService();
+        ReflectionTestUtils.setField(svc, "systemSettingService", settings);
+        ReflectionTestUtils.setField(svc, "externalProviderResolver",
+                new ExternalProviderResolver(settings, true));
+        ReflectionTestUtils.setField(svc, "platformGatewayClient", gateway);
+        ReflectionTestUtils.setField(svc, "defaultTushareToken", "ts-token");
+        ReflectionTestUtils.setField(svc, "defaultTushareApiUrl", "http://127.0.0.1:1");
+        return svc;
+    }
+
+    @Test
+    @DisplayName("某位管理层没有职务：不抛异常，基本信息与股东两组照样落库")
+    void nullTitleDoesNotWipeEverything() {
+        TushareService svc = serviceWith(Map.of(
+                "stock_basic", "{\"code\":0,\"data\":{\"fields\":[\"ts_code\",\"name\",\"fullname\"],"
+                        + "\"items\":[[\"000001.SZ\",\"平安银行\",\"平安银行股份有限公司\"]]}}",
+                "stock_company", "{\"code\":0,\"data\":{\"fields\":[\"reg_capital\",\"office\"],"
+                        + "\"items\":[[\"194亿\",\"深圳市\"]]}}",
+                "top10_holders", "{\"code\":0,\"data\":{\"fields\":[\"ann_date\",\"end_date\",\"holder_name\",\"hold_amount\",\"hold_ratio\"],"
+                        + "\"items\":[[\"20240101\",\"20231231\",\"中国平安\",\"1000\",\"49.5\"]]}}",
+                // 第二行的 title 是 null——真实数据里就这样
+                "stk_managers", "{\"code\":0,\"data\":{\"fields\":[\"name\",\"title\",\"begin_date\",\"end_date\"],"
+                        + "\"items\":[[\"张三\",\"董事长\",\"20200101\",null],[\"李四\",null,\"20200101\",null]]}}"
+        ));
+
+        List<ProjectVariable> vars = svc.fetchAndCreateVariables(1L, "平安银行");
+
+        assertTrue(vars.stream().anyMatch(v -> "注册资本".equals(v.getName())),
+                "基本信息组不该因为管理层一行坏数据而丢失");
+        assertTrue(vars.stream().anyMatch(v -> "第1大股东名称".equals(v.getName())),
+                "股东组不该因为管理层一行坏数据而丢失");
+        String directors = vars.stream().filter(v -> "董事列表".equals(v.getName()))
+                .map(ProjectVariable::getValue).findFirst().orElse(null);
+        assertEquals("张三", directors, "有职务的照常归类");
+        String executives = vars.stream().filter(v -> "高管列表".equals(v.getName()))
+                .map(ProjectVariable::getValue).findFirst().orElse(null);
+        assertEquals("李四", executives, "职务缺失的落到「高管」兜底组，不该丢人也不该带 null");
+    }
+
+    @Test
+    @DisplayName("姓名缺失的行整行跳过，不生成「null(独董)」这种脏值")
+    void blankNameRowIsSkipped() {
+        TushareService svc = serviceWith(Map.of(
+                "stock_basic", "{\"code\":0,\"data\":{\"fields\":[\"ts_code\",\"name\",\"fullname\"],"
+                        + "\"items\":[[\"000001.SZ\",\"平安银行\",\"平安银行股份有限公司\"]]}}",
+                "stk_managers", "{\"code\":0,\"data\":{\"fields\":[\"name\",\"title\",\"begin_date\",\"end_date\"],"
+                        + "\"items\":[[null,\"独立董事\",\"20200101\",null],[\"张三\",\"独立董事\",\"20200101\",null]]}}"
+        ));
+
+        List<ProjectVariable> vars = svc.fetchAndCreateVariables(1L, "平安银行");
+
+        String directors = vars.stream().filter(v -> "董事列表".equals(v.getName()))
+                .map(ProjectVariable::getValue).findFirst().orElse(null);
+        assertEquals("张三(独董)", directors, "实际为：" + directors);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/WebFavoriteServiceScreenshotFailureTest.java
+++ b/backend/src/test/java/com/checkba/service/WebFavoriteServiceScreenshotFailureTest.java
@@ -1,0 +1,68 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.WebFavorite;
+import com.checkba.repository.WebFavoriteRepository;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 收藏截图存储失败时的上报口径：截图是唯一载荷时必须报错（否则落一条空收藏还回 200），
+ * 还有正文兜底时才允许降级保存。
+ */
+class WebFavoriteServiceScreenshotFailureTest {
+
+    private static final String PNG_BASE64 =
+            "data:image/png;base64," + Base64.getEncoder().encodeToString(new byte[]{1, 2, 3});
+
+    private WebFavoriteRepository repository;
+    private StorageService storageService;
+    private WebFavoriteService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(WebFavoriteRepository.class);
+        storageService = mock(StorageService.class);
+        StorageServiceFactory factory = mock(StorageServiceFactory.class);
+        when(factory.getStorageService()).thenReturn(storageService);
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        service = new WebFavoriteService(repository, factory);
+    }
+
+    @Test
+    @DisplayName("截图是唯一载荷时，存储失败必须抛出，不能落一条空收藏")
+    void screenshotOnlyFavoriteFailsLoudlyWhenStorageThrows() {
+        when(storageService.save(anyString(), any())).thenThrow(new RuntimeException("disk full"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.createFavorite(1L, 2L, "标题", "https://example.com", "", PNG_BASE64, null));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("还有正文兜底时，截图存储失败降级保存，正文不丢")
+    void favoriteWithTextKeepsContentWhenScreenshotStorageThrows() {
+        when(storageService.save(anyString(), any())).thenThrow(new RuntimeException("disk full"));
+
+        WebFavorite fav = service.createFavorite(1L, 2L, "标题", "https://example.com", "正文", PNG_BASE64, null);
+
+        assertEquals("正文", fav.getContent());
+        assertNull(fav.getImagePath());
+        verify(repository).save(any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/WizardStateServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/WizardStateServiceTest.java
@@ -44,14 +44,31 @@ class WizardStateServiceTest {
 
     @Test
     void resetWindowIsNotAnonymous() {
-        // 管理员 reset：标记显式为 "false"，向导重新开放，但不是匿名窗口
+        // 管理员 reset：标记显式为 "false"，向导重新开放，但不是匿名窗口。
+        // reset 必然发生在向导跑成功之后，ai.activeProvider 那一行一定在。
         when(systemSettingService.get(WizardStateService.KEY_WIZARD_COMPLETED, null)).thenReturn("false");
-        lenient().when(systemSettingRepository.count()).thenReturn(0L);
+        when(systemSettingService.get("ai.activeProvider", null)).thenReturn("OPENROUTER");
+        lenient().when(systemSettingRepository.count()).thenReturn(3L);
 
         WizardStateService s = service();
         assertFalse(s.isInitialized(), "reset 后向导重新开放");
         assertFalse(s.inAnonymousSetupWindow(),
                 "reset 窗口必须带管理员会话——匿名放行等于把改写 AI baseUrl 的入口重新打开");
+    }
+
+    @Test
+    void freshInstallWithPrewrittenFalseMarkerIsStillAnonymousWindow() {
+        // 全新安装（非单机模式）启动时 DataInitializer 会先把标记钉成 "false"，
+        // 于是标记永远非 null——按「标记为空才算匿名窗口」的旧判据，
+        // 向导里的本地 Ollama / 本地 ASR 探测在每一台全新机器上都会 401，
+        // 正好是这个类的注释说要防的那种死法。
+        when(systemSettingService.get(WizardStateService.KEY_WIZARD_COMPLETED, null)).thenReturn("false");
+        when(systemSettingService.get("ai.activeProvider", null)).thenReturn(null);
+        lenient().when(systemSettingRepository.count()).thenReturn(1L);
+
+        WizardStateService s = service();
+        assertFalse(s.isInitialized(), "全新安装不算已初始化");
+        assertTrue(s.inAnonymousSetupWindow(), "从没有人选过 AI 提供商 = 向导还没跑完，匿名窗口仍开着");
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorTruncationTagSafetyTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorTruncationTagSafetyTest.java
@@ -1,0 +1,85 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 展示截断不许把外层 {@code <tool_output>} 的闭合吞掉。
+ *
+ * <p>截断先于中和发生（截断口径按原文字数），所以截断点可能落在载荷里某个标签形状的中间：
+ * 剩下的半截 {@code <tool_output status="SUC} 没有 {@code >}，{@link AgentTagProtocol} 认不出它、
+ * 原样放行；紧随其后的是截断后缀和外层自己的 {@code </tool_output>}，前端 tagRegex 的
+ * {@code [^>]*} 属性段会一路吃到那个闭合标签的 {@code >}，把真正的闭合当成属性吞掉——
+ * 于是本轮剩下的正文全被塞进工具输出折叠区，工具行一直转圈。
+ */
+@DisplayName("截断点落在标签形状中间")
+class AgentOrchestratorTruncationTagSafetyTest {
+
+    /** 与前端 {@code createProtocolTagRegex()} 同形 */
+    private static final Pattern FRONTEND_TAG = Pattern.compile(
+            "<(/?)(" + String.join("|", AgentTagProtocol.TAGS) + ")(\\s+[^>]*)?>");
+
+    @Test
+    @DisplayName("截断在属性中间：外层闭合仍是独立的一个标签")
+    void truncationInsideAttributesKeepsWrapperClose() {
+        String raw = "子任务日志：<tool_output status=\"SUCCESS\">已完成</tool_output>";
+        int cut = raw.indexOf("SUCCESS") + 3; // 落在属性值中间，此处没有 '>'
+
+        String delta = String.format("<tool_output status=\"SUCCESS\">%s</tool_output>",
+                AgentTagProtocol.escape(AgentOrchestrator.truncate(raw, cut)));
+
+        List<String> tags = scan(delta);
+        assertEquals(2, tags.size(), "只该有外层的一开一闭：" + delta);
+        assertEquals("<tool_output status=\"SUCCESS\">", tags.get(0));
+        assertEquals("</tool_output>", tags.get(1),
+                "外层闭合被载荷里的半截标签当成属性吞掉了：" + delta);
+    }
+
+    @Test
+    @DisplayName("截断在标签名中间：同样不许留下半截标签")
+    void truncationInsideTagNameKeepsWrapperClose() {
+        String raw = "结果里提到 <final>，后面还有很多内容";
+        String delta = String.format("<tool_output status=\"SUCCESS\">%s</tool_output>",
+                AgentTagProtocol.escape(AgentOrchestrator.truncate(raw, raw.indexOf("<final") + 3)));
+
+        assertEquals(List.of("<tool_output status=\"SUCCESS\">", "</tool_output>"), scan(delta), delta);
+    }
+
+    @Test
+    @DisplayName("普通尖括号不因此被多切：截断点照旧按字数")
+    void plainAngleBracketIsNotTagShape() {
+        String raw = "报价 a < b 时按下限计，后面还有很长一段说明文字需要展示给用户";
+        int cut = raw.indexOf('<') + 12;
+
+        assertTrue(AgentOrchestrator.truncate(raw, cut).startsWith(raw.substring(0, cut)),
+                "非标签形状的 < 不该触发回退，否则展示内容凭空少一截");
+    }
+
+    @Test
+    @DisplayName("切口正好停在 '<' 或 '</' 上：不越界、也不留半截")
+    void truncationAtAngleBracketBoundary() {
+        String raw = "内容<//tool_output>结尾"; // 让切口分别停在 '<' 与 '</' 之后
+        int lt = raw.indexOf('<');
+        for (int cut : new int[]{lt, lt + 1, lt + 2, lt + 5}) {
+            String delta = String.format("<tool_output status=\"SUCCESS\">%s</tool_output>",
+                    AgentTagProtocol.escape(AgentOrchestrator.truncate(raw, cut)));
+            assertEquals(List.of("<tool_output status=\"SUCCESS\">", "</tool_output>"), scan(delta),
+                    "cut=" + cut + " 时：" + delta);
+        }
+    }
+
+    private List<String> scan(String s) {
+        Matcher m = FRONTEND_TAG.matcher(s);
+        List<String> out = new ArrayList<>();
+        while (m.find()) out.add(m.group());
+        return out;
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillRegistryTest.java
@@ -411,4 +411,59 @@ class SkillRegistryTest {
 
         assertEquals(1, registry.getSkills().size());
     }
+
+    /**
+     * 读 DISABLED_KEY 时可以卡住的设置服务：用来把 loadDisabledState 停在
+     * 「名单还没读回来」的那一瞬间，验证并发的无锁读方不会读到空名单。
+     */
+    private static class GatedSystemSettingService extends InMemorySystemSettingService {
+        final java.util.concurrent.CountDownLatch entered = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.atomic.AtomicBoolean armed = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        @Override
+        public String get(String key, String defaultValue) {
+            if (SkillRegistry.DISABLED_KEY.equals(key) && armed.compareAndSet(true, false)) {
+                entered.countDown();
+                try {
+                    release.await(10, java.util.concurrent.TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return super.get(key, defaultValue);
+        }
+    }
+
+    @Test
+    @DisplayName("并发：重载启停名单期间，无锁读方不该读到空名单（被停用的 skill 短暂变成启用）")
+    void disabledStateIsNotTornWhileReloading() throws Exception {
+        writeSkill(tempDir.resolve("test-skill"), "test-skill", null);
+        GatedSystemSettingService settings = new GatedSystemSettingService();
+
+        SkillProperties props = new SkillProperties();
+        props.setDir(tempDir.toString());
+        props.setDisabledCacheTtlMs(600_000); // 读方 TTL 不到期，走的就是无锁快路径
+        SkillRegistry registry = new SkillRegistry(props, settings, new PluginService(), null);
+        registry.init();
+        registry.setEnabled("test-skill", false);
+        assertFalse(registry.isEnabled("test-skill"));
+
+        settings.armed.set(true);
+        Thread reloader = new Thread(registry::rescan, "skill-rescan");
+        reloader.start();
+        try {
+            assertTrue(settings.entered.await(10, java.util.concurrent.TimeUnit.SECONDS),
+                    "重载线程应停在读禁用名单这一步");
+            org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(
+                    java.time.Duration.ofSeconds(5),
+                    () -> assertFalse(registry.isEnabled("test-skill"),
+                            "重载途中被停用的 skill 不该被读成启用"));
+        } finally {
+            settings.release.countDown();
+            reloader.join(10_000);
+        }
+
+        assertFalse(registry.isEnabled("test-skill"), "重载结束后仍是停用");
+    }
 }

--- a/backend/src/test/java/com/checkba/version/CloudSyncUploadRepushTest.java
+++ b/backend/src/test/java/com/checkba/version/CloudSyncUploadRepushTest.java
@@ -1,0 +1,150 @@
+package com.checkba.version;
+
+import com.checkba.model.entity.CloudConnection;
+import com.checkba.model.entity.ProjectRemote;
+import com.checkba.repository.CloudConnectionRepository;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectRemoteRepository;
+import com.checkba.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * 上传被拒 → 自动整合 → 合并后重推的诚实回报（稳定性审计）。
+ *
+ * 全 mock 的窄口径用例：真实双仓 fixture（CloudSyncUpdateTest）没法在 integrateFromCloud
+ * 的 fetch 与 completeCloudMerge 的重推之间插一手让远端再前进一版，而这正是本用例要
+ * 复现的时序——合并在本地落地了，回传却没到云端。
+ */
+class CloudSyncUploadRepushTest {
+
+    private static final long PROJECT = 7L;
+    private static final String LOCAL_TIP = "local-tip-sha";
+    private static final String CLOUD_TIP = "cloud-tip-sha";
+
+    private ProjectRepoService repo;
+    private WorkSessionService sessions;
+    private ProjectRemoteRepository remotes;
+    private ProjectRemote remoteRow;
+    private CloudSyncService cloud;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(ProjectRepoService.class);
+        sessions = mock(WorkSessionService.class);
+        ProjectTreeManifestService manifests = mock(ProjectTreeManifestService.class);
+        ProjectFileRepository files = mock(ProjectFileRepository.class);
+        CloudConnectionRepository connections = mock(CloudConnectionRepository.class);
+        remotes = mock(ProjectRemoteRepository.class);
+        ProjectRepository projects = mock(ProjectRepository.class);
+
+        CloudConnection conn = new CloudConnection();
+        conn.setId(1L);
+        conn.setUsername("韩泽伟");
+        conn.setDisplayName("韩泽伟");
+        conn.setDeviceToken("awdt_test");
+        when(connections.findById(1L)).thenReturn(Optional.of(conn));
+
+        remoteRow = new ProjectRemote();
+        remoteRow.setId(1L);
+        remoteRow.setProjectId(PROJECT);
+        remoteRow.setConnectionId(1L);
+        remoteRow.setPendingUpload(false);
+        remoteRow.setLastSyncSha("已同步到这里");
+        when(remotes.findByProjectId(PROJECT)).thenReturn(Optional.of(remoteRow));
+        when(remotes.save(any(ProjectRemote.class))).thenAnswer(i -> i.getArgument(0));
+
+        when(sessions.repoLock(PROJECT)).thenReturn(new ReentrantLock());
+        when(sessions.activeSession(PROJECT)).thenReturn(Optional.empty());
+        when(sessions.onDraftBranch(PROJECT)).thenReturn(false);
+        when(sessions.resolveAffectedFileIds(anyLong(), any())).thenReturn(List.of(42L));
+
+        when(repo.mainBranch()).thenReturn("master");
+        when(repo.repositoryMerging(PROJECT)).thenReturn(false);
+        when(repo.fetchFromOrigin(anyLong(), any(), any())).thenReturn(CLOUD_TIP);
+        when(repo.resolveRef(anyLong(), any())).thenReturn(LOCAL_TIP);
+        // 两条线已分叉：云端不是本地的祖先，本地也不是云端的祖先 → 走真合并
+        when(repo.isAncestor(anyLong(), any(), any())).thenReturn(false);
+        when(repo.mergeNoCommit(anyLong(), any(), any(), any(), any()))
+                .thenReturn(new MergeOutcome(true, false, List.of(), null));
+        when(repo.diffNameStatus(anyLong(), any(), any())).thenReturn(List.of());
+
+        cloud = new CloudSyncService(repo, sessions, manifests, files, connections, remotes, projects);
+    }
+
+    /** 第一次推被拒（同事先交了稿），第二次推（合并后的回传）按 outcome 给结果。 */
+    private void pushRejectedThen(ProjectRepoService.PushOutcome second) {
+        when(repo.pushMainlineToOrigin(anyLong(), any(), any()))
+                .thenReturn(new ProjectRepoService.PushOutcome(false, true, "远端已前移"))
+                .thenReturn(second);
+    }
+
+    /**
+     * 合并落地但回传没到云端（裁决窗口那一瞬远端又被推进 / 网络抖断）：绝不能报 UPLOADED
+     * ——界面会显示「已交稿」，而云端根本没有这份合并，同事永远看不到。
+     */
+    @Test
+    void repushRejectedAfterAutoMergeIsNotReportedAsUploaded() {
+        pushRejectedThen(new ProjectRepoService.PushOutcome(false, true, "远端又被推进了"));
+
+        CloudSyncService.UploadResult r = cloud.uploadToCloud(PROJECT, false);
+
+        assertNotEquals(CloudSyncService.UploadStatus.UPLOADED, r.status(),
+                "合并没到云端，不能报成功交稿");
+        assertEquals(CloudSyncService.UploadStatus.OFFLINE_PENDING, r.status());
+        assertNotNull(r.message(), "要给律师一句实话：这次没交上，改动已记下");
+        assertTrue(remoteRow.getPendingUpload(), "待上传黄灯要留着");
+        assertEquals(List.of(42L), r.affectedFileIds(),
+                "整合改写了磁盘，受影响文件 id 仍要带回给重载链");
+    }
+
+    /** 重推抛异常（连接断了）与被拒同口径。 */
+    @Test
+    void repushThrowingAfterAutoMergeIsNotReportedAsUploaded() {
+        when(repo.pushMainlineToOrigin(anyLong(), any(), any()))
+                .thenReturn(new ProjectRepoService.PushOutcome(false, true, "远端已前移"))
+                .thenThrow(new VersionException("连接断了"));
+
+        CloudSyncService.UploadResult r = cloud.uploadToCloud(PROJECT, false);
+
+        assertEquals(CloudSyncService.UploadStatus.OFFLINE_PENDING, r.status());
+        assertTrue(remoteRow.getPendingUpload());
+    }
+
+    /** 反向守卫：重推真的落地了就该照常报 UPLOADED（别把好路径一起改红）。 */
+    @Test
+    void repushLandedAfterAutoMergeStaysUploaded() {
+        pushRejectedThen(new ProjectRepoService.PushOutcome(true, false, null));
+
+        CloudSyncService.UploadResult r = cloud.uploadToCloud(PROJECT, false);
+
+        assertEquals(CloudSyncService.UploadStatus.UPLOADED, r.status());
+        assertFalse(remoteRow.getPendingUpload());
+        assertEquals(List.of(42L), r.affectedFileIds());
+    }
+
+    /**
+     * 反向守卫二：快进路径压根不推（本地没有云端没有的提交），整合完本地就等于云端
+     * ——不能因为 remote.pendingUpload 的历史值把它误报成失败。
+     */
+    @Test
+    void fastForwardIntegrateStaysUploadedEvenWithoutPush() {
+        remoteRow.setPendingUpload(true); // 历史遗留的黄灯
+        pushRejectedThen(new ProjectRepoService.PushOutcome(false, true, "远端已前移"));
+        // 本地是云端的祖先 → 快进分支（不经过 completeCloudMerge，也就没有重推）
+        when(repo.isAncestor(PROJECT, "master", "refs/remotes/origin/master")).thenReturn(true);
+
+        CloudSyncService.UploadResult r = cloud.uploadToCloud(PROJECT, false);
+
+        assertEquals(CloudSyncService.UploadStatus.UPLOADED, r.status());
+    }
+}

--- a/desktop/main/drawio-server.js
+++ b/desktop/main/drawio-server.js
@@ -166,7 +166,18 @@ function startDrawioServer() {
           'Content-Length': st.size,
           ...cacheHeaders,
         })
-        createReadStream(filePath).pipe(res)
+        // ReadStream 的 'error' 必须自己收着：它是 EventEmitter，没人听时 Node 会
+        // 直接抛，而这一抛发生在 try/catch 之外的事件循环里、主进程又没有
+        // uncaughtException 兜底——结果不是这一个请求 404，是整个 Electron 应用
+        // 无提示消失。stat 到读完之间随时可能出错：pack 根每次请求现读（装完即
+        // 生效），广场正好在传输途中更新/撤销这一版就会把目录换掉；外接盘被拔、
+        // 杀毒锁文件、磁盘读错误同理。
+        // 200 的响应头（含按 st.size 算的 Content-Length）在上面已经落定，改不回
+        // 500 了；只能掐断连接，让浏览器把它当成一次传输失败，而不是拿到一个长度
+        // 对不上的半截文件。
+        const stream = createReadStream(filePath)
+        stream.on('error', () => { res.destroy() })
+        stream.pipe(res)
       } catch (e) {
         res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' }).end('not found')
       }

--- a/desktop/main/services/update-service.js
+++ b/desktop/main/services/update-service.js
@@ -56,6 +56,13 @@ function fetchUrl(url, { toFile = null, maxBytes = MAX_COMPONENT_BYTES, timeoutM
     let u
     try { u = new URL(url) } catch (e) { return reject(new Error(`bad url: ${url}`)) }
     const mod = u.protocol === 'http:' ? http : https
+    // 任何失败路径都得先关掉已经开出去的写入流：fetchFirst 失败后会用同一个
+    // toFile 换下个镜像重试，不关就是每次回退、每个检查周期漏一个 fd。
+    let out = null
+    const fail = (e) => {
+      if (out) out.destroy()
+      reject(e)
+    }
     const req = mod.get(u, { timeout: timeoutMs }, (res) => {
       const sc = res.statusCode || 0
       if (sc >= 300 && sc < 400 && res.headers.location && redirects < 5) {
@@ -69,7 +76,7 @@ function fetchUrl(url, { toFile = null, maxBytes = MAX_COMPONENT_BYTES, timeoutM
       const hash = crypto.createHash('sha256')
       let total = 0
       const chunks = []
-      const out = toFile ? fs.createWriteStream(toFile) : null
+      out = toFile ? fs.createWriteStream(toFile) : null
       res.on('data', (c) => {
         total += c.length
         if (total > maxBytes) {
@@ -86,10 +93,10 @@ function fetchUrl(url, { toFile = null, maxBytes = MAX_COMPONENT_BYTES, timeoutM
         if (out) out.end(done)
         else done()
       })
-      res.on('error', reject)
+      res.on('error', fail)
     })
     req.on('timeout', () => req.destroy(new Error(`timeout: ${url}`)))
-    req.on('error', reject)
+    req.on('error', fail)
   })
 }
 

--- a/desktop/scripts/build-patch-assets.js
+++ b/desktop/scripts/build-patch-assets.js
@@ -107,7 +107,8 @@ function fetchText(url) {
       }
       if (res.statusCode !== 200) {
         res.resume()
-        return reject(new Error(`HTTP ${res.statusCode}: ${url}`))
+        // 带上 statusCode：调用方要靠它区分"确实没有上一版"(404) 与"这次没拿到"(其余)
+        return reject(Object.assign(new Error(`HTTP ${res.statusCode}: ${url}`), { statusCode: res.statusCode }))
       }
       let body = ''
       res.on('data', (c) => { body += c })
@@ -119,16 +120,37 @@ function fetchText(url) {
   })
 }
 
-async function loadPrevManifest(prev) {
+// 拉取上一版 manifest。**只有"确实不存在"才允许返回 null**（URL 404 / 本地文件缺失
+// ——即首个补丁版本）；网络抖动、超时、5xx、WAF 返回的 HTML、schema 不符一律重试后炸掉
+// 构建。原因：prev 为 null 时下面的 channels 会退成 {}，latestMajor/majorDownloadPage/
+// telemetryUrl 也全部回落默认值，生成的 manifest 只剩当前大版本一条通道；
+// deploy/update-mirror-sync.sh 会把它原子替换到线上，已发布的其它大版本通道就此被
+// 静默抹掉（无报错、无告警、无备份），停在旧大版本的用户从此收不到增量补丁。
+// 宁可让 tag 构建红着重跑，也不能悄悄发一份残缺清单。
+async function loadPrevManifest(prev, { attempts = 3, retryDelayMs = 2000 } = {}) {
   if (!prev) return null
-  try {
-    const text = /^https?:/.test(prev) ? await fetchText(prev) : fs.readFileSync(prev, 'utf8')
-    const m = JSON.parse(text)
-    return m && m.schema === 1 ? m : null
-  } catch (e) {
-    console.warn(`[build-patch-assets] 上一版 manifest 不可用（首个补丁版本属正常）: ${e.message}`)
-    return null
+  const isUrl = /^https?:/.test(prev)
+  let lastErr = null
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const text = isUrl ? await fetchText(prev) : fs.readFileSync(prev, 'utf8')
+      const m = JSON.parse(text)
+      if (!m || m.schema !== 1) {
+        throw Object.assign(new Error(`上一版 manifest schema 不是 1（拿到 ${m && m.schema}）: ${prev}`), { fatal: true })
+      }
+      return m
+    } catch (e) {
+      if (e.statusCode === 404 || e.code === 'ENOENT') {
+        console.warn(`[build-patch-assets] 上一版 manifest 不存在（首个补丁版本属正常）: ${prev}`)
+        return null
+      }
+      if (e.fatal) throw e
+      lastErr = e
+      console.warn(`[build-patch-assets] 上一版 manifest 拉取失败（第 ${i}/${attempts} 次）: ${e.message}`)
+      if (i < attempts) await new Promise((r) => setTimeout(r, retryDelayMs * i))
+    }
   }
+  throw new Error(`上一版 manifest 拉取失败，已重试 ${attempts} 次: ${prev} — ${lastErr && lastErr.message}`)
 }
 
 async function main() {
@@ -262,4 +284,9 @@ async function main() {
   console.log(`[build-patch-assets] done: ${outDir}`)
 }
 
-main().catch((e) => fail(e.stack || String(e)))
+// CLI 入口只在直接执行本文件时跑；被 require() 当模块用时（单测）只取函数。
+if (require.main === module) {
+  main().catch((e) => fail(e.stack || String(e)))
+}
+
+module.exports = { loadPrevManifest, fetchText }

--- a/desktop/tests/build-patch-assets.test.js
+++ b/desktop/tests/build-patch-assets.test.js
@@ -1,0 +1,106 @@
+// dev-board#74 稳定性审计：loadPrevManifest 原先把"拉不到上一版 manifest"一律
+// 吞成 null 并打印一条"首个补丁版本属正常"的告警。CI 每次 tag 构建都用
+// --prev https://www.aiworkdeck.com/update/desktop/manifest.json，只要遇上一次网络
+// 抖动 / 15s 超时 / nginx reload 期间的 5xx，生成的 manifest 就只剩当前大版本一条
+// 通道（channels 从 {} 起算，latestMajor/majorDownloadPage/telemetryUrl 也回落默认
+// 值），随后被 update-mirror-sync.sh 原子替换到线上，旧大版本用户静默失去增量更新。
+//
+// 口径：只有 404 / ENOENT（确实没有上一版）才返回 null，其余失败重试后抛错炸构建。
+
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const http = require('http')
+
+const { loadPrevManifest } = require('../scripts/build-patch-assets')
+
+const FAST = { attempts: 3, retryDelayMs: 5 }
+
+// 起一个可编程的本地 http server，模拟镜像站的各种响应
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const srv = http.createServer(handler)
+    srv.listen(0, '127.0.0.1', () => resolve({ srv, url: `http://127.0.0.1:${srv.address().port}/manifest.json` }))
+  })
+}
+
+const PREV = {
+  schema: 1,
+  latestMajor: '0.22',
+  majorDownloadPage: 'https://www.aiworkdeck.com/start',
+  telemetryUrl: 'https://addin.aiworkdeck.com/api/update/telemetry',
+  channels: { '0.20': { latest: '0.20.3', components: [] }, '0.22': { latest: '0.22.0', components: [] } }
+}
+
+test('镜像 500：重试后抛错炸构建，绝不吞成 null', async (t) => {
+  let hits = 0
+  const { srv, url } = await startServer((req, res) => { hits++; res.writeHead(500); res.end('bad gateway') })
+  t.after(() => srv.close())
+  await assert.rejects(() => loadPrevManifest(url, FAST), /拉取失败，已重试 3 次/)
+  assert.strictEqual(hits, 3, '应当重试满 3 次')
+})
+
+test('WAF 返回 200 + HTML（JSON 解析失败）：抛错，不得当成首个补丁版本', async (t) => {
+  const { srv, url } = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html' }); res.end('<html>blocked</html>')
+  })
+  t.after(() => srv.close())
+  await assert.rejects(() => loadPrevManifest(url, FAST), /拉取失败，已重试 3 次/)
+})
+
+test('schema 不是 1：立刻抛错，不重试也不吞', async (t) => {
+  let hits = 0
+  const { srv, url } = await startServer((req, res) => {
+    hits++; res.writeHead(200, { 'content-type': 'application/json' }); res.end(JSON.stringify({ schema: 2 }))
+  })
+  t.after(() => srv.close())
+  await assert.rejects(() => loadPrevManifest(url, FAST), /schema 不是 1/)
+  assert.strictEqual(hits, 1, 'schema 不符是确定性错误，不该重试')
+})
+
+test('镜像 404：视为首个补丁版本，返回 null（既有行为不变）', async (t) => {
+  const { srv, url } = await startServer((req, res) => { res.writeHead(404); res.end('not found') })
+  t.after(() => srv.close())
+  assert.strictEqual(await loadPrevManifest(url, FAST), null)
+})
+
+test('本地文件不存在：返回 null（既有行为不变）', async () => {
+  assert.strictEqual(await loadPrevManifest(path.join(os.tmpdir(), 'no-such-manifest-xyz.json'), FAST), null)
+})
+
+test('未传 --prev：返回 null（既有行为不变）', async () => {
+  assert.strictEqual(await loadPrevManifest(undefined, FAST), null)
+})
+
+test('正常拿到上一版：原样返回，channels/latestMajor 等字段完整', async (t) => {
+  const { srv, url } = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' }); res.end(JSON.stringify(PREV))
+  })
+  t.after(() => srv.close())
+  const m = await loadPrevManifest(url, FAST)
+  assert.deepStrictEqual(Object.keys(m.channels).sort(), ['0.20', '0.22'])
+  assert.strictEqual(m.telemetryUrl, PREV.telemetryUrl)
+})
+
+test('第一次抖动、第二次成功：重试救回上一版，通道不丢', async (t) => {
+  let hits = 0
+  const { srv, url } = await startServer((req, res) => {
+    hits++
+    if (hits === 1) { res.writeHead(502); res.end('bad gateway'); return }
+    res.writeHead(200, { 'content-type': 'application/json' }); res.end(JSON.stringify(PREV))
+  })
+  t.after(() => srv.close())
+  const m = await loadPrevManifest(url, FAST)
+  assert.deepStrictEqual(Object.keys(m.channels).sort(), ['0.20', '0.22'])
+})
+
+test('本地路径：能正常读回上一版 manifest', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-prev-'))
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }))
+  const fp = path.join(dir, 'manifest.json')
+  fs.writeFileSync(fp, JSON.stringify(PREV))
+  const m = await loadPrevManifest(fp, FAST)
+  assert.strictEqual(m.latestMajor, '0.22')
+})

--- a/desktop/tests/drawio-server.test.js
+++ b/desktop/tests/drawio-server.test.js
@@ -181,3 +181,39 @@ test('内置根优先于 pack 根', async (t) => {
   assert.match(res.body, /BUILTIN-DRAWIO/)
   assert.doesNotMatch(res.body, /PACK-DRAWIO/)
 })
+
+test('读流中途出错只失败这一个请求，不能掀掉整个进程', async (t) => {
+  // 造「stat 成功但 open 失败」：chmod 000 之后 stat 只需要父目录的搜索权限，
+  // 仍然报告是个普通文件，而 createReadStream 打开时 EACCES。这比真去抢
+  // stat 与 open 之间那几毫秒（删目录/拔盘/杀毒锁文件）稳定得多，暴露的是
+  // 同一条路径：ReadStream 的 'error' 没人听 → Node 直接抛 → 主进程没有
+  // uncaughtException 兜底 → 整个 Electron 应用当场消失。
+  if (process.platform === 'win32' || (process.getuid && process.getuid() === 0)) {
+    t.skip('Windows 与 root 下权限位不生效，造不出 stat 成功而 open 失败的文件')
+    return
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-unreadable-'))
+  const emptyPacks = fs.mkdtempSync(path.join(os.tmpdir(), 'drawio-packs-empty-'))
+  fs.writeFileSync(path.join(dir, 'index.html'), '<html>drawio</html>')
+  const locked = path.join(dir, 'locked.js')
+  fs.writeFileSync(locked, 'console.log(1)')
+  fs.chmodSync(locked, 0o000)
+
+  process.env.AIWORKDECK_DRAWIO_DIR = dir
+  process.env.AIWORKDECK_PACKS_DIR = emptyPacks
+  t.after(async () => {
+    await stopDrawioServer()
+    fs.chmodSync(locked, 0o600)
+    await rmrf(dir)
+    await rmrf(emptyPacks)
+  })
+
+  const { origin } = await startDrawioServer()
+  // 200 的头（含 Content-Length）已经定了，改不回 500，所以约定是掐断这一条连接：
+  // 客户端看到的是一次传输失败，而不是长度对不上的半截文件。
+  await assert.rejects(get(origin, '/locked.js'), '读不出来的文件应当让这一个请求失败')
+  // 进程还活着的直接证据：同一个 server 继续正常服务下一个请求。
+  const idx = await get(origin, '/')
+  assert.strictEqual(idx.status, 200)
+  assert.match(idx.body, /drawio/)
+})

--- a/desktop/tests/update-service.test.js
+++ b/desktop/tests/update-service.test.js
@@ -7,7 +7,7 @@ const http = require('http')
 const crypto = require('crypto')
 const { spawnSync } = require('child_process')
 const overlay = require('../main/services/overlay')
-const { createUpdateService } = require('../main/services/update-service')
+const { createUpdateService, fetchUrl } = require('../main/services/update-service')
 
 // 端到端（本地 HTTP 伪造更新服务器）：manifest 验签 → 组件下载 → sha256 →
 // 解压 → 激活 → 状态机；以及验签失败 / 哈希不符 / 降级拒绝三条失败路径。
@@ -287,4 +287,71 @@ test('组件级去重：本机已有同版本组件时跳过下载仍推进指�
   assert.strictEqual(state.phase, 'ready')
   assert.strictEqual(overlay.effectiveVersion(ctx), '0.11.2')
   assert.strictEqual(overlay.readCurrent(ctx).components['backend-app'].version, '0.11.1')
+})
+
+// dev-board#74 稳定性审计：fetchUrl 在任何失败路径上都不关闭已创建的 WriteStream。
+// 中途断连 / 超时 / 超过 maxBytes 三条路都只 reject(e) 或 req.destroy(e)，
+// out 的 fd 一直挂着；而 fetchFirst 失败后会用同一个 toFile 换下个镜像重试，
+// 于是每次镜像回退、每个 6 小时检查周期都漏一个 fd。
+// 口径：失败时必须 out.destroy()，断言点是 WriteStream 真的 emit 了 'close'（fd 已关）。
+function waitClosed(stream, ms = 2000) {
+  return new Promise((resolve, reject) => {
+    if (stream.closed) return resolve()
+    const t = setTimeout(() => reject(new Error('WriteStream 未在超时内 close，fd 泄漏')), ms)
+    stream.once('close', () => { clearTimeout(t); resolve() })
+  })
+}
+
+// 把 fs.createWriteStream 换成会记账的版本，拿到 fetchUrl 内部创建的那个流
+function spyWriteStreams(t) {
+  const created = []
+  const orig = fs.createWriteStream
+  fs.createWriteStream = function (...args) {
+    const s = orig.apply(fs, args)
+    created.push(s)
+    return s
+  }
+  t.after(() => { fs.createWriteStream = orig })
+  return created
+}
+
+test('下载中途断连：WriteStream 被销毁，不泄漏文件描述符', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'upd-fd-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  // 先发头 + 半截 body，再直接掐 socket
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Length': '10000' })
+    res.write('partial-body')
+    setTimeout(() => res.socket.destroy(), 20)
+  })
+  await new Promise((r) => server.listen(0, '127.0.0.1', r))
+  t.after(() => server.close())
+  const url = `http://127.0.0.1:${server.address().port}/x.tar.gz`
+
+  const created = spyWriteStreams(t)
+  await assert.rejects(() => fetchUrl(url, { toFile: path.join(root, 'x.tar.gz'), timeoutMs: 5000 }))
+  assert.strictEqual(created.length, 1, 'fetchUrl 应当只建了一个 WriteStream')
+  await waitClosed(created[0])
+})
+
+test('超过 maxBytes 上限：WriteStream 被销毁，不泄漏文件描述符', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'upd-fd-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const big = Buffer.alloc(64 * 1024, 0x41)
+  const server = http.createServer((req, res) => {
+    res.writeHead(200)
+    const tick = setInterval(() => { if (!res.write(big)) { /* 背压交给 res */ } }, 5)
+    res.on('close', () => clearInterval(tick))
+  })
+  await new Promise((r) => server.listen(0, '127.0.0.1', r))
+  t.after(() => server.close())
+  const url = `http://127.0.0.1:${server.address().port}/huge.tar.gz`
+
+  const created = spyWriteStreams(t)
+  await assert.rejects(
+    () => fetchUrl(url, { toFile: path.join(root, 'huge.tar.gz'), maxBytes: 32 * 1024, timeoutMs: 5000 }),
+    /大小上限/
+  )
+  assert.strictEqual(created.length, 1)
+  await waitClosed(created[0])
 })

--- a/desktop/tests/workflow-release-gating.test.js
+++ b/desktop/tests/workflow-release-gating.test.js
@@ -92,3 +92,33 @@ test('desktop-build.yml：镜像同步必须排在 release 之后（它是从 Gi
   assert.ok(needs.includes('release'),
     'sync-mirror 必须 needs: release，否则会和发布并行、拉不到 Release 资产')
 })
+
+// dev-board#74 稳定性审计：pysvc 缓存的 key 只由 requirements.lock 与打包脚本
+// 组成，唯独漏了各服务自己的源码（prepare-python-service.js 的 --src 会把它
+// cpSync 进被缓存的 pysvc/ 目录）。只改 pptx-service/backend、kokoro-service、
+// asr-service 的源码而不动 lock 时 key 不变，缓存命中就把「Bundle X-service」
+// 整步跳过，装机包里带的还是上一次构建的旧源码——构建全绿、冒烟也过（跑的是
+// 旧代码），tag 构建会把缺了刚合并那笔改动的安装包发出去且毫无告警。
+test('desktop-build.yml：pysvc 缓存 key 必须覆盖各服务源码，否则改源码会命中旧缓存发出旧代码', () => {
+  const doc = loadWorkflow('desktop-build.yml')
+  const steps = doc.jobs.build.steps
+  const cacheSteps = steps.filter((s) =>
+    typeof s.uses === 'string' && s.uses.startsWith('actions/cache@') &&
+    String((s.with && s.with.path) || '').includes('/pysvc'))
+  assert.ok(cacheSteps.length > 0, '应该存在缓存 pysvc 目录的步骤（本用例的前提）')
+
+  for (const cache of cacheSteps) {
+    const key = String(cache.with.key)
+    // 被这条缓存的 cache-hit 门控、且带 --src（有自有源码）的打包步骤
+    const gated = steps.filter((s) =>
+      String(s.if || '').includes(`steps.${cache.id}.outputs.cache-hit`) &&
+      /--src\s/.test(String(s.run || '')))
+    assert.ok(gated.length > 0, `${cache.id} 应该门控着若干带 --src 的打包步骤（本用例的前提）`)
+    for (const s of gated) {
+      const src = String(s.run).match(/--src\s+(\S+)/)[1]
+      assert.ok(key.includes(`'${src}/**'`),
+        `缓存 ${cache.id} 的 key 没覆盖 ${src}：只改这个服务的源码 key 不变，` +
+        `缓存命中会把打包步骤整步跳过，装机包里还是旧源码。key=${key}`)
+    }
+  }
+})

--- a/frontend/scripts/check-emit-bindings.mjs
+++ b/frontend/scripts/check-emit-bindings.mjs
@@ -14,7 +14,10 @@ import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join, dirname, resolve, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '../src')
+// CHECK_EMITS_SRC 只给单测用（指向临时 fixture 目录），正常跑走默认的 src/
+const SRC = process.env.CHECK_EMITS_SRC
+  ? resolve(process.env.CHECK_EMITS_SRC)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '../src')
 
 // 原生/透传事件白名单（组件上绑这些不要求子组件 emit）
 const NATIVE_EVENTS = new Set([
@@ -77,7 +80,9 @@ for (const f of vueFiles) {
     const emits = emitsByFile.get(target)
     if (emits === undefined || emits === null) continue // 非本仓组件或动态 emit → 跳过
     // 标签可能写成 <PascalCase 或 <kebab-case>
-    const tagPattern = new RegExp(`<(?:${tag}|${toKebab(tag)})\\b([^>]*)`, 'g')
+    // 属性区先整段吃掉引号字面量，否则 :prop="a > b" 里的裸 '>' 会被当成标签闭合，
+    // 把它后面的 @event 绑定整个漏检
+    const tagPattern = new RegExp(`<(?:${tag}|${toKebab(tag)})\\b((?:"[^"]*"|'[^']*'|[^>])*)`, 'g')
     for (const m of code.matchAll(tagPattern)) {
       const attrs = m[1]
       for (const ev of attrs.matchAll(/@([\w-]+(?::[\w-]+)?)(?:\.[\w.]+)*=/g)) {

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -1162,8 +1162,20 @@ export default {
        pptConfigData.value = null
        // Optionally notify backend of cancellation? Not strictly needed as AI task handles timeout or just hangs.
        // Ideally we should tell user "Cancelled".
+       // 形状必须与 useAgentStream.createAssistantBubble 一致：RootBubble 对
+       // thinking.status / processes.length / artifacts.length 都是裸解引用，
+       // 少字段就在渲染时抛 TypeError，Vue 3 把这条气泡换成空注释节点——
+       // 用户根本看不到「已取消」。
        bubbles.value.push({
           role: 'ASSISTANT',
+          thinking: { status: 'done', content: '', duration: 0 },
+          title: '',
+          planTodos: [],
+          processes: [],
+          artifacts: [],
+          walkthrough: '',
+          question: null,
+          isStreaming: false,
           content: t('chat.pptCancelled'),
           timestamp: new Date().toLocaleTimeString()
        })
@@ -1186,8 +1198,17 @@ export default {
           await performPptGeneration(params)
 
           // Add a system bubble saying "Starting generation..."
+          // 同上：字段少了这条提示会被 Vue 的渲染错误兜底吞成空节点。
           bubbles.value.push({
              role: 'ASSISTANT',
+             thinking: { status: 'done', content: '', duration: 0 },
+             title: '',
+             planTodos: [],
+             processes: [],
+             artifacts: [],
+             walkthrough: '',
+             question: null,
+             isStreaming: false,
              content: t('chat.pptStarting', { variant: pptExportEditable.value ? t('chat.pptVariantEditable') : t('chat.pptVariantImage') }),
              timestamp: new Date().toLocaleTimeString()
           })

--- a/frontend/src/components/DdRequestEditor.vue
+++ b/frontend/src/components/DdRequestEditor.vue
@@ -9,6 +9,7 @@
           v-model="requestName"
           @blur="updateRequestName"
           @confirm="updateRequestName"
+          :disabled="deleted"
           :placeholder="request ? request.name : $t('panels.ddLoadingPlaceholder')"
         />
         <view class="status-badge" v-if="request" :class="request.status">
@@ -17,7 +18,7 @@
         <text class="progress-info" v-if="items.length > 0">{{ $t('panels.ddProgress', { completed: completedCount, total: items.length }) }}</text>
       </view>
 
-      <view style="display: flex; gap: 10px; align-items: center;">
+      <view style="display: flex; gap: 10px; align-items: center;" v-if="!deleted">
         <button class="delete-list-btn" @tap="handleDeleteRequest">{{ $t('panels.ddDeleteList') }}</button>
         <button class="new-btn" @tap="handleAddItem">
             <text>{{ $t('panels.ddNewItem') }}</text>
@@ -182,6 +183,11 @@ export default {
       selectedItemId: null,
       expandedItems: new Set(),
       hoveredItemId: null,
+      // 本组件在工作台里没有 :key，切换不同尽调清单标签时是同一个实例被复用，
+      // 只靠 requestId watcher 再发一次请求。响应可能乱序回来，用递增序号
+      // 只认最后一次发出的那次结果；删除清单时也把序号推进一格作废在途请求。
+      fetchSeq: 0,
+      deleted: false,
 
       // Comments
       showCommentsDrawer: false,
@@ -244,17 +250,21 @@ export default {
   },
   methods: {
     async fetchData() {
+      const seq = ++this.fetchSeq
       try {
         const res = await api.getDdRequestDetails(this.requestId)
+        if (seq !== this.fetchSeq) return
         this.request = res.request
         this.requestName = this.request.name
         this.items = res.items
       } catch (e) {
+        if (seq !== this.fetchSeq) return
         console.error('Fetch DD details failed', e)
       }
     },
 
     async updateRequestName() {
+        if (!this.request) return
         if (!this.requestName || this.requestName === this.request.name) return
         try {
             await api.updateDdRequest(this.requestId, this.requestName)
@@ -438,10 +448,18 @@ export default {
                     try {
                         await api.deleteDdRequest(this.requestId)
                         uni.showToast({title: this.$t('panels.ddDeleted'), icon: 'success'})
+                        // 父组件（工作台）没有接 @deleted，标签不会自动关；
+                        // 这里先把本地状态清空，免得面板继续渲染已删清单的行、
+                        // 用户接着编辑又拿已不存在的 id 去打接口。
+                        this.deleted = true
+                        this.fetchSeq++
+                        this.request = null
+                        this.requestName = ''
+                        this.items = []
+                        this.selectedItemId = null
+                        this.showCommentsDrawer = false
                         // Emit event to close editor or refresh list
                         this.$emit('deleted')
-                        // For now just back?
-                        // uni.navigateBack()
                     } catch(e) {
                          uni.showToast({title: this.$t('panels.ddDeleteFailed'), icon: 'none'})
                          console.error(e)

--- a/frontend/src/components/DocDiffViewer.vue
+++ b/frontend/src/components/DocDiffViewer.vue
@@ -40,7 +40,10 @@
     <!-- Monaco Diff Editor 容器 -->
     <!-- #ifdef H5 -->
     <view class="diff-container" ref="diffContainer">
-      <div id="monaco-diff-container" class="monaco-container"></div>
+      <!-- 容器只能用模板 ref 取，不能挂全局 id：分栏模式下左右两个窗格会同时挂载
+           两个 DocDiffViewer，硬编码 id 会让两边都拿到 DOM 里靠前的那一个容器，
+           后挂载的实例把 Monaco 建进了别人的窗格。 -->
+      <div ref="monacoContainer" class="monaco-container"></div>
     </view>
     <!-- #endif -->
     
@@ -202,7 +205,7 @@ export default {
         // 动态加载 Monaco Editor
         const monaco = await this.loadMonaco()
         
-        const container = document.getElementById('monaco-diff-container')
+        const container = this.$refs.monacoContainer
         if (!container) {
           throw new Error(this.$t('editor.diff.containerMissing'))
         }

--- a/frontend/src/components/EasyVoicePane.vue
+++ b/frontend/src/components/EasyVoicePane.vue
@@ -483,9 +483,12 @@ export default {
         const callback = (content) => {
             if (content) {
                 this.text = content;
-                // Split into sentences for karaoke highlighting
-                this.sentences = this.splitTextToSentences(content)
-                console.log('[EasyVoice] Split into', this.sentences.length, 'sentences')
+                // sentences 是「当前这段音频的时间轴」，不是「文本框里现在有什么」，
+                // 所以导入时不能顺手把它换掉：旧音频还在播的话，ontimeupdate 会按旧音频
+                // 的时长算出下标、去新文档的句子数组里取字符串 emit 出去——而导入路径
+                // （project-overview 的 handleEasyVoiceDocRequest）随后就 openFile 打开了
+                // 新文档，那些句子在新文档里真能被 find 到，选区于是跟着旧音频乱跳。
+                // handleGenerate 在每次合成前都会按当前正文重算，这里不需要提前拆句。
                 uni.showToast({ title: this.$t('panels.evImportedDocSuccess'), icon: 'success' })
             } else {
                  uni.showToast({ title: this.$t('panels.evCannotGetDocContent'), icon: 'none' })

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -520,10 +520,19 @@ export default {
     // 装载 + 发布就绪。两个入口：onEndpointReady（常规：mount 时就有 file，或
     // 备胎空白 boot 完成），以及 file watcher（备胎在引擎就绪后被过继）。
     async finishDocLoad() {
+      // 重入闸：卡住 30s 露出的「重试」按钮会在原来那次装载**仍在途**时（弱网/挂起
+      // 代理下 XHR 的 60s 超时还没到）再起一条链路，两条各自 dispatch 一次
+      // load_document，且后完成的那条按最后写者赢覆盖 ready/statusKey/docKind——
+      // 迟到的失败能把重试的成功盖成 loadFailed（连带关掉保存闸），迟到的成功能把
+      // 重试装好的文档连同其间的编辑整个换掉。世代号让被取代的那条在每个 await
+      // 之后自行退场：只有最新一次尝试有权推命令、改状态、发 ready。
+      const seq = this._docLoadSeq = (this._docLoadSeq || 0) + 1
       if (this.file) {
         try {
           await this.loadDocument()
+          if (seq !== this._docLoadSeq) return
         } catch (e) {
+          if (seq !== this._docLoadSeq) return
           // Load failed → the seeded prototype is still showing. Surface it; the
           // editor stays usable (AI/IME act on whatever is shown) but the content
           // is wrong, so this is loud, not silent. docLoadFailed 关保存闸——
@@ -606,6 +615,9 @@ export default {
       // load_document 结果是否还对着「当前显示着的那次失败」，而不是被后来的
       // 重试/换文档盖过之后依然生效。
       this._loadGen = (this._loadGen || 0) + 1
+      // 本次装载所属的 finishDocLoad 世代（见那里的重入闸）；下载回来后若已被
+      // 更晚的一次尝试取代，就不能再把命令推给 worker。
+      const seq = this._docLoadSeq || 0
       const url = getFileDownloadUrl(fileId)
       let buf = this._bytesPromise ? await this._bytesPromise : null
       if (!buf) {
@@ -632,6 +644,9 @@ export default {
         this.appendLog('文档为空（新建/未保存）→ 显示空白文档 / empty doc → blank editor: ' + name)
         return false
       }
+      // office 是单线程消息循环，两条 load_document 会按到达顺序依次执行，后到的
+      // 那条把先装好的文档整个换掉——被取代的这次到此为止，不再发命令。
+      if (seq !== (this._docLoadSeq || 0)) throw new Error('装载已被更晚的一次尝试取代 / load superseded')
       this.appendLog('▶ load_document「' + name + '」(' + bytes.length + ' bytes) …')
       this.bootMilestone(86, 95, 'openingDoc')
       // 当前登录用户名随文档传给 worker：用户本人编辑的修订以用户名署名，

--- a/frontend/src/components/MarketPane.vue
+++ b/frontend/src/components/MarketPane.vue
@@ -615,6 +615,7 @@ export default {
         uni.showToast({ title: this.$t('market.installedEnableHint'), icon: 'none' })
         await this.loadPlugins()
         await this.loadPluginMarket()
+        this.notifyMarketChanged()
       } catch (e) {
         console.error('安装插件失败:', e)
         uni.showToast({ title: e?.message || this.$t('market.installFailedNeedAdmin'), icon: 'none' })
@@ -630,6 +631,7 @@ export default {
         uni.showToast({ title: this.$t('market.uninstalledToast'), icon: 'none' })
         await this.loadPlugins()
         await this.loadPluginMarket()
+        this.notifyMarketChanged()
       } catch (e) {
         console.error('卸载插件失败:', e)
         uni.showToast({ title: e?.message || this.$t('market.uninstallFailedNeedAdmin'), icon: 'none' })
@@ -660,6 +662,7 @@ export default {
         await setPluginEnabled(plugin.id, enabled)
         plugin.enabled = enabled
         uni.showToast({ title: enabled ? this.$t('market.enabledToast') : this.$t('market.disabledToggleToast'), icon: 'none' })
+        this.notifyMarketChanged()
       } catch (e) {
         console.error('切换插件状态失败:', e)
         // 回滚开关显示
@@ -711,7 +714,9 @@ export default {
         this.switching = false
       }
     },
-    // 面板型 skill 的启停直接决定左栏有没有那个图标，必须立刻通知工作台重算。
+    // 装/卸/启停改的是全局安装状态：面板型 skill 的启停决定左栏有没有那个图标，
+    // 装卸决定左栏广场面板那一行是「安装」还是「已安装」——都必须立刻通知外部重算，
+    // 否则同屏的 MarketSidebarPanel 会一直停在旧状态（本页嵌在设置 tab 里时两者共存）。
     // 两个事件都发：广场有两个宿主（左栏列表面板、中栏详情 tab），工作台两个都订。
     notifyMarketChanged() {
       uni.$emit('awd:market-changed')
@@ -773,6 +778,7 @@ export default {
         uni.showToast({ title: skill.installed ? this.$t('market.updatedToast') : this.$t('market.genericInstalledToast'), icon: 'none' })
         await this.loadSkills()
         await this.loadMarket()
+        this.notifyMarketChanged()
       } catch (e) {
         console.error('安装 Skill 失败:', e)
         uni.showToast({ title: e?.message || this.$t('market.installFailedNeedAdmin'), icon: 'none' })
@@ -788,6 +794,7 @@ export default {
         uni.showToast({ title: this.$t('market.uninstalledToast'), icon: 'none' })
         await this.loadSkills()
         await this.loadMarket()
+        this.notifyMarketChanged()
       } catch (e) {
         console.error('卸载 Skill 失败:', e)
         uni.showToast({ title: e?.message || this.$t('market.uninstallFailedNeedAdmin'), icon: 'none' })

--- a/frontend/src/components/PlainTextEditor.vue
+++ b/frontend/src/components/PlainTextEditor.vue
@@ -94,6 +94,7 @@ export default {
     this._seq = 0              // 每次用户编辑 +1；保存完成时对账判定期间有没有新输入
     this._saveTimer = null
     this._retryTimer = null
+    this._inflight = null      // 在途上传的 Promise；flushSave 靠它等真正结束
     this._applyingRemote = false
     this._loadOk = false
     this._md = null
@@ -234,7 +235,9 @@ export default {
       const content = this._view.state.doc.toString()
       this.saving = true
       try {
-        await this.uploadContent(content)
+        // 句柄留给 flushSave：关闭前必须等这一次真正结束，不能只看 saving 标志
+        this._inflight = this.uploadContent(content)
+        await this._inflight
         this.saveFailed = false
         // 保存期间又有输入的话保持脏、让防抖继续跑；没有才清脏
         if (this._seq === seq) this.dirty = false
@@ -247,6 +250,7 @@ export default {
         this._retryTimer = setTimeout(() => { this._retryTimer = null; if (this.dirty) this.save() }, RETRY_DELAY)
         return false
       } finally {
+        this._inflight = null
         this.saving = false
       }
     },
@@ -275,8 +279,12 @@ export default {
     async flushSave() {
       clearTimeout(this._saveTimer)
       this._saveTimer = null
-      for (let i = 0; i < 100 && this.saving; i++) {
-        await new Promise((r) => setTimeout(r, 100))
+      // 必须等在途保存真正结束（xhr.timeout 60s 封顶），不能只等固定几秒就放行：
+      // 放行时 saving 还是 true，紧接着的 save() 会原地 no-op（只重挂一个防抖定时器），
+      // 而组件随即卸载、定时器被 beforeUnmount 清掉——在途请求发出**之后**的那批输入
+      // 就静默丢了。成功失败都只当作「不再在途」，脏内容交给下面这次 save 兜住。
+      while (this._inflight) {
+        try { await this._inflight } catch (e) { /* 失败已在 save 里记账 */ }
       }
       if (this.dirty) await this.save()
     },

--- a/frontend/src/components/PluginPane.vue
+++ b/frontend/src/components/PluginPane.vue
@@ -85,6 +85,23 @@ export default {
       default: ''
     }
   },
+  data() {
+    return {
+      // 会话代次：调用点没给 :key，同一个面板槽位换插件时组件被复用、iframe 只换 src，
+      // 于是 A 发起的桥调用可能在 B 已经载入之后才 resolve。响应按 seq 匹配，而新插件的
+      // 序号也从 1 起，投错窗口就是把 A 的数据（可能含 B 无权读的文件内容）兑现给 B。
+      // 换插件时自增，回响应前比对，代次对不上就丢弃。
+      sessionGeneration: 0
+    }
+  },
+  watch: {
+    url() {
+      this.sessionGeneration++
+    },
+    pluginId() {
+      this.sessionGeneration++
+    }
+  },
   computed: {
     // 只有走 /api/plugin-web/ 的 Web 插件才 sandbox + 握手。
     // 绑定 null 会让 Vue 移除该属性，绝对 URL 形态因此与改造前逐字节一致。
@@ -132,16 +149,20 @@ export default {
       const msg = event.data
       if (!msg || msg.awd !== PROTOCOL || msg.type !== 'call') return
 
+      // 发起调用时的代次，await 之后据此判断这条响应还属不属于当前插件
+      const generation = this.sessionGeneration
       let out
       try {
         out = await this.handleCall(String(msg.method || ''), msg.params || {})
       } catch (e) {
         out = { ok: false, error: { code: 'internal_error', message: (e && e.message) || '调用失败' } }
       }
-      this.reply(msg.seq, out)
+      this.reply(msg.seq, out, generation)
     },
 
-    reply(seq, out) {
+    reply(seq, out, generation) {
+      // 代次已过期：调用发出后面板换了插件，这条响应属于上一个插件，丢弃
+      if (generation !== undefined && generation !== this.sessionGeneration) return
       const frame = this.$refs.pluginFrame
       if (!frame || !frame.contentWindow) return
       const msg = { awd: PROTOCOL, type: 'result', seq, ok: !!out.ok }

--- a/frontend/src/components/ReviewPanel.vue
+++ b/frontend/src/components/ReviewPanel.vue
@@ -85,7 +85,7 @@ export default {
     refreshKey: { type: Number, default: 0 },
   },
   data() {
-    return { tab: 'rev', revisions: [], comments: [], error: '' }
+    return { tab: 'rev', revisions: [], comments: [], error: '', resolving: false }
   },
   computed: {
     // 引擎按「一次编辑操作」记一条 redline：连按 Backspace 删掉一个词，就是一个字
@@ -143,16 +143,25 @@ export default {
     gotoComment(c) { this.run('goto_comment', { index: c.index }) },
     // 整组处置。**必须从高索引往低处理**：index 就是枚举序，处置掉一条之后比它
     // 大的索引全部前移一位，而比它小的不受影响——倒着走，剩下的索引才一直有效。
+    // 连点两次会并发跑两轮：两轮手里是同一份索引，第一轮处置掉一条后引擎里的索引
+    // 已经前移，第二轮那份索引会打到别的修订上（引擎照样返回 success）。加重入闸，
+    // 处置期间的重复点击直接忽略。
     async resolveGroup(g, action) {
-      const indices = g.items.map((r) => r.index).sort((a, b) => b - a)
-      let done = 0
-      for (const index of indices) {
-        if (await this.run('resolve_revision', { index, action })) done++
+      if (this.resolving) return
+      this.resolving = true
+      try {
+        const indices = g.items.map((r) => r.index).sort((a, b) => b - a)
+        let done = 0
+        for (const index of indices) {
+          if (await this.run('resolve_revision', { index, action })) done++
+        }
+        if (done) this.$emit('changed')
+        // 引擎没命中的如实说，别让用户以为整组都处理完了
+        if (done < indices.length) this.error = this.$t('editor.review.groupPartialFail', { total: indices.length, failed: indices.length - done })
+        await this.reload()
+      } finally {
+        this.resolving = false
       }
-      if (done) this.$emit('changed')
-      // 引擎没命中的如实说，别让用户以为整组都处理完了
-      if (done < indices.length) this.error = this.$t('editor.review.groupPartialFail', { total: indices.length, failed: indices.length - done })
-      await this.reload()
     },
     async resolveAll(action) {
       const res = await this.run('resolve_all_revisions', { action })

--- a/frontend/src/components/SearchPanel.vue
+++ b/frontend/src/components/SearchPanel.vue
@@ -367,7 +367,8 @@ export default {
         this.collapsedFiles = {}
       } catch (e) {
         console.error('Search failed:', e)
-        uni.showToast({ title: 'Search failed', icon: 'none' })
+        // 失败提示同样按 seq 收口：陈旧请求的迟到失败不该盖在新结果上弹「搜索失败」
+        if (seq === this._searchSeq) uni.showToast({ title: 'Search failed', icon: 'none' })
       } finally {
         if (seq === this._searchSeq) this.loading = false
       }

--- a/frontend/src/components/TagManager.vue
+++ b/frontend/src/components/TagManager.vue
@@ -22,7 +22,7 @@
           :style="{ backgroundColor: newTagColor }"
           @click="toggleColorPicker"
         ></view>
-        <button class="add-btn" @click="handleAdd" :disabled="!newTagName">{{ $t('files.add') }}</button>
+        <button class="add-btn" @click="handleAdd" :disabled="!newTagName || adding">{{ $t('files.add') }}</button>
       </view>
 
       <view class="type-segment">
@@ -123,6 +123,8 @@ export default {
       newTagName: '',
       newTagType: TAG_TYPE_NORMAL,
       newTagColor: TAG_TYPE_DEFAULT_COLORS[TAG_TYPE_NORMAL],
+      // 创建请求在途标志：名字要等请求返回才清，没有这道闸双击就会用同名再发一次
+      adding: false,
       showColorPicker: false,
       presetColors: [
         '#EF4444', '#F97316', '#F59E0B', '#10B981', '#3B82F6',
@@ -174,7 +176,9 @@ export default {
       return TAG_TYPE_I18N_KEYS[normalizeTagType(tag)];
     },
     async handleAdd() {
+      if (this.adding) return;
       if (!this.newTagName.trim()) return;
+      this.adding = true;
       try {
         await api.createTag(this.projectId, {
           name: this.newTagName.trim(),
@@ -187,6 +191,8 @@ export default {
         this.refreshTags();
       } catch (e) {
         uni.showToast({ title: 'Failed to create tag', icon: 'none' });
+      } finally {
+        this.adding = false;
       }
     },
     startEdit(tag) {

--- a/frontend/src/components/admin/AdminPane.vue
+++ b/frontend/src/components/admin/AdminPane.vue
@@ -1443,6 +1443,8 @@ export default {
       // 用户反馈与优化者（右下角浮窗提交 → 优化者分诊 → 开 PR / 发邮件）
       feedbackList: [],
       feedbackDetail: null,
+      // 最后一次点开详情的目标 id：慢到的旧响应不许覆盖后点的那条
+      feedbackDetailPendingId: null,
       feedbackLoading: false,
       feedbackFilter: '',
       feedbackFilters: [
@@ -2192,6 +2194,7 @@ export default {
     setFeedbackFilter(key) {
       this.feedbackFilter = key
       this.feedbackDetail = null
+      this.feedbackDetailPendingId = null
       this.loadFeedbackList()
     },
     async triggerOptimizer() {
@@ -2207,10 +2210,14 @@ export default {
     async toggleFeedbackDetail(id) {
       if (this.feedbackDetail && this.feedbackDetail.id === id) {
         this.feedbackDetail = null
+        this.feedbackDetailPendingId = null
         return
       }
+      this.feedbackDetailPendingId = id
       try {
         const res = await getFeedbackDetail(id)
+        // 先点 A 再点 B、A 的响应后到时直接丢弃，否则会把 B 的详情顶掉、A 自己弹开
+        if (this.feedbackDetailPendingId !== id) return
         const d = (res && res.data) || {}
         this.feedbackDetail = {
           id,
@@ -2219,6 +2226,7 @@ export default {
           contextText: this.formatContext(d.contextJson),
         }
       } catch (e) {
+        if (this.feedbackDetailPendingId !== id) return
         uni.showToast({ title: (e && e.message) || this.$t('admin.loadDetailFailed'), icon: 'none' })
       }
     },

--- a/frontend/src/components/project-calendar/ProjectCalendarPane.vue
+++ b/frontend/src/components/project-calendar/ProjectCalendarPane.vue
@@ -33,7 +33,11 @@
       <AwdDatePicker v-model="quickDate" type="date" />
       <view class="pcp-quick-actions">
         <view class="pcp-quick-btn" @tap="quickCreateOpen = false">{{ $t('calendar.cancel') }}</view>
-        <view class="pcp-quick-btn pcp-quick-btn-primary" @tap="submitQuickCreate">{{ $t('calendar.save') }}</view>
+        <view
+          class="pcp-quick-btn pcp-quick-btn-primary"
+          :style="quickSaving ? 'opacity:0.6;cursor:default' : ''"
+          @tap="submitQuickCreate"
+        >{{ $t('calendar.save') }}</view>
       </view>
     </view>
 
@@ -84,6 +88,7 @@ export default {
   props: {
     projectId: { type: [Number, String], required: true },
   },
+  emits: ['leave-workbench'],
   data() {
     return {
       tasks: [],
@@ -92,6 +97,7 @@ export default {
       quickCreateOpen: false,
       quickTitle: '',
       quickDate: '',
+      quickSaving: false,
       activeTask: null,
     }
   },
@@ -178,6 +184,10 @@ export default {
         uni.showToast({ title: this.$t('calendar.requiredDate'), icon: 'none' })
         return
       }
+      // 回车（@confirm）和点「保存」是两条独立入口，网络往返期间两条都点得动，
+      // 各发一次 createTask 就多出一条标题日期完全相同的任务，只能手删。
+      if (this.quickSaving) return
+      this.quickSaving = true
       try {
         await createTask({ projectId: this.projectId, title, dueDate: this.quickDate })
         this.quickCreateOpen = false
@@ -185,6 +195,8 @@ export default {
         this.loadTasks()
       } catch (e) {
         uni.showToast({ title: (e && e.message) || this.$t('calendar.saveFailed'), icon: 'none' })
+      } finally {
+        this.quickSaving = false
       }
     },
     async toggleActiveDone() {
@@ -226,8 +238,12 @@ export default {
       })
     },
     openGlobalCalendar() {
-      // 工作台参与的跳转一律 reLaunch（见 CLAUDE.md 导航总规则）
-      uni.reLaunch({ url: '/pages/calendar/calendar' })
+      // 不在这里自己 reLaunch：离开工作台前必须先把编辑器里的未存改动落盘
+      // （flushDirtyEditors 吃的是挂在工作台页面实例上的编辑器引用，子组件够不到），
+      // 否则律师刚敲的那几秒改动会静默丢失——就是 #489 修过的那一类。
+      // 统一交给父页面的 leaveWorkbench：它先落盘再 reLaunch
+      // （工作台参与的跳转一律 reLaunch，见 CLAUDE.md 导航总规则）。
+      this.$emit('leave-workbench', '/pages/calendar/calendar')
     },
   },
 }

--- a/frontend/src/components/project-home/ConversationList.vue
+++ b/frontend/src/components/project-home/ConversationList.vue
@@ -23,7 +23,9 @@
         <text v-if="hasPreview(c)" class="conv-preview">{{ c.lastMessage }}</text>
         <text class="conv-meta">{{ metaOf(c) }}</text>
       </view>
-      <view v-if="hasMore" class="conv-more" @tap="$emit('load-more')">{{ $t('projects.loadMoreConversations') }}</view>
+      <view v-if="hasMore" class="conv-more" :class="{ 'conv-more-busy': loading }" @tap="onLoadMore">
+        {{ loading ? $t('projects.conversationsLoadingHint') : $t('projects.loadMoreConversations') }}
+      </view>
     </template>
   </view>
 </template>
@@ -59,6 +61,13 @@ export default {
     },
     metaOf(c) {
       return [c.ownerName, formatDateTime(c.updatedAt)].filter(Boolean).join(' · ')
+    },
+    // 翻页游标要等响应回来才更新，连点两下会用同一份游标取回同一页拼进列表，
+    // 于是同一个 conversationId 出现两次，v-for 的 :key 撞车、卡片重复渲染。
+    // 请求在飞时不再派发，行本身改成加载中文案（不隐藏，免得内容跳位）。
+    onLoadMore() {
+      if (this.loading) return
+      this.$emit('load-more')
     },
   },
 }
@@ -154,6 +163,11 @@ export default {
   font-size: 12px;
   color: #1A5336;
   cursor: pointer;
+}
+
+.conv-more-busy {
+  color: #6C757D;
+  cursor: default;
 }
 
 /* 响应祖先 .project-home-pane 的实际渲染宽度，见 project-home-pane.scss 的注释 */

--- a/frontend/src/components/userprofile/PersonalSettingsPanel.vue
+++ b/frontend/src/components/userprofile/PersonalSettingsPanel.vue
@@ -47,7 +47,7 @@
               <input class="bind-input code" type="number" maxlength="6" v-model="totpCodeInput" :placeholder="$t('account.appCodePlaceholder')" />
             </view>
             <view class="bind-actions">
-              <button class="btn-bind-confirm" @tap="confirmTotpBind">{{ $t('account.finishBindBtn') }}</button>
+              <button class="btn-bind-confirm" :disabled="totpSubmitting" @tap="confirmTotpBind">{{ $t('account.finishBindBtn') }}</button>
               <text class="bind-link" @tap="cancelTotpPanel">{{ $t('common.cancel') }}</text>
             </view>
           </template>
@@ -58,7 +58,7 @@
               <input class="bind-input code" type="number" maxlength="6" v-model="totpCodeInput" :placeholder="$t('account.appCodePlaceholder')" />
             </view>
             <view class="bind-actions">
-              <button class="btn-bind-confirm" @tap="confirmTotpDisable">{{ $t('account.confirmUnbindBtn') }}</button>
+              <button class="btn-bind-confirm" :disabled="totpSubmitting" @tap="confirmTotpDisable">{{ $t('account.confirmUnbindBtn') }}</button>
               <text class="bind-link" @tap="cancelTotpPanel">{{ $t('common.cancel') }}</text>
             </view>
           </template>
@@ -82,7 +82,7 @@
             </button>
           </view>
           <view class="bind-actions">
-            <button class="btn-bind-confirm" @tap="confirmBindPhone">{{ $t('account.confirmBindBtn') }}</button>
+            <button class="btn-bind-confirm" :disabled="bindSubmitting" @tap="confirmBindPhone">{{ $t('account.confirmBindBtn') }}</button>
             <text class="bind-link" @tap="cancelBindPhone">{{ $t('common.cancel') }}</text>
           </view>
           <text class="bind-tip">{{ $t('account.bindPhoneTip') }}</text>
@@ -106,7 +106,7 @@
             </button>
           </view>
           <view class="bind-actions">
-            <button class="btn-bind-confirm" @tap="confirmBindEmail">{{ $t('account.confirmBindBtn') }}</button>
+            <button class="btn-bind-confirm" :disabled="bindEmailSubmitting" @tap="confirmBindEmail">{{ $t('account.confirmBindBtn') }}</button>
             <text class="bind-link" @tap="cancelBindEmail">{{ $t('common.cancel') }}</text>
           </view>
           <text class="bind-tip">{{ $t('account.bindEmailTip') }}</text>
@@ -239,6 +239,10 @@ export default {
       totpCodeInput: '',
       totpBusy: false, // startSetup 在飞期间为 true，防止重复点击触发并发请求
       _totpRequestSeq: 0, // 请求代次：只接受"此刻最新一次"发出的响应
+      // 上面两个管的是「开始设置」那一步；下面这个管「确认」那一步——
+      // 验证码是一次性的：连点两次会并发发两次请求，第二次必然失败，
+      // 于是成功 toast 后面又叠一个失败 toast。三个闸各管一个面板。
+      totpSubmitting: false,
 
       // 手机号绑定（登录短信验证，仅 server 模式且启用时显示）
       showBindPhone: false,
@@ -246,6 +250,7 @@ export default {
       bindCodeInput: '',
       bindCountdown: 0,
       bindCountdownTimer: null,
+      bindSubmitting: false,
 
       // 邮箱绑定（与手机号并列的二次验证方式；绑了之后优先走邮件，省短信费）
       showBindEmail: false,
@@ -253,6 +258,7 @@ export default {
       bindEmailCodeInput: '',
       bindEmailCountdown: 0,
       bindEmailCountdownTimer: null,
+      bindEmailSubmitting: false,
     }
   },
   mounted() {
@@ -432,6 +438,8 @@ export default {
         uni.showToast({ title: this.$t('account.enterSixDigitCode'), icon: 'none' })
         return
       }
+      if (this.totpSubmitting) return
+      this.totpSubmitting = true
       try {
         await totpActivate(this.totpCodeInput)
         this.userInfo = { ...this.userInfo, totpEnabled: true }
@@ -440,6 +448,8 @@ export default {
         this.cancelTotpPanel()
       } catch (e) {
         uni.showToast({ title: e.message || this.$t('account.bindFailed'), icon: 'none' })
+      } finally {
+        this.totpSubmitting = false
       }
     },
     async confirmTotpDisable() {
@@ -447,6 +457,8 @@ export default {
         uni.showToast({ title: this.$t('account.enterSixDigitCode'), icon: 'none' })
         return
       }
+      if (this.totpSubmitting) return
+      this.totpSubmitting = true
       try {
         await totpDisable(this.totpCodeInput)
         this.userInfo = { ...this.userInfo, totpEnabled: false }
@@ -455,6 +467,8 @@ export default {
         this.cancelTotpPanel()
       } catch (e) {
         uni.showToast({ title: e.message || this.$t('account.unbindFailed'), icon: 'none' })
+      } finally {
+        this.totpSubmitting = false
       }
     },
     cancelTotpPanel() {
@@ -496,6 +510,8 @@ export default {
         uni.showToast({ title: this.$t('account.enterSixDigitCode'), icon: 'none' })
         return
       }
+      if (this.bindSubmitting) return
+      this.bindSubmitting = true
       try {
         const res = await bindPhone(this.bindPhoneInput, this.bindCodeInput)
         uni.showToast({ title: this.$t('account.bindSuccessToast'), icon: 'success' })
@@ -505,6 +521,8 @@ export default {
         this.cancelBindPhone()
       } catch (e) {
         uni.showToast({ title: e.message || this.$t('account.bindFailed'), icon: 'none' })
+      } finally {
+        this.bindSubmitting = false
       }
     },
     cancelBindPhone() {
@@ -546,6 +564,8 @@ export default {
         uni.showToast({ title: this.$t('account.enterSixDigitCode'), icon: 'none' })
         return
       }
+      if (this.bindEmailSubmitting) return
+      this.bindEmailSubmitting = true
       try {
         const res = await bindEmail(this.bindEmailInput.trim(), this.bindEmailCodeInput)
         uni.showToast({ title: this.$t('account.bindSuccessToast'), icon: 'success' })
@@ -555,6 +575,8 @@ export default {
         this.cancelBindEmail()
       } catch (e) {
         uni.showToast({ title: e.message || this.$t('account.bindFailed'), icon: 'none' })
+      } finally {
+        this.bindEmailSubmitting = false
       }
     },
     cancelBindEmail() {

--- a/frontend/src/components/version/VersionTimeline.vue
+++ b/frontend/src/components/version/VersionTimeline.vue
@@ -130,7 +130,7 @@ export default {
   },
   emits: ['reload-files', 'compare-file', 'draft-created'],
   data() {
-    return { versions: [], expanded: {}, selected: null, loadError: false, draftBranches: [] }
+    return { versions: [], expanded: {}, selected: null, loadError: false, draftBranches: [], loadSeq: 0 }
   },
   watch: {
     fileFilter() {
@@ -163,12 +163,20 @@ export default {
     this.load()
   },
   methods: {
+    // fileFilter 每变一次就重新 load()，前一次在途的请求不会被取消。先点文件过滤、
+    // 紧接着点「查看全部」时，两个请求带着不同 fileId 前后脚发出，先发的那个若后回，
+    // 会把已经渲染好的全量时间线覆盖成过滤结果——列表内容和当前过滤状态对不上，
+    // isCurrentHead 拿实时 fileFilter 配陈旧 versions 还会高亮错节点。用自增序号
+    // 只认最后一次发出的请求的响应。
     async load() {
+      const seq = ++this.loadSeq
       try {
         const res = await getVersionTimeline(this.projectId, 50, this.fileFilter && this.fileFilter.fileId)
+        if (seq !== this.loadSeq) return
         this.versions = ((res && res.data && res.data.versions) || [])
         this.loadError = false
       } catch (e) {
+        if (seq !== this.loadSeq) return
         console.warn('[Version] 读取时间线失败', e)
         this.loadError = true
         uni.showToast({ title: this.$t('version.loadFailedToast'), icon: 'none' })

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -1,4 +1,4 @@
-import { ref, reactive, nextTick } from 'vue'
+import { ref, reactive, nextTick, onUnmounted, getCurrentInstance } from 'vue'
 import { getApiBaseUrl, getConversationMetadata } from '@/services/api.js'
 import { getSessionId } from '@/utils/auth.js'
 import { createProtocolTagRegex, decodeProtocolTags } from '@/composables/agentTagProtocol.mjs'
@@ -77,6 +77,9 @@ export function useAgentStream() {
     // Abort Controllers
     let sseAbortController = null
     let messageAbortController = null
+    // 本实例最近一次挂上模块级单例的网络恢复回调（卸载时据此判断单例是不是自己的，
+    // 无条件置空会踩掉后挂载实例的重连入口）
+    let myNetworkRecoveryHook = null
 
     // --- 断线自动重连状态（F-05）---
     let reconnectAttempts = 0
@@ -316,9 +319,10 @@ export function useAgentStream() {
                 lastSseActivityAt = Date.now()
                 startHeartbeatMonitor()
                 // 网络恢复/回前台时经模块级单例回调触发本实例重连
-                activeNetworkRecoveryHook = (reason) => {
+                myNetworkRecoveryHook = (reason) => {
                     if (!isConnected.value && currentConversationId.value) scheduleReconnect(reason)
                 }
+                activeNetworkRecoveryHook = myNetworkRecoveryHook
                 resolve()
 
                 // 建连即补拉一次在跑的后台任务：background_task_start 只在任务起跑那一刻发一次，
@@ -1517,6 +1521,23 @@ export function useAgentStream() {
         console.log('[AgentStream] Rolled back to message index:', messageIndex, 'remaining:', bubbles.value.length)
 
         return content
+    }
+
+    // 组件卸载时收尾：SSE reader 循环、心跳 interval、待触发的重连定时器都活在闭包里，
+    // 页面被销毁（工作台的跳转一律 reLaunch，整个页面栈都拆掉）后它们不会自己停。
+    // 后果不只是白耗流量：僵尸实例还会 scheduleReconnect，与新挂载的实例轮流把对方
+    // 从同一会话的 SSE 上挤下去。activeNetworkRecoveryHook 是模块级单例，
+    // 只有它当前指向本实例时才置空，否则会踩掉后挂载实例的重连入口。
+    if (getCurrentInstance()) {
+        onUnmounted(() => {
+            if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+            // 先清会话 id：scheduleReconnect 与重连回调都以它为准，置空即断掉续命链
+            currentConversationId.value = null
+            stopHeartbeatMonitor()
+            if (activeNetworkRecoveryHook === myNetworkRecoveryHook) activeNetworkRecoveryHook = null
+            myNetworkRecoveryHook = null
+            resetSSE()
+        })
     }
 
     return {

--- a/frontend/src/pages/calendar/calendar.vue
+++ b/frontend/src/pages/calendar/calendar.vue
@@ -89,6 +89,8 @@ export default {
       defaultDate: '',
       currentFrom: '',
       currentTo: '',
+      // loadTasks 的请求序号，见该方法里的乱序说明
+      loadSeq: 0,
     }
   },
   created() {
@@ -140,11 +142,18 @@ export default {
     },
 
     async loadTasks(from, to) {
+      // 连点翻月/切视图会连发请求，先发的（旧区间）响应可能后到。FullCalendar 只画
+      // 落在当前视图区间内的事件，旧结果落地的表现是当前月份大面积空白（只剩两个
+      // 区间重叠的那几条），直到再翻一次或保存/删除触发 refresh 才恢复。只认最后
+      // 一次请求的结果，被放弃的那次连失败提示也一并咽掉。
+      const seq = ++this.loadSeq
       try {
         const res = await getCalendarTasks(from, to)
+        if (seq !== this.loadSeq) return
         this.tasks = (res.data && res.data.tasks) || []
         this.calendarOptions.events = this.buildEvents()
       } catch (e) {
+        if (seq !== this.loadSeq) return
         console.error('[calendar] 加载日程失败', e)
         uni.showToast({ title: this.$t('calendar.loadFailed'), icon: 'none' })
       }

--- a/frontend/src/pages/newproject/index.vue
+++ b/frontend/src/pages/newproject/index.vue
@@ -227,12 +227,13 @@ export default {
         const res = await createProject({ projectType: 'BLANK', name: this.blankName })
         const projectId = res && res.id
         uni.showToast({ title: this.$t('account.projectCreateSuccess'), icon: 'success' })
+        // busy 一直保持到 reLaunch 真把页面带走：请求返回到跳转之间还有 500ms，
+        // 这段时间里放开按钮，再点一下就会用同一个名字再建一个空白项目
         setTimeout(() => {
           uni.reLaunch({ url: `/pages/project-overview/project-overview?id=${projectId}` })
         }, 500)
       } catch (err) {
         uni.showToast({ title: (err && err.message) || this.$t('account.createProjectFailed'), icon: 'none' })
-      } finally {
         this.busy = false
       }
     },

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -379,6 +379,7 @@
         :project-id="projectId"
         :allow-folder="filePickerAllowFolder"
         @confirm="handleFilePickerConfirm"
+        @cancel="handleFilePickerCancel"
       />
 
       <!-- Invite Modal (Refactored to AI WorkDeck) -->
@@ -658,6 +659,7 @@
           <ProjectCalendarPane
             v-else-if="leftPaneKey === 'calendar'"
             :project-id="projectId"
+            @leave-workbench="leaveWorkbench"
           />
           <PluginDevPanel
             v-else-if="leftPaneKey === 'dev'"
@@ -891,8 +893,13 @@
                       :file="activeFileLeft"
                       :project-id="projectId"
                     />
+                    <!-- key 不能省：两个对比标签命中同一个 v-else-if 分支，没有 key
+                         Vue 会就地复用同一个组件实例，而 DocDiffViewer 只在 mounted()
+                         里取一次文档、对 sourceId/targetId 没有 watch——标题换成了新的
+                         两份文档，Monaco 里画的还是上一对（右窗格同理）。 -->
                     <DocDiffViewer
                       v-else-if="isDiffTab(activeFileLeft)"
+                      :key="activeFileLeft.id"
                       :source-id="activeFileLeft.diffSource.id"
                       :target-id="activeFileLeft.diffTarget.id"
                       :source-name="activeFileLeft.diffSource.name"
@@ -1014,6 +1021,7 @@
                     />
                     <DocDiffViewer
                       v-else-if="isDiffTab(activeFileRight)"
+                      :key="activeFileRight.id"
                       :source-id="activeFileRight.diffSource.id"
                       :target-id="activeFileRight.diffTarget.id"
                       :source-name="activeFileRight.diffSource.name"
@@ -3328,6 +3336,16 @@ export default {
         this.openFile(file)
     },
 
+    // 三个面板（脱敏 / 诉讼可视化 / EasyVoice）共用这一个选择器，各自把 resume 回调
+    // 暂存在页面字段上。用户点取消（含点遮罩、点 ×）时不清，残留的旧回调会在下一次
+    // 别的面板开选择器时抢先命中 handleFilePickerConfirm 的分支——新面板的回调永远不
+    // 会被调用，用户选了文件却什么都没发生。
+    handleFilePickerCancel() {
+        this.desensitizeFileSelectCallback = null
+        this.litigationScopeCallback = null
+        this.easyVoiceImportCallback = null
+    },
+
     async handleFilePickerConfirm(file) {
         if (!file || !file.id) return
 
@@ -3629,13 +3647,18 @@ export default {
       this.startRenameProject()
     },
     async confirmRenameProject() {
-      if (!this.renameProjectName || !this.renameProjectName.trim()) {
+      // 名字必须在 await 之前取下来存成局部变量。uni-app H5 的 input 在派发 @confirm
+      // 之后会立刻 input.blur()（confirm-hold 默认 false），模板上 @blur 绑的正是
+      // cancelRenameProject——它同步把 renameProjectName 清成 ''。await 回来再读这个
+      // 字段，写进标题的就是空串（显示成「未命名项目」），而服务端存的其实是对的。
+      const newName = (this.renameProjectName || '').trim()
+      if (!newName) {
         uni.showToast({ title: this.$t('workbench.projectNameEmpty'), icon: 'none' })
         return
       }
       try {
-        await renameProject(this.projectId, this.renameProjectName.trim())
-        this.project.name = this.renameProjectName.trim()
+        await renameProject(this.projectId, newName)
+        this.project.name = newName
         this.isRenamingProject = false
         uni.showToast({ title: this.$t('workbench.renameSuccess'), icon: 'success' })
       } catch (e) {

--- a/frontend/src/utils/meetingRecorder.js
+++ b/frontend/src/utils/meetingRecorder.js
@@ -18,6 +18,8 @@ import { resolveTrackEndedStatus } from '@/utils/meetingRecorderStatus.js'
 const CHUNK_TIMESLICE_MS = 5000
 const UPLOAD_TIMEOUT_MS = 60000
 const LEVEL_INTERVAL_MS = 200
+// 收尾阶段单块上传的重试上限（录音进行中仍然无限重试，见 uploadChunkWithRetry）
+const STOP_UPLOAD_MAX_ATTEMPTS = 5
 
 export const recorderState = reactive({
   status: 'idle', // idle | starting | recording | paused | stopping
@@ -44,6 +46,8 @@ let uploadQueue = []
 let uploadOffset = 0
 let uploading = false
 let recordingDone = false
+// 收尾阶段重试封顶后放弃上传：余下的块直接丢弃，不再拖住 stopRecording
+let uploadAbandoned = false
 // 本模块最近写进 recorderState.error 的那条「上传受阻」原文，传通之后据此清理。
 // 原先比的是文案前缀，文案进了 i18n 就不能这么判（英文版永远匹配不上）；
 // 而清空又必须只认自己写的那条，不能顺手抹掉别处的报错——留原文比对是两者兼顾的写法。
@@ -142,6 +146,7 @@ export async function startRecording(projectId, deviceId) {
     uploadOffset = 0
     uploading = false
     recordingDone = false
+    uploadAbandoned = false
     uploadStalledNotice = ''
 
     const mimeType = pickAudioMime()
@@ -233,6 +238,7 @@ async function drainUploadQueue() {
   uploading = true
   try {
     while (uploadQueue.length > 0) {
+      if (uploadAbandoned) { uploadQueue = []; break }
       const blob = uploadQueue[0]
       const isLast = recordingDone && uploadQueue.length === 1
       await uploadChunkWithRetry(blob, uploadOffset, isLast)
@@ -240,6 +246,13 @@ async function drainUploadQueue() {
       recorderState.uploadedBytes = uploadOffset
       uploadQueue.shift()
     }
+  } catch (e) {
+    // 收尾阶段重试封顶后抛到这里：丢掉余下的块，让下面的 resolve 能触发，
+    // 否则 stopRecording 的 await stopped 永远不返回（status 钉死在 stopping）。
+    uploadAbandoned = true
+    uploadQueue = []
+    uploadStalledNotice = ''
+    recorderState.error = t('common.uploadFailed')
   } finally {
     uploading = false
   }
@@ -253,6 +266,7 @@ async function drainUploadQueue() {
 
 async function uploadChunkWithRetry(blob, offset, isLast) {
   let attempt = 0
+  let stopAttempt = 0
   // 录音进行期间无限重试（指数退避封顶 10s）：块顺序不能乱，丢一块整段音频作废
   for (;;) {
     try {
@@ -264,6 +278,11 @@ async function uploadChunkWithRetry(blob, offset, isLast) {
       return
     } catch (e) {
       attempt += 1
+      // 收尾阶段另算一份重试次数并封顶：stopRecording 的 await stopped 挂在这个循环上，
+      // 永久性失败（鉴权过期、后台把文件删了）会把 status 钉死在 'stopping'，
+      // 面板与顶部胶囊的停止按钮跟着永远禁用，用户只能强杀应用。
+      // 单独计数是为了不把录音期间已经攒下的失败次数算进来——那些多半是断网这类瞬时故障。
+      if (recorderState.status === 'stopping' && (stopAttempt += 1) >= STOP_UPLOAD_MAX_ATTEMPTS) throw e
       uploadStalledNotice = t('meeting.uploadStalled', { attempt })
       recorderState.error = uploadStalledNotice
       await new Promise(r => setTimeout(r, Math.min(1000 * attempt, 10000)))

--- a/frontend/tests/check-emits/emit-bindings.test.mjs
+++ b/frontend/tests/check-emits/emit-bindings.test.mjs
@@ -1,0 +1,62 @@
+// 静态护栏自身的回归测试：属性里出现裸 '>' 时，护栏不许把后面的 @event 漏掉。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), '../../scripts/check-emit-bindings.mjs')
+
+// 造一棵最小 src/：一个不 emit 'some-event' 的子组件 + 一个绑了它的父组件
+function makeFixture(parentTemplate) {
+  const root = mkdtempSync(join(tmpdir(), 'check-emits-'))
+  mkdirSync(join(root, 'components'), { recursive: true })
+  // 脚本尾部的反馈浮窗护栏要求这个文件存在
+  writeFileSync(join(root, 'components/FeedbackWidget.vue'), '<template><div class="awdfb-mask"></div></template>\n')
+  writeFileSync(join(root, 'components/ChildComp.vue'), '<script setup>\nconst emit = defineEmits([\'other-event\'])\n</script>\n')
+  writeFileSync(
+    join(root, 'components/ParentComp.vue'),
+    `<template>\n${parentTemplate}\n</template>\n<script setup>\nimport ChildComp from './ChildComp.vue'\n</script>\n`,
+  )
+  return root
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: 'utf8',
+    env: { ...process.env, CHECK_EMITS_SRC: root },
+  })
+}
+
+test('属性值里含裸 > 时，后面的死绑定仍要被抓出来', () => {
+  const root = makeFixture('  <ChildComp :disabled="count > 5" @some-event="handler" />')
+  try {
+    const r = run(root)
+    assert.equal(r.status, 1, `期望检查失败，实际 stdout=${r.stdout} stderr=${r.stderr}`)
+    assert.match(r.stderr, /@some-event/)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('没有裸 > 的死绑定照旧能被抓出来', () => {
+  const root = makeFixture('  <ChildComp @some-event="handler" />')
+  try {
+    const r = run(root)
+    assert.equal(r.status, 1, `期望检查失败，实际 stdout=${r.stdout} stderr=${r.stderr}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('子组件确实 emit 的绑定不报错', () => {
+  const root = makeFixture('  <ChildComp :disabled="count > 5" @other-event="handler" />')
+  try {
+    const r = run(root)
+    assert.equal(r.status, 0, `期望检查通过，实际 stderr=${r.stderr}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/frontend/tests/meeting-recorder/stop-upload-cap.test.mjs
+++ b/frontend/tests/meeting-recorder/stop-upload-cap.test.mjs
@@ -1,0 +1,87 @@
+// 审计（dev-board#74）：上传永久失败时 stopRecording() 永不返回，status 钉死在
+// 'stopping'，面板与顶部胶囊的停止按钮永远禁用，会议在后端一直是 RECORDING。
+//
+// 这里不做源码文本断言，而是真跑一遍引擎：把 meetingRecorder.js 的四处 import
+// 改写成本目录的替身模块（node 解析不了 uni 的 @/ 别名），落到临时文件再 import。
+// 替身的上传端点必然失败，等价于鉴权过期或文件被后台删掉。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as stubs from './stubs.mjs'
+
+const realSetTimeout = globalThis.setTimeout
+const sleep = (ms) => new Promise((r) => realSetTimeout(r, ms))
+// 竞速用的兜底计时器：不 unref 的话，用例过了之后进程还要空等它到点
+const sleepUnref = (ms) => new Promise((r) => { const h = realSetTimeout(r, ms); if (h.unref) h.unref() })
+
+function buildModuleUrl() {
+  const src = readFileSync(new URL('../../src/utils/meetingRecorder.js', import.meta.url), 'utf8')
+  const stubsUrl = new URL('./stubs.mjs', import.meta.url).href
+  const rewritten = src
+    .replace(/from 'vue'/, `from '${stubsUrl}'`)
+    .replace(/from '@\/services\/api\.js'/, `from '${stubsUrl}'`)
+    .replace(/from '@\/utils\/auth\.js'/, `from '${stubsUrl}'`)
+    .replace(/from '@\/i18n'/, `from '${stubsUrl}'`)
+  const out = join(tmpdir(), `meeting-recorder-under-test-${process.pid}.mjs`)
+  writeFileSync(out, rewritten, 'utf8')
+  return out
+}
+
+class FakeRecorder {
+  constructor() { this.state = 'recording'; FakeRecorder.instance = this }
+  start() {}
+  stop() { this.state = 'inactive'; if (this.onstop) this.onstop() }
+}
+FakeRecorder.isTypeSupported = () => false
+
+function installGlobals() {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { mediaDevices: { getUserMedia: async () => ({ getTracks: () => [] }) } },
+    configurable: true, writable: true,
+  })
+  globalThis.MediaRecorder = FakeRecorder
+  // 只提供 XHR 的形状；本模块在非 H5 条件编译分支里会立刻 reject，
+  // 走的是同一条「上传失败」路径，重试逻辑不区分失败原因。
+  globalThis.XMLHttpRequest = class {
+    open() {} setRequestHeader() {} send() {} abort() {}
+  }
+  // 退避是 1s 起步的真等待，测试里压成 1ms
+  globalThis.setTimeout = (fn, ms, ...rest) => realSetTimeout(fn, ms >= 1000 ? 1 : ms, ...rest)
+}
+
+const attemptOf = (err) => {
+  const m = /"attempt":(\d+)/.exec(err || '')
+  return m ? Number(m[1]) : 0
+}
+
+test('上传永久失败时 stopRecording 会封顶放弃，而不是把 status 钉死在 stopping', async () => {
+  installGlobals()
+  const rec = await import(buildModuleUrl())
+  try {
+    await rec.startRecording('p1')
+    assert.equal(rec.recorderState.status, 'recording')
+
+    FakeRecorder.instance.ondataavailable({ data: { size: 1024 } })
+
+    // 先确认录音进行期间仍然是无限重试（这条是刻意保留的耐久性设计，不许被封顶改掉）
+    const deadline = Date.now() + 5000
+    while (attemptOf(rec.recorderState.error) < 8 && Date.now() < deadline) await sleep(5)
+    assert.ok(attemptOf(rec.recorderState.error) >= 8,
+      '录音进行期间应当持续重试，实际 error=' + rec.recorderState.error)
+    assert.equal(rec.recorderState.status, 'recording')
+
+    const result = await Promise.race([
+      rec.stopRecording(),
+      sleepUnref(5000).then(() => 'TIMEOUT'),
+    ])
+    assert.notEqual(result, 'TIMEOUT',
+      'stopRecording 必须返回：否则 status 永远停在 stopping，停止按钮永远禁用')
+    assert.equal(rec.recorderState.status, 'idle')
+    assert.equal(stubs.finishCallCount(), 1, '放弃上传后仍要回写 finish，别把会议留在 RECORDING')
+    assert.ok(rec.recorderState.error, '放弃上传要留一条报错给用户')
+  } finally {
+    globalThis.setTimeout = realSetTimeout
+  }
+})

--- a/frontend/tests/meeting-recorder/stubs.mjs
+++ b/frontend/tests/meeting-recorder/stubs.mjs
@@ -1,0 +1,18 @@
+// meetingRecorder.js 的依赖替身（见 stop-upload-cap.test.mjs 的模块改写）。
+// 上传端点固定失败，用来模拟「鉴权过期 / 文件被后台删掉」这类永久性失败。
+
+let finishCalls = 0
+
+// 断言只看状态里的值，不需要真的响应式；而且 worktree 里不一定装了 node_modules，
+// 依赖 vue 会让这条用例在干净检出上跑不起来。
+export const reactive = (o) => o
+
+export const getApiBaseUrl = () => 'http://127.0.0.1:0'
+export const getAuthHeaders = () => ({ 'X-Test': '1' })
+export const createMeetingRecording = async () => ({
+  meeting: { id: 'm1', audioFileId: 'f1' }, configured: true,
+})
+export const finishMeetingRecording = async () => { finishCalls += 1; return { id: 'm1', status: 'RECORDED' } }
+export const finishCallCount = () => finishCalls
+// 断言里要能读出 attempt，所以把参数一起编进返回值
+export const t = (key, params) => (params ? key + JSON.stringify(params) : key)

--- a/frontend/tests/project-home/agent-stream-unmount.test.mjs
+++ b/frontend/tests/project-home/agent-stream-unmount.test.mjs
@@ -1,0 +1,70 @@
+// useAgentStream 的卸载收尾（审计 dev-board#74）。
+//
+// 病灶：composable 里的 SSE reader 循环、心跳 interval、待触发的重连定时器全都活在闭包里，
+// 没有任何生命周期钩子回收。工作台的跳转按约定一律 reLaunch（CLAUDE.md），页面栈整个销毁，
+// 于是流到一半离开工作台的那个实例变成僵尸：它仍会 scheduleReconnect，与新挂载的实例
+// 轮流把对方从同一会话的 SSE 上挤下去（后端每会话只留一个 emitter）；模块级单例
+// activeNetworkRecoveryHook 也还指着已销毁实例的闭包。
+//
+// 与本目录既有用例同口径，做源码级契约断言：useAgentStream.js 带 @/ 别名与 uni 全局，
+// node 直接 import 不进来（见 api-contract.test.mjs 抬头的说明）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/composables/useAgentStream.js', import.meta.url), 'utf8')
+const stripComments = (s) =>
+  s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+const CODE = stripComments(SRC)
+
+test('从 vue 引入 onUnmounted 与 getCurrentInstance', () => {
+  const line = CODE.split('\n').find((l) => l.includes("from 'vue'"))
+  assert.ok(line, "找不到 from 'vue' 的 import")
+  assert.match(line, /onUnmounted/, '没有 onUnmounted 就没有回收时机')
+  assert.match(line, /getCurrentInstance/, '组件外调用时不能盲注册钩子')
+})
+
+// 钩子体：从 onUnmounted( 到该块结束，用括号配平截取，避免把后面的代码算进来
+function unmountBody(code) {
+  const start = code.indexOf('onUnmounted(')
+  if (start < 0) return null
+  let depth = 0
+  for (let i = start + 'onUnmounted'.length; i < code.length; i++) {
+    if (code[i] === '(') depth++
+    else if (code[i] === ')') { depth--; if (depth === 0) return code.slice(start, i + 1) }
+  }
+  return null
+}
+
+test('注册了 onUnmounted 清理，且挂在 getCurrentInstance 守卫之后', () => {
+  const body = unmountBody(CODE)
+  assert.ok(body, '没有 onUnmounted 清理块')
+  const guard = CODE.indexOf('getCurrentInstance()')
+  assert.ok(guard >= 0 && guard < CODE.indexOf('onUnmounted('),
+    'onUnmounted 必须在 getCurrentInstance() 守卫之内注册')
+})
+
+test('清理块把重连定时器、心跳、SSE 连接一并收掉', () => {
+  const body = unmountBody(CODE)
+  assert.match(body, /clearTimeout\(reconnectTimer\)/, '待触发的重连定时器要清掉')
+  assert.match(body, /reconnectTimer\s*=\s*null/)
+  assert.match(body, /stopHeartbeatMonitor\(\)/, '10s 心跳 interval 要停')
+  assert.match(body, /resetSSE\(\)/, 'reader 循环靠 abort 才能结束')
+})
+
+test('清理块先清 currentConversationId，断掉 scheduleReconnect 的续命链', () => {
+  const body = unmountBody(CODE)
+  assert.match(body, /currentConversationId\.value\s*=\s*null/,
+    'scheduleReconnect/重连回调都以 currentConversationId 为准，不清就还会重连')
+})
+
+test('只在模块级单例仍指向本实例时才释放它', () => {
+  const body = unmountBody(CODE)
+  assert.match(body, /activeNetworkRecoveryHook\s*===\s*myNetworkRecoveryHook/,
+    '无条件置空会踩掉后挂载实例的网络恢复入口')
+  assert.match(body, /activeNetworkRecoveryHook\s*=\s*null/)
+  // 比对的前提：connectSSE 里赋值时要留下本实例的那份引用
+  assert.match(CODE, /myNetworkRecoveryHook\s*=\s*\(reason\)\s*=>/,
+    'connectSSE 要先把回调存进实例级变量再挂到模块级单例上')
+  assert.match(CODE, /activeNetworkRecoveryHook\s*=\s*myNetworkRecoveryHook/)
+})

--- a/frontend/tests/project-home/calendar-load-race.test.mjs
+++ b/frontend/tests/project-home/calendar-load-race.test.mjs
@@ -1,0 +1,99 @@
+// 审计（dev-board#74）：calendar.vue 的 loadTasks() 没有请求乱序保护。
+// 连续快点 prev/next 或切视图，每次 datesSet 都立刻发一个新请求；先发的（旧区间）
+// 响应若后到，就会把 calendarOptions.events 覆盖成旧区间的任务集合。FullCalendar
+// 只画落在当前视图区间内的事件，所以用户看到的不是「别的月份的卡片」，而是当前
+// 月份大面积空白——只剩两个区间重叠的那几条。
+//
+// 与本目录既有用例同口径（见 version-timeline-race.test.mjs）：把 .vue 的 <script>
+// 块抽出来真跑一遍 loadTasks()，组件带 @/ 别名 import 不进来，改成注入依赖。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/calendar/calendar.vue', import.meta.url), 'utf8')
+
+function loadOptions(getCalendarTasks, uniStub) {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export\s+default/, 'return')
+  const stub = {}
+  const factory = new Function(
+    'FullCalendar', 'dayGridPlugin', 'timeGridPlugin', 'listPlugin', 'interactionPlugin',
+    'zhCnLocale', 'getCalendarTasks', 'getMyProjects', 'updateTask', 'getAppLanguage',
+    'colorForProject', 'getDayMarkType', 'isDone', 'toEventStart', 'TaskDialog',
+    'UpcomingList', 'uni', body)
+  return factory(stub, stub, stub, stub, stub, stub,
+    getCalendarTasks,
+    () => Promise.resolve([]),
+    () => Promise.resolve({}),
+    () => 'zh-CN',
+    () => ({ bg: '#000', text: '#fff' }),
+    () => 'workday',
+    () => false,
+    (t) => t.dueDate,
+    stub, stub,
+    uniStub || { showToast() {} })
+}
+
+function makeVm(options) {
+  const vm = Object.assign({}, options.data())
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  vm.$t = (k) => k
+  return vm
+}
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+const taskOf = (id, dueDate) => ({ id, title: 't' + id, dueDate, projectId: 1 })
+
+test('先发的旧月份请求后到，不许覆盖后发的新月份结果', async () => {
+  const gates = { '2026-08-01': deferred(), '2026-09-01': deferred() }
+  const vm = makeVm(loadOptions((from) => gates[from].promise))
+
+  // 1) 停在 8 月，请求在途
+  const aug = vm.loadTasks('2026-08-01', '2026-09-01')
+  // 2) 立刻点「下一月」，datesSet 推进区间并发第二个请求
+  vm.currentFrom = '2026-09-01'
+  vm.currentTo = '2026-10-01'
+  const sep = vm.loadTasks('2026-09-01', '2026-10-01')
+
+  // 3) 后发的先回，先发的后回（网络乱序）
+  gates['2026-09-01'].resolve({ data: { tasks: [taskOf(20, '2026-09-10')] } })
+  await sep
+  gates['2026-08-01'].resolve({ data: { tasks: [taskOf(10, '2026-08-10')] } })
+  await aug
+
+  assert.deepEqual(vm.calendarOptions.events.map((e) => e.id), ['20'],
+    '旧月份的迟到响应把当前月份的事件覆盖了，用户看到的是一片空白')
+})
+
+test('旧请求失败不许给已经加载好的新月份弹加载失败', async () => {
+  const gates = { '2026-08-01': deferred(), '2026-09-01': deferred() }
+  const toasts = []
+  const vm = makeVm(loadOptions((from) => gates[from].promise,
+    { showToast: (o) => toasts.push(o) }))
+
+  const aug = vm.loadTasks('2026-08-01', '2026-09-01')
+  const sep = vm.loadTasks('2026-09-01', '2026-10-01')
+  gates['2026-09-01'].resolve({ data: { tasks: [taskOf(20, '2026-09-10')] } })
+  await sep
+  gates['2026-08-01'].resolve(Promise.reject(new Error('boom')))
+  await aug
+
+  assert.deepEqual(toasts, [], '被放弃的旧请求失败了也不该打断当前视图')
+  assert.deepEqual(vm.calendarOptions.events.map((e) => e.id), ['20'])
+})
+
+test('正常顺序下最后一次请求的结果照常生效', async () => {
+  const vm = makeVm(loadOptions((from) =>
+    Promise.resolve({ data: { tasks: [taskOf(from === '2026-08-01' ? 10 : 20, from)] } })))
+  await vm.loadTasks('2026-08-01', '2026-09-01')
+  assert.deepEqual(vm.calendarOptions.events.map((e) => e.id), ['10'])
+  await vm.loadTasks('2026-09-01', '2026-10-01')
+  assert.deepEqual(vm.calendarOptions.events.map((e) => e.id), ['20'])
+})

--- a/frontend/tests/project-home/conversation-list-load-more-inflight.test.mjs
+++ b/frontend/tests/project-home/conversation-list-load-more-inflight.test.mjs
@@ -1,0 +1,53 @@
+// 审计（dev-board#74）：ConversationList 的「加载更多」直接 @tap="$emit('load-more')"，
+// 没有重入闸。父组件的翻页游标（nextBefore/nextBeforeId）要等响应回来才更新，
+// 所以在第一次请求落地前连点两下，第二次带的是同一份游标，取回同一页拼进列表——
+// 同一个 conversationId 在数组里出现两次，v-for 的 :key 撞车，卡片重复渲染并触发
+// Vue 的 duplicate key 告警。
+//
+// 用例不做纯文本断言，按本目录既有路子把 <script> 抽出来跑（同
+// review-panel-double-tap.test.mjs）：组件的 import 走 @/ 别名，node 直接进不来，
+// 这里用不到那些纯函数，剥掉 import 行即可。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/components/project-home/ConversationList.vue', import.meta.url), 'utf8')
+
+function makeVm(props) {
+  const script = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s+'[^']*'\s*$/gm, '')
+  // eslint-disable-next-line no-new-func
+  const component = new Function(script.replace('export default', 'return'))()
+  const emitted = []
+  const vm = Object.assign(
+    { $t: (k) => k, $emit: (...a) => emitted.push(a) },
+    props,
+    component.methods)
+  return { vm, emitted }
+}
+
+test('第一次请求还没落地时再点，不再派发 load-more', () => {
+  const { vm, emitted } = makeVm({ loading: false, hasMore: true })
+  vm.onLoadMore()
+  // 父组件在 loadConversations 开头同步置 conversationsLoading = true，prop 随之下来
+  vm.loading = true
+  vm.onLoadMore()
+  vm.onLoadMore()
+  assert.deepEqual(emitted.map((e) => e[0]), ['load-more'], '同一份游标只许发一次')
+})
+
+test('这一轮落地后闸放开，还能接着翻下一页', () => {
+  const { vm, emitted } = makeVm({ loading: true, hasMore: true })
+  vm.onLoadMore()
+  assert.equal(emitted.length, 0)
+  vm.loading = false
+  vm.onLoadMore()
+  assert.deepEqual(emitted.map((e) => e[0]), ['load-more'], '闸没放开就再也翻不了页')
+})
+
+test('加载更多行走 onLoadMore，不再裸 emit', () => {
+  const row = SRC.split('\n').find((l) => l.includes('class="conv-more"'))
+  assert.ok(row, '找不到加载更多行')
+  assert.match(row, /@tap="onLoadMore"/, '裸 $emit 绕开了重入闸')
+})

--- a/frontend/tests/project-home/dd-request-editor-race.test.mjs
+++ b/frontend/tests/project-home/dd-request-editor-race.test.mjs
@@ -1,0 +1,136 @@
+// 审计（dev-board#74）：DdRequestEditor 在 project-overview 里没有 :key，
+// 切换不同尽调清单标签时是同一个实例被复用，requestId watcher 只是再调一次
+// fetchData()，先发的那次若后返回就会把后发那次的数据整个盖掉——头部标题、
+// 状态和行数据全是上一份清单的，而 requestId 指向的却是新那份。
+// 另一条：删除清单后父组件没接 @deleted，面板还留着已删清单的行，
+// 再操作就是拿已不存在的 id 打接口。组件这一侧得自己把状态清干净。
+// 做法同 SearchPanel/VersionTimeline：把 <script> 抽出来真跑一遍，依赖注入。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/components/DdRequestEditor.vue', import.meta.url), 'utf8')
+
+function loadOptions(api, uni) {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export\s+default/, 'return')
+  const factory = new Function('api', 'getApiBaseUrl', 'getSessionId', 'ICONS', 'uni', body)
+  return factory(api, () => '', () => '', {}, uni)
+}
+
+function makeVm(options, props) {
+  const vm = Object.assign({}, options.data(), props)
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  for (const [k, fn] of Object.entries(options.computed))
+    Object.defineProperty(vm, k, { get: fn.bind(vm) })
+  vm.$t = (k) => k
+  vm.emitted = []
+  vm.$emit = (name, payload) => vm.emitted.push([name, payload])
+  vm.$forceUpdate = () => {}
+  return vm
+}
+
+const deferred = () => {
+  let resolve, reject
+  const promise = new Promise((r, j) => { resolve = r; reject = j })
+  return { promise, resolve, reject }
+}
+
+const detail = (name, id) => ({ request: { id, name, status: 'DRAFT' }, items: [{ id, title: name, status: 'PENDING' }] })
+
+test('切标签后迟到的旧清单响应不许盖掉当前清单', async () => {
+  const gates = { A: deferred(), B: deferred() }
+  let calls = 0
+  const options = loadOptions(
+    { getDdRequestDetails: () => (++calls === 1 ? gates.A.promise : gates.B.promise) },
+    { showToast: () => {} })
+  const vm = makeVm(options, { requestId: 1 })
+
+  const first = vm.fetchData()   // 打开清单 A（网络慢）
+  vm.requestId = 2               // 立刻切到清单 B，实例复用，watcher 再发一次
+  const second = vm.fetchData()
+
+  gates.B.resolve(detail('B', 2))
+  await second
+  gates.A.resolve(detail('A', 1))
+  await first
+
+  assert.equal(vm.request.id, 2, '显示的清单和 requestId 对不上了')
+  assert.equal(vm.requestName, 'B')
+  assert.deepEqual(vm.items.map(i => i.id), [2], '行数据是上一份清单的')
+})
+
+test('最新一次响应照常落地', async () => {
+  const options = loadOptions(
+    { getDdRequestDetails: (id) => Promise.resolve(detail('B', id)) },
+    { showToast: () => {} })
+  const vm = makeVm(options, { requestId: 7 })
+
+  await vm.fetchData()
+
+  assert.equal(vm.request.id, 7)
+  assert.equal(vm.requestName, 'B')
+  assert.equal(vm.items.length, 1)
+})
+
+test('删除清单后面板要清空，不再留着已删清单的行', async () => {
+  const options = loadOptions(
+    {
+      getDdRequestDetails: (id) => Promise.resolve(detail('A', id)),
+      deleteDdRequest: () => Promise.resolve()
+    },
+    { showToast: () => {}, showModal: (o) => o.success({ confirm: true }) })
+  const vm = makeVm(options, { requestId: 1 })
+  await vm.fetchData()
+  assert.equal(vm.items.length, 1)
+
+  await vm.handleDeleteRequest()
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(vm.request, null, '已删清单的抬头还在')
+  assert.deepEqual(vm.items, [], '已删清单的行还在')
+  assert.equal(vm.deleted, true)
+  assert.deepEqual(vm.emitted.map(e => e[0]), ['deleted'])
+})
+
+test('删除时在途的 fetch 回来不许把已删清单重新填回去', async () => {
+  const gate = deferred()
+  const options = loadOptions(
+    {
+      getDdRequestDetails: () => gate.promise,
+      deleteDdRequest: () => Promise.resolve()
+    },
+    { showToast: () => {}, showModal: (o) => o.success({ confirm: true }) })
+  const vm = makeVm(options, { requestId: 1 })
+
+  const pending = vm.fetchData()
+  await vm.handleDeleteRequest()
+  await new Promise(r => setTimeout(r, 0))
+  gate.resolve(detail('A', 1))
+  await pending
+
+  assert.equal(vm.request, null, '已删的清单被在途响应填了回来')
+  assert.deepEqual(vm.items, [])
+})
+
+test('删除后改标题不再对已不存在的清单发请求', async () => {
+  const calls = []
+  const options = loadOptions(
+    {
+      getDdRequestDetails: (id) => Promise.resolve(detail('A', id)),
+      deleteDdRequest: () => Promise.resolve(),
+      updateDdRequest: (id, name) => { calls.push([id, name]); return Promise.resolve() }
+    },
+    { showToast: () => {}, showModal: (o) => o.success({ confirm: true }) })
+  const vm = makeVm(options, { requestId: 1 })
+  await vm.fetchData()
+  await vm.handleDeleteRequest()
+  await new Promise(r => setTimeout(r, 0))
+
+  vm.requestName = '随手改的名字'
+  await vm.updateRequestName()
+
+  assert.deepEqual(calls, [], '对着已删除的清单发了改名请求')
+})

--- a/frontend/tests/project-home/easy-voice-karaoke.test.mjs
+++ b/frontend/tests/project-home/easy-voice-karaoke.test.mjs
@@ -1,0 +1,31 @@
+// 审计（dev-board#74）：EasyVoicePane 的卡拉OK 高亮与正在播的音频脱钩。
+// 源码文本断言——本仓既有 node:test 用例的一贯写法（组件带 @/ 别名，import 不进来）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/EasyVoicePane.vue', import.meta.url), 'utf8')
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+const CODE = stripComments(SRC)
+
+// sentences 是「当前这段音频的时间轴」，不是「文本框里现在有什么」。
+// 导入时就把它整块换掉，而旧音频还在播：ontimeupdate 会拿旧音频的时长算出下标，
+// 去新文档的句子数组里取字符串 emit 出去，编辑器的选区就跟着旧音频在新文档里乱跳。
+test('importFromDoc 不改写 sentences（时间轴归音频，不归文本框）', () => {
+  const start = CODE.indexOf('async importFromDoc()')
+  assert.ok(start > 0, '找不到 importFromDoc')
+  const body = CODE.slice(start, CODE.indexOf('async handleGenerate()'))
+  assert.ok(body.length > 0 && body.length < 2000, 'importFromDoc 函数体切取失败')
+  assert.ok(!/this\.sentences\s*=/.test(body),
+    '导入正文不许改 sentences：旧音频还在播时会把高亮串到新文档去')
+})
+
+test('sentences 的唯一写点在 handleGenerate（生成前重算）', () => {
+  const writes = CODE.match(/this\.sentences\s*=/g) || []
+  assert.equal(writes.length, 1, 'sentences 只许在生成音频前赋值一次，实际 ' + writes.length + ' 处')
+  const start = CODE.indexOf('async handleGenerate()')
+  const body = CODE.slice(start, CODE.indexOf('downloadAudio()'))
+  assert.match(body, /this\.sentences\s*=\s*this\.splitTextToSentences\(this\.text\)/,
+    'handleGenerate 必须在生成前按当前正文重算 sentences')
+})

--- a/frontend/tests/project-home/libre-editor-retry-reentrancy.test.mjs
+++ b/frontend/tests/project-home/libre-editor-retry-reentrancy.test.mjs
@@ -1,0 +1,117 @@
+// 审计（dev-board#74）：LibreOfficeEditor 的「重试」没有重入闸。
+//
+// 病灶：下载挂起（弱网 / 代理收了头就不给正文，XHR 的 60s 超时还没到）时，
+// startBootTrickle 的 30s stuck 计时器先把「重试」按钮亮出来。用户一点，
+// retryLoad → finishDocLoad → loadDocument 就在**原来那条仍在途的链路**旁边
+// 又起了一条，两条各自 dispatch 一次 load_document。后完成的那条按最后写者赢
+// 覆盖 ready / statusKey / docKind：迟到的失败把重试的成功盖成 loadFailed
+// （docLoadFailed 同时是保存闸，一置位 autosave 就全部拒绝），迟到的成功把
+// 重试装好的文档连同其间的编辑整个换掉，ready 也会重复发一次。
+//
+// 这份用例不是源码文本断言：把 .vue 的 <script> 抠出来 new Function 求值，
+// 拿到真的 methods，用桩 this 真跑 finishDocLoad / retryLoad 的并发时序。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/LibreOfficeEditor.vue', import.meta.url), 'utf8')
+
+// 组件带 @/ 别名，import 不进来；只取 <script> 主体，把 import 行剥掉、
+// export default 换成 return，外部符号由 new Function 的形参喂桩。
+function loadMethods() {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import .*$/gm, '')
+    .replace(/export default \{/, 'return {')
+  const factory = new Function(
+    'getFileDownloadUrl', 'getCurrentUser', 'createRelayExecutor',
+    'webviewTransport', 'iframeTransport', 'ReviewPanel', 'EditorToolbar',
+    'getAuthHeaders', 'host', body)
+  return factory((id) => '/download/' + id, () => ({ name: '测试用户' })).methods
+}
+
+const METHODS = loadMethods()
+const tick = () => new Promise((r) => setTimeout(r, 0))
+function deferred() {
+  let resolve
+  const promise = new Promise((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+// 引擎已就绪、正在装真文档的那一刻的组件状态。
+function makeVm() {
+  const vm = {
+    file: { id: 7, name: '起诉状.docx', fileType: 'docx', fileSize: 4096 },
+    ready: false,
+    statusKey: 'loadingDoc',
+    docKind: 'writer',
+    docLoadFailed: false,
+    bootPct: 75, bootCap: 95, bootStageKey: 'openingDoc',
+    dlLoaded: 0, dlTotal: 0, stuck: true,
+    _endpointUp: true,
+    emitted: [], dispatched: [],
+    $emit(ev) { this.emitted.push(ev) },
+    appendLog() {},
+    startBootTrickle() {},   // 定时器与本条无关，停掉以免拖住测试进程
+    executor: {
+      executeCommand: async (action) => { vm.dispatched.push(action); return { success: true, kind: 'writer' } },
+    },
+  }
+  for (const name of ['finishDocLoad', 'loadDocument', 'retryLoad', 'bootMilestone']) vm[name] = METHODS[name].bind(vm)
+  return vm
+}
+
+test('迟到的失败不许把重试装载好的文档判成 loadFailed（关掉保存闸）', async () => {
+  const vm = makeVm()
+  const hung = deferred()
+  vm._bytesPromise = hung.promise            // 初次预取挂在半路
+  const stale = vm.finishDocLoad()
+  await tick()
+  assert.deepEqual(vm.dispatched, [], '原始链路还卡在下载上')
+
+  vm.fetchArrayBuffer = async () => new ArrayBuffer(4096)   // 重试这次秒下完
+  vm.retryLoad()
+  await tick(); await tick()
+  assert.equal(vm.statusKey, 'ready')
+  assert.equal(vm.docLoadFailed, false)
+
+  hung.resolve(new ArrayBuffer(0))           // 挂起的那笔最终回了个空响应
+  await stale
+  assert.equal(vm.docLoadFailed, false, '被取代的那次失败不得关掉保存闸')
+  assert.equal(vm.statusKey, 'ready', '被取代的那次不得把状态盖成 loadFailed')
+})
+
+test('重试期间只推一次 load_document，ready 也只发一次', async () => {
+  const vm = makeVm()
+  const hung = deferred()
+  vm._bytesPromise = hung.promise
+  const stale = vm.finishDocLoad()
+  await tick()
+
+  vm.fetchArrayBuffer = async () => new ArrayBuffer(4096)
+  vm.retryLoad()
+  await tick(); await tick()
+
+  hung.resolve(new ArrayBuffer(4096))        // 挂起的那笔最终也成功回来了
+  await stale
+  assert.equal(vm.dispatched.filter((a) => a === 'load_document').length, 1,
+    '两条 load_document 会被单线程 office 依次执行，后到的把先装好的文档整个换掉')
+  assert.equal(vm.emitted.filter((e) => e === 'ready').length, 1)
+})
+
+test('没有并发时正常装载不受影响', async () => {
+  const vm = makeVm()
+  vm.fetchArrayBuffer = async () => new ArrayBuffer(4096)
+  await vm.finishDocLoad()
+  assert.deepEqual(vm.dispatched, ['load_document'])
+  assert.equal(vm.statusKey, 'ready')
+  assert.equal(vm.ready, true)
+  assert.equal(vm.emitted.filter((e) => e === 'ready').length, 1)
+})
+
+test('装载真失败时仍然置位保存闸（重入闸不许吞掉真失败）', async () => {
+  const vm = makeVm()
+  vm.fetchArrayBuffer = async () => { throw new Error('boom') }
+  await vm.finishDocLoad()
+  assert.equal(vm.docLoadFailed, true)
+  assert.equal(vm.statusKey, 'loadFailed')
+})

--- a/frontend/tests/project-home/market-pane-notify.test.mjs
+++ b/frontend/tests/project-home/market-pane-notify.test.mjs
@@ -1,0 +1,43 @@
+// 审计（dev-board#74）：MarketPane 的装/卸/启停不广播，左栏广场面板停在旧状态。
+// 源码文本断言——本仓既有 node:test 用例的一贯写法（组件带 @/ 别名，import 不进来）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const src = readFileSync(new URL('../../src/components/MarketPane.vue', import.meta.url), 'utf8')
+  .replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+/** 取两个方法名之间的那段方法体 */
+const body = (from, to) => {
+  const start = src.indexOf(from)
+  assert.ok(start > 0, `找不到 ${from}`)
+  const end = src.indexOf(to, start)
+  assert.ok(end > start, `找不到 ${from} 之后的 ${to}`)
+  return src.slice(start, end)
+}
+
+// MarketSidebarPanel（左栏广场面板）只订 'awd:market-changed'，
+// 广场嵌在设置 tab 里时两者同屏共存：这边装完不广播，那边的按钮就一直显示「安装」。
+test('notifyMarketChanged 广播左栏订阅的那个事件', () => {
+  const fn = body('notifyMarketChanged() {', 'activationIndex(')
+  assert.match(fn, /uni\.\$emit\('awd:market-changed'\)/,
+    'MarketSidebarPanel 订的是 awd:market-changed，不发这个它就刷新不了')
+})
+
+for (const [name, next] of [
+  ['async installPlugin(', 'async uninstallPlugin('],
+  ['async uninstallPlugin(', 'categoryLabel('],
+  ['async onToggle(', 'async loadSkills('],
+  ['async installSkill(', 'async uninstallSkill('],
+  ['async uninstallSkill(', 'async rescan('],
+]) {
+  test(`${name.replace('async ', '').replace('(', '')} 成功后通知外部刷新`, () => {
+    const fn = body(name, next)
+    assert.match(fn, /this\.notifyMarketChanged\(\)/,
+      '装/卸/启停改变的是全局安装状态，不广播左栏与工作台会停在旧状态')
+    // 广播必须在成功路径上（catch 之前），失败不该谎报变更
+    const idx = fn.indexOf('this.notifyMarketChanged()')
+    const catchIdx = fn.indexOf('} catch (e)')
+    assert.ok(catchIdx < 0 || idx < catchIdx, '广播要留在 try 的成功路径里')
+  })
+}

--- a/frontend/tests/project-home/newproject-duplicate-create.test.mjs
+++ b/frontend/tests/project-home/newproject-duplicate-create.test.mjs
@@ -1,0 +1,73 @@
+// 审计（dev-board#74）：浏览器降级建空白项目时，busy 在请求返回后立刻放开，
+// 而真正的 reLaunch 还压在 500ms 的 setTimeout 里。这段窗口里按钮是活的，
+// blankName 也没清，再点一下就会用同一个名字再建一个空白项目。
+//
+// 组件带 @/ 别名 import 不进来（本仓既有写法），这里把 onCreateBlank 的函数体抠出来
+// 用 new Function 起真身跑，依赖全部注入，属于行为断言而非文本断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const src = readFileSync(new URL('../../src/pages/newproject/index.vue', import.meta.url), 'utf8')
+
+// 从 `async onCreateBlank() {` 起做括号配对，取出完整函数体
+function extractBody(name) {
+  const head = src.indexOf(`async ${name}() {`)
+  assert.ok(head > 0, `找不到 ${name}`)
+  const start = src.indexOf('{', head)
+  let depth = 0
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1)
+  }
+  throw new Error(`${name} 的括号没配上`)
+}
+
+function build() {
+  const calls = { posts: 0, toasts: [], relaunches: [], timers: [] }
+  const createProject = async () => { calls.posts++; return { id: calls.posts } }
+  const uni = {
+    showToast: (o) => calls.toasts.push(o),
+    reLaunch: (o) => calls.relaunches.push(o.url),
+  }
+  // 假 setTimeout：只收回调不真排期，测试里手动触发，免得等 500ms
+  const fakeSetTimeout = (cb) => { calls.timers.push(cb); return 1 }
+  const fn = new Function(
+    'createProject', 'uni', 'setTimeout',
+    `return async function onCreateBlank() ${extractBody('onCreateBlank')}`,
+  )(createProject, uni, fakeSetTimeout)
+  const ctx = { blankName: '甲公司诉乙公司', busy: false, $t: (k) => k }
+  return { fn, ctx, calls }
+}
+
+test('创建成功后、reLaunch 真正跳走之前，再点创建不会重复建项目', async () => {
+  const { fn, ctx, calls } = build()
+
+  await fn.call(ctx)
+  assert.equal(calls.posts, 1)
+  assert.equal(calls.relaunches.length, 0, 'reLaunch 还压在 setTimeout 里，页面没跳走')
+
+  // 用户在这 500ms 里又点了一下（成功反馈只有一个 toast，双击很常见）
+  await fn.call(ctx)
+  assert.equal(calls.posts, 1, '第二次点击必须被挡住，否则会多出一个同名空白项目')
+
+  // 跳转照旧发生，落到第一次创建的项目
+  calls.timers.forEach((cb) => cb())
+  assert.deepEqual(calls.relaunches, ['/pages/project-overview/project-overview?id=1'])
+})
+
+test('创建失败后按钮要放开，允许重试', async () => {
+  const { calls } = build()
+  const boom = async () => { calls.posts++; throw new Error('网络错误') }
+  const uni = { showToast: (o) => calls.toasts.push(o), reLaunch: () => {} }
+  const fn = new Function(
+    'createProject', 'uni', 'setTimeout',
+    `return async function onCreateBlank() ${extractBody('onCreateBlank')}`,
+  )(boom, uni, (cb) => { calls.timers.push(cb) })
+  const ctx = { blankName: '甲公司诉乙公司', busy: false, $t: (k) => k }
+
+  await fn.call(ctx)
+  assert.equal(ctx.busy, false, '失败后 busy 必须放开，否则用户再也点不动创建')
+  await fn.call(ctx)
+  assert.equal(calls.posts, 2, '失败后应当能重试')
+})

--- a/frontend/tests/project-home/personal-settings-reentrancy.test.mjs
+++ b/frontend/tests/project-home/personal-settings-reentrancy.test.mjs
@@ -1,0 +1,101 @@
+// 审计（dev-board#74）：PersonalSettingsPanel 的四个「确认绑定/解绑」handler 没有
+// 重入闸，连点两次会并发发两次请求——第一次成功、第二次因验证码一次性失效而 reject，
+// 于是成功 toast 后面又叠一个失败 toast，用户以为绑定失败。
+//
+// 这份用例不做源码文本断言，直接把组件的 <script> 抽出来跑：把 import 换成桩，
+// export default 换成 return，再用普通对象当 this 调 methods。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/components/userprofile/PersonalSettingsPanel.vue', import.meta.url), 'utf8')
+
+function makeVm(deps, uniStub) {
+  const script = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+  const importRe = /import\s*\{([\s\S]*?)\}\s*from\s*'[^']+'\s*;?/g
+  const locals = []
+  let m
+  while ((m = importRe.exec(script)) !== null) {
+    for (const part of m[1].split(',')) {
+      const t = part.trim()
+      if (!t) continue
+      locals.push(/\sas\s/.test(t) ? t.split(/\s+as\s+/)[1].trim() : t)
+    }
+  }
+  const preamble = locals
+    .map((n) => `const ${n} = deps[${JSON.stringify(n)}] || (() => { throw new Error('未打桩: ${n}') });`)
+    .join('\n')
+  const body = script.replace(importRe, '').replace('export default', 'return')
+  // eslint-disable-next-line no-new-func
+  const component = new Function('deps', 'uni', preamble + '\n' + body)(deps, uniStub)
+  const base = { $t: (k) => k }
+  return Object.assign(base, component.data.call(base), component.methods)
+}
+
+// 一次性验证码：第一次成功，第二次必然失败
+function onceOnly(okValue) {
+  const state = { calls: 0 }
+  state.fn = () => {
+    state.calls++
+    return state.calls === 1
+      ? Promise.resolve(okValue)
+      : Promise.reject(new Error('验证码已失效'))
+  }
+  return state
+}
+
+function setup(depsOverride) {
+  const toasts = []
+  const deps = Object.assign({ setSessionUser: () => {}, getAppLanguage: () => 'zh-CN' }, depsOverride)
+  const vm = makeVm(deps, { showToast: (o) => toasts.push(o.title) })
+  return { vm, toasts }
+}
+
+test('手机号：确认绑定连点两次只发一次请求，成功后不再弹失败', async () => {
+  const api = onceOnly({ data: { phoneMasked: '138****0000' } })
+  const { vm, toasts } = setup({ bindPhone: api.fn })
+  vm.bindPhoneInput = '13800000000'
+  vm.bindCodeInput = '123456'
+  await Promise.all([vm.confirmBindPhone(), vm.confirmBindPhone()])
+  assert.equal(api.calls, 1, '第二次点击必须被重入闸挡住')
+  assert.deepEqual(toasts, ['account.bindSuccessToast'], '不该在成功 toast 之后再叠一个失败 toast')
+})
+
+test('邮箱：确认绑定连点两次只发一次请求，成功后不再弹失败', async () => {
+  const api = onceOnly({ data: { emailMasked: 'a***@b.com' } })
+  const { vm, toasts } = setup({ bindEmail: api.fn })
+  vm.bindEmailInput = 'a@b.com'
+  vm.bindEmailCodeInput = '123456'
+  await Promise.all([vm.confirmBindEmail(), vm.confirmBindEmail()])
+  assert.equal(api.calls, 1, '第二次点击必须被重入闸挡住')
+  assert.deepEqual(toasts, ['account.bindSuccessToast'])
+})
+
+test('认证器：完成绑定连点两次只发一次请求', async () => {
+  const api = onceOnly({ data: {} })
+  const { vm, toasts } = setup({ totpActivate: api.fn })
+  vm.totpCodeInput = '123456'
+  await Promise.all([vm.confirmTotpBind(), vm.confirmTotpBind()])
+  assert.equal(api.calls, 1, '第二次点击必须被重入闸挡住')
+  assert.deepEqual(toasts, ['account.totpBoundSuccess'])
+})
+
+test('认证器：确认解绑连点两次只发一次请求', async () => {
+  const api = onceOnly({ data: {} })
+  const { vm, toasts } = setup({ totpDisable: api.fn })
+  vm.totpCodeInput = '123456'
+  await Promise.all([vm.confirmTotpDisable(), vm.confirmTotpDisable()])
+  assert.equal(api.calls, 1, '第二次点击必须被重入闸挡住')
+  assert.deepEqual(toasts, ['account.totpUnboundSuccess'])
+})
+
+test('请求失败后闸要放开，允许用户重试', async () => {
+  let calls = 0
+  const { vm } = setup({ bindPhone: () => { calls++; return Promise.reject(new Error('验证码错误')) } })
+  vm.bindPhoneInput = '13800000000'
+  vm.bindCodeInput = '123456'
+  await vm.confirmBindPhone()
+  await vm.confirmBindPhone()
+  assert.equal(calls, 2, '失败后不放开闸，用户就再也点不动了')
+})

--- a/frontend/tests/project-home/plaintext-flush-save.test.mjs
+++ b/frontend/tests/project-home/plaintext-flush-save.test.mjs
@@ -1,0 +1,127 @@
+// 关闭标签时的落盘竞态（dev-board#74 审计）：flushSave 只等固定几秒就放行，
+// 在途的那一次自动保存还没回来时，saving 仍是 true，紧接着的 save() 原地 no-op
+// （只重挂一个防抖定时器），而组件随即卸载、定时器被 beforeUnmount 清掉——
+// 在途请求发出**之后**的那批输入就这么静默丢了。
+//
+// 组件带 @/ 别名 import 不进来，这里把 <script> 块摘出来、剥掉 import 后当函数求值
+// （被剥掉的符号只在没被调用的方法体里出现），拿到 options 后手工拼一个实例。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SFC = readFileSync(
+  new URL('../../src/components/PlainTextEditor.vue', import.meta.url), 'utf8')
+
+function loadOptions(setTimeoutStub, clearTimeoutStub) {
+  const script = SFC.match(/<script>([\s\S]*?)<\/script>/)[1]
+  const body = script
+    .replace(/^import .*$/gm, '')
+    .replace('export default', 'return')
+  // eslint-disable-next-line no-new-func
+  return new Function('setTimeout', 'clearTimeout', body)(setTimeoutStub, clearTimeoutStub)
+}
+
+function makeEditor() {
+  const uploads = []          // { content, resolve, reject, done }
+  const deferred = []
+  // 防抖/重试（>=1s）在测试里挂起不放行；flushSave 的百毫秒轮询立刻推进，
+  // 免得真的等满十秒。
+  const setTimeoutStub = (fn, ms) => {
+    if (ms >= 1000) return 1
+    Promise.resolve().then(fn)
+    return 2
+  }
+  const opts = loadOptions(setTimeoutStub, () => {})
+  const inst = Object.assign({}, opts.data(), {
+    phase: 'ready',
+    _loadOk: true,
+    _seq: 0,
+    _saveTimer: null,
+    _retryTimer: null,
+    _inflight: null,
+    _view: { state: { doc: { toString: () => inst._text } } },
+    _text: 'v1'
+  })
+  for (const [k, fn] of Object.entries(opts.methods)) inst[k] = fn.bind(inst)
+  // 网络层替身：每次上传挂起，由测试决定什么时候回来
+  inst.uploadContent = (content) => new Promise((resolve, reject) => {
+    const d = { content, resolve, reject }
+    uploads.push(d)
+    deferred.push(d)
+  })
+  const edit = (text) => { inst._text = text; inst.onUserEdit() }
+  return { inst, uploads, edit }
+}
+
+const tick = async (n = 8) => { for (let i = 0; i < n; i++) await Promise.resolve() }
+
+test('flushSave 必须等在途保存回来，再把之后的输入存出去', async () => {
+  const { inst, uploads, edit } = makeEditor()
+
+  // 1) 自动保存起飞，抓的是当时的内容
+  edit('v1 + 第一批')
+  const first = inst.save()
+  await tick()
+  assert.equal(uploads.length, 1)
+  assert.equal(uploads[0].content, 'v1 + 第一批')
+  assert.equal(inst.saving, true)
+
+  // 2) 请求还没回来，用户又打了一批字
+  edit('v1 + 第一批 + 第二批')
+
+  // 3) 关标签：closeFile 在这里 await flushSave
+  let flushed = false
+  const flush = inst.flushSave().then(() => { flushed = true })
+  await tick(800)   // 足够老实现的百次轮询跑完
+
+  assert.equal(flushed, false,
+    'flushSave 不许在在途请求回来之前就放行——放行时 saving 还是 true，' +
+    '接下来的 save() 只会 no-op，第二批输入随卸载一起丢')
+
+  // 4) 慢请求终于回来
+  uploads[0].resolve()
+  await first
+  await tick()
+  assert.equal(uploads.length, 2, '在途保存结束后必须补发第二批输入')
+  assert.equal(uploads[1].content, 'v1 + 第一批 + 第二批')
+
+  uploads[1].resolve()
+  await flush
+  assert.equal(flushed, true)
+  assert.equal(inst.dirty, false)
+})
+
+test('在途保存失败也要放行，并按当前内容再存一次', async () => {
+  const { inst, uploads, edit } = makeEditor()
+  edit('第一批')
+  const first = inst.save()
+  await tick()
+  edit('第一批 + 第二批')
+
+  const flush = inst.flushSave()
+  uploads[0].reject(new Error('network error'))
+  await first
+  await tick()
+  assert.equal(uploads.length, 2)
+  assert.equal(uploads[1].content, '第一批 + 第二批')
+  uploads[1].resolve()
+  await flush
+  assert.equal(inst.dirty, false)
+})
+
+test('没有在途保存时 flushSave 直接落盘一次（回归守卫）', async () => {
+  const { inst, uploads, edit } = makeEditor()
+  edit('只有一批')
+  const flush = inst.flushSave()
+  await tick()
+  assert.equal(uploads.length, 1)
+  uploads[0].resolve()
+  await flush
+  assert.equal(inst.dirty, false)
+})
+
+test('不脏也没有在途保存时不空存一次', async () => {
+  const { inst, uploads } = makeEditor()
+  await inst.flushSave()
+  assert.equal(uploads.length, 0)
+})

--- a/frontend/tests/project-home/plugin-pane-stale-reply.test.mjs
+++ b/frontend/tests/project-home/plugin-pane-stale-reply.test.mjs
@@ -1,0 +1,105 @@
+// 审计（dev-board#74）：PluginPane 在三处调用点都没带 :key，同一个面板槽位换插件时
+// 组件被复用、iframe 只是换了 src。插件 A 发起的桥调用（files.list / files.read 都是
+// 真网络往返）若在换成插件 B 之后才 resolve，reply() 只检查 contentWindow 存在，
+// 就把 A 的响应按 seq 投进了 B 的窗口——B 的 SDK 序号也从 1 起，会拿别人的数据
+// 兑现自己的 promise（B 可能根本没有 file_read 权限）。
+// 同 SearchPanel 的做法：把 <script> 抽出来真跑一遍，依赖当参数注入。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/components/PluginPane.vue', import.meta.url), 'utf8')
+
+function loadOptions(deps) {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export\s+default/, 'return')
+  const factory = new Function(
+    'getProjectFiles', 'getFileText', 'getAppLanguage', 'uni', body)
+  return factory(deps.getProjectFiles, deps.getFileText, () => 'zh-CN', deps.uni || {})
+}
+
+function makeVm(options, props) {
+  const vm = Object.assign({}, options.data ? options.data() : {}, props)
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  for (const [k, fn] of Object.entries(options.computed))
+    Object.defineProperty(vm, k, { get: fn.bind(vm) })
+  return vm
+}
+
+// 换插件：改 url（顺带改 pluginId/permissions），并触发组件自己的 watch。
+function switchPlugin(options, vm, next) {
+  Object.assign(vm, next)
+  const w = options.watch || {}
+  for (const key of Object.keys(next)) {
+    const h = w[key]
+    if (typeof h === 'function') h.call(vm)
+    else if (h && typeof h.handler === 'function') h.handler.call(vm)
+  }
+}
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+const makeWindow = () => {
+  const inbox = []
+  return { inbox, postMessage: (m) => inbox.push(m) }
+}
+
+const URL_A = 'http://127.0.0.1:9696/api/plugin-web/alpha/index.html'
+const URL_B = 'http://127.0.0.1:9696/api/plugin-web/beta/index.html'
+
+test('换插件之后，前一个插件迟到的桥响应不许投进新插件的窗口', async () => {
+  const gate = deferred()
+  const options = loadOptions({ getProjectFiles: () => gate.promise })
+  const winA = makeWindow()
+  const winB = makeWindow()
+  const frame = { contentWindow: winA }
+  const vm = makeVm(options, {
+    url: URL_A, pluginId: 'alpha', permissions: ['file_read'], projectId: 7
+  })
+  vm.$refs = { pluginFrame: frame }
+
+  // 插件 A 发起一次慢调用
+  const pending = vm.onMessage({
+    source: winA,
+    data: { awd: 1, type: 'call', seq: 1, method: 'files.list', params: {} }
+  })
+
+  // 还没回来就把同一个槽位换成插件 B：组件复用，iframe 换 src
+  switchPlugin(options, vm, { url: URL_B, pluginId: 'beta', permissions: [] })
+  frame.contentWindow = winB
+
+  gate.resolve([{ id: 1, name: 'secret.txt', fileSize: 3, isFolder: false }])
+  await pending
+
+  assert.deepEqual(winB.inbox, [], '插件 A 的响应被投进了插件 B 的窗口')
+})
+
+test('没换插件时正常回响应', async () => {
+  const options = loadOptions({
+    getProjectFiles: () => Promise.resolve([
+      { id: 1, name: 'a.txt', fileSize: 3, isFolder: false }
+    ])
+  })
+  const win = makeWindow()
+  const vm = makeVm(options, {
+    url: URL_A, pluginId: 'alpha', permissions: ['file_read'], projectId: 7
+  })
+  vm.$refs = { pluginFrame: { contentWindow: win } }
+
+  await vm.onMessage({
+    source: win,
+    data: { awd: 1, type: 'call', seq: 1, method: 'files.list', params: {} }
+  })
+
+  assert.equal(win.inbox.length, 1, '正常调用没有拿到响应')
+  assert.equal(win.inbox[0].type, 'result')
+  assert.equal(win.inbox[0].seq, 1)
+  assert.equal(win.inbox[0].ok, true)
+  assert.equal(win.inbox[0].result.files.length, 1)
+})

--- a/frontend/tests/project-home/ppt-bubble-shape.test.mjs
+++ b/frontend/tests/project-home/ppt-bubble-shape.test.mjs
@@ -1,0 +1,52 @@
+// 审计（dev-board#74）：PPT 配置弹窗的取消/开始两条确认气泡形状不全。
+// 源码文本断言——本仓既有 node:test 用例的一贯写法（组件带 @/ 别名，import 不进来）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const read = (rel) => readFileSync(new URL('../../src/' + rel, import.meta.url), 'utf8')
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+// RootBubble 对助手气泡的这三个字段是**裸解引用**（没有 ?. 也没有默认值）：
+// 模板首行读 bubble.thinking.status，isReady / hasContent 读 processes.length、
+// artifacts.length。少一个字段这条气泡就在渲染时抛 TypeError——Vue 3 会捕获并
+// 换成一个空注释节点，用户那句「已取消」/「开始生成」于是无声消失。
+const REQUIRED = ['thinking', 'processes', 'artifacts']
+
+test('RootBubble 确实裸解引用 thinking/processes/artifacts（本用例的前提）', () => {
+  const src = read('components/AgentMessage/RootBubble.vue')
+  assert.match(src, /bubble\.thinking\.status/, 'thinking 已改成可空解引用，本用例前提失效')
+  assert.match(src, /bubble\.processes\.length/, 'processes 已改成可空解引用，本用例前提失效')
+  assert.match(src, /bubble\.artifacts\.length/, 'artifacts 已改成可空解引用，本用例前提失效')
+})
+
+// 取出函数体里 bubbles.value.push({ ... }) 的那个对象字面量（括号配平地截）
+const pushedBubbleOf = (src, fnName) => {
+  const start = src.indexOf('const ' + fnName)
+  assert.ok(start > 0, '找不到 ' + fnName)
+  const open = src.indexOf('bubbles.value.push({', start)
+  assert.ok(open > 0, fnName + ' 里找不到 bubbles.value.push({')
+  let depth = 0
+  let i = open + 'bubbles.value.push('.length
+  const from = i
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') { depth--; if (depth === 0) break }
+  }
+  return src.slice(from, i + 1)
+}
+
+for (const fn of ['cancelPptConfig', 'confirmPptGeneration']) {
+  test(`${fn} 推的助手气泡带齐 RootBubble 必需字段`, () => {
+    const src = stripComments(read('components/ChatInterface.vue'))
+    const literal = pushedBubbleOf(src, fn)
+    assert.match(literal, /role:\s*'ASSISTANT'/, fn + ' 推的应该是助手气泡')
+    for (const key of REQUIRED) {
+      assert.match(literal, new RegExp('\\b' + key + '\\s*:'),
+        `${fn} 推的气泡缺 ${key}，RootBubble 渲染时会抛 TypeError，这条确认消息会整条消失`)
+    }
+    assert.match(literal, /thinking:\s*\{[^}]*status:/,
+      fn + ' 的 thinking 必须是带 status 的对象')
+  })
+}

--- a/frontend/tests/project-home/project-calendar-quick-create.test.mjs
+++ b/frontend/tests/project-home/project-calendar-quick-create.test.mjs
@@ -1,0 +1,75 @@
+// 审计（dev-board#74）：左栏日历面板的快速新建没有防重复提交。
+// 输入框按回车触发一次 submitQuickCreate，网络往返还没回来时再点「保存」，
+// 两次调用各自发起一次 createTask，服务端就多出一条标题与日期完全相同的任务。
+//
+// 组件带 @/ 别名 import 不进来（本目录既有写法），这里把 submitQuickCreate 的
+// 函数体抠出来用 new Function 起真身跑，依赖全部注入，属于行为断言而非文本断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const src = readFileSync(
+  new URL('../../src/components/project-calendar/ProjectCalendarPane.vue', import.meta.url), 'utf8')
+
+// 从 `async submitQuickCreate() {` 起做括号配对，取出完整函数体
+function extractBody(name) {
+  const head = src.indexOf(`async ${name}() {`)
+  assert.ok(head > 0, `找不到 ${name}`)
+  const start = src.indexOf('{', head)
+  let depth = 0
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1)
+  }
+  throw new Error(`${name} 的括号没配上`)
+}
+
+function build(createTask) {
+  const calls = { creates: 0, toasts: [], loads: 0 }
+  const uni = { showToast: (o) => calls.toasts.push(o) }
+  const fn = new Function(
+    'createTask', 'uni',
+    `return async function submitQuickCreate() ${extractBody('submitQuickCreate')}`,
+  )(createTask, uni)
+  const ctx = {
+    projectId: 7,
+    quickTitle: '开庭',
+    quickDate: '2026-09-01',
+    quickCreateOpen: true,
+    quickSaving: false,
+    $t: (k) => k,
+    loadTasks: () => { calls.loads++ },
+  }
+  return { fn, ctx, calls }
+}
+
+test('第一次提交还在飞的时候再提交一次，不会建出两条同名任务', async () => {
+  let release
+  const pending = new Promise((r) => { release = r })
+  const { fn, ctx, calls } = build(async () => { calls.creates++; await pending })
+
+  const first = fn.call(ctx)
+  // 回车之后、请求返回之前，用户又点了一下「保存」
+  const second = fn.call(ctx)
+  assert.equal(calls.creates, 1, '第二次提交必须被挡住，否则服务端多一条重复任务')
+
+  release()
+  await Promise.all([first, second])
+  assert.equal(calls.creates, 1)
+  assert.equal(ctx.quickCreateOpen, false)
+})
+
+test('提交失败后放开，允许重试', async () => {
+  const { fn, ctx, calls } = build(async () => { calls.creates++; throw new Error('网络错误') })
+
+  await fn.call(ctx)
+  assert.equal(ctx.quickSaving, false, '失败后必须放开，否则用户再也点不动保存')
+  await fn.call(ctx)
+  assert.equal(calls.creates, 2, '失败后应当能重试')
+})
+
+test('保存按钮在提交期间给出禁用态，不是只靠代码里的闸悄悄吞掉点击', () => {
+  const btn = src.match(/<view[^>]*pcp-quick-btn-primary[^>]*>/)
+  assert.ok(btn, '找不到保存按钮')
+  assert.match(btn[0], /quickSaving/, '保存按钮要跟着 quickSaving 变成禁用态')
+})

--- a/frontend/tests/project-home/project-overview-rescan.test.mjs
+++ b/frontend/tests/project-home/project-overview-rescan.test.mjs
@@ -1,0 +1,119 @@
+// 稳定性审计复扫（dev-board#74）里落在工作台 project-overview.vue 上的三条结论。
+// 组件带 @/ 别名、import 不进来，所以走本仓既有的两种写法：
+// 能抠出来单跑的函数就真跑一遍（重命名竞态），模板接线只能做源码文本断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/project-overview.vue', import.meta.url),
+  'utf8'
+)
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+const CODE = stripComments(SRC)
+
+// 从起始位置抠出一段花括号配平的函数体（跳过字符串里的括号）
+function braceBody(src, header) {
+  const at = src.indexOf(header)
+  assert.ok(at >= 0, `找不到 ${header}`)
+  let i = src.indexOf('{', at)
+  const start = i + 1
+  let depth = 0
+  let quote = null
+  for (; i < src.length; i++) {
+    const ch = src[i]
+    if (quote) {
+      if (ch === '\\') { i++; continue }
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue }
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return src.slice(start, i)
+    }
+  }
+  throw new Error(`${header} 的花括号没配平`)
+}
+
+// ---------- 1. 项目重命名：blur 清空字段后不能把空名字写进标题 ----------
+//
+// uni-app H5 的 input 在 @confirm 之后会立刻 input.blur()（confirm-hold 默认 false），
+// 模板上 @blur 绑的正是 cancelRenameProject——它同步把 renameProjectName 清成 ''。
+// 所以每一次「敲回车确认重命名」都会走到：confirm 挂在 await 上 → blur 清字段 →
+// await 回来再读 this.renameProjectName，写进标题的是空串（显示成「未命名项目」），
+// 而服务端存的其实是正确的新名字。名字必须在 await 之前取下来。
+function buildConfirmRename(renameProject, uni) {
+  const body = braceBody(CODE, 'async confirmRenameProject()')
+  // eslint-disable-next-line no-new-func
+  return new Function('renameProject', 'uni', `return async function confirmRenameProject() {${body}}`)(
+    renameProject,
+    uni
+  )
+}
+
+test('确认重命名后立刻 blur（uni 的 confirm 必然触发），标题仍写入正确的新名字', async () => {
+  let resolveRename
+  const renameProject = () => new Promise((r) => { resolveRename = r })
+  const fn = buildConfirmRename(renameProject, { showToast() {} })
+  const ctx = {
+    projectId: 7,
+    project: { name: '旧名字' },
+    renameProjectName: '新名字',
+    isRenamingProject: true,
+    $t: (k) => k
+  }
+  const pending = fn.call(ctx)
+  // input.blur() → cancelRenameProject()：同步清字段
+  ctx.isRenamingProject = false
+  ctx.renameProjectName = ''
+  resolveRename({ code: 0 })
+  await pending
+  assert.equal(ctx.project.name, '新名字', 'await 回来重读 renameProjectName 会写进空串')
+})
+
+test('重命名请求带上的也是确认那一刻的名字', async () => {
+  const seen = []
+  const renameProject = (id, name) => { seen.push([id, name]); return Promise.resolve({ code: 0 }) }
+  const fn = buildConfirmRename(renameProject, { showToast() {} })
+  const ctx = { projectId: 7, project: {}, renameProjectName: '  带空格的名字  ', $t: (k) => k }
+  await fn.call(ctx)
+  assert.deepEqual(seen, [[7, '带空格的名字']])
+})
+
+// ---------- 2. 文件选择器：取消时必须清掉三个面板各自暂存的回调 ----------
+//
+// 脱敏 / 诉讼可视化 / EasyVoice 三个面板共用页面级的同一个 FilePickerDialog，
+// 各自把 resume 回调存在页面字段上。用户点「取消」时没人清，下一次别的面板再开选择器，
+// handleFilePickerConfirm 先撞上残留的旧回调就 return 了——新面板的回调永远不会被调用，
+// 用户选了文件却什么都没发生。
+test('FilePickerDialog 监听了 cancel', () => {
+  const tpl = CODE.slice(CODE.indexOf('<FilePickerDialog'), CODE.indexOf('<FilePickerDialog') + 400)
+  assert.match(tpl, /@cancel=/, '不听 cancel，退出选择器时三个回调字段全留在页面上')
+})
+
+test('取消处理清空三个面板的回调字段', () => {
+  const body = braceBody(CODE, 'handleFilePickerCancel()')
+  for (const field of ['desensitizeFileSelectCallback', 'litigationScopeCallback', 'easyVoiceImportCallback']) {
+    assert.match(body, new RegExp(`this\\.${field}\\s*=\\s*null`), `${field} 没被清空`)
+  }
+})
+
+// ---------- 3. 文档对比标签：DocDiffViewer 必须带 key ----------
+//
+// 两个对比标签（A vs B、C vs D）命中同一个 v-else-if 分支，没有 key 时 Vue 就地复用
+// 同一个组件实例：props 换了，但 DocDiffViewer 只在 mounted() 里 loadDocuments()、
+// 对 sourceId/targetId 没有 watch，Monaco 里画的还是上一对文档——标题说 C vs D，
+// 正文是 A vs B。同分支里的 VersionCompareTab / 版本文本对比早就带 key 了。
+test('两个窗格的对比标签 DocDiffViewer 都带 key', () => {
+  for (const side of ['Left', 'Right']) {
+    const marker = `isDiffTab(activeFile${side})`
+    const at = CODE.indexOf(marker)
+    assert.ok(at > 0, `找不到 ${marker}`)
+    const tagStart = CODE.lastIndexOf('<DocDiffViewer', at)
+    const tag = CODE.slice(tagStart, CODE.indexOf('/>', at))
+    assert.match(tag, /:key=/, `${side} 窗格的对比标签没有 key，切换两个对比标签会复用旧实例`)
+  }
+})

--- a/frontend/tests/project-home/review-panel-double-tap.test.mjs
+++ b/frontend/tests/project-home/review-panel-double-tap.test.mjs
@@ -1,0 +1,79 @@
+// 审计（dev-board#74）：ReviewPanel 的修订卡片「接受/拒绝」没有重入闸，连点两次会
+// 并发跑两轮 resolveGroup。两轮手里是同一份索引，第一轮处置掉一条后引擎里比它大的
+// 索引全部前移，第二轮那份索引已经过期，会打到文档里别的修订上——用户没看过的改动
+// 被悄悄接受/拒绝，引擎还返回 success:true。
+//
+// 用例不做源码文本断言，直接把组件的 <script> 抽出来跑：export default 换成 return，
+// 再用普通对象当 this 调 methods（同 personal-settings-reentrancy.test.mjs 的路子）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/ReviewPanel.vue', import.meta.url), 'utf8')
+
+function makeVm(executor) {
+  const script = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+  // eslint-disable-next-line no-new-func
+  const component = new Function(script.replace('export default', 'return'))()
+  const base = { $t: (k) => k, $emit: () => {}, executor }
+  return Object.assign(base, component.data.call(base), component.methods, {
+    revisionGroups: component.computed.revisionGroups,
+  })
+}
+
+// 假引擎：live 是当前修订列表，index 就是数组下标；处置一条后其余前移——与真引擎一致。
+function makeEngine(ids) {
+  const live = ids.slice()
+  const resolved = []
+  return {
+    live,
+    resolved,
+    async executeCommand(action, params) {
+      await Promise.resolve()
+      if (action === 'list_revisions') {
+        return {
+          success: true,
+          revisions: live.map((id, i) => ({
+            index: i, id, text: id, type: 'Insert', author: 'u', date: 'd',
+            // 只有 C 与前一条 B 首尾相接，于是 B+C 并成一张卡片
+            contiguous: id === 'C',
+          })),
+        }
+      }
+      if (action === 'list_comments') return { success: true, comments: [] }
+      if (action === 'resolve_revision') {
+        if (params.index < 0 || params.index >= live.length) return { success: false, message: 'out of range' }
+        resolved.push(live[params.index])
+        live.splice(params.index, 1)
+        return { success: true }
+      }
+      return { success: true }
+    },
+  }
+}
+
+test('修订卡片连点两次接受，只处置本组的修订，不误伤别的', async () => {
+  // A B C D E：B(1)+C(2) 是一组，A/D/E 与用户点的这张卡片无关
+  const engine = makeEngine(['A', 'B', 'C', 'D', 'E'])
+  const vm = makeVm(engine)
+  await vm.reload()
+  const groups = vm.revisionGroups.call(vm)
+  const g = groups.find((x) => x.items.length > 1)
+  assert.deepEqual(g.items.map((r) => r.index), [1, 2], '前置条件：卡片覆盖索引 1 与 2')
+
+  await Promise.all([vm.resolveGroup(g, 'accept'), vm.resolveGroup(g, 'accept')])
+
+  assert.deepEqual(engine.resolved.slice().sort(), ['B', 'C'], '只许处置本组的 B 与 C')
+  assert.deepEqual(engine.live, ['A', 'D', 'E'], 'A/D/E 是用户没看过的修订，不许被动过')
+})
+
+test('处置完成后闸要放开，允许接着处置下一张卡片', async () => {
+  const engine = makeEngine(['A', 'B', 'C', 'D', 'E'])
+  const vm = makeVm(engine)
+  await vm.reload()
+  const g1 = vm.revisionGroups.call(vm).find((x) => x.items.length > 1)
+  await vm.resolveGroup(g1, 'accept')
+  const g2 = vm.revisionGroups.call(vm)[0]
+  await vm.resolveGroup(g2, 'reject')
+  assert.deepEqual(engine.live, ['D', 'E'], '闸没放开的话第二张卡片就点不动了')
+})

--- a/frontend/tests/project-home/search-panel-stale-toast.test.mjs
+++ b/frontend/tests/project-home/search-panel-stale-toast.test.mjs
@@ -1,0 +1,72 @@
+// 审计（dev-board#74）：SearchPanel.performSearch() 的 catch 分支没跟着 seq 走。
+// 快速连点两个标签时（toggleTag 不去抖，每次都直接发请求），先发的那次若在
+// 后发的那次成功落地之后才失败，仍会弹一次「搜索失败」——屏幕上明明是新结果。
+// 同 VersionTimeline 的做法：把 <script> 抽出来真跑一遍，api 当参数注入。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/components/SearchPanel.vue', import.meta.url), 'utf8')
+
+function loadOptions(api, uni) {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export\s+default/, 'return')
+  const factory = new Function(
+    'searchProjectContent', 'getProjectTags', 'FileTypeIcon',
+    'TAG_TYPE_PARTY', 'TAG_TYPE_ISSUE', 'TAG_TYPE_NORMAL', 'normalizeTagType',
+    'uni', body)
+  return factory(api.searchProjectContent, () => Promise.resolve([]), {},
+    'PARTY', 'ISSUE', 'NORMAL', () => 'NORMAL', uni)
+}
+
+function makeVm(options, props) {
+  const vm = Object.assign({}, options.data(), props)
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  for (const [k, fn] of Object.entries(options.computed))
+    Object.defineProperty(vm, k, { get: fn.bind(vm) })
+  vm.$t = (k) => k
+  return vm
+}
+
+const deferred = () => {
+  let resolve, reject
+  const promise = new Promise((r, j) => { resolve = r; reject = j })
+  return { promise, resolve, reject }
+}
+
+test('先发请求的迟到失败不许在新结果已经渲染之后弹错误提示', async () => {
+  const gates = { A: deferred(), B: deferred() }
+  let calls = 0
+  const toasts = []
+  const options = loadOptions(
+    { searchProjectContent: () => (++calls === 1 ? gates.A.promise : gates.B.promise) },
+    { showToast: (o) => toasts.push(o) })
+  const vm = makeVm(options, { projectId: 1 })
+
+  const first = vm.performSearch()   // 勾标签 A
+  const second = vm.performSearch()  // 立刻再勾标签 B
+
+  // 后发的先成功，先发的后失败（网络抖动/超时）
+  gates.B.resolve({ totalMatches: 1, totalFiles: 1, results: [] })
+  await second
+  gates.A.reject(new Error('network hiccup'))
+  await first
+
+  assert.deepEqual(toasts, [], '陈旧请求的失败弹了提示，但面板上是有效的新结果')
+  assert.equal(vm.loading, false)
+  assert.equal(vm.results.totalMatches, 1, '新结果不该被覆盖')
+})
+
+test('最新一次请求失败照常提示', async () => {
+  const toasts = []
+  const options = loadOptions(
+    { searchProjectContent: () => Promise.reject(new Error('boom')) },
+    { showToast: (o) => toasts.push(o) })
+  const vm = makeVm(options, { projectId: 1 })
+
+  await vm.performSearch()
+
+  assert.equal(toasts.length, 1, '当前请求失败必须提示用户')
+})

--- a/frontend/tests/project-home/tagmanager-add-inflight.test.mjs
+++ b/frontend/tests/project-home/tagmanager-add-inflight.test.mjs
@@ -1,0 +1,87 @@
+// 审计（dev-board#74）：标签管理的「添加」没有在途闸。newTagName 要等 await 返回才清，
+// 按钮的 :disabled 又只看 newTagName，所以在请求返回前双击（或回车后紧接着点一下）
+// 会用同一个名字发两次 createTag：第一次建成，第二次被后端的同项目重名校验驳回，
+// 弹出「Failed to create tag」——一次其实成功的操作却给了用户失败提示。
+//
+// 组件带 @/ 别名 import 不进来（本目录既有写法），这里把 handleAdd 的函数体抠出来
+// 用 new Function 起真身跑，依赖全部注入，属于行为断言而非文本断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const src = readFileSync(new URL('../../src/components/TagManager.vue', import.meta.url), 'utf8')
+
+function extractBody(name) {
+  const head = src.indexOf(`async ${name}() {`)
+  assert.ok(head > 0, `找不到 ${name}`)
+  const start = src.indexOf('{', head)
+  let depth = 0
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1)
+  }
+  throw new Error(`${name} 的括号没配上`)
+}
+
+// 后端对同一项目内的标签名唯一，重名请求直接抛错
+function build({ latency = true } = {}) {
+  const calls = { creates: [], toasts: [], releases: [] }
+  const names = new Set()
+  const api = {
+    createTag: (projectId, payload) => {
+      calls.creates.push(payload.name)
+      const run = () => {
+        if (names.has(payload.name)) throw new Error('标签名已存在')
+        names.add(payload.name)
+        return { id: names.size }
+      }
+      if (!latency) return Promise.resolve(run())
+      return new Promise((resolve, reject) => {
+        calls.releases.push(() => { try { resolve(run()) } catch (e) { reject(e) } })
+      })
+    }
+  }
+  const uni = { showToast: (o) => calls.toasts.push(o) }
+  const fn = new Function(
+    'api', 'uni', 'TAG_TYPE_NORMAL', 'TAG_TYPE_DEFAULT_COLORS',
+    `return async function handleAdd() ${extractBody('handleAdd')}`,
+  )(api, uni, 'NORMAL', { NORMAL: '#6B7280' })
+  const ctx = {
+    projectId: 1,
+    newTagName: '原告主张',
+    newTagType: 'NORMAL',
+    newTagColor: '#6B7280',
+    refreshTags() {},
+  }
+  return { fn, ctx, calls }
+}
+
+test('请求在途时再点添加不会重复提交同一个名字', async () => {
+  const { fn, ctx, calls } = build()
+
+  const first = fn.call(ctx)
+  // 第一次请求还没返回（newTagName 也就还没清），用户又点了一下
+  const second = fn.call(ctx)
+  assert.equal(calls.creates.length, 1, '在途期间第二次点击必须被挡住')
+
+  calls.releases.forEach((cb) => cb())
+  await Promise.all([first, second])
+  assert.deepEqual(calls.toasts, [], '一次成功的创建不该弹出失败提示')
+  assert.equal(ctx.newTagName, '', '成功后输入框要清空')
+})
+
+test('创建失败后闸要放开，允许重试', async () => {
+  const { fn, ctx, calls } = build({ latency: false })
+
+  await fn.call(ctx)
+  assert.equal(calls.creates.length, 1)
+
+  ctx.newTagName = '原告主张'
+  await fn.call(ctx)
+  assert.equal(calls.creates.length, 2, '失败后应当能重试，闸不能卡死')
+  assert.equal(calls.toasts.length, 1, '重名失败照旧提示')
+})
+
+test('按钮的禁用条件要带上在途标志', () => {
+  assert.match(src, /:disabled="!newTagName \|\| adding"/)
+})

--- a/frontend/tests/project-home/version-timeline-race.test.mjs
+++ b/frontend/tests/project-home/version-timeline-race.test.mjs
@@ -1,0 +1,74 @@
+// 审计（dev-board#74）：VersionTimeline.load() 没有请求乱序保护。
+// 这里不做源码文本断言，而是把 .vue 的 <script> 块抽出来真跑一遍 load()——
+// 组件带 @/ 别名 import 不进来，改成把两个 api 函数当参数注入。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/components/version/VersionTimeline.vue', import.meta.url), 'utf8')
+
+// 抽 <script> 块：去掉 import 行（别名解析不了），export default 换成 return。
+function loadOptions(api) {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export\s+default/, 'return')
+  const factory = new Function(
+    'getVersionTimeline', 'getDraftTimeline', 'VersionNodeDetail', 'uni', body)
+  return factory(api.getVersionTimeline, api.getDraftTimeline, {}, { showToast() {} })
+}
+
+function makeVm(options, props) {
+  const vm = Object.assign({}, options.data(), props)
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  for (const [k, fn] of Object.entries(options.computed))
+    Object.defineProperty(vm, k, { get: fn.bind(vm) })
+  vm.$t = (k) => k
+  return vm
+}
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+test('先发的过滤请求后到，不许覆盖后发的全量结果', async () => {
+  const gates = { A: deferred(), all: deferred() }
+  const options = loadOptions({
+    getVersionTimeline: (_pid, _limit, fileId) => gates[fileId || 'all'].promise,
+    getDraftTimeline: () => Promise.resolve({ data: { versions: [] } }),
+  })
+  const vm = makeVm(options, { projectId: 1, fileFilter: { fileId: 'A' }, drafts: [] })
+
+  // 1) 按文件过滤，请求在途
+  const filtered = vm.load()
+  // 2) 立刻点「查看全部」清掉过滤，第二个请求发出
+  vm.fileFilter = null
+  const unfiltered = vm.load()
+
+  // 3) 后发的先回，先发的后回（网络乱序）
+  gates.all.resolve({ data: { versions: [{ sha: 'unfiltered', kind: 'session' }] } })
+  await unfiltered
+  gates.A.resolve({ data: { versions: [{ sha: 'filtered', kind: 'session' }] } })
+  await filtered
+
+  assert.deepEqual(vm.versions.map(v => v.sha), ['unfiltered'],
+    '过滤请求的迟到响应把已清掉过滤的时间线覆盖了')
+  // isCurrentHead 读的是实时 fileFilter 配陈旧 versions，会高亮错节点
+  assert.equal(vm.isCurrentHead({ sha: 'unfiltered' }), true)
+})
+
+test('正常顺序下最后一次请求的结果照常生效', async () => {
+  const options = loadOptions({
+    getVersionTimeline: (_pid, _limit, fileId) =>
+      Promise.resolve({ data: { versions: [{ sha: fileId || 'all', kind: 'session' }] } }),
+    getDraftTimeline: () => Promise.resolve({ data: { versions: [] } }),
+  })
+  const vm = makeVm(options, { projectId: 1, fileFilter: { fileId: 'A' }, drafts: [] })
+  await vm.load()
+  assert.deepEqual(vm.versions.map(v => v.sha), ['A'])
+  vm.fileFilter = null
+  await vm.load()
+  assert.deepEqual(vm.versions.map(v => v.sha), ['all'])
+})


### PR DESCRIPTION
把 `docs/AUDIT_2026-08-20_REMAINING.md` 末尾「补扫批次」的 41 条逐条落实：**40 条已修，1 条判为已修/误报不动**。一个文件一个 agent 并行修（文件互不重叠，避免互相踩），diff 我自己复核，验收我自己跑。

## 后端（11 条）

| 文件 | 病灶 |
|---|---|
| `ProjectFileController` | `createFolder/createFile/move` 不校验 `parentId` 归属，能把节点建成**永久看不见的孤儿**；补闸：同项目 + 是文件夹 + 未软删 |
| `ProjectService.deleteProject` | 只删 project 行，**9 张项目级表 + 磁盘目录 + 版本仓库全留成孤儿**。裸 `Long projectId` 列不生成外键，`ddl-auto=update` 下数据库层没有 `ON DELETE CASCADE`，级联只能手写。IDE 化本地文件夹项目的目录是用户自己的，**只解绑不删** |
| `AgentOrchestrator` | 截断点落在半截协议标签里（`<tool_output status="SUC`），中和认不出、原样放行；前端属性段 `[^>]*` 一路吃掉真正的闭合标签，本轮剩下的正文全被塞进折叠区。补 `tagSafeCut`：**只回退「还能长成已知标签」的形状**，合同里的 `<甲方`、比较符 `a < b` 照旧按字数切 |
| `SkillRegistry` | `loadDisabledState` 先 clear 再从 DB 重填，三次往返期间无锁读方把**停用的 skill 读成启用**。改成读完再整体换引用，字段转 `volatile` |
| 另 7 处 | `CloudSyncService` / `WebFavoriteController` / `WebFavoriteService` / `WizardStateService` / `TushareService` / `ProjectFileService`，详见文件注释 |

## 前端（25 条）

- **`useAgentStream`**：卸载后 SSE reader 循环、心跳、重连定时器仍在跑，两个实例互相把对方从同一会话挤下去 → 补 `onUnmounted` 清理
- **`ProjectCalendarPane`**：裸 `uni.reLaunch` 离开工作台，绕过 `flushDirtyEditors`，刚敲的改动静默丢失（#489 修过的同一类）→ 改为向上 emit，由父页面既有的 `leaveWorkbench` 先落盘再跳。**这条是子 agent 按「不许跨文件改」的规矩留下的，我自己补的**
- 其余为并发 / 实例复用 / 重入类：`DocDiffViewer`、`ReviewPanel`、`PluginPane`、`DdRequestEditor`、`PlainTextEditor`、`SearchPanel`、`AdminPane` 等

## 桌面与 CI（4 条）

- `drawio-server` / `zetaoffice-server`：`createReadStream` 未挂 `error` 监听，**文件读一半出错直接掀掉整个 Electron 主进程**
- `update-service`：`fetchUrl` 各失败路径不关 `WriteStream`，泄漏 fd
- `build-patch-assets` + `desktop-build.yml`：Python 服务缓存键漏了服务源码，会静默跳过打包、**发出带旧 sidecar 的包**
- `check-emit-bindings`：属性里出现字面量 `>` 时正则截断，后面的事件绑定整段扫不到，**门禁静默放行**

## 刻意没修的 1 条

`ClientInvitationService` 通用邀请码 TOCTOU。已被 #501 修过（`findByProjectIdAndType` 改返回 List + 调用方 `earliest()` 读时去重），且验证者并列给的另一修法「`(project_id,type)` 唯一约束」**对本 schema 有害**——`CLIENT_NAMED` 一个项目本来就多行，加约束会把具名邀请打死（`ProjectInvitationLookupTest.namedInvitationsMayCoexist` 就是钉这条的护栏）。硬修只会把正常代码改坏。

## 验收（全部我自己跑，不采信子 agent 自述）

| 门禁 | 结果 |
|---|---|
| backend `mvn test` | **2206 通过 0 失败**（基线 2142，多出的是本轮新增用例） |
| `test:project-home` | **149/149** |
| desktop 测试 | **62 通过 0 失败** |
| `check:emits` / `check:nav` / `check:nav:full` / `check:locales` | 全绿 |
| `build:h5` | 构建通过 |

新增测试 30 余个用例，绝大多数按「先红后绿」写；前端无组件测试位的少数几条改用源码级契约断言（沿用本仓 `tests/project-home/` 既有口径）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)