### PR TITLE
fix(backend): 启动期竞态、安装卸载互锁、重启后任务永远转圈等十五条（dev-board#74）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AccountController.java
+++ b/backend/src/main/java/com/checkba/controller/AccountController.java
@@ -7,6 +7,7 @@ import com.checkba.service.account.AccountService;
 import com.checkba.service.account.AccountSwitchCleanup;
 import com.checkba.service.account.MachineAccountGuard;
 import com.checkba.service.ai.PlatformAiChannel;
+import com.checkba.service.LangText;
 import com.checkba.service.ai.PlatformUsageAccountant;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -282,6 +283,15 @@ public class AccountController {
             // 官网不可达不该让整个用量面板报错——本地统计仍然有价值
             platform.put("available", false);
             platform.put("message", e.getMessage());
+            return platform;
+        } catch (RuntimeException e) {
+            // 官网返回的 JSON 形状与约定漂移（比如 entries 里混进非对象元素）会在这里抛
+            // ClassCastException 之类的运行时异常，不是 AccountException，此前接不住，
+            // 冒泡出 usage() 把 data.put("local", ...) 已经算好的本地统计一起丢掉。
+            // 契约漂移只应该降级 platform 这一段，处理方式与上面的 AccountException 一致。
+            log.warn("platform 用量解析失败（官网返回形状与约定不符）: {}", e.toString());
+            platform.put("available", false);
+            platform.put("message", LangText.of("平台用量暂不可用", "Platform usage is temporarily unavailable"));
             return platform;
         }
         putAiQuota(platform);

--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -9,11 +9,13 @@ import com.checkba.service.LangText;
 import com.checkba.service.UserService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
@@ -904,7 +906,11 @@ public class AuthController {
                 User user = staticUserService.getUserById(userId);
                 return user != null ? user.getDisplayName() : null; // Use DisplayName as creator name
             } catch (Exception e) {
-                 return null;
+                // 只补日志、不改行为：这里吞掉的异常与"用户真的不存在"返回同一个 null，
+                // 调用方（署名归属等）区分不出"这次查询失败"和"查无此人"，但改成向上
+                // 抛/返回错误码会动到所有调用方的既有语义，代价大于收益——先把故障留痕。
+                log.warn("getUsernameFromSession: getUserById({}) 失败，按 null 处理: {}", userId, e.toString());
+                return null;
             }
         }
         return null;

--- a/backend/src/main/java/com/checkba/controller/FeedbackIngestController.java
+++ b/backend/src/main/java/com/checkba/controller/FeedbackIngestController.java
@@ -68,34 +68,39 @@ public class FeedbackIngestController {
         }
         String installId = str(payload.get("installId"));
         String clientRef = str(payload.get("clientRef"));
-        try {
-            guard.check(installId, files);
-        } catch (IllegalStateException e) {
-            // 这台没开收件箱：让上传方看见 404 而不是「被限流」，免得它永远重试
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(e.getMessage()));
-        } catch (FeedbackIngestGuard.QuotaExceededException e) {
-            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(error(e.getMessage()));
-        } catch (IllegalArgumentException e) {
-            // 请求本身不合法（缺 installId、附件过大）：429 会让上传方一直重试同一条坏请求
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error(e.getMessage()));
-        }
-        if (clientRef == null || clientRef.isBlank()) {
-            return ResponseEntity.ok(error(LangText.of("缺少 clientRef", "Missing clientRef")));
-        }
-        try {
-            UserFeedback fb = feedbackService.ingest(installId, clientRef,
-                    new FeedbackService.IngestRequest(
-                            str(payload.get("kind")), str(payload.get("text")),
-                            str(payload.get("voiceTranscript")), str(payload.get("page")),
-                            str(payload.get("appVersion")), str(payload.get("platform")),
-                            str(payload.get("contextJson"))),
-                    files);
-            return ResponseEntity.ok(success(Map.of("id", fb.getId())));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.ok(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("反馈收件失败 installId={}", installId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(LangText.of("收件失败", "Ingest failed")));
+        // check() 只读 count 判定配额，真正的落库在 feedbackService.ingest() 里；两者包进
+        // 同一段按 installId 分条的互斥区间，堵住"两个并发请求都查到还没到每日上限、
+        // 都通过 check() 再各自落库"的窗口（见 FeedbackIngestGuard.lockFor 的注释）。
+        synchronized (guard.lockFor(installId)) {
+            try {
+                guard.check(installId, files);
+            } catch (IllegalStateException e) {
+                // 这台没开收件箱：让上传方看见 404 而不是「被限流」，免得它永远重试
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(e.getMessage()));
+            } catch (FeedbackIngestGuard.QuotaExceededException e) {
+                return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(error(e.getMessage()));
+            } catch (IllegalArgumentException e) {
+                // 请求本身不合法（缺 installId、附件过大）：429 会让上传方一直重试同一条坏请求
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error(e.getMessage()));
+            }
+            if (clientRef == null || clientRef.isBlank()) {
+                return ResponseEntity.ok(error(LangText.of("缺少 clientRef", "Missing clientRef")));
+            }
+            try {
+                UserFeedback fb = feedbackService.ingest(installId, clientRef,
+                        new FeedbackService.IngestRequest(
+                                str(payload.get("kind")), str(payload.get("text")),
+                                str(payload.get("voiceTranscript")), str(payload.get("page")),
+                                str(payload.get("appVersion")), str(payload.get("platform")),
+                                str(payload.get("contextJson"))),
+                        files);
+                return ResponseEntity.ok(success(Map.of("id", fb.getId())));
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.ok(error(e.getMessage()));
+            } catch (Exception e) {
+                log.error("反馈收件失败 installId={}", installId, e);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error(LangText.of("收件失败", "Ingest failed")));
+            }
         }
     }
 

--- a/backend/src/main/java/com/checkba/repository/DeviceTokenRepository.java
+++ b/backend/src/main/java/com/checkba/repository/DeviceTokenRepository.java
@@ -2,11 +2,23 @@ package com.checkba.repository;
 
 import com.checkba.model.entity.DeviceToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
     Optional<DeviceToken> findByTokenHash(String tokenHash);
     List<DeviceToken> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 空转设备令牌清理用：见 DeviceTokenService.purgeIdleTokens。lastUsedAt 从未用过时为
+    // null（issue() 不写它），此时按 createdAt 兜底判定，否则永久发出一次就再也不清理。
+    @Modifying
+    @Query("DELETE FROM DeviceToken t WHERE " +
+            "(t.lastUsedAt IS NOT NULL AND t.lastUsedAt < :cutoff) OR " +
+            "(t.lastUsedAt IS NULL AND t.createdAt < :cutoff)")
+    int deleteIdleBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/backend/src/main/java/com/checkba/service/DeviceTokenService.java
+++ b/backend/src/main/java/com/checkba/service/DeviceTokenService.java
@@ -3,6 +3,8 @@ package com.checkba.service;
 import com.checkba.controller.AuthController;
 import com.checkba.model.entity.DeviceToken;
 import com.checkba.repository.DeviceTokenRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -16,6 +18,8 @@ import java.util.List;
 
 @Service
 public class DeviceTokenService {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DeviceTokenService.class);
 
     public static final String TOKEN_PREFIX = "awdt_";
 
