### PR TITLE
feat(installer): Windows 单包双架构——x64 全量 + arm64 原生 Electron 壳覆盖层（dev-board#341）

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -663,6 +663,23 @@ jobs:
         run: |
           # 与 macOS 同构：安装包只带一个 pysvc.tar.gz（文件数大降、安装更快），首启解压
           node desktop/scripts/pack-pysvc.js --bundle desktop/bundled/win-x64
+      - name: Build arm64 Electron shell overlay (Windows)
+        # Windows 单包双架构（dev-board#341）：产出纯 arm64 壳目录供 NSIS
+        # customInstall 覆盖用。app.asar 无原生依赖双架构通用，剪掉 resources/
+        #（几 GB 的 x64 重资源）后只剩 Electron 运行时约 120MB。
+        if: runner.os == 'Windows'
+        working-directory: desktop
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        shell: pwsh
+        run: |
+          npx electron-builder --dir --arm64
+          if (-not (Test-Path 'release\win-arm64-unpacked\AI WorkDeck.exe')) { throw 'arm64 unpacked dir missing' }
+          Remove-Item -Recurse -Force 'release\win-arm64-unpacked\resources'
+          New-Item -ItemType Directory -Force 'build\win\arm64-shell' | Out-Null
+          Move-Item 'release\win-arm64-unpacked\*' 'build\win\arm64-shell\'
+          Remove-Item -Recurse -Force 'release\win-arm64-unpacked'
+          "arm64 shell files: $((Get-ChildItem -Recurse 'build\win\arm64-shell' | Measure-Object Length -Sum).Sum / 1MB) MB"
       - name: Render one-click installer art (Windows)
         # 一键安装 UI（awd-oneclick-ui.nsh，dev-board#339）的位图构建现场渲染、
         # 不入库；缺了这步 NSIS 编译会因 File 找不到 generated/*.bmp 直接失败

--- a/.github/workflows/installer-ui-smoke.yml
+++ b/.github/workflows/installer-ui-smoke.yml
@@ -65,10 +65,18 @@ jobs:
           path: shots/
           if-no-files-found: warn
 
+      - name: Upload rendered art for the ARM job
+        uses: actions/upload-artifact@v4
+        with:
+          name: oneclick-art-desktop
+          path: desktop/build/win/generated/
+          retention-days: 1
+
   # 真 ARM64 Windows（public 仓才有的 windows-11-arm runner）：验证一键 UI 在
   # ARM 上的实际表现（NSIS 产物是 x86，走系统转译层），并断言双架构检测判据
   #（dev-board#341 的 customInstall 用同一注册表位）。探索性 job，失败不拦主 job。
   smoke-arm:
+    needs: smoke
     runs-on: windows-11-arm
     timeout-minutes: 25
     continue-on-error: true
@@ -84,28 +92,32 @@ jobs:
           if ($out -notmatch 'ARM64') { throw "native arch not ARM64: $out" }
           Write-Host 'detection ok: ARM64'
 
-      - name: Ensure Chrome / ImageMagick / NSIS
+      - name: Ensure NSIS
         shell: pwsh
         run: |
-          if (-not (Test-Path 'C:\Program Files\Google\Chrome\Application\chrome.exe')) {
-            choco install googlechrome -y --no-progress --ignore-checksums
-          }
-          if (-not (Get-Command magick -ErrorAction SilentlyContinue)) {
-            choco install imagemagick -y --no-progress
-          }
           if (-not (Get-Command makensis -ErrorAction SilentlyContinue)) {
             choco install nsis -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\Program Files (x86)\NSIS'
           }
 
-      - name: Render art + compile harness (zh)
+      # 位图复用 x64 job 的渲染产物：ARM runner 镜像的 ImageMagick 缺模块注册表
+      #（RegistryKeyLookupFailed，连 PNG 都解不了，首轮真机 run 实锤），而位图
+      # 本来就与架构无关，没必要在 ARM 上再渲染一遍
+      - name: Download rendered art from x64 job
+        uses: actions/download-artifact@v4
+        with:
+          name: oneclick-art-desktop
+          path: desktop/build/win/generated/
+
+      - name: Compile harness (zh)
         shell: pwsh
         run: |
           $ws = $env:GITHUB_WORKSPACE
