### PR TITLE
fix(agent): 截断守卫覆盖 todo_write/final，且认得被切断的开标签（dev-board#100）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -313,4 +313,4 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 - 前端：`npm run check:emits`；标签协议编解码 `npm run test:tag-protocol`（node:test，零依赖）；UI 链路 `npm run test:app-e2e`。
 - Office 插件的标签解析：`node --test office-addin/taskpane/lib/sse.test.js`（零依赖，未进 CI）。
 
-- **工具参数太长会把模型输出撑到截断**（实测：一章起草里 4 次）。编排器检测到 `<tool_code>` 未闭合会回喂提示让模型重发，最多两轮；**两轮还截断就把原因写进最终正文**（「参数太长…没有执行完」），不再静默收尾。根治办法不是调 max_tokens，而是别让模型回抄大参数：让工具自己把内容写进文档（尽调插件 `dd_table`/`dd_phrases` 的 `docFileId` 就是这么做的）。回归用例 `cases-harness-recovery.json` 的 `truncated-tool-code-persists-tells-the-user`。
+- **工具参数太长会把模型输出撑到截断**（实测：一章起草里 4 次）。编排器检测到 `<tool_code>` 未闭合会回喂提示让模型重发，最多两轮；**两轮还截断就把原因写进最终正文**（「参数太长…没有执行完」），不再静默收尾。根治办法不是调 max_tokens，而是别让模型回抄大参数：让工具自己把内容写进文档（尽调插件 `dd_table`/`dd_phrases` 的 `docFileId` 就是这么做的）。截断守卫覆盖 `<tool_code>` / `<todo_write>` / `<final>` 三个「开了必须闭」的标签，且**开标签自己被切断也算**（实测最短一次只输出了 `<todo_write`）；只守 tool_code 的话模型在 todo 清单里被切断就静默收尾，一轮丢四个回合。回归用例 `cases-harness-recovery.json` 的 `truncated-tool-code-persists-tells-the-user` 与 `truncated-todo-write-also-corrected`。

--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -290,3 +290,5 @@ txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue�
 - 原语级测试不够，必须走完 UI 链路验证（用户明确要求过）。
 
 - **枚举列宽**：`evidence_link_target.method` 是 varchar(32) —— 枚举里最长的 `written_statement` 有 17 个字符，原来的 16 让「书面确认」型链接**永远存不进去**（真实起草跑分报 `Value too long for column method`）。改枚举时一并核对列宽，回归测试 `EvidenceLinkServiceTest.enumColumnsAreWideEnoughForEveryAllowedValue` 钉住。
