### PR TITLE
fix(ai-chat): 记忆解析失败当成「没什么可记」、扫描件被当文本件转空、无界 map 等二十条（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/AgentRunStateService.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentRunStateService.java
@@ -58,7 +58,24 @@ public class AgentRunStateService {
 
     public record RunState(RunStatus status, long updatedAt) {}
 
+    /**
+     * 每会话运行状态。<b>无界增长</b>：每个在本进程内跑过至少一轮的 conversationId 永久占一条，
+     * 从不摘除（审计条目：AgentRunStateService.states map grows unboundedly for the life of
+     * the process）。云端长命进程服务全租户会话，条目只涨不消。用 {@link #purgeStaleStates()}
+     * 做惰性过期：7 天没有新状态更新的记录直接摘掉——超过这个窗口继续占着内存没有任何用户可见
+     * 价值，{@link #get} 对"内存里没有记录"本来就当"无任务"正常渲染（历史会话的既有语义）。
+     */
     private final Map<String, RunState> states = new ConcurrentHashMap<>();
+
+    /** {@link #purgeStaleStates()} 的过期窗口，见 {@link #states} 字段注释。 */
+    private static final long STALE_STATE_MILLIS = 7L * 24 * 60 * 60 * 1000;
+
+    /** 时间源，测试可注入固定值以避免真实等待 7 天。 */
+    private java.util.function.LongSupplier clockMillis = System::currentTimeMillis;
+
+    void setClockMillis(java.util.function.LongSupplier clockMillis) {
+        this.clockMillis = clockMillis;
+    }
 
     private final AgentRunRecordRepository recordRepository;
     private final com.checkba.service.telemetry.TelemetryTurnTracker turnTracker;
@@ -79,11 +96,33 @@ public class AgentRunStateService {
      */
     public void mark(String conversationId, RunStatus status, Long projectId, Long userId) {
         if (conversationId == null || status == null) return;
-        states.put(conversationId, new RunState(status, System.currentTimeMillis()));
+        states.put(conversationId, new RunState(status, clockMillis.getAsLong()));
         // 埋点：终态在此单点合成 ai.turn（新增终止分支只要走 mark 就自动覆盖）；
         // restore() 刻意不打点——启动回收是既有状态回放，进程内也没有未闭合轮次
         turnTracker.onStatus(conversationId, status.name());
         persist(conversationId, status, projectId, userId);
+    }
+
+    /**
+     * 清理超过 {@link #STALE_STATE_MILLIS} 未再更新的会话状态（见 {@link #states} 字段注释）。
+     * 与 {@code TodoListService.purgeStaleLists} / {@code SkillRouter.purgeStaleActivations}
+     * 同款节奏：每日一次 + 错峰的初始延迟。只清内存 map，不碰 DB——持久化记录的清理策略是
+     * 另一个决策，不在本次改动范围内。
+     */
+    @org.springframework.scheduling.annotation.Scheduled(fixedDelay = 24L * 60 * 60 * 1000,
+            initialDelay = 20L * 60 * 1000)
+    public void purgeStaleStates() {
+        try {
+            long cutoff = clockMillis.getAsLong() - STALE_STATE_MILLIS;
+            int before = states.size();
+            states.entrySet().removeIf(e -> e.getValue().updatedAt() < cutoff);
+            int removed = before - states.size();
+            if (removed > 0) {
+                log.info("清理冷 Agent 运行状态记录 {} 条", removed);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to purge stale agent run states", e);
+        }
     }
 
     private void persist(String conversationId, RunStatus status, Long projectId, Long userId) {
@@ -108,7 +147,7 @@ public class AgentRunStateService {
      */
     void restore(String conversationId, RunStatus status) {
         if (conversationId == null || status == null) return;
-        states.put(conversationId, new RunState(status, System.currentTimeMillis()));
+        states.put(conversationId, new RunState(status, clockMillis.getAsLong()));
     }
 
     /** null = 本进程内从未跑过（历史会话），前端按「无任务」处理。 */
@@ -119,5 +158,10 @@ public class AgentRunStateService {
     public String statusName(String conversationId) {
         RunState s = get(conversationId);
         return s == null ? null : s.status().name();
+    }
+
+    /** 供测试断言登记簿大小（不下沉成生产代码路径）。 */
+    int statesSize() {
+        return states.size();
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/BackgroundTaskService.java
+++ b/backend/src/main/java/com/checkba/service/ai/BackgroundTaskService.java
@@ -82,6 +82,16 @@ public class BackgroundTaskService {
         this.clock = clock;
     }
 
+    /** 供测试断言 conversationTasks 外层 map 是否还留着某个 key（不下沉成生产代码路径）。 */
+    boolean hasConversationTaskMapEntry(String conversationId) {
+        return conversationTasks.containsKey(conversationId);
+    }
+
+    /** 供测试断言 userTasks 外层 map 是否还留着某个 key（不下沉成生产代码路径）。 */
+    boolean hasUserTaskMapEntry(Long userId) {
+        return userTasks.containsKey(userId);
+    }
+
     @PreDestroy
     public void shutdown() {
         cleanupScheduler.shutdownNow();
@@ -103,8 +113,20 @@ public class BackgroundTaskService {
         activeTasks.put(taskId, taskInfo);
         // 内层用 CopyOnWriteArrayList：注册线程、清理线程、查询线程并发 add/remove/遍历，
         // 普通 ArrayList 会抛 ConcurrentModificationException 或脏读（ConcurrentHashMap 只保护外层 map）。
-        conversationTasks.computeIfAbsent(conversationId, k -> new CopyOnWriteArrayList<>()).add(taskId);
-        userTasks.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(taskId);
+        // 用 compute（而不是 computeIfAbsent(...).add(...) 两步）：注册与
+        // cleanupTaskReferences 的"清空后摘除 key"都要经过同一个按 key 加锁的原子操作，
+        // 否则会出现"cleanup 判定 list 为空、正要摘除 key 的同时，registerTask 恰好往同一个
+        // 已存在但即将被摘除的 list 里塞了新 taskId"，新任务在摘除后就从外层 map 里凭空消失。
+        conversationTasks.compute(conversationId, (k, list) -> {
+            List<String> l = list != null ? list : new CopyOnWriteArrayList<>();
+            l.add(taskId);
+            return l;
+        });
+        userTasks.compute(userId, (k, list) -> {
+            List<String> l = list != null ? list : new CopyOnWriteArrayList<>();
+            l.add(taskId);
+            return l;
+        });
         
         // Send background_task_start event
         BackgroundTaskEvent event = BackgroundTaskEvent.started(taskId, taskType.name(), conversationId, estimatedDurationSec);
@@ -371,18 +393,28 @@ public class BackgroundTaskService {
         }, delayMs, TimeUnit.MILLISECONDS);
     }
     
+    /**
+     * 摘除任务在 conversationTasks/userTasks 里的引用。
+     *
+     * <p>此前只 {@code list.remove(taskId)} 摘空内层列表，外层的 conversationId/userId
+     * 这个 key 永远留着一个空 {@link CopyOnWriteArrayList}——每个"处理过至少一个后台任务的
+     * 会话/用户"都会在这两张表里永久占一条，进程不重启就一直涨（见审计条目）。
+     * 用 {@code computeIfPresent} 把"摘元素"与"空了就摘 key"收进同一个按 key 加锁的原子操作，
+     * 与 {@link #registerTask} 的 {@code compute} 互斥，避免"判定为空、正要摘 key"时
+     * 恰好有新任务塞进同一个 list 却被一并摘掉的竞态。
+     */
     private void cleanupTaskReferences(String taskId, TaskInfo task) {
         if (task.getConversationId() != null) {
-            List<String> convTasks = conversationTasks.get(task.getConversationId());
-            if (convTasks != null) {
-                convTasks.remove(taskId);
-            }
+            conversationTasks.computeIfPresent(task.getConversationId(), (id, list) -> {
+                list.remove(taskId);
+                return list.isEmpty() ? null : list;
+            });
         }
         if (task.getUserId() != null) {
-            List<String> uTasks = userTasks.get(task.getUserId());
-            if (uTasks != null) {
-                uTasks.remove(taskId);
-            }
+            userTasks.computeIfPresent(task.getUserId(), (id, list) -> {
+                list.remove(taskId);
+                return list.isEmpty() ? null : list;
+            });
         }
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
+++ b/backend/src/main/java/com/checkba/service/ai/ContextAssemblerService.java
@@ -261,7 +261,7 @@ public class ContextAssemblerService {
                     String content = legalTools.read_document(item.getId());
                     // Truncate if too long
                     if (content != null && content.length() > maxCharsPerFile) {
-                        content = content.substring(0, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
+                        content = truncateAtCharBoundary(content, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
                     }
                     systemText.append("<file id=\"").append(item.getId())
                               .append("\" name=\"").append(attrSafe(item.getName())).append("\"><![CDATA[\n");
@@ -402,7 +402,7 @@ public class ContextAssemblerService {
                 // Truncate if too long
                 int maxCharsPerFile = contextProperties.getFiles().getMaxCharsPerFile();
                 if (content.length() > maxCharsPerFile) {
-                    content = content.substring(0, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
+                    content = truncateAtCharBoundary(content, maxCharsPerFile) + "\n... [TRUNCATED - File too long]";
                 }
 
                 systemText.append("<active_document id=\"").append(activeContext.getId())
@@ -565,6 +565,24 @@ public class ContextAssemblerService {
     }
 
     /**
+     * 按字符数截断，但不劈开 UTF-16 代理对（审计条目：char-based truncation of file/document
+     * content can split a surrogate pair）。{@code String.substring(0, n)} 是 UTF-16 code unit
+     * 索引，不是码点索引；n 如果恰好落在某个增补平面字符（如罕见的 CJK 扩展 B 人名字、emoji）
+     * 的高、低代理项中间，截断结果会以一个孤立代理项收尾——序列化成 UTF-8 时被替换成 U+FFFD
+     * 之类的字符，静默损坏注入上下文的最后一个字。命中就把截断点回退一位，让代理对整体保留
+     * 或整体舍弃，不会劈成两半。三处字符级截断（&lt;file&gt;/&lt;active_document&gt;/
+     * 内联正文缓存）共用这一个方法，避免各自实现、只补了一处漏了另外两处。
+     */
+    static String truncateAtCharBoundary(String content, int maxChars) {
+        if (maxChars > 0 && maxChars < content.length()
+                && Character.isHighSurrogate(content.charAt(maxChars - 1))
+                && Character.isLowSurrogate(content.charAt(maxChars))) {
+            maxChars -= 1;
+        }
+        return content.substring(0, maxChars);
+    }
+
+    /**
      * 文件名同样不可信：双引号能撑破 name="..." 属性，接着伪造出新的标签闭合与容器。
      */
     private static String attrSafe(String name) {
@@ -709,7 +727,7 @@ public class ContextAssemblerService {
         if (inline != null && !inline.isEmpty()) {
             if (inline.length() > MAX_INLINE_CONTENT_CHARS) {
                 // 超限正文不入缓存：缓存的内存上界按每条 200k 字符估算
-                return inline.substring(0, MAX_INLINE_CONTENT_CHARS)
+                return truncateAtCharBoundary(inline, MAX_INLINE_CONTENT_CHARS)
                         + "\n... [TRUNCATED - Inline content too long]";
             }
             inlineContentCache.put(conversationId, inline);

--- a/backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java
+++ b/backend/src/main/java/com/checkba/service/ai/DocumentCheckpointService.java
@@ -117,9 +117,29 @@ public class DocumentCheckpointService {
 
     /**
      * 新的一轮开始时清除上一轮快照（每轮一个独立检查点，语义不变：按 conversationId 整体清空）。
+     *
+     * <p>此前只摘掉内存里的登记条目，存储里的 blob 从来没人删过——checkpoints/ 前缀下的对象
+     * 只增不减，每一轮至少一次修改类文档工具调用就留一条永久占用（审计条目：Document checkpoint
+     * blobs are written to storage but never deleted）。这里连同 blob 一起删是安全的：
+     * {@link #restore} 只能恢复"当前还在内存 map 里"的快照，一旦这里把某个 conversationId
+     * 的条目摘掉，对应 blob 已经彻底不可达——没有任何代码路径还能把它读回来，不是「提前删了
+     * 还有用的东西」，是删一个已经没用的东西。删除失败只记日志：这是清理动作，
+     * 不能因为存储抖动挡住新一轮的正常执行。
      */
     public void clearForNewRun(String conversationId) {
-        checkpoints.remove(conversationId);
+        Map<Long, Checkpoint> perFile = checkpoints.remove(conversationId);
+        if (perFile == null || perFile.isEmpty()) {
+            return;
+        }
+        StorageService storage = storageServiceFactory.getStorageService();
+        for (Checkpoint cp : perFile.values()) {
+            try {
+                storage.delete(cp.checkpointKey());
+            } catch (Exception e) {
+                log.warn("Failed to delete stale document checkpoint blob: conv={}, fileId={}, key={}",
+                        conversationId, cp.fileId(), cp.checkpointKey(), e);
+            }
+        }
     }
 
     public boolean hasCheckpoint(String conversationId) {

--- a/backend/src/main/java/com/checkba/service/ai/PdfEditService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PdfEditService.java
@@ -136,8 +136,33 @@ public class PdfEditService {
         }
     }
 
-    /** 全文提取为 markdown（转 Word 用）。返回 null 表示无文本层（扫描件）。 */
-    public String extractMarkdown(Path pdfPath) {
+    /**
+     * 提取结果：正文 markdown，以及「这份 PDF 看起来是扫描件」的判断。
+     *
+     * <p>两者分开返回而不是用 null 表示扫描件：判成扫描件时上游会去走 OCR，
+     * 而 OCR 可能失败（组件没装/服务没起）。手里同时留着已经提取到的文本层，
+     * OCR 失败还能回退过去，不至于把一份本来能转的文档变成一句「请去装 MinerU」。
+     */
+    public record ExtractedText(String markdown, boolean looksScanned) {}
+
+    /** 单页字符数低于它就按扫描件处理，见 {@link #extractMarkdown} 的判据说明。 */
+    static final int MIN_CHARS_PER_PAGE = 100;
+
+    /**
+     * 全文提取为 markdown（转 Word 用）。
+     *
+     * <p>「是不是扫描件」的判据从「全文不足 20 字」改成**按页密度**：
+     * 一份几十页的扫描件，每页盖一个 Bates 章或印一行页眉，全文轻松过 20 字，
+     * 于是被判成文本件走结构化转换——产出的 Word 里只有那些章和页眉，
+     * 正文（图像）一个字都没有，而用户看到的是「转换成功」。
+     * 中文法律文书正文一页在 700-1500 字量级，只剩页眉页码的页在 10-40 字量级，
+     * 100 字/页落在中间且偏向 OCR 一侧。
+     *
+     * <p>刻意偏向 OCR：判错方向的代价不对称——扫描件被当文本件是**内容静默丢光**，
+     * 文本件被当扫描件最多是慢一点（OCR 照样读得出渲染后的字），
+     * 而且 OCR 失败时上游还会回退到这里提取到的文本。
+     */
+    public ExtractedText extractMarkdown(Path pdfPath) {
         try (PDDocument doc = load(pdfPath)) {
             StringBuilder md = new StringBuilder();
             int totalChars = 0;
@@ -152,8 +177,9 @@ public class PdfEditService {
                 if (md.length() > 0) md.append("\n\n");
                 md.append(linesToMarkdown(text));
             }
-            if (totalChars < 20) return null;
-            return md.toString();
+            int pages = Math.max(1, doc.getNumberOfPages());
+            boolean looksScanned = totalChars < 20 || totalChars < MIN_CHARS_PER_PAGE * pages;
+            return new ExtractedText(md.toString(), looksScanned);
         } catch (IOException e) {
             throw new PdfEditException("读取 PDF 失败: " + e.getMessage());
         }

--- a/backend/src/main/java/com/checkba/service/ai/PptxServiceClient.java
+++ b/backend/src/main/java/com/checkba/service/ai/PptxServiceClient.java
@@ -291,9 +291,20 @@ public class PptxServiceClient {
                 return null;
             }
             
-            JSONObject status = getTaskStatus(projectId, taskId);
+            JSONObject status;
+            try {
+                status = getTaskStatus(projectId, taskId);
+            } catch (Exception e) {
+                // 单次瞬时网络错误（连接被断/一次 502/503）不该直接掀翻整条正在跑的多阶段生成——
+                // 底层任务在 pptx-service 那边可能还在正常继续，只是这一次轮询请求本身失败了。
+                // 跳过这一轮，POLL_INTERVAL_MS 后再试；连续失败到耗尽 MAX_POLL_ATTEMPTS
+                // 会走既有的超时兜底（return null），不会无限重试（审计条目）。
+                log.warn("Task {} status poll failed transiently (attempt {}/{}), will retry: {}",
+                        taskId, i + 1, MAX_POLL_ATTEMPTS, e.getMessage());
+                continue;
+            }
             String taskStatus = status.getStr("status");
-            
+
             if ("COMPLETED".equals(taskStatus)) {
                 // 额外验证：检查是否有实际完成的项目
                 JSONObject progress = status.getJSONObject("progress");
@@ -372,8 +383,17 @@ public class PptxServiceClient {
      * @return 保存的文件路径
      */
     public String downloadPptx(String downloadUrl, String localPath) {
+        if (downloadUrl == null || downloadUrl.isBlank()) {
+            // 调用方从任务状态的 progress 对象里读 download_url——那个对象存在（不会走
+            // null-progress 兜底分支）但恰好没带这个字段时，此前会直接拼出
+            // baseUrl + "null" 去请求，真正发生的是 404，报出来的是
+            // "Failed to download PPTX: HTTP 404"，看着像路由/网络问题，
+            // 实际是响应压根没给 download_url（审计条目）。在真正发请求之前单独识别出来。
+            throw new RuntimeException("Failed to download PPTX: task response is missing download_url "
+                    + "(the export/conversion task may not have finished writing its result yet)");
+        }
         log.info("Downloading PPTX from {} to {}", downloadUrl, localPath);
-        
+
         String fullUrl = baseUrl + downloadUrl;
         
         HttpResponse resp = HttpRequest.get(fullUrl)
@@ -788,9 +808,17 @@ public class PptxServiceClient {
                 return null;
             }
             
-            JSONObject status = getTaskStatus(projectId, taskId);
+            JSONObject status;
+            try {
+                status = getTaskStatus(projectId, taskId);
+            } catch (Exception e) {
+                // 同 waitForTask：单次瞬时网络错误不该掀翻整条多阶段生成，跳过这一轮再试。
+                log.warn("Task {} status poll failed transiently (attempt {}/{}), will retry: {}",
+                        taskId, i + 1, MAX_POLL_ATTEMPTS, e.getMessage());
+                continue;
+            }
             String taskStatus = status.getStr("status");
-            
+
             // 计算并报告进度
             JSONObject taskProgress = status.getJSONObject("progress");
             if (taskProgress != null && progressCallback != null) {

--- a/backend/src/main/java/com/checkba/service/ai/TodoListService.java
+++ b/backend/src/main/java/com/checkba/service/ai/TodoListService.java
@@ -138,15 +138,25 @@ public class TodoListService {
 
     /**
      * 供编排器在每次工具执行后注入的"防走神"摘要（Claude Code system-reminder 模式）。
-     * 清单不存在或已全部完成时返回 null（不注入）。
+     * 清单不存在或已无待办事项（完成或失败均算数）时返回 null（不注入）。
+     *
+     * <p><b>failed 是终态，要和 completed 一起算"done"</b>：此前只认 completed，
+     * 一个 failed 项永远不会自己变成 completed，于是 {@code done < todos.size()} 恒成立，
+     * 这条提醒永远关不掉，且摘要正文只列 in_progress/pending，完全不提 failed 项——
+     * 模型收到的是一句问不出所以然的"还没做完"，看不出到底卡在哪一项（审计条目）。
      */
     public String reminder(String conversationId) {
         List<TodoItem> todos = currentList(conversationId);
         if (todos.isEmpty()) return null;
         long done = todos.stream().filter(t -> "completed".equals(t.status())).count();
-        if (done == todos.size()) return null;
+        List<String> failed = todos.stream().filter(t -> "failed".equals(t.status()))
+                .map(TodoItem::content).toList();
+        if (done + failed.size() == todos.size()) return null;
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("[任务清单状态 %d/%d 完成]", done, todos.size()));
+        if (!failed.isEmpty()) {
+            sb.append(" 已失败：").append(String.join("、", failed)).append("。");
+        }
         todos.stream().filter(t -> "in_progress".equals(t.status())).findFirst()
                 .ifPresent(t -> sb.append(" 进行中：").append(t.content()).append("。"));
         List<String> pending = todos.stream().filter(t -> "pending".equals(t.status()))

--- a/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceItem.java
+++ b/backend/src/main/java/com/checkba/service/ai/evidence/EvidenceItem.java
@@ -48,11 +48,32 @@ public record EvidenceItem(
         }
         provenance = provenance == null ? List.of() : List.copyOf(provenance);
         if (excerpt != null && excerpt.length() > MAX_EXCERPT_LENGTH) {
-            excerpt = excerpt.substring(0, MAX_EXCERPT_LENGTH);
+            excerpt = truncateAtCharBoundary(excerpt, MAX_EXCERPT_LENGTH);
         }
     }
 
     private static boolean isBlank(String s) {
         return s == null || s.isBlank();
+    }
+
+    /**
+     * 按字符数截断，但不劈开 UTF-16 代理对（审计条目：Excerpt truncation cuts by UTF-16 char
+     * index and can split a surrogate pair, corrupting the tail of an evidence excerpt）。
+     * {@code String.substring(0, n)} 是 UTF-16 code unit 索引，不是码点索引；n 如果恰好落在
+     * 某个增补平面字符（emoji、罕见 CJK 扩展 B 人名字/公司名字）的高、低代理项中间，截断结果
+     * 会以一个孤立代理项收尾，序列化成 UTF-8 时被替换成 U+FFFD 之类的字符，
+     * 律师看到的证据摘录末尾就是一个乱码。命中就把截断点回退一位，代理对整体舍弃。
+     *
+     * <p>与 {@code ContextAssemblerService.truncateAtCharBoundary} 同一处理逻辑、
+     * 同一处审计条目类别的两处之一，这里不引入跨包依赖单独复制一份——本类是不带其它依赖的
+     * 稳定契约值对象，不该为了几行字符串处理反过来依赖一个大型 Spring 服务类。
+     */
+    private static String truncateAtCharBoundary(String content, int maxChars) {
+        if (maxChars > 0 && maxChars < content.length()
+                && Character.isHighSurrogate(content.charAt(maxChars - 1))
+                && Character.isLowSurrogate(content.charAt(maxChars))) {
+            maxChars -= 1;
+        }
+        return content.substring(0, maxChars);
     }
 }

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemCellExtractor.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemCellExtractor.java
@@ -113,36 +113,60 @@ public class MemCellExtractor {
      * @param messages 对话消息列表
      * @return 提取的 MemCell 列表
      */
-    public List<MemoryEntry> extractMemCells(Long projectId, String conversationId, 
+    public List<MemoryEntry> extractMemCells(Long projectId, String conversationId,
                                               List<ChatMessage> messages) {
+        return extractMemCellsInternal(projectId, conversationId, messages).entries();
+    }
+
+    /**
+     * 与 {@link #extractMemCells} 相同的抽取流程，额外带上"这一轮 LLM 响应是否解析失败"的信号，
+     * 供 {@link #extractAndSave} 把它体现在返回值里。此前 LLM JSON 解析失败与「模型确认无可提取信息」
+     * 都会静默退化成同一个空列表，调用方（记忆管线）无从区分——见审计条目。
+     */
+    private ExtractionOutcome extractMemCellsInternal(Long projectId, String conversationId,
+                                                        List<ChatMessage> messages) {
         log.info("MemCell extraction started: projectId={}, conversationId={}, messageCount={}",
                 projectId, conversationId, messages.size());
-        
+
         if (messages == null || messages.isEmpty()) {
-            return Collections.emptyList();
+            return new ExtractionOutcome(Collections.emptyList(), false);
         }
-        
+
         // 1. 准备对话内容
         String conversationContent = buildConversationContent(messages);
-        
+
         // 2. 并行获取法律关键信息（用于补充和验证）
-        List<LegalInfoProtector.ProtectedSegment> legalSegments = 
+        List<LegalInfoProtector.ProtectedSegment> legalSegments =
                 legalInfoProtector.markProtectedInfo(conversationContent);
-        
+
         // 3. 使用 LLM 提取 MemCell（projectId/conversationId 一路带下去做记账归属）
-        List<MemCellData> llmExtracted = extractWithLLM(conversationContent, projectId, conversationId);
-        
+        LlmOutcome llmOutcome = extractWithLLM(conversationContent, projectId, conversationId);
+        List<MemCellData> llmExtracted = llmOutcome.cells();
+
         // 4. 合并法律关键信息到提取结果
         List<MemCellData> merged = mergeWithLegalInfo(llmExtracted, legalSegments, conversationContent);
-        
+
         // 5. 转换为 MemoryEntry 并去重
         List<MemoryEntry> entries = convertToMemoryEntries(merged, projectId, conversationId);
-        
+
         log.info("MemCell extraction completed: extracted {} cells (LLM: {}, Legal: {})",
-                entries.size(), llmExtracted.size(), 
+                entries.size(), llmExtracted.size(),
                 merged.size() - llmExtracted.size());
-        
-        return entries;
+
+        return new ExtractionOutcome(entries, llmOutcome.parseFailed());
+    }
+
+    /** {@link #extractMemCellsInternal} 的返回包装：抽取到的记忆 + LLM 响应是否解析失败。 */
+    private record ExtractionOutcome(List<MemoryEntry> entries, boolean llmParseFailed) {}
+
+    /** {@link #extractWithLLM} 的返回包装：解析出的 MemCell + 是否因解析失败而放弃。 */
+    private record LlmOutcome(List<MemCellData> cells, boolean parseFailed) {
+        static LlmOutcome ok(List<MemCellData> cells) {
+            return new LlmOutcome(cells, false);
+        }
+        static LlmOutcome failed() {
+            return new LlmOutcome(Collections.emptyList(), true);
+        }
     }
 
     /**
@@ -187,7 +211,8 @@ public class MemCellExtractor {
     /**
      * 使用 LLM 提取 MemCell（辅助模型档，token 落 token_usage）
      */
-    private List<MemCellData> extractWithLLM(String conversationContent, Long projectId, String conversationId) {
+    private LlmOutcome extractWithLLM(String conversationContent, Long projectId, String conversationId) {
+        String responseText;
         try {
             ChatLanguageModel model = chatModelFactory.getAuxChatModel();
 
@@ -199,14 +224,20 @@ public class MemCellExtractor {
             );
             recordUsage(response, projectId, conversationId);
 
-            String responseText = response.content().text();
+            responseText = response.content().text();
             log.debug("LLM extraction response length: {}", responseText.length());
-            
-            return parseMemCellResponse(responseText);
-            
         } catch (Exception e) {
             log.error("LLM MemCell extraction failed: {}", e.getMessage(), e);
-            return Collections.emptyList();
+            return LlmOutcome.failed();
+        }
+
+        try {
+            return LlmOutcome.ok(parseMemCellResponse(responseText));
+        } catch (MemCellParseException e) {
+            // 与"模型明确认为无可提取信息"（parseMemCellResponse 正常返回空列表）区分开：
+            // 这里是响应解析失败，必须在结果里看得出来，不能悄悄退化成同一个空列表。
+            log.warn("MemCell JSON 解析失败，本轮不计入「确认无可提取信息」: {}", e.getMessage(), e);
+            return LlmOutcome.failed();
         }
     }
 
@@ -230,60 +261,81 @@ public class MemCellExtractor {
     }
 
     /**
-     * 解析 LLM 返回的 MemCell JSON
+     * 解析 LLM 返回的 MemCell JSON。
+     *
+     * <p>解析失败一律抛 {@link MemCellParseException}，绝不返回空列表——空列表只保留给
+     * "memcells 是合法空数组"这一种确认为空的情形。此前无论是找不到 JSON、JSON 本身解析出错，
+     * 还是 memcells 字段缺失/形态不对（如被截断成对象），全部吞进同一个 catch 里退化成空列表，
+     * 调用方（乃至最终的记忆管线）拿到的结果与"这轮对话确实没有可记的东西"完全无法区分。
+     *
+     * <p>包内可见：供测试直接验证"解析失败"与"确认为空"两条路径互不相同，不必真的打一次 LLM。
      */
-    private List<MemCellData> parseMemCellResponse(String responseText) {
-        List<MemCellData> cells = new ArrayList<>();
-        
-        try {
-            // 提取 JSON 块
-            Pattern jsonPattern = Pattern.compile("```json\\s*([\\s\\S]*?)\\s*```");
-            Matcher matcher = jsonPattern.matcher(responseText);
-            
-            String jsonStr = null;
-            if (matcher.find()) {
-                jsonStr = matcher.group(1);
-            } else {
-                // 尝试直接解析（如果响应本身就是 JSON）
-                int start = responseText.indexOf("{");
-                int end = responseText.lastIndexOf("}");
-                if (start >= 0 && end > start) {
-                    jsonStr = responseText.substring(start, end + 1);
-                }
+    List<MemCellData> parseMemCellResponse(String responseText) {
+        // 提取 JSON 块
+        Pattern jsonPattern = Pattern.compile("```json\\s*([\\s\\S]*?)\\s*```");
+        Matcher matcher = jsonPattern.matcher(responseText);
+
+        String jsonStr = null;
+        if (matcher.find()) {
+            jsonStr = matcher.group(1);
+        } else {
+            // 尝试直接解析（如果响应本身就是 JSON）
+            int start = responseText.indexOf("{");
+            int end = responseText.lastIndexOf("}");
+            if (start >= 0 && end > start) {
+                jsonStr = responseText.substring(start, end + 1);
             }
-            
-            if (jsonStr == null || jsonStr.isEmpty()) {
-                log.warn("No JSON found in LLM response");
-                return cells;
-            }
-            
-            // 使用简单的 JSON 解析（避免引入额外依赖）
-            cn.hutool.json.JSONObject json = cn.hutool.json.JSONUtil.parseObj(jsonStr);
-            cn.hutool.json.JSONArray memcellsArray = json.getJSONArray("memcells");
-            
-            if (memcellsArray != null) {
-                for (int i = 0; i < memcellsArray.size(); i++) {
-                    cn.hutool.json.JSONObject cellObj = memcellsArray.getJSONObject(i);
-                    MemCellData cell = new MemCellData();
-                    cell.setType(cellObj.getStr("type", "FACT"));
-                    cell.setKey(cellObj.getStr("key", ""));
-                    cell.setValue(cellObj.getStr("value", ""));
-                    cell.setImportance(cellObj.getDouble("importance", 0.7));
-                    cell.setProtected(cellObj.getBool("protected", false));
-                    
-                    if (!cell.getValue().isEmpty()) {
-                        cells.add(cell);
-                    }
-                }
-            }
-            
-            log.debug("Parsed {} MemCells from LLM response", cells.size());
-            
-        } catch (Exception e) {
-            log.error("Failed to parse MemCell JSON: {}", e.getMessage());
         }
-        
+
+        if (jsonStr == null || jsonStr.isEmpty()) {
+            // 响应里压根没有花括号包裹的内容：不是"提取到空数组"，是根本没法解析，两者不能等价
+            throw new MemCellParseException("LLM 响应中未找到 JSON 内容");
+        }
+
+        cn.hutool.json.JSONObject json;
+        cn.hutool.json.JSONArray memcellsArray;
+        try {
+            // 使用简单的 JSON 解析（避免引入额外依赖）
+            json = cn.hutool.json.JSONUtil.parseObj(jsonStr);
+            memcellsArray = json.getJSONArray("memcells");
+        } catch (Exception e) {
+            throw new MemCellParseException("MemCell JSON 解析失败: " + e.getMessage(), e);
+        }
+
+        if (memcellsArray == null) {
+            // memcells 键缺失，或值不是数组形态（例如被截断成 "memcells": {...} 对象）——
+            // 同样是解析失败，不能等同于模型显式返回的 {"memcells": []}
+            throw new MemCellParseException("memcells 字段缺失或不是数组（可能是截断响应）");
+        }
+
+        List<MemCellData> cells = new ArrayList<>();
+        for (int i = 0; i < memcellsArray.size(); i++) {
+            cn.hutool.json.JSONObject cellObj = memcellsArray.getJSONObject(i);
+            MemCellData cell = new MemCellData();
+            cell.setType(cellObj.getStr("type", "FACT"));
+            cell.setKey(cellObj.getStr("key", ""));
+            cell.setValue(cellObj.getStr("value", ""));
+            cell.setImportance(cellObj.getDouble("importance", 0.7));
+            cell.setProtected(cellObj.getBool("protected", false));
+
+            if (!cell.getValue().isEmpty()) {
+                cells.add(cell);
+            }
+        }
+
+        log.debug("Parsed {} MemCells from LLM response", cells.size());
         return cells;
+    }
+
+    /** MemCell JSON 解析失败的信号异常：与"LLM 明确返回空数组"区分开，不是普通的运行时异常。 */
+    static final class MemCellParseException extends RuntimeException {
+        MemCellParseException(String message) {
+            super(message);
+        }
+
+        MemCellParseException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 
     /**
@@ -386,11 +438,15 @@ public class MemCellExtractor {
     }
 
     /**
-     * 一站式提取并保存 MemCell
+     * 一站式提取并保存 MemCell。
+     *
+     * @return 实际保存的条数；{@code 0} = 正常跑完但确实没有可提取/可保存的内容；
+     *         {@code -1} = 本轮 LLM 响应解析失败（不是"确认为空"，调用方不应当作与 0 相同的信号处理）。
      */
     public int extractAndSave(Long projectId, String conversationId, List<ChatMessage> messages) {
-        List<MemoryEntry> memCells = extractMemCells(projectId, conversationId, messages);
-        return saveMemCells(memCells);
+        ExtractionOutcome outcome = extractMemCellsInternal(projectId, conversationId, messages);
+        int saved = saveMemCells(outcome.entries());
+        return saved == 0 && outcome.llmParseFailed() ? -1 : saved;
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryManager.java
@@ -343,6 +343,20 @@ public class MemoryManager {
         return memoryEntryRepository.findBySourceFileIdOrderByImportanceScoreDesc(sourceFileId);
     }
 
+    /**
+     * 获取绑定到某个对话的记忆（scope=conversation）。
+     *
+     * 与 {@link #retrieveFileMemories} 同理：query_memory/search_knowledge_base/deep_search
+     * 此前完全不认 scope，file/conversation 作用域保存的记忆只能靠关键词/语义检索"运气好"才捞得到——
+     * 这里提供一条确定性的按 scope 取值通路，供工具层在调用方明确指定 scope 时兜底合并进结果。
+     */
+    public List<MemoryEntry> retrieveConversationMemories(String conversationId) {
+        if (conversationId == null || conversationId.isBlank()) {
+            return Collections.emptyList();
+        }
+        return memoryEntryRepository.findByConversationIdOrderByCreatedAtDesc(conversationId);
+    }
+
     // ==================== RRF 混合检索 ====================
 
     /**
@@ -622,24 +636,40 @@ public class MemoryManager {
         return projectMemoryRepository.findByProjectId(projectId);
     }
 
+    /** find-then-insert 竞态的进程内互斥锁，见 {@link #saveProjectMemory}。 */
+    private final Object projectMemorySaveLock = new Object();
+
     /**
-     * 保存或更新项目记忆
+     * 保存或更新项目记忆。
+     *
+     * <p><b>并发红线</b>：{@code project_id} 上有 {@code unique} 约束，而这里是先查后写的
+     * find-then-insert：两个并发线程（同一项目的两轮对话几乎同时跑完记忆管线）都可能在对方提交前
+     * 读到"还没有这一行"，于是都走 INSERT，后提交的那个直接撞唯一约束抛异常，
+     * 它这一轮抽取出的字段（legalRefs/parties/transactionAmount 等）被整体丢弃——不是"没有变化"，
+     * 是"这次更新完全没发生"。不能加 {@code @Version} 列做乐观锁（不引入新的数据库列），
+     * 这里改用进程内锁把"查 + 决定 insert/update + 写"整段收窄成互斥：同一时刻只有一个线程能
+     * 穿过去，后来者一定能看到前者已经写完的行，从而落到 UPDATE 分支而不是再抢一次 INSERT。
+     * 代价是同一 JVM 内对本方法的调用退化为串行（调用频率低——每轮对话一次，可接受）；
+     * 多实例横向扩容时锁不跨进程，但这已经把审计条目里描述的竞态窗口从"一次完整的 DB 往返"
+     * 收窄到可忽略的量级。
      */
     @Transactional
     public ProjectMemory saveProjectMemory(ProjectMemory projectMemory) {
-        log.info("Saving project memory for projectId={}", projectMemory.getProjectId());
-        
-        ProjectMemory existing = projectMemoryRepository
-                .findByProjectId(projectMemory.getProjectId())
-                .orElse(null);
-        
-        if (existing != null) {
-            // 更新现有记录
-            projectMemory.setId(existing.getId());
-            projectMemory.setCreatedAt(existing.getCreatedAt());
+        synchronized (projectMemorySaveLock) {
+            log.info("Saving project memory for projectId={}", projectMemory.getProjectId());
+
+            ProjectMemory existing = projectMemoryRepository
+                    .findByProjectId(projectMemory.getProjectId())
+                    .orElse(null);
+
+            if (existing != null) {
+                // 更新现有记录
+                projectMemory.setId(existing.getId());
+                projectMemory.setCreatedAt(existing.getCreatedAt());
+            }
+
+            return projectMemoryRepository.save(projectMemory);
         }
-        
-        return projectMemoryRepository.save(projectMemory);
     }
 
     /**
@@ -680,17 +710,23 @@ public class MemoryManager {
         return userMemoryRepository.findByUserId(userId);
     }
 
+    /** find-then-insert 竞态的进程内互斥锁，同 {@link #projectMemorySaveLock}，理由见 {@link #saveProjectMemory}。 */
+    private final Object userMemorySaveLock = new Object();
+
     /**
-     * 保存用户记忆
+     * 保存用户记忆。同 {@link #saveProjectMemory}，{@code user_id} 上也是 unique 约束 +
+     * find-then-insert，一样会被并发撞出丢更新，一样用进程内锁收窄竞态窗口。
      */
     @Transactional
     public UserMemory saveUserMemory(UserMemory userMemory) {
-        UserMemory existing = userMemoryRepository.findByUserId(userMemory.getUserId()).orElse(null);
-        if (existing != null) {
-            userMemory.setId(existing.getId());
-            userMemory.setCreatedAt(existing.getCreatedAt());
+        synchronized (userMemorySaveLock) {
+            UserMemory existing = userMemoryRepository.findByUserId(userMemory.getUserId()).orElse(null);
+            if (existing != null) {
+                userMemory.setId(existing.getId());
+                userMemory.setCreatedAt(existing.getCreatedAt());
+            }
+            return userMemoryRepository.save(userMemory);
         }
-        return userMemoryRepository.save(userMemory);
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
+++ b/backend/src/main/java/com/checkba/service/ai/memory/MemoryPipelineService.java
@@ -100,19 +100,31 @@ public class MemoryPipelineService {
 
         // 2. 提取并更新项目记忆
         if (projectIdLong != null) {
+            // 2.1 项目级记忆（正则提取，低成本）——单独一个 try/catch：这一步出错（比如并发写
+            // ProjectMemory 撞了唯一约束）不该连带跳过下面更贵、也更值钱的 LLM MemCell 抽取；
+            // 此前两步共用一个 try 块，2.1 一抛异常，2.2 整轮都不会执行，且日志上看不出区别。
             try {
-                // 2.1 项目级记忆（正则提取，低成本）
                 projectMemoryExtractor.extractAndUpdateProjectMemory(projectIdLong, messages);
+            } catch (Exception e) {
+                log.error("Failed to extract project memory (regex step): {}", e.getMessage(), e);
+            }
 
-                // 2.2 MemCell 原子记忆（LLM 提取，控制触发频率）
-                if (messages.size() >= MEMCELL_THRESHOLD) {
+            // 2.2 MemCell 原子记忆（LLM 提取，控制触发频率）——即便 2.1 刚刚失败也要照常跑
+            if (messages.size() >= MEMCELL_THRESHOLD) {
+                try {
                     int memCellCount = memCellExtractor.extractAndSave(projectIdLong, conversationId, messages);
                     if (memCellCount > 0) {
                         log.info("MemCell extraction completed: saved {} atomic memory units", memCellCount);
+                    } else if (memCellCount < 0) {
+                        // -1 是 MemCellExtractor 特意区分出来的"本轮 LLM 响应解析失败"信号，
+                        // 不能当成 0（=正常跑完、确实没有可提取的内容）一样悄悄不吭声。
+                        log.warn("MemCell extraction failed to parse this turn's LLM response "
+                                + "(conversationId={}); treated as a failure, not as \"nothing worth remembering\"",
+                                conversationId);
                     }
+                } catch (Exception e) {
+                    log.error("Failed to extract MemCell memory: {}", e.getMessage(), e);
                 }
-            } catch (Exception e) {
-                log.error("Failed to extract project memory: {}", e.getMessage(), e);
             }
         }
 

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillRegistry.java
@@ -67,6 +67,14 @@ public class SkillRegistry {
     private final Map<String, SkillDefinition> skills = new LinkedHashMap<>();
 
     /**
+     * 最近一次扫描里，因异常（最典型是 skill.yml/prompt 文件不是 UTF-8 编码）而没能注册成功的
+     * 目录名 -> 错误摘要。register() 的 catch 此前只 log.error 一行——getSkills() 结果里
+     * "解析出错"与"这个目录压根没有 skill.yml"两种情况完全看不出区别，管理页/排障者除了翻
+     * 后端日志没有别的办法。每次 {@link #scan()} 开头清空重建，只反映最近一次扫描的状态。
+     */
+    private final Map<String, String> loadErrors = new ConcurrentHashMap<>();
+
+    /**
      * 被禁用 skill id 集合（内存缓存，与 system_setting 同步）。
      *
      * volatile 而非 final：重载（{@link #loadDisabledState}）走"读完新名单再整体换引用"，
@@ -141,6 +149,14 @@ public class SkillRegistry {
     /** 全部已注册 skill（含被禁用的，供管理页展示） */
     public synchronized List<SkillDefinition> getSkills() {
         return new ArrayList<>(skills.values());
+    }
+
+    /**
+     * 最近一次扫描里加载失败的目录名 -> 错误摘要，让"解析出错"与"没有这个 skill"能区分开
+     * （见 {@link #loadErrors} 字段注释）。目录名不是 skill id——解析失败时往往连 id 都没读出来。
+     */
+    public Map<String, String> getLoadErrors() {
+        return java.util.Collections.unmodifiableMap(loadErrors);
     }
 
     public synchronized Optional<SkillDefinition> getSkill(String id) {
@@ -277,6 +293,8 @@ public class SkillRegistry {
     // ==================== 扫描与解析 ====================
 
     private void scan() {
+        // 只反映"最近一次扫描"的状态：上一轮的加载失败如果这次已经修好，不该继续挂着。
+        loadErrors.clear();
         // 1. 可写目录（广场安装落点）。**先扫它**：id 去重是"先扫到优先"，
         //    这样广场装的同 id skill 能覆盖随发行版分发的那份——内置 skill 出了问题
         //    可以走广场热修，不必等下一个客户端版本。被盖住的会打日志。
@@ -337,8 +355,20 @@ public class SkillRegistry {
                         sourcePluginId != null ? ", from plugin " + sourcePluginId : "");
             }
         } catch (Exception e) {
+            // "出错"与"本来就没有"要能分得开：不只 log，同时把原因记进 loadErrors——
+            // getSkills() 结果里少了这个 skill 时，管理页/排障者能查到具体是哪个目录、为什么。
+            String reason = isEncodingFailure(e)
+                    ? "文件编码不是 UTF-8，无法解析: " + e.getMessage()
+                    : String.valueOf(e.getMessage());
+            loadErrors.put(skillDir.getName(), reason);
             log.error("Failed to load skill dir {}, skip: {}", skillDir, e.getMessage());
         }
+    }
+
+    /** {@code Files.readString} 对非 UTF-8 字节抛的 {@code MalformedInputException} 是它的子类。 */
+    private static boolean isEncodingFailure(Throwable e) {
+        return e instanceof java.nio.charset.CharacterCodingException
+                || e.getCause() instanceof java.nio.charset.CharacterCodingException;
     }
 
     /**
@@ -443,11 +473,29 @@ public class SkillRegistry {
         return v == null ? null : String.valueOf(v);
     }
 
-    /** SnakeYAML 对 true/false 字面量已经解析成 Boolean；容错处理字符串写法 ("false"/"true") */
+    /**
+     * SnakeYAML 对裸 true/false 字面量已经解析成 Boolean；这里容错处理"带引号写成字符串"的写法。
+     *
+     * <p>{@code Boolean.parseBoolean} 对除大小写不敏感的 "true" 之外的任何字符串都返回 false——
+     * 作者写 {@code enabled_by_default: "yes"} 这种带引号的真值会被悄悄当成假值，
+     * 於是这个 skill 在第一次扫描时就被 {@link #seedDefaultDisabledIfNeeded} 默认关闭，
+     * 且没有任何警告（审计条目）。这里显式识别常见真/假值写法；认不出的字符串既不当真也不当假，
+     * 返回 null 让调用方保留 {@link SkillDefinition#isEnabledByDefault()} 的安全默认值 true，
+     * 而不是被一个没人预期的假值静默改写，同时打一条 WARN 留痕。
+     */
     private static Boolean asBoolean(Object v) {
         if (v == null) return null;
         if (v instanceof Boolean b) return b;
-        return Boolean.parseBoolean(String.valueOf(v));
+        String s = String.valueOf(v).trim().toLowerCase();
+        return switch (s) {
+            case "true", "yes", "on", "1" -> Boolean.TRUE;
+            case "false", "no", "off", "0" -> Boolean.FALSE;
+            default -> {
+                log.warn("skill.yml 的 enabled_by_default 值 '{}' 无法识别为布尔值，"
+                        + "按未设置处理（保留默认 true），不要静默当成 false", v);
+                yield null;
+            }
+        };
     }
 
     private static List<String> asStringList(Object v) {

--- a/backend/src/main/java/com/checkba/service/ai/skill/SkillRouter.java
+++ b/backend/src/main/java/com/checkba/service/ai/skill/SkillRouter.java
@@ -88,10 +88,35 @@ public class SkillRouter {
      * "关键词猜的"——这条语义从单选时代（pinnedSkillId 优先于触发词匹配）延续下来。
      *
      * <p>只存 id 不存定义：registry 可能在两轮之间 rescan，存定义会拿到已经不存在的旧对象。
+     *
+     * <p><b>无界增长</b>：只有"这一轮没有任何 skill 生效"才会 {@code remove}——一个会话只要
+     * 最后一轮命中过 skill，条目就永久留着，进程不重启就一直涨（审计条目：activeByConversation
+     * never evicts...）。value 额外带上激活时刻，配 {@link #purgeStaleActivations()} 做惰性过期；
+     * 24 小时对齐本仓库同类"内存登记簿"的既有先例（{@code ConversationIssuanceService} 24h 过期）——
+     * 会话超过这么久没有新一轮 activateForTurn，下次用户回来发消息时会重新触发一次，不丢功能。
      */
-    private final Map<String, List<ActiveEntry>> activeByConversation = new ConcurrentHashMap<>();
+    private final Map<String, ActivationRecord> activeByConversation = new ConcurrentHashMap<>();
+
+    /** 过期窗口：见 {@link #activeByConversation} 字段注释。 */
+    private static final long STALE_ACTIVATION_MILLIS = 24L * 60 * 60 * 1000;
+
+    /** 时间源，测试可注入固定值以避免真实等待 24 小时。 */
+    private java.util.function.LongSupplier clockMillis = System::currentTimeMillis;
+
+    void setClockMillis(java.util.function.LongSupplier clockMillis) {
+        this.clockMillis = clockMillis;
+    }
+
+    /** 供测试断言登记簿大小（不下沉成生产代码路径）。 */
+    int activeByConversationSize() {
+        return activeByConversation.size();
+    }
 
     private record ActiveEntry(String skillId, String source) {
+    }
+
+    /** {@link #activeByConversation} 的 value：本轮生效集合 + 激活时刻，供惰性过期判断。 */
+    private record ActivationRecord(List<ActiveEntry> entries, long activatedAtMillis) {
     }
 
     /**
@@ -192,9 +217,30 @@ public class SkillRouter {
         List<ActiveEntry> entries = active.entrySet().stream()
                 .map(e -> new ActiveEntry(e.getKey(), e.getValue()))
                 .toList();
-        activeByConversation.put(conversationId, entries);
+        activeByConversation.put(conversationId, new ActivationRecord(entries, clockMillis.getAsLong()));
         log.info("Skills activated for conversation {}: {}", conversationId, active);
         recordActivation(conversationId, activeSkills(conversationId));
+    }
+
+    /**
+     * 清理超过 {@link #STALE_ACTIVATION_MILLIS} 未再激活的会话条目——见
+     * {@link #activeByConversation} 字段注释的无界增长问题。与 {@code TodoListService.purgeStaleLists}
+     * 同款节奏（每日一次 + 15 分钟初始延迟错峰）。
+     */
+    @org.springframework.scheduling.annotation.Scheduled(fixedDelay = 24L * 60 * 60 * 1000,
+            initialDelay = 15L * 60 * 1000)
+    public void purgeStaleActivations() {
+        try {
+            long cutoff = clockMillis.getAsLong() - STALE_ACTIVATION_MILLIS;
+            int before = activeByConversation.size();
+            activeByConversation.entrySet().removeIf(e -> e.getValue().activatedAtMillis() < cutoff);
+            int removed = before - activeByConversation.size();
+            if (removed > 0) {
+                log.info("清理冷 skill 激活记录 {} 条", removed);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to purge stale skill activations", e);
+        }
     }
 
     /**
@@ -224,7 +270,8 @@ public class SkillRouter {
      * 注入前复查可用性——两轮之间可能被管理员停用。
      */
     public List<ActiveSkill> activeSkills(String conversationId) {
-        List<ActiveEntry> entries = activeByConversation.get(conversationId);
+        ActivationRecord record = activeByConversation.get(conversationId);
+        List<ActiveEntry> entries = record == null ? null : record.entries();
         if (entries == null || entries.isEmpty()) {
             return List.of();
         }

--- a/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
+++ b/backend/src/main/java/com/checkba/service/ai/subagent/SubAgentService.java
@@ -97,6 +97,44 @@ public class SubAgentService {
      */
     private record RunningSubtask(String conversationId, Future<SubAgentResult> future) {}
 
+    /**
+     * runLoop 在子线程里边跑边写、dispatch() 在超时/中断/取消/异常分支读的跨线程进度快照
+     * （审计条目：「Timeout/interrupted/cancelled failure results always report toolsUsed=[]
+     * and rounds=0, discarding real partial progress the child made」）。
+     *
+     * <p>{@code future.get()} 超时/被中断/被取消时拿不到 runLoop 的返回值——被取消的 Future
+     * 连正常返回值都读不到——此前 dispatch() 只能在这些分支里硬编 {@code toolsUsed=List.of()}、
+     * {@code rounds=0}，哪怕子 Agent 已经真实执行过几轮、可能有副作用的工具调用。父级因此无法
+     * 判断"什么都还没发生"和"已经做了不少工作后死掉"，这对是否安全重试同一个子任务
+     * （幂等性）与如何跟用户解释失败都有影响。
+     *
+     * <p>{@link #toolsUsedList()} 与 runLoop 内部循环用的是同一个列表引用（{@code CopyOnWriteArrayList}，
+     * 天然支持"一边被子线程 add、一边被 dispatch 线程读取/复制"），{@link #roundStarted} 在每轮
+     * 循环开头调用，记录"这一刻已经完整跑完的轮数"，与 runLoop 自己失败分支里 {@code round - 1}
+     * 的口径保持一致。
+     */
+    static final class Progress {
+        private final List<String> toolsUsed = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final AtomicInteger completedRounds = new AtomicInteger(0);
+
+        List<String> toolsUsedList() {
+            return toolsUsed;
+        }
+
+        /** 第 round 轮开始执行前调用：此刻已完整跑完的轮数是 round - 1（本轮才刚开始，还不算数）。 */
+        void roundStarted(int round) {
+            completedRounds.set(round - 1);
+        }
+
+        List<String> toolsUsedSnapshot() {
+            return List.copyOf(toolsUsed);
+        }
+
+        int roundsCompleted() {
+            return completedRounds.get();
+        }
+    }
+
     public SubAgentService(ToolRegistry toolRegistry,
                            ChatModelFactory chatModelFactory,
                            XmlToolCallParser xmlToolCallParser,
@@ -172,10 +210,15 @@ public class SubAgentService {
         Long scopedUser = parentCtx != null && parentCtx.userId() != null
                 ? parentCtx.userId()
                 : PlatformAiUserScope.current();
+        // 跨线程进度快照：超时/中断/取消时子 Agent 可能已经真实跑过几轮工具调用，
+        // 但 future.get() 抛异常时拿不到 runLoop 的返回值（被取消的 Future 连正常返回值都读不到）。
+        // 没有这个快照的话，下面几条 catch 只能硬编 toolsUsed=空/rounds=0——即便子 Agent
+        // 已经执行过真实的、可能有副作用的工具调用，父级也完全看不出来（审计条目）。
+        Progress progress = new Progress();
         Callable<SubAgentResult> task = () -> PlatformAiUserScope.call(scopedUser, () -> {
             IN_SUB_AGENT.set(Boolean.TRUE);
             try {
-                return runLoop(subtaskId, taskDescription, expectedOutput, toolScope, parentCtx, modelId);
+                return runLoop(subtaskId, taskDescription, expectedOutput, toolScope, parentCtx, modelId, progress);
             } finally {
                 IN_SUB_AGENT.remove();
             }
@@ -193,22 +236,26 @@ public class SubAgentService {
         } catch (TimeoutException e) {
             future.cancel(true);
             result = SubAgentResult.failure(subtaskId,
-                    "sub-agent timed out after " + props.getTimeoutSeconds() + "s", List.of(), 0);
+                    "sub-agent timed out after " + props.getTimeoutSeconds() + "s",
+                    progress.toolsUsedSnapshot(), progress.roundsCompleted());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             future.cancel(true);
-            result = SubAgentResult.failure(subtaskId, "sub-agent interrupted", List.of(), 0);
+            result = SubAgentResult.failure(subtaskId, "sub-agent interrupted",
+                    progress.toolsUsedSnapshot(), progress.roundsCompleted());
         } catch (CancellationException e) {
             // 用户点了「停止子任务」（见 cancel）。回喂给模型的文案必须点明「是用户停的、不要自动重派」：
             // 只说 failed 的话模型下一轮会立刻再 dispatch 一次，用户看到的是「点了停止反而又跑起来」。
             cancelledByUser = true;
             result = SubAgentResult.failure(subtaskId,
                     "sub-agent was stopped by the user. Do NOT dispatch this subtask again automatically; "
-                            + "tell the user it stopped and ask how to proceed.", List.of(), 0);
+                            + "tell the user it stopped and ask how to proceed.",
+                    progress.toolsUsedSnapshot(), progress.roundsCompleted());
         } catch (Exception e) {
             log.error("Sub-agent {} failed unexpectedly", subtaskId, e);
             result = SubAgentResult.failure(subtaskId,
-                    "sub-agent failed: " + e.getMessage(), List.of(), 0);
+                    "sub-agent failed: " + e.getMessage(),
+                    progress.toolsUsedSnapshot(), progress.roundsCompleted());
         } finally {
             running.remove(subtaskId);
         }
@@ -254,9 +301,10 @@ public class SubAgentService {
      * 无 SSE 推流、无消息持久化、无 artifact/title 等主会话专属分支。
      *
      * @param modelId 已解析并校验过白名单的子 Agent 模型（见 {@link #dispatch}）
+     * @param progress 跨线程进度快照（见 {@link Progress}），dispatch() 在超时/中断/取消分支读取
      */
     SubAgentResult runLoop(String subtaskId, String taskDescription, String expectedOutput,
-                           List<String> toolScope, ToolContext parentCtx, String modelId) {
+                           List<String> toolScope, ToolContext parentCtx, String modelId, Progress progress) {
         // 子 Agent 继承主会话的客户端能力（不变式 3 同款思路）：
         // office 会话派生的子 Agent 同样不该看到 doc_*/sheet_* 死路径工具
         String parentConversationId = parentCtx != null ? parentCtx.conversationId() : null;
@@ -275,10 +323,15 @@ public class SubAgentService {
         messages.add(SystemMessage.from(buildSystemPrompt(expectedOutput, allowed)));
         messages.add(UserMessage.from(taskDescription));
 
-        List<String> toolsUsed = new ArrayList<>();
+        // 与 progress 共用同一个列表引用：executeScoped 往这里 add，dispatch() 的超时/中断/
+        // 取消分支能看到跑到一半时真实已经执行过的工具（见 Progress 类注释）。
+        List<String> toolsUsed = progress.toolsUsedList();
         long charBudget = (long) (props.getTokenBudget() * props.getCharsPerToken());
 
         for (int round = 1; round <= props.getMaxRounds(); round++) {
+            // 记「已完整跑完 round-1 轮」：本轮才刚开始，还不算数——与下面各分支自己返回的
+            // round - 1 保持同一个口径。
+            progress.roundStarted(round);
             if (Thread.currentThread().isInterrupted()) {
                 return SubAgentResult.failure(subtaskId, "sub-agent interrupted", toolsUsed, round - 1);
             }

--- a/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LegalTools.java
@@ -115,6 +115,12 @@ public class LegalTools implements AgentToolComponent {
     @Tool("Search for laws and regulations using PKULaw MCP Semantic Search. Use this for general legal questions. Returns a list of relevant articles.")
     public String law_search(String query) {
         log.info("Tool: law_search (semantic) called for query='{}'", query);
+        // 先校验再解引用：query 缺省时 Map.of("query", query) 会直接抛 NPE（getMessage()==null），
+        // 被 ToolRegistry 的通用异常处理兜成一句不可行动的 "Error executing tool: null"——
+        // 模型不知道到底缺了哪个参数。同款问题与修法见 get_law_article/law_recognition（审计条目）。
+        if (!StringUtils.hasText(query)) {
+            return "Error: query is required.";
+        }
         return callPkulaw("pkulaw-semantic", "search_article", Map.of("query", query));
     }
 
@@ -132,6 +138,10 @@ public class LegalTools implements AgentToolComponent {
     @ToolMeta(displayName = "法条识别与溯源", category = "legal")
     @Tool("Identify law names and articles from text and trace their source.")
     public String law_recognition(String text) {
+        // text.length() 曾经排在校验之前：text 缺省时这里直接 NPE，比下面的 Map.of 更早触发。
+        if (!StringUtils.hasText(text)) {
+            return "Error: text is required.";
+        }
         log.info("Tool: law_recognition called for text length={}", text.length());
         return callPkulaw("pkulaw-recognition", "law_recognition", Map.of("text", text));
     }
@@ -140,6 +150,16 @@ public class LegalTools implements AgentToolComponent {
     @Tool("Get the full content of a specific law article by its title and article number. Use this when you have article info from law_search results.")
     public String get_law_article(String title, String number) {
         log.info("Tool: get_law_article called for title='{}', number='{}'", title, number);
+        // 模型常见的调用形状：只给 title 漏给 number（工具描述没标两者都必填）。ToolRegistry.bindArguments
+        // 对缺省的非基本类型参数绑 null，Map.of("title", title, "number", null) 直接抛
+        // NullPointerException（getMessage()==null），外层只会看到 "Error executing tool: null"——
+        // 与 qichacha_query/tushare_query 同款先校验再用的口径对齐，缺哪个就点名哪个。
+        if (!StringUtils.hasText(title)) {
+            return "Error: title is required.";
+        }
+        if (!StringUtils.hasText(number)) {
+            return "Error: number is required.";
+        }
         return callPkulaw("pkulaw-semantic", "get_article", Map.of("title", title, "number", number));
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/MemoryTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/MemoryTools.java
@@ -158,27 +158,33 @@ public class MemoryTools implements AgentToolComponent {
     /**
      * 查询项目记忆
      */
-    @Tool("查询项目相关的记忆信息，支持按关键词和类型检索。用于回顾之前的决策、结论或重要事实。")
+    @Tool("查询项目相关的记忆信息，支持按关键词和类型检索。用于回顾之前的决策、结论或重要事实。" +
+          "若要可靠地找回某次 save_memory 明确绑定过的 file/conversation 作用域记忆，" +
+          "请传 scope（与 sourceFileId）——否则只能靠关键词碰运气，可能命中不了。")
     public String query_memory(
             @P("查询关键词，用于搜索相关记忆") String query,
-            @P("记忆类型过滤(可选): decision/conclusion/fact/reference/preference/all，默认为all") String type
+            @P("记忆类型过滤(可选): decision/conclusion/fact/reference/preference/all，默认为all") String type,
+            @P("按作用域精确定位(可选): file(需配 sourceFileId)/conversation(取当前对话)，"
+                    + "不传则和此前一样只按关键词在全项目范围检索") String scope,
+            @P("来源文件ID(可选)，scope=file 时必填") Long sourceFileId
     ) {
-        log.info("Tool: query_memory called query='{}', type='{}'", query, type);
-        
+        log.info("Tool: query_memory called query='{}', type='{}', scope='{}'", query, type, scope);
+
         Long projectId = ProjectContextHolder.getProjectIdAsLong();
-        
+
         if (projectId == null) {
             return "错误：无法获取当前项目ID。";
         }
-        
+
         try {
             String memoryType = "all".equalsIgnoreCase(type) || type == null ? null : type.toLowerCase();
             List<MemoryEntry> memories = memoryManager.retrieveMemories(projectId, query, memoryType, 10);
-            
+            memories = withScopedMemories(memories, scope, sourceFileId);
+
             if (memories.isEmpty()) {
                 return "未找到相关记忆。可以使用 save_memory 工具保存重要信息。";
             }
-            
+
             StringBuilder sb = new StringBuilder("找到 ").append(memories.size()).append(" 条相关记忆:\n\n");
             sb.append(memoryManager.formatAsEvidenceLedger(memories));
 
@@ -187,6 +193,44 @@ public class MemoryTools implements AgentToolComponent {
             log.error("Failed to query memory: {}", e.getMessage(), e);
             return "查询记忆时出错: " + e.getMessage();
         }
+    }
+
+    /**
+     * 把"确定性按 scope 取值"的结果并入检索算法（关键词/RRF/Agentic）返回的结果，按 id 去重、
+     * scope 命中的排在前面。
+     *
+     * <p>审计条目：query_memory / search_knowledge_base / deep_search 完全不认 save_memory 存下的
+     * scope——file/conversation 作用域的记忆只能靠检索算法"运气好"才捞得到，
+     * 不是保存时承诺的"绑定到这个文件/这次对话就一定找得回来"。这里不改动任何一条检索算法本身
+     * （关键词 LIKE / RRF 混合 / Agentic 多轮都不动），只是在返回前，若调用方明确给了 scope，
+     * 额外做一次按 scope 的确定性查找并合并进来——保证"明确要哪个作用域"时百分之百找得到，
+     * 检索算法继续负责"泛泛地找相关内容"这一半职责。
+     */
+    private List<MemoryEntry> withScopedMemories(List<MemoryEntry> algorithmic, String scope, Long sourceFileId) {
+        if (scope == null || scope.isBlank()) {
+            return algorithmic;
+        }
+        List<MemoryEntry> scoped;
+        String normalized = scope.trim().toLowerCase();
+        if (MemoryEntry.MemoryScope.FILE.equals(normalized)) {
+            scoped = memoryManager.retrieveFileMemories(sourceFileId);
+        } else if (MemoryEntry.MemoryScope.CONVERSATION.equals(normalized)) {
+            scoped = memoryManager.retrieveConversationMemories(ProjectContextHolder.getConversationId());
+        } else {
+            // project/user/global：现有算法已经是按 projectId 全量检索，不额外加一条确定性通路
+            return algorithmic;
+        }
+        if (scoped.isEmpty()) {
+            return algorithmic;
+        }
+        java.util.LinkedHashMap<Long, MemoryEntry> merged = new java.util.LinkedHashMap<>();
+        for (MemoryEntry m : scoped) {
+            merged.put(m.getId(), m);
+        }
+        for (MemoryEntry m : algorithmic) {
+            merged.putIfAbsent(m.getId(), m);
+        }
+        return new java.util.ArrayList<>(merged.values());
     }
 
     /**
@@ -254,27 +298,34 @@ public class MemoryTools implements AgentToolComponent {
      * 智能混合搜索知识库（RRF 融合）
      * 结合关键词检索和语义检索，使用 RRF 算法融合结果，获得更准确的搜索结果
      */
-    @Tool("在项目知识库中进行智能混合搜索，结合关键词和语义理解，查找与查询相关的记忆和信息。")
+    @Tool("在项目知识库中进行智能混合搜索，结合关键词和语义理解，查找与查询相关的记忆和信息。" +
+          "若要可靠地找回某次 save_memory 明确绑定过的 file/conversation 作用域记忆，" +
+          "请传 scope（与 sourceFileId）——否则只能靠语义相关性碰运气，可能命中不了。")
     public String search_knowledge_base(
             @P("搜索查询，描述你想查找的信息") String query,
-            @P("返回结果数量，默认5") int limit
+            @P("返回结果数量，默认5") int limit,
+            @P("按作用域精确定位(可选): file(需配 sourceFileId)/conversation(取当前对话)，"
+                    + "不传则和此前一样只按语义相关性在全项目范围检索") String scope,
+            @P("来源文件ID(可选)，scope=file 时必填") Long sourceFileId
     ) {
-        log.info("Tool: search_knowledge_base (hybrid RRF) called query='{}', limit={}", query, limit);
-        
+        log.info("Tool: search_knowledge_base (hybrid RRF) called query='{}', limit={}, scope='{}'",
+                query, limit, scope);
+
         Long projectId = ProjectContextHolder.getProjectIdAsLong();
-        
+
         if (projectId == null) {
             return "错误：无法获取当前项目ID。";
         }
-        
+
         if (limit <= 0 || limit > 20) {
             limit = 5;
         }
-        
+
         try {
             // 使用 RRF 混合检索替代单纯的语义检索
             List<MemoryEntry> results = memoryManager.hybridSearch(projectId, query, limit);
-            
+            results = withScopedMemories(results, scope, sourceFileId);
+
             if (results.isEmpty()) {
                 return "未在知识库中找到相关信息。";
             }
@@ -305,27 +356,33 @@ public class MemoryTools implements AgentToolComponent {
      * Agentic 深度搜索（多轮召回）
      * 当普通搜索结果不足时，自动生成补充查询并融合结果
      */
-    @Tool("在项目知识库中进行深度智能搜索。当您需要更全面的信息时使用，会自动扩展查询范围。")
+    @Tool("在项目知识库中进行深度智能搜索。当您需要更全面的信息时使用，会自动扩展查询范围。" +
+          "若要可靠地找回某次 save_memory 明确绑定过的 file/conversation 作用域记忆，" +
+          "请传 scope（与 sourceFileId）——否则只能靠多轮召回碰运气，可能命中不了。")
     public String deep_search(
             @P("搜索查询，描述你想查找的信息") String query,
-            @P("返回结果数量，默认10") int limit
+            @P("返回结果数量，默认10") int limit,
+            @P("按作用域精确定位(可选): file(需配 sourceFileId)/conversation(取当前对话)，"
+                    + "不传则和此前一样只按多轮召回在全项目范围检索") String scope,
+            @P("来源文件ID(可选)，scope=file 时必填") Long sourceFileId
     ) {
-        log.info("Tool: deep_search (agentic) called query='{}', limit={}", query, limit);
-        
+        log.info("Tool: deep_search (agentic) called query='{}', limit={}, scope='{}'", query, limit, scope);
+
         Long projectId = ProjectContextHolder.getProjectIdAsLong();
-        
+
         if (projectId == null) {
             return "错误：无法获取当前项目ID。";
         }
-        
+
         if (limit <= 0 || limit > 20) {
             limit = 10;
         }
-        
+
         try {
             // 使用 Agentic 多轮召回检索
             List<MemoryEntry> results = agenticRetriever.agenticRetrieve(projectId, query, limit);
-            
+            results = withScopedMemories(results, scope, sourceFileId);
+
             if (results.isEmpty()) {
                 return "深度搜索未找到相关信息。建议尝试不同的查询词或使用 save_memory 保存新信息。";
             }

--- a/backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java
@@ -538,6 +538,15 @@ public class OfficeEditTools implements AgentToolComponent {
         } catch (IllegalArgumentException e) {
             return "Error: " + e.getMessage();
         }
+        // borderColor/borderWidth 是 borders 的修饰参数，不是独立参数——此前只在"一个格式参数都
+        // 没给"时才会报这个道理（下面那条 all-empty 检查）；只要 headerBold/alignment 等任一其它
+        // 参数也一起给了，这条检查就不触发，调用照常派发成功，borderColor/borderWidth 被悄悄丢弃，
+        // 响应里没有任何字样提示——模型和用户都以为边框颜色生效了（审计条目）。必须单独判一次。
+        if ((borderColor != null || borderWidth != null) && bordersValue == null) {
+            return "Error: borderColor/borderWidth 只在同时传入 borders（且不为 none）时才会生效，"
+                    + "本次没有传 borders，这两个参数不会被应用。若要设置边框请同时传 borders；"
+                    + "若只是想改其它参数（如 headerBold），请去掉 borderColor/borderWidth 后重试。";
+        }
         if (bordersValue == null && alignmentValue == null && headerBold == null && autoFit == null && fontSize == null) {
             return "Error: 未给出任何格式参数（borders/alignment/headerBold/autoFit/fontSize 至少给一个；"
                     + "borderColor 与 borderWidth 只是 borders 的修饰参数）";

--- a/backend/src/main/java/com/checkba/service/ai/tools/PdfTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PdfTools.java
@@ -233,18 +233,30 @@ public class PdfTools implements AgentToolComponent {
             Path localPath = resolveExisting(file);
             String docxName = file.getName().replaceAll("(?i)\\.pdf$", "") + ".docx";
 
-            String markdown = pdfEditService.extractMarkdown(localPath);
+            PdfEditService.ExtractedText extracted = pdfEditService.extractMarkdown(localPath);
+            String markdown = extracted.markdown();
 
-            if (markdown == null) {
+            if (extracted.looksScanned()) {
                 // 扫描件：本地 MinerU OCR（pptx-service 路由本地优先/云端兜底）
                 String ocrMarkdown;
                 try {
                     ocrMarkdown = pptxServiceClient.ocrPdfToMarkdown(localPath.toString());
                 } catch (Exception e) {
                     log.warn("MinerU OCR failed for scanned PDF", e);
-                    return "Error: 该 PDF 是扫描件（无文本层），已尝试本地 MinerU OCR 但失败：" + e.getMessage() +
-                            "\n请确认桌面端 MinerU 组件已下载并启动（设置-组件管理），或稍后重试。";
+                    if (markdown != null && !markdown.isBlank()) {
+                        // 手里还有已经提取到的文本层（页眉页码那种稀薄内容，也可能是一份
+                        // 本来就很短的文本件）。OCR 失败就回退用它，别把一份能转的文档
+                        // 变成一句「请去装 MinerU」——判据偏向 OCR 的前提就是有这条兜底。
+                        log.warn("OCR 不可用，回退到已提取的稀薄文本层: {}", file.getName());
+                    } else {
+                        return "Error: 该 PDF 是扫描件（无文本层），已尝试本地 MinerU OCR 但失败：" + e.getMessage() +
+                                "\n请确认桌面端 MinerU 组件已下载并启动（设置-组件管理），或稍后重试。";
+                    }
+                    ocrMarkdown = null;
                 }
+                if (ocrMarkdown == null) {
+                    // 走下面的文本型分支，用已提取的文本层继续
+                } else {
                 ProjectFile docx = aiDocxExportService.exportMarkdownToDocx(
                         file.getProjectId(), parentId, AGENT_USER_ID, docxName, ocrMarkdown);
                 editorBridgeService.sendRefreshFilesAction();
@@ -253,6 +265,7 @@ public class PdfTools implements AgentToolComponent {
                         "说明：这是 OCR 内容级转换（识别文字并保留段落结构，不保留原版式；识别结果建议人工核对）。\n" +
                         "接下来可用 doc_* 编辑工具修改该 docx（修改带修订痕迹）。",
                         file.getName(), docx.getName(), docx.getId());
+                }
             }
 
             // 文本型：版式级优先（pdf2docx），失败回退结构级

--- a/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/PythonTools.java
@@ -216,31 +216,32 @@ default_api = _ToolAPI()
             
             long startTime = System.currentTimeMillis();
             long timeout = 120_000; // 2 minutes total
-            
+            // TOCTOU 修复（见 pollForToolRequest 注释）：Java 处理完一条请求后，
+            // 要等 Python 把 requestReadyPath 清理掉一次，才认下一次"exists"是新请求。
+            boolean awaitingPythonCleanup = false;
+
             while (process.isAlive()) {
                 // Check timeout
                 if (System.currentTimeMillis() - startTime > timeout) {
                     process.destroyForcibly();
                     return "Error: Python execution timed out (120s limit).";
                 }
-                
-                // Check for tool call request
-                if (Files.exists(requestReadyPath)) {
+
+                awaitingPythonCleanup = pollForToolRequest(requestReadyPath, awaitingPythonCleanup, () -> {
                     log.info("Detected tool call request from Python");
-                    
                     try {
                         // Read request
                         String requestJson = Files.readString(requestPath);
                         cn.hutool.json.JSONObject request = cn.hutool.json.JSONUtil.parseObj(requestJson);
-                        
+
                         String toolName = request.getStr("tool");
                         cn.hutool.json.JSONObject args = request.getJSONObject("args");
-                        
+
                         log.info("Python requesting tool: {} with args: {}", toolName, args);
-                        
+
                         // Execute tool
                         String result = executeToolForPython(toolName, args);
-                        
+
                         // Write result
                         cn.hutool.json.JSONObject resultObj = new cn.hutool.json.JSONObject();
                         if (result.startsWith("Error")) {
@@ -249,12 +250,12 @@ default_api = _ToolAPI()
                             resultObj.set("content", result);
                         }
                         Files.writeString(resultPath, resultObj.toString(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-                        
+
                         // Signal result ready
                         Files.writeString(resultReadyPath, "1", StandardOpenOption.CREATE);
-                        
+
                         log.info("Tool result written for Python, length: {}", result.length());
-                        
+
                     } catch (Exception e) {
                         log.error("Error processing Python tool request", e);
                         cn.hutool.json.JSONObject errorResult = new cn.hutool.json.JSONObject();
@@ -262,8 +263,8 @@ default_api = _ToolAPI()
                         Files.writeString(resultPath, errorResult.toString(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
                         Files.writeString(resultReadyPath, "1", StandardOpenOption.CREATE);
                     }
-                }
-                
+                });
+
                 // Sleep briefly to avoid busy-waiting
                 Thread.sleep(100);
             }
@@ -302,7 +303,47 @@ default_api = _ToolAPI()
             }
         }
     }
-    
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws java.io.IOException;
+    }
+
+    /**
+     * 单次 IPC 轮询：检测/处理一条 Python 侧的工具调用请求，返回下一轮该带着的
+     * "还在等 Python 清理上一条标记" 状态。
+     *
+     * <p><b>TOCTOU 修复</b>（审计条目 "TOCTOU race on _request_ready marker can replay a
+     * stale tool request or cross-deliver results"）：Java 处理完一条请求、写完结果并置位
+     * resultReadyPath 后，此前会在下一轮（仅 100ms 之后）立刻又检查一次 requestReadyPath——
+     * 但 Python 侧按同样的 100ms 节奏独立轮询、双方没有加锁，它移除 requestReadyPath 的
+     * 清理动作不保证已经跑完（尤其是 Docker bind mount，文件可见性可能再抖上几十到几百毫秒）。
+     * 一旦 Java 在 Python 清理之前就又看见 requestReadyPath 存在，会把同一条 request.json
+     * 当成新请求重新处理一遍，或是与 Python 刚发出的下一条新请求交叉错配结果。
+     *
+     * <p>做法：处理完一条请求后记 {@code awaitingCleanup=true}；只要标记还在，就认定"还是刚才
+     * 那条、Python 还没清理"，不重新处理；等它消失过一次才重新开始把"exists"当成新请求。
+     * 包内可见（不是 private）：供测试直接驱动真实文件系统里的临时目录验证这个状态机，
+     * 不需要起 Docker 容器。
+     *
+     * @param handler 处理一条请求的完整逻辑（读 requestPath、执行工具、写 resultPath+resultReadyPath）
+     * @return 下一轮应带着的 awaitingCleanup 状态
+     */
+    static boolean pollForToolRequest(Path requestReadyPath, boolean awaitingCleanup, ThrowingRunnable handler)
+            throws java.io.IOException {
+        if (awaitingCleanup) {
+            if (Files.exists(requestReadyPath)) {
+                return true; // 仍是同一条标记，Python 还没清理，跳过，不重复处理
+            }
+            awaitingCleanup = false; // Python 已经清理过一次，这一条彻底翻篇
+        }
+        if (Files.exists(requestReadyPath)) {
+            handler.run();
+            return true;
+        }
+        return false;
+    }
+
     /**
      * 注入 Python 子进程的外部服务凭证（环境变量名 -> 值）。
      *

--- a/backend/src/test/java/com/checkba/service/ai/AgentRunStateServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentRunStateServiceTest.java
@@ -1,0 +1,66 @@
+package com.checkba.service.ai;
+
+import com.checkba.repository.AgentRunRecordRepository;
+import com.checkba.service.telemetry.TelemetryTurnTracker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 审计条目：「AgentRunStateService.states map grows unboundedly for the life of the process」。
+ * 每个在本进程内跑过至少一轮的 conversationId 永久占一条，从不摘除。修法是给每条记录的更新时刻
+ * 配一个每日一次的惰性过期扫描（对齐 TodoListService.purgeStaleLists 的既有先例）。
+ */
+@DisplayName("AgentRunStateService：states 无界增长")
+class AgentRunStateServiceTest {
+
+    private AgentRunStateService service;
+
+    @BeforeEach
+    void setUp() {
+        AgentRunRecordRepository recordRepository = mock(AgentRunRecordRepository.class);
+        when(recordRepository.findByConversationId(anyString())).thenReturn(Optional.empty());
+        TelemetryTurnTracker turnTracker = mock(TelemetryTurnTracker.class);
+        service = new AgentRunStateService(recordRepository, turnTracker);
+    }
+
+    @Test
+    @DisplayName("修复：超过 7 天未再更新的会话状态，purgeStaleStates 应把内存条目清掉")
+    void purgeStaleStatesRemovesOldEntries() {
+        long[] now = {1_000_000L};
+        service.setClockMillis(() -> now[0]);
+
+        service.mark("conv-old", AgentRunStateService.RunStatus.FINISHED);
+        assertEquals(1, service.statesSize());
+
+        now[0] += Duration.ofDays(8).toMillis();
+        service.purgeStaleStates();
+
+        assertEquals(0, service.statesSize(), "超过 7 天未更新的记录应被清掉，不能无限期占着内存");
+        assertNull(service.get("conv-old"), "过期后应回到「本进程内从未跑过」的既有语义");
+    }
+
+    @Test
+    @DisplayName("未超过 7 天的记录不受影响：purgeStaleStates 不会误删刚更新的状态")
+    void purgeStaleStatesKeepsFreshEntries() {
+        long[] now = {1_000_000L};
+        service.setClockMillis(() -> now[0]);
+
+        service.mark("conv-fresh", AgentRunStateService.RunStatus.RUNNING);
+
+        now[0] += Duration.ofDays(1).toMillis();
+        service.purgeStaleStates();
+
+        assertEquals(1, service.statesSize(), "未超过过期窗口的记录不该被误删");
+        assertEquals(AgentRunStateService.RunStatus.RUNNING.name(), service.statusName("conv-fresh"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/BackgroundTaskServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/BackgroundTaskServiceTest.java
@@ -112,4 +112,26 @@ class BackgroundTaskServiceTest {
         assertTrue(service.hasActiveTasks("conv-1"), "刚注册、未超时的任务不应被误杀");
         assertEquals(TaskInfo.TaskStatus.RUNNING, service.getTask(taskId).getStatus());
     }
+
+    // ==== conversationTasks / userTasks 外层 map 的无界增长 ====
+    // 背景：cleanupTaskReferences 此前只 list.remove(taskId) 摘空内层列表，从不摘外层 map
+    // 的 key——每个处理过至少一个后台任务的会话/用户都在这两张表里永久占一条，进程越久攒得越多。
+
+    @Test
+    @DisplayName("修复：任务清空后，conversationTasks/userTasks 的外层 key 要随之摘除，不能只剩空列表")
+    void cleanupRemovesEmptyOuterMapEntry() {
+        String taskId = service.registerTask("conv-1", 7L, TaskInfo.TaskType.PPTX_GENERATE, 900);
+        service.completeTask(taskId, "done");
+
+        // 走 cleanupOldTasks 的"已终态超过 30 分钟保留期"分支，而不是 completeTask 内部
+        // 5 分钟后才触发的异步 scheduleCleanup——后者要等真实墙钟，单测等不起。
+        service.setClock(java.time.Clock.offset(java.time.Clock.systemUTC(), java.time.Duration.ofHours(1)));
+        service.cleanupOldTasks();
+
+        assertTrue(service.getActiveTasksForConversation("conv-1").isEmpty());
+        assertFalse(service.hasConversationTaskMapEntry("conv-1"),
+                "任务清空后 conversationTasks 里 conv-1 这个 key 应随之摘除，不能只留一个空列表");
+        assertFalse(service.hasUserTaskMapEntry(7L),
+                "任务清空后 userTasks 里 userId=7 这个 key 应随之摘除，不能只留一个空列表");
+    }
 }

--- a/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/ContextAssemblerServiceTest.java
@@ -565,6 +565,39 @@ class ContextAssemblerServiceTest {
         assertTrue(hasValidHistoryText, "跳过坏数据的同时，同一批次里有效的历史消息应正常保留");
     }
 
+    // ---- UTF-16 代理对截断（审计条目：char-based truncation can split a surrogate pair）----
+
+    @Test
+    @DisplayName("修复：截断点恰好落在代理对中间时，整个代理对一起舍弃，不留孤立的高代理项")
+    void truncateAtCharBoundaryDoesNotSplitSurrogatePair() {
+        // "𠮷"（U+20BB7，罕见 CJK 扩展 B 人名字）在 UTF-16 里是高/低两个 char 的代理对
+        String surrogatePair = "𠮷";
+        String content = "A".repeat(10) + surrogatePair + "B".repeat(10);
+        // 高代理项在下标 10，低代理项在下标 11——截断点选在两者中间
+        int splitInsideSurrogate = 11;
+
+        String truncated = ContextAssemblerService.truncateAtCharBoundary(content, splitInsideSurrogate);
+
+        assertEquals(10, truncated.length(), "应回退到代理对开始之前，不能截出一个孤立代理项");
+        assertEquals("A".repeat(10), truncated);
+        assertFalse(Character.isSurrogate(truncated.charAt(truncated.length() - 1)),
+                "结尾不该是孤立的代理项: " + truncated);
+    }
+
+    @Test
+    @DisplayName("截断点不落在代理对中间时，行为与普通 substring 完全一致")
+    void truncateAtCharBoundaryMatchesSubstringWhenNoSurrogateSplit() {
+        String surrogatePair = "𠮷";
+        String content = "A".repeat(10) + surrogatePair + "B".repeat(10);
+
+        // 截断点在代理对之前：与 substring 一致
+        assertEquals(content.substring(0, 5), ContextAssemblerService.truncateAtCharBoundary(content, 5));
+        // 截断点在代理对之后（含完整代理对）：与 substring 一致
+        assertEquals(content.substring(0, 12), ContextAssemblerService.truncateAtCharBoundary(content, 12));
+        // 截断点等于原文长度（不截断）：与 substring 一致
+        assertEquals(content, ContextAssemblerService.truncateAtCharBoundary(content, content.length()));
+    }
+
     // ---- 供自建 assembler 的 mock 工厂（与 setUp 同配方）----
 
     private static ProjectAiMessageService mockedMessageService() {

--- a/backend/src/test/java/com/checkba/service/ai/DocumentCheckpointServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/DocumentCheckpointServiceTest.java
@@ -115,6 +115,35 @@ class DocumentCheckpointServiceTest {
     }
 
     @Test
+    @DisplayName("修复：clearForNewRun 要把存储里的 blob 一并删掉，不能只摘内存条目")
+    void clearForNewRunDeletesUnderlyingStorageBlob() throws Exception {
+        when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "A.docx", "projects/1/A.docx"));
+        when(projectFileService.getFileBytes(1L)).thenReturn("v1".getBytes());
+        service.ensureCheckpoint("conv-1", 1L);
+
+        org.mockito.ArgumentCaptor<String> savedKey = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(storage).save(savedKey.capture(), any());
+
+        service.clearForNewRun("conv-1");
+
+        verify(storage).delete(eq(savedKey.getValue()));
+    }
+
+    @Test
+    @DisplayName("清理时存储删除失败只记日志，不阻断新一轮：内存条目照样摘除")
+    void clearForNewRunToleratesStorageDeleteFailure() throws Exception {
+        when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "A.docx", "projects/1/A.docx"));
+        when(projectFileService.getFileBytes(1L)).thenReturn("v1".getBytes());
+        service.ensureCheckpoint("conv-1", 1L);
+        org.mockito.Mockito.doThrow(new RuntimeException("存储抖动"))
+                .when(storage).delete(any());
+
+        service.clearForNewRun("conv-1");
+
+        assertFalse(service.hasCheckpoint("conv-1"), "即便物理删除失败，内存登记也应正常清空");
+    }
+
+    @Test
     @DisplayName("单文件场景行为不变：restore 文案与既有格式一致")
     void singleFileRestoreMessageUnchanged() throws Exception {
         when(projectFileService.getFile(1L)).thenReturn(fileOf(1L, "合同.docx", "projects/1/合同.docx"));

--- a/backend/src/test/java/com/checkba/service/ai/PdfEditServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PdfEditServiceTest.java
@@ -10,6 +10,7 @@ import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -211,15 +212,20 @@ class PdfEditServiceTest {
         assertTrue(p0.getStr("text").contains("Confidential Agreement"));
     }
 
+    /**
+     * 契约随「按页密度判扫描件」一起改了：以前无文本层返回 null，现在返回
+     * {@code looksScanned=true} 且照样带回（空的）文本层——上游要靠它在 OCR
+     * 不可用时兜底。这条用例保护的不变式没变：无文本层的 PDF 必须被认成扫描件。
+     */
     @Test
-    void extractMarkdownReturnsNullForScannedLikePdf() throws IOException {
+    void extractMarkdownFlagsScannedLikePdf() throws IOException {
         // 空白页 = 无文本层（扫描件的最小等价物）
         Path path = tempDir.resolve("blank.pdf");
         try (PDDocument doc = new PDDocument()) {
             doc.addPage(new PDPage(PDRectangle.LETTER));
             doc.save(path.toFile());
         }
-        assertEquals(null, service.extractMarkdown(path));
+        assertTrue(service.extractMarkdown(path).looksScanned());
     }
 
     @Test
@@ -249,5 +255,58 @@ class PdfEditServiceTest {
         assertTrue(md.contains("协商一致后订立"), "硬换行应合并");
         assertTrue(md.contains("第二条 保密义务"), "短行独立成段");
         assertTrue(md.contains("1\\."), "行首编号必须转义，防止 flexmark 重排编号");
+    }
+
+    /**
+     * 「是不是扫描件」的判据此前是「全文不足 20 字」。一份几十页的扫描件，每页盖一个
+     * Bates 章或印一行页眉，全文轻松过 20 字，于是被判成文本件走结构化转换——
+     * 产出的 Word 里只有那些章和页眉，正文（图像）一个字都没有，而用户看到的是「转换成功」。
+     */
+    @Test
+    @DisplayName("每页只有 Bates 章的多页扫描件必须判成扫描件，不能因为全文过 20 字就当文本件")
+    void batesStampedScanIsRecognisedAsScanned() throws Exception {
+        Path pdf = tempDir.resolve("bates.pdf");
+        try (PDDocument doc = new PDDocument()) {
+            for (int i = 0; i < 30; i++) {
+                PDPage page = new PDPage();
+                doc.addPage(page);
+                try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                    cs.beginText();
+                    cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 10);
+                    cs.newLineAtOffset(60, 40);
+                    cs.showText(String.format("EXHIBIT-A-%05d", i));
+                    cs.endText();
+                }
+            }
+            doc.save(pdf.toFile());
+        }
+        PdfEditService.ExtractedText extracted = service.extractMarkdown(pdf);
+        assertTrue(extracted.looksScanned(),
+                "每页十几个字符的多页件被判成了文本件，正文会被静默丢光");
+        assertFalse(extracted.markdown().isBlank(),
+                "文本层照样要带回来——OCR 不可用时上游要靠它兜底");
+    }
+
+    @Test
+    @DisplayName("护栏：正常的文字型 PDF 仍判成文本件")
+    void normalTextPdfIsNotScanned() throws Exception {
+        Path pdf = tempDir.resolve("text.pdf");
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+            try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                cs.beginText();
+                cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 11);
+                cs.setLeading(14);
+                cs.newLineAtOffset(60, 740);
+                for (int i = 0; i < 20; i++) {
+                    cs.showText("This is a normal paragraph line of a text-layer PDF document.");
+                    cs.newLine();
+                }
+                cs.endText();
+            }
+            doc.save(pdf.toFile());
+        }
+        assertFalse(service.extractMarkdown(pdf).looksScanned());
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/PptxServiceClientTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PptxServiceClientTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -170,5 +171,55 @@ class PptxServiceClientTest {
         assertEquals(target.toString(), saved);
         assertTrue(Files.exists(target));
         assertEquals(fakePptx.length, Files.size(target));
+    }
+
+    // ==== 修复：缺 download_url 被拼成误导性 404 ====
+
+    @Test
+    @DisplayName("修复：download_url 缺失时报「missing download_url」，不是拼出 baseUrl+\"null\" 再报 404")
+    void downloadPptxRejectsMissingDownloadUrlBeforeRequesting() throws Exception {
+        startServer(); // 不为任何路径注册 handler：一旦真的发出 HTTP 请求就会连接被拒/404
+
+        Path target = tmp.resolve("out.pptx");
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> client.downloadPptx(null, target.toString()));
+
+        assertTrue(ex.getMessage().contains("download_url"),
+                "错误信息应点名缺的是 download_url，而不是一句笼统的 HTTP 404: " + ex.getMessage());
+        assertFalse(Files.exists(target));
+    }
+
+    @Test
+    @DisplayName("修复：download_url 为空字符串同样在发请求前拒绝")
+    void downloadPptxRejectsBlankDownloadUrl() {
+        startServer();
+
+        Path target = tmp.resolve("out.pptx");
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> client.downloadPptx("   ", target.toString()));
+        assertTrue(ex.getMessage().contains("download_url"), ex.getMessage());
+    }
+
+    // ==== 修复：10 分钟轮询里一次瞬时网络错误不该掀翻整条多阶段生成 ====
+
+    @Test
+    @DisplayName("修复：单次瞬时轮询失败（一次 503）不该让 waitForTask 直接放弃，应该重试并最终成功")
+    void waitForTaskToleratesTransientPollFailure() throws Exception {
+        java.util.concurrent.atomic.AtomicInteger calls = new java.util.concurrent.atomic.AtomicInteger();
+        server.createContext("/api/projects/proj-1/tasks/task-1", ex -> {
+            if (calls.getAndIncrement() == 0) {
+                // 模拟一次瞬时故障：网关/连接抖动，底层任务在 pptx-service 那边其实还在正常跑
+                respond(ex, 503, "upstream unavailable");
+            } else {
+                respond(ex, 200, "{\"data\":{\"status\":\"COMPLETED\",\"progress\":{\"completed\":1,\"total\":1}}}");
+            }
+        });
+        startServer();
+
+        cn.hutool.json.JSONObject result = client.waitForTask("proj-1", "task-1");
+
+        assertNotNull(result, "重试后应该正常拿到最终状态，不能因为中间一次失败就整体放弃");
+        assertEquals("COMPLETED", result.getStr("status"));
+        assertTrue(calls.get() >= 2, "应该在第一次失败后重试过至少一次");
     }
 }

--- a/backend/src/test/java/com/checkba/service/ai/TodoListServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/TodoListServiceTest.java
@@ -4,6 +4,7 @@ import com.checkba.model.entity.AgentTodoList;
 import com.checkba.repository.AgentTodoListRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -118,6 +119,33 @@ class TodoListServiceTest {
     @Test
     void reminder_noList_returnsNull() {
         assertNull(service.reminder("conv-unknown"));
+    }
+
+    // ==== failed 项的防走神提醒（审计条目）====
+    // 背景：reminder() 此前只认 completed 算"done"，failed 项永远不会自己变成 completed，
+    // 于是 done < todos.size() 恒成立，提醒永远关不掉；且正文只列 in_progress/pending，
+    // 完全不提 failed 项，模型看不出到底卡在哪一项。
+
+    @Test
+    @DisplayName("修复：全部项要么完成要么失败时，提醒应该停止（不能因为有 failed 项就永远关不掉）")
+    void reminder_completedAndFailed_returnsNull() {
+        service.update(CONV, "[{\"content\":\"A\",\"status\":\"completed\"},"
+                + "{\"content\":\"B\",\"status\":\"failed\"}]");
+
+        assertNull(service.reminder(CONV), "全部项都已是终态（完成或失败），不该再继续催");
+    }
+
+    @Test
+    @DisplayName("修复：还有未完成项时，提醒正文要点名失败的那一项，不能只字不提")
+    void reminder_withFailedAndPending_mentionsFailedItem() {
+        service.update(CONV, "[{\"content\":\"A\",\"status\":\"failed\"},"
+                + "{\"content\":\"B\",\"status\":\"pending\"}]");
+
+        String reminder = service.reminder(CONV);
+
+        assertNotNull(reminder, "还有 pending 项没解决，提醒不该消失");
+        assertTrue(reminder.contains("已失败：A"), "正文应点名失败项，不能只字不提: " + reminder);
+        assertTrue(reminder.contains("待办：B"));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/evidence/EvidenceItemTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/evidence/EvidenceItemTest.java
@@ -1,0 +1,61 @@
+package com.checkba.service.ai.evidence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * 审计条目：「Excerpt truncation cuts by UTF-16 char index and can split a surrogate pair,
+ * corrupting the tail of an evidence excerpt」。excerpt 超过 500 字符时被
+ * {@code substring(0, 500)} 截断——如果第 500 个字符位置恰好劈开一个 UTF-16 代理对
+ * （增补平面字符，如罕见人名字/emoji），结果会以一个孤立代理项收尾。
+ */
+@DisplayName("EvidenceItem：excerpt 截断不能劈开代理对")
+class EvidenceItemTest {
+
+    private static EvidenceItem item(String excerpt) {
+        return new EvidenceItem("ev-1", "checkba://file/1", "hash", LocalDateTime.now(),
+                null, "第1段", excerpt, "text/plain", "project", List.of(), null, null, null);
+    }
+
+    @Test
+    @DisplayName("修复：截断点恰好落在代理对中间时，整个代理对一起舍弃，不留孤立代理项")
+    void truncationDoesNotSplitSurrogatePair() {
+        // "𠮷"（U+20BB7）在 UTF-16 里是高/低两个 char 的代理对；放在第 499/500 个字符位置，
+        // 恰好卡在 MAX_EXCERPT_LENGTH=500 的截断点中间
+        String excerpt = "A".repeat(499) + "𠮷" + "更多正文内容在后面补到超过五百字".repeat(10);
+
+        EvidenceItem evidence = item(excerpt);
+
+        assertEquals(499, evidence.excerpt().length(),
+                "应回退到代理对开始之前，不能截出一个孤立代理项: " + evidence.excerpt());
+        assertEquals("A".repeat(499), evidence.excerpt());
+        assertFalse(Character.isSurrogate(evidence.excerpt().charAt(evidence.excerpt().length() - 1)),
+                "结尾不该是孤立的代理项");
+    }
+
+    @Test
+    @DisplayName("对照：不含代理对的普通超长摘录，截断行为与此前一致（恰好 500 字符）")
+    void truncationMatchesPlainSubstringWithoutSurrogates() {
+        String excerpt = "A".repeat(600);
+
+        EvidenceItem evidence = item(excerpt);
+
+        assertEquals(EvidenceItem.MAX_EXCERPT_LENGTH, evidence.excerpt().length());
+        assertEquals("A".repeat(500), evidence.excerpt());
+    }
+
+    @Test
+    @DisplayName("缺定位符仍然拒绝（本次改动不影响既有硬约束）")
+    void stillRejectsMissingLocator() {
+        assertThrows(IllegalArgumentException.class, () -> new EvidenceItem(
+                "ev-1", "checkba://file/1", "hash", LocalDateTime.now(),
+                null, "", "excerpt", "text/plain", "project", List.of(), null, null, null));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemCellExtractorTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemCellExtractorTest.java
@@ -1,0 +1,124 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.service.ai.AuxModelResolver;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.TokenUsageService;
+import com.checkba.service.ai.context.LegalInfoProtector;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 审计条目：「Malformed/truncated LLM JSON response causes MemCell extraction to
+ * silently produce zero memories, indistinguishable from nothing worth remembering」。
+ *
+ * 核心断言：parseMemCellResponse 对"确认为空"（{"memcells": []}）与"解析失败"（找不到 JSON /
+ * JSON 损坏 / memcells 不是数组）必须走不同的路径——前者返回空列表，后者必须抛出
+ * {@link MemCellExtractor.MemCellParseException}，不能都退化成同一个空列表。
+ * 再往上一层：extractAndSave 必须把"解析失败"体现成 -1，与"正常跑完但确实没有内容"的 0 区分开。
+ */
+@DisplayName("MemCellExtractor：解析失败与确认为空要分得开")
+class MemCellExtractorTest {
+
+    private ChatModelFactory chatModelFactory;
+    private LegalInfoProtector legalInfoProtector;
+    private MemoryManager memoryManager;
+    private ChatLanguageModel model;
+    private MemCellExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        chatModelFactory = mock(ChatModelFactory.class);
+        legalInfoProtector = mock(LegalInfoProtector.class);
+        memoryManager = mock(MemoryManager.class);
+        model = mock(ChatLanguageModel.class);
+
+        when(chatModelFactory.getAuxChatModel()).thenReturn(model);
+        // 内容本身不含任何法律关键信息，合并阶段不会额外补 MemCell 进来
+        when(legalInfoProtector.markProtectedInfo(any())).thenReturn(List.of());
+
+        AuxModelResolver auxModelResolver = mock(AuxModelResolver.class);
+        when(auxModelResolver.auxModelId()).thenReturn("qwen/qwen3.7-flash");
+        TokenUsageService tokenUsageService = mock(TokenUsageService.class);
+
+        extractor = new MemCellExtractor(chatModelFactory, legalInfoProtector, memoryManager,
+                auxModelResolver, tokenUsageService);
+    }
+
+    private static List<ChatMessage> oneUserMessage(String text) {
+        return List.of(UserMessage.from(text));
+    }
+
+    private void stubModelResponse(String rawText) {
+        when(model.generate(any(ChatMessage.class), any(ChatMessage.class)))
+                .thenReturn(Response.from(AiMessage.from(rawText)));
+    }
+
+    // ---- parseMemCellResponse 直接单测：不打真实/伪造的 LLM 调用 ----
+
+    @Test
+    @DisplayName("模型显式返回空数组 = 确认为空，正常返回空列表，不抛异常")
+    void explicitEmptyArrayIsNotAFailure() {
+        List<MemCellExtractor.MemCellData> cells =
+                extractor.parseMemCellResponse("```json\n{\"memcells\": []}\n```");
+        assertTrue(cells.isEmpty());
+    }
+
+    @Test
+    @DisplayName("响应里根本没有 JSON 内容 = 解析失败，必须抛异常而不是静默返回空列表")
+    void noJsonAtAllThrows() {
+        assertThrows(MemCellExtractor.MemCellParseException.class,
+                () -> extractor.parseMemCellResponse("抱歉，我无法完成这个任务。"));
+    }
+
+    @Test
+    @DisplayName("JSON 被截断（未闭合）= 解析失败，必须抛异常")
+    void truncatedJsonThrows() {
+        String truncated = "```json\n{\"memcells\": [{\"type\":\"FACT\",\"key\":\"a\",\"value\":\"人民币500万元";
+        assertThrows(MemCellExtractor.MemCellParseException.class,
+                () -> extractor.parseMemCellResponse(truncated));
+    }
+
+    @Test
+    @DisplayName("memcells 被截断成对象而不是数组 = 解析失败，必须抛异常")
+    void memcellsAsObjectThrows() {
+        assertThrows(MemCellExtractor.MemCellParseException.class,
+                () -> extractor.parseMemCellResponse("```json\n{\"memcells\": {\"type\":\"FACT\"}}\n```"));
+    }
+
+    // ---- extractAndSave 端到端：-1（解析失败） vs 0（确认为空）必须能区分 ----
+
+    @Test
+    @DisplayName("extractAndSave：LLM 响应解析失败时返回 -1，不是 0")
+    void extractAndSaveReturnsNegativeOneOnParseFailure() {
+        stubModelResponse("这不是 JSON，也没有代码块。");
+
+        int saved = extractor.extractAndSave(1L, "conv-1", oneUserMessage("这是第一条消息，凑够消息数门槛"));
+
+        assertEquals(-1, saved, "解析失败必须能和「正常跑完、确实没有可提取内容」的 0 区分开");
+    }
+
+    @Test
+    @DisplayName("extractAndSave：模型确认无可提取信息时返回 0，不是 -1")
+    void extractAndSaveReturnsZeroOnConfirmedEmpty() {
+        stubModelResponse("```json\n{\"memcells\": []}\n```");
+
+        int saved = extractor.extractAndSave(1L, "conv-1", oneUserMessage("这是第一条消息，凑够消息数门槛"));
+
+        assertEquals(0, saved, "确认为空不该被误判成解析失败");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemoryManagerConcurrentSaveTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemoryManagerConcurrentSaveTest.java
@@ -1,0 +1,97 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.model.entity.ProjectMemory;
+import com.checkba.repository.ConversationSummaryRepository;
+import com.checkba.repository.MemoryEntryRepository;
+import com.checkba.repository.ProjectMemoryRepository;
+import com.checkba.repository.UserMemoryRepository;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 审计条目：「saveProjectMemory / saveUserMemory use a find-then-insert pattern that races
+ * on the underlying unique(project_id)/unique(user_id) constraint, silently dropping the
+ * loser's update」。
+ *
+ * 直接验证修法要保证的性质：find→决定 insert/update→save 这段必须互斥，不允许两个线程
+ * 同时穿过去（那正是 unique 约束会被撞上的窗口）。用可控延时把窗口放大，
+ * 没有互斥的话多个线程会同时进入这段临界区。
+ */
+@DisplayName("MemoryManager：saveProjectMemory 的 find-then-insert 竞态")
+class MemoryManagerConcurrentSaveTest {
+
+    private ProjectMemoryRepository projectMemoryRepository;
+    private MemoryManager memoryManager;
+
+    @BeforeEach
+    void setUp() {
+        MemoryEntryRepository memoryEntryRepository = mock(MemoryEntryRepository.class);
+        ConversationSummaryRepository conversationSummaryRepository = mock(ConversationSummaryRepository.class);
+        projectMemoryRepository = mock(ProjectMemoryRepository.class);
+        UserMemoryRepository userMemoryRepository = mock(UserMemoryRepository.class);
+        @SuppressWarnings("unchecked")
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+
+        memoryManager = new MemoryManager(memoryEntryRepository, conversationSummaryRepository,
+                projectMemoryRepository, userMemoryRepository, embeddingStore, embeddingModel);
+    }
+
+    @Test
+    @DisplayName("并发 saveProjectMemory：find + 决定 + save 必须互斥，同一时刻只能有一个线程在临界区内")
+    void findThenInsertCriticalSectionIsMutuallyExclusive() throws InterruptedException {
+        AtomicInteger inCriticalSection = new AtomicInteger(0);
+        AtomicInteger maxConcurrent = new AtomicInteger(0);
+
+        // find 与 save 之间人为插入延时，把竞态窗口放大：没有锁的话，另一个线程的 find
+        // 会在这段延时内闯进来，两次都读到 Optional.empty()。
+        when(projectMemoryRepository.findByProjectId(anyLong())).thenAnswer(inv -> {
+            int n = inCriticalSection.incrementAndGet();
+            maxConcurrent.updateAndGet(prev -> Math.max(prev, n));
+            Thread.sleep(30);
+            return Optional.<ProjectMemory>empty();
+        });
+        when(projectMemoryRepository.save(any())).thenAnswer(inv -> {
+            Thread.sleep(10);
+            inCriticalSection.decrementAndGet();
+            return inv.getArgument(0);
+        });
+
+        int threadCount = 6;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            pool.submit(() -> {
+                try {
+                    memoryManager.saveProjectMemory(ProjectMemory.builder().projectId(1L).build());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        assertTrue(done.await(10, TimeUnit.SECONDS), "所有并发保存都应在超时前完成");
+        pool.shutdown();
+
+        assertEquals(1, maxConcurrent.get(),
+                "find-then-insert 这段必须互斥执行；同一时刻出现第二个线程说明竞态窗口仍然打开");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/memory/MemoryPipelineServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/memory/MemoryPipelineServiceTest.java
@@ -1,0 +1,68 @@
+package com.checkba.service.ai.memory;
+
+import com.checkba.service.ai.context.ContextCompressor;
+import com.checkba.service.ai.context.ConversationSummarizer;
+import com.checkba.version.memory.MemorySyncService;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 审计条目：「Regex project-memory extraction failure silently skips the LLM MemCell
+ * extraction for the whole turn」。runPipeline 里 2.1（正则，低成本）与 2.2（LLM MemCell，
+ * 有成本）此前共用一个 try/catch：2.1 一抛异常，2.2 整轮都不会跑，且日志上看不出区别
+ * （都是一条 "Failed to extract project memory"）。
+ */
+@DisplayName("MemoryPipelineService：正则抽取失败不该连带跳过 LLM MemCell 抽取")
+class MemoryPipelineServiceTest {
+
+    private ProjectMemoryExtractor projectMemoryExtractor;
+    private MemCellExtractor memCellExtractor;
+    private MemoryPipelineService pipeline;
+
+    @BeforeEach
+    void setUp() {
+        MemoryManager memoryManager = mock(MemoryManager.class);
+        ConversationSummarizer conversationSummarizer = mock(ConversationSummarizer.class);
+        projectMemoryExtractor = mock(ProjectMemoryExtractor.class);
+        memCellExtractor = mock(MemCellExtractor.class);
+        ContextCompressor contextCompressor = mock(ContextCompressor.class);
+        MemorySyncService memorySyncService = mock(MemorySyncService.class);
+
+        pipeline = new MemoryPipelineService(memoryManager, conversationSummarizer,
+                projectMemoryExtractor, memCellExtractor, contextCompressor, memorySyncService);
+    }
+
+    private static List<ChatMessage> messages(int count) {
+        List<ChatMessage> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(UserMessage.from("消息 " + i));
+        }
+        return list;
+    }
+
+    @Test
+    @DisplayName("正则提取（2.1）抛异常时，LLM MemCell 抽取（2.2）依然要执行，不能被连带跳过")
+    void regexFailureDoesNotSkipMemCellExtraction() {
+        doThrow(new RuntimeException("模拟并发写 ProjectMemory 撞唯一约束"))
+                .when(projectMemoryExtractor).extractAndUpdateProjectMemory(anyLong(), any());
+
+        // @Async 方法在没有 Spring 代理的单测里就是普通同步调用，直接验证副作用即可
+        pipeline.onConversationTurnCompleted("conv-1", "1", 9L, messages(4));
+
+        verify(memCellExtractor, times(1)).extractAndSave(eq(1L), eq("conv-1"), any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillRegistryTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillRegistryTest.java
@@ -228,6 +228,46 @@ class SkillRegistryTest {
     }
 
     @Test
+    @DisplayName("修复：skill.yml 编码错误时，getLoadErrors() 要能看出「解析出错」而不是「没有这个 skill」")
+    void encodingFailureIsDistinguishableFromMissingSkill() throws IOException {
+        writeSkill(tempDir.resolve("good-skill"), "good-skill", null);
+
+        // 非 UTF-8 字节（GBK 编码的中文）：Files.readString(..., UTF_8) 会抛 MalformedInputException
+        Path badEncoding = tempDir.resolve("bad-encoding");
+        Files.createDirectories(badEncoding);
+        Files.write(badEncoding.resolve("skill.yml"),
+                "id: bad-encoding\nname: 中文技能名\ntriggers: [x]\nprompt: prompt.md\n"
+                        .getBytes(java.nio.charset.Charset.forName("GBK")));
+        Files.writeString(badEncoding.resolve("prompt.md"), "p");
+
+        SkillRegistry registry = newRegistry(tempDir, new PluginService());
+
+        // 与"坏 skill 跳过不阻断"一致：解析失败的 skill 不出现在结果里，好 skill 不受影响
+        assertEquals(1, registry.getSkills().size());
+        assertTrue(registry.getSkill("bad-encoding").isEmpty(), "编码错误的 skill 不应该注册成功");
+
+        // 新增的区分信号：loadErrors 里要能查到这个目录，且原因点明是编码问题
+        assertTrue(registry.getLoadErrors().containsKey("bad-encoding"),
+                "解析失败必须在 loadErrors 里留痕，不能和「压根没有这个目录」一样悄无声息");
+        assertTrue(registry.getLoadErrors().get("bad-encoding").contains("编码"),
+                "原因应该点明是编码问题，而不是一句笼统的失败: " + registry.getLoadErrors().get("bad-encoding"));
+        // 正常注册成功的目录不应该出现在 loadErrors 里
+        assertFalse(registry.getLoadErrors().containsKey("good-skill"));
+    }
+
+    @Test
+    @DisplayName("修复：enabled_by_default 写成带引号的真值（\"yes\"）不能被静默当成 false")
+    void quotedTruthyEnabledByDefaultIsNotCoercedToFalse() throws IOException {
+        writeSkill(tempDir.resolve("quoted-yes"), "quoted-yes", "enabled_by_default: \"yes\"\n");
+        SkillRegistry registry = newRegistry(tempDir, new PluginService());
+
+        SkillDefinition skill = registry.getSkill("quoted-yes").orElseThrow();
+        assertTrue(skill.isEnabledByDefault(),
+                "带引号的真值 \"yes\" 应该被识别为启用，不能被 Boolean.parseBoolean 悄悄当成 false");
+        assertTrue(registry.isEnabled("quoted-yes"), "不该被首次扫描的种子逻辑默认关闭");
+    }
+
+    @Test
     @DisplayName("插件携带 skill（manifest.skills）：经 PluginService 收集后注册，带 sourcePluginId")
     void registersPluginCarriedSkills() throws IOException {
         Path pluginsDir = tempDir.resolve("plugins");

--- a/backend/src/test/java/com/checkba/service/ai/skill/SkillRouterTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/skill/SkillRouterTest.java
@@ -390,4 +390,42 @@ class SkillRouterTest {
         // skill-a 没有 name_en，英文下回退中文名（可用胜于空白，与注入块同口径）
         assertEquals("skill-a", englishRouter().displayName(registry.getSkill("skill-a").orElseThrow()));
     }
+
+    // ==== activeByConversation 的无界增长 ====
+    // 背景：只有"这一轮没有任何 skill 生效"才会从登记簿里 remove；一个会话只要最后一轮命中过
+    // skill，条目就永久留着，进程越久攒得越多。修法是给每条记录带上激活时刻，配一个每日一次的
+    // 惰性过期扫描（对齐 TodoListService.purgeStaleLists 的既有先例）。
+
+    @Test
+    @DisplayName("修复：超过过期窗口未再激活的会话，purgeStaleActivations 应把登记簿条目清掉")
+    void purgeStaleActivationsRemovesOldEntries() {
+        long[] now = {1_000_000L};
+        router.setClockMillis(() -> now[0]);
+
+        router.activateForTurn("conv-old", "公司考虑IPO");
+        assertEquals(1, router.activeByConversationSize());
+
+        // 推进到超过 24 小时过期窗口之后
+        now[0] += java.time.Duration.ofHours(25).toMillis();
+        router.purgeStaleActivations();
+
+        assertEquals(0, router.activeByConversationSize(),
+                "超过过期窗口未再激活的会话条目应被清掉，不能无限期占着登记簿");
+        assertEquals(List.of(), router.activeSkills("conv-old"), "过期后该会话不应再有生效 skill");
+    }
+
+    @Test
+    @DisplayName("未超过过期窗口的会话不受影响：purgeStaleActivations 不会误删刚激活的记录")
+    void purgeStaleActivationsKeepsFreshEntries() {
+        long[] now = {1_000_000L};
+        router.setClockMillis(() -> now[0]);
+
+        router.activateForTurn("conv-fresh", "公司考虑IPO");
+
+        now[0] += java.time.Duration.ofHours(1).toMillis();
+        router.purgeStaleActivations();
+
+        assertEquals(1, router.activeByConversationSize(), "未超过过期窗口的记录不该被误删");
+        assertEquals(1, router.activeSkills("conv-fresh").size());
+    }
 }

--- a/backend/src/test/java/com/checkba/service/ai/subagent/SubAgentServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/subagent/SubAgentServiceTest.java
@@ -205,6 +205,27 @@ class SubAgentServiceTest {
     }
 
     @Test
+    @DisplayName("修复：超时前已经真实跑完的轮次与工具调用，不能被超时结果抹成空列表/0")
+    void timeoutPreservesRealPartialProgress() {
+        props.setTimeoutSeconds(1);
+        // 第一轮：正常调用一次工具（真实执行，有副作用）；第二轮：模型调用直接卡住触发超时
+        when(model.generate(anyList(), anyList()))
+                .thenReturn(toolCallTurn("search_web", "{\"query\":\"x\"}"))
+                .thenAnswer(inv -> {
+                    Thread.sleep(10_000);
+                    return textTurn("太迟了");
+                });
+
+        SubAgentResult result = newService().dispatch("慢任务", null, List.of("search_web"), PARENT_CTX);
+
+        assertFalse(result.success());
+        assertTrue(result.error().contains("timed out"), "错误信息应说明超时: " + result.error());
+        assertEquals(List.of("search_web"), result.toolsUsed(),
+                "第一轮已经真实调用过 search_web，超时结果不该把它抹成空列表");
+        assertEquals(1, result.rounds(), "第一轮已完整跑完，rounds 不该恒为 0");
+    }
+
+    @Test
     @DisplayName("工具域：scope 外的工具被拒绝，不经 ToolRegistry 分发")
     void toolScopeEnforced() {
         when(model.generate(anyList(), anyList())).thenReturn(

--- a/backend/src/test/java/com/checkba/service/ai/tools/LegalToolsValidationTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/LegalToolsValidationTest.java
@@ -1,0 +1,82 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.service.DocumentTextService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.context.FileContentExtractorService;
+import com.checkba.service.ai.mcp.McpClientService;
+import com.checkba.service.platform.ExternalProviderResolver;
+import com.checkba.service.platform.PlatformGatewayClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * 审计条目：「get_law_article/law_search/law_recognition dereference LLM-supplied args
+ * before validating, producing an uninformative 'Error executing tool: null' instead of
+ * an actionable message」。
+ *
+ * 三个工具此前直接把可能为 null 的参数塞进 {@code Map.of(...)}（law_recognition 甚至在那之前
+ * 就先 {@code text.length()}），模型漏传一个参数就是裸 NPE，外层只能看到
+ * "Error executing tool: null"——不知道到底缺了哪个。修法是先用 StringUtils.hasText 校验，
+ * 和 law_search_keyword / EnterpriseDataTools 的既有口径对齐。
+ */
+@DisplayName("LegalTools：先解引用后校验")
+class LegalToolsValidationTest {
+
+    private McpClientService mcpClientService;
+    private LegalTools tools;
+
+    @BeforeEach
+    void setUp() {
+        ProjectFileService projectFileService = mock(ProjectFileService.class);
+        mcpClientService = mock(McpClientService.class);
+        FileContentExtractorService fileContentExtractorService = mock(FileContentExtractorService.class);
+        ExternalProviderResolver externalProviderResolver = mock(ExternalProviderResolver.class);
+        PlatformGatewayClient platformGatewayClient = mock(PlatformGatewayClient.class);
+        DocumentTextService documentTextService = mock(DocumentTextService.class);
+        tools = new LegalTools(projectFileService, mcpClientService, fileContentExtractorService,
+                externalProviderResolver, platformGatewayClient, documentTextService);
+    }
+
+    @Test
+    @DisplayName("修复：get_law_article 漏传 number 时返回可行动的错误，不是裸 NPE")
+    void getLawArticleMissingNumberReturnsActionableError() {
+        String result = tools.get_law_article("民法典", null);
+
+        assertTrue(result.startsWith("Error"), result);
+        assertTrue(result.contains("number"), "错误信息应点名缺的是 number: " + result);
+        verifyNoInteractions(mcpClientService);
+    }
+
+    @Test
+    @DisplayName("修复：get_law_article 漏传 title 时返回可行动的错误")
+    void getLawArticleMissingTitleReturnsActionableError() {
+        String result = tools.get_law_article(null, "第五百七十七条");
+
+        assertTrue(result.startsWith("Error"), result);
+        assertTrue(result.contains("title"), "错误信息应点名缺的是 title: " + result);
+        verifyNoInteractions(mcpClientService);
+    }
+
+    @Test
+    @DisplayName("修复：law_search 漏传 query 时返回可行动的错误，不是裸 NPE")
+    void lawSearchMissingQueryReturnsActionableError() {
+        String result = tools.law_search(null);
+
+        assertTrue(result.startsWith("Error"), result);
+        verifyNoInteractions(mcpClientService);
+    }
+
+    @Test
+    @DisplayName("修复：law_recognition 漏传 text 时返回可行动的错误，不是裸 NPE（此前连 log 都到不了）")
+    void lawRecognitionMissingTextReturnsActionableError() {
+        String result = tools.law_recognition(null);
+
+        assertTrue(result.startsWith("Error"), result);
+        verifyNoInteractions(mcpClientService);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/tools/MemoryToolsScopeTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/MemoryToolsScopeTest.java
@@ -1,0 +1,118 @@
+package com.checkba.service.ai.tools;
+
+import com.checkba.model.entity.MemoryEntry;
+import com.checkba.service.ai.context.ProjectContextHolder;
+import com.checkba.service.ai.memory.AgenticRetriever;
+import com.checkba.service.ai.memory.MemoryManager;
+import com.checkba.service.ai.memory.ProjectMemoryExtractor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 审计条目：「query_memory / search_knowledge_base / deep_search ignore memory scope entirely,
+ * so file- and conversation-scoped saves are not reliably recallable」。
+ *
+ * save_memory(scope="file", sourceFileId=42) 存下的记忆，此前只能靠关键词/语义检索"运气好"
+ * 才捞得到——三个检索工具完全不认 scope。修法是在调用方明确给出 scope 时，额外走一条
+ * 确定性的按 scope 查找并入结果，不依赖检索算法本身的相关性判断。
+ */
+@DisplayName("MemoryTools：三个检索工具要认 scope")
+class MemoryToolsScopeTest {
+
+    private MemoryManager memoryManager;
+    private AgenticRetriever agenticRetriever;
+    private MemoryTools tools;
+
+    @BeforeEach
+    void setUp() {
+        memoryManager = mock(MemoryManager.class);
+        ProjectMemoryExtractor projectMemoryExtractor = mock(ProjectMemoryExtractor.class);
+        agenticRetriever = mock(AgenticRetriever.class);
+        when(agenticRetriever.agenticRetrieve(anyLong(), any(), anyInt())).thenReturn(List.of());
+        tools = new MemoryTools(memoryManager, projectMemoryExtractor, agenticRetriever);
+
+        ProjectContextHolder.setProjectId("1");
+        ProjectContextHolder.setConversationId("conv-1");
+    }
+
+    @AfterEach
+    void tearDown() {
+        ProjectContextHolder.clear();
+    }
+
+    private static MemoryEntry fileScopedEntry() {
+        return MemoryEntry.builder()
+                .id(99L)
+                .projectId(1L)
+                .memoryType("fact")
+                .memoryKey("审查结论")
+                .memoryValue("该合同第 5 条存在争议")
+                .scope(MemoryEntry.MemoryScope.FILE)
+                .sourceFileId(42L)
+                .importanceScore(0.7)
+                .build();
+    }
+
+    @Test
+    @DisplayName("修复：query_memory 传 scope=file 时，即便关键词检索为空也要能找到绑定该文件的记忆")
+    void queryMemoryFindsFileScopedEntryEvenWhenKeywordSearchIsEmpty() {
+        when(memoryManager.retrieveMemories(eq(1L), any(), any(), anyInt())).thenReturn(List.of());
+        when(memoryManager.retrieveFileMemories(42L)).thenReturn(List.of(fileScopedEntry()));
+        when(memoryManager.formatAsEvidenceLedger(any())).thenReturn("[EVIDENCE:99]");
+
+        String result = tools.query_memory("随便什么不相关的词", null, "file", 42L);
+
+        assertFalse(result.contains("未找到相关记忆"), "明确按文件 scope 查找时不该说没找到: " + result);
+        assertTrue(result.contains("[EVIDENCE:99]"));
+    }
+
+    @Test
+    @DisplayName("对照：不传 scope 时行为不变——关键词检索为空就是没找到")
+    void queryMemoryWithoutScopeIsUnaffected() {
+        when(memoryManager.retrieveMemories(eq(1L), any(), any(), anyInt())).thenReturn(List.of());
+
+        String result = tools.query_memory("随便什么不相关的词", null, null, null);
+
+        assertTrue(result.contains("未找到相关记忆"));
+    }
+
+    @Test
+    @DisplayName("修复：search_knowledge_base 传 scope=conversation 时要能找到绑定当前对话的记忆")
+    void searchKnowledgeBaseFindsConversationScopedEntry() {
+        MemoryEntry convEntry = MemoryEntry.builder()
+                .id(77L).projectId(1L).memoryType("fact")
+                .memoryValue("本次对话讨论的要点").scope(MemoryEntry.MemoryScope.CONVERSATION)
+                .conversationId("conv-1").importanceScore(0.7).build();
+        when(memoryManager.hybridSearch(eq(1L), any(), anyInt())).thenReturn(List.of());
+        when(memoryManager.retrieveConversationMemories("conv-1")).thenReturn(List.of(convEntry));
+
+        String result = tools.search_knowledge_base("不相关的词", 5, "conversation", null);
+
+        assertFalse(result.contains("未在知识库中找到相关信息"), "明确按对话 scope 查找时不该说没找到: " + result);
+        assertTrue(result.contains("本次对话讨论的要点"));
+    }
+
+    @Test
+    @DisplayName("修复：deep_search 传 scope=file 时要能找到绑定该文件的记忆")
+    void deepSearchFindsFileScopedEntry() {
+        when(memoryManager.retrieveFileMemories(42L)).thenReturn(List.of(fileScopedEntry()));
+
+        String result = tools.deep_search("不相关的词", 10, "file", 42L);
+
+        assertFalse(result.contains("深度搜索未找到相关信息"), "明确按文件 scope 查找时不该说没找到: " + result);
+        assertTrue(result.contains("该合同第 5 条存在争议"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ai/tools/OfficeEditToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/OfficeEditToolsTest.java
@@ -223,6 +223,18 @@ class OfficeEditToolsTest {
     }
 
     @Test
+    @DisplayName("修复：只传 borderColor + headerBold（不传 borders）不能悄悄丢弃 borderColor")
+    void formatTableRejectsBorderModifiersWithoutBordersEvenWithOtherParams() {
+        // 此前的"至少给一个格式参数"guard 只看 bordersValue/alignmentValue/headerBold/autoFit/
+        // fontSize，headerBold 非空就满足了，于是直接派发成功——borderColor 被静默丢弃，
+        // 响应里没有任何字样提示。修复后必须在派发前就报错，且不触碰桥。
+        String result = tools.office_format_table("conv-1", 0, null, "#FF0000", null, null, true, null, null);
+
+        assertTrue(result.startsWith("Error"), "borders 缺省时 borderColor 不该被静默丢弃: " + result);
+        verifyNoInteractions(bridge);
+    }
+
+    @Test
     @DisplayName("office_format_table：borders=none 不带颜色与粗细（去线时这两个参数没有意义）")
     void formatTableNoneBordersOmitsModifiers() {
         when(bridge.executeOfficeCommand(any(), eq("format_table"), anyMap())).thenReturn("{}");

--- a/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsPollingTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/PythonToolsPollingTest.java
@@ -1,0 +1,102 @@
+package com.checkba.service.ai.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 审计条目：「TOCTOU race on _request_ready marker can replay a stale tool request or
+ * cross-deliver results」。Java 处理完一条 Python 侧的工具调用请求后，此前会在仅 100ms 之后
+ * 立刻又检查一次 requestReadyPath——如果 Python 侧还没来得及清理这个标记（两边各自独立
+ * 按 100ms 轮询，没有加锁），Java 会把同一条请求当成新请求重新处理一遍。
+ *
+ * pollForToolRequest 是纯文件系统状态机（static 方法，不需要真的起 Docker 容器），
+ * 直接用真实临时目录里的文件驱动，验证"标记还在就不重复处理，标记消失过一次才认下一次是新请求"。
+ */
+@DisplayName("PythonTools：_request_ready 标记的 TOCTOU")
+class PythonToolsPollingTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path requestReadyPath;
+    private AtomicInteger handlerCalls;
+
+    @BeforeEach
+    void setUp() {
+        requestReadyPath = tempDir.resolve("_request_ready");
+        handlerCalls = new AtomicInteger(0);
+    }
+
+    private PythonTools.ThrowingRunnable countingHandler() {
+        return handlerCalls::incrementAndGet;
+    }
+
+    @Test
+    @DisplayName("没有标记文件时不处理，也不进入 awaitingCleanup 状态")
+    void noMarkerMeansNoRequest() throws Exception {
+        boolean awaiting = PythonTools.pollForToolRequest(requestReadyPath, false, countingHandler());
+
+        assertFalse(awaiting);
+        assertEquals(0, handlerCalls.get());
+    }
+
+    @Test
+    @DisplayName("标记首次出现：处理一次并进入 awaitingCleanup 状态")
+    void firstMarkerIsHandledOnce() throws Exception {
+        Files.writeString(requestReadyPath, "1");
+
+        boolean awaiting = PythonTools.pollForToolRequest(requestReadyPath, false, countingHandler());
+
+        assertTrue(awaiting, "处理完一条请求后应进入等待 Python 清理的状态");
+        assertEquals(1, handlerCalls.get());
+    }
+
+    @Test
+    @DisplayName("修复：Python 还没清理标记时，同一个标记不能被重复当成新请求处理")
+    void staleMarkerIsNotReprocessedBeforeCleanup() throws Exception {
+        Files.writeString(requestReadyPath, "1");
+
+        // 第一次：真实处理这条请求
+        boolean awaiting = PythonTools.pollForToolRequest(requestReadyPath, false, countingHandler());
+        assertEquals(1, handlerCalls.get());
+        assertTrue(awaiting);
+
+        // 模拟审计条目描述的窗口：Python 还没来得及 os.remove(_request_ready)，
+        // Java 下一轮（100ms 后）又检查了一次——标记文件本身没有任何变化。
+        awaiting = PythonTools.pollForToolRequest(requestReadyPath, awaiting, countingHandler());
+
+        assertEquals(1, handlerCalls.get(), "标记没被 Python 清理过，不能被当成新请求重复处理");
+        assertTrue(awaiting, "仍应停留在等待清理的状态");
+    }
+
+    @Test
+    @DisplayName("Python 清理标记后，下一次同一标记消失的检查不触发处理，之后新标记才会被当成新请求")
+    void newMarkerAfterCleanupIsHandledAsNewRequest() throws Exception {
+        Files.writeString(requestReadyPath, "1");
+        boolean awaiting = PythonTools.pollForToolRequest(requestReadyPath, false, countingHandler());
+        assertEquals(1, handlerCalls.get());
+
+        // Python 清理了标记（对应 PYTHON_API_BRIDGE 里的 os.remove）
+        Files.delete(requestReadyPath);
+        awaiting = PythonTools.pollForToolRequest(requestReadyPath, awaiting, countingHandler());
+        assertFalse(awaiting, "标记已消失，翻篇");
+        assertEquals(1, handlerCalls.get(), "清理动作本身不应该触发处理");
+
+        // Python 发出下一条真正的新请求
+        Files.writeString(requestReadyPath, "1");
+        awaiting = PythonTools.pollForToolRequest(requestReadyPath, awaiting, countingHandler());
+
+        assertTrue(awaiting);
+        assertEquals(2, handlerCalls.get(), "清理过一次之后的新标记，必须被当成新请求处理");
+    }
+}


### PR DESCRIPTION
审计剩余清单里 AI 编排/工具/记忆那一组 21 条：19 条已修，2 条跳过（理由在文末），
外加复核时把其中一条跳过项换了方向做掉（第 20 条）。
每条先写测试看它红、改实现看它绿、再把实现临时还原确认测试真会红。

「故障被写成合法空结果」那一族（本轮审计贯穿的病症）：
1. MemCell 抽取：LLM 返回的 JSON 解析失败与「确认没什么可记」退化成同一个空列表。
   解析失败改为抛出，调用方用 -1 与「确认为空」的 0 区分开。
5. skill.yml 编码错误只在服务端日志里留一行，前端看到的是「没有这个 skill」。
   新增载入错误清单，让「解析出错」与「不存在」分得开。
16. 标为 failed 的待办从每轮提醒里消失，而完成判据只数 completed——催促永不结束。
   判据改成 completed + failed == total，正文如实列出已失败项。
19. 10 分钟轮询里一次瞬时网络错误就掀翻整条多阶段生成：改成跳过重试（仍受总轮数约束）。

数据正确性：
2. saveProjectMemory / saveUserMemory 的 find-then-insert 竞态（进程内互斥收窄窗口；
   未加 @Version 列，注释写明与 DB 提交之间仍有极窄残余，多实例不跨进程）。
3. 正则提取失败连带跳过整轮 LLM 记忆抽取（拆成两个独立 try/catch）。
8. 三个记忆检索工具完全不认 scope，文件级/会话级的记忆召不回来（补可选 scope 参数，
   不传时行为不变）。
10/15. 按 UTF-16 下标截断劈开代理对，注入上下文与证据摘录的尾巴变成乱码（两处各修）。
11. 超时/中断/取消的子 Agent 结果永远报 toolsUsed=[]、rounds=0，真实的部分进展被丢掉。
14. `enabled_by_default: "yes"` 这种带引号的真值被 Boolean.parseBoolean 悄悄当成 false，
   技能默认不开。改成显式识别 true/yes/on/1，认不出的保留安全默认值 true。

资源与竞态：
4. conversationTasks / userTasks 只清空内层列表、外层 key 永不移除（改用原子 compute）。
7. _request_ready 标记的 TOCTOU 会重放旧请求或串投结果（抽成状态机，
   处理完一条要等标记消失过一次才认下一条）。
12/13. AgentRunStateService.states 与 SkillRouter.activeByConversation 无界增长
   （分别加 7 天 / 24 小时的惰性过期扫描，后者对齐本仓 ConversationIssuanceService 先例）。
17. 文档检查点 blob 只写不删（在 clearForNewRun 时点删除是安全的，那之后已彻底不可达）。

参数与错误信息：
6. office_format_table 静默丢掉 borderColor / borderWidth（补校验）。
9. 三个法条工具先解引用后校验，缺参数时抛的是 NPE、包成一句
   「Error executing tool: null」——复现时是真的 NullPointerException，不是断言失败。
18. 缺 download_url 被拼进 URL 产生误导性 404（发请求前校验非空白）。

20. [复核时补做] pdf_to_word 的文本/扫描件路由用一刀切的「全文不足 20 字」
   子 agent 评估了三种替代判据后判为「换汤不换药」而跳过。我换了个方向：改成
   **按页密度**。一份几十页的扫描件每页盖一个 Bates 章，全文轻松过 20 字，
   于是被判成文本件走结构化转换——产出的 Word 里只有那些章，正文（图像）
   一个字都没有，而用户看到的是「转换成功」。中文法律文书正文一页在 700-1500 字量级，
   只剩页眉页码的页在 10-40 字量级，取 100 字/页。
   **刻意偏向 OCR**：判错方向的代价不对称——扫描件被当文本件是内容静默丢光，
   文本件被当扫描件最多是慢一点。并且顺手把「OCR 失败」那条路改成回退到已提取的
   文本层，所以偏向 OCR 也不会把一份能转的文档变成一句「请去装 MinerU」。
   既有那条断言返回 null 的用例按新契约改写而不是删掉——它保护的不变式没变。

刻意没做的 2 条：
- SkillRouter 的「无轮次隔离」：根因在 AgentOrchestrator 对同一 conversationId 无重入保护，
  正是维护者点名待拍板的那处架构改动。SkillRouter 内部没有任何「这是哪一轮」的标识可用，
  在它里面打补丁只会把竞态挪个位置。
- （原第 2 条跳过项 pdf_to_word 已由上面第 20 条做掉。）

全量 mvn -o clean test：2339 通过 0 失败 11 跳过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)