### PR TITLE
fix(evidence): 建链失败可见回执 + 拖拽 ghost 修复（dev-board#139）

### DIFF
--- a/frontend/src/components/EvidenceMethodBar.vue
+++ b/frontend/src/components/EvidenceMethodBar.vue
@@ -1,30 +1,38 @@
 <template>
-  <view v-if="visible" class="evidence-bar" @mousedown.stop @tap.stop>
+  <view v-if="visible" class="evidence-bar" :class="{ 'is-error': isError }" @mousedown.stop @tap.stop>
     <svg class="evidence-bar-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path v-for="(d, i) in linkIcon" :key="i" :d="d" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
-    <text class="evidence-bar-linked">{{ $t('workbench.evidence.linked', { name: fileName }) }}</text>
-    <text class="evidence-bar-sep">·</text>
-    <text class="evidence-bar-label">{{ $t('workbench.evidence.methodLabel') }}</text>
-    <view class="evidence-bar-chips">
-      <view
-        v-for="m in methods"
-        :key="m"
-        class="evidence-chip"
-        :class="{ on: m === method }"
-        @tap="pick(m)"
-      >{{ $t('workbench.evidence.method.' + m) }}</view>
-    </view>
+    <template v-if="isError">
+      <text class="evidence-bar-linked">{{ $t('workbench.evidence.failedTitle', { name: fileName }) }}</text>
+      <text v-if="errorText" class="evidence-bar-error-text">{{ errorText }}</text>
+    </template>
+    <template v-else>
+      <text class="evidence-bar-linked">{{ $t('workbench.evidence.linked', { name: fileName }) }}</text>
+      <text class="evidence-bar-sep">·</text>
+      <text class="evidence-bar-label">{{ $t('workbench.evidence.methodLabel') }}</text>
+      <view class="evidence-bar-chips">
+        <view
+          v-for="m in methods"
+          :key="m"
+          class="evidence-chip"
+          :class="{ on: m === method }"
+          @tap="pick(m)"
+        >{{ $t('workbench.evidence.method.' + m) }}</view>
+      </view>
+    </template>
     <text class="evidence-bar-close" @tap="$emit('close')">x</text>
   </view>
 </template>
 
 <script>
-// 拖文件到编辑器建链成功后的 method 浮动小条（spec §4.1）。纯展示，状态在宿主
+// 拖文件到编辑器建链的回执小条（spec §4.1）。纯展示，状态在宿主
 // （evidenceLinkActions.js），这里只回传点击。
-// **不自动收起**：它既是「关联成功」的回执，又是「按什么方式核查」的提问，
-// 自动消失两件事都办不成（dev-board#138）。所以视觉上按"成功态"做：绿色描边 +
-// 链接图标，让用户在窗格底部一眼认出来，而不是当成一排普通 chip。
+// **不自动收起**：它既是回执，又是「按什么方式核查」的提问，自动消失两件事都
+// 办不成（dev-board#138）。成功态：绿色描边 + method chips。
+// **失败也走小条**（dev-board#139）：uni.showToast 在编辑器场景会被 webview
+// 遮挡（#133 定性），建链失败若只弹 toast 就是「文字变成了链接但库里没记录、
+// 用户毫无感知」——失败态红描边 + 原因，凡编辑器回执一律不用 toast。
 import { EVIDENCE_METHODS } from '@/utils/evidenceLocator.js'
 import { ICONS } from '@/config/icons.js'
 
