### PR TITLE
chore(release): v0.24.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
小版本（增量补丁）。`patch-gate` 判据四类文件零改动 —— `desktop/main`、`desktop/preload`、`desktop/build`、`backend/pom.xml`，本地跑 `patch-gate.sh v0.24.1` 明确「通过：变更全部在补丁边界内」。存量用户拿补丁（backend app.jar + h5），不必重下 1.3GB。

## 本版内容（自 v0.24.0）
- **#583** 尽调等纯工具插件的独立启动页面：`manifest.guide` → `PluginGuidePane`（简介/快速开始/怎么用/工具清单，一键动作以 AGENT 模式发进 AI 对话）；**拖拽建链释放后无提示**（`METHOD_BAR_TTL_MS` 未定义抛 ReferenceError，链接建上了却没反馈）；rail 图标破图（指向不存在的 png）；「无法打开文件」模态死路；启用插件顺带启用其携带的 skill。
- **#582** 插件携带的 skill 装完就出现，不必重启后端。
- **#581** 领域文档补两条地雷。

## 四道门禁（全绿）
| 门禁 | 结果 | v0.24.0 基线 |
|---|---|---|
| `mvn test` | **2681 / 0 失败** | 2674 |
| app-e2e | **131 步 / 0 失败**（J6.7、J12 按环境跳过） | 135 / 0 |
| desktop-e2e | **全通**（10 步，保存链路全绿） | 全通 |
| lowa-e2e | **461 / 0 失败** | 461 |

跑法说明：本轮用独立后端 9821 + vite 5176（**9797 与 5174 都被其它会话的进程占着**，第一轮 e2e 因此打到了别人的树上、19 步假失败；换端口后干净复现全绿）。

## 配套已完成
- 官网：修掉 #94 引入的 typecheck 错误（[website#95](https://github.com/zeweihan/aiworkdeck_website/pull/95)），**两台已部署成功**——此前自 12:15 起一直没上线。
- 尽调插件 **0.5.0 已上架公网 registry**（带 guide），jar 字节 sha256 与本地一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)