### PR TITLE
feat(ui): 头像直达设置、标签中键关闭、收藏卡片压扁、撤死设置（dev-board#96-#99）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -159,21 +159,25 @@ toEventStart），五个消费组件都从这里拿，别再各写一份。
 `type="date"/"time"` 会静默降级成文本框。日期/时间输入一律用 `components/AwdDatePicker.vue`
 （mounted 手工挂真原生 input 绕开 uni 模板劫持；只监听 change 防中间值上抛）。
 
-## 顶栏头像下拉与统一「设置」标签（2026-08-19 立，2026-08-20 并）
+## 顶栏头像与统一「设置」标签（2026-08-19 立，2026-08-20 并，2026-08-21 撤下拉）
 
 rail 底部的**齿轮与用户头像都撤了**，收进顶栏右上角「活动记录」右侧的
-`.header-account`：头像 `.avatar-btn` → 下拉 `.avatar-menu`。
-**2026-08-20 起下拉只有一项「设置」**——个人中心并进了系统设置，两个入口各开一整块
-面板、彼此还互相跳（个人中心侧栏给管理员插一条「系统设置」走 navigateTo，设置页侧栏
-又有一条「个人中心」）是用户点名抱怨过的形态。那一项**不再按 `isClientView` 收**：
-客户也有自己的工作记录与账号安全，「系统」组由面板内部按 isAdmin 自己收。
+`.header-account`：头像 `.avatar-btn`，**点击直接 `goToSystemSettings` 开设置标签，
+没有下拉了**（dev-board#96）。沿革：2026-08-20 个人中心并进系统设置后下拉只剩一项
+「设置」——两个入口各开一整块面板、彼此还互相跳（个人中心侧栏给管理员插一条
+「系统设置」走 navigateTo，设置页侧栏又有一条「个人中心」）是用户点名抱怨过的形态；
+2026-08-21 连那个只有一项的下拉也撤了，`avatarMenuOpen` / `toggleAvatarMenu` /
+`.avatar-menu*` 样式 / App.vue 里菜单那两行 no-drag 全删，`check:nav` 现在断言这些名字
+一个都不许回来。头像**不按 `isClientView` 收**：客户也有自己的工作记录与账号安全，
+「系统」组由面板内部按 isAdmin 自己收。
 
 - **入口**：`goToSystemSettings(opts)` → `openSettingsTab(opts)`，中栏开单例标签
   （`tabType:'admin-settings'`、`isTabVisible` 常显、直接 push 进 leftFiles 绕过
   `isFileTypeSupported`——与 market-detail / 浏览器 tab 同法）。整页跳转会把标签、
   编辑器、AI 会话整个换掉，改个 API Key 的代价是回来重开一遍文件。
   **`goToUserProfile` / `openUserProfileTab` / `tabType:'user-profile'` 全没了**，
-  `check-navigation-contract.mjs` 现在守的是「头像下拉恰好一项、且这四个名字一个都不许回来」。
+  `check-navigation-contract.mjs` 现在守的是「头像直接指向 goToSystemSettings、没有下拉，
+  且这些旧名字一个都不许回来」。
 - **深链等价物**：`openSettingsTab({ nav, service })` 对应薄壳页的
   `?nav=platform&service=ocr`（网关错误提示的逃生门指着它）。标签是单例，
   已经开着时再带深链进来只改 props——所以 **`AdminPane` 里加了
@@ -375,6 +379,14 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
   激活态白底 + 2px mint 顶线、12px/500 文件名、× 悬停或激活才显形。
   **`.tab-item` 的高度写死 36px 不用 `height:100%`**：中间隔着 uni `scroll-view`
   的内层包裹元素，那条 100% 链断了标签会塌成 0 高。
