### PR TITLE
docs(dd): P1 设计定稿（插件宿主 SPI + 尽调 JAR 插件）

### DIFF
--- a/docs/superpowers/plans/2026-08-21-evidence-link-p0.md
+++ b/docs/superpowers/plans/2026-08-21-evidence-link-p0.md
@@ -1,0 +1,989 @@
+# EvidenceLink P0（内置底座）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把「报告文字 ↔ 底稿文件」关联从一张 `linkKey→fileIdsJson` 表升级成有书签锚点、有目标位置、可双向查询、有状态机的内置事实表，并补齐规模底座前 6 条与大文档 e2e 基线。
+
+**Architecture:** 后端新表 `evidence_link` / `evidence_link_target` + `EvidenceLinkService` 单一出口 + 启动迁移；worker 五个书签原语把锚点从字符属性升级为命名书签；前端拖拽建链改到编辑器区域、点击链接按 targetId 定位、审阅面板加「证据」页、改字后 worker 核对书签回写 stale；SDK 加三方法；稳定性改造与大文档基线组独立成单元。
+
+**Tech Stack:** Spring Boot 3 / JPA（H2 desktop + PG cloud，ddl-auto update）/ JUnit5+Mockito；uni-app Vue3 + `node --test`；LibreOffice WASM worker（zetajs）+ puppeteer lowa-e2e；Ed25519 签名的 Web 插件 SDK（postMessage）。
+
+**Spec:** `docs/superpowers/specs/2026-08-21-evidence-link-p0-design.md`（下称 SPEC）
+
+## Global Constraints
+
+- 全局禁 emoji（代码/UI/文档/commit）。
+- worktree 内编辑与构建同树；`mvn` 用 JDK 21（`JAVA_HOME=$(/usr/libexec/java_home -v 21)`）；前端 npm。
+- `docs/` 在 .gitignore，入库用 `git add -f`。
+- 新增 worker action 后必须 `npm run build:zetaoffice` 再跑 lowa-e2e（测试 serve 的是 dist）。
+- worker 失败返回同时写 `message` 与 `error`。
+- 段落索引 0 基；locator 页码 1 基；坐标 0..1。
+- 书签名 = linkKey，新建 `EVID_<ULID 26 位>`，只含 `[A-Za-z0-9_]`。
+- 新增 @Component 工具 / 构造器参数要同步 `RealToolBeans` 与 EvalHarness（本期无 AI 工具，但改 `EditorBridgeService` 构造要查 EvalHarness）。
+- `check:emits` 必须绿；新增 `$emit` 要在 `emits:` 声明。
+- 商业化：本期全部内置、不门控。
+- 同一棵 worktree 同时只跑一个改文件的 agent；单元 A-G 各一棵 worktree。
+- 提交信息尾行 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+
+## 单元与合并顺序
+
+| 单元 | 看板 | 分支 | 依赖 | 模型档 |
+|---|---|---|---|---|
+| A 后端表/Service/REST/迁移 | #102 | `feat/evidence-link-backend` | 无 | 主模型（契约） |
+| B worker 五原语 + e2e 证据锚点组 | #103 | `feat/evidence-link-worker` | 无 | 主模型（契约） |
+| C 拖拽建链 + method 小条 + 定位 | #104 | `feat/evidence-link-drop-locate` | A、B 契约（可先按契约写，合并前 rebase） | 主模型 |
+| D 审阅面板证据页 + stale 弹窗 | #105 | `feat/evidence-link-panel` | A、B 契约 | 主模型 |
+| E SDK 三方法 + 宿主 + 官网 | #106 | `feat/evidence-link-sdk` | A 契约 | 主模型（契约）；官网搬运 Sonnet |
+| F 稳定性 #1/#2/#6 | #107 | `fix/scale-import-create-tree` | 无 | Sonnet 低档写，校验主模型 |
+| G 稳定性 #3/#4/#5 + 大文档组 | #108 | `perf/worker-batching-big-doc` | 无（与 B 同文件 office_thread.js，**后合者 rebase**） | 主模型 |
+
+合并顺序 A → B → 其余任意。每单元一个 PR，auto-merge。
+
+## File Structure
+
+**后端（A）**
+- Create `backend/src/main/java/com/checkba/model/entity/EvidenceLink.java` — 主表实体
+- Create `backend/src/main/java/com/checkba/model/entity/EvidenceLinkTarget.java` — 子表实体
+- Create `backend/src/main/java/com/checkba/repository/EvidenceLinkRepository.java` / `EvidenceLinkTargetRepository.java`
+- Create `backend/src/main/java/com/checkba/service/evidence/AnchorHash.java` — 归一化 + sha256（纯函数）
+- Create `backend/src/main/java/com/checkba/service/evidence/Ulid.java` — 26 位 Crockford ULID
+- Create `backend/src/main/java/com/checkba/service/evidence/EvidenceLinkService.java` — 单一出口
+- Create `backend/src/main/java/com/checkba/service/evidence/EvidenceLinkViews.java` — `LinkView` / `TargetView` / `TargetInput` record
+- Create `backend/src/main/java/com/checkba/service/evidence/EvidenceLinkMigrationRunner.java` — doc_file_link → 新表
+- Create `backend/src/main/java/com/checkba/controller/EvidenceLinkController.java` — `/api/projects/{pid}/evidence-links`
+- Modify `backend/src/main/java/com/checkba/controller/DocFileLinkController.java` — 改只读代理
+- Modify `backend/src/main/java/com/checkba/model/entity/ProjectFile.java` — 加 `metaJson`
+- Modify `backend/src/main/java/com/checkba/service/ProjectFileService.java` — 彻底删除时级联
+- Modify `backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java` `doc_set_hyperlink` 白名单 + `office_thread.js set_hyperlink_at_anchor` 白名单（B 顺手）
+- Test `backend/src/test/java/com/checkba/service/evidence/{AnchorHashTest,UlidTest,EvidenceLinkServiceTest,EvidenceLinkMigrationRunnerTest}.java`
+- Create `backend/src/test/resources/fixtures/anchor-hash-vectors.json`（前端同一份拷贝 `frontend/tests/evidence/anchor-hash-vectors.json`，`AnchorHashParityTest` 比对两份 sha256 相同）
+
+**worker（B）**
+- Modify `frontend/src/zetaoffice/public/office_thread.js` — 五原语 + `set_hyperlink_at_anchor` 白名单
+- Modify `frontend/tests/lowa-e2e/run.mjs` — 新组「证据锚点」
+
+**前端（C/D）**
+- Create `frontend/src/utils/anchorHash.js`、`frontend/src/utils/ulid.js`、`frontend/src/utils/evidenceLocator.js`（locator 摘要文案）
+- Create `frontend/src/pages/project-overview/evidenceLinkActions.js` — drop 四步、链接解包、打开定位（替代 project-overview.vue 里 `createWpsSelectionFileLink` / `openFileLinkTarget`）
+- Create `frontend/src/components/EvidenceMethodBar.vue`、`EvidencePanel.vue`、`EvidenceStaleBar.vue`
+- Modify `frontend/src/components/LibreOfficeEditor.vue` — drop 接收、`pendingLocator` 消费、stale 检测、证据 tab 数据流
+- Modify `frontend/src/components/ReviewPanel.vue` — 第三 tab 壳
+- Modify `frontend/src/components/FilePreview.vue` — pdf `#page=` / 图片框 / 媒体 seek
+- Modify `frontend/src/pages/project-overview/fileOpenTabs.js` — `openFile(file, opts)`
+- Modify `frontend/src/pages/project-overview/project-overview.vue` — 删 FileLinkDropZone、接新模块
+- Delete `frontend/src/components/FileLinkDropZone.vue`
+- Modify `frontend/src/services/api.js` — evidence-links 封装
+- Modify `frontend/src/locales/zh-CN/*.json` 与 `en-US/*.json` — 新词条
+- Test `frontend/tests/evidence/*.test.mjs`（`npm run test:evidence` 新脚本）
+
+**SDK（E）**
+- Modify `sdk/plugin-sdk/awd-plugin-sdk.js`、`examples/hello-web-plugin/awd-plugin-sdk.js`、`frontend/src/components/PluginPane.vue`、`docs/PLUGIN_SPEC.md`；官网仓 `lib/plugin-template.ts` + 模拟器（另一个仓，PR 单开）
+
+**稳定性（F/G）**
+- Modify `LocalProjectService.java`、`ProjectFileService.java`、`ProjectFileRepository.java`、`FileTree.vue`、`EditorBridgeService.java`、`office_thread.js`、`libreofficeExecutorClient.js`、`zetaOfficeRelay.js`
+- Create `frontend/tests/lowa-e2e/fixtures/gen-big-doc.py`、`frontend/tests/lowa-e2e/big-doc.mjs`
+
+---
+
+# 单元 A：后端 EvidenceLink（#102）
+
+### Task A1: AnchorHash 与 Ulid 纯函数
+
+**Files:**
+- Create: `backend/src/main/java/com/checkba/service/evidence/AnchorHash.java`
+- Create: `backend/src/main/java/com/checkba/service/evidence/Ulid.java`
+- Create: `backend/src/test/resources/fixtures/anchor-hash-vectors.json`
+- Test: `backend/src/test/java/com/checkba/service/evidence/AnchorHashTest.java`、`UlidTest.java`
+
+**Interfaces:**
+- Produces: `AnchorHash.normalize(String) -> String`、`AnchorHash.of(String) -> String`（64 位小写 hex）；`Ulid.next() -> String`（26 位大写 Crockford）。前端 `utils/anchorHash.js` 必须对同一向量产出同一 hash。
+
+- [ ] **Step 1: 写向量文件**
+
+`backend/src/test/resources/fixtures/anchor-hash-vectors.json`：
+```json
+[
+  { "in": "根据《营业执照》，收购人成立于 2020 年。", "norm": "根据《营业执照》,收购人成立于2020年." },
+  { "in": "  根据《营业执照》，\n收购人成立于 2020 年。", "norm": "根据《营业执照》,收购人成立于2020年." },
+  { "in": "ＡＢＣ（全角）", "norm": "ABC(全角)" },
+  { "in": "", "norm": "" }
+]
+```
+归一化规则（两端都按这个实现）：NFKC → 删除全部 Unicode 空白（`\s` 与 U+3000）→ 中文标点映射 `，→,` `。→.` `；→;` `：→:` `！→!` `？→?` `（→(` `）→)` `「」『』“”‘’→` 删除（引号一律删）→ 保留《》书名号。
+
+- [ ] **Step 2: 写失败测试**
+
+```java
+package com.checkba.service.evidence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import java.io.InputStream;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnchorHashTest {
+    @Test
+    void normalizeMatchesVectors() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/fixtures/anchor-hash-vectors.json")) {
+            for (JsonNode v : new ObjectMapper().readTree(in)) {
+                assertEquals(v.get("norm").asText(), AnchorHash.normalize(v.get("in").asText()), v.get("in").asText());
+            }
+        }
+    }
+    @Test
+    void hashIs64Hex() {
+        assertTrue(AnchorHash.of("abc").matches("[0-9a-f]{64}"));
+        assertEquals(AnchorHash.of("a b"), AnchorHash.of("ab"));
+        assertNotEquals(AnchorHash.of("ab"), AnchorHash.of("ac"));
+    }
+}
+```
+```java
+class UlidTest {
+    @Test void shape() { String u = Ulid.next(); assertEquals(26, u.length()); assertTrue(u.matches("[0-9A-HJKMNP-TV-Z]{26}")); }
+    @Test void monotonicWithinMillisIsNotRequiredButUnique() {
+        java.util.Set<String> s = new java.util.HashSet<>();
+        for (int i = 0; i < 10000; i++) assertTrue(s.add(Ulid.next()));
+    }
+}
+```
+
+- [ ] **Step 3: 跑测试确认红**
+
+Run: `cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q test -Dtest='AnchorHashTest,UlidTest'`
+Expected: 编译失败（类不存在）
+
+- [ ] **Step 4: 实现**
+
+```java
+package com.checkba.service.evidence;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.text.Normalizer;
+import java.util.Map;
+
+/** 锚点文字归一化 + sha256。前端 utils/anchorHash.js 是同一算法，改一处必须同步另一处并更新向量。 */
+public final class AnchorHash {
+    private static final Map<Character, String> PUNCT = Map.ofEntries(
+            Map.entry('，', ","), Map.entry('。', "."), Map.entry('；', ";"), Map.entry('：', ":"),
+            Map.entry('！', "!"), Map.entry('？', "?"), Map.entry('（', "("), Map.entry('）', ")"),
+            Map.entry('「', ""), Map.entry('」', ""), Map.entry('『', ""), Map.entry('』', ""),
+            Map.entry('“', ""), Map.entry('”', ""), Map.entry('‘', ""), Map.entry('’', ""),
+            Map.entry('"', ""), Map.entry('\'', ""));
+    private AnchorHash() {}
+    public static String normalize(String s) {
+        if (s == null) return "";
+        String n = Normalizer.normalize(s, Normalizer.Form.NFKC);
+        StringBuilder b = new StringBuilder(n.length());
+        for (int i = 0; i < n.length(); i++) {
+            char c = n.charAt(i);
+            if (Character.isWhitespace(c) || c == '　') continue;
+            String m = PUNCT.get(c);
+            if (m != null) b.append(m); else b.append(c);
+        }
+        return b.toString();
+    }
+    public static String of(String s) {
+        try {
+            byte[] d = MessageDigest.getInstance("SHA-256").digest(normalize(s).getBytes(StandardCharsets.UTF_8));
+            StringBuilder h = new StringBuilder(64);
+            for (byte x : d) h.append(String.format("%02x", x));
+            return h.toString();
+        } catch (Exception e) { throw new IllegalStateException(e); }
+    }
+}
+```
+注意：NFKC 会把全角逗号 `，`(U+FF0C) 归成 `,`，所以 PUNCT 里的 `，` 分支实际很少命中；`。`(U+3002) NFKC 不变，必须靠表。向量第 1 条就是为了钉这个。
+
+```java
+package com.checkba.service.evidence;
+
+import java.security.SecureRandom;
+
+/** 26 位 Crockford base32 ULID：前 10 位毫秒时间戳，后 16 位随机。只用于书签名，不追求单调。 */
+public final class Ulid {
+    private static final char[] ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ".toCharArray();
+    private static final SecureRandom RND = new SecureRandom();
+    private Ulid() {}
+    public static String next() {
+        char[] out = new char[26];
+        long t = System.currentTimeMillis();
+        for (int i = 9; i >= 0; i--) { out[i] = ALPHABET[(int) (t & 31)]; t >>>= 5; }
+        byte[] r = new byte[10]; RND.nextBytes(r);
+        long a = 0; for (int i = 0; i < 5; i++) a = (a << 8) | (r[i] & 0xff);
+        long b = 0; for (int i = 5; i < 10; i++) b = (b << 8) | (r[i] & 0xff);
+        for (int i = 17; i >= 10; i--) { out[i] = ALPHABET[(int) (a & 31)]; a >>>= 5; }
+        for (int i = 25; i >= 18; i--) { out[i] = ALPHABET[(int) (b & 31)]; b >>>= 5; }
+        return new String(out);
+    }
+}
+```
+
+- [ ] **Step 5: 跑测试确认绿** 同 Step 3 命令，Expected: PASS
+
+- [ ] **Step 6: Commit**
+```bash
+git add backend/src/main/java/com/checkba/service/evidence backend/src/test
+git commit -m "feat(evidence): AnchorHash 归一化与 Ulid 纯函数 + 前后端共用向量"
+```
+
+### Task A2: 实体与 Repository
+
+**Files:**
+- Create: `model/entity/EvidenceLink.java`、`model/entity/EvidenceLinkTarget.java`
+- Create: `repository/EvidenceLinkRepository.java`、`repository/EvidenceLinkTargetRepository.java`
+- Modify: `model/entity/ProjectFile.java`（加 `metaJson`）
+
+**Interfaces:**
+- Produces: 实体字段见 SPEC §1.1/§1.2；`EvidenceLinkRepository.findByProjectIdAndLinkKey`、`findByProjectIdAndDocFileIdOrderByIdAsc`、`findByProjectIdAndDocFileIdAndStatus`、`findByProjectIdAndDocFileIdAndSectionPathStartingWith`、`findByProjectIdAndIdIn`；`EvidenceLinkTargetRepository.findByLinkIdOrderBySortOrderAscIdAsc`、`findByLinkIdIn`、`findByFileId`、`findByFileIdIn`、`existsByLinkIdAndFileIdAndLocatorHash`、`countByFileIdIn`（返回 `List<Object[]>{fileId,count}` 的 @Query）。
+
+- [ ] **Step 1: 写实体**
+
+```java
+@Entity
+@Table(name = "evidence_link", indexes = {
+        @Index(name = "idx_evl_project_key", columnList = "project_id,link_key", unique = true),
+        @Index(name = "idx_evl_doc", columnList = "project_id,doc_file_id"),
+        @Index(name = "idx_evl_section", columnList = "project_id,doc_file_id,section_path")
+})
+@Getter @Setter
+public class EvidenceLink {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
+    @Column(name = "project_id", nullable = false) private Long projectId;
+    @Column(name = "doc_file_id", nullable = false) private Long docFileId;
+    @Column(name = "link_key", length = 64, nullable = false) private String linkKey;
+    @Column(name = "anchor_text", length = 1000) private String anchorText;
+    @Column(name = "anchor_hash", length = 64) private String anchorHash;
+    @Column(name = "section_path", length = 512) private String sectionPath;
+    @Column(name = "section_title", length = 512) private String sectionTitle;
+    @Column(length = 16, nullable = false) private String status = STATUS_ACTIVE;
+    @Column(name = "created_by_kind", length = 8, nullable = false) private String createdByKind = KIND_HUMAN;
+    @Column(name = "created_by") private Long createdBy;
+    @Column(name = "created_at") private LocalDateTime createdAt;
+    @Column(name = "updated_at") private LocalDateTime updatedAt;
+    @Column(name = "checked_at") private LocalDateTime checkedAt;
+
+    public static final String STATUS_ACTIVE = "active", STATUS_UNVERIFIED = "unverified",
+            STATUS_STALE = "stale", STATUS_ORPHAN = "orphan";
+    public static final String KIND_HUMAN = "human", KIND_AI = "ai", KIND_PLUGIN = "plugin";
+}
+```
+`EvidenceLinkTarget`：`id, linkId, fileId, locatorJson(TEXT), locatorHash(64 not null), relation(16 not null, 默认 "supports"), method(16), confidence(Short), note(512), sortOrder(Integer 默认 0), createdByKind(8), createdBy, createdAt`；索引 `idx_evt_link(link_id)`、`idx_evt_file(file_id)`、唯一 `idx_evt_dedupe(link_id,file_id,locator_hash)`。常量 `RELATIONS = Set.of("supports","contradicts","partial")`、`METHODS = Set.of("written_review","written_statement","web_check","third_party","interview")`。
+
+Lombok 在本仓已用（`@RequiredArgsConstructor`/`@Data` 见 DocFileLinkService），`@Getter @Setter` 可用。
+
+`ProjectFile.java` 加：
+```java
+/** 来源元数据（JSON）：网核截图 {sourceUrl, capturedAt, provider}；P1 起 {docketNo}。无则 null。 */
+@Column(name = "meta_json", columnDefinition = "TEXT")
+private String metaJson;
+```
+加 getter/setter（该类是手写 getter/setter 风格，照旧）。
+
+- [ ] **Step 2: 写 Repository**
+
+```java
+public interface EvidenceLinkRepository extends JpaRepository<EvidenceLink, Long> {
+    Optional<EvidenceLink> findByProjectIdAndLinkKey(Long projectId, String linkKey);
+    List<EvidenceLink> findByProjectIdAndDocFileIdOrderByIdAsc(Long projectId, Long docFileId);
+    List<EvidenceLink> findByProjectIdAndDocFileIdAndStatusOrderByIdAsc(Long projectId, Long docFileId, String status);
+    List<EvidenceLink> findByProjectIdAndDocFileIdAndSectionPathStartingWithOrderByIdAsc(Long projectId, Long docFileId, String prefix);
+    List<EvidenceLink> findByProjectIdAndIdIn(Long projectId, Collection<Long> ids);
+    long countByProjectId(Long projectId);
+}
+public interface EvidenceLinkTargetRepository extends JpaRepository<EvidenceLinkTarget, Long> {
+    List<EvidenceLinkTarget> findByLinkIdOrderBySortOrderAscIdAsc(Long linkId);
+    List<EvidenceLinkTarget> findByLinkIdInOrderBySortOrderAscIdAsc(Collection<Long> linkIds);
+    List<EvidenceLinkTarget> findByFileId(Long fileId);
+    List<EvidenceLinkTarget> findByFileIdIn(Collection<Long> fileIds);
+    boolean existsByLinkIdAndFileIdAndLocatorHash(Long linkId, Long fileId, String locatorHash);
+    void deleteByLinkId(Long linkId);
+    @Query("select t.fileId, count(t) from EvidenceLinkTarget t where t.fileId in :fileIds group by t.fileId")
+    List<Object[]> countByFileIds(@Param("fileIds") Collection<Long> fileIds);
+}
+```
+
+- [ ] **Step 3: 编译** `mvn -q compile` Expected: 通过
+- [ ] **Step 4: Commit** `git commit -m "feat(evidence): evidence_link/evidence_link_target 实体与 Repository；ProjectFile.metaJson"`
+
+### Task A3: EvidenceLinkService（TDD）
+
+**Files:**
+- Create: `service/evidence/EvidenceLinkViews.java`、`service/evidence/EvidenceLinkService.java`
+- Test: `service/evidence/EvidenceLinkServiceTest.java`（Mockito，仿 `TagServiceTest`）
+
+**Interfaces:**
+- Produces（供 Controller/SDK/P1 工具调用）:
+```java
+record TargetInput(Long fileId, String locatorJson, String relation, String method, Short confidence, String note) {}
+record TargetView(Long id, Long fileId, FileBrief file, JsonNode locator, String relation, String method, Short confidence, String note) {}
+record FileBrief(Long id, String name, String fileType, Long parentId, boolean isDeleted) {}
+record LinkView(Long id, String linkKey, Long docFileId, String anchorText, String anchorHash, String sectionPath, String sectionTitle,
+                String status, String createdByKind, LocalDateTime createdAt, LocalDateTime updatedAt, List<TargetView> targets) {}
+record AnchorReport(String linkKey, boolean exists, String text) {}
+
+LinkView create(Long userId, Long projectId, Long docFileId, String linkKey, String anchorText, String sectionPath, String sectionTitle, String createdByKind, List<TargetInput> targets)
+LinkView addTargets(Long userId, Long projectId, String linkKey, List<TargetInput> targets)
+TargetView updateTarget(Long userId, Long projectId, Long targetId, TargetInput patch)   // null 字段 = 不改
+void removeTarget(Long userId, Long projectId, Long targetId)
+void delete(Long userId, Long projectId, String linkKey)
+LinkView getByKey(Long userId, Long projectId, String linkKey)
+List<LinkView> listByDoc(Long userId, Long projectId, Long docFileId, String status, String sectionPathPrefix)
+List<LinkView> listByFile(Long userId, Long projectId, Long fileId)
+List<LinkView> listByParty(Long userId, Long projectId, Long docFileId, Long tagId)
+List<String> reportAnchors(Long userId, Long projectId, Long docFileId, List<AnchorReport> reports)  // 返回状态变了的 linkKey
+LinkView keepAnchor(Long userId, Long projectId, String linkKey)
+LinkView rebind(Long userId, Long projectId, String linkKey, String newLinkKey, String anchorText, String sectionPath, String sectionTitle)
+Map<Long, Long> refCounts(Long projectId, Collection<Long> fileIds)
+void onFilePurged(Long projectId, Long fileId)   // ProjectFileService 彻底删除时调用
+```
+- Consumes: `ProjectMemberService.hasReadPermission/hasWritePermission`、`ProjectFileRepository.findById/findAllById`、`FileTagRepository.findByTagId`、`AnchorHash`、`Ulid`。
+
+- [ ] **Step 1: 写失败测试（覆盖下列行为，每条一个 @Test）**
+
+```java
+class EvidenceLinkServiceTest {
+    EvidenceLinkRepository links = mock(EvidenceLinkRepository.class);
+    EvidenceLinkTargetRepository targets = mock(EvidenceLinkTargetRepository.class);
+    ProjectFileRepository files = mock(ProjectFileRepository.class);
+    FileTagRepository fileTags = mock(FileTagRepository.class);
+    ProjectMemberService members = mock(ProjectMemberService.class);
+    EvidenceLinkService svc;
+
+    @BeforeEach void setUp() {
+        svc = new EvidenceLinkService(links, targets, files, fileTags, members, new ObjectMapper());
+        when(members.hasReadPermission(1L, 9L)).thenReturn(true);
+        when(members.hasWritePermission(1L, 9L)).thenReturn(true);
+        when(links.save(any())).thenAnswer(inv -> { EvidenceLink l = inv.getArgument(0); if (l.getId()==null) l.setId(100L); return l; });
+        when(targets.save(any())).thenAnswer(inv -> { EvidenceLinkTarget t = inv.getArgument(0); if (t.getId()==null) t.setId(200L); return t; });
+        ProjectFile doc = file(10L, 1L, "报告.docx"); ProjectFile pdf = file(11L, 1L, "执照.pdf");
+        when(files.findById(10L)).thenReturn(Optional.of(doc));
+        when(files.findById(11L)).thenReturn(Optional.of(pdf));
+        when(files.findAllById(any())).thenAnswer(inv -> { List<ProjectFile> out = new ArrayList<>(); for (Object id : (Iterable<?>) inv.getArgument(0)) files.findById((Long) id).ifPresent(out::add); return out; });
+    }
+    static ProjectFile file(long id, long pid, String name) { ProjectFile f = new ProjectFile(); f.setId(id); f.setProjectId(pid); f.setName(name); f.setIsDeleted(false); return f; }
+
+    @Test void createGeneratesEvidKeyAndActiveForHuman() {
+        var v = svc.create(9L, 1L, 10L, null, "根据《营业执照》", "一/（一）", "主体资格", "human",
+                List.of(new EvidenceLinkService.TargetInput(11L, "{\"type\":\"pdf\",\"page\":1}", null, "written_review", null, null)));
+        assertTrue(v.linkKey().startsWith("EVID_")); assertEquals(31, v.linkKey().length());
+        assertEquals("active", v.status()); assertEquals(AnchorHash.of("根据《营业执照》"), v.anchorHash());
+        assertEquals(1, v.targets().size()); assertEquals("supports", v.targets().get(0).relation());
+    }
+    @Test void createByAiIsUnverified() { /* createdByKind="ai" → status unverified */ }
+    @Test void createRejectsForeignFile() { /* files.findById(11L) 返回 projectId=2 → IllegalArgumentException，不 save */ }
+    @Test void createRejectsBadRelationOrMethod() { /* relation="maybe" / method="guess" → IllegalArgumentException */ }
+    @Test void createRejectsContradictsWithoutTarget() { /* targets 空且 relation contradicts 无意义：targets 为空列表 → IllegalArgumentException("至少一个底稿") */ }
+    @Test void createRejectsNonMember() { /* hasWritePermission false → IllegalArgumentException("无权限") */ }
+    @Test void addTargetsDedupesByLocatorHash() { /* existsByLinkIdAndFileIdAndLocatorHash true → 不 save，返回原 targets */ }
+    @Test void reportAnchorsTransitions() {
+        // active + text 变 → stale；unverified + text 变 → stale；stale + text 同 → 仍 stale；任何状态 exists=false → orphan；active + text 同 → 不变、checkedAt 更新
+    }
+    @Test void keepAnchorRefreshesHashAndActivates() { /* stale → active，anchorText/anchorHash 用 report 里最新 text（Service 在 reportAnchors 时把最新 text 暂存在 anchorText？不——keepAnchor 收 newText 参数由前端传 check_link_anchors 的 text */ }
+    @Test void rebindReplacesKeyAndActivates() { /* orphan → active，linkKey 换成新值，唯一冲突 → IllegalArgumentException */ }
+    @Test void onFilePurgedCascades() { /* 删 target；该 link 无 target 后 status=orphan */ }
+    @Test void listByPartyFiltersByTag() { /* fileTags.findByTagId(5L) → fileId 11 → 只返回含该 target 的 link */ }
+    @Test void refCountsMapsRows() { /* countByFileIds 返回 [[11L,3L]] → {11:3} */ }
+}
+```
+`keepAnchor` 签名修正为 `keepAnchor(userId, projectId, linkKey, String currentText)`——前端把 `check_link_anchors` 返回的 `text` 一起传上来；Interfaces 块与 REST 随之同步（`POST /{linkKey}/keep` body `{text}`）。
+
+- [ ] **Step 2: 跑确认红** `mvn -q test -Dtest=EvidenceLinkServiceTest` Expected: 编译失败
+
+- [ ] **Step 3: 实现 Service（要点）**
+
+```java
+@Service @RequiredArgsConstructor
+public class EvidenceLinkService {
+    private final EvidenceLinkRepository links; private final EvidenceLinkTargetRepository targets;
+    private final ProjectFileRepository files; private final FileTagRepository fileTags;
+    private final ProjectMemberService members; private final ObjectMapper om;
+
+    private void requireRead(Long pid, Long uid) { if (uid == null || !members.hasReadPermission(pid, uid)) throw new IllegalArgumentException(LangText.of("无权限访问该项目", "No access to this project")); }
+    private void requireWrite(Long pid, Long uid) { if (uid == null || !members.hasWritePermission(pid, uid)) throw new IllegalArgumentException(LangText.of("无权限修改该项目", "No write access to this project")); }
+    private ProjectFile requireProjectFile(Long pid, Long fid) { ProjectFile f = fid == null ? null : files.findById(fid).orElse(null); if (f == null || !pid.equals(f.getProjectId())) throw new IllegalArgumentException(LangText.of("文件不属于该项目: ", "File not in project: ") + fid); return f; }
+    static String locatorHash(String json) { if (json == null || json.isBlank()) return "-"; return AnchorHash.of(canonical(json)); }
+    // canonical：Jackson 解析后按键排序再序列化（ObjectMapper ORDER_MAP_ENTRIES_BY_KEYS + 递归 TreeMap）；解析失败 → IllegalArgumentException("locatorJson 不是合法 JSON")
+
+    @Transactional public LinkView create(...) {
+        requireWrite(projectId, userId); requireProjectFile(projectId, docFileId);
+        if (targets == null || targets.isEmpty()) throw new IllegalArgumentException(LangText.of("至少关联一个底稿", "At least one target required"));
+        String key = StringUtils.hasText(linkKey) ? linkKey.trim() : "EVID_" + Ulid.next();
+        if (!key.matches("[A-Za-z0-9_]{1,64}")) throw new IllegalArgumentException("linkKey 只能含字母数字下划线");
+        if (links.findByProjectIdAndLinkKey(projectId, key).isPresent()) throw new IllegalArgumentException(LangText.of("链接已存在: ", "Link exists: ") + key);
+        EvidenceLink l = new EvidenceLink(); ...; l.setStatus(KIND_AI.equals(kind) ? STATUS_UNVERIFIED : STATUS_ACTIVE); l.setAnchorHash(AnchorHash.of(anchorText)); ...
+        l = links.save(l); int order = 0; for (TargetInput t : targets) saveTarget(projectId, l, t, order++, kind, userId);
+        return view(l);
+    }
+    // reportAnchors：按 linkKey 批量取；exists=false → orphan；否则 hash(text) != anchorHash 且 status in (active,unverified,stale) → stale；checkedAt=now；返回变化的 key
+    // keepAnchor：status→active，anchorText=currentText，anchorHash=of(currentText)
+    // view()：targets 一次 findByLinkIdIn + files.findAllById 批量，不 N+1
+}
+```
+
+- [ ] **Step 4: 跑确认绿**；补 `mvn -q test -Dtest='EvidenceLinkServiceTest,AnchorHashTest'`
+- [ ] **Step 5: Commit** `git commit -m "feat(evidence): EvidenceLinkService 单一出口——建链/追加/反查/状态机/权限"`
+
+### Task A4: 迁移 Runner + ProjectFileService 级联
+
+**Files:**
+- Create: `service/evidence/EvidenceLinkMigrationRunner.java`
+- Modify: `service/ProjectFileService.java`（彻底删除路径调用 `evidenceLinkService.onFilePurged`；软删不动）
+- Test: `service/evidence/EvidenceLinkMigrationRunnerTest.java`
+
+- [ ] **Step 1: 失败测试**
+```java
+@Test void migratesEachDocFileLinkRowOnce() {
+    // doc_file_link 两行：A(wpsFileId "w1" → ProjectFile 10, fileIds [11,12]) B(wpsFileId 查不到)
+    // 期望：links.save 1 次（key 原值 lk_x，status unverified，createdByKind human）、targets.save 2 次；B 跳过计数 1
+    // 第二次 run：links.countByProjectId>0 → 什么都不做
+}
+```
+- [ ] **Step 2: 实现**
+```java
+@Component @RequiredArgsConstructor @Slf4j
+public class EvidenceLinkMigrationRunner implements ApplicationRunner {
+    private final DocFileLinkRepository old; private final EvidenceLinkRepository links; private final EvidenceLinkTargetRepository targets;
+    private final ProjectFileRepository files; private final ObjectMapper om;
+    @Override @Transactional public void run(ApplicationArguments args) {
+        if (links.count() > 0) return;
+        List<DocFileLink> rows; try { rows = old.findAll(); } catch (Exception e) { log.info("doc_file_link 不存在，跳过迁移"); return; }
+        int ok = 0, skipped = 0;
+        for (DocFileLink r : rows) {
+            ProjectFile doc = files.findByProjectIdAndWpsFileId(r.getProjectId(), r.getDocWpsFileId()).orElse(null); // 若 Repository 无此方法则加
+            if (doc == null) { skipped++; continue; }
+            EvidenceLink l = new EvidenceLink(); l.setProjectId(r.getProjectId()); l.setDocFileId(doc.getId()); l.setLinkKey(r.getLinkKey());
+            l.setAnchorText(r.getAnchorText()); l.setAnchorHash(AnchorHash.of(r.getAnchorText())); l.setStatus(EvidenceLink.STATUS_UNVERIFIED);
+            l.setCreatedByKind(EvidenceLink.KIND_HUMAN); l.setCreatedBy(r.getUserId()); l.setCreatedAt(r.getCreatedAt()); l.setUpdatedAt(LocalDateTime.now());
+            l = links.save(l);
+            List<Long> ids = parse(r.getFileIdsJson()); int order = 0;
+            for (Long fid : ids) { EvidenceLinkTarget t = new EvidenceLinkTarget(); t.setLinkId(l.getId()); t.setFileId(fid); t.setLocatorHash("-"); t.setRelation("supports"); t.setSortOrder(order++); t.setCreatedByKind("human"); t.setCreatedBy(r.getUserId()); t.setCreatedAt(r.getCreatedAt()); targets.save(t); }
+            ok++;
+        }
+        log.info("EvidenceLink 迁移完成: migrated={}, skipped={}", ok, skipped);
+    }
+}
+```
+`ProjectFileRepository` 若没有 `findByProjectIdAndWpsFileId` 就加一个 `Optional<ProjectFile>`（先 grep）。
+- [ ] **Step 3: ProjectFileService 彻底删除处**：找到 `permanentlyDelete`/清空回收站的实现（grep `deleteById\|delete(` 在 ProjectFileService），在每个实体真删前调 `evidenceLinkService.onFilePurged(projectId, id)`。循环依赖：EvidenceLinkService 不注入 ProjectFileService，只注入 Repository，无环。
+- [ ] **Step 4: 跑 `mvn -q test -Dtest='EvidenceLink*'`**，再 `mvn -q test`（全量，约 2300 用例）确认无连带红
+- [ ] **Step 5: Commit** `git commit -m "feat(evidence): doc_file_link 启动迁移 + 彻底删除级联 orphan"`
+
+### Task A5: Controller + 旧控制器只读代理 + doc_set_hyperlink 白名单
+
+**Files:**
+- Create: `controller/EvidenceLinkController.java`
+- Modify: `controller/DocFileLinkController.java`（POST 删除或 410；GET 代理 `evidenceLinkService.getByKey` 并转成旧 `DocFileLinkResult` 形状——`files` = targets 的 file 去重）
+- Modify: `service/ai/tools/DocumentEditTools.java` `doc_set_hyperlink` 的 url 校验放行 `https://checkba-internal.local/open?u=checkba://filelink` 前缀
+- Test: `controller/EvidenceLinkControllerTest.java`（MockMvc standalone，仿既有 controller 测试；至少：未登录 401 信封、非成员拒绝、POST 建链 200、GET ?fileId 反查）
+
+- [ ] **Step 1: Controller**
+```java
+@RestController @RequestMapping("/api/projects/{projectId}/evidence-links") @RequiredArgsConstructor
+public class EvidenceLinkController {
+    private final EvidenceLinkService svc;
+    private Long uid(String sid) { Long u = AuthController.getUserIdFromSession(sid); if (u == null) throw new IllegalArgumentException("请先登录"); return u; }
+    @PostMapping public LinkView create(@PathVariable Long projectId, @RequestBody CreateReq r, @RequestHeader(value="X-Session-Id", required=false) String sid) {
+        return svc.create(uid(sid), projectId, r.docFileId, r.linkKey, r.anchorText, r.sectionPath, r.sectionTitle, r.createdByKind == null ? "human" : r.createdByKind, r.targets); }
+    @GetMapping public List<LinkView> list(@PathVariable Long projectId, @RequestParam(required=false) Long docFileId, @RequestParam(required=false) Long fileId,
+            @RequestParam(required=false) Long partyTagId, @RequestParam(required=false) String status, @RequestParam(required=false) String sectionPath, @RequestHeader(...) String sid) {
+        Long u = uid(sid);
+        if (fileId != null) return svc.listByFile(u, projectId, fileId);
+        if (docFileId == null) throw new IllegalArgumentException("docFileId 或 fileId 必填");
+        if (partyTagId != null) return svc.listByParty(u, projectId, docFileId, partyTagId);
+        return svc.listByDoc(u, projectId, docFileId, status, sectionPath);
+    }
+    @GetMapping("/ref-counts") public Map<Long, Long> refCounts(@PathVariable Long projectId, @RequestParam List<Long> fileIds, ...) { uid(sid)+requireRead; return svc.refCounts(projectId, fileIds); }
+    @GetMapping("/{linkKey}") ... getByKey
+    @PostMapping("/{linkKey}/targets") ... addTargets(body List<TargetInput>)
+    @PatchMapping("/targets/{targetId}") ... updateTarget
+    @DeleteMapping("/targets/{targetId}") ... removeTarget
+    @DeleteMapping("/{linkKey}") ... delete
+    @PostMapping("/anchors/report") ... reportAnchors(body {docFileId, reports:[{linkKey, exists, text}]}) → {changed:[...]}
+    @PostMapping("/{linkKey}/keep") ... keepAnchor(body {text})
+    @PostMapping("/{linkKey}/rebind") ... rebind(body {newLinkKey, anchorText, sectionPath, sectionTitle})
+}
+```
+`/ref-counts` 必须排在 `/{linkKey}` 之前注册没关系（Spring 按最具体匹配），但 linkKey 正则限制 `{linkKey:[A-Za-z0-9_]+}` 避免吃掉 `ref-counts`——`ref-counts` 含 `-`，不匹配，安全。
+- [ ] **Step 2: MockMvc 测试 → 红 → 实现 → 绿**
+- [ ] **Step 3: 更新 `.claude/agents/ai-doc-bridge.md`**：新增「EvidenceLink 契约」一节（表结构、状态机、locator schema、REST 表、worker 五原语名、AnchorHash 双端同步红线、书签名=linkKey、`filelink?k=&t=`）。直接把 SPEC §1/§2/§3/§5 的表压缩搬入。
+- [ ] **Step 4: 全量 `mvn -q test`；Commit；push；`gh pr create` + `gh pr merge --auto --squash`；看板 #102 写落实记录 → 待复测**（纯后端改动用户无感？否——它改变了点击链接的行为，保持待复测）。
+
+---
+
+# 单元 B：worker 五原语 + lowa-e2e 证据锚点组（#103）
+
+### Task B1: 五原语
+
+**Files:**
+- Modify: `frontend/src/zetaoffice/public/office_thread.js`（紧跟 `insert_link_with_bookmark` 之后，约 :3187）
+
+**Interfaces:**
+- Produces（action 名与返回形状是 C/D 的契约）：
+  - `bookmark_selection {name}` → `{success, name, text}` | `{success:false, error, message}`
+  - `get_bookmark_context {name}` → `{success, exists, text, sectionPath, sectionTitle, paragraphIndex}`
+  - `check_link_anchors {names[]}` → `{success, items:[{name, exists, text}]}`
+  - `adopt_legacy_links {}` → `{success, adopted:[name], skipped}`
+  - `goto_bookmark {name}` → `{success}` | 失败 `{success:false, error, message}`
+
+- [ ] **Step 1: 实现**
+```js
+  // ---- EvidenceLink 锚点原语（dev-board#103）：书签名 = linkKey ----------------
+  function bmFail(msg) { return { success: false, error: msg, message: msg }; }
+  function selectionRange() {
+    const sel = ctrl.getSelection(); let range = null;
+    try { if (sel && typeof sel.getByIndex === 'function' && sel.getCount() > 0) range = sel.getByIndex(0); } catch (e) {}
+    return range;
+  }
+  // 从 range 所在段落向前找标题链：OutlineLevel 1..6，每级只取最近一个，直到遇到 1 级或文首
+  function headingChainOf(range) {
+    const chain = []; // [{level, text}]
+    let seen = 99;
+    try {
+      const en = xModel.getText().createEnumeration();
+      const cmp = xModel.getText(); // XTextRangeCompare
+      const paras = [];
+      while (en.hasMoreElements()) { const el = en.nextElement(); if (el.supportsService && el.supportsService('com.sun.star.text.Paragraph')) paras.push(el); }
+      let idx = -1;
+      for (let i = 0; i < paras.length; i++) { if (cmp.compareRegionStarts(paras[i].getStart(), range.getStart()) >= 0 && cmp.compareRegionEnds(paras[i].getEnd(), range.getStart()) <= 0) { idx = i; break; } }
+      if (idx < 0) return { chain: [], paragraphIndex: -1 };
+      for (let i = idx; i >= 0 && seen > 1; i--) {
+        let lvl = 0; try { lvl = Number(paras[i].getPropertyValue('OutlineLevel')) || 0; } catch (e) {}
+        if (lvl > 0 && lvl < seen) { chain.unshift({ level: lvl, text: (paras[i].getString() || '').trim().slice(0, 200) }); seen = lvl; }
+      }
+      return { chain, paragraphIndex: idx };
+    } catch (e) { return { chain: [], paragraphIndex: -1 }; }
+  }
+```
+注意：`compareRegionStarts`/`compareRegionEnds` 对跨 story（表格单元格）会抛，外层已 try。表格内的选区 `paragraphIndex=-1`、sectionPath 为空——P0 接受（契约里说「不可靠时为空」）。
+
+```js
+  bookmark_selection(p) {
+    if (!isWriterDoc()) return bmFail(NOT_TEXT_DOC_MSG);
+    const name = String((p && p.name) || '');
+    if (!/^[A-Za-z0-9_]{1,64}$/.test(name)) return bmFail('bookmark name must match [A-Za-z0-9_]{1,64}');
+    const range = selectionRange();
+    const text = range ? (range.getString() || '') : '';
+    if (!range || !text.length) return bmFail('no selection to bookmark');
+    const bms = xModel.getBookmarks();
+    if (bms.hasByName(name)) return bmFail('bookmark exists: ' + name);
+    const bm = xModel.createInstance('com.sun.star.text.Bookmark'); bm.setName(name);
+    range.getText().insertTextContent(range, bm, true);
+    return { success: true, name: name, text: text };
+  },
+  get_bookmark_context(p) {
+    const name = String((p && p.name) || ''); const range = anchorRange(name);
+    if (!range) return { success: true, exists: false, text: '', sectionPath: '', sectionTitle: '', paragraphIndex: -1 };
+    const h = headingChainOf(range);
+    return { success: true, exists: true, text: range.getString() || '', sectionPath: h.chain.map(function (c) { return c.text; }).join('/'),
+             sectionTitle: h.chain.length ? h.chain[h.chain.length - 1].text : '', paragraphIndex: h.paragraphIndex };
+  },
+  check_link_anchors(p) {
+    const names = Array.isArray(p && p.names) ? p.names.slice(0, 200) : [];
+    const bms = xModel.getBookmarks(); const items = [];
+    for (let i = 0; i < names.length; i++) {
+      const n = String(names[i]); let exists = false, text = '';
+      try { if (bms.hasByName(n)) { exists = true; text = bms.getByName(n).getAnchor().getString() || ''; } } catch (e) {}
+      items.push({ name: n, exists: exists, text: text });
+    }
+    return { success: true, items: items };
+  },
+  adopt_legacy_links() {
+    if (!isWriterDoc()) return bmFail(NOT_TEXT_DOC_MSG);
+    const bms = xModel.getBookmarks(); const adopted = []; let skipped = 0;
+    try {
+      const en = xModel.getText().createEnumeration();
+      while (en.hasMoreElements()) {
+        const para = en.nextElement();
+        if (!para.supportsService || !para.supportsService('com.sun.star.text.Paragraph')) continue;
+        const pen = para.createEnumeration();
+        while (pen.hasMoreElements()) {
+          const portion = pen.nextElement(); let url = '';
+          try { url = String(portion.getPropertyValue('HyperLinkURL') || ''); } catch (e) { continue; }
+          const m = /filelink\?k=([A-Za-z0-9_%\-]+)/.exec(url); if (!m) continue;
+          const key = decodeURIComponent(m[1]).replace(/[^A-Za-z0-9_]/g, '_');
+          if (bms.hasByName(key)) { skipped++; continue; }
+          const bm = xModel.createInstance('com.sun.star.text.Bookmark'); bm.setName(key);
+          portion.getText().insertTextContent(portion, bm, true); adopted.push(key);
+        }
+      }
+    } catch (e) { return bmFail('adopt_legacy_links failed: ' + errStr(e)); }
+    return { success: true, adopted: adopted, skipped: skipped };
+  },
+  goto_bookmark(p) {
+    const name = String((p && p.name) || ''); const range = anchorRange(name);
+    if (!range) return bmFail('bookmark not found: ' + name);
+    if (!selectVisibly(range)) return bmFail('could not select bookmark: ' + name);
+    return { success: true };
+  },
+```
+同一 run 被多个相邻 portion 拆开（格式变化）时，只有第一个 portion 会被套书签（后面的 `hasByName` 命中 skipped）——书签覆盖不全但锚点有效；lowa-e2e 断言只验 `exists` 与文字前缀。
+
+- [ ] **Step 2: `set_hyperlink_at_anchor` 白名单**（:3150）：`if (!/^https?:\/\//i.test(url))` 保持，但这已放行 `https://checkba-internal.local/...`，无需改（后端 `doc_set_hyperlink` 的校验在 A5 放行）。核对即可。
+- [ ] **Step 3: `node --check frontend/src/zetaoffice/public/office_thread.js`**；`npm run build:zetaoffice`；`diff src/zetaoffice/public/office_thread.js dist/zetaoffice/office_thread.js`
+- [ ] **Step 4: Commit** `git commit -m "feat(lowa): EvidenceLink 书签锚点五原语 bookmark_selection/get_bookmark_context/check_link_anchors/adopt_legacy_links/goto_bookmark"`
+
+### Task B2: lowa-e2e 新组「证据锚点」
+
+**Files:**
+- Modify: `frontend/tests/lowa-e2e/run.mjs`（新组放在现有最后一组之后；看 README 里组的写法与步数基线）
+
+- [ ] **Step 1: 写组**（按 run.mjs 里既有 `group(...)`/`step(...)` 的辅助写；下面是逻辑）
+```
+1. load 空白 writer；type 三段："一、主体资格\n根据《营业执照》，收购人成立于2020年。\n（一）基本情况\n收购人注册资本1000万元。"
+   第 1 段与第 3 段用 set_paragraph_format 设 headingLevel 1 / 2（既有原语）。
+2. 选中「收购人成立于2020年」（find_text_locations → set_selection）；bookmark_selection {name:'EVID_TEST1'} → success；再调一次同名 → success:false 且 error 含 'exists'。
+3. get_bookmark_context {name:'EVID_TEST1'} → exists:true, text 前缀 '收购人成立于', sectionPath === '一、主体资格', paragraphIndex === 1。
+4. 选中第 4 段文字 → bookmark_selection 'EVID_TEST2' → get_bookmark_context.sectionPath === '一、主体资格/（一）基本情况'。
+5. 光标移到 EVID_TEST1 内部（goto_bookmark 后按 Right），type '（有限合伙）'；check_link_anchors {names:['EVID_TEST1','EVID_TEST2']} → TEST1.text 含 '（有限合伙）'、TEST2.text 不变。
+6. 选中 TEST2 整段文字删除（Backspace）；check_link_anchors → TEST2.exists === false（LO 会把空范围书签保留为点书签吗？实测：整段删除含书签范围时书签随之删除；若实测仍 exists 且 text==='' 则契约改为「exists && text==='' 视同 orphan」，把这条写进 ai-doc-bridge）。
+7. 旧链接：选中 '注册资本' → set_selection_hyperlink {url:'https://checkba-internal.local/open?u=checkba%3A%2F%2Ffilelink%3Fk%3Dlk_old_1'} → adopt_legacy_links → adopted 含 'lk_old_1'；再调一次 → adopted 空、skipped 1；get_bookmark_context 'lk_old_1' → text === '注册资本'。
+8. export_document → 重新 load 字节 → check_link_anchors ['EVID_TEST1','lk_old_1'] 都 exists（书签经 docx 往返）。
+9. goto_bookmark 'EVID_TEST1' → success；get_ui_state 选区文字前缀 '收购人成立于'。goto_bookmark 'NOPE' → success:false, error 非空。
+```
+- [ ] **Step 2: 跑** `cd frontend && npm run test:lowa-e2e`（需要引擎：`LOWA_ENGINE_DIR` 指向兄弟树或 `node ../desktop/scripts/fetch-lowa-assets.js`）。Expected: 新组全绿，总步数基线 README 更新。
+- [ ] **Step 3: 如第 6 步实测与预期不同，按实测改契约并记入 ai-doc-bridge.md。**
+- [ ] **Step 4: Commit、PR、auto-merge；#103 落实记录。**
+
+---
+
+# 单元 C：拖拽建链 + method 小条 + 定位（#104）
+
+### Task C1: 前端纯函数与 API 封装
+
+**Files:**
+- Create: `frontend/src/utils/anchorHash.js`、`frontend/src/utils/ulid.js`、`frontend/src/utils/evidenceLocator.js`
+- Create: `frontend/tests/evidence/anchor-hash-vectors.json`（= 后端那份字节拷贝）、`frontend/tests/evidence/anchorHash.test.mjs`、`locator.test.mjs`
+- Modify: `frontend/src/services/api.js`（在 `getDocFileLink` 旁）
+- Modify: `frontend/package.json` scripts 加 `"test:evidence": "node --test tests/evidence/*.test.mjs"`
+
+- [ ] **Step 1: 测试**
+```js
+// anchorHash.test.mjs
+import test from 'node:test'; import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { normalizeAnchor, anchorHash } from '../../src/utils/anchorHash.js';
+const vectors = JSON.parse(readFileSync(new URL('./anchor-hash-vectors.json', import.meta.url)));
+test('normalize matches shared vectors', () => { for (const v of vectors) assert.equal(normalizeAnchor(v.in), v.norm); });
+test('hash is 64 hex and whitespace-insensitive', async () => {
+  assert.match(await anchorHash('abc'), /^[0-9a-f]{64}$/);
+  assert.equal(await anchorHash('a b'), await anchorHash('ab'));
+});
+```
+后端向量文件里**补一个 `hash` 字段**（A1 顺手：测试里由 Java 算出后写死），前端断言 `anchorHash(v.in) === v.hash`——这才是真正的双端对拍。A1 的 Step 1 向量文件改为含 `hash`，`AnchorHashTest` 也断言它。
+
+```js
+// locator.test.mjs
+import { locatorSummary, parseFileLinkUrl } from '../../src/utils/evidenceLocator.js';
+test('summary', () => {
+  assert.equal(locatorSummary({ type: 'pdf', page: 3 }, (k, p) => k + JSON.stringify(p || {})), 'evidence.loc.page{"page":3}');
+  assert.equal(locatorSummary(null, k => k), 'evidence.loc.wholeFile');
+});
+test('parse wrapped filelink with t', () => {
+  const u = 'https://checkba-internal.local/open?u=' + encodeURIComponent('checkba://filelink?k=EVID_X&projectId=1&t=42');
+  assert.deepEqual(parseFileLinkUrl(u), { linkKey: 'EVID_X', projectId: '1', targetId: 42 });
+  assert.equal(parseFileLinkUrl('https://example.com'), null);
+});
+```
+- [ ] **Step 2: 实现**
+`anchorHash.js`：`normalizeAnchor` 同 Java 规则（`String.prototype.normalize('NFKC')`，`/\s|　/g` 删除，标点表同）；`anchorHash` 用 `crypto.subtle.digest('SHA-256')`（浏览器与 node 18+ 都有 `globalThis.crypto.subtle`），返回 Promise<string>。
+`ulid.js`：同 Java 算法，`crypto.getRandomValues`。
+`evidenceLocator.js`：
+```js
+export function locatorSummary(loc, t) {
+  if (!loc || !loc.type) return t('evidence.loc.wholeFile');
+  switch (loc.type) {
+    case 'pdf': return loc.page ? t('evidence.loc.page', { page: loc.page }) : t('evidence.loc.wholeFile');
+    case 'docx': return loc.quote ? t('evidence.loc.quote', { quote: String(loc.quote).slice(0, 20) }) : t('evidence.loc.wholeFile');
+    case 'image': return loc.rect ? t('evidence.loc.region') : t('evidence.loc.wholeFile');
+    case 'media': return t('evidence.loc.time', { time: fmtMs(loc.startMs) });
+    case 'web': return loc.url ? t('evidence.loc.web', { host: hostOf(loc.url) }) : t('evidence.loc.wholeFile');
+    case 'sheet': return t('evidence.loc.cell', { sheet: loc.sheet || '', cell: loc.cell || '' });
+    default: return t('evidence.loc.wholeFile');
+  }
+}
+export function parseFileLinkUrl(raw) { /* 解包 https://checkba-internal.local/open?u= → checkba://filelink?k=&projectId=&t= ；非法返回 null；t 解析为 Number 或 null */ }
+export function buildFileLinkUrl(base, linkKey, projectId, targetId) { /* 反向 */ }
+```
+`api.js`：
+```js
+export const createEvidenceLink = (pid, body) => request({ url: `/api/projects/${pid}/evidence-links`, method: 'POST', data: body })
+export const getEvidenceLink = (pid, key) => request({ url: `/api/projects/${pid}/evidence-links/${encodeURIComponent(key)}`, method: 'GET' })
+export const listEvidenceLinks = (pid, params) => request({ url: `/api/projects/${pid}/evidence-links`, method: 'GET', data: params })
+export const addEvidenceTargets = (pid, key, targets) => request({ url: `/api/projects/${pid}/evidence-links/${encodeURIComponent(key)}/targets`, method: 'POST', data: targets })
+export const updateEvidenceTarget = (pid, id, patch) => request({ url: `/api/projects/${pid}/evidence-links/targets/${id}`, method: 'PATCH', data: patch })
+export const removeEvidenceTarget = (pid, id) => request({ url: `/api/projects/${pid}/evidence-links/targets/${id}`, method: 'DELETE' })
+export const deleteEvidenceLink = (pid, key) => request({ url: `/api/projects/${pid}/evidence-links/${encodeURIComponent(key)}`, method: 'DELETE' })
+export const reportEvidenceAnchors = (pid, docFileId, reports) => request({ url: `/api/projects/${pid}/evidence-links/anchors/report`, method: 'POST', data: { docFileId, reports } })
+export const keepEvidenceAnchor = (pid, key, text) => request({ url: `/api/projects/${pid}/evidence-links/${encodeURIComponent(key)}/keep`, method: 'POST', data: { text } })
+export const rebindEvidenceLink = (pid, key, body) => request({ url: `/api/projects/${pid}/evidence-links/${encodeURIComponent(key)}/rebind`, method: 'POST', data: body })
+export const evidenceRefCounts = (pid, fileIds) => request({ url: `/api/projects/${pid}/evidence-links/ref-counts`, method: 'GET', data: { fileIds: fileIds.join(',') } })
+```
+`request` 的名字以 api.js 里既有封装为准（看 `createDocFileLink` 怎么写，照抄）。
+- [ ] **Step 3: `npm run test:evidence` 绿；Commit。**
+
+### Task C2: 拖到编辑器建链 + method 小条
+
+**Files:**
+- Create: `frontend/src/pages/project-overview/evidenceLinkActions.js`（mixin 形态，与 `stagingArea.js` 同款导出 `{ data(), methods }`）
+- Create: `frontend/src/components/EvidenceMethodBar.vue`
+- Modify: `frontend/src/components/LibreOfficeEditor.vue`：最外层 `<view class="libre-root">` 加 `@dragover.prevent="onEvidenceDragOver" @dragleave="onEvidenceDragLeave" @drop.prevent="onEvidenceDrop"`，拖拽中加类 `evidence-drop-armed`（描边）；`emits` 加 `'evidence-drop'`，drop 时 `this.$emit('evidence-drop', { file })`（文件 JSON 来自 `e.dataTransfer.getData('application/x-checkba-file')`，文件夹忽略）。
+- Modify: `project-overview.vue`：删除 `FileLinkDropZone` 的 import/注册/模板/`onFileLinkZoneDrop`/`createWpsSelectionFileLink`；两处 `<LibreOfficeEditor>` 加 `@evidence-drop="onEvidenceDrop($event, 'left'|'right')"`；`openFileLinkTarget` 与两处 `getDocFileLink` 解包改调新模块。
+- Delete: `frontend/src/components/FileLinkDropZone.vue`
+- Modify: locales：`workbench.evidence.*`（selectFirst「先选中要关联的文字」、linked「已关联《{name}》」、method.written_review 等五个、dropHint「松开即关联到选中文字」）
+- Test: `frontend/tests/evidence/evidenceLinkActions.test.mjs`（把 `createEvidenceLinkForDrop` 抽成可注入 `exec/api` 的纯函数测试）
+
+- [ ] **Step 1: 纯函数 + 测试**
+```js
+// evidenceLinkActions.js（节选，可测部分）
+export async function createEvidenceLinkForDrop({ exec, api, projectId, docFileId, file, wrap, internalBase, t }) {
+  const cur = await exec('get_selection_hyperlink', {});
+  const selText = cur && cur.success ? String(cur.text || '').trim() : '';
+  if (!selText) return { ok: false, reason: 'no_selection' };
+  let linkKey = ''; const parsed = parseFileLinkUrl(cur.url || '');
+  if (parsed && parsed.linkKey) linkKey = parsed.linkKey;
+  let created = false;
+  if (!linkKey) {
+    linkKey = 'EVID_' + ulid();
+    const bm = await exec('bookmark_selection', { name: linkKey });
+    if (!bm || !bm.success) return { ok: false, reason: 'bookmark_failed', message: bm && bm.error };
+    const url = wrap(`${internalBase}?k=${encodeURIComponent(linkKey)}&projectId=${encodeURIComponent(String(projectId))}`);
+    const r = await exec('set_selection_hyperlink', { url });
+    if (!r || !r.success) return { ok: false, reason: 'hyperlink_failed', message: r && r.message };
+    created = true;
+  }
+  const ctx = await exec('get_bookmark_context', { name: linkKey });
+  const target = { fileId: Number(file.id), relation: 'supports', method: 'written_review' };
+  const view = created
+    ? await api.createEvidenceLink(projectId, { docFileId, linkKey, anchorText: selText, sectionPath: ctx && ctx.sectionPath || '', sectionTitle: ctx && ctx.sectionTitle || '', createdByKind: 'human', targets: [target] })
+    : await api.addEvidenceTargets(projectId, linkKey, [target]);
+  const tgt = (view.targets || []).find(x => Number(x.fileId) === Number(file.id)) || null;
+  return { ok: true, linkKey, view, targetId: tgt && tgt.id };
+}
+```
+测试：mock `exec` 按 action 返回；断言无选区 → `no_selection`；新建走 `bookmark_selection`+`set_selection_hyperlink`+`createEvidenceLink`；选区已带 `filelink?k=` → 只 `addEvidenceTargets`；bookmark 失败不调 api。
+- [ ] **Step 2: `EvidenceMethodBar.vue`**：props `{ visible, fileName, method, targetId }`，emits `['change','close']`；五个 chip，`@tap` emit `change({targetId, method})`；内部 3s 定时器 `close`（每次 props 变化重置）。样式：浅色、编辑器底部悬浮、`z-index` 高于画布，不遮审阅面板。
+- [ ] **Step 3: 接线**：`onEvidenceDrop({file}, side)` → 调纯函数（exec = 该侧 `libreOfficeExecutor`；docFileId = 该侧 activeFile.id）→ toast 或显示 method bar；`change` → `updateEvidenceTarget` + `uni.$emit('awd:evidence-changed', {docFileId})`。
+- [ ] **Step 4: `npm run check:emits`、`npm run test:evidence`；dev H5 真渲染走查（`ui-live-walkthrough-recipe` 记忆配方）：拖文件到编辑器 → 无选区 toast → 选中后拖 → 小条出现 → 点「访谈」→ 网络面板看到 PATCH。**
+- [ ] **Step 5: Commit** `git commit -m "feat(evidence): 拖到编辑器即建书签+链接+入库，method 浮动小条；下线 FileLinkDropZone"`
+
+### Task C3: 点击链接定位 + openFile(locator)
+
+**Files:**
+- Modify: `fileOpenTabs.js` `openFile(file, opts = {})`：`opts.locator` 存进 tab 对象 `pendingLocator`（`targetList.push({ ...file, pendingLocator: opts.locator || null })`；已打开时 `existing.pendingLocator = opts.locator || null`）。
+- Modify: `project-overview.vue` 两处链接解包：`parseFileLinkUrl` → `getEvidenceLink` → 选 target（`t` 命中 / 单 target / 弹窗列 targets 显示 `file.name + locatorSummary`）→ `openFileLinkTarget(target)`：`openFile(file, { locator: target.locator })`。
+- Modify: `LibreOfficeEditor.vue`：`ready` 后与 `file.pendingLocator` 变化时 `consumeLocator()`：`bookmark` → `goto_bookmark`；否则 `quote` → `find_text_locations {query: quote, limit: 1}` → `set_selection {anchor}`；消费后 `this.$emit('locator-consumed', file.id)` 由宿主清空。
+- Modify: `FilePreview.vue`：props 加 `locator`；pdf 分支 `:src="blobUrl + (locator && locator.type==='pdf' && locator.page ? '#page=' + locator.page : '')"`；image 分支在图片容器里 `<view v-if="rectStyle" class="evidence-rect" :style="rectStyle">`（`rectStyle` 由 `locator.rect` × 当前渲染尺寸算，随缩放 watch）；audio/video：`loadedmetadata` 后若 `locator.startMs` → `currentTime = startMs/1000`。
+- Modify: `agentClientActions.js` `handleEditorOpenFile`：透传 `action.locator`（后端 A5 已允许字段，P1 才真发）。
+
+- [ ] **Step 1: 实现以上；`check:emits`。**
+- [ ] **Step 2: dev 真渲染走查**：造一条 pdf target `{type:'pdf',page:2}` → 点击文档链接 → 右侧 pdf 打开在第 2 页；图片 rect 画框可见；音频从 startMs 起播。
+- [ ] **Step 3: Commit、rebase 到含 A/B 的 master、PR、auto-merge；#104 落实记录。**
+
+---
+
+# 单元 D：审阅面板「证据」页 + stale 弹窗（#105）
+
+### Task D1: EvidencePanel 数据与分组（纯函数先行）
+
+**Files:**
+- Create: `frontend/src/utils/evidenceGrouping.js`、`frontend/tests/evidence/grouping.test.mjs`
+- Create: `frontend/src/components/EvidencePanel.vue`
+- Modify: `ReviewPanel.vue`：tab 三枚（`editor.review.evidenceTab` 「证据 {count}」），`tab==='evd'` 时渲染 `<EvidencePanel :executor :project-id :doc-file-id @locate="$emit('locate', $event)" />`；emits 加 `'locate'`。
+- Modify: `LibreOfficeEditor.vue`：`<ReviewPanel>` 传 `:project-id :doc-file-id="file.id"`，`@locate="onEvidenceLocate"`（`this.$emit('open-evidence-target', payload)` 给宿主去 openFile）。
+- Modify: `project-overview.vue`：`@open-evidence-target` → `openFileLinkTarget(target)`。
+
+- [ ] **Step 1: 分组纯函数 + 测试**
+```js
+export function groupBySection(links) { /* Map<sectionPath||'__none__', links[]>，按首次出现顺序；返回 [{key, title, items}] */ }
+export function groupByParty(links, fileTagsById /* Map<fileId, tags[]> */) { /* 每个 link 按其 targets 的 PARTY 标签落组（可多组）；无 PARTY → '__none__' */ }
+export function filterByStatus(links, status /* 'all'|'unverified'|'stale'|'orphan' */) {}
+```
+测试：三条 link，两条同 sectionPath；一条 target 文件挂两个 PARTY → 出现在两组；status 过滤。
+- [ ] **Step 2: EvidencePanel.vue**：顶部 segmented「按章节 / 按主体」+ 状态下拉；列表按 D1 分组；卡片见 SPEC §4.3；动作：
+  - 点卡片 → `executor.executeCommand('goto_bookmark', {name: link.linkKey})`
+  - 点 target → emit `locate({ fileId, locator })`
+  - 「保留关联」（stale）→ `check_link_anchors([key])` 取 text → `keepEvidenceAnchor`
+  - 「重新指定」（orphan）→ 进入 rebinding 态：提示「选中新文字后点确认」→ 确认时 `bookmark_selection(EVID_new)` + `set_selection_hyperlink` + `rebindEvidenceLink`
+  - 「删除」→ `deleteEvidenceLink`；target 行方法 chip → `updateEvidenceTarget`；target 删 → `removeEvidenceTarget`
+  - 数据：`mounted` 与 `uni.$on('awd:evidence-changed')` 时 `listEvidenceLinks({docFileId})`；主体视图需要 `tags`：用 `getProjectFiles(pid, null, true)` 已带 `tags` 的树一次取 Map（文件树已有缓存则复用 props 传入）。`beforeUnmount` `$off`。
+  - PARTY 判定用 `normalizeTagType(tag.type) === 'PARTY'`（`utils/tagTypes.js`）。
+- [ ] **Step 3: locales**：`editor.review.evidenceTab`、`evidence.view.bySection/byParty`、`evidence.status.active/unverified/stale/orphan`、`evidence.action.keep/rebind/delete/confirmRebind`、`evidence.group.none`、`evidence.loc.*`。
+- [ ] **Step 4: `check:emits`、`test:evidence`；dev 走查：建两条 link → 打开面板 → 切视图 → 点 target 定位。Commit。**
+
+### Task D2: stale 检测 + 弹窗
+
+**Files:**
+- Create: `frontend/src/components/EvidenceStaleBar.vue`
+- Create: `frontend/src/utils/evidenceStaleQueue.js` + `tests/evidence/staleQueue.test.mjs`（合并规则纯函数）
+- Modify: `LibreOfficeEditor.vue`
+
+- [ ] **Step 1: 合并规则纯函数 + 测试**
+```js
+export class StaleQueue {
+  constructor({ now = () => Date.now(), windowMs = 3000 } = {}) { this.now = now; this.windowMs = windowMs; this.ignored = new Set(); this.lastShown = new Map(); this.pending = new Map(); }
+  offer(linkKey, text) { if (this.ignored.has(linkKey)) return false; const t = this.now(); const last = this.lastShown.get(linkKey) || 0; if (t - last < this.windowMs) return false; this.pending.set(linkKey, text); return true; }
+  flush() { const items = [...this.pending.entries()].map(([linkKey, text]) => ({ linkKey, text })); const t = this.now(); for (const i of items) this.lastShown.set(i.linkKey, t); this.pending.clear(); return items; }
+  ignore(linkKey) { this.ignored.add(linkKey); }
+}
+```
+测试：同 key 3s 内 offer 两次只入队一次；ignore 后不入队；flush 合并多条。
+- [ ] **Step 2: LibreOfficeEditor 接线**：
+  - `onDocModified` 里除 autosave 外起 `_staleTimer = setTimeout(runAnchorCheck, 3000)`（每次 modified 重置）；`flushSave` 前也 `runAnchorCheck()`。
+  - `runAnchorCheck`：若 `_cmdBusy > 0` 则 1s 后重试；取 `this._evidenceCache`（`listEvidenceLinks({docFileId})` 在 ready 后 + `awd:evidence-changed` 时刷新）；按 200 分批 `check_link_anchors`；对每条：`!exists` → report orphan；`await anchorHash(text) !== link.anchorHash && link.status !== 'stale'` → report stale + `queue.offer(key, text)`；一次 `reportEvidenceAnchors(pid, docFileId, reports)`；有变化 → 更新缓存 + `uni.$emit('awd:evidence-changed')` + `staleItems = queue.flush()` 显示 bar。
+  - ready 后首轮：先 `adopt_legacy_links`（只对 writer 文档），再 `runAnchorCheck()`。
+- [ ] **Step 3: EvidenceStaleBar.vue**：props `{ items }`，单条显示「这段文字有 N 份底稿，文字已改动」（N = link.targets.length），多条「N 段文字已改动」可展开；按钮 [保留关联]（→ `keepEvidenceAnchor` 全部 / 单条）[查看底稿]（→ emit `locate` 首个 target）[忽略]（→ `queue.ignore`）。非阻塞：`position:absolute; top:0` 叠在编辑器顶部，不抢焦点。
+- [ ] **Step 4: lowa-e2e 不测此层（它在宿主）；app-e2e 不新增旅程，走 dev 真渲染走查：建 link → 改字 → 3s 内弹条 → 保留 → 面板变绿；删段 → 面板红。Commit、PR、auto-merge；#105 落实记录。**
+
+---
+
+# 单元 E：SDK 三方法（#106）
+
+### Task E1: SDK 与宿主
+
+**Files:**
+- Modify: `sdk/plugin-sdk/awd-plugin-sdk.js`（方法表注释 + `awd.evidence = { link, list, locate }` 三个 `call` 包装）
+- Modify: `examples/hello-web-plugin/awd-plugin-sdk.js`（字节拷贝）
+- Modify: `frontend/src/components/PluginPane.vue` `handleCall` 三个 case
+- Modify: `docs/PLUGIN_SPEC.md` §8 方法表
+- Test: 既有 SDK parity 测试（grep `sha256` in frontend/tests 或 scripts，找到比对三份副本的那条）照常；`frontend/tests/evidence/pluginEvidence.test.mjs` 测宿主端纯函数 `resolveAnchor`
+
+- [ ] **Step 1: 宿主端纯函数 + 测试**
+```js
+// frontend/src/utils/pluginEvidence.js
+export async function resolveAnchor(exec, anchor) {
+  if (anchor && anchor.selection === true) {
+    const cur = await exec('get_selection_hyperlink', {}); const text = cur && cur.success ? String(cur.text || '').trim() : '';
+    if (!text) return { error: { code: 'no_selection', message: '编辑器当前没有选区' } };
+    return { mode: 'selection', text, existingUrl: cur.url || '' };
+  }
+  if (anchor && typeof anchor.quote === 'string' && anchor.quote.trim()) {
+    const r = await exec('find_text_locations', { query: anchor.quote.trim(), limit: 2 });
+    const n = r && Array.isArray(r.matches) ? r.matches.length : 0;
+    if (n !== 1) return { error: { code: 'anchor_ambiguous', message: n === 0 ? '引文未命中' : '引文命中多处' } };
+    return { mode: 'quote', anchorId: r.matches[0].anchor, text: r.matches[0].text || anchor.quote.trim() };
+  }
+  return { error: { code: 'anchor_ambiguous', message: 'anchor 需为 {selection:true} 或 {quote}' } };
+}
+```
+（`find_text_locations` 返回字段名以 office_thread.js :1665-1700 为准，先读再写。）
+- [ ] **Step 2: 宿主 case**
+```js
+case 'evidence.list': {
+  if (!this.hasPermission('file_read')) return this.denied('file_read')
+  const docFileId = params.docPath ? await this.fileIdByPath(params.docPath) : this.activeDocFileId()
+  const q = params.path ? { fileId: await this.fileIdByPath(params.path) } : { docFileId, status: params.status, sectionPath: params.sectionPath }
+  if (!q.fileId && !q.docFileId) return { ok: false, error: { code: 'no_active_document', message: '没有打开的文档' } }
+  const links = await listEvidenceLinks(this.projectId, q)
+  return { ok: true, result: { links: links.map(l => this.toPluginLink(l)) } }   // path 由 fileId 反查（复用 listProjectFiles 的 path 表）
+}
+case 'evidence.link': {
+  if (!this.hasPermission('editor')) return this.denied('editor')
+  const exec = this.activeExecutor(); if (!exec) return { ok:false, error:{ code:'no_active_document', message:'没有打开的文档' } }
+  const a = await resolveAnchor(exec, params.anchor); if (a.error) return { ok:false, error:a.error }
+  if (a.mode === 'quote') await exec('set_selection', { anchor: a.anchorId })   // 让后续 bookmark_selection 有选区
+  // 复用 C2 的 createEvidenceLinkForDrop 的核心，但 targets 多个且带 locator/relation/method/note；createdByKind:'plugin'
+  ...
+  return { ok:true, result:{ linkKey, targetIds } }
+}
+case 'evidence.locate': {
+  if (!this.hasPermission('editor')) return this.denied('editor')
+  const link = await getEvidenceLink(this.projectId, String(params.linkKey)).catch(() => null)
+  if (!link) return { ok:false, error:{ code:'not_found', message:'链接不存在' } }
+  const tgt = params.targetId ? link.targets.find(t => t.id === Number(params.targetId)) : null
+  if (tgt) uni.$emit('awd:open-evidence-target', { fileId: tgt.fileId, locator: tgt.locator }); else await this.activeExecutor()('goto_bookmark', { name: link.linkKey })
+  return { ok:true, result:{} }
+}
+```
+`activeExecutor()`/`activeDocFileId()`：PluginPane 今天拿不到编辑器——需要宿主（project-overview）通过 props 注入 `getActiveEditor()`（返回 `{executor, fileId}`），与 `VariablePanel` 拿 `getEditor` 适配器的既有做法一致（grep `getEditor` 在 project-overview.vue）。`awd:open-evidence-target` 由 project-overview 监听 → `openFileLinkTarget`。
+- [ ] **Step 3: SDK 文件**：注释方法表加三行；`awd.evidence = { link: p => call('evidence.link', p), list: p => call('evidence.list', p), locate: p => call('evidence.locate', p) }`；错误码注释加 `anchor_ambiguous / no_selection / not_found / no_active_document`。拷贝到 examples。
+- [ ] **Step 4: `docs/PLUGIN_SPEC.md` §8 表加三行；跑既有 SDK 副本一致性测试 + `test:evidence`；Commit、PR。**
+
+### Task E2: 官网仓同步（Sonnet 可做，主模型验收）
+
+在 `aiworkdeckweb` 仓：`lib/plugin-template.ts` 内联 SDK 更新为同字节；模板的宿主模拟器（`?type=web` 五件套里的 mock host）给三方法假实现（`evidence.link` 返回 `{linkKey:'EVID_MOCK', targetIds:[1]}`、`list` 返回空数组、`locate` 返回 `{}`）；开 PR。验收：桌面仓 SDK 一致性测试对官网文件 sha256 一致（测试怎么拿官网文件看既有实现）。
+
+---
+
+# 单元 F：稳定性 #1 #2 #6（#107）
+
+### Task F1: 导入硬顶
+
+**Files:** `LocalProjectService.java:40,195-197,351,397`；前端对账结果消费处（grep `truncated` in frontend/src）；Test `LocalProjectServiceImportCapTest.java`
+
+- [ ] `MAX_IMPORT_ENTRIES = 30000`；超出时把 `truncated=true, truncatedCount=N` 放进对账返回 DTO（看 `reconcileProject` 返回类型，加两个字段）；前端拿到 `truncated` 时 `uni.showModal`「本次导入已截断，N 项未纳入：目录超过 30000 项，请拆分项目」一次（按 projectId 记 sessionStorage 防重复）。
+- [ ] 测试：临时目录造 30001 个空文件（`Files.createFile` 循环，1-2s）→ reconcile → 入库 30000 + truncated；造 3001 个 → 全部入库、truncated=false。
+- [ ] Commit。
+
+### Task F2: 新建文件 O(N²) + 同名自动编号
+
+**Files:** `ProjectFileService.java:91-96, 224-229`；`ProjectFileRepository.java`（加 `@Query("select max(f.sortOrder) from ProjectFile f where f.projectId=:pid and ((:parent is null and f.parentId is null) or f.parentId=:parent)") Integer maxSortOrder(...)`）；Test `ProjectFileServiceCreateConflictTest.java`
+
+- [ ] `createFile(..., ConflictPolicy policy)`：新增重载，旧签名委托 `FAIL`（行为不变）；`RENAME` 时循环 `name (n)`（扩展名前插入）直到 `existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse` 为 false，上限 1000；`createOrUpdateFile` 不动。`createFolder` 同样改 `maxSortOrder` 单查。
+- [ ] 把后端内部的「截图/导出落盘」调用点（`MeetingRecordingService.exportTranscript` 的 `uniqueName`、`AiDocxExportService`、`PdfTools` pdf_to_word）改成传 `RENAME`，各自手写的 uniqueName 删掉。
+- [ ] 测试：mock repo，`existsBy...` 对 `a.pdf`、`a (1).pdf` 返回 true → 得 `a (2).pdf`；`maxSortOrder` 被调用且 `findByProjectIdAndParentIdOrderBySortOrderAsc` **never**。
+- [ ] Commit。
+
+### Task F3: 文件树懒加载 + 窗口化
+
+**Files:** `FileTree.vue:1292, 422, 561, 1746-1830`；后端 `ProjectFileController.java:67-93`（`?parentId=` 已支持单层？先看）；Test：`frontend/tests/evidence/treeBuild.test.mjs`（把 `buildTreeView` 的分组逻辑抽到 `utils/fileTreeBuild.js` 测）
+
+- [ ] `buildTreeView`：先 `const byParent = new Map()` 一次分组，递归只取 `byParent.get(id)`；排序比较器不变。测试：1000 节点构建 < 50ms（断言调用 `filter` 次数为 0 更直接：用抽出的纯函数计数）。
+- [ ] 懒加载：`getProjectFiles(pid, null, true)` 仍整棵拉（后端一次下发可接受，盘点结论），但**渲染**改为：每个展开文件夹的子项超过 100 时只渲染前 100 + 「展开更多（还有 N 项）」行，点一次加 200。这是窗口化的最小形态，不引入第三方虚拟列表（uni 下稳定性优先）。
+- [ ] 「被引用 N 次」角标：树刷新后对当前已渲染的文件 id 分批 `evidenceRefCounts`，结果存 `refCounts` Map，文件行右侧小灰字 `引用 N`（N>0 才显示）。
+- [ ] app-e2e 现有旅程跑一遍不红（J 系列涉及文件树的）；Commit、PR；#107 落实记录。
+
+---
+
+# 单元 G：稳定性 #3 #4 #5 + 大文档基线组（#108）
+
+### Task G1: 大文档夹具与基线组（先建尺子）
+
+**Files:** `frontend/tests/lowa-e2e/fixtures/gen-big-doc.py`、`frontend/tests/lowa-e2e/big-doc.mjs`、`package.json` 加 `"test:lowa-big": "LOWA_E2E_BIG=1 node tests/lowa-e2e/big-doc.mjs"`、README
+
+- [ ] `gen-big-doc.py`：按稳定性盘点附录 A（150 页 / 每页 1 个二级标题 + 4 段约 220 字 + 分页符 / 随机 30 页 12x5 表 / 随机 20 页 900x600 噪声 JPEG q75）；固定 `random.seed(20260821)`；输出到 `$TMPDIR/awd-big-doc/big.docx`（不入库）。依赖 `python3 -m pip install --user python-docx pillow`，脚本开头检查并给出安装命令。
+- [ ] `big-doc.mjs`：复用 run.mjs 的 server/puppeteer 启动（把那段抽成 `tests/lowa-e2e/_boot.mjs` 共用），加载 big.docx，逐项计时（`performance.now()` 在 `page.evaluate` 内，结果裁掉大字段再跨界），**每项跑 3 次取中位数**，输出表格，并与阈值比较：
+  | 项 | 硬阈 |
+  |---|---|
+  | load_document | < 15s |
+  | get_document_text 第 2 次（同参数） | < 300ms（G3 后） |
+  | find_replace 修订 150 命中 | < 8s（G2 后） |
+  | apply_house_style 921 段 | 不超时（< 120s）且 `truncated === false`（G2 后） |
+  | export_document | < 10s |
+  | 连续 30s 无 modified（导出后） | 0 次 |
+  未达阈值 → 进程退出码 1 并打印实测；**先跑一次记录改造前基线**写进 README。
+- [ ] Commit `test(lowa): 大文档基线组（150 页/30 表/20 图，三次中位数）`。
+
+### Task G2: 批量命令分批 + 进度 + 分级超时
+
+**Files:** `office_thread.js` `find_replace`(:1632-1645)、`apply_house_style`(:2946-2984)、`resolve_all_revisions`(:3492)；`libreofficeExecutorClient.js:189-191`、`zetaOfficeRelay.js:108-112`（超时表）；`EditorBridgeService.java:66,286`（按 action 分级）；`DocumentEditTools.java` 对应工具描述补「大量命中会分批，返回 progress」
+
+- [ ] worker：`find_replace` 去掉每命中 `selectVisibly`，结束只滚到首处；命中 > 50 时按 30 一批处理，每批后 `postMessage({type:'progress', reqId, done, total})`（relay 已有 `type` 分发，加一个 `progress` 分支转发给宿主 `onProgress(reqId)` 回调；宿主在 AI 过程卡上显示「第 x/y 处」）；`p.cancelToken` 检查：宿主可 `executeCommand('cancel', {reqId})` 置位 `cancelled[reqId]`，批间检查即停，返回 `{success:true, cancelled:true, done}`。
+- [ ] `apply_house_style`：按 500 元素一批，批间 `await` 一个宏任务让 export/progress 有机会；`truncated` 字段永远返回（false/true）；去掉 5000 硬顶（改为分批到底）。
+- [ ] `resolve_all_revisions`：前后只各数一次 redline（原本就只 dispatch 一次，主要是 `countRedlines` 两次 O(N) —— 保留，但 `list_revisions` 加 `since` 游标不在本期）。
+- [ ] 超时：前端两处超时表加 `find_replace/apply_house_style/resolve_all_revisions/insert_table: 120000`；后端 `EditorBridgeService` 加 `static final Map<String,Integer> ACTION_TIMEOUT_SECONDS = Map.of("doc_open_file_sync",180,"find_replace",120,"apply_house_style",120,"resolve_all_revisions",120,"export_document",180)`，`future.get` 用它，默认 30。**构造器不变**（EvalHarness 免改）。
+- [ ] 测试：`EditorBridgeServiceTest` 加「find_replace 超时 120s」的反射断言；lowa-e2e 既有组 + 大文档组：150 命中 < 8s。
+- [ ] Commit。
+
+### Task G3: 段落索引缓存
+
+**Files:** `office_thread.js` `eachParagraph`(:169-178)、`get_document_text`(:2451-2477)、`get_paragraph/modify_paragraph`(:1744-1775)、modified 监听器(:1449)
+
+- [ ] 新增 `paraIndex = { ranges: null, total: 0 }`；`buildParaIndex()` 一次枚举把每段 `XTextRange`（段落对象本身）推进数组；`invalidateParaIndex()` 在 `modified` 监听器、`load_document`、`undo/redo`、所有写原语末尾调用（写原语统一走 `verifySnapshot()` 的话在那里挂一次即可——先 grep 确认写原语都调它）。
+- [ ] `get_document_text`：`startParagraph` 直接从 `paraIndex.ranges[start]` 起读；`total = paraIndex.total`。`get_paragraph/modify_paragraph/select_paragraph` 同样走索引。
+- [ ] 风险：段落对象在文档被编辑后可能失效（UNO 对象引用被销毁抛异常）——任何一处读到异常就 `invalidateParaIndex()` 重建一次再读，仍失败才返回错误。
+- [ ] lowa-e2e 既有组全绿（段落号 0 基回归）；大文档组 `get_document_text` 二次 < 300ms。
+- [ ] Commit；**rebase 到含 B 的 master**（同文件）；PR、auto-merge；#108 落实记录。大文档组改造前后两组数字写进 README 与交付报告。
+
+---
+
+# 收尾（P0 定稿，自己做不外包）
+
+- [ ] 七个 PR 全合并后在 master 上：`mvn -q test` 全量、`npm run check:emits`、`npm run test:evidence`、`npm run test:lowa-e2e`、`npm run test:lowa-big`、`npm run test:app-e2e`（与基线失败集对照，见 `app-e2e-j1-login-flake` 记忆）。
+- [ ] `/code-review` 级对抗复核：对 A（状态机/权限/迁移）、B（书签往返）、D（stale 误报）、G（索引失效）各起一轮「找→反驳→确认」。
+- [ ] 「还原病灶即转红」抽查：注释掉 `reportAnchors` 的 orphan 分支跑 `EvidenceLinkServiceTest`；把 `anchor-hash-vectors.json` 的一条 hash 改一位跑 `AnchorHashParityTest` 与 `anchorHash.test.mjs`；把 `MAX_IMPORT_ENTRIES` 改回 3000 跑 `LocalProjectServiceImportCapTest`。三处都必须转红。
+- [ ] `.claude/agents/ai-doc-bridge.md` 契约段、`doc-editor.md`（新原语 + 段落索引缓存地雷）、`plugin-system.md`（SDK 三方法）、`utility-tools.md`（FilePreview locator）、`sidebar-shell.md`（FileLinkDropZone 下线、编辑器 drop）已随各 PR 更新；核对一遍。
+- [ ] #102-#108 全部「待复测」并带复测提示；母卡 #100 评论 P0 小结（PR 列表 + 大文档改造前后数字 + 真机走查清单）。
+- [ ] 记忆：写 `evidence-link-p0-shipped.md`（契约地雷 + 实测数字 + 走查清单位置）。

