### PR TITLE
docs(office-addin): WPS 加载项两条真机发现——每宿主各需授信一次、任务窗格 id 三宿主共用键（dev-board#270）

### DIFF
--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -121,6 +121,8 @@ description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT
 - **在线模式**：加载项 url = `<baseUrl>/wps/`（必须以 / 结尾，`GET url+ribbon.xml` 裸可达）；发版 = 覆盖静态目录，用户无需重装。壳文件（ribbon.xml/index.html/main.js/js/*）必须 no-cache，ui/assets/* 带 hash 长缓存。
 - **个人版安装唯一通路**：install.html 经本机 WPS 常驻服务 127.0.0.1:58890 `/deployaddons/runParams` 写用户 `%APPDATA%\kingsoft\wps\jsaddons\publish.xml`（个人版 12.1.0.16910 起 oem.ini/jsplugins.xml 被禁）。企业版私有部署仍走 jsplugins.xml + oem.ini `JSPluginsServer`。
 - 三宿主 = publish.xml 里三条记录（type=wps/et/wpp，同一 url、同名 aiworkdeck）。
+- **每个宿主首次加载各弹一次「是否信任」**（2026-08-29 实测）：安装页一次写三条记录，但授信是**按宿主**发生的，不点「确定」那个宿主就不出「AI WorkDeck」选项卡。用户会以为「表格/演示的插件没装上」——排查这类反馈先问有没有在那个宿主里点过确定。
+- **`awd_taskpane_id` 这个 PluginStorage 键是三个宿主共用的**（`wps/js/ribbon.js` 的 `AWD_PANE_KEY`，`wpsDoc.hideWpsTaskPane` 读同一个）。`ToggleAwdPane` 拿到 id 后只要 `GetTaskPane(id)` 返回真值就 toggle 并 return，**不会为当前宿主新建**——先在文字里开过窗格，再去表格点「AI 助手」就可能什么都不发生（toggle 的是另一个宿主的窗格）。2026-08-29 在表格里实测到「选项卡有、点了没反应」，这是首要嫌疑。修法是把键按宿主分（ribbon 侧用 `Application.Documents/Workbooks/Presentations` 三者之一判宿主，任务窗格侧用已验证的 `detectWpsHost()`），**改完必须真机三宿主各开一次验过再发**——别在没验证的情况下动这个壳，文字/演示两个宿主目前是好的。
 
 ### 已知地雷（WPS 面）
 

--- a/office-addin/README.md
+++ b/office-addin/README.md
@@ -421,6 +421,11 @@ npm run build:wps    # 拼 dist-wps/（默认 --url https://addin.aiworkdeck.com
   main.js/js/*）响应头要 no-cache，`wps/ui/assets/*` 带 hash 可长缓存。
 - `GET <baseUrl>/wps/ribbon.xml` 必须裸可达（别过 SPA 回退/鉴权），安装页的
   「状态」列就是拿它验的。
+- **每个宿主首次加载会各弹一次「是否信任」**（2026-08-29 实测）：安装页把三条记录
+  （文字/表格/演示）一次写进 publish.xml，但 WPS 是**在各宿主第一次真正加载加载项时**
+  才弹「加载项"aiworkdeck"（位于 …）首次加载，是否信任？」。**不点「确定」，那个宿主的
+  ribbon 里就不会出现「AI WorkDeck」选项卡**——看起来像「表格/演示的插件没装上」，
+  其实只是没授信。装完记得三个宿主各开一次并点确定。
 - 用户安装：浏览器打开 `<baseUrl>/install.html` → 点「安装」。页面经本机 WPS
   常驻服务（127.0.0.1:58890，`ksoWPSCloudSvr://` 协议可拉起）把三条记录
   （文字/表格/演示）写进用户 `%APPDATA%\kingsoft\wps\jsaddons\publish.xml`，


### PR DESCRIPTION
发版后在真机走查 WPS 表格/演示时发现两件事，本 PR **只落文档不改代码**。

## 1. 每个宿主首次加载会各弹一次「是否信任」

安装页把三条记录（文字/表格/演示）一次写进 `publish.xml`，但 WPS 是**在各宿主第一次真正加载加载项时**才弹「加载项"aiworkdeck"（位于 …）首次加载，是否信任？」。**不点「确定」，那个宿主的 ribbon 里就不会出现「AI WorkDeck」选项卡**。

实测：表格里一开始没有选项卡 → 点过确定 → 选项卡立刻出现。

用户会以为「表格/演示的插件没装上」，其实只是没授信。已写进 `office-addin/README.md` 的安装说明与领域文档，排查这类反馈先问有没有在那个宿主里点过确定。

## 2. `awd_taskpane_id` 是三个宿主共用的一个 PluginStorage 键（**未修，留卡**）

`wps/js/ribbon.js` 的 `AWD_PANE_KEY` 是单个常量，`wpsDoc.hideWpsTaskPane` 读的也是它。`ToggleAwdPane` 拿到 id 后**只要 `GetTaskPane(id)` 返回真值就 toggle 并 return，不会为当前宿主新建窗格**——先在文字里开过窗格，再去表格点「AI 助手」，toggle 的是另一个宿主的窗格，当前宿主什么都不发生。

实测到表格「选项卡有、点了没反应」，这是首要嫌疑。

**为什么不在本轮改**：修法是把键按宿主分，ribbon 侧要用 `Application.Documents/Workbooks/Presentations` 判宿主——而这个判定我本轮没能在真机上验证，文字与演示两个宿主目前是好用的，贸然改有把好宿主弄坏的风险。留 dev-board#270 单独做，改完必须三宿主各开一次验过再发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)