+- **标签支持鼠标中键关闭（2026-08-21，dev-board#97）**：`.tab-item` 上挂
+  `@mousedown="onTabMouseDown"` + `@auxclick="onTabAuxClick"`（两个方法在
+  `fileOpenTabs.js`，紧挨 `closeFile`），中键走的就是 `closeFile(file.id, pane)`——
+  与点 × 同一条路径，脏改动落盘/BrowserView 销毁等闸门一个不少。mousedown 与 auxclick
+  两处都对 `button===1` preventDefault（压掉 Linux/Windows 的中键自动滚动）。
+  uni-h5 的 `<view>` 默认 inheritAttrs，原生 `auxclick` 直接落到 `<uni-view>` 上。
+  标签没有「固定/不可关」概念，所以没有例外分支；要加固定标签时先在这里加判断。
+  app-e2e J6.3 末尾用 `page.mouse.click(..., { button: 'middle' })` 关设置标签兼作覆盖。
 
 ## 相关文件
 

--- a/frontend/scripts/check-navigation-contract.mjs
+++ b/frontend/scripts/check-navigation-contract.mjs
@@ -460,19 +460,21 @@ check('工作台「全部项目」用 reLaunch 去项目列表页，且离开前
   return null
 })
 
-check('顶栏头像下拉只剩「设置」一项（2026-08-20 新契约）', () => {
-  // 用户的原话是「个人中心和系统设置是整个面板切换、还互相跳」。合并之后
-  // 下拉里只能有一个入口，个人内容是那一页里的「个人」组。
+check('顶栏头像直接开设置标签，没有下拉（2026-08-21，dev-board#96）', () => {
+  // 2026-08-20 个人中心并进设置后下拉只剩一项，2026-08-21 连这个只有一项的下拉也撤了：
+  // 点头像 = goToSystemSettings，同一条路径。个人内容是设置页里的「个人」组。
   const src = readVue('src/pages/project-overview/project-overview.vue')
-  const items = src.split('avatar-menu-item').length - 1
-  if (items !== 1) return '头像下拉应当恰好一项，实际 ' + items + ' 项'
-  for (const dead of ['openUserProfileTab', 'goToUserProfile', "workbench.profile", "'user-profile'"]) {
-    if (src.includes(dead)) return '还残留个人中心标签那一套: ' + dead
+  for (const dead of ['avatar-menu', 'avatarMenuOpen', 'toggleAvatarMenu',
+    'openUserProfileTab', 'goToUserProfile', "workbench.profile", "'user-profile'"]) {
+    if (src.includes(dead)) return '还残留头像下拉/个人中心标签那一套: ' + dead
   }
+  const i = src.indexOf('class="avatar-btn"')
+  if (i < 0) return '找不到 .avatar-btn'
+  const btn = src.slice(i, i + 200)
+  if (!btn.includes('goToSystemSettings')) return '头像没有直接指向 goToSystemSettings'
   // 客户也要进得去：个人组的工作记录/账号安全对他一样成立，收系统组是面板自己的事
-  const menu = src.slice(src.indexOf('avatar-menu"'), src.indexOf('avatar-menu"') + 400)
-  if (menu.includes('isClientView')) return '设置入口不该按 isClientView 藏起来（客户也有自己的个人组）'
-  if (!menu.includes('goToSystemSettings')) return '下拉里那一项没有指向 goToSystemSettings'
+  const block = src.slice(src.indexOf('class="header-account"'), i + 600)
+  if (block.includes('isClientView')) return '设置入口不该按 isClientView 藏起来（客户也有自己的个人组）'
   return null
 })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -257,12 +257,10 @@ html.is-desktop .project-header .header-center,
 html.is-desktop .project-header .header-tools,
 html.is-desktop .project-header .top-bar-btn,
 html.is-desktop .project-header .icon-btn,
-/* 右上角头像与它的下拉（2026-08-19 从 rail 底部搬上来）。菜单是绝对定位的，
-   一部分会画到 .header-account 之外，所以四条都要显式写，靠祖先盖不住。 */
+/* 右上角头像（2026-08-19 从 rail 底部搬上来；2026-08-21 起点击直接开设置标签，
+   下拉已撤）。 */
 html.is-desktop .project-header .header-account,
-html.is-desktop .project-header .avatar-btn,
-html.is-desktop .project-header .avatar-menu-mask,
-html.is-desktop .project-header .avatar-menu {
+html.is-desktop .project-header .avatar-btn {
     -webkit-app-region: no-drag;
 }
 

--- a/frontend/src/components/admin/AdminPane.vue
+++ b/frontend/src/components/admin/AdminPane.vue
@@ -274,17 +274,6 @@
                 </view>
 
                 <view class="form-row">
-                  <text class="form-label">{{ $t('platform.budgetTaskLimitLabel') }}</text>
-                  <input
-                    v-model="budgetForm.taskLimit"
-                    class="form-input"
-                    type="digit"
-                    :placeholder="$t('platform.budgetUnit')"
-                  />
-                </view>
-                <text class="field-note">{{ $t('platform.budgetTaskLimitNote') }}</text>
-
-                <view class="form-row">
                   <text class="form-label">{{ $t('platform.budgetLowBalanceLabel') }}</text>
                   <input
                     v-model="budgetForm.lowBalance"
@@ -1525,7 +1514,7 @@ export default {
       // 控件立刻可用）。远端那一半单独放 platformRemote，异步填，填不上就是「—」。
       platformState: {
         services: [], platformAvailable: false, accountConnected: false,
-        budget: { taskLimitCents: 0, lowBalanceCents: 0 },
+        budget: { lowBalanceCents: 0 },
       },
       // 远端那一半（GET /api/platform-services/remote）。三个 null 与空 enabled 表
       // 都是「不知道」的初值，**不是** 0 / 未开放——在真值到达之前一律显示破折号。
@@ -1539,7 +1528,7 @@ export default {
       // 花费闸门的两个阈值，界面上以 Credits（元）为单位编辑，存库是分。
       // 与档位不同，它们是输入框而不是开关：跟着每个字符写库既没必要也会打断输入，
       // 所以留一个明确的保存动作。
-      budgetForm: { taskLimit: '0', lowBalance: '0' },
+      budgetForm: { lowBalance: '0' },
       budgetBusy: false,
       // 每项的「使用自己的 Key（高级）」是否展开。默认全收起；
       // ?nav=platform&service=ocr 这样的深链会就地展开对应那一项（错误提示的逃生门）。
@@ -2954,15 +2943,16 @@ export default {
     },
     async onSaveBudget() {
       if (this.budgetBusy) return
-      const taskLimitCents = this.creditsToCents(this.budgetForm.taskLimit)
       const lowBalanceCents = this.creditsToCents(this.budgetForm.lowBalance)
-      if (taskLimitCents < 0 || lowBalanceCents < 0) {
+      if (lowBalanceCents < 0) {
         uni.showToast({ title: this.$t('platform.budgetInvalid'), icon: 'none' })
         return
       }
       this.budgetBusy = true
       try {
-        await savePlatformBudget(taskLimitCents, lowBalanceCents)
+        // 「单次任务花费上限」2026-08-21 撤出界面：后端从没有执行点，文案却承诺「花到这个数会问一句」。
+        // 端点仍收两个字段，这里恒传 0（= 不启用）保持兼容。
+        await savePlatformBudget(0, lowBalanceCents)
         uni.showToast({ title: this.$t('platform.budgetSaved'), icon: 'none' })
       } catch (e) {
         uni.showToast({ title: (e && e.message) || this.$t('platform.budgetSaveFailed'), icon: 'none' })
@@ -2983,14 +2973,12 @@ export default {
           platformAvailable: !!s.platformAvailable,
           accountConnected: !!s.accountConnected,
           budget: {
-            taskLimitCents: Number((s.budget && s.budget.taskLimitCents) || 0),
             lowBalanceCents: Number((s.budget && s.budget.lowBalanceCents) || 0),
           },
         }
         // 输入框跟着库里的值走。旧后端不返回 budget 时这里落成 0 = 不启用，
         // 与后端默认值一致，不会凭空冒出一个用户没设过的阈值。
         this.budgetForm = {
-          taskLimit: (this.platformState.budget.taskLimitCents / 100).toFixed(2),
           lowBalance: (this.platformState.budget.lowBalanceCents / 100).toFixed(2),
         }
         this.platformServicesError = ''

--- a/frontend/src/components/userprofile/PersonalFavoritesPanel.vue
+++ b/frontend/src/components/userprofile/PersonalFavoritesPanel.vue
@@ -17,21 +17,23 @@
     </view>
     <view v-else class="favorites-list">
       <view v-for="fav in favorites" :key="fav.id" class="favorite-card">
-        <view class="favorite-header">
-          <text class="favorite-title">{{ fav.title || (fav.sourceUrl ? fav.sourceUrl : $t('account.untitledExcerpt')) }}</text>
-          <button class="btn-danger-outline small" @tap.stop="handleDeleteFavorite(fav.id)">{{ $t('common.delete') }}</button>
+        <view v-if="fav.imagePath" class="favorite-thumb">
+          <image class="fav-img" mode="aspectFill" :src="getFavoriteImageUrl(fav.id)" />
         </view>
-        <view v-if="fav.sourceUrl" class="favorite-url">
-          <text class="url-text">{{ fav.sourceUrl }}</text>
-        </view>
-        <view v-if="fav.imagePath" class="favorite-image">
-          <image class="fav-img" mode="widthFix" :src="getFavoriteImageUrl(fav.id)" />
-        </view>
-        <view class="favorite-content">
-          <text class="content-text">{{ fav.content }}</text>
-        </view>
-        <view class="favorite-footer">
-          <text class="time-text">{{ formatTime(fav.createdAt) }}</text>
+        <view class="favorite-body">
+          <view class="favorite-header">
+            <text class="favorite-title">{{ fav.title || (fav.sourceUrl ? fav.sourceUrl : $t('account.untitledExcerpt')) }}</text>
+            <button class="btn-danger-outline small" @tap.stop="handleDeleteFavorite(fav.id)">{{ $t('common.delete') }}</button>
+          </view>
+          <view v-if="fav.sourceUrl" class="favorite-url">
+            <text class="url-text">{{ fav.sourceUrl }}</text>
+          </view>
+          <view v-if="fav.content" class="favorite-content">
+            <text class="content-text">{{ fav.content }}</text>
+          </view>
+          <view class="favorite-footer">
+            <text class="time-text">{{ formatTime(fav.createdAt) }}</text>
+          </view>
         </view>
       </view>
     </view>
@@ -118,28 +120,53 @@ $text-light: #ADB5BD;
 }
 
 .favorites-list {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 10px;
 }
 
+// 2026-08-21 卡片压扁：原先单列纵排、截图 widthFix 撑满设置页整宽，一张卡一屏高。
+// 现在自适应网格 + 左侧固定缩略图 + 正文两行截断，宽屏一行放两三张。
 .favorite-card {
+  display: flex;
+  gap: 10px;
   background: $brand-white;
-  border-radius: 14px;
-  box-shadow: 0 4px 16px rgba(18, 52, 77, 0.05);
+  border-radius: 8px;
   border: 1px solid rgba(224, 224, 224, 0.7);
-  padding: 16px;
+  padding: 10px 12px;
+  min-width: 0;
+}
+
+.favorite-thumb {
+  flex-shrink: 0;
+  width: 88px;
+  height: 66px;
+}
+
+.fav-img {
+  width: 88px;
+  height: 66px;
+  border-radius: 6px;
+  border: 1px solid rgba(224, 224, 224, 0.7);
+  display: block;
+}
+
+.favorite-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .favorite-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
 }
 
 .favorite-title {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   color: $text-main;
   flex: 1;
@@ -149,44 +176,42 @@ $text-light: #ADB5BD;
 }
 
 .favorite-url {
-  margin-top: 6px;
+  margin-top: 2px;
 }
 
 .url-text {
-  font-size: 12px;
+  font-size: 11px;
   color: $text-light;
-  word-break: break-all;
-}
-
-.favorite-image {
-  margin-top: 10px;
-}
-
-.fav-img {
-  width: 100%;
-  border-radius: 10px;
-  border: 1px solid rgba(224, 224, 224, 0.7);
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .favorite-content {
-  margin-top: 10px;
+  margin-top: 4px;
 }
 
 .content-text {
-  font-size: 13px;
+  font-size: 12px;
   color: $text-secondary;
-  line-height: 1.6;
-  white-space: pre-wrap;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
 }
 
 .favorite-footer {
-  margin-top: 10px;
+  margin-top: auto;
+  padding-top: 4px;
   display: flex;
   justify-content: flex-end;
 }
 
 .time-text {
-  font-size: 12px;
+  font-size: 11px;
   color: $text-light;
 }
 

--- a/frontend/src/locales/en-US/platform.js
+++ b/frontend/src/locales/en-US/platform.js
@@ -69,8 +69,6 @@ export default {
   // ---- Spending thresholds ----
   budgetTitle: 'Spending alerts',
   budgetSubtitle: 'Set either to 0 to turn it off. These decide when we ask you a question, not a hard cap.',
-  budgetTaskLimitLabel: 'Per-task spending cap',
-  budgetTaskLimitNote: 'When one task reaches this amount we ask whether to continue; confirm and it carries on. Not a prompt on every call.',
   budgetLowBalanceLabel: 'Warn when balance drops below',
   budgetLowBalanceNote: 'Shows a warning on this panel once the balance falls below this amount, so a transcription does not run out halfway.',
   budgetUnit: 'Credits',

--- a/frontend/src/locales/zh-CN/platform.js
+++ b/frontend/src/locales/zh-CN/platform.js
@@ -69,9 +69,7 @@ export default {
   // ---- 花费闸门 ----
   budgetTitle: '花费提醒',
   budgetSubtitle: '两个阈值都填 0 表示不启用。这里管的是「什么时候问你一句」，不是硬性封顶。',
-  budgetTaskLimitLabel: '单次任务花费上限',
   // 刻意不做「每次调用前弹确认」——与「零配置、少打扰」的产品目标冲突。
-  budgetTaskLimitNote: '一次任务累计花到这个数时问一句「是否继续」，确认后照常往下跑。不是每次调用都问。',
   budgetLowBalanceLabel: '余额低于此值时提醒',
   budgetLowBalanceNote: '余额掉到这个数以下时在这块面板上提醒，免得转写跑到一半才发现不够。',
   budgetUnit: 'Credits',

--- a/frontend/src/locales/zh-CN/workbench.js
+++ b/frontend/src/locales/zh-CN/workbench.js
@@ -51,7 +51,7 @@ export default {
   systemSettings: '系统设置（AI 提供商 / API Key）',
   clientInitial: '客',
   addMember: '加人',
-  // 顶栏右上角的头像下拉（2026-08-19 从 rail 底部搬上来；2026-08-20 个人中心并进设置后只剩一项）
+  // 顶栏右上角头像的 title（2026-08-19 从 rail 底部搬上来；2026-08-21 起点击直接开设置标签，下拉已撤）
   accountMenu: '设置',
   settingsTabName: '设置',
   // 「语音」面板内部的两个 tab

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -239,6 +239,22 @@ export const fileOpenTabsMethods = {
       }
     },
 
+    /**
+     * 标签条的鼠标中键（dev-board#97）：中键单击 = 点 ×，走同一条 closeFile
+     * （含 Office/文本脏改动先落盘、浏览器标签销毁 BrowserView 等既有闸门）。
+     * 中键在 Linux/Windows 上 mousedown 会起「自动滚动」光标，auxclick 前就得拦，
+     * 所以 mousedown 与 auxclick 两处都 preventDefault；左/右键一律放行
+     * （左键是 @tap 激活，右键没有菜单）。标签没有「固定」概念，全部可关。
+     */
+    onTabMouseDown(e) {
+      if (e && e.button === 1) e.preventDefault()
+    },
+    onTabAuxClick(e, file, pane) {
+      if (!e || e.button !== 1) return
+      e.preventDefault()
+      e.stopPropagation()
+      this.closeFile(file.id, pane)
+    },
     async closeFile(fileId, pane) {
       const list = pane === 'left' ? this.leftFiles : this.rightFiles
       const idProp = pane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -412,10 +412,9 @@ $bg-white: #FFFFFF;
   border-right: none;
 }
 
-/* 右上角头像与它的下拉。独立成一格（不进 .header-tools）是因为它对客户视图
-   也渲染，而整片工具区在客户视图里是收起来的。position:relative 给菜单定位。 */
+/* 右上角头像。独立成一格（不进 .header-tools）是因为它对客户视图
+   也渲染，而整片工具区在客户视图里是收起来的。 */
 .header-account {
-  position: relative;
   display: flex;
   align-items: center;
 }
@@ -438,38 +437,6 @@ $bg-white: #FFFFFF;
 
   &:hover {
     border-color: $color-accent;
-  }
-}
-
-.avatar-menu-mask {
-  position: fixed;
-  inset: 0;
-  z-index: 1999;
-}
-
-.avatar-menu {
-  position: absolute;
-  top: calc(100% + 10px);
-  right: 0;
-  min-width: 150px;
-  background: #fff;
-  border: 1px solid #e9ecef;
-  border-radius: 8px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.14);
-  z-index: 2000;
-  padding: 6px 0;
-}
-
-.avatar-menu-item {
-  padding: 8px 14px;
-  cursor: pointer;
-  display: flex;
-  font-size: 13px;
-  color: #2c3338;
-  white-space: nowrap;
-
-  &:hover {
-    background: rgba(91, 209, 151, 0.1);
   }
 }
 

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -220,18 +220,13 @@
              2026-08-20：个人中心并进了「设置」，下拉只剩这一项——两个入口各开一个
              整面板、彼此还互相跳的形态是用户明确抱怨过的。客户同样要能进（个人组
              的工作记录/账号安全对他一样成立），面板内的「系统」组自己按 isAdmin 收。
-             顶栏里每一个能点的东西都必须在 App.vue 的 no-drag 名单里，
-             下拉菜单本身也要——它画在 .project-header 这条 drag 区之内。 -->
+             2026-08-21（dev-board#96）：只剩一项的下拉没有存在的理由，点头像直接开
+             设置标签（同一条 goToSystemSettings 路径），下拉与它的 state/样式一并撤掉。
+             顶栏里每一个能点的东西都必须在 App.vue 的 no-drag 名单里。 -->
         <view class="header-account">
-          <view class="avatar-btn" @tap.stop="toggleAvatarMenu" :title="$t('workbench.accountMenu')">
+          <view class="avatar-btn" @tap.stop="goToSystemSettings" :title="$t('workbench.accountMenu')">
             <image v-if="currentUser && currentUser.avatarUrl" :src="currentUser.avatarUrl" class="avatar-img" />
             <text v-else class="avatar-text">{{ getInitial(userDisplayName || currentUser?.displayName) || 'U' }}</text>
-          </view>
-          <view v-if="avatarMenuOpen" class="avatar-menu-mask" @tap.stop="avatarMenuOpen = false"></view>
-          <view v-if="avatarMenuOpen" class="avatar-menu" @tap.stop>
-            <view class="avatar-menu-item" @tap="goToSystemSettings">
-              <text>{{ $t('workbench.settingsTabName') }}</text>
-            </view>
           </view>
         </view>
       </view>
@@ -740,6 +735,8 @@
                       }"
                       :draggable="true"
                       @tap="activateTab(file, 'left')"
+                      @mousedown="onTabMouseDown"
+                      @auxclick="onTabAuxClick($event, file, 'left')"
                       @dragstart="onTabDragStart($event, file, 'left')"
                       @dragover.prevent="onTabDragOver($event, file, 'left')"
                       @drop.prevent="onTabDropOnItem($event, file, 'left')"
@@ -778,6 +775,8 @@
                       }"
                       :draggable="true"
                       @tap="activateTab(file, 'right')"
+                      @mousedown="onTabMouseDown"
+                      @auxclick="onTabAuxClick($event, file, 'right')"
                       @dragstart="onTabDragStart($event, file, 'right')"
                       @dragover.prevent="onTabDragOver($event, file, 'right')"
                       @drop.prevent="onTabDropOnItem($event, file, 'right')"
@@ -1766,7 +1765,6 @@ export default {
       // 一个不渲染的 tab 上（v-else 兜底能救，但 tab 条上没有高亮项，看着像坏了）。
       voiceTab: 'tts',
       // 顶栏右上角头像下拉（只有「设置」一项）
-      avatarMenuOpen: false,
       // 单文件历史：右键「这份文件的历史」时设置，version 面板据此只显示这份文件的版本
       versionFileFilter: null,
       // 有一次采纳停在待裁决状态（/status 的 adoptConflict）。版本面板之外也要提示，
@@ -4377,9 +4375,6 @@ export default {
     goBack() {
       uni.navigateBack()
     },
-    toggleAvatarMenu() {
-      this.avatarMenuOpen = !this.avatarMenuOpen
-    },
     /**
      * 设置：中栏开标签，不再整页跳转（2026-08-19）。
      * 整页跳转会把工作台（标签、编辑器、AI 会话）整个换掉，改个 API Key 的代价
@@ -4387,7 +4382,6 @@ export default {
      * pages/admin 薄壳页仍在，直链与浏览器端走那条。
      */
     goToSystemSettings(opts) {
-      this.avatarMenuOpen = false
       this.openSettingsTab(opts)
     },
     /**

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -788,36 +788,30 @@ try {
   })
   await shot('j6-rails')
 
-  // ============ J6.3 顶栏头像下拉 → 系统设置中栏标签 ============
-  // 2026-08-19：rail 底部的齿轮与头像撤掉，改成顶栏右上角头像的下拉；
+  // ============ J6.3 顶栏头像 → 系统设置中栏标签 ============
+  // 2026-08-19：rail 底部的齿轮与头像撤掉，改成顶栏右上角头像；
   // 「系统设置」不再整页跳转，而是中栏的一个标签（薄壳页仍在，J7 单独覆盖）。
-  console.log('== J6.3 头像下拉与设置标签 ==')
-  // .avatar-btn 是开关（toggleAvatarMenu），菜单开着再点会关掉；且点任一菜单项后
-  // 菜单自动收起。所以每一步都要「不在开着才点」，不能盲点。
-  const openAvatarMenu = async () => {
-    if (!(await page.$('.avatar-menu'))) {
-      await mouseClickSel('.avatar-btn')
-      await page.waitForSelector('.avatar-menu', { timeout: 8000 })
-    }
-  }
-  await step('头像下拉只有「设置」一项（2026-08-20 个人中心已并入）', async () => {
-    await openAvatarMenu()
-    const items = await page.evaluate(
-      () => [...document.querySelectorAll('.avatar-menu-item')].map((e) => e.innerText.trim()))
-    if (items.length !== 1) throw new Error('头像下拉应当只剩一项，实际: ' + JSON.stringify(items))
-    if (!items[0].includes('设置')) throw new Error('那一项不是「设置」: ' + JSON.stringify(items))
-  })
-  await step('点「设置」开中栏标签而不是跳页', async () => {
-    await openAvatarMenu()
-    await mouseClickSel('.avatar-menu-item')
+  // 2026-08-21（dev-board#96）：头像下拉撤了，点头像直接开设置标签。
+  console.log('== J6.3 头像与设置标签 ==')
+  await step('点头像直接开中栏设置标签，没有下拉、不跳页', async () => {
+    await mouseClickSel('.avatar-btn')
+    if (await page.$('.avatar-menu')) throw new Error('头像下拉又回来了（应当直接开设置标签）')
     await page.waitForSelector('.page-admin.is-embedded', { timeout: 15000 })
     const h = await page.evaluate(() => location.hash)
     if (h.includes('pages/admin/admin')) throw new Error('设置又变回整页跳转了')
     // 个人组与系统组都要在同一页里够得着
     await waitText('工作记录', 10000)
     await waitText('账户与安全', 10000)
-    // 关掉这个标签，别把后面的旅程都压在设置页上
-    await mouseClickSel('.tab-item.active .tab-close')
+  })
+  await step('鼠标中键单击标签关闭它（dev-board#97）', async () => {
+    // 关掉设置标签，别把后面的旅程都压在设置页上——顺便覆盖中键关闭：
+    // 与点 × 同一条 closeFile 路径，mousedown/auxclick 都 preventDefault。
+    const box = await page.$eval('.tab-item.active', (el) => {
+      const r = el.getBoundingClientRect()
+      return { x: r.left + r.width / 2, y: r.top + r.height / 2 }
+    })
+    await page.mouse.click(box.x, box.y, { button: 'middle' })
+    await page.waitForFunction(() => !document.querySelector('.page-admin.is-embedded'), { timeout: 8000 })
   })
   await shot('j6-settings-tab')
 


### PR DESCRIPTION
## 改动（四张卡）
- **#96** 右上角头像：菜单里只有「设置」一项，改为点击直达设置标签，删掉菜单、mask、`avatarMenuOpen` 及 no-drag 名单两行。
- **#97** 工作台左右窗格 `.tab-item` 支持鼠标中键关闭（`auxclick` button===1 → 走既有 `closeFile` 含未保存闸门；`mousedown` 阻止中键自动滚动）。标签本无双击/右键/固定概念，未加。
- **#99** 「我的收藏」卡片：单列纵排 + 截图 widthFix 撑满整宽 → 自适应网格（300px 起）+ 88×66 固定缩略图 + 正文两行截断。
- **#98（部分）** 撤掉「单次任务花费上限」：`platform.budget.taskLimitCents` 只有写入与回显、无执行点，文案却承诺「花到这个数会问一句」。端点不动，前端恒传 0。BYOK/Ollama 是否从官方版隐藏另行拍板。

## 验证
- `check:nav` / `check:nav:full` / `check:emits` / `check:locales` 通过；`test:commands` 17/17、`test:auth-redirect` 3/3、`test:tag-protocol` 8/8、`test:zeta-relay` 4/4。
- `test:project-home` 259 过 / 2 红，stash 后 master 基线同样 2 红（`root-bubble-step-group-toggle`、`thinking-card-ghost-collapse`），既有失败。
- app-e2e J6.3 改为：点头像直开设置、断言无 `.avatar-menu`、中键关闭设置标签。本树无 node_modules 未跑 e2e，靠 CI。

## 人工走查
头像单击直开设置（单例）；Office 文档有未保存改动时中键关闭先落盘；浏览器标签中键关闭 BrowserView 被销毁；收藏页多张截图时一行两三张。

🤖 Generated with [Claude Code](https://claude.com/claude-code)