### PR TITLE
chore: 法宝 MCP 补齐全部 10 个 server（实测清单）

### DIFF
--- a/.claude/agents/doc-insight.md
+++ b/.claude/agents/doc-insight.md
@@ -155,7 +155,7 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
 
 ## 已知地雷
 
-1. **法宝点数已于 2026-08-27 恢复**（新 token 在 `backend/.env` 的 `PKULAW_TOKEN`，法宝 MCP 控制台 mcp.pkulaw.com；五个 server 六个工具当天逐一 `tools/call` 实测有真数据）。若再见 `tools/call` 401「checking remaining points」= 点数又耗尽，是账务问题不是回归：LAW/CASE 实体一律 UNAVAILABLE + note 带上游原话，先查点数不要改代码。
+1. **法宝点数已于 2026-08-27 恢复**（新 token 在 `backend/.env` 的 `PKULAW_TOKEN`，法宝 MCP 控制台 mcp.pkulaw.com；**全部 10 个 server 当天逐一 `tools/call` 实测有真数据**，完整清单与工具面见 application.yml mcp.servers 注释与 EXTERNAL_SERVICES.md 法宝行）。管线当前只用其中四个（semantic/keyword/case-semantic + qichacha），另外几个是现成的升级件：`pkulaw-case-number` 的 `anhao_recognition(text)` 能把案号标准化并直接给出判决书标题/法院/法宝链接（可作 CASE 实体的先导步，替代裸语义搜）；`pkulaw-citation-validator` 的 `adjust_provisions` 返回权威法条原文（可做「文档引用条号配错」的校验维度）；`pkulaw-doc-link` 能为整段文本加法宝超链接。接入时按 InsightProperties 的配置化先例来。若再见 `tools/call` 401「checking remaining points」= 点数又耗尽，是账务问题不是回归：LAW/CASE 实体一律 UNAVAILABLE + note 带上游原话，先查点数不要改代码。
    同理 `QICHACHA_MCP_TOKEN` 缺省时企业模糊搜索静默降级为「只认工商全称」——不报错，只是简称查不到。
 2. **`PlatformAiUserScope` 不跟随线程池**。管线跑在自己的池里，`startParse` 提交时必须
    `PlatformAiUserScope.run(userId, …)` 包住**整段**（不只是模型调用那一行）；`refreshEntity` 在控制器线程上跑，同样要包。

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -105,6 +105,43 @@ mcp:
     # 企查查智能体数据平台：模糊搜索（get_company_by_query），把文中的简称解析成
     # 工商全称，再交给 REST 的 ECIInfoVerify/GetInfo（那条只认全称，非全称回 201 无结果）。
     # 与 external.qichacha.key/secret 是两套凭证，别混用。
+    # 法宝其余五个 server（2026-08-27 维护者从官网控制台抄来完整清单，逐一实测可用；
+    # 与法规/案例五件套同一把 token）。工具面：
+    #   pkulaw-fatiao            get_law_item_content(title, tiao_num 数字)  按数字条号取法条
+    #   pkulaw-doc-link          get_linked_content(message)                为文本加法宝超链接
+    #   pkulaw-citation-validator adjust_provisions(userlaw/answerlaw/prompt) 引用校验与幻觉修正，返回权威原文
+    #   pkulaw-case-number       anhao_recognition(text)                    案号识别+标准化（带法院/判决书标题/法宝链接/GID）
+    #   pkulaw-agg               聚合 server：以 server.tool 命名空间挂全部 10 个工具（URL 带 /mcp 后缀，别掉）
+    - name: pkulaw-fatiao
+      url: https://apim-gateway.pkulaw.com/mcp-fatiao
+      token: ${PKULAW_TOKEN:}
+      token-setting-key: external.pkulaw.token
+      timeout-seconds: 60
+      enabled: true
+    - name: pkulaw-doc-link
+      url: https://apim-gateway.pkulaw.com/add-doc-link
+      token: ${PKULAW_TOKEN:}
+      token-setting-key: external.pkulaw.token
+      timeout-seconds: 60
+      enabled: true
+    - name: pkulaw-citation-validator
+      url: https://apim-gateway.pkulaw.com/pku_citation_validator
+      token: ${PKULAW_TOKEN:}
+      token-setting-key: external.pkulaw.token
+      timeout-seconds: 60
+      enabled: true
+    - name: pkulaw-case-number
+      url: https://apim-gateway.pkulaw.com/case_number_recognition
+      token: ${PKULAW_TOKEN:}
+      token-setting-key: external.pkulaw.token
+      timeout-seconds: 60
+      enabled: true
+    - name: pkulaw-agg
+      url: https://apim-gateway.pkulaw.com/mcp-law-agg/mcp
+      token: ${PKULAW_TOKEN:}
+      token-setting-key: external.pkulaw.token
+      timeout-seconds: 60
+      enabled: true
     - name: qichacha-company
       url: https://agent.qcc.com/mcp/company/stream
       token: ${QICHACHA_MCP_TOKEN:}


### PR DESCRIPTION
维护者从 mcp.pkulaw.com 控制台抄来完整配置，本 PR 把此前探测缺失的 5 个 server 补进 mcp.servers（同一把 PKULAW_TOKEN），每个都已 tools/list + tools/call 真数据实测：

| server | 工具 | 用途 |
|---|---|---|
| pkulaw-fatiao | get_law_item_content(title, tiao_num 数字) | 按数字条号取法条（带锚点链接） |
| pkulaw-doc-link | get_linked_content(message) | 为文本智能加法宝超链接 |
| pkulaw-citation-validator | adjust_provisions(userlaw/answerlaw/prompt) | 引用校验/幻觉修正，返回权威原文 |
| pkulaw-case-number | anhao_recognition(text) | 案号识别+标准化（法院/判决书标题/法宝链接/GID/位置） |
| pkulaw-agg | server.tool 命名空间全量 | 聚合 server（URL 带 /mcp 后缀） |

解析管线代码不变（仍用四个通道）；doc-insight.md 已记录两个现成升级件的接入口径。yml 经解析校验 11 个 server 正常，DocInsightServiceTest 17/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)