### PR TITLE
fix(plugin): 插件带的 skill 装完就要出现，别等重启后端（dev-board#131）

### DIFF
--- a/backend/src/main/java/com/checkba/service/ai/PluginService.java
+++ b/backend/src/main/java/com/checkba/service/ai/PluginService.java
@@ -108,6 +108,21 @@ public class PluginService {
     private ToolRegistry toolRegistry;
 
     /**
+     * 反向依赖 SkillRegistry，仅用于 rescan() 后让它把插件携带的 skill 重新拉一遍。
+     * 注入方式与上面的 ToolRegistry 同款（@Lazy + required=false）——SkillRegistry
+     * 的构造器依赖 PluginService，构造器注入会成环；直接 new PluginService(...) 的
+     * 既有测试则停留 null，rescan() 判空跳过。
+     *
+     * <p>为什么必须在这里连上：插件携带的 skill 目录是 loadPlugins() 扫出来的，
+     * SkillRegistry 只在自己 @PostConstruct 与 rescan() 时来拉一次。装完/启用完插件
+     * 只重扫了插件侧，skill 侧不动——工具注册上了、skill 却要等下次重启才出现，
+     * 用户看到的就是「广场装完、插件开了，但让它干活它不认」。
+     */
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    @org.springframework.context.annotation.Lazy
+    private com.checkba.service.ai.skill.SkillRegistry skillRegistry;
+
+    /**
      * 插件宿主 SPI（规范 v2.4 §4/§11）：实例化出的工具类若实现 HostAware，注入按插件 id 绑定的 PluginHost。
      * 用 ObjectProvider 懒取——PluginHostFactory 背后挂着 EditorBridgeService/ProjectFileService 一串，
      * 构造器注入会把本类拖进启动死环；required=false 让直接 new 的测试照旧。
@@ -160,6 +175,11 @@ public class PluginService {
     /** 供测试直接装配 ToolRegistry（生产环境由 Spring 按上面的 @Autowired 字段注入）。 */
     void setToolRegistry(ToolRegistry toolRegistry) {
         this.toolRegistry = toolRegistry;
+    }
+
+    /** 供测试直接装配 SkillRegistry（生产环境由 Spring 按上面的 @Autowired 字段注入）。 */
+    void setSkillRegistry(com.checkba.service.ai.skill.SkillRegistry skillRegistry) {
+        this.skillRegistry = skillRegistry;
     }
 
     /** 供测试查看当前这一代插件 JAR ClassLoader 的快照。 */
@@ -247,6 +267,12 @@ public class PluginService {
         // 必须让 ToolRegistry 那层懒加载缓存失效，否则旧 bean 会继续被分发执行。
         if (toolRegistry != null) {
             toolRegistry.invalidatePluginToolCache();
+        }
+        // 插件带来的 skill 也要跟着重来一遍——否则 skill 要等下次重启才出现（见字段注释）。
+        // SkillRegistry.rescan() 只读 getPluginSkillDirs()/isEnabled()，两者都不持本对象的锁，
+        // 在这里同步调用不会与 PluginService 形成锁序环。
+        if (skillRegistry != null) {
+            skillRegistry.rescan();
         }
         log.info("Plugin rescan done: {} plugins, {} tools", plugins.size(), pluginTools.size());
 

--- a/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/PluginServiceTest.java
@@ -293,6 +293,37 @@ class PluginServiceTest {
         verify(toolRegistry).invalidatePluginToolCache();
     }
 
+    /**
+     * 真机复现（2026-08-23，广场上架尽调插件当天）：从插件广场装完 due-diligence、
+     * 在插件页启用之后，10 个 dd_* 工具都注册上了，但它携带的「尽调报告」skill
+     * 在 /api/skills/list 里根本不出现——手工 POST /api/skills/rescan 才冒出来。
+     *
+     * <p>根因是两套注册表各扫各的：插件携带的 skill 目录由 PluginService.loadPlugins()
+     * 扫出来放进 pluginSkillDirs，而 SkillRegistry 只在自己 @PostConstruct 和 rescan()
+     * 时来拉一次。装插件/启用插件只触发了插件侧 rescan，skill 侧不动，于是要等下次
+     * 重启后端才生效。用户看到的形态是「装完开了，但让它干活它不认」。
+     */
+    @Test
+    @DisplayName("修复：rescan 之后插件携带的 skill 也要立刻重扫（不必重启后端）")
+    void rescanAlsoRescansPluginSkills() throws IOException {
+        com.checkba.service.ai.skill.SkillRegistry skillRegistry =
+                mock(com.checkba.service.ai.skill.SkillRegistry.class);
+        service.setSkillRegistry(skillRegistry);
+        writeManifest("hello-plugin", FULL_MANIFEST);
+
+        service.rescan();
+
+        verify(skillRegistry).rescan();
+    }
+
+    @Test
+    @DisplayName("未装配 SkillRegistry（既有测试直接 new PluginService(...)）时 rescan 不受影响")
+    void rescanToleratesMissingSkillRegistry() throws IOException {
+        writeManifest("hello-plugin", FULL_MANIFEST);
+        service.init();
+        assertDoesNotThrow(service::rescan);
+    }
+
     @Test
     @DisplayName("未装配 ToolRegistry（既有测试直接 new PluginService(...)）时 rescan 不受影响")
     void rescanToleratesMissingToolRegistry() throws IOException {


### PR DESCRIPTION
上架尽调插件当天真机复现：从广场装 `due-diligence`、在插件页启用之后，10 个 `dd_*` 工具都注册上了，但它携带的「尽调报告」skill 在 `/api/skills/list` 里根本不出现——手工 `POST /api/skills/rescan` 才冒出来。用户看到的形态是「装完开了，但让它干活它不认」。

## 根因

两套注册表各扫各的：插件携带的 skill 目录由 `PluginService.loadPlugins()` 扫进 `pluginSkillDirs`，而 `SkillRegistry` 只在自己 `@PostConstruct` 与 `rescan()` 时来拉一次。装插件 / 启用插件只触发了插件侧 rescan，skill 侧不动 → 要等下次重启后端才生效。

## 修法

`PluginService.rescan()` 末尾顺带调 `SkillRegistry.rescan()`。注入沿用既有 `ToolRegistry` 那招（`@Lazy` + `required=false`），破 `SkillRegistry → PluginService` 的构造器环，直接 `new PluginService(...)` 的既有测试停留 null。

锁序：`SkillRegistry.rescan()` 只读 `getPluginSkillDirs()`（Lombok `@Getter`，非同步）与 `isEnabled()`（非同步），都不持 `PluginService` 的锁，同步调用不构成环。

## 验证

- `PluginServiceTest` 30 条通过；**去掉修复即转红**（新增两条：装配了 SkillRegistry 时 rescan 必须带上它、没装配时不受影响）。
- 真机：清空插件目录起后端 → skill 7 个 → 广场安装 → 启用插件 → **不做任何手工重扫** → skill 8 个，「尽调报告」直接可见、可启用（触发词 尽调报告 / 法律意见书 / 底稿…）。

## 影响面

0.24.0 已发布，存量用户的绕行办法是插件面板右上角的「重新扫描」按钮（它本来就同时打 `plugins/rescan` 与 `skills/rescan`），或者重启应用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)