### PR TITLE
feat(auth): App 审核专用账号的固定验证码（配置开关，默认关）

### DIFF
--- a/backend/src/main/java/com/checkba/config/ReviewAccountGate.java
+++ b/backend/src/main/java/com/checkba/config/ReviewAccountGate.java
@@ -70,6 +70,15 @@ public class ReviewAccountGate {
                 + "auth.review-account.identity 关闭。", masked(id));
     }
 
+    /**
+     * 明确关闭的一个实例。给不关心这条旁路的构造点用（测试基本都是），
+     * 比 {@code new ReviewAccountGate("", "")} 读起来清楚：一眼看得出这里
+     * 是「没有旁路」，而不是「参数忘了填」。
+     */
+    public static ReviewAccountGate disabled() {
+        return new ReviewAccountGate("", "");
+    }
+
     /** 这条旁路是否开着。 */
     public boolean enabled() {
         return identity != null;

--- a/backend/src/main/java/com/checkba/config/ReviewAccountGate.java
+++ b/backend/src/main/java/com/checkba/config/ReviewAccountGate.java
@@ -1,0 +1,112 @@
+package com.checkba.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * App 审核专用账号的固定验证码。
+ *
+ * <p><b>为什么需要这个。</b>iOS 两个 App 的登录只有验证码一条路：手机号走中国
+ * 短信，邮箱走收件箱。Apple 的审核员两样都拿不到——他没有中国号码，也打不开
+ * 我们的邮箱。没有这条口子，审核员卡在首屏，App Store 审核指南 2.1
+ * （App Completeness）必拒。行业常规做法就是给审核账号配一个固定码，写进
+ * ASC 的「审核备注」。
+ *
+ * <p><b>这是一个认证旁路，按认证旁路对待：</b>
+ * <ul>
+ *   <li>默认关。两个配置项任意一个为空即全关，不存在「配了一半」的中间态。</li>
+ *   <li>只对<b>配置里那一个</b>标识生效，别的手机号/邮箱一律走原路。</li>
+ *   <li>只开在免密登录（signin）那条路上，绑定手机号/绑定邮箱不走这里。</li>
+ *   <li>码写错格式就<b>拒绝启动</b>——照 {@link PhoneLoginGuard} 的同一口径。
+ *       一个配歪了的旁路比没有旁路更糟：它会以「审核员登不进去」的形式在
+ *       几天后才暴露，而那时排查方向已经跑到客户端去了。</li>
+ * </ul>
+ *
+ * <p><b>运维要求：</b>审核账号里不要放真实数据。谁拿到那 6 位码就能登进这一个
+ * 账号，而这个码是写在 ASC 备注里给外部人看的。审核结束后把
+ * {@code auth.review-account.identity} 清空即可关掉。
+ *
+ * <p>配置（服务器 env / application.yml，别入库）：
+ * <pre>
+ *   auth.review-account.identity: appreview@example.com   # 手机号或邮箱，写规范化后的形式
+ *   auth.review-account.code: "246813"                    # 6 位数字
+ * </pre>
+ */
+@Component
+public class ReviewAccountGate {
+
+    private static final Logger log = LoggerFactory.getLogger(ReviewAccountGate.class);
+
+    private final String identity;
+    private final byte[] code;
+
+    public ReviewAccountGate(
+            @Value("${auth.review-account.identity:}") String identity,
+            @Value("${auth.review-account.code:}") String code) {
+
+        String id = identity == null ? "" : identity.trim().toLowerCase();
+        String cd = code == null ? "" : code.trim();
+
+        if (id.isEmpty() || cd.isEmpty()) {
+            this.identity = null;
+            this.code = null;
+            return;
+        }
+        if (!cd.matches("\\d{6}")) {
+            throw new IllegalStateException(
+                    "auth.review-account.code 必须是 6 位数字（当前长度 " + cd.length() + "）："
+                            + "客户端的验证码输入框只收 6 位数字，配成别的形式等于这条旁路"
+                            + "永远走不通，而症状要等审核员登不进去才看得见。");
+        }
+        this.identity = id;
+        this.code = cd.getBytes(StandardCharsets.UTF_8);
+        // 生产上开着这条口子是有意为之还是配漏了，只能靠这行日志区分。
+        log.warn("App 审核账号旁路已启用：{} 可用固定验证码登录。审核结束后清空 "
+                + "auth.review-account.identity 关闭。", masked(id));
+    }
+
+    /** 这条旁路是否开着。 */
+    public boolean enabled() {
+        return identity != null;
+    }
+
+    /**
+     * 这个标识是不是审核账号。
+     *
+     * <p>传进来的应当是各服务**规范化之后**的标识（手机号过 normalizePhone、
+     * 邮箱过 MailRouter.normalize），配置里也要写规范化后的形式——两边不一致
+     * 的表现是旁路静默失效。
+     */
+    public boolean matches(String normalizedIdentity) {
+        if (!enabled() || normalizedIdentity == null) {
+            return false;
+        }
+        return identity.equals(normalizedIdentity.trim().toLowerCase());
+    }
+
+    /**
+     * 审核账号 + 正确的固定码。
+     *
+     * <p>定长比较：这 6 位码不像一次性码那样验一次就作废，它长期有效，
+     * 逐位早退的比较在这里是有意义的侧信道。
+     */
+    public boolean accepts(String normalizedIdentity, String candidate) {
+        if (!matches(normalizedIdentity) || candidate == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(code, candidate.trim().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String masked(String id) {
+        int at = id.indexOf('@');
+        if (at > 1) {
+            return id.charAt(0) + "***" + id.substring(at);
+        }
+        return id.length() <= 4 ? "***" : id.substring(0, 3) + "****" + id.substring(id.length() - 2);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
+++ b/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
@@ -1,5 +1,6 @@
 package com.checkba.service.mail;
 
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.LangText;
@@ -40,17 +41,20 @@ public class MailAuthService {
     private final UserRepository userRepository;
     private final boolean localMode;
     private final boolean passwordlessEnabled;
+    private final ReviewAccountGate reviewAccount;
 
     @Autowired
     public MailAuthService(VerificationCodeStore codeStore, MailRouter mailRouter,
                            UserRepository userRepository,
                            @Value("${security.local-mode:false}") boolean localMode,
-                           @Value("${mail.passwordless-login-enabled:false}") boolean passwordlessEnabled) {
+                           @Value("${mail.passwordless-login-enabled:false}") boolean passwordlessEnabled,
+                           ReviewAccountGate reviewAccount) {
         this.codeStore = codeStore;
         this.mailRouter = mailRouter;
         this.userRepository = userRepository;
         this.localMode = localMode;
         this.passwordlessEnabled = passwordlessEnabled;
+        this.reviewAccount = reviewAccount;
     }
 
     /** 邮箱验证在本部署形态下是否启用（非 local-mode 且至少一条发信通道配齐）。 */
@@ -134,6 +138,11 @@ public class MailAuthService {
             throw new IllegalArgumentException(LangText.of("邮箱登录未启用", "Passwordless email sign-in is not enabled"));
         }
         String normalized = MailRouter.normalize(email);
+        // 审核账号的码是固定的，没有信要发。与「未注册」走同一条静默返回，
+        // 回包对外完全一致。
+        if (reviewAccount.matches(normalized)) {
+            return;
+        }
         if (userRepository.findByVerifiedEmail(normalized).isEmpty()) {
             return;
         }
@@ -149,6 +158,14 @@ public class MailAuthService {
             throw new IllegalArgumentException(LangText.of("邮箱登录未启用", "Passwordless email sign-in is not enabled"));
         }
         String normalized = MailRouter.normalize(email);
+        // 旁路只免掉「拿到码」这一步，**不建号**：审核账号必须事先注册好并验过
+        // 邮箱，否则下面那句 findByVerifiedEmail 照样把它挡回去。邮箱这条路本来
+        // 就只登录不建号，旁路不该顺手改掉这个语义。
+        if (reviewAccount.accepts(normalized, code)) {
+            return userRepository.findByVerifiedEmail(normalized)
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            LangText.of("验证码错误或已过期", "Incorrect or expired verification code")));
+        }
         if (!codeStore.verify(SCENE_SIGNIN, normalized, code)) {
             throw new IllegalArgumentException(LangText.of("验证码错误或已过期", "Incorrect or expired verification code"));
         }

--- a/backend/src/main/java/com/checkba/service/sms/SmsAuthService.java
+++ b/backend/src/main/java/com/checkba/service/sms/SmsAuthService.java
@@ -1,5 +1,6 @@
 package com.checkba.service.sms;
 
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.LangText;
@@ -43,14 +44,17 @@ public class SmsAuthService {
     private final VerificationCodeStore codeStore;
     private final UserRepository userRepository;
     private final boolean localMode;
+    private final ReviewAccountGate reviewAccount;
 
     @Autowired
     public SmsAuthService(List<SmsGateway> gateways, VerificationCodeStore codeStore, UserRepository userRepository,
-                          @Value("${security.local-mode:false}") boolean localMode) {
+                          @Value("${security.local-mode:false}") boolean localMode,
+                          ReviewAccountGate reviewAccount) {
         this.gateways = gateways;
         this.codeStore = codeStore;
         this.userRepository = userRepository;
         this.localMode = localMode;
+        this.reviewAccount = reviewAccount;
     }
 
     /** 短信验证在本部署形态下是否启用（任一通道可用即算启用）。 */
@@ -101,7 +105,13 @@ public class SmsAuthService {
      */
     public void sendSigninCode(String phone) {
         requireActive();
-        sendWithRollback(SCENE_SIGNIN, normalizePhone(phone));
+        String normalized = normalizePhone(phone);
+        // 审核账号的码是固定的，没有可发的东西。照常返回：回包必须与普通号码
+        // 一模一样，否则这个端点就成了「这个号是不是审核号」的探测器。
+        if (reviewAccount.matches(normalized)) {
+            return;
+        }
+        sendWithRollback(SCENE_SIGNIN, normalized);
     }
 
     /**
@@ -111,6 +121,9 @@ public class SmsAuthService {
     public String verifySigninCode(String phone, String code) {
         requireActive();
         String normalized = normalizePhone(phone);
+        if (reviewAccount.accepts(normalized, code)) {
+            return normalized;
+        }
         if (!codeStore.verify(SCENE_SIGNIN, normalized, code)) {
             throw new IllegalArgumentException(
                     LangText.of("验证码错误或已过期", "Incorrect or expired verification code"));

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -191,6 +191,16 @@ auth:
   # 格式非法会回落默认值而不是无限期放行——配错就静默延期是最难发现的失效。
   # **与官网 lib/phone-policy.ts 的 DEFAULT_BINDING_DEADLINE 同值，改一边就要改另一边。**
   phone-binding-deadline: ${AUTH_PHONE_BINDING_DEADLINE:2026-09-30}
+  # App 审核专用账号的固定验证码。见 config/ReviewAccountGate。
+  # 存在的理由：iOS 两个 App 的登录只有验证码一条路，Apple 审核员既没有中国
+  # 号码收短信、也打不开我们的邮箱，没有这条口子会卡在首屏被判 2.1。
+  # **这是认证旁路**：两项任一为空即全关；只对配置里那一个标识生效；只开在
+  # 免密登录上，绑定流程不走它；码不是 6 位数字直接拒绝启动。
+  # 审核账号里别放真实数据——那 6 位码是写在 ASC 审核备注里给外部人看的。
+  # 审核结束后把 identity 清空即可关闭。
+  review-account:
+    identity: ${AUTH_REVIEW_ACCOUNT_IDENTITY:}
+    code: ${AUTH_REVIEW_ACCOUNT_CODE:}
 
 sms:
   enabled: ${SMS_AUTH_ENABLED:false}

--- a/backend/src/test/java/com/checkba/config/PhoneBindingGateTest.java
+++ b/backend/src/test/java/com/checkba/config/PhoneBindingGateTest.java
@@ -1,5 +1,6 @@
 package com.checkba.config;
 
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.auth.VerificationCodeStore;
@@ -32,7 +33,8 @@ class PhoneBindingGateTest {
     private static SmsAuthService activeSms() {
         return new SmsAuthService(
                 List.of(new SmsService(OK_TRANSPORT, true, "ak", "sk", "sign", "tpl")),
-                new VerificationCodeStore(), mock(UserRepository.class), false);
+                new VerificationCodeStore(), mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
     }
 
     private static PhoneLoginGuard guard(boolean required, String deadline) {

--- a/backend/src/test/java/com/checkba/config/ReviewAccountGateTest.java
+++ b/backend/src/test/java/com/checkba/config/ReviewAccountGateTest.java
@@ -1,0 +1,64 @@
+package com.checkba.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 审核账号旁路。这是认证旁路，所以「关着的时候确实是关的」比「开着的时候能用」
+ * 更值得测——前者错了是安全事故，后者错了只是审核员登不进去。
+ */
+class ReviewAccountGateTest {
+
+    @Test
+    @DisplayName("两项都空 = 关闭，任何标识与码都不放行")
+    void disabledByDefault() {
+        ReviewAccountGate gate = new ReviewAccountGate("", "");
+        assertFalse(gate.enabled());
+        assertFalse(gate.matches("appreview@example.com"));
+        assertFalse(gate.accepts("appreview@example.com", "246813"));
+    }
+
+    @Test
+    @DisplayName("只配了一半也算关闭，不存在半开状态")
+    void halfConfiguredIsDisabled() {
+        assertFalse(new ReviewAccountGate("appreview@example.com", "").enabled());
+        assertFalse(new ReviewAccountGate("", "246813").enabled());
+        assertFalse(new ReviewAccountGate(null, null).enabled());
+    }
+
+    @Test
+    @DisplayName("码不是 6 位数字就拒绝启动")
+    void refusesToStartOnMalformedCode() {
+        assertThrows(IllegalStateException.class, () -> new ReviewAccountGate("a@b.com", "12345"));
+        assertThrows(IllegalStateException.class, () -> new ReviewAccountGate("a@b.com", "abcdef"));
+        assertThrows(IllegalStateException.class, () -> new ReviewAccountGate("a@b.com", "1234567"));
+        assertDoesNotThrow(() -> new ReviewAccountGate("a@b.com", "123456"));
+    }
+
+    @Test
+    @DisplayName("只对配置里那一个标识生效")
+    void onlyMatchesConfiguredIdentity() {
+        ReviewAccountGate gate = new ReviewAccountGate("appreview@example.com", "246813");
+        assertTrue(gate.matches("appreview@example.com"));
+        assertTrue(gate.matches("  AppReview@Example.com  "), "大小写与空白应被规范化");
+        assertFalse(gate.matches("someoneelse@example.com"));
+        assertFalse(gate.matches(""));
+        assertFalse(gate.matches(null));
+    }
+
+    @Test
+    @DisplayName("认标识也要认码：标识对码错、码对标识错，都不放行")
+    void requiresBothIdentityAndCode() {
+        ReviewAccountGate gate = new ReviewAccountGate("13800000000", "246813");
+        assertTrue(gate.accepts("13800000000", "246813"));
+        assertTrue(gate.accepts("13800000000", " 246813 "));
+        assertFalse(gate.accepts("13800000000", "000000"), "码错不该放行");
+        assertFalse(gate.accepts("13900000000", "246813"), "别的号码拿到码也不该放行");
+        assertFalse(gate.accepts("13800000000", null));
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AuthControllerPhoneGateTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerPhoneGateTest.java
@@ -1,6 +1,7 @@
 package com.checkba.controller;
 
 import com.checkba.config.PhoneLoginGuard;
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.AuthAbuseGuard;
@@ -61,7 +62,8 @@ class AuthControllerPhoneGateTest {
     private static PhoneLoginGuard guard(boolean required, String deadline) {
         SmsAuthService sms = new SmsAuthService(
                 List.of(new SmsService(OK_TRANSPORT, true, "ak", "sk", "sign", "tpl")),
-                new VerificationCodeStore(), mock(UserRepository.class), false);
+                new VerificationCodeStore(), mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
         return new PhoneLoginGuard(sms, required, false, deadline);
     }
 

--- a/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.checkba.service.mail;
 
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.auth.VerificationCodeStore;
@@ -53,7 +54,8 @@ class MailAuthServiceTest {
         UserRepository repo = mock(UserRepository.class);
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
         MailAuthService svc = new MailAuthService(
-                new VerificationCodeStore(), new MailRouter(List.of(gw)), repo, localMode, passwordless);
+                new VerificationCodeStore(), new MailRouter(List.of(gw)), repo, localMode, passwordless,
+                ReviewAccountGate.disabled());
         return new Fixture(svc, gw, repo);
     }
 
@@ -69,7 +71,8 @@ class MailAuthServiceTest {
 
         MailRouter empty = new MailRouter(List.of());
         assertFalse(new MailAuthService(new VerificationCodeStore(), empty,
-                mock(UserRepository.class), false, true).active(), "没有通道就不算启用");
+                mock(UserRepository.class), false, true,
+                ReviewAccountGate.disabled()).active(), "没有通道就不算启用");
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/sms/SmsAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsAuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.checkba.service.sms;
 
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.service.auth.VerificationCodeStore;
 import com.checkba.repository.UserRepository;
@@ -37,18 +38,21 @@ class SmsAuthServiceTest {
     void activeGating() {
         UserRepository repo = mock(UserRepository.class);
         VerificationCodeStore store = new VerificationCodeStore();
-        assertFalse(new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), store, repo, true).active(),
+        assertFalse(new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), store, repo, true,
+                ReviewAccountGate.disabled()).active(),
                 "local-mode 必须旁路");
-        assertTrue(new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), store, repo, false).active());
+        assertTrue(new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), store, repo, false,
+                ReviewAccountGate.disabled()).active());
         SmsService disabled = new SmsService(OK_TRANSPORT, false, "ak", "sk", "sign", "tpl");
-        assertFalse(new SmsAuthService(List.of(disabled), store, repo, false).active());
+        assertFalse(new SmsAuthService(List.of(disabled), store, repo, false, ReviewAccountGate.disabled()).active());
     }
 
     @Test
     @DisplayName("requiresCode：启用且已绑手机号才要求；存量未绑定用户不拦")
     void requiresCodeOnlyWithPhone() {
         SmsAuthService svc = new SmsAuthService(
-                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), false);
+                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
         assertTrue(svc.requiresCode(user(1, "13800000000")));
         assertFalse(svc.requiresCode(user(1, null)));
         assertFalse(svc.requiresCode(user(1, "")));
@@ -63,7 +67,8 @@ class SmsAuthServiceTest {
         SmsAuthService svc = new SmsAuthService(List.of(enabledSms((url, body, auth) -> {
             sentBody.set(body);
             return new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
-        })), store, mock(UserRepository.class), false);
+        })), store, mock(UserRepository.class), false,
+            ReviewAccountGate.disabled());
 
         User alice = user(1, "13800000000");
         assertEquals("138****0000", svc.sendLoginCode(alice));
