### PR TITLE
docs(legal): K 图形商标 35/42 类升级为已注册（三类全注册口径）

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Commercial licensing is available for:
 
 See [LICENSE](legal/LICENSE) and [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md). For commercial licensing, contact [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com).
 
-The **AI WorkDeck logo** (the "K" mark) is a registered trademark in China (Class 9, reg. no. 89857424; the Class 35 and 42 applications have cleared publication and are pending registration). "**AI WorkDeck**" is used as a trade name and unregistered word mark ("AI WorkDeck™"), protected together with the aiworkdeck.com domain under applicable unfair-competition law. Building on the kernel is welcome under the licenses above, but using the **AI WorkDeck** name or logo to market a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
+The **AI WorkDeck logo** (the "K" mark) is a registered trademark in China (Classes 9, 35, and 42; reg. nos. 89857424, 89857389, 89857390). "**AI WorkDeck**" is used as a trade name and unregistered word mark ("AI WorkDeck™"), protected together with the aiworkdeck.com domain under applicable unfair-competition law. Building on the kernel is welcome under the licenses above, but using the **AI WorkDeck** name or logo to market a commercial offering requires a brand or certification agreement — see [TRADEMARKS.md](legal/TRADEMARKS.md) and the **Brand & Certification Programs** in [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md).
 
 ## Background
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -349,7 +349,7 @@ AI WorkDeck 社区版基于 GNU Affero General Public License v3.0 发布。
 
 详见 [LICENSE](legal/LICENSE) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md)。商业许可请联系 [hi@aiworkdeck.com](mailto:hi@aiworkdeck.com)。
 
-**AI WorkDeck 标识**（K 形图形）已在中国注册为商标（第 9 类，注册号 89857424；第 35、42 类申请已过初审公告、待核准注册）。「**AI WorkDeck**」作为商号与未注册文字商标使用（标 ™），与 aiworkdeck.com 域名一起受反不正当竞争法保护。欢迎在上述许可下基于内核构建产品，但将 **AI WorkDeck** 名称或标识用于商业产品的营销需要品牌或认证协议——见 [TRADEMARKS.md](legal/TRADEMARKS.md) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md) 中的**品牌与认证计划**。
+**AI WorkDeck 标识**（K 形图形）已在中国注册为商标（第 9、35、42 类，注册号 89857424、89857389、89857390）。「**AI WorkDeck**」作为商号与未注册文字商标使用（标 ™），与 aiworkdeck.com 域名一起受反不正当竞争法保护。欢迎在上述许可下基于内核构建产品，但将 **AI WorkDeck** 名称或标识用于商业产品的营销需要品牌或认证协议——见 [TRADEMARKS.md](legal/TRADEMARKS.md) 与 [COMMERCIAL-LICENSE.md](legal/COMMERCIAL-LICENSE.md) 中的**品牌与认证计划**。
 
 ## 背景
 

--- a/legal/COMMERCIAL-LICENSE.md
+++ b/legal/COMMERCIAL-LICENSE.md
@@ -26,7 +26,7 @@ Please contact our licensing team to discuss your specific use case and pricing:
 - **Website:** [www.aiworkdeck.com](https://www.aiworkdeck.com)
 
 ## Brand & Certification Programs
-**AI WorkDeck™** is our unregistered word mark and trade name; the AI WorkDeck logo (the "K" mark) is a registered trademark in China in Class 9 (see [`TRADEMARKS.md`](TRADEMARKS.md) for the per-class status). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
+**AI WorkDeck™** is our unregistered word mark and trade name; the AI WorkDeck logo (the "K" mark) is a registered trademark in China in Classes 9, 35, and 42 (see [`TRADEMARKS.md`](TRADEMARKS.md) for the per-class detail). We license the brand to partners who meet our quality bar, so customers can trust that a deployment, plugin, or integration is genuinely compatible and supported.
 
 | Program | What you get |
 |---|---|

--- a/legal/TRADEMARKS.md
+++ b/legal/TRADEMARKS.md
@@ -9,15 +9,15 @@ All marks below are held by 北京京微资易科技有限公司, the entity beh
 
 ### 2.1 The logo (device mark)
 
-The AI WorkDeck logo — the stylised "K" device — is filed with the China National Intellectual Property Administration in three classes, one of which has issued:
+The AI WorkDeck logo — the stylised "K" device — is registered with the China National Intellectual Property Administration in three classes:
 
-| Class | Goods / services | Reg. or app. no. | Status |
+| Class | Goods / services | Reg. no. | Status |
 |---|---|---|---|
 | 9 | Computer software (downloadable software, file and database management software, OCR, chatbot software) | 89857424 | **Registered** 2026-07-27; exclusive right runs to 2036-07-26 |
-| 35 | Advertising and business services | 89857389 | Preliminarily approved and published 2026-05-27; three-month opposition window closed 2026-08-27; **registration pending confirmation** |
-| 42 | SaaS, PaaS, software design and hosting | 89857390 | Preliminarily approved and published 2026-05-27; three-month opposition window closed 2026-08-27; **registration pending confirmation** |
+| 35 | Advertising and business services | 89857389 | **Registered**; published 2026-05-27, unopposed; exclusive right runs from 2026-08-27 |
+| 42 | SaaS, PaaS, software design and hosting | 89857390 | **Registered**; published 2026-05-27, unopposed; exclusive right runs from 2026-08-27 |
 
-The ® symbol is used with the device mark only for the Class 9 goods on which it is registered. The Class 35 and 42 applications have cleared examination and their opposition windows, but until the registrations are formally confirmed and published we do not mark them ®. This table is updated as the register changes.
+The ® symbol is used with the device mark for the classes in which it is registered. This table is updated as the register changes.
 
 ### 2.2 The name (word mark)
 


### PR DESCRIPTION
dev-board#253 收尾。维护者确认 35/42 类已注册（初审公告 2026-05-27 无异议，专用权自 2026-08-27 起算）。TRADEMARKS.md 表格、README 双语、COMMERCIAL-LICENSE 同步为三类全注册；AI WorkDeck 文字商标仍为未注册 ™ 口径不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)