### PR TITLE
fix(style): docx_inspect_template 自己落盘 _模板/画像.json（dev-board#110 后续）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -33,7 +33,7 @@ description: AI↔文档编辑桥接领域。任务涉及 doc_*/sheet_*/slide_* 
 - `backend/src/main/java/com/checkba/service/ai/tools/SlideEditTools.java` — slide_* 演示文稿（Impress）原语，独立文件（不塞进 DocumentEditTools，后者已 70+ 方法），`List<AgentToolComponent>` 自动发现，ToolRegistry 无需改动。当前只有设计 Phase 1 的 7 个原语，见下方专节。
 - `backend/src/main/java/com/checkba/util/DocxStyleHelper.java` — write_docx/AiDocxExportService 两条 flexmark 生成路径的样式：`applyProfile(pkg, StyleProfile)` 在 render 后、save 前调用；`applyStandardFormat(pkg)` = `applyProfile(pkg, StyleProfiles.houseDefault())`。数值不再写在代码里，单源是 `backend/src/main/resources/style-profiles/house-default.json`（见下方「样式画像 styleProfile」节）。
 - `backend/src/main/java/com/checkba/util/style/` — `StyleProfile`（Jackson 树 + 类型化访问器 + 叶子 merge）、`StyleProfiles`（houseDefault/parse/toJson）、`Units`/`DocxStyleWriter`（单位换算与 wml 落法）、`DocxProfileReader`（docx4j 直读模板 → 画像）。
-- `backend/src/main/java/com/checkba/service/ai/tools/TemplateTools.java` — `docx_inspect_template(fileIds, options?)`：学习团队模板 → styleProfile v1 JSON；`.doc` 返回「另存 docx 或编辑器打开后学习」提示不报错。
+- `backend/src/main/java/com/checkba/service/ai/tools/TemplateTools.java` — `docx_inspect_template(fileIds, options?)`：学习团队模板 → styleProfile v1 JSON，并**自己写进项目 `_模板/画像.json`**（同名就地覆盖，返回值带 `savedProfileFileId`/`savedProfilePath`，失败带 `saveError`）——写端只认这个文件，别让模型转抄；`.doc` 返回「另存 docx 或编辑器打开后学习」提示不报错。
 - `backend/src/main/java/com/checkba/service/ai/StyleProfileResolver.java` — 写端画像解析顺序：工具显式 `styleProfileJson` > 项目 `_模板/画像.json` > SystemSetting `dd.styleProfile.default` > house-default；选中的画像总 merge 到 house-default 上补齐缺省叶子。
 - `backend/src/main/java/com/checkba/service/ai/tools/CheckpointTools.java` — `doc_restore_checkpoint`。
 - `backend/src/main/java/com/checkba/service/ai/tools/ToolMeta.java` — `@ToolMeta(displayName/category/fileEffect)`；`fileEffect="MODIFIED"` 是检查点触发依据。
@@ -208,7 +208,7 @@ txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue�
 - `table`：`borders.source ∈ cell|table|style|none` + `outside/insideH/insideV {style,width,color}`（source=cell 时写端同时落 `tcBorders`）；`columnWidths {mode: twips|percent|cm, samples: [[...]]}`（写端挑列数相符的样本落 `tblGrid`+`tcW`+`tblLayout fixed`）；`header {rows, repeatOnEachPage, bold, alignment, verticalAlign, fill}`；`cell.byContentType {text|number|date|serial: {alignment}}`（分类正则 `DocxProfileReader.classifyCell`，与旧 NUMERIC_CELL 同源）；`zebra`。
 - `page`：`size {width,height,orientation}`（mm，1 位小数）、`margins`（cm）、`docGrid {type, linePitch}`。`headerFooter.footer.pageNumber {enabled, pattern: "第 {PAGE} 页 共 {NUMPAGES} 页", alignment, format, start}`（写端拆成文本 run + FldChar 域）。`toc {enabled, levels: "1-2", hyperlinks, title}`（写端插 TOC 域 + `settings.xml updateFields`，主标题之后）。
 - 读端口径：样式链 docDefaults → basedOn 递归 → 本样式给声明值；主题字体槽位（minorHAnsi 之类）查 theme1.xml 解析成实际名并保留 `theme` 槽位名；表格三层边框不合并只判定层级。
