### PR TITLE
refactor(evidence): 建链核心抽成服务 + 插件 SPI linkAtQuote（dev-board#100 P2）

### DIFF
--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -200,3 +200,5 @@ JAR 插件拿宿主能力的唯一契约：`com.checkba:plugin-api:1.0.0`，源�
 - 后端：`cd backend && mvn test`（JDK 21）。
 - skill 触发链路：起后端后对话输入触发词验证注入；skill 管理 API `/api/skills/list|{id}/enable|{id}/disable|rescan`（admin）。
 - 前端面板：`cd frontend && npm run test:app-e2e` 覆盖主要旅程。
+
+- **`Evidence.linkAtQuote(projectId, docFileId, anchorQuote, targets)`（SPI 1.1.0 新增）**：插件按引文建链的唯一正路。宿主内部走 `EvidenceAnchorService`（查引文必须恰好命中一次 → set_selection → bookmark_selection（书签名 = linkKey）→ 内部超链接 → get_bookmark_context → 落库），与 AI 工具 `doc_link_evidence` **同一份实现**。插件**不要**自己用 `Docs.exec` 拼这套原语——书签名规则、超链接 scheme、章节路径口径都是契约，两份实现必然漂移。

--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -169,7 +169,7 @@ manifest.json 要点：id（必需）/name/version/icon/author/permissions（fil
 
 ## 宿主 SPI（plugin-api，规范 v2.4，dev-board#109）
 
-JAR 插件拿宿主能力的唯一契约：`com.checkba:plugin-api:1.0.0`，源码 `backend/plugin-api/`
+JAR 插件拿宿主能力的唯一契约：`com.checkba:plugin-api:1.1.0`（1.0.0 编译的插件照常加载，接口只增不改），源码 `backend/plugin-api/`
 （**独立 Maven 工程**，不是 backend 的子模块；backend 以普通依赖引用）。方法表与鉴权/配额规则在
 `docs/PLUGIN_SPEC.md` §11，这里只记落点与地雷。
 

--- a/backend/plugin-api/pom.xml
+++ b/backend/plugin-api/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.checkba</groupId>
     <artifactId>plugin-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>plugin-api</name>

