### PR TITLE
fix(editor-bridge): worker 失败只填 message 时不要回传 error:null（dev-board#100）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -290,3 +290,5 @@ txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue�
 - 原语级测试不够，必须走完 UI 链路验证（用户明确要求过）。
 
 - **枚举列宽**：`evidence_link_target.method` 是 varchar(32) —— 枚举里最长的 `written_statement` 有 17 个字符，原来的 16 让「书面确认」型链接**永远存不进去**（真实起草跑分报 `Value too long for column method`）。改枚举时一并核对列宽，回归测试 `EvidenceLinkServiceTest.enumColumnsAreWideEnoughForEveryAllowedValue` 钉住。
+
+- **worker 失败原因不能丢**：`agentClientActions.handleEditorCommand` 回传失败时 `error` 缺省要退到 `message` —— worker 里大量失败分支只填 `message`（`delete_match` 的「match index out of range」之类），只取 `error` 的话模型收到 `{"error": "null"}`，只能瞎猜着重试。回归用例 `frontend/tests/project-home/editor-command-failure-reason.test.mjs`。

--- a/frontend/src/pages/project-overview/agentClientActions.js
+++ b/frontend/src/pages/project-overview/agentClientActions.js
@@ -474,7 +474,11 @@ export const agentClientActionMethods = {
             const result = await this.libreOfficeExecutor.executeCommand(
                 commandAction, Object.assign({}, params, { __agent: true }))
             const successFlag = result && result.success !== false
-            await sendEditorResult(conversationId, requestId, successFlag, result, (result && result.error) || null)
+            // 失败原因优先取 error，没有就退到 message：worker 里大量失败分支只填 message
+            //（如 delete_match 的「match index out of range」），只取 error 的话模型收到的是
+            // {"error": "null"}，等于没告诉它哪里错了，它只能瞎猜着重试。
+            const failReason = result ? (result.error || result.message || null) : null
+            await sendEditorResult(conversationId, requestId, successFlag, result, successFlag ? (result && result.error) || null : failReason)
         } catch (e) {
             console.error('[ProjectOverview] LibreOffice command error:', e)
             await sendEditorResult(conversationId, requestId, false, null, e.message)

--- a/frontend/tests/project-home/editor-command-failure-reason.test.mjs
+++ b/frontend/tests/project-home/editor-command-failure-reason.test.mjs
@@ -1,0 +1,58 @@
+// 尽调起草实测（dev-board#100）：worker 的失败分支大多只填 message（如 delete_match 的
+// 「match index out of range」），而回传只取 result.error —— 模型收到的是 {"error": "null"}，
+// 等于没告诉它哪里错了，只能瞎猜着重试（实测因此触发了一串无效的删改）。
+// 修法：失败时 error 缺省退到 message。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createSerialQueue } from '../../src/utils/asyncSerialize.js'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/agentClientActions.js', import.meta.url), 'utf8')
+
+function loadMethods(sent) {
+  const body = SRC
+    .replace(/^import .*$/gm, '')
+    .replace(/export function shouldFlushDocStream[\s\S]*?\n\}\n/, '')
+    .replace(/export const agentClientActionMethods = \{/, 'return {')
+  const factory = new Function('sendEditorResult', 'getFileDetail', 'createSerialQueue', 'uni', body)
+  return factory(
+    async (conversationId, requestId, success, result, error) => { sent.push({ success, result, error }) },
+    async () => null, createSerialQueue, { showToast: () => {} })
+}
+
+function makeVm(result, sent) {
+  const vm = {
+    projectId: 1,
+    libreOfficeActive: true,
+    libreOfficeExecutor: { executeCommand: async () => result },
+    $refs: {},
+    $t: (k) => k,
+  }
+  for (const [k, fn] of Object.entries(loadMethods(sent))) vm[k] = fn.bind(vm)
+  return vm
+}
+
+test('worker 只填 message 的失败：回传的 error 要带上原因，不能是 null', async () => {
+  const sent = []
+  const vm = makeVm({ success: false, message: 'match index out of range: 1' }, sent)
+  await vm.handleEditorCommand({ action: 'delete_match', params: {}, requestId: 'r1', conversationId: 'c1' })
+  assert.equal(sent.length, 1)
+  assert.equal(sent[0].success, false)
+  assert.equal(sent[0].error, 'match index out of range: 1')
+})
+
+test('worker 填了 error 的失败：原样回传', async () => {
+  const sent = []
+  const vm = makeVm({ success: false, error: '样式不存在: Heading 9', message: '样式不存在: Heading 9' }, sent)
+  await vm.handleEditorCommand({ action: 'set_style', params: {}, requestId: 'r2', conversationId: 'c2' })
+  assert.equal(sent[0].error, '样式不存在: Heading 9')
+})
+
+test('成功的命令不因为带 message 就被当成失败', async () => {
+  const sent = []
+  const vm = makeVm({ success: true, message: 'ok', inserted: '表1-1' }, sent)
+  await vm.handleEditorCommand({ action: 'insert_at_cursor', params: {}, requestId: 'r3', conversationId: 'c3' })
+  assert.equal(sent[0].success, true)
+  assert.equal(sent[0].error, null)
+})


### PR DESCRIPTION
## 现象

尽调起草实测里模型收到这样的工具结果：

```
doc_delete_match(...) => FAILURE {"error": "null"}
```

worker 侧 `delete_match` 失败时返回的是 `{success:false, message:'match index out of range: 1'}`——只填了 `message`，没填 `error`。而 `agentClientActions.handleEditorCommand` 回传时只取 `result.error`，于是原因在链路上丢了，模型只知道失败、不知道为什么，接着瞎猜着重试（实测触发了一串无效的删改）。

同样的形状此前也出现过一次：`doc_apply_style_profile` 报「画像下发失败: {"error": "null"}」。

## 改动

失败时 `error` 缺省退到 `message`（成功路径不变，避免把带 message 的成功结果误判成失败）。worker 里大量失败分支只填 `message`，这一行让它们全部恢复可读。

## 测试

`frontend/tests/project-home/editor-command-failure-reason.test.mjs` 三例：只填 message 的失败要带上原因、填了 error 的原样回传、成功带 message 不被当失败。**把回退去掉第一例立刻转红**（已实测 pass 2 / fail 1）。

Generated with Claude Code
