### PR TITLE
feat(wps-addin): WPS 加载项全量落地——三宿主执行器+宿主桥+在线分发（dev-board#244）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -29,6 +29,10 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    （`AI-WorkDeck-Office-Addin.dmg/.exe`）。安装器只带 manifest，但版本号要与
    桌面端同步，用户侧才对得上号。不做这步 = 发版没发插件端，维护者原话
    「不然用户不会弄」。
+   **WPS 加载项（2026-08-28 起）随同一步发**：`cd office-addin && npm run build &&
+   npm run build:wps`，把 dist-wps/ 覆盖上传两台 addin 服务器的
+   `/opt/aiworkdeck/cloud/web/wps-addin/`（在线模式无安装器概念，覆盖静态目录即
+   全量用户生效；壳文件 no-cache 的 nginx 口径见 office-addin/README.md「WPS 加载项」章）。
 5. **EN 走查（打 tag 前必过）**：① 以英文语言设置跑 app-e2e 全量（含 J12 英文旅程：切 en-US 断言工作台四列英文锚点 + AI 过程卡工具名无中文，语言键 `awd_app_language`，切语言必须整页 reload）；② 编辑器 boot 用 `?uilang=en-US` 并以 office_thread.js 的 ooLocale 诊断确认 en-US 生效（issue #66 的诊断口径）；③ 人工过一遍英文主界面截图（工作台/设置/AI 面板）。
 6. DMG 安装窗口视觉（PR#204）：`build.dmg` 里的 `contents` 坐标是**图标中心、原点在窗口内容区左上角（不含标题栏）**；窗口尺寸由背景图 1x 像素尺寸决定（660x420），所以没写 `window`。背景图 `desktop/build/background.png` + `background@2x.png` 由 electron-builder 自动合成 hidpi TIFF，源文件是 `desktop/build/dmg-background.html`（顶部注释有 headless Chrome 重新生成命令）。改图标落位必须同步改 HTML 里的光晕/箭头位置，否则错位。
 

--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -1,6 +1,6 @@
 ---
 name: office-addin
-description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务窗格插件（office-addin/）、manifest、Office.js、插件与后端的对话/上下文契约、sideload 调试时，先读本文档再动代码。
+description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT 任务窗格插件（office-addin/）、manifest、Office.js、WPS 加载项（wps/ 壳、wpsExecutor、publish 安装页）、插件与后端的对话/上下文契约、sideload 调试时，先读本文档再动代码。
 ---
 
 # Office 插件 领域地图
@@ -98,3 +98,38 @@ description: Microsoft Office 插件领域。任务涉及 Word/Excel/PPT 任务�
 - sideload 手测清单与步骤全在 `office-addin/README.md`（Word 工具桥场景 + Excel/PPT 场景 + 断线重连/awdk 连接场景）。
 - 后端单测（JDK 21）：`mvn test -Dtest='ContextAssemblerServiceTest,InlineContentCacheTest,OfficeBridgeServiceTest,OfficeResultControllerTest,ToolRegistryCapabilityFilterTest,OfficeEditToolsTest'`；连接/登录链路是 `mvn test -Dtest='AwdkLoginServiceTest,AuthControllerHardeningTest,AccountServiceTest'`。
 - **设置页的连接链路要走完整条 UI**（原语级测试盖不住 Vue 的接线，见 feedback「验证要走完 UI 链路」）：`npm run build` 后用 `python3 -m http.server` 静态托管 `dist/`（`base:'./'` 决定了它在任何路径下都能开），另起一个桩后端实现 `/api/auth/account-login{,/send-code}`、`/api/auth/awdk-login`、`/api/projects/my` 并带 CORS 头，在浏览器里逐条跑「发验证码（含滑块）→ 错码 → 正确码 → 邮箱口令 → 粘 Key」（桩后端要实现 `/api/auth/account-login/captcha-config`——回真实的 `{provider:'aliyun',sceneId,prefix}` 才能验到滑块真的弹出来，回 `{provider:null}` 只能验到降级分支），判据是 `localStorage.awd_addin_token` 与视图是否切走。`main.js` 在没有 Office 全局时直接挂载，所以不需要真宿主。
+
+## WPS 加载项（2026-08-28，dev-board#244）
+
+同一套任务窗格 Vue 源码构建出的第二个宿主家族：WPS 文字/表格/演示（Windows/Linux 版 WPS；**Mac 版 WPS 不支持加载项**）。后端零改动——officeHost 仍是 word/excel/powerpoint 三值、clientCapability 仍是 'office'、office_command 契约与回传路径完全一致。
+
+### 关键文件
+
+- `taskpane/lib/hostBridge.js` — **Vue 层唯一宿主入口**：按运行环境分发到 Office 面（wordDoc/officeExecutor）或 WPS 面（wpsDoc/wpsExecutor）。chatSession/ChatView 只许 import 这里，不许直连两个家族的实现文件。detectHost/readDocumentMeta 走「officeDetectHost 优先 + 全局对象兜底」的判定顺序（office.js 半初始化窗口期 + 既有测试钉着，别改成 hostFamily 一刀切）。
+- `taskpane/lib/wpsDoc.js` — WPS 三宿主文档读取（契约同 wordDoc.js）。表格读取必须 Value2 批量（跨进程桥约 0.2ms/调用，逐格会拖死任务窗格）。
+- `taskpane/lib/wpsExecutor.js` + `wpsWordHandlers.js` / `wpsEtHandlers.js` / `wpsWppHandlers.js` — office_command 的 WPS 执行器（分发器 + 三张宿主 HANDLERS 表）。**命令名与参数/返回值契约以 officeExecutor.js 为准绳**；宿主守卫按前缀（excel_*/ppt_*/其余归 word）。
+- `taskpane-wps.html` — WPS 构建入口（不含 office.js；window.wps 由宿主注入）。与 taskpane.html 同出一个 dist（vite 双入口），build.target 压 es2018 给参差的 CEF 内核留余量。
+- `wps/` — ribbon 薄壳（vanilla JS，不进 Vite）：ribbon.xml（三宿主共用）+ index.html/main.js/js/*（在线模式 WPS 启动拉 url/index.html）+ `vendor/publish-template.html`（官方 wpsjs@2.2.3 publish.html 原样 vendor，构建脚本只做 PUBLISH_REPLACE_STRING/SERVERID_REPLEASE_STRING 两处替换 + 标题品牌化，**机制代码不许手改**）。
+- `scripts/build-wps.mjs` — `npm run build:wps` 出 dist-wps/（wps/ 壳 + wps/ui/=dist 拷贝 + install.html + jsplugins.xml）。默认部署地址 https://addin.aiworkdeck.com/wps-addin。
+
+### 分发契约
+
+- **在线模式**：加载项 url = `<baseUrl>/wps/`（必须以 / 结尾，`GET url+ribbon.xml` 裸可达）；发版 = 覆盖静态目录，用户无需重装。壳文件（ribbon.xml/index.html/main.js/js/*）必须 no-cache，ui/assets/* 带 hash 长缓存。
+- **个人版安装唯一通路**：install.html 经本机 WPS 常驻服务 127.0.0.1:58890 `/deployaddons/runParams` 写用户 `%APPDATA%\kingsoft\wps\jsaddons\publish.xml`（个人版 12.1.0.16910 起 oem.ini/jsplugins.xml 被禁）。企业版私有部署仍走 jsplugins.xml + oem.ini `JSPluginsServer`。
+- 三宿主 = publish.xml 里三条记录（type=wps/et/wpp，同一 url、同名 aiworkdeck）。
+
+### 已知地雷（WPS 面）
+
+- **不许依赖 wps.Enum**：枚举表在旧宿主上不存在（官方模板都是手工 WPS_Enum 兜底）。三张 HANDLERS 表一律用本地数值常量（VBA 同值）。
+- JSAPI 三折算规则（表格面最易踩）：集合 `.Item()` 函数调用；带参属性按函数调（`Address(false,false)`/`Cells.Item(r,c)`）；**赋值走 Value2**（Value 在 JSAPI 是只读方法）。
+- 颜色是 BGR 打包数值（低字节红），与 #RRGGBB 互转必须过转换函数；表格列宽单位是字符宽不是磅（1 字符≈5.69 磅）。
+- WPS 批注/修订只有 1-based 序号无 GUID；表格批注是老式单条（reply 降级文本追加、resolve 不支持）；文字 `insert_image` 本版不支持（无 base64 直插路）。
+- 文字面比 Office.js 强的三处（别照抄 Office 版降级）：行距最小值原生支持（wdLineSpaceAtLeast）、NameFarEast/NameAscii 无门槛、中文编号 wdListNumberStyleSimpChinNum* 原生支持；PPT AddSlide(Index, CustomLayout) 原生带插入位置。
+- `sse.js` 双通道：流式 fetch 探测不过（或 resp.body 缺失）整条降级 XHR onprogress。**XHR abort 是同步收尾**——close() 里必须先记 wasReading 再 abort，否则 onClose 双触发（已修，sse.test.js 钉住）。
+- 官方模板 index.html 的角色：本地模式下 WPS 自动生成 index.html、开发者不许自建；**在线模式相反**，WPS 从服务器拉 url/index.html，我们必须提供。两句话都对，别拿一句去改另一边。
+- 真机验证欠账（写代码时留意勿固化错误假设）：install.html 在最新个人版的 enable 是否有 2024 整改后的额外校验（头号风险）；CEF 内核 fetch/ReadableStream 实测；字符偏移口径（Document.Range(start,end) 与 JS 字符串索引）；12.1.0.26895+ 停靠任务窗格挡 ribbon 鼠标的平台 bug（bbs 93291）。
+
+### 验证
+
+- `npm test`（含 wps*Handlers 单测与 sse XHR 通道用例）+ `npm run build` + `npm run build:wps`。
+- 真机清单见 office-addin/README.md「WPS 加载项」章（Windows 虚拟机装个人版 WPS）。

--- a/office-addin/.gitignore
+++ b/office-addin/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 dist-deploy*/
+dist-wps/

--- a/office-addin/README.md
+++ b/office-addin/README.md
@@ -5,6 +5,9 @@ office.js 从微软官方 CDN 以 script 标签引入，不打包进 bundle。
 宿主支持 Word（全功能，含原生修订）、Excel（区域读写/查找 + 单元格格式/边框/行列/合并/排序/工作表/冻结窗格/公式），
 PowerPoint（页文本读取/跨页替换，需 PowerPointApi 1.4）。
 
+**同一套任务窗格源码也构建为 WPS 加载项**（文字/表格/演示三宿主，Windows/Linux
+版 WPS；Mac 版 WPS 不支持加载项），见文末「WPS 加载项」一章。
+
 插件独立连接后端实例（律所自建服务器 / 官方云 / 同机桌面版 `http://127.0.0.1:5269`）。
 常规形态是**用 AI WorkDeck 账户登录**（手机号+验证码，或邮箱+口令），与桌面版同一个账户；
 私有部署与团队服务器可在「高级设置」里改用官网账户 Key（awdk_）或手工粘贴的设备令牌。
@@ -380,3 +383,68 @@ npx office-addin-manifest validate dist-deploy/manifest.xml    # 校验生产 ma
   静默回退客户端生成 `conv-<毫秒>`。
 - 流式文本按 XML 标签轻量分流：`<final>` 与标签外文本为主回复、`<thinking>` 折叠展示，
   `<process>`/`<artifact>` 等暂不渲染。
+
+## WPS 加载项
+
+同一套 Vue 任务窗格另出一个 WPS 构建（`taskpane-wps.html` 入口，不含 office.js，
+`window.wps` 由 WPS 宿主注入）。宿主家族在运行时由 `taskpane/lib/hostBridge.js`
+判定：文档读取走 `wpsDoc.js`，office_command 执行走 `wpsExecutor.js`
+（文字/表格/演示三张 HANDLERS 表：`wpsWordHandlers.js` / `wpsEtHandlers.js` /
+`wpsWppHandlers.js`，命令名与参数/返回值契约同 `officeExecutor.js`——后端与模型
+看不出两个家族的差别，officeHost 仍是 word/excel/powerpoint 三值）。
+
+### 结构
+
+```
+wps/
+  ribbon.xml            功能区（三宿主共用，一个「AI 助手」按钮开关任务窗格）
+  index.html main.js    在线模式入口（WPS 启动拉 url/index.html → main.js → js/*）
+  js/ribbon.js util.js  ribbon 薄壳（vanilla JS，不进 Vite；回调按全局函数名查找）
+  vendor/publish-template.html
+                        官方 wpsjs@2.2.3 的 publish.html 原样 vendor（安装页模板，
+                        金山许可允许再分发；勿手改机制代码，构建脚本只做两处
+                        字符串替换 + 标题品牌化）
+scripts/build-wps.mjs   部署产物生成器（见下）
+```
+
+### 构建与部署
+
+```bash
+npm run build        # 先出 dist/（含 taskpane-wps.html）
+npm run build:wps    # 拼 dist-wps/（默认 --url https://addin.aiworkdeck.com/wps-addin）
+```
+
+`dist-wps/` 整体上传到服务器 `<baseUrl>` 对应路径。要点：
+
+- 在线模式：WPS 启动时直接从服务器拉 `wps/ribbon.xml` 与 `wps/index.html`，
+  **发版 = 覆盖静态目录，用户无需重装**；`wps/` 下的壳文件（ribbon.xml/index.html/
+  main.js/js/*）响应头要 no-cache，`wps/ui/assets/*` 带 hash 可长缓存。
+- `GET <baseUrl>/wps/ribbon.xml` 必须裸可达（别过 SPA 回退/鉴权），安装页的
+  「状态」列就是拿它验的。
+- 用户安装：浏览器打开 `<baseUrl>/install.html` → 点「安装」。页面经本机 WPS
+  常驻服务（127.0.0.1:58890，`ksoWPSCloudSvr://` 协议可拉起）把三条记录
+  （文字/表格/演示）写进用户 `%APPDATA%\kingsoft\wps\jsaddons\publish.xml`，
+  重启 WPS 生效。个人版 12.1.0.16910 起这是唯一受支持的安装通路。
+- 企业版私有部署：`dist-wps/jsplugins.xml` 部署到内网，客户端 `office6/cfgs/oem.ini`
+  配 `JSPluginsServer=<jsplugins.xml 地址>`；之后增删改只动服务器。
+
+### 已知差异与降级（对 Office 版）
+
+- 文字：行距「最小值 16 磅」原生支持（Office.js 只能固定值）；中西文分设字体、
+  中文编号（一、二、）原生支持；批注/修订定位符只有序号（无 GUID）；
+  `insert_image` 本版不支持（WPS JSAPI 无 base64 直插路）。
+- 表格：批注是老式单条（`reply_comment` 降级为文本追加，`resolve_comment` 不支持）；
+  列宽单位是字符宽（磅换算按 1 字符≈5.69 磅）；颜色 BGR 数值与 #RRGGBB 互转。
+- 演示：`ppt_add_slide` 原生带插入位置（无需 Office.js 那套「追加再挪」）；
+  下划线只有开/关；子串挂链失败降级整段。
+- SSE：老内核探测不到流式 fetch 时自动降级 XHR onprogress（`sse.js`），语义一致。
+
+### 真机验证清单（Windows 虚拟机装个人版 WPS 最新版）
+
+1. `install.html` 一键安装是否成功写入 publish.xml（2024-06 整改后的头号机制风险）；
+2. 任务窗格能开、`window.wps` 有值、能登录能对话（fetch/ReadableStream 实测，
+   Alt+F12 开 devtools 看 `[Addin]` 日志）；
+3. 文字宿主跑一轮改文档（修订可见、接受/拒绝正常）、表格 Value2 批量读写、
+   演示加页挪页；
+4. `wps.Enum` 缺失时本地常量表是否够用（三张 HANDLERS 表都不依赖 wps.Enum）；
+5. 已知平台坑回归：12.1.0.26895/28043 停靠任务窗格挡 ribbon 鼠标（bbs 93291）。

--- a/office-addin/package.json
+++ b/office-addin/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "build:deploy": "node scripts/build-manifest.mjs",
+    "build:wps": "node scripts/build-wps.mjs",
     "test": "node --test taskpane/lib/*.test.js",
     "build:installers": "node installer/build-installers.mjs"
   },

--- a/office-addin/scripts/build-wps.mjs
+++ b/office-addin/scripts/build-wps.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * WPS 加载项部署产物生成器（仅用 node 内置模块，无新依赖）。
+ *
+ * WPS 侧没有 manifest.xml——分发走「在线模式」：WPS 启动时从我们服务器拉
+ * url/ribbon.xml 与 url/index.html；安装动作由 install.html（官方 publish.html
+ * 模板的定制版）经本机 WPS 常驻服务（127.0.0.1:58890）把加载项记录写进用户的
+ * jsaddons/publish.xml。个人版 12.1.0.16910 起这是唯一受支持的安装通路；
+ * 企业版私有部署另出一份 jsplugins.xml（配 oem.ini 的 JSPluginsServer 用）。
+ *
+ * 产物布局（--out 目录，默认 dist-wps/，整体上传到 <baseUrl> 对应路径）：
+ *   wps/                加载项本体（在线模式的 url 指这里，必须以 / 结尾可达）
+ *     ribbon.xml        功能区（三宿主共用）
+ *     index.html        入口页（引 main.js）
+ *     main.js  js/      ribbon 薄壳（vanilla JS，不进 Vite）
+ *     images/           ribbon 图标（构建时从 assets/ 拷入）
+ *     ui/               任务窗格 = Vite 产物整份拷贝（taskpane-wps.html 是 WPS 入口）
+ *   install.html        一键安装页（官方模板 + 我们的三宿主清单）
+ *   jsplugins.xml       企业版私有部署模板
+ *
+ * 用法：
+ *   node scripts/build-wps.mjs [--url https://addin.aiworkdeck.com/wps-addin] [--out dist-wps]
+ *   部署地址也可用环境变量 WPS_ADDIN_BASE_URL 提供；先跑 npm run build 出 dist/。
+ *
+ * 与 wpsjs CLI 的关系：机制一比一对拍其 publish.js（PUBLISH_REPLACE_STRING /
+ * SERVERID_REPLEASE_STRING 两处替换），模板 wps/vendor/publish-template.html 来自
+ * wpsjs@2.2.3 npm 包 src/lib/res/publish.html，原样 vendor（金山许可允许再分发）。
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_BASE_URL = 'https://addin.aiworkdeck.com/wps-addin'
+/** 加载项注册名（写进用户本机 publish.xml；三宿主同名不同 type） */
+const ADDON_NAME = 'aiworkdeck'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+function parseArgs(argv) {
+  const args = { url: process.env.WPS_ADDIN_BASE_URL || DEFAULT_BASE_URL, out: 'dist-wps' }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--url') args.url = argv[++i] || ''
+    else if (a === '--out') args.out = argv[++i] || args.out
+    else if (a === '--help' || a === '-h') args.help = true
+    else {
+      console.error(`未知参数：${a}`)
+      args.help = true
+    }
+  }
+  return args
+}
+
+function fail(message) {
+  console.error(`[build-wps] ${message}`)
+  process.exit(1)
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (args.help) {
+  console.log('用法：node scripts/build-wps.mjs [--url https://addin.example.com/wps-addin] [--out dist-wps]')
+  process.exit(0)
+}
+
+const baseUrl = (args.url || '').trim().replace(/\/+$/, '')
+if (!baseUrl) fail('缺少部署地址：--url（或环境变量 WPS_ADDIN_BASE_URL）')
+if (!/^https?:\/\/[^\s/]+/.test(baseUrl)) fail(`部署地址必须是 http(s) origin：${baseUrl}`)
+if (!baseUrl.startsWith('https://')) {
+  console.warn('[build-wps] 警告：非 https 地址，仅内网私有部署可接受')
+}
+// 在线模式的加载项 url 必须以 / 结尾（WPS 按 url+ribbon.xml 拉取）
+const addonUrl = `${baseUrl}/wps/`
+
+const distDir = path.join(rootDir, 'dist')
+if (!fs.existsSync(path.join(distDir, 'taskpane-wps.html'))) {
+  fail('未找到 dist/taskpane-wps.html：先跑 npm run build')
+}
+
+const outDir = path.resolve(rootDir, args.out)
+fs.rmSync(outDir, { recursive: true, force: true })
+fs.mkdirSync(path.join(outDir, 'wps', 'images'), { recursive: true })
+
+// 1) ribbon 薄壳
+const shellDir = path.join(rootDir, 'wps')
+for (const f of ['ribbon.xml', 'index.html', 'main.js']) {
+  fs.copyFileSync(path.join(shellDir, f), path.join(outDir, 'wps', f))
+}
+fs.cpSync(path.join(shellDir, 'js'), path.join(outDir, 'wps', 'js'), { recursive: true })
+fs.copyFileSync(path.join(rootDir, 'assets', 'icon-32.png'), path.join(outDir, 'wps', 'images', 'icon-32.png'))
+
+// 2) 任务窗格：Vite 产物整份进 ui/
+fs.cpSync(distDir, path.join(outDir, 'wps', 'ui'), { recursive: true })
+
+// 3) install.html：官方 publish.html 模板 + 我们的清单（对拍 wpsjs publish.js 的两处替换）
+const addons = ['wps', 'et', 'wpp'].map((type) => ({
+  name: ADDON_NAME,
+  addonType: type,
+  online: 'true',
+  multiUser: 'true',
+  customDomain: '',
+  url: addonUrl
+}))
+let installHtml = fs.readFileSync(path.join(shellDir, 'vendor', 'publish-template.html'), 'utf-8')
+if (!installHtml.includes('PUBLISH_REPLACE_STRING') || !installHtml.includes('SERVERID_REPLEASE_STRING')) {
+  fail('publish-template.html 缺少替换占位符（模板被改动过？）')
+}
+installHtml = installHtml.replace(/PUBLISH_REPLACE_STRING/, JSON.stringify(addons))
+// multiUser=true 对应 CLI 的 getServerId() 分支（Linux 多用户场景，Windows 单用户无副作用）
+installHtml = installHtml.replace(/SERVERID_REPLEASE_STRING/, 'getServerId()')
+// 轻量品牌化：只动标题文案，不碰任何机制代码
+installHtml = installHtml
+  .replace('<title>WPS加载项配置</title>', '<title>AI WorkDeck - WPS 加载项安装</title>')
+  .replace('>WPS加载项配置</div>', '>AI WorkDeck - WPS 加载项安装</div>')
+fs.writeFileSync(path.join(outDir, 'install.html'), installHtml)
+
+// 4) 企业版私有部署模板（oem.ini 的 JSPluginsServer 指向这份文件的部署地址）
+const jsplugins = ['<jsplugins>']
+for (const a of addons) {
+  jsplugins.push(`    <jspluginonline name="${a.name}" type="${a.addonType}" url="${a.url}"/>`)
+}
+jsplugins.push('</jsplugins>', '')
+fs.writeFileSync(path.join(outDir, 'jsplugins.xml'), jsplugins.join('\n'))
+
+console.log(`[build-wps] 完成：${outDir}`)
+console.log(`  加载项 url：${addonUrl}（部署后 GET ${addonUrl}ribbon.xml 必须直接可达，别过 SPA 回退/鉴权）`)
+console.log(`  安装页：${baseUrl}/install.html`)
+console.log('  缓存口径：ribbon.xml / index.html / main.js / js/* 建议 no-cache；ui/assets/* 带 hash 可长缓存')

--- a/office-addin/taskpane-wps.html
+++ b/office-addin/taskpane-wps.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>AI WorkDeck</title>
+  <!-- WPS 任务窗格入口：不引 office.js（那是微软家族的），window.wps 由 WPS 宿主注入 -->
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/taskpane/main.js"></script>
+</body>
+</html>

--- a/office-addin/taskpane/components/ChatView.vue
+++ b/office-addin/taskpane/components/ChatView.vue
@@ -294,8 +294,7 @@ import {
   toggleSkill, loadConversationList, switchConversation, attachedFiles, toggleAttachedFile,
   loadProjectFiles, removeConversation, retitleConversation
 } from '../lib/chatSession.js'
-import { readDocumentMeta, detectHost } from '../lib/wordDoc.js'
-import { locateInDocument } from '../lib/officeExecutor.js'
+import { readDocumentMeta, detectHost, locateInDocument } from '../lib/hostBridge.js'
 import { micSupported, startRecording, MAX_RECORD_MS } from '../lib/wavRecorder.js'
 import { postDictate } from '../lib/api.js'
 import { t } from '../lib/i18n.js'

--- a/office-addin/taskpane/lib/chatSession.js
+++ b/office-addin/taskpane/lib/chatSession.js
@@ -5,8 +5,10 @@ import {
   deleteConversation as apiDeleteConversation, renameConversation as apiRenameConversation
 } from './api.js'
 import { createSseConnection, createTagStreamParser } from './sse.js'
-import { readActiveDocument, readDocumentMeta, detectHost, hashContent } from './wordDoc.js'
-import { executeOfficeCommand, commandDisplayName } from './officeExecutor.js'
+import {
+  readActiveDocument, readDocumentMeta, detectHost, hashContent,
+  executeCommand, commandDisplayName
+} from './hostBridge.js'
 import {
   loadConversationId, saveConversationId, isConfigured, loadModelChoice, saveModelChoice
 } from './settings.js'
@@ -583,7 +585,7 @@ async function handleClientAction(dataStr) {
   // 光标一直闪。失败要落在 chip 上（错误详情给用户看，不只回传给模型）。
   let result
   try {
-    result = await executeOfficeCommand(action.command, action.args)
+    result = await executeCommand(action.command, action.args)
   } catch (e) {
     result = { ok: false, error: (e && e.message) || String(e) }
   }

--- a/office-addin/taskpane/lib/hostBridge.js
+++ b/office-addin/taskpane/lib/hostBridge.js
@@ -1,0 +1,104 @@
+/**
+ * 宿主桥：同一套任务窗格 Vue 层跑在两个宿主家族里——Microsoft Office（Office.js）
+ * 与 WPS（WPS 加载项 JSAPI）。Vue 层（chatSession/ChatView）只 import 本模块，
+ * 由这里按运行环境分发到 wordDoc/officeExecutor（Office 面）或 wpsDoc/wpsExecutor
+ * （WPS 面）。两个家族的实现文件互不感知，各自忠于各自宿主的原生 API。
+ *
+ * 环境判定：Office 家族看 Office.context（office.js 由 taskpane.html 以 script
+ * 标签引入，WPS 构建的入口页不含它）；WPS 家族看 window.wps（WPS 任务窗格 webview
+ * 注入）。两者不会共存——一份构建产物只服务一个家族，这里的判定是运行时兜底，
+ * 也让普通浏览器直开调试（两者皆无）时优雅降级，行为与改造前一致。
+ *
+ * 对后端而言两个家族无差别：officeHost 仍是 word/excel/powerpoint 三值
+ * （WPS 文字/表格/演示分别映射），clientCapability 仍是 'office'，
+ * office_command 契约与回传路径完全一致——后端零改动是本设计的硬约束。
+ */
+import {
+  officeAvailable,
+  detectHost as officeDetectHost,
+  readActiveDocument as officeReadActiveDocument,
+  readDocumentMeta as officeReadDocumentMeta
+} from './wordDoc.js'
+import {
+  executeOfficeCommand,
+  commandDisplayName as sharedCommandDisplayName,
+  locateInDocument as officeLocateInDocument
+} from './officeExecutor.js'
+import {
+  wpsAvailable,
+  detectWpsHost,
+  readWpsActiveDocument,
+  readWpsDocumentMeta
+} from './wpsDoc.js'
+import { executeWpsCommand, locateInWpsDocument } from './wpsExecutor.js'
+
+export { hashContent } from './wordDoc.js'
+
+/** 'office' | 'wps' | ''（普通浏览器调试） */
+export function hostFamily() {
+  if (officeAvailable()) return 'office'
+  if (wpsAvailable()) return 'wps'
+  return ''
+}
+
+export function hostAvailable() {
+  return hostFamily() !== ''
+}
+
+/**
+ * 当前宿主：'word' | 'excel' | 'powerpoint' | ''。
+ * WPS 文字/表格/演示归一到同一套三值——后端按 officeHost 细分工具可见性，
+ * 不感知家族差异。
+ *
+ * 注意判定顺序不是走 hostFamily：officeDetectHost 自带「Office.context 取不到时
+ * 按 Word/Excel 全局对象兜底」的降级路（office.js 未初始化的窗口期 + 既有测试
+ * 依赖它），必须先问它、拿不到再问 WPS，语义才与改造前逐点一致。
+ */
+export function detectHost() {
+  const officeHost = officeDetectHost()
+  if (officeHost) return officeHost
+  if (wpsAvailable()) return detectWpsHost()
+  return ''
+}
+
+export async function readActiveDocument() {
+  const family = hostFamily()
+  if (family === 'office') return officeReadActiveDocument()
+  if (family === 'wps') return readWpsActiveDocument()
+  return null
+}
+
+/**
+ * 与 readActiveDocument 不同，这里跟 detectHost 同款「不要求 officeAvailable」——
+ * 壳（id/name/fileType）在 office.js 半初始化状态下也要能出（旧实现如此，
+ * 发送契约测试钉着这条）。
+ */
+export function readDocumentMeta() {
+  if (officeDetectHost()) return officeReadDocumentMeta()
+  if (wpsAvailable() && detectWpsHost()) return readWpsDocumentMeta()
+  return null
+}
+
+/**
+ * 执行一条 office_command。与两个家族的执行器同契约：永不 throw，
+ * 一律返回 {ok:true, data} 或 {ok:false, error}。
+ */
+export async function executeCommand(command, args) {
+  const family = hostFamily()
+  if (family === 'office') return executeOfficeCommand(command, args)
+  if (family === 'wps') return executeWpsCommand(command, args)
+  return { ok: false, error: '宿主环境不可用：请在 Office 或 WPS 任务窗格中使用本插件' }
+}
+
+/** 命令中文名表两个家族共用（officeExecutor 里的纯数据表，不碰宿主 API） */
+export function commandDisplayName(command) {
+  return sharedCommandDisplayName(command)
+}
+
+/** 引用定位（正文引文 chip 点击选中），仅 Word/文字宿主 */
+export async function locateInDocument(text) {
+  const family = hostFamily()
+  if (family === 'office') return officeLocateInDocument(text)
+  if (family === 'wps') return locateInWpsDocument(text)
+  return { found: false }
+}

--- a/office-addin/taskpane/lib/site.js
+++ b/office-addin/taskpane/lib/site.js
@@ -33,7 +33,8 @@ export function rechargeUrl(serverUrl) {
 /**
  * 在系统浏览器打开外链。Office 任务窗格里 window.open 在部分宿主（Mac Word 的
  * WKWebView）会被吞，官方姿势是 Office.context.ui.openBrowserWindow；
- * 老宿主没有该 API 时回退 window.open。
+ * WPS 任务窗格的对应姿势是 wps.OAAssist.ShellExecute（官方 wpsjs 模板 util.js
+ * 同款用法）；两者都没有时回退 window.open。
  */
 export function openExternal(url) {
   if (!url) return
@@ -41,6 +42,15 @@ export function openExternal(url) {
     if (typeof Office !== 'undefined' && Office.context && Office.context.ui
         && typeof Office.context.ui.openBrowserWindow === 'function') {
       Office.context.ui.openBrowserWindow(url)
+      return
+    }
+  } catch (e) {
+    // 落到下一条通路
+  }
+  try {
+    if (typeof wps !== 'undefined' && wps && wps.OAAssist
+        && typeof wps.OAAssist.ShellExecute === 'function') {
+      wps.OAAssist.ShellExecute(url)
       return
     }
   } catch (e) {

--- a/office-addin/taskpane/lib/sse.js
+++ b/office-addin/taskpane/lib/sse.js
@@ -1,6 +1,9 @@
 /**
  * SSE 消费：与主前端 useAgentStream 同一方式——fetch + ReadableStream 手工解析
  * `event:`/`data:` 行（不用 EventSource，因为要携带 X-Session-Id 请求头）。
+ * 老内核降级：WPS 任务窗格的 CEF 内核版本参差，探测不到流式 fetch 能力
+ * （或运行时拿不到 resp.body 读流）时整条降级为 XHR onprogress 增量读，
+ * 行协议解析、心跳看门狗、重连语义两条通道完全一致。
  *
  * 断线自动重连：
  * - 首次建连失败：ready reject，不重连（保持「后端不可达」的即时报错体验）；
@@ -18,6 +21,23 @@ const RECONNECT_MAX_MS = 30000
 const DEAD_CONNECTION_MS = 40000
 const WATCHDOG_TICK_MS = 5000
 
+/**
+ * fetch 流式消费的能力探测。WPS 任务窗格跑在随宿主版本参差的 CEF 内核里，
+ * 老内核可能没有 ReadableStream/AbortController（fetch 本身也可能没有）——
+ * 探测不过就整条降级到 XHR onprogress 通道（任何年代的内核都有）。
+ * Office 家族的现代 webview 恒走 fetch 主路，行为不变。
+ */
+function streamFetchSupported() {
+  try {
+    return typeof fetch === 'function'
+      && typeof AbortController === 'function'
+      && typeof TextDecoder === 'function'
+      && typeof ReadableStream !== 'undefined'
+  } catch (e) {
+    return false
+  }
+}
+
 export function createSseConnection({ baseUrl, token, conversationId, onEvent, onClose, onStatus }) {
   let controller = null
   let closed = false
@@ -26,24 +46,61 @@ export function createSseConnection({ baseUrl, token, conversationId, onEvent, o
   let watchdogTimer = null
   let lastActivity = Date.now()
   let reading = false
+  // fetch 主路在运行时发现拿不到读流（个别内核 resp.body 为空）时永久翻到 XHR
+  let forceXhr = !streamFetchSupported()
 
   const notifyStatus = (status) => {
     try { if (onStatus) onStatus(status) } catch (e) { /* ignore */ }
   }
 
+  const connectUrl = () => `${baseUrl}/api/agent/connect/${conversationId}`
+
+  function httpError(status) {
+    const err = new Error(`SSE 建连失败（HTTP ${status}）：令牌无效或后端拒绝了请求`)
+    // 挂上状态码：403（会话不归当前用户/签发登记已丢）是调用方能自愈的，其余不能
+    err.status = status
+    return err
+  }
+
+  /** `event:`/`data:` 行协议的增量解析（fetch 与 XHR 两条读流通道共用） */
+  function createLineParser() {
+    let buffer = ''
+    let eventName = null
+    let eventData = ''
+    const flush = () => {
+      if (eventData) {
+        try { onEvent(eventName, eventData) } catch (e) { console.error('[Addin] onEvent 异常', e) }
+      }
+      eventName = null
+      eventData = ''
+    }
+    return {
+      feed(text) {
+        buffer += text
+        const lines = buffer.split(/\r?\n/)
+        buffer = lines.pop() // 保留最后一段不完整行
+        for (const line of lines) {
+          if (!line.trim()) { flush(); continue }
+          if (line.startsWith('event:')) {
+            eventName = line.substring(6).trim()
+          } else if (line.startsWith('data:')) {
+            let v = line.substring(5)
+            if (v.startsWith(' ')) v = v.substring(1)
+            eventData += (eventData ? '\n' : '') + v
+          }
+        }
+      }
+    }
+  }
+
   async function connectOnce() {
     controller = new AbortController()
-    const resp = await fetch(`${baseUrl}/api/agent/connect/${conversationId}`, {
+    const resp = await fetch(connectUrl(), {
       method: 'GET',
       headers: { 'X-Session-Id': token || '' },
       signal: controller.signal
     })
-    if (!resp.ok) {
-      const err = new Error(`SSE 建连失败（HTTP ${resp.status}）：令牌无效或后端拒绝了请求`)
-      // 挂上状态码：403（会话不归当前用户/签发登记已丢）是调用方能自愈的，其余不能
-      err.status = resp.status
-      throw err
-    }
+    if (!resp.ok) throw httpError(resp.status)
     return resp
   }
 
@@ -63,50 +120,116 @@ export function createSseConnection({ baseUrl, token, conversationId, onEvent, o
     if (watchdogTimer) { clearInterval(watchdogTimer); watchdogTimer = null }
   }
 
+  /** 读流收尾（两条通道共用）：主动关闭→通知，意外断流→重连 */
+  function finishReading() {
+    reading = false
+    stopWatchdog()
+    if (closed) {
+      if (onClose) onClose()
+    } else {
+      scheduleReconnect()
+    }
+  }
+
   async function readLoop(resp) {
     reading = true
     const reader = resp.body.getReader()
     const decoder = new TextDecoder('utf-8')
-    let buffer = ''
-    let eventName = null
-    let eventData = ''
-    const flush = () => {
-      if (eventData) {
-        try { onEvent(eventName, eventData) } catch (e) { console.error('[Addin] onEvent 异常', e) }
-      }
-      eventName = null
-      eventData = ''
-    }
+    const parser = createLineParser()
     try {
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
         lastActivity = Date.now()
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split(/\r?\n/)
-        buffer = lines.pop() // 保留最后一段不完整行
-        for (const line of lines) {
-          if (!line.trim()) { flush(); continue }
-          if (line.startsWith('event:')) {
-            eventName = line.substring(6).trim()
-          } else if (line.startsWith('data:')) {
-            let v = line.substring(5)
-            if (v.startsWith(' ')) v = v.substring(1)
-            eventData += (eventData ? '\n' : '') + v
-          }
-        }
+        parser.feed(decoder.decode(value, { stream: true }))
       }
     } catch (e) {
       if (e.name !== 'AbortError' || !closed) console.warn('[Addin] SSE 读流中断', e)
     } finally {
-      reading = false
-      stopWatchdog()
-      if (closed) {
-        if (onClose) onClose()
-      } else {
-        scheduleReconnect()
-      }
+      finishReading()
     }
+  }
+
+  /**
+   * XHR 降级通道：onreadystatechange 里增量读 responseText。
+   * 返回 Promise，语义与 connectOnce 对齐——头部到达且 200 时 resolve（此时
+   * reading 已置起、读流由回调驱动），非 200/网络失败时 reject。整条响应会
+   * 累积在 responseText 里，后端每轮结束主动关流，单轮体量有限，可接受。
+   */
+  function connectAndReadXhr() {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+      controller = { abort() { try { xhr.abort() } catch (e) { /* 已关 */ } } }
+      let seen = 0
+      let opened = false
+      let settled = false
+      const parser = createLineParser()
+      const consumeNew = () => {
+        let text = ''
+        try { text = xhr.responseText || '' } catch (e) { return /* abort 后个别引擎不让读 */ }
+        if (text.length > seen) {
+          lastActivity = Date.now()
+          parser.feed(text.slice(seen))
+          seen = text.length
+        }
+      }
+      xhr.onreadystatechange = () => {
+        if (!opened && xhr.readyState >= 2 && xhr.status) {
+          if (xhr.status === 200) {
+            opened = true
+            reading = true
+            if (!settled) { settled = true; resolve() }
+          } else {
+            const err = httpError(xhr.status)
+            try { xhr.abort() } catch (e) { /* ignore */ }
+            if (!settled) { settled = true; reject(err) }
+            return
+          }
+        }
+        if (opened && (xhr.readyState === 3 || xhr.readyState === 4)) consumeNew()
+        if (xhr.readyState === 4 && opened) finishReading()
+      }
+      xhr.onerror = xhr.ontimeout = () => {
+        if (!settled) {
+          settled = true
+          reject(new Error('SSE 建连失败：网络不可达'))
+          return
+        }
+        // 已在读流中失败：走统一收尾（重连或关闭）
+        if (opened && reading) finishReading()
+      }
+      // abort（看门狗/close 主动掐）在部分引擎只触发 onabort 不触发 readystatechange，
+      // 两边都挂收尾；finishReading 内 reading 置 false，双触发也只收尾一次
+      xhr.onabort = () => {
+        if (opened && reading) finishReading()
+      }
+      try {
+        xhr.open('GET', connectUrl(), true)
+        xhr.setRequestHeader('X-Session-Id', token || '')
+        xhr.send()
+      } catch (e) {
+        if (!settled) { settled = true; reject(e) }
+      }
+    })
+  }
+
+  /**
+   * 建连一次（通道自适应）：fetch 主路拿不到读流（老内核 resp.body 缺失）时
+   * 永久翻到 XHR 再试本次。resolve 即已连上且读流开始维护。
+   */
+  async function connectAndRead() {
+    if (!forceXhr) {
+      const resp = await connectOnce()
+      if (resp.body && typeof resp.body.getReader === 'function') {
+        startWatchdog()
+        readLoop(resp)
+        return
+      }
+      console.warn('[Addin] fetch 响应无读流，SSE 降级到 XHR 通道')
+      forceXhr = true
+    }
+    await connectAndReadXhr()
+    startWatchdog()
   }
 
   let connecting = false
@@ -115,11 +238,9 @@ export function createSseConnection({ baseUrl, token, conversationId, onEvent, o
     if (closed || connecting) return
     connecting = true
     try {
-      const resp = await connectOnce()
+      await connectAndRead()
       backoffMs = RECONNECT_BASE_MS
       notifyStatus('connected')
-      startWatchdog()
-      readLoop(resp)
     } catch (e) {
       if (!closed) {
         console.warn('[Addin] SSE 重连失败，继续退避', e)
@@ -142,11 +263,9 @@ export function createSseConnection({ baseUrl, token, conversationId, onEvent, o
   }
 
   const ready = (async () => {
-    // 首连失败直接抛给调用方（不进重连循环）；成功后交给 readLoop 维护
-    const resp = await connectOnce()
+    // 首连失败直接抛给调用方（不进重连循环）；成功后由读流通道维护
+    await connectAndRead()
     notifyStatus('connected')
-    startWatchdog()
-    readLoop(resp)
   })()
 
   return {
@@ -168,9 +287,12 @@ export function createSseConnection({ baseUrl, token, conversationId, onEvent, o
       closed = true
       stopWatchdog()
       if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+      // 先记住 abort 前是否有活跃读流：XHR 通道的 abort 会**同步**触发 finishReading
+      // （其中已含 onClose），abort 后再看 reading 会误判成「没有读流」而二次 onClose
+      const wasReading = reading
       if (controller) controller.abort()
-      // 没有活跃读流（重连等待期/首连未成）时不会再有 finally 收尾，这里直接通知关闭
-      if (!reading && onClose) onClose()
+      // 没有活跃读流（重连等待期/首连未成）时不会再有收尾回调，这里直接通知关闭
+      if (!wasReading && onClose) onClose()
     }
   }
 }

--- a/office-addin/taskpane/lib/sse.test.js
+++ b/office-addin/taskpane/lib/sse.test.js
@@ -9,7 +9,7 @@
  */
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { createTagStreamParser } from './sse.js'
+import { createTagStreamParser, createSseConnection } from './sse.js'
 
 /** 把整段文本喂给解析器，返回三路输出 */
 function parse(chunks) {
@@ -109,4 +109,104 @@ test('同一输入逐字节喂入（实时流式）结果一致', () => {
 test('正文数值比较 <80%> 原样放行（数字开头不像协议标签）', () => {
   const { main } = parse('<final>担保比例<80%>时豁免</final>')
   assert.equal(main, '担保比例<80%>时豁免')
+})
+
+// ==================== XHR 降级通道（WPS 老内核，无流式 fetch） ====================
+// createSseConnection 在建连时探测流式 fetch 能力，探测不过整条走 XHR onprogress。
+// 这里临时抹掉 ReadableStream 迫使降级，验证：行协议解析一致、增量消费、
+// close() 只触发一次 onClose（XHR abort 是同步收尾，曾有双触发隐患）。
+
+test('XHR 降级通道：增量消费事件、请求头带令牌、close 单次收尾', async () => {
+  const savedRS = globalThis.ReadableStream
+  const savedXHR = globalThis.XMLHttpRequest
+  const instances = []
+  class FakeXhr {
+    constructor() {
+      instances.push(this)
+      this.readyState = 0
+      this.status = 0
+      this.responseText = ''
+      this.headers = {}
+      this.aborted = false
+    }
+    open(method, url) { this.url = url }
+    setRequestHeader(k, v) { this.headers[k] = v }
+    send() {
+      setTimeout(() => {
+        this.status = 200
+        this.readyState = 2
+        this.onreadystatechange && this.onreadystatechange()
+        this.pushChunk('event: text_delta\ndata: {"a":1}\n\n')
+      }, 0)
+    }
+    pushChunk(t) {
+      this.readyState = 3
+      this.responseText += t
+      this.onreadystatechange && this.onreadystatechange()
+    }
+    abort() {
+      this.aborted = true
+      this.readyState = 4
+      this.onabort && this.onabort()
+    }
+  }
+  globalThis.ReadableStream = undefined
+  globalThis.XMLHttpRequest = FakeXhr
+  try {
+    const events = []
+    let closes = 0
+    const conn = createSseConnection({
+      baseUrl: 'https://x.example',
+      token: 'awdt_xhr',
+      conversationId: 'conv-xhr-1',
+      onEvent: (name, data) => events.push([name, data]),
+      onClose: () => { closes++ }
+    })
+    await conn.ready
+    await new Promise((r) => setTimeout(r, 5))
+    const xhr = instances[0]
+    assert.equal(xhr.url, 'https://x.example/api/agent/connect/conv-xhr-1')
+    assert.equal(xhr.headers['X-Session-Id'], 'awdt_xhr')
+    assert.deepEqual(events[0], ['text_delta', '{"a":1}'])
+    // 多字节分段推进：跨 chunk 的半行要接得上
+    xhr.pushChunk('event: bubble_end\ndata: {"do')
+    xhr.pushChunk('ne":true}\n\n')
+    assert.deepEqual(events[1], ['bubble_end', '{"done":true}'])
+    conn.close()
+    assert.ok(xhr.aborted, 'close 必须 abort 掉 XHR')
+    assert.equal(closes, 1, 'onClose 只许触发一次（同步 abort 曾有双触发隐患）')
+  } finally {
+    globalThis.ReadableStream = savedRS
+    globalThis.XMLHttpRequest = savedXHR
+  }
+})
+
+test('XHR 降级通道：非 200 首连 ready 即拒绝并带状态码（自愈判定依赖它）', async () => {
+  const savedRS = globalThis.ReadableStream
+  const savedXHR = globalThis.XMLHttpRequest
+  class Fake403 {
+    open() {}
+    setRequestHeader() {}
+    send() {
+      setTimeout(() => {
+        this.status = 403
+        this.readyState = 2
+        this.onreadystatechange && this.onreadystatechange()
+      }, 0)
+    }
+    abort() { this.readyState = 4 }
+  }
+  globalThis.ReadableStream = undefined
+  globalThis.XMLHttpRequest = Fake403
+  try {
+    const conn = createSseConnection({
+      baseUrl: 'https://x.example', token: 't', conversationId: 'c',
+      onEvent: () => {}, onClose: () => {}
+    })
+    await assert.rejects(conn.ready, (e) => e.status === 403)
+    conn.close()
+  } finally {
+    globalThis.ReadableStream = savedRS
+    globalThis.XMLHttpRequest = savedXHR
+  }
 })

--- a/office-addin/taskpane/lib/wpsDoc.js
+++ b/office-addin/taskpane/lib/wpsDoc.js
@@ -1,0 +1,167 @@
+/**
+ * WPS 加载项 JSAPI 文档访问（与 wordDoc.js 同职责的 WPS 家族实现）：
+ * 宿主检测 + 读取当前文档内容，作为 activeContext 内联正文随对话请求上送。
+ *
+ * 入口对象：WPS 任务窗格 webview 注入的 window.wps——文字宿主 wps.WpsApplication()、
+ * 表格宿主 wps.EtApplication()、演示宿主 wps.WppApplication()，对象模型为 VBA 同构
+ * 的同步 API。宿主归一到与 Office 家族相同的三值（word/excel/powerpoint），
+ * 后端 officeHost 契约不感知家族差异。
+ */
+
+// 与 wordDoc.js 一致的上限口径
+const MAX_BODY_CHARS = 200_000
+const MAX_EXCEL_ROWS = 2000
+const MAX_PPT_SLIDES = 100
+
+export function wpsAvailable() {
+  return typeof wps !== 'undefined' && wps != null
+}
+
+/**
+ * 当前 WPS 宿主：'word' | 'excel' | 'powerpoint' | ''。
+ * 三个 Application 入口只有当前宿主的可用，其余的不存在或调用即抛——
+ * 逐个 try 是官方示例的标准姿势。
+ */
+export function detectWpsHost() {
+  if (!wpsAvailable()) return ''
+  try {
+    if (typeof wps.WpsApplication === 'function' && wps.WpsApplication()) return 'word'
+  } catch (e) { /* 非文字宿主 */ }
+  try {
+    if (typeof wps.EtApplication === 'function' && wps.EtApplication()) return 'excel'
+  } catch (e) { /* 非表格宿主 */ }
+  try {
+    if (typeof wps.WppApplication === 'function' && wps.WppApplication()) return 'powerpoint'
+  } catch (e) { /* 非演示宿主 */ }
+  return ''
+}
+
+/** 当前宿主的 Application 对象；不可用时抛错（调用方兜 try/catch） */
+export function wpsApp() {
+  const host = detectWpsHost()
+  if (host === 'word') return wps.WpsApplication()
+  if (host === 'excel') return wps.EtApplication()
+  if (host === 'powerpoint') return wps.WppApplication()
+  throw new Error('WPS 环境不可用')
+}
+
+function documentDisplayName(fallback) {
+  try {
+    const host = detectWpsHost()
+    const app = wpsApp()
+    const doc = host === 'word' ? app.ActiveDocument
+      : host === 'excel' ? app.ActiveWorkbook : app.ActivePresentation
+    if (doc && doc.Name) return String(doc.Name)
+  } catch (e) { /* 未打开文档时用通称 */ }
+  return fallback
+}
+
+function readWordBody() {
+  const app = wps.WpsApplication()
+  const doc = app.ActiveDocument
+  if (!doc) throw new Error('当前没有打开的文档')
+  const text = String(doc.Range().Text || '')
+  return { text, name: documentDisplayName('当前 WPS 文档'), fileType: 'docx' }
+}
+
+/** Address 在 JSAPI 是带参属性=按函数调（$A$1 绝对引用关掉）；个别版本可能是纯属性，兜一手 */
+function rangeAddress(range) {
+  try {
+    if (typeof range.Address === 'function') return String(range.Address(false, false) || '')
+    return String(range.Address || '')
+  } catch (e) {
+    return ''
+  }
+}
+
+function readEtSheet() {
+  const app = wps.EtApplication()
+  const sheet = app.ActiveSheet
+  if (!sheet) throw new Error('当前没有打开的工作簿')
+  const used = sheet.UsedRange
+  const name = String(sheet.Name || '')
+  if (!used) return { text: `工作表「${name}」为空`, name: documentDisplayName('当前 WPS 工作簿'), fileType: 'xlsx' }
+  const rowCount = used.Rows.Count
+  const colCount = used.Columns.Count
+  const shownRows = Math.min(rowCount, MAX_EXCEL_ROWS)
+  // 跨进程桥逐格取值极慢（官方性能口径约 0.2ms/调用），必须 Value2 批量读；
+  // 单格时 Value2 是标量，归一成二维再统一处理
+  let values = used.Value2
+  if (!Array.isArray(values)) values = [[values]]
+  const lines = []
+  for (let r = 0; r < shownRows && r < values.length; r++) {
+    const row = Array.isArray(values[r]) ? values[r] : [values[r]]
+    const cells = []
+    for (let c = 0; c < colCount && c < row.length; c++) {
+      const v = row[c]
+      cells.push(v == null ? '' : String(v))
+    }
+    lines.push(cells.join('\t'))
+  }
+  let out = `工作表「${name}」（区域 ${rangeAddress(used)}）：\n` + lines.join('\n')
+  if (rowCount > MAX_EXCEL_ROWS) {
+    out += `\n...（共 ${rowCount} 行，仅附前 ${MAX_EXCEL_ROWS} 行）`
+  }
+  return { text: out, name: documentDisplayName('当前 WPS 工作簿'), fileType: 'xlsx' }
+}
+
+function readWppSlides() {
+  const app = wps.WppApplication()
+  const pres = app.ActivePresentation
+  if (!pres) throw new Error('当前没有打开的演示文稿')
+  const total = pres.Slides.Count
+  const shown = Math.min(total, MAX_PPT_SLIDES)
+  const lines = []
+  for (let i = 1; i <= shown; i++) {
+    const slide = pres.Slides.Item(i)
+    const texts = []
+    const shapeCount = slide.Shapes.Count
+    for (let s = 1; s <= shapeCount; s++) {
+      const shape = slide.Shapes.Item(s)
+      try {
+        if (shape.TextFrame && shape.TextFrame.HasText) {
+          const t = String(shape.TextFrame.TextRange.Text || '').trim()
+          if (t) texts.push(t)
+        }
+      } catch (e) { /* 个别形状没有文本框架 */ }
+    }
+    lines.push(`第${i}页：${texts.join(' | ') || '（无文本）'}`)
+  }
+  let out = lines.join('\n')
+  if (total > MAX_PPT_SLIDES) {
+    out += `\n...（共 ${total} 页，仅附前 ${MAX_PPT_SLIDES} 页）`
+  }
+  return { text: out, name: documentDisplayName('当前 WPS 演示文稿'), fileType: 'pptx' }
+}
+
+/** 只取文档元信息（名字/类型），不读正文——契约同 wordDoc.readDocumentMeta */
+export function readWpsDocumentMeta() {
+  const host = detectWpsHost()
+  if (!host) return null
+  const fallback = host === 'word' ? '当前 WPS 文档'
+    : host === 'excel' ? '当前 WPS 工作簿' : '当前 WPS 演示文稿'
+  const fileType = host === 'word' ? 'docx' : host === 'excel' ? 'xlsx' : 'pptx'
+  return { id: 'office-current-document', name: documentDisplayName(fallback), fileType }
+}
+
+export async function readWpsActiveDocument() {
+  if (!wpsAvailable()) return null
+  try {
+    const host = detectWpsHost()
+    let doc
+    if (host === 'word') doc = readWordBody()
+    else if (host === 'excel') doc = readEtSheet()
+    else if (host === 'powerpoint') doc = readWppSlides()
+    else return null
+    const text = doc.text || ''
+    return {
+      id: 'office-current-document',
+      name: doc.name,
+      fileType: doc.fileType,
+      inlineContent: text.length > MAX_BODY_CHARS ? text.slice(0, MAX_BODY_CHARS) : text
+    }
+  } catch (e) {
+    console.warn('[Addin] 读取 WPS 文档内容失败', e)
+    return null
+  }
+}

--- a/office-addin/taskpane/lib/wpsEtHandlers.js
+++ b/office-addin/taskpane/lib/wpsEtHandlers.js
@@ -1,0 +1,921 @@
+/**
+ * WPS 表格宿主 HANDLERS：office_command 的 excel_* 全 26 命令在 WPS 加载项
+ * JSAPI（jsaddon，taskpane 网页内同步对象模型）上的实现。
+ *
+ * 契约以 officeExecutor.js 为准绳：命令名、参数、返回值形状与 Office.js 版
+ * 逐一对齐，行为差异只体现在返回值的 note/via 等说明字段里。
+ *
+ * WPS JSAPI 三条折算规则（全文件通用，来自调研 wps-et-api.md）：
+ * 1. 集合索引一律 .Item(...) 函数调用（Worksheets.Item / Cells.Item / Borders.Item）；
+ * 2. 带参属性按函数调用（Address(false,false)、Resize(r,c)、Offset(r,c)）；
+ * 3. Value 在 JSAPI 里是只读方法——取值 rng.Value2，赋值只能 rng.Value2 = ...。
+ *
+ * 性能口径：跨进程桥约 0.2ms/次调用，大区域读写必须 Value2 二维数组一次进出，
+ * 禁止逐格循环（get_range / set_values / search / get_overview / set_formulas 均按此写）。
+ *
+ * 枚举不依赖 wps.Enum（其键名规律官方未成文）：本文件自建数值常量表，
+ * 数值与 VBA 完全一致（官方枚举分册抄录）。
+ *
+ * 真机验证要点（按优先级，钉死后可删注记）：
+ * 1. Value2 多格读回的 JS 形状（二维/单行降维/空格编组）——read2D 已做防御性归一；
+ * 2. 透视表全链路 PivotCaches().Create → CreatePivotTable → 字段编排（编组链最长，
+ *    任何一环失败可能表现为 undefined 而非异常）；
+ * 3. 公式错误值（#DIV/0! 等）经 Value2 的编组形态；
+ * 4. Worksheet.Delete / Unprotect 的弹窗抑制效果；
+ * 5. Range.Sort 的 Key1 传 Range 对象编组；Names.Add RefersTo 字符串路线；
+ * 6. colorScale 的 ColorScaleCriteria 精调（失败已降级为 ET 默认三色刻度）；
+ * 7. 空工作表的 UsedRange 行为（VBA 口径返回 A1 单格而非 null）。
+ */
+
+/* ==================== 入口与通用 helper ==================== */
+
+/** 表格宿主 Application 入口（仅在 WPS 表格进程内有效） */
+function app() {
+  return wps.EtApplication()
+}
+
+/** 按名取工作表；名为空取活动工作表（与 officeExecutor.resolveSheet 同口径） */
+function resolveSheet(sheetName) {
+  const wb = app().ActiveWorkbook
+  if (!wb) throw new Error('当前没有打开的工作簿')
+  return sheetName ? wb.Worksheets.Item(sheetName) : wb.ActiveSheet
+}
+
+/** 0 起的行列号转 A1 地址（与 officeExecutor.cellAddress 同实现） */
+function cellAddress(rowIndex, colIndex) {
+  let col = ''
+  let n = colIndex + 1
+  while (n > 0) {
+    const rem = (n - 1) % 26
+    col = String.fromCharCode(65 + rem) + col
+    n = Math.floor((n - 1) / 26)
+  }
+  return col + (rowIndex + 1)
+}
+
+/** 0 起的列号转字母（供行列范围拼 A1 引用，如 "C:E"） */
+function columnLetter(colIndex) {
+  let col = ''
+  let n = colIndex + 1
+  while (n > 0) {
+    const rem = (n - 1) % 26
+    col = String.fromCharCode(65 + rem) + col
+    n = Math.floor((n - 1) / 26)
+  }
+  return col
+}
+
+/** A1 单元格引用解析为 1 起行列号（容忍 $ 与表名前缀） */
+function parseCellRef(addr) {
+  const bare = String(addr).split('!').pop().replace(/\$/g, '')
+  const m = /^([A-Za-z]+)(\d+)$/.exec(bare)
+  if (!m) throw new Error(`单元格地址非法：${addr}`)
+  let col = 0
+  for (const ch of m[1].toUpperCase()) col = col * 26 + (ch.charCodeAt(0) - 64)
+  return { row: Number(m[2]), col }
+}
+
+/**
+ * '#RRGGBB' 十六进制 → WPS/VBA 的 BGR 长整型（r + g*256 + b*65536）。
+ * 契约层颜色参数与 Office 版一致收 #RRGGBB，落 WPS 前必须转换。
+ */
+export function hexToBgr(hex) {
+  const bare = String(hex).trim().replace(/^#/, '')
+  if (!/^[0-9a-fA-F]{6}$/.test(bare)) {
+    throw new Error(`颜色格式非法：${hex}（应为 #RRGGBB）`)
+  }
+  const n = parseInt(bare, 16)
+  return ((n & 0xff) << 16) | (n & 0xff00) | ((n >> 16) & 0xff)
+}
+
+/** BGR 长整型 → '#RRGGBB'（读回方向的反向转换） */
+export function bgrToHex(bgr) {
+  const n = Number(bgr) >>> 0
+  const r = n & 0xff
+  const g = (n >> 8) & 0xff
+  const b = (n >> 16) & 0xff
+  return '#' + [r, g, b].map((x) => x.toString(16).padStart(2, '0')).join('').toUpperCase()
+}
+
+/**
+ * 区域读为二维数组（Value2 一次性批量取回）。
+ * 多格返回 JS 二维数组、单格返回标量为主形态；单行/单列是否降维官方未成文，
+ * 这里做防御性归一，保证出参恒为 rows x cols 的二维数组。
+ */
+function read2D(rng) {
+  const rows = rng.Rows.Count
+  const cols = rng.Columns.Count
+  const v = rng.Value2
+  if (rows === 1 && cols === 1) return [[Array.isArray(v) ? (Array.isArray(v[0]) ? v[0][0] : v[0]) : v]]
+  if (!Array.isArray(v)) return [[v]]
+  if (!Array.isArray(v[0])) {
+    // 一维形态：单行降成 [a,b,...]，单列降成 [a,b,...]，按区域形状还原
+    if (rows === 1) return [v]
+    if (cols === 1) return v.map((x) => [x])
+  }
+  return v
+}
+
+/** 破坏性操作（删表/合并丢值等）抑制确认弹窗，finally 恢复原状态 */
+function withAlertsSuppressed(fn) {
+  const a = app()
+  let prev = true
+  try { prev = a.DisplayAlerts !== false } catch (e) { /* 读不到按默认 true */ }
+  a.DisplayAlerts = false
+  try {
+    return fn()
+  } finally {
+    a.DisplayAlerts = prev
+  }
+}
+
+/** 空工作表判定：UsedRange 为空引用，或退化为 1x1 且无值（VBA 口径空表返回 A1 单格） */
+function usedRangeIsEmpty(used) {
+  if (!used) return true
+  if (used.Rows.Count === 1 && used.Columns.Count === 1) {
+    const v = used.Value2
+    return v == null || v === ''
+  }
+  return false
+}
+
+/* ==================== 数值常量表（VBA 同值，不依赖 wps.Enum） ==================== */
+
+/** excel_get_range 返回值的行数上限（与 officeExecutor.MAX_EXCEL_RESULT_ROWS 同值） */
+const MAX_EXCEL_RESULT_ROWS = 500
+/** excel_search 展示的命中上限（与 officeExecutor.MAX_SEARCH_HITS 同值） */
+const MAX_SEARCH_HITS = 20
+
+/** XlHAlign：horizontalAlignment 小写短名 → 数值 */
+const ET_H_ALIGN = { left: -4131, center: -4108, right: -4152 }
+/** XlVAlign：verticalAlignment 小写短名 → 数值（契约的 middle 对应 xlVAlignCenter） */
+const ET_V_ALIGN = { top: -4160, middle: -4108, bottom: -4107 }
+
+/** XlBordersIndex */
+const ET_BORDER_INDEX = {
+  EdgeTop: 8, EdgeBottom: 9, EdgeLeft: 7, EdgeRight: 10,
+  InsideVertical: 11, InsideHorizontal: 12
+}
+/** borders → 参与的边集合（none 复用 all 的边去清空），键名与 Office 版同表 */
+const ET_BORDER_LOCATIONS = {
+  all: ['EdgeTop', 'EdgeBottom', 'EdgeLeft', 'EdgeRight', 'InsideHorizontal', 'InsideVertical'],
+  outside: ['EdgeTop', 'EdgeBottom', 'EdgeLeft', 'EdgeRight'],
+  inside: ['InsideHorizontal', 'InsideVertical']
+}
+/** XlBorderWeight：style 小写短名 → 数值 */
+const ET_BORDER_WEIGHTS = { thin: 2, medium: -4138, thick: 4 }
+/** XlLineStyle */
+const xlContinuous = 1
+const xlLineStyleNone = -4142
+
+/** XlInsertShiftDirection / XlDeleteShiftDirection */
+const xlShiftDown = -4121
+const xlShiftUp = -4162
+const xlShiftToRight = -4161
+const xlShiftToLeft = -4159
+
+/** XlSortOrder / XlYesNoGuess */
+const xlAscending = 1
+const xlDescending = 2
+const xlYes = 1
+const xlNo = 2
+
+/** XlFormatConditionType / XlFormatConditionOperator（数据验证的 Operator 复用同一枚举） */
+const xlCellValue = 1
+const xlBetween = 1
+const ET_CF_OPERATORS = { greaterthan: 5, lessthan: 6, between: xlBetween, equalto: 3 }
+
+/** XlDVType / XlDVAlertStyle */
+const ET_DV_TYPES = { wholenumber: 1, list: 3, date: 4 }
+const xlValidAlertStop = 1
+
+/** XlChartType：chartType 小写短名 → 数值（v1 起步四种，与 Office 版同集） */
+const ET_CHART_TYPES = { column: 51 /* xlColumnClustered */, line: 4 /* xlLine */, pie: 5 /* xlPie */, bar: 57 /* xlBarClustered */ }
+
+/** XlPivotTableSourceType / XlPivotFieldOrientation */
+const xlDatabase = 1
+const xlRowField = 1
+
+/** 合法 action 清单（校验文案与 Office 版同腔调） */
+const ET_EDIT_ROWS_COLS_ACTIONS = ['insert_rows', 'delete_rows', 'insert_cols', 'delete_cols', 'set_width', 'set_height']
+const ET_MERGE_ACTIONS = ['merge', 'unmerge']
+const ET_SHEET_ACTIONS = ['add', 'rename', 'delete', 'move', 'activate']
+const ET_FREEZE_ACTIONS = ['freeze_rows', 'freeze_cols', 'freeze_at', 'unfreeze']
+const ET_AUTOFILTER_ACTIONS = ['apply', 'clear', 'remove']
+
+/**
+ * 列宽单位换算：Office 版契约 size 单位是磅，WPS ColumnWidth 单位是标准字体
+ * 字符宽（VBA 语义）。换算依据：Excel 默认列宽 8.43 字符 = 48 磅，
+ * 即 1 字符 ≈ 48 / 8.43 ≈ 5.69 磅。行高两边都是磅，直落无需换算。
+ */
+const POINTS_PER_CHAR = 5.69
+
+/** colorScale 默认三色刻度色（低到高：红-黄-绿），与 Office 版视觉口径一致 */
+const ET_CF_COLOR_SCALE_HEX = ['#F8696B', '#FFEB84', '#63BE7B']
+
+/* ==================== HANDLERS ==================== */
+
+export const WPS_ET_HANDLERS = {
+
+  // ==================== 读写/查找 ====================
+
+  async excel_get_range(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    const sheet = resolveSheet(sheetName)
+    const name = String(sheet.Name)
+    const rng = rangeAddress ? sheet.Range(rangeAddress) : sheet.UsedRange
+    if (!rangeAddress && usedRangeIsEmpty(rng)) {
+      return { sheet: name, address: '', rows: 0, cols: 0, values: [], note: '工作表为空' }
+    }
+    if (!rng) throw new Error(`无法解析区域：${rangeAddress}`)
+    let values = read2D(rng)
+    let truncated = false
+    if (values.length > MAX_EXCEL_RESULT_ROWS) {
+      values = values.slice(0, MAX_EXCEL_RESULT_ROWS)
+      truncated = true
+    }
+    return {
+      sheet: name,
+      address: rng.Address(false, false),
+      rows: rng.Rows.Count,
+      cols: rng.Columns.Count,
+      values,
+      truncated
+    }
+  },
+
+  async excel_set_values(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    const values = args.values
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    if (!Array.isArray(values) || !values.length || !Array.isArray(values[0])) {
+      throw new Error('values 必须是非空二维数组')
+    }
+    const sheet = resolveSheet(sheetName)
+    let rng = sheet.Range(rangeAddress)
+    const rows = values.length
+    const cols = values[0].length
+    const rngRows = rng.Rows.Count
+    const rngCols = rng.Columns.Count
+    if (rngRows === 1 && rngCols === 1 && (rows > 1 || cols > 1)) {
+      // 单元格起点：按 values 尺寸向右下展开（Resize 带参属性按函数调用）
+      rng = rng.Resize(rows, cols)
+    } else if (rngRows !== rows || rngCols !== cols) {
+      throw new Error(`区域尺寸（${rngRows}x${rngCols}）与 values 尺寸（${rows}x${cols}）不一致`)
+    }
+    // 赋值只能走 Value2（JSAPI 里 Value 是只读方法）；二维数组一次性写入
+    rng.Value2 = values
+    return { written: rows * cols, address: rng.Address(false, false) }
+  },
+
+  async excel_search(args) {
+    const query = String(args.query || '')
+    const sheetName = String(args.sheetName || '')
+    if (!query) throw new Error('查找文本不能为空')
+    const sheet = resolveSheet(sheetName)
+    const name = String(sheet.Name)
+    const used = sheet.UsedRange
+    if (usedRangeIsEmpty(used)) return { sheet: name, count: 0, matches: [] }
+    const values = read2D(used)
+    // WPS 的 Row/Column 是 1 起，cellAddress 收 0 起——先归零再拼
+    const baseRow = used.Row - 1
+    const baseCol = used.Column - 1
+    const needle = query.toLowerCase()
+    const matches = []
+    let count = 0
+    for (let r = 0; r < values.length; r++) {
+      const row = values[r] || []
+      for (let c = 0; c < row.length; c++) {
+        const cell = row[c]
+        if (cell == null) continue
+        const text = String(cell)
+        if (text.toLowerCase().includes(needle)) {
+          count++
+          if (matches.length < MAX_SEARCH_HITS) {
+            matches.push({ address: cellAddress(baseRow + r, baseCol + c), value: text.slice(0, 500) })
+          }
+        }
+      }
+    }
+    return { sheet: name, count, shown: matches.length, matches }
+  },
+
+  // ==================== 格式/结构 ====================
+
+  async excel_format_cells(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const sheet = resolveSheet(sheetName)
+    const rng = sheet.Range(rangeAddress)
+    const applied = {}
+    if (args.fontName) { rng.Font.Name = String(args.fontName); applied.fontName = args.fontName }
+    if (args.fontSize != null) { rng.Font.Size = Number(args.fontSize); applied.fontSize = args.fontSize }
+    if (args.bold != null) { rng.Font.Bold = !!args.bold; applied.bold = !!args.bold }
+    if (args.italic != null) { rng.Font.Italic = !!args.italic; applied.italic = !!args.italic }
+    if (args.fontColor) { rng.Font.Color = hexToBgr(args.fontColor); applied.fontColor = args.fontColor }
+    if (args.fillColor) { rng.Interior.Color = hexToBgr(args.fillColor); applied.fillColor = args.fillColor }
+    if (args.horizontalAlignment) {
+      const key = String(args.horizontalAlignment).trim().toLowerCase()
+      const v = ET_H_ALIGN[key]
+      if (!v) throw new Error(`horizontalAlignment 值非法：${args.horizontalAlignment}（合法值：${Object.keys(ET_H_ALIGN).join('/')}）`)
+      rng.HorizontalAlignment = v
+      applied.horizontalAlignment = key
+    }
+    if (args.verticalAlignment) {
+      const key = String(args.verticalAlignment).trim().toLowerCase()
+      const v = ET_V_ALIGN[key]
+      if (!v) throw new Error(`verticalAlignment 值非法：${args.verticalAlignment}（合法值：${Object.keys(ET_V_ALIGN).join('/')}）`)
+      rng.VerticalAlignment = v
+      applied.verticalAlignment = key
+    }
+    if (args.wrapText != null) { rng.WrapText = !!args.wrapText; applied.wrapText = !!args.wrapText }
+    if (args.numberFormat) {
+      // WPS 的 NumberFormat 单字符串作用于整区域（无需像 Office.js 铺二维数组）；
+      // 用英文格式代码（"General"/"0.00" 等），与 NumberFormatLocal 是两个口径
+      const fmt = String(args.numberFormat)
+      rng.NumberFormat = fmt
+      applied.numberFormat = fmt
+    }
+    return { address: rng.Address(false, false), applied }
+  },
+
+  async excel_set_borders(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const borders = String(args.borders || '').trim().toLowerCase()
+    if (borders !== 'none' && !ET_BORDER_LOCATIONS[borders]) {
+      throw new Error(`borders 值非法：${args.borders}（合法值：all/outside/inside/none）`)
+    }
+    const style = String(args.style || 'thin').trim().toLowerCase()
+    const weight = ET_BORDER_WEIGHTS[style] || ET_BORDER_WEIGHTS.thin
+    const color = String(args.color || '#000000')
+    const colorBgr = hexToBgr(color)
+    const sheet = resolveSheet(sheetName)
+    const rng = sheet.Range(rangeAddress)
+    const ids = borders === 'none' ? ET_BORDER_LOCATIONS.all : ET_BORDER_LOCATIONS[borders]
+    for (const id of ids) {
+      const b = rng.Borders.Item(ET_BORDER_INDEX[id])
+      if (borders === 'none') {
+        b.LineStyle = xlLineStyleNone
+      } else {
+        b.LineStyle = xlContinuous
+        b.Weight = weight
+        b.Color = colorBgr
+      }
+    }
+    const result = { address: rng.Address(false, false), borders }
+    if (borders !== 'none') {
+      result.style = ET_BORDER_WEIGHTS[style] ? style : 'thin'
+      result.color = color
+    }
+    return result
+  },
+
+  async excel_edit_rows_cols(args) {
+    const action = String(args.action || '').trim().toLowerCase()
+    if (!ET_EDIT_ROWS_COLS_ACTIONS.includes(action)) {
+      throw new Error(`action 值非法：${args.action}（合法值：${ET_EDIT_ROWS_COLS_ACTIONS.join('/')}）`)
+    }
+    const index = Math.floor(Number(args.index))
+    if (!Number.isFinite(index) || index < 0) throw new Error('index 不能为负')
+    let count = args.count == null ? 1 : Math.floor(Number(args.count))
+    if (!Number.isFinite(count) || count < 1) count = 1
+    const needsSize = action === 'set_width' || action === 'set_height'
+    let size = null
+    if (needsSize) {
+      size = Number(args.size)
+      if (!Number.isFinite(size) || size <= 0) throw new Error('size 须为正数')
+    }
+    const sheet = resolveSheet(String(args.sheetName || ''))
+    const isRowAction = action === 'insert_rows' || action === 'delete_rows' || action === 'set_height'
+    const range = isRowAction
+      ? sheet.Rows.Item(`${index + 1}:${index + count}`)
+      : sheet.Columns.Item(`${columnLetter(index)}:${columnLetter(index + count - 1)}`)
+    const result = { action, index, count }
+    if (action === 'insert_rows') range.Insert(xlShiftDown)
+    else if (action === 'delete_rows') range.Delete(xlShiftUp)
+    else if (action === 'insert_cols') range.Insert(xlShiftToRight)
+    else if (action === 'delete_cols') range.Delete(xlShiftToLeft)
+    else if (action === 'set_width') {
+      // 契约 size 单位是磅（对齐 Office 版），WPS ColumnWidth 是字符宽——按 1 字符≈5.69 磅折算
+      range.ColumnWidth = size / POINTS_PER_CHAR
+      result.size = size
+      result.note = `列宽已按 1 字符宽≈${POINTS_PER_CHAR} 磅折算写入（${size} 磅 ≈ ${(size / POINTS_PER_CHAR).toFixed(2)} 字符宽）`
+    } else if (action === 'set_height') {
+      // 行高两边单位都是磅，直落
+      range.RowHeight = size
+      result.size = size
+    }
+    return result
+  },
+
+  async excel_merge_cells(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const action = String(args.action || '').trim().toLowerCase()
+    if (!ET_MERGE_ACTIONS.includes(action)) {
+      throw new Error(`action 值非法：${args.action}（合法值：merge/unmerge）`)
+    }
+    const sheet = resolveSheet(sheetName)
+    const rng = sheet.Range(rangeAddress)
+    // merge 丢弃非左上角值时 ET 可能弹提示，统一抑制
+    withAlertsSuppressed(() => {
+      if (action === 'merge') rng.Merge()
+      else rng.UnMerge()
+    })
+    return { address: rng.Address(false, false), action }
+  },
+
+  async excel_sort_range(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const keyColumn = Math.floor(Number(args.keyColumn))
+    if (!Number.isFinite(keyColumn) || keyColumn < 0) throw new Error('keyColumn 不能为负')
+    const ascending = args.ascending !== false
+    const hasHeader = !!args.hasHeader
+    const sheet = resolveSheet(sheetName)
+    const rng = sheet.Range(rangeAddress)
+    // Key1 收 Range 对象（不收数字下标）：区域内相对列 0 起 → Columns.Item 1 起
+    const keyRng = rng.Columns.Item(keyColumn + 1)
+    // Range.Sort(Key1, Order1, Key2, Type, Order2, Key3, Order3, Header, ...)，可选参数 null 占位
+    rng.Sort(keyRng, ascending ? xlAscending : xlDescending,
+      null, null, null, null, null,
+      hasHeader ? xlYes : xlNo)
+    return { address: rng.Address(false, false), keyColumn, ascending, hasHeader }
+  },
+
+  async excel_manage_sheets(args) {
+    const action = String(args.action || '').trim().toLowerCase()
+    if (!ET_SHEET_ACTIONS.includes(action)) {
+      throw new Error(`action 值非法：${args.action}（合法值：${ET_SHEET_ACTIONS.join('/')}）`)
+    }
+    const sheetName = String(args.sheetName || '')
+    if (action !== 'add' && !sheetName) throw new Error('sheetName 不能为空')
+    const wb = app().ActiveWorkbook
+    if (!wb) throw new Error('当前没有打开的工作簿')
+    const sheets = wb.Worksheets
+    const result = { action }
+    let target
+    if (action === 'add') {
+      // WPS 的 Sheets.Add 无参默认插在活动表之前，显式 After 末表对齐 Office.js 的末尾追加
+      target = sheets.Add(null, sheets.Item(sheets.Count))
+      if (sheetName) target.Name = sheetName
+    } else if (action === 'delete') {
+      if (sheets.Count <= 1) {
+        throw new Error('无法删除：工作簿至少要保留一张工作表')
+      }
+      target = sheets.Item(sheetName)
+      // Worksheet.Delete 会弹确认对话框，必须抑制并 finally 恢复
+      withAlertsSuppressed(() => { target.Delete() })
+      return result
+    } else {
+      target = sheets.Item(sheetName)
+      if (action === 'rename') {
+        const newName = String(args.newName || '')
+        if (!newName) throw new Error('newName 不能为空')
+        target.Name = newName
+      } else if (action === 'move') {
+        const position = Math.floor(Number(args.position))
+        if (!Number.isFinite(position) || position < 0) throw new Error('position 不能为负')
+        // Move 必须给 Before/After 之一（都不给会移到新工作簿）；position 0 起
+        if (position === 0) target.Move(sheets.Item(1))
+        else target.Move(null, sheets.Item(Math.min(position, sheets.Count)))
+      } else if (action === 'activate') {
+        target.Activate()
+      }
+    }
+    // WPS 的 Index 是 1 起，出参减 1 对齐 Office.js 的 position 0 起
+    result.name = String(target.Name)
+    result.position = target.Index - 1
+    return result
+  },
+
+  async excel_freeze_panes(args) {
+    const action = String(args.action || '').trim().toLowerCase()
+    if (!ET_FREEZE_ACTIONS.includes(action)) {
+      throw new Error(`action 值非法：${args.action}（合法值：${ET_FREEZE_ACTIONS.join('/')}）`)
+    }
+    const sheetName = String(args.sheetName || '')
+    const sheet = resolveSheet(sheetName)
+    // 冻结是 Window 级状态，作用于活动表——指定表时先激活（与 Office.js 表级 API 的行为差异）
+    if (sheetName) sheet.Activate()
+    const win = app().ActiveWindow
+    if (action === 'unfreeze') {
+      win.FreezePanes = false
+      win.Split = false
+      return { action }
+    }
+    // 重设前先解除既有冻结，保证 SplitRow/SplitColumn 生效
+    win.FreezePanes = false
+    if (action === 'freeze_rows' || action === 'freeze_cols') {
+      let count = Math.floor(Number(args.count))
+      if (!Number.isFinite(count) || count < 1) count = 1
+      if (action === 'freeze_rows') { win.SplitRow = count; win.SplitColumn = 0 }
+      else { win.SplitColumn = count; win.SplitRow = 0 }
+      win.FreezePanes = true
+      return { action, count }
+    }
+    // freeze_at：冻结指定单元格左上方区域，折算成 SplitRow/SplitColumn（免依赖选区语义）
+    const cellAddr = String(args.cellAddress || '')
+    if (!cellAddr) throw new Error('cellAddress 不能为空')
+    const { row, col } = parseCellRef(cellAddr)
+    win.SplitRow = row - 1
+    win.SplitColumn = col - 1
+    win.FreezePanes = true
+    return { action, cellAddress: cellAddr }
+  },
+
+  async excel_set_formulas(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    const formulas = args.formulas
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    if (!Array.isArray(formulas) || !formulas.length || !Array.isArray(formulas[0])) {
+      throw new Error('formulas 必须是非空二维数组')
+    }
+    const sheet = resolveSheet(sheetName)
+    let rng = sheet.Range(rangeAddress)
+    const rows = formulas.length
+    const cols = formulas[0].length
+    const rngRows = rng.Rows.Count
+    const rngCols = rng.Columns.Count
+    if (rngRows === 1 && rngCols === 1 && (rows > 1 || cols > 1)) {
+      rng = rng.Resize(rows, cols)
+    } else if (rngRows !== rows || rngCols !== cols) {
+      throw new Error(`区域尺寸（${rngRows}x${rngCols}）与 formulas 尺寸（${rows}x${cols}）不一致`)
+    }
+    // Formula 属性走 en-US 文法（逗号分隔、英文函数名、跨表 'Sheet name'!A1），与 Office 版直通
+    rng.Formula = formulas
+    // 写入后读回 Value2 批量扫描 # 开头的错误值（#DIV/0! 等），契约同 officeExecutor
+    const values = read2D(rng)
+    const baseRow = rng.Row - 1
+    const baseCol = rng.Column - 1
+    const formulaErrors = []
+    for (let r = 0; r < values.length; r++) {
+      const row = values[r] || []
+      for (let c = 0; c < row.length; c++) {
+        const v = row[c]
+        if (typeof v === 'string' && v.startsWith('#')) {
+          formulaErrors.push({ address: cellAddress(baseRow + r, baseCol + c), value: v })
+        }
+      }
+    }
+    const result = { written: rows * cols, address: rng.Address(false, false) }
+    if (formulaErrors.length) result.formulaErrors = formulaErrors
+    return result
+  },
+
+  async excel_get_overview() {
+    const wb = app().ActiveWorkbook
+    if (!wb) throw new Error('当前没有打开的工作簿')
+    const activeName = String(wb.ActiveSheet.Name)
+    const n = wb.Worksheets.Count
+    const sheets = []
+    for (let i = 1; i <= n; i++) {
+      const s = wb.Worksheets.Item(i)
+      const u = s.UsedRange
+      sheets.push({
+        name: String(s.Name),
+        active: String(s.Name) === activeName,
+        usedRange: usedRangeIsEmpty(u)
+          ? null
+          : { address: u.Address(false, false), rows: u.Rows.Count, cols: u.Columns.Count }
+      })
+    }
+    return { sheetCount: n, sheets }
+  },
+
+  async excel_select_range(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const sheet = resolveSheet(sheetName)
+    // 跨表 Select 必须先激活目标表，否则报错
+    if (sheetName) sheet.Activate()
+    const rng = sheet.Range(rangeAddress)
+    rng.Select()
+    return { address: rng.Address(false, false) }
+  },
+
+  async excel_set_autofilter(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    const action = String(args.action || '').trim().toLowerCase()
+    if (!ET_AUTOFILTER_ACTIONS.includes(action)) {
+      throw new Error(`action 值非法：${args.action}（合法值：apply/clear/remove）`)
+    }
+    if (action === 'apply' && !rangeAddress) throw new Error('apply 需要 rangeAddress')
+    const sheet = resolveSheet(sheetName)
+    if (action === 'apply') {
+      // 无参 AutoFilter() 是「切换」语义——先撤掉既有箭头再套，保证幂等为「开」
+      sheet.AutoFilterMode = false
+      sheet.Range(rangeAddress).AutoFilter()
+    } else if (action === 'clear') {
+      // ShowAllData 在无筛选条件时报错，先查 FilterMode（与 AutoFilterMode 互相独立）
+      if (sheet.FilterMode) sheet.ShowAllData()
+    } else {
+      sheet.AutoFilterMode = false
+    }
+    const result = { action }
+    if (action === 'apply') result.rangeAddress = rangeAddress
+    return result
+  },
+
+  async excel_conditional_format(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const action = String(args.action || 'apply').trim().toLowerCase()
+    const sheet = resolveSheet(sheetName)
+    const fcs = sheet.Range(rangeAddress).FormatConditions
+    if (action === 'clearall') {
+      fcs.Delete()
+      return { action: 'clearAll' }
+    }
+    // apply：每次先清空该区域现有规则再套用新规则，不叠加（与 Office 版同口径）
+    fcs.Delete()
+    const ruleType = String(args.ruleType || '').trim().toLowerCase()
+    if (ruleType === 'cellvalue') {
+      const operator = ET_CF_OPERATORS[String(args.operator || '').trim().toLowerCase()]
+      if (!operator) throw new Error(`operator 值非法：${args.operator}（合法值：greaterThan/lessThan/between/equalTo）`)
+      const fc = operator === xlBetween
+        ? fcs.Add(xlCellValue, operator, String(args.value1), String(args.value2))
+        : fcs.Add(xlCellValue, operator, String(args.value1))
+      fc.Interior.Color = hexToBgr(String(args.fillColor || '#FFC7CE'))
+    } else if (ruleType === 'colorscale') {
+      const cs = fcs.AddColorScale(3)
+      // ColorScaleCriteria 精调是类推用法，真机若不通降级为 ET 默认三色刻度
+      try {
+        for (let i = 0; i < 3; i++) {
+          cs.ColorScaleCriteria.Item(i + 1).FormatColor.Color = hexToBgr(ET_CF_COLOR_SCALE_HEX[i])
+        }
+      } catch (e) {
+        // 保持 ET 默认三色刻度，视觉与桌面端略有偏差
+      }
+    } else {
+      throw new Error(`ruleType 值非法：${args.ruleType}（合法值：cellValue/colorScale）`)
+    }
+    return { action: 'apply', ruleType }
+  },
+
+  // ==================== 批注（WPS 只有老式单条 Comment，无线程/回复/解决语义） ====================
+
+  async excel_add_comment(args) {
+    const sheetName = String(args.sheetName || '')
+    const cellAddr = String(args.cellAddress || '')
+    const comment = String(args.comment || '')
+    if (!cellAddr) throw new Error('cellAddress 不能为空')
+    if (!comment) throw new Error('批注内容不能为空')
+    const sheet = resolveSheet(sheetName)
+    const rng = sheet.Range(cellAddr)
+    // 已有批注时 AddComment 会报错，先删旧的（覆盖语义）
+    const existing = rng.Comment
+    if (existing) existing.Delete()
+    rng.AddComment(comment)
+    return { cellAddress: cellAddr, added: true }
+  },
+
+  async excel_get_comments(args) {
+    const scope = args.scope === 'workbook' ? 'workbook' : 'sheet'
+    const wb = app().ActiveWorkbook
+    if (!wb) throw new Error('当前没有打开的工作簿')
+    const targets = []
+    if (scope === 'workbook') {
+      const n = wb.Worksheets.Count
+      for (let i = 1; i <= n; i++) targets.push(wb.Worksheets.Item(i))
+    } else {
+      targets.push(resolveSheet(String(args.sheetName || '')))
+    }
+    const comments = []
+    for (const sheet of targets) {
+      const cms = sheet.Comments
+      const count = cms ? cms.Count : 0
+      for (let i = 1; i <= count; i++) {
+        const c = cms.Item(i)
+        const entry = {
+          cellAddress: c.Parent.Address(false, false),
+          content: String(c.Text() || ''),
+          author: String(c.Author || ''),
+          // WPS 老式批注没有创建时间/解决状态/回复模型，按契约字段降级为恒定值
+          createdAt: null,
+          resolved: false,
+          replies: []
+        }
+        if (scope === 'workbook') entry.sheet = String(sheet.Name)
+        comments.push(entry)
+      }
+    }
+    return { count: comments.length, comments }
+  },
+
+  async excel_reply_comment(args) {
+    const sheetName = String(args.sheetName || '')
+    const cellAddr = String(args.cellAddress || '')
+    const reply = String(args.reply || '')
+    if (!cellAddr) throw new Error('cellAddress 不能为空')
+    if (!reply) throw new Error('回复内容不能为空')
+    const sheet = resolveSheet(sheetName)
+    const c = sheet.Range(cellAddr).Comment
+    if (!c) throw new Error('该单元格没有批注')
+    // 降级实现：WPS 老式批注无回复模型，把回复追加为批注正文的一行
+    const existing = String(c.Text() || '')
+    c.Text(existing + '\n回复：' + reply)
+    return { cellAddress: cellAddr, replied: true, via: 'appendText' }
+  },
+
+  async excel_resolve_comment() {
+    // WPS 老式批注对象没有 resolved 语义（无线程批注模型），明确报不支持
+    throw new Error('WPS 表格批注不支持标记解决')
+  },
+
+  async excel_delete_comment(args) {
+    const sheetName = String(args.sheetName || '')
+    const cellAddr = String(args.cellAddress || '')
+    if (!cellAddr) throw new Error('cellAddress 不能为空')
+    const sheet = resolveSheet(sheetName)
+    const c = sheet.Range(cellAddr).Comment
+    if (!c) throw new Error('该单元格没有批注')
+    c.Delete()
+    return { cellAddress: cellAddr, deleted: true }
+  },
+
+  // ==================== 数据验证 ====================
+
+  async excel_set_data_validation(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    const action = String(args.action || 'apply').trim().toLowerCase()
+    if (!rangeAddress) throw new Error('区域地址不能为空')
+    const sheet = resolveSheet(sheetName)
+    const rng = sheet.Range(rangeAddress)
+    const v = rng.Validation
+    if (action === 'clear') {
+      v.Delete()
+      return { action: 'clear' }
+    }
+    const type = String(args.type || '').trim().toLowerCase()
+    // 已有规则时 Add 会报错，先删旧规则
+    v.Delete()
+    if (type === 'list') {
+      const source = String(args.listSource || '')
+      if (!source) throw new Error('type=list 时 listSource 不能为空')
+      // Formula1 = 逗号分隔值列表 或 "=$A$1:$A$5" 工作表引用；Operator 对 list 无实义，按官方示例传 xlBetween 占位
+      v.Add(ET_DV_TYPES.list, xlValidAlertStop, xlBetween, source)
+      v.InCellDropdown = true
+    } else if (type === 'wholenumber' || type === 'date') {
+      const operator = ET_CF_OPERATORS[String(args.operator || '').trim().toLowerCase()]
+      if (!operator) throw new Error(`operator 值非法：${args.operator}`)
+      if (operator === ET_CF_OPERATORS.between) {
+        v.Add(ET_DV_TYPES[type], xlValidAlertStop, operator, String(args.value1), String(args.value2))
+      } else {
+        v.Add(ET_DV_TYPES[type], xlValidAlertStop, operator, String(args.value1))
+      }
+    } else {
+      throw new Error(`type 值非法：${args.type}（合法值：wholeNumber/list/date）`)
+    }
+    return { action: 'apply', type, address: rng.Address(false, false) }
+  },
+
+  // ==================== 图表 ====================
+
+  async excel_add_chart(args) {
+    const sheetName = String(args.sheetName || '')
+    const dataRangeAddress = String(args.dataRangeAddress || '')
+    if (!dataRangeAddress) throw new Error('数据源区域不能为空')
+    const typeKey = String(args.chartType || '').trim().toLowerCase()
+    const chartType = ET_CHART_TYPES[typeKey]
+    if (!chartType) throw new Error(`chartType 值非法：${args.chartType}（合法值：column/line/pie/bar）`)
+    const sheet = resolveSheet(sheetName)
+    // ChartObjects 是方法（带括号）；Add(Left, Top, Width, Height) 四参必选，单位磅
+    const co = sheet.ChartObjects().Add(50, 40, 360, 220)
+    const chart = co.Chart
+    chart.SetSourceData(sheet.Range(dataRangeAddress))
+    chart.ChartType = chartType
+    if (args.title) {
+      // HasTitle 前置是硬要求（不置 true 直接设 ChartTitle 报错）
+      chart.HasTitle = true
+      chart.ChartTitle.Text = String(args.title)
+    }
+    return { added: true, name: String(co.Name), chartType: typeKey }
+  },
+
+  // ==================== 命名区域 ====================
+
+  async excel_define_name(args) {
+    const sheetName = String(args.sheetName || '')
+    const action = String(args.action || '').trim().toLowerCase()
+    const name = String(args.name || '')
+    if (!name) throw new Error('name 不能为空')
+    if (action !== 'add' && action !== 'remove') throw new Error(`action 值非法：${args.action}（合法值：add/remove）`)
+    const wb = app().ActiveWorkbook
+    if (!wb) throw new Error('当前没有打开的工作簿')
+    if (action === 'add') {
+      const rangeAddress = String(args.rangeAddress || '')
+      if (!rangeAddress) throw new Error('add 需要 rangeAddress')
+      const sheet = resolveSheet(sheetName)
+      const rng = sheet.Range(rangeAddress)
+      // RefersTo 走 A1 字符串路线（表名加引号防空格），Range 对象编组待真机验证
+      wb.Names.Add(name, "='" + String(sheet.Name) + "'!" + rng.Address())
+      return { action: 'add', name }
+    }
+    let nm
+    try {
+      nm = wb.Names.Item(name)
+    } catch (e) {
+      nm = null
+    }
+    if (!nm) throw new Error(`未找到命名区域：${name}`)
+    nm.Delete()
+    return { action: 'remove', name }
+  },
+
+  // ==================== 工作表保护 ====================
+
+  async excel_protect_sheet(args) {
+    const sheetName = String(args.sheetName || '')
+    const action = String(args.action || '').trim().toLowerCase()
+    const password = args.password ? String(args.password) : undefined
+    if (action !== 'protect' && action !== 'unprotect') throw new Error(`action 值非法：${args.action}（合法值：protect/unprotect）`)
+    const sheet = resolveSheet(sheetName)
+    if (action === 'protect') {
+      sheet.Protect(password)
+    } else {
+      // 有密码保护且不传密码时 ET 会弹输入框，密码错误抛异常照透传
+      sheet.Unprotect(password)
+    }
+    return { action }
+  },
+
+  // ==================== 行列分组 ====================
+
+  async excel_group_rows_cols(args) {
+    const sheetName = String(args.sheetName || '')
+    const rangeAddress = String(args.rangeAddress || '')
+    const action = String(args.action || '').trim().toLowerCase()
+    const by = String(args.by || '').trim().toLowerCase()
+    if (!rangeAddress) throw new Error('rangeAddress 不能为空')
+    if (action !== 'group' && action !== 'ungroup') throw new Error(`action 值非法：${args.action}（合法值：group/ungroup）`)
+    if (by !== 'rows' && by !== 'cols') throw new Error(`by 值非法：${args.by}（合法值：rows/cols）`)
+    const sheet = resolveSheet(sheetName)
+    // 大纲分组要求整行/整列区域，EntireRow/EntireColumn 归一化后 "A1:C5"/"2:5"/"C:E" 皆合法
+    const target = by === 'rows'
+      ? sheet.Range(rangeAddress).EntireRow
+      : sheet.Range(rangeAddress).EntireColumn
+    if (action === 'group') target.Group()
+    else target.Ungroup()
+    return { action, by }
+  },
+
+  // ==================== 透视表 ====================
+
+  async excel_add_pivot_table(args) {
+    const sheetName = String(args.sheetName || '')
+    const sourceRangeAddress = String(args.sourceRangeAddress || '')
+    const destinationCellAddress = String(args.destinationCellAddress || '')
+    const rowFields = Array.isArray(args.rowFields) ? args.rowFields : []
+    const valueFields = Array.isArray(args.valueFields) ? args.valueFields : []
+    if (!sourceRangeAddress) throw new Error('sourceRangeAddress 不能为空')
+    if (!destinationCellAddress) throw new Error('destinationCellAddress 不能为空')
+    if (!rowFields.length) throw new Error('rowFields 不能为空')
+    if (!valueFields.length) throw new Error('valueFields 不能为空')
+    const wb = app().ActiveWorkbook
+    if (!wb) throw new Error('当前没有打开的工作簿')
+    const sheet = resolveSheet(sheetName)
+    // 真机验证清单第二位：PivotCaches().Create → CreatePivotTable → 字段编排编组链最长，
+    // 任何一环编组失败可能表现为 undefined 而非异常，写入后要读回校验
+    const src = "'" + String(sheet.Name) + "'!" + sourceRangeAddress
+    // PivotCaches 是方法不是属性（带括号）；Version 省略 = xlPivotTableVersion12
+    const cache = wb.PivotCaches().Create(xlDatabase, src)
+    const name = args.pivotName ? String(args.pivotName) : `PivotTable_${Date.now()}`
+    const pivot = cache.CreatePivotTable(sheet.Range(destinationCellAddress), name)
+    if (!pivot) throw new Error('透视表创建失败：CreatePivotTable 未返回对象')
+    for (const field of rowFields) {
+      const pf = pivotFieldOrThrow(pivot, field)
+      pf.Orientation = xlRowField
+    }
+    for (const field of valueFields) {
+      pivot.AddDataField(pivotFieldOrThrow(pivot, field))
+    }
+    return { added: true, name: String(pivot.Name || name), rowFields, valueFields }
+  }
+}
+
+/** 取透视表字段，取不到时给出与 Office 版同款的排障提示 */
+function pivotFieldOrThrow(pivot, field) {
+  let pf
+  try {
+    pf = pivot.PivotFields(String(field))
+  } catch (e) {
+    pf = null
+  }
+  if (!pf) {
+    throw new Error(`未找到透视表字段：${field}（字段名须与源区域首行列标题完全一致，可先用 office_excel_get_range 核对）`)
+  }
+  return pf
+}

--- a/office-addin/taskpane/lib/wpsEtHandlers.test.js
+++ b/office-addin/taskpane/lib/wpsEtHandlers.test.js
@@ -1,0 +1,799 @@
+/**
+ * wpsEtHandlers.js 的单元测试（node 自带 test runner，零依赖）：
+ *   node --test office-addin/taskpane/lib/wpsEtHandlers.test.js
+ *
+ * 手法：mock globalThis.wps（EtApplication 返回假对象模型），逐命令断言
+ * JSAPI 调用形态与返回值契约。重点盯三折算规则（.Item 函数调用/带参属性
+ * 函数化/赋值走 Value2）、颜色 BGR 转换、DisplayAlerts 抑制与恢复、
+ * 批注降级路径、先清后套等 WPS 特有行为。真机行为（Value2 编组形状等）
+ * 无法在此覆盖，见 wpsEtHandlers.js 文件头的真机验证要点。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { WPS_ET_HANDLERS, hexToBgr, bgrToHex } from './wpsEtHandlers.js'
+
+/* ==================== mock 工具 ==================== */
+
+/** 造一个假 Application：DisplayAlerts 带 setter 日志，供抑制/恢复断言 */
+function makeApp({ workbook, window: win } = {}) {
+  const alertsLog = []
+  let alerts = true
+  const appObj = { ActiveWorkbook: workbook, ActiveWindow: win, _alertsLog: alertsLog }
+  Object.defineProperty(appObj, 'DisplayAlerts', {
+    get() { return alerts },
+    set(v) { alerts = v; alertsLog.push(v) }
+  })
+  return appObj
+}
+
+/** 安装 globalThis.wps，返回恢复函数 */
+function installWps(appObj) {
+  const original = globalThis.wps
+  globalThis.wps = { EtApplication: () => appObj }
+  return () => {
+    if (original === undefined) delete globalThis.wps
+    else globalThis.wps = original
+  }
+}
+
+/** 造一个假 Range（属性按需覆写） */
+function makeRange(overrides = {}) {
+  const rng = {
+    Rows: { Count: 1 },
+    Columns: { Count: 1, Item() { return makeRange() } },
+    Row: 1,
+    Column: 1,
+    Value2: undefined,
+    Address() { return 'A1' },
+    Font: {},
+    Interior: {},
+    ...overrides
+  }
+  return rng
+}
+
+/** 造一个假工作表 */
+function makeSheet(name, overrides = {}) {
+  return { Name: name, ...overrides }
+}
+
+/** 造 Worksheets 集合（按 1 起下标或名字取） */
+function makeSheetsCollection(sheetList) {
+  return {
+    get Count() { return sheetList.length },
+    Item(key) {
+      if (typeof key === 'number') return sheetList[key - 1]
+      const found = sheetList.find((s) => s.Name === key)
+      if (!found) throw new Error(`未找到工作表：${key}`)
+      return found
+    }
+  }
+}
+
+/** 一条龙：单表工作簿环境，返回 {appObj, sheet, restore} */
+function makeSingleSheetEnv(sheetOverrides = {}, appOverrides = {}) {
+  const sheet = makeSheet('Sheet1', sheetOverrides)
+  const workbook = {
+    ActiveSheet: sheet,
+    Worksheets: makeSheetsCollection([sheet])
+  }
+  const appObj = makeApp({ workbook, ...appOverrides })
+  const restore = installWps(appObj)
+  return { appObj, sheet, workbook, restore }
+}
+
+/* ==================== 颜色转换纯函数 ==================== */
+
+test('hexToBgr：#RRGGBB 转 BGR 长整型（VBA RGB 字节序）', () => {
+  assert.equal(hexToBgr('#FF0000'), 0x0000ff)   // 纯红 = 255
+  assert.equal(hexToBgr('#00FF00'), 0x00ff00)   // 纯绿
+  assert.equal(hexToBgr('#0000FF'), 0xff0000)   // 纯蓝
+  assert.equal(hexToBgr('#336699'), 0x996633)
+  assert.equal(hexToBgr('FFFFFF'), 0xffffff)    // 容忍无 # 前缀
+})
+
+test('bgrToHex：反向转换与 hexToBgr 互逆', () => {
+  assert.equal(bgrToHex(hexToBgr('#F8696B')), '#F8696B')
+  assert.equal(bgrToHex(0x0000ff), '#FF0000')
+  assert.equal(bgrToHex(0), '#000000')
+})
+
+test('hexToBgr：非法输入抛中文错误', () => {
+  assert.throws(() => hexToBgr('#FFF'), /颜色格式非法/)
+  assert.throws(() => hexToBgr('red'), /颜色格式非法/)
+})
+
+/* ==================== excel_get_range ==================== */
+
+test('excel_get_range：二维值批量读回与地址口径', async () => {
+  const rng = makeRange({
+    Rows: { Count: 2 },
+    Columns: { Count: 2 },
+    Value2: [[1, 'x'], [null, 2]],
+    Address(rowAbs, colAbs) {
+      assert.equal(rowAbs, false)
+      assert.equal(colAbs, false)
+      return 'A1:B2'
+    }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: (addr) => { assert.equal(addr, 'A1:B2'); return rng } })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_get_range({ rangeAddress: 'A1:B2' })
+    assert.deepEqual(out, {
+      sheet: 'Sheet1', address: 'A1:B2', rows: 2, cols: 2,
+      values: [[1, 'x'], [null, 2]], truncated: false
+    })
+  } finally { restore() }
+})
+
+test('excel_get_range：空工作表返回 note（UsedRange 退化为无值单格）', async () => {
+  const used = makeRange({ Value2: null })
+  const { restore } = makeSingleSheetEnv({ UsedRange: used })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_get_range({})
+    assert.equal(out.note, '工作表为空')
+    assert.equal(out.rows, 0)
+    assert.deepEqual(out.values, [])
+  } finally { restore() }
+})
+
+test('excel_get_range：单行一维返回被归一为二维', async () => {
+  const rng = makeRange({
+    Rows: { Count: 1 },
+    Columns: { Count: 3 },
+    Value2: [1, 2, 3],
+    Address() { return 'A1:C1' }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_get_range({ rangeAddress: 'A1:C1' })
+    assert.deepEqual(out.values, [[1, 2, 3]])
+  } finally { restore() }
+})
+
+/* ==================== excel_set_values ==================== */
+
+test('excel_set_values：二维数组整体经 Value2 写入', async () => {
+  const rng = makeRange({
+    Rows: { Count: 2 },
+    Columns: { Count: 2 },
+    Address() { return 'A1:B2' }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_set_values({ rangeAddress: 'A1:B2', values: [[1, 2], [3, 4]] })
+    assert.deepEqual(rng.Value2, [[1, 2], [3, 4]])
+    assert.deepEqual(out, { written: 4, address: 'A1:B2' })
+  } finally { restore() }
+})
+
+test('excel_set_values：单元格起点按 values 尺寸 Resize 展开', async () => {
+  const resized = makeRange({
+    Rows: { Count: 2 },
+    Columns: { Count: 2 },
+    Address() { return 'B2:C3' }
+  })
+  let resizeArgs = null
+  const rng = makeRange({
+    Rows: { Count: 1 },
+    Columns: { Count: 1 },
+    Resize(r, c) { resizeArgs = [r, c]; return resized }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_set_values({ rangeAddress: 'B2', values: [['a', 'b'], ['c', 'd']] })
+    assert.deepEqual(resizeArgs, [2, 2])
+    assert.deepEqual(resized.Value2, [['a', 'b'], ['c', 'd']])
+    assert.equal(out.address, 'B2:C3')
+  } finally { restore() }
+})
+
+test('excel_set_values：尺寸不一致与空参数的错误路径', async () => {
+  const rng = makeRange({ Rows: { Count: 3 }, Columns: { Count: 1 } })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_set_values({ rangeAddress: 'A1:A3', values: [[1, 2]] }),
+      /区域尺寸（3x1）与 values 尺寸（1x2）不一致/
+    )
+    await assert.rejects(WPS_ET_HANDLERS.excel_set_values({ values: [[1]] }), /区域地址不能为空/)
+    await assert.rejects(WPS_ET_HANDLERS.excel_set_values({ rangeAddress: 'A1', values: 'x' }), /values 必须是非空二维数组/)
+  } finally { restore() }
+})
+
+/* ==================== excel_search ==================== */
+
+test('excel_search：JS 层全表扫描，基址按 1 起 Row/Column 折算', async () => {
+  const used = makeRange({
+    Rows: { Count: 2 },
+    Columns: { Count: 2 },
+    Row: 2,
+    Column: 2,
+    Value2: [['hello', 'world'], ['HELLOX', 3]]
+  })
+  const { restore } = makeSingleSheetEnv({ UsedRange: used })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_search({ query: 'hello' })
+    assert.equal(out.count, 2)
+    assert.equal(out.shown, 2)
+    assert.deepEqual(out.matches.map((m) => m.address), ['B2', 'B3'])
+    assert.equal(out.sheet, 'Sheet1')
+  } finally { restore() }
+})
+
+test('excel_search：空查找串报错', async () => {
+  const { restore } = makeSingleSheetEnv({})
+  try {
+    await assert.rejects(WPS_ET_HANDLERS.excel_search({ query: '' }), /查找文本不能为空/)
+  } finally { restore() }
+})
+
+/* ==================== excel_format_cells ==================== */
+
+test('excel_format_cells：颜色转 BGR、对齐转数值枚举', async () => {
+  const rng = makeRange({ Address() { return 'A1:B2' } })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_format_cells({
+      rangeAddress: 'A1:B2',
+      fontColor: '#FF0000',
+      fillColor: '#0000FF',
+      bold: true,
+      horizontalAlignment: 'center',
+      verticalAlignment: 'middle',
+      numberFormat: '0.00'
+    })
+    assert.equal(rng.Font.Color, 0x0000ff)        // 红 → BGR 255
+    assert.equal(rng.Interior.Color, 0xff0000)    // 蓝 → BGR 16711680
+    assert.equal(rng.Font.Bold, true)
+    assert.equal(rng.HorizontalAlignment, -4108)  // xlHAlignCenter
+    assert.equal(rng.VerticalAlignment, -4108)    // xlVAlignCenter
+    assert.equal(rng.NumberFormat, '0.00')
+    assert.equal(out.applied.fontColor, '#FF0000')
+    assert.equal(out.applied.horizontalAlignment, 'center')
+  } finally { restore() }
+})
+
+test('excel_format_cells：非法对齐值报错', async () => {
+  const rng = makeRange({})
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_format_cells({ rangeAddress: 'A1', horizontalAlignment: 'justify' }),
+      /horizontalAlignment 值非法/
+    )
+  } finally { restore() }
+})
+
+/* ==================== excel_set_borders ==================== */
+
+test('excel_set_borders：outside 四边挂线，Borders.Item 收数值枚举', async () => {
+  const borderCalls = {}
+  const rng = makeRange({
+    Borders: {
+      Item(idx) {
+        borderCalls[idx] = borderCalls[idx] || {}
+        return borderCalls[idx]
+      }
+    },
+    Address() { return 'A1:C3' }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_set_borders({
+      rangeAddress: 'A1:C3', borders: 'outside', style: 'thick', color: '#00FF00'
+    })
+    // xlEdgeTop=8 / xlEdgeBottom=9 / xlEdgeLeft=7 / xlEdgeRight=10
+    assert.deepEqual(Object.keys(borderCalls).map(Number).sort((a, b) => a - b), [7, 8, 9, 10])
+    for (const b of Object.values(borderCalls)) {
+      assert.equal(b.LineStyle, 1)      // xlContinuous
+      assert.equal(b.Weight, 4)         // xlThick
+      assert.equal(b.Color, 0x00ff00)
+    }
+    assert.equal(out.style, 'thick')
+  } finally { restore() }
+})
+
+test('excel_set_borders：none 走六边清空；非法值报错', async () => {
+  const borderCalls = {}
+  const rng = makeRange({
+    Borders: { Item(idx) { borderCalls[idx] = borderCalls[idx] || {}; return borderCalls[idx] } },
+    Address() { return 'A1' }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    await WPS_ET_HANDLERS.excel_set_borders({ rangeAddress: 'A1', borders: 'none' })
+    assert.equal(Object.keys(borderCalls).length, 6)
+    for (const b of Object.values(borderCalls)) assert.equal(b.LineStyle, -4142)  // xlLineStyleNone
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_set_borders({ rangeAddress: 'A1', borders: 'diagonal' }),
+      /borders 值非法/
+    )
+  } finally { restore() }
+})
+
+/* ==================== excel_edit_rows_cols ==================== */
+
+test('excel_edit_rows_cols：列宽按 1 字符≈5.69 磅折算并 note 交底', async () => {
+  const colRange = {}
+  let colKey = null
+  const { restore } = makeSingleSheetEnv({
+    Columns: { Item(key) { colKey = key; return colRange } }
+  })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_edit_rows_cols({ action: 'set_width', index: 2, size: 48 })
+    assert.equal(colKey, 'C:C')
+    assert.ok(Math.abs(colRange.ColumnWidth - 48 / 5.69) < 1e-9)
+    assert.equal(out.size, 48)
+    assert.match(out.note, /5\.69 磅/)
+  } finally { restore() }
+})
+
+test('excel_edit_rows_cols：插行走 Rows.Item + Insert(xlShiftDown)', async () => {
+  let insertArg = null
+  let rowKey = null
+  const rowRange = { Insert(shift) { insertArg = shift } }
+  const { restore } = makeSingleSheetEnv({
+    Rows: { Item(key) { rowKey = key; return rowRange } }
+  })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_edit_rows_cols({ action: 'insert_rows', index: 1, count: 2 })
+    assert.equal(rowKey, '2:3')
+    assert.equal(insertArg, -4121)  // xlShiftDown
+    assert.deepEqual(out, { action: 'insert_rows', index: 1, count: 2 })
+  } finally { restore() }
+})
+
+/* ==================== excel_merge_cells ==================== */
+
+test('excel_merge_cells：Merge 前抑制弹窗、结束后恢复', async () => {
+  let merged = false
+  const rng = makeRange({ Merge() { merged = true }, Address() { return 'A1:B2' } })
+  const { appObj, restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_merge_cells({ rangeAddress: 'A1:B2', action: 'merge' })
+    assert.equal(merged, true)
+    assert.deepEqual(appObj._alertsLog, [false, true])   // 先抑制、后恢复
+    assert.equal(appObj.DisplayAlerts, true)
+    assert.deepEqual(out, { address: 'A1:B2', action: 'merge' })
+  } finally { restore() }
+})
+
+/* ==================== excel_sort_range ==================== */
+
+test('excel_sort_range：Key1 传区域内相对列 Range，Order/Header 用 VBA 数值', async () => {
+  let sortArgs = null
+  const keyRng = { _tag: 'keyRange' }
+  const rng = makeRange({
+    Columns: { Count: 3, Item(i) { assert.equal(i, 2); return keyRng } },
+    Sort(...args) { sortArgs = args },
+    Address() { return 'A1:C5' }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_sort_range({
+      rangeAddress: 'A1:C5', keyColumn: 1, ascending: false, hasHeader: true
+    })
+    assert.equal(sortArgs[0], keyRng)
+    assert.equal(sortArgs[1], 2)     // xlDescending
+    assert.deepEqual(sortArgs.slice(2, 7), [null, null, null, null, null])
+    assert.equal(sortArgs[7], 1)     // xlYes
+    assert.deepEqual(out, { address: 'A1:C5', keyColumn: 1, ascending: false, hasHeader: true })
+  } finally { restore() }
+})
+
+/* ==================== excel_manage_sheets ==================== */
+
+test('excel_manage_sheets：最后一张表拒删（可读中文错误）', async () => {
+  const { restore } = makeSingleSheetEnv({})
+  try {
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_manage_sheets({ action: 'delete', sheetName: 'Sheet1' }),
+      /无法删除：工作簿至少要保留一张工作表/
+    )
+  } finally { restore() }
+})
+
+test('excel_manage_sheets：删除时抑制确认弹窗，出错也 finally 恢复', async () => {
+  let deleted = false
+  const s1 = makeSheet('Sheet1', { Delete() { deleted = true } })
+  const s2 = makeSheet('Sheet2', { Delete() { throw new Error('删除被拒绝') } })
+  const workbook = { ActiveSheet: s1, Worksheets: makeSheetsCollection([s1, s2]) }
+  const appObj = makeApp({ workbook })
+  const restore = installWps(appObj)
+  try {
+    const out = await WPS_ET_HANDLERS.excel_manage_sheets({ action: 'delete', sheetName: 'Sheet1' })
+    assert.equal(deleted, true)
+    assert.deepEqual(appObj._alertsLog, [false, true])
+    assert.deepEqual(out, { action: 'delete' })
+    // Delete 抛异常时 DisplayAlerts 也必须恢复
+    appObj._alertsLog.length = 0
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_manage_sheets({ action: 'delete', sheetName: 'Sheet2' }),
+      /删除被拒绝/
+    )
+    assert.equal(appObj.DisplayAlerts, true)
+    assert.deepEqual(appObj._alertsLog, [false, true])
+  } finally { restore() }
+})
+
+test('excel_manage_sheets：add 显式 After 末表追加，位置出参 0 起', async () => {
+  let addArgs = null
+  const s1 = makeSheet('Sheet1', { Index: 1 })
+  const added = makeSheet('', { Index: 2 })
+  const sheetList = [s1]
+  const sheets = {
+    get Count() { return sheetList.length },
+    Item(key) { return typeof key === 'number' ? sheetList[key - 1] : sheetList.find((s) => s.Name === key) },
+    Add(before, after) { addArgs = [before, after]; sheetList.push(added); return added }
+  }
+  const workbook = { ActiveSheet: s1, Worksheets: sheets }
+  const restore = installWps(makeApp({ workbook }))
+  try {
+    const out = await WPS_ET_HANDLERS.excel_manage_sheets({ action: 'add', sheetName: '汇总' })
+    assert.deepEqual(addArgs, [null, s1])       // After = 原末表
+    assert.equal(added.Name, '汇总')
+    assert.deepEqual(out, { action: 'add', name: '汇总', position: 1 })
+  } finally { restore() }
+})
+
+/* ==================== excel_freeze_panes ==================== */
+
+test('excel_freeze_panes：freeze_rows / freeze_at / unfreeze 三态', async () => {
+  const win = {}
+  const { restore } = makeSingleSheetEnv({}, { window: win })
+  try {
+    let out = await WPS_ET_HANDLERS.excel_freeze_panes({ action: 'freeze_rows', count: 2 })
+    assert.equal(win.SplitRow, 2)
+    assert.equal(win.SplitColumn, 0)
+    assert.equal(win.FreezePanes, true)
+    assert.deepEqual(out, { action: 'freeze_rows', count: 2 })
+
+    out = await WPS_ET_HANDLERS.excel_freeze_panes({ action: 'freeze_at', cellAddress: 'C3' })
+    assert.equal(win.SplitRow, 2)      // 冻结 C3 左上 = 前 2 行
+    assert.equal(win.SplitColumn, 2)   // 前 2 列
+    assert.equal(win.FreezePanes, true)
+
+    out = await WPS_ET_HANDLERS.excel_freeze_panes({ action: 'unfreeze' })
+    assert.equal(win.FreezePanes, false)
+    assert.equal(win.Split, false)
+    assert.deepEqual(out, { action: 'unfreeze' })
+  } finally { restore() }
+})
+
+/* ==================== excel_set_formulas ==================== */
+
+test('excel_set_formulas：Formula 写入后读回 Value2 收集 # 错误值', async () => {
+  const rng = makeRange({
+    Rows: { Count: 1 },
+    Columns: { Count: 2 },
+    Row: 1,
+    Column: 1,
+    get Value2() { return ['#DIV/0!', 6] },   // 写入后的读回形态（单行一维，练归一化）
+    Address() { return 'A1:B1' }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_set_formulas({
+      rangeAddress: 'A1:B1', formulas: [['=1/0', '=2*3']]
+    })
+    assert.deepEqual(rng.Formula, [['=1/0', '=2*3']])
+    assert.equal(out.written, 2)
+    assert.deepEqual(out.formulaErrors, [{ address: 'A1', value: '#DIV/0!' }])
+  } finally { restore() }
+})
+
+/* ==================== excel_get_overview ==================== */
+
+test('excel_get_overview：逐表聚合，空表 usedRange 为 null', async () => {
+  const s1 = makeSheet('Sheet1', {
+    UsedRange: makeRange({ Rows: { Count: 3 }, Columns: { Count: 2 }, Value2: [[1]], Address() { return 'A1:B3' } })
+  })
+  const s2 = makeSheet('Sheet2', { UsedRange: makeRange({ Value2: null }) })
+  const workbook = { ActiveSheet: s1, Worksheets: makeSheetsCollection([s1, s2]) }
+  const restore = installWps(makeApp({ workbook }))
+  try {
+    const out = await WPS_ET_HANDLERS.excel_get_overview()
+    assert.equal(out.sheetCount, 2)
+    assert.deepEqual(out.sheets[0], { name: 'Sheet1', active: true, usedRange: { address: 'A1:B3', rows: 3, cols: 2 } })
+    assert.deepEqual(out.sheets[1], { name: 'Sheet2', active: false, usedRange: null })
+  } finally { restore() }
+})
+
+/* ==================== excel_set_autofilter ==================== */
+
+test('excel_set_autofilter：apply 先撤旧箭头再套（幂等为开）', async () => {
+  const calls = []
+  let filterCalled = false
+  const rng = makeRange({ AutoFilter() { filterCalled = true; calls.push('autofilter') } })
+  const sheet = makeSheet('Sheet1', { Range: () => rng })
+  Object.defineProperty(sheet, 'AutoFilterMode', {
+    set(v) { calls.push(['mode', v]) },
+    get() { return false }
+  })
+  const workbook = { ActiveSheet: sheet, Worksheets: makeSheetsCollection([sheet]) }
+  const restore = installWps(makeApp({ workbook }))
+  try {
+    const out = await WPS_ET_HANDLERS.excel_set_autofilter({ action: 'apply', rangeAddress: 'A1:C10' })
+    assert.deepEqual(calls, [['mode', false], 'autofilter'])
+    assert.equal(filterCalled, true)
+    assert.deepEqual(out, { action: 'apply', rangeAddress: 'A1:C10' })
+  } finally { restore() }
+})
+
+/* ==================== excel_conditional_format ==================== */
+
+test('excel_conditional_format：apply 先清后套，不叠加', async () => {
+  const calls = []
+  const fc = { Interior: {} }
+  const fcs = {
+    Delete() { calls.push('delete') },
+    Add(type, op, f1, f2) { calls.push(['add', type, op, f1, f2]); return fc }
+  }
+  const rng = makeRange({ FormatConditions: fcs })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_conditional_format({
+      rangeAddress: 'A1:A10', ruleType: 'cellValue', operator: 'greaterThan', value1: 10, fillColor: '#FF0000'
+    })
+    assert.deepEqual(calls, ['delete', ['add', 1, 5, '10', undefined]])  // 先 Delete 再 Add(xlCellValue, xlGreater)
+    assert.equal(fc.Interior.Color, 0x0000ff)
+    assert.deepEqual(out, { action: 'apply', ruleType: 'cellvalue' })
+  } finally { restore() }
+})
+
+test('excel_conditional_format：clearAll 只清不套', async () => {
+  const calls = []
+  const fcs = { Delete() { calls.push('delete') }, Add() { calls.push('add') } }
+  const rng = makeRange({ FormatConditions: fcs })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_conditional_format({ rangeAddress: 'A1:A10', action: 'clearAll' })
+    assert.deepEqual(calls, ['delete'])
+    assert.deepEqual(out, { action: 'clearAll' })
+  } finally { restore() }
+})
+
+/* ==================== 批注（降级路径） ==================== */
+
+test('excel_add_comment：已有批注先删再加（覆盖语义）', async () => {
+  let oldDeleted = false
+  let addedText = null
+  const rng = makeRange({
+    Comment: { Delete() { oldDeleted = true } },
+    AddComment(text) { addedText = text }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_add_comment({ cellAddress: 'B2', comment: '待核对' })
+    assert.equal(oldDeleted, true)
+    assert.equal(addedText, '待核对')
+    assert.deepEqual(out, { cellAddress: 'B2', added: true })
+  } finally { restore() }
+})
+
+test('excel_get_comments：老式批注降级字段（createdAt/resolved/replies 恒定）', async () => {
+  const comment = {
+    Parent: { Address() { return 'B2' } },
+    Text() { return '存疑' },
+    Author: '张三'
+  }
+  const { restore } = makeSingleSheetEnv({
+    Comments: { Count: 1, Item(i) { assert.equal(i, 1); return comment } }
+  })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_get_comments({})
+    assert.equal(out.count, 1)
+    assert.deepEqual(out.comments[0], {
+      cellAddress: 'B2', content: '存疑', author: '张三',
+      createdAt: null, resolved: false, replies: []
+    })
+  } finally { restore() }
+})
+
+test('excel_reply_comment：降级为批注正文追加「回复：」行并交底 via', async () => {
+  let newText = null
+  const comment = {
+    Text(text) {
+      if (text === undefined) return '原批注'
+      newText = text
+    }
+  }
+  const rng = makeRange({ Comment: comment })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_reply_comment({ cellAddress: 'B2', reply: '已确认' })
+    assert.equal(newText, '原批注\n回复：已确认')
+    assert.deepEqual(out, { cellAddress: 'B2', replied: true, via: 'appendText' })
+  } finally { restore() }
+})
+
+test('excel_resolve_comment：WPS 无解决语义，明确报不支持', async () => {
+  const { restore } = makeSingleSheetEnv({})
+  try {
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_resolve_comment({ cellAddress: 'B2' }),
+      /WPS 表格批注不支持标记解决/
+    )
+  } finally { restore() }
+})
+
+test('excel_delete_comment：无批注单元格报可读错误', async () => {
+  const rng = makeRange({ Comment: null })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_delete_comment({ cellAddress: 'B2' }),
+      /该单元格没有批注/
+    )
+  } finally { restore() }
+})
+
+/* ==================== excel_set_data_validation ==================== */
+
+test('excel_set_data_validation：list 先删旧规则再 Add 并开下拉', async () => {
+  const calls = []
+  const validation = {
+    Delete() { calls.push('delete') },
+    Add(...args) { calls.push(['add', ...args]) }
+  }
+  const rng = makeRange({ Validation: validation, Address() { return 'A1:A10' } })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_set_data_validation({
+      rangeAddress: 'A1:A10', type: 'list', listSource: '是,否'
+    })
+    assert.deepEqual(calls, ['delete', ['add', 3, 1, 1, '是,否']])  // xlValidateList, xlValidAlertStop, xlBetween 占位
+    assert.equal(validation.InCellDropdown, true)
+    assert.deepEqual(out, { action: 'apply', type: 'list', address: 'A1:A10' })
+  } finally { restore() }
+})
+
+/* ==================== excel_add_chart ==================== */
+
+test('excel_add_chart：ChartObjects() 函数调用建图，HasTitle 前置', async () => {
+  let addArgs = null
+  let sourceRange = null
+  const chart = {
+    SetSourceData(rng) { sourceRange = rng },
+    ChartTitle: {}
+  }
+  const co = { Chart: chart, Name: '图表 1' }
+  const dataRng = { _tag: 'data' }
+  const { restore } = makeSingleSheetEnv({
+    ChartObjects() { return { Add(...args) { addArgs = args; return co } } },
+    Range: () => dataRng
+  })
+  try {
+    const out = await WPS_ET_HANDLERS.excel_add_chart({
+      dataRangeAddress: 'A1:B5', chartType: 'column', title: '销量'
+    })
+    assert.deepEqual(addArgs, [50, 40, 360, 220])
+    assert.equal(sourceRange, dataRng)
+    assert.equal(chart.ChartType, 51)       // xlColumnClustered
+    assert.equal(chart.HasTitle, true)
+    assert.equal(chart.ChartTitle.Text, '销量')
+    assert.deepEqual(out, { added: true, name: '图表 1', chartType: 'column' })
+  } finally { restore() }
+})
+
+/* ==================== excel_define_name ==================== */
+
+test('excel_define_name：add 拼带引号表名的 RefersTo；remove 未找到报错', async () => {
+  let addArgs = null
+  const names = {
+    Add(name, refersTo) { addArgs = [name, refersTo] },
+    Item(name) { throw new Error(`名称不存在：${name}`) }
+  }
+  const rng = makeRange({ Address() { return '$A$1:$B$2' } })
+  const sheet = makeSheet('数据表', { Range: () => rng })
+  const workbook = { ActiveSheet: sheet, Worksheets: makeSheetsCollection([sheet]), Names: names }
+  const restore = installWps(makeApp({ workbook }))
+  try {
+    const out = await WPS_ET_HANDLERS.excel_define_name({ action: 'add', name: '结算区', rangeAddress: 'A1:B2' })
+    assert.deepEqual(addArgs, ['结算区', "='数据表'!$A$1:$B$2"])
+    assert.deepEqual(out, { action: 'add', name: '结算区' })
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_define_name({ action: 'remove', name: '不存在的名字' }),
+      /未找到命名区域：不存在的名字/
+    )
+  } finally { restore() }
+})
+
+/* ==================== excel_group_rows_cols / excel_protect_sheet ==================== */
+
+test('excel_group_rows_cols：按 EntireRow/EntireColumn 归一化后分组', async () => {
+  let grouped = false
+  let ungrouped = false
+  const rng = makeRange({
+    EntireRow: { Group() { grouped = true } },
+    EntireColumn: { Ungroup() { ungrouped = true } }
+  })
+  const { restore } = makeSingleSheetEnv({ Range: () => rng })
+  try {
+    let out = await WPS_ET_HANDLERS.excel_group_rows_cols({ rangeAddress: '2:5', action: 'group', by: 'rows' })
+    assert.equal(grouped, true)
+    assert.deepEqual(out, { action: 'group', by: 'rows' })
+    out = await WPS_ET_HANDLERS.excel_group_rows_cols({ rangeAddress: 'C:E', action: 'ungroup', by: 'cols' })
+    assert.equal(ungrouped, true)
+    assert.deepEqual(out, { action: 'ungroup', by: 'cols' })
+  } finally { restore() }
+})
+
+test('excel_protect_sheet：protect/unprotect 透传密码；非法 action 报错', async () => {
+  const calls = []
+  const { restore } = makeSingleSheetEnv({
+    Protect(pwd) { calls.push(['protect', pwd]) },
+    Unprotect(pwd) { calls.push(['unprotect', pwd]) }
+  })
+  try {
+    await WPS_ET_HANDLERS.excel_protect_sheet({ action: 'protect', password: 'abc' })
+    await WPS_ET_HANDLERS.excel_protect_sheet({ action: 'unprotect', password: 'abc' })
+    assert.deepEqual(calls, [['protect', 'abc'], ['unprotect', 'abc']])
+    await assert.rejects(WPS_ET_HANDLERS.excel_protect_sheet({ action: 'lock' }), /action 值非法/)
+  } finally { restore() }
+})
+
+/* ==================== excel_add_pivot_table ==================== */
+
+test('excel_add_pivot_table：PivotCaches().Create 全签名链路与字段编排', async () => {
+  let createArgs = null
+  let createPivotArgs = null
+  const fields = {
+    地区: { Orientation: null },
+    销量: { _tag: 'valueField' }
+  }
+  const dataFieldCalls = []
+  const pivot = {
+    Name: '透视1',
+    PivotFields(name) {
+      if (!fields[name]) throw new Error('字段不存在')
+      return fields[name]
+    },
+    AddDataField(pf) { dataFieldCalls.push(pf) }
+  }
+  const cache = { CreatePivotTable(dest, name) { createPivotArgs = [dest, name]; return pivot } }
+  const destRng = { _tag: 'dest' }
+  const sheet = makeSheet('Sheet1', { Range: () => destRng })
+  const workbook = {
+    ActiveSheet: sheet,
+    Worksheets: makeSheetsCollection([sheet]),
+    PivotCaches() { return { Create(type, src) { createArgs = [type, src]; return cache } } }
+  }
+  const restore = installWps(makeApp({ workbook }))
+  try {
+    const out = await WPS_ET_HANDLERS.excel_add_pivot_table({
+      sourceRangeAddress: 'A1:C10', destinationCellAddress: 'E1',
+      rowFields: ['地区'], valueFields: ['销量'], pivotName: '透视1'
+    })
+    assert.deepEqual(createArgs, [1, "'Sheet1'!A1:C10"])   // xlDatabase + 带表名源地址
+    assert.deepEqual(createPivotArgs, [destRng, '透视1'])
+    assert.equal(fields['地区'].Orientation, 1)             // xlRowField
+    assert.deepEqual(dataFieldCalls, [fields['销量']])
+    assert.deepEqual(out, { added: true, name: '透视1', rowFields: ['地区'], valueFields: ['销量'] })
+    // 字段名对不上时给排障提示
+    await assert.rejects(
+      WPS_ET_HANDLERS.excel_add_pivot_table({
+        sourceRangeAddress: 'A1:C10', destinationCellAddress: 'E1',
+        rowFields: ['不存在的列'], valueFields: ['销量']
+      }),
+      /未找到透视表字段：不存在的列/
+    )
+  } finally { restore() }
+})
+
+/* ==================== excel_select_range ==================== */
+
+test('excel_select_range：指定表先 Activate 再 Select', async () => {
+  const calls = []
+  const rng = makeRange({ Select() { calls.push('select') }, Address() { return 'B2:C3' } })
+  const sheet = makeSheet('明细', { Activate() { calls.push('activate') }, Range: () => rng })
+  const workbook = { ActiveSheet: makeSheet('Sheet1'), Worksheets: makeSheetsCollection([sheet]) }
+  const restore = installWps(makeApp({ workbook }))
+  try {
+    const out = await WPS_ET_HANDLERS.excel_select_range({ sheetName: '明细', rangeAddress: 'B2:C3' })
+    assert.deepEqual(calls, ['activate', 'select'])
+    assert.deepEqual(out, { address: 'B2:C3' })
+  } finally { restore() }
+})

--- a/office-addin/taskpane/lib/wpsExecutor.js
+++ b/office-addin/taskpane/lib/wpsExecutor.js
@@ -1,0 +1,77 @@
+/**
+ * office_command 的 WPS 家族执行器（与 officeExecutor.js 同契约）：
+ * 后端 OfficeBridgeService 经 SSE client_action 下发 {tool:'office_command',
+ * requestId, command, args}，本模块按 command 分发到 WPS 加载项 JSAPI 实现并
+ * 返回 {ok, data|error}，由调用方 POST /api/agent/office/result 回传。
+ *
+ * 硬规则与 Office 面完全一致：
+ * - 后端注册的每个 office_* 工具都必须有对应实现，未知 command 立即回
+ *   {ok:false, error:'unsupported command'}，绝不静默吞掉；
+ * - 宿主守卫是最后一道防线（正常情况下后端已按 officeHost 过滤）；
+ * - executeWpsCommand 永不 throw。
+ *
+ * 命令名与参数/返回值契约以 officeExecutor.js 为准绳——两个家族对后端和模型
+ * 呈现同一张工具表，行为差异（如 WPS 有真的「最小值行距」而 Office.js 没有）
+ * 只体现在返回值的说明字段里。
+ *
+ * 各宿主 HANDLERS 拆在三个文件里（文字/表格/演示），本文件只做合并与分发。
+ */
+
+import { wpsAvailable, detectWpsHost } from './wpsDoc.js'
+import { WPS_WORD_HANDLERS, locateInWpsDocument as locateImpl } from './wpsWordHandlers.js'
+import { WPS_ET_HANDLERS } from './wpsEtHandlers.js'
+import { WPS_WPP_HANDLERS } from './wpsWppHandlers.js'
+
+const HANDLERS = {
+  ...WPS_WORD_HANDLERS,
+  ...WPS_ET_HANDLERS,
+  ...WPS_WPP_HANDLERS
+}
+
+/** 与 officeExecutor.COMMAND_HOSTS 同口径：前缀定宿主，其余归文字 */
+function requiredHostOf(command) {
+  if (command.startsWith('excel_')) return 'excel'
+  if (command.startsWith('ppt_')) return 'powerpoint'
+  return 'word'
+}
+
+const HOST_LABELS = { word: 'WPS 文字', excel: 'WPS 表格', powerpoint: 'WPS 演示' }
+
+/** 引用定位（正文引文 chip 点击选中），仅文字宿主 */
+export async function locateInWpsDocument(text) {
+  if (!wpsAvailable() || detectWpsHost() !== 'word') return { found: false }
+  try {
+    return await locateImpl(text)
+  } catch (e) {
+    return { found: false }
+  }
+}
+
+/**
+ * 执行一条 office_command。永不 throw：一律返回 {ok:true, data} 或 {ok:false, error}。
+ */
+export async function executeWpsCommand(command, args) {
+  if (!wpsAvailable()) {
+    return { ok: false, error: 'WPS 环境不可用：请在 WPS 任务窗格中使用本插件' }
+  }
+  const handler = HANDLERS[command]
+  if (!handler) {
+    return { ok: false, error: `unsupported command: ${command}` }
+  }
+  const requiredHost = requiredHostOf(command)
+  const host = detectWpsHost()
+  if (host !== requiredHost) {
+    return {
+      ok: false,
+      error: `unsupported host: 该命令只在 ${HOST_LABELS[requiredHost]} 中可用（当前宿主：${HOST_LABELS[host] || '未知'}）`
+    }
+  }
+  try {
+    const data = await handler(args || {})
+    return { ok: true, data: data == null ? {} : data }
+  } catch (e) {
+    const message = (e && e.message) || String(e)
+    console.warn('[Addin] office_command 执行失败（WPS）', command, e)
+    return { ok: false, error: message }
+  }
+}

--- a/office-addin/taskpane/lib/wpsWordHandlers.js
+++ b/office-addin/taskpane/lib/wpsWordHandlers.js
@@ -1,0 +1,1736 @@
+/**
+ * WPS 文字宿主的 office_command 执行实现（33 个 Word 面命令）。
+ *
+ * 契约以 officeExecutor.js 为准绳：命令名、参数字段、返回值结构、错误文案腔调
+ * 全部对齐 Office 面——两个家族对后端和模型呈现同一张工具表，行为差异只体现
+ * 在返回值的说明字段里（如本宿主的 lineSpacingMode:'atLeast'、fontSplit:true）。
+ *
+ * API 依据：调研映射表 wps-word-api.md（open.wps.cn 文档 + wps-jsapi typings），
+ * 对象模型为 VBA 同构的**同步**调用。不依赖 wps.Enum——本文件内置 VBA 同值的
+ * 数值常量表（常量名保留 VBA 名以便对照）。
+ *
+ * 核心口径（与 Office 面的差异）：
+ * - 定位统一走「全文快照 indexOf + Document.Range(start, end) 字符偏移直切」，
+ *   绕开 Find 的 255 上限与不跨段限制；但偏移口径（内嵌对象/域/批注标记可能
+ *   占位）是调研标注的头号真机验证项，所以**每次按偏移落笔前必须校验
+ *   range.Text 与预期旧文一致**，不一致立即回退（整段替换或 Find 兜底）。
+ * - 修改类命令包 withTracking：保存 Document.TrackRevisions → 置 true →
+ *   finally 恢复；TrackRevisions 读写抛异常时降级直改并标 tracked:false。
+ * - 批注/修订定位符：WPS 只有 1-based Index、无 GUID——对外 id 就是 0 起的
+ *   序号字符串（与 index 同口径），每次操作前重新读集合（序号随接受/拒绝/
+ *   删除塌缩重排，officeExecutor 批次 9 同款地雷）。
+ *
+ * 真机验证清单要点（按风险排序，详见调研文档末节）：
+ *  1. 字符偏移一致性：doc.Range().Text 的 JS 索引 ↔ doc.Range(s,e) 映射
+ *     （含表格 \x07、域、批注引用标记的占位）——本文件的逐笔校验是安全阀；
+ *  2. Comment.Replies.Add 能否创建线程回复（已备 appendText 降级）；
+ *  3. 修订开启下 .Text='' 删除的占位行为与右到左偏移稳定性；
+ *  4. Find.Execute 位置传参在 JS 桥的兼容性（仅作偏移失准时的兜底路）；
+ *  5. Font.Color（BGR）与 TextColor.RGB（RGB）两条颜色通路的字节序；
+ *  6. 逐段/逐格循环的跨桥性能（500 段 apply_standard_format、大表读写）。
+ */
+
+import { minimalEdits } from './minimalEdit.js'
+// 律所标准格式（HOUSE）单源：backend/src/main/resources/style-profiles/house-default.json
+// 的字节副本，由 frontend/scripts/sync-house-profile.mjs 同步（与 officeExecutor 同一份）。
+import houseProfile from './house-default.json' with { type: 'json' }
+
+/* ==================== VBA 同值常量表（不依赖 wps.Enum） ==================== */
+// 数值出处：wps-jsapi@1.0.5 typings，与 Word VBA 逐一相同（调研文档已抄录核对）。
+// 注意：勿混入 WebOffice(docs-center) SDK 那套不同数值的枚举。
+
+// MsoTriState / 特殊值
+const msoTrue = -1
+const msoFalse = 0
+const wdUndefined = 9999999
+// WdUnderline
+const wdUnderlineNone = 0
+const wdUnderlineSingle = 1
+const wdUnderlineDouble = 3
+const wdUnderlineDotted = 4
+const wdUnderlineWavy = 11
+// WdParagraphAlignment
+const wdAlignParagraphLeft = 0
+const wdAlignParagraphCenter = 1
+const wdAlignParagraphRight = 2
+const wdAlignParagraphJustify = 3
+// WdBuiltinStyle
+const wdStyleNormal = -1
+const wdStyleHeading1 = -2
+const wdStyleHeading2 = -3
+const wdStyleHeading3 = -4
+const wdStyleHeading4 = -5
+// WdLineSpacing
+const wdLineSpaceAtLeast = 3
+// WdListGalleryType / WdListNumberStyle / WdListApplyTo / WdDefaultListBehavior
+const wdNumberGallery = 2
+const wdListNumberStyleSimpChinNum2 = 38 // 「一、二、三」样式
+const wdListApplyToWholeList = 0
+const wdWord9ListBehavior = 1
+// WdFindWrap / WdReplace
+const wdFindStop = 0
+const wdReplaceOne = 1
+// WdBreakType
+const wdSectionBreakNextPage = 2
+const wdPageBreak = 7
+// WdHeaderFooterIndex
+const wdHeaderFooterPrimary = 1
+// WdRowAlignment
+const wdAlignRowLeft = 0
+const wdAlignRowCenter = 1
+const wdAlignRowRight = 2
+// WdLineStyle
+const wdLineStyleNone = 0
+const wdLineStyleSingle = 1
+// WdAutoFitBehavior
+const wdAutoFitWindow = 2
+// WdBorderType（Borders.Item 的六个索引）
+const wdBorderTop = -1
+const wdBorderLeft = -2
+const wdBorderBottom = -3
+const wdBorderRight = -4
+const wdBorderHorizontal = -5
+const wdBorderVertical = -6
+// WdContentControlType
+const wdContentControlRichText = 0
+// WdBuiltInProperty
+const wdPropertyTitle = 1
+const wdPropertySubject = 2
+const wdPropertyAuthor = 3
+const wdPropertyKeywords = 4
+const wdPropertyComments = 5
+const wdPropertyCategory = 18
+// WdSelectionType
+const wdSelectionIP = 1
+
+/* ==================== 通用上限（与 officeExecutor 同口径） ==================== */
+
+const MAX_TEXT_CHARS = 200_000
+const MAX_SEARCH_HITS = 20
+const MAX_NUMBERING_PARAGRAPHS = 200
+const MAX_STANDARD_FORMAT_PARAGRAPHS = 500
+const HOUSE_TITLE_MAX_CHARS = 50
+const HOUSE_HEADING_MAX_CHARS = 40
+const ANCHOR_FALLBACK_MIN_CHARS = 4
+
+/* ==================== 入口与基础工具 ==================== */
+
+/** 文字宿主 Application 入口（全局 wps.WpsApplication()），全文件唯一收敛点 */
+function app() {
+  const w = globalThis.wps
+  if (!w || typeof w.WpsApplication !== 'function') {
+    throw new Error('WPS 文字环境不可用：请在 WPS 文字任务窗格中使用本插件')
+  }
+  const a = w.WpsApplication()
+  if (!a) throw new Error('WPS 文字环境不可用：请在 WPS 文字任务窗格中使用本插件')
+  return a
+}
+
+/** 当前活动文档；没有打开文档时报错（官方原文：ActiveDocument 无文档会出错） */
+function activeDoc() {
+  let doc
+  try {
+    doc = app().ActiveDocument
+  } catch (e) {
+    doc = null
+  }
+  if (!doc) throw new Error('当前没有打开的文档')
+  return doc
+}
+
+function truncate(text) {
+  const s = text || ''
+  return s.length > MAX_TEXT_CHARS
+    ? { text: s.slice(0, MAX_TEXT_CHARS), truncated: true, totalChars: s.length }
+    : { text: s, truncated: false, totalChars: s.length }
+}
+
+/** 全文快照。WPS/VBA 的段落符是 \r（Chr(13)），不做归一化——偏移定位必须用原文 */
+function bodyText(doc) {
+  return String(doc.Range().Text || '')
+}
+
+/** 模型给的锚点/插入文本可能带 \n，写入/比对前统一成 WPS 的段落符 \r */
+function normalizeNewlines(s) {
+  return String(s == null ? '' : s).replace(/\r\n/g, '\r').replace(/\n/g, '\r')
+}
+
+/**
+ * 在开启 WPS 原生修订（Document.TrackRevisions）的前提下执行 fn，结束后恢复原值。
+ * TrackRevisions 读或写抛异常（旧版/受限文档）时降级为直接修改，标 tracked:false
+ * ——与 officeExecutor.withTracking 同契约。fn 为同步函数（WPS JSAPI 是同步桥）。
+ */
+function withTracking(doc, fn) {
+  let prev = null
+  let trackable = true
+  try {
+    prev = doc.TrackRevisions
+    doc.TrackRevisions = true
+  } catch (e) {
+    trackable = false
+  }
+  if (!trackable) {
+    return { ...fn(), tracked: false }
+  }
+  try {
+    return { ...fn(), tracked: true }
+  } finally {
+    try {
+      doc.TrackRevisions = prev
+    } catch (e) { /* 恢复失败不掩盖主结果 */ }
+  }
+}
+
+/**
+ * 结构性删除（删行/删列）契约上 tracked:false（与 Office 面一致）。WPS 下若用户
+ * 开着修订，删除会记成结构修订、被删行还留在表中导致连删错位——所以执行期临时
+ * 关掉修订，结束后恢复。TrackRevisions 不可用时按原样直删。
+ */
+function withTrackingOff(doc, fn) {
+  let prev = null
+  let restorable = true
+  try {
+    prev = doc.TrackRevisions
+    doc.TrackRevisions = false
+  } catch (e) {
+    restorable = false
+  }
+  try {
+    return fn()
+  } finally {
+    if (restorable) {
+      try {
+        doc.TrackRevisions = prev
+      } catch (e) { /* 恢复失败不掩盖主结果 */ }
+    }
+  }
+}
+
+/** needle 在 hay 中的全部非重叠命中偏移（升序） */
+function allIndexes(hay, needle) {
+  const out = []
+  if (!needle) return out
+  let i = hay.indexOf(needle)
+  while (i !== -1) {
+    out.push(i)
+    i = hay.indexOf(needle, i + needle.length)
+  }
+  return out
+}
+
+/**
+ * 锚点跨段降级选段。抄自 officeExecutor.pickAnchorFallback（dev-board#149）——
+ * WPS 的 indexOf 定位天然跨段，这里只作「归一化后仍未命中」时的兜底。
+ */
+function pickAnchorFallback(anchor, position) {
+  const segments = String(anchor || '')
+    .split(/\r\n|\n|\r/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= ANCHOR_FALLBACK_MIN_CHARS)
+  if (!segments.length) return null
+  if (position === 'after') return segments[segments.length - 1]
+  if (position === 'before') return segments[0]
+  return segments.reduce((longest, s) => (s.length > longest.length ? s : longest))
+}
+
+/**
+ * 锚点定位：全文 indexOf（区分大小写），跨段锚点（\n 归一成 \r 后）原生支持；
+ * 仍未命中时按 pickAnchorFallback 拆段兜底。返回全部命中偏移与实际使用的 needle。
+ */
+function locateAnchorAll(doc, anchorText, { position = null, message } = {}) {
+  const body = bodyText(doc)
+  let needle = normalizeNewlines(anchorText)
+  let offsets = allIndexes(body, needle)
+  let degraded = false
+  if (!offsets.length && /\r/.test(needle)) {
+    const fallback = pickAnchorFallback(needle, position)
+    if (fallback) {
+      const alt = allIndexes(body, fallback)
+      if (alt.length) {
+        offsets = alt
+        needle = fallback
+        degraded = true
+      }
+    }
+  }
+  if (!offsets.length) {
+    const suffix = /\r/.test(needle)
+      ? `；锚点跨段，已尝试按段内文本降级仍未命中：${needle.slice(0, 40)}`
+      : ''
+    throw new Error((message || '未找到目标文本，请确认 anchorText 与文档内容精确一致（可先用 search 命令核对）') + suffix)
+  }
+  return { offsets, needle, degraded }
+}
+
+/**
+ * 按偏移切 Range 并校验其 Text 与预期一致（偏移口径安全阀）。
+ * 不一致说明文档含占位符（表格结束符/域/批注标记），偏移直切不可信。
+ */
+function verifiedRange(doc, start, expected) {
+  const r = doc.Range(start, start + expected.length)
+  if (String(r.Text) !== expected) {
+    throw new Error('定位校验失败：按字符偏移取到的文本与预期不一致（文档可能含表格、域等占位内容），请换一段更独特的锚点文本重试')
+  }
+  return r
+}
+
+/** 单命中锚点（写入类命令通用）：取第一处命中并校验偏移 */
+function anchorRange(doc, anchorText, opts = {}) {
+  const { offsets, needle } = locateAnchorAll(doc, anchorText, opts)
+  return { range: verifiedRange(doc, offsets[0], needle), start: offsets[0], needle, total: offsets.length }
+}
+
+/* ==================== 枚举映射（小写短名 ↔ VBA 数值） ==================== */
+
+const UNDERLINE_TYPES = {
+  none: wdUnderlineNone,
+  single: wdUnderlineSingle,
+  double: wdUnderlineDouble,
+  dotted: wdUnderlineDotted,
+  wave: wdUnderlineWavy
+}
+
+const ALIGNMENTS = {
+  left: wdAlignParagraphLeft,
+  center: wdAlignParagraphCenter,
+  right: wdAlignParagraphRight,
+  justify: wdAlignParagraphJustify
+}
+
+const PARAGRAPH_STYLES = {
+  normal: wdStyleNormal,
+  heading1: wdStyleHeading1,
+  heading2: wdStyleHeading2,
+  heading3: wdStyleHeading3,
+  heading4: wdStyleHeading4
+}
+
+const TABLE_ALIGNMENTS = { left: wdAlignRowLeft, center: wdAlignRowCenter, right: wdAlignRowRight }
+
+const NUMBERING_KINDS = ['bullet', 'decimal', 'chinese', 'none']
+
+/** WdRevisionType 数值 → 可读类型名（回译给模型；数值出处见调研 WdRevisionType 全表） */
+const REVISION_TYPE_NAMES = {
+  1: 'inserted',
+  2: 'deleted',
+  3: 'property',
+  4: 'paragraphNumber',
+  5: 'displayField',
+  6: 'reconcile',
+  7: 'conflict',
+  8: 'style',
+  9: 'replace',
+  10: 'paragraphProperty',
+  11: 'tableProperty',
+  12: 'sectionProperty',
+  13: 'styleDefinition',
+  14: 'movedFrom',
+  15: 'movedTo',
+  16: 'cellInsertion',
+  17: 'cellDeletion',
+  18: 'cellMerge'
+}
+
+/** 模型常给英文/中文内置样式名，样式名直赋失败时按此表落枚举常量（apply_style 垫底） */
+const BUILTIN_STYLE_BY_NAME = {
+  'normal': wdStyleNormal,
+  '正文': wdStyleNormal,
+  'heading 1': wdStyleHeading1,
+  'heading1': wdStyleHeading1,
+  '标题 1': wdStyleHeading1,
+  '标题1': wdStyleHeading1,
+  'heading 2': wdStyleHeading2,
+  'heading2': wdStyleHeading2,
+  '标题 2': wdStyleHeading2,
+  '标题2': wdStyleHeading2,
+  'heading 3': wdStyleHeading3,
+  'heading3': wdStyleHeading3,
+  '标题 3': wdStyleHeading3,
+  '标题3': wdStyleHeading3,
+  'heading 4': wdStyleHeading4,
+  'heading4': wdStyleHeading4,
+  '标题 4': wdStyleHeading4,
+  '标题4': wdStyleHeading4
+}
+
+/** 读格式时把样式名回译成 styleBuiltIn 短名（读不出对应关系就不给这个字段） */
+const STYLE_SHORT_BY_NAME = {
+  'normal': 'normal',
+  '正文': 'normal',
+  'heading 1': 'heading1',
+  '标题 1': 'heading1',
+  'heading 2': 'heading2',
+  '标题 2': 'heading2',
+  'heading 3': 'heading3',
+  '标题 3': 'heading3',
+  'heading 4': 'heading4',
+  '标题 4': 'heading4'
+}
+
+/** 小写短名 → 数值；非法值报错并列出合法值（0 是合法枚举值，必须用 in 判断） */
+function toEnumValue(table, raw, field) {
+  const key = String(raw).trim().toLowerCase()
+  if (!(key in table)) {
+    throw new Error(`${field} 值非法：${raw}（合法值：${Object.keys(table).join('/')}）`)
+  }
+  return table[key]
+}
+
+/** 数值 → 小写短名（读格式时回译，让模型读到的词与能填的词一致） */
+function fromEnumValue(table, raw) {
+  if (raw == null) return raw
+  const hit = Object.keys(table).find((key) => table[key] === raw)
+  return hit || raw
+}
+
+/* ==================== 颜色（WPS 是 BGR Long，不是 hex 串） ==================== */
+
+function parseHexColor(hex) {
+  const m = /^#?([0-9a-f]{6})$/i.exec(String(hex).trim())
+  if (!m) throw new Error(`颜色格式非法：${hex}（应为 #RRGGBB）`)
+  const v = parseInt(m[1], 16)
+  return { r: (v >> 16) & 0xff, g: (v >> 8) & 0xff, b: v & 0xff }
+}
+
+/** '#RRGGBB' → Font.Color 的 BGR Long */
+function hexToBgr(hex) {
+  const { r, g, b } = parseHexColor(hex)
+  return (b << 16) | (g << 8) | r
+}
+
+/** '#RRGGBB' → TextColor.RGB 的 RGB Long（与 Font.Color 字节序相反，备胎通路用） */
+function hexToRgbLong(hex) {
+  const { r, g, b } = parseHexColor(hex)
+  return r | (g << 8) | (b << 16)
+}
+
+/** Font.Color 的 BGR Long → '#RRGGBB'；自动色（负值）与混合（wdUndefined）回 null */
+function bgrToHex(bgr) {
+  const n = Number(bgr)
+  if (!Number.isFinite(n) || n < 0 || n === wdUndefined) return null
+  const b = (n >> 16) & 0xff
+  const g = (n >> 8) & 0xff
+  const r = n & 0xff
+  return '#' + [r, g, b].map((x) => x.toString(16).padStart(2, '0')).join('')
+}
+
+/** MsoTriState/混合值 → 布尔或 null（wdUndefined=混合格式读不出单一值） */
+function triToBool(v) {
+  if (v == null || v === wdUndefined) return null
+  return v !== 0
+}
+
+/* ==================== 字符/段落格式计划 ==================== */
+
+function buildFontPlan(args) {
+  const props = {}
+  const applied = {}
+  if (args.fontName) {
+    props.Name = String(args.fontName)
+    applied.name = String(args.fontName)
+  }
+  if (args.fontSize != null) {
+    props.Size = Number(args.fontSize)
+    applied.size = Number(args.fontSize)
+  }
+  if (args.bold != null) {
+    props.Bold = args.bold ? msoTrue : msoFalse
+    applied.bold = !!args.bold
+  }
+  if (args.italic != null) {
+    props.Italic = args.italic ? msoTrue : msoFalse
+    applied.italic = !!args.italic
+  }
+  if (args.underline != null) {
+    props.Underline = toEnumValue(UNDERLINE_TYPES, args.underline, 'underline')
+    applied.underline = String(args.underline).trim().toLowerCase()
+  }
+  if (args.strikeThrough != null) {
+    props.StrikeThrough = args.strikeThrough ? msoTrue : msoFalse
+    applied.strikeThrough = !!args.strikeThrough
+  }
+  if (args.doubleStrikeThrough != null) {
+    props.DoubleStrikeThrough = args.doubleStrikeThrough ? msoTrue : msoFalse
+    applied.doubleStrikeThrough = !!args.doubleStrikeThrough
+  }
+  let colorBgr = null
+  let colorRgb = null
+  if (args.color) {
+    colorBgr = hexToBgr(args.color)
+    colorRgb = hexToRgbLong(args.color)
+    applied.color = String(args.color)
+  }
+  return { props, applied, colorBgr, colorRgb, empty: !Object.keys(applied).length }
+}
+
+function applyFontPlan(font, plan) {
+  for (const [key, value] of Object.entries(plan.props)) font[key] = value
+  if (plan.colorBgr != null) {
+    try {
+      font.Color = plan.colorBgr // 主路：Font.Color，BGR 序
+    } catch (e) {
+      font.TextColor.RGB = plan.colorRgb // 备胎：TextColor.RGB，RGB 序（调研第 5 验证项）
+    }
+  }
+}
+
+/**
+ * 段落格式计划。lineSpacing 落成「最小值」行距（LineSpacingRule=wdLineSpaceAtLeast
+ * + LineSpacing 两件套，WPS 官方口径必须两个都设）——这是 WPS 相对 Office.js 的
+ * 能力升级（Office 面只能 exact），返回值用 lineSpacingMode:'atLeast' 向模型交底。
+ */
+function buildParagraphPlan(args) {
+  const ops = []
+  const applied = {}
+  if (args.alignment != null) {
+    const v = toEnumValue(ALIGNMENTS, args.alignment, 'alignment')
+    ops.push((pf) => { pf.Alignment = v })
+    applied.alignment = String(args.alignment).trim().toLowerCase()
+  }
+  if (args.lineSpacing != null) {
+    const v = Number(args.lineSpacing)
+    ops.push((pf) => {
+      pf.LineSpacingRule = wdLineSpaceAtLeast
+      pf.LineSpacing = v
+    })
+    applied.lineSpacing = v
+  }
+  const POINT_FIELDS = [
+    ['spaceBefore', 'SpaceBefore'],
+    ['spaceAfter', 'SpaceAfter'],
+    ['firstLineIndent', 'FirstLineIndent'],
+    ['leftIndent', 'LeftIndent'],
+    ['rightIndent', 'RightIndent']
+  ]
+  for (const [argKey, propKey] of POINT_FIELDS) {
+    if (args[argKey] != null) {
+      const v = Number(args[argKey])
+      ops.push((pf) => { pf[propKey] = v })
+      applied[argKey] = v
+    }
+  }
+  return { ops, applied, empty: !Object.keys(applied).length }
+}
+
+/* ==================== 律所标准格式（HOUSE） ==================== */
+
+/**
+ * 抄自 officeExecutor.houseFromProfile（不 import officeExecutor：会把 Office 面
+ * 代码拽进依赖图）。三处写端（后端 DocxStyleHelper / LOWA worker / 插件）同一份
+ * JSON 源，改规范只改那一个 JSON。
+ */
+function houseFromProfile(p) {
+  const d = (p && p.defaults) || {}
+  const body = (p && p.body) || {}
+  const h1 = ((p && p.headings) || []).find((h) => h && Number(h.level) === 1) || {}
+  const cell = ((p && p.table) || {}).cell || {}
+  const pt = (len, fontPt, fallback) => {
+    if (!len || len.value == null) return fallback
+    const v = Number(len.value)
+    if (!isFinite(v)) return fallback
+    switch (len.unit || 'pt') {
+      case 'pt': return v
+      case 'chars': return v * fontPt
+      case 'lines': return v * fontPt * 1.2
+      case 'mm': return v * 72 / 25.4
+      case 'cm': return v * 720 / 25.4
+      case 'twips': return v / 20
+      default: return fallback
+    }
+  }
+  const bodyPt = pt(body.size, 12, pt(d.size, 12, 12))
+  const ls = body.lineSpacing || {}
+  return {
+    fontAsian: (body.font && body.font.eastAsia) || (d.font && d.font.eastAsia) || '楷体_GB2312',
+    fontWestern: (body.font && body.font.western) || (d.font && d.font.western) || 'Arial',
+    bodyPt,
+    titlePt: pt(h1.size, bodyPt, 16),
+    spaceAfterPt: pt(body.spaceAfter, bodyPt, 18),
+    lineSpacingPt: ls.rule === 'atLeast' || ls.rule === 'exactly' ? pt({ value: ls.value, unit: ls.unit || 'pt' }, bodyPt, 16) : 16,
+    firstLineIndentPt: pt(body.firstLineIndent, bodyPt, 2 * bodyPt),
+    tablePt: pt(cell.size, 10, 10)
+  }
+}
+const HOUSE = houseFromProfile(houseProfile)
+
+/** 小标题启发式（抄自 officeExecutor，与 LOWA 规范一致） */
+const HEADING_RE = /^(第[一二三四五六七八九十百千零〇\d]+[条章节款项]|[一二三四五六七八九十]+[、.．]|[（(][一二三四五六七八九十\d]+[)）]|\d+[、.．])/
+
+/* ==================== 中文数字（编号降级用） ==================== */
+
+const CHINESE_DIGITS = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九']
+
+/** 1~200 的中文数字。抄自 officeExecutor.chineseNumeral（同一份口径，改要两处同步） */
+function chineseNumeral(n) {
+  if (n < 10) return CHINESE_DIGITS[n]
+  if (n < 20) return '十' + (n % 10 ? CHINESE_DIGITS[n % 10] : '')
+  if (n < 100) return CHINESE_DIGITS[Math.floor(n / 10)] + '十' + (n % 10 ? CHINESE_DIGITS[n % 10] : '')
+  const head = CHINESE_DIGITS[Math.floor(n / 100)] + '百'
+  const rest = n % 100
+  if (!rest) return head
+  if (rest < 10) return head + '零' + CHINESE_DIGITS[rest]
+  if (rest < 20) return head + '一十' + (rest % 10 ? CHINESE_DIGITS[rest % 10] : '')
+  return head + CHINESE_DIGITS[Math.floor(rest / 10)] + '十' + (rest % 10 ? CHINESE_DIGITS[rest % 10] : '')
+}
+
+/* ==================== 表格工具 ==================== */
+
+/** 单元格坐标 "B2" → 0 起的 {row, col}。抄自 officeExecutor.parseCellRef（批次 8） */
+function parseCellRef(ref) {
+  const m = /^([A-Za-z]{1,3})(\d{1,6})$/.exec(String(ref || '').trim())
+  if (!m) throw new Error(`单元格坐标格式非法：${ref}（应为列字母+行号，如 B2）`)
+  const letters = m[1].toUpperCase()
+  let col = 0
+  for (let i = 0; i < letters.length; i++) col = col * 26 + (letters.charCodeAt(i) - 64)
+  return { row: Number(m[2]) - 1, col: col - 1 }
+}
+
+/** 命令入参 tableIndex 是 0 起，WPS 集合 1-based——这里统一换算并做越界校验 */
+function getTable(doc, rawIndex) {
+  let index = Math.floor(Number(rawIndex))
+  if (!Number.isFinite(index) || index < 0) index = 0
+  const tables = doc.Tables
+  const count = tables.Count
+  if (!count) throw new Error('当前文档中没有表格')
+  if (index >= count) {
+    throw new Error(`tableIndex ${index} 越界：文档中共 ${count} 张表格（序号从 0 开始）`)
+  }
+  return { table: tables.Item(index + 1), index, count }
+}
+
+/** 剥掉单元格文本尾部的结束符 \r\x07（VBA 铁律，WPS 未明文——两种残留形态都剥） */
+function cleanCellText(raw) {
+  return String(raw == null ? '' : raw).replace(/\r?\x07$/, '').replace(/\r$/, '')
+}
+
+/** borderWidth 磅数 → WdLineWidth 枚举（值 = 磅 × 8，取最近档位） */
+const LINE_WIDTH_STEPS = [[0.25, 2], [0.5, 4], [0.75, 6], [1, 8], [1.5, 12], [2.25, 18], [3, 24]]
+function toLineWidth(ptWidth) {
+  let best = LINE_WIDTH_STEPS[0]
+  for (const step of LINE_WIDTH_STEPS) {
+    if (Math.abs(step[0] - ptWidth) < Math.abs(best[0] - ptWidth)) best = step
+  }
+  return best[1]
+}
+
+/* ==================== 批注/修订定位（1-based Index，无 GUID） ==================== */
+
+/**
+ * WPS 批注没有 GUID：commentId 与 commentIndex 都按 0 起序号解释（get_comments
+ * 返回的 id 就是序号字符串）。每次调用重新读集合再定位——序号随删除/解决塌缩。
+ */
+function resolveCommentIndex(args, count) {
+  const hasId = args.commentId != null && String(args.commentId).trim() !== ''
+  const hasIndex = args.commentIndex != null && args.commentIndex >= 0
+  if (!hasId && !hasIndex) {
+    throw new Error('缺少批注定位参数（commentId 或 commentIndex）')
+  }
+  const idx = Math.floor(Number(hasId ? args.commentId : args.commentIndex))
+  if (!Number.isFinite(idx)) {
+    throw new Error('WPS 宿主的批注没有 GUID，commentId 只接受批注序号（0 开始）——请先用 office_get_comments 获取序号')
+  }
+  if (idx < 0 || idx >= count) {
+    throw new Error(`批注序号 ${idx} 越界：文档共 ${count} 条批注（序号从 0 开始），请先用 office_get_comments 核对`)
+  }
+  return idx
+}
+
+/** Comment.Date / Revision.Date 的字符串尽力转 ISO；转不动就原样返回 */
+function toIso(raw) {
+  if (raw == null || raw === '') return null
+  try {
+    const t = new Date(raw)
+    return isNaN(t.getTime()) ? String(raw) : t.toISOString()
+  } catch (e) {
+    return String(raw)
+  }
+}
+
+/* ==================== replace_text 的最小修订落笔 ==================== */
+
+/**
+ * 对单个命中做字符级最小修订。返回：
+ *  - null：命中 Range 的偏移校验失败（文档含占位符），调用方走 Find 兜底；
+ *  - { via:'minimal', edits:n }：最小修订落笔完成（n=0 表示新旧一致未动笔）；
+ *  - { via:'full' }：整段替换（多行新文/差异覆盖整段/差异段校验失败）。
+ * 全部校验在任何写入之前完成；应用从右到左（修订开着时被删文本仍留在正文占位，
+ * 左侧偏移不动——这也是右到左顺序的保险）。
+ */
+function applyHit(doc, hitStart, needle, newText, multiline) {
+  const hitRange = doc.Range(hitStart, hitStart + needle.length)
+  if (String(hitRange.Text) !== needle) return null
+  if (!multiline) {
+    const edits = minimalEdits(needle, newText)
+    if (!edits.length) return { via: 'minimal', edits: 0 }
+    const whole = edits.length === 1 && edits[0].start === 0 && edits[0].end === needle.length
+    if (!whole) {
+      let verified = true
+      for (const e of edits) {
+        if (e.start === e.end) continue // 纯插入段没有旧文可校
+        const seg = doc.Range(hitStart + e.start, hitStart + e.end)
+        if (String(seg.Text) !== e.oldText) {
+          verified = false
+          break
+        }
+      }
+      if (verified) {
+        for (let k = edits.length - 1; k >= 0; k--) {
+          const e = edits[k]
+          if (e.start === e.end) {
+            doc.Range(hitStart + e.start, hitStart + e.start).InsertBefore(e.newText)
+          } else {
+            // 替换或删除（newText 为空即删除；修订开着时表现为删除修订标记）
+            doc.Range(hitStart + e.start, hitStart + e.end).Text = e.newText
+          }
+        }
+        return { via: 'minimal', edits: edits.length }
+      }
+    }
+  }
+  hitRange.Text = newText
+  return { via: 'full' }
+}
+
+/** 偏移口径失准时的兜底：Find.Execute 位置传参整替一处（官方 15 参签名的前 11 参） */
+function findReplaceOnce(doc, needle, replaceText) {
+  let find
+  try {
+    find = doc.Range().Find
+  } catch (e) {
+    return false
+  }
+  if (!find || typeof find.Execute !== 'function') return false
+  try {
+    if (typeof find.ClearFormatting === 'function') find.ClearFormatting()
+    // Execute(FindText, MatchCase, MatchWholeWord, MatchWildcards, MatchSoundsLike,
+    //         MatchAllWordForms, Forward, Wrap, Format, ReplaceWith, Replace)
+    return !!find.Execute(needle, true, false, false, false, false, true, wdFindStop, false, replaceText, wdReplaceOne)
+  } catch (e) {
+    return false
+  }
+}
+
+/* ==================== 引用定位（正文引文 chip 点击选中） ==================== */
+
+/** Find 定位语义的 WPS 实现：indexOf 命中 + Range.Select()。不区分大小写。 */
+export async function locateInWpsDocument(text) {
+  const needle = normalizeNewlines(String(text || '').trim())
+  if (!needle) return { found: false }
+  const w = globalThis.wps
+  if (!w || typeof w.WpsApplication !== 'function') return { found: false }
+  let doc
+  try {
+    doc = w.WpsApplication().ActiveDocument
+  } catch (e) {
+    return { found: false }
+  }
+  if (!doc) return { found: false }
+  try {
+    const body = bodyText(doc)
+    const lower = body.toLowerCase()
+    let probe = needle.toLowerCase()
+    let i = lower.indexOf(probe)
+    if (i < 0 && /\r/.test(needle)) {
+      const fallback = pickAnchorFallback(needle, null)
+      if (fallback) {
+        probe = fallback.toLowerCase()
+        i = lower.indexOf(probe)
+      }
+    }
+    if (i < 0) return { found: false }
+    doc.Range(i, i + probe.length).Select()
+    return { found: true, count: allIndexes(lower, probe).length }
+  } catch (e) {
+    return { found: false, error: (e && e.message) || String(e) }
+  }
+}
+
+/* ==================== HANDLERS ==================== */
+
+export const WPS_WORD_HANDLERS = {
+  async get_text() {
+    return truncate(bodyText(activeDoc()))
+  },
+
+  async get_selection() {
+    activeDoc()
+    const sel = app().Selection
+    let text = ''
+    try {
+      // 光标（无选区）时 Selection.Text 按 VBA 惯例返回右侧一个字符——按空处理
+      if (sel && sel.Type === wdSelectionIP) text = ''
+      else text = String((sel && sel.Text) || '')
+    } catch (e) {
+      text = String((sel && sel.Text) || '')
+    }
+    return truncate(text)
+  },
+
+  async search(args) {
+    const query = String(args.query || '')
+    if (!query) throw new Error('查找文本不能为空')
+    const doc = activeDoc()
+    const body = bodyText(doc)
+    // 不区分大小写；JS indexOf 无 255 上限、天然跨段（needle 归一成 \r 再搜）
+    const needle = normalizeNewlines(query).toLowerCase()
+    const lower = body.toLowerCase()
+    const offsets = allIndexes(lower, needle)
+    const shown = offsets.slice(0, MAX_SEARCH_HITS)
+    const matches = shown.map((offset, i) => {
+      // 命中上下文 = 命中所在段落的完整文本（\r 为段落符）
+      const paraStart = lower.lastIndexOf('\r', offset - 1) + 1
+      let paraEnd = lower.indexOf('\r', offset)
+      if (paraEnd < 0) paraEnd = body.length
+      return { index: i + 1, context: body.slice(paraStart, paraEnd).slice(0, 500) }
+    })
+    return { count: offsets.length, shown: shown.length, matches }
+  },
+
+  async replace_text(args) {
+    const searchText = String(args.searchText || '')
+    const replaceText = args.replaceText == null ? '' : String(args.replaceText)
+    const replaceAll = !!args.replaceAll
+    if (!searchText) throw new Error('查找文本不能为空')
+    // 与 Office 面同口径的快速失败：跨段 searchText 不做静默降级——降级只会命中
+    // 其中一段，却要把完整的多段 replaceText 塞进去，结果是内容重复/错位。
+    if (/[\r\n]/.test(searchText)) {
+      throw new Error('searchText 跨段落（含换行），请逐段替换：每次以单段内的文本为 searchText，并只提供该段的替换文本')
+    }
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const body = bodyText(doc)
+      const offsets = allIndexes(body, searchText)
+      if (!offsets.length) {
+        throw new Error('未找到目标文本，请确认 searchText 与文档内容精确一致（可先用 search 命令核对）')
+      }
+      const targets = replaceAll ? offsets : [offsets[0]]
+      const newText = normalizeNewlines(replaceText)
+      const multiline = /\r/.test(newText)
+      // 偏移口径预检：任何一处命中的偏移文本对不上（文档含表格/域等占位符），
+      // 整体切换到纯 Find 循环——不许偏移路径与 Find 兜底混跑。混跑的病灶：
+      // Find.Execute 永远替换文档里最靠前的命中，与右到左循环当前处理的那处
+      // 错位，replaceAll 下会提前吃掉左侧命中、最后一轮反过来报「未命中」。
+      const allVerified = targets.every(
+        (start) => String(doc.Range(start, start + searchText.length).Text) === searchText
+      )
+      if (!allVerified) {
+        let replaced = 0
+        for (let k = 0; k < targets.length; k++) {
+          if (!findReplaceOnce(doc, searchText, newText)) break
+          replaced++
+        }
+        if (!replaced) {
+          throw new Error('替换失败：文档字符偏移与文本快照不一致，且查找替换兜底未命中，请先用 search 命令核对目标文本')
+        }
+        const result = { replaced, totalMatches: offsets.length, via: 'fullReplace', edits: 0, fallbacks: replaced }
+        if (replaced < targets.length) {
+          result.note = `按查找替换兜底完成 ${replaced}/${targets.length} 处（文档含占位内容，字符级最小修订不可用）`
+        }
+        return result
+      }
+      let minimal = 0
+      let fallbacks = 0
+      let editSegments = 0
+      // 多个命中从右到左处理：前一处的写入不会推移后面命中的定位（与 Office 面同理由）
+      for (let k = targets.length - 1; k >= 0; k--) {
+        const applied = applyHit(doc, targets[k], searchText, newText, multiline)
+        if (applied == null || applied.via === 'full') {
+          // 预检通过后 applyHit 不应再返回 null；防御性并入整替计数
+          fallbacks++
+        } else {
+          minimal++
+          editSegments += applied.edits
+        }
+      }
+      const result = {
+        replaced: targets.length,
+        totalMatches: offsets.length,
+        via: fallbacks === 0 ? 'minimalRedline' : (minimal === 0 ? 'fullReplace' : 'mixed'),
+        edits: editSegments
+      }
+      if (fallbacks) result.fallbacks = fallbacks
+      if (!editSegments && !fallbacks) result.note = '新旧文本一致，未产生修订'
+      return result
+    })
+  },
+
+  async insert_text(args) {
+    const text = String(args.text || '')
+    const anchorText = String(args.anchorText || '')
+    const position = args.position === 'before' ? 'before' : 'after'
+    if (!text) throw new Error('插入文本不能为空')
+    const doc = activeDoc()
+    const content = normalizeNewlines(text)
+    return withTracking(doc, () => {
+      if (anchorText) {
+        const { range } = anchorRange(doc, anchorText, {
+          position,
+          message: '未找到锚点文本，请确认 anchorText 与文档内容精确一致'
+        })
+        if (position === 'before') range.InsertBefore(content)
+        else range.InsertAfter(content)
+      } else {
+        // 无锚点：落在用户当前光标/选区处（选区被替换，与光标插入语义一致）
+        app().Selection.Text = content
+      }
+      return { inserted: true, anchored: !!anchorText, position: anchorText ? position : 'selection' }
+    })
+  },
+
+  async add_comment(args) {
+    const anchorText = String(args.anchorText || '')
+    const comment = String(args.comment || '')
+    if (!anchorText) throw new Error('批注目标文本不能为空')
+    if (!comment) throw new Error('批注内容不能为空')
+    const doc = activeDoc()
+    const { range } = anchorRange(doc, anchorText, {
+      message: '未找到批注目标文本，请确认 anchorText 与文档内容精确一致'
+    })
+    doc.Comments.Add(range, comment)
+    return { commented: true }
+  },
+
+  // ==================== 格式（走 WPS 原生修订） ====================
+
+  async format_text(args) {
+    const anchorText = String(args.anchorText || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    const plan = buildFontPlan(args)
+    if (plan.empty) {
+      throw new Error('未给出任何格式参数（fontName/fontSize/bold/italic/underline/strikeThrough/doubleStrikeThrough/color 至少给一个）')
+    }
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { offsets, needle } = locateAnchorAll(doc, anchorText)
+      const targetOffsets = args.applyToAll ? offsets : [offsets[0]]
+      for (const offset of targetOffsets) {
+        const range = verifiedRange(doc, offset, needle)
+        applyFontPlan(range.Font, plan)
+      }
+      return { formatted: targetOffsets.length, totalMatches: offsets.length, applied: plan.applied }
+    })
+  },
+
+  async set_paragraph_format(args) {
+    const anchorText = String(args.anchorText || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    const plan = buildParagraphPlan(args)
+    const styleBuiltIn = args.styleBuiltIn == null
+      ? null
+      : toEnumValue(PARAGRAPH_STYLES, args.styleBuiltIn, 'styleBuiltIn')
+    if (styleBuiltIn == null && plan.empty) {
+      throw new Error('未给出任何格式参数（alignment/lineSpacing/spaceBefore/spaceAfter/firstLineIndent/leftIndent/rightIndent/styleBuiltIn 至少给一个）')
+    }
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { offsets, needle } = locateAnchorAll(doc, anchorText)
+      const targetOffsets = args.applyToAll ? offsets : [offsets[0]]
+      const paragraphs = targetOffsets.map((offset) => verifiedRange(doc, offset, needle).Paragraphs.Item(1))
+      // 套内置样式会把段落格式重置成样式自带的那套，必须先落样式再落其余参数
+      if (styleBuiltIn != null) {
+        for (const p of paragraphs) p.Range.Style = styleBuiltIn
+      }
+      for (const p of paragraphs) {
+        const pf = p.Format
+        for (const op of plan.ops) op(pf)
+      }
+      const applied = styleBuiltIn != null ? { ...plan.applied, styleBuiltIn: args.styleBuiltIn } : plan.applied
+      const result = { formatted: paragraphs.length, totalMatches: offsets.length, applied }
+      // WPS 原生支持「最小值」行距（Office 面只能 exact），向模型交底
+      if (args.lineSpacing != null) result.lineSpacingMode = 'atLeast'
+      return result
+    })
+  },
+
+  async get_formatting(args) {
+    const anchorText = String(args.anchorText || '')
+    const doc = activeDoc()
+    let range
+    let source
+    if (anchorText) {
+      range = anchorRange(doc, anchorText).range
+      source = 'anchor'
+    } else {
+      range = app().Selection.Range
+      source = 'selection'
+    }
+    const paragraph = range.Paragraphs.Item(1)
+    const font = range.Font
+    const pf = paragraph.Format
+    const num = (v) => (v == null || v === wdUndefined ? null : Number(v))
+    let styleName = null
+    try {
+      // Style 属性的 JS 返回形态未文档化：可能是样式对象也可能是字符串
+      const st = paragraph.Style
+      if (st != null) {
+        styleName = typeof st === 'object' ? String(st.NameLocal || st.Name || '') : String(st)
+      }
+    } catch (e) { /* 样式读不出不阻塞其余格式信息 */ }
+    const styleShort = styleName ? STYLE_SHORT_BY_NAME[styleName.trim().toLowerCase()] : undefined
+    return {
+      source,
+      text: String(range.Text || '').slice(0, 200),
+      font: {
+        name: font.Name === wdUndefined ? null : font.Name,
+        size: num(font.Size),
+        bold: triToBool(font.Bold),
+        italic: triToBool(font.Italic),
+        underline: font.Underline === wdUndefined ? null : fromEnumValue(UNDERLINE_TYPES, font.Underline),
+        strikeThrough: triToBool(font.StrikeThrough),
+        color: bgrToHex(font.Color)
+      },
+      paragraph: {
+        alignment: fromEnumValue(ALIGNMENTS, pf.Alignment),
+        lineSpacing: num(pf.LineSpacing),
+        // 比 Office 面多回的字段：WPS 行距有 rule 维度（3=atLeast/4=exactly 等）
+        lineSpacingRule: num(pf.LineSpacingRule),
+        spaceBefore: num(pf.SpaceBefore),
+        spaceAfter: num(pf.SpaceAfter),
+        firstLineIndent: num(pf.FirstLineIndent),
+        leftIndent: num(pf.LeftIndent),
+        rightIndent: num(pf.RightIndent),
+        style: styleName,
+        styleBuiltIn: styleShort
+      }
+    }
+  },
+
+  async set_numbering(args) {
+    const anchorText = String(args.anchorText || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    const kind = String(args.kind || '').trim().toLowerCase()
+    if (!NUMBERING_KINDS.includes(kind)) {
+      throw new Error(`kind 值非法：${args.kind}（合法值：${NUMBERING_KINDS.join('/')}）`)
+    }
+    let count = Math.floor(Number(args.paragraphCount))
+    if (!Number.isFinite(count) || count < 1) count = 1
+    count = Math.min(count, MAX_NUMBERING_PARAGRAPHS)
+    const doc = activeDoc()
+    const needle = normalizeNewlines(anchorText)
+    return withTracking(doc, () => {
+      const paras = doc.Paragraphs
+      const total = paras.Count
+      let start = -1
+      for (let k = 1; k <= total; k++) {
+        if (String(paras.Item(k).Range.Text || '').includes(needle)) {
+          start = k
+          break
+        }
+      }
+      if (start < 0) {
+        throw new Error('未找到锚点段落，请确认 anchorText 与文档内容精确一致（可先用 search 命令核对）')
+      }
+      const last = Math.min(total, start + count - 1)
+      const targetCount = last - start + 1
+      const range = doc.Range(paras.Item(start).Range.Start, paras.Item(last).Range.End)
+      const lf = range.ListFormat
+      if (kind === 'none') {
+        lf.RemoveNumbers()
+        return { paragraphs: targetCount, kind, via: 'listApi' }
+      }
+      if (kind === 'bullet') {
+        lf.ApplyBulletDefault()
+        return { paragraphs: targetCount, kind, via: 'listApi' }
+      }
+      if (kind === 'decimal') {
+        lf.ApplyNumberDefault()
+        return { paragraphs: targetCount, kind, via: 'listApi' }
+      }
+      // chinese：原生 wdListNumberStyleSimpChinNum2（38，「一、二、」）走 ListTemplate
+      // ——Office.js 做不到的能力升级；失败降级手写「一、」前缀
+      try {
+        const lt = app().ListGalleries.Item(wdNumberGallery).ListTemplates.Item(1)
+        const lv = lt.ListLevels.Item(1)
+        lv.NumberStyle = wdListNumberStyleSimpChinNum2
+        lv.NumberFormat = '%1、'
+        lf.ApplyListTemplateWithLevel(lt, false, wdListApplyToWholeList, wdWord9ListBehavior, 1)
+        return { paragraphs: targetCount, kind, via: 'listTemplate' }
+      } catch (e) {
+        // 从后往前写前缀：前面段落的插入不会推移未写段落的定位
+        for (let k = last; k >= start; k--) {
+          doc.Paragraphs.Item(k).Range.InsertBefore(chineseNumeral(k - start + 1) + '、')
+        }
+        return {
+          paragraphs: targetCount,
+          kind,
+          via: 'literalText',
+          note: '当前 WPS 版本套用中文编号列表模板失败，编号已作为文字写入各段段首'
+        }
+      }
+    })
+  },
+
+  async format_table(args) {
+    const borders = args.borders == null ? null : String(args.borders).trim().toLowerCase()
+    if (borders && !['all', 'outside', 'inside', 'none'].includes(borders)) {
+      throw new Error(`borders 值非法：${args.borders}（合法值：all/outside/inside/none）`)
+    }
+    const alignment = args.alignment == null ? null : toEnumValue(TABLE_ALIGNMENTS, args.alignment, 'alignment')
+    const fontSize = args.fontSize == null ? null : Number(args.fontSize)
+    if (!borders && alignment == null && args.headerBold == null && args.autoFit == null && fontSize == null) {
+      throw new Error('未给出任何格式参数（borders/alignment/headerBold/autoFit/fontSize 至少给一个）')
+    }
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { table, index, count } = getTable(doc, args.tableIndex)
+      const applied = {}
+      if (borders === 'none') {
+        try {
+          table.Borders.Enable = 0
+        } catch (e) {
+          // Enable 是 VBA 惯用法但 WPS 未给示例——备胎逐边关（1x1 表可能缺内框线，逐边容错）
+          for (const side of [wdBorderTop, wdBorderLeft, wdBorderBottom, wdBorderRight, wdBorderHorizontal, wdBorderVertical]) {
+            try {
+              table.Borders.Item(side).LineStyle = wdLineStyleNone
+            } catch (e2) { /* 该边不存在 */ }
+          }
+        }
+        applied.borders = 'none'
+      } else if (borders) {
+        const colorHex = String(args.borderColor || '#000000')
+        const colorBgr = hexToBgr(colorHex)
+        const widthPt = Number(args.borderWidth) > 0 ? Number(args.borderWidth) : 1
+        const lineWidth = toLineWidth(widthPt)
+        const b = table.Borders
+        if (borders === 'all' || borders === 'outside') {
+          b.OutsideLineStyle = wdLineStyleSingle
+          b.OutsideLineWidth = lineWidth
+          b.OutsideColor = colorBgr
+        }
+        if (borders === 'all' || borders === 'inside') {
+          b.InsideLineStyle = wdLineStyleSingle
+          b.InsideLineWidth = lineWidth
+          b.InsideColor = colorBgr
+        }
+        applied.borders = borders
+        applied.borderColor = colorHex
+        applied.borderWidth = widthPt
+      }
+      if (alignment != null) {
+        table.Rows.Alignment = alignment
+        applied.alignment = String(args.alignment).trim().toLowerCase()
+      }
+      if (args.headerBold != null) {
+        table.Rows.Item(1).Range.Font.Bold = args.headerBold ? msoTrue : msoFalse
+        applied.headerBold = !!args.headerBold
+      }
+      if (fontSize != null) {
+        table.Range.Font.Size = fontSize
+        applied.fontSize = fontSize
+      }
+      if (args.autoFit) {
+        table.AutoFitBehavior(wdAutoFitWindow)
+        applied.autoFit = true
+      }
+      return { tableIndex: index, tableCount: count, rowCount: table.Rows.Count, applied }
+    })
+  },
+
+  async apply_standard_format(args) {
+    const scope = String(args.scope || 'document').trim().toLowerCase() === 'selection' ? 'selection' : 'document'
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const paras = scope === 'selection' ? app().Selection.Range.Paragraphs : doc.Paragraphs
+      const total = paras.Count
+      const truncated = total > MAX_STANDARD_FORMAT_PARAGRAPHS
+      const limit = truncated ? MAX_STANDARD_FORMAT_PARAGRAPHS : total
+
+      let firstNonEmptySeen = false
+      let titles = 0
+      let headings = 0
+      let bodies = 0
+      for (let k = 1; k <= limit; k++) {
+        const p = paras.Item(k)
+        const text = String(p.Range.Text || '').replace(/\r$/, '').trim()
+        if (!text) continue
+        let kind = 'body'
+        if (!firstNonEmptySeen) {
+          firstNonEmptySeen = true
+          if (text.length <= HOUSE_TITLE_MAX_CHARS) kind = 'title'
+        } else if (text.length <= HOUSE_HEADING_MAX_CHARS && HEADING_RE.test(text)) {
+          kind = 'heading'
+        }
+        const f = p.Range.Font
+        // 中西文分设字体（NameFarEast/NameAscii/NameOther）在 WPS 无版本门槛
+        f.NameFarEast = HOUSE.fontAsian
+        f.NameAscii = HOUSE.fontWestern
+        f.NameOther = HOUSE.fontWestern
+        f.Size = kind === 'title' ? HOUSE.titlePt : HOUSE.bodyPt
+        f.Bold = kind !== 'body' ? msoTrue : msoFalse
+        f.Color = 0 // 黑色（BGR）
+        const pf = p.Format
+        pf.Alignment = kind === 'title' ? wdAlignParagraphCenter : wdAlignParagraphJustify
+        // 真·最小值行距（wdLineSpaceAtLeast + LineSpacing 两件套）——Office 面做不到
+        pf.LineSpacingRule = wdLineSpaceAtLeast
+        pf.LineSpacing = HOUSE.lineSpacingPt
+        pf.SpaceBefore = 0
+        pf.SpaceAfter = HOUSE.spaceAfterPt
+        pf.FirstLineIndent = kind === 'body' ? HOUSE.firstLineIndentPt : 0
+        if (kind === 'title') titles++
+        else if (kind === 'heading') headings++
+        else bodies++
+      }
+
+      // 表格字号只在全文范围处理（选区里的表格不在 v1 范围，与 Office 面一致）
+      let tableCount = 0
+      if (scope === 'document') {
+        const tables = doc.Tables
+        tableCount = tables.Count
+        for (let k = 1; k <= tableCount; k++) {
+          tables.Item(k).Range.Font.Size = HOUSE.tablePt
+        }
+      }
+
+      const result = {
+        scope,
+        paragraphs: titles + headings + bodies,
+        titles,
+        headings,
+        tables: tableCount,
+        fontSplit: true,
+        // WPS 原生支持「行距最小值 16 磅」（Office 面被迫降成 exact）
+        lineSpacingMode: 'atLeast'
+      }
+      if (truncated) {
+        result.truncated = true
+        result.totalParagraphs = total
+      }
+      if (scope === 'selection') result.note = '选区范围不处理表格字号'
+      return result
+    })
+  },
+
+  // ==================== 表格结构 ====================
+
+  async insert_table(args) {
+    const rows = args.rows
+    if (!Array.isArray(rows) || !rows.length || !Array.isArray(rows[0]) || !rows[0].length) {
+      throw new Error('rowsJson 不能为空表')
+    }
+    const rowCount = rows.length
+    const colCount = rows[0].length
+    const anchorText = String(args.anchorText || '')
+    const position = args.position === 'before' ? 'before' : 'after'
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      let at
+      if (anchorText) {
+        const { range } = anchorRange(doc, anchorText, {
+          position,
+          message: '未找到锚点文本，请确认 anchorText 与文档内容精确一致'
+        })
+        const pos = position === 'before' ? range.Start : range.End
+        at = doc.Range(pos, pos) // Tables.Add 的 Range 未折叠会替换区域内容，必须折叠
+      } else {
+        const sr = app().Selection.Range
+        at = doc.Range(sr.End, sr.End)
+      }
+      const table = doc.Tables.Add(at, rowCount, colCount)
+      for (let r = 1; r <= rowCount; r++) {
+        for (let c = 1; c <= colCount; c++) {
+          const v = rows[r - 1][c - 1]
+          table.Cell(r, c).Range.Text = v == null ? '' : String(v)
+        }
+      }
+      if (args.headerBold) table.Rows.Item(1).Range.Font.Bold = msoTrue
+      return { inserted: true, rows: rowCount, cols: colCount, anchored: !!anchorText }
+    })
+  },
+
+  async table_read(args) {
+    const doc = activeDoc()
+    const { table, index, count } = getTable(doc, args.tableIndex)
+    const out = []
+    const rowCount = table.Rows.Count
+    for (let r = 1; r <= rowCount; r++) {
+      // 按行遍历 Cells（不是 Cell(r,c) 坐标）：合并单元格时坐标访问会出错，Cells 数量天然可变
+      const cells = table.Rows.Item(r).Cells
+      const row = []
+      const cellCount = cells.Count
+      for (let c = 1; c <= cellCount; c++) {
+        row.push(cleanCellText(cells.Item(c).Range.Text).trim())
+      }
+      out.push(row)
+    }
+    return {
+      tableIndex: index,
+      tableCount: count,
+      rowCount: out.length,
+      colCount: table.Columns.Count,
+      cells: out
+    }
+  },
+
+  async table_set_cell(args) {
+    const { row, col } = parseCellRef(args.cell)
+    const text = args.text == null ? '' : String(args.text)
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { table } = getTable(doc, args.tableIndex)
+      let cell
+      try {
+        cell = table.Cell(row + 1, col + 1)
+      } catch (e) {
+        cell = null
+      }
+      if (!cell) {
+        throw new Error(`单元格 ${args.cell} 不存在（可能越界或落在合并单元格里），请先用 office_table_read 核对`)
+      }
+      const cr = cell.Range
+      const cur = cleanCellText(cr.Text)
+      const newText = normalizeNewlines(text)
+      const multiline = /\r/.test(newText)
+      // 最小修订：单元格 Range 的 Start 给出绝对偏移，差异段直接偏移落笔（右到左）
+      let via = null
+      let edits = 0
+      if (!multiline && cur) {
+        const cellStart = cr.Start
+        const minimal = minimalEdits(cur, newText)
+        if (!minimal.length) {
+          via = 'unchanged'
+        } else if (!(minimal.length === 1 && minimal[0].start === 0 && minimal[0].end === cur.length)) {
+          let verified = true
+          for (const e of minimal) {
+            if (e.start === e.end) continue
+            if (String(doc.Range(cellStart + e.start, cellStart + e.end).Text) !== e.oldText) {
+              verified = false
+              break
+            }
+          }
+          if (verified) {
+            for (let k = minimal.length - 1; k >= 0; k--) {
+              const e = minimal[k]
+              if (e.start === e.end) doc.Range(cellStart + e.start, cellStart + e.start).InsertBefore(e.newText)
+              else doc.Range(cellStart + e.start, cellStart + e.end).Text = e.newText
+            }
+            via = 'minimalRedline'
+            edits = minimal.length
+          }
+        }
+      }
+      if (via == null) {
+        // 整格替换兜底：优先内容子 Range（避开 \r\x07 结束符），偏移不可信时退回
+        // cell.Range.Text 整赋（VBA 惯用法，Word 会保住结束符——WPS 待真机验证）
+        const content = doc.Range(cr.Start, cr.Start + cur.length)
+        if (String(content.Text) === cur) content.Text = newText
+        else cr.Text = newText
+        via = 'fullReplace'
+      }
+      return { cell: args.cell, via, edits }
+    })
+  },
+
+  async table_add_row(args) {
+    let position = Math.floor(Number(args.position))
+    if (!Number.isFinite(position)) position = -1
+    const count = Math.max(1, Math.floor(Number(args.count)) || 1)
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { table, index } = getTable(doc, args.tableIndex)
+      for (let k = 0; k < count; k++) {
+        const rowCount = table.Rows.Count
+        if (position < 0 || position >= rowCount) table.Rows.Add() // 省略参数 = 加到末尾
+        else table.Rows.Add(table.Rows.Item(position + 1)) // 插在该行之前
+      }
+      return { tableIndex: index, added: count, rowCount: table.Rows.Count }
+    })
+  },
+
+  // 表格结构删除不产生修订（tracked:false 契约与 Office 面一致）；WPS 下修订开着会把
+  // 被删行留在表中导致连删错位，所以执行期临时关修订（见 withTrackingOff 注释）
+  async table_delete_row(args) {
+    const position = Math.floor(Number(args.position))
+    const count = Math.max(1, Math.floor(Number(args.count)) || 1)
+    if (!Number.isFinite(position) || position < 0) throw new Error('缺少要删的行号（position，0 开始）')
+    const doc = activeDoc()
+    return withTrackingOff(doc, () => {
+      const { table, index } = getTable(doc, args.tableIndex)
+      const rowCount = table.Rows.Count
+      if (position >= rowCount) {
+        throw new Error(`rowIndex ${position} 越界：表格共 ${rowCount} 行（序号从 0 开始）`)
+      }
+      if (rowCount - count < 1) {
+        throw new Error(`表格至少要留一行，当前 ${rowCount} 行删不了 ${count} 行`)
+      }
+      // 同一 index 连删 count 次：删掉一行后，后面的行顶上来
+      for (let k = 0; k < count; k++) table.Rows.Item(position + 1).Delete()
+      return { tableIndex: index, deleted: count, rowCount: table.Rows.Count, tracked: false }
+    })
+  },
+
+  async table_add_col(args) {
+    let position = Math.floor(Number(args.position))
+    if (!Number.isFinite(position)) position = -1
+    const count = Math.max(1, Math.floor(Number(args.count)) || 1)
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { table, index } = getTable(doc, args.tableIndex)
+      const cols = table.Columns
+      for (let k = 0; k < count; k++) {
+        const colCount = cols.Count
+        if (position < 0 || position >= colCount) cols.Add() // 省略参数 = 加到末尾
+        else cols.Add(cols.Item(position + 1)) // 插在该列之前（中间插列在 WPS 无版本门槛）
+      }
+      return { tableIndex: index, added: count, colCount: cols.Count }
+    })
+  },
+
+  async table_delete_col(args) {
+    const position = Math.floor(Number(args.position))
+    const count = Math.max(1, Math.floor(Number(args.count)) || 1)
+    if (!Number.isFinite(position) || position < 0) throw new Error('缺少要删的列号（position，0 开始）')
+    const doc = activeDoc()
+    return withTrackingOff(doc, () => {
+      const { table, index } = getTable(doc, args.tableIndex)
+      const cols = table.Columns
+      const colCount = cols.Count
+      if (position >= colCount) {
+        throw new Error(`colIndex ${position} 越界：表格共 ${colCount} 列（序号从 0 开始）`)
+      }
+      if (colCount - count < 1) {
+        throw new Error(`表格至少要留一列，当前 ${colCount} 列删不了 ${count} 列`)
+      }
+      for (let k = 0; k < count; k++) cols.Item(position + 1).Delete()
+      return { tableIndex: index, deleted: count, colCount: cols.Count, tracked: false }
+    })
+  },
+
+  // ==================== 结构（分页符/超链接/页眉页脚） ====================
+
+  async insert_break(args) {
+    const type = args.breakType === 'sectionNext' ? wdSectionBreakNextPage : wdPageBreak
+    const anchorText = String(args.anchorText || '')
+    const position = args.position === 'before' ? 'before' : 'after'
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      let pos
+      if (anchorText) {
+        const { range } = anchorRange(doc, anchorText, {
+          position,
+          message: '未找到锚点文本，请确认 anchorText 与文档内容精确一致'
+        })
+        pos = position === 'before' ? range.Start : range.End
+      } else {
+        const sr = app().Selection.Range
+        pos = position === 'before' ? sr.Start : sr.End
+      }
+      // InsertBreak 的 Range 未折叠会替换区域内容（官方原文警告），先折叠到目标点
+      doc.Range(pos, pos).InsertBreak(type)
+      return { inserted: true, breakType: args.breakType || 'page', anchored: !!anchorText }
+    })
+  },
+
+  async set_hyperlink(args) {
+    const anchorText = String(args.anchorText || '')
+    const url = String(args.url || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    if (!url) throw new Error('url 不能为空')
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { range } = anchorRange(doc, anchorText)
+      // 不传 TextToDisplay：本命令语义是「给现有文本加链」，传了会替换锚点文本
+      doc.Hyperlinks.Add(range, url)
+      return { linked: true, url }
+    })
+  },
+
+  async edit_header_footer(args) {
+    const part = args.part === 'footer' ? 'footer' : 'header'
+    const text = args.text == null ? '' : String(args.text)
+    const alignment = args.alignment == null ? null : toEnumValue(ALIGNMENTS, args.alignment, 'alignment')
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const section = doc.Sections.Item(1)
+      const hf = (part === 'footer' ? section.Footers : section.Headers).Item(wdHeaderFooterPrimary)
+      // 页眉/页脚在独立 story，偏移与正文互不相干；整替与 Office 面 insertText(replace) 同语义
+      hf.Range.Text = normalizeNewlines(text)
+      if (alignment != null) {
+        // 一把设全部段落（ParagraphFormat 作用于 Range 内所有段落）
+        hf.Range.ParagraphFormat.Alignment = alignment
+      }
+      return { part, textLength: text.length, alignment: args.alignment || null }
+    })
+  },
+
+  // ==================== 批注（读取/回复/解决） ====================
+
+  async get_comments() {
+    const doc = activeDoc()
+    const cs = doc.Comments
+    const count = cs.Count
+    const comments = []
+    for (let i = 1; i <= count; i++) {
+      const c = cs.Item(i)
+      let anchorTextVal = ''
+      try {
+        anchorTextVal = String((c.Scope && c.Scope.Text) || '').slice(0, 200)
+      } catch (e) { /* 锚定区取不到不阻塞列表 */ }
+      let isReply = false
+      try {
+        isReply = !!c.Ancestor
+      } catch (e) { /* 老版本没有 Ancestor */ }
+      comments.push({
+        index: i - 1,
+        // WPS 批注无 GUID：id 就是 0 起的序号字符串（与 index 同口径），
+        // 序号随删除/接受塌缩——后续操作前会重新读集合
+        id: String(i - 1),
+        author: String(c.Author || ''),
+        content: String((c.Range && c.Range.Text) || '').replace(/\r$/, ''),
+        createdAt: toIso(c.Date),
+        resolved: !!c.Done,
+        anchorText: anchorTextVal,
+        isReply
+      })
+    }
+    return { count, comments }
+  },
+
+  async reply_comment(args) {
+    const reply = String(args.reply || '')
+    if (!reply) throw new Error('回复内容不能为空')
+    const doc = activeDoc()
+    // 每次操作前重新读集合（序号随删除/解决塌缩重排）
+    const cs = doc.Comments
+    const idx = resolveCommentIndex(args, cs.Count)
+    const c = cs.Item(idx + 1)
+    try {
+      // 主路：Comment.Replies（Comments 集合）上 Add——调研标注的最高风险类推，
+      // 无官方示例，真机不通就走降级
+      c.Replies.Add(c.Scope, reply)
+      return { replied: true }
+    } catch (e) {
+      try {
+        // 降级：把回复文本追加进原批注正文（不是线程回复，返回值交底）
+        const r = c.Range
+        const prev = String(r.Text || '').replace(/\r$/, '')
+        r.Text = prev ? prev + '\r' + reply : reply
+        return {
+          replied: true,
+          via: 'appendText',
+          note: '当前 WPS 版本不支持批注线程回复，回复内容已追加到原批注正文末尾'
+        }
+      } catch (e2) {
+        throw new Error(`回复批注失败：${(e2 && e2.message) || String(e2)}`)
+      }
+    }
+  },
+
+  async resolve_comment(args) {
+    const resolved = args.resolved !== false
+    const doc = activeDoc()
+    const cs = doc.Comments
+    const idx = resolveCommentIndex(args, cs.Count)
+    cs.Item(idx + 1).Done = resolved // Done 可读写，可反向设 false 重开
+    return { resolved }
+  },
+
+  // ==================== 修订读取/接受/拒绝 ====================
+
+  async get_revisions() {
+    const doc = activeDoc()
+    const rs = doc.Revisions
+    const count = rs.Count
+    const revisions = []
+    for (let i = 1; i <= count; i++) {
+      const r = rs.Item(i)
+      let text = ''
+      try {
+        text = String((r.Range && r.Range.Text) || '').slice(0, 200)
+      } catch (e) { /* 结构修订可能无文本 */ }
+      const typeRaw = Number(r.Type)
+      revisions.push({
+        index: i - 1,
+        author: String(r.Author || ''),
+        date: toIso(r.Date),
+        type: REVISION_TYPE_NAMES[typeRaw] || String(r.Type),
+        text
+      })
+    }
+    return { count, revisions }
+  },
+
+  async accept_revision(args) {
+    const doc = activeDoc()
+    const rs = doc.Revisions
+    if (args.all) {
+      rs.AcceptAll()
+      return { acceptedAll: true }
+    }
+    // 每次重新读集合：Accept 单条后集合立即塌缩、序号重排
+    const index = Math.floor(Number(args.revisionIndex))
+    if (!Number.isFinite(index) || index < 0 || index >= rs.Count) {
+      throw new Error(`revisionIndex ${args.revisionIndex} 越界：文档共 ${rs.Count} 条修订（序号从 0 开始）`)
+    }
+    rs.Item(index + 1).Accept()
+    return { accepted: true, revisionIndex: index }
+  },
+
+  async reject_revision(args) {
+    const doc = activeDoc()
+    const rs = doc.Revisions
+    if (args.all) {
+      rs.RejectAll()
+      return { rejectedAll: true }
+    }
+    const index = Math.floor(Number(args.revisionIndex))
+    if (!Number.isFinite(index) || index < 0 || index >= rs.Count) {
+      throw new Error(`revisionIndex ${args.revisionIndex} 越界：文档共 ${rs.Count} 条修订（序号从 0 开始）`)
+    }
+    rs.Item(index + 1).Reject()
+    return { rejected: true, revisionIndex: index }
+  },
+
+  // ==================== 脚注/尾注 ====================
+
+  async insert_footnote(args) {
+    const anchorText = String(args.anchorText || '')
+    const text = String(args.text || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    if (!text) throw new Error('脚注正文内容不能为空')
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { range } = anchorRange(doc, anchorText)
+      // 脚注号打在锚点末尾（折叠到 End）；Reference 传 undefined 触发自动编号
+      doc.Footnotes.Add(doc.Range(range.End, range.End), undefined, text)
+      return { inserted: true }
+    })
+  },
+
+  async insert_endnote(args) {
+    const anchorText = String(args.anchorText || '')
+    const text = String(args.text || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    if (!text) throw new Error('尾注正文内容不能为空')
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { range } = anchorRange(doc, anchorText)
+      doc.Endnotes.Add(doc.Range(range.End, range.End), undefined, text)
+      return { inserted: true }
+    })
+  },
+
+  // ==================== 图片插入（本版不支持） ====================
+
+  async insert_image() {
+    // WPS 的 InlineShapes.AddPicture 只吃本地文件路径，没有 base64 直插通路，
+    // wps.FileSystem 也没有可用的二进制写接口——不能静默吞，明确告知模型
+    throw new Error('WPS 宿主暂不支持插入图片：当前版本无法从 base64 数据直接插图（本地路径方案待后续版本支持），请勿重试该命令，可改为在文中说明图片位置')
+  },
+
+  // ==================== 样式应用 ====================
+
+  async apply_style(args) {
+    const anchorText = String(args.anchorText || '')
+    const styleName = String(args.styleName || '')
+    if (!anchorText) throw new Error('目标文本不能为空')
+    if (!styleName) throw new Error('样式名不能为空')
+    const doc = activeDoc()
+    return withTracking(doc, () => {
+      const { offsets, needle } = locateAnchorAll(doc, anchorText)
+      const targetOffsets = args.applyToAll ? offsets : [offsets[0]]
+      const paragraphs = targetOffsets.map((offset) => verifiedRange(doc, offset, needle).Paragraphs.Item(1))
+      for (const p of paragraphs) {
+        try {
+          // Range.Style 接受本地化样式名/整数常量/样式对象（官方原文）
+          p.Range.Style = styleName
+        } catch (e) {
+          // 样式名不存在（常见：模型给英文名而文档是中文版）——按内置样式常量表垫底
+          const builtin = BUILTIN_STYLE_BY_NAME[styleName.trim().toLowerCase()]
+          if (builtin == null) {
+            throw new Error(`样式「${styleName}」不存在：请使用文档里已有的样式名（中文版内置样式如「标题 1」），或改用 set_paragraph_format 的 styleBuiltIn 参数`)
+          }
+          p.Range.Style = builtin
+        }
+      }
+      return { applied: paragraphs.length, totalMatches: offsets.length, styleName }
+    })
+  },
+
+  // ==================== 内容控件 ====================
+
+  async manage_content_control(args) {
+    const action = String(args.action || '')
+    const tag = String(args.tag || '')
+    if (!tag) throw new Error('tag 不能为空')
+    const doc = activeDoc()
+
+    if (action === 'insert') {
+      const anchorText = String(args.anchorText || '')
+      if (!anchorText) throw new Error('insert 需要 anchorText')
+      return withTracking(doc, () => {
+        const { range } = anchorRange(doc, anchorText, {
+          message: '未找到锚点文本，请确认 anchorText 与文档内容精确一致'
+        })
+        // 包裹锚点所在段落（与 Office 面的 Paragraph.insertContentControl 同语义）
+        const pr = range.Paragraphs.Item(1).Range
+        const cc = doc.ContentControls.Add(wdContentControlRichText, pr)
+        cc.Tag = tag
+        if (args.title) cc.Title = String(args.title)
+        return { inserted: true, tag }
+      })
+    }
+
+    // 定位：优先 SelectContentControlsByTag，退回遍历集合过滤 Tag
+    let cc = null
+    try {
+      if (typeof doc.SelectContentControlsByTag === 'function') {
+        const ccs = doc.SelectContentControlsByTag(tag)
+        if (ccs && ccs.Count > 0) cc = ccs.Item(1)
+      }
+    } catch (e) { /* 走遍历 */ }
+    if (!cc) {
+      try {
+        const all = doc.ContentControls
+        for (let k = 1; k <= all.Count; k++) {
+          const item = all.Item(k)
+          if (String(item.Tag || '') === tag) {
+            cc = item
+            break
+          }
+        }
+      } catch (e) { /* 集合不可用按未找到处理 */ }
+    }
+    if (!cc) throw new Error(`未找到 tag 为 ${tag} 的内容控件`)
+
+    if (action === 'read') {
+      return { tag, title: String(cc.Title || ''), text: String((cc.Range && cc.Range.Text) || '').replace(/\r$/, '') }
+    }
+    if (action === 'set_text') {
+      const text = args.text == null ? '' : String(args.text)
+      return withTracking(doc, () => {
+        cc.Range.Text = normalizeNewlines(text)
+        return { updated: true, tag }
+      })
+    }
+    if (action === 'delete') {
+      const keepContent = !!args.keepContent
+      return withTracking(doc, () => {
+        // 参数语义与 Office 面相反：WPS/VBA 是 Delete(DeleteContents)，传 !keepContent
+        cc.Delete(!keepContent)
+        return { deleted: true, tag, keepContent }
+      })
+    }
+    throw new Error(`action 值非法：${args.action}`)
+  },
+
+  // ==================== 文档属性 ====================
+
+  async set_document_properties(args) {
+    const doc = activeDoc()
+    const props = doc.BuiltInDocumentProperties
+    const applied = {}
+    const setProp = (key, enumVal, raw) => {
+      if (raw == null) return
+      props.Item(enumVal).Value = String(raw)
+      applied[key] = raw
+    }
+    // 文档属性无修订概念，不走 withTracking（与 Office 面一致）
+    setProp('title', wdPropertyTitle, args.title)
+    setProp('subject', wdPropertySubject, args.subject)
+    setProp('author', wdPropertyAuthor, args.author)
+    setProp('keywords', wdPropertyKeywords, args.keywords)
+    setProp('comments', wdPropertyComments, args.comments)
+    setProp('category', wdPropertyCategory, args.category)
+    return { applied }
+  }
+}

--- a/office-addin/taskpane/lib/wpsWordHandlers.test.js
+++ b/office-addin/taskpane/lib/wpsWordHandlers.test.js
@@ -1,0 +1,498 @@
+/**
+ * wpsWordHandlers 单测：mock globalThis.wps 的 VBA 风对象模型（同步桥），
+ * 覆盖偏移直切定位、最小修订与回退、withTracking 保存/恢复、编号降级、
+ * 批注回复降级与若干错误路径。
+ *   node --test office-addin/taskpane/lib/wpsWordHandlers.test.js
+ *
+ * mock 的文档主体是一根 JS 字符串：Range(s,e) 直接切片读写，段落按 \r 派生
+ * ——这与 WPS 的字符偏移口径同构，天然能验证「右到左应用」的偏移稳定性
+ * （mock 的写入会真实推移右侧偏移，应用顺序错了测试就会红）。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { WPS_WORD_HANDLERS as H, locateInWpsDocument } from './wpsWordHandlers.js'
+
+/* ==================== VBA 风 mock ==================== */
+
+function installWps(opts = {}) {
+  const state = {
+    text: opts.text || '',
+    track: false,
+    trackLog: [],
+    writes: [], // {kind, prop, value, start, end}
+    calls: [], // {name, ...}
+    selected: null
+  }
+
+  function fullLen() {
+    return state.text.length
+  }
+
+  function makeRecorder(kind, start, end) {
+    return new Proxy({}, {
+      set(t, prop, v) {
+        if (opts.throwOnWrite && opts.throwOnWrite.kind === kind && opts.throwOnWrite.prop === prop) {
+          throw new Error(`mock：拒绝写 ${kind}.${prop}`)
+        }
+        state.writes.push({ kind, prop, value: v, start, end })
+        t[prop] = v
+        return true
+      },
+      get(t, prop) {
+        return t[prop]
+      }
+    })
+  }
+
+  function paragraphSegs() {
+    const parts = state.text.split('\r')
+    const segs = []
+    let pos = 0
+    for (let k = 0; k < parts.length; k++) {
+      const segStart = pos
+      const segEnd = pos + parts[k].length + (k < parts.length - 1 ? 1 : 0)
+      segs.push({ start: segStart, end: segEnd })
+      pos = segEnd
+    }
+    return segs
+  }
+
+  function makeParagraph(seg) {
+    return {
+      get Range() {
+        return makeRange(seg.start, seg.end)
+      },
+      get Format() {
+        return makeRecorder('paraFormat', seg.start, seg.end)
+      }
+    }
+  }
+
+  function paragraphsIn(s, e) {
+    let list = paragraphSegs().filter((g) => g.start < e && s < g.end)
+    if (!list.length) list = paragraphSegs().filter((g) => s >= g.start && s <= g.end)
+    const items = list.map(makeParagraph)
+    return { Count: items.length, Item: (i) => items[i - 1] }
+  }
+
+  const listFormat = {
+    RemoveNumbers: () => state.calls.push({ name: 'RemoveNumbers' }),
+    ApplyBulletDefault: () => state.calls.push({ name: 'ApplyBulletDefault' }),
+    ApplyNumberDefault: () => state.calls.push({ name: 'ApplyNumberDefault' }),
+    ApplyListTemplateWithLevel: (...a) => state.calls.push({ name: 'ApplyListTemplateWithLevel', args: a })
+  }
+
+  function makeRange(start, end) {
+    let s = start
+    let e = end
+    return {
+      get Start() { return s },
+      get End() { return e },
+      get Text() {
+        // readSkew：模拟「文档含占位符导致偏移口径失准」——非全文 Range 的读带偏移
+        const skew = opts.readSkew && !(s === 0 && e === fullLen()) ? opts.readSkew : 0
+        return state.text.slice(s + skew, e + skew)
+      },
+      set Text(v) {
+        state.text = state.text.slice(0, s) + v + state.text.slice(e)
+        e = s + v.length
+      },
+      InsertBefore(t) {
+        state.text = state.text.slice(0, s) + t + state.text.slice(s)
+      },
+      InsertAfter(t) {
+        state.text = state.text.slice(0, e) + t + state.text.slice(e)
+      },
+      Select() {
+        state.selected = [s, e]
+      },
+      InsertBreak(type) {
+        state.calls.push({ name: 'InsertBreak', type, start: s })
+      },
+      get Font() {
+        return makeRecorder('font', s, e)
+      },
+      get ParagraphFormat() {
+        return makeRecorder('paraFormat', s, e)
+      },
+      get Paragraphs() {
+        return paragraphsIn(s, e)
+      },
+      get ListFormat() {
+        return listFormat
+      },
+      set Style(v) {
+        state.writes.push({ kind: 'range', prop: 'Style', value: v, start: s, end: e })
+      },
+      get Find() {
+        return {
+          ClearFormatting() {},
+          Execute: (...a) => {
+            state.calls.push({ name: 'Find.Execute', args: a })
+            const findText = a[0]
+            const replaceWith = a[9]
+            if (state.text.includes(findText)) {
+              state.text = state.text.replace(findText, replaceWith == null ? '' : replaceWith)
+              return true
+            }
+            return false
+          }
+        }
+      }
+    }
+  }
+
+  const doc = {
+    get TrackRevisions() {
+      if (opts.trackBroken) throw new Error('mock：TrackRevisions 不可用')
+      return state.track
+    },
+    set TrackRevisions(v) {
+      if (opts.trackBroken) throw new Error('mock：TrackRevisions 不可用')
+      state.track = !!v
+      state.trackLog.push(!!v)
+    },
+    Range(s, e) {
+      return s == null ? makeRange(0, fullLen()) : makeRange(s, e == null ? s : e)
+    },
+    get Paragraphs() {
+      const items = paragraphSegs().map(makeParagraph)
+      return { Count: items.length, Item: (i) => items[i - 1] }
+    },
+    Comments: opts.comments || {
+      Count: 0,
+      Item: () => { throw new Error('mock：无批注') },
+      Add: (r, t) => state.calls.push({ name: 'Comments.Add', start: r.Start, end: r.End, text: t })
+    },
+    ...(opts.docExtras || {})
+  }
+  // add_comment 的默认 Comments 也要有 Add
+  if (opts.comments && !opts.comments.Add) {
+    opts.comments.Add = (r, t) => state.calls.push({ name: 'Comments.Add', start: r.Start, end: r.End, text: t })
+  }
+
+  const listLevel = makeRecorder('listLevel', 0, 0)
+  const listTemplate = { ListLevels: { Item: () => listLevel } }
+  const appObj = {
+    ActiveDocument: doc,
+    Selection: {
+      get Text() { return '' },
+      set Text(v) { state.calls.push({ name: 'Selection.Text=', value: v }) },
+      get Range() { return makeRange(opts.selStart || 0, opts.selEnd || opts.selStart || 0) },
+      Type: opts.selType
+    },
+    get ListGalleries() {
+      if (opts.listGalleriesBroken) throw new Error('mock：ListGalleries 不可用')
+      return { Item: () => ({ ListTemplates: { Item: () => listTemplate } }) }
+    }
+  }
+
+  globalThis.wps = { WpsApplication: () => appObj }
+  return { state, doc, listTemplate }
+}
+
+/* ==================== get_text / get_selection / search ==================== */
+
+test('get_text：返回全文与截断标记', async () => {
+  const { } = installWps({ text: '第一段\r第二段\r' })
+  const data = await H.get_text({})
+  assert.equal(data.text, '第一段\r第二段\r')
+  assert.equal(data.truncated, false)
+  assert.equal(data.totalChars, 8)
+})
+
+test('get_selection：光标态（wdSelectionIP）按空处理', async () => {
+  installWps({ text: '正文', selType: 1 })
+  const data = await H.get_selection({})
+  assert.equal(data.text, '')
+})
+
+test('search：跨段计数与段落上下文', async () => {
+  installWps({ text: '甲方应付款。\r乙方应收款。\r甲方违约。' })
+  const data = await H.search({ query: '甲方' })
+  assert.equal(data.count, 2)
+  assert.equal(data.shown, 2)
+  assert.equal(data.matches[0].context, '甲方应付款。')
+  assert.equal(data.matches[1].context, '甲方违约。')
+})
+
+/* ==================== replace_text ==================== */
+
+test('replace_text：最小修订路径（差异段落笔 + 修订开关保存/恢复）', async () => {
+  const { state } = installWps({ text: '甲方应当支付价款。\r' })
+  const data = await H.replace_text({ searchText: '支付价款', replaceText: '支付全部价款' })
+  assert.equal(state.text, '甲方应当支付全部价款。\r')
+  assert.equal(data.via, 'minimalRedline')
+  assert.equal(data.replaced, 1)
+  assert.ok(data.edits >= 1)
+  assert.equal(data.tracked, true)
+  // withTracking：先开 true、finally 恢复原值 false
+  assert.deepEqual(state.trackLog, [true, false])
+  assert.equal(state.track, false)
+})
+
+test('replace_text：replaceAll 多命中从右到左应用（偏移不互相推移）', async () => {
+  const { state } = installWps({ text: '见附件一。见附件一。见附件一。' })
+  const data = await H.replace_text({ searchText: '附件一', replaceText: '附件二', replaceAll: true })
+  assert.equal(state.text, '见附件二。见附件二。见附件二。')
+  assert.equal(data.replaced, 3)
+  assert.equal(data.via, 'minimalRedline')
+})
+
+test('replace_text：新旧文完全不同时回退整段替换（fullReplace）', async () => {
+  const { state } = installWps({ text: '本条待定。\r' })
+  const data = await H.replace_text({ searchText: '本条待定', replaceText: '双方另行协商' })
+  assert.equal(state.text, '双方另行协商。\r')
+  assert.equal(data.via, 'fullReplace')
+  assert.equal(data.fallbacks, 1)
+})
+
+test('replace_text：偏移校验失败时走 Find.Execute 兜底', async () => {
+  // readSkew=1 模拟占位符导致的偏移失准：非全文 Range 读到的文本对不上
+  const { state } = installWps({ text: 'ABCDEFGH', readSkew: 1 })
+  const data = await H.replace_text({ searchText: 'CDE', replaceText: 'XYZ' })
+  assert.equal(state.text, 'ABXYZFGH')
+  assert.equal(data.via, 'fullReplace')
+  assert.equal(data.fallbacks, 1)
+  assert.ok(state.calls.some((c) => c.name === 'Find.Execute'))
+})
+
+test('replace_text：跨段 searchText 快速失败', async () => {
+  installWps({ text: '第一段\r第二段\r' })
+  await assert.rejects(
+    H.replace_text({ searchText: '第一段\n第二段', replaceText: '合并段' }),
+    /跨段落/
+  )
+})
+
+test('replace_text：未命中报错（错误路径）', async () => {
+  installWps({ text: '正文内容。\r' })
+  await assert.rejects(
+    H.replace_text({ searchText: '不存在的文本', replaceText: 'x' }),
+    /未找到目标文本/
+  )
+})
+
+/* ==================== insert_text ==================== */
+
+test('insert_text：锚点后插与前插，\\n 归一为 \\r', async () => {
+  let env = installWps({ text: '合同正文。\r' })
+  let data = await H.insert_text({ text: '（补充）', anchorText: '合同正文', position: 'after' })
+  assert.equal(env.state.text, '合同正文（补充）。\r')
+  assert.equal(data.inserted, true)
+  assert.equal(data.position, 'after')
+  assert.equal(data.tracked, true)
+
+  env = installWps({ text: '合同正文。\r' })
+  data = await H.insert_text({ text: '序言\n', anchorText: '合同正文', position: 'before' })
+  assert.equal(env.state.text, '序言\r合同正文。\r')
+  assert.equal(data.position, 'before')
+})
+
+test('insert_text：TrackRevisions 不可用时降级直改并标 tracked:false', async () => {
+  const { state } = installWps({ text: '合同正文。\r', trackBroken: true })
+  const data = await H.insert_text({ text: '（补充）', anchorText: '合同正文', position: 'after' })
+  assert.equal(state.text, '合同正文（补充）。\r')
+  assert.equal(data.tracked, false)
+})
+
+/* ==================== add_comment ==================== */
+
+test('add_comment：Comments.Add 收到锚点 Range 与批注内容', async () => {
+  const { state } = installWps({ text: '前言。争议条款在此。\r' })
+  const data = await H.add_comment({ anchorText: '争议条款', comment: '此处建议补充管辖约定' })
+  assert.equal(data.commented, true)
+  const call = state.calls.find((c) => c.name === 'Comments.Add')
+  assert.ok(call)
+  assert.equal(call.start, 3)
+  assert.equal(call.end, 7)
+  assert.equal(call.text, '此处建议补充管辖约定')
+})
+
+/* ==================== set_paragraph_format ==================== */
+
+test('set_paragraph_format：lineSpacing 落成最小值行距（rule=3 两件套）', async () => {
+  const { state } = installWps({ text: '标题\r正文内容一段。\r' })
+  const data = await H.set_paragraph_format({ anchorText: '正文内容', lineSpacing: 16 })
+  const rule = state.writes.find((w) => w.kind === 'paraFormat' && w.prop === 'LineSpacingRule')
+  const ls = state.writes.find((w) => w.kind === 'paraFormat' && w.prop === 'LineSpacing')
+  assert.ok(rule && rule.value === 3, 'LineSpacingRule 必须显式设为 wdLineSpaceAtLeast(3)')
+  assert.ok(ls && ls.value === 16)
+  assert.equal(data.lineSpacingMode, 'atLeast')
+  assert.equal(data.formatted, 1)
+  assert.equal(data.tracked, true)
+})
+
+test('set_paragraph_format：先落 styleBuiltIn 再落其余参数', async () => {
+  const { state } = installWps({ text: '一、总则\r正文。\r' })
+  await H.set_paragraph_format({ anchorText: '一、总则', styleBuiltIn: 'heading1', alignment: 'center' })
+  const styleWrite = state.writes.find((w) => w.kind === 'range' && w.prop === 'Style')
+  const alignWrite = state.writes.find((w) => w.kind === 'paraFormat' && w.prop === 'Alignment')
+  assert.ok(styleWrite && styleWrite.value === -2, 'heading1 → wdStyleHeading1(-2)')
+  assert.ok(alignWrite && alignWrite.value === 1)
+  assert.ok(state.writes.indexOf(styleWrite) < state.writes.indexOf(alignWrite), '样式必须先于其余参数落笔')
+})
+
+/* ==================== set_numbering ==================== */
+
+test('set_numbering：中文编号走原生 ListTemplate（NumberStyle=38）', async () => {
+  const { state } = installWps({ text: '第一条内容\r第二条内容\r第三条内容\r' })
+  const data = await H.set_numbering({ anchorText: '第一条内容', kind: 'chinese', paragraphCount: 2 })
+  const style = state.writes.find((w) => w.kind === 'listLevel' && w.prop === 'NumberStyle')
+  const fmt = state.writes.find((w) => w.kind === 'listLevel' && w.prop === 'NumberFormat')
+  assert.ok(style && style.value === 38, 'wdListNumberStyleSimpChinNum2 = 38')
+  assert.ok(fmt && fmt.value === '%1、')
+  const apply = state.calls.find((c) => c.name === 'ApplyListTemplateWithLevel')
+  assert.ok(apply)
+  // (lt, ContinuePreviousList=false, wdListApplyToWholeList=0, wdWord9ListBehavior=1, ApplyLevel=1)
+  assert.deepEqual(apply.args.slice(1), [false, 0, 1, 1])
+  assert.equal(data.via, 'listTemplate')
+  assert.equal(data.paragraphs, 2)
+  assert.equal(data.tracked, true)
+})
+
+test('set_numbering：ListTemplate 失败降级手写「一、」前缀（从后往前写）', async () => {
+  const { state } = installWps({ text: '第一条内容\r第二条内容\r第三条内容\r', listGalleriesBroken: true })
+  const data = await H.set_numbering({ anchorText: '第一条内容', kind: 'chinese', paragraphCount: 2 })
+  assert.equal(state.text, '一、第一条内容\r二、第二条内容\r第三条内容\r')
+  assert.equal(data.via, 'literalText')
+  assert.ok(data.note)
+})
+
+/* ==================== withTracking finally 恢复 ==================== */
+
+test('withTracking：执行中途抛错也要在 finally 恢复修订开关', async () => {
+  const { state } = installWps({
+    text: '目标文本一处。\r',
+    throwOnWrite: { kind: 'font', prop: 'Bold' }
+  })
+  await assert.rejects(H.format_text({ anchorText: '目标文本', bold: true }), /拒绝写/)
+  assert.equal(state.track, false, '抛错后修订开关必须恢复原值')
+  assert.deepEqual(state.trackLog, [true, false])
+})
+
+/* ==================== reply_comment ==================== */
+
+function makeCommentMock() {
+  const comment = {
+    Author: '审阅人',
+    Done: false,
+    Date: '2026/08/28 10:00:00',
+    Range: {
+      _t: '原批注内容\r',
+      get Text() { return this._t },
+      set Text(v) { this._t = v }
+    },
+    Scope: { Text: '锚定文本', Start: 0, End: 4 },
+    Replies: null
+  }
+  return comment
+}
+
+test('reply_comment：Replies.Add 可用时走线程回复', async () => {
+  const comment = makeCommentMock()
+  const added = []
+  comment.Replies = { Add: (scope, text) => added.push({ scope, text }) }
+  installWps({ text: '锚定文本。\r', comments: { Count: 1, Item: () => comment } })
+  const data = await H.reply_comment({ commentIndex: 0, reply: '已按建议修改' })
+  assert.equal(data.replied, true)
+  assert.equal(data.via, undefined)
+  assert.equal(added.length, 1)
+  assert.equal(added[0].text, '已按建议修改')
+})
+
+test('reply_comment：Replies.Add 不可用时降级追加进批注正文（via appendText）', async () => {
+  const comment = makeCommentMock()
+  comment.Replies = { Add: () => { throw new Error('mock：Replies.Add 不支持') } }
+  installWps({ text: '锚定文本。\r', comments: { Count: 1, Item: () => comment } })
+  const data = await H.reply_comment({ commentId: '0', reply: '已按建议修改' })
+  assert.equal(data.replied, true)
+  assert.equal(data.via, 'appendText')
+  assert.ok(comment.Range.Text.includes('原批注内容'))
+  assert.ok(comment.Range.Text.includes('已按建议修改'))
+})
+
+test('reply_comment：序号越界与缺参（错误路径）', async () => {
+  const comment = makeCommentMock()
+  installWps({ text: '锚定文本。\r', comments: { Count: 1, Item: () => comment } })
+  await assert.rejects(H.reply_comment({ commentIndex: 5, reply: 'x' }), /越界/)
+  await assert.rejects(H.reply_comment({ reply: 'x' }), /缺少批注定位参数/)
+})
+
+/* ==================== get_comments ==================== */
+
+test('get_comments：id 是 0 起序号字符串，resolved 映射 Done', async () => {
+  const comment = makeCommentMock()
+  comment.Done = true
+  installWps({ text: '锚定文本。\r', comments: { Count: 1, Item: () => comment } })
+  const data = await H.get_comments({})
+  assert.equal(data.count, 1)
+  assert.equal(data.comments[0].id, '0')
+  assert.equal(data.comments[0].index, 0)
+  assert.equal(data.comments[0].author, '审阅人')
+  assert.equal(data.comments[0].content, '原批注内容')
+  assert.equal(data.comments[0].resolved, true)
+  assert.equal(data.comments[0].anchorText, '锚定文本')
+})
+
+/* ==================== 其余错误路径 ==================== */
+
+test('insert_image：明确报错不支持（不许静默吞）', async () => {
+  installWps({ text: '正文。\r' })
+  await assert.rejects(H.insert_image({ imageBase64: 'abc' }), /不支持插入图片/)
+})
+
+test('format_text：underline 枚举非法（错误路径）', async () => {
+  installWps({ text: '正文。\r' })
+  await assert.rejects(H.format_text({ anchorText: '正文', underline: 'zigzag' }), /underline 值非法/)
+})
+
+test('format_table：文档无表格（错误路径）', async () => {
+  installWps({ text: '正文。\r', docExtras: { Tables: { Count: 0 } } })
+  await assert.rejects(H.format_table({ alignment: 'center' }), /没有表格/)
+})
+
+/* ==================== locateInWpsDocument ==================== */
+
+test('locateInWpsDocument：命中即 Select，未命中返回 found:false', async () => {
+  const { state } = installWps({ text: '甲方应付款。\r乙方应收款。\r' })
+  const hit = await locateInWpsDocument('乙方应收款')
+  assert.equal(hit.found, true)
+  assert.equal(hit.count, 1)
+  assert.deepEqual(state.selected, [7, 12])
+  const miss = await locateInWpsDocument('不存在的引文')
+  assert.equal(miss.found, false)
+})
+
+/* ==================== 导出面完整性 ==================== */
+
+test('HANDLERS 覆盖任务书列出的全部 Word 面命令', () => {
+  const expected = [
+    'get_text', 'get_selection', 'search', 'replace_text', 'insert_text', 'add_comment',
+    'format_text', 'set_paragraph_format', 'get_formatting', 'set_numbering', 'format_table',
+    'apply_standard_format', 'insert_table', 'table_read', 'table_set_cell', 'table_add_row',
+    'table_delete_row', 'table_add_col', 'table_delete_col', 'insert_break', 'set_hyperlink',
+    'edit_header_footer', 'get_comments', 'reply_comment', 'resolve_comment', 'get_revisions',
+    'accept_revision', 'reject_revision', 'insert_footnote', 'insert_endnote', 'insert_image',
+    'apply_style', 'manage_content_control', 'set_document_properties'
+  ]
+  // 任务书写「33 个」但逐条列举实为 34 条（get_text..set_document_properties），以列举为准
+  assert.equal(expected.length, 34)
+  for (const name of expected) {
+    assert.equal(typeof H[name], 'function', `缺少 handler：${name}`)
+  }
+})
+
+test('replace_text：replaceAll + 偏移失准 = 整体切纯 Find 循环，计数正确不误报（混跑病灶回归）', async () => {
+  // 三处命中 + readSkew：旧实现在右到左循环里逐个掉 Find 兜底，Find 恒替换最靠前
+  // 的命中，与当前处理的那处错位——最后一轮会因「全部已被提前替换」反过来抛错。
+  // 修复后：预检发现任一偏移失准即整体走 Find 循环，三处全替、无异常。
+  const { state } = installWps({ text: '甲AA乙AA丙AA丁', readSkew: 1 })
+  const data = await H.replace_text({ searchText: 'AA', replaceText: 'BB', replaceAll: true })
+  assert.equal(state.text, '甲BB乙BB丙BB丁')
+  assert.equal(data.replaced, 3)
+  assert.equal(data.via, 'fullReplace')
+  assert.equal(data.fallbacks, 3)
+  assert.equal(state.calls.filter((c) => c.name === 'Find.Execute').length, 3)
+})

--- a/office-addin/taskpane/lib/wpsWppHandlers.js
+++ b/office-addin/taskpane/lib/wpsWppHandlers.js
@@ -1,0 +1,558 @@
+/**
+ * WPS 演示宿主（WPP）的 office_command HANDLERS。
+ *
+ * 命令名与参数/返回值契约以 officeExecutor.js 为准绳——两个家族对后端和模型
+ * 呈现同一张工具表；WPS 侧的能力差异只体现在返回值的 note 说明字段里。
+ *
+ * 对象模型：VBA 同构的同步 JSAPI（wps.WppApplication().ActivePresentation 起步），
+ * 没有 Office.js 的 PowerPoint.run/context.sync/requirement set 概念，全版本同一
+ * 能力面。枚举不依赖 wps.Enum 命名空间，本文件定死数值常量（与 Office VBA 同值）。
+ *
+ * 真机验证要点（详见调研 wps-wpp-api.md 的「需真机验证清单」）：
+ * - TextRange.Text 段落分隔符是 \r 还是 \n（textMatch/searchText 跨段匹配口径）；
+ * - Characters() 切出的子串上挂 ActionSettings 超链接是否生效（本文件已带整段降级）；
+ * - Font.NameFarEast 对中文字体名是否必须（本文件 Name/NameFarEast 双设）；
+ * - MsoShapeType 数值抽查对拍（msoPicture=13/msoPlaceholder=14/msoTable=19/msoTextBox=17）；
+ * - Shape.Id 会话内稳定性（get_slide_details → delete_shape 的 id 往返）。
+ */
+
+// ==================== 枚举数值常量（VBA 同值，不依赖 wps.Enum） ====================
+
+/** MsoTriState */
+const msoTrue = -1
+const msoFalse = 0
+/** MsoTextOrientation：AddTextbox 首参 */
+const msoTextOrientationHorizontal = 1
+/** MsoAutoShapeType（v1 起步三种；Office.js 的 ellipse 对应 VBA 的 Oval） */
+const msoShapeRectangle = 1
+const msoShapeIsoscelesTriangle = 7
+const msoShapeOval = 9
+/** MsoShapeType（识别用） */
+const msoTable = 19
+/** ActionSettings 索引与动作类型 */
+const ppMouseClick = 1
+const ppActionHyperlink = 7
+
+/** MsoShapeType 数值 → 可读名（Shape.Type 返回裸数值，转成语义词给模型看） */
+const MSO_SHAPE_TYPE_NAMES = {
+  1: 'autoShape',
+  3: 'chart',
+  5: 'freeform',
+  6: 'group',
+  9: 'line',
+  13: 'picture',
+  14: 'placeholder',
+  16: 'media',
+  17: 'textBox',
+  19: 'table'
+}
+
+/** 命令层 shapeType 短名 → MsoAutoShapeType 数值 */
+const WPS_SHAPE_TYPES = {
+  rectangle: msoShapeRectangle,
+  ellipse: msoShapeOval,
+  triangle: msoShapeIsoscelesTriangle
+}
+
+/** 下划线线型合法值（与 Office 面同一张表；WPS 只有开/关，非 none 一律降级为开） */
+const PPT_UNDERLINE_STYLES = ['none', 'single', 'double', 'dotted', 'wave']
+
+/** 新增文本框/形状的默认位置尺寸（磅），与 officeExecutor.PPT_SHAPE_DEFAULTS 同值 */
+const PPT_SHAPE_DEFAULTS = { left: 50, top: 50, width: 400, height: 100 }
+
+/** ppt_replace_text 续查上限：防 replaceText 再含 searchText 时死循环 */
+const MAX_REPLACE_PER_FRAME = 1000
+
+// ==================== 颜色转换（导出的纯函数） ====================
+
+/** '#RRGGBB' → COM RGB 数值（BGR 打包，低字节是红：value = R + (G<<8) + (B<<16)） */
+export function hexToComRgb(hex) {
+  const raw = String(hex || '').trim().replace(/^#/, '')
+  if (!/^[0-9a-fA-F]{6}$/.test(raw)) {
+    throw new Error(`颜色值非法：${hex}（应为 #RRGGBB 形式，如 #336699）`)
+  }
+  const n = parseInt(raw, 16)
+  return ((n >> 16) & 0xff) | (n & 0xff00) | ((n & 0xff) << 16)
+}
+
+/** COM RGB 数值 → '#RRGGBB'（hexToComRgb 的逆变换） */
+export function comRgbToHex(value) {
+  const n = Number(value) >>> 0
+  const r = n & 0xff
+  const g = (n >> 8) & 0xff
+  const b = (n >> 16) & 0xff
+  return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')
+}
+
+// ==================== 宿主访问辅助 ====================
+
+/** 演示宿主 Application 入口（唯一取法，便于真机联调时统一替换） */
+function app() {
+  return wps.WppApplication()
+}
+
+/** 当前演示文稿；没打开时抛中文错误 */
+function activePresentation() {
+  const pres = app().ActivePresentation
+  if (!pres) throw new Error('当前没有打开的演示文稿')
+  return pres
+}
+
+/** slideNumber 参数校验（1 基整数），报错文案与 officeExecutor 一致 */
+function toSlideNumber(raw) {
+  const n = Math.floor(Number(raw))
+  if (!Number.isFinite(n) || n < 1) throw new Error('slideNumber 须为大于等于 1 的整数')
+  return n
+}
+
+/** 按 1 基页码取幻灯片，越界抛错（文案与 officeExecutor.getSlideOrThrow 同口径） */
+function getSlideOrThrow(pres, slideNumber) {
+  const count = pres.Slides.Count
+  if (slideNumber > count) {
+    throw new Error(`slideNumber ${slideNumber} 越界：演示文稿共 ${count} 页（页码从 1 开始）`)
+  }
+  return pres.Slides.Item(slideNumber)
+}
+
+/**
+ * 形状是否带文本：HasTextFrame/HasText 是 MsoTriState（msoTrue=-1 为真值），
+ * truthy 判断同时兼容布尔形态；个别形状访问 TextFrame 即抛，按无文本处理。
+ */
+function shapeHasText(sp) {
+  try {
+    return !!(sp.HasTextFrame && sp.TextFrame && sp.TextFrame.HasText)
+  } catch (e) {
+    return false
+  }
+}
+
+/** 形状整段文本（调用前须 shapeHasText 为真） */
+function shapeText(sp) {
+  return String(sp.TextFrame.TextRange.Text || '')
+}
+
+/** 段落分隔符归一：WPS/VBA 的 TextRange.Text 段落间是 \r，统一成 \n 再比对 */
+function normalizeBreaks(text) {
+  return String(text).replace(/\r\n?/g, '\n')
+}
+
+/** 形状是否为表格：优先 HasTable，个别版本缺该属性时退回 Type 数值判断 */
+function shapeIsTable(sp) {
+  try {
+    if (sp.HasTable) return true
+  } catch (e) { /* 无 HasTable 属性的宿主版本 */ }
+  return sp.Type === msoTable
+}
+
+/** 定位一页上的表格形状：shapeId 精确指定，或缺省取第一个表格 */
+function findTableShape(slide, shapeId) {
+  const shapes = slide.Shapes
+  const id = shapeId == null ? '' : String(shapeId)
+  for (let j = 1; j <= shapes.Count; j++) {
+    const sp = shapes.Item(j)
+    if (id) {
+      if (String(sp.Id) !== id) continue
+      if (!shapeIsTable(sp)) {
+        throw new Error(`id 为 ${id} 的形状不是表格（可先用 office_ppt_get_slide_details 核对）`)
+      }
+      return sp
+    }
+    if (shapeIsTable(sp)) return sp
+  }
+  if (id) throw new Error(`未找到 id 为 ${id} 的形状（可先用 office_ppt_get_slide_details 核对）`)
+  throw new Error('该页没有表格，请先用 office_ppt_add_table 插入或核对 shapeId')
+}
+
+/** 读一格文本：去掉末尾段落符（WPS 空单元格可能返回单个 \r） */
+function readCellText(table, row, col) {
+  const raw = String(table.Cell(row, col).Shape.TextFrame.TextRange.Text || '')
+  return normalizeBreaks(raw).replace(/\n$/, '')
+}
+
+/** 鼠标单击动作设置：兼容 ActionSettings(idx) 函数式与 ActionSettings.Item(idx) 两种形态 */
+function mouseClickAction(textRange) {
+  const settings = textRange.ActionSettings
+  if (typeof settings === 'function') return textRange.ActionSettings(ppMouseClick)
+  return settings.Item(ppMouseClick)
+}
+
+/** 对一段 TextRange 挂超链接：官方示例顺序是先设动作类型再设地址 */
+function applyHyperlink(textRange, url) {
+  const action = mouseClickAction(textRange)
+  action.Action = ppActionHyperlink
+  action.Hyperlink.Address = url
+}
+
+// ==================== HANDLERS ====================
+
+export const WPS_WPP_HANDLERS = {
+  async ppt_get_slides() {
+    const pres = activePresentation()
+    const count = pres.Slides.Count
+    const slides = []
+    for (let i = 1; i <= count; i++) {
+      const shapes = pres.Slides.Item(i).Shapes
+      const texts = []
+      for (let j = 1; j <= shapes.Count; j++) {
+        const sp = shapes.Item(j)
+        if (!shapeHasText(sp)) continue
+        const t = shapeText(sp).trim()
+        if (t) texts.push(t)
+      }
+      slides.push({ slide: i, texts })
+    }
+    return { slideCount: count, slides }
+  },
+
+  async ppt_replace_text(args) {
+    const searchText = String(args.searchText || '')
+    const replaceText = args.replaceText == null ? '' : String(args.replaceText)
+    if (!searchText) throw new Error('查找文本不能为空')
+    const pres = activePresentation()
+    let replaced = 0
+    const touchedSlides = []
+    for (let i = 1; i <= pres.Slides.Count; i++) {
+      let slideTouched = false
+      const shapes = pres.Slides.Item(i).Shapes
+      for (let j = 1; j <= shapes.Count; j++) {
+        const sp = shapes.Item(j)
+        if (!shapeHasText(sp)) continue
+        // TextRange.Replace 原生保留其余文字格式（优于整串回写 .Text）；
+        // 找不到返回 null 而非抛错。MatchCase 传 msoTrue 对齐 Office 面的区分大小写口径。
+        let tr = sp.TextFrame.TextRange
+        let hit = tr.Replace(searchText, replaceText, 0, msoTrue, msoFalse)
+        let guard = 0
+        while (hit != null && ++guard <= MAX_REPLACE_PER_FRAME) {
+          replaced++
+          slideTouched = true
+          // 官方示例的续查法：从命中末尾切出剩余 range 再 Replace
+          tr = tr.Characters(hit.Start + hit.Length, tr.Length)
+          hit = tr.Replace(searchText, replaceText, 0, msoTrue, msoFalse)
+        }
+      }
+      if (slideTouched) touchedSlides.push(i)
+    }
+    if (!replaced) {
+      throw new Error('未找到目标文本，请确认 searchText 与幻灯片文本精确一致（可先用 ppt_get_slides 核对）')
+    }
+    return { replaced, slides: touchedSlides }
+  },
+
+  async ppt_format_text(args) {
+    const searchText = String(args.searchText || '')
+    if (!searchText) throw new Error('查找文本不能为空')
+    const applied = {}
+    if (args.fontName) applied.name = String(args.fontName)
+    if (args.fontSize != null) applied.size = Number(args.fontSize)
+    if (args.bold != null) applied.bold = !!args.bold
+    if (args.italic != null) applied.italic = !!args.italic
+    let underlineStyle = null
+    if (args.underline != null) {
+      underlineStyle = String(args.underline).trim().toLowerCase()
+      if (!PPT_UNDERLINE_STYLES.includes(underlineStyle)) {
+        throw new Error(`underline 值非法：${args.underline}（合法值：${PPT_UNDERLINE_STYLES.join('/')}）`)
+      }
+      applied.underline = underlineStyle
+    }
+    if (args.color) applied.color = String(args.color)
+    if (!Object.keys(applied).length) {
+      throw new Error('未给出任何格式参数（fontName/fontSize/bold/italic/underline/color 至少给一个）')
+    }
+    const colorRgb = args.color ? hexToComRgb(args.color) : null
+
+    const pres = activePresentation()
+    // JS 侧在整串文本上找偏移，宿主侧只做 Characters 切片（每次属性访问都是跨进程
+    // RPC，别在宿主对象上逐字符遍历）。格式不改文本长度，多目标无须从右到左应用。
+    const targets = []
+    outer:
+    for (let i = 1; i <= pres.Slides.Count; i++) {
+      const shapes = pres.Slides.Item(i).Shapes
+      for (let j = 1; j <= shapes.Count; j++) {
+        const sp = shapes.Item(j)
+        if (!shapeHasText(sp)) continue
+        const text = shapeText(sp)
+        let from = 0
+        while (true) {
+          const idx = text.indexOf(searchText, from)
+          if (idx === -1) break
+          targets.push({ slide: i, shape: j, start: idx + 1 }) // Characters 的 Start 是 1 基
+          from = idx + searchText.length
+          if (!args.applyToAll) break outer
+        }
+      }
+    }
+    if (!targets.length) {
+      throw new Error('未找到目标文本，请确认 searchText 与幻灯片文本精确一致（可先用 ppt_get_slides 核对）')
+    }
+    for (const t of targets) {
+      const sub = pres.Slides.Item(t.slide).Shapes.Item(t.shape)
+        .TextFrame.TextRange.Characters(t.start, searchText.length)
+      const font = sub.Font
+      if (applied.name) {
+        font.Name = applied.name
+        font.NameFarEast = applied.name // 中文字体名两处都设，只设 Name 可能不生效
+      }
+      if (applied.size != null) font.Size = applied.size
+      if (applied.bold != null) font.Bold = applied.bold ? msoTrue : msoFalse
+      if (applied.italic != null) font.Italic = applied.italic ? msoTrue : msoFalse
+      if (underlineStyle != null) font.Underline = underlineStyle === 'none' ? msoFalse : msoTrue
+      if (colorRgb != null) font.Color.RGB = colorRgb
+    }
+    const result = { formatted: targets.length, applied }
+    if (underlineStyle && underlineStyle !== 'none' && underlineStyle !== 'single') {
+      result.note = `WPS 演示的下划线只有开/关线型，${underlineStyle} 已降级为普通下划线`
+    }
+    return result
+  },
+
+  async ppt_add_slide(args) {
+    const position = args.position != null ? Math.floor(Number(args.position)) : null
+    const title = args.title ? String(args.title) : ''
+    const body = args.body ? String(args.body) : ''
+    const pres = activePresentation()
+    const count = pres.Slides.Count
+    // AddSlide(Index, CustomLayout) 原生带插入位置，一步到位——没有 Office.js
+    // 「追加再挪」的降级语义（注意 WPS 没有 Slides.Add，只有 AddSlide）。
+    const index = position != null ? Math.max(1, Math.min(position, count + 1)) : count + 1
+    // 版式取插入位置附近的现有页保持观感一致；空演示文稿兜底母版版式
+    const layout = count > 0
+      ? pres.Slides.Item(Math.min(Math.max(index - 1, 1), count)).CustomLayout
+      : pres.SlideMaster.CustomLayouts.Item(2)
+    const slide = pres.Slides.AddSlide(index, layout)
+    let titleAdded = false
+    let bodyAdded = false
+    if (title) {
+      const box = slide.Shapes.AddTextbox(msoTextOrientationHorizontal, 40, 30, 600, 60)
+      box.TextFrame.TextRange.Text = title
+      box.TextFrame.TextRange.Font.Size = 28
+      box.TextFrame.TextRange.Font.Bold = msoTrue
+      titleAdded = true
+    }
+    if (body) {
+      const box = slide.Shapes.AddTextbox(msoTextOrientationHorizontal, 40, 110, 600, 300)
+      box.TextFrame.TextRange.Text = body
+      bodyAdded = true
+    }
+    return { slideAdded: true, position: index, moved: false, titleAdded, bodyAdded }
+  },
+
+  async ppt_delete_slide(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const pres = activePresentation()
+    const count = pres.Slides.Count
+    // WPS 本身允许删光所有幻灯片；「只剩一页拒删」是与 Office 面对齐的安全契约
+    if (count <= 1) {
+      throw new Error('演示文稿只剩一页，无法删除（保留最后一页是安全约定）')
+    }
+    if (slideNumber > count) {
+      throw new Error(`slideNumber ${slideNumber} 越界：演示文稿共 ${count} 页（页码从 1 开始）`)
+    }
+    pres.Slides.Item(slideNumber).Delete()
+    return { deleted: true, slideNumber, remaining: count - 1 }
+  },
+
+  async ppt_add_text_box(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const text = String(args.text || '')
+    if (!text) throw new Error('文本框内容不能为空')
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    // 注意与 Office.js 的参数错位：WPS 首参是方向枚举，文本要事后赋 TextRange.Text
+    const box = slide.Shapes.AddTextbox(
+      msoTextOrientationHorizontal,
+      args.left != null ? Number(args.left) : PPT_SHAPE_DEFAULTS.left,
+      args.top != null ? Number(args.top) : PPT_SHAPE_DEFAULTS.top,
+      args.width != null ? Number(args.width) : PPT_SHAPE_DEFAULTS.width,
+      args.height != null ? Number(args.height) : PPT_SHAPE_DEFAULTS.height
+    )
+    box.TextFrame.TextRange.Text = text
+    const font = box.TextFrame.TextRange.Font
+    if (args.fontSize != null) font.Size = Number(args.fontSize)
+    if (args.bold != null) font.Bold = args.bold ? msoTrue : msoFalse
+    if (args.color) font.Color.RGB = hexToComRgb(args.color)
+    return { added: true, slideNumber }
+  },
+
+  async ppt_move_slide(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const toPosition = Math.floor(Number(args.toPosition))
+    if (!Number.isFinite(toPosition) || toPosition < 1) throw new Error('toPosition 须为大于等于 1 的整数')
+    const pres = activePresentation()
+    const count = pres.Slides.Count
+    if (slideNumber > count) {
+      throw new Error(`slideNumber ${slideNumber} 越界：演示文稿共 ${count} 页（页码从 1 开始）`)
+    }
+    const to = Math.max(1, Math.min(toPosition, count))
+    pres.Slides.Item(slideNumber).MoveTo(to)
+    return { moved: true, from: slideNumber, to }
+  },
+
+  async ppt_add_shape(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const key = String(args.shapeType || '').trim().toLowerCase()
+    const shapeTypeValue = WPS_SHAPE_TYPES[key]
+    if (!shapeTypeValue) {
+      throw new Error(`shapeType 值非法：${args.shapeType}（合法值：${Object.keys(WPS_SHAPE_TYPES).join('/')}）`)
+    }
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const shape = slide.Shapes.AddShape(
+      shapeTypeValue,
+      args.left != null ? Number(args.left) : PPT_SHAPE_DEFAULTS.left,
+      args.top != null ? Number(args.top) : PPT_SHAPE_DEFAULTS.top,
+      args.width != null ? Number(args.width) : 200,
+      args.height != null ? Number(args.height) : 150
+    )
+    if (args.fillColor) {
+      shape.Fill.Solid() // 新形状默认主题填充，设纯色前先定填充类型
+      shape.Fill.ForeColor.RGB = hexToComRgb(args.fillColor)
+    }
+    return { added: true, slideNumber, shapeType: key }
+  },
+
+  async ppt_get_slide_details(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const shapes = slide.Shapes
+    const result = []
+    for (let j = 1; j <= shapes.Count; j++) {
+      const sp = shapes.Item(j)
+      const type = Number(sp.Type)
+      result.push({
+        id: String(sp.Id), // WPS 的 Id 是数值，统一 String 化保 shapeId 契约类型
+        type: MSO_SHAPE_TYPE_NAMES[type] || `unknown(${type})`,
+        left: sp.Left,
+        top: sp.Top,
+        width: sp.Width,
+        height: sp.Height,
+        text: shapeHasText(sp) ? shapeText(sp).slice(0, 500) : ''
+      })
+    }
+    return { slideNumber, shapeCount: result.length, shapes: result }
+  },
+
+  async ppt_delete_shape(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const shapeId = args.shapeId ? String(args.shapeId) : ''
+    const textMatch = args.textMatch ? String(args.textMatch) : ''
+    if (!shapeId && !textMatch) throw new Error('shapeId 与 textMatch 须至少给一个')
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const shapes = slide.Shapes
+    const wanted = normalizeBreaks(textMatch) // 段落符 \r/\n 归一后再全等比较
+    let target = null
+    for (let j = 1; j <= shapes.Count; j++) {
+      const sp = shapes.Item(j)
+      if (shapeId) {
+        if (String(sp.Id) === shapeId) { target = sp; break }
+      } else if (shapeHasText(sp) && normalizeBreaks(shapeText(sp)) === wanted) {
+        target = sp
+        break
+      }
+    }
+    if (!target) {
+      throw new Error(shapeId
+        ? `未找到 id 为 ${shapeId} 的形状（可先用 ppt_get_slide_details 核对）`
+        : '未找到文字内容与 textMatch 精确一致的形状（可先用 ppt_get_slide_details 核对）')
+    }
+    const deletedId = String(target.Id)
+    target.Delete()
+    return { deleted: true, slideNumber, shapeId: deletedId }
+  },
+
+  async ppt_add_table(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const rows = Array.isArray(args.rows) ? args.rows : null
+    const rowCount = rows ? rows.length : Math.floor(Number(args.rowCount))
+    const colCount = rows ? (rows[0] ? rows[0].length : 0) : Math.floor(Number(args.colCount))
+    if (!rowCount || rowCount < 1 || !colCount || colCount < 1) throw new Error('表格行列数非法')
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const shape = slide.Shapes.AddTable(rowCount, colCount)
+    if (args.left != null) shape.Left = Number(args.left)
+    if (args.top != null) shape.Top = Number(args.top)
+    if (args.width != null) shape.Width = Number(args.width)
+    if (args.height != null) shape.Height = Number(args.height)
+    if (rows) {
+      const table = shape.Table
+      for (let r = 0; r < rowCount; r++) {
+        for (let c = 0; c < colCount; c++) {
+          // 单元格写入链中间的 .Shape 别漏；Cell 的行列是 1 基
+          table.Cell(r + 1, c + 1).Shape.TextFrame.TextRange.Text =
+            String(rows[r] && rows[r][c] != null ? rows[r][c] : '')
+        }
+      }
+    }
+    return { added: true, slideNumber, rows: rowCount, cols: colCount }
+  },
+
+  async ppt_table_read(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const table = findTableShape(slide, args.shapeId).Table
+    const rowCount = table.Rows.Count
+    const colCount = table.Columns.Count
+    // WPS 没有批量 values 读法，只能逐格取（每格一次 RPC，大表会有可感延迟）
+    const cells = []
+    for (let r = 1; r <= rowCount; r++) {
+      const row = []
+      for (let c = 1; c <= colCount; c++) row.push(readCellText(table, r, c))
+      cells.push(row)
+    }
+    return { slideNumber, rowCount, colCount, cells }
+  },
+
+  async ppt_table_set_cell(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const row = Math.floor(Number(args.row))
+    const col = Math.floor(Number(args.col))
+    if (!Number.isFinite(row) || row < 0) throw new Error('row 不能为负')
+    if (!Number.isFinite(col) || col < 0) throw new Error('col 不能为负')
+    const text = args.text == null ? '' : String(args.text)
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const table = findTableShape(slide, args.shapeId).Table
+    // 契约的 row/col 是 0 基，WPS Cell 是 1 基；越界用行列数前置检查保住中文报错文案
+    if (row + 1 > table.Rows.Count || col + 1 > table.Columns.Count) {
+      throw new Error(`单元格 (${row},${col}) 不存在，请先用 office_ppt_table_read 核对`)
+    }
+    table.Cell(row + 1, col + 1).Shape.TextFrame.TextRange.Text = text
+    return { slideNumber, row, col, updated: true }
+  },
+
+  async ppt_set_hyperlink(args) {
+    const slideNumber = toSlideNumber(args.slideNumber)
+    const searchText = String(args.searchText || '')
+    const url = String(args.url || '')
+    if (!searchText) throw new Error('查找文本不能为空')
+    if (!url) throw new Error('url 不能为空')
+    const pres = activePresentation()
+    const slide = getSlideOrThrow(pres, slideNumber)
+    const shapes = slide.Shapes
+    for (let j = 1; j <= shapes.Count; j++) {
+      const sp = shapes.Item(j)
+      if (!shapeHasText(sp)) continue
+      const text = shapeText(sp)
+      const idx = text.indexOf(searchText)
+      if (idx === -1) continue
+      const whole = sp.TextFrame.TextRange
+      try {
+        // 首选：Characters 切出的精确子串挂链（VBA 类推路线，真机可能不支持）
+        applyHyperlink(whole.Characters(idx + 1, searchText.length), url)
+        return { slideNumber, linked: true, url }
+      } catch (e) {
+        // 降级：整个文本框文字挂链，并在返回值交底
+        applyHyperlink(whole, url)
+        return {
+          slideNumber,
+          linked: true,
+          url,
+          note: '子串挂链在当前 WPS 版本不可用，已降级为对整个文本框文字设置超链接'
+        }
+      }
+    }
+    throw new Error('未找到目标文本，请确认 searchText 与幻灯片文本精确一致（可先用 office_ppt_get_slides 核对）')
+  }
+}

--- a/office-addin/taskpane/lib/wpsWppHandlers.test.js
+++ b/office-addin/taskpane/lib/wpsWppHandlers.test.js
@@ -1,0 +1,479 @@
+/**
+ * wpsWppHandlers 单测：node 自带 test runner，零依赖。
+ * mock globalThis.wps 里的 WPP 对象模型（VBA 同构同步 API），
+ * 契约口径以 officeExecutor.js 的 ppt_* 为准绳。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { WPS_WPP_HANDLERS as H, hexToComRgb, comRgbToHex } from './wpsWppHandlers.js'
+
+// ==================== mock WPP 对象模型 ====================
+
+let idSeq = 1000
+function nextId() { return ++idSeq }
+
+function makeFont() { return { Color: { RGB: null } } }
+
+/**
+ * TextRange mock：offset 为 0 基绝对起点，length=null 表示动态到文本末尾。
+ * Characters(Start, Length) 的 Start 是相对本 range 的 1 基；Replace 找不到返回 null，
+ * 命中则原地替换并返回 {Start(1 基相对), Length(替换后长度)}——与调研口径一致。
+ */
+function makeRange(state, offset, length, ctx, isSub = false) {
+  function end() {
+    const cap = length == null ? Infinity : offset + length
+    return Math.min(cap, state.text.length)
+  }
+  const self = {
+    Font: makeFont(),
+    get Text() { return state.text.slice(offset, end()) },
+    set Text(v) { state.text = state.text.slice(0, offset) + String(v) + state.text.slice(end()) },
+    get Length() { return end() - offset },
+    Characters(start, len) {
+      const abs = offset + (start - 1)
+      const sub = makeRange(state, abs, len, ctx, true)
+      ctx.log.push({ start, len, absStart: abs, range: sub })
+      return sub
+    },
+    ActionSettings(idx) {
+      if (isSub && ctx.subActionThrows) throw new Error('mock: 子串不支持 ActionSettings')
+      self._actions = self._actions || {}
+      self._actions[idx] = self._actions[idx] || { Action: 0, Hyperlink: { Address: '' } }
+      return self._actions[idx]
+    },
+    Replace(findWhat, replaceWhat) {
+      const span = state.text.slice(offset, end())
+      const p = span.indexOf(findWhat)
+      if (p === -1) return null
+      state.text = state.text.slice(0, offset + p) + replaceWhat +
+        state.text.slice(offset + p + findWhat.length)
+      return { Start: p + 1, Length: String(replaceWhat).length }
+    }
+  }
+  return self
+}
+
+function makeTableObj(rowsData) {
+  const cells = rowsData.map((r) => r.map((t) => ({ text: String(t) })))
+  return {
+    Rows: { get Count() { return cells.length } },
+    Columns: { get Count() { return cells[0].length } },
+    Cell(r, c) {
+      if (r < 1 || r > cells.length || c < 1 || c > cells[0].length) throw new Error('mock: cell 越界')
+      const st = cells[r - 1][c - 1]
+      return { Shape: { TextFrame: { TextRange: {
+        get Text() { return st.text },
+        set Text(v) { st.text = String(v) }
+      } } } }
+    },
+    _cells: cells
+  }
+}
+
+function makeShape(spec, parentArr) {
+  const ctx = { log: [], subActionThrows: !!spec.subActionThrows }
+  const shape = {
+    Id: spec.id != null ? spec.id : nextId(),
+    Type: spec.type != null ? spec.type : 17,
+    Left: spec.left != null ? spec.left : 10,
+    Top: spec.top != null ? spec.top : 20,
+    Width: spec.width != null ? spec.width : 100,
+    Height: spec.height != null ? spec.height : 50,
+    HasTextFrame: 0,
+    HasTable: 0,
+    _charLog: ctx.log,
+    Delete() { parentArr.splice(parentArr.indexOf(shape), 1) }
+  }
+  if (spec.text != null) {
+    const state = { text: String(spec.text) }
+    shape._state = state
+    shape.HasTextFrame = -1
+    shape.TextFrame = {
+      get HasText() { return state.text ? -1 : 0 },
+      TextRange: makeRange(state, 0, null, ctx)
+    }
+  }
+  if (spec.table) {
+    shape.Type = 19
+    shape.HasTable = -1
+    shape.Table = makeTableObj(spec.table)
+  }
+  return shape
+}
+
+function makeSlide(shapeSpecs) {
+  const arr = []
+  const slide = {
+    _shapes: arr,
+    CustomLayout: { tag: 'layout-' + nextId() },
+    Shapes: {
+      get Count() { return arr.length },
+      Item(j) {
+        if (j < 1 || j > arr.length) throw new Error('mock: shape 序号越界')
+        return arr[j - 1]
+      },
+      AddTextbox(orientation, left, top, width, height) {
+        const sp = makeShape({ text: '', left, top, width, height }, arr)
+        sp._addTextboxArgs = { orientation, left, top, width, height }
+        arr.push(sp)
+        return sp
+      },
+      AddShape(type, left, top, width, height) {
+        const sp = makeShape({ type: 1, left, top, width, height }, arr)
+        sp._autoShapeType = type
+        sp.Fill = { _solid: false, Solid() { sp.Fill._solid = true }, ForeColor: { RGB: null } }
+        arr.push(sp)
+        return sp
+      },
+      AddTable(rows, cols) {
+        const sp = makeShape({
+          table: Array.from({ length: rows }, () => Array.from({ length: cols }, () => ''))
+        }, arr)
+        arr.push(sp)
+        return sp
+      }
+    }
+  }
+  for (const spec of shapeSpecs) arr.push(makeShape(spec, arr))
+  return slide
+}
+
+/** slideSpecs：每页一个 shape spec 数组 */
+function makeDeck(slideSpecs) {
+  const slides = []
+  function wireSlide(s) {
+    s.Delete = () => { slides.splice(slides.indexOf(s), 1) }
+    s.MoveTo = (to) => {
+      const i = slides.indexOf(s)
+      slides.splice(i, 1)
+      slides.splice(to - 1, 0, s)
+    }
+    return s
+  }
+  const pres = {
+    _slides: slides,
+    SlideMaster: { CustomLayouts: { Item(i) { return { master: i } } } },
+    Slides: {
+      get Count() { return slides.length },
+      Item(i) {
+        if (i < 1 || i > slides.length) throw new Error('mock: slide 序号越界')
+        return slides[i - 1]
+      },
+      AddSlide(index, layout) {
+        const s = wireSlide(makeSlide([]))
+        s._layoutUsed = layout
+        slides.splice(index - 1, 0, s)
+        return s
+      }
+    }
+  }
+  for (const spec of slideSpecs) slides.push(wireSlide(makeSlide(spec)))
+  return pres
+}
+
+function install(pres) {
+  globalThis.wps = { WppApplication: () => ({ ActivePresentation: pres }) }
+  return pres
+}
+
+// ==================== 颜色转换 ====================
+
+test('hexToComRgb/comRgbToHex：BGR 打包（低字节红）与往返', () => {
+  assert.equal(hexToComRgb('#336699'), 0x996633)
+  assert.equal(hexToComRgb('ff0000'), 0x0000ff)
+  assert.equal(comRgbToHex(0x996633), '#336699')
+  assert.equal(comRgbToHex(hexToComRgb('#0a1b2c')), '#0a1b2c')
+  assert.throws(() => hexToComRgb('#f00'), /颜色值非法/)
+  assert.throws(() => hexToComRgb('红色'), /颜色值非法/)
+})
+
+// ==================== ppt_get_slides ====================
+
+test('ppt_get_slides：逐页收集非空文本，跳过无文本/空文本形状', async () => {
+  install(makeDeck([
+    [{ text: ' 标题一 ' }, { type: 13 }],
+    [{ text: '第二页' }, { text: '' }]
+  ]))
+  const out = await H.ppt_get_slides()
+  assert.equal(out.slideCount, 2)
+  assert.deepEqual(out.slides[0], { slide: 1, texts: ['标题一'] })
+  assert.deepEqual(out.slides[1], { slide: 2, texts: ['第二页'] })
+})
+
+test('无打开的演示文稿：抛中文错误', async () => {
+  install(null)
+  await assert.rejects(H.ppt_get_slides(), /当前没有打开的演示文稿/)
+})
+
+// ==================== ppt_replace_text ====================
+
+test('ppt_replace_text：TextRange.Replace 续查多命中，跨页统计', async () => {
+  const pres = install(makeDeck([
+    [{ text: '甲方与甲方' }],
+    [{ text: '甲方代表签字' }, { type: 13 }]
+  ]))
+  const out = await H.ppt_replace_text({ searchText: '甲方', replaceText: '乙方' })
+  assert.equal(out.replaced, 3)
+  assert.deepEqual(out.slides, [1, 2])
+  assert.equal(pres.Slides.Item(1).Shapes.Item(1)._state.text, '乙方与乙方')
+  assert.equal(pres.Slides.Item(2).Shapes.Item(1)._state.text, '乙方代表签字')
+})
+
+test('ppt_replace_text：未命中抛错、searchText 空抛错', async () => {
+  install(makeDeck([[{ text: '正文' }]]))
+  await assert.rejects(H.ppt_replace_text({ searchText: '不存在', replaceText: 'x' }), /未找到目标文本/)
+  await assert.rejects(H.ppt_replace_text({ searchText: '' }), /查找文本不能为空/)
+})
+
+// ==================== ppt_format_text ====================
+
+test('ppt_format_text：Characters 按 1 基精确切子串，applyToAll 命中全部', async () => {
+  const pres = install(makeDeck([[{ text: '本合同期限为三年，续约三年' }]]))
+  const out = await H.ppt_format_text({
+    searchText: '三年', bold: true, color: '#c00000', fontName: '宋体', applyToAll: true
+  })
+  assert.equal(out.formatted, 2)
+  const log = pres.Slides.Item(1).Shapes.Item(1)._charLog
+  assert.equal(log.length, 2)
+  assert.deepEqual([log[0].start, log[0].len], [7, 2]) // 0 基偏移 6 → 1 基 7
+  assert.deepEqual([log[1].start, log[1].len], [12, 2])
+  for (const entry of log) {
+    assert.equal(entry.range.Font.Bold, -1)
+    assert.equal(entry.range.Font.Color.RGB, hexToComRgb('#c00000'))
+    assert.equal(entry.range.Font.Name, '宋体')
+    assert.equal(entry.range.Font.NameFarEast, '宋体') // 中文字体双设
+  }
+})
+
+test('ppt_format_text：默认只格式化第一处命中', async () => {
+  const pres = install(makeDeck([[{ text: '三年之后又三年' }]]))
+  const out = await H.ppt_format_text({ searchText: '三年', italic: true })
+  assert.equal(out.formatted, 1)
+  assert.equal(pres.Slides.Item(1).Shapes.Item(1)._charLog.length, 1)
+})
+
+test('ppt_format_text：下划线 wave 降级为开并 note 交底，none 落关', async () => {
+  const pres = install(makeDeck([[{ text: '重点条款' }]]))
+  const out = await H.ppt_format_text({ searchText: '重点', underline: 'wave' })
+  assert.match(out.note, /降级为普通下划线/)
+  assert.equal(pres.Slides.Item(1).Shapes.Item(1)._charLog[0].range.Font.Underline, -1)
+
+  const pres2 = install(makeDeck([[{ text: '重点条款' }]]))
+  const out2 = await H.ppt_format_text({ searchText: '重点', underline: 'none' })
+  assert.equal(out2.note, undefined)
+  assert.equal(pres2.Slides.Item(1).Shapes.Item(1)._charLog[0].range.Font.Underline, 0)
+})
+
+test('ppt_format_text：非法下划线值与无格式参数报错', async () => {
+  install(makeDeck([[{ text: '正文' }]]))
+  await assert.rejects(H.ppt_format_text({ searchText: '正文', underline: 'thick' }), /underline 值非法/)
+  await assert.rejects(H.ppt_format_text({ searchText: '正文' }), /未给出任何格式参数/)
+})
+
+// ==================== ppt_add_slide ====================
+
+test('ppt_add_slide：AddSlide 原生带插入位置，版式取附近现有页', async () => {
+  const pres = install(makeDeck([[{ text: '第一页' }], [{ text: '第二页' }]]))
+  const out = await H.ppt_add_slide({ position: 2, title: '新标题', body: '新正文' })
+  assert.deepEqual(out, { slideAdded: true, position: 2, moved: false, titleAdded: true, bodyAdded: true })
+  assert.equal(pres.Slides.Count, 3)
+  const added = pres.Slides.Item(2)
+  assert.equal(added._layoutUsed, pres.Slides.Item(1).CustomLayout)
+  assert.equal(added.Shapes.Count, 2)
+  const titleBox = added.Shapes.Item(1)
+  assert.equal(titleBox._state.text, '新标题')
+  assert.equal(titleBox._addTextboxArgs.orientation, 1) // msoTextOrientationHorizontal
+  assert.equal(titleBox.TextFrame.TextRange.Font.Size, 28)
+  assert.equal(titleBox.TextFrame.TextRange.Font.Bold, -1)
+  assert.equal(added.Shapes.Item(2)._state.text, '新正文')
+})
+
+test('ppt_add_slide：空演示文稿兜底母版版式，缺省追加到末尾', async () => {
+  const pres = install(makeDeck([]))
+  const out = await H.ppt_add_slide({})
+  assert.equal(out.position, 1)
+  assert.deepEqual(pres.Slides.Item(1)._layoutUsed, { master: 2 })
+
+  const pres2 = install(makeDeck([[{ text: 'A' }]]))
+  const out2 = await H.ppt_add_slide({})
+  assert.equal(out2.position, 2)
+  assert.equal(pres2.Slides.Count, 2)
+})
+
+// ==================== ppt_delete_slide ====================
+
+test('ppt_delete_slide：正常删除；只剩一页拒删；越界报错', async () => {
+  const pres = install(makeDeck([[{ text: 'A' }], [{ text: 'B' }]]))
+  const out = await H.ppt_delete_slide({ slideNumber: 1 })
+  assert.deepEqual(out, { deleted: true, slideNumber: 1, remaining: 1 })
+  assert.equal(pres.Slides.Item(1).Shapes.Item(1)._state.text, 'B')
+  await assert.rejects(H.ppt_delete_slide({ slideNumber: 1 }), /只剩一页/)
+
+  install(makeDeck([[{ text: 'A' }], [{ text: 'B' }]]))
+  await assert.rejects(H.ppt_delete_slide({ slideNumber: 5 }), /越界/)
+  await assert.rejects(H.ppt_delete_slide({ slideNumber: 0 }), /大于等于 1 的整数/)
+})
+
+// ==================== ppt_add_text_box ====================
+
+test('ppt_add_text_box：默认几何 50/50/400/100，字体与颜色落地', async () => {
+  const pres = install(makeDeck([[{ text: '已有' }]]))
+  const out = await H.ppt_add_text_box({ slideNumber: 1, text: '新文本', fontSize: 20, bold: true, color: '#ff0000' })
+  assert.deepEqual(out, { added: true, slideNumber: 1 })
+  const box = pres.Slides.Item(1).Shapes.Item(2)
+  assert.deepEqual(box._addTextboxArgs, { orientation: 1, left: 50, top: 50, width: 400, height: 100 })
+  assert.equal(box._state.text, '新文本')
+  assert.equal(box.TextFrame.TextRange.Font.Size, 20)
+  assert.equal(box.TextFrame.TextRange.Font.Bold, -1)
+  assert.equal(box.TextFrame.TextRange.Font.Color.RGB, 255) // #ff0000 低字节是红
+})
+
+test('ppt_add_text_box：空文本与越界页码报错', async () => {
+  install(makeDeck([[{ text: 'A' }]]))
+  await assert.rejects(H.ppt_add_text_box({ slideNumber: 1, text: '' }), /文本框内容不能为空/)
+  await assert.rejects(H.ppt_add_text_box({ slideNumber: 9, text: 'x' }), /越界/)
+})
+
+// ==================== ppt_move_slide ====================
+
+test('ppt_move_slide：MoveTo 1 基移动，toPosition 越界 clamp', async () => {
+  const pres = install(makeDeck([[{ text: 'A' }], [{ text: 'B' }], [{ text: 'C' }]]))
+  const out = await H.ppt_move_slide({ slideNumber: 3, toPosition: 1 })
+  assert.deepEqual(out, { moved: true, from: 3, to: 1 })
+  const order = [1, 2, 3].map((i) => pres.Slides.Item(i).Shapes.Item(1)._state.text)
+  assert.deepEqual(order, ['C', 'A', 'B'])
+
+  const out2 = await H.ppt_move_slide({ slideNumber: 1, toPosition: 99 })
+  assert.equal(out2.to, 3)
+  await assert.rejects(H.ppt_move_slide({ slideNumber: 9, toPosition: 1 }), /越界/)
+})
+
+// ==================== ppt_add_shape ====================
+
+test('ppt_add_shape：ellipse 映射 msoShapeOval=9，填充先 Solid 再 RGB', async () => {
+  const pres = install(makeDeck([[{ text: 'A' }]]))
+  const out = await H.ppt_add_shape({ slideNumber: 1, shapeType: 'ellipse', fillColor: '#00ff00' })
+  assert.deepEqual(out, { added: true, slideNumber: 1, shapeType: 'ellipse' })
+  const sp = pres.Slides.Item(1).Shapes.Item(2)
+  assert.equal(sp._autoShapeType, 9)
+  assert.equal(sp.Fill._solid, true)
+  assert.equal(sp.Fill.ForeColor.RGB, hexToComRgb('#00ff00'))
+  await assert.rejects(H.ppt_add_shape({ slideNumber: 1, shapeType: 'star' }), /shapeType 值非法/)
+})
+
+// ==================== ppt_get_slide_details ====================
+
+test('ppt_get_slide_details：Type 数值转可读名、Id 转字符串、文本截断 500', async () => {
+  install(makeDeck([[
+    { id: 5, type: 17, text: '长'.repeat(600), left: 1, top: 2, width: 3, height: 4 },
+    { id: 6, table: [['x']] },
+    { id: 7, type: 42 }
+  ]]))
+  const out = await H.ppt_get_slide_details({ slideNumber: 1 })
+  assert.equal(out.shapeCount, 3)
+  assert.deepEqual(out.shapes[0], {
+    id: '5', type: 'textBox', left: 1, top: 2, width: 3, height: 4, text: '长'.repeat(500)
+  })
+  assert.equal(out.shapes[1].type, 'table')
+  assert.equal(out.shapes[2].type, 'unknown(42)')
+})
+
+// ==================== ppt_delete_shape ====================
+
+test('ppt_delete_shape：textMatch 全等定位（\\r/\\n 段落符归一）', async () => {
+  const pres = install(makeDeck([[{ text: '别删我' }, { id: 33, text: '第一行\r第二行' }]]))
+  const out = await H.ppt_delete_shape({ slideNumber: 1, textMatch: '第一行\n第二行' })
+  assert.deepEqual(out, { deleted: true, slideNumber: 1, shapeId: '33' })
+  assert.equal(pres.Slides.Item(1).Shapes.Count, 1)
+  assert.equal(pres.Slides.Item(1).Shapes.Item(1)._state.text, '别删我')
+})
+
+test('ppt_delete_shape：shapeId 定位与错误路径', async () => {
+  const pres = install(makeDeck([[{ id: 8, text: 'A' }, { id: 9, type: 13 }]]))
+  const out = await H.ppt_delete_shape({ slideNumber: 1, shapeId: 9 })
+  assert.equal(out.shapeId, '9')
+  assert.equal(pres.Slides.Item(1).Shapes.Count, 1)
+  await assert.rejects(H.ppt_delete_shape({ slideNumber: 1, shapeId: '404' }), /未找到 id 为 404/)
+  await assert.rejects(H.ppt_delete_shape({ slideNumber: 1, textMatch: '不存在' }), /textMatch 精确一致/)
+  await assert.rejects(H.ppt_delete_shape({ slideNumber: 1 }), /至少给一个/)
+})
+
+// ==================== ppt_add_table / ppt_table_read / ppt_table_set_cell ====================
+
+test('ppt_add_table：rows 二维数组建表填格（Cell 1 基），几何按给参落地', async () => {
+  const pres = install(makeDeck([[]]))
+  const out = await H.ppt_add_table({
+    slideNumber: 1, rows: [['甲', '乙'], ['丙', '丁']], left: 30, top: 40
+  })
+  assert.deepEqual(out, { added: true, slideNumber: 1, rows: 2, cols: 2 })
+  const sp = pres.Slides.Item(1).Shapes.Item(1)
+  assert.equal(sp.Left, 30)
+  assert.equal(sp.Top, 40)
+  assert.deepEqual(sp.Table._cells.map((r) => r.map((c) => c.text)), [['甲', '乙'], ['丙', '丁']])
+  await assert.rejects(H.ppt_add_table({ slideNumber: 1 }), /表格行列数非法/)
+})
+
+test('ppt_table_read：逐格读取并去掉末尾段落符，缺省取第一个表格', async () => {
+  install(makeDeck([[
+    { text: '不是表格' },
+    { table: [['甲', '乙\r'], ['丙', '']] }
+  ]]))
+  const out = await H.ppt_table_read({ slideNumber: 1 })
+  assert.deepEqual(out, { slideNumber: 1, rowCount: 2, colCount: 2, cells: [['甲', '乙'], ['丙', '']] })
+})
+
+test('ppt_table_read：shapeId 定位与无表格报错', async () => {
+  install(makeDeck([[
+    { id: 11, table: [['一']] },
+    { id: 12, table: [['二']] }
+  ]]))
+  const out = await H.ppt_table_read({ slideNumber: 1, shapeId: '12' })
+  assert.deepEqual(out.cells, [['二']])
+  await assert.rejects(H.ppt_table_read({ slideNumber: 1, shapeId: '404' }), /未找到 id 为 404/)
+
+  install(makeDeck([[{ text: '没有表格' }]]))
+  await assert.rejects(H.ppt_table_read({ slideNumber: 1 }), /该页没有表格/)
+})
+
+test('ppt_table_set_cell：契约 0 基转 Cell 1 基，越界报单元格不存在', async () => {
+  const pres = install(makeDeck([[{ table: [['a', 'b'], ['c', 'd']] }]]))
+  const out = await H.ppt_table_set_cell({ slideNumber: 1, row: 1, col: 1, text: '新值' })
+  assert.deepEqual(out, { slideNumber: 1, row: 1, col: 1, updated: true })
+  assert.equal(pres.Slides.Item(1).Shapes.Item(1).Table._cells[1][1].text, '新值')
+  await assert.rejects(H.ppt_table_set_cell({ slideNumber: 1, row: 5, col: 0, text: 'x' }),
+    /单元格 \(5,0\) 不存在/)
+  await assert.rejects(H.ppt_table_set_cell({ slideNumber: 1, row: -1, col: 0, text: 'x' }), /row 不能为负/)
+})
+
+// ==================== ppt_set_hyperlink ====================
+
+test('ppt_set_hyperlink：子串路线——先 Action=ppActionHyperlink 再设 Address', async () => {
+  const pres = install(makeDeck([[{ text: '详见官网链接' }]]))
+  const out = await H.ppt_set_hyperlink({ slideNumber: 1, searchText: '官网', url: 'https://aiworkdeck.com' })
+  assert.deepEqual(out, { slideNumber: 1, linked: true, url: 'https://aiworkdeck.com' })
+  const log = pres.Slides.Item(1).Shapes.Item(1)._charLog
+  assert.equal(log.length, 1)
+  assert.deepEqual([log[0].start, log[0].len], [3, 2]) // 0 基偏移 2 → 1 基 3
+  const action = log[0].range._actions[1] // ppMouseClick=1
+  assert.equal(action.Action, 7) // ppActionHyperlink
+  assert.equal(action.Hyperlink.Address, 'https://aiworkdeck.com')
+})
+
+test('ppt_set_hyperlink：子串挂链失败降级整段挂链并 note 交底', async () => {
+  const pres = install(makeDeck([[{ text: '点此访问', subActionThrows: true }]]))
+  const out = await H.ppt_set_hyperlink({ slideNumber: 1, searchText: '访问', url: 'https://wps.cn' })
+  assert.equal(out.linked, true)
+  assert.match(out.note, /降级为对整个文本框文字设置超链接/)
+  const whole = pres.Slides.Item(1).Shapes.Item(1).TextFrame.TextRange
+  assert.equal(whole._actions[1].Action, 7)
+  assert.equal(whole._actions[1].Hyperlink.Address, 'https://wps.cn')
+})
+
+test('ppt_set_hyperlink：未命中与空参报错', async () => {
+  install(makeDeck([[{ text: '正文' }]]))
+  await assert.rejects(H.ppt_set_hyperlink({ slideNumber: 1, searchText: '不存在', url: 'https://x.cn' }),
+    /未找到目标文本/)
+  await assert.rejects(H.ppt_set_hyperlink({ slideNumber: 1, searchText: '', url: 'https://x.cn' }),
+    /查找文本不能为空/)
+  await assert.rejects(H.ppt_set_hyperlink({ slideNumber: 1, searchText: '正文', url: '' }), /url 不能为空/)
+})

--- a/office-addin/vite.config.js
+++ b/office-addin/vite.config.js
@@ -47,8 +47,15 @@ export default defineConfig(({ command }) => ({
     https: devHttps()
   },
   build: {
+    // WPS 任务窗格跑在随宿主版本参差的 CEF 内核里（可能低至 Chromium 7x），
+    // 语法降到 es2018 消掉可选链等新语法的硬解析错；Office 家族的现代 webview
+    // 跑降级产物无差别。运行时能力（fetch/ReadableStream）转译不了，真机验证。
+    target: 'es2018',
     rollupOptions: {
-      input: path.resolve(rootDir, 'taskpane.html')
+      input: {
+        taskpane: path.resolve(rootDir, 'taskpane.html'),
+        'taskpane-wps': path.resolve(rootDir, 'taskpane-wps.html')
+      }
     }
   }
 }))

--- a/office-addin/wps/index.html
+++ b/office-addin/wps/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="utf-8">
+    <script type="text/javascript" src="./main.js"></script>
+</html>
+<!-- WPS 加载项入口页：WPS 在线模式启动时拉取 url/index.html（与官方 wpsjs 模板同构，只引 main.js） -->

--- a/office-addin/wps/js/ribbon.js
+++ b/office-addin/wps/js/ribbon.js
@@ -1,0 +1,46 @@
+// AI WorkDeck WPS 加载项 ribbon 回调（薄壳）：唯一职责是开/关任务窗格。
+// 回调按 ribbon.xml 里写的全局函数名查找（WPS 机制，无注册 API）。
+// 业务全部活在任务窗格网页（ui/taskpane-wps.html，Vue 应用）里。
+
+var AWD_PANE_KEY = "awd_taskpane_id"
+
+function OnAddinLoad(ribbonUI) {
+    if (typeof (window.Application.ribbonUI) != "object") {
+        window.Application.ribbonUI = ribbonUI
+    }
+    if (typeof (window.Application.Enum) != "object") {
+        // 旧版宿主没有内置枚举表时用本地兜底（官方模板同款做法）
+        window.Application.Enum = WPS_Enum
+    }
+    return true
+}
+
+function OnAction(control) {
+    if (control.Id === "btnAwdPane") {
+        ToggleAwdPane()
+    }
+    return true
+}
+
+function ToggleAwdPane() {
+    var app = window.Application
+    var tsId = app.PluginStorage.getItem(AWD_PANE_KEY)
+    if (tsId) {
+        try {
+            var pane = app.GetTaskPane(tsId)
+            if (pane) {
+                pane.Visible = !pane.Visible
+                return
+            }
+        } catch (e) {
+            // 句柄失效（文档窗口重建等）：走重建
+        }
+    }
+    var created = app.CreateTaskPane(GetUrlPath() + "/ui/taskpane-wps.html")
+    app.PluginStorage.setItem(AWD_PANE_KEY, created.ID)
+    created.Visible = true
+}
+
+function GetImage(control) {
+    return "images/icon-32.png"
+}

--- a/office-addin/wps/js/util.js
+++ b/office-addin/wps/js/util.js
@@ -1,0 +1,11 @@
+// 官方 wpsjs 模板同款工具：枚举兜底表 + 取当前加载项部署目录。
+// 注：官方注释称「后续版本 wps.Enum 会自动支持全部枚举」，现阶段人工定义所需子集。
+var WPS_Enum = {
+    msoCTPDockPositionLeft: 0,
+    msoCTPDockPositionRight: 2
+}
+
+function GetUrlPath() {
+    let e = document.location.toString()
+    return -1 != (e = decodeURI(e)).indexOf("/") && (e = e.substring(0, e.lastIndexOf("/"))), e
+}

--- a/office-addin/wps/main.js
+++ b/office-addin/wps/main.js
@@ -1,0 +1,4 @@
+// WPS 加载项 JS 入口（由 index.html 包含）：按官方 wpsjs 模板惯例用 document.write
+// 依序引入脚本。ribbon 页没有可见 UI，逻辑全在 js/ 下的两个文件里。
+document.write("<script language='javascript' src='js/util.js'></script>");
+document.write("<script language='javascript' src='js/ribbon.js'></script>");

--- a/office-addin/wps/ribbon.xml
+++ b/office-addin/wps/ribbon.xml
@@ -1,0 +1,11 @@
+<customUI xmlns="http://schemas.microsoft.com/office/2006/01/customui" onLoad="OnAddinLoad">
+    <ribbon startFromScratch="false">
+        <tabs>
+            <tab id="awdTab" label="AI WorkDeck">
+                <group id="awdGroup" label="AI WorkDeck">
+                    <button id="btnAwdPane" label="AI 助手" onAction="OnAction" getImage="GetImage" visible="true" size="large"/>
+                </group>
+            </tab>
+        </tabs>
+    </ribbon>
+</customUI>

--- a/office-addin/wps/vendor/publish-template.html
+++ b/office-addin/wps/vendor/publish-template.html
@@ -1,0 +1,632 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>WPS加载项配置</title>
+    <link rel="icon" type="image/png" sizes="32x32"
+        href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAAXNSR0IArs4c6QAAPnFJREFUeAHdfXmYbFV176nqvt0XZVLAIWpiRL0gaBAlahiCiHkvQc2LMaJRQTSJ+cz3mZDETPo90UAMJnny/ngKTowxIhg/YzRfFNEIKMjoFcQLqBAxGBACXBC6b3ed9xvW2mdXdXV13xHIrq6z91l7/dZvDfucqjo1dK/5b9gOOL3dff7+TevaXoN7u65tm6f32na3puntgnB3aQbtLr0+xi3GbL1mYztoNza93kbI0Lcbe23vnl6/uakd9Dag3zDz6DUbrjmud7f0/xtteo/0WPb7ZLtz++O5QwdN74i2aV+AeNahwI9DIVFYhIfqs/Uw9rBFvR12C4HHUpaeNoHhyoABiaiHBXU7FhIWRP8yyC/s9Wcvuu73evd1wEfe6BG3AFDwmebOhUMGzeCIweLgCBTmIBRmOgvtEjisDI6FZjFdziw610ZXXBXau7FwXH7aw8Lq8Fw0WliaWMDZ4vJ+r39h0x9c2Dx+7cXXvbo3T8wjpWWOHvb+7vuB+RcOeoM34NT8mkE7eKzLCbddG/ufBaRQcoTHgvHoDZnPBLEIvCKWxh4LQ0sgCl4vFtoq/BUavt2Fh5xPrOn3z17/tplLq6mH7fBhvQD2+WD71Ladfz2cfAOS/kwVNVLp0zd36ipizOLhCJVUC2JMsbQ+KDe+2CoPGYHndCwAqcqeRhBXeC0Iymv+3g04M5092w7Oueb4nW426uG3dQ4eZn6tO3X++XgcfweK/qtwUA/emXsdzUNFcYF1hEOVAak4esyv5sLA0BlAcXMiCke8hoELHtrLNo4/QLKzhL/XB7j9TL/tn3TtH85ckXYeLj39fdi0Z31g06GLzeI74dAvRVniSEs3s1jpcmqphNLljIqkvlsMQrCQqrD2dHRrP3ZhQKMleC0rTlX8rjRk6RunjU8OqVQPF5j9wppm6sT1f7jmIlp7OLTK+4fOnWee+sBL8BT7XTjqD2XynNvu6HVBqqMSrpZn9SoqfQdKBQh8JH7c2cBBR+hZtMSvkj+L7EUxwi9XYrHUfoBDzx96zUXTU9PvXv/7a75E5EPZIgsPjQvP+XD75LmFufcjK69KD3QMoSgqYyTSJYVGHGDW7RYIi5+BuJ6BJ6SyNYSnos/30KrwNF5hCp5ytlLXMoDQeLlnB4rFgqeDUqARNHL0++dPTc8cv/5tvVst3PHbzNsOZT78y+30jzbM/QEusryrbQY7M4E+elkTu5SJU18KBTfLOFxXwjl2drOUiUs7nKeq7CdGMOICn/O0Bh3a0hHLXpgRPPTCqHtZsl+j/H6OQibMV/zYuw/3d+954OwpX3lxb4Emd2SztzuQcd9TNx22OFj8AOq4X0mqEh1liMTbpSwO9pg0FZ8zUZyqKJrWTHf0l0QTogUS4ZIDtraGX96O8IsmeMiUi0CiEf5uIXtRtL3edVNT/bd+6w/WfNV2dsx2hy0AHvW3XT9/Il4n/wlyUXjrRClhWgypYLWUq4haE5DH2ih44qrCGlnhy5mDibU8R8M4H/Weq/DCkNQzMbCUvLjVdqwFPP5wmdlnHjjNNZNnqbRBoRYkVNG/b68DZ965o84GXSaKN9t+sP/H2qdsmp/7B8R/cBYzT61ko4xtSWIojLmcTVwmmwth6PQqjIxxggbccwFol0KOXTSLpCj5aELsL7VyJvBZNEFH8KFiavJUeMXT8Rte4THVa5tL+rOzr9kRzw0yKrm4PTb7nvbgUXisP3PQtntEJUDj5JfCl1M7PcijJL3BsoCXyhs3sVNO4RJ1YRSbtFTPKcfcUHd5fi0m4qTFHqPcGccvi1RwG+KHqCzqEf5ilFyISaahX/h7zZ3AHnvt29d+Lkxvl66/XazC6Alt21932tzJi23vs7h0u0emyH1sWcxoPopdICZEhY75TCpVC15Fop4NSAdZZMKddGzTfma3xstYgDEmP29CB/8QXvpJ54LlHqfIz7vZadcjzpXqSkpB8mZP2Qh/09sDjwefffbfzp3MXFJje7Tag21mn2/YLNz14FntoDmaRr3CXVwmo9t3mhi8kqJCwSX2VWMqvQjoboXnImCxApcFsD2p2krqKPEuku2ZPwsvfNGtHCCu8q34L7c9l7LSk57+0Uyxyb1hfmt0siE8obr3z933qTPHnLcd3miSf+DYZm3dR9td2vm5f4TBIxVuJCGTTKKuUB1tl/xO5nTFvhYFl0LgmdSqjbOZ/FZTtTo8R1KIWdhn8nMtqq/sq5oAGNLZSpVx/JqjahkQjZaxxC65uvixk35YW1uoXrDbHrOvvOTN+MzCNmzpwjYx+Zyz2sfN3T//+bYdPM8Gad4Z0FFMIROtNGoHG+gwIXVBuU+YEhF4jJU3TCS+S7qUadDNihgvwy9bYRc6Jfnj8GHLRyYV4milg/jrjtgqlZvLX8UkF4B3ROEbhfAZtyvXrJ355avf1rtDettgU3m9ddb2/Uj7M4NNc19EMp/hwjn9tFonuIyZPwQqB6pC2wu7lc5Rj9a4P3omoX7OKGsSQJPF4RitS2dwis9jzvvIJ4dgYU+73mwGvzwN++HwkNWh+Okk/Yz47UHGswx/r7lxpj/70qv/uHdLpbHFw8zRFhsgUEf+T+YvxuvdZ9iQQ2FhMmAX0cHVRWQCqkoZHonxQppwxNH7zFog1algHEGBiwwJXpZ/CJc7MCq/As84wqe0pUW3Gn4bkh/2yLa8aJMv+hLLMH/mwVokbW6c6s8esv7tvdsDucXdVj+75GP+3H1zn28HAxz59EOZw5CBdo2Jy6A1xyJloUbH1MyjKEwITRma8CqIGVTc2pY0rBtw2SOu4JNTboz4MsJPFmEn8We08gPaoVvzdyvdCzIXZe2/ZYF3eEqpffcWVM8YLM59/uCTW3+mMUm2oN+qBcBn++0cnvD1Gj/mw2G7GJ4jGS4kjh+MdRTBSY4lV5J8hKfvqe99zwlJPO5s3M+EcK8km/xh04qeE/ck/qpY4/jFSO5J/HSN9+CXKjbyE719pwIa5dDjPXMRM/af+lb0PvaEh9wNPXJ+bzv3j7/Bj8htRdviBXACXpsu/PjBs+DIkfQrE5/FoasZIL31zZ46KRgrIJ8pLHOgHMumeidRCYtApctx4CUuibd+zU9932xgCZ7K0KA9JVqFsdcZj+NLvHsXNc40wV/7NBq/UcxLh5cvzF/wC0+F8Ck5an6hMT9o2iOv//78WSdsxXWCLV4A//Ch+ffiQsXRDpiJg1vhtB3EjvYjWO14xXPCSXDSud+pRnYqCS1kItyHthJFHt6pRM2S3dinjENOdvwSSrcALYLMFmqfgAcHZ8wfaPBrP/klDjxkFLPRHq0lvpMDL79CsWhz0MmEByjxUsNG+4PB0Z86ee69KdvcPrK1eTBe3l0cNJ8FGJ+StmNpQW6nDApD811MUI+AFGgkjVIbUHC0WfDKAiXRqJgLoGjTKtpy/JrDRraomUbNn1iqpUebwy88PZDpsKmA0hotuxW7EX/KIwHYHcErl/aYusJn/P7Y2cuv/bPNv2y82WcAvrEzWGzPhN8ovt1mR4ccFJzkkcHANGEdBwYBc64J6sSQqjUeStwfajEvmeZkqKiQbyx/aKR98df4oBEf5Ew7b6P8wttjOgurS/kpFzoLE7apWfhjTD21DJM2w67mMM4pm+OeJbSVDwmStPj4adueedDftU+x0dVvN2sB8C1dvqsH0j3oVDqkIQTlMQ8KDrBzVC4pEjtnuAOyLSK4KFIGDQaKW7YMmvvCKGFZCmhCqMLV/IGnFeFt3iZH8LSkhRS6daKFr3zRcBQf/BRnLOl/zV8iGsXbqDJgXyN/4XNtiwHIP0dCj/d4ALVhjYpoFYPNWgB6P3/QHqxEySm65KQzKDuURaSCQ1VROGbACpoYTgMdSRvCV3qMYVm82MfzeyGN4Xd6aXYJP51SktFnLFQr/FwedhxCGaCR0JWi8dSTwlL+Ws74eTdXhQ9+2mYjRn5xVPhTBh3JhD/4zkvnTxRolRszrEKZn+TBt3G+gtf7LFvlVCaI7o4xl851IWikoJkArglu0ApeiwMCiaWgREkpE4DJ1HdShixIlZuSXGi7hXHY8eKTVsyFxYrfyed04Ef47aK20mFIEQ5BUbAqNk0y7gn8QhLMP9vOWF3sJAmfrAgAtPr4NEHTP/xbf7a6Txat6gzA08riYPABFp8kTopXbhayOMhZJinvdEpZoYjBxIqHjPvCUwc3NskUUNihPBYKJoVnWqhf8JhPC/SNcuqmbeFt3HjM5ZknbRU8cckfPPSZItrUWDvgZx+2KGcE6RMByZ/xFzztRPzUs81hvOxgzn51uan5hS0+BZ41wkfuVvtQsKoFcNv1c8cj3P3gqYIsWxYmmpIRwShgzsU8g8lmBLbMAa1ZoGQxQV3AGKV9JcwWCp67OY8h+XkTPriH8NJPOi6eELBDy8IN8XfOJTAk4XTO28IwPz1J/zL+hBFX8UsMnbJgiI1bOKdOet0GMu3Etosfpve769K54wVaYWMLE5T40e35hfnr8aGO8uldBpZFpaOOBr0KFX1lkzrWt27BcxEwSYHLBER2SqdCK4mBL/aYAtiOwguf9ip+JaryreZP2ykrPaOif7RTbC7lt4YXXvI7DrsvPK2M45ePniu8kVsxVfzDuQl7iR+Jn7rw677+9Oy+6/908kfOVzwDzC3MnwKDKL5DLY4q9XSTLQqsRHmfMi8OFqhrKhg/JMkb9dlK0J094TXPYK0mVeAyGYmXTQStfcVOO/U98JhL3bQvrZo/dHJedip+7keCxUcX06b5ww9J04fO/4zVKCIxGuJ3bjRfxU89N4xiMRE3yq/cUN40OzeD+VMStVzf2R2j8cxTN72kGSxcwCkFyQETLbe1o5l0iBI1Osik0TuONWTiOOrwWchQ5qRbYMjquRF+2HURQg59JX8cfhl+njX4N5T8cXgFsgJ/FZNMgJOhKmf0jULlggPPqF+Gfyg22ZYBbgATyL0EmaOqKhmzPThy/Tt2WvYbSBPPAL128V0yS5/RFEg1EE/tEMcSQtOrsBRGarIyvMlUOSGBZ7LkfG412/HnrNSj+MHt5BkvJtmyW8X/xKMfWoSwIXzwm9AopmAiPrDJn+UoCxMGEs8+55OfedANdnRkU1t/iQIoWo1nvl0j+5720j6MvStx4/ql1kMrvqj5VRlEQhyYHaejhaDODMdqGEgO8+EgMfwbOuLITr3RBoxb4Cfx19iEBRfItp5fDtoOqRj3UPyr4E8/rNrFxH2GCslwq+Mf4bc2A3UFPAp4Hb9EwdWfPmz9X4z/QuqyZ4ABvqVb7JEOycyiKwl0Mh0dHVNTyQ/HiE9ZjL0gzKDFVduydgcmZjl+uTHiS3LZfKQQyaBPtIXbEn5pYVJ+hP/S9kbxABd7UIOF8Ln237KR+OEHOXPLPvGUGmNnE5++BqHzGVaIB0gxFHz6EtFax+h2oG9cp6mhnvglzd/PH1xOZ1xIpUt6Sl7KKeGYAQVxOkSc8DkXxajlJuaEA2KvdZM2g8dJsfY4/gDJztby0xXGlD6lv2aXh44rFlPmKGOVHvEORPmT/6Pxax5UuJWYSL6N+dOP6WbqoKvfufT3CcafAfTjDIzBRXTYdNNNIwYUiXK6MIv9TIRyAETu09YQnqYCL6tMCNMBmRKCveTnvm/S1FijxCu5HT+DLvyRYNrKliMVBtbUgr/2Kfkz/oIPSPoKCvtEUhFDIXxKjppfdqgavnHf84GvfCr4lElZFpwr+g0Y8yPuwk8HQoZ+ode+w6jhLTSGm36WpZn/3ugl33TWQdthcjlg2ujIaHRIXwXJwrIPfXYyEvvhvPAYM6hiJ5KV/CwyA48Neu47aE3FmPOyM2Qv+IiWPPcDH3LZTHz2suv4yW//Ap+cDgBCDZbwW5tzw/wZa0yQhApaHPYzD8jx/KljWsdCD53Hpp2amn3aNX/eu1n2Y7PknSP+Jg8+1g1qkNt/qWofNtVDkmR4IxItpEAxB0OBcJo4zD0Jn2B7x2FrmoOe1G92nhGQs9ulbVpsm+/d1TanX7nQfPbbTqL8UFCgpKOOEjv2n6mS95ji3GsP6OM+1fzMY/AzZP3t6+89D7bN178/aP76i5uaO+83v70JV+Gb3bIfmX/vxRY+RwG6mABijfi3uDj/ekwMvVlkJKTZ9vng3A0w/owkUJ+GqVTGAc1VL/dIZHni0s5Tdm2as1450zxhlyWUSb3d+lMuXmg+9A1/9V7+pc90Jcf0H395qv6Tw6eaY5635PjYbj6m4e/fOWje/PFNzR33qdx0UDllHtnoX+aU+5lnxyGNKFHggSuYXu+G9e9cu45a2YaeA+in2PjpXiZChYwjJ7VVfO+ojMUpyojgKu0cpVO20zR/euj0Q1J8evZ7L5pqnryr/eO+Wik+PWfDNpK7z1695g0HTkm6ozc/u0e/+T3kygsxih9OSOb0SuKFkB4yCgWltaC8l+KHTts888AT51+YCPZDC0C/wwcjLmKsICh59cE4C66icxViAgkrqyv0SCz90INY+y948hAVxTusrZnqNceooIgs/VIinbSSSMzR/zcdNBUF2GEuDhEd9NORQ/iiFn4x6bypuOx5QOqgRDBSVVFUoxKnDQhD7MJg8IaarFSFH/HmjzBy0gQ1uSGSk1O7dARNiWQXDkFkvcBTDtmmRSo/dO2Vz55qdp11ZPYi/A+XMmFPxEPV/1hX0vKQOLygetpX+wU3lM7K/8h75p+LIyvHRcHFQUjBxyzq9Jr6o+RdpPj5VSg/VqWksbyznFxlxZhXZx75JCCV6UzIxaDVGk7RoYtuGcjGQ7V51Jpec/TPMVylRX366fgcwTHPm2qmtvMTvpVycPFN+MA3b5lb5p8p5Qb+q6iScd+yLL7mgGPP22htsP/YDRsePCR9KAtgoVk4Io0pISTgnRQqpCGW2CGlzALrpMNKMmYDj8nmY1c/xKcAuP+65043M3poD6flp+Ni7DvPts2v40zxUDa+ejn7ikUXrsoffeq8dv5TIjkLzjoJk2U3IuunPW36qLVbeZrbG/SPwMs/26ShqtGcjQwf/Vx8KjL02VMnKI1OM5jbcMeg+dJ3F5uX7D05wXf+pG0e9BP2yoPhITnSdM5QxtifOOFVxl6P7jUv27fffPpaHGElxvS717wGZ4hHrfDy9D/uGWVOD1bud1rTNI95lDO0nPY/fWvQ/GiEI/OfuVagtf8uBI9U5d/HPhjC1a424BauVxaAvMHj/84Lt8/9F9D41e3ONU6WXQNNQCKttE7XxR8OTvjOQLP/4/rNea+Z/E2mM69aaE6+CGeLgguOml+TTEvXkv/8169p9gXPcu27eJn1itP5g97ApwFwTeOjdF98y2yz184pXGrhErxOf8v5mzKJY/nteGWjxNE27335muZl+y1/ACzicxIvO3W++eE94CaOZhLP+NPhyAU9TCYvaAOGMhP4fDggBjYXHrvn7GO+gp+6V6b4e/uw5LOBLAIFEmFJhnsWXIbCEZFSifPFFe8LbwNi5Py1t7fNRTdPfih4NU7Bj1kro8AROoZfXPCEc1Lp+E/H6XNS2xsvsw7XWSjwNI8bCzOp+LR5Oq8liNOJHsfPklCeuaFtMjx5917zyzj7TGqfu26g4gtPHP8ifhVfprgxPxUssoxlYZ4pHeV3faBHe6j1Paw5mjziP1vQRJKRANZIUwovHCHDzS6EQ4nXAgm8rCgWjT4YF2SGrXR7O+HJ2nEHci3SJjv39tsiidMuJurg/uU7i81/3MuELN8ehZOQMU4wx8c9f/kjk5a+85+D5rJbbFd5GeFX0iPxzJnsQzF5fucX8HbMhCeX+BGt5iNfW1DhjHbcmX9V2qJgxg7dYfzKkYvOwhd8xe9shE3Cen4Y8BmA/2kjiubEwzIM2X6X4DSeq6sEKutkizuw9G4IT3u4X3Nb01z6g8lH6Wt/Di/ZZoimmc3jx2Juzsbl3+XabVgc/4pFwqZEwedDf7bf7L3n5KPz9MtRHEXkI1z4krOwRYuURfxSx+aJuAj1sv0m2//X6wfNzXfaDnPnOzuMxYNedsfwUyVv0GWe5SshshU+hS3O41kQ/7tKXAhq23U2HoQlEKq4ZbK4x7EJwIDmBeFxOkmdutWL5YOXTV4Aj8YTsWN5GTZNwpDsKRHL8BfltjkfT6TuxbX1ce2sK/F75PomFSJQQpvmuIMmF0eL5nray6giycAzStsxn8eQhq/04c0vmm54MWq5RsxHLvGiLQWj5QwBvZmDn7aBSf/ZG2dfqOWzAnHR5E/uYX6AmqP1+Q+WcAHocZ2ejXvfR5/M14Sgsys0iHEGS0c1Ds+B4b4crJz8xq2D5qr/mHxd4HU4CzwaZwHzRLCwwUZ/lvBzinfw/WRT23xy/dJFxkXxKcrDL/q2LyL/+Z+efPo/B2eUBTxBI87NcdEH+aIYzV/ilz9t83g8qfy1Z09eYF+6YdDccIdtK66Kh/EoYspwlxZ68jgHHnvC+ZeW1Kkd9ZRNChkBNr3e4w54f7t7X/9dS2pWZLEUGHVwy30TEmy5BjJKB9EqR4WTqMLLmjQ1+sBly5+mqbXrWlyPP4AvSuyPE5t49/SN3qgFv4vUa865ahFXHxWt57H95DcXsTjCVewT/6afL6+Ei1492DjXNud9Ew8ssl/NwHT6RqnnKRz26Y0vmGpmpsPHCl4PP3yxX/cLSzy50k72wV8sjeFXPqA/vDDCnxE8pYONm9b1cRzu41DSpaSgStcy2e5jLh2lkxRJHPiUhQmvXS8IKn7t39tm/Y8mnwV4/X6nqA95c0GmV0x6Bm1uzjh8vpv2z3hczTaPxfD3WBTUp2tsT8Jj8y89c/LRed41i80DeNU4lh9cNb/NdvHv8aimeRXeTp7U/u2mxeZ6PMFkG8JXIFmk0xlvzGU+7EMCkj/30VOkoNNfi+AZL3ov4rHASctVXq9smRG3DYdmGEySETzIJAlfqGWN6GPhrPRcYPed8J48HgqYmfRtlL/2itaprISA48zqJeHnsRjuwPvstJML5xg885/0zJxnkHOu4DNz49ApDvogDu1jQ179mT8ADY/+tXhVM6l9GG9VC8wt88Jgo1hCcjfnMCD3KD/3/VfhGSdwaoHTuIofMezDf2iztzmdOIJqAlvAFk5l0OlgmeM0byq8A+E+/7JxTnj5yIle82+4sPIdXCGc1N6IJ4OzfD5IfBrEWBFXQPNVDxfQuenHuO7wPT8X0LN44WxrN7wxxDeIJjUumtvxXwFZF/ke/Bzngiwh0rbsI3sA7IZrGa9+7mT7X//eoPnmD8PCCB7GMloVcnP56YvciQC7/DgWLY+22RvfJe3tzgCZUBU+aBUgLEgxjGTQ0i6FzFJAE4bkKGIyrsNT3TbDGDvY/+Clk58L7InLt7+BQgmvbeDH8INA/Aw8Y+GFoYux0L6LxZD8hB6NU/NKl33PwDWLxJA1c0E8mxaCh9hCykSCnPzH4rnFSvZPu3hTFRGt8m68uGDIOTVJ8ntvMr98ga2CYU7kX6LFtHsfwl0yEPdZRCDCPRWVY0bGO8bqZN76cp0Ocy5uY/GYSzmdvOC7bXPjjyefBd6EU7VfRjE5gWcHLvtCXrTgV2jB8w081zjpAjzzowbmeaOt163wgY+Lcea4MX6PkxgnsuZPme2SXklBTLvgTaXX4l3FSe0KvDt61a3QiEUTAVBgPzNOGanymjFmL6CSUfgx8NhGNfZCcvwZC2vPhwB9709B0hm5gD7GNGYpJ8oIO5Wce5XDJDCJ5R2qG7lYnG+a01a4Ovh4vMHzSl1ISasgXI4fFMlPNvr173dHgsKrlz+r3+w54Zo/rZ9xOZ+ZG899t5o/ZeitqAGHr3v+NN5Z5Gj5dpoe+zGfrkX+hEKeWTCbTQXHJYuY6KTBUeMVp/ldF+vU3lMdfzv39Y+URwBcDKxMKSoLT8Yg4Q6NcZ53OxsOY064nINeWTiJD4zt48rcDW1zy39NPgv8Fk6pfMMmsq0+/SR/pid9oo/yjZ5qvvP/WHziZ1LjZd9Lb/Z78ozKkTH8YX5yQCju5N9pTdu8fgX738R1EF1WFnYYLw7IFUfkuebnOOPKGJ0T5jl8JD5940KK+lFW8JS37S79pu9fm0xiKvCmgOrEUSRpty2FhciUJhBhElNdgaK3jxpYZKO8xnLqCtcFfgov2V7xLD8XcMA0HE5xGB7Ie/mNUe0/VaD+i0/DZV+8ITSpnfGNeD8+7Yf/Yus2Nli2zsBr8T7Gbnj1Mqmdhtf9rE/6L20WjTzpO7hdB6ZPyvYGyimvRzIoPSoYy/h5zAzhxZr+4SGg1/bxb9R9FJuGjnEkJNF2Kox7FYVR4nAjgZxKA9TNu2yBkPupK/7QCdnnvtM2t96z8lmgh4gMH8bX/AoYfA7cvMn/xhWOzh/hvYJ/uZ6vHAJPv5FI28o4OL2Ufy1OLMfgpd+k9u3bBs3FePZP+77DNscqPDPERon5ldsV+DM2IjM3xOkOO1kjzioOKnG+4RlAqKqIFmALmJxi0BLGTKebR1gSaJ+6iZM7DklgxplOhH3OEsdLrR/GkTep8fP5v7LPlINIPAykTfMj4OCnnLPZ9n9Crznopycf/Wfjdf9AX3YAOuOQ32kF9mJRcJ4qyf9qvGR97Aof+DjtEh79SpJ8s4dhE5ZUcFk0P23X+Sebi0hi8yvGsMmyyi/a4DzxVaNMeMl7ejNoIx0aUqQx3GVT7N28HKQR3qygnobV2EnOIGOM/ZyXgyIfwUP2Gbwf/qONgTN6yfZ3cIThpQsNm5+u4pb2MbDvkLHJR/oD+UpHPy/7no/LvsQYZ9vcKsk2KFtQCD3r8HIvL/xMajfcPmi+vIGL3P4X6/SPFYCYdWA8o/yuD/Sgq1iJkQ9kxBhgWhWecsqkgg0GNSZt4ceENvZBhP9AEQ6FUXkiUzYYFNLimE1GgqA2LselSZtUdE/TIbE49qifDvHK20dWeEXAx29evjWGOQg8eo6TP+dzYfwUvpX00hUu+34Sn1u8H4uAGOHhcNqR07FhHEUe/L+Oj5Ot9IGSD/HoFza2qk0UhyUL/80u8o5nGFmsqLjQAngpnlqIBVNU4w422YjpbUQm81+QkDDugbB/wwmmc06yjWeCbdyui002QIbeybKDBQ/jJdHyydyfwuf17rifzMu333mhjzSxZVDo8zbKT9+OwWP/Spd9/x5vFSuezJjc4IbJQi+547fUPk/jUeVNeMt3Uvs+rnV88ds++uv82Ta3cYOvWgg6fBnJCH/Mk4sI4bmFPK0QYxxd7hZY+u9eGCyAttkohxQcbESQNo79aHWxOFcwyksmB8qJp0P0nSLcZU9OeiwHg1O2QnkeH4o/Ha/BJ7V1e/WbF+/dLcTiC7nG8O+KTwCteNn321h4uOybeC6aunUJppSxOcnUegXe7n0CXqVMah/G0Z+HgmwTX8U/VDBmq+QqrGo/OTp+ztIO75ylHeZa+ca+ECoAR9pDh14YPATgdcLGJGMNPM7KefUkwZCTNCKnrAPrasJHYHTHjthBkrKlk3Yo8JziHTY/+c2F5r/w6eBJ7XdxxJFLgbMP5eT3vm0f/dyVP+3Ly740UuKnASU1kyWBWSgHJ288gn4LH/ea1H6AaxyfvxaLGjj5VeFJap9tgWNpQZGxKUfsNWZPvY5fPgKTjT4ZF3jNAcTX2gZzwv7zIQDvBfAzqEo8FZRQGpHIxhwqt25lVBykvEoUg4ABOUNneRty0nZKgILTOkAAPrDQa87A6XhS2+8J/eaQp8qyYByJVMQcyyi+1dvisu/kAvFl2U0/pr756flL+Uap4qCh4KEKG11Fo/8vw/sU/MDnpPYRHP38qBpb0SQVbvKb8uSCTctcJMVEVOQv8fRKtaIcO8R4eXU42WE+Ei897KJRjH/jew+eUA++6z1KORUU0uC+m417QYQiJqhLkIBWhMwWjAihncWMi25pHXRnwviP4+Ph/Mr0pMazQAbd6YX/YfDluHi04mVfXoQCldl6eK+gaf7ipdPN4U8vr5LFoyRXeeFT0d/CF08ntdvwGf9/xkfUlOMscgDSnnJSQs38V1aVZipE/jCkqODDc3cZf4XnkH5X/Nbq34RXAVPfsSnOW6yVRYrKlssSmlp1xeNwhR0BKAnIqC841cRtY5ZiTIfQaqn3jP8JzgJnr3AWOAC/M/BCva63leS3bTOtdNn3enwoRZdlYcIIHNXxXkG+rFPuMEuPmaNcuP8Tek/Fq5JJ7aP4pO8m1F+5ZR7ilgcCPRdvxZ/FiqicP2ipVfzJa7+Tw/mjVTWnufCnBzxw4NOGfq/fbKAiBS6cDXGff9k4J6dpV8UbJtAc5KMBDuHTYI0PBfMFPhYYP8FzH16WTWo8C6jRZthVQjA+bO9VfNo3X3ZW+GPj9fzzntJv9n+i05vxkYtjSn/74MlH/+24pvFpfKLIKWMcjkV4HSwpkdHO/4hf4ZAQrcsP1cwfE+oYu3yMBVJZtpqMEWc8F0Ifte/PPHrNBpcSIQEsI/Azwo6e+14YWcOwqi7x1KKjDDNtaeVzX3drFlBEWPDBTzH570XxP77Cdwp5Ze95T7J1s3T8x/385ALx9PyF8rEx2AD/YU/rDX1E/LgXdl+WUiyuYXMkniM8Ha9GJrXTcfQv4LebI0zFVOu7kCkxvwsJGXxhEV0HDZVTJTcgwlNNjZrYIZl8jDHthM/FFvQJWxys2dC/5rje3TB0OwV2KItIFKWWa6xIOjmdLIW2YnEibQ3h4QnltsUZ2veiExPm7GRZRg0/xv2T+YiAkDHtLb8QbxIlHv1+j2+a5+MIntT4JUx+RFxJoyJwb0TB6/YSXDx68m700nr0jOOVjv47cS3j/KvzvQ1jFFXlo2Nl5BEf5rLw9klZkV+Z5+QnxgdX+M9OdmKfttBsgeOoK/m9uG6/5oTe3coQ9jeUwkiVrgVUDtMUm2Uahjx4TC7D1MItxloIBZZWaYFJ6Vrhh1B4bRu9HDwXp9FJ7ReeOoVTNTSSH/0bXzBcyFG8PiKOTwmr0REEwlcWo+8V8OLRMTyTyFn7fxieHO4L3UntzEsXm3k+t8wEQblED1tR8s6E9FLDGeDkWLzkHVQj4AsK8efiSDzdT+vUB78e+r0A+v3LEpyrlAkhWKBILGXKBOWQ2XgS2zxlWonRWxoRJ17he0XSZjpLJ4WXXsd/Bo7UB/FZ/0ntd/FaPPE/hR95WOmyLz/tqzNL8QlfD4srjKM8/wsfTN1tLZPm+N+ywmP/3biGcS4/TIqb80rPHBv3S16pUfEzAO1DJi7OZTExTHvCsybUq/HB0cntrzhH+Kd6/cvoUyzj9kJThsM0nsTUEgl6irmvINxrFxs6Iscwxxt13GsygZopO7FnG/ZAKPITrb7Br2bhdDrmix7GefuL+MLnur3MesxBk7+Hx/cc/l6fGM5o8BFxnOb5uD6u8fuKR+MjZNR+0c/2mmfj1cekdg7e1XxwUxe/ixRRw0jJSzVieZ1nKhjL+Fd4P18+yRfWiHflLPBhn5l1pNAMfvh0IXFxBpi9CJ8M4ZJ1S2PsJQRK41i9shaEsKjCixjqVBXGC6I4lXjMGT6CN1D8Shj0nTj60Gs+htfqo1/0kHK1eQvOArvu1Kz4TRx+C/cOvuuYPqH/NRzlk94reC0+lziDzxK+5ZDJDy0bce3i4/E9QvqfuXEsmUc4Te7gL70i9VximUuWM/HqmUBhnRvsROGVfk76lvyBTztYWAu79WcvgqIXwHX4nji+Lni5jjjZJEN9pyoaeSpntEIhZk/HOJc60ozVSFnXumCEByRtmh92qlXMWTZ+PPsfeUFlQjsST9j+4siVP417Ji/8gKPmvxSfHJ7U9sCnk9991HRz4ApPLD+O9zHun2NEYZ/+j4ufMcoHslJHiYeq4x/CV47R51wMxDk7FT7qkHjZrvFA4IdALv/KCT1ktDwEYNDr65Qgi3ImvOaYRukwWq5IjaTH6Si+NKhkjAOnnWq+2IIl6clSsc+kEM8bm3Uwhvyj+Ai5vqOnmaUb+ngUrvxNahfhV0puwrdwxUEeuorbFT9oG35aZ1I7av/Jtvmc4hx88VXeV7GRwaUiWeRS8+bnPONjhrllzLzpj3oYKP+BKbasJZtCwoDwlAvHaIJT1kOetcZs92DWH1xI5wy0K4SrIOhoj9JsdoLy4eCEZxGpLYBRDMMjW1iCD+7kz/lceIzjtnub5rPXTX5FkP4t15+BAtGPtM/ANEb/sRW+o7CczZR/As8r7nnA9mQTRIVHSs5AvWWBkp+xZz4Tx/ghVh2zFuaDFcmBV76NTXz6RDtUc7PVfj8Odgi7BfD4tRfj2tBdVgFErNBAn7I0zp5WSew5mme02KMz6bGYubFsCC9p6AtuW7ZH+wK7zwBB+qGv47W73tkiaPPat3HZ9xu3RKIAFZds03V8RwGfS/xh+Qj55tl+AK9SzsZLP9phnLz5r4tfMcU8rTtW5IZj+eEcGO34lTPN0V5lq8JQnLaSX0YJwc1zGFGx379r72b6Ys1jUxbAda/uzePdoU8kiRwiHxo7GZEjHjtAK8iwtKgc2qFLPFsGGHtyxjhCgBEuxmQj3ubVZ4C33t3gQ5uTT9XmWLrNo58RkM/JCU7sc12dnZeGl8InSs7DZeu7fmJb9NXxisk45cPFrvk5yfh556x9kgXhhFBKOQq8cmOMlIQKvOyM4adPuOHt30+cd0KPP5KkVhYA99b0+2c78V3mCZJbMFyKBELLPVeKVRylc4SFHnoXO+xSjiB4V+Ds6QBa8nvfeqP8H/o6P7iZCONW2vLXvb6gT/tCM/kRxSj/p/GZwHtxGt+cxg+xnInLvmyKidHwTz4iR+w1tpyTip+5DV+Sj3k1jlPQZ7FpbNz7+cTTluzYwnL8tkl7/bOTi/3QAlj/tplLwXkDScVNZ4JAhQkkadlKgNxJRwmUYxRlMHQxUaEa+HTePbAZNM2QP+zV/N+7E7/otWHzzgLn4Nk5Xv67hSu0LbuQJ/8DeCJ3Lo7mzWmfvmbQ/Pj+8JU2FWvaJikIlR+NZJrSUX7mWgWlbtqJ+IWXn4IrTVkbSjLXsjnKD3uKEz8WfdUJM5fagrdDC0Cifu9s58fupHIaZp8tScObEDt8ylKV9tJZ4ju5Fxhnu2b2WiY8QLSc/B/6mr/r3+GWH/Gy7/nX4IueiQ+6sh/8Fveaj+PJHI/q1TRem/joJfzpuNQO/8s+5A5AA/mPOYqSv2RamMCnueyZtHJAGc+t84k5YW0zIUO98zd09HN+yQKYbQfn0Bydkys0jLtWEIaWYiaqaHdDVwgWWAD6q0YTRSNWYxYy8VIUANqy3fHbHBeL7XBmAz9ijZ9UXU3jp315ZU74CfyOsW3uxFWRz+HDqatpn8X7Cf95L6LQH6MJ/8mTBiAqeyP8VMk58SNY5ybQdJo6zI3G1GYsPCDcNIcd2xnBU0W4fjs7NXNOQEq3ZAFcc/xON8PQZ7JAqcl93tSiQDnHXnOQyz05C91Qp6PCC+exnRWQcAp9twWNA66FZH8s4ZhB8yywUuMRyoszwo/hD9EwP2yfgZeE5lyegdck+HEvtdr/iL/YhkKXH1I5T8YZzvjFB6wKmskr04zdRbdfWX6JhXV9Ai9/Asyu137m0hOG/1sIxUsWgIRt7yQ6IUcZDBq3pWgpiAiLRmAopi4dSozwtKU5GkAbxUObCgxVScC8eyp3/OZrmmv1NavJi4BHMn8ZRPjg9x7pndCYRRf8cIA/2XbRCmeYz+PKZPeyEVjZZyFpyrYyfsU9jj+DUaawQzDx9IXjClNspacioi61fSv44Jcdzk/1T5LiyGbsArj2D2euAPUXkrBbcQyO3tE5WqL3sVC4izljWMTQkzgxw3IFB0dLIRKPvvAQj1uxW/gtOzWPQPKPNL5SOJNfN6vtVra0uJRg+MdQ0ufgPx3XHJZrvBbho59AJUM8WXhyhlHzR5x1LOInMXXZVfzGpwXb4rxyFT675D7Q6KdyxjnaEX/imy9cfcLS/xhGzNgFwIk1zdSJ7E3IEVsuCY7ro8d6ogN/OiZXwhEihvCQc14xq2MSJEEHC7xTvhyeWDT+xMp5eII3rp2N4t+UP0Ej05X/zClb6TmI+eC/Cj8u8U/LvAvJ4t+CVyOlyc+0z96x1P6njJihsEJQUMFPfxJPa0N4YkzhTvkMgSRGEN/vuZaEjLZEjMq1/6z/88BX8XTwUO0oVifJWSMU+/hjsRiQJSlzkHI6VK2EHSlHL+NUCDznqjYUNOa8T50wSl7wvxnv5fMt28fjK2B8zc+3e7kAav48+pgUYuSHuJbnn4Lebx8y1bwKtvfCT2n8EBeizsLzg3Ov4JNEHpHm10KSSxBU7oFInlI2jt+q5pcrI/EzTpnlZMSfdpbllyHqA93vXXT1X649LEWjfcU8OtU0z/m/m16ysLB4QV0wukOnS4tkdit1xKSUHaY8YjjDBhTisngSOctVX9gl8wK0URaMr/eLFxJzQ0n0kqUNL6rkZ8GUuJwmKmLkl0D0+f4aX/smjJlr/rpg8qN2p/gURsfxQ0d5Dz8ESf+W4ee0fOhPHXn1e9Z8KdVH+2UfAqi4/vfXfAkfSDjfSbHXDgaTJOYdNEoQ6SIGJRNzTqp1Upc9Y7Ryhbcw8kN54MmBOdsiB+c4jV7jYX5fMDOWGN7SRxunPRmgEc+xD35NCdXZyAWmr42P4U8/aNWmOyz5s3icVRxUkh3zy49J/IHr7JDJHGKMPFCa/LaPjyVOKD71Jy4AKkzNzB4PYr13zP0SBMOC0/Q7HcvTqnpJ6Y5cElIbALKYxEkjZNpDMCGVfeGzZjbg5IkbmiP8tC2/aIU6Yqi8IKAkzLPahkx4oSBNPOtUWhaRxNThRGdTBQ9cwRcsIV38xAle4yN+zlBXtms85CV/nJcBbryYkh/n/vtmpmePr6BjhysugPVv690Kynenq0yeHYsVCN5CSgo6BR3e2OQskyu5BNjYYQdinWI/AjTOtrmNSKnccZAHu+KifWqhJ1YyzkkhMVDgfvAH0jqQ0QT9ENqGbQdb+yeD4pAd8tAc5gmmB8JTTpnUqRA5k83KlrUwTR0gR/khDSOFn/Eo/2GLHNIJjeSHzXdfdkLvVs5OaisuAIL3PHD2FPy+/HVOsc05XPoeAaFX4umYnLG2FwtEECee/SjeKbMNYjQPxdQzq7c1nsmTTsVvtNlqfiiqxYzzRjwzz2KEjYKHeJi/IKHvMXEr8cOsucQjF4yXfDx/p8UFma3yptji7Ij/vf51u6+ZPSVRk/pVLYCvvLi3MNX23woqXSJmotiUqHQEfd4UbeiwQFraTLBC8REqvLCZ1EBTlhkTDTchkzyPcPPbNimS3clwxgGt+G13DD9dzBvsaCHQV/2N8Me8/Kdfups/rThS4kjfFTj53XcYuRi2GEfmN/npG52RHPPCw7zlnOvGeMMXiv234iNf418bS7vbrGoBUP1bf7zmq3DufYZGklQQB5lB2Xm4JkeDqHI23aUe7wpNdrqEMZwsbFiwvQhZ88TjVvCyoTQBQinuNqk+k8UZ2SY+MWGLU/Yp/KcqhWyMp+zRtvk5NRSLfCKbkdrSjxofRUx+OljHIrT0O0aO0qalHb98gT/i6rXvu/qkNV+lX6tpq14ANLbXgTPvBMklJNQRByeVMPbB5sLTOTbrKUBgiHMLPFxW4LIjddmlvgwoKDCid7ICTzkwvC3hZxoqHic+8LRDByo8ierFyrG06ILshD2Nw6/AqCBhy3G5TMYFHvbIsc3ez3cAil0LoebvNZfsNj37zvRlNT2926y2/9+1T2kHD14N8j2UfCY8m5KEHQYtRznBgdduKRadxo2J9gz10BIPaWmSBT70E5f2RFHjxW/e5Jc98rLAy/BbTk3yBz74Ler8lk7YS377FfjEpR2KQ588yVHHb3nJlnWoq0UUeDiiBUqHwh4pYOdOfHD9uZef1PsBNFfdNusMQKvX/lHvByA7Fk75+YACZEDZsnidTOmks3RewVu37FPmP0wEvtZjrLh1+iN4+SATHd4q2soi7UXxcyrtyafibvKnFnqK5E/4T1MSe98FoQ7u6T+HdRvhN0vgORf89GlsG8NPLvpOdG+qPXZzi0+ezV4ABF379rWfA+ffcJyBcOyVSncYTYQSuz61WpqJF4QbWtEfrRVA2LY5YaiJIuZRHEjjY67ga/6cg2nakS35KFprTuCnS8SojfBTlnP0i7F7kYc+sNLRnEbS94Ku5ir+ITxVZGMpP02y9fu9v7nyPazJ5rctWgCk+Y0/mv1zBH6unYOACS2Fh2dMRPjjvHDPEgaoZBXJCL4k0gYYp5Ii+x5n0kMkvsKvzFT8id9Cfnoha/Q7bCV/CRJz8hHcji2jJzr8h3LivfQ8RxvE2uPAM7AhE1IaxkMEunNfMTXz52Fpszv6s8WN/4X6+pvnuPKOpL9uHDg9pdD0HbcuafZc8wJVbsgQk+CkECPTkPsI62wVvJSDXtrD/Pat40+/Cl5pDXzwS0TOlfjlOp0d5tcebRXfxvNTz94GfoSfs24jvlh+wdPXzB5Vf8o3lFfdpfVVA0YVD/5ou8s9d859GQl4Xp1Y6yE05iYSqdIxJ3KeGQv6kqhMGOfYQrPGd1KNqKUj30SWKYmcGObXETaOPxbNsJ3AoxuNazn/S5yFHx7AL8odK3ry177SPm60mTzyg/RoKY9EWui4rnzULrMvvuRP83ceY2ozuy1+CEieS97Mnxqb/RU8I7xRTmKCAeqOsYNPbacu90rPdRBJ8pKgnnULXhMVnjllKz0HMb8Mf0HDVsJkQ3YqfGEf9r/gSTtqAALO2030LDL20n/vaVaUgseuusBrUlaMGMLLpvJ7407Ts7+ytcUnV+eRmbd4+9y/bX9m02D+i+1g8IzayHDS8jToZKsMGsIN9HQmj9LYQQepJzTHfSalO4rIRoVQG6nMOP484sRGXia2uIRBGdNoWJB46ZFqVfPLiRF+ehXuw27gQZBSqi/hlyFsZDw0OSau17+xaWdeevVJvVtSbWv6rT4DJPnVf9y7pd+bOQRfM7+SLudN85EUpanbYEo7sWVZIjFKOizEis/DzdqRUiWkwoNDR4swye75+igiGWfdupGyLT+pEHj24BnCy+sxeGJ5H+GnpuMqlCvzyz9wy5b5aQf7V+40PXPItio+PdpmC4DG1r+9d/uuvZkXY3iBwq6S4iQiDCUZGjmHYDmnUqionqNMd6SPJRvCMxuSxxzHkSxNKeWBp23MDeEFB4Y+MNnZe0/7NT99S7x6kggT+JX4A9/ZkQPF5jh+ysSFXrlBTvmY/7UTercTva3aNl0AdIqPS/s+bfYovB99rlcwE6w0h8+RcBSF86xbJiYLJTmlnMeNzVsOAi+JZ7WNIjJpRmGbeNaptCimiKnDic6mjtbAFXzBkr5bDMTZrwo/wi/bNR6IXEy0ZQO04sWU/LIt5xTHuXy2vy0e8ytXNNzmC4BWz8MXTV/1JzO/CdffhyeHiMzBiZGFYmDomQjuMuioREmwZJyTQmJggfvKGntpWQcy55OEuNlwanBW+sQr8WFX5qBFMDW4lV+U8U8Kw5hiK6zTppAwIDzlNtxxyrrlNT85RCRkx6/Y8G1dTL7vFdMzv7k1L/XIsFxjzNu17f/XDx6FbJyJ0PYQERLjBChExc79LmFOwpBTkWDn0Ee486at7BU8RGk/cg5T1ItQg9/1CTzmCl6aw2nhnIpOcfqCocfmK/jgF0YLneyBTwzlOdZAhu0m9mOB3dmf6h27pVf4ZHYVm+FIVwHYEpWD8AbSA3MP/gOwB7sQLkiEnaUpCegG0GDClUgXS/iQCc/pEaeyGHk0KqEqHBSLrUgzRYGXWYxZMDbhISxHbEjTp+S3rr22rMKX4vPoJz005EvHX/ARCw78S9a0a1+7Jdf25eJmbLbLQ8Ao/+V4A2nPF609HC9hTkYCHCaS4COD+YBISWESMVZJmKiwJART66RlEbPQ7I2zLWop0WFJVnTU0Qabi1BjaIOzlAmvPXsiP2p8FDH5jQq87IzhD6uiL0wRIP03jkZO3n167eE7oviRCbu0o7bP/utNhzWDxQ+Abz9yKnAkNBJgN5CMLHLpczFE8n0kdQVLO8UmMllktFeay8wis6VOzT8kCz4vAiK8eDaXnx6YseOXVyw842+a63rt1Fs358Mc9GZrm33aWiubiT/8y+30XZfOHT8YNP8bse+s5NJGFiqTrpR1qeO8ksUetzxak95F5J6TnMVSL1GHy7ksJFG2F3j5UtmRQsefHLmQPK2SyjdaSw4t4sSH3znX6/fvwz9wfM+u07PvX+3HuGhqW7WHZAGk8885uX3yYGHuFJTy15mQchRGseokc66cDWAgEy957A8tiFq/XlAqLE2BBCaJYdOCwpzkFEivWgC1vdQveoGHrfRryQJIe+qTv/epmTUzf7CaT++Sanu0h3QBZEDPOWnTS5re4ruQm0PLWSBSmYXPNZEOU+4ixpGWtXJVmWFYYB09X6YhS7mKPlQ0AbQkSiGJL7bssW252MUPTmktYUkJQi3KzO8db/Hzwxfhid67r37PTst+Y6fW357j8HJ7Uqze9nP+atOh7WDxncj3L2XhmEAW2vssXpwpIGNTAVxSF6AUKxNf9VGYDhN42gKPNMMu97VU2Mc8+ZK/WxSxEFx9zVOv4GM5hXNf4Bc1r/rLNRdJ52GweVgtgMzHc0+cf/6g174DX+/+VTiIh0jOONEaQZCLwgFUYWThKKIeboYbw518qNBCEBQbKZlHhTdRFN/yPCsYN7woqaE2wo+r7XTiM72p3knLfUU7oQ9FX2XuoaCfzHnAe9untu3869vF9hhoPkPHKArlQrBi6X6MmfzqaC2aXAiQs3BsS/CBK2eG0JNuwZELeFFwwdCW+YcXlOfAdyPmz+LPsoz7ZQ7afjg0R/Bw8GQFHw48cf6F+HG4N7SD9jVI7mNLsYRzYVTaqA0DY4lcKMxoYVAWZwUUULJKR/jACW8D1IhFQ3PdYkqbYtJ66N/V7+O3FvFTbKO/xiUjD8PNI2YBZO74MbQNGx48BKfWI5p2gHvvIFTH/9clq6ZiAKE+TtwYLyk+imnVKg06spONfXe+4GLiXtrBmlrAgrgcBb+QP7/KX+DcXtfsa4+25biKfFua3XG2Dv9/7c733D13aLvYHIF/+/wCfFh9HYr6uBJYVfhYEaVT9WMJ5JnCDyEse9ey4Ohvx7+K24Aj/zIU/kL+5Hr+6nan/cga1XE+sjyf4O0B7293H2zctA5Pv/bBv0Zah+/K7Y3i7Y7C7YInljvj+jd+R6TdBcczeh7TA/4D7Y3toNmIj1jfh+Jiv70ba+O7+IL8hqnp5jv8B0v8HzsTaB+RU/8fkqGiqm2YS3gAAAAASUVORK5CYII=">
+    <style>
+        body {
+            margin: 30px;
+        }
+
+        .addonList {
+            max-width: 80%;
+            flex-direction: column;
+            padding: 18px;
+            border-radius: 4px;
+            border: 1px solid silver;
+        }
+
+        .addonItem {
+            font-size: 16px;
+            line-height: 36px;
+            margin-bottom: 4px;
+        }
+
+        .addonItem:hover {
+            border-radius: 2px;
+            border: 1px dashed silver;
+        }
+
+        .addonItemName1 {
+            display: inline-block;
+            width: 15%;
+            text-align: left;
+            vertical-align: middle;
+            word-wrap: break-word;
+        }
+
+        .addonItemName2 {
+            display: inline-block;
+            width: 10%;
+            vertical-align: middle;
+            text-align: left;
+            word-wrap: break-word;
+        }
+
+        .addonItemName3 {
+            display: inline-block;
+            width: 10%;
+            vertical-align: middle;
+            text-align: left;
+            word-wrap: break-word;
+        }
+
+        .addonItemName4 {
+            display: inline-block;
+            width: 25%;
+            text-align: left;
+            vertical-align: middle;
+            word-wrap: break-word;
+        }
+
+        .addonItemName5 {
+            display: inline-block;
+            width: 10%;
+            text-align: left;
+            vertical-align: middle;
+            word-wrap: break-word;
+        }
+
+        .addonItemName6 {
+            display: inline-block;
+            width: 5%;
+            text-align: left;
+            vertical-align: middle;
+            word-wrap: break-word;
+        }
+
+        .addonItemButton {
+            padding: 4px 8px;
+            background-color: #417ff9;
+            display: inline-block;
+            cursor: pointer;
+            box-sizing: border-box;
+            border-radius: 4px;
+            text-align: center;
+            color: #fff;
+        }
+
+        .addonItemButton:hover {
+            background-color: #5696ff;
+        }
+
+        .addonItemTitle {
+            padding: 0px;
+            border-bottom: 1px solid silver;
+        }
+
+        .addonItemTitle:hover {
+            border-radius: 0px;
+            border: 0px;
+        }
+
+        .ClearAll {
+            max-width: 80%;
+            margin-top: 20px;
+            font-size: 16px;
+            line-height: 36px;
+            text-align: center;
+            cursor: pointer;
+            border: 1px dashed silver;
+            padding: 0px 18px;
+        }
+
+        .ClearAll:hover {
+            border-radius: 2px;
+            background-color: silver;
+        }
+
+        .divTitle {
+            font-size: 30px;
+            font-weight: bolder;
+            margin-bottom: 20px;
+        }
+    </style>
+    <script>
+        function getHttpObj() {
+            var httpobj = null;
+            if (IEVersion() < 10) {
+                try {
+                    httpobj = new XDomainRequest();
+                } catch (e1) {
+                    httpobj = new createXHR();
+                }
+            } else {
+                httpobj = new createXHR();
+            }
+            return httpobj;
+        }
+        //兼容IE低版本的创建xmlhttprequest对象的方法
+        function createXHR() {
+            if (typeof XMLHttpRequest != 'undefined') { //兼容高版本浏览器
+                return new XMLHttpRequest();
+            } else if (typeof ActiveXObject != 'undefined') { //IE6 采用 ActiveXObject， 兼容IE6
+                var versions = [ //由于MSXML库有3个版本，因此都要考虑
+                    'MSXML2.XMLHttp.6.0',
+                    'MSXML2.XMLHttp.3.0',
+                    'MSXML2.XMLHttp'
+                ];
+
+                for (var i = 0; i < versions.length; i++) {
+                    try {
+                        return new ActiveXObject(versions[i]);
+                    } catch (e) {
+                        //跳过
+                    }
+                }
+            } else {
+                throw new Error('您的浏览器不支持XHR对象');
+            }
+        }
+
+        var fromCharCode = String.fromCharCode;
+        // encoder stuff
+        var cb_utob = function (c) {
+            if (c.length < 2) {
+                var cc = c.charCodeAt(0);
+                return cc < 0x80 ? c :
+                    cc < 0x800 ? (fromCharCode(0xc0 | (cc >>> 6)) +
+                        fromCharCode(0x80 | (cc & 0x3f))) :
+                        (fromCharCode(0xe0 | ((cc >>> 12) & 0x0f)) +
+                            fromCharCode(0x80 | ((cc >>> 6) & 0x3f)) +
+                            fromCharCode(0x80 | (cc & 0x3f)));
+            } else {
+                var cc = 0x10000 +
+                    (c.charCodeAt(0) - 0xD800) * 0x400 +
+                    (c.charCodeAt(1) - 0xDC00);
+                return (fromCharCode(0xf0 | ((cc >>> 18) & 0x07)) +
+                    fromCharCode(0x80 | ((cc >>> 12) & 0x3f)) +
+                    fromCharCode(0x80 | ((cc >>> 6) & 0x3f)) +
+                    fromCharCode(0x80 | (cc & 0x3f)));
+            }
+        };
+        var re_utob = /[\uD800-\uDBFF][\uDC00-\uDFFFF]|[^\x00-\x7F]/g;
+        var utob = function (u) {
+            return u.replace(re_utob, cb_utob);
+        };
+        var _encode = function (u) {
+            var isUint8Array = Object.prototype.toString.call(u) === '[object Uint8Array]';
+            if (isUint8Array)
+                return u.toString('base64')
+            else
+                return btoa(utob(String(u)));
+        }
+
+        if (typeof btoa !== 'function') btoa = func_btoa;
+
+        function func_btoa(input) {
+            var str = String(input);
+            var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+            for (
+                // initialize result and counter
+                var block, charCode, idx = 0, map = chars, output = '';
+                // if the next str index does not exist:
+                //   change the mapping table to "="
+                //   check if d has no fractional digits
+                str.charAt(idx | 0) || (map = '=', idx % 1);
+                // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
+                output += map.charAt(63 & block >> 8 - idx % 1 * 8)
+            ) {
+                charCode = str.charCodeAt(idx += 3 / 4);
+                if (charCode > 0xFF) {
+                    throw new InvalidCharacterError("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
+                }
+                block = block << 8 | charCode;
+            }
+            return output;
+        }
+
+        function encode(u, urisafe) {
+            return !urisafe ?
+                _encode(u) :
+                _encode(String(u)).replace(/[+\/]/g, function (m0) {
+                    return m0 == '+' ? '-' : '_';
+                }).replace(/=/g, '');
+        }
+
+        function IEVersion() {
+            var userAgent = navigator.userAgent; //取得浏览器的userAgent字符串  
+            var isIE = userAgent.indexOf("compatible") > -1 && userAgent.indexOf("MSIE") > -1; //判断是否IE<11浏览器  
+            var isEdge = userAgent.indexOf("Edge") > -1 && !isIE; //判断是否IE的Edge浏览器  
+            var isIE11 = userAgent.indexOf('Trident') > -1 && userAgent.indexOf("rv:11.0") > -1;
+            if (isIE) {
+                var reIE = new RegExp("MSIE (\\d+\\.\\d+);");
+                reIE.test(userAgent);
+                var fIEVersion = parseFloat(RegExp["$1"]);
+                if (fIEVersion == 7) {
+                    return 7;
+                } else if (fIEVersion == 8) {
+                    return 8;
+                } else if (fIEVersion == 9) {
+                    return 9;
+                } else if (fIEVersion == 10) {
+                    return 10;
+                } else {
+                    return 6; //IE版本<=7
+                }
+            } else if (isEdge) {
+                return 20; //edge
+            } else if (isIE11) {
+                return 11; //IE11  
+            } else {
+                return 30; //不是ie浏览器
+            }
+        }
+
+        /**
+         * 生成guid的接口
+         * @returns guid
+         */
+        function guid() {
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+                var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+                return v.toString(16);
+            });
+        }
+
+        /**
+         * 自定义协议启动服务端
+         * 默认不带参数serverId，linux未升级之前不要使用多用户
+         */
+        function InitWpsCloudSvr() {
+            if (serverId == undefined)
+                window.location.href = "ksoWPSCloudSvr://start=RelayHttpServer"//是否启动wps弹框
+            else
+                window.location.href = "ksoWPSCloudSvr://start=RelayHttpServer" + "&serverId=" + serverId //是否启动wps弹框
+        }
+
+        var serverId = SERVERID_REPLEASE_STRING;
+
+        /**
+         * 获取serverId的接口
+         * @returns serverId
+         */
+        function getServerId() {
+            if (window.localStorage) {
+                if (localStorage.getItem("serverId")) {
+                    //
+                }
+                else {
+                    localStorage.setItem("serverId", guid());
+                }
+                return localStorage.getItem("serverId");
+            }
+            else {
+                return guid();
+            }
+        }
+
+        function startWps(req, t, callback) {
+            function startWpsInnder(reqInner, tryCount, bPop) {
+                if (tryCount < 1) {
+                    if (callback)
+                        callback({
+                            status: 2,
+                            message: "请允许浏览器打开WPS Office"
+                        });
+                    return;
+                }
+                var bRetry = true;
+                var xmlReq = getHttpObj();
+                //WPS客户端提供的接收参数的本地服务，HTTP服务端口为58890，HTTPS服务端口为58891
+                //这俩配置，取一即可，不可同时启用
+                xmlReq.open(reqInner.type, reqInner.url);
+                xmlReq.onload = function (res) {
+                    if (res.target.status != 200) {
+                        var responseStr = IEVersion() < 10 ? xmlReq.responseText : res.target.response;
+                        var errorMessage = JSON.parse(responseStr)
+                        if (errorMessage.data == "Subserver not available." && tryCount == 4 && bPop) {
+                            InitWpsCloudSvr();
+                            setTimeout(function () {
+                                if (bRetry) {
+                                    bRetry = false;
+                                    startWpsInnder(reqInner, --tryCount, false);
+                                }
+                            }, 3000);
+                        }
+                    }
+                    if (callback)
+                        callback({
+                            status: 0,
+                            res: res
+                        });
+                }
+                xmlReq.ontimeout = xmlReq.onerror = function (res) {
+                    xmlReq.bTimeout = true;
+                    if (bPop) { //打开wps并传参
+                        InitWpsCloudSvr()
+                    }
+                    setTimeout(function () {
+                        if (bRetry) {
+                            bRetry = false;
+                            startWpsInnder(reqInner, --tryCount, false);
+                        }
+                    }, 1000);
+                }
+                if (IEVersion() < 10) {
+                    xmlReq.onreadystatechange = function () {
+                        if (xmlReq.readyState != 4)
+                            return;
+                        if (xmlReq.bTimeout) {
+                            return;
+                        }
+                        if (xmlReq.status === 200)
+                            xmlReq.onload();
+                        else
+                            xmlReq.onerror();
+                    }
+                }
+                xmlReq.timeout = 3000;
+                xmlReq.send(t)
+            }
+            startWpsInnder(req, 4, true);
+            return;
+        }
+
+        function CheckPlugin(element) {
+            var id = GetAddonId(element);
+            var ele = document.getElementById(id + "_status");
+            var xmlReq = getHttpObj();
+            var offline = element.online === "false";
+            var url = offline ? element.url : element.url + "ribbon.xml";
+            xmlReq.open("POST", "http://localhost:58890/redirect/runParams");
+            xmlReq.onload = function (res) {
+                if ((offline && res.target.response.startsWith("7z"))
+                    || !offline && res.target.response.startsWith("<customUI")) {
+                    ele.style.color = "green";
+                    ele.style.textAlign = "center";
+                    ele.innerHTML = "正常";
+                } else {
+                    ele.style.color = "white";
+                    ele.style.backgroundColor = "gray";
+                    ele.style.textAlign = "center";
+                    ele.innerHTML = "无效";
+                    ele.title = offline ? ("不是有效的7z格式" + url) : ("不是有效的ribbon.xml，" + url);
+                }
+            }
+            xmlReq.onerror = function (res) {
+                xmlReq.bTimeout = true;
+                ele.style.color = "white";
+                ele.style.backgroundColor = "gray";
+                ele.style.textAlign = "center";
+                ele.innerHTML = "无效";
+                ele.title = "网页路径不可访问，如果是跨域问题，不影响使用：" + url;
+            }
+            xmlReq.ontimeout = function (res) {
+                xmlReq.bTimeout = true;
+                ele.style.color = "white";
+                ele.style.backgroundColor = "gray";
+                ele.style.textAlign = "center";
+                ele.innerHTML = "异常";
+                ele.title = "访问超时，" + url;
+            }
+            if (IEVersion() < 10) {
+                xmlReq.onreadystatechange = function () {
+                    if (xmlReq.readyState != 4)
+                        return;
+                    if (xmlReq.bTimeout) {
+                        return;
+                    }
+                    if (xmlReq.status === 200)
+                        xmlReq.onload();
+                    else
+                        xmlReq.onerror();
+                }
+            }
+            xmlReq.timeout = 5000;
+            var data = {
+                method: "get",
+                url: url,
+                data: ""
+            }
+            var sendData = FormatSendData(data)
+            xmlReq.send(sendData);
+        }
+
+        function GetAddonId(element) {
+            return element.name + "/" + element.addonType;
+        }
+
+        function UpdateElement(element, cmd) {
+            if (typeof element.name === 'undefined')
+                return
+            var id = GetAddonId(element);
+            var addonList = document.getElementById("addonList");
+            //var param = JSON.stringify(element).replace(/"/g, "\'");
+            var buttonLabel = cmd === 'enable' ? "安装" : "卸载";
+            var des = "文字";
+            if (element.addonType == "et")
+                des = "电子表格";
+            else if (element.addonType == "wpp")
+                des = "演示";
+            var loadType = "在线";
+            if (element.online == "false")
+                loadType = "离线";
+            var old = document.getElementById(id);
+            if (old !== null) {
+                var oldOnline = old.wpsaddon.online === "false";
+                var newOnline = element.online === "false";
+                if (cmd === 'disable'
+                    && (oldOnline !== newOnline
+                        || old.wpsaddon.url !== element.url
+                        || (oldOnline && old.wpsaddon.version !== element.version))) {
+                    buttonLabel = "更新/卸载";
+                    cmd = "choose";
+                }
+                old.wpsaddoncmd = cmd;
+                document.getElementById(id + '_button').innerHTML = buttonLabel;
+                document.getElementById(id + '_domain').innerHTML = element.customDomain;
+            } else {
+                var ele = document.createElement("div");
+                ele.className = "addonItem";
+                ele.id = id;
+                ele.wpsaddon = element;
+                ele.wpsaddoncmd = cmd;
+                ele.innerHTML =
+                    '<div class="addonItemName1">' + element.name + '</div>\n' +
+                    '<div class="addonItemName2">' + des + '</div>\n' +
+                    '<div class="addonItemName3">' + loadType + '</div>\n' +
+                    '<div class="addonItemName4">' + element.url + '</div>\n' +
+                    '<div class="addonItemName1" id="' + id + '_domain' + '">' + element.customDomain + '</div>\n' +
+                    '<div class="addonItemName5"><div class="addonItemButton" id="' + id + '_button' + '" onclick="WpsAddonHandle(\'' + id + '\')">' + buttonLabel + '</div></div>\n' +
+                    '<div class="addonItemName6" id="' + id + '_status' + '">验证中...</div>\n';
+                addonList.appendChild(ele);
+                CheckPlugin(element);
+            }
+        }
+
+        function WpsAddonHandle(id) {
+            var ele = document.getElementById(id);
+            var element = ele.wpsaddon;
+            var cmd = ele.wpsaddoncmd;
+            WpsAddonHandleEx(element, cmd)
+        }
+
+        function WpsAddonHandleEx(element, cmd) {
+            if (cmd === "choose") {
+                if (confirm("点击确定将更新 WPS 加载项，或点击取消完成卸载")) {
+                    cmd = "enable";
+                } else {
+                    cmd = "disable";
+                }
+            }
+            var data = FormartData(element, cmd);
+            var req = { url: "http://localhost:58890/deployaddons/runParams", type: "POST" };
+            startWps(req, data, function (res) {
+                if (res.status == 0) {
+                    if (cmd === "disableall") {
+                        window.location.reload();
+                    } else {
+                        if (res.res.target.response == "OK"
+                            || (res.res.target.response == "" && res.res.target.status == 200)) {
+                            var newCmd = 'disable';
+                            if (cmd === 'disable')
+                                newCmd = 'enable';
+                            UpdateElement(element, newCmd)
+                            alert("配置成功！");
+                        }
+                        else {
+                            alert("配置失败！");
+                        }
+                    }
+                } else {
+                    alert(res.message);
+                }
+            });
+        }
+
+        function FormartData(element, cmd) {
+            var data = {
+                "cmd": cmd, //"enable", 启用， "disable", 禁用, "disableall", 禁用所有
+                "name": element.name,
+                "url": element.url,
+                "addonType": element.addonType,
+                "online": element.online,
+                "version": element.version,
+                "customDomain": element.customDomain
+            }
+            return FormatSendData(data);
+        }
+
+        function FormatSendData(data) {
+            var strData = JSON.stringify(data);
+            if (IEVersion() < 10)
+                eval("strData = '" + JSON.stringify(strData) + "';");
+
+            if (serverVersion >= "1.0.2" && serverId != undefined) {
+                var base64Data = encode(strData);
+                return JSON.stringify({
+                    serverId: serverId,
+                    data: base64Data
+                })
+            }
+            else {
+                return encode(strData);
+            }
+        }
+
+        function LoadLocalAddons() {
+            var baseData
+            if (serverVersion >= "1.0.2" && serverId != undefined)
+                baseData = JSON.stringify({ serverId: serverId });
+            var req = { url: "http://127.0.0.1:58890/publishlist", type: "POST" };
+            startWps(req, baseData, function (res) {
+                if (res.status == 0) {
+                    var addonList = document.getElementById("addonList");
+                    var curList = JSON.parse(res.res.target.response);
+                    curList.forEach(function (element) {
+                        if (element.enable === "false")
+                            return;
+                        UpdateElement(element, 'disable')
+                    });
+                } else {
+                    alert(res.message);
+                }
+            });
+        }
+
+        function LoadPublishAddons() {
+            var addonList = document.getElementById("addonList");
+            var curList = PUBLISH_REPLACE_STRING;
+            curList.forEach(function (element) {
+                var param = JSON.stringify(element).replace("\"", "\'");
+                UpdateElement(element, 'enable')
+            });
+        }
+
+        var serverVersion = "wait";
+        function InitSdk() {
+            var req = { url: "http://127.0.0.1:58890/version", type: "POST" };
+            startWps(
+                req,
+                JSON.stringify({ serverId: serverId }),
+                function (res) {
+                    if (res.status !== 0) {
+                        return;
+                    }
+                    if (serverVersion == "wait") {
+                        serverVersion = res.res.target.response;
+                        LoadPublishAddons();
+                        LoadLocalAddons();
+                    }
+                },
+            );
+        }
+
+        function LoadAddons() {
+            var addonList = document.getElementById("addonList");
+            addonList.style.maxWidth = 800 * window.devicePixelRatio + "px";
+            var ClearAll = document.getElementById("ClearAll");
+            ClearAll.style.maxWidth = 800 * window.devicePixelRatio + "px";
+            InitSdk();
+        }
+
+        function ClearAll() {
+            if (confirm('确定要禁用所有WPS加载项吗？')) {
+                var element = {};
+                WpsAddonHandleEx(element, 'disableall');
+            }
+        }
+    </script>
+</head>
+
+<body onload="LoadAddons()">
+    <div class="divTitle">WPS加载项配置</div>
+    <div class="addonList" id="addonList">
+        <div class="addonItem addonItemTitle">
+            <div class="addonItemName1">加载项名称</div>
+            <div class="addonItemName2">类型</div>
+            <div class="addonItemName3">加载方式</div>
+            <div class="addonItemName4">URL</div>
+            <div class="addonItemName1">自定义域名</div>
+            <div class="addonItemName5">管理</div>
+            <div class="addonItemName6">状态</div>
+        </div>
+    </div>
+    <div class="ClearAll" onclick="ClearAll()" id="ClearAll">禁用所有 WPS 加载项</div>
+</body>
+
+</html>


### PR DESCRIPTION
## 概要

现有 Office 插件（Word/Excel/PPT 任务窗格）的同一套 Vue 源码，新增构建为 **WPS 加载项**（文字/表格/演示三宿主，Windows/Linux 版 WPS）。后端零改动：officeHost 仍是 word/excel/powerpoint 三值，clientCapability 仍是 'office'，office_command 契约与回传路径完全一致。

## 主要改动

- **宿主桥** `hostBridge.js`：Vue 层唯一宿主入口，运行时分发 Office.js / WPS 两家族；chatSession/ChatView 切到桥上，行为与改造前逐点一致（既有测试全数钉住）。
- **WPS 执行器**：`wpsExecutor.js` 分发器 + 三张 HANDLERS 表（文字 34 / 表格 26 / 演示 14 命令），命令名与参数/返回值契约以 officeExecutor.js 为准绳。不依赖 wps.Enum（本地 VBA 同值常量表）。
  - 文字面能力升级：行距最小值（wdLineSpaceAtLeast）、中西文分设字体、中文编号「一、二、」全部原生；replace_text 走字符偏移直切 + 逐笔校验 + 失准整体切纯 Find 循环（不许两路径混跑）。
  - 降级项全部在返回值 via/note 交底：表格批注 reply 降级文本追加、resolve 不支持；文字 insert_image 本版不支持；演示下划线只有开/关。
- **SSE 双通道**：老 CEF 内核探测不到流式 fetch 时降级 XHR onprogress（语义一致）；顺手修了 XHR 同步 abort 造成 onClose 双触发的隐患。
- **分发**：`wps/` ribbon 薄壳（对拍官方 wpsjs@2.2.3 模板）+ 官方 publish.html 模板 vendor + `npm run build:wps` 一步产出 dist-wps/（加载项本体 + install.html 一键安装页 + 企业版 jsplugins.xml）。在线模式发版 = 覆盖静态目录，用户无需重装。
- 文档：README「WPS 加载项」章（含真机验证清单）、领域文档 office-addin.md WPS 一节、eng-infra 发版硬步骤补 WPS 条目。

## 验证

- `npm test` 161 项全绿（新增 95：三宿主 handler 单测 mock 真实偏移推移、SSE XHR 通道、混跑病灶回归）
- `npm run build` + `npm run build:wps` 产物验证
- 真机验证待 Windows 虚拟机（清单在 README，头号风险 = 最新个人版上 install.html 的 enable 是否有 2024 整改后的额外校验）

🤖 Generated with [Claude Code](https://claude.com/claude-code)