### PR TITLE
feat(mobile-sync): 手机影像云中转 blob 迁 OSS（dev-board#236）

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -16,8 +16,16 @@ dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
 
 - `service/mobile/MobileRelayStoreService.java` — 云端（server 侧）：目录按 (userId,
   deviceId) 整批替换、影像入库（幂等键 userId+clientMediaId）、ACK（置 deliveredAt +
-  **立即删 blob**、行保留供 status）、每日 TTL 清理。blob 落
-  `{storage.local.root-path}/mobile-relay/{userId}/{clientMediaId}`。
+  **立即删 blob**、行保留供 status）、每日 TTL 清理。blob 存取经
+  `MobileRelayBlobStore` 接缝（dev-board#236）：本地实现落
+  `{storage.local.root-path}/mobile-relay/{userId}/{clientMediaId}`（desktop/测试默认）；
+  云后端配齐 `MOBILE_RELAY_OSS_*` 环境变量则走 OSS 私有桶（北京 `awd-mobile-relay`/
+  国际站 `awd-mobile-relay-intl`，key = `mobile-relay/{userId}/{clientMediaId}`，
+  桶生命周期 35 天兜底）。storagePath 存定位符（本地=绝对路径，OSS=object key），
+  其「非空=占配额」的第二重身份不变；存量本地行按 `/` 前缀双读兼容。
+  下载契约红线：`GET /inbox/{id}/content` 必须 2xx + `application/octet-stream` +
+  裸字节，**不许 302 到签名 URL**——桌面端 `MobileRelayClientService` 不跟随重定向
+  且硬校验 Content-Type。
 - `controller/MobileRelayController.java` — `/api/mobile/*` 全组端点。鉴权一律
   `X-Session-Id`：手机端带登录会话，桌面端带 awdt_ 设备令牌（`AuthController.
   getUserIdFromSession` 两种都解析）。响应风格同 `/api/projects/my`（裸数组）。

--- a/backend/src/main/java/com/checkba/controller/MobileRelayController.java
+++ b/backend/src/main/java/com/checkba/controller/MobileRelayController.java
@@ -6,7 +6,7 @@ import com.checkba.service.LangText;
 import com.checkba.service.mobile.MobileRelayStoreService;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -153,16 +153,20 @@ public class MobileRelayController {
         return out;
     }
 
-    /** 桌面端：取件字节流。 */
+    /**
+     * 桌面端：取件字节流。契约红线（MobileRelayClientService 硬校验）：成功必须是
+     * 2xx + Content-Type application/octet-stream + 裸字节，不许 302 到签名 URL。
+     */
     @GetMapping("/inbox/{id}/content")
