### PR TITLE
test(e2e): dev Electron 用自己的 profile，别被装好的应用顶掉（dev-board#128）

### DIFF
--- a/frontend/tests/_lib/electron-cdp.mjs
+++ b/frontend/tests/_lib/electron-cdp.mjs
@@ -10,6 +10,8 @@
 //   ④ 连上之后钉稳输入通道——见 INPUT_FLAGS 与 hardenPageInput 的注释。
 
 import { spawn, execSync } from 'node:child_process'
+import os from 'node:os'
+import path from 'node:path'
 
 // 驱动一个"不在最前面"的窗口时，必须关掉 Chromium 的后台降级。被遮挡/非活动的
 // 窗口一旦被降级，**跟焦点绑定的输入**（mousePressed / mouseReleased / keyDown）
@@ -38,8 +40,18 @@ export const pickCdpPort = (envName, from) => {
 
 // detached 让它自成进程组，收尾时 kill(-pid) 能把 npx→node→Electron 整棵树带走。
 // 测试进程自己被 Ctrl-C / 异常退出时也要收，否则下一轮又撞上一个占着端口的孤儿。
+// 装好的 AI WorkDeck.app 开着的时候，dev 实例会被 main.js 的
+// requestSingleInstanceLock 当场 app.quit()——单实例锁按 userData 目录判重，两边
+// 默认是同一个。现象极不好认：Electron 起来、打了 "DevTools listening"、随即无声退出，
+// 套件只看见「CDP 端点未就绪」或连 ws 时 ECONNREFUSED。给 dev 实例挑一个自己的
+// profile 目录，锁就各归各的，维护者不必为跑一次门禁去关自己的应用。
+// （按端口取名：同一个套件重跑复用同一份 profile，不会把 tmp 撑爆。）
+export const devProfileDir = (cdpPort) =>
+  path.join(os.tmpdir(), 'awd-e2e-electron-profile-' + cdpPort)
+
 export const spawnElectron = ({ desktopDir, cdpPort, env, extraArgs = [] }) => {
-  const elec = spawn('npx', ['electron', '.', '--remote-debugging-port=' + cdpPort, ...INPUT_FLAGS, ...extraArgs], {
+  const elec = spawn('npx', ['electron', '.', '--remote-debugging-port=' + cdpPort,
+    '--user-data-dir=' + devProfileDir(cdpPort), ...INPUT_FLAGS, ...extraArgs], {
     cwd: desktopDir,
     env: { ...process.env, ...env },
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -55,13 +67,21 @@ export const spawnElectron = ({ desktopDir, cdpPort, env, extraArgs = [] }) => {
   return { elec, killTree }
 }
 
-export const waitForCdpWs = async (cdpPort, tries = 60) => {
+// elec 传进来时顺带看着它：进程自己先退了就不必再干等满 60 秒，
+// 而且能把退出码报出来（"起不来"和"起来了但没听端口"是两种病）。
+export const waitForCdpWs = async (cdpPort, tries = 60, elec = null) => {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
   for (let i = 0; i < tries; i++) {
     await sleep(1000)
     const ws = await fetch('http://127.0.0.1:' + cdpPort + '/json/version')
       .then((r) => r.json()).then((j) => j.webSocketDebuggerUrl).catch(() => null)
     if (ws) return ws
+    if (elec && elec.exitCode !== null) {
+      console.error('Electron 起来后自己退了（exitCode=' + elec.exitCode
+        + '）。最常见的是装好的 AI WorkDeck 正开着、单实例锁把 dev 实例顶掉了，'
+        + '或者 dev server 地址不对。日志见 ' + path.join(os.tmpdir(), '*-electron.log'))
+      return null
+    }
   }
   return null
 }

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -112,7 +112,7 @@ const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'desktop-e2e-electro
 elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-const ws = await waitForCdpWs(CDP_PORT)
+const ws = await waitForCdpWs(CDP_PORT, 60, elec)
 if (!ws) { console.error('CDP 端点未就绪（端口 ' + CDP_PORT + '）'); killTree(); process.exit(1) }
 
 {
@@ -162,7 +162,13 @@ try {
       const x = r.x + r.width / 2, y = r.y + r.height / 2
       const hit = document.elementFromPoint(x, y)
       if (hit && el.contains(hit)) return { x, y }
-      let who = hit ? hit.tagName.toLowerCase() : '(空白)'
+      // 点在视口外时 elementFromPoint 直接返回 null，跟"被浮层盖住"是两种病，
+      // 只报一句 (空白) 分不出来——把当时的矩形与视口一起带上。
+      let who = hit ? hit.tagName.toLowerCase()
+        : ('(空白) rect=' + Math.round(r.x) + ',' + Math.round(r.y) + ' ' + Math.round(r.width) + 'x' + Math.round(r.height)
+           + ' 视口=' + window.innerWidth + 'x' + window.innerHeight
+           + ' 文档高=' + Math.round(document.scrollingElement.scrollHeight)
+           + ' 滚动=' + Math.round(document.scrollingElement.scrollTop))
       try { if (hit && hit.shadowRoot) who += ': ' + hit.shadowRoot.textContent.replace(/\\s+/g, ' ').trim().slice(0, 200) } catch (e) {}
       return { x, y, blockedBy: who }
     }`

--- a/frontend/tests/feedback-e2e/run.mjs
+++ b/frontend/tests/feedback-e2e/run.mjs
@@ -80,7 +80,7 @@ const elecLog = fs.createWriteStream(path.join(os.tmpdir(), 'feedback-e2e-electr
 elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-const ws = await waitForCdpWs(CDP_PORT)
+const ws = await waitForCdpWs(CDP_PORT, 60, elec)
 if (!ws) { console.error('CDP 端点未就绪（端口 ' + CDP_PORT + '）'); killTree(); process.exit(1) }
 {
   const bad = cdpOwnershipError(CDP_PORT, elec)

--- a/frontend/tests/meeting-e2e/run.mjs
+++ b/frontend/tests/meeting-e2e/run.mjs
@@ -128,7 +128,7 @@ const { elec, killTree } = spawnElectron({
   elec.stdout.pipe(elecLog); elec.stderr.pipe(elecLog)
 }
 
-const ws = await waitForCdpWs(CDP_PORT)
+const ws = await waitForCdpWs(CDP_PORT, 60, elec)
 if (!ws) { killTree(); die('CDP 端点未就绪（端口 ' + CDP_PORT + '）') }
 {
   const bad = cdpOwnershipError(CDP_PORT, elec)


### PR DESCRIPTION
发版跑门禁时发现：只要 `/Applications/AI WorkDeck.app` 正开着，desktop-e2e / meeting-e2e / feedback-e2e 三套 Electron 套件全起不来。

## 真因

`main.js` 的 `requestSingleInstanceLock` 按 userData 目录判重，dev 实例与装好的应用默认同一个目录，第二个进程被 `app.quit()` 当场顶掉。

现象极不好认：Electron 起来了、打了 `DevTools listening`、随即无声退出，套件只看见「CDP 端点未就绪」，或者晚一点连 ws 时 `ECONNREFUSED`，日志里一个字的错都没有。

## 改动（全在测试侧，不动产品代码）

1. `spawnElectron` 给 dev 实例挑自己的 `--user-data-dir`（按 CDP 端口取名，同一套件重跑复用同一份，不会把 tmp 撑爆）——单实例锁各归各的，维护者不必为跑一次门禁去关自己的应用。
2. `waitForCdpWs` 收下子进程句柄：进程自己先退了就立刻报退出码与最常见成因，不再干等满 60 秒才丢一句没头没尾的超时。
3. desktop-e2e 的命中校验把「点在视口外」（`elementFromPoint` 返回 null）和「被浮层盖住」分开报——以前两种都只印一句 `(空白)`。

## 验证

装好的应用开着，`npm run test:desktop-e2e` 全绿：

```
✓ 列表页桌面形态 / ✓ 免登进入项目 / ✓ BrowserView 保活 / ✓ 关标签才销毁
✓ 新建 Word 并打开 / ✓ 引擎就绪 / ✓ 工具栏接上引擎 / ✓ 点按钮文档状态真变了
✓ 宿主执行器插入 / ✓ 自动保存 / ✓ API 下载 docx 验证落盘
结果：桌面保存链路全通
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)