### PR TITLE
fix(addin): 会话 403 自愈，根治插件发消息被锁死（dev-board#142）

### DIFF
--- a/office-addin/taskpane/lib/api.js
+++ b/office-addin/taskpane/lib/api.js
@@ -272,19 +272,24 @@ export async function refreshPlatformAiKey({ serverUrl, token }, key) {
  */
 export async function createConversation({ serverUrl, token }, projectId) {
   const base = normalizeBaseUrl(serverUrl)
-  try {
-    const resp = await fetch(`${base}/api/agent/conversations`, {
-      method: 'POST',
-      headers: headers(token),
-      body: JSON.stringify({ projectId })
-    })
-    if (!resp.ok) return null
-    const data = await resp.json()
-    if (data && typeof data.conversationId === 'string' && data.conversationId) {
-      return data.conversationId
-    }
-  } catch (e) {
-    // 静默降级：会话 ID 回退客户端生成
+  const resp = await fetch(`${base}/api/agent/conversations`, {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify({ projectId })
+  })
+  // 只有 404（旧后端没有签发端点）允许回退客户端自造 ID——那种后端也不校验签发。
+  // 403/5xx 一律抛出：强制签发的云后端上，自造 ID 生来就是死的，落盘等于把用户锁死
+  // （2026-08-24 mac 插件「SSE 403」事故的根因之一）。
+  if (resp.status === 404) return null
+  if (!resp.ok) {
+    const err = new Error(`会话签发失败（HTTP ${resp.status}）`)
+    err.status = resp.status
+    throw err
+  }
+  let data = null
+  try { data = await resp.json() } catch (e) { return null }
+  if (data && typeof data.conversationId === 'string' && data.conversationId) {
+    return data.conversationId
   }
   return null
 }

--- a/office-addin/taskpane/lib/chatSession.js
+++ b/office-addin/taskpane/lib/chatSession.js
@@ -182,7 +182,7 @@ export async function activateSession({ settings, projectId }) {
 async function preconnect() {
   if (!ctx.projectId || !ctx.settings || !isConfigured(ctx.settings)) return
   if (!conversationId) {
-    // 会话 ID 优先服务端签发；旧后端无该端点时静默回退客户端生成。
+    // 会话 ID 优先服务端签发；仅旧后端（端点 404）时回退客户端生成。
     // 按项目落本机存储，任务窗格重建后据它接回同一场对话。
     const gen = generation
     const issued = await createConversation(ctx.settings, parseInt(ctx.projectId, 10))
@@ -190,7 +190,24 @@ async function preconnect() {
     conversationId = issued || `conv-${Date.now()}`
     saveConversationId(ctx.projectId, conversationId)
   }
-  await ensureConnection()
+  try {
+    await ensureConnection()
+  } catch (e) {
+    // 自愈：存量会话 ID 已死（云后端签发登记簿是内存态，重启即清；或 localStorage 里
+    // 留着历史版本自造的 conv-*）。特征是 connect 403 且本地没有任何消息——有消息的
+    // 会话走 DB 归属判定不会 403。丢弃死 ID → 重新签发 → 只重试一次。
+    const canHeal = e && e.status === 403 && !messages.value.length
+    if (!canHeal) throw e
+    const gen = generation
+    console.warn('[Addin] 存量会话已失效（connect 403），丢弃并重新签发', conversationId)
+    conversationId = null
+    saveConversationId(ctx.projectId, '')
+    const issued = await createConversation(ctx.settings, parseInt(ctx.projectId, 10))
+    if (gen !== generation) return
+    conversationId = issued || `conv-${Date.now()}`
+    saveConversationId(ctx.projectId, conversationId)
+    await ensureConnection()
+  }
 }
 
 /**

--- a/office-addin/taskpane/lib/chatSession.test.js
+++ b/office-addin/taskpane/lib/chatSession.test.js
@@ -1,0 +1,142 @@
+/**
+ * 会话自愈回归用例（dev-board#142，2026-08-24 mac 插件「SSE 403」事故）。
+ *   node --test office-addin/taskpane/lib/chatSession.test.js
+ *
+ * 病灶：官方云强制服务端签发会话（conversation-issuance-required），而签发登记簿
+ * 是进程内存态——后端一重启登记即丢，localStorage 里钉着的存量会话 ID 从此
+ * connect 恒 403。旧代码两处放大成永久自锁：
+ *   1) connect 403 只 console.warn，不丢弃死 ID，下次还是拿它连；
+ *   2) createConversation 任何失败（含 403）都静默回 null，随后把客户端自造的
+ *      conv-<毫秒> 落进 localStorage——在强制签发的云上生来就是死的。
+ * 下面用例分别还原这两个病灶：把自愈逻辑拿掉（或恢复「失败回退自造 ID」）就会转红。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// ---- localStorage 内存桩：settings.js 的持久化走它 ----
+const store = new Map()
+globalThis.localStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => { store.set(k, String(v)) },
+  removeItem: (k) => { store.delete(k) }
+}
+
+const { activateSession, messages, stop } = await import('./chatSession.js')
+const { createConversation } = await import('./api.js')
+
+/** 永不出数据的 SSE 响应体（建连成功后读流挂起，不影响用例收尾） */
+function sseOkResponse() {
+  return {
+    ok: true,
+    status: 200,
+    body: { getReader: () => ({ read: () => new Promise(() => {}) }) }
+  }
+}
+
+function jsonReply(body, ok = true, status = 200) {
+  return { ok, status, json: async () => body }
+}
+
+function stubFetch(handler) {
+  const original = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options })
+    return handler(String(url), options)
+  }
+  return {
+    calls,
+    restore: () => { globalThis.fetch = original }
+  }
+}
+
+test('存量会话 connect 403 时自愈：丢弃死 ID → 重新签发 → 重连成功', async () => {
+  store.set('awd_addin_conv_7', 'conv-dead-123')
+  const f = stubFetch((url) => {
+    if (url.includes('/api/ai/history')) return jsonReply([])
+    if (url.includes('/api/agent/connect/conv-dead-123')) return jsonReply({}, false, 403)
+    if (url.endsWith('/api/agent/conversations')) return jsonReply({ conversationId: 'conv-fresh-456' })
+    if (url.includes('/api/agent/connect/conv-fresh-456')) return sseOkResponse()
+    throw new Error(`未预期的请求: ${url}`)
+  })
+  try {
+    await activateSession({
+      settings: { serverUrl: 'https://cloud.example', token: 'awdt_t1' },
+      projectId: '7'
+    })
+    // 死 ID 已被换成服务端新签发的 ID，并落回 localStorage
+    assert.equal(store.get('awd_addin_conv_7'), 'conv-fresh-456')
+    // 完整自愈链：403 建连 → 重签发 → 新 ID 建连
+    const urls = f.calls.map(c => c.url)
+    assert.ok(urls.some(u => u.includes('/connect/conv-dead-123')))
+    assert.ok(urls.some(u => u.endsWith('/api/agent/conversations')))
+    assert.ok(urls.some(u => u.includes('/connect/conv-fresh-456')))
+  } finally {
+    await stop()
+    f.restore()
+  }
+})
+
+test('签发被拒（403）不回退自造 conv-* ID，更不落盘', async () => {
+  store.delete('awd_addin_conv_9')
+  const f = stubFetch((url) => {
+    if (url.includes('/api/ai/history')) return jsonReply([])
+    if (url.endsWith('/api/agent/conversations')) return jsonReply({ message: 'denied' }, false, 403)
+    if (url.includes('/api/agent/cancel/')) return jsonReply({})
+    throw new Error(`未预期的请求: ${url}`)
+  })
+  try {
+    await activateSession({
+      settings: { serverUrl: 'https://cloud.example', token: 'awdt_t2' },
+      projectId: '9'
+    })
+    // 预连失败被吞掉（不打断用户），但绝不能把自造 ID 写进 localStorage 锁死后续
+    assert.equal(store.get('awd_addin_conv_9') || '', '')
+    assert.ok(!f.calls.some(c => c.url.includes('/api/agent/connect/conv-')))
+  } finally {
+    await stop()
+    f.restore()
+  }
+})
+
+test('createConversation：404（旧后端）回退 null，403 抛错带状态码', async () => {
+  const f404 = stubFetch(() => jsonReply({}, false, 404))
+  try {
+    assert.equal(await createConversation({ serverUrl: 'https://x', token: 't' }, 1), null)
+  } finally { f404.restore() }
+
+  const f403 = stubFetch(() => jsonReply({}, false, 403))
+  try {
+    await assert.rejects(
+      () => createConversation({ serverUrl: 'https://x', token: 't' }, 1),
+      (e) => e.status === 403
+    )
+  } finally { f403.restore() }
+})
+
+test('自愈只针对空会话：有历史消息的会话 403 不重签（那是权限/账号问题）', async () => {
+  store.set('awd_addin_conv_11', 'conv-history-1')
+  let issuedCalls = 0
+  const f = stubFetch((url) => {
+    if (url.includes('/api/ai/history')) {
+      return jsonReply([{ role: 'USER', content: '早先的问题' }])
+    }
+    if (url.includes('/api/agent/connect/conv-history-1')) return jsonReply({}, false, 403)
+    if (url.endsWith('/api/agent/conversations')) { issuedCalls++; return jsonReply({ conversationId: 'conv-x' }) }
+    if (url.includes('/api/agent/cancel/')) return jsonReply({})
+    throw new Error(`未预期的请求: ${url}`)
+  })
+  try {
+    await activateSession({
+      settings: { serverUrl: 'https://cloud.example', token: 'awdt_t3' },
+      projectId: '11'
+    })
+    assert.equal(issuedCalls, 0)
+    // 历史消息还在，会话 ID 没被丢
+    assert.equal(store.get('awd_addin_conv_11'), 'conv-history-1')
+    assert.ok(messages.value.length >= 1)
+  } finally {
+    await stop()
+    f.restore()
+  }
+})

--- a/office-addin/taskpane/lib/sse.js
+++ b/office-addin/taskpane/lib/sse.js
@@ -38,7 +38,12 @@ export function createSseConnection({ baseUrl, token, conversationId, onEvent, o
       headers: { 'X-Session-Id': token || '' },
       signal: controller.signal
     })
-    if (!resp.ok) throw new Error(`SSE 建连失败（HTTP ${resp.status}）：令牌无效或后端拒绝了请求`)
+    if (!resp.ok) {
+      const err = new Error(`SSE 建连失败（HTTP ${resp.status}）：令牌无效或后端拒绝了请求`)
+      // 挂上状态码：403（会话不归当前用户/签发登记已丢）是调用方能自愈的，其余不能
+      err.status = resp.status
+      throw err
+    }
     return resp
   }
 


### PR DESCRIPTION
mac 插件「SSE 建连失败 (HTTP 403)」根因闭环：云后端会话签发登记簿是内存态（重启即清），客户端死 ID 钉在 localStorage 永不自愈 + 签发失败回退自造 ID 落盘，形成永久自锁。本 PR 客户端自愈：403 空会话丢弃重签重试一次；自造 ID 只在旧后端（404）时允许。四条回归用例（两条病灶还原验证）。

合并后需重建 taskpane 资产部署到 addin.aiworkdeck.com 才对存量用户生效。

dev-board: zeweihan/dev-board#142

🤖 Generated with [Claude Code](https://claude.com/claude-code)