### PR TITLE
feat(office-addin): WPS 安装页样式对齐官网设计规范（dev-board#246）

### DIFF
--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -109,7 +109,7 @@ description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT
 - `taskpane/lib/wpsDoc.js` — WPS 三宿主文档读取（契约同 wordDoc.js）。表格读取必须 Value2 批量（跨进程桥约 0.2ms/调用，逐格会拖死任务窗格）。
 - `taskpane/lib/wpsExecutor.js` + `wpsWordHandlers.js` / `wpsEtHandlers.js` / `wpsWppHandlers.js` — office_command 的 WPS 执行器（分发器 + 三张宿主 HANDLERS 表）。**命令名与参数/返回值契约以 officeExecutor.js 为准绳**；宿主守卫按前缀（excel_*/ppt_*/其余归 word）。
 - `taskpane-wps.html` — WPS 构建入口（不含 office.js；window.wps 由宿主注入）。与 taskpane.html 同出一个 dist（vite 双入口），build.target 压 es2018 给参差的 CEF 内核留余量。
-- `wps/` — ribbon 薄壳（vanilla JS，不进 Vite）：ribbon.xml（三宿主共用）+ index.html/main.js/js/*（在线模式 WPS 启动拉 url/index.html）+ `vendor/publish-template.html`（官方 wpsjs@2.2.3 publish.html 原样 vendor，构建脚本只做 PUBLISH_REPLACE_STRING/SERVERID_REPLEASE_STRING 两处替换 + 标题品牌化，**机制代码不许手改**）。
+- `wps/` — ribbon 薄壳（vanilla JS，不进 Vite）：ribbon.xml（三宿主共用）+ index.html/main.js/js/*（在线模式 WPS 启动拉 url/index.html）+ `vendor/publish-template.html`（官方 wpsjs@2.2.3 publish.html 原样 vendor，构建脚本只做 PUBLISH_REPLACE_STRING/SERVERID_REPLEASE_STRING 两处替换 + 标题品牌化 + 追加 BRAND_STYLE 覆盖样式（对齐官网 DESIGN.md，选择器钉在模板既有类名上，dev-board#246），**机制代码不许手改**——「验证中/正常/无效」状态色是机制 JS 写 inline 的，样式层刻意不碰）。
 - `scripts/build-wps.mjs` — `npm run build:wps` 出 dist-wps/（wps/ 壳 + wps/ui/=dist 拷贝 + install.html + jsplugins.xml）。默认部署地址 https://addin.aiworkdeck.com/wps-addin。
 
 ### 分发契约

--- a/office-addin/README.md
+++ b/office-addin/README.md
@@ -403,7 +403,7 @@ wps/
   vendor/publish-template.html
                         官方 wpsjs@2.2.3 的 publish.html 原样 vendor（安装页模板，
                         金山许可允许再分发；勿手改机制代码，构建脚本只做两处
-                        字符串替换 + 标题品牌化）
+                        字符串替换 + 标题品牌化 + 注入品牌覆盖样式）
 scripts/build-wps.mjs   部署产物生成器（见下）
 ```
 

--- a/office-addin/scripts/build-wps.mjs
+++ b/office-addin/scripts/build-wps.mjs
@@ -34,6 +34,87 @@ const DEFAULT_BASE_URL = 'https://addin.aiworkdeck.com/wps-addin'
 /** 加载项注册名（写进用户本机 publish.xml；三宿主同名不同 type） */
 const ADDON_NAME = 'aiworkdeck'
 
