### PR TITLE
docs(dd): 尽调报告模块总方案与三份盘点（dev-board#100）

### DIFF
--- a/docs/superpowers/specs/2026-08-21-dd-linkage-inventory.md
+++ b/docs/superpowers/specs/2026-08-21-dd-linkage-inventory.md
@@ -1,0 +1,226 @@
+# 尽调报告「勾稽」能力盘点（dev-board#100，只读）
+
+日期：2026-08-21。范围：律师单人用的尽调报告模块所依赖的「报告段落 ↔ 底稿文件」勾稽与核查能力，现状精确到文件:行号。与面向客户的「尽调清单」插件（`DdRequest`/`DdItem`，`DdService.java`）无关，本文不盘它。
+
+行号以分支 `claude/ai-legal-due-diligence-optimization-822c5a`（commit 735c919a）为准。姊妹文档：`2026-08-21-due-diligence-lite-evaluation.md` §1.3/§1.4（同一需求的早期评估，本文在它之上把数据模型与保活/反查/触发点钉死）。
+
+---
+
+## 0. 一页结论
+
+- 现有「拖拽关联」的真身是 **选区超链接 + 一张 `doc_file_link` 表**：文档里写 `https://checkba-internal.local/open?u=checkba://filelink?k=<linkKey>`，表里记 `linkKey → fileIds[]`。**没有目标文件内的位置**（页码/坐标/时间点），**不能反查**（只能按 linkKey 精确查），**不随文档编辑保活**（靠字符属性跟着文字走，文字没了记录就成孤儿，无人清理）。AI 工具面完全不感知它。
+- tag 系统是纯文件级多对多，三型只是 `String type` 白名单；**与 DocFileLink 零交集**；文件树不能按标签筛选（筛选在搜索面板），文件夹不能打标签（前端挡、后端不挡）。「主体 = PARTY 标签、章节 = 文件夹」单章节够用；多章节归属现模型表达不了（`parentId` 单值）。
+- 定位能力：docx 侧书签锚点体系完整（`find_text_locations` → `set_selection`），但 `openFileLinkTarget` 打开目标文件后**一个定位参数都不传**；PDF 是 iframe 原生渲染，无跳页/叠加高亮入口（`pdf_highlight` 是永久写入）；图片只有缩放；音频有进度条可 seek 但无外部时间点参数。「一键打开底稿并定位」今天停在「打开文件首屏」。
+- 改文字提示新底稿：全链路**没有任何段落级变更事件**。最细粒度的信号是 worker `modified` → 前端 autosave → `POST /api/files/{id}/upload` → `onChangeSignal(projectId)`（项目级）。修订接受只 `$emit('changed')` 给面板。最合适的挂点是 worker 侧「按书签锚点比对」而非后端。
+- 外部截图落地：`WebFavorite`（`favorites/<userId>/` 独立存储）与 `ProjectFile` 是**两套存储**；已有「网核」链路（右键 → capturePage → createFavorite → `insert_link_with_bookmark` 写 `checkba://webfav?id=`）可抄，但要落到项目文件夹并建 DocFileLink 需要走 `ProjectFileService.createFile/createOrUpdateFile` + `DocFileLinkService.createOrAppend`，两者后端内部均可直接调用。
+
+---
+
+## 1. 拖拽关联
+
+### 1.1 现状
+
+| 环节 | 文件:行号 | 说明 |
+|---|---|---|
+| 实体 | `backend/src/main/java/com/checkba/model/entity/DocFileLink.java:17-66` | 表 `doc_file_link`，唯一索引 `(project_id, link_key)`（:18）。字段：`projectId`、`userId`（创建者）、`docWpsFileId`（关联所在文档，:35）、`linkKey`（写进超链接的 key，:41）、`anchorText`（选区文本快照，注释「仅用于展示/排查」，:47）、`rangeStart/rangeEnd`（注释「仅用于排查；文档编辑后会变化，不作为定位依据」，:50-56）、`fileIdsJson`（JSON 数组，一条链接可挂多文件，:62）。**没有任何「目标文件内位置」字段**（页码/引文/坐标/时间点）。 |
+| Repository | `repository/DocFileLinkRepository.java:9` | 唯一方法 `findByProjectIdAndLinkKey`。无按 fileId 反查、无按 docWpsFileId 列表。 |
+| Service | `service/DocFileLinkService.java:46-107` | `createOrAppend`：校验 fileIds 归属项目（:61-67），linkKey 空则生成 `lk_<uuid>`（:69），已存在则合并 fileIds 去重（:90-102）；**只允许创建者修改**（:83-85）。`getByKey`（:110-123）**只允许创建者读取**（:119-121），返回 `files` 元数据时 `findById(...).ifPresent` 静默跳过已删文件（:145）。 |
+| Controller | `controller/DocFileLinkController.java:12-51` | `POST /api/projects/{pid}/doc-links`（:19）、`GET /api/projects/{pid}/doc-links/{linkKey}`（:41）。无 DELETE、无列表。 |
+| 前端 API | `frontend/src/services/api.js:1754-1768` | `createDocFileLink` / `getDocFileLink`。 |
+| 拖拽源 | `frontend/src/components/FileTree.vue:431-434, 2442-2494` | `dragstart` 写 `application/x-checkba-file` / `text/checkba-file-json`（:2473-2475）+ `$emit('file-drag-start')`，仅非文件夹。 |
+| 投放区 | `frontend/src/components/FileLinkDropZone.vue:74-78`；挂载 `project-overview.vue:684` | **不是拖到编辑器画布上的某处**，是拖到侧栏的「左/右投放区」，只回传 `{side}`。仅当某窗格打开的是 Word 类文档时显示（`hasOpenWpsWord`）。 |
+| 建关联 | `project-overview.vue:3788-3865`（`createWpsSelectionFileLink`） | ① `get_selection_hyperlink` 读**拖拽瞬间编辑器里的当前选区**文本与既有链接（:3802）；无选区提示「先选中文字」（:3810-3813）。② 选区已带 `checkba://filelink` 则复用 linkKey（:3816-3830），否则生成 `lk_<ts>_<rand>`，拼 `checkba://filelink?k=&projectId=`，`wrapWpsInternalLink`（:3735-3742）包成 `https://checkba-internal.local/open?u=…`（常量 `frontend/src/config/workbenchActions.js:17,23`），调 `set_selection_hyperlink` 写入（:3836-3843）。③ `createDocFileLink` 入库，**`rangeStart/rangeEnd` 恒传 `null`**（:3851-3859）。 |
+| worker 写链接 | `frontend/src/zetaoffice/public/office_thread.js:3126-3140`（`set_selection_hyperlink`） | 只给选区 cursor 设 `HyperLinkURL` 字符属性，**不建书签**。 |
+| `insert_link_with_bookmark` | `office_thread.js:3164-3186` | **这是「网核」链路用的，不是文件拖拽用的**：光标处插入文本 + 可选超链接 + 一个 `com.sun.star.text.Bookmark` 包住插入的 run，书签名 `(bookmarkName || 'MARK_'+ts)` 去非法字符、重名加 `_n`。调用方 `project-overview.vue:4286-4311`（`handleWebLinkDrop`，bookmarkName=`WEB_EVID_<favId>`，url=`checkba://webfav?id=`）。 |
+| 点击回宿主 | `office_thread.js:3192-3212`（`get_hyperlink_at_cursor`）；`components/LibreOfficeEditor.vue:452-453`（`open-url`）；`project-overview.vue:839/858/987`（`@open-url="onLibreOpenUrl"`） | LO WASM 不触发超链接激活，页面监听画布点击后问 worker 光标所在链接。 |
+| 解包与打开 | `project-overview.vue:2850-2872`（桌面 `onOpenInternal`）与 `:2927-2949`（web 包装链接），两处同逻辑 | `getDocFileLink` → 0 个文件 toast「关联文件不存在」；1 个直接 `openFileLinkTarget`；多个弹 `filelink-dialog`（:1436-1461）逐项 `openFileLinkTarget(f.id)`（:1446）。 |
+| `openFileLinkTarget` | `project-overview.vue:3870-3886` | `getFileDetail(pid, fid)` → `this.openFile(file)`。**没有页码/锚点/时间点参数**；`openFile`（`pages/project-overview/fileOpenTabs.js:108-160`）签名只收 `file` 对象。 |
+| AI 侧 | `service/ai/tools/DocumentEditTools.java:1276-1299`（`doc_set_hyperlink`） | 只收 http/https（worker `set_hyperlink_at_anchor` :3150 同样卡白名单），不落 DocFileLink。全 `service/ai/**` 无任何文件引用 `DocFileLink`。 |
+
+**保活**：关联「跟随」完全依赖文档格式对「带 HyperLinkURL 属性的文字 run」的保真——段落整体移动、行内改字能带着走；选区被整段删除重打、修订拒绝把插入文字回退、或把这段文字剪切为纯文本再粘回时，链接属性消失。后端 `DocFileLink` 行**不会被感知、不会被清理**（全仓 grep `DocFileLinkRepository` 只有 Service 内两处调用，无文件删除/回收站/版本退回钩子）。版本退回/检查点恢复（`service/ai/DocumentCheckpointService.java:79-99`）按 fileId 整体覆盖字节，`docWpsFileId` 不变，记录仍查得到，但链接文字是否还在取决于快照。
+
+**反查**：两个方向都没有。给定 fileId 查「报告里哪些段落引用了它」——Repository 无方法、Controller 无端点、UI 无列表；给定一段文字查底稿——只有点击后的被动弹窗，没有「选中段落 → 右栏列底稿」的主动视图。
+
+### 1.2 距离目标的缺口
+
+1. 关联没有目标文件内位置（页/坐标/时间/引文），点开只能到首屏。
+2. 不可反查（fileId → 段落、文档 → 全部关联），做不了「底稿被哪些结论引用」「这份报告哪些段落还没底稿」两张表。
+3. 无保活/孤儿感知：无法回答「这段文字的链接是否还在」「这条记录还对应得上文字吗」。
+4. `anchorText` 只是快照，不参与定位；`rangeStart/End` 名存实亡。
+5. 权限「创建者私有」（:83-85, :119-121）——律师单人用暂不碍事，但与同事共看报告时会报「无权限」。
+6. AI 不能建、不能读、不能核对关联。
+7. 投放口径反直觉：拖到侧栏投放区而非文字上，且依赖拖拽前的选区。
+
+### 1.3 建议的最小改动
+
+- **锚点从字符属性升级为书签**：建关联时同时给选区套一个命名书签（名字就用 linkKey，`insert_link_with_bookmark` 已有同款写法，改成「对既有选区套书签」即可，`office_thread.js` 新增一个 `bookmark_selection(name)` 或给 `set_selection_hyperlink` 加 `bookmarkName` 参数）。书签随 docx 往返（`office_thread.js:104-110` 注释已证实 bookmark round-trip OOXML），段落移动/改字跟着走，`getBookmarks().hasByName(linkKey)` 一句就能判断关联是否还活着。
+- **表加位置列**：`DocFileLink` 加一个 `locatorJson`（每个 fileId 一条：`{fileId, page, rect?, quote?, timeMs?}`），或拆成子表 `doc_file_link_target`。先做 `page` + `quote` + `timeMs` 三个字段即可覆盖 pdf/图片/音频。
+- **Repository 补两个查询**：`findByProjectIdAndDocWpsFileId`（列文档全部关联）、`findByProjectIdAndFileIdsJsonContaining`（或改存子表后按 fileId 查）。Controller 补 `GET /doc-links?docWpsFileId=`、`GET /doc-links?fileId=`、`DELETE /{linkKey}`。
+- **AI 工具**：新增 `doc_link_source(anchorId, fileIds[], locator?)`（建 DocFileLink + 写书签 + 设内链，一次完成）与 `doc_list_links(docWpsFileId?)`；`doc_set_hyperlink` 的 http/https 白名单加 `https://checkba-internal.local/` 前缀例外。
+- 权限放宽为项目成员可读（Service 注释本就写着「后续可扩展为项目内共享」）。
+
+---
+
+## 2. tag 系统
+
+### 2.1 现状
+
+| 项 | 文件:行号 | 说明 |
+|---|---|---|
+| Tag 实体 | `model/entity/Tag.java:19-78` | 表 `project_tag`，唯一 `(project_id,name)`。`type` 是 `String`（:61），注释「NORMAL/PARTY/ISSUE；null 视同 NORMAL」，白名单校验在 `service/TagService.java:26-33`，默认色 :19-21/:87-95。`isSystem`（:55）标自动打标。 |
+| FileTag | `model/entity/FileTag.java:19-53` | 表 `project_file_tag`，唯一 `(file_id,tag_id)`，字段 `fileId/tagId/createdBy/createdAt`。**无 anchor/range 字段**——标签只能挂文件，不能挂段落。一个文件多标签天然支持。 |
+| Repository | `repository/TagRepository.java:14-30`；`repository/FileTagRepository.java:13-43` | `findByTagIdIn`（按标签列文件，搜索用）、`findByFileIdIn`（批量取标签）。**无按 type 查询**，分组全在应用层。 |
+| REST | `controller/TagController.java:35-71`（标签 CRUD，`/api/projects/{pid}/tags`）；`controller/ProjectFileController.java:510-541`（`POST/DELETE /files/{fileId}/tags[/{tagId}]`）；文件列表 :89-92 批量 populate `tags` | 挂标端点**不判 isFolder**——后端允许给文件夹打标签。 |
+| AI 工具 | `service/ai/tools/TagTools.java:41-181` | `tag_list`（按三型分组）、`tag_file(fileId, tagName, type)`（get-or-create，撞同名不同型时复用不改型）、`tag_remove_from_file`。不判文件夹。 |
+| 文件树展示 | `components/FileTree.vue:441-443, 578-580` | 每个**非文件夹**文件行左侧 `tag-strip` 渐变色条；右键「管理标签」仅 `!isFolder`（:316）。**文件树没有按标签筛选/分组/排序**（排序只有 name/date/type，:379-389, :987）。 |
+| 按标签筛选 | `components/SearchPanel.vue:40-49, 204-286`；后端 `service/ContentSearchService.java:52-84` | 在搜索面板：多选标签 AND 过滤，支持纯标签无关键词搜索；按 PARTY/ISSUE/NORMAL 分组头渲染（`utils/tagTypes.js`）。 |
+| 自动打标 | `service/ai/AutoTaggingService.java:53, 137` | 上传完成后 LLM 出 5 个系统标签（`isSystem=true`），有幂等闸。 |
+| 与 DocFileLink 交集 | 全仓 grep | 后端零文件同时引用两者；前端只在 `project-overview.vue`/`api.js` 两个聚合文件里同时出现，无功能耦合。 |
+| 文件夹模型 | `model/entity/ProjectFile.java:39-45` | 文件与文件夹同表，`parentId` 单值外键 + `isFolder`；无冗余 path 列。移动：`PUT /files/{id}/move`（`ProjectFileController.java:357`）、`POST /files/batch/move`（:309）；AI `move_project_file`/`move_file`（`FileTools.java:545`）/`create_folder`（:643）。 |
+
+### 2.2 对「主体 × 章节」两个正交维度的评估
+
+- 主体用 PARTY 标签：**够**。多对多，一份底稿涉及多个主体就挂多个 PARTY 标签；搜索面板能按其筛。缺的是文件树直接按 PARTY 分组浏览。
+- 章节用文件夹：**单章节够**（`股东大会核查/<公司>/01..05` 已是先例）。
+- 同一底稿既属第三章又属子公司 B：**现模型可表达**——放进「第三章」文件夹 + 挂 PARTY「子公司 B」，两个维度各走各的载体。
+- 同一底稿既属第三章又属第五章（章节维度多值）：**表达不了**，`parentId` 单值；只能复制文件或用 NORMAL 标签冒充章节（失去树形浏览）。
+- 「章节」其实是报告的结构而不是文件的属性：真正的章节归属应该由 **DocFileLink 推导**（这份底稿被第三章的段落引用 = 它属于第三章），而不是靠人手把文件挪进章节夹。现状两套系统零交集，这条推导今天做不了。
+
+### 2.3 缺口与最小改动
+
+1. 文件树加「按标签分组/筛选」视图（复用 `ContentSearchService` 的 tagIds AND 过滤或前端就地按 `item.tags` 过滤；`FileTree.vue` 已有 `sortMode` 开关可照抄加 `groupBy`）。
+2. 若要章节也成多值维度：`TagService.validateType` 白名单加 `CHAPTER`，`tagTypes.js` 的 `TAG_TYPE_ORDER/COLORS/I18N` 各加一项，`SearchPanel`/`TagSelector` 分组自动跟上（spec 2026-08-20 已预留「加档位=加枚举值」）。但更推荐：**章节归属从 DocFileLink 反查派生**（见 §1.3 补的 `findBy…FileId` 查询），不再让律师手工维护第二份章节归属。
+3. 给文件夹打标签只需放开前端三处 `!isFolder`（:316/:441/:578），后端已通。
+4. `TagRepository` 补 `findByProjectIdAndType`，`TagService.deleteTag` 补 FileTag 级联清理（:153-166 注释自陈未做）。
+
+---
+
+## 3. 编辑器侧定位 / 高亮
+
+### 3.1 现状
+
+| 载体 | 文件:行号 | 能做什么 | 不能做什么 |
+|---|---|---|---|
+| docx（LOWA） | `office_thread.js:88-102`（`anchorBookmark`/`anchorRange`，隐藏书签 `__ai_anchor_N`）、`:1665-1700`（`find_text_locations`，返回稳定 anchorId + 前后文，上限 50）、`:1853-1862`（`set_selection`，只收 anchor，拟人滚动选中）、`:3268`（`add_comment` 收 anchor）、`:3465`/`:3527`（`goto_revision`/`goto_comment`，仅 ReviewPanel 用，无 AI 工具）、`:5481-5493`（`clear_anchors`，全仓无自动调用点——`__ai_anchor_*` 书签是否随保存进 docx 未核实） | 文本定位、选中、滚动到位、批注，书签体系完整且可命名（`insert_link_with_bookmark` :3181） | `goto` 只支持 start/end（:1842）；宿主打开文件无「带锚点打开」参数：`fileOpenTabs.js:108` 的 `openFile(file)`、后端 `EditorBridgeService.sendOpenFileAction`（:107-123）payload 只有 fileId/fileName/fileType/wpsFileId/trackRevisions/userName，前端 `agentClientActions.js:41-42` 直接 `handleEditorOpenFile`。 |
+| PDF 预览 | `components/FilePreview.vue:53-60`（H5 `<iframe :src="blobUrl">`，Chromium 原生 PDF 引擎）、:303-306 | 标准 annotation 可见；`file.wpsFileId` 变化自动重拉 | 无跳页参数（blob URL 后可加 `#page=N`，Chromium viewer 支持，但代码未接）；无叠加高亮层；无文本选区事件回宿主。 |
+| `pdf_highlight` | `service/ai/tools/PdfTools.java:101-122`；`service/ai/PdfEditService.java:248-269` | PDFBox 写 `PDAnnotationHighlight` 后 `doc.save` —— **永久写入文件**（`fileEffect=MODIFIED`，有检查点） | 不是叠加层；不能「临时高亮给你看」。`pdf_inspect`（`PdfTools.java:81-96`）逐页返回文本与 `has_text_layer`，页码 0 起，可用于算页码。 |
+| 图片 | `FilePreview.vue:67-92, 776-861` | 缩放/平移/百分比 | 无标注、框选、矩形高亮。 |
+| 音频 | `FilePreview.vue:117, 381-470`（`new Audio()` 自绘进度条，`onSeekDown` 设 `currentTime`） | UI 内 seek | 无外部 `startTime` 参数；转写 `MeetingTranscriptParser.java:52-81` 的 `Segment` 有 start/end 毫秒，存于 `MeetingRecording.transcriptJson`（`model/entity/MeetingRecording.java:82`）；`components/MeetingRecordingPanel.vue:249-256` 把时间戳渲染成纯文本、无 `@tap`，`togglePlay`（:863-885）只能从头播——时间戳与播放器没打通。 |
+| 网核收藏 | `project-overview.vue:2820-2848` | `checkba://webfav?id=` → 打开收藏面板 + `focusFavorite(id)` 卡片高亮 | 只是卡片，不是项目文件。 |
+
+**「从报告某段一键打开底稿并定位」链路今天走到**：点击链接 → 解 linkKey → 查表 → 打开文件（首屏）。断在「打开之后」：DocFileLink 无位置 → `openFile` 无参数 → 各预览器无定位入口。
+
+### 3.2 最小改动
+
+- `openFile(file, {locator})` 加第二参数并透传到标签对象；`LibreOfficeEditor` ready 后若有 `locator.bookmark`/`locator.quote` 调 `find_text_locations`+`set_selection`（worker 原语现成，零改动）；`FilePreview` PDF 分支 `blobUrl + '#page=' + (page+1)`；图片分支按 `locator.rect` 画一个绝对定位的高亮框（只是一层 div）；音频分支 ready 后设 `currentTime=locator.timeMs/1000`。
+- PDF 要精确到文字高亮而不改文件：把 iframe 换成 pdf.js 文本层才有叠加能力，属中改，先用 `#page=` 过渡。
+- 后端 `sendOpenFileAction(file, locator)` 同步加字段，AI 侧 `doc_open_file` 加可选 `locator`。
+
+---
+
+## 4. 改文字时提示「是否有新底稿」
+
+### 4.1 现有信号与钩子
+
+| 信号 | 文件:行号 | 粒度 | 评估 |
+|---|---|---|---|
+| worker `modified` | `components/LibreOfficeEditor.vue:447-454, 768-783`（`scheduleAutoSave`） | 文档级布尔（「脏了」） | 最早、最频繁；不知道改了哪段。 |
+| autosave 落点 | `controller/FileController.java:362-514`（`POST /api/files/{id}/upload` legacy 分支）→ :474 `refreshProjectKnowledgeIncremental`、:478/:501 `autoTagFile`、:514 `signalChange` | 文件级 | 每次存盘都跑，已踩过「副作用按次累积」的坑（AutoTagging 幂等闸）；挂段落级检查代价高（要重新抽全文比对）。 |
+| `onChangeSignal` | `version/WorkSessionService.java:216`（`(long projectId, Long userId, String userName)`）；调用点 `FileController.java:127-130`、`service/ProjectFileService.java:1205-1210`（8 处）、`service/ai/tools/TextFileEditTools.java:209-212` | `(projectId, userId, userName)`，**项目级**，连 fileId 都不带 | 只用于开工作段 + 防抖存档，不是内容事件。 |
+| 修订接受/拒绝 | `components/ReviewPanel.vue:156-173`（`resolve_revision` 后 `$emit('changed')`）→ `LibreOfficeEditor.vue:89`（`@changed="onReviewChanged"`）→ `:762` → `onDocModified`（:765） | 面板级 | 被压扁成与打字相同的「文档变脏」；AI 侧 `doc_accept_revision` 等（`DocumentEditTools.java:1143-1194`）同样只转发 worker。worker `list_revisions` 能给每条修订的文本与位置，是补事件的素材。 |
+| AI 工具 MODIFIED | `service/ai/AgentOrchestrator.java:250-258`（首个 MODIFIED 前建检查点）、`:356-373`（`applyToolSideEffects`）、`:1647-1665`（`notifyFileChange`：SSE `file_change` + 落 `ConversationFileChange{conversationId,fileName,changeType}`，无 fileId/无 diff） | 轮次级 | 无可订阅的内容事件；全仓唯一 `ApplicationEvent` 是 `MainlineMergedEvent`（`WorkSessionService.java:722`）。 |
+| 版本记录 | `version/ProjectRepoService.java:342`（JGit `DiffCommand`，文件级 name-status） | 文件级 | 无段落 diff；docx 是二进制，git diff 无意义。`VersionCompareTab.vue` 走 worker `compare_document` 做的是视觉对比。 |
+| 文本抽取 | `service/DocumentTextService.java:37-74`；`service/ai/ProjectRagService.java:71-77`（`refreshProjectKnowledgeIncremental` 实为 `retrieverCache.remove`，懒重建）；`FileController.java:585`（`/compare` 手动一次性全文比对） | 全文字符串，Tika，无缓存 | 可做「上次快照 vs 本次」粗比对，但要自建快照表。 |
+| 事实/证据层 | `service/ai/evidence/ClaimLink.java:20-31`（`claimId/evidenceIds/relation/confidence/reviewer/missingEvidence`，纯内存记录，未落库）；`EvidenceItem.java:27-53`（`sourceUri/contentHash/locator`，检索时现算）；`MemoryEvidenceRetriever.java:44-86`（`contentHash=sha256(记忆文本)`，不是来源文件哈希；`sourceUri=checkba://file/<id>`）；`model/entity/MemoryEntry.java:84`（`sourceFileId` 外键，无来源内容哈希/版本）；`model/entity/ProjectProfileField.java:66`（`evidence` 字符串，概览页专用） | 无「报告段落 ↔ 文件」登记 | 概念上最接近（claim ↔ evidence ↔ missingEvidence），但没有持久化也没接编辑器；文件改了不会级联标记相关记忆过期。 |
+
+结论：**没有任何段落级「被改了」的事件**，也没有「段落 ↔ 底稿」的一致性检查。
+
+### 4.2 挂点比较与建议
+
+| 挂点 | 粒度 | 代价 | 判定 |
+|---|---|---|---|
+| worker 内：每次 `modified` 后（防抖）遍历 linkKey 书签，比对书签当前文本与 `anchorText` 快照 | 段落/句级，精准 | 书签按名取 `getAnchor().getString()` 是 O(关联数) 的同步调用，几百条在 office 线程上要节流（`find_text_locations` 上限 50 的教训，:1669-1671） | **首选**。书签消失 = 底稿链接被删；文本变化 = 提示「这段改过，底稿是否仍支撑」。结果经 `lo-relay` 回宿主，由右栏渲染。 |
+| 修订面板：accept/reject 后对涉及的修订区间查有无书签重叠 | 修订级 | 小 | 补充路径，覆盖「接受 AI 改写」这一高风险动作。 |
+| autosave 后端：抽全文与上次快照 diff，再按 anchorText 匹配 | 文件级→段落级 | 每次存盘全文抽取；anchorText 相似匹配不可靠 | 不推荐作主路径，可作离线核查（「整份报告哪些关联已失效」报表）。 |
+| AI 工具 MODIFIED post-hook | 轮次级 | 小 | 只覆盖 AI 改动，漏人工改动。 |
+
+最小改动：① `DocFileLink` 建关联时写书签（§1.3）；② worker 新增 `check_link_anchors(names[])` 返回 `{name, exists, text}`；③ `LibreOfficeEditor.vue` 在 `modified` 防抖（与 autosave 同节奏）后调用它并 emit `link-anchors-changed`；④ 宿主右栏把「文字已变 / 书签已丢」标黄并给「重新指定底稿」按钮。
+
+---
+
+## 5. 外部截图服务落地
+
+### 5.1 现状
+
+| 路径 | 文件:行号 | 适配度 |
+|---|---|---|
+| 「网核」既有链路 | `desktop/main/main.js:808-840`（BrowserView 右键「加入网核收藏」→ `capturePage` → `checkba:webmark`）；`pages/project-overview/ocrActions.js:480-575`（组 `meta{kind:'webmark', capturedAt, sourceUrl, sourceHost, title, selection, docFileName}` → `createProjectFavorite` → `insert_link_with_bookmark`） | 概念最接近：截图 + 网址 + 时间 + 落文档标记。但产物是 **WebFavorite，不是项目文件**。 |
+| WebFavorite 存储 | `model/entity/WebFavorite.java:12-60`（`sourceUrl/title/content/imagePath/meta`，抓取时间在 `meta` JSON 里）；`service/WebFavoriteService.java:45-71`（base64 → `favorites/<userId>/<uuid>.png`，同一 `StorageService` 但 `storage/ProjectStorageResolver.java:19-26` 把 `favorites/` 列为独立于 `projects/{id}/` 的全局命名空间）；`controller/WebFavoriteController.java:66-89, 108` | 不在文件树、不能被 DocFileLink 引用（它要 fileId）、不能挪进 `尽调/<主体>/<章节>/网核/`；全仓无「收藏转项目文件」代码路径。 |
+| 项目文件写入（前端） | `controller/ProjectFileController.java:217-245`（`POST /files/file`，body `{parentId,name,fileType,fileSize}` 先建记录）→ `controller/FileController.java:362`（`POST /api/files/{id}/upload` 传字节） | 两步、面向前端；后端内部不必走 HTTP。 |
+| 项目文件写入（后端内部） | `service/ProjectFileService.java:78`（`createFolder(projectId,parentId,name,userId)`）、:184（`createOrUpdateFile(projectId,parentId,name,fileType,size,storagePath,…)`，幂等）、:211（`createFile`）；存储 `storageServiceFactory.getStorageService().save(path, stream)`（`WebFavoriteService.java:71` 同款） | **最适合**：服务内直接 建夹 → save 字节 → 登记 → `signalChange`。 |
+| AI `write_file` | `service/ai/tools/FileTools.java:333-390` | 只写文本、只写根目录（子目录要求再 `scan_files`，:369-375），不适合图片。 |
+| AI `write_docx` | `FileTools.java:392-419`（`parentFolderId` 走 `service/ai/AiDocxExportService.java:41-122`：`createFile` → `storageService.save(filePath, bis)` → 回填 fileSize） | 有「指定文件夹落盘 + 注册 + RAG 刷新」的完整范式可抄。 |
+| 多级文件夹确保 | `FileTools.java:587-614`（`move_file` 内联「逐段查/建文件夹」循环，非公共方法）；`service/meeting/MeetingRecordingService.java:293-304`（`ensureFolder`，仅一级） | 没有公共的 `ensureFolderPath(segments)`，要抽出来。 |
+| 外部服务先例 | `pdf_to_word`（`PdfTools.java:279-291`：`createFile` → `Files.move` → `repository.save` → `sendRefreshFilesAction`+`sendOpenFileAction`）、`MeetingRecordingService.exportTranscript`（:220-237，**最贴近**：`ensureFolder` → `uniqueName` → `createFile` → `StorageService.save(bytes)`） | 都是「后端拿到字节 → ProjectFileService 登记 → 刷新」，直接复用。注意 `sendRefreshFilesAction`/`sendOpenFileAction` 依赖 `currentConversationId` ThreadLocal（`EditorBridgeService.java:107-112`），非对话上下文（后台批量导入）调用会静默跳过，文件树不刷新。 |
+| 元数据承载 | `ProjectFile.java:27-122` | **无** sourceUrl/capturedAt/meta 列；`DocFileLink` 也没有。WebFavorite 的 `meta` 是唯一现成的 JSON 槽。 |
+| 批量与事务 | `DocFileLinkService.createOrAppend` 是普通 `@Transactional` Spring bean，可被任何后端服务注入直接调用（:45-53） | 无批量 API，但一批图片循环调用即可，在一个外层事务里。 |
+| 无头截图 | `main.js:1081-1100`（`browser-wait-ready`）、:1175（`ocr-capture-view`）；后端 `service/ai/tools/WebTools.java:194-275`（`browse_url`，Playwright headless，带 SSRF 守卫，只取 `page.content()`，未调 `page.screenshot()`） | 桌面只能截**已打开的 BrowserView**；后端 Playwright 加一行 `screenshot()` 即可出 PNG，是「自产截图」的最小改动点；外部服务返图则不需要。 |
+
+### 5.2 最小改动
+
+- 新建后端 `EvidenceCaptureService.ingest(projectId, userId, items[{url, title, capturedAt, imageBytes, subject, chapter, anchor?}])`：
+  1. `ProjectFileService.createFolder` 逐级确保 `尽调/<主体>/<章节>/网核/`（按 name+parentId 查重，`createFolder` 本身不幂等要自己查）；
+  2. `StorageService.save("projects/<pid>/…/<host>_<ts>.png")` + `createOrUpdateFile`；
+  3. 来源元数据：在 `ProjectFile` 加一列 `metaJson`（或先复用 `tag_file` 打 PARTY=主体 + NORMAL=`来源:<host>`，零表改动但信息弱）；
+  4. 若 `anchor` 非空，`DocFileLinkService.createOrAppend` 建关联，返回包装 URL 给调用方写进文档；
+  5. `editorBridgeService.sendRefreshFilesAction()` + `workSessionService.onChangeSignal`。
+- WebFavorite 与项目文件不合并，只加一个「转为项目文件」动作（读 `imagePath` 字节 → 上面的 ingest），让老的网核卡片也能进文件夹、被 DocFileLink 引用。
+
+---
+
+## 6. 勾稽数据模型现状图（文字版）
+
+```
+ProjectFile (project_file)                       Tag (project_tag)
+  id, projectId, parentId ──┐单值树               id, projectId, name, color,
+  isFolder, name, fileType  │                      type: "NORMAL"|"PARTY"|"ISSUE"|null,
+  filePath, wpsFileId, uid  │                      isSystem
+  [无 sourceUrl/meta]        │                          ▲
+        ▲   ▲               └── parentId ──► ProjectFile │
+        │   │                                           │
+        │   └──────── FileTag (project_file_tag) ───────┘
+        │             fileId ↔ tagId  多对多，文件级，无 anchor
+        │             （前端只让非文件夹挂；后端不拦）
+        │
+        │ fileIdsJson: [fileId,…]（JSON 字符串，无外键）
+        │
+   DocFileLink (doc_file_link)
+     projectId + linkKey (唯一)
+     userId（创建者私有）
+     docWpsFileId ──────────────► ProjectFile.wpsFileId（报告所在文档，字符串软引用）
+     anchorText（快照，不定位）
+     rangeStart/rangeEnd（恒 null）
+     [无 目标文件内位置：page/rect/quote/timeMs]
+        ▲
+        │ 文档内字符属性 HyperLinkURL =
+        │   https://checkba-internal.local/open?u=checkba://filelink?k=<linkKey>&projectId=
+        │ （无书签；文字没了属性就没了，表行无人清理）
+   报告 .docx（LOWA 内）
+        │
+        │ 另一条并行链：insert_link_with_bookmark → 书签 WEB_EVID_<favId>
+        │   + HyperLinkURL = …?u=checkba://webfav?id=<favId>
+        ▼
+   WebFavorite (web_favorite)                ← 与 ProjectFile 无外键、独立存储前缀 favorites/<userId>/
+     sourceUrl, title, content, imagePath, meta(JSON: capturedAt/sourceHost/selection/docFileName)
+
+   第三种内部 scheme：checkba://file/<id>（MemoryEvidenceRetriever.java:88，evidence.retrieve.v1 的 sourceUri）
+   ClaimLink（内存 record：claimId, evidenceIds[], relation, missingEvidence[]）—— 未落库、未接编辑器
+
+变更信号（均非段落级）：
+   worker modified ─► LibreOfficeEditor autosave ─► POST /api/files/{id}/upload
+     ─► refreshProjectKnowledgeIncremental / autoTagFile / signalChange(projectId) ─► WorkSessionService.onChangeSignal
+   ReviewPanel resolve_revision ─► $emit('changed')（仅刷新面板）
+   AgentOrchestrator: 首个 MODIFIED 工具前建检查点（无 post-hook）
+```
+
+三套「引用」彼此不通：FileTag（文件级分类）、DocFileLink（段落→文件，无位置、无反查）、WebFavorite（截图卡片，不在文件树）。要做勾稽，核心是把 DocFileLink 升级为「有书签锚点 + 有目标位置 + 可双向查询」的事实表，并让网核截图落成 ProjectFile 走同一张表。

