### PR TITLE
docs(agents): 补两条本轮踩出来的地雷（dev-board#127 #128）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -112,6 +112,23 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 
 ## 已知地雷
 
+**装好的应用开着，三套 Electron e2e 全起不来（2026-08-23 修）**：`main.js` 的
+`requestSingleInstanceLock` 按 userData 目录判重，dev 实例与 `/Applications/AI WorkDeck.app`
+默认同一个目录，第二个进程被 `app.quit()` 当场顶掉。现象极不好认——Electron 起来、
+打了 `DevTools listening`、随即无声退出，套件只看见「CDP 端点未就绪」或连 ws 时
+`ECONNREFUSED`。`tests/_lib/electron-cdp.mjs` 的 `spawnElectron` 现在给 dev 实例挑
+自己的 `--user-data-dir`（按 CDP 端口取名），`waitForCdpWs` 收下子进程句柄、进程先退
+就立刻报退出码。**新 profile 是空的**：`appLanguage` 对全新安装按 `navigator.language`
+猜语言（Electron 常报 en-*），断言中文字面量的套件必须像 desktop-e2e 那样先写
+`localStorage.awd_app_language='zh-CN'` 再整页 `goto`（只改 hash 是同文档导航，模块不重来）。
+
+**dev vite 的状态会被文件churn 弄脏**：worktree 里大批文件被改回改去（合并冲突、
+stash 误 pop 之类）之后，5174 上的页面可能变成**整页无样式**（`.page-project-overview`
+的 display 变 block、文档高两万多像素），而 CSS 其实都在、控制台一个错都没有。
+按「点在视口外」的形态红在 e2e 里，很容易误读成布局回归。**先重启 vite 再判**。
+
+
+
 - **`@ActiveProfiles("desktop")` 的 `@SpringBootTest` 必须同时把 `spring.datasource.url` 覆盖成
   `jdbc:h2:mem:`**（写法照 IdorAuthIntegrationTest / DesktopContextSmokeTest）：desktop profile
   的默认数据源是 `~/.aiworkdeck/local` 文件库且带 `AUTO_SERVER=TRUE`，开发机上测试会直接附着到

--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -161,6 +161,24 @@ toEventStart），五个消费组件都从这里拿，别再各写一份。
 `type="date"/"time"` 会静默降级成文本框。日期/时间输入一律用 `components/AwdDatePicker.vue`
 （mounted 手工挂真原生 input 绕开 uni 模板劫持；只监听 change 防中间值上抛）。
 
+## 地雷：uni-app H5 把 `<view>` 上的事件重建成普通对象，`button` 一类字段全丢
+
+uni-h5 的 `createNativeEvent` 收到 `<view>`（以及别的内置元素）上的原生事件后，
+**重新造一个普通对象**交给回调，只有 `{ type, timeStamp, target, currentTarget,
+detail }` 加两个转发方法；随后按类型补字段，而补的分支只有四类——
+`click` / `mouse` 开头（含 `contextmenu`）/ `touch` 系 / 键盘——**并且补的只是坐标**
+（`normalizeMouseEvent` 抄 pageX/clientY 一类，`button` 谁都没抄）。
+
+后果：`@auxclick`、`@mousedown` 这类靠 `e.button` 分左右中键的写法在 H5/桌面端**恒不成立**。
+dev-board#97 的「中键关闭标签」就这么静默失效了一整轮：auxclick 确实派发到了标签上、
+`onTabAuxClick` 确实被调用，但 `e.button === undefined`，`e.button !== 1` 恒真一路 return。
+
+判定与修法（`fileOpenTabs.js` 的 `mouseButtonOf`）：键位从**当前正在派发的原生事件**
+（`window.event`）上取，回调里带 `button` 时优先用回调的（原生事件没被包装的平台走那条）。
+同理，凡是要读 `dataTransfer` / `clientX` / `key` 一类原生字段的 `<view>` 事件处理器，
+先确认这一类在不在上面那四个补字段分支里；`tabDragSplit.js` 的 `onTabDragStart`
+就是靠 `if (evt && evt.dataTransfer)` 兜住的（拖拽状态记在组件上，不依赖 dataTransfer）。
+
 ## 顶栏头像与统一「设置」标签（2026-08-19 立，2026-08-20 并，2026-08-21 撤下拉）
 
 rail 底部的**齿轮与用户头像都撤了**，收进顶栏右上角「活动记录」右侧的


### PR DESCRIPTION
按 CLAUDE.md 的维护规则，#579 与 #580 本该在各自 PR 里顺手更新领域文档，漏了，补上。

- **sidebar-shell**：uni-app H5 的 `createNativeEvent` 把 `<view>` 上的事件重建成普通对象，只给 click / mouse 系 / touch / keyboard 四类补字段、且补的只是坐标（`button` 谁都没抄）。所有靠 `e.button` 分键位的写法在 H5/桌面端恒不成立——中键关标签因此静默失效一整轮。附判定与修法，以及「要读 dataTransfer/clientX/key 先确认在不在那四个分支里」。
- **eng-infra**：① 装好的应用开着时三套 Electron e2e 全起不来（单实例锁按 userData 判重），以及新 profile 是空的、语言会被 `navigator.language` 猜成英文，断言中文的套件要先写 `awd_app_language` 再整页 goto；② dev vite 状态被文件 churn 弄脏会整页无样式而控制台一个错都没有，**先重启 vite 再判**（本轮真误读过一次）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)