### PR TITLE
fix(ai-chat): 插件更新后仍跑旧代码、空消息毒死会话、卡住的任务永不回收等十条（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/AiAgentController.java
@@ -152,6 +152,13 @@ public class AiAgentController {
             return ResponseEntity.status(403).body("{\"status\":\"error\", \"message\":\"" +
                     LangText.of("无权操作该会话", "You do not have permission for this conversation") + "\"}");
         }
+        // message 为空/纯空白必须在入口拒绝：一旦落库，ContextAssemblerService 回放历史时
+        // langchain4j 的 UserMessage.from(text) 会对空白文本抛异常——存量脏数据已经在
+        // ContextAssemblerService 里加了容错，但新请求应该在这里就被挡下，不该先污染会话。
+        if (request.getMessage() == null || request.getMessage().isBlank()) {
+            return ResponseEntity.status(400).body("{\"status\":\"error\", \"message\":\"" +
+                    LangText.of("消息内容不能为空", "Message cannot be empty") + "\"}");
+        }
 
         log.info("Received Agent Chat Request: project={}, conversation={}, mode={}, msg={}",
                 request.getProjectId(), request.getConversationId(), request.getAgentMode(), request.getMessage());

--- a/backend/src/main/java/com/checkba/service/ai/BackgroundTaskService.java
+++ b/backend/src/main/java/com/checkba/service/ai/BackgroundTaskService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PreDestroy;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -58,8 +59,27 @@ public class BackgroundTaskService {
                 return t;
             });
 
+    /**
+     * RUNNING 任务卡死回收的时间源。生产环境走真实系统时钟；测试用 {@link #setClock} 换成
+     * 可控时钟——不这样做的话，"注册任务后不更新、等它被判定为卡死" 这条路径没法在单测里
+     * 用秒级等待验证（真要卡死回收阈值那么久，测试根本跑不完）。
+     */
+    private volatile Clock clock = Clock.systemUTC();
+
+    /**
+     * RUNNING 状态卡死回收阈值（分钟）：超过这个时长仍未更新进度/心跳的 RUNNING 任务视为卡死。
+     * 与下面"已终态任务保留多久供前端查询"的 30 分钟数值相同但语义不同，各自命名以免以后
+     * 需要分别调整时混在一起。
+     */
+    private static final long STALE_RUNNING_TIMEOUT_MINUTES = 30;
+
     public BackgroundTaskService(SseEmitterService sseEmitterService) {
         this.sseEmitterService = sseEmitterService;
+    }
+
+    /** 供测试注入可控时钟（生产环境走真实系统时钟，见 {@link #clock} 字段注释）。 */
+    void setClock(Clock clock) {
+        this.clock = clock;
     }
 
     @PreDestroy
