### PR TITLE
fix(release): 发版推送与 cron 抢锁，官网下载页停在上一版（v0.23.0 实测）

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -730,6 +730,13 @@ jobs:
           ls -la artifacts
           DEST=/www/wwwroot/update/desktop/installers
           SSH_OPTS="-i $HOME/.ssh/mirror_key -o IdentitiesOnly=yes -o ServerAliveInterval=20"
+
+          # **推送之前先落 marker**：服务器上的 cron 每小时一发，看到新鲜 marker 就
+          # 直接让路（deploy/update-mirror-sync.sh 顶部的判断）。不落这个的话，推送
+          # 途中起来的那一发 cron 会先抢到 flock、再花一小时从 GitHub 重拉同一批包，
+          # 把下面的收尾步骤卡到超时——latest.json 停在上一版、本 job 转红、官网
+          # 下载页继续发旧版（v0.17.0 与 v0.23.0 各踩一次，后者靠人工介入才补上）。
+          ssh $SSH_OPTS "root@$MIRROR_HOST" 'touch /var/lock/awd-release-push-in-progress'
           # --partial --append-verify：这条链路断过（scp 传到 694MB/1437MB 掉线），
           # 断点续传比重传整包可靠。
           for f in artifacts/*.dmg artifacts/*.exe; do
@@ -755,12 +762,32 @@ jobs:
           # 安装包已就位，跑一次同步脚本让它补 latest.json 与补丁包（会 skip exists）。
           # **先等锁再跑**：脚本自带 `flock -n`，撞上 cron 那一发就静默 exit 0，
           # latest.json 停在上一版、下面的校验必挂（v0.17.0 实测）。
-          # `flock -w 1200 ... true` 只是「等到锁空出来就立刻放手」，随后由脚本
+          # `flock -w 3600 ... true` 只是「等到锁空出来就立刻放手」，随后由脚本
           # 自己去加锁。两步之间的窗口极小，真撞上了下面的校验也会报出来。
+          # 上面的 marker 已经挡住「推送途中新起的 cron」；这里的等待是为了另一种
+          # 情形——推送开始之前就已经在跑的那一发，它拉完 GitHub 才会放手，
+          # 1200s 不够（v0.23.0 实测超时），放宽到一小时。
+          # FORCE=1：让脚本无视自己刚落下的 marker。
           ssh $SSH_OPTS "root@$MIRROR_HOST" \
-            'flock -w 1200 /var/lock/awd-update-mirror-sync.lock true \
-             && cd /www/wwwroot/update/desktop && bash update-mirror-sync.sh' | tail -8
+            'flock -w 3600 /var/lock/awd-update-mirror-sync.lock true \
+             && cd /www/wwwroot/update/desktop && FORCE=1 bash update-mirror-sync.sh' | tail -8
 
+          # marker 的清理在下面独立的 always() 步骤里做——这里失败也要清掉，
+          # 否则残留 marker 会让 cron 白白让路（有 90 分钟过期兜底，但那是最后一道）。
           echo "校验 latest.json 指向 ${GITHUB_REF_NAME}"
           curl -fsS --max-time 20 https://www.aiworkdeck.com/update/desktop/installers/latest.json | tee /tmp/latest.json
           grep -q "\"${GITHUB_REF_NAME}\"" /tmp/latest.json || { echo "::error::latest.json 未指向 ${GITHUB_REF_NAME}"; exit 1; }
+
+      - name: Clear release-push marker
+        # 必须 always()：推送失败/校验失败时同样要清，否则 marker 留在服务器上，
+        # 接下来 90 分钟的 cron 全部让路，镜像反而更新不了。
+        if: always()
+        env:
+          MIRROR_HOST: ${{ secrets.MIRROR_HOST }}
+        run: |
+          set -uo pipefail
+          [ -n "${MIRROR_HOST:-}" ] || exit 0
+          [ -f ~/.ssh/mirror_key ] || exit 0
+          ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes "root@$MIRROR_HOST" \
+            'rm -f /var/lock/awd-release-push-in-progress' || \
+            echo "::warning::marker 清理失败，90 分钟后自动过期"

--- a/deploy/update-mirror-sync.sh
+++ b/deploy/update-mirror-sync.sh
@@ -92,11 +92,46 @@ prune_old_installers() {
 # 测试只想拿上面的函数，不要跑同步本身（deploy/update-mirror-sync_prune_test.sh）
 [ "${MIRROR_SYNC_SOURCE_ONLY:-0}" = "1" ] && return 0
 
+# 发版推送进行中就让路：tag 构建的 release job 会把安装包从境外 runner 直推上来
+# （上行不受境内拉 GitHub 那 ~12KB/s 的限制）。这个窗口里 cron 再去 GitHub 拉同一批
+# 包不但纯属浪费，还会**先抢到下面那把锁再拉上一小时**，把随后来收尾的 CI 卡在
+# flock 上超时——latest.json 停在上一版、job 转红、官网下载页继续发旧版。
+# v0.17.0 踩过一次（当时只加了 CI 侧的 flock 等待），v0.23.0 又踩一次：cron 在
+# 16:17 开跑（那一刻 exe 还没推完，它的 skip-exists 判据当时确实不成立），
+# CI 等锁 1200s 超时，官网下载页停在 0.22.0 直到人工介入。
+# 所以让路要发生在**抢锁之前**：CI 推送前落 marker、收尾后删除。
+# FORCE=1 是 CI 自己回头调用本脚本时用的，marker 拦不住它。
+# marker 放 /var/lock 不放 WEB_ROOT——那个 location 只 deny .sh/.py，别的文件名公网可下。
+PUSH_MARKER="${PUSH_MARKER:-/var/lock/awd-release-push-in-progress}"
+# mtime 取值分两种 stat：GNU（线上 Linux）与 BSD（开发机 macOS 跑单测）。
+# **两种都拿不到时按「新鲜」处理**：这里唯一的安全方向是让路。反过来兜底成
+# 「已过期」等于 stat 一变脸这道闸就悄悄失效，又回到 v0.23.0 那个坑，
+# 而且不会有任何告警。真正防「marker 永久残留」的是下面的 90 分钟上限。
+marker_mtime() { stat -c%Y "$1" 2>/dev/null || stat -f%m "$1" 2>/dev/null; }
+if [ "${FORCE:-0}" != "1" ] && [ -f "$PUSH_MARKER" ]; then
+  marker_mt="$(marker_mtime "$PUSH_MARKER")"
+  if [ -z "$marker_mt" ]; then
+    echo "[mirror-sync] 读不到 marker 的 mtime，按新鲜处理并让路（安全方向）" >&2
+    exit 0
+  fi
+  marker_age=$(( $(date +%s) - marker_mt ))
+  # 上限按「最慢的一次整包推送」留：3GB 两个包实测 ~25 分钟，90 分钟足够宽。
+  # 超过就当 CI 半路死了没清理，忽略 marker 照常跑，避免镜像因为一个残留文件永久停更。
+  if [ "$marker_age" -lt 5400 ]; then
+    echo "[mirror-sync] 发版推送进行中（marker ${marker_age}s 前落下），本次让路"
+    exit 0
+  fi
+  echo "[mirror-sync] marker 已过期（${marker_age}s），当作残留忽略" >&2
+fi
+
 # 全局互斥锁：安装包是 GB 级、大陆拉 GitHub 可能一跑数小时，cron 每小时一发，
 # 不加锁必然叠车——2026-08-14 实测三个并发实例互分带宽，每个只剩 ~15KB/s，
 # 谁都跑不完。锁不住就静默退出，把机会留给在跑的那个。
-exec 9>/var/lock/awd-update-mirror-sync.lock
-flock -n 9 || { echo "[mirror-sync] 已有实例在跑（/var/lock/awd-update-mirror-sync.lock），本次退出"; exit 0; }
+# 锁路径可覆盖只为让单测能在开发机上跑（macOS 没有 /var/lock）；线上不要设它，
+# 换了路径就等于没锁——cron 与 CI 各锁各的，叠车照旧。
+LOCK_FILE="${LOCK_FILE:-/var/lock/awd-update-mirror-sync.lock}"
+exec 9>"$LOCK_FILE"
+flock -n 9 || { echo "[mirror-sync] 已有实例在跑（$LOCK_FILE），本次退出"; exit 0; }
 
 mkdir -p "$WEB_ROOT/assets" "$WEB_ROOT/installers"
 TMP="$(mktemp -d)"

--- a/deploy/update-mirror-sync_marker_test.sh
+++ b/deploy/update-mirror-sync_marker_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# update-mirror-sync.sh 的「发版推送让路」单元测试
+# ---------------------------------------------------------------------------
+# 只测抢锁之前那个 marker 判断：造一个假的 marker 文件，跑真脚本，断言它
+# 在**任何网络动作之前**就退出（或该忽略时不退出）。不碰网络、不碰真镜像目录。
+#
+# 用法：bash deploy/update-mirror-sync_marker_test.sh
+# 退出码：0=全通过。
+#
+# 起因是 v0.23.0 发版：CI 16:15 开始推安装包，服务器 cron 16:17 起来（那一刻
+# exe 还没推完，它的 skip-exists 判据当时确实成立不了），抢到 flock 后从 GitHub
+# 慢拉 1.59GB；CI 推完回头等锁，1200s 超时，本脚本从没跑过，latest.json 停在
+# 上一版，sync-mirror job 转红、官网下载页停在 0.22.0 直到人工介入。
+# v0.17.0 已经踩过一次同款（当时只加了 CI 侧的 flock 等待，没挡住「推送途中
+# 新起的 cron」）。治法是让路发生在抢锁之前，用例 1 就是这个回归。
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAIL=0
+
+ok()  { printf '\033[32m  PASS\033[0m %s\n' "$*"; }
+bad() { printf '\033[31m  FAIL\033[0m %s\n' "$*"; FAIL=1; }
+
+ROOT="$(mktemp -d)"
+cleanup() { rm -rf "$ROOT"; }
+trap cleanup EXIT
+
+# 本用例测的是**抢锁之前**那道 marker 闸，不是锁本身。开发机（macOS）没有
+# flock，缺了它脚本会在锁那步就退出，用例 2-4「有没有越过闸」的正向信号
+# （fetching latest release metadata）永远出不来。给个只在缺失时生效的垫片，
+# 让被测的那段逻辑照常往下跑。线上 Linux 有真 flock，垫片不参与。
+SHIM=""
+if ! command -v flock >/dev/null 2>&1; then
+  SHIM="$ROOT/shim"; mkdir -p "$SHIM"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$SHIM/flock"; chmod +x "$SHIM/flock"
+  printf '\033[33m  提示\033[0m 本机没有 flock，已用垫片跳过加锁（被测对象是 marker 闸，不是锁）\n'
+fi
+
+# 跑真脚本，把 marker / WEB_ROOT / 锁都指到临时目录。
+# REPO 指向一个必然打不通的地址：万一 marker 没拦住，脚本会往下走到取 release
+# 元数据那步然后失败——这正是我们要区分的两种结局，绝不会真去动网络或镜像。
+run_script() {
+  PUSH_MARKER="$ROOT/marker" \
+  WEB_ROOT="$ROOT/web" \
+  REPO="invalid.localhost/nonexistent" \
+  API="http://127.0.0.1:1/nope" \
+  LOCK_FILE="$ROOT/lock" \
+  PATH="${SHIM:+$SHIM:}$PATH" \
+  "$@" bash "$HERE/update-mirror-sync.sh" 2>&1
+}
+
+# --- 用例 1：marker 新鲜 → 让路，且在任何网络动作之前就退出 ---
+touch "$ROOT/marker"
+out="$(run_script)"
+rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q '发版推送进行中'; then
+  ok "marker 新鲜时让路并 exit 0"
+else
+  bad "marker 新鲜时应当让路 exit 0，实际 rc=$rc；输出：$out"
+fi
+if printf '%s' "$out" | grep -q 'fetching latest release metadata'; then
+  bad "让路发生得太晚——已经走到取元数据那步（必须在抢锁之前就退出）"
+else
+  ok "让路发生在抢锁与取元数据之前"
+fi
+
+# --- 用例 2：FORCE=1 无视 marker（CI 自己回头调用时用的口子）---
+out="$(run_script env FORCE=1)"
+if printf '%s' "$out" | grep -q 'fetching latest release metadata'; then
+  ok "FORCE=1 无视 marker，继续往下跑"
+else
+  bad "FORCE=1 没能越过 marker（或根本没跑起来）——CI 推完永远补不上 latest.json；输出：$out"
+fi
+
+# --- 用例 3：marker 过期（>90 分钟）当作残留忽略 ---
+# 不然 CI 半路死掉留下的一个空文件能让镜像永久停更。
+touch -d '3 hours ago' "$ROOT/marker" 2>/dev/null || touch -t "$(date -v-3H +%Y%m%d%H%M 2>/dev/null)" "$ROOT/marker"
+out="$(run_script)"
+if printf '%s' "$out" | grep -q 'fetching latest release metadata'; then
+  ok "过期 marker 当作残留忽略，继续往下跑"
+else
+  bad "过期 marker 仍在拦（或根本没跑起来）——CI 半路死掉会让镜像永久停更；输出：$out"
+fi
+
+# --- 用例 4：没有 marker 时照常往下走 ---
+rm -f "$ROOT/marker"
+out="$(run_script)"
+if printf '%s' "$out" | grep -q 'fetching latest release metadata'; then
+  ok "无 marker 时照常往下走"
+else
+  bad "无 marker 时没能正常往下走；输出：$out"
+fi
+
+[ "$FAIL" -eq 0 ] && printf '\033[32m全部通过\033[0m\n' || printf '\033[31m有用例失败\033[0m\n'
+exit "$FAIL"

--- a/desktop/tests/workflow-release-gating.test.js
+++ b/desktop/tests/workflow-release-gating.test.js
@@ -122,3 +122,41 @@ test('desktop-build.yml：pysvc 缓存 key 必须覆盖各服务源码，否则�
     }
   }
 })
+
+// v0.23.0 发版实测：sync-mirror job 转红、官网下载页停在 0.22.0 直到人工介入。
+// 时间线——CI 16:15 开始推安装包，服务器 cron 16:17 起来（那一刻 exe 还没推完，
+// 它的 skip-exists 判据当时确实成立不了），抢到 flock 后从 GitHub 慢拉 1.59GB；
+// CI 推完回头等锁，1200s 超时，update-mirror-sync.sh 从没跑过，latest.json 停在
+// 上一版，最后那条校验 exit 1。v0.17.0 已经踩过一次同款（当时的处置只是加了
+// CI 侧的 flock 等待，没挡住「推送途中新起的 cron」）。
+//
+// 治法是让路发生在**抢锁之前**：推送前落 marker，cron 见到新鲜 marker 就退出。
+// 下面三条各钉住这条链的一环，任何一环被摘掉都会让那个窗口重新打开。
+test('desktop-build.yml：推安装包之前必须落 release-push marker，否则途中起来的 cron 会抢锁慢拉', () => {
+  const doc = loadWorkflow('desktop-build.yml')
+  const step = doc.jobs['sync-mirror'].steps.find((s) => /rsync/.test(String(s.run || '')))
+  assert.ok(step, 'sync-mirror 里应该有那个 rsync 推送步骤（本用例的前提）')
+  const run = String(step.run)
+  const markerAt = run.indexOf('touch /var/lock/awd-release-push-in-progress')
+  const rsyncAt = run.indexOf('rsync ')
+  assert.ok(markerAt !== -1, '推送步骤里没有落 marker：cron 会在推送途中抢锁重拉同一批包')
+  assert.ok(markerAt < rsyncAt,
+    'marker 必须落在 rsync 之前——落在后面等于把那 20 多分钟的窗口原样留着')
+})
+
+test('desktop-build.yml：CI 回头跑同步脚本必须带 FORCE=1，否则被自己刚落的 marker 拦下', () => {
+  const doc = loadWorkflow('desktop-build.yml')
+  const step = doc.jobs['sync-mirror'].steps.find((s) => /update-mirror-sync\.sh/.test(String(s.run || '')))
+  assert.ok(step, '应该有调用 update-mirror-sync.sh 的步骤（本用例的前提）')
+  assert.match(String(step.run), /FORCE=1\s+bash update-mirror-sync\.sh/,
+    'CI 自己调用同步脚本时没带 FORCE=1：会被自己刚落下的 marker 挡住，latest.json 永远不翻')
+})
+
+test('desktop-build.yml：marker 必须有 always() 的清理步骤，否则失败一次会让 cron 白让路', () => {
+  const doc = loadWorkflow('desktop-build.yml')
+  const cleanup = doc.jobs['sync-mirror'].steps.find((s) =>
+    /rm -f \/var\/lock\/awd-release-push-in-progress/.test(String(s.run || '')))
+  assert.ok(cleanup, '没有清理 marker 的步骤：推送失败后 marker 残留，接下来的 cron 全部让路')
+  assert.equal(String(cleanup.if || '').trim(), 'always()',
+    '清理步骤必须 if: always()——只在成功时清等于「失败那次留下的残留最坏」')
+})


### PR DESCRIPTION
v0.23.0 发版时 `sync-mirror` job 转红，官网 `/start` 一直发 0.22.0 直到人工介入。

## 时间线

| 时刻 | 发生了什么 |
|---|---|
| 16:15 | CI 开始往镜像推安装包（境外 runner 上行快，dmg 7 分钟、exe 再 6 分钟） |
| 16:17 | 服务器 cron 起来。**那一刻 exe 还没推完**，它的 skip-exists 判据当时确实成立不了 |
| 16:17→ | cron 抢到 flock，开始从 GitHub 拉 1.59GB（境内实测 ~12KB/s） |
| 16:28 | CI 推完两个包（字节数与 Release 资产完全一致） |
| 16:28→48 | CI `flock -w 1200` 等锁，20 分钟超时 |
| 16:48 | `update-mirror-sync.sh` 从没跑过 → `latest.json` 停在 v0.22.0 → 末尾校验 `exit 1` |

`v0.17.0` 踩过同款，当时的处置只是在 CI 侧加 flock 等待——那挡得住「推送开始**前**就在跑的 cron」，挡不住「推送**途中**新起的 cron」，所以这次又踩。

## 治法：让路发生在抢锁之前

- CI 推包**前**在服务器落 marker（`/var/lock/awd-release-push-in-progress`），收尾用 `if: always()` 清掉（失败那次留下的残留最坏）；
- `update-mirror-sync.sh` 在抢锁之前检查 marker，新鲜就直接 `exit 0` 让路；CI 自己回头调用时带 `FORCE=1` 越过自己刚落的那个；
- marker 设 90 分钟上限，CI 半路死掉不会让镜像永久停更；
- CI 侧等待从 1200s 放宽到 3600s，覆盖「推送开始前就在跑」那种情形。

## 写单测时被自己的实现绊了一下

marker 年龄原本写成 `stat -c%Y ... || echo 0`。stat 一失败就静默当成「已过期」——**那是把闸悄悄关掉的方向**，等于回到本 bug，而且不会有任何告警。改成 GNU/BSD 两种 stat 都试，两种都拿不到时按「新鲜」处理，因为这里唯一的安全方向是让路；防「marker 永久残留」的是那个 90 分钟上限，不该靠 stat 失败来兜。

## 验证

| 项 | 结果 |
|---|---|
| `deploy/update-mirror-sync_marker_test.sh`（新增） | 5 条全通过 |
| **病灶还原** | 摘掉 marker 闸 → 2 条转红（另 3 条守的是「别过度拦截」方向，本就该保持绿） |
| `desktop npm test` | 71 通过（+3 条 workflow 守卫） |
| **病灶还原** | 拿掉 touch marker / `FORCE=1` / `always()` → 对应 3 条全部转红 |
| 既有 `update-mirror-sync_prune_test.sh` | 不受影响，仍全绿 |

## 当前线上状态（已人工补齐）

已核对：镜像上两个安装包的字节数与 Release 资产**完全一致**，人工放掉那个多余的 cron 下载并重跑同步脚本后 `latest.json` 已指向 v0.23.0，两站 revalidate 回调成功，官网与国际站下载区都已显示 0.23.0。

**没有重跑那个红掉的 job**：重跑用的是 tag 上的旧 workflow，验证不到本 PR 的改动，只会白传 3GB。红色留在记录里，本 PR 的说明就是它的注解。

🤖 Generated with [Claude Code](https://claude.com/claude-code)