### PR TITLE
chore(release): v0.28.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.27.5",
+  "version": "0.28.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
小版本 v0.27.5 被 patch gate 拒绝（`backend/plugin-api/pom.xml` 1.1.0→1.2.0，来自 PR #660 的 P3 工作），按项目规则改发大版本。闸拦对了：补丁只发 backend-app、不发 lib/，真发 0.27.5 会让存量用户「新 backend-app 配旧 plugin-api jar」，P3 新接口一调就 NoSuchMethodError。

本版内容：
- **插件三端双边根因修复**（dev-board#285-288，PR #663）——云侧已部署，本 tag 让桌面端也拿到后端侧改进
- 插件规范 v2.8/v2.9（PR #660-662）

🤖 Generated with [Claude Code](https://claude.com/claude-code)