### PR TITLE
fix(ai-chat): 项目记忆里的关键日期写一次就冻住、同项目并发提取互相覆盖（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/memory/ProjectMemoryExtractor.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/ProjectMemoryExtractor.java
@@ -44,9 +44,40 @@ public class ProjectMemoryExtractor {
     private static final Pattern PARTY_PATTERN = Pattern.compile("(甲方|乙方|丙方|丁方|发行人|标的公司|上市公司|交易对方)[：:：]\\s*([^\\n,，。]+)");
 
     /**
+     * 同项目的提取互斥用的分条锁。
+     *
+     * <p>整段是「读 ProjectMemory -> 就地改 -> 保存」，此前没有任何锁；而记忆提取跑在
+     * {@code @Async("memoryExecutor")} 上（核心线程数 2），同一项目的两轮对话几乎同时结束
+     * 就会撞上：后写的那次带着自己读到的旧快照落库，前一次提取出的法条引用、金额、
+     * 当事方全部丢失，而且丢得毫无痕迹。
+     *
+     * <p>用固定条数的锁数组而不是按 id 建锁的 Map：Map 会随项目数无界增长，
+     * 而这里只要「同一项目串行」这一个性质，撞条带来的额外串行完全可以接受。
+     * 单实例基线（与验证码存储同一实现边界），多实例部署需要外置锁或乐观锁。
+     */
+    private static final Object[] PROJECT_LOCKS = new Object[16];
+
+    static {
+        for (int i = 0; i < PROJECT_LOCKS.length; i++) {
+            PROJECT_LOCKS[i] = new Object();
+        }
+    }
+
+    private static Object lockFor(Long projectId) {
+        int idx = projectId == null ? 0 : (int) Math.floorMod(projectId, PROJECT_LOCKS.length);
+        return PROJECT_LOCKS[idx];
+    }
+
+    /**
      * 从对话消息中提取信息并更新项目记忆
      */
     public void extractAndUpdateProjectMemory(Long projectId, List<ChatMessage> messages) {
+        synchronized (lockFor(projectId)) {
+            doExtractAndUpdateProjectMemory(projectId, messages);
+        }
+    }
+
+    private void doExtractAndUpdateProjectMemory(Long projectId, List<ChatMessage> messages) {
         log.info("Extracting project memory from {} messages for projectId={}", messages.size(), projectId);
         
         StringBuilder allContent = new StringBuilder();
@@ -102,11 +133,21 @@ public class ProjectMemoryExtractor {
             }
         }
         
-        // 更新关键日期
-        if (!dates.isEmpty() && pm.getKeyDates() == null) {
-            Map<String, String> keyDates = new HashMap<>();
-            for (int i = 0; i < Math.min(dates.size(), 5); i++) {
-                keyDates.put("日期" + (i + 1), dates.get(i));
+        // 更新关键日期：本轮提到的排在前面，再补上已记住的旧日期，最多留 5 条。
+        // 此前的判据是 `pm.getKeyDates() == null`——写一次就成了闩，此后每一轮都被挡掉。
+        // 对照同一段里的 legalRefs（每轮并集）与 transactionAmount（见到更大值就更新），
+        // 只有关键日期永久冻结；而 ProjectMemory.toContextString() 每轮都把它注进上下文，
+        // 交割日改期之后助手还在把原定日期当现行日期引用——法律期限场景下这是会出事的。
+        if (!dates.isEmpty()) {
+            java.util.LinkedHashSet<String> merged = new java.util.LinkedHashSet<>(dates);
+            if (pm.getKeyDates() != null) {
+                merged.addAll(pm.getKeyDates().values());
+            }
+            Map<String, String> keyDates = new java.util.LinkedHashMap<>();
+            int i = 0;
+            for (String date : merged) {
+                if (i >= 5) break;
+                keyDates.put("日期" + (++i), date);
             }
             pm.setKeyDates(keyDates);
         }

--- a/backend/src/test/java/com/checkba/service/ai/memory/ProjectMemoryExtractorTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/ProjectMemoryExtractorTest.java
@@ -1,5 +1,6 @@
 package com.checkba.service.ai.memory;
 
+import com.checkba.model.entity.ProjectMemory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -161,5 +162,78 @@ class ProjectMemoryExtractorTest {
         assertTrue(amounts.values().stream()
                 .anyMatch(a -> a.compareTo(new BigDecimal("50000000")) == 0)); // 5000万
     }
-}
 
+    /**
+     * keyDates 是个一次性写入的闩：第一轮提到日期后 pm.getKeyDates() 不再为 null，
+     * 此后每一轮都被那道 == null 的判断挡掉。对照同一段里的 legalRefs（每轮并集）
+     * 与 transactionAmount（见到更大值就更新），只有 keyDates 永久冻结。
+     * ProjectMemory.toContextString() 每轮都把这份陈旧日期注进上下文——
+     * 交割日改期之后，助手还在把原定日期当现行日期引用，在法律期限场景下是会出事的。
+     */
+    @Test
+    @DisplayName("关键日期必须能被后续轮次更新，不是写一次就冻住")
+    void keyDatesMustNotFreezeAfterFirstTurn() {
+        ProjectMemory stored = ProjectMemory.builder().projectId(1L).build();
+        org.mockito.Mockito.when(memoryManager.getProjectMemory(1L))
+                .thenAnswer(inv -> java.util.Optional.of(stored));
+        org.mockito.Mockito.when(memoryManager.saveProjectMemory(org.mockito.ArgumentMatchers.any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        extractor.extractAndUpdateProjectMemory(1L, List.of(
+                dev.langchain4j.data.message.UserMessage.from("交割日定于2026年1月15日。")));
+        assertNotNull(stored.getKeyDates());
+        assertTrue(stored.getKeyDates().containsValue("2026年1月15日"));
+
+        extractor.extractAndUpdateProjectMemory(1L, List.of(
+                dev.langchain4j.data.message.UserMessage.from("交割日顺延至2026年3月20日。")));
+        assertTrue(stored.getKeyDates().containsValue("2026年3月20日"),
+                "改期后的新日期必须进记忆，实际是：" + stored.getKeyDates());
+    }
+
+    /**
+     * 同一项目的两轮对话并发跑记忆提取时会互相覆盖：整段是「读 ProjectMemory → 就地改 →
+     * 保存」，全程没有任何锁；而 MemoryPipelineService 是 @Async("memoryExecutor")，
+     * 线程池核心数 2，两轮同时结束就会撞上。后写的那次带着自己读到的旧快照落库，
+     * 前一次提取出的法条引用、金额、当事方全部丢失，而且丢得毫无痕迹。
+     *
+     * <p>这里用 mock 当交会点做成确定性断言：让第一个线程停在读表处，
+     * 第二个线程若还能往下走，就说明同一项目的提取没有互斥。
+     */
+    @Test
+    @DisplayName("同一项目的并发提取必须互斥，否则后写的那次会盖掉前一次")
+    void concurrentExtractionOnSameProjectIsMutuallyExclusive() throws Exception {
+        ProjectMemory stored = ProjectMemory.builder().projectId(9L).build();
+        java.util.concurrent.CountDownLatch entered = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicInteger reads = new java.util.concurrent.atomic.AtomicInteger();
+        org.mockito.Mockito.when(memoryManager.getProjectMemory(9L)).thenAnswer(inv -> {
+            if (reads.incrementAndGet() == 1) {
+                entered.countDown();
+                release.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            }
+            return java.util.Optional.of(stored);
+        });
+        org.mockito.Mockito.when(memoryManager.saveProjectMemory(org.mockito.ArgumentMatchers.any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(2);
+        try {
+            java.util.concurrent.Future<?> first = pool.submit(() -> extractor.extractAndUpdateProjectMemory(9L,
+                    List.of(dev.langchain4j.data.message.UserMessage.from("依据《公司法》第十六条。"))));
+            assertTrue(entered.await(5, java.util.concurrent.TimeUnit.SECONDS), "第一轮应当进入临界区");
+
+            java.util.concurrent.Future<?> second = pool.submit(() -> extractor.extractAndUpdateProjectMemory(9L,
+                    List.of(dev.langchain4j.data.message.UserMessage.from("依据《证券法》第五十三条。"))));
+            assertThrows(java.util.concurrent.TimeoutException.class,
+                    () -> second.get(600, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    "同一项目的记忆提取必须互斥：读与写之间放行第二轮就会丢更新");
+
+            release.countDown();
+            first.get(5, java.util.concurrent.TimeUnit.SECONDS);
+            second.get(5, java.util.concurrent.TimeUnit.SECONDS);
+            assertEquals(2, stored.getLegalRefs().size(), "两轮的法条引用都要在：" + stored.getLegalRefs());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
两条，都先写测试看它红、改实现看它绿。

1. [MEDIUM] keyDates 是个一次性写入的闩，改期后的新日期永远进不去
   判据是 `!dates.isEmpty() && pm.getKeyDates() == null`——第一轮提到日期后就再也不为 null，
   此后每一轮都被挡掉。对照同一段里的 legalRefs（每轮并集）与 transactionAmount
   （见到更大值就更新），只有关键日期永久冻结。
   而 ProjectMemory.toContextString() 每轮都把这份陈旧日期注进上下文：交割日顺延之后，
   助手还在把原定日期当现行日期引用——法律期限场景下这是会出事的。
   实测：第一轮记下「2026年1月15日」，第二轮说「顺延至2026年3月20日」，
   记忆里仍然只有 {日期1=2026年1月15日}。
   修法：本轮提到的排在前面、再补上已记住的旧日期，最多留 5 条。

2. [HIGH] 同一项目的并发记忆提取互相覆盖，丢得毫无痕迹
   整段是「读 ProjectMemory → 就地改 → 保存」，全程没有任何锁；而记忆提取跑在
   @Async("memoryExecutor") 上（核心线程数 2），同一项目的两轮对话几乎同时结束就会撞上。
   后写的那次带着自己读到的旧快照落库，前一次提取出的法条引用、金额、当事方全部丢失。
   修法：按 projectId 分条加锁（固定 16 条，不用按 id 建锁的 Map——那会随项目数无界增长，
   而这里只要「同一项目串行」这一个性质，撞条带来的额外串行完全可以接受）。
   单实例基线，与验证码存储同一实现边界；多实例部署需要外置锁或乐观锁。
   测试用 mock 当交会点做成确定性断言（让第一个线程停在读表处，
   第二个还能往下走就说明没互斥），不靠 sleep 撞运气。

全量 mvn test：2195 通过 0 失败 11 跳过。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)