### PR TITLE
fix(lowa): adopt_legacy_links 生产 URL 形态 key 提取 + 逐目标隔离（dev-board#103 复核）

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -128,8 +128,8 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 |---|---|---|
 | `bookmark_selection` | `{name}` | `{success, name, text}`；空选区 / 非法名 / **重名精确拒绝**（不像 `insert_link_with_bookmark` 那样加 `_n`） |
 | `get_bookmark_context` | `{name}` | `{success, exists, text, sectionPath, sectionTitle, paragraphIndex}`；不存在是 `exists:false` 不是失败 |
-| `check_link_anchors` | `{names[]}` | `{success, items:[{name, exists, text}]}`；单次 ≤200，宿主分批 |
-| `adopt_legacy_links` | `{}` | `{success, adopted:[name], skipped}`；收编 `filelink?k=<key>` 超链接 run 为同名书签，幂等 |
+| `check_link_anchors` | `{names[]}` | `{success, items:[{name, exists, text}], truncated}`；单次 ≤200（超出截断并置 `truncated:true`），宿主分批 |
+| `adopt_legacy_links` | `{}` | `{success, adopted:[name], skipped, skippedInvalid}`；先对整条 URL decodeURIComponent（最多两层）再匹配 `filelink?k=<key>`（到 `&`/`#` 止），生产形态 `open?u=encodeURIComponent('checkba://filelink?k=…&projectId=…')` 取到的 key 恰等于原 key；key 含 `[A-Za-z0-9_]` 以外字符（如后端兜底 `lk_<UUID>` 带 `-`）**不改写、计入 `skippedInvalid`（按去重 key 计）**；逐目标 try/catch，单个坏 run 只 `skipped++`；幂等 |
 | `goto_bookmark` | `{name}` | `{success, name}`；`anchorRange` + `selectVisibly`，不借 `set_selection`（它只认 `__ai_anchor_*`） |
 
 真机实测结论（lowa-e2e 组 27，2026-08-21）：
@@ -141,6 +141,6 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 
 ## 验证
 
-- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，27 组人机模拟，2026-08-21 基线 417 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
+- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，27 组人机模拟，2026-08-21 基线 421 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
 - 涉桌面壳/webview：`npm run test:desktop-e2e`（弹 dev Electron 窗口，验证保存落盘链路）。
 - 全应用：`npm run test:app-e2e`。改编辑器三件套（原语/白名单/worker）必跑 lowa-e2e。

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -3227,8 +3227,10 @@ const EXEC = {
     const name = String((p && p.name) || '');
     if (!/^[A-Za-z0-9_]{1,64}$/.test(name)) return bmFail('bookmark name must match [A-Za-z0-9_]{1,64}: ' + name);
     const range = selectionRange();
-    const text = range ? (range.getString() || '') : '';
-    if (!range || !text.length) return bmFail('no selection to bookmark');
+    // 形状/图片选区不是 XTextRange（没有 getString），不能落到外层 dispatcher 只带 message
+    if (!range || typeof range.getString !== 'function') return bmFail('no text selection to bookmark');
+    const text = range.getString() || '';
+    if (!text.length) return bmFail('no selection to bookmark');
     const bms = xModel.getBookmarks();
     if (bms.hasByName(name)) return bmFail('bookmark exists: ' + name);
     try {
@@ -3267,14 +3269,31 @@ const EXEC = {
       try { if (bms.hasByName(n)) { exists = true; text = bms.getByName(n).getAnchor().getString() || ''; } } catch (e) {}
       items.push({ name: n, exists: exists, text: text });
     }
-    return { success: true, items: items };
+    const total = Array.isArray(p && p.names) ? p.names.length : 0;
+    return { success: true, items: items, truncated: total > 200 };
   },
   // 旧式关联（超链接 filelink?k=<key>）收编为同名书签；已有同名书签的跳过。
   // 同一 run 被格式变化拆成多个 portion 时只有第一个被套上（后面 hasByName 命中
   // skipped）——书签覆盖不全但锚点有效。
   adopt_legacy_links() {
     if (!isWriterDoc()) return bmFail(NOT_TEXT_DOC_MSG);
-    const adopted = []; let skipped = 0;
+    const adopted = []; let skipped = 0, skippedInvalid = 0;
+    const invalidSeen = {};
+    // 生产链接形态：https://checkba-internal.local/open?u= + encodeURIComponent(
+    // 'checkba://filelink?k=<key>&projectId=<pid>')，即 ...%3Fk%3Dlk_x%26projectId%3D42。
+    // 先把整条 URL 解码（最多两层）再匹配，key 取到 & / # 为止；key 含
+    // [A-Za-z0-9_] 以外字符（后端兜底 lk_<UUID> 带 -）不能静默改写成别的名字
+    // ——那会永远对不上 link_key 且二次运行被 hasByName 误判 skipped——计入
+    // skippedInvalid 跳过。
+    function legacyKeyOf(url) {
+      let s = String(url || '');
+      for (let i = 0; i < 2 && /%[0-9A-Fa-f]{2}/.test(s); i++) {
+        try { s = decodeURIComponent(s); } catch (e) { break; }
+      }
+      const m = /filelink\?k=([^&#\s]+)/.exec(s);
+      if (!m) return null;
+      return { key: m[1], valid: /^[A-Za-z0-9_]{1,64}$/.test(m[1]) };
+    }
     try {
       const bms = xModel.getBookmarks();
       const xText = xModel.getText();
@@ -3291,28 +3310,29 @@ const EXEC = {
           const portion = pen.nextElement();
           let url = '';
           try { url = String(portion.getPropertyValue('HyperLinkURL') || ''); } catch (e) { continue; }
-          const m = /filelink(?:\?|%3F)k(?:=|%3D)([A-Za-z0-9_%\-]+)/.exec(url);
-          if (!m) continue;
-          let key = m[1];
-          try { key = decodeURIComponent(key); } catch (e) {}
-          key = key.replace(/[^A-Za-z0-9_]/g, '_');
-          if (!key) continue;
-          targets.push({ key: key, start: portion.getStart(), end: portion.getEnd() });
+          const k = legacyKeyOf(url);
+          if (!k) continue;
+          // 同一 run 常被书签/格式边界拆成多个 portion：非法 key 按去重后的 key 计数
+          if (!k.valid) { if (!invalidSeen[k.key]) { invalidSeen[k.key] = true; skippedInvalid++; } continue; }
+          targets.push({ key: k.key, start: portion.getStart(), end: portion.getEnd() });
         }
       }
+      // 逐目标隔离：一个坏 run 不能把已成功的 adopted 整体报成失败
       for (let i = 0; i < targets.length; i++) {
         const t = targets[i];
-        if (bms.hasByName(t.key)) { skipped++; continue; }
-        const cur = xText.createTextCursorByRange(t.start);
-        cur.gotoRange(t.end, true);
-        if (!(cur.getString() || '').length) { skipped++; continue; }
-        const bm = xModel.createInstance('com.sun.star.text.Bookmark');
-        bm.setName(t.key);
-        xText.insertTextContent(cur, bm, true);
-        adopted.push(t.key);
+        try {
+          if (bms.hasByName(t.key)) { skipped++; continue; }
+          const cur = xText.createTextCursorByRange(t.start);
+          cur.gotoRange(t.end, true);
+          if (!(cur.getString() || '').length) { skipped++; continue; }
+          const bm = xModel.createInstance('com.sun.star.text.Bookmark');
+          bm.setName(t.key);
+          xText.insertTextContent(cur, bm, true);
+          adopted.push(t.key);
+        } catch (e) { skipped++; }
       }
     } catch (e) { return bmFail('adopt_legacy_links failed: ' + errStr(e)); }
-    return { success: true, adopted: adopted, skipped: skipped };
+    return { success: true, adopted: adopted, skipped: skipped, skippedInvalid: skippedInvalid };
   },
   // 跳到书签：anchorRange + selectVisibly（不借 set_selection，它只认 __ai_anchor_*）。
   goto_bookmark(p) {

--- a/frontend/tests/lowa-e2e/README.md
+++ b/frontend/tests/lowa-e2e/README.md
@@ -43,9 +43,10 @@ npm run test:lowa-e2e
 9-26. 见 run.mjs 各组标题（条款识别 / 修订署名与颗粒度 / 批注 / 版本对比 / 表格 / Calc / Impress / 工具栏与查找 / chrome 退场）
 27. EvidenceLink 证据锚点（dev-board#103）：bookmark_selection / get_bookmark_context /
     check_link_anchors / adopt_legacy_links / goto_bookmark，含书签内插字扩张、整段删除
-    书签随之消失、旧式 filelink 超链接收编、docx 往返存活（27 步）
+    书签随之消失、旧式 filelink 超链接收编（含生产 URL 形态与非法 key 跳过）、
+    docx 往返存活（31 步）
 
-步数基线：2026-08-21 组 27 落地后 417 步全绿（此前 390）。
+步数基线：2026-08-21 组 27 落地后 421 步全绿（此前 390）。
 
 ## 机制说明
 

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -1731,6 +1731,25 @@ try {
     check('再次收编幂等（adopted 空、skipped>=1）', ad2.success === true && (ad2.adopted || []).length === 0 && ad2.skipped >= 1, JSON.stringify(ad2))
     const cOld = await exec('get_bookmark_context', { name: 'lk_old_1' })
     check('收编后的书签文字 = 链接文字', cOld.exists === true && cOld.text === '注册资本', JSON.stringify(cOld))
+    // 7b. 生产 URL 形态：整体 encodeURIComponent、带 &projectId=——key 必须恰等于原 key，
+    // 不许把 %26projectId%3D42 吞进去改写成 lk_123_abc_projectId_42
+    await exec('goto', { type: 'end' })
+    await exec('insert_at_cursor', { text: '\n经营范围为软件开发。' })
+    await selectText('经营范围')
+    const prodUrl = 'https://checkba-internal.local/open?u=' + encodeURIComponent('checkba://filelink?k=lk_123_abc&projectId=42')
+    await exec('set_selection_hyperlink', { url: prodUrl })
+    const ad3 = await exec('adopt_legacy_links', {})
+    check('生产 URL 形态收编 key 恰等于 lk_123_abc', ad3.success === true && JSON.stringify(ad3.adopted) === '["lk_123_abc"]', JSON.stringify(ad3))
+    check('收编后书签文字 = 经营范围', (await exec('get_bookmark_context', { name: 'lk_123_abc' })).text === '经营范围')
+    // 7c. 非法 key（后端兜底 lk_<UUID> 带 -）：跳过并计入 skippedInvalid，不静默改写
+    await exec('goto', { type: 'end' })
+    await exec('insert_at_cursor', { text: '\n法定代表人为张三。' })
+    await selectText('法定代表人')
+    await exec('set_selection_hyperlink', { url: 'https://checkba-internal.local/open?u=' + encodeURIComponent('checkba://filelink?k=lk_a-b&projectId=42') })
+    const ad4 = await exec('adopt_legacy_links', {})
+    check('带 - 的 key 进 skippedInvalid 且不收编', ad4.success === true && ad4.skippedInvalid === 1 && (ad4.adopted || []).length === 0, JSON.stringify(ad4))
+    const ck4 = await exec('check_link_anchors', { names: ['lk_a-b', 'lk_a_b'] })
+    check('非法 key 没被改写成别名落成书签', ck4.items.every((x) => x.exists === false) && ck4.truncated === false, JSON.stringify(ck4))
 
     // 8. docx 往返：书签经 export/load 存活
     await exec('clear_anchors', {})


### PR DESCRIPTION
PR #540 复核四条的 follow-up。

1. **Critical** `adopt_legacy_links` key 提取：整条 URL 先 `decodeURIComponent`（最多两层）再匹配 `filelink\?k=([^&#\s]+)`。生产形态 `open?u=encodeURIComponent('checkba://filelink?k=lk_123_abc&projectId=42')` 取到的 key 恰等于 `lk_123_abc`（此前会吞进 `%26projectId%3D42` 改写成 `lk_123_abc_projectId_42`）。key 含 `[A-Za-z0-9_]` 以外字符（后端兜底 `lk_<UUID>` 带 `-`）不静默改写，计入 `skippedInvalid`（按去重 key 计）。
2. **Important** 插入循环逐目标 try/catch，单个坏 run 只 `skipped++`，不把已成功的 adopted 整体报成 `success:false`。
3. **Minor** `bookmark_selection`：非 XTextRange 选区（形状）守卫 `typeof range.getString === 'function'`，走 `bmFail` 双字段。
4. **Minor** `check_link_anchors` 返回加 `truncated: names.length > 200`。

返回形状：`adopt_legacy_links` → `{success, adopted, skipped, skippedInvalid}`；`check_link_anchors` → `{success, items, truncated}`。doc-editor.md 表格与基线同步。

### e2e
组 27 新增 4 步：生产 URL 形态断言 `adopted === ["lk_123_abc"]`；`lk_a-b` 形态断言 `skippedInvalid === 1` 且 `lk_a-b`/`lk_a_b` 都不存在。`build:zetaoffice` + diff 一致 + `npm run test:lowa-e2e`：**421 passed, 0 failed**（基线 417 → 421）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
