### PR TITLE
fix(frontend): AI 起草写进错的文档、暂存区丢系统拖拽、编辑器 boot 吞异常等十四条（dev-board#74）

### DIFF
--- a/frontend/src/components/AgentMessage/RootBubble.vue
+++ b/frontend/src/components/AgentMessage/RootBubble.vue
@@ -195,13 +195,19 @@ const processGroups = computed(() => {
 })
 
 // 流式进行中默认展开最新一组；结束后（含历史消息）全部收起。用户手动开合后以用户为准
+// 展开状态按分组下标 gi 记，不能按 key（= stepIndex 派生的 's0'/'s1'/...）记：模型
+// 回退重做某一步时（比如 step 1 失败又重跑一次 step 0）processGroups 会产生两个
+// 非相邻但 stepIndex 相同、因此 key 相同的分组，按 key 记会让它们共用同一个槽位，
+// 点开/收起其中一个连带把另一个也翻了状态。gi 是各分组在当前渲染里的下标，
+// processes 只增不减（同一轮内不会重排/截断），已经渲染出来的分组的 gi 不会变，
+// 天然互不冲突。
 const groupToggles = ref({})
 const isGroupExpanded = (key, gi) => {
-  if (key in groupToggles.value) return groupToggles.value[key]
+  if (gi in groupToggles.value) return groupToggles.value[gi]
   return !!props.bubble.isStreaming && gi === processGroups.value.length - 1
 }
 const toggleGroup = (key, gi) => {
-  groupToggles.value = { ...groupToggles.value, [key]: !isGroupExpanded(key, gi) }
+  groupToggles.value = { ...groupToggles.value, [gi]: !isGroupExpanded(key, gi) }
 }
 const isGroupDone = (g) => g.procs.every(p =>
   !(p.items || []).some(it => it.status === 'doing' || it.status === 'loading' || it.status === 'thinking')

--- a/frontend/src/components/AgentMessage/ThinkingCard.vue
+++ b/frontend/src/components/AgentMessage/ThinkingCard.vue
@@ -61,7 +61,42 @@ const isExpanded = ref(true)
 const liveSeconds = ref(0)
 let timerInterval = null
 
+// updateTime/stopTimer/startTimer 挪到 watch(...) 前面（原来在后面）：下面的
+// watch 加了 immediate:true 之后，回调会在 watch() 这条语句执行的当下就同步
+// 跑一次（Vue 的 immediate watcher 就是这个语义，不是排到下一轮再跑），如果
+// startTimer/stopTimer 仍按原来的顺序声明在 watch 之后，immediate 回调此刻还
+// 引用不到它们——会话在 <script setup> 的执行顺序里踩中 const 的暂时性死区，
+// 直接抛 ReferenceError: Cannot access 'stopTimer' before initialization，
+// 整个组件渲染失败（用真实 Vue 组件挂载复现过，不是理论推测）。纯挪动顺序，
+// 三个函数体一字未改。
+const updateTime = () => {
+    if (!props.startTime) {
+        liveSeconds.value = 0
+        return
+    }
+    const diff = Math.floor((Date.now() - props.startTime) / 1000)
+    liveSeconds.value = diff > 0 ? diff : 0
+}
+
+const stopTimer = () => {
+    if (timerInterval) clearInterval(timerInterval)
+    timerInterval = null
+}
+
+const startTimer = () => {
+    stopTimer()
+    // Initial calc
+    updateTime()
+    timerInterval = setInterval(updateTime, 1000)
+}
+
 // Auto-collapse when done
+// immediate:true 是必需的，不是可选优化：RootBubble.vue 把 ghost 变体渲染在
+// v-if/v-else 两个结构不同的分支里，isReady 一旦翻真就整体换分支——Vue 会卸载
+// 旧的 ThinkingCard、挂载全新一个实例，而不是复用同一个组件更新 prop。挂载那
+// 一刻如果 status 已经是 'done'（很常见：标题/正文往往比"思考结束"晚不了多久
+// 出现），没有 immediate 这个 watcher 一次都不会跑——isExpanded 停在默认的
+// true，ghost 卡永远摊开显示模型的原始思维链，而不是折成一行"Thought for Ns"。
 watch(() => props.status, (newVal) => {
   if (newVal === 'done') {
     isExpanded.value = false
@@ -70,7 +105,7 @@ watch(() => props.status, (newVal) => {
     isExpanded.value = true
     startTimer()
   }
-})
+}, { immediate: true })
 
 onMounted(() => {
     if (props.status === 'thinking') {
@@ -81,27 +116,6 @@ onMounted(() => {
 onUnmounted(() => {
     stopTimer()
 })
-
-const startTimer = () => {
-    stopTimer()
-    // Initial calc
-    updateTime()
-    timerInterval = setInterval(updateTime, 1000)
-}
-
-const stopTimer = () => {
-    if (timerInterval) clearInterval(timerInterval)
-    timerInterval = null
-}
-
-const updateTime = () => {
-    if (!props.startTime) {
-        liveSeconds.value = 0
-        return
-    }
-    const diff = Math.floor((Date.now() - props.startTime) / 1000)
-    liveSeconds.value = diff > 0 ? diff : 0
-}
 
 const displayDuration = computed(() => {
     // If actively thinking, show live timer

--- a/frontend/src/components/AwdSelect.vue
+++ b/frontend/src/components/AwdSelect.vue
@@ -107,7 +107,16 @@ export default {
         : { left: r.left + 'px', top: (r.bottom + 4) + 'px', minWidth: r.width + 'px' }
     },
     attachDismiss() {
-      this._dismiss = () => this.close()
+      this._dismiss = (e) => {
+        // 下拉菜单自己超过 280px 就会出现内部滚动条（见组件头注释）。滚动事件不
+        // 冒泡，但这里用的是捕获段（第三参 true），会连菜单自己内部的滚动也一起
+        // 收到——不加这道判断，用户在菜单里往下滚一下，菜单立刻把自己关掉，列表
+        // 长一点根本没法用。只有目标不在菜单内部（真正可能让触发器坐标失效的
+        // 外部容器滚动）时才按原逻辑关闭。
+        const menuEl = this.$el && this.$el.querySelector('.awd-select-menu')
+        if (menuEl && e && e.target && menuEl.contains(e.target)) return
+        this.close()
+      }
       // 捕获段：调用点大多在 scroll-view 里，滚动事件不冒泡到 window
       window.addEventListener('scroll', this._dismiss, true)
       window.addEventListener('resize', this._dismiss)

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -1139,11 +1139,14 @@ export default {
     watch(() => bubbles.value.length, () => {
        scrollToBottom()
     })
-    // Deep watch active bubble changes (e.g. streaming content)
-    watch(bubbles, () => {
-       // Optional: throttle scroll?
-       // For now simple trigger
-    }, { deep: true })
+    // 曾经有一个 `watch(bubbles, () => {}, { deep: true })`：回调体是空的（注释也
+    // 写着"for now simple trigger"），从来没做任何事。deep watch 每次触发都要把
+    // bubbles 整棵响应式对象图（含全部消息/工具输出/artifact）重新遍历一遍来
+    // 重建依赖追踪，而流式回答的每一个 token 都会命中它（currentAssistantBubble
+    // 的 content 在 SSE 每个 chunk 都会变）——对话越长这个空转的代价越大，长
+    // 工具调用/长回答期间会明显卡顿。上面那条浅层 watch（只看 length）已经覆盖
+    // "新气泡出现要滚到底"，这条 deep watch 删掉不改变任何行为，纯粹省掉这份
+    // 空转开销。
 
     const scrollToBottom = () => {
        nextTick(() => {
@@ -1279,6 +1282,13 @@ export default {
     }
 
     const startNewChat = () => {
+      // 流式进行中点"新建对话"：以前只清前端状态（setConversationId(null) 触发的
+      // resetSSE 只是断本地连接），从不通知后端——编排器在服务端继续跑这一轮
+      // （模型调用、可能有副作用的工具调用），用户却完全看不到任何迹象，白烧
+      // 资源/额度。复用 handleAbort 同一条 abort()（内部先 POST /api/agent/cancel
+      // 再断连接）；不 await 它——新建对话本身不该被这次网络请求拖住，abort()
+      // 对已经清空的气泡/会话状态做的收尾判断都是空值安全的。
+      if (isStreaming.value) abort()
       setConversationId(null)  // This now triggers resetSSE internally
       clearBubbles()           // Use composable method
       selectedSkillIds.value = [] // 手动选的技能属于这一段对话，新会话从干净状态开始

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -222,6 +222,7 @@
 import { getFileDownloadUrl, getArchiveEntries, extractArchive } from '@/services/api.js'
 import { getAuthHeaders, getSessionId } from '@/utils/auth.js'
 import { ICONS } from '@/config/icons.js'
+import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 
 // docx-preview 依赖 Chromium DOM，仅 H5/桌面构建启用；其它平台落 Office 占位分支
 // #ifdef H5
@@ -724,13 +725,22 @@ export default {
       this.archiveLoading = true
       this.archiveError = ''
       this.archiveEntries = []
+      // 竞态防护：与 loadMediaResource 同一类毛病——快速切换 zip/rar/7z 文件时，
+      // reloadPreview 会为新文件再调一次本方法，旧请求若后回来会用旧文件的条目
+      // 覆盖新文件已经显示的列表。用请求代次判定"这份响应是否还对得上最新一次
+      // 调用"；同时把 file 摘成局部变量，不在 await 之后再读 this.file（那时可能
+      // 已经换成别的文件了）。
+      const seq = (this._archiveReqSeq = (this._archiveReqSeq || 0) + 1)
+      const file = this.file
       try {
-        const res = await getArchiveEntries(this.file.projectId, this.file.id)
+        const res = await getArchiveEntries(file.projectId, file.id)
+        if (!shouldAcceptResponse(seq, this._archiveReqSeq)) return
         this.archiveEntries = (res && res.entries) || []
       } catch (e) {
+        if (!shouldAcceptResponse(seq, this._archiveReqSeq)) return
         this.archiveError = (e && e.message) || this.$t('files.archiveReadFailed')
       } finally {
-        this.archiveLoading = false
+        if (shouldAcceptResponse(seq, this._archiveReqSeq)) this.archiveLoading = false
       }
     },
     // 解压到压缩包所在目录下的新文件夹；成功后通知宿主刷新资源管理器

--- a/frontend/src/components/FileStagingArea.vue
+++ b/frontend/src/components/FileStagingArea.vue
@@ -298,7 +298,12 @@ export default {
                   // Note: text/plain might be just an index if from FileTree, so we need validation
                   if (rawData.startsWith('{')) {
                       const data = JSON.parse(rawData)
-                      if (data.fileId) {
+                      // 文件夹没有守卫会被当成普通文件收进暂存区：FileTree.vue 的拖拽对
+                      // 文件/文件夹一视同仁（handleDragStart 里 fileType 写的是
+                      // item.isFolder ? 'folder' : item.fileType），暂存区消费端是给 AI
+                      // 读内容用的，读一个文件夹只会拿到空/报错，且这里的容错只打日志，
+                      // 用户看不出区别——直接在源头拒绝。
+                      if (data.fileId && data.fileType !== 'folder') {
                           files.push({
                               id: data.fileId,
                               name: data.name,
@@ -316,7 +321,8 @@ export default {
       // 2. Fallback: Check global variable (for environments where dataTransfer is restricted/cleared)
       if (files.length === 0 && typeof document !== 'undefined' && document.__checkbaDraggedFile) {
           const data = document.__checkbaDraggedFile
-          if (data.fileId) {
+          // 同上：这条全局兜底走的是同一份 {fileId, fileType} 形状，文件夹要挡在这里
+          if (data.fileId && data.fileType !== 'folder') {
              files.push({
                 id: data.fileId,
                 name: data.name,
@@ -329,7 +335,19 @@ export default {
       }
 
       if (files.length > 0) {
-          this.$emit('drop', files) 
+          this.$emit('drop', files)
+          return
+      }
+
+      // 3. 真实的 OS 文件拖拽（Finder/Explorer/桌面）：面板对任意拖拽都会亮起
+      //    "松手暂存文件" 遮罩（见 onDragEnter/onDragOver），但上面两步只认得
+      //    "项目里已有文件"的内部格式（应用内 JSON / 全局兜底变量）。拖一个真实
+      //    磁盘文件进来时两步都取不出数据，以前到这里就直接什么都不做——遮罩
+      //    消失、用户以为暂存了，其实什么也没发生。dataTransfer.files 是浏览器
+      //    给的原生 File 列表，交给宿主走真正的上传通道。
+      const osFiles = e && e.dataTransfer && e.dataTransfer.files
+      if (osFiles && osFiles.length > 0) {
+          this.$emit('drop-files', Array.from(osFiles))
       }
     },
     

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -935,7 +935,12 @@ export default {
       dragCurrentY: 0,
       isDragging: false,
       dragOverIndex: -1, // H5拖拽悬停索引
-      draggedIndex: -1, // H5拖拽源索引
+      draggedIndex: -1, // H5拖拽源索引（仅用于"是不是原地放下"的快速判断，实际
+                         // 移动谁必须靠下面的 draggedFileId 重新按 id 查，见 handleDrop）
+      draggedFileId: null, // H5拖拽源文件 id：dragstart 时记下，drop 时按 id（而不是
+                            // 下标）在（可能已经因为后台重载而重排过的）displayFiles
+                            // 里重新定位，防止把并发上传触发的 loadFiles() 期间
+                            // 挪了位置的另一个文件当成拖拽源移走
       // 树形结构相关
       allFiles: [], // 完整文件树
       expandedFolders: new Set(), // 展开的文件夹ID集合
@@ -2430,6 +2435,7 @@ export default {
     handleDragStart(e, item, index) {
       console.log('拖拽开始:', index)
       this.draggedIndex = index
+      this.draggedFileId = (item && item.id != null) ? item.id : null
       uni.$emit('file-drag-start')
       // 向外部暴露“拖拽文件开始”（用于 WPS 文档建立关联）
       try {
@@ -2529,12 +2535,26 @@ export default {
           if (this.draggedIndex === index) {
             this.dragOverIndex = -1
             this.draggedIndex = -1
+            this.draggedFileId = null
             return
           }
 
           try {
-            // BUGFIX: Use displayFiles instead of files
-            const draggedItem = this.displayFiles[this.draggedIndex]
+            // BUGFIX（原用 displayFiles[this.draggedIndex]，仍会撞上同一类竞态）：
+            // dragstart 与 drop 之间可能有后台重载（比如并发批量上传完成触发的
+            // loadFiles()）把 displayFiles 重新排序/过滤过，draggedIndex 这个下标
+            // 到 drop 时可能已经指向另一个文件——按 dragstart 时记下的 id 重新在
+            // 当前 displayFiles 里查，查不到说明拖拽源已经不在列表里（被移走/
+            // 删除/过滤掉了），放弃这次移动而不是把错的文件挪过去。
+            const draggedItem = this.displayFiles.find(f => f.id === this.draggedFileId)
+            if (!draggedItem) {
+              console.warn('拖拽源文件已不在列表中，取消移动')
+              uni.showToast({ title: this.$t('fileTree.moveFailed'), icon: 'none' })
+              this.dragOverIndex = -1
+              this.draggedIndex = -1
+              this.draggedFileId = null
+              return
+            }
 
             // Prevent self-parenting or no-op moves if needed check
             if (draggedItem.id === targetParentId) return
@@ -2599,9 +2619,11 @@ export default {
 
       this.dragOverIndex = -1
       this.draggedIndex = -1
+      this.draggedFileId = null
     },
     handleDragEnd() {
       this.draggedIndex = -1
+      this.draggedFileId = null
       this.dragOverIndex = -1
       this.$emit('file-drag-end')
       uni.$emit('file-drag-end')
@@ -2625,13 +2647,23 @@ export default {
       // Case 1: Internal FileTree Drag
       if (this.draggedIndex !== -1) {
           try {
-            const draggedItem = this.displayFiles[this.draggedIndex]
+            // 同 handleDrop 的 BUGFIX：按 dragstart 时记下的 id 重新定位，不用可能
+            // 已经因后台重载而过期的下标。
+            const draggedItem = this.displayFiles.find(f => f.id === this.draggedFileId)
+            if (!draggedItem) {
+              console.warn('拖拽源文件已不在列表中，取消移动')
+              uni.showToast({ title: this.$t('fileTree.moveFailed'), icon: 'none' })
+              this.draggedIndex = -1
+              this.draggedFileId = null
+              return
+            }
 
             // If already in root (parentId is null or matches), we might still want to allow movement if subfolder -> root
             await moveFile(projectId, draggedItem.id, targetParentId, newSortOrder)
             await this.loadFiles()
             uni.showToast({ title: this.$t('fileTree.moveToRootSuccess'), icon: 'success' })
             this.draggedIndex = -1
+            this.draggedFileId = null
           } catch (error) {
             console.error('移动到根目录失败:', error)
             uni.showToast({ title: error.message || this.$t('fileTree.moveFailed'), icon: 'none' })
@@ -3281,7 +3313,13 @@ export default {
                            (parentId == null && this.parentId == null) ||
                            (String(parentId) === String(this.parentId))
 
-      const tempId = Date.now()
+      // 并发批量上传（CONCURRENCY=3）时，processNext() 在同一 tick 里背靠背调用
+      // 本方法：每次调用在真正 await createFile(...) 之前都是纯同步代码，三次
+      // Date.now() 落在同一毫秒里完全可能拿到一模一样的值。撞车的两行会共享同一
+      // 个 id——Vue :key 靠它做身份识别，进度/文件名会在两行之间串掉，且
+      // findIndex(f => f.id === tempId) 只命中第一条，另一条永远等不到真实记录
+      // 替换，卡死在"正在上传"。叠加一个自增序号，保证同一毫秒内也互不相同。
+      const tempId = Date.now() * 1000 + (this._uploadTempIdSeq = ((this._uploadTempIdSeq || 0) + 1) % 1000)
       // Transfer file object from pending cache to new ID cache
       if (pendingTempId && this.uploadFileObjects[pendingTempId]) {
            this.uploadFileObjects[tempId] = this.uploadFileObjects[pendingTempId]

--- a/frontend/src/composables/zetaOfficeBoot.js
+++ b/frontend/src/composables/zetaOfficeBoot.js
@@ -80,7 +80,22 @@ export function bootZetaOffice(options = {}) {
       '(spike: node serve.mjs; product: Electron onHeadersReceived).'))
   }
 
-  return new Promise(async (resolve, reject) => {
+  // HIGH（审计 dev-board#74）：the executor below used to be `async (resolve, reject) => {...}`
+  // passed directly to `new Promise(...)`. An async function handed to the Promise
+  // constructor only gets its SYNCHRONOUS PREFIX covered by the constructor's implicit
+  // try/catch — once it suspends at the first `await` (a few lines down, fetching CJK
+  // fonts), any later throw becomes an unhandled rejection of the executor's own
+  // DISCARDED return promise, never a call to `reject`. Same problem for `s.onload`
+  // below: it's a plain (non-async) DOM callback, so a synchronous throw inside it
+  // (e.g. `Module.uno_main` missing) never reaches `reject` either. Either failure mode
+  // left this promise (and the caller's loading overlay) hung forever with no error
+  // surfaced. Fix: keep the Promise executor itself synchronous and non-throwing (it
+  // only wires up an inner async IIFE + a plain onload handler), and explicitly funnel
+  // every exception — from any point in the async body, or from the onload callback —
+  // into `reject`.
+  return new Promise((resolve, reject) => {
+    const rejectWithError = (e) => reject(e instanceof Error ? e : new Error(String(e)))
+    ;(async () => {
     // Files to write into the LOWA MEMFS before main() (CJK font). Each
     // { path:'/instdir/...', bytes:Uint8Array }. Fetched here (async) because
     // preRun runs synchronously; written there because /instdir merge-mounts only
@@ -277,13 +292,22 @@ export function bootZetaOffice(options = {}) {
     // only after soffice.js has run — so wire it in onload. (Verified against the
     // allotropia/zetajs web-office example.)
     s.onload = function () {
-      log('soffice.js loaded — initializing office thread…')
-      Module.uno_main.then(function (port) {
-        port.onmessage = onMessage
-        log('thread port ready')
-        resolve({ port, dispose })
-      }, function (err) { dispose(); reject(new Error('uno_main rejected: ' + err)) })
+      // s.onload is a plain DOM callback (not async): a synchronous throw here
+      // (e.g. Module.uno_main being missing/undefined) would otherwise vanish —
+      // nothing upstream catches it, so the boot promise would hang forever.
+      try {
+        log('soffice.js loaded — initializing office thread…')
+        Module.uno_main.then(function (port) {
+          port.onmessage = onMessage
+          log('thread port ready')
+          resolve({ port, dispose })
+        }, function (err) { dispose(); reject(new Error('uno_main rejected: ' + err)) })
+      } catch (e) {
+        dispose()
+        rejectWithError(e)
+      }
     }
     document.body.appendChild(s)
+    })().catch(rejectWithError)
   })
 }

--- a/frontend/src/pages/project-overview/agentClientActions.js
+++ b/frontend/src/pages/project-overview/agentClientActions.js
@@ -2,6 +2,19 @@
 // doc 流式写入缓冲、编辑器打开/重载/命令执行与结果回传。
 // 经展开进组件 methods（纯搬移，Phase 1 外置），`this` 即 project-overview 页面实例。
 import { sendEditorResult, getFileDetail } from '@/services/api.js'
+import { createSerialQueue } from '@/utils/asyncSerialize.js'
+
+// CRITICAL（审计 dev-board#74）：流式缓冲与它究竟该写进哪个文档必须绑在一起才能判断
+// "现在还能不能落字"。syncLibreExecutor（librePool.js）会把 libreOfficeExecutor 重指到
+// "当前活动文件"——生成期间用户切一次 tab，flush 就会把 AI 写的内容悄悄插进一份无关文档。
+// targetFileId 是流式会话在 doc_open_file_sync 时绑定的文件；currentFileId 是 executor
+// 此刻实际服务的文件（resolveLibreExecutorFileId 反查）。两者对不上就不许写。
+// targetFileId 为空（理论上不会发生，流式协议恒先 open_sync 才有 stream_data）时放行，
+// 与改动前的行为保持一致，不无谓收紧。
+export function shouldFlushDocStream(targetFileId, currentFileId) {
+    if (targetFileId == null) return true
+    return currentFileId != null && String(currentFileId) === String(targetFileId)
+}
 
 export const agentClientActionMethods = {
     handleClientAction(action) {
@@ -71,6 +84,15 @@ export const agentClientActionMethods = {
     async flushDocStreamBuffer() {
         if (!this._docStreamBuffer || this._docStreamBusy) return
         if (!this.libreOfficeActive || !this.libreOfficeExecutor) return
+        // CRITICAL：落字前核对这份 executor 现在服务的是不是流式会话自己打开的那个
+        // 文件——不一致说明用户切走了/换文档了，缓冲原样保留（不丢数据，等切回来
+        // 或被下一次 open_sync 的 reset 清掉），如实报告，绝不写进错的文档。
+        const currentFileId = this.resolveLibreExecutorFileId(this.libreOfficeExecutor)
+        if (!shouldFlushDocStream(this._docStreamTargetFileId, currentFileId)) {
+            console.error('[ProjectOverview] doc stream target mismatch, refusing to write into unrelated document:',
+                { targetFileId: this._docStreamTargetFileId, currentFileId })
+            return
+        }
         this._docStreamBusy = true
         const text = this._docStreamBuffer
         this._docStreamBuffer = ''
@@ -114,8 +136,20 @@ export const agentClientActionMethods = {
     /**
      * 处理 AI Agent 的同步打开文件请求 (用于流式写入)
      * 打开文件，等待内置 LibreOffice 编辑器就绪后返回结果给后端（#79）
+     *
+     * 只是一层重入闸：真正的活儿在 _handleEditorOpenFileSyncImpl 里，这里把每次调用
+     * 接进 _docOpenSyncQueue 串行化（同款做法见 DrawioEditor.persist 的 _persistQueue）。
+     * handleClientAction 是同步分发、不认在飞标记——后端重试丢失 ack 的请求，或新一轮
+     * 生成在上一轮最长 90s 的 editor-ready 等待还没完时到达，都会让两次调用并发执行；
+     * 不串行的话，后到的那次第 5 步"重置流式缓冲"会在先到的那次仍在写的时候把它的
+     * 缓冲区冲掉/丢弃，静默丢字且后端毫无感知。串行化后两次调用绝不交叉，各自完整
+     * 跑完（含各自的 sendEditorResult ack）才轮到下一个。
      */
     async handleEditorOpenFileSync(action) {
+        if (!this._docOpenSyncQueue) this._docOpenSyncQueue = createSerialQueue()
+        return this._docOpenSyncQueue(() => this._handleEditorOpenFileSyncImpl(action))
+    },
+    async _handleEditorOpenFileSyncImpl(action) {
         console.log('[ProjectOverview] Open File Sync:', action)
         const { params, requestId, conversationId } = action
 
@@ -165,6 +199,9 @@ export const agentClientActionMethods = {
             this._docStreamBuffer = ''
             if (this._docStreamTimer) { clearTimeout(this._docStreamTimer); this._docStreamTimer = null }
             this._docStreamBusy = false
+            // 这条流式会话正式绑定到这份文件——flushDocStreamBuffer 落字前必须核对
+            // executor 此刻服务的还是不是它，见文件头 shouldFlushDocStream。
+            this._docStreamTargetFileId = file.id
             // worker 端 markdown 状态机也要硬清（上一条流若异常中断会留下半张表/半行）
             try { await this.libreOfficeExecutor.executeCommand('stream_flush', { discard: true }) } catch (e) {}
             console.log('[ProjectOverview] Stream state reset, ready for streaming')

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -40,10 +40,16 @@ export const fileOpenTabsMethods = {
         if (target) {
           this.openFile(target)
         } else {
+          // 新建项目流程带 openFileId 直接落地工作台，用户期待那份刚建好的文件
+          // 已经打开——找不到时以前只 console.warn，界面上什么反应都没有，用户
+          // 分不清"文件确实不存在"还是"后端还没写完/网络抖了一下"。同名方法
+          // handleOpenFileFromChat 找不到文件时已经会弹这句提示，这里补齐同款。
           console.warn('[project-overview] openPendingLocalFile: file not found', fileId)
+          uni.showToast({ title: this.$t('workbenchOps.fileNotFound'), icon: 'none' })
         }
       } catch (e) {
         console.warn('[project-overview] openPendingLocalFile failed', e)
+        uni.showToast({ title: this.$t('workbenchOps.fetchFileListFailed'), icon: 'none' })
       }
     },
 

--- a/frontend/src/pages/project-overview/librePool.js
+++ b/frontend/src/pages/project-overview/librePool.js
@@ -23,6 +23,18 @@ export const librePoolMethods = {
     getLibreExecutorMap() {
         return this._libreExecMap || (this._libreExecMap = {})
     },
+    // 反查某个 executor 此刻绑定的 fileId（按对象恒等，同 onLibreClose 的查法）。
+    // syncLibreExecutor 会把 libreOfficeExecutor 重指到"当前活动文件"——AI 流式
+    // 写入落字前必须核对这份 executor 现在到底服务哪个文件，见 agentClientActions.js
+    // 的 flushDocStreamBuffer。找不到（executor 已被换掉/未注册）返回 null。
+    resolveLibreExecutorFileId(executor) {
+        if (!executor) return null
+        const map = this.getLibreExecutorMap()
+        for (const k of Object.keys(map)) {
+            if (map[k] === executor) return k.slice(k.indexOf(':') + 1)
+        }
+        return null
+    },
     setLibreRef(pane, fileId, el) {
         const refs = this._libreRefs || (this._libreRefs = {})
         const key = pane + ':' + fileId

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -699,6 +699,7 @@
             :files="stagingFiles"
             :usage="stagingUsage"
             @drop="onStagingDrop"
+            @drop-files="onStagingDropFiles"
             @clear="handleStagingClear"
             @remove="handleStagingRemove"
             @open="handleStagingOpen"

--- a/frontend/src/pages/project-overview/stagingArea.js
+++ b/frontend/src/pages/project-overview/stagingArea.js
@@ -154,6 +154,38 @@ export const stagingAreaMethods = {
         uni.showToast({ title: this.$t('workbenchOps.addToStagingFailed'), icon: 'none' })
       }
     },
+    // 真实 OS 文件拖拽（Finder/Explorer/桌面）落进暂存区（FileStagingArea.onDrop 的
+    // 第 3 分支：dataTransfer.files 是原生 File 列表，而不是"项目里已有文件"的引用）。
+    // 与 onStagingDrop（移动已有文件）不同——这些文件磁盘上有、项目里没有，得先真
+    // 传上去。复用 FileTree 的上传队列（$refs.fileTree.confirmUpload 读的就是
+    // selectedFiles/selectedUploadParent，上传对话框本身也只是把这两个字段填好再
+    // 调它）而不是另起一套上传逻辑——分片续传/并发控制那一整套已经在那里踩过坑。
+    async onStagingDropFiles(fileList) {
+      if (!fileList || fileList.length === 0) return
+      if (!this.stagingFolderId) await this.ensureStagingFolder()
+      if (!this.stagingFolderId) {
+        uni.showToast({ title: this.$t('workbenchOps.addToStagingFailed'), icon: 'none' })
+        return
+      }
+      const fileTree = this.$refs.fileTree
+      if (!fileTree || typeof fileTree.confirmUpload !== 'function') {
+        console.warn('[ProjectOverview] onStagingDropFiles: fileTree ref not ready')
+        return
+      }
+      fileTree.selectedFiles = Array.from(fileList)
+      fileTree.selectedUploadParent = this.stagingFolderId
+      fileTree.isFolderUpload = false
+      this.stagingPinned = true
+      await fileTree.confirmUpload()
+      uni.showToast({ title: this.$t('workbenchOps.addedToStaging'), icon: 'none' })
+      // confirmUpload 只是把上传队列发出去，不等它落盘完成（进度另有 FileTree 自己的
+      // 批量上传状态条）。这里做的是尽力而为的补拉，不是完成通知——暂存列表另有
+      // 独立状态（stagingFiles），FileTree 完成一批后只会刷新它自己的树，不知道
+      // 目标是暂存区。真正做到"传完立即精确出现"需要给 confirmUpload 加完成回调，
+      // 超出这条缺陷的范围；先用两次延时补拉覆盖常见的小文件场景。
+      this.loadStagingFiles()
+      setTimeout(() => this.loadStagingFiles(), 2500)
+    },
     handleStagingClear() {
        // Optional: Move all back to root? Or just clear list (which creates orphans in .stagezone)?
        // User didn't specify, but "Clear" usually means empty the list.

--- a/frontend/tests/project-home/archive-entries-stale-guard.test.mjs
+++ b/frontend/tests/project-home/archive-entries-stale-guard.test.mjs
@@ -1,0 +1,125 @@
+// 审计（dev-board#74）MEDIUM：loadArchiveEntries 没有陈旧守卫，快速切换 zip/rar/7z
+// 文件会显示错的条目列表。
+//
+// 病灶：reloadPreview 为每个新文件重新调一次 loadArchiveEntries，方法内部既不带
+// 请求代次、也没有像 loadMediaResource 那样用 _mediaReqId 判断陈旧——先发出但后
+// 回来的旧文件响应会覆盖已经显示的新文件条目列表；而且 this.file 是在 await 之后
+// 才读的活引用，读到的可能已经是切换后的新文件。
+//
+// 修法：仿 loadMediaResource 的思路，但复用已有的共享工具 utils/requestGeneration.js
+// （shouldAcceptResponse，同一份已经在 PersonalSettingsPanel 的 TOTP 竞态修复里用过，
+// 见 request-generation.test.mjs 覆盖该工具本身），并把 file 摘成局部变量避免读到
+// 切换后的引用。
+//
+// FilePreview.vue 依赖不多（api.js 三个函数 + auth.js 两个函数 + ICONS 常量），
+// 照 libre-editor-retry-reentrancy.test.mjs 的套路抠 <script> 求值，shouldAcceptResponse
+// 直接传真实实现（不是重新发明一个假的判定逻辑）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { shouldAcceptResponse } from '../../src/utils/requestGeneration.js'
+
+const SRC = readFileSync(new URL('../../src/components/FilePreview.vue', import.meta.url), 'utf8')
+
+function loadMethods(getArchiveEntriesImpl) {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    // uni-app 条件编译：H5/非 H5 两个分支都留着会撞名（IS_H5 declared twice）。
+    // 本仓测试只跑 H5 分支的行为（loadArchiveEntries 与平台判定无关），丢非 H5 分支。
+    .replace(/\/\/\s*#ifndef H5[\s\S]*?\/\/\s*#endif\n/, '')
+    .replace(/\/\/\s*#ifdef H5\n/, '')
+    .replace(/\/\/\s*#endif\n/, '')
+    .replace(/export default \{/, 'return {')
+  const factory = new Function(
+    'getFileDownloadUrl', 'getArchiveEntries', 'extractArchive',
+    'getAuthHeaders', 'getSessionId', 'ICONS', 'shouldAcceptResponse',
+    body)
+  return factory(
+    () => '/download', getArchiveEntriesImpl, async () => ({}),
+    () => ({}), () => 'sess', {}, shouldAcceptResponse
+  ).methods
+}
+
+function makeVm(methods) {
+  const vm = {
+    file: null,
+    archiveLoading: false,
+    archiveError: '',
+    archiveEntries: [],
+    $t: (k) => k,
+  }
+  vm.loadArchiveEntries = methods.loadArchiveEntries.bind(vm)
+  return vm
+}
+
+const deferred = () => {
+  let resolve, reject
+  const promise = new Promise((r, j) => { resolve = r; reject = j })
+  return { promise, resolve, reject }
+}
+
+test('快速切换两个压缩包：先发出但后回来的旧响应不许覆盖新文件已经显示的条目列表', async () => {
+  const gates = { A: deferred(), B: deferred() }
+  const calls = []
+  const methods = loadMethods((projectId, fileId) => {
+    calls.push(fileId)
+    return gates[fileId].promise
+  })
+  const vm = makeVm(methods)
+
+  vm.file = { projectId: 1, id: 'A' }
+  const pA = vm.loadArchiveEntries() // 用户点开 A
+  vm.file = { projectId: 1, id: 'B' } // 还没等 A 回来就切到 B
+  const pB = vm.loadArchiveEntries()
+
+  // B（当前正看着的文件）先回来
+  gates.B.resolve({ entries: ['b1.txt', 'b2.txt'] })
+  await pB
+  assert.deepEqual(vm.archiveEntries, ['b1.txt', 'b2.txt'])
+  assert.equal(vm.archiveLoading, false)
+
+  // A 这时才姗姗来迟——必须被丢弃，不能覆盖 B 已经显示的内容
+  gates.A.resolve({ entries: ['a1.txt'] })
+  await pA
+  assert.deepEqual(vm.archiveEntries, ['b1.txt', 'b2.txt'], '陈旧响应不许覆盖当前文件的条目列表')
+  assert.equal(vm.archiveLoading, false, '陈旧响应也不许把 loading 状态重新翻回 false 覆盖（虽然这里凑巧都是 false，仍要走同一条判定）')
+  assert.deepEqual(calls, ['A', 'B'])
+})
+
+test('陈旧请求的失败（网络错误）同样不许覆盖当前文件已经显示的成功结果', async () => {
+  const gates = { A: deferred(), B: deferred() }
+  const methods = loadMethods((projectId, fileId) => gates[fileId].promise)
+  const vm = makeVm(methods)
+
+  vm.file = { projectId: 1, id: 'A' }
+  const pA = vm.loadArchiveEntries()
+  vm.file = { projectId: 1, id: 'B' }
+  const pB = vm.loadArchiveEntries()
+
+  gates.B.resolve({ entries: ['b1.txt'] })
+  await pB
+  gates.A.reject(new Error('network hiccup'))
+  await pA
+
+  assert.deepEqual(vm.archiveEntries, ['b1.txt'])
+  assert.equal(vm.archiveError, '', '陈旧请求的失败不许把错误文案写进当前文件的状态')
+})
+
+test('最新一次请求失败照常显示错误（不能被判定逻辑连累成永远不报错）', async () => {
+  const methods = loadMethods(async () => { throw new Error('boom') })
+  const vm = makeVm(methods)
+  vm.file = { projectId: 1, id: 'A' }
+  await vm.loadArchiveEntries()
+  assert.equal(vm.archiveError, 'boom')
+  assert.equal(vm.archiveLoading, false)
+})
+
+test('没有并发时正常加载不受影响（回归保护）', async () => {
+  const methods = loadMethods(async () => ({ entries: ['x.txt'] }))
+  const vm = makeVm(methods)
+  vm.file = { projectId: 1, id: 'A' }
+  await vm.loadArchiveEntries()
+  assert.deepEqual(vm.archiveEntries, ['x.txt'])
+  assert.equal(vm.archiveLoading, false)
+  assert.equal(vm.archiveError, '')
+})

--- a/frontend/tests/project-home/audit-rE-source-assertions.test.mjs
+++ b/frontend/tests/project-home/audit-rE-source-assertions.test.mjs
@@ -1,0 +1,125 @@
+// 审计（dev-board#74）本轮（claude/audit-rE-fe1）四条源码文本断言：ChatInterface.vue
+// 与 FileTree.vue 体量太大（4500+/5300+ 行、几十个 @/ 别名 import），本仓 node:test
+// 一贯限制是这类文件抠 <script> 求值风险太高（需要枚举全部 import 做桩，任何一个
+// 漏了都会整份炸掉），照 audit-b2-source-assertions.test.mjs 的先例走源码文本核实：
+// 判定条件本身能抽出纯函数的都已经在各自独立的 *.test.mjs 里用真实逻辑跑过
+// （createSerialQueue 见 async-serialize.test.mjs，shouldFlushDocStream 见
+// doc-stream-target-mismatch.test.mjs）；这里覆盖的是"确认真的接上了线"。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const read = (rel) => readFileSync(new URL('../../src/' + rel, import.meta.url), 'utf8')
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+// 抠出 name(...) { ... } 形式的一个方法体（按大括号配平截断），用于在大文件里
+// 定位一段代码而不必整份 new Function。
+function extractBlock(src, marker, braceOpenOffset) {
+  const start = src.indexOf(marker)
+  assert.ok(start > 0, '找不到 ' + JSON.stringify(marker))
+  let i = start + (braceOpenOffset != null ? braceOpenOffset : marker.length)
+  while (src[i] !== '{') i++
+  let depth = 0
+  const openIdx = i
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') { depth--; if (depth === 0) { i++; break } }
+  }
+  return src.slice(start, i)
+}
+
+// ======================================================================
+// 1. ChatInterface.vue：流式中途「新建对话」不发取消请求
+// ======================================================================
+
+test('startNewChat 在 isStreaming 时必须调用 abort()（内部会 POST /api/agent/cancel），且排在清空会话状态之前', () => {
+  const src = stripComments(read('components/ChatInterface.vue'))
+  const body = extractBlock(src, 'const startNewChat = () =>')
+  assert.match(body, /if \(isStreaming\.value\) abort\(\)/,
+    '必须在 isStreaming 时调用 abort()——这是唯一真正向后端发取消请求的路径（handleAbort 用的就是它）')
+  const abortIdx = body.indexOf('abort()')
+  const setConvIdx = body.indexOf('setConversationId(null)')
+  assert.ok(abortIdx > 0 && setConvIdx > abortIdx,
+    'abort() 必须排在 setConversationId(null) 之前——发完取消请求再清前端状态，不能反过来')
+})
+
+test('handleAbort 确实调用同一个 abort()（核实两处复用的是同一份取消逻辑，不是各写一份）', () => {
+  const src = stripComments(read('components/ChatInterface.vue'))
+  const body = extractBlock(src, 'const handleAbort = () =>')
+  assert.match(body, /\babort\(\)/)
+})
+
+// ======================================================================
+// 2. ChatInterface.vue：bubbles 全树空 deep watcher 每个 token 全量重遍历
+// ======================================================================
+
+test('bubbles 上不应该再挂一个空回调体的 deep watcher（唯一保留的 watch 只看 length）', () => {
+  const src = stripComments(read('components/ChatInterface.vue'))
+  assert.doesNotMatch(src, /watch\(bubbles,/,
+    '不能再对 bubbles 整棵对象图做 deep watch——原来的回调体是空的，纯粹白白遍历一遍')
+  assert.doesNotMatch(src, /\{\s*deep:\s*true\s*\}/,
+    '本组件不该再有任何 { deep: true } 的 watch（唯一一处曾经存在的就是本条要删的这个）')
+  assert.match(src, /watch\(\(\) => bubbles\.value\.length, \(\) => \{\s*scrollToBottom\(\)/,
+    '新气泡出现时滚到底部的浅层 watch 必须保留——这是唯一还需要的行为')
+})
+
+// ======================================================================
+// 3. FileTree.vue：并发批量上传生成重复临时 id
+// ======================================================================
+
+test('uploadSingleFile 的 tempId 生成必须叠加一个自增序号，不能是裸 Date.now()', () => {
+  const src = stripComments(read('components/FileTree.vue'))
+  const body = extractBlock(src, 'async uploadSingleFile(projectId, file, parentId, pendingTempId = null)')
+  assert.doesNotMatch(body, /const tempId = Date\.now\(\)\n/,
+    '裸 Date.now() 在并发批量上传（CONCURRENCY=3 背靠背同步调用）里可能在同一毫秒内撞出重复 id')
+  assert.match(body, /const tempId = Date\.now\(\) \* 1000 \+ \(this\._uploadTempIdSeq/,
+    '必须叠加一个组件级自增序号，保证同一毫秒内也互不相同')
+})
+
+test('接线核实：processNext 确实是同步背靠背调用（本条缺陷的触发前提仍然成立）', () => {
+  const src = stripComments(read('components/FileTree.vue'))
+  const body = extractBlock(src, 'for (let i = 0; i < Math.min(CONCURRENCY, uploadQueue.length); i++)', 0)
+  assert.match(body, /processNext\(\)/)
+  assert.doesNotMatch(body, /await processNext\(\)/,
+    '如果这里改成了 await，触发条件就不成立了——本用例的前提失效，需要重新评估这条修复是否还有必要')
+})
+
+// ======================================================================
+// 4. FileTree.vue：按下标解析拖拽目标会与后台重载竞态导致移进错的文件夹
+// ======================================================================
+
+test('handleDragStart 必须记下 draggedFileId（不能只记下标）', () => {
+  const src = stripComments(read('components/FileTree.vue'))
+  const body = extractBlock(src, 'handleDragStart(e, item, index) {', 0)
+  assert.match(body, /this\.draggedFileId = \(item && item\.id != null\) \? item\.id : null/)
+})
+
+for (const [marker, offset] of [
+  ['async handleDrop(e, index) {', 0],
+  ['async onRootDrop(e) {', 0],
+]) {
+  test(marker + ' 必须按 draggedFileId 重新定位拖拽源，不能再用 displayFiles[this.draggedIndex]', () => {
+    const src = stripComments(read('components/FileTree.vue'))
+    const body = extractBlock(src, marker, offset)
+    assert.doesNotMatch(body, /displayFiles\[this\.draggedIndex\]/,
+      '直接按下标取，dragstart 与 drop 之间的后台重载（比如并发上传完成触发的 loadFiles）会让下标指向另一个文件')
+    assert.match(body, /this\.displayFiles\.find\(f => f\.id === this\.draggedFileId\)/,
+      '必须按 dragstart 时记下的 id 重新查找')
+    // 查不到必须提前退出，不能带着 undefined 继续往下调 moveFile
+    const findIdx = body.indexOf('this.displayFiles.find(f => f.id === this.draggedFileId)')
+    const notFoundGuardIdx = body.indexOf('if (!draggedItem)', findIdx)
+    const moveFileIdx = body.indexOf('moveFile(projectId', findIdx)
+    assert.ok(notFoundGuardIdx > findIdx && notFoundGuardIdx < moveFileIdx,
+      '查不到时必须提前 return，不能拿 undefined.id 去调 moveFile')
+  })
+}
+
+test('draggedIndex 与 draggedFileId 必须在同一批复位点一起清空（不能只清一个，留另一个变成陈旧值）', () => {
+  const src = stripComments(read('components/FileTree.vue'))
+  // 逐个统计两个字段被赋值为"复位"的次数，必须相等（每次 draggedIndex = -1 都配一次 draggedFileId = null）
+  const idxResets = (src.match(/this\.draggedIndex = -1/g) || []).length
+  const fileIdResets = (src.match(/this\.draggedFileId = null/g) || []).length
+  assert.ok(idxResets >= 4, '预期至少 4 处复位点（handleDrop 早退/handleDrop 未命中/handleDrop 尾部/handleDragEnd/onRootDrop 未命中/onRootDrop 尾部）')
+  assert.equal(fileIdResets, idxResets, 'draggedFileId 的复位次数必须与 draggedIndex 完全一致，不能有遗漏')
+})

--- a/frontend/tests/project-home/awd-select-menu-scroll.test.mjs
+++ b/frontend/tests/project-home/awd-select-menu-scroll.test.mjs
@@ -1,0 +1,118 @@
+// 审计（dev-board#74）MEDIUM：AwdSelect 自己的下拉滚动会立刻把菜单关掉。
+//
+// 病灶：attachDismiss 在 window 上挂了捕获段（第三参 true）的 scroll 监听器，用来
+// 侦测"外部容器滚动导致触发器坐标失效"从而关闭菜单。但捕获段会连菜单自己内部
+// （超过 280px 出现的滚动条）的 scroll 事件也一起收到——用户在菜单里往下滚一下，
+// 菜单立刻自己把自己关掉，长列表根本没法用。
+//
+// 修法：滚动事件的 target 落在菜单内部（menuEl.contains(e.target)）时忽略，只有
+// 目标在菜单之外时才按原逻辑关闭。
+//
+// AwdSelect.vue 是 Options API 且零外部依赖（没有 import），照本仓一贯套路抠
+// <script> 求值即可，连桩参数都不用传。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/AwdSelect.vue', import.meta.url), 'utf8')
+
+function loadMethods() {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/export default \{/, 'return {')
+  const factory = new Function(body)
+  return factory().methods
+}
+
+const METHODS = loadMethods()
+
+function makeVm(menuEl) {
+  const vm = {
+    open: true,
+    closeCount: 0,
+    emitted: [],
+    $el: { querySelector: (sel) => (sel === '.awd-select-menu' ? menuEl : null) },
+    close() { this.closeCount++; this.open = false; this.emitted.push('cancel') },
+  }
+  for (const name of ['attachDismiss', 'detachDismiss']) vm[name] = METHODS[name].bind(vm)
+  return vm
+}
+
+test('滚动事件的 target 落在下拉菜单内部（含子元素）时不许关闭菜单', () => {
+  const listeners = {}
+  const priorWindow = globalThis.window
+  globalThis.window = {
+    addEventListener: (type, fn) => { listeners[type] = fn },
+    removeEventListener: (type, fn) => { if (listeners[type] === fn) delete listeners[type] },
+  }
+  try {
+    const item = {} // 菜单里的一个选项 DOM 节点
+    const menuEl = { contains: (node) => node === item || node === menuEl }
+    const vm = makeVm(menuEl)
+    vm.attachDismiss()
+    assert.equal(typeof listeners.scroll, 'function', 'attachDismiss 必须注册 scroll 监听')
+
+    listeners.scroll({ type: 'scroll', target: item }) // 菜单内部子元素上的滚动
+    assert.equal(vm.closeCount, 0, '菜单自己内部的滚动不许把自己关掉——这正是本条缺陷')
+
+    listeners.scroll({ type: 'scroll', target: menuEl }) // 菜单容器自身
+    assert.equal(vm.closeCount, 0)
+  } finally {
+    globalThis.window = priorWindow
+  }
+})
+
+test('目标不在菜单内部的滚动（比如触发器所在的外部 scroll-view）仍然关闭菜单——回归保护', () => {
+  const listeners = {}
+  const priorWindow = globalThis.window
+  globalThis.window = {
+    addEventListener: (type, fn) => { listeners[type] = fn },
+    removeEventListener: (type, fn) => { if (listeners[type] === fn) delete listeners[type] },
+  }
+  try {
+    const menuEl = { contains: () => false }
+    const vm = makeVm(menuEl)
+    vm.attachDismiss()
+
+    const outsideEl = {}
+    listeners.scroll({ type: 'scroll', target: outsideEl })
+    assert.equal(vm.closeCount, 1, '外部滚动仍然要关闭菜单，不能因为加了这道判断就整体失灵')
+  } finally {
+    globalThis.window = priorWindow
+  }
+})
+
+test('resize 事件不受这道判断影响，照常关闭菜单——回归保护', () => {
+  const listeners = {}
+  const priorWindow = globalThis.window
+  globalThis.window = {
+    addEventListener: (type, fn) => { listeners[type] = fn },
+    removeEventListener: (type, fn) => { if (listeners[type] === fn) delete listeners[type] },
+  }
+  try {
+    const menuEl = { contains: () => false }
+    const vm = makeVm(menuEl)
+    vm.attachDismiss()
+    assert.equal(typeof listeners.resize, 'function')
+    listeners.resize({ type: 'resize' })
+    assert.equal(vm.closeCount, 1)
+  } finally {
+    globalThis.window = priorWindow
+  }
+})
+
+test('菜单元素还没渲染出来（querySelector 返回 null，比如 open 刚翻但 DOM 还没挂载）时不报错，按原逻辑关闭', () => {
+  const listeners = {}
+  const priorWindow = globalThis.window
+  globalThis.window = {
+    addEventListener: (type, fn) => { listeners[type] = fn },
+    removeEventListener: () => {},
+  }
+  try {
+    const vm = makeVm(null)
+    vm.attachDismiss()
+    assert.doesNotThrow(() => listeners.scroll({ type: 'scroll', target: {} }))
+    assert.equal(vm.closeCount, 1)
+  } finally {
+    globalThis.window = priorWindow
+  }
+})

--- a/frontend/tests/project-home/doc-open-sync-reentrancy.test.mjs
+++ b/frontend/tests/project-home/doc-open-sync-reentrancy.test.mjs
@@ -1,0 +1,118 @@
+// 审计（dev-board#74）MEDIUM：doc_open_file_sync 没有重入闸，重复/重试的同步打开
+// 请求会冲掉在途请求的流式缓冲。
+//
+// 病灶：handleClientAction 同步分发，不认在飞标记。后端丢失 ack 后重试、或新一轮
+// 生成在上一轮最长 90s 的 editor-ready 等待还没完时就到达，两次 handleEditorOpenFileSync
+// 会并发跑，第二次跑到"第 5 步：重置流式缓冲"时会把第一次仍在使用的缓冲区清空/丢弃，
+// 静默丢字。
+//
+// 修法：把整段实现挪进 _handleEditorOpenFileSyncImpl，对外的 handleEditorOpenFileSync
+// 只是一层薄封装，接进 createSerialQueue()（与 DrawioEditor.persist 同款串行化工具，
+// 见 async-serialize.test.mjs 覆盖该工具本身的正确性），保证两次调用绝不交叉。
+//
+// agentClientActions.js 带 @/ 别名 import，本仓一贯限制是这类文件 import 不进来
+// （见 audit-b2-source-assertions.test.mjs 文件头）；用 new Function 抠 <script> 主体
+// 求值，createSerialQueue 直接引用真实实现（该工具自身的正确性已有独立测试覆盖）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createSerialQueue } from '../../src/utils/asyncSerialize.js'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/agentClientActions.js', import.meta.url), 'utf8')
+
+function loadMethods(sendEditorResultImpl, getFileDetailImpl) {
+  const body = SRC
+    .replace(/^import .*$/gm, '')
+    .replace(/export function shouldFlushDocStream[\s\S]*?\n\}\n/, '')
+    .replace(/export const agentClientActionMethods = \{/, 'return {')
+  const factory = new Function('sendEditorResult', 'getFileDetail', 'createSerialQueue', 'uni', body)
+  return factory(sendEditorResultImpl, getFileDetailImpl, createSerialQueue, { showToast: () => {} })
+}
+
+function makeVm(methods) {
+  const vm = {
+    projectId: 1,
+    $refs: { fileTree: { loadFiles: async () => {} } },
+    openedFiles: [],
+    openFile: async (file) => { vm.openedFiles.push(file.id) },
+    libreOfficeActive: true,
+    libreOfficeExecutor: { executeCommand: async () => ({ success: true }) },
+    $t: (k) => k,
+  }
+  for (const [k, fn] of Object.entries(methods)) vm[k] = fn.bind(vm)
+  return vm
+}
+
+// 编辑器就绪轮询里的 setTimeout(resolve, 500) 每次迭代都会真等 500ms（就算一开始
+// libreOfficeActive/libreOfficeExecutor 已经就绪，循环体也是"先 sleep 再判断"）。
+// 把 setTimeout 短路成 0ms，测试跑起来不用真等。
+function withFastTimers(fn) {
+  const real = globalThis.setTimeout
+  globalThis.setTimeout = (cb, ms, ...args) => real(cb, 0, ...args)
+  return fn().finally(() => { globalThis.setTimeout = real })
+}
+
+test('第二个 doc_open_file_sync 必须排队等第一个完全跑完，不能在中途插进来执行', async () => {
+  await withFastTimers(async () => {
+    const events = []
+    let releaseA
+    const gateA = new Promise((resolve) => { releaseA = resolve })
+
+    const getFileDetailImpl = async (projectId, fileId) => {
+      events.push('getFileDetail:' + fileId)
+      if (fileId === 'A') await gateA // A 卡在这里，直到测试手动放行
+      return { id: fileId, name: fileId + '.docx' }
+    }
+    const sendEditorResultImpl = async (conversationId, requestId) => {
+      events.push('ack:' + requestId)
+    }
+
+    const methods = loadMethods(sendEditorResultImpl, getFileDetailImpl)
+    const vm = makeVm(methods)
+
+    const pA = vm.handleEditorOpenFileSync({ params: { fileId: 'A' }, requestId: 'req-A', conversationId: 'c1' })
+    // 让 A 跑到卡住的 getFileDetail（经过串行队列的 .then 跳转 + loadFiles 的 await）
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+
+    const pB = vm.handleEditorOpenFileSync({ params: { fileId: 'B' }, requestId: 'req-B', conversationId: 'c1' })
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+
+    assert.deepEqual(events, ['getFileDetail:A'],
+      'B 必须排队等待——A 还卡着的时候 B 不许已经跑到它自己的 getFileDetail，' +
+      '否则两条请求会交叉执行，B 先跑完的第 5 步会把 A 仍在用的流式缓冲清空/丢弃')
+
+    releaseA()
+    await Promise.all([pA, pB])
+
+    assert.deepEqual(events, ['getFileDetail:A', 'ack:req-A', 'getFileDetail:B', 'ack:req-B'],
+      '两次调用必须完整地一前一后跑完，各自的 ack 都要送达，且不交叉')
+    assert.deepEqual(vm.openedFiles, ['A', 'B'])
+  })
+})
+
+test('单次调用（没有并发）行为不受影响：正常打开成功并回一次 ack', async () => {
+  await withFastTimers(async () => {
+    const acks = []
+    const methods = loadMethods(
+      async (conversationId, requestId, ok) => { acks.push({ requestId, ok }) },
+      async (projectId, fileId) => ({ id: fileId, name: fileId + '.docx' }))
+    const vm = makeVm(methods)
+
+    await vm.handleEditorOpenFileSync({ params: { fileId: 'X' }, requestId: 'req-X', conversationId: 'c1' })
+
+    assert.deepEqual(acks, [{ requestId: 'req-X', ok: true }])
+    assert.deepEqual(vm.openedFiles, ['X'])
+  })
+})
+
+test('接线核实：公开方法只是薄封装，真正的逻辑在 _handleEditorOpenFileSyncImpl 里，且经过 _docOpenSyncQueue', () => {
+  const src = SRC.replace(/^\s*\/\/.*$/gm, '')
+  const start = src.indexOf('async handleEditorOpenFileSync(action) {')
+  assert.ok(start > 0, '找不到 handleEditorOpenFileSync')
+  const end = src.indexOf('async _handleEditorOpenFileSyncImpl', start)
+  const body = src.slice(start, end)
+  assert.match(body, /createSerialQueue\(\)/, '必须用 createSerialQueue 建队列')
+  assert.match(body, /this\._docOpenSyncQueue\(\(\) => this\._handleEditorOpenFileSyncImpl\(action\)\)/,
+    '必须把真正的实现接进队列，而不是直接跑')
+})

--- a/frontend/tests/project-home/doc-stream-target-mismatch.test.mjs
+++ b/frontend/tests/project-home/doc-stream-target-mismatch.test.mjs
@@ -1,0 +1,135 @@
+// 审计（dev-board#74）CRITICAL：AI 流式起草写进当前聚焦的文档，而不是它打开的那个。
+//
+// 病灶：_docStreamBuffer（doc_stream_data 的本地缓冲）与它该写进哪个文档之间没有
+// 任何绑定；flushDocStreamBuffer 落字时用的是 this.libreOfficeExecutor，而
+// librePool.js 的 syncLibreExecutor 会把这个指针重指到"当前活动文件"——AI 还在
+// 给文件 A 生成内容时，用户切一次 tab（或 A 被 LRU 淘汰），下一次 150ms flush
+// 就会把 A 的内容悄悄写进用户现在看着的、完全无关的文档 B，且没有任何错误提示。
+//
+// 修法：doc_open_file_sync 建立流式会话时把目标 fileId 记进 _docStreamTargetFileId；
+// flushDocStreamBuffer 落字前用 shouldFlushDocStream 比对"目标文件"与"executor 现在
+// 实际服务的文件"（resolveLibreExecutorFileId 反查），不一致就不写。
+//
+// 这里能用纯函数真跑的部分（shouldFlushDocStream 的判定逻辑）直接执行验证；
+// 完整链路（syncLibreExecutor 重指、150ms 定时器）涉及 uni-app 组件与真实
+// LibreOffice 执行器，只能源码文本核实"确实接上了"，端到端要人工走查
+// （见交付说明）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const read = (rel) => readFileSync(new URL('../../src/' + rel, import.meta.url), 'utf8')
+const stripComments = (s) =>
+  s.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+// agentClientActions.js 带 @/ 别名 import（services/api.js、utils/asyncSerialize.js），
+// 本仓 node:test 用例的一贯限制是这类文件 import 不进来（见 audit-b2-source-assertions
+// 的文件头注释）。shouldFlushDocStream 是纯函数、零外部依赖，直接从源码文本里抠出来
+// new Function 求值，比整份 import 稳妥。
+function loadShouldFlushDocStream() {
+  const src = read('pages/project-overview/agentClientActions.js')
+  const start = src.indexOf('export function shouldFlushDocStream')
+  assert.ok(start > 0, '找不到 shouldFlushDocStream 的导出')
+  const braceStart = src.indexOf('{', start)
+  let depth = 0
+  let i = braceStart
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') { depth--; if (depth === 0) { i++; break } }
+  }
+  const fnSrc = src.slice(start, i).replace(/^export /, '')
+  return new Function('return (' + fnSrc + ')')()
+}
+
+const shouldFlushDocStream = loadShouldFlushDocStream()
+
+// ---- 1. 纯函数：shouldFlushDocStream 的判定本身 ----
+
+test('目标文件与 executor 当前服务的文件一致时允许落字', () => {
+  assert.equal(shouldFlushDocStream('file-1', 'file-1'), true)
+  // fileId 在不同来源（params 回显 vs 后端记录）里可能是 number 也可能是 string，
+  // 判定必须做字符串归一比较，不能因为类型不同而误判成不一致
+  assert.equal(shouldFlushDocStream(1, '1'), true)
+  assert.equal(shouldFlushDocStream('1', 1), true)
+})
+
+test('CRITICAL：目标文件与当前 executor 服务的文件不一致时必须拒绝落字', () => {
+  assert.equal(shouldFlushDocStream('file-A', 'file-B'), false, '用户切到了别的文档，不许把流式内容写进去')
+})
+
+test('executor 反查不到任何文件（已被换掉/未注册）时必须拒绝落字，不能当成"随便写"', () => {
+  assert.equal(shouldFlushDocStream('file-A', null), false)
+})
+
+test('目标文件从未建立（理论上不会发生，流式协议恒先 open_sync）时放行，不收紧既有行为', () => {
+  assert.equal(shouldFlushDocStream(null, 'file-B'), true)
+  assert.equal(shouldFlushDocStream(undefined, 'file-B'), true)
+})
+
+// ---- 2. 接线核实：flush 前确实调用了这个判定，且比对失败时不执行 stream_insert ----
+
+test('flushDocStreamBuffer 落字前必须调用 shouldFlushDocStream 比对，不一致时 return（不执行 stream_insert）', () => {
+  const src = stripComments(read('pages/project-overview/agentClientActions.js'))
+  const start = src.indexOf('async flushDocStreamBuffer()')
+  assert.ok(start > 0, '找不到 flushDocStreamBuffer')
+  const end = src.indexOf('async handleDocStreamEnd', start)
+  const body = src.slice(start, end > 0 ? end : start + 2000)
+
+  assert.match(body, /resolveLibreExecutorFileId\(this\.libreOfficeExecutor\)/,
+    '必须反查 executor 此刻实际绑定的 fileId')
+  assert.match(body, /shouldFlushDocStream\(this\._docStreamTargetFileId,\s*currentFileId\)/,
+    '必须用目标 fileId 与当前 fileId 调用判定函数')
+
+  const guardIdx = body.indexOf('shouldFlushDocStream(')
+  const insertIdx = body.indexOf("executeCommand('stream_insert'")
+  assert.ok(guardIdx > 0 && insertIdx > guardIdx,
+    '比对必须排在真正调用 stream_insert 之前，不能查完还是无条件写')
+
+  // 不一致分支必须 return，不能落到 busy=true / stream_insert
+  const mismatchBranch = body.slice(body.indexOf('if (!shouldFlushDocStream'), insertIdx)
+  assert.match(mismatchBranch, /return/, '比对不一致的分支必须提前 return')
+})
+
+test('doc_open_file_sync 建立流式会话时必须把目标 fileId 记下来，供 flush 前比对', () => {
+  const src = stripComments(read('pages/project-overview/agentClientActions.js'))
+  const start = src.indexOf('async _handleEditorOpenFileSyncImpl(action)')
+  assert.ok(start > 0, '找不到 _handleEditorOpenFileSyncImpl')
+  const body = src.slice(start, start + 3000)
+  assert.match(body, /this\._docStreamTargetFileId\s*=\s*file\.id/,
+    '第 5 步重置缓冲时必须绑定这条流式会话的目标文件')
+  // 必须排在重置缓冲之后（同一批状态复位），在返回成功结果之前
+  const resetIdx = body.indexOf('this._docStreamBuffer = ')
+  const bindIdx = body.indexOf('this._docStreamTargetFileId = file.id')
+  const ackIdx = body.indexOf('sendEditorResult(conversationId, requestId, true')
+  assert.ok(resetIdx > 0 && bindIdx > resetIdx && bindIdx < ackIdx,
+    '绑定必须在缓冲复位之后、成功回执之前完成')
+})
+
+test('librePool.js 提供 resolveLibreExecutorFileId：按对象恒等反查 executor 绑定的 fileId', () => {
+  const src = stripComments(read('pages/project-overview/librePool.js'))
+  const start = src.indexOf('resolveLibreExecutorFileId(executor)')
+  assert.ok(start > 0, '找不到 resolveLibreExecutorFileId')
+  const body = src.slice(start, start + 500)
+  assert.match(body, /getLibreExecutorMap\(\)/, '必须查同一份 pane:fileId → executor 注册表')
+  assert.match(body, /map\[k\] === executor/, '必须按对象恒等匹配，不能猜 key')
+})
+
+// ---- 3. 真跑一遍 resolveLibreExecutorFileId 本身（不依赖 Vue，纯对象操作） ----
+
+test('resolveLibreExecutorFileId 真实行为：反查命中/不命中', () => {
+  const execA = { name: 'execA' }
+  const execB = { name: 'execB' }
+  const vm = {
+    _libreExecMap: { 'left:file-A': execA, 'right:file-B': execB },
+    getLibreExecutorMap() { return this._libreExecMap },
+  }
+  // 直接从源码里取出这一个方法真跑（不依赖其余 librePoolMethods）
+  const src = readFileSync(new URL('../../src/pages/project-overview/librePool.js', import.meta.url), 'utf8')
+  const bodyMatch = src.match(/resolveLibreExecutorFileId\(executor\) \{([\s\S]*?)\n    \},/)
+  assert.ok(bodyMatch, '提取不到 resolveLibreExecutorFileId 方法体')
+  const fn = new Function('executor', bodyMatch[1])
+  assert.equal(fn.call(vm, execA), 'file-A')
+  assert.equal(fn.call(vm, execB), 'file-B')
+  assert.equal(fn.call(vm, { name: 'unregistered' }), null, '没注册过的 executor 必须返回 null，不能瞎猜')
+  assert.equal(fn.call(vm, null), null)
+})

--- a/frontend/tests/project-home/pending-local-file-silent-fail.test.mjs
+++ b/frontend/tests/project-home/pending-local-file-silent-fail.test.mjs
@@ -1,0 +1,78 @@
+// 审计（dev-board#74）MEDIUM：openPendingLocalFile 找不到文件、或拉取文件列表出错
+// 时完全静默——只有 console.warn，用户在界面上看不到任何反应。
+//
+// 触发场景：newproject 页带 openFileId 查询参数落地工作台，project-overview.vue
+// 用 setTimeout(() => this.openPendingLocalFile(pendingId), 600) 打开刚创建的文件；
+// 如果后端还没写完/索引没跟上（600ms 窗口不够），或 getProjectFiles 网络抖动，
+// 调用方与用户都分不清"文件真不存在"还是"再试一次就好"还是"网络错了"。
+//
+// 修法：找不到与请求失败两个分支都补上 uni.showToast，复用同文件里
+// handleOpenFileFromChat（紧邻的姊妹方法）已经在用的同款 i18n key，不新造文案。
+//
+// fileOpenTabs.js 带 @/ 别名 import，照本仓一贯套路抠出来 new Function 求值；
+// uni 作为显式参数传入（同 search-panel-stale-toast.test.mjs 的做法），不用
+// globalThis 全局污染。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/fileOpenTabs.js', import.meta.url), 'utf8')
+
+function loadMethods(getProjectFilesImpl, uniStub) {
+  const body = SRC
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export const fileOpenTabsMethods = \{/, 'return {')
+  const factory = new Function('getProjectFiles', 'activityTracker', 'GLYPHS', 'fileGlyph', 'uni', body)
+  return factory(getProjectFilesImpl, { track: () => {} }, {}, () => '', uniStub)
+}
+
+// 返回 { vm, toasts }：toasts 是 uni.showToast 调用记录，供各用例断言"到底弹没弹"。
+function makeVm(getProjectFilesImpl) {
+  const toasts = []
+  const methods = loadMethods(getProjectFilesImpl, { showToast: (opts) => toasts.push(opts) })
+  const vm = {
+    projectId: 1,
+    openedFiles: [],
+    $t: (k) => k,
+    openFile(f) { vm.openedFiles.push(f) },
+  }
+  vm.openPendingLocalFile = methods.openPendingLocalFile.bind(vm)
+  return { vm, toasts }
+}
+
+test('文件确实不存在时必须提示用户，不能只是 console.warn', async () => {
+  const { vm, toasts } = makeVm(async () => ({ data: [{ id: 999, name: 'other.docx', isFolder: false }] }))
+  await vm.openPendingLocalFile(42)
+  assert.deepEqual(vm.openedFiles, [], '不该打开任何文件')
+  assert.equal(toasts.length, 1, '找不到文件必须弹一次提示')
+})
+
+test('getProjectFiles 请求失败时必须提示用户，不能只是 console.warn', async () => {
+  const { vm, toasts } = makeVm(async () => { throw new Error('network hiccup') })
+  await vm.openPendingLocalFile(42)
+  assert.deepEqual(vm.openedFiles, [])
+  assert.equal(toasts.length, 1, '请求失败必须弹一次提示')
+})
+
+test('文件存在时正常打开，不弹多余的提示（回归保护）', async () => {
+  const { vm, toasts } = makeVm(async () => ({ data: [{ id: 42, name: 'brief.docx', isFolder: false }] }))
+  await vm.openPendingLocalFile(42)
+  assert.deepEqual(vm.openedFiles, [{ id: 42, name: 'brief.docx', isFolder: false }])
+  assert.equal(toasts.length, 0)
+})
+
+test('fileId 为空时直接返回，不请求也不提示（回归保护，原有早退语义不变）', async () => {
+  let called = false
+  const { vm, toasts } = makeVm(async () => { called = true; return { data: [] } })
+  await vm.openPendingLocalFile(null)
+  assert.equal(called, false)
+  assert.equal(toasts.length, 0)
+})
+
+test('文件夹与目标 id 相同不算命中（isFolder 必须被排除，回归保护，原有过滤条件不变）', async () => {
+  const { vm, toasts } = makeVm(async () => ({ data: [{ id: 42, name: 'a-folder', isFolder: true }] }))
+  await vm.openPendingLocalFile(42)
+  assert.deepEqual(vm.openedFiles, [])
+  assert.equal(toasts.length, 1)
+})

--- a/frontend/tests/project-home/root-bubble-step-group-toggle.test.mjs
+++ b/frontend/tests/project-home/root-bubble-step-group-toggle.test.mjs
@@ -1,0 +1,123 @@
+// 审计（dev-board#74）MEDIUM：步骤分组的展开状态只按 stepIndex 记，导致两组联动。
+//
+// 病灶：processGroups 按 processes 数组里连续同 stepIndex 的项收成一组，key 形如
+// 's0'/'s1'。模型回退重做某一步时（比如 step 1 失败又重跑一次 step 0），会产生
+// 两个非相邻、但 stepIndex 相同因此 key 相同的分组。isGroupExpanded/toggleGroup
+// 以前按 key 记展开状态（groupToggles.value[key]），两个同 key 的分组因此共用
+// 一个槽位——点开/收起其中一个连带把另一个也翻了状态。
+//
+// 修法：改按分组下标 gi 记（processes 只增不减，已渲染分组的 gi 不会变，天然
+// 互不冲突）。
+//
+// RootBubble.vue 是 <script setup>，但脚本主体只依赖 computed/ref（真实 'vue' export，
+// 在非组件上下文也能正常工作——已用一次性 smoke test 验证过）与 defineProps/
+// defineEmits（编译宏，运行时不存在，用极简桩替换）。用真实的 Vue 响应式系统跑，
+// 而不是纯源码文本断言，能验证 gi 分组是否真的互不干扰这个"行为"本身。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { computed, ref, reactive } from 'vue'
+
+const SRC = readFileSync(
+  new URL('../../src/components/AgentMessage/RootBubble.vue', import.meta.url), 'utf8')
+
+function mountRootBubble(bubble) {
+  const body = SRC.match(/<script setup>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import .*$/gm, '')
+  const props = reactive({ bubble, isLatest: false })
+  const factory = new Function(
+    'computed', 'ref', 't', 'defineProps', 'defineEmits',
+    body + '\nreturn { processGroups, isGroupExpanded, toggleGroup, groupToggles }')
+  return factory(
+    computed, ref,
+    (key, vars) => (vars ? key + JSON.stringify(vars) : key), // t()：桩，不关心具体文案
+    () => props,                                              // defineProps(schema) → 真实 props
+    () => (() => {}))                                         // defineEmits(names) → 空 emit
+}
+
+test('两个 stepIndex 相同但不相邻的分组（重跑早前步骤），先各自成组，不合并', () => {
+  const bubble = reactive({
+    isStreaming: false,
+    processes: [
+      { id: 'a', stepIndex: 0, stepTitle: 'Step A', items: [] },
+      { id: 'b', stepIndex: 1, stepTitle: 'Step B', items: [] },
+      { id: 'c', stepIndex: 0, stepTitle: 'Step A retry', items: [] },
+    ],
+  })
+  const { processGroups } = mountRootBubble(bubble)
+  const groups = processGroups.value
+  assert.equal(groups.length, 3, '三段应该分成三组（s0, s1, s0），不能因为 key 相同就合并非相邻的组')
+  assert.equal(groups[0].key, 's0')
+  assert.equal(groups[1].key, 's1')
+  assert.equal(groups[2].key, 's0')
+})
+
+test('CRITICAL 行为：展开其中一个 stepIndex=0 的分组，不联动展开/收起另一个同 key 的分组', () => {
+  const bubble = reactive({
+    isStreaming: false,
+    processes: [
+      { id: 'a', stepIndex: 0, stepTitle: 'Step A', items: [] },
+      { id: 'b', stepIndex: 1, stepTitle: 'Step B', items: [] },
+      { id: 'c', stepIndex: 0, stepTitle: 'Step A retry', items: [] },
+    ],
+  })
+  const { processGroups, isGroupExpanded, toggleGroup } = mountRootBubble(bubble)
+  const groups = processGroups.value
+  const [g0, , g2] = groups // g0.key === g2.key === 's0'，但 gi 分别是 0 和 2
+
+  // 初始都收起（isStreaming=false 时默认全收）
+  assert.equal(isGroupExpanded(g0.key, 0), false)
+  assert.equal(isGroupExpanded(g2.key, 2), false)
+
+  toggleGroup(g2.key, 2) // 用户点开第三组（proc c 所在、更晚出现的那组）
+  assert.equal(isGroupExpanded(g2.key, 2), true, '刚点开的这组应该展开')
+  assert.equal(isGroupExpanded(g0.key, 0), false,
+    '这是本条缺陷的核心：第一组（同样 key=s0）绝不能被联动展开')
+
+  toggleGroup(g0.key, 0) // 再点开第一组
+  assert.equal(isGroupExpanded(g0.key, 0), true)
+  assert.equal(isGroupExpanded(g2.key, 2), true, '两组现在都展开，是各自独立点开的结果，不是联动')
+
+  toggleGroup(g2.key, 2) // 收起第三组
+  assert.equal(isGroupExpanded(g2.key, 2), false)
+  assert.equal(isGroupExpanded(g0.key, 0), true, '收起第三组不该连带收起第一组')
+})
+
+test('流式进行中默认展开最后一组，其余收起（回归保护，未受 gi 改动影响）', () => {
+  const bubble = reactive({
+    isStreaming: true,
+    processes: [
+      { id: 'a', stepIndex: 0, stepTitle: 'Step A', items: [] },
+      { id: 'b', stepIndex: 1, stepTitle: 'Step B', items: [] },
+    ],
+  })
+  const { processGroups, isGroupExpanded } = mountRootBubble(bubble)
+  const groups = processGroups.value
+  assert.equal(isGroupExpanded(groups[0].key, 0), false)
+  assert.equal(isGroupExpanded(groups[1].key, 1), true, '流式进行中默认展开最新一组')
+})
+
+test('用户手动收起过"当前最新组"后，即使它还是最新组也保持用户选择（回归保护）', () => {
+  const bubble = reactive({
+    isStreaming: true,
+    processes: [{ id: 'a', stepIndex: 0, stepTitle: 'Step A', items: [] }],
+  })
+  const { processGroups, isGroupExpanded, toggleGroup } = mountRootBubble(bubble)
+  const g0 = processGroups.value[0]
+  assert.equal(isGroupExpanded(g0.key, 0), true, '流式中默认展开')
+  toggleGroup(g0.key, 0)
+  assert.equal(isGroupExpanded(g0.key, 0), false, '用户手动收起后，以用户选择为准')
+})
+
+test('单一无归属分组（无 stepIndex，含历史消息）能正常展开/收起', () => {
+  const bubble = reactive({
+    isStreaming: false,
+    processes: [{ id: 'a', items: [] }, { id: 'b', items: [] }],
+  })
+  const { processGroups, isGroupExpanded, toggleGroup } = mountRootBubble(bubble)
+  const groups = processGroups.value
+  assert.equal(groups.length, 1, '无 stepIndex 的项应该收进同一个"执行过程"组')
+  assert.equal(groups[0].key, '')
+  toggleGroup(groups[0].key, 0)
+  assert.equal(isGroupExpanded(groups[0].key, 0), true)
+})

--- a/frontend/tests/project-home/staging-drop-external-files.test.mjs
+++ b/frontend/tests/project-home/staging-drop-external-files.test.mjs
@@ -1,0 +1,121 @@
+// 审计（dev-board#74）两条，都在 FileStagingArea.vue 的 onDrop：
+//
+// HIGH：暂存区放置区静默丢弃真实的系统文件拖拽。面板对任意拖拽都亮起"松手暂存
+// 文件"遮罩，但 onDrop 只认得"项目里已有文件"的内部格式（应用内 JSON /
+// document.__checkbaDraggedFile 兜底）；真实拖一个 Finder/Explorer 里的文件进来，
+// 两条路径都取不出数据，以前直接什么都不做——遮罩消失，用户以为暂存了，其实
+// 什么也没发生。
+//
+// MEDIUM：把文件夹拖进暂存区没有类型守卫。FileTree.vue 的拖拽对文件/文件夹一视
+// 同仁，folder 的 payload 里 fileType==='folder'；暂存区消费端是给 AI 读内容用的，
+// 读一个文件夹只会拿到空/报错。
+//
+// 修法：onDrop 新增第 3 分支，识别到 dataTransfer.files（浏览器原生 File 列表，
+// 内部格式两条路径都判定为空时才会走到这里）就 emit('drop-files', ...) 交给宿主
+// 走真实上传；两条内部格式解析路径都加 fileType !== 'folder' 守卫。
+//
+// FileStagingArea.vue 是 Options API 且依赖不多（ICONS 常量 + UnlockHint 组件，
+// 组件 import 只在 template/components 里用到，跟 methods 逻辑无关），照
+// libre-editor-retry-reentrancy.test.mjs 的套路把 <script> 抠出来 new Function
+// 求值，真跑 onDrop。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/FileStagingArea.vue', import.meta.url), 'utf8')
+
+function loadOptions() {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import .*$/gm, '')
+    .replace(/export default \{/, 'return {')
+  const factory = new Function('ICONS', 'UnlockHint', body)
+  return factory({}, {})
+}
+
+function makeVm() {
+  const options = loadOptions()
+  const vm = Object.assign({}, options.data())
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  vm.emitted = []
+  vm.$emit = (name, payload) => vm.emitted.push({ name, payload })
+  return vm
+}
+
+test('真实 OS 文件拖拽（dataTransfer.files，内部格式两条路径都取不到数据）触发 drop-files，而不是被静默丢弃', () => {
+  const vm = makeVm()
+  const fakeFile = { name: 'report.docx', size: 1024 }
+  const e = {
+    dataTransfer: {
+      getData: () => '', // 两条内部格式（application/x-checkba-file、text/checkba-file-json、text/plain）都空
+      files: [fakeFile],
+    },
+  }
+  vm.onDrop(e)
+  assert.deepEqual(vm.emitted, [{ name: 'drop-files', payload: [fakeFile] }])
+})
+
+test('多个真实文件一起拖入，drop-files 带上完整列表', () => {
+  const vm = makeVm()
+  const files = [{ name: 'a.pdf' }, { name: 'b.docx' }]
+  const e = { dataTransfer: { getData: () => '', files } }
+  vm.onDrop(e)
+  assert.deepEqual(vm.emitted, [{ name: 'drop-files', payload: files }])
+})
+
+test('内部格式拖了个文件夹（fileType===folder）不许被当成可暂存文件收进列表，也不会误落进 OS 兜底分支', () => {
+  const vm = makeVm()
+  const e = {
+    dataTransfer: {
+      getData: (type) => type === 'application/x-checkba-file'
+        ? JSON.stringify({ fileId: 99, name: '合同文件夹', fileType: 'folder', wpsFileId: null })
+        : '',
+      files: [], // 内部拖拽没有原生 File 列表
+    },
+  }
+  vm.onDrop(e)
+  assert.deepEqual(vm.emitted, [], '文件夹必须被拒绝，且不产生任何 emit（不是"暂存"也不是"上传"）')
+})
+
+test('正常文件（非文件夹）内部拖拽照常工作——回归保护，不能因为加了文件夹守卫就误伤普通文件', () => {
+  const vm = makeVm()
+  const e = {
+    dataTransfer: {
+      getData: (type) => type === 'application/x-checkba-file'
+        ? JSON.stringify({ fileId: 7, name: '起诉状.docx', fileType: 'docx', wpsFileId: 'w1' })
+        : '',
+      files: [],
+    },
+  }
+  vm.onDrop(e)
+  assert.deepEqual(vm.emitted, [{
+    name: 'drop',
+    payload: [{ id: 7, name: '起诉状.docx', fileType: 'docx', wpsFileId: 'w1' }],
+  }])
+})
+
+test('全局兜底变量路径（document.__checkbaDraggedFile）同样挡文件夹，且无论是否收进列表都要消费掉该变量', () => {
+  const vm = makeVm()
+  const priorDocument = globalThis.document
+  globalThis.document = { __checkbaDraggedFile: { fileId: 5, name: '文件夹', fileType: 'folder' } }
+  try {
+    const e = { dataTransfer: { getData: () => '', files: [] } }
+    vm.onDrop(e)
+    assert.deepEqual(vm.emitted, [])
+    assert.equal(globalThis.document.__checkbaDraggedFile, null)
+  } finally {
+    globalThis.document = priorDocument
+  }
+})
+
+test('全局兜底变量路径对普通文件仍然照常工作（回归保护）', () => {
+  const vm = makeVm()
+  const priorDocument = globalThis.document
+  globalThis.document = { __checkbaDraggedFile: { fileId: 6, name: 'x.pdf', fileType: 'pdf' } }
+  try {
+    const e = { dataTransfer: { getData: () => '', files: [] } }
+    vm.onDrop(e)
+    assert.deepEqual(vm.emitted, [{ name: 'drop', payload: [{ id: 6, name: 'x.pdf', fileType: 'pdf', wpsFileId: undefined }] }])
+  } finally {
+    globalThis.document = priorDocument
+  }
+})

--- a/frontend/tests/project-home/staging-drop-files-upload.test.mjs
+++ b/frontend/tests/project-home/staging-drop-files-upload.test.mjs
@@ -1,0 +1,95 @@
+// 审计（dev-board#74）HIGH 的落地一半：FileStagingArea 发出 drop-files 之后，
+// project-overview 的消费端 stagingArea.js#onStagingDropFiles 是否真的把文件
+// 接进了 FileTree 的上传队列（selectedFiles/selectedUploadParent + confirmUpload），
+// 而不是也一样悄悄什么都不做。
+//
+// stagingArea.js 依赖不多（api.js 四个函数 + externalLink.js/siteLinks.js 各一个，
+// 后两个只在配额超限分支用到，与本条无关），照本仓一贯套路抠 <script> 求值。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+// onStagingDropFiles 补拉暂存列表用的是真实 setTimeout(…, 2500)（详见实现里的注释：
+// 尽力而为的补拉，不是完成通知）——测试不关心这 2.5s 本身，短路成 0ms 避免拖慢套件。
+const realSetTimeout = globalThis.setTimeout
+globalThis.setTimeout = (fn, ms, ...args) => realSetTimeout(fn, 0, ...args)
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/stagingArea.js', import.meta.url), 'utf8')
+
+function loadMethods() {
+  const body = SRC
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export const stagingAreaMethods = \{/, 'return {')
+  const factory = new Function(
+    'getProjectFiles', 'createFolder', 'batchMoveFiles', 'getStageUsage',
+    'openExternalUrl', 'accountPageUrl', 'uni', body)
+  return factory(
+    async () => ({ data: [] }), async () => ({ id: 'stage-1' }), async () => {}, async () => null,
+    () => {}, () => '', { showToast: () => {} })
+}
+
+function makeVm(methods, { confirmUploadImpl } = {}) {
+  const vm = {
+    projectId: 1,
+    stagingFolderId: 'stage-1', // 已经建好暂存目录（ensureStagingFolder 早退分支）
+    stagingPinned: false,
+    stagingFiles: [],
+    loadStagingFilesCalls: 0,
+    $refs: {
+      fileTree: {
+        selectedFiles: null,
+        selectedUploadParent: null,
+        isFolderUpload: true, // 故意设个"错"的初值，验证方法会把它归零
+        confirmUpload: confirmUploadImpl || (async () => {}),
+      },
+    },
+    $t: (k) => k,
+  }
+  for (const [k, fn] of Object.entries(methods)) vm[k] = fn.bind(vm)
+  vm.loadStagingFiles = async () => { vm.loadStagingFilesCalls++ }
+  return vm
+}
+
+test('拖入的真实文件必须接进 FileTree 的上传队列（selectedFiles/selectedUploadParent），而不是只弹个提示就结束', async () => {
+  const methods = loadMethods()
+  const vm = makeVm(methods)
+  const fileA = { name: 'a.pdf' }
+  const fileB = { name: 'b.docx' }
+  await vm.onStagingDropFiles([fileA, fileB])
+
+  assert.deepEqual(vm.$refs.fileTree.selectedFiles, [fileA, fileB],
+    '必须把拖进来的原生 File 列表塞进 FileTree 的 selectedFiles')
+  assert.equal(vm.$refs.fileTree.selectedUploadParent, 'stage-1',
+    '上传目标必须是暂存目录，不能传去别的地方')
+  assert.equal(vm.$refs.fileTree.isFolderUpload, false, '这是文件拖拽，不是文件夹上传模式')
+  assert.equal(vm.stagingPinned, true, '暂存面板应该自动展开，让用户看到上传进度')
+})
+
+test('空文件列表直接早退，不建目录、不碰 FileTree', async () => {
+  const methods = loadMethods()
+  let confirmUploadCalled = false
+  const vm = makeVm(methods, { confirmUploadImpl: async () => { confirmUploadCalled = true } })
+  await vm.onStagingDropFiles([])
+  await vm.onStagingDropFiles(null)
+  assert.equal(confirmUploadCalled, false)
+  assert.equal(vm.stagingPinned, false)
+})
+
+test('FileTree 的 ref 还没挂载好时不抛异常，只记警告', async () => {
+  const methods = loadMethods()
+  const vm = makeVm(methods)
+  vm.$refs.fileTree = null
+  await assert.doesNotReject(() => vm.onStagingDropFiles([{ name: 'x.pdf' }]))
+})
+
+test('拖入时暂存目录还没建过（stagingFolderId 为空）会先建目录再上传', async () => {
+  const methods = loadMethods()
+  const vm = makeVm(methods)
+  vm.stagingFolderId = null
+  vm.ensureStagingFolder = async function () { this.stagingFolderId = 'newly-created' }
+  let capturedParent = null
+  vm.$refs.fileTree.confirmUpload = async function () { capturedParent = this.selectedUploadParent }
+  await vm.onStagingDropFiles([{ name: 'x.pdf' }])
+  assert.equal(capturedParent, 'newly-created')
+})

--- a/frontend/tests/project-home/thinking-card-ghost-collapse.test.mjs
+++ b/frontend/tests/project-home/thinking-card-ghost-collapse.test.mjs
@@ -1,0 +1,95 @@
+// 审计（dev-board#74）MEDIUM：幽灵 ThinkingCard 永不自动折叠。
+//
+// 病灶：RootBubble.vue 把 ThinkingCard 的 card/ghost 两个变体渲染在结构不同的
+// v-if/v-else 分支里（不是同一个组件切 prop，是"卸载旧的、挂载全新一个"）。
+// isReady 一旦从 false 翻真，就从 card 分支切到 ghost 分支——挂载那一刻如果
+// bubble.thinking.status 已经是 'done'（很常见：标题/正文往往紧跟在思考结束
+// 后出现），ThinkingCard 内部"自动折叠"的 watch(() => props.status, ...) 没有
+// immediate:true 就一次都不会跑——isExpanded 停在 ref(true) 的默认值，ghost 卡
+// 永远摊开显示模型原始思维链，而不是折成一行"Thought for Ns"。
+//
+// 修法：watch 加 immediate:true。**附带修复**：immediate 回调在 watch() 这条
+// 语句执行的当下就同步跑，而 startTimer/stopTimer 原来声明在 watch(...) 之后——
+// 单纯加 immediate:true 会让回调在这两个 const 完成初始化之前就去引用它们，踩中
+// 暂时性死区抛 ReferenceError（用 @vue/server-renderer 真实挂载复现过，不是
+// 空想的边界情况）。已把这两个函数（连同它们依赖的 updateTime）挪到 watch 之前，
+// 纯移动顺序、函数体一字未改。
+//
+// ThinkingCard.vue 是 <script setup>，逻辑只依赖 ref/watch/computed/onMounted/
+// onUnmounted（真实 'vue' export，在非组件上下文里 ref/watch/computed 正常工作，
+// onMounted/onUnmounted 只是 warn+no-op，不会抛异常）与 defineProps（编译宏，
+// 桩成"忽略 schema、直接返回外部传入的 props"）。用真实 Vue 响应式系统跑，直接
+// 验证"挂载时 status 已经是 done，isExpanded 是不是立刻为 false"这个行为本身。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { ref, watch, computed, onMounted, onUnmounted, nextTick } from 'vue'
+
+const SRC = readFileSync(
+  new URL('../../src/components/AgentMessage/ThinkingCard.vue', import.meta.url), 'utf8')
+
+// startTimer 会真的 setInterval(updateTime, 1000)——不 unref 的话，任何一个
+// status:'thinking' 的用例都会让 node --test 进程挂着退不出去（本条缺陷本身
+// 与这个计时器无关，纯粹是让测试进程能正常收尾）。
+const realSetInterval = globalThis.setInterval
+globalThis.setInterval = (fn, ms, ...args) => {
+  const t = realSetInterval(fn, ms, ...args)
+  if (t && typeof t.unref === 'function') t.unref()
+  return t
+}
+
+function extractScriptSetupBody() {
+  return SRC.match(/<script setup>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import .*$/gm, '')
+}
+
+function mountThinkingCard(props) {
+  const body = extractScriptSetupBody()
+  const factory = new Function(
+    'ref', 'watch', 'computed', 'onMounted', 'onUnmounted', 't', 'defineProps',
+    body + '\nreturn { isExpanded, toggle }')
+  return factory(ref, watch, computed, onMounted, onUnmounted, (k) => k, () => props)
+}
+
+test('CRITICAL 行为：挂载时 status 已经是 done（ghost 变体重挂载的常见场景），isExpanded 必须立刻是 false', () => {
+  const { isExpanded } = mountThinkingCard({ status: 'done', duration: 12.3, content: 'reasoning...', startTime: 0 })
+  assert.equal(isExpanded.value, false,
+    '没有 immediate:true 的话这里会停在 ref(true) 的默认值——卡片永远摊开显示')
+})
+
+test('挂载时仍在 thinking，保持展开（回归保护）', () => {
+  const { isExpanded } = mountThinkingCard({ status: 'thinking', duration: 0, content: '', startTime: Date.now() })
+  assert.equal(isExpanded.value, true)
+})
+
+test('挂载时是 idle（初始占位态），不触发任何一支分支，保持默认展开（回归保护）', () => {
+  const { isExpanded } = mountThinkingCard({ status: 'idle', duration: 0, content: '', startTime: 0 })
+  assert.equal(isExpanded.value, true, 'idle 分支没有对应的 if/else-if，isExpanded 应保持默认值')
+})
+
+test('挂载后 status 从 thinking 变为 done，照常触发折叠（回归保护，非 immediate 场景不受影响）', async () => {
+  // watch 需要一个真实的、值会变的响应式 source 才能在"挂载后"这个时间点触发；
+  // 用一个 ref 包一层模拟 Vue 组件在 props.status 变化时重新求值的效果。
+  const statusRef = ref('thinking')
+  const body = extractScriptSetupBody()
+  const factory = new Function(
+    'ref', 'watch', 'computed', 'onMounted', 'onUnmounted', 't', 'defineProps',
+    body + '\nreturn { isExpanded }')
+  const { isExpanded } = factory(ref, watch, computed, onMounted, onUnmounted, (k) => k,
+    () => ({ get status() { return statusRef.value }, duration: 0, content: '', startTime: Date.now() }))
+  assert.equal(isExpanded.value, true)
+  statusRef.value = 'done'
+  // watch 默认 flush:'pre'，回调不是同步触发的——要等一轮 Vue 的调度队列
+  // flush 完才看得到效果，同真实组件里 props 变化到 watcher 回调之间的关系一致。
+  await nextTick()
+  assert.equal(isExpanded.value, false, '非 immediate 场景（挂载后的真实状态变化）本来就能正常折叠，本条修复不能破坏它')
+})
+
+test('toggle() 手动开合仍然可用（回归保护）', () => {
+  const { isExpanded, toggle } = mountThinkingCard({ status: 'done', duration: 1, content: 'x', startTime: 0 })
+  assert.equal(isExpanded.value, false)
+  toggle()
+  assert.equal(isExpanded.value, true)
+  toggle()
+  assert.equal(isExpanded.value, false)
+})

--- a/frontend/tests/project-home/zeta-boot-executor-reject.test.mjs
+++ b/frontend/tests/project-home/zeta-boot-executor-reject.test.mjs
@@ -1,0 +1,111 @@
+// 审计（dev-board#74）HIGH：bootZetaOffice() 的 async Promise-executor 吞掉首个
+// await 之后抛出的异常，boot 的 promise（连同编辑器加载遮罩）永远悬空。
+//
+// 病灶：`new Promise(async (resolve, reject) => {...})`——传给 Promise 构造器的
+// executor 只要是 async 函数，构造器的隐式 try/catch 只兜得住"挂起在第一个 await
+// 之前"的同步前缀；一旦挂起过，之后再抛的异常会变成这个 async 函数自己那个被
+// 丢弃的返回 promise 的 unhandled rejection，压根不会调用 reject。s.onload 同样
+// 中招——它是普通（非 async）DOM 回调，里面的同步抛出没有任何东西兜底。
+//
+// 这个模块本身是"framework-agnostic"的纯 ES module（文件头注释明说 NO Vue），
+// 可以直接 import 真跑，不需要走本仓那套"抠 <script> 再 new Function"的套路。
+// 用最小的 document/self 桩，制造"首个 await 之后同步抛异常"与"s.onload 内部同步
+// 抛异常"两种触发场景，断言 boot() 返回的 promise 必须在有限时间内 reject，
+// 而不是永远不 settle。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { bootZetaOffice } from '../../src/composables/zetaOfficeBoot.js'
+
+// 真实 setTimeout（在 shim globalThis.setTimeout 之前捕获），供测试自己的"等一小段
+// 时间看 promise 有没有 settle"计时，不受被测代码内部计时器影响。
+const realSetTimeout = globalThis.setTimeout
+
+// bootZetaOffice 内部起了一个 1s 一跳的 setInterval（保持 Qt 窗口跟画布同尺寸），
+// 只有调用方拿到 resolve 出的 dispose() 才会清掉；本测试文件不少路径走的是
+// reject（早退），根本拿不到 dispose。不 unref 的话这个定时器会让 node --test
+// 进程永远退不出去（不是本条要修的缺陷——这里只是让测试进程能正常收尾）。
+const realSetInterval = globalThis.setInterval
+globalThis.setInterval = (fn, ms, ...args) => {
+  const t = realSetInterval(fn, ms, ...args)
+  if (t && typeof t.unref === 'function') t.unref()
+  return t
+}
+
+const delay = (ms, val) => new Promise((r) => realSetTimeout(() => r(val), ms))
+
+// 把 bootZetaOffice() 的 promise 与一个短暂超时哨兵赛跑：赢家是超时哨兵，
+// 说明 promise 在这段时间内没有 settle（复现"永远悬空"）；赢家是 reject/resolve，
+// 说明 promise 确实 settle 了。
+async function raceSettle(promise, timeoutMs = 300) {
+  const TIMEOUT = Symbol('timeout')
+  const settled = promise.then(
+    (v) => ({ ok: true, value: v }),
+    (e) => ({ ok: false, error: e }))
+  const result = await Promise.race([settled, delay(timeoutMs, TIMEOUT)])
+  return result
+}
+
+test('首个 await 之后（fontFetches 完成之后的同步代码）抛出的异常必须 reject，而不是永远悬空', async () => {
+  // 不传 fontUrl/fontUrls：fontList 为空，Promise.all([]) 立即 resolve，"首个 await"
+  // 瞬间跨过——随后进入的是纯同步代码（构造 CJK_ALIAS_GROUPS、Module 对象……），
+  // 让 document.createElement 在这段同步代码里抛异常，精确复现"过了第一个 await
+  // 之后的同步抛出"这个失败模式。
+  globalThis.document = {
+    createElement: () => { throw new Error('boom-create-element') },
+    body: { appendChild: () => {} },
+  }
+  try {
+    // sofficeBaseUrl:'' 跳过需要 globalThis.location 的绝对化分支，聚焦本条要测的路径
+    const result = await raceSettle(bootZetaOffice({ canvas: {}, sofficeBaseUrl: '' }))
+    assert.notEqual(result, undefined)
+    assert.equal(result.ok, false, 'boot() 的 promise 必须在合理时间内 reject——不能永远挂起（这正是本条缺陷的表现）')
+    assert.match(String(result.error && result.error.message), /boom-create-element/)
+  } finally {
+    delete globalThis.document
+  }
+})
+
+test('s.onload 内部同步抛出的异常（如 Module.uno_main 不存在）必须 reject', async () => {
+  // 模拟"脚本加载完成"：真实浏览器里 onload 是异步触发的，这里用同步调用简化——
+  // 触发条件本身与"异步 vs 同步调用 onload"无关，只与"onload 内部抛出能不能传出去"
+  // 有关。bootZetaOffice 自己会把不带 uno_main 的 Module 挂到 globalThis.Module 上
+  // （真实场景里 uno_main 是 soffice.js 加载完之后才挂上去的），我们不加载真实
+  // soffice.js，所以 Module.uno_main 天然是 undefined，访问它的 .then 会抛 TypeError。
+  globalThis.document = {
+    createElement: () => ({}),
+    body: { appendChild: (el) => { if (el.onload) el.onload() } },
+  }
+  try {
+    const result = await raceSettle(bootZetaOffice({ canvas: {}, sofficeBaseUrl: '' }))
+    assert.notEqual(result, undefined)
+    assert.equal(result.ok, false, 's.onload 内部的同步抛出也必须 reject，不能被吞掉')
+    assert.match(String(result.error && result.error.message),
+      /uno_main|Cannot read propert/i)
+  } finally {
+    delete globalThis.document
+    delete globalThis.Module
+  }
+})
+
+test('正常路径不受影响：onload 里 uno_main 正常 resolve 时 boot() 照常 resolve', async () => {
+  let resolveUnoMain
+  globalThis.document = {
+    createElement: () => ({}),
+    body: {
+      appendChild: (el) => {
+        // 先把 Module.uno_main 换成一个受控 promise，再触发 onload
+        globalThis.Module.uno_main = new Promise((r) => { resolveUnoMain = r })
+        if (el.onload) el.onload()
+        resolveUnoMain({ onmessage: null })
+      },
+    },
+  }
+  try {
+    const result = await raceSettle(bootZetaOffice({ canvas: {}, sofficeBaseUrl: '' }))
+    assert.equal(result.ok, true, '正常路径必须照常 resolve，本条修复不能引入新的失败')
+    assert.ok(result.value && result.value.port, 'resolve 值必须带上 port')
+  } finally {
+    delete globalThis.document
+    delete globalThis.Module
+  }
+})


### PR DESCRIPTION
审计剩余清单里前端「工作台/文件树/编辑器」那一组，十四条全部落地。
每条先写测试看它红、改实现看它绿、再把实现临时还原确认测试真会红。

1. [CRITICAL] AI 流式起草写进用户当前聚焦的文档，而不是它自己打开的那个
   流式缓冲与目标文档之间没有任何绑定，而 syncLibreExecutor 会把执行器重指到
   「当前活动文件」。生成期间用户切一次标签（或分屏换个焦点），下一次 150ms 的 flush
   就把 AI 写的内容悄悄插进一份无关文档——两头都不报错。
   修法：在 doc_open_file_sync 时把这条流式会话绑定到具体 fileId，落字前反查执行器
   此刻服务的是哪个文件，对不上就**拒绝写入**、如实报错、缓冲原样保留（不丢数据）。
   端到端（真的切标签）只能人工走查，判定逻辑做成了纯函数并有断言。

2. [HIGH] 暂存区放置区静默丢弃真实的系统文件拖拽
   拖进去时覆盖层照常显示「松手暂存文件」，松手后什么都不发生——只认内部拖拽格式。
   补一条读 dataTransfer.files 的分支，复用文件树既有的分片上传队列而不是另写一套。
   **一处明说的取舍**：那个上传方法不报完成，要做到「上传一完成就精确刷新暂存区」
   得改文件树的完成信号，超出本条范围；现在是「发起上传 + 立刻与 2.5 秒后各刷一次」，
   代码注释里写明了这个局限。

3. [HIGH] bootZetaOffice 的 async Promise executor 吞掉首个 await 之后的所有异常
   `new Promise(async (resolve, reject) => {...})` 只兜得住同步前缀，之后抛出的异常
   与 s.onload 里的同步抛出都变成被丢弃的 unhandled rejection，boot promise 永远不 settle，
   编辑器卡在加载态。改成 executor 保持同步、函数体包进 async IIFE 并 .catch(reject)。
   这条的红特别硬：还原修复后测试直接以 `failureType: 'unhandledRejection'` 失败，
   而不是超时——正是审计描述的那个失败形态。

4/5. 流式中途「新建对话」不发取消请求（后端继续烧着，用户以为停了）；
   bubbles 全树的空 deep watcher 每个 token 全量重遍历整棵消息/工具输出图。前者接上既有
   取消通道，后者直接删掉（真正需要的滚动行为由既有的浅层长度 watcher 覆盖）。

6. [MEDIUM] 幽灵 ThinkingCard 永不自动折叠（watcher 缺 immediate，而组件恰好在状态
   已经变完之后才挂载）。补 immediate 时**撞出一个真 bug**：这样会让回调在 watch() 调用点
   同步触发，而 startTimer/stopTimer 是在那之后用 const 声明的——真实的 TDZ ReferenceError，
   用 Vue 的 SSR 渲染实测复现，靠把三个函数挪到 watcher 之前解决（纯位置调整，无逻辑改动）。

7. 把文件夹拖进暂存区无类型守卫（与第 2 条同一处改动，两条内部格式解析路径都挡）。
8. loadArchiveEntries 无陈旧守卫：快速切换 zip/rar/7z 会显示上一个压缩包的条目列表。
   复用上一轮抽出来的 shouldAcceptResponse。
9. 并发批量上传生成重复临时 id：三个上传在同一毫秒里同步发起，`Date.now()` 撞号，
   在途列表被搅乱。加组件级序号。
10. 按下标解析拖拽目标会与后台重载竞态：dragstart 时记的下标到 drop 时可能已经指向
   另一个文件（比如批量上传完成触发了重载），文件被移进错的文件夹。改成按 id 解析，
   找不到就中止并提示。（同文件的移动端触摸重排是另一种下标读取形态，不在本条范围，未动。）
11. openPendingLocalFile 找不到文件或 fetch 出错时完全静默：补提示，复用同文件姊妹方法
   已有的 i18n key，没有新增文案。
12. doc_open_file_sync 无重入守卫：重试或新一轮生成撞上一轮最长 90 秒的等待时，
   后到的那次会把先到那次仍在用的流式缓冲冲掉，静默丢字。用串行队列串起来。
13. AwdSelect 自己的下拉滚动会立刻把菜单关掉（捕获阶段的 scroll 监听不区分事件来源）。
14. 步骤分组的展开状态只按 stepIndex 记：同一步骤被重试时会出现两个非相邻分组共用一个 key，
   点开一个另一个跟着展开。改成按数组下标记。

门禁：check:emits / check:nav / check:nav:full / check:locales 全绿；
test:project-home 269 例全过（含本批新增的 11 个测试文件）。
本批测试大量用真 Vue（reactive/watch/computed）与 @vue/server-renderer 实跑，
不是文本匹配。

需要人工走查：AI 生成中途切标签（确认不再串文档且控制台有报错）；
把真实系统文件拖进暂存区（约 2.5 秒后应出现）；并发上传 + 文件树拖拽。

过程如实记一笔：子 agent 中途误用过一次 git stash，当场发现并 pop 回来。
我已核验仓库主人 2026-06-18 的备份完好——27 个文件、三段式结构齐全，
物理备份目录也在，没有丢失。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)