### PR TITLE
fix(evidence): 拖拽建链的回执别 3 秒就没（dev-board#138）

### DIFF
--- a/frontend/src/components/EvidenceMethodBar.vue
+++ b/frontend/src/components/EvidenceMethodBar.vue
@@ -1,5 +1,8 @@
 <template>
   <view v-if="visible" class="evidence-bar" @mousedown.stop @tap.stop>
+    <svg class="evidence-bar-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path v-for="(d, i) in linkIcon" :key="i" :d="d" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
     <text class="evidence-bar-linked">{{ $t('workbench.evidence.linked', { name: fileName }) }}</text>
     <text class="evidence-bar-sep">·</text>
     <text class="evidence-bar-label">{{ $t('workbench.evidence.methodLabel') }}</text>
@@ -17,9 +20,13 @@
 </template>
 
 <script>
-// 拖文件到编辑器建链成功后的 method 浮动小条（spec §4.1）。纯展示：状态与 3s 自动收起
-// 计时都在宿主（evidenceLinkActions.js 的 armEvidenceMethodBarTimer），这里只回传点击。
+// 拖文件到编辑器建链成功后的 method 浮动小条（spec §4.1）。纯展示，状态在宿主
+// （evidenceLinkActions.js），这里只回传点击。
+// **不自动收起**：它既是「关联成功」的回执，又是「按什么方式核查」的提问，
+// 自动消失两件事都办不成（dev-board#138）。所以视觉上按"成功态"做：绿色描边 +
+// 链接图标，让用户在窗格底部一眼认出来，而不是当成一排普通 chip。
 import { EVIDENCE_METHODS } from '@/utils/evidenceLocator.js'
