### PR TITLE
chore(release): v0.26.3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
小版本（补丁通道）。v0.26.2 之后仅一笔前端修复：
- #622 rail 整理拖拽误落对话区不再报「未获取到拖拽数据」；整理按钮挪到顶栏原「已连接账户」chip 位置并删除该 chip（dev-board#220/#221，用户 16:31 截图反馈）

门禁：v0.26.2 全量四道门禁（2808/0、75/0、461/0、131 步全绿）+ 本笔 delta 的 check:emits 与 build:h5；补丁边界零壳层改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)