### PR TITLE
fix(ui): 标签栏滚动条隐藏+滚轮横滚（dev-board#140）

### DIFF
--- a/frontend/src/components/ClipboardPanel.vue
+++ b/frontend/src/components/ClipboardPanel.vue
@@ -6,7 +6,7 @@
       class="clip-unlock-hint"
       :text="$t('panels.cpUnlockHint', { count: hiddenCount })"
     />
-    <scroll-view class="clip-body" :scroll-y="false" :scroll-x="true" show-scrollbar="false">
+    <scroll-view class="clip-body" :scroll-y="false" :scroll-x="true" :show-scrollbar="false">
       <view v-if="loading" class="loading">{{ $t('panels.cpLoading') }}</view>
       <view v-else-if="items.length === 0" class="empty">{{ $t('panels.cpEmpty') }}</view>
       <view v-else class="list-grid">

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -1642,6 +1642,19 @@ $bg-white: #FFFFFF;
 .tabs-scroll {
   width: 100%;
   height: 100%;
+
+  /* VS Code 式标签栏：滚动条整条隐藏（横滚靠滚轮，onTabsWheel）。
+     真正 overflow 的是 uni-h5 scroll-view 的内层元素（不带本组件 scope id），要 :deep 兜住。 */
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  :deep(*) {
+    scrollbar-width: none;
+  }
+  :deep(*::-webkit-scrollbar) {
+    display: none;
+  }
 }
 
 .tabs-list {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -726,7 +726,7 @@
             <view class="tabs-bar">
               <!-- 左侧窗格的 Tabs -->
               <view class="tabs-pane tabs-pane-left" :class="{ 'half-width': splitMode }">
-                <scroll-view class="tabs-scroll" scroll-x show-scrollbar="false">
+                <scroll-view class="tabs-scroll" scroll-x :show-scrollbar="false" @wheel.prevent="onTabsWheel">
                   <view
                     class="tabs-list"
                     @dragover.prevent="onTabDropZoneDragOver('left')"
@@ -766,7 +766,7 @@
 
               <!-- 右侧窗格的 Tabs (仅在分屏时显示) -->
               <view v-if="splitMode" class="tabs-pane tabs-pane-right">
-                <scroll-view class="tabs-scroll" scroll-x show-scrollbar="false">
+                <scroll-view class="tabs-scroll" scroll-x :show-scrollbar="false" @wheel.prevent="onTabsWheel">
                   <view
                     class="tabs-list"
                     @dragover.prevent="onTabDropZoneDragOver('right')"

--- a/frontend/src/pages/project-overview/tabDragSplit.js
+++ b/frontend/src/pages/project-overview/tabDragSplit.js
@@ -48,6 +48,23 @@ export const tabDragSplitMethods = {
       this.onTabDragEnd()
     },
 
+    onTabsWheel(evt) {
+      // VS Code 式标签栏：滚动条整条隐藏，纵向滚轮映射为横向滚动。
+      // scroll-view 真正 overflow 的是 uni-h5 渲染出的内层元素，不是根元素本身，按 scrollWidth 找。
+      const root = evt?.currentTarget
+      if (!root || typeof root.querySelectorAll !== 'function') return
+      let scroller = null
+      if (root.scrollWidth > root.clientWidth) scroller = root
+      if (!scroller) {
+        for (const el of root.querySelectorAll('*')) {
+          if (el.scrollWidth > el.clientWidth + 1) { scroller = el; break }
+        }
+      }
+      if (!scroller) return
+      const delta = Math.abs(evt.deltaX) > Math.abs(evt.deltaY) ? evt.deltaX : evt.deltaY
+      scroller.scrollLeft += delta
+    },
+
     getTabDragPayload(evt) {
       try {
         const raw = evt?.dataTransfer?.getData('application/json')


### PR DESCRIPTION
维护者反馈标签页横向滚动条太粗。根因是 `show-scrollbar="false"` 少冒号绑定（字符串 truthy），隐藏从未生效。对齐 VS Code 方案：整条隐藏 + 滚轮横滚，另修 ClipboardPanel 同型 bug。

dev-board: zeweihan/dev-board#140

🤖 Generated with [Claude Code](https://claude.com/claude-code)