+/**
+ * 安装页品牌覆盖样式（对齐官网 DESIGN.md：纸面底 + 衬线标题/眉标 + 白卡 + 品牌绿）。
+ * 只追加 <style>，vendor 模板与机制 JS 一行不改；选择器全部钉在模板既有类名上。
+ * 衬线字体走系统栈（Songti/SimSun 兜底），不引外部字体——安装页要在离线/内网可用。
+ */
+const BRAND_STYLE = `    <style id="awd-brand">
+        body {
+            margin: 0;
+            padding: 48px 24px 64px;
+            background: #F8F9FA;
+            color: #212529;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Inter", sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+        .awd-eyebrow {
+            max-width: 760px;
+            margin: 0 auto 10px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.22em;
+            color: #1A5336;
+        }
+        .awd-eyebrow-line { width: 32px; height: 1px; background: #1A5336; }
+        .divTitle {
+            max-width: 760px;
+            margin: 0 auto 28px;
+            font-family: "Noto Serif SC", "Source Han Serif SC", "Songti SC", "SimSun", serif;
+            font-size: 32px;
+            font-weight: 700;
+            color: #123A26;
+        }
+        .addonList {
+            max-width: 760px !important; /* 机制 JS 会写 inline 800*dpr，压回 */
+            margin: 0 auto;
+            padding: 8px 24px 16px;
+            background: #fff;
+            border: 1px solid rgba(233, 236, 239, 0.9);
+            border-radius: 12px;
+            box-shadow: 0 18px 40px -18px rgba(18, 58, 38, 0.12);
+        }
+        .addonItem { font-size: 13px; line-height: 40px; margin-bottom: 0; border-radius: 6px; }
+        .addonItem .addonItemName4 { font-size: 12px; line-height: 1.6; color: #868E96; word-break: break-all; }
+        .addonItem:hover { border: 0; border-radius: 6px; background: #F1F3F5; }
+        .addonItemTitle,
+        .addonItemTitle:hover {
+            background: transparent;
+            border: 0;
+            border-bottom: 1px solid #E9ECEF;
+            border-radius: 0;
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            color: #868E96;
+        }
+        .addonItemButton { padding: 5px 14px; background-color: #1A5336; border-radius: 6px; font-size: 12px; }
+        .addonItemButton:hover { background-color: #123A26; }
+        .ClearAll {
+            max-width: 760px !important;
+            margin: 24px auto 0;
+            box-sizing: border-box;
+            font-size: 13px;
+            line-height: 40px;
+            color: #868E96;
+            background: #fff;
+            border: 1px solid #E9ECEF;
+            border-radius: 8px;
+        }
+        .ClearAll:hover { border-radius: 8px; border-color: #ADB5BD; background: #F1F3F5; color: #C0392B; }
+        /* 空态：WPS 本地服务没连上时表格只剩表头，给一句解释（纯 CSS，不动机制） */
+        .addonList:has(.addonItemTitle:only-child)::after {
+            content: "未检测到已发布的加载项。请确认本机已安装并启动过 WPS Office，并允许浏览器打开 WPS 以连接本地服务。";
+            display: block;
+            padding: 28px 0 20px;
+            text-align: center;
+            font-size: 13px;
+            color: #868E96;
+        }
+    </style>`
+
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
 function parseArgs(argv) {
@@ -107,10 +188,16 @@ if (!installHtml.includes('PUBLISH_REPLACE_STRING') || !installHtml.includes('SE
 installHtml = installHtml.replace(/PUBLISH_REPLACE_STRING/, JSON.stringify(addons))
 // multiUser=true 对应 CLI 的 getServerId() 分支（Linux 多用户场景，Windows 单用户无副作用）
 installHtml = installHtml.replace(/SERVERID_REPLEASE_STRING/, 'getServerId()')
-// 轻量品牌化：只动标题文案，不碰任何机制代码
+// 轻量品牌化：只动标题文案 + 注入覆盖样式，不碰任何机制代码。
+// 样式对齐官网 DESIGN.md（dev-board#246）：纸面底色 + 衬线大标题/眉标 + 白卡 +
+// 品牌绿按钮；vendor 模板保持原样，全部覆盖走这里追加的 <style>。
+// 机制 JS 会往 .addonList/.ClearAll 写 inline maxWidth（800*dpr），只能用
+// !important 压回；「验证中/正常/无效」状态色也是 inline 写入，刻意不动。
 installHtml = installHtml
   .replace('<title>WPS加载项配置</title>', '<title>AI WorkDeck - WPS 加载项安装</title>')
-  .replace('>WPS加载项配置</div>', '>AI WorkDeck - WPS 加载项安装</div>')
+  .replace('>WPS加载项配置</div>', '>WPS 加载项安装</div>')
+  .replace('<div class="divTitle">', '<div class="awd-eyebrow"><span class="awd-eyebrow-line"></span>AI WORKDECK</div>\n    <div class="divTitle">')
+  .replace('</head>', `${BRAND_STYLE}\n</head>`)
 fs.writeFileSync(path.join(outDir, 'install.html'), installHtml)
 
 // 4) 企业版私有部署模板（oem.ini 的 JSPluginsServer 指向这份文件的部署地址）


### PR DESCRIPTION
## 背景
用户反馈 WPS 加载项安装页太丑：默认衬线字体、空表格无空态、虚线调试按钮、内容铺满大屏，顶着 AI WorkDeck 的名字却是工程调试页观感。要求对齐官网 CSS 风格。

## 做法
- 按官网 DESIGN.md：纸面底色（#F8F9FA）+ 眉标（0.22em tracking + 细线）+ 衬线大标题（系统衬线栈，不引外部字体，安装页需离线可用）+ 白卡（圆角/描边/投影同官网卡片模板）+ 品牌绿按钮（king-forest #1A5336）+「禁用所有」幽灵按钮化（hover 转告警红字）
- 纯 CSS 空态：WPS 本地服务未连上时表格只剩表头（用户截图正是此形态），现在有一句解释文案（:has 选择器，不动 DOM）
- **红线遵守**：vendor 的 wpsjs publish 模板与机制 JS 一行不改，全部覆盖样式走 build-wps.mjs 的 BRAND_STYLE 注入，选择器钉在模板既有类名上；机制写 inline 的 maxWidth 用 !important 压回；状态色 inline 刻意不碰
- README 与 .claude/agents/office-addin.md 口径同步

## 验证
build:wps 产物 file:// 真渲染截图走查：空态、有数据两种形态均对齐官网调性。部署 = 覆盖 addin.aiworkdeck.com 静态目录的 install.html（合并后随下次插件发版或单独覆盖均可）。

dev-board#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
