### PR TITLE
chore(release): v0.27.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## v0.27.2

自 v0.27.1 起的补丁区间：

- #639 插件端账号级全量项目列表
- #640 跨设备文件传输（拉取+投送双链路）
- #641 社区治理层与权利集中（CLA v1.1/CLA-bot/治理阶梯/RFC/社区基金）
- 492e1dd9 CLA allowlist 加 claude
- #643 商标文档更新

## 发版前自查（全部通过）

- patch-gate：变更全部在补丁边界内（壳/preload/build/pom/requirements.lock/fetch-lowa-assets 零改动）
- mvn test：2861/2861
- check:emits + build:h5：101 个 .vue 契约通过
- lowa-e2e：461/461
- app-e2e：131 通过 / 0 失败（基线；J6.7、J12 工具名软断言 skip 属正常信号）
- 英文走查：uilang=en-US ooLocale 检查 PASS + J12 截图人工过目 UI chrome 全英文
- LOWA 引擎三解析验证（阿里 DNS / DoH / 默认）+ 引擎文件 206