### PR TITLE
fix(infra): SSE 收尾掐掉重连、脚本打死别人的进程、双开跑两套后端等九条（dev-board#74）

### DIFF
--- a/backend/restart-backend.sh
+++ b/backend/restart-backend.sh
@@ -3,6 +3,7 @@ set -e
 
 # 确保脚本在 backend 目录下执行，解决从根目录即使 invoked 找不到 pom.xml 的问题
 cd "$(dirname "$0")"
+BACKEND_DIR=$(pwd)
 
 echo "== 1. 打包 =="
 mvn clean package -DskipTests
@@ -10,16 +11,26 @@ mvn clean package -DskipTests
 echo "== 2. 停止旧进程（端口 9696） =="
 PID=$(lsof -ti:9696 || true)
 if [ -n "$PID" ]; then
-  echo "找到进程 PID=${PID}，kill..."
-  # 使用 kill -0 检查进程是否存在，避免 kill 失败导致脚本退出
-  if kill -0 $PID 2>/dev/null; then
-    kill $PID || true
-    sleep 2
-    # 如果进程还在，强制杀死
+  # 端口 9696 是全局资源，多个 worktree 并行开发时可能是另一个 checkout 的、完全
+  # 健康的后端占着——不是本脚本起的进程就不杀，只报警（dev-board#74 审计条目：
+  # restart-all.sh 同一问题，这里独立调用时也要有同样的防护，否则 restart-all.sh
+  # 里加的保护会在这一步被绕开重新杀掉）。lsof 拿不到 cwd 时按"不是本 checkout"处理。
+  PID_CWD=$(lsof -a -p "$PID" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')
+  if [ "$PID_CWD" != "$BACKEND_DIR" ]; then
+    echo "⚠️ 端口 9696 被其它工作目录的进程占用 (PID: $PID, 工作目录: ${PID_CWD:-未知})，不是本 checkout 启动的，不会杀它。"
+    echo "   新 Jar 无法绑定到 9696，下面的启动步骤会因端口占用而失败——先去占用端口的那个 worktree 里停止。"
+  else
+    echo "找到进程 PID=${PID}，kill..."
+    # 使用 kill -0 检查进程是否存在，避免 kill 失败导致脚本退出
     if kill -0 $PID 2>/dev/null; then
-      echo "进程仍在运行，强制杀死..."
-      kill -9 $PID || true
+      kill $PID || true
       sleep 2
+      # 如果进程还在，强制杀死
+      if kill -0 $PID 2>/dev/null; then
+        echo "进程仍在运行，强制杀死..."
+        kill -9 $PID || true
+        sleep 2
+      fi
     fi
   fi
 else

--- a/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
+++ b/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
@@ -26,6 +26,28 @@ public class MeetingRecordingController {
     private final MeetingTranscriptionService transcriptionService;
     private final ProjectMemberService projectMemberService;
 
+    // 并发「开始录音」竞态防护：前端 isRecordingActive() 只是同一个 JS 运行时里的
+    // 内存标记（utils/meetingRecorder.js 的模块级单例），管不到"同一账号在桌面端 +
+    // 浏览器标签页各开一份""同一项目的多个成员各自点了开始"这类跨客户端场景——
+    // 这两种都是正常使用即可触发，不需要恶意操作。MeetingRecordingService.create()
+    // 内部 uniqueName() 是"查名字是否存在→建档"两步式，中间有窗口：两个并发请求都
+    // 查到"名字不存在"，各自建出一行同名 ProjectFile，物理路径只由 projectId/
+    // parentId/name 决定（不含行 id），两行会落到同一个物理文件上，后续两段录音的
+    // 分片上传各写各的 audioFileId 却写进同一个文件，互相覆盖。
+    //
+    // 锁必须包住对 meetingService.create() 的整次调用（含其 @Transactional 提交），
+    // 而不能放进 create() 内部再对自身方法做同类里自调用——Spring 的事务代理只在
+    // "经过代理的外部调用"上生效，同类自调用会绕开代理导致 @Transactional 整个失效。
+    // 放在控制器这层、包住经代理的服务调用，两头都对。
+    // 单机/单进程部署（当前架构）已经能完整堵住这条路径；水平扩到多实例需要数据库锁，
+    // 不在当前架构范围内，届时再加。
+    private final java.util.concurrent.ConcurrentHashMap<Long, Object> startRecordingLocks =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
+    private Object startRecordingLock(Long projectId) {
+        return startRecordingLocks.computeIfAbsent(projectId, k -> new Object());
+    }
+
     private Long requireMemberByProject(String sessionId, Long projectId) {
         Long userId = AuthController.getUserIdFromSession(sessionId);
         if (userId == null) throw new IllegalArgumentException("未登录");
@@ -45,7 +67,10 @@ public class MeetingRecordingController {
             @PathVariable Long projectId,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = requireMemberByProject(sessionId, projectId);
-        MeetingRecording meeting = meetingService.create(projectId, userId);
+        MeetingRecording meeting;
+        synchronized (startRecordingLock(projectId)) {
+            meeting = meetingService.create(projectId, userId);
+        }
         Map<String, Object> result = new HashMap<>();
         result.put("meeting", meeting);
         result.put("configured", transcriptionService.isConfigured());

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -109,6 +109,9 @@ public class AgentOrchestrator {
     private final Map<String, StringBuilder> activeStreamContent = new ConcurrentHashMap<>();
     // 本轮 ASSISTANT 消息的行 ID：同一轮内的增量保存/最终保存更新同一行，跨轮次互不覆盖
     private final Map<String, Long> activeAssistantMessageId = new ConcurrentHashMap<>();
+    // 本轮开始时记下的 SSE 连接代次：收尾调用 sseEmitterService.close() 时原样带回，
+    // 防止跑了半天的旧一轮在收尾时把期间用户重连建立的新连接误杀（见 SseEmitterService.close 注释）
+    private final Map<String, Long> turnConnectionEpoch = new ConcurrentHashMap<>();
 
     private final ChatModelFactory chatModelFactory;
     private final ProjectAiMessageService messageService;
@@ -157,6 +160,15 @@ public class AgentOrchestrator {
         cancelledConversations.remove(conversationId);
         activeStreamContent.remove(conversationId);
         activeAssistantMessageId.remove(conversationId);
+        turnConnectionEpoch.remove(conversationId);
+    }
+
+    /**
+     * 收尾关闭本轮 SSE 连接：带上本轮开始时记下的代次，交给 SseEmitterService 做匹配判断。
+     * 只处理这一处的误杀，不动取消/恢复相关逻辑。
+     */
+    private void closeSse(String conversationId) {
+        sseEmitterService.close(conversationId, turnConnectionEpoch.getOrDefault(conversationId, 0L));
     }
 
     /**
@@ -192,7 +204,7 @@ public class AgentOrchestrator {
         // 发送取消事件
         sseEmitterService.send(conversationId, "cancelled",
                 "{\"message\":\"" + LangText.of("用户已停止生成", "Generation stopped by the user") + "\"}");
-        sseEmitterService.close(conversationId);
+        closeSse(conversationId);
         
         // 清理状态
         clearCancelledState(conversationId);
@@ -406,6 +418,9 @@ public class AgentOrchestrator {
         cancelledConversations.remove(conversationId);
         activeStreamContent.put(conversationId, new StringBuilder());
         activeAssistantMessageId.remove(conversationId);
+        // 本轮开始时先取一次 SSE 连接代次存起来：本轮期间无论重试/递归多少层，
+        // 收尾时各处 close() 都带这同一个值，与用户中途重连产生的新代次区分开
+        turnConnectionEpoch.put(conversationId, sseEmitterService.currentEpoch(conversationId));
         // 埋点轮次上下文先于 mark 建立：终态由 AgentRunStateService.mark 单点合成 ai.turn
         java.util.Map<String, Object> turnAttrs = new java.util.HashMap<>();
         turnAttrs.put("mode", agentMode == null ? null : agentMode.name());
@@ -528,12 +543,12 @@ public class AgentOrchestrator {
             log.info("平台通道不可用 [{}]，会话 {}: {}", e.getKind(), conversationId, e.getMessage());
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
             sseEmitterService.send(conversationId, "error", e.getMessage());
-            sseEmitterService.close(conversationId);
+            closeSse(conversationId);
         } catch (Exception e) {
             log.error("Agent Loop Error for conversation: " + conversationId, e);
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
             sseEmitterService.send(conversationId, "error", "Internal Error: " + e.getMessage());
-            sseEmitterService.close(conversationId);
+            closeSse(conversationId);
         }
     }
 
@@ -559,7 +574,7 @@ public class AgentOrchestrator {
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.PAUSED);
             // status=paused 让前端渲染一键「继续」按钮（区别于 finished 的正常收尾）
             sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"paused\",\"reason\":\"max_depth\"}");
-            sseEmitterService.close(conversationId);
+            closeSse(conversationId);
             clearCancelledState(conversationId);
             return;
         }
@@ -569,7 +584,7 @@ public class AgentOrchestrator {
             log.info("Ask mode: stopping loop at depth {}", depth);
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.FINISHED);
             sseEmitterService.send(conversationId, "bubble_end", "{}");
-            sseEmitterService.close(conversationId);
+            closeSse(conversationId);
             clearCancelledState(conversationId);
             return;
         }
@@ -578,12 +593,13 @@ public class AgentOrchestrator {
         editorBridgeService.setCurrentConversationId(conversationId);
 
         AgentStreamHandler handler = new AgentStreamHandler(
-            sseEmitterService, 
-            conversationId, 
-            tokenUsageService, 
-            projectId, 
-            userId, 
-            modelId
+            sseEmitterService,
+            conversationId,
+            tokenUsageService,
+            projectId,
+            userId,
+            modelId,
+            turnConnectionEpoch.getOrDefault(conversationId, 0L)
         );
         
 
@@ -679,7 +695,7 @@ public class AgentOrchestrator {
                 saveAssistantMessage(conversationId, projectId, userId, truncPersisted);
                 agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.PAUSED);
                 sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"paused\",\"reason\":\"max_tokens\"}");
-                sseEmitterService.close(conversationId);
+                closeSse(conversationId);
                 clearCancelledState(conversationId);
                 return;
             }
@@ -1024,7 +1040,7 @@ public class AgentOrchestrator {
                     agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.AWAITING_APPROVAL);
                     // 发送 bubble_end 表示当前响应结束（等待用户审批）
                     sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"awaiting_approval\"}");
-                    sseEmitterService.close(conversationId);
+                    closeSse(conversationId);
                     clearCancelledState(conversationId);
                     return; // Stop and wait for user action
                 }
@@ -1074,7 +1090,7 @@ public class AgentOrchestrator {
                 saveAssistantMessage(conversationId, projectId, userId, truncContent);
                 agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.PAUSED);
                 sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"paused\",\"reason\":\"max_tokens\"}");
-                sseEmitterService.close(conversationId);
+                closeSse(conversationId);
                 clearCancelledState(conversationId);
                 activeStreamContent.remove(conversationId);
                 return;
@@ -1103,7 +1119,7 @@ public class AgentOrchestrator {
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.FINISHED);
             // 发送 bubble_end 表示整个循环真正结束
             sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"finished\"}");
-            sseEmitterService.close(conversationId);
+            closeSse(conversationId);
             // 清理取消状态
             clearCancelledState(conversationId);
             activeStreamContent.remove(conversationId); // CLEANUP
@@ -1247,7 +1263,7 @@ public class AgentOrchestrator {
             log.info("故障转移中止，平台通道不可用 [{}]，会话 {}: {}", ae.getKind(), conversationId, ae.getMessage());
             agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.ERROR);
             sseEmitterService.send(conversationId, "error", ae.getMessage());
-            sseEmitterService.close(conversationId);
+            closeSse(conversationId);
             clearCancelledState(conversationId);
             return true;
         } catch (Exception e) {
@@ -1323,7 +1339,7 @@ public class AgentOrchestrator {
                     logText + partialContent
                             + LangText.of("\n\n[生成出错，已中断]", "\n\n[Generation error, interrupted]"));
         }
-        sseEmitterService.close(conversationId);
+        closeSse(conversationId);
         clearCancelledState(conversationId);
         editorBridgeService.clearCurrentConversationId();
     }
@@ -1537,7 +1553,7 @@ public class AgentOrchestrator {
         agentRunStateService.mark(conversationId, AgentRunStateService.RunStatus.AWAITING_INPUT);
         // status=awaiting_input：会话列表显示「待回答」（区别于待审批），前端解锁输入区
         sseEmitterService.send(conversationId, "bubble_end", "{\"status\":\"awaiting_input\"}");
-        sseEmitterService.close(conversationId);
+        closeSse(conversationId);
         clearCancelledState(conversationId);
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentStreamHandler.java
@@ -20,6 +20,9 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
     private final String projectId;
     private final Long userId;
     private final String modelId;
+    // 调用方在本轮开始时记下的 SSE 连接代次，close() 收尾时原样带回
+    // （见 SseEmitterService.close 的注释：防止误杀期间重连建立的新连接）
+    private final long connectionEpoch;
 
     private final StringBuilder fullContentBuilder = new StringBuilder();
     private boolean isBubbleStarted = false;
@@ -93,13 +96,14 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
         if (f != null) f.cancel(false);
     }
 
-    public AgentStreamHandler(SseEmitterService sseEmitterService, String conversationId, TokenUsageService tokenUsageService, String projectId, Long userId, String modelId) {
+    public AgentStreamHandler(SseEmitterService sseEmitterService, String conversationId, TokenUsageService tokenUsageService, String projectId, Long userId, String modelId, long connectionEpoch) {
         this.sseEmitterService = sseEmitterService;
         this.conversationId = conversationId;
         this.tokenUsageService = tokenUsageService;
         this.projectId = projectId;
         this.userId = userId;
         this.modelId = modelId;
+        this.connectionEpoch = connectionEpoch;
     }
 
     // Callback for each token generated (for real-time tracking)
@@ -551,7 +555,7 @@ public class AgentStreamHandler implements StreamingResponseHandler<AiMessage> {
             // 无回调（单次响应）：保持旧行为——发 error 并关流，
             // 否则 SSE 连接会挂到 30 分钟超时、前端永久显示加载态。
             sseEmitterService.send(conversationId, "error", "Stream Error: " + error.getMessage());
-            sseEmitterService.close(conversationId);
+            sseEmitterService.close(conversationId, connectionEpoch);
         }
     }
     

--- a/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
+++ b/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
@@ -20,6 +20,13 @@ public class SseEmitterService {
     // Key: conversationId (or sessionId) -> SseEmitter
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
+    // Key: connectionId -> 当前连接代次，每次 createConnection 建连自增。
+    // close(connectionId, epoch) 靠它判断"要关的是不是这一次连接"，见 close() 的注释。
+    private final Map<String, Long> epochs = new ConcurrentHashMap<>();
+
+    /** 代次表的清理阈值：远大于任何真实并发会话数，触到才动手，正常运行期间等于不清理。 */
+    private static final int EPOCH_PURGE_THRESHOLD = 10_000;
+
     // 心跳广播：15s 一次，双重作用——(a) 长工具执行期间通道零字节流动，企业网关/
     // 代理的空闲回收窗口（常见 60~120s）会静默掐连接，心跳保活穿透；
     // (b) 前端据 lastHeartbeat 判定连接死活，超时触发自动重连（F-04/F-05）。
@@ -51,6 +58,10 @@ public class SseEmitterService {
      * @return SseEmitter 实例
      */
     public SseEmitter createConnection(String connectionId) {
+        // 代次自增：本次建连之后，任何持有旧代次的 close() 调用都不再匹配当前连接
+        epochs.merge(connectionId, 1L, Long::sum);
+        purgeEpochsIfOversized();
+
         // 设置超时时间，0表示不过期 (由客户端重连或业务逻辑控制断开)
         // Spring Boot 默认可能是 30s，这里设为 30分钟
         SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
@@ -109,9 +120,48 @@ public class SseEmitterService {
     }
     
     /**
-     * 关闭连接
+     * 调用方（一轮 Agent 运行）应在本轮开始时取一次当前代次存起来，收尾调用 {@link #close}
+     * 时原样带回——用来分辨"现在映射的这个 emitter 还是不是本轮建连的那个"。
      */
-    public void close(String connectionId) {
+    /**
+     * 代次表不能在 close() 时随手删掉——删了之后新连接的代次会从 1 重新开始，
+     * 一条迟到的、手里攥着旧代次 1 的 close() 就会误判成"匹配"，把新连接掐掉，
+     * 正是这次要修的那个病。所以只能按规模兜底清理：超过阈值时，
+     * 把当前没有活连接的那些键清掉。
+     *
+     * <p>清掉之后若真有迟到的 close 找上门，它看到的当前代次是 0、与自己手里的对不上，
+     * 于是**跳过关闭**——落在安全的一侧（最坏是某个 emitter 没被显式收尾，
+     * 由 30 分钟超时或下一次重连顶掉），不会误关活连接。
+     */
+    private void purgeEpochsIfOversized() {
+        if (epochs.size() <= EPOCH_PURGE_THRESHOLD) return;
+        epochs.keySet().removeIf(id -> !emitters.containsKey(id));
+    }
+
+    public long currentEpoch(String connectionId) {
+        return epochs.getOrDefault(connectionId, 0L);
+    }
+
+    /**
+     * 关闭连接。
+     *
+     * <p>close() 和 createConnection() 各自跑在不同线程上：后台的 Agent 轮次结束时调用本方法，
+     * 与此同时用户可能因为刷新页面/开新标签/断线重连而并发调用 createConnection() 建立了一个
+     * 全新的 emitter。旧单参版本 {@code emitters.remove(connectionId)} 不认这个区别，谁后写入
+     * map 就删谁，会把刚重连、什么错都没有的新连接一并掐掉。
+     *
+     * <p>epoch 只在与当前代次一致时才真正 complete；重连已经把代次往前推了的话，这次 close
+     * 就是"迟到的旧一轮善后"，原地跳过——新连接自己的生命周期不受影响。
+     *
+     * @param connectionId 会话ID或用户ID
+     * @param epoch 调用方在本轮开始时通过 {@link #currentEpoch} 记下的代次
+     */
+    public void close(String connectionId, long epoch) {
+        if (epochs.getOrDefault(connectionId, 0L) != epoch) {
+            log.debug("Skip close for {}: stale epoch {} (current {}), a newer connection already took over",
+                    connectionId, epoch, epochs.get(connectionId));
+            return;
+        }
         SseEmitter emitter = emitters.remove(connectionId);
         if (emitter != null) {
             emitter.complete();

--- a/backend/src/test/java/com/checkba/controller/MeetingRecordingControllerConcurrentStartTest.java
+++ b/backend/src/test/java/com/checkba/controller/MeetingRecordingControllerConcurrentStartTest.java
@@ -1,0 +1,151 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.MeetingRecording;
+import com.checkba.service.LocalIdentityService;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.UserSessionService;
+import com.checkba.service.meeting.MeetingRecordingService;
+import com.checkba.service.meeting.MeetingTranscriptionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * dev-board#74 稳定性审计：并发「开始录音」竞态。
+ *
+ * <p>前端 {@code isRecordingActive()}（frontend/src/utils/meetingRecorder.js）只是
+ * 同一个 JS 运行时里的内存标记，管不到"同一账号桌面端 + 浏览器标签页各开一份""同一
+ * 项目多个成员各自点了开始"这类跨客户端并发——这两种都是正常使用即可触发，不需要
+ * 恶意操作。{@link MeetingRecordingService#create} 内部 {@code uniqueName()} 是
+ * "查名字是否存在 → 建档"两步式，中间有窗口：两个并发请求都能查到"名字不存在"，
+ * 各自建出一行同名 ProjectFile，物理路径只由 projectId/parentId/name 决定（不含行
+ * id），两行会落到同一个物理文件上，后续两段录音的分片上传各写各的 audioFileId
+ * 却写进同一个文件，互相覆盖。
+ *
+ * <p>本测试验证控制器层新加的按 projectId 分桶的锁，把 {@code create()} 的整次
+ * 调用（含其内部 {@code @Transactional} 提交）正确串行化。
+ */
+class MeetingRecordingControllerConcurrentStartTest {
+
+    @BeforeEach
+    void setUp() {
+        // 本类不走 Spring TestContext，AuthController 的 static 指针可能被别的测试类
+        // 钉在别处——先钉一个关着 local-mode 的空实例，逼 getUserIdFromSession 落到
+        // staticUserSessionService（本测试下面自己注册的 mock），不受执行顺序影响
+        // （同 DeviceTokenServiceTest 的自钉写法）。
+        AuthController.registerLocalIdentityService(
+                new LocalIdentityService(null, null, null, null, false));
+    }
+
+    @Test
+    @DisplayName("并发「开始录音」互斥：同一 projectId 第二个请求必须等第一个建档完全结束才能进")
+    void createIsSerializedPerProject() throws Exception {
+        MeetingRecordingService meetingService = mock(MeetingRecordingService.class);
+        MeetingTranscriptionService transcriptionService = mock(MeetingTranscriptionService.class);
+        ProjectMemberService projectMemberService = mock(ProjectMemberService.class);
+        UserSessionService userSessionService = mock(UserSessionService.class);
+        when(userSessionService.resolveUserId("sess-a")).thenReturn(7L);
+        when(userSessionService.resolveUserId("sess-b")).thenReturn(8L);
+        AuthController.registerUserSessionService(userSessionService);
+
+        when(projectMemberService.hasReadPermission(eq(1L), anyLong())).thenReturn(true);
+
+        // 可控闸门：第一次调用停在"临界区里"，直到测试主动放行——把"两个请求确实在
+        // 同时进行"这件事做成确定性的，不靠 sleep 撞运气（同 VerificationCodeStoreTest 的写法）。
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicInteger callCount = new AtomicInteger();
+        when(meetingService.create(eq(1L), anyLong())).thenAnswer(inv -> {
+            int n = callCount.incrementAndGet();
+            if (n == 1) {
+                entered.countDown();
+                assertTrue(release.await(5, TimeUnit.SECONDS), "release 门必须在超时前被打开");
+            }
+            MeetingRecording m = new MeetingRecording();
+            m.setId((long) n);
+            m.setProjectId(1L);
+            return m;
+        });
+
+        MeetingRecordingController controller =
+                new MeetingRecordingController(meetingService, transcriptionService, projectMemberService);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<Map<String, Object>> first = pool.submit(() -> controller.create(1L, "sess-a"));
+            assertTrue(entered.await(5, TimeUnit.SECONDS), "第一个 create 应当已经进入 meetingService.create()");
+
+            Future<Map<String, Object>> second = pool.submit(() -> controller.create(1L, "sess-b"));
+            assertThrows(TimeoutException.class, () -> second.get(600, TimeUnit.MILLISECONDS),
+                    "同一 projectId 的开始录音必须互斥：不然两个并发请求都能查到「名字不存在」，"
+                            + "各建一份指向同一物理路径的 ProjectFile，两段录音互相覆盖");
+
+            release.countDown();
+            assertNotNull(first.get(5, TimeUnit.SECONDS));
+            assertNotNull(second.get(5, TimeUnit.SECONDS));
+            assertEquals(2, callCount.get(), "两个请求最终都要成功建档，锁只是串行化，不是拒绝第二个");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("不同 projectId 互不阻塞：锁按项目分桶，不会把无关项目的开始录音也串行化")
+    void differentProjectsDoNotBlockEachOther() throws Exception {
+        MeetingRecordingService meetingService = mock(MeetingRecordingService.class);
+        MeetingTranscriptionService transcriptionService = mock(MeetingTranscriptionService.class);
+        ProjectMemberService projectMemberService = mock(ProjectMemberService.class);
+        UserSessionService userSessionService = mock(UserSessionService.class);
+        when(userSessionService.resolveUserId("sess-a")).thenReturn(7L);
+        when(userSessionService.resolveUserId("sess-b")).thenReturn(8L);
+        AuthController.registerUserSessionService(userSessionService);
+        when(projectMemberService.hasReadPermission(anyLong(), anyLong())).thenReturn(true);
+
+        CountDownLatch project1Entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        when(meetingService.create(eq(1L), anyLong())).thenAnswer(inv -> {
+            project1Entered.countDown();
+            assertTrue(release.await(5, TimeUnit.SECONDS));
+            MeetingRecording m = new MeetingRecording();
+            m.setId(1L);
+            return m;
+        });
+        when(meetingService.create(eq(2L), anyLong())).thenReturn(new MeetingRecording());
+
+        MeetingRecordingController controller =
+                new MeetingRecordingController(meetingService, transcriptionService, projectMemberService);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<Map<String, Object>> first = pool.submit(() -> controller.create(1L, "sess-a"));
+            assertTrue(project1Entered.await(5, TimeUnit.SECONDS));
+
+            // 项目 2 与项目 1 互不相干，即便项目 1 还卡在临界区里，项目 2 的请求也必须立刻通过
+            Future<Map<String, Object>> other = pool.submit(() -> controller.create(2L, "sess-b"));
+            assertNotNull(other.get(2, TimeUnit.SECONDS), "不同 projectId 不应该被彼此的锁挡住");
+
+            release.countDown();
+            assertNotNull(first.get(5, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/AgentStreamWatchdogTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentStreamWatchdogTest.java
@@ -24,7 +24,7 @@ class AgentStreamWatchdogTest {
     private AgentStreamHandler handlerWithErrorSink(AtomicReference<Throwable> sink, CountDownLatch fired) {
         AgentStreamHandler handler = new AgentStreamHandler(
                 mock(SseEmitterService.class), "conv-watchdog-test",
-                mock(TokenUsageService.class), "1", 1L, "deepseek/deepseek-v4-flash");
+                mock(TokenUsageService.class), "1", 1L, "deepseek/deepseek-v4-flash", 0L);
         handler.setOnError(err -> {
             sink.set(err);
             fired.countDown();

--- a/backend/src/test/java/com/checkba/service/ai/SseEmitterServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/SseEmitterServiceTest.java
@@ -1,0 +1,53 @@
+package com.checkba.service.ai;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * close(connectionId, epoch) 的代次校验：
+ * 旧的单参 close(connectionId) 谁后写入 map 就删谁，会把"本轮收尾"和"用户并发重连"两件事
+ * 搅在一起——迟到的旧一轮 close() 会把刚刚重连、什么错都没有的新 emitter 一并杀掉。
+ *
+ * <p>Spring 的 ResponseBodyEmitter/SseEmitter 在没有真实 Servlet 请求（handler 未 initialize）
+ * 时仍然维护 complete 标志：complete() 之后再 send() 必抛 IllegalStateException（Assert.state
+ * 先于 handler null 检查），因此这里不需要起真实 HTTP 请求也能观察"这个 emitter 是否被误杀"。
+ */
+class SseEmitterServiceTest {
+
+    @Test
+    void staleEpochCloseDoesNotKillReconnectedEmitter() throws Exception {
+        SseEmitterService svc = new SseEmitterService();
+        String id = "conv-epoch-1";
+
+        // 首次建连；调用方（Agent 轮次）在"本轮开始时"记下这一刻的代次
+        svc.createConnection(id);
+        long staleEpoch = svc.currentEpoch(id);
+
+        // 期间用户刷新页面/开新标签重连：产生一个全新 emitter，代次自增
+        SseEmitter reconnected = svc.createConnection(id);
+
+        // 旧一轮此刻才收尾，带着已经过期的代次调用 close —— 不该动到重连后的新连接
+        svc.close(id, staleEpoch);
+
+        // 新连接必须还活着：能正常 send 而不抛 IllegalStateException("已 complete")
+        assertDoesNotThrow(() -> reconnected.send("still-alive"),
+                "旧一轮的 close() 用过期 epoch 时不应该 complete 掉重连后的新 emitter");
+    }
+
+    @Test
+    void matchingEpochCloseStillCompletesEmitter() throws Exception {
+        SseEmitterService svc = new SseEmitterService();
+        String id = "conv-epoch-2";
+
+        SseEmitter emitter = svc.createConnection(id);
+
+        // 没有发生重连：代次没变，close 应该照常生效（不能把 bug 修成"永远不关"）
+        svc.close(id, svc.currentEpoch(id));
+
+        assertThrows(IllegalStateException.class, () -> emitter.send("dead"),
+                "epoch 与当前一致时 close() 必须照常 complete 掉这个 emitter");
+    }
+}

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -10,6 +10,32 @@ const { createModelManager } = require('./services/model-manager')
 const { initLocalFileService } = require('./file-service')
 const { createBrowserViewRegistry } = require('./browser-views')
 
+// 单实例锁：必须在文件最开头、任何 app.whenReady()/服务拉起逻辑之前拿。
+//
+// 没有这把锁时，双击启动两次会各自独立走到 whenReady() 之后的
+// services.allocatePorts() → services.startEager()，两个进程都对着同一个
+// ~/.aiworkdeck 数据目录（H2 单机库）各起一套 Java 后端——真正撞上这条路径的不是
+// "端口已被占用"那么简单（后面 backend-service.js 的端口链 + isOurBackend 复用探测
+// 本来就处理得了这种情况），而是两种更窄的时序竞态：① 首启瞬间两个进程的
+// allocateBackendPort() 几乎同时跑，各自 canBind() 探测到同一个端口"当下空闲"就都
+// 选中它，等真正 spawn 时后一个才会撞见占用；② isOurBackend() 探测自家后端时用的
+// 1.5s 超时，在 JVM 刚起、Spring 还在做上下文刷新、响应不过来的窗口期会被误判成
+// "陌生进程占用"，进而降级到端口链下一档另起一套全新后端。requestSingleInstanceLock
+// 直接把第二个进程在此拦停、退出，让它永远走不到 whenReady()，上面两种竞态都无从
+// 发生——不修 allocateBackendPort/isOurBackend 本身（那是复用逻辑，另一类问题）。
+const singleInstanceLock = app.requestSingleInstanceLock()
+if (!singleInstanceLock) {
+  app.quit()
+  return
+}
+app.on('second-instance', () => {
+  // 用户又点了一次图标/关联文件：把已经在跑的这个实例的窗口拉到前台，
+  // 而不是让第二次点击悄无声息地什么都不发生
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    mainWindow.focus()
+  }
+})
 
 const DEV_SERVER_URL = process.env.CHECKBA_DEV_SERVER_URL || 'http://localhost:5173'
 const IS_DEV = process.env.AIWORKDECK_DESKTOP_DEV === '1'
@@ -283,6 +309,27 @@ function attachCopyListener(webContents, sourceLabel) {
   })
 }
 
+// 下载弹「另存为」对话框的监听器：挂在 session 上，跟 attachCopyListener 一样用
+// 一个标记位去重。macOS 下关主窗口不退出应用（见下方 window-all-closed），用户可以
+// 反复点 Dock 图标触发 createMainWindow() 重开窗口——mainWindow.webContents.session
+// 默认走的是共享的 session.defaultSession，不去重的话每 reopen 一次就多挂一个
+// will-download 监听器，永久累积、从不释放，重开够多次会打出
+// MaxListenersExceededWarning，且以后每次下载都会把已经死掉的旧回调重复触发一遍。
+function attachDownloadListener(session) {
+  if (!session || session.__checkbaDownloadBound) return
+  session.__checkbaDownloadBound = true
+  session.on('will-download', (event, item, webContents) => {
+    // Set options for the save dialog
+    item.setSaveDialogOptions({
+      title: require('./app-language').t({ zh: '保存文件', en: 'Save File' }),
+      defaultPath: item.getFilename() // Use the default filename suggestion
+    })
+    // Note: If item.setSavePath() is NOT called, Electron implicitly shows the dialog
+    // (unless global "Always ask..." is disabled, but setSaveDialogOptions helps hint it).
+    // To strictly FORCE it, we would need to check existing configuration, but usually this is enough.
+  })
+}
+
 function createMainWindow() {
   // 后端实际端口（打包态默认 5269，冲突自动降级，见 backend-service.js 端口链）。
   // 经 additionalArguments 同步注入 preload → window.checkbaDesktop.apiBaseUrl，
@@ -420,16 +467,7 @@ function createMainWindow() {
   attachCopyListener(mainWindow.webContents, 'renderer')
 
   // Handle file downloads: ensure "Safe As" dialog appears
-  mainWindow.webContents.session.on('will-download', (event, item, webContents) => {
-    // Set options for the save dialog
-    item.setSaveDialogOptions({
-      title: require('./app-language').t({ zh: '保存文件', en: 'Save File' }),
-      defaultPath: item.getFilename() // Use the default filename suggestion
-    })
-    // Note: If item.setSavePath() is NOT called, Electron implicitly shows the dialog 
-    // (unless global "Always ask..." is disabled, but setSaveDialogOptions helps hint it).
-    // To strictly FORCE it, we would need to check existing configuration, but usually this is enough.
-  })
+  attachDownloadListener(mainWindow.webContents.session)
 
   startClipboardWatcher()
 }

--- a/desktop/main/services/backend-service.js
+++ b/desktop/main/services/backend-service.js
@@ -121,8 +121,17 @@ function spawnEnv(ctx) {
   const env = { ...process.env }
   // 开发态默认 prod profile，打包态默认 desktop（H2 单机库），仍可用 env 覆盖
   if (!env.SPRING_PROFILES_ACTIVE) env.SPRING_PROFILES_ACTIVE = ctx.packaged ? 'desktop' : 'prod'
-  // 统一端口（仍可用配置文件覆盖）
-  if (!env.SERVER_PORT) env.SERVER_PORT = String(ctx.ports.backend)
+  // 端口必须以 ctx.ports.backend 为准，不能像上面 SPRING_PROFILES_ACTIVE 那样
+  // "env 里已经有就不覆盖"：ServiceManager.waitStartOrExit 轮询就绪、渲染层注入的
+  // apiBaseUrl，用的都是 allocateBackendPort() 已经选定并写进 ctx.ports.backend
+  // 的那一个端口；如果继承自宿主 shell/环境的 SERVER_PORT（不少框架的常见环境变量
+  // 名，用户从终端启动或某些托管环境里就可能已经被设过）先占了这个位置，JVM 会
+  // 绑到那个不相关的端口上，而 ServiceManager 还在死等 ctx.ports.backend 那个端口
+  // 开放——探测永远等不到，白等一整个 startTimeoutMs 后把明明健康的 JVM 当启动
+  // 失败杀掉重试。真要强制指定端口，走的是上面 allocateBackendPort() 里专门开的
+  // CHECKBA_BACKEND_PORT 口子（会正确流入 ctx.ports.backend），不需要也不该再认
+  // 环境里裸的 SERVER_PORT。
+  env.SERVER_PORT = String(ctx.ports.backend)
   // 其他本地服务的动态端口注入（Spring SystemEnvironmentPropertySource 将
   // external.pptx-service.base-url 解析为 EXTERNAL_PPTX_SERVICE_BASE_URL）
   if (ctx.ports['pptx-service']) {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/workflow-release-gating.test.js"
+    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/scripts/prepare-python-service.js
+++ b/desktop/scripts/prepare-python-service.js
@@ -56,12 +56,30 @@ function pythonBin(pyRoot) {
     : path.join(pyRoot, 'bin', 'python3.11')
 }
 
+function pythonMarker(pyRoot) {
+  return path.join(pyRoot, '.pbs-extract-complete')
+}
+
+// 缓存判据不能只看 python3.11 二进制在不在：tar 中途被打断（本地 Ctrl-C、OOM-kill、
+// 磁盘满，或 CI 任务被取消/重跑但 workspace 保留）时，bin/python3.11 可能已经落地，
+// 但 stdlib/site-packages 支撑文件还没解压完就没了——下一次调用如果只查这一个文件，
+// 会当"已经装好"直接复用这个残缺运行时，打包出一个每个 Python 子服务启动即崩的安装包。
+// marker 文件是整个下载+解压成功之后最后一步才写的：被打断的流程不可能留下它，
+// 用它而不是"多查几个文件"是因为查再多文件也只是缩小遗漏窗口，marker 才是
+// "流程完整跑完"本身的证明。
+function isPythonRuntimeComplete(pyRoot) {
+  return fs.existsSync(pythonBin(pyRoot)) && fs.existsSync(pythonMarker(pyRoot))
+}
+
 function ensurePython(outDir) {
   const pyRoot = path.join(outDir, 'python')
-  if (fs.existsSync(pythonBin(pyRoot))) {
+  if (isPythonRuntimeComplete(pyRoot)) {
     console.log(`python runtime already present: ${pyRoot}`)
     return pyRoot
   }
+  // 缓存判无效（首次 / 上次被打断过）：整个目录清掉重来，避免半成品残留文件与
+  // 本次新解压的文件混在一起，产出一个"部分新、部分旧"的更难排查的运行时
+  fs.rmSync(pyRoot, { recursive: true, force: true })
   const triple = pbsTriple()
   const name = `cpython-${PY_VERSION}+${PBS_RELEASE}-${triple}-install_only.tar.gz`
   const url = process.env.PBS_BASE_URL
@@ -79,6 +97,7 @@ function ensurePython(outDir) {
     console.error(`unexpected layout after extract: ${pyRoot}`)
     process.exit(1)
   }
+  fs.writeFileSync(pythonMarker(pyRoot), '')
   return pyRoot
 }
 
@@ -136,4 +155,11 @@ function main() {
   console.log(`  app:     ${appDir}`)
 }
 
-main()
+// require.main 判断：直接执行（node prepare-python-service.js / 构建流水线调用）时
+// 行为不变，照旧跑 main() 真下载真解压；被测试文件 require() 拿 isPythonRuntimeComplete
+// 时不触发下载/解压副作用（同 fetch-lowa-assets.js 的 checkMagic 那套用法）。
+if (require.main === module) {
+  main()
+}
+
+module.exports = { isPythonRuntimeComplete, pythonBin, pythonMarker }

--- a/desktop/tests/prepare-python-service.test.js
+++ b/desktop/tests/prepare-python-service.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
+const { isPythonRuntimeComplete, pythonBin, pythonMarker } = require('../scripts/prepare-python-service')
+
+// dev-board#74 稳定性审计：ensurePython() 原来的缓存判据只看 python3.11 二进制在不在。
+// tar 中途被打断（Ctrl-C/OOM-kill/磁盘满，或 CI 任务被取消/重跑但 workspace 保留）时，
+// bin/python3.11 可能已经落地，但 stdlib/site-packages 支撑文件还没解压完——下一次调用
+// 会把这个残缺运行时当"已经装好"直接复用，打包出一个每个 Python 子服务启动即崩的安装包。
+// isPythonRuntimeComplete() 现在还要求一个"整个下载+解压流程最后一步才写"的 marker 文件
+// 存在，被打断的流程不可能留下它。
+
+function mkTmpOut() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-python-service-test-'))
+}
+
+test('全新目录（从未装过）判定为不完整', () => {
+  const outDir = mkTmpOut()
+  try {
+    const pyRoot = path.join(outDir, 'python')
+    assert.strictEqual(isPythonRuntimeComplete(pyRoot), false)
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('tar 被打断的现场（二进制落地但 marker 没写）必须判定为不完整', () => {
+  const outDir = mkTmpOut()
+  try {
+    const pyRoot = path.join(outDir, 'python')
+    // 复现"被打断"的现场：只有 bin/python3.11 落地，marker 文件不存在
+    // （tar 是不是恰好先写出这一个文件不重要，关键是 marker 只在全部完成后才写）
+    fs.mkdirSync(path.dirname(pythonBin(pyRoot)), { recursive: true })
+    fs.writeFileSync(pythonBin(pyRoot), '')
+    assert.strictEqual(fs.existsSync(pythonMarker(pyRoot)), false, '前置条件：marker 不存在')
+    assert.strictEqual(isPythonRuntimeComplete(pyRoot), false,
+      '只有二进制、没有 marker 时必须判定为不完整——这正是旧实现会误判为"已装好"的场景')
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('真正跑完一轮（二进制 + marker 都在）判定为完整，不会白白重装', () => {
+  const outDir = mkTmpOut()
+  try {
+    const pyRoot = path.join(outDir, 'python')
+    fs.mkdirSync(path.dirname(pythonBin(pyRoot)), { recursive: true })
+    fs.writeFileSync(pythonBin(pyRoot), '')
+    fs.writeFileSync(pythonMarker(pyRoot), '')
+    assert.strictEqual(isPythonRuntimeComplete(pyRoot), true)
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('只有 marker、二进制缺失（比如运行时被误删）也必须判定为不完整', () => {
+  const outDir = mkTmpOut()
+  try {
+    const pyRoot = path.join(outDir, 'python')
+    fs.mkdirSync(pyRoot, { recursive: true })
+    fs.writeFileSync(pythonMarker(pyRoot), '')
+    assert.strictEqual(isPythonRuntimeComplete(pyRoot), false)
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true })
+  }
+})

--- a/desktop/tests/service-manager.test.js
+++ b/desktop/tests/service-manager.test.js
@@ -146,6 +146,33 @@ test('backend allocator walks the 5269/5369/5169 chain past a foreign listener',
   }
 })
 
+test('spawned backend env.SERVER_PORT always follows ctx.ports.backend, not an inherited SERVER_PORT', () => {
+  // 原实现是 `if (!env.SERVER_PORT) env.SERVER_PORT = String(ctx.ports.backend)`——
+  // 宿主 shell/环境如果恰好已经设过 SERVER_PORT（不少框架的常见变量名），这个判断
+  // 会让继承值赢，JVM 绑到一个 ServiceManager 根本不知道的端口上；waitStartOrExit
+  // 还在死等 ctx.ports.backend 那个端口开放，永远等不到，把明明健康的 JVM 当启动
+  // 失败杀掉重试。ctx.ports.backend 是 allocateBackendPort() 已经选定、渲染层也据此
+  // 注入 apiBaseUrl 的唯一真源，必须无条件赢过任何继承值。
+  const { createBackendDescriptor } = require('../main/services/backend-service')
+  const d = createBackendDescriptor()
+  const prevServerPort = process.env.SERVER_PORT
+  process.env.SERVER_PORT = '6001' // 模拟宿主环境已经设过这个变量，且与分配到的端口不同
+  try {
+    const ctx = {
+      packaged: false,
+      resourcesPath: null,
+      dataDir: require('os').tmpdir(),
+      projectRoot: path.join(__dirname, '..'),
+      ports: { backend: 5269 }
+    }
+    const cmds = d.commands(ctx)
+    assert.strictEqual(cmds[0].env.SERVER_PORT, '5269')
+  } finally {
+    if (prevServerPort === undefined) delete process.env.SERVER_PORT
+    else process.env.SERVER_PORT = prevServerPort
+  }
+})
+
 test('falls through failed candidate to next command', async () => {
   const mgr = makeManager()
   mgr.register(fakeDescriptor({

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -60,7 +60,11 @@ catch { console.error('缺少 puppeteer-core：cd frontend && npm i -D puppeteer
 // ---- preflight ----
 for (const [what, ok] of [
   ['dev server ' + DEVURL, await fetch(DEVURL).then(() => true).catch(() => false)],
-  ['后端 ' + BACKEND, await fetch(BACKEND + '/api/skills/market/list').then(() => true).catch(() => false)],
+  // r.ok 而不是"能拿到响应就算活"：fetch() 对 4xx/5xx 照样 resolve，只有网络层失败
+  // 才会走 catch。以前这里只要连得上端口就判 OK，后端 500（比如 skill 注册表坏了）
+  // 会被判成健康，前置检查形同虚设，失败要等 ~10 分钟后在无关步骤里以一堆看不懂的
+  // 报错冒出来，而不是这里干脆利落的"前置缺失"提示。
+  ['后端 ' + BACKEND, await fetch(BACKEND + '/api/skills/market/list').then((r) => r.ok).catch(() => false)],
   ['引擎 dist/zetaoffice/lowa', fs.existsSync(path.join(frontendDir, 'dist/zetaoffice/lowa/soffice.js'))],
   ['desktop/node_modules', fs.existsSync(path.join(desktopDir, 'node_modules'))],
 ]) { if (!ok) { console.error('前置缺失: ' + what); process.exit(2) } }
@@ -73,7 +77,12 @@ async function api(ep, opts = {}) {
     headers: { 'Content-Type': 'application/json', ...(QA.sid ? { 'X-Session-Id': QA.sid } : {}) },
     body: opts.body ? JSON.stringify(opts.body) : undefined,
   })
-  return r.json().catch(() => null)
+  const body = await r.json().catch(() => null)
+  // 4xx/5xx 以前直接把响应体（甚至 null）当正常结果原样返回，调用方看到的只是
+  // "字段缺失/数组为空"这类下游症状，真实原因（后端拒绝了这次请求）被吞掉、没人
+  // 打印出来。这里改成一律抛出，让每个调用点原有的 throw/catch 逻辑接住真实原因。
+  if (!r.ok) throw new Error('API ' + (opts.method || 'GET') + ' ' + ep + ' -> ' + r.status + ': ' + JSON.stringify(body))
+  return body
 }
 {
   // 冷启动后端可能还锁着/未过向导：解锁门与向导分流由 app-e2e J1 专门覆盖，
@@ -852,7 +861,11 @@ try {
   })
 } finally {
   try { if (site) site.close() } catch {}
-  try { await api('/api/projects/' + QA.projectId, { method: 'DELETE' }) } catch {}
+  // 以前这里是空 catch：清理失败（后端瞬时不可达/DELETE 4xx 等）完全无声无息，
+  // QA_<timestamp> 项目连同真实生成的 docx 永久留在项目列表里，没有任何输出能
+  // 告诉维护者为什么、需要手动去清。至少打一行，让残留有迹可查。
+  try { await api('/api/projects/' + QA.projectId, { method: 'DELETE' }) }
+  catch (e) { console.error('⚠️ 清理测试项目失败（' + QA.project + ' #' + QA.projectId + '）：' + e.message + '；需要手动去项目列表删除') }
   try { browser.disconnect() } catch {}
   killTree()
   await sleep(1500)

--- a/restart-all.sh
+++ b/restart-all.sh
@@ -3,6 +3,19 @@ set -e
 
 PROJECT_ROOT=$(cd "$(dirname "$0")" && pwd)
 
+# 端口号（9696/5173）是全局资源：多个 worktree 各自跑本脚本会抢同一个端口，
+# lsof -ti:PORT 找到的 PID 未必是本 checkout 起的进程，可能是另一个 worktree 正在
+# 用的、完全健康的后端/前端。杀之前用这个函数确认占用者的工作目录确实在本
+# checkout 下，不是就不杀，只报警——避免"跑一下本脚本就把别人的开发环境弄挂了、
+# 还看不出原因"（dev-board#74 审计条目）。lsof 拿不到 cwd（权限/平台差异）时
+# 一并当"不是本 checkout"处理，拿不准就不杀。
+pid_belongs_to_this_checkout() {
+    local pid="$1"
+    local cwd
+    cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')
+    [ -n "$cwd" ] && [[ "$cwd" == "$PROJECT_ROOT"* ]]
+}
+
 echo "=================================================="
 echo "   Checkba Project One-Click RESTART"
 echo "=================================================="
@@ -33,38 +46,39 @@ else
 fi
 
 # ==========================================
-# 1. 停止 PPTX 服务 (Docker)
+# 1. PPTX 服务 (Docker)
 # ==========================================
 echo ""
-echo ">>> [1/6] 停止 PPTX 服务 (Docker)..."
+echo ">>> [1/6] 检查 PPTX 服务 (Docker)..."
 if [ "$DOCKER_AVAILABLE" = true ]; then
     if docker ps -q -f name=checkba-pptx-service 2>/dev/null | grep -q .; then
-        echo "找到 PPTX 服务容器，正在停止..."
-        docker stop checkba-pptx-service 2>/dev/null || true
-        docker rm checkba-pptx-service 2>/dev/null || true
-        sleep 1
-        echo "✓ PPTX 服务已停止"
+        # 容器名在 docker-compose.yml 里是写死的全局名字，多个 worktree 共享同一个
+        # 容器实例，不像端口那样能分辨"是不是本 checkout 起的"。以前这里无条件
+        # stop+rm：随便哪个 worktree 跑一下本脚本就把这个可能正被别的会话用着的
+        # 容器杀掉，而启动阶段又没有 --build，杀了重建也不会拿到新代码，纯粹是
+        # 白白中断服务。改成留着不动——启动阶段的 docker-compose up -d 对配置没变
+        # 的容器是幂等的，已经在跑就什么都不做；真要强制重建，手动 docker restart。
+        echo "PPTX 服务容器已在运行，保留不动（多 worktree 共享同一实例，交给启动阶段的 up -d 幂等处理）"
     else
-        echo "未找到运行中的 PPTX 服务容器"
+        echo "未找到运行中的 PPTX 服务容器，稍后启动阶段会创建"
     fi
 else
     echo "Docker 不可用，跳过..."
 fi
 
 # ==========================================
-# 1.5 停止 MinerU 服务 (Docker)
+# 1.5 MinerU 服务 (Docker)
 # ==========================================
 echo ""
-echo ">>> [1.5/6] 停止 MinerU 服务 (Docker)..."
+echo ">>> [1.5/6] 检查 MinerU 服务 (Docker)..."
 if [ "$DOCKER_AVAILABLE" = true ]; then
     if docker ps -q -f name=checkba-mineru-service 2>/dev/null | grep -q .; then
-        echo "找到 MinerU 服务容器，正在停止..."
-        docker stop checkba-mineru-service 2>/dev/null || true
-        docker rm checkba-mineru-service 2>/dev/null || true
-        sleep 1
-        echo "✓ MinerU 服务已停止"
+        # 理由同上面 PPTX：容器名全局共享，无条件 stop+rm 会杀掉别的 worktree/会话
+        # 正用着的容器，且没有 --build 步骤，杀了重建也拿不到新代码。留着不动，
+        # 交给启动阶段幂等的 docker-compose up -d。
+        echo "MinerU 服务容器已在运行，保留不动（多 worktree 共享同一实例，交给启动阶段的 up -d 幂等处理）"
     else
-        echo "未找到运行中的 MinerU 服务容器"
+        echo "未找到运行中的 MinerU 服务容器，稍后启动阶段会创建"
     fi
 else
     echo "Docker 不可用，跳过..."
@@ -96,16 +110,21 @@ echo ""
 echo ">>> [2/6] 停止后端 Java 服务 (端口 9696)..."
 BACKEND_PID=$(lsof -ti:9696 || true)
 if [ -n "$BACKEND_PID" ]; then
-    echo "找到后端进程 (PID: $BACKEND_PID)，正在停止..."
-    kill $BACKEND_PID 2>/dev/null || true
-    sleep 2
-    # 如果进程还在，强制杀死
-    if kill -0 $BACKEND_PID 2>/dev/null; then
-        echo "进程仍在运行，强制杀死..."
-        kill -9 $BACKEND_PID 2>/dev/null || true
-        sleep 1
+    if pid_belongs_to_this_checkout "$BACKEND_PID"; then
+        echo "找到后端进程 (PID: $BACKEND_PID)，正在停止..."
+        kill $BACKEND_PID 2>/dev/null || true
+        sleep 2
+        # 如果进程还在，强制杀死
+        if kill -0 $BACKEND_PID 2>/dev/null; then
+            echo "进程仍在运行，强制杀死..."
+            kill -9 $BACKEND_PID 2>/dev/null || true
+            sleep 1
+        fi
+        echo "✓ 后端服务已停止"
+    else
+        echo "⚠️ 端口 9696 被其它工作目录的进程占用 (PID: $BACKEND_PID)，不是本 checkout 启动的，本脚本不会杀它。"
+        echo "   多个 worktree 并行时端口是抢的：去那个 worktree 里停止，或者本目录先不启动后端。"
     fi
-    echo "✓ 后端服务已停止"
 else
     echo "端口 9696 未被占用"
 fi
@@ -136,10 +155,15 @@ echo ""
 echo ">>> [4/6] 停止前端 H5 (端口 5173)..."
 H5_PID=$(lsof -ti:5173 || true)
 if [ -n "$H5_PID" ]; then
-    echo "找到前端进程 (PID: $H5_PID)，正在停止..."
-    kill -9 $H5_PID 2>/dev/null || true
-    sleep 1
-    echo "✓ 前端 H5 已停止"
+    if pid_belongs_to_this_checkout "$H5_PID"; then
+        echo "找到前端进程 (PID: $H5_PID)，正在停止..."
+        kill -9 $H5_PID 2>/dev/null || true
+        sleep 1
+        echo "✓ 前端 H5 已停止"
+    else
+        echo "⚠️ 端口 5173 被其它工作目录的进程占用 (PID: $H5_PID)，不是本 checkout 启动的，本脚本不会杀它。"
+        echo "   多个 worktree 并行时端口是抢的：去那个 worktree 里停止，或者本目录先不启动前端。"
+    fi
 else
     echo "端口 5173 未被占用"
 fi


### PR DESCRIPTION
审计剩余清单里的基建/桌面壳/会议那一组，九条全部落地。
每条先写测试看它红、改实现看它绿、再把实现临时还原确认测试真会红；
写不了自动化测试的（shell 脚本、Electron 主进程生命周期）在文末写了人工验证方式。

1. [HIGH] SSE 收尾会把重连后建立的新连接一并掐掉
   `close(connectionId)` 用的是单参 remove，谁后写进 map 就删谁；而同文件另外三处
   都用了两参 `remove(connectionId, emitter)`，注释里还专门点名了这个风险——唯独 close 漏了。
   后台轮次结束调 close 的同时，用户可能因为刷新页面/开新标签/断线重连刚建好一个新 emitter，
   于是一个什么错都没有的新连接被迟到的旧一轮善后掐掉。
   修法：给每个 connectionId 加自增代次，建连即自增；一轮 Agent 运行在**开头**取一次代次存住，
   收尾时带回，只有代次仍匹配才真正 complete。**没有碰取消/恢复那块逻辑**（维护者点名待拍板）。
   审校补充：代次表不能在 close 时随手删——删了新连接会从 1 重新开始，一条攥着旧代次 1 的
   迟到 close 就会误判成匹配，正是这次要修的病。改成按规模兜底清理（超过 1 万个键时清掉
   当前没有活连接的那些），清掉之后迟到的 close 看到代次 0、对不上，**跳过关闭**——落在安全一侧。

2. [HIGH] restart-all.sh 按全局端口/容器名操作，多 worktree 并行时打死别人的进程
   加 `pid_belongs_to_this_checkout()`（用 `lsof -d cwd` 比对占用者的工作目录），
   不属于本检出的一律只告警不杀。`backend/restart-backend.sh` 需要同一道守卫——
   否则它会在 START 阶段把同一个外来进程再杀一次，把前面的保护整个抵消。
   PPTX/MinerU 是宿主全局容器名、没有 per-worktree 身份，改成不再无条件 stop+rm，
   靠 START 阶段本来就幂等的 `docker-compose up -d`。

3/4. [HIGH/LOW] desktop-e2e 驱动脚本：清理失败完全静默、前置检查把 4xx/5xx 当成健康
   `api()` 对 4xx/5xx 根本不抛（直接把响应体甚至 null 当正常结果返回），
   所以清理项目失败连 catch 都进不去，QA_<timestamp> 项目连同真实生成的 docx 永久留在列表里；
   前置可达性检查同理，后端 500 也算「后端 OK」，真失败要等十分钟后在无关步骤里
   以一堆看不懂的报错冒出来。两处都改成看 `r.ok`，清理失败至少留一行。

5. [HIGH] 没有单实例锁，双击启动能跑起两套后端
   **纠正审计原文的诊断**：H2 的 URL 带 `AUTO_SERVER=TRUE`，并不排他；常规多开也会走
   端口复用路径。真正能起两套的是两个进程在各自 spawn 之前都 canBind 同一个端口（TOCTOU），
   或者 `isOurBackend` 的 1.5 秒探测撞上还在 Spring refresh 的 JVM 被误判成「外来进程」。
   在 main.js 最顶部加 `requestSingleInstanceLock()`，拿不到就 quit；补 `second-instance`
   把已有窗口提到前面。

6. [MEDIUM] will-download 监听每次建窗都往共享 session 上挂一遍
   macOS 下关窗不退出、点 Dock 再建窗，反复叠加。照抄同一函数里 attachCopyListener
   已有的绑定标记做去重。

7. [MEDIUM] SERVER_PORT 环境变量继承让 JVM 实际监听口与探测口失配
   端口分配只认 CHECKBA_BACKEND_PORT，却在 spawn 时保留了环境里已有的 SERVER_PORT——
   JVM 听 A、就绪探测在等 B，超时后杀进程重试，最终报 backend failed to start。
   去掉那个条件，分配出来的口一律压过继承值。

8. [MEDIUM] python 运行时的缓存判据只看二进制在不在
   解压被打断时 bin/ 已落盘、lib/ 没落完，下次直接早返回，拿一个残缺的 python 往下跑。
   改成只有解压全部成功才写的完成标记 + 二进制双条件。

9. [HIGH] 并发「开始录音」建出两条指向同一物理路径的文件行
   **推翻上一轮的判定**（上一轮判「找不到第二个并发调用方」）：前端那道
   `isRecordingActive()` 守卫是模块级单例，只在一个 JS 运行时内有效——
   同一账号「桌面端 + 浏览器标签」同时开、或同项目两个成员同时开，都绕不过它，
   而 create() 的鉴权只要求项目成员、不要求独占。库里也没有对应的唯一约束。
   按 projectId 在**控制器层**加锁（不放进服务里：Spring 的代理式 AOP 下同类自调用
   会静默绕过事务）。

顺带说明：子 agent 另外报了一处「finally 引用 try 内 let site」的越界 bug 并开了任务卡，
复核后确认是误读——该声明本来就在 try 外面（master 第 126 行），无需改动。

测试：backend 全量 2286 通过 0 失败 11 跳过；desktop `npm test` 68 例 67 过 1 跳过
（跳过的是本机 5269 端口被真实后端占用，自跳过）；两个 shell 脚本 `bash -n` 通过。

人工验证：
- 双击启动两次，第二次应立刻退出并把已有窗口提到前面，且只有一个 Java 进程；
- 从两个 worktree 分别跑 restart-all.sh，第二次应告警而不是杀掉第一个的进程。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)