--- a/docs/superpowers/specs/2026-08-21-dd-scale-stability-inventory.md
+++ b/docs/superpowers/specs/2026-08-21-dd-scale-stability-inventory.md
@@ -1,0 +1,178 @@
+# 尽调报告工况下的流畅度与大文档稳定性盘点（dev-board#100）
+
+日期：2026-08-21。性质：只读盘点 + 一次真引擎实测，未改任何产品代码。
+工况假设：报告 100-300 页 A4 docx（大量表格与图片）、项目内成百上千份关联底稿（pdf/jpg/png/音频）、几百张网核截图。
+结论先行：维护者判断「架构够用、缺流畅度与大文档稳定性」成立。盘出的热点集中在四类——(1) office 单线程上的全文同步操作（全文枚举、修订、全文格式化、整档导出）；(2) 后端按「整份文件」处理的路径（Tika 全文抽取、检查点整份拷贝、Git 全量 add）；(3) 文件数量线性/平方放大的路径（新建文件的同级扫描、整棵树一次性拉取且无虚拟滚动、导入 3000 条硬顶）；(4) 几处上限口径互相矛盾（10MB / 2MB / 50MB / 30s / 180s）。
+
+行号均以本树（`735c919a`）为准，改动后请重新 grep。
+
+---
+
+## 0. 实测数据（真引擎，150 页样本）
+
+环境：借兄弟 worktree `elated-blackburn-ead7ab`（与本树同 HEAD 735c919a）的 `frontend/dist/zetaoffice` + r4 引擎（soffice.wasm 45.5MB br），无头 Chrome（puppeteer-core，`headless:'new'`），本机 Apple Silicon。样本由 python-docx 生成：150 页、921 段、30 张 12x5 表格、20 张 900x600 噪声 JPEG，**6.6MB**。命令走 `window.__loExecutor.executeCommand`（`?verify=1` 暴露的执行器，与生产 relay 同一条 worker 通道），耗时为 worker 内部 `performance.now()` 差（`inner_ms`），不含 CDP 序列化。
+
+| 操作 | 实测 | 备注 |
+|---|---|---|
+| 引擎就绪（goto → 首条命令返回） | 约 3.5s | 热盘、无头；生产里冷启动受 150MB wasm 编译影响（固定端口缓存见 doc-editor.md） |
+| `load_document` 6.6MB/150 页 | 2.7s / 3.8s（两次） | 期间 office 线程完全阻塞，无进度 |
+| `get_ui_state` / `get_formatting` | 20-35ms / 8ms | O(1)，不是热点 |
+| `get_document_text`（默认 200 段/15000 字预算，返回 132 段） | **2.2s / 5.2s**（两次） | 每次调用都从头枚举 921 段；AI 翻一页读 = 卡画布 2-5s |
+| `get_document_text {startParagraph:800}` | 2.0s | 跳过前 800 段仍要枚举，证实 O(n) |
+| `find_text_locations`，600 命中（顶 50） | **3.0s** | 50 个书签 + 上下文取回 |
+| `find_text_locations`，1 命中 | 70ms | XSearchable 本身快，慢在每个命中的锚点/上下文 |
+| `find_navigate`，600 命中（顶 500） | 2.6s | 每次导航重算全部命中位置 |
+| `export_document` 6.6MB | **1.2s-2.3s** | 自动保存每次都付这笔；页面侧另有字节跨界拷贝 |
+| `find_replace` 修订模式，150 命中 | **20.5s**（137ms/命中） | 36 命中 7.8s（216ms/命中）。后端 `EDITOR_ACTION_TIMEOUT=30s`：**约 200 命中即超时**，而 worker 仍在继续改 |
+| `list_revisions`（300 条，顶 200） | 4.2s | 审阅面板一次刷新 |
+| `resolve_all_revisions accept`，300 条 | **19.8s** | 「全部接受」按钮卡 20s |
+| `apply_house_style`（921 段 + 30 表） | **>30s，执行器超时失败** | worker 未停（后续命令排队），宿主已报失败——「成功一半」的典型 |
+| 页面总内存（`measureUserAgentSpecificMemory`，含 WASM 线性内存与 worker） | 约 2.4GB | 空白基线未测，不能把差值全归文档；保活 3 + 备胎 1 = 4 实例的 RSS 需用 Activity Monitor 复核 |
+
+脚本（生成样本 + 驱动）在会话 scratchpad，配方见附录 A；可按需抄进 `frontend/tests/lowa-e2e/` 做成常驻「大文档基线组」。
+
+---
+
+## A. 大 docx 在 LOWA 里
+
+### A1 打开耗时与内存
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 字节预取 | `frontend/src/components/LibreOfficeEditor.vue:735-755` `fetchArrayBuffer`，`xhr.timeout = 60000`（:744），失败重试一次（:624-632）；整文件 GET，无 Range/分片 | 50MB 文档弱网 60s 到顶即整份重下 | 下载超时按体积放大（如 60s + 每 MB 2s）；保留整文件 GET（本地后端无带宽问题） |
+| 字节跨界 | `LibreOfficeEditor.vue:634,657` 把 `Uint8Array` 经 `executeCommand('load_document', {bytes})` 发出；三跳全是结构化克隆，没有 transfer list（`useZetaOfficeWebview.js:38/80`，`libreofficeExecutorClient.js:197`）；worker 端 `office_thread.js:2298` `Array.from(new Int8Array(...))` 把字节炸成装箱 JS 数组（zetajs 编组硬约束） | 50MB 文档峰值内存约为体积的 6-8 倍（三次克隆 + 每字节 8B 的 JS 数组） | webview 内两跳改 transfer（`postMessage(m, [buf])`）；`Array.from` 这步受 zetajs 约束无法省，但可在写 MEMFS 时改用 `FS.writeFile(u8)` 绕开（策略 1 本就是写文件再 `loadComponentFromURL`，:2320-2335，字节数组只在策略 2 `private:stream` 才必需） |
+| 只读预览接力 | `LibreOfficeEditor.vue:564-606` 字节到手即 `docx-preview.renderAsync` 整篇渲染（`breakPages:true` 非懒加载） | 150-300 页含图的 HTML 全量渲染与引擎 boot 抢主线程，大文档上「感知更快」可能反成卡顿源 | 超过阈值（如 5MB 或段落数）只渲染前 N 页；或渲到 `requestIdleCallback` 里分片 |
+| 引擎加载阻塞 | `office_thread.js:2274-2350` 同步 `loadComponentFromURL`，无进度；宿主里程碑只是滴答（`LibreOfficeEditor.vue:337-391` `startBootTrickle`），同一 `bootStageKey` 停 30s 亮「重试」 | 实测 6.6MB 2.7-3.8s；几十 MB 含高清扫描件的文档可能接近 30s 误亮重试 | stuck 阈值按字节数放大；加载阶段文案区分「引擎启动」与「文档解析」 |
+| 保活池 | `frontend/src/pages/project-overview/librePool.js:9` `LIBRE_KEEPALIVE_MAX = 3`，注释「每实例数百 MB」；备胎常驻 1 个（:70-118）；淘汰前 `flushSave`（:145-159） | 实测单页约 2.4GB 分配量；4 个大文档实例并存有 GB 级内存风险，且常量不随文档体积调整 | 按已加载文档体积计权（大文档记 2-3 份额）；或 16GB 以下机器降到 2 |
+
+### A2 自动保存
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 触发/延迟 | `LibreOfficeEditor.vue:779-784` `max(200, min(2500, 15000-脏龄))`；让路条件 :792-798（`_cmdBusy>0` 或距上次命令 <1.5s，且脏龄 <60s → 2s 后重试） | 60s 强制保存兜底意味着 AI 修订风暴期间最多每 60s 强插一次 1-2s 的导出冻结 | 强制阈值按上次导出耗时放大（导出 2s 的文档 60s 放到 120s） |
+| 导出本体 | `office_thread.js:2369-2432` `storeToURL('private:stream')` 全文同步序列化，经 `XOutputStream.writeBytes` 攒成 JS 数组再拼 `Uint8Array`（:2385-2389, 2429-2432） | 实测 6.6MB 1.2-2.3s，期间画布冻结（注释 `LibreOfficeEditor.vue:787-791` 已写明）；几十 MB 含图文档可到 5-10s | 无增量导出可做；只能「少导」：每 N 次 modified 与空闲时机合并、AI 工具在飞时不导（已有）、关闭/切换时再强制 |
+| modified 循环 | worker 端 `exportInFlight` 闸 + 导出后恢复 `isModified`（:2400-2406，监听器 :1449）；宿主端 `export_document` 不计入活跃编辑（`LibreOfficeEditor.vue:481`）；节流 `editor-main.js:179` 前沿丢弃 500ms | 已修（注释记录「每 3 秒一轮整份上传」事故）；大文档若循环复发代价翻倍 | 保留 e2e 探针（autosave-export-modified-loop 记忆）；大文档基线组里加「连续 30s 无 modified」断言 |
+| 上传 | `LibreOfficeEditor.vue:888-899` 整文件 multipart，无分片；失败 15s 慢速重试（:806-809） | 本地后端无带宽问题；Web 态（iframe 传输）几十 MB 每 2.5s 一次会打爆带宽 | Web 态自动保存间隔至少按体积放大 |
+| 版本记录联动 | 每次上传 `signalChange` → `WorkSessionService.onChangeSignal`（`WorkSessionService.java:216-240`），防抖 2 分钟（:55），真正提交见 A6 | 自动保存不直接等于提交，防抖已合并 | 无需改 |
+
+### A3 修订（redline）
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 批量替换 | `office_thread.js:1632-1645` `find_replace`：每命中 `selectVisibly` 滚视图 + `applyMinimalRedline`；`minimalEdits` 有界 LCS，`oMid.length*nMid.length > 250000` 退化整段替换（:331-337），单处 O(m·n) 有上界 | 实测 **137-216ms/命中**（大头在 UNO 往返与滚视图，不在 LCS）；150 命中 20s；**约 200 命中撞 `EditorBridgeService.java:66` 30s 超时**，worker 还在继续改、后端已告诉模型失败，模型可能重发一次造成双改 | (1) 去掉每命中 `selectVisibly`，只在结束时滚到首处；(2) 超过 N 命中时 worker 分批并回传进度（SSE 有现成通道）；(3) 后端把 find_replace 一类批量工具的超时提到 120s，或改「先数命中再决定是否拆批」 |
+| 审阅面板 | `list_revisions` 顶 200/500（:3418-3424）实测 4.2s；`resolve_all_revisions`（:3492-3499）一次 dispatch 但前后各 `countRedlines()` 全枚举（:203-210），实测 300 条 19.8s；逐组处置 `ReviewPanel.vue:148-162` 串行 `resolve_revision`，每条 `redlineAt(index)` O(index) + 两次 `countRedlines()` O(N)（:3477-3491） | 上千条修订时按组处置近 O(K·N) 次枚举；「全部接受」卡 20s 且无进度 | `resolve_revision` 批量版（一次命令处置一组、只数一次）；面板刷新带 `since` 游标；大文档上把「全部接受」做成带遮罩的长任务 |
+| 页边模式 | `ShowChangesInMargin`（:1389-1391）依赖 r3+ 补丁；非纯视图设置 | 大量修订时页边互叠（已知残留）；对性能影响未测 | 不动 |
+
+### A4 worker 命令复杂度（每次 AI 工具调用都在 office 单线程上同步跑）
+
+并发模型：`libreofficeExecutorClient.js:151/154` 与 `zetaOfficeRelay.js:72/75` 只有按 reqId 的 pending Map，**没有队列/互斥**；串行化完全来自 worker 单事件循环——一条 20s 的命令把后面所有命令（含自动保存的 export、IME 快捷键的 `ui_command`）全部排队。超时：默认 30s，`load_document`/`export_document` 180s（`libreofficeExecutorClient.js:189-191`，`zetaOfficeRelay.js:108-112`）。
+
+| 命令 | 实现 | 复杂度 | 备注 |
+|---|---|---|---|
+| `get_document_text` :2451-2477 | `eachParagraph`（:169-178）从头枚举到末尾算 `total` | O(全文段落) 每次 | 实测 2-5s；AI 逐页读 300 页 = 每页付一次全扫 |
+| `get_paragraph`/`modify_paragraph` :1744-1775 | 手写枚举到第 N 段 | O(N) | 同上 |
+| `get_outline` :1777-1790 | 全枚举**无上限** | O(n) | 唯一连封顶都没有的 |
+| `get_clauses` :1796-1841 | 全枚举，输出顶 300 条（:1818），无 truncated 字段 | O(n) | 超 300 条静默截断 |
+| `insert_under_heading` :3010-3031 | 线性扫到命中标题 | O(n) | |
+| `apply_house_style` :2946-2984 | 顶层元素顶 5000（:2949）；每表 `styleTableStandard`（:712-732）逐格设属性 | O(段 + 表×格) | **实测 >30s 超时**；超 5000 元素静默不处理且返回 `success:true` 无 truncated（:2981） |
+| `find_text_locations` :1665-1691 | XSearchable + 每命中插书签 + 6 次光标遍历，顶 50 | O(命中) | 实测 3.0s@50；书签跟文档一起存进 docx |
+| `find_navigate` :1932-1968 | 收集 ≤500 命中后 `compareRegionStarts` 定位当前序号 | O(命中) 每次导航 | 2.6s |
+| `set_selection`/`replace_at_position` :1853-1872 | `getBookmarks().getByName` | O(1) | 不是热点 |
+| `list_comments` :3500+ | 文本字段枚举，顶 500 | O(字段数) | 批注多的尽调稿尚可 |
+| `insert_image` :3218-3250 | 逐字节 `charCodeAt` + `Array.from(Int8Array)`，**无字节上限**（只封显示宽度 `MAX_W=15000`） | O(图片字节) | 上限只在 Java 侧 2MB |
+| `get_ui_state`/`get_formatting` :2000/:2889 | 读光标属性 | O(1) | 轮询安全 |
+
+建议（A4 总）：(1) worker 内建一张「段落游标缓存」——`get_document_text` 记住上次 `(startParagraph → enumeration 位置)` 或一次性建 `index → XTextRange` 数组并在 modified 时失效，把逐页读从 O(n) 降到 O(窗口)；(2) `total` 另走一次性计数并缓存；(3) 凡有上限的原语统一返回 `truncated`；(4) 大命令（`apply_house_style`、`find_replace` >50 命中、`resolve_all_revisions`）拆批并发进度，宿主显示「AI 正在处理第 x/y 处」。
+
+### A5 AI 改文档链路：读取上限与上下文
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 桥超时 | `EditorBridgeService.java:66` 30s，`:286` `future.get`；`doc_start_stream` 走 `doc_open_file_sync`（`DocumentEditTools.java:209-214`）也吃这 30s，而前端 load 预算是 180s | 整档加载类动作两端预算不对称 | 按 action 分级超时（open/stream 180s、批量改 120s、其余 30s） |
+| 读全文 | `doc_get_document_text`（`DocumentEditTools.java:570-586`）透传分页，worker 15000 字/次、≤500 段 | 300 页约 40-60 万字 = 30-40 次翻页，每次 2-5s 全扫（A4） | 同 A4(1)；另给模型 `get_outline` + 按标题区间读的组合 |
+| 活动文档进上下文 | `ContextAssemblerService.java:723-746`：内联正文（≤200000 字，:711）> 哈希缓存 > **回退 `legalTools.read_document`（:745）** → `DocumentTextService.java:67` Tika `setMaxStringLength(5MB 字符)` 同步全文解析；再截 `max-chars-per-file: 50000`（`application.yml:262`） | 缓存未命中时**每轮对话**都可能对几十 MB docx 做一次同步 Tika 全文解析，解析完才截断 | 回退前看文件体积与段数，超阈值改走编辑器桥的 `get_outline` + 前 N 段；或把 Tika 结果按 fileId+mtime 落盘缓存 |
+| 工具读文件上限不一致 | `FileTools.java:163` `read_file` >10MB 直接拒；`extract_file_text`（:258-297）/`read_document` 无体积闸；输出统一截 `ToolFileGuard.MAX_TOOL_TEXT_CHARS = 80_000`（:47）；文件夹材料闸 10MB（`FileContextLoader.java:202`，`application.yml:260`） | 同一份 30MB 报告，三个入口三种结果，模型会反复换工具试 | 统一一个「大文件策略」：超阈值一律可读但走分页/摘要，错误文案指向正确工具 |
+| 分片上传 | `FileTree.vue:3422` `CHUNK_SIZE = 5MB` 串行分片，每片 60s、重试 3 次；后端 `FileController.java` ~:400-460 `resolveUploadStoragePath` 已修「第 2+ 块写进孤儿文件」地雷；无校验和 | 已修；剩余风险是断网续传后无内容校验 | 上传完成回传 sha256 比对（可选） |
+
+### A6 检查点 / 版本记录对大文件
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 检查点 | `DocumentCheckpointService.java:54-73` `getFileBytes` 整份进堆 + `storage.save` 整份落盘；每轮每文件一次；`clearForNewRun`（:129-143）清理 | 50MB 文档一次 50MB 堆分配 + 50MB 写；多会话并发叠加无限流 | 改流式拷贝（`Files.copy`）；云端 1.5GB 堆下给并发检查点加信号量 |
+| Git 提交 | `ProjectRepoService.java:178-179` 两遍 `add(".")`，无 gitignore/体积过滤（注释 :63-73 自认）；`blobAt` 50MB 闸（:74）；`RepoMaintenanceJob.java:29-40` 每日 gc 不清历史 | docx 是 zip，Git delta 几乎无效，仓库随每次停顿提交近线性膨胀；超 50MB 的文档在版本记录里不能看/比 | 对 >N MB 二进制（音视频、扫描件）默认不入库（`.awd/` 里写 ignore 清单）；docx 仍入库但给项目设置里一个「版本保留天数」 |
+| 对比 | 桌面 docx 走修订稿对比 = 两版都要 `load_document` + diff | 大文档对比等于两次打开 + 一次全文 diff | 先比段落哈希只对改动段落 diff |
+
+---
+
+## B. 成百上千文件的项目
+
+### B1 文件树与索引（后端）
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| **导入硬顶** | `LocalProjectService.java:40` `MAX_IMPORT_ENTRIES = 3000`，`:351/:397` 超出 `truncated=true` 只 `log.warn`（:197），**对账从不回头读被截断的部分**（:195 注释） | **千份底稿 + 几百截图 + 目录项很可能突破 3000**，超出的文件在工作台里永远不可见、AI 也搜不到，且用户无任何提示 | 把上限提到 2-3 万并在界面上显式提示截断；或改为分批导入 |
+| 对账 | `reconcileProject`：两次全表 `findByProjectId`（:201, :335）+ `walkFileTree`（:345，深 20） | 每次对账 O(N)，不是按变更子集 | 先用 watcher 事件定位变更子树，只对账子树 |
+| watcher | `LocalRootWatchService.java:43` `DEBOUNCE_MILLIS = 800`，每事件重排（:165-179） | 截图逐张保存（间隔 >800ms）→ 每张触发一次全量对账 | 防抖 800ms 之外再加「最短间隔 5s」的节流 |
+| **新建文件 O(N²)** | `ProjectFileService.java:224-229`（`createFile`）与 :91-96（`createFolder`）：每次新建先同名查询，再 `findByProjectIdAndParentIdOrderBySortOrderAsc` 拉整个同级列表只为算 `maxSortOrder` | 300 张截图进同一文件夹 ≈ 45,000 行累计读取，同步在每次 HTTP 请求里 | 改 `select max(sortOrder)` 单条 SQL；批量导入时在内存里递增 |
+| tree.json | `ProjectTreeManifestService.java:59` `capture` 全表 + 排序，`apply` 内核再查两次（:183, :330-334）；8 个调用点；每次整份重写 | 1000 文件的 tree.json 约几百 KB，每 2 分钟自动存档重写一次，可接受；复合成本在与 Git 全量 add 同一次提交 | 暂不动 |
+| Git 全量 add | `ProjectRepoService.java:178-179` 两遍遍历工作区全部文件（含 pdf/jpg/音频） | 每次提交 O(全部文件) stat；千文件级尚可，万文件级开始秒级 | 同 A6 的 ignore 清单；第二遍 `setUpdate(true)` 可合并 |
+| AI `list_files` | `FileTools.java:196-241` **无分页无上限**，且每次调用 `dbPathIndex`（:712-728）全表 + 逐行回溯父链拼路径，无缓存 | 几百张截图的文件夹一次 list 把几百行塞进模型上下文；每次工具调用重建全项目路径索引 | 加 `limit/offset`（默认 100）+ 「还有 N 个」；`dbPathIndex` 按 projectId 缓存、文件变更时失效 |
+| `search_project_files` | :73-153 文件名 glob，命中 50 终止（:105）；不读内容 | 安全 | 缺内容搜索是功能缺口不是性能问题 |
+| `extract_file_text` 文件夹 | `describeFolder` 顶 200（:307） | 安全 | |
+| 向量索引 | `ProjectRagService.java:79-135` `buildRetriever` 同步全目录 Tika + 逐段串行 embed，`scanDirectory`（:137-167）无上限；唯一消费方 `DynamicContentRetriever` 已与 v1 链路一起摘除（类注释 :14-27），`refreshProjectKnowledgeIncremental`（:69-76）只清缓存 | **当前不在热路径**；一旦有人重新接 `getRetrieverForProject`，千文件项目会同步卡数分钟 | 标注为「禁止直接复用」或删掉；真要做内容检索另起异步索引 |
+| 列表接口 | `ProjectFileController.java:67-93` `?tree=true` 整棵树一次返回，标签走 IN 查询非 N+1（`FileTagService.java:64-74`） | 1000 节点一次下发约数百 KB JSON，可接受；万级开始明显 | 暂不动，配合前端懒展开 |
+
+### B2 前端文件树
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 一次性拉树 | `FileTree.vue:1292` `getProjectFiles(projectId, null, true)` | 见 B1 | 首屏只拉根层，展开时按 parentId 拉 |
+| 无虚拟滚动 | `:422`/`:561` `v-for="(item, index) in displayFiles"` 整段渲染；`recycle` 关键字只是回收站 | 展开含几百张截图的文件夹 = 几百个节点一次挂载，H5/uni 渲染层卡 | 引入窗口化渲染（uni 可用 `recycle-view`/手写 IntersectionObserver 分页）；或折叠超 100 子项的文件夹显示「展开更多」 |
+| 树构建 | `:1746-1809` `buildTreeView` 每层对全量 `allFiles` `filter+sort` 递归；`refreshTreeView`（:1810-1830）整棵重算 | O(N × 展开文件夹数)，排序/过滤切换时整棵重算 | 先按 parentId 分组一次（Map），递归只取子集 |
+| 缩略图 | 无服务端缩略图（grep `thumb` 只命中 CSS）；列表用类型图标不拉原图；单图预览 `FilePreview.vue:519/598` 原图整包下载 `createObjectURL` | 列表安全；预览几 MB 截图每张整包 | 后端加 `?thumb=320` 按需生成缓存（`Thumbnails`/ImageIO） |
+
+### B3 图片进文档
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| `doc_insert_image` | `DocumentEditTools.java:1301-1337` 上限 2MB（:1326），`readAllBytes` → base64 → 经 SSE `client_action` 单帧下发 → worker 逐字节解码（`office_thread.js:3218-3250`） | 网核截图常 1-5MB，超 2MB 直接拒绝；base64 膨胀 33% 走 SSE | 后端先压缩/缩放到 ≤1600px JPEG 再下发（Java ImageIO 几十毫秒），上限提到 10MB 原图 |
+| `write_docx` | `FileTools.java:393-451` flexmark `DocxRenderer`，**无图片资源绑定代码** | markdown 里的图片引用落不进 docx | 生成后用 docx4j/POI 二次注入，或明确在工具描述里说「不含图」让模型改走 `doc_insert_image` |
+
+---
+
+## C. 外部截图批量落盘
+
+| 项 | 现状 | 预估瓶颈 | 建议 |
+|---|---|---|---|
+| 上传上限 | `application.yml:33-36` multipart 20GB；`ai.files.max-file-size-bytes` 10MB（:260）是上下文注入用，别混淆 | 无实际限制 | 无需改 |
+| 批量/并发 | `FileController.java:362-365` 单文件 upload 且需先有 fileId；`ProjectFileController.java:217-238` 单条建元数据；无批量端点、无限流、无 chunk（grep 无命中） | 几百张 = 几百对「建记录 + 传字节」请求；服务端只靠 DB/JGit 锁背压 | 加 `POST /files/batch`（multipart 多文件、一次事务、内存递增 sortOrder） |
+| 同名冲突 | `ProjectFileService.java:224-226` 新建同名直接抛「已存在同名文件」；前端自动加 `(1)` 只在「新建 Word」一处（`FileTree.vue:1408-1417`），截图保存链 `ocrActions.js` 未复用 | 手机/浏览器默认文件名相同的截图批量保存会连续失败 | 服务端统一「同名自动 (n)」策略，或 `createOrUpdateFile` 语义给调用方选择 |
+| 截图链路 | `desktop/main/main.js:1175-1182` `capturePage().toDataURL()` → IPC base64 → `ocrActions.js:342-343` `fetch(dataUrl).blob()` → `:358-365` createFile → `:379-393` `uni.uploadFile`；四跳两次 base64，无「保存全部」 | 单张可用；几百张要人工重复几百次，且每次命中 B1 的 O(N) 同级扫描 | 主进程直接落盘到临时文件后传路径；加多选/连拍「批量保存到文件夹」 |
+| 手机中转 | `MobileRelayController.java:80-101` `/media` 单文件 `MultipartFile`，ACK `:157-161`，状态批查 `:110-121`；`MobileRelayStoreService.java:53` `MAX_DIR_ENTRIES = 1000` 只限目录条目 | 目录镜像 1000 条硬顶——千份底稿的项目在手机端目录会被截 | 目录镜像分页或提上限；上传侧并发靠客户端队列（已有断点恢复） |
+
+---
+
+## 按风险排序的前 10 条待办（上百页报告 + 千份底稿）
+
+1. **`MAX_IMPORT_ENTRIES = 3000` 静默截断**（`LocalProjectService.java:40/351/397`）——IDE 化项目底稿超 3000 项就永远丢文件且无提示。数据可见性问题，优先级最高。
+2. **批量改稿撞 30s 桥超时而 worker 仍在改**（`office_thread.js:1632-1645` + `EditorBridgeService.java:66`）——实测 137-216ms/命中，约 200 命中即超时；模型收到失败后重发会双改。分批 + 进度 + 分级超时。
+3. **`apply_house_style` 150 页即超时且 5000 元素静默截断**（`office_thread.js:2949/2981`）——「成功一半」无任何标记。拆批 + `truncated`。
+4. **`get_document_text` 每页 O(n) 全扫 2-5s 冻画布**（`office_thread.js:169-178, 2451-2477`）——AI 读 300 页要扫 30-40 遍全文。段落游标缓存。
+5. **活动文档回退 Tika 全文解析每轮可能重跑**（`ContextAssemblerService.java:745` → `DocumentTextService.java:67`）——几十 MB docx 同步解析完才截 50000 字。按体积改走桥读大纲/落盘缓存。
+6. **新建文件 O(N²) 同级扫描 + 同名即失败**（`ProjectFileService.java:224-229`）——几百张截图落盘的直接痛点。`max(sortOrder)` 单查 + 同名自动编号 + 批量端点。
+7. **审阅面板批量处置 20s 无进度、逐组 O(K·N)**（`office_thread.js:3477-3499`，`ReviewPanel.vue:148-162`）——上千条修订的尽调稿审阅体验。批量 resolve 原语 + 长任务遮罩。
+8. **前端文件树整棵拉取 + 无虚拟滚动 + 每层全量 filter**（`FileTree.vue:1292/422/561/1746-1809`）——千节点树的卡顿来源。按需展开 + 窗口化。
+9. **保活 3 + 备胎 1 的内存不按文档体积计权**（`librePool.js:9`）——实测单页约 2.4GB 分配量；4 个大报告并存有 OOM 风险。计权 LRU，先用 Activity Monitor 复核 RSS。
+10. **Git 全量 add 无体积过滤 + docx 无 delta + 50MB 读取闸**（`ProjectRepoService.java:74/178-179`，`RepoMaintenanceJob.java:29-40`）——含图报告反复编辑让 `.git` 线性膨胀，超 50MB 后版本记录里看不了。ignore 清单 + 保留期。
+
+次级（不进前 10 但值得记）：`doc_insert_image` 2MB 上限对截图偏紧（B3）；`list_files` 无分页 + `dbPathIndex` 无缓存（B1）；`find_text_locations` 书签随文档存盘（A4）；`read_file`/`extract_file_text`/材料闸三种大小口径（A5）；`ProjectRagService.buildRetriever` 是休眠的同步全项目重扫陷阱（B1）；只读预览全量渲染与 boot 抢 CPU（A1）；`LocalRootWatchService` 逐张保存触发逐次全量对账（B1）。
+
+---
+
+## 附录 A：实测配方（可抄进 lowa-e2e 做「大文档基线组」）
+
+样本生成（python-docx + PIL）：150 页，每页 1 个二级标题 + 4 段约 220 字中文 + 分页符；随机 30 页插 12x5 `Table Grid` 表，随机 20 页插 900x600 `os.urandom` 噪声 JPEG（quality 75，约 330KB/张），结果 921 段 / 6.6MB。
+
+驱动：仿 `frontend/tests/lowa-e2e/run.mjs` 起 COOP/COEP 静态服务（dist + `/lowa/` 引擎 + `/big.docx`），puppeteer-core 无头 Chrome 打开 `editor.html?verify=1&lowa=/lowa/`，`waitForFunction('!!window.__loExecutor')`，页内 `fetch('/big.docx')` → `Array.from(new Uint8Array(buf))` → `executeCommand('load_document', {bytes, name:'big.docx'})`，随后逐条计时（`performance.now()` 包在 `page.evaluate` 内部，`bytes`/`matches`/`paragraphs` 在页内裁掉再跨界，避免 CDP JSON 序列化把耗时算进去）。内存用 `performance.measureUserAgentSpecificMemory()`（需跨源隔离，刚好具备）。
+
+两次运行的原始数字见上表；差异（`get_document_text` 2.2s vs 5.2s）说明同机抖动可达 2 倍，做基线组时取 3 次中位数、阈值放 3 倍。

