### PR TITLE
chore(release): v0.27.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
小版本补丁发布：收编 v0.27.0 后的用户可见修复——
- #634 编辑器工具栏下拉打不开（fixed 定位逃出裁剪）
- #631 AI 面板中文界面漏英文
- #632 品牌字标 logo 大写 D
- #635 浏览器降级态幽灵编辑按钮
另含 #628 中转 blob 迁 OSS（后端业务面）、#633/#636 WPS 加载项（服务器侧已部署）。

patch-gate 预检通过（desktop/ 主体、pom、引擎、requirements 零改动）。
四道门禁全绿：mvn 2823/0、desktop 单测 0 失败、lowa-e2e 461/0、app-e2e 131 步。

dev-board#248

🤖 Generated with [Claude Code](https://claude.com/claude-code)