### PR TITLE
fix(frontend): 请求定序与重入守卫一族十三条——慢响应盖掉新数据、双击发两次请求（dev-board#74）

### DIFF
--- a/frontend/src/components/ClipboardPanel.vue
+++ b/frontend/src/components/ClipboardPanel.vue
@@ -75,6 +75,7 @@ import { getClipboardTypeMeta } from '@/config/clipboard.js'
 import { getSessionId } from '@/utils/auth.js'
 import { ICONS } from '@/config/icons.js'
 import UnlockHint from '@/components/UnlockHint.vue'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 
 export default {
 
@@ -98,7 +99,8 @@ export default {
       items: [],
       // 免费额度下被隐藏（注意：不是被删除）的历史记录条数。解锁后这些记录会原样回来。
       hiddenCount: 0,
-      confirmDeleteId: null
+      confirmDeleteId: null,
+      _refreshSeq: 0
     }
   },
   mounted() {
@@ -116,10 +118,16 @@ export default {
     formatTypeLabel(type) {
       return (getClipboardTypeMeta(type)?.label || String(type || ''))
     },
+    // query 同样绑的是父级搜索框、没有去抖（连 ProjectFavoritesPanel 那种同关键字
+    // 节流都没有），每敲一下键就发一次 listClipboard。响应到达顺序不保证跟敲键顺序
+    // 一致，先敲的（陈旧）关键字若后回，会把已经渲染好的最新结果和「N 条被免费额度
+    // 隐藏」提示一起盖成陈旧值。只认"此刻最新一次"发出的那份。
     async refresh() {
+      const seq = ++this._refreshSeq
       this.loading = true
       try {
         const res = await listClipboard(this.query, 80)
+        if (!shouldAcceptResponse(seq, this._refreshSeq)) return
         // PR-C 起后端返回 { items, limited, hiddenCount, ... }；
         // 数组分支保留给旧后端（桌面壳可能连着未升级的 backend），此时按无额度处理。
         if (Array.isArray(res)) {
@@ -130,10 +138,11 @@ export default {
           this.hiddenCount = res?.limited ? (res.hiddenCount || 0) : 0
         }
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._refreshSeq)) return
         console.error('加载剪贴板失败:', e)
         uni.showToast({ title: this.$t('panels.cpLoadFailed'), icon: 'none' })
       } finally {
-        this.loading = false
+        if (shouldAcceptResponse(seq, this._refreshSeq)) this.loading = false
       }
     },
     preview(it) {

--- a/frontend/src/components/FeedbackWidget.vue
+++ b/frontend/src/components/FeedbackWidget.vue
@@ -185,6 +185,7 @@ import { getRecentErrors, recentErrorCount } from '@/utils/errorBuffer.js'
 import { getLastProjectId } from '@/utils/recentProjects.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
 import { t as t$ } from '@/i18n'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 
 const MAX_IMAGES = 10
 const MAX_RECORD_SECONDS = 120
@@ -259,6 +260,7 @@ export default {
       mineList: [],
       mineLoading: false,
       mineError: '',
+      _mineRequestSeq: 0, // 请求代次：只接受"此刻最新一次" openMine 发出的响应
     }
   },
   computed: {
@@ -430,19 +432,24 @@ export default {
       this.view = 'form'
     },
     // 「我的反馈」视图：每次打开都重新拉一遍，状态会随后台优化者的处理进度变化，
-    // 缓存旧列表只会让用户看到过期的「待发送」。
+    // 缓存旧列表只会让用户看到过期的「待发送」。back 不取消在途请求，快速
+    // myFeedback->back->myFeedback 会并发出两个请求；用请求代次只认最后一次发出的响应，
+    // 防止先发的（陈旧）响应后回来把已经渲染好的新列表盖掉。
     async openMine() {
       this.view = 'mine'
       this.mineLoading = true
       this.mineError = ''
+      const seq = ++this._mineRequestSeq
       try {
         const res = await getMyFeedback()
+        if (!shouldAcceptResponse(seq, this._mineRequestSeq)) return
         const items = (res && res.data && res.data.items) || []
         this.mineList = items.map(formatMineItem)
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._mineRequestSeq)) return
         this.mineError = (e && e.message) || this.$t('feedback.loadFailed')
       } finally {
-        this.mineLoading = false
+        if (shouldAcceptResponse(seq, this._mineRequestSeq)) this.mineLoading = false
       }
     },
     // PR 链接必须走系统浏览器/新标签页：桌面端主进程会拦截渲染层的 window.open，
@@ -559,6 +566,12 @@ export default {
         this.setStatus(this.$t('feedback.recordingUnsupported'), true)
         return
       }
+      // getUserMedia 在飞（权限弹窗展示期间）this.recording 还是 false，二次点击会
+      // 重入整段 try、开出第二路 getUserMedia/MediaRecorder，互相踩踏 this._recorder/
+      // this._stream/this._recordTimer。用独立的启动中标志挡住重入，不能复用 recording
+      // ——它要等 await 之后才置真。
+      if (this._startingRecording) return
+      this._startingRecording = true
       try {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
         const mimeType = pickAudioMime()
@@ -596,6 +609,8 @@ export default {
         }, 1000)
       } catch (e) {
         this.setStatus(this.$t('feedback.micPermissionDenied', { message: (e && e.message) || e }), true)
+      } finally {
+        this._startingRecording = false
       }
     },
     /** @returns {Promise<void>} 录音真正落成 File 之后才 resolve。 */

--- a/frontend/src/components/ProjectFavoritesPanel.vue
+++ b/frontend/src/components/ProjectFavoritesPanel.vue
@@ -67,6 +67,7 @@
 import { getProjectFavorites, deleteFavorite, getFavoriteImageUrl } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
 import { isDesktopHost } from '@/services/host.js'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 
 export default {
 
@@ -93,6 +94,7 @@ export default {
       scrollIntoView: '',
       highlightId: null,
       _lastRefreshAt: 0,
+      _refreshSeq: 0,
       confirmDeleteId: null
     }
   },
