### PR TITLE
fix(agent): 工具调用被截断且纠正无效时，把原因写给用户（dev-board#100）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -312,3 +312,5 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
   `AI_INTERNAL_ERROR`；read_document 对真实 docx fixture 返回非空正文、空文档给可行动说明）。
 - 前端：`npm run check:emits`；标签协议编解码 `npm run test:tag-protocol`（node:test，零依赖）；UI 链路 `npm run test:app-e2e`。
 - Office 插件的标签解析：`node --test office-addin/taskpane/lib/sse.test.js`（零依赖，未进 CI）。
+
+- **工具参数太长会把模型输出撑到截断**（实测：一章起草里 4 次）。编排器检测到 `<tool_code>` 未闭合会回喂提示让模型重发，最多两轮；**两轮还截断就把原因写进最终正文**（「参数太长…没有执行完」），不再静默收尾。根治办法不是调 max_tokens，而是别让模型回抄大参数：让工具自己把内容写进文档（尽调插件 `dd_table`/`dd_phrases` 的 `docFileId` 就是这么做的）。回归用例 `cases-harness-recovery.json` 的 `truncated-tool-code-persists-tells-the-user`。

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -967,7 +967,13 @@ public class AgentOrchestrator {
                             depth + 1, executionLog, agentMode, guard);
                     return;
                 }
-                log.warn("Truncated tool_code persisted after corrections for {}, finishing normally", conversationId);
+                // 两轮纠正还在截断：多半是这次工具调用的参数太长（整张表、整段正文回抄）。
+                // 「静默收尾」会让用户看着一个做了一半的任务发呆——这里把原因追进正文，
+                // 让人知道该怎么办（换更小的参数、或用能自己写文档的工具）。
+                log.warn("Truncated tool_code persisted after corrections for {}, finishing with a visible note", conversationId);
+                content = content + "\n\n> 上一步的工具调用参数太长，模型输出被截断了两次，这一步没有执行完。"
+                        + "常见原因是要写进文档的表格或正文被整段塞进了工具参数。"
+                        + "可以让我把这一步拆小（分几次写），或改用能直接把内容写进文档的工具重试。";
             }
 
             // 3. Check for Artifacts

--- a/backend/src/test/resources/ai-eval/cases/cases-harness-recovery.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-harness-recovery.json
@@ -21,10 +21,19 @@
     },
     "expect": {
       "toolCalls": [
-        { "name": "create_folder", "argsContain": { "folderName": "尽调材料" } }
+        {
+          "name": "create_folder",
+          "argsContain": {
+            "folderName": "尽调材料"
+          }
+        }
       ],
-      "promptContains": ["标签未闭合"],
-      "structureContains": ["<final>"],
+      "promptContains": [
+        "标签未闭合"
+      ],
+      "structureContains": [
+        "<final>"
+      ],
       "bubbleEndStatus": "finished"
     }
   },
@@ -47,10 +56,48 @@
     },
     "expect": {
       "toolCalls": [
-        { "name": "doc_find_replace", "argsContain": { "findText": "甲方", "replaceText": "委托方" } }
+        {
+          "name": "doc_find_replace",
+          "argsContain": {
+            "findText": "甲方",
+            "replaceText": "委托方"
+          }
+        }
       ],
-      "structureContains": ["<tool_output status=\"FAILURE\">", "<final>"],
+      "structureContains": [
+        "<tool_output status=\"FAILURE\">",
+        "<final>"
+      ],
       "bubbleEndStatus": "finished"
+    }
+  },
+  {
+    "id": "truncated-tool-code-persists-tells-the-user",
+    "title": "两轮纠正后仍截断：收尾要把原因写进正文，不许静默做一半（dev-board#100 实测 4 次）",
+    "category": "files",
+    "protocol": "xml",
+    "userInput": "把这张表写进报告",
+    "turns": [
+      {
+        "text": "<process name=\"插入表格\"><tool_code>doc_insert_table(rowsJson=\"[[\\\"名称\\\",\\\"甲\\\"],[\\\"住所\\\""
+      },
+      {
+        "text": "<process name=\"插入表格\"><tool_code>doc_insert_table(rowsJson=\"[[\\\"名称\\\",\\\"甲\\\"],[\\\"住所\\\""
+      },
+      {
+        "text": "<process name=\"插入表格\"><tool_code>doc_insert_table(rowsJson=\"[[\\\"名称\\\",\\\"甲\\\"],[\\\"住所\\\""
+      }
+    ],
+    "toolStubs": {},
+    "expect": {
+      "promptContains": [
+        "标签未闭合"
+      ],
+      "bubbleEndStatus": "finished",
+      "structureContains": [
+        "参数太长",
+        "没有执行完"
+      ]
     }
   }
 ]


### PR DESCRIPTION
## 现象

尽调起草的真实跑分里，后端日志出现 4 次「模型把整张表的 rowsJson 回抄到一半被截断」：编排器纠正两轮无效后按「正常收尾」结束。用户侧看到的是任务做了一半、没有报错、没有解释。

## 改动

两轮纠正仍截断时，把原因追进最终正文（参数太长、这一步没有执行完），并给出两条可操作的路：拆小，或改用能直接把内容写进文档的工具。日志措辞同步改成 finishing with a visible note。

根治方向不在这个 PR：真正的解法是别让模型回抄大参数（尽调插件已改成由插件自己写表写段，走 SPI Evidence.linkAtQuote，见 PR #567）。

## 测试

cases-harness-recovery.json 新增回放用例 truncated-tool-code-persists-tells-the-user（三轮都截断 → 断言最终正文含「参数太长」「没有执行完」）。把修复还原后该用例转红（Run 17 失败，已实测），确认不是空断言。OrchestratorReplayEvalTest 42 例全绿。

Generated with Claude Code
