### PR TITLE
feat(plugin): 插件规范 v2.5——Web 面板直调工具端点与桥方法（dev-board#207/#208/#210 宿主侧）

### DIFF
--- a/.claude/agents/plugin-system.md
+++ b/.claude/agents/plugin-system.md
@@ -44,7 +44,7 @@ description: 插件系统领域（具体插件实现）。任务涉及尽调/脱
   - **后端契约**：`PluginService.PluginMetadata.guide`（`PluginGuide`/`PluginQuickAction`）；`parseManifest` 丢弃 quickActions 里缺 label 或 prompt 的条目；`PluginController.PluginView` 透传 `guide`。测试 `PluginServiceTest.parsesGuideBlock/guideAbsentIsNull`、`frontend/tests/evidence/methodBarTimer.test.mjs` 无关，guide 面板前端无独立单测（真渲染走查配方见 [[ui-live-walkthrough-recipe]]，注入 `/api/plugins/list` 造 guide）。
   - **地雷（都在 dev-board#132 修掉，别改回去）**：① `dynamicPlugins[].icon` 不要回退 `/static/plugin_default.png`——**那文件不存在**，会 404 成 HTML 破图；registry 的 `icon` 是 emoji（全站禁 emoji、不当图片渲染）。纯工具插件的 rail 图标由模板里 `v-else-if="p.isDynamic"` 的拼图 SVG 兜底。② `toggleLeftPane` **不再** `openFile({fileType:'plugin'})` 开中栏标签——`isFileTypeSupported` 没有 `'plugin'`，那条老路只会弹「无法打开文件」模态、从没渲染出东西；动态插件一律左栏面板渲染（「左栏一个图标 = 一个插件」）。中栏 `activeFileLeft.fileType==='plugin'` 的 PluginPane 分支现已是死代码，留着无害。③ `leftPaneTitle` 要先查 `activeDynamicPlugin.label`，否则动态插件标题掉进兜底显示成「资源管理器」。
 
-### 三方 Web 插件（规范 v2.3，docs/PLUGIN_SPEC.md §8）
+### 三方 Web 插件（规范 v2.5，docs/PLUGIN_SPEC.md §8）
 
 `manifest.frontendEntry` 从「预留」激活。两种形态在 PluginPane 里**行为刻意不同**：
 
@@ -54,6 +54,8 @@ description: 插件系统领域（具体插件实现）。任务涉及尽调/脱
 **绝不给 sandbox 加 `allow-same-origin`。** 同源的 iframe 能读 localStorage 里的 `X-Session-Id` 并打全部 `/api/*`，等于白送宿主权限。
 
 桥协议（`PluginPane.vue` 宿主端 / `sdk/plugin-sdk/awd-plugin-sdk.js` 插件端 / 官网模板与宿主模拟器，**三处同一份契约**）：`init` 握手 → `call{seq,method,params}` → `result{seq,ok,result|error}`；双向来源校验（宿主认 `event.source === iframe.contentWindow`，插件认 `window.parent`），targetOrigin 只能 `'*'`（opaque origin）。v1 方法：`context.get` / `files.list` / `files.read` / `ui.toast` / `storage.get` / `storage.set`；错误码 `permission_denied` / `unknown_method` / `quota_exceeded` / `not_found`。
+
+**v2.5 新增三方法**（`PluginPane.handleCall`，SDK 版本 `1.0.0`→`1.1.0`，老宿主对新方法一律回 `unknown_method`，插件要能降级）：`tools.invoke {name, args?}` -> `{output}`——经直调端点 `POST /api/plugins/{id}/tools/{tool}`（`PluginController.invokeTool`）调本插件自己的 JAR 工具，安全闸自上而下是登录会话 → 项目写权限（`ProjectMemberService.hasWritePermission`）→ 工具名必须是该插件 manifest `tools` 声明的 → 插件启用未封禁，再落到 `ToolRegistry.execute` 走 manifest permissions/宿主 SPI 配额/`ToolContext` 服务端定 projectId·userId 这套 AI 链路同款闸；`chat.send {prompt}`（≤4000 字）-> `{}`——把 prompt 当可见用户消息发进 AI 对话，与 PluginGuidePane quickActions 同一条 kickoff 路；`ui.openFile {path}` -> `{}`（需 `file_read`）——复用 `awd:open-evidence-target` 事件链把项目文件开到工作台中栏。新增错误码 `invalid_params` / `invoke_failed`。设计意图：Web 面板做结构化操作时直调自家工具绕过模型，但一步都不绕过安全闸。
 
 **这是 manifest permissions 第一次成为真实边界**：缺 `file_read` 时 `files.*` 直接 `permission_denied`；`network` 决定 PluginWebController 下发的 CSP 是 `connect-src 'none'` 还是 `connect-src https:`。JAR 插件同 JVM 同权限，做不到这一点。
 
@@ -80,8 +82,10 @@ description: 插件系统领域（具体插件实现）。任务涉及尽调/脱
   （PluginDevTools，新工具组件记得同步 RealToolBeans——已加）。
 - 内置 skill `backend/skills/plugin-dev/`（enabled_by_default:false，requiresSkill 门控
   左栏「插件开发」面板 PluginDevPanel.vue，rail 排在 market 之后）。**prompt.md 是
