### PR TITLE
fix(office-addin): WPS 壳补 manifest.xml、任务窗格 id 按宿主分键（dev-board#270）

### DIFF
--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -121,9 +121,13 @@ description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT
 - **在线模式**：加载项 url = `<baseUrl>/wps/`（必须以 / 结尾）。WPS **每次启动宿主都成对拉 `url/manifest.xml` 与 `url/ribbon.xml`**，两者都得裸可达（别过 SPA 回退/鉴权）；`index.html` 要等用户点按钮才拉。`manifest.xml` 照 wpsjs 脚手架模板（`<JsPlugin><ApiVersion>/<Name>/<Description>`，`<Name>` 与 `ADDON_NAME` 同源），三宿主共用一份——2026-08-29 之前构建脚本从没产出过它，线上一直 404。发版 = 覆盖静态目录，用户无需重装。壳文件（manifest.xml/ribbon.xml/index.html/main.js/js/*）必须 no-cache，ui/assets/* 带 hash 长缓存。
 - **个人版安装唯一通路**：install.html 经本机 WPS 常驻服务 127.0.0.1:58890 `/deployaddons/runParams` 写用户 `%APPDATA%\kingsoft\wps\jsaddons\publish.xml`（个人版 12.1.0.16910 起 oem.ini/jsplugins.xml 被禁）。企业版私有部署仍走 jsplugins.xml + oem.ini `JSPluginsServer`。
 - 三宿主 = publish.xml 里三条记录（type=wps/et/wpp，同一 url、同名 aiworkdeck）。
-- **每个宿主首次加载各弹一次「是否信任」**（2026-08-29 实测）：安装页一次写三条记录，但授信是**按宿主**发生的，不点「确定」那个宿主就不出「AI WorkDeck」选项卡。用户会以为「表格/演示的插件没装上」——排查这类反馈先问有没有在那个宿主里点过确定。
+- **每个宿主首次加载各弹一次「是否信任」，而且点完还得重启那个宿主**（2026-08-29 三宿主实测）：安装页一次写三条记录，但授信是**按宿主**发生的；不点「允许」那个宿主不出「AI WorkDeck」选项卡，**点了「允许」当次会话也照样不出**——加载项要到该宿主下次启动才真正加载。用户会以为「表格/演示的插件没装上」或者「点了允许也没用」。给用户的话术必须带上重启这一步。
 - **任务窗格 id 的 PluginStorage 键按宿主分**（`wps/js/ribbon.js` 的 `AwdPaneKey()` 与 `wpsDoc.taskPaneKey()` 后缀同源 wps/et/wpp，改一边就得改另一边）。理由：三宿主共用一份 PluginStorage，而窗格 id 是各宿主进程内从 1 开始自增的——共用一个键的话，文字里存下的 `id=1` 会被表格拿去 `GetTaskPane(1)`，那是表格自己的 1 号窗格（很可能是别家加载项的），于是点我们的按钮开/关了别人的窗格。ribbon 侧判宿主用 `Application.Presentations/Workbooks/Documents`（三者恰好各有一个非空），**不能用 `Application.Name`**——见下面「Name 判不了是不是 WPS」那条。
-- **「选项卡在、图标空白、点了没反应」= 本机注册态坏掉，不是代码问题**（dev-board#270，2026-08-29 定案）。判据看服务器访问日志：坏的时候 WPS 每次启动宿主都成对拉到 `manifest.xml` + `ribbon.xml`（UA 为空、HTTP/1.1，都是 200，所以**网络是通的**），但**从不去拉 `index.html`/`main.js`/`js/*`**——JS 入口没加载，`OnAddinLoad`/`GetImage`/`OnAction` 一个都没执行，所以图标空白、点击零请求。恢复办法只有一个：**重新走一遍 install.html 安装**。已逐个排除的假根因，别再走一遍：`publish.xml` 的 `enable="enable_dev"`（表格那条至今仍是 `enable_dev` 且工作正常，WPS 自己就这么写）、`jsaddinblockhost.ini`、PluginStorage 共用键、per-host 授信（`authaddin.json` 三个宿主都是 `enable:true,isload:true`）、COM 启动方式、整机重启。
+- **「选项卡不见了 / 图标空白 / 点了没反应」= 该宿主的授信没落地，不是代码问题**（dev-board#270，2026-08-29 三宿主真机定案）。
+  - **机器可读的判据在 `%APPDATA%\kingsoft\wps\jsaddons\authaddin.json`**：每个宿主一条 `{enable, isload}`。**`isload:false` 就是这个病**——实测演示宿主 `enable:true, isload:false` 时，每次启动都重弹授信框、选项卡始终不出现；三个宿主都 `isload:true` 时一切正常。`publish.xml` 只说注册了什么，说明不了加载与否，别拿它当判据。
+  - 服务器访问日志的对应形态：坏的时候 WPS 每次启动宿主仍会成对拉到 `manifest.xml` + `ribbon.xml`（UA 为空、HTTP/1.1、200，**所以网络是通的**），但**不拉 `index.html`/`main.js`/`js/*`**——JS 入口没加载，三个回调一个都没执行。
+  - **恢复办法（就是给用户的话术）**：到安装页把该宿主那条**先「卸载」再「安装」，然后重启这个宿主**。两步缺一不可——单独重启不管用，装完不重启也不管用（**授信框弹出的那一次会话不会加载加载项**，实测三个宿主都这样：点完允许当次仍无选项卡，重启才有）。
+  - 已逐个排除的假根因，别再走一遍：`publish.xml` 的 `enable="enable_dev"`（表格那条至今仍是 `enable_dev` 且工作正常，WPS 自己写的就是这个值；反倒是被手工改成 `enable` 的演示那条一直 `isload:false`）、`jsaddinblockhost.ini`、PluginStorage 共用键、COM 启动方式、整机重启、虚拟机网络不通。
 
 ### 已知地雷（WPS 面）
 

--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -113,16 +113,17 @@ description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT
 - `taskpane/lib/wpsDoc.js` — WPS 三宿主文档读取（契约同 wordDoc.js）。表格读取必须 Value2 批量（跨进程桥约 0.2ms/调用，逐格会拖死任务窗格）。
 - `taskpane/lib/wpsExecutor.js` + `wpsWordHandlers.js` / `wpsEtHandlers.js` / `wpsWppHandlers.js` — office_command 的 WPS 执行器（分发器 + 三张宿主 HANDLERS 表）。**命令名与参数/返回值契约以 officeExecutor.js 为准绳**；宿主守卫按前缀（excel_*/ppt_*/其余归 word）。
 - `taskpane-wps.html` — WPS 构建入口（不含 office.js；window.wps 由宿主注入）。与 taskpane.html 同出一个 dist（vite 双入口），build.target 压 es2018 给参差的 CEF 内核留余量。
