### PR TITLE
feat(feedback): 反馈看板并入官网 admin 的后端支撑（dev-board#152）

### DIFF
--- a/.claude/agents/feedback-optimizer.md
+++ b/.claude/agents/feedback-optimizer.md
@@ -55,6 +55,14 @@ description: 用户反馈闭环领域。任务涉及右下角反馈浮窗、反�
 - 优化者通知里的直达链接来自 `OptimizerFeedbackSource.consoleRef(fb)`（default null）：
   Remote 来源返回 `<baseUrl>/feedback-console/?fb=<id>`，Local 来源保持 null
   （桌面端自带 admin 看板），正文里就不出现这一节。
+- 直达地址可用 `optimizer.remote.console-url`（env `OPTIMIZER_REMOTE_CONSOLE_URL`，
+  `{id}` 占位）改指官网 admin 的「用户反馈」分区（dev-board#152）：
+  `https://www.aiworkdeck.com/zh/admin?tab=feedback&fb={id}`——维护者只登录官网后台一处。
+- 官网侧（aiworkdeck_website 仓）：`app/[lang]/admin/FeedbackInbox.tsx` 分区 +
+  `/api/admin/feedback/*` 三条服务端代理（admin cookie 鉴权，取件密钥只在服务端）；
+  官网实例 env 需配 `AWD_FEEDBACK_INBOX_TOKEN`（= 收件箱 FEEDBACK_OPTIMIZER_TOKEN）。
+  为此 `GET /api/feedback` 列表/详情也认 X-Optimizer-Token（只读，密钥本就能取
+  全部待办与附件，未升格信任级；没配密钥恒拒绝）。
 - 页面安全约定：用户可控文本一律 textContent 渲染；附件用 fetch + `X-Session-Id`
   头取 blob 再喂给 `<img>`/`<audio>`，凭据不进 URL（URL 里的 token 会落 nginx access log）。
   登录支持 4005 二次验证（totp/sms/mail）。会话键与 h5 同名 `checkba_session_id`。

