### PR TITLE
feat(plugin-api): 插件宿主 SPI v1.0.0 + PluginHostImpl + 后台任务 PluginJobService（dev-board#109）

### DIFF
--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -167,6 +167,34 @@ manifest.json 要点：id（必需）/name/version/icon/author/permissions（fil
 - **「先落中间态再 `executor.submit`」的服务（会议转写就是），测试里断中间态必须先卡住后台线程**：`save` mock 成原样返回入参时，方法返回的对象与测试持有的是同一个可变实例，后台那个瞬间返回的 mock 会抢先把它改成终态，断言成败取决于 runner 调度（#394 修的就是这个间歇红）。用 `CountDownLatch` 卡住后台调用的那个 mock，断完中间态再 `countDown` 放行。
 - SubAgentTools 曾因循环依赖断启动，用 @Lazy 解决（PR#98），插件/工具类注入编排器时注意。
 
+## 宿主 SPI（plugin-api，规范 v2.4，dev-board#109）
+
+JAR 插件拿宿主能力的唯一契约：`com.checkba:plugin-api:1.0.0`，源码 `backend/plugin-api/`
+（**独立 Maven 工程**，不是 backend 的子模块；backend 以普通依赖引用）。方法表与鉴权/配额规则在
+`docs/PLUGIN_SPEC.md` §11，这里只记落点与地雷。
+
+- **先 install 再构建 backend**：`mvn -q -f backend/plugin-api/pom.xml install`。它不在任何远端仓库，
+  新机器 / 新 worktree 上 `mvn` backend 报 `Could not resolve com.checkba:plugin-api` 就是漏了这步。
+  CI（`ci.yml`）与桌面打包（`desktop-build.yml` 两个平台）都已加这一步。
+- 宿主实现：`service/plugin/PluginHostFactory`（按插件 id 缓存 `PluginHost`、持有调用上下文 ThreadLocal、
+  集中注入全部宿主服务）、`PluginHostImpl`（八个子接口的内部类）、`PluginHostQuota`（60 次/分钟/插件）、
+  `PluginJobService`（后台任务，每插件 2 线程池）+ `PluginJobController`（`/api/plugin-jobs`）+ 实体 `PluginJob`。
+- 注入链：`PluginService.loadJar` 实例化后 `injectHostIfAware` → `HostAware.setHost(factory.forPlugin(id))`。
+  `PluginService` 经 `ObjectProvider<PluginHostFactory>` 懒取（构造器注入会成启动死环）。
+- 调用上下文：`ToolRegistry.execute` 在 `tool.fromPlugin()` 分支 `pluginHostFactory.bindCall(ctx)`，
+  finally 里 `clear()`（与 `ToolContextHolder` 同一处）。字段注入 `required=false`——
+  `new ToolRegistry(...)` 的测试与 EvalHarness 不受影响；后台任务体由 `Jobs.start` 的包装重新绑定快照。
+- `ProjectFileService.ensureFolderPath(projectId, userId, segments)` 是「逐级确保文件夹」的单一出处：
+  插件 `Files.createFolderPath`、`FileTools.move_file` 目标目录补建、会议录音目录三处都走它。
+- `Settings.projectStyleProfileJson` 当前是 H 的过渡实现（项目 `_模板/画像.json` > SystemSetting
+  `dd.styleProfile.default` > classpath `house-default.json`）；单元 I 合并后改调 `StyleProfiles.resolveForProject`。
+- **地雷**：`Docs.*` 依赖 `EditorBridgeService` 自己的 ThreadLocal 会话——后台任务线程上是空的，
+  `PluginHostImpl` 按 `call().conversationId()` 临时绑定再还原，别绕开它直接调 bridge。
+  `Llm.complete` 的温度 / maxTokens 由通道侧模型配置决定（`ChatModelFactory` 给的是预建实例），
+  `LlmOptions` 里这两个字段目前是声明性的。
+- 测试：`PluginJobServiceTest`、`PluginHostImplTest`、`ProjectFileServiceEnsureFolderPathTest`。
+  示例：`examples/hello-plugin` 的 `helloListFiles`。
+
 ## 验证
 
 - 后端：`cd backend && mvn test`（JDK 21）。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
+      - name: Install plugin-api (host SPI, local artifact)
+        # backend 以普通依赖引用 com.checkba:plugin-api，它是 backend/plugin-api 独立工程，
+        # 不在任何远端仓库，必须先 install 进本机 ~/.m2 再跑 backend 的 Maven。
+        run: mvn -B -q -f backend/plugin-api/pom.xml install
       - name: Test
         working-directory: backend
         # forkNode 走 TCP 而不是默认的 stdout 管道：套件里有测试进程往 native stdout

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -102,6 +102,8 @@ jobs:
         env:
           JAVA_HOME: ${{ steps.jdk.outputs.path }}
         run: |
+          # 插件宿主 SPI 是本仓独立工程，不在远端仓库：先 install 再打 backend
+          mvn -B -q -f backend/plugin-api/pom.xml install
           # Apple Silicon only（2026-07-03 决策放弃 Intel Mac）：单 arm64 jar + arm64 JRE
           mvn -B -q -DskipTests -Djavacpp.platform=macosx-arm64 -f backend/pom.xml package
           node desktop/scripts/prepare-backend.js \
@@ -185,6 +187,7 @@ jobs:
         env:
           JAVA_HOME: ${{ steps.jdk.outputs.path }}
         run: |
+          mvn -B -q -f backend/plugin-api/pom.xml install
           mvn -B -q -DskipTests -Djavacpp.platform=windows-x86_64 -f backend/pom.xml package
           node desktop/scripts/prepare-backend.js \
             --jar backend/target/backend-0.0.1-SNAPSHOT.jar \

