### PR TITLE
fix(workbench): 中键关闭标签在 H5/桌面端从来没生效过（dev-board#127）

### DIFF
--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -11,6 +11,17 @@ import { ICONS as GLYPHS, fileGlyph } from '@/config/icons.js'
 // 必须与后端 TextFileEditTools.PLAIN_TEXT_TYPES 完全一致，改这里要同步改那边。
 const PLAIN_TEXT_TYPES = ['txt', 'md', 'markdown', 'json', 'js', 'mjs', 'css', 'html', 'htm', 'yml', 'yaml']
 
+// 取鼠标事件的键位。uni-app H5 会把 <view> 上的原生事件重新包装成普通对象
+// （uni-h5 的 createNativeEvent），只给 click / mouse 系 / touch / keyboard 几类补字段，
+// 补的也只是坐标，`button` 一类都没有；`auxclick` 连"补字段"这一步都不走，
+// 回调拿到的只有 { type, timeStamp, target, currentTarget, detail }。
+// 所以中键判定不能只看回调里的事件对象，要回退到当前正在派发的原生事件。
+function mouseButtonOf(e) {
+  if (e && typeof e.button === 'number') return e.button
+  const native = typeof window !== 'undefined' ? window.event : null
+  return native && typeof native.button === 'number' ? native.button : -1
+}
+
 export const fileOpenTabsMethods = {
     handleFileTreeSelect(file) {
       if (!file || file.isFolder) return
@@ -251,12 +262,12 @@ export const fileOpenTabsMethods = {
      * （左键是 @tap 激活，右键没有菜单）。标签没有「固定」概念，全部可关。
      */
     onTabMouseDown(e) {
-      if (e && e.button === 1) e.preventDefault()
+      if (mouseButtonOf(e) === 1 && e && e.preventDefault) e.preventDefault()
     },
     onTabAuxClick(e, file, pane) {
-      if (!e || e.button !== 1) return
-      e.preventDefault()
-      e.stopPropagation()
+      if (!e || !file || mouseButtonOf(e) !== 1) return
+      if (e.preventDefault) e.preventDefault()
+      if (e.stopPropagation) e.stopPropagation()
       this.closeFile(file.id, pane)
     },
     async closeFile(fileId, pane) {

--- a/frontend/tests/project-home/tab-middle-click-close.test.mjs
+++ b/frontend/tests/project-home/tab-middle-click-close.test.mjs
@@ -1,0 +1,89 @@
+// dev-board#97 的「中键单击标签关闭」在 H5/桌面端从来没生效过：
+// uni-app H5 把 <view> 上的原生事件重新包装成普通对象（uni-h5 createNativeEvent），
+// 只给 click / mouse 系 / touch / keyboard 几类补字段，补的还只是坐标——`button`
+// 一类都没有，`auxclick` 连补都不补。于是 onTabAuxClick 里的 `e.button !== 1`
+// 恒真，一路 return，标签纹丝不动（app-e2e「鼠标中键单击标签关闭它」实测卡死在这）。
+//
+// 修法：键位改从当前正在派发的原生事件（window.event）上取，回调里带 button 时优先用回调的。
+// 本文件钉住三件事：包装过的 auxclick 能关标签、右键的 auxclick 不能关、
+// 中键 mousedown 仍然 preventDefault（不然 Chrome 的自动滚动会把 auxclick 吃掉）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/fileOpenTabs.js', import.meta.url), 'utf8')
+
+function loadMethods() {
+  const body = SRC
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export const fileOpenTabsMethods = \{/, 'return {')
+  const factory = new Function('getProjectFiles', 'activityTracker', 'GLYPHS', 'fileGlyph', 'uni', 'window', body)
+  return (win) => factory(async () => [], { track: () => {} }, {}, () => '', {}, win)
+}
+const load = loadMethods()
+
+// uni-app H5 交给回调的事件对象：没有 button，只有 type/target 与两个转发方法。
+function uniWrappedEvent(type, native) {
+  let prevented = false
+  return {
+    ev: {
+      type,
+      timeStamp: 0,
+      detail: {},
+      target: {},
+      currentTarget: {},
+      preventDefault() { prevented = true; native.defaultPrevented = true },
+      stopPropagation() {},
+    },
+    get prevented() { return prevented },
+  }
+}
+
+function makeVm(methods) {
+  const closed = []
+  const vm = { closeFile(id, pane) { closed.push([id, pane]) } }
+  vm.onTabAuxClick = methods.onTabAuxClick.bind(vm)
+  vm.onTabMouseDown = methods.onTabMouseDown.bind(vm)
+  return { vm, closed }
+}
+
+test('中键 auxclick：uni 包装掉 button 也要关掉标签', () => {
+  const native = { button: 1, defaultPrevented: false }
+  const methods = load({ event: native })
+  const { vm, closed } = makeVm(methods)
+  const w = uniWrappedEvent('auxclick', native)
+  vm.onTabAuxClick(w.ev, { id: 'admin-settings' }, 'left')
+  assert.deepEqual(closed, [['admin-settings', 'left']])
+  assert.equal(w.prevented, true, 'auxclick 也要 preventDefault')
+})
+
+test('右键 auxclick 不关标签', () => {
+  const native = { button: 2, defaultPrevented: false }
+  const methods = load({ event: native })
+  const { vm, closed } = makeVm(methods)
+  vm.onTabAuxClick(uniWrappedEvent('auxclick', native).ev, { id: 'f1' }, 'right')
+  assert.deepEqual(closed, [], '右键不该关标签')
+})
+
+test('回调里带 button 时以回调为准（原生事件未被包装的平台）', () => {
+  const methods = load({ event: { button: 2 } }) // window.event 故意给成右键
+  const { vm, closed } = makeVm(methods)
+  vm.onTabAuxClick({ button: 1, preventDefault() {}, stopPropagation() {} }, { id: 'f2' }, 'left')
+  assert.deepEqual(closed, [['f2', 'left']])
+})
+
+test('中键 mousedown 仍然 preventDefault（挡住自动滚动，否则 auxclick 不会来）', () => {
+  const native = { button: 1, defaultPrevented: false }
+  const methods = load({ event: native })
+  const { vm } = makeVm(methods)
+  const w = uniWrappedEvent('mousedown', native)
+  vm.onTabMouseDown(w.ev)
+  assert.equal(w.prevented, true)
+
+  const native2 = { button: 0, defaultPrevented: false }
+  const m2 = load({ event: native2 })
+  const w2 = uniWrappedEvent('mousedown', native2)
+  makeVm(m2).vm.onTabMouseDown(w2.ev)
+  assert.equal(w2.prevented, false, '左键不许拦（拦了就选不中标签）')
+})


### PR DESCRIPTION
发版前跑 app-e2e 稳定卡在「鼠标中键单击标签关闭它（dev-board#97）」这一步（8s 超时，设置标签纹丝不动）。因为 `fileOpenTabs.js` 本轮被动过，没当抖动放过。

## 真因

真机探针（dev H5 + puppeteer 真中键）显示：`auxclick` 确实派发到了标签上、`onTabAuxClick` 也确实被调用，但 `e.button === undefined`。

uni-app H5 的 `createNativeEvent` 会把 `<view>` 上的原生事件重建成普通对象，只给 click / mouse 系 / touch / keyboard 四类补字段，补的还只是坐标（`normalizeMouseEvent` 只抄 pageX/clientX 一类，`button` 谁都没抄）；`auxclick` 四类都不沾，回调拿到的只有 `{ type, timeStamp, target, currentTarget, detail }`。

于是 `onTabAuxClick` 里的 `e.button !== 1` 恒真，一路 return —— dev-board#97 这个功能从落地起在 H5/桌面端就没生效过。`onTabMouseDown` 里挡 Chrome 自动滚动的 `preventDefault` 同理从没执行过。

## 修法

键位改从当前正在派发的原生事件（`window.event`）上取，回调里带 `button` 时优先用回调的——原生事件没被包装的平台照旧走那条路。

## 验证

- 回归测试 `frontend/tests/project-home/tab-middle-click-close.test.mjs`：4 条（中键关、右键不关、回调带 button 时以回调为准、中键 mousedown 仍 preventDefault）。**还原病灶即转红**（4 条里红 2 条）。
- 真机：dev H5 起工作台 → 点头像开设置标签 → puppeteer 真中键 → 标签关闭；再开一次右键点标签 → 不关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)