-  Web 插件开发的权威 spec**（目录契约/manifest 规则/沙箱边界/SDK 桥 v1 全量 API/迭代流程），
-  改桥协议或 manifest 规则时必须同步它，否则 AI 会按旧契约写插件。
+  Web 插件开发的权威 spec**（目录契约/manifest 规则/沙箱边界/SDK 桥 v1+v2.5 全量 API/迭代流程），
+  改桥协议或 manifest 规则时必须同步它，否则 AI 会按旧契约写插件。dev 安装的插件 manifest
+  `tools` 强制为空，所以 `tools.invoke` 在本机自测环境下永远只收 `invoke_failed`——
+  prompt.md 已加提醒，别让 AI 对用户承诺一个本机测不出效果的功能。
 - 骨架模板在 `backend/src/main/resources/plugin-dev/`（template-index.html +
   awd-plugin-sdk.js 副本）。**SDK 至此有四份分发副本 + 宿主端实现**（原三份 + 本 classpath
   副本），classpath 副本与源头的逐字节一致由 `PluginDevSdkParityTest` 守着。

--- a/backend/skills/plugin-dev/prompt.md
+++ b/backend/skills/plugin-dev/prompt.md
@@ -53,7 +53,7 @@
 - 插件页面是普通 HTML/CSS/JS，没有构建步骤：不要写 JSX/TypeScript/import 语法，用浏览器直接能跑的 ES5/ES6 脚本。
 - SDK 必须用同步 `<script src="./awd-plugin-sdk.js">` 引入且排在业务脚本之前：宿主在 iframe load 后立刻发握手，晚注册会错过它，`awd.ready()` 永远挂起。
 
-## SDK 桥 API（v1 全量）
+## SDK 桥 API（v1 全量 + v2.5 新增）
 
 引入 SDK 后全局有 `awd` 对象：
 
@@ -65,9 +65,14 @@
 | `awd.ui.toast(message)` | 字符串 | `{}` | 在宿主界面弹一条提示 |
 | `awd.storage.get(key)` | 字符串 | 存过的值，无则 `null` | 插件级 KV |
 | `awd.storage.set(key, value)` | 字符串 + 可序列化值 | `{}` | 插件级 KV，总量上限 64KB，超限报 `quota_exceeded` |
-| `awd.call(method, params)` | 任意 v1 方法 | 宿主的 result | 底层通道，上面的都是它的封装 |
+| `awd.tools.invoke(name, args?)` | 工具名 + 可选参数对象 | 工具原始字符串输出（自行 `JSON.parse`） | **v2.5 新增**：直调本插件 manifest `tools` 里声明的 JAR 工具，绕过模型；`name` 不是本插件工具时报 `invoke_failed` |
+| `awd.chat.send(prompt)` | 字符串，上限 4000 字 | `{}` | **v2.5 新增**：把 `prompt` 作为可见用户消息发进 AI 对话（起草类动作走这条，不要直调工具） |
+| `awd.ui.openFile(path)` | 文件 path | `{}` | **v2.5 新增**：把项目文件打开到工作台中栏；需 `file_read` |
+| `awd.call(method, params)` | 任意方法 | 宿主的 result | 底层通道，上面的都是它的封装 |
 
-错误处理：reject 的 Error 带 `code` 字段——`permission_denied`（manifest 没声明所需权限）、`unknown_method`（宿主不认识的方法）、`quota_exceeded`（KV 超限）、`not_found`。给用户看的报错要转成中文人话。
+错误处理：reject 的 Error 带 `code` 字段——`permission_denied`（manifest 没声明所需权限）、`unknown_method`（宿主不认识的方法，多见于老宿主还不支持 v2.5 新方法，插件要能降级处理）、`quota_exceeded`（KV 超限或 `chat.send` 的 prompt 超 4000 字）、`not_found`（`ui.openFile` 的文件不存在）、`invalid_params`（`tools.invoke`/`chat.send` 参数缺失或形状不对）、`invoke_failed`（`tools.invoke` 目标工具未声明或执行出错）。给用户看的报错要转成中文人话。
+
+`awd.tools.invoke` 提醒：**开发安装的插件 manifest `tools` 必须为空**（见上文「开发安装只收纯 Web 插件」），所以这个方法在本地自测环境下永远拿不到工具、只会收 `invoke_failed`；只有走插件广场审核上架、且插件确实声明了 JAR 工具时才会真正生效。给用户写代码前先确认这一点，别承诺一个本机测不出效果的功能。
 
 最小可用示例（骨架的 index.html 就是这个形状）：
 

