### PR TITLE
chore(release): v0.24.0——尽调报告模块 P0-P3 全量

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## v0.24.0

尽调报告模块 P0-P3 全量落地（dev-board#100），自 v0.23.0 起 48 个提交。

### P0 底座：EvidenceLink（内置能力）
`evidence_link` 两张表与双向查询、书签锚点化的拖拽关联、`filelink?k=&t=` 定位、证据面板与改字浮条、三方 Web 插件 SDK v1、稳定性六条（导入不再静默丢文件、同级新建去 O(N²)、文件树虚拟滚动、批量改稿分批/进度/取消、apply_house_style 分批、段落索引缓存）。

**大文档实测**（150 页 / 30 表 / 20 图 / 6.6MB）：修订模式 `find_replace` 150 处命中 **28.5 秒 → 157-162 毫秒**；`apply_house_style` **超时 → 18-21 秒**；`get_document_text` 二次调用 21 毫秒。

### P1 起草
插件宿主 SPI（`com.checkba:plugin-api` 1.1.0）、模板画像 `docx_inspect_template`（学完自己落盘 `_模板/画像.json`）、worker 样式画像原语、`doc_link_evidence`。

### P2 勾稽与交付件
`EvidenceVerifyService` 四类要素对账 + `evidence_verify`；审阅面板「底稿」页（章节树 ⇄ 主体、状态筛选、置信度与引文、点击定位）；三份交付件导出（底稿目录 / 查验计划 / 缺口清单，docx + xlsx）。

### P3 网核与定位
`WebVerifyProvider` 接口 + 手工 zip 离线落盘与自动挂链（按拍板只留接口，不做爬取）；底稿定位增强（pdf 跳页与引文卡、图片画框随缩放旋转、音视频停帧）；稳定性余项五条。

### 一并修掉的既有缺陷
- `evidence_link_target.method` 列宽放不下 `written_statement`，**「书面确认」型链接从 P0 起就存不进去**；
- worker 失败只填 message 时回传给模型的是 `error: null`，原因整条链路丢失；
- 工具调用被截断且纠正无效时静默收尾，现在把原因写给用户；截断守卫从只看 `<tool_code>` 扩到 `todo_write`/`final`，且认得被切断的开标签。

### 验证
黄金对照（样本项目，本机隔离环境）三阶段：**入库 82/0 · 起草 25/0 · 交付件与勾稽 30/0**。起草产出 74 条底稿链接、六份骨干文件全部跨 ≥2 章、缺口清单命中 9/10、底稿目录条目 = 实体数且带反向链接、版式全过（楷体 GB2312 12pt / 目录域 1-2 / 单元格级边框 / 标题字面编号 100%）。发版四门见 PR 检查。

Generated with Claude Code