--- a/backend/src/main/java/com/checkba/controller/FeedbackController.java
+++ b/backend/src/main/java/com/checkba/controller/FeedbackController.java
@@ -106,9 +106,12 @@ public class FeedbackController {
     @GetMapping
     public ResponseEntity<?> list(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
+            @RequestHeader(value = "X-Optimizer-Token", required = false) String optimizerTokenHeader,
             @RequestParam(value = "status", required = false) String status,
             @RequestParam(value = "limit", required = false, defaultValue = "50") int limit) {
-        if (requireAdmin(sessionId) == null) {
+        // 取件密钥也可读列表（只读）：官网 admin 的「用户反馈」分区经服务端代理用它拉数据，
+        // 该密钥本就能取全部待办反馈与附件（/pending、attachment 端点），信任级没有升格
+        if (!optimizerTokenOk(optimizerTokenHeader) && requireAdmin(sessionId) == null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(LangText.of("需要管理员权限", "Admin access required")));
         }
         List<Map<String, Object>> items = new ArrayList<>();
@@ -121,8 +124,10 @@ public class FeedbackController {
     @GetMapping("/{id}")
     public ResponseEntity<?> detail(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId,
+            @RequestHeader(value = "X-Optimizer-Token", required = false) String optimizerTokenHeader,
             @PathVariable Long id) {
-        if (requireAdmin(sessionId) == null) {
+        // 同 list：取件密钥可读详情（只读），供官网 admin 代理
+        if (!optimizerTokenOk(optimizerTokenHeader) && requireAdmin(sessionId) == null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(LangText.of("需要管理员权限", "Admin access required")));
         }
         UserFeedback fb = feedbackRepository.findById(id).orElse(null);

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerProperties.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerProperties.java
@@ -72,6 +72,13 @@ public class OptimizerProperties {
         private String baseUrl = "";
         /** 与收件箱 feedback.optimizer-token 相同的共享密钥 */
         private String token = "";
+        /**
+         * 通知正文里「在浏览器里看这条反馈」的地址模板，{id} 会被替换成反馈 id。
+         * 留空用默认的云端反馈控制台（baseUrl + /feedback-console/?fb={id}）；
+         * 官网 admin 并入反馈看板后可指到那里，如
+         * https://www.aiworkdeck.com/zh/admin?tab=feedback&fb={id}
+         */
+        private String consoleUrl = "";
     }
 
     @Getter

--- a/backend/src/main/java/com/checkba/service/optimizer/OptimizerSourceConfig.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/OptimizerSourceConfig.java
@@ -36,6 +36,6 @@ public class OptimizerSourceConfig {
             throw new IllegalStateException("optimizer.remote.base-url 必须是 https（本机回环除外）");
         }
         log.info("[optimizer] 反馈来源 = 云端收件箱 {}", base);
-        return new RemoteFeedbackSource(base, token);
+        return new RemoteFeedbackSource(base, token, props.getRemote().getConsoleUrl());
     }
 }

--- a/backend/src/main/java/com/checkba/service/optimizer/RemoteFeedbackSource.java
+++ b/backend/src/main/java/com/checkba/service/optimizer/RemoteFeedbackSource.java
@@ -30,12 +30,19 @@ public class RemoteFeedbackSource implements OptimizerFeedbackSource {
 
     private final String baseUrl;
     private final String token;
+    /** 「在浏览器里看这条反馈」的地址模板（{id} 占位）；空 = 云端反馈控制台默认页 */
+    private final String consoleUrlTemplate;
     private final HttpClient client;
     private final ObjectMapper mapper = new ObjectMapper();
 
     public RemoteFeedbackSource(String baseUrl, String token) {
+        this(baseUrl, token, "");
+    }
+
+    public RemoteFeedbackSource(String baseUrl, String token, String consoleUrlTemplate) {
         this.baseUrl = baseUrl == null ? "" : baseUrl.trim().replaceAll("/$", "");
         this.token = token == null ? "" : token.trim();
+        this.consoleUrlTemplate = consoleUrlTemplate == null ? "" : consoleUrlTemplate.trim();
         this.client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
     }
 
@@ -141,6 +148,9 @@ public class RemoteFeedbackSource implements OptimizerFeedbackSource {
 
     @Override
     public String consoleRef(UserFeedback fb) {
+        if (!consoleUrlTemplate.isEmpty()) {
+            return consoleUrlTemplate.replace("{id}", String.valueOf(fb.getId()));
+        }
         return baseUrl + "/feedback-console/?fb=" + fb.getId();
     }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -411,6 +411,10 @@ optimizer:
   remote:
     base-url: ${OPTIMIZER_REMOTE_URL:}
     token: ${OPTIMIZER_REMOTE_TOKEN:}
+    # 通知正文「在浏览器里看这条反馈」的地址模板（{id} 占位）；
+    # 留空 = 云端反馈控制台；官网 admin 并入反馈看板后可指到
+    # https://www.aiworkdeck.com/zh/admin?tab=feedback&fb={id}
+    console-url: ${OPTIMIZER_REMOTE_CONSOLE_URL:}
   repo:
     # 仓库工作副本的绝对路径（维护者机器上的一份 clone）
     path: ${OPTIMIZER_REPO_PATH:}

--- a/backend/src/test/java/com/checkba/controller/FeedbackControllerOptimizerReadTest.java
+++ b/backend/src/test/java/com/checkba/controller/FeedbackControllerOptimizerReadTest.java
@@ -1,0 +1,84 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.UserFeedback;
+import com.checkba.repository.UserFeedbackRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
+import com.checkba.service.feedback.FeedbackService;
+import com.checkba.service.feedback.FeedbackUploadService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * 取件密钥（X-Optimizer-Token）对 {@code GET /api/feedback} 列表与详情的只读放行
+ * （dev-board#152：官网 admin 的「用户反馈」分区经服务端代理用它拉数据）。
+ * 该密钥本就能取全部待办反馈与附件，这里没有升格信任级；
+ * 但没配密钥 / 密钥不对时必须回落到管理员判定，不留「未配置即放行」。
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedbackControllerOptimizerReadTest {
+
+    @Mock
+    private FeedbackService feedbackService;
+    @Mock
+    private FeedbackUploadService uploadService;
+    @Mock
+    private UserFeedbackRepository feedbackRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AdminAccessService adminAccessService;
+
+    @InjectMocks
+    private FeedbackController controller;
+
+    @Test
+    void optimizerTokenGrantsListAndDetail() {
+        ReflectionTestUtils.setField(controller, "optimizerToken", "tok");
+        when(feedbackService.list(null, 50)).thenReturn(List.of());
+        UserFeedback fb = new UserFeedback();
+        fb.setId(10L);
+        when(feedbackRepository.findById(10L)).thenReturn(Optional.of(fb));
+        when(feedbackService.attachmentsOf(10L)).thenReturn(List.of());
+
+        assertEquals(200, controller.list(null, "tok", null, 50).getStatusCode().value());
+        assertEquals(200, controller.detail(null, "tok", 10L).getStatusCode().value());
+    }
+
+    @Test
+    void wrongOrMissingTokenFallsBackToAdminCheck() {
+        ReflectionTestUtils.setField(controller, "optimizerToken", "tok");
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession(null)).thenReturn(null);
+            ResponseEntity<?> wrong = controller.list(null, "not-the-token", null, 50);
+            assertEquals(HttpStatus.FORBIDDEN, wrong.getStatusCode());
+            ResponseEntity<?> missing = controller.detail(null, null, 10L);
+            assertEquals(HttpStatus.FORBIDDEN, missing.getStatusCode());
+        }
+    }
+
+    @Test
+    void unconfiguredTokenNeverGrants() {
+        // 服务端没配 feedback.optimizer-token 时，带任何 token 都不放行（默认拒绝）
+        ReflectionTestUtils.setField(controller, "optimizerToken", "");
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession(null)).thenReturn(null);
+            ResponseEntity<?> resp = controller.list(null, "anything", null, 50);
+            assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/optimizer/RemoteFeedbackSourceTest.java
+++ b/backend/src/test/java/com/checkba/service/optimizer/RemoteFeedbackSourceTest.java
@@ -103,6 +103,20 @@ class RemoteFeedbackSourceTest {
         assertEquals(base + "/api/feedback/12/attachment/3", src.attachmentRef(fb, a));
     }
 
+    /** 官网 admin 并入反馈看板后（dev-board#152），邮件直达地址可用模板改指官网。 */
+    @Test
+    void consoleRefUsesTemplateWhenConfigured() {
+        UserFeedback fb = new UserFeedback();
+        fb.setId(12L);
+        // 默认：云端反馈控制台
+        assertEquals(base + "/feedback-console/?fb=12",
+                new RemoteFeedbackSource(base, "tok").consoleRef(fb));
+        // 配了模板：{id} 被替换
+        RemoteFeedbackSource custom = new RemoteFeedbackSource(base, "tok",
+                "https://www.aiworkdeck.com/zh/admin?tab=feedback&fb={id}");
+        assertEquals("https://www.aiworkdeck.com/zh/admin?tab=feedback&fb=12", custom.consoleRef(fb));
+    }
+
     @Test
     void saveSendsResolutionBack() throws Exception {
         RemoteFeedbackSource src = new RemoteFeedbackSource(base, "tok");

--- a/deploy/optimizer/optimizer.env.example
+++ b/deploy/optimizer/optimizer.env.example
@@ -4,6 +4,9 @@
 # ---- 反馈从哪来：云端收件箱 ----
 OPTIMIZER_SOURCE=remote
 OPTIMIZER_REMOTE_URL=https://addin.aiworkdeck.com
+# 通知里「在浏览器里看这条反馈」的地址模板（{id} 占位）；留空用云端反馈控制台。
+# 官网 admin 有「用户反馈」分区（dev-board#152）后指到官网，统一登录：
+OPTIMIZER_REMOTE_CONSOLE_URL=https://www.aiworkdeck.com/zh/admin?tab=feedback&fb={id}
 # 与收件箱那侧的 FEEDBACK_OPTIMIZER_TOKEN 必须一字不差
 OPTIMIZER_REMOTE_TOKEN=
 


### PR DESCRIPTION
官网 admin 新增「用户反馈」分区（官网仓 PR 配套），本 PR 是桌面端仓的支撑面：

- `GET /api/feedback` 列表与详情端点接受 `X-Optimizer-Token`（只读）。官网 Next.js 服务端代理持取件密钥拉取数据；该密钥既有能力已含全部待办反馈与附件，此处未升格信任级；未配置密钥时恒拒绝（新增 3 条测试钉住，含默认拒绝）。
- `optimizer.remote.console-url`（env `OPTIMIZER_REMOTE_CONSOLE_URL`，`{id}` 占位）：优化者通知里「在浏览器里看这条反馈」的地址模板，配置后指向官网 admin（统一登录）；留空保持云端反馈控制台默认（测试钉住两种形态）。

验证：`mvn test -Dtest='FeedbackController*Test,RemoteFeedbackSourceTest,Optimizer*Test'` 57/57 绿；本地起后端（test-token）+ 官网 dev server 联调，浏览器深链 `/zh/admin?tab=feedback&fb=1` 全链路通（列表/详情/图片/音频播放）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)