### PR TITLE
fix(mobile-sync): 手机端永远读不到项目——它登在号码已被转走的孤儿账号上（dev-board#95）

### DIFF
--- a/backend/src/main/java/com/checkba/service/mobile/OrphanPhoneSessionReconciler.java
+++ b/backend/src/main/java/com/checkba/service/mobile/OrphanPhoneSessionReconciler.java
@@ -1,0 +1,106 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.UserSessionService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * 启动期对账：作废「手机号已被转走的孤儿账号」的登录会话（dev-board#95）。
+ *
+ * <h3>要治的是什么</h3>
+ * 手机端账号归一（dev-board#30）的做法是：官网账户带着经短信验证的手机号来桥接时，
+ * {@code UserService.claimPhoneFromWebsite} 把号码从原持有者转到桥接账号名下，
+ * <b>并作废原持有者的全部会话</b>（dev-board#75），逼手机端重新走短信登录、落到归一后的账号。
+ *
+ * <p>但那条作废是<b>认领那一刻</b>的一次性动作。在它上线之前就已经被拆开的账号，
+ * 号码早就转走了、认领不会再发生一次，于是原持有者的会话<b>永远不会被作废</b>——
+ * 而它又不会自己过期（7 天滑动过期，手机端每次轮询都在续命）。
+ *
+ * <p>后果不是报错，是<b>静默的空</b>：{@code GET /api/mobile/projects} 按 userId 取目录，
+ * 孤儿账号名下什么都没有，返回一个合法的空数组。手机端显示「没有项目」，
+ * 没有任何提示说「你登在另一个账号上」，重进多少次都一样。
+ * 2026-08-21 现场实证：桌面端每隔几分钟就把 10 个项目推到 user 3 名下，
+ * 而手机端手里那张会话属于 user 4，从 8-20 09:20 一直用到第二天，一个项目都读不到。
+ *
+ * <h3>怎么认出孤儿账号</h3>
+ * 靠 {@code findOrCreateByPhone} 留下的两个印记，缺一不可：
+ * <ul>
+ *   <li>{@code displayName} 是<b>掩码手机号</b>（{@code 186****1590}）——只有短信登录建号会这么写；</li>
+ *   <li>{@code phone} 为空——号码已经被 {@code claimPhoneFromWebsite} 转走了。</li>
+ * </ul>
+ * 两条同时成立 = 这个账号唯一的登录入口（用那个号码收短信）已经指向别人了，
+ * 它的会话再也不可能被合法地重新签发，作废掉是安全的。
+ *
+ * <p>只匹配 displayName 不看 phone 会误伤正常的短信登录账号；
+ * 只看 phone 为空会误伤 admin、官网桥接账号这些本来就没绑号的。
+ *
+ * <p>幂等：作废过就没有会话了，之后每次启动都是 0 条。
+ */
+@Service
+@Slf4j
+public class OrphanPhoneSessionReconciler implements CommandLineRunner {
+
+    /** SmsAuthService.maskPhone 的产物形状：前 3 位 + **** + 后 4 位。 */
+    private static final Pattern MASKED_PHONE = Pattern.compile("^1\\d{2}\\*{4}\\d{4}$");
+
+    private final UserRepository userRepository;
+    private final UserSessionService userSessionService;
+
+    public OrphanPhoneSessionReconciler(UserRepository userRepository,
+                                        UserSessionService userSessionService) {
+        this.userRepository = userRepository;
+        this.userSessionService = userSessionService;
+    }
+
+    @Override
+    public void run(String... args) {
+        reconcile();
+    }
+
+    /** @return 被作废的会话总数（供测试与日志用） */
+    public long reconcile() {
+        long revoked = 0;
+        int accounts = 0;
+        List<User> all;
+        try {
+            all = userRepository.findAll();
+        } catch (RuntimeException e) {
+            // 对账是顺手活，读不到用户表不该拦住启动
+            log.warn("孤儿手机账号对账跳过：读取用户表失败 {}", e.toString());
+            return 0;
+        }
+        for (User u : all) {
+            if (!isOrphanPhoneAccount(u)) continue;
+            try {
+                long n = userSessionService.revokeAllForUser(u.getId());
+                if (n > 0) {
+                    accounts++;
+                    revoked += n;
+                    log.info("孤儿手机账号 {}（{}）的号码已转走，作废其 {} 条遗留会话——"
+                            + "手机端会被迫重新短信登录，落到归一后的账号",
+                            u.getId(), u.getDisplayName(), n);
+                }
+            } catch (RuntimeException e) {
+                log.warn("作废孤儿账号 {} 的会话失败：{}", u.getId(), e.toString());
+            }
+        }
+        if (accounts > 0) {
+            log.info("孤儿手机账号对账完成：{} 个账号、{} 条会话", accounts, revoked);
+        }
+        return revoked;
+    }
+
+    /** 掩码手机号做 displayName + phone 已空 = 号码被转走的短信登录孤儿号。 */
+    boolean isOrphanPhoneAccount(User u) {
+        if (u == null || u.getId() == null) return false;
+        if (u.getPhone() != null && !u.getPhone().isBlank()) return false;
+        String display = u.getDisplayName();
+        return display != null && MASKED_PHONE.matcher(display).matches();
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/OrphanPhoneSessionReconcilerTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/OrphanPhoneSessionReconcilerTest.java
@@ -1,0 +1,132 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.UserSessionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * 孤儿手机账号会话对账（dev-board#95）。
+ *
+ * <p>现场：桌面端每几分钟把 10 个项目推到 user 3 名下，手机端手里那张会话却属于
+ * user 4——一个 displayName 是掩码手机号、phone 已被转走的孤儿号。
+ * {@code /api/mobile/projects} 按 userId 取目录，于是返回一个<b>合法的空数组</b>：
+ * 不报错、不提示，手机端就是「一个项目都读不到」，重进多少次都一样。
+ * 认领时作废会话那条（dev-board#75）只在认领那一刻生效，救不了在它之前就被拆开的账号。
+ */
+class OrphanPhoneSessionReconcilerTest {
+
+    private User user(Long id, String username, String displayName, String phone) {
+        User u = new User();
+        u.setId(id);
+        u.setUsername(username);
+        u.setDisplayName(displayName);
+        u.setPhone(phone);
+        return u;
+    }
+
+    private OrphanPhoneSessionReconciler reconciler(UserRepository repo, UserSessionService sessions) {
+        return new OrphanPhoneSessionReconciler(repo, sessions);
+    }
+
+    @Test
+    @DisplayName("号码被转走的孤儿号：作废它的遗留会话，手机端才会被迫重登到归一后的账号")
+    void revokesSessionsOfOrphanPhoneAccount() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        // 现场那一对：user 3 拿着号码，user 4 是被转走号码后的孤儿
+        when(repo.findAll()).thenReturn(List.of(
+                user(3L, "awd_hanzewei", "韩泽伟", "18610211590"),
+                user(4L, "uspe8yzah", "186****1590", null)));
+        when(sessions.revokeAllForUser(4L)).thenReturn(3L);
+
+        long revoked = reconciler(repo, sessions).reconcile();
+
+        assertEquals(3L, revoked);
+        verify(sessions).revokeAllForUser(4L);
+        verify(sessions, never()).revokeAllForUser(3L);
+    }
+
+    @Test
+    @DisplayName("号码还在的短信登录账号绝不能碰——那是正常账号，作废会把人踢下线")
+    void leavesLivePhoneAccountAlone() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(repo.findAll()).thenReturn(List.of(
+                user(7L, "abc123xyz", "138****4321", "13800014321")));
+
+        assertEquals(0L, reconciler(repo, sessions).reconcile());
+        verify(sessions, never()).revokeAllForUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("admin 与官网桥接账号本来就没绑号，不能因为 phone 为空就被当成孤儿")
+    void leavesAccountsThatNeverHadAPhoneAlone() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(repo.findAll()).thenReturn(List.of(
+                user(1L, "admin", "管理员", null),
+                user(3L, "awd_hanzewei", "韩泽伟", null)));
+
+        assertEquals(0L, reconciler(repo, sessions).reconcile());
+        verify(sessions, never()).revokeAllForUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("掩码形状要卡准：像手机号但不是 maskPhone 产物的 displayName 不算数")
+    void onlyMatchesTheMaskPhoneShape() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(repo.findAll()).thenReturn(List.of(
+                user(11L, "a", "18610211590", null),      // 没打码的完整号码
+                user(12L, "b", "186***1590", null),       // 星号数量不对
+                user(13L, "c", "286****1590", null),      // 不是 1 开头
+                user(14L, "d", "186****1590 (旧)", null)));// 有后缀
+
+        assertEquals(0L, reconciler(repo, sessions).reconcile());
+        verify(sessions, never()).revokeAllForUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("对账是顺手活：读用户表炸了也不能拦住启动")
+    void surviveRepositoryFailure() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(repo.findAll()).thenThrow(new RuntimeException("db down"));
+
+        assertDoesNotThrow(() -> assertEquals(0L, reconciler(repo, sessions).reconcile()));
+    }
+
+    @Test
+    @DisplayName("单个账号作废失败不能中断整轮对账")
+    void oneFailureDoesNotAbortTheSweep() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(repo.findAll()).thenReturn(List.of(
+                user(4L, "a", "186****1590", null),
+                user(5L, "b", "139****8888", null)));
+        when(sessions.revokeAllForUser(4L)).thenThrow(new RuntimeException("boom"));
+        when(sessions.revokeAllForUser(5L)).thenReturn(2L);
+
+        assertEquals(2L, reconciler(repo, sessions).reconcile());
+        verify(sessions).revokeAllForUser(5L);
+    }
+
+    @Test
+    @DisplayName("幂等：没有遗留会话时是 0 条，重复启动不产生副作用")
+    void idempotentWhenNothingToRevoke() {
+        UserRepository repo = mock(UserRepository.class);
+        UserSessionService sessions = mock(UserSessionService.class);
+        when(repo.findAll()).thenReturn(List.of(user(4L, "a", "186****1590", null)));
+        when(sessions.revokeAllForUser(4L)).thenReturn(0L);
+
+        assertEquals(0L, reconciler(repo, sessions).reconcile());
+    }
+}


