### PR TITLE
feat(lowa): EvidenceLink 书签锚点五原语 + lowa-e2e 证据锚点组（dev-board#103）

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -120,8 +120,27 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - webview/uni 存储格式坑与宿主侧 e2e 配方见 lowa-keepalive 记录（PR#159）。
 - **预热备胎是同一个 LibreOfficeEditor 组件（file=null）**：任何在组件树/DOM 里"找编辑器实例"的探针（如 desktop-e2e FIND_EDITOR）必须过滤 `file` 非空，否则命令打在隐藏空白备胎上、样样"成功"但真文档纹丝不动。备胎未激活用 visibility 隐藏（绝对定位占位），不能改 display:none——引擎要在有尺寸画布里 boot。
 
+## EvidenceLink 书签原语（dev-board#103，office_thread.js）
+
+书签名 = linkKey（`EVID_<ULID>`，只含 `[A-Za-z0-9_]`），底稿关联挂在命名书签上跟着文字走。五个 host-initiated action（已入 `EDITOR_ACTIONS` 白名单；失败一律 `bmFail()` 双字段 error+message）：
+
+| action | 参数 | 返回 |
+|---|---|---|
+| `bookmark_selection` | `{name}` | `{success, name, text}`；空选区 / 非法名 / **重名精确拒绝**（不像 `insert_link_with_bookmark` 那样加 `_n`） |
+| `get_bookmark_context` | `{name}` | `{success, exists, text, sectionPath, sectionTitle, paragraphIndex}`；不存在是 `exists:false` 不是失败 |
+| `check_link_anchors` | `{names[]}` | `{success, items:[{name, exists, text}]}`；单次 ≤200，宿主分批 |
+| `adopt_legacy_links` | `{}` | `{success, adopted:[name], skipped}`；收编 `filelink?k=<key>` 超链接 run 为同名书签，幂等 |
+| `goto_bookmark` | `{name}` | `{success, name}`；`anchorRange` + `selectVisibly`，不借 `set_selection`（它只认 `__ai_anchor_*`） |
+
+真机实测结论（lowa-e2e 组 27，2026-08-21）：
+- **书签覆盖的文字被整段删除后，LO 连书签一起删掉**：`check_link_anchors` 回 `exists:false`，不会留空点书签。宿主判 orphan 仍用「`!exists || text===''`」双口径（text 为空是防御）。
+- 书签内部插字会扩张书签；**正好在书签末端插入不扩张**（e2e 要先 `collapse_selection end` + `move_cursor left` 再插）。
+- 书签经 docx export/load 往返存活（文字含后插的字）。
+- `adopt_legacy_links` 不能把 TextPortion 直接喂 `insertTextContent`（抛 IllegalArgumentException），要 `createTextCursorByRange(start)` + `gotoRange(end, true)` 在正文上造区间游标；且先收集目标再插书签，枚举中改段落会让 portion 枚举失效。
+- `headingChainOf` 用 `XTextRangeCompare` 定位段落，表格单元格内的书签跨 story 比较会抛 → `sectionPath` 空、`paragraphIndex -1`（P0 接受）。
+
 ## 验证
 
-- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，12 组人机模拟，基线 38 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
+- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，27 组人机模拟，2026-08-21 基线 417 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
 - 涉桌面壳/webview：`npm run test:desktop-e2e`（弹 dev Electron 窗口，验证保存落盘链路）。
 - 全应用：`npm run test:app-e2e`。改编辑器三件套（原语/白名单/worker）必跑 lowa-e2e。

