### PR TITLE
chore(release): v0.27.5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.27.4",
+  "version": "0.27.5",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
插件三端双边根因修复随本版发出（dev-board#285-288，PR #663 已合并）。

云侧已部署完毕（北京 + 新加坡后端 jar、两站 office-addin 资产、北京 WPS 壳，
资产哈希 main-BUa4nPFZ.js，八个端点冒烟全 200）；本 PR 只做版本号，
让桌面端把后端侧修复（SSE 断点续传、text_delta 转义、上下文提示词）作为
应用内补丁发给存量 0.27.x 用户，并让插件安装器版本号与桌面端对齐。

小版本补丁合规：改动只在 backend/src 与 office-addin，未触 desktop 壳 / pom / LOWA 引擎。

🤖 Generated with [Claude Code](https://claude.com/claude-code)