### PR TITLE
ci(desktop): 治住 drawio 测试在 Windows 上拦发版的 EPERM（dev-board#146 复发）

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -129,6 +129,28 @@ jobs:
           fi
           [ "$SKIP" = "1" ] && echo "SKIP_DRAWIO_TESTS=1" >> "$GITHUB_ENV"
           echo "drawio tests: $([ "$SKIP" = "1" ] && echo SKIPPED || echo FULL)"
+      # Windows runner 上 Defender 实时扫描会给刚落盘的临时文件加排他句柄，
+      # drawio-server 测试的 t.after 删临时目录时报 EPERM（hookFailed），
+      # 断言全过、只有清理失败，却把整个发版拦下——v0.25.1/#609/v0.26.0/v0.27.5/v0.28.0
+      # 都被咬过（dev-board#146）。PR 上靠「没碰 drawio 就跳过」绕开了，
+      # 而 tag 发版永远全量跑，于是这个坑专挑发版咬。
+      #
+      # 这一步直接治病根：把 runner 的 Temp 目录加进 Defender 排除项。
+      # **失败不许中断构建**（|| true）：部分 runner 镜像本来就禁用了 Defender，
+      # 或者不给加排除项——那种情况下退回测试侧的 EPERM 兜底（drawio-server.test.js
+      # 的 rmrf），不该因为"加排除项没成功"就把发版拦了。
+      - name: Exclude runner Temp from Defender (Windows EPERM guard)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          try {
+            Add-MpPreference -ExclusionPath $env:RUNNER_TEMP -ErrorAction Stop
+            Add-MpPreference -ExclusionPath $env:TEMP -ErrorAction Stop
+            Write-Host "Defender exclusions added: $env:RUNNER_TEMP ; $env:TEMP"
+          } catch {
+            Write-Host "Defender exclusion not applied (harmless): $($_.Exception.Message)"
+          }
       - name: Desktop unit tests
         working-directory: desktop
         # drawio 测试曾在 Windows 上锁死 110 分钟不退出（v0.26.0 首发 run）：

--- a/desktop/tests/drawio-server.test.js
+++ b/desktop/tests/drawio-server.test.js
@@ -74,6 +74,38 @@ async function rmrf(dir) {
   }
 }
 
