### PR TITLE
fix(auth): 审核账号旁路给该身份单独建号（#680 的补丁）+ 补 runbook 的 javacpp 平台收窄

### DIFF
--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -122,6 +122,29 @@ public class UserService {
         return new PhoneAccount(userRepository.save(user), true);
     }
 
+    /**
+     * App 审核账号：按已验证邮箱找，没有就建一个**专用空账号**。
+     *
+     * <p>只给 {@link com.checkba.config.ReviewAccountGate} 那条路调用。
+     *
+     * <p>为什么要建号而不是要求事先绑好：{@code verified_email} 全仓只有
+     * {@code MailAuthService.confirmBind} 一处写入，而它要求先登录——也就是说
+     * 「事先绑好」等于把审核邮箱绑到某个真人账号上，那个固定验证码就成了进
+     * 真人账号的钥匙。单独建一个空账号，那把码就只开得了这一个空房间。
+     *
+     * <p>手机号那条不需要这个方法：{@link #findOrCreateByPhone} 本来就建号。
+     */
+    @org.springframework.transaction.annotation.Transactional
+    public User findOrCreateReviewAccount(String verifiedEmail) {
+        return userRepository.findByVerifiedEmail(verifiedEmail).orElseGet(() -> {
+            User user = registerExternal(allocatePhoneUsername(), "App Review");
+            user.setEmail(verifiedEmail);
+            user.setVerifiedEmail(verifiedEmail);
+            user.setUpdatedAt(LocalDateTime.now());
+            return userRepository.save(user);
+        });
+    }
+
     public record PhoneAccount(User user, boolean created) {}
 
     private static final org.slf4j.Logger claimLog = org.slf4j.LoggerFactory.getLogger(UserService.class);

--- a/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
+++ b/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
@@ -4,6 +4,7 @@ import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
 import com.checkba.service.LangText;
+import com.checkba.service.UserService;
 import com.checkba.service.auth.VerificationCodeStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,19 +43,22 @@ public class MailAuthService {
     private final boolean localMode;
     private final boolean passwordlessEnabled;
     private final ReviewAccountGate reviewAccount;
+    private final UserService userService;
 
     @Autowired
     public MailAuthService(VerificationCodeStore codeStore, MailRouter mailRouter,
                            UserRepository userRepository,
                            @Value("${security.local-mode:false}") boolean localMode,
                            @Value("${mail.passwordless-login-enabled:false}") boolean passwordlessEnabled,
-                           ReviewAccountGate reviewAccount) {
+                           ReviewAccountGate reviewAccount,
+                           UserService userService) {
         this.codeStore = codeStore;
         this.mailRouter = mailRouter;
         this.userRepository = userRepository;
         this.localMode = localMode;
         this.passwordlessEnabled = passwordlessEnabled;
         this.reviewAccount = reviewAccount;
+        this.userService = userService;
     }
 
     /** 邮箱验证在本部署形态下是否启用（非 local-mode 且至少一条发信通道配齐）。 */
@@ -158,13 +162,12 @@ public class MailAuthService {
             throw new IllegalArgumentException(LangText.of("邮箱登录未启用", "Passwordless email sign-in is not enabled"));
         }
         String normalized = MailRouter.normalize(email);
-        // 旁路只免掉「拿到码」这一步，**不建号**：审核账号必须事先注册好并验过
-        // 邮箱，否则下面那句 findByVerifiedEmail 照样把它挡回去。邮箱这条路本来
-        // 就只登录不建号，旁路不该顺手改掉这个语义。
+        // 审核账号没有就建一个专用空账号。**这是这条旁路唯一会建号的地方**，
+        // 且只对配置里那一个标识。理由见 UserService#findOrCreateReviewAccount：
+        // verified_email 只能靠「登录后绑定」写上去，要求事先绑好等于把审核邮箱
+        // 挂到某个真人账号上，那个固定码就成了进真账号的钥匙。
         if (reviewAccount.accepts(normalized, code)) {
-            return userRepository.findByVerifiedEmail(normalized)
-                    .orElseThrow(() -> new IllegalArgumentException(
-                            LangText.of("验证码错误或已过期", "Incorrect or expired verification code")));
+            return userService.findOrCreateReviewAccount(normalized);
         }
         if (!codeStore.verify(SCENE_SIGNIN, normalized, code)) {
             throw new IllegalArgumentException(LangText.of("验证码错误或已过期", "Incorrect or expired verification code"));

--- a/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
@@ -3,6 +3,7 @@ package com.checkba.service.mail;
 import com.checkba.config.ReviewAccountGate;
 import com.checkba.model.entity.User;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.UserService;
 import com.checkba.service.auth.VerificationCodeStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,12 +56,38 @@ class MailAuthServiceTest {
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
         MailAuthService svc = new MailAuthService(
                 new VerificationCodeStore(), new MailRouter(List.of(gw)), repo, localMode, passwordless,
-                ReviewAccountGate.disabled());
+                ReviewAccountGate.disabled(), mock(UserService.class));
         return new Fixture(svc, gw, repo);
     }
 
     private static Fixture fixture() {
         return fixture(false, true);
+    }
+
+    @Test
+    @DisplayName("审核账号：固定码放行并落到专用账号，不经验证码 store")
+    void reviewAccountBypassesCodeStoreAndLandsOnItsOwnAccount() {
+        MailGateway gw = new RecordingGateway();
+        UserRepository repo = mock(UserRepository.class);
+        UserService users = mock(UserService.class);
+        User reviewer = new User();
+        reviewer.setId(999L);
+        reviewer.setUsername("appreview");
+        when(users.findOrCreateReviewAccount("appreview@example.com")).thenReturn(reviewer);
+
+        MailAuthService svc = new MailAuthService(
+                new VerificationCodeStore(), new MailRouter(List.of(gw)), repo, false, true,
+                new ReviewAccountGate("appreview@example.com", "246813"), users);
+
+        // 没发过任何码，直接用固定码换账号
+        assertSame(reviewer, svc.verifySigninCode("appreview@example.com", "246813"));
+
+        // 码错就不该放行，也不该退化成「查已验证邮箱」
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.verifySigninCode("appreview@example.com", "000000"));
+        // 别的地址即使拿到那把码也不放行
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.verifySigninCode("someoneelse@example.com", "246813"));
     }
 
     @Test
