### PR TITLE
fix(backend): 「查了再做」竞态十条——额度被并发绕过、重复文件夹、幽灵行、深度截断静默丢文件（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
@@ -2,6 +2,8 @@ package com.checkba.repository;
 
 import com.checkba.model.entity.ProjectFile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +13,16 @@ public interface ProjectFileRepository extends JpaRepository<ProjectFile, Long> 
      * 根据项目 ID 查询所有文件（包含已删除），用于文件树清单采集
      */
     List<ProjectFile> findByProjectId(Long projectId);
+
+    /**
+     * 悲观行锁读取（SELECT ... FOR UPDATE）。用于把「查当前用量 + 判断放行」钉进调用方
+     * 已经开着的那个事务里：行锁与事务同生命周期，提交/回滚前不释放——不像进程内锁那样
+     * 在方法返回时就提前释放，能正确堵住 check-then-act 竞态（见 StageQuotaService.checkAdmission
+     * 的用法与注释）。三个受支持的数据库（H2/PostgreSQL/MySQL）都支持 FOR UPDATE。
+     */
+    @Lock(jakarta.persistence.LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT pf FROM ProjectFile pf WHERE pf.id = :id")
+    Optional<ProjectFile> lockById(Long id);
 
     /**
      * 根据项目 ID 和父文件夹 ID 查询文件列表（按排序序号排序，排除已删除）

--- a/backend/src/main/java/com/checkba/service/DdService.java
+++ b/backend/src/main/java/com/checkba/service/DdService.java
@@ -5,7 +5,10 @@ import com.checkba.repository.*;
 import com.checkba.storage.StorageServiceFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.UUID;
 
@@ -34,6 +38,28 @@ public class DdService {
     private final ProjectFileRepository projectFileRepository;
     private final ProjectFileService projectFileService;
     private final StorageServiceFactory storageServiceFactory;
+
+    /**
+     * 本 bean 的懒加载自身代理，只为让 {@link #ensureFolderTx} 经 Spring 的事务代理真正开出
+     * 独立新事务——写法与 {@link ProjectProfileService#self} 同一套。
+     */
+    @Autowired
+    @Lazy
+    DdService self;
+
+    /**
+     * ensureFolder 按 (projectId, parentId, name) 序列化「查是否已有 + 没有就建」这段临界区。
+     * uploadFile 本身带 @Transactional，如果只在这个既有事务里加一把进程内锁——锁在方法
+     * 返回时就释放，而 createFolder 的插入要到 uploadFile 整个方法返回、AOP 代理提交时才
+     * 真正落库；第二个线程拿到锁后即使重新查库，看到的仍是第一个线程未提交的旧状态，
+     * 照样会插出重复文件夹。project_file 表按团队约定不加 (project_id, parent_id, name)
+     * 唯一约束（ddl-auto: update + 可能已有重复数据，风险大于收益），所以也没有「插入撞约束
+     * 后重查」这条退路可用。于是锁必须包住一个自己独立提交的新事务：ensureFolder 只做
+     * 加锁与转发，真正的查+建放进 {@link #ensureFolderTx}（REQUIRES_NEW，挂起
+     * uploadFile 的外层事务、自己开一个物理事务并在方法返回时提交），锁直到这个子事务
+     * 提交之后才释放，下一个等锁的线程进来时数据库里已经是提交后的真实状态。
+     */
+    private final ConcurrentHashMap<String, Object> ensureFolderLocks = new ConcurrentHashMap<>();
 
     /**
      * 获取项目的尽调请求列表
@@ -296,6 +322,15 @@ public class DdService {
     }
 
     private ProjectFile ensureFolder(Long projectId, Long parentId, String name, Long userId) {
+        String key = projectId + "/" + parentId + "/" + name;
+        Object lock = ensureFolderLocks.computeIfAbsent(key, k -> new Object());
+        synchronized (lock) {
+            return self.ensureFolderTx(projectId, parentId, name, userId);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    ProjectFile ensureFolderTx(Long projectId, Long parentId, String name, Long userId) {
         Optional<ProjectFile> folderOpt = projectFileRepository.findByProjectIdAndParentIdAndName(projectId, parentId, name);
         if (folderOpt.isPresent()) {
             return folderOpt.get();

--- a/backend/src/main/java/com/checkba/service/FileVariableService.java
+++ b/backend/src/main/java/com/checkba/service/FileVariableService.java
@@ -13,11 +13,37 @@ public class FileVariableService {
 
     private final FileVariableRepository fileVariableRepository;
 
+    /**
+     * 本 bean 的懒加载自身代理。同类方法互相调用不经 Spring 代理，@Transactional 会被静默
+     * 绕过，所以重试必须经由它转发。字段注入 + @Lazy 打破自引用的构造期死环，
+     * 写法与 ProjectVariableService.self / ProjectProfileService.self 同一套。
+     */
+    @org.springframework.beans.factory.annotation.Autowired
+    @org.springframework.context.annotation.Lazy
+    FileVariableService self;
+
+
     public List<FileVariable> getVariables(Long fileId) {
         return fileVariableRepository.findByFileId(fileId);
     }
 
+    /**
+     * 先查后建，(file_id, name) 上有真实 DB 唯一约束。理由与做法同
+     * {@link UserVariableService#createOrUpdateVariable}：撞约束会把当前事务标 rollback-only，
+     * 同方法内 catch 救不回来，重试必须落在经 self 转发出来的新事务里。
+     */
     public FileVariable createOrUpdateVariable(FileVariable variable) {
+        try {
+            return self.createOrUpdateVariableTx(variable);
+        } catch (org.springframework.dao.DataIntegrityViolationException
+                | org.springframework.transaction.UnexpectedRollbackException e) {
+            return self.createOrUpdateVariableTx(variable);
+        }
+    }
+
+    @org.springframework.transaction.annotation.Transactional(
+            propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public FileVariable createOrUpdateVariableTx(FileVariable variable) {
         return fileVariableRepository.findByFileIdAndName(variable.getFileId(), variable.getName())
                 .map(existing -> {
                     existing.setValue(variable.getValue());

--- a/backend/src/main/java/com/checkba/service/LocalProjectService.java
+++ b/backend/src/main/java/com/checkba/service/LocalProjectService.java
@@ -204,7 +204,8 @@ public class LocalProjectService {
         for (ProjectFile f : rows) {
             if (Boolean.TRUE.equals(f.getIsDeleted())) continue;
             Path physical;
-            if (Boolean.TRUE.equals(f.getIsFolder())) {
+            boolean isFolder = Boolean.TRUE.equals(f.getIsFolder());
+            if (isFolder) {
                 physical = root.resolve(relativeFolderPath(f, byId));
             } else if (StringUtils.hasText(f.getFilePath())) {
                 try {
@@ -215,7 +216,25 @@ public class LocalProjectService {
             } else {
                 continue; // 无物理路径的行（历史遗留）不动
             }
-            if (!Files.exists(physical)) {
+            boolean missing = !Files.exists(physical);
+            if (!missing && isFolder) {
+                // macOS 默认的 APFS/HFS+ 等大小写不敏感、大小写保留的文件系统上，仅改大小写的
+                // 重命名（"Docs" -> "docs"）之后，旧大小写路径的 Files.exists 依然为 true
+                // （不敏感匹配命中了同一个物理目录），这一行永远不会被判定为缺失——importFolder
+                // 那侧因为 rowKey 按大小写敏感比对，已经在同一轮对账里为新大小写建了一个新行，
+                // 于是旧行成为再也清不掉的永久幽灵行。toRealPath() 能拿到磁盘上的真实大小写；
+                // 与库里存的名字不一致，说明这一行对应的物理目录已经不是"这个大小写"了，
+                // 按缺失处理，交给下面的软删除（下一轮对账会让新大小写那行成为唯一存活的行）。
+                try {
+                    String realName = physical.toRealPath().getFileName().toString();
+                    if (!realName.equals(f.getName())) {
+                        missing = true;
+                    }
+                } catch (IOException ignored) {
+                    // 拿不到真实路径（权限/竞态）时保持原判断，不误伤
+                }
+            }
+            if (missing) {
                 // 父级已被软删除的行会随递归一起处理，重复调用无害（幂等）
                 try {
                     projectFileService.delete(f.getId(), ownerId);
@@ -364,6 +383,16 @@ public class LocalProjectService {
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                     String fileName = file.getFileName().toString();
                     if (fileName.startsWith(".")) return FileVisitResult.CONTINUE;
+                    if (attrs.isDirectory()) {
+                        // walkFileTree 到达 maxDepth=MAX_IMPORT_DEPTH 时，正卡在边界上的目录
+                        // 不会走 preVisitDirectory（那样就得再往下探一层，超出 maxDepth），
+                        // 而是被当成一个不透明的条目直接扔进 visitFile——这里看到的"文件"
+                        // 其实是目录，就是深度封顶的信号：它自己和它底下的一切都不会再被
+                        // 任何回调访问到，是本轮扫描静默漏掉的那一段。与 MAX_IMPORT_ENTRIES
+                        // 上限不同，这里没有天然会执行到的判断点，必须主动识别这个信号。
+                        stats.truncated = true;
+                        return FileVisitResult.CONTINUE;
+                    }
                     if (!attrs.isRegularFile()) return FileVisitResult.CONTINUE;
                     if (stats.imported >= MAX_IMPORT_ENTRIES) {
                         stats.truncated = true;

--- a/backend/src/main/java/com/checkba/service/ProjectVariableService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectVariableService.java
@@ -3,7 +3,12 @@ package com.checkba.service;
 import com.checkba.model.entity.ProjectVariable;
 import com.checkba.repository.ProjectVariableRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,6 +17,16 @@ public class ProjectVariableService {
 
     @Autowired
     private ProjectVariableRepository repository;
+
+    /**
+     * 本 bean 的懒加载自身代理，只为让 createOrUpdateVariable 的重试真正经过 Spring 的事务
+     * 代理开出一个新事务——同类方法互相调用（this.xxxTx(...)）不经代理，@Transactional
+     * 会被静默绕过。字段注入 + @Lazy 打破自引用的构造期死环，写法与 ProjectProfileService.self
+     * 同一套（该类头部注释有更完整的踩坑记录）。
+     */
+    @Autowired
+    @Lazy
+    ProjectVariableService self;
 
     public List<ProjectVariable> getVariablesByProject(Long projectId) {
         return repository.findByProjectId(projectId);
@@ -22,7 +37,27 @@ public class ProjectVariableService {
         return repository.findById(id).map(ProjectVariable::getProjectId).orElse(null);
     }
 
+    /**
+     * 先查后建，(project_id, name) 上有真实 DB 唯一约束。两个并发请求都读到空 Optional
+     * 时都会落入插入分支，第二个物理 INSERT 撞约束抛 DataIntegrityViolationException——
+     * 若这段逻辑本身带 @Transactional，撞约束会在方法出口把当前事务标记 rollback-only，
+     * 同方法内 catch 住异常继续执行也救不回来，方法能正常返回但提交时照样抛
+     * UnexpectedRollbackException（ProjectProfileService 类头部注释记录了这个踩过的坑）。
+     *
+     * 于是本方法不带 @Transactional，重试通过 {@link #self} 转发到 REQUIRES_NEW 的
+     * {@link #createOrUpdateVariableTx}，两次尝试各自落在独立的新事务里：第二次重试进
+     * 新事务后再 find，能读到对方已提交的那一行，按更新语义写、保留它的 id/创建者信息。
+     */
     public ProjectVariable createOrUpdateVariable(ProjectVariable variable) {
+        try {
+            return self.createOrUpdateVariableTx(variable);
+        } catch (DataIntegrityViolationException | UnexpectedRollbackException e) {
+            return self.createOrUpdateVariableTx(variable);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ProjectVariable createOrUpdateVariableTx(ProjectVariable variable) {
         ProjectVariable existing = repository.findByProjectIdAndName(variable.getProjectId(), variable.getName())
                 .orElse(null);
 
@@ -35,7 +70,7 @@ public class ProjectVariableService {
                 existing.setCreatorId(variable.getCreatorId());
                 existing.setCreatorName(variable.getCreatorName());
             }
-            
+
             // TODO: Implement template parsing logic for nested variables
             if ("TEXT".equals(variable.getType())) {
                 existing.setResolvedValue(variable.getValue());

--- a/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
+++ b/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
@@ -10,7 +10,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
@@ -22,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 股东大会核查会话管理：建档、材料关联。
@@ -51,6 +56,23 @@ public class ShareholderMeetingService {
     private final StorageServiceFactory storageServiceFactory;
     private final CninfoAnnouncementService cninfoService;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 本 bean 的懒加载自身代理，只为让 {@link #ensureFolderTx} 经 Spring 的事务代理真正开出
+     * 独立新事务——写法与 {@link ProjectProfileService#self}、{@link DdService#self} 同一套，
+     * 三处 ensureFolder 是同一形状的 check-then-create 竞态、同一套修法。
+     */
+    @Autowired
+    @Lazy
+    ShareholderMeetingService self;
+
+    /**
+     * ensureFolder 按 (projectId, parentId, name) 序列化"查是否已有 + 没有就建"这段临界区，
+     * 理由与 {@link DdService#ensureFolderLocks} 完全一致：project_file 不加唯一约束，
+     * 没有"插入撞约束后重查"的退路，只能靠进程内锁 + REQUIRES_NEW 子事务把"查+建"钉死成
+     * 一个原子操作——锁必须包住子事务的提交，不能只包住方法调用本身。
+     */
+    private final ConcurrentHashMap<String, Object> ensureFolderLocks = new ConcurrentHashMap<>();
 
     public List<ShareholderMeetingCheck> list(Long projectId) {
         return checkRepository.findByProjectIdOrderByCreatedAtDesc(projectId);
@@ -145,6 +167,15 @@ public class ShareholderMeetingService {
      * 幂等确保文件夹存在（同名已存在则直接返回）。
      */
     private ProjectFile ensureFolder(Long projectId, Long parentId, String name, Long userId) {
+        String key = projectId + "/" + parentId + "/" + name;
+        Object lock = ensureFolderLocks.computeIfAbsent(key, k -> new Object());
+        synchronized (lock) {
+            return self.ensureFolderTx(projectId, parentId, name, userId);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    ProjectFile ensureFolderTx(Long projectId, Long parentId, String name, Long userId) {
         Optional<ProjectFile> existing = projectFileRepository
                 .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, parentId, name);
         if (existing.isPresent() && Boolean.TRUE.equals(existing.get().getIsFolder())) {

--- a/backend/src/main/java/com/checkba/service/UserVariableService.java
+++ b/backend/src/main/java/com/checkba/service/UserVariableService.java
@@ -13,11 +13,40 @@ public class UserVariableService {
     @Autowired
     private UserVariableRepository repository;
 
+    /**
+     * 本 bean 的懒加载自身代理。同类方法互相调用不经 Spring 代理，@Transactional 会被静默
+     * 绕过，所以重试必须经由它转发。字段注入 + @Lazy 打破自引用的构造期死环，
+     * 写法与 ProjectVariableService.self / ProjectProfileService.self 同一套。
+     */
+    @org.springframework.beans.factory.annotation.Autowired
+    @org.springframework.context.annotation.Lazy
+    UserVariableService self;
+
+
     public List<UserVariable> getVariablesByUser(Long userId) {
         return repository.findByUserId(userId);
     }
 
+    /**
+     * 先查后建，(user_id, name) 上有真实 DB 唯一约束。两个并发保存都读到空时都会走插入分支，
+     * 第二个 INSERT 撞约束抛 DataIntegrityViolationException，被兜底处理器变成
+     * 「服务器内部错误」——而用户做的只是同时在两处保存同名变量。
+     * 本方法不带 @Transactional：撞约束会把当前事务标 rollback-only，同方法内 catch
+     * 也救不回来（提交时照样抛 UnexpectedRollbackException）。重试经 self 转发到
+     * REQUIRES_NEW 的新事务，再查一次就能读到对方已提交的那行、按更新语义写。
+     */
     public UserVariable createOrUpdateVariable(Long userId, UserVariable variable) {
+        try {
+            return self.createOrUpdateVariableTx(userId, variable);
+        } catch (org.springframework.dao.DataIntegrityViolationException
+                | org.springframework.transaction.UnexpectedRollbackException e) {
+            return self.createOrUpdateVariableTx(userId, variable);
+        }
+    }
+
+    @org.springframework.transaction.annotation.Transactional(
+            propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public UserVariable createOrUpdateVariableTx(Long userId, UserVariable variable) {
         UserVariable existing = repository.findByUserIdAndName(userId, variable.getName())
                 .orElse(null);
 

--- a/backend/src/main/java/com/checkba/service/ai/AutoTaggingService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AutoTaggingService.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,6 +31,23 @@ public class AutoTaggingService {
     private final TokenUsageService tokenUsageService;
 
     /**
+     * 按 fileId 序列化整个自动打标签流程（check-then-act 竞态修复，dev-board#74）。
+     *
+     * <p>hasAutoTags() 是一次裸 SELECT，没有锁也没有事务；它与第一次
+     * {@code fileTagService.addTagToFile} 落库之间隔着一整趟 LLM 往返（几百毫秒到几秒）。
+     * 同一个 fileId 的两次自动保存/上传离得够近时，都会在这段窗口里读到"还没打过标签"，
+     * 各自跑一遍 LLM、各自落一遍标签——这正是类头注释里那次"单文件堆到 338 个标签"的
+     * 生产事故的更小规模复现。</p>
+     *
+     * <p>这里不需要 ProjectVariableService/DdService 那种"进程锁 + REQUIRES_NEW 子事务"
+     * 组合：本方法本身不带 @Transactional，从 hasAutoTags() 的检查到最后一次
+     * fileTagService.addTagToFile() 落标签，中间调用的每一个 @Transactional 方法都各自
+     * REQUIRED 独立成一次提交（没有外层事务参与进来），锁在整段流程结束时才释放，
+     * 释放时前面每一次落库都已经真正提交——不会出现"锁放了但对方看不到"的假修陷阱。</p>
+     */
+    private final ConcurrentHashMap<Long, Object> autoTagLocks = new ConcurrentHashMap<>();
+
+    /**
      * Automatically generate and attach tags to a file based on its content.
      */
     public void autoTagFile(Long projectId, Long fileId, String storagePath, Long userId) {
@@ -38,6 +56,13 @@ public class AutoTaggingService {
     }
 
     private void autoTagFileInScope(Long projectId, Long fileId, String storagePath, Long userId) {
+        Object lock = autoTagLocks.computeIfAbsent(fileId, k -> new Object());
+        synchronized (lock) {
+            autoTagFileLocked(projectId, fileId, storagePath, userId);
+        }
+    }
+
+    private void autoTagFileLocked(Long projectId, Long fileId, String storagePath, Long userId) {
         // 一个文件只自动打一次标签。上传端点同时是编辑器自动保存的落点
         // （FileController 的 legacy 分支），没有这道闸的话每存一次盘就再跑一次 LLM：
         // 每轮返回 5 个措辞不同的新词，getOrCreateSystemTag 又只按精确字符串去重，

--- a/backend/src/main/java/com/checkba/service/quota/StageQuotaService.java
+++ b/backend/src/main/java/com/checkba/service/quota/StageQuotaService.java
@@ -106,11 +106,19 @@ public class StageQuotaService {
         if (!limited()) return;
         if (!isStagingFolder(targetParentId)) return;
 
+        // 悲观行锁：把接下来的「查当前用量 + 判断放行」钉进调用方（move/batchMove，都是
+        // @Transactional）已经开着的那个事务里。这里不能用进程内锁（synchronized）代替——
+        // 那种锁在本方法返回时就会释放，而 move/batchMove 真正的写入要等外层 @Transactional
+        // 方法整体返回、AOP 代理提交时才落库；第二个并发请求拿到进程锁后即使重新查库，
+        // 看到的仍是第一个请求尚未提交的旧用量，两边都会放行，合计超额（审计原话描述的
+        // 竞态）。行锁不同：它与事务同生命周期，第二个请求的锁获取会一直阻塞到第一个请求
+        // 的事务提交（或回滚）为止，锁到手时数据库里已经是提交后的真实用量。
+        ProjectFile stagingFolder = projectFileRepository.lockById(targetParentId).orElse(null);
+
         // 缓存区所属项目：跨项目的 id 一律不参与计算。批量移动的归属校验在
         // ProjectFileService 的循环里（逐个 move 之前），比本方法晚；不在这里划清项目边界的话，
         // 越权探测者能靠「是否被额度拒绝」推断出别人项目里某个文件的大小。
-        Long stageProjectId = projectFileRepository.findById(targetParentId)
-                .map(ProjectFile::getProjectId).orElse(null);
+        Long stageProjectId = stagingFolder == null ? null : stagingFolder.getProjectId();
 
         Subtree existing = subtree(stageProjectId, targetParentId);
         long count = existing.files().size();

--- a/backend/src/main/java/com/checkba/service/storage/StorageLocationService.java
+++ b/backend/src/main/java/com/checkba/service/storage/StorageLocationService.java
@@ -125,15 +125,20 @@ public class StorageLocationService {
         try {
             Files.createDirectories(target);
             assertWritable(target);
+            // 逐文件指纹（相对路径 -> 大小+mtime），复制前先拍一张快照。
+            Map<String, FileFingerprint> sourceBefore = snapshot(source);
             sourceTally = tally(source);
             copyTree(source, target);
             Tally targetTally = tally(target);
-            // 源侧复查：只比「复制前的源」和「复制后的目标」是不够的。复制一棵大树要几分钟，
-            // 期间自动保存/AI 改文档/浏览器下载都会往源里落盘；落在已经被 copyTree 走过的目录里
-            // 的那些文件不会出现在目标里，而两侧数字仍然相等——校验通过、指针切走，
-            // 那个文件在文件树里看得见却打不开。宁可让用户重来一次。
-            Tally sourceAfter = tally(source);
-            if (sourceAfter.files != sourceTally.files || sourceAfter.bytes != sourceTally.bytes) {
+            // 源侧复查：只比「复制前后源的聚合文件数/总字节数」是不够的——那只能抓住整棵树
+            // 新增/删除了文件，抓不住"某个已经被 copyTree 走过的文件被原地改写成同样字节数
+            // 的新内容"这种情况：文件数没变、总字节数也没变，聚合数字两边仍然相等，校验会
+            // 误判通过。复制一棵大树要几分钟，期间自动保存/AI 改文档/浏览器下载都会往源里
+            // 落盘，命中这个缝隙的窗口不算窄。改成逐文件（大小 + mtime）指纹比对：
+            // 新增、删除、原地改写（哪怕字节数不变）都会让某一路径的指纹在两次快照间不相等，
+            // Map.equals 天然覆盖这三种情况。宁可让用户重来一次。
+            Map<String, FileFingerprint> sourceAfter = snapshot(source);
+            if (!sourceAfter.equals(sourceBefore)) {
                 throw new StorageException(LangText.of(
                         "迁移期间原目录发生了变化（可能有文档在自动保存，或有下载/AI 改动在进行），"
                                 + "为确保一个文件都不落下，已放弃本次迁移并保持原位置。请关闭正在编辑的文档后重试。",
@@ -299,6 +304,27 @@ public class StorageLocationService {
     }
 
     record Tally(long files, long bytes) {}
+
+    record FileFingerprint(long size, long mtimeMillis) {}
+
+    /**
+     * 逐文件指纹快照（相对路径 -> 大小+mtime）。只做 stat，不读内容——树可能有几十 GB，
+     * 全量取内容哈希会让这道复查本身变成新的性能问题。size+mtime 足以抓住"原地改写"：
+     * 内容变了，mtime 必然跟着变。
+     */
+    private Map<String, FileFingerprint> snapshot(Path root) throws IOException {
+        Map<String, FileFingerprint> result = new java.util.HashMap<>();
+        if (!Files.exists(root)) return result;
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                result.put(root.relativize(file).toString(),
+                        new FileFingerprint(attrs.size(), attrs.lastModifiedTime().toMillis()));
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return result;
+    }
 
     /** package-private 是留给测试的接缝：覆写它即可制造「校验不通过」以验证回滚。 */
     Tally tally(Path root) throws IOException {

--- a/backend/src/test/java/com/checkba/service/DdServiceEnsureFolderConcurrentTest.java
+++ b/backend/src/test/java/com/checkba/service/DdServiceEnsureFolderConcurrentTest.java
@@ -1,0 +1,177 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.DdItem;
+import com.checkba.model.entity.DdRequest;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.DdItemRepository;
+import com.checkba.repository.DdRequestRepository;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * dev-board#74 审计条目：DdService.ensureFolder 的 check-then-create 竞态——两个尽调清单项
+ * （同一 DdRequest 下的兄弟项）第一次上传文件时并发触发，都会先确保共享的祖先文件夹存在
+ * （"客户提供的文件" 根目录、请求名子目录），(project_id, parent_id, name) 上没有 DB
+ * 唯一约束（团队约定不加），两次并发的"查不到就建"都能通过检查各插一行，产生重复文件夹。
+ *
+ * 真 Spring 容器 + 真 H2：代理包在 {@link ProjectFileRepository} 前面，在
+ * findByProjectIdAndParentIdAndName 上做"第一个到达的先暂停，等第二个也到达（或超时）
+ * 再继续"的单向门——不能用双向栅栏对称等待，因为修复后第二个线程会卡在 DB 行锁式的
+ * 进程内锁上，根本走不到这次查询，双向栅栏会互相等成死锁。单向门只让先到的那个等一小段
+ * 超时，最坏情况多等这一个超时窗口，不会卡死。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:dd-ensure-folder-race;MODE=PostgreSQL;"
+                + "DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "storage.local.root-path=target/test-storage-dd-ensure-folder-race"
+})
+@ActiveProfiles("desktop")
+class DdServiceEnsureFolderConcurrentTest {
+
+    static final AtomicReference<ReadGate> ACTIVE_GATE = new AtomicReference<>();
+
+    @TestConfiguration
+    static class RacingRepositoryConfig {
+
+        @Bean
+        @Primary
+        ProjectFileRepository racingProjectFileRepository(
+                @Qualifier("projectFileRepository") ProjectFileRepository real) {
+            InvocationHandler handler = (proxy, method, args) -> {
+                Object result = invokeReal(real, method, args);
+                ReadGate gate = ACTIVE_GATE.get();
+                if (gate != null && "findByProjectIdAndParentIdAndName".equals(method.getName())
+                        && args != null && args.length == 3) {
+                    Long projectId = (Long) args[0];
+                    Long parentId = (Long) args[1];
+                    String name = (String) args[2];
+                    gate.onRead(projectId + "/" + parentId + "/" + name);
+                }
+                return result;
+            };
+            return (ProjectFileRepository) Proxy.newProxyInstance(
+                    ProjectFileRepository.class.getClassLoader(),
+                    new Class<?>[]{ProjectFileRepository.class},
+                    handler);
+        }
+
+        private static Object invokeReal(Object real, java.lang.reflect.Method method, Object[] args) {
+            try {
+                return method.invoke(real, args);
+            } catch (InvocationTargetException ite) {
+                Throwable cause = ite.getCause();
+                if (cause instanceof RuntimeException re) throw re;
+                if (cause instanceof Error err) throw err;
+                throw new RuntimeException(cause);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * 单向门：只栅指定 key 的头两次读。第一个到达的线程原地等第二个也到达（最多 3 秒，
+     * 超时就直接放行，避免修复生效后第二个线程被进程内锁挡住、永远等不到而死锁）；
+     * 第二个到达的线程只负责唤醒第一个，自己立即放行，不等待。
+     */
+    static final class ReadGate {
+        private final String targetKey;
+        private final AtomicBoolean firstArrived = new AtomicBoolean(false);
+        private final CountDownLatch secondArrived = new CountDownLatch(1);
+
+        ReadGate(String targetKey) { this.targetKey = targetKey; }
+
+        void onRead(String key) throws InterruptedException {
+            if (!targetKey.equals(key)) return;
+            if (firstArrived.compareAndSet(false, true)) {
+                secondArrived.await(3, TimeUnit.SECONDS);
+            } else {
+                secondArrived.countDown();
+            }
+        }
+    }
+
+    @Autowired
+    private DdService ddService;
+    @Autowired
+    private DdRequestRepository ddRequestRepository;
+    @Autowired
+    private DdItemRepository ddItemRepository;
+    @Autowired
+    private ProjectFileRepository projectFileRepository;
+
+    @AfterEach
+    void tearDown() {
+        ACTIVE_GATE.set(null);
+    }
+
+    @Test
+    void 并发上传兄弟清单项共用同一个客户文件根目录不产生重复() throws Exception {
+        long projectId = 9201L;
+        DdRequest req = new DdRequest();
+        req.setProjectId(projectId);
+        req.setName("尽调请求-并发测试");
+        req.setCreatedBy(9L);
+        req = ddRequestRepository.save(req);
+
+        DdItem itemA = new DdItem();
+        itemA.setDdRequestId(req.getId());
+        itemA.setTitle("文件A");
+        itemA.setSortOrder(0);
+        itemA = ddItemRepository.save(itemA);
+
+        DdItem itemB = new DdItem();
+        itemB.setDdRequestId(req.getId());
+        itemB.setTitle("文件B");
+        itemB.setSortOrder(1);
+        itemB = ddItemRepository.save(itemB);
+
+        // 两个上传共享的第一个 ensureFolder 调用：ensureFolder(projectId, null, "客户提供的文件", ...)
+        ACTIVE_GATE.set(new ReadGate(projectId + "/null/客户提供的文件"));
+
+        MockMultipartFile fileA = new MockMultipartFile("file", "a.pdf", "application/pdf", new byte[]{1});
+        MockMultipartFile fileB = new MockMultipartFile("file", "b.pdf", "application/pdf", new byte[]{2});
+        Long itemAId = itemA.getId();
+        Long itemBId = itemB.getId();
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<DdItem> f1 = pool.submit(() -> ddService.uploadFile(itemAId, fileA, 9L));
+            Future<DdItem> f2 = pool.submit(() -> ddService.uploadFile(itemBId, fileB, 9L));
+            assertNotNull(f1.get(20, TimeUnit.SECONDS));
+            assertNotNull(f2.get(20, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+
+        List<ProjectFile> clientFolders = projectFileRepository.findByProjectId(projectId).stream()
+                .filter(f -> Boolean.TRUE.equals(f.getIsFolder()) && "客户提供的文件".equals(f.getName()))
+                .toList();
+        assertEquals(1, clientFolders.size(),
+                "两个并发上传必须共用同一个「客户提供的文件」根目录，不能各建一个: " + clientFolders);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/DdServiceUploadFileTest.java
+++ b/backend/src/test/java/com/checkba/service/DdServiceUploadFileTest.java
@@ -88,8 +88,13 @@ class DdServiceUploadFileTest {
     }
 
     private DdService buildService(ProjectFileRepository repo) {
-        return new DdService(ddRequestRepository, ddItemRepository,
+        DdService svc = new DdService(ddRequestRepository, ddItemRepository,
                 mock(DdCommentRepository.class), repo, projectFileService, storageServiceFactory);
+        // ensureFolder 经 self 转发到 REQUIRES_NEW 的 ensureFolderTx（并发竞态修复，
+        // dev-board#74）；生产环境里 self 是 Spring 注入的 @Lazy 代理，这里手工 new
+        // 没有容器，直接把 service 自己接上去，与 ProjectProfileServiceTest 同一套写法。
+        svc.self = svc;
+        return svc;
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
@@ -253,6 +253,65 @@ class LocalProjectServiceTest {
     }
 
     /**
+     * Files.walkFileTree 的 maxDepth 参数在深度封顶时是"静默"的：preVisitDirectory/visitFile
+     * 对超出 MAX_IMPORT_DEPTH 的目录/文件根本不会被调用，没有任何一次遍历回调会执行到"置位
+     * truncated"这行代码——与 MAX_IMPORT_ENTRIES 上限不同，那个上限的判断天然长在每次回调
+     * 内部，有机会置位。深层文件因此永远静默不进文件树，无日志无 API 信号。
+     */
+    @Test
+    void reportsTruncationWhenNestingExceedsMaxDepth(@TempDir Path folder) throws Exception {
+        Path deepest = folder;
+        for (int i = 1; i <= LocalProjectService.MAX_IMPORT_DEPTH + 1; i++) {
+            deepest = deepest.resolve("d" + i);
+        }
+        Files.createDirectories(deepest);
+        Files.writeString(deepest.resolve("leaf.txt"), "x");
+
+        LocalProjectService.OpenLocalResult r = svc.openLocalFolder(folder.toString(), false, null, null, 1L);
+
+        assertTrue(r.truncated(),
+                "深度超过 MAX_IMPORT_DEPTH 时必须报出截断，否则深层文件永远静默不进文件树且无任何信号");
+    }
+
+    /**
+     * macOS 默认的 APFS/HFS+ 等大小写不敏感、大小写保留的文件系统上，仅改大小写的重命名
+     * （"Docs" -> "docs"）之后：importFolder 的 rowKey 按大小写敏感比对，识别不出这是同一个
+     * 物理目录，会为新大小写建一个新行；而删除同步那一侧，旧行的 Files.exists(root.resolve("Docs"))
+     * 在大小写不敏感文件系统上依然为 true（不敏感匹配命中了同一个物理目录），永远不会被判定
+     * 为缺失——旧行从此成为再也清不掉的永久幽灵行。
+     *
+     * 只在真正大小写不敏感、大小写保留的文件系统上才能复现，用探测式 Assumption 而不是按
+     * 操作系统名称猜测（CI 若跑在大小写敏感的文件系统上，用例据此跳过，不制造假红/假绿）。
+     */
+    @Test
+    void caseOnlyRenameOnCaseInsensitiveFsRetiresStaleGhostRow(@TempDir Path folder) throws Exception {
+        Files.createDirectories(folder.resolve("Docs"));
+        Long projectId = svc.openLocalFolder(folder.toString(), false, null, null, 1L).project().getId();
+
+        boolean caseInsensitiveAndPreserving = Files.exists(folder.resolve("docs"));
+        org.junit.jupiter.api.Assumptions.assumeTrue(caseInsensitiveAndPreserving,
+                "当前文件系统大小写敏感，跳过（此缺陷只在大小写不敏感盘上出现）");
+
+        // 大小写重命名不能直接 Files.move("Docs", "docs")：在 APFS 这类大小写不敏感盘上，
+        // rename(2) 系统调用发现新旧路径解析到同一个物理目录时按 POSIX 语义直接判定"无事可做"，
+        // 连显示大小写都不会更新（实测：mv 走 Finder/shell 的两步改名会真的生效，
+        // 直接单步 Files.move 则是空操作）——这里用同样的"先改到临时名、再改成目标名"
+        // 两步手法，制造出与真实 Finder 改名完全相同的终态：磁盘上的真实大小写已经是 "docs"。
+        Path tmp = folder.resolve("Docs__awd_test_tmp__");
+        Files.move(folder.resolve("Docs"), tmp);
+        Files.move(tmp, folder.resolve("docs"));
+
+        svc.reconcileProject(projectId);
+
+        List<ProjectFile> aliveFolders = projectFileRepository.findByProjectId(projectId).stream()
+                .filter(f -> Boolean.TRUE.equals(f.getIsFolder()) && !Boolean.TRUE.equals(f.getIsDeleted()))
+                .toList();
+        assertEquals(1, aliveFolders.size(),
+                "改大小写重命名后应只剩一个存活的文件夹行，旧大小写那行必须被对账清掉: " + aliveFolders);
+        assertEquals("docs", aliveFolders.get(0).getName(), "存活的应该是新大小写那一行");
+    }
+
+    /**
      * 全链路冒烟：文件系统事件 → 防抖 → reconcileProject → 落库。
      * NOT_SUPPORTED：默认测试事务不提交，watcher 线程的新事务看不见项目行，链路必假。
      *

--- a/backend/src/test/java/com/checkba/service/ProjectVariableConcurrentSaveTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectVariableConcurrentSaveTest.java
@@ -1,0 +1,172 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectVariable;
+import com.checkba.repository.ProjectVariableRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * dev-board#74 审计条目：createOrUpdateVariable 的 TOCTOU 撞唯一约束报通用 500。
+ *
+ * 走法与 {@code ProjectProfileFieldConcurrentSaveTest} 完全一致（同一个坑、同一套修法）：
+ * 真 Spring 容器 + 真 H2 + 真 (project_id, name) 唯一约束 + 真事务，代理包在
+ * {@link ProjectVariableRepository} 前面，在 findByProjectIdAndName / save 两个方法上
+ * 做仲裁，逼出两次并发写都读到空 Optional、都尝试 INSERT 的真实竞态窗口，而不是靠线程
+ * 调度的运气——没有仲裁的话，先起步的线程可能在后起步的线程查库之前就已经提交，
+ * 后者的 find 会直接读到那一行走更新分支，竞态窗口被跳过，断言却可能照样通过（假阳性）。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:project-variable-concurrent-save;MODE=PostgreSQL;"
+                + "DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1"
+})
+@ActiveProfiles("desktop")
+class ProjectVariableConcurrentSaveTest {
+
+    static final AtomicReference<RaceArbiter> ACTIVE_ARBITER = new AtomicReference<>();
+
+    @TestConfiguration
+    static class RacingRepositoryConfig {
+
+        @Bean
+        @Primary
+        ProjectVariableRepository racingProjectVariableRepository(
+                @Qualifier("projectVariableRepository") ProjectVariableRepository real) {
+            InvocationHandler handler = (proxy, method, args) -> {
+                RaceArbiter arbiter = ACTIVE_ARBITER.get();
+                if (arbiter != null && "save".equals(method.getName())
+                        && args != null && args.length == 1 && args[0] instanceof ProjectVariable) {
+                    ProjectVariable entity = (ProjectVariable) args[0];
+                    return arbiter.aroundSave(entity, () -> invokeReal(real, method, args));
+                }
+                if (arbiter != null && "findByProjectIdAndName".equals(method.getName())
+                        && args != null && args.length == 2) {
+                    return arbiter.aroundFind(() -> invokeReal(real, method, args));
+                }
+                return invokeReal(real, method, args);
+            };
+            return (ProjectVariableRepository) Proxy.newProxyInstance(
+                    ProjectVariableRepository.class.getClassLoader(),
+                    new Class<?>[]{ProjectVariableRepository.class},
+                    handler);
+        }
+
+        private static Object invokeReal(Object real, java.lang.reflect.Method method, Object[] args) {
+            try {
+                return method.invoke(real, args);
+            } catch (InvocationTargetException ite) {
+                Throwable cause = ite.getCause();
+                if (cause instanceof RuntimeException re) throw re;
+                if (cause instanceof Error err) throw err;
+                throw new RuntimeException(cause);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    static final class RaceArbiter {
+        private final AtomicBoolean firstClaimed = new AtomicBoolean(false);
+        private final CountDownLatch firstSaveDispatched = new CountDownLatch(1);
+        private final AtomicReference<String> firstValue = new AtomicReference<>();
+        private final CountDownLatch bothFindsDone = new CountDownLatch(2);
+
+        Object aroundFind(Callable<Object> realFind) throws Exception {
+            Object result = realFind.call();
+            bothFindsDone.countDown();
+            if (!bothFindsDone.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("等待两个线程的 find() 都完成超时");
+            }
+            return result;
+        }
+
+        Object aroundSave(ProjectVariable entity, Callable<Object> realSave) throws Exception {
+            if (firstClaimed.compareAndSet(false, true)) {
+                firstValue.set(entity.getValue());
+                try {
+                    return realSave.call();
+                } finally {
+                    firstSaveDispatched.countDown();
+                }
+            }
+            if (!firstSaveDispatched.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("等待第一个请求调用 save() 超时");
+            }
+            return realSave.call();
+        }
+    }
+
+    @Autowired
+    private ProjectVariableService service;
+    @Autowired
+    private ProjectVariableRepository repository;
+
+    @AfterEach
+    void tearDown() {
+        ACTIVE_ARBITER.set(null);
+    }
+
+    private static ProjectVariable variable(Long projectId, String name, String value) {
+        ProjectVariable v = new ProjectVariable();
+        v.setProjectId(projectId);
+        v.setName(name);
+        v.setValue(value);
+        v.setType("TEXT");
+        return v;
+    }
+
+    @Test
+    void 并发创建同名变量不抛异常_库里只留一行() throws Exception {
+        long projectId = 9101L;
+        RaceArbiter arbiter = new RaceArbiter();
+        ACTIVE_ARBITER.set(arbiter);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<ProjectVariable> f1 = pool.submit(
+                    () -> service.createOrUpdateVariable(variable(projectId, "甲方名称", "并发值-A")));
+            Future<ProjectVariable> f2 = pool.submit(
+                    () -> service.createOrUpdateVariable(variable(projectId, "甲方名称", "并发值-B")));
+
+            // 断言的核心：两次并发写都必须成功返回，不能有一边被 catch(Exception) 兜成
+            // {code:1,"服务器内部错误"}（GlobalExceptionHandler 会把 DataIntegrityViolationException
+            // /UnexpectedRollbackException 都吞成这个通用错误，这里绕过控制器直接测服务层，
+            // 异常会原样从 Future.get() 抛出）。
+            ProjectVariable r1 = f1.get(15, TimeUnit.SECONDS);
+            ProjectVariable r2 = f2.get(15, TimeUnit.SECONDS);
+            assertNotNull(r1);
+            assertNotNull(r2);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        List<ProjectVariable> rows = repository.findByProjectId(projectId);
+        assertEquals(1, rows.size(), "唯一约束下最终只应该留一行: " + rows);
+
+        String expectedFinalValue = "并发值-A".equals(arbiter.firstValue.get()) ? "并发值-B" : "并发值-A";
+        assertEquals(expectedFinalValue, rows.get(0).getValue(),
+                "库里应该留后到的那次写入——先插入那行随后被重试路径的更新覆盖了值");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ShareholderMeetingEnsureFolderConcurrentTest.java
+++ b/backend/src/test/java/com/checkba/service/ShareholderMeetingEnsureFolderConcurrentTest.java
@@ -1,0 +1,144 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.ShareholderMeetingCheck;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * dev-board#74 审计条目：ShareholderMeetingService.ensureFolder 的 TOCTOU 竞态——双击
+ * "开始核查"按钮或前端重试，会让两次 start()/fetch-cninfo 同时跑到 ensureWorkpaperFolders，
+ * 都先确保底稿夹根目录（"股东大会核查"）存在。(project_id, parent_id, name) 上没有 DB
+ * 唯一约束，两次并发的"查不到就建"都能通过检查各插一行，产生重复文件夹。
+ * 与 {@code DdServiceEnsureFolderConcurrentTest} 同一形状、同一套单向门测试手法
+ * （类头注释里有完整的死锁规避说明）。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:shm-ensure-folder-race;MODE=PostgreSQL;"
+                + "DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "storage.local.root-path=target/test-storage-shm-ensure-folder-race"
+})
+@ActiveProfiles("desktop")
+class ShareholderMeetingEnsureFolderConcurrentTest {
+
+    static final AtomicReference<ReadGate> ACTIVE_GATE = new AtomicReference<>();
+
+    @TestConfiguration
+    static class RacingRepositoryConfig {
+
+        @Bean
+        @Primary
+        ProjectFileRepository racingProjectFileRepository(
+                @Qualifier("projectFileRepository") ProjectFileRepository real) {
+            InvocationHandler handler = (proxy, method, args) -> {
+                Object result = invokeReal(real, method, args);
+                ReadGate gate = ACTIVE_GATE.get();
+                if (gate != null && "findByProjectIdAndParentIdAndNameAndIsDeletedFalse".equals(method.getName())
+                        && args != null && args.length == 3) {
+                    Long projectId = (Long) args[0];
+                    Long parentId = (Long) args[1];
+                    String name = (String) args[2];
+                    gate.onRead(projectId + "/" + parentId + "/" + name);
+                }
+                return result;
+            };
+            return (ProjectFileRepository) Proxy.newProxyInstance(
+                    ProjectFileRepository.class.getClassLoader(),
+                    new Class<?>[]{ProjectFileRepository.class},
+                    handler);
+        }
+
+        private static Object invokeReal(Object real, java.lang.reflect.Method method, Object[] args) {
+            try {
+                return method.invoke(real, args);
+            } catch (InvocationTargetException ite) {
+                Throwable cause = ite.getCause();
+                if (cause instanceof RuntimeException re) throw re;
+                if (cause instanceof Error err) throw err;
+                throw new RuntimeException(cause);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /** 单向门，语义与 {@code DdServiceEnsureFolderConcurrentTest.ReadGate} 完全一致。 */
+    static final class ReadGate {
+        private final String targetKey;
+        private final AtomicBoolean firstArrived = new AtomicBoolean(false);
+        private final CountDownLatch secondArrived = new CountDownLatch(1);
+
+        ReadGate(String targetKey) { this.targetKey = targetKey; }
+
+        void onRead(String key) throws InterruptedException {
+            if (!targetKey.equals(key)) return;
+            if (firstArrived.compareAndSet(false, true)) {
+                secondArrived.await(3, TimeUnit.SECONDS);
+            } else {
+                secondArrived.countDown();
+            }
+        }
+    }
+
+    @Autowired
+    private ShareholderMeetingService meetingService;
+    @Autowired
+    private ProjectFileRepository projectFileRepository;
+
+    @AfterEach
+    void tearDown() {
+        ACTIVE_GATE.set(null);
+    }
+
+    @Test
+    void 并发确保底稿夹根目录不产生重复文件夹() throws Exception {
+        long projectId = 9301L;
+        ShareholderMeetingCheck check = meetingService.create(
+                projectId, "某某股份有限公司", "600000", "2026年第一次临时股东大会",
+                LocalDate.of(2026, 8, 21), 9L);
+
+        // 两次调用共享的第一个 ensureFolder：ensureFolder(projectId, null, WORKPAPER_ROOT, ...)
+        ACTIVE_GATE.set(new ReadGate(projectId + "/null/" + ShareholderMeetingService.WORKPAPER_ROOT));
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> f1 = pool.submit(() -> meetingService.ensureWorkpaperFolders(check, 9L));
+            Future<?> f2 = pool.submit(() -> meetingService.ensureWorkpaperFolders(check, 9L));
+            assertNotNull(f1.get(20, TimeUnit.SECONDS));
+            assertNotNull(f2.get(20, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+
+        List<ProjectFile> rootFolders = projectFileRepository.findByProjectId(projectId).stream()
+                .filter(f -> Boolean.TRUE.equals(f.getIsFolder())
+                        && ShareholderMeetingService.WORKPAPER_ROOT.equals(f.getName()))
+                .toList();
+        assertEquals(1, rootFolders.size(),
+                "两次并发的 ensureWorkpaperFolders 必须共用同一个底稿夹根目录，不能各建一个: " + rootFolders);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ShareholderMeetingServiceCninfoOrphanTest.java
+++ b/backend/src/test/java/com/checkba/service/ShareholderMeetingServiceCninfoOrphanTest.java
@@ -48,6 +48,10 @@ class ShareholderMeetingServiceCninfoOrphanTest {
     void setUp() {
         svc = new ShareholderMeetingService(checkRepository, projectFileRepository,
                 projectFileService, storageServiceFactory, cninfoService);
+        // ensureFolder 经 self 转发到 REQUIRES_NEW 的 ensureFolderTx（并发竞态修复，
+        // dev-board#74）；生产环境里 self 是 Spring 注入的 @Lazy 代理，这里手工 new
+        // 没有容器，直接把 service 自己接上去，与 ProjectProfileServiceTest 同一套写法。
+        svc.self = svc;
         when(storageServiceFactory.getStorageService()).thenReturn(storageService);
     }
 

--- a/backend/src/test/java/com/checkba/service/VariableSiblingRetryTest.java
+++ b/backend/src/test/java/com/checkba/service/VariableSiblingRetryTest.java
@@ -1,0 +1,99 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.FileVariable;
+import com.checkba.model.entity.UserVariable;
+import com.checkba.repository.FileVariableRepository;
+import com.checkba.repository.UserVariableRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 用户变量与文件变量的「先查后建」撞唯一约束。
+ *
+ * <p>这两个服务与 ProjectVariableService 是同一形状、同样有真实 DB 唯一约束
+ * （user_id+name / file_id+name）。两个并发保存都读到空时都会走插入分支，
+ * 第二个 INSERT 撞约束抛 DataIntegrityViolationException，被兜底处理器变成
+ * 「服务器内部错误」——而用户做的只是同时在两处保存同名变量。
+ *
+ * <p>事务语义那一层（为什么重试必须落在 REQUIRES_NEW 的新事务里）已由
+ * {@code ProjectVariableConcurrentSaveTest} 用真容器 + 真 H2 + 真唯一约束钉住；
+ * 这里只钉「撞约束后确实会重试一次、并返回对方已提交的那一行」这条行为，
+ * 不重复搭那套重量级脚手架。
+ */
+class VariableSiblingRetryTest {
+
+    @Test
+    @DisplayName("用户变量：撞唯一约束后重试并返回既有行，而不是把异常抛给用户")
+    void userVariableRetriesOnConstraintViolation() {
+        UserVariableRepository repo = mock(UserVariableRepository.class);
+        UserVariableService svc = new UserVariableService();
+        ReflectionTestUtils.setField(svc, "repository", repo);
+        ReflectionTestUtils.setField(svc, "self", svc);
+
+        UserVariable winner = new UserVariable();
+        winner.setId(7L);
+        winner.setUserId(1L);
+        winner.setName("甲方");
+
+        AtomicInteger finds = new AtomicInteger();
+        when(repo.findByUserIdAndName(1L, "甲方")).thenAnswer(inv ->
+                finds.incrementAndGet() == 1 ? Optional.empty() : Optional.of(winner));
+        when(repo.save(any(UserVariable.class))).thenAnswer(inv -> {
+            UserVariable v = inv.getArgument(0);
+            if (v.getId() == null) throw new DataIntegrityViolationException("unique(user_id,name)");
+            return v;
+        });
+
+        UserVariable input = new UserVariable();
+        input.setName("甲方");
+        input.setValue("北京某某公司");
+
+        UserVariable saved = svc.createOrUpdateVariable(1L, input);
+        assertSame(winner, saved, "重试后应落到对方已提交的那一行上做更新");
+        assertEquals("北京某某公司", saved.getValue());
+        assertEquals(2, finds.get(), "必须重查一次，否则拿不到对方刚提交的行");
+    }
+
+    @Test
+    @DisplayName("文件变量：撞唯一约束后重试并返回既有行")
+    void fileVariableRetriesOnConstraintViolation() {
+        FileVariableRepository repo = mock(FileVariableRepository.class);
+        FileVariableService svc = new FileVariableService(repo);
+        ReflectionTestUtils.setField(svc, "self", svc);
+
+        FileVariable winner = new FileVariable();
+        winner.setId(9L);
+        winner.setFileId(3L);
+        winner.setName("乙方");
+
+        AtomicInteger finds = new AtomicInteger();
+        when(repo.findByFileIdAndName(3L, "乙方")).thenAnswer(inv ->
+                finds.incrementAndGet() == 1 ? Optional.empty() : Optional.of(winner));
+        when(repo.save(any(FileVariable.class))).thenAnswer(inv -> {
+            FileVariable v = inv.getArgument(0);
+            if (v.getId() == null) throw new DataIntegrityViolationException("unique(file_id,name)");
+            return v;
+        });
+
+        FileVariable input = new FileVariable();
+        input.setFileId(3L);
+        input.setName("乙方");
+        input.setValue("上海某某公司");
+
+        FileVariable saved = svc.createOrUpdateVariable(input);
+        assertSame(winner, saved);
+        assertEquals("上海某某公司", saved.getValue());
+        assertEquals(2, finds.get());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/AutoTaggingConcurrentTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AutoTaggingConcurrentTest.java
@@ -1,0 +1,127 @@
+package com.checkba.service.ai;
+
+import com.checkba.model.entity.Tag;
+import com.checkba.service.DocumentTextService;
+import com.checkba.service.FileTagService;
+import com.checkba.service.TagService;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * dev-board#74 审计条目：自动打标签闸的 check-then-act 竞态——两次近乎同时的自动保存/
+ * 上传事件对同一 fileId 触发 autoTagFile，hasAutoTags() 是裸 SELECT、与第一次落标签之间
+ * 隔着一整趟 LLM 往返，都读到"还没打过标签"就都跑一遍 LLM、都落一遍标签，标签数翻倍。
+ *
+ * <p>用真实两个线程 + Mockito 手工维护的"内存标签表"复现：{@code FileTagService} 与
+ * {@code TagService} 都不是数据库支撑的真实实现，而是用一个同步 List 手工模拟状态——
+ * 这样才能在断言里精确数出"到底落了几条标签"，不依赖 Mockito 的调用计数。
+ *
+ * <p>并发构造用单向门（语义与 DdService/ShareholderMeetingService 的 ensureFolder 竞态
+ * 测试同一套）：栅在 hasAutoTags() 内部调用的 fileTagService.getTagsByFileId 上。不能用
+ * 双向栅栏对称等待——修复后第二个线程会卡在按 fileId 的进程内锁上，根本走不到这次调用，
+ * 双向栅栏会互相等成死锁；单向门只让先到的那个等一小段超时，最坏情况多等这一段，不会死锁。
+ */
+class AutoTaggingConcurrentTest {
+
+    /** 单向门：只栅头两次调用，其余（如有）直接放行。 */
+    static final class ReadGate {
+        private final AtomicBoolean firstArrived = new AtomicBoolean(false);
+        private final CountDownLatch secondArrived = new CountDownLatch(1);
+
+        void onRead() throws InterruptedException {
+            if (firstArrived.compareAndSet(false, true)) {
+                secondArrived.await(3, TimeUnit.SECONDS);
+            } else {
+                secondArrived.countDown();
+            }
+        }
+    }
+
+    @Test
+    void 并发自动保存不会把同一文件的标签打两遍() throws Exception {
+        long fileId = 555L;
+        long projectId = 9501L;
+
+        // 手工维护的"标签表"：list 里的每一条代表一次真实落库的 FileTag
+        List<Tag> insertedTags = Collections.synchronizedList(new ArrayList<>());
+        ReadGate gate = new ReadGate();
+
+        FileTagService fileTagService = mock(FileTagService.class);
+        when(fileTagService.getTagsByFileId(fileId)).thenAnswer(inv -> {
+            gate.onRead();
+            return new ArrayList<>(insertedTags);
+        });
+
+        AtomicLong tagIdSeq = new AtomicLong(100);
+        TagService tagService = mock(TagService.class);
+        when(tagService.getOrCreateSystemTag(anyLong(), anyString(), anyString())).thenAnswer(inv -> {
+            Tag t = new Tag();
+            t.setId(tagIdSeq.incrementAndGet());
+            t.setName(inv.getArgument(1));
+            t.setIsSystem(true);
+            return t;
+        });
+        // addTagToFile 落库：往"表"里追加一行，模拟真实的 FileTag 落库
+        org.mockito.Mockito.doAnswer(inv -> {
+            Tag t = new Tag();
+            t.setId((Long) inv.getArgument(1));
+            t.setIsSystem(true);
+            insertedTags.add(t);
+            return null;
+        }).when(fileTagService).addTagToFile(anyLong(), anyLong(), anyLong());
+
+        DocumentTextService documentTextService = mock(DocumentTextService.class);
+        when(documentTextService.extractText(any()))
+                .thenReturn("这是一份股权转让协议，甲方与乙方就标的公司股权转让事宜达成如下条款……".repeat(3));
+
+        ChatLanguageModel model = mock(ChatLanguageModel.class);
+        when(model.generate(any(UserMessage.class))).thenAnswer(inv -> {
+            // 模拟真实 LLM 往返耗时，拉宽竞态窗口（非必须——单向门已经保证竞态一定发生，
+            // 这里只是让复现更贴近真实场景的"上百毫秒到几秒"）
+            Thread.sleep(50);
+            return Response.from(AiMessage.from("合同,协议,担保,保证金,违约"));
+        });
+
+        ChatModelFactory chatModelFactory = mock(ChatModelFactory.class);
+        when(chatModelFactory.getAuxChatModel()).thenReturn(model);
+
+        AutoTaggingService service = new AutoTaggingService(
+                chatModelFactory, tagService, fileTagService, documentTextService,
+                mock(AuxModelResolver.class), mock(TokenUsageService.class));
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> f1 = pool.submit(() -> service.autoTagFile(projectId, fileId, "some/path.docx", 1L));
+            Future<?> f2 = pool.submit(() -> service.autoTagFile(projectId, fileId, "some/path.docx", 2L));
+            f1.get(15, TimeUnit.SECONDS);
+            f2.get(15, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertEquals(5, insertedTags.size(),
+                "两次并发自动打标签必须只有一次真正落标签（5 个），不能两次都落导致标签翻倍: "
+                        + insertedTags.size());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/quota/StageQuotaConcurrentMoveTest.java
+++ b/backend/src/test/java/com/checkba/service/quota/StageQuotaConcurrentMoveTest.java
@@ -1,0 +1,210 @@
+package com.checkba.service.quota;
+
+import com.checkba.model.dto.ProjectFileBatchRequest;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectFileService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * dev-board#74 审计条目：StageQuotaService.checkAdmission 的 check-then-act 竞态——
+ * 两个并发 batchMove 请求各自读到同一份"移入前用量"，都算出未超额、都放行，合计超出
+ * FREE_MAX_FILES。
+ *
+ * <p>与 DdService/ShareholderMeetingService 那两条 ensureFolder 竞态不同形状：checkAdmission
+ * 本身不带 @Transactional，是在调用方（ProjectFileService.move/batchMove，本来就是
+ * @Transactional）已经开着的事务里跑的。这里不能再用"进程内锁 + REQUIRES_NEW 子事务"那一套
+ * ——那样反而会把 move 真正的写入拆到另一个事务里，动了 move 本已很复杂的失败回滚语义。
+ * 改用悲观行锁（SELECT ... FOR UPDATE）钉住这个已经存在的事务边界：锁在事务提交/回滚前
+ * 不释放，第二个请求的锁获取会等到第一个请求整体提交为止，锁到手时看到的已经是提交后的
+ * 真实用量。
+ *
+ * <p>并发构造手法与 DdService/ShareholderMeetingService 的两个 ensureFolder 竞态测试同一套
+ * "单向门"：不能用双向栅栏对称等待，修复后第二个线程会卡在行锁上，走不到这次查询，
+ * 双向栅栏会互相等成死锁；单向门只让先到的那个等一小段超时。
+ */
+@SpringBootTest(properties = {
+        // LOCK_TIMEOUT 显式拉长到 10 秒：H2 默认行锁等待上限只有 2 秒，比下面 ReadGate
+        // 单向门里"先到者最多等 3 秒"还短——第二个线程真去抢行锁时会先被 H2 自己的锁超时
+        // 打断，而不是等到 ReadGate 放行，制造出与竞态本身无关的假失败。
+        "spring.datasource.url=jdbc:h2:mem:stage-quota-concurrent-move;MODE=PostgreSQL;"
+                + "DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000",
+        "storage.local.root-path=target/test-storage-stage-quota-race",
+        "security.license.dir=target/test-license-stage-quota-race",
+        "security.local-mode=true"
+})
+@ActiveProfiles("desktop")
+class StageQuotaConcurrentMoveTest {
+
+    static final AtomicReference<ReadGate> ACTIVE_GATE = new AtomicReference<>();
+
+    @TestConfiguration
+    static class RacingRepositoryConfig {
+
+        @Bean
+        @Primary
+        ProjectFileRepository racingProjectFileRepository(
+                @Qualifier("projectFileRepository") ProjectFileRepository real) {
+            InvocationHandler handler = (proxy, method, args) -> {
+                ReadGate gate = ACTIVE_GATE.get();
+                if (gate != null
+                        && "findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc".equals(method.getName())
+                        && args != null && args.length == 2) {
+                    Object result = invokeReal(real, method, args);
+                    gate.onRead(String.valueOf(args[1]));
+                    return result;
+                }
+                return invokeReal(real, method, args);
+            };
+            return (ProjectFileRepository) Proxy.newProxyInstance(
+                    ProjectFileRepository.class.getClassLoader(),
+                    new Class<?>[]{ProjectFileRepository.class},
+                    handler);
+        }
+
+        private static Object invokeReal(Object real, java.lang.reflect.Method method, Object[] args) {
+            try {
+                return method.invoke(real, args);
+            } catch (InvocationTargetException ite) {
+                Throwable cause = ite.getCause();
+                if (cause instanceof RuntimeException re) throw re;
+                if (cause instanceof Error err) throw err;
+                throw new RuntimeException(cause);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /** 单向门，语义与 {@code DdServiceEnsureFolderConcurrentTest.ReadGate} 完全一致。 */
+    static final class ReadGate {
+        private final String targetKey;
+        private final AtomicBoolean firstArrived = new AtomicBoolean(false);
+        private final CountDownLatch secondArrived = new CountDownLatch(1);
+
+        ReadGate(String targetKey) { this.targetKey = targetKey; }
+
+        void onRead(String key) throws InterruptedException {
+            if (!targetKey.equals(key)) return;
+            if (firstArrived.compareAndSet(false, true)) {
+                secondArrived.await(3, TimeUnit.SECONDS);
+            } else {
+                secondArrived.countDown();
+            }
+        }
+    }
+
+    @Autowired
+    private ProjectFileService projectFileService;
+    @Autowired
+    private ProjectFileRepository projectFileRepository;
+
+    @AfterEach
+    void tearDown() {
+        ACTIVE_GATE.set(null);
+    }
+
+    private ProjectFile save(Long projectId, Long parentId, String name, boolean isFolder, Long size) {
+        ProjectFile f = new ProjectFile();
+        f.setProjectId(projectId);
+        f.setParentId(parentId);
+        f.setName(name);
+        f.setIsFolder(isFolder);
+        f.setFileSize(size);
+        f.setIsDeleted(false);
+        f.setSortOrder(0);
+        f.setUserId(1L);
+        f.setCreatedAt(LocalDateTime.now());
+        f.setUpdatedAt(LocalDateTime.now());
+        return projectFileRepository.save(f);
+    }
+
+    @Test
+    void 并发批量移入缓存区不能合计超过免费额度() throws Exception {
+        long projectId = 9401L;
+        Long stagingFolderId = save(projectId, null, StageQuotaService.STAGING_FOLDER_NAME, true, null).getId();
+
+        // 缓存区已有 18 个文件（上限 20），刚好留 2 个名额
+        for (int i = 0; i < 18; i++) {
+            save(projectId, stagingFolderId, "existing" + i + ".txt", false, 1L);
+        }
+
+        // 两批各 2 个文件，各自单独看都没超额（18+2=20），并发一起看就超了（18+2+2=22）
+        Long a1 = save(projectId, null, "a1.txt", false, 1L).getId();
+        Long a2 = save(projectId, null, "a2.txt", false, 1L).getId();
+        Long b1 = save(projectId, null, "b1.txt", false, 1L).getId();
+        Long b2 = save(projectId, null, "b2.txt", false, 1L).getId();
+
+        ACTIVE_GATE.set(new ReadGate(String.valueOf(stagingFolderId)));
+
+        ProjectFileBatchRequest reqA = new ProjectFileBatchRequest();
+        reqA.setFileIds(List.of(a1, a2));
+        reqA.setTargetParentId(stagingFolderId);
+        ProjectFileBatchRequest reqB = new ProjectFileBatchRequest();
+        reqB.setFileIds(List.of(b1, b2));
+        reqB.setTargetParentId(stagingFolderId);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        int rejections = 0;
+        try {
+            Future<Object> fA = pool.submit(() -> {
+                projectFileService.batchMove(projectId, reqA, 1L);
+                return null;
+            });
+            Future<Object> fB = pool.submit(() -> {
+                projectFileService.batchMove(projectId, reqB, 1L);
+                return null;
+            });
+
+            rejections += countQuotaRejection(fA);
+            rejections += countQuotaRejection(fB);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertEquals(1, rejections,
+                "两批各 2 个、合计会超额，必须恰好拒绝一批，不能两批都放行也不能两批都拒绝");
+
+        long finalCount = projectFileRepository
+                .findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc(projectId, stagingFolderId)
+                .size();
+        assertTrue(finalCount <= StageQuotaService.FREE_MAX_FILES,
+                "缓存区最终文件数不能超过免费额度: " + finalCount);
+    }
+
+    private static int countQuotaRejection(Future<Object> future) throws Exception {
+        try {
+            future.get(20, TimeUnit.SECONDS);
+            return 0;
+        } catch (java.util.concurrent.ExecutionException e) {
+            if (e.getCause() instanceof com.checkba.exception.StageQuotaExceededException) {
+                return 1;
+            }
+            throw e;
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/quota/StageQuotaServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/quota/StageQuotaServiceTest.java
@@ -50,6 +50,10 @@ class StageQuotaServiceTest {
         put(folder(OTHER_FOLDER, "合同"));
 
         when(repository.findById(any())).thenAnswer(inv -> Optional.ofNullable(table.get(inv.getArgument(0))));
+        // lockById 是悲观行锁读取（并发竞态修复，dev-board#74），对这张纯内存假表而言
+        // 语义上就是同一次查找——真实的行锁互斥由 ProjectFileRepositoryStagingLockConcurrentTest
+        // 用真 Spring 容器 + 真 H2 验证。
+        when(repository.lockById(any())).thenAnswer(inv -> Optional.ofNullable(table.get(inv.getArgument(0))));
         when(repository.findByProjectIdAndParentIdAndIsDeletedFalseOrderBySortOrderAsc(any(), any()))
                 .thenAnswer(inv -> {
                     Long parent = inv.getArgument(1);

--- a/backend/src/test/java/com/checkba/service/storage/StorageLocationServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/storage/StorageLocationServiceTest.java
@@ -295,6 +295,50 @@ class StorageLocationServiceTest {
         assertFalse(Files.exists(stateDir.resolve("storage-location.json")), "放弃的迁移不得落配置");
     }
 
+    /**
+     * 旧实现的源侧复查只比较聚合数字（文件数 + 总字节数），抓不住"复制窗口期间，
+     * 已经被 copyTree 走过的某个文件被原地改写成同样字节数的新内容"这种情况——
+     * 文件数没变、总字节数也没变，两次聚合数字仍然相等，校验会误判通过，
+     * 而目标里躺着的是改写前的旧内容，用户在文件树里看得见却打不开最新版本。
+     * 改成逐文件（大小 + mtime）指纹比对后，同样字节数的原地改写也能被抓住。
+     */
+    @Test
+    @DisplayName("迁移窗口期间已复制文件被原地改写成同样字节数：整体放弃，不留下内容过期的副本")
+    void sameSizeInPlaceModificationDuringCopyAbortsMigration() throws IOException {
+        Path target = tempDir.resolve("外置硬盘/awd");
+        Path targetReal = target.toAbsolutePath().normalize();
+        Path rewritten = source.resolve("projects/1/合同.docx");
+        // 原内容"甲方乙方"与新内容"乙方甲方"字节数相同（各占 8 字节，UTF-8 下中文各 3 字节），
+        // 聚合的文件数与总字节数因此两边都不变——旧实现的聚合比对必定判定"没变化"。
+        long originalSize = Files.size(rewritten);
+        assertEquals(originalSize, "乙方甲方".getBytes(java.nio.charset.StandardCharsets.UTF_8).length,
+                "测试前提：替换内容必须与原内容字节数相同，否则测的是旧实现本来就能抓住的场景");
+
+        // 时序模拟：copyTree 走完之后（即对目标那次统计时）原地改写源里已经被复制过的文件，
+        // 换成同样字节数的新内容并显式钉一个更晚的 mtime（不依赖文件系统时间戳分辨率）。
+        StorageLocationService svc = new StorageLocationService(resolver, stateDir.toString()) {
+            @Override
+            Tally tally(Path root) throws IOException {
+                Tally t = super.tally(root);
+                if (root.toAbsolutePath().normalize().equals(targetReal)) {
+                    Files.writeString(rewritten, "乙方甲方");
+                    Files.setLastModifiedTime(rewritten,
+                            java.nio.file.attribute.FileTime.from(Files.getLastModifiedTime(rewritten).toInstant().plusSeconds(5)));
+                }
+                return t;
+            }
+        };
+
+        StorageException e = assertThrows(StorageException.class, () -> svc.migrate(target.toString()));
+        assertTrue(e.getMessage().contains("迁移期间"), "文案要说清原因，用户才知道下一步是关掉正在编辑的文档");
+
+        // 指针留在原位，源目录里的最新内容（改写后的）完好，没有被误当成"没变化"而放行
+        assertEquals(source.toAbsolutePath().normalize(), resolver.globalRoot());
+        assertEquals("乙方甲方", Files.readString(rewritten));
+        assertEquals(3L, countFiles(source));
+        assertFalse(Files.exists(stateDir.resolve("storage-location.json")), "放弃的迁移不得落配置");
+    }
+
     @Test
     @DisplayName("目标是指向源目录内部的软链：按真实路径判定并拒绝，不污染源数据根")
     void symlinkTargetPointingIntoSourceRejected() throws IOException {


### PR DESCRIPTION
审计剩余清单里的竞态那一组 8 条，加上复核时顺手补的 2 条同形状（见文末）。
每条先写测试看它红、改实现看它绿、再把实现临时还原确认测试真会红。

**这一组最容易做成假修的地方**（子 agent 自己识破了，记在这里免得下次再踩）：
这些方法大多跑在调用方已经开着的 @Transactional 里。**在里面加进程内 synchronized 是假修**——
锁在方法返回时就释放，而真正的写入要等外层方法整体返回、AOP 代理提交时才落库；
第二个请求拿到锁后重新查库，看到的仍是第一个请求尚未提交的旧数据，两边照样都放行。
所以按场景分别用了三种正确做法，每条都在注释里写清为什么选那一种。

1. [MEDIUM] 缓存区免费额度被并发批量移动一起绕过
   两个并发请求读到同一份移动前的用量，都算出「加完还没超」，都提交，合计超额且用户零提示。
   用**悲观行锁**（新增 `ProjectFileRepository.lockById`，SELECT ... FOR UPDATE）把
   「查用量 + 判放行」钉进调用方那个事务里——行锁与事务同生命周期，第二个请求会一直阻塞
   到第一个提交为止，锁到手时读到的已是提交后的真实用量。
   锁只在「确实要执行额度」且「目标确实是缓存区」之后才取，其它移动不受影响。

2. [MEDIUM] 迁移中途的重新盘点抓不到同尺寸的原地改写
   原来只比对总文件数与总字节数，一个已经拷完的文件被就地改成同样大小时完全看不出来。
   改成按「路径 → 大小 + 修改时间」的逐文件指纹比对。

3. [MEDIUM] macOS 大小写不敏感盘上只改大小写的重命名留下永久幽灵行
   删除同步用 `Files.exists` 判断物理是否还在，而大小写不敏感的盘上旧大小写照样返回 true，
   旧行永远清不掉。改成用 `toRealPath()` 取磁盘上的真实大小写来比对。
   （做这条时还发现：`Files.move` 单步改大小写在 APFS 上是空操作，测试必须借临时名两步走。）

4/5. [MEDIUM] 两处 ensureFolder 的 check-then-create 竞态造成重复文件夹
   尽调批量上传时多个条目共享同一个还没建出来的祖先目录；股东大会双击「开始核查」同理。
   重复文件夹一出现，之后按名字查会随机命中其中一个，文件被分散到两个同名目录里，
   在用户正看着的那个里「消失」。
   用「按 key 的进程锁 + REQUIRES_NEW 子事务」（照抄 ProjectProfileService 既有做法）：
   锁外套新事务，建好即提交，第二个请求拿到锁后能查到真实存在的那一行。
   **一处可见的行为变化**：尽调那侧的脚手架目录现在即使 uploadFile 后续失败也会留下
   （原来会一起回滚）。判为与「幂等地保证目录在」的既有取向一致，且空目录无害。

6. [MEDIUM] createOrUpdateVariable 的 TOCTOU 撞唯一约束报「服务器内部错误」
   (project_id, name) 上有真实唯一约束，两个并发保存都读到空就都插入，第二个撞约束。
   注意撞约束会把当前事务标 rollback-only，**同方法内 catch 也救不回来**（提交时照样抛
   UnexpectedRollbackException），所以重试必须经 self 转发到 REQUIRES_NEW 的新事务。

7. [LOW] MAX_IMPORT_DEPTH 封顶时静默丢弃深层文件（条目数上限那条是有 truncated 标志的）
   实现时发现一个反直觉的事实：`Files.walkFileTree` 到达 maxDepth 时，卡在边界上的目录
   **不会**走 preVisitDirectory，而是被当成不透明条目扔进 visitFile。
   第一版按 preVisitDirectory 判断是死代码、测试一直红，靠一个最小探针才定位到。

8. [MEDIUM] 自动打标签闸的 check-then-act 让并发保存把标签翻倍
   两次自动保存都在对方的 LLM 往返结束前通过了「有没有自动标签」的检查。
   这个方法没有外层事务（下游各自独立提交），所以按 fileId 加进程锁把
   「检查 + LLM + 写入」整段串起来就够，不需要 REQUIRES_NEW。

复核时补的两条（子 agent 标为「同形状但不在范围内」）：
9/10. UserVariableService / FileVariableService 的 createOrUpdateVariable
   与第 6 条形状完全相同，(user_id, name) / (file_id, name) 也都有真实唯一约束——
   用户只是同时在两处保存同名变量，就会看到「服务器内部错误」。按同一模式修。
   事务语义那一层已由第 6 条的真容器测试钉住，这两条只钉「撞约束后确实重试一次、
   并落到对方已提交的那一行上」，不重复搭那套重量级脚手架。

并发测试的写法：锁类修复用**单向闸**而不是对称栅栏——修好之后第二个线程根本到不了
被闸住的那次调用（它先被锁挡住了），对称栅栏会直接死锁。
另外 H2 默认 2 秒的锁超时短于闸门等待时间，额度那条测试里显式调到 10 秒，
否则会冒出一个与真实竞态无关的假红。

全量 mvn test：2292 通过 0 失败 11 跳过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)