### PR TITLE
fix(frontend): scroll-view 卸载后仍写 scrollTop——给 uni-h5 补空判（dev-board#349）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -69,6 +69,18 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    `ui-harness.nsi` 收 `-DREQUIRED_KB`，smoke 工作流多编一个所需空间约 858GB 的
    `harness-nospace.exe`，用 `installer-smoke.ps1 -ExpectBlocked` 断言「弹了提示框 +
    进程没退 + 窗口还是 760 宽的大卡片（开装了会缩成 360×132 的角落进度卡）」。
+6.5.3. **`uni-h5` 补丁（`frontend/scripts/patch-uni-h5-scrollview.mjs` + frontend `package.json` 的 `postinstall`，dev-board#349）**：
+   uni-h5 的 scroll-view 在 `onMounted` 里排一个 `nextTick` 补写 scrollTop/scrollLeft，
+   回调对元素 ref **没有空判**；组件在同一批 flush 里被卸载（`v-if` 分支翻转、路由离开）时
+   `main.value` 已是 null，控制台常驻两条同根因的错误（`TypeError: Cannot set properties
+   of null (setting 'scrollTop')` + 我们 main.js 全局兜底打出的「未处理的 Promise rejection」）。
+   补丁给 `uni-h5.es.js`/`uni-h5.cjs.js` 各加三处真值判断（两条 `_scroll*Changed` 的直写 +
+   动画分支 `scrollTo` 的入口），锚点在文件内必须唯一，**对不上就 exit 1 让安装失败**——
+   升级 `@dcloudio/uni-h5` 后若报「结构已变」，先搜新版的 `_scrollTopChanged` 看是否已自带
+   空判，是就删掉补丁与 postinstall 钩子。产物侧靠 `npm ci` 触发 postinstall（ci.yml 的
+   frontend job 与 desktop-build.yml 的 Build frontend 步骤都会跑到）。
+   回归护栏在 `tests/app-e2e/run.mjs` 结尾：**控制台异常信号整体不判死**（历史噪音多），
+   但 `setting 'scrollTop'` 这一条单拎出来判死。
 6.6. **`dmg-builder` 补丁（`desktop/scripts/patch-dmg-builder.js` + package.json `postinstall`，安装器 UI 重设计新增）**：macOS 26.2+ 起 Finder 拒读 dmgbuild 写入 `.DS_Store` 的 `pBBk` 背景书签，导致桌面端主 DMG 背景不显示（electron-builder#9072 / dmgbuild#273，同版 Obsidian/Podman Desktop 同期中招）。`npm ci`/`npm install` 后自动对 `node_modules/dmg-builder/vendor/dmgbuild/core.py` 做定点补丁（跳过 Bookmark 生成，`icvp` 里的 alias 通道保留，老系统照常工作）。**升级 electron-builder 后若补丁脚本报「结构已变」**：先确认新版是否已自带该修复，再决定要不要删掉本补丁，不要盲目跳过。
 
 ## 测试命令总表

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "uni-preset-vue",
   "version": "0.0.0",
   "scripts": {
+    "postinstall": "node scripts/patch-uni-h5-scrollview.mjs",
     "check:emits": "node scripts/check-emit-bindings.mjs",
     "check:locales": "node scripts/check-locale-parity.mjs",
     "check:nav": "node scripts/check-navigation-contract.mjs",

--- a/frontend/scripts/patch-uni-h5-scrollview.mjs
+++ b/frontend/scripts/patch-uni-h5-scrollview.mjs
@@ -1,0 +1,60 @@
+// uni-h5 的 scroll-view 在挂载后用 nextTick 补写一次 scrollTop/scrollLeft，但那个回调
+// 对元素 ref 没有任何空判：组件在同一批 flush 里被卸载（v-if 分支翻转、路由离开）时，
+// main.value 已经是 null，于是产线控制台常驻两条——
+//   TypeError: Cannot set properties of null (setting 'scrollTop')
+//   未处理的 Promise rejection（nextTick 的 promise 链把上面那条包了一层）
+// 复现路径：项目列表页 → 统一设置页（AdminPane 里 PersonalWorkLogPanel 的
+// `<scroll-view v-else scroll-y>` 随 loading/空/有数据三分支挂载又卸载）。dev-board#349。
+//
+// 上游没有空判，我们这边**无法**取消它已经排好的 nextTick，只能补这道守卫。
+// 语义上也正是对的：元素都没了，本来就没有什么可滚的。
+// 三处替换都只在原表达式前加一个 main.value 真值判断，行为对正常路径逐字节不变。
+//
+// 若将来升级 @dcloudio/uni-h5 后此处报「结构已变」：先确认新版是否已自带空判
+//（搜 _scrollTopChanged），是就删掉本补丁与 package.json 的 postinstall 钩子。
+// 写法与 desktop/scripts/patch-dmg-builder.js 同一套路。
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const distDir = path.join(here, '..', 'node_modules', '@dcloudio', 'uni-h5', 'dist')
+
+// [坏形态, 好形态]。锚点必须在目标文件里唯一，否则宁可报错也不乱改。
+const EDITS = [
+  ['main.value.scrollTop = val;', 'main.value && (main.value.scrollTop = val);'],
+  ['main.value.scrollLeft = val;', 'main.value && (main.value.scrollLeft = val);'],
+  // 带 scroll-with-animation 的那条分支走 scrollTo，同一个卸载竞态会崩在
+  // container.scrollWidth 上（聊天区自动滚动就在这条路上）。一并守住。
+  ['const container = main.value;', 'const container = main.value;\n    if (!container) return;'],
+]
+
+const targets = ['uni-h5.es.js', 'uni-h5.cjs.js']
+let patched = 0
+let already = 0
+
+for (const name of targets) {
+  const file = path.join(distDir, name)
+  if (!fs.existsSync(file)) {
+    // 依赖没装齐（如只跑了后端的 CI 腿）时不拦安装：真要用到时构建会自己暴露
+    console.log(`[patch-uni-h5] 未找到 ${name}，跳过`)
+    continue
+  }
+  let src = fs.readFileSync(file, 'utf8')
+  let changed = false
+  for (const [bad, good] of EDITS) {
+    if (src.includes(good)) { continue }               // 已打过
+    const n = src.split(bad).length - 1
+    if (n !== 1) {
+      console.error(`[patch-uni-h5] ${name} 里锚点 ${JSON.stringify(bad)} 出现 ${n} 次（期望 1 次）。`)
+      console.error('[patch-uni-h5] uni-h5 结构已变：先确认新版是否已自带空判，再决定改锚点还是删掉本补丁（dev-board#349）。')
+      process.exit(1)
+    }
+    src = src.replace(bad, good)
+    changed = true
+  }
+  if (changed) { fs.writeFileSync(file, src); patched++ } else { already++ }
+}
+
+if (patched) console.log(`[patch-uni-h5] 已补 scroll-view 卸载后写 scrollTop 的空判（${patched} 个产物，dev-board#349）`)
+else if (already) console.log('[patch-uni-h5] 已打过补丁')

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -2389,4 +2389,18 @@ fs.writeFileSync(path.join(OUT, 'report.json'), JSON.stringify(report, null, 2))
 console.log('\n===== 结果 =====')
 console.log('步骤: ' + passed + ' 通过, ' + stepFails + ' 失败; 异常信号 ' + issues.length + ' 条 (截图/报告: ' + OUT + ')')
 for (const i of issues) console.log('  - [' + i.sev + '] ' + i.what)
-process.exit(stepFails ? 1 : 0)
+
+// dev-board#349 的定点护栏。scroll-view 在卸载后仍被框架补写一次 scrollTop，曾经让
+// 产线控制台常驻两条（TypeError + 未处理的 Promise rejection，同一个根因），复现路径
+// 就是本套件走的「项目列表页 → 统一设置页」。修法是给 uni-h5 补空判
+//（frontend/scripts/patch-uni-h5-scrollview.mjs，npm postinstall 自动打）。
+// **控制台异常信号整体不判死**（历史噪音很多，一刀切会天天红），所以这一条单拎出来判死：
+// 补丁没打上（换了 uni-h5 版本、跳过了 postinstall）它立刻回来，不单独判死的话
+// 就只是报告里多两行没人看。
+const scrollTopRegression = issues.filter((i) => /setting 'scrollTop'/.test(i.what))
+if (scrollTopRegression.length) {
+  console.log('\n[dev-board#349] scroll-view 卸载后写 scrollTop 的异常又出现了 ' + scrollTopRegression.length + ' 条。')
+  console.log('  先确认 frontend/node_modules/@dcloudio/uni-h5 上的空判补丁是否还在：')
+  console.log('  cd frontend && node scripts/patch-uni-h5-scrollview.mjs')
+}
+process.exit(stepFails || scrollTopRegression.length ? 1 : 0)


### PR DESCRIPTION
修 dev-board#349。

## 根因与卡上的猜测不一样

卡上猜触发点是 `ChatInterface.vue` 的 `scrollTop.value += 10000`（约 1214 行）与 `FileStagingArea.vue`。读了框架源码并核对堆栈行号后，**两个都不是**：

- 崩的那行是 `uni-h5.es.js:14370` 的 `main.value.scrollTop = val`，位于 `_scrollTopChanged` 里**不带动画**的那条分支。`ChatInterface` 的 scroll-view 显式设了 `:scroll-with-animation="true"`（`ChatInterface.vue:248`），走的是另一条 `scrollTo` 分支，**压根到不了这一行**。
- `FileStagingArea.vue` 的 `scrollTop` 从 `data()` 初始化成 0 之后，全文件再没有任何一处写它。
- 调用方是堆栈里的第二帧 `14483`：
  ```js
  onMounted(() => {
    nextTick(() => {
      _scrollTopChanged(scrollTopNumber.value);   // <- 14483
      _scrollLeftChanged(scrollLeftNumber.value);
    });
  ```
  这是**挂载时框架自己排的那一次补写**，与我们代码里写不写 scrollTop 完全无关。

也就是说：任何 `<scroll-view scroll-y>` 只要在同一批 flush 里挂载又卸载（`v-if` 分支翻转、路由离开），这个 `nextTick` 回调跑到时 `main.value` 已经是 `null`，就崩。复现路径上的那个是统一设置页 `AdminPane.vue:1124` 渲染的 `PersonalWorkLogPanel.vue:36` —— `<scroll-view v-else scroll-y>`，挂在 loading / 空 / 有数据三分支上。

两条错误是同一个根因：Vue 打出 TypeError，`nextTick` 的 promise 链再把它变成一条未处理 rejection，被 `main.js:31` 的全局兜底打成第二条。

## 修法

框架层没有空判，而我们**无法取消**它已经排好的 `nextTick`，只能补这道守卫；语义上也正是对的——元素都没了，本来就没有什么可滚的。照 `desktop/scripts/patch-dmg-builder.js` 的既有套路加一个 `postinstall` 补丁（`frontend/scripts/patch-uni-h5-scrollview.mjs`），对 `uni-h5.es.js` / `uni-h5.cjs.js` 各加三处真值判断：

1. `_scrollTopChanged` 的直写；
2. `_scrollLeftChanged` 的直写；
3. 动画分支 `scrollTo` 的入口 —— 聊天区自动滚动就在这条路上，同一个卸载竞态会崩在 `container.scrollWidth`，一并守住。

锚点在目标文件里必须唯一，**对不上就 `exit 1` 让安装失败**（升级 uni-h5 后报「结构已变」时先看新版是否已自带空判，是就删掉补丁与钩子）。产物侧靠 `npm ci` 触发 postinstall —— `ci.yml` 的 frontend job 与 `desktop-build.yml` 的 Build frontend 步骤都会跑到。

**没有动 `ChatInterface.vue` 一个字**：卡上担心的「改坏聊天区自动滚动这条高频 UI 路径」这条风险不存在。

## 回归护栏

加在 `tests/app-e2e/run.mjs` 结尾。**控制台异常信号整体不判死**（历史噪音多，一刀切会天天红），但 `setting 'scrollTop'` 这一条单拎出来判死 —— 不然补丁哪天掉了也只是报告里多两行没人看。

## 验证（冷启动隔离环境：后端 9797 + dev server 5175，配方见 eng-infra）

**定点探针**，真实鼠标点击走「项目列表页 → 个人中心」：

| | 加载项目列表页 | 跳转到设置页后 |
|---|---|---|
| 改前 | 0 条信号 | **2 条**（`未处理的 Promise rejection` + `TypeError: Cannot set properties of null (setting 'scrollTop')`） |
| 改后 | 0 条信号 | **0 条** |

**全量 `npm run test:app-e2e`，两轮对照**：

| | 步骤 | 异常信号 | 退出码 |
|---|---|---|---|
| 打了补丁 | **131 通过 / 0 失败** | 4 条（1 info + 2 环境 skip + 1 条 J1 上的既有 console 错误） | 0 |
| 还原病灶（把补丁从 node_modules 摘掉） | 131 通过 / 0 失败 | 5 条，多出的正是那两条，出现在 **J2 项目列表页 + 个人设置** | **1**，并打出新护栏的提示 |

摘补丁时校验过三个锚点各自唯一、改后形态存在。两轮的 131/0 一致，说明滚动行为没坏——差异只在这两条信号上。

（打补丁那轮多出的 `[console] JSHandle@error` 出现在 **J1 首启解锁门**，在跳设置页之前；还原病灶那轮它没出现，是条间歇性的既有信号，与本改动无关。）

## 复测提示

打开开发者工具跳一趟「项目列表页 → 设置」，控制台不应再出现 `Cannot set properties of null (setting 'scrollTop')` 与随之而来的未处理 rejection；聊天区发消息后仍应平滑滚到底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)