### PR TITLE
chore(release): v0.27.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.26.3",
+  "version": "0.27.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
大版本（全量安装包）。收编补丁通道装不下的壳层改动与 v0.26.2 之后全部增量：
- #622 rail 整理拖拽误报修复 + 顶栏整理按钮 + 删「已连接账户」chip（已随 0.26.3 补丁先行）
- #623 窗口失焦交通灯消失——原生外观锁定浅色（壳层，只能随大版本）
- #625 颜色令牌化 + 浅色/深色双主题 + 账户入口合并（dev-board#223/#225）
- #626 手机端云中转 3G 配额 + TTL 30 天 + audio 类型；资源管理器右键转写（dev-board#226-228）

## 发版门禁（0.27.0 内容全量重跑）
- backend mvn clean package：**2819 / 0**
- desktop npm test：**0 失败**（含 #623 新增 native-theme-light）
- lowa-e2e（本树重建 glue + r4 引擎）：**461 / 0**
- app-e2e（全新隔离环境）：**131 步全绿 exit 0**（J6.7/J12 文档化条件跳过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)