### PR TITLE
feat(mobile-sync): 云中转 3G 配额+TTL 30 天+录音类型；资源管理器右键转写

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -3,11 +3,12 @@ name: mobile-sync
 description: 手机端同步领域。任务涉及手机端项目目录镜像、现场影像云中转（/api/mobile/*）、桌面侧 MobileRelayClientService、桥接认领手机号、aiworkdeck_mobile 仓的 iOS/小程序客户端时，先读本文档再动代码。
 ---
 
-# 手机端同步（项目目录镜像 + 现场影像云中转）
+# 手机端同步（项目目录镜像 + 现场影像/录音云中转）
 
-手机端（独立仓 `1-3 aiworkdeck_mobile`：iOS Swift + 微信小程序）拍现场影像，归档到
-桌面端项目的「现场影像/YYYY-MM-DD/」。**桌面端是项目的唯一权威源**，云端只做两件事：
-目录镜像（手机「选择项目」的数据源）与影像中转区（ACK 即删 + 7 天 TTL 兜底）。
+手机端（独立仓 `1-3 aiworkdeck_mobile`：iOS Swift + 微信小程序）拍现场影像与录音，归档到
+桌面端项目的「现场影像/YYYY-MM-DD/」（image/video）或「现场录音/YYYY-MM-DD/」（audio，
+dev-board#228）。**桌面端是项目的唯一权威源**，云端只做两件事：
+目录镜像（手机「选择项目」的数据源）与影像中转区（ACK 即删 + 30 天 TTL 兜底）。
 权威 spec：`aiworkdeck_mobile/docs/specs/2026-08-20-project-sync-relay.md`（根因复盘见
 dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
 
@@ -35,7 +36,17 @@ dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
 - 目录条目 = `{deviceId, key, name}`；`key` 是**那台桌面机本地库的项目 id**，跨机同号
   不同物，任何消费方必须连 deviceId 一起用。
 - 影像幂等键 = (userId, clientMediaId)，clientMediaId 只收 UUID 形态（路径穿越围栏）。
-- 删除由 ACK 触发，TTL 只是兜底——两个机制不能混。
+- 删除由 ACK 触发，TTL（30 天，dev-board#226 从 7 天延长）只是兜底——两个机制不能混。
+- `mediaType ∈ {image, video, audio}`（audio 自 dev-board#228）。桌面落盘根目录由它推导：
+  audio → 「现场录音」，其余 → 「现场影像」；rootFolder 同时参与幂等判据与 storagePath
+  拼接，改动必须两处同源（`MobileRelayClientService.landAndAck`）。
+- **每用户 3GB 配额**（dev-board#226）：只计未投递 blob（storagePath 非空行）的 fileSize
+  之和，ACK 即删 = 释放配额。检查在写盘前按声明大小做（幂等重传先于配额检查，不占新
+  空间不得拒）；并发上传可略超上限（最多一件，接受的软度）。拒绝走
+  IllegalArgumentException → HTTP 200 + `{code:1,message:"云端空间已满…"}`，恰是两端
+  客户端能透传到界面的形状（非 2xx 的 body 会被客户端丢弃，别改成 413）。
+- `GET /api/mobile/media/usage` → `{usedBytes, quotaBytes}`（裸对象）；
+  `/media/status` 未投递件带 `expiresAt`（createdAt+TTL，ISO 字符串）供手机端做到期提醒。
 - 桌面落盘文件名 = 原名 + clientMediaId 前 8 位（`landedFileName`）：跨轮重试的幂等锚点，
   「同名已在 → 只补 ACK」。
 - 客户端换账号守卫：state 里的账户指纹与 `AccountService.accountFingerprintOrNull()`

--- a/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
+++ b/backend/src/main/java/com/checkba/controller/MeetingRecordingController.java
@@ -120,6 +120,38 @@ public class MeetingRecordingController {
         return meeting;
     }
 
+    /**
+     * 资源管理器右键转写（dev-board#227）：把项目里已有的音频文件注册成会议记录并
+     * 立即提交转写（与面板 finish 的自动提交同一套闸：凭证已配、平台档告知已确认）。
+     * 幂等：同一文件重复注册返回既有记录；仅当记录尚可转写（RECORDED/FAILED/EMPTY）
+     * 时才提交，TRANSCRIBED/TRANSCRIBING 的不重复扣费。
+     */
+    @PostMapping("/projects/{projectId}/register-file")
+    public Map<String, Object> registerFile(
+            @PathVariable Long projectId,
+            @RequestBody RegisterFileDto dto,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireMemberByProject(sessionId, projectId);
+        if (dto == null || dto.getFileId() == null) {
+            throw new IllegalArgumentException(LangText.of("缺少文件标识", "Missing file id"));
+        }
+        MeetingRecording meeting = meetingService.registerExisting(projectId, dto.getFileId(), userId);
+        boolean submitted = false;
+        boolean transcribable = MeetingRecording.STATUS_RECORDED.equals(meeting.getStatus())
+                || MeetingRecording.STATUS_FAILED.equals(meeting.getStatus())
+                || MeetingRecording.STATUS_EMPTY.equals(meeting.getStatus());
+        if (transcribable && transcriptionService.isConfigured()
+                && !transcriptionService.recordingNoticePending()) {
+            meeting = transcriptionService.startTranscription(meeting.getId());
+            submitted = true;
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("meeting", meeting);
+        result.put("configured", transcriptionService.isConfigured());
+        result.put("submitted", submitted);
+        return result;
+    }
+
     /** 手动（重新）提交转写。 */
     @PostMapping("/{meetingId}/transcribe")
     public MeetingRecording transcribe(
@@ -185,6 +217,11 @@ public class MeetingRecordingController {
     }
 
     // ==================== DTO ====================
+
+    @Data
+    public static class RegisterFileDto {
+        private Long fileId;
+    }
 
     @Data
     public static class FinishDto {

--- a/backend/src/main/java/com/checkba/controller/MobileRelayController.java
+++ b/backend/src/main/java/com/checkba/controller/MobileRelayController.java
@@ -98,7 +98,8 @@ public class MobileRelayController {
         LocalDateTime captured = parseCapturedAt(capturedAt);
         try (InputStream in = file.getInputStream()) {
             MobileMediaInbox item = store.storeMedia(
-                    userId, deviceId, projectKey, clientMediaId, fileName, mediaType, captured, in);
+                    userId, deviceId, projectKey, clientMediaId, fileName, mediaType, captured,
+                    file.getSize(), in);
             Map<String, Object> out = new LinkedHashMap<>();
             out.put("code", 0);
             out.put("id", item.getId());
@@ -108,6 +109,13 @@ public class MobileRelayController {
         } catch (IOException e) {
             throw new IllegalStateException(LangText.of("影像暂存失败", "Failed to store media"), e);
         }
+    }
+
+    /** 手机端：中转区用量与配额（裸对象，dev-board#226）。 */
+    @GetMapping("/media/usage")
+    public Map<String, Object> mediaUsage(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        return store.usage(requireUser(sessionId));
     }
 
     /** 手机端：查询影像投递状态（裸数组）。 */

--- a/backend/src/main/java/com/checkba/model/entity/MeetingRecording.java
+++ b/backend/src/main/java/com/checkba/model/entity/MeetingRecording.java
@@ -47,6 +47,13 @@ public class MeetingRecording {
     /** 录音音频在项目文件树里的 ProjectFile ID */
     private Long audioFileId;
 
+    /**
+     * 本记录是否「代管」音频文件（dev-board#227）。面板录音流程自建的占位文件归本记录管，
+     * 删除记录连带删文件；资源管理器右键转写注册的是用户已有的文件，删除记录时绝不能
+     * 动它。null（存量行）一律视同 true——存量行全部来自面板流程。
+     */
+    private Boolean ownsAudioFile;
+
     /** 录音时长（毫秒），结束录音时由前端回报 */
     private Long durationMs;
 

--- a/backend/src/main/java/com/checkba/model/entity/MobileMediaInbox.java
+++ b/backend/src/main/java/com/checkba/model/entity/MobileMediaInbox.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
  * 手机端现场影像中转区的一件待取件。
  *
  * <p>生命周期：手机上传（幂等键 user_id + client_media_id）→ 桌面端取件落盘后 ACK
- * （置 deliveredAt + <b>立即删除 blob</b>，行保留供手机端查「已抵达」）→ 7 天清理任务删行。
+ * （置 deliveredAt + <b>立即删除 blob</b>，行保留供手机端查「已抵达」）→ 30 天清理任务删行。
  * 删除由 ACK 触发、不由时间触发，TTL 只是兜底——两个机制不能混（spec 不变式 1）。
  */
 @Entity
@@ -42,7 +42,7 @@ public class MobileMediaInbox {
     @Column(nullable = false, length = 512)
     private String fileName;
 
-    /** image | video */
+    /** image | video | audio */
     @Column(nullable = false, length = 16)
     private String mediaType;
 

--- a/backend/src/main/java/com/checkba/repository/MobileMediaInboxRepository.java
+++ b/backend/src/main/java/com/checkba/repository/MobileMediaInboxRepository.java
@@ -2,6 +2,8 @@ package com.checkba.repository;
 
 import com.checkba.model.entity.MobileMediaInbox;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -19,4 +21,9 @@ public interface MobileMediaInboxRepository extends JpaRepository<MobileMediaInb
     List<MobileMediaInbox> findByUserIdAndClientMediaIdIn(Long userId, List<String> clientMediaIds);
 
     List<MobileMediaInbox> findByCreatedAtBefore(LocalDateTime cutoff);
+
+    /** 未投递 blob 的字节总和（storagePath 非空 = blob 还占着中转区），配额口径。 */
+    @Query("select coalesce(sum(m.fileSize), 0) from MobileMediaInbox m"
+            + " where m.userId = :userId and m.storagePath is not null")
+    long sumPendingBytes(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * 会议录音生命周期：建档（含音频文件占位）→ 结束 → 说话人改名 / 导出 / 删除，
@@ -77,8 +78,63 @@ public class MeetingRecordingService {
         meeting.setTitle(title);
         meeting.setStatus(MeetingRecording.STATUS_RECORDING);
         meeting.setAudioFileId(audio.getId());
+        meeting.setOwnsAudioFile(true);
         meeting.setCreatedBy(userId);
         return meetingRepository.save(meeting);
+    }
+
+    /**
+     * 资源管理器右键转写（dev-board#227）：把项目里一个已存在的音频文件注册成一条
+     * 会议记录，复用整条转写链路（三档编排、说话人分离、纪要都在其上）。
+     *
+     * <p>不复制字节——{@code audioFileId} 是裸外键，转写侧 resolveAudioPath 只按
+     * ProjectFile.filePath 取文件，不关心它在哪个文件夹。{@code ownsAudioFile=false}：
+     * 删除这条记录不许连带删用户的原始文件。
+     *
+     * <p>幂等：同一文件已注册过则返回既有记录（防止重复点右键各花一次转写费）。
+     */
+    @Transactional
+    public MeetingRecording registerExisting(Long projectId, Long fileId, Long userId) {
+        ProjectFile file = projectFileRepository.findById(fileId).orElse(null);
+        if (file == null || Boolean.TRUE.equals(file.getIsDeleted())
+                || !projectId.equals(file.getProjectId())) {
+            throw new IllegalArgumentException(LangText.of("文件不存在", "File not found"));
+        }
+        if (Boolean.TRUE.equals(file.getIsFolder())) {
+            throw new IllegalArgumentException(LangText.of("不能转写文件夹", "Cannot transcribe a folder"));
+        }
+        if (!isAudioFileName(file.getName())) {
+            throw new IllegalArgumentException(LangText.of("该文件不是音频文件", "Not an audio file"));
+        }
+
+        for (MeetingRecording existing : meetingRepository.findByProjectIdOrderByCreatedAtDesc(projectId)) {
+            if (fileId.equals(existing.getAudioFileId())) {
+                return existing;
+            }
+        }
+
+        String name = file.getName();
+        int dot = name.lastIndexOf('.');
+        MeetingRecording meeting = new MeetingRecording();
+        meeting.setProjectId(projectId);
+        meeting.setTitle(dot > 0 ? name.substring(0, dot) : name);
+        // 字节已在，直接进 RECORDED（可转写态），跳过 RECORDING
+        meeting.setStatus(MeetingRecording.STATUS_RECORDED);
+        meeting.setAudioFileId(fileId);
+        meeting.setOwnsAudioFile(false);
+        meeting.setCreatedBy(userId);
+        return meetingRepository.save(meeting);
+    }
+
+    /** 可注册转写的音频扩展名。与前端 FileTree 右键菜单的判定保持一致。 */
+    private static final Set<String> AUDIO_EXTENSIONS = Set.of(
+            "mp3", "m4a", "aac", "wav", "flac", "ogg", "opus", "amr", "wma", "webm");
+
+    public static boolean isAudioFileName(String name) {
+        if (name == null) return false;
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) return false;
+        return AUDIO_EXTENSIONS.contains(name.substring(dot + 1).toLowerCase());
     }
 
     public List<MeetingRecording> list(Long projectId) {
@@ -132,12 +188,18 @@ public class MeetingRecordingService {
         return meetingRepository.save(meeting);
     }
 
-    /** 删除会议记录与音频文件（音频删除失败只记日志，不挡记录删除）。 */
+    /**
+     * 删除会议记录与音频文件（音频删除失败只记日志，不挡记录删除）。
+     *
+     * <p>音频只在本记录代管时（面板流程自建的占位文件）连带删除；右键转写注册的记录
+     * （ownsAudioFile=false）指向用户已有的文件，删除记录绝不能把他的原始录音丢进回收站。
+     * null 视同代管（存量行全部来自面板流程）。
+     */
     @Transactional
     public void delete(Long meetingId, Long userId) {
         MeetingRecording meeting = get(meetingId);
         meetingRepository.delete(meeting);
-        if (meeting.getAudioFileId() != null) {
+        if (meeting.getAudioFileId() != null && !Boolean.FALSE.equals(meeting.getOwnsAudioFile())) {
             try {
                 projectFileService.delete(meeting.getAudioFileId(), userId);
             } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingTranscriptionService.java
@@ -399,6 +399,20 @@ public class MeetingTranscriptionService {
         return saved;
     }
 
+    /**
+     * 上报给上游的音频格式：取 prepared 文件的真实扩展名。prepared 要么是转码产物（.mp3），
+     * 要么是转码失败时回退的原始文件——旧实现硬编码「非 mp3 即 webm」，那个假设只在
+     * 音频全部来自前端 MediaRecorder（webm）的时代成立；右键转写与手机录音进来后
+     * 原始文件可能是 m4a/wav 等任意格式，把 m4a 字节当 webm 上报会让听悟拒识或识别乱码
+     * （dev-board#227）。无扩展名时仍回落 webm（历史占位文件的形态）。
+     */
+    static String audioFormat(File prepared) {
+        String n = prepared.getName();
+        int dot = n.lastIndexOf('.');
+        String ext = dot >= 0 && dot < n.length() - 1 ? n.substring(dot + 1).toLowerCase() : "";
+        return ext.isEmpty() ? "webm" : ext;
+    }
+
     /** 音频本体的定位与非空校验，两档共用。 */
     private Path resolveAudioPath(MeetingRecording meeting) throws Exception {
         ProjectFile audio = projectFileRepository.findById(meeting.getAudioFileId())
@@ -462,7 +476,7 @@ public class MeetingTranscriptionService {
 
             workDir = Files.createTempDirectory("awd-meeting-");
             File prepared = transcodeWithTimeout(audioPath.toFile(), workDir);
-            String format = prepared.getName().endsWith(".mp3") ? "mp3" : "webm";
+            String format = audioFormat(prepared);
             long durationSec = estimateDurationSec(meeting, prepared);
 
             // ① 凭证：余额闸在这一步就生效，用户不会白传两小时录音才被拒
@@ -581,7 +595,7 @@ public class MeetingTranscriptionService {
 
             workDir = Files.createTempDirectory("awd-meeting-");
             File prepared = transcodeWithTimeout(audioPath.toFile(), workDir);
-            String ext = prepared.getName().endsWith(".mp3") ? "mp3" : "webm";
+            String ext = audioFormat(prepared);
             String objectKey = ossObjectKey(meeting, ext);
 
             String signedUrl = ossClient.uploadAndSign(settings, objectKey, prepared, URL_TTL);

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
@@ -188,6 +188,8 @@ public class MobileRelayClientService {
 
     /** 归档根目录名，与 buildPhysicalPath 会拼出的物理路径同构，见 landAndAck 内注释。 */
     private static final String MEDIA_ROOT_FOLDER = "现场影像";
+    /** 录音（mediaType=audio）落这个根目录——律师找录音不该去翻「现场影像」。 */
+    private static final String AUDIO_ROOT_FOLDER = "现场录音";
 
     private void landAndAck(JsonNode item) throws IOException, InterruptedException {
         long itemId = item.path("id").asLong();
@@ -207,7 +209,12 @@ public class MobileRelayClientService {
         }
 
         String dateStr = captureDate(item);
-        ProjectFile root = ensureFolder(projectId, null, MEDIA_ROOT_FOLDER, userId);
+        // 根目录按类型分流：音频进「现场录音」，图片/视频照旧进「现场影像」。rootFolder 必须
+        // 从 mediaType 稳定推导——它同时参与幂等判据（同名文件查找）与 storagePath 拼接，
+        // 跨轮重试两处要落在同一棵目录下。
+        String mediaType = item.path("mediaType").asText("image");
+        String rootFolderName = "audio".equals(mediaType) ? AUDIO_ROOT_FOLDER : MEDIA_ROOT_FOLDER;
+        ProjectFile root = ensureFolder(projectId, null, rootFolderName, userId);
         ProjectFile day = ensureFolder(projectId, root.getId(), dateStr, userId);
 
         String landedName = landedFileName(item.path("fileName").asText(),
@@ -239,20 +246,20 @@ public class MobileRelayClientService {
             // 事务包裹它，一旦返回即已提交，此后任何失败都救不回来（旧实现先 createFile 再
             // save，save 抛 IOException 时行已落库、ACK 没发，下一轮却只按"同名文件已在"的
             // 幂等判据误判成功直接补 ACK）。storagePath 与 buildPhysicalPath 会算出的路径同构
-            // （两层目录名就是上面 ensureFolder 用的 MEDIA_ROOT_FOLDER 与 dateStr），显式传给
+            // （两层目录名就是上面 ensureFolder 用的 rootFolderName 与 dateStr），显式传给
             // createFile 而不是留空自动推导，为的是下面这行 save 能在建库之前先拿到确定的
             // 存储 key；createFile 内部 createFromTemplate 见文件已存在会直接跳过，不会用
             // 模板覆盖已经落好的真内容。真落盘失败（磁盘满/网络中断）时异常在 createFile 之前
             // 抛出，本轮不落一条库记录，下一轮幂等判据自然判定"未落地"、重新下载，
             // 不需要额外的补偿删除。
             String storagePath = String.format("projects/%d/%s/%s/%s",
-                    projectId, MEDIA_ROOT_FOLDER, dateStr, landedName);
+                    projectId, rootFolderName, dateStr, landedName);
             try (InputStream in = content.body()) {
                 storageServiceFactory.getStorageService().save(storagePath, in);
             }
             ProjectFile record = projectFileService.createFile(
                     projectId, day.getId(), landedName,
-                    item.path("mediaType").asText("image"),
+                    mediaType,
                     item.path("fileSize").asLong(0),
                     storagePath, null, userId);
             // storagePath 是照着 ProjectFileService.buildPhysicalPath 的格式手拼的，
@@ -264,7 +271,7 @@ public class MobileRelayClientService {
                         storagePath, record.getFilePath());
             }
             log.info("手机同步：影像 {} 已落盘 项目={} 文件={}/{}/{}",
-                    itemId, projectId, MEDIA_ROOT_FOLDER, dateStr, landedName);
+                    itemId, projectId, rootFolderName, dateStr, landedName);
         }
         HttpResponse<String> ack = authed("POST", "/api/mobile/inbox/" + itemId + "/ack", "{}");
         if (!okEnvelope(ack)) {

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayStoreService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayStoreService.java
@@ -40,8 +40,13 @@ import java.util.regex.Pattern;
  *   <li>目录按 (userId, deviceId) 整批替换——projectKey 是那台桌面机本地库的项目 id，
  *       跨机同号不同物；</li>
  *   <li>影像幂等键 (userId, clientMediaId)，重传返回既有记录；</li>
- *   <li>删除由桌面端 ACK 触发（删 blob 留行），7 天 TTL 只是兜底（行与残留 blob 一并删）。</li>
+ *   <li>删除由桌面端 ACK 触发（删 blob 留行），30 天 TTL 只是兜底（行与残留 blob 一并删）。</li>
  * </ul>
+ *
+ * <p>容量口径（dev-board#226）：每用户 3GB，只计<b>未投递的 blob</b>（storagePath 非空的行）——
+ * ACK 即删 blob 就是释放配额，空间循环利用。配额检查在写盘之前按声明大小做，两笔并发上传
+ * 可能同时通过检查而略超上限（最多超一件的量，nginx 单请求 200MB 封顶），接受这个软度，
+ * 换取不引锁。
  */
 @Service
 @Slf4j
@@ -51,7 +56,13 @@ public class MobileRelayStoreService {
     private static final Pattern MEDIA_ID = Pattern.compile("^[A-Fa-f0-9-]{8,64}$");
     /** 单设备目录上限：正常律师机器几十个项目，超出多半是调用方出错，不让它撑爆表。 */
     private static final int MAX_DIR_ENTRIES = 1000;
-    private static final Duration TTL = Duration.ofDays(7);
+    /**
+     * TTL 从 7 天延长到 30 天（dev-board#226）：7 天意味着桌面端一周不开机，用户拍的
+     * 证据就被清掉——手机本地虽默认保留原件，但用户感知是「传上去的丢了」。
+     */
+    static final Duration TTL = Duration.ofDays(30);
+    /** 每用户中转区配额：3GB，只计未投递的 blob（ACK 即删 = 释放配额）。 */
+    static final long QUOTA_BYTES = 3L * 1024 * 1024 * 1024;
 
     private final MobileProjectDirRepository dirRepository;
     private final MobileMediaInboxRepository inboxRepository;
@@ -163,11 +174,11 @@ public class MobileRelayStoreService {
      */
     public MobileMediaInbox storeMedia(Long userId, String deviceId, String projectKey,
                                        String clientMediaId, String fileName, String mediaType,
-                                       LocalDateTime capturedAt, InputStream content) {
+                                       LocalDateTime capturedAt, long declaredSize, InputStream content) {
         try {
-            return self.storeMediaTx(userId, deviceId, projectKey, clientMediaId, fileName, mediaType, capturedAt, content);
+            return self.storeMediaTx(userId, deviceId, projectKey, clientMediaId, fileName, mediaType, capturedAt, declaredSize, content);
         } catch (DataIntegrityViolationException | UnexpectedRollbackException e) {
-            return self.storeMediaTx(userId, deviceId, projectKey, clientMediaId, fileName, mediaType, capturedAt, content);
+            return self.storeMediaTx(userId, deviceId, projectKey, clientMediaId, fileName, mediaType, capturedAt, declaredSize, content);
         }
     }
 
@@ -181,7 +192,7 @@ public class MobileRelayStoreService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public MobileMediaInbox storeMediaTx(Long userId, String deviceId, String projectKey,
                                        String clientMediaId, String fileName, String mediaType,
-                                       LocalDateTime capturedAt, InputStream content) {
+                                       LocalDateTime capturedAt, long declaredSize, InputStream content) {
         requireDeviceId(deviceId);
         if (projectKey == null || projectKey.isBlank()) {
             throw new IllegalArgumentException(LangText.of("缺少项目标识", "Missing project key"));
@@ -192,14 +203,25 @@ public class MobileRelayStoreService {
         if (fileName == null || fileName.isBlank()) {
             throw new IllegalArgumentException(LangText.of("缺少文件名", "Missing file name"));
         }
-        if (!"image".equals(mediaType) && !"video".equals(mediaType)) {
-            throw new IllegalArgumentException(LangText.of("影像类型只能是 image 或 video", "Media type must be image or video"));
+        if (!"image".equals(mediaType) && !"video".equals(mediaType) && !"audio".equals(mediaType)) {
+            throw new IllegalArgumentException(LangText.of("影像类型只能是 image、video 或 audio",
+                    "Media type must be image, video or audio"));
         }
 
         Optional<MobileMediaInbox> existing = inboxRepository.findByUserIdAndClientMediaId(userId, clientMediaId);
         if (existing.isPresent()) {
-            // 幂等：弱网重传、进程被杀重启都不产生重复件（spec 不变式 2）
+            // 幂等：弱网重传、进程被杀重启都不产生重复件（spec 不变式 2）。
+            // 幂等命中必须先于配额检查——重传不占新空间，配额满也不能把重传拒成失败。
             return existing.get();
+        }
+
+        // 配额检查在写盘之前、按声明大小做（controller 传 MultipartFile.getSize()，就是实际
+        // 字节数）。只计未投递的 blob：桌面端收走（ACK）即释放，空间循环利用。
+        long usedBytes = inboxRepository.sumPendingBytes(userId);
+        if (usedBytes + Math.max(0, declaredSize) > QUOTA_BYTES) {
+            throw new IllegalArgumentException(LangText.of(
+                    "云端空间已满（3GB）：请在桌面端打开 AI WorkDeck 收取已上传的文件后重试",
+                    "Cloud relay storage is full (3GB). Open AI WorkDeck on your desktop to collect pending items, then retry."));
         }
 
         Path blob = relayRoot.resolve(String.valueOf(userId)).resolve(clientMediaId);
@@ -271,14 +293,26 @@ public class MobileRelayStoreService {
             m.put("delivered", item.getDeliveredAt() != null);
             m.put("waitingSeconds", item.getDeliveredAt() != null ? 0L
                     : Math.max(0L, Duration.between(item.getCreatedAt(), now).getSeconds()));
+            // 未投递件带 TTL 到期时刻，手机端据此做「快到期」提醒（dev-board#226）
+            if (item.getDeliveredAt() == null) {
+                m.put("expiresAt", item.getCreatedAt().plus(TTL).toString());
+            }
             out.add(m);
         }
         return out;
     }
 
+    /** 中转区用量（只计未投递 blob）与配额，手机端设置页展示用。 */
+    public Map<String, Object> usage(Long userId) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("usedBytes", inboxRepository.sumPendingBytes(userId));
+        m.put("quotaBytes", QUOTA_BYTES);
+        return m;
+    }
+
     // ==================== TTL 兜底 ====================
 
-    /** 每天一次：超过 7 天的行（含未投递的）删行 + 删残留 blob。ACK 才是主删除机制。 */
+    /** 每天一次：超过 30 天的行（含未投递的）删行 + 删残留 blob。ACK 才是主删除机制。 */
     @Scheduled(initialDelay = 15 * 60 * 1000, fixedDelay = 24 * 60 * 60 * 1000)
     @Transactional
     public void cleanupExpired() {

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingRecordingServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingRecordingServiceTest.java
@@ -31,13 +31,18 @@ class MeetingRecordingServiceTest {
              {"speaker":"2","start":63000,"end":65000,"text":"我们接受，但要求首期不低于五成"}]
             """;
 
+    private ProjectFileRepository projectFileRepository;
+    private ProjectFileService projectFileService;
+
     @BeforeEach
     void setUp() {
         meetingRepository = mock(MeetingRecordingRepository.class);
+        projectFileRepository = mock(ProjectFileRepository.class);
+        projectFileService = mock(ProjectFileService.class);
         when(meetingRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         service = new MeetingRecordingService(
-                meetingRepository, mock(ProjectFileRepository.class),
-                mock(ProjectFileService.class), mock(StorageServiceFactory.class));
+                meetingRepository, projectFileRepository,
+                projectFileService, mock(StorageServiceFactory.class));
     }
 
     /** LangText 是静态指针，登记过就必须清掉，否则污染后面的测试类。 */
@@ -175,5 +180,110 @@ class MeetingRecordingServiceTest {
         assertEquals("会议录音", MeetingRecordingService.folderName());
         switchToEnglish();
         assertEquals("Meeting Recordings", MeetingRecordingService.folderName());
+    }
+
+    // ==================== 右键转写：注册已有音频文件（dev-board#227） ====================
+
+    private com.checkba.model.entity.ProjectFile audioFile(Long id, Long projectId, String name) {
+        com.checkba.model.entity.ProjectFile f = new com.checkba.model.entity.ProjectFile();
+        f.setId(id);
+        f.setProjectId(projectId);
+        f.setName(name);
+        f.setIsFolder(false);
+        f.setIsDeleted(false);
+        return f;
+    }
+
+    @Test
+    @DisplayName("注册已有音频：直接进 RECORDED、不代管文件、标题去扩展名")
+    void registerExistingCreatesRecordedNonOwningMeeting() {
+        when(projectFileRepository.findById(77L))
+                .thenReturn(Optional.of(audioFile(77L, 1L, "现场谈话_a1b2c3d4.m4a")));
+        when(meetingRepository.findByProjectIdOrderByCreatedAtDesc(1L)).thenReturn(java.util.List.of());
+
+        MeetingRecording m = service.registerExisting(1L, 77L, 10001L);
+        assertEquals(MeetingRecording.STATUS_RECORDED, m.getStatus());
+        assertEquals(77L, m.getAudioFileId());
+        assertEquals(Boolean.FALSE, m.getOwnsAudioFile());
+        assertEquals("现场谈话_a1b2c3d4", m.getTitle());
+    }
+
+    @Test
+    @DisplayName("注册幂等：同一文件已注册过返回既有记录，不建重复行（防重复扣费）")
+    void registerExistingIsIdempotentPerFile() {
+        when(projectFileRepository.findById(77L))
+                .thenReturn(Optional.of(audioFile(77L, 1L, "rec.mp3")));
+        MeetingRecording existing = new MeetingRecording();
+        existing.setId(5L);
+        existing.setProjectId(1L);
+        existing.setAudioFileId(77L);
+        existing.setStatus(MeetingRecording.STATUS_TRANSCRIBED);
+        when(meetingRepository.findByProjectIdOrderByCreatedAtDesc(1L))
+                .thenReturn(java.util.List.of(existing));
+
+        MeetingRecording m = service.registerExisting(1L, 77L, 10001L);
+        assertEquals(5L, m.getId());
+        org.mockito.Mockito.verify(meetingRepository, org.mockito.Mockito.never()).save(any());
+    }
+
+    @Test
+    @DisplayName("注册围栏：非音频/文件夹/跨项目/已删除一律拒绝")
+    void registerExistingRejectsInvalidTargets() {
+        when(projectFileRepository.findById(1L))
+                .thenReturn(Optional.of(audioFile(1L, 1L, "合同.docx")));
+        assertThrows(IllegalArgumentException.class, () -> service.registerExisting(1L, 1L, 10001L));
+
+        com.checkba.model.entity.ProjectFile folder = audioFile(2L, 1L, "语音资料");
+        folder.setIsFolder(true);
+        when(projectFileRepository.findById(2L)).thenReturn(Optional.of(folder));
+        assertThrows(IllegalArgumentException.class, () -> service.registerExisting(1L, 2L, 10001L));
+
+        when(projectFileRepository.findById(3L))
+                .thenReturn(Optional.of(audioFile(3L, 99L, "rec.mp3")));
+        assertThrows(IllegalArgumentException.class, () -> service.registerExisting(1L, 3L, 10001L));
+
+        com.checkba.model.entity.ProjectFile deleted = audioFile(4L, 1L, "rec.mp3");
+        deleted.setIsDeleted(true);
+        when(projectFileRepository.findById(4L)).thenReturn(Optional.of(deleted));
+        assertThrows(IllegalArgumentException.class, () -> service.registerExisting(1L, 4L, 10001L));
+    }
+
+    @Test
+    @DisplayName("删除记录：代管的（面板占位/存量 null）连带删音频，注册的不动用户原始文件")
+    void deleteCascadesOnlyForOwnedAudio() {
+        MeetingRecording registered = transcribedMeeting();
+        registered.setAudioFileId(77L);
+        registered.setOwnsAudioFile(false);
+        when(meetingRepository.findById(9L)).thenReturn(Optional.of(registered));
+        service.delete(9L, 10001L);
+        org.mockito.Mockito.verify(projectFileService, org.mockito.Mockito.never())
+                .delete(any(), any());
+
+        MeetingRecording legacy = transcribedMeeting();
+        legacy.setId(10L);
+        legacy.setAudioFileId(88L);
+        legacy.setOwnsAudioFile(null); // 存量行
+        when(meetingRepository.findById(10L)).thenReturn(Optional.of(legacy));
+        service.delete(10L, 10001L);
+        org.mockito.Mockito.verify(projectFileService).delete(88L, 10001L);
+    }
+
+    @Test
+    @DisplayName("isAudioFileName：按扩展名判定，大小写不敏感")
+    void audioFileNameDetection() {
+        assertTrue(MeetingRecordingService.isAudioFileName("rec.m4a"));
+        assertTrue(MeetingRecordingService.isAudioFileName("REC.MP3"));
+        assertFalse(MeetingRecordingService.isAudioFileName("合同.docx"));
+        assertFalse(MeetingRecordingService.isAudioFileName("noext"));
+        assertFalse(MeetingRecordingService.isAudioFileName(null));
+    }
+
+    @Test
+    @DisplayName("audioFormat：按真实扩展名上报，不再硬编码「非 mp3 即 webm」")
+    void audioFormatFollowsRealExtension() {
+        assertEquals("mp3", MeetingTranscriptionService.audioFormat(new java.io.File("x.mp3")));
+        assertEquals("m4a", MeetingTranscriptionService.audioFormat(new java.io.File("现场谈话.M4A")));
+        assertEquals("wav", MeetingTranscriptionService.audioFormat(new java.io.File("a.b.wav")));
+        assertEquals("webm", MeetingTranscriptionService.audioFormat(new java.io.File("noext")));
     }
 }

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
@@ -252,6 +252,24 @@ class MobileRelayClientHttpTest {
     }
 
     @Test
+    @DisplayName("音频取件（mediaType=audio）：落「现场录音/日期」而不是「现场影像」，storagePath 同构")
+    void pollInboxLandsAudioIntoAudioFolder() {
+        inboxJson = "[{\"id\":11,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"现场谈话.m4a\",\"mediaType\":\"audio\",\"fileSize\":10,"
+                + "\"capturedAt\":\"2026-08-19T21:00:00\",\"createdAt\":\"2026-08-20T09:00:00\"}]";
+        service().pollInbox();
+
+        assertTrue(tree.stream().anyMatch(f -> Boolean.TRUE.equals(f.getIsFolder()) && "现场录音".equals(f.getName())));
+        assertFalse(tree.stream().anyMatch(f -> "现场影像".equals(f.getName())), "音频不该建影像根目录");
+        assertTrue(tree.stream().anyMatch(f -> !Boolean.TRUE.equals(f.getIsFolder())
+                && "现场谈话-0a1b2c3d.m4a".equals(f.getName())));
+        assertEquals(1, savedStorageKeys.size());
+        assertTrue(savedStorageKeys.get(0).startsWith("projects/42/现场录音/2026-08-19/"),
+                "storagePath 必须与 ensureFolder 的目录同构，实际: " + savedStorageKeys.get(0));
+        assertEquals(List.of("/api/mobile/inbox/11/ack"), acked);
+    }
+
+    @Test
     @DisplayName("幂等：同名已落盘（上轮 ACK 丢失）不重复建文件，直接补 ACK")
     void pollInboxSkipsAlreadyLanded() {
         ProjectFile root = addNode(null, "现场影像", true);

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceConcurrentStoreTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceConcurrentStoreTest.java
@@ -64,7 +64,7 @@ class MobileRelayStoreServiceConcurrentStoreTest {
                 .thenThrow(new DataIntegrityViolationException("duplicate key: user_id, client_media_id"));
 
         MobileMediaInbox result = service.storeMedia(1L, "dev-a", "42", MEDIA_ID,
-                "IMG_0001.jpg", "image", null,
+                "IMG_0001.jpg", "image", null, 5,
                 new ByteArrayInputStream("bytes".getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(existing.getId(), result.getId(), "撞约束之后必须回落到既有记录，而不是把异常甩给调用方");

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceTest.java
@@ -28,8 +28,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * - 影像入库幂等键 (userId, clientMediaId)，重复上传返回既有记录、不重写 blob；
  * - clientMediaId 只收 UUID 形态（路径穿越围栏）；
  * - ACK：置 deliveredAt + 立即删 blob，行保留供 status 查询；
- * - status：delivered 与等待秒数；
- * - 7 天 TTL 清理：删行 + 删残留 blob（ACK 是主机制，TTL 只是兜底）。
+ * - status：delivered 与等待秒数，未投递件带 expiresAt；
+ * - 30 天 TTL 清理：删行 + 删残留 blob（ACK 是主机制，TTL 只是兜底）；
+ * - 3GB 每用户配额：只计未投递 blob，ACK 即释放（dev-board#226）。
  *
  * 内存 H2（MODE=PostgreSQL）约定同 WorkSessionRepositoryTest。
  */
@@ -67,9 +68,10 @@ class MobileRelayStoreServiceTest {
     }
 
     private MobileMediaInbox store(String clientMediaId, String content) {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         return service.storeMedia(1L, "dev-a", "42", clientMediaId,
-                "IMG_0001.jpg", "image", null,
-                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+                "IMG_0001.jpg", "image", null, bytes.length,
+                new ByteArrayInputStream(bytes));
     }
 
     @Test
@@ -193,16 +195,100 @@ class MobileRelayStoreServiceTest {
     }
 
     @Test
-    @DisplayName("7 天 TTL 兜底：过期行删除，未投递的残留 blob 一并删")
+    @DisplayName("30 天 TTL 兜底：过期行删除，未投递的残留 blob 一并删；未过期的不动")
     void ttlCleanupRemovesRowsAndOrphanBlobs() {
         MobileMediaInbox item = store(MEDIA_ID, "payload");
+        // 8 天前：7 天 TTL 时代会被清掉，30 天口径下必须还在（dev-board#226 延长的意义所在）
         item.setCreatedAt(LocalDateTime.now().minusDays(8));
         inboxRepository.save(item);
         Path blob = Path.of(item.getStoragePath());
         assertTrue(Files.exists(blob));
 
         service.cleanupExpired();
+        assertTrue(Files.exists(blob), "8 天的件在 30 天 TTL 下不该被清");
+        assertEquals(1, inboxRepository.count());
+
+        item.setCreatedAt(LocalDateTime.now().minusDays(31));
+        inboxRepository.save(item);
+        service.cleanupExpired();
         assertFalse(Files.exists(blob));
         assertEquals(0, inboxRepository.count());
+    }
+
+    @Test
+    @DisplayName("mediaType 收 audio（手机录音走同一条中转链路），其余类型拒绝")
+    void audioMediaTypeIsAccepted() {
+        MobileMediaInbox item = service.storeMedia(1L, "dev-a", "42", MEDIA_ID,
+                "REC_0001.m4a", "audio", null, 7,
+                new ByteArrayInputStream("audio-x".getBytes(StandardCharsets.UTF_8)));
+        assertEquals("audio", item.getMediaType());
+        assertThrows(IllegalArgumentException.class, () -> service.storeMedia(
+                1L, "dev-a", "42", "0a1b2c3d-1111-4222-8333-444455557777",
+                "x.bin", "binary", null, 1,
+                new ByteArrayInputStream(new byte[]{1})));
+    }
+
+    @Test
+    @DisplayName("status：未投递件带 expiresAt（createdAt+TTL），已投递件不带")
+    void statusCarriesExpiresAtForUndelivered() {
+        MobileMediaInbox item = store(MEDIA_ID, "payload");
+        Map<String, Object> pending = service.status(1L, List.of(MEDIA_ID)).get(0);
+        assertEquals(item.getCreatedAt().plus(MobileRelayStoreService.TTL).toString(),
+                pending.get("expiresAt"));
+
+        service.ack(1L, item.getId());
+        Map<String, Object> delivered = service.status(1L, List.of(MEDIA_ID)).get(0);
+        assertFalse(delivered.containsKey("expiresAt"), "已投递件没有到期概念");
+    }
+
+    @Test
+    @DisplayName("配额：未投递 blob 占满 3GB 后拒绝新上传，ACK 释放后恢复；重传不受配额影响")
+    void quotaBlocksNewUploadsAndAckFrees() throws Exception {
+        // 直接造一行占满配额的未投递件（不真写 3GB 字节）
+        Path bigBlob = blobRoot.resolve("1").resolve("big-blob");
+        Files.createDirectories(bigBlob.getParent());
+        Files.writeString(bigBlob, "placeholder");
+        MobileMediaInbox big = new MobileMediaInbox();
+        big.setUserId(1L);
+        big.setDeviceId("dev-a");
+        big.setProjectKey("42");
+        big.setClientMediaId("ffffffff-0000-4000-8000-00000000aaaa");
+        big.setFileName("huge.mov");
+        big.setMediaType("video");
+        big.setFileSize(MobileRelayStoreService.QUOTA_BYTES);
+        big.setStoragePath(bigBlob.toString());
+        big.setCreatedAt(LocalDateTime.now());
+        inboxRepository.saveAndFlush(big);
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> store(MEDIA_ID, "one-more-byte"));
+        assertTrue(e.getMessage().contains("云端空间已满"), "配额拒绝要给用户可读的原因，实际: " + e.getMessage());
+
+        // 同 clientMediaId 的重传是幂等命中，配额满也不能拒（不占新空间）
+        MobileMediaInbox again = service.storeMedia(1L, "dev-a", "42", big.getClientMediaId(),
+                "huge.mov", "video", null, 3, new ByteArrayInputStream("xxx".getBytes(StandardCharsets.UTF_8)));
+        assertEquals(big.getId(), again.getId());
+
+        // 别的用户不受影响
+        MobileMediaInbox other = service.storeMedia(2L, "dev-z", "1", MEDIA_ID,
+                "IMG.jpg", "image", null, 3, new ByteArrayInputStream("abc".getBytes(StandardCharsets.UTF_8)));
+        assertNotNull(other.getId());
+
+        // ACK 即删 blob = 释放配额，循环利用
+        service.ack(1L, big.getId());
+        MobileMediaInbox landed = store(MEDIA_ID, "fits-now");
+        assertNotNull(landed.getId());
+    }
+
+    @Test
+    @DisplayName("usage：只计未投递 blob 的字节数，带配额上限")
+    void usageCountsOnlyPendingBlobs() {
+        MobileMediaInbox item = store(MEDIA_ID, "12345");
+        Map<String, Object> usage = service.usage(1L);
+        assertEquals(5L, usage.get("usedBytes"));
+        assertEquals(MobileRelayStoreService.QUOTA_BYTES, usage.get("quotaBytes"));
+
+        service.ack(1L, item.getId());
+        assertEquals(0L, service.usage(1L).get("usedBytes"), "ACK 之后配额应释放");
     }
 }

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -304,6 +304,16 @@
           </view>
           <text class="context-menu-text">{{ $t('fileTree.download') }}</text>
         </view>
+        <view v-if="contextMenu.targetItem && transcribeEnabled && isAudioFile(contextMenu.targetItem)" class="context-menu-item" @tap="$emit('transcribe-audio', contextMenu.targetItem); closeContextMenu()">
+          <view class="context-menu-icon" style="display: flex; align-items: center; justify-content: center;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" stroke-linecap="round" stroke-linejoin="round"/>
+              <line x1="12" y1="19" x2="12" y2="23" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </view>
+          <text class="context-menu-text">{{ $t('fileTree.transcribe') }}</text>
+        </view>
         <view v-if="contextMenu.targetItem" class="context-menu-item" @tap="handleRename(contextMenu.targetItem); closeContextMenu()">
           <view class="context-menu-icon" style="display: flex; align-items: center; justify-content: center;">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -964,6 +974,11 @@ export default {
     hiddenFileIds: {
       type: Array,
       default: () => []
+    },
+    // 右键「转写」项的可见性：随会议录音 skill 的启用状态（父组件传 meetingRecorderEnabled）
+    transcribeEnabled: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -2322,6 +2337,16 @@ export default {
         this.allFiles.find(f => f.id === id)
       ).filter(Boolean)
       return selectedFiles.every(f => !f.isFolder && docTypes.includes((f.fileType || '').toLowerCase()))
+    },
+
+    /**
+     * 右键「转写」项的判定：扩展名在音频集合内（与后端 MeetingRecordingService
+     * 的 AUDIO_EXTENSIONS 白名单保持一致）
+     */
+    isAudioFile(item) {
+      if (!item || item.isFolder) return false
+      const audioTypes = ['mp3', 'm4a', 'aac', 'wav', 'flac', 'ogg', 'opus', 'amr', 'wma', 'webm']
+      return audioTypes.includes((item.fileType || '').toLowerCase())
     },
 
     /**

--- a/frontend/src/components/FileTypeIcon.vue
+++ b/frontend/src/components/FileTypeIcon.vue
@@ -125,6 +125,13 @@ export default {
                }
            case 'mp3':
            case 'wav':
+           case 'm4a':
+           case 'aac':
+           case 'flac':
+           case 'ogg':
+           case 'opus':
+           case 'amr':
+           case 'wma':
            case 'audio':
                return {
                   viewBox: vb1024,

--- a/frontend/src/components/MeetingRecordingPanel.vue
+++ b/frontend/src/components/MeetingRecordingPanel.vue
@@ -336,9 +336,20 @@ export default {
     currentUser: {
       type: Object,
       default: null
+    },
+    // 资源管理器右键转写后要定位/展开的会议 id（dev-board#227）。
+    // 面板可能因转写而被切出来（v-if 重新挂载），所以 mounted 与 watch 两头都处理。
+    focusMeetingId: {
+      type: [String, Number],
+      default: null
     }
   },
   emits: ['generate-minutes'],
+  watch: {
+    focusMeetingId() {
+      this.applyFocus()
+    }
+  },
   data() {
     return {
       meetings: [],
@@ -474,7 +485,7 @@ export default {
     }
   },
   mounted() {
-    this.loadMeetings()
+    this.loadMeetings().then(() => this.applyFocus())
     this.loadAsrTier()
     this.loadAsrNotice()
     this.loadAudioDevices()
@@ -708,6 +719,17 @@ export default {
       const meeting = await stopRecording()
       await this.loadMeetings()
       if (meeting && meeting.id) this.expandedId = meeting.id
+    },
+
+    // 右键转写入口的定位：把 focusMeetingId 指到的会议展开并立刻刷新一次进度（dev-board#227）
+    async applyFocus() {
+      if (this.focusMeetingId == null) return
+      await this.loadMeetings()
+      const id = Number(this.focusMeetingId)
+      if (this.meetings.some(m => Number(m.id) === id)) {
+        this.expandedId = id
+        this.refreshOne(id)
+      }
     },
 
     // ==================== 详情 ====================

--- a/frontend/src/locales/en-US/fileTree.js
+++ b/frontend/src/locales/en-US/fileTree.js
@@ -39,6 +39,10 @@ export default {
   // Context menu
   compareDocuments: 'Compare Documents',
   download: 'Download',
+  transcribe: 'Transcribe',
+  transcribeSubmitted: 'Transcription submitted. Check progress in the meeting recordings panel.',
+  transcribeRegistered: 'Added to the meeting recordings panel. Configure a transcription service to start.',
+  transcribeFailed: 'Failed to start transcription',
   rename: 'Rename',
   fileHistory: 'File History',
   revealInFinder: 'Reveal in Finder',

--- a/frontend/src/locales/zh-CN/fileTree.js
+++ b/frontend/src/locales/zh-CN/fileTree.js
@@ -39,6 +39,10 @@ export default {
   // 右键菜单
   compareDocuments: '比较文档',
   download: '下载',
+  transcribe: '转写',
+  transcribeSubmitted: '已提交转写，请在会议录音面板查看进度',
+  transcribeRegistered: '已加入会议录音面板，配置转写服务后可开始转写',
+  transcribeFailed: '转写发起失败',
   rename: '重命名',
   fileHistory: '这份文件的历史',
   revealInFinder: '在访达中显示',

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -598,6 +598,8 @@
             @file-deleted="handleFileDeleted"
             @file-history="onFileHistory"
             @reveal-file="onRevealFile"
+            :transcribe-enabled="meetingRecorderEnabled"
+            @transcribe-audio="onTranscribeAudio"
           />
           <DdFilesPanel
             v-else-if="leftPaneKey === 'dd-files'"
@@ -657,6 +659,7 @@
                 v-if="effectiveVoiceTab === 'recorder'"
                 :project-id="projectId"
                 :current-user="currentUser"
+                :focus-meeting-id="meetingFocusId"
                 @generate-minutes="handleMeetingMinutesStart"
               />
               <EasyVoicePane
@@ -1432,6 +1435,7 @@
                   v-if="effectiveVoiceTab === 'recorder'"
                   :project-id="projectId"
                   :current-user="currentUser"
+                  :focus-meeting-id="meetingFocusId"
                   @generate-minutes="handleMeetingMinutesStart"
                 />
                 <EasyVoicePane
@@ -1977,7 +1981,8 @@ import {
   getAccountBalance, // Credits 余额 chip（dev-board#187，后端带 TTL 缓存的轻端点）
   getCloudStatus, // 协作 chip：这份案卷有没有放进团队案件库、状态如何
   checkCloud, // 协作 chip 的联网刷新（cloudStatus 是不联网的本地快照）
-  getCurrentUser as getCurrentUserApi // 顶栏头像：补一次真实接口，本地缓存只是首屏兜底
+  getCurrentUser as getCurrentUserApi, // 顶栏头像：补一次真实接口，本地缓存只是首屏兜底
+  registerMeetingFromFile // 右键转写：音频文件注册进会议录音面板（dev-board#227）
 } from '@/services/api.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
 import { signOut } from '@/utils/signOut.js'
@@ -2133,6 +2138,8 @@ export default {
       avatarMenuOpen: false,
       // 单文件历史：右键「这份文件的历史」时设置，version 面板据此只显示这份文件的版本
       versionFileFilter: null,
+      // 右键转写后要在会议录音面板里定位/展开的会议 id（dev-board#227）
+      meetingFocusId: null,
       // 有一次采纳停在待裁决状态（/status 的 adoptConflict）。版本面板之外也要提示，
       // 见模板里的 .adopt-pending-bar。版本面板打开时由它的 /status 拉取实时同步。
       adoptConflictPending: false,
@@ -3599,6 +3606,25 @@ export default {
     onFileHistory(file) {
       this.versionFileFilter = { fileId: file.id, name: file.name }
       if (this.leftPaneKey !== 'version') this.toggleLeftPane('version')
+    },
+    // 右键「转写」：注册成会议记录（凭证已配则后端顺手提交转写），跳会议录音面板定位到它
+    // （dev-board#227）。菜单项本身已按 meetingRecorderEnabled 门控，这里不再重复判。
+    async onTranscribeAudio(file) {
+      try {
+        const res = await registerMeetingFromFile(this.projectId, file.id)
+        this.meetingFocusId = res && res.meeting ? res.meeting.id : null
+        this.voiceTab = 'recorder'
+        if (this.leftPaneKey !== 'voice') this.toggleLeftPane('voice')
+        uni.showToast({
+          title: res && res.submitted
+            ? this.$t('fileTree.transcribeSubmitted')
+            : this.$t('fileTree.transcribeRegistered'),
+          icon: 'none'
+        })
+      } catch (error) {
+        console.error('转写发起失败:', error)
+        uni.showToast({ title: (error && error.message) || this.$t('fileTree.transcribeFailed'), icon: 'none' })
+      }
     },
     // IDE 化窗口标题
     updateWindowTitle() {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2462,6 +2462,17 @@ export function transcribeMeetingRecording(meetingId) {
   })
 }
 
+// 资源管理器右键转写：把项目里已有的音频文件注册成会议记录并（凭证已配时）自动提交转写。
+// 返回 { meeting, configured, submitted }（dev-board#227）
+export function registerMeetingFromFile(projectId, fileId) {
+  return request({
+    url: `/api/meetings/projects/${projectId}/register-file`,
+    method: 'POST',
+    data: { fileId },
+    header: { 'Content-Type': 'application/json' }
+  })
+}
+
 export function updateMeetingRecording(meetingId, payload) {
   return request({
     url: `/api/meetings/${meetingId}`,


### PR DESCRIPTION
落实 dev-board#226 / #227 / #228（主仓部分）。

## dev-board#226 云端空间
- 每用户 **3GB 配额**：只计未投递 blob（ACK 即删 = 释放，循环利用）；写盘前按声明大小检查；幂等重传先于配额检查（重传不占新空间，满额不得拒）；拒绝文案走 `HTTP 200 + {code:1,message}`，两端手机客户端可直接透传到队列界面
- TTL **7 天 → 30 天**（桌面一周不开机不再丢件），`/media/status` 未投递件带 `expiresAt` 供手机端做到期提醒
- 新增 `GET /api/mobile/media/usage` → `{usedBytes, quotaBytes}`

## dev-board#228（桌面半边）
- 中转区 `mediaType` 放行 `audio`；桌面取件按类型分流：音频落「现场录音/YYYY-MM-DD/」，影像照旧「现场影像/」

## dev-board#227 右键转写
- `POST /api/meetings/projects/{pid}/register-file`：把项目里已有音频文件注册成会议记录，复用三档转写链路（byok/platform/local，说话人分离与 AI 纪要同享、同一套计费）；凭证已配自动提交
- 幂等：同文件重复注册返回既有记录（防重复扣费）；`ownsAudioFile=false`：删除会议记录**不**连带删用户原始文件（存量 null 视同代管，行为不变）
- 修雷：转码失败回退硬编码「非 mp3 即 webm」→ 按真实扩展名上报（m4a 不再被当 webm 喂给听悟）
- 前端：FileTree 右键「转写」（按 meetingRecorderEnabled 门控、音频扩展名判定）→ 注册后跳语音面板并定位展开该条；FileTypeIcon 补 m4a/aac/flac/ogg/opus/amr/wma 音频图标

## 验证
- `mvn test`：MobileRelay* 26 例 + Meeting* 79 例全绿（含新增配额/audio 落盘/注册幂等/删除代管/audioFormat 用例）
- 前端 `check:locales` / `check:emits` / `check:nav` 全绿
- 领域文档 `.claude/agents/mobile-sync.md` 同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)