@@ -180,16 +182,22 @@ export default {
       if (!force && this._lastRefreshAt && now - this._lastRefreshAt < 1200 && this.query === this._lastRefreshQuery) return
       this._lastRefreshAt = now
       this._lastRefreshQuery = this.query
+      // query 绑的是父级搜索框、没有去抖，每敲一下键就发一次请求；不同关键字的
+      // 响应到达顺序不保证跟敲键顺序一致。先敲的（陈旧）关键字若后回，会把
+      // 已经渲染好的最新搜索结果盖掉。只认"此刻最新一次"发出的那份。
+      const seq = ++this._refreshSeq
       this.loading = true
       try {
         const pid = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
         const list = await getProjectFavorites(pid, this.query, 80)
+        if (!shouldAcceptResponse(seq, this._refreshSeq)) return
         this.items = Array.isArray(list) ? list : (list?.data || [])
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._refreshSeq)) return
         console.error('加载项目收藏失败:', e)
         uni.showToast({ title: this.$t('panels.pfLoadFailed'), icon: 'none' })
       } finally {
-        this.loading = false
+        if (shouldAcceptResponse(seq, this._refreshSeq)) this.loading = false
       }
     },
     requestDelete(id) {

--- a/frontend/src/components/VariablePanel.vue
+++ b/frontend/src/components/VariablePanel.vue
@@ -86,6 +86,7 @@ import {
   saveUserVariable,
   deleteUserVariable
 } from '@/services/api.js'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 
 export default {
   props: {
@@ -112,7 +113,12 @@ export default {
       docFields: [],
       showCreateModal: false,
       createForm: { name: '' },
-      confirmDeleteKey: null
+      confirmDeleteKey: null,
+      // 每个数据源各自的请求代次：三者都被 refresh() 之外的写操作
+      //（confirmDelete/insertVariable 等）单独调用，只在 refresh() 层面挡是不够的。
+      _projectVarsSeq: 0,
+      _userVarsSeq: 0,
+      _docFieldsSeq: 0
     }
   },
   computed: {
@@ -212,37 +218,52 @@ export default {
       }
     },
 
+    // 三个 fetch* 不止被 refresh() 调用，scope 切换连点、或切换紧跟着一次
+    // confirmDelete/insertVariable 触发的单独刷新，都会让同一数据源的两次请求
+    // 并发在飞。网络到达顺序不保证跟发出顺序一致，先发的（陈旧）响应若后回，
+    // 会把已经生效的新数据覆盖回去——比如刚删掉的变量又冒出来，或刚改的值
+    // 被打回旧值。三者各自独立的请求代次，只认"此刻最新一次"发出的那份。
     async fetchProjectVars() {
+      const seq = ++this._projectVarsSeq
       if (!this.projectId) {
-        this.projectVars = []
+        if (shouldAcceptResponse(seq, this._projectVarsSeq)) this.projectVars = []
         return
       }
       try {
         const res = await getProjectVariables(this.projectId)
+        if (!shouldAcceptResponse(seq, this._projectVarsSeq)) return
         this.projectVars = Array.isArray(res) ? res : (res.data || [])
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._projectVarsSeq)) return
         this.projectVars = []
       }
     },
 
     async fetchUserVars() {
+      const seq = ++this._userVarsSeq
       try {
         const res = await getUserVariables()
+        if (!shouldAcceptResponse(seq, this._userVarsSeq)) return
         this.userVars = Array.isArray(res) ? res : (res.data || [])
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._userVarsSeq)) return
         this.userVars = []
       }
     },
 
     async fetchDocFields() {
+      const seq = ++this._docFieldsSeq
       const editor = this.getEditor ? this.getEditor() : null
       if (!editor || typeof editor.listVariableFields !== 'function') {
-        this.docFields = []
+        if (shouldAcceptResponse(seq, this._docFieldsSeq)) this.docFields = []
         return
       }
       try {
-        this.docFields = await editor.listVariableFields()
+        const fields = await editor.listVariableFields()
+        if (!shouldAcceptResponse(seq, this._docFieldsSeq)) return
+        this.docFields = fields
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._docFieldsSeq)) return
         this.docFields = []
       }
     },

--- a/frontend/src/components/admin/AdminPane.vue
+++ b/frontend/src/components/admin/AdminPane.vue
@@ -325,6 +325,7 @@
             <button
               class="btn-save"
               type="primary"
+              :disabled="saving"
               :loading="saving"
               @tap="handleSave"
             >
@@ -520,6 +521,7 @@
             <button
               class="btn-save"
               type="primary"
+              :disabled="saving"
               :loading="saving"
               @tap="handleSave"
             >
@@ -1367,6 +1369,7 @@ import { accountPageUrl, siteBaseUrl, loadSiteLinks, resetSiteLinks } from '@/ut
 import { host } from '@/services/host.js'
 import { setGlobalOverlay } from '@/utils/overlayState.js'
 import { refreshEntitlements, isEnabled, FEATURES } from '@/composables/useEntitlement.js'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 import UnlockHint from '@/components/UnlockHint.vue'
 import MarketPane from '@/components/MarketPane.vue'
 import AwdSelect from '@/components/AwdSelect.vue'
