### PR TITLE
fix(editor): 工具栏下拉弹层 fixed 定位——样式/字体/颜色下拉此前完全打不开（dev-board#245）

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -102,6 +102,7 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - **`.uno:Grow` / `.uno:Shrink` 在本引擎是哑弹**（派发不报错，CharHeight 纹丝不动）。字号步进走 `get_ui_state` 读当前值 + `format_selection {fontSize}`。参数名不对称是既有契约：读回叫 `sizePt`，写入叫 `fontSize`，别改。
 - 撤销/重做可用性走 `xModel.getUndoManager()`（XUndoManagerSupplier 的**方法**）；`getPropertyValue('UndoManager')` 抛 UnknownPropertyException。
 - `XSelectionChangeListener` 装得上、选区变化每次触发，但**纯光标移动基本不触发**——工具栏状态刷新必须是「事件 + 聚焦时轮询」混合。
+- **工具栏弹层（样式/字体/字色/高亮/插入五个下拉）必须 fixed 定位**（dev-board#245）：工具栏行是横向 scroll-view（竖向 overflow hidden），外面又套 pane/workbench 一串 `overflow:hidden`，绝对定位的菜单会被裁得只剩顶边、看起来就是「点了打不开」——从自建工具栏诞生（#356）起就裁死，任何 e2e 都没点过下拉所以一直漏网。现行实现：`toggleMenu`/`openInsert` 打开瞬间 `capturePopPos` 取触发器视口坐标，`popStyle(width)` 内联 `position:fixed` + z 900（弹窗遮罩 1000+ 之下、窗格与编辑器 webview 之上）；`popPos` 取不到时退回原 absolute（会被裁，属降级）。新增弹层照抄这套，别再放回文档流。desktop-e2e 有「还原病灶即转红」的回归步骤（真实鼠标点开 → hit-test 命中菜单 → 选「标题 1」引擎样式真变）。
 - `format_selection` 拒绝空选区，工具栏「先设格式再打字」这条路目前是断的（P2 待补）。
 - **本引擎不支持尾注**：`insert_endnote` 设 `IsEndnote` 时抛 IllegalArgumentException（脚注正常）。工具栏刻意没有这一项；e2e 组 26 锁住「明确拒绝且给出可读原因」，将来引擎支持了那条会红，提醒把菜单项加回去。
 - **`insert_footnote` 之后视图光标停在脚注区里**：紧接着的 `select_all`/`replace_selection` 会打在脚注上而不是正文。

--- a/frontend/src/components/EditorToolbar.vue
+++ b/frontend/src/components/EditorToolbar.vue
@@ -15,11 +15,11 @@
 
         <!-- 段落样式 -->
         <view class="etb-drop" :class="{ open: menu === 'style' }">
-          <view class="etb-field w110" :title="$t('editor.toolbar.paraStyle')" @tap.stop="toggleMenu('style')">
+          <view ref="trig_style" class="etb-field w110" :title="$t('editor.toolbar.paraStyle')" @tap.stop="toggleMenu('style')">
             <text class="etb-field-t">{{ styleLabel }}</text>
             <text class="etb-caret">⌄</text>
           </view>
-          <scroll-view v-if="menu === 'style'" class="etb-menu w160" scroll-y @tap.stop>
+          <scroll-view v-if="menu === 'style'" class="etb-menu w160" :style="popStyle(160)" scroll-y @tap.stop>
             <view v-for="s in styleOptions" :key="s.name" class="etb-item"
                   :class="{ on: s.name === state.paragraph.styleName }" @tap.stop="applyStyle(s.name)">
               <text class="etb-item-t">{{ s.label }}</text>
@@ -29,11 +29,11 @@
 
         <!-- 字体 -->
         <view class="etb-drop" :class="{ open: menu === 'font' }">
-          <view class="etb-field w110" :title="$t('editor.toolbar.font')" @tap.stop="toggleMenu('font')">
+          <view ref="trig_font" class="etb-field w110" :title="$t('editor.toolbar.font')" @tap.stop="toggleMenu('font')">
             <text class="etb-field-t">{{ fontLabel }}</text>
             <text class="etb-caret">⌄</text>
           </view>