--- a/backend/plugin-api/src/main/java/com/checkba/plugin/api/Evidence.java
+++ b/backend/plugin-api/src/main/java/com/checkba/plugin/api/Evidence.java
@@ -5,6 +5,15 @@ public interface Evidence {
     LinkView create(long projectId, long docFileId, String linkKey, String anchorText, String sectionPath,
                     String sectionTitle, java.util.List<TargetInput> targets);
     LinkView addTargets(long projectId, String linkKey, java.util.List<TargetInput> targets);
+
+    /**
+     * 按报告原文片段建链：宿主负责查引文（必须恰好命中一次）、打书签、套内部超链接、取章节路径并落库，
+     * 与 AI 工具 doc_link_evidence 同一份实现。插件不要自己拼这套 worker 原语。
+     *
+     * @throws IllegalArgumentException 引文命中 0 处或多处（消息可直接转述给用户）
+     * @throws IllegalStateException    当前没有打开的会话/文档
+     */
+    LinkView linkAtQuote(long projectId, long docFileId, String anchorQuote, java.util.List<TargetInput> targets);
     java.util.List<LinkView> listByDoc(long projectId, long docFileId);
     java.util.List<LinkView> listByFile(long projectId, long fileId);
 }

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.checkba</groupId>
             <artifactId>plugin-api</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -41,6 +41,8 @@ public class DocumentEditTools implements AgentToolComponent {
     // 构造器加参：手工 new 的测试（ParagraphIndexBaseTest / DocumentEditToolsEvidenceTest）要同步；
     // RealToolBeans 走反射取最长构造器，自动跟上
     private final com.checkba.service.evidence.EvidenceLinkService evidenceLinkService;
+    /** 建链核心（引文→书签→超链接→落库）唯一实现，AI 工具与插件宿主共用。 */
+    private final com.checkba.service.evidence.EvidenceAnchorService evidenceAnchorService;
     // doc_link_evidence 在动编辑器之前预校验写权限：worker 写完再被 Service 拒，文档里会留孤儿书签
     private final com.checkba.service.ProjectMemberService projectMemberService;
     // 样式画像解析（dev-board#111）：doc_apply_style_profile / doc_start_stream 按 §3.4 顺序取项目画像；
@@ -1438,7 +1440,8 @@ public class DocumentEditTools implements AgentToolComponent {
     // ==================== 证据链接（EvidenceLink，dev-board#112） ====================
 
     /** 文档内超链接的 web 包装前缀，与前端 workbenchActions.WPS_INTERNAL_HTTP_LINK_BASE / evidenceLocator.buildFileLinkUrl 同形。 */
-    static final String INTERNAL_LINK_BASE = "https://checkba-internal.local/open";
+    /** 单一来源在 EvidenceAnchorService；这里保留别名，历史引用不改。 */
+    static final String INTERNAL_LINK_BASE = com.checkba.service.evidence.EvidenceAnchorService.INTERNAL_LINK_BASE;
     private static final java.util.Set<String> EVIDENCE_METHODS = com.checkba.model.entity.EvidenceLinkTarget.METHODS;
     private static final java.util.Set<String> EVIDENCE_RELATIONS = com.checkba.model.entity.EvidenceLinkTarget.RELATIONS;
     /** 报告只能是 Writer 文档：书签/超链接原语只在 Writer 里有意义。 */
@@ -1504,59 +1507,9 @@ public class DocumentEditTools implements AgentToolComponent {
         }
 
         try {
-            String anchor = anchorId;
-            String matchedText = null;
-            if (!hasAnchor) {
-                com.fasterxml.jackson.databind.JsonNode found = workerJson(
-                        editorBridgeService.executeEditorCommand("find_text_locations", java.util.Map.of("keyword", anchorQuote.trim())));
-                com.fasterxml.jackson.databind.JsonNode matches = found.path("matches");
-                int n = matches.isArray() ? matches.size() : 0;
-                if (n == 0) {
-                    clearAnchorsQuietly();
-                    return "Error: anchorQuote 在文档中命中 0 处，未建链。请核对原文（标点、空格要一致），或先用 doc_find_text 定位后传 anchorId";
-                }
-                if (n > 1) {
-                    clearAnchorsQuietly();
-                    return "Error: anchorQuote 在文档中命中 " + n + " 处，无法唯一定位，未建链。请给更长、更独特的片段，或用 doc_find_text 挑出那一处后传 anchorId";
-                }
-                anchor = matches.get(0).path("anchorId").asText(null);
-                matchedText = matches.get(0).path("text").asText(null);
-                if (anchor == null || anchor.isBlank()) {
-                    return "Error: 查找结果缺少 anchorId，未建链";
-                }
-            }
-
-            workerJson(editorBridgeService.executeEditorCommand("set_selection", java.util.Map.of("anchor", anchor)));
-            // 选区已经落定，查找留下的锚点标记可以清掉（顺序不能反：set_selection 靠 anchorId 定位）
-            if (!hasAnchor) clearAnchorsQuietly();
-
-            String linkKey = "EVID_" + com.checkba.service.evidence.Ulid.next();
-            com.fasterxml.jackson.databind.JsonNode bm = workerJson(
-                    editorBridgeService.executeEditorCommand("bookmark_selection", java.util.Map.of("name", linkKey)));
-            String bookmarkText = bm.path("text").asText(null);
-
-            String inner = "checkba://filelink?k=" + linkKey + "&projectId=" + projectId;
-            String url = INTERNAL_LINK_BASE + "?u=" + java.net.URLEncoder.encode(inner, java.nio.charset.StandardCharsets.UTF_8);
-            workerJson(editorBridgeService.executeEditorCommand("set_selection_hyperlink", java.util.Map.of("url", url)));
-
-            String sectionPath = "";
-            String sectionTitle = "";
-            String contextText = null;
-            try {
-                com.fasterxml.jackson.databind.JsonNode ctx = workerJson(
-                        editorBridgeService.executeEditorCommand("get_bookmark_context", java.util.Map.of("name", linkKey)));
-                sectionPath = ctx.path("sectionPath").asText("");
-                sectionTitle = ctx.path("sectionTitle").asText("");
-                contextText = ctx.path("text").asText(null);
-            } catch (IllegalStateException e) {
-                // 书签与超链接已写入，章节信息拿不到不致命：sectionPath 留空，链照样落库
-                log.warn("doc_link_evidence: get_bookmark_context failed for {}: {}", linkKey, e.getMessage());
-            }
-            String anchorText = firstNonBlank(contextText, bookmarkText, matchedText, anchorQuote);
-
-            com.checkba.service.evidence.EvidenceLinkViews.LinkView view = evidenceLinkService.create(
-                    userId, projectId, docFileId, linkKey, anchorText, sectionPath, sectionTitle,
-                    com.checkba.model.entity.EvidenceLink.KIND_AI, targets);
+            com.checkba.service.evidence.EvidenceLinkViews.LinkView view = evidenceAnchorService.linkAtQuote(
+                    userId, projectId, docFileId, anchorQuote, anchorId, targets,
+                    com.checkba.model.entity.EvidenceLink.KIND_AI);
 
             java.util.Map<String, Object> out = new java.util.LinkedHashMap<>();
             out.put("linkKey", view.linkKey());
@@ -1564,7 +1517,7 @@ public class DocumentEditTools implements AgentToolComponent {
             out.put("sectionPath", view.sectionPath() == null ? "" : view.sectionPath());
             out.put("status", view.status());
             return EVIDENCE_JSON.writeValueAsString(out);
-        } catch (IllegalStateException e) {
+        } catch (IllegalArgumentException | IllegalStateException e) {
             return "Error: " + e.getMessage();
         } catch (Exception e) {
             log.error("Failed to link evidence", e);

--- a/backend/src/main/java/com/checkba/service/evidence/EvidenceAnchorService.java
+++ b/backend/src/main/java/com/checkba/service/evidence/EvidenceAnchorService.java
@@ -1,0 +1,125 @@
+package com.checkba.service.evidence;
+
+import com.checkba.service.ai.EditorBridgeService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 「按引文在报告里建一条底稿链接」的唯一实现：查引文 → 选中 → 打书签（名 = linkKey）→ 套内部超链接
+ * → 取章节上下文 → 落库。
+ *
+ * <p>抽出来之前这段只长在 {@code DocumentEditTools.doc_link_evidence} 里，插件想建链只能自己
+ * 重走一遍 worker 原语，两份实现迟早漂移（书签名规则、超链接 scheme、章节路径口径都是契约）。
+ * 现在 AI 工具与插件宿主都从这里走。
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EvidenceAnchorService {
+
+    /** 内部链接跳板地址：与前端 buildFileLinkUrl 同形，改这里等于改契约（有测试钉住）。 */
+    public static final String INTERNAL_LINK_BASE = "https://checkba-internal.local/open";
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final EditorBridgeService editorBridgeService;
+    private final EvidenceLinkService evidenceLinkService;
+
+    /**
+     * @param anchorQuote 报告原文片段，必须在文档中恰好出现一次；与 anchorId 二选一
+     * @param anchorId    doc_find_text 拿到的锚点 id；给了就不再查找
+     * @throws IllegalArgumentException 引文命中 0 处或多处（消息可直接回给模型/插件）
+     */
+    public EvidenceLinkViews.LinkView linkAtQuote(Long userId, Long projectId, Long docFileId,
+                                                  String anchorQuote, String anchorId,
+                                                  List<EvidenceLinkViews.TargetInput> targets,
+                                                  String createdByKind) {
+        boolean hasAnchor = anchorId != null && !anchorId.isBlank();
+        String anchor = anchorId;
+        String matchedText = null;
+        if (!hasAnchor) {
+            JsonNode found = workerJson(editorBridgeService.executeEditorCommand(
+                    "find_text_locations", Map.of("keyword", anchorQuote.trim())));
+            JsonNode matches = found.path("matches");
+            int n = matches.isArray() ? matches.size() : 0;
+            if (n == 0) {
+                clearAnchorsQuietly();
+                throw new IllegalArgumentException("anchorQuote 在文档中命中 0 处，未建链。请核对原文（标点、空格要一致），"
+                        + "或先用 doc_find_text 定位后传 anchorId");
+            }
+            if (n > 1) {
+                clearAnchorsQuietly();
+                throw new IllegalArgumentException("anchorQuote 在文档中命中 " + n + " 处，无法唯一定位，未建链。"
+                        + "请给更长、更独特的片段，或用 doc_find_text 挑出那一处后传 anchorId");
+            }
+            anchor = matches.get(0).path("anchorId").asText(null);
+            matchedText = matches.get(0).path("text").asText(null);
+            if (anchor == null || anchor.isBlank()) {
+                throw new IllegalArgumentException("查找结果缺少 anchorId，未建链");
+            }
+        }
+
+        workerJson(editorBridgeService.executeEditorCommand("set_selection", Map.of("anchor", anchor)));
+        // 选区已经落定，查找留下的锚点标记可以清掉（顺序不能反：set_selection 靠 anchorId 定位）
+        if (!hasAnchor) clearAnchorsQuietly();
+
+        String linkKey = "EVID_" + Ulid.next();
+        JsonNode bm = workerJson(editorBridgeService.executeEditorCommand("bookmark_selection", Map.of("name", linkKey)));
+        String bookmarkText = bm.path("text").asText(null);
+
+        String inner = "checkba://filelink?k=" + linkKey + "&projectId=" + projectId;
+        String url = INTERNAL_LINK_BASE + "?u=" + URLEncoder.encode(inner, StandardCharsets.UTF_8);
+        workerJson(editorBridgeService.executeEditorCommand("set_selection_hyperlink", Map.of("url", url)));
+
+        String sectionPath = "";
+        String sectionTitle = "";
+        String contextText = null;
+        try {
+            JsonNode ctx = workerJson(editorBridgeService.executeEditorCommand("get_bookmark_context", Map.of("name", linkKey)));
+            sectionPath = ctx.path("sectionPath").asText("");
+            sectionTitle = ctx.path("sectionTitle").asText("");
+            contextText = ctx.path("text").asText(null);
+        } catch (IllegalStateException e) {
+            // 书签与超链接已写入，章节信息拿不到不致命：sectionPath 留空，链照样落库
+            log.warn("linkAtQuote: get_bookmark_context failed for {}: {}", linkKey, e.getMessage());
+        }
+        String anchorText = firstNonBlank(contextText, bookmarkText, matchedText, anchorQuote);
+
+        return evidenceLinkService.create(userId, projectId, docFileId, linkKey, anchorText,
+                sectionPath, sectionTitle, createdByKind, targets);
+    }
+
+    private void clearAnchorsQuietly() {
+        try {
+            editorBridgeService.executeEditorCommand("clear_anchors", Map.of());
+        } catch (RuntimeException ignore) {
+            // 清锚点失败不影响主流程
+        }
+    }
+
+    private static String firstNonBlank(String... xs) {
+        for (String x : xs) if (x != null && !x.isBlank()) return x;
+        return null;
+    }
+
+    private JsonNode workerJson(String raw) {
+        try {
+            JsonNode n = JSON.readTree(raw == null ? "{}" : raw);
+            JsonNode err = n.get("error");
+            if (err != null && !err.isNull()) throw new IllegalStateException(err.asText());
+            return n;
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("编辑器返回无法解析: " + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostFactory.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostFactory.java
@@ -46,6 +46,7 @@ public class PluginHostFactory {
     final TagRepository tagRepository;
     final FileTagService fileTagService;
     final EvidenceLinkService evidenceLinkService;
+    final com.checkba.service.evidence.EvidenceAnchorService evidenceAnchorService;
     final PluginJobService pluginJobService;
     final EditorBridgeService editorBridgeService;
     final SystemSettingService systemSettingService;
@@ -71,6 +72,7 @@ public class PluginHostFactory {
                              TagRepository tagRepository,
                              FileTagService fileTagService,
                              EvidenceLinkService evidenceLinkService,
+                             com.checkba.service.evidence.EvidenceAnchorService evidenceAnchorService,
                              PluginJobService pluginJobService,
                              EditorBridgeService editorBridgeService,
                              SystemSettingService systemSettingService,
@@ -80,7 +82,7 @@ public class PluginHostFactory {
                              TokenUsageService tokenUsageService,
                              ObjectMapper objectMapper) {
         this(projectFileService, projectFileRepository, storageServiceFactory, projectMemberService, documentTextService,
-                ocrService, tagService, tagRepository, fileTagService, evidenceLinkService, pluginJobService,
+                ocrService, tagService, tagRepository, fileTagService, evidenceLinkService, evidenceAnchorService, pluginJobService,
                 editorBridgeService, systemSettingService, styleProfileResolver, chatModelFactory, auxModelResolver,
                 tokenUsageService, objectMapper, new PluginHostQuota());
     }
@@ -95,6 +97,7 @@ public class PluginHostFactory {
                       TagRepository tagRepository,
                       FileTagService fileTagService,
                       EvidenceLinkService evidenceLinkService,
+                      com.checkba.service.evidence.EvidenceAnchorService evidenceAnchorService,
                       PluginJobService pluginJobService,
                       EditorBridgeService editorBridgeService,
                       SystemSettingService systemSettingService,
@@ -114,6 +117,7 @@ public class PluginHostFactory {
         this.tagRepository = tagRepository;
         this.fileTagService = fileTagService;
         this.evidenceLinkService = evidenceLinkService;
+        this.evidenceAnchorService = evidenceAnchorService;
         this.pluginJobService = pluginJobService;
         this.editorBridgeService = editorBridgeService;
         this.systemSettingService = systemSettingService;

--- a/backend/src/main/java/com/checkba/service/plugin/PluginHostImpl.java
+++ b/backend/src/main/java/com/checkba/service/plugin/PluginHostImpl.java
@@ -551,6 +551,18 @@ class PluginHostImpl implements PluginHost {
 
     // ------------------------------------------------------------------ Evidence
 
+    /** EditorBridgeService 按自己的 ThreadLocal 找会话；后台任务线程上没有，这里按调用上下文临时绑定。 */
+    private <T> T withConversation(String conversationId, java.util.function.Supplier<T> body) {
+        String previous = f.editorBridgeService.getCurrentConversationId();
+        f.editorBridgeService.setCurrentConversationId(conversationId);
+        try {
+            return body.get();
+        } finally {
+            if (previous == null) f.editorBridgeService.clearCurrentConversationId();
+            else f.editorBridgeService.setCurrentConversationId(previous);
+        }
+    }
+
     private final class EvidenceImpl implements Evidence {
 
         private List<EvidenceLinkViews.TargetInput> in(List<TargetInput> targets) {
@@ -575,6 +587,22 @@ class PluginHostImpl implements PluginHost {
             ToolCall c = requireWrite(projectId);
             return out(f.evidenceLinkService.create(c.userId(), projectId, docFileId, linkKey, anchorText,
                     sectionPath, sectionTitle, com.checkba.model.entity.EvidenceLink.KIND_PLUGIN, in(targets)));
+        }
+
+        @Override
+        public LinkView linkAtQuote(long projectId, long docFileId, String anchorQuote, List<TargetInput> targets) {
+            ToolCall c = requireWrite(projectId);
+            if (anchorQuote == null || anchorQuote.isBlank()) {
+                throw new IllegalArgumentException(LangText.of("anchorQuote 不能为空", "anchorQuote must not be empty"));
+            }
+            if (targets == null || targets.isEmpty()) {
+                throw new IllegalArgumentException(LangText.of("至少要有一条底稿", "At least one evidence target is required"));
+            }
+            // 建链要走 worker，必须有会话；与 Docs.exec 同一套约束
+            if (!StringUtils.hasText(c.conversationId())) throw new IllegalStateException("no active conversation");
+            return withConversation(c.conversationId(), () -> out(f.evidenceAnchorService.linkAtQuote(
+                    c.userId(), projectId, docFileId, anchorQuote, null, in(targets),
+                    com.checkba.model.entity.EvidenceLink.KIND_PLUGIN)));
         }
 
         @Override
@@ -660,18 +688,6 @@ class PluginHostImpl implements PluginHost {
                 throw new IllegalStateException("no active conversation");
             }
             return c.conversationId();
-        }
-
-        /** EditorBridgeService 按自己的 ThreadLocal 找会话；后台任务线程上没有，这里按调用上下文临时绑定。 */
-        private <T> T withConversation(String conversationId, java.util.function.Supplier<T> body) {
-            String previous = f.editorBridgeService.getCurrentConversationId();
-            f.editorBridgeService.setCurrentConversationId(conversationId);
-            try {
-                return body.get();
-            } finally {
-                if (previous == null) f.editorBridgeService.clearCurrentConversationId();
-                else f.editorBridgeService.setCurrentConversationId(previous);
-            }
         }
 
         @Override

--- a/backend/src/test/java/com/checkba/service/ai/tools/DocumentEditToolsEvidenceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/DocumentEditToolsEvidenceTest.java
@@ -66,7 +66,7 @@ class DocumentEditToolsEvidenceTest {
         evidence = Mockito.mock(EvidenceLinkService.class);
         repo = Mockito.mock(ProjectFileRepository.class);
         members = Mockito.mock(ProjectMemberService.class);
-        tools = new DocumentEditTools(null, repo, bridge, null, evidence, members, null);
+        tools = new DocumentEditTools(null, repo, bridge, null, evidence, new com.checkba.service.evidence.EvidenceAnchorService(bridge, evidence), members, null);
         ProjectContextHolder.setProjectId(String.valueOf(PROJECT_ID));
         ProjectContextHolder.setUserId(USER_ID);
         when(members.hasWritePermission(PROJECT_ID, USER_ID)).thenReturn(true);

--- a/backend/src/test/java/com/checkba/service/ai/tools/DocumentEditToolsStyleTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/DocumentEditToolsStyleTest.java
@@ -40,7 +40,7 @@ class DocumentEditToolsStyleTest {
     void setUp() {
         bridge = Mockito.mock(EditorBridgeService.class);
         resolver = Mockito.mock(StyleProfileResolver.class);
-        tools = new DocumentEditTools(null, null, bridge, null, null, null, resolver);
+        tools = new DocumentEditTools(null, null, bridge, null, null, null, null, resolver);
         when(bridge.executeEditorCommand(any(), any())).thenReturn("{\"success\":true}");
         ProjectContextHolder.setProjectId("7");
     }
@@ -82,7 +82,7 @@ class DocumentEditToolsStyleTest {
     @Test
     @DisplayName("doc_apply_style_profile：没有解析器时按 house-default 下发，scope 缺省 document")
     void applyStyleProfileFallsBackToHouseDefault() {
-        DocumentEditTools bare = new DocumentEditTools(null, null, bridge, null, null, null, null);
+        DocumentEditTools bare = new DocumentEditTools(null, null, bridge, null, null, null, null, null);
         bare.doc_apply_style_profile(null);
         Map<String, Object> profile = (Map<String, Object>) paramsOf("set_style_profile").get("profile");
         assertEquals("律所标准格式（HOUSE）", profile.get("name"));
@@ -180,14 +180,14 @@ class DocumentEditToolsStyleTest {
         when(pfs.getFile(100L)).thenReturn(f);
         when(bridge.executeEditorCommand(eq("doc_open_file_sync"), any())).thenReturn("{\"status\":\"ready\"}");
         when(bridge.getCurrentConversationId()).thenReturn("conv");
-        DocumentEditTools bare = new DocumentEditTools(pfs, null, bridge, null, null, null, null);
+        DocumentEditTools bare = new DocumentEditTools(pfs, null, bridge, null, null, null, null, null);
         bare.doc_start_stream(100L, null, null);
         assertFalse(paramsOf("doc_open_file_sync").containsKey("styleProfile"));
 
         Mockito.clearInvocations(bridge);
         when(resolver.resolve(7L, null)).thenReturn(StyleProfiles.houseDefault().merge(StyleProfiles.parse(
                 "{\"body\":{\"font\":{\"western\":\"Times New Roman\"}}}")));
-        DocumentEditTools withResolver = new DocumentEditTools(pfs, null, bridge, null, null, null, resolver);
+        DocumentEditTools withResolver = new DocumentEditTools(pfs, null, bridge, null, null, null, null, resolver);
         withResolver.doc_start_stream(100L, null, null);
         assertTrue(paramsOf("doc_open_file_sync").containsKey("styleProfile"));
     }

--- a/backend/src/test/java/com/checkba/service/ai/tools/ParagraphIndexBaseTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/ParagraphIndexBaseTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.verify;
 class ParagraphIndexBaseTest {
 
     private static DocumentEditTools toolsWithBridge(EditorBridgeService bridge) {
-        return new DocumentEditTools(null, null, bridge, null, null, null, null);
+        return new DocumentEditTools(null, null, bridge, null, null, null, null, null);
     }
 
     /** 收集所有 @P 说明里提到「段落」的参数 */

--- a/backend/src/test/java/com/checkba/service/plugin/PluginHostImplTest.java
+++ b/backend/src/test/java/com/checkba/service/plugin/PluginHostImplTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -100,6 +101,7 @@ class PluginHostImplTest {
         when(members.hasWritePermission(PROJECT, USER)).thenReturn(true);
         factory = new PluginHostFactory(projectFileService, projectFileRepository, storageServiceFactory, members,
                 documentTextService, ocrService, tagService, tagRepository, fileTagService, evidenceLinkService,
+                new com.checkba.service.evidence.EvidenceAnchorService(editorBridge, evidenceLinkService),
                 pluginJobService, editorBridge, settings, styleProfileResolver, chatModelFactory, auxModelResolver,
                 tokenUsageService, new ObjectMapper(), new PluginHostQuota());
         host = factory.forPlugin("dd");
@@ -306,6 +308,28 @@ class PluginHostImplTest {
         String h2 = host.files().sha256(PROJECT, 7L);
         assertEquals(h1, h2);
         verify(storage, org.mockito.Mockito.times(1)).load("projects/1/h.txt");
+    }
+
+    @Test
+    void evidenceLinkAtQuoteGoesThroughTheHostAnchorFlow() {
+        // 插件不许自己拼 worker 原语建链：宿主按引文查找→选中→打书签→套超链接→落库，与 doc_link_evidence 同一份实现
+        when(editorBridge.executeEditorCommand(eq("find_text_locations"), anyMap()))
+                .thenReturn("{\"matches\":[{\"anchorId\":\"a1\",\"text\":\"表1-1 收购人主体基本情况表\"}]}");
+        when(editorBridge.executeEditorCommand(eq("set_selection"), anyMap())).thenReturn("{}");
+        when(editorBridge.executeEditorCommand(eq("bookmark_selection"), anyMap())).thenReturn("{\"text\":\"表1-1 收购人主体基本情况表\"}");
+        when(editorBridge.executeEditorCommand(eq("set_selection_hyperlink"), anyMap())).thenReturn("{}");
+        when(editorBridge.executeEditorCommand(eq("get_bookmark_context"), anyMap()))
+                .thenReturn("{\"sectionPath\":\"一/（一）\",\"sectionTitle\":\"基本情况\",\"text\":\"表1-1 收购人主体基本情况表\"}");
+        EvidenceLinkViews.LinkView view = new EvidenceLinkViews.LinkView(9L, "EVID_Y", 3L, "表1-1 收购人主体基本情况表", "hash",
+                "一/（一）", "基本情况", "unverified", "plugin", null, null, List.of());
+        when(evidenceLinkService.create(eq(USER), eq(PROJECT), eq(3L), anyString(), anyString(), eq("一/（一）"),
+                eq("基本情况"), eq("plugin"), anyList())).thenReturn(view);
+
+        LinkView out = host.evidence().linkAtQuote(PROJECT, 3L, "表1-1 收购人主体基本情况表",
+                List.of(new TargetInput(4L, null, "supports", "written_review", null, null)));
+        assertEquals("EVID_Y", out.linkKey());
+        assertEquals("一/（一）", out.sectionPath());
+        verify(editorBridge).executeEditorCommand(eq("bookmark_selection"), anyMap());
     }
 
     @Test


### PR DESCRIPTION
## 为什么

黄金对照阶段 B 实跑里，模型把 `doc_insert_table` 的大 `rowsJson` 回抄到一半时输出被截断（后端日志 `Truncated tool_code persisted after corrections`），整个回合作废——表格没插进去、链接也没挂上。这类失败与提示词无关：**只要让模型回抄大参数，就有截断风险**。

根治办法是让插件自己写表、自己挂链接（模型一章从 ~26 次调用降到 ~8 次）。但插件要建链就得有一条正路：否则它只能用 `Docs.exec` 把 worker 原语重拼一遍，而书签名规则（`EVID_<ULID>` = linkKey）、内部超链接 scheme、章节路径口径都是契约，两份实现迟早漂移。

## 改了什么

- 新增 `EvidenceAnchorService`：引文查找（必须恰好命中一次）→ set_selection → bookmark_selection → 内部超链接 → get_bookmark_context → 落库。`doc_link_evidence` 改为委托，**行为与错误文案一字未改**（既有 13 例证据测试原样通过）。
- `INTERNAL_LINK_BASE` 单一来源移进该服务（前端 buildFileLinkUrl 同形，有测试钉住），`DocumentEditTools` 保留别名常量。
- `plugin-api` 1.1.0：`Evidence` 新增 `linkAtQuote(projectId, docFileId, anchorQuote, targets)`；宿主实现要求写权限 + 有活动会话，`createdByKind=plugin`。接口只增不改，1.0.0 编译的插件照常加载。
- `withConversation` 从 DocsImpl 提到外层类复用。

## 测试

新增 `PluginHostImplTest.evidenceLinkAtQuoteGoesThroughTheHostAnchorFlow` 钉住这条路（查引文→书签→超链接→章节→落库全序列）。相关 115 例（PluginHost / DocumentEditTools / EvidenceLink / EvidenceVerify）全绿。

Generated with Claude Code