--- a/backend/src/main/java/com/checkba/controller/ai/PluginController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginController.java
@@ -5,6 +5,8 @@ import com.checkba.repository.UserRepository;
 import com.checkba.service.AdminAccessService;
 import com.checkba.service.LangText;
 import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.tools.ToolContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +45,8 @@ public class PluginController {
     private final UserRepository userRepository;
     private final AdminAccessService adminAccessService;
     private final com.checkba.service.telemetry.TelemetryService telemetryService;
+    private final ToolRegistry toolRegistry;
+    private final com.checkba.service.ProjectMemberService projectMemberService;
 
     @lombok.Data
     public static class PluginView {
@@ -185,6 +189,52 @@ public class PluginController {
         telemetryService.record("plugin.lifecycle",
                 Map.of("pluginId", pluginId, "op", enabled ? "enable" : "disable"));
         return ResponseEntity.ok(ok());
+    }
+
+    /**
+     * Web 面板直调本插件工具（规范 v2.5）：绕过模型，不绕过任何安全闸——
+     * 登录会话 + 项目写权限 + 工具必须是该插件 manifest 声明的；
+     * 之后走与 AI 链路同一个 {@link com.checkba.service.ai.ToolRegistry#execute}，
+     * manifest 权限校验、宿主 SPI 配额、projectId/userId 以服务端为准的规则全部照旧。
+     * 请求体：{"projectId": 123, "args": {...}}；args 里与 ToolContext 同名的参数会被服务端值覆盖。
+     */
+    @PostMapping("/{id}/tools/{tool}")
+    public ResponseEntity<Map<String, Object>> invokeTool(
+            @PathVariable("id") String pluginId,
+            @PathVariable("tool") String toolName,
+            @org.springframework.web.bind.annotation.RequestBody(required = false) Map<String, Object> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error(LangText.of("请先登录", "Please sign in first")));
+        }
+        PluginService.PluginMetadata meta = pluginService.getPlugin(pluginId);
+        if (meta == null || !pluginService.isEnabled(pluginId) || pluginService.revokedReason(pluginId) != null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(LangText.of("插件不存在或未启用: ", "Plugin not found or disabled: ") + pluginId));
+        }
+        boolean declared = meta.getTools() != null && meta.getTools().stream()
+                .anyMatch(t -> toolName.equals(t.getName()));
+        if (!declared) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(LangText.of("该插件未声明此工具: ", "Tool not declared by this plugin: ") + toolName));
+        }
+        Object pidRaw = body == null ? null : body.get("projectId");
+        Long projectId = pidRaw instanceof Number n ? n.longValue() : null;
+        if (projectId == null || !projectMemberService.hasWritePermission(projectId, userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(LangText.of("无权限访问该项目", "No access to this project")));
+        }
+        Object args = body.get("args");
+        String argsJson;
+        try {
+            argsJson = args == null ? "{}" : new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(args);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(error(LangText.of("args 不是合法 JSON 对象", "args is not a valid JSON object")));
+        }
+        ToolRegistry.ToolResult result = toolRegistry.execute(toolName,
+                argsJson, new ToolContext(projectId, null, userId, null));
+        Map<String, Object> out = new HashMap<>();
+        out.put("code", result.found() ? 0 : 1);
+        out.put("output", result.output());
+        return ResponseEntity.ok(out);
     }
 
     private PluginView toView(PluginService.PluginMetadata meta) {

--- a/backend/src/main/resources/plugin-dev/awd-plugin-sdk.js
+++ b/backend/src/main/resources/plugin-dev/awd-plugin-sdk.js
@@ -22,9 +22,18 @@
  *   evidence.locate { linkKey, targetId? }
  *                                     -> {}                需 editor；有 targetId 打开底稿定位，否则跳到文档里的锚点
  *
+ * v2.5 新增（宿主 0.27 起；老宿主返回 unknown_method，插件要能降级）：
+ *   tools.invoke  { name, args? }     -> { output }        直调本插件 manifest 声明的 JAR 工具；
+ *                                        output 是工具原始字符串输出（通常为 JSON）。权限/配额/项目归属
+ *                                        由宿主端点按 AI 链路同一套规则校验，工具名不属于本插件即 invoke_failed
+ *   chat.send     { prompt }          -> {}                把 prompt 作为可见的用户消息发进 AI 对话
+ *                                        （与启动面板快捷按钮同一条路），上限 4000 字
+ *   ui.openFile   { path }            -> {}                需 file_read；把项目文件打开到工作台中栏
+ *
  * 错误码：permission_denied（manifest 未声明所需权限）、unknown_method（宿主不认识的方法）、
  *   anchor_ambiguous（引文 0 或多处命中 / anchor 形状不对）、no_selection（要求选区但当前没有）、
- *   not_found（链接或文件不存在）、no_active_document（当前没有打开的 Word 文档）。
+ *   not_found（链接或文件不存在）、no_active_document（当前没有打开的 Word 文档）、
+ *   invalid_params（参数缺失或形状不对）、invoke_failed（工具执行被拒或出错）。
  *
  * 重要：本文件必须用普通同步 <script> 引入，且排在业务脚本之前——
  * 宿主在 iframe load 后立刻发 init，晚注册监听会错过握手，ready() 将永远挂起。
@@ -79,7 +88,7 @@
 
   var awd = {
     /** SDK 版本，与桥协议版本无关 */
-    version: '1.0.0',
+    version: '1.1.0',
     /** 握手拿到的上下文；ready() 之前为 null */
     context: null,
     /** 等待宿主握手，resolve 值即 awd.context */
@@ -95,7 +104,21 @@
       read: function (path) { return call('files.read', { path: path }); }
     },
     ui: {
-      toast: function (message) { return call('ui.toast', { message: message }); }
+      toast: function (message) { return call('ui.toast', { message: message }); },
+      /** 把项目文件打开到工作台中栏（需 file_read） */
+      openFile: function (path) { return call('ui.openFile', { path: path }); }
+    },
+    tools: {
+      /** 直调本插件的 JAR 工具 -> 工具原始字符串输出（自行 JSON.parse） */
+      invoke: function (name, args) {
+        return call('tools.invoke', { name: name, args: args || {} }).then(function (r) {
+          return r && r.output != null ? r.output : '';
+        });
+      }
+    },
+    chat: {
+      /** 把 prompt 作为可见用户消息发进 AI 对话（起草类动作走这条，不直调工具） */
+      send: function (prompt) { return call('chat.send', { prompt: prompt }); }
     },
     storage: {
       /** -> 存过的值，没有则 null */

--- a/backend/src/test/java/com/checkba/controller/ai/PluginControllerInvokeToolTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/PluginControllerInvokeToolTest.java
@@ -1,0 +1,166 @@
+package com.checkba.controller.ai;
+
+import com.checkba.controller.AuthController;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.SystemSettingService;
+import com.checkba.service.ai.PluginService;
+import com.checkba.service.ai.ToolRegistry;
+import com.checkba.service.ai.tools.ToolContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 直调端点 POST /api/plugins/{id}/tools/{tool}（规范 v2.5）的安全闸测试：
+ * 未登录 401 / 插件未启用或工具未声明 404 / 无项目写权限 403 /
+ * 放行时 ToolContext 的 projectId 与 userId 必须来自服务端而不是请求体 args。
+ */
+class PluginControllerInvokeToolTest {
+
+    @TempDir
+    Path pluginsDir;
+
+    private final Map<String, String> settingStore = new HashMap<>();
+    private PluginService pluginService;
+    private ToolRegistry toolRegistry;
+    private ProjectMemberService projectMemberService;
+    private PluginController controller;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        SystemSettingService settings = mock(SystemSettingService.class);
+        when(settings.get(anyString(), anyString())).thenAnswer(inv ->
+                settingStore.getOrDefault(inv.getArgument(0), inv.getArgument(1)));
+        doAnswer(inv -> settingStore.put(inv.getArgument(0), inv.getArgument(1)))
+                .when(settings).set(anyString(), anyString());
+        Path dir = pluginsDir.resolve("dd-demo");
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("manifest.json"), """
+                {
+                  "id": "dd-demo",
+                  "name": "尽调演示",
+                  "version": "1.0.0",
+                  "permissions": ["file_read", "file_write"],
+                  "tools": [{"name": "dd_ping", "description": "ping"}]
+                }
+                """);
+        pluginService = new PluginService(settings, pluginsDir.toString());
+        pluginService.init();
+        toolRegistry = mock(ToolRegistry.class);
+        projectMemberService = mock(ProjectMemberService.class);
+        controller = new PluginController(pluginService,
+                mock(com.checkba.service.ai.PluginMarketService.class),
+                mock(com.checkba.service.ai.PluginRevocationService.class),
+                mock(com.checkba.repository.UserRepository.class),
+                mock(com.checkba.service.AdminAccessService.class),
+                mock(com.checkba.service.telemetry.TelemetryService.class),
+                toolRegistry, projectMemberService);
+    }
+
+    private Map<String, Object> body(Long projectId) {
+        Map<String, Object> b = new HashMap<>();
+        b.put("projectId", projectId);
+        Map<String, Object> args = new HashMap<>();
+        args.put("chapter", 3);
+        args.put("projectId", 999L); // 模型/面板伪造的跨项目 id，必须被服务端值压掉
+        b.put("args", args);
+        return b;
+    }
+
+    @Test
+    @DisplayName("未登录 401")
+    void unauthenticated() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession(any())).thenReturn(null);
+            ResponseEntity<Map<String, Object>> r = controller.invokeTool("dd-demo", "dd_ping", body(1L), null);
+            assertEquals(401, r.getStatusCode().value());
+            verifyNoInteractions(toolRegistry);
+        }
+    }
+
+    @Test
+    @DisplayName("未声明的工具 404，不进 ToolRegistry")
+    void undeclaredTool() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            ResponseEntity<Map<String, Object>> r = controller.invokeTool("dd-demo", "read_file", body(1L), "sess");
+            assertEquals(404, r.getStatusCode().value());
+            verifyNoInteractions(toolRegistry);
+        }
+    }
+
+    @Test
+    @DisplayName("插件禁用后 404")
+    void disabledPlugin() {
+        pluginService.setEnabled("dd-demo", false);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            ResponseEntity<Map<String, Object>> r = controller.invokeTool("dd-demo", "dd_ping", body(1L), "sess");
+            assertEquals(404, r.getStatusCode().value());
+            verifyNoInteractions(toolRegistry);
+        }
+    }
+
+    @Test
+    @DisplayName("无项目写权限 403")
+    void noProjectPermission() {
+        when(projectMemberService.hasWritePermission(1L, 7L)).thenReturn(false);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            ResponseEntity<Map<String, Object>> r = controller.invokeTool("dd-demo", "dd_ping", body(1L), "sess");
+            assertEquals(403, r.getStatusCode().value());
+            verifyNoInteractions(toolRegistry);
+        }
+    }
+
+    @Test
+    @DisplayName("放行：ToolContext 用服务端 projectId/userId，args 原样透传")
+    void happyPath() {
+        when(projectMemberService.hasWritePermission(1L, 7L)).thenReturn(true);
+        when(toolRegistry.execute(eq("dd_ping"), anyString(), any()))
+                .thenReturn(new ToolRegistry.ToolResult("pong: dd-demo", null, true));
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            ResponseEntity<Map<String, Object>> r = controller.invokeTool("dd-demo", "dd_ping", body(1L), "sess");
+            assertEquals(200, r.getStatusCode().value());
+            assertEquals(0, r.getBody().get("code"));
+            assertEquals("pong: dd-demo", r.getBody().get("output"));
+            ArgumentCaptor<ToolContext> ctx = ArgumentCaptor.forClass(ToolContext.class);
+            ArgumentCaptor<String> argsJson = ArgumentCaptor.forClass(String.class);
+            verify(toolRegistry).execute(eq("dd_ping"), argsJson.capture(), ctx.capture());
+            assertEquals(1L, ctx.getValue().projectId());
+            assertEquals(7L, ctx.getValue().userId());
+            assertNull(ctx.getValue().conversationId());
+            assertTrue(argsJson.getValue().contains("\"chapter\":3"));
+        }
+    }
+
+    @Test
+    @DisplayName("缺 projectId 直接 403，不猜项目")
+    void missingProjectId() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            Map<String, Object> b = new HashMap<>();
+            b.put("args", Map.of());
+            ResponseEntity<Map<String, Object>> r = controller.invokeTool("dd-demo", "dd_ping", b, "sess");
+            assertEquals(403, r.getStatusCode().value());
+            verifyNoInteractions(toolRegistry);
+        }
+    }
+}

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -1,7 +1,8 @@
-# 插件规范 v2.4（Plugin Spec v2.4）
+# 插件规范 v2.5（Plugin Spec v2.5）
 
 > 适用版本：v1 自 0.4.x；v2（权限执行 + 启停过滤）自 Phase 3A；v2.1（插件携带 Skill）自 Phase 3B；
