### PR TITLE
chore(release): v0.24.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
拖拽建链的回执不再 3 秒消失（dev-board#138，PR #585）。

前端单文件改动，补丁闸判定为**小版本 overlay 补丁**——存量用户拿到的是几十 KB 的 frontend-h5 增量，不是完整安装包。

四道门禁全绿：

- `mvn test` **2681 / 0**
- `app-e2e` **131 步 / 0 失败**
- `desktop-e2e` 桌面保存链路全通
- `lowa-e2e` **461 / 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)