### PR TITLE
fix(preview): FilePreview 声明 showEditBtn prop，藏掉浏览器降级态的死编辑按钮（dev-board#247）

### DIFF
--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -9,7 +9,7 @@
         <view class="preview-title-row">
           <text class="preview-title">{{ file.name }}</text>
           <button
-            v-if="canEdit"
+            v-if="canEdit && showEditBtn"
             class="btn-edit"
             type="primary"
             size="mini"
@@ -311,6 +311,11 @@ export default {
     locator: {
       type: Object,
       default: null
+    },
+    // 调用点若不接 @edit 就传 false 藏掉编辑按钮，否则会渲染一个点了没反应的死按钮
+    showEditBtn: {
+      type: Boolean,
+      default: true
     }
   },
   data() {


### PR DESCRIPTION
## 问题
frontend/src/components/FilePreview.vue 没有声明 `showEditBtn` prop，但 project-overview.vue 两处 FilePreview 调用点都传了 `:show-edit-btn="false"`，被 Vue 静默忽略。组件的编辑按钮 `v-if="canEdit"`（office 文件+wpsFileId 即显示），`@tap` 后 `$emit('edit')`，而两处调用点都没监听 `@edit`——浏览器降级态（无 checkbaDesktop）下用户看到一个点了毫无反应的「编辑」按钮（2026-08-28 dev H5 走查 dev-board#245 时实证）。

## 修法
给组件补 `showEditBtn` prop（默认 true），`canEdit && showEditBtn` 才渲染编辑按钮。全仓仅 project-overview.vue 两处真实调用点，且都显式传 false 又都不接 `@edit`——按钮在这两处点了本来就没反应，隐藏严格正确。桌面态打开 office 文件直进编辑器分支，不经预览的编辑按钮，不受影响。

## 验证
- `npm run check:emits` 通过（101 个 .vue）
- `npm run test:evidence` 132 全绿
- `npm run test:project-home` 296 全绿

dev-board: zeweihan/dev-board#247

🤖 Generated with [Claude Code](https://claude.com/claude-code)