### PR TITLE
fix(backend): 无上限与永不清理一族七条——输出撑爆内存、令牌与日志永久堆积、上限判得太晚（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/repository/UserActivityLogRepository.java
+++ b/backend/src/main/java/com/checkba/repository/UserActivityLogRepository.java
@@ -3,10 +3,15 @@ package com.checkba.repository;
 import com.checkba.model.entity.UserActivityLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UserActivityLogRepository extends JpaRepository<UserActivityLog, Long> {
     // 限制返回最近 500 条：活动日志随每次页面访问/开关文件持续增长，无界全量查询有 OOM/慢查询风险；
     // "最近动态"语义天然有界，500 条足够展示。
     List<UserActivityLog> findTop500ByUserIdOrderByTimestampDesc(Long userId);
+
+    // 保留窗口清理：该表此前没有 TTL/归档/@Scheduled 清理，行数随全量历史使用单调增长。
+    // 见 UserActivityLogService.purgeOld()。
+    long deleteByTimestampBefore(LocalDateTime cutoff);
 }

--- a/backend/src/main/java/com/checkba/service/DeviceTokenService.java
+++ b/backend/src/main/java/com/checkba/service/DeviceTokenService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.HexFormat;
@@ -17,6 +18,14 @@ import java.util.List;
 public class DeviceTokenService {
 
     public static final String TOKEN_PREFIX = "awdt_";
+
+    /**
+     * lastUsedAt 写回节流：一分钟内的重复请求不再落盘。
+     * 修复病灶：resolveUserId 原来对每一次设备令牌请求都无条件 SELECT+UPDATE，
+     * 云端协作客户端任何一次轮询/只读请求都会被打成一次写库，放大 DB 写负载与行锁竞争。
+     * 与同一文件夹下 UserSessionService 的 TOUCH_INTERVAL 是同一手法，数值也保持一致。
+     */
+    static final Duration TOUCH_INTERVAL = Duration.ofMinutes(1);
 
     private static final SecureRandom RANDOM = new SecureRandom();
 
@@ -49,8 +58,13 @@ public class DeviceTokenService {
         if (plaintext == null || !plaintext.startsWith(TOKEN_PREFIX)) return null;
         return repository.findByTokenHash(sha256(plaintext))
                 .map(t -> {
-                    t.setLastUsedAt(LocalDateTime.now());
-                    repository.save(t);
+                    LocalDateTime now = LocalDateTime.now();
+                    // 节流：lastUsedAt 从未写过，或已超过节流窗口，才补一次写；
+                    // 窗口内的重复请求（同一设备的高频轮询）不再逐请求落库。
+                    if (t.getLastUsedAt() == null || t.getLastUsedAt().plus(TOUCH_INTERVAL).isBefore(now)) {
+                        t.setLastUsedAt(now);
+                        repository.save(t);
+                    }
                     return t.getUserId();
                 })
                 .orElse(null);

--- a/backend/src/main/java/com/checkba/service/UserActivityLogService.java
+++ b/backend/src/main/java/com/checkba/service/UserActivityLogService.java
@@ -5,15 +5,26 @@ import com.checkba.model.entity.UserActivityLog;
 import com.checkba.repository.ProjectRepository;
 import com.checkba.repository.UserActivityLogRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserActivityLogService {
+
+    /**
+     * 日志保留窗口（天）。本类自己定的默认值，非产品要求：这张表目前只服务
+     * getUserLogs 的「最近动态」（findTop500ByUserIdOrderByTimestampDesc，见该方法注释），
+     * 没有任何更长周期的统计依赖它，180 天足够覆盖「最近」语义，同时不再无限增长。
+     */
+    static final long RETENTION_DAYS = 180;
 
     private final UserActivityLogRepository repository;
     private final ProjectRepository projectRepository;
@@ -52,5 +63,18 @@ public class UserActivityLogService {
         }
 
         return logs;
+    }
+
+    /**
+     * 定时清理超出保留窗口的活动日志——此前这张表没有 TTL/归档/@Scheduled 清理，
+     * 行数随全量历史使用单调增长（不止活跃用户，所有历史用户都在贡献行数）。
+     * 写法与同一份代码里 UserSessionService.purgeExpired() 一致。
+     */
+    @Scheduled(fixedDelay = 24 * 60 * 60 * 1000, initialDelay = 15 * 60 * 1000)
+    public void purgeOld() {
+        long removed = repository.deleteByTimestampBefore(LocalDateTime.now().minusDays(RETENTION_DAYS));
+        if (removed > 0) {
+            log.info("清理过期用户活动日志 {} 条", removed);
+        }
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/LitigationVisualService.java
+++ b/backend/src/main/java/com/checkba/service/ai/LitigationVisualService.java
@@ -316,16 +316,18 @@ public class LitigationVisualService {
 
             if (!proc.waitFor(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
                 proc.destroyForcibly();
+                // 超时这一刻排空线程可能还卡在 synchronized(sink) 里追加最后一行——
+                // 读必须跟它用同一把锁，否则 toString() 可能读到半写内容，
+                // 极端情况下内部数组扩容中途还可能抛异常，被外层 catch 吞掉后
+                // 把「出图超时」这个清楚的提示换成一个看起来像引擎崩溃的困惑消息。
                 return new Result(false, JSONUtil.createObj().set("ok", false)
-                        .set("error", "出图超时（" + TIMEOUT_MS / 1000 + " 秒）"), err.toString());
+                        .set("error", "出图超时（" + TIMEOUT_MS / 1000 + " 秒）"), readSink(err));
             }
             op.join(5000);
             ep.join(5000);
 
-            String stdout;
-            String stderr;
-            synchronized (out) { stdout = out.toString().trim(); }
-            synchronized (err) { stderr = err.toString().trim(); }
+            String stdout = readSink(out);
+            String stderr = readSink(err);
 
             if (stdout.isEmpty()) {
                 // cli.py 的契约是「无论成败都打一行 JSON」。什么都没有，说明解释器
@@ -362,6 +364,18 @@ public class LitigationVisualService {
         t.setDaemon(true);
         t.start();
         return t;
+    }
+
+    /**
+     * 安全地取出 pump() 排空线程正在写的缓冲区快照。StringBuilder 本身不是线程安全的，
+     * 必须跟 pump() 里 append 用的同一把锁（sink 自身的对象监视器）同步，
+     * 否则 toString() 可能在 append 中途读到半写内容，甚至在内部数组扩容中途抛异常。
+     * 包可见：供测试直接驱动，不依赖真实子进程。
+     */
+    static String readSink(StringBuilder sink) {
+        synchronized (sink) {
+            return sink.toString().trim();
+        }
     }
 
     /** 读一份引擎自带的参考文档（渐进披露用）。越界返回 null。 */

--- a/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginMarketService.java
@@ -12,7 +12,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -526,16 +529,45 @@ public class PluginMarketService {
      * @param bearer 非空时带 {@code Authorization: Bearer}；付费项 file 端点需要
      */
     protected RegistryReply httpGetBytes(String url, String bearer) {
-        HttpResponse resp;
+        HttpResponse resp = null;
         try {
             HttpRequest req = HttpRequest.get(url).setConnectionTimeout(5000).setReadTimeout(60000);
             if (bearer != null && !bearer.isBlank()) {
                 req.header("Authorization", "Bearer " + bearer);
             }
             resp = req.execute();
+            // 病灶：原来是 resp.bodyBytes() 把整份响应先吃进内存，MAX_FILE_BYTES 只在
+            // readBinary() 里事后判 data.length——恶意/异常大响应（被拒绝之前）已经把
+            // 堆占满了，注释里"防御恶意注册表打爆内存"的说法名不副实。改成边读边计数，
+            // 超限立即掐断连接，不等整份读完。
+            return new RegistryReply(resp.getStatus(), readCapped(resp.bodyStream()));
+        } catch (IllegalStateException e) {
+            throw e; // 50MB 上限异常：原样透传，message 已经是最终提示
         } catch (Exception e) {
             throw new IllegalStateException(LangText.of("下载失败: ", "Download failed: ") + e.getMessage());
+        } finally {
+            if (resp != null) {
+                resp.close();
+            }
         }
-        return new RegistryReply(resp.getStatus(), resp.bodyBytes());
+    }
+
+    /**
+     * 流式读取并边读边计数，超过 MAX_FILE_BYTES 立即掐断——不像 resp.bodyBytes() 那样
+     * 先把整份响应吃进内存再判长度。包可见：供测试直接驱动，不依赖真实网络/50MB 数据。
+     */
+    static byte[] readCapped(InputStream in) throws IOException {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        long total = 0;
+        int n;
+        while ((n = in.read(chunk)) != -1) {
+            total += n;
+            if (total > MAX_FILE_BYTES) {
+                throw new IllegalStateException(LangText.of("文件超过 50 MB 上限", "File exceeds the 50 MB limit"));
+            }
+            buf.write(chunk, 0, n);
+        }
+        return buf.toByteArray();
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -59,6 +59,22 @@ public class PluginService {
     private final Map<String, File> pluginDirById = new ConcurrentHashMap<>();
 
     /**
+     * 当前这一代已加载的插件 JAR ClassLoader。loadJar() 每次都 new 一个 URLClassLoader，
+     * 从来没有配对的 close()——rescan()/热重载/装卸插件反复调用，长期运行的服务器进程
+     * 上会不断攒 fd 与已加载类的元数据。
+     *
+     * <p>不在 loadJar() 里当场关：那会让刚加载出来的插件类立刻失效（工具对象若懒加载
+     * 同一 JAR 里此刻还没碰过的辅助类会失败——URLClassLoader.close() 不影响已加载的类，
+     * 但会让该 loader 之后再也读不到 jar 里的新类/资源）。改成在 rescan() 里统一处理：
+     * 新一代通过 loadPlugins() 完整重建、注册表已经整体换过、ToolRegistry 缓存也失效之后，
+     * 上一代不再可能被任何新请求经 pluginTools 查到，这时才安全关闭。
+     *
+     * <p>本字段的读写全部发生在 synchronized(this) 的方法里（rescan / setEnabled 都是），
+     * 不需要并发安全的集合类型。
+     */
+    private final List<URLClassLoader> loadedClassLoaders = new ArrayList<>();
+
+    /**
      * 被平台封禁的插件 id -> 原因（由 PluginRevocationService 从注册表同步）。
      * 命中者强制禁用且不允许用户重新启用，见 docs/PLUGIN_DISTRIBUTION.md §8。
      */
@@ -101,6 +117,11 @@ public class PluginService {
     /** 供测试直接装配 ToolRegistry（生产环境由 Spring 按上面的 @Autowired 字段注入）。 */
     void setToolRegistry(ToolRegistry toolRegistry) {
         this.toolRegistry = toolRegistry;
+    }
+
+    /** 供测试查看当前这一代插件 JAR ClassLoader 的快照。 */
+    List<URLClassLoader> loadedClassLoaders() {
+        return new ArrayList<>(loadedClassLoaders);
     }
 
     /** 兼容构造器：仅供既有单测直接 new 使用（无持久化，启停状态只存内存） */
@@ -167,6 +188,10 @@ public class PluginService {
      * 注意：已由旧 ClassLoader 加载的类不会被卸载（MVP 可接受），重扫主要用于发现新装插件。
      */
     public synchronized void rescan() {
+        // 上一代 loader 留到新一代完整接管注册表之后才关，见 loadedClassLoaders 字段注释。
+        List<URLClassLoader> previousGeneration = new ArrayList<>(loadedClassLoaders);
+        loadedClassLoaders.clear();
+
         plugins.clear();
         pluginTools.clear();
         toolSpecifications.clear();
@@ -181,6 +206,15 @@ public class PluginService {
             toolRegistry.invalidatePluginToolCache();
         }
         log.info("Plugin rescan done: {} plugins, {} tools", plugins.size(), pluginTools.size());
+
+        // 新一代已经完整接管，上一代不可能再被任何请求经 pluginTools 查到，此时关闭安全。
+        for (URLClassLoader old : previousGeneration) {
+            try {
+                old.close();
+            } catch (IOException e) {
+                log.debug("关闭上一代插件 ClassLoader 失败（忽略）: {}", e.getMessage());
+            }
+        }
     }
 
     /**
@@ -600,6 +634,7 @@ public class PluginService {
 
     private void loadJar(File jar, String pluginId) throws IOException, ClassNotFoundException {
         URLClassLoader loader = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader());
+        loadedClassLoaders.add(loader);
 
         try (java.util.jar.JarFile jarFile = new java.util.jar.JarFile(jar)) {
             Enumeration<java.util.jar.JarEntry> entries = jarFile.entries();

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -46,6 +46,15 @@ public class PythonTools implements AgentToolComponent {
 
     private static final String DOCKER_IMAGE = "python:3.9-slim";
 
+    /**
+     * stdout/stderr 排空缓冲区的字符数上限。本类自己定的默认值（非产品要求）：
+     * 病灶是子进程输出无上限地堆进 JVM 堆里的 StringBuilder——AI 脚本一次
+     * read_document 一份大文档再 print 出来，或死循环脚本在 120 秒超时前疯狂
+     * 打印，都可能把并发跑着的多个 run_python 共同挤爆后端堆，殃及其它请求。
+     * 2MB 字符足够容纳绝大多数正常调试/分析输出的可读部分。
+     */
+    static final int MAX_OUTPUT_CHARS = 2 * 1024 * 1024;
+
     // Python helper code that provides the default_api object
     private static final String PYTHON_API_BRIDGE = """
 # === Auto-injected API Bridge ===
@@ -318,14 +327,27 @@ default_api = _ToolAPI()
 
     /**
      * 后台守护线程持续读取进程输出流到缓冲，防止管道写阻塞导致子进程挂死。
+     *
+     * <p>缓冲区有上限（{@link #MAX_OUTPUT_CHARS}）：超出后不再追加，但仍继续把流读空
+     * ——子进程输出超过 OS 管道缓冲（~64KB）就会阻塞在 write，停止读取会让进程
+     * 永远退不出去，只是把已经不需要的多余内容原地丢弃即可。
      */
-    private Thread pumpStream(java.io.InputStream in, StringBuilder sink) {
+    Thread pumpStream(java.io.InputStream in, StringBuilder sink) {
         Thread t = new Thread(() -> {
             try (BufferedReader r = new BufferedReader(
                     new InputStreamReader(in, java.nio.charset.StandardCharsets.UTF_8))) {
                 String line;
+                boolean truncated = false;
                 while ((line = r.readLine()) != null) {
-                    synchronized (sink) { sink.append(line).append('\n'); }
+                    synchronized (sink) {
+                        if (sink.length() < MAX_OUTPUT_CHARS) {
+                            sink.append(line).append('\n');
+                        } else if (!truncated) {
+                            sink.append("\n... [输出超过 ").append(MAX_OUTPUT_CHARS / (1024 * 1024))
+                                    .append("MB 上限，已截断] ...\n");
+                            truncated = true;
+                        }
+                    }
                 }
             } catch (java.io.IOException ignored) {
                 // 进程结束/流关闭时正常退出

--- a/backend/src/main/java/com/checkba/service/telemetry/MatterClassifierService.java
+++ b/backend/src/main/java/com/checkba/service/telemetry/MatterClassifierService.java
@@ -40,6 +40,23 @@ public class MatterClassifierService {
     /** 已分类会话（进程内去重即可：重启后重复分类的概率与代价都可忽略） */
     private final Set<String> classified = ConcurrentHashMap.newKeySet();
 
+    /**
+     * classified 去重集合的上界；本类自己定的默认值（产品未提出具体要求），非精确值：
+     * 单条几十字节的会话 id，一万条内存占用可忽略，只是不能真的无上界。命中上界后
+     * 整体清空重来（见 classifyAsync）——代价是清空后可能重复分类个别会话，
+     * 但这本来就是纯遥测、无用户可见影响，换取「不无限增长」足够划算。
+     * 包可见 + 非 final：测试用小上界驱动，不必真跑一万次。
+     */
+    int maxClassifiedEntries = 10_000;
+
+    /**
+     * AI 分类调用的重试次数上界。classifyAsync 只在会话首轮被调用，去重位一旦提前置上
+     * 就再没有第二次机会——与其让一次瞬时失败（网络抖动/模型偶发 5xx）永久丢掉这条
+     * 会话的事项类别遥测，不如原地重试几次。次数是本类自己定的，不重试到永远。
+     * 包可见 + 非 final：测试用。
+     */
+    int maxClassifyAttempts = 3;
+
     private final ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "matter-classifier");
         t.setDaemon(true);
@@ -65,6 +82,9 @@ public class MatterClassifierService {
             if (conversationId == null || firstUserMessage == null || firstUserMessage.isBlank()) return;
             if (skillMatched) return;
             if (!settings.rollupEnabled()) return;
+            if (classified.size() >= maxClassifiedEntries) {
+                classified.clear();
+            }
             if (!classified.add(conversationId)) return;
             String snippet = firstUserMessage.length() > 500
                     ? firstUserMessage.substring(0, 500) : firstUserMessage;
@@ -76,15 +96,22 @@ public class MatterClassifierService {
     }
 
     private void classify(String conversationId, String message) {
-        try {
-            ChatLanguageModel model = chatModelFactory.getChatModel(classifierModel);
-            String raw = model.generate(PROMPT_PREFIX + message);
-            MatterCategory category = MatterCategory.parse(raw);
-            telemetryService.recordConv("matter.classified", conversationId,
-                    Map.of("category", category.display(), "source", "ai"));
-        } catch (Exception e) {
-            log.debug("事项分类失败（忽略）: {}", e.toString());
+        Exception lastError = null;
+        for (int attempt = 1; attempt <= maxClassifyAttempts; attempt++) {
+            try {
+                ChatLanguageModel model = chatModelFactory.getChatModel(classifierModel);
+                String raw = model.generate(PROMPT_PREFIX + message);
+                MatterCategory category = MatterCategory.parse(raw);
+                telemetryService.recordConv("matter.classified", conversationId,
+                        Map.of("category", category.display(), "source", "ai"));
+                return;
+            } catch (Exception e) {
+                lastError = e;
+                log.debug("事项分类第 {}/{} 次尝试失败: {}", attempt, maxClassifyAttempts, e.toString());
+            }
         }
+        log.debug("事项分类失败（已重试 {} 次，忽略）: {}", maxClassifyAttempts,
+                lastError == null ? "" : lastError.toString());
     }
 
     /** 测试用：等待异步队列排空 */

--- a/backend/src/test/java/com/checkba/service/DeviceTokenServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/DeviceTokenServiceTest.java
@@ -116,4 +116,35 @@ class DeviceTokenServiceTest {
         assertEquals(1, mineOfB.size());
         assertEquals(issuedB.id(), mineOfB.get(0).getId());
     }
+
+    // ==== 修复：resolveUserId 原来每个设备令牌请求都无条件写一次库（SELECT+UPDATE），
+    // 云端协作客户端的每次轮询/读接口都被打成一次写。节流到「一分钟内不重复落盘」，
+    // 与同一份代码里 UserSessionService 的 TOUCH_INTERVAL 节流手法一致。
+
+    @Test
+    void resolveUserIdThrottlesRepeatedLastUsedAtWrites() {
+        DeviceTokenService.IssuedToken issued = svc.issue(42L, "MacBook"); // save #1：签发本身要落库
+
+        // 节流窗口内连续解析三次，应该只在首次（lastUsedAt 从未写过）补一次 save，
+        // 之后的重复请求不能再逐请求写库。
+        assertEquals(42L, svc.resolveUserId(issued.plaintext()));
+        assertEquals(42L, svc.resolveUserId(issued.plaintext()));
+        assertEquals(42L, svc.resolveUserId(issued.plaintext()));
+
+        org.mockito.Mockito.verify(repo, org.mockito.Mockito.times(2)).save(any());
+    }
+
+    @Test
+    void resolveUserIdWritesAgainAfterThrottleWindowElapses() {
+        DeviceTokenService.IssuedToken issued = svc.issue(42L, "MacBook"); // save #1
+        svc.resolveUserId(issued.plaintext()); // save #2：lastUsedAt 首次从 null 写入
+
+        DeviceToken token = byHash.values().iterator().next();
+        // 手工把 lastUsedAt 拨回节流窗口之外，模拟「一分钟后又来了一次请求」。
+        token.setLastUsedAt(token.getLastUsedAt().minus(DeviceTokenService.TOUCH_INTERVAL).minusSeconds(1));
+
+        assertEquals(42L, svc.resolveUserId(issued.plaintext())); // save #3：窗口已过，应重新写
+
+        org.mockito.Mockito.verify(repo, org.mockito.Mockito.times(3)).save(any());
+    }
 }

--- a/backend/src/test/java/com/checkba/service/UserActivityLogServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/UserActivityLogServiceTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
@@ -105,5 +106,23 @@ class UserActivityLogServiceTest {
         service.getUserLogs(USER);
 
         verify(projectRepository, org.mockito.Mockito.never()).findAllById(any());
+    }
+
+    // ==== 修复：user_activity_log 此前没有任何 TTL/归档/@Scheduled 清理，行数随全量历史
+    // 使用单调增长（见类头注释）。补一个按保留窗口清理的定时任务，与同一份代码里
+    // UserSessionService.purgeExpired() 的写法一致。
+
+    @Test
+    void purgeOldDeletesRowsOlderThanRetentionWindow() {
+        when(repository.deleteByTimestampBefore(any())).thenReturn(3L);
+
+        service.purgeOld();
+
+        org.mockito.ArgumentCaptor<java.time.LocalDateTime> captor =
+                org.mockito.ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+        verify(repository).deleteByTimestampBefore(captor.capture());
+        long daysBeforeNow = java.time.Duration.between(captor.getValue(), java.time.LocalDateTime.now()).toDays();
+        assertTrue(Math.abs(daysBeforeNow - UserActivityLogService.RETENTION_DAYS) <= 1,
+                "清理截止时间应约为「现在减保留天数」，实际相差 " + daysBeforeNow + " 天");
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/LitigationVisualServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/LitigationVisualServiceTest.java
@@ -13,6 +13,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -347,6 +349,52 @@ class LitigationVisualServiceTest {
         assertNull(svc.readReference("../cli.py"), "穿越出 engine/ 应被挡");
         assertNull(svc.readReference("/etc/passwd"), "绝对路径应被挡");
         assertNull(svc.readReference("references/../../PATCHES.md"), "绕回上层应被挡");
+    }
+
+    // ==== 并发安全 ====
+
+    /**
+     * 修复：超时分支读 stderr 用的是裸 {@code err.toString()}，没有跟排空线程写
+     * 用的同一把锁（{@code synchronized(sink)}）同步——StringBuilder 本身不是
+     * 线程安全的，toString() 与 append() 并发时可能读到半写的内容，极端情况下
+     * 还可能因为内部数组扩容中途而抛异常，被外层 catch 吞掉后把「出图超时」这个
+     * 清楚的提示换成一个看起来像引擎崩溃的困惑消息。
+     *
+     * <p>不依赖自然产生的竞态窗口（那样测试会时红时绿）：用两个 CountDownLatch
+     * 把交错顺序摆死——写线程先拿到锁、追加一半内容后卡住不放锁，主线程这时去读。
+     * 若读跟写线程用的是同一把锁，读必须被挡住，直到写线程把剩下内容追加完、
+     * 释放锁之后，读到的才是完整值；若读没有同步，会立刻读到「半写」的内容。
+     */
+    @Test
+    @DisplayName("修复：超时分支读 stderr 必须与排空线程的写用同一把锁，不能读到半写的内容")
+    void timeoutPathReadsStderrUnderTheSameLockTheWriterUses() throws Exception {
+        StringBuilder sink = new StringBuilder();
+        CountDownLatch writerHoldingLock = new CountDownLatch(1);
+        CountDownLatch releaseWriter = new CountDownLatch(1);
+        Thread writer = new Thread(() -> {
+            synchronized (sink) {
+                sink.append("partial");
+                writerHoldingLock.countDown();
+                try {
+                    // 最多卡 1 秒——即便主线程的读没有被挡住（说明有 bug），测试也不会真的卡死。
+                    releaseWriter.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+                sink.append("-done");
+            }
+        });
+        writer.start();
+        assertTrue(writerHoldingLock.await(2, TimeUnit.SECONDS), "写线程应先拿到锁并追加了一半内容");
+
+        long startNanos = System.nanoTime();
+        String observed = LitigationVisualService.readSink(sink);
+        long blockedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+        writer.join(2000);
+
+        assertEquals("partial-done", observed,
+                "读必须等写线程把完整内容追加完才能拿到——读到 \"" + observed + "\" 说明没有跟写用同一把锁同步");
+        assertTrue(blockedMillis >= 800,
+                "同步读应该被写线程持锁的那段时间（约 1 秒）挡住，实际只等了 " + blockedMillis + "ms");
     }
 
     // ==== doctor ====

--- a/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginMarketServiceTest.java
@@ -10,9 +10,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Signature;
@@ -598,5 +601,40 @@ class PluginMarketServiceTest {
         var list = svc.listMarket();
         assertEquals(0, list.get(0).getPriceCents(), "负数按未知");
         assertEquals(0, list.get(1).getPriceCents(), "超上限只可能是畸形值，不能当真价展示");
+    }
+
+    // ==== 修复：50MB 单文件下载上限原来是在 resp.bodyBytes() 把整份响应吃进内存之后才判的，
+    // 恶意/异常大响应能在被拒绝之前先把堆占满。readCapped 必须边读边计数，超限立即掐断。
+
+    @Test
+    @DisplayName("修复：readCapped 边读边计数，超过 50MB 立即掐断，不必先把整份响应吃进内存")
+    void readCappedAbortsWithoutMaterializingOversizedResponse() {
+        // 永不返回 -1、也不预先分配任何内存的 InputStream：只有真正「边读边判」的实现
+        // 才能在有限时间内收敛——先读完整份再判长度的实现会一直读到 OOM/超时都不返回。
+        InputStream endless = new InputStream() {
+            @Override
+            public int read() {
+                return 'x';
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                java.util.Arrays.fill(b, off, off + len, (byte) 'x');
+                return len;
+            }
+        };
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            IllegalStateException e = assertThrows(IllegalStateException.class,
+                    () -> PluginMarketService.readCapped(endless));
+            assertTrue(e.getMessage().contains("50 MB"), e.getMessage());
+        });
+    }
+
+    @Test
+    @DisplayName("readCapped 对未超限的正常响应原样返回全部字节")
+    void readCappedReturnsFullDataWhenUnderLimit() throws Exception {
+        byte[] small = "hello world".getBytes(StandardCharsets.UTF_8);
+        byte[] result = PluginMarketService.readCapped(new ByteArrayInputStream(small));
+        assertArrayEquals(small, result);
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -301,6 +301,49 @@ class PluginServiceTest {
         assertDoesNotThrow(service::rescan);
     }
 
+    /**
+     * 修复：loadJar() 每次都 new 一个 URLClassLoader 加载插件 JAR，从来没有配对的 close()。
+     * rescan()/PluginDevService 热重载/广场装卸插件都会反复调用它，长期运行的服务器
+     * 进程上会不断攒 fd 与已加载类的元数据，最终可能导致插件 JAR 加载开始抛 IOException。
+     *
+     * <p>不能在 loadJar() 里当场关：那会让刚加载出来的插件类立刻失效（已注册的工具对象
+     * 若懒加载同一 JAR 里此刻还没碰过的辅助类会失败）。安全的时机是「下一代已经
+     * 完整接管注册表之后」——此时上一代不再可能被任何新请求经 pluginTools 查到。
+     * 用 JDK 21 实测过的行为验证「真的调用了 close()」：close() 后，loader 上
+     * 从未被访问过的资源会读不到（返回 null），而不是抛异常——这是比检查内部字段
+     * 更可靠的信号。
+     */
+    @Test
+    @DisplayName("修复：rescan 关闭上一代插件 ClassLoader，不能只增不减地攒 fd")
+    void rescanClosesPreviousGenerationClassLoaders() throws IOException {
+        Path pluginDir = pluginsDir.resolve("loader-plugin");
+        Files.createDirectories(pluginDir);
+        writeRealJar(pluginDir.resolve("tool.jar"));
+        writeManifest("loader-plugin",
+                "{\"id\": \"loader-plugin\", \"name\": \"L\", \"backendJars\": [\"tool.jar\"]}");
+
+        service.init();
+        assertEquals(1, service.loadedClassLoaders().size(), "第一代应注册 1 个 loader");
+        java.net.URLClassLoader first = service.loadedClassLoaders().get(0);
+        assertNotNull(first.getResourceAsStream("hello/Foo.class"), "关闭前应能正常读取 jar 内容");
+
+        service.rescan();
+
+        assertEquals(1, service.loadedClassLoaders().size(), "重扫后应只保留新一代，不累积");
+        assertNotSame(first, service.loadedClassLoaders().get(0), "新一代应是全新的 loader 实例");
+        assertNull(first.getResourceAsStream("hello/Foo.class"),
+                "上一代 loader 必须在新一代接管注册表后被 close，否则 fd 一直攒（病灶）");
+    }
+
+    /** 写一个真正合法的 JAR（含两个 class 条目，字节内容不必是合法字节码——不测加载，只测 loader 生命周期）。 */
+    private void writeRealJar(Path jarPath) throws IOException {
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(Files.newOutputStream(jarPath))) {
+            jos.putNextEntry(new java.util.jar.JarEntry("hello/Foo.class"));
+            jos.write(new byte[]{1, 2, 3, 4});
+            jos.closeEntry();
+        }
+    }
+
     // ==== backendJars 路径校验 ====
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsOutputCapTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsOutputCapTest.java
@@ -1,0 +1,66 @@
+package com.checkba.service.ai.tools;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 修复：run_python 的 stdout/stderr 排空线程原来把子进程输出无上限地塞进
+ * JVM 堆里的 StringBuilder（AI 脚本 print 一份大文档，或死循环脚本在 120 秒
+ * 超时前疯狂打印，都能把堆撑爆，殃及同一后端 JVM 上不相干的请求）。
+ * pumpStream 必须边读边丢弃超限部分，而不是先攒满再判。
+ */
+class PythonToolsOutputCapTest {
+
+    private static PythonTools tools() {
+        return new PythonTools(null, null, null, null);
+    }
+
+    /** 构造一份远超上限的多行输出（约 20MB），不依赖真实子进程/Docker。 */
+    private static String bigMultilineText(int lineCount, int lineLength) {
+        String oneLine = "x".repeat(lineLength);
+        StringBuilder raw = new StringBuilder(lineCount * (lineLength + 1));
+        for (int i = 0; i < lineCount; i++) {
+            raw.append(oneLine).append('\n');
+        }
+        return raw.toString();
+    }
+
+    @Test
+    @DisplayName("修复：超限输出必须被截断，不能无上限塞进 StringBuilder")
+    void pumpStreamCapsUnboundedOutput() throws InterruptedException {
+        String raw = bigMultilineText(20_000, 1000); // 约 20,000,000 字符，远超任何合理上限
+        InputStream in = new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8));
+
+        StringBuilder sink = new StringBuilder();
+        Thread t = tools().pumpStream(in, sink);
+        t.join(15_000);
+
+        assertFalse(t.isAlive(), "排空线程应在有限流读完后正常结束");
+        synchronized (sink) {
+            assertTrue(sink.length() < raw.length(),
+                    "超限内容必须被截断，实际长度 " + sink.length() + "，原始长度 " + raw.length());
+            assertTrue(sink.length() <= PythonTools.MAX_OUTPUT_CHARS + 2000,
+                    "截断后的长度应贴着上限，不能明显超出，实际长度 " + sink.length());
+        }
+    }
+
+    @Test
+    @DisplayName("未超限的正常输出原样保留，不受截断逻辑影响")
+    void pumpStreamKeepsNormalOutputIntact() throws InterruptedException {
+        String line = "hello from python";
+        InputStream in = new ByteArrayInputStream((line + "\n").getBytes(StandardCharsets.UTF_8));
+        StringBuilder sink = new StringBuilder();
+        Thread t = tools().pumpStream(in, sink);
+        t.join(5000);
+        synchronized (sink) {
+            assertTrue(sink.toString().contains(line));
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/telemetry/MatterClassifierServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/telemetry/MatterClassifierServiceTest.java
@@ -103,4 +103,47 @@ class MatterClassifierServiceTest {
             svc.flush();
         });
     }
+
+    // ==== 修复：classifyAsync 只在会话首轮被调用，去重位提前置上后就再没有第二次机会——
+    // 真正值得做的是给 AI 调用本身加有限次重试，以及给去重集合加上界（见类注释与 PR 说明）。
+
+    @Test
+    void transientFailureIsRetriedAndSucceedsOnSecondAttempt() throws Exception {
+        // 第一次调用（网络抖动/瞬时 5xx 等）失败，第二次成功——不该像原来那样一次失败就永久放弃。
+        when(model.generate(anyString()))
+                .thenThrow(new RuntimeException("model down"))
+                .thenReturn("合规监管");
+        svc.classifyAsync("conv-7", "帮我看看合规要求", false);
+        String attrs = capturedCategory();
+        assertTrue(attrs.contains("合规监管"));
+        verify(model, times(2)).generate(anyString());
+    }
+
+    @Test
+    void retriesGiveUpAfterBoundedAttempts() throws Exception {
+        when(model.generate(anyString())).thenThrow(new RuntimeException("model down"));
+        assertDoesNotThrow(() -> {
+            svc.classifyAsync("conv-8", "帮我看看合规要求", false);
+            svc.flush();
+        });
+        // 重试次数必须有限——不能因为一直失败就无限重试拖住后台线程。
+        verify(model, times(svc.maxClassifyAttempts)).generate(anyString());
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void classifiedSetHasUpperBoundAndResetsInsteadOfGrowingForever() throws Exception {
+        when(model.generate(anyString())).thenReturn("其他法律事务");
+        svc.maxClassifiedEntries = 2; // 缩小上界，测试不必真跑一万次
+
+        svc.classifyAsync("conv-a", "问题一", false);
+        svc.classifyAsync("conv-b", "问题二", false);
+        svc.flush();
+        // 去重集合已达上界（2），第三个不同会话到来时必须整体清空重来，
+        // 而不是无限增长——即便这意味着 conv-a 会被重复分类一次。
+        svc.classifyAsync("conv-a", "问题一，再来一次", false);
+        svc.flush();
+
+        verify(model, times(3)).generate(anyString());
+    }
 }


### PR DESCRIPTION
审计剩余清单里「无上限/无清理/资源不释放」那一组，七条全部落地，无跳过。
每条先写测试看它红、改实现看它绿、再把实现临时还原确认测试真会红。

1. [MEDIUM] 事项分类的去重位在异步 AI 调用成功之前就置上，且集合无上界
   一次瞬时失败（网关超时、配额用尽）就让这个会话的事项类别在整个进程生命期内
   再也产不出来；而 `classified` 是个没有 TTL 也没有上界的 Set，
   每个不同 conversationId 攒一条，云端进程能连着跑几周。
   注意：`classifyAsync` 只在会话首轮被调用，所以「失败后把去重位摘掉」拿不到第二次机会——
   真正有用的是给那次调用加有限次重试（3 次），外加给集合加上界（1 万条，触顶整体清空）。
   两个阈值都是本类自定的，不是产品拍板的数字。

2. [MEDIUM] 设备令牌鉴权每个请求都写一次库
   照抄同目录 `UserSessionService` 既有的 1 分钟节流写法；补了 `lastUsedAt` 为 null 的判空
   （`issue()` 不初始化该字段，与 UserSession 不同）。

3. [MEDIUM] user_activity_log 永不清理，无限增长
   加定时清理（写法与 `UserSessionService.purgeExpired()` 一致），保留 180 天——
   这张表只服务「最近 500 条」查询，没有更长周期的依赖。
   仓库新增的是对既有 timestamp 列的派生删除方法，**没有加数据库列**。

4. [MEDIUM] Python 子进程的 stdout/stderr 进无上限 StringBuilder
   一段疯狂打印的脚本能把后端堆撑爆。加 2MB 上限；
   **超限后仍继续把流读空**——停止排空会让子进程因管道写满而永久挂起，那比 OOM 更难查。

5. [MEDIUM] 超时路径读共享 stderr 缺同步
   排空线程写的时候持 `synchronized(sink)`，而超时分支是裸 `toString()`；
   正常路径的读反倒是同步的，口径不一致。抽出统一的读方法。
   测试没有去赌自然竞态窗口（那样会时红时绿），而是用两个 CountDownLatch 把交错顺序摆死。

6. [MEDIUM] 每次加载 JAR 新建的 URLClassLoader 从不 close
   rescan / 热重载 / 装卸插件反复调用，长期运行的进程上不断攒 fd 与类元数据。
   **不在 loadJar() 里当场关**（那会让刚加载的插件类立刻失效），改成
   「记录并在 rescan 时统一关掉上一代」：新一代通过 loadPlugins() 完整重建、
   注册表整体换过、ToolRegistry 缓存也失效之后，上一代不可能再被任何新请求查到，这时才关。
   **残留风险如实记下**：rescan 触发那一瞬间正在执行的旧一代工具调用，
   若恰好第一次触达该 JAR 里此前从未加载过的辅助类，仍可能因 loader 已关闭而失败。
   这与该文件原有注释承认的「已加载的类不会被卸载（MVP 可接受）」是同一类残留，
   本次只收口 fd 累积，不解决类卸载本身。

7. [MEDIUM] 50MB 单文件下载上限是在整个响应已经进内存之后才判的
   `bodyBytes()` 先吃满内存，`readBinary` 才判长度——上限形同虚设。
   改成流式边读边计数，超过 50MB（产品既定值，未改）立即掐断；
   顺带补了 `resp.close()`（现在可能提前中止读取，必须显式释放连接）。
   `readBinary` 里原有的事后检查保留，作为大量单测直接打桩 httpGetBytes 那些场景的防线。
   这条的红特别直接：还原成「先读完再判」后直接把 fork 出来的测试 JVM 打挂
   （OutOfMemoryError: Required array length 2147483639 + 9 too large）。

自定阈值汇总（都不是产品拍板的数字，写在这里方便回查）：
分类重试 3 次 / 已分类会话上界 1 万条 / 活动日志保留 180 天 / 子进程输出 2MB。

全量 mvn test：2275 通过 0 失败 11 跳过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)