+
+- **worker 失败原因不能丢**：`agentClientActions.handleEditorCommand` 回传失败时 `error` 缺省要退到 `message` —— worker 里大量失败分支只填 `message`（`delete_match` 的「match index out of range」之类），只取 `error` 的话模型收到 `{"error": "null"}`，只能瞎猜着重试。回归用例 `frontend/tests/project-home/editor-command-failure-reason.test.mjs`。

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -953,16 +953,15 @@ public class AgentOrchestrator {
             // 任务做一半、无错误提示、无继续按钮。这里回喂提示让模型重发，最多纠正 2 轮。
             // 含 <question> 时不走纠正回路：模型问了问题、同时输出被截断，此刻正确的动作是
             // 停下来等回答（下面 3.2），而不是催它重发工具调用——那等于让它带着未决问题继续猜。
-            if (agentMode != AgentMode.ASK && !containsQuestion(content)
-                    && content.contains("<tool_code>") && !content.contains("</tool_code>")) {
+            if (agentMode != AgentMode.ASK && !containsQuestion(content) && endsWithUnclosedTag(content)) {
                 if (guard.malformedToolRounds < 2) {
                     guard.malformedToolRounds++;
                     log.warn("Truncated tool_code detected for {} (correction round {}), asking model to re-emit",
                             conversationId, guard.malformedToolRounds);
                     messages.add(dev.langchain4j.data.message.UserMessage.from(
-                            "[系统提醒] 你上一条输出中的 <tool_code> 标签未闭合（内容可能被截断），"
-                            + "该工具调用没有被执行。请重新、完整地输出这次工具调用；"
-                            + "若任务其实已完成，请直接输出最终总结。"));
+                            "[系统提醒] 你上一条输出中的标签未闭合（<tool_code> / <todo_write> / <final> 之一，内容被截断），"
+                            + "这次输出没有生效。请重新、完整地输出这一步；参数很长时先拆小，"
+                            + "或改用能直接把内容写进文档的工具。若任务其实已完成，请直接输出最终总结。"));
                     runLoop(model, messages, conversationId, projectId, userId, modelId,
                             depth + 1, executionLog, agentMode, guard);
                     return;
@@ -1534,6 +1533,28 @@ public class AgentOrchestrator {
      * 用户看了，此时按「有问题」停机远好过当成正常收尾——后者会让用户对着一个没有下文的
      * 问句，而会话状态显示已完成。
      */
+    /** 开了必须闭的结构标签（截断守卫用）。 */
+    private static final java.util.List<String> TRUNCATION_GUARDED_TAGS =
+            java.util.List.of("tool_code", "todo_write", "final");
+
+    /**
+     * 输出是不是在某个结构标签里被截断了。
+     *
+     * <p>原来只看 `<tool_code>`：模型在 `<todo_write>` 的长 JSON 里被切断时不算，回合就静默收尾——
+     * 尽调起草实测一轮里连丢四个回合（每次只输出 12-500 字符就断），用户看到的是「什么都没发生」。
+     */
+    static boolean endsWithUnclosedTag(String content) {
+        if (content == null || content.isBlank()) return false;
+        for (String tag : TRUNCATION_GUARDED_TAGS) {
+            // 开标签用前缀匹配：截断可能发生在开标签自己身上（实测最短的一次只输出了 "<todo_write"）
+            int open = content.lastIndexOf("<" + tag);
+            if (open < 0) continue;
+            int close = content.lastIndexOf("</" + tag + ">");
+            if (close < open) return true;
+        }
+        return false;
+    }
+
     static boolean containsQuestion(String content) {
         return content != null && QUESTION_TAG_START.matcher(content).find();
     }

--- a/backend/src/test/resources/ai-eval/cases/cases-harness-recovery.json
+++ b/backend/src/test/resources/ai-eval/cases/cases-harness-recovery.json
@@ -99,5 +99,41 @@
         "没有执行完"
       ]
     }
+  },
+  {
+    "id": "truncated-todo-write-also-corrected",
+    "title": "在 <todo_write> 里被截断也要进纠正回路，不能静默收尾（尽调起草实测一轮丢 4 个回合）",
+    "category": "files",
+    "protocol": "xml",
+    "userInput": "起草第一章",
+    "turns": [
+      {
+        "text": "<todo_write"
+      },
+      {
+        "text": "<process name=\"取素材\"><tool_code>list_files({\"projectId\": 1})</tool_code></process>"
+      },
+      {
+        "text": "<final>第一章素材已取。</final>"
+      }
+    ],
+    "toolStubs": {
+      "list_files": "Contents: [FILE] a.pdf (fileId=1)"
+    },
+    "expect": {
+      "toolCalls": [
+        {
+          "name": "list_files",
+          "argsContain": {}
+        }
+      ],
+      "promptContains": [
+        "标签未闭合"
+      ],
+      "structureContains": [
+        "<final>"
+      ],
+      "bubbleEndStatus": "finished"
+    }
   }
 ]

