### PR TITLE
fix(i18n): 本机用户中文名的两处快照式泄漏——变量库创建者与版本时间线署名（dev-board#351）

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -47,6 +47,14 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `backend/src/main/java/com/checkba/config/LocalModeAccessFilter.java` — 免登模式的每请求准入闸（回环校验 + 反代痕迹拒绝 + 跨站 Origin 硬拦截）。
 - `backend/src/main/java/com/checkba/config/LocalModeLoopbackGuard.java` — 启动强不变式：local-mode 必须绑回环地址，否则拒绝启动。
 - `AuthController.getUserIdFromSession()` 在 local-mode 下把任何请求解析为本机用户（90 余处调用方一行未改）。
+- **「本机用户」是库里恒存的中文哨兵，界面语言只在读出来时替换**（`LocalIdentityService.displayNameOf`，
+  v0.30.0 + dev-board#351）。库里存的值一个字都不动——改写入侧会让同一个人在中英文界面下留下两种身份。
+  出口全集（新增读出口要跟着补，别再漏）：`/api/auth/me`、`/api/local-identity/{status,candidates}`、
+  项目成员与 owner（`ProjectMemberController`）、项目列表 `managerName`（`ProjectService`）、
+  变量库创建者（`ProjectVariableController.VariableView`）、版本时间线署名（`ProjectRepoService.toEntry`）。
+  后两处是**快照**——名字被抄进了 project_variables / Git 提交对象，读时本地化是唯一够得着的修法。
+  **不许就地改实体的 `creatorName`**：实体在 OSIV 会话里受管，一旦被脏检查刷回库，库里就成了
+  「Local user」，中文界面反过来看到英文，且不可逆——所以那条路走的是只读视图 `VariableView`。
 
 **账户连接（PR-B）**
 - `backend/src/main/java/com/checkba/service/account/AccountService.java` — 与官网账户的唯一连接方式是 `awdk_` Key。

--- a/.claude/agents/version-control.md
+++ b/.claude/agents/version-control.md
@@ -154,6 +154,14 @@ description: 项目级版本记录领域。任务涉及版本记录/工作段（
 
   `unionApply` 保留两参版本（`base` 隐式传 `null`，委托三参版本）——v1 语义原样不变，`TreeManifestSyncTest.unionApplyRestoresFromRecycleBinButNeverSendsAnActiveRowThere` 是它的护栏，护栏测试 `UnionReviveGuardTest`（`handDeletedFileSurvivesSessionEndMerge` 是被否决场景的直接回归；`draftCreatedFileStillRevivesOnAdopt` 是 v1 关键场景不回归的回归；`genuineReviveByPeerIsApplied`/`twoArgUnionApplyKeepsV1Semantics` 分别钉矩阵与两参路径）。
 
+**时间线署名是读时本地化的，不是存储值**（dev-board#351）：`ProjectRepoService.toEntry()` 把
+`c.getAuthorIdent().getName()` 过一道 `LocalIdentityService.displayNameOf` 再放进 `VersionEntry.authorName`。
+单机模式的提交作者名就是库里那个中文哨兵「本机用户」，它随提交写进了 Git 对象；历史永不重写，
+作者名还派生了提交邮箱（`WorkSessionService.email`），所以**只能在出参侧换**，写入侧一字不动——
+否则同一个人在中英文界面下会往版本库里留下两种署名。真实用户名（含云端协作方）原样透传。
+护栏测试：`ProjectRepoHistoryTest.localUserAuthorIsLocalizedOnReadWithoutRewritingHistory`
+（同一个仓库中/英/中读三遍，值必须来回切得回去，证明提交对象没被改写）。
+
 ## 已知地雷
 
 1. **历史永不重写**——硬不变量，理由与 Git 自己一致，为将来推云端仓库（v2）打基础。唯一例外是删除从未合并进主线的工作段分支（`discardSession`/`deleteBranch(force=true)`）。护栏测试：`RepoMaintenanceTest.gcPreservesEveryReachableVersion`，GC 前后逐条比对每个 `VersionEntry.sha()`。