@@ -84,7 +89,8 @@ class SmsAuthServiceTest {
         AtomicReference<Boolean> fail = new AtomicReference<>(true);
         SmsAuthService svc = new SmsAuthService(List.of(enabledSms((url, body, auth) ->
                 fail.get() ? new SmsTransport.Reply(500, "boom")
-                           : new SmsTransport.Reply(200, "{\"Code\":\"OK\"}"))), store, mock(UserRepository.class), false);
+                           : new SmsTransport.Reply(200, "{\"Code\":\"OK\"}"))), store, mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
         User alice = user(1, "13800000000");
         assertThrows(IllegalArgumentException.class, () -> svc.sendLoginCode(alice));
         fail.set(false);
@@ -96,7 +102,8 @@ class SmsAuthServiceTest {
     void bindRejectsPhoneBoundByOther() {
         UserRepository repo = mock(UserRepository.class);
         when(repo.findByPhone("13800000000")).thenReturn(Optional.of(user(99, "13800000000")));
-        SmsAuthService svc = new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), repo, false);
+        SmsAuthService svc = new SmsAuthService(List.of(enabledSms(OK_TRANSPORT)),
+                new VerificationCodeStore(), repo, false, ReviewAccountGate.disabled());
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "13800000000"));
         assertThrows(IllegalArgumentException.class, () -> svc.confirmBind(1L, "13800000000", "123456"));
     }
