### PR TITLE
feat(desktop): rail 整理模式 + 变量库前端隐藏（dev-board#215/#216）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -375,7 +375,10 @@ defaultDock / allowedDocks / svgPaths）+ 纯函数 `resolveDocks(overrides)` �
 v1 收录四个：variables / favorites / clipboard（默认 bottom，三档都行）、voice（默认 left，
 left|right，**不给 bottom**——底栏放不下它内部那两个 tab）。
 2026-08-27 加第五个：**insight（依据）**，默认 **right**、left|right（同样不给 bottom——
-底栏放不下判决书全文）。它是编辑器工具栏「解析」按钮的联动窗格，要和正文并排看，
+底栏放不下判决书全文）。
+**同日 'variables'（变量库）从注册表隐藏（dev-board#216，前端隐藏非拆除）**：现役成员
+只剩 favorites / clipboard / voice / insight 四个；变量库的死分支与休眠件清单见
+`.claude/agents/utility-tools.md`「变量库」一节，恢复/彻底拆除都先读那里。它是编辑器工具栏「解析」按钮的联动窗格，要和正文并排看，
 内容是 `components/InsightPane.vue`（外部检索 / 一致性校验两个 tab），详见
 `.claude/agents/doc-insight.md` 的「前端」一节。
 **它带来一处视觉变化**：`rightDockPanels` 从此默认非空，AI 面板顶部恒有一条
@@ -401,6 +404,11 @@ dock tab 条（「AI 助手 | 依据」）——在它之前那条 tab 条只有
 已记项之后。rail 按钮 `draggable="!isClientView"`，`onRailDragStart` 会级联调
 `onPanelDragStart`（可停靠面板拖出去落投放区仍走停靠，rail 内松手即排序），
 dragover 实时改 `railOrderDraft` 草稿、dragend 提交并持久化。
+**整理模式（dev-board#215）**：rail 底部 `.rail-edit-btn`（GLYPHS.sort）切换
+`railEditMode`——页面根挂 `.rail-edit-mode`，可拖项（`.rail-btn.is-sortable` 与
+两处 `.is-movable` tab）抖动+虚线框（iPhone 编辑主屏幕隐喻，prefers-reduced-motion
+下只留框不抖）；编辑态下 `onRailBtnTap` 拦截点击不打开面板。不持久化。
+由来：0.26.x 里可拖的 rail 图标只有语音一个、无任何指引，被复测判「根本没实现」。
 
 **顶栏头像下拉（dev-board#205，2026-08-27）**：恢复成两项（设置 / 退出登录，
 `avatarMenuOpen` + `.avatar-menu`），退出走 `utils/signOut.js` 唯一编排。

--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -303,6 +303,27 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 - **权益失效不等于把人锁在外面**：`applyOnStartup` 无条件应用自选存储根（权益失效后数据照常读写），因此 `GET /api/storage/location` 与「恢复默认位置」都**不设权益闸**——否则 Key 被吊销 + 外置盘拔掉的用户既看不到自己数据在哪，也换不回默认位置。付费闸只加在「改到新的自选位置」这个动作上。
 - `StorageException` 默认落到通用异常处理器会被替换成「服务器内部错误」（防路径回显）。存储位置那几条用户语言文案是在 `StorageLocationController` 里转成 `IllegalArgumentException` 才送出去的，新增可回显文案要走同一条路且确保不含路径。
 
