### PR TITLE
chore(release): v0.27.4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.27.3",
+  "version": "0.27.4",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
v0.27.4 小版本（应用内补丁：backend-app / frontend-h5 / zetaoffice-wrapper）。

内容：PR #657——深色模式全面收口（资源管理器/编辑器区域/外围组件）、插件桥 v2.6 主题通道（SDK 1.2.0）、插件生态对标 VS Code 路线文档。

合并后打 tag v0.27.4 触发双平台构建与补丁产物。

🤖 Generated with [Claude Code](https://claude.com/claude-code)