--- a/backend/src/main/java/com/checkba/controller/ProjectVariableController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectVariableController.java
@@ -2,12 +2,14 @@ package com.checkba.controller;
 
 import com.checkba.model.entity.ProjectVariable;
 import com.checkba.service.LangText;
+import com.checkba.service.LocalIdentityService;
 import com.checkba.service.ProjectMemberService;
 import com.checkba.service.ProjectVariableService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -30,12 +32,56 @@ public class ProjectVariableController {
         return userId;
     }
 
+    /**
+     * 变量的对外形态。字段与 {@link ProjectVariable} 逐一对应，JSON 形状一字不变。
+     *
+     * <p>为什么不直接回实体：{@code creatorName} 是**写时快照**——建变量那一刻把
+     * {@code User.displayName} 抄了一份存进 project_variables，单机模式下抄到的就是中文
+     * 哨兵「本机用户」，英文界面照样显示中文（dev-board#351）。同族的读时本地化那一招
+     * （{@code LocalIdentityService.displayNameOf}）要落在这个字段上，而实体在 OSIV 会话里
+     * 是受管对象：就地改它一旦被 Hibernate 脏检查刷回库，库里存的就成了「Local user」，
+     * 中文界面反过来看到英文，是不可逆的数据污染。多一个只读视图，改动只落在出参上。
+     * 同族已修的另外几处（/api/auth/me、项目成员、项目列表 managerName）本来就是往新
+     * 对象里 put，天然没有这个问题——这里补齐的是唯一一处直接回实体的。
+     */
+    public record VariableView(
+            Long id,
+            Long projectId,
+            String name,
+            String value,
+            String variableGroup,
+            String resolvedValue,
+            String type,
+            Long creatorId,
+            String creatorName,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt) {
+
+        public static VariableView of(ProjectVariable v) {
+            return new VariableView(
+                    v.getId(),
+                    v.getProjectId(),
+                    v.getName(),
+                    v.getValue(),
+                    v.getVariableGroup(),
+                    v.getResolvedValue(),
+                    v.getType(),
+                    v.getCreatorId(),
+                    // 库里恒存中文哨兵，按当前界面语言替换；真实用户名一个字都不动
+                    LocalIdentityService.displayNameOf(v.getCreatorName()),
+                    v.getCreatedAt(),
+                    v.getUpdatedAt());
+        }
+    }
+
     @GetMapping("/project/{projectId}")
