### PR TITLE
fix(backend): 数字类脱敏规则把立案号、快递单号当成身份证/银行卡打码（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/model/SensitiveType.java
+++ b/backend/src/main/java/com/checkba/model/SensitiveType.java
@@ -12,7 +12,7 @@ public enum SensitiveType {
     PHONE(
         "PHONE",
         "手机号",
-        "1[3-9]\\d{9}",
+        "(?<!\\d)1[3-9]\\d{9}(?!\\d)",
         "138****1234",
         "保留前3后4位"
     ),
@@ -20,7 +20,7 @@ public enum SensitiveType {
     ID_CARD(
         "ID_CARD",
         "身份证号",
-        "\\d{15}|\\d{17}[0-9Xx]",
+        "(?<![0-9Xx])(?:\\d{17}[0-9Xx]|\\d{15})(?![0-9Xx])",
         "3301**********1234",
         "保留前6后4位"
     ),
@@ -36,7 +36,7 @@ public enum SensitiveType {
     BANK_CARD(
         "BANK_CARD",
         "银行卡号",
-        "\\d{16,19}",
+        "(?<!\\d)\\d{16,19}(?!\\d)",
         "6222******8888",
         "保留前6后4位"
     ),
@@ -52,7 +52,7 @@ public enum SensitiveType {
     FIXED_PHONE(
         "FIXED_PHONE",
         "固定电话",
-        "0\\d{2,3}-?\\d{7,8}",
+        "(?<!\\d)0\\d{2,3}-?\\d{7,8}(?!\\d)",
         "010-****5678",
         "保留区号和后4位"
     ),
@@ -114,6 +114,72 @@ public enum SensitiveType {
     /**
      * Mask the original string based on the type's strategy
      */
+    /**
+     * 这个候选串是不是真的像它被判定的那类信息。
+     *
+     * <p>纯正则分不开「18 位立案号」与「18 位身份证号」——它们长得一模一样。
+     * 身份证有 GB 11643 的 mod-11-2 校验位、银行卡有 Luhn 校验位，
+     * 用它们能把绝大多数误判挡掉；而**校验不过的号本来就不是有效的身份证/银行卡**，
+     * 给它打码是误伤，不是保护。法律文书必须逐字可引，改坏正文的代价不比漏打码小。
+     *
+     * <p>其余类型没有可用的校验位，一律放行（行为不变）。
+     */
+    public boolean isPlausible(String candidate) {
+        if (candidate == null || candidate.isEmpty()) return false;
+        return switch (this) {
+            case ID_CARD -> isPlausibleIdCard(candidate);
+            case BANK_CARD -> luhnValid(candidate);
+            default -> true;
+        };
+    }
+
+    /** 18 位查 mod-11-2 校验位与出生日期；15 位没有校验位，只查出生日期。 */
+    private static boolean isPlausibleIdCard(String value) {
+        if (value.length() == 15) {
+            return isRealDate("19" + value.substring(6, 12));
+        }
+        if (value.length() != 18) return false;
+        if (!isRealDate(value.substring(6, 14))) return false;
+        int[] weights = {7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2};
+        char[] codes = {'1', '0', 'X', '9', '8', '7', '6', '5', '4', '3', '2'};
+        int sum = 0;
+        for (int i = 0; i < 17; i++) {
+            char c = value.charAt(i);
+            if (c < '0' || c > '9') return false;
+            sum += (c - '0') * weights[i];
+        }
+        return Character.toUpperCase(value.charAt(17)) == codes[sum % 11];
+    }
+
+    /** yyyyMMdd 是不是一个真实存在的日期（顺带挡掉 2026 年之后与 1900 年之前的荒谬值）。 */
+    private static boolean isRealDate(String yyyyMMdd) {
+        try {
+            java.time.LocalDate d = java.time.LocalDate.parse(
+                    yyyyMMdd, java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
+            int year = d.getYear();
+            return year >= 1900 && !d.isAfter(java.time.LocalDate.now());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static boolean luhnValid(String value) {
+        int sum = 0;
+        boolean doubleIt = false;
+        for (int i = value.length() - 1; i >= 0; i--) {
+            char c = value.charAt(i);
+            if (c < '0' || c > '9') return false;
+            int d = c - '0';
+            if (doubleIt) {
+                d *= 2;
+                if (d > 9) d -= 9;
+            }
+            sum += d;
+            doubleIt = !doubleIt;
+        }
+        return sum % 10 == 0;
+    }
+
     public String mask(String original) {
         if (original == null || original.isEmpty()) {
             return original;

--- a/backend/src/main/java/com/checkba/service/SensitiveService.java
+++ b/backend/src/main/java/com/checkba/service/SensitiveService.java
@@ -301,6 +301,8 @@ public class SensitiveService {
 
                 Matcher matcher = type.getPattern().matcher(text);
                 while (matcher.find()) {
+                    // 校验位过不去的（18 位立案号之类）不是这类信息，涂黑它就是把正文改坏
+                    if (!type.isPlausible(matcher.group())) continue;
                     addRedactionArea(type, matcher.start(), matcher.end());
                 }
             }
@@ -374,7 +376,7 @@ public class SensitiveService {
         }
     }
 
-    private String replaceSensitiveData(String content, String strategyCode) {
+    String replaceSensitiveData(String content, String strategyCode) {
         if (StrUtil.isEmpty(content)) return content;
         
         SensitiveType type = SensitiveType.fromCode(strategyCode);
@@ -387,7 +389,8 @@ public class SensitiveService {
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String original = matcher.group();
-            String masked = type.mask(original);
+            // 同上：校验位过不去的原样留下，法律文书必须逐字可引
+            String masked = type.isPlausible(original) ? type.mask(original) : original;
             matcher.appendReplacement(sb, Matcher.quoteReplacement(masked));
         }
         matcher.appendTail(sb);

--- a/backend/src/test/java/com/checkba/model/SensitiveTypeMatchTest.java
+++ b/backend/src/test/java/com/checkba/model/SensitiveTypeMatchTest.java
@@ -1,0 +1,93 @@
+package com.checkba.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Matcher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 数字类脱敏规则的过度匹配。
+ *
+ * <p>病灶两层：
+ * <ol>
+ *   <li>模式两端没有「不接数字」的断言，于是一串更长的数字（快递单号、流水号、
+ *       拼接时间戳）里会被切出一段当成银行卡号/身份证号打码——原文被改坏，
+ *       而用户看不到任何「这里可能误判了」的提示；</li>
+ *   <li>即便长度正好，18 位的案号与 18 位的身份证号在纯正则眼里长得一模一样。
+ *       身份证有 mod-11-2 校验位、银行卡有 Luhn 校验位，能把绝大多数误判挡掉，
+ *       而校验不过的号本来就不是有效的身份证/银行卡，给它打码就是误伤。</li>
+ * </ol>
+ * 法律文书必须逐字可引，改坏正文的代价不比漏打码小。
+ */
+class SensitiveTypeMatchTest {
+
+    /** 用给定前缀算出 Luhn 校验位，拼成一张合法卡号（测试自证，不写死魔数）。 */
+    private static String withLuhn(String prefix) {
+        int sum = 0;
+        boolean doubleIt = true;
+        for (int i = prefix.length() - 1; i >= 0; i--) {
+            int d = prefix.charAt(i) - '0';
+            if (doubleIt) {
+                d *= 2;
+                if (d > 9) d -= 9;
+            }
+            sum += d;
+            doubleIt = !doubleIt;
+        }
+        return prefix + ((10 - sum % 10) % 10);
+    }
+
+    private static String firstMatch(SensitiveType type, String text) {
+        Matcher m = type.getPattern().matcher(text);
+        return m.find() ? m.group() : null;
+    }
+
+    @Test
+    @DisplayName("更长的数字串里不许切出一段当成银行卡号")
+    void bankCardDoesNotMatchInsideALongerDigitRun() {
+        String text = "运单号 1234567890123456789012345 已签收。";
+        assertNull(firstMatch(SensitiveType.BANK_CARD, text),
+                "长数字串里被切出一段打码，正文就被改坏了");
+    }
+
+    @Test
+    @DisplayName("更长的数字串里不许切出一段当成手机号/身份证号")
+    void phoneAndIdCardDoNotMatchInsideALongerDigitRun() {
+        assertNull(firstMatch(SensitiveType.PHONE, "流水号 99913800001111999 结转。"));
+        assertNull(firstMatch(SensitiveType.ID_CARD, "编号 9911010519491231002X9 备案。"));
+    }
+
+    @Test
+    @DisplayName("身份证：校验位过得去的才算，18 位案号不算")
+    void idCardRequiresChecksum() {
+        assertTrue(SensitiveType.ID_CARD.isPlausible("11010519491231002X"), "这是标准的合法样例号");
+        assertFalse(SensitiveType.ID_CARD.isPlausible("202601011234567890"),
+                "18 位立案号不是身份证号，不该被当成身份证打码");
+    }
+
+    @Test
+    @DisplayName("银行卡：Luhn 过得去的才算")
+    void bankCardRequiresLuhn() {
+        String valid = withLuhn("622202100112233");
+        assertEquals(16, valid.length());
+        assertTrue(SensitiveType.BANK_CARD.isPlausible(valid));
+        assertFalse(SensitiveType.BANK_CARD.isPlausible("202601011234567890"),
+                "18 位立案号不是卡号，不该被当成银行卡打码");
+    }
+
+    @Test
+    @DisplayName("护栏：正常的手机号/身份证/卡号照样命中，别把该打的码打漏了")
+    void realValuesStillMatch() {
+        assertEquals("13800001111", firstMatch(SensitiveType.PHONE, "联系电话 13800001111。"));
+        assertEquals("11010519491231002X",
+                firstMatch(SensitiveType.ID_CARD, "身份证号 11010519491231002X。"));
+        String card = withLuhn("622202100112233");
+        assertEquals(card, firstMatch(SensitiveType.BANK_CARD, "卡号 " + card + "。"));
+        assertTrue(SensitiveType.PHONE.isPlausible("13800001111"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/SensitiveTextReplaceTest.java
+++ b/backend/src/test/java/com/checkba/service/SensitiveTextReplaceTest.java
@@ -1,0 +1,32 @@
+package com.checkba.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 正文替换这条路上的过度匹配：法律文书里到处是长数字（立案号、送达回证号、流水号），
+ * 它们被当成身份证/银行卡打码，文书就不再逐字可引了，而用户看不到任何提示。
+ */
+class SensitiveTextReplaceTest {
+
+    private final SensitiveService service = new SensitiveService();
+
+    @Test
+    @DisplayName("18 位立案号不动，真身份证照打码")
+    void caseNumberSurvivesWhileRealIdIsMasked() {
+        String text = "案号 202601011234567890，当事人身份证号 11010519491231002X。";
+        String out = service.replaceSensitiveData(text, "ID_CARD");
+        assertTrue(out.contains("202601011234567890"), "立案号被改坏了：" + out);
+        assertTrue(!out.contains("11010519491231002X"), "真身份证没打码：" + out);
+    }
+
+    @Test
+    @DisplayName("超长数字串整体不动，不许从中间切一段打码")
+    void longDigitRunIsLeftAlone() {
+        String text = "运单号 1234567890123456789012345 已签收。";
+        assertEquals(text, service.replaceSensitiveData(text, "BANK_CARD"));
+    }
+}


### PR DESCRIPTION
这条是我分派 7 组任务时漏掉的一条，自己补上。

病灶两层：

1. **模式两端没有「不接数字」的断言**。于是一串更长的数字里会被切出一段来打码——
   25 位运单号里切出 19 位当银行卡号、17 位流水号里切出 11 位当手机号。
   原文被改坏，而用户看不到任何「这里可能误判了」的提示。
   顺带暴露一个此前没人注意的事实：`\d{15}|\d{17}[0-9Xx]` 这条模式对一个**合法的
   18 位身份证号**只匹配到前 15 位（左边的 `\d{15}` 分支先赢），
   打出来的码位置是错的。加了断言之后两个分支的顺序也调过来了。

2. **即便长度正好，18 位立案号与 18 位身份证号在纯正则眼里长得一模一样**。
   身份证有 GB 11643 的 mod-11-2 校验位、银行卡有 Luhn 校验位，用它们能把绝大多数
   误判挡掉；而校验不过的号**本来就不是有效的身份证/银行卡**，给它打码是误伤、不是保护。
   新增 `SensitiveType.isPlausible()`：ID_CARD 查校验位与出生日期（15 位没有校验位，
   只查日期），BANK_CARD 查 Luhn，其余类型没有可用校验位一律放行（行为不变）。
   正文替换与 PDF 涂黑两条路都接上这道判定。

取舍说明：这是一次**收紧**脱敏规则，方向上与维护者点名要先拍板的 CHINESE_NAME 那条同族。
区别在于这条在 #498 清单里是明确要修的，且判据是客观校验位而不是语义猜测——
校验不过的串按定义就不是身份证/银行卡。法律文书必须逐字可引，改坏正文的代价不比漏打码小。
真实号码几乎必然通过校验位（那是发证时算出来的），所以漏打码的风险很小；
若发现有手抄错的号因此漏掉，把 isPlausible 的对应分支改回 true 即可。

红：5 个新用例全红，其中正文那条的红特别直白——
`案号 202601011234567890` 被打成 `案号 202601********7890`。
绿：全部通过，且护栏用例钉住「正常的手机号/身份证/卡号照样命中」。
防空断言：把 isPlausible 还原成恒真，3 条立刻复红。

全量 mvn test：2270 通过 0 失败 11 跳过。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)