### PR DESCRIPTION
「手机端还是同步不到桌面端的项目」——**不是同步没跑，是两边根本不是同一个账号。**

## 现场取证（2026-08-21 云端库）

```
mobile_project_dir:  user_id=3  device=Zeweis-MacBook-Pro  entries=10  last=17:15:49
user_session:        全部 3 条会话  user_id=4              last_used=08-21 08:32

app_users:
 id |   username   | display_name | phone
  3 | awd_hanzewei | 韩泽伟        | 18610211590
  4 | uspe8yzah    | 186****1590  | (空)
```

桌面端每几分钟把 10 个项目推到 **user 3** 名下（日志：`手机同步：项目目录已推送（10 项）`），手机端手里那张会话却属于 **user 4**。

## 根因

`user 4` 是 `findOrCreateByPhone` 在 8-17 建的短信登录号（`display_name` 写的就是掩码手机号）。后来官网账户来桥接，`claimPhoneFromWebsite` 把号码**转到了 user 3 名下**，user 4 就此成为孤儿。

dev-board#75 已经给认领加了「顺手作废原持有者的会话」——但那是**认领那一刻**的一次性动作。在它上线之前就被拆开的账号，号码早就转走了、认领不会再发生一次，会话于是**永远不会被作废**；而它还有 7 天滑动过期，手机端每次轮询都在给它续命。