--- a/docs/superpowers/specs/2026-08-21-dd-p1-drafting-design.md
+++ b/docs/superpowers/specs/2026-08-21-dd-p1-drafting-design.md
@@ -1,0 +1,194 @@
+# 尽调 P1 设计：模板画像 + 插件宿主 SPI + 尽调 JAR 插件（入库整理/起草/勾稽写入）
+
+日期：2026-08-21 ｜ 母卡：dev-board#100 ｜ 上游：总方案 §2 / §5 / §7、样式盘点、样本画像（本机）、P0 设计（EvidenceLink）
+状态：2026-08-21 22:50 维护者通过；私有仓由维护者自建，建好后告知仓名。
+
+## 0. 本期拍板（2026-08-21 22:40）
+
+- **尽调插件 = 独立 JAR 插件**，不入主仓。源码放私有仓 `zeweihan/aiworkdeck-dd-plugin`（待建），走 `PluginMarketService` 签名分发，广场付费项 `plugin:due-diligence`。
+- 由此 P1 必须先把**插件宿主 SPI** 做出来：今天 JAR 插件只有「无参构造 + @Tool」一种能力，拿不到项目文件/OCR/标签/EvidenceLink/后台任务。SPI 是内置、开源、只加不破。
+
+## 1. 分层（谁在主仓、谁在插件）
+
+| 能力 | 落点 | 门控 |
+|---|---|---|
+| `docx_inspect_template` + `styleProfile` schema + `house-default.json` 单源 + `write_docx(styleProfileJson)` + worker `set_style_profile/apply_style_profile` | 主仓（内置） | 无 |
+| `doc_link_evidence` / `doc_list_evidence` AI 工具 | 主仓（内置，EvidenceLink 的 AI 面） | 无 |
+| 插件宿主 SPI `com.checkba.plugin.api.*`（新 Maven 模块 `plugin-api`，发布到本地仓库 + GitHub Packages） | 主仓（内置） | 无 |
+| `dd_ingest` 后台任务、编号/去重/版本链/状态词/归类/PARTY 标签、引用句式库、表格模板、尽调 skill prompt、黄金对照跑分器 | `aiworkdeck-dd-plugin`（JAR + skills/due-diligence/） | `plugin:due-diligence` 已购且已启用 |
+
+## 2. 插件宿主 SPI（`plugin-api` 模块）
+
+### 2.1 注入方式
+
+JAR 工具类仍无参构造；若实现 `com.checkba.plugin.api.HostAware`，`PluginService.loadJar` 实例化后调用 `setHost(PluginHost host)`。`PluginHost` 是宿主实现的门面（主仓 `service/plugin/PluginHostImpl`），按插件 id 绑定（日志、配额、任务归属都带 pluginId）。
+
+```java
+public interface HostAware { void setHost(PluginHost host); }
+
+public interface PluginHost {
+    String pluginId();
+    ToolCall call();                     // 当前工具调用上下文：projectId/userId/conversationId/modelId（ThreadLocal 透传，非调用期为 null）
+    Files files();
+    Text text();
+    Tags tags();
+    Evidence evidence();
+    Jobs jobs();
+    Docs docs();
+    Settings settings();
+    Llm llm();
+}
+```
+
+### 2.2 子接口（P1 最小集，字段只加不破）
+
+```java
+interface Files {
+    List<FileInfo> list(long projectId, Long parentId, boolean recursive);          // FileInfo{id,name,parentId,isFolder,fileType,size,path,sha256?,metaJson}
+    FileInfo get(long projectId, long fileId);
+    InputStream open(long projectId, long fileId);
+    FileInfo createFolderPath(long projectId, List<String> segments);               // 逐级确保
+    FileInfo write(long projectId, Long parentId, String name, InputStream bytes, ConflictPolicy policy); // RENAME/FAIL
+    FileInfo move(long projectId, long fileId, Long newParentId);
+    FileInfo rename(long projectId, long fileId, String newName);
+    void setMeta(long projectId, long fileId, Map<String,Object> metaPatch);        // 合并进 ProjectFile.metaJson
+    String sha256(long projectId, long fileId);                                     // 宿主缓存到 metaJson.sha256
+}
+interface Text {
+    String extract(long projectId, long fileId, int maxChars);                      // Tika；docx/pdf/xls
+    OcrResult ocr(long projectId, long fileId, OcrOptions o);                       // 走平台网关（扣 Credits）；OcrResult{text, blocks[{text,rect,page}]}
+    List<String> pdfPageTexts(long projectId, long fileId, int fromPage, int toPage);
+}
+interface Tags {
+    TagInfo getOrCreate(long projectId, String name, String type);                  // type NORMAL/PARTY/ISSUE；同名不同型复用不改型
+    void tagFile(long projectId, long fileId, long tagId);
+    List<TagInfo> tagsOf(long projectId, long fileId);
+}
+interface Evidence {                                                                // 直接映射 EvidenceLinkService（P0）
+    LinkView create(long projectId, long docFileId, String linkKey, String anchorText, String sectionPath, String sectionTitle, List<TargetInput> targets);
+    LinkView addTargets(long projectId, String linkKey, List<TargetInput> targets);
+    List<LinkView> listByDoc(long projectId, long docFileId);
+    List<LinkView> listByFile(long projectId, long fileId);
+}
+interface Jobs {
+    JobHandle start(String kind, String title, JobBody body);                       // 后台线程池（每插件最多 2 并发），JobBody.run(JobContext ctx) 里 ctx.progress(done,total,message) / ctx.checkCancelled()
+    JobStatus status(String jobId);
+    void cancel(String jobId);
+}
+interface Docs {                                                                    // 经 EditorBridgeService，仅在有 conversationId 时可用
+    String exec(String action, Map<String,Object> params);                          // 白名单：doc_* 已在 EDITOR_ACTIONS 的 action
+    void refreshFiles();                                                            // sendRefreshFilesAction
+    void openFile(long fileId, Map<String,Object> locator);
+}
+interface Settings {
+    String get(String key); void set(String key, String value);                     // 键自动加前缀 plugin.<id>.
+    String projectStyleProfileJson(long projectId);                                 // 解析顺序见 §3.4
+}
+interface Llm {
+    String complete(String systemPrompt, String userPrompt, LlmOptions o);          // 走平台通道，扣 Credits；记 pluginId
+}
+```
+
+- **鉴权**：所有方法先校 `call().userId()` 对 projectId 的读/写权限（复用 ProjectMemberService）；无调用上下文（后台任务线程）时用 `JobContext` 里快照的 userId。
+- **后台任务**：`PluginJobService`（主仓）——内存 + `plugin_job` 表（id, pluginId, kind, title, status queued/running/done/failed/cancelled, done/total/message, resultJson, projectId, userId, createdAt/updatedAt）；REST `GET /api/plugin-jobs?projectId=`、`GET /api/plugin-jobs/{id}`、`POST /{id}/cancel`；有 conversationId 时同时经 SSE `client_action: plugin_job_progress` 推给对话；前端 `ChatInterface` 的 `BackgroundTaskIndicator` 接这条事件（它已是通用任务指示器）。
+- **配额**：`Llm`/`Text.ocr` 都走平台网关（按用户 Credits），不给插件独立计费；每插件每分钟 60 次宿主调用上限（防 runaway），超限抛 `HostQuotaException`。
+- 模块发布：`plugin-api` 作为主仓子模块（`backend/plugin-api/`，`com.checkba:plugin-api:1.0.0`），插件以 `provided` 依赖它；版本号独立于桌面版本，只加不破。
+- `docs/PLUGIN_SPEC.md` 升 v2.4：§4 加 `HostAware`、§11 SPI 方法表；`examples/hello-plugin` 加一个用 `host.files().list` 的工具示范。
+
+## 3. 模板画像（内置）
+
+### 3.1 `docx_inspect_template(fileIds[], options?)` → styleProfile v1
+
+- docx4j 直读 `styles.xml / numbering.xml / document.xml / theme1.xml / sectPr / header*.xml`；schema 照样式盘点 §2（schemaVersion 1，全部长度字段带 unit；font 分槽；numbering.kind auto/literal；table 到单元格级边框 + gridCol twips；toc 域；headerFooter）。
+- 多份取众数、置信度；`.doc` → 提示「另存 docx 或在编辑器打开后学习」（LOWA 兜底 `inspect_template_lowa` 放 P3）。
+- 实现：新 `service/ai/tools/TemplateTools.java`（`AgentToolComponent`）+ `util/style/StyleProfile.java`（记录 + Jackson + 单位换算）+ `util/style/DocxProfileReader.java`；注册三处（@Component 自动 / `RealToolBeans` / `toolDisplayNames.js`）。
+- 样本验收：对样本报告 1 定稿 docx 跑出的 profile 必须满足：body.font.eastAsia=`KaiTi_GB2312`、size 12pt、firstLineIndent 0、spaceAfter 18pt、lineSpacing atLeast 16pt；headings[0].numbering `{kind:auto, numFmt:chineseCountingThousand, lvlText:'%1、'}`、headings[1] `（%2）`、headings[2] `%3.`；table.cell.size 10pt；table.borders.source=`cell`；toc `\o "1-2"`。
+
+### 3.2 HOUSE 单源化
+
+- `backend/src/main/resources/style-profiles/house-default.json`（HOUSE 的 JSON 化）。
+- `DocxStyleHelper.applyStandardFormat(pkg, StyleProfile)`：常量全部改读 profile；补标题多级自动编号（`NumberingDefinitionsPart`）、literal 编号拼接、单元格级边框、`tblGrid` 列宽、表头底纹/重复表头、页面 `SectPr`、页眉页脚 + PAGE/NUMPAGES 域、TOC 域 + `updateFields`。
+- worker：`HOUSE` → `ACTIVE_PROFILE`（默认内嵌同一份 JSON）；新 action `set_style_profile {profile}`、`apply_style_profile {scope: document|selection|styles-only}`（先改 ParagraphStyles 定义再最小直接格式，保留 `keepWeight`）；`format_selection` 加 `fontNameAsian`；`format_table` 露出 `borderColor/borderStyle/outside-inside/headerFill/repeatHeader/columnWidthsCm`；`insert_toc`、`set_page_setup`、`edit_header_footer` 加页码域/字体。
+- Office 插件 `officeExecutor.js` 的 `HOUSE` 改读同一 JSON（构建时内联）。
+- **对拍测试**：`HouseProfileParityTest`（Java 读 house-default.json 与 DocxStyleHelper 实际落盘值对拍）+ `tests/evidence/houseProfile.test.mjs`（worker 内嵌 JSON 与资源文件 sha256 一致）+ office-addin 同款；替代「三处逐字一致」。
+- `write_docx(markdown, fileName, parentFolderId?, styleProfileJson?)`；缺省按 §3.4 解析。`doc_open_file` 成功后 `EditorBridgeService` 追发 `set_style_profile`。
+
+### 3.3 模板上传 UX
+
+- 权威存放：项目 `_模板/` 文件夹；`_模板/画像.json` + `画像.md`（人话摘要，AI 写）。
+- AI 面板拖入 → skill 引导调 `docx_inspect_template` → `<question>` 反问确认关键项（标题级数 / 编号 auto 或 literal / 表格边框层级）→ 落 `_模板/`。
+- 概览页 `ProjectHomePane` 显示「已学习：楷体 12pt / 三级编号 / N 类表格」一行（读 `画像.json`）。
+
+### 3.4 画像解析顺序
+
+工具显式 `styleProfileJson` > 项目 `_模板/画像.json` > `SystemSetting dd.styleProfile.default` > `house-default.json`。
+
+## 4. EvidenceLink 的 AI 面（内置）
+
+- `doc_link_evidence(anchorQuote | anchorId, targetsJson, method?, relation?, note?)`：worker 定位（`find_text_locations` 唯一命中或已有 anchorId）→ `bookmark_selection(EVID_…)` + `set_selection_hyperlink` + `get_bookmark_context` → `EvidenceLinkService.create(createdByKind=ai → unverified)`；`targetsJson: [{fileId|path, locator?, relation?, method?}]`。返回 `{linkKey, targetIds, sectionPath}`。
+- `doc_list_evidence(docFileId?, fileId?, sectionPath?, status?)` → 精简 LinkView 列表（供模型自查「哪些段落还没底稿」）。
+- 四件套：DocumentEditTools @Tool、EDITOR_ACTIONS（复用 P0 五原语，无新 action）、`toolDisplayNames.js`、`RealToolBeans`。`ContextAssemblerService` docx 分支加一句：事实陈述写完必须 `doc_link_evidence`。
+
+## 5. 尽调插件（`aiworkdeck-dd-plugin`）
+
+### 5.1 仓库与包
+
+```
+aiworkdeck-dd-plugin/
+├── manifest.json              # id due-diligence, permissions [file_read,file_write,editor,network], tools[], skills ["skills/due-diligence"], backendJars
+├── pom.xml                    # provided: plugin-api, langchain4j-core
+├── src/main/java/com/aiworkdeck/dd/…
+├── skills/due-diligence/{skill.yml, prompt.md, phrasebook.yml, table-templates.yml}
+├── golden/                    # 黄金对照跑分器（本地跑，读 DD_SAMPLE_ROOT；期望值文件只在本机）
+└── README.md
+```
+
+### 5.2 `dd_ingest(projectId, rootFolderId, reportDocFileId?, options)`（后台任务）
+
+流水线（样本硬要求 1-5 + 主体识别）：
+1. **扫描**：`files.list(recursive)`；过滤 `.DS_Store`、`~$*`、`__MACOSX`；zip 只记 `metaJson.snapshot={zipFileId, mtime}` 不解压（目录为准；无同名目录时才解压到 `_解压/<zip名>/`）。
+2. **编号主键**：文件名前缀 `^(\d+)-(\d+)(?:-(\d+))?(?:-(\d+))?\s` → `metaJson.docketNo`（章-节-序[-主体序]）；缺则按所在章节夹分配 `章-节-自增`；重复编号 → 合并候选。
+3. **去重**：`files.sha256` 字节级；近似：同标题主干 + 同扩展名 + 大小差 < 1%（mp4 两次导出）或图像尺寸倍数关系（扫描件）→ 标 `metaJson.dupOf=<实体 fileId>`，不删文件；实体 = 该组最早编号/最完整者。
+4. **状态词**：`【修订】【用印稿】【有标黄】(1) ---副本 -mkckh-mkhzw（待补充）` 抽成 `metaJson.stateWords[]`、`proofreaders[]`、`copyIndex`，标题主干 `metaJson.title`。
+5. **版本链**：按标题主干分组，排序键 `(阶段词优先级 初稿<内核稿<内核回复<拟定稿<定稿, 日期, vN, HHMM, mtime)`；`.doc/.pdf` 成对时 pdf 标 `exportOf`；组内最终版 `metaJson.versionFinal=true`，其余 `versionOf`。
+6. **归类**：章节 = 文件所在章节夹（`N-章节名`）→ `metaJson.chapter`；无章节夹的散件按文件名关键词 + 首页文本（`text.extract` 前 2000 字 / 图片 `text.ocr`）用 `llm.complete` 归到章节树；置信度 < 0.6 进「待归类」。
+7. **主体识别**：文件名前缀主体简称（`收购人关于…`、`甲关于…`）+ 执照/身份证 OCR 名称 → `tags.getOrCreate(name, PARTY)` + `tagFile`；主体别名表来自 `dd_ingest` options.parties（skill 第一步让用户确认主体清单）。
+8. **输出**：`resultJson {entities, duplicates, versions, chapters, unclassified, parties, gaps:[]（P1 只收「（待补充）」子夹与空章节）}`，写 `_尽调/入库报告.md`（人话）+ `_尽调/入库.json`。进度 `ctx.progress(done,total,当前文件名)`。
+
+### 5.3 起草相关工具
+
+- `dd_chapter_materials(projectId, chapter)` → 该章实体文件列表（去重后、最终版、带 PARTY、带 docketNo、带已被哪些 link 引用）。
+- `dd_table(templateId, partyTagId)` → 按 `table-templates.yml`（主体基本情况 9×2 / 自然人 / 出资结构 / 控制企业 / 三年财务）生成 `rowsJson` + 每格 `source:{fileId, locator}`（执照 OCR 字段、xls 单元格 `{type:'sheet',sheet,cell}`）；数字格式：千分位两位小数、百分比两位小数、负数 `-` 前置、空 `-`、身份证中段 `********`。
+- `dd_phrase(kind, slots)` → 句式库渲染（六种固定句式，`phrasebook.yml`），返回句子 + 该句应挂的证据类型。
+- `dd_gap_candidates(projectId)` → 「报告引用了但池里没有」候选（P1：来自 `（待补充）` 子夹、空章节、句式槽位缺文件；P2 接核查）。
+- `dd_docket_index(projectId, reportDocFileId)` → 文件级底稿目录数据（实体 × 章节 × 被引段落反向链接），P2 再导出 docx/xlsx。
+
+### 5.4 skill `due-diligence`
+
+prompt.md 工作流：确认主体清单 → `dd_ingest`（等进度）→ 读入库报告 → 学模板（`docx_inspect_template`）→ 按章节循环：`dd_chapter_materials` → 表格段 `dd_table` + `doc_insert_table` → 事实句 `dd_phrase` + `doc_insert_at_cursor`/流式 → **每句 `doc_link_evidence`** → 找不到底稿写「【待补：…】」并记缺口 → 章末 `doc_list_evidence` 自查。约束段挂消息末位（`prompt-constraints-need-last-position` 记忆）。`skill.yml` `allowedTools` 列全（含 doc_*、dd_*、docx_inspect_template、tag_*、extract_file_text）。
+
+### 5.5 黄金对照跑分器（`golden/`）
+
+- `DD_SAMPLE_ROOT` 指向样本只读目录；跑分器先把底稿池 1 **复制到本机 scratch**（机密不出本机），建一个 IDE 本地文件夹项目，跑 `dd_ingest`，再用 skill 跑 6 章起草（真 LLM），然后断言：
+  - 去重后实体数 ∈ [80, 90]；骨干 6 文件各出现在 ≥2 章 `dd_chapter_materials`；
+  - 6 章黄金对照表（本机期望文件 `golden/expect.local.json`，**不入库**）：必含文件全部出现在该章材料，不应出现的不出现；
+  - 缺口候选 ⊇ 人工 8 条（语义匹配：用 `llm.complete` 判同义，阈值 0.8）；
+  - 误入文件（池根目录意向书 pdf）`chapter=null`；`10-专业机构/` 三份视频 `dupOf` 指向 `1-6/` 视频；
+  - 底稿目录条目数 = 实体数，每条 `referencedBy.length ≥ 0` 且骨干文件 ≥ 2；
+  - 出稿 docx 用 `docx_inspect_template` 回读：楷体 GB2312 12pt / `一、（一）1.` / 单元格级边框 / 目录域 `\o "1-2"`。
+- 输出 `golden/report.local.md`；交付时只报数字，不报文件名。
+
+## 6. 验证
+
+- 主仓：`TemplateToolsTest`（fixtures 一份合成模板 docx）、`DocxStyleHelperProfileTest`（写后 docx4j 回读对拍）、`HouseProfileParityTest`、`PluginHostImplTest`（鉴权/配额/任务状态机）、`PluginJobServiceTest`、`DocumentEditToolsEvidenceTest`（doc_link_evidence 四件套 + unverified）、lowa-e2e 新组（`set_style_profile` → `get_formatting` 对拍；`insert_toc`）。
+- 插件仓：单测（编号解析/去重/版本链/状态词各一组向量）、`golden/` 本地跑。
+- 真机走查：拖模板 → 学 → 概览页一行 → 起草一章 → 审阅面板证据页全部 unverified → 点击定位。
+
+## 7. 刻意不做（P1）
+
+核查与 relation 自动判定（P2）；导出 docx/xlsx 四件套（P2）；网核（P3）；LOWA 兜底读模板（P3）；多报告共池的投影 UI（P2 用 EvidenceLink 反查派生）；设置页「团队默认画像」UI（只留 SystemSetting 键）。
+
+## 8. 已确认
+
+1. 私有仓 `zeweihan/aiworkdeck-dd-plugin`（名字暂定）由维护者自建；建好前插件代码在本机 scratch 目录起草，不进主仓。
+2. `plugin-api` 先只发本地 `~/.m2` + 随主仓源码；GitHub Packages 等插件仓 CI 需要时再加。

