### PR TITLE
chore(release): v0.26.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
0.26.0 之后合入三个 PR，全部落在补丁边界内（patch-gate 四条：desktop 壳 / backend pom / LOWA 引擎 / requirements.lock 均无改动），发小版本补丁。

本版内容：
- #611 法宝 MCP 补齐全部 10 个 server（官网控制台完整清单，逐一实测）
- #614 解析管线接入案号识别先导与法条引用校验（dev-board#181/#182 补充）
- #613 office-addin UI 细节六连修（dev-board#192-197）

本机全量自验（JDK 21）：
- backend `mvn -B test` — 2802 tests, 0 failures, 11 skipped
- frontend `check:emits` / `check:locales` / `check:nav:full` / `test:project-home`(293) / `test:evidence`(132) / `test:insight`(83) / `test:panel-dock`(9) / `test:commands`(21) / `build:h5` 全通过
- desktop `npm test` — 75 pass / 1 skipped
- office-addin `npm test` — 63 pass

dev-board#199
