### PR TITLE
feat(governance): 社区治理层与权利集中——CLA v1.1/CLA-bot/治理阶梯/社区基金/商标口径统一

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,35 +2,47 @@
 
 Thank you for your interest in contributing to AI WorkDeck! We welcome contributions from the community to help improve the kernel.
 
-## Licensing & CLA
-**By submitting a Pull Request, you agree to the terms in our [Contributor License Agreement (CLA)](../legal/CLA.md).**
+New here? The project's governance — roles, the contributor → reviewer → maintainer ladder, and the RFC process for substantial changes — is described in [GOVERNANCE.md](../GOVERNANCE.md). Current maintainers are listed in [MAINTAINERS.md](../MAINTAINERS.md). Some issues carry cash bounties — see [BOUNTIES.md](../BOUNTIES.md).
 
-Briefly:
-1. You assert that you own the code you are submitting (DCO).
-2. You grant the project maintainers the right to distribute your code under both the **AGPLv3** (for the community) and a **Commercial License** (for enterprise customers).
+## Licensing & CLA
+
+All code contributions require a signed [Contributor License Agreement (CLA)](../legal/CLA.md). Briefly:
+
+1. You assert that you own the code you are submitting (DCO), and you grant a patent license for it.
+2. You grant 北京京微资易科技有限公司 (the project's Steward) the right to distribute your code under both the **AGPLv3** (for the community) and a **commercial license** (for enterprise customers).
+3. You keep the copyright in your work — the CLA is a license, not an assignment.
+
+Signing is automatic in the PR flow: on your first pull request, the CLA Assistant bot comments with a link, and you sign by replying with the sentence it requests. One signature covers all your past and future contributions. **Unsigned PRs are not merged.**
 
 *This rights grant is essential for the project's long-term sustainability and dual-licensing model.*
 
 ## How to Contribute
+
 1. **Fork the repository** on GitHub.
 2. **Create a new branch** for your feature or bugfix.
 3. **Commit your changes** with clear, descriptive commit messages.
 4. **Push to your branch** and submit a **Pull Request (PR)**.
 
+For substantial changes (new subsystems, public API or plugin-SDK contract changes), open an [RFC](../rfcs/0000-template.md) first — see [GOVERNANCE.md](../GOVERNANCE.md#rfc-process).
+
 ## Code Style
+
 - Please follow the existing code style in the project.
 - Ensure all tests pass before submitting.
 - Add new tests for new features where appropriate.
 
 ## Reporting Issues
+
 - Use the GitHub Issues tab to report bugs.
 - Please check existing issues to avoid duplicates.
 - Provide reproduction steps and environment details.
 
 ## Pull Request Process
+
 1. We will review your PR as soon as possible.
 2. We may ask for changes or clarifications.
 3. Once approved, we will merge your contribution.
 
 ## Code of Conduct
-Please be respectful and professional in all interactions. We want to keep this community welcoming and helpful.
+
+Please be respectful and professional in all interactions ([CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)). We want to keep this community welcoming and helpful.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,28 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/zeweihan/aiworkdeck/blob/master/legal/CLA.md'
+          # signatures live on an unprotected branch; master requires PRs and would reject the bot's push
+          branch: 'cla-signatures'
+          allowlist: zeweihan,*[bot]

--- a/BOUNTIES.md
+++ b/BOUNTIES.md
@@ -1,0 +1,29 @@
+# Bounty Program
+
+Some issues carry a cash bounty, funded by the [Community Fund](README.md#community-fund). Bounty issues are labeled `bounty` and state the amount in the issue body.
+
+## How it works
+
+1. **Claim.** Comment on the bounty issue to claim it. A maintainer assigns it to you. Claims go stale after 14 days without visible progress, at which point the issue reopens for others.
+2. **Submit.** Open a pull request referencing the issue. The PR must meet the normal contribution bar ([CONTRIBUTING.md](.github/CONTRIBUTING.md)) and requires a signed [CLA](legal/CLA.md).
+3. **Acceptance.** A maintainer reviews and merges. The bounty is earned when the PR is merged (or, for non-code bounties, when the deliverable is accepted in writing on the issue).
+4. **Payment.** Comment or email hi@aiworkdeck.com with your preferred method. We pay within 14 days of acceptance: Alipay or WeChat Pay for contributors in China; PayPal or bank transfer internationally.
+
+## Tiers
+
+Amounts are stated per issue. Typical ranges:
+
+| Tier | Typical scope | Range (CNY) |
+|---|---|---|
+| Starter | Reproductions, docs fixes, small bugs (`good first issue`) | 100 – 300 |
+| Standard | Well-scoped bugs and small features | 500 – 1,500 |
+| Major | Subsystem work, tricky bugs, performance | 2,000 – 5,000 |
+| Security | Per [SECURITY.md](.github/SECURITY.md) severity, responsibly disclosed | case by case |
+
+## Terms
+
+- A bounty is a **one-off service payment** for an accepted deliverable. It creates no employment, partnership, agency, or ongoing relationship of any kind.
+- Intellectual property in the deliverable is licensed per the [CLA](legal/CLA.md), same as any other contribution.
+- One bounty per issue; if multiple people contribute materially to the accepted solution, the maintainer splits the bounty at their reasonable discretion, stated on the issue.
+- Bounty listings are invitations, not offers: the amount is payable only on acceptance of the deliverable by a maintainer. The Steward (北京京微资易科技有限公司) may adjust amounts, tiers, and rules prospectively at any time; changes never reduce a bounty already claimed and in progress.
+- Taxes on bounty income are the recipient's responsibility.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,67 @@
+# AI WorkDeck Governance
+
+This document describes how the AI WorkDeck project is run: who decides what, how contributors gain responsibility, and where the boundary sits between community governance and the commercial stewardship of the project.
+
+## Structure at a glance
+
+- **The community** develops AI WorkDeck in the open: issues, RFCs, pull requests, and a monthly community call.
+- **Contributors, reviewers, and maintainers** form a merit ladder. Roles are earned through sustained work and carry real technical authority.
+- **The Steward** — 北京京微资易科技有限公司 (Beijing Jingwei Ziyi Technology Co., Ltd.), together with its international affiliate 真善美承泽有限公司 (Zhen Shan Mei Grace Legacy Limited, operating workdeck.ai) — provides infrastructure, funds development, holds the trademarks, and is the sole commercial licensor. See [legal/CLA.md](legal/CLA.md), [legal/TRADEMARKS.md](legal/TRADEMARKS.md), and [legal/COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
+
+**Governance roles are technical, not economic.** Becoming a reviewer or maintainer grants review and merge authority and a real voice in the project's direction. It does not grant — and nothing in this document should be read to grant — any right to revenue, equity, trademark use, or commercial licensing, all of which rest with the Steward. Community economics (bounties, marketplace revenue sharing, the community fund) are governed by their own documents: [BOUNTIES.md](BOUNTIES.md) and [legal/MARKETPLACE-TERMS.md](legal/MARKETPLACE-TERMS.md).
+
+## Roles
+
+### Contributor
+
+Anyone who has had a pull request merged, published a Skill or plugin through the marketplace, or made a sustained non-code contribution (documentation, triage, translations). No application needed. All code contributions require a signed [CLA](legal/CLA.md).
+
+### Reviewer
+
+Contributors with a track record — typically several merged, non-trivial pull requests over two to three months and constructive participation in reviews — may be nominated (by anyone, including themselves) to become reviewers. Maintainers confirm by lazy consensus.
+
+Reviewers get GitHub triage permission: they label and close issues, request changes on pull requests, and their review approval is a strong signal for merging. Reviewers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+### Maintainer
+
+Reviewers who have shown consistent judgment across a subsystem — knowing not just how to change the code but when not to — may be nominated by an existing maintainer. Existing maintainers confirm by consensus.
+
+Maintainers get merge rights and are expected to: review promptly in their areas, uphold the engineering conventions in [CLAUDE.md](CLAUDE.md) and the domain docs, shepherd RFCs, and mentor contributors. Maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+### Inactivity and stepping down
+
+Roles are duties, not titles. A reviewer or maintainer inactive for six months moves to emeritus status (listed, honored, no permissions) and can return by resuming activity. Anyone may step down at any time.
+
+## Decision making
+
+- **Day-to-day changes** (bug fixes, small features, docs): one maintainer approval merges. Lazy consensus — silence is assent.
+- **Substantial changes** (new subsystems, public API or plugin-SDK contract changes, data-format or protocol changes, licensing-adjacent mechanics): require an RFC (below).
+- **Reserved to the Steward**: trademark and brand use, commercial licensing, legal terms (the documents in `legal/`), security-embargo decisions, marketplace listing policy, and the operation of hosted services (aiworkdeck.com / workdeck.ai). The Steward exercises final say on these regardless of RFC outcomes.
+- **Disagreements** are resolved by discussion first; if maintainers cannot reach consensus, the Steward's appointed lead maintainer decides.
+
+## RFC process
+
+For substantial changes, open a pull request adding a document to [`rfcs/`](rfcs/) based on [`rfcs/0000-template.md`](rfcs/0000-template.md).
+
+1. **Draft**: copy the template to `rfcs/0000-my-feature.md` (the number is assigned at merge) and open a PR.
+2. **Discussion**: at least 14 days open for comment. Maintainers and affected contributors weigh in on the PR.
+3. **Decision**: maintainers accept (merge) or reject (close with rationale) by consensus. Accepted RFCs get a number and become the reference for implementation PRs.
+4. **Implementation** can be done by anyone, in one PR or many, referencing the RFC.
+
+Small, reversible changes never need an RFC. When unsure, open an issue and ask.
+
+## Community call
+
+A monthly community call is held online (announced in [GitHub Discussions](https://github.com/zeweihan/aiworkdeck/discussions) at least one week ahead, with agenda collected in the announcement thread). Notes are posted back to the same thread. The call covers: what shipped, roadmap movement, open RFCs, and open floor.
+
+## Roadmap
+
+The public roadmap lives in the [README's Roadmap section](README.md#roadmap) and is refreshed as items ship. Larger directional items land as RFCs first. Feature requests: [GitHub issues](https://github.com/zeweihan/aiworkdeck/issues) or the [feature-request form](https://www.aiworkdeck.com/en/feature-request).
+
+## Code of conduct
+
+All spaces are covered by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Reports go to hi@aiworkdeck.com and are handled by the Steward.
+
+## Companion repositories
+
+The official companion repositories — the website, the mobile clients, and published plugins/SDK examples — follow this same governance, the same CLA, and the same dual-licensing arrangement as this kernel repository, and each states so in its own README.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+# Maintainers and Reviewers
+
+Roles and the promotion ladder are defined in [GOVERNANCE.md](GOVERNANCE.md). Governance roles carry technical authority only; they do not carry economic rights (see GOVERNANCE.md).
+
+## Maintainers
+
+| Name | GitHub | Areas |
+|---|---|---|
+| Han Zewei | [@zeweihan](https://github.com/zeweihan) | Project lead; all areas |
+
+## Reviewers
+
+Reviewer seats are open. The bar and the nomination process are in [GOVERNANCE.md](GOVERNANCE.md#reviewer) — sustained, non-trivial contributions over two to three months. Nominate yourself or someone else by opening an issue titled `Nomination: <github handle>`.
+
+## Emeritus
+
+None yet.
+
+## Becoming a contributor
+
+Start with [CONTRIBUTING.md](.github/CONTRIBUTING.md). Good first contributions are listed in the [README](README.md#contributing), and bounty-carrying issues are labeled `bounty` — see [BOUNTIES.md](BOUNTIES.md).

--- a/README.md
+++ b/README.md
@@ -308,9 +308,17 @@ Shipped since this list was first written: the public plugin SDK with examples, 
 - [ ] Better self-hosting guides for private law-firm and enterprise deployments
 - [ ] Bilingual documentation for the community edition
 
+## Governance
+
+AI WorkDeck is developed in the open, with a contributor → reviewer → maintainer ladder, an RFC process for substantial changes, and a monthly community call — see [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md). The project is stewarded by 北京京微资易科技有限公司 (with 真善美承泽有限公司 / Zhen Shan Mei Grace Legacy Limited operating the international offering), which holds the trademarks and is the sole commercial licensor. Governance roles carry technical authority, not economic rights.
+
+### Community Fund
+
+We commit **20% of net commercial-licensing revenue** to a community fund that pays issue bounties ([BOUNTIES.md](BOUNTIES.md)), Skill-creation grants, and community events. This is a unilateral public policy of the steward company, not a contractual promise to any individual; the percentage and rules may be adjusted prospectively as the project grows.
+
 ## Contributing
 
-We welcome issues, discussions, docs improvements, integration notes, and focused pull requests. Please read [CONTRIBUTING.md](.github/CONTRIBUTING.md) before submitting a PR.
+We welcome issues, discussions, docs improvements, integration notes, and focused pull requests. Please read [CONTRIBUTING.md](.github/CONTRIBUTING.md) before submitting a PR. Code contributions require a one-time [CLA signature](legal/CLA.md), handled automatically by a bot on your first PR. Issues labeled `bounty` pay cash on merge — see [BOUNTIES.md](BOUNTIES.md).
 
 Useful first contributions:
 
@@ -343,7 +351,7 @@ Commercial licensing is available for:
 
 See [LICENSE](legal/LICENSE) and [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md). For commercial licensing, contact [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com).
 
-**AI WorkDeck™** is our unregistered word mark; the AI WorkDeck logo is a registered trademark in China (Class 9, reg. no. 89857424). Building on the kernel is welcome under the licenses above, but using the **AI WorkDeck** name or logo for a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
+The **AI WorkDeck logo** (the "K" mark) is a registered trademark in China (Class 9, reg. no. 89857424; the Class 35 and 42 applications have cleared publication and are pending registration). "**AI WorkDeck**" is used as a trade name and unregistered word mark ("AI WorkDeck™"), protected together with the aiworkdeck.com domain under applicable unfair-competition law. Building on the kernel is welcome under the licenses above, but using the **AI WorkDeck** name or logo to market a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
 
 ## Background
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -306,9 +306,17 @@ chmod +x restart-all.sh
 - [ ] 面向律所与企业私有化部署的更好的自托管指南
 - [ ] 社区版双语文档
 
+## 治理
+
+AI WorkDeck 以开放方式开发：贡献者 → 评审者 → 维护者的晋升阶梯、重大变更走 RFC 流程、每月一次社区例会——详见 [GOVERNANCE.md](GOVERNANCE.md) 与 [MAINTAINERS.md](MAINTAINERS.md)。项目由北京京微资易科技有限公司作为 steward 运营（海外发行由真善美承泽有限公司 Zhen Shan Mei Grace Legacy Limited 承担），商标与商业授权集中于公司；治理角色承载技术权限，不附带任何经济权利。
+
+### 社区基金
+
+我们承诺将**商业授权净收入的 20%** 注入社区基金，用于 issue 悬赏（[BOUNTIES.md](BOUNTIES.md)）、Skill 创作补贴与社区活动。这是公司单方面的公开政策，不构成对任何个人的合同承诺；比例与规则可能随项目发展前瞻性调整。
+
 ## 参与贡献
 
-欢迎 issue、讨论、文档改进、集成笔记和目标明确的 PR。提交 PR 前请先阅读 [CONTRIBUTING.md](.github/CONTRIBUTING.md)。
+欢迎 issue、讨论、文档改进、集成笔记和目标明确的 PR。提交 PR 前请先阅读 [CONTRIBUTING.md](.github/CONTRIBUTING.md)。代码贡献需要一次性签署 [CLA](legal/CLA.md)，首个 PR 上由机器人自动引导完成。带 `bounty` 标签的 issue 合并即有现金悬赏——见 [BOUNTIES.md](BOUNTIES.md)。
 
 适合上手的第一批贡献：
 
@@ -341,7 +349,7 @@ AI WorkDeck 社区版基于 GNU Affero General Public License v3.0 发布。
 
 详见 [LICENSE](legal/LICENSE) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md)。商业许可请联系 [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com)。
 
-**AI WorkDeck™** 是我们的未注册文字商标；AI WorkDeck 标识已在中国注册（第 9 类，注册号 89857424）。欢迎在上述许可下基于内核构建产品，但将 **AI WorkDeck** 名称或标识用于商业产品需要品牌或认证协议——见 [TRADEMARKS.md](legal/TRADEMARKS.md) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md) 中的**品牌与认证计划**。
+**AI WorkDeck 标识**（K 形图形）已在中国注册为商标（第 9 类，注册号 89857424；第 35、42 类申请已过初审公告、待核准注册）。「**AI WorkDeck**」作为商号与未注册文字商标使用（标 ™），与 aiworkdeck.com 域名一起受反不正当竞争法保护。欢迎在上述许可下基于内核构建产品，但将 **AI WorkDeck** 名称或标识用于商业产品的营销需要品牌或认证协议——见 [TRADEMARKS.md](legal/TRADEMARKS.md) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md) 中的**品牌与认证计划**。
 
 ## 背景
 

--- a/legal/CLA.md
+++ b/legal/CLA.md
@@ -1,29 +1,54 @@
 # Contributor License Agreement (CLA)
 
+*Version 1.1, effective 2026-08-28. Version 1.0 (acceptance by contribution) continues to govern contributions submitted before this date; signing this version ratifies and re-confirms those prior grants under the terms below.*
+
 ## 1. Purpose
-To maintain the sustainability of the **AI WorkDeck** project and its ability to offer dual-licensing options (AGPLv3 for open source, Commercial for proprietary use), we require that all contributions be accompanied by a grant of rights. This ensures that the project maintainers have the necessary legal standing to defend the project and offer commercial licenses to enterprise users who cannot comply with the AGPLv3.
 
-## 2. Agreement by Contribution
-By submitting a Pull Request (PR), patch, or other contribution to this repository, you (the "Contributor") agree to the terms of this policy. You acknowledge that your contribution is your original work or that you have the right to submit it under these terms.
+To keep the **AI WorkDeck** project sustainable, it is offered under a dual-licensing model: AGPLv3 for the community, and commercial licenses for organizations that cannot comply with the AGPLv3. For that model to be lawful when the codebase contains work from many contributors, all rights necessary to relicense must be concentrated in a single entity. This agreement collects those rights. It is a *license*, not a copyright assignment — you keep ownership of your work.
 
-## 3. Grant of License
-You hereby grant to the project maintainers (and their successors and assigns) a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contribution and such derivative works.
+## 2. Definitions
 
-**Crucially, this grant includes the right for the project maintainers to:**
-1.  Relicense your contribution under the **GNU Affero General Public License v3.0 (AGPLv3)** (or any later version).
-2.  Relicense your contribution under a **proprietary Commercial License** to third parties.
+- **"Steward"** means 北京京微资易科技有限公司 (Beijing Jingwei Ziyi Technology Co., Ltd.), the company that stewards the AI WorkDeck project, holds its trademarks, and offers its commercial licenses in mainland China — together with its affiliates (including 真善美承泽有限公司 / Zhen Shan Mei Grace Legacy Limited, which operates the project's international offering at workdeck.ai), successors, and assigns.
+- **"Contribution"** means any original work of authorship (code, documentation, designs, translations, or other material) intentionally submitted by you to this project, in any form (pull request, patch, issue attachment, or otherwise).
 
-## 4. Moral Rights
-You retain ownership of the copyright in your contribution. This agreement is a *license*, not a copyright assignment. You continue to have the right to use your own contribution in any way you see fit.
+## 3. Grant of Copyright License
 
-## 5. Developer Certificate of Origin (DCO)
-By contributing, you certify that:
-- (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
-- (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
-- (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+You hereby grant to the Steward a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contribution and such derivative works.
 
-## 6. Future Formalization
-As the project grows, we may implement an automated system (e.g., CLA Assistant) to collect digital signatures. You agree that your prior contributions will continue to be governed by the terms accepted at the time of submission, and you agree to sign a formal version of this text if requested to strictly formalize the record for legal auditing purposes.
+**This grant expressly includes the right for the Steward to:**
+
+1. License and relicense your Contribution under the **GNU Affero General Public License v3.0** (or any later version);
+2. License and relicense your Contribution, alone or as part of the project, under **proprietary commercial licenses** to third parties, including closed-source distribution;
+3. Exercise these rights across the entire AI WorkDeck project family (the kernel and the official companion repositories — website, mobile clients, plugins, SDKs — that state they are governed by this CLA).
+
+## 4. Grant of Patent License
+
+You hereby grant to the Steward and to recipients of software distributed by the Steward a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated below) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contribution and the project incorporating it, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contribution alone or by combination of your Contribution with the project to which it was submitted.
+
+If any entity institutes patent litigation against you or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the project incorporating it, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this agreement for that Contribution or project shall terminate as of the date such litigation is filed.
+
+## 5. Originality and Right to Submit (Developer Certificate of Origin)
+
+By contributing, you represent and certify that:
+
+- (a) The Contribution was created in whole or in part by you, and you have the right to grant the licenses above; or
+- (b) The Contribution is based upon previous work that, to the best of your knowledge, is covered under an appropriate open source license, and you have the right under that license to submit that work with modifications under the same terms; or
+- (c) The Contribution was provided directly to you by some other person who certified (a), (b) or (c), and you have not modified it.
+
+You further represent that: your Contribution is your original creation to the extent stated above; you are legally entitled to grant these licenses (and, if your employer has rights to intellectual property you create, you have received permission to contribute on its behalf or your employer has waived such rights); and you will disclose within the Contribution any third-party licenses, restrictions, or known claims associated with any part of it.
+
+## 6. What You Keep
+
+You retain full ownership of the copyright in your Contribution and the unrestricted right to use, license, and distribute your own work in any way you see fit. Nothing in this agreement limits what you may do with your own code outside this project.
+
+## 7. How to Sign
+
+Signing is handled by the CLA Assistant bot on your first pull request: the bot comments with a link, and you sign by replying with the exact sentence it requests. The signature is recorded in the repository. **Pull requests from contributors who have not signed are not merged.** Contributors who submitted work before signing was automated are asked to sign once; that signature covers their past and future Contributions.
+
+## 8. Miscellaneous
+
+This agreement does not obligate the Steward to use or include your Contribution, and does not create any duty of support, employment, partnership, or agency. It is governed by the laws of the People's Republic of China. If any provision is held unenforceable, the remainder stays in effect.
 
 ---
-*If you have questions about these terms or cannot agree to them, please contact legal@aiworkdeck.com before submitting your contribution.*
+
+*Questions about these terms: contact legal@aiworkdeck.com before submitting your contribution.*

--- a/legal/COMMERCIAL-LICENSE.md
+++ b/legal/COMMERCIAL-LICENSE.md
@@ -26,7 +26,7 @@ Please contact our licensing team to discuss your specific use case and pricing:
 - **Website:** [www.aiworkdeck.com](https://www.aiworkdeck.com)
 
 ## Brand & Certification Programs
-**AI WorkDeck™** is our word mark and the AI WorkDeck logo is a registered trademark (see [`TRADEMARKS.md`](TRADEMARKS.md) for the per-class status). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
+**AI WorkDeck™** is our unregistered word mark and trade name; the AI WorkDeck logo (the "K" mark) is a registered trademark in China in Class 9 (see [`TRADEMARKS.md`](TRADEMARKS.md) for the per-class status). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
 
 | Program | What you get |
 |---|---|

--- a/legal/MARKETPLACE-TERMS.md
+++ b/legal/MARKETPLACE-TERMS.md
@@ -1,0 +1,36 @@
+# Marketplace Revenue Sharing Terms
+
+*Version 1.0, 2026-08-28. These terms cover Skills and plugins published through the AI WorkDeck marketplaces ([aiworkdeck.com](https://www.aiworkdeck.com/zh/skills) and [workdeck.ai](https://www.workdeck.ai/en/skills)). The China marketplace (aiworkdeck.com) is operated by 北京京微资易科技有限公司; the international marketplace (workdeck.ai) is operated by 真善美承泽有限公司 (Zhen Shan Mei Grace Legacy Limited). "Platform" below means the operator of the site you publish on. These terms may be revised prospectively; revisions never apply retroactively to revenue already earned.*
+
+## 1. What you keep
+
+**You retain full copyright in the Skills and plugins you author.** Publishing through the marketplace grants the Platform only the non-exclusive rights needed to operate the marketplace: hosting, distribution to AI WorkDeck installs, display of listing metadata, review and signing of packages, and localization of listing text. You may unpublish at any time (existing installs are not revoked), and you may distribute the same work anywhere else.
+
+Author earnings come from **your own works**. Publishing in the marketplace gives no rights to, and no revenue interest in, the AI WorkDeck kernel or its commercial licensing — and vice versa: kernel contributions are governed by the [CLA](CLA.md), not by these terms.
+
+## 2. Revenue split
+
+For **paid listings**, the platform commission is **15%** of net receipts (gross receipts minus payment-channel fees, taxes collected, and refunds). **85% goes to the author.**
+
+- Free listings carry no fees in either direction.
+- The commission rate may be revised prospectively with at least 30 days' notice on the marketplace pages; the rate in force at the time of each sale applies to that sale.
+
+## 3. Settlement
+
+- Earnings accrue per sale and are visible in your marketplace account.
+- Settlement is **monthly**, within 15 days after month end, for balances of at least CNY 100 (below the threshold, the balance rolls over).
+- Payment via Alipay, WeChat Pay, or bank transfer (China site); PayPal or bank transfer (international site). Authors are responsible for their own taxes; where law requires the platform to withhold, it will.
+
+## 4. Refunds
+
+Purchaser refunds within 7 days of purchase for non-functioning listings are honored and deducted from the author's accrued earnings. Refunds beyond that window are at the platform's discretion after checking with the author.
+
+## 5. Review, signing, and takedown
+
+- Every plugin is human-reviewed and Ed25519-signed before listing; Skills go live on submission and are reviewed after the fact.
+- The platform may reject or delist works that are broken, infringing, deceptive, malicious, or in breach of law or these terms. Where practical, authors are notified with reasons and a chance to fix.
+- If a listing is removed for infringement claims, accrued but unsettled earnings for that listing are held until the claim is resolved.
+
+## 6. Contact
+
+Marketplace questions and settlement issues: hi@aiworkdeck.com.

--- a/legal/TRADEMARKS.md
+++ b/legal/TRADEMARKS.md
@@ -14,16 +14,16 @@ The AI WorkDeck logo — the stylised "K" device — is filed with the China Nat
 | Class | Goods / services | Reg. or app. no. | Status |
 |---|---|---|---|
 | 9 | Computer software (downloadable software, file and database management software, OCR, chatbot software) | 89857424 | **Registered** 2026-07-27; exclusive right runs to 2036-07-26 |
-| 35 | Advertising and business services | 89857389 | Preliminarily approved and published 2026-05-27; **application pending** |
-| 42 | SaaS, PaaS, software design and hosting | 89857390 | Preliminarily approved and published 2026-05-27; **application pending** |
+| 35 | Advertising and business services | 89857389 | Preliminarily approved and published 2026-05-27; three-month opposition window closed 2026-08-27; **registration pending confirmation** |
+| 42 | SaaS, PaaS, software design and hosting | 89857390 | Preliminarily approved and published 2026-05-27; three-month opposition window closed 2026-08-27; **registration pending confirmation** |
 
-The ® symbol is used with the device mark only for the Class 9 goods on which it is registered. The Class 35 and 42 applications have cleared examination but are not yet registered, and we do not mark them ®.
+The ® symbol is used with the device mark only for the Class 9 goods on which it is registered. The Class 35 and 42 applications have cleared examination and their opposition windows, but until the registrations are formally confirmed and published we do not mark them ®. This table is updated as the register changes.
 
 ### 2.2 The name (word mark)
 
-**AI WorkDeck™** and **AI WorkDeck Kernel™** are unregistered trademarks used in commerce to identify this software and the related services we provide. There is no word-mark registration, so we mark them ™ rather than ®.
+**AI WorkDeck™** and **AI WorkDeck Kernel™** are unregistered trademarks used in commerce to identify this software and the related services we provide. There is no word-mark registration, so we mark them ™ rather than ®. "AI WorkDeck" is also our trade name, used and protected together with the **aiworkdeck.com** domain.
 
-Unregistered marks are still protectable. Unauthorized commercial use that causes confusion as to the source of goods or services may infringe our rights under the Anti-Unfair Competition Law, independently of any registration.
+Unregistered marks are still protectable. Unauthorized commercial use that causes confusion as to the source of goods or services — including confusingly similar names or domains — may infringe our rights under the Anti-Unfair Competition Law, independently of any registration.
 
 ## 3. Trade Dress & Look and Feel
 In addition to the name, the **distinctive visual appearance and user experience (UX/UI) flow** of the AI WorkDeck IDE constitutes our **Trade Dress**.

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,31 @@
+# RFC 0000: (title)
+
+- **Status**: Draft | Accepted | Rejected | Implemented
+- **Author(s)**: @your-github-handle
+- **Created**: YYYY-MM-DD
+- **Discussion**: link to the RFC pull request
+
+## Summary
+
+One paragraph: what is being proposed.
+
+## Motivation
+
+What problem does this solve, for whom, and why now? What happens if we do nothing?
+
+## Design
+
+The substance of the proposal. Include:
+
+- User-visible behavior and UI changes, if any
+- API / contract / data-format changes (plugin SDK, editor primitives, storage layout, endpoints)
+- Migration and backward-compatibility story
+- Security and privacy considerations
+
+## Alternatives considered
+
+What other approaches were weighed, and why this one.
+
+## Open questions
+
+Anything unresolved that discussion should settle.


### PR DESCRIPTION
dev-board#253 #255 #257。

- CLA v1.1：商业再许可权落到京微资易主体、新增专利授权、签署制；CLA Assistant workflow（v2.6.1，签名存 cla-signatures 分支），合并后将把 CLAAssistant 设为 master required check
- 治理：GOVERNANCE.md（阶梯/RFC/月会/治理与经济分离）、MAINTAINERS.md、rfcs/ 模板
- 社区经济：README 社区基金章节（净商业授权收入 20%，单方政策）、BOUNTIES.md、legal/MARKETPLACE-TERMS.md（15% 抽成、作者保留著作权）
- 商标口径：README 双语与 COMMERCIAL-LICENSE 统一为「K 图形 9 类已注册（35/42 异议期届满待核准确认）、AI WorkDeck 文字为商号+未注册商标 ™ 受反法保护」

🤖 Generated with [Claude Code](https://claude.com/claude-code)