+## 变量库（2026-08-27 已前端隐藏，dev-board#216）
+
+维护者裁决「不稳定、不好理解，干掉」，执行口径是**前端隐藏、深层保留休眠**（拆除
+牵连 LOWA 变量书签胶水，风险大于收益）。隐藏的唯一开关是
+`config/panelRegistry.js` 摘掉 `'variables'` 条目 + `config/commands/view.js` 摘掉
+`view.toolVariables` 菜单项（`menuCommands.js` 的 `toolVariables` 状态键同删）——
+底栏 tab、三档停靠、菜单、状态条入口全部随之消失，存量 `awd_panel_docks` override
+由 `sanitizeDockOverrides` 自动清掉。
+
+**仍然活着、动别的功能时别误伤的休眠件**：
+- `project-overview.vue` 三处 `VariablePanel` 宿主是**不可达死分支**（left/bottom/right
+  host 的 `=== 'variables'` 判断永远不命中），import 与 `getLibreVariableBridge` /
+  `handleOpenCreateVariable` / `handleSyncVariable` 三个方法都还在；
+- `/pages/variable-library` 独立页仍可直链打开（app-e2e J7 钉着它能渲染）；
+- 后端 `/api/variables*`、`/api/file-variables` 端点与数据表原样保留（用户数据不动）；
+- LOWA 变量书签胶水（`libreofficeExecutorClient.js` / `office_thread.js` 里的
+  variable 函数）一行没动——引擎胶水是高危区。
+
+恢复 = 把注册表条目与菜单项加回来；彻底拆除 = 以上清单倒着清，并同步
+`tests/panel-dock/dock-resolve.test.mjs`（已按隐藏后的成员改写）与 e2e J7。
+
 ## 验证
 
 - desktop 服务栈：`cd desktop && npm test`（service-manager/model-manager/pysvc-runtime/**browser-views**）。

--- a/frontend/src/config/commands/view.js
+++ b/frontend/src/config/commands/view.js
@@ -47,14 +47,8 @@ export const VIEW_COMMANDS = [
 
   // group 2 留给动态生成的「打开视图」子菜单
 
-  {
-    id: 'view.toolVariables',
-    label: { zh: '变量库', en: 'Variables' },
-    menu: 'view', group: 3,
-    type: 'checkbox', checked: 'toolVariables',
-    when: ['workbench', 'notClient'],
-    run: 'wb:openTool:variables',
-  },
+  // 'view.toolVariables'（变量库）2026-08-27 随功能前端隐藏一并摘除（dev-board#216），
+  // 恢复时连 panelRegistry 的 'variables' 条目一起加回。
   {
     id: 'view.toolFavorites',
     label: { zh: '收藏夹', en: 'Favorites' },

--- a/frontend/src/config/panelRegistry.js
+++ b/frontend/src/config/panelRegistry.js
@@ -31,13 +31,11 @@ const toPaths = (paths) => (paths || []).map((d) => ({ d }))
  * 已被本表取代）；语音原本是 rail 上的一个左栏面板。
  */
 export const MOVABLE_PANELS = [
-  {
-    key: 'variables',
-    labelKey: 'config.tools.variables',
-    defaultDock: 'bottom',
-    allowedDocks: ['left', 'right', 'bottom'],
-    svgPaths: toPaths(ICONS.braces),
-  },
+  // 'variables'（变量库）2026-08-27（dev-board#216）**前端隐藏、非拆除**：维护者裁决
+  // 「不稳定、不好理解，干掉」，但深层（VariablePanel 组件、project-overview 三处
+  // 死分支、/pages/variable-library 独立页、后端 /api/variables*、LOWA 变量书签胶水）
+  // 一律保留休眠——从注册表摘掉后所有入口（底栏 tab/停靠/菜单）自然消失，
+  // sanitizeDockOverrides 会把存量 override 清掉。恢复=把条目加回来+还原 view.js 菜单项。
   {
     key: 'favorites',
     labelKey: 'config.tools.favorites',

--- a/frontend/src/locales/en-US/workbench.js
+++ b/frontend/src/locales/en-US/workbench.js
@@ -80,6 +80,8 @@ export default {
   newOrCopy: 'New / Duplicate',
   emptyWorkspace: 'Select a file to get started',
   emptyWorkspaceHint: 'Open a file from the explorer on the left, or create a new document',
+  railEditEnter: 'Arrange sidebar (drag to reorder or dock)',
+  railEditDone: 'Done arranging',
   leftPaneIdle: 'Left pane idle',
   rightPaneIdle: 'Right pane idle',
   // Bottom tools panel

--- a/frontend/src/locales/zh-CN/workbench.js
+++ b/frontend/src/locales/zh-CN/workbench.js
@@ -80,6 +80,8 @@ export default {
   newOrCopy: '新建/复制',
   emptyWorkspace: '选择文件开始工作',
   emptyWorkspaceHint: '从左侧资源管理器打开文件，或新建一份文档',
+  railEditEnter: '整理侧栏（拖动排序或停靠）',
+  railEditDone: '完成整理',
   leftPaneIdle: '左侧空闲',
   rightPaneIdle: '右侧空闲',
   // 底部工具面板

--- a/frontend/src/pages/project-overview/menuCommands.js
+++ b/frontend/src/pages/project-overview/menuCommands.js
@@ -44,7 +44,6 @@ export const menuCommandsMethods = {
       sidebarOpen: !this.sidebarCollapsed,
       toolsPanelOpen: !!this.showToolsPanel,
       aiPanelOpen: !!this.showAiPanel,
-      toolVariables: !!this.showToolsPanel && this.activeToolKey === 'variables',
       toolFavorites: !!this.showToolsPanel && this.activeToolKey === 'favorites',
       toolClipboard: !!this.showToolsPanel && this.activeToolKey === 'clipboard',
       recording: !!this.isRecording,

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -4424,6 +4424,36 @@ $bg-white: #FFFFFF;
   opacity: 0.35;
 }
 
+/* 整理模式（dev-board#215）：可拖项抖动 + 虚线框，iPhone 编辑主屏幕的隐喻 */
+@keyframes rail-wiggle {
+  0% { transform: rotate(-2.5deg); }
+  50% { transform: rotate(2.5deg); }
+  100% { transform: rotate(-2.5deg); }
+}
+
+.rail-edit-mode .rail-btn.is-sortable,
+.rail-edit-mode .panel-tab.is-movable,
+.rail-edit-mode .right-dock-tab.is-movable {
+  animation: rail-wiggle 0.32s ease-in-out infinite;
+  outline: 1.5px dashed $color-accent;
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+/* 动画敏感用户：只留虚线框，不抖 */
+@media (prefers-reduced-motion: reduce) {
+  .rail-edit-mode .rail-btn.is-sortable,
+  .rail-edit-mode .panel-tab.is-movable,
+  .rail-edit-mode .right-dock-tab.is-movable {
+    animation: none;
+  }
+}
+
+.rail-edit-btn.active {
+  color: $color-primary;
+  background: $color-accent-pale;
+}
+
 /* —— 右侧面板的 tab 条（只有真有面板停到右侧时才渲染） —— */
 .right-dock-tabs {
   display: flex;

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -1,5 +1,5 @@
 <template>
-  <view class="page-project-overview" :class="{ 'compact-mode': isCompactLayout, 'is-resizing': resizing && resizing.active }">
+  <view class="page-project-overview" :class="{ 'compact-mode': isCompactLayout, 'is-resizing': resizing && resizing.active, 'rail-edit-mode': railEditMode }">
     <!-- 顶部固定项目信息 -->
     <view class="project-header">
       <view class="header-left">
@@ -269,10 +269,10 @@
           v-for="p in LEFT_SIDEBAR_PLUGINS"
           :key="p.key"
           class="rail-btn"
-          :class="{ active: (leftPaneKey === p.key && !sidebarCollapsed) || (p.key === 'staging' && stagingPinned), 'is-movable': isMovablePanel(p.key), 'rail-dragging': draggingRailKey === p.key }"
+          :class="{ active: (leftPaneKey === p.key && !sidebarCollapsed) || (p.key === 'staging' && stagingPinned), 'is-movable': isMovablePanel(p.key), 'is-sortable': !isClientView, 'rail-dragging': draggingRailKey === p.key }"
           :title="p.label"
           :draggable="!isClientView"
-          @tap="toggleLeftPane(p.key)"
+          @tap="onRailBtnTap(p.key)"
           @dragstart="onRailDragStart(p.key, $event)"
           @dragover="onRailDragOver(p.key, $event)"
           @dragend="onRailDragEnd"
@@ -307,6 +307,22 @@
             </svg>
           </view>
           <text v-else class="rail-icon">{{ p.icon }}</text>
+        </view>
+
+        <!-- 整理模式开关（dev-board#215）：iPhone 编辑主屏幕式——按下后所有可拖项
+             抖动+虚线框明示可拖，编辑态下点击不打开面板，再按一次退出 -->
+        <view
+          v-if="!isClientView"
+          class="rail-btn rail-edit-btn"
+          :class="{ active: railEditMode }"
+          :title="railEditMode ? $t('workbench.railEditDone') : $t('workbench.railEditEnter')"
+          @tap="toggleRailEditMode"
+        >
+          <view class="rail-icon-wrapper">
+            <svg class="rail-icon-svg" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path v-for="(d, gi) in GLYPHS.sort" :key="gi" :d="d" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="rail-icon-path" />
+            </svg>
+          </view>
         </view>
 
         <!-- Spacer -->

--- a/frontend/src/pages/project-overview/railSort.js
+++ b/frontend/src/pages/project-overview/railSort.js
@@ -19,6 +19,9 @@ export const railSortData = () => ({
   railOrderDraft: null,
   // 正在拖的 rail 项 key（与 draggingPanelKey 并存：后者只对可停靠面板生效）
   draggingRailKey: null,
+  // 整理模式（dev-board#215）：iPhone 编辑主屏幕式抖动编辑态。
+  // 开着时可拖项抖动+虚线框，点击不打开面板（防止想拖却点开）。不持久化。
+  railEditMode: false,
 })
 
 export const railSortMethods = {
@@ -52,6 +55,17 @@ export const railSortMethods = {
     const unknown = list.filter((p) => !idx.has(p.key))
     known.sort((a, b) => idx.get(a.key) - idx.get(b.key))
     return [...known, ...unknown]
+  },
+
+  toggleRailEditMode() {
+    this.railEditMode = !this.railEditMode
+    if (this.railEditMode) track('ui.railEditMode', {})
+  },
+
+  /** rail 项点击：整理模式下不打开面板（iPhone 抖动态下点 app 也不启动）。 */
+  onRailBtnTap(key) {
+    if (this.railEditMode) return
+    this.toggleLeftPane(key)
   },
 
   onRailDragStart(key, evt) {

--- a/frontend/tests/commands/commands.test.mjs
+++ b/frontend/tests/commands/commands.test.mjs
@@ -110,7 +110,7 @@ test('客户视图下 AI 菜单整条不可用', () => {
 
 test('客户视图拿不到插件广场与底部工具', () => {
   const client = { page: 'workbench', role: 'CLIENT', flags: { hasProject: true } }
-  for (const id of ['ai.pluginMarket', 'view.toolsPanel', 'view.toolVariables', 'tools.ocrCapture']) {
+  for (const id of ['ai.pluginMarket', 'view.toolsPanel', 'view.toolFavorites', 'tools.ocrCapture']) {
     assert.equal(isEnabled(COMMAND_BY_ID.get(id), client), false, id + ' 对客户可用了')
   }
 })

--- a/frontend/tests/panel-dock/dock-resolve.test.mjs
+++ b/frontend/tests/panel-dock/dock-resolve.test.mjs
@@ -34,7 +34,8 @@ test('注册表自洽：key 唯一、defaultDock 在 allowedDocks 里、allowedD
 
 test('没有 override 时全部落到 defaultDock', () => {
   const docks = resolveDocks({})
-  assert.deepEqual(keysOf(docks.bottom), ['variables', 'favorites', 'clipboard'])
+  // 'variables' 2026-08-27 从注册表隐藏（dev-board#216），bottom 只剩两项
+  assert.deepEqual(keysOf(docks.bottom), ['favorites', 'clipboard'])
   assert.deepEqual(keysOf(docks.left), ['voice'])
   assert.deepEqual(keysOf(docks.right), ['insight'])
   // undefined / null 与空对象等价
@@ -43,32 +44,33 @@ test('没有 override 时全部落到 defaultDock', () => {
 })
 
 test('合法 override 生效，各档内保持注册表顺序', () => {
-  const docks = resolveDocks({ voice: 'right', clipboard: 'left', variables: 'right' })
-  assert.deepEqual(keysOf(docks.right), ['variables', 'voice', 'insight'], '右档没有按注册表顺序')
+  const docks = resolveDocks({ voice: 'right', clipboard: 'left', favorites: 'right' })
+  assert.deepEqual(keysOf(docks.right), ['favorites', 'voice', 'insight'], '右档没有按注册表顺序')
   assert.deepEqual(keysOf(docks.left), ['clipboard'])
-  assert.deepEqual(keysOf(docks.bottom), ['favorites'])
+  assert.deepEqual(keysOf(docks.bottom), [])
 })
 
 test('allowedDocks 之外的 override 回落 default（语音不许进底栏）', () => {
   assert.equal(resolveDock('voice', { voice: 'bottom' }), 'left')
   const docks = resolveDocks({ voice: 'bottom' })
   assert.deepEqual(keysOf(docks.left), ['voice'])
-  assert.deepEqual(keysOf(docks.bottom), ['variables', 'favorites', 'clipboard'])
+  assert.deepEqual(keysOf(docks.bottom), ['favorites', 'clipboard'])
 })
 
 test('非法值与未知 key 一律回落 default，不抛异常', () => {
-  assert.equal(resolveDock('variables', { variables: 'floating' }), 'bottom')
-  assert.equal(resolveDock('variables', { variables: '' }), 'bottom')
-  assert.equal(resolveDock('variables', { variables: null }), 'bottom')
+  assert.equal(resolveDock('favorites', { favorites: 'floating' }), 'bottom')
+  assert.equal(resolveDock('favorites', { favorites: '' }), 'bottom')
+  assert.equal(resolveDock('favorites', { favorites: null }), 'bottom')
   assert.equal(resolveDock('nope', { nope: 'left' }), null)
-  const docks = resolveDocks({ nope: 'left', variables: 'nowhere' })
-  assert.deepEqual(keysOf(docks.bottom), ['variables', 'favorites', 'clipboard'])
+  // 'variables' 隐藏后就是「存量 override 指向已下线面板」的真实用例
+  const docks = resolveDocks({ nope: 'left', variables: 'left' })
+  assert.deepEqual(keysOf(docks.bottom), ['favorites', 'clipboard'])
   assert.deepEqual(keysOf(docks.left), ['voice'], '未知 key 混进了左档')
   assert.deepEqual(keysOf(docks.right), ['insight'], '未知 key 混进了右档')
 })
 
 test('三个档位恒定存在（宿主直接读 .left/.right/.bottom，不做存在性判断）', () => {
-  for (const overrides of [{}, { voice: 'right' }, { variables: 'left', favorites: 'left', clipboard: 'left' }]) {
+  for (const overrides of [{}, { voice: 'right' }, { favorites: 'left', clipboard: 'left' }]) {
     const docks = resolveDocks(overrides)
     for (const d of DOCKS) assert.ok(Array.isArray(docks[d]), d + ' 档不是数组')
   }
@@ -83,7 +85,7 @@ test('每个面板恰好落在一个档里', () => {
 
 test('sanitizeDockOverrides 只留下能用的条目', () => {
   assert.deepEqual(
-    sanitizeDockOverrides({ voice: 'right', clipboard: 'bottom', variables: 'floating', ghost: 'left' }),
+    sanitizeDockOverrides({ voice: 'right', clipboard: 'bottom', variables: 'left', ghost: 'left' }),
     { voice: 'right', clipboard: 'bottom' }
   )
   assert.deepEqual(sanitizeDockOverrides({ voice: 'bottom' }), {}, '不被允许的档没有被清掉')
@@ -96,7 +98,8 @@ test('sanitizeDockOverrides 只留下能用的条目', () => {
 test('isMovablePanel / isDockAllowed / getMovablePanel 的口径与注册表一致', () => {
   assert.ok(isMovablePanel('voice'))
   assert.ok(!isMovablePanel('files'), '文件树不是可停靠面板（rail 上不许出现拖拽手柄）')
-  assert.ok(isDockAllowed('variables', 'left'))
+  assert.ok(isDockAllowed('favorites', 'left'))
+  assert.ok(!isMovablePanel('variables'), "'variables' 已隐藏（dev-board#216），不许再是可停靠面板")
   assert.ok(!isDockAllowed('voice', 'bottom'))
   assert.ok(!isDockAllowed('files', 'left'))
   assert.equal(getMovablePanel('favorites').defaultDock, 'bottom')


### PR DESCRIPTION
2026-08-27 下午追加两条指示（dev-board#215/#216），并回应 #180 复测反馈「跨栏停靠拖拽根本没实现（0.26.0）」。

## 调查结论（#180 反馈）
- panelDocking 代码确认在 v0.26.0 内；dev H5 真渲染探针证实 draggable 落 DOM、监听已绑、事件链能点亮投放区——接线是通的。
- 真因：0.26.x 可拖的 rail 图标只有「语音」一个，且界面无任何可拖指引，观感等于没实现。上一 PR（#617）已让全部 rail 图标可拖排序，本 PR 补可发现性。

## 改动
1. **#215 整理模式**：rail 底部新增整理按钮，按下进入 iPhone 编辑主屏幕式编辑态——所有可拖项（rail 图标 + 可停靠 tab）抖动+虚线框，编辑态下点击不打开面板（只能拖），再按退出；prefers-reduced-motion 只留框不抖。
2. **#216 变量库前端隐藏**（按维护者指示降级为隐藏、非拆除）：panelRegistry 摘 'variables' + view 菜单摘 view.toolVariables，底栏 tab/停靠/菜单/状态条全部消失，存量停靠 override 自动清理。**深层全保留休眠**（VariablePanel 死分支、/pages/variable-library 直链页、后端 /api/variables*、LOWA 变量书签胶水），清单与恢复/拆除口径写进 utility-tools.md「变量库」一节 + 记忆库注意事项。

## 自验证
- check:locales / check:nav / check:emits / test:panel-dock（按隐藏后成员改写）/ test:commands 全绿；build:h5 通过。
- dev H5 + puppeteer 真渲染：整理按钮渲染、编辑态类与抖动动画生效、编辑态点击被拦、退出后恢复；状态条只剩收藏夹/剪贴板，全页无「变量」入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)