### PR TITLE
feat(feedback): 云端反馈控制台——邮件直达链接+浏览器看图听语音（dev-board#151）

### DIFF
--- a/.claude/agents/feedback-optimizer.md
+++ b/.claude/agents/feedback-optimizer.md
@@ -43,7 +43,21 @@ description: 用户反馈闭环领域。任务涉及右下角反馈浮窗、反�
 - `controller/OptimizerController` — `/api/optimizer/run|status`（管理员，run 是异步）
 - 维护者机器上的常驻配方：`deploy/optimizer/`（run 脚本 + launchd plist + 搬机器步骤）
 
-**看板**：`frontend/src/pages/admin/admin.vue` 的 `activeNav === 'feedback'` 分区
+**看板**：`frontend/src/components/admin/AdminPane.vue` 的 `activeNav === 'feedback'` 分区
+（`pages/admin/admin.vue` 只是薄壳）——这是桌面端本地库的入口。
+
+**反馈控制台（云端收件箱的浏览器入口，2026-08-25 dev-board#151）**
+- `backend/src/main/resources/static/feedback-console/index.html` — 自包含单页，
+  jar 的 classpath:/static/ 直接托管在 `/feedback-console/`；云端 nginx 有一条
+  location 反代给后端（`deploy/cloud/nginx-addin.conf.example`）。
+- 由来：h5 客户端（含 admin 看板）2026-08-19 从 addin.aiworkdeck.com 退役后，
+  云端收件箱在浏览器里没有任何入口，优化者邮件里的裸附件 API 地址点开是 403 死胡同。
+- 优化者通知里的直达链接来自 `OptimizerFeedbackSource.consoleRef(fb)`（default null）：
+  Remote 来源返回 `<baseUrl>/feedback-console/?fb=<id>`，Local 来源保持 null
+  （桌面端自带 admin 看板），正文里就不出现这一节。
+- 页面安全约定：用户可控文本一律 textContent 渲染；附件用 fetch + `X-Session-Id`
+  头取 blob 再喂给 `<img>`/`<audio>`，凭据不进 URL（URL 里的 token 会落 nginx access log）。
+  登录支持 4005 二次验证（totp/sms/mail）。会话键与 h5 同名 `checkba_session_id`。
 
 ## 不变式（改之前先读）
 

--- a/backend/src/main/java/com/checkba/config/FeedbackConsoleConfig.java
+++ b/backend/src/main/java/com/checkba/config/FeedbackConsoleConfig.java
@@ -1,0 +1,25 @@
+package com.checkba.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 反馈控制台（classpath:/static/feedback-console/index.html）的目录路径转发。
+ *
+ * <p>Spring Boot 的 welcome page 机制只作用于根路径，/feedback-console/ 这种
+ * 子目录不会自动落到它的 index.html 上——优化者邮件里的直达链接
+ * （/feedback-console/?fb=N）会 500。forward 保留原始请求的 query string，
+ * 页面 JS 读 location.search 不受影响。
+ */
+@Configuration
+public class FeedbackConsoleConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/feedback-console")
+                .setViewName("forward:/feedback-console/index.html");
+        registry.addViewController("/feedback-console/")
+                .setViewName("forward:/feedback-console/index.html");
+    }
+}

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerFeedbackSource.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerFeedbackSource.java
@@ -28,6 +28,15 @@ public interface OptimizerFeedbackSource {
     /** 邮件里给维护者看的附件地址（本地是磁盘路径，远端是可直接打开的 URL）。 */
     String attachmentRef(UserFeedback fb, FeedbackAttachment a);
 
+    /**
+     * 这条反馈在浏览器里的直达地址（反馈控制台，登录后看图听语音），没有就返回 null。
+     * 远端来源指向云端后台的 /feedback-console/；本地来源没有浏览器入口（桌面端
+     * 自带 admin 看板），返回 null，通知正文里就不出现这一行。
+     */
+    default String consoleRef(UserFeedback fb) {
+        return null;
+    }
+
     /** 人话描述，进状态接口，方便一眼看出这台优化者在读谁。 */
     String describe();
 }

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerIssueNotifier.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerIssueNotifier.java
@@ -145,7 +145,7 @@ public class OptimizerIssueNotifier implements OptimizerNotifier {
                 sb.append("- ").append(a.getType()).append(' ')
                         .append(source == null ? a.getStoredName() : source.attachmentRef(fb, a)).append('\n');
             }
