### PR TITLE
fix(desktop-tests): drawio 测试 teardown 加 EPERM/EBUSY 外层短重试（dev-board#146）

### DIFF
--- a/desktop/tests/drawio-server.test.js
+++ b/desktop/tests/drawio-server.test.js
@@ -44,8 +44,24 @@ function seedPack(packsDir, opts = {}) {
 // 一起卡死——当句柄正是本进程读流 autoClose 排队待跑的 fs.close 时，同步重试
 // 给多大预算都永远等不到释放（run 32237671073 实测 5.6s 预算整段跑穿）。
 // fs.promises.rm 的重试间隔走 setTimeout，让出事件循环，挂起的 close 才有机会执行。
-function rmrf(dir) {
-  return fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+//
+// 外层再包一圈 EPERM/EBUSY 短重试：windows-latest 上 Defender 实时扫描会拿着
+// 排他句柄锁临时文件，rm 内部扫描目录的 lstat 直接报 EPERM（形态：hookFailed
+// "EPERM: operation not permitted, lstat '...\Temp\drawio-*\index.html'"，
+// 2026-08-24 一天内咬了两次、rerun 即绿，run 32709185491）。rm 自带的
+// maxRetries=10/retryDelay=100 总预算约 5.5s，扫描锁窗口可以更长，且内部
+// 重试次数用完就把 EPERM 原样抛出——t.after 里一抛就是 hookFailed。这里每轮
+// 都是完整重跑 rm（诚实重试，不跳过、不吞其它错误码），重试仍失败就照常抛。
+async function rmrf(dir) {
+  const RETRIES = 3
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    } catch (e) {
+      if ((e.code !== 'EPERM' && e.code !== 'EBUSY') || attempt >= RETRIES) throw e
+      await new Promise((r) => setTimeout(r, 500 * (attempt + 1)))
+    }
+  }
 }
 
 function get(origin, urlPath) {


### PR DESCRIPTION
## 背景
desktop/tests/drawio-server.test.js 在 windows-latest runner 上间歇性 hookFailed：
`EPERM: operation not permitted, lstat 'C:\Users\RUNNER~1\AppData\Local\Temp\drawio-*\index.html'`。
2026-08-24 一天内咬了两次（用例 16 与 20 各一次，rerun 即绿，run 32709185491），疑为 Defender 实时扫描持排他句柄锁临时文件。

## 根因
teardown 的 rmrf 已用 `fs.promises.rm` 自带重试（maxRetries=10 / retryDelay=100，总预算约 5.5s），但 Defender 扫描锁窗口可以更长；内部重试次数用完后 EPERM 原样抛出，`t.after` 里一抛就是 hookFailed。

## 修法
rmrf 外层加最多 3 轮针对 EPERM/EBUSY 的短重试（500ms 递增间隔），每轮完整重跑 rm。诚实重试：不跳过用例、不伪造被测行为、其它错误码照常抛出。形态已记录在测试注释里。

## 验证
- 本机 `desktop npm test` 76/76 全绿（先 npm ci 补齐 worktree 依赖）。
- Windows 侧靠常规 CI 验证。

关联：dev-board#146

🤖 Generated with [Claude Code](https://claude.com/claude-code)