@@ -1446,6 +1449,7 @@ export default {
       // 最后一次点开详情的目标 id：慢到的旧响应不许覆盖后点的那条
       feedbackDetailPendingId: null,
       feedbackLoading: false,
+      feedbackListSeq: 0, // 请求代次：切筛选档太快时，只认"此刻最新一次"发出的列表响应
       feedbackFilter: '',
       feedbackFilters: [
         { key: '', label: this.$t('admin.filterAll') },
@@ -2125,6 +2129,11 @@ export default {
       })
     },
     onNavTap(nav) {
+      // 记忆同步卡的 v-model 直接绑在 this.memoryRepos[i].form 上，loadMemoryRepos()
+      // 每次都用全新对象整体替换这个数组。已经在记忆同步页时再点一次同一个导航项
+      // （双击，或切走又立刻切回同一项），不该触发重拉——否则正在卡片里敲还没保存的
+      // URL/密钥会被这次重拉悄悄冲掉，用户毫无察觉。
+      const wasAlreadyOnMemory = this.activeNav === 'memory'
       this.activeNav = nav.key
       if (nav.key === 'cloud') {
         this.loadCloudConnections()
@@ -2140,7 +2149,7 @@ export default {
         this.loadIdentityCandidates()
         refreshEntitlements()
       }
-      if (nav.key === 'memory') {
+      if (nav.key === 'memory' && !wasAlreadyOnMemory) {
         this.loadMemoryRepos()
       }
       if (nav.key === 'feedback') {
@@ -2152,15 +2161,21 @@ export default {
     async reloadFeedbackPanel() {
       await Promise.all([this.loadFeedbackList(), this.loadOptimizerStatus()])
     },
+    // 切筛选档 A->B 太快时，A、B 两个 getFeedbackList 请求会同时在飞；到达顺序不
+    // 保证跟点击顺序一致。先点的 A 若后回，会把已经渲染好的 B 筛选结果盖成 A 的，
+    // 界面显示的高亮筛选档跟列表内容对不上。只认"此刻最新一次"发出的那份响应。
     async loadFeedbackList() {
+      const seq = ++this.feedbackListSeq
       this.feedbackLoading = true
       try {
         const res = await getFeedbackList(this.feedbackFilter, 100)
+        if (!shouldAcceptResponse(seq, this.feedbackListSeq)) return
         this.feedbackList = ((res && res.data && res.data.items) || [])
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this.feedbackListSeq)) return
         uni.showToast({ title: (e && e.message) || this.$t('admin.loadFeedbackFailed'), icon: 'none' })
       } finally {
-        this.feedbackLoading = false
+        if (shouldAcceptResponse(seq, this.feedbackListSeq)) this.feedbackLoading = false
       }
     },
     async loadOptimizerStatus() {
@@ -3095,6 +3110,9 @@ export default {
       }
     },
     async handleSave() {
+      // 按钮只绑了 :loading，没绑 :disabled，uni-app 的 loading 态本身不拦 tap；
+      // 同文件其它写操作（onSaveBudget/onSwitchSite 等）都在方法体开头挡一道，这里补齐。
+      if (this.saving) return
       this.saving = true
       try {
         await saveAdminConfig(this.form)

--- a/frontend/src/components/version/VersionNodeDetail.vue
+++ b/frontend/src/components/version/VersionNodeDetail.vue
@@ -142,17 +142,24 @@ export default {
       this.$emit('close')
     },
     confirmRevert() {
+      // 本文件其它两个写操作（submitMilestone/submitDraftCreate）都靠 busy 挡重入，
+      // 这里漏了：确认框关掉之后按钮和弹窗都还能再点一次，在第一个 revertToVersion
+      // 请求飞着时能弹出并确认第二个 uni.showModal，打出两个并发的退回请求。
+      if (this.busy) return
       uni.showModal({
         title: this.$t('version.revertToVersion'),
         content: this.$t('version.revertConfirmContent'),
         success: async (r) => {
           if (!r.confirm) return
+          this.busy = true
           try {
             const res = await revertToVersion(this.projectId, this.version.sha)
             const affectedFileIds = (res && res.data && res.data.affectedFileIds) || []
             this.$emit('reload-files', affectedFileIds)
           } catch (e) {
             uni.showToast({ title: (e && e.message) || this.$t('version.revertFailed'), icon: 'none' })
+          } finally {
+            this.busy = false
           }
         },
       })

--- a/frontend/src/components/version/VersionPanel.vue
+++ b/frontend/src/components/version/VersionPanel.vue
@@ -101,6 +101,7 @@ import {
   getVersionStatus, enableVersionControl, listDrafts,
   getCloudStatus, checkCloud, listCloudConnections,
 } from '@/services/api.js'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 import WorkSessionBar from './WorkSessionBar.vue'
 import VersionTimeline from './VersionTimeline.vue'
 import DraftList from './DraftList.vue'
@@ -143,6 +144,7 @@ export default {
       hasConnection: false,
       timelineKey: 0,
       busy: false,
+      refreshSeq: 0,
     }
   },
   watch: {
@@ -159,10 +161,17 @@ export default {
     }).catch(() => {})
   },
   methods: {
+    // refresh() 的触发源很多（mounted/collabRefreshToken watcher/onReload，onReload 又被
+    // WorkSessionBar 结束工作段、三选一冲突弹窗 resolved/aborted 等一堆事件各自触发），
+    // 互相之间可能重叠。没有请求代次的话，先发的那次 getVersionStatus 若后回，会把
+    // 后发的那次已经渲染好的更新状态覆盖回旧值——工作段/稿态/采纳冲突全部倒退，
+    // 且没有任何错误提示。只认"此刻最新一次" refresh 发出的响应。
     async refresh() {
+      const seq = ++this.refreshSeq
       this.loading = true
       try {
         const res = await getVersionStatus(this.projectId)
+        if (!shouldAcceptResponse(seq, this.refreshSeq)) return
         const d = (res && res.data) || {}
         this.enabled = !!d.enabled
         this.working = !!d.working
@@ -184,13 +193,14 @@ export default {
           this.hasConnection = false
         }
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this.refreshSeq)) return
         // 读取失败绝不能落到"未开启"引导页——那会让律师误以为从没开过版本记录，
         // 去重复点开启。宁可显示可区分的错误态，保留 enabled 的上一次已知值。
         console.warn('[Version] 读取状态失败', e)
         this.loadError = true
         uni.showToast({ title: this.$t('version.loadFailedToast'), icon: 'none' })
       } finally {
-        this.loading = false
+        if (shouldAcceptResponse(seq, this.refreshSeq)) this.loading = false
       }
     },
     async fetchDrafts() {

--- a/frontend/src/pages/login/login.vue
+++ b/frontend/src/pages/login/login.vue
@@ -126,7 +126,7 @@
                </view>
                <text class="link-text">{{ $t('account.forgotPassword') }}</text>
             </view>
-            <button class="action-btn" :loading="loginLoading" @tap="handleLogin">{{ $t('account.loginBtn') }}</button>
+            <button class="action-btn" :disabled="loginLoading" :loading="loginLoading" @tap="handleLogin">{{ $t('account.loginBtn') }}</button>
           </view>
 
           <!-- Second Factor Step（登录二次验证：认证器 / 邮箱 / 短信） -->
@@ -144,7 +144,7 @@
                 {{ smsCountdown > 0 ? $t('account.resendCountdown', { count: smsCountdown }) : $t('account.resendCode') }}
               </text>
             </view>
-            <button class="action-btn" :loading="loginLoading" @tap="handleSmsLogin">{{ $t('account.verifyAndLoginBtn') }}</button>
+            <button class="action-btn" :disabled="loginLoading" :loading="loginLoading" @tap="handleSmsLogin">{{ $t('account.verifyAndLoginBtn') }}</button>
           </view>
 
           <!-- Register Form -->
@@ -165,7 +165,7 @@
               <text class="label">{{ $t('account.confirmPasswordLabel') }}</text>
               <input class="glass-input" type="password" v-model="registerForm.passwordConfirm" @confirm="handleRegister" :placeholder="$t('account.confirmPasswordPlaceholder')" placeholder-class="placeholder-style" />
             </view>
-            <button class="action-btn" :loading="registerLoading" @tap="handleRegister">{{ $t('account.registerBtn') }}</button>
+            <button class="action-btn" :disabled="registerLoading" :loading="registerLoading" @tap="handleRegister">{{ $t('account.registerBtn') }}</button>
           </view>
 
           <!-- Client Form -->
@@ -174,7 +174,7 @@
               <text class="label">{{ $t('account.caseAccessCodeLabel') }}</text>
               <input class="glass-input" type="text" v-model="clientForm.accessCode" @confirm="handleClientLogin" :placeholder="$t('account.caseAccessCodePlaceholder')" placeholder-class="placeholder-style" />
             </view>
-            <button class="action-btn" :loading="clientLoginLoading" @tap="handleClientLogin">{{ $t('account.enterCaseBtn') }}</button>
+            <button class="action-btn" :disabled="clientLoginLoading" :loading="clientLoginLoading" @tap="handleClientLogin">{{ $t('account.enterCaseBtn') }}</button>
           </view>
 
           <view class="card-footer">
@@ -366,6 +366,10 @@ export default {
       }
     },
     async handleSmsLogin() {
+      // <button loading> 只画个转圈图标，不会自己拦第二次 tap；模板已经补了
+      // :disabled="loginLoading"，这里在方法体里再挡一道，防止事件在响应式
+      // 状态生效前抢跑发出第二个请求。
+      if (this.loginLoading) return;
       if (!this.smsCodeInput || this.smsCodeInput.length < 6) {
         uni.showToast({ title: this.$t('account.enterSixDigitCode'), icon: 'none' });
         return;
@@ -395,6 +399,7 @@ export default {
       }, 300);
     },
     async handleClientLogin() {
+      if (this.clientLoginLoading) return;
       if (!this.clientForm.accessCode) {
         uni.showToast({ title: this.$t('account.caseAccessCodePlaceholder'), icon: 'none' });
         return;
@@ -419,6 +424,7 @@ export default {
       }
     },
     async handleLogin() {
+      if (this.loginLoading) return;
       if (!this.loginForm.username || !this.loginForm.password) {
         uni.showToast({ title: this.$t('account.enterUsernamePassword'), icon: 'none' });
         return;
@@ -448,6 +454,7 @@ export default {
       }
     },
     async handleRegister() {
+      if (this.registerLoading) return;
       if (!this.registerForm.username || !this.registerForm.password) {
         uni.showToast({ title: this.$t('account.enterUsernamePassword'), icon: 'none' });
         return;

--- a/frontend/src/pages/project-list/project-list.vue
+++ b/frontend/src/pages/project-list/project-list.vue
@@ -341,6 +341,7 @@
  * 兜底在工作台的 onHide/onUnload（admin / plugin-market / variable-library 都没做）。
  */
 import { getMyProjects, deleteProject, renameProject, getProjectMembers, removeProjectMember, getCurrentUser as getCurrentUserApi } from '@/services/api.js'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 import { getProjectTypeLabel } from '@/config/projectTypes.js'
 import { roleLabel, ROLE_LABELS } from '@/config/memberRoles.js'
 import { getCurrentUser, getSessionId } from '@/utils/auth.js'
@@ -414,6 +415,8 @@ export default {
       namingVisible: false,
       namingParentDir: '',
       namingName: '',
+
+      loadProjectsSeq: 0,
     }
   },
   onLoad() {
@@ -448,7 +451,13 @@ export default {
         console.error('获取用户信息失败:', e)
       }
     },
+    // 触发源不止一处（onShow 每次页面重新可见都会跑一次，删除/移出成员/邀请成功
+    // 各自还会再补跑一次），互相之间没有取消机制。每个都要等 N+1 的成员查询
+    // fan-out 落地，谁的 Promise.all 后落地就覆盖 this.projects——旧的那次快照
+    // 若在新的一次（比如删除后的刷新）之后才落地，会把刚删掉的项目重新摆回列表。
+    // 用请求代次只认"此刻最新一次"发出的那份快照。
     async loadProjects() {
+      const seq = ++this.loadProjectsSeq
       this.projectsLoading = true
       try {
         // getMyProjects 返回的是裸数组（ProjectController 直接返 List<ProjectCardDTO>，
@@ -474,8 +483,10 @@ export default {
             return { ...p, members: [] }
           }
         }))
+        if (!shouldAcceptResponse(seq, this.loadProjectsSeq)) return
         this.projects = projectsWithMembers
       } catch (error) {
+        if (!shouldAcceptResponse(seq, this.loadProjectsSeq)) return
         console.error('加载项目列表失败:', error)
         // 桌面端免登：绝不跳 login（launch 分流已保证桌面不进登录页，这里若跳就是死胡同），
         // 只提示错误。浏览器端保留原「登录失效回登录页」兜底。
@@ -489,7 +500,7 @@ export default {
           })
         }
       } finally {
-        this.projectsLoading = false
+        if (shouldAcceptResponse(seq, this.loadProjectsSeq)) this.projectsLoading = false
       }
     },
 
@@ -751,14 +762,24 @@ export default {
         uni.showToast({ title: this.$t('projects.projectNameEmpty'), icon: 'none' })
         return
       }
+      // 输入框同时绑了 @confirm="confirmRename" 和 @blur="cancelRename"：请求飞着时
+      // 点别处会触发 blur，同步把 renamingProjectId/renameValue 清空。续写要是等
+      // await 回来才去读 this.renamingProjectId 就已经是 null 了，find 恒失配，
+      // 卡片名字更新不到本地状态。提前把 id/name 存成局部变量，不再依赖会被
+      // 并发清掉的响应式状态；success 之后也只在仍是本次这轮 rename 时才去关输入框，
+      // 避免误关掉期间用户又对另一个项目开的新一轮改名。
+      const id = this.renamingProjectId
+      const name = this.renameValue.trim()
       try {
-        await renameProject(this.renamingProjectId, this.renameValue.trim())
-        const project = this.projects.find((p) => p.id === this.renamingProjectId)
+        await renameProject(id, name)
+        const project = this.projects.find((p) => p.id === id)
         if (project) {
-          project.name = this.renameValue.trim()
+          project.name = name
         }
-        this.renamingProjectId = null
-        this.renameValue = ''
+        if (this.renamingProjectId === id) {
+          this.renamingProjectId = null
+          this.renameValue = ''
+        }
         uni.showToast({ title: this.$t('projects.renameSuccess'), icon: 'success' })
       } catch (e) {
         console.error('重命名失败', e)

--- a/frontend/tests/project-home/audit-rf-fe2-batch.test.mjs
+++ b/frontend/tests/project-home/audit-rf-fe2-batch.test.mjs
@@ -1,0 +1,679 @@
+// 审计（dev-board#74，dev-board#498 待处理清单）第 rF 批：面板/表单/列表侧的
+// 请求定序 / 在途守卫缺陷。docs/AUDIT_2026-08-20_REMAINING.md 里给的原始行号
+// （780/815/899/906/913/920/927/934/941/948/955/962/969/990）在合入 #506/#517
+// 两次补扫与标注之后已经漂移，跟行号旁边给的中文描述对不上——本文件按内容在当前
+// 文档里重新定位到的真实位置是 843/878/962/969/976/983/990/997/1004/1011/1018/
+// 1025/1032/1053，14 条描述按顺序逐一命中，判定详情见交付回报。
+//
+// 这批里大半是同一个形状：请求定序（先发的响应比后发的晚回，不许覆盖）或
+// 在途重入守卫（请求飞着时再点一次不该再发一次）。能复用 utils/requestGeneration.js
+// 的 shouldAcceptResponse() 就复用，不单独写一套代次判断。
+//
+// 组件带 @/ 别名 import 不进来（本仓 node:test 的一贯限制）。这里统一走「抠出单个
+// 方法的函数体，用 new Function 起真身、依赖全部显式注入」的路子（同
+// tagmanager-add-inflight.test.mjs / version-timeline-race.test.mjs 的既有写法），
+// 只在明确判不出行为差异、只能核实接线的地方才退回源码文本断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { shouldAcceptResponse } from '../../src/utils/requestGeneration.js'
+
+function read(rel) {
+  return readFileSync(new URL('../../src/' + rel, import.meta.url), 'utf8')
+}
+
+// 抠出一个方法的花括号函数体。signature 必须精确到能唯一定位「方法定义」本身
+// （例如 'async refresh() {'），不能只写方法名——很多方法名在同一个文件里还会
+// 以 this.xxx()/@tap="xxx" 的形式作为调用点出现好几次。
+function extractMethod(src, signature) {
+  const head = src.indexOf(signature)
+  assert.ok(head > 0, `找不到方法定义：${signature}`)
+  const braceStart = head + signature.length - 1
+  assert.equal(src[braceStart], '{', `定位到的不是花括号起点：${signature}`)
+  let depth = 0
+  for (let i = braceStart; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}' && --depth === 0) return src.slice(braceStart, i + 1)
+  }
+  throw new Error(`括号没配上：${signature}`)
+}
+
+function deferred() {
+  let resolve, reject
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+// ======================================================================
+// 1. FeedbackWidget.vue toggleRecording()：getUserMedia 在飞时无重入守卫
+//    （文档现址 843，原始清单行号误标 780）
+// ======================================================================
+
+const FW_SRC = read('components/FeedbackWidget.vue')
+
+function makeToggleRecording(getUserMediaImpl) {
+  const body = extractMethod(FW_SRC, 'async toggleRecording() {')
+  return new Function(
+    'navigator', 'MediaRecorder',
+    `return (async function toggleRecording() ${body})`,
+  )({ mediaDevices: { getUserMedia: getUserMediaImpl } }, function FakeMediaRecorder() {})
+}
+
+test('toggleRecording: getUserMedia 在飞时二次点击不会重入，不发出第二个权限请求', async () => {
+  let calls = 0
+  const gate = deferred()
+  const fn = makeToggleRecording(() => { calls++; return gate.promise })
+  const ctx = { recording: false, audio: null, $t: (k) => k, setStatus() {} }
+
+  const first = fn.call(ctx)
+  const second = fn.call(ctx) // this.recording 要等 await 后才置真，此刻仍是 false
+
+  assert.equal(calls, 1, '权限弹窗结果出来前二次点击必须被挡住，不能开出第二路 getUserMedia')
+
+  gate.reject(new Error('denied'))
+  await first
+  await second
+})
+
+test('toggleRecording: 权限请求失败后闸要放开，允许重新发起录音', async () => {
+  let calls = 0
+  const fn = makeToggleRecording(() => { calls++; return Promise.reject(new Error('denied')) })
+  const ctx = { recording: false, audio: null, $t: (k) => k, setStatus() {} }
+
+  await fn.call(ctx)
+  assert.equal(calls, 1)
+  await fn.call(ctx)
+  assert.equal(calls, 2, '第一次失败后应当能重新点击发起录音，不能被永久锁死')
+})
+
+// ======================================================================
+// 5. FeedbackWidget.vue openMine()：无请求定序（文档现址 976，原始行号误标 913）
+// ======================================================================
+
+function makeOpenMine(getMyFeedbackImpl) {
+  const body = extractMethod(FW_SRC, 'async openMine() {')
+  return new Function(
+    'getMyFeedback', 'formatMineItem', 'shouldAcceptResponse',
+    `return (async function openMine() ${body})`,
+  )(getMyFeedbackImpl, (x) => x, shouldAcceptResponse)
+}
+
+test('openMine: 先发后回的响应不能盖掉后发先回的新列表', async () => {
+  const gates = [deferred(), deferred()]
+  let n = 0
+  const fn = makeOpenMine(() => gates[n++].promise)
+  const ctx = { view: '', mineLoading: false, mineError: '', mineList: [], $t: (k) => k, _mineRequestSeq: 0 }
+
+  const first = fn.call(ctx)  // myFeedback -> back -> myFeedback 的第一次
+  const second = fn.call(ctx) // 很快又点了一次
+
+  gates[1].resolve({ data: { items: [{ id: 'B' }] } })
+  await second
+  gates[0].resolve({ data: { items: [{ id: 'A-stale' }] } })
+  await first
+
+  assert.deepEqual(ctx.mineList, [{ id: 'B' }], '陈旧响应不许覆盖已经渲染的新列表')
+  assert.equal(ctx.mineLoading, false)
+})
+
+// ======================================================================
+// 2. VersionPanel.vue refresh()：无在途守卫（文档现址 878，原始行号误标 815）
+// ======================================================================
+
+const VP_SRC = read('components/version/VersionPanel.vue')
+
+function makeVersionPanelVm(api) {
+  const vm = {
+    loading: true, loadError: false, enabled: false, working: false, changedCount: 0,
+    onDraft: null, drafts: [], adoptConflict: null, cloudConflict: null, sessionEndConflict: null,
+    cloud: null, hasConnection: false, timelineKey: 0, busy: false, refreshSeq: 0,
+    projectId: 1,
+    $t: (k) => k,
+    $emit: () => {},
+  }
+  const uni = { showToast() {} }
+  for (const name of ['refresh', 'fetchDrafts', 'fetchCloudState']) {
+    const body = extractMethod(VP_SRC, `async ${name}() {`)
+    vm[name] = new Function(
+      'getVersionStatus', 'listDrafts', 'getCloudStatus', 'listCloudConnections',
+      'shouldAcceptResponse', 'uni',
+      `return (async function ${name}() ${body})`,
+    )(api.getVersionStatus, api.listDrafts, api.getCloudStatus, api.listCloudConnections, shouldAcceptResponse, uni).bind(vm)
+  }
+  return vm
+}
+
+test('VersionPanel.refresh: 两次调用乱序回来，陈旧响应不许覆盖新响应写好的状态', async () => {
+  const gates = [deferred(), deferred()]
+  let n = 0
+  const vm = makeVersionPanelVm({
+    getVersionStatus: () => gates[n++].promise,
+    listDrafts: () => Promise.resolve({ data: { drafts: [] } }),
+    getCloudStatus: () => Promise.resolve({ data: null }),
+    listCloudConnections: () => Promise.resolve({ data: { connections: [] } }),
+  })
+
+  const first = vm.refresh()  // 例如 onReload -> refresh（结束工作段触发），慢
+  const second = vm.refresh() // 例如 collabRefreshToken watcher 触发，快
+
+  gates[1].resolve({ data: { enabled: true, working: false, changedCount: 0, onDraft: null } })
+  await second
+  gates[0].resolve({ data: { enabled: false, working: true, changedCount: 9, onDraft: { x: 1 } } })
+  await first
+
+  assert.equal(vm.enabled, true, '陈旧响应不许把新响应写好的 enabled 覆盖回去')
+  assert.equal(vm.working, false, '陈旧响应不许让工作段状态倒退')
+  assert.equal(vm.changedCount, 0)
+  assert.equal(vm.loading, false, '最新一次请求完成后 loading 必须落回 false')
+})
+
+test('VersionPanel.refresh: 正常单次调用照常把状态写进去（不能过度守卫）', async () => {
+  const vm = makeVersionPanelVm({
+    getVersionStatus: () => Promise.resolve({ data: { enabled: true, working: true, changedCount: 3, onDraft: { name: 'd1' } } }),
+    listDrafts: () => Promise.resolve({ data: { drafts: [{ id: 1 }] } }),
+    getCloudStatus: () => Promise.resolve({ data: { linked: true } }),
+    listCloudConnections: () => Promise.resolve({ data: { connections: [{ id: 9 }] } }),
+  })
+  await vm.refresh()
+  assert.equal(vm.enabled, true)
+  assert.equal(vm.changedCount, 3)
+  assert.deepEqual(vm.drafts, [{ id: 1 }])
+  assert.equal(vm.hasConnection, true)
+  assert.equal(vm.loading, false)
+})
+
+// ======================================================================
+// 3. AdminPane.vue loadFeedbackList()：反馈筛选切换竞态（文档现址 962，原始行号误标 899）
+// ======================================================================
+
+const AP_SRC = read('components/admin/AdminPane.vue')
+
+function makeAdminFeedbackVm(getFeedbackListImpl) {
+  const body = extractMethod(AP_SRC, 'async loadFeedbackList() {')
+  const vm = {
+    feedbackFilter: '', feedbackList: [], feedbackLoading: false, feedbackListSeq: 0,
+    $t: (k) => k,
+  }
+  vm.loadFeedbackList = new Function(
+    'getFeedbackList', 'shouldAcceptResponse', 'uni',
+    `return (async function loadFeedbackList() ${body})`,
+  )(getFeedbackListImpl, shouldAcceptResponse, { showToast() {} }).bind(vm)
+  return vm
+}
+
+test('AdminPane.loadFeedbackList: 切筛选档太快，陈旧档位的响应不许覆盖新档位的列表', async () => {
+  const gates = { A: deferred(), B: deferred() }
+  const vm = makeAdminFeedbackVm((filterKey) => gates[filterKey].promise)
+
+  vm.feedbackFilter = 'A'
+  const first = vm.loadFeedbackList()  // 点了「全部」
+  vm.feedbackFilter = 'B'
+  const second = vm.loadFeedbackList() // 很快又点了「待处理」
+
+  gates.B.resolve({ data: { items: [{ id: 'b1' }] } })
+  await second
+  gates.A.resolve({ data: { items: [{ id: 'a1-stale' }] } })
+  await first
+
+  assert.deepEqual(vm.feedbackList, [{ id: 'b1' }], '陈旧筛选档的响应不许覆盖当前筛选档已经渲染好的列表')
+  assert.equal(vm.feedbackLoading, false)
+})
+
+// ======================================================================
+// 4. AdminPane.vue onNavTap()：重点「记忆同步」丢弃未保存表单（文档现址 969，原始行号误标 906）
+// ======================================================================
+
+function makeOnNavTapVm() {
+  const body = extractMethod(AP_SRC, 'onNavTap(nav) {')
+  const calls = {
+    loadMemoryRepos: 0, loadCloudConnections: 0, loadPlatformServices: 0,
+    loadSite: 0, loadAccount: 0, loadStorageLocation: 0, loadIdentityCandidates: 0,
+    reloadFeedbackPanel: 0, refreshEntitlements: 0,
+  }
+  const onNavTap = new Function(
+    'refreshEntitlements',
+    `return (function onNavTap(nav) ${body})`,
+  )(() => { calls.refreshEntitlements++ })
+  const vm = {
+    activeNav: 'ai',
+    loadMemoryRepos() { calls.loadMemoryRepos++ },
+    loadCloudConnections() { calls.loadCloudConnections++ },
+    loadPlatformServices() { calls.loadPlatformServices++ },
+    loadSite() { calls.loadSite++ },
+    loadAccount() { calls.loadAccount++ },
+    loadStorageLocation() { calls.loadStorageLocation++ },
+    loadIdentityCandidates() { calls.loadIdentityCandidates++ },
+    reloadFeedbackPanel() { calls.reloadFeedbackPanel++ },
+  }
+  vm.onNavTap = onNavTap.bind(vm)
+  return { vm, calls }
+}
+
+test('onNavTap: 已经在记忆同步页时再点一次同一个导航项，不重新触发 loadMemoryRepos', () => {
+  const { vm, calls } = makeOnNavTapVm()
+  vm.onNavTap({ key: 'memory' })
+  assert.equal(calls.loadMemoryRepos, 1, '第一次进入必须加载')
+  vm.onNavTap({ key: 'memory' })
+  assert.equal(calls.loadMemoryRepos, 1, '已经在该页时再点一次不该重新拉，否则会冲掉未保存的表单')
+})
+
+test('onNavTap: 从别的导航项切进记忆同步页仍要正常加载，别的导航项行为不受影响', () => {
+  const { vm, calls } = makeOnNavTapVm()
+  vm.onNavTap({ key: 'feedback' })
+  vm.onNavTap({ key: 'memory' })
+  assert.equal(calls.reloadFeedbackPanel, 1)
+  assert.equal(calls.loadMemoryRepos, 1)
+  vm.onNavTap({ key: 'account' })
+  vm.onNavTap({ key: 'memory' }) // 离开又回来：正常重新加载
+  assert.equal(calls.loadMemoryRepos, 2)
+})
+
+// ======================================================================
+// 14. AdminPane.vue handleSave()：无重入守卫（文档现址 1053，原始行号误标 990）
+// ======================================================================
+
+test('AdminPane.handleSave: 请求飞着时二次点击不会重复发出保存请求', async () => {
+  const gate = deferred()
+  let calls = 0
+  const body = extractMethod(AP_SRC, 'async handleSave() {')
+  const vm = { saving: false, form: { x: 1 }, loadModelCatalog() {}, $t: (k) => k }
+  vm.handleSave = new Function(
+    'saveAdminConfig', 'uni',
+    `return (async function handleSave() ${body})`,
+  )(() => { calls++; return gate.promise }, { showToast() {} }).bind(vm)
+
+  const first = vm.handleSave()
+  const second = vm.handleSave()
+  assert.equal(calls, 1, '第一个保存请求在飞时二次点击不该再发一次')
+
+  gate.resolve({})
+  await first
+  await second
+  assert.equal(vm.saving, false)
+})
+
+test('AdminPane: 两处「保存配置」按钮都绑了 :disabled="saving"（此前只绑 :loading）', () => {
+  const count = (AP_SRC.match(/:disabled="saving"/g) || []).length
+  assert.equal(count, 2, '两处保存按钮都要有 :disabled 绑定，跟 handleSave 的重入闸配套')
+})
+
+// ======================================================================
+// 6. EasyVoicePane.vue：生成的音频 Blob URL 卸载时从不 revoke
+//    文档现址 983（原始行号误标 927）——复核结论：**已经修复，不需要改动**。
+//
+//    beforeUnmount() 里已经有：
+//      this._unmounted = true
+//      if (this.audioUrl) { URL.revokeObjectURL(this.audioUrl); this.audioUrl = '' }
+//    并且已有专门的回归测试锁住这两行：
+//      tests/project-home/audit-b2-source-assertions.test.mjs
+//      「beforeUnmount 置卸载位并释放 audioUrl」
+//    大概率是上一轮 PR#510「TTS 卸载后自动播放泄漏」顺带修的（同一个 _unmounted
+//    判据、同一个 beforeUnmount 钩子）。这里不重复造一份测试，只留下这条说明，
+//    交付回报里也会点出来，别被空跑的红/绿状态误导成"这条我修的"。
+// ======================================================================
+
+// ======================================================================
+// 7. login.vue：登录/注册/客户登录按钮只绑 :loading 不绑 :disabled，允许重复提交
+//    （文档现址 990，原始行号误标 934）
+// ======================================================================
+
+const LOGIN_SRC = read('pages/login/login.vue')
+
+function makeLoginHandler(name, apiParamName, apiImpl) {
+  const body = extractMethod(LOGIN_SRC, `async ${name}() {`)
+  return new Function(
+    apiParamName, 'uni',
+    `return (async function ${name}() ${body})`,
+  )(apiImpl, { showToast() {}, reLaunch() {} })
+}
+
+test('login: handleLogin 请求飞着时二次点击不会重复发出登录请求', async () => {
+  let calls = 0
+  const gate = deferred()
+  const fn = makeLoginHandler('handleLogin', 'login', () => { calls++; return gate.promise })
+  const ctx = { loginLoading: false, loginForm: { username: 'u', password: 'p' }, $t: (k) => k, finishLogin() {} }
+
+  const first = fn.call(ctx)
+  const second = fn.call(ctx)
+  assert.equal(calls, 1, '第一个登录请求在飞时二次点击不该再发一次')
+
+  gate.reject(new Error('bad credentials'))
+  await first
+  await second
+  assert.equal(ctx.loginLoading, false, '失败后闸要放开')
+})
+
+test('login: handleSmsLogin 请求飞着时二次提交验证码不会重复请求', async () => {
+  let calls = 0
+  const gate = deferred()
+  const fn = makeLoginHandler('handleSmsLogin', 'login', () => { calls++; return gate.promise })
+  const ctx = {
+    loginLoading: false, loginForm: { username: 'u', password: 'p' },
+    smsCodeInput: '123456', $t: (k) => k, finishLogin() {}, resetSmsStep() {},
+  }
+
+  const first = fn.call(ctx)
+  const second = fn.call(ctx)
+  assert.equal(calls, 1)
+
+  gate.reject(new Error('bad code'))
+  await first
+  await second
+})
+
+test('login: handleRegister 请求飞着时二次点击不会重复发出注册请求', async () => {
+  let calls = 0
+  const gate = deferred()
+  const fn = makeLoginHandler('handleRegister', 'register', () => { calls++; return gate.promise })
+  const ctx = {
+    registerLoading: false,
+    registerForm: { username: 'u', password: 'password1', passwordConfirm: 'password1', displayName: '' },
+    $t: (k) => k,
+  }
+
+  const first = fn.call(ctx)
+  const second = fn.call(ctx)
+  assert.equal(calls, 1)
+
+  gate.reject(new Error('username taken'))
+  await first
+  await second
+})
+
+test('login: handleClientLogin 请求飞着时二次点击不会重复发出访问码登录请求', async () => {
+  let calls = 0
+  const gate = deferred()
+  const fn = makeLoginHandler('handleClientLogin', 'clientLogin', () => { calls++; return gate.promise })
+  const ctx = { clientLoginLoading: false, clientForm: { accessCode: 'code123' }, $t: (k) => k }
+
+  const first = fn.call(ctx)
+  const second = fn.call(ctx)
+  assert.equal(calls, 1)
+
+  gate.reject(new Error('invalid code'))
+  await first
+  await second
+})
+
+test('login: 四个提交按钮都绑了 :disabled，跟随各自的 loading 标志（此前只绑 :loading）', () => {
+  assert.match(LOGIN_SRC, /:disabled="loginLoading" :loading="loginLoading" @tap="handleLogin"/)
+  assert.match(LOGIN_SRC, /:disabled="loginLoading" :loading="loginLoading" @tap="handleSmsLogin"/)
+  assert.match(LOGIN_SRC, /:disabled="registerLoading" :loading="registerLoading" @tap="handleRegister"/)
+  assert.match(LOGIN_SRC, /:disabled="clientLoginLoading" :loading="clientLoginLoading" @tap="handleClientLogin"/)
+})
+
+// ======================================================================
+// 8. VariablePanel.vue：并发 refresh 竞态让慢响应盖掉更新的变量/字段数据
+//    （文档现址 997，原始行号误标 941）
+// ======================================================================
+
+const VARP_SRC = read('components/VariablePanel.vue')
+
+function makeVariablePanelVm(api) {
+  const vm = {
+    projectId: 1, projectVars: [], userVars: [], docFields: [],
+    _projectVarsSeq: 0, _userVarsSeq: 0, _docFieldsSeq: 0,
+    getEditor: api.getEditor || null,
+  }
+  const deps = {
+    getProjectVariables: api.getProjectVariables || (() => Promise.resolve([])),
+    getUserVariables: api.getUserVariables || (() => Promise.resolve([])),
+  }
+  for (const name of ['fetchProjectVars', 'fetchUserVars', 'fetchDocFields']) {
+    const body = extractMethod(VARP_SRC, `async ${name}() {`)
+    vm[name] = new Function(
+      'getProjectVariables', 'getUserVariables', 'shouldAcceptResponse',
+      `return (async function ${name}() ${body})`,
+    )(deps.getProjectVariables, deps.getUserVariables, shouldAcceptResponse).bind(vm)
+  }
+  return vm
+}
+
+test('VariablePanel.fetchProjectVars: 两次调用乱序回来，陈旧响应不许覆盖新响应的变量列表', async () => {
+  const gates = [deferred(), deferred()]
+  let n = 0
+  const vm = makeVariablePanelVm({ getProjectVariables: () => gates[n++].promise })
+
+  const first = vm.fetchProjectVars()  // 切到 Project 标签触发的一次
+  const second = vm.fetchProjectVars() // 紧接着删除一条变量触发的刷新
+
+  gates[1].resolve([{ name: 'fresh' }])
+  await second
+  gates[0].resolve([{ name: 'stale-should-be-deleted' }])
+  await first
+
+  assert.deepEqual(vm.projectVars, [{ name: 'fresh' }], '刚删掉的变量不许因为陈旧响应又冒出来')
+})
+
+test('VariablePanel.fetchUserVars: 独立写操作触发的调用跟 refresh() 触发的调用共享同一份代次', async () => {
+  const gates = [deferred(), deferred()]
+  let n = 0
+  const vm = makeVariablePanelVm({ getUserVariables: () => gates[n++].promise })
+
+  const fromRefresh = vm.fetchUserVars() // 假设是 refresh() 触发的
+  const fromDelete = vm.fetchUserVars()  // 用户紧接着删除一条又单独触发了一次
+
+  gates[1].resolve([{ name: 'after-delete' }])
+  await fromDelete
+  gates[0].resolve([{ name: 'before-delete-stale' }])
+  await fromRefresh
+
+  assert.deepEqual(vm.userVars, [{ name: 'after-delete' }])
+})
+
+test('VariablePanel.fetchDocFields: 两次调用乱序回来，陈旧响应不许覆盖新响应的字段列表', async () => {
+  const gates = [deferred(), deferred()]
+  let n = 0
+  const editor = { listVariableFields: () => gates[n++].promise }
+  const vm = makeVariablePanelVm({ getEditor: () => editor })
+
+  const first = vm.fetchDocFields()
+  const second = vm.fetchDocFields()
+
+  gates[1].resolve([{ varName: 'fresh' }])
+  await second
+  gates[0].resolve([{ varName: 'stale' }])
+  await first
+
+  assert.deepEqual(vm.docFields, [{ varName: 'fresh' }])
+})
+
+// ======================================================================
+// 9. project-list.vue confirmRename()：blur 在途时把 renamingProjectId 置空
+//    （文档现址 1004，原始行号误标 948）
+// ======================================================================
+
+const PL_SRC = read('pages/project-list/project-list.vue')
+
+function makeProjectListRenameVm(renameProjectImpl) {
+  const confirmBody = extractMethod(PL_SRC, 'async confirmRename() {')
+  const cancelBody = extractMethod(PL_SRC, 'cancelRename() {')
+  const vm = {
+    renamingProjectId: 1,
+    renameValue: '新名字',
+    projects: [{ id: 1, name: '旧名字' }, { id: 2, name: '另一个项目' }],
+    $t: (k) => k,
+  }
+  vm.confirmRename = new Function(
+    'renameProject', 'uni',
+    `return (async function confirmRename() ${confirmBody})`,
+  )(renameProjectImpl, { showToast() {} }).bind(vm)
+  vm.cancelRename = new Function(`return (function cancelRename() ${cancelBody})`)().bind(vm)
+  return vm
+}
+
+test('confirmRename: 请求飞着时 blur 触发 cancelRename 清空 id，续写仍要能改到卡片名字', async () => {
+  const gate = deferred()
+  const vm = makeProjectListRenameVm(() => gate.promise)
+
+  const p = vm.confirmRename() // 用户按 Enter 提交，请求飞着
+  vm.cancelRename()            // 紧接着点了别处：renamingProjectId/renameValue 被清空
+
+  assert.equal(vm.renamingProjectId, null, '前置条件：blur 确实清空了')
+
+  gate.resolve({})
+  await p
+
+  const project = vm.projects.find((x) => x.id === 1)
+  assert.equal(project.name, '新名字', '异步续写必须仍然改到正确的那张卡片，不能因为 id 被清空就丢更新')
+})
+
+test('confirmRename: blur 期间用户对另一个项目开了新一轮改名，前一轮成功不许把它关掉', async () => {
+  const gate = deferred()
+  const vm = makeProjectListRenameVm(() => gate.promise)
+
+  const p = vm.confirmRename() // 对项目 1 改名，请求飞着
+  vm.cancelRename()
+  vm.renamingProjectId = 2     // 用户接着对项目 2 开了新一轮改名（新的 startRename）
+  vm.renameValue = '项目2的新名字'
+
+  gate.resolve({})
+  await p
+
+  assert.equal(vm.renamingProjectId, 2, '项目 1 的改名成功续写不许把项目 2 正在进行的改名输入框关掉')
+})
+
+// ======================================================================
+// 10. project-list.vue loadProjects()：无在途/定序守卫
+//     （文档现址 1011，原始行号误标 955）
+// ======================================================================
+
+function makeLoadProjectsVm(getMyProjectsImpl, getProjectMembersImpl) {
+  const body = extractMethod(PL_SRC, 'async loadProjects() {')
+  const vm = { projects: [], projectsLoading: false, loadProjectsSeq: 0, isDesktop: true, $t: (k) => k }
+  vm.loadProjects = new Function(
+    'getMyProjects', 'getProjectMembers', 'shouldAcceptResponse', 'uni',
+    `return (async function loadProjects() ${body})`,
+  )(getMyProjectsImpl, getProjectMembersImpl, shouldAcceptResponse, { showToast() {}, reLaunch() {} }).bind(vm)
+  return vm
+}
+
+test('loadProjects: 两次调用乱序回来，陈旧快照不许把刚删除的项目复活', async () => {
+  const gates = [deferred(), deferred()]
+  let call = 0
+  const getProjectMembers = () => Promise.resolve({ data: [] })
+  const vm = makeLoadProjectsVm(() => gates[call++].promise, getProjectMembers)
+
+  const first = vm.loadProjects()  // 例如 onShow 触发的一次，慢
+  const second = vm.loadProjects() // 例如删除后触发的一次，快
+
+  gates[1].resolve([{ id: 1, name: 'P1' }])                          // 新的一次先回：项目2已经删了
+  await second
+  gates[0].resolve([{ id: 1, name: 'P1' }, { id: 2, name: 'P2-deleted' }]) // 旧的一次后回：还带着已删的项目2
+  await first
+
+  assert.deepEqual(vm.projects.map((p) => p.id), [1], '陈旧快照不许把刚删除的项目复活进列表')
+  assert.equal(vm.projectsLoading, false)
+})
+
+// ======================================================================
+// 11. VersionNodeDetail.vue confirmRevert()：唯一没有忙碌重入守卫的写操作
+//     （文档现址 1018，原始行号误标 962——凑巧这个数字在当前文档里对应另一条，
+//     已在交付回报里说明）
+// ======================================================================
+
+const VND_SRC = read('components/version/VersionNodeDetail.vue')
+
+function makeVersionNodeDetailVm(revertToVersionImpl) {
+  const body = extractMethod(VND_SRC, 'confirmRevert() {')
+  const modalCalls = []
+  const uni = { showModal: (o) => modalCalls.push(o), showToast() {} }
+  const vm = { busy: false, projectId: 1, version: { sha: 'abc123', when: Date.now() }, $t: (k) => k, $emit: () => {} }
+  vm.confirmRevert = new Function(
+    'revertToVersion', 'uni',
+    `return (function confirmRevert() ${body})`,
+  )(revertToVersionImpl, uni).bind(vm)
+  return { vm, modalCalls }
+}
+
+test('confirmRevert: 请求飞着时再次点击不会弹出第二个确认框', async () => {
+  const gate = deferred()
+  let calls = 0
+  const { vm, modalCalls } = makeVersionNodeDetailVm(() => { calls++; return gate.promise })
+
+  vm.confirmRevert()
+  assert.equal(modalCalls.length, 1)
+  const successPromise = modalCalls[0].success({ confirm: true }) // 用户确认，revertToVersion 飞着
+  assert.equal(vm.busy, true, '确认之后应立即同步置忙碌，不能等请求回来才置')
+
+  vm.confirmRevert() // 忙碌期间再点一次「退回到这一版」
+  assert.equal(modalCalls.length, 1, '忙碌期间不该再弹出第二个确认框')
+
+  gate.resolve({ data: { affectedFileIds: [] } })
+  await successPromise
+
+  assert.equal(calls, 1, '只应发出一次 revertToVersion 请求')
+  assert.equal(vm.busy, false, '完成后闸要放开，允许下一次退回')
+})
+
+// ======================================================================
+// 12. ProjectFavoritesPanel.vue：收藏搜索竞态（文档现址 1025，原始行号误标 969
+//     ——凑巧这个数字在当前文档里对应另一条，已在交付回报里说明）
+// ======================================================================
+
+const PFP_SRC = read('components/ProjectFavoritesPanel.vue')
+
+function makeFavoritesVm(getProjectFavoritesImpl) {
+  const body = extractMethod(PFP_SRC, 'async refresh(force = false) {')
+  const vm = {
+    projectId: 1, query: '', items: [], loading: false,
+    _lastRefreshAt: 0, _lastRefreshQuery: undefined, _refreshSeq: 0,
+    $t: (k) => k,
+  }
+  vm.refresh = new Function(
+    'getProjectFavorites', 'shouldAcceptResponse', 'uni',
+    `return (async function refresh(force = false) ${body})`,
+  )(getProjectFavoritesImpl, shouldAcceptResponse, { showToast() {} }).bind(vm)
+  return vm
+}
+
+test('ProjectFavoritesPanel.refresh: 搜索关键字连续变化，陈旧关键字的响应不许覆盖新关键字的结果', async () => {
+  const gates = { a: deferred(), ab: deferred() }
+  const vm = makeFavoritesVm((_pid, q) => gates[q || 'a'].promise)
+
+  vm.query = 'a'
+  const first = vm.refresh(true)  // force 绕开节流，只隔离测请求定序
+  vm.query = 'ab'
+  const second = vm.refresh(true)
+
+  gates.ab.resolve([{ id: 'ab-1' }])
+  await second
+  gates.a.resolve([{ id: 'a-1-stale' }])
+  await first
+
+  assert.deepEqual(vm.items, [{ id: 'ab-1' }], '陈旧关键字的响应不许覆盖已经渲染的新搜索结果')
+})
+
+// ======================================================================
+// 13. ClipboardPanel.vue：剪贴板搜索竞态（文档现址 1032，原始行号误标 969
+//     ——与上一条撞到同一个原始行号，本身就是原始清单行号已经过时的证据之一）
+// ======================================================================
+
+const CBP_SRC = read('components/ClipboardPanel.vue')
+
+function makeClipboardVm(listClipboardImpl) {
+  const body = extractMethod(CBP_SRC, 'async refresh() {')
+  const vm = { query: '', items: [], loading: false, hiddenCount: 0, _refreshSeq: 0, $t: (k) => k }
+  vm.refresh = new Function(
+    'listClipboard', 'shouldAcceptResponse', 'uni',
+    `return (async function refresh() ${body})`,
+  )(listClipboardImpl, shouldAcceptResponse, { showToast() {} }).bind(vm)
+  return vm
+}
+
+test('ClipboardPanel.refresh: 搜索关键字连续变化，陈旧关键字的响应不许覆盖新关键字的结果', async () => {
+  const gates = { a: deferred(), ab: deferred() }
+  const vm = makeClipboardVm((q) => gates[q || 'a'].promise)
+
+  vm.query = 'a'
+  const first = vm.refresh()
+  vm.query = 'ab'
+  const second = vm.refresh()
+
+  gates.ab.resolve({ items: [{ id: 'ab-1' }], limited: false })
+  await second
+  gates.a.resolve({ items: [{ id: 'a-1-stale' }], limited: false })
+  await first
+
+  assert.deepEqual(vm.items, [{ id: 'ab-1' }], '陈旧关键字的响应不许覆盖已经渲染的新搜索结果')
+})


### PR DESCRIPTION
审计剩余清单里前端「面板/表单/列表」那一组。绝大多数是同一个形状：
异步响应回来时不检查自己是不是最新那一次，或者按钮只画了转圈图标却不真的拦第二次点击。

复用上一轮已经抽出来的 `utils/requestGeneration.js` 的 `shouldAcceptResponse()`，
没有让每个组件各写一套计数器；「忙碌重入」那几条则沿用各文件自己既有的
`busy` / `xLoading` 约定。

1. FeedbackWidget.toggleRecording：入口只判 `this.recording`，而它要到 await
   getUserMedia 之后才置位——权限对话框还开着时再点一次，第二个 recorder/stream
   直接覆盖第一个，第一条流的轨道此后无人可停、第一个计时器句柄也丢了。
2. VersionPanel.refresh：mounted、协作事件、十余处子组件事件都能触发，彼此重叠时
   慢响应会把工作段状态、采纳冲突等回退成陈旧值，还连带把陈旧事件推给页面级 chip。
3. AdminPane 反馈筛选：快速切换筛选 tab 会在新 chip 下显示上一档的列表。
4. AdminPane 导航：重新点一次「记忆同步」会无条件重载，把用户正在填的仓库连接表单冲掉。
   只改了这一支——同结构的 cloud/platform/account/feedback 分支也会无条件重载，
   但清单说的是这一条，没有顺手扫全。
5. FeedbackWidget.openMine：返回后再开「我的反馈」，慢的那次响应会盖掉新的。
6. EasyVoicePane 的 Blob URL 卸载不 revoke：**复核发现已经修好了**——PR #510 修
   「TTS 卸载后自动播放泄漏」时顺带在 beforeUnmount 里 revoke 了，且已有测试钉住。
   本次未改，不重复加测试。
7. login.vue 四个按钮（登录 / 短信二次验证 / 注册 / 客户登录）只绑 :loading 不绑 :disabled。
   uni 的 <button loading> 只画转圈图标、不拦点击。模板补 :disabled（照 wizard.vue 既有做法），
   方法体里再挡一道，防止事件在响应式状态生效前抢跑。
8. VariablePanel：三个取数方法各自独立定序（不能只在 refresh 层加闸——
   confirmDelete / insertVariable 也会单独调它们）。
9. project-list 重命名：在途时 blur 触发的 cancelRename 会把 renamingProjectId 置空，
   异步续写因此更新不到卡片。改成 await 前把 id/name 抓成局部变量，
   并且只在输入框仍属于这一轮重命名时才清空。
10. project-list.loadProjects：无在途/定序守卫，重叠的陈旧调用能把刚删掉的项目复活。
11. VersionNodeDetail.confirmRevert：是这个文件里唯一没跟 busy 约定的写操作，
    双击能发两次退回。
12/13. 收藏面板与剪贴板面板的搜索竞态：快速输入时慢响应盖掉新结果。
    收藏那侧保留了既有的 1.2 秒节流与 force 语义（有测试钉着），只另加定序。
14. AdminPane.handleSave：同文件的 onSaveBudget / onSwitchSite 都有重入守卫，唯独它没有。

顺带记一笔：子 agent 发现我给的行号是在 PR #517 合并前取的（那个 PR 往清单顶部
插了约 63 行说明），它靠标题全文检索重新定位并核对到 14/14 顺序吻合，没有做错条目。

门禁：check:emits / check:nav / check:nav:full / check:locales 全绿；
test:project-home 213 例全过（189 既有 + 24 新增）。
红/绿证据：把 9 个被改文件整体还原后跑新测试，24 例里 21 例正确变红
（另 3 例是刻意的非回归哨兵，本来就该绿），恢复后 24/24 绿。

需要人工走查：权限对话框弹出时连点录音按钮；记忆同步表单填一半重点导航项；
四个登录按钮 loading 期间应呈禁用态；弱网下重命名项目后立刻点别处；
弱网下连点两次「退回到这一版」；收藏/剪贴板搜索框快速输入；连点两次「保存配置」。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)