-            sb.append("\n附件地址是收件箱上的：直接点开要先登录那台后台，也可以带取件密钥取——\n")
+            sb.append("\n附件裸地址在浏览器里会 403（要带凭据），命令行取用取件密钥——\n")
                     .append("`curl -H \"X-Optimizer-Token: <token>\" '<地址>' -o shot.png`\n");
             boolean audioNoTranscript = attachments.stream()
                     .anyMatch(a -> FeedbackAttachment.TYPE_AUDIO.equals(a.getType()))
@@ -153,6 +153,12 @@ public class OptimizerIssueNotifier implements OptimizerNotifier {
             if (audioNoTranscript) {
                 sb.append("\n> 这条带语音但没有转写，内容需要你亲自听一遍。\n");
             }
+        }
+
+        // 反馈控制台直达（有浏览器入口的来源才有）
+        String console = source == null ? null : source.consoleRef(fb);
+        if (console != null && !console.isBlank()) {
+            sb.append("\n在浏览器里看这条反馈（登录 admin 后直接看截图、听语音）：").append(console).append('\n');
         }
         return sb.toString();
     }

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerMailer.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerMailer.java
@@ -162,8 +162,16 @@ public class OptimizerMailer implements OptimizerNotifier {
             }
         }
 
+        // 反馈控制台直达（有浏览器入口的来源才有；本地来源为 null，不出现这一行）
+        String console = source == null ? null : source.consoleRef(fb);
+        if (console != null && !console.isBlank()) {
+            sb.append("\n== 在浏览器里看这条反馈 ==\n")
+                    .append(console).append('\n')
+                    .append("（登录 admin 后直接看截图、听语音，不用 curl）\n");
+        }
+
         sb.append("\n--\n")
-                .append("附件是 http(s) 地址时，直接点开需要先登录那台后台；也可以带取件密钥取：\n")
+                .append("附件裸地址在浏览器里会 403（要带凭据），命令行取用取件密钥：\n")
                 .append("  curl -H \"X-Optimizer-Token: <你的 token>\" '<附件地址>' -o shot.png\n")
                 .append("这封信由 AI WorkDeck 优化者自动发出。**回信不会被系统读取**——\n")
                 .append("要推进就直接去改代码，或把这条反馈的 status 改掉（表 user_feedback，id=")

--- a/backend/src/main/java/com/checkba/service/optimizer/RemoteFeedbackSource.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/RemoteFeedbackSource.java
@@ -140,6 +140,11 @@ public class RemoteFeedbackSource implements OptimizerFeedbackSource {
     }
 
     @Override
+    public String consoleRef(UserFeedback fb) {
+        return baseUrl + "/feedback-console/?fb=" + fb.getId();
+    }
+
+    @Override
     public String describe() {
         return "云端收件箱 " + baseUrl;
     }