@@ -312,8 +332,23 @@ public class BackgroundTaskService {
      */
     @Scheduled(fixedRate = 10 * 60 * 1000)
     public void cleanupOldTasks() {
-        Instant cutoff = Instant.now().minusSeconds(30 * 60); // 30 minutes
-        
+        Instant now = Instant.now(clock);
+        Instant cutoff = now.minusSeconds(30 * 60); // 30 minutes
+        Instant staleRunningCutoff = now.minusSeconds(STALE_RUNNING_TIMEOUT_MINUTES * 60);
+
+        // 卡死的 RUNNING 任务：外部服务挂掉 / 调用方异常路径漏调 complete/failTask（PptxTools
+        // 曾经就是这样——registerTask 之后两条异常分支直接 return，从不碰 taskId），此前下面的
+        // removeIf 只认"非活跃"，RUNNING 永远 isActive()==true，三张登记表永久留着一条，
+        // hasActiveTasks 恒为 true，前端进度卡永远转下去。转终态复用 failTask 的既有语义
+        // （发 SSE 通知前端、scheduleCleanup 延迟摘除条目），不在这里另起一套清理逻辑。
+        activeTasks.forEach((taskId, task) -> {
+            if (task.isActive() && task.getLastUpdatedAt().isBefore(staleRunningCutoff)) {
+                log.warn("Reclaiming stuck RUNNING task {} (type={}, no update since {})",
+                        taskId, task.getTaskType(), task.getLastUpdatedAt());
+                failTask(taskId, "任务长时间无响应，已自动终止");
+            }
+        });
+
         activeTasks.entrySet().removeIf(entry -> {
             TaskInfo task = entry.getValue();
             if (!task.isActive() && task.getLastUpdatedAt().isBefore(cutoff)) {

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -491,10 +491,22 @@ public class ContextAssemblerService {
         // 转换为 ChatMessage 列表
         java.util.List<dev.langchain4j.data.message.ChatMessage> historyMessages = new java.util.ArrayList<>();
         for (com.checkba.model.entity.ProjectAiMessage entity : historyEntities) {
+            String content = entity.getContent();
+            if (content == null || content.isBlank()) {
+                // 容错存量脏数据：langchain4j 的 UserMessage/AiMessage.from(text) 对 null/空白
+                // 一律抛 IllegalArgumentException("text cannot be null or blank")。入口现在已经
+                // 拒绝空白 message（见 AiAgentController），但这挡不住已经落库的历史坏数据——
+                // 不跳过的话，只要该会话曾经存过一条空内容消息，此后每一轮 assemble 都会在这里
+                // 抛出异常，被兜底 catch 变成 SSE error，整个 conversationId 永久报废。
+                // 存量数据修不回来，只能在回放时跳过这一条，不能掀翻整轮上下文组装。
+                log.warn("Skipping blank history message id={} role={} in conversation={} during context assembly",
+                        entity.getId(), entity.getRole(), conversationId);
+                continue;
+            }
             if ("USER".equalsIgnoreCase(entity.getRole())) {
-                historyMessages.add(dev.langchain4j.data.message.UserMessage.from(entity.getContent()));
+                historyMessages.add(dev.langchain4j.data.message.UserMessage.from(content));
             } else if ("ASSISTANT".equalsIgnoreCase(entity.getRole())) {
-                historyMessages.add(dev.langchain4j.data.message.AiMessage.from(entity.getContent()));
+                historyMessages.add(dev.langchain4j.data.message.AiMessage.from(content));
             }
         }
         

--- a/backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java
+++ b/backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java
@@ -32,18 +32,29 @@ public class DocumentCheckpointService {
     private final StorageServiceFactory storageServiceFactory;
     private final EditorBridgeService editorBridgeService;
 
-    /** conversationId -> 本轮快照信息 */
-    private final Map<String, Checkpoint> checkpoints = new ConcurrentHashMap<>();
+    /**
+     * conversationId -> (fileId -> 本轮快照信息)。
+     *
+     * <p>此前 key 只有 conversationId、幂等判据也只看 conversationId 是否已有快照——
+     * 同一轮里 doc_open_file 切换活跃文档后（guard.activeFileId 变了），第二个文件的
+     * 修改类工具执行前 ensureCheckpoint 直接因为「本会话已有快照」短路跳过，第二个文件
+     * 从未被快照过。doc_restore_checkpoint 恢复时用的还是第一个文件的快照：覆盖 A、
+     * 对 A 发 reload，却告诉用户「已恢复，本轮所有修改已丢弃」——用户这一轮真正改的是 B，
+     * B 的修改一个都没回退，且用户会误以为已经恢复干净。
+     * 按 (conversationId, fileId) 存快照才能让同一轮里碰过的每个文件都能被独立恢复。
+     */
+    private final Map<String, Map<Long, Checkpoint>> checkpoints = new ConcurrentHashMap<>();
 
     private record Checkpoint(Long fileId, String checkpointKey, long createdAt) {}
 
     /**
-     * 为指定文件创建本轮快照（幂等：同一会话已有快照则跳过）。
+     * 为指定文件创建本轮快照（幂等：同一会话同一文件已有快照则跳过；不同文件各自独立）。
      * 任何失败只记日志、不阻断工具执行——快照是保险，不是主流程。
      */
     public void ensureCheckpoint(String conversationId, Long fileId) {
         if (conversationId == null || fileId == null) return;
-        if (checkpoints.containsKey(conversationId)) return;
+        Map<Long, Checkpoint> perFile = checkpoints.computeIfAbsent(conversationId, k -> new ConcurrentHashMap<>());
+        if (perFile.containsKey(fileId)) return;
         try {
             ProjectFile file = projectFileService.getFile(fileId);
             if (file == null || file.getFilePath() == null) return;
@@ -53,7 +64,7 @@ public class DocumentCheckpointService {
             String checkpointKey = "checkpoints/" + conversationId + "/" + fileId + "_" + System.currentTimeMillis();
             StorageService storage = storageServiceFactory.getStorageService();
             storage.save(checkpointKey, new ByteArrayInputStream(bytes));
-            checkpoints.put(conversationId, new Checkpoint(fileId, checkpointKey, System.currentTimeMillis()));
+            perFile.put(fileId, new Checkpoint(fileId, checkpointKey, System.currentTimeMillis()));
             log.info("Document checkpoint created: conv={}, fileId={}, key={}, size={}",
                     conversationId, fileId, checkpointKey, bytes.length);
         } catch (Exception e) {
@@ -62,43 +73,57 @@ public class DocumentCheckpointService {
     }
 
     /**
-     * 恢复本轮快照：把快照内容写回原文件存储路径，并通知编辑器重载。
-     * 返回给模型的结果描述。
+     * 恢复本轮快照：把本轮碰过的<b>全部</b>文件的快照内容写回原存储路径，并逐个通知编辑器重载。
+     * 返回给模型的结果描述（多文件时合并成一条，个别文件失败不影响其余文件继续恢复）。
      */
     public String restore(String conversationId) {
-        Checkpoint cp = checkpoints.get(conversationId);
-        if (cp == null) {
+        Map<Long, Checkpoint> perFile = checkpoints.get(conversationId);
+        if (perFile == null || perFile.isEmpty()) {
             return "Error: 本轮没有可恢复的文档快照（本轮尚未执行过修改类工具，或快照创建失败）。请改用 doc_undo 逐步撤销。";
         }
-        try {
-            ProjectFile file = projectFileService.getFile(cp.fileId());
-            if (file == null || file.getFilePath() == null) {
-                return "Error: 快照对应的文件已不存在。";
+        StorageService storage = storageServiceFactory.getStorageService();
+        java.util.List<String> restoredNames = new java.util.ArrayList<>();
+        java.util.List<String> failures = new java.util.ArrayList<>();
+        for (Checkpoint cp : perFile.values()) {
+            try {
+                ProjectFile file = projectFileService.getFile(cp.fileId());
+                if (file == null || file.getFilePath() == null) {
+                    failures.add("文件 " + cp.fileId() + " 已不存在");
+                    continue;
+                }
+                try (InputStream in = storage.load(cp.checkpointKey()).getInputStream()) {
+                    storage.save(file.getFilePath(), in);
+                }
+                // 通知前端编辑器重新加载该文件（丢弃编辑器内当前状态）
+                editorBridgeService.sendReloadFileAction(file);
+                restoredNames.add(file.getName());
+                log.info("Document checkpoint restored: conv={}, fileId={}, key={}",
+                        conversationId, cp.fileId(), cp.checkpointKey());
+            } catch (Exception e) {
+                log.error("Failed to restore document checkpoint for conv={}, fileId={}", conversationId, cp.fileId(), e);
+                failures.add("文件 " + cp.fileId() + " 恢复失败：" + e.getMessage());
             }
-            StorageService storage = storageServiceFactory.getStorageService();
-            try (InputStream in = storage.load(cp.checkpointKey()).getInputStream()) {
-                storage.save(file.getFilePath(), in);
-            }
-            // 通知前端编辑器重新加载该文件（丢弃编辑器内当前状态）
-            editorBridgeService.sendReloadFileAction(file);
-            log.info("Document checkpoint restored: conv={}, fileId={}, key={}",
-                    conversationId, cp.fileId(), cp.checkpointKey());
-            return String.format("已将《%s》恢复到本轮开始前的快照，编辑器正在重新加载。本轮所有修改（含修订）已丢弃，请重新规划后再操作。",
-                    file.getName());
-        } catch (Exception e) {
-            log.error("Failed to restore document checkpoint for conv={}", conversationId, e);
-            return "Error: 快照恢复失败：" + e.getMessage();
         }
+        if (restoredNames.isEmpty()) {
+            return "Error: 快照恢复失败：" + String.join("；", failures);
+        }
+        String names = restoredNames.stream()
+                .map(n -> "《" + n + "》")
+                .collect(java.util.stream.Collectors.joining("、"));
+        String failureSuffix = failures.isEmpty() ? "" : "（另有恢复失败：" + String.join("；", failures) + "）";
+        return String.format("已将%s恢复到本轮开始前的快照，编辑器正在重新加载。本轮所有修改（含修订）已丢弃，请重新规划后再操作。%s",
+                names, failureSuffix);
     }
 
     /**
-     * 新的一轮开始时清除上一轮快照（每轮一个独立检查点）。
+     * 新的一轮开始时清除上一轮快照（每轮一个独立检查点，语义不变：按 conversationId 整体清空）。
      */
     public void clearForNewRun(String conversationId) {
         checkpoints.remove(conversationId);
     }
 
     public boolean hasCheckpoint(String conversationId) {
-        return checkpoints.containsKey(conversationId);
+        Map<Long, Checkpoint> perFile = checkpoints.get(conversationId);
+        return perFile != null && !perFile.isEmpty();
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/LitigationVisualService.java
+++ b/backend/src/main/java/com/checkba/service/ai/LitigationVisualService.java
@@ -96,13 +96,19 @@ public class LitigationVisualService {
     }
 
     /**
-     * 向 pack 服务登记「随包内置资源在场」探针：广场的 packReady 与自动补下载
-     * 都靠它区分「资源真缺」与「老版本随包资源还在」。
+     * 向 pack 服务登记「随包内置资源在场」探针，并登记「pack 状态变化」回调。
+     *
+     * <p>探针供广场的 packReady 与自动补下载区分「资源真缺」与「老版本随包资源还在」；
+     * 状态变化回调解决另一个问题——{@link #resolved} 是懒加载且只算一次的缓存，用户在
+     * 广场点「安装/卸载」是不重启后端的 live 操作，此前没有任何生产调用点会碰
+     * {@link #invalidate()}，装完 pack 面板仍然显示上一次探测出的「不可用」，
+     * 只能重启后端才会生效。
      */
     @jakarta.annotation.PostConstruct
     void registerPackProbe() {
         if (packService != null) {
             packService.registerBuiltinProbe(PACK_ID, this::isEngineAvailableWithoutPack);
+            packService.onPackChanged(PACK_ID, this::invalidate);
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/PdfEditService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PdfEditService.java
@@ -81,10 +81,13 @@ public class PdfEditService {
     public static class RedactResult {
         public final int matchCount;
         public final List<Integer> rasterizedPages;
+        /** 传入但在文档里一个匹配都没找到的文本（常见于 AI 猜错人名/证件号）；空列表 = 全部命中。 */
+        public final List<String> missing;
 
-        RedactResult(int matchCount, List<Integer> rasterizedPages) {
+        RedactResult(int matchCount, List<Integer> rasterizedPages, List<String> missing) {
             this.matchCount = matchCount;
             this.rasterizedPages = rasterizedPages;
+            this.missing = missing;
         }
     }
 
@@ -335,12 +338,13 @@ public class PdfEditService {
 
             doc.save(pdfPath.toFile());
             List<Integer> pages = new ArrayList<>(affected);
-            if (!missing.isEmpty()) {
-                throw new PdfEditException(String.format(
-                        "部分完成：%d 处已脱敏（第 %s 页已转为图片页），但以下文本未找到: %s",
-                        all.size(), pages, missing));
-            }
-            return new RedactResult(all.size(), pages);
+            // 部分命中不算失败：上面这行 doc.save 已经把打码+光栅化后的字节不可逆地写回了
+            // pdfPath——磁盘已经变了。此前这里在写盘之后才抛异常，调用方 PdfTools.pdf_redact
+            // 的 finishModification（轮换 wpsFileId、更新 fileSize/updatedAt、发 reload）
+            // 被异常跳过，磁盘已改、DB 与预览还停在旧版本，两者从此不一致。
+            // 缺失目标（常见于 AI 猜错人名/证件号）如实带回 missing 字段，让调用方据此照实
+            // 报告，而不是把一次真实生效的脱敏说成一次失败。
+            return new RedactResult(all.size(), pages, missing);
         } catch (IOException e) {
             throw new PdfEditException("脱敏失败: " + e.getMessage());
         }

--- a/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
@@ -240,13 +240,7 @@ public class PluginMarketService {
             File target = new File(pluginsDir, id);
             FileUtil.del(target);
             Files.createDirectories(target.toPath().getParent());
-            try {
-                Files.move(staging, target.toPath(), StandardCopyOption.ATOMIC_MOVE);
-            } catch (Exception atomicFailed) {
-                // 跨文件系统时原子移动不可用，退化为拷贝
-                FileUtil.copyContent(staging.toFile(), target, true);
-                FileUtil.del(staging.toFile());
-            }
+            moveStagingToTarget(staging, target);
         } catch (RuntimeException e) {
             FileUtil.del(staging.toFile());
             throw e;
@@ -261,6 +255,32 @@ public class PluginMarketService {
         log.info("Installed market plugin '{}' v{} (disabled until user confirms)", id, version);
         installDeclaredPacks(id);
         return id;
+    }
+
+    /**
+     * 把校验通过的 staging 目录整体落到插件目录：优先原子 move，跨文件系统时退化为拷贝。
+     *
+     * <p>抽成独立方法只为了可测——install() 本身要走网络下载与验签，太重，不好在单测里
+     * 单独触发"拷贝兜底也失败"这条分支。
+     *
+     * <p>不变式：任一步失败都不留半成品。拷贝兜底失败时 target 可能已经是半成品（拷贝到
+     * 一半就断了），必须把它一并清掉再把异常抛给调用方——调用方（install()）只清理
+     * staging，且这条异常在 markDisabledBeforeLoad/rescan 之前抛出，PluginService
+     * 账上根本没有这个插件 id，残缺目录不清掉就会永久留在盘上、谁也不认领。
+     */
+    void moveStagingToTarget(Path staging, File target) throws java.io.IOException {
+        try {
+            Files.move(staging, target.toPath(), StandardCopyOption.ATOMIC_MOVE);
+        } catch (Exception atomicFailed) {
+            // 跨文件系统时原子移动不可用，退化为拷贝
+            try {
+                FileUtil.copyContent(staging.toFile(), target, true);
+            } catch (Exception copyFailed) {
+                FileUtil.del(target);
+                throw copyFailed;
+            }
+            FileUtil.del(staging.toFile());
+        }
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -80,11 +80,27 @@ public class PluginService {
 
     private final String pluginsDir;
 
+    /**
+     * 反向依赖 ToolRegistry，仅用于 rescan() 后使其插件工具缓存失效（见该字段注入点注释）。
+     * 字段注入 + {@code required=false}：ToolRegistry 的构造器已经依赖 PluginService，
+     * 若在这里改成构造器注入会形成启动死环（本仓 SubAgentTools 也用同一招 @Lazy 破环）；
+     * required=false 使大量 {@code new PluginService(...)} 直接构造的既有测试不受影响
+     * ——字段停留 null，rescan() 对 null 判空跳过即可，测试无需关心这层缓存失效。
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    @org.springframework.context.annotation.Lazy
+    private ToolRegistry toolRegistry;
+
     @org.springframework.beans.factory.annotation.Autowired
     public PluginService(SystemSettingService systemSettingService,
                          @Value("${ai.plugins.dir:plugins}") String pluginsDir) {
         this.systemSettingService = systemSettingService;
         this.pluginsDir = pluginsDir;
+    }
+
+    /** 供测试直接装配 ToolRegistry（生产环境由 Spring 按上面的 @Autowired 字段注入）。 */
+    void setToolRegistry(ToolRegistry toolRegistry) {
+        this.toolRegistry = toolRegistry;
     }
 
     /** 兼容构造器：仅供既有单测直接 new 使用（无持久化，启停状态只存内存） */
@@ -159,6 +175,11 @@ public class PluginService {
         pluginDirById.clear();
         loadDisabledState();
         loadPlugins();
+        // 插件更新/卸载后 loadPlugins() 可能已经把同名工具换成了新 bean，
+        // 必须让 ToolRegistry 那层懒加载缓存失效，否则旧 bean 会继续被分发执行。
+        if (toolRegistry != null) {
+            toolRegistry.invalidatePluginToolCache();
+        }
         log.info("Plugin rescan done: {} plugins, {} tools", plugins.size(), pluginTools.size());
     }
 
@@ -528,7 +549,16 @@ public class PluginService {
                         pluginId, jarName);
                 return null;
             }
-            return jarFile.isFile() ? jarFile : null;
+            if (!jarFile.isFile()) {
+                // manifest 声明了 backendJars 但文件不在——解压不全/被手删/打包漏了都会走到这里。
+                // 此前这条路径不打任何日志，调用方 `if (jarFile != null) loadJar(...)` 又没有
+                // else 分支：插件照常出现在列表里、启停可用，就是 0 个工具，日志里搜插件 id
+                // 与 jar 名全是空，排障无从下手。
+                log.warn("Plugin {} declares backendJar '{}' but file does not exist: {}",
+                        pluginId, jarName, jarFile);
+                return null;
+            }
+            return jarFile;
         } catch (IOException e) {
             log.error("Plugin {} backendJar '{}' path check failed: {}", pluginId, jarName, e.getMessage());
             return null;

--- a/backend/src/main/java/com/checkba/service/ai/PptxServiceClient.java
+++ b/backend/src/main/java/com/checkba/service/ai/PptxServiceClient.java
@@ -44,6 +44,16 @@ public class PptxServiceClient {
     @Value("${external.pptx-service.timeout:120}")
     private int timeoutSeconds;
 
+    /** 供测试把 baseUrl 指向本地 stub HTTP server（生产环境走上面的 @Value 注入）。 */
+    void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    /** 供测试设置超时（默认构造不经 Spring @Value 注入时 timeoutSeconds 恒为 0）。 */
+    void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
     private static final int POLL_INTERVAL_MS = 2000; // 轮询间隔 2 秒
     private static final int MAX_POLL_ATTEMPTS = 300;  // 最大轮询次数 (10 分钟)
 
@@ -245,12 +255,30 @@ public class PptxServiceClient {
         return JSONUtil.parseObj(resp.body()).getJSONObject("data");
     }
 
+    /** waitForTask* 系列的 status 是否为 FAILED（区别于「无结构化信息」的 null）。 */
+    private static boolean isTaskFailed(JSONObject status) {
+        return status != null && "FAILED".equals(status.getStr("status"));
+    }
+
+    /**
+     * 从一次 waitForTask* 的返回中提取可读的失败原因。status 为 null（轮询被中断/超时/
+     * COMPLETED 但零成功项）时没有结构化信息可给，返回 null；FAILED 时取 error_message，
+     * 缺失或空白同样返回 null——调用方据此决定要不要在拼出的错误文案里附上详情。
+     */
+    private static String taskFailureDetail(JSONObject status) {
+        if (status == null) return null;
+        String error = status.getStr("error_message");
+        return (error != null && !error.isBlank()) ? error : null;
+    }
+
     /**
      * 等待任务完成
-     * 
+     *
      * @param projectId 项目 ID
      * @param taskId 任务 ID
-     * @return 任务最终状态对象 (JSON)，如果失败或超时返回 null
+     * @return 任务最终状态对象 (JSON)；成功或 FAILED（带 error_message，供调用方读出真实失败
+     *         原因）都会返回该对象；轮询被中断/超时/COMPLETED 但零成功项这类无结构化信息可给的
+     *         情形仍返回 null，调用方需用 {@link #isTaskFailed(JSONObject)} 判定失败态。
      */
     public JSONObject waitForTask(String projectId, String taskId) {
         log.info("Waiting for task {} to complete...", taskId);
@@ -287,9 +315,13 @@ public class PptxServiceClient {
             } else if ("FAILED".equals(taskStatus)) {
                 String error = status.getStr("error_message");
                 log.error("Task {} failed: {}", taskId, error);
-                return null;
+                // 此前这里返回 null，error_message 只进日志——调用方拿到 null 就只能硬编码
+                // "Description generation failed" / "Image generation failed" 这类通用文案，
+                // "api key 无效" "配额用尽" "模型 id 写错" 在用户眼里全长一个样，无从自救。
+                // 返回 status（带着 error_message）而不是 null，让调用方能把真实原因拼进去。
+                return status;
             }
-            
+
             // 打印进度
             JSONObject progress = status.getJSONObject("progress");
             if (progress != null) {
@@ -351,20 +383,41 @@ public class PptxServiceClient {
         if (resp.getStatus() != 200) {
             throw new RuntimeException("Failed to download PPTX: HTTP " + resp.getStatus());
         }
-        
+
+        byte[] bytes = resp.bodyBytes();
+        // 只校验 HTTP 200 远远不够：pptx-service 偶发返回空 body 或一段 JSON 错误信息，
+        // 此前这里无条件写盘、无条件返回成功路径——上游据此 setSuccess(true)，PptxTools
+        // 把可能是 0 字节甚至根本不是 PPTX 的文件注册进项目文件库，回给用户"PPTX 生成成功！"，
+        // 全链路没有一处会发现文件是空的。PPTX 是 ZIP 容器，魔数恒为 PK\x03\x04，一并校验。
+        if (bytes == null || bytes.length == 0) {
+            throw new RuntimeException("Failed to download PPTX: empty response body");
+        }
+        if (!isPptxMagic(bytes)) {
+            throw new RuntimeException("Failed to download PPTX: response is not a valid PPTX file (bad magic number)");
+        }
+
         try {
             Path path = Paths.get(localPath);
             Files.createDirectories(path.getParent());
-            
+
             try (FileOutputStream fos = new FileOutputStream(localPath)) {
-                fos.write(resp.bodyBytes());
+                fos.write(bytes);
             }
-            
+
             log.info("PPTX downloaded to: {}", localPath);
             return localPath;
         } catch (Exception e) {
             throw new RuntimeException("Failed to save PPTX: " + e.getMessage(), e);
         }
+    }
+
+    /** PPTX（Office Open XML）本质是 ZIP 容器，前 4 字节魔数恒为 PK\x03\x04。 */
+    private static boolean isPptxMagic(byte[] bytes) {
+        return bytes.length >= 4
+                && bytes[0] == 0x50 // 'P'
+                && bytes[1] == 0x4B // 'K'
+                && bytes[2] == 0x03
+                && bytes[3] == 0x04;
     }
 
     /**
@@ -435,18 +488,20 @@ public class PptxServiceClient {
             // 3. 生成描述（传递模型配置）
             String descTaskId = startGenerateDescriptions(projectId, language, modelConfig);
             JSONObject descTaskResult = waitForTask(projectId, descTaskId);
-            if (descTaskResult == null) {
+            if (descTaskResult == null || isTaskFailed(descTaskResult)) {
                 result.setSuccess(false);
-                result.setError("Description generation failed");
+                String detail = taskFailureDetail(descTaskResult);
+                result.setError(detail != null ? "Description generation failed: " + detail : "Description generation failed");
                 return result;
             }
-            
+
             // 4. 生成图片（传递模型配置）
             String imgTaskId = startGenerateImages(projectId, language, templateStyle, modelConfig);
             JSONObject imgTaskResult = waitForTask(projectId, imgTaskId);
-            if (imgTaskResult == null) {
+            if (imgTaskResult == null || isTaskFailed(imgTaskResult)) {
                 result.setSuccess(false);
-                result.setError("Image generation failed");
+                String detail = taskFailureDetail(imgTaskResult);
+                result.setError(detail != null ? "Image generation failed: " + detail : "Image generation failed");
                 return result;
             }
             
@@ -472,8 +527,8 @@ public class PptxServiceClient {
                 try {
                     String editableTaskId = startExportEditable(projectId, filename, modelConfig);
                     JSONObject editableTaskResult = waitForTask(projectId, editableTaskId);
-                    
-                    if (editableTaskResult != null) {
+
+                    if (editableTaskResult != null && !isTaskFailed(editableTaskResult)) {
                         JSONObject editableProgress = editableTaskResult.getJSONObject("progress");
                         if (editableProgress != null) {
                             downloadUrl = editableProgress.getStr("download_url");
@@ -490,8 +545,12 @@ public class PptxServiceClient {
                             result.setEditable(false);
                         }
                     } else {
-                        // 可编辑导出失败，回退到纯图片版本
-                        log.warn("Editable export failed, falling back to image-only export");
+                        // 可编辑导出失败，回退到纯图片版本（这是软失败，不设 result.setError——
+                        // 整体仍按纯图片版本成功收尾；detail 非空时把真实原因写进日志，方便排查
+                        // 为什么好端端的可编辑版本又回退了，而不是让用户和支持一起去猜）
+                        String detail = taskFailureDetail(editableTaskResult);
+                        log.warn("Editable export failed{}, falling back to image-only export",
+                                detail != null ? ": " + detail : "");
                         downloadUrl = exportPptx(projectId, filename);
                         result.setEditable(false);
                     }
@@ -594,24 +653,26 @@ public class PptxServiceClient {
             JSONObject descTaskResult = waitForTaskWithProgress(projectId, descTaskId, 10, 25, 
                     "generating_descriptions",
                     LangText.of("正在生成页面描述", "Generating page descriptions"), progressCallback);
-            if (descTaskResult == null) {
+            if (descTaskResult == null || isTaskFailed(descTaskResult)) {
                 result.setSuccess(false);
-                result.setError("Description generation failed");
+                String detail = taskFailureDetail(descTaskResult);
+                result.setError(detail != null ? "Description generation failed: " + detail : "Description generation failed");
                 return result;
             }
             reportProgress.accept(25, new String[]{"generating_descriptions",
                     LangText.of("页面描述生成完成", "Page descriptions generated")});
-            
+
             // 4. 生成图片 (25% -> 70%)
             reportProgress.accept(27, new String[]{"generating_images",
                     LangText.of("正在生成幻灯片图片...", "Generating slide images...")});
             String imgTaskId = startGenerateImages(projectId, language, templateStyle, modelConfig);
-            JSONObject imgTaskResult = waitForTaskWithProgress(projectId, imgTaskId, 25, 70, 
+            JSONObject imgTaskResult = waitForTaskWithProgress(projectId, imgTaskId, 25, 70,
                     "generating_images",
                     LangText.of("正在生成幻灯片图片", "Generating slide images"), progressCallback);
-            if (imgTaskResult == null) {
+            if (imgTaskResult == null || isTaskFailed(imgTaskResult)) {
                 result.setSuccess(false);
-                result.setError("Image generation failed");
+                String detail = taskFailureDetail(imgTaskResult);
+                result.setError(detail != null ? "Image generation failed: " + detail : "Image generation failed");
                 return result;
             }
             
@@ -643,7 +704,7 @@ public class PptxServiceClient {
                             "exporting_pptx",
                             LangText.of("正在导出可编辑版本", "Exporting the editable version"), progressCallback);
                     
-                    if (editableTaskResult != null) {
+                    if (editableTaskResult != null && !isTaskFailed(editableTaskResult)) {
                         JSONObject editableProgress = editableTaskResult.getJSONObject("progress");
                         if (editableProgress != null) {
                             downloadUrl = editableProgress.getStr("download_url");
@@ -658,7 +719,9 @@ public class PptxServiceClient {
                             result.setEditable(false);
                         }
                     } else {
-                        log.warn("Editable export failed, falling back to image-only export");
+                        String detail = taskFailureDetail(editableTaskResult);
+                        log.warn("Editable export failed{}, falling back to image-only export",
+                                detail != null ? ": " + detail : "");
                         downloadUrl = exportPptx(projectId, filename);
                         result.setEditable(false);
                     }
@@ -708,9 +771,10 @@ public class PptxServiceClient {
      * @param stage 阶段标识
      * @param baseMessage 基础消息
      * @param progressCallback 进度回调（可选）
-     * @return 任务最终状态
+     * @return 任务最终状态；成功或 FAILED（带 error_message）都返回该对象，
+     *         语义同 {@link #waitForTask(String, String)}
      */
-    private JSONObject waitForTaskWithProgress(String projectId, String taskId, 
+    private JSONObject waitForTaskWithProgress(String projectId, String taskId,
                                                 int startProgress, int endProgress,
                                                 String stage, String baseMessage,
                                                 ProgressCallback progressCallback) {
@@ -760,7 +824,8 @@ public class PptxServiceClient {
             } else if ("FAILED".equals(taskStatus)) {
                 String error = status.getStr("error_message");
                 log.error("Task {} failed: {}", taskId, error);
-                return null;
+                // 同 waitForTask：返回 status 而不是 null，让调用方能读到 error_message
+                return status;
             }
         }
         

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -233,6 +233,25 @@ public class ToolRegistry {
     }
 
     /**
+     * 使插件工具缓存失效：插件重扫/在线安装/卸载后，旧 JAR 加载出的 bean 不应再被分发。
+     *
+     * pluginToolCache 只是 resolve() 的懒加载优化层（省掉每次调用都做的反射方法扫描），
+     * pluginService.getPluginTools() 才是事实来源。插件更新后 PluginService.rescan() 会
+     * 用新 URLClassLoader 加载出全新的 bean 实例覆盖同名 key，但此前 pluginToolCache 里
+     * 一旦缓存过就永不过期——resolve() 命中缓存直接返回，永远看不到新 bean，用户在广场点
+     * 「更新/卸载」后 AI 调的还是旧版本的工具，全程零报错。
+     *
+     * 清空后不会立即重新扫描：下一次 resolve() 撞 miss 时按现有懒加载路径重新解析并回填。
+     */
+    public void invalidatePluginToolCache() {
+        int size = pluginToolCache.size();
+        pluginToolCache.clear();
+        if (size > 0) {
+            log.info("Plugin tool cache invalidated: {} cached entries cleared", size);
+        }
+    }
+
+    /**
      * 已注册工具名，按长度降序（供 XML 协议解析做最长名优先匹配，
      * 避免 pptx_generate 误匹配 pptx_generate_outline 的调用）。
      */

--- a/backend/src/main/java/com/checkba/service/ai/tools/PdfTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PdfTools.java
@@ -172,8 +172,12 @@ public class PdfTools implements AgentToolComponent {
             Path localPath = resolveExisting(file);
             PdfEditService.RedactResult result = pdfEditService.redact(localPath, texts, pageIndex);
             finishModification(file, localPath);
-            return String.format("脱敏完成：共 %d 处，涉及页面 %s（这些页已转为图片页，文字层已彻底移除，其余页不受影响）。预览将自动刷新。",
-                    result.matchCount, result.rasterizedPages);
+            // 部分命中不算失败：已经真实生效的脱敏必须走 finishModification（否则磁盘已改、
+            // DB 与预览还停在旧版本），缺失目标如实报告，别把已经生效的操作说成失败。
+            String missingNote = result.missing.isEmpty() ? ""
+                    : String.format("；以下文本未找到，未被脱敏（请核对原文是否逐字一致）: %s", result.missing);
+            return String.format("脱敏完成：共 %d 处，涉及页面 %s（这些页已转为图片页，文字层已彻底移除，其余页不受影响）。预览将自动刷新。%s",
+                    result.matchCount, result.rasterizedPages, missingNote);
         } catch (Exception e) {
             return errorOf("脱敏失败", e);
         }

--- a/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PptxTools.java
@@ -303,7 +303,11 @@ public class PptxTools implements AgentToolComponent {
                                           String modelId, String conversationId, Long userId,
                                           boolean exportEditable) {
         log.info("Info: pptx_generate_internal start, topic={}, editable={}", topic, exportEditable);
-        
+
+        // 提到外层 try 之外声明：下面两条异常路径（DB 注册失败的内层 catch、方法级的外层 catch）
+        // 都要在失败时把这个任务标成 failTask，否则 registerTask 登记的这条 RUNNING 永远留在
+        // BackgroundTaskService 的三张表里——hasActiveTasks 恒为 true，前端进度卡永远转下去。
+        String taskId = null;
         try {
             // 检查服务
             if (!pptxServiceClient.isHealthy()) {
@@ -352,8 +356,7 @@ public class PptxTools implements AgentToolComponent {
             log.info("Starting PPTX generation to: {}, using model: {}, exportEditable: {}", localPath, modelId, exportEditable);
             PptxServiceClient.PptxGenerationResult result;
             
-            // 如果有 conversationId，使用带进度回调的版本
-            String taskId = null;
+            // 如果有 conversationId，使用带进度回调的版本（taskId 已提到外层 try 之外声明）
             if (conversationId != null && userId != null) {
                 // 注册后台任务
                 taskId = backgroundTaskService.registerTask(
@@ -457,8 +460,12 @@ public class PptxTools implements AgentToolComponent {
                 return successMsg.toString();
                 
             } catch (Exception e) {
-                // 文件已生成但注册失败
+                // 文件已生成但注册失败：任务对用户而言并未真正完成（文件不在项目文件树里可用），
+                // 之前这里直接 return，taskId 那条 RUNNING 记录永远留在 BackgroundTaskService 里。
                 log.warn("PPTX file created but DB registration failed", e);
+                if (taskId != null) {
+                    backgroundTaskService.failTask(taskId, "PPTX 已生成但注册到数据库失败: " + e.getMessage());
+                }
                 return String.format(
                         "PPTX 已生成但注册到数据库失败。\n" +
                         "- 文件名: %s\n" +
@@ -468,9 +475,15 @@ public class PptxTools implements AgentToolComponent {
                         finalFileName, result.getPagesCount(), localPath.toString(), e.getMessage()
                 );
             }
-            
+
         } catch (Exception e) {
+            // 同上：这条外层 catch 覆盖服务不可用/网络失败等更早期的异常，taskId 若已注册
+            // 同样必须标失败，否则这条 RUNNING 记录永远回收不了（本条是 dev-board#74 的触发场景：
+            // AI 调 pptx_generate、pptx-service 网络失败）。
             log.error("PPTX generation failed", e);
+            if (taskId != null) {
+                backgroundTaskService.failTask(taskId, e.getMessage());
+            }
             return "PPTX 生成过程中出错: " + e.getMessage();
         }
     }

--- a/backend/src/main/java/com/checkba/service/pack/NativePackService.java
+++ b/backend/src/main/java/com/checkba/service/pack/NativePackService.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BooleanSupplier;
@@ -131,6 +132,39 @@ public class NativePackService {
      * （规范 §5 的解析优先级「随包优先于 pack」）。
      */
     private final Map<String, BooleanSupplier> builtinProbes = new ConcurrentHashMap<>();
+
+    /**
+     * pack 状态变化（安装成功 / 卸载 / 被平台封禁）的回调：packId -> 监听器列表。
+     *
+     * <p>存在的理由：资源消费方（如 {@link com.checkba.service.ai.LitigationVisualService}）
+     * 常常把「运行时解析结果」缓存起来避免重复探测，但那份缓存只在进程刚启动、pack 还没装
+     * 时探测过一次就再也不会变——用户装完 pack 不重启后端，缓存的「不可用」会一直显示下去。
+     * 与上面的 builtinProbes 同一套设计原则：本服务不反向依赖具体消费方，由消费方自己在
+     * {@code @PostConstruct} 里登记回调，本服务只管在状态变化时机触发。
+     */
+    private final Map<String, List<Runnable>> changeListeners = new ConcurrentHashMap<>();
+
+    /**
+     * 登记 pack 状态变化回调（安装成功 / 卸载 / 被平台封禁时触发）。
+     * 供资源消费方失效自己的解析缓存，见 {@link #changeListeners} 字段说明。
+     */
+    public void onPackChanged(String packId, Runnable listener) {
+        if (packId != null && listener != null) {
+            changeListeners.computeIfAbsent(packId, k -> new CopyOnWriteArrayList<>()).add(listener);
+        }
+    }
+
+    private void notifyPackChanged(String packId) {
+        List<Runnable> listeners = changeListeners.get(packId);
+        if (listeners == null) return;
+        for (Runnable listener : listeners) {
+            try {
+                listener.run();
+            } catch (Exception e) {
+                log.warn("Pack change listener for {} failed: {}", packId, e.getMessage());
+            }
+        }
+    }
 
     private volatile HttpClient httpClient;
 
@@ -328,6 +362,9 @@ public class NativePackService {
             String version = doInstall(packId, st);
             st.setState(STATE_READY);
             st.setInstalledVersion(version);
+            // 装完让资源消费方的运行时解析缓存失效——不然用户装完 pack 不重启后端，
+            // 面板/工具仍然显示上一次探测出的「不可用」。
+            notifyPackChanged(packId);
             return version;
         } catch (RuntimeException e) {
             // 因封禁被拒不是「安装失败」：状态要如实停在 revoked，否则广场把平台封禁
@@ -483,6 +520,8 @@ public class NativePackService {
         statuses.remove(packId);
         manifestCache.remove(packId);
         log.info("Uninstalled native pack {}", packId);
+        // 卸载同理要让缓存失效——否则面板/工具会照着卸载前的探测结果继续显示可用。
+        notifyPackChanged(packId);
     }
 
     // ==================== 下载 ====================
@@ -885,6 +924,8 @@ public class NativePackService {
             statuses.remove(r.id());
             hit.add(r.id());
             log.warn("Native pack {} v{} revoked by platform: {}", r.id(), installed, r.reason());
+            // 封禁同样是「资源解析结果变了」，消费方缓存的可用性判定要跟着刷新
+            notifyPackChanged(r.id());
         }
         return hit;
     }

--- a/backend/src/test/java/com/checkba/controller/ai/AiAgentControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/AiAgentControllerTest.java
@@ -46,6 +46,7 @@ class AiAgentControllerTest {
     private SubAgentService subAgentService;
     private PptxTools pptxTools;
     private ProjectMemberService projectMemberService;
+    private AgentOrchestrator agentOrchestrator;
     private AiAgentController controller;
 
     @BeforeEach
@@ -55,9 +56,10 @@ class AiAgentControllerTest {
         subAgentService = mock(SubAgentService.class);
         pptxTools = mock(PptxTools.class);
         projectMemberService = mock(ProjectMemberService.class);
+        agentOrchestrator = mock(AgentOrchestrator.class);
         controller = new AiAgentController(
                 mock(SseEmitterService.class),
-                mock(AgentOrchestrator.class),
+                agentOrchestrator,
                 messageService,
                 backgroundTaskService,
                 pptxTools,
@@ -182,6 +184,52 @@ class AiAgentControllerTest {
             verify(messageService, timeout(5000)).saveMessage(eq("42"), eq(7L), eq("conv-1"),
                     eq("ASSISTANT"), eq(toolOutput), display.capture());
             assertEquals("PPTX 生成失败: pptx-service 返回 500", display.getValue());
+        }
+    }
+
+    /**
+     * 修既存缺陷：message="" 能过 POST /chat 落库，此后 ContextAssemblerService 每次回放历史
+     * 都会在这条空内容消息上抛 langchain4j 的 IllegalArgumentException，该 conversationId
+     * 永久报废、用户只能新建会话。入口必须在污染会话之前挡下空白 message。
+     */
+    @Test
+    @DisplayName("空白 message 在入口被拒绝（400），不落任何库、不起任何轮次")
+    void blankMessageRejectedBeforeOrchestration() {
+        AiAgentController.AgentChatRequest req = new AiAgentController.AgentChatRequest();
+        req.setProjectId(42L);
+        req.setConversationId("conv-1");
+        req.setMessage("   "); // 纯空白，trim 后为空
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(7L);
+            when(projectMemberService.hasReadPermission(42L, 7L)).thenReturn(true);
+            when(messageService.canUseConversation("conv-1", 7L)).thenReturn(true);
+
+            ResponseEntity<?> resp = controller.startSession(req, "s");
+
+            assertEquals(400, resp.getStatusCode().value());
+            assertTrue(String.valueOf(resp.getBody()).contains("消息内容不能为空"), String.valueOf(resp.getBody()));
+            verify(agentOrchestrator, never()).handleUserMessage(any(), any());
+        }
+    }
+
+    @Test
+    @DisplayName("null message 同样在入口被拒绝（400）")
+    void nullMessageRejectedBeforeOrchestration() {
+        AiAgentController.AgentChatRequest req = new AiAgentController.AgentChatRequest();
+        req.setProjectId(42L);
+        req.setConversationId("conv-1");
+        // message 未设置，保持 null
+
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("s")).thenReturn(7L);
+            when(projectMemberService.hasReadPermission(42L, 7L)).thenReturn(true);
+            when(messageService.canUseConversation("conv-1", 7L)).thenReturn(true);
+
+            ResponseEntity<?> resp = controller.startSession(req, "s");
+
+            assertEquals(400, resp.getStatusCode().value());
+            verify(agentOrchestrator, never()).handleUserMessage(any(), any());
         }
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/BackgroundTaskServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/BackgroundTaskServiceTest.java
@@ -4,6 +4,7 @@ import com.checkba.model.ai.TaskInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -69,5 +70,46 @@ class BackgroundTaskServiceTest {
         assertFalse(service.cancelTask(taskId, null));
         assertTrue(service.cancelTask(taskId, "conv-1"));
         assertFalse(service.cancelTask(taskId, "conv-1"), "已取消的任务不能再取消一次");
+    }
+
+    // ==== 卡死 RUNNING 任务的兜底回收 ====
+    // 背景：cleanupOldTasks 此前的 removeIf 条件是 !task.isActive()，RUNNING 永远
+    // isActive()==true 故永不回收。触发场景：AI 调 pptx_generate，pptx-service 网络失败，
+    // PptxTools 里 registerTask 之后的异常路径直接 return 不碰 taskId——三张登记表永久留一条
+    // RUNNING，hasActiveTasks 恒为 true，前端进度卡永远转下去。
+
+    @Test
+    @DisplayName("修复：卡死超过阈值的 RUNNING 任务被 cleanupOldTasks 强制终态化并广播")
+    void reclaimsStuckRunningTaskAfterTimeout() {
+        String taskId = service.registerTask("conv-1", 7L, TaskInfo.TaskType.PPTX_GENERATE, 900);
+        assertTrue(service.hasActiveTasks("conv-1"));
+
+        // 模拟卡死：既不 complete 也不 fail，只把服务内部的时间源推进到远超回收阈值
+        // （registerTask 落的 startedAt/lastUpdatedAt 用的是真实系统时钟，早于推进后的"现在"）
+        service.setClock(java.time.Clock.offset(java.time.Clock.systemUTC(), java.time.Duration.ofHours(2)));
+
+        service.cleanupOldTasks();
+
+        assertFalse(service.hasActiveTasks("conv-1"), "卡死超过阈值的 RUNNING 任务应被回收，不再计入活跃任务");
+
+        // 用 SSE 广播的载荷断言终态是 FAILED，而不是读 getTask(taskId) 之后的状态——
+        // 注入的时钟被推远到 2 小时后，failTask 内部用真实 Instant.now() 落的 lastUpdatedAt
+        // 相对推远后的"现在"也早已超过下面清理已终态任务的 30 分钟保留期，条目可能在同一次
+        // cleanupOldTasks 调用里被连带摘除；广播内容才是不依赖这个时序细节的稳定断言点。
+        ArgumentCaptor<String> payload = ArgumentCaptor.forClass(String.class);
+        verify(sse).send(eq("conv-1"), eq("background_task_complete"), payload.capture());
+        assertTrue(payload.getValue().contains("\"FAILED\""),
+                "应以失败终态广播通知前端，而不是让进度卡无声挂起：" + payload.getValue());
+    }
+
+    @Test
+    @DisplayName("未超阈值的 RUNNING 任务不受影响：cleanupOldTasks 不会误杀正常在跑的任务")
+    void doesNotReclaimFreshRunningTask() {
+        String taskId = service.registerTask("conv-1", 7L, TaskInfo.TaskType.PPTX_GENERATE, 900);
+
+        service.cleanupOldTasks();
+
+        assertTrue(service.hasActiveTasks("conv-1"), "刚注册、未超时的任务不应被误杀");
+        assertEquals(TaskInfo.TaskStatus.RUNNING, service.getTask(taskId).getStatus());
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -524,6 +525,44 @@ class ContextAssemblerServiceTest {
 
         assertTrue(systemText.contains("SIMPLIFIED CHINESE ONLY"), "中文模式 Language 行不变");
         assertFalse(systemText.contains("ENGLISH ONLY"), "中文模式不应出现英文 Language 行");
+    }
+
+    // ==== 历史回放容错：一条空白 content 的历史消息不许掀翻整轮 assemble ====
+    // 背景：POST /chat 此前没挡住 message="" 落库；ContextAssemblerService 回放历史时
+    // langchain4j 的 UserMessage.from(text) 对空白文本一律抛 IllegalArgumentException，
+    // 存量脏数据一旦落库，该 conversationId 此后每一轮都会在这里抛异常、永久报废。
+
+    @Test
+    @DisplayName("修复：历史里一条空白 content 的消息被跳过，不再让整轮 assemble 抛异常")
+    void blankHistoryMessageIsSkippedNotThrown() {
+        com.checkba.model.entity.ProjectAiMessage blank = new com.checkba.model.entity.ProjectAiMessage();
+        blank.setId(1L);
+        blank.setRole("USER");
+        blank.setContent(""); // 存量脏数据：曾经落库的空白 message
+
+        com.checkba.model.entity.ProjectAiMessage ok = new com.checkba.model.entity.ProjectAiMessage();
+        ok.setId(2L);
+        ok.setRole("USER");
+        ok.setContent("这是一条正常的历史消息");
+
+        ProjectAiMessageService msgSvc = mock(ProjectAiMessageService.class);
+        when(msgSvc.listByConversationId("conv-1")).thenReturn(List.of(blank, ok));
+
+        ContextAssemblerService withBlankHistory = new ContextAssemblerService(
+                legalTools, msgSvc, mock(FileContextLoader.class),
+                new AiContextProperties(), mockedSkillRouter(), new ClientCapabilityService(),
+                new InlineContentCache(), mockedMemoryManager(), mockedCompressor(),
+                mock(com.checkba.service.AppLanguageService.class));
+
+        List<ChatMessage> messages = assertDoesNotThrow(() -> withBlankHistory.assemble(
+                "conv-1", "帮我修订一下", null, null, null, null, "88", AgentMode.AGENT, 1L, null),
+                "空白历史消息不应掀翻整轮上下文组装");
+
+        boolean hasValidHistoryText = messages.stream()
+                .filter(m -> m instanceof dev.langchain4j.data.message.UserMessage)
+                .map(m -> ((dev.langchain4j.data.message.UserMessage) m).singleText())
+                .anyMatch("这是一条正常的历史消息"::equals);
+        assertTrue(hasValidHistoryText, "跳过坏数据的同时，同一批次里有效的历史消息应正常保留");
     }
 
     // ---- 供自建 assembler 的 mock 工厂（与 setUp 同配方）----

--- a/backend/src/test/java/com/checkba/service/ai/DocumentCheckpointServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/DocumentCheckpointServiceTest.java
@@ -1,0 +1,130 @@
+package com.checkba.service.ai;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.ProjectFileService;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 文档检查点按 (conversationId, fileId) 存的修复。
+ *
+ * 背景：此前 key 只有 conversationId，幂等判据 `checkpoints.containsKey(conversationId)`
+ * 完全不看 fileId。同一轮里 doc_open_file 切换活跃文档后，第二个文件的第一次修改类工具
+ * 执行前 ensureCheckpoint 会因为"本会话已有快照"直接跳过——第二个文件从未被快照。
+ * restore() 用的是第一个文件的快照：覆盖 A、对 A 发 reload，却告诉用户"本轮所有修改已丢弃"
+ * ——用户这一轮真正改的是 B，B 的修改一个都没回退。
+ */
+class DocumentCheckpointServiceTest {
+
+    private ProjectFileService projectFileService;
+    private StorageService storage;
+    private EditorBridgeService editorBridgeService;
+    private DocumentCheckpointService service;
+
+    private ProjectFile fileOf(Long id, String name, String path) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setName(name);
+        f.setFilePath(path);
+        return f;
+    }
+
+    @BeforeEach
+    void setUp() {
+        projectFileService = mock(ProjectFileService.class);
+        StorageServiceFactory storageServiceFactory = mock(StorageServiceFactory.class);
+        storage = mock(StorageService.class);
+        when(storageServiceFactory.getStorageService()).thenReturn(storage);
+        editorBridgeService = mock(EditorBridgeService.class);
+        service = new DocumentCheckpointService(projectFileService, storageServiceFactory, editorBridgeService);
+    }
+
+    @Test
+    @DisplayName("修复：同一轮里两个不同文件各自建快照，不会因为「本会话已有快照」互相顶掉")
+    void ensureCheckpointKeepsSnapshotsForEachFileIndependently() throws Exception {
+        when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "A.docx", "projects/1/A.docx"));
+        when(projectFileService.getFile(2L)).thenReturn(fileOf(2L, "B.docx", "projects/1/B.docx"));
+        when(projectFileService.getFileBytes(1L)).thenReturn("内容A".getBytes());
+        when(projectFileService.getFileBytes(2L)).thenReturn("内容B".getBytes());
+        when(storage.load(org.mockito.ArgumentMatchers.contains("1_")))
+                .thenReturn(new ByteArrayResource("内容A".getBytes()));
+        when(storage.load(org.mockito.ArgumentMatchers.contains("2_")))
+                .thenReturn(new ByteArrayResource("内容B".getBytes()));
+
+        service.ensureCheckpoint("conv-1", 1L);
+        service.ensureCheckpoint("conv-1", 2L);
+
+        // 两个文件的快照都要存在——用 restore() 的行为反向验证：应同时覆盖 A 与 B，
+        // 而不是只覆盖第一个文件（这正是修复前的故障现象）
+        String result = service.restore("conv-1");
+
+        assertTrue(result.contains("A.docx"), "应包含第一个文件：" + result);
+        assertTrue(result.contains("B.docx"), "应包含第二个文件，修复前这里会漏掉：" + result);
+        verify(storage).save(eq("projects/1/A.docx"), any());
+        verify(storage).save(eq("projects/1/B.docx"), any());
+        verify(editorBridgeService, times(1)).sendReloadFileAction(argThatFileId(1L));
+        verify(editorBridgeService, times(1)).sendReloadFileAction(argThatFileId(2L));
+    }
+
+    private ProjectFile argThatFileId(Long id) {
+        return org.mockito.ArgumentMatchers.argThat(f -> f != null && id.equals(f.getId()));
+    }
+
+    @Test
+    @DisplayName("幂等：同一文件重复 ensureCheckpoint 只建一次快照（不因为改了别的文件而重建）")
+    void ensureCheckpointIsIdempotentPerFile() throws Exception {
+        when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "A.docx", "projects/1/A.docx"));
+        when(projectFileService.getFileBytes(1L)).thenReturn("v1".getBytes());
+
+        service.ensureCheckpoint("conv-1", 1L);
+        service.ensureCheckpoint("conv-1", 1L); // 重复调用（同一文件的下一个修改类工具执行前也会调）
+        service.ensureCheckpoint("conv-1", 1L);
+
+        verify(projectFileService, times(1)).getFileBytes(1L);
+        verify(storage, times(1)).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("hasCheckpoint / clearForNewRun 对齐新的按文件存储语义")
+    void hasCheckpointAndClearForNewRun() throws Exception {
+        assertFalse(service.hasCheckpoint("conv-1"));
+
+        when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "A.docx", "projects/1/A.docx"));
+        when(projectFileService.getFileBytes(1L)).thenReturn("v1".getBytes());
+        service.ensureCheckpoint("conv-1", 1L);
+        assertTrue(service.hasCheckpoint("conv-1"));
+
+        service.clearForNewRun("conv-1");
+        assertFalse(service.hasCheckpoint("conv-1"), "新一轮开始应清空上一轮全部文件的快照");
+        assertTrue(service.restore("conv-1").startsWith("Error"), "清空后 restore 应回落到既有的无快照提示");
+    }
+
+    @Test
+    @DisplayName("单文件场景行为不变：restore 文案与既有格式一致")
+    void singleFileRestoreMessageUnchanged() throws Exception {
+        when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "合同.docx", "projects/1/合同.docx"));
+        when(projectFileService.getFileBytes(1L)).thenReturn("内容".getBytes());
+        when(storage.load(any())).thenReturn(new ByteArrayResource("内容".getBytes()));
+
+        service.ensureCheckpoint("conv-1", 1L);
+        String result = service.restore("conv-1");
+
+        assertTrue(result.contains("已将《合同.docx》恢复到本轮开始前的快照"), result);
+        assertTrue(result.contains("本轮所有修改（含修订）已丢弃"), result);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/LitigationVisualServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/LitigationVisualServiceTest.java
@@ -2,9 +2,11 @@ package com.checkba.service.ai;
 
 import cn.hutool.json.JSONArray;
 import cn.hutool.json.JSONObject;
+import com.checkba.service.pack.NativePackService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -16,8 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * 诉讼可视化的进程边界测试——真起 Python、真跑引擎、真落盘。
@@ -88,6 +94,77 @@ class LitigationVisualServiceTest {
         if (why != null) {
             assertTrue(why.contains("litviz") || why.contains("Python"), "说明应指明缺什么：" + why);
         }
+    }
+
+    /**
+     * 修复：resolved 此前只算一次且全仓没有任何生产调用点会碰 invalidate()——用户在广场
+     * 装完 litigation-visual 资源包（live 安装，不重启后端）后，runtime() 会一直返回
+     * 装包前缓存的旧结果。
+     *
+     * <p>不依赖"litviz 目录一开始必须完全解析不到"（cwd 相对路径的兜底可能会在这台机器上
+     * 真的找到仓库里的 litviz/，环境不同结果不同）：只断言"configuredDir 刚落盘 cli.py 后，
+     * 不失效缓存则 runtime() 还是原来那个缓存实例；失效后才会重新解析并优先命中 configuredDir"
+     * ——这条钉住的是缓存本身会不会刷新，与这台机器上到底有没有真实 litviz/ 无关。
+     */
+    @Test
+    @DisplayName("修复：invalidate() 后重新探测，pack 装完不必重启后端就能生效")
+    void invalidateForcesReResolutionAfterCliPyAppears(@org.junit.jupiter.api.io.TempDir Path tempDir) throws Exception {
+        LitigationVisualService fresh = new LitigationVisualService();
+        ReflectionTestUtils.setField(fresh, "configuredDir", tempDir.toString());
+        ReflectionTestUtils.setField(fresh, "configuredPython", "");
+        ReflectionTestUtils.setField(fresh, "configuredGraphvizDir", "");
+
+        Path tempDirNormalized = tempDir.toAbsolutePath().normalize();
+        // tempDir 里还没有 cli.py：resolveLitvizDir 跳过它，缓存下当时能解析到的结果
+        LitigationVisualService.Runtime before = fresh.runtime();
+        assertFalse(tempDirNormalized.equals(before.litvizDir()), "cli.py 还没落盘，不应解析到 tempDir");
+
+        // 模拟"用户在广场装完 litigation-visual 资源包"：cli.py 落盘到 configuredDir
+        Files.writeString(tempDir.resolve("cli.py"), "# fake cli\n", StandardCharsets.UTF_8);
+
+        // 不失效缓存的话，runtime() 应仍返回失效前缓存的同一个实例——钉住修复前的故障现象
+        assertSame(before, fresh.runtime(), "不失效缓存时应仍返回同一个缓存实例（钉住修复前的行为）");
+
+        fresh.invalidate();
+
+        LitigationVisualService.Runtime after = fresh.runtime();
+        assertEquals(tempDirNormalized, after.litvizDir(),
+                "失效后应重新解析；configuredDir 优先级最高，应命中刚落盘的 cli.py");
+    }
+
+    /**
+     * 上一条测的是"invalidate() 本身管不管用"——这条测的是修复真正加的那一行：
+     * registerPackProbe 有没有把 invalidate 注册给 packService，pack 状态变化时
+     * 是不是真的会调用到它。两条缺一都不能证明生产环境里这条链路是通的。
+     */
+    @Test
+    @DisplayName("修复：registerPackProbe 把 invalidate 登记进 packService.onPackChanged，回调触发时真的会重新解析")
+    void registerPackProbeWiresInvalidateToPackService(@org.junit.jupiter.api.io.TempDir Path tempDir) throws Exception {
+        LitigationVisualService fresh = new LitigationVisualService();
+        ReflectionTestUtils.setField(fresh, "configuredDir", tempDir.toString());
+        ReflectionTestUtils.setField(fresh, "configuredPython", "");
+        ReflectionTestUtils.setField(fresh, "configuredGraphvizDir", "");
+
+        NativePackService packService = mock(NativePackService.class);
+        ReflectionTestUtils.setField(fresh, "packService", packService);
+
+        fresh.registerPackProbe(); // 模拟 Spring 的 @PostConstruct
+
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(packService).onPackChanged(eq(LitigationVisualService.PACK_ID), captor.capture());
+
+        Path tempDirNormalized = tempDir.toAbsolutePath().normalize();
+        LitigationVisualService.Runtime before = fresh.runtime();
+        assertFalse(tempDirNormalized.equals(before.litvizDir()));
+
+        Files.writeString(tempDir.resolve("cli.py"), "# fake cli\n", StandardCharsets.UTF_8);
+        assertSame(before, fresh.runtime(), "登记的回调触发前不该重新解析");
+
+        // 模拟 NativePackService 在 install()/uninstall()/syncRevoked() 里调用注册的回调
+        captor.getValue().run();
+
+        assertEquals(tempDirNormalized, fresh.runtime().litvizDir(),
+                "packService 触发注册的回调后应该重新解析并命中刚落盘的 cli.py");
     }
 
     // ==== 出图 ====

--- a/backend/src/test/java/com/checkba/service/ai/PdfEditServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PdfEditServiceTest.java
@@ -154,6 +154,35 @@ class PdfEditServiceTest {
         assertTrue(e.getMessage().contains("未找到"));
     }
 
+    /**
+     * 修复：texts 里混一个原文没有的目标（LLM 猜错人名/证件号是常态）时，此前的行为是
+     * ——先把命中的那部分真实、不可逆地打码写回磁盘，然后才抛异常。调用方 PdfTools 的
+     * finishModification（轮换 wpsFileId、更新 fileSize/updatedAt、发 reload）被异常
+     * 跳过，磁盘已改、DB 与预览却还停在旧版本，两者从此不一致——磁盘状态与返回结果不一致
+     * 正是这条要守住的不变式。
+     *
+     * <p>裁决：部分命中不算失败（选项 a）。理由：redact 本身不可逆且以秒计生效，AI 给错
+     * 一个名字不该连累已经正确定位到的那些也不落地——真正敏感的内容应该立刻被打码，
+     * 而不是因为清单里一个查无此文的名字就整体作废、逼用户拿着仍然明文的文件回去重试。
+     */
+    @Test
+    void redactPartialMatchSucceedsAndReportsDiskStateHonestly() throws IOException {
+        Path pdf = samplePdf();
+
+        // "Confidential" 命中，"不存在的文本" 不命中——不再抛异常，正常返回
+        PdfEditService.RedactResult result = service.redact(pdf, List.of("Confidential", "不存在的文本"), null);
+
+        assertEquals(1, result.matchCount, "只有真正命中的那部分应计入 matchCount");
+        assertEquals(List.of("不存在的文本"), result.missing, "未命中的目标要如实带回，不能吞掉");
+        assertEquals(List.of(0), result.rasterizedPages);
+
+        // 磁盘状态必须与返回结果一致：既然 result 说命中了 1 处并光栅化了第 0 页，
+        // 磁盘上就必须真的看不到 Confidential 了——不允许"报告成功但磁盘其实没变"，
+        // 也不允许"磁盘变了但调用方拿到的是异常、不知道已经生效"。
+        String after = extractText(pdf);
+        assertFalse(after.contains("Confidential"), "命中的目标必须已经真实打码到磁盘");
+    }
+
     @Test
     void replaceOverlaysNewText() throws IOException {
         Path pdf = samplePdf();

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -196,6 +196,33 @@ class PluginMarketServiceTest {
     }
 
     @Test
+    @DisplayName("修复：兜底拷贝也失败时 target 一并清掉，不留半成品目录（要么装成，要么什么都不留）")
+    void moveStagingToTargetCleansUpTargetWhenFallbackCopyFails() throws Exception {
+        // 病灶复现三步：
+        // 1) 先让原子 move 失败——target 预置成非空目录，POSIX rename 语义下移动一个目录
+        //    到已存在的非空目录会失败（ENOTEMPTY），逼进兜底拷贝分支；
+        // 2) 兜底拷贝也失败——target 下预置一个与 staging 内嵌套路径同名的「文件」占位，
+        //    拷贝到该路径时因为要把文件当目录写入而抛异常；
+        // 3) 断言异常确实抛出，且 target 整个目录被清干净，不留半成品。
+        Path staging = Files.createTempDirectory("moveStagingToTargetTest-staging-");
+        Files.writeString(staging.resolve("a.txt"), "A", StandardCharsets.UTF_8);
+        Files.createDirectories(staging.resolve("sub"));
+        Files.writeString(staging.resolve("sub").resolve("b.txt"), "B", StandardCharsets.UTF_8);
+
+        java.io.File target = pluginsDir.resolve("demo").toFile();
+        Files.createDirectories(target.toPath());
+        Files.writeString(target.toPath().resolve("existing-junk.txt"), "占位，撑起非空目录", StandardCharsets.UTF_8);
+        // 与 staging/sub 同名但是文件——拷贝 sub/b.txt 时会因为「同名节点已是文件」而失败
+        Files.writeString(target.toPath().resolve("sub"), "我是文件不是目录", StandardCharsets.UTF_8);
+
+        PluginMarketService svc = service(publicKeyPem);
+        assertThrows(Exception.class, () -> svc.moveStagingToTarget(staging, target));
+
+        assertFalse(Files.exists(target.toPath()),
+                "兜底拷贝失败后 target 必须被清掉，不能留下拷贝到一半的半成品目录");
+    }
+
+    @Test
     @DisplayName("安装：签名无效时中止，不发起任何文件下载")
     void installAbortsOnBadSignature() throws Exception {
         Map<String, String> files = new TreeMap<>();

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -277,6 +278,29 @@ class PluginServiceTest {
         assertTrue(service.isEnabled("hello-plugin"));
     }
 
+    @Test
+    @DisplayName("rescan 使 ToolRegistry 的插件工具缓存失效（否则更新/卸载后旧 bean 仍被分发）")
+    void rescanInvalidatesToolRegistryPluginCache() throws IOException {
+        ToolRegistry toolRegistry = mock(ToolRegistry.class);
+        service.setToolRegistry(toolRegistry);
+
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+        verifyNoInteractions(toolRegistry);
+
+        service.rescan();
+
+        verify(toolRegistry).invalidatePluginToolCache();
+    }
+
+    @Test
+    @DisplayName("未装配 ToolRegistry（既有测试直接 new PluginService(...)）时 rescan 不受影响")
+    void rescanToleratesMissingToolRegistry() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+        assertDoesNotThrow(service::rescan);
+    }
+
     // ==== backendJars 路径校验 ====
 
     @Test
@@ -292,6 +316,37 @@ class PluginServiceTest {
         assertNull(service.resolveBackendJar(pluginDir.toFile(), "../../../etc/passwd", "evil-plugin"));
         assertNull(service.resolveBackendJar(pluginDir.toFile(), null, "evil-plugin"));
         assertNull(service.resolveBackendJar(pluginDir.toFile(), "  ", "evil-plugin"));
+    }
+
+    @Test
+    @DisplayName("修复：backendJar 文件缺失时打一条 WARN，带上插件 id 与缺失的 jar 名")
+    void missingBackendJarFileLogsWarningWithPluginIdAndJarName() throws IOException {
+        // 病灶：manifest 声明了 backendJars 但解压不全/被手删/打包漏了——此前这条路径
+        // 一个字日志都不打，调用方 `if (jarFile != null) loadJar(...)` 又没有 else 分支。
+        // 插件照常出现在列表里、启停可用，就是 0 个工具，日志里搜插件 id 与 jar 名全是空。
+        Path pluginDir = pluginsDir.resolve("gap-plugin");
+        Files.createDirectories(pluginDir);
+
+        ch.qos.logback.classic.Logger logbackLogger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(PluginService.class);
+        ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
+                new ch.qos.logback.core.read.ListAppender<>();
+        appender.start();
+        logbackLogger.addAppender(appender);
+        try {
+            File result = service.resolveBackendJar(pluginDir.toFile(), "missing-tool.jar", "gap-plugin");
+            assertNull(result, "文件不存在时仍应返回 null（行为不变）");
+        } finally {
+            logbackLogger.detachAppender(appender);
+        }
+
+        boolean logged = appender.list.stream().anyMatch(e ->
+                e.getLevel() == ch.qos.logback.classic.Level.WARN
+                        && e.getFormattedMessage().contains("gap-plugin")
+                        && e.getFormattedMessage().contains("missing-tool.jar"));
+        assertTrue(logged, "应有一条 WARN 日志同时点名插件 id 与缺失的 jar 名，实际日志：" +
+                appender.list.stream().map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+                        .collect(java.util.stream.Collectors.joining(" | ")));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/PptxServiceClientTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PptxServiceClientTest.java
@@ -1,0 +1,174 @@
+package com.checkba.service.ai;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PptxServiceClient 两个修复对着**真 HTTP 桩**跑（不 mock 传输层）：
+ *
+ * <p>1. waitForTask/waitForTaskWithProgress 的 FAILED 分支此前返回 null，把 pptx-service
+ * 回传的 error_message 丢在日志里，调用方只能硬编码 "Description generation failed" 之类
+ * 的通用文案——"api key 无效""配额用尽""模型 id 写错"在用户眼里全长一个样，无从自救。
+ *
+ * <p>2. downloadPptx 只校验 HTTP 200 就当成功，字节长度、content-type、PPTX 魔数一概不查，
+ * 空 body 也会被无条件写盘并报告"生成成功"。
+ */
+class PptxServiceClientTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private PptxServiceClient client;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeEach
+    void setUp() throws java.io.IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        client = new PptxServiceClient();
+        client.setTimeoutSeconds(10);
+    }
+
+    private void startServer() {
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        client.setBaseUrl(baseUrl);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    private static String readBody(InputStream in) throws java.io.IOException {
+        return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange ex, int status, String body) throws java.io.IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        ex.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(bytes);
+        }
+        ex.close();
+    }
+
+    private static void respondBytes(com.sun.net.httpserver.HttpExchange ex, int status, byte[] bytes) throws java.io.IOException {
+        ex.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(bytes);
+        }
+        ex.close();
+    }
+
+    // ==== 修复 5：FAILED 分支的 error_message 一路带到调用方 ====
+
+    /** 走完 create/outline/descriptions 三步，让第 4 步（等待描述生成任务）返回 FAILED。 */
+    private void stubUpToDescriptionsThenFail(String errorMessage) {
+        server.createContext("/api/projects/proj-1/tasks/task-desc-1", ex -> {
+            readBody(ex.getRequestBody());
+            respond(ex, 200, "{\"data\":{\"status\":\"FAILED\",\"error_message\":\"" + errorMessage + "\"}}");
+        });
+        server.createContext("/api/projects/proj-1/generate/descriptions", ex -> {
+            readBody(ex.getRequestBody());
+            respond(ex, 202, "{\"data\":{\"task_id\":\"task-desc-1\"}}");
+        });
+        server.createContext("/api/projects/proj-1/generate/outline", ex -> {
+            readBody(ex.getRequestBody());
+            respond(ex, 200, "{\"data\":{\"pages\":[]}}");
+        });
+        server.createContext("/api/projects", ex -> {
+            readBody(ex.getRequestBody());
+            respond(ex, 201, "{\"data\":{\"project_id\":\"proj-1\"}}");
+        });
+    }
+
+    @Test
+    @DisplayName("修复：generatePptxSync 在描述生成任务 FAILED 时，最终结果的 error 里带着真实 error_message")
+    void generatePptxSyncPropagatesRealErrorMessage() {
+        stubUpToDescriptionsThenFail("invalid api key");
+        startServer();
+
+        PptxServiceClient.PptxGenerationResult result =
+                client.generatePptxSync("尽调汇报", "zh", null, null, null, false);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("invalid api key"),
+                "真实失败原因必须出现在最终结果里，而不是被一句通用文案盖掉：" + result.getError());
+    }
+
+    @Test
+    @DisplayName("修复：generatePptxWithProgress（真实调用点）同样传递 error_message，不只是同步版本")
+    void generatePptxWithProgressPropagatesRealErrorMessage() {
+        stubUpToDescriptionsThenFail("配额已用尽");
+        startServer();
+
+        PptxServiceClient.PptxGenerationResult result = client.generatePptxWithProgress(
+                "尽调汇报", "zh", null, null, null, false, (progress, stage, message) -> { });
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("配额已用尽"),
+                "真实失败原因必须出现在最终结果里：" + result.getError());
+    }
+
+    // ==== 修复 6：downloadPptx 校验非空 + PPTX 魔数 ====
+
+    @Test
+    @DisplayName("修复：下载 URL 返回 200 + 空 body，downloadPptx 必须失败，不能写出 0 字节文件")
+    void downloadPptxRejectsEmptyBody() throws Exception {
+        server.createContext("/download/empty.pptx", ex -> respondBytes(ex, 200, new byte[0]));
+        startServer();
+
+        Path target = tmp.resolve("out.pptx");
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> client.downloadPptx("/download/empty.pptx", target.toString()));
+        assertTrue(ex.getMessage().contains("empty"), ex.getMessage());
+        assertFalse(Files.exists(target), "校验失败不应留下 0 字节文件");
+    }
+
+    @Test
+    @DisplayName("修复：下载 URL 返回 200 + 一段 JSON（不是 PPTX），downloadPptx 必须失败")
+    void downloadPptxRejectsNonPptxBody() throws Exception {
+        server.createContext("/download/error.pptx", ex ->
+                respond(ex, 200, "{\"error\":\"upstream image model unavailable\"}"));
+        startServer();
+
+        Path target = tmp.resolve("out.pptx");
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> client.downloadPptx("/download/error.pptx", target.toString()));
+        assertTrue(ex.getMessage().contains("not a valid PPTX"), ex.getMessage());
+        assertFalse(Files.exists(target), "校验失败不应把 JSON 错误信息当 PPTX 写盘");
+    }
+
+    @Test
+    @DisplayName("对照组：真实 PPTX 字节（含魔数）应正常下载落盘，字节内容不失真")
+    void downloadPptxAcceptsValidPptxBytes() throws Exception {
+        byte[] fakePptx = new byte[]{0x50, 0x4B, 0x03, 0x04, 0x01, 0x02, 0x03};
+        server.createContext("/download/real.pptx", ex -> respondBytes(ex, 200, fakePptx));
+        startServer();
+
+        Path target = tmp.resolve("out.pptx");
+        String saved = client.downloadPptx("/download/real.pptx", target.toString());
+
+        assertEquals(target.toString(), saved);
+        assertTrue(Files.exists(target));
+        assertEquals(fakePptx.length, Files.size(target));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ToolRegistryTest.java
@@ -287,4 +287,47 @@ class ToolRegistryTest {
         reg2.init();
         assertEquals("plugin:ok", reg2.execute("plugin_echo", "{\"text\":\"ok\"}", ctx).output());
     }
+
+    // ==== 插件工具缓存失效（pluginToolCache 从不失效的修复） ====
+
+    /** 插件工具「v1」：与 FakePluginToolsV2 故意同名（plugin_versioned），模拟插件更新前后的两个 bean */
+    static class FakePluginToolsV1 {
+        @Tool("versioned v1")
+        public String plugin_versioned(@P("x") String x) {
+            return "v1:" + x;
+        }
+    }
+
+    /** 插件工具「v2」：同名不同实现，模拟插件更新后新 JAR 加载出的 bean */
+    static class FakePluginToolsV2 {
+        @Tool("versioned v2")
+        public String plugin_versioned(@P("x") String x) {
+            return "v2:" + x;
+        }
+    }
+
+    @Test
+    @DisplayName("修复：pluginToolCache 不失效会一直分发旧 bean；invalidatePluginToolCache 后拿到新 bean")
+    void invalidatePluginToolCacheDropsStaleBean() {
+        PluginService ps = new PluginService();
+        ps.registerToolObject(new FakePluginToolsV1(), "my-plugin");
+        ToolRegistry reg = new ToolRegistry(List.of(new FakeTools()), ps, new ClientCapabilityService());
+        reg.init();
+
+        // 首次 resolve 命中 v1，并把它塞进 pluginToolCache
+        assertEquals("v1:hi", reg.execute("plugin_versioned", "{\"x\":\"hi\"}", ctx).output());
+
+        // 模拟插件更新：PluginService.rescan() 会用新 URLClassLoader 加载出新 bean 覆盖同名 key
+        ps.registerToolObject(new FakePluginToolsV2(), "my-plugin");
+
+        // 不失效缓存的话，resolve() 命中缓存直接返回旧 RegisteredTool，永远看不到 v2
+        // ——这一行钉住修复前的真实故障：插件已经换了新版本，AI 调用的还是旧版工具。
+        assertEquals("v1:hi", reg.execute("plugin_versioned", "{\"x\":\"hi\"}", ctx).output(),
+                "换 bean 但未失效缓存时应仍拿到旧版（钉住修复前的故障现象）");
+
+        reg.invalidatePluginToolCache();
+
+        assertEquals("v2:hi", reg.execute("plugin_versioned", "{\"x\":\"hi\"}", ctx).output(),
+                "失效后应重新从 PluginService 解析，拿到插件更新后的新 bean");
+    }
 }

--- a/backend/src/test/java/com/checkba/service/ai/tools/PptxToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/PptxToolsTest.java
@@ -1,0 +1,142 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.config.AiModelProperties;
+import com.checkba.model.ai.TaskInfo;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.BackgroundTaskService;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.PlatformAiChannel;
+import com.checkba.service.ai.PptxServiceClient;
+import com.checkba.storage.ProjectStorageResolver;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * pptx_generate 卡死 RUNNING 任务的修复：registerTask 之后如果 pptx-service 调用抛异常
+ * （网络失败是真实触发场景），此前两条异常路径（外层 catch、DB 注册失败的内层 catch）
+ * 直接 return 不碰 taskId——BackgroundTaskService 里那条 RUNNING 永久留着，
+ * hasActiveTasks 恒为 true，前端进度卡永远转下去。
+ */
+class PptxToolsTest {
+
+    private PptxServiceClient pptxServiceClient;
+    private BackgroundTaskService backgroundTaskService;
+    private ChatModelFactory chatModelFactory;
+    private ProjectFileRepository projectFileRepository;
+    private ProjectFileService projectFileService;
+    private ProjectStorageResolver storageResolver;
+    private PptxTools pptxTools;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeEach
+    void setUp() {
+        pptxServiceClient = mock(PptxServiceClient.class);
+        projectFileService = mock(ProjectFileService.class);
+        projectFileRepository = mock(ProjectFileRepository.class);
+        when(projectFileRepository.findByProjectIdOrderBySortOrderAsc(anyLong()))
+                .thenReturn(Collections.emptyList());
+        EditorBridgeService editorBridgeService = mock(EditorBridgeService.class);
+        StorageServiceFactory storageServiceFactory = mock(StorageServiceFactory.class);
+        com.checkba.config.AiModelProperties aiModelProperties = mock(AiModelProperties.class);
+        backgroundTaskService = mock(BackgroundTaskService.class);
+        chatModelFactory = mock(ChatModelFactory.class);
+        when(chatModelFactory.resolveProvider()).thenReturn(AiModelProperties.Provider.OPENROUTER);
+        when(chatModelFactory.resolveOpenRouterApiKey()).thenReturn("sk-test");
+        when(chatModelFactory.resolveOpenRouterBaseUrl()).thenReturn("https://openrouter.ai/api/v1");
+        when(chatModelFactory.resolveDefaultModel()).thenReturn("deepseek/deepseek-v4");
+        PlatformAiChannel platformAiChannel = mock(PlatformAiChannel.class);
+        storageResolver = mock(ProjectStorageResolver.class);
+        when(storageResolver.resolve(anyString())).thenReturn(tmp.resolve("out.pptx"));
+
+        pptxTools = new PptxTools(pptxServiceClient, projectFileService, projectFileRepository,
+                editorBridgeService, storageServiceFactory, aiModelProperties, backgroundTaskService,
+                chatModelFactory, platformAiChannel, storageResolver);
+    }
+
+    @Test
+    @DisplayName("修复：pptx-service 网络失败（外层 catch）时已注册的后台任务被标记失败，不再永久卡在 RUNNING")
+    void outerCatchFailsRegisteredTaskOnServiceException() {
+        when(pptxServiceClient.isHealthy()).thenReturn(true);
+        when(backgroundTaskService.registerTask(eq("conv-1"), eq(7L),
+                eq(TaskInfo.TaskType.PPTX_GENERATE), any())).thenReturn("task-1");
+        when(pptxServiceClient.generatePptxWithProgress(anyString(), anyString(), any(), anyString(),
+                any(), anyBoolean(), any()))
+                .thenThrow(new RuntimeException("Connection refused: pptx-service"));
+
+        String result = pptxTools.performPptGenerationWithProgress(
+                "尽调汇报", 42L, null, "报告", null, "zh",
+                "deepseek/deepseek-v4", "conv-1", 7L, false);
+
+        assertTrue(result.contains("PPTX 生成过程中出错"), result);
+        assertTrue(result.contains("Connection refused"), result);
+        verify(backgroundTaskService).failTask(eq("task-1"), contains("Connection refused"));
+    }
+
+    @Test
+    @DisplayName("修复：文件已生成但 DB 注册失败（内层 catch）时同样标记后台任务失败")
+    void innerCatchFailsRegisteredTaskWhenDbRegistrationThrows() throws Exception {
+        Path localPath = tmp.resolve("out.pptx");
+        Files.write(localPath, "fake pptx bytes".getBytes()); // 模拟 pptx-service 已经把文件写到本地
+
+        PptxServiceClient.PptxGenerationResult ok = new PptxServiceClient.PptxGenerationResult();
+        ok.setSuccess(true);
+        ok.setProjectId("proj-1");
+        ok.setPagesCount(5);
+        ok.setEditable(true);
+
+        when(pptxServiceClient.isHealthy()).thenReturn(true);
+        when(backgroundTaskService.registerTask(eq("conv-1"), eq(7L),
+                eq(TaskInfo.TaskType.PPTX_GENERATE), any())).thenReturn("task-2");
+        when(pptxServiceClient.generatePptxWithProgress(anyString(), anyString(), any(), anyString(),
+                any(), anyBoolean(), any())).thenReturn(ok);
+        when(projectFileService.createOrUpdateFile(any(), any(), anyString(), anyString(),
+                any(), anyString(), anyString(), any()))
+                .thenThrow(new RuntimeException("DB 写入失败"));
+
+        String result = pptxTools.performPptGenerationWithProgress(
+                "尽调汇报", 42L, null, "报告", null, "zh",
+                "deepseek/deepseek-v4", "conv-1", 7L, false);
+
+        assertTrue(result.contains("PPTX 已生成但注册到数据库失败"), result);
+        verify(backgroundTaskService).failTask(eq("task-2"), contains("DB 写入失败"));
+    }
+
+    @Test
+    @DisplayName("无 conversationId/userId 时未注册任务，异常路径不应调用 failTask（没有 taskId 可标）")
+    void noTaskRegisteredWhenConversationMissing() {
+        when(pptxServiceClient.isHealthy()).thenReturn(true);
+        when(pptxServiceClient.generatePptxSync(anyString(), anyString(), any(), anyString(), any(), anyBoolean()))
+                .thenThrow(new RuntimeException("网络错误"));
+
+        String result = pptxTools.performPptGenerationWithProgress(
+                "尽调汇报", 42L, null, "报告", null, "zh",
+                "deepseek/deepseek-v4", null, null, false);
+
+        assertTrue(result.contains("PPTX 生成过程中出错"), result);
+        verify(backgroundTaskService, never()).failTask(any(), any());
+        verify(backgroundTaskService, never()).registerTask(any(), any(), any(), any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
@@ -349,6 +349,31 @@ class NativePackServiceTest {
     }
 
     @Test
+    @DisplayName("修复：安装/封禁/卸载都会触发登记的状态变化回调，供资源消费方失效自己的运行时解析缓存")
+    void notifiesRegisteredListenerOnInstallRevokeAndUninstall() throws Exception {
+        // 病灶：LitigationVisualService.resolved 是懒加载且只算一次的缓存，此前
+        // NativePackService 全仓没有任何生产调用点会碰 invalidate()——用户在广场点
+        // 「安装/卸载」是不重启后端的 live 操作，装完 pack 面板仍显示上次探测出的「不可用」。
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        primary.files.put("/revoked", ("[{\"id\":\"" + PACK_ID + "\",\"version\":\"*\",\"reason\":\"test\"}]")
+                .getBytes(StandardCharsets.UTF_8));
+
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        java.util.concurrent.atomic.AtomicInteger fired = new java.util.concurrent.atomic.AtomicInteger(0);
+        svc.onPackChanged(PACK_ID, fired::incrementAndGet);
+
+        svc.install(PACK_ID);
+        assertEquals(1, fired.get(), "安装成功应触发一次回调");
+
+        assertEquals(List.of(PACK_ID), svc.syncRevoked());
+        assertEquals(2, fired.get(), "被平台封禁应再触发一次回调");
+
+        svc.uninstall(PACK_ID);
+        assertEquals(3, fired.get(), "卸载应再触发一次回调");
+    }
+
+    @Test
     @DisplayName("命中封禁表后资源解析视而不见，但本地文件不删")
     void revokedPackBecomesInvisible() throws Exception {
         byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION
十条 AI 编排/工具侧缺陷（子 agent 完成，我复核并按下面说明处理了两处判断）。
每条都是先写测试看它红、改实现看它绿、再把实现临时还原确认测试真会红。

1. [HIGH] ToolRegistry.pluginToolCache 从不失效，插件更新/卸载后旧 bean 还在执行
   全仓只有「声明/get/put」三处，没有任何 remove/clear。PluginService.rescan() 清的是
   它自己的表，动不到这个缓存；loadJar 每次新建 URLClassLoader 且旧 loader 从不 close，
   旧 bean 仍能正常反射执行。用户在插件广场点「更新/卸载」后，AI 调的还是旧版本，零报错。
   修法：新增失效入口，rescan() 末尾调用。ToolRegistry 的构造器已经依赖 PluginService，
   所以反向那一侧用 @Lazy + required=false 的字段注入破环（本仓 SubAgentTools 同款做法）。

2. [HIGH] 一条空内容的历史消息永久毒化整个会话
   入口没有非空校验，message="" 能落库（content 列 nullable=false 只挡得住 null）；
   此后每一轮 assemble 回放到它，langchain4j 的 UserMessage.from 一律抛
   「text cannot be null or blank」，被兜底 catch 变成 SSE error——该会话永久报废，
   用户只能新建。两头都堵：入口拒绝空白 message；回放时跳过坏数据并 WARN
   （存量数据修不回来，必须容错）。

3. [HIGH] 卡住的 RUNNING 任务永远不回收
   cleanupOldTasks 的条件是「非活跃」，RUNNING 永远活跃故永不回收；而 PptxTools 里
   registerTask 之后有两条异常路径直接 return，不碰 taskId。pptx-service 一次网络失败，
   三张表就永久留一条 RUNNING。修法：给 RUNNING 加 30 分钟兜底回收（时间源可注入），
   并把那两条异常路径补上 failTask。

4. [HIGH] 文档检查点只按 conversationId 存，同轮切文件后恢复到错的文档
   幂等判据完全不看 fileId，而同一轮里 doc_open_file 会把活跃文件切到 B。
   于是 restore 用的是 A 的快照：覆盖 A、对 A 发 reload，还告诉用户
   「已将《A》恢复到本轮开始前的快照，本轮所有修改已丢弃」——而用户这一轮真正改的是 B，
   B 的修改一个都没回退。改成按 (conversationId, fileId) 存，restore 覆盖本轮碰过的全部文件。

5. [HIGH] pptx 微服务的真实失败原因被丢掉，换成一句通用串
   error_message 只进日志，方法只能返回 null，调用方据 null 硬编码
   "Description generation failed" 之类。「api key 无效」「配额用尽」「模型 id 写错」
   在用户眼里全长一个样，无从自救。改成一路带到用户可见的信息里。

6. [HIGH] downloadPptx 只看 HTTP 200 就当成功，空 body 也照写照报成功
   对字节长度、content-type、PPTX 魔数一概不查，上游随即 setSuccess(true)，
   把可能是 0 字节的文件注册进项目文件库并返回「PPTX 生成成功！」。
   全链路没有一处会发现文件是空的。补上非空 + PK 魔数校验。

7. [HIGH] litviz 运行时解析结果永久缓存，装完 pack 也不生效
   双检锁只算一次，类里的 invalidate() 全仓没有任何生产调用点；而 pack 是 live 安装，
   装完不重启也没人回调。更糟的是面板 status / unavailableReason / probeDotOnPath
   三条路都会在 pack 装好前就把「不可用」缓存住——用户装完诉讼可视化资源包，
   功能仍显示不可用，只能重启后端。
   修法：NativePackService 新增通用的 pack 变化回调注册表（与既有 builtinProbes 同一
   设计原则：本服务不反向依赖具体消费方），在安装成功/卸载/封禁三处触发。

8. [HIGH] 插件 backendJar 文件缺失时静默跳过，日志一个字都没有
   同一方法里的路径逃逸分支与 IOException 分支都有 log.error，唯独「文件不在」是哑的。
   结果：插件出现在列表里、启停可用，但 0 个工具，日志里搜插件 id 与 jar 名都是空。补 WARN。

9. [HIGH] 插件安装的拷贝兜底失败后，残缺目录留在盘上且不在账里
   旧版本先被删掉 → 原子移动失败 → 兜底拷贝再抛 → 外层 catch 只删 staging、从不删 target，
   且异常在登记之前抛出。半成品目录既留在盘上又不在 PluginService 的账里，
   直接违反这个方法自己写的不变式「任一步失败都不留半成品」。

10. [HIGH] pdf_redact 已经把改过的 PDF 写回磁盘，然后才抛异常
    doc.save 已不可逆地改写了原文件，紧接着因为「有目标没找到」抛异常；
    调用方的 finishModification（轮换 wpsFileId、更新 fileSize/updatedAt、发 reload）
    被跳过——磁盘已改，DB 与预览还停在旧版本。触发是常态：AI 给的清单里混一个原文
    没有的名字（猜错人名/证件号很常见）。
    **裁决（产品判断，请复核）**：部分命中不算失败，如实带回 missing 清单让调用方照实报告。
    理由是 redact 不可逆且以秒计生效，不该因为清单里一个查无此文的名字，
    让已经定位到的敏感信息也不落地；反过来做的话「猜错一个名字 = 其余全部不脱敏」，
    对安全功能是更差的默认值。全部未命中那条分支维持原样（它本来就在写盘前抛）。

留给维护者的两处：
- 第 3 条的 30 分钟阈值是硬编码常量，未做成配置项。生产上若 PPT 生成经常超过这个时长需要调大。
- 第 10 条的方向若与产品口径相反（宁可全部不做也不能半吊子脱敏），改法是先在临时文件里
  完成全部处理、确认无 missing 才原子替换原文件。

全量 mvn test：2224 通过 0 失败 11 跳过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)