### PR TITLE
chore(release): v0.30.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
版本号 bump，单文件 `desktop/package.json`（0.29.0 → 0.30.0）。

内容见 dev-board#344 与 #681：Product Hunt 发布前的四端稳定性审计与加固。

**为什么是大版本（X）而非小版本**：`desktop/main`、`desktop/preload`、`desktop/build`
都有改动，`patch-gate.sh` 会拒绝小版本 tag——这些只能随大版本走。

发版门（合并前已全部在本机真跑通过）：
- 后端 `mvn test` 2953 / 0 失败
- 前端静态门 + 12 套单测全绿；h5 构建通过
- 桌面端单测 82/82；插件端 293/293 + Office/WPS 双构建
- LOWA 真引擎 e2e 466 / 0
- 全应用 e2e 131 通过 / 0 失败（含 J12 英文旅程）
- 桌面端 e2e 全通
- CI（#681）：Backend / Frontend / Desktop / Build (windows-latest) 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)