--- a/backend/src/main/resources/static/feedback-console/index.html
+++ b/backend/src/main/resources/static/feedback-console/index.html
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>反馈控制台 - AI WorkDeck</title>
+<!--
+  维护者用的反馈控制台：优化者邮件里的「后台直达」链接落在这里。
+  登录 admin 账号后直接看截图、听语音（h5 客户端 2026-08-19 已从云端退役，
+  这一页就是云端收件箱唯一的浏览器入口）。
+
+  由 backend.jar 的 classpath:/static/ 直接托管（路径 /feedback-console/），
+  云端 nginx 需要一条 location 把本路径反代给后端（见 deploy/cloud/nginx-addin.conf.example）。
+
+  安全约定：
+  - 反馈正文/用户名是用户可控输入，渲染一律 textContent，绝不 innerHTML；
+  - 附件用 fetch + X-Session-Id 头取回 blob 再放给 <img>/<audio>，
+    凭据不进 URL（URL 里的 token 会落 nginx access log）。
+-->
+<style>
+  :root {
+    --ink: #1f2328;
+    --ink-soft: #57606a;
+    --paper: #faf9f7;
+    --card: #ffffff;
+    --line: #e4e1db;
+    --accent: #1a5336;
+    --accent-soft: #eef4f0;
+    --warn: #9d3b3b;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font: 15px/1.7 -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 32px 20px 64px; }
+  header.site {
+    display: flex; align-items: baseline; gap: 12px;
+    border-bottom: 1px solid var(--line); padding-bottom: 14px; margin-bottom: 24px;
+  }
+  header.site h1 {
+    font: 600 20px/1.3 "Songti SC", "STSong", Georgia, serif;
+    margin: 0; letter-spacing: .02em;
+  }
+  header.site .who { margin-left: auto; color: var(--ink-soft); font-size: 13px; }
+  header.site .who a { color: var(--accent); cursor: pointer; text-decoration: none; }
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 20px 24px; margin-bottom: 16px;
+  }
+  .muted { color: var(--ink-soft); font-size: 13px; }
+  .error-line { color: var(--warn); font-size: 14px; min-height: 1.5em; margin: 8px 0 0; }
+  /* 登录 */
+  .login-card { max-width: 400px; margin: 48px auto 0; }
+  .login-card h2 { font: 600 17px/1.4 "Songti SC", Georgia, serif; margin: 0 0 4px; }
+  .field { margin-top: 14px; }
+  .field label { display: block; font-size: 13px; color: var(--ink-soft); margin-bottom: 4px; }
+  .field input {
+    width: 100%; padding: 9px 12px; font-size: 15px;
+    border: 1px solid var(--line); border-radius: 8px; background: #fff; color: var(--ink);
+  }
+  .field input:focus { outline: none; border-color: var(--accent); }
+  .btn {
+    display: inline-block; margin-top: 18px; padding: 9px 22px;
+    background: var(--accent); color: #fff; border: none; border-radius: 8px;
+    font-size: 15px; cursor: pointer;
+  }
+  .btn[disabled] { opacity: .5; cursor: default; }
+  .btn.ghost {
+    background: transparent; color: var(--accent);
+    border: 1px solid var(--accent); margin-left: 10px;
+  }
+  /* 列表 */
+  table.fb-list { width: 100%; border-collapse: collapse; font-size: 14px; }
+  table.fb-list th, table.fb-list td {
+    text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  table.fb-list th { color: var(--ink-soft); font-weight: 500; white-space: nowrap; }
+  table.fb-list tr.row { cursor: pointer; }
+  table.fb-list tr.row:hover { background: var(--accent-soft); }
+  .tag {
+    display: inline-block; padding: 1px 8px; border-radius: 999px;
+    font-size: 12px; background: var(--accent-soft); color: var(--accent); white-space: nowrap;
+  }
+  .tag.gray { background: #f0efec; color: var(--ink-soft); }
+  /* 详情 */
+  .detail h2 { font: 600 18px/1.4 "Songti SC", Georgia, serif; margin: 0 0 2px; }
+  .meta-line { color: var(--ink-soft); font-size: 13px; margin-bottom: 14px; }
+  .sec-title {
+    font-size: 13px; color: var(--ink-soft); letter-spacing: .06em;
+    margin: 18px 0 6px; text-transform: uppercase;
+  }
+  .quote {
+    border-left: 3px solid var(--accent); background: var(--accent-soft);
+    padding: 10px 14px; border-radius: 0 8px 8px 0; white-space: pre-wrap; word-break: break-word;
+  }
+  .att-block { margin-top: 10px; }
+  .att-block img {
+    max-width: 100%; border: 1px solid var(--line); border-radius: 8px; display: block;
+  }
+  .att-block audio { width: 100%; margin-top: 4px; }
+  .att-name { font-size: 13px; color: var(--ink-soft); margin: 10px 0 4px; }
+  .att-name a { color: var(--accent); }
+  pre.ctx {
+    background: #f6f5f2; border: 1px solid var(--line); border-radius: 8px;
+    padding: 12px 14px; font-size: 12.5px; line-height: 1.6; overflow-x: auto;
+    white-space: pre-wrap; word-break: break-word;
+  }
+  details summary { cursor: pointer; color: var(--ink-soft); font-size: 13px; }
+  a.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="site">
+    <h1>AI WorkDeck 反馈控制台</h1>
+    <span class="who" id="who"></span>
+  </header>
+
+  <!-- 登录 -->
+  <div id="view-login" class="card login-card hidden">
+    <h2>登录后台</h2>
+    <p class="muted">反馈附件里有用户的截图与运行现场，需要 admin 账号。</p>
+    <div id="login-step-pwd">
+      <div class="field">
+        <label for="in-user">账号</label>
+        <input id="in-user" autocomplete="username" value="admin">
+      </div>
+      <div class="field">
+        <label for="in-pass">密码</label>
+        <input id="in-pass" type="password" autocomplete="current-password">
+      </div>
+    </div>
+    <div id="login-step-code" class="hidden">
+      <div class="field">
+        <label for="in-code" id="code-label">验证码</label>
+        <input id="in-code" inputmode="numeric" autocomplete="one-time-code">
+      </div>
+      <button class="btn ghost" id="btn-resend" type="button">重发验证码</button>
+    </div>
+    <button class="btn" id="btn-login" type="button">登录</button>
+    <p class="error-line" id="login-error"></p>
+  </div>
+
+  <!-- 列表 -->
+  <div id="view-list" class="card hidden">
+    <p class="muted" style="margin-top:0">最近 100 条反馈，点击查看详情。</p>
+    <table class="fb-list">
+      <thead><tr><th>#</th><th>类型</th><th>状态</th><th>时间</th><th>用户</th><th>内容</th></tr></thead>
+      <tbody id="list-body"></tbody>
+    </table>
+    <p class="muted" id="list-empty" style="display:none">还没有反馈。</p>
+  </div>
+
+  <!-- 详情 -->
+  <div id="view-detail" class="card detail hidden">
+    <p style="margin:0 0 12px"><a class="back" href="./">&larr; 全部反馈</a></p>
+    <h2 id="d-title"></h2>
+    <p class="meta-line" id="d-meta"></p>
+    <div class="sec-title">用户原话</div>
+    <div class="quote" id="d-text"></div>
+    <div id="d-transcript-wrap" class="hidden">
+      <div class="sec-title">语音转写</div>
+      <div class="quote" id="d-transcript"></div>
+    </div>
+    <div id="d-atts"></div>
+    <div id="d-triage-wrap" class="hidden">
+      <div class="sec-title">优化者分诊</div>
+      <div id="d-triage" style="white-space:pre-wrap"></div>
+    </div>
+    <div id="d-ctx-wrap" class="hidden" style="margin-top:16px">
+      <details><summary>运行现场（contextJson）</summary><pre class="ctx" id="d-ctx"></pre></details>
+    </div>
+    <p class="error-line" id="detail-error"></p>
+  </div>
+
+  <p class="muted" id="global-loading" style="text-align:center">加载中…</p>
+</div>
+
+<script>
+(function () {
+  'use strict';
+  var SID_KEY = 'checkba_session_id'; // 与既有 h5 客户端同键，历史会话可直接续用
+  var qs = new URLSearchParams(location.search);
+  var fbId = /^\d+$/.test(qs.get('fb') || '') ? qs.get('fb') : null;
+  var pendingSecondFactor = null; // 4005 信封里的 method
+
+  function $(id) { return document.getElementById(id); }
+  function show(id) { $(id).classList.remove('hidden'); }
+  function hide(id) { $(id).classList.add('hidden'); }
+  function sid() { try { return localStorage.getItem(SID_KEY) || ''; } catch (e) { return ''; } }
+
+  function showView(name) {
+    ['view-login', 'view-list', 'view-detail'].forEach(function (v) { hide(v); });
+    hide('global-loading');
+    show(name);
+  }
+
+  function api(path, opts) {
+    opts = opts || {};
+    var headers = opts.headers || {};
+    var s = sid();
+    if (s) headers['X-Session-Id'] = s;
+    if (opts.json) headers['Content-Type'] = 'application/json';
+    return fetch(path, {
+      method: opts.method || 'GET',
+      headers: headers,
+      body: opts.json ? JSON.stringify(opts.json) : undefined
+    });
+  }
+
+  // 需要登录：HTTP 401/403，或业务信封 code=4010
+  function needsLogin(httpStatus, body) {
+    if (httpStatus === 401 || httpStatus === 403) return true;
+    return !!(body && body.code === 4010);
+  }
+
+  function kindLabel(k) { return k === 'IDEA' ? '建议' : '报障'; }
+  function statusLabel(s) {
+    return ({ NEW: '待处理', PR_OPENED: '已开 PR', EMAILED: '已发邮件',
+      SKIPPED: '已跳过', FAILED: '处理失败' })[s] || s || '';
+  }
+  function shortTime(t) { return t ? String(t).replace('T', ' ').slice(0, 16) : ''; }
+
+  // ---------- 登录 ----------
+  function showLogin(msg) {
+    showView('view-login');
+    $('login-error').textContent = msg || '';
+    $('in-pass').focus();
+  }
+
+  function sendCode() {
+    var payload = { scene: 'login', username: $('in-user').value.trim(), password: $('in-pass').value };
+    var path = pendingSecondFactor === 'mail' ? '/api/auth/mail/send-code' : '/api/auth/sms/send-code';
+    api(path, { method: 'POST', json: payload }).then(function (r) { return r.json(); })
+      .then(function (body) {
+        if (body.code === 0) {
+          var masked = body.data && (body.data.emailMasked || body.data.phoneMasked);
+          $('login-error').textContent = '验证码已发送' + (masked ? '至 ' + masked : '');
+        } else {
+          $('login-error').textContent = body.message || '发送失败';
+        }
+      })
+      .catch(function () { $('login-error').textContent = '网络错误，发送失败'; });
+  }
+
+  function doLogin() {
+    var btn = $('btn-login');
+    btn.disabled = true;
+    $('login-error').textContent = '';
+    var payload = { username: $('in-user').value.trim(), password: $('in-pass').value };
+    var code = $('in-code').value.trim();
+    if (pendingSecondFactor && code) payload.smsCode = code;
+    api('/api/auth/login', { method: 'POST', json: payload })
+      .then(function (r) { return r.json(); })
+      .then(function (body) {
+        btn.disabled = false;
+        if (body.code === 0 && body.data && body.data.sessionId) {
+          try { localStorage.setItem(SID_KEY, body.data.sessionId); } catch (e) {}
+          pendingSecondFactor = null;
+          init();
+          return;
+        }
+        if (body.code === 4005) {
+          // 密码已对，进入二次验证（TOTP 的码在认证器里，不必发）
+          pendingSecondFactor = (body.data && body.data.method) || 'sms';
+          show('login-step-code');
+          $('code-label').textContent = pendingSecondFactor === 'totp' ? '认证器动态码'
+            : pendingSecondFactor === 'mail' ? '邮箱验证码' : '短信验证码';
+          if (pendingSecondFactor === 'totp') { $('btn-resend').classList.add('hidden'); }
+          else { $('btn-resend').classList.remove('hidden'); sendCode(); }
+          $('in-code').focus();
+          return;
+        }
+        $('login-error').textContent = body.message || '登录失败';
+      })
+      .catch(function () {
+        btn.disabled = false;
+        $('login-error').textContent = '网络错误，请重试';
+      });
+  }
+
+  // ---------- 附件（blob 取回，凭据走请求头，不进 URL）----------
+  function attachTo(container, feedbackId, att) {
+    var nameLine = document.createElement('div');
+    nameLine.className = 'att-name';
+    nameLine.textContent = (att.type || '') + ' · ' + (att.name || '附件 ' + att.id)
+      + (att.sizeBytes ? ' · ' + Math.max(1, Math.round(att.sizeBytes / 1024)) + ' KB' : '');
+    container.appendChild(nameLine);
+
+    var block = document.createElement('div');
+    block.className = 'att-block';
+    block.textContent = '附件加载中…';
+    container.appendChild(block);
+
+    api('/api/feedback/' + feedbackId + '/attachment/' + att.id)
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.blob();
+      })
+      .then(function (blob) {
+        block.textContent = '';
+        var url = URL.createObjectURL(blob);
+        if (att.type === 'IMAGE') {
+          var img = document.createElement('img');
+          img.src = url;
+          img.alt = att.name || '';
+          block.appendChild(img);
+        } else if (att.type === 'AUDIO') {
+          var audio = document.createElement('audio');
+          audio.controls = true;
+          audio.src = url;
+          block.appendChild(audio);
+        }
+        // 统一给一条下载链接兜底（浏览器放不了 webm 时至少能下走）
+        var dl = document.createElement('a');
+        dl.href = url;
+        dl.download = att.name || ('attachment-' + att.id);
+        dl.textContent = '下载原件';
+        dl.style.fontSize = '13px';
+        var p = document.createElement('div');
+        p.className = 'att-name';
+        p.appendChild(dl);
+        block.appendChild(p);
+      })
+      .catch(function (e) {
+        block.textContent = '附件加载失败（' + e.message + '）';
+      });
+  }
+
+  // ---------- 详情 ----------
+  function renderDetail(d) {
+    showView('view-detail');
+    $('d-title').textContent = '反馈 #' + d.id + '（' + kindLabel(d.kind) + '）';
+    var meta = [statusLabel(d.status), shortTime(d.createdAt), d.username,
+      d.page, d.appVersion, d.platform].filter(Boolean).join(' · ');
+    $('d-meta').textContent = meta;
+    $('d-text').textContent = (d.text && d.text.trim()) || '（没写文字）';
+
+    if (d.voiceTranscript) {
+      show('d-transcript-wrap');
+      $('d-transcript').textContent = d.voiceTranscript;
+    }
+
+    var atts = d.attachments || [];
+    var host = $('d-atts');
+    host.textContent = '';
+    if (atts.length) {
+      var title = document.createElement('div');
+      title.className = 'sec-title';
+      title.textContent = '附件（' + atts.length + ' 件）';
+      host.appendChild(title);
+      atts.forEach(function (a) { attachTo(host, d.id, a); });
+    }
+
+    var triageLines = [];
+    if (d.triageVerdict) triageLines.push('判定：' + d.triageVerdict);
+    if (d.triageJson) {
+      try {
+        var t = JSON.parse(d.triageJson);
+        if (t.summary) triageLines.push('复述：' + t.summary);
+        if (t.reason) triageLines.push('依据：' + t.reason);
+        if (t.severity) triageLines.push('严重度：' + t.severity);
+      } catch (e) { /* 非 JSON 就只显示 verdict */ }
+    }
+    if (triageLines.length) {
+      show('d-triage-wrap');
+      $('d-triage').textContent = triageLines.join('\n');
+    }
+
+    if (d.contextJson) {
+      show('d-ctx-wrap');
+      var pretty = d.contextJson;
+      try { pretty = JSON.stringify(JSON.parse(d.contextJson), null, 2); } catch (e) {}
+      $('d-ctx').textContent = pretty;
+    }
+  }
+
+  function loadDetail(id) {
+    api('/api/feedback/' + id).then(function (r) {
+      return r.json().catch(function () { return {}; }).then(function (body) {
+        if (needsLogin(r.status, body)) { showLogin(sid() ? '会话已过期或不是 admin 账号，请重新登录' : ''); return; }
+        if (body.code === 0 && body.data) { renderDetail(body.data); return; }
+        showView('view-detail');
+        $('detail-error').textContent = body.message || ('加载失败（HTTP ' + r.status + '）');
+      });
+    }).catch(function () {
+      showView('view-detail');
+      $('detail-error').textContent = '网络错误，加载失败';
+    });
+  }
+
+  // ---------- 列表 ----------
+  function renderList(items) {
+    showView('view-list');
+    var tbody = $('list-body');
+    tbody.textContent = '';
+    $('list-empty').style.display = items.length ? 'none' : 'block';
+    items.forEach(function (fb) {
+      var tr = document.createElement('tr');
+      tr.className = 'row';
+      function td(text) {
+        var el = document.createElement('td');
+        el.textContent = text == null ? '' : String(text);
+        tr.appendChild(el);
+        return el;
+      }
+      td(fb.id);
+      var kindTd = document.createElement('td');
+      var kindTag = document.createElement('span');
+      kindTag.className = 'tag' + (fb.kind === 'IDEA' ? ' gray' : '');
+      kindTag.textContent = kindLabel(fb.kind);
+      kindTd.appendChild(kindTag);
+      tr.appendChild(kindTd);
+      td(statusLabel(fb.status));
+      td(shortTime(fb.createdAt));
+      td(fb.username);
+      var snippet = (fb.text && fb.text.trim()) || fb.voiceTranscript || '（语音/截图）';
+      td(snippet.length > 60 ? snippet.slice(0, 60) + '…' : snippet);
+      tr.addEventListener('click', function () { location.search = '?fb=' + fb.id; });
+      tbody.appendChild(tr);
+    });
+  }
+
+  function loadList() {
+    api('/api/feedback?limit=100').then(function (r) {
+      return r.json().catch(function () { return {}; }).then(function (body) {
+        if (needsLogin(r.status, body)) { showLogin(sid() ? '会话已过期或不是 admin 账号，请重新登录' : ''); return; }
+        if (body.code === 0 && body.data) { renderList(body.data.items || []); return; }
+        showLogin(body.message || ('加载失败（HTTP ' + r.status + '）'));
+      });
+    }).catch(function () { showLogin('网络错误，无法连接后台'); });
+  }
+
+  function signOut() {
+    try { localStorage.removeItem(SID_KEY); } catch (e) {}
+    location.href = './';
+  }
+
+  function init() {
+    var who = $('who');
+    who.textContent = '';
+    if (sid()) {
+      var a = document.createElement('a');
+      a.textContent = '退出登录';
+      a.addEventListener('click', signOut);
+      who.appendChild(a);
+    }
+    if (fbId) loadDetail(fbId); else loadList();
+  }
+
+  $('btn-login').addEventListener('click', doLogin);
+  $('btn-resend').addEventListener('click', sendCode);
+  ['in-pass', 'in-code'].forEach(function (id) {
+    $(id).addEventListener('keydown', function (e) { if (e.key === 'Enter') doLogin(); });
+  });
+
+  init();
+})();
+</script>
+</body>
+</html>

