### PR TITLE
ci(desktop-tests): drawio 测试按改动面跳过 + 单测步骤 15 分钟超时

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -142,6 +142,14 @@ stash 误 pop 之类）之后，5174 上的页面可能变成**整页无样式**
   drawio-server.test.js 的 rmrf 帮手是范本）：读流 autoClose 的 fs.close 回调可能还排在事件
   循环里，rmSync 的 maxRetries 是同步忙等、会把事件循环连同那个 close 一起卡死，给多大预算
   都是 ENOTEMPTY 跑穿（run 32237671073 实测证伪过 rmSync 重试版）。纯文件读写的测试不受影响。
+- **drawio-server 测试在 CI 按改动面跳过（PR#612）**：这组用例真起 HTTP 服务+真读写 Temp
+  目录，Windows runner 的 Defender 会拿排他句柄锁临时文件 → teardown EPERM（hookFailed），
+  外层重试只是把 8 秒的步骤拖成几分钟再挂，v0.26.0 首发 run 更锁死 110 分钟（force-cancel
+  才解）。desktop-build.yml 的「Detect drawio changes」在 PR/push 区间未碰
+  `desktop/main/drawio-server.js` / `desktop/tests/drawio-server.test.js` /
+  `desktop/scripts/fetch-drawio-assets.js` 时注入 `SKIP_DRAWIO_TESTS=1`（测试文件顶层早退）；
+  **tag 发版与 workflow_dispatch 永远全量**。Desktop unit tests 步骤有 `timeout-minutes: 15`
+  兜底。改动这三份文件之一时，自查该 PR 的 Detect 步骤输出应为 FULL。
 - 发版有个跨仓的时间差：镜像脚本删旧包 vs 官网页面 ISR 缓存。两边任何一边改保留策略/缓存时长前，先看 `deploy/update-mirror-sync.sh` 里 prune_old_installers 的注释。
 - macOS CI 红要当真查（Apple 协议过期事件后恢复）；`--admin` 合并与 worktree 删分支技巧见 ci-macos 记录。
 - iCloud 驱逐会掏空本地文件（打包/测试环境两次踩）；EMFILE 用抬 ulimit 解。

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -56,6 +56,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # 全量历史：Detect drawio changes 需要拿 PR base / push before 做 diff
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -94,8 +97,43 @@ jobs:
       - name: Install desktop dependencies
         working-directory: desktop
         run: npm ci
+      - name: Detect drawio changes (skip drawio tests when untouched)
+        shell: bash
+        run: |
+          # drawio-server 测试要真起 HTTP 服务 + 真读写 Temp 目录，是 Windows
+          # runner 上 Defender 锁文件 EPERM（hookFailed）与步骤卡死的主要来源
+          #（dev-board#146；v0.25.1/#609/v0.26.0 三个发版 run 都被咬过）。
+          # 本区间没碰 drawio 服务/测试/资源脚本就整套跳过（测试文件内识别
+          # SKIP_DRAWIO_TESTS=1）；tag 发版与手动触发永远全量跑。
+          SKIP=0
+          if [[ "$GITHUB_REF" == refs/tags/* || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "tag/manual trigger: full suite"
+          else
+            BASE=""
+            [ "$GITHUB_EVENT_NAME" = "pull_request" ] && BASE="${{ github.event.pull_request.base.sha }}"
+            [ "$GITHUB_EVENT_NAME" = "push" ] && BASE="${{ github.event.before }}"
+            if [ -n "$BASE" ] && git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+              CHANGED=$(git diff --name-only "$BASE...$GITHUB_SHA" -- \
+                desktop/main/drawio-server.js \
+                desktop/tests/drawio-server.test.js \
+                desktop/scripts/fetch-drawio-assets.js)
+              if [ -z "$CHANGED" ]; then
+                echo "drawio untouched since $BASE — skipping drawio-server tests"
+                SKIP=1
+              else
+                echo "drawio files changed:"; echo "$CHANGED"
+              fi
+            else
+              echo "no usable base commit ($BASE) — full suite"
+            fi
+          fi
+          [ "$SKIP" = "1" ] && echo "SKIP_DRAWIO_TESTS=1" >> "$GITHUB_ENV"
+          echo "drawio tests: $([ "$SKIP" = "1" ] && echo SKIPPED || echo FULL)"
       - name: Desktop unit tests
         working-directory: desktop
+        # drawio 测试曾在 Windows 上锁死 110 分钟不退出（v0.26.0 首发 run）：
+        # 正常全量 ≤5 分钟，给 3 倍预算快挂，别再拖到 job 默认 6 小时上限。
+        timeout-minutes: 15
         run: npm test
       - name: Bundle backend (macOS arm64)
         if: runner.os == 'macOS'

--- a/desktop/tests/drawio-server.test.js
+++ b/desktop/tests/drawio-server.test.js
@@ -8,6 +8,16 @@
 //    pack 根惰性解析（revoked / 无完成标记的版本不参与）。
 
 const test = require('node:test')
+
+// CI 按改动面跳过（desktop-build.yml 的「Detect drawio changes」步骤注入）：
+// 这组用例要真起 HTTP 服务 + 真读写 Temp 目录，是 Windows runner 上 Defender
+// 锁临时文件 EPERM 的主要来源（dev-board#146，多次发版被它咬）。本区间没碰
+// drawio 服务/本测试/资源脚本时整套不打；tag 发版与手动触发永远全量。
+if (process.env.SKIP_DRAWIO_TESTS === '1') {
+  test('drawio-server 全套用例跳过（本区间未改动 drawio）', { skip: true }, () => {})
+  return
+}
+
 const assert = require('node:assert')
 const fs = require('fs')
 const os = require('os')


### PR DESCRIPTION
## 起因

最近三个发版/PR run 的 Windows job 都栽在 Desktop unit tests 的 drawio-server 测试上：
- v0.25.1 首发：teardown 删 Temp 目录 EPERM（hookFailed），单用例空转 264 秒后挂
- #609 PR 检查：同一症状
- v0.26.0 首发：步骤锁死 110 分钟不退出（正常 ≤5 分钟），force-cancel 才解

根因：这组测试真起 HTTP 服务 + 真读写 Temp 目录，Windows runner 的 Defender 实时扫描会拿排他句柄锁临时文件。#436/#511/#593 三次修 teardown 重试，但重试只是把 8 秒的步骤拖成几分钟再挂，没解决锁文件本身。

## 改法（两个闸门）

1. **按改动面跳过**：PR/push 区间未碰 `desktop/main/drawio-server.js` / `desktop/tests/drawio-server.test.js` / `desktop/scripts/fetch-drawio-assets.js` 时，新增 `Detect drawio changes` 步骤注入 `SKIP_DRAWIO_TESTS=1`，测试文件内早退。**tag 发版与手动触发永远全量**——发版门禁不放松。
2. **步骤超时**：Desktop unit tests 加 `timeout-minutes: 15`（正常 ≤5 分钟，3 倍预算快挂，不再拖到 job 默认 6h 上限）。

## 验证

- 本地 `SKIP_DRAWIO_TESTS=1 node --test tests/drawio-server.test.js` → 1 skipped / 0 fail
- 不带环境变量全量 → 8 pass / 0 fail
- 本 PR 自身的 windows 构建即是一次真实验证（本 PR 改了 drawio-server.test.js，Detect 步骤应判定为 changed 走全量）