-- 工具链：`docx_inspect_template` 产出 → 存项目 `_模板/画像.json` → `write_docx(..., styleProfileJson?)` 缺省自动取用（顺序见 `StyleProfileResolver`）。
+- 工具链：`docx_inspect_template` 产出并**自行落盘** `_模板/画像.json` → `doc_apply_style_profile` / `write_docx(..., styleProfileJson?)` 缺省自动取用（顺序见 `StyleProfileResolver`）。2026-08-22 前这一步靠模型 `write_file` 转抄，实测掉字段（黄金对照 B v6/v7 正文字体没套上）。
 - fixtures：`backend/src/test/resources/fixtures/gen-template-sample.py`（python-docx 生成 `template-sample.docx`，改 fixture 改脚本重跑）、`house-parity.md` + `house-before.json`（对拍基线）。
 
 ## 命名双轨现状（PR#192，下个发布周期摘旧名）

--- a/backend/src/main/java/com/checkba/service/ai/tools/TemplateTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/TemplateTools.java
@@ -2,6 +2,8 @@ package com.checkba.service.ai.tools;
 
 import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.StyleProfileResolver;
 import com.checkba.storage.StorageServiceFactory;
 import com.checkba.util.style.DocxProfileReader;
 import com.checkba.util.style.StyleProfile;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -35,16 +38,22 @@ public class TemplateTools implements AgentToolComponent {
 
     static final String DOC_HINT = "是 .doc 老格式，读不了样式：请先另存为 .docx，或在编辑器打开后再学习。";
 
+    /** 落盘画像用的写入者（与 write_file / write_docx 同一个 Agent 身份）。 */
+    private static final Long AGENT_USER_ID = 10001L;
+
     private final ProjectFileRepository projectFileRepository;
     private final StorageServiceFactory storageServiceFactory;
+    /** 落盘 _模板/画像.json 用；单测里可为 null（只学不存）。 */
+    private final ProjectFileService projectFileService;
 
     @ToolMeta(displayName = "学习模板格式", category = "file")
     @Tool("Learn the formatting profile (styleProfile v1 JSON) of one or more team template .docx files: body/heading "
             + "fonts (eastAsia + western), sizes, alignment, spacing, line spacing, first-line indent, heading numbering "
             + "(auto numPr vs literal text like 一、（一）1.), table borders (table vs cell level), column widths, header row, "
             + "page setup, header/footer page-number pattern, TOC field. Pass the database fileIds of the templates "
-            + "(comma-separated for several; the majority value wins and a confidence is reported). The returned JSON can be "
-            + "saved as the project's 画像.json and passed to write_docx as styleProfileJson.")
+            + "(comma-separated for several; the majority value wins and a confidence is reported). The profile is saved "
+            + "automatically as the project's _模板/画像.json (that is the file doc_apply_style_profile and write_docx read), "
+            + "so you never need to write it yourself; the returned JSON carries savedProfileFileId/savedProfilePath.")
     public String docx_inspect_template(
             @P("Template file database IDs, comma-separated, e.g. \"123\" or \"123,456\"") String fileIds,
             @P(value = "Optional JSON options, e.g. {\"name\":\"某律所尽调报告模板\"}", required = false) String options
@@ -94,16 +103,63 @@ public class TemplateTools implements AgentToolComponent {
             String name = optionName(options);
             if (name != null) profile.root().put("name", name);
             String json = StyleProfiles.toJson(profile);
+            // 自己落盘：doc_apply_style_profile / write_docx 只认项目里的 _模板/画像.json。
+            // 以前只把 JSON 交给模型让它 write_file 转抄——实测会掉字段（黄金对照 B v6/v7）。
+            Long projectId = sources.isEmpty() ? null : projectIdOf(ids);
+            try {
+                ProjectFile saved = saveProjectProfile(projectId, json);
+                if (saved != null) {
+                    profile.root().put("savedProfileFileId", saved.getId());
+                    profile.root().put("savedProfilePath", StyleProfileResolver.TEMPLATE_FOLDER + "/" + StyleProfileResolver.PROFILE_FILE);
+                } else {
+                    profile.root().put("saveError", "没有项目上下文，画像未保存：请用 write_file 写入 "
+                            + StyleProfileResolver.TEMPLATE_FOLDER + "/" + StyleProfileResolver.PROFILE_FILE);
+                }
+            } catch (Exception e) {
+                log.warn("docx_inspect_template: 画像落盘失败", e);
+                profile.root().put("saveError", "画像未能保存（" + e.getMessage() + "）：请用 write_file 写入 "
+                        + StyleProfileResolver.TEMPLATE_FOLDER + "/" + StyleProfileResolver.PROFILE_FILE);
+            }
             StringBuilder sb = new StringBuilder();
             if (!skipped.isEmpty()) {
                 sb.append(String.join("\n", skipped)).append('\n');
             }
-            sb.append(json);
+            sb.append(StyleProfiles.toJson(profile));
             return ToolFileGuard.capToolText("styleProfile", sb.toString());
         } catch (Exception e) {
             log.warn("docx_inspect_template failed", e);
             return "Error: failed to learn template: " + e.getMessage();
         }
+    }
+
+    /** 模板文件所属项目（多份取第一份能查到的）。 */
+    private Long projectIdOf(List<Long> ids) {
+        for (Long id : ids) {
+            Optional<ProjectFile> opt = projectFileRepository.findById(id);
+            if (opt.isPresent() && opt.get().getProjectId() != null) return opt.get().getProjectId();
+        }
+        return null;
+    }
+
+    /**
+     * 把画像写进项目的 {@code _模板/画像.json}：同名就地覆盖（不生成「画像 (1).json」），
+     * 没有项目上下文或没有 ProjectFileService（单测）时返回 null。
+     */
+    ProjectFile saveProjectProfile(Long projectId, String json) {
+        if (projectId == null || projectFileService == null) return null;
+        byte[] data = json.getBytes(StandardCharsets.UTF_8);
+        ProjectFile folder = projectFileService.ensureFolderPath(projectId, AGENT_USER_ID,
+                List.of(StyleProfileResolver.TEMPLATE_FOLDER));
+        Optional<ProjectFile> existing = projectFileRepository.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(
+                projectId, folder.getId(), StyleProfileResolver.PROFILE_FILE);
+        ProjectFile target = existing.orElseGet(() -> projectFileService.createFile(projectId, folder.getId(),
+                StyleProfileResolver.PROFILE_FILE, "json", (long) data.length, null, null, AGENT_USER_ID));
+        storageServiceFactory.getStorageService().save(target.getFilePath(), new ByteArrayInputStream(data));
+        if (existing.isPresent()) {
+            projectFileService.createOrUpdateFile(projectId, folder.getId(), StyleProfileResolver.PROFILE_FILE,
+                    "json", (long) data.length, target.getFilePath(), null, AGENT_USER_ID);
+        }
+        return target;
     }
 
     static List<Long> parseIds(String fileIds) {

--- a/backend/src/test/java/com/checkba/service/ai/tools/TemplateToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/TemplateToolsTest.java
@@ -2,6 +2,8 @@ package com.checkba.service.ai.tools;
 
 import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.ProjectFileRepository;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ai.StyleProfileResolver;
 import com.checkba.service.ai.context.ProjectContextHolder;
 import com.checkba.storage.StorageService;
 import com.checkba.storage.StorageServiceFactory;
@@ -13,6 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,7 +50,107 @@ class TemplateToolsTest {
                 .thenReturn(new ClassPathResource("fixtures/template-sample.docx"));
         StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
         Mockito.when(factory.getStorageService()).thenReturn(storage);
-        return new TemplateTools(repo, factory);
+        return new TemplateTools(repo, factory, null);
+    }
+
+    private static ProjectFile folder(long id, long projectId, String name) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(projectId);
+        f.setName(name);
+        f.setIsFolder(true);
+        f.setFileType("folder");
+        return f;
+    }
+
+    @Test
+    @DisplayName("学完自己落盘 _模板/画像.json：建夹 + 建文件 + 存字节，返回带 savedProfileFileId")
+    void savesProfileIntoProject() {
+        ProjectContextHolder.setProjectId("7");
+        ProjectFileRepository repo = Mockito.mock(ProjectFileRepository.class);
+        Mockito.when(repo.findById(1L)).thenReturn(Optional.of(file(1L, 7L, "模板.docx", "docx")));
+        Mockito.when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(7L, 90L, StyleProfileResolver.PROFILE_FILE))
+                .thenReturn(Optional.empty());
+        ProjectFileService pfs = Mockito.mock(ProjectFileService.class);
+        Mockito.when(pfs.ensureFolderPath(7L, 10001L, List.of(StyleProfileResolver.TEMPLATE_FOLDER)))
+                .thenReturn(folder(90L, 7L, StyleProfileResolver.TEMPLATE_FOLDER));
+        Mockito.when(pfs.createFile(Mockito.eq(7L), Mockito.eq(90L), Mockito.eq(StyleProfileResolver.PROFILE_FILE),
+                        Mockito.eq("json"), Mockito.anyLong(), Mockito.isNull(), Mockito.isNull(), Mockito.eq(10001L)))
+                .thenReturn(file(91L, 7L, StyleProfileResolver.PROFILE_FILE, "json"));
+
+        StorageService storage = Mockito.mock(StorageService.class);
+        Mockito.when(storage.load(Mockito.anyString())).thenReturn(new ClassPathResource("fixtures/template-sample.docx"));
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        Mockito.when(factory.getStorageService()).thenReturn(storage);
+
+        String out = new TemplateTools(repo, factory, pfs).docx_inspect_template("1", null);
+        StyleProfile p = StyleProfiles.parse(out);
+        assertEquals(91L, p.root().get("savedProfileFileId").asLong(), out);
+        assertEquals("_模板/画像.json", p.root().get("savedProfilePath").asText());
+        assertFalse(p.root().has("saveError"), out);
+
+        org.mockito.ArgumentCaptor<InputStream> bytes = org.mockito.ArgumentCaptor.forClass(InputStream.class);
+        Mockito.verify(storage).save(Mockito.eq("projects/7/画像.json"), bytes.capture());
+        String written = new String(readAll(bytes.getValue()), StandardCharsets.UTF_8);
+        // 存的是干净画像本身：解析得回来，且不含只给模型看的落盘回执字段
+        StyleProfile reparsed = StyleProfiles.parse(written);
+        assertEquals("楷体_GB2312", reparsed.body().font().eastAsia());
+        assertFalse(written.contains("savedProfileFileId"), written.substring(0, Math.min(200, written.length())));
+    }
+
+    @Test
+    @DisplayName("已有画像：就地覆盖同一个 fileId，不生成「画像 (1).json」")
+    void overwritesExistingProfile() {
+        ProjectContextHolder.setProjectId("7");
+        ProjectFileRepository repo = Mockito.mock(ProjectFileRepository.class);
+        Mockito.when(repo.findById(1L)).thenReturn(Optional.of(file(1L, 7L, "模板.docx", "docx")));
+        ProjectFile old = file(55L, 7L, StyleProfileResolver.PROFILE_FILE, "json");
+        Mockito.when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(7L, 90L, StyleProfileResolver.PROFILE_FILE))
+                .thenReturn(Optional.of(old));
+        ProjectFileService pfs = Mockito.mock(ProjectFileService.class);
+        Mockito.when(pfs.ensureFolderPath(7L, 10001L, List.of(StyleProfileResolver.TEMPLATE_FOLDER)))
+                .thenReturn(folder(90L, 7L, StyleProfileResolver.TEMPLATE_FOLDER));
+
+        StorageService storage = Mockito.mock(StorageService.class);
+        Mockito.when(storage.load(Mockito.anyString())).thenReturn(new ClassPathResource("fixtures/template-sample.docx"));
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        Mockito.when(factory.getStorageService()).thenReturn(storage);
+
+        String out = new TemplateTools(repo, factory, pfs).docx_inspect_template("1", null);
+        assertEquals(55L, StyleProfiles.parse(out).root().get("savedProfileFileId").asLong());
+        Mockito.verify(pfs, Mockito.never()).createFile(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.anyLong());
+        Mockito.verify(storage).save(Mockito.eq(old.getFilePath()), Mockito.any(InputStream.class));
+    }
+
+    @Test
+    @DisplayName("落盘失败：画像照样返回，但带上让模型自己 write_file 的 saveError")
+    void saveFailureIsVisible() {
+        ProjectContextHolder.setProjectId("7");
+        ProjectFileRepository repo = Mockito.mock(ProjectFileRepository.class);
+        Mockito.when(repo.findById(1L)).thenReturn(Optional.of(file(1L, 7L, "模板.docx", "docx")));
+        ProjectFileService pfs = Mockito.mock(ProjectFileService.class);
+        Mockito.when(pfs.ensureFolderPath(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList()))
+                .thenThrow(new IllegalStateException("磁盘满"));
+
+        StorageService storage = Mockito.mock(StorageService.class);
+        Mockito.when(storage.load(Mockito.anyString())).thenReturn(new ClassPathResource("fixtures/template-sample.docx"));
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        Mockito.when(factory.getStorageService()).thenReturn(storage);
+
+        String out = new TemplateTools(repo, factory, pfs).docx_inspect_template("1", null);
+        StyleProfile p = StyleProfiles.parse(out);
+        assertTrue(p.root().get("saveError").asText().contains("磁盘满"), out);
+        assertTrue(p.root().get("saveError").asText().contains("write_file"), out);
+        assertEquals("楷体_GB2312", p.body().font().eastAsia());
+    }
+
+    private static byte[] readAll(InputStream in) {
+        try (InputStream i = in) {
+            return i.readAllBytes();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @Test


### PR DESCRIPTION
## 问题

尽调黄金对照阶段 B 实跑（v6/v7）里，报告正文字体/字号始终没套上模板：

- `docx_inspect_template` 只把画像 JSON 返回给模型；
- `doc_apply_style_profile` 与 `write_docx` 走 `StyleProfileResolver`，只认项目里的 `_模板/画像.json`；
- 中间那步「模型用 write_file 把 JSON 转抄进去」实测会掉字段，甚至根本不写。

契约被模型补位，就一定会漏。

## 改动

- `TemplateTools.docx_inspect_template` 学完自己写 `_模板/画像.json`：`ensureFolderPath` 建夹，同名**就地覆盖**（不生成「画像 (1).json」），字节走 StorageService。
- 返回值带 `savedProfileFileId` / `savedProfilePath`；落盘失败带 `saveError`，明确指回 `write_file` 兜底。存进文件的是干净画像本身，不含这些回执字段。
- 工具描述改写：说明画像会自动保存，模型不必自己写。
- `.claude/agents/ai-doc-bridge.md` 同步这条契约与踩坑来由。

## 测试

`TemplateToolsTest` 新增三例（建夹+建文件+存字节并校验落盘内容、已有画像就地覆盖不新建、落盘失败仍返回画像且带 saveError），连同既有 5 例与 `StyleProfileTest` 全绿：12/0/0。

Generated with Claude Code