--- a/backend/src/test/java/com/checkba/service/optimizer/OptimizerMailerTest.java
+++ b/backend/src/test/java/com/checkba/service/optimizer/OptimizerMailerTest.java
@@ -110,6 +110,32 @@ class OptimizerMailerTest {
         assertTrue(body.contains("回信不会被系统读取"));
     }
 
+    /**
+     * 病灶（dev-board#151）：邮件里只有裸附件 API 地址，维护者在浏览器里点开是 403 死胡同。
+     * 修法：来源能给出浏览器入口（云端反馈控制台）时，正文必须带上直达链接。
+     */
+    @Test
+    @DisplayName("云端来源的邮件带反馈控制台直达链接")
+    void bodyCarriesConsoleLinkWhenSourceHasOne() {
+        OptimizerFeedbackSource s = sourceRef("https://addin.example/api/feedback/12/attachment/3");
+        when(s.consoleRef(any())).thenReturn("https://addin.example/feedback-console/?fb=12");
+
+        mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_SUGGESTION), List.of(), s, "");
+        String body = capturedBody();
+        assertTrue(body.contains("https://addin.example/feedback-console/?fb=12"),
+                "正文要有控制台直达链接：" + body);
+        assertTrue(body.contains("听语音"));
+    }
+
+    @Test
+    @DisplayName("本地来源没有浏览器入口，正文不出现控制台一节")
+    void bodyOmitsConsoleLineForLocalSource() {
+        // mock 未打桩的 default 方法返回 null，正好等价于 LocalFeedbackSource 的行为
+        mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_SUGGESTION),
+                List.of(), sourceRef(""), "");
+        assertFalse(capturedBody().contains("在浏览器里看这条反馈"));
+    }
+
     @Test
     void unclearVerdictAsksForADecision() {
         mailer.send(feedback(), triage(FeedbackTriageService.VERDICT_UNCLEAR),

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -30,6 +30,9 @@
   acme/                <- certbot webroot
   web/                 <- index.html 为跳官网的静态重定向页（h5 已退役，见上）
   web/office-addin/    <- Office 插件任务窗格（office-addin 构建产物，见 office-addin.md）
+  （/feedback-console/ 不在 web/ 下：维护者反馈控制台由 backend.jar 的
+   classpath:/static/ 直接托管，nginx 有一条 location 反代给后端——
+   更新它 = 正常更新后端 jar，见 nginx-addin.conf.example）
   web/zetaoffice/      <- 退役残留（原 h5 的 LOWA 引擎载荷），留置不清理
 ```
 

--- a/deploy/cloud/nginx-addin.conf.example
+++ b/deploy/cloud/nginx-addin.conf.example
@@ -69,6 +69,18 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ---- 反馈控制台（维护者用；优化者邮件里的「后台直达」落点）----
+    # 页面在 backend.jar 的 classpath:/static/feedback-console/，随后端一起发版，
+    # 这里只需反代给后端；无需在 web/ 下铺任何文件。
+    location /feedback-console/ {
+        proxy_pass http://127.0.0.1:9696;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ---- Office 插件任务窗格（dist-deploy 托管在 web/office-addin/）----
     # office.js 必须从微软 CDN 加载（跨域脚本），COEP require-corp 会拦掉它，
     # 因此本路径不得继承全站 COOP/COEP——location 内出现任意 add_header 即丢弃继承头，


### PR DESCRIPTION
## 背景

优化者邮件里的附件是裸 API 地址（`/api/feedback/{id}/attachment/{aid}`），维护者在浏览器点开是 403 死胡同——该端点只认管理员会话或 X-Optimizer-Token，而 h5 客户端（含 admin 看板）2026-08-19 已从 addin.aiworkdeck.com 退役，云端收件箱在浏览器里没有任何入口。维护者指示：点邮件链接、登录、直接听（dev-board#151）。

## 改动

- **新增反馈控制台**：`backend/src/main/resources/static/feedback-console/index.html`，自包含单页（无构建步骤），由 jar 的 classpath:/static/ 托管在 `/feedback-console/`。登录 admin 后：列表（最近 100 条）→ 详情（原话/转写/分诊/现场）→ 截图内嵌显示、语音内嵌播放、原件可下载。
- `FeedbackConsoleConfig`：目录路径 forward 到 index.html（Spring Boot welcome page 只作用于根路径）。
- `OptimizerFeedbackSource.consoleRef(fb)`（default null）：Remote 来源返回 `<baseUrl>/feedback-console/?fb=<id>`；邮件与 Issue 正文注入「在浏览器里看这条反馈」直达链接，Local 来源不出现此节。
- nginx 样例新增 `/feedback-console/` 反代 location；deploy/cloud/README 与领域文档同步。

## 安全

- 用户可控文本一律 textContent 渲染，杜绝反馈正文 XSS；
- 附件用 fetch + X-Session-Id 头取 blob 再喂 img/audio，凭据不进 URL（不落 access log）；
- 登录打既有 `/api/auth/login`（nginx 已有 limit_req），支持 4005 二次验证（totp/sms/mail）。

## 验证

- `mvn test -Dtest='Optimizer*Test,RemoteFeedbackSourceTest'` 50/50 绿（含 2 条新用例：云端来源带直达链接/本地来源不带）；
- 本地真链路：desktop profile 起后端 → curl 提交带 wav+png 的反馈 → 浏览器打开 `/feedback-console/?fb=1`，详情渲染、音频真实播放（currentTime 前进 0.68s）、图片 blob 解码（naturalWidth=1）、列表视图正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)