### PR TITLE
桌面端：窗口失焦时交通灯消失（dev-board#218）

### DIFF
--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { app, BrowserWindow, BrowserView, ipcMain, shell, desktopCapturer, screen, clipboard, Menu, globalShortcut } = require('electron')
+const { app, BrowserWindow, BrowserView, ipcMain, shell, desktopCapturer, screen, clipboard, Menu, globalShortcut, nativeTheme } = require('electron')
 const { createServiceManager } = require('./services/service-manager')
 const { createBackendDescriptor } = require('./services/backend-service')
 const { createPptxDescriptor } = require('./services/pptx-service')
@@ -1623,6 +1623,12 @@ app.on('open-file', (event, p) => {
 })
 
 app.whenReady().then(() => {
+  // 原生外观锁定浅色：外壳是浅色单主题（配色红线，深色 chrome 已被否决）。
+  // 不锁的话原生层跟随系统——系统开深色时，窗口失焦后 macOS 按深色规则绘制
+  // 交通灯，落在我们的浅色顶栏上等于隐形（实测失活态偏离背景像素数为 0，
+  // 也就是整组按钮凭空消失；锁浅色后恢复成标准的三个灰色圆点）。
+  // 一并把原生右键菜单、滚动条、系统对话框拉回与浅色 UI 一致。
+  try { nativeTheme.themeSource = 'light' } catch (e) { /* ignore */ }
   initLocalFileService()
   // IDE 化应用菜单（File 全套 + 最近打开；动作发回渲染层处理）
   try {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js"
+    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/tests/native-theme-light.test.js
+++ b/desktop/tests/native-theme-light.test.js
@@ -1,0 +1,39 @@
+// 原生外观锁定浅色（dev-board#218）。
+//
+// 病灶：外壳是浅色单主题，但原生层默认跟随系统。系统开深色时，主窗口一失焦
+// macOS 就按深色规则绘制交通灯，落在我们的浅色顶栏上完全不可见——实测失活态
+// 抓图里交通灯区域偏离背景的像素数为 0（整组按钮凭空消失），锁浅色后恢复成
+// 标准的三个灰色圆点。
+//
+// main.js 起手就 new BrowserWindow / 拉服务，node 直接 require 不进来，
+// 因此与 frontend 的契约用例同口径做源码级断言。
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const SRC = fs.readFileSync(path.join(__dirname, '../main/main.js'), 'utf8')
+const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+test('从 electron 引入 nativeTheme', () => {
+  const line = CODE.split('\n').find((l) => l.includes("require('electron')"))
+  assert.ok(line, "找不到顶层 require('electron')")
+  assert.match(line, /nativeTheme/, '不引入就没法锁外观')
+})
+
+test('themeSource 锁成 light', () => {
+  assert.match(CODE, /nativeTheme\.themeSource\s*=\s*'light'/,
+    "外壳是浅色单主题；跟随系统会让深色下的失焦窗口丢掉交通灯")
+  assert.ok(!/themeSource\s*=\s*'(dark|system)'/.test(CODE),
+    '不允许有把外观改回深色/跟随系统的分支')
+})
+
+test('锁外观发生在第一次建主窗口之前', () => {
+  const lock = CODE.indexOf("nativeTheme.themeSource = 'light'")
+  // 只找调用点，跳过函数定义（definition 在文件上半部分）
+  const call = CODE.search(/(?<!function\s)createMainWindow\(\)/)
+  assert.ok(lock >= 0, '找不到锁外观那一行')
+  assert.ok(call >= 0, '找不到 createMainWindow() 调用点')
+  assert.ok(lock < call,
+    '窗口建完再改外观会让首个窗口以系统外观创建，交通灯仍然会丢')
+})


### PR DESCRIPTION
## 现象
窗口未选中时，左上角红黄绿按钮整组消失（macOS 原生行为应为变灰仍可见）。

## 根因
外壳是浅色单主题（配色红线），但原生层默认跟随系统外观。维护者机器处于**系统深色模式**：窗口一失焦，macOS 就按深色规则绘制交通灯，落在我们的浅色顶栏（#F6F8F9）上完全不可见。

真机抓图量化（交通灯区域偏离背景的像素数，170x48 区域）：

| 状态 | 修复前 | 修复后 |
|---|---|---|
| 激活 | 1278（彩色） | 1278（彩色） |
| **失焦** | **0（整组消失）** | 1278（标准灰色圆点） |

对照实验另确认：默认边框窗（`frame: true`）在同样条件下失焦仍显示灰点，只有 `titleBarStyle: 'hidden'` 这条路径会整组丢失。

## 修法
`app.whenReady()` 里锁 `nativeTheme.themeSource = 'light'`，位置在 `createMainWindow()` 调用之前（窗口建完再改，首个窗口仍会以系统外观创建）。

顺带把原生右键菜单、滚动条、系统对话框拉回与浅色 UI 一致。

**副作用（需要知情）**：内置浏览器里支持 `prefers-color-scheme` 的第三方页面此后一律浅色渲染。应用内部代码零处使用 `prefers-color-scheme`（已 grep 确认），内部 UI 不受影响。

## 验证
- 真机跑本分支代码（非合成复现）：失焦态恢复三个灰色圆点，见上表。
- 新增 `desktop/tests/native-theme-light.test.js` 源码级契约断言（引入 nativeTheme / 锁 light / 锁在建窗之前），已接进 `desktop` 的 `npm test`；还原病灶即 3/3 转红已验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)