@@ -36,6 +44,11 @@ export default {
     fileName: { type: String, default: '' },
     method: { type: String, default: 'written_review' },
     targetId: { type: [Number, String], default: null },
+    status: { type: String, default: 'success' },
+    errorText: { type: String, default: '' },
+  },
+  computed: {
+    isError() { return this.status === 'error' },
   },
   data() {
     return { methods: EVIDENCE_METHODS, linkIcon: ICONS.link }
@@ -60,6 +73,10 @@ export default {
   box-shadow: 0 6px 20px rgba(26, 83, 54, 0.22);
   font-size: 12px; color: #1e293b;
 }
+.evidence-bar.is-error { border-color: #B42318; box-shadow: 0 6px 20px rgba(180, 35, 24, 0.18); }
+.evidence-bar.is-error .evidence-bar-icon,
+.evidence-bar.is-error .evidence-bar-linked { color: #B42318; }
+.evidence-bar-error-text { color: #475569; max-width: 420px; }
 .evidence-bar-icon { width: 15px; height: 15px; flex: none; color: #1A5336; }
 .evidence-bar-linked { font-weight: 600; color: #1A5336; max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .evidence-bar-sep { color: #94a3b8; }

--- a/frontend/src/components/FileStagingArea.vue
+++ b/frontend/src/components/FileStagingArea.vue
@@ -107,6 +107,7 @@
 
 <script>
 import { ICONS } from '@/config/icons.js'
+import { warmDragImage, applyDragImage } from '@/utils/dragImage.js'
 import UnlockHint from '@/components/UnlockHint.vue'
 export default {
   name: 'FileStagingArea',
@@ -174,7 +175,8 @@ export default {
 
   },
   mounted() {
-      // Marquee listeners removed
+      // 预加载拖拽 ghost 小徽标（与 FileTree 同一份，见 utils/dragImage.js）
+      warmDragImage()
   },
   beforeUnmount() {
       // Marquee listeners removed
@@ -236,6 +238,8 @@ export default {
       // Standard data format for internal file drag
       if (event.dataTransfer) {
           event.dataTransfer.effectAllowed = 'copy'
+          // 小徽标拖拽影像：不设的话是整行元素快照（含 × 删除钮）浮在正文上
+          applyDragImage(event)
           // Use the same format as FileTree to handle drop in editors
           event.dataTransfer.setData('application/json', JSON.stringify(file))
           // Also text/plain for general use

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -917,6 +917,7 @@ import { groupByParent, buildTreeFromGroups } from '@/utils/fileTreeBuild.js'
 import { evidenceRefCounts } from '@/services/api.js'
 import { createRefCountsFetcher } from '@/utils/fileTreeRefCounts.js'
 import CircularProgress from '@/components/CircularProgress.vue'
+import { warmDragImage, applyDragImage } from '@/utils/dragImage.js'
 import FileTypeIcon from '@/components/FileTypeIcon.vue'
 import TagChip from '@/components/TagChip.vue'
 import TagSelector from '@/components/TagSelector.vue'
@@ -1319,6 +1320,8 @@ export default {
     }
   },
   mounted() {
+    // 预加载拖拽 ghost 小徽标（dragstart 现场加载来不及，见 utils/dragImage.js）
+    warmDragImage()
     // selectionMode 关闭时，确保不残留选中态
     if (!this.selectionMode) {
       this.clearChecked()
@@ -2558,11 +2561,9 @@ export default {
         // 允许 copy/link/move
         e.dataTransfer.effectAllowed = 'all'
 
-        // 设置自定义拖拽图片
-        const img = new Image()
-        img.src = '/static/Drag.png'
-        // 设置图片热点为中心 (假设图片大概 30x30, 这里的 offset 可以根据实际图调整)
-        e.dataTransfer.setDragImage(img, 15, 15)
+        // 自定义拖拽影像：预加载好的小徽标（见 utils/dragImage.js——现场 new Image
+        // 来不及加载，Chromium 会回退成整行元素快照，操作图标一起浮在正文上）
+        applyDragImage(e)
 
         // 设置拖拽数据
         try {

--- a/frontend/src/locales/en-US/workbench.js
+++ b/frontend/src/locales/en-US/workbench.js
@@ -214,6 +214,8 @@ export default {
   // EvidenceLink: drop-to-link in the editor / method bar / link locating (evidenceLinkActions.js, EvidenceMethodBar.vue, LibreOfficeEditor.vue)
   evidence: {
     selectFirst: 'Select the text to link first',
+    failedTitle: '"{name}" was not linked',
+    retryHint: '; drag onto the same text again to retry',
     selfLink: 'A document cannot be linked to itself',
     bookmarkFailed: 'Could not create the bookmark, reselect the text and try again',
     linked: 'Linked to "{name}"',

--- a/frontend/src/locales/zh-CN/workbench.js
+++ b/frontend/src/locales/zh-CN/workbench.js
@@ -212,6 +212,8 @@ export default {
   // EvidenceLink：拖到编辑器建链 / method 小条 / 链接定位（evidenceLinkActions.js、EvidenceMethodBar.vue、LibreOfficeEditor.vue）
   evidence: {
     selectFirst: '先选中要关联的文字',
+    failedTitle: '《{name}》未关联上',
+    retryHint: '；重新拖拽到同一段文字即可重试',
     selfLink: '不能把文档关联到自己',
     bookmarkFailed: '建立书签失败，请重新选中文字后再试',
     linked: '已关联《{name}》',

--- a/frontend/src/pages/project-overview/evidenceLinkActions.js
+++ b/frontend/src/pages/project-overview/evidenceLinkActions.js
@@ -22,9 +22,11 @@ function unwrap(resp) {
 export const evidenceLinkData = () => ({
   // method 浮动小条：连续拖放只保留最后一条（对象整体替换）。
   // docFileId 用于把小条钉在建链的那份文档上——换标签/关文档后它不该还挂着。
+  // status: 'success' | 'error'——失败回执也走小条（toast 会被编辑器 webview 遮挡，
+  // dev-board#133/#139：失败只弹 toast = 用户毫无感知的静默失败）。
   evidenceMethodBar: {
     visible: false, side: 'left', fileName: '', method: 'written_review',
-    targetId: null, linkKey: '', docFileId: null,
+    targetId: null, linkKey: '', docFileId: null, status: 'success', errorText: '',
   },
 })
 
@@ -43,7 +45,10 @@ export const evidenceLinkMethods = {
       return
     }
     if (Number(file.id) === Number(doc.id)) {
-      uni.showToast({ title: this.$t('workbench.evidence.selfLink'), icon: 'none' })
+      this.showEvidenceMethodBarError({
+        side, fileName: file.name || '', docFileId: Number(doc.id),
+        message: this.$t('workbench.evidence.selfLink'),
+      })
       return
     }
     const pid = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
@@ -55,13 +60,21 @@ export const evidenceLinkMethods = {
         projectId: pid, docFileId: Number(doc.id), file, internalBase: this.WPS_INTERNAL_HTTP_LINK_BASE || '',
       })
     } catch (e) {
-      uni.showToast({ title: (e && e.message) || this.$t('workbench.linkFailed'), icon: 'none' })
+      // API 入库失败：此时书签+超链接多半已写入文档（正文里文字已变成链接），
+      // 只弹 toast 会被 webview 遮挡成「看起来关联上了」的静默半成品——必须上小条。
+      // 重拖同一段文字会走 recovered 分支收编死锚点，提示里把这条路告诉用户。
+      this.showEvidenceMethodBarError({
+        side, fileName: file.name || '', docFileId: Number(doc.id),
+        message: ((e && e.message) || this.$t('workbench.linkFailed')) + this.$t('workbench.evidence.retryHint'),
+      })
       return
     }
     if (!res.ok) {
       const key = res.reason === 'no_selection' ? 'workbench.evidence.selectFirst'
         : res.reason === 'bookmark_failed' ? 'workbench.evidence.bookmarkFailed' : 'workbench.setHyperlinkFailed'
-      uni.showToast({ title: this.$t(key), icon: 'none' })
+      this.showEvidenceMethodBarError({
+        side, fileName: file.name || '', docFileId: Number(doc.id), message: this.$t(key),
+      })
       return
     }
     this.showEvidenceMethodBar({
@@ -82,6 +95,15 @@ export const evidenceLinkMethods = {
     this.evidenceMethodBar = {
       visible: true, side, fileName, method: 'written_review', targetId, linkKey,
       docFileId: docFileId == null ? null : Number(docFileId),
+      status: 'success', errorText: '',
+    }
+  },
+  /** 建链失败的回执小条（同一个位置、红描边）。toast 在编辑器场景会被 webview 遮挡，不许用。 */
+  showEvidenceMethodBarError({ side, fileName, docFileId, message }) {
+    this.evidenceMethodBar = {
+      visible: true, side, fileName, method: 'written_review', targetId: null, linkKey: '',
+      docFileId: docFileId == null ? null : Number(docFileId),
+      status: 'error', errorText: message || this.$t('workbench.linkFailed'),
     }
   },
   closeEvidenceMethodBar() {

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -835,6 +835,8 @@
                     :file-name="evidenceMethodBar.fileName"
                     :method="evidenceMethodBar.method"
                     :target-id="evidenceMethodBar.targetId"
+                    :status="evidenceMethodBar.status"
+                    :error-text="evidenceMethodBar.errorText"
                     @change="onEvidenceMethodChange"
                     @close="closeEvidenceMethodBar"
                   />
@@ -1011,6 +1013,8 @@
                     :file-name="evidenceMethodBar.fileName"
                     :method="evidenceMethodBar.method"
                     :target-id="evidenceMethodBar.targetId"
+                    :status="evidenceMethodBar.status"
+                    :error-text="evidenceMethodBar.errorText"
                     @change="onEvidenceMethodChange"
                     @close="closeEvidenceMethodBar"
                   />
@@ -3655,7 +3659,10 @@ export default {
     isEvidenceBarOnActiveDoc(activeFile) {
       const pinned = this.evidenceMethodBar && this.evidenceMethodBar.docFileId
       if (pinned == null) return true // 旧状态/测试桩没带 docFileId 时不收
-      return !!activeFile && Number(activeFile.id) === Number(pinned)
+      // Number() 出 NaN（非数值 id 文档）按未钉处理：NaN === NaN 恒 false 会让小条永久隐藏
+      const pinnedNum = Number(pinned)
+      if (!Number.isFinite(pinnedNum)) return true
+      return !!activeFile && Number(activeFile.id) === pinnedNum
     },
     isTabVisible(file) {
       if (!file) return false

--- a/frontend/src/utils/dragImage.js
+++ b/frontend/src/utils/dragImage.js
@@ -1,0 +1,42 @@
+// 文件拖拽的 ghost 小徽标（FileTree 与文件暂存区共用，dev-board#139）。
+//
+// 两个坑，都在这里一并解决：
+// 1) dragstart 里现场 `new Image()` 再 setDragImage：同步执行时图片还没加载完，
+//    Chromium 规定此时回退**拖拽源元素快照**——于是整行文件卡片（含悬停时显示的
+//    下载/复制/删除操作图标）浮在正文上。必须预加载，dragstart 只引用现成的。
+// 2) /static/Drag.png 原图 200x200：setDragImage 按图片固有尺寸渲染，直接用
+//    还是一个巨大 ghost。加载后经 canvas 缩成 32px 小徽标再用。
+let readyImage = null
+let warming = false
+
+export function warmDragImage() {
+  if (readyImage || warming) return
+  if (typeof Image === 'undefined' || typeof document === 'undefined') return
+  warming = true
+  const src = new Image()
+  src.onload = () => {
+    try {
+      const c = document.createElement('canvas')
+      c.width = 32
+      c.height = 32
+      c.getContext('2d').drawImage(src, 0, 0, 32, 32)
+      const small = new Image()
+      small.onload = () => { readyImage = small }
+      small.src = c.toDataURL('image/png')
+    } catch (e) {
+      // canvas 不可用（罕见）：退回原图，大总比整行快照好认
+      readyImage = src
+    }
+  }
+  src.src = '/static/Drag.png'
+}
+
+/** dragstart 里调用：徽标已就绪则设为拖拽影像，未就绪保持默认（下次就有了） */
+export function applyDragImage(e) {
+  if (!readyImage || !e || !e.dataTransfer) return
+  try {
+    e.dataTransfer.setDragImage(readyImage, 16, 16)
+  } catch (err) {
+    // 非 H5 环境无此 API
+  }
+}

--- a/frontend/tests/evidence/methodBarFailureReceipt.test.mjs
+++ b/frontend/tests/evidence/methodBarFailureReceipt.test.mjs
@@ -1,0 +1,107 @@
+// 建链失败也要有可见回执（dev-board#139）：uni.showToast 在编辑器场景会被 webview
+// 遮挡（#133 定性），失败只弹 toast = 「文字变成了链接但库里没记录、用户毫无感知」。
+// 这里锚定：onEvidenceDrop 的失败分支（API 异常 / no_selection / 自链）一律走
+// showEvidenceMethodBarError（红描边小条，钉在建链文档上），不再走 toast。
+// 把失败分支改回 uni.showToast 就会转红。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/pages/project-overview/evidenceLinkActions.js', import.meta.url), 'utf8')
+
+function extract(name, opts = {}) {
+  const re = new RegExp((opts.async ? 'async ' : '') + name + '\\((.*?)\\) \\{[\\s\\S]*?\\n  \\},')
+  const m = SRC.match(re)
+  assert.ok(m, '没找到 ' + name)
+  const body = m[0].replace(/,$/, '')
+  // 对象方法简写 → 函数表达式；外部依赖经参数注入
+  return new Function(
+    'createEvidenceLinkForDrop', 'uni',
+    'return ' + (opts.async ? 'async function ' : 'function ') + body.replace(/^async /, '')
+  )
+}
+
+function makeSelf() {
+  const toasts = []
+  const self = {
+    evidenceMethodBar: {
+      visible: false, side: 'left', fileName: '', method: 'written_review',
+      targetId: null, linkKey: '', docFileId: null, status: 'success', errorText: '',
+    },
+    activeFileLeft: { id: 10, name: '主文档.docx' },
+    activeFileRight: null,
+    projectId: '1',
+    WPS_INTERNAL_HTTP_LINK_BASE: 'https://x.local/open',
+    getLibreExecutorMap: () => ({ 'left:10': { executeCommand: async () => ({}) } }),
+    $t: (k) => k,
+    toasts,
+  }
+  const uniStub = { showToast: (o) => toasts.push(o), $emit: () => {} }
+  // showEvidenceMethodBar / showEvidenceMethodBarError 用文件里的真实现
+  self.showEvidenceMethodBar = extract('showEvidenceMethodBar')(null, uniStub).bind(self)
+  self.showEvidenceMethodBarError = extract('showEvidenceMethodBarError')(null, uniStub).bind(self)
+  return { self, uniStub, toasts }
+}
+
+const payload = { file: { id: 77, name: '营业执照.pdf', fileType: 'pdf' } }
+
+test('API 入库失败 → 红描边小条钉在建链文档上，不弹 toast', async () => {
+  const { self, uniStub, toasts } = makeSelf()
+  const drop = extract('onEvidenceDrop', { async: true })(
+    async () => { throw new Error('HTTP 404') }, uniStub
+  )
+  await drop.call(self, payload, 'left')
+  assert.equal(self.evidenceMethodBar.visible, true)
+  assert.equal(self.evidenceMethodBar.status, 'error')
+  assert.equal(self.evidenceMethodBar.docFileId, 10)
+  assert.match(self.evidenceMethodBar.errorText, /HTTP 404/)
+  assert.match(self.evidenceMethodBar.errorText, /retryHint/)
+  assert.equal(toasts.length, 0, '失败回执不许走 toast（会被 webview 遮挡）')
+})
+
+test('无选区 → 小条失败态提示先选文字，不弹 toast', async () => {
+  const { self, uniStub, toasts } = makeSelf()
+  const drop = extract('onEvidenceDrop', { async: true })(
+    async () => ({ ok: false, reason: 'no_selection' }), uniStub
+  )
+  await drop.call(self, payload, 'left')
+  assert.equal(self.evidenceMethodBar.status, 'error')
+  assert.match(self.evidenceMethodBar.errorText, /selectFirst/)
+  assert.equal(toasts.length, 0)
+})
+
+test('拖到自己身上 → 小条失败态，不弹 toast', async () => {
+  const { self, uniStub, toasts } = makeSelf()
+  const drop = extract('onEvidenceDrop', { async: true })(
+    async () => { throw new Error('不该走到建链') }, uniStub
+  )
+  await drop.call(self, { file: { id: 10, name: '主文档.docx' } }, 'left')
+  assert.equal(self.evidenceMethodBar.status, 'error')
+  assert.match(self.evidenceMethodBar.errorText, /selfLink/)
+  assert.equal(toasts.length, 0)
+})
+
+test('成功路径回执为成功态（status=success，method chips 语境）', async () => {
+  const { self, uniStub } = makeSelf()
+  const drop = extract('onEvidenceDrop', { async: true })(
+    async () => ({ ok: true, linkKey: 'EVID_X', targetId: 501, view: { targets: [] } }), uniStub
+  )
+  await drop.call(self, payload, 'left')
+  assert.equal(self.evidenceMethodBar.visible, true)
+  assert.equal(self.evidenceMethodBar.status, 'success')
+  assert.equal(self.evidenceMethodBar.errorText, '')
+  assert.equal(self.evidenceMethodBar.linkKey, 'EVID_X')
+})
+
+test('失败态被新的一次成功整体替换（连续拖放只留最后一条）', async () => {
+  const { self, uniStub } = makeSelf()
+  const fail = extract('onEvidenceDrop', { async: true })(async () => { throw new Error('x') }, uniStub)
+  await fail.call(self, payload, 'left')
+  assert.equal(self.evidenceMethodBar.status, 'error')
+  const ok = extract('onEvidenceDrop', { async: true })(
+    async () => ({ ok: true, linkKey: 'EVID_Y', targetId: 1, view: { targets: [] } }), uniStub
+  )
+  await ok.call(self, payload, 'left')
+  assert.equal(self.evidenceMethodBar.status, 'success')
+  assert.equal(self.evidenceMethodBar.errorText, '')
+})

--- a/frontend/tests/evidence/methodBarPinnedDoc.test.mjs
+++ b/frontend/tests/evidence/methodBarPinnedDoc.test.mjs
@@ -33,3 +33,8 @@ test('没带 docFileId 的旧状态 → 不收（不因为兼容问题把回执�
   const self = { evidenceMethodBar: { docFileId: null } }
   assert.equal(fn.call(self, { id: 8 }), true)
 })
+
+test('docFileId 非数值（Number→NaN）按未钉处理 → 不收（NaN===NaN 恒 false 会把小条永久藏死）', () => {
+  const self = { evidenceMethodBar: { docFileId: 'not-a-number' } }
+  assert.equal(fn.call(self, { id: 8 }), true)
+})


### PR DESCRIPTION
配合 #589（后端复用版本闸）根治「拖拽建链看似成功实则静默失败、小条从不出现」：失败回执上小条（红描边、钉文档，不再用会被 webview 遮挡的 toast）；拖拽 ghost 改预加载 32px 小徽标（原来是未加载图回退成整行快照）；NaN 加固。测试 24 条全绿，含还原病灶转红校验。

dev-board: zeweihan/dev-board#139

🤖 Generated with [Claude Code](https://claude.com/claude-code)