### PR TITLE
release: v0.23.0 版本号（dev-board#86）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
自 v0.22.0 起 52 个提交，主体是 dev-board#74 稳定性审计收官（44 个 fix）。

## 为什么是 0.23.0 而不是 0.22.1

`desktop/scripts/patch-gate.sh` 的四条硬边界里踩了两条：

- `desktop/main/`：drawio-server.js、main.js、backend-service.js、update-service.js 都有改动——mac 上 .app 内所有文件被签名密封，壳层改动补丁到不了用户手里；
- `desktop/scripts/fetch-lowa-assets.js`：LOWA 引擎来源变了（24.2.8-zhcn-r4），引擎只随大版本走。

所以走全量安装包。

## 发版前验证

| 项 | 结果 |
|---|---|
| `mvn -B clean package`（JDK 21） | 2361 通过 / 0 失败（基线 2339） |
| `desktop npm test` | 67 通过 / 1 跳过 / 0 失败 |
| `frontend check:emits` | 通过（97 个 .vue） |
| `frontend test:commands` | 17 通过 |
| `app-e2e`（含 J12 英文旅程） | 见下方评论 |
| LOWA 引擎 URL 三处解析 | 北京 8.152.169.44 / 新加坡 8.219.94.204 / 默认解析 全部 200 |
| `build.extraResources` | h5 / zetaoffice / backend / jre / python / pysvc / skills 齐；litviz+graphviz 自 v0.21.0 起走 native pack，不在包内属预期 |

合并后打 `v0.23.0` tag 触发双平台构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)