### PR TITLE
fix(scale): #550 复核修复——RENAME 不覆盖回收站文件/截断计数/引用角标防抖（dev-board#107）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
+++ b/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
@@ -30,8 +30,9 @@ public class MeetingRecordingController {
     // 内存标记（utils/meetingRecorder.js 的模块级单例），管不到"同一账号在桌面端 +
     // 浏览器标签页各开一份""同一项目的多个成员各自点了开始"这类跨客户端场景——
     // 这两种都是正常使用即可触发，不需要恶意操作。MeetingRecordingService.create()
-    // 内部 uniqueName() 是"查名字是否存在→建档"两步式，中间有窗口：两个并发请求都
-    // 查到"名字不存在"，各自建出一行同名 ProjectFile，物理路径只由 projectId/
+    // 经 ProjectFileService.createFile(RENAME) 建音频占位，RENAME 仍是"查名字是否
+    // 被占→建档"两步式，中间有窗口：两个并发请求都查到"名字不存在"，各自建出
+    // 一行同名 ProjectFile，物理路径只由 projectId/
     // parentId/name 决定（不含行 id），两行会落到同一个物理文件上，后续两段录音的
     // 分片上传各写各的 audioFileId 却写进同一个文件，互相覆盖。
     //

--- a/backend/src/main/java/com/checkba/controller/ProjectController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectController.java
@@ -122,6 +122,7 @@ public class ProjectController {
         data.put("importedCount", r.importedCount());
         data.put("truncated", r.truncated());
         data.put("truncatedCount", r.truncatedCount());
+        data.put("truncatedCountCapped", r.truncatedCountCapped());
         Map<String, Object> result = new HashMap<>();
         result.put("code", 0);
         result.put("data", data);

--- a/backend/src/main/java/com/checkba/service/LocalProjectService.java
+++ b/backend/src/main/java/com/checkba/service/LocalProjectService.java
@@ -42,6 +42,16 @@ public class LocalProjectService {
     static final int DEFAULT_MAX_IMPORT_ENTRIES = 30000;
     private int maxImportEntries = DEFAULT_MAX_IMPORT_ENTRIES;
     static final int MAX_IMPORT_DEPTH = 20;
+    /**
+     * 命中导入上限后，被跳过的子树只数不入库；数到这个数就停（标 truncatedCountCapped），
+     * 免得为了一个提示数字扫穿一整棵误选的超大目录。
+     */
+    static final int DEFAULT_TRUNCATED_COUNT_CAP = 100_000;
+    private int truncatedCountCap = DEFAULT_TRUNCATED_COUNT_CAP;
+
+    void setTruncatedCountCapForTest(int cap) {
+        this.truncatedCountCap = cap;
+    }
 
     /** 仅供测试覆盖导入上限（包内可见）。生产路径永远用 DEFAULT_MAX_IMPORT_ENTRIES。 */
     void setMaxImportEntriesForTest(int maxImportEntries) {
@@ -82,7 +92,8 @@ public class LocalProjectService {
     public record LocalProjectOpened(long projectId, String localRoot) {}
 
     public record OpenLocalResult(Project project, boolean reused, Long openFileId,
-                                  int importedCount, boolean truncated, int truncatedCount) {}
+                                  int importedCount, boolean truncated, int truncatedCount,
+                                  boolean truncatedCountCapped) {}
 
     /**
      * 打开/复用本地文件夹项目。
@@ -125,7 +136,8 @@ public class LocalProjectService {
         eventPublisher.publishEvent(new LocalProjectOpened(project.getId(), canonical));
         telemetryService.record("project.created", java.util.Map.of(
                 "kind", "local", "reused", reused, "importedCount", stats.imported));
-        return new OpenLocalResult(project, reused, openFileId, stats.imported, stats.truncated, stats.truncatedCount);
+        return new OpenLocalResult(project, reused, openFileId, stats.imported, stats.truncated,
+                stats.truncatedCount, stats.truncatedCountCapped);
     }
 
     private record ProjectResolution(Project project, boolean reused) {}
@@ -163,7 +175,8 @@ public class LocalProjectService {
         return new ProjectResolution(project, false);
     }
 
-    public record ReconcileResult(int changed, boolean rootMissing, boolean truncated, int truncatedCount) {}
+    public record ReconcileResult(int changed, boolean rootMissing, boolean truncated, int truncatedCount,
+                                  boolean truncatedCountCapped) {}
 
     /**
      * 磁盘 ↔ 数据库文件树对账（watcher 触发；幂等，只写数据库、绝不写磁盘）：
@@ -187,12 +200,12 @@ public class LocalProjectService {
     public ReconcileResult reconcileProject(Long projectId) {
         Project project = projectRepository.findById(projectId).orElse(null);
         if (project == null || !StringUtils.hasText(project.getLocalRoot())) {
-            return new ReconcileResult(0, false, false, 0);
+            return new ReconcileResult(0, false, false, 0, false);
         }
         Path root = Paths.get(project.getLocalRoot());
         if (!Files.isDirectory(root)) {
             log.warn("对账跳过：项目文件夹不可达 project={}, root={}", projectId, root);
-            return new ReconcileResult(0, true, false, 0);
+            return new ReconcileResult(0, true, false, 0, false);
         }
         Long ownerId = project.getUserId();
 
@@ -256,7 +269,7 @@ public class LocalProjectService {
         if (changed > 0) {
             log.info("对账完成: project={}, changed={}", projectId, changed);
         }
-        return new ReconcileResult(changed, false, stats.truncated, stats.truncatedCount);
+        return new ReconcileResult(changed, false, stats.truncated, stats.truncatedCount, stats.truncatedCountCapped);
     }
 
     private String relativeFolderPath(ProjectFile folder, Map<Long, ProjectFile> byId) {
@@ -325,7 +338,56 @@ public class LocalProjectService {
         int imported;   // 本次处理（含无变化跳过）的条目数，用于上限控制
         int changed;    // 真正新建/更新的条目数，用于「有没有发生变化」判断
         boolean truncated;
-        int truncatedCount; // 命中上限之后未纳入的条目数（尽力而为的精确计数，见下方 preVisitDirectory/visitFile）
+        int truncatedCount; // 命中上限之后未纳入的条目数（被跳过的子树做有界计数，见 countSkippedSubtree）
+        boolean truncatedCountCapped; // 计数本身也撞了 truncatedCountCap：真实数字只会更大
+    }
+
+    /**
+     * 对一棵不再入库的子树做有界计数（目录自身 + 其下非隐藏的文件/目录），累加进 stats.truncatedCount。
+     * 此前这里只给整棵子树记 1，前端却据此写「N 项未纳入」——一个 5 万文件的目录被报成 1 项。
+     * 计数到 truncatedCountCap 即终止并置 truncatedCountCapped，调用方据此把文案改成「超过 N 项」。
+     */
+    private void countSkippedSubtree(Path dir, ImportStats stats) {
+        stats.truncated = true;
+        int remaining = truncatedCountCap - stats.truncatedCount;
+        if (remaining <= 0) {
+            stats.truncatedCountCapped = true;
+            return;
+        }
+        final int[] counted = {0};
+        try {
+            Files.walkFileTree(dir, java.util.Collections.emptySet(), MAX_IMPORT_DEPTH, new SimpleFileVisitor<>() {
+                private FileVisitResult tally() {
+                    if (counted[0] >= remaining) {
+                        stats.truncatedCountCapped = true;
+                        return FileVisitResult.TERMINATE;
+                    }
+                    counted[0]++;
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path d, BasicFileAttributes attrs) {
+                    if (!d.equals(dir) && d.getFileName().toString().startsWith(".")) return FileVisitResult.SKIP_SUBTREE;
+                    return tally();
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path f, BasicFileAttributes attrs) {
+                    if (f.getFileName().toString().startsWith(".")) return FileVisitResult.CONTINUE;
+                    if (!attrs.isRegularFile() && !attrs.isDirectory()) return FileVisitResult.CONTINUE;
+                    return tally();
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path f, IOException exc) {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            log.warn("统计被截断子树失败（已数 {} 项）: {} ({})", counted[0], dir, e.getMessage());
+        }
+        stats.truncatedCount += counted[0];
     }
 
     /**
@@ -359,10 +421,9 @@ public class LocalProjectService {
                     if (dir.equals(root)) return FileVisitResult.CONTINUE;
                     if (dir.getFileName().toString().startsWith(".")) return FileVisitResult.SKIP_SUBTREE;
                     if (stats.imported >= maxImportEntries) {
-                        // 命中上限后不再下钻子树（避免为了精确计数而扫穿一整棵误选的超大目录），
-                        // 只把这个目录条目本身计入 truncatedCount——「至少 N 项」而非精确到子树内的每一项。
-                        stats.truncated = true;
-                        stats.truncatedCount++;
+                        // 命中上限后不再把子树入库，只做一次有界计数（上限 truncatedCountCap），
+                        // 让前端的「约 N 项未纳入」有一个接近真实的数字。
+                        countSkippedSubtree(dir, stats);
                         return FileVisitResult.SKIP_SUBTREE;
                     }
                     Long parentId = dirIds.get(dir.getParent());
@@ -403,8 +464,7 @@ public class LocalProjectService {
                         // 其实是目录，就是深度封顶的信号：它自己和它底下的一切都不会再被
                         // 任何回调访问到，是本轮扫描静默漏掉的那一段。与 MAX_IMPORT_ENTRIES
                         // 上限不同，这里没有天然会执行到的判断点，必须主动识别这个信号。
-                        stats.truncated = true;
-                        stats.truncatedCount++;
+                        countSkippedSubtree(file, stats);
                         return FileVisitResult.CONTINUE;
                     }
                     if (!attrs.isRegularFile()) return FileVisitResult.CONTINUE;

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -238,12 +238,12 @@ public class ProjectFileService {
             throw new IllegalArgumentException(LangText.of("用户 ID 不能为空", "User ID must not be empty"));
         }
 
-        String finalName = name;
+        String finalName = name.trim();
         if (policy == ConflictPolicy.RENAME) {
-            finalName = resolveConflictingName(projectId, parentId, name.trim());
-        } else if (projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(projectId, parentId, name, -1L)) {
-            // 检查同名文件是否存在
-            throw new IllegalArgumentException(LangText.of("该文件夹下已存在同名文件: ", "A file with this name already exists: ") + name);
+            finalName = resolveConflictingName(projectId, parentId, finalName);
+        } else if (projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(projectId, parentId, finalName, -1L)) {
+            // 检查同名文件是否存在（与 RENAME 对称：按 trim 后的名字查，落库的也是 trim 后的名字）
+            throw new IllegalArgumentException(LangText.of("该文件夹下已存在同名文件: ", "A file with this name already exists: ") + finalName);
         }
 
         // 获取当前父文件夹下的最大排序序号（单条聚合查询，见 ProjectFileRepository.maxSortOrder）
@@ -288,9 +288,17 @@ public class ProjectFileService {
     /**
      * RENAME 策略：同名时在扩展名前插入 " (n)" 直到不冲突，上限 1000 次尝试
      * （超出后大概率是查询本身有问题，抛错比死循环/无限重试更安全）。
+     *
+     * <p>「冲突」同时看两处，任一命中都继续加序号：
+     * <ul>
+     * <li>数据库里<b>含回收站</b>的同名行。软删除只翻 isDeleted 不动磁盘，回收站里那份
+     *     「a.pdf」的字节仍躺在按名字算出的 filePath 上；若只查活着的行就把「a.pdf」判为可用，
+     *     调用方随后 save/move(REPLACE_EXISTING) 会把回收站文件盖掉，律师一还原拿到的是新文件的内容。</li>
+     * <li>物理目标路径已存在（行被彻底删了但文件残留、或外部写入）。</li>
+     * </ul>
      */
     private String resolveConflictingName(Long projectId, Long parentId, String name) {
-        if (!projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(projectId, parentId, name, -1L)) {
+        if (!conflictingNameTaken(projectId, parentId, name)) {
             return name;
         }
         String base = name;
@@ -302,11 +310,19 @@ public class ProjectFileService {
         }
         for (int i = 1; i <= 1000; i++) {
             String candidate = base + " (" + i + ")" + ext;
-            if (!projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(projectId, parentId, candidate, -1L)) {
+            if (!conflictingNameTaken(projectId, parentId, candidate)) {
                 return candidate;
             }
         }
         throw new IllegalArgumentException(LangText.of("该文件夹下同名文件过多，请手动改名: ", "Too many files with this name in this folder; please rename manually: ") + name);
+    }
+
+    private boolean conflictingNameTaken(Long projectId, Long parentId, String candidate) {
+        if (projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(projectId, parentId, candidate, -1L)) {
+            return true;
+        }
+        String physicalPath = buildPhysicalPath(projectId, parentId, candidate);
+        return storageServiceFactory.getStorageService().exists(physicalPath);
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
@@ -66,9 +66,11 @@ public class MeetingRecordingService {
                 + now.format(DateTimeFormatter.ofPattern("MM-dd HH:mm"));
 
         ProjectFile folder = ensureFolder(projectId, userId);
-        String audioName = uniqueName(projectId, folder.getId(), title, ".webm");
+        // 同名处置交给 ProjectFileService 的 RENAME 策略（含回收站同名与物理路径已存在的判定），
+        // 不再自己先探测再拼 (n) 后缀。
         ProjectFile audio = projectFileService.createFile(
-                projectId, folder.getId(), audioName, "webm", 0L, null, null, userId);
+                projectId, folder.getId(), title + ".webm", "webm", 0L, null, null, userId,
+                ProjectFileService.ConflictPolicy.RENAME);
 
         MeetingRecording meeting = new MeetingRecording();
         meeting.setProjectId(projectId);
@@ -300,17 +302,6 @@ public class MeetingRecordingService {
             }
         }
         return projectFileService.createFolder(projectId, null, preferred, userId);
-    }
-
-    /** createFile 对同名文件抛异常，这里先探测再加 (2)/(3) 后缀。 */
-    private String uniqueName(Long projectId, Long parentId, String base, String ext) {
-        String name = base + ext;
-        int i = 2;
-        while (projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(projectId, parentId, name, -1L)) {
-            name = base + " (" + i + ")" + ext;
-            i++;
-        }
-        return name;
     }
 
     private String sanitize(String name) {

--- a/backend/src/test/java/com/checkba/controller/ProjectControllerOpenLocalGateTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectControllerOpenLocalGateTest.java
@@ -63,7 +63,7 @@ class ProjectControllerOpenLocalGateTest {
             p.setId(7L);
             p.setName("案卷");
             when(localProjectService.openLocalFolder("/Users/me/案卷", false, null, null, 1L))
-                    .thenReturn(new LocalProjectService.OpenLocalResult(p, false, null, 3, false, 0));
+                    .thenReturn(new LocalProjectService.OpenLocalResult(p, false, null, 3, false, 0, false));
 
             Map<String, Object> result = controller.openLocalFolder(
                     Map.of("localRoot", "/Users/me/案卷"), "sess");
@@ -87,7 +87,7 @@ class ProjectControllerOpenLocalGateTest {
             p.setId(9L);
             p.setName("大项目");
             when(localProjectService.openLocalFolder("/Users/me/大项目", false, null, null, 1L))
-                    .thenReturn(new LocalProjectService.OpenLocalResult(p, false, null, 50, true, 7));
+                    .thenReturn(new LocalProjectService.OpenLocalResult(p, false, null, 50, true, 7, false));
 
             Map<String, Object> result = controller.openLocalFolder(
                     Map.of("localRoot", "/Users/me/大项目"), "sess");

--- a/backend/src/test/java/com/checkba/service/LocalProjectServiceImportCapTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalProjectServiceImportCapTest.java
@@ -100,6 +100,51 @@ class LocalProjectServiceImportCapTest {
         assertEquals(TEST_CAP, rows.size(), "入库行数必须封顶，多出的文件不许静默进库");
     }
 
+    /**
+     * #550 复核 M1：命中上限后被跳过的子树此前只记 1，前端却据此写「N 项未纳入」。
+     * 现在对被跳过的子树做有界计数。布局：50 个根文件 + zz/（10 文件 + inner/ 20 文件），
+     * 共 82 项；无论文件系统遍历顺序如何（先进目录还是先扫文件），未纳入的都应是 82-50=32。
+     */
+    @Test
+    void skippedSubtreeIsCountedNotJustOne(@TempDir Path folder) throws Exception {
+        for (int i = 0; i < TEST_CAP; i++) {
+            Files.createFile(folder.resolve("f" + i + ".txt"));
+        }
+        Path zz = Files.createDirectory(folder.resolve("zz"));
+        for (int i = 0; i < 10; i++) {
+            Files.createFile(zz.resolve("z" + i + ".txt"));
+        }
+        Path inner = Files.createDirectory(zz.resolve("inner"));
+        for (int i = 0; i < 20; i++) {
+            Files.createFile(inner.resolve("i" + i + ".txt"));
+        }
+        Files.createFile(zz.resolve(".hidden")); // 隐藏项不入库也不计数
+
+        LocalProjectService.OpenLocalResult r = svc.openLocalFolder(folder.toString(), false, null, null, 1L);
+
+        assertTrue(r.truncated());
+        assertEquals(TEST_CAP, r.importedCount());
+        assertEquals(82 - TEST_CAP, r.truncatedCount(), "被跳过的子树要按实际条目数计，不能整棵只算 1");
+        assertFalse(r.truncatedCountCapped());
+    }
+
+    /** M1：计数本身也有上限；撞上就停并标 truncatedCountCapped，前端改口「超过 N 项」。 */
+    @Test
+    void truncatedCountStopsAtCapAndFlagsIt(@TempDir Path folder) throws Exception {
+        svc.setMaxImportEntriesForTest(0);      // 第一项就越限，zz/ 整棵走「跳过并计数」
+        svc.setTruncatedCountCapForTest(10);
+        Path zz = Files.createDirectory(folder.resolve("zz"));
+        for (int i = 0; i < 30; i++) {
+            Files.createFile(zz.resolve("z" + i + ".txt"));
+        }
+
+        LocalProjectService.OpenLocalResult r = svc.openLocalFolder(folder.toString(), false, null, null, 1L);
+
+        assertTrue(r.truncated());
+        assertEquals(10, r.truncatedCount(), "数到上限即停");
+        assertTrue(r.truncatedCountCapped(), "撞了计数上限必须标出来，真实数字只会更大");
+    }
+
     @Test
     void underCapEntriesAllImportedNoTruncation(@TempDir Path folder) throws Exception {
         int total = 30; // 明显小于上限 50

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceCreateConflictTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceCreateConflictTest.java
@@ -22,9 +22,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * 新建文件的同名冲突策略（dev-board#107 单元 F2）：
- * - 旧签名（无 policy 参数）行为不变：同名直接报错；
- * - RENAME 策略：自动加 " (n)" 直到不冲突；
+ * 新建文件的同名冲突策略（dev-board#107 单元 F2，#550 复核 H1/L3 加固）：
+ * - 旧签名（无 policy 参数）行为不变：同名直接报错（按 trim 后的名字查，与 RENAME 对称）；
+ * - RENAME 策略：自动加 " (n)" 直到不冲突——「冲突」含回收站里的同名行与物理路径已存在，
+ *   否则回收站文件会被新文件盖掉，还原后内容错位；
  * - 新建不再拉整个同级列表求 max(sortOrder)，改走单条聚合查询
  *   （findByProjectIdAndParentIdOrderBySortOrderAsc 绝不该被调用）。
  */
@@ -41,11 +42,25 @@ class ProjectFileServiceCreateConflictTest {
     @Mock
     private com.checkba.service.telemetry.TelemetryService telemetryService;
 
+    @Mock
+    private com.checkba.storage.StorageService storageService;
+
     @InjectMocks
     private ProjectFileService projectFileService;
 
     private static final long PROJECT_ID = 1L;
     private static final long PARENT_ID = 5L;
+
+    @org.junit.jupiter.api.BeforeEach
+    void wireStorage() {
+        when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+    }
+
+    /** 模拟数据库里（含回收站）是否有同名行。 */
+    private void dbHas(String name, boolean taken) {
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                PROJECT_ID, PARENT_ID, name, -1L)).thenReturn(taken);
+    }
 
     @Test
     void oldSignatureStillFailsOnSameName() {
@@ -55,19 +70,26 @@ class ProjectFileServiceCreateConflictTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> projectFileService.createFile(PROJECT_ID, PARENT_ID, "a.pdf", "pdf", 10L, null, null, 1L));
         org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("a.pdf"));
-        // RENAME 专用的查重不该被 FAIL 策略调用
-        verify(projectFileRepository, never()).existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
-                anyLong(), any(), any(), anyLong());
+        verify(projectFileRepository, never()).save(any(ProjectFile.class));
+    }
+
+    @Test
+    void failPolicyChecksTrimmedNameLikeRename() {
+        // L3：落库的是 trim 后的名字，同名检查也必须按 trim 后的名字查，否则 " a.pdf " 能绕过查重
+        dbHas("a.pdf", true);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.createFile(PROJECT_ID, PARENT_ID, "  a.pdf ", "pdf", 10L, null, null, 1L));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("a.pdf"));
+        verify(projectFileRepository).existsByProjectIdAndParentIdAndNameAndIdNot(PROJECT_ID, PARENT_ID, "a.pdf", -1L);
+        verify(projectFileRepository, never()).save(any(ProjectFile.class));
     }
 
     @Test
     void renamePolicyAppendsIncrementingSuffixUntilFree() {
-        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
-                PROJECT_ID, PARENT_ID, "a.pdf", -1L)).thenReturn(true);
-        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
-                PROJECT_ID, PARENT_ID, "a (1).pdf", -1L)).thenReturn(true);
-        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
-                PROJECT_ID, PARENT_ID, "a (2).pdf", -1L)).thenReturn(false);
+        dbHas("a.pdf", true);
+        dbHas("a (1).pdf", true);
+        dbHas("a (2).pdf", false);
         when(projectFileRepository.maxSortOrder(PROJECT_ID, PARENT_ID)).thenReturn(3);
         when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -78,15 +100,11 @@ class ProjectFileServiceCreateConflictTest {
         assertEquals(4, saved.getSortOrder());
         verify(projectFileRepository).maxSortOrder(PROJECT_ID, PARENT_ID);
         verify(projectFileRepository, never()).findByProjectIdAndParentIdOrderBySortOrderAsc(anyLong(), any());
-        // FAIL 策略专用的查重不该被 RENAME 策略调用
-        verify(projectFileRepository, never()).existsByProjectIdAndParentIdAndNameAndIdNot(
-                anyLong(), any(), any(), anyLong());
     }
 
     @Test
     void renamePolicyReturnsOriginalNameWhenNoConflict() {
-        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
-                PROJECT_ID, PARENT_ID, "unique.pdf", -1L)).thenReturn(false);
+        dbHas("unique.pdf", false);
         when(projectFileRepository.maxSortOrder(PROJECT_ID, PARENT_ID)).thenReturn(null);
         when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -95,8 +113,51 @@ class ProjectFileServiceCreateConflictTest {
 
         assertEquals("unique.pdf", saved.getName());
         assertEquals(0, saved.getSortOrder(), "空文件夹（maxSortOrder=null）新建的第一个文件序号应为 0");
-        verify(projectFileRepository, times(1)).existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
+        verify(projectFileRepository, times(1)).existsByProjectIdAndParentIdAndNameAndIdNot(
                 eq(PROJECT_ID), eq(PARENT_ID), eq("unique.pdf"), eq(-1L));
+    }
+
+    /**
+     * H1 病灶：RENAME 此前只查「活着」的同名行。回收站里的 a.pdf 字节仍在按名字算出的
+     * 物理路径上，判「a.pdf 可用」会让调用方 save/move(REPLACE_EXISTING) 把它盖掉。
+     * 这里模拟的是「不过滤 isDeleted 的查重」命中（即软删同名存在），必须得到 a (1).pdf。
+     */
+    @Test
+    void renamePolicyTreatsSoftDeletedSiblingAsConflict() {
+        dbHas("a.pdf", true);      // 只有回收站里有这一行
+        dbHas("a (1).pdf", false);
+        when(projectFileRepository.maxSortOrder(PROJECT_ID, PARENT_ID)).thenReturn(null);
+        when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ProjectFile saved = projectFileService.createFile(PROJECT_ID, PARENT_ID, "a.pdf", "pdf", 10L, null, null, 1L,
+                ProjectFileService.ConflictPolicy.RENAME);
+
+        assertEquals("a (1).pdf", saved.getName());
+        // 绝不能再靠「只看活着的行」那个查询做决定
+        verify(projectFileRepository, never()).existsByProjectIdAndParentIdAndNameAndIdNotAndIsDeletedFalse(
+                anyLong(), any(), any(), anyLong());
+    }
+
+    /** H1：库里没同名行、但物理路径上已有文件（行被彻底删了字节残留/外部写入），同样继续加序号。 */
+    @Test
+    void renamePolicyTreatsExistingPhysicalFileAsConflict() {
+        dbHas("a.pdf", false);
+        dbHas("a (1).pdf", false);
+        dbHas("a (2).pdf", false);
+        // buildPhysicalPath 在 mock 仓库下（父目录查不到）得到 projects/1/<name>
+        when(storageService.exists("projects/1/a.pdf")).thenReturn(true);
+        when(storageService.exists("projects/1/a (1).pdf")).thenReturn(true);
+        when(storageService.exists("projects/1/a (2).pdf")).thenReturn(false);
+        when(projectFileRepository.maxSortOrder(PROJECT_ID, PARENT_ID)).thenReturn(null);
+        when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ProjectFile saved = projectFileService.createFile(PROJECT_ID, PARENT_ID, "a.pdf", "pdf", 10L, null, null, 1L,
+                ProjectFileService.ConflictPolicy.RENAME);
+
+        assertEquals("a (2).pdf", saved.getName());
+        assertEquals("projects/1/a (2).pdf", saved.getFilePath());
+        verify(storageService).exists("projects/1/a.pdf");
+        verify(storageService).exists("projects/1/a (1).pdf");
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingFolderLanguageTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingFolderLanguageTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -158,6 +159,23 @@ class MeetingFolderLanguageTest {
                 eq(MeetingRecordingService.FOLDER_NAME_EN), eq(10001L));
         assertTrue(res.file().getName().startsWith("Transcript_"),
                 "英文下导出文件名不该是「转写稿_」：" + res.file().getName());
+    }
+
+    /**
+     * #550 复核 L1：音频占位不再自己探测同名拼 (n)，统一走 createFile 的 RENAME 策略
+     * （那条路径才认回收站同名与物理路径已存在）。
+     */
+    @Test
+    @DisplayName("开始录音的音频占位走 createFile(RENAME)，不再自探同名")
+    void audioPlaceholderUsesRenamePolicy() {
+        service.create(1L, 9L);
+
+        verify(projectFileService).createFile(eq(1L), eq(100L), endsWith(".webm"), eq("webm"),
+                eq(0L), isNull(), isNull(), eq(9L), eq(ProjectFileService.ConflictPolicy.RENAME));
+        verify(projectFileService, never()).createFile(anyLong(), any(), anyString(), anyString(),
+                anyLong(), any(), any(), anyLong());
+        verify(projectFileRepository, never()).existsByProjectIdAndParentIdAndNameAndIdNot(
+                anyLong(), any(), anyString(), anyLong());
     }
 
     @Test

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -895,6 +895,7 @@ import { host } from '@/services/host.js'
 import { findTopmostDeletedAncestor, summarizeDeleteResults } from '@/utils/fileTreeRecycle.js'
 import { groupByParent, buildTreeFromGroups } from '@/utils/fileTreeBuild.js'
 import { evidenceRefCounts } from '@/services/api.js'