-          node desktop/scripts/render-oneclick-art.mjs --product desktop --out desktop/build/win/generated --version 9.9.9
           New-Item -ItemType Directory -Force payload | Out-Null
           1..4 | ForEach-Object { fsutil file createnew ("payload\blob$_.bin") 41943040 }
           makensis /INPUTCHARSET UTF8 /DHARNESS_LANG=SimpChinese "/DGENART=$ws\desktop\build\win\generated" "/DPAYLOAD=$ws\payload" "/DOUTFILE=$ws\harness-zh.exe" desktop\build\win\ui-harness.nsi
+          if ($LASTEXITCODE -ne 0) { throw "makensis failed" }
+          if (-not (Test-Path "$ws\harness-zh.exe")) { throw 'harness exe missing' }
 
       - name: Drive harness with screenshots (ARM real machine)
         shell: pwsh

--- a/.github/workflows/installer-ui-smoke.yml
+++ b/.github/workflows/installer-ui-smoke.yml
@@ -7,7 +7,7 @@ name: installer-ui-smoke
 
 on:
   push:
-    branches: [claude/installer-oneclick-ui]
+    branches: [claude/installer-oneclick-ui, claude/win-dual-arch]
   workflow_dispatch:
 
 jobs:
@@ -63,4 +63,56 @@ jobs:
         with:
           name: installer-ui-shots
           path: shots/
+          if-no-files-found: warn
+
+  # 真 ARM64 Windows（public 仓才有的 windows-11-arm runner）：验证一键 UI 在
+  # ARM 上的实际表现（NSIS 产物是 x86，走系统转译层），并断言双架构检测判据
+  #（dev-board#341 的 customInstall 用同一注册表位）。探索性 job，失败不拦主 job。
+  smoke-arm:
+    runs-on: windows-11-arm
+    timeout-minutes: 25
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert native arch detection reads ARM64
+        shell: pwsh
+        run: |
+          $out = reg query 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' /v PROCESSOR_ARCHITECTURE
+          if ($out -notmatch 'ARM64') { throw "native arch not ARM64: $out" }
+          Write-Host 'detection ok: ARM64'
+
+      - name: Ensure Chrome / ImageMagick / NSIS
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'C:\Program Files\Google\Chrome\Application\chrome.exe')) {
+            choco install googlechrome -y --no-progress --ignore-checksums
+          }
+          if (-not (Get-Command magick -ErrorAction SilentlyContinue)) {
+            choco install imagemagick -y --no-progress
+          }
+          if (-not (Get-Command makensis -ErrorAction SilentlyContinue)) {
+            choco install nsis -y --no-progress
+            Add-Content $env:GITHUB_PATH 'C:\Program Files (x86)\NSIS'
+          }
+
+      - name: Render art + compile harness (zh)
+        shell: pwsh
+        run: |
+          $ws = $env:GITHUB_WORKSPACE
+          node desktop/scripts/render-oneclick-art.mjs --product desktop --out desktop/build/win/generated --version 9.9.9
+          New-Item -ItemType Directory -Force payload | Out-Null
+          1..4 | ForEach-Object { fsutil file createnew ("payload\blob$_.bin") 41943040 }
+          makensis /INPUTCHARSET UTF8 /DHARNESS_LANG=SimpChinese "/DGENART=$ws\desktop\build\win\generated" "/DPAYLOAD=$ws\payload" "/DOUTFILE=$ws\harness-zh.exe" desktop\build\win\ui-harness.nsi
+
+      - name: Drive harness with screenshots (ARM real machine)
+        shell: pwsh
+        run: pwsh -File desktop/scripts/installer-smoke.ps1 -Exe harness-zh.exe -OutDir shots-arm/zh
+
+      - name: Upload ARM screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-ui-shots-arm
+          path: shots-arm/
           if-no-files-found: warn

--- a/.github/workflows/installer-ui-smoke.yml
+++ b/.github/workflows/installer-ui-smoke.yml
@@ -78,7 +78,9 @@ jobs:
       - name: Assert native arch detection reads ARM64
         shell: pwsh
         run: |