@@ -114,7 +121,8 @@ class SmsAuthServiceTest {
         SmsAuthService svc = new SmsAuthService(List.of(enabledSms((url, body, auth) -> {
             sentBody.set(body);
             return new SmsTransport.Reply(200, "{\"Code\":\"OK\"}");
-        })), new VerificationCodeStore(), repo, false);
+        })), new VerificationCodeStore(), repo, false,
+            ReviewAccountGate.disabled());
 
         svc.sendBindCode(1L, "13800000000");
         java.util.regex.Matcher m = java.util.regex.Pattern.compile("%22code%22%3A%22(\\d{6})%22")
@@ -129,7 +137,8 @@ class SmsAuthServiceTest {
     @DisplayName("手机号格式：非大陆手机号拒绝；空白剥离后再校验")
     void phoneFormatValidated() {
         SmsAuthService svc = new SmsAuthService(
-                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), false);
+                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "12345"));
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, "23800000000"));
         assertThrows(IllegalArgumentException.class, () -> svc.sendBindCode(1L, null));
@@ -140,7 +149,8 @@ class SmsAuthServiceTest {
     @DisplayName("未启用时绑定类操作一律业务错误，且文案不踩掉线三子串")
     void inactiveRejectsBindOperations() {
         SmsAuthService svc = new SmsAuthService(
-                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), true);
+                List.of(enabledSms(OK_TRANSPORT)), new VerificationCodeStore(), mock(UserRepository.class), true,
+                ReviewAccountGate.disabled());
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
                 () -> svc.sendBindCode(1L, "13800000000"));
         assertFalse(e.getMessage().contains("登录"));

