### PR TITLE
fix(backend): 回收站里的材料被当成在场、剪贴板删记录不删对象、任务标题类型不对报「服务器内部错误」（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/TaskController.java
+++ b/backend/src/main/java/com/checkba/controller/TaskController.java
@@ -63,7 +63,7 @@ public class TaskController {
         Long userId = requireWrite(projectId, sessionId);
 
         Long fileId = toLong(body.get("fileId"));
-        String title = (String) body.get("title");
+        String title = toText(body.get("title"));
         LocalDate dueDate = toLocalDate(body.get("dueDate"));
         LocalTime dueTime = toLocalTime(body.get("dueTime"));
 
@@ -98,6 +98,18 @@ public class TaskController {
 
     private ResponseEntity<Map<String, Object>> ok(Map<String, Object> data) {
         return ResponseEntity.ok(Map.of("code", 0, "data", data));
+    }
+
+    /**
+     * 裸强转 {@code (String)} 传进来一个数字就抛 ClassCastException——那不是
+     * IllegalArgumentException，绕过 GlobalExceptionHandler 那条能给出人话的分支，
+     * 落到兜底处理器变成「服务器内部错误」，还给一条普通的参数校验失败打了 ERROR 堆栈。
+     * 调用方看不出真正的原因只是 title 类型不对。
+     */
+    private String toText(Object v) {
+        if (v == null) return null;
+        if (v instanceof String str) return str;
+        throw new IllegalArgumentException(LangText.of("标题必须是文本", "The title must be text"));
     }
 
     private Long toLong(Object v) {

--- a/backend/src/main/java/com/checkba/service/ClipboardService.java
+++ b/backend/src/main/java/com/checkba/service/ClipboardService.java
@@ -18,6 +18,8 @@ import java.util.Map;
 @Service
 public class ClipboardService {
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ClipboardService.class);
+
     /** 免费版最多回溯的条数（Spec §5）。 */
     public static final int FREE_MAX_ITEMS = 20;
     /** 免费版保留天数（Spec §5）。与条数上限**同时**生效，取更严者。 */
@@ -172,6 +174,31 @@ public class ClipboardService {
             throw new IllegalArgumentException(LangText.of("无权删除该记录", "You do not have permission to delete this record"));
         }
         repository.delete(item);
+        // 文件型记录的字节此前从不删：每删一条就永久漏一份对象。这是维护者看不见的泄漏——
+        // 功能上一切正常，只有磁盘/对象存储用量在慢慢涨。放在删行之后，且失败只记日志：
+        // 对象删不掉不该让用户的删除操作失败（下场是记录还在，用户会一直删不掉）。
+        deleteBlobQuietly(item);
+    }
+
+    /** 取出文件型记录的存储 key 并删除；不是文件型、meta 坏了、删不掉，一律只记日志。 */
+    private void deleteBlobQuietly(ClipboardItem item) {
+        if ("TEXT".equals(item.getType())) return;
+        String path;
+        try {
+            Map<String, Object> meta = new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readValue(item.getMeta(), Map.class);
+            Object raw = meta.get("path");
+            path = raw instanceof String str ? str : null;
+        } catch (Exception e) {
+            log.warn("剪贴板记录 {} 的 meta 无法解析，跳过删除底层对象: {}", item.getId(), e.toString());
+            return;
+        }
+        if (!StringUtils.hasText(path)) return;
+        try {
+            getStorageService().delete(path);
+        } catch (Exception e) {
+            log.warn("剪贴板记录 {} 的底层对象删除失败: path={}", item.getId(), path, e);
+        }
     }
 }
 

--- a/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
+++ b/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
@@ -322,10 +322,21 @@ public class ShareholderMeetingService {
         return id == null ? List.of() : List.of(id);
     }
 
-    private List<ProjectFile> findFiles(List<Long> ids) {
+    /**
+     * 按 id 取材料文件，**排除回收站里的**。
+     *
+     * <p>裸 findById 不过滤 isDeleted，而 ProjectFileService 完全不知道股东大会核查这回事、
+     * 文件被删时从不解绑材料槽。于是材料被丢进回收站之后，kick-off prompt 仍把它列成
+     * 一份在场的材料、也不进「缺失材料」告警——与这段代码为 null 槽位精心实现的
+     * 缺失提示自相矛盾；若文件已被彻底删除，后续复制或 AI 读取还会失败，
+     * 而清单从没提醒过它没了。
+     */
+    List<ProjectFile> findFiles(List<Long> ids) {
         List<ProjectFile> files = new ArrayList<>();
         for (Long id : ids) {
-            projectFileRepository.findById(id).ifPresent(files::add);
+            projectFileRepository.findById(id)
+                    .filter(f -> !Boolean.TRUE.equals(f.getIsDeleted()))
+                    .ifPresent(files::add);
         }
         return files;
     }

--- a/backend/src/test/java/com/checkba/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/TaskControllerTest.java
@@ -95,6 +95,25 @@ class TaskControllerTest {
         }
     }
 
+    /**
+     * title 是裸强转 (String)。传个数字进来抛的是 ClassCastException——不是
+     * IllegalArgumentException，绕过 GlobalExceptionHandler 那条能给出人话的分支，
+     * 落到兜底 Exception 处理器变成「服务器内部错误」，还给一条普通的参数校验失败
+     * 打了 ERROR 级堆栈。调用方看不出真正的原因只是 title 类型不对。
+     */
+    @Test
+    void createRejectsNonStringTitleWithUserFacingError() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            when(projectMemberService.hasWritePermission(7L, 1L)).thenReturn(true);
+            when(projectMemberService.isClient(7L, 1L)).thenReturn(false);
+            Map<String, Object> body = Map.of("projectId", 7, "title", 123, "dueDate", "2026-09-01");
+
+            assertThrows(IllegalArgumentException.class, () -> controller.create(body, "sess"));
+            verify(taskService, never()).createTask(any(), any(), any(), any(), any(), any());
+        }
+    }
+
     @Test
     void createRejectsClient() {
         try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {

--- a/backend/src/test/java/com/checkba/service/ClipboardBlobCleanupTest.java
+++ b/backend/src/test/java/com/checkba/service/ClipboardBlobCleanupTest.java
@@ -1,0 +1,76 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ClipboardItem;
+import com.checkba.repository.ClipboardItemRepository;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 删除文件型剪贴板记录时，底层对象也要一起删掉。
+ *
+ * <p>病灶：delete() 只删数据库行，从不调 StorageService.delete——每删一条文件型记录
+ * 就永久漏一份对象。这是维护者看不见的泄漏：功能上一切正常，只有磁盘/对象存储用量
+ * 在慢慢涨，涨到出问题时也很难回溯到剪贴板这个功能上。
+ */
+class ClipboardBlobCleanupTest {
+
+    private static final Long USER = 7L;
+
+    private ClipboardItemRepository repository;
+    private StorageService storage;
+    private ClipboardService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ClipboardItemRepository.class);
+        storage = mock(StorageService.class);
+        StorageServiceFactory factory = mock(StorageServiceFactory.class);
+        when(factory.getStorageService()).thenReturn(storage);
+        EntitlementService entitlement = mock(EntitlementService.class);
+        service = new ClipboardService(repository, factory, entitlement, true);
+    }
+
+    private ClipboardItem item(String type, String meta) {
+        ClipboardItem it = new ClipboardItem();
+        it.setId(9L);
+        it.setUserId(USER);
+        it.setType(type);
+        it.setMeta(meta);
+        return it;
+    }
+
+    @Test
+    @DisplayName("删除文件型记录时一并删掉存储里的对象")
+    void deletingFileItemAlsoRemovesTheBlob() {
+        when(repository.findById(9L)).thenReturn(Optional.of(item("IMAGE", "{\"path\":\"clipboard/7/abc\"}")));
+
+        service.delete(9L, USER);
+
+        verify(repository).delete(org.mockito.ArgumentMatchers.any());
+        verify(storage).delete("clipboard/7/abc");
+    }
+
+    @Test
+    @DisplayName("文本记录不碰存储；meta 里没有 path 也不该炸")
+    void textItemAndMissingPathAreSafe() {
+        when(repository.findById(9L)).thenReturn(Optional.of(item("TEXT", "{}")));
+        service.delete(9L, USER);
+        verify(storage, never()).delete(anyString());
+
+        when(repository.findById(9L)).thenReturn(Optional.of(item("IMAGE", "not-json")));
+        service.delete(9L, USER);
+        verify(storage, never()).delete(anyString());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ShareholderMeetingMaterialLookupTest.java
+++ b/backend/src/test/java/com/checkba/service/ShareholderMeetingMaterialLookupTest.java
@@ -1,0 +1,74 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ShareholderMeetingCheckRepository;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * 材料查找必须排除回收站里的文件。
+ *
+ * <p>病灶：findFiles 用的是裸 findById，不过滤 isDeleted，而 ProjectFileService 完全不知道
+ * 股东大会核查这回事，文件被删时从不 detachMaterial。于是把材料丢进回收站之后，
+ * 「开始核查」的 kick-off prompt 仍把它列成一份在场的材料、也不进「缺失材料」告警——
+ * 与这段代码为 null 槽位精心实现的「缺失材料」提示自相矛盾。
+ * 文件若已被彻底删除（字节没了），后续复制或 AI 读取还会失败，而清单从没提醒过它没了。
+ */
+@ExtendWith(MockitoExtension.class)
+class ShareholderMeetingMaterialLookupTest {
+
+    @Mock private ShareholderMeetingCheckRepository checkRepository;
+    @Mock private ProjectFileRepository projectFileRepository;
+    @Mock private ProjectFileService projectFileService;
+    @Mock private StorageServiceFactory storageServiceFactory;
+    @Mock private CninfoAnnouncementService cninfoService;
+
+    private ShareholderMeetingService svc;
+
+    @BeforeEach
+    void setUp() {
+        svc = new ShareholderMeetingService(checkRepository, projectFileRepository,
+                projectFileService, storageServiceFactory, cninfoService);
+    }
+
+    private static ProjectFile file(long id, boolean deleted) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setName("f" + id + ".pdf");
+        f.setIsDeleted(deleted);
+        return f;
+    }
+
+    @Test
+    @DisplayName("回收站里的材料不算在场，只留还活着的")
+    void trashedMaterialIsNotTreatedAsPresent() {
+        ProjectFile live = file(1L, false);
+        when(projectFileRepository.findById(1L)).thenReturn(Optional.of(live));
+        when(projectFileRepository.findById(2L)).thenReturn(Optional.of(file(2L, true)));
+
+        assertEquals(List.of(live), svc.findFiles(List.of(1L, 2L)),
+                "被丢进回收站的材料仍被当成在场，「缺失材料」告警因此不会提到它");
+    }
+
+    @Test
+    @DisplayName("isDeleted 为 null 的历史数据按未删除处理")
+    void nullDeletedFlagCountsAsAlive() {
+        ProjectFile legacy = file(3L, false);
+        legacy.setIsDeleted(null);
+        when(projectFileRepository.findById(3L)).thenReturn(Optional.of(legacy));
+
+        assertEquals(List.of(legacy), svc.findFiles(List.of(3L)));
+    }
+}


### PR DESCRIPTION
三条，每条先写测试看它红、改实现看它绿。

1. [MEDIUM] 股东大会核查：回收站里的材料仍被当成在场
   findFiles 用的是裸 findById，不过滤 isDeleted，而 ProjectFileService 完全不知道
   股东大会核查这回事、文件被删时从不解绑材料槽。于是把材料丢进回收站之后，
   「开始核查」的 kick-off prompt 仍把它列成一份在场的材料、也不进「缺失材料」告警——
   与这段代码为 null 槽位精心实现的缺失提示自相矛盾。若文件已被彻底删除（字节没了），
   后续复制或 AI 读取还会失败，而清单从没提醒过它没了。
   修法：findFiles 过滤掉软删除行；isDeleted 为 null 的历史数据按未删除处理。

2. [MEDIUM] 删除文件型剪贴板记录时不删底层对象
   delete() 只删数据库行，从不调 StorageService.delete——每删一条文件型记录就永久
   漏一份对象。这是维护者看不见的泄漏：功能上一切正常，只有磁盘/对象存储用量在慢慢涨，
   涨到出问题时也很难回溯到剪贴板这个功能上。
   修法：删行之后删对象；不是文件型、meta 坏了、删不掉一律只记日志——对象删不掉
   不该让用户的删除操作失败（那样记录还在，用户会一直删不掉）。

3. [LOW] POST /api/tasks 的 title 是裸强转
   传个数字进来抛的是 ClassCastException——不是 IllegalArgumentException，
   绕过 GlobalExceptionHandler 那条能给出人话的分支，落到兜底处理器变成
   「服务器内部错误」，还给一条普通的参数校验失败打了 ERROR 级堆栈。
   调用方看不出真正的原因只是 title 类型不对。改成明确报「标题必须是文本」。

全量 mvn test：2195 通过 0 失败 11 跳过。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)