### PR TITLE
fix(addin): 插件审计剩余确认项 10 条修掉 9 条（dev-board#288）

### DIFF
--- a/.claude/agents/office-addin.md
+++ b/.claude/agents/office-addin.md
@@ -162,9 +162,42 @@ description: Microsoft Office 与 WPS 插件领域。任务涉及 Word/Excel/PPT
 - **PPT 内联正文里的「第N页：」与「 | 」是插件加的装饰**，已在正文开头加一行交底；
   改这两个读取器时装饰与说明要一起改（`wpsDoc.PPT_INLINE_NOTE` 与 `wordDoc.PPT_INLINE_NOTE` 同源两份）。
 
-**已知未修**：对抗式复核确认但本轮未修的 11 条（Office/ppt 组合形状不可达、
-Office 面 apply_standard_format 无 run 合并、Excel 整表过桥、页眉页脚整体覆写等）
-与未验证的中低危 115 条，清单在 dev-board#288 的评论里。
+### 2026-08-30 下午：审计剩余项（dev-board#288，10 条确认项修掉 9 条）
+
+- **Excel 读取路径的截断必须发生在过桥之前**（`wordDoc.readExcelSheet` 与
+  `officeExecutor.excel_get_range`）：先只 load 尺寸，再用 `getRangeByIndexes`
+  （ExcelApi 1.1，无门槛）取截断后的区间。此前是把整片已用区域的 values 编组过桥再切前
+  2000 / 500 行，几万行的台账能让任务窗格无响应几十秒。WPS 面早就是「先 Resize 再取 Value2」。
+- **Office/PPT `loadPptTextFrames` 支持组合形状递归**：`Shape.group` / `ShapeGroup.shapes`
+  是 **PowerPointApi 1.8**（微软官方文档核实；`ShapeType.group` 本身是 1.4）。
+  **1.8 不可用时静默退化成只收顶层、绝不报错**。表格文字不并进来——Office 面有
+  `ppt_table_read` / `ppt_table_set_cell` 专门通道（WPS 面没有，所以它把表格并进了遍历）。
+- **`ppt_replace_text` 只改命中段**：整框回写 `textRange.text` 会抹平框内所有分段字符格式
+  与超链接还报成功。改逐处 `getSubstring` 并**从右到左应用**（偏移按原文算，右边先改
+  不推移左边）。`TextRange.text` 可写与 `getSubstring` 都是 PowerPointApi 1.4，无需新守卫。
+- **`edit_header_footer` 没给 text 就不许动文字**（两个家族同修）：旧写法无条件整替、
+  text 兜底成空串，模型只想改对齐就把用户页眉清空。显式传空串仍是「清空」这个合法意图，
+  两者分开；都不给时报错。返回值加 `textUpdated`。
+- **`excel_add_pivot_table`**：目标地址支持跨表（`splitSheetQualifiedAddress`，
+  含 `'带空格 表'!A1` 的引号包裹）；字段名改成「建表 → 读层级名 → 全对得上才继续，
+  对不上就把刚建的表删掉再报错并列出可用字段」，不留空透视表。
+- **`excel_protect_sheet` 的密码是 ExcelApi 1.7 那一档**：旧宿主上参数被直接忽略，
+  表被保护但**没有密码**还报成功。安全动作不许静默降级——不支持时明确报错，
+  并回读 `protection.protected` 报真实状态。
+- `office_ppt_add_slide` 的工具描述与实现对齐（实现是「新页成为第 N 页」，描述写的是
+  「插到第 N 页之后」，差一位；两个执行器一致，改的是描述）。
+
+**唯一没修的一条，以及为什么**：`standard-format-revision-flood`（Office 面
+`apply_standard_format` 逐段落笔，WPS 面已按 run 合并）。不修的理由不是没时间——
+**这条在 Office 面缺一个真机判据**：WPS 那次合并是维护者按真机观察到的「每段一条修订」
+裁决的，而 Word 是否会把相邻的同款格式修订自动合并，本机无法验证。
+而且 Office.js 里 `Range` 只能整段设 `font`，`lineSpacing`/`spaceAfter`/`firstLineIndent`
+仍须逐段设——照搬 WPS 的 `doc.Range(首段.Start, 末段.End)` 一次落笔在 Office 面没有对应写法，
+`expandTo` 拼出来的区间又缺少 WPS 那条「`merged.Paragraphs.Count === run 段数`」安全阀。
+在整篇文档的格式路径上照着未经验证的假设改，风险是「半篇文档格式被刷坏」，
+比多几十条格式修订严重得多。要做先补真机观察 + 同款安全阀。
+
+**未验证的中低危 115 条**（从未做过对抗式复核）清单在 dev-board#288 的评论里。
 
 ## 验证
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/OfficeEditTools.java
@@ -1578,13 +1578,13 @@ public class OfficeEditTools implements AgentToolComponent {
     }
 
     @Tool("在当前 PowerPoint 演示文稿中新增一页幻灯片，可选写入标题与正文文本框。" +
-          "position 指定插入到第几页之后（1 起；不传则追加到末尾）——PowerPoint JS API 只能把新页加到末尾" +
+          "position 指定新页插入后成为第几页（1 起，即插在原第 position 页之前；不传则追加到末尾）——PowerPoint JS API 只能把新页加到末尾" +
           "再挪动位置，挪动需要 PowerPointApi 1.8（较新 Microsoft 365），旧版宿主上会追加到末尾但不挪动位置，" +
           "返回值 moved/note 字段说明实际情况。title/body 用文本框承载（需要 PowerPointApi 1.4），位置尺寸用固定默认值。")
     @ToolMeta(displayName = "新增幻灯片", category = "office", fileEffect = "MODIFIED")
     public String office_ppt_add_slide(
             @P("会话ID（系统自动注入）") String conversationId,
-            @P("插入到第几页之后（1 起；不传则追加到末尾）") Integer position,
+            @P("新页插入后成为第几页（1 起，即插在原第 position 页之前；不传则追加到末尾）") Integer position,
             @P("标题文本（可选）") String title,
             @P("正文文本（可选）") String body
     ) {

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionServiceTest.java
@@ -151,8 +151,14 @@ class MeetingTranscriptionServiceTest {
         a.start();
         assertTrue(aPaused.await(5, TimeUnit.SECONDS), "线程 A 应该先卡在 findById 里");
 
-        AtomicReference<MeetingRecording> bResult = new AtomicReference<>();
-        Thread b = new Thread(() -> bResult.set(svc.startTranscription(7L)));
+        // **状态要在 B 线程里当场取快照**，不能把共享的 MeetingRecording 对象存下来、
+        // 等两个线程都 join 完再读 getStatus()：A 的异步后续（executor.submit 里的
+        // 转码/建任务/失败落库）跑在同一个对象上，join 之后再读，读到的可能是 A 后来
+        // 写进去的 FAILED，与 B 当时短路返回时看到的值无关。
+        // 2026-08-30 这条在 CI 上真的翻红过（expected TRANSCRIBING but was FAILED），
+        // 与被测的「并发只提交一次」语义毫无关系，纯粹是断言取值时机写错了。
+        AtomicReference<String> bStatus = new AtomicReference<>();
+        Thread b = new Thread(() -> bStatus.set(svc.startTranscription(7L).getStatus()));
         b.start();
 
         Thread.sleep(300); // 有锁的话 B 这时候应该还卡在方法入口，等 A 彻底做完
@@ -164,7 +170,7 @@ class MeetingTranscriptionServiceTest {
 
         // 只应该有一次真正走到校验+提交；B 命中的是方法开头既有的幂等短路分支
         verify(lastResolver, times(1)).resolve(anyString());
-        assertEquals(MeetingRecording.STATUS_TRANSCRIBING, bResult.get().getStatus());
+        assertEquals(MeetingRecording.STATUS_TRANSCRIBING, bStatus.get());
     }
 
     @Test

--- a/office-addin/taskpane/lib/officeExcelRead.test.js
+++ b/office-addin/taskpane/lib/officeExcelRead.test.js
@@ -1,0 +1,143 @@
+/**
+ * Office/Excel 面读取路径的过桥量（dev-board#288）：
+ *   node --test office-addin/taskpane/lib/officeExcelRead.test.js
+ *
+ * 病灶：`excel_get_range` 与随消息附带的表格正文都是**先把整片已用区域的 values
+ * 编组过桥、再切前 N 行**。几万行的台账上，这一趟能让任务窗格无响应几十秒——
+ * 而切完之后真正用到的只有前 500 / 2000 行。WPS 面（wpsDoc.readEtSheet）早就是
+ * 「先 Resize 再取 Value2」，Office 面一直没跟。
+ *
+ * 不变式：**截断必须发生在过桥之前**——`load('values')` 只许落在截断后的区间上，
+ * 整片已用区域只许被问尺寸（rowCount/columnCount/address）。
+ * 本用例直接盯这条不变式，而不是盯耗时（耗时在 mock 里没有意义）。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+/** 记录每个 Range 上 load 过哪些属性，便于断言「谁被要了 values」 */
+function makeRange(spec) {
+  const r = {
+    _tag: spec.tag,
+    _loaded: [],
+    rowIndex: spec.rowIndex || 0,
+    columnIndex: spec.columnIndex || 0,
+    rowCount: spec.rowCount,
+    columnCount: spec.columnCount,
+    address: spec.address || 'A1',
+    isNullObject: !!spec.isNullObject,
+    values: spec.values,
+    load(props) { this._loaded.push(String(props)) }
+  }
+  return r
+}
+
+/**
+ * 装一个假的 Excel 命名空间。
+ * used = 整片已用区域（大）；byIndexes = getRangeByIndexes 切出来的小区间。
+ */
+function installExcel({ totalRows, cols, sliceFactory }) {
+  const saved = globalThis.Excel
+  const used = makeRange({ tag: 'used', rowCount: totalRows, columnCount: cols, address: `A1:C${totalRows}` })
+  const slices = []
+  const sheet = {
+    name: '测算表',
+    load() {},
+    getUsedRangeOrNullObject() { return used },
+    getRangeByIndexes(r, c, nr, nc) {
+      const s = sliceFactory(nr, nc)
+      s._tag = 'slice'
+      s._req = { r, c, nr, nc }
+      slices.push(s)
+      return s
+    },
+    getRange() { return used }
+  }
+  globalThis.Excel = {
+    run: async (cb) => cb({
+      workbook: {
+        worksheets: {
+          getActiveWorksheet: () => sheet,
+          getItem: () => sheet
+        }
+      },
+      sync: async () => {}
+    })
+  }
+  return {
+    used,
+    slices,
+    restore() {
+      if (saved === undefined) delete globalThis.Excel
+      else globalThis.Excel = saved
+    }
+  }
+}
+
+function rowsOf(n, cols) {
+  return Array.from({ length: n }, (_, i) => Array.from({ length: cols }, (_, c) => `r${i}c${c}`))
+}
+
+// officeAvailable() 看的是 Office.context；detectHost() 优先 Office.context.host。
+// 两者都要有，读取路径才走得到 Excel 分支。
+globalThis.Office = {
+  HostType: { Word: 'Word', Excel: 'Excel', PowerPoint: 'PowerPoint' },
+  context: { host: 'Excel', document: { url: 'C:/x/测算表.xlsx' } }
+}
+
+const { readActiveDocument } = await import('./wordDoc.js')
+
+test('随消息附带的表格正文：整片已用区域只许被问尺寸，values 只许落在截断后的区间上', async () => {
+  // 10 万行的台账，只展示前 2000 行
+  const env = installExcel({
+    totalRows: 100000,
+    cols: 3,
+    sliceFactory: (nr, nc) => makeRange({ tag: 'slice', rowCount: nr, columnCount: nc, values: rowsOf(nr, nc) })
+  })
+  // detectHost 走 Excel 分支
+  const savedWord = globalThis.Word
+  const savedPpt = globalThis.PowerPoint
+  delete globalThis.Word
+  delete globalThis.PowerPoint
+  try {
+    const doc = await readActiveDocument()
+    assert.ok(doc, '应读到内容')
+    // 不变式一：整片已用区域**不许**被要 values
+    const usedLoads = env.used._loaded.join(' ')
+    assert.ok(!/values/.test(usedLoads),
+      `整片已用区域不该被 load values（会把 10 万行编组过桥），实际 load 了：${usedLoads}`)
+    assert.ok(/rowCount/.test(usedLoads), '应当只问尺寸')
+    // 不变式二：确实切了 2000 行的小区间，values 落在它身上
+    assert.equal(env.slices.length, 1, '应当切一次小区间')
+    assert.equal(env.slices[0]._req.nr, 2000, `只该取 2000 行，实际 ${env.slices[0]._req.nr}`)
+    assert.ok(env.slices[0]._loaded.join(' ').includes('values'), '小区间才是被要 values 的那个')
+    // 内容与「共多少行」的交代都要对
+    assert.ok(doc.inlineContent.includes('共 100000 行，仅附前 2000 行'), doc.inlineContent.slice(-80))
+  } finally {
+    env.restore()
+    if (savedWord !== undefined) globalThis.Word = savedWord
+    if (savedPpt !== undefined) globalThis.PowerPoint = savedPpt
+  }
+})
+
+test('小表照旧一次取回，不多切一刀', async () => {
+  const env = installExcel({
+    totalRows: 12,
+    cols: 3,
+    sliceFactory: (nr, nc) => makeRange({ tag: 'slice', rowCount: nr, columnCount: nc, values: rowsOf(nr, nc) })
+  })
+  env.used.values = rowsOf(12, 3)
+  const savedWord = globalThis.Word
+  const savedPpt = globalThis.PowerPoint
+  delete globalThis.Word
+  delete globalThis.PowerPoint
+  try {
+    const doc = await readActiveDocument()
+    assert.equal(env.slices.length, 0, '行数没超上限时不该再切区间')
+    assert.ok(env.used._loaded.join(' ').includes('values'), '小表直接在已用区域上取值')
+    assert.ok(!doc.inlineContent.includes('仅附前'), '不该出现截断说明')
+  } finally {
+    env.restore()
+    if (savedWord !== undefined) globalThis.Word = savedWord
+    if (savedPpt !== undefined) globalThis.PowerPoint = savedPpt
+  }
+})

--- a/office-addin/taskpane/lib/officeExecutor.js
+++ b/office-addin/taskpane/lib/officeExecutor.js
@@ -1403,16 +1403,25 @@ const HANDLERS = {
 
   async edit_header_footer(args) {
     const part = args.part === 'footer' ? 'footer' : 'header'
-    const text = args.text == null ? '' : String(args.text)
+    // **没给 text 就不许动文字**（dev-board#288）：旧写法无条件整替，
+    // 模型只想改对齐方式（不传 text）时，text 兜底成空串，一调用就把用户的页眉清空，
+    // 返回值还报成功。显式传空串仍然是「清空」这个合法意图，两者必须分开。
+    const hasText = args.text != null
+    const text = hasText ? String(args.text) : ''
     const alignment = args.alignment == null ? null : toEnumValue(ALIGNMENTS, args.alignment, 'alignment')
+    if (!hasText && !alignment) {
+      throw new Error('edit_header_footer 需要至少给 text（要写入的文字，传空串表示清空）或 alignment 之一')
+    }
     return Word.run(async (context) => {
       return withTracking(context, async () => {
         const section = context.document.sections.getFirst()
         const body = part === 'footer'
           ? section.getFooter(Word.HeaderFooterType.primary)
           : section.getHeader(Word.HeaderFooterType.primary)
-        body.insertText(text, Word.InsertLocation.replace)
-        await context.sync()
+        if (hasText) {
+          body.insertText(text, Word.InsertLocation.replace)
+          await context.sync()
+        }
         if (alignment) {
           const paragraphs = body.paragraphs
           paragraphs.load('items')
@@ -1420,7 +1429,12 @@ const HANDLERS = {
           paragraphs.items.forEach((p) => { p.alignment = alignment })
           await context.sync()
         }
-        return { part, textLength: text.length, alignment: args.alignment || null }
+        return {
+          part,
+          textUpdated: hasText,
+          textLength: hasText ? text.length : null,
+          alignment: args.alignment || null
+        }
       })
     })
   },
@@ -2395,13 +2409,27 @@ const HANDLERS = {
     if (action !== 'protect' && action !== 'unprotect') throw new Error(`action 值非法：${args.action}（合法值：protect/unprotect）`)
     return Excel.run(async (context) => {
       const sheet = resolveSheet(context, sheetName)
+      // **密码是 ExcelApi 1.7 那一档**（dev-board#288）：旧宿主上第二个参数会被
+      // 直接忽略——工作表照样被保护，但**没有密码**，返回值还报成功。
+      // 安全动作不许半途而废：要么真的加上密码，要么明说做不到，绝不静默降级。
+      if (action === 'protect' && password !== undefined && !excelApiSupported('1.7')) {
+        throw new Error('当前 Excel 版本不支持给工作表保护设置密码（需要 ExcelApi 1.7）。'
+          + '不带密码的保护仍然可用——去掉 password 参数重试即可，'
+          + '但必须明确告诉用户这层保护是没有密码的。')
+      }
       if (action === 'protect') {
         sheet.protection.protect(undefined, password)
       } else {
         sheet.protection.unprotect(password)
       }
+      // 回读真实状态，别只报"我发过这条命令"
+      sheet.protection.load('protected')
       await context.sync()
-      return { action }
+      return {
+        action,
+        protected: sheet.protection.protected,
+        passwordApplied: action === 'protect' && password !== undefined
+      }
     })
   },
 
@@ -2443,21 +2471,46 @@ const HANDLERS = {
     return Excel.run(async (context) => {
       const sheet = resolveSheet(context, sheetName)
       const source = sheet.getRange(sourceRangeAddress)
-      const destination = sheet.getRange(destinationCellAddress)
+      // **目标地址允许跨表**（dev-board#288）：工具描述一直承诺可以把透视表放到另一张
+      // 工作表，代码却把 "报表!A1" 整个丢给源表的 getRange，跨表落点根本到不了。
+      const dest = splitSheetQualifiedAddress(destinationCellAddress)
+      const destSheet = dest.sheetName ? resolveSheet(context, dest.sheetName) : sheet
+      const destination = destSheet.getRange(dest.address)
       const name = args.pivotName ? String(args.pivotName) : `PivotTable_${Date.now()}`
       const pivot = sheet.pivotTables.add(name, source, destination)
       pivot.load('name')
+      // 字段名要在**落笔之前**校验完（dev-board#288）：旧写法先建表、再逐个
+      // hierarchies.getItem(字段)，字段名拼错时抛的是英文 ItemNotFound，
+      // 而那张空透视表已经留在用户的工作表上了。层级名只有建表后才拿得到，
+      // 所以改成「建表 → 读层级名 → 全部对得上才继续，对不上就把表删掉再报错」。
+      pivot.hierarchies.load('items/name')
       await context.sync()
+      const available = (pivot.hierarchies.items || []).map((h) => String(h.name))
+      const wanted = rowFields.concat(valueFields).map(String)
+      const missing = wanted.filter((f) => !available.includes(f))
+      if (missing.length) {
+        try {
+          pivot.delete()
+          await context.sync()
+        } catch (e) { /* 删不掉也要把错误说清楚，不能吞掉 */ }
+        throw new Error(`透视表字段不存在：${missing.join('、')}。`
+          + `源区域 ${sourceRangeAddress} 可用字段：${available.join('、') || '（无——请确认源区域第一行是标题行）'}。`
+          + '请用其中之一重试；已自动清除刚建出的空透视表。')
+      }
       for (const field of rowFields) {
-        const hierarchy = pivot.hierarchies.getItem(String(field))
-        pivot.rowHierarchies.add(hierarchy)
+        pivot.rowHierarchies.add(pivot.hierarchies.getItem(String(field)))
       }
       for (const field of valueFields) {
-        const hierarchy = pivot.hierarchies.getItem(String(field))
-        pivot.dataHierarchies.add(hierarchy)
+        pivot.dataHierarchies.add(pivot.hierarchies.getItem(String(field)))
       }
       await context.sync()
-      return { added: true, name: pivot.name, rowFields, valueFields }
+      return {
+        added: true,
+        name: pivot.name,
+        rowFields,
+        valueFields,
+        destinationSheet: dest.sheetName || sheet.name
+      }
     })
   },
 
@@ -2917,6 +2970,19 @@ const HANDLERS = {
 
 /** excel_get_range 返回值的行数上限（防超长工具输出撑爆模型上下文） */
 const MAX_EXCEL_RESULT_ROWS = 500
+
+/**
+ * 拆 "工作表!地址" 形式的限定地址。没有 `!` 时 sheetName 为空（表示用当前表）。
+ * 支持 Excel 对含空格表名的单引号包裹（'我的 表'!A1）。
+ */
+function splitSheetQualifiedAddress(raw) {
+  const text = String(raw || '')
+  const at = text.lastIndexOf('!')
+  if (at === -1) return { sheetName: '', address: text }
+  let name = text.slice(0, at)
+  if (name.startsWith("'") && name.endsWith("'")) name = name.slice(1, -1).replace(/''/g, "'")
+  return { sheetName: name, address: text.slice(at + 1) }
+}
 
 /** 按名取工作表；名为空取活动工作表 */
 function resolveSheet(context, sheetName) {

--- a/office-addin/taskpane/lib/officeExecutor.js
+++ b/office-addin/taskpane/lib/officeExecutor.js
@@ -2492,9 +2492,22 @@ const HANDLERS = {
         for (const tf of slideFrames) {
           if (tf.isNullObject || !tf.hasText) continue
           const text = tf.textRange.text || ''
-          if (!text.includes(searchText)) continue
-          replaced += text.split(searchText).length - 1
-          tf.textRange.text = text.split(searchText).join(replaceText)
+          // 归一化定位（dev-board#286）：命中区间是原文坐标
+          const hits = findAllNormalized(text, searchText)
+          if (!hits.length) continue
+          // **只改命中的那一段，不整框回写**（dev-board#288）：
+          // 旧写法 `tf.textRange.text = 整段新文本` 会把这个文本框里所有分段字符格式
+          // （加粗、字号、颜色）与超链接一并抹平，然后报成功——用户看到的是"改是改了，
+          // 但这一页的排版全没了"。TextRange.text 可写、getSubstring 都是 PowerPointApi 1.4
+          // （官方文档核实），与本命令既有的版本门槛同档，不需要额外守卫。
+          //
+          // **从右到左应用**：所有 getSubstring 的偏移都是按原文算的，右边先改不会推移
+          // 左边的坐标；反过来则第二处起全部错位（与 Word 面 replace_text 同一条纪律）。
+          for (let k = hits.length - 1; k >= 0; k--) {
+            const h = hits[k]
+            tf.textRange.getSubstring(h.start, h.end - h.start).text = replaceText
+          }
+          replaced += hits.length
           slideTouched = true
         }
         if (slideTouched) touchedSlides.push(i + 1)
@@ -2503,7 +2516,8 @@ const HANDLERS = {
         throw new Error('未找到目标文本，请确认 searchText 与幻灯片文本精确一致（可先用 ppt_get_slides 核对）')
       }
       await context.sync()
-      return { replaced, slides: touchedSlides }
+      // via 交底用的是哪条路：substring 表示只改了命中段、框内其余格式与超链接保持原样
+      return { replaced, slides: touchedSlides, via: 'substring' }
     })
   },
 

--- a/office-addin/taskpane/lib/officeExecutor.js
+++ b/office-addin/taskpane/lib/officeExecutor.js
@@ -1739,23 +1739,28 @@ const HANDLERS = {
       const range = rangeAddress
         ? sheet.getRange(rangeAddress)
         : sheet.getUsedRangeOrNullObject(true)
-      range.load('values,address,rowCount,columnCount,isNullObject')
+      // **先只取尺寸，值等截断之后再取**（dev-board#288）：返回值最多给
+      // MAX_EXCEL_RESULT_ROWS 行，把整片区域的 values 编组过桥就是白搬。
+      // 几万行的台账上，这一趟能让任务窗格无响应几十秒。与 wordDoc.readExcelSheet
+      // 同一条纪律：截断必须发生在过桥之前。
+      range.load('address,rowCount,columnCount,isNullObject,rowIndex,columnIndex')
       await context.sync()
       if (range.isNullObject) {
         return { sheet: sheet.name, address: '', rows: 0, cols: 0, values: [], note: '工作表为空' }
       }
-      let values = range.values
-      let truncated = false
-      if (values.length > MAX_EXCEL_RESULT_ROWS) {
-        values = values.slice(0, MAX_EXCEL_RESULT_ROWS)
-        truncated = true
-      }
+      const totalRows = range.rowCount
+      const truncated = totalRows > MAX_EXCEL_RESULT_ROWS
+      const target = truncated
+        ? sheet.getRangeByIndexes(range.rowIndex, range.columnIndex, MAX_EXCEL_RESULT_ROWS, range.columnCount)
+        : range
+      target.load('values')
+      await context.sync()
       return {
         sheet: sheet.name,
         address: range.address,
-        rows: range.rowCount,
+        rows: totalRows,
         cols: range.columnCount,
-        values,
+        values: target.values || [],
         truncated
       }
     })
@@ -3069,14 +3074,64 @@ function getSlideOrThrow(slides, slideNumber) {
 }
 
 /** 载入全部幻灯片各形状的 TextFrame（含 hasText 与 textRange.text），返回按页分组的数组 */
+/** 组合形状递归的深度上限（每一层多一次 sync，与 WPS 面同口径） */
+const PPT_GROUP_MAX_DEPTH = 4
+
+/**
+ * 逐页收集**所有承载文字的 TextFrame**，含组合形状（group）里的子形状。
+ *
+ * 为什么要递归（dev-board#288）：演示稿里图示+标注、SmartArt 转出来的内容都是组合形状，
+ * 文字在子形状上；只看顶层 `getTextFrameOrNullObject()` 的话，这些字既读不到也改不了——
+ * 用户看着满屏字，AI 说这页没这段内容。WPS 面（wpsWppHandlers.textBearingShapes）已经
+ * 按「表格 → 组合递归 → 普通文本框」三条路收，Office 面此前只有第三条。
+ *
+ * 版本门槛：`Shape.group` / `ShapeGroup.shapes` 是 **PowerPointApi 1.8**（官方文档核实，
+ * 与本文件表格三件套同档）；`ShapeType.group` 本身是 1.4。**1.8 不支持时不报错**，
+ * 退化成「只收顶层」——与改造前逐字一致，不该因为想多读一点就把老宿主整条打死。
+ *
+ * 表格文字不在这里收：Office 面有 ppt_table_read / ppt_table_set_cell 专门通道
+ * （WPS 面没有那条通道，所以它把表格并进了遍历）。
+ */
 async function loadPptTextFrames(context) {
   const slides = context.presentation.slides
   slides.load('items')
   await context.sync()
-  slides.items.forEach((slide) => slide.shapes.load('items'))
+  slides.items.forEach((slide) => slide.shapes.load('items/type'))
   await context.sync()
-  const frames = slides.items.map((slide) =>
-    slide.shapes.items.map((shape) => {
+
+  const perSlide = slides.items.map((slide) => slide.shapes.items.slice())
+  if (pptApiSupported('1.8')) {
+    // 逐层展开组合：只在这一层真的有组合时才多花一次 sync
+    for (let depth = 0; depth < PPT_GROUP_MAX_DEPTH; depth++) {
+      const pending = []
+      perSlide.forEach((shapes, si) => {
+        shapes.forEach((shape) => {
+          if (String(shape.type) !== 'Group') return
+          try {
+            const inner = shape.group.shapes
+            inner.load('items/type')
+            pending.push({ si, inner })
+          } catch (e) { /* 个别形状取不到子集合，跳过它 */ }
+        })
+      })
+      if (!pending.length) break
+      await context.sync()
+      // 展开后的子形状替换掉本层的组合壳（组合壳自身没有文字）
+      const nextLevel = perSlide.map(() => [])
+      pending.forEach(({ si, inner }) => {
+        try {
+          for (const child of inner.items) nextLevel[si].push(child)
+        } catch (e) { /* 子集合读失败只丢这一个组合 */ }
+      })
+      perSlide.forEach((shapes, si) => {
+        const kept = shapes.filter((sp) => String(sp.type) !== 'Group')
+        perSlide[si] = kept.concat(nextLevel[si])
+      })
+    }
+  }
+
+  const frames = perSlide.map((shapes) =>
+    shapes.map((shape) => {
       const tf = shape.getTextFrameOrNullObject()
       tf.load('hasText,isNullObject')
       tf.textRange.load('text')

--- a/office-addin/taskpane/lib/officePptShapes.test.js
+++ b/office-addin/taskpane/lib/officePptShapes.test.js
@@ -15,17 +15,32 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
+/**
+ * 带状态的文本形状：记录「整框回写」与「子串替换」两种写入，
+ * 用来钉住 ppt_replace_text 不许再整框回写（会抹平框内格式与超链接）。
+ */
 function textShape(text) {
-  return {
-    type: 'TextBox',
-    getTextFrameOrNullObject() {
+  const st = { text, wholeWrites: 0, subWrites: [] }
+  const range = {
+    get text() { return st.text },
+    set text(v) { st.wholeWrites++; st.text = String(v) },
+    load() {},
+    getSubstring(start, length) {
       return {
-        isNullObject: false,
-        hasText: !!text,
-        textRange: { text, load() {} },
-        load() {}
+        load() {},
+        get text() { return st.text.slice(start, start + length) },
+        set text(v) {
+          st.subWrites.push({ start, length, value: String(v) })
+          st.text = st.text.slice(0, start) + String(v) + st.text.slice(start + length)
+        }
       }
     }
+  }
+  const frame = { isNullObject: false, get hasText() { return !!st.text }, textRange: range, load() {} }
+  return {
+    type: 'TextBox',
+    _state: st,
+    getTextFrameOrNullObject() { return frame }
   }
 }
 
@@ -114,5 +129,34 @@ test('PowerPointApi 1.8 不可用时静默退化成只收顶层，绝不报错',
     assert.equal(out.ok, true, `老宿主上不该报错：${out.error}`)
     const texts = out.data.slides[0].texts
     assert.deepEqual(texts, ['本页标题'], '1.8 缺失时只收顶层，与改造前一致')
+  } finally { restore() }
+})
+
+test('ppt_replace_text：只改命中的那一段，不许整框回写（整框回写会抹平框内格式与超链接）', async () => {
+  const shape = textShape('甲方应向乙方支付，甲方另行承担税费')
+  const restore = install({ supports18: true, slides: [[shape]] })
+  try {
+    const out = await executeOfficeCommand('ppt_replace_text', { searchText: '甲方', replaceText: '委托人' })
+    assert.equal(out.ok, true, out.error)
+    assert.equal(out.data.replaced, 2)
+    assert.equal(shape._state.text, '委托人应向乙方支付，委托人另行承担税费')
+    assert.equal(shape._state.wholeWrites, 0,
+      `不许对整个 TextRange 赋值（会抹平框内所有分段格式与超链接），实际整框写了 ${shape._state.wholeWrites} 次`)
+    assert.equal(shape._state.subWrites.length, 2, '应当逐处走 getSubstring')
+    // 从右到左：先改靠后那一处，左边的偏移才不会被推移
+    assert.ok(shape._state.subWrites[0].start > shape._state.subWrites[1].start,
+      `必须从右到左应用，实际顺序 ${JSON.stringify(shape._state.subWrites.map((w) => w.start))}`)
+  } finally { restore() }
+})
+
+test('ppt_replace_text：全角半角差异也要命中（锚点归一化）', async () => {
+  const shape = textShape('违约责任（含逾期利息）由甲方承担')
+  const restore = install({ supports18: true, slides: [[shape]] })
+  try {
+    const out = await executeOfficeCommand('ppt_replace_text', {
+      searchText: '违约责任(含逾期利息)', replaceText: '违约责任'
+    })
+    assert.equal(out.ok, true, out.error)
+    assert.equal(shape._state.text, '违约责任由甲方承担')
   } finally { restore() }
 })

--- a/office-addin/taskpane/lib/officePptShapes.test.js
+++ b/office-addin/taskpane/lib/officePptShapes.test.js
@@ -1,0 +1,118 @@
+/**
+ * Office/PowerPoint 面的形状遍历（dev-board#288）：
+ *   node --test office-addin/taskpane/lib/officePptShapes.test.js
+ *
+ * 病灶：`loadPptTextFrames` 只对顶层形状取 `getTextFrameOrNullObject()`，
+ * **组合形状（group）里的文字完全不可达**——而演示稿里图示+标注、SmartArt 转出来的
+ * 内容恰恰都是组合。用户看着满屏字，AI 说这页没这段内容。
+ * WPS 面（wpsWppHandlers.textBearingShapes）早就按三条路收，Office 面此前只有一条。
+ *
+ * 两条不变式：
+ * 1. PowerPointApi 1.8 可用时，组合（含嵌套）里的文字要读得到；
+ * 2. 1.8 不可用时**不许报错**，退化成「只收顶层」——与改造前逐字一致。
+ *    老宿主上不该因为想多读一点就把整条命令打死。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+function textShape(text) {
+  return {
+    type: 'TextBox',
+    getTextFrameOrNullObject() {
+      return {
+        isNullObject: false,
+        hasText: !!text,
+        textRange: { text, load() {} },
+        load() {}
+      }
+    }
+  }
+}
+
+function groupShape(children) {
+  return {
+    type: 'Group',
+    group: {
+      shapes: {
+        items: children,
+        load() {}
+      }
+    },
+    getTextFrameOrNullObject() {
+      // 组合壳自身没有文字
+      return { isNullObject: true, hasText: false, textRange: { text: '', load() {} }, load() {} }
+    }
+  }
+}
+
+/** 装 PowerPoint 命名空间 + Office.context.requirements（版本门槛由它决定） */
+function install({ slides, supports18 }) {
+  const savedPpt = globalThis.PowerPoint
+  const savedOffice = globalThis.Office
+  globalThis.Office = {
+    HostType: { Word: 'Word', Excel: 'Excel', PowerPoint: 'PowerPoint' },
+    context: {
+      host: 'PowerPoint',
+      document: { url: 'C:/x/方案.pptx' },
+      requirements: {
+        isSetSupported: (name, ver) => {
+          if (name !== 'PowerPointApi') return false
+          if (ver === '1.4') return true
+          if (ver === '1.8') return !!supports18
+          return false
+        }
+      }
+    }
+  }
+  globalThis.PowerPoint = {
+    run: async (cb) => cb({
+      presentation: {
+        slides: {
+          items: slides.map((shapes) => ({ shapes: { items: shapes, load() {} } })),
+          load() {}
+        }
+      },
+      sync: async () => {}
+    })
+  }
+  return () => {
+    if (savedPpt === undefined) delete globalThis.PowerPoint; else globalThis.PowerPoint = savedPpt
+    if (savedOffice === undefined) delete globalThis.Office; else globalThis.Office = savedOffice
+  }
+}
+
+const { executeOfficeCommand } = await import('./officeExecutor.js')
+
+test('组合形状里的文字要读得到（含组合套组合）', async () => {
+  const restore = install({
+    supports18: true,
+    slides: [[
+      textShape('本页标题'),
+      groupShape([
+        textShape('图示标注甲'),
+        groupShape([textShape('嵌套标注乙')])
+      ])
+    ]]
+  })
+  try {
+    const out = await executeOfficeCommand('ppt_get_slides', {})
+    assert.equal(out.ok, true, out.error)
+    const texts = out.data.slides[0].texts
+    assert.ok(texts.includes('本页标题'))
+    assert.ok(texts.includes('图示标注甲'), `组合子形状文字应读到，实际 ${JSON.stringify(texts)}`)
+    assert.ok(texts.includes('嵌套标注乙'), '组合套组合也要递归')
+  } finally { restore() }
+})
+
+test('PowerPointApi 1.8 不可用时静默退化成只收顶层，绝不报错', async () => {
+  const restore = install({
+    supports18: false,
+    slides: [[textShape('本页标题'), groupShape([textShape('看不到的标注')])]]
+  })
+  try {
+    const out = await executeOfficeCommand('ppt_get_slides', {})
+    assert.equal(out.ok, true, `老宿主上不该报错：${out.error}`)
+    const texts = out.data.slides[0].texts
+    assert.deepEqual(texts, ['本页标题'], '1.8 缺失时只收顶层，与改造前一致')
+  } finally { restore() }
+})

--- a/office-addin/taskpane/lib/wordDoc.js
+++ b/office-addin/taskpane/lib/wordDoc.js
@@ -62,14 +62,26 @@ async function readExcelSheet() {
     const sheet = context.workbook.worksheets.getActiveWorksheet()
     sheet.load('name')
     const used = sheet.getUsedRangeOrNullObject(true)
-    used.load('values,address,isNullObject')
+    // **先只取尺寸，不取值**（dev-board#288）：既然只展示前 MAX_EXCEL_ROWS 行，
+    // 把整片已用区域的 values 编组过桥就是白搬——几万行的台账「一问就卡死几十秒」，
+    // 而且卡的是同步桥上的任务窗格。WPS 面（wpsDoc.readEtSheet）早就是「先 Resize
+    // 再取 Value2」，Office 面一直没跟。截断必须发生在过桥之前。
+    used.load('address,isNullObject,rowIndex,columnIndex,rowCount,columnCount')
     await context.sync()
     if (used.isNullObject) return `工作表「${sheet.name}」为空`
-    const rows = used.values.slice(0, MAX_EXCEL_ROWS)
+    const totalRows = used.rowCount
+    const shownRows = Math.min(totalRows, MAX_EXCEL_ROWS)
+    // getRangeByIndexes 是 ExcelApi 1.1，无版本门槛
+    const slice = shownRows < totalRows
+      ? sheet.getRangeByIndexes(used.rowIndex, used.columnIndex, shownRows, used.columnCount)
+      : used
+    slice.load('values')
+    await context.sync()
+    const rows = slice.values || []
     const lines = rows.map((row) => row.map((v) => (v == null ? '' : String(v))).join('\t'))
     let out = `工作表「${sheet.name}」（区域 ${used.address}）：\n` + lines.join('\n')
-    if (used.values.length > MAX_EXCEL_ROWS) {
-      out += `\n...（共 ${used.values.length} 行，仅附前 ${MAX_EXCEL_ROWS} 行）`
+    if (totalRows > MAX_EXCEL_ROWS) {
+      out += `\n...（共 ${totalRows} 行，仅附前 ${MAX_EXCEL_ROWS} 行）`
     }
     return out
   })

--- a/office-addin/taskpane/lib/wpsWordHandlers.js
+++ b/office-addin/taskpane/lib/wpsWordHandlers.js
@@ -1702,19 +1702,31 @@ export const WPS_WORD_HANDLERS = {
 
   async edit_header_footer(args) {
     const part = args.part === 'footer' ? 'footer' : 'header'
-    const text = args.text == null ? '' : String(args.text)
+    // **没给 text 就不许动文字**（dev-board#288）：旧写法无条件整替，
+    // 模型只想改对齐方式（不传 text）时，text 兜底成空串，一调用就把用户的页眉清空，
+    // 返回值还报成功。显式传空串仍然是「清空」这个合法意图，两者必须分开。
+    const hasText = args.text != null
+    const text = hasText ? String(args.text) : ''
     const alignment = args.alignment == null ? null : toEnumValue(ALIGNMENTS, args.alignment, 'alignment')
+    if (!hasText && !alignment) {
+      throw new Error('edit_header_footer 需要至少给 text（要写入的文字，传空串表示清空）或 alignment 之一')
+    }
     const doc = activeDoc()
     return withTracking(doc, () => {
       const section = doc.Sections.Item(1)
       const hf = (part === 'footer' ? section.Footers : section.Headers).Item(wdHeaderFooterPrimary)
       // 页眉/页脚在独立 story，偏移与正文互不相干；整替与 Office 面 insertText(replace) 同语义
-      hf.Range.Text = normalizeNewlines(text)
+      if (hasText) hf.Range.Text = normalizeNewlines(text)
       if (alignment != null) {
         // 一把设全部段落（ParagraphFormat 作用于 Range 内所有段落）
         hf.Range.ParagraphFormat.Alignment = alignment
       }
-      return { part, textLength: text.length, alignment: args.alignment || null }
+      return {
+        part,
+        textUpdated: hasText,
+        textLength: hasText ? text.length : null,
+        alignment: args.alignment || null
+      }
     })
   },
 

--- a/office-addin/taskpane/lib/wpsWordHandlers.test.js
+++ b/office-addin/taskpane/lib/wpsWordHandlers.test.js
@@ -232,7 +232,24 @@ function installWps(opts = {}) {
     }
   }
 
+  // 页眉/页脚（独立 story）。state.hf 记录被写过什么，用来钉住
+  // 「只给 alignment 时不许动文字」这条（dev-board#288）。
+  state.hf = { header: { text: opts.headerText || '原页眉', writes: 0, alignment: null } }
+  const headerRange = {
+    get Text() { return state.hf.header.text },
+    set Text(v) { state.hf.header.writes++; state.hf.header.text = String(v) },
+    ParagraphFormat: {
+      set Alignment(v) { state.hf.header.alignment = v },
+      get Alignment() { return state.hf.header.alignment }
+    }
+  }
+  const sectionObj = {
+    Headers: { Item: () => ({ Range: headerRange }) },
+    Footers: { Item: () => ({ Range: headerRange }) }
+  }
+
   const doc = {
+    Sections: { Item: () => sectionObj },
     get TrackRevisions() {
       if (opts.trackBroken) throw new Error('mock：TrackRevisions 不可用')
       return state.track
@@ -927,4 +944,29 @@ test('replace_text：replaceAll + 偏移失准 = 整体切纯 Find 循环，计�
   assert.equal(data.via, 'fullReplace')
   assert.equal(data.fallbacks, 3)
   assert.equal(state.calls.filter((c) => c.name === 'Find.Execute').length, 3)
+})
+
+/* ============ edit_header_footer：只给 alignment 不许清空页眉（dev-board#288） ============ */
+
+test('edit_header_footer：只改对齐方式时绝不许动页眉文字', async () => {
+  // 旧写法无条件整替，text 兜底成空串——模型只想改对齐，一调用就把用户的页眉清空，
+  // 返回值还报成功。律师的页眉常是所名/文号，清掉了很难第一时间发现。
+  const { state } = installWps({ text: '正文\r', headerText: '某某律师事务所' })
+  const out = await H.edit_header_footer({ part: 'header', alignment: 'center' })
+  assert.equal(state.hf.header.text, '某某律师事务所', '页眉文字不该被动')
+  assert.equal(state.hf.header.writes, 0, `不该对页眉 Range.Text 赋值，实际写了 ${state.hf.header.writes} 次`)
+  assert.equal(out.textUpdated, false, '返回值要如实说没改文字')
+  assert.ok(state.hf.header.alignment != null, '对齐方式应当改到')
+})
+
+test('edit_header_footer：显式传空串仍然是「清空」这个合法意图', async () => {
+  const { state } = installWps({ text: '正文\r', headerText: '某某律师事务所' })
+  const out = await H.edit_header_footer({ part: 'header', text: '' })
+  assert.equal(state.hf.header.text, '')
+  assert.equal(out.textUpdated, true)
+})
+
+test('edit_header_footer：text 与 alignment 都不给时报错，而不是静默清空', async () => {
+  installWps({ text: '正文\r', headerText: '某某律师事务所' })
+  await assert.rejects(H.edit_header_footer({ part: 'header' }), /至少给 text.*或 alignment/)
 })


### PR DESCRIPTION
2026-08-30 那轮审计里「对抗式复核确认、发版时没修」的 10 条，本 PR 修掉 9 条。

## 修了什么

| 严重度 | 问题 | 修法 |
|---|---|---|
| high | Excel 面每问一句都把整片已用区域编组过桥后才截断 | 截断挪到过桥之前：先只 load 尺寸，再用 `getRangeByIndexes`（ExcelApi 1.1）取截断后区间。`excel_get_range` 同款 |
| medium | Office/PPT 组合形状里的文字完全不可达 | `loadPptTextFrames` 支持组合递归。`Shape.group`/`ShapeGroup.shapes` 经**微软官方文档核实**是 PowerPointApi 1.8，**1.8 不可用时静默退化只收顶层、绝不报错** |
| medium | `ppt_replace_text` 整框回写抹平框内格式与超链接还报成功 | 改逐处 `getSubstring`，**从右到左应用**；顺带接上锚点归一化 |
| medium | `edit_header_footer` 只想改对齐就把页眉清空 | 没给 text 就不动文字（两个家族同修）；显式空串仍是「清空」；都不给时报错。返回值加 `textUpdated` |
| low | 透视表目标地址跨表不可达 | 新增 `splitSheetQualifiedAddress`（含 `'带空格 表'!A1` 引号包裹） |
| low | 透视表先建后校验，字段拼错留下空表 | 建表 → 读层级名 → 全对得上才继续，对不上删表再报错并列出可用字段 |
| low | 保护工作表的密码在旧宿主被静默忽略 | ExcelApi 1.7 守卫 + 回读 `protection.protected`。安全动作不许静默降级 |
| low | `ppt_add_slide` position 语义与描述差一位 | 两个执行器一致，改的是工具描述 |

## 唯一没修那条，以及为什么

`standard-format-revision-flood`（Office 面 `apply_standard_format` 逐段落笔，WPS 面已按 run 合并）。

**不是没时间，是缺一个真机判据。** WPS 那次合并是维护者按真机观察到的「每段一条修订」裁决的；
Word 是否会自动合并相邻同款格式修订，本机验证不了。而且 Office.js 里 `Range` 只能整段设 `font`，
`lineSpacing`/`spaceAfter`/`firstLineIndent` 仍须逐段设——照搬 WPS 的一次落笔在 Office 面没有对应写法，
`expandTo` 拼出来的区间又缺少 WPS 那条 `merged.Paragraphs.Count === run 段数` 安全阀。
在整篇文档的格式路径上按未经验证的假设改，风险是「半篇文档格式被刷坏」，比多几十条格式修订严重得多。

## 另外

顺手修了一条**挡住 v0.28.0 发版**的抖动用例：`MeetingTranscriptionServiceTest` 把共享的
`MeetingRecording` 对象存下来、等两个线程 join 完才读状态，读到的是 A 线程异步后续写进去的 FAILED。
改成在 B 线程里当场取快照，被测语义未动。不声称「证明不再抖」——竞态证不了否命题。

## 验证

- `npm test` 293 通过（新增 officeExcelRead 2 / officePptShapes 4 / wpsWordHandlers 3）
- 每组新用例都验证过「还原病灶即转红」
- `mvn compile` 通过；`npm run build` 通过

**这一轮踩到第三次同款陷阱并已写进纪律**：还原病灶的脚本只 `assert pattern in s`，
挡得住「找不到」挡不住「不唯一」——`if (pptApiSupported('1.8')) {` 在 officeExecutor.js 里有两处，
第一版 sabotage 打到了 `ppt_add_slide` 的 moveTo 分支上，用例照样绿。此后一律 assert 出现次数为 1。

dev-board#288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