--- a/backend/plugin-api/pom.xml
+++ b/backend/plugin-api/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.checkba</groupId>
+    <artifactId>plugin-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>plugin-api</name>
+    <description>AI WorkDeck 插件宿主 SPI（纯接口，无第三方依赖；版本独立于桌面端，只加不破）</description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/ConflictPolicy.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/ConflictPolicy.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** {@link Files#write} 遇到同名文件时的处置。 */
+public enum ConflictPolicy { FAIL, RENAME }

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Docs.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Docs.java
@@ -1,0 +1,9 @@
+package com.checkba.plugin.api;
+
+/** 编辑器桥：仅在有 conversationId 的工具调用期可用；无会话抛 IllegalStateException("no active conversation")。 */
+public interface Docs {
+    /** action 必须在宿主 EDITOR_ACTIONS 白名单内；返回编辑器回传的 JSON。 */
+    String exec(String action, java.util.Map<String, Object> params);
+    void refreshFiles();
+    void openFile(long fileId, java.util.Map<String, Object> locator);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Evidence.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Evidence.java
@@ -1,0 +1,10 @@
+package com.checkba.plugin.api;
+
+/** 证据链接（createdByKind 恒为 plugin）。 */
+public interface Evidence {
+    LinkView create(long projectId, long docFileId, String linkKey, String anchorText, String sectionPath,
+                    String sectionTitle, java.util.List<TargetInput> targets);
+    LinkView addTargets(long projectId, String linkKey, java.util.List<TargetInput> targets);
+    java.util.List<LinkView> listByDoc(long projectId, long docFileId);
+    java.util.List<LinkView> listByFile(long projectId, long fileId);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/FileInfo.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/FileInfo.java
@@ -1,0 +1,8 @@
+package com.checkba.plugin.api;
+
+/**
+ * 项目文件树节点。{@code path} 是项目根起的逻辑路径（"a/b/c.docx"）；
+ * {@code sha256} 只在宿主已计算并缓存时非空（见 {@link Files#sha256}）；{@code metaJson} 为原始 JSON 串，可为 null。
+ */
+public record FileInfo(long id, String name, Long parentId, boolean folder, String fileType, long size,
+                       String path, String sha256, String metaJson) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Files.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Files.java
@@ -1,0 +1,22 @@
+package com.checkba.plugin.api;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+/** 项目文件树（读写都先校项目成员权限）。 */
+public interface Files {
+    /** parentId 为 null 表示项目根；recursive=true 时返回整棵子树（路径已拼好）。 */
+    List<FileInfo> list(long projectId, Long parentId, boolean recursive);
+    FileInfo get(long projectId, long fileId);
+    InputStream open(long projectId, long fileId);
+    /** 逐级确保文件夹存在，返回最深一级。 */
+    FileInfo createFolderPath(long projectId, List<String> segments);
+    FileInfo write(long projectId, Long parentId, String name, InputStream bytes, ConflictPolicy policy);
+    FileInfo move(long projectId, long fileId, Long newParentId);
+    FileInfo rename(long projectId, long fileId, String newName);
+    /** 浅合并进 metaJson（值为 null 的键删除）。 */
+    void setMeta(long projectId, long fileId, Map<String, Object> metaPatch);
+    /** 宿主算一次并缓存到 metaJson.sha256（连同 sha256At）。 */
+    String sha256(long projectId, long fileId);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/HostAware.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/HostAware.java
@@ -1,0 +1,9 @@
+package com.checkba.plugin.api;
+
+/**
+ * 插件工具类若实现本接口，宿主在无参构造实例化后立即调用 {@link #setHost(PluginHost)}，
+ * 注入按插件 id 绑定的宿主门面。不实现则与旧规范完全一致（只有 @Tool）。
+ */
+public interface HostAware {
+    void setHost(PluginHost host);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/HostQuotaException.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/HostQuotaException.java
@@ -1,0 +1,6 @@
+package com.checkba.plugin.api;
+
+/** 每插件每分钟宿主调用次数超限。 */
+public class HostQuotaException extends RuntimeException {
+    public HostQuotaException(String m) { super(m); }
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobBody.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobBody.java
@@ -1,0 +1,6 @@
+package com.checkba.plugin.api;
+
+@FunctionalInterface
+public interface JobBody {
+    void run(JobContext ctx) throws Exception;
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobContext.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobContext.java
@@ -1,0 +1,11 @@
+package com.checkba.plugin.api;
+
+/** 后台任务体内可用的上下文：汇报进度、响应取消、读取发起时的调用快照、写入结果。 */
+public interface JobContext {
+    void progress(long done, long total, String message);
+    /** 已被取消时抛 InterruptedException；任务体应在循环里定期调用。 */
+    void checkCancelled() throws InterruptedException;
+    /** 任务发起时的调用上下文快照（projectId/userId/conversationId），后台线程上 {@link PluginHost#call()} 为 null 时用它。 */
+    ToolCall call();
+    void result(String resultJson);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobHandle.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobHandle.java
@@ -1,0 +1,3 @@
+package com.checkba.plugin.api;
+
+public record JobHandle(String jobId) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobStatus.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/JobStatus.java
@@ -1,0 +1,5 @@
+package com.checkba.plugin.api;
+
+/** status 取值：queued / running / done / failed / cancelled。 */
+public record JobStatus(String jobId, String kind, String title, String status, long done, long total,
+                        String message, String resultJson, String error) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Jobs.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Jobs.java
@@ -1,0 +1,8 @@
+package com.checkba.plugin.api;
+
+/** 后台任务：每插件最多 2 并发，多余的排队；进度经 REST 与 SSE 推给前端。 */
+public interface Jobs {
+    JobHandle start(String kind, String title, JobBody body);
+    JobStatus status(String jobId);
+    void cancel(String jobId);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/LinkView.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/LinkView.java
@@ -1,0 +1,5 @@
+package com.checkba.plugin.api;
+
+/** 证据链接视图（精简版）。 */
+public record LinkView(long id, String linkKey, long docFileId, String anchorText, String sectionPath,
+                       String sectionTitle, String status, java.util.List<TargetView> targets) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Llm.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Llm.java
@@ -1,0 +1,6 @@
+package com.checkba.plugin.api;
+
+/** LLM 补全：走平台通道、扣用户 Credits、记 pluginId。 */
+public interface Llm {
+    String complete(String systemPrompt, String userPrompt, LlmOptions o);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/LlmOptions.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/LlmOptions.java
@@ -1,0 +1,6 @@
+package com.checkba.plugin.api;
+
+/** LLM 调用选项；modelId 为 null 时宿主用辅助模型（便宜档）。 */
+public record LlmOptions(String modelId, double temperature, int maxTokens) {
+    public static LlmOptions cheap() { return new LlmOptions(null, 0.0, 2048); }
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/OcrBlock.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/OcrBlock.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** 一个 OCR 文本块：page 从 1 起；x/y/w/h 为页面归一化坐标（0..1）。 */
+public record OcrBlock(String text, int page, double x, double y, double w, double h) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/OcrOptions.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/OcrOptions.java
@@ -1,0 +1,6 @@
+package com.checkba.plugin.api;
+
+/** OCR 选项：blocks=true 时尽量返回带坐标的文本块（宿主网关不返回坐标时 blocks 为空列表）。 */
+public record OcrOptions(boolean blocks, String language) {
+    public static OcrOptions text() { return new OcrOptions(false, "zh"); }
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/OcrResult.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/OcrResult.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** OCR 结果：全文 + 可选文本块。 */
+public record OcrResult(String text, java.util.List<OcrBlock> blocks) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/PluginHost.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/PluginHost.java
@@ -1,0 +1,19 @@
+package com.checkba.plugin.api;
+
+/**
+ * 宿主门面：插件拿到项目文件/文本抽取/标签/证据链接/后台任务/编辑器/设置/LLM 的唯一入口。
+ * 每个方法在宿主侧都先做项目成员鉴权，并受每插件每分钟的调用配额约束（超限抛 {@link HostQuotaException}）。
+ */
+public interface PluginHost {
+    String pluginId();
+    /** 当前工具调用上下文（ThreadLocal 透传）；非工具调用期（如后台任务线程）为 null，此时用 {@link JobContext#call()}。 */
+    ToolCall call();
+    Files files();
+    Text text();
+    Tags tags();
+    Evidence evidence();
+    Jobs jobs();
+    Docs docs();
+    Settings settings();
+    Llm llm();
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Settings.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Settings.java
@@ -1,0 +1,9 @@
+package com.checkba.plugin.api;
+
+/** 插件级键值设置（键自动加前缀 plugin.&lt;id&gt;.）与项目样式画像。 */
+public interface Settings {
+    String get(String key);
+    void set(String key, String value);
+    /** 项目样式画像 JSON（解析顺序见 SPEC §3.4）；没有任何画像时返回 null。 */
+    String projectStyleProfileJson(long projectId);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/TagInfo.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/TagInfo.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** 标签；type 为 NORMAL / PARTY / ISSUE（null 视同 NORMAL）。 */
+public record TagInfo(long id, String name, String type, String color) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Tags.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Tags.java
@@ -1,0 +1,8 @@
+package com.checkba.plugin.api;
+
+/** 标签：同名不同型复用不改型。 */
+public interface Tags {
+    TagInfo getOrCreate(long projectId, String name, String type);
+    void tagFile(long projectId, long fileId, long tagId);
+    java.util.List<TagInfo> tagsOf(long projectId, long fileId);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/TargetInput.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/TargetInput.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** 建链/追加时的一个底稿位置（与宿主 EvidenceLinkViews.TargetInput 字段一一对应）。 */
+public record TargetInput(Long fileId, String locatorJson, String relation, String method, Short confidence, String note) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/TargetView.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/TargetView.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** 证据链接的一个底稿目标。 */
+public record TargetView(long id, long fileId, String fileName, String locatorJson, String relation, String method) {}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Text.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Text.java
@@ -1,0 +1,9 @@
+package com.checkba.plugin.api;
+
+/** 文本抽取与 OCR。ocr 走平台网关（扣用户 Credits），插件不自带 key。 */
+public interface Text {
+    String extract(long projectId, long fileId, int maxChars);
+    OcrResult ocr(long projectId, long fileId, OcrOptions o);
+    /** PDF 分页文本；页码从 1 起、闭区间。 */
+    java.util.List<String> pdfPageTexts(long projectId, long fileId, int fromPage, int toPage);
+}

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/ToolCall.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/ToolCall.java
@@ -1,0 +1,4 @@
+package com.checkba.plugin.api;
+
+/** 一次工具调用的上下文快照：项目、会话、用户、模型。 */
+public record ToolCall(Long projectId, String conversationId, Long userId, String modelId) {}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,6 +21,13 @@
         <commons-lang3.version>3.14.0</commons-lang3.version>
     </properties>
     <dependencies>
+        <!-- 插件宿主 SPI（backend/plugin-api 独立工程，先 mvn -f backend/plugin-api/pom.xml install）。
+             版本独立于桌面端，只加不破；插件以 provided 依赖同一坐标。 -->
+        <dependency>
+            <groupId>com.checkba</groupId>
+            <artifactId>plugin-api</artifactId>
+            <version>1.0.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/backend/src/main/java/com/checkba/controller/PluginJobController.java
+++ b/backend/src/main/java/com/checkba/controller/PluginJobController.java
@@ -1,0 +1,73 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.PluginJob;
+import com.checkba.service.LangText;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.plugin.PluginJobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 插件后台任务 REST（插件规范 v2.4 §11 Jobs）。
+ * 鉴权：登录 + 项目成员（读）；取消要写权限（CLIENT 角色只能看）。
+ * 没有 projectId 的任务（插件在无项目上下文下起的）只有 admin 能看，这里不开放。
+ */
+@RestController
+@RequestMapping("/api/plugin-jobs")
+@RequiredArgsConstructor
+public class PluginJobController {
+
+    private final PluginJobService jobs;
+    private final ProjectMemberService projectMemberService;
+
+    private Long uid(String sessionId) {
+        Long u = AuthController.getUserIdFromSession(sessionId);
+        if (u == null) throw new IllegalArgumentException("请先登录");
+        return u;
+    }
+
+    private void requireRead(Long projectId, Long userId) {
+        if (projectId == null || !projectMemberService.hasReadPermission(projectId, userId)) {
+            throw new IllegalArgumentException(LangText.of("无权访问该资源", "You don't have permission to access this resource"));
+        }
+    }
+
+    @GetMapping
+    public List<PluginJob> list(@RequestParam Long projectId,
+                                @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireRead(projectId, uid(sessionId));
+        return jobs.listByProject(projectId);
+    }
+
+    @GetMapping("/{id}")
+    public PluginJob get(@PathVariable String id,
+                         @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long u = uid(sessionId);
+        PluginJob j = jobs.get(id);
+        if (j == null) throw new IllegalArgumentException(LangText.of("任务不存在: ", "Job not found: ") + id);
+        requireRead(j.getProjectId(), u);
+        return j;
+    }
+
+    @PostMapping("/{id}/cancel")
+    public Map<String, Object> cancel(@PathVariable String id,
+                                      @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long u = uid(sessionId);
+        PluginJob j = jobs.get(id);
+        if (j == null) throw new IllegalArgumentException(LangText.of("任务不存在: ", "Job not found: ") + id);
+        if (j.getProjectId() == null || !projectMemberService.hasWritePermission(j.getProjectId(), u)) {
+            throw new IllegalArgumentException(LangText.of("无权访问该资源", "You don't have permission to access this resource"));
+        }
+        jobs.cancel(id);
+        return Map.of("jobId", id, "status", jobs.status(id).status());
+    }
+}

--- a/backend/src/main/java/com/checkba/model/entity/PluginJob.java
+++ b/backend/src/main/java/com/checkba/model/entity/PluginJob.java
@@ -1,0 +1,82 @@
+package com.checkba.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 插件后台任务（插件规范 v2.4 §11 Jobs）。id 是 26 位 ULID（宿主生成），
+ * 状态 queued / running / done / failed / cancelled 只前进不回退。
+ * 进度字段由 {@code PluginJobService} 节流落库，内存态才是实时值。
+ */
+@Entity
+@Table(name = "plugin_job", indexes = {
+        @Index(name = "idx_plugin_job_project", columnList = "project_id,created_at"),
+        @Index(name = "idx_plugin_job_status", columnList = "status")
+})
+@Getter
+@Setter
+public class PluginJob {
+
+    public static final String STATUS_QUEUED = "queued";
+    public static final String STATUS_RUNNING = "running";
+    public static final String STATUS_DONE = "done";
+    public static final String STATUS_FAILED = "failed";
+    public static final String STATUS_CANCELLED = "cancelled";
+
+    @Id
+    @Column(length = 26, nullable = false)
+    private String id;
+
+    @Column(name = "plugin_id", length = 64, nullable = false)
+    private String pluginId;
+
+    @Column(length = 64, nullable = false)
+    private String kind;
+
+    @Column(length = 256)
+    private String title;
+
+    @Column(length = 16, nullable = false)
+    private String status = STATUS_QUEUED;
+
+    @Column(nullable = false)
+    private long done;
+
+    @Column(nullable = false)
+    private long total;
+
+    @Column(length = 512)
+    private String message;
+
+    @Column(name = "result_json", columnDefinition = "TEXT")
+    private String resultJson;
+
+    @Column(columnDefinition = "TEXT")
+    private String error;
+
+    @Column(name = "project_id")
+    private Long projectId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "conversation_id", length = 64)
+    private String conversationId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public boolean isTerminal() {
+        return STATUS_DONE.equals(status) || STATUS_FAILED.equals(status) || STATUS_CANCELLED.equals(status);
+    }
+}

--- a/backend/src/main/java/com/checkba/repository/PluginJobRepository.java
+++ b/backend/src/main/java/com/checkba/repository/PluginJobRepository.java
@@ -1,0 +1,16 @@
+package com.checkba.repository;
+
+import com.checkba.model.entity.PluginJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+public interface PluginJobRepository extends JpaRepository<PluginJob, String> {
+
+    List<PluginJob> findByProjectIdOrderByCreatedAtDesc(Long projectId);
+
+    List<PluginJob> findByStatusIn(Collection<String> statuses);
+}

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -954,6 +954,43 @@ public class ProjectFileService {
         return createFolder(projectId, parentId, name, userId);
     }
 
+    /**
+     * 从项目根起逐级确保文件夹存在（"a/b/c" → 三段），返回最深一级。
+     * 空白段跳过；某段已存在但是文件而不是文件夹时抛 IllegalArgumentException（不会把文件当目录往下钻）。
+     * 插件宿主 Files.createFolderPath、AI 工具 move_file 的目标目录补建、会议录音目录都走这里，
+     * 同名查找口径（未删除、同父、同名）只在这一处。
+     */
+    @Transactional
+    public ProjectFile ensureFolderPath(Long projectId, Long userId, List<String> segments) {
+        if (projectId == null) {
+            throw new IllegalArgumentException(LangText.of("项目 ID 不能为空", "Project ID must not be empty"));
+        }
+        ProjectFile current = null;
+        Long parentId = null;
+        if (segments != null) {
+            for (String raw : segments) {
+                String seg = raw == null ? "" : raw.trim();
+                if (seg.isEmpty()) continue;
+                Optional<ProjectFile> existing = projectFileRepository
+                        .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, parentId, seg);
+                if (existing.isPresent()) {
+                    if (!Boolean.TRUE.equals(existing.get().getIsFolder())) {
+                        throw new IllegalArgumentException(LangText.of(
+                                "路径段已存在但不是文件夹: ", "Path segment exists but is not a folder: ") + seg);
+                    }
+                    current = existing.get();
+                } else {
+                    current = createFolder(projectId, parentId, seg, userId);
+                }
+                parentId = current.getId();
+            }
+        }
+        if (current == null) {
+            throw new IllegalArgumentException(LangText.of("文件夹路径不能为空", "Folder path must not be empty"));
+        }
+        return current;
+    }
+
     private ProjectFile ensureConversationFolder(Long projectId, Long parentId, String conversationId, Long userId) {
         // 1. Try by wpsFileId (Robust lookup)
         Optional<ProjectFile> byWpsId = projectFileRepository.findByWpsFileId(conversationId).stream().findFirst();

--- a/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
+++ b/backend/src/main/java/com/checkba/service/ai/EditorBridgeService.java
@@ -192,6 +192,22 @@ public class EditorBridgeService {
     }
 
     /**
+     * 单名 client_action（无双轨旧名）：显式指定会话，不依赖 ThreadLocal 的当前会话——
+     * 插件后台任务跑在自己的线程池上，这里拿不到 currentConversationId。
+     * 载荷 = fields + {action}。
+     */
+    public void sendClientAction(String action, String conversationId, Map<String, Object> fields) {
+        if (action == null || conversationId == null) return;
+        try {
+            java.util.Map<String, Object> payloadMap = new java.util.HashMap<>(fields != null ? fields : Map.of());
+            payloadMap.put("action", action);
+            sseEmitterService.send(conversationId, "client_action", objectMapper.writeValueAsString(payloadMap));
+        } catch (Exception e) {
+            log.warn("Failed to send client_action {} to {}: {}", action, conversationId, e.getMessage());
+        }
+    }
+
+    /**
      * 发送刷新文件树的 SSE 事件到前端
      */
     public void sendRefreshFilesAction() {

--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -107,6 +107,43 @@ public class PluginService {
     @org.springframework.context.annotation.Lazy
     private ToolRegistry toolRegistry;
 
+    /**
+     * 插件宿主 SPI（规范 v2.4 §4/§11）：实例化出的工具类若实现 HostAware，注入按插件 id 绑定的 PluginHost。
+     * 用 ObjectProvider 懒取——PluginHostFactory 背后挂着 EditorBridgeService/ProjectFileService 一串，
+     * 构造器注入会把本类拖进启动死环；required=false 让直接 new 的测试照旧。
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private org.springframework.beans.factory.ObjectProvider<com.checkba.service.plugin.PluginHostFactory> pluginHostFactoryProvider;
+
+    /** 供测试直接装配。 */
+    void setPluginHostFactory(com.checkba.service.plugin.PluginHostFactory factory) {
+        this.pluginHostFactoryProvider = new org.springframework.beans.factory.ObjectProvider<>() {
+            @Override public com.checkba.service.plugin.PluginHostFactory getObject(Object... args) { return factory; }
+            @Override public com.checkba.service.plugin.PluginHostFactory getIfAvailable() { return factory; }
+            @Override public com.checkba.service.plugin.PluginHostFactory getIfUnique() { return factory; }
+            @Override public com.checkba.service.plugin.PluginHostFactory getObject() { return factory; }
+        };
+    }
+
+    /**
+     * 实例化后的钩子：实现了 {@link com.checkba.plugin.api.HostAware} 的工具类拿到宿主门面。
+     * 宿主工厂不可用（测试直接 new、或启动早期）时只记 WARN——插件照常注册，只是拿不到 host。
+     */
+    void injectHostIfAware(Object instance, String pluginId) {
+        if (!(instance instanceof com.checkba.plugin.api.HostAware aware)) {
+            return;
+        }
+        com.checkba.service.plugin.PluginHostFactory factory =
+                pluginHostFactoryProvider != null ? pluginHostFactoryProvider.getIfAvailable() : null;
+        if (factory == null) {
+            log.warn("Plugin {} tool {} implements HostAware but no PluginHostFactory is available; host not injected",
+                    pluginId, instance.getClass().getName());
+            return;
+        }
+        aware.setHost(factory.forPlugin(pluginId));
+        log.info("Injected PluginHost into {} (plugin {})", instance.getClass().getName(), pluginId);
+    }
+
     @org.springframework.beans.factory.annotation.Autowired
     public PluginService(SystemSettingService systemSettingService,
                          @Value("${ai.plugins.dir:plugins}") String pluginsDir) {
@@ -655,6 +692,7 @@ public class PluginService {
                             log.info("Found tool class in plugin: {}", className);
                             // Instantiate and register
                             Object instance = cls.getDeclaredConstructor().newInstance();
+                            injectHostIfAware(instance, pluginId);
                             registerToolObject(instance, pluginId);
                         }
                     } catch (Throwable e) {

--- a/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
+++ b/backend/src/main/java/com/checkba/service/ai/ToolRegistry.java
@@ -150,6 +150,19 @@ public class ToolRegistry {
     private final Map<String, RegisteredTool> pluginToolCache = new ConcurrentHashMap<>();
     private final List<ToolSpecification> builtinSpecifications = new ArrayList<>();
 
+    /**
+     * 插件宿主 SPI（规范 v2.4 §11）：分发插件工具前把服务端上下文绑到 PluginHostFactory 的 ThreadLocal，
+     * 与下面 ToolContextHolder.set 同一处设、同一处清。字段注入 + required=false：
+     * 大量 {@code new ToolRegistry(...)} 直接构造的既有测试（含 EvalHarness）不受影响，null 即跳过。
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.plugin.PluginHostFactory pluginHostFactory;
+
+    /** 供测试直接装配。 */
+    void setPluginHostFactory(com.checkba.service.plugin.PluginHostFactory pluginHostFactory) {
+        this.pluginHostFactory = pluginHostFactory;
+    }
+
     public ToolRegistry(List<AgentToolComponent> toolComponents, PluginService pluginService,
                         ClientCapabilityService clientCapabilityService) {
         this.toolComponents = toolComponents;
@@ -338,6 +351,10 @@ public class ToolRegistry {
                         + "' requires permission(s) " + missing
                         + " not declared in the plugin manifest \"permissions\".", tool, true);
             }
+            // 宿主 SPI 的调用上下文（projectId/userId 以服务端为准，模型传的参数不可信）
+            if (pluginHostFactory != null) {
+                pluginHostFactory.bindCall(ctx);
+            }
         }
 
         // 装填线程上下文：修复流式回调线程与请求线程不一致导致的 ThreadLocal 丢失/串会话问题
@@ -369,6 +386,9 @@ public class ToolRegistry {
             // 同时清理 ProjectContextHolder：装填时设置了它（见上），此前只清 ToolContextHolder，
             // 池化回调线程复用会残留上个会话的 projectId/userId，导致记忆作用域串号。
             ProjectContextHolder.clear();
+            if (pluginHostFactory != null) {
+                pluginHostFactory.clear();
+            }
         }
     }
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/FileTools.java
@@ -588,25 +588,9 @@ public class FileTools implements AgentToolComponent {
             if (parentDir != null) {
                 ProjectFile folder = index.get(parentDir);
                 if (folder == null) {
-                    // 逐段补建缺失的目标文件夹
-                    Long parentId = null;
-                    StringBuilder walked = new StringBuilder();
-                    for (String seg : parentDir.split("/")) {
-                        if (walked.length() > 0) walked.append('/');
-                        walked.append(seg);
-                        ProjectFile existing = index.get(walked.toString());
-                        if (existing != null) {
-                            if (!Boolean.TRUE.equals(existing.getIsFolder())) {
-                                return "Error: '" + walked + "' exists but is a file, not a folder.";
-                            }
-                            parentId = existing.getId();
-                        } else {
-                            ProjectFile created = projectFileService.createFolder(projectId, parentId, seg, toolUserId());
-                            index.put(walked.toString(), created);
-                            parentId = created.getId();
-                        }
-                    }
-                    targetFolderId = parentId;
+                    // 逐段补建缺失的目标文件夹（某段已存在但是文件时抛 IllegalArgumentException，下面统一转成 Error 返回）
+                    targetFolderId = projectFileService.ensureFolderPath(projectId, toolUserId(),
+                            java.util.Arrays.asList(parentDir.split("/"))).getId();
                 } else if (!Boolean.TRUE.equals(folder.getIsFolder())) {
                     return "Error: '" + parentDir + "' exists but is a file, not a folder.";
                 } else {

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
@@ -299,7 +299,8 @@ public class MeetingRecordingService {
                 return existing.get();
             }
         }
-        return projectFileService.createFolder(projectId, null, preferred, userId);
+        // 两个语言名都不在：按界面语言建一个（ensureFolderPath 是全仓「逐级确保文件夹」的单一出处）
+        return projectFileService.ensureFolderPath(projectId, userId, List.of(preferred));
     }
 
     /** createFile 对同名文件抛异常，这里先探测再加 (2)/(3) 后缀。 */

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostFactory.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostFactory.java
@@ -1,0 +1,150 @@
+package com.checkba.service.plugin;
+
+import com.checkba.plugin.api.PluginHost;
+import com.checkba.plugin.api.ToolCall;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.TagRepository;
+import com.checkba.service.DocumentTextService;
+import com.checkba.service.FileTagService;
+import com.checkba.service.OcrService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.SystemSettingService;
+import com.checkba.service.TagService;
+import com.checkba.service.ai.AuxModelResolver;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.TokenUsageService;
+import com.checkba.service.ai.tools.ToolContext;
+import com.checkba.service.evidence.EvidenceLinkService;
+import com.checkba.storage.StorageServiceFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 按插件 id 发放 {@link PluginHost}（缓存），并持有「当前调用上下文」的 ThreadLocal：
+ * {@code ToolRegistry} 在分发插件工具前 {@link #bindCall}、分发后 {@link #clear}（与 ToolContextHolder 同一处）；
+ * 后台任务线程由 {@code PluginJobService} 的任务体包装同样绑定一份快照。
+ *
+ * <p>所有宿主服务集中在这里注入，{@link PluginHostImpl} 只拿引用——单元 I/J/K 给宿主加能力时只改这两处。
+ */
+@Service
+public class PluginHostFactory {
+
+    final ProjectFileService projectFileService;
+    final ProjectFileRepository projectFileRepository;
+    final StorageServiceFactory storageServiceFactory;
+    final ProjectMemberService projectMemberService;
+    final DocumentTextService documentTextService;
+    final OcrService ocrService;
+    final TagService tagService;
+    final TagRepository tagRepository;
+    final FileTagService fileTagService;
+    final EvidenceLinkService evidenceLinkService;
+    final PluginJobService pluginJobService;
+    final EditorBridgeService editorBridgeService;
+    final SystemSettingService systemSettingService;
+    final ChatModelFactory chatModelFactory;
+    final AuxModelResolver auxModelResolver;
+    final TokenUsageService tokenUsageService;
+    final ObjectMapper objectMapper;
+    final PluginHostQuota quota;
+
+    private final ThreadLocal<ToolCall> currentCall = new ThreadLocal<>();
+    private final Map<String, PluginHost> hosts = new ConcurrentHashMap<>();
+
+    @Autowired
+    public PluginHostFactory(ProjectFileService projectFileService,
+                             ProjectFileRepository projectFileRepository,
+                             StorageServiceFactory storageServiceFactory,
+                             ProjectMemberService projectMemberService,
+                             DocumentTextService documentTextService,
+                             OcrService ocrService,
+                             TagService tagService,
+                             TagRepository tagRepository,
+                             FileTagService fileTagService,
+                             EvidenceLinkService evidenceLinkService,
+                             PluginJobService pluginJobService,
+                             EditorBridgeService editorBridgeService,
+                             SystemSettingService systemSettingService,
+                             ChatModelFactory chatModelFactory,
+                             AuxModelResolver auxModelResolver,
+                             TokenUsageService tokenUsageService,
+                             ObjectMapper objectMapper) {
+        this(projectFileService, projectFileRepository, storageServiceFactory, projectMemberService, documentTextService,
+                ocrService, tagService, tagRepository, fileTagService, evidenceLinkService, pluginJobService,
+                editorBridgeService, systemSettingService, chatModelFactory, auxModelResolver, tokenUsageService,
+                objectMapper, new PluginHostQuota());
+    }
+
+    PluginHostFactory(ProjectFileService projectFileService,
+                      ProjectFileRepository projectFileRepository,
+                      StorageServiceFactory storageServiceFactory,
+                      ProjectMemberService projectMemberService,
+                      DocumentTextService documentTextService,
+                      OcrService ocrService,
+                      TagService tagService,
+                      TagRepository tagRepository,
+                      FileTagService fileTagService,
+                      EvidenceLinkService evidenceLinkService,
+                      PluginJobService pluginJobService,
+                      EditorBridgeService editorBridgeService,
+                      SystemSettingService systemSettingService,
+                      ChatModelFactory chatModelFactory,
+                      AuxModelResolver auxModelResolver,
+                      TokenUsageService tokenUsageService,
+                      ObjectMapper objectMapper,
+                      PluginHostQuota quota) {
+        this.projectFileService = projectFileService;
+        this.projectFileRepository = projectFileRepository;
+        this.storageServiceFactory = storageServiceFactory;
+        this.projectMemberService = projectMemberService;
+        this.documentTextService = documentTextService;
+        this.ocrService = ocrService;
+        this.tagService = tagService;
+        this.tagRepository = tagRepository;
+        this.fileTagService = fileTagService;
+        this.evidenceLinkService = evidenceLinkService;
+        this.pluginJobService = pluginJobService;
+        this.editorBridgeService = editorBridgeService;
+        this.systemSettingService = systemSettingService;
+        this.chatModelFactory = chatModelFactory;
+        this.auxModelResolver = auxModelResolver;
+        this.tokenUsageService = tokenUsageService;
+        this.objectMapper = objectMapper != null ? objectMapper : new ObjectMapper();
+        this.quota = quota != null ? quota : new PluginHostQuota();
+    }
+
+    public PluginHost forPlugin(String pluginId) {
+        if (pluginId == null || pluginId.isBlank()) {
+            throw new IllegalArgumentException("pluginId required");
+        }
+        return hosts.computeIfAbsent(pluginId, id -> new PluginHostImpl(id, this));
+    }
+
+    /** 分发插件工具前调用：把服务端上下文绑到当前线程（模型传的 projectId/userId 一律不可信）。 */
+    public void bindCall(ToolContext ctx) {
+        if (ctx == null) {
+            currentCall.remove();
+            return;
+        }
+        currentCall.set(new ToolCall(ctx.projectId(), ctx.conversationId(), ctx.userId(), ctx.modelId()));
+    }
+
+    /** 后台任务线程用：直接绑一份快照。 */
+    public void bindCall(ToolCall call) {
+        if (call == null) currentCall.remove(); else currentCall.set(call);
+    }
+
+    public void clear() {
+        currentCall.remove();
+    }
+
+    ToolCall currentCall() {
+        return currentCall.get();
+    }
+}

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostImpl.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostImpl.java
@@ -1,0 +1,732 @@
+package com.checkba.service.plugin;
+
+import com.checkba.model.entity.PluginJob;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.Tag;
+import com.checkba.plugin.api.ConflictPolicy;
+import com.checkba.plugin.api.Docs;
+import com.checkba.plugin.api.Evidence;
+import com.checkba.plugin.api.FileInfo;
+import com.checkba.plugin.api.Files;
+import com.checkba.plugin.api.JobBody;
+import com.checkba.plugin.api.JobHandle;
+import com.checkba.plugin.api.JobStatus;
+import com.checkba.plugin.api.Jobs;
+import com.checkba.plugin.api.LinkView;
+import com.checkba.plugin.api.Llm;
+import com.checkba.plugin.api.LlmOptions;
+import com.checkba.plugin.api.OcrBlock;
+import com.checkba.plugin.api.OcrOptions;
+import com.checkba.plugin.api.OcrResult;
+import com.checkba.plugin.api.PluginHost;
+import com.checkba.plugin.api.Settings;
+import com.checkba.plugin.api.TagInfo;
+import com.checkba.plugin.api.Tags;
+import com.checkba.plugin.api.TargetInput;
+import com.checkba.plugin.api.TargetView;
+import com.checkba.plugin.api.Text;
+import com.checkba.plugin.api.ToolCall;
+import com.checkba.service.LangText;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.PlatformAiUserScope;
+import com.checkba.service.evidence.EvidenceLinkViews;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.util.StringUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * {@link PluginHost} 的宿主实现（插件规范 v2.4 §11）。按插件 id 绑定；每个方法先过配额再校项目成员权限。
+ *
+ * <p>调用上下文来自 {@link PluginHostFactory#currentCall()}：工具分发期由 ToolRegistry 绑定，
+ * 后台任务期由 {@link Jobs#start} 的任务体包装绑定快照。两者都没有时一律拒绝——
+ * 插件不能在没有用户身份的线程上读写项目。
+ */
+@Slf4j
+class PluginHostImpl implements PluginHost {
+
+    /** Docs.exec 放行的编辑器原语：AI 管线已经在用的 writer/sheet/slide 下发名；宿主自用与诊断原语不开放。 */
+    static final Set<String> DOC_ACTIONS = Set.of(
+            // writer
+            "insert_at_cursor", "replace_selection", "find_replace", "get_selection", "find_text_locations",
+            "replace_nth_match", "delete_match", "delete_text", "get_paragraph", "modify_paragraph", "get_outline",
+            "goto", "set_selection", "replace_at_position", "clear_anchors", "get_document_text", "get_cursor_context",
+            "get_clauses", "select_paragraph", "collapse_selection", "delete_selection", "format_selection",
+            "set_paragraph_format", "undo", "redo", "insert_paragraph", "insert_table", "insert_break", "insert_image",
+            "insert_under_heading", "format_table", "get_formatting", "set_style", "set_numbering", "edit_header_footer",
+            "apply_house_style", "add_comment", "list_comments", "reply_comment", "set_comment_resolved", "delete_comment",
+            "list_revisions", "resolve_revision", "resolve_all_revisions", "set_hyperlink_at_anchor",
+            "bookmark_selection", "get_bookmark_context", "goto_bookmark", "check_link_anchors",
+            "get_selection_hyperlink", "set_selection_hyperlink", "insert_link_with_bookmark",
+            // calc
+            "sheet_get_overview", "sheet_read_range", "sheet_write_cells", "sheet_format_cells", "sheet_set_borders",
+            "sheet_merge_cells", "sheet_set_row_col", "sheet_edit_rows_cols", "sheet_manage_sheets", "sheet_search",
+            "sheet_select_range", "sheet_sort_range", "sheet_set_autofilter", "sheet_freeze_panes",
+            "sheet_conditional_format", "sheet_set_data_validation", "sheet_define_name", "sheet_group_rows_cols",
+            "sheet_protect_sheet", "sheet_add_chart", "sheet_add_pivot_table", "sheet_add_comment",
+            "sheet_get_comments", "sheet_delete_comment",
+            // impress
+            "slide_get_overview", "slide_get_page", "slide_goto", "slide_add_page", "slide_delete_page",
+            "slide_move_page", "slide_add_text_box", "slide_add_shape", "slide_add_table", "slide_delete_shape",
+            "slide_format_shape", "slide_format_text");
+
+    static final Set<String> IMAGE_TYPES = Set.of("png", "jpg", "jpeg", "bmp", "gif", "webp", "tif", "tiff");
+    static final int OCR_MAX_PAGES = 50;
+    static final String STYLE_PROFILE_SETTING = "dd.styleProfile.default";
+    static final String STYLE_PROFILE_RESOURCE = "style-profiles/house-default.json";
+    static final String TEMPLATE_FOLDER = "_模板";
+    static final String TEMPLATE_PROFILE_FILE = "画像.json";
+
+    private final String pluginId;
+    private final PluginHostFactory f;
+
+    private final Files files = new FilesImpl();
+    private final Text text = new TextImpl();
+    private final Tags tags = new TagsImpl();
+    private final Evidence evidence = new EvidenceImpl();
+    private final Jobs jobs = new JobsImpl();
+    private final Docs docs = new DocsImpl();
+    private final Settings settings = new SettingsImpl();
+    private final Llm llm = new LlmImpl();
+
+    PluginHostImpl(String pluginId, PluginHostFactory factory) {
+        this.pluginId = pluginId;
+        this.f = factory;
+    }
+
+    @Override public String pluginId() { return pluginId; }
+    @Override public ToolCall call() { return f.currentCall(); }
+    @Override public Files files() { return files; }
+    @Override public Text text() { return text; }
+    @Override public Tags tags() { return tags; }
+    @Override public Evidence evidence() { return evidence; }
+    @Override public Jobs jobs() { return jobs; }
+    @Override public Docs docs() { return docs; }
+    @Override public Settings settings() { return settings; }
+    @Override public Llm llm() { return llm; }
+
+    // ------------------------------------------------------------------ guards
+
+    /** 配额 + 必须有调用上下文。 */
+    private ToolCall enter() {
+        f.quota.acquire(pluginId);
+        ToolCall c = f.currentCall();
+        if (c == null || c.userId() == null) {
+            throw new IllegalStateException(LangText.of(
+                    "插件 " + pluginId + " 在没有调用上下文的线程上访问宿主",
+                    "Plugin " + pluginId + " called the host without a call context"));
+        }
+        return c;
+    }
+
+    private ToolCall requireRead(long projectId) {
+        ToolCall c = enter();
+        if (!f.projectMemberService.hasReadPermission(projectId, c.userId())) {
+            throw new IllegalArgumentException(LangText.of("无权限访问该项目", "No access to this project"));
+        }
+        return c;
+    }
+
+    private ToolCall requireWrite(long projectId) {
+        ToolCall c = enter();
+        if (!f.projectMemberService.hasWritePermission(projectId, c.userId())) {
+            throw new IllegalArgumentException(LangText.of("无权限修改该项目", "No write access to this project"));
+        }
+        return c;
+    }
+
+    private ProjectFile requireProjectFile(long projectId, long fileId) {
+        ProjectFile pf = f.projectFileRepository.findById(fileId).orElse(null);
+        if (pf == null || !Long.valueOf(projectId).equals(pf.getProjectId()) || Boolean.TRUE.equals(pf.getIsDeleted())) {
+            throw new IllegalArgumentException(LangText.of("文件不存在: ", "File not found: ") + fileId);
+        }
+        return pf;
+    }
+
+    private byte[] readBytes(ProjectFile pf) {
+        if (Boolean.TRUE.equals(pf.getIsFolder()) || !StringUtils.hasText(pf.getFilePath())) {
+            throw new IllegalArgumentException(LangText.of("不是可读文件: ", "Not a readable file: ") + pf.getName());
+        }
+        try (InputStream in = f.storageServiceFactory.getStorageService().load(pf.getFilePath()).getInputStream()) {
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String ext(String name) {
+        if (name == null) return "";
+        int dot = name.lastIndexOf('.');
+        return dot > 0 && dot < name.length() - 1 ? name.substring(dot + 1).toLowerCase() : "";
+    }
+
+    private Map<String, Object> readMeta(ProjectFile pf) {
+        if (!StringUtils.hasText(pf.getMetaJson())) return new LinkedHashMap<>();
+        try {
+            return f.objectMapper.readValue(pf.getMetaJson(), new TypeReference<LinkedHashMap<String, Object>>() {});
+        } catch (Exception e) {
+            return new LinkedHashMap<>();
+        }
+    }
+
+    private void writeMeta(ProjectFile pf, Map<String, Object> meta) {
+        try {
+            pf.setMetaJson(f.objectMapper.writeValueAsString(meta));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        f.projectFileRepository.save(pf);
+    }
+
+    // ------------------------------------------------------------------ Files
+
+    private final class FilesImpl implements Files {
+
+        private Map<Long, ProjectFile> index(long projectId) {
+            Map<Long, ProjectFile> m = new HashMap<>();
+            for (ProjectFile p : f.projectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(projectId)) {
+                m.put(p.getId(), p);
+            }
+            return m;
+        }
+
+        private String pathOf(ProjectFile p, Map<Long, ProjectFile> idx) {
+            StringBuilder sb = new StringBuilder(p.getName());
+            Long parent = p.getParentId();
+            int guard = 0;
+            while (parent != null && guard++ < 64) {
+                ProjectFile pp = idx.get(parent);
+                if (pp == null) break;
+                sb.insert(0, pp.getName() + "/");
+                parent = pp.getParentId();
+            }
+            return sb.toString();
+        }
+
+        private FileInfo info(ProjectFile p, Map<Long, ProjectFile> idx) {
+            Map<String, Object> meta = readMeta(p);
+            Object sha = meta.get("sha256");
+            return new FileInfo(p.getId(), p.getName(), p.getParentId(), Boolean.TRUE.equals(p.getIsFolder()),
+                    p.getFileType(), p.getFileSize() == null ? 0L : p.getFileSize(), pathOf(p, idx),
+                    sha instanceof String s ? s : null, p.getMetaJson());
+        }
+
+        private boolean under(ProjectFile p, Long ancestorId, Map<Long, ProjectFile> idx) {
+            if (ancestorId == null) return true;
+            Long parent = p.getParentId();
+            int guard = 0;
+            while (parent != null && guard++ < 64) {
+                if (parent.equals(ancestorId)) return true;
+                ProjectFile pp = idx.get(parent);
+                if (pp == null) return false;
+                parent = pp.getParentId();
+            }
+            return false;
+        }
+
+        @Override
+        public List<FileInfo> list(long projectId, Long parentId, boolean recursive) {
+            requireRead(projectId);
+            Map<Long, ProjectFile> idx = index(projectId);
+            List<FileInfo> out = new ArrayList<>();
+            for (ProjectFile p : idx.values()) {
+                boolean hit = recursive ? under(p, parentId, idx) : java.util.Objects.equals(p.getParentId(), parentId);
+                if (hit) out.add(info(p, idx));
+            }
+            out.sort(java.util.Comparator.comparing(FileInfo::path));
+            return out;
+        }
+
+        @Override
+        public FileInfo get(long projectId, long fileId) {
+            requireRead(projectId);
+            ProjectFile p = requireProjectFile(projectId, fileId);
+            return info(p, index(projectId));
+        }
+
+        @Override
+        public InputStream open(long projectId, long fileId) {
+            requireRead(projectId);
+            return new ByteArrayInputStream(readBytes(requireProjectFile(projectId, fileId)));
+        }
+
+        @Override
+        public FileInfo createFolderPath(long projectId, List<String> segments) {
+            ToolCall c = requireWrite(projectId);
+            ProjectFile folder = f.projectFileService.ensureFolderPath(projectId, c.userId(), segments);
+            return info(folder, index(projectId));
+        }
+
+        @Override
+        public FileInfo write(long projectId, Long parentId, String name, InputStream bytes, ConflictPolicy policy) {
+            ToolCall c = requireWrite(projectId);
+            if (!StringUtils.hasText(name)) throw new IllegalArgumentException("name required");
+            byte[] data;
+            try {
+                data = bytes == null ? new byte[0] : bytes.readAllBytes();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            ProjectFileService.ConflictPolicy p = policy == ConflictPolicy.RENAME
+                    ? ProjectFileService.ConflictPolicy.RENAME : ProjectFileService.ConflictPolicy.FAIL;
+            String type = ext(name);
+            ProjectFile created = f.projectFileService.createFile(projectId, parentId, name.trim(),
+                    type.isEmpty() ? "bin" : type, (long) data.length, null, null, c.userId(), p);
+            try {
+                f.storageServiceFactory.getStorageService().save(created.getFilePath(), new ByteArrayInputStream(data));
+            } catch (Exception e) {
+                throw new IllegalStateException(LangText.of("写入文件失败: ", "Failed to write file: ") + e.getMessage(), e);
+            }
+            return info(created, index(projectId));
+        }
+
+        @Override
+        public FileInfo move(long projectId, long fileId, Long newParentId) {
+            ToolCall c = requireWrite(projectId);
+            requireProjectFile(projectId, fileId);
+            if (newParentId != null) {
+                ProjectFile target = requireProjectFile(projectId, newParentId);
+                if (!Boolean.TRUE.equals(target.getIsFolder())) {
+                    throw new IllegalArgumentException(LangText.of("目标不是文件夹", "Target is not a folder"));
+                }
+            }
+            ProjectFile moved = f.projectFileService.move(fileId, newParentId, null, c.userId());
+            return info(moved, index(projectId));
+        }
+
+        @Override
+        public FileInfo rename(long projectId, long fileId, String newName) {
+            ToolCall c = requireWrite(projectId);
+            requireProjectFile(projectId, fileId);
+            ProjectFile renamed = f.projectFileService.rename(fileId, newName, c.userId());
+            return info(renamed, index(projectId));
+        }
+
+        @Override
+        public void setMeta(long projectId, long fileId, Map<String, Object> metaPatch) {
+            requireWrite(projectId);
+            ProjectFile p = requireProjectFile(projectId, fileId);
+            if (metaPatch == null || metaPatch.isEmpty()) return;
+            Map<String, Object> meta = readMeta(p);
+            for (Map.Entry<String, Object> e : metaPatch.entrySet()) {
+                if (e.getValue() == null) meta.remove(e.getKey()); else meta.put(e.getKey(), e.getValue());
+            }
+            writeMeta(p, meta);
+        }
+
+        @Override
+        public String sha256(long projectId, long fileId) {
+            requireRead(projectId);
+            ProjectFile p = requireProjectFile(projectId, fileId);
+            Map<String, Object> meta = readMeta(p);
+            String stamp = p.getUpdatedAt() == null ? "" : p.getUpdatedAt().toString();
+            if (meta.get("sha256") instanceof String cached && stamp.equals(meta.get("sha256At"))) {
+                return cached;
+            }
+            byte[] data = readBytes(p);
+            String hex;
+            try {
+                hex = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(data));
+            } catch (java.security.NoSuchAlgorithmException e) {
+                throw new IllegalStateException(e);
+            }
+            meta.put("sha256", hex);
+            meta.put("sha256At", stamp);
+            try {
+                writeMeta(p, meta);
+            } catch (Exception e) {
+                log.debug("sha256 cache write skipped for file {}: {}", fileId, e.getMessage());
+            }
+            return hex;
+        }
+    }
+
+    // ------------------------------------------------------------------ Text
+
+    private final class TextImpl implements Text {
+
+        @Override
+        public String extract(long projectId, long fileId, int maxChars) {
+            requireRead(projectId);
+            ProjectFile p = requireProjectFile(projectId, fileId);
+            String s;
+            try {
+                s = f.documentTextService.extractText(p);
+            } catch (Exception e) {
+                throw new IllegalStateException(LangText.of("文本抽取失败: ", "Text extraction failed: ") + e.getMessage(), e);
+            }
+            if (s == null) return "";
+            return maxChars > 0 && s.length() > maxChars ? s.substring(0, maxChars) : s;
+        }
+
+        @Override
+        public OcrResult ocr(long projectId, long fileId, OcrOptions o) {
+            ToolCall c = requireRead(projectId);
+            ProjectFile p = requireProjectFile(projectId, fileId);
+            OcrOptions opt = o == null ? OcrOptions.text() : o;
+            byte[] data = readBytes(p);
+            String type = StringUtils.hasText(p.getFileType()) ? p.getFileType().toLowerCase() : ext(p.getName());
+            List<String> pageImages = new ArrayList<>();
+            if ("pdf".equals(type)) {
+                try (PDDocument doc = Loader.loadPDF(data)) {
+                    PDFRenderer renderer = new PDFRenderer(doc);
+                    int pages = Math.min(doc.getNumberOfPages(), OCR_MAX_PAGES);
+                    for (int i = 0; i < pages; i++) {
+                        BufferedImage img = renderer.renderImageWithDPI(i, 150);
+                        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                        ImageIO.write(img, "png", bos);
+                        pageImages.add(Base64.getEncoder().encodeToString(bos.toByteArray()));
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            } else if (IMAGE_TYPES.contains(type)) {
+                pageImages.add(Base64.getEncoder().encodeToString(data));
+            } else {
+                throw new IllegalArgumentException(LangText.of(
+                        "OCR 只支持图片与 PDF: ", "OCR supports images and PDF only: ") + p.getName());
+            }
+            // 平台网关按用户计费：在发起用户的作用域里调
+            StringBuilder all = new StringBuilder();
+            List<OcrBlock> blocks = new ArrayList<>();
+            for (int i = 0; i < pageImages.size(); i++) {
+                String b64 = pageImages.get(i);
+                com.checkba.service.ocr.OcrResult r = PlatformAiUserScope.call(c.userId(), () -> f.ocrService.recognizeGeneral(b64));
+                String t = r == null || r.getText() == null ? "" : r.getText();
+                if (all.length() > 0) all.append('\n');
+                all.append(t);
+                if (opt.blocks()) {
+                    // 网关不回坐标，块粒度到页：一页一块、整页矩形
+                    blocks.add(new OcrBlock(t, i + 1, 0, 0, 1, 1));
+                }
+            }
+            return new OcrResult(all.toString(), blocks);
+        }
+
+        @Override
+        public List<String> pdfPageTexts(long projectId, long fileId, int fromPage, int toPage) {
+            requireRead(projectId);
+            ProjectFile p = requireProjectFile(projectId, fileId);
+            byte[] data = readBytes(p);
+            List<String> out = new ArrayList<>();
+            try (PDDocument doc = Loader.loadPDF(data)) {
+                int n = doc.getNumberOfPages();
+                int from = Math.max(1, fromPage);
+                int to = toPage <= 0 ? n : Math.min(n, toPage);
+                PDFTextStripper stripper = new PDFTextStripper();
+                for (int pg = from; pg <= to; pg++) {
+                    stripper.setStartPage(pg);
+                    stripper.setEndPage(pg);
+                    out.add(stripper.getText(doc));
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            return out;
+        }
+    }
+
+    // ------------------------------------------------------------------ Tags
+
+    private final class TagsImpl implements Tags {
+
+        private TagInfo info(Tag t) {
+            return new TagInfo(t.getId(), t.getName(), t.getType() == null ? "NORMAL" : t.getType(), t.getColor());
+        }
+
+        @Override
+        public TagInfo getOrCreate(long projectId, String name, String type) {
+            requireWrite(projectId);
+            if (!StringUtils.hasText(name)) throw new IllegalArgumentException("name required");
+            Tag t = f.tagService.getOrCreateTag(projectId, name.trim(), StringUtils.hasText(type) ? type : "NORMAL", null);
+            return info(t);
+        }
+
+        @Override
+        public void tagFile(long projectId, long fileId, long tagId) {
+            ToolCall c = requireWrite(projectId);
+            requireProjectFile(projectId, fileId);
+            Optional<Tag> t = f.tagRepository.findById(tagId);
+            if (t.isEmpty() || !Long.valueOf(projectId).equals(t.get().getProjectId())) {
+                throw new IllegalArgumentException(LangText.of("标签不存在: ", "Tag not found: ") + tagId);
+            }
+            f.fileTagService.addTagToFile(fileId, tagId, c.userId());
+        }
+
+        @Override
+        public List<TagInfo> tagsOf(long projectId, long fileId) {
+            requireRead(projectId);
+            requireProjectFile(projectId, fileId);
+            return f.fileTagService.getTagsByFileId(fileId).stream().map(this::info).toList();
+        }
+    }
+
+    // ------------------------------------------------------------------ Evidence
+
+    private final class EvidenceImpl implements Evidence {
+
+        private List<EvidenceLinkViews.TargetInput> in(List<TargetInput> targets) {
+            if (targets == null) return List.of();
+            return targets.stream().map(t -> new EvidenceLinkViews.TargetInput(
+                    t.fileId(), t.locatorJson(), t.relation(), t.method(), t.confidence(), t.note())).toList();
+        }
+
+        private LinkView out(EvidenceLinkViews.LinkView v) {
+            List<TargetView> ts = v.targets() == null ? List.of() : v.targets().stream().map(t -> new TargetView(
+                    t.id() == null ? 0 : t.id(), t.fileId() == null ? 0 : t.fileId(),
+                    t.file() == null ? null : t.file().name(),
+                    t.locator() == null || t.locator().isNull() ? null : t.locator().toString(),
+                    t.relation(), t.method())).toList();
+            return new LinkView(v.id() == null ? 0 : v.id(), v.linkKey(), v.docFileId() == null ? 0 : v.docFileId(),
+                    v.anchorText(), v.sectionPath(), v.sectionTitle(), v.status(), ts);
+        }
+
+        @Override
+        public LinkView create(long projectId, long docFileId, String linkKey, String anchorText, String sectionPath,
+                               String sectionTitle, List<TargetInput> targets) {
+            ToolCall c = requireWrite(projectId);
+            return out(f.evidenceLinkService.create(c.userId(), projectId, docFileId, linkKey, anchorText,
+                    sectionPath, sectionTitle, com.checkba.model.entity.EvidenceLink.KIND_PLUGIN, in(targets)));
+        }
+
+        @Override
+        public LinkView addTargets(long projectId, String linkKey, List<TargetInput> targets) {
+            ToolCall c = requireWrite(projectId);
+            return out(f.evidenceLinkService.addTargets(c.userId(), projectId, linkKey, in(targets),
+                    com.checkba.model.entity.EvidenceLink.KIND_PLUGIN));
+        }
+
+        @Override
+        public List<LinkView> listByDoc(long projectId, long docFileId) {
+            ToolCall c = requireRead(projectId);
+            return f.evidenceLinkService.listByDoc(c.userId(), projectId, docFileId, null, null)
+                    .stream().map(this::out).toList();
+        }
+
+        @Override
+        public List<LinkView> listByFile(long projectId, long fileId) {
+            ToolCall c = requireRead(projectId);
+            return f.evidenceLinkService.listByFile(c.userId(), projectId, fileId).stream().map(this::out).toList();
+        }
+    }
+
+    // ------------------------------------------------------------------ Jobs
+
+    private final class JobsImpl implements Jobs {
+
+        @Override
+        public JobHandle start(String kind, String title, JobBody body) {
+            ToolCall c = enter();
+            if (c.projectId() != null && !f.projectMemberService.hasWritePermission(c.projectId(), c.userId())) {
+                throw new IllegalArgumentException(LangText.of("无权限修改该项目", "No write access to this project"));
+            }
+            ToolCall snapshot = c;
+            // 任务线程上也要有调用上下文：任务体里的 host.files()/llm() 才能鉴权与计费
+            JobBody wrapped = ctx -> {
+                f.bindCall(snapshot);
+                try {
+                    body.run(ctx);
+                } finally {
+                    f.clear();
+                }
+            };
+            return f.pluginJobService.start(pluginId, kind, title, snapshot, wrapped);
+        }
+
+        @Override
+        public JobStatus status(String jobId) {
+            enter();
+            PluginJob j = f.pluginJobService.get(jobId);
+            if (j == null || !pluginId.equals(j.getPluginId())) return null;
+            return f.pluginJobService.status(jobId);
+        }
+
+        @Override
+        public void cancel(String jobId) {
+            enter();
+            PluginJob j = f.pluginJobService.get(jobId);
+            if (j == null || !pluginId.equals(j.getPluginId())) return;
+            f.pluginJobService.cancel(jobId);
+        }
+    }
+
+    // ------------------------------------------------------------------ Docs
+
+    private final class DocsImpl implements Docs {
+
+        private String conversation() {
+            ToolCall c = enter();
+            if (!StringUtils.hasText(c.conversationId())) {
+                throw new IllegalStateException("no active conversation");
+            }
+            return c.conversationId();
+        }
+
+        /** EditorBridgeService 按自己的 ThreadLocal 找会话；后台任务线程上没有，这里按调用上下文临时绑定。 */
+        private <T> T withConversation(String conversationId, java.util.function.Supplier<T> body) {
+            String previous = f.editorBridgeService.getCurrentConversationId();
+            f.editorBridgeService.setCurrentConversationId(conversationId);
+            try {
+                return body.get();
+            } finally {
+                if (previous == null) f.editorBridgeService.clearCurrentConversationId();
+                else f.editorBridgeService.setCurrentConversationId(previous);
+            }
+        }
+
+        @Override
+        public String exec(String action, Map<String, Object> params) {
+            String conv = conversation();
+            if (action == null || !DOC_ACTIONS.contains(action)) {
+                throw new IllegalArgumentException(LangText.of(
+                        "编辑器原语不在白名单内: ", "Editor action not allowed: ") + action);
+            }
+            return withConversation(conv, () -> f.editorBridgeService.executeEditorCommand(action, params == null ? Map.of() : params));
+        }
+
+        @Override
+        public void refreshFiles() {
+            String conv = conversation();
+            withConversation(conv, () -> {
+                f.editorBridgeService.sendRefreshFilesAction();
+                return null;
+            });
+        }
+
+        @Override
+        public void openFile(long fileId, Map<String, Object> locator) {
+            ToolCall c = enter();
+            if (!StringUtils.hasText(c.conversationId())) throw new IllegalStateException("no active conversation");
+            if (c.projectId() == null) throw new IllegalStateException("no project context");
+            requireRead(c.projectId());
+            ProjectFile p = requireProjectFile(c.projectId(), fileId);
+            withConversation(c.conversationId(), () -> {
+                f.editorBridgeService.sendOpenFileAction(p);
+                if (locator != null && !locator.isEmpty()) {
+                    Map<String, Object> fields = new HashMap<>();
+                    fields.put("fileId", p.getId());
+                    fields.put("locator", locator);
+                    f.editorBridgeService.sendClientAction("plugin_open_locator", c.conversationId(), fields);
+                }
+                return null;
+            });
+        }
+    }
+
+    // ------------------------------------------------------------------ Settings
+
+    private final class SettingsImpl implements Settings {
+
+        private String key(String k) {
+            if (!StringUtils.hasText(k)) throw new IllegalArgumentException("key required");
+            return "plugin." + pluginId + "." + k.trim();
+        }
+
+        @Override
+        public String get(String key) {
+            enter();
+            return f.systemSettingService.get(key(key), null);
+        }
+
+        @Override
+        public void set(String key, String value) {
+            enter();
+            f.systemSettingService.set(key(key), value);
+        }
+
+        /**
+         * 解析顺序（SPEC §3.4，去掉「工具显式传参」那一级）：项目 `_模板/画像.json` >
+         * SystemSetting dd.styleProfile.default > classpath house-default.json > null。
+         * 单元 I 合并后这里改调 StyleProfiles.resolveForProject，顺序不变。
+         */
+        @Override
+        public String projectStyleProfileJson(long projectId) {
+            requireRead(projectId);
+            String fromProject = projectTemplateProfile(projectId);
+            if (StringUtils.hasText(fromProject)) return fromProject;
+            String fromSetting = f.systemSettingService.get(STYLE_PROFILE_SETTING, null);
+            if (StringUtils.hasText(fromSetting)) return fromSetting;
+            try (InputStream in = PluginHostImpl.class.getClassLoader().getResourceAsStream(STYLE_PROFILE_RESOURCE)) {
+                if (in != null) return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                log.debug("house-default style profile unreadable: {}", e.getMessage());
+            }
+            return null;
+        }
+
+        private String projectTemplateProfile(long projectId) {
+            try {
+                Optional<ProjectFile> folder = f.projectFileRepository
+                        .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, null, TEMPLATE_FOLDER);
+                if (folder.isEmpty() || !Boolean.TRUE.equals(folder.get().getIsFolder())) return null;
+                Optional<ProjectFile> file = f.projectFileRepository
+                        .findByProjectIdAndParentIdAndNameAndIsDeletedFalse(projectId, folder.get().getId(), TEMPLATE_PROFILE_FILE);
+                if (file.isEmpty()) return null;
+                String json = new String(readBytes(file.get()), StandardCharsets.UTF_8);
+                JsonNode node = f.objectMapper.readTree(json);
+                return node != null && node.isObject() ? json : null;
+            } catch (Exception e) {
+                log.debug("project template profile unreadable for project {}: {}", projectId, e.getMessage());
+                return null;
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ Llm
+
+    private final class LlmImpl implements Llm {
+
+        @Override
+        public String complete(String systemPrompt, String userPrompt, LlmOptions o) {
+            ToolCall c = enter();
+            if (!StringUtils.hasText(userPrompt)) throw new IllegalArgumentException("userPrompt required");
+            LlmOptions opt = o == null ? LlmOptions.cheap() : o;
+            // 平台通道：modelId 为空走辅助模型（便宜档，与自动打标签同一条）；温度/最大 token 由通道侧模型配置决定
+            String modelId = StringUtils.hasText(opt.modelId()) ? opt.modelId() : f.auxModelResolver.auxModelId();
+            ChatLanguageModel model = StringUtils.hasText(opt.modelId())
+                    ? f.chatModelFactory.getChatModel(opt.modelId()) : f.chatModelFactory.getAuxChatModel();
+            List<ChatMessage> messages = new ArrayList<>();
+            if (StringUtils.hasText(systemPrompt)) messages.add(SystemMessage.from(systemPrompt));
+            messages.add(UserMessage.from(userPrompt));
+            Response<AiMessage> r = PlatformAiUserScope.call(c.userId(), () -> model.generate(messages));
+            try {
+                if (r.tokenUsage() != null) {
+                    f.tokenUsageService.recordUsage(c.projectId(), c.userId(), modelId, r.tokenUsage(), c.conversationId());
+                }
+            } catch (Exception e) {
+                log.warn("plugin {} llm usage record failed: {}", pluginId, e.getMessage());
+            }
+            log.info("plugin {} llm.complete model={} tokens={}", pluginId, modelId, r.tokenUsage());
+            return r.content() == null ? "" : r.content().text();
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostQuota.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostQuota.java
@@ -1,0 +1,47 @@
+package com.checkba.service.plugin;
+
+import com.checkba.plugin.api.HostQuotaException;
+import com.checkba.service.LangText;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 每插件每分钟宿主调用次数上限（滑动窗口）。防 runaway 插件把宿主打满，不是计费单位——
+ * LLM/OCR 的钱按用户 Credits 在平台网关算。
+ */
+public class PluginHostQuota {
+
+    public static final int DEFAULT_LIMIT_PER_MINUTE = 60;
+    private static final long WINDOW_MS = 60_000L;
+
+    private final int limit;
+    private final Map<String, Deque<Long>> windows = new ConcurrentHashMap<>();
+
+    public PluginHostQuota() {
+        this(DEFAULT_LIMIT_PER_MINUTE);
+    }
+
+    public PluginHostQuota(int limit) {
+        this.limit = limit;
+    }
+
+    /** 记一次调用；超限抛 {@link HostQuotaException}（不记入窗口，超限期间重试不会把窗口越推越满）。 */
+    public void acquire(String pluginId) {
+        Deque<Long> q = windows.computeIfAbsent(pluginId, k -> new ArrayDeque<>());
+        long now = System.currentTimeMillis();
+        synchronized (q) {
+            while (!q.isEmpty() && now - q.peekFirst() >= WINDOW_MS) {
+                q.pollFirst();
+            }
+            if (q.size() >= limit) {
+                throw new HostQuotaException(LangText.of(
+                        "插件 " + pluginId + " 宿主调用超过每分钟 " + limit + " 次上限",
+                        "Plugin " + pluginId + " exceeded the host call quota of " + limit + " per minute"));
+            }
+            q.addLast(now);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/plugin/PluginJobService.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginJobService.java
@@ -1,0 +1,334 @@
+package com.checkba.service.plugin;
+
+import com.checkba.model.entity.PluginJob;
+import com.checkba.plugin.api.JobBody;
+import com.checkba.plugin.api.JobContext;
+import com.checkba.plugin.api.JobHandle;
+import com.checkba.plugin.api.JobStatus;
+import com.checkba.plugin.api.ToolCall;
+import com.checkba.repository.PluginJobRepository;
+import com.checkba.service.LangText;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.PlatformAiUserScope;
+import com.checkba.service.evidence.Ulid;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 插件后台任务（插件规范 v2.4 §11 Jobs）。
+ *
+ * <p>每个插件一份 2 线程池（第 3 个任务排队），任务体在 {@link PlatformAiUserScope} 里跑，
+ * 使其中的 LLM/OCR 调用落在发起用户的 Credits 上。进度写库按 {@code progressThrottleMs} 节流，
+ * 内存态（{@link #status}）永远是实时值；终态必落库。有 conversationId 时每次落库同时经
+ * SSE {@code client_action: plugin_job_progress} 推给对话（前端 BackgroundTaskIndicator 消费）。
+ *
+ * <p>宿主重启后库里还停在 queued/running 的任务没有人会再推进，启动时统一标 failed（宿主重启）。
+ */
+@Service
+@Slf4j
+public class PluginJobService {
+
+    public static final String CLIENT_ACTION = "plugin_job_progress";
+    static final int PER_PLUGIN_CONCURRENCY = 2;
+
+    private final PluginJobRepository repo;
+    /** 可为 null（测试直接 new 时）；生产由 Spring 注入。 */
+    private final EditorBridgeService editorBridge;
+    private final long progressThrottleMs;
+
+    private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
+    private final Map<String, JobState> jobs = new ConcurrentHashMap<>();
+
+    @Autowired
+    public PluginJobService(PluginJobRepository repo, EditorBridgeService editorBridge) {
+        this(repo, editorBridge, 500);
+    }
+
+    PluginJobService(PluginJobRepository repo, EditorBridgeService editorBridge, long progressThrottleMs) {
+        this.repo = repo;
+        this.editorBridge = editorBridge;
+        this.progressThrottleMs = progressThrottleMs;
+    }
+
+    /** 一个在本进程生命周期内的任务：实体 + 取消标记 + 提交句柄。 */
+    private static final class JobState {
+        final PluginJob job;
+        final AtomicBoolean cancelled = new AtomicBoolean();
+        final AtomicBoolean finished = new AtomicBoolean();
+        volatile Future<?> future;
+        /** 上一次 progress 落库的时刻（0 = 还没落过，首次 progress 必写）；状态切换的落库不计入节流时钟。 */
+        volatile long lastProgressPersistMs;
+        volatile String resultJson;
+
+        JobState(PluginJob job) { this.job = job; }
+    }
+
+    @PostConstruct
+    void recoverOrphans() {
+        try {
+            List<PluginJob> orphans = repo.findByStatusIn(List.of(PluginJob.STATUS_QUEUED, PluginJob.STATUS_RUNNING));
+            for (PluginJob j : orphans) {
+                j.setStatus(PluginJob.STATUS_FAILED);
+                j.setError(LangText.of("宿主重启，任务中断", "Host restarted; job interrupted"));
+                j.setUpdatedAt(LocalDateTime.now());
+                repo.save(j);
+            }
+            if (!orphans.isEmpty()) {
+                log.warn("PluginJobService: marked {} orphan job(s) as failed after host restart", orphans.size());
+            }
+        } catch (Exception e) {
+            log.warn("PluginJobService: orphan recovery skipped: {}", e.getMessage());
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        for (ExecutorService ex : executors.values()) {
+            ex.shutdownNow();
+        }
+    }
+
+    public JobHandle start(String pluginId, String kind, String title, ToolCall call, JobBody body) {
+        if (pluginId == null || pluginId.isBlank()) throw new IllegalArgumentException("pluginId required");
+        if (kind == null || kind.isBlank()) throw new IllegalArgumentException("kind required");
+        if (body == null) throw new IllegalArgumentException("body required");
+
+        LocalDateTime now = LocalDateTime.now();
+        PluginJob job = new PluginJob();
+        job.setId(Ulid.next());
+        job.setPluginId(pluginId);
+        job.setKind(kind);
+        job.setTitle(title);
+        job.setStatus(PluginJob.STATUS_QUEUED);
+        if (call != null) {
+            job.setProjectId(call.projectId());
+            job.setUserId(call.userId());
+            job.setConversationId(call.conversationId());
+        }
+        job.setCreatedAt(now);
+        job.setUpdatedAt(now);
+        JobState state = new JobState(job);
+        jobs.put(job.getId(), state);
+        persist(state);
+
+        ToolCall snapshot = call != null ? call : new ToolCall(null, null, null, null);
+        state.future = executorFor(pluginId).submit(() -> run(state, snapshot, body));
+        return new JobHandle(job.getId());
+    }
+
+    public JobStatus status(String jobId) {
+        if (jobId == null) return null;
+        JobState s = jobs.get(jobId);
+        if (s != null) return toStatus(s.job);
+        return repo.findById(jobId).map(PluginJobService::toStatus).orElse(null);
+    }
+
+    /** 实体视图（REST 用）：内存优先，其次数据库。 */
+    public PluginJob get(String jobId) {
+        if (jobId == null) return null;
+        JobState s = jobs.get(jobId);
+        if (s != null) return s.job;
+        return repo.findById(jobId).orElse(null);
+    }
+
+    public List<PluginJob> listByProject(Long projectId) {
+        List<PluginJob> fromDb = repo.findByProjectIdOrderByCreatedAtDesc(projectId);
+        // 库里的进度是节流后的旧值，能用内存态的就换成内存态
+        return fromDb.stream().map(j -> {
+            JobState s = jobs.get(j.getId());
+            return s != null ? s.job : j;
+        }).toList();
+    }
+
+    public void cancel(String jobId) {
+        JobState s = jobs.get(jobId);
+        if (s == null) {
+            // 不在本进程内存里：要么已结束，要么是孤儿；孤儿由启动恢复处理，这里不动
+            return;
+        }
+        s.cancelled.set(true);
+        // queued→cancelled 与 run() 里的 queued→running 互斥：不锁的话 run() 刚过守卫、
+        // 这里把它标成 cancelled 并移出内存，run() 接着又把状态写回 running，终态永远落不下来
+        synchronized (s) {
+            if (PluginJob.STATUS_QUEUED.equals(s.job.getStatus())) {
+                if (s.future != null) s.future.cancel(false);
+                finish(s, PluginJob.STATUS_CANCELLED, null);
+                return;
+            }
+        }
+        if (s.future != null) s.future.cancel(true);
+    }
+
+    // ------------------------------------------------------------------ internals
+
+    private ExecutorService executorFor(String pluginId) {
+        return executors.computeIfAbsent(pluginId, id -> {
+            AtomicInteger n = new AtomicInteger();
+            return new ThreadPoolExecutor(PER_PLUGIN_CONCURRENCY, PER_PLUGIN_CONCURRENCY, 0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>(), r -> {
+                Thread t = new Thread(r, "plugin-job-" + id + "-" + n.incrementAndGet());
+                t.setDaemon(true);
+                return t;
+            });
+        });
+    }
+
+    private void run(JobState s, ToolCall call, JobBody body) {
+        synchronized (s) {
+            if (s.finished.get() || s.cancelled.get()) {
+                if (!s.finished.get()) finish(s, PluginJob.STATUS_CANCELLED, null);
+                return;
+            }
+            s.job.setStatus(PluginJob.STATUS_RUNNING);
+            persist(s);
+        }
+        JobContext ctx = new Ctx(s, call);
+        try {
+            Long userId = call.userId();
+            if (userId != null) {
+                PlatformAiUserScope.call(userId, () -> {
+                    try {
+                        body.run(ctx);
+                        return null;
+                    } catch (Exception e) {
+                        throw new BodyException(e);
+                    }
+                });
+            } else {
+                body.run(ctx);
+            }
+            finish(s, s.cancelled.get() ? PluginJob.STATUS_CANCELLED : PluginJob.STATUS_DONE, null);
+        } catch (Throwable t) {
+            Throwable cause = t instanceof BodyException ? t.getCause() : t;
+            if (s.cancelled.get() || cause instanceof InterruptedException) {
+                finish(s, PluginJob.STATUS_CANCELLED, null);
+            } else {
+                log.warn("Plugin job {} ({}/{}) failed", s.job.getId(), s.job.getPluginId(), s.job.getKind(), cause);
+                finish(s, PluginJob.STATUS_FAILED, cause.getClass().getSimpleName() + ": " + cause.getMessage());
+            }
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    /** 把任务体的受检异常穿过 Supplier 边界。 */
+    private static final class BodyException extends RuntimeException {
+        BodyException(Throwable cause) { super(cause); }
+    }
+
+    private void finish(JobState s, String status, String error) {
+        if (!s.finished.compareAndSet(false, true)) return;
+        s.job.setStatus(status);
+        s.job.setError(error);
+        if (PluginJob.STATUS_DONE.equals(status)) {
+            s.job.setResultJson(s.resultJson);
+            if (s.job.getTotal() > 0) s.job.setDone(s.job.getTotal());
+        }
+        persist(s);
+        // 终态留在内存里（status()/get() 不必回库，库里的 save 也可能还没提交），
+        // 只在条目过多时按创建时间淘汰已结束的
+        evictTerminalIfOversized();
+    }
+
+    private static final int MEMORY_CAP = 500;
+
+    private void evictTerminalIfOversized() {
+        if (jobs.size() <= MEMORY_CAP) return;
+        jobs.values().stream()
+                .filter(st -> st.finished.get())
+                .sorted(java.util.Comparator.comparing(st -> st.job.getCreatedAt()))
+                .limit(Math.max(1, jobs.size() - MEMORY_CAP))
+                .forEach(st -> jobs.remove(st.job.getId()));
+    }
+
+    private void persist(JobState s) {
+        s.job.setUpdatedAt(LocalDateTime.now());
+        try {
+            repo.save(s.job);
+        } catch (Exception e) {
+            log.warn("Plugin job {} persist failed: {}", s.job.getId(), e.getMessage());
+        }
+        push(s.job);
+    }
+
+    private void push(PluginJob job) {
+        if (editorBridge == null || job.getConversationId() == null) return;
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("jobId", job.getId());
+        fields.put("pluginId", job.getPluginId());
+        fields.put("kind", job.getKind());
+        fields.put("title", job.getTitle());
+        fields.put("status", job.getStatus());
+        fields.put("done", job.getDone());
+        fields.put("total", job.getTotal());
+        fields.put("message", job.getMessage());
+        fields.put("error", job.getError());
+        fields.put("conversationId", job.getConversationId());
+        try {
+            editorBridge.sendClientAction(CLIENT_ACTION, job.getConversationId(), fields);
+        } catch (Exception e) {
+            log.debug("Plugin job {} SSE push failed: {}", job.getId(), e.getMessage());
+        }
+    }
+
+    private static JobStatus toStatus(PluginJob j) {
+        return new JobStatus(j.getId(), j.getKind(), j.getTitle(), j.getStatus(), j.getDone(), j.getTotal(),
+                j.getMessage(), j.getResultJson(), j.getError());
+    }
+
+    /** 任务体看到的上下文。 */
+    private final class Ctx implements JobContext {
+        private final JobState s;
+        private final ToolCall call;
+
+        Ctx(JobState s, ToolCall call) {
+            this.s = s;
+            this.call = call;
+        }
+
+        @Override
+        public void progress(long done, long total, String message) {
+            s.job.setDone(done);
+            s.job.setTotal(total);
+            s.job.setMessage(message != null && message.length() > 512 ? message.substring(0, 512) : message);
+            long now = System.currentTimeMillis();
+            if (s.lastProgressPersistMs == 0 || now - s.lastProgressPersistMs >= progressThrottleMs) {
+                s.lastProgressPersistMs = now;
+                persist(s);
+            }
+        }
+
+        @Override
+        public void checkCancelled() throws InterruptedException {
+            if (s.cancelled.get() || Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException(LangText.of("任务已取消", "Job cancelled"));
+            }
+        }
+
+        @Override
+        public ToolCall call() {
+            return call;
+        }
+
+        @Override
+        public void result(String resultJson) {
+            s.resultJson = resultJson;
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceEnsureFolderPathTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceEnsureFolderPathTest.java
@@ -1,0 +1,95 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ensureFolderPath（dev-board#109 单元 H3）：逐级复用已有文件夹、缺的补建、
+ * 某段是文件时拒绝、空白段跳过、全空报错。插件宿主 Files.createFolderPath / move_file / 会议录音目录共用。
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectFileServiceEnsureFolderPathTest {
+
+    @Mock
+    private ProjectFileRepository repo;
+    @Mock
+    private com.checkba.service.ai.ProjectRagService projectRagService;
+    @Mock
+    private com.checkba.storage.StorageServiceFactory storageServiceFactory;
+    @Mock
+    private com.checkba.service.telemetry.TelemetryService telemetryService;
+
+    @InjectMocks
+    private ProjectFileService svc;
+
+    private ProjectFile node(long id, Long parentId, String name, boolean folder) {
+        ProjectFile p = new ProjectFile();
+        p.setId(id);
+        p.setProjectId(1L);
+        p.setParentId(parentId);
+        p.setName(name);
+        p.setIsFolder(folder);
+        return p;
+    }
+
+    @Test
+    @DisplayName("已有的段复用、缺的段补建，返回最深一级")
+    void reusesExistingAndCreatesMissing() {
+        ProjectFile a = node(10L, null, "a", true);
+        when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(1L, null, "a")).thenReturn(Optional.of(a));
+        when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(1L, 10L, "b")).thenReturn(Optional.empty());
+        when(repo.maxSortOrder(anyLong(), any())).thenReturn(null);
+        when(repo.save(any(ProjectFile.class))).thenAnswer(inv -> {
+            ProjectFile p = inv.getArgument(0);
+            p.setId(11L);
+            return p;
+        });
+
+        ProjectFile deepest = svc.ensureFolderPath(1L, 9L, Arrays.asList("a", " b "));
+        assertEquals(11L, deepest.getId());
+        assertEquals("b", deepest.getName());
+        assertEquals(10L, deepest.getParentId());
+    }
+
+    @Test
+    @DisplayName("某段已存在但是文件：拒绝，不往下建")
+    void segmentIsFileRejected() {
+        ProjectFile f = node(10L, null, "a", false);
+        when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(1L, null, "a")).thenReturn(Optional.of(f));
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> svc.ensureFolderPath(1L, 9L, List.of("a", "b")));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("a"));
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("空白段跳过；全部为空报错")
+    void blankSegments() {
+        ProjectFile a = node(10L, null, "a", true);
+        when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(1L, null, "a")).thenReturn(Optional.of(a));
+        assertEquals(10L, svc.ensureFolderPath(1L, 9L, Arrays.asList("", "a", "  ")).getId());
+        assertThrows(IllegalArgumentException.class, () -> svc.ensureFolderPath(1L, 9L, List.of("", " ")));
+        assertThrows(IllegalArgumentException.class, () -> svc.ensureFolderPath(1L, 9L, null));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingFolderLanguageTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingFolderLanguageTest.java
@@ -61,8 +61,9 @@ class MeetingFolderLanguageTest {
                 anyLong(), isNull(), anyString())).thenReturn(Optional.empty());
         when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
                 anyLong(), any(), anyString(), anyLong())).thenReturn(false);
-        when(projectFileService.createFolder(anyLong(), isNull(), anyString(), anyLong()))
-                .thenAnswer(inv -> folder(inv.getArgument(2)));
+        // 新建走 ProjectFileService.ensureFolderPath（全仓逐级建文件夹的单一出处，dev-board#109 单元 H3）
+        when(projectFileService.ensureFolderPath(anyLong(), anyLong(), any()))
+                .thenAnswer(inv -> folder(((java.util.List<String>) inv.getArgument(2)).get(0)));
         when(projectFileService.createFile(anyLong(), any(), anyString(), anyString(),
                 anyLong(), any(), any(), anyLong()))
                 .thenAnswer(inv -> file(inv.getArgument(2)));
@@ -130,7 +131,7 @@ class MeetingFolderLanguageTest {
 
         assertEquals(MeetingRecordingService.FOLDER_NAME, res.folderName(),
                 "回给界面的必须是实际目录名，否则「见 X 文件夹」会指错地方");
-        verify(projectFileService, never()).createFolder(anyLong(), isNull(), anyString(), anyLong());
+        verify(projectFileService, never()).ensureFolderPath(anyLong(), anyLong(), any());
     }
 
     @Test
@@ -142,7 +143,7 @@ class MeetingFolderLanguageTest {
         MeetingRecordingService.ExportResult res = service.exportTranscript(9L, 10001L);
 
         assertEquals(MeetingRecordingService.FOLDER_NAME_EN, res.folderName());
-        verify(projectFileService, never()).createFolder(anyLong(), isNull(), anyString(), anyLong());
+        verify(projectFileService, never()).ensureFolderPath(anyLong(), anyLong(), any());
     }
 
     @Test
@@ -154,8 +155,8 @@ class MeetingFolderLanguageTest {
         MeetingRecordingService.ExportResult res = service.exportTranscript(9L, 10001L);
 
         assertEquals(MeetingRecordingService.FOLDER_NAME_EN, res.folderName());
-        verify(projectFileService).createFolder(eq(1L), isNull(),
-                eq(MeetingRecordingService.FOLDER_NAME_EN), eq(10001L));
+        verify(projectFileService).ensureFolderPath(eq(1L), eq(10001L),
+                eq(java.util.List.of(MeetingRecordingService.FOLDER_NAME_EN)));
         assertTrue(res.file().getName().startsWith("Transcript_"),
                 "英文下导出文件名不该是「转写稿_」：" + res.file().getName());
     }

--- a/backend/src/test/java/com/checkba/service/plugin/PluginHostImplTest.java
+++ b/backend/src/test/java/com/checkba/service/plugin/PluginHostImplTest.java
@@ -1,0 +1,381 @@
+package com.checkba.service.plugin;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.model.entity.Tag;
+import com.checkba.plugin.api.ConflictPolicy;
+import com.checkba.plugin.api.HostAware;
+import com.checkba.plugin.api.HostQuotaException;
+import com.checkba.plugin.api.LinkView;
+import com.checkba.plugin.api.PluginHost;
+import com.checkba.plugin.api.TargetInput;
+import com.checkba.plugin.api.ToolCall;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.TagRepository;
+import com.checkba.service.DocumentTextService;
+import com.checkba.service.FileTagService;
+import com.checkba.service.OcrService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.SystemSettingService;
+import com.checkba.service.TagService;
+import com.checkba.service.ai.AuxModelResolver;
+import com.checkba.service.ai.ChatModelFactory;
+import com.checkba.service.ai.EditorBridgeService;
+import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.TokenUsageService;
+import com.checkba.service.ai.tools.ToolContext;
+import com.checkba.service.evidence.EvidenceLinkService;
+import com.checkba.service.evidence.EvidenceLinkViews;
+import com.checkba.storage.StorageService;
+import com.checkba.storage.StorageServiceFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * PluginHostImpl 契约（dev-board#109 单元 H3）：非成员拒绝、配额第 61 次抛、Docs.exec 无会话抛、
+ * Files.write 走 RENAME、Evidence 建链 createdByKind=plugin、Settings 键前缀、HostAware 注入、
+ * 无调用上下文一律拒绝。全部宿主服务 mock。
+ */
+class PluginHostImplTest {
+
+    ProjectFileService projectFileService = mock(ProjectFileService.class);
+    ProjectFileRepository projectFileRepository = mock(ProjectFileRepository.class);
+    StorageServiceFactory storageServiceFactory = mock(StorageServiceFactory.class);
+    StorageService storage = mock(StorageService.class);
+    ProjectMemberService members = mock(ProjectMemberService.class);
+    DocumentTextService documentTextService = mock(DocumentTextService.class);
+    OcrService ocrService = mock(OcrService.class);
+    TagService tagService = mock(TagService.class);
+    TagRepository tagRepository = mock(TagRepository.class);
+    FileTagService fileTagService = mock(FileTagService.class);
+    EvidenceLinkService evidenceLinkService = mock(EvidenceLinkService.class);
+    PluginJobService pluginJobService = mock(PluginJobService.class);
+    EditorBridgeService editorBridge = mock(EditorBridgeService.class);
+    SystemSettingService settings = mock(SystemSettingService.class);
+    ChatModelFactory chatModelFactory = mock(ChatModelFactory.class);
+    AuxModelResolver auxModelResolver = mock(AuxModelResolver.class);
+    TokenUsageService tokenUsageService = mock(TokenUsageService.class);
+
+    PluginHostFactory factory;
+    PluginHost host;
+
+    static final long PROJECT = 1L;
+    static final long USER = 9L;
+
+    @BeforeEach
+    void setUp() {
+        when(storageServiceFactory.getStorageService()).thenReturn(storage);
+        when(members.hasReadPermission(PROJECT, USER)).thenReturn(true);
+        when(members.hasWritePermission(PROJECT, USER)).thenReturn(true);
+        factory = new PluginHostFactory(projectFileService, projectFileRepository, storageServiceFactory, members,
+                documentTextService, ocrService, tagService, tagRepository, fileTagService, evidenceLinkService,
+                pluginJobService, editorBridge, settings, chatModelFactory, auxModelResolver, tokenUsageService,
+                new ObjectMapper(), new PluginHostQuota());
+        host = factory.forPlugin("dd");
+        factory.bindCall(new ToolContext(PROJECT, "conv-1", USER, null));
+    }
+
+    @AfterEach
+    void tearDown() {
+        factory.clear();
+    }
+
+    private ProjectFile file(long id, String name, boolean folder) {
+        ProjectFile p = new ProjectFile();
+        p.setId(id);
+        p.setProjectId(PROJECT);
+        p.setName(name);
+        p.setIsFolder(folder);
+        p.setFileType(folder ? null : "txt");
+        p.setFilePath("projects/1/" + name);
+        p.setFileSize(3L);
+        p.setIsDeleted(false);
+        when(projectFileRepository.findById(id)).thenReturn(Optional.of(p));
+        return p;
+    }
+
+    @Test
+    @DisplayName("forPlugin 按 id 缓存同一实例；call() 透传 ToolRegistry 绑定的上下文")
+    void factoryCachesAndExposesCall() {
+        assertSame(host, factory.forPlugin("dd"));
+        assertEquals("dd", host.pluginId());
+        ToolCall c = host.call();
+        assertEquals(PROJECT, c.projectId());
+        assertEquals(USER, c.userId());
+        assertEquals("conv-1", c.conversationId());
+        factory.clear();
+        assertNull(host.call());
+    }
+
+    @Test
+    @DisplayName("非项目成员：读写都拒绝（IllegalArgumentException），不碰仓库")
+    void nonMemberRejected() {
+        factory.bindCall(new ToolContext(PROJECT, null, 77L, null));
+        assertThrows(IllegalArgumentException.class, () -> host.files().list(PROJECT, null, false));
+        assertThrows(IllegalArgumentException.class, () -> host.files().createFolderPath(PROJECT, List.of("a")));
+        assertThrows(IllegalArgumentException.class, () -> host.tags().getOrCreate(PROJECT, "x", "PARTY"));
+        verify(projectFileRepository, never()).findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(anyLong());
+        verify(projectFileService, never()).ensureFolderPath(anyLong(), anyLong(), anyList());
+    }
+
+    @Test
+    @DisplayName("没有调用上下文的线程（既非工具分发也非任务体）一律拒绝")
+    void noCallContextRejected() {
+        factory.clear();
+        assertThrows(IllegalStateException.class, () -> host.files().list(PROJECT, null, false));
+        assertThrows(IllegalStateException.class, () -> host.settings().get("k"));
+    }
+
+    @Test
+    @DisplayName("配额：每插件每分钟 60 次，第 61 次抛 HostQuotaException；别的插件不受影响")
+    void quota61stCallThrows() {
+        for (int i = 0; i < 60; i++) {
+            host.settings().get("k");
+        }
+        assertThrows(HostQuotaException.class, () -> host.settings().get("k"));
+        PluginHost other = factory.forPlugin("other");
+        other.settings().get("k");
+    }
+
+    @Test
+    @DisplayName("Docs.exec：无 conversationId 抛 IllegalStateException(no active conversation)；非白名单 action 拒绝")
+    void docsExecRequiresConversationAndWhitelist() {
+        factory.bindCall(new ToolContext(PROJECT, null, USER, null));
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> host.docs().exec("find_replace", Map.of()));
+        assertEquals("no active conversation", ex.getMessage());
+
+        factory.bindCall(new ToolContext(PROJECT, "conv-1", USER, null));
+        assertThrows(IllegalArgumentException.class, () -> host.docs().exec("load_document", Map.of()));
+        assertThrows(IllegalArgumentException.class, () -> host.docs().exec("export_document", Map.of()));
+
+        when(editorBridge.executeEditorCommand(eq("find_replace"), any())).thenReturn("{\"ok\":1}");
+        assertEquals("{\"ok\":1}", host.docs().exec("find_replace", Map.of("find", "a")));
+        // 按调用上下文临时绑定会话再还原（后台任务线程上 bridge 自己的 ThreadLocal 是空的）
+        verify(editorBridge).setCurrentConversationId("conv-1");
+        verify(editorBridge).clearCurrentConversationId();
+    }
+
+    @Test
+    @DisplayName("Files.write 走 ProjectFileService.createFile 的 RENAME 策略并把字节写进存储")
+    void filesWriteUsesRenamePolicy() throws Exception {
+        ProjectFile created = file(50L, "r.txt", false);
+        when(projectFileService.createFile(eq(PROJECT), isNull(), eq("r.txt"), eq("txt"), eq(3L), isNull(), isNull(),
+                eq(USER), eq(ProjectFileService.ConflictPolicy.RENAME))).thenReturn(created);
+        when(projectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(PROJECT)).thenReturn(List.of(created));
+
+        var info = host.files().write(PROJECT, null, "r.txt",
+                new ByteArrayInputStream("abc".getBytes(StandardCharsets.UTF_8)), ConflictPolicy.RENAME);
+        assertEquals(50L, info.id());
+        assertEquals("r.txt", info.path());
+        ArgumentCaptor<java.io.InputStream> bytes = ArgumentCaptor.forClass(java.io.InputStream.class);
+        verify(storage).save(eq("projects/1/r.txt"), bytes.capture());
+        assertEquals("abc", new String(bytes.getValue().readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("Files.write FAIL 策略原样透传；createFolderPath 经 ensureFolderPath")
+    void filesFailPolicyAndFolderPath() {
+        ProjectFile created = file(51L, "f.txt", false);
+        when(projectFileService.createFile(anyLong(), any(), anyString(), anyString(), anyLong(), any(), any(), anyLong(),
+                eq(ProjectFileService.ConflictPolicy.FAIL))).thenReturn(created);
+        when(projectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(PROJECT)).thenReturn(List.of(created));
+        host.files().write(PROJECT, null, "f.txt", new ByteArrayInputStream(new byte[0]), ConflictPolicy.FAIL);
+        verify(projectFileService).createFile(anyLong(), any(), anyString(), anyString(), anyLong(), any(), any(), anyLong(),
+                eq(ProjectFileService.ConflictPolicy.FAIL));
+
+        ProjectFile folder = file(60L, "b", true);
+        when(projectFileService.ensureFolderPath(PROJECT, USER, List.of("a", "b"))).thenReturn(folder);
+        when(projectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(PROJECT)).thenReturn(List.of(folder));
+        assertEquals(60L, host.files().createFolderPath(PROJECT, List.of("a", "b")).id());
+    }
+
+    @Test
+    @DisplayName("Files.list 递归带路径；get 拒绝别的项目的文件（IDOR）")
+    void filesListPathsAndIdor() {
+        ProjectFile root = file(1L, "卷宗", true);
+        ProjectFile sub = file(2L, "合同", true);
+        sub.setParentId(1L);
+        ProjectFile doc = file(3L, "a.docx", false);
+        doc.setParentId(2L);
+        when(projectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(PROJECT)).thenReturn(List.of(root, sub, doc));
+
+        var all = host.files().list(PROJECT, null, true);
+        assertEquals(3, all.size());
+        assertTrue(all.stream().anyMatch(f -> f.path().equals("卷宗/合同/a.docx") && !f.folder()));
+        var underRoot = host.files().list(PROJECT, 1L, false);
+        assertEquals(1, underRoot.size());
+        assertEquals("卷宗/合同", underRoot.get(0).path());
+
+        ProjectFile foreign = file(99L, "x.txt", false);
+        foreign.setProjectId(2L);
+        assertThrows(IllegalArgumentException.class, () -> host.files().get(PROJECT, 99L));
+    }
+
+    @Test
+    @DisplayName("Files.sha256 算一次后缓存到 metaJson（sha256 + sha256At），同一 updatedAt 不再读存储")
+    void sha256CachedInMeta() throws Exception {
+        ProjectFile p = file(7L, "h.txt", false);
+        p.setUpdatedAt(java.time.LocalDateTime.of(2026, 8, 22, 1, 0));
+        when(storage.load("projects/1/h.txt")).thenReturn(new ByteArrayResource("abc".getBytes(StandardCharsets.UTF_8)));
+        when(projectFileRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        String h1 = host.files().sha256(PROJECT, 7L);
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", h1);
+        assertTrue(p.getMetaJson().contains("\"sha256\""));
+        assertTrue(p.getMetaJson().contains("sha256At"));
+
+        String h2 = host.files().sha256(PROJECT, 7L);
+        assertEquals(h1, h2);
+        verify(storage, org.mockito.Mockito.times(1)).load("projects/1/h.txt");
+    }
+
+    @Test
+    @DisplayName("Evidence.create 映射到 EvidenceLinkService.create(createdByKind=plugin)")
+    void evidenceCreatePassesPluginKind() {
+        EvidenceLinkViews.LinkView view = new EvidenceLinkViews.LinkView(5L, "EVID_X", 3L, "anchor", "hash", "1.2", "title",
+                "active", "plugin", null, null, List.of(
+                new EvidenceLinkViews.TargetView(8L, 4L, new EvidenceLinkViews.FileBrief(4L, "b.pdf", "pdf", null, false),
+                        null, "supports", "plugin", null, null)));
+        when(evidenceLinkService.create(eq(USER), eq(PROJECT), eq(3L), eq("EVID_X"), eq("anchor"), eq("1.2"), eq("title"),
+                eq("plugin"), anyList())).thenReturn(view);
+
+        LinkView out = host.evidence().create(PROJECT, 3L, "EVID_X", "anchor", "1.2", "title",
+                List.of(new TargetInput(4L, null, "supports", "plugin", null, null)));
+        assertEquals("EVID_X", out.linkKey());
+        assertEquals(1, out.targets().size());
+        assertEquals("b.pdf", out.targets().get(0).fileName());
+        assertEquals(8L, out.targets().get(0).id());
+    }
+
+    @Test
+    @DisplayName("Tags：getOrCreate 透传 type，tagFile 拒绝别的项目的标签")
+    void tags() {
+        Tag t = new Tag();
+        t.setId(11L);
+        t.setProjectId(PROJECT);
+        t.setName("甲方");
+        t.setType("PARTY");
+        t.setColor("#fff");
+        when(tagService.getOrCreateTag(PROJECT, "甲方", "PARTY", null)).thenReturn(t);
+        assertEquals("PARTY", host.tags().getOrCreate(PROJECT, "甲方", "PARTY").type());
+
+        file(3L, "a.docx", false);
+        when(tagRepository.findById(11L)).thenReturn(Optional.of(t));
+        host.tags().tagFile(PROJECT, 3L, 11L);
+        verify(fileTagService).addTagToFile(3L, 11L, USER);
+
+        Tag foreign = new Tag();
+        foreign.setId(12L);
+        foreign.setProjectId(2L);
+        when(tagRepository.findById(12L)).thenReturn(Optional.of(foreign));
+        assertThrows(IllegalArgumentException.class, () -> host.tags().tagFile(PROJECT, 3L, 12L));
+    }
+
+    @Test
+    @DisplayName("Settings：键自动加前缀 plugin.<id>.；styleProfile 先 SystemSetting 再 classpath 兜底")
+    void settingsPrefixAndStyleProfile() {
+        host.settings().set("k", "v");
+        verify(settings).set("plugin.dd.k", "v");
+        when(settings.get("plugin.dd.k", null)).thenReturn("v");
+        assertEquals("v", host.settings().get("k"));
+
+        when(settings.get(PluginHostImpl.STYLE_PROFILE_SETTING, null)).thenReturn("{\"schemaVersion\":1}");
+        assertEquals("{\"schemaVersion\":1}", host.settings().projectStyleProfileJson(PROJECT));
+
+        when(settings.get(PluginHostImpl.STYLE_PROFILE_SETTING, null)).thenReturn(null);
+        String fallback = host.settings().projectStyleProfileJson(PROJECT);
+        boolean resourcePresent = PluginHostImpl.class.getClassLoader().getResource(PluginHostImpl.STYLE_PROFILE_RESOURCE) != null;
+        if (resourcePresent) assertNotNull(fallback); else assertNull(fallback);
+    }
+
+    @Test
+    @DisplayName("Jobs.start 把调用快照交给 PluginJobService，并在任务体内重新绑定上下文")
+    void jobsStartBindsSnapshotInsideBody() throws Exception {
+        ArgumentCaptor<com.checkba.plugin.api.JobBody> body = ArgumentCaptor.forClass(com.checkba.plugin.api.JobBody.class);
+        when(pluginJobService.start(eq("dd"), eq("ingest"), eq("t"), any(), body.capture()))
+                .thenReturn(new com.checkba.plugin.api.JobHandle("J1"));
+        final ToolCall[] seen = new ToolCall[1];
+        assertEquals("J1", host.jobs().start("ingest", "t", ctx -> seen[0] = host.call()).jobId());
+
+        // 模拟任务线程：没有上下文，任务体包装会自己绑快照、结束后清掉
+        Thread th = new Thread(() -> {
+            try {
+                body.getValue().run(null);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        th.start();
+        th.join(5000);
+        assertNotNull(seen[0]);
+        assertEquals(USER, seen[0].userId());
+        assertEquals(PROJECT, seen[0].projectId());
+    }
+
+    @Test
+    @DisplayName("PluginService.injectHostIfAware：HostAware 工具拿到绑定本插件 id 的 host，普通工具不受影响")
+    void pluginServiceInjectsHost() {
+        PluginService ps = new PluginService();
+        final PluginHost[] got = new PluginHost[1];
+        HostAware tool = h -> got[0] = h;
+        // 没有工厂：只记 WARN，不注入
+        invokeInject(ps, tool, "dd");
+        assertNull(got[0]);
+        // 有工厂：注入绑定同 id 的实例
+        invokeInjectWithFactory(ps, tool, "dd");
+        assertNotNull(got[0]);
+        assertEquals("dd", got[0].pluginId());
+        assertSame(host, got[0]);
+        invokeInjectWithFactory(ps, new Object(), "dd");
+    }
+
+    private void invokeInject(PluginService ps, Object tool, String pluginId) {
+        try {
+            var m = PluginService.class.getDeclaredMethod("injectHostIfAware", Object.class, String.class);
+            m.setAccessible(true);
+            m.invoke(ps, tool, pluginId);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void invokeInjectWithFactory(PluginService ps, Object tool, String pluginId) {
+        try {
+            var set = PluginService.class.getDeclaredMethod("setPluginHostFactory", PluginHostFactory.class);
+            set.setAccessible(true);
+            set.invoke(ps, factory);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        invokeInject(ps, tool, pluginId);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/plugin/PluginJobServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/plugin/PluginJobServiceTest.java
@@ -1,0 +1,236 @@
+package com.checkba.service.plugin;
+
+import com.checkba.model.entity.PluginJob;
+import com.checkba.plugin.api.JobHandle;
+import com.checkba.plugin.api.JobStatus;
+import com.checkba.plugin.api.ToolCall;
+import com.checkba.repository.PluginJobRepository;
+import com.checkba.service.ai.EditorBridgeService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * PluginJobService 契约（dev-board#109 单元 H2）：
+ * 生命周期 queued→running→done、进度节流写库、取消经 checkCancelled 抛 InterruptedException、
+ * 每插件并发 2、宿主重启把库里 running 的标 failed。Repository 与 EditorBridgeService 全 mock。
+ */
+class PluginJobServiceTest {
+
+    PluginJobRepository repo = mock(PluginJobRepository.class);
+    EditorBridgeService bridge = mock(EditorBridgeService.class);
+    PluginJobService svc;
+
+    /** 每次 save 的快照（status/done/error），因为 save 传入的是同一个可变实例，直接留引用看不到历史。 */
+    final List<String[]> saved = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        when(repo.save(any())).thenAnswer(inv -> {
+            PluginJob j = inv.getArgument(0);
+            synchronized (saved) {
+                saved.add(new String[]{j.getStatus(), String.valueOf(j.getDone()), j.getError(), j.getResultJson()});
+            }
+            return j;
+        });
+        when(repo.findByStatusIn(anyList())).thenReturn(List.of());
+        svc = new PluginJobService(repo, bridge, 500);
+    }
+
+    @AfterEach
+    void tearDown() {
+        svc.shutdown();
+    }
+
+    private static ToolCall call(String conversationId) {
+        return new ToolCall(1L, conversationId, 9L, null);
+    }
+
+    private static JobStatus await(PluginJobService svc, String jobId, String status) throws Exception {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            JobStatus s = svc.status(jobId);
+            if (s != null && status.equals(s.status())) return s;
+            Thread.sleep(10);
+        }
+        throw new AssertionError("job " + jobId + " never reached " + status + ", last=" + svc.status(jobId));
+    }
+
+    @Test
+    @DisplayName("start → running → done，resultJson 落库，进度节流：500ms 内第二次 progress 不写库")
+    void lifecycleAndThrottle() throws Exception {
+        CountDownLatch inBody = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        JobHandle h = svc.start("p1", "ingest", "入库", call(null), ctx -> {
+            ctx.progress(1, 3, "第一步");
+            ctx.progress(2, 3, "第二步");
+            inBody.countDown();
+            release.await(5, TimeUnit.SECONDS);
+            ctx.result("{\"ok\":true}");
+        });
+        assertNotNull(h.jobId());
+        assertTrue(inBody.await(5, TimeUnit.SECONDS));
+
+        // 内存态永远是最新的
+        JobStatus mid = svc.status(h.jobId());
+        assertEquals("running", mid.status());
+        assertEquals(2, mid.done());
+        assertEquals("第二步", mid.message());
+        // 库里只有第一次 progress（done=1），第二次在 500ms 节流窗口内没写
+        synchronized (saved) {
+            assertTrue(saved.stream().anyMatch(s -> "running".equals(s[0]) && "1".equals(s[1])), saved.toString());
+            assertFalse(saved.stream().anyMatch(s -> "running".equals(s[0]) && "2".equals(s[1])), saved.toString());
+        }
+
+        release.countDown();
+        JobStatus done = await(svc, h.jobId(), "done");
+        assertEquals("{\"ok\":true}", done.resultJson());
+        assertEquals(3, done.total());
+        synchronized (saved) {
+            assertTrue(saved.stream().anyMatch(s -> "done".equals(s[0]) && "{\"ok\":true}".equals(s[3])), saved.toString());
+        }
+    }
+
+    @Test
+    @DisplayName("有 conversationId 时每次落库同时经 SSE client_action plugin_job_progress 推给对话")
+    void pushesSseWhenConversationPresent() throws Exception {
+        JobHandle h = svc.start("p1", "ingest", "入库", call("conv-1"), ctx -> ctx.progress(1, 1, "完成"));
+        await(svc, h.jobId(), "done");
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> fields = ArgumentCaptor.forClass(Map.class);
+        verify(bridge, org.mockito.Mockito.atLeast(2))
+                .sendClientAction(eq("plugin_job_progress"), eq("conv-1"), fields.capture());
+        Map<String, Object> last = fields.getValue();
+        assertEquals(h.jobId(), last.get("jobId"));
+        assertEquals("done", last.get("status"));
+        assertEquals("p1", last.get("pluginId"));
+    }
+
+    @Test
+    @DisplayName("cancel：任务体的 checkCancelled 抛 InterruptedException，状态 cancelled")
+    void cancelRunning() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        AtomicBoolean sawInterrupt = new AtomicBoolean();
+        JobHandle h = svc.start("p1", "ingest", "入库", call(null), ctx -> {
+            started.countDown();
+            try {
+                for (int i = 0; i < 1000; i++) {
+                    ctx.checkCancelled();
+                    Thread.sleep(5);
+                }
+            } catch (InterruptedException e) {
+                sawInterrupt.set(true);
+                throw e;
+            }
+        });
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+        svc.cancel(h.jobId());
+        JobStatus s = await(svc, h.jobId(), "cancelled");
+        assertEquals("cancelled", s.status());
+        assertTrue(sawInterrupt.get(), "body must observe cancellation via checkCancelled");
+    }
+
+    @Test
+    @DisplayName("任务体抛异常 → failed 并带 error")
+    void failure() throws Exception {
+        JobHandle h = svc.start("p1", "ingest", "入库", call(null), ctx -> {
+            throw new IllegalStateException("boom");
+        });
+        JobStatus s = await(svc, h.jobId(), "failed");
+        assertTrue(s.error().contains("boom"), s.error());
+    }
+
+    @Test
+    @DisplayName("每插件并发 2：第 3 个排队 queued，前面放行后才跑；另一个插件不受影响")
+    void perPluginConcurrency() throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch twoRunning = new CountDownLatch(2);
+        JobHandle a = svc.start("p1", "k", "a", call(null), ctx -> { twoRunning.countDown(); release.await(5, TimeUnit.SECONDS); });
+        JobHandle b = svc.start("p1", "k", "b", call(null), ctx -> { twoRunning.countDown(); release.await(5, TimeUnit.SECONDS); });
+        assertTrue(twoRunning.await(5, TimeUnit.SECONDS));
+        JobHandle c = svc.start("p1", "k", "c", call(null), ctx -> { });
+        Thread.sleep(150);
+        assertEquals("queued", svc.status(c.jobId()).status());
+        // 其他插件有自己的池
+        JobHandle other = svc.start("p2", "k", "o", call(null), ctx -> { });
+        await(svc, other.jobId(), "done");
+        assertEquals("queued", svc.status(c.jobId()).status());
+
+        release.countDown();
+        await(svc, a.jobId(), "done");
+        await(svc, b.jobId(), "done");
+        await(svc, c.jobId(), "done");
+    }
+
+    @Test
+    @DisplayName("取消排队中的任务：立即 cancelled，任务体不执行")
+    void cancelQueued() throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch twoRunning = new CountDownLatch(2);
+        svc.start("p1", "k", "a", call(null), ctx -> { twoRunning.countDown(); release.await(5, TimeUnit.SECONDS); });
+        svc.start("p1", "k", "b", call(null), ctx -> { twoRunning.countDown(); release.await(5, TimeUnit.SECONDS); });
+        assertTrue(twoRunning.await(5, TimeUnit.SECONDS));
+        AtomicBoolean ran = new AtomicBoolean();
+        JobHandle c = svc.start("p1", "k", "c", call(null), ctx -> ran.set(true));
+        svc.cancel(c.jobId());
+        assertEquals("cancelled", svc.status(c.jobId()).status());
+        release.countDown();
+        Thread.sleep(100);
+        assertFalse(ran.get());
+    }
+
+    @Test
+    @DisplayName("启动时把库里 queued/running 的孤儿标 failed（宿主重启）")
+    void recoverOrphansOnStartup() {
+        PluginJob orphan = new PluginJob();
+        orphan.setId("01ORPHAN");
+        orphan.setPluginId("p1");
+        orphan.setStatus("running");
+        when(repo.findByStatusIn(anyList())).thenReturn(List.of(orphan));
+        svc.recoverOrphans();
+        assertEquals("failed", orphan.getStatus());
+        assertNotNull(orphan.getError());
+        assertTrue(orphan.getError().contains("宿主重启") || orphan.getError().toLowerCase().contains("restart"), orphan.getError());
+        verify(repo).save(orphan);
+    }
+
+    @Test
+    @DisplayName("status 对不在内存里的任务回读数据库；未知 id 返回 null")
+    void statusFallsBackToDb() {
+        PluginJob j = new PluginJob();
+        j.setId("01DB");
+        j.setPluginId("p1");
+        j.setKind("k");
+        j.setTitle("t");
+        j.setStatus("done");
+        j.setDone(3);
+        j.setTotal(3);
+        when(repo.findById("01DB")).thenReturn(Optional.of(j));
+        when(repo.findById("nope")).thenReturn(Optional.empty());
+        JobStatus s = svc.status("01DB");
+        assertEquals("done", s.status());
+        assertEquals(3, s.done());
+        assertEquals(null, svc.status("nope"));
+    }
+}

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -1,7 +1,7 @@
-# 插件规范 v2.3（Plugin Spec v2.3）
+# 插件规范 v2.4（Plugin Spec v2.4）
 
 > 适用版本：v1 自 0.4.x；v2（权限执行 + 启停过滤）自 Phase 3A；v2.1（插件携带 Skill）自 Phase 3B；
-> v2.3（Web 插件 + `packs` 依赖）自 native pack Phase B。
+> v2.3（Web 插件 + `packs` 依赖）自 native pack Phase B；v2.4（宿主 SPI `plugin-api` + 后台任务）自尽调 P1。
 > 示例插件：[examples/hello-plugin/](../examples/hello-plugin/)（JAR 工具）、
 > [examples/hello-web-plugin/](../examples/hello-web-plugin/)（纯前端）。
 > 后端实现：`PluginService`（扫描/解析/启停）、`PluginController`（HTTP API）、
@@ -135,6 +135,12 @@ Java 侧没有进程内沙箱可用（`SecurityManager` 已于 JEP 411 废弃、
   不是隔离：插件能看见宿主的全部类（Spring、项目自己的 `com.checkba.*` service/repository）。
   依赖冲突自行规避；无法解析的类会被跳过。
 - `backendJars` 的路径必须落在插件目录内（含子目录），`../` 逃逸会被拒绝并记 ERROR。
+- **`HostAware`（v2.4）**：工具类若实现 `com.checkba.plugin.api.HostAware`，宿主在无参构造实例化后
+  立即调用 `setHost(PluginHost)`，注入按插件 id 绑定的宿主门面（项目文件 / 文本抽取与 OCR / 标签 /
+  证据链接 / 后台任务 / 编辑器桥 / 设置 / LLM）。不实现则与旧规范完全一致。方法表见 §11。
+  插件代码**只许**引用 `com.checkba.plugin.api.*`：SPI 之外的宿主内部类（`com.checkba.service.*` 等）
+  虽然在同一 JVM 里看得见，但不是契约，随时会改；插件仓应有一条「源码不含 `import com.checkba.service`」
+  的静态测试（ArchUnit 风格反射断言）。
 
 ## 5. 启用 / 禁用
 
@@ -355,9 +361,84 @@ opaque origin 使然，不能靠 `event.origin` 判断。
 - **v2.2**：加载期收口——禁用即不加载 JAR（§5）、`backendJars` 路径逃逸校验（§4）；
   在线分发落地：平台 Ed25519 签名 + 人工审核 + 客户端验签 + 远程封禁，见
   [docs/PLUGIN_DISTRIBUTION.md](PLUGIN_DISTRIBUTION.md)。
-- **v2.3（当前）**：`frontendEntry` 从「预留」激活为 Web 插件形态（§8）——`web/` 静态服务、
+- **v2.3**：`frontendEntry` 从「预留」激活为 Web 插件形态（§8）——`web/` 静态服务、
   sandbox iframe、postMessage 桥、CSP；**permissions 在 Web 插件上第一次成为真实的执行边界**。
   manifest 新增 `packs` 字段（§9）。
+- **v2.4（当前）**：JAR 插件的宿主 SPI——独立 Maven 工件 `com.checkba:plugin-api:1.0.0`
+  （`backend/plugin-api/`，纯接口、无第三方依赖、版本独立于桌面端、只加不破），`HostAware` 注入（§4），
+  `PluginHost` 八个子接口（§11），后台任务 `plugin_job` 表 + `/api/plugin-jobs` + SSE
+  `client_action: plugin_job_progress`，每插件每分钟 60 次宿主调用配额。manifest 无新增字段。
 - 规划中：进程外插件形态（MCP server）为不需要独立 UI 的插件提供真正的隔离边界。
   **进程内沙箱不在规划中**——Java 侧无此能力（§3），不要再把它列为待办；
   Web 插件那条路已经用「不同源 + 桥」拿到了同等效果，代价是能力必须逐个显式开放。
+
+## 11. 宿主 SPI（`plugin-api`，v2.4）
+
+工件 `com.checkba:plugin-api:1.0.0`（源码 `backend/plugin-api/`，Java 21，无第三方依赖）。
+不在远端仓库：本地 `mvn -q -f backend/plugin-api/pom.xml install` 后，插件以 `provided` 依赖它
+（示例 `examples/hello-plugin/pom.xml`）。**只加不破**：已发布的方法签名与 record 字段不改不删，
+新增能力走新方法 / 新 record 字段追加。
+
+### 11.1 注入与调用上下文
+
+```java
+public interface HostAware { void setHost(PluginHost host); }
+public interface PluginHost {
+    String pluginId(); ToolCall call();
+    Files files(); Text text(); Tags tags(); Evidence evidence();
+    Jobs jobs(); Docs docs(); Settings settings(); Llm llm();
+}
+public record ToolCall(Long projectId, String conversationId, Long userId, String modelId) {}
+```
+
+- `call()` 是**服务端**的调用上下文（ThreadLocal）：工具分发期由 `ToolRegistry` 在分发插件工具前绑定、
+  分发后清除；后台任务体内由宿主按 `Jobs.start` 时的快照重新绑定。模型传进工具参数里的 projectId /
+  userId 一律不可信，以 `call()` 为准。
+- 两种线程之外（插件自己起的线程、静态初始化）调用宿主 → `IllegalStateException`。
+- **鉴权**：每个方法先校 `call().userId()` 对 projectId 的读/写权限（项目成员表），非成员抛
+  `IllegalArgumentException`；fileId 必须属于该 projectId（IDOR 防护）。
+- **配额**：每插件每分钟 60 次宿主调用（滑动窗口），超限抛 `HostQuotaException`。这是防 runaway，
+  不是计费——`Llm` / `Text.ocr` 的钱按**用户 Credits** 在平台网关算，插件不自带 key。
+
+### 11.2 方法表
+
+| 子接口 | 方法 | 权限 | 宿主落点 / 备注 |
+|---|---|---|---|
+| `Files` | `list(projectId, parentId, recursive)` | 读 | 返回 `FileInfo{id,name,parentId,folder,fileType,size,path,sha256?,metaJson}`，`path` 从项目根起 |
+| | `get(projectId, fileId)` / `open(projectId, fileId)` | 读 | `open` 返回整份字节的 InputStream |
+| | `createFolderPath(projectId, segments)` | 写 | `ProjectFileService.ensureFolderPath`，逐级确保；某段是文件则抛 |
+| | `write(projectId, parentId, name, bytes, ConflictPolicy)` | 写 | `RENAME` 同名自动 " (n)"，`FAIL` 同名抛；fileType 取扩展名 |
+| | `move` / `rename` | 写 | 与前端文件树右键同一条服务路径（同名校验/环检测/物理搬迁都继承） |
+| | `setMeta(projectId, fileId, patch)` | 写 | 浅合并进 `ProjectFile.metaJson`，值为 null 的键删除 |
+| | `sha256(projectId, fileId)` | 读 | 算一次缓存到 `metaJson.sha256` + `sha256At`（= updatedAt），同版本不再读存储 |
+| `Text` | `extract(projectId, fileId, maxChars)` | 读 | `DocumentTextService`（Tika / PDFBox） |
+| | `ocr(projectId, fileId, OcrOptions)` | 读 | 图片直接、PDF 逐页渲染（150 dpi，上限 50 页）后走 `OcrService`（平台网关，扣 Credits）；`blocks=true` 时块粒度到页（网关不回坐标） |
+| | `pdfPageTexts(projectId, fileId, from, to)` | 读 | PDFBox 分页文本，页码从 1 起闭区间，`to<=0` = 到末页 |
+| `Tags` | `getOrCreate(projectId, name, type)` | 写 | `TagService.getOrCreateTag`：同名不同型复用不改型；type 空 = NORMAL |
+| | `tagFile` / `tagsOf` | 写 / 读 | 标签必须属于同一项目 |
+| `Evidence` | `create(...)` / `addTargets(...)` | 写 | `EvidenceLinkService`，`createdByKind=plugin`（状态 active） |
+| | `listByDoc` / `listByFile` | 读 | 精简 `LinkView{id,linkKey,docFileId,anchorText,sectionPath,sectionTitle,status,targets[]}` |
+| `Jobs` | `start(kind, title, JobBody)` | 写（有 projectId 时） | 每插件 2 并发、多余排队；任务体在发起用户的计费作用域里跑；`JobContext.progress/checkCancelled/call/result` |
+| | `status(jobId)` / `cancel(jobId)` | - | 只认本插件的任务；取消 = 标记 + 中断线程，任务体要在 `checkCancelled` 处配合 |
+| `Docs` | `exec(action, params)` | 会话 | `EditorBridgeService.executeEditorCommand`；action 必须在宿主白名单（AI 管线在用的 writer / `sheet_*` / `slide_*` 下发名），无 conversationId 抛 `IllegalStateException("no active conversation")` |
+| | `refreshFiles()` / `openFile(fileId, locator)` | 会话 | 刷新文件树 / 打开文件（locator 非空时追发 `client_action: plugin_open_locator`） |
+| `Settings` | `get(key)` / `set(key, value)` | - | `system_setting`，键自动加前缀 `plugin.<id>.` |
+| | `projectStyleProfileJson(projectId)` | 读 | 项目 `_模板/画像.json` > `dd.styleProfile.default` > classpath `style-profiles/house-default.json` > null |
+| `Llm` | `complete(system, user, LlmOptions)` | - | 平台通道；`modelId` 空 = 辅助模型（便宜档，与自动打标签同一条）；token 记账带 pluginId 日志 |
+
+### 11.3 后台任务的外部面
+
+- 表 `plugin_job`：`id`（26 位 ULID）、`plugin_id`、`kind`、`title`、`status`（queued / running / done /
+  failed / cancelled）、`done` / `total` / `message`、`result_json`、`error`、`project_id`、`user_id`、
+  `conversation_id`、时间戳。进度写库按 500ms 节流，内存态才是实时值；终态必落库；宿主重启时
+  库里还在 queued / running 的统一标 failed（宿主重启）。
+- REST：`GET /api/plugin-jobs?projectId=`、`GET /api/plugin-jobs/{id}`（登录 + 项目成员）、
+  `POST /api/plugin-jobs/{id}/cancel`（写权限）。
+- SSE：有 conversationId 时每次落库同时发 `client_action` `{action:"plugin_job_progress", jobId, pluginId,
+  kind, title, status, done, total, message, error, conversationId}`；前端并入
+  `BackgroundTaskIndicator`（类型 `PLUGIN_JOB`），挂载时按项目补拉在跑的。
+
+### 11.4 示例
+
+`examples/hello-plugin` 的 `helloListFiles`：实现 `HostAware`，经 `host.files().list(projectId, null, false)`
+列项目根目录；manifest 为它声明 `file_read`。

--- a/examples/hello-plugin/README.md
+++ b/examples/hello-plugin/README.md
@@ -1,7 +1,8 @@
 # hello-plugin 示例插件
 
-插件规范 v1（[docs/PLUGIN_SPEC.md](../../docs/PLUGIN_SPEC.md)）的最小可运行示例：
-提供 `helloEcho`（文本回显）与 `helloWordCount`（字数统计）两个 AI 工具。
+插件规范（[docs/PLUGIN_SPEC.md](../../docs/PLUGIN_SPEC.md)）的最小可运行示例：
+提供 `helloEcho`（文本回显）、`helloWordCount`（字数统计）两个纯函数工具，
+以及 `helloListFiles`——实现 `HostAware` 后经宿主 SPI（规范 v2.4 §11）列出项目根目录。
 
 ## 目录
 
@@ -15,9 +16,10 @@ examples/hello-plugin/
 
 ## 构建
 
-需要 JDK 17+ 与 Maven：
+需要 JDK 17+ 与 Maven。宿主 SPI `com.checkba:plugin-api` 不在中央仓库，先从本仓库装进本地 Maven 仓：
 
 ```bash
+mvn -q -f backend/plugin-api/pom.xml install
 cd examples/hello-plugin
 mvn -q package
 # 产物：target/hello-plugin-1.0.0.jar

--- a/examples/hello-plugin/manifest.json
+++ b/examples/hello-plugin/manifest.json
@@ -2,10 +2,10 @@
   "id": "hello-plugin",
   "name": "Hello 示例插件",
   "version": "1.0.0",
-  "description": "演示插件规范 v1 的最小示例：提供文本回显与字数统计两个 AI 工具。",
+  "description": "演示插件规范的最小示例：文本回显、字数统计，以及一个经宿主 SPI 列项目文件的工具。",
   "author": "AI Workdeck",
   "homepage": "https://github.com/zeweihan/checkba_cloud",
-  "permissions": [],
+  "permissions": ["file_read"],
   "tools": [
     {
       "name": "helloEcho",
@@ -14,6 +14,11 @@
     {
       "name": "helloWordCount",
       "description": "统计输入文本的字符数与词数"
+    },
+    {
+      "name": "helloListFiles",
+      "description": "列出当前项目根目录（宿主 SPI 示范）",
+      "permissions": ["file_read"]
     }
   ],
   "backendJars": [

--- a/examples/hello-plugin/pom.xml
+++ b/examples/hello-plugin/pom.xml
@@ -27,5 +27,13 @@
             <version>${langchain4j.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- 宿主 SPI（规范 v2.4 §11）：HostAware / PluginHost 等纯接口；运行时由宿主提供，故 provided。
+             本地构建前先 mvn -q -f ../../backend/plugin-api/pom.xml install -->
+        <dependency>
+            <groupId>com.checkba</groupId>
+            <artifactId>plugin-api</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/examples/hello-plugin/src/main/java/com/example/hello/HelloTools.java
+++ b/examples/hello-plugin/src/main/java/com/example/hello/HelloTools.java
@@ -1,16 +1,31 @@
 package com.example.hello;
 
+import com.checkba.plugin.api.FileInfo;
+import com.checkba.plugin.api.HostAware;
+import com.checkba.plugin.api.PluginHost;
+import com.checkba.plugin.api.ToolCall;
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 
+import java.util.List;
+
 /**
- * 示例插件工具类（插件规范 v1，见 docs/PLUGIN_SPEC.md）。
+ * 示例插件工具类（插件规范 v2.4，见 docs/PLUGIN_SPEC.md）。
  *
  * 约定：
  * - 必须有无参构造函数（宿主通过反射实例化）；
  * - 工具方法用 @Tool 注解，方法名即工具名，需与 manifest.json 的 tools[].name 一致；
- * - description 用中文写清楚用途，Agent 依赖它决定是否调用。
+ * - description 用中文写清楚用途，Agent 依赖它决定是否调用；
+ * - 实现 {@link HostAware} 即可拿到宿主门面 {@link PluginHost}（§11 SPI），不实现也照常工作。
  */
-public class HelloTools {
+public class HelloTools implements HostAware {
+
+    private PluginHost host;
+
+    @Override
+    public void setHost(PluginHost host) {
+        this.host = host;
+    }
 
     @Tool("原样回显输入文本，用于验证插件链路是否打通")
     public String helloEcho(String text) {
@@ -25,5 +40,31 @@ public class HelloTools {
         int chars = text.length();
         int words = text.trim().split("\\s+").length;
         return "字符数: " + chars + ", 词数: " + words;
+    }
+
+    /**
+     * 宿主 SPI 示范：经 {@code host.files().list} 列出当前项目根目录。
+     * projectId 参数由宿主按服务端上下文强制注入（模型传什么都会被覆盖），
+     * 与 {@code host.call().projectId()} 取到的是同一个值。
+     */
+    @Tool("列出当前项目根目录下的文件与文件夹（宿主 SPI 示范）")
+    public String helloListFiles(@P("项目 ID，由宿主注入") Long projectId) {
+        if (host == null) {
+            return "Error: host not injected (plugin loaded by a host older than spec v2.4).";
+        }
+        ToolCall call = host.call();
+        long pid = projectId != null ? projectId : (call != null && call.projectId() != null ? call.projectId() : -1L);
+        if (pid < 0) {
+            return "Error: no project context.";
+        }
+        List<FileInfo> files = host.files().list(pid, null, false);
+        if (files.isEmpty()) {
+            return "(empty project)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (FileInfo f : files) {
+            sb.append(f.folder() ? "[dir]  " : "[file] ").append(f.name()).append(" (id=").append(f.id()).append(")\n");
+        }
+        return sb.toString().trim();
     }
 }

--- a/frontend/src/components/BackgroundTaskIndicator.vue
+++ b/frontend/src/components/BackgroundTaskIndicator.vue
@@ -155,7 +155,8 @@ const getTaskTypeName = (type) => {
     'PPTX_MODIFY': t('chat.taskPptModify'),
     'FILE_PROCESS': t('chat.taskFileProcess'),
     'WEB_FETCH': t('chat.taskWebFetch'),
-    'OTHER': t('chat.taskOther')
+    'OTHER': t('chat.taskOther'),
+    'PLUGIN_JOB': t('chat.taskPluginJob')
   }
   return names[type] || type
 }

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -649,7 +649,7 @@ import BackgroundTaskIndicator from './BackgroundTaskIndicator.vue'
 import { useAgentStream } from '@/composables/useAgentStream.js'
 import { parseToolBlock } from '@/composables/agentTagProtocol.mjs'
 import { ref, watch, onMounted, nextTick, getCurrentInstance, computed } from 'vue'
-import { createFile, getProjectFiles, getApiBaseUrl, rollbackConversation, performPptGeneration, getSkills, fetchAiModels, getAiConfig, cancelBackgroundTask } from '@/services/api.js'
+import { createFile, getProjectFiles, getApiBaseUrl, rollbackConversation, performPptGeneration, getSkills, fetchAiModels, getAiConfig, cancelBackgroundTask, listPluginJobs, cancelPluginJob } from '@/services/api.js'
 import { getAuthHeaders } from '@/utils/auth.js'
 import { getAppLanguage } from '@/utils/appLanguage.js'
 import { t } from '@/i18n'
@@ -692,6 +692,7 @@ export default {
       onTitleUpdate,
       backgroundTasks,
       dismissBackgroundTask,
+      upsertPluginJob,
       lastHeartbeat,
       tokenUsage,
       fileChanges,
@@ -1133,7 +1134,21 @@ export default {
     onMounted(() => {
       loadModelCatalog()
       loadAiProvider()
+      restoreRunningPluginJobs()
     })
+
+    // 插件后台任务跨页面/跨重连仍在跑：SSE 只在进度变化时推一次，刷新页面或切回工作台的用户
+    // 要等下一次 progress 才能看到它。挂载时按项目拉一次在跑的，接回浮窗。
+    const restoreRunningPluginJobs = async () => {
+      if (!props.projectId) return
+      try {
+        const list = await listPluginJobs(props.projectId)
+        if (!Array.isArray(list)) return
+        list.filter(j => j && (j.status === 'queued' || j.status === 'running')).forEach(upsertPluginJob)
+      } catch (e) {
+        console.warn('[ChatInterface] restore plugin jobs failed:', e)
+      }
+    }
 
     // Scroll to bottom when bubbles change
     watch(() => bubbles.value.length, () => {
@@ -1450,11 +1465,25 @@ export default {
       'PPTX_MODIFY': t('chat.taskPptModify'),
       'FILE_PROCESS': t('chat.taskFileProcess'),
       'WEB_FETCH': t('chat.taskWebFetch'),
-      'OTHER': t('chat.taskOther')
+      'OTHER': t('chat.taskOther'),
+      'PLUGIN_JOB': t('chat.taskPluginJob')
     })[type] || type || t('chat.taskBackgroundFallback')
 
     const handleCancelTask = async (task) => {
       if (!task || !task.taskId || stoppingTasks.value[task.taskId]) return
+      // 插件后台任务（PluginJobService）按 jobId 取消，归属校验是项目成员，不走会话那条路
+      if (task.type === 'PLUGIN_JOB') {
+        stoppingTasks.value = { ...stoppingTasks.value, [task.taskId]: true }
+        try {
+          await cancelPluginJob(task.taskId)
+          uni.showToast({ title: t('chat.stoppingTask'), icon: 'none' })
+        } catch (e) {
+          console.warn('[ChatInterface] 停止插件后台任务失败:', e)
+          uni.showToast({ title: t('chat.stopNotEffective'), icon: 'none' })
+          stoppingTasks.value = { ...stoppingTasks.value, [task.taskId]: false }
+        }
+        return
+      }
       // conversationId 优先取任务自己带的：后台任务跨会话切换仍在跑，
       // 拿当前会话去停别的会话的任务会被后端 403 挡掉
       const cid = task.conversationId || currentConversationId.value

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -291,6 +291,41 @@ export function useAgentStream() {
         }
     }
 
+    // 插件后台任务 → backgroundTasks 条目。载荷来自 SSE `plugin_job_progress` 或 REST /api/plugin-jobs
+    // （字段同形：jobId/pluginId/kind/title/status/done/total/message/error/conversationId；REST 实体用 id）。
+    // 状态词映射到浮窗认识的四个：queued/running→running，done→completed，failed/cancelled 原样。
+    const upsertPluginJob = (d) => {
+        const jobId = d && (d.jobId || d.id)
+        if (!jobId) return
+        const status = d.status === 'done' ? 'completed'
+            : (d.status === 'failed' || d.status === 'cancelled') ? d.status
+            : 'running'
+        const total = Number(d.total) || 0
+        const done = Number(d.done) || 0
+        const progress = status === 'completed' ? 100 : (total > 0 ? Math.min(100, Math.round(done / total * 100)) : 0)
+        const message = d.status === 'failed' ? (d.error || d.message || t('agentStream.taskFailed'))
+            : d.status === 'done' ? (d.message || t('agentStream.taskCompleted'))
+            : (d.message || d.title || t('agentStream.taskInProgress'))
+        const existing = backgroundTasks.value[jobId]
+        const entry = {
+            taskId: jobId,
+            type: 'PLUGIN_JOB',
+            pluginId: d.pluginId,
+            kind: d.kind,
+            title: d.title,
+            conversationId: d.conversationId || (existing && existing.conversationId) || null,
+            progress,
+            message,
+            stage: d.status,
+            status,
+            error: d.error,
+            startedAt: existing ? existing.startedAt : Date.now(),
+            lastUpdate: Date.now()
+        }
+        if (status !== 'running' && !(existing && existing.completedAt)) entry.completedAt = Date.now()
+        backgroundTasks.value[jobId] = existing ? Object.assign(existing, entry) : entry
+    }
+
     // --- SSE Connection ---
     const connectSSE = (conversationId) => {
         if (sseAbortController && isConnected.value) return Promise.resolve()
@@ -790,6 +825,11 @@ export function useAgentStream() {
         } else if (evt === 'client_action') {
             try {
                 const d = JSON.parse(dataStr)
+                // 插件后台任务进度（PluginJobService，规范 v2.4 §11）：状态归 backgroundTasks，
+                // 与 PPT 生成等 Agent 后台任务同一张表、同一个浮窗；仍继续下发给页面级 handler。
+                if (d && d.action === 'plugin_job_progress') {
+                    upsertPluginJob(d)
+                }
                 // Trigger registered callbacks
                 if (clientActionHandler.value) {
                     clientActionHandler.value(d)
@@ -1569,6 +1609,8 @@ export function useAgentStream() {
         dismissBackgroundTask: (taskId) => {
             if (taskId && backgroundTasks.value[taskId]) delete backgroundTasks.value[taskId]
         },
+        // 插件后台任务：SSE 之外的补种入口（ChatInterface 挂载时拉 /api/plugin-jobs 把在跑的接回浮窗）
+        upsertPluginJob,
         // 切回会话时重连 SSE：后端 connect 会推 run_state（运行中还会推 state_recovery 续流）。
         reattachSSE: async (conversationId) => {
             if (!conversationId) return

--- a/frontend/src/locales/en-US/chat.js
+++ b/frontend/src/locales/en-US/chat.js
@@ -108,6 +108,7 @@ export default {
   taskFileProcess: 'File Processing',
   taskWebFetch: 'Web Fetch',
   taskOther: 'Other Task',
+  taskPluginJob: 'Plugin Job',
   taskBackgroundFallback: 'Background Task',
   backgroundTasksHeader: 'Background Tasks',
   viewTaskDetails: 'View task details',

--- a/frontend/src/locales/zh-CN/chat.js
+++ b/frontend/src/locales/zh-CN/chat.js
@@ -108,6 +108,7 @@ export default {
   taskFileProcess: '文件处理',
   taskWebFetch: '网页获取',
   taskOther: '其他任务',
+  taskPluginJob: '插件任务',
   taskBackgroundFallback: '后台任务',
   backgroundTasksHeader: '后台任务',
   viewTaskDetails: '查看任务详情',

--- a/frontend/src/pages/project-overview/agentClientActions.js
+++ b/frontend/src/pages/project-overview/agentClientActions.js
@@ -30,6 +30,13 @@ export const agentClientActionMethods = {
         if (isNewName) this._editorContractV2 = true
         if (isLegacyName && this._editorContractV2) return
 
+        // 插件后台任务进度（规范 v2.4 §11 Jobs）：状态已在 useAgentStream 的 client_action 入口
+        // 写进 backgroundTasks（ChatInterface 的 BackgroundTaskIndicator 消费），页面这层无事可做。
+        // 显式占一个分支是为了让读者在这张路由表上能找到它，而不是靠"什么都没匹配上"兜底。
+        if (action.action === 'plugin_job_progress') {
+            return
+        }
+
         if (action.action === 'refresh_files') {
             if (this.$refs.fileTree && this.$refs.fileTree.loadFiles) {
                 console.log('[ProjectOverview] Refreshing File Tree...')

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -476,6 +476,31 @@ export function cancelBackgroundTask(conversationId, taskId) {
   });
 }
 
+// ===================== 插件后台任务（插件规范 v2.4 §11 Jobs） =====================
+// 与上面的 Agent 后台任务是两套簿记：这套按项目归属、id 是 ULID、由 PluginJobService 驱动，
+// 进度经 SSE client_action `plugin_job_progress` 推送；这三个封装给列表/详情/取消用。
+export function listPluginJobs(projectId) {
+  return request({
+    url: `/api/plugin-jobs?projectId=${encodeURIComponent(projectId)}`,
+    method: 'GET',
+  });
+}
+
+export function getPluginJob(jobId) {
+  return request({
+    url: `/api/plugin-jobs/${encodeURIComponent(jobId)}`,
+    method: 'GET',
+  });
+}
+
+// 取消只翻标记 + 中断任务线程；任务体要在 checkCancelled 处配合才会真正停下，文案只许说「正在停止」
+export function cancelPluginJob(jobId) {
+  return request({
+    url: `/api/plugin-jobs/${encodeURIComponent(jobId)}/cancel`,
+    method: 'POST',
+  });
+}
+
 // 获取 AI 公共配置（如默认供应商）
 export function getAiConfig() {
   return request({


### PR DESCRIPTION
尽调 P1 单元 H（dev-board#109）：JAR 插件第一次拿到宿主能力。spec `docs/superpowers/specs/2026-08-21-dd-p1-drafting-design.md` §2。

## 做了什么

**H1 `plugin-api`（纯接口）**
- 新增独立 Maven 工程 `backend/plugin-api/`（`com.checkba:plugin-api:1.0.0`，Java 21，零依赖，只加不破）：`HostAware` / `PluginHost` + `Files` / `Text` / `Tags` / `Evidence` / `Jobs` / `Docs` / `Settings` / `Llm` 与全部 record。
- `backend/pom.xml` 普通依赖引用；`ci.yml` 与 `desktop-build.yml`（两平台）在 backend 的 Maven 前先 `install` 它（不在远端仓库）。
- `examples/hello-plugin`：`provided` 依赖 + `HostAware` 示范工具 `helloListFiles`。

**H2 后台任务**
- 实体 `PluginJob`（表 `plugin_job`，ULID id）、`PluginJobService`（每插件 2 线程池、进度 500ms 节流落库、`checkCancelled` 取消、任务体在 `PlatformAiUserScope` 里跑、启动时孤儿标 failed）。
- `EditorBridgeService.sendClientAction` 单名版；SSE `client_action: plugin_job_progress`。
- `PluginJobController`：`GET /api/plugin-jobs?projectId=`、`GET /{id}`、`POST /{id}/cancel`（登录 + 项目成员；取消要写权限）。
- 前端：`BackgroundTaskIndicator` 多一种来源 `PLUGIN_JOB`（SSE 入口 upsert + 挂载时补拉在跑的），停止按钮按 jobId 取消，`api.js` 三封装。

**H3 宿主实现**
- `PluginHostFactory`（按插件 id 缓存 + 调用上下文 ThreadLocal）/ `PluginHostImpl`（八个子接口，每方法先配额再鉴权，fileId 必须属于 projectId）/ `PluginHostQuota`（60 次/分钟/插件）。
- `ToolRegistry` 分发插件工具前 `bindCall`、finally `clear`（字段注入 `required=false`，测试构造点与 EvalHarness 不动）；`PluginService.loadJar` 对 `HostAware` 实例注入 host（`ObjectProvider` 懒取防死环）。
- `ProjectFileService.ensureFolderPath` 成为逐级建文件夹单一出处：`FileTools.move_file` 与会议录音目录收敛到它。
- `Llm` / `Text.ocr` 走平台通道（用户 Credits），不自带 key。
- `docs/PLUGIN_SPEC.md` 升 v2.4（§4 HostAware、§10 版本、新 §11 SPI 方法表）；`.claude/agents/plugin-system.md` 加「宿主 SPI」节。

## 待 I 接通

`Settings.projectStyleProfileJson` 目前是过渡实现（项目 `_模板/画像.json` > `dd.styleProfile.default` > classpath `house-default.json`），单元 I 合并后改调 `StyleProfiles.resolveForProject`。

## 验证

- 新增 `PluginJobServiceTest`(8) / `PluginHostImplTest`(14) / `ProjectFileServiceEnsureFolderPathTest`(3) 全绿。
- 全量 `mvn test`：2457 run，仅 `MeetingFolderLanguageTest` 两条因 mock 的是旧 `createFolder` 接缝而红，已改到 `ensureFolderPath`，复跑绿。
- 前端 `npm run check:emits` / `check:locales` 通过；`examples/hello-plugin` 本机 `mvn package` 通过。

## 合并后

新 worktree / 新机器跑 backend 前先 `mvn -q -f backend/plugin-api/pom.xml install`（plugin-system.md 已记）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
