### PR TITLE
chore(release): v0.26.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号 0.25.2 → 0.26.0（desktop/package.json 单一来源）。

本次发版纳入 v0.25.2 之后的三个 PR：
- #607 企查查知识产权工具 + 执行过程卡输出可读化（dev-board#178 #179）
- #608 支付路径与会员体系一揽子（dev-board#183-191）
- #609 解析/依据窗格与面板停靠三件套（dev-board#180 #181 #182）

注：#609 的 windows 检查挂在已知的 drawio-server.test.js 临时文件 EPERM 偶发（与 v0.25.1 首发同一症状），非代码问题。