--- a/docs/superpowers/specs/2026-08-21-dd-p1-drafting-design.md
+++ b/docs/superpowers/specs/2026-08-21-dd-p1-drafting-design.md
@@ -1,7 +1,7 @@
 # 尽调 P1 设计：模板画像 + 插件宿主 SPI + 尽调 JAR 插件（入库整理/起草/勾稽写入）
 
 日期：2026-08-21 ｜ 母卡：dev-board#100 ｜ 上游：总方案 §2 / §5 / §7、样式盘点、样本画像（本机）、P0 设计（EvidenceLink）
-状态：2026-08-21 22:50 维护者通过；私有仓由维护者自建，建好后告知仓名。
+状态：2026-08-21 22:50 维护者通过；私有仓 `zeweihan/aiworkdeck-dd-plugin` 已由本会话创建（22:55）。
 
 ## 0. 本期拍板（2026-08-21 22:40）
 
@@ -190,5 +190,5 @@ prompt.md 工作流：确认主体清单 → `dd_ingest`（等进度）→ 读�
 
 ## 8. 已确认
 
-1. 私有仓 `zeweihan/aiworkdeck-dd-plugin`（名字暂定）由维护者自建；建好前插件代码在本机 scratch 目录起草，不进主仓。
+1. 私有仓 `zeweihan/aiworkdeck-dd-plugin` 已建（private，默认分支 main），插件源码只进这里，不进主仓。
 2. `plugin-api` 先只发本地 `~/.m2` + 随主仓源码；GitHub Packages 等插件仓 CI 需要时再加。

