### PR TITLE
feat(plugin-host): 后台任务线程配额 1200 次/分钟 + FileInfo.updatedAt 增量字段（dev-board#109）

### DIFF
--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -177,7 +177,7 @@ JAR 插件拿宿主能力的唯一契约：`com.checkba:plugin-api:1.0.0`，源�
   新机器 / 新 worktree 上 `mvn` backend 报 `Could not resolve com.checkba:plugin-api` 就是漏了这步。
   CI（`ci.yml`）与桌面打包（`desktop-build.yml` 两个平台）都已加这一步。
 - 宿主实现：`service/plugin/PluginHostFactory`（按插件 id 缓存 `PluginHost`、持有调用上下文 ThreadLocal、
-  集中注入全部宿主服务）、`PluginHostImpl`（八个子接口的内部类）、`PluginHostQuota`（60 次/分钟/插件）、
+  集中注入全部宿主服务）、`PluginHostImpl`（八个子接口的内部类）、`PluginHostQuota`（工具线程 60 次/分钟/插件，后台任务线程 1200 次——`PluginHostFactory.bindJob` 标记的 JobContext 期间）、
   `PluginJobService`（后台任务，每插件 2 线程池）+ `PluginJobController`（`/api/plugin-jobs`）+ 实体 `PluginJob`。
 - 注入链：`PluginService.loadJar` 实例化后 `injectHostIfAware` → `HostAware.setHost(factory.forPlugin(id))`。
   `PluginService` 经 `ObjectProvider<PluginHostFactory>` 懒取（构造器注入会成启动死环）。

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/FileInfo.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/FileInfo.java
@@ -2,7 +2,8 @@ package com.checkba.plugin.api;
 
 /**
  * 项目文件树节点。{@code path} 是项目根起的逻辑路径（"a/b/c.docx"）；
- * {@code sha256} 只在宿主已计算并缓存时非空（见 {@link Files#sha256}）；{@code metaJson} 为原始 JSON 串，可为 null。
+ * {@code sha256} 只在宿主已计算并缓存时非空（见 {@link Files#sha256}）；{@code metaJson} 为原始 JSON 串，可为 null；
+ * {@code updatedAt} 为最后修改时间（epoch millis，可为 null；1.0.0 增量字段，永远是最后一个分量）。
  */
 public record FileInfo(long id, String name, Long parentId, boolean folder, String fileType, long size,
-                       String path, String sha256, String metaJson) {}
+                       String path, String sha256, String metaJson, Long updatedAt) {}

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostFactory.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostFactory.java
@@ -55,6 +55,7 @@ public class PluginHostFactory {
     final PluginHostQuota quota;
 
     private final ThreadLocal<ToolCall> currentCall = new ThreadLocal<>();
+    private final ThreadLocal<Boolean> inJob = new ThreadLocal<>();
     private final Map<String, PluginHost> hosts = new ConcurrentHashMap<>();
 
     @Autowired
@@ -135,16 +136,28 @@ public class PluginHostFactory {
         currentCall.set(new ToolCall(ctx.projectId(), ctx.conversationId(), ctx.userId(), ctx.modelId()));
     }
 
-    /** 后台任务线程用：直接绑一份快照。 */
+    /** 直接绑一份快照（工具线程语义：60 次/分钟窗口）。 */
     public void bindCall(ToolCall call) {
         if (call == null) currentCall.remove(); else currentCall.set(call);
     }
 
+    /** 后台任务线程用：绑快照并标记「在 job 线程」，配额走 1200 次/分钟的大窗口。 */
+    public void bindJob(ToolCall call) {
+        bindCall(call);
+        if (call != null) inJob.set(Boolean.TRUE);
+    }
+
     public void clear() {
         currentCall.remove();
+        inJob.remove();
     }
 
     ToolCall currentCall() {
         return currentCall.get();
+    }
+
+    /** 当前线程是否处于 JobContext 绑定期间（决定配额窗口）。 */
+    boolean inJob() {
+        return Boolean.TRUE.equals(inJob.get());
     }
 }

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostImpl.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostImpl.java
@@ -145,7 +145,7 @@ class PluginHostImpl implements PluginHost {
 
     /** 配额 + 必须有调用上下文。 */
     private ToolCall enter() {
-        f.quota.acquire(pluginId);
+        f.quota.acquire(pluginId, f.inJob());
         ToolCall c = f.currentCall();
         if (c == null || c.userId() == null) {
             throw new IllegalStateException(LangText.of(
@@ -272,7 +272,8 @@ class PluginHostImpl implements PluginHost {
             Object sha = meta.get("sha256");
             return new FileInfo(p.getId(), p.getName(), p.getParentId(), Boolean.TRUE.equals(p.getIsFolder()),
                     p.getFileType(), p.getFileSize() == null ? 0L : p.getFileSize(), pathOf(p, idx),
-                    sha instanceof String s ? s : null, p.getMetaJson());
+                    sha instanceof String s ? s : null, p.getMetaJson(),
+                    p.getUpdatedAt() == null ? null : p.getUpdatedAt().atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli());
         }
 
         private boolean under(ProjectFile p, Long ancestorId, Map<Long, ProjectFile> idx) {
@@ -602,7 +603,7 @@ class PluginHostImpl implements PluginHost {
             ToolCall snapshot = c;
             // 任务线程上也要有调用上下文：任务体里的 host.files()/llm() 才能鉴权与计费
             JobBody wrapped = ctx -> {
-                f.bindCall(snapshot);
+                f.bindJob(snapshot);
                 try {
                     body.run(ctx);
                 } finally {

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostQuota.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostQuota.java
@@ -11,26 +11,43 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * 每插件每分钟宿主调用次数上限（滑动窗口）。防 runaway 插件把宿主打满，不是计费单位——
  * LLM/OCR 的钱按用户 Credits 在平台网关算。
+ *
+ * <p>两个窗口（dev-board#109，单元 L 实跑反馈）：工具调用线程 60 次/分钟；
+ * <b>后台任务线程</b>（JobContext 绑定期间）1200 次/分钟——批量入库每个文件至少两次宿主调用，
+ * 60 是硬瓶颈。两个窗口按 (pluginId, 模式) 分开计数。
  */
 public class PluginHostQuota {
 
     public static final int DEFAULT_LIMIT_PER_MINUTE = 60;
+    public static final int DEFAULT_JOB_LIMIT_PER_MINUTE = 1200;
     private static final long WINDOW_MS = 60_000L;
 
-    private final int limit;
+    private final int toolLimit;
+    private final int jobLimit;
     private final Map<String, Deque<Long>> windows = new ConcurrentHashMap<>();
 
     public PluginHostQuota() {
-        this(DEFAULT_LIMIT_PER_MINUTE);
+        this(DEFAULT_LIMIT_PER_MINUTE, DEFAULT_JOB_LIMIT_PER_MINUTE);
     }
 
-    public PluginHostQuota(int limit) {
-        this.limit = limit;
+    public PluginHostQuota(int toolLimit, int jobLimit) {
+        this.toolLimit = toolLimit;
+        this.jobLimit = jobLimit;
     }
 
-    /** 记一次调用；超限抛 {@link HostQuotaException}（不记入窗口，超限期间重试不会把窗口越推越满）。 */
+    /** 工具调用线程的窗口。 */
     public void acquire(String pluginId) {
-        Deque<Long> q = windows.computeIfAbsent(pluginId, k -> new ArrayDeque<>());
+        acquire(pluginId, false);
+    }
+
+    /**
+     * 记一次调用；超限抛 {@link HostQuotaException}（不记入窗口，超限期间重试不会把窗口越推越满）。
+     *
+     * @param inJob 是否在后台任务线程（JobContext 绑定期间）——用 1200 次/分钟的大窗口
+     */
+    public void acquire(String pluginId, boolean inJob) {
+        int limit = inJob ? jobLimit : toolLimit;
+        Deque<Long> q = windows.computeIfAbsent(pluginId + (inJob ? "#job" : "#tool"), k -> new ArrayDeque<>());
         long now = System.currentTimeMillis();
         synchronized (q) {
             while (!q.isEmpty() && now - q.peekFirst() >= WINDOW_MS) {
@@ -38,8 +55,9 @@ public class PluginHostQuota {
             }
             if (q.size() >= limit) {
                 throw new HostQuotaException(LangText.of(
-                        "插件 " + pluginId + " 宿主调用超过每分钟 " + limit + " 次上限",
-                        "Plugin " + pluginId + " exceeded the host call quota of " + limit + " per minute"));
+                        "插件 " + pluginId + " 宿主调用超过每分钟 " + limit + " 次上限" + (inJob ? "（后台任务）" : ""),
+                        "Plugin " + pluginId + " exceeded the host call quota of " + limit + " per minute"
+                                + (inJob ? " (background job)" : "")));
             }
             q.addLast(now);
         }

--- a/backend/src/test/java/com/checkba/service/plugin/PluginHostImplTest.java
+++ b/backend/src/test/java/com/checkba/service/plugin/PluginHostImplTest.java
@@ -166,6 +166,53 @@ class PluginHostImplTest {
     }
 
     @Test
+    @DisplayName("配额：后台任务线程（bindJob）走 1200 次/分钟的大窗口，与工具线程的 60 次分开计数")
+    void quotaJobThreadHasLargerWindow() {
+        factory.bindJob(new ToolCall(PROJECT, null, USER, null));
+        for (int i = 0; i < 1200; i++) {
+            host.settings().get("k");
+        }
+        assertThrows(HostQuotaException.class, () -> host.settings().get("k"));
+        // 回到工具线程：自己的 60 次窗口还是空的
+        factory.clear();
+        factory.bindCall(new ToolContext(PROJECT, "conv-1", USER, null));
+        for (int i = 0; i < 60; i++) {
+            host.settings().get("k");
+        }
+        assertThrows(HostQuotaException.class, () -> host.settings().get("k"));
+    }
+
+    @Test
+    @DisplayName("Jobs.start 的任务体包装以 job 模式绑定（大窗口），结束后清掉")
+    void jobsBodyRunsInJobMode() throws Exception {
+        ArgumentCaptor<com.checkba.plugin.api.JobBody> body = ArgumentCaptor.forClass(com.checkba.plugin.api.JobBody.class);
+        when(pluginJobService.start(eq("dd"), eq("ingest"), eq("t"), any(), body.capture()))
+                .thenReturn(new com.checkba.plugin.api.JobHandle("J2"));
+        host.jobs().start("ingest", "t", ctx -> {
+            for (int i = 0; i < 100; i++) host.settings().get("k"); // 超过 60，job 窗口放行
+        });
+        Thread th = new Thread(() -> {
+            try { body.getValue().run(null); } catch (Exception e) { throw new RuntimeException(e); }
+            assertTrue(!factory.inJob() && host.call() == null);
+        });
+        th.start();
+        th.join(5000);
+        assertTrue(!th.isAlive());
+    }
+
+    @Test
+    @DisplayName("FileInfo.updatedAt 填 ProjectFile.updatedAt（epoch millis），为空则 null")
+    void fileInfoCarriesUpdatedAt() {
+        ProjectFile p = file(80L, "u.txt", false);
+        p.setUpdatedAt(java.time.LocalDateTime.of(2026, 8, 22, 1, 0));
+        ProjectFile q = file(81L, "v.txt", false);
+        when(projectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(PROJECT)).thenReturn(List.of(p, q));
+        long expected = p.getUpdatedAt().atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli();
+        assertEquals(expected, host.files().get(PROJECT, 80L).updatedAt());
+        assertNull(host.files().get(PROJECT, 81L).updatedAt());
+    }
+
+    @Test
     @DisplayName("Docs.exec：无 conversationId 抛 IllegalStateException(no active conversation)；非白名单 action 拒绝")
     void docsExecRequiresConversationAndWhitelist() {
         factory.bindCall(new ToolContext(PROJECT, null, USER, null));

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -397,14 +397,14 @@ public record ToolCall(Long projectId, String conversationId, Long userId, Strin
 - 两种线程之外（插件自己起的线程、静态初始化）调用宿主 → `IllegalStateException`。
 - **鉴权**：每个方法先校 `call().userId()` 对 projectId 的读/写权限（项目成员表），非成员抛
   `IllegalArgumentException`；fileId 必须属于该 projectId（IDOR 防护）。
-- **配额**：每插件每分钟 60 次宿主调用（滑动窗口），超限抛 `HostQuotaException`。这是防 runaway，
+- **配额**：每插件每分钟宿主调用上限（滑动窗口）——工具调用线程 60 次，后台任务线程（`JobContext` 绑定期间）1200 次，两者分开计数；超限抛 `HostQuotaException`。这是防 runaway，
   不是计费——`Llm` / `Text.ocr` 的钱按**用户 Credits** 在平台网关算，插件不自带 key。
 
 ### 11.2 方法表
 
 | 子接口 | 方法 | 权限 | 宿主落点 / 备注 |
 |---|---|---|---|
-| `Files` | `list(projectId, parentId, recursive)` | 读 | 返回 `FileInfo{id,name,parentId,folder,fileType,size,path,sha256?,metaJson}`，`path` 从项目根起 |
+| `Files` | `list(projectId, parentId, recursive)` | 读 | 返回 `FileInfo{id,name,parentId,folder,fileType,size,path,sha256?,metaJson,updatedAt?}`（`updatedAt` 为 epoch millis、可 null，1.0.0 增量字段、永远是最后一个分量），`path` 从项目根起 |
 | | `get(projectId, fileId)` / `open(projectId, fileId)` | 读 | `open` 返回整份字节的 InputStream |
 | | `createFolderPath(projectId, segments)` | 写 | `ProjectFileService.ensureFolderPath`，逐级确保；某段是文件则抛 |
 | | `write(projectId, parentId, name, bytes, ConflictPolicy)` | 写 | `RENAME` 同名自动 " (n)"，`FAIL` 同名抛；fileType 取扩展名 |


### PR DESCRIPTION
单元 L（尽调 ingest）实跑反馈两条（dev-board#109）：

1. **配额分窗口**：后台任务线程（`JobContext` 绑定期间，`PluginHostFactory.bindJob` 标记）1200 次/分钟，工具调用线程仍 60；`PluginHostQuota` 按 (pluginId, 模式) 分开计数。批量入库每文件 ≥2 次宿主调用，60 是硬瓶颈。
2. **`FileInfo.updatedAt`**（epoch millis，Long，可 null）作为最后一个分量追加，`FilesImpl` 填 `ProjectFile.updatedAt`；`plugin-api` 版本 1.0.0 不变（纯增量），本机已重新 install；PLUGIN_SPEC §11 FileInfo 行与配额说明同步，plugin-system.md 同步。

## 验证
`mvn -q test -Dtest=PluginHost*,PluginJob*`：PluginHostImplTest 16→19（job 大窗口、任务体 job 模式绑定与清理、updatedAt），PluginJobServiceTest 8；27/27 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
