### PR TITLE
fix(desktop): 后端复用 build 指纹闸（dev-board#139 结构性根因）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/WizardController.java
+++ b/backend/src/main/java/com/checkba/controller/WizardController.java
@@ -63,6 +63,11 @@ public class WizardController {
         Map<String, Object> body = new HashMap<>();
         body.put("code", 0);
         body.put("initialized", isInitialized());
+        // 后端 build 指纹（桌面壳 spawn 时经 AWD_BACKEND_BUILD 注入 jar 的 size-mtime）。
+        // 桌面壳复用端口上的既有后端前用它验明「不但是我们的后端，而且是当前版本的
+        // 后端」——2026-08-24 维护者真机复用了 8-21 的陈旧后端，evidence-links 一路
+        // 404 且毫无提示（dev-board#139）。非桌面壳拉起的进程（dev/云端）此值为空串。
+        body.put("build", System.getenv().getOrDefault("AWD_BACKEND_BUILD", ""));
         return ResponseEntity.ok(body);
     }
 

--- a/desktop/main/services/backend-service.js
+++ b/desktop/main/services/backend-service.js
@@ -13,19 +13,112 @@ const DESKTOP_PORT_CHAIN = [5269, 5369, 5169]
 // 端口上监听的是不是我们自己的后端：探 GET /api/admin/wizard，
 // 该端点免鉴权、回环放行，返回体带 "initialized" 特征字段。
 // 用于防止把陌生进程（恰好占了链上端口）误当后端复用。
-function isOurBackend(port, timeoutMs = 1500) {
+// 返回 { ours, build }：build 是后端启动时经 AWD_BACKEND_BUILD 注入的 jar 指纹
+// （旧后端/非桌面壳拉起的后端为空串）。
+function probeBackend(port, timeoutMs = 1500) {
   return new Promise((resolve) => {
     const req = http.get(
       { host: '127.0.0.1', port, path: '/api/admin/wizard', timeout: timeoutMs },
       (res) => {
         let body = ''
         res.on('data', (c) => { if (body.length < 4096) body += c })
-        res.on('end', () => resolve(res.statusCode === 200 && body.includes('"initialized"')))
+        res.on('end', () => {
+          const ours = res.statusCode === 200 && body.includes('"initialized"')
+          let build = ''
+          try { build = String(JSON.parse(body).build || '') } catch (e) { /* 旧后端无此字段 */ }
+          resolve({ ours, build })
+        })
       }
     )
-    req.on('timeout', () => { req.destroy(); resolve(false) })
-    req.on('error', () => resolve(false))
+    req.on('timeout', () => { req.destroy(); resolve({ ours: false, build: '' }) })
+    req.on('error', () => resolve({ ours: false, build: '' }))
   })
+}
+
+/**
+ * 当前会启动的那份 app.jar 的指纹（size-mtime）。spawn 时经 AWD_BACKEND_BUILD 注入，
+ * wizard 端点原样回显；复用前对比即可识破「监听着端口的是更新前残留的陈旧后端」——
+ * 2026-08-24 维护者真机就复用了 8-21 的旧后端，evidence-links 一路 404 还毫无提示
+ * （dev-board#139 根因之一）。指纹取文件属性而不取版本号，是因为 overlay 补丁换
+ * app.jar 不改壳版本号，AWD_APP_VERSION 分辨不出 0.24.0 壳下的 0.24.1/0.24.2 后端。
+ */
+function backendBuildId(ctx) {
+  try {
+    const st = fs.statSync(jarPath(ctx))
+    return `${st.size}-${Math.round(st.mtimeMs)}`
+  } catch (e) {
+    return ''
+  }
+}
+
+/**
+ * 复用裁决（纯函数，单测覆盖）：
+ * - 陌生进程 → 'skip'（走下一个端口/重新分配）
+ * - 自家后端且指纹一致 → 'reuse'（多开实例/上次残留的同版本后端，正常复用）
+ * - 自家后端但指纹不一致（陈旧版本）→ 'replace'（礼貌终止后原地重启；
+ *   终止失败时调用方退回 'reuse'——陈旧但能用，好过 H2 文件锁把新后端卡死）
+ * dev 态不做指纹校验：restart-backend.sh 等外部工作流拉起的后端没有注入指纹，
+ * 版本闸只针对打包态「更新后复用残留旧后端」的形态。
+ */
+function decideReuse(probe, { packaged, expectedBuild }) {
+  if (!probe.ours) return 'skip'
+  if (!packaged) return 'reuse'
+  if (!expectedBuild || probe.build === expectedBuild) return 'reuse'
+  return 'replace'
+}
+
+/** 找出监听该端口的 pid（仅回环）。失败返回 null。 */
+function pidListeningOn(port) {
+  try {
+    if (process.platform === 'win32') {
+      const out = execFileSync('netstat', ['-ano', '-p', 'tcp'], { encoding: 'utf8' })
+      for (const line of out.split(/\r?\n/)) {
+        const m = line.trim().match(/^TCP\s+\S+:(\d+)\s+\S+\s+LISTENING\s+(\d+)$/i)
+        if (m && Number(m[1]) === port) return Number(m[2])
+      }
+      return null
+    }
+    const out = execFileSync('lsof', ['-ti', `tcp:${port}`, '-sTCP:LISTEN'], { encoding: 'utf8' })
+    const pid = Number(out.split(/\s+/).filter(Boolean)[0])
+    return Number.isFinite(pid) ? pid : null
+  } catch (e) {
+    return null
+  }
+}
+
+/**
+ * 终止端口上的陈旧后端并等它放开端口。只在 probeBackend 验明「确是我们的后端、
+ * 但版本不是当前要启动的」之后调用——按端口找 pid 定点终止，绝不按进程名扫射
+ * （多会话并行时按名杀会误伤别人的后端）。返回是否已释放端口。
+ */
+async function terminateStaleBackend(port, waitMs = 8000) {
+  const pid = pidListeningOn(port)
+  if (!pid) return !(await isPortOpen(port))
+  try {
+    if (process.platform === 'win32') execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'])
+    else process.kill(pid, 'SIGTERM')
+  } catch (e) {
+    return false
+  }
+  const deadline = Date.now() + waitMs
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    if (!(await isPortOpen(port))) return true
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  // SIGTERM 没生效：升级 SIGKILL 再等一小段（win32 上面已经是 /F 强杀）
+  if (process.platform !== 'win32') {
+    try { process.kill(pid, 'SIGKILL') } catch (e) { return false }
+    const hardDeadline = Date.now() + 3000
+    while (Date.now() < hardDeadline) {
+      // eslint-disable-next-line no-await-in-loop
+      if (!(await isPortOpen(port))) return true
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => setTimeout(r, 250))
+    }
+  }
+  return false
 }
 
 // 能否真实绑定该端口（listen 后立刻释放；比 isPortOpen 的 connect 探测可靠——
