### PR TITLE
fix(i18n): AI 面板空态文案接入词典，修中文界面英文泄漏（dev-board#243）

### DIFF
--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -441,7 +441,7 @@
              </view>
           </view>
           <view v-else class="history-empty-placeholder">
-             <text>Your recent chats will appear here</text>
+             <text>{{ $t('chat.recentChatsEmpty') }}</text>
           </view>
           <view class="history-disclaimer">{{ $t('chat.aiDisclaimer') }}</view>
        </view>

--- a/frontend/src/locales/en-US/chat.js
+++ b/frontend/src/locales/en-US/chat.js
@@ -57,6 +57,7 @@ export default {
   inputPlaceholderEmpty: 'Ask a question, drag files or folders here, or paste contract text...',
   inputPlaceholder: 'Ask anything or describe a task',
   recentChats: 'Recent Conversations',
+  recentChatsEmpty: 'Your recent chats will appear here',
   aiDisclaimer: 'AI-generated content is for reference only and does not constitute a formal legal opinion. Use at your own risk.',
   newConversation: 'New Conversation',
   justNow: 'Just now',

--- a/frontend/src/locales/zh-CN/chat.js
+++ b/frontend/src/locales/zh-CN/chat.js
@@ -57,6 +57,7 @@ export default {
   inputPlaceholderEmpty: '请输入问题、拖拽文件/文件夹至此、粘贴合同文本或描述案情...',
   inputPlaceholder: '问点什么，或描述要做的事',
   recentChats: '近期对话',
+  recentChatsEmpty: '最近的对话会显示在这里',
   aiDisclaimer: 'AI生成内容仅供参考，不构成正式意见，请自负责任使用。',
   newConversation: '新对话',
   justNow: '刚刚',


### PR DESCRIPTION
## 背景
2026-08-28 README 截图走查发现：AI 面板空历史占位文案 "Your recent chats will appear here" 硬编码在 ChatInterface.vue（约 444 行），中文界面下 i18n 泄漏，导致带 AI 面板的截图弃用。

## 改动
- `ChatInterface.vue` 空态占位改为 `$t('chat.recentChatsEmpty')`（与同区块 `chat.recentChats` 头部用法一致）
- `locales/zh-CN/chat.js` 新增 `recentChatsEmpty: '最近的对话会显示在这里'`
- `locales/en-US/chat.js` 新增 `recentChatsEmpty: 'Your recent chats will appear here'`

## 自验证
- `npm run check:emits` 通过（101 个 .vue）
- `node scripts/check-locale-parity.mjs` 通过（23 个命名空间）
- `npm run test:commands` 21 pass / 0 fail

dev-board: zeweihan/dev-board#243

🤖 Generated with [Claude Code](https://claude.com/claude-code)