### PR TITLE
feat: 企查查知识产权工具 + 执行过程卡输出可读化（dev-board#178 #179）

### DIFF
--- a/backend/src/main/java/com/checkba/service/QichachaService.java
+++ b/backend/src/main/java/com/checkba/service/QichachaService.java
@@ -33,6 +33,10 @@ public class QichachaService {
 
     private static final int GATEWAY_TIMEOUT_SECONDS = 30;
 
+    /** MCP 端点实测 10-20s 常态（智能体数据平台聚合查询），30s 会掐掉正常调用。 */
+
+    private static final int IPR_GATEWAY_TIMEOUT_SECONDS = 60;
+
     @Autowired
     private SystemSettingService systemSettingService;
 
@@ -65,6 +69,34 @@ public class QichachaService {
      */
     public String queryEciInfoJson(String searchKey) {
         return fetchEciInfoResult(searchKey).toString();
+    }
+
+    /**
+     * 企业知识产权类查询（商标/专利/软著/备案等，dev-board#179）。
+     *
+     * <p>REST 那把 key 只购买了工商详情接口（ECIInfoVerify/GetInfo），字段里本来就没有
+     * 商标/域名；知识产权走企查查「智能体数据平台」的 MCP 服务器（网关代调，凭证在
+     * 官网侧 gateway-config.json 的 qichachaMcpToken）。{@code mcpTool} 是网关 op，
+     * 白名单由 {@link com.checkba.service.ai.tools.EnterpriseDataTools} 的 kind 映射钉住，
+     * 不接受模型自由拼名。
+     *
+     * <p>仅平台档提供：BYOK/团队服务器没有这把订阅凭证的下发通道（与 AI 子钥不同，
+     * 企查查不支持签发受限子凭证——见 licensing-billing 领域文档 D5 一节）。
+     */
+    public String queryIprJson(String mcpTool, String searchKey) {
+        if (externalProviderResolver.resolve(
+                com.checkba.service.platform.ExternalServiceProvider.QICHACHA)
+                != com.checkba.service.platform.ExternalServiceProvider.PLATFORM) {
+            throw new IllegalStateException(
+                    "企业知识产权查询仅官方版平台通道提供，当前部署未启用。请基于已有信息继续完成任务。");
+        }
+        com.checkba.service.platform.PlatformGatewayClient.Result result =
+                platformGatewayClient.call("qichacha", mcpTool,
+                        Map.of("searchKey", searchKey), IPR_GATEWAY_TIMEOUT_SECONDS);
+        // 网关原样透传 MCP 响应正文（JSON 或 SSE），解析与法宝共用同一个解析器，
+        // 格式漂移只会漂一次
+        return com.checkba.service.ai.mcp.McpResponseParser.parse(
+                result.data().path("raw").asText(""));
     }
 
     /** 取一次工商详情的 {@code Result}。两档在这里分，上面两个方法都不关心谁出的钱。 */

--- a/backend/src/main/java/com/checkba/service/ai/tools/EnterpriseDataTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/EnterpriseDataTools.java
@@ -76,6 +76,44 @@ public class EnterpriseDataTools implements AgentToolComponent {
         }
     }
 
+    /** kind → 企查查智能体数据平台 ipr 服务器的工具名。白名单：模型只能挑档，不能自由拼名。 */
+    private static final Map<String, String> IPR_KINDS = Map.of(
+            "trademark", "get_trademark_info",
+            "patent", "get_patent_info",
+            "intl_patent", "get_international_patent",
+            "software_copyright", "get_software_copyright_info",
+            "work_copyright", "get_copyright_work_info",
+            "icp", "get_internet_service_info",
+            "ipr_pledge", "get_ipr_pledge");
+
+    @ToolMeta(displayName = "查询企业知识产权", category = "data")
+    @Tool("Look up a Chinese company's intellectual-property records by company name or unified social credit code. "
+            + "kind must be one of: trademark (商标), patent (专利), intl_patent (国际专利), "
+            + "software_copyright (软件著作权), work_copyright (作品著作权), "
+            + "icp (网站域名 ICP 备案与小程序备案), ipr_pledge (知识产权出质). "
+            + "Call once per kind needed. Returns readable text.")
+    public String qichacha_ipr(String companyName, String kind) {
+        log.info("Tool: qichacha_ipr called for '{}' kind='{}'", companyName, kind);
+        if (!StringUtils.hasText(companyName)) {
+            return "Error: companyName is required.";
+        }
+        String mcpTool = IPR_KINDS.get(kind == null ? "" : kind.trim());
+        if (mcpTool == null) {
+            return "Error: kind 必须是 " + String.join("/", IPR_KINDS.keySet()) + " 之一。收到的是：" + kind;
+        }
+        try {
+            String text = qichachaService.queryIprJson(mcpTool, companyName);
+            return StringUtils.hasText(text) ? text : "该企业暂无对应的知识产权记录。";
+        } catch (GatewayException e) {
+            return unavailable("企业知识产权查询", e);
+        } catch (Exception e) {
+            log.warn("企业知识产权查询失败: {}", e.toString());
+            // 同 qichacha_query：失败标记不能少，否则判据听不见
+            return "错误：企业知识产权查询失败：" + e.getMessage()
+                    + " 本次已跳过该查询，请基于已有信息继续完成任务。";
+        }
+    }
+
     @ToolMeta(displayName = "查询金融数据", category = "data")
     @Tool("Query Tushare financial data for Chinese listed companies. apiName is the Tushare interface name "
             + "(e.g. stock_basic, stock_company, top10_holders, stk_managers, daily, income, balancesheet). "

--- a/backend/src/main/resources/prompts/system_prompt.en.md
+++ b/backend/src/main/resources/prompts/system_prompt.en.md
@@ -372,6 +372,11 @@ The `law_*` tools are backed by a **PRC (Mainland China) law database**. They co
   social credit code. Returns JSON.
 - Full legal name or credit code only; for partial names, use `search_web` first to
   find the exact name.
+- `qichacha_ipr(companyName, kind)`: intellectual-property records — kind is one of
+  trademark / patent / intl_patent / software_copyright / work_copyright /
+  icp (website & mini-program ICP filings, i.e. domains) / ipr_pledge. The registry
+  record does NOT contain these; questions about trademarks/patents/domains must go
+  through this tool, one call per kind.
 
 ### 5.2 Financial data (`tushare_query`)
 - `tushare_query(apiName, paramsJson, fields)`: Tushare Pro interfaces (e.g.

--- a/backend/src/main/resources/prompts/system_prompt.md
+++ b/backend/src/main/resources/prompts/system_prompt.md
@@ -332,6 +332,7 @@ If you lack critical details, **STOP and ASK** using the `<question>` tag. Do NO
 ### 5.1 企业工商信息 (`qichacha_query`)
 - `qichacha_query(companyName)`：按公司全称或统一社会信用代码查工商登记（名称/注册资本/地址/股东/高管），返回 JSON。
 - 只认完整全称或信用代码；简称/关键词查不到时，先用 `search_web` 找全称再查。
+- `qichacha_ipr(companyName, kind)`：查企业知识产权——kind 取 trademark(商标)/patent(专利)/intl_patent(国际专利)/software_copyright(软著)/work_copyright(作品著作权)/icp(网站域名与小程序备案)/ipr_pledge(知产出质)。工商详情里**没有**这些数据，用户问商标/专利/域名必须走本工具，每档一次调用。
 
 ### 5.2 金融数据 (`tushare_query`)
 - `tushare_query(apiName, paramsJson, fields)`：Tushare Pro 接口（如 `stock_basic`、`top10_holders`）。

--- a/backend/src/test/java/com/checkba/service/platform/ExternalServiceDualTierRoutingTest.java
+++ b/backend/src/test/java/com/checkba/service/platform/ExternalServiceDualTierRoutingTest.java
@@ -187,6 +187,44 @@ class ExternalServiceDualTierRoutingTest {
                     () -> service(ExternalServiceProvider.PLATFORM, gateway).searchCompany("某某有限公司", "TARGET"));
             assertEquals(GatewayException.Kind.SERVICE_DISABLED, e.getKind());
         }
+
+        // ---- 知识产权类（dev-board#179）：op = MCP 工具名，网关回 {raw:...}，
+        // 解析与法宝共用 McpResponseParser ----
+
+        @Test
+        @DisplayName("IPR 平台档：走网关的 qichacha/get_trademark_info，SSE 信封解析出正文")
+        void iprPlatformCallsGatewayAndParsesSse() {
+            String sse = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"商标 3 条\"}]}}\n";
+            PlatformGatewayClient gateway = gatewayReturning(
+                    "{\"raw\":" + cn.hutool.json.JSONUtil.quote(sse) + "}");
+
+            String text = service(ExternalServiceProvider.PLATFORM, gateway)
+                    .queryIprJson("get_trademark_info", "某某有限公司");
+
+            assertEquals("商标 3 条", text);
+            verify(gateway).call(eq("qichacha"), eq("get_trademark_info"), anyMap(), anyInt());
+        }
+
+        @Test
+        @DisplayName("IPR 非平台档：不打网关，抛可读的「仅官方版提供」")
+        void iprNonPlatformRefusesWithoutGateway() {
+            PlatformGatewayClient gateway = mock(PlatformGatewayClient.class);
+            IllegalStateException e = assertThrows(IllegalStateException.class,
+                    () -> service(ExternalServiceProvider.BYOK, gateway)
+                            .queryIprJson("get_trademark_info", "某某有限公司"));
+            assertTrue(e.getMessage().contains("仅官方版平台通道"));
+            verifyNoInteractions(gateway);
+        }
+
+        @Test
+        @DisplayName("IPR 平台档失败：kind 活着到调用方")
+        void iprPlatformFailureKeepsKind() {
+            PlatformGatewayClient gateway = gatewayFailing(GatewayException.Kind.NO_CREDITS);
+            GatewayException e = assertThrows(GatewayException.class,
+                    () -> service(ExternalServiceProvider.PLATFORM, gateway)
+                            .queryIprJson("get_patent_info", "某某有限公司"));
+            assertEquals(GatewayException.Kind.NO_CREDITS, e.getKind());
+        }
     }
 
     // =======================================================================

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "test:meeting-e2e": "node tests/meeting-e2e/run.mjs",
     "test:project-home": "node --test tests/project-home/*.test.mjs",
     "test:auth-redirect": "node --test tests/auth-redirect/*.test.mjs",
-    "test:commands": "node --test tests/commands/commands.test.mjs",
+    "test:commands": "node --test tests/commands/*.test.mjs",
     "test:zeta-relay": "node --test tests/zeta-relay/*.test.mjs",
     "test:evidence": "node --test tests/evidence/*.test.mjs",
     "test:plugin-sdk": "node --test tests/plugin-sdk/*.test.mjs"

--- a/frontend/src/components/AgentMessage/ProcessCard.vue
+++ b/frontend/src/components/AgentMessage/ProcessCard.vue
@@ -107,7 +107,9 @@
                     <!-- 子任务结果单独渲染：dispatch_subtask 的输出是 SubAgentResult 的 JSON，
                          裸 JSON 对律师毫无意义。解析不出预期结构就退回纯文本（下方分支）。 -->
                     <SubtaskResultCard v-if="subtaskResult(item)" :result="subtaskResult(item)" />
-                    <div v-else class="output-text">{{ outputText(item) }}</div>
+                    <!-- 原始 JSON 对律师是一段「代码」（dev-board#178）：能解析的一律
+                         渲染成缩进键值文本（空字段/语法噪音剥掉），解析不了的才按原文展示。 -->
+                    <div v-else class="output-text">{{ humanOutput(item) }}</div>
                     <!-- 截断标记由后端 SSE 侧加（AgentOrchestrator.toolOutputDisplayLimit 按
                          工具分档：结果型工具 16000，其余 4000），必须明示：模型看到的是全文，
                          这里没有。刻意不写具体字数——上限是分档的，写死数字就会说谎。 -->
@@ -140,6 +142,7 @@ import ThinkingCard from './ThinkingCard.vue'
 import SubtaskResultCard from './SubtaskResultCard.vue'
 import FileTypeIcon from '../FileTypeIcon.vue'
 import { toolDisplayName, toolRawName } from '@/utils/toolDisplayNames.js'
+import { humanizeToolOutput } from '@/utils/toolOutputHumanize.js'
 import { isEnglish } from '@/utils/appLanguage.js'
 import { t } from '@/i18n'
 
@@ -215,6 +218,18 @@ const openOutputs = ref({})
 const hasOutput = (item) => !!(item && item.output && String(item.output).trim())
 
 const outputText = (item) => String((item && item.output) || '').trim()
+
+// 可读化缓存：与 subtaskCache 同理，流式中 output 每个 token 都在变。
+const humanCache = new Map()
+const humanOutput = (item) => {
+    const raw = outputText(item)
+    if (humanCache.has(raw)) return humanCache.get(raw)
+    const human = humanizeToolOutput(raw)
+    const shown = human != null ? human : raw
+    if (humanCache.size > 16) humanCache.clear()
+    humanCache.set(raw, shown)
+    return shown
+}
 
 const isOutputOpen = (idx) => !!openOutputs.value[idx]
 

--- a/frontend/src/utils/toolDisplayNames.js
+++ b/frontend/src/utils/toolDisplayNames.js
@@ -27,6 +27,7 @@ const NAMES = {
   // platform 档下没有可注入的凭证，失败会表现成「查不到数据」而不是「未配置」）。
   // 文案与后端 @ToolMeta(displayName) 逐字对齐，两侧有护栏用例钉着，别改措辞。
   qichacha_query: { zh: '查询企业工商信息', en: 'Company registry lookup' },
+  qichacha_ipr: { zh: '查询企业知识产权', en: 'Company IP lookup' },
   tushare_query: { zh: '查询金融数据', en: 'Financial data lookup' },
   // 法律
   law_search: { zh: '语义搜索法规', en: 'Search regulations' },

--- a/frontend/src/utils/toolOutputHumanize.js
+++ b/frontend/src/utils/toolOutputHumanize.js
@@ -1,0 +1,88 @@
+// 工具输出的可读化（dev-board#178）。
+//
+// 执行过程卡的折叠区此前直接展示工具返回的原始 JSON——对律师是一段「代码」，
+// 观感差且没有信息组织。但整个折叠区不能删：它是 PR#180 口径下「律师必须能
+// 点开看工具到底查到了什么」的入口（例如 find 的 12 处命中）。
+// 取中：保留点开能力，点开后**绝不显示原始代码**——能解析成 JSON 的一律
+// 渲染成缩进的「键：值」可读文本，解析不了的按原样当纯文本展示（那本来就
+// 是给人看的话）。
+//
+// 刻意丢弃的东西（这正是「太底层」的来源）：null/空串/空数组/空对象字段、
+// 括号引号逗号这些语法噪音。超长字符串与超长清单截断——模型看到的是全文，
+// 这里只是给人扫一眼的视图。
+
+const MAX_STRING = 200
+const MAX_LINES = 200
+const MAX_ARRAY_ITEMS = 30
+const MAX_DEPTH = 6
+
+function isEmptyValue(v) {
+  if (v === null || v === undefined) return true
+  if (typeof v === 'string' && v.trim() === '') return true
+  if (Array.isArray(v) && v.length === 0) return true
+  if (typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0) return true
+  return false
+}
+
+function scalarText(v) {
+  if (typeof v === 'string') {
+    const s = v.trim()
+    return s.length > MAX_STRING ? s.slice(0, MAX_STRING) + '…' : s
+  }
+  return String(v)
+}
+
+function renderInto(lines, value, indent, depth) {
+  if (lines.length >= MAX_LINES) return
+  const pad = '  '.repeat(indent)
+  if (Array.isArray(value)) {
+    const shown = value.filter((v) => !isEmptyValue(v)).slice(0, MAX_ARRAY_ITEMS)
+    for (const v of shown) {
+      if (lines.length >= MAX_LINES) return
+      if (typeof v === 'object' && v !== null) {
+        lines.push(pad + '-')
+        if (depth < MAX_DEPTH) renderInto(lines, v, indent + 1, depth + 1)
+      } else {
+        lines.push(pad + '- ' + scalarText(v))
+      }
+    }
+    const hidden = value.length - shown.length
+    if (hidden > 0 && lines.length < MAX_LINES) lines.push(pad + `…（另 ${hidden} 条略）`)
+    return
+  }
+  for (const [k, v] of Object.entries(value)) {
+    if (lines.length >= MAX_LINES) return
+    if (isEmptyValue(v)) continue
+    if (typeof v === 'object' && v !== null) {
+      lines.push(pad + k + '：')
+      if (depth < MAX_DEPTH) renderInto(lines, v, indent + 1, depth + 1)
+    } else {
+      lines.push(pad + k + '：' + scalarText(v))
+    }
+  }
+}
+
+/**
+ * 把工具输出转成给人看的文本。
+ * @param {string} raw 工具输出原文
+ * @returns {string|null} 可读文本；解析不出 JSON 时返回 null（调用方按纯文本展示原文）
+ */
+export function humanizeToolOutput(raw) {
+  const text = String(raw || '').trim()
+  if (!text) return null
+  const first = text.charAt(0)
+  if (first !== '{' && first !== '[') return null
+  // SSE 截断标记拼在 JSON 之后会让整段 parse 失败——剥掉后缀再试一次，
+  // 剥完仍失败（截断落在 JSON 中间）就退回纯文本，不猜。
+  let body = text
+  for (const suffix of ['...(截断)', '...(truncated)']) {
+    if (body.endsWith(suffix)) body = body.slice(0, -suffix.length).trim()
+  }
+  let parsed
+  try { parsed = JSON.parse(body) } catch (e) { return null }
+  if (parsed === null || typeof parsed !== 'object') return null
+  const lines = []
+  renderInto(lines, parsed, 0, 0)
+  if (lines.length >= MAX_LINES) lines.push('…（其余略）')
+  return lines.length ? lines.join('\n') : null
+}

--- a/frontend/tests/commands/toolOutputHumanize.test.mjs
+++ b/frontend/tests/commands/toolOutputHumanize.test.mjs
@@ -1,0 +1,40 @@
+// 工具输出可读化（dev-board#178）：执行过程卡点开后不许出现原始 JSON 代码。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { humanizeToolOutput } from '../../src/utils/toolOutputHumanize.js'
+
+test('企查查形态的 JSON 渲染成键值文本：无括号引号、空字段剥除', () => {
+  const raw = JSON.stringify({
+    QccCode: 'QCN7VUF3P6',
+    Partners: [{
+      StockName: '韩泽伟', StockType: '自然人股东', StockPercent: '56.00%',
+      InvestType: '', RealCapi: '', PaidUpCapital: '', CapiDate: '',
+      TagsList: ['大股东', '实际控制人'],
+    }],
+    Address: '',
+  })
+  const out = humanizeToolOutput(raw)
+  assert.ok(out.includes('StockName：韩泽伟'))
+  assert.ok(out.includes('- 大股东'))
+  assert.ok(!out.includes('{') && !out.includes('"'), '不许残留 JSON 语法噪音')
+  assert.ok(!out.includes('InvestType') && !out.includes('Address'), '空字段该剥掉')
+})
+
+test('非 JSON 输出返回 null（调用方按纯文本展示原文）', () => {
+  assert.equal(humanizeToolOutput('已找到 12 处匹配，详见文档。'), null)
+  assert.equal(humanizeToolOutput(''), null)
+})
+
+test('带 SSE 截断后缀的 JSON：剥后缀能解析则渲染，截在 JSON 中间则退回纯文本', () => {
+  const whole = JSON.stringify({ a: 1 }) + '...(截断)'
+  assert.ok(humanizeToolOutput(whole).includes('a：1'))
+  const midway = '{"a":1,"b":"xx...(truncated)'
+  assert.equal(humanizeToolOutput(midway), null)
+})
+
+test('超长字符串与超长清单被截断', () => {
+  const raw = JSON.stringify({ text: 'x'.repeat(500), list: Array.from({ length: 60 }, (_, i) => 'i' + i) })
+  const out = humanizeToolOutput(raw)
+  assert.ok(out.includes('…'))
+  assert.ok(out.includes('另 30 条略'))
+})


### PR DESCRIPTION
## dev-board#179 企查查知识产权
维护者复测发现商标/域名查不到。根因：REST key 只购买了工商详情接口，字段里本来就没有知识产权数据——不是企查查权限故障。新工具 `qichacha_ipr(companyName, kind)` 经网关代调智能体数据平台 MCP ipr 服务器（7 档白名单：商标/专利/国际专利/软著/作品著作权/网络服务备案(域名)/知产出质），实测该公司商标 3 条、备案 12 条全部可查。网关侧：官网仓 PR#103（凭证已部署两台机）。测试：ExternalServiceDualTierRoutingTest 22/22（新增 IPR 三条）。

## dev-board#178 执行过程卡
点开工具输出不再显示原始 JSON：能解析的渲染成缩进键值文本（空字段/语法噪音剥除、超长截断），解析不了的按纯文本展示。折叠区本身保留（PR#180 口径）。测试：toolOutputHumanize 4 条，test:commands 收宽为 glob 进 CI（21/21）。