### PR TITLE
fix(desktop-e2e): finally 里关本地测试站点是死代码，site 声明挪出 try 块（dev-board#76）

### DIFF
--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -120,6 +120,10 @@ const step = async (name, fn) => {
 }
 
 const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null })
+// 本地测试站点（浏览器面板那组用），下面 finally 里要兜底关掉它。
+// 声明必须留在 try 外面：try 块里的 let 对同级 finally 不可见，写在里面 finally 只会抛
+// ReferenceError，再被那行自己的空 catch 吞掉——兜底就成了永不生效的死代码。
+let site = null
 try {
   // main renderer page = the dev URL
   let page = null
@@ -317,7 +321,7 @@ try {
   // 用本机起的两页小站而不是真网站：断言不能挂在外网可达性上。
   const SITE_PORT = pickFreePort(8811)
   const SITE = 'http://127.0.0.1:' + SITE_PORT
-  let site = null
+  site = null
   const clickTabAt = async (idx) => {
     const box = await page.evaluate((check, i) => {
       const el = document.querySelectorAll('.tabs-pane-left .tab-item')[i]


### PR DESCRIPTION
## 问题

`frontend/tests/desktop-e2e/run.mjs` 顶层 `try {`（原 123 行）内部声明 `let site = null`（原 320 行），而配对的 `} finally {` 里有：

```js
try { if (site) site.close() } catch {}
```

JS 里 try 块的 `let` 声明对同级 finally 块不可见，这一句必抛 `ReferenceError: site is not defined`，又被它自己那个空 `catch {}` 原地吞掉。结果是这段「兜底关闭本地测试站点」的代码从来没生效过。

## 影响

不崩溃，但确实是死代码。`site` 是浏览器面板标签页切换那组子测试用的本机 HTTP 小站；正常路径下 step 内部已经显式 `close()` 并置 `site = null`，finally 只是「某个 step 中途失败」时的兜底。因为 `step()` 自己吞异常，失败时会带着监听中的服务器一路跑到 finally，而兜底不生效 → 服务器一直监听到进程退出（`killTree()` + `sleep(1500)` 之后）。后果是一两秒的端口占用，不是灾难，但该修。

## 修法

`let site = null` 挪到 `try` 之前（模块顶层，紧挨 `const browser = ...`），原处改成普通赋值 `site = null`，并留注释说明为什么不能写回 try 里。

## 自验证

从真实文件里机械抽取 `site` 声明行 + finally 体（逐字照搬，只把 `api`/`browser`/`killTree` 等副作用调用打桩），拼成作用域骨架跑红绿：

- 还原病灶（声明放回 try 内）→ 红：兜底 close 未执行，exit 1
- 当前形态 → 绿：兜底 close 已执行，exit 0

骨架里放了 `globalThis.site` 哨兵（其 `close()` 直接抛），确保 finally 读到的是模块级声明而不是全局泄漏。另跑 `node --check frontend/tests/desktop-e2e/run.mjs` 通过。

顺手核了 finally 体引用的其余标识符（`api` 70 行、`QA` 69 行、`browser` 122 行、`killTree` 97 行、`sleep` 105 行）全在模块级，同形状问题只有 `site` 一处。

没有真跑完整 desktop-e2e（需真实 Electron + 后端 + dev server）——这是纯词法作用域问题，跑不跑不改变结论。

dev-board#76

🤖 Generated with [Claude Code](https://claude.com/claude-code)