### PR TITLE
feat(auth): 邮箱免密登录改为注册登录合一（国际版没有注册入口的问题）

### DIFF
--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -145,6 +145,29 @@ public class UserService {
         });
     }
 
+    /**
+     * 邮箱免密登录/注册：按已验证邮箱找，没有就建号。
+     *
+     * <p>与 {@link #findOrCreateByPhone} 同一口径——验证码验过就是对该邮箱的控制权
+     * 证明，和短信那条没有本质区别。国际版只有邮箱这一条路能走（境外收不到中国
+     * 短信），如果邮箱只登录不建号，境外用户就**没有任何**注册入口。
+     */
+    @org.springframework.transaction.annotation.Transactional
+    public EmailAccount findOrCreateByEmail(String verifiedEmail) {
+        java.util.Optional<User> existing = userRepository.findByVerifiedEmail(verifiedEmail);
+        if (existing.isPresent()) {
+            return new EmailAccount(existing.get(), false);
+        }
+        User user = registerExternal(allocatePhoneUsername(),
+                com.checkba.service.mail.MailAuthService.maskEmail(verifiedEmail));
+        user.setEmail(verifiedEmail);
+        user.setVerifiedEmail(verifiedEmail);
+        user.setUpdatedAt(LocalDateTime.now());
+        return new EmailAccount(userRepository.save(user), true);
+    }
+
+    public record EmailAccount(User user, boolean created) {}
+
     public record PhoneAccount(User user, boolean created) {}
 
     private static final org.slf4j.Logger claimLog = org.slf4j.LoggerFactory.getLogger(UserService.class);