--- a/frontend/src/pages/project-overview/agentClientActions.js
+++ b/frontend/src/pages/project-overview/agentClientActions.js
@@ -474,7 +474,11 @@ export const agentClientActionMethods = {
             const result = await this.libreOfficeExecutor.executeCommand(
                 commandAction, Object.assign({}, params, { __agent: true }))
             const successFlag = result && result.success !== false
-            await sendEditorResult(conversationId, requestId, successFlag, result, (result && result.error) || null)
+            // 失败原因优先取 error，没有就退到 message：worker 里大量失败分支只填 message
+            //（如 delete_match 的「match index out of range」），只取 error 的话模型收到的是
+            // {"error": "null"}，等于没告诉它哪里错了，它只能瞎猜着重试。
+            const failReason = result ? (result.error || result.message || null) : null
+            await sendEditorResult(conversationId, requestId, successFlag, result, successFlag ? (result && result.error) || null : failReason)
         } catch (e) {
             console.error('[ProjectOverview] LibreOffice command error:', e)
             await sendEditorResult(conversationId, requestId, false, null, e.message)

--- a/frontend/tests/project-home/editor-command-failure-reason.test.mjs
+++ b/frontend/tests/project-home/editor-command-failure-reason.test.mjs
@@ -1,0 +1,58 @@
+// 尽调起草实测（dev-board#100）：worker 的失败分支大多只填 message（如 delete_match 的
+// 「match index out of range」），而回传只取 result.error —— 模型收到的是 {"error": "null"}，
+// 等于没告诉它哪里错了，只能瞎猜着重试（实测因此触发了一串无效的删改）。
+// 修法：失败时 error 缺省退到 message。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createSerialQueue } from '../../src/utils/asyncSerialize.js'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/agentClientActions.js', import.meta.url), 'utf8')
+
+function loadMethods(sent) {
+  const body = SRC
+    .replace(/^import .*$/gm, '')
+    .replace(/export function shouldFlushDocStream[\s\S]*?\n\}\n/, '')
+    .replace(/export const agentClientActionMethods = \{/, 'return {')
+  const factory = new Function('sendEditorResult', 'getFileDetail', 'createSerialQueue', 'uni', body)
+  return factory(
+    async (conversationId, requestId, success, result, error) => { sent.push({ success, result, error }) },
+    async () => null, createSerialQueue, { showToast: () => {} })
+}
+
+function makeVm(result, sent) {
+  const vm = {
+    projectId: 1,
+    libreOfficeActive: true,
+    libreOfficeExecutor: { executeCommand: async () => result },
+    $refs: {},
+    $t: (k) => k,
+  }
+  for (const [k, fn] of Object.entries(loadMethods(sent))) vm[k] = fn.bind(vm)
+  return vm
+}
+
+test('worker 只填 message 的失败：回传的 error 要带上原因，不能是 null', async () => {
+  const sent = []
+  const vm = makeVm({ success: false, message: 'match index out of range: 1' }, sent)
+  await vm.handleEditorCommand({ action: 'delete_match', params: {}, requestId: 'r1', conversationId: 'c1' })
+  assert.equal(sent.length, 1)
+  assert.equal(sent[0].success, false)
+  assert.equal(sent[0].error, 'match index out of range: 1')
+})
+
+test('worker 填了 error 的失败：原样回传', async () => {
+  const sent = []
+  const vm = makeVm({ success: false, error: '样式不存在: Heading 9', message: '样式不存在: Heading 9' }, sent)
+  await vm.handleEditorCommand({ action: 'set_style', params: {}, requestId: 'r2', conversationId: 'c2' })
+  assert.equal(sent[0].error, '样式不存在: Heading 9')
+})
+
+test('成功的命令不因为带 message 就被当成失败', async () => {
+  const sent = []
+  const vm = makeVm({ success: true, message: 'ok', inserted: '表1-1' }, sent)
+  await vm.handleEditorCommand({ action: 'insert_at_cursor', params: {}, requestId: 'r3', conversationId: 'c3' })
+  assert.equal(sent[0].success, true)
+  assert.equal(sent[0].error, null)
+})


### PR DESCRIPTION
## 现象

尽调起草的一轮真实跑分里，连续四个回合什么都没做完：模型每次只输出十几到几百字符就断，日志里**一条截断记录都没有**，回合按「正常收尾」结束。

原因：截断守卫只看 `<tool_code>` 未闭合。这几次模型是在 `<todo_write>` 的长 JSON 里被切断的，最短的一次只输出了 `<todo_write` —— 连开标签都没写完。守卫看不见，纠正回路就不触发。

## 改动

- 守卫改成覆盖三个「开了必须闭」的标签：`tool_code` / `todo_write` / `final`。
- 开标签用前缀匹配（`<todo_write` 也算），因为截断可能发生在开标签自身。
- 纠正提示补一句「参数很长时先拆小，或改用能直接把内容写进文档的工具」。

## 测试

`cases-harness-recovery.json` 新增 `truncated-todo-write-also-corrected`（首轮只输出 `<todo_write` → 断言进纠正回路、下一轮工具正常执行、最终有 `<final>`）。**把 `todo_write` 从守卫清单里去掉该用例立刻转红**（已实测）。`OrchestratorReplayEvalTest` 43 例全绿。

Generated with Claude Code