@@ -78,6 +82,21 @@ public class DeviceTokenService {
 
     public List<DeviceToken> listMine(Long userId) {
         return repository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    private static final long IDLE_EXPIRY_DAYS = 365;
+
+    @Scheduled(fixedDelay = 24 * 60 * 60 * 1000L, initialDelay = 90 * 60 * 1000L)
+    @Transactional
+    public void purgeIdleTokens() {
+        try {
+            int removed = repository.deleteIdleBefore(LocalDateTime.now().minusDays(IDLE_EXPIRY_DAYS));
+            if (removed > 0) {
+                log.info("清理空转设备令牌 {} 条（>{} 天未用）", removed, IDLE_EXPIRY_DAYS);
+            }
+        } catch (Exception e) {
+            log.warn("空转设备令牌清理失败: {}", e.toString());
+        }
     }
 
     private static String sha256(String s) {

--- a/backend/src/main/java/com/checkba/service/ProjectMemberService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectMemberService.java
@@ -8,6 +8,7 @@ import com.checkba.repository.ProjectMemberRepository;
 import com.checkba.repository.ProjectRepository;
 import com.checkba.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,7 +69,16 @@ public class ProjectMemberService {
         member.setProjectId(projectId);
         member.setUserId(user.getId());
         member.setRole(role);
-        projectMemberRepository.save(member);
+        try {
+            projectMemberRepository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            // 先查后插不是原子的：两个并发请求都查到"不在项目中"就都会插入，第二个撞上
+            // (project_id, user_id) 唯一约束。这里不追加恢复性查询——本方法整体
+            // @Transactional，插入失败后同一事务在部分数据库（如 Postgres）上已经
+            // 不可再用，追加查询本身会再报错——只把异常翻译成查重分支本该给出的提示，
+            // 跟着事务一起干净回滚。
+            throw new IllegalArgumentException("用户已在项目中");
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
+++ b/backend/src/main/java/com/checkba/service/ShareholderMeetingService.java
@@ -185,25 +185,47 @@ public class ShareholderMeetingService {
     }
 
     /**
+     * 同一 checkId 的底稿夹装配互斥用的分条锁。
+     *
+     * <p>ensureFolder 是「查不到就建」，查和建之间没有锁；start()/fetchFromCninfo() 都会
+     * 调 ensureWorkpaperFolders，双击「开始核查」或前端网络重试都可能并发命中。这条链路
+     * 里 ensureWorkpaperFolders/ensureFolder 本身都不是 @Transactional，真正的提交只发生
+     * 在 projectFileService.createFolder() 这个独立代理调用内部、同步完成——所以把锁包在
+     * 这整段外层能如实盖住提交，不是「锁在 @Transactional 方法里、提交前就放了」那种假修。
+     *
+     * <p>用固定条数的锁数组而不是按 id 建锁的 Map：写法与 ProjectMemoryExtractor 的
+     * PROJECT_LOCKS 同款，避免锁随 check 数量无界增长。单实例基线，多实例部署需要外置锁。
+     */
+
+
+    /**
      * 确保底稿夹五级子目录就绪，回写 workpaperFolderId。
      * 返回 slot 子文件夹名 → 文件夹 ID 的映射。
      */
+    /**
+     * 这里不再自己加锁：真正需要互斥的是「同名文件夹的查了再建」，而那道闸已经在
+     * {@link #ensureFolder} 里按 (projectId, parentId, name) 加了，并且配了 REQUIRES_NEW
+     * 让它盖住那次独立提交。在外面再包一层按 checkId 的锁是同一件事的第二套机制，
+     * 保护范围更粗、还容易让下一个人不知道该看哪一个。
+     */
     public Map<String, Long> ensureWorkpaperFolders(ShareholderMeetingCheck check, Long userId) {
-        Long projectId = check.getProjectId();
-        ProjectFile root = ensureFolder(projectId, null, WORKPAPER_ROOT, userId);
-        String checkFolderName = sanitizeName(check.getCompanyName() + "_" + check.getMeetingName());
-        ProjectFile checkFolder = ensureFolder(projectId, root.getId(), checkFolderName, userId);
+        {
+            Long projectId = check.getProjectId();
+            ProjectFile root = ensureFolder(projectId, null, WORKPAPER_ROOT, userId);
+            String checkFolderName = sanitizeName(check.getCompanyName() + "_" + check.getMeetingName());
+            ProjectFile checkFolder = ensureFolder(projectId, root.getId(), checkFolderName, userId);
 
-        Map<String, Long> folders = new LinkedHashMap<>();
-        for (String sub : List.of(FOLDER_NOTICE, FOLDER_RESOLUTION, FOLDER_VOTE, FOLDER_WORKPAPER, FOLDER_OPINION)) {
-            folders.put(sub, ensureFolder(projectId, checkFolder.getId(), sub, userId).getId());
-        }
+            Map<String, Long> folders = new LinkedHashMap<>();
+            for (String sub : List.of(FOLDER_NOTICE, FOLDER_RESOLUTION, FOLDER_VOTE, FOLDER_WORKPAPER, FOLDER_OPINION)) {
+                folders.put(sub, ensureFolder(projectId, checkFolder.getId(), sub, userId).getId());
+            }
 
-        if (!checkFolder.getId().equals(check.getWorkpaperFolderId())) {
-            check.setWorkpaperFolderId(checkFolder.getId());
-            checkRepository.save(check);
+            if (!checkFolder.getId().equals(check.getWorkpaperFolderId())) {
+                check.setWorkpaperFolderId(checkFolder.getId());
+                checkRepository.save(check);
+            }
+            return folders;
         }
-        return folders;
     }
 
     /** 文件夹/文件名清洗：剥掉路径分隔符等非法字符（validateNodeName 会拒绝） */

--- a/backend/src/main/java/com/checkba/service/feedback/FeedbackIngestGuard.java
+++ b/backend/src/main/java/com/checkba/service/feedback/FeedbackIngestGuard.java
@@ -83,6 +83,32 @@ public class FeedbackIngestGuard {
         }
     }
 
+    /**
+     * installId 维度的分条锁，供 {@code FeedbackIngestController#ingest} 把
+     * check() 与真正的落库动作（{@code FeedbackService.ingest}）包进同一段互斥区间。
+     *
+     * <p>check() 只读 count，真正的插入在别处（FeedbackService.ingest），二者之间
+     * 此前完全没有互斥：两个并发请求都能查到"还没到每日上限"再各自落库，共同越过配额。
+     * 全站日上限不在这把锁的保护范围内——不同 installId 之间仍可能小幅越过，
+     * 但这不是这道闸主要防的"同一个人一次性猛刷"场景，2000/天的余量也足够宽松，
+     * 不值得为此换成跨请求的全局串行。
+     *
+     * <p>固定条数的锁数组而非按 installId 建 Map：写法与 ProjectMemoryExtractor 的
+     * PROJECT_LOCKS 同款，避免锁随 installId 数量无界增长。单实例基线。
+     */
+    private static final Object[] INSTALL_LOCKS = new Object[32];
+
+    static {
+        for (int i = 0; i < INSTALL_LOCKS.length; i++) {
+            INSTALL_LOCKS[i] = new Object();
+        }
+    }
+
+    public Object lockFor(String installId) {
+        int idx = installId == null ? 0 : Math.floorMod(installId.hashCode(), INSTALL_LOCKS.length);
+        return INSTALL_LOCKS[idx];
+    }
+
     /** 供状态展示：收件箱是否在收、今天收了多少。 */
     public long todayCount() {
         return feedbackRepository.countByCreatedAtAfter(LocalDateTime.now().minusDays(1));

--- a/backend/src/main/java/com/checkba/service/feedback/FeedbackService.java
+++ b/backend/src/main/java/com/checkba/service/feedback/FeedbackService.java
@@ -59,6 +59,9 @@ public class FeedbackService {
         if (text.length() > MAX_TEXT_CHARS) {
             text = text.substring(0, MAX_TEXT_CHARS);
         }
+        // 先把全部附件校验完（只读 MultipartFile 自身元信息，不碰磁盘/DB），
+        // 任何一个不合法都在这里抛出，不该落下一条已提交、附件却只存了一半的行。
+        validateAttachments(safeFiles);
 
         UserFeedback fb = new UserFeedback();
         fb.setUserId(userId);
@@ -90,29 +93,43 @@ public class FeedbackService {
         return feedbackRepository.save(fb);
     }
 
-    private List<FeedbackAttachment> storeAttachments(Long feedbackId, List<MultipartFile> files) throws IOException {
-        Path dir = feedbackDir(feedbackId);
-        Files.createDirectories(dir);
-        List<FeedbackAttachment> out = new ArrayList<>();
+    /**
+     * 只读每个 MultipartFile 自身的元信息（体积/ContentType），不碰磁盘也不碰 DB——
+     * 因此可以、也必须在建反馈行之前先跑完整批，任何一个不合法就整体拒绝，
+     * 不会出现"前几个已经落库、后面这个才失败"的半成品状态。
+     * 判定逻辑必须和 storeAttachments 的落盘分支逐条对应，两边分开是因为
+     * "校验会不会通过"与"通过之后具体怎么存"是两件不同的事，硬合成一趟循环
+     * 才是当初留下这个坑的原因。
+     */
+    private void validateAttachments(List<MultipartFile> files) {
         int images = 0;
         int audios = 0;
-        int seq = 0;
         for (MultipartFile f : files) {
             if (f == null || f.isEmpty()) continue;
             if (f.getSize() > MAX_ATTACHMENT_BYTES) {
                 throw new IllegalArgumentException(LangText.of("附件过大（上限 20MB）：", "Attachment is too large (20MB limit): ") + safeName(f.getOriginalFilename()));
             }
             String ct = f.getContentType() == null ? "" : f.getContentType().toLowerCase();
-            String type;
             if (ct.startsWith("audio/")) {
                 if (++audios > MAX_AUDIOS) throw new IllegalArgumentException(LangText.of("最多附 1 段语音", "At most 1 voice note may be attached"));
-                type = FeedbackAttachment.TYPE_AUDIO;
             } else if (ct.startsWith("image/")) {
                 if (++images > MAX_IMAGES) throw new IllegalArgumentException(LangText.of("最多附 " + MAX_IMAGES + " 张图片", "At most " + MAX_IMAGES + " images may be attached"));
-                type = FeedbackAttachment.TYPE_IMAGE;
             } else {
                 throw new IllegalArgumentException(LangText.of("只接受图片与语音附件：", "Only image and voice attachments are accepted: ") + safeName(f.getOriginalFilename()));
             }
+        }
+    }
+
+    /** 落盘 + 落库。调用前必须已经过 validateAttachments，这里不再重复校验、只管存。 */
+    private List<FeedbackAttachment> storeAttachments(Long feedbackId, List<MultipartFile> files) throws IOException {
+        Path dir = feedbackDir(feedbackId);
+        Files.createDirectories(dir);
+        List<FeedbackAttachment> out = new ArrayList<>();
+        int seq = 0;
+        for (MultipartFile f : files) {
+            if (f == null || f.isEmpty()) continue;
+            String ct = f.getContentType() == null ? "" : f.getContentType().toLowerCase();
+            String type = ct.startsWith("audio/") ? FeedbackAttachment.TYPE_AUDIO : FeedbackAttachment.TYPE_IMAGE;
 
             // 落盘文件名由服务端生成：客户端文件名一律只作展示，不参与路径拼接
             String ext = extensionFor(type, ct, f.getOriginalFilename());
@@ -166,6 +183,9 @@ public class FeedbackService {
             throw new IllegalArgumentException(LangText.of("空反馈", "Empty feedback"));
         }
         if (text.length() > MAX_TEXT_CHARS) text = text.substring(0, MAX_TEXT_CHARS);
+        // 与 submit() 同理：先校验完全部附件，再落第一行库——ingest() 按 clientRef 去重，
+        // 半成品行一旦落库，后续同 clientRef 的重试会直接命中它、永远没有机会补全附件。
+        validateAttachments(safeFiles);
 
         UserFeedback fb = new UserFeedback();
         fb.setUserId(null);

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
@@ -317,8 +317,25 @@ public class MeetingTranscriptionService {
     /**
      * 提交转写。同步只做状态置位（TRANSCRIBING），耗时步骤进后台执行器。
      * RECORDED / FAILED 可提交；TRANSCRIBING/TRANSCRIBED 幂等返回。
+     *
+     * <p>方法开头的状态判定与真正落库的 {@code setStatus(TRANSCRIBING) + save()} 之间
+     * 隔着一整段校验逻辑，此前中间完全没有互斥：自动结束时触发一次 + 客户端超时重试
+     * 一次，或"重新提交转写"连点两下，都可能各自通过判定、各自提交一次——BYOK 档是
+     * 两次真实的听悟建任务调用，platform 档是两次网关提交（对同一次转写扣两次费）。
+     * 复用 {@link #refreshLock}：与 {@link #refreshIfNeeded} 共享同一把按会议维度的锁，
+     * 这两个方法本就在读改写同一个 status 字段，理应互斥。
      */
     public MeetingRecording startTranscription(Long meetingId) {
+        ReentrantLock lock = refreshLock(meetingId);
+        lock.lock();
+        try {
+            return doStartTranscription(meetingId);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private MeetingRecording doStartTranscription(Long meetingId) {
         MeetingRecording meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new IllegalArgumentException(
                         LangText.of("会议不存在: ", "Meeting not found: ") + meetingId));

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerMailer.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerMailer.java
@@ -6,7 +6,10 @@ import com.checkba.service.mail.MailRouter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 「建议 / 拿不准」这条出口：给维护者发一封信。
@@ -26,6 +29,20 @@ public class OptimizerMailer implements OptimizerNotifier {
 
     private final OptimizerProperties props;
     private final MailRouter mailRouter;
+
+    /**
+     * 已经成功发信的 (feedbackId, 收件人) 记录，进程内存、不落库。
+     *
+     * <p>病灶：多收件人分属不同通道，某条通道故障时该收件人发送失败，异常冒泡出去，
+     * 外层 notifyOrFail 把这条反馈判失败转 NEW 重试；下一轮定时任务重跑会把已经
+     * 收到过的收件人再发一封，故障通道修好之前每天都重复。
+     *
+     * <p>不落库的理由：optimizer.mail.to 是维护者自己的邮箱，重发一次是「视觉上的
+     * 不一致」而不是数据丢失（审计原话），不值得为它加表/加列。代价是进程重启会
+     * 清空这份记忆，重启后最多再重发一轮——可接受，且 optimizer 本来就是每天一次的
+     * 定时任务，重启不常发生在两次运行之间。
+     */
+    private final Set<String> mailed = ConcurrentHashMap.newKeySet();
 
     public OptimizerMailer(OptimizerProperties props, MailRouter mailRouter) {
         this.props = props;
@@ -69,11 +86,23 @@ public class OptimizerMailer implements OptimizerNotifier {
         String body = body(fb, triage, attachments, source, extraNote);
         // 逐个收件人分别发：多个收件人可能分属不同通道（维护者的 Gmail 与同事的 QQ 邮箱
         // 走的不是同一条），塞进同一封信就只能挑一条通道发，另一半到达率白丢。
+        // 全部收件人都要试一遍，不能因为前一个失败就不再尝试后面的——否则同一次重试
+        // 永远只可能推进到"第一个故障收件人"为止，排在它后面的人永远收不到信。
+        List<String> failed = new ArrayList<>();
         for (String to : props.getMail().getTo().split(",")) {
             String trimmed = to.trim();
-            if (!trimmed.isEmpty()) {
+            if (trimmed.isEmpty()) continue;
+            String key = fb.getId() + ":" + trimmed;
+            if (!mailed.add(key)) continue; // 这条反馈已经成功发给过这个收件人，跳过
+            try {
                 mailRouter.send(trimmed, subject, body);
+            } catch (RuntimeException e) {
+                mailed.remove(key); // 没发成功，撤销标记，留给下一轮重试
+                failed.add(trimmed);
             }
+        }
+        if (!failed.isEmpty()) {
+            throw new IllegalStateException("邮件发送失败: " + String.join(",", failed));
         }
         log.info("[optimizer] 已发送反馈 #{} 的邮件到 {}", fb.getId(), props.getMail().getTo());
     }

--- a/backend/src/main/java/com/checkba/service/pack/NativePackService.java
+++ b/backend/src/main/java/com/checkba/service/pack/NativePackService.java
@@ -125,6 +125,22 @@ public class NativePackService {
     private final Map<String, CachedManifest> manifestCache = new ConcurrentHashMap<>();
 
     /**
+     * 按 packId 维度的互斥，取代此前 install()/uninstall() 共用的同一把 {@code synchronized(this)}
+     * 服务级对象锁。旧写法下卸载一个已装好的 pack B 会被另一个正在下载的、完全无关的 pack A
+     * 卡住——install() 一次下载最长可以跑到 3 次重试 × 10 分钟超时，uninstall() 的请求线程
+     * 会在这整段时间里空等，没有任何报错或提示。装/卸不同 pack 之间不该互相阻塞；
+     * 同一个 packId 上的并发操作仍需要互斥（下载中途不能被卸载删了目录）。
+     * packId 来自固定的插件市场目录（见 requireValidId 的 PACK_ID 校验），不是用户可任意
+     * 生成的值，这个 map 不会无界增长——与本类里 statuses/manifestCache 同一形态。
+     */
+    private final Map<String, Object> packLocks = new ConcurrentHashMap<>();
+
+    /** 包级可见性（无修饰符）纯为单测：并发回归要从外面拿到与 install()/uninstall() 同一把锁。 */
+    Object packLock(String packId) {
+        return packLocks.computeIfAbsent(packId, id -> new Object());
+    }
+
+    /**
      * 「随包内置资源在场」探针：packId -> 判定函数，由资源消费方（如
      * {@link com.checkba.service.ai.LitigationVisualService}）自行登记。
      *
@@ -352,32 +368,34 @@ public class NativePackService {
      *
      * @return 安装的版本号
      */
-    public synchronized String install(String packId) {
+    public String install(String packId) {
         requireValidId(packId);
-        requireEnabled();
-        PackStatus st = liveStatus(packId);
-        try {
-            st.setState(STATE_DOWNLOADING);
-            st.setError(null);
-            String version = doInstall(packId, st);
-            st.setState(STATE_READY);
-            st.setInstalledVersion(version);
-            // 装完让资源消费方的运行时解析缓存失效——不然用户装完 pack 不重启后端，
-            // 面板/工具仍然显示上一次探测出的「不可用」。
-            notifyPackChanged(packId);
-            return version;
-        } catch (RuntimeException e) {
-            // 因封禁被拒不是「安装失败」：状态要如实停在 revoked，否则广场把平台封禁
-            // 显示成一次网络出错，用户只会一遍遍重试
-            JSONObject current = readCurrent(packId);
-            if (current != null && current.getBool("revoked", false)) {
-                st.setState(STATE_REVOKED);
-                st.setInstalledVersion(current.getStr("version"));
-            } else {
-                st.setState(STATE_FAILED);
+        synchronized (packLock(packId)) {
+            requireEnabled();
+            PackStatus st = liveStatus(packId);
+            try {
+                st.setState(STATE_DOWNLOADING);
+                st.setError(null);
+                String version = doInstall(packId, st);
+                st.setState(STATE_READY);
+                st.setInstalledVersion(version);
+                // 装完让资源消费方的运行时解析缓存失效——不然用户装完 pack 不重启后端，
+                // 面板/工具仍然显示上一次探测出的「不可用」。
+                notifyPackChanged(packId);
+                return version;
+            } catch (RuntimeException e) {
+                // 因封禁被拒不是「安装失败」：状态要如实停在 revoked，否则广场把平台封禁
+                // 显示成一次网络出错，用户只会一遍遍重试
+                JSONObject current = readCurrent(packId);
+                if (current != null && current.getBool("revoked", false)) {
+                    st.setState(STATE_REVOKED);
+                    st.setInstalledVersion(current.getStr("version"));
+                } else {
+                    st.setState(STATE_FAILED);
+                }
+                st.setError(e.getMessage());
+                throw e;
             }
-            st.setError(e.getMessage());
-            throw e;
         }
     }
 
@@ -492,36 +510,38 @@ public class NativePackService {
     }
 
     /** 卸载：删 packs/&lt;id&gt;/ 整目录（含 current.json）。canonical 守卫只许删正下方。 */
-    public synchronized void uninstall(String packId) {
+    public void uninstall(String packId) {
         requireValidId(packId);
-        Path root = packsRoot();
-        Path dir = root.resolve(packId);
-        try {
-            String canonicalRoot = root.toFile().getCanonicalPath();
-            String canonicalDir = dir.toFile().getCanonicalPath();
-            if (!canonicalDir.startsWith(canonicalRoot + java.io.File.separator)) {
-                throw new IllegalArgumentException(LangText.of("非法资源包目录: ", "Invalid pack directory: ") + packId);
+        synchronized (packLock(packId)) {
+            Path root = packsRoot();
+            Path dir = root.resolve(packId);
+            try {
+                String canonicalRoot = root.toFile().getCanonicalPath();
+                String canonicalDir = dir.toFile().getCanonicalPath();
+                if (!canonicalDir.startsWith(canonicalRoot + java.io.File.separator)) {
+                    throw new IllegalArgumentException(LangText.of("非法资源包目录: ", "Invalid pack directory: ") + packId);
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException(LangText.of("路径检查失败: ", "Path check failed: ") + e.getMessage());
             }
-        } catch (IOException e) {
-            throw new IllegalStateException(LangText.of("路径检查失败: ", "Path check failed: ") + e.getMessage());
-        }
-        if (!Files.isDirectory(dir)) {
-            // 从未装成功：pack 目录不存在，但可能有失败安装留下的 staging 残留（.part 等）。
-            // 卸载本该是幂等的收口动作——不能因为"没装成功"就拒绝清理，把用户卡在
-            // 「装不上、卸不掉」的死循环里（见 416 断点续传死循环的排查记录）。
+            if (!Files.isDirectory(dir)) {
+                // 从未装成功：pack 目录不存在，但可能有失败安装留下的 staging 残留（.part 等）。
+                // 卸载本该是幂等的收口动作——不能因为"没装成功"就拒绝清理，把用户卡在
+                // 「装不上、卸不掉」的死循环里（见 416 断点续传死循环的排查记录）。
+                deleteStaging(packId);
+                statuses.remove(packId);
+                manifestCache.remove(packId);
+                log.info("Pack {} was never installed; cleared staging leftovers only", packId);
+                return;
+            }
+            FileUtil.del(dir.toFile());
             deleteStaging(packId);
             statuses.remove(packId);
             manifestCache.remove(packId);
-            log.info("Pack {} was never installed; cleared staging leftovers only", packId);
-            return;
+            log.info("Uninstalled native pack {}", packId);
+            // 卸载同理要让缓存失效——否则面板/工具会照着卸载前的探测结果继续显示可用。
+            notifyPackChanged(packId);
         }
-        FileUtil.del(dir.toFile());
-        deleteStaging(packId);
-        statuses.remove(packId);
-        manifestCache.remove(packId);
-        log.info("Uninstalled native pack {}", packId);
-        // 卸载同理要让缓存失效——否则面板/工具会照着卸载前的探测结果继续显示可用。
-        notifyPackChanged(packId);
     }
 
     // ==================== 下载 ====================
@@ -915,17 +935,26 @@ public class NativePackService {
         List<String> hit = new ArrayList<>();
         for (RevokedPack r : revoked) {
             if (r.id() == null) continue;
-            JSONObject current = readCurrent(r.id());
-            if (current == null) continue;
-            String installed = current.getStr("version");
-            boolean matches = "*".equals(r.version()) || r.version() == null || r.version().equals(installed);
-            if (!matches || current.getBool("revoked", false)) continue;
-            writeCurrent(r.id(), installed, true);
-            statuses.remove(r.id());
-            hit.add(r.id());
-            log.warn("Native pack {} v{} revoked by platform: {}", r.id(), installed, r.reason());
-            // 封禁同样是「资源解析结果变了」，消费方缓存的可用性判定要跟着刷新
-            notifyPackChanged(r.id());
+            // 读 current.json -> 判定 -> 写回不是原子的；install()/uninstall() 收尾时也会写
+            // current.json（升级完成 writeCurrent + pruneOtherVersions 删旧版本目录）。不加锁
+            // 的话，这里读到的版本号可能是并发升级提交之前的快照，写回时就会用一个已经被
+            // pruneOtherVersions 删掉目录的旧版本号，把刚升级完的新版本盖掉——新版本没有被
+            // 封禁，却被这次过期的写操作误标成 revoked。与 install()/uninstall() 共用同一把
+            // 按 packId 分的锁（packLock），跟它们对这一个 pack 的临界区互斥即可堵死这个窗口
+            // ——不用 synchronized(this)：那会让这里顺带卡住其它完全无关 pack 的安装/卸载。
+            synchronized (packLock(r.id())) {
+                JSONObject current = readCurrent(r.id());
+                if (current == null) continue;
+                String installed = current.getStr("version");
+                boolean matches = "*".equals(r.version()) || r.version() == null || r.version().equals(installed);
+                if (!matches || current.getBool("revoked", false)) continue;
+                writeCurrent(r.id(), installed, true);
+                statuses.remove(r.id());
+                hit.add(r.id());
+                log.warn("Native pack {} v{} revoked by platform: {}", r.id(), installed, r.reason());
+                // 封禁同样是「资源解析结果变了」，消费方缓存的可用性判定要跟着刷新
+                notifyPackChanged(r.id());
+            }
         }
         return hit;
     }

--- a/backend/src/main/java/com/checkba/service/platform/ExternalProviderBackfill.java
+++ b/backend/src/main/java/com/checkba/service/platform/ExternalProviderBackfill.java
@@ -1,10 +1,9 @@
 package com.checkba.service.platform;
 
 import com.checkba.service.SystemSettingService;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -79,8 +78,17 @@ public class ExternalProviderBackfill {
         injectedDefaults.put("external.pkulaw.token", pkulawToken);
     }
 
-    @EventListener(ApplicationReadyEvent.class)
-    public void onStartup() {
+    /**
+     * 刻意用 {@code @PostConstruct} 而不是 {@code ApplicationReadyEvent}：内嵌 Tomcat
+     * 在 {@code refresh()} 收尾（{@code finishRefresh -> startWebServer}）就已经开始收
+     * 连接，而 {@code ApplicationReadyEvent} 要等 {@code refresh()} 返回、
+     * {@code CommandLineRunner} 跑完才发出——只挂后者，升级后第一批落在这个窗口里的
+     * 请求会撞见还没回填的默认档位（见类注释）。{@code @PostConstruct} 在本 bean
+     * 的依赖（{@code SystemSettingService}/{@code ExternalProviderResolver}）已经
+     * 就绪之后、且必然早于 {@code finishRefresh()} 执行，能把这个窗口关掉。
+     */
+    @PostConstruct
+    void onStartup() {
         try {
             int written = backfill();
             if (written > 0) {

--- a/backend/src/main/java/com/checkba/service/platform/PlatformGatewayClient.java
+++ b/backend/src/main/java/com/checkba/service/platform/PlatformGatewayClient.java
@@ -85,7 +85,11 @@ public class PlatformGatewayClient {
 
         PlatformGatewayTransport.Reply reply =
                 transport.send("POST", siteProfileService.baseUrl() + path, key, idempotencyKey, body, timeoutSeconds);
-        if (reply.networkFailure()) {
+        // 中断与其它网络失败长得一模一样（transport 捕获 InterruptedException 后恢复中断标志、
+        // 照样返回 NETWORK_FAILURE）；线程已经被要求停下时不该再发起一次最长可以再等
+        // timeoutSeconds 的阻塞调用——那会拖慢优雅关闭。只 peek 不清，标志留给线程原本的
+        // 所有者去处理。
+        if (reply.networkFailure() && !Thread.currentThread().isInterrupted()) {
             reply = transport.send("POST", siteProfileService.baseUrl() + path, key, idempotencyKey, body, timeoutSeconds);
         }
         return handle(reply);
@@ -96,7 +100,7 @@ public class PlatformGatewayClient {
         String key = requireKey();
         PlatformGatewayTransport.Reply reply =
                 transport.send("GET", siteProfileService.baseUrl() + path, key, null, null, timeoutSeconds);
-        if (reply.networkFailure()) {
+        if (reply.networkFailure() && !Thread.currentThread().isInterrupted()) {
             reply = transport.send("GET", siteProfileService.baseUrl() + path, key, null, null, timeoutSeconds);
         }
         return handle(reply);

--- a/backend/src/main/java/com/checkba/service/telemetry/TelemetryService.java
+++ b/backend/src/main/java/com/checkba/service/telemetry/TelemetryService.java
@@ -15,7 +15,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -37,14 +39,29 @@ public class TelemetryService {
     private final ObjectMapper mapper = new ObjectMapper();
     private final String appVersion;
 
-    /** 独立于业务线程池：埋点洪峰不与编排循环抢线程；有界队列，满了直接丢 */
-    private final ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
-        Thread t = new Thread(r, "telemetry-writer");
-        t.setDaemon(true);
-        return t;
-    });
+    /**
+     * 队列容量：类注释一直写着"有界队列，满了直接丢"，但此前用
+     * {@code Executors.newSingleThreadExecutor(...)} 构造，背后是无界
+     * {@code LinkedBlockingQueue}——名不副实，DB 持续卡顿时排队的 Runnable
+     * （每个都攥着一个 Map + Instant）会无界堆积，把这条"过载安全阀"变成堆内存隐患。
+     * 2000 是按埋点这个场景选的：一次很猛的突发（如一轮工具调用风暴）也远用不到这个量级，
+     * 真撞上多半是 DB 卡死这种异常情况，此时"丢新事件保内存"就是设计里说的正确行为。
+     */
+    static final int QUEUE_CAPACITY = 2000;
 
+    /** 声明顺序必须在 executor 之前——下面的拒绝策略里引用它，字段初始化按声明顺序跑。 */
     private final AtomicLong dropped = new AtomicLong();
+
+    /** 独立于业务线程池：埋点洪峰不与编排循环抢线程；有界队列，满了直接丢 */
+    private final ExecutorService executor = new ThreadPoolExecutor(
+            1, 1, 0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(QUEUE_CAPACITY),
+            r -> {
+                Thread t = new Thread(r, "telemetry-writer");
+                t.setDaemon(true);
+                return t;
+            },
+            (r, exec) -> dropped.incrementAndGet()); // 队列满了直接丢弃计数，不抛异常、不阻塞调用方
 
     public TelemetryService(TelemetryEventRepository repository,
                             InstallIdentityService identity,

--- a/backend/src/main/java/com/checkba/service/telemetry/TelemetryUploadService.java
+++ b/backend/src/main/java/com/checkba/service/telemetry/TelemetryUploadService.java
@@ -105,10 +105,13 @@ public class TelemetryUploadService {
         sync();
     }
 
+    /** 补算窗口：与 uploadPendingRollups 的补传窗口口径一致，不无限往前找缺口。 */
+    private static final int BACKFILL_DAYS = 30;
+
     /** 聚合昨日（及漏算日）并上报未传的 rollup；Tier 2 开时批量上报事件。全程静默失败。 */
     public void sync() {
         try {
-            rollupService.rollupFor(LocalDate.now().minusDays(1));
+            backfillMissingRollups();
             if (!settings.rollupEnabled()) return;
             uploadPendingRollups();
             if (settings.eventsEnabled()) {
@@ -116,6 +119,26 @@ public class TelemetryUploadService {
             }
         } catch (Exception e) {
             log.debug("telemetry 上报轮次失败（静默）: {}", e.toString());
+        }
+    }
+
+    /**
+     * 这是一个不常驻 24/7 的桌面应用；此前每轮只补算"昨日"，应用关了几天没开
+     * （长周末）中间跳过的那几天永远没人替它们算——events 表里有数据，
+     * TelemetryDailyRollup 行永远不会出现，那几天的匿名统计静默永久丢失。
+     *
+     * <p>昨日无条件重算：临近午夜落库的事件可能在第二天才被处理，用旧值覆盖同一天
+     * 是既有行为，不能因为加了补算就丢了这条。更早的日子只在完全没有 rollup 行时才
+     * 补——rollupFor 本身是幂等 upsert，但没必要每天重新算 29 天前已经算对的数据。
+     */
+    private void backfillMissingRollups() {
+        LocalDate today = LocalDate.now();
+        rollupService.rollupFor(today.minusDays(1));
+        for (int i = 2; i <= BACKFILL_DAYS; i++) {
+            LocalDate day = today.minusDays(i);
+            if (rollupRepository.findByDate(day).isEmpty()) {
+                rollupService.rollupFor(day);
+            }
         }
     }
 

--- a/backend/src/test/java/com/checkba/controller/AccountControllerUsageMalformedLedgerTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerUsageMalformedLedgerTest.java
@@ -1,0 +1,58 @@
+package com.checkba.controller;
+
+import com.checkba.repository.TokenUsageRepository;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.account.AccountSwitchCleanup;
+import com.checkba.service.account.MachineAccountGuard;
+import com.checkba.service.ai.PlatformAiChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 病灶：GET /api/account/usage 的 platformUsage() 只捕获 AccountException。官网
+ * /api/account/ledger 的 entries 数组里混进一个非对象元素（契约漂移/网站侧 bug）会在
+ * .stream().filter(entry -&gt; ... entry.get("kind") ...) 这一步抛 ClassCastException——
+ * 不是 AccountException，接不住，冒泡出 usage()，把已经算好的 local 段一起丢掉。
+ * 本该只是「platform 段降级」，结果变成整个端点报错，即使本地统计完全正常。
+ */
+class AccountControllerUsageMalformedLedgerTest {
+
+    private AccountController controller;
+    private AccountService accountService;
+
+    @BeforeEach
+    void setUp() {
+        AuthController.registerLocalIdentityService(null);
+        accountService = mock(AccountService.class);
+        MachineAccountGuard guard = mock(MachineAccountGuard.class); // requireMachineScope 默认放行（void no-op）
+        controller = new AccountController(accountService, mock(PlatformAiChannel.class),
+                mock(AccountSwitchCleanup.class), mock(TokenUsageRepository.class), guard);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("platform ledger 混进非对象元素时，platform 段降级、local 段仍然返回")
+    void malformedLedgerEntryDegradesPlatformSectionOnly() {
+        when(accountService.isConnected()).thenReturn(true);
+        when(accountService.fetchProfile()).thenReturn(Map.of("balanceCents", 100, "plan", "free"));
+        // entries 里混进一个非对象元素：静态类型骗过编译器，运行时才在流处理里炸
+        List<Map<String, Object>> malformed = (List<Map<String, Object>>) (List<?>) List.of("not-a-map");
+        when(accountService.fetchLedger()).thenReturn(malformed);
+
+        Map<String, Object> resp = controller.usage(null);
+
+        Map<String, Object> data = (Map<String, Object>) resp.get("data");
+        assertNotNull(data.get("local"), "local 段不该被一起丢掉");
+        Map<String, Object> platform = (Map<String, Object>) data.get("platform");
+        assertEquals(false, platform.get("available"), "platform 段应该降级而不是让整个端点报错");
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerGetUsernameLoggingTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerGetUsernameLoggingTest.java
@@ -1,0 +1,91 @@
+package com.checkba.controller;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.checkba.service.LocalIdentityService;
+import com.checkba.service.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * getUsernameFromSession 吞异常——仅补日志、不改行为的护栏。
+ *
+ * <p>病灶：{@code userService.getUserById(userId)} 抛出的任何瞬时异常（DB 连接抖动、
+ * 懒加载失败……）被 {@code catch (Exception e) { return null; }} 原样吞掉，与「用户真的
+ * 不存在」返回同一个 null，调用方（署名归属等）区分不出「这次查询失败」和「查无此人」。
+ * #498 复核时判定为「刻意没做的」——正确修法只是补一条日志，不改变任何用户可见行为，
+ * 这里只做这一步：仍然返回 null，但留一条日志。
+ */
+class AuthControllerGetUsernameLoggingTest {
+
+    private Object previousLocalIdentity;
+
+    private static Field localIdentityField() throws Exception {
+        Field field = AuthController.class.getDeclaredField("staticLocalIdentityService");
+        field.setAccessible(true);
+        return field;
+    }
+
+    /** 静态注册位是全局状态，用完必须还原，否则会污染同一 JVM 里的其它测试。 */
+    @BeforeEach
+    void rememberLocalIdentity() throws Exception {
+        previousLocalIdentity = localIdentityField().get(null);
+    }
+
+    @AfterEach
+    void restoreLocalIdentity() throws Exception {
+        localIdentityField().set(null, previousLocalIdentity);
+    }
+
+    @Test
+    @DisplayName("userService.getUserById 抛异常时记一条日志，但仍然返回 null（行为不变）")
+    void logsExceptionButStillReturnsNull() throws Exception {
+        UserService userService = mock(UserService.class);
+        when(userService.getUserById(anyLong())).thenThrow(new RuntimeException("模拟 DB 抖动"));
+
+        LocalIdentityService localIdentity = mock(LocalIdentityService.class);
+        when(localIdentity.isLocalMode()).thenReturn(true);
+        when(localIdentity.localUserId()).thenReturn(7L);
+        AuthController.registerLocalIdentityService(localIdentity);
+
+        com.checkba.service.UserSessionService sessions = new com.checkba.service.UserSessionService(
+                mock(com.checkba.repository.UserSessionRepository.class), 365);
+        // 构造即注册 staticUserService（构造器里的既有副作用，其它测试同样依赖这个模式）
+        new AuthController(userService, null, null, null, null, null, null, null, null,
+                sessions, true, null);
+
+        ch.qos.logback.classic.Logger logbackLogger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(AuthController.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logbackLogger.addAppender(appender);
+
+        String result;
+        try {
+            // sessionId=null + local-mode：直接走 localIdentity.localUserId()，
+            // 不需要再搭一整套 session 解析就能命中 getUserById 抛异常这条路径。
+            result = AuthController.getUsernameFromSession(null);
+        } finally {
+            logbackLogger.detachAppender(appender);
+        }
+
+        assertNull(result, "行为不能变——吞异常返回 null 这件事本身不动");
+
+        boolean logged = appender.list.stream().anyMatch(e ->
+                e.getLevel() == Level.WARN || e.getLevel() == Level.ERROR);
+        assertTrue(logged, "getUserById 抛异常时应该留一条日志，此前完全静默。实际日志：" +
+                appender.list.stream().map(ILoggingEvent::getFormattedMessage)
+                        .collect(java.util.stream.Collectors.joining(" | ")));
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/FeedbackIngestQuotaRaceTest.java
+++ b/backend/src/test/java/com/checkba/controller/FeedbackIngestQuotaRaceTest.java
@@ -1,0 +1,106 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.UserFeedback;
+import com.checkba.repository.UserFeedbackRepository;
+import com.checkba.service.feedback.FeedbackIngestGuard;
+import com.checkba.service.feedback.FeedbackService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 病灶：FeedbackIngestGuard.check() 只读 count 判定配额，真正的落库在
+ * FeedbackService.ingest() 里，两者之间此前完全没有互斥——两个并发的
+ * POST /api/feedback/ingest（同一 installId）都能查到"还没到每日上限"、
+ * 都通过 check()，再各自落库，共同越过配额。
+ *
+ * <p>修法：controller 把 check() 与 ingest() 包进同一段按 installId 分条的互斥区间
+ * （FeedbackIngestGuard.lockFor）。这里直接证明互斥这条结构性质——真实的「越过配额」
+ * 结果依赖具体的计数时序，不如「二者互斥」这条能稳定验证。
+ */
+class FeedbackIngestQuotaRaceTest {
+
+    private UserFeedbackRepository repo;
+    private FeedbackIngestGuard guard;
+    private FeedbackService feedbackService;
+    private FeedbackIngestController controller;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        repo = mock(UserFeedbackRepository.class);
+        guard = new FeedbackIngestGuard(repo);
+        ReflectionTestUtils.setField(guard, "enabled", true);
+        ReflectionTestUtils.setField(guard, "perInstallDaily", 20);
+        ReflectionTestUtils.setField(guard, "globalDaily", 2000);
+        ReflectionTestUtils.setField(guard, "maxAttachments", 4);
+        ReflectionTestUtils.setField(guard, "maxAttachmentBytes", 5_242_880L);
+        feedbackService = mock(FeedbackService.class);
+        controller = new FeedbackIngestController(feedbackService, guard, repo);
+
+        UserFeedback saved = new UserFeedback();
+        saved.setId(1L);
+        when(feedbackService.ingest(anyString(), anyString(), any(), any())).thenReturn(saved);
+    }
+
+    private static String payload(String installId, String clientRef) {
+        return "{\"installId\":\"" + installId + "\",\"clientRef\":\"" + clientRef + "\",\"kind\":\"BUG\"}";
+    }
+
+    @Test
+    @DisplayName("ingest 端点与持有同一 installId 分条锁的另一段代码互斥")
+    void ingestIsMutuallyExclusiveWithSameInstallLock() throws Exception {
+        String installId = "install-race";
+
+        CountDownLatch holderReady = new CountDownLatch(1);
+        CountDownLatch releaseHolder = new CountDownLatch(1);
+        Thread holder = new Thread(() -> {
+            synchronized (guard.lockFor(installId)) {
+                holderReady.countDown();
+                try {
+                    releaseHolder.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        });
+        holder.start();
+        assertTrue(holderReady.await(2, TimeUnit.SECONDS));
+
+        AtomicBoolean ingestDone = new AtomicBoolean(false);
+        Thread requester = new Thread(() -> {
+            controller.ingest(payload(installId, "1"), List.of());
+            ingestDone.set(true);
+        });
+        requester.start();
+
+        Thread.sleep(2000); // holder 最多能撑到 5 秒，检查点留在 2 秒，边际够宽
+        assertFalse(ingestDone.get(),
+                "ingest 不该在同一 installId 的锁还没让出时就跑完——说明没有和它互斥");
+
+        releaseHolder.countDown();
+        requester.join(3000);
+        assertTrue(ingestDone.get(), "锁一放，ingest 应该很快跑完");
+    }
+
+    @Test
+    @DisplayName("行为不变：正常单次提交仍然成功")
+    void normalSubmissionStillSucceeds() {
+        ResponseEntity<?> resp = controller.ingest(payload("install-normal", "1"), List.of());
+        assertEquals(200, resp.getStatusCode().value());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/DeviceTokenServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/DeviceTokenServiceTest.java
@@ -5,7 +5,9 @@ import com.checkba.model.entity.DeviceToken;
 import com.checkba.repository.DeviceTokenRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +21,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DeviceTokenServiceTest {
@@ -104,6 +108,36 @@ class DeviceTokenServiceTest {
         DeviceTokenService.IssuedToken issuedB = svc.issue(2L, "B's phone");
         svc.revoke(1L, issuedB.id());
         assertEquals(2L, svc.resolveUserId(issuedB.plaintext()));
+    }
+
+    @Test
+    void resolveUserIdCoalescesLastUsedAtWrites() {
+        // 病灶：resolveUserId 每次命中都无条件 save()，而它是每个设备令牌请求的必经之路——
+        // 高频轮询（移动端同步中转、activity 上报、编辑器自动保存）把每次读请求都变成一次
+        // DB 写。这里验证：同一令牌短时间内连续解析两次，只应该多落一次库（节流生效），
+        // 而不是每次都写。
+        DeviceTokenService.IssuedToken issued = svc.issue(42L, "MacBook"); // save #1：签发
+        svc.resolveUserId(issued.plaintext()); // lastUsedAt 此前是 null，必然落库一次：save #2
+        svc.resolveUserId(issued.plaintext()); // 紧接着再解析一次：节流窗口内，不该再落库
+
+        verify(repo, times(2)).save(any());
+    }
+
+    @Test
+    void purgeIdleTokensDeletesRowsOlderThan365Days() {
+        // 病灶：device_token 没有任何过期/清理机制——同一 auth 子系统里 UserSessionService
+        // 有 @Scheduled 每日清理过期会话，device_token 没有。签发了忘记撤销的令牌永久留在
+        // 库里。365 天与 UserSessionService 桌面档 security.session-idle-days 默认值一致：
+        // 设备令牌是「长期配对」语义，不该比会话更容易被清掉。
+        when(repo.deleteIdleBefore(any())).thenReturn(3);
+
+        svc.purgeIdleTokens();
+
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(repo).deleteIdleBefore(captor.capture());
+        long daysAgo = java.time.Duration.between(captor.getValue(), LocalDateTime.now()).toDays();
+        assertTrue(daysAgo >= 364 && daysAgo <= 365,
+                "空转清理窗口应为 365 天左右，实际传入的 cutoff 是 " + daysAgo + " 天前");
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ProjectMemberServiceAddMemberRaceTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectMemberServiceAddMemberRaceTest.java
@@ -1,0 +1,81 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.User;
+import com.checkba.repository.ProjectInvitationRepository;
+import com.checkba.repository.ProjectMemberRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * addMember 的重复校验是「先查后插」：两个并发请求都查到「不在项目中」就都会插入，
+ * 第二个撞上 project_member(project_id, user_id) 唯一约束抛
+ * DataIntegrityViolationException——未被 GlobalExceptionHandler 任何具名
+ * {@code @ExceptionHandler} 接住，落进通用兜底回一句和输入毫不相关的「服务器内部错误」，
+ * 而不是查重分支本该给出的「用户已在项目中」。
+ *
+ * <p>addMember 整体是 {@code @Transactional}：修法只把插入异常翻译成同一条
+ * IllegalArgumentException 后立即向外抛、不在同一事务里再发任何查询——插入失败后
+ * 部分数据库（如 Postgres）的当前事务已经不可再用，追加恢复性查询本身会再报错。
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectMemberServiceAddMemberRaceTest {
+
+    private static final Long PROJECT_ID = 1L;
+    private static final Long OWNER_ID = 10L;
+    private static final Long TARGET_USER_ID = 20L;
+
+    @Mock private ProjectMemberRepository projectMemberRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private ProjectInvitationRepository invitationRepository;
+
+    private ProjectMemberService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProjectMemberService(
+                projectMemberRepository, userRepository, projectRepository, invitationRepository);
+    }
+
+    @Test
+    @DisplayName("插入撞上并发唯一约束时，报「用户已在项目中」而不是「服务器内部错误」")
+    void insertRaceSurfacesFriendlyDuplicateMessage() {
+        Project project = new Project();
+        project.setId(PROJECT_ID);
+        project.setUserId(OWNER_ID); // 请求者是项目所有者，直接过权限检查
+        when(projectRepository.findById(PROJECT_ID)).thenReturn(Optional.of(project));
+
+        User target = new User();
+        target.setId(TARGET_USER_ID);
+        target.setUsername("newmember");
+        when(userRepository.findByUsername("newmember")).thenReturn(Optional.of(target));
+
+        // 查重时（先查后插的"查"）还没有——两个并发请求都会看到这个状态
+        when(projectMemberRepository.findByProjectIdAndUserId(PROJECT_ID, TARGET_USER_ID))
+                .thenReturn(Optional.empty());
+        // 插入时撞上另一个并发请求已经提交的同一行
+        when(projectMemberRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> service.addMember(PROJECT_ID, "newmember", "MEMBER", OWNER_ID));
+
+        assertEquals("用户已在项目中", e.getMessage(),
+                "应该是查重分支本该给出的提示，而不是唯一约束异常原样冒泡");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectVariableServiceConcurrentCreateTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectVariableServiceConcurrentCreateTest.java
@@ -1,0 +1,83 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectVariable;
+import com.checkba.repository.ProjectVariableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * createOrUpdateVariable 的插入分支是「先查后插」：两个并发请求都查到「不存在」就都会
+ * 走插入分支，第二个撞上 project_variables(project_id, name) 唯一约束抛
+ * DataIntegrityViolationException——这本该被当成一次更新（两边语义上都是「给这个变量
+ * 设这个值」，没有歧义），却会冒泡成一句和输入毫不相关的「服务器内部错误」。
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectVariableServiceConcurrentCreateTest {
+
+    @Mock
+    private ProjectVariableRepository repository;
+
+    private ProjectVariableService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProjectVariableService();
+        ReflectionTestUtils.setField(service, "repository", repository);
+        // createOrUpdateVariable 现在经 self 转发到 REQUIRES_NEW 的 createOrUpdateVariableTx
+        // （同批另一条修复）。纯 Mockito 测试里没有 Spring 代理，把 self 指回自己：
+        // 事务语义在这条用例里本来就测不到（它测的是「撞约束后回退成更新」这条行为），
+        // 不接上 self 的话调用直接 NPE。
+        ReflectionTestUtils.setField(service, "self", service);
+    }
+
+    private static ProjectVariable variable(Long id, Long projectId, String name, String value) {
+        ProjectVariable v = new ProjectVariable();
+        v.setId(id);
+        v.setProjectId(projectId);
+        v.setName(name);
+        v.setValue(value);
+        v.setType("TEXT");
+        return v;
+    }
+
+    @Test
+    @DisplayName("插入撞上并发唯一约束时退回更新，而不是把异常甩给调用方")
+    void insertRaceFallsBackToUpdateInsteadOfThrowing() {
+        ProjectVariable incoming = variable(null, 1L, "案号", "新值");
+
+        // 第一次查：两边并发请求都看到「不存在」；冲突之后重新查：另一边已经提交
+        ProjectVariable alreadyCommitted = variable(99L, 1L, "案号", "旧值");
+        when(repository.findByProjectIdAndName(1L, "案号"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(alreadyCommitted));
+        // 单条 any() 桩，在 thenAnswer 里按参数状态分流——避免同一方法挂两条 argThat
+        // 桩时，Mockito 用 null 占位符重放已注册的匹配器，把测试自己先炸了。
+        when(repository.save(any(ProjectVariable.class))).thenAnswer(inv -> {
+            ProjectVariable v = inv.getArgument(0);
+            if (v.getId() == null) {
+                throw new DataIntegrityViolationException("duplicate key");
+            }
+            return v;
+        });
+
+        ProjectVariable result = service.createOrUpdateVariable(incoming);
+
+        assertEquals(99L, result.getId(), "应该落到已经存在的那一行，而不是继续尝试插入新行");
+        assertEquals("新值", result.getValue(), "值仍要按本次请求更新");
+        verify(repository, times(2)).findByProjectIdAndName(1L, "案号");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ShareholderMeetingEnsureFolderRaceTest.java
+++ b/backend/src/test/java/com/checkba/service/ShareholderMeetingEnsureFolderRaceTest.java
@@ -1,0 +1,137 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.ShareholderMeetingCheck;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ShareholderMeetingCheckRepository;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+/**
+ * 病灶：ensureFolder（经 ensureWorkpaperFolders 被 start()/fetchFromCninfo() 调用）是
+ * 「查不到就建」，查和建之间没有锁，两次并发调用（双击「开始核查」、前端网络重试）都能
+ * 查到「不存在」再各自建一个，产生同名重复文件夹。
+ *
+ * <p>与被判定"锁是假修"的另外两条 check-then-act 竞态（缓存区额度、DdService.ensureFolder）
+ * 不同：这条链路里 ensureWorkpaperFolders/ensureFolder/start() 自己都不是 @Transactional，
+ * 真正的提交只发生在 projectFileService.createFolder() 这个独立代理调用内部、同步完成——
+ * 所以把锁包在 ensureWorkpaperFolders 外层能如实盖住这次提交，不是「锁在提交前就放了」
+ * 那种假修。
+ */
+@ExtendWith(MockitoExtension.class)
+class ShareholderMeetingEnsureFolderRaceTest {
+
+    @Mock private ShareholderMeetingCheckRepository checkRepository;
+    @Mock private ProjectFileRepository projectFileRepository;
+    @Mock private ProjectFileService projectFileService;
+    @Mock private StorageServiceFactory storageServiceFactory;
+    @Mock private CninfoAnnouncementService cninfoService;
+
+    private ShareholderMeetingService svc;
+
+    @BeforeEach
+    void setUp() {
+        svc = new ShareholderMeetingService(checkRepository, projectFileRepository,
+                projectFileService, storageServiceFactory, cninfoService);
+        // ensureFolder 现在经 self 转发到 REQUIRES_NEW 的 ensureFolderTx（同批另一条修复）。
+        // 纯 Mockito 测试里没有 Spring 代理，把 self 指回自己：事务语义在这条用例里本来
+        // 就测不到（它测的是互斥），但不接上 self 的话调用直接 NPE。
+        org.springframework.test.util.ReflectionTestUtils.setField(svc, "self", svc);
+    }
+
+    private static String key(Long parentId, String name) {
+        return parentId + "/" + name;
+    }
+
+    @Test
+    @DisplayName("同一 checkId 并发调用 ensureWorkpaperFolders 不产生重复的底稿夹根目录")
+    void concurrentEnsureWorkpaperFoldersDoesNotDuplicateRootFolder() throws Exception {
+        ShareholderMeetingCheck check = new ShareholderMeetingCheck();
+        check.setId(1L);
+        check.setProjectId(100L);
+        check.setCompanyName("某公司");
+        check.setMeetingName("2026年年度股东大会");
+
+        Map<String, ProjectFile> store = new ConcurrentHashMap<>();
+        AtomicLong idSeq = new AtomicLong(1);
+        AtomicInteger rootCreateCount = new AtomicInteger(0);
+
+        Thread[] threadARef = new Thread[1];
+        CountDownLatch aPausedInCreate = new CountDownLatch(1);
+        CountDownLatch releaseA = new CountDownLatch(1);
+
+        when(projectFileRepository.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(
+                anyLong(), nullable(Long.class), anyString()))
+                .thenAnswer(inv -> {
+                    Long parentId = inv.getArgument(1);
+                    String name = inv.getArgument(2);
+                    return Optional.ofNullable(store.get(key(parentId, name)));
+                });
+
+        when(projectFileService.createFolder(anyLong(), nullable(Long.class), anyString(), anyLong()))
+                .thenAnswer(inv -> {
+                    Long parentId = inv.getArgument(1);
+                    String name = inv.getArgument(2);
+                    if (ShareholderMeetingService.WORKPAPER_ROOT.equals(name)) {
+                        rootCreateCount.incrementAndGet();
+                        // 只让线程 A 在"创建根目录"这一步暂停，模拟查到"不存在"之后、
+                        // 真正落库完成之前的窗口——这正是 TOCTOU 的那个缝隙。
+                        // 线程 B（如果没有锁）会在这段暂停期间闯进来，同样查到"不存在"、
+                        // 同样调用 createFolder，于是 rootCreateCount 会变成 2。
+                        if (Thread.currentThread() == threadARef[0]) {
+                            aPausedInCreate.countDown();
+                            assertTrue(releaseA.await(5, TimeUnit.SECONDS), "测试主线程应该及时放行 A");
+                        }
+                    }
+                    ProjectFile f = new ProjectFile();
+                    f.setId(idSeq.getAndIncrement());
+                    f.setName(name);
+                    f.setIsFolder(true);
+                    store.put(key(parentId, name), f);
+                    return f;
+                });
+
+        Thread a = new Thread(() -> {
+            threadARef[0] = Thread.currentThread();
+            svc.ensureWorkpaperFolders(check, 1L);
+        });
+        a.start();
+        assertTrue(aPausedInCreate.await(5, TimeUnit.SECONDS), "线程 A 应该先进入根目录创建的临界窗口");
+
+        // 此时线程 A 卡在"根目录已判定不存在、createFolder 尚未返回"的缝隙里。
+        // 加了锁的话，线程 B 这次调用应该整个卡在方法入口，等 A 彻底做完才轮到自己；
+        // 没加锁的话，B 会立刻查到"不存在"，也调一次 createFolder，制造重复根目录。
+        Thread b = new Thread(() -> svc.ensureWorkpaperFolders(check, 1L));
+        b.start();
+
+        Thread.sleep(300); // 给 B 机会在无锁情况下抢跑；有锁的话这段时间 B 应该原地卡住
+        releaseA.countDown();
+
+        a.join(5000);
+        b.join(5000);
+
+        assertEquals(1, rootCreateCount.get(),
+                "底稿夹根目录只应该被创建一次，重复创建说明 ensureWorkpaperFolders 没有互斥");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/feedback/FeedbackServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/feedback/FeedbackServiceTest.java
@@ -73,6 +73,11 @@ class FeedbackServiceTest {
         return new MockMultipartFile("files", name, "audio/webm", new byte[]{9, 8, 7});
     }
 
+    /** 非图片/语音附件——用来触发 storeAttachments 里段落中段的校验失败。 */
+    private static MockMultipartFile rejectedType(String name) {
+        return new MockMultipartFile("files", name, "video/mp4", new byte[]{1, 2, 3});
+    }
+
     @Test
     void submitStoresRowAndAttachments() throws Exception {
         UserFeedback fb = service.submit(7L,
@@ -200,5 +205,40 @@ class FeedbackServiceTest {
         assertTrue(tail.endsWith("line 2999\n"), "取的是尾部");
         assertTrue(tail.length() <= 16 * 1024, "尾巴要截断，别把整份日志塞进库");
         assertFalse(tail.startsWith("line 0\n"), "截断处的半行残句要丢掉");
+    }
+
+    /**
+     * 病灶：storeAttachments 是"边校验边落盘落库"的单趟循环——第 1 个附件校验通过、
+     * 已经落库，第 2 个才校验失败抛异常，但反馈行本身在 storeAttachments 被调用之前
+     * 就已经 save() 过一次了。异常从 submit() 冒泡出去，调用方看到"提交失败"、
+     * 通常会精简附件后重试，留下第一次那条已提交但 contextJson==null、缺诊断信息的
+     * 半成品行——它不会被标成任何错误，会被当成正常行继续走上传/分诊流程。
+     *
+     * <p>修法：把附件校验拆成独立的、只读 MultipartFile 自身元信息（不碰磁盘/DB）的
+     * 预检查，挪到 feedbackRepository.save(fb) 之前跑完；任何一个附件不合法，整条提交
+     * 都不该落下任何行。
+     */
+    @Test
+    void submitDoesNotPersistFeedbackRowWhenALaterAttachmentFailsValidation() {
+        assertThrows(IllegalArgumentException.class, () -> service.submit(7L,
+                new FeedbackService.SubmitRequest("BUG", "点保存没反应", null, null, null),
+                List.of(png("a.png"), rejectedType("b.mp4"))));
+
+        verify(feedbackRepo, never()).save(any());
+        verify(attachmentRepo, never()).save(any());
+        assertTrue(savedAttachments.isEmpty());
+    }
+
+    @Test
+    void ingestDoesNotPersistFeedbackRowWhenALaterAttachmentFailsValidation() {
+        when(feedbackRepo.findByInstallIdAndClientRef(any(), any())).thenReturn(java.util.Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> service.ingest("install-1", "ref-1",
+                new FeedbackService.IngestRequest("BUG", "崩了", null, null, "9.9.9", "mac", null),
+                List.of(png("a.png"), rejectedType("b.mp4"))));
+
+        verify(feedbackRepo, never()).save(any());
+        verify(attachmentRepo, never()).save(any());
+        assertTrue(savedAttachments.isEmpty());
     }
 }

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionServiceTest.java
@@ -37,6 +37,8 @@ class MeetingTranscriptionServiceTest {
     private TingwuClient tingwu;
     private MeetingOssClient oss;
     private MeetingTranscriptionService.UrlFetcher fetcher;
+    /** service() 内部现建的档位解析桩；并发测试需要在外面 verify 它被调了几次。 */
+    private ExternalProviderResolver lastResolver;
 
     private static final String TRANSCRIPTION_JSON = """
             {"Transcription":{"Paragraphs":[{"SpeakerId":"1","Words":[
@@ -60,6 +62,7 @@ class MeetingTranscriptionServiceTest {
         // 本类整体验的是 byok 档：档位解析恒回 BYOK，网关那两个协作者一次都不该被碰
         ExternalProviderResolver resolver = mock(ExternalProviderResolver.class);
         when(resolver.resolve(anyString())).thenReturn(ExternalServiceProvider.BYOK);
+        lastResolver = resolver;
         return new MeetingTranscriptionService(
                 meetingRepository, mock(ProjectFileRepository.class), null, settingService,
                 mock(MeetingAudioTranscoder.class), tingwu, oss,
@@ -106,6 +109,62 @@ class MeetingTranscriptionServiceTest {
         MeetingRecording out = service(true).startTranscription(7L);
         assertEquals(MeetingRecording.STATUS_TRANSCRIBED, out.getStatus());
         verifyNoInteractions(tingwu);
+    }
+
+    /**
+     * 病灶：起手的状态判定（TRANSCRIBING/TRANSCRIBED 幂等短路）与真正落库的
+     * {@code meeting.setStatus(TRANSCRIBING) + meetingRepository.save(meeting)} 之间
+     * 隔着一整段校验逻辑，中间完全没有互斥。两个近乎同时的请求（自动结束时触发一次 +
+     * 客户端超时重试一次，或者「重新提交转写」连点两下）都会读到同一个"还没在转写"的
+     * 状态、都通过校验，最终都会各自提交一次转写——BYOK 档是两次真实的听悟建任务调用
+     * （真花钱），platform 档是两次网关提交（各自预扣一次 Credits，等于对同一次转写
+     * 扣两次费）。
+     *
+     * <p>修法：整个方法体包一把按 meetingId 分条的锁（同一实例内互斥）。第二个请求
+     * 拿到锁时，第一个请求早已经把状态改成 TRANSCRIBING 并落库——它会在方法最开头
+     * 那个既有的幂等短路分支直接返回，不会走到校验和提交。
+     */
+    @Test
+    @DisplayName("同一会议并发提交转写：第二个请求命中幂等短路，不会重复提交")
+    void concurrentStartTranscriptionOnlySubmitsOnce() throws Exception {
+        MeetingRecording m = meeting(MeetingRecording.STATUS_RECORDED);
+        Thread[] threadA = new Thread[1];
+        CountDownLatch aPaused = new CountDownLatch(1);
+        CountDownLatch releaseA = new CountDownLatch(1);
+        when(meetingRepository.findById(7L)).thenAnswer(inv -> {
+            if (Thread.currentThread() == threadA[0]) {
+                aPaused.countDown();
+                assertTrue(releaseA.await(5, TimeUnit.SECONDS), "测试主线程应该及时放行 A");
+            }
+            return Optional.of(m);
+        });
+
+        MeetingTranscriptionService svc = service(true);
+        // resolver.resolve(...) 只在方法开头的幂等短路之后才会被调到，且完全同步（跑在
+        // 调用方线程上、方法返回前必然已经调完）——用它的调用次数判定"这个线程有没有
+        // 真正走到校验+提交"，不受 executor.submit(...) 那段异步后续（转码/建任务/失败
+        // 落库）时序不确定的干扰。
+        Thread a = new Thread(() -> {
+            threadA[0] = Thread.currentThread();
+            svc.startTranscription(7L);
+        });
+        a.start();
+        assertTrue(aPaused.await(5, TimeUnit.SECONDS), "线程 A 应该先卡在 findById 里");
+
+        AtomicReference<MeetingRecording> bResult = new AtomicReference<>();
+        Thread b = new Thread(() -> bResult.set(svc.startTranscription(7L)));
+        b.start();
+
+        Thread.sleep(300); // 有锁的话 B 这时候应该还卡在方法入口，等 A 彻底做完
+        verify(lastResolver, never()).resolve(anyString());
+
+        releaseA.countDown();
+        a.join(5000);
+        b.join(5000);
+
+        // 只应该有一次真正走到校验+提交；B 命中的是方法开头既有的幂等短路分支
+        verify(lastResolver, times(1)).resolve(anyString());
+        assertEquals(MeetingRecording.STATUS_TRANSCRIBING, bResult.get().getStatus());
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/optimizer/OptimizerMailerTest.java
+++ b/backend/src/test/java/com/checkba/service/optimizer/OptimizerMailerTest.java
@@ -138,4 +138,40 @@ class OptimizerMailerTest {
         mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_SUGGESTION), List.of(), sourceRef(""), "");
         verify(router, times(2)).send(any(), any(), any());
     }
+
+    /**
+     * 病灶：多收件人分属不同通道，其中一条通道故障时，send() 对第二个收件人的调用
+     * 会抛异常冒泡出去；OptimizerAgentService.notifyOrFail 接住后把这条反馈判 FAILED/
+     * 转 NEW 重试。没有任何 (feedbackId, 收件人) 维度的"已发送"记录——下一轮定时任务
+     * 重跑，会把已经收到过的第一个收件人再发一封，故障通道修好之前每天都重复。
+     *
+     * <p>修法：进程内存记一份"这条反馈已经成功发给过谁"，不落库（optimizer.mail.to
+     * 是维护者自己的邮箱，重发一次不是数据丢失，不值得为它加表/加列；进程重启会清空
+     * 这份记忆，届时最多再重发一轮，可接受）。同时把"一个收件人失败就不再尝试后面的
+     * 收件人"这条连带问题一起改掉：循环内 catch，全部收件人都试一遍，最后才把失败的
+     * 那些聚合成一个异常抛出去（触发外层重试，但只重试真正没发成功的那些人）。
+     */
+    @Test
+    @DisplayName("重试不会给已经成功收到过的收件人重复发信")
+    void retryDoesNotResendToAlreadyMailedRecipient() {
+        props.getMail().setTo("a@domestic.example,b@global.example");
+        doThrow(new RuntimeException("b 通道故障")).when(router)
+                .send(eq("b@global.example"), any(), any());
+
+        UserFeedback fb = feedback();
+        // 第一轮：a 成功，b 故障——整体应该仍然报失败（触发外层重试机制）
+        assertThrows(RuntimeException.class, () -> mailer.send(fb,
+                triage(FeedbackTriageService.VERDICT_SUGGESTION), List.of(), sourceRef(""), ""));
+        verify(router, times(1)).send(eq("a@domestic.example"), any(), any());
+        verify(router, times(1)).send(eq("b@global.example"), any(), any());
+
+        // b 通道修好了，下一轮定时任务重跑（同一个 fb，同一批收件人）
+        reset(router);
+        when(router.active()).thenReturn(true);
+        mailer.send(fb, triage(FeedbackTriageService.VERDICT_SUGGESTION), List.of(), sourceRef(""), "");
+
+        // a 已经收到过，这一轮不该再发；b 之前没发成功，这一轮该补上
+        verify(router, never()).send(eq("a@domestic.example"), any(), any());
+        verify(router, times(1)).send(eq("b@global.example"), any(), any());
+    }
 }

--- a/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/pack/NativePackServiceTest.java
@@ -26,6 +26,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -464,6 +467,96 @@ class NativePackServiceTest {
         svc.install(PACK_ID);
         assertEquals(List.of(), svc.syncRevoked());
         assertTrue(svc.isReady(PACK_ID));
+    }
+
+    @Test
+    @DisplayName("修复：syncRevoked 与 install()/uninstall() 互斥——不会用升级提交前的旧版本号" +
+            "把并发升级刚写完的 current.json 盖掉")
+    void syncRevokedIsMutuallyExclusiveWithConcurrentInstall() throws Exception {
+        // 病灶：syncRevoked() 对每个 pack 都是「读 current.json -> 判定 -> 写回」，
+        // install()/uninstall() 收尾时也会写 current.json，但只有 install/uninstall
+        // 互相持有同一把按 packId 分的锁（packLock）——syncRevoked 此前完全没加锁。
+        // 真实的坏结果（读到升级提交前的旧版本号、写回时把刚升级完的新版本盖掉）依赖
+        // 几毫秒级的本地文件 I/O 时序，没法在测试里稳定掐出那个窗口（审计条目自己也
+        // 这么写）；能稳定验证、且正是修复手段本身的，是「二者互斥」这条结构性质——
+        // 这里直接证明它。
+        byte[] archive = tarGzWithContents(Map.of("cli.py", "x".getBytes(StandardCharsets.UTF_8)));
+        publish(primary, archive, "litviz", List.of("*"), true);
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        svc.install(PACK_ID); // 真实装一遍，建立「已装 1.0.0」这一前提
+        Path packDir = packsRoot().resolve(PACK_ID);
+        primary.files.put("/revoked", ("[{\"id\":\"" + PACK_ID + "\",\"version\":\"1.0.0\",\"reason\":\"test\"}]")
+                .getBytes(StandardCharsets.UTF_8));
+
+        // holder 最多持锁 5 秒（留够调度抖动的余量），中途检查点设在 2 秒——
+        // 两者之间留 3 秒安全边际，不靠贴着毫秒级窗口猜时序。
+        CountDownLatch holderReady = new CountDownLatch(1);
+        CountDownLatch releaseHolder = new CountDownLatch(1);
+        Thread holder = new Thread(() -> {
+            synchronized (svc.packLock(PACK_ID)) { // 与 install()/uninstall() 同一把按 packId 分的锁
+                holderReady.countDown();
+                try {
+                    releaseHolder.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        });
+        holder.start();
+        assertTrue(holderReady.await(2, TimeUnit.SECONDS));
+
+        AtomicBoolean syncDone = new AtomicBoolean(false);
+        Thread syncer = new Thread(() -> {
+            svc.syncRevoked();
+            syncDone.set(true);
+        });
+        syncer.start();
+
+        Thread.sleep(2000); // holder 最多能撑到 5 秒，这里检查点在 2 秒，边际够宽
+        assertFalse(syncDone.get(),
+                "syncRevoked 不该在 install/uninstall 的临界区还没让出锁时就跑完——说明没有和它们互斥");
+
+        releaseHolder.countDown();
+        syncer.join(3000);
+        assertTrue(syncDone.get(), "锁一放，syncRevoked 应该很快跑完");
+    }
+
+    @Test
+    @DisplayName("修复：卸载一个无关 pack 不会被另一个正在安装的 pack 卡住")
+    void uninstallOfUnrelatedPackDoesNotBlockOnInFlightInstall() throws Exception {
+        // 病灶：install()/uninstall() 此前共用同一把服务级对象锁（synchronized(this) 方法）。
+        // pack A 的下载可能因为重试跑到 3 次 x 10 分钟，这段时间里 uninstall 一个完全无关
+        // 的 pack B 的请求线程会在这把锁上空等，没有任何报错或提示——"卸载"按钮转圈但
+        // 用户根本猜不到是被另一个 pack 拖住的。修法是把锁从服务级收窄到 packId 级，
+        // 这里用同样的"外部持锁 + 检查点"手法直接证明：pack A 的锁被别人攥着时，
+        // pack B 的 uninstall() 完全不受影响。
+        NativePackService svc = service(publicKeyPem, primary.baseUrl());
+        String packA = PACK_ID; // "litigation-visual"，模拟正在安装、下载慢的那个
+        String packB = "other-pack"; // 从未安装过，走 uninstall() 的幂等收口分支即可验证
+
+        CountDownLatch holderReady = new CountDownLatch(1);
+        CountDownLatch releaseHolder = new CountDownLatch(1);
+        Thread holder = new Thread(() -> {
+            synchronized (svc.packLock(packA)) {
+                holderReady.countDown();
+                try {
+                    releaseHolder.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        });
+        holder.start();
+        assertTrue(holderReady.await(2, TimeUnit.SECONDS), "线程应该先拿到 pack A 的锁");
+
+        try {
+            long start = System.nanoTime();
+            svc.uninstall(packB); // 完全无关的 pack，不该等 pack A 的锁
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs < 1000,
+                    "卸载无关 pack 不该被 pack A 的锁拖住，实际耗时 " + elapsedMs + "ms");
+        } finally {
+            releaseHolder.countDown();
+            holder.join(3000);
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/platform/ExternalProviderBackfillTest.java
+++ b/backend/src/test/java/com/checkba/service/platform/ExternalProviderBackfillTest.java
@@ -3,6 +3,7 @@ package com.checkba.service.platform;
 import com.checkba.service.SystemSettingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -116,5 +117,38 @@ class ExternalProviderBackfillTest {
 
         assertEquals(ExternalServiceProvider.ALL.size(), b.backfill());
         assertEquals(0, b.backfill(), "第二次不该再写任何行");
+    }
+
+    /**
+     * 内嵌 Tomcat 在 refresh() 收尾（finishRefresh -> startWebServer）就开始收连接，
+     * 而 ApplicationReadyEvent 要等 refresh() 返回、CommandLineRunner 跑完才发出——
+     * 只挂这一个事件，升级后第一批落在这个窗口里的请求会读到还没回填的默认档位。
+     *
+     * <p>这里不去起真的内嵌 Tomcat 掐时间点（那样测出来的是抖动，不是回归），
+     * 而是验证回填这件事本身发生在 {@code ctx.refresh()} 之内、不依赖
+     * ApplicationReadyEvent 被发出——这正是两种触发方式在时序上的真实差别。
+     */
+    @Test
+    @DisplayName("回填必须在 refresh() 内完成，不能只挂 ApplicationReadyEvent（否则赶不上内嵌 Tomcat 开始收连接）")
+    void backfillCompletesDuringContextRefreshWithoutApplicationReadyEvent() {
+        Map<String, String> rows = new HashMap<>();
+        SystemSettingService settings = settingsWith(rows);
+        ExternalProviderResolver resolver = new ExternalProviderResolver(settings, true);
+
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.registerBean(ExternalProviderBackfill.class, () -> new ExternalProviderBackfill(
+                settings, resolver, "", "", "", "", "", "", "", "", "", ""));
+        try {
+            // 只 refresh()，刻意不发 ApplicationReadyEvent——对应内嵌 Tomcat 已经开始
+            // 收连接、但 ApplicationReadyEvent 尚未发出的那个窗口。
+            ctx.refresh();
+
+            for (ExternalServiceProvider.Descriptor d : ExternalServiceProvider.ALL) {
+                assertNotNull(rows.get(ExternalProviderResolver.providerKey(d.service())),
+                        "回填必须在 refresh() 内完成，不能等 ApplicationReadyEvent 才跑：" + d.service());
+            }
+        } finally {
+            ctx.close();
+        }
     }
 }

--- a/backend/src/test/java/com/checkba/service/platform/PlatformGatewayClientTest.java
+++ b/backend/src/test/java/com/checkba/service/platform/PlatformGatewayClientTest.java
@@ -96,6 +96,45 @@ class PlatformGatewayClientTest {
         assertNotNull(transport.calls.get(0).idempotencyKey(), "会扣费的调用必须带幂等键");
     }
 
+    /**
+     * 病灶：HttpPlatformGatewayTransport 捕获 InterruptedException 后会恢复中断标志
+     * （{@code Thread.currentThread().interrupt()}），但返回的 Reply 与其它网络失败长得
+     * 一模一样——PlatformGatewayClient 分不出"这次失败是因为调用方线程被要求停下"还是
+     * "单纯网络抖动"，于是仍然照常重试一次：在一个已经被要求停止的线程上又发起一次
+     * 最长可以再等 timeoutSeconds 的阻塞调用，拖慢优雅关闭。
+     *
+     * <p>修法：重试前查一下当前线程的中断标志（peek，不清）；已经被中断就不重试，
+     * 直接按网络失败处理，把控制权尽快还给调用方。
+     */
+    @Test
+    @DisplayName("第一次调用后线程已被中断时，不再发起重试")
+    void doesNotRetryWhenThreadAlreadyInterrupted() {
+        transport = new RecordingTransport() {
+            @Override
+            public Reply send(String method, String url, String bearerKey, String idempotencyKey,
+                              String jsonBody, int timeoutSeconds) {
+                Reply r = super.send(method, url, bearerKey, idempotencyKey, jsonBody, timeoutSeconds);
+                // 模拟 HttpPlatformGatewayTransport 捕获 InterruptedException 后的真实行为：
+                // 恢复中断标志、把这次结果当网络失败返回。
+                Thread.currentThread().interrupt();
+                return r;
+            }
+        };
+        transport.reply(PlatformGatewayTransport.Reply.NETWORK_FAILURE, null);
+        client = new PlatformGatewayClient(transport, accountService, siteProfileService);
+
+        try {
+            // 只关心发出去几次请求，不关心这次失败具体报成哪种 GatewayException
+            try {
+                client.call("search", "web", Map.of("query", "x"), 30);
+            } catch (GatewayException ignored) {
+            }
+            assertEquals(1, transport.calls.size(), "线程已经被要求停止，不该再发第二次请求");
+        } finally {
+            assertTrue(Thread.interrupted(), "中断标志本该留给线程原本的所有者处理（顺带清掉，不污染后续用例）");
+        }
+    }
+
     @Test
     @DisplayName("两次网络失败后回 GATEWAY_UNREACHABLE，且文案明说不是用户的网络问题")
     void unreachableSaysNotYourNetwork() {

--- a/backend/src/test/java/com/checkba/service/telemetry/TelemetryServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/telemetry/TelemetryServiceTest.java
@@ -97,4 +97,41 @@ class TelemetryServiceTest {
             svc.flush();
         });
     }
+
+    /**
+     * 病灶：类注释写的是"独立于业务线程池……有界队列，满了直接丢"，但
+     * {@code Executors.newSingleThreadExecutor(...)} 背后是无界 {@code LinkedBlockingQueue}——
+     * 名不副实。DB 持续卡顿时，排队的 Runnable（每个都攥着一个 Map + Instant）会无界堆积，
+     * 把这条"过载安全阀"变成了一条会把后端堆内存吃满的隐患，而 droppedCount() 因为
+     * "满了丢弃"这条路径从没真正触发过，还会低报积压。
+     *
+     * <p>验证方式：让唯一的消费线程卡住（repo.save 阻塞），持续提交超过队列容量的事件，
+     * 断言超出部分被记成丢弃而不是无限排队——不直接读内部队列大小（那是实现细节），
+     * 用 droppedCount() 这个已有的自监控指标即可稳定判定。
+     */
+    @Test
+    void queueIsBoundedAndDropsOverflowInsteadOfGrowingWithoutLimit() throws Exception {
+        java.util.concurrent.CountDownLatch releaseConsumer = new java.util.concurrent.CountDownLatch(1);
+        when(repo.save(any())).thenAnswer(inv -> {
+            releaseConsumer.await(10, java.util.concurrent.TimeUnit.SECONDS);
+            return inv.getArgument(0);
+        });
+
+        try {
+            // 第一条被唯一的消费线程立刻取走并卡住；之后的都得排队。提交数刻意比队列容量多
+            // 一截，超出的那部分必须被丢弃计数，而不是内存无限堆积。
+            // 断言就放在这个循环之后：拒绝策略在 execute() 调用当下、调用方线程上同步执行，
+            // 不需要等消费线程排空——此时它还卡着，不能用 flush()（那会去抢同一条队列，
+            // 队列满的话 flush 自己的探测任务也会被拒绝而永远等不到结果，白等超时）。
+            int overflow = 50;
+            for (int i = 0; i < TelemetryService.QUEUE_CAPACITY + overflow; i++) {
+                svc.record("ai.tool", Map.of("toolName", "doc_replace_text", "success", true));
+            }
+
+            assertTrue(svc.droppedCount() >= overflow - 1,
+                    "队列满了之后继续提交应该被丢弃计数，实际 droppedCount()=" + svc.droppedCount());
+        } finally {
+            releaseConsumer.countDown(); // 放行消费线程，不留卡住的后台线程
+        }
+    }
 }

--- a/backend/src/test/java/com/checkba/service/telemetry/TelemetryUploadServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/telemetry/TelemetryUploadServiceTest.java
@@ -1,0 +1,94 @@
+package com.checkba.service.telemetry;
+
+import com.checkba.model.entity.TelemetryDailyRollup;
+import com.checkba.repository.TelemetryDailyRollupRepository;
+import com.checkba.repository.TelemetryEventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 病灶：sync() 每轮只补算"昨日"一天。这是一个不常驻 24/7 的桌面应用——用户关了几天
+ * 没开（长周末），再打开时 onStartup()/scheduledSync() 只算回前一天，中间那几天
+ * telemetry_event 表里明明有数据，却永远不会有对应的 TelemetryDailyRollup 行，
+ * 那几天的匿名统计永久静默丢失，没有任何日志或错误信号。
+ */
+class TelemetryUploadServiceTest {
+
+    TelemetryDailyRollupRepository rollupRepository;
+    TelemetryEventRepository eventRepository;
+    TelemetryRollupService rollupService;
+    TelemetrySettings settings;
+    InstallIdentityService identity;
+    TelemetryUploadService service;
+
+    @BeforeEach
+    void setUp() {
+        rollupRepository = mock(TelemetryDailyRollupRepository.class);
+        eventRepository = mock(TelemetryEventRepository.class);
+        rollupService = mock(TelemetryRollupService.class);
+        settings = mock(TelemetrySettings.class);
+        identity = mock(InstallIdentityService.class);
+        // rollup 上报关掉，sync() 补算完当天缺口后直接返回，不需要再打桩上传链路
+        when(settings.rollupEnabled()).thenReturn(false);
+        // 默认每天都已经有 rollup 行——测试各自按需覆盖成"缺失"
+        when(rollupRepository.findByDate(any())).thenAnswer(inv ->
+                Optional.of(new TelemetryDailyRollup()));
+
+        service = new TelemetryUploadService(rollupRepository, eventRepository, rollupService,
+                settings, identity, "https://example.invalid/telemetry", (url, body) -> 200);
+    }
+
+    @Test
+    @DisplayName("昨日无条件重算（late-arriving 事件在临近午夜才落库）")
+    void yesterdayIsAlwaysRolledUpUnconditionally() {
+        service.sync();
+
+        verify(rollupService).rollupFor(LocalDate.now().minusDays(1));
+    }
+
+    @Test
+    @DisplayName("应用关了几天没开：中间跳过的日子在下次启动时被补算")
+    void gapDaysWithoutAnyRollupRowAreBackfilled() {
+        LocalDate today = LocalDate.now();
+        LocalDate gapDay = today.minusDays(3); // 长周末跳过的那天，events 表有数据但从没算过
+        when(rollupRepository.findByDate(gapDay)).thenReturn(Optional.empty());
+
+        service.sync();
+
+        verify(rollupService).rollupFor(gapDay);
+    }
+
+    @Test
+    @DisplayName("已经有 rollup 行的老日子不重复计算（只补真正缺失的）")
+    void alreadyRolledUpOlderDaysAreNotRecomputed() {
+        LocalDate twoDaysAgo = LocalDate.now().minusDays(2);
+        // 默认桩已经让 findByDate 一律返回"存在"
+
+        service.sync();
+
+        verify(rollupService, never()).rollupFor(twoDaysAgo);
+    }
+
+    @Test
+    @DisplayName("回溯窗口有界：不会无限往前找缺口")
+    void backfillWindowIsBounded() {
+        when(rollupRepository.findByDate(any())).thenReturn(Optional.empty()); // 全部"缺失"
+
+        service.sync();
+
+        // 30 天窗口（与 uploadPendingRollups 的补传窗口口径一致）：昨天 + 更早 29 天 = 30 次
+        verify(rollupService, times(30)).rollupFor(any());
+    }
+}

--- a/pptx-service/backend/app.py
+++ b/pptx-service/backend/app.py
@@ -121,6 +121,10 @@ def create_app():
     with app.app_context():
         # Load settings from database and sync to app.config
         _load_settings_to_config(app)
+        # 启动对账：上一条进程遗留的 PENDING/PROCESSING 任务在数据库里还挂着，
+        # 而跑它们的执行器早已随进程消失，前端轮询会永远转圈。见 TaskManager 里的说明。
+        from services.task_manager import task_manager
+        task_manager.reconcile_orphaned_tasks()
 
     # Health check endpoint
     @app.route('/health')

--- a/pptx-service/backend/services/task_manager.py
+++ b/pptx-service/backend/services/task_manager.py
@@ -63,6 +63,38 @@ class TaskManager:
         """Shutdown the executor"""
         self.executor.shutdown(wait=True)
 
+    @staticmethod
+    def reconcile_orphaned_tasks():
+        """启动时对账：把上一条进程遗留的 PENDING/PROCESSING 任务标成失败。
+
+        active_tasks 是进程内的字典，进程一重启（部署、崩溃、被 OOM 杀掉、容器重启）
+        就没了，而数据库里那些行还停在 PENDING/PROCESSING。此前没有任何启动钩子或
+        定时器去清它们：前端轮询那个 task_id 会一直转下去——没有报错、没有超时、
+        也没有任何办法恢复，除非用户自己察觉并重开一个任务。
+
+        本服务是单进程运行（app.py 里 app.run(use_reloader=False)），所以启动这一刻
+        「正在跑」的任务必然为零，把残留一律判失败是安全的；写明原因让用户知道
+        该重试，而不是对着一个永远转圈的进度条干等。
+        """
+        try:
+            orphaned = Task.query.filter(Task.status.in_(['PENDING', 'PROCESSING'])).all()
+            if not orphaned:
+                return 0
+            now = datetime.utcnow()
+            for task in orphaned:
+                task.status = 'FAILED'
+                task.error_message = '服务重启导致任务中断，请重新发起'
+                task.completed_at = now
+            db.session.commit()
+            logger.warning(
+                "启动对账：%d 个上一条进程遗留的任务已标记为失败（原状态 PENDING/PROCESSING）",
+                len(orphaned))
+            return len(orphaned)
+        except Exception as e:
+            db.session.rollback()
+            logger.error("启动对账失败: %s", e, exc_info=True)
+            return 0
+
 
 # Global task manager instance
 task_manager = TaskManager(max_workers=4)

--- a/pptx-service/backend/tests/unit/test_task_reconcile.py
+++ b/pptx-service/backend/tests/unit/test_task_reconcile.py
@@ -1,0 +1,62 @@
+"""启动对账：进程重启后遗留的 PENDING/PROCESSING 任务不能永远挂着。
+
+病灶：active_tasks 是进程内字典，重启即丢；数据库里那些行还停在 PENDING/PROCESSING，
+而跑它们的执行器已经不存在。前端轮询那个 task_id 会一直转下去——没有报错、没有超时、
+也没有任何恢复途径，除非用户自己察觉并重开一个任务。
+
+这里刻意不用 conftest 的 app fixture：那个 fixture 走 create_app()，会连带 import
+整条控制器链（pdf2docx 等重依赖）。本条测的是对账逻辑本身，只需要 models 与一个
+最小 Flask 应用，跑得起来也跑得快。
+"""
+import uuid
+
+import pytest
+from flask import Flask
+
+from models import db, Task, Project
+from services.task_manager import TaskManager
+
+
+@pytest.fixture()
+def minimal_app(tmp_path):
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{tmp_path / 'reconcile.db'}"
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+
+
+def _make_task(status):
+    project = Project(id=str(uuid.uuid4()), idea_prompt='对账测试')
+    db.session.add(project)
+    task = Task(id=str(uuid.uuid4()), project_id=project.id,
+                task_type='GENERATE_IMAGES', status=status)
+    db.session.add(task)
+    db.session.commit()
+    return task.id
+
+
+def test_orphaned_tasks_are_failed_on_startup(minimal_app):
+    pending_id = _make_task('PENDING')
+    processing_id = _make_task('PROCESSING')
+    done_id = _make_task('COMPLETED')
+
+    changed = TaskManager.reconcile_orphaned_tasks()
+    assert changed == 2
+
+    for tid in (pending_id, processing_id):
+        task = db.session.get(Task, tid)
+        assert task.status == 'FAILED', '重启遗留的任务必须落到可见的失败终态'
+        assert task.error_message, '要写明原因，否则用户不知道该重试'
+        assert task.completed_at is not None
+
+    # 已经结束的任务不许被动
+    assert db.session.get(Task, done_id).status == 'COMPLETED'
+
+
+def test_reconcile_is_idempotent(minimal_app):
+    _make_task('PENDING')
+    assert TaskManager.reconcile_orphaned_tasks() == 1
+    assert TaskManager.reconcile_orphaned_tasks() == 0


### PR DESCRIPTION
审计剩余清单里的后端杂项那一组。子 agent 完成 14 条 + 我复核时补做了它按范围跳过的 1 条。
每条先写测试看它红、改实现看它绿；对锁类修复还做了「把实现临时还原、确认测试真会红」。

1. [MEDIUM] 启动期回填与 HTTP 监听竞态：升级后的第一个请求可能读到旧的默认供应商。
   改用 @PostConstruct，回填完成之前不接请求。
2. [MEDIUM] 资源包的 install() 与 uninstall() 共用同一个对象锁（synchronized(this)）——
   卸载一个毫不相干的包会被另一个包正在跑的多分钟下载整个堵住。改成按 packId 分锁。
   防空断言时量到：临时把分锁改回恒返回 this，卸载被拖住整整 5007ms，与持锁上限吻合。
3. [MEDIUM] getUsernameFromSession 吞掉所有异常返回 null，与「查无此人」无法区分——
   而它正是各处用来给上传/操作署名的那一次调用，一次瞬时故障就静默记成空创建者。
   补日志（这条只改日志、不改行为，用 logback ListAppender 断言）。
4. [MEDIUM] 会议 finish / transcribe 没有双提交守卫，重复点击会把同一段音频提交两次转写：
   BYOK 档是两次真实的云端计费调用并互相覆盖 taskId，平台档是两次预扣 Credits。
   复用既有的按会议锁。
5. [MEDIUM] 反馈附件校验失败留下一条已提交、没有正文也没有上下文的空行，而用户被告知提交失败。
   校验前置到落库之前（提交与收件两条路都改）。
6. [MEDIUM] 遥测只 rollup「昨天」：应用没开的那几天永远不会有 rollup 行，那几天的数据永久丢。
   改成昨日无条件重算 + 往前 30 天窗口补缺失。
7. [LOW] 网关调用被中断时静默转成重试而不是把中断传上去（重试前先 peek 中断标志）。
8. [LOW] syncRevoked 与并发安装的读改写竞态会把 current.json 回退到陈旧版本（与第 2 条共用分锁）。
9. [LOW] addMember 的重复校验竞态撞唯一约束，用户看到的是「服务器内部错误」而不是
   本来准备好的「用户已在项目中」。翻译成友好提示。
10. [LOW] ingest 配额 check-then-insert 不原子，并发提交能一起越过每日上限（按 installId 分条锁）。
11. [LOW] OptimizerMailer 部分失败后重试会给已经发过的收件人重复发信。
    **明说局限**：去重记在进程内存里，能覆盖同进程内的重试（该任务每天一次、进程通常
    跑得比重试间隔久），但进程重启后紧邻的下一轮仍可能重发一次。做成跨重启需要新表或加列，没做。
12. [LOW] 遥测写队列注释写着「有界丢弃」，实际是无界队列——慢 DB 会让它无限堆积。
    改成手工 ThreadPoolExecutor + 容量 2000。
13. [LOW] device_token 永不清理（含已撤销/悬空的）。365 天空转清理，数字抄
    security.session-idle-days 的桌面档默认值。
14. [LOW] AccountController.usage 里一条来自官网的坏账目会把已经算好的本地统计一起丢掉。
    **catch 范围比清单点名的 ClassCastException 更宽**（RuntimeException）：好处是同时接住
    其它形状漂移，代价是理论上会把这段里真正的编程错误也降级成「platform 暂不可用」；
    这段 try 只包了两次外部取数 + 一次过滤，判为可接受，记在这里备查。

15. [复核时补做] pptx-service 崩溃/重启后 PENDING/PROCESSING 任务永远转圈
    子 agent 按「只改 backend/」的范围限制跳过了这条（它在 pptx-service/ 的 Python 侧）——
    那是我划的范围，不是不用修。active_tasks 是进程内字典，重启即丢，而库里那些行还停在
    PENDING/PROCESSING：前端轮询会一直转下去，没有报错、没有超时、也没有恢复途径。
    加启动对账：把残留一律标成失败并写明「服务重启导致任务中断，请重新发起」。
    本服务单进程运行（app.run(use_reloader=False)），启动这一刻「正在跑」的必然为零，
    一律判失败是安全的。测试刻意不走 conftest 的 app fixture（那个会连带 import 整条
    控制器链的重依赖），只用 models + 一个最小 Flask 应用，跑得起来也跑得快。

三处与其它批次重叠、复核时合并处理的：
- DeviceTokenService：本批的「空转清理」与 #520 的「写库节流」是互补的两半，合起来保留。
- ProjectVariableService / user_activity_log：#520/#522 已经修过且做法更完整（前者的
  重试落在 REQUIRES_NEW 新事务里），保留那两个版本，本批对应改动丢弃。
- ShareholderMeetingService.ensureFolder：#522 已按「按 key 分锁 + REQUIRES_NEW」修过，
  本批又在外面套了一层按 checkId 的锁。同一件事两套机制、保护范围更粗，去掉外层那一层；
  #522 的锁足以让本批那条并发用例保持绿（已实测）。
  两条测试因此需要把 self 接回自身（纯 Mockito 无 Spring 代理），已一并处理。

自定阈值（都不是产品拍板的数字）：device_token 365 天、遥测队列 2000。

全量 mvn test：2318 通过 0 失败 11 跳过；pptx-service 新增用例 2 例通过。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)