### PR TITLE
fix(ai-chat): 设置页显式选了本地 Ollama，白名单模型仍把内容发去 OpenRouter（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
+++ b/backend/src/main/java/com/checkba/service/ai/ChatModelFactory.java
@@ -108,6 +108,21 @@ public class ChatModelFactory {
     }
 
     /**
+     * 用户是否在设置页里**显式**把供应商选成了本地 OLLAMA。
+     *
+     * <p>必须与 {@link #resolveProvider()} 区分开：yml 的静态默认值恰好也是 OLLAMA，
+     * 而那只是「还没配过」，不代表用户要求内容留在本机——既有契约是
+     * 「静态供应商是什么都不妨碍用户从模型选择器里挑云端模型」（见
+     * ChatModelFactoryTest.allowedModelAlwaysUsesOpenRouter）。
+     * 只有 DB 里真写着 OLLAMA，才是那句明确的「不要把内容发出去」。
+     */
+    private boolean isExplicitLocalProvider() {
+        String configured = systemSettingService.get("ai.activeProvider", null);
+        return configured != null
+                && AiModelProperties.Provider.OLLAMA.name().equalsIgnoreCase(configured.trim());
+    }
+
+    /**
      * 读取系统设置，DB 里的空白值视为未配置、回退默认值。
      * 向导/管理后台保存时未填的字段会以空串写入 DB（toSettingsUpdates 的 safe()），
      * 直接用会把 baseUrl 等必填项置空导致构建模型失败。
@@ -231,6 +246,18 @@ public class ChatModelFactory {
         // Strategy:
         // - If modelID is "default" or local-looking => use Configured Provider (Ollama) properties.
         // - If modelID looks like "provider/model" (e.g. "anthropic/claude") => Force OpenRouter if generic, or check allowed list.
+
+        // 显式选了本地档时必须先于白名单短路判定：那是在明确表达「内容不出这台机器」，
+        // 法律文书场景下那是产品承诺、不是偏好。而白名单判定原本排在前面，只要 modelId
+        // 恰好在白名单里就一律被拽去 OpenRouter；更要命的是辅助模型的默认 id
+        // （qwen/qwen3.7-flash）本身就在白名单里——OLLAMA 档下每一次辅助调用都在走云端。
+        if (isExplicitLocalProvider()) {
+            if (!"default".equals(targetModel) && AllowedModels.isAllowed(targetModel)) {
+                log.warn("供应商为本地 OLLAMA，忽略云端模型 '{}'，改用本地模型 {}",
+                        targetModel, resolveOllamaModelName());
+            }
+            return getOrCreateOllamaModel(resolveOllamaModelName());
+        }
 
         if (AllowedModels.isAllowed(targetModel)) {
             // It's a valid OpenRouter/Cloud model
@@ -435,6 +462,18 @@ public class ChatModelFactory {
         // 同 getChatModel：平台通道先于白名单短路
         if (provider == AiModelProperties.Provider.AWD_CLOUD) {
             return getOrCreatePlatformStreamingModel(resolvePlatformModel(targetModel));
+        }
+
+        // 显式选了本地档时必须先于白名单短路判定：那是在明确表达「内容不出这台机器」，
+        // 法律文书场景下那是产品承诺、不是偏好。而白名单判定原本排在前面，只要 modelId
+        // 恰好在白名单里就一律被拽去 OpenRouter；更要命的是辅助模型的默认 id
+        // （qwen/qwen3.7-flash）本身就在白名单里——OLLAMA 档下每一次辅助调用都在走云端。
+        if (isExplicitLocalProvider()) {
+            if (!"default".equals(targetModel) && AllowedModels.isAllowed(targetModel)) {
+                log.warn("供应商为本地 OLLAMA，忽略云端模型 '{}'，改用本地模型 {}",
+                        targetModel, resolveOllamaModelName());
+            }
+            return getOrCreateOllamaStreamingModel(resolveOllamaModelName());
         }
 
         if (AllowedModels.isAllowed(targetModel)) {

--- a/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ChatModelFactoryTest.java
@@ -98,6 +98,33 @@ class ChatModelFactoryTest {
                 "白名单内的模型必须走 OpenRouter，而不是落到本地 Ollama");
     }
 
+    /**
+     * 选了本地 Ollama 就是在明确表达「不要把内容发出去」——法律文书场景下这是产品承诺，
+     * 不是偏好。而白名单短路判定排在供应商判定之前：只要 modelId 恰好在白名单里，
+     * 一律被拦去 OpenRouter。更要命的是辅助模型的默认 id（qwen/qwen3.7-flash）
+     * 本身就在白名单里，于是 OLLAMA 档下**每一次辅助调用都在走云端**。
+     */
+    @Test
+    @DisplayName("供应商=OLLAMA 时，白名单模型不得把流量拽去 OpenRouter")
+    void ollamaProviderKeepsAllowedModelsLocal() {
+        properties.setProvider(AiModelProperties.Provider.OLLAMA);
+        setDbProvider("OLLAMA");
+
+        ChatLanguageModel model = factory.getChatModel(AllowedModels.QWEN_3_7_FLASH.getModelId());
+        assertInstanceOf(OllamaChatModel.class, model,
+                "选了本地供应商却把内容发去 OpenRouter：" + model.getClass().getName());
+    }
+
+    @Test
+    @DisplayName("供应商=OLLAMA 时，辅助模型同样留在本地")
+    void ollamaProviderKeepsAuxModelLocal() {
+        properties.setProvider(AiModelProperties.Provider.OLLAMA);
+        setDbProvider("OLLAMA");
+
+        assertInstanceOf(OllamaChatModel.class, factory.getAuxChatModel(),
+                "辅助调用用户根本看不见也选不了，更不该越过本地供应商");
+    }
+
     @Test
     @DisplayName("供应商=OLLAMA（DB 未配置）：空 modelId 仍走本地 Ollama（回归保护）")
     void ollamaProviderStillUsesOllama() {


### PR DESCRIPTION
病灶：getChatModel / getStreamingChatModel 里，`AllowedModels.isAllowed(targetModel)`
这道短路判定排在供应商判定之前。只要 modelId 恰好在白名单里，一律被拽去 OpenRouter；
而辅助模型的默认 id（qwen/qwen3.7-flash）本身就在白名单里——于是本地档下
**每一次辅助调用都在走云端**，而辅助调用用户根本看不见也选不了。
选本地 Ollama 就是在明确表达「内容不出这台机器」，法律文书场景下那是产品承诺、不是偏好。

修法上有个必须区分的坑：`resolveProvider()` 把「用户在设置页显式选了 OLLAMA」与
「谁都没配过、yml 静态默认恰好是 OLLAMA」压成了同一个值。而既有契约
（ChatModelFactoryTest.allowedModelAlwaysUsesOpenRouter）明确要求后者不能妨碍用户
从模型选择器里挑云端模型——那条断言是刻意的，不能为了让新用例变绿去弱化它。
所以新增 isExplicitLocalProvider()：只有 DB 里真写着 OLLAMA 才算那句「不要发出去」，
这时忽略云端 modelId 并落回本地模型（同时打一条 WARN，别让用户以为选的云端模型生效了）。
两条路径（同步与流式）都加。

红：新增两个用例（正文模型、辅助模型），修前实测都拿到 OpenAiChatModel。
绿：两条转 OllamaChatModel，既有的 allowedModelAlwaysUsesOpenRouter 原样通过。

全量 mvn test：2228 通过 0 失败 11 跳过。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)