-    public ResponseEntity<List<ProjectVariable>> getVariables(
+    public ResponseEntity<List<VariableView>> getVariables(
             @PathVariable Long projectId,
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireMember(sessionId, projectId);
-        return ResponseEntity.ok(service.getVariablesByProject(projectId));
+        return ResponseEntity.ok(service.getVariablesByProject(projectId).stream()
+                .map(VariableView::of)
+                .toList());
     }
 
     @PostMapping
@@ -49,7 +95,7 @@ public class ProjectVariableController {
             String username = AuthController.getUsernameFromSession(sessionId);
             variable.setCreatorName(username != null ? username : "Unknown");
         }
-        return ResponseEntity.ok(service.createOrUpdateVariable(variable));
+        return ResponseEntity.ok(VariableView.of(service.createOrUpdateVariable(variable)));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/checkba/version/ProjectRepoService.java
+++ b/backend/src/main/java/com/checkba/version/ProjectRepoService.java
@@ -1,5 +1,6 @@
 package com.checkba.version;
 
+import com.checkba.service.LocalIdentityService;
 import com.checkba.storage.ProjectStorageResolver;
 import org.eclipse.jgit.api.CreateBranchCommand;
 import org.eclipse.jgit.api.DiffCommand;
@@ -364,7 +365,13 @@ public class ProjectRepoService {
         return new VersionEntry(
                 c.getName(),
                 c.getShortMessage(),
-                c.getAuthorIdent().getName(),
+                // 提交作者名是**写进 Git 历史的快照**，读时本地化只能落在出参上：历史永不
+                // 重写，作者名还派生了提交邮箱（WorkSessionService.email），改写入侧等于同一个
+                // 人在中英文界面下留下两种署名，把版本库里的身份劈成两半。单机模式下作者名
+                // 就是库里那个中文哨兵「本机用户」，英文界面的时间线会照原样显示中文
+                // （dev-board#351）；这里按当前界面语言替换后再交给 UI，真实用户名（含云端
+                // 协作方的署名）一个字都不动，Git 对象一字节都没碰。
+                LocalIdentityService.displayNameOf(c.getAuthorIdent().getName()),
                 Instant.ofEpochSecond(c.getCommitTime()),
                 kind == null ? "auto" : kind,
                 note,

--- a/backend/src/test/java/com/checkba/controller/ProjectVariableViewTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectVariableViewTest.java
@@ -1,0 +1,130 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectVariable;
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
+import com.checkba.service.LocalIdentityService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 变量库创建者名的读时本地化（dev-board#351）。
+ *
+ * <p>{@code ProjectVariable.creatorName} 是写时快照：建变量那一刻把 User.displayName 抄进
+ * project_variables，单机模式下抄到的是中文哨兵「本机用户」。v0.30.0 的读时本地化只覆盖了
+ * 直接读 User 的五处，够不着这张表，英文界面的变量面板照旧显示中文。修法是出参侧映射，
+ * **不碰库里存的值**——这也是本测试最后两条断言守的东西。
+ */
+class ProjectVariableViewTest {
+
+    @AfterEach
+    void resetLangText() {
+        LangText.reset();
+    }
+
+    private ProjectVariable localUserVariable() {
+        ProjectVariable v = new ProjectVariable();
+        v.setId(11L);
+        v.setProjectId(7L);
+        v.setName("甲方");
+        v.setValue("某某科技有限公司");
+        v.setVariableGroup("当事人");
+        v.setResolvedValue("某某科技有限公司");
+        v.setType("TEXT");
+        v.setCreatorId(3L);
+        v.setCreatorName(LocalIdentityService.LOCAL_DISPLAY_NAME);
+        v.setCreatedAt(LocalDateTime.of(2026, 9, 1, 10, 0));
+        v.setUpdatedAt(LocalDateTime.of(2026, 9, 1, 11, 0));
+        return v;
+    }
+
+    private void useEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+    }
+
+    @Test
+    void sentinelCreatorIsLocalizedInEnglishUi() {
+        useEnglish();
+        assertEquals("Local user",
+                ProjectVariableController.VariableView.of(localUserVariable()).creatorName());
+    }
+
+    @Test
+    void sentinelCreatorStaysChineseInChineseUi() {
+        LangText.reset(); // 未登记 = 中文，与既有默认态一致
+        assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME,
+                ProjectVariableController.VariableView.of(localUserVariable()).creatorName());
+    }
+
+    @Test
+    void realCreatorNamePassesThroughEvenInEnglishUi() {
+        useEnglish();
+        ProjectVariable v = localUserVariable();
+        v.setCreatorName("韩泽伟");
+        assertEquals("韩泽伟", ProjectVariableController.VariableView.of(v).creatorName());
+    }
+
+    @Test
+    void nullCreatorNameSurvivesSoFrontendFallbackStillFires() {
+        // VariablePanel.vue 的 `it.creatorName || 'Project'` 回退依赖 null 原样传出
+        useEnglish();
+        ProjectVariable v = localUserVariable();
+        v.setCreatorName(null);
+        assertNull(ProjectVariableController.VariableView.of(v).creatorName());
+    }
+
+    /** 本地化只发生在出参上：实体一个字段都不许被改（改了会被 OSIV 会话刷回库）。 */
+    @Test
+    void mappingDoesNotMutateTheEntity() {
+        useEnglish();
+        ProjectVariable v = localUserVariable();
+
+        ProjectVariableController.VariableView view = ProjectVariableController.VariableView.of(v);
+
+        assertEquals("Local user", view.creatorName());
+        assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME, v.getCreatorName(),
+                "实体的 creatorName 被就地改写了——Hibernate 脏检查会把英文刷回库，中文界面反过来看到英文");
+    }
+
+    /** 出参逐字段照抄，且新加的实体字段不能被这层视图静默吞掉。 */
+    @Test
+    void viewCarriesEveryEntityField() {
+        ProjectVariable v = localUserVariable();
+        ProjectVariableController.VariableView view = ProjectVariableController.VariableView.of(v);
+
+        assertEquals(v.getId(), view.id());
+        assertEquals(v.getProjectId(), view.projectId());
+        assertEquals(v.getName(), view.name());
+        assertEquals(v.getValue(), view.value());
+        assertEquals(v.getVariableGroup(), view.variableGroup());
+        assertEquals(v.getResolvedValue(), view.resolvedValue());
+        assertEquals(v.getType(), view.type());
+        assertEquals(v.getCreatorId(), view.creatorId());
+        assertEquals(v.getCreatedAt(), view.createdAt());
+        assertEquals(v.getUpdatedAt(), view.updatedAt());
+
+        Set<String> viewFields = Arrays.stream(ProjectVariableController.VariableView.class.getRecordComponents())
+                .map(RecordComponent::getName)
+                .collect(Collectors.toSet());
+        Set<String> entityFields = Arrays.stream(ProjectVariable.class.getDeclaredFields())
+                .filter(f -> !f.isSynthetic() && !Modifier.isStatic(f.getModifiers()))
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+        assertEquals(entityFields, viewFields,
+                "ProjectVariable 加了新字段就要同步加进 VariableView，否则接口静默少一个字段");
+    }
+}