-    public ResponseEntity<FileSystemResource> content(
+    public ResponseEntity<InputStreamResource> content(
             @PathVariable("id") Long id,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         Long userId = requireUser(sessionId);
-        FileSystemResource resource = new FileSystemResource(store.contentPath(userId, id));
+        MobileRelayStoreService.ContentBlob blob = store.openContent(userId, id);
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
-                .body(resource);
+                .contentLength(blob.length())
+                .body(new InputStreamResource(blob.stream()));
     }
 
     /** 桌面端：确认落盘。置 deliveredAt 并立即删除 blob。 */

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayBlobStore.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayBlobStore.java
@@ -1,0 +1,33 @@
+package com.checkba.service.mobile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * 中转区 blob 的存取接缝（模式照抄 {@code MeetingOssClient}：接口的存在理由是测试用桩）。
+ *
+ * <p>locator 是 {@code MobileMediaInbox.storagePath} 里存的定位符：本地实现 = 绝对路径，
+ * OSS 实现 = object key。它的第二重身份（非空 = 占配额）由 {@link MobileRelayStoreService}
+ * 维护，本接口不感知。
+ */
+public interface MobileRelayBlobStore {
+
+    /** put 的结果：写进 storagePath 的定位符 + 实际写入字节数（配额账本的口径）。 */
+    record StoredBlob(String locator, long size) {}
+
+    /**
+     * 写入一件 blob。失败抛未检查异常，由调用方翻译成用户可见的「影像暂存失败」。
+     *
+     * @param declaredSize controller 传 MultipartFile.getSize()，即实际字节数；
+     *                     OSS 实现用它做 Content-Length 避免全量缓冲
+     */
+    StoredBlob put(Long userId, String clientMediaId, InputStream content, long declaredSize);
+
+    /** 打开内容流。调用方负责关闭。 */
+    InputStream open(String locator) throws IOException;
+
+    boolean exists(String locator);
+
+    /** 删除失败只 warn 绝不抛——blob 删不掉不该挡住 ACK/TTL 的行级操作。 */
+    void deleteQuietly(String locator);
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayLocalBlobStore.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayLocalBlobStore.java
@@ -1,0 +1,56 @@
+package com.checkba.service.mobile;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * 本地盘实现：行为与抽象前的 MobileRelayStoreService 逐字一致
+ * （blob 落 {root}/mobile-relay/{userId}/{clientMediaId}，locator = 绝对路径）。
+ * desktop/prod profile 与全部测试默认走它。
+ */
+@Slf4j
+public final class MobileRelayLocalBlobStore implements MobileRelayBlobStore {
+
+    private final Path relayRoot;
+
+    public MobileRelayLocalBlobStore(String storageRoot) {
+        this.relayRoot = Path.of(storageRoot, "mobile-relay").toAbsolutePath().normalize();
+    }
+
+    @Override
+    public StoredBlob put(Long userId, String clientMediaId, InputStream content, long declaredSize) {
+        Path blob = relayRoot.resolve(String.valueOf(userId)).resolve(clientMediaId);
+        try {
+            Files.createDirectories(blob.getParent());
+            long size = Files.copy(content, blob, StandardCopyOption.REPLACE_EXISTING);
+            return new StoredBlob(blob.toString(), size);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public InputStream open(String locator) throws IOException {
+        return Files.newInputStream(Path.of(locator));
+    }
+
+    @Override
+    public boolean exists(String locator) {
+        return Files.exists(Path.of(locator));
+    }
+
+    @Override
+    public void deleteQuietly(String locator) {
+        try {
+            Files.deleteIfExists(Path.of(locator));
+        } catch (IOException e) {
+            log.warn("删除中转 blob 失败，留给 TTL/生命周期兜底: {}", locator, e);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayOssBlobStore.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayOssBlobStore.java
@@ -1,0 +1,112 @@
+package com.checkba.service.mobile;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.model.ObjectMetadata;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * OSS 实现（dev-board#236）：中转 blob 落平台自己的私有桶，locator = object key
+ * （{keyPrefix}{userId}/{clientMediaId}）。
+ *
+ * <p>与 {@code MeetingOssClientImpl} 的刻意分歧：那边按调用建客户端（低频转写），
+ * 这边上传/下载/删除是持续流量，客户端做成单例、由配置类负责 shutdown。
+ *
+ * <p>迁移期双读：存量行的 storagePath 是老的本地绝对路径（以 {@code /} 开头），
+ * 读/删原样走文件系统；这些行最迟 30 天被 ACK 或 TTL 消化掉，之后这个分支就是死代码，
+ * 但删它不值得冒险。
+ */
+@Slf4j
+public final class MobileRelayOssBlobStore implements MobileRelayBlobStore, AutoCloseable {
+
+    private final OSS oss;
+    private final String bucket;
+    private final String keyPrefix;
+
+    public MobileRelayOssBlobStore(OSS oss, String bucket, String keyPrefix) {
+        this.oss = oss;
+        this.bucket = bucket;
+        this.keyPrefix = keyPrefix;
+    }
+
+    @Override
+    public StoredBlob put(Long userId, String clientMediaId, InputStream content, long declaredSize) {
+        String key = keyPrefix + userId + "/" + clientMediaId;
+        CountingInputStream counted = new CountingInputStream(content);
+        ObjectMetadata meta = new ObjectMetadata();
+        if (declaredSize > 0) {
+            // 有 Content-Length SDK 才流式直传；不设会全量缓冲进堆（nginx 单请求 200MB，缓冲不起）
+            meta.setContentLength(declaredSize);
+        }
+        oss.putObject(bucket, key, counted, meta);
+        return new StoredBlob(key, counted.count);
+    }
+
+    @Override
+    public InputStream open(String locator) throws IOException {
+        if (isLegacyLocalPath(locator)) {
+            return Files.newInputStream(Path.of(locator));
+        }
+        return oss.getObject(bucket, locator).getObjectContent();
+    }
+
+    @Override
+    public boolean exists(String locator) {
+        if (isLegacyLocalPath(locator)) {
+            return Files.exists(Path.of(locator));
+        }
+        return oss.doesObjectExist(bucket, locator);
+    }
+
+    @Override
+    public void deleteQuietly(String locator) {
+        try {
+            if (isLegacyLocalPath(locator)) {
+                Files.deleteIfExists(Path.of(locator));
+            } else {
+                oss.deleteObject(bucket, locator);
+            }
+        } catch (Exception e) {
+            // OSSException/ClientException 是 RuntimeException：catch-all 才保得住
+            // 「删不掉不挡 ACK」的语义（形状照抄 MeetingOssClientImpl.deleteQuietly）
+            log.warn("删除中转 blob 失败，留给桶生命周期兜底: {}", locator, e);
+        }
+    }
+
+    private static boolean isLegacyLocalPath(String locator) {
+        return locator.startsWith("/");
+    }
+
+    @Override
+    public void close() {
+        oss.shutdown();
+    }
+
+    /** put 需要真实写入字节数做配额账本，SDK 不回传，只能自己数。 */
+    private static final class CountingInputStream extends FilterInputStream {
+        long count;
+
+        CountingInputStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = super.read();
+            if (b >= 0) count++;
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int n = super.read(b, off, len);
+            if (n > 0) count += n;
+            return n;
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayStorageConfig.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayStorageConfig.java
@@ -1,0 +1,44 @@
+package com.checkba.service.mobile;
+
+import com.aliyun.oss.OSSClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 中转 blob 存储的装配（dev-board#236）。本仓不用 @ConditionalOnProperty，
+ * 按配置在工厂方法里二选一。
+ *
+ * <p>开关与凭证全走环境变量（MOBILE_RELAY_OSS_*，注入点 /opt/aiworkdeck/cloud/env）：
+ * 云后端配齐即走 OSS；desktop/团队服务器不配，维持本地盘，行为与迁移前逐字一致。
+ * enabled=true 但配置不全是部署事故，宁可启动即炸也不静默回落本地盘——
+ * 回落意味着「以为在 OSS 上其实还在 ECS」，正是这次迁移要消灭的状态。
+ */
+@Configuration
+@Slf4j
+public class MobileRelayStorageConfig {
+
+    @Bean
+    public MobileRelayBlobStore mobileRelayBlobStore(
+            @Value("${mobile.relay.oss.enabled:false}") boolean ossEnabled,
+            @Value("${mobile.relay.oss.endpoint:}") String endpoint,
+            @Value("${mobile.relay.oss.bucket:}") String bucket,
+            @Value("${mobile.relay.oss.access-key-id:}") String accessKeyId,
+            @Value("${mobile.relay.oss.access-key-secret:}") String accessKeySecret,
+            @Value("${mobile.relay.oss.key-prefix:mobile-relay/}") String keyPrefix,
+            @Value("${storage.local.root-path:data}") String storageRoot) {
+        if (!ossEnabled) {
+            return new MobileRelayLocalBlobStore(storageRoot);
+        }
+        if (endpoint.isBlank() || bucket.isBlank() || accessKeyId.isBlank() || accessKeySecret.isBlank()) {
+            throw new IllegalStateException(
+                    "mobile.relay.oss.enabled=true 但 endpoint/bucket/AK 不完整——"
+                    + "检查 MOBILE_RELAY_OSS_ENDPOINT / MOBILE_RELAY_OSS_BUCKET / "
+                    + "MOBILE_RELAY_OSS_AK_ID / MOBILE_RELAY_OSS_AK_SECRET");
+        }
+        log.info("影像中转 blob 走 OSS: bucket={}, endpoint={}", bucket, endpoint);
+        return new MobileRelayOssBlobStore(
+                new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret), bucket, keyPrefix);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayStoreService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayStoreService.java
@@ -7,7 +7,6 @@ import com.checkba.repository.MobileProjectDirRepository;
 import com.checkba.service.LangText;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,9 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -66,7 +62,7 @@ public class MobileRelayStoreService {
 
     private final MobileProjectDirRepository dirRepository;
     private final MobileMediaInboxRepository inboxRepository;
-    private final Path relayRoot;
+    private final MobileRelayBlobStore blobStore;
 
     /**
      * 本 bean 的懒加载自身代理，只为让 storeMedia 撞约束后的重试真正经过 Spring 的事务代理
@@ -81,10 +77,10 @@ public class MobileRelayStoreService {
     @Autowired
     public MobileRelayStoreService(MobileProjectDirRepository dirRepository,
                                    MobileMediaInboxRepository inboxRepository,
-                                   @Value("${storage.local.root-path:data}") String storageRoot) {
+                                   MobileRelayBlobStore blobStore) {
         this.dirRepository = dirRepository;
         this.inboxRepository = inboxRepository;
-        this.relayRoot = Path.of(storageRoot, "mobile-relay").toAbsolutePath().normalize();
+        this.blobStore = blobStore;
     }
 
     public record DirEntry(String key, String name) {}
@@ -224,12 +220,10 @@ public class MobileRelayStoreService {
                     "Cloud relay storage is full (3GB). Open AI WorkDeck on your desktop to collect pending items, then retry."));
         }
 
-        Path blob = relayRoot.resolve(String.valueOf(userId)).resolve(clientMediaId);
-        long size;
+        MobileRelayBlobStore.StoredBlob stored;
         try {
-            Files.createDirectories(blob.getParent());
-            size = Files.copy(content, blob, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
+            stored = blobStore.put(userId, clientMediaId, content, declaredSize);
+        } catch (Exception e) {
             throw new IllegalStateException(LangText.of("影像暂存失败", "Failed to store media"), e);
         }
 
@@ -240,8 +234,8 @@ public class MobileRelayStoreService {
         row.setClientMediaId(clientMediaId);
         row.setFileName(sanitizeFileName(fileName));
         row.setMediaType(mediaType);
-        row.setFileSize(size);
-        row.setStoragePath(blob.toString());
+        row.setFileSize(stored.size());
+        row.setStoragePath(stored.locator());
         row.setCapturedAt(capturedAt);
         row.setCreatedAt(LocalDateTime.now());
         return inboxRepository.save(row);
@@ -252,29 +246,31 @@ public class MobileRelayStoreService {
         return inboxRepository.findByUserIdAndDeviceIdAndDeliveredAtIsNullOrderByCreatedAtAsc(userId, deviceId);
     }
 
+    /** openContent 的返回：内容流（调用方/Spring 负责关闭）+ 字节数（Content-Length 用）。 */
+    public record ContentBlob(InputStream stream, long length) {}
+
     /** 取件内容：只有属主且尚未投递的能读。 */
-    public Path contentPath(Long userId, Long itemId) {
+    public ContentBlob openContent(Long userId, Long itemId) {
         MobileMediaInbox item = owned(userId, itemId);
         if (item.getDeliveredAt() != null || item.getStoragePath() == null) {
             throw new IllegalArgumentException(LangText.of("该影像已投递", "This media item has already been delivered"));
         }
-        Path p = Path.of(item.getStoragePath());
-        if (!Files.exists(p)) {
+        if (!blobStore.exists(item.getStoragePath())) {
             throw new IllegalArgumentException(LangText.of("影像内容不存在", "Media content not found"));
         }
-        return p;
+        try {
+            return new ContentBlob(blobStore.open(item.getStoragePath()), item.getFileSize());
+        } catch (IOException e) {
+            throw new IllegalArgumentException(LangText.of("影像内容不存在", "Media content not found"), e);
+        }
     }
 
     @Transactional
     public void ack(Long userId, Long itemId) {
         MobileMediaInbox item = owned(userId, itemId);
         if (item.getStoragePath() != null) {
-            try {
-                Files.deleteIfExists(Path.of(item.getStoragePath()));
-            } catch (IOException e) {
-                // blob 删不掉不该挡住投递确认：行先标记，残留 blob 由 TTL 清理兜底
-                log.warn("ACK 删除 blob 失败，留给 TTL 清理: item={}, path={}", itemId, item.getStoragePath(), e);
-            }
+            // blob 删不掉不该挡住投递确认（deleteQuietly 只 warn）：行先标记，残留由 TTL/桶生命周期兜底
+            blobStore.deleteQuietly(item.getStoragePath());
             item.setStoragePath(null);
         }
         if (item.getDeliveredAt() == null) {
@@ -319,11 +315,7 @@ public class MobileRelayStoreService {
         List<MobileMediaInbox> expired = inboxRepository.findByCreatedAtBefore(LocalDateTime.now().minus(TTL));
         for (MobileMediaInbox item : expired) {
             if (item.getStoragePath() != null) {
-                try {
-                    Files.deleteIfExists(Path.of(item.getStoragePath()));
-                } catch (IOException e) {
-                    log.warn("TTL 清理 blob 失败: item={}, path={}", item.getId(), item.getStoragePath(), e);
-                }
+                blobStore.deleteQuietly(item.getStoragePath());
             }
             inboxRepository.delete(item);
         }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -525,6 +525,19 @@ optimizer:
     to: ${OPTIMIZER_MAIL_TO:}
     subject-prefix: "[AI WorkDeck 优化者]"
 
+# 手机端云中转（/api/mobile/*）的 blob 存储（dev-board#236）。
+# 默认本地盘（storage.local.root-path/mobile-relay）；云后端配齐 MOBILE_RELAY_OSS_*
+# 环境变量即切 OSS 私有桶（中转是短生命周期暂存，与下方 storage.oss 的文档存储无关）。
+mobile:
+  relay:
+    oss:
+      enabled: ${MOBILE_RELAY_OSS_ENABLED:false}
+      endpoint: ${MOBILE_RELAY_OSS_ENDPOINT:}
+      bucket: ${MOBILE_RELAY_OSS_BUCKET:}
+      access-key-id: ${MOBILE_RELAY_OSS_AK_ID:}
+      access-key-secret: ${MOBILE_RELAY_OSS_AK_SECRET:}
+      key-prefix: mobile-relay/
+
 # 文件存储配置
 storage:
   # 存储类型：local（本地文件系统）或 oss（对象存储）

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayOssBlobStoreTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayOssBlobStoreTest.java
@@ -1,0 +1,86 @@
+package com.checkba.service.mobile;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.OSSObject;
+import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PutObjectResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * OSS 实现的契约测试（mock OSS，模式同 MeetingTranscriptionServiceTest）：
+ * key 组装、真实字节计数、legacy 本地路径双读、删除失败不抛。
+ */
+class MobileRelayOssBlobStoreTest {
+
+    private final OSS oss = mock(OSS.class);
+    private final MobileRelayOssBlobStore store =
+            new MobileRelayOssBlobStore(oss, "awd-mobile-relay", "mobile-relay/");
+
+    @Test
+    void putComposesKeyAndCountsRealBytes() {
+        when(oss.putObject(anyString(), anyString(), any(InputStream.class), any(ObjectMetadata.class)))
+                .thenAnswer(inv -> {
+                    // 模拟 SDK 消费整个流
+                    inv.getArgument(2, InputStream.class).readAllBytes();
+                    return new PutObjectResult();
+                });
+
+        byte[] payload = "JPEG-BYTES".getBytes(StandardCharsets.UTF_8);
+        MobileRelayBlobStore.StoredBlob stored =
+                store.put(42L, "abc-def", new ByteArrayInputStream(payload), payload.length);
+
+        assertEquals("mobile-relay/42/abc-def", stored.locator());
+        assertEquals(payload.length, stored.size(), "size 必须是真实读到的字节数");
+
+        ArgumentCaptor<ObjectMetadata> meta = ArgumentCaptor.forClass(ObjectMetadata.class);
+        verify(oss).putObject(eq("awd-mobile-relay"), eq("mobile-relay/42/abc-def"),
+                any(InputStream.class), meta.capture());
+        assertEquals(payload.length, meta.getValue().getContentLength(),
+                "必须带 Content-Length，否则 SDK 全量缓冲进堆");
+    }
+
+    @Test
+    void openAndExistsRouteKeysToOss() throws Exception {
+        OSSObject obj = new OSSObject();
+        obj.setObjectContent(new ByteArrayInputStream("x".getBytes(StandardCharsets.UTF_8)));
+        when(oss.getObject("awd-mobile-relay", "mobile-relay/1/k")).thenReturn(obj);
+        when(oss.doesObjectExist("awd-mobile-relay", "mobile-relay/1/k")).thenReturn(true);
+
+        assertTrue(store.exists("mobile-relay/1/k"));
+        assertEquals("x", new String(store.open("mobile-relay/1/k").readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void legacyAbsolutePathsBypassOss(@TempDir Path dir) throws Exception {
+        Path legacy = dir.resolve("blob");
+        Files.writeString(legacy, "legacy-bytes");
+
+        assertTrue(store.exists(legacy.toString()));
+        assertEquals("legacy-bytes",
+                new String(store.open(legacy.toString()).readAllBytes(), StandardCharsets.UTF_8));
+
+        store.deleteQuietly(legacy.toString());
+        assertFalse(Files.exists(legacy), "legacy 路径的删除仍走文件系统");
+        verifyNoInteractions(oss);
+    }
+
+    @Test
+    void deleteQuietlyNeverThrows() {
+        doThrow(new OSSException("boom")).when(oss).deleteObject(anyString(), anyString());
+        assertDoesNotThrow(() -> store.deleteQuietly("mobile-relay/1/k"),
+                "删不掉不该挡住 ACK/TTL 的行级操作");
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceConcurrentStoreTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceConcurrentStoreTest.java
@@ -43,7 +43,8 @@ class MobileRelayStoreServiceConcurrentStoreTest {
     void setUp() {
         dirRepository = mock(MobileProjectDirRepository.class);
         inboxRepository = mock(MobileMediaInboxRepository.class);
-        service = new MobileRelayStoreService(dirRepository, inboxRepository, blobRoot.toString());
+        service = new MobileRelayStoreService(dirRepository, inboxRepository,
+                new MobileRelayLocalBlobStore(blobRoot.toString()));
         service.self = service;
     }
 

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayStoreServiceTest.java
@@ -60,7 +60,8 @@ class MobileRelayStoreServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new MobileRelayStoreService(dirRepository, inboxRepository, blobRoot.toString());
+        service = new MobileRelayStoreService(dirRepository, inboxRepository,
+                new MobileRelayLocalBlobStore(blobRoot.toString()));
         // storeMedia 撞唯一约束时的重试经 self 转发到 storeMediaTx（新事务）；生产环境里 self
         // 是 Spring 注入的 @Lazy 代理，这里手工 new 没有容器，直接把 service 自己接上去——
         // 写法与理由同 ProjectProfileServiceTest。

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -81,6 +81,18 @@
 
 - 日志：`journalctl -u aiworkdeck-cloud -f`
 - 更新后端：本地重新 package → scp 覆盖 backend.jar → `systemctl restart aiworkdeck-cloud`
+
+## 手机影像云中转的 OSS 存储（dev-board#236）
+
+- blob 不再落 ECS 本地盘，走平台私有桶：北京 `awd-mobile-relay`（cn-beijing），
+  国际站 `awd-mobile-relay-intl`（ap-southeast-1，国际站账号）。桶生命周期 35 天
+  过期 + 7 天清失败分片，只是兜底——主删除机制仍是桌面端 ACK 即删（代码 TTL 30 天次之）。
+- RAM 子用户 `awd-mobile-relay`：仅该桶 Get/Put/Delete/List/HeadObject + GetBucketStat，
+  secret 位置见 EXTERNAL_SERVICES.md §1.1。
+- 开关与凭证 = env 里的 `MOBILE_RELAY_OSS_*` 五项（见 env.example）；不配即回落本地盘
+  （desktop/团队服务器形态）。enabled=true 而配置不全会拒绝启动，属刻意设计。
+- 存量本地 blob 无需搬迁：storagePath 以 `/` 开头的旧行走双读兼容，最迟 30 天被
+  ACK/TTL 消化。
   （会话已 DB 落库，重启不掉浏览器登录态）
 - 更新插件任务窗格：office-addin `npm run build:deploy -- --url https://addin.aiworkdeck.com/office-addin`
   → 覆盖 web/office-addin/（**不要**动 web/ 根下的重定向 index.html，也不要再铺 h5）

--- a/deploy/cloud/env.example
+++ b/deploy/cloud/env.example
@@ -12,6 +12,15 @@ AWD_PLATFORM_KEY_SECRET=CHANGE_ME
 # 会话/账户状态文件目录（license/account/entitlements 等落 ~/.aiworkdeck）
 HOME=/opt/aiworkdeck/cloud/home
 
+# 手机影像云中转的 OSS 存储（dev-board#236）。四项配齐才启用；enabled=true 而配置
+# 不全会拒绝启动（宁可炸也不静默回落本地盘）。RAM 子用户 awd-mobile-relay（仅该桶
+# 读写删列），北京走内网 endpoint（oss-cn-beijing-internal.aliyuncs.com，流量免费）。
+MOBILE_RELAY_OSS_ENABLED=true
+MOBILE_RELAY_OSS_ENDPOINT=oss-cn-beijing-internal.aliyuncs.com
+MOBILE_RELAY_OSS_BUCKET=awd-mobile-relay
+MOBILE_RELAY_OSS_AK_ID=CHANGE_ME
+MOBILE_RELAY_OSS_AK_SECRET=CHANGE_ME
+
 # 可选：登录短信验证（大陆阿里云通道）
 # SMS_AUTH_ENABLED=true
 # SMS_ACCESS_KEY_ID=


### PR DESCRIPTION
用户指示：用户的东西长期放 OSS，不能一直在 ECS 本地盘。

## 设计
- `MobileRelayBlobStore` 接缝 + Local/OSS 双实现；storagePath 存定位符（本地=绝对路径 / OSS=object key），「非空=占配额」不变式与配额 SQL 零改动；存量本地行按 `/` 前缀双读兼容，30 天内被 ACK/TTL 自然消化，无需搬数据。
- 桌面端下载契约逐字保持（2xx + `application/octet-stream` + 裸字节，不做 302 签名 URL——客户端不跟随重定向且硬校验 Content-Type）。
- 装配按 `MOBILE_RELAY_OSS_*` 环境变量：云后端配齐即 OSS；desktop/团队服务器不配保持本地盘。enabled 而配置不全启动即拒，不静默回落。
- 桶 `awd-mobile-relay`（cn-beijing，私有/Standard，生命周期 35 天过期+7 天清失败分片作兜底）与 RAM 子用户（仅桶级 Get/Put/Delete/List/Head/GetBucketStat）已建好；国际站 `awd-mobile-relay-intl` 同型。

## 验证
- `mvn test -Dtest='MobileRelay*Test'` 31 项全绿（含新增 OSS 契约测试 4 项）。
- 部署后将在北京线上做完整链路冒烟（上传→OSS 对象在→下载字节一致→ACK→对象删）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)