-> v2.3（Web 插件 + `packs` 依赖）自 native pack Phase B；v2.4（宿主 SPI `plugin-api` + 后台任务）自尽调 P1。
+> v2.3（Web 插件 + `packs` 依赖）自 native pack Phase B；v2.4（宿主 SPI `plugin-api` + 后台任务）自尽调 P1；
+> v2.5（Web 插件直调工具端点 + 桥新增 `tools.invoke`/`chat.send`/`ui.openFile`）自尽调 P1 补充。
 > 示例插件：[examples/hello-plugin/](../examples/hello-plugin/)（JAR 工具）、
 > [examples/hello-web-plugin/](../examples/hello-web-plugin/)（纯前端）。
 > 后端实现：`PluginService`（扫描/解析/启停）、`PluginController`（HTTP API）、
@@ -177,6 +178,7 @@ Java 侧没有进程内沙箱可用（`SecurityManager` 已于 JEP 411 废弃、
 | POST | `/api/plugins/{id}/disable` | admin | 禁用插件 |
 | POST | `/api/plugins/rescan` | admin | 重新扫描 plugins/ 目录，返回 `{ code, pluginCount, toolCount }` |
 | GET | `/api/plugin-web/{id}/**` | 无 | Web 插件静态资源（`plugins/<id>/web/` 之下），见 §8.2 |