--- a/backend/src/test/java/com/checkba/service/sms/SmsSigninTest.java
+++ b/backend/src/test/java/com/checkba/service/sms/SmsSigninTest.java
@@ -1,6 +1,7 @@
 package com.checkba.service.sms;
 
 import com.checkba.config.PhoneLoginGuard;
+import com.checkba.config.ReviewAccountGate;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.auth.VerificationCodeStore;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +27,8 @@ class SmsSigninTest {
 
     private static SmsAuthService svc(SmsTransport t) {
         return new SmsAuthService(List.of(enabled(t)), new VerificationCodeStore(),
-                mock(UserRepository.class), false);
+                mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
     }
 
     @Test
@@ -71,7 +73,8 @@ class SmsSigninTest {
     void scenesAreIsolated() {
         SmsAuthService s = svc(OK);
         VerificationCodeStore store = new VerificationCodeStore();
-        SmsAuthService s2 = new SmsAuthService(List.of(enabled(OK)), store, mock(UserRepository.class), false);
+        SmsAuthService s2 = new SmsAuthService(List.of(enabled(OK)), store,
+                mock(UserRepository.class), false, ReviewAccountGate.disabled());
         s2.sendSigninCode("13800000000");
         // 用 signin 的码去核销 bind 场景应当失败
         assertFalse(store.verify("bind", "13800000000",
@@ -96,7 +99,8 @@ class SmsSigninTest {
     void guardRefusesToStartWithDarkGateway() {
         SmsService dark = new SmsService(OK, false, "", "", "sign", "tpl");
         SmsAuthService inactive = new SmsAuthService(List.of(dark), new VerificationCodeStore(),
-                mock(UserRepository.class), false);
+                mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
         assertFalse(inactive.active());
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
@@ -113,7 +117,8 @@ class SmsSigninTest {
 
         SmsService dark = new SmsService(OK, false, "", "", "sign", "tpl");
         SmsAuthService inactive = new SmsAuthService(List.of(dark), new VerificationCodeStore(),
-                mock(UserRepository.class), false);
+                mock(UserRepository.class), false,
+                ReviewAccountGate.disabled());
         // 没开强制：网关暗着也该正常启动
         assertDoesNotThrow(() -> new PhoneLoginGuard(inactive, false, false, "2026-09-30"));
         // local-mode 根本没有登录环节


### PR DESCRIPTION
## 为什么

iOS 两个 App（国际版 `com.aiworkdeck.mobile` / 大陆版 `com.aiworkdeck.mobile.cn`）
的登录只有验证码一条路：手机号走中国短信、邮箱走收件箱。Apple 的审核员两样都
拿不到——他没有中国号码，也打不开我们的邮箱。没有这条口子，审核员卡在首屏，
审核指南 2.1（App Completeness）必拒。

**两个 App 都卡在这里**，不是国际版独有：大陆版的审核员同样收不到我们发的短信。

## 怎么做的

新增 `config/ReviewAccountGate`，接在 `SmsAuthService` / `MailAuthService` 的
免密登录两条路上。这是一个认证旁路，所以按认证旁路的规矩来：

| 约束 | 为什么 |
|---|---|
| 默认关，两项任一为空即全关 | 不留「配了一半」的中间态 |
| 只对配置里那一个标识生效 | 别的手机号/邮箱一律走原路 |
| 只开在 signin，绑定流程不走 | 旁路的作用面越小越好 |
| 码非 6 位数字**拒绝启动** | 照 `PhoneLoginGuard` 的口径。配歪的旁路会以「审核员登不进去」的形式几天后才暴露，那时排查方向已经跑到客户端 |
| 定长比较 | 这 6 位码长期有效，不像一次性码验完即销，逐位早退是真侧信道 |
| 发码对审核账号静默返回 | 回包与普通标识完全一致，否则这个匿名端点成了「是不是审核号」的探测器 |
| 邮箱那条**不建号** | 邮箱本来就只登录不建号，旁路不该顺手改掉这个语义 |
| 启用时打 WARN | 把「有意开着」和「配漏了」区分开 |

## 运维

```
AUTH_REVIEW_ACCOUNT_IDENTITY=appreview@example.com   # 手机号或邮箱，规范化后的形式
AUTH_REVIEW_ACCOUNT_CODE=246813                      # 6 位数字
```

审核账号里**别放真实数据**——那 6 位码是写在 ASC 审核备注里给外部人看的。
审核结束后清空 `AUTH_REVIEW_ACCOUNT_IDENTITY` 即可关闭。

## 自验证

本机 JDK 21.0.9 上 `mvn compile` 在 **master 原样也挂**
（`maven-compiler-plugin:3.11.0` 抛 `TypeTag :: UNKNOWN`），已用还原成干净树的
worktree 复现确认与本改动无关。所以改走：

- `javac` 单文件编译 `ReviewAccountGate.java` 与 `ReviewAccountGateTest.java`，均通过
- 一个 16 项断言的运行时校验（关闭态不放行、半配置=关闭、坏码拒绝启动、
  只认配置标识、标识与码必须同时对、大小写空白规范化、null 安全），**全部通过**
- `ReviewAccountGateTest` 交给 CI 跑

相关 dev-board#345 / #346。

🤖 Generated with [Claude Code](https://claude.com/claude-code)