-- `wps/` — ribbon 薄壳（vanilla JS，不进 Vite）：ribbon.xml（三宿主共用）+ index.html/main.js/js/*（在线模式 WPS 启动拉 url/index.html）+ `vendor/publish-template.html`（官方 wpsjs@2.2.3 publish.html 原样 vendor，构建脚本只做 PUBLISH_REPLACE_STRING/SERVERID_REPLEASE_STRING 两处替换 + 标题品牌化 + 追加 BRAND_STYLE 覆盖样式（对齐官网 DESIGN.md，选择器钉在模板既有类名上，dev-board#246），**机制代码不许手改**——「验证中/正常/无效」状态色是机制 JS 写 inline 的，样式层刻意不碰）。
-- `scripts/build-wps.mjs` — `npm run build:wps` 出 dist-wps/（wps/ 壳 + wps/ui/=dist 拷贝 + install.html + jsplugins.xml）。默认部署地址 https://addin.aiworkdeck.com/wps-addin。
+- `wps/` — ribbon 薄壳（vanilla JS，不进 Vite）：manifest.xml + ribbon.xml（都三宿主共用）+ index.html/main.js/js/*（在线模式 WPS 启动拉 url/index.html）+ `vendor/publish-template.html`（官方 wpsjs@2.2.3 publish.html 原样 vendor，构建脚本只做 PUBLISH_REPLACE_STRING/SERVERID_REPLEASE_STRING 两处替换 + 标题品牌化 + 追加 BRAND_STYLE 覆盖样式（对齐官网 DESIGN.md，选择器钉在模板既有类名上，dev-board#246），**机制代码不许手改**——「验证中/正常/无效」状态色是机制 JS 写 inline 的，样式层刻意不碰）。
+- `scripts/build-wps.mjs` — `npm run build:wps` 出 dist-wps/（wps/ 壳含 manifest.xml + wps/ui/=dist 拷贝 + install.html + jsplugins.xml）。默认部署地址 https://addin.aiworkdeck.com/wps-addin。
 
 ### 分发契约
 
-- **在线模式**：加载项 url = `<baseUrl>/wps/`（必须以 / 结尾，`GET url+ribbon.xml` 裸可达）；发版 = 覆盖静态目录，用户无需重装。壳文件（ribbon.xml/index.html/main.js/js/*）必须 no-cache，ui/assets/* 带 hash 长缓存。
+- **在线模式**：加载项 url = `<baseUrl>/wps/`（必须以 / 结尾）。WPS **每次启动宿主都成对拉 `url/manifest.xml` 与 `url/ribbon.xml`**，两者都得裸可达（别过 SPA 回退/鉴权）；`index.html` 要等用户点按钮才拉。`manifest.xml` 照 wpsjs 脚手架模板（`<JsPlugin><ApiVersion>/<Name>/<Description>`，`<Name>` 与 `ADDON_NAME` 同源），三宿主共用一份——2026-08-29 之前构建脚本从没产出过它，线上一直 404。发版 = 覆盖静态目录，用户无需重装。壳文件（manifest.xml/ribbon.xml/index.html/main.js/js/*）必须 no-cache，ui/assets/* 带 hash 长缓存。
 - **个人版安装唯一通路**：install.html 经本机 WPS 常驻服务 127.0.0.1:58890 `/deployaddons/runParams` 写用户 `%APPDATA%\kingsoft\wps\jsaddons\publish.xml`（个人版 12.1.0.16910 起 oem.ini/jsplugins.xml 被禁）。企业版私有部署仍走 jsplugins.xml + oem.ini `JSPluginsServer`。
 - 三宿主 = publish.xml 里三条记录（type=wps/et/wpp，同一 url、同名 aiworkdeck）。
 - **每个宿主首次加载各弹一次「是否信任」**（2026-08-29 实测）：安装页一次写三条记录，但授信是**按宿主**发生的，不点「确定」那个宿主就不出「AI WorkDeck」选项卡。用户会以为「表格/演示的插件没装上」——排查这类反馈先问有没有在那个宿主里点过确定。
-- **`awd_taskpane_id` 这个 PluginStorage 键是三个宿主共用的**（`wps/js/ribbon.js` 的 `AWD_PANE_KEY`，`wpsDoc.hideWpsTaskPane` 读同一个）。`ToggleAwdPane` 拿到 id 后只要 `GetTaskPane(id)` 返回真值就 toggle 并 return，**不会为当前宿主新建**——先在文字里开过窗格，再去表格点「AI 助手」就可能什么都不发生（toggle 的是另一个宿主的窗格）。2026-08-29 在表格里实测到「选项卡有、点了没反应」，这是首要嫌疑。修法是把键按宿主分（ribbon 侧用 `Application.Documents/Workbooks/Presentations` 三者之一判宿主，任务窗格侧用已验证的 `detectWpsHost()`），**改完必须真机三宿主各开一次验过再发**——别在没验证的情况下动这个壳，文字/演示两个宿主目前是好的。
+- **任务窗格 id 的 PluginStorage 键按宿主分**（`wps/js/ribbon.js` 的 `AwdPaneKey()` 与 `wpsDoc.taskPaneKey()` 后缀同源 wps/et/wpp，改一边就得改另一边）。理由：三宿主共用一份 PluginStorage，而窗格 id 是各宿主进程内从 1 开始自增的——共用一个键的话，文字里存下的 `id=1` 会被表格拿去 `GetTaskPane(1)`，那是表格自己的 1 号窗格（很可能是别家加载项的），于是点我们的按钮开/关了别人的窗格。ribbon 侧判宿主用 `Application.Presentations/Workbooks/Documents`（三者恰好各有一个非空），**不能用 `Application.Name`**——见下面「Name 判不了是不是 WPS」那条。
+- **「选项卡在、图标空白、点了没反应」= 本机注册态坏掉，不是代码问题**（dev-board#270，2026-08-29 定案）。判据看服务器访问日志：坏的时候 WPS 每次启动宿主都成对拉到 `manifest.xml` + `ribbon.xml`（UA 为空、HTTP/1.1，都是 200，所以**网络是通的**），但**从不去拉 `index.html`/`main.js`/`js/*`**——JS 入口没加载，`OnAddinLoad`/`GetImage`/`OnAction` 一个都没执行，所以图标空白、点击零请求。恢复办法只有一个：**重新走一遍 install.html 安装**。已逐个排除的假根因，别再走一遍：`publish.xml` 的 `enable="enable_dev"`（表格那条至今仍是 `enable_dev` 且工作正常，WPS 自己就这么写）、`jsaddinblockhost.ini`、PluginStorage 共用键、per-host 授信（`authaddin.json` 三个宿主都是 `enable:true,isload:true`）、COM 启动方式、整机重启。
 
 ### 已知地雷（WPS 面）
 
@@ -151,7 +152,7 @@ description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT
 - **演示稿的正文常常不在 TextFrame 里**：表格形状（对比表、时间表、条款对照）的文字在 `Table.Cell(r,c).Shape` 里、组合形状（图示+标注、SmartArt 转出来的）的文字在子形状里。只看 `TextFrame` 会把整页读成「（无文本）」——用户看着满屏字，AI 说这页没内容。`wpsDoc.collectShapeText` 已按「表格 → 组合递归 → 普通文本框」三条路收，单个形状读失败只跳过它、不许拖垮整篇。
 - **同步桥的循环纪律（ET/WPP 同样适用）**：`Count` 不许写在 for 的条件位（每轮都要跨桥重取）、`TextFrame`/`Range` 取一次存局部变量。`shapeHasText` 原先连取三次 `TextFrame`，上百页的演示稿光这一处就是几千次白跑。
 - 官方模板 index.html 的角色：本地模式下 WPS 自动生成 index.html、开发者不许自建；**在线模式相反**，WPS 从服务器拉 url/index.html，我们必须提供。两句话都对，别拿一句去改另一边。
-- **停靠任务窗格冻住 ribbon 是真机实锤**（2026-08-28 复测，bbs 93291 平台 bug，官方未修、社区全部规避手段无效）：窗格打开期间整条 ribbon 拒收鼠标，而关窗格按钮在 ribbon 上=死锁。解法：App.vue 头部有 WPS 家族专属「收起面板」按钮（hostBridge.hidePanel → wpsDoc.hideWpsTaskPane，经 PluginStorage 共享键 awd_taskpane_id 取窗格句柄自藏），收起即解锁、重开走 ribbon「AI 助手」。**别把这颗按钮当冗余删掉**。
+- **停靠任务窗格冻住 ribbon 是真机实锤**（2026-08-28 复测，bbs 93291 平台 bug，官方未修、社区全部规避手段无效）：窗格打开期间整条 ribbon 拒收鼠标，而关窗格按钮在 ribbon 上=死锁。解法：App.vue 头部有 WPS 家族专属「收起面板」按钮（hostBridge.hidePanel → wpsDoc.hideWpsTaskPane，经 PluginStorage 的**按宿主分键** `awd_taskpane_id_{wps,et,wpp}` 取窗格句柄自藏），收起即解锁、重开走 ribbon「AI 助手」。**别把这颗按钮当冗余删掉**。
 - office 会话的产出去向规则在 ContextAssemblerService（中英两处）：起草/生成类请求默认写进当前打开的文档，不许新建项目文件保存（2026-08-28 真机复测教训：模型曾把「写简报」落成建空项目文件）。宿主措辞已中性化（「Microsoft Word 或 WPS 文字」等六处），别改回单提微软。
 - 真机已验：install.html 一键安装、任务窗格 window.wps、登录、SSE 流式全通（2026-08-28，WPS 365/Win）。仍欠：Replies.Add/透视表/子串挂链三个类推 API。
 - **字符偏移口径已实测定案（2026-08-29，WPS 12.1.0.28043，原始报告在 `office-addin/scripts/measurements/`）**——这是 dev-board#264「含表格文档成片死路」的根因：

--- a/office-addin/scripts/build-wps.mjs
+++ b/office-addin/scripts/build-wps.mjs
@@ -61,6 +61,19 @@ const BRAND_STYLE = `    <style id="awd-brand">
             color: #1A5336;
         }
         .awd-eyebrow-line { width: 32px; height: 1px; background: #1A5336; }
+        .awd-note {
+            max-width: 760px;
+            margin: -18px auto 24px;
+            padding: 12px 16px;
+            background: #fff;
+            border: 1px solid rgba(233, 236, 239, 0.9);
+            border-left: 3px solid #1A5336;
+            border-radius: 8px;
+            font-size: 13px;
+            line-height: 1.8;
+            color: #495057;
+        }
+        .awd-note b { color: #123A26; }
         .divTitle {
             max-width: 760px;
             margin: 0 auto 28px;
@@ -189,7 +202,20 @@ if (!installHtml.includes('PUBLISH_REPLACE_STRING') || !installHtml.includes('SE
 installHtml = installHtml.replace(/PUBLISH_REPLACE_STRING/, JSON.stringify(addons))
 // multiUser=true 对应 CLI 的 getServerId() 分支（Linux 多用户场景，Windows 单用户无副作用）
 installHtml = installHtml.replace(/SERVERID_REPLEASE_STRING/, 'getServerId()')
-// 轻量品牌化：只动标题文案 + 注入覆盖样式，不碰任何机制代码。
+/**
+ * 安装完成后的必读提示。这不是客套话——**不写这三句，用户装完就会以为插件坏了**
+ * （dev-board#270 的支持成本全部来自这里，2026-08-29 三宿主真机实测）：
+ * 授信是按宿主各弹一次的，而且点完「允许」当次会话仍然不加载，必须重启那个宿主。
+ * 顺带把「选项卡不见了」的自助恢复步骤也写上，省得每次都来问。
+ */
+const AWD_INSTALL_NOTE = `    <div class="awd-note">
+      装好之后还有两步，缺一不可：<br>
+      1. 分别打开 WPS <b>文字 / 表格 / 演示</b>，各会弹一次「是否允许加载项运行」，点<b>允许</b>——授信是按宿主分别发生的。<br>
+      2. <b>重启该宿主</b>。点完允许的那一次不会加载，重启后「AI WorkDeck」选项卡才出现。<br>
+      如果哪个宿主的选项卡不见了、或者图标空白点了没反应：在上表把那一行<b>先「卸载」再「安装」，然后重启该宿主</b>即可恢复。
+    </div>`
+
+// 轻量品牌化：只动标题文案 + 加一段安装提示 + 注入覆盖样式，不碰任何机制代码。
 // 样式对齐官网 DESIGN.md（dev-board#246）：纸面底色 + 衬线大标题/眉标 + 白卡 +
 // 品牌绿按钮；vendor 模板保持原样，全部覆盖走这里追加的 <style>。
 // 机制 JS 会往 .addonList/.ClearAll 写 inline maxWidth（800*dpr），只能用