--- a/docs/superpowers/specs/2026-08-21-dd-style-learning-inventory.md
+++ b/docs/superpowers/specs/2026-08-21-dd-style-learning-inventory.md
@@ -1,0 +1,330 @@
+# 尽调报告「学习团队模板」格式颗粒度盘点与设计（dev-board#100）
+
+日期：2026-08-21。性质：只读盘点 + 设计建议，未改产品代码。
+前置文档：`.claude/agents/ai-doc-bridge.md`（HOUSE、格式原语、doc_get_formatting）、`.claude/agents/doc-editor.md`、
+`docs/superpowers/specs/2026-08-21-due-diligence-lite-evaluation.md`（三期方案，本文是其 §1.1「模板画像」一项的展开）。
+
+## 0. 结论先行
+
+1. **后端写 docx 的路径是 docx4j，不是 POI。** `write_docx`（`FileTools.java:392`）与 `AiDocxExportService` 都走 flexmark-docx-converter → `org.docx4j.openpackaging.packages.WordprocessingMLPackage`，`DocxStyleHelper.applyStandardFormat()` 改的是 docx4j 的 `Styles/PPr/RPr/Tbl/Tc` 对象。POI 5.2.5 在 classpath 上，但 XWPF 只在 `SensitiveService`（读段落/页眉页脚文本做脱敏）与 `MeetingRecordingService`（写纪要）两处用到，**全仓没有一行读 `styles.xml`/段落属性/表格属性/`numbering.xml` 的代码**。读模板与写报告用同一套 docx4j 对象模型最省事，且 docx4j 自带 `PropertyResolver`（样式继承链 + docDefaults 的有效值解析），POI 没有对应物。
+2. **现有读取面只有两个口，都不够**：`extract_file_text` 是 Tika 纯文本（零格式，且 `capToolText` 会截断）；`doc_get_formatting` 只读光标所在处的字符/段落属性，要求模板已在 LOWA 打开，拿不到页面/页眉页脚/编号定义/表格边框/列宽。
+3. **绝大部分颗粒度从 XML 直读（docx4j）比 LOWA 更准**，因为 XML 保留了「声明单位」：`w:ind/@firstLineChars`（2 字符）、`w:spacing/@lineRule`（auto 倍数 vs atLeast/exact 磅）、`w:rFonts/@eastAsia` 与 `@asciiTheme`、`w:numFmt=chineseCounting` + `lvlText="%1、"`。LOWA 导入后把这些全折算成 1/100 mm 与枚举，「2 字符」变成 8.47 mm，「一、」变成 NumberingType 常量，倒推不回来。
+4. **必须走 LOWA 的只有四类**：(a) 主题字体/缺字体替换后的**实际渲染字体名**；(b) 表格样式条件格式（`tblStylePr` firstRow/band1Horz 斑马纹）叠加直接格式后的**单元格有效值**（docx4j PropertyResolver 不解析表格样式）；(c) 老格式 `.doc/.wps` 模板（POI HWPF 残缺，docx4j 不支持）；(d) **写完后的核验回读**（同一引擎读写闭环）。
+5. **写报告两条路都有缺口**，最大的一条是「中文字体」：`doc_format_selection(fontName)` 只设 `CharFontName`（西文），`CharFontNameAsian` 只有 `apply_house_style` 的 HOUSE 常量能设；编辑器路径也改不了样式定义本身、设不了页面边距/页码域/目录/自定义编号文本/单元格底纹/分边框线。docx4j 路径能力上无硬缺口，只是 flexmark 生成的列表与标题要后处理接管。
+6. 建议新增一个**后端只读工具 `docx_inspect_template`**（docx4j）产出 `styleProfile` JSON，并让三处写端（`DocxStyleHelper`、worker 的 `HOUSE` 系列、插件端 `HOUSE`）都改成「读 profile、HOUSE 退化为默认 profile」。分期见 §5。
+
+---
+
+## 1. 读模板：现状与覆盖矩阵
+
+### 1.1 现有入口能拿到什么
+
+| 入口 | 位置 | 能拿到 | 拿不到 |
+|---|---|---|---|
+| `extract_file_text` | `FileTools.java:259` → `DocumentTextService.parse`（Tika） | 纯文本、段落顺序、表格按 tab/换行摊平 | 一切格式；长文被 `ToolFileGuard.capToolText` 截断 |
+| `doc_get_document_text` | worker `get_document_text`（`office_thread.js:2451`） | 每段 `index/text`，有 OutlineLevel 的段附 `headingLevel/style` | 字体字号行距缩进；表格只给文本 |
+| `doc_get_formatting` | `DocumentEditTools.java:976` → worker `get_formatting`（`:2889`） | **光标处**：CharFontName/CharFontNameAsian/CharHeight/粗斜下删/颜色/高亮；ParaStyleName/对齐/行距(模式+值)/段前后/首行·左·右缩进(磅)/OutlineLevel/是否编号；所在表名与行列数 | 只有一处；缩进已折算成磅（丢了「字符」单位）；无边框/列宽/单元格对齐/页面/页眉页脚/编号格式 |
+| `list_styles`（宿主原语，非 AI 工具） | worker `:2075` | 样式名 + 显示名 + inUse | 样式的任何属性 |
+| `get_ui_state`（宿主） | worker `:2028` 一带 | 列表种类 bullet/number | 编号文本、层级 |
+
+结论：今天没有任何一条路能把模板「整篇」的格式读成结构化数据。
+
+### 1.2 后端库现状
+
+- docx4j 11.3.2（`~/.m2/repository/org/docx4j/docx4j-core/11.3.2`，随 `flexmark-docx-converter 0.64.0` 传入，pom 未直接声明）。已用类：`WordprocessingMLPackage`、`StyleDefinitionsPart`、`Styles/Style/PPr/RPr/RFonts/Tbl/Tr/Tc/TblPr/TblBorders/TcPr`。
+- POI 5.2.5 `poi-ooxml`（pom 显式）。`SensitiveService.java:76-95` 遍历 `getParagraphs()/getHeaderList()/getFooterList()` 只取文本。
+- **没有**：`XWPFStyles`、`XWPFNumbering`、`PropertyResolver`、`ThemePart`、任何 `CTTblBorders/CTTcPr/CTSectPr` 读取。
+
+### 1.3 目标颗粒度 × 读取手段覆盖矩阵
+
+「XML」= docx4j（或 POI XWPF，两者都能，推荐 docx4j 以与写端同模型）；「LOWA」= 打开模板后走 UNO 读。
+
+| 颗粒度 | XML 能读到 | XML 读不准/读不到 | LOWA 能补什么 | 推荐 |
+|---|---|---|---|---|
+| 标题有几级、每级样式 | `styles.xml` 中 `w:outlineLvl`、`Heading1-9` 及 basedOn 链；正文中各级标题实例的 `pPr/pStyle` | 模板用自定义样式名（如「报告一级标题」）且无 outlineLvl 时要靠实例启发式（编号前缀「一、」「（一）」） | OutlineLevel 同样缺；无优势 | XML + 启发式 |
+| 标题字体（中/西文）字号加粗 | `rFonts/@ascii @hAnsi @eastAsia @cs` 与 `@asciiTheme/@eastAsiaTheme`；`sz/szCs`（半磅）；`b/bCs`；`color` | 主题字体只得到 `minorHAnsi/majorEastAsia` 这种槽位名，要再查 `theme1.xml` 的 `a:minorFont/a:latin`、`a:ea`、`a:font script="Hans"`；docx4j `ThemePart`/`RunFontSelector` 有解析逻辑但 API 面偏内部，需核实 | `CharFontName/CharFontNameAsian` 直接是**渲染用的实际名**（缺字体时是替换后的名） | XML 取「声明名」（模板意图）；LOWA 取「渲染名」作核验 |
+| 标题编号样式 | `numbering.xml`：`abstractNum/lvl` 的 `numFmt`（decimal/chineseCounting/chineseCountingThousand/lowerLetter…）、`lvlText`（`%1、` `（%1）` `%1.%2`）、`start`、`suff`、`lvl/pPr/ind`、`lvl/rPr`；段落 `numPr(numId, ilvl)`；`num/lvlOverride` | 无 | `NumberingRules` 只给 NumberingType 枚举 + Prefix/Suffix；读得到但不如 XML 直接 | **XML**（这是最典型的「LOWA 读不准」项） |
+| 标题缩进/段前段后 | `ind/@left @firstLine @firstLineChars @hanging @hangingChars`；`spacing/@before @after @beforeLines @afterLines @line @lineRule` | 无；注意 `*Chars/*Lines` 优先级高于磅值属性 | 全部折成 1/100 mm，单位丢失 | **XML** |
+| 正文字体字号行距首行缩进对齐 | 同上 + `docDefaults` + `Normal` 样式；**有效值**用 `PropertyResolver.getEffectivePPr/getEffectiveRPr` | PropertyResolver 覆盖 docDefaults→样式链→直接格式，但**不含**编号级别 pPr 与表格样式条件格式 | 有效值（含编号级缩进） | XML 为主，LOWA 核验 |
+| 表格边框线型/粗细/颜色 | `tblPr/tblBorders`（val single/double/dashed…，sz 八分之一磅，color）；`tcPr/tcBorders` 单格覆盖；`tblStyle` 指向的表格样式 `tblPr/tblBorders` | 三层叠加（表格样式→表级→单元格级）docx4j 不自动合并，要自己写 | `TableBorder2`（表级）+ 单元格 `TopBorder/...`（`BorderLine2`：LineWidth、LineStyle、Color）是**合并后**的 | XML 读声明 + 自写三层合并；LOWA 可做交叉校验 |
+| 表头样式 | `trPr/tblHeader`（重复表头）；首行 tc 的 `shd`、run `b`；表格样式 `tblStylePr[@type=firstRow]`；`tblLook/@firstRow` | 条件格式是否生效要看 `tblLook` 位 | 首行单元格有效属性（已叠加） | XML（声明）+ LOWA（有效） |
+| 单元格对齐（水平/垂直） | 段落 `jc`；`tcPr/vAlign` | 无 | `ParaAdjust`、`VertOrient` | XML |
+| 数字/文字/日期在单元格里的格式 | 只能按单元格文本分类（`DocxStyleHelper.NUMERIC_CELL` 同款正则）后分别统计 jc/字体；Word 没有「单元格数据类型」概念 | 日期识别要正则（`2024年1月1日`、`2024-01-01`） | 同样只能靠文本分类 | XML，按内容类型聚合统计 |
+| 列宽 | `tblGrid/gridCol/@w`（twips）；`tcPr/tcW`（type dxa/pct/auto）；`tblPr/tblW`、`tblLayout` | `autofit` + `tcW type=auto` 时 XML 里是 0，真实宽度由 Word 排版决定 | `TableColumnSeparators`（相对位置）+ `Width` 是排版后的有效值 | XML 优先，autofit 时退 LOWA |
+| 斑马纹 | 表格样式 `tblStylePr[@type=band1Horz/band2Horz]/tcPr/shd`；或逐行 `tcPr/shd/@fill` | 要识别「隔行规律」 | 单元格 `BackColor` 有效值 | XML（样式）/ LOWA（直接格式时省事） |
+| 页眉页脚文字与格式 | `sectPr/headerReference` → `header1.xml` 段落 runs；`titlePg`（首页不同）；`evenAndOddHeaders` | 无 | `HeaderText/FooterText`（首节） | XML |
+| 页码 | `fldSimple[@instr="PAGE"]` / `instrText` 含 `PAGE`、`NUMPAGES`、`SECTIONPAGES`；`sectPr/pgNumType/@fmt @start`；页码周围文字「第 页 共 页」 | 无 | `PageNumber` 文本域可枚举但费事 | XML |
+| 页面（纸张/边距/方向/分栏/网格） | `sectPr/pgSz`、`pgMar`、`cols`、`docGrid/@type @linePitch` | 无 | 页面样式 `Width/Height/LeftMargin/...` | XML |
+| 目录 | `instrText` 含 `TOC \o "1-3" \h \z \u`（取级数、是否超链接）；目录段落样式 `TOC1/TOC2` 的属性；`sdt[docPartGallery=Table of Contents]` 包裹 | 无 | `ContentIndex` 服务 `Level`、`CreateFromOutline` | XML |
+| 字符样式（强调/引用用的） | `styles.xml type=character` | 无 | CharacterStyles 家族 | XML |
+| 老格式 .doc/.wps | POI HWPF 只读到部分段落属性，无样式/表格边框 | —— | LOWA 能打开 .doc 并读有效属性；.wps 不支持 | **LOWA**（或提示用户先另存 docx） |
+
+### 1.4 「必须走 LOWA」清单（归纳）
+
+1. 缺字体替换后的实际字体名（模板声明 `楷体_GB2312` 而机器上没有时，LOWA 会报替换后的名；这决定「AI 起草后看起来像不像」）。
+2. 表格样式条件格式 + 直接格式叠加后的单元格有效值（斑马纹/首行底纹/边框），docx4j 不做这一层合并。
+3. `.doc` 模板。
+4. 写后核验闭环：写完用同引擎 `get_formatting`/新增的 `get_table_format` 读回对比 profile，差异报给模型（与 `sheet_write_cells` 的 `formulaErrors` 自纠同一思路）。
+
+其余全部颗粒度 XML 直读更准、更快（不需要起引擎，云端/插件会话也能用）。
+
+---
+
+## 2. 样式画像 `styleProfile` JSON schema
+
+设计原则：
+- **单位随声明走**：每个长度字段都是 `{value, unit}`，unit ∈ `pt | chars | lines | percent | mm | twips`；行距 `{rule: auto|atLeast|exactly, value, unit}`（auto 时 value 是倍数，如 1.5）。这样「2 字符」「段后 0.5 行」「1.5 倍」「最小值 16 磅」都能无损表达。
+- **字体分槽**：`font: {eastAsia, ascii, hAnsi, cs, theme: {eastAsia, ascii}}`，`ascii/hAnsi` 通常相同，允许只写 `western`。读到主题字体时 `theme` 记槽位名、`eastAsia/western` 记解析后的实际名。
+- **每个叶子可缺省**：缺省=不约束，写端用默认 profile（HOUSE）补。
+- **来源与置信度**：每个块带 `source: style|instance|inferred` 与 `samples`（统计自多少实例），多份模板冲突时可裁决。
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "某某律所尽调报告模板",
+  "learnedFrom": [{"fileId": 123, "name": "XX公司法律尽职调查报告.docx", "kind": "docx"}],
+  "learnedAt": "2026-08-21T10:00:00+08:00",
+  "page": {
+    "size": {"width": {"value": 210, "unit": "mm"}, "height": {"value": 297, "unit": "mm"}, "orientation": "portrait"},
+    "margins": {"top": {"value": 2.54, "unit": "cm"}, "bottom": {"value": 2.54, "unit": "cm"}, "left": {"value": 3.17, "unit": "cm"}, "right": {"value": 3.17, "unit": "cm"}},
+    "docGrid": {"type": "lines", "linePitch": {"value": 15.6, "unit": "pt"}}
+  },
+  "defaults": {
+    "font": {"eastAsia": "宋体", "western": "Times New Roman"},
+    "size": {"value": 12, "unit": "pt"}, "color": "#000000", "lang": {"eastAsia": "zh-CN", "western": "en-US"}
+  },
+  "body": {
+    "styleId": "Normal", "source": "style", "samples": 412,
+    "font": {"eastAsia": "楷体_GB2312", "western": "Arial"},
+    "size": {"value": 12, "unit": "pt"}, "bold": false, "color": "#000000",
+    "alignment": "justify",
+    "lineSpacing": {"rule": "atLeast", "value": 16, "unit": "pt"},
+    "spaceBefore": {"value": 0, "unit": "pt"}, "spaceAfter": {"value": 18, "unit": "pt"},
+    "firstLineIndent": {"value": 2, "unit": "chars"},
+    "leftIndent": {"value": 0, "unit": "pt"}, "rightIndent": {"value": 0, "unit": "pt"},
+    "afterTableSpaceBefore": {"value": 18, "unit": "pt"}
+  },
+  "headings": [
+    {
+      "level": 1, "styleId": "Heading1", "styleName": "标题 1", "source": "style", "samples": 9,
+      "font": {"eastAsia": "黑体", "western": "Arial"}, "size": {"value": 16, "unit": "pt"},
+      "bold": true, "color": "#000000", "alignment": "center",
+      "lineSpacing": {"rule": "auto", "value": 1.5}, "spaceBefore": {"value": 12, "unit": "pt"}, "spaceAfter": {"value": 12, "unit": "pt"},
+      "firstLineIndent": {"value": 0, "unit": "pt"}, "leftIndent": {"value": 0, "unit": "pt"}, "hangingIndent": null,
+      "keepWithNext": true, "pageBreakBefore": false,
+      "numbering": {"kind": "auto", "numFmt": "chineseCounting", "lvlText": "%1、", "start": 1, "suffix": "nothing", "numIndent": {"value": 0, "unit": "pt"}}
+    },
+    {
+      "level": 2, "styleId": "Heading2", "source": "style", "samples": 31,
+      "font": {"eastAsia": "楷体_GB2312", "western": "Arial"}, "size": {"value": 12, "unit": "pt"}, "bold": true, "alignment": "justify",
+      "lineSpacing": {"rule": "atLeast", "value": 16, "unit": "pt"}, "spaceBefore": {"value": 0, "unit": "pt"}, "spaceAfter": {"value": 18, "unit": "pt"},
+      "firstLineIndent": {"value": 2, "unit": "chars"},
+      "numbering": {"kind": "literal", "numFmt": "chineseCounting", "lvlText": "（%1）", "start": 1, "suffix": "nothing"}
+    },
+    {
+      "level": 3, "styleId": "Heading3", "source": "instance", "samples": 57,
+      "font": {"eastAsia": "楷体_GB2312", "western": "Arial"}, "size": {"value": 12, "unit": "pt"}, "bold": true,
+      "numbering": {"kind": "literal", "numFmt": "decimal", "lvlText": "%1.", "suffix": "space"}
+    }
+  ],
+  "numbering": {
+    "abstractNumId": 3, "multilevelLinked": true,
+    "levels": [
+      {"ilvl": 0, "numFmt": "chineseCounting", "lvlText": "%1、", "indent": {"left": {"value": 0, "unit": "pt"}, "hanging": {"value": 0, "unit": "pt"}}},
+      {"ilvl": 1, "numFmt": "chineseCounting", "lvlText": "（%2）"},
+      {"ilvl": 2, "numFmt": "decimal", "lvlText": "%3."}
+    ],
+    "bodyLists": {"bullet": {"lvlText": "", "font": "Symbol"}, "decimal": {"lvlText": "%1."}}
+  },
+  "table": {
+    "source": "instance", "samples": 14, "tableStyleId": "TableGrid",
+    "width": {"value": 100, "unit": "percent"}, "alignment": "center", "layout": "fixed",
+    "cellMargins": {"top": {"value": 0, "unit": "pt"}, "left": {"value": 0.19, "unit": "cm"}},
+    "borders": {
+      "outside": {"style": "single", "width": {"value": 1.5, "unit": "pt"}, "color": "#000000"},
+      "insideH": {"style": "single", "width": {"value": 0.5, "unit": "pt"}, "color": "#000000"},
+      "insideV": {"style": "single", "width": {"value": 0.5, "unit": "pt"}, "color": "#000000"}
+    },
+    "header": {
+      "rows": 1, "repeatOnEachPage": true, "bold": true, "alignment": "center", "verticalAlign": "center",
+      "fill": "#D9D9D9", "font": {"eastAsia": "黑体", "western": "Arial"}, "size": {"value": 10, "unit": "pt"}
+    },
+    "cell": {
+      "font": {"eastAsia": "楷体_GB2312", "western": "Arial"}, "size": {"value": 10, "unit": "pt"},
+      "lineSpacing": {"rule": "atLeast", "value": 12, "unit": "pt"},
+      "spaceBefore": {"value": 0.2, "unit": "lines"}, "spaceAfter": {"value": 0.2, "unit": "lines"},
+      "firstLineIndent": {"value": 0, "unit": "pt"}, "verticalAlign": "center",
+      "byContentType": {
+        "text":   {"alignment": "left"},
+        "number": {"alignment": "right", "thousandsSeparator": true, "decimals": 2},
+        "date":   {"alignment": "center", "pattern": "yyyy年M月d日"},
+        "serial": {"alignment": "center"}
+      }
+    },
+    "zebra": {"enabled": false, "oddFill": null, "evenFill": "#F2F2F2"},
+    "columnWidths": {"mode": "percent", "samples": [[15, 55, 30], [10, 30, 30, 30]]},
+    "rowHeight": {"rule": "atLeast", "value": 0.8, "unit": "cm"},
+    "caption": {"position": "above", "style": "Caption", "pattern": "表 %1"}
+  },
+  "headerFooter": {
+    "header": {"enabled": true, "text": "XX律师事务所  法律尽职调查报告", "alignment": "right", "font": {"eastAsia": "宋体", "western": "Arial"}, "size": {"value": 9, "unit": "pt"}, "borderBottom": {"style": "single", "width": {"value": 0.5, "unit": "pt"}}},
+    "footer": {"enabled": true, "pageNumber": {"enabled": true, "pattern": "第 {PAGE} 页 共 {NUMPAGES} 页", "alignment": "center", "format": "decimal", "start": 1}, "text": null},
+    "differentFirstPage": true, "differentOddEven": false
+  },
+  "toc": {"enabled": true, "levels": 3, "hyperlinks": true, "title": "目  录", "titleStyle": {"size": {"value": 16, "unit": "pt"}, "bold": true, "alignment": "center"}, "entryStyles": {"TOC1": {"bold": true}, "TOC2": {"leftIndent": {"value": 2, "unit": "chars"}}}, "pageBreakAfter": true},
+  "characterStyles": {"emphasis": {"styleId": "Strong", "bold": true}, "quote": {"styleId": "Quotations", "italic": false, "leftIndent": {"value": 2, "unit": "chars"}}},
+  "notes": ["二级标题编号是手打的字面文本（非自动编号），生成时按 literal 拼接"],
+  "confidence": {"headings": 0.92, "table": 0.7, "headerFooter": 1.0}
+}
+```
+
+约定说明：
+- `numbering.kind`：`auto`=文档里用 numPr 自动编号；`literal`=标题文字自带「（一）」。律所模板两种都常见，写端要分别走「套 NumberingRules/numPr」与「拼字符串」两条路，读端必须区分（判据：段落有无 `numPr`，文本是否以编号正则开头）。
+- `chars`/`lines` 单位落到 docx 用 `firstLineChars`/`beforeLines`（1/100 字符、1/100 行）；落到 LOWA 用当前字号折算（现有 `set_paragraph_format.firstLineIndentChars` 已这么做）。
+- 缺省 profile（HOUSE 的 JSON 化）随后端资源文件发布：`backend/src/main/resources/style-profiles/house-default.json`，三处写端的单测对拍这个文件，替代今天「三处逐字一致」的人工约定。
+
+---
+
+## 3. 写报告：两条路各能落哪些字段
+
+### 3.1 `write_docx`（flexmark → docx4j，`FileTools.java:392` / `AiDocxExportService.java`）
+
+现状：`DocxStyleHelper.applyStandardFormat(pkg)` 在 render 后、save 前改 `Normal/BodyText/ParagraphTextBody/Quotations/Heading1-6` 样式 + 遍历正文表格刷 `tblBorders/tcPr/vAlign/jc/sz/b`。全部数值来自常量。
+
+| profile 字段 | docx4j 能否落 | 落法 | 现状 |
+|---|---|---|---|
+| body/headings 字体（含 eastAsia） | 能 | `RFonts.setEastAsia/setAscii/setHAnsi/setCs`（已有 `houseRPr`） | 已做，常量 |
+| 字号/加粗/颜色 | 能 | `HpsMeasure`/`BooleanDefaultTrue`/`Color`（已有） | 已做，常量 |
+| 对齐/段前段后/行距(含 rule)/缩进(含 chars) | 能 | `PPrBase.Spacing` `setLineRule(AUTO/AT_LEAST/EXACT)`、`Ind.setFirstLineChars`（已有 `housePPr`） | 已做，常量；Heading 2-6 与正文同款 |
+| keepWithNext/pageBreakBefore | 能 | `PPr.setKeepNext/setPageBreakBefore` | 未做 |
+| 标题自动编号（一、（一）1.） | 能 | 建 `NumberingDefinitionsPart`，`Numbering/AbstractNum/Lvl`（numFmt=CHINESE_COUNTING，lvlText），Heading 样式 `PPr.setNumPr` | **未做**；flexmark 不给标题编号，有序列表会生成自己的 numbering，需后处理接管 |
+| 标题字面编号（literal） | 能 | 后处理遍历 `P` 按 outlineLvl 计数器拼前缀 | 未做 |
+| 表格边框（分 outside/inside，线型/粗细/颜色） | 能 | `TblBorders` 六边各自 `CTBorder(val, sz, color)`（已有 `gridBorder`，六边同值） | 部分 |
+| 单元格边框覆盖 | 能 | `TcPr.setTcBorders` | 未做 |
+| 表头样式（加粗/底纹/居中/重复表头） | 能 | run `b`、`TcPr.setShd(CTShd fill)`、`jc`、`TrPr` 加 `CTTblHeader` | 加粗居中已做；底纹/重复未做 |
+| 单元格按内容类型对齐 | 能 | 现有 `NUMERIC_CELL` 分流 + 加日期/序号正则 | 数字已做 |
+| 列宽 | 能 | `TblGrid.getGridCol().setW` + 每 `TcPr.setTcW(type=dxa/pct)`；`TblPr.setTblLayout(FIXED)` | **未做**（flexmark 生成的列宽是自动） |
+| 斑马纹 | 能 | 逐行 `TcPr.shd` | 未做 |
+| 行高 | 能 | `TrPr` 加 `CTHeight(val, hRule)` | 未做 |
+| 页面（纸张/边距/网格） | 能 | `SectPr.getPgSz/getPgMar/getDocGrid`（`MainDocumentPart.getContents().getBody().getSectPr()`） | 未做 |
+| 页眉页脚文字 | 能 | `HeaderPart/FooterPart` + `SectPr.getEGHdrFtrReferences()`；`titlePg` | 未做 |
+| 页码「第 X 页 共 Y 页」 | 能 | `fldSimple instr="PAGE"`/`NUMPAGES` 或 `FldChar` 三件套 | 未做 |
+| 目录 | 能生成**域**，不能生成**条目** | `TocGenerator`（docx4j 有）或手写 `TOC \o "1-3" \h` 域 + `settings.xml updateFields=true`（Word 打开时提示更新）；LOWA 侧打开后可派发 `.uno:UpdateAllIndexes` 真生成 | 未做 |
+| 字符样式 | 能 | 样式定义 + run `rStyle` | 未做 |
+
+结论：docx4j 路径**没有能力缺口**，全是工作量。风险点：flexmark 把 markdown 标题映射为 `Heading1..6`、列表映射为它自带的 numbering，后处理要在 render 之后整体接管（已有的 `overrideBaseStyles` 就是这个模式）。
+
+### 3.2 编辑器路径（LOWA，`DocumentEditTools` → worker）
+
+| profile 字段 | 可用原语 | 能落 | 缺口 |
+|---|---|---|---|
+| 正文/标题字体 | `doc_format_selection(fontName)`；`doc_apply_standard_format` | 西文 `CharFontName`；HOUSE 的中西文 | **`fontName` 只设 `CharFontName`，没有 `fontNameAsian` 参数**；profile 的 eastAsia 字体无法按选区落 |
+| 字号/粗斜下删/颜色/高亮 | `doc_format_selection` | 全部 | 作用于当前选区，一段一段调，整篇要循环 |
+| 对齐/标题级别/行距(6 种模式)/段前后/首行缩进(chars 或 pt)/左右缩进 | `doc_set_paragraph_format` | 全部（行距与缩进的单位语义与 profile 对得上） | keepWithNext/pageBreakBefore 没有 |
+| 套既有样式 | `doc_set_style(styleName)` | 套用 | **不能创建/修改样式定义**；模板的 `Heading 1` 属性写不进去，只能逐段直接格式 |
+| 编号 | `doc_set_numbering(preset, level)` | bullet/decimal/chinese/multilevel/none 四个预设 | 不能给「一、→（一）→1.」这种混合多级、不能自定义 `lvlText`/起始值/缩进；`chinese` 只是第一级 |
+| 整篇套规范 | `doc_apply_standard_format` → `apply_house_style` | 字体中西文/字号/对齐/段距/行距/缩进/标题加粗/表格标准式/表后段前 | **全部来自 HOUSE 常量，不接参数**；首段≤60 字当主标题的启发式 |
+| 表格边框 | `doc_format_table(borderWidthPt)` | 六边同宽实线 | worker 收 `borderColor` 但 Java `@P` 没暴露；**无线型（双线/虚线）、无 outside/inside 区分、无单格边框** |
+| 表头 | `doc_format_table(firstRowBold)` / `applyStandard` | 首行加粗；标准式含居中 | **无底纹、无重复表头、无表头字体** |
+| 单元格对齐 | `doc_format_table(cellVerticalAlign)`；标准式按数字正则居右 | 垂直对齐；水平只在标准式 | 水平对齐不可单独指定；按内容类型/按列不可配置 |
+| 列宽/行高 | `doc_format_table(columnWidthsPercent, rowHeightPt, rowHeightRule)` | 百分比列宽、行高 | 绝对列宽（cm）没有 |
+| 斑马纹/单元格底纹 | 无 | —— | **缺口**（worker 需加 `BackColor`） |
+| 新建表 | `doc_insert_table(rowsJson, headerRow)` → `insertStyledTable` | 按 HOUSE 建 | 不接 profile |
+| 流式落字 | `doc_start_stream` → `stream_insert` | 按 HOUSE | 不接 profile |
+| 页眉页脚 | `doc_edit_header_footer(target, text, align)` | 文本 + 对齐 | **无页码域、无字体字号、无首页不同、无底边线** |
+| 页面设置 | 无 | —— | **缺口**（页面样式 `Width/Height/LeftMargin/TopMargin`、`GridMode`） |
+| 目录 | 无 | —— | **缺口**（`com.sun.star.text.ContentIndex` 插入 + `update()`） |
+| 样式定义改写 | 无 | —— | **缺口**：`xModel.getStyleFamilies().getByName('ParagraphStyles').getByName('Heading 1').setPropertyValue(...)` 在 UNO 里是标准操作；改样式比逐段直接格式好——后续流式/手打文字自动继承，docx 导出也落到 `styles.xml` |
+
+### 3.3 两条路都写不了的（今日缺口）
+
+1. **中文字体按选区/按样式设定**（docx4j 能，但 write_docx 不接参数；LOWA 没参数）。
+2. **自定义编号定义**（numFmt + lvlText + 多级绑定）。
+3. **页面设置、页码域、目录**：write_docx 未实现，LOWA 无原语。
+4. **表格的线型/分边/底纹/重复表头/绝对列宽**。
+5. **样式定义级别的写入**（LOWA 路径）。
+6. 把 profile 当参数传进任何写端（根本缺口：三处 HOUSE 都是常量）。
+
+### 3.4 写端设计建议
+
+- **不要给每个原语加十几个参数**。新增一个动作 `apply_style_profile {profile, scope: document|selection|styles-only}`，worker 把 `HOUSE` 换成 `ACTIVE_PROFILE`（默认=HOUSE JSON），`applyHouseChar/applyHousePara/styleTableStandard/insertStyledTable/stream_insert` 全部读 `ACTIVE_PROFILE`。`doc_open_file` 之后由后端把项目的 profile 下发一次（新 action `set_style_profile`），之后 `doc_insert_table`/`doc_start_stream` 自然按模板走，AI 不必每次传。
+- `apply_style_profile` 优先**改样式定义**（ParagraphStyles 的 `Standard`/`Heading N`、表格用 `Table Contents`/`Table Heading`），再对已有段落做最小直接格式（沿用 `keepWeight` 不抹当事人加粗的约定）。
+- `doc_format_table` 补 `borderColor`（Java 侧露出）、`borderStyle`、`outsideBorder/insideBorder` 分开、`headerFill`、`zebraFill`、`repeatHeader`、`columnWidthsCm`；或者干脆让它接 `tableProfileJson`。
+- `doc_format_selection` 补 `fontNameAsian`。
+- 新增 `doc_set_page_setup`、`doc_insert_toc`、`doc_edit_header_footer` 加 `pageNumberPattern/fontSize/fontName`。
+- `write_docx(styleProfileJson?)`：`DocxStyleHelper.applyStandardFormat(pkg, profile)` 重载，常量路径改为 `profile == null ? HOUSE_DEFAULT : profile`；`AiDocxExportService` 同步透传。
+- 插件端 `officeExecutor.js` 的 `HOUSE` 是第三个消费者（`office_apply_standard_format`），同样改成接 profile；本文不展开，但「三处逐字一致」的地雷在 profile 化之后变成「三处都对拍 `house-default.json`」。
+
+---
+
+## 4. 模板上传 UX 与画像存放
+
+### 4.1 候选入口比较
+
+| 方式 | 优点 | 缺点 |
+|---|---|---|
+| 项目内 `_模板/` 文件夹（用户把过往报告拖进去 / AI 建夹） | 零新 UI；走现有上传、版本记录、项目共享；团队成员都看得见、能换；与「尽调/」章节文件夹同一心智 | 依赖约定文件夹名；跨项目复用要再拷一次 |
+| 设置页上传（`pages/userprofile` 或 admin） | 全局一次、处处生效 | 设置页今天没有文件上传件；个人设置≠团队共识；web/h5 与桌面同步问题 |
+| AI 面板拖入（`FileStagingArea.vue` 已支持拖放进会话） | 最顺手，「这是我们的模板，照着学」一句话 | 暂存区文件是会话附件不是项目文件，学完要落地才可复用 |
+
+**建议：以项目 `_模板/` 文件夹为权威存放，AI 面板拖入作为快捷入口**（拖入时 AI 调 `docx_inspect_template` 学习，并把文件 `move_project_file` 进 `_模板/`、画像落 `_模板/画像.json`）。设置页只做「团队默认画像」的查看/重置（第二期）。
+
+### 4.2 画像存放与优先级
+
+| 存放 | 适用 | 说明 |
+|---|---|---|
+| 项目文件 `_模板/画像.json`（+ AI 写的 `画像.md` 人话摘要） | 项目级，团队共用 | 进版本记录、可手改、`extract_file_text` 能读回（json 属纯文本类型需确认 `PLAIN_TEXT_TYPES` 是否放行 json；不放行就用 `.md` 承载 JSON 代码块） |
+| `SystemSetting` `dd.styleProfile.default` | 律所级默认（admin 设） | `SystemSetting(key,value TEXT)` 现成；桌面单机版=本机默认，云后端=团队默认 |
+| 记忆（`project_memory`） | 只存指针与偏好（「本所默认用 A 画像」） | 不存 JSON 本体，召回不稳定且不可手改 |
+| skill 目录 `backend/skills/due-diligence/` | 出厂默认 profile 与 prompt | 随 skill 分发 |
+
+解析顺序：工具显式 `styleProfileJson` > 当前项目 `_模板/画像.json` > `SystemSetting` 默认 > `house-default.json`。多人共用：项目文件天然共享；律所级靠 admin 设置；冲突时后学的覆盖并在 `画像.md` 里留一行变更记录（版本记录兜底可退回）。
+
+### 4.3 学习流程（用户视角）
+
+1. 用户拖入 1-3 份过往报告，说「学这个模板」。
+2. AI 调 `docx_inspect_template(fileIds[])`：多份取众数，置信度写进 `confidence`；.doc 文件提示「请另存为 docx 或在编辑器里打开后再学」（或走 LOWA 兜底）。
+3. AI 用 `<question>` 结构化反问一次确认关键项（标题几级、编号自动还是手打、表格样式），写 `_模板/画像.json` + `画像.md`。
+4. 起草：`write_docx(..., styleProfileJson)` 或编辑器路径自动 `set_style_profile`。
+5. 核验：LOWA 打开后 `get_formatting` 抽样（首段、各级标题首个、首张表）与 profile 比对，差异回报。
+
+---
+
+## 5. 分期与代码面
+
+### 第一期：最小可用（标题 + 正文 + 基础表格），约 4-5 天
+
+目标：学到各级标题与正文的字体（中西文）/字号/加粗/对齐/行距/段前后/缩进 + 编号形态（auto/literal + lvlText）+ 表格的边框粗细颜色/表头加粗底纹/单元格字号对齐/列宽百分比；`write_docx` 与编辑器整篇格式化都按 profile 走。
+
+| 代码面 | 改动 |
+|---|---|
+| `backend/.../tools/TemplateTools.java`（新） | `@Tool docx_inspect_template(fileIds, options)`：docx4j 打开 → `PropertyResolver` 取 Normal/Heading 有效值 → 遍历正文实例按 outlineLvl/编号正则聚合众数 → 表格聚合 → 输出 profile v1（§2 子集：page 略、headerFooter 略、toc 略）。注册进 `RealToolBeans`、`toolDisplayNames.js` |
+| `backend/.../util/StyleProfile.java`（新） | profile 的 Java 记录 + Jackson 解析 + 单位换算（chars/lines/pt/twips）+ `house-default.json` 加载 |
+| `backend/src/main/resources/style-profiles/house-default.json`（新） | HOUSE 的 JSON 化 |
+| `DocxStyleHelper.java` | `applyStandardFormat(pkg, StyleProfile)`；常量改读 profile；表格分 outside/inside 边框、表头底纹、列宽 `tblGrid/tcW` |
+| `FileTools.java` / `AiDocxExportService.java` | `write_docx` 加可选 `styleProfileJson`；缺省时按 §4.2 顺序解析项目 `_模板/画像.json` |
+| `office_thread.js` | `HOUSE` → `ACTIVE_PROFILE`；新 action `set_style_profile`、`apply_style_profile`（先改 ParagraphStyles 定义再扫段落）；`format_selection` 加 `fontNameAsian`；`format_table` 露出 `borderColor/borderStyle/headerFill/outside-inside` |
+| `libreofficeExecutorClient.js` | EDITOR_ACTIONS 加两个 action |
+| `DocumentEditTools.java` | `doc_apply_style_profile`、`doc_format_selection` 加参、`doc_format_table` 加参；`doc_open_file` 成功后由 `EditorBridgeService` 追发 `set_style_profile` |
+| `ContextAssemblerService.java` | docx 分支提示：项目有画像时用 `doc_apply_style_profile`/`write_docx(styleProfileJson)` |
+| `backend/skills/due-diligence/prompt.md` | 学习→确认→落画像→起草的工作流 |
+| 测试 | `TemplateToolsTest`（fixtures：一份带三级标题+表格的 docx，断言 profile 字段）；`DocxStyleHelperTest`（profile 落盘后重新读回对拍）；lowa-e2e 新组（apply_style_profile 后 `get_formatting` 对拍）；三处默认值对拍 `house-default.json` 的单测 |
+
+### 第二期：完整颗粒度，约 8-10 天（在一期之上）
+
+| 代码面 | 改动 |
+|---|---|
+| `TemplateTools` | 补 page/headerFooter（含页码域模式识别）/toc/numbering 完整定义/字符样式/斑马纹/按内容类型（数字千分位、日期样式）/行高/重复表头；多模板众数与冲突报告；表格样式三层合并；主题字体解析（`ThemePart`） |
+| `DocxStyleHelper` | 页面 `SectPr`、`HeaderPart/FooterPart` + PAGE/NUMPAGES 域、`NumberingDefinitionsPart`（标题多级自动编号）、literal 编号拼接、TOC 域 + `updateFields`、斑马纹、行高、重复表头、keepWithNext |
+| `office_thread.js` | 新 action：`set_page_setup`、`insert_toc`（ContentIndex + update）、`edit_header_footer` 加页码域/字体、`set_numbering` 接自定义 `levels[]`（NumberingRules 的 NumberingType/Prefix/Suffix/StartWith）、`format_table` 加 `zebraFill/repeatHeader/columnWidthsCm`、`get_table_format`（核验用读回）|
+| `DocumentEditTools` | 对应新工具 `doc_set_page_setup`、`doc_insert_toc`、`doc_get_table_format`、`doc_set_numbering` 新签名（注意位置参数映射对旧会话回放的影响）|
+| LOWA 兜底读取 | `inspect_template_lowa`（worker）：.doc 模板或需要渲染字体名时，打开后整篇扫描输出同 schema 的 profile，后端合并 |
+| `officeExecutor.js` | 插件端 `office_apply_standard_format` 接 profile（同一 schema） |
+| 前端 | `_模板/` 文件夹识别（文件树图标/说明）；设置页「团队默认画像」查看/重置；admin `SystemSetting` 项 |
+| 测试 | fixtures 扩到含页眉页脚/目录/多级编号/斑马纹的模板；e2e 走「拖入模板→学→起草→核验」全链路 |
+
+### 工期外的风险
+
+- docx4j `PropertyResolver` 对 `firstLineChars` 等「字符单位」属性是否原样保留需实测（它的目标是渲染，可能已折算）；读声明值时建议绕过 resolver 直接读 `Style.getPPr()` 链，resolver 只用来补缺省。
+- flexmark 生成的 `Heading` 样式 id 与中文 Word 模板的样式 id（`1`、`2`，显示名「标题 1」）不同，profile 里同时记 `styleId` 与 `styleName`，写端按 outlineLvl 而不是按 id 对位。
+- LOWA 改样式定义会触发 `modified` → 自动保存，属预期；但 `RecordChanges=true` 下属性变更不进修订，安全网仍是检查点。

--- a/docs/superpowers/specs/2026-08-21-due-diligence-module-proposal.md
+++ b/docs/superpowers/specs/2026-08-21-due-diligence-module-proposal.md
@@ -1,0 +1,130 @@
+# 尽调报告模块总方案（合成稿）
+
+日期：2026-08-21 ｜ 看板卡：dev-board#100 ｜ 状态：待维护者拍板后进 brainstorm → 正式 spec → 分期 plan
+依据：四份盘点（同目录 `2026-08-21-dd-linkage-inventory.md` / `dd-scale-stability-inventory.md` / `dd-style-learning-inventory.md` / `dd-sample-corpus-profile.md`）+ 维护者三次口径。
+本文取代上午的 `2026-08-21-due-diligence-lite-evaluation.md`（那份按「轻量 skill」理解，作废）。
+
+---
+
+## 0. 一页结论
+
+**定位**：律师单人用的「底稿驱动起草」工作台——输入是一堆零散客户文件 + 网核截图 zip + 团队模板，输出是一份按律所版式的报告初稿，**报告里每条事实陈述都挂着底稿**，且关联可双向查、可定位到底稿内位置、改字时能提醒。与现有面向客户协作的「尽调清单」插件无关。
+
+**架构判断**：原语层基础确实好（LOWA 书签/定位/内部链接协议、文件树、标签、docx4j 写端、Tika/OCR、Playwright、平台网关），但**勾稽的事实表要重建**——今天的拖拽关联只是「选区超链接 + linkKey→fileIds 表」，没有目标位置、不能反查、文字删了就成孤儿、AI 零感知；tag / DocFileLink / WebFavorite 三套引用互不相通。
+
+**四根支柱**（对应四份盘点）：
+1. **勾稽事实表** `EvidenceLink`：书签锚点 + 目标位置 + 双向查询，网核截图落成项目文件走同一张表。
+2. **规模底座**：样本才 36 页 / 103 份底稿就已触到 `MAX_IMPORT_ENTRIES=3000` 之外的多条红线；上百页 + 千份底稿前必须先修 10 条中的前 6 条。
+3. **样式画像**：docx4j 直读 XML（不是 POI、不是 LOWA），`styleProfile` 带单位，HOUSE 三处常量改成可注入 profile。
+4. **语料契约**：以样本项目为黄金对照（6 章对照 + 全局断言），流水线 10 条硬要求是验收清单。
+
+**分期**：P0 底座与事实表（2 周）→ P1 入库整理 + 模板学习 + 初稿（2 周）→ P2 勾稽核查 + 改字提醒 + 底稿目录/缺口清单（1.5 周）→ P3 网核 zip 接入 + 定位高亮 + 规模打磨（1.5 周）。约 7 周，可并行压到 5 周。
+
+---
+
+## 1. 数据模型：把「引用」统一成一张事实表
+
+### 1.1 EvidenceLink（升级自 DocFileLink，同表加列不换表）
+
+| 列 | 含义 | 来源 |
+|---|---|---|
+| `linkKey` | 书签名 = 文档内锚点，`EVID_<ulid>` | 现有 |
+| `docFileId` | 报告所在 ProjectFile（改用 id，不再用 wpsFileId 软引用） | 改 |
+| `anchorText` / `anchorHash` | 锚点文字快照 + 归一化 hash（改字检测用） | 加 hash |
+| `sectionPath` | 报告章节路径（`一/（二）/3`），由书签所在标题链派生，落库便于按章节聚合 | 新 |
+| `targets[]` | 子表 `evidence_link_target`：`fileId`、`locatorJson`、`relation`（supports / contradicts / partial）、`method`（书面审查/书面说明/网络核查/第三方材料/访谈）、`confidence`、`createdBy`（human / ai） | 新 |
+| `locatorJson` | `{page, quote, rect}`（pdf/docx）/ `{rect}`（图片）/ `{startMs,endMs}`（音频视频）/ `{url, capturedAt}`（网核） | 新 |
+| `status` | active / orphan（书签不在了）/ stale（锚点文字变了）/ unverified | 新 |
+
+关键改变：
+- **锚点用命名书签而不是字符属性**：书签随段落移动、跨修订接受存活；`insert_link_with_bookmark` 已有这条路，拖拽关联改走它。
+- **双向查询**：`findByTargetFileId`、`findByDocFileId`、`findBySectionPath`，加索引。
+- **网核截图 = ProjectFile**：zip 解包后落 `尽调/<章节>/网核/<站点>_<日期>.png`，`ProjectFile.metaJson` 记 `{sourceUrl, capturedAt, provider}`；WebFavorite 保留给浏览器面板随手收藏，不再是尽调主链。
+- **主体**：物理树 = 章节（报告目录即文件夹），主体 = `PARTY` 标签（样本 12 个主体、同一主体材料散在 9 处，做成文件夹层会逼用户复制文件）。章节多重归属不用复制文件，由 EvidenceLink 反查派生「该文件被哪些章节引用」。
+- **文件稳定 ID**：样本里律师手工维护的 `章-节-序` 编号要解析进 `metaJson.docketNo`，缺则分配，重复则合并；字节级去重只合并实体不删视图。
+
+### 1.2 三种内部 scheme 收敛
+
+`checkba://filelink?k=`（保留，为主）/ `checkba://webfav?id=`（浏览器收藏）/ `checkba://file/<id>`（evidence.retrieve）——P0 起 `filelink` 支持 `&t=<targetIndex>` 直达某个 target 的 locator；后两者不再新增用法。
+
+---
+
+## 2. 流水线（AI 侧）
+
+```
+入库整理 ──► 模板学习 ──► 起草 ──► 勾稽核查 ──► 交付件
+```
+
+**A. 入库整理**（样本硬要求 1-5）：解压 zip（zip 当快照，目录为准）；过滤 `.DS_Store`/`~$`/`__MACOSX`；解析编号主键；字节级 + 近似去重（同名同尺寸、mp4 差几字节的两次导出）；状态词（【修订】【用印稿】(1) ---副本）抽成元数据；版本链判定（阶段词 > 日期 > vN > HHMM > mtime，按标题主干分组）；按章节夹/文件名/首页 OCR 归类到报告章节树；主体识别打 PARTY 标签。工具：`extract_file_text`、`ocr_*`、`move_project_file`、`tag_file` 现成，新增 `dd_ingest`（一次性批处理，后台任务 + 进度卡，避免 AI 逐文件调用撞 30s）。
+
+**B. 模板学习**（样式盘点）：`docx_inspect_template(fileId)` 用 docx4j 直读 styles/numbering/document.xml，输出 `styleProfile`（每个长度字段 `{value, unit}`；字体分 eastAsia/western/theme 槽；编号区分 auto/literal；表格到单元格级边框、列宽 twips、表头、数字格式）。样本实证：楷体 GB2312 12pt / 表格 10pt / 无首行缩进 / 段后 18pt / 最小行距 16pt / `一、（一）1.` 多级列表 / 单元格级边框 / 目录域 `\o "1-2"`——与 HOUSE 默认完全不同，**出稿必须按律所模板**。同时抽「引用句式库」（样本六种固定句式，句式本身就是引用）与「表格模板」（主体 × 字段，4 张基本情况表同构）。画像落 `_模板/画像.json`，团队共享、进版本记录。
+
+**C. 起草**：按章节、按主体 × 表格模板生成；每条事实句用句式库写，并**同步写 EvidenceLink**（AI 工具 `doc_link_evidence(anchor, targets[], method)`）；数字从 xls/审计报告结构化源取并回指单元格；找不到底稿的事实写「【待补：…】」并进缺口清单，不得编造（EVIDENCE_CONTRACT 不变式）。写端：`write_docx` 加 `styleProfileJson`，docx4j 路径补编号/列宽/页眉页脚/目录。
+
+**D. 勾稽核查**：对每个 EvidenceLink 做「陈述 ↔ 底稿」一致性判定（执照三要素 OCR 对账、日期/金额/股比对账、网核截图 OCR 对 URL 与主体名）；输出 relation/confidence；审阅面板新增「底稿」标签页，按章节/主体/状态筛选，点击定位。
+
+**E. 交付件**（样本四件套）：报告 docx；**文件级底稿目录**（人工流程缺的那一环，= EvidenceLink 按章节导出，每条带反向链接）；查验计划（method 枚举自动归类）；缺口清单（验收：⊇ 人工 `未提供文件.xlsx` 8 条）；章节树 zip。
+
+**F. 改字提醒**：worker 侧 `modified` 事件后按命名书签比对 `anchorHash`，变了标 stale 并在审阅面板「底稿」页亮黄；AI 改稿（doc_* 工具）后自动重跑受影响 link 的核查；「是否有新底稿」= 入库整理时新文件归类到某章节后，扫该章节 stale/unverified 的 link 提示。
+
+---
+
+## 3. 规模底座（稳定性盘点前 10 条，按本模块相关度重排）
+
+实测基线（真引擎 r4，150 页/30 表/20 图/6.6MB）：打开 2.7-3.8s 可接受；`get_document_text` 每次 2.2-5.2s 全扫；修订模式 `find_replace` 150 命中 20.5s；`apply_house_style` >30s 超时且 5000 元素静默截断；页面内存约 2.4GB。
+
+P0 必修：
+1. `MAX_IMPORT_ENTRIES=3000` 静默丢文件（LocalProjectService.java:40/351/397）→ 分批 + 明确告警。
+2. 新建文件同级 O(N²) 扫描 + 同名直接报错（ProjectFileService.java:224-229）→ 索引 + 同名自动加序；这是几百张截图落盘的直接痛点。
+3. 批量改稿撞 30s 桥超时而 worker 继续改（双改风险）→ 分段提交 + 可取消 + 进度。
+4. `apply_house_style` 改成按段落范围分批，truncated 必须上报。
+5. `get_document_text` 分页全扫 → 段落索引缓存（书签/标题链一次建好，改动增量维护）。
+6. 文件树整棵拉取无虚拟滚动（FileTree.vue）→ 懒加载 + 虚拟列表；`list_files` 分页。
+
+P3 再修：审阅面板批量处置 O(K·N)、保活池按体积计权、Git 全量 add 无体积过滤、`doc_insert_image` 2MB 上限、手机端镜像 `MAX_DIR_ENTRIES=1000`。
+发版前把实测配方进 lowa-e2e「大文档基线组」，三次取中位数。
+
+---
+
+## 4. UI/UX 补充点
+
+- **模板上传**：项目 `_模板/` 文件夹为权威存放 + AI 面板拖入快捷入口；上传即触发画像并在概览页显示「已学习：楷体 12pt / 四级编号 / 17 类表格」。
+- **审阅面板「底稿」页**：章节树 ⇄ 主体两种视图切换；每条 link 显示状态色（active/stale/orphan/unverified）、method、confidence；点击打开底稿并定位（pdf 跳页 + 引文高亮叠加层，图片画框，音视频 seek）。
+- **拖拽关联升级**：把文件拖到**文字上**（不是侧栏投放区）即建书签 + link，并弹 method 选择。
+- **文件树**：按 PARTY 标签筛选、显示「被引用 N 次」角标、未引用底稿灰显（样本 21 份零引用里 18 份是重复、2 份误入、1 份引而不注——灰显能直接暴露）。
+- **缺口清单与底稿目录**：一键导出 xlsx / docx。
+- **版本链**：同名多版只在树里显示最终版，其余折叠进「历史版本」。
+
+---
+
+## 5. 分期与工期
+
+| 期 | 内容 | 代码面 | 工期 |
+|---|---|---|---|
+| P0 底座 | EvidenceLink 表与双向查询、书签锚点化的拖拽关联、`filelink&t=` 定位、稳定性前 6 条、lowa-e2e 大文档基线组 | backend: DocFileLink→EvidenceLink 实体/Repo/Service/Controller；frontend: project-overview 拖拽链路、FileTree 虚拟滚动；worker: 段落索引、分批 house style | 2 周 |
+| P1 起草 | `dd_ingest` 后台任务、`docx_inspect_template` + styleProfile、`write_docx(styleProfileJson)`、引用句式库与表格模板、`doc_link_evidence` 工具、尽调 skill prompt | backend: TemplateTools/DdIngestService/FileTools/DocxStyleHelper；skills/due-diligence/ | 2 周 |
+| P2 勾稽 | 一致性核查、审阅面板「底稿」页、改字 stale 检测、底稿目录/查验计划/缺口清单导出 | backend: EvidenceVerifyService；frontend: ReviewPanel 新 tab；worker: anchorHash 比对 | 1.5 周 |
+| P3 网核与定位 | zip 接入（公司名 → 外部服务 → 解包落盘 → 自动 link）、pdf 叠加层高亮、图片画框、音视频 seek、稳定性余项 | backend: WebVerifyIngest + 平台网关一条新服务；frontend: FilePreview | 1.5 周 |
+
+验收：P1 末用样本项目跑黄金对照 6 章 + 全局断言（去重后实体≈85、骨干文件≥2 章、缺口清单 ⊇ 8 条、误入文件不归类、底稿目录条目数=实体数）。
+
+---
+
+## 6. 刻意不做
+
+拖拽调序大纲 UI（大纲=文件夹，文件树可拖）；短信通知；token 独立计费（Credits 统一）；新左栏面板（审阅面板加 tab 即可）；自动逐站爬取（接外部 zip 服务，验证码与合规都不碰）；独立阅读器。
+
+---
+
+## 7. 待拍板（4 个）
+
+1. **网核 zip 的内部格式**：需要一个真实返回样例（是否每张图带 URL/时间戳的 manifest？没有就只能靠 OCR 抽 URL）。这决定 P3 的落盘与 link 自动化程度。
+2. **HOUSE 常量改成 profile 注入**会动三处逐字一致的契约（worker / DocxStyleHelper / Office 插件），是否允许在 P1 一并做（否则只能走「先按 HOUSE 出稿再 apply_style_profile 二次套版」，大文档上慢）。
+3. **改字提醒的力度**：只在审阅面板亮黄（推荐，不打断），还是编辑时弹提示。
+4. **商业定位**：内置（官方版用户升级即得）还是广场付费项接 entitlement。影响 skill.yml 与 registry。
+
+---
+
+## 8. 下一步
+
+拍板后按 superpowers 流程走：brainstorm（对齐 P0 数据模型细节）→ writing-plans 出 P0 任务级 plan → subagent-driven 执行。P0 不依赖任何待拍板项，可以先动。


### PR DESCRIPTION
纯文档。尽调报告模块总方案（合成稿）+ 勾稽能力 / 大文档稳定性（含真引擎实测数字）/ 细颗粒度样式学习 三份盘点。样本语料画像含客户项目细节，不入库。

🤖 Generated with [Claude Code](https://claude.com/claude-code)