@@ -72,7 +99,7 @@ class MailAuthServiceTest {
         MailRouter empty = new MailRouter(List.of());
         assertFalse(new MailAuthService(new VerificationCodeStore(), empty,
                 mock(UserRepository.class), false, true,
-                ReviewAccountGate.disabled()).active(), "没有通道就不算启用");
+                ReviewAccountGate.disabled(), mock(UserService.class)).active(), "没有通道就不算启用");
     }
 
     @Test

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -82,6 +82,16 @@
 - 日志：`journalctl -u aiworkdeck-cloud -f`
 - 更新后端：本地重新 package → scp 覆盖 backend.jar → `systemctl restart aiworkdeck-cloud`
 
+  **package 必须带 `-Djavacpp.platform=linux-x86_64`**：
+  ```bash
+  cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) \
+    mvn -B -DskipTests -Djavacpp.platform=linux-x86_64 package
+  ```
+  `javacv-platform` 不加这个属性会把**所有**平台的 natives 都打进去
+  （windows / macosx / ios / ppc64le…），产物从 424 MB 涨到 1.04 GB。
+  多出来的 600 MB 在 Linux 上一行都用不到，纯粹白传白占盘。
+  产物大小可以当校验：和线上那份差不多（±1 MB）才对。
+
 ## 手机影像云中转的 OSS 存储（dev-board#236）
 
 - blob 不再落 ECS 本地盘，走平台私有桶：北京 `awd-mobile-relay`（cn-beijing），


### PR DESCRIPTION
#680 合进去的是我迭代过程中的中间版本，落地时走不通。这个 PR 补上。

## 为什么 #680 那版走不通

那版的邮箱旁路仍要过 `findByVerifiedEmail`。而 `verified_email` 全仓只有
`MailAuthService.confirmBind` 一处写入，它**要求先登录**——也就是说「审核账号
事先注册好并验过邮箱」在产品里的唯一走法，是把审核邮箱绑到某个**真人账号**上。
那样写在 ASC 审核备注里给 Apple 审核员看的那 6 位固定码，就成了进真人账号的钥匙。

生产库实测也印证了：`app_users` 8 个用户，`verified_email` 全为空，这条路本来
也走不通——审核员会拿到「验证码错误或已过期」。

## 改法

命中审核身份时走 `UserService#findOrCreateReviewAccount`：没有就建一个**专用空
账号**（`registerExternal` 的无密码外部账号形态，displayName `App Review`）。

- 建号只发生在这一条路，且只对配置里那一个标识
- 手机号那条不受影响——`findOrCreateByPhone` 本来就建号
- 那把码从此只开得了这一个空房间

## 顺带：runbook 补一条

`deploy/cloud/README.md` 的「更新后端」没记 `-Djavacpp.platform=linux-x86_64`。
不加它 `javacv-platform` 会把所有平台的 natives 都打进 jar（windows / macosx /
ios / ppc64le…），产物 424 MB → **1.04 GB**。这次部署差点就把那个 1 GB 的包传上去，
所以顺手写进 runbook，并给出「产物大小和线上差不多才对」这个校验。

## 自验证

JDK 21（与 CI 同版本）：52 个测试全过，含新增的
`reviewAccountBypassesCodeStoreAndLandsOnItsOwnAccount`——固定码不经验证码 store
直接换到专用账号；码错不放行、也不退化成查已验证邮箱；别的地址拿到那把码也不放行。

相关 dev-board#345 / #346。

🤖 Generated with [Claude Code](https://claude.com/claude-code)