+| POST | `/api/plugins/{id}/tools/{tool}` | 登录 + 项目写权限 | **v2.5 新增**：直调插件工具，见 §8.7 |
 
 管理接口鉴权与 AdminConfigController 一致：`X-Session-Id` 请求头 → session 用户名为 `admin`。
 
@@ -294,6 +296,19 @@ opaque origin 使然，不能靠 `event.origin` 判断。
 `no_selection`（`anchor.selection: true` 但编辑器当前没有选区）、
 `no_active_document`（当前聚焦窗格没有打开的 Word 文档，或 `docPath` 不是它）。
 
+**v2.5 新增方法**（宿主 0.27 起；老宿主对未知方法一律回 `unknown_method`，插件需按此降级）：
+
+| 方法 | 参数 | 返回 | 权限 |
+|---|---|---|---|
+| `tools.invoke` | `{ name, args? }` | `{ output }`，`output` 是工具原始字符串输出（通常为 JSON，插件自行 `JSON.parse`） | 无独立 permission；工具名必须是本插件 manifest `tools` 里声明的，见 §8.7 |
+| `chat.send` | `{ prompt }`，上限 4000 字 | `{}` | — |
+| `ui.openFile` | `{ path }` | `{}` | `file_read` |
+
+对应错误码：`invalid_params`（`tools.invoke` 缺 `name`，或 `chat.send` 的 `prompt` 为空）、
+`invoke_failed`（`tools.invoke` 的目标工具未声明 / 执行出错）、
+`quota_exceeded`（`chat.send` 的 `prompt` 超 4000 字）、
+`not_found`（`ui.openFile` 的 `path` 在项目文件里找不到）。
+
 `evidence.*`（EvidenceLink，P0）：
 
 - 路径口径与 `files.*` 一致（项目内相对路径），宿主负责 path 与 fileId 的互换；
@@ -329,11 +344,37 @@ opaque origin 使然，不能靠 `event.origin` 判断。
 `awd.evidence.link(params)` / `awd.evidence.list(params)` / `awd.evidence.locate(params)` 是
 三个 `call` 的直通包装，同样返回原始 result。
 
+**v2.5**：SDK 版本号 `1.0.0` → `1.1.0`（`awd.version`，与桥协议版本 `PROTOCOL` 无关），新增
+`awd.tools.invoke(name, args)`（解包糖衣，直接返回 `output` 字符串）、`awd.chat.send(prompt)`、
+`awd.ui.openFile(path)`，均为对应新方法的直通/糖衣包装。
+
 ### 8.6 开发工作流
 
 官网插件模板 zip 带一份 `dev/host-simulator.html`——一个假扮宿主桥的静态页，
 起个本地静态服务就能在浏览器里开发调试，不必装桌面端。模拟器的 sandbox 属性与桌面端
 一致（同样没有 `allow-same-origin`）：调试时为了方便加上它，装进桌面端会立刻失败。
