### PR TITLE
chore(release): v0.25.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.24.2",
+  "version": "0.25.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本升到 0.25.0（大版本全量包：#589 动了 Electron 壳，overlay 盖不到）。四项修复随版：#587/#588/#589/#590。门禁 mvn 2681/0、app-e2e 131/0、lowa-e2e 461/0、desktop 单测 76/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)