@@ -198,7 +224,13 @@ installHtml = installHtml
   .replace('<title>WPS加载项配置</title>', '<title>AI WorkDeck - WPS 加载项安装</title>')
   .replace('>WPS加载项配置</div>', '>WPS 加载项安装</div>')
   .replace('<div class="divTitle">', '<div class="awd-eyebrow"><span class="awd-eyebrow-line"></span>AI WORKDECK</div>\n    <div class="divTitle">')
+  .replace('<div class="addonList"', `${AWD_INSTALL_NOTE}\n    <div class="addonList"`)
   .replace('</head>', `${BRAND_STYLE}\n</head>`)
+// 提示段是靠锚点插进去的，锚点漂了就会静默丢掉——而丢掉的正是「装完要重启宿主」
+// 这句话，用户装完只会以为插件坏了。宁可构建失败也不出一份没有提示的安装页。
+if (!installHtml.includes('awd-note')) {
+  fail('install.html 未能插入安装提示段（publish-template.html 的 .addonList 锚点变了？）')
+}
 fs.writeFileSync(path.join(outDir, 'install.html'), installHtml)
 
 // 4) 企业版私有部署模板（oem.ini 的 JSPluginsServer 指向这份文件的部署地址）

--- a/office-addin/scripts/build-wps.mjs
+++ b/office-addin/scripts/build-wps.mjs
@@ -2,14 +2,15 @@
 /**
  * WPS 加载项部署产物生成器（仅用 node 内置模块，无新依赖）。
  *
- * WPS 侧没有 manifest.xml——分发走「在线模式」：WPS 启动时从我们服务器拉
- * url/ribbon.xml 与 url/index.html；安装动作由 install.html（官方 publish.html
- * 模板的定制版）经本机 WPS 常驻服务（127.0.0.1:58890）把加载项记录写进用户的
- * jsaddons/publish.xml。个人版 12.1.0.16910 起这是唯一受支持的安装通路；
- * 企业版私有部署另出一份 jsplugins.xml（配 oem.ini 的 JSPluginsServer 用）。
+ * 分发走「在线模式」：WPS 启动宿主时从我们服务器成对拉 url/manifest.xml 与
+ * url/ribbon.xml，用户点按钮时再拉 url/index.html；安装动作由 install.html
+ * （官方 publish.html 模板的定制版）经本机 WPS 常驻服务（127.0.0.1:58890）把加载项
+ * 记录写进用户的 jsaddons/publish.xml。个人版 12.1.0.16910 起这是唯一受支持的
+ * 安装通路；企业版私有部署另出一份 jsplugins.xml（配 oem.ini 的 JSPluginsServer 用）。
  *
  * 产物布局（--out 目录，默认 dist-wps/，整体上传到 <baseUrl> 对应路径）：
  *   wps/                加载项本体（在线模式的 url 指这里，必须以 / 结尾可达）
+ *     manifest.xml      加载项清单（三宿主共用；WPS 每次启动宿主都会拉）
  *     ribbon.xml        功能区（三宿主共用）
  *     index.html        入口页（引 main.js）
  *     main.js  js/      ribbon 薄壳（vanilla JS，不进 Vite）
@@ -163,7 +164,7 @@ fs.mkdirSync(path.join(outDir, 'wps', 'images'), { recursive: true })
 
 // 1) ribbon 薄壳
 const shellDir = path.join(rootDir, 'wps')
-for (const f of ['ribbon.xml', 'index.html', 'main.js']) {
+for (const f of ['manifest.xml', 'ribbon.xml', 'index.html', 'main.js']) {
   fs.copyFileSync(path.join(shellDir, f), path.join(outDir, 'wps', f))
 }
 fs.cpSync(path.join(shellDir, 'js'), path.join(outDir, 'wps', 'js'), { recursive: true })
@@ -209,6 +210,6 @@ jsplugins.push('</jsplugins>', '')
 fs.writeFileSync(path.join(outDir, 'jsplugins.xml'), jsplugins.join('\n'))
 
 console.log(`[build-wps] 完成：${outDir}`)
-console.log(`  加载项 url：${addonUrl}（部署后 GET ${addonUrl}ribbon.xml 必须直接可达，别过 SPA 回退/鉴权）`)
+console.log(`  加载项 url：${addonUrl}（部署后 GET ${addonUrl}manifest.xml 与 ${addonUrl}ribbon.xml 都必须直接可达，别过 SPA 回退/鉴权）`)
 console.log(`  安装页：${baseUrl}/install.html`)
-console.log('  缓存口径：ribbon.xml / index.html / main.js / js/* 建议 no-cache；ui/assets/* 带 hash 可长缓存')
+console.log('  缓存口径：manifest.xml / ribbon.xml / index.html / main.js / js/* 建议 no-cache；ui/assets/* 带 hash 可长缓存')

--- a/office-addin/taskpane/lib/wpsDoc.js
+++ b/office-addin/taskpane/lib/wpsDoc.js
@@ -203,16 +203,27 @@ function readWppSlides() {
 }
 
 /**
+ * 任务窗格 id 在 PluginStorage 里的键。**必须按宿主分**：三个宿主共用同一个加载项
+ * 注册与一份 PluginStorage，而窗格 id 是各宿主进程内从 1 开始自增的——同一个键会让
+ * 文字里存下的 id 被表格拿去开关它自己的同号窗格（可能是别家加载项的）。
+ * 后缀与 ribbon 壳的 `AwdHostTag()` 严格同源——两边改一个就得改另一个。
+ */
+const WPS_HOST_TAG = { word: 'wps', excel: 'et', powerpoint: 'wpp' }
+function taskPaneKey() {
+  return 'awd_taskpane_id_' + (WPS_HOST_TAG[detectWpsHost()] || 'unknown')
+}
+
+/**
  * 从任务窗格内部把自己收起（Visible=false）。
  * 为什么需要：WPS 平台 bug（bbs 93291，12.1.0.26895 起）——JS 停靠任务窗格打开
  * 期间整条 ribbon 拒收鼠标事件，而关窗格的按钮恰恰在 ribbon 上，用户会被锁死。
  * 窗格页自己有 window.wps，从内部藏掉窗格即可解锁 ribbon；重开走 ribbon 的
- * 「AI 助手」按钮（toggle）。窗格 ID 与 ribbon 壳共享 PluginStorage 同一键
- * （wps/js/ribbon.js 的 AWD_PANE_KEY）。
+ * 「AI 助手」按钮（toggle）。窗格 id 从 ribbon 壳写进 PluginStorage 的同一个
+ * 按宿主键里取（wps/js/ribbon.js 的 `AwdPaneKey()`）。
  */
 export function hideWpsTaskPane() {
   try {
-    const id = wps.PluginStorage.getItem('awd_taskpane_id')
+    const id = wps.PluginStorage.getItem(taskPaneKey())
     if (!id) return false
     const pane = wps.GetTaskPane(id)
     if (pane) {

--- a/office-addin/taskpane/lib/wpsDoc.test.js
+++ b/office-addin/taskpane/lib/wpsDoc.test.js
@@ -10,7 +10,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { readWpsActiveDocument, detectWpsHost } from './wpsDoc.js'
+import { readWpsActiveDocument, detectWpsHost, hideWpsTaskPane } from './wpsDoc.js'
 
 /** 安装只有表格宿主的 globalThis.wps，返回 { calls, restore } */
 function installEt(sheet) {
@@ -185,5 +185,65 @@ test('演示：单个形状读失败不许拖垮整篇', async () => {
   try {
     const out = await readWpsActiveDocument()
     assert.ok(out.inlineContent.includes('后面这段还在'), out.inlineContent)
+  } finally { restore() }
+})
+
+/* ==================== 任务窗格自收起（按宿主分键） ==================== */
+
+/**
+ * 造一份三宿主共用的 PluginStorage：文字与表格各自存过自己的窗格 id，
+ * 另外还有一个别家加载项占着的同号窗格——这正是分键要防的场面。
+ */
+function installPaneEnv(host, storage, panes) {
+  const original = globalThis.wps
+  const hostEntry = { word: 'WpsApplication', excel: 'EtApplication', powerpoint: 'WppApplication' }[host]
+  const base = {
+    WpsApplication() { throw new Error('非文字宿主') },
+    EtApplication() { throw new Error('非表格宿主') },
+    WppApplication() { throw new Error('非演示宿主') },
+    PluginStorage: { getItem: (k) => (k in storage ? storage[k] : null) },
+    GetTaskPane: (id) => panes[id] || null
+  }
+  base[hostEntry] = () => ({ ActiveDocument: {}, ActiveWorkbook: {}, ActivePresentation: {} })
+  globalThis.wps = base
+  return () => {
+    if (original === undefined) delete globalThis.wps
+    else globalThis.wps = original
+  }
+}
+
+test('收起窗格：表格宿主收的是表格自己的窗格，不是文字那个', () => {
+  // 窗格 id 在各宿主进程内从 1 开始自增，三宿主又共用一份 PluginStorage。
+  // 不按宿主分键的话，文字存下的 id 会被表格拿去 GetTaskPane——关掉的是表格里
+  // 碰巧同号的那个窗格（很可能是别家加载项的），我们自己的窗格纹丝不动。
+  const wordPane = { Visible: true }
+  const etPane = { Visible: true }
+  const storage = { awd_taskpane_id_wps: 'W', awd_taskpane_id_et: 'E' }
+  const restore = installPaneEnv('excel', storage, { W: wordPane, E: etPane })
+  try {
+    assert.equal(hideWpsTaskPane(), true)
+    assert.equal(etPane.Visible, false, '应当收起表格宿主自己的窗格')
+    assert.equal(wordPane.Visible, true, '不许去动文字宿主的窗格')
+  } finally { restore() }
+})
+
+test('收起窗格：文字宿主读文字的键', () => {
+  const wordPane = { Visible: true }
+  const etPane = { Visible: true }
+  const storage = { awd_taskpane_id_wps: 'W', awd_taskpane_id_et: 'E' }
+  const restore = installPaneEnv('word', storage, { W: wordPane, E: etPane })
+  try {
+    assert.equal(hideWpsTaskPane(), true)
+    assert.equal(wordPane.Visible, false)
+    assert.equal(etPane.Visible, true)
+  } finally { restore() }
+})
+
+test('收起窗格：本宿主没存过 id 时老实返回 false，不去乱猜别的键', () => {
+  const etPane = { Visible: true }
+  const restore = installPaneEnv('powerpoint', { awd_taskpane_id_et: 'E' }, { E: etPane })
+  try {
+    assert.equal(hideWpsTaskPane(), false)
+    assert.equal(etPane.Visible, true)
   } finally { restore() }
 })

--- a/office-addin/wps/js/ribbon.js
+++ b/office-addin/wps/js/ribbon.js
@@ -1,43 +1,93 @@
 // AI WorkDeck WPS 加载项 ribbon 回调（薄壳）：唯一职责是开/关任务窗格。
 // 回调按 ribbon.xml 里写的全局函数名查找（WPS 机制，无注册 API）。
 // 业务全部活在任务窗格网页（ui/taskpane-wps.html，Vue 应用）里。
+//
+// 两条纪律（2026-08-29 排查 dev-board#270 期间加固；**都不是 #270 的根因**，
+// 那次的根因是本机注册态坏掉、重装安装页才恢复，见 .claude/agents/office-addin.md）：
+// 1. **任何一步都不许把异常抛出回调之外**。ribbon 回调是 WPS 侧调进来的，
+//    抛出去只会被宿主吞掉，用户看不到任何报错，我们也拿不到线索；这里失败的每一步
+//    都只影响该步本身，不该连累同一个回调里的其余动作。
+// 2. **任务窗格 id 必须按宿主分键**。三个宿主（文字/表格/演示）共用一个 addin
+//    注册与一份 PluginStorage，而窗格 id 是各宿主进程内从 1 开始自增的。用同一个键
+//    的话，文字里存下的 id=1 会被表格拿去 GetTaskPane(1)——那是表格自己的 1 号窗格，
+//    可能压根是别家加载项的，于是点我们的按钮去开/关了别人的窗格。
 
-var AWD_PANE_KEY = "awd_taskpane_id"
+var AWD_PANE_KEY_BASE = "awd_taskpane_id"
+
+/**
+ * 当前宿主标签：wps（文字）/ et（表格）/ wpp（演示）。
+ * 判据是三个宿主各自独有的顶层集合——真机实测（WPS 12.1.0.28043）三者恰好各有
+ * 一个非空：文字有 Documents、表格有 Workbooks、演示有 Presentations。
+ * 兜底再看 Application.Name（实测分别返回 Microsoft Word / Excel / PowerPoint
+ * ——WPS 为兼容 Word VBA 宏刻意这么报，所以它判不了「是不是 WPS」，
+ * 但判「是哪个宿主」是准的）。
+ */
+function AwdHostTag() {
+    var app = null
+    try { app = window.Application } catch (e) { return "unknown" }
+    if (!app) return "unknown"
+    try { if (app.Presentations) return "wpp" } catch (e) { /* 非演示宿主 */ }
+    try { if (app.Workbooks) return "et" } catch (e) { /* 非表格宿主 */ }
+    try { if (app.Documents) return "wps" } catch (e) { /* 非文字宿主 */ }
+    try {
+        var n = String(app.Name || "")
+        if (n.indexOf("PowerPoint") >= 0) return "wpp"
+        if (n.indexOf("Excel") >= 0) return "et"
+        if (n.indexOf("Word") >= 0) return "wps"
+    } catch (e) { /* 连 Name 都取不到就认了 */ }
+    return "unknown"
+}
+
+/** 任务窗格 id 在 PluginStorage 里的键——按宿主分，任务窗格侧用同一套后缀 */
+function AwdPaneKey() {
+    return AWD_PANE_KEY_BASE + "_" + AwdHostTag()
+}
 
 function OnAddinLoad(ribbonUI) {
-    if (typeof (window.Application.ribbonUI) != "object") {
-        window.Application.ribbonUI = ribbonUI
-    }
-    if (typeof (window.Application.Enum) != "object") {
-        // 旧版宿主没有内置枚举表时用本地兜底（官方模板同款做法）
-        window.Application.Enum = WPS_Enum
-    }
+    // 往宿主 Application 上挂属性属于官方模板的可选便利。各自 try/catch：
+    // 万一某个宿主/版本不让挂，也不该连累同一个回调里的另一步。
+    try {
+        if (typeof (window.Application.ribbonUI) != "object") {
+            window.Application.ribbonUI = ribbonUI
+        }
+    } catch (e) { /* 该宿主不允许挂属性，不影响回调本身 */ }
+    try {
+        if (typeof (window.Application.Enum) != "object") {
+            // 旧版宿主没有内置枚举表时用本地兜底（官方模板同款做法）
+            window.Application.Enum = WPS_Enum
+        }
+    } catch (e) { /* 同上 */ }
     return true
 }
 
 function OnAction(control) {
-    if (control.Id === "btnAwdPane") {
-        ToggleAwdPane()
-    }
+    var id = ""
+    try { id = control.Id } catch (e) { /* 取不到 id 就当没点中 */ }
+    try {
+        if (id === "btnAwdPane") ToggleAwdPane()
+    } catch (e) { /* 异常冒出回调只会被宿主静默吞掉，用户与我们都拿不到线索 */ }
     return true
 }
 
 function ToggleAwdPane() {
     var app = window.Application
-    var tsId = app.PluginStorage.getItem(AWD_PANE_KEY)
+    var key = AwdPaneKey()
+    var tsId = null
+    try { tsId = app.PluginStorage.getItem(key) } catch (e) { tsId = null }
     if (tsId) {
         try {
             var pane = app.GetTaskPane(tsId)
             if (pane) {
-                pane.Visible = !pane.Visible
-                return
+                // 写回读校验：句柄失效时（宿主重启、窗口重建）有的版本不抛异常、
+                // 只是写不进去。写完读回来确认生效了才算复用成功，否则走重建。
+                var want = !pane.Visible
+                pane.Visible = want
+                if (pane.Visible === want) return
             }
-        } catch (e) {
-            // 句柄失效（文档窗口重建等）：走重建
-        }
+        } catch (e) { /* 句柄失效：走重建 */ }
     }
     var created = app.CreateTaskPane(GetUrlPath() + "/ui/taskpane-wps.html")
-    app.PluginStorage.setItem(AWD_PANE_KEY, created.ID)
+    try { app.PluginStorage.setItem(key, created.ID) } catch (e) { /* 存不下只影响下次复用 */ }
     created.Visible = true
 }
 

--- a/office-addin/wps/manifest.xml
+++ b/office-addin/wps/manifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  加载项清单。结构照 wpsjs@2.2.3 脚手架模板（packages/@wps-jsapi/{wps,et,wpp}/manifest.xml）。
+
+  为什么必须有这份文件：WPS 每次启动宿主都会先 GET <url>/manifest.xml，再 GET
+  <url>/ribbon.xml——2026-08-29 真机访问日志实测，两个请求成对出现在每一次宿主启动。
+  我们此前从未产出过它，线上一直 404（dev-board#270 排查时发现）。
+
+  三宿主共用同一个 url，所以只有这一份；Name 与 build-wps.mjs 的 ADDON_NAME 同源。
+  官方 et 模板里的 <Functions> 段是给自定义表格函数用的，我们没有，不写。
+-->
+<JsPlugin>
+  <ApiVersion>1.0.0</ApiVersion>
+  <Name>aiworkdeck</Name>
+  <Description>AI WorkDeck 法律 AI 工作台</Description>
+</JsPlugin>


### PR DESCRIPTION
## 背景

dev-board#270：WPS 三宿主都出现「AI WorkDeck 选项卡不见了 / 图标空白 / 点了没反应」。

## 真根因（三宿主真机定案，不是本 PR 改的代码问题）

判据在 `%APPDATA%\kingsoft\wps\jsaddons\authaddin.json`——每个宿主一条 `{enable, isload}`，**`isload:false` 就是这个病**。实测演示宿主处在 `enable:true, isload:false` 时，每次启动都重弹授信框、选项卡始终不出现；三个宿主都 `isload:true` 时一切正常。`publish.xml` 只说注册了什么，说明不了加载与否，不能当判据。

服务器访问日志的对应形态：坏的时候 WPS 每次启动宿主**仍会**成对拉到 `manifest.xml` + `ribbon.xml`（UA 为空、HTTP/1.1、200，**所以网络是通的**），但不拉 `index.html`/`main.js`/`js/*`——JS 入口没加载，三个回调一个都没执行。

还测出一条此前不知道的行为，也是 #270 支持成本的真正来源：**点完「允许」的那一次会话不会加载加载项，必须重启该宿主**。三个宿主都是这样。用户点了允许、什么也没发生，自然认为插件坏了。

恢复办法（已写成可直接转给用户的话术）：安装页上把该宿主那行**先「卸载」再「安装」，然后重启该宿主**。两步缺一不可。

逐个排除掉的假根因，判据都写进领域文档了，别再走一遍：

| 假根因 | 证伪方式 |
|---|---|
| `publish.xml` 的 `enable="enable_dev"` | 表格那条至今仍是 `enable_dev` 且工作正常，WPS 自己写的就是这个值；反倒是被手工改成 `enable` 的演示那条一直 `isload:false` |
| 虚拟机网络不通 | 坏的那段时间 WPS 自己发的 manifest/ribbon 请求全是 200 |
| `jsaddinblockhost.ini` | 删掉后照样不加载 |
| PluginStorage 共用键 | 干净会话、表格先开、storage 为空，仍然打不开 |
| COM 启动方式 / 整机重启 | 都试过，症状不变 |

## 本 PR 改了什么

**1. 安装页补必读提示** — 授信按宿主各弹一次 / 点完要重启该宿主 / 选项卡不见了如何自助恢复。仍然只动文案与样式，不碰 vendor 模板的机制代码；提示段靠 `.addonList` 锚点插入，锚点漂了直接构建失败（丢掉的恰恰是最需要说的那句话）。

**2. 补 `wps/manifest.xml`（真实缺口）** — WPS 每次启动宿主都要拉它，而构建脚本从没产出过，线上一直 404。结构照 wpsjs@2.2.3 脚手架模板，三宿主共用一份，`Name` 与 `ADDON_NAME` 同源。同时加进 `build-wps.mjs` 的拷贝清单、可达性提示与 no-cache 缓存口径。

**3. 任务窗格 id 的 PluginStorage 键按宿主分**（`awd_taskpane_id_{wps,et,wpp}`）— 三宿主共用一份 PluginStorage，而窗格 id 是各宿主进程内从 1 开始自增的。共用一个键的话，文字里存下的 `id=1` 会被表格拿去 `GetTaskPane(1)`，那是表格自己的 1 号窗格、很可能是别家加载项的，于是点我们的按钮去开/关了别人的窗格。ribbon 壳与任务窗格两侧后缀严格同源。判宿主用 `Application.Presentations/Workbooks/Documents`，**不用 `Application.Name`**（WPS 为兼容 Word VBA 宏，Name 一律返回 `Microsoft Word`/`Excel`/`PowerPoint`）。

**4. ribbon 回调加固** — 两处属性挂载各自 try/catch、`OnAction` 不让异常冒出去、复用窗格句柄前做写回读校验。

## 验证

- `cd office-addin && npm test` → 256 passed（新增 3 条收起窗格用例）
- `npm run build` / `npm run build:wps` 通过，产物含 `wps/manifest.xml` 与安装页提示段
- **还原病灶校验**：把键改回共用的 `awd_taskpane_id` 后，新增用例中 2 条转红
- **真机三宿主走查**（WPS 12.1.0.28043）：文字 / 表格 / 演示的选项卡、图标、任务窗格全部正常，三个窗格可同时存在；`authaddin.json` 三条均为 `enable=True isload=True`
- 线上（北京）已铺，字节与本地产物 sha256 一致，`manifest.xml`/`ribbon.xml`/`index.html`/`main.js`/`js/*`/`ui/*` 全部 200

## 走查中发现的既有缺陷（非本次引入，已单独开卡）

两个以上宿主同时开任务窗格时，三个窗格恢复同一个 conversationId，而 `SseEmitterService.emitters` 每个 conversationId 只允许一条连接、新连接直接顶掉旧的 → 无限乒乓，`/api/agent/connect` 约 55 次/分钟。已开 dev-board#271。

🤖 Generated with [Claude Code](https://claude.com/claude-code)