--- a/docs/superpowers/specs/2026-08-21-evidence-link-p0-design.md
+++ b/docs/superpowers/specs/2026-08-21-evidence-link-p0-design.md
@@ -1,0 +1,281 @@
+# EvidenceLink P0 设计（内置底座）：文字 ↔ 文件关联事实表
+
+日期：2026-08-21 ｜ 母卡：dev-board#100 ｜ 上游：`2026-08-21-due-diligence-module-proposal.md` §1 / §5 / §7
+状态：brainstorm 定稿（四项拍板见 §0），待维护者过目后进 writing-plans。
+
+本文只定 P0——平台内置、不门控的部分。尽调插件（P1 起）只是它的第一个消费方。
+
+---
+
+## 0. 本次拍板（2026-08-21 21:55）
+
+| 问题 | 结论 |
+|---|---|
+| 存储形态 | **新表** `evidence_link` + `evidence_link_target`，启动时幂等迁移 `doc_file_link`；旧表只读保留一个发版周期 |
+| 拖到文字上无选区时 | **必须先选中**，toast「先选中文字」；不做拖放点→光标的合成点击 |
+| 查验方法选择 | 建链即成，编辑器内浮动小条（默认「书面审查」，五个 chip 可改，3s 自动收起） |
+| SDK 锚点来源 | `anchor:{selection:true}`（宿主当前选区）与 `anchor:{quote}`（宿主 `find_text_locations` 取唯一命中）两种 |
+
+其余均按总方案：书签锚点、目标位置子表、双向查询、状态机、改字弹窗、`filelink&t=`、审阅面板「证据」页、稳定性前 6 条、lowa-e2e 大文档基线组。
+
+---
+
+## 1. 数据模型
+
+### 1.1 `evidence_link`（主表，一条 = 报告里一个锚点）
+
+| 列 | 类型 | 说明 |
+|---|---|---|
+| `id` | bigint PK | |
+| `project_id` | bigint, not null, idx | |
+| `doc_file_id` | bigint, not null, idx | 报告所在 `ProjectFile.id`（不再用 wpsFileId 软引用） |
+| `link_key` | varchar(64), not null | **= 文档内书签名**。新建 `EVID_<26 位 ULID>`（31 字符，低于 Word 40 字符上限）；迁移行保留原 `lk_*`。唯一索引 `(project_id, link_key)` |
+| `anchor_text` | varchar(1000) | 锚点文字快照（截 1000） |
+| `anchor_hash` | char(64) | `sha256(normalize(anchorText))`，normalize = 去全部空白 + 全角/半角标点归一 + NFKC |
+| `section_path` | varchar(512), idx | 书签所在标题链，`一/（二）/3`；由 worker 派生，不可靠时为空 |
+| `section_title` | varchar(512) | 最近一级标题文字（展示用） |
+| `status` | varchar(16), not null | `active` / `unverified` / `stale` / `orphan`（§1.3） |
+| `created_by_kind` | varchar(8), not null | `human` / `ai` / `plugin` |
+| `created_by` | bigint | userId |
+| `created_at` / `updated_at` / `checked_at` | timestamp | `checked_at` = 最近一次 worker 核对书签的时间 |
+
+### 1.2 `evidence_link_target`（子表，一条 = 一个底稿位置）
+
+| 列 | 类型 | 说明 |
+|---|---|---|
+| `id` | bigint PK | 即 `filelink&t=` 里的 `t` |
+| `link_id` | bigint, not null, idx | FK → evidence_link（应用层级联删除） |
+| `file_id` | bigint, not null, idx | `ProjectFile.id`，必须属于同项目（IDOR 校验沿用） |
+| `locator_json` | text | §1.4，可空 = 整个文件 |
+| `locator_hash` | char(64), not null | sha256(canonical locatorJson)，空 locator 记 `-`；只为唯一索引服务 |
+| `relation` | varchar(16), not null | `supports` / `contradicts` / `partial`；默认 `supports`。**`contradicts` 必须有真实 target**——与 evidence.retrieve.v1 的 ClaimLink 不变式一致，「查无此据」用缺口清单表达，不用 contradicts |
+| `method` | varchar(16) | `written_review`（书面审查）/ `written_statement`（书面说明）/ `web_check`（网络核查）/ `third_party`（第三方材料）/ `interview`（访谈）；可空 |
+| `confidence` | smallint | 0-100，人工建 = null |
+| `note` | varchar(512) | 自由备注 |
+| `sort_order` | int | 同一 link 内显示顺序 |
+| `created_by_kind` / `created_by` / `created_at` | | 同主表 |
+
+唯一索引 `(link_id, file_id, locator_hash)`，`locator_hash` = sha256(canonical locatorJson)（空 locator 记 `-`），防同位置重复挂。
+
+### 1.3 状态机
+
+```
+          建链(human/plugin)            建链(ai)
+               │                          │
+               ▼                          ▼
+            active ◄── 用户「保留关联」── unverified
+               │  ▲                         │
+   anchorHash 变│  │用户「保留关联」          │anchorHash 变
+               ▼  │                         ▼
+             stale ─────────────────────► stale
+               │
+   书签不在了   ▼（任何状态）
+             orphan ── 用户「重新指定」→ active（换 linkKey 书签）/ 删除
+```
+
+- 状态**只由 worker 核对结果与用户动作驱动**，后端不猜。
+- P2 的核查服务会加 `verified_at` 与按 relation/confidence 回写，不改这张状态机。
+- `orphan` 不自动删：它是「这段文字被删了但底稿还在」的证据，审阅面板列出来让用户处置。
+
+### 1.4 `locatorJson` 分型 schema
+
+`type` 判别；**页码 1 基**；坐标 0..1 归一化（相对该页/图片的宽高）；毫秒整数。未知字段忽略不报错，缺 `type` 视为整文件。
+
+```jsonc
+{ "type": "pdf",   "page": 3, "quote": "统一社会信用代码 91…", "rects": [{ "page": 3, "x": 0.12, "y": 0.30, "w": 0.60, "h": 0.04 }] }
+{ "type": "docx",  "bookmark": "EVID_…", "quote": "…", "paragraphIndex": 57 }   // paragraphIndex 0 基，与 doc_* 一致
+{ "type": "image", "rect": { "x": 0.1, "y": 0.2, "w": 0.3, "h": 0.1 } }
+{ "type": "media", "startMs": 125000, "endMs": 143000 }
+{ "type": "web",   "url": "https://…", "capturedAt": "2026-08-21T10:00:00+08:00", "rect": { … } }
+{ "type": "sheet", "sheet": "资产负债表", "cell": "C12" }
+```
+
+- `web` 的 `url/capturedAt` 同时落 `ProjectFile.metaJson`（P0 新增 text 列 `meta_json`，`{sourceUrl, capturedAt, provider}`），locator 里的是该 link 视角的冗余，便于单条导出。
+- P0 定位能力：`docx` 走书签/quote；`pdf` 走 `#page=`；`image` 画框；`media` seek。pdf 引文级叠加高亮（`rects`）P3 接 pdf.js 时启用，P0 只存不画。
+
+### 1.5 旧数据迁移
+
+`EvidenceLinkMigrationRunner`（ApplicationRunner，幂等，`evidence_link` 非空或 `doc_file_link` 不存在即跳过）：
+- 每行 `doc_file_link` → 一条 `evidence_link`（`link_key` 原值，`doc_file_id` 按 `(project_id, wps_file_id)` 反查 `ProjectFile`，查不到的行跳过并 WARN 计数）+ `fileIdsJson` 每个 fileId 一条 target（`locator_json` 空、`relation=supports`、`method` 空、`created_by_kind=human`）；`status=unverified`（还没核对过书签）。
+- 文档里旧链接只有字符属性没有书签：worker 新原语 `adopt_legacy_links` 在文档打开后（`ready` 之后、首轮 `check_link_anchors` 之前）扫全文 `HyperLinkURL` 含 `filelink?k=` 的 run，对没有同名书签的就地套书签（名 = k）。之后状态由正常核对得出。
+- 旧表、旧 `DocFileLinkController`（`/api/projects/{pid}/doc-links`）保留但**改为只读代理到新 Service**（前端老版本仍能点开链接），下个发版周期删。
+
+---
+
+## 2. 后端
+
+### 2.1 `EvidenceLinkService`（单一出口）
+
+```
+create(userId, projectId, docFileId, linkKey?, anchorText, sectionPath?, sectionTitle?, createdByKind, targets[])  → LinkView
+addTargets(userId, projectId, linkKey, targets[])                                                                → LinkView
+updateTarget(userId, projectId, targetId, {relation?, method?, confidence?, note?, locatorJson?})                → TargetView
+removeTarget(userId, projectId, targetId)
+delete(userId, projectId, linkKey)
+getByKey(userId, projectId, linkKey)                                                                              → LinkView
+listByDoc(userId, projectId, docFileId, {status?, sectionPath?})                                                  → LinkView[]
+listByFile(userId, projectId, fileId)                                                                             → LinkView[]   // 反查：这份底稿被哪些段落引用
+listBySection(userId, projectId, docFileId, sectionPathPrefix)                                                    → LinkView[]
+listByParty(userId, projectId, docFileId, tagId)                                                                  → LinkView[]   // 主体视图：targets.file 挂了该 PARTY 标签
+reportAnchors(userId, projectId, docFileId, [{linkKey, exists, text}])                                            → {changed:[linkKey…]}   // worker 核对结果回写状态
+keepAnchor(userId, projectId, linkKey)                                                                            // stale→active，刷新 anchorText/anchorHash
+rebind(userId, projectId, linkKey, newLinkKey, anchorText)                                                        // orphan→active，换书签
+refCounts(projectId, fileIds[])                                                                                   → Map<fileId, count>   // 文件树「被引用 N 次」角标
+```
+
+- 权限：读 = `hasReadPermission`，写 = `hasWritePermission`（不再创建者私有）。
+- `LinkView = {id, linkKey, docFileId, anchorText, sectionPath, sectionTitle, status, createdByKind, createdAt, updatedAt, targets:[{id, fileId, file:{id,name,fileType,parentId,isDeleted}, locator, relation, method, confidence, note}]}`。
+- 文件删除/回收站：`ProjectFileService` 软删文件时**不删 link**，`LinkView.file.isDeleted=true` 由面板灰显；彻底删除时级联删 target，target 空的 link 标 `orphan`（这是唯一由后端改状态的例外，因为 worker 看不见文件系统）。
+
+### 2.2 REST `/api/projects/{pid}/evidence-links`
+
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| POST | `/` | create |
+| GET | `/{linkKey}` | getByKey |
+| GET | `/?docFileId=&status=&sectionPath=` | listByDoc |
+| GET | `/?fileId=` | listByFile |
+| GET | `/?docFileId=&partyTagId=` | listByParty |
+| POST | `/{linkKey}/targets` | addTargets |
+| PATCH | `/targets/{targetId}` | updateTarget |
+| DELETE | `/targets/{targetId}` | removeTarget |
+| DELETE | `/{linkKey}` | delete |
+| POST | `/anchors/report` | reportAnchors（worker 核对结果） |
+| POST | `/{linkKey}/keep` | keepAnchor |
+| POST | `/{linkKey}/rebind` | rebind |
+| GET | `/ref-counts?fileIds=` | refCounts |
+
+错误信封沿用项目惯例；付费闸门不在这里（内置能力）。
+
+### 2.3 AI 工具面
+
+P0 **不**加 `doc_link_evidence`（P1 随起草一起上，避免工具先于 prompt 上线被模型乱用）。但 `doc_set_hyperlink` 的 http/https 白名单**在 P0 放行** `https://checkba-internal.local/open?u=checkba://filelink` 前缀（否则 P1 的工具没法复用同一条写链接路径）。
+
+---
+
+## 3. worker（office_thread.js）新原语
+
+| action | 参数 | 返回 | 说明 |
+|---|---|---|---|
+| `bookmark_selection` | `{name}` | `{success, name, text}` | 给**当前选区**套命名书签；选区空 → 失败；重名 → 失败（不像 insert_link_with_bookmark 那样加 `_n`，linkKey 必须精确） |
+| `get_bookmark_context` | `{name}` | `{exists, text, sectionPath, sectionTitle, paragraphIndex}` | 从书签锚点向前扫 `OutlineLevel>0` 的段落拼标题链（最多 6 级），配合 `get_outline` 的同一判据 |
+| `check_link_anchors` | `{names[]}` | `{items:[{name, exists, text}]}` | 批量核对；单次 ≤ 200 个，超出由宿主分批 |
+| `adopt_legacy_links` | `{}` | `{adopted:[name…], skipped}` | §1.5；只处理 `filelink?k=` 且无同名书签的 run |
+| `goto_bookmark` | `{name}` | `{success}` | `anchorRange(name)` + `selectVisibly`；不再借 `set_selection`（它只认 `__ai_anchor_*`） |
+
+- 四件套地雷：`EDITOR_ACTIONS` 白名单 + `toolDisplayNames.js` 不需要（P0 无 AI 工具），但 **`libreofficeExecutorClient.js` 与 `zetaOfficeRelay.js` 的 action 透传不需改**（按名透传）。
+- 失败返回同时写 `message` 与 `error`（已知地雷）。
+- `check_link_anchors` 在 office 线程上是 O(关联数) 的同步调用：宿主侧节流——`modified` 防抖 3s 或保存后触发，且只核对**当前文档**的 link；单文档超过 200 条分批、批间让路 autosave。
+
+---
+
+## 4. 前端
+
+### 4.1 拖拽建链升级
+
+- 投放区从侧栏 `FileLinkDropZone` 改到**编辑器区域本身**：`LibreOfficeEditor.vue` 外层容器 `@dragover/@drop` 接 `application/x-checkba-file`（文件夹不接）。拖拽进行中整个编辑器描一圈高亮边，提示「松开即关联到选中文字」。原 `FileLinkDropZone` 删除。
+- drop 处理（`evidenceLinkActions.js`，从 project-overview.vue 拆出的新模块）：
+  1. `get_selection_hyperlink` 读选区；空 → toast「先选中文字」返回。
+  2. 选区已带 `filelink?k=` → 复用 linkKey（追加 target）；否则生成 `EVID_<ulid>`，`bookmark_selection(name)` + `set_selection_hyperlink(wrapped url)`。
+  3. `get_bookmark_context(name)` 取 sectionPath/sectionTitle。
+  4. `POST /evidence-links`（或 `/targets`），target `{fileId, relation:'supports', method:'written_review'}`。
+  5. 浮动小条 `EvidenceMethodBar.vue`：锚在编辑器底部，「已关联《文件名》· 方法：[书面审查][书面说明][网络核查][第三方材料][访谈]」，点 chip → `PATCH /targets/{id}`；3s 无操作自动收起；连续拖放只保留最后一条。
+- web 包装链接、`checkba://filelink?k=&projectId=` 内层格式**不变**，新增可选 `&t=<targetId>`。
+
+### 4.2 点击链接与定位
+
+- `onLibreOpenUrl` 解包：`k` → `GET /evidence-links/{k}`；带 `t` 且命中 → 直接打开该 target；不带 `t` 且 targets>1 → 现有 `filelink-dialog` 改为列出 target（文件名 + 方法 + 定位摘要）。
+- `openFile(file, {locator})`：`fileOpenTabs.openFile` 加可选第二参，tab 对象带 `pendingLocator`；消费方：
+  - `LibreOfficeEditor` ready 后：`locator.bookmark` → `goto_bookmark`；否则 `quote` → `find_text_locations` 首个命中 → `set_selection`；消费后清 `pendingLocator`。
+  - `FilePreview` pdf：`blobUrl + '#page=' + page`（Chromium 原生 viewer）；image：按 `rect` 叠一个绝对定位高亮框（随缩放联动）；audio/video：`loadedmetadata` 后 `currentTime = startMs/1000`。
+- 后端 `sendOpenFileAction(file, locator?)` 同步加字段（P1 AI 工具要用）。
+
+### 4.3 审阅面板「证据」页
+
+`ReviewPanel.vue` 加第三个 tab「证据」（`editor.review.evidenceTab`），内容组件 `EvidencePanel.vue`（独立文件，ReviewPanel 只做 tab 壳）：
+- 顶部切换「按章节 / 按主体」+ 状态筛选（全部 / 待核 / 已变 / 失联）。
+- 按章节：按 `sectionPath` 分组折叠，组头显示章节标题与计数；按主体：按 targets 文件的 PARTY 标签分组（无 PARTY 的归「未归属」）。
+- 每条卡片：锚点文字（截两行）· 状态色点（active 绿 / unverified 灰 / stale 黄 / orphan 红）· targets 列表（文件名 + 方法 chip + 定位摘要如「第 3 页」「02:05」）。
+- 动作：点卡片 → `goto_bookmark`；点 target → 打开并定位；stale 卡「保留关联」；orphan 卡「重新指定」（进入「选中新文字后点确认」模式）/「删除」；target 行可改方法、删。
+- 数据：打开 tab 时 `listByDoc(docFileId)` 一次 + 监听 `evidence-changed` 事件刷新；状态变化来自 4.4。
+
+### 4.4 改字 stale 检测与弹窗
+
+- `LibreOfficeEditor.vue`：`onDocModified` 之后起 3s 防抖（与 autosave 共用 `_cmdBusy` 让路规则），到点或 `flushSave` 前调 `check_link_anchors(names)`（names = 当前文档 `listByDoc` 缓存里的 linkKey）。
+- 对比本地缓存的 `anchorHash`（归一化算法前后端各一份，**对拍测试**钉住同一份向量）：变了 → `POST /anchors/report` → 更新缓存状态 → emit `evidence-changed`。
+- 弹窗 `EvidenceStaleBar.vue`：编辑器顶部非阻塞条「这段文字有 N 份底稿，文字已改动：[保留关联] [查看底稿] [忽略]」。合并规则：同一 linkKey 在一次连续编辑（两次 `modified` 间隔 <3s 视为连续）里只弹一次；多条同时 stale 合并为一条「N 段文字已改动」并展开列表；忽略 = 本会话不再为该 linkKey 弹，状态仍是 stale，面板照常亮黄。
+- 审阅面板关闭时也要弹（弹窗不依赖面板打开）。
+
+### 4.5 文件树
+
+- 「被引用 N 次」角标：树刷新时 `GET /ref-counts?fileIds=`（只查当前可见节点，分批 ≤ 200）。
+- 零引用文件**不**在 P0 灰显（要等 P1 入库整理后才有意义，灰显会误伤普通项目）。
+
+---
+
+## 5. 三方 Web 插件 SDK v1 新增（契约只加不破）
+
+| 方法 | 参数 | 返回 | 权限 |
+|---|---|---|---|
+| `evidence.link` | `{ anchor: { selection: true } \| { quote }, docPath?, targets: [{ path, locator?, relation?, method?, note? }] }` | `{ linkKey, targetIds: [] }` | `editor` |
+| `evidence.list` | `{ docPath?, path?, sectionPath?, status? }` | `{ links: [{ linkKey, docPath, anchorText, sectionPath, status, targets: [{ targetId, path, locator, relation, method }] }] }` | `file_read` |
+| `evidence.locate` | `{ linkKey, targetId? }` | `{}` | `editor` |
+
+- 路径口径与 `files.*` 一致（项目内相对路径），宿主负责 path ↔ fileId。
+- `anchor.quote`：宿主 `find_text_locations` 必须**恰好 1 个**命中，0 或多 → `{code:'anchor_ambiguous'}`；`selection:true` 而当前无选区 → `{code:'no_selection'}`。错误码新增这两个 + `not_found`（链接/文件不存在）。
+- `docPath` 缺省 = 当前聚焦窗格打开的 Word 文档；没有 → `no_active_document`。
+- 四处同步：`sdk/plugin-sdk/awd-plugin-sdk.js`（源头）、官网 `lib/plugin-template.ts` 内联副本、`examples/hello-web-plugin/` 副本（三者 sha256 一致的测试要更新）、`PluginPane.vue` 宿主实现；官网模板的宿主模拟器补这三个方法的假实现。
+- `docs/PLUGIN_SPEC.md` §8 方法表同步。
+
+---
+
+## 6. 稳定性前 6 条（P0 必修，按盘点编号）
+
+| # | 改动 | 验证 |
+|---|---|---|
+| 1 | `MAX_IMPORT_ENTRIES` 3000 → 30000，超出时 `truncated` 进对账结果 + 前端一次性 toast「本次导入截断，N 项未纳入」；对账改为按 watcher 事件子树 | 单测造 3001 条目录 → 全部入库；30001 条 → 截断提示可见 |
+| 2 | `createFile/createFolder` 的同级全量扫描 → `select max(sort_order)` 单查；同名冲突 → 服务端统一加 ` (n)`（`createFile` 新增 `onConflict=rename\|fail` 参数，默认 `rename`，老调用点显式传 `fail` 保持行为） | 单测：300 次同名 create 各得唯一名；查询计数断言 |
+| 3 | `find_replace` 等批量改稿：worker 超过 50 命中分批（每批 ≤ 30）并经 relay 回传进度；`EditorBridgeService` 按 action 分级超时（open/stream 180s、批量 120s、其余 30s）；取消 = 后续批次不再执行 | lowa-e2e 大文档组：150 命中 < 8s |
+| 4 | `apply_house_style` 按段落范围分批（每批 500 元素）+ `truncated` 字段 + 进度 | 大文档组：921 段不超时、无 truncated |
+| 5 | `get_document_text` 段落索引缓存：一次建 `index → XTextRange` 数组，`modified` 时失效、下次按需重建；`total` 缓存 | 大文档组：第二次翻页 < 300ms |
+| 6 | `FileTree.vue` 首屏只拉根层、展开按 parentId 拉；超过 100 子项的文件夹窗口化渲染；`buildTreeView` 先按 parentId 分组 | 单测 + app-e2e 现有旅程不红 |
+
+---
+
+## 7. lowa-e2e「大文档基线组」
+
+- 夹具生成脚本 `frontend/tests/lowa-e2e/fixtures/gen-big-doc.py`（python-docx + PIL，150 页/30 表/20 图，按稳定性盘点附录 A），产物不入库、首次运行生成到 scratch。
+- 组内步骤：`load_document` / `get_document_text` 两次 / `find_text_locations` 600 命中 / `find_replace` 修订 150 命中 / `apply_house_style` / `export_document` / 连续 30s 无 `modified`。
+- **三次取中位数**，阈值 = 基线 × 3（同机抖动 2 倍已实证）；`find_replace` 150 命中 < 8s、`apply_house_style` 不超时且 `truncated=false`、`get_document_text` 二次 < 300ms 是硬阈。
+- `LOWA_E2E_BIG=1` 时才跑（默认 e2e 基线不拖慢）；CI 不跑，发版前本机跑。
+
+---
+
+## 8. 测试与验证
+
+- 后端：`EvidenceLinkServiceTest`（建/追加/反查/状态机/权限/IDOR/迁移幂等）、`AnchorHashParityTest`（与前端共用 `fixtures/anchor-hash-vectors.json`）、`ProjectFileServiceConflictTest`、`LocalProjectImportCapTest`。
+- 前端：`anchorHash.test.js`（同一向量）、`evidenceLinkActions.test.js`（drop 四步与 method bar）、`EvidencePanel` 分组逻辑单测、`check:emits`。
+- worker：lowa-e2e 新组「证据锚点」（选中 → bookmark_selection → 改字 → check_link_anchors 变 → 删字 → exists=false → adopt_legacy_links 对旧链接套书签）+ 大文档组。
+- SDK：`sdk/plugin-sdk` 的 parity 测试加三方法；官网模拟器同步。
+- 真机走查（交付时列给维护者）：拖拽到文字 → 小条改方法 → 点链接定位 pdf 第 N 页 → 改字弹窗 → 面板按章节/主体切换。
+
+---
+
+## 9. 刻意不做（P0）
+
+AI 工具 `doc_link_evidence`（P1）；pdf 引文叠加高亮与 pdf.js（P3）；零引用文件灰显（P1 后）；核查服务与 relation 自动判定（P2）；拖放点→光标合成点击（已拍板不做）；新左栏面板；`CHAPTER` 标签类型（章节归属由反查派生）。
+
+---
+
+## 10. 实施切分（供 writing-plans）
+
+可并行的独立单元（各一棵 worktree）：
+A. 后端实体/Repo/Service/Controller/迁移 + 测试（契约文件，主模型）
+B. worker 五原语 + lowa-e2e 证据锚点组（契约文件，主模型）
+C. 前端拖拽建链 + method bar + 链接定位 + openFile(locator)（依赖 A/B 的契约，可按契约先写）
+D. 审阅面板「证据」页 + stale 弹窗（依赖 A/B 契约）
+E. SDK 三方法 + PluginPane 宿主实现 + 官网同步（契约文件）
+F. 稳定性 #1/#2/#6（后端 + FileTree，机械，Sonnet 可做；校验自己做）
+G. 稳定性 #3/#4/#5 + 大文档基线组（worker 性能改造，主模型）
+
+合并顺序：A → B → (C, D, E, F, G 任意，后合者 rebase 重跑)。每个单元一个 PR；A/B 合并后 `.claude/agents/ai-doc-bridge.md` 的契约段随 PR 落地。


### PR DESCRIPTION
P1 brainstorm 定稿。拍板：尽调插件为独立 JAR（私有仓，维护者自建）；主仓新增 plugin-api 宿主 SPI、模板画像、HOUSE 单源、doc_link_evidence。

🤖 Generated with [Claude Code](https://claude.com/claude-code)