### PR TITLE
chore(release): v0.25.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
补丁版本（应用内增量更新）：#605 拖拽建链修复 + 官方版外部服务档位收口（dev-board#171/#172）、#604 Word 插件任务窗格修复（dev-board#173-177）。改动均在补丁允许组件（backend-app/frontend-h5/zetaoffice-wrapper）内，patch-gate 规则已预核。