### PR TITLE
fix: WPS 包剔除多余的 Office 入口页；Release 说明去掉每版重复的「自本版本起」

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -721,7 +721,7 @@ jobs:
             - **macOS · Apple Silicon (M 系列)** — `AI WorkDeck-<ver>-arm64.dmg`（已签名公证 / signed & notarized）
             - **Windows · x64** — `AI WorkDeck Setup <ver>.exe`（暂未签名，首次运行 SmartScreen 提示属正常 / not yet code-signed; a SmartScreen prompt on first run is expected）
 
-            > 自本版本起不再提供 Intel Mac 安装包（依赖生态已停发 x86_64 预编译组件）。/ Intel mac builds are discontinued as of this release.
+            > 不提供 Intel Mac 安装包（依赖生态已停发 x86_64 预编译组件，2026-07-03 起）。/ No Intel Mac build (upstream dependencies no longer ship x86_64 binaries; since 2026-07-03).
 
             官网 / Website: https://www.aiworkdeck.com
 

--- a/office-addin/scripts/build-wps.mjs
+++ b/office-addin/scripts/build-wps.mjs
@@ -183,8 +183,17 @@ for (const f of ['manifest.xml', 'ribbon.xml', 'index.html', 'main.js']) {
 fs.cpSync(path.join(shellDir, 'js'), path.join(outDir, 'wps', 'js'), { recursive: true })
 fs.copyFileSync(path.join(rootDir, 'assets', 'icon-32.png'), path.join(outDir, 'wps', 'images', 'icon-32.png'))
 
-// 2) 任务窗格：Vite 产物整份进 ui/
+// 2) 任务窗格：Vite 产物整份进 ui/。
+// 但 dist/ 是双入口（taskpane.html = Office 面，taskpane-wps.html = WPS 面），
+// 整份拷会把 Office 那个入口也带进 WPS 分发包——它没人引用，却是一个能被公网取到的
+// 第二入口，而且 <script> 引的是微软全球 CDN 的 office.js（国内慢/不通）、在 WPS 里
+// 打开必然白屏。删掉它：WPS 面只认 taskpane-wps.html。
 fs.cpSync(distDir, path.join(outDir, 'wps', 'ui'), { recursive: true })
+const officeEntry = path.join(outDir, 'wps', 'ui', 'taskpane.html')
+if (fs.existsSync(officeEntry)) fs.rmSync(officeEntry)
+if (!fs.existsSync(path.join(outDir, 'wps', 'ui', 'taskpane-wps.html'))) {
+  fail('ui/taskpane-wps.html 不在产物里（vite 双入口配置被改动？）')
+}
 
 // 3) install.html：官方 publish.html 模板 + 我们的清单（对拍 wpsjs publish.js 的两处替换）
 const addons = ['wps', 'et', 'wpp'].map((type) => ({


### PR DESCRIPTION
发 v0.27.3 后全量核对查出来的两条，都经过对抗式复核（同批还有三条被复核判为误报，已剔除）。

## 1. WPS 分发包里多出一份没人引用的 `wps/ui/taskpane.html`

`dist/` 是双入口（`taskpane.html` = Office 面，`taskpane-wps.html` = WPS 面），`build-wps.mjs` 整份 `cpSync` 把 Office 那个入口也带进了 WPS 包。

实测线上可取：`https://addin.aiworkdeck.com/wps-addin/wps/ui/taskpane.html` → 200 / 554B，`<script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js">`——微软全球 CDN 在国内慢/不通，而且这页在 WPS 里打开必然白屏（没有 Office 宿主）。纯粹的多余入口。

改为拷完即删，并加一条「`taskpane-wps.html` 必须在」的兜底断言——免得将来 vite 双入口配置一改就静默产出空包。

## 2. Release body 的「自本版本起不再提供 Intel Mac 安装包」

这句写死在 workflow 模板里，**每一版都重复出现**。复核者往回翻了 v0.25.0 至 v0.27.2 共八个版本，句子一字不差。放弃 Intel 是 2026-07-03 的一次性决策，写成「自本版本起 / as of this release」会让每一版的读者都以为是这版才砍的。

改成陈述现状并注明决策日期。

## 线上已同步

北京 `wps-addin/wps/ui/` 已用 `--delete-after` 重铺：多余页现在是真 404（146B），`taskpane-wps.html` 200 照常。

## 验证

- `cd office-addin && npm test` → 256 passed
- `npm run build && npm run build:wps` 后 `ui/` 下只剩 `taskpane-wps.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)