-          <scroll-view v-if="menu === 'font'" class="etb-menu w180" scroll-y @tap.stop>
+          <scroll-view v-if="menu === 'font'" class="etb-menu w180" :style="popStyle(180)" scroll-y @tap.stop>
             <view v-for="f in fontOptions" :key="f" class="etb-item"
                   :class="{ on: f === state.character.font }" @tap.stop="applyFont(f)">
               <text class="etb-item-t">{{ f }}</text>
@@ -59,21 +59,21 @@
 
         <!-- 字色 / 高亮 -->
         <view class="etb-drop" :class="{ open: menu === 'color' }">
-          <view class="etb-btn" :title="$t('editor.toolbar.textColor')" @tap.stop="toggleMenu('color')">
+          <view ref="trig_color" class="etb-btn" :title="$t('editor.toolbar.textColor')" @tap.stop="toggleMenu('color')">
             <text class="etb-tx">A</text>
             <view class="etb-swatch" :style="{ background: state.character.color === 'auto' ? '#2C3338' : state.character.color }"></view>
           </view>
-          <view v-if="menu === 'color'" class="etb-palette" @tap.stop>
+          <view v-if="menu === 'color'" class="etb-palette" :style="popStyle(128)" @tap.stop>
             <view v-for="c in TEXT_COLORS" :key="c.v" class="etb-chip" :style="{ background: c.v === 'auto' ? '#2C3338' : c.v }"
                   :title="$t('editor.toolbar.colors.' + c.t)" @tap.stop="applyColor('color', c.v)"></view>
           </view>
         </view>
         <view class="etb-drop" :class="{ open: menu === 'hl' }">
-          <view class="etb-btn" :title="$t('editor.toolbar.highlight')" @tap.stop="toggleMenu('hl')">
+          <view ref="trig_hl" class="etb-btn" :title="$t('editor.toolbar.highlight')" @tap.stop="toggleMenu('hl')">
             <svg class="etb-ico" viewBox="0 0 24 24" fill="none"><path v-for="(d,i) in ICONS.marker" :key="i" :d="d" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>
             <view class="etb-swatch" :style="{ background: state.character.highlight === 'none' ? 'transparent' : state.character.highlight }"></view>
           </view>
-          <view v-if="menu === 'hl'" class="etb-palette" @tap.stop>
+          <view v-if="menu === 'hl'" class="etb-palette" :style="popStyle(128)" @tap.stop>
             <view v-for="c in HL_COLORS" :key="c.v" class="etb-chip" :class="{ none: c.v === 'none' }"
                   :style="{ background: c.v === 'none' ? '#fff' : c.v }" :title="$t('editor.toolbar.colors.' + c.t)" @tap.stop="applyColor('highlight', c.v)"></view>
           </view>
@@ -104,11 +104,11 @@
 
         <!-- 插入 -->
         <view class="etb-drop" :class="{ open: menu === 'insert' }">
-          <view class="etb-field w72" :title="$t('editor.toolbar.insert')" @tap.stop="openInsert">
+          <view ref="trig_insert" class="etb-field w72" :title="$t('editor.toolbar.insert')" @tap.stop="openInsert">
             <text class="etb-field-t">{{ $t('editor.toolbar.insert') }}</text>
             <text class="etb-caret">⌄</text>
           </view>
-          <view v-if="menu === 'insert'" class="etb-menu w200 pad" @tap.stop>
+          <view v-if="menu === 'insert'" class="etb-menu w200 pad" :style="popStyle(200)" @tap.stop>
             <!-- 一级清单 -->
             <template v-if="!insertMode">
               <view class="etb-item" @tap.stop="insertMode = 'table'"><text class="etb-item-t">{{ $t('editor.toolbar.insertTable') }}</text></view>
