### PR TITLE
fix(evidence): 复核修复——exists 可空/target kind/refCounts 项目过滤/locator 数字归一（dev-board#102）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -140,7 +140,7 @@ txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue�
 | `evidence_link`（一条 = 一个书签锚点） | `evidence_link_target`（一条 = 一个底稿位置，id 即 `filelink&t=` 的 t） |
 |---|---|
 | `project_id`、`doc_file_id`（报告 ProjectFile.id，不再用 wpsFileId 软引用） | `link_id`（应用层级联删除）、`file_id`（必须同项目，IDOR 在 Service） |
-| `link_key` varchar(64) **= 文档内书签名**，唯一 `(project_id, link_key)`；新建 `EVID_<26 位 ULID>`（31 字符，只含 `[A-Za-z0-9_]`），迁移行保留 `lk_*` | `locator_json` text（可空 = 整个文件）、`locator_hash` char(64) = sha256(键排序 canonical JSON)，空记 `-`；唯一 `(link_id, file_id, locator_hash)` |
+| `link_key` varchar(64) **= 文档内书签名**，唯一 `(project_id, link_key)`；新建 `EVID_<26 位 ULID>`（31 字符，只含 `[A-Za-z0-9_]`），迁移行保留 `lk_*` | `locator_json` text（可空 = 整个文件）、`locator_hash` char(64) = sha256(键排序 + 数字归一的 canonical JSON，根必须是对象)，空记 `-`；唯一 `(link_id, file_id, locator_hash)` |
 | `anchor_text` varchar(1000) 快照、`anchor_hash` = `AnchorHash.of(anchorText)` | `relation` supports/contradicts/partial（默认 supports；**contradicts 必须有真实 target**，「查无此据」走缺口清单） |
 | `section_path`（标题链 `一/（二）/3`，worker 派生）、`section_title` | `method` written_review/written_statement/web_check/third_party/interview，可空 |
 | `status` active/unverified/stale/orphan；`created_by_kind` human/ai/plugin | `confidence` 0-100（人工 = null）、`note`、`sort_order` |
@@ -162,10 +162,10 @@ txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue�
 | GET | `/?docFileId=&status=&sectionPath=` | listByDoc（sectionPath 是前缀） |
 | GET | `/?fileId=` | listByFile（反查，优先于 docFileId） |
 | GET | `/?docFileId=&partyTagId=` | listByParty（targets.file 挂了该 PARTY 标签） |
-| POST | `/{linkKey}/targets` | addTargets（body 是 TargetInput 数组；同 locatorHash 去重） |
+| POST | `/{linkKey}/targets?createdByKind=` | addTargets（body 是 TargetInput 数组；同 locatorHash 去重；createdByKind human/ai/plugin 缺省 human，记在 target 上） |
 | PATCH | `/targets/{targetId}` | updateTarget（null 字段不改） |
 | DELETE | `/targets/{targetId}` / `/{linkKey}` | removeTarget / delete |
-| POST | `/anchors/report` | `{docFileId, reports:[{linkKey, exists, text}]}` → `{changed:[linkKey]}`（worker 核对回写） |
+| POST | `/anchors/report` | `{docFileId, reports:[{linkKey, exists, text}]}` → `{changed:[linkKey], ignored:N}`（worker 核对回写；`exists` 缺失的条目不改状态、计入 ignored，不许当 false 打 orphan） |
 | POST | `/{linkKey}/keep` | `{text}` keepAnchor |
 | POST | `/{linkKey}/rebind` | `{newLinkKey, anchorText, sectionPath?, sectionTitle?}` |
 | GET | `/ref-counts?fileIds=` | `Map<fileId, count>`（文件树角标） |

--- a/backend/src/main/java/com/checkba/controller/EvidenceLinkController.java
+++ b/backend/src/main/java/com/checkba/controller/EvidenceLinkController.java
@@ -4,6 +4,7 @@ import com.checkba.service.LangText;
 import com.checkba.service.ProjectMemberService;
 import com.checkba.service.evidence.EvidenceLinkService;
 import com.checkba.service.evidence.EvidenceLinkViews.AnchorReport;