+
+### 8.7 直调插件工具端点（v2.5）
+
+`PluginController.invokeTool`：`POST /api/plugins/{id}/tools/{tool}`。设计意图：Web 面板做
+结构化操作时直调自家 JAR 工具，绕过模型、不绕过任何安全闸——是桥 `tools.invoke` 方法
+（见 §8.4）的服务端落点。
+
+请求体：`{ projectId, args }`；鉴权走会话（`X-Session-Id`），不是插件自己的 postMessage 桥。
+
+响应：`{ code: 0 | 1, output }`，`output` 是工具执行的原始字符串（`code: 1` 时装的是失败信息，
+不是 HTTP 层错误）。
+
+安全闸（自上而下，任一不过直接拒绝，不进 ToolRegistry）：
+
+1. 登录会话有效（否则 401）；
+2. 插件存在、已启用、未被平台封禁（否则 404，口径与 §8.2 静态服务一致——不泄露「存在但被禁」）；
+3. `tool` 必须是该插件 manifest `tools` 里声明的名字（否则 404：不能借这条路调到别的插件或
+   宿主内置工具）；
+4. 调用者对 `projectId` 有**项目写权限**（`ProjectMemberService.hasWritePermission`，否则 403）；
+5. 落到 `ToolRegistry.execute`：manifest `permissions` 校验（§3）、宿主 SPI 配额（§11.1）、
+   `ToolContext` 的 `projectId`/`userId` 以服务端解析结果为准（不信任请求体里的用户身份）——
+   与 AI 编排器调用同一插件工具时完全同一套闸，直调端点只是换了个触发源。
 
 ## 9. 插件依赖原生资源包（packs，v2.3）
 
@@ -364,10 +405,13 @@ opaque origin 使然，不能靠 `event.origin` 判断。
 - **v2.3**：`frontendEntry` 从「预留」激活为 Web 插件形态（§8）——`web/` 静态服务、
   sandbox iframe、postMessage 桥、CSP；**permissions 在 Web 插件上第一次成为真实的执行边界**。
   manifest 新增 `packs` 字段（§9）。
-- **v2.4（当前）**：JAR 插件的宿主 SPI——独立 Maven 工件 `com.checkba:plugin-api:1.0.0`
+- **v2.4**：JAR 插件的宿主 SPI——独立 Maven 工件 `com.checkba:plugin-api:1.0.0`
   （`backend/plugin-api/`，纯接口、无第三方依赖、版本独立于桌面端、只加不破），`HostAware` 注入（§4），
   `PluginHost` 八个子接口（§11），后台任务 `plugin_job` 表 + `/api/plugin-jobs` + SSE
   `client_action: plugin_job_progress`，每插件每分钟 60 次宿主调用配额。manifest 无新增字段。
+- **v2.5（当前）**：Web 插件直调工具端点 `POST /api/plugins/{id}/tools/{tool}`（§8.7），
+  服务端落点在 `PluginController.invokeTool`；桥/SDK 新增 `tools.invoke`/`chat.send`/`ui.openFile`
+  三个方法（§8.4、§8.5），SDK 版本号 `1.0.0` → `1.1.0`。manifest 无新增字段。
 - 规划中：进程外插件形态（MCP server）为不需要独立 UI 的插件提供真正的隔离边界。
   **进程内沙箱不在规划中**——Java 侧无此能力（§3），不要再把它列为待办；
   Web 插件那条路已经用「不同源 + 桥」拿到了同等效果，代价是能力必须逐个显式开放。

--- a/examples/hello-web-plugin/web/awd-plugin-sdk.js
+++ b/examples/hello-web-plugin/web/awd-plugin-sdk.js
@@ -22,9 +22,18 @@
  *   evidence.locate { linkKey, targetId? }
  *                                     -> {}                需 editor；有 targetId 打开底稿定位，否则跳到文档里的锚点
  *
+ * v2.5 新增（宿主 0.27 起；老宿主返回 unknown_method，插件要能降级）：
+ *   tools.invoke  { name, args? }     -> { output }        直调本插件 manifest 声明的 JAR 工具；
+ *                                        output 是工具原始字符串输出（通常为 JSON）。权限/配额/项目归属
+ *                                        由宿主端点按 AI 链路同一套规则校验，工具名不属于本插件即 invoke_failed
+ *   chat.send     { prompt }          -> {}                把 prompt 作为可见的用户消息发进 AI 对话
+ *                                        （与启动面板快捷按钮同一条路），上限 4000 字
+ *   ui.openFile   { path }            -> {}                需 file_read；把项目文件打开到工作台中栏
+ *
  * 错误码：permission_denied（manifest 未声明所需权限）、unknown_method（宿主不认识的方法）、
  *   anchor_ambiguous（引文 0 或多处命中 / anchor 形状不对）、no_selection（要求选区但当前没有）、
- *   not_found（链接或文件不存在）、no_active_document（当前没有打开的 Word 文档）。
+ *   not_found（链接或文件不存在）、no_active_document（当前没有打开的 Word 文档）、
+ *   invalid_params（参数缺失或形状不对）、invoke_failed（工具执行被拒或出错）。
  *
  * 重要：本文件必须用普通同步 <script> 引入，且排在业务脚本之前——
  * 宿主在 iframe load 后立刻发 init，晚注册监听会错过握手，ready() 将永远挂起。