--- a/frontend/src/composables/libreofficeExecutorClient.js
+++ b/frontend/src/composables/libreofficeExecutorClient.js
@@ -71,6 +71,9 @@ export const EDITOR_ACTIONS = [
   // [#79 click-to-open] LO WASM 不触发 window.open（v0.7.1 真机证实）：编辑器页
   // 监听 canvas 点击后经此原语读取光标处链接再转发宿主。
   'get_hyperlink_at_cursor',
+  // [EvidenceLink dev-board#103] 书签名 = linkKey 的证据锚点五原语。Host-initiated
+  //（EvidenceLink 服务 / 拖拽关联 / 底稿面板），不是 AI 管线；失败双字段 error+message。
+  'bookmark_selection', 'get_bookmark_context', 'check_link_anchors', 'adopt_legacy_links', 'goto_bookmark',
   // [批注] Word comment on an anchored range — 解释/说明类文字不进正文的通道
   // （backend doc_add_comment）。
   'add_comment',

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -100,6 +100,39 @@ function anchorRange(name) {
   if (!bms.hasByName(name)) return null;
   return bms.getByName(name).getAnchor(); // XTextRange
 }
+// ---- EvidenceLink 书签原语 helpers（dev-board#103）-----------------------------
+function bmFail(msg) { return { success: false, error: msg, message: msg }; }
+// 当前选区的第一个 range（无选区 → null）。
+function selectionRange() {
+  const sel = ctrl.getSelection();
+  let range = null;
+  try { if (sel && typeof sel.getByIndex === 'function' && sel.getCount() > 0) range = sel.getByIndex(0); } catch (e) {}
+  return range;
+}
+// 从 range 所在段落向前找标题链：OutlineLevel 1..6，每级只取最近的一个，直到
+// 遇到 1 级或文首。返回 {chain:[{level,text}], paragraphIndex}；定位不到（跨
+// story 比较抛异常、表格单元格等）时 chain 为空、paragraphIndex -1。
+function headingChainOf(range) {
+  const chain = [];
+  let seen = 99;
+  try {
+    const body = xModel.getText(); // XTextRangeCompare
+    const paras = [];
+    eachParagraph(function (el) { paras.push(el); return false; });
+    const start = range.getStart();
+    let idx = -1;
+    for (let i = 0; i < paras.length; i++) {
+      if (body.compareRegionStarts(paras[i].getStart(), start) >= 0 && body.compareRegionEnds(paras[i].getEnd(), start) <= 0) { idx = i; break; }
+    }
+    if (idx < 0) return { chain: [], paragraphIndex: -1 };
+    for (let i = idx; i >= 0 && seen > 1; i--) {
+      let lvl = 0;
+      try { lvl = Number(paras[i].getPropertyValue('OutlineLevel')) || 0; } catch (e) {}
+      if (lvl > 0 && lvl < seen) { chain.unshift({ level: lvl, text: (paras[i].getString() || '').trim().slice(0, 200) }); seen = lvl; }
+    }
+    return { chain: chain, paragraphIndex: idx };
+  } catch (e) { return { chain: [], paragraphIndex: -1 }; }
+}
 
 // #104 variable fields: a NAMED bookmark spanning the inserted value marks a
 // "document field" bound to a (scope, varName) variable — the WPS 域 semantics
@@ -3183,6 +3216,111 @@ const EXEC = {
     xText.insertTextContent(cur, bm, true);
     try { vc.gotoRange(cur.getEnd(), false); } catch (e) {}
     return Object.assign({ success: true, bookmarkName: name, text: text, url: url }, verifySnapshot());
+  },
+  // ---- EvidenceLink 锚点原语（dev-board#103）：书签名 = linkKey ----------------
+  // 尽调报告里「每条事实必有底稿」：底稿与正文的关联落在命名书签上，书签随
+  // 文字走、经 docx 往返存活。与 insert_link_with_bookmark 不同，这里给的是
+  // **当前选区**套书签，且重名精确拒绝（linkKey 必须一一对应，不许加 _n 后缀）。
+  // 失败返回同时写 error 与 message（宿主只回传 result.error 的已知地雷）。
+  bookmark_selection(p) {
+    if (!isWriterDoc()) return bmFail(NOT_TEXT_DOC_MSG);
+    const name = String((p && p.name) || '');
+    if (!/^[A-Za-z0-9_]{1,64}$/.test(name)) return bmFail('bookmark name must match [A-Za-z0-9_]{1,64}: ' + name);
+    const range = selectionRange();
+    const text = range ? (range.getString() || '') : '';
+    if (!range || !text.length) return bmFail('no selection to bookmark');
+    const bms = xModel.getBookmarks();
+    if (bms.hasByName(name)) return bmFail('bookmark exists: ' + name);
+    try {
+      const bm = xModel.createInstance('com.sun.star.text.Bookmark');
+      bm.setName(name);
+      range.getText().insertTextContent(range, bm, true); // bAbsorb: 书签覆盖整个选区
+    } catch (e) { return bmFail('bookmark_selection failed: ' + errStr(e)); }
+    return { success: true, name: name, text: text };
+  },
+  // 书签所在位置的上下文：文字 + 标题链（OutlineLevel>0 的段落，与 get_outline
+  // 同判据）+ 段落索引（0 基）。不存在 → exists:false（不是失败）。表格单元格内
+  // 的书签跨 story 比较会抛，sectionPath 为空、paragraphIndex -1（P0 接受）。
+  get_bookmark_context(p) {
+    const name = String((p && p.name) || '');
+    const range = anchorRange(name);
+    if (!range) return { success: true, exists: false, text: '', sectionPath: '', sectionTitle: '', paragraphIndex: -1 };
+    const h = headingChainOf(range);
+    return {
+      success: true, exists: true, text: range.getString() || '',
+      sectionPath: h.chain.map(function (c) { return c.text; }).join('/'),
+      sectionTitle: h.chain.length ? h.chain[h.chain.length - 1].text : '',
+      paragraphIndex: h.paragraphIndex,
+    };
+  },
+  // 批量核对：单次最多 200 个（宿主分批、批间让路 autosave）。真机实测（lowa-e2e
+  // 组 27）：书签覆盖的文字被整段删除后 LO 连书签一起删掉，exists:false；宿主以
+  // 「!exists || text===''」判 orphan（text 为空是防御口径，正常路径不会出现）。
+  check_link_anchors(p) {
+    const names = Array.isArray(p && p.names) ? p.names.slice(0, 200) : [];
+    let bms = null;
+    try { bms = xModel.getBookmarks(); } catch (e) { return bmFail('check_link_anchors failed: ' + errStr(e)); }
+    const items = [];
+    for (let i = 0; i < names.length; i++) {
+      const n = String(names[i]);
+      let exists = false, text = '';
+      try { if (bms.hasByName(n)) { exists = true; text = bms.getByName(n).getAnchor().getString() || ''; } } catch (e) {}
+      items.push({ name: n, exists: exists, text: text });
+    }
+    return { success: true, items: items };
+  },
+  // 旧式关联（超链接 filelink?k=<key>）收编为同名书签；已有同名书签的跳过。
+  // 同一 run 被格式变化拆成多个 portion 时只有第一个被套上（后面 hasByName 命中
+  // skipped）——书签覆盖不全但锚点有效。
+  adopt_legacy_links() {
+    if (!isWriterDoc()) return bmFail(NOT_TEXT_DOC_MSG);
+    const adopted = []; let skipped = 0;
+    try {
+      const bms = xModel.getBookmarks();
+      const xText = xModel.getText();
+      // 先收集再插书签：枚举过程中改段落内容会让 portion 枚举失效。
+      // TextPortion 本身不能直接喂 insertTextContent（真机抛 IllegalArgumentException），
+      // 要用 createTextCursorByRange 在正文上造一个覆盖该 portion 的区间游标。
+      const targets = [];
+      const en = xText.createEnumeration();
+      while (en.hasMoreElements()) {
+        const para = en.nextElement();
+        if (!para.supportsService || !para.supportsService('com.sun.star.text.Paragraph')) continue;
+        const pen = para.createEnumeration();
+        while (pen.hasMoreElements()) {
+          const portion = pen.nextElement();
+          let url = '';
+          try { url = String(portion.getPropertyValue('HyperLinkURL') || ''); } catch (e) { continue; }
+          const m = /filelink(?:\?|%3F)k(?:=|%3D)([A-Za-z0-9_%\-]+)/.exec(url);
+          if (!m) continue;
+          let key = m[1];
+          try { key = decodeURIComponent(key); } catch (e) {}
+          key = key.replace(/[^A-Za-z0-9_]/g, '_');
+          if (!key) continue;
+          targets.push({ key: key, start: portion.getStart(), end: portion.getEnd() });
+        }
+      }
+      for (let i = 0; i < targets.length; i++) {
+        const t = targets[i];
+        if (bms.hasByName(t.key)) { skipped++; continue; }
+        const cur = xText.createTextCursorByRange(t.start);
+        cur.gotoRange(t.end, true);
+        if (!(cur.getString() || '').length) { skipped++; continue; }
+        const bm = xModel.createInstance('com.sun.star.text.Bookmark');
+        bm.setName(t.key);
+        xText.insertTextContent(cur, bm, true);
+        adopted.push(t.key);
+      }
+    } catch (e) { return bmFail('adopt_legacy_links failed: ' + errStr(e)); }
+    return { success: true, adopted: adopted, skipped: skipped };
+  },
+  // 跳到书签：anchorRange + selectVisibly（不借 set_selection，它只认 __ai_anchor_*）。
+  goto_bookmark(p) {
+    const name = String((p && p.name) || '');
+    const range = anchorRange(name);
+    if (!range) return bmFail('bookmark not found: ' + name);
+    if (!selectVisibly(range)) return bmFail('could not select bookmark: ' + name);
+    return { success: true, name: name };
   },
   // read the hyperlink URL at the (collapsed) view cursor — the click-to-open
   // seam: LO WASM does NOT surface hyperlink activation (no window.open, real-

--- a/frontend/tests/lowa-e2e/README.md
+++ b/frontend/tests/lowa-e2e/README.md
@@ -40,6 +40,12 @@ npm run test:lowa-e2e
 6. Cmd+C/V/X 系统剪贴板复制、多段粘贴覆盖选区、剪切
 7. Home / Shift+End 选择 / Option+← 跳词 / Cmd+← 行首 / Cmd+↓ 文尾
 8. Tab 制表符、Shift+Enter 软回车、Esc 取消选区、PageUp/Down
+9-26. 见 run.mjs 各组标题（条款识别 / 修订署名与颗粒度 / 批注 / 版本对比 / 表格 / Calc / Impress / 工具栏与查找 / chrome 退场）
+27. EvidenceLink 证据锚点（dev-board#103）：bookmark_selection / get_bookmark_context /
+    check_link_anchors / adopt_legacy_links / goto_bookmark，含书签内插字扩张、整段删除
+    书签随之消失、旧式 filelink 超链接收编、docx 往返存活（27 步）
+
+步数基线：2026-08-21 组 27 落地后 417 步全绿（此前 390）。
 
 ## 机制说明
 

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -1650,6 +1650,109 @@ try {
     await exec('set_chrome', { menubar: true, statusbar: true, toolbars: true, rulers: true })
   }
 
+  // ---------- 组 27：EvidenceLink 证据锚点——书签原语五件套（dev-board#103）----------
+  // 书签名 = linkKey：bookmark_selection / get_bookmark_context / check_link_anchors /
+  // adopt_legacy_links / goto_bookmark。每条事实必有底稿，底稿挂在书签上跟着文字走。
+  console.log('\n[27] EvidenceLink 证据锚点：书签五原语')
+  {
+    await exec('debug_fresh_document')
+    await exec('debug_set_record_changes', { on: false })
+    await exec('ui_command', { name: 'select_all' })
+    await exec('replace_selection', { text: '一、主体资格\n根据《营业执照》，收购人成立于2020年。\n（一）基本情况\n收购人注册资本1000万元。' })
+    await exec('select_paragraph', { index: 0 })
+    await exec('set_paragraph_format', { headingLevel: 1 })
+    await exec('select_paragraph', { index: 2 })
+    await exec('set_paragraph_format', { headingLevel: 2 })
+    const ol = await exec('get_outline')
+    check('标题层级就位（1 级 + 2 级）', ol.count === 2 && ol.outline[0].level === 1 && ol.outline[1].level === 2, JSON.stringify(ol))
+    const selectText = async (kw) => {
+      const ft = await exec('find_text_locations', { keyword: kw })
+      if (!ft.success || ft.count < 1) return ft
+      return exec('set_selection', { anchor: ft.matches[0].anchorId })
+    }
+
+    // 2. 选区套书签；重名精确拒绝（linkKey 不许悄悄加 _n 后缀）
+    await selectText('收购人成立于2020年')
+    const b1 = await exec('bookmark_selection', { name: 'EVID_TEST1' })
+    check('bookmark_selection 成功且回显文字', b1.success === true && b1.name === 'EVID_TEST1' && b1.text === '收购人成立于2020年', JSON.stringify(b1))
+    const dup = await exec('bookmark_selection', { name: 'EVID_TEST1' })
+    check('同名书签被拒绝（error 含 exists，双字段）', dup.success === false && /exists/.test(dup.error || '') && dup.message === dup.error, JSON.stringify(dup))
+    const badName = await exec('bookmark_selection', { name: 'bad-name!' })
+    check('非法书签名被拒绝', badName.success === false && !!badName.error, JSON.stringify(badName))
+
+    // 3. 上下文：标题链 + 段落索引（0 基）
+    const c1 = await exec('get_bookmark_context', { name: 'EVID_TEST1' })
+    check('get_bookmark_context 命中且文字前缀正确', c1.success === true && c1.exists === true && c1.text.indexOf('收购人成立于') === 0, JSON.stringify(c1))
+    check('sectionPath 为一级标题', c1.sectionPath === '一、主体资格' && c1.sectionTitle === '一、主体资格', JSON.stringify(c1))
+    check('paragraphIndex 为 1（0 基）', c1.paragraphIndex === 1, JSON.stringify(c1.paragraphIndex))
+    const cNone = await exec('get_bookmark_context', { name: 'EVID_NOPE' })
+    check('不存在的书签 exists=false 且 success', cNone.success === true && cNone.exists === false && cNone.paragraphIndex === -1, JSON.stringify(cNone))
+
+    // 4. 二级标题下的选区：标题链两级拼接
+    await exec('select_paragraph', { index: 3 })
+    const b2 = await exec('bookmark_selection', { name: 'EVID_TEST2' })
+    check('第二个书签成功', b2.success === true && b2.text === '收购人注册资本1000万元。', JSON.stringify(b2))
+    const c2 = await exec('get_bookmark_context', { name: 'EVID_TEST2' })
+    check('sectionPath 两级拼接', c2.exists === true && c2.sectionPath === '一、主体资格/（一）基本情况' && c2.sectionTitle === '（一）基本情况' && c2.paragraphIndex === 3, JSON.stringify(c2))
+
+    // 5. 书签内部插字：书签随文字扩张，别的书签不动。光标先收到书签末端再左移
+    // 一格（落在书签内部——正好在末端插入不会扩张书签）。
+    await exec('goto_bookmark', { name: 'EVID_TEST1' })
+    await exec('collapse_selection', { to: 'end' })
+    await exec('move_cursor', { dir: 'left' })
+    await exec('insert_at_cursor', { text: '（有限合伙）' })
+    const ck1 = await exec('check_link_anchors', { names: ['EVID_TEST1', 'EVID_TEST2'] })
+    const it1 = (ck1.items || []).find((x) => x.name === 'EVID_TEST1') || {}
+    const it2 = (ck1.items || []).find((x) => x.name === 'EVID_TEST2') || {}
+    check('check_link_anchors 返回两条', ck1.success === true && (ck1.items || []).length === 2, JSON.stringify(ck1))
+    check('书签内插字后 TEST1.text 含新字', it1.exists === true && it1.text.indexOf('（有限合伙）') >= 0, JSON.stringify(it1))
+    check('TEST2 不受影响', it2.exists === true && it2.text === '收购人注册资本1000万元。', JSON.stringify(it2))
+
+    // 6. 整段文字删除：书签成孤儿。真机实测（2026-08-21）：LO 把书签连同文字一起
+    // 删掉，exists:false（不是留空点书签）。宿主侧仍以「!exists || text===''」判
+    // orphan（见 .claude/agents/doc-editor.md「EvidenceLink 书签原语」）。
+    await exec('select_paragraph', { index: 3 })
+    await focus()
+    await key('Backspace', 'Backspace', 8)
+    const ck2 = await exec('check_link_anchors', { names: ['EVID_TEST2'] })
+    const gone = (ck2.items || [])[0] || {}
+    check('整段删除后 TEST2 书签随之消失（exists=false）', gone.name === 'EVID_TEST2' && gone.exists === false && gone.text === '', JSON.stringify(ck2))
+    check('整段删除后正文不再含原句', (await doc()).indexOf('注册资本1000万元') < 0, await doc())
+
+    // 7. 旧式超链接（filelink?k=）收编为书签
+    await exec('goto', { type: 'end' })
+    await exec('insert_at_cursor', { text: '收购人注册资本1000万元。' })
+    await selectText('注册资本')
+    const hl = await exec('set_selection_hyperlink', { url: 'https://checkba-internal.local/open?u=checkba%3A%2F%2Ffilelink%3Fk%3Dlk_old_1' })
+    check('旧式超链接已设置', hl.success === true && hl.text === '注册资本', JSON.stringify(hl))
+    const ad1 = await exec('adopt_legacy_links', {})
+    check('adopt_legacy_links 收编 lk_old_1', ad1.success === true && (ad1.adopted || []).indexOf('lk_old_1') >= 0, JSON.stringify(ad1))
+    const ad2 = await exec('adopt_legacy_links', {})
+    check('再次收编幂等（adopted 空、skipped>=1）', ad2.success === true && (ad2.adopted || []).length === 0 && ad2.skipped >= 1, JSON.stringify(ad2))
+    const cOld = await exec('get_bookmark_context', { name: 'lk_old_1' })
+    check('收编后的书签文字 = 链接文字', cOld.exists === true && cOld.text === '注册资本', JSON.stringify(cOld))
+
+    // 8. docx 往返：书签经 export/load 存活
+    await exec('clear_anchors', {})
+    const evBytes = await page.evaluate(async () => {
+      const r = await window.__loExecutor.executeCommand('export_document', { name: 'evidence.docx' })
+      return r && r.bytes ? Array.from(r.bytes) : null
+    })
+    check('导出字节非空', !!evBytes && evBytes.length > 0)
+    const ld = await exec('load_document', { bytes: evBytes, name: 'evidence-roundtrip.docx', authorName: '测试用户' })
+    check('重新载入成功', ld.success === true, JSON.stringify(ld).slice(0, 160))
+    const ck3 = await exec('check_link_anchors', { names: ['EVID_TEST1', 'lk_old_1'] })
+    check('往返后两枚书签都在', ck3.success === true && (ck3.items || []).length === 2 && ck3.items.every((x) => x.exists === true), JSON.stringify(ck3))
+    check('往返后 TEST1 文字仍含插入字', ((ck3.items || [])[0] || {}).text.indexOf('（有限合伙）') >= 0, JSON.stringify(ck3))
+
+    // 9. 跳转：选中书签范围；不存在的书签明确拒绝
+    const g1 = await exec('goto_bookmark', { name: 'EVID_TEST1' })
+    check('goto_bookmark 成功', g1.success === true, JSON.stringify(g1))
+    check('跳转后选区即书签文字', ((await exec('get_selection')).text || '').indexOf('收购人成立于') === 0, JSON.stringify(await exec('get_selection')))
+    const g0 = await exec('goto_bookmark', { name: 'NOPE' })
+    check('不存在的书签跳转被拒绝（双字段）', g0.success === false && !!g0.error && g0.message === g0.error, JSON.stringify(g0))
+  }
+
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
 } finally {
   await browser.close()


### PR DESCRIPTION
## 单元 B：worker 五原语 + lowa-e2e 证据锚点组（dev-board#103）

书签名 = linkKey，底稿关联挂在命名书签上跟着文字走。五个 host-initiated action，已入 `EDITOR_ACTIONS` 白名单（spec 写的「按名透传」不成立：`libreofficeExecutorClient.js` 对白名单外 action 直接拒绝 `Unknown action`）；失败一律 `bmFail()` 双字段 `error`+`message`。

| action | 参数 | 返回 |
|---|---|---|
| `bookmark_selection` | `{name}` | `{success, name, text}`；空选区 / 名不合 `[A-Za-z0-9_]{1,64}` / 重名精确拒绝（`error` 含 `exists`） |
| `get_bookmark_context` | `{name}` | `{success, exists, text, sectionPath, sectionTitle, paragraphIndex}`；不存在 → `exists:false, paragraphIndex:-1`（success） |
| `check_link_anchors` | `{names[]}` | `{success, items:[{name, exists, text}]}`，单次 ≤200 |
| `adopt_legacy_links` | `{}` | `{success, adopted:[name], skipped}`；收编 `filelink?k=<key>` 超链接 run，幂等 |
| `goto_bookmark` | `{name}` | `{success, name}` / `{success:false, error, message}` |

### 真机实测结论（写进 `.claude/agents/doc-editor.md` 新节「EvidenceLink 书签原语」）
- 第 6 步：书签覆盖的文字整段删除后 **LO 连书签一起删**，`exists:false`，不留空点书签。宿主 orphan 判定仍用 `!exists || text===''`。
- 正好在书签末端插字不扩张书签，内部插字扩张；docx 往返存活。
- TextPortion 直接喂 `insertTextContent` 抛 IllegalArgumentException，改为先收集目标、再 `createTextCursorByRange(start)+gotoRange(end,true)` 套书签。

### e2e
`npm run test:lowa-e2e` 新增组 27「EvidenceLink 证据锚点」27 步；总步数 390 → **417 全绿**（既有 26 组无变红）。README 与 doc-editor.md 基线已更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