--- a/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
+++ b/backend/src/main/java/com/checkba/service/mail/MailAuthService.java
@@ -133,8 +133,8 @@ public class MailAuthService {
     /**
      * 免密登录发码。
      *
-     * <p>**邮箱未绑定任何账号时，不发信但照常返回**——回包对「已注册」和「未注册」必须
-     * 完全一致，否则这个匿名端点就成了账号枚举器，谁都能拿它批量探测某人是不是用户。
+     * <p>**注册登录合一**：未注册的邮箱也会收到码，验过就建号（与手机号那条同口径）。
+     * 正因为已注册/未注册在「收不收得到码」上没有差别，这个匿名端点才不是账号枚举器。
      * IP 维度的限频在 AuthAbuseGuard，邮箱维度的冷却与日上限在 VerificationCodeStore。
      */
     public void sendSigninCode(String email) {
@@ -142,20 +142,22 @@ public class MailAuthService {
             throw new IllegalArgumentException(LangText.of("邮箱登录未启用", "Passwordless email sign-in is not enabled"));
         }
         String normalized = MailRouter.normalize(email);
-        // 审核账号的码是固定的，没有信要发。与「未注册」走同一条静默返回，
-        // 回包对外完全一致。
+        // 审核账号的码是固定的，没有信要发。
         if (reviewAccount.matches(normalized)) {
             return;
         }
-        if (userRepository.findByVerifiedEmail(normalized).isEmpty()) {
-            return;
-        }
+        // **对未注册地址也发**：这条和手机号那条一样是「注册登录合一」，
+        // 验过码没有账号就建一个。既然已注册与未注册都会收到码、回包也一致，
+        // 就不存在「这个邮箱注册过没有」的枚举面了——原先那条「未注册不发信」
+        // 的静默返回反而是枚举器（对方能从「收没收到信」读出结论）。
+        // 代价是任意地址都能触发一封信，靠 AuthAbuseGuard 的 IP 限频与
+        // VerificationCodeStore 的邮箱冷却/当日上限兜住，与短信同一套护栏。
         sendWithRollback(SCENE_SIGNIN, normalized, LangText.of("登录验证码", "Sign-in Verification Code"));
     }
 
     /**
-     * 核销免密登录码并返回对应账号。错码/过期/无此账号一律同一句话——
-     * 同样是为了不泄露该邮箱是否注册过。
+     * 核销免密登录码并返回对应账号；该邮箱没有账号就建一个。
+     * 错码与过期一律同一句话，不区分。
      */
     public User verifySigninCode(String email, String code) {
         if (!passwordlessActive()) {
@@ -172,8 +174,8 @@ public class MailAuthService {
         if (!codeStore.verify(SCENE_SIGNIN, normalized, code)) {
             throw new IllegalArgumentException(LangText.of("验证码错误或已过期", "Incorrect or expired verification code"));
         }
-        return userRepository.findByVerifiedEmail(normalized)
-                .orElseThrow(() -> new IllegalArgumentException(LangText.of("验证码错误或已过期", "Incorrect or expired verification code")));
+        // 验过码即证明控制权，没有账号就建——与 findOrCreateByPhone 同口径。
+        return userService.findOrCreateByEmail(normalized).user();
     }
 
     // ==================== 内部 ====================

--- a/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mail/MailAuthServiceTest.java
@@ -54,14 +54,48 @@ class MailAuthServiceTest {
         RecordingGateway gw = new RecordingGateway();
         UserRepository repo = mock(UserRepository.class);
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        UserService users = mock(UserService.class);
+        // 建号那步默认回落到「按已验证邮箱查到的那个人」，这样老用例不必每个都去 stub；
+        // 真要验建号行为的用例自己另建 fixture。
+        when(users.findOrCreateByEmail(anyString())).thenAnswer(inv -> {
+            String addr = inv.getArgument(0);
+            User u = repo.findByVerifiedEmail(addr).orElseGet(() -> user(0, addr));
+            return new UserService.EmailAccount(u, false);
+        });
         MailAuthService svc = new MailAuthService(
                 new VerificationCodeStore(), new MailRouter(List.of(gw)), repo, localMode, passwordless,
-                ReviewAccountGate.disabled(), mock(UserService.class));
+                ReviewAccountGate.disabled(), users);
         return new Fixture(svc, gw, repo);
     }
 
     private static Fixture fixture() {
         return fixture(false, true);
+    }
+
+    @Test
+    @DisplayName("注册登录合一：未注册邮箱也发码，验过即建号")
+    void unknownEmailGetsCodeAndAccountIsCreated() {
+        RecordingGateway gw = new RecordingGateway();
+        UserRepository repo = mock(UserRepository.class);
+        UserService users = mock(UserService.class);
+        User fresh = new User();
+        fresh.setId(777L);
+        when(users.findOrCreateByEmail("newcomer@example.com"))
+                .thenReturn(new UserService.EmailAccount(fresh, true));
+
+        VerificationCodeStore store = new VerificationCodeStore();
+        MailAuthService svc = new MailAuthService(
+                store, new MailRouter(List.of(gw)), repo, false, true,
+                ReviewAccountGate.disabled(), users);
+
+        // 未注册地址也该真的发出一封信（旧行为是静默不发）
+        svc.sendSigninCode("newcomer@example.com");
+        assertFalse(gw.sent.isEmpty(), "未注册邮箱也应收到验证码");
+
+        // 拿到的码验过之后，账号被建出来
+        String code = gw.lastCode();
+        assertSame(fresh, svc.verifySigninCode("newcomer@example.com", code));
+        verify(users).findOrCreateByEmail("newcomer@example.com");
     }
 
     @Test
@@ -188,18 +222,26 @@ class MailAuthServiceTest {
     }
 
     @Test
-    @DisplayName("免密登录：未注册的邮箱不发信但照常返回，不泄露该邮箱是否是用户")
+    @DisplayName("免密登录：已注册与未注册的表现完全一致，读不出该邮箱是不是用户")
     void signinDoesNotLeakRegistrationStatus() {
-        Fixture f = fixture();
-        when(f.repo().findByVerifiedEmail("stranger@gmail.com")).thenReturn(Optional.empty());
+        // 反枚举的不变量变了：以前靠「未注册不发信」，那反而是枚举器——对方从
+        // 收没收到信就能读出结论。现在两者都发码、都能验过，真正没有差别可读。
+        Fixture known = fixture();
+        when(known.repo().findByVerifiedEmail("dave@gmail.com"))
+                .thenReturn(Optional.of(user(5, "dave@gmail.com")));
+        Fixture unknown = fixture();
+        when(unknown.repo().findByVerifiedEmail(anyString())).thenReturn(Optional.empty());
 
-        assertDoesNotThrow(() -> f.svc().sendSigninCode("stranger@gmail.com"));
-        assertTrue(f.gw().sent.isEmpty(), "未注册就不该真发信");
+        known.svc().sendSigninCode("dave@gmail.com");
+        unknown.svc().sendSigninCode("stranger@gmail.com");
+        assertEquals(known.gw().sent.size(), unknown.gw().sent.size(), "发信与否不能有差别");
 
-        // 错码与查无此人给同一句话
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> f.svc().verifySigninCode("stranger@gmail.com", "123456"));
-        assertEquals("验证码错误或已过期", e.getMessage());
+        // 错码在两边给同一句话
+        for (Fixture f : List.of(known, unknown)) {
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                    () -> f.svc().verifySigninCode("whoever@gmail.com", "123456"));
+            assertEquals("验证码错误或已过期", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
## 问题

国际版 iOS 只有邮箱这一条登录路（境外收不到中国短信）。而邮箱那条此前**只登录
不建号**——`sendSigninCode` 对未注册地址静默不发信——等于**境外用户没有任何注册
入口**，想用这个 App 得先在别处把账号弄出来。生产库也印证：`app_users` 8 个用户，
`verified_email` 全为空。

## 改法

与 `findOrCreateByPhone` 同一口径：未注册地址也发码，验过码即证明对该邮箱的控制权，
没有账号就建（`UserService#findOrCreateByEmail`）。

## 顺带修正了反枚举的口径

原注释说「未注册不发信」是在防账号枚举。**它本身就是枚举器**——对方从「收没收到
信」就能读出这个邮箱注册过没有。现在两种情况都发码、都能验过，才真的没有差别可读。

代价是任意地址都能触发一封信，靠 `AuthAbuseGuard` 的 IP 限频与
`VerificationCodeStore` 的邮箱冷却 / 当日上限兜住，与短信那条共用同一套护栏。

## 自验证

JDK 21（与 CI 同版本）：**53 个测试全过**。
- 新增 `unknownEmailGetsCodeAndAccountIsCreated`
- 旧的 `signinDoesNotLeakRegistrationStatus` 断言的是被推翻的行为，重写成断言真正的
  不变量：已注册与未注册在「发信与否」「错码文案」上完全一致

相关 dev-board#345。

🤖 Generated with [Claude Code](https://claude.com/claude-code)