+import com.checkba.service.evidence.EvidenceLinkViews.AnchorReportResult;
 import com.checkba.service.evidence.EvidenceLinkViews.LinkView;
 import com.checkba.service.evidence.EvidenceLinkViews.TargetInput;
 import com.checkba.service.evidence.EvidenceLinkViews.TargetView;
@@ -89,12 +90,14 @@ public class EvidenceLinkController {
         return svc.getByKey(uid(sessionId), projectId, linkKey);
     }
 
+    /** body 是 TargetInput 数组；可选 ?createdByKind=human|ai|plugin（默认 human）记在每条 target 上。 */
     @PostMapping("/" + KEY + "/targets")
     public LinkView addTargets(@PathVariable Long projectId,
                                @PathVariable String linkKey,
                                @RequestBody List<TargetInput> targets,
+                               @RequestParam(required = false) String createdByKind,
                                @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
-        return svc.addTargets(uid(sessionId), projectId, linkKey, targets);
+        return svc.addTargets(uid(sessionId), projectId, linkKey, targets, createdByKind);
     }
 
     @PatchMapping("/targets/{targetId}")
@@ -121,7 +124,7 @@ public class EvidenceLinkController {
         return Map.of("success", true);
     }
 
-    /** worker check_link_anchors 的结果回写：{docFileId, reports:[{linkKey, exists, text}]} → {changed:[linkKey]}。 */
+    /** worker check_link_anchors 的结果回写：{docFileId, reports:[{linkKey, exists, text}]} → {changed:[linkKey], ignored:N}（exists 缺失的条目不改状态、计入 ignored）。 */
     @PostMapping("/anchors/report")
     public Map<String, Object> reportAnchors(@PathVariable Long projectId,
                                              @RequestBody ReportReq r,
@@ -129,8 +132,8 @@ public class EvidenceLinkController {
         if (r.getDocFileId() == null) {
             throw new IllegalArgumentException(LangText.of("docFileId 必填", "docFileId required"));
         }
-        List<String> changed = svc.reportAnchors(uid(sessionId), projectId, r.getDocFileId(), r.getReports());
-        return Map.of("changed", changed);
+        AnchorReportResult res = svc.reportAnchors(uid(sessionId), projectId, r.getDocFileId(), r.getReports());
+        return Map.of("changed", res.changed(), "ignored", res.ignored());
     }
 
     /** 用户「保留关联」，body {text} = 当前锚点文字。 */

--- a/backend/src/main/java/com/checkba/service/evidence/EvidenceLinkMigrationRunner.java
+++ b/backend/src/main/java/com/checkba/service/evidence/EvidenceLinkMigrationRunner.java
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * doc_file_link → evidence_link 启动迁移（spec §1.5）。幂等：evidence_link 非空或 doc_file_link 读不到即跳过。
+ * doc_file_link → evidence_link 启动迁移（spec §1.5）。幂等：evidence_link 非空即跳过。
  * 每行 → 一条 link（link_key 原值、status=unverified、doc_file_id 按 (project_id, wps_file_id) 反查，
  * 反查不到的行跳过并计数）+ fileIdsJson 每个 fileId 一条 target（locator 空、supports、human）。
  * 旧表保留一个发版周期，由 DocFileLinkController 只读代理到新 Service。
@@ -47,13 +47,8 @@ public class EvidenceLinkMigrationRunner implements ApplicationRunner {
         lastMigrated = 0;
         lastSkipped = 0;
         if (links.count() > 0) return;
-        List<DocFileLink> rows;
-        try {
-            rows = old.findAll();
-        } catch (Exception e) {
-            log.info("doc_file_link 不可读，跳过 EvidenceLink 迁移: {}", e.getMessage());
-            return;
-        }
+        // DocFileLink 实体仍在、表由 JPA 建好，这里不包 try/catch：事务内 catch 仓库异常救不了启动（已 rollback-only）
+        List<DocFileLink> rows = old.findAll();
         if (rows.isEmpty()) return;
         LocalDateTime now = LocalDateTime.now();
         for (DocFileLink r : rows) {

--- a/backend/src/main/java/com/checkba/service/evidence/EvidenceLinkService.java
+++ b/backend/src/main/java/com/checkba/service/evidence/EvidenceLinkService.java
@@ -11,6 +11,7 @@ import com.checkba.repository.ProjectFileRepository;
 import com.checkba.service.LangText;
 import com.checkba.service.ProjectMemberService;
 import com.checkba.service.evidence.EvidenceLinkViews.AnchorReport;
+import com.checkba.service.evidence.EvidenceLinkViews.AnchorReportResult;
 import com.checkba.service.evidence.EvidenceLinkViews.FileBrief;
 import com.checkba.service.evidence.EvidenceLinkViews.LinkView;
 import com.checkba.service.evidence.EvidenceLinkViews.TargetInput;
@@ -18,6 +19,7 @@ import com.checkba.service.evidence.EvidenceLinkViews.TargetView;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -120,12 +122,18 @@ public class EvidenceLinkService {
         return view(l);
     }
 
+    /** createdByKind 记在 target 上（human/ai/plugin，null = human），SDK/插件追加时传 plugin。 */
     @Transactional
-    public LinkView addTargets(Long userId, Long projectId, String linkKey, List<TargetInput> targetInputs) {
+    public LinkView addTargets(Long userId, Long projectId, String linkKey, List<TargetInput> targetInputs,
+                               String createdByKind) {
         requireWrite(projectId, userId);
         EvidenceLink l = requireLink(projectId, linkKey);
         if (targetInputs == null || targetInputs.isEmpty()) {
             throw new IllegalArgumentException(LangText.of("至少关联一个底稿", "At least one target required"));
+        }
+        String kind = StringUtils.hasText(createdByKind) ? createdByKind.trim() : KIND_HUMAN;
+        if (!KINDS.contains(kind)) {
+            throw new IllegalArgumentException(LangText.of("createdByKind 非法: ", "Illegal createdByKind: ") + kind);
         }
         for (TargetInput t : targetInputs) validateTarget(projectId, t, true);
 
@@ -139,7 +147,7 @@ public class EvidenceLinkService {
         for (TargetInput t : targetInputs) {
             String h = locatorHash(t.locatorJson());
             if (targets.existsByLinkIdAndFileIdAndLocatorHash(l.getId(), t.fileId(), h)) continue;
-            saveTarget(l, t, h, order++, KIND_HUMAN, userId, now);
+            saveTarget(l, t, h, order++, kind, userId, now);
             added = true;
         }
         if (added) {
@@ -210,10 +218,11 @@ public class EvidenceLinkService {
      * orphan 不会因 exists=true 复活（复活只走 rebind）。每条都刷 checkedAt。
      */
     @Transactional
-    public List<String> reportAnchors(Long userId, Long projectId, Long docFileId, List<AnchorReport> reports) {
+    public AnchorReportResult reportAnchors(Long userId, Long projectId, Long docFileId, List<AnchorReport> reports) {
         requireWrite(projectId, userId);
         List<String> changed = new ArrayList<>();
-        if (reports == null || reports.isEmpty()) return changed;
+        int ignored = 0;
+        if (reports == null || reports.isEmpty()) return new AnchorReportResult(changed, 0);
         Map<String, EvidenceLink> byKey = new HashMap<>();
         for (EvidenceLink l : links.findByProjectIdAndDocFileIdOrderByIdAsc(projectId, docFileId)) {
             byKey.put(l.getLinkKey(), l);
@@ -221,6 +230,8 @@ public class EvidenceLinkService {
         LocalDateTime now = LocalDateTime.now();
         for (AnchorReport r : reports) {
             if (r == null || r.linkKey() == null) continue;
+            // exists 缺失 = payload 不完整，不能当 false 把链接打成 orphan（orphan 只能 rebind 救回）
+            if (r.exists() == null) { ignored++; continue; }
             EvidenceLink l = byKey.get(r.linkKey());
             if (l == null) continue;
             String before = l.getStatus();
@@ -237,7 +248,7 @@ public class EvidenceLinkService {
             }
             links.save(l);
         }
-        return changed;
+        return new AnchorReportResult(changed, ignored);
     }
 
     /** 用户「保留关联」：stale/unverified → active，anchorText/anchorHash 刷成当前文字。orphan 不能保留。 */
@@ -360,12 +371,17 @@ public class EvidenceLinkService {
         return out;
     }
 
-    /** 文件树「被引用 N 次」角标。无权限校验——Controller 负责 requireRead。 */
+    /** 文件树「被引用 N 次」角标。无权限校验——Controller 负责 requireRead；不属于 projectId 的 fileId 直接不计、不查。 */
     @Transactional(readOnly = true)
     public Map<Long, Long> refCounts(Long projectId, Collection<Long> fileIds) {
         Map<Long, Long> out = new HashMap<>();
-        if (fileIds == null || fileIds.isEmpty()) return out;
-        for (Object[] row : targets.countByFileIds(fileIds)) {
+        if (fileIds == null || fileIds.isEmpty() || projectId == null) return out;
+        List<Long> mine = new ArrayList<>();
+        for (ProjectFile f : files.findAllById(fileIds)) {
+            if (projectId.equals(f.getProjectId())) mine.add(f.getId());
+        }
+        if (mine.isEmpty()) return out;
+        for (Object[] row : targets.countByFileIds(mine)) {
             out.put(((Number) row[0]).longValue(), ((Number) row[1]).longValue());
         }
         return out;
@@ -373,7 +389,10 @@ public class EvidenceLinkService {
 
     // ---------------------------------------------------------------- helpers
 
-    /** sha256(canonical locatorJson)：键递归排序后序列化；空/空白 = "-"；非法 JSON 抛 IllegalArgumentException。 */
+    /**
+     * sha256(canonical locatorJson)：键递归排序 + 数字归一（1 与 1.0 同 hash）后序列化；空/空白 = "-"；
+     * 非法 JSON 或根不是对象（裸数组/标量）抛 IllegalArgumentException。
+     */
     static String locatorHash(String json) {
         if (json == null || json.isBlank()) return EvidenceLinkTarget.EMPTY_LOCATOR_HASH;
         return AnchorHash.of(canonical(json));
@@ -388,8 +407,8 @@ public class EvidenceLinkService {
         } catch (Exception e) {
             throw new IllegalArgumentException(LangText.of("locatorJson 不是合法 JSON", "locatorJson is not valid JSON"));
         }
-        if (node == null || node.isMissingNode()) {
-            throw new IllegalArgumentException(LangText.of("locatorJson 不是合法 JSON", "locatorJson is not valid JSON"));
+        if (node == null || !node.isObject()) {
+            throw new IllegalArgumentException(LangText.of("locatorJson 必须是 JSON 对象", "locatorJson must be a JSON object"));
         }
         try {
             return CANON.writeValueAsString(sortKeys(node));
@@ -413,6 +432,10 @@ public class EvidenceLinkService {
             ArrayNode a = CANON.createArrayNode();
             for (JsonNode c : n) a.add(sortKeys(c));
             return a;
+        }
+        if (n.isNumber()) {
+            // 1 / 1.0 / 1.00 归成同一个节点，否则同一位置因序列化习惯不同会被当成两条
+            return DecimalNode.valueOf(n.decimalValue().stripTrailingZeros());
         }
         return n;
     }

--- a/backend/src/main/java/com/checkba/service/evidence/EvidenceLinkViews.java
+++ b/backend/src/main/java/com/checkba/service/evidence/EvidenceLinkViews.java
@@ -24,6 +24,9 @@ public final class EvidenceLinkViews {
                            String sectionPath, String sectionTitle, String status, String createdByKind,
                            LocalDateTime createdAt, LocalDateTime updatedAt, List<TargetView> targets) {}
 
-    /** worker check_link_anchors 的一条核对结果。 */
-    public record AnchorReport(String linkKey, boolean exists, String text) {}
+    /** worker check_link_anchors 的一条核对结果。exists 为 null（漏字段/半截 payload）的条目跳过，不许当成 false 打 orphan。 */
+    public record AnchorReport(String linkKey, Boolean exists, String text) {}
+
+    /** reportAnchors 的结果：状态变了的 linkKey + 因 exists 缺失被忽略的条数。 */
+    public record AnchorReportResult(List<String> changed, int ignored) {}
 }

--- a/backend/src/test/java/com/checkba/controller/EvidenceLinkControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/EvidenceLinkControllerTest.java
@@ -4,6 +4,7 @@ import com.checkba.config.GlobalExceptionHandler;
 import com.checkba.service.ProjectMemberService;
 import com.checkba.service.evidence.EvidenceLinkService;
 import com.checkba.service.evidence.EvidenceLinkViews.AnchorReport;
+import com.checkba.service.evidence.EvidenceLinkViews.AnchorReportResult;
 import com.checkba.service.evidence.EvidenceLinkViews.FileBrief;
 import com.checkba.service.evidence.EvidenceLinkViews.LinkView;
 import com.checkba.service.evidence.EvidenceLinkViews.TargetInput;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -181,20 +183,24 @@ class EvidenceLinkControllerTest {
     void anchorsReport回写返回changed() throws Exception {
         try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
             auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(9L);
-            when(svc.reportAnchors(eq(9L), eq(1L), eq(10L), anyList())).thenReturn(List.of("EVID_A"));
+            when(svc.reportAnchors(eq(9L), eq(1L), eq(10L), anyList()))
+                    .thenReturn(new AnchorReportResult(List.of("EVID_A"), 1));
             String body = om.writeValueAsString(Map.of("docFileId", 10, "reports", List.of(
                     Map.of("linkKey", "EVID_A", "exists", true, "text", "改了"),
-                    Map.of("linkKey", "EVID_B", "exists", false))));
+                    Map.of("linkKey", "EVID_B", "exists", false),
+                    Map.of("linkKey", "EVID_C", "text", "漏了 exists"))));
             mvc().perform(post("/api/projects/1/evidence-links/anchors/report").header("X-Session-Id", "sess")
                             .contentType(MediaType.APPLICATION_JSON).content(body))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.changed[0]").value("EVID_A"));
+                    .andExpect(jsonPath("$.changed[0]").value("EVID_A"))
+                    .andExpect(jsonPath("$.ignored").value(1));
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<List<AnchorReport>> cap = ArgumentCaptor.forClass(List.class);
             verify(svc).reportAnchors(eq(9L), eq(1L), eq(10L), cap.capture());
-            assertEquals(2, cap.getValue().size());
-            assertEquals(false, cap.getValue().get(1).exists());
+            assertEquals(3, cap.getValue().size());
+            assertEquals(Boolean.FALSE, cap.getValue().get(1).exists());
+            assertNull(cap.getValue().get(2).exists(), "漏字段反序列化成 null，不是 false");
             verify(svc, never()).create(anyLong(), anyLong(), anyLong(), any(), any(), any(), any(), any(), any());
         }
     }
@@ -214,10 +220,12 @@ class EvidenceLinkControllerTest {
                             .content("{\"newLinkKey\":\"EVID_B\",\"anchorText\":\"新\",\"sectionPath\":\"二\",\"sectionTitle\":\"财务\"}"))
                     .andExpect(jsonPath("$.linkKey").value("EVID_B"));
 
-            when(svc.addTargets(eq(9L), eq(1L), eq("EVID_A"), anyList())).thenReturn(link("EVID_A"));
-            mvc().perform(post("/api/projects/1/evidence-links/EVID_A/targets").header("X-Session-Id", "sess")
+            when(svc.addTargets(eq(9L), eq(1L), eq("EVID_A"), anyList(), eq("plugin"))).thenReturn(link("EVID_A"));
+            mvc().perform(post("/api/projects/1/evidence-links/EVID_A/targets").param("createdByKind", "plugin")
+                            .header("X-Session-Id", "sess")
                             .contentType(MediaType.APPLICATION_JSON).content("[{\"fileId\":12,\"relation\":\"partial\"}]"))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.linkKey").value("EVID_A"));
 
             when(svc.updateTarget(eq(9L), eq(1L), eq(200L), any())).thenReturn(link("EVID_A").targets().get(0));
             mvc().perform(patch("/api/projects/1/evidence-links/targets/200").header("X-Session-Id", "sess")

--- a/backend/src/test/java/com/checkba/service/evidence/EvidenceLinkMigrationRunnerTest.java
+++ b/backend/src/test/java/com/checkba/service/evidence/EvidenceLinkMigrationRunnerTest.java
@@ -113,14 +113,6 @@ class EvidenceLinkMigrationRunnerTest {
     }
 
     @Test
-    @DisplayName("doc_file_link 表不存在（findAll 抛异常）→ 跳过，不炸启动")
-    void missingOldTableIsSkipped() throws Exception {
-        when(old.findAll()).thenThrow(new RuntimeException("table not found"));
-        runner.run(null);
-        verify(links, never()).save(any());
-    }
-
-    @Test
     @DisplayName("fileIdsJson 坏掉或为空 → 建链但无 target；非法 JSON 不炸")
     void badFileIdsJsonYieldsNoTargets() throws Exception {
         ProjectFile doc = new ProjectFile();

--- a/backend/src/test/java/com/checkba/service/evidence/EvidenceLinkServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/evidence/EvidenceLinkServiceTest.java
@@ -233,7 +233,7 @@ class EvidenceLinkServiceTest {
         String h = EvidenceLinkService.locatorHash("{\"page\":3,\"type\":\"pdf\"}");
         when(targets.existsByLinkIdAndFileIdAndLocatorHash(100L, 11L, h)).thenReturn(true);
 
-        LinkView v = svc.addTargets(9L, 1L, "EVID_A", List.of(target(11L, "{\"type\":\"pdf\",\"page\":3}")));
+        LinkView v = svc.addTargets(9L, 1L, "EVID_A", List.of(target(11L, "{\"type\":\"pdf\",\"page\":3}")), null);
         verify(targets, never()).save(any());
         assertEquals(0, v.targets().size());
     }
@@ -247,13 +247,28 @@ class EvidenceLinkServiceTest {
         savedTargets.add(t0);
         when(targets.findByLinkIdOrderBySortOrderAscIdAsc(100L)).thenReturn(List.of(t0));
 
-        LinkView v = svc.addTargets(9L, 1L, "EVID_A", List.of(target(12L, null)));
+        LinkView v = svc.addTargets(9L, 1L, "EVID_A", List.of(target(12L, null)), null);
         assertEquals(2, v.targets().size());
         ArgumentCaptor<EvidenceLinkTarget> cap = ArgumentCaptor.forClass(EvidenceLinkTarget.class);
         verify(targets).save(cap.capture());
         assertEquals(1, cap.getValue().getSortOrder());
         assertEquals("-", cap.getValue().getLocatorHash());
+        assertEquals("human", cap.getValue().getCreatedByKind(), "缺省 kind = human");
         assertNotNull(l.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("addTargets：createdByKind=plugin 记在 target 上；非法 kind 拒绝且不落库")
+    void addTargetsRecordsCreatedByKind() {
+        existing("EVID_A", "active", "x");
+        svc.addTargets(9L, 1L, "EVID_A", List.of(target(12L, null)), "plugin");
+        ArgumentCaptor<EvidenceLinkTarget> cap = ArgumentCaptor.forClass(EvidenceLinkTarget.class);
+        verify(targets).save(cap.capture());
+        assertEquals("plugin", cap.getValue().getCreatedByKind());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.addTargets(9L, 1L, "EVID_A", List.of(target(11L, null)), "robot"));
+        verify(targets, times(1)).save(any());
     }
 
     @Test
@@ -318,7 +333,7 @@ class EvidenceLinkServiceTest {
                 new AnchorReport("D", false, null),
                 new AnchorReport("E", true, "原　文。"),
                 new AnchorReport("F", true, "原文"),
-                new AnchorReport("ZZZ", true, "不存在的 key 忽略")));
+                new AnchorReport("ZZZ", true, "不存在的 key 忽略"))).changed();
 
         assertEquals("stale", a.getStatus());
         assertEquals("stale", b.getStatus());
@@ -336,9 +351,28 @@ class EvidenceLinkServiceTest {
         EvidenceLink o = new EvidenceLink(); o.setId(1L); o.setLinkKey("O"); o.setStatus("orphan"); o.setAnchorHash(AnchorHash.of("原文"));
         o.setProjectId(1L); o.setDocFileId(10L);
         when(links.findByProjectIdAndDocFileIdOrderByIdAsc(1L, 10L)).thenReturn(List.of(o));
-        List<String> changed = svc.reportAnchors(9L, 1L, 10L, List.of(new AnchorReport("O", true, "原文")));
+        List<String> changed = svc.reportAnchors(9L, 1L, 10L, List.of(new AnchorReport("O", true, "原文"))).changed();
         assertEquals("orphan", o.getStatus());
         assertTrue(changed.isEmpty());
+    }
+
+    @Test
+    @DisplayName("reportAnchors：exists 缺失（半截 payload）不改状态、不打 orphan，计入 ignored")
+    void reportAnchorsIgnoresMissingExists() {
+        EvidenceLink a = new EvidenceLink(); a.setId(1L); a.setLinkKey("A"); a.setStatus("active"); a.setAnchorHash(AnchorHash.of("原文"));
+        EvidenceLink b = new EvidenceLink(); b.setId(2L); b.setLinkKey("B"); b.setStatus("active"); b.setAnchorHash(AnchorHash.of("原文"));
+        for (EvidenceLink l : List.of(a, b)) { l.setProjectId(1L); l.setDocFileId(10L); }
+        when(links.findByProjectIdAndDocFileIdOrderByIdAsc(1L, 10L)).thenReturn(List.of(a, b));
+
+        var res = svc.reportAnchors(9L, 1L, 10L, List.of(
+                new AnchorReport("A", null, "改了"),
+                new AnchorReport("B", false, null)));
+
+        assertEquals("active", a.getStatus(), "exists=null 不许当 false");
+        assertNull(a.getCheckedAt());
+        assertEquals("orphan", b.getStatus());
+        assertEquals(List.of("B"), res.changed());
+        assertEquals(1, res.ignored());
     }
 
     @Test
@@ -479,6 +513,24 @@ class EvidenceLinkServiceTest {
     }
 
     @Test
+    @DisplayName("refCounts：他项目的 fileId 不返回、也不带进计数查询；全是他项目的不查库")
+    void refCountsFiltersByProject() {
+        when(files.findById(13L)).thenReturn(Optional.of(file(13L, 2L, "别家.pdf")));
+        when(targets.countByFileIds(anyCollection())).thenReturn(List.<Object[]>of(new Object[]{11L, 3L}));
+
+        Map<Long, Long> m = svc.refCounts(1L, List.of(11L, 13L));
+        assertEquals(3L, m.get(11L));
+        assertNull(m.get(13L));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<java.util.Collection<Long>> cap = ArgumentCaptor.forClass(java.util.Collection.class);
+        verify(targets).countByFileIds(cap.capture());
+        assertEquals(List.of(11L), new ArrayList<>(cap.getValue()));
+
+        assertTrue(svc.refCounts(1L, List.of(13L)).isEmpty());
+        verify(targets, times(1)).countByFileIds(anyCollection());
+    }
+
+    @Test
     @DisplayName("locatorHash：canonical（键排序）后再 hash；空/空白 = \"-\"")
     void locatorHashIsCanonical() {
         assertEquals("-", EvidenceLinkService.locatorHash(null));
@@ -490,5 +542,19 @@ class EvidenceLinkServiceTest {
         assertEquals(EvidenceLinkService.locatorHash("{\"a\":{\"z\":1,\"b\":[{\"y\":1,\"x\":2}]}}"),
                 EvidenceLinkService.locatorHash("{\"a\":{\"b\":[{\"x\":2,\"y\":1}],\"z\":1}}"));
         assertThrows(IllegalArgumentException.class, () -> EvidenceLinkService.locatorHash("{nope"));
+    }
+
+    @Test
+    @DisplayName("locatorHash：数字归一（1 / 1.0 / 1.00 同 hash，嵌套也算）；根不是对象（裸数组/标量）拒绝")
+    void locatorHashNormalisesNumbersAndRejectsNonObjectRoot() {
+        assertEquals(EvidenceLinkService.locatorHash("{\"page\":1}"), EvidenceLinkService.locatorHash("{\"page\":1.0}"));
+        assertEquals(EvidenceLinkService.locatorHash("{\"page\":1}"), EvidenceLinkService.locatorHash("{\"page\":1.00}"));
+        assertEquals(EvidenceLinkService.locatorHash("{\"rect\":{\"x\":0.5,\"w\":100}}"),
+                EvidenceLinkService.locatorHash("{\"rect\":{\"w\":100.0,\"x\":0.50}}"));
+        assertNotEquals(EvidenceLinkService.locatorHash("{\"page\":1}"), EvidenceLinkService.locatorHash("{\"page\":1.5}"));
+        assertThrows(IllegalArgumentException.class, () -> EvidenceLinkService.locatorHash("[1]"));
+        assertThrows(IllegalArgumentException.class, () -> EvidenceLinkService.locatorHash("\"x\""));
+        assertThrows(IllegalArgumentException.class, () -> EvidenceLinkService.locatorHash("42"));
+        assertThrows(IllegalArgumentException.class, () -> EvidenceLinkService.locatorHash("null"));
     }
 }


### PR DESCRIPTION
## 复核修复（dev-board#102，follow-up of #543，基于最新 master）

1. **exists 可空**：`AnchorReport.exists` 改 `Boolean`；null（漏字段/半截 payload）条目跳过、不改状态、不打 orphan，计入返回值 `ignored`。Service 返回 `AnchorReportResult{changed, ignored}`，REST `/anchors/report` 回 `{changed:[...], ignored:N}`。
2. **target kind**：`addTargets(..., createdByKind)`，REST `POST /{linkKey}/targets?createdByKind=human|ai|plugin`（缺省 human，非法拒绝），SDK/插件追加能记 plugin。
3. **refCounts 项目过滤**：先按 `files.findAllById` 过滤出属于 projectId 的 fileId 再 `countByFileIds`；他项目 fileId 不返回、不带进查询；全是他项目的不查库。
4. **locator 数字归一**：canonical 时数字节点 `decimalValue().stripTrailingZeros()`，`1`/`1.0`/`1.00` 同 hash；根不是对象（裸数组/标量/null）拒绝。
5. **迁移 Runner**：去掉事务内的 try/catch（救不了启动，内层已 rollback-only）与对应 `missingOldTableIsSkipped` 测试；`lastMigrated/lastSkipped` 测试缝保留。

`.claude/agents/ai-doc-bridge.md` 契约段同步（REST 表两行 + locator_hash 说明）。

## 测试

- `mvn -q test -Dtest=EvidenceLink*,AnchorHash*,DocFileLink*`：AnchorHashTest 4、UlidTest 3、EvidenceLinkServiceTest 30（+4：缺 exists 不改状态 / addTargets 记 kind / refCounts 他项目过滤 / 数字归一与非对象根）、EvidenceLinkMigrationRunnerTest 3、EvidenceLinkControllerTest 9（report 断言 ignored 与漏字段反序列化为 null；targets 带 createdByKind）、DocFileLinkControllerProxyTest 3，全绿。
- 全量 `mvn -q test`：见 PR 评论/报告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