@@ -79,7 +88,7 @@
 
   var awd = {
     /** SDK 版本，与桥协议版本无关 */
-    version: '1.0.0',
+    version: '1.1.0',
     /** 握手拿到的上下文；ready() 之前为 null */
     context: null,
     /** 等待宿主握手，resolve 值即 awd.context */
@@ -95,7 +104,21 @@
       read: function (path) { return call('files.read', { path: path }); }
     },
     ui: {
-      toast: function (message) { return call('ui.toast', { message: message }); }
+      toast: function (message) { return call('ui.toast', { message: message }); },
+      /** 把项目文件打开到工作台中栏（需 file_read） */
+      openFile: function (path) { return call('ui.openFile', { path: path }); }
+    },
+    tools: {
+      /** 直调本插件的 JAR 工具 -> 工具原始字符串输出（自行 JSON.parse） */
+      invoke: function (name, args) {
+        return call('tools.invoke', { name: name, args: args || {} }).then(function (r) {
+          return r && r.output != null ? r.output : '';
+        });
+      }
+    },
+    chat: {
+      /** 把 prompt 作为可见用户消息发进 AI 对话（起草类动作走这条，不直调工具） */
+      send: function (prompt) { return call('chat.send', { prompt: prompt }); }
     },
     storage: {
       /** -> 存过的值，没有则 null */

--- a/frontend/src/components/PluginPane.vue
+++ b/frontend/src/components/PluginPane.vue
@@ -35,7 +35,7 @@
 //   请求  插件 -> 宿主   { awd: 1, type: 'call', seq, method, params }
 //   响应  宿主 -> 插件   { awd: 1, type: 'result', seq, ok, result | error: { code, message } }
 import {
-  getProjectFiles, getFileText,
+  getProjectFiles, getFileText, invokePluginTool,
   createEvidenceLink, addEvidenceTargets, getEvidenceLink, listEvidenceLinks
 } from '@/services/api.js'
 import { getAppLanguage } from '@/utils/appLanguage.js'
@@ -70,6 +70,9 @@ function extOf(name) {
 
 export default {
   name: 'PluginPane',
+  // chat.send 与 PluginGuidePane 的快捷按钮走同一条 kickoff 路：
+  // prompt 作为可见的用户消息进入 AI 对话，用户随时可停，不存在静默注入
+  emits: ['kickoff'],
   props: {
     url: {
       type: String,
@@ -234,6 +237,44 @@ export default {
             return { ok: false, error: { code: 'quota_exceeded', message: '插件存储超过 64 KB 上限' } }
           }
           this.writeStore(serialized)
+          return { ok: true, result: {} }
+        }
+
+        // ==== 规范 v2.5 新增的三个方法 ====
+
+        case 'tools.invoke': {
+          // 直调本插件自己的 JAR 工具：权限/配额/projectId 都在后端端点与 ToolRegistry 里闸，
+          // 桥这里只负责转发；插件不可能借这条路调到别的插件或宿主内置工具（端点按 manifest 校验）
+          const name = String(params.name == null ? '' : params.name).trim()
+          if (!name) return { ok: false, error: { code: 'invalid_params', message: '缺少工具名 name' } }
+          let res
+          try {
+            res = await invokePluginTool(this.pluginId, name, this.projectId, params.args || {})
+          } catch (e) {
+            return { ok: false, error: { code: 'invoke_failed', message: (e && e.message) || '工具调用失败' } }
+          }
+          const body = res && res.output !== undefined ? res : (res && res.data) || {}
+          if (body.code !== 0) {
+            return { ok: false, error: { code: 'invoke_failed', message: String(body.output || body.message || '工具调用失败') } }
+          }
+          return { ok: true, result: { output: body.output == null ? '' : String(body.output) } }
+        }
+
+        case 'chat.send': {
+          const prompt = String(params.prompt == null ? '' : params.prompt).trim()
+          if (!prompt) return { ok: false, error: { code: 'invalid_params', message: 'prompt 不能为空' } }
+          if (prompt.length > 4000) return { ok: false, error: { code: 'quota_exceeded', message: 'prompt 超过 4000 字上限' } }
+          this.$emit('kickoff', { prompt })
+          return { ok: true, result: {} }
+        }
+
+        case 'ui.openFile': {
+          if (!this.hasPermission('file_read')) return this.denied('file_read')
+          const path = String(params.path == null ? '' : params.path)
+          const hit = (await this.listProjectFiles()).find(f => f.path === path)
+          if (!hit) return { ok: false, error: { code: 'not_found', message: '文件不存在：' + path } }
+          // 与 evidence.locate 打开底稿同一条路：工作台监听后走 openFileLinkTarget
+          uni.$emit('awd:open-evidence-target', { fileId: hit.id, locator: null, linkKey: null })
           return { ok: true, result: {} }
         }
 

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -760,6 +760,7 @@
             :permissions="activeDynamicPlugin.permissions || []"
             :project-id="projectId"
             :get-active-editor="getPluginActiveEditor"
+            @kickoff="onPluginQuickAction"
           />
           <PluginGuidePane
             v-else-if="activeDynamicPlugin"

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -619,6 +619,17 @@ export function uninstallMarketPlugin(pluginId) {
   });
 }
 
+// Web 面板直调本插件的 JAR 工具（规范 v2.5）：登录会话 + 项目写权限 + 工具须为该插件声明；
+// 返回 { code, output }，output 是工具的原始字符串输出（通常是 JSON 或 "Error: ..."）
+export function invokePluginTool(pluginId, toolName, projectId, args) {
+  return request({
+    url: `/api/plugins/${pluginId}/tools/${toolName}`,
+    method: 'POST',
+    data: { projectId, args: args || {} },
+    header: { 'Content-Type': 'application/json' },
+  });
+}
+
 // 重新扫描 plugins/ 目录（仅管理员）
 export function rescanPlugins() {
   return request({

--- a/frontend/tests/plugin-sdk/sdk-parity.test.mjs
+++ b/frontend/tests/plugin-sdk/sdk-parity.test.mjs
@@ -31,3 +31,10 @@ test('SDK 暴露 evidence.link / list / locate', () => {
     assert.ok(text.indexOf("call('" + m + "'") >= 0, '缺 ' + m)
   }
 })
+
+test('SDK 暴露 v2.5 的 tools.invoke / chat.send / ui.openFile', () => {
+  const text = source.toString('utf8')
+  for (const m of ['tools.invoke', 'chat.send', 'ui.openFile']) {
+    assert.ok(text.indexOf("call('" + m + "'") >= 0, '缺 ' + m)
+  }
+})

--- a/sdk/plugin-sdk/awd-plugin-sdk.js
+++ b/sdk/plugin-sdk/awd-plugin-sdk.js
@@ -22,9 +22,18 @@
  *   evidence.locate { linkKey, targetId? }
  *                                     -> {}                需 editor；有 targetId 打开底稿定位，否则跳到文档里的锚点
  *
+ * v2.5 新增（宿主 0.27 起；老宿主返回 unknown_method，插件要能降级）：
+ *   tools.invoke  { name, args? }     -> { output }        直调本插件 manifest 声明的 JAR 工具；
+ *                                        output 是工具原始字符串输出（通常为 JSON）。权限/配额/项目归属
+ *                                        由宿主端点按 AI 链路同一套规则校验，工具名不属于本插件即 invoke_failed
+ *   chat.send     { prompt }          -> {}                把 prompt 作为可见的用户消息发进 AI 对话
+ *                                        （与启动面板快捷按钮同一条路），上限 4000 字
+ *   ui.openFile   { path }            -> {}                需 file_read；把项目文件打开到工作台中栏
+ *
  * 错误码：permission_denied（manifest 未声明所需权限）、unknown_method（宿主不认识的方法）、
  *   anchor_ambiguous（引文 0 或多处命中 / anchor 形状不对）、no_selection（要求选区但当前没有）、
- *   not_found（链接或文件不存在）、no_active_document（当前没有打开的 Word 文档）。
+ *   not_found（链接或文件不存在）、no_active_document（当前没有打开的 Word 文档）、
+ *   invalid_params（参数缺失或形状不对）、invoke_failed（工具执行被拒或出错）。
  *
  * 重要：本文件必须用普通同步 <script> 引入，且排在业务脚本之前——
  * 宿主在 iframe load 后立刻发 init，晚注册监听会错过握手，ready() 将永远挂起。
@@ -79,7 +88,7 @@
 
   var awd = {
     /** SDK 版本，与桥协议版本无关 */
-    version: '1.0.0',
+    version: '1.1.0',
     /** 握手拿到的上下文；ready() 之前为 null */
     context: null,
     /** 等待宿主握手，resolve 值即 awd.context */
@@ -95,7 +104,21 @@
       read: function (path) { return call('files.read', { path: path }); }
     },
     ui: {
-      toast: function (message) { return call('ui.toast', { message: message }); }
+      toast: function (message) { return call('ui.toast', { message: message }); },
+      /** 把项目文件打开到工作台中栏（需 file_read） */
+      openFile: function (path) { return call('ui.openFile', { path: path }); }
+    },
+    tools: {
+      /** 直调本插件的 JAR 工具 -> 工具原始字符串输出（自行 JSON.parse） */
+      invoke: function (name, args) {
+        return call('tools.invoke', { name: name, args: args || {} }).then(function (r) {
+          return r && r.output != null ? r.output : '';
+        });
+      }
+    },
+    chat: {
+      /** 把 prompt 作为可见用户消息发进 AI 对话（起草类动作走这条，不直调工具） */
+      send: function (prompt) { return call('chat.send', { prompt: prompt }); }
     },
     storage: {
       /** -> 存过的值，没有则 null */


### PR DESCRIPTION
## 背景
尽调插件产品级升级（dev-board#207 skeleton 拆细 / #208 内置模板 / #210 专用界面）的宿主侧地基。设计文档（UI 路径图）见会话 artifact；插件本体改造在私有仓 aiworkdeck-dd-plugin v0.6.0。

## 改动
- **直调端点** `POST /api/plugins/{id}/tools/{tool}`：Web 面板做结构化操作时直调自家 JAR 工具。安全闸：登录会话 → 插件启用未封禁 → 工具必须是该插件 manifest 声明 → 项目写权限 → ToolRegistry.execute 原有 manifest 权限/宿主配额/服务端 ToolContext 全部照走。
- **桥/SDK v2.5 三方法**：`tools.invoke`（经上述端点）、`chat.send`（与 PluginGuidePane quickActions 同一条可见 kickoff 路，上限 4000 字）、`ui.openFile`（需 file_read，复用 awd:open-evidence-target 链路）。SDK 1.0.0→1.1.0，仓内三副本逐字节同步（官网仓副本另行 PR）。
- 文档同步：PLUGIN_SPEC v2.5（§8.4/§8.5/§8.7）、backend/skills/plugin-dev/prompt.md、.claude/agents/plugin-system.md。

## 验证
- 后端：PluginControllerInvokeToolTest 6 条（401/404/403/服务端 ToolContext 压掉伪造 projectId/缺 projectId 拒绝）+ PluginWebControllerTest/PluginServiceTest 全绿。
- 前端：test:plugin-sdk（含新增 v2.5 方法断言）与 check:emits 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)