@@ -344,7 +344,7 @@ export default {
   },
   data() {
     return {
-      state: EMPTY(), styleList: [], fontList: [], menu: '', formattingMarks: false,
+      state: EMPTY(), styleList: [], fontList: [], menu: '', popPos: null, formattingMarks: false,
       // 插入菜单：'' | 'table' | 'link' | 'comment'
       insertMode: '', insertErr: '', grid: { r: 0, c: 0 }, linkUrl: '', commentText: '', formText: '', selText: '',
       // 查找替换
@@ -443,7 +443,28 @@ export default {
     },
     ui(name) { this.closeMenus(); return this.call('ui_command', { name }).then((r) => this.after(r)) },
     run(action) { this.closeMenus(); return this.call(action, {}).then((r) => this.after(r)) },
-    toggleMenu(name) { this.menu = this.menu === name ? '' : name },
+    toggleMenu(name) {
+      const opening = this.menu !== name
+      this.menu = opening ? name : ''
+      if (opening) this.capturePopPos(name)
+    },
+    // 弹层不能留在文档流里定位：工具栏行是横向 scroll-view（overflow 竖向 hidden），
+    // 外面还套着 pane/workbench 一串 overflow:hidden，绝对定位的菜单会被裁得只剩
+    // 顶边一条、看起来就是「点了打不开」（dev-board#245）。打开瞬间取触发器视口
+    // 坐标，用 fixed 逃出所有裁剪上下文；z 序压在弹窗遮罩（1000+）之下、窗格与
+    // 编辑器 webview 之上。
+    capturePopPos(name) {
+      const ref = this.$refs['trig_' + name]
+      const el = ref && (ref.$el || ref)
+      const rect = el && el.getBoundingClientRect ? el.getBoundingClientRect() : null
+      this.popPos = rect ? { left: rect.left, top: rect.bottom + 4 } : null
+    },
+    popStyle(width) {
+      if (!this.popPos) return {}
+      const vw = (typeof window !== 'undefined' && window.innerWidth) || 0
+      const left = vw ? Math.min(this.popPos.left, Math.max(8, vw - width - 8)) : this.popPos.left
+      return { position: 'fixed', left: left + 'px', top: this.popPos.top + 'px', zIndex: 900 }
+    },
     closeMenus() { this.menu = ''; this.insertMode = ''; this.insertErr = '' },
 
     // ---- 插入菜单 ----
@@ -451,6 +472,7 @@ export default {
       const opening = this.menu !== 'insert'
       this.insertMode = ''; this.insertErr = ''; this.grid = { r: 0, c: 0 }
       this.menu = opening ? 'insert' : ''
+      if (opening) this.capturePopPos('insert')
       // 选区文字要现读：菜单里要显示「给『xxx』加链接」，而 get_ui_state 只回
       // collapsed 布尔值。顺带刷新一次状态，免得按上一次的选区判空。
       if (opening) {

--- a/frontend/tests/desktop-e2e/run.mjs
+++ b/frontend/tests/desktop-e2e/run.mjs
@@ -823,6 +823,59 @@ try {
     console.log('      加粗: ' + r.beforeBold + ' → ' + r.afterBold + '，按钮已高亮')
   })
 
+  await step('工具栏下拉真的能打开并选中（dev-board#245 回归）', async () => {
+    // 病灶形态：样式/字体/颜色下拉曾被工具栏横向 scroll-view 的竖向 overflow +
+    // 窗格一串 overflow:hidden 裁死——菜单状态开了、DOM 也在，画面上一条都看不
+    // 见，用户看到的就是「点了打不开」。修法是打开时 fixed 定位逃出裁剪上下文。
+    // 断言三件事：① 真实鼠标点开；② 菜单中心 hit-test 命中菜单自己（没被裁剪/
+    // 遮挡，还原病灶这里立刻转红）；③ 点「标题 1」后引擎里的段落样式真的变了。
+    const box = await page.evaluate(() => {
+      const el = document.querySelector('.etb-field.w110')
+      if (!el) return null
+      const r = el.getBoundingClientRect()
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+    })
+    if (!box) throw new Error('找不到段落样式下拉触发器')
+    await page.mouse.click(box.x, box.y)
+    await sleep(600)
+    const st = await page.evaluate(() => {
+      const el = document.querySelector('.etb-menu')
+      if (!el) return { present: false }
+      const r = el.getBoundingClientRect()
+      const top = document.elementFromPoint(r.x + r.width / 2, r.y + Math.min(r.height / 2, 40))
+      return { present: true, covered: top ? !(el === top || el.contains(top)) : true,
+        topEl: top ? top.tagName + '.' + String(top.className).slice(0, 50) : 'none',
+        rect: { y: Math.round(r.y), h: Math.round(r.height) } }
+    })
+    if (!st.present) throw new Error('点了下拉但 .etb-menu 没出现')
+    if (st.covered) throw new Error('下拉菜单被裁剪/遮挡（hit-test 未命中菜单）: ' + JSON.stringify(st))
+    const item = await page.evaluate(() => {
+      for (const it of document.querySelectorAll('.etb-menu .etb-item')) {
+        const t = it.querySelector('.etb-item-t')
+        if (t && /标题 1|Heading 1/.test(t.textContent)) {
+          const r = it.getBoundingClientRect()
+          return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+        }
+      }
+      return null
+    })
+    if (!item) throw new Error('样式清单里找不到「标题 1」')
+    await page.mouse.click(item.x, item.y)
+    await sleep(900)
+    const after = await page.evaluate(async (finder) => {
+      const ed = eval(finder + '; findEditor()')
+      const ui = await ed.executor.executeCommand('get_ui_state', {})
+      return ui && ui.paragraph ? ui.paragraph.styleName : null
+    }, FIND_EDITOR)
+    if (!/Heading 1|标题 1/.test(String(after))) throw new Error('点了「标题 1」但引擎样式还是: ' + after)
+    // 换回正文，别让后面的保存链路步骤带着标题样式跑
+    await page.evaluate(async (finder) => {
+      const ed = eval(finder + '; findEditor()')
+      await ed.executor.executeCommand('set_style', { name: 'Standard' })
+    }, FIND_EDITOR)
+    console.log('      下拉可开可选：段落样式 → ' + after)
+  })
+
   await step('宿主执行器插入标记文本', async () => {
     const r = await page.evaluate(async (finder, marker) => {
       const ed = eval(finder + '; findEditor()')


### PR DESCRIPTION
## 现象
用户报告（2026-08-28）：编辑器工具栏的下拉全部打不开——段落样式、字体、字色、高亮、插入，点了没任何反应。「一直都在」，非近期回归。

## 根因（dev Electron + 真引擎探针实证）
菜单其实**每次都真的打开了**（`menu` 状态、DOM、`display:block` 都在），但它绝对定位在工具栏横向 scroll-view 里——uni-h5 的 scroll-view 竖向 overflow hidden，行高仅 43px；外层再套 pane-content/workbench 等一串 `overflow:hidden`。290px 高的菜单被裁到一个像素不剩，菜单中心 hit-test 命中的是编辑器 webview。自建工具栏诞生（#356，08-14）起即如此；lowa-e2e 只测原语、desktop-e2e 只点过 .etb-btn，没有任何用例点过下拉，所以一直漏网。

## 修法
打开瞬间 `capturePopPos` 取触发器 `getBoundingClientRect`，五个弹层统一 `popStyle(width)` 内联 `position:fixed`（z 900：弹窗遮罩 1000+ 之下、窗格与编辑器 webview 之上），左缘按视口宽 clamp；`popPos` 取不到时退回原 absolute 兜底。

## 验证
- 修复前探针：`covered:true`、topEl=WEBVIEW（菜单不可见）；修复后：hit-test 命中菜单条目，截图五个弹层完整可见可点
- **desktop-e2e 新增常驻回归步骤**：真实鼠标点开样式下拉 → hit-test 命中菜单 → 点「标题 1」→ `get_ui_state` 断言引擎段落样式真变（还原病灶即转红已单独验证：无修复时该步骤准确失败）
- desktop-e2e 全量 13/13 绿；lowa-e2e 461/0
- 同 PR 更新 .claude/agents/doc-editor.md（弹层 fixed 定位地雷入档）

dev-board#245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