+import { createRefCountsFetcher } from '@/utils/fileTreeRefCounts.js'
 import CircularProgress from '@/components/CircularProgress.vue'
 import FileTypeIcon from '@/components/FileTypeIcon.vue'
 import TagChip from '@/components/TagChip.vue'
@@ -1270,6 +1271,9 @@ export default {
         this.isBatchUploading = false
         this.batchUploadTotalSize = 0
         this.batchUploadFinishedSize = 0
+        // 「展开更多」的渲染上限与引用角标都是按项目的，换项目必须归零
+        this.revealCounts = {}
+        this.refCounts = {}
         this.restoreUploadState()
         this.loadFiles()
       }
@@ -1343,6 +1347,9 @@ export default {
       }
 
       this.loading = true
+      // 整树重载：窗口化上限回到初始值，引用角标整批重拉（旧值会被覆盖而不是叠加）
+      this.revealCounts = {}
+      this.refCounts = {}
       try {
         // 确保 projectId 是数字类型
         const projectId = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
@@ -1371,7 +1378,7 @@ export default {
           const hiddenNames = new Set(['.stagezone', '__staging_area__'])
           this.files = files.filter(f => !hiddenNames.has(f.name))
         }
-        this.scheduleRefCountsFetch()
+        this.scheduleRefCountsFetch({ reload: true })
         console.log('加载文件列表成功:', this.files)
       } catch (error) {
         // 完整打印错误信息，包括堆栈、响应数据等
@@ -1898,27 +1905,20 @@ export default {
       this.scheduleRefCountsFetch()
     },
     // 「被引用 N 次」角标：树刷新/展开更多后，对当前渲染的文件 id 分批拉取引用计数。
-    // 接口不存在（单元 A 可能未合并）或出错时静默不显示角标，不 mock 后端。
-    async scheduleRefCountsFetch() {
+    // 防抖/去重/过期丢弃/缺失置 0 的规则在 utils/fileTreeRefCounts.js（有 node 测试）。
+    // 接口不存在或出错时静默不显示角标，不 mock 后端。
+    scheduleRefCountsFetch({ reload = false } = {}) {
       if (!this.projectId) return
+      if (!this._refCountsFetcher) {
+        this._refCountsFetcher = createRefCountsFetcher({
+          fetch: (projectId, ids) => evidenceRefCounts(projectId, ids),
+          apply: (counts) => { this.refCounts = { ...this.refCounts, ...counts } }
+        })
+      }
       const ids = this.windowedDisplayFiles
         .filter(f => !f.__loadMore && !f.isFolder)
         .map(f => f.id)
-      if (ids.length === 0) return
-      const BATCH_SIZE = 200
-      for (let i = 0; i < ids.length; i += BATCH_SIZE) {
-        const batch = ids.slice(i, i + BATCH_SIZE)
-        try {
-          const res = await evidenceRefCounts(this.projectId, batch)
-          // 兼容 {code:0, data:{...}} 信封与裸对象两种形状（单元 A 的端点形状以合并时为准）
-          const counts = (res && res.data && typeof res.data === 'object') ? res.data : res
-          if (counts && typeof counts === 'object') {
-            this.refCounts = { ...this.refCounts, ...counts }
-          }
-        } catch (e) {
-          // 端点未合并/出错：角标就不显示，不打扰用户、不 mock 数据
-        }
-      }
+      this._refCountsFetcher.schedule(this.projectId, ids, { reload })
     },
     // 计算项目的缩进（用于树形结构）
     getItemPadding(item) {

--- a/frontend/src/locales/en-US/common.js
+++ b/frontend/src/locales/en-US/common.js
@@ -34,7 +34,8 @@ export default {
   // ---- utils/ideOpen.js ----
   openProjectFailed: 'Failed to open the project. Please try again later',
   folderImportTruncatedTitle: 'Import truncated',
-  folderImportTruncated: 'This import was truncated, {count} item(s) were not included: the folder exceeds 30,000 items, please split the project',
+  folderImportTruncated: 'This import was truncated, about {count} item(s) were not included: the folder exceeds 30,000 items, please split the project',
+  folderImportTruncatedCapped: 'This import was truncated, more than {count} items were not included: the folder exceeds 30,000 items, please split the project',
   openFolder: 'Open Folder',
   openFile: 'Open File',
   open: 'Open',

--- a/frontend/src/locales/zh-CN/common.js
+++ b/frontend/src/locales/zh-CN/common.js
@@ -34,7 +34,8 @@ export default {
   // ---- utils/ideOpen.js ----
   openProjectFailed: '打开项目失败，请稍后重试',
   folderImportTruncatedTitle: '导入已截断',
-  folderImportTruncated: '本次导入已截断，{count} 项未纳入：目录超过 30000 项，请拆分项目',
+  folderImportTruncated: '本次导入已截断，约 {count} 项未纳入：目录超过 30000 项，请拆分项目',
+  folderImportTruncatedCapped: '本次导入已截断，超过 {count} 项未纳入：目录超过 30000 项，请拆分项目',
   openFolder: '打开文件夹',
   openFile: '打开文件',
   open: '打开',

--- a/frontend/src/utils/fileTreeRefCounts.js
+++ b/frontend/src/utils/fileTreeRefCounts.js
@@ -1,0 +1,76 @@
+// FileTree.vue「被引用 N 次」角标的拉取调度（dev-board#107，#550 复核 M2）。
+// 纯逻辑抽出来为了能在 node:test 里直接单测；组件只负责把 fetch/apply 注进来。
+//
+// 四条规则：
+// 1. 300ms 防抖：展开/收起/展开更多连点时只发一轮请求；
+// 2. 已经拿到过计数、且没有整树 reload 的 id 不再重复请求；
+// 3. generation 计数：reload 或切项目后，之前在途的响应一律丢弃；
+// 4. 响应里缺失的 id 视为 0，覆盖旧值——角标要能从 3 变回 0，不能只增不减。
+
+export function createRefCountsFetcher({ fetch, apply, delayMs = 300, batchSize = 200, timers = globalThis }) {
+  let timer = null
+  let generation = 0
+  let pendingProjectId = null
+  let pendingIds = new Set()
+  const requested = new Set()
+
+  function reset() {
+    requested.clear()
+    pendingIds = new Set()
+    generation++
+    if (timer !== null) {
+      timers.clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  async function flush() {
+    timer = null
+    const projectId = pendingProjectId
+    const ids = Array.from(pendingIds)
+    pendingIds = new Set()
+    if (!projectId || ids.length === 0) return
+    const gen = generation
+    for (let i = 0; i < ids.length; i += batchSize) {
+      const batch = ids.slice(i, i + batchSize)
+      let res
+      try {
+        res = await fetch(projectId, batch)
+      } catch (e) {
+        // 端点未合并/出错：角标就不显示；放开这批 id，下次刷新再试
+        batch.forEach(id => requested.delete(id))
+        continue
+      }
+      if (gen !== generation) return // 过期响应：期间发生了 reload/切项目
+      const counts = (res && res.data && typeof res.data === 'object') ? res.data : res
+      const normalized = {}
+      for (const id of batch) {
+        const v = counts && typeof counts === 'object' ? Number(counts[id]) : 0
+        normalized[id] = Number.isFinite(v) && v > 0 ? v : 0
+      }
+      apply(normalized)
+    }
+  }
+
+  /**
+   * @param {number|string} projectId
+   * @param {Array<number|string>} ids 当前渲染出来的文件 id
+   * @param {{reload?: boolean}} [opts] reload=true 表示整树重载/切项目：清掉「已请求」记忆并丢弃在途响应
+   */
+  function schedule(projectId, ids, { reload = false } = {}) {
+    if (reload || (pendingProjectId !== null && pendingProjectId !== projectId)) reset()
+    pendingProjectId = projectId
+    if (!projectId) return
+    for (const id of ids || []) {
+      if (!requested.has(id)) {
+        requested.add(id)
+        pendingIds.add(id)
+      }
+    }
+    if (pendingIds.size === 0) return
+    if (timer !== null) timers.clearTimeout(timer)
+    timer = timers.setTimeout(flush, delayMs)
+  }
+
+  return { schedule, reset }
+}

--- a/frontend/src/utils/ideOpen.js
+++ b/frontend/src/utils/ideOpen.js
@@ -31,7 +31,8 @@ async function launchProject(payload) {
   if (d.truncated && shouldWarnTruncatedOnce(d.projectId)) {
     uni.showModal({
       title: t('common.folderImportTruncatedTitle'),
-      content: t('common.folderImportTruncated', { count: d.truncatedCount || 0 }),
+      content: t(d.truncatedCountCapped ? 'common.folderImportTruncatedCapped' : 'common.folderImportTruncated',
+        { count: d.truncatedCount || 0 }),
       showCancel: false,
     })
   }

--- a/frontend/tests/evidence/refCounts.test.mjs
+++ b/frontend/tests/evidence/refCounts.test.mjs
@@ -1,0 +1,120 @@
+// FileTree.vue 引用角标拉取调度（#550 复核 M2）：
+//   cd frontend && npm run test:evidence
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRefCountsFetcher } from '../../src/utils/fileTreeRefCounts.js'
+
+// 手动推进的假定时器：只跑被 schedule 排进来的回调
+function fakeTimers() {
+  let seq = 0
+  const pending = new Map()
+  return {
+    setTimeout(fn, ms) { const id = ++seq; pending.set(id, { fn, ms }); return id },
+    clearTimeout(id) { pending.delete(id) },
+    get size() { return pending.size },
+    // 不 await 回调本身（在途请求可能永远不回来），只让微任务队列跑空
+    async fire() {
+      const entries = Array.from(pending.entries())
+      pending.clear()
+      for (const [, { fn }] of entries) fn()
+      await new Promise(r => setImmediate(r))
+    },
+  }
+}
+
+function harness({ responder } = {}) {
+  const timers = fakeTimers()
+  const calls = []
+  const applied = []
+  let resolvers = []
+  const fetch = (projectId, ids) => {
+    calls.push({ projectId, ids: [...ids] })
+    if (responder) return Promise.resolve(responder(projectId, ids))
+    return new Promise(resolve => resolvers.push(resolve))
+  }
+  const fetcher = createRefCountsFetcher({ fetch, apply: c => applied.push(c), delayMs: 300, batchSize: 2, timers })
+  return { timers, calls, applied, fetcher, resolveNext: v => resolvers.shift()(v) }
+}
+
+test('连续 schedule 在 300ms 内只发一轮请求（防抖）', async () => {
+  const h = harness({ responder: (_, ids) => Object.fromEntries(ids.map(id => [id, 1])) })
+  h.fetcher.schedule(1, [11])
+  h.fetcher.schedule(1, [11, 12])
+  assert.equal(h.timers.size, 1, '第二次 schedule 应重置同一个定时器，而不是再排一个')
+  assert.equal(h.calls.length, 0, '防抖期内不发请求')
+  await h.timers.fire()
+  assert.equal(h.calls.length, 1)
+  assert.deepEqual(h.calls[0].ids, [11, 12])
+})
+
+test('已拿到计数的 id 不再重复请求；reload 后才重新全量请求', async () => {
+  const h = harness({ responder: (_, ids) => Object.fromEntries(ids.map(id => [id, 2])) })
+  h.fetcher.schedule(1, [11, 12])
+  await h.timers.fire()
+  assert.equal(h.calls.length, 1)
+
+  h.fetcher.schedule(1, [11, 12, 13]) // 展开更多：只多了 13
+  await h.timers.fire()
+  assert.equal(h.calls.length, 2)
+  assert.deepEqual(h.calls[1].ids, [13])
+
+  h.fetcher.schedule(1, [11, 12, 13]) // 没有新 id：连定时器都不该排
+  assert.equal(h.timers.size, 0)
+
+  h.fetcher.schedule(1, [11, 12, 13], { reload: true })
+  await h.timers.fire()
+  assert.equal(h.calls.length, 4, 'reload 后全量重拉，batchSize=2 分两批')
+  assert.deepEqual(h.calls[2].ids, [11, 12])
+  assert.deepEqual(h.calls[3].ids, [13])
+})
+
+test('响应里缺失的 id 视为 0，覆盖旧值（只增不减的角标是错的）', async () => {
+  let round = 0
+  const h = harness({ responder: (_, ids) => (round++ === 0 ? { 11: 3, 12: 1 } : { 12: 1 }) })
+  h.fetcher.schedule(1, [11, 12])
+  await h.timers.fire()
+  assert.deepEqual(h.applied[0], { 11: 3, 12: 1 })
+
+  h.fetcher.schedule(1, [11, 12], { reload: true })
+  await h.timers.fire()
+  assert.deepEqual(h.applied[1], { 11: 0, 12: 1 }, '11 这次没回来，必须显式写 0 把旧的 3 盖掉')
+})
+
+test('reload / 切项目后丢弃在途的过期响应', async () => {
+  const h = harness()
+  h.fetcher.schedule(1, [11])
+  await h.timers.fire()
+  assert.equal(h.calls.length, 1)
+
+  h.fetcher.schedule(2, [21], { reload: true }) // 切到项目 2
+  h.resolveNext({ 11: 9 })                       // 项目 1 的响应这时才回来
+  await new Promise(r => setImmediate(r))
+  assert.equal(h.applied.length, 0, '过期响应不得写进角标')
+
+  await h.timers.fire()
+  assert.equal(h.calls.length, 2)
+  assert.equal(h.calls[1].projectId, 2)
+  h.resolveNext({ 21: 4 })
+  await new Promise(r => setImmediate(r))
+  assert.deepEqual(h.applied, [{ 21: 4 }])
+})
+
+test('分批拉取，某批失败只放开那一批，下次能重试', async () => {
+  let n = 0
+  const h = harness({ responder: (_, ids) => { if (++n === 1) throw new Error('boom'); return Object.fromEntries(ids.map(id => [id, 1])) } })
+  h.fetcher.schedule(1, [11, 12, 13])
+  await h.timers.fire()
+  assert.equal(h.calls.length, 2, 'batchSize=2：三个 id 分两批')
+  assert.deepEqual(h.applied, [{ 13: 1 }])
+
+  h.fetcher.schedule(1, [11, 12, 13])
+  await h.timers.fire()
+  assert.deepEqual(h.calls[2].ids, [11, 12], '失败的那批要重发，成功过的 13 不重发')
+})
+
+test('兼容 {code, data} 信封', async () => {
+  const h = harness({ responder: () => ({ code: 0, data: { 11: 5 } }) })
+  h.fetcher.schedule(1, [11])
+  await h.timers.fire()
+  assert.deepEqual(h.applied, [{ 11: 5 }])
+})


### PR DESCRIPTION
## Summary

PR #550（单元 F：稳定性 #1/#2/#6）复核发现的六项修复，每项带测试。

- **H1** `ProjectFileService.createFile(RENAME)`：冲突判定改为「含回收站的同名行 OR 物理路径已存在（storage.exists）」，任一命中继续加序号。此前只查 `IsDeletedFalse` 的行；软删除只翻 `isDeleted` 不动磁盘，回收站里 `a.pdf` 的字节仍在按名字算出的 `filePath` 上，RENAME 判「a.pdf 可用」后调用方 `save`/`Files.move(REPLACE_EXISTING)` 会把它盖掉，还原后拿到的是新文件内容。
- **M1** `LocalProjectService`：命中导入上限后被跳过的子树做一次有界计数（只 walk 不入库，上限 100000，撞顶标 `truncatedCountCapped`），不再整棵只记 1；`OpenLocalResult`/`ReconcileResult`/`open-local` 接口透出该字段；前端文案改「约 N 项未纳入」，撞顶时「超过 N 项未纳入」。
- **M2** `FileTree.vue` 引用角标拉取抽到 `utils/fileTreeRefCounts.js`：300ms 防抖；已取过且未整树 reload 的 id 不再请求；generation 计数丢弃过期响应（reload/切项目）；响应缺失的 id 置 0 覆盖旧值（角标能从 3 回到 0）。
- **L1** `MeetingRecordingService.create` 音频占位改走 `ConflictPolicy.RENAME`，删 `uniqueName`；控制器 TOCTOU 注释同步改写（锁仍需要，RENAME 仍是查→建两步）。
- **L2** `FileTree.vue` `revealCounts`/`refCounts` 在 `projectId` 变化与 `loadFiles` 时清空。
- **L3** `createFile` FAIL 路径按 trim 后的名字查重并报错，与 RENAME 对称。

## Test plan

- [x] `mvn -q test -Dtest='ProjectFileService*,LocalProjectService*,MeetingRecording*,MeetingFolder*,ProjectControllerOpenLocal*'`：新增 `renamePolicyTreatsSoftDeletedSiblingAsConflict` / `renamePolicyTreatsExistingPhysicalFileAsConflict` / `failPolicyChecksTrimmedNameLikeRename` / `skippedSubtreeIsCountedNotJustOne` / `truncatedCountStopsAtCapAndFlagsIt` / `audioPlaceholderUsesRenamePolicy`，全绿
- [x] `mvn -q test`（JDK 21）全量：342 个测试类、2438 用例，0 failures/errors
- [x] `npm run test:evidence`：40/40（新增 `tests/evidence/refCounts.test.mjs` 6 条）
- [x] `npm run check:emits`：97 个 .vue 通过
- [x] `npm run check:locales` 通过（新增 `common.folderImportTruncatedCapped` 中英）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