--- a/backend/src/test/java/com/checkba/version/ProjectRepoHistoryTest.java
+++ b/backend/src/test/java/com/checkba/version/ProjectRepoHistoryTest.java
@@ -1,6 +1,10 @@
 package com.checkba.version;
 
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
+import com.checkba.service.LocalIdentityService;
 import com.checkba.storage.StorageProperties;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -10,6 +14,8 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ProjectRepoHistoryTest {
 
@@ -171,5 +177,50 @@ class ProjectRepoHistoryTest {
         byte[] old = s.readBlobAtCommit(7L, first, "合同.txt");
         assertEquals("初稿", new String(old, StandardCharsets.UTF_8));
         assertNull(s.readBlobAtCommit(7L, first, "不存在.txt"));
+    }
+
+    // ==================== 时间线署名的读时本地化（dev-board#351）====================
+    // 单机模式的提交作者名就是库里那个中文哨兵「本机用户」，它随提交写进了 Git 历史。
+    // 历史永不重写，作者名还派生了提交邮箱，所以只能在**读出来交给 UI 时**按界面语言换，
+    // Git 对象一字节都不许动——下面两条用同一个仓库分别以中/英文读一遍来钉死这一点。
+
+    @AfterEach
+    void resetLangText() {
+        LangText.reset();
+    }
+
+    private void useEnglish() {
+        AppLanguageService en = mock(AppLanguageService.class);
+        when(en.isEnglish()).thenReturn(true);
+        LangText.register(en);
+    }
+
+    @Test
+    void localUserAuthorIsLocalizedOnReadWithoutRewritingHistory(@TempDir Path root) throws Exception {
+        Files.createDirectories(root.resolve("projects/7"));
+        Files.writeString(root.resolve("projects/7/合同.txt"), "初稿");
+        ProjectRepoService s = svc(root);
+        // 提交侧照旧写哨兵值：写入语义不动，历史里永远是同一个署名
+        s.init(7L, LocalIdentityService.LOCAL_DISPLAY_NAME, "本机用户@aiworkdeck.local");
+
+        LangText.reset();
+        assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME, s.log(7L, "HEAD", 1).get(0).authorName(),
+                "中文界面下时间线署名应保持哨兵原值");
+
+        useEnglish();
+        assertEquals("Local user", s.log(7L, "HEAD", 1).get(0).authorName(),
+                "英文界面下时间线署名应本地化");
+
+        LangText.reset();
+        assertEquals(LocalIdentityService.LOCAL_DISPLAY_NAME, s.log(7L, "HEAD", 1).get(0).authorName(),
+                "切回中文又变了 = 提交对象被改写了，本地化必须只作用于出参");
+    }
+
+    @Test
+    void realAuthorNameIsNeverTouchedEvenInEnglishUi(@TempDir Path root) throws Exception {
+        ProjectRepoService s = seeded(root);   // 作者是真实姓名「韩泽伟」
+        useEnglish();
+        assertEquals("韩泽伟", s.log(7L, "HEAD", 1).get(0).authorName(),
+                "云端协作方的真实署名在英文界面下也一个字都不能动");
     }
 }