@@ -43,12 +136,24 @@ async function allocateBackendPort(ctx) {
   if (process.env.CHECKBA_BACKEND_PORT) return Number(process.env.CHECKBA_BACKEND_PORT)
   // dev 态维持 9696：复用 restart-backend.sh 起的后端，脚本/CI 不受影响
   if (!ctx.packaged) return 9696
+  const expectedBuild = backendBuildId(ctx)
   for (const cand of DESKTOP_PORT_CHAIN) {
     // eslint-disable-next-line no-await-in-loop
     if (await isPortOpen(cand)) {
-      // 有人在听：是自己的后端（上次残留/多开实例）则复用，陌生进程则跳过
+      // 有人在听：同版本自家后端复用，陌生进程跳过，陈旧自家后端定点终止后原地重启
       // eslint-disable-next-line no-await-in-loop
-      if (await isOurBackend(cand)) return cand
+      const verdict = decideReuse(await probeBackend(cand), { packaged: true, expectedBuild })
+      if (verdict === 'reuse') return cand
+      if (verdict === 'replace') {
+        // eslint-disable-next-line no-await-in-loop
+        const freed = await terminateStaleBackend(cand)
+        // eslint-disable-next-line no-await-in-loop
+        if (freed && await canBind(cand)) return cand
+        // 终止不了（权限/僵尸）：退而复用陈旧后端——它还握着 H2 文件锁，
+        // 硬起新后端只会双双卡死；陈旧但能用，好过打不开
+        console.warn(`[backend] 端口 ${cand} 上的陈旧后端无法终止，退而复用（功能可能落后于本体版本）`)
+        return cand
+      }
       continue
     }
     // eslint-disable-next-line no-await-in-loop
@@ -176,6 +281,8 @@ function spawnEnv(ctx) {
   if (!env.AWD_APP_VERSION) {
     try { env.AWD_APP_VERSION = require('electron').app.getVersion() } catch (e) { /* 非 electron 环境跳过 */ }
   }
+  // 后端 build 指纹：wizard 端点回显，复用前对比识破陈旧残留后端（见 backendBuildId）
+  env.AWD_BACKEND_BUILD = backendBuildId(ctx)
   return env
 }
 
@@ -215,8 +322,20 @@ function createBackendDescriptor() {
     eager: true,
     logName: 'backend',
     port: (ctx) => allocateBackendPort(ctx),
-    // 占用端口的监听者必须验明正身才可复用（防"粘"到陌生进程）
-    verifyReuse: (ctx, port) => isOurBackend(port),
+    // 占用端口的监听者必须验明正身才可复用（防"粘"到陌生进程）。
+    // 打包态额外校验 build 指纹：陈旧残留后端先定点终止（成功则返回 false 让
+    // 管理器重走分配链原地重启；失败则退而复用，理由见 allocateBackendPort）。
+    verifyReuse: async (ctx, port) => {
+      const verdict = decideReuse(await probeBackend(port), {
+        packaged: ctx.packaged, expectedBuild: backendBuildId(ctx),
+      })
+      if (verdict === 'reuse') return true
+      if (verdict === 'skip') return false
+      const freed = await terminateStaleBackend(port)
+      if (freed) return false
+      console.warn(`[backend] 端口 ${port} 上的陈旧后端无法终止，退而复用（功能可能落后于本体版本）`)
+      return true
+    },
     // 复用校验失败（分配后被抢）时重新走一遍分配链
     reallocatePort: (ctx) => allocateBackendPort(ctx),
     startTimeoutMs: (ctx) => (ctx.packaged ? 60000 : 15000),
@@ -230,4 +349,8 @@ function createBackendDescriptor() {
   }
 }
 
-module.exports = { createBackendDescriptor, backendLayout, javaLaunchArgs }
+module.exports = {
+  createBackendDescriptor, backendLayout, javaLaunchArgs,
+  // 复用版本闸的可测面（backend-reuse-gate.test.js）
+  decideReuse, probeBackend, backendBuildId,
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js"
+    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/tests/backend-reuse-gate.test.js
+++ b/desktop/tests/backend-reuse-gate.test.js
@@ -1,0 +1,76 @@
+// 后端复用版本闸（dev-board#139 根因之一）：更新后的应用把 8-21 残留的陈旧后端
+// 当自家后端直接复用，新前端打旧后端 404 且毫无提示。闸的裁决必须满足：
+//   陌生进程 skip / 同指纹自家后端 reuse / 打包态指纹不一致 replace / dev 态不看指纹。
+// 把 decideReuse 退回「只认 initialized 就复用」（旧行为）时，第 3、4 条会转红。
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const http = require('http')
+
+const { decideReuse, probeBackend } = require('../main/services/backend-service')
+
+test('decideReuse：陌生进程 skip（打包/dev 一致）', () => {
+  assert.equal(decideReuse({ ours: false, build: '' }, { packaged: true, expectedBuild: 'a' }), 'skip')
+  assert.equal(decideReuse({ ours: false, build: 'a' }, { packaged: false, expectedBuild: '' }), 'skip')
+})
+
+test('decideReuse：打包态同指纹复用，指纹不一致要求替换', () => {
+  assert.equal(decideReuse({ ours: true, build: '100-1' }, { packaged: true, expectedBuild: '100-1' }), 'reuse')
+  // 陈旧残留后端（更新前的 jar 指纹）——不许再被静默复用
+  assert.equal(decideReuse({ ours: true, build: '100-1' }, { packaged: true, expectedBuild: '200-2' }), 'replace')
+  // 旧版后端连 build 字段都没有（空串）——同样视为陈旧
+  assert.equal(decideReuse({ ours: true, build: '' }, { packaged: true, expectedBuild: '200-2' }), 'replace')
+})
+
+test('decideReuse：算不出期望指纹时不拦（新装/异常兜底），dev 态不看指纹', () => {
+  assert.equal(decideReuse({ ours: true, build: 'anything' }, { packaged: true, expectedBuild: '' }), 'reuse')
+  // dev 态后端由 restart-backend.sh 等外部流程拉起，没有注入指纹，不能被闸误杀
+  assert.equal(decideReuse({ ours: true, build: '' }, { packaged: false, expectedBuild: '999-9' }), 'reuse')
+})
+
+test('probeBackend：解析 wizard 响应的 initialized 特征与 build 指纹', async () => {
+  const srv = http.createServer((req, res) => {
+    if (req.url === '/api/admin/wizard') {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ code: 0, initialized: true, build: '4242-1724480000000' }))
+    } else {
+      res.statusCode = 404
+      res.end()
+    }
+  })
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r))
+  const port = srv.address().port
+  try {
+    const probe = await probeBackend(port)
+    assert.deepEqual(probe, { ours: true, build: '4242-1724480000000' })
+  } finally {
+    srv.close()
+  }
+})
+
+test('probeBackend：旧后端无 build 字段 → 空串；陌生响应 → ours=false', async () => {
+  const srv = http.createServer((req, res) => {
+    if (req.url === '/api/admin/wizard') {
+      res.end(JSON.stringify({ code: 0, initialized: false }))
+    } else {
+      res.end('hello')
+    }
+  })
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r))
+  const port = srv.address().port
+  try {
+    const probe = await probeBackend(port)
+    assert.equal(probe.ours, true)
+    assert.equal(probe.build, '')
+  } finally {
+    srv.close()
+  }
+
+  const stranger = http.createServer((req, res) => { res.end('not a backend') })
+  await new Promise((r) => stranger.listen(0, '127.0.0.1', r))
+  try {
+    const probe = await probeBackend(stranger.address().port)
+    assert.equal(probe.ours, false)
+  } finally {
+    stranger.close()
+  }
+})


### PR DESCRIPTION
维护者真机「0.24.2 的 UI 打着 08-21 的旧后端」的结构性根因：后端复用只验明身份不验版本。本 PR 给复用加 jar 指纹闸：同指纹复用、陈旧后端定点终止后原地重启、终止失败退而复用保可用性；dev 态不受影响。

dev-board: zeweihan/dev-board#139

🤖 Generated with [Claude Code](https://claude.com/claude-code)