-          $out = reg query 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' /v PROCESSOR_ARCHITECTURE
+          # reg query 输出是行数组：-notmatch 对数组做过滤不是布尔，必须先拼成串
+          #（首轮真机 run 实锤：值明明是 ARM64 断言却红）
+          $out = (reg query 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' /v PROCESSOR_ARCHITECTURE) | Out-String
           if ($out -notmatch 'ARM64') { throw "native arch not ARM64: $out" }
           Write-Host 'detection ok: ARM64'
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,5 @@ desktop/bundled/
 
 # 一键安装器位图（构建现场渲染，几十 MB 不入库，dev-board#339）
 desktop/build/win/generated/
+desktop/build/win/arm64-shell/
 office-addin/installer/win/generated/

--- a/desktop/build/installer.nsh
+++ b/desktop/build/installer.nsh
@@ -42,3 +42,23 @@
 !macro customFinishPage
   !insertmacro AWD_UI_PAGE_FINISH
 !macroend
+
+!macro customInstall
+  ; Windows 单包双架构（dev-board#341）：主体照旧是 x64 全量（后端 javacv 无
+  ; windows-arm64 natives，Python 侧同样，只能留在转译层跑）；安装器额外携带一份
+  ; 纯 arm64 Electron 壳（app.asar 零原生依赖、双架构通用，壳只有运行时文件，
+  ; 压缩后约 +45MB）。装到 ARM64 Windows 时覆盖到 $INSTDIR，渲染与 LOWA WASM
+  ; 走原生，重计算留在转译层由 #340 的看门狗兜住。x64 机器上这段不执行。
+  ; 壳目录由 desktop-build.yml 在打包前用 electron-builder --dir --arm64 生成并
+  ; 剪掉 resources/；本地无此目录时降级为纯 x64 安装器（只提示不报错，-WX 下
+  ; !warning 会打断编译）。
+  !if /FileExists "${BUILD_RESOURCES_DIR}\win\arm64-shell\AI WorkDeck.exe"
+    ReadRegStr $0 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "PROCESSOR_ARCHITECTURE"
+    ${If} $0 == "ARM64"
+      SetOutPath $INSTDIR
+      File /r "${BUILD_RESOURCES_DIR}\win\arm64-shell\*"
+    ${EndIf}
+  !else
+    !echo "arm64-shell 缺席：本次产物为纯 x64 安装器（CI 之外的构建路径属正常）"
+  !endif
+!macroend

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -12,6 +12,7 @@ using System;
 using System.Runtime.InteropServices;
 public class W {
   [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int w, int ht, uint f);
   [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
   [DllImport("user32.dll")] public static extern bool SetCursorPos(int x, int y);
   [DllImport("user32.dll")] public static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
@@ -29,6 +30,10 @@ while ((Get-Date) -lt $deadline) {
 }
 if ($p.MainWindowHandle -eq [IntPtr]::Zero) { throw "installer window never appeared" }
 $h = $p.MainWindowHandle
+# 置顶：ARM runner 的桌面盖着一层 OOBE 隐私设置全屏窗（真机 run 实锤：点击全打在
+# 它身上，还顺手关了微软的墨迹开关）。TOPMOST 后点击与截图必然落在安装器上，
+# 不用管背后是什么。HWND_TOPMOST=-1，SWP_NOMOVE|SWP_NOSIZE=0x3
+[W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
 [W]::SetForegroundWindow($h) | Out-Null
 Start-Sleep -Milliseconds 800
 

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -19,6 +19,7 @@ public class W {
   [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT pt);
   [DllImport("user32.dll")] public static extern IntPtr GetAncestor(IntPtr h, uint flags);
   [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("user32.dll")] public static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
   public struct RECT { public int L, T, R, B; }
   public struct POINT { public int x, y; }
 }
@@ -41,24 +42,36 @@ $h = $p.MainWindowHandle
 [W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
 [W]::SetForegroundWindow($h) | Out-Null
 Start-Sleep -Milliseconds 800
-for ($try = 0; $try -lt 6; $try++) {
-  $r0 = New-Object W+RECT
-  [W]::GetWindowRect($h, [ref]$r0) | Out-Null
-  $pt = New-Object W+POINT
-  $pt.x = [int](($r0.L + $r0.R) / 2); $pt.y = [int](($r0.T + $r0.B) / 2)
-  $top = [W]::GetAncestor([W]::WindowFromPoint($pt), 2)   # GA_ROOT
-  if ($top -eq $h) { Write-Host "line of sight clear (try $try)"; break }
-  $tpid = [uint32]0
-  [W]::GetWindowThreadProcessId($top, [ref]$tpid) | Out-Null
-  if ($tpid -ne 0 -and $tpid -ne $PID -and $tpid -ne $p.Id) {
-    $blocker = Get-Process -Id $tpid -ErrorAction SilentlyContinue
-    Write-Host "killing overlay process: $($blocker.ProcessName) (pid $tpid)"
-    Stop-Process -Id $tpid -Force -ErrorAction SilentlyContinue
+# 视线清障：目标点被别的窗口盖住时——先 ESC（关掉开始菜单/弹出层，杀 OOBE 的
+# 副作用就是弹开始菜单，真机实锤），仍在就杀掉遮挡进程，再置顶重探
+function Clear-Overlay([int]$x, [int]$y) {
+  for ($try = 0; $try -lt 6; $try++) {
+    $pt = New-Object W+POINT
+    $pt.x = $x; $pt.y = $y
+    $top = [W]::GetAncestor([W]::WindowFromPoint($pt), 2)   # GA_ROOT
+    if ($top -eq $h) { if ($try -gt 0) { Write-Host "line of sight restored (try $try)" }; return }
+    [W]::keybd_event(0x1B, 0, 0, [UIntPtr]::Zero)   # ESC down
+    [W]::keybd_event(0x1B, 0, 2, [UIntPtr]::Zero)   # ESC up
+    Start-Sleep -Milliseconds 500
+    $top2 = [W]::GetAncestor([W]::WindowFromPoint($pt), 2)
+    if ($top2 -ne $h -and $top2 -ne [IntPtr]::Zero) {
+      $tpid = [uint32]0
+      [W]::GetWindowThreadProcessId($top2, [ref]$tpid) | Out-Null
+      if ($tpid -ne 0 -and $tpid -ne $PID -and $tpid -ne $p.Id) {
+        $blocker = Get-Process -Id $tpid -ErrorAction SilentlyContinue
+        Write-Host "killing overlay process: $($blocker.ProcessName) (pid $tpid)"
+        Stop-Process -Id $tpid -Force -ErrorAction SilentlyContinue
+      }
+    }
+    Start-Sleep -Seconds 1
+    [W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
+    [W]::SetForegroundWindow($h) | Out-Null
   }
-  Start-Sleep -Seconds 1
-  [W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
-  [W]::SetForegroundWindow($h) | Out-Null
+  Write-Warning "line of sight still blocked at ($x,$y)"
 }
+$r0 = New-Object W+RECT
+[W]::GetWindowRect($h, [ref]$r0) | Out-Null
+Clear-Overlay ([int](($r0.L + $r0.R) / 2)) ([int](($r0.T + $r0.B) / 2))
 
 function Get-Rect {
   $r = New-Object W+RECT
@@ -80,6 +93,8 @@ function Shot([string]$name) {
 }
 
 function ClickAt([int]$bx, [int]$by) {
+  $r = Get-Rect
+  Clear-Overlay ($r.L + $bx) ($r.T + $by)
   $r = Get-Rect
   [W]::SetCursorPos($r.L + $bx, $r.T + $by) | Out-Null
   Start-Sleep -Milliseconds 120

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -16,7 +16,11 @@ public class W {
   [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
   [DllImport("user32.dll")] public static extern bool SetCursorPos(int x, int y);
   [DllImport("user32.dll")] public static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
+  [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT pt);
+  [DllImport("user32.dll")] public static extern IntPtr GetAncestor(IntPtr h, uint flags);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
   public struct RECT { public int L, T, R, B; }
+  public struct POINT { public int x, y; }
 }
 "@
 
@@ -30,12 +34,31 @@ while ((Get-Date) -lt $deadline) {
 }
 if ($p.MainWindowHandle -eq [IntPtr]::Zero) { throw "installer window never appeared" }
 $h = $p.MainWindowHandle
-# 置顶：ARM runner 的桌面盖着一层 OOBE 隐私设置全屏窗（真机 run 实锤：点击全打在
-# 它身上，还顺手关了微软的墨迹开关）。TOPMOST 后点击与截图必然落在安装器上，
-# 不用管背后是什么。HWND_TOPMOST=-1，SWP_NOMOVE|SWP_NOSIZE=0x3
+# 置顶 + 反遮挡：ARM runner 桌面盖着一层 OOBE 隐私设置全屏窗，且它自己也是
+# 置顶层（TOPMOST 压不过，真机两轮实锤）。用 WindowFromPoint 探测卡片中心
+# 实际最上层归属，不是我们就杀掉那个进程（runner 一次性虚机，无副作用），
+# 循环直到视线畅通。HWND_TOPMOST=-1，SWP_NOMOVE|SWP_NOSIZE=0x3
 [W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
 [W]::SetForegroundWindow($h) | Out-Null
 Start-Sleep -Milliseconds 800
+for ($try = 0; $try -lt 6; $try++) {
+  $r0 = New-Object W+RECT
+  [W]::GetWindowRect($h, [ref]$r0) | Out-Null
+  $pt = New-Object W+POINT
+  $pt.x = [int](($r0.L + $r0.R) / 2); $pt.y = [int](($r0.T + $r0.B) / 2)
+  $top = [W]::GetAncestor([W]::WindowFromPoint($pt), 2)   # GA_ROOT
+  if ($top -eq $h) { Write-Host "line of sight clear (try $try)"; break }
+  $tpid = [uint32]0
+  [W]::GetWindowThreadProcessId($top, [ref]$tpid) | Out-Null
+  if ($tpid -ne 0 -and $tpid -ne $PID -and $tpid -ne $p.Id) {
+    $blocker = Get-Process -Id $tpid -ErrorAction SilentlyContinue
+    Write-Host "killing overlay process: $($blocker.ProcessName) (pid $tpid)"
+    Stop-Process -Id $tpid -Force -ErrorAction SilentlyContinue
+  }
+  Start-Sleep -Seconds 1
+  [W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
+  [W]::SetForegroundWindow($h) | Out-Null
+}
 
 function Get-Rect {
   $r = New-Object W+RECT


### PR DESCRIPTION
用户决策：Windows 只发一个包，x64 与 ARM64 都兼容，不让用户选（mac 维持 arm64-only）。

## 为什么不是双全量
- 现装器已 1517MB，双架构全量约 3GB，不可接受；
- 后端 javacv（opencv/ffmpeg/leptonica/openblas）无 windows-arm64 natives，Python 侧（torch 等）同样——纯 arm64 后端=砍掉 OCR/多媒体。

## 落法（混合单包，约 +45MB / +3%）
- 主体照旧 x64 全量；
- CI 在打包前 `electron-builder --dir --arm64` 产出**纯 arm64 Electron 壳**（桌面壳零原生 node 依赖，app.asar 双架构通用；剪掉 resources/ 只剩运行时约 120MB）；
- NSIS `customInstall`（解压之后执行）读注册表原生 PROCESSOR_ARCHITECTURE，ARM64 机器上覆盖进安装目录：**渲染与 LOWA WASM 全原生**，JVM/Python 重计算留在转译层由 #340 看门狗兜住；
- x64 机器零变化；自动更新（/S 静默重装）同样走覆盖，更新后壳保持原生；
- 本地/无壳目录构建自动降级纯 x64 安装器（compile-time 守卫，不吃 -WX）。

## 验证
- installer-ui-smoke 新增 **windows-11-arm 真机 job**（public 仓 runner；探索性 continue-on-error）：断言检测判据读到 ARM64 + 一键 UI 全流程真机截图；
- desktop-build Windows 腿新增壳构建步骤，PR 上全量编译验证。

已知边界：Windows 10 on ARM（只带 x86 转译、无 x64 转译）后端仍起不来——此前纯 x64 包连壳都跑不起来，属既有边界不回退。

🤖 Generated with [Claude Code](https://claude.com/claude-code)