### PR DESCRIPTION
修 dev-board#351。v0.30.0（dev-board#344）已修掉直接读 `User.displayName` 的五处，剩下两处是把名字**快照**写进了别处，读时本地化那一招够不着。

## 1. 变量库创建者（`ProjectVariable.creatorName`）

建变量时 `AuthController.getUsernameFromSession()` 把 `displayName` 抄进 `project_variables.creator_name`，单机模式抄到的就是中文哨兵「本机用户」。英文界面的变量面板（`VariablePanel.vue` 的 `var-creator`）照旧显示中文。

修法：出参侧只读视图 `ProjectVariableController.VariableView`，字段与实体逐一对应、JSON 形状一字不变，只在 `creatorName` 上过一道 `LocalIdentityService.displayNameOf`。

**为什么不就地改实体**：`ProjectVariable` 在 OSIV 会话里是受管对象。就地改它一旦被 Hibernate 脏检查刷回库，库里存的就成了「Local user」，中文界面反过来看到英文，而且不可逆。同族已修的另外几处（`/api/auth/me`、项目成员、`managerName`）本来就是往新对象里 put，天然没有这个问题——这里补齐的是唯一一处直接回实体的。

## 2. 版本时间线署名（Git 提交作者名）

提交作者名随提交写进了 Git 对象，`VersionTimeline.vue` / `VersionNodeDetail.vue` 直接渲染 `VersionEntry.authorName`。

修法：只在 `ProjectRepoService.toEntry()` 的出参侧替换，**写入侧和 Git 对象一字节没动**。历史永不重写，作者名还派生了提交邮箱（`WorkSessionService.email`），改写入侧等于同一个人在中英文界面下往版本库里留下两种署名。已读过 `.claude/agents/version-control.md`：本改动不触碰第 4 条地雷（`MergeCommand` 没有 `setAuthor`，必须 `setCommit(false)` 后手工 `setAuthor`）——那条管的是写入侧，这里只动读出侧。

两处都只认哨兵值**精确相等**，真实用户名（含云端协作方的署名）原样透传；`null` 也原样传出，`VariablePanel.vue` 的 `creatorName || 'Project'` 回退不受影响。

## 刻意没做

`WorkSessionService.email()` 派生的 `本机用户@aiworkdeck.local`。`VersionEntry` 不带 email、UI 全链路读不到它（`ActivityFeed.vue` 头注释也记着这一点），改了反而会把已有历史的作者身份劈成两半。

`ProjectTreeManifestService` 清单里的 `author` **不能动**——那是 `username`（不是 `displayName`），`normalizeV2` 拿它反查 `userId`，是功能键不是文案。

## 验证

- 新增 `ProjectVariableViewTest`（6 条）：中/英/真实名/null 四种输入，外加两条护栏——「映射不得改动实体」（防 OSIV 刷回）与「实体字段全覆盖」（反射比对，防以后加字段被视图静默吞掉）。
- `ProjectRepoHistoryTest` 加两条：同一个仓库按中→英→中读三遍，值必须来回切得回去，证明提交对象没被改写；真实姓名在英文界面下不变。
- **还原病灶对照**（先做的）：把两处 `displayNameOf` 摘掉后 3 条断言转红（`expected: <Local user> but was: <本机用户>`），摘除时已校验锚点唯一、改后形态存在。
- backend 全量 `mvn -B test`：**2967 通过 / 0 失败 / 0 错误**（JDK 21）。

## 复测提示

英文界面（设置里切 en-US 后整页 reload）打开任一项目：变量库里自己建的变量，创建者应显示 `Local user`；版本记录时间线的节点署名同样应是 `Local user`。切回中文两处都应变回「本机用户」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)