+/**
+ * **teardown 专用**的目录清理：删不掉时不掀掉整场发版。
+ *
+ * 为什么单开一个而不是改 rmrf：rmrf 是「诚实重试」，语义不能动——真删不掉就该抛。
+ * 但抛在 `t.after` 里就是 hookFailed，而这时**断言已经全部通过了**，
+ * 失败的只是「Windows 让不让你删这个临时文件」，与被测行为毫无关系。
+ * 这个坑已经拦过 v0.25.1 / #609 / v0.26.0 / v0.27.5 / v0.28.0 五次发版（dev-board#146）：
+ * PR 上靠「没碰 drawio 就跳过」绕开了，而 tag 发版永远全量跑，于是它专挑发版咬。
+ * 治本的一手在 CI 侧（desktop-build.yml 给 runner Temp 加 Defender 排除项），
+ * 这里是那一手不生效时的兜底。
+ *
+ * 放行范围卡到最窄，别把它变成「清理失败一律不管」：
+ *   - 只在 win32 且 CI 上放行（本机开发照旧抛，免得真有句柄泄漏被埋掉）；
+ *   - 只放行 EPERM / EBUSY（Defender 锁文件的形态），其余错误码原样抛；
+ *   - 放行时大声打日志，留下痕迹。
+ * 一次性 runner 上留个临时目录是无害的；把发版拦住不是。
+ */
+const TOLERATE_CLEANUP_EPERM = process.platform === 'win32' && !!process.env.CI
+
+async function cleanupDir(dir) {
+  try {
+    return await rmrf(dir)
+  } catch (e) {
+    if (TOLERATE_CLEANUP_EPERM && (e.code === 'EPERM' || e.code === 'EBUSY')) {
+      console.warn('[drawio-test] 清理临时目录失败但不阻断（Windows CI 上 Defender 锁文件）：'
+        + `${dir} — ${e.code}: ${e.message}`)
+      return undefined
+    }
+    throw e
+  }
+}
+
 function get(origin, urlPath) {
   return new Promise((resolve, reject) => {
     http
@@ -115,7 +147,7 @@ test('烙好之后能起、能取文件、挡得住路径穿越', async (t) => {
     // 不关服务的话 node --test 的事件循环永远不空，测试跑完也不退出
     await stopDrawioServer()
     fs.rmSync(outside, { force: true })
-    await rmrf(root)
+    await cleanupDir(root)
   })
 
   assert.strictEqual(await isAvailable(), true)
@@ -146,8 +178,8 @@ test('pack 根命中：内置资源缺失时从 pack 提供文件', async (t) =>
   process.env.AIWORKDECK_PACKS_DIR = packsDir
   t.after(async () => {
     await stopDrawioServer()
-    await rmrf(emptyBuiltin)
-    await rmrf(packsDir)
+    await cleanupDir(emptyBuiltin)
+    await cleanupDir(packsDir)
   })
 
   assert.strictEqual(await isAvailable(), true, '内置根没有 index.html，应当落到 pack 根')
@@ -165,8 +197,8 @@ test('revoked:true 的 pack 版本不参与解析', async (t) => {
   process.env.AIWORKDECK_DRAWIO_DIR = emptyBuiltin
   process.env.AIWORKDECK_PACKS_DIR = packsDir
   t.after(async () => {
-    await rmrf(emptyBuiltin)
-    await rmrf(packsDir)
+    await cleanupDir(emptyBuiltin)
+    await cleanupDir(packsDir)
   })
 
   assert.strictEqual(await isAvailable(), false, 'current.json 标了 revoked，pack 根不该被当成可用')
@@ -180,8 +212,8 @@ test('版本目录缺 .pack-complete 时不参与解析', async (t) => {
   process.env.AIWORKDECK_DRAWIO_DIR = emptyBuiltin
   process.env.AIWORKDECK_PACKS_DIR = packsDir
   t.after(async () => {
-    await rmrf(emptyBuiltin)
-    await rmrf(packsDir)
+    await cleanupDir(emptyBuiltin)
+    await cleanupDir(packsDir)
   })
 
   assert.strictEqual(await isAvailable(), false, '没有 .pack-complete 说明安装事务未完成，不该被当成可用')
@@ -197,8 +229,8 @@ test('内置根优先于 pack 根', async (t) => {
   process.env.AIWORKDECK_PACKS_DIR = packsDir
   t.after(async () => {
     await stopDrawioServer()
-    await rmrf(builtinDir)
-    await rmrf(packsDir)
+    await cleanupDir(builtinDir)
+    await cleanupDir(packsDir)
   })
 
   const { origin } = await startDrawioServer()
@@ -230,8 +262,8 @@ test('读流中途出错只失败这一个请求，不能掀掉整个进程', as
   t.after(async () => {
     await stopDrawioServer()
     fs.chmodSync(locked, 0o600)
-    await rmrf(dir)
-    await rmrf(emptyPacks)
+    await cleanupDir(dir)
+    await cleanupDir(emptyPacks)
   })
 
   const { origin } = await startDrawioServer()

--- a/desktop/tests/workflow-release-gating.test.js
+++ b/desktop/tests/workflow-release-gating.test.js
@@ -160,3 +160,31 @@ test('desktop-build.yml：marker 必须有 always() 的清理步骤，否则失�
   assert.equal(String(cleanup.if || '').trim(), 'always()',
     '清理步骤必须 if: always()——只在成功时清等于「失败那次留下的残留最坏」')
 })
+
+// drawio-server 测试在 Windows runner 上被 Defender 锁临时文件、清理钩子报 EPERM，
+// 已经拦过 v0.25.1 / #609 / v0.26.0 / v0.27.5 / v0.28.0 五次发版（dev-board#146）。
+// PR 上靠「没碰 drawio 就跳过」绕开，而 tag 发版永远全量跑——所以它专挑发版咬。
+// 治本的一手是给 runner 的 Temp 目录加 Defender 排除项，且必须排在跑测试之前。
+test('desktop-build.yml：Windows 腿必须在跑单元测试之前给 Temp 加 Defender 排除项', () => {
+  const doc = loadWorkflow('desktop-build.yml')
+  const build = doc.jobs && doc.jobs.build
+  assert.ok(build, 'build job 应存在')
+  const steps = build.steps || []
+  const exclusionIdx = steps.findIndex((s) =>
+    typeof s.name === 'string' && /Defender/i.test(s.name))
+  const testIdx = steps.findIndex((s) =>
+    typeof s.name === 'string' && /Desktop unit tests/i.test(s.name))
+
+  assert.ok(exclusionIdx >= 0, '缺少 Defender 排除项步骤——它是 Windows EPERM 拦发版的治本手')
+  assert.ok(testIdx >= 0, '找不到 Desktop unit tests 步骤')
+  assert.ok(exclusionIdx < testIdx,
+    `Defender 排除项必须排在单元测试之前（实际 ${exclusionIdx} vs ${testIdx}）`)
+
+  const step = steps[exclusionIdx]
+  assert.match(String(step.if || ''), /runner\.os\s*==\s*'Windows'/,
+    'Defender 排除项只该在 Windows 腿跑')
+  // 加排除项失败不许拦构建：部分 runner 镜像禁用了 Defender 或不给加，
+  // 那种情况下退回测试侧的 EPERM 兜底即可，不该因此把发版拦了。
+  assert.equal(step['continue-on-error'], true,
+    'Defender 排除项失败不许中断构建（continue-on-error 必须为 true）')
+})


### PR DESCRIPTION
这个坑已经拦过 **v0.25.1 / #609 / v0.26.0 / v0.27.5 / v0.28.0 五次发版**。

形态：drawio-server 测试在系统 Temp 里造目录、写 30 字节的 index.html，测完 `t.after` 删不掉——Defender 实时扫描拿着排他句柄，`rm` 内部 `lstat` 报 EPERM。**断言 79 通过、0 失败，挂的纯粹是清理钩子**，却把整条发版拦下。既有缓解是「PR 上没碰 drawio 就跳过」，而 tag 发版永远全量跑，所以它专挑发版咬。

## 两手一起上

1. **治本（CI 侧）**：Windows 腿在跑单元测试**之前**给 `RUNNER_TEMP` / `TEMP` 加 Defender 排除项。加不上不许中断构建——部分 runner 镜像禁用了 Defender 或不给加，那种情况退回第 2 手。
2. **兜底（测试侧）**：teardown 专用的 `cleanupDir`。**不动 `rmrf` 的语义**（作者写明「诚实重试，不跳过、不吞其它错误码」），放行范围卡到最窄：只在 win32 且 CI、只对 EPERM/EBUSY、放行时大声打日志。本机开发照旧抛。

## 不是走「压缩再解压」那条路

维护者提过能不能照 mac 的 pysvc 单包首启解压来治。查下来那条路治的是**打包/签名**（多碎文件），而这里失败的临时文件是**测试自己在运行时造的**，与 drawio 以什么形态进安装包无关——drawio 也不在 `extraResources` 里，它烙在 `frontend/dist`。所以那条路对这个失败不起作用。

（drawio 裁剪后仍有约 45MB 碎文件落盘，对 mac 签名/公证耗时确实是负担，那是**另一个**值得单独立卡的问题。）

## 验证
- `workflow-release-gating.test.js` 新增用例钉住「排除项存在、只在 Windows 跑、排在单元测试之前、continue-on-error」，**已验证把它挪到测试之后即转红**
- desktop `npm test` 81 通过

dev-board#146

🤖 Generated with [Claude Code](https://claude.com/claude-code)