后果不是报错，是**静默的空**：`/api/mobile/projects` 按 userId 取目录，孤儿号名下什么都没有，返回一个**合法的空数组**。手机端显示「没有项目」，没有任何提示说「你登在另一个账号上」，重进多少次都一样。

## 修法

启动期对账一次：作废孤儿号的遗留会话，逼手机端重新走短信登录、落到归一后的账号。

孤儿号靠 `findOrCreateByPhone` 留下的**两个印记同时判定**：
- `displayName` 是掩码手机号（`186****1590`）——只有短信登录建号会这么写；
- `phone` 已空——号码被 `claimPhoneFromWebsite` 转走了。

少任何一条都会误伤：只看 displayName 会踢掉号码还在的正常短信登录账号；只看 phone 为空会踢掉 admin 和官网桥接账号（它们本来就没绑号）。幂等——作废过之后每次启动都是 0 条。

## 验证

| 项 | 结果 |
|---|---|
| 新增用例 | 7 条全通过 |
| 误伤方向覆盖 | 号码还在的短信账号 / 从没绑过号的 admin 与桥接账号 / 掩码形状不对的四种变体 |
| 容错 | 读用户表炸了不拦启动；单个账号作废失败不中断整轮 |
| **病灶还原** | 判定改成恒 false → 2 条转红；改回 → 7 条全绿（实跑） |

合并后要给云后端换 jar 重启，对账才会在生产上跑到——届时 user 4 那 3 条会话会被清掉，手机端重新短信登录即可看到 10 个项目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)