+import { ICONS } from '@/config/icons.js'
 
 export default {
   name: 'EvidenceMethodBar',
@@ -31,7 +38,7 @@ export default {
     targetId: { type: [Number, String], default: null },
   },
   data() {
-    return { methods: EVIDENCE_METHODS }
+    return { methods: EVIDENCE_METHODS, linkIcon: ICONS.link }
   },
   methods: {
     pick(m) {
@@ -49,11 +56,12 @@ export default {
   max-width: calc(100% - 32px);
   display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
   padding: 8px 12px; border-radius: 10px;
-  background: #fff; border: 1px solid #DEE2E6;
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+  background: #fff; border: 1px solid #1A5336;
+  box-shadow: 0 6px 20px rgba(26, 83, 54, 0.22);
   font-size: 12px; color: #1e293b;
 }
-.evidence-bar-linked { font-weight: 600; max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.evidence-bar-icon { width: 15px; height: 15px; flex: none; color: #1A5336; }
+.evidence-bar-linked { font-weight: 600; color: #1A5336; max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .evidence-bar-sep { color: #94a3b8; }
 .evidence-bar-label { color: #64748b; }
 .evidence-bar-chips { display: flex; gap: 6px; flex-wrap: wrap; }

--- a/frontend/src/pages/project-overview/evidenceLinkActions.js
+++ b/frontend/src/pages/project-overview/evidenceLinkActions.js
@@ -13,12 +13,6 @@ import { createEvidenceLinkForDrop, pickEvidenceTarget } from './evidenceLinkCor
 
 export { createEvidenceLinkForDrop, pickEvidenceTarget }
 
-// method 浮动小条无操作时的自动收起延时（ms）。此前这个常量漏定义，
-// armEvidenceMethodBarTimer 的 setTimeout 直接撞 ReferenceError——建链已成功，
-// 但抛出打断了紧随的 awd:evidence-changed 通知，小条也永不收起，用户「释放后没反应」
-// （dev-board#135，真机复现）。
-const METHOD_BAR_TTL_MS = 3000
-
 // request() 已把 {code:0,data} 整体 resolve 出来，这里统一剥一层。
 function unwrap(resp) {
   if (resp && typeof resp === 'object' && 'code' in resp && 'data' in resp) return resp.data
@@ -26,8 +20,12 @@ function unwrap(resp) {
 }
 
 export const evidenceLinkData = () => ({
-  // method 浮动小条：连续拖放只保留最后一条（对象整体替换）
-  evidenceMethodBar: { visible: false, side: 'left', fileName: '', method: 'written_review', targetId: null, linkKey: '' },
+  // method 浮动小条：连续拖放只保留最后一条（对象整体替换）。
+  // docFileId 用于把小条钉在建链的那份文档上——换标签/关文档后它不该还挂着。
+  evidenceMethodBar: {
+    visible: false, side: 'left', fileName: '', method: 'written_review',
+    targetId: null, linkKey: '', docFileId: null,
+  },
 })
 
 export const evidenceLinkMethods = {
@@ -66,26 +64,32 @@ export const evidenceLinkMethods = {
       uni.showToast({ title: this.$t(key), icon: 'none' })
       return
     }
-    this.showEvidenceMethodBar({ side, fileName: file.name || '', targetId: res.targetId, linkKey: res.linkKey })
+    this.showEvidenceMethodBar({
+      side, fileName: file.name || '', targetId: res.targetId, linkKey: res.linkKey, docFileId: Number(doc.id),
+    })
     uni.$emit('awd:evidence-changed', { docFileId: Number(doc.id), linkKey: res.linkKey })
   },
 
-  showEvidenceMethodBar({ side, fileName, targetId, linkKey }) {
-    this.evidenceMethodBar = { visible: true, side, fileName, method: 'written_review', targetId, linkKey }
-    this.armEvidenceMethodBarTimer()
-  },
-  armEvidenceMethodBarTimer() {
-    clearTimeout(this._evidenceBarTimer)
-    this._evidenceBarTimer = setTimeout(() => { this.evidenceMethodBar.visible = false }, METHOD_BAR_TTL_MS)
+  /**
+   * 建链成功后的确认小条。**不自动收起**：它同时是「已经关联上了」的回执和
+   * 「这条底稿按什么方式核查」的提问，3 秒自动消失两件事都办不成——用户松手时
+   * 眼睛在正文的落点上，等看向窗格左下角，小条已经没了，于是「什么都没发生」
+   * （dev-board#138，维护者真机反馈；#135 修的是它压根不显示，这次修的是它留不住）。
+   * 收起只由用户动作驱动：点 ×、选了方法、又建了新的一条（整体替换）、
+   * 或者换到别的文档（模板里按 docFileId 收，见 project-overview.vue）。
+   */
+  showEvidenceMethodBar({ side, fileName, targetId, linkKey, docFileId }) {
+    this.evidenceMethodBar = {
+      visible: true, side, fileName, method: 'written_review', targetId, linkKey,
+      docFileId: docFileId == null ? null : Number(docFileId),
+    }
   },
   closeEvidenceMethodBar() {
-    clearTimeout(this._evidenceBarTimer)
     this.evidenceMethodBar.visible = false
   },
   async onEvidenceMethodChange({ targetId, method }) {
     if (!targetId || !method) return
     this.evidenceMethodBar.method = method
-    this.armEvidenceMethodBarTimer()
     const pid = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
     try {
       await updateEvidenceTarget(pid, targetId, { method })

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -831,7 +831,7 @@
                   <!-- EvidenceLink method 浮动小条：拖文件到编辑器建链成功后出现，钉在窗格底部 -->
                   <EvidenceMethodBar
                     v-if="evidenceMethodBar.side === 'left'"
-                    :visible="evidenceMethodBar.visible"
+                    :visible="evidenceMethodBar.visible && isEvidenceBarOnActiveDoc(activeFileLeft)"
                     :file-name="evidenceMethodBar.fileName"
                     :method="evidenceMethodBar.method"
                     :target-id="evidenceMethodBar.targetId"
@@ -1007,7 +1007,7 @@
                 >
                   <EvidenceMethodBar
                     v-if="evidenceMethodBar.side === 'right'"
-                    :visible="evidenceMethodBar.visible"
+                    :visible="evidenceMethodBar.visible && isEvidenceBarOnActiveDoc(activeFileRight)"
                     :file-name="evidenceMethodBar.fileName"
                     :method="evidenceMethodBar.method"
                     :target-id="evidenceMethodBar.targetId"
@@ -3646,6 +3646,17 @@ export default {
       this.showFilePicker = true
     },
 
+    /**
+     * method 小条钉在建链的那份文档上。小条不再自动收起（dev-board#138），
+     * 所以必须有这一条：换标签、关文档之后，它不能还挂在别的文档上说「已关联」。
+     * 用渲染期判断而不是 watch —— watch 漏一个入口（关标签/分屏挪动/退出项目）
+     * 就是一条挂错文档的回执，判断放在渲染期漏不掉。
+     */
+    isEvidenceBarOnActiveDoc(activeFile) {
+      const pinned = this.evidenceMethodBar && this.evidenceMethodBar.docFileId
+      if (pinned == null) return true // 旧状态/测试桩没带 docFileId 时不收
+      return !!activeFile && Number(activeFile.id) === Number(pinned)
+    },
     isTabVisible(file) {
       if (!file) return false
       // dd-request 或者 fileType 为 dd 的属于尽调清单类标签

--- a/frontend/tests/evidence/methodBarPinnedDoc.test.mjs
+++ b/frontend/tests/evidence/methodBarPinnedDoc.test.mjs
@@ -1,0 +1,35 @@
+// method 小条不再自动收起（dev-board#138）之后必须补的一条：它得钉在建链的那份文档上。
+// 否则换标签/关文档之后，上一份文档的「已关联《x》」还挂在窗格左下角——比不显示更糟，
+// 因为它在对另一份文档说谎。判断放在渲染期（isEvidenceBarOnActiveDoc），不是 watch：
+// watch 漏一个入口（关标签/分屏挪动/退出项目）就是一条挂错文档的回执。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const VUE = readFileSync(new URL('../../src/pages/project-overview/project-overview.vue', import.meta.url), 'utf8')
+
+// 从 SFC 里抠出这个方法体求值（同本仓 @/ 别名文件的一贯做法）
+const m = VUE.match(/isEvidenceBarOnActiveDoc\(activeFile\) \{[\s\S]*?\n    \},/)
+assert.ok(m, '没找到 isEvidenceBarOnActiveDoc')
+const fn = new Function('return function ' + m[0].replace(/,$/, ''))()
+
+test('活跃文档就是建链那份 → 显示', () => {
+  const self = { evidenceMethodBar: { docFileId: 7 } }
+  assert.equal(fn.call(self, { id: 7 }), true)
+  assert.equal(fn.call(self, { id: '7' }), true, 'id 可能是字符串')
+})
+
+test('换到别的文档 → 收起', () => {
+  const self = { evidenceMethodBar: { docFileId: 7 } }
+  assert.equal(fn.call(self, { id: 8 }), false)
+})
+
+test('窗格里没有活跃文档（关掉了）→ 收起', () => {
+  const self = { evidenceMethodBar: { docFileId: 7 } }
+  assert.equal(fn.call(self, null), false)
+})
+
+test('没带 docFileId 的旧状态 → 不收（不因为兼容问题把回执吞掉）', () => {
+  const self = { evidenceMethodBar: { docFileId: null } }
+  assert.equal(fn.call(self, { id: 8 }), true)
+})

--- a/frontend/tests/evidence/methodBarTimer.test.mjs
+++ b/frontend/tests/evidence/methodBarTimer.test.mjs
@@ -1,8 +1,14 @@
-// 回归：拖放建链成功后 method 小条的自动收起计时。
-// 真机复现（dev-board#135，dev Electron + H5 双跑）：armEvidenceMethodBarTimer 引用了
-// 从未定义的 METHOD_BAR_TTL_MS，setTimeout 第二参撞 ReferenceError → showEvidenceMethodBar
-// 抛出，onEvidenceDrop 里紧随其后的 uni.$emit('awd:evidence-changed') 再不执行（面板/编辑器
-// 不刷新、小条不自动收起），生产构建下响应式更新可能整个丢失＝用户「释放后什么都没有」。
+// 回归：拖放建链成功后 method 小条的显示与收起时机。
+//
+// 两轮真机反馈叠在这一个文件里：
+// ① dev-board#135：armEvidenceMethodBarTimer 引用了从未定义的 METHOD_BAR_TTL_MS，
+//    setTimeout 第二参撞 ReferenceError → showEvidenceMethodBar 抛出，onEvidenceDrop 里
+//    紧随其后的 uni.$emit('awd:evidence-changed') 再不执行（面板/编辑器不刷新）＝
+//    用户「释放后什么都没有」。
+// ② dev-board#138：常量补上之后小条确实显示了，但 3 秒自动收起——它同时是「已关联」
+//    的回执和「按什么方式核查」的提问，两件事都办不成：用户松手时眼睛在正文落点上，
+//    等看向窗格左下角，小条已经没了，于是仍然是「什么都没发生」。改成不自动收起，
+//    只由用户动作（点 ×、选方法、建新的一条）与文档切换驱动。
 //
 // evidenceLinkActions.js 带 @/ 别名 import，node --test 直接 import 进不来：剥掉 import 行、
 // export 换 return，用普通对象当 this 调 methods（同 review-panel-double-tap.test.mjs 的路子）。
@@ -15,7 +21,6 @@ const SRC = readFileSync(new URL('../../src/pages/project-overview/evidenceLinkA
   .replace(/^export \{[^}]*\}$/gm, '')
   .replace(/^export const/gm, 'const')
 
-// 尾部拼一个收集器，把两个导出对象吐出来
 const mod = new Function(SRC + '\nreturn { evidenceLinkData, evidenceLinkMethods }')()
 const { evidenceLinkData, evidenceLinkMethods } = mod
 
@@ -23,24 +28,42 @@ function ctx() {
   return { ...evidenceLinkData(), ...evidenceLinkMethods, $t: (k) => k }
 }
 
-test('showEvidenceMethodBar 不抛错，小条置为可见（不再撞 ReferenceError）', () => {
+test('showEvidenceMethodBar 不抛错，小条置为可见（#135：不再撞 ReferenceError）', () => {
   const self = ctx()
   assert.doesNotThrow(() => {
-    evidenceLinkMethods.showEvidenceMethodBar.call(self, { side: 'left', fileName: '营业执照.pdf', targetId: 5, linkKey: 'EVID_X' })
+    evidenceLinkMethods.showEvidenceMethodBar.call(self,
+      { side: 'left', fileName: '营业执照.pdf', targetId: 5, linkKey: 'EVID_X', docFileId: 7 })
   })
   assert.equal(self.evidenceMethodBar.visible, true)
   assert.equal(self.evidenceMethodBar.fileName, '营业执照.pdf')
-  clearTimeout(self._evidenceBarTimer)
+  assert.equal(self.evidenceMethodBar.docFileId, 7, '小条要记住是给哪份文档建的链')
 })
 
-test('armEvidenceMethodBarTimer 排定的是有限延时，回调把小条收起', async () => {
+test('#138：小条不再排定自动收起计时，等多久都还在', async () => {
   const self = ctx()
-  self.evidenceMethodBar.visible = true
-  assert.doesNotThrow(() => evidenceLinkMethods.armEvidenceMethodBarTimer.call(self))
-  assert.ok(self._evidenceBarTimer, '应排定了自动收起计时器')
-  clearTimeout(self._evidenceBarTimer)
-  // 手动跑一遍回调语义：置回不可见
-  self._evidenceBarTimer = setTimeout(() => { self.evidenceMethodBar.visible = false }, 0)
-  await new Promise((r) => setTimeout(r, 5))
+  evidenceLinkMethods.showEvidenceMethodBar.call(self,
+    { side: 'left', fileName: '章程.pdf', targetId: 6, linkKey: 'EVID_Y', docFileId: 7 })
+  assert.equal(self._evidenceBarTimer, undefined, '不该再有自动收起计时器')
+  await new Promise((r) => setTimeout(r, 30))
+  assert.equal(self.evidenceMethodBar.visible, true, '过了时间小条仍在（收起只由用户动作驱动）')
+})
+
+test('点 × 收起小条', () => {
+  const self = ctx()
+  evidenceLinkMethods.showEvidenceMethodBar.call(self,
+    { side: 'left', fileName: '决议.pdf', targetId: 7, linkKey: 'EVID_Z', docFileId: 7 })
+  evidenceLinkMethods.closeEvidenceMethodBar.call(self)
   assert.equal(self.evidenceMethodBar.visible, false)
+})
+
+test('再建一条链接：整体替换成新的那条，不叠加', () => {
+  const self = ctx()
+  evidenceLinkMethods.showEvidenceMethodBar.call(self,
+    { side: 'left', fileName: '第一份.pdf', targetId: 1, linkKey: 'EVID_1', docFileId: 7 })
+  evidenceLinkMethods.showEvidenceMethodBar.call(self,
+    { side: 'right', fileName: '第二份.pdf', targetId: 2, linkKey: 'EVID_2', docFileId: 9 })
+  assert.equal(self.evidenceMethodBar.fileName, '第二份.pdf')
+  assert.equal(self.evidenceMethodBar.side, 'right')
+  assert.equal(self.evidenceMethodBar.docFileId, 9)
+  assert.equal(self.evidenceMethodBar.method, 'written_review', '新的一条回到默认方法')
 })


### PR DESCRIPTION
维护者在 v0.24.1 上反馈：「链接建上了要给用户明显反馈啊」。

## 真机量到的形态

dev Electron + 真 webview + 截图取证：method 小条**确实显示了**——窗格左下角、`z-index: 30`、压在 webview 上面没被遮挡，`elementFromPoint` 打在它自己的 chip 上，内容也对（「已关联《x》· 方法：书面审查/书面说明/网络核查/第三方材料/访谈」）。

问题是它 **3 秒后自动收起**（`METHOD_BAR_TTL_MS = 3000`）。用户松手时眼睛在正文的落点上，等看向窗格左下角，小条已经没了 —— 仍然是「什么都没发生」。dev-board#135 修的是它压根不显示，这次修的是它留不住。

而且这条小条同时是两件事：**回执**（已经关联上了）+ **提问**（这条底稿按什么方式核查）。3 秒两件事都办不成：读完文件名就该到时间，更别说在五个方法里挑一个。

## 改动

- **去掉自动收起计时**。收起只由用户动作驱动：点 ×、选了方法、又建了新的一条（对象整体替换）。
- **小条钉在建链的那份文档上**（新增 `docFileId`），换标签/关文档自动收。不自动收起之后必须有这条，否则上一份文档的「已关联《x》」会挂在别的文档上说谎。判断放渲染期（`isEvidenceBarOnActiveDoc`）而不是 watch —— watch 漏一个入口（关标签/分屏挪动/退出项目）就是一条挂错文档的回执。
- **视觉按成功态做**：绿色描边 + 链接图标 + 文件名用品牌绿，别让它看着像一排普通 chip。

## 验证

- `tests/evidence/` 122 条通过。`methodBarTimer.test.mjs` 改写成钉新契约——**把 3 秒计时放回去即转红**；新增 `methodBarPinnedDoc.test.mjs` 四条覆盖换文档收起、id 类型、无 docFileId 的旧状态不误收。
- 真机：t+0.3s / t+4s / t+12s 小条都在（改之前 t+4s 已消失），换到另一份文档后自动收起。
- `check:emits` / `check:locales` / `check:nav` 全过；`test:project-home` 293 条、`test:commands` 17 条通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
