### PR TITLE
fix(installer): 欢迎大卡片右上角 ✕ 关不掉安装器——Quit 换成 WM_COMMAND IDCANCEL（dev-board#354）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -81,6 +81,18 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    frontend job 与 desktop-build.yml 的 Build frontend 步骤都会跑到）。
    回归护栏在 `tests/app-e2e/run.mjs` 结尾：**控制台异常信号整体不判死**（历史噪音多），
    但 `setting 'scrollTop'` 这一条单拎出来判死。
+6.5.4. **NSIS 地雷：`Quit` 在 nsDialogs 回调里不生效**（dev-board#354，CI 实锤）：
+   `nsDialogs::Show` 跑的是它自己的消息循环——`while (g_dialog.hwDialog) { GetMessage(...); ... }`，
+   **不看 `GetMessage` 的返回值**，只看对话框句柄还在不在。而 NSIS 的 `Quit` 编译成
+   `g_quit_flag++` + `PostQuitMessage(0)`，那条 `WM_QUIT` 被这个循环取走后直接丢弃，
+   循环照转，安装器关不掉。所以**自定义页的任何 `${NSD_OnClick}` 回调里都不要用 `Quit`**，
+   一律 `SendMessage $HWNDPARENT ${WM_COMMAND} <id> 0` 交回 NSIS 页面机
+   （1 = 下一步，2 = 取消/退出），由页面机销毁对话框、Show 的循环才会退出。
+   引擎里三处按钮都是这个写法。诊断配方（当时靠它一轮 CI 定案，值得复用）：
+   同一行相邻热区点一下看 `IsIconic`，证明**点击落到了热区上**；再从外部 `PostMessage`
+   一发 `WM_COMMAND`/`IDCANCEL`，证明**退出通道本身是通的**——两条对照一起把结论
+   钉死在「关窗动作写错了」而不是「点击没命中」。用例：`installer-smoke.ps1 -CloseOnly`
+   （smoke 工作流的「Drive zh harness close button」步骤），是这条路径唯一的覆盖。
 6.6. **`dmg-builder` 补丁（`desktop/scripts/patch-dmg-builder.js` + package.json `postinstall`，安装器 UI 重设计新增）**：macOS 26.2+ 起 Finder 拒读 dmgbuild 写入 `.DS_Store` 的 `pBBk` 背景书签，导致桌面端主 DMG 背景不显示（electron-builder#9072 / dmgbuild#273，同版 Obsidian/Podman Desktop 同期中招）。`npm ci`/`npm install` 后自动对 `node_modules/dmg-builder/vendor/dmgbuild/core.py` 做定点补丁（跳过 Bookmark 生成，`icvp` 里的 alias 通道保留，老系统照常工作）。**升级 electron-builder 后若补丁脚本报「结构已变」**：先确认新版是否已自带该修复，再决定要不要删掉本补丁，不要盲目跳过。
 
 ## 测试命令总表

--- a/.github/workflows/installer-ui-smoke.yml
+++ b/.github/workflows/installer-ui-smoke.yml
@@ -52,6 +52,13 @@ jobs:
         shell: pwsh
         run: pwsh -File desktop/scripts/installer-smoke.ps1 -Exe harness-zh.exe -OutDir shots/zh
 
+      - name: Drive zh harness close button (欢迎卡右上角 ✕ 必须退出，dev-board#354)
+        shell: pwsh
+        # 单独起一个进程只测这一下：欢迎卡一出来就点 ✕，不经过任何对话框或别的热区。
+        # 失败时日志里会带两条对照（同排的最小化热区是否生效、外部发 IDCANCEL 是否能关），
+        # 直接分辨「点击没落到热区上」还是「关窗动作没生效」。
+        run: pwsh -File desktop/scripts/installer-smoke.ps1 -Exe harness-zh.exe -OutDir shots/close -CloseOnly
+
       - name: Drive en harness with screenshots
         shell: pwsh
         run: pwsh -File desktop/scripts/installer-smoke.ps1 -Exe harness-en.exe -OutDir shots/en

--- a/desktop/build/win/awd-oneclick-ui.nsh
+++ b/desktop/build/win/awd-oneclick-ui.nsh
@@ -356,9 +356,16 @@ Function AwdPrivacyClick
   ExecShell "open" "${AWD_UI_PRIVACY_URL}"
 FunctionEnd
 
+; 大卡片右上角 ✕。**这里不能用 Quit**（dev-board#354，CI 实锤）：Quit 只是
+; g_quit_flag++ 加一发 PostQuitMessage，而此刻正处在 nsDialogs::Show 自己的消息
+; 循环里——那个循环只看对话框句柄还在不在，不看 GetMessage 的返回值，WM_QUIT 被它
+; 取走后直接丢弃，循环照转，安装器就此关不掉，用户只能去任务管理器杀。
+; 改走「取消」（IDCANCEL=2）交回 NSIS 页面机：页面机会销毁对话框，Show 的循环
+; 随之退出。与完成卡两个按钮用的 SendMessage WM_COMMAND 同族，那条路已被
+; zh/en 两条冒烟流程实跑覆盖。三个安装器都没定义 MUI_ABORTWARNING，不会多弹确认框。
 Function AwdCloseClick
   Pop $0
-  Quit
+  SendMessage $HWNDPARENT ${WM_COMMAND} 2 0
 FunctionEnd
 
 Function AwdMinClick

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -198,9 +198,9 @@ if ($ExpectBlocked) {
   # 开装了窗口会缩成 360x132 的角落小进度卡；还是 760 宽就说明确实没开装
   if ($wb -lt 700) { throw "installer proceeded to the progress card despite insufficient space (window width $wb)" }
   # 收尾直接杀进程，不点大卡片的 ✕。本用例要断言的是「闸拦住了、没开装」，上面
-  # 三条断言已经全覆盖；关窗行为由 zh/en 两条正常流程在完成卡上覆盖。首轮 CI 实跑里
-  # 这一步点 ✕ 后进程 2 秒内没退（AwdCloseClick 是 Quit，从 nsDialogs::Show 的回调里
-  # 调用是否即时生效没有验证过），拿一条与本闸无关的路径把用例判红不值当。
+  # 三条断言已经全覆盖；大卡片 ✕ 的关窗行为由 -CloseOnly 那条独立用例覆盖，
+  # 不在这里重复点——首轮实跑就是因为把两件事绑在一根流程上，点 ✕ 没退出时
+  # 分不清是闸的问题还是关窗的问题（dev-board#354，根因已确认并修掉）。
   $p.Kill()
   Write-Host 'blocked flow completed: gate fired, install never started'
   exit 0

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -6,7 +6,12 @@ param(
   [Parameter(Mandatory = $true)][string]$OutDir,
   # 磁盘空间闸（dev-board#350）的反向用例：用一个所需空间大到不可能满足的
   # harness 产物驱动，断言「点了立即安装，但没开装」。
-  [switch]$ExpectBlocked
+  [switch]$ExpectBlocked,
+  # 关窗路径专用（dev-board#354）：欢迎大卡片右上角 ✕ 点下去安装器就该退出。
+  # 这条路径原先没有任何用例覆盖过（zh/en 正常流程关的是完成卡的 ✕，走的是另一个
+  # 函数），且必须单独跑——接在别的点击或对话框后面会被焦点/ESC 干扰，分不清
+  # 「点击没落到热区上」还是「关窗动作本身没生效」。
+  [switch]$CloseOnly
 )
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.Drawing
@@ -25,6 +30,9 @@ public class W {
   [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
   [DllImport("user32.dll")] public static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
   [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int cmd);
+  [DllImport("user32.dll")] public static extern bool PostMessage(IntPtr h, uint msg, IntPtr wp, IntPtr lp);
   public struct RECT { public int L, T, R, B; }
   public struct POINT { public int x, y; }
 }
@@ -122,6 +130,49 @@ function ClickAt([int]$bx, [int]$by) {
 
 # 1. 大卡片首页
 Shot '01-welcome'
+
+if ($CloseOnly) {
+  # 先把视线清障单独做掉再断言进程还活着：Clear-Overlay 挡不住视线时会按 ESC，
+  # 而 NSIS 下 ESC 本身就等于「取消」，安装器会因此退出——那样点都没点就绿了。
+  # 这一步把这个假绿口子堵上；清完障后 ClickAt 里那次 Clear-Overlay 会在第 0 轮
+  # 直接返回，不会再按 ESC。
+  $rc = Get-Rect
+  Clear-Overlay ($rc.L + 732) ($rc.T + 24)
+  if ($p.HasExited) { throw "installer exited before the close click was issued (line-of-sight cleanup interfered)" }
+  # 点右上角 ✕（AWDUI_CLOSE 712,8,40,32 → 中心 732,24）。欢迎卡刚出来、没弹过任何
+  # 对话框、没点过任何别的热区，是这条路径最干净的一次点击。
+  ClickAt 732 24
+  Start-Sleep -Seconds 3
+  if ($p.HasExited) {
+    Write-Host 'close flow completed: welcome card close button exited the installer'
+    exit 0
+  }
+  # 没退出。下面两条对照都跑一遍并把结论留在日志里，回归时不用再猜是哪一头坏了。
+  Shot '02-still-open'
+  # 对照一：同一行、左边 44px 的最小化热区（AWDUI_MIN 668,8,40,32 → 中心 688,24），
+  # 走的是 ShowWindow，与关窗机制无关。它生效 = 这一行热区确实被点中了，
+  # 那么 ✕ 关不掉就只能是 AwdCloseClick 里的关窗动作没生效。
+  ClickAt 688 24
+  Start-Sleep -Milliseconds 800
+  $iconic = [W]::IsIconic($h)
+  Write-Host "diag: minimize hotspot (688,24) -> IsIconic=$iconic"
+  if ($iconic) {
+    [W]::ShowWindow($h, 9) | Out-Null    # SW_RESTORE
+    Start-Sleep -Milliseconds 500
+    [W]::SetWindowPos($h, [IntPtr](-1), 0, 0, 0, 0, 0x3) | Out-Null
+    [W]::SetForegroundWindow($h) | Out-Null
+    Start-Sleep -Milliseconds 500
+  }
+  # 对照二：从外部发一次「取消」（WM_COMMAND，IDCANCEL=2），即走 NSIS 页面机自己的
+  # 退出通道——完成卡的 ✕ 用的就是同族的 WM_COMMAND，已知可用。它能关掉、而 ✕ 关不掉，
+  # 就把结论钉死在「AwdCloseClick 用的退出方式不对」上。
+  [W]::PostMessage($h, 0x0111, [IntPtr]2, [IntPtr]::Zero) | Out-Null
+  Start-Sleep -Seconds 3
+  Write-Host "diag: WM_COMMAND IDCANCEL from outside -> HasExited=$($p.HasExited)"
+  if (-not $p.HasExited) { $p.Kill() }
+  throw "installer did not exit after clicking the welcome card close button"
+}
+
 # 2. 展开自定义安装（AWDUI_TOGGLE 44,448,130,26 → 中心 109,461）
 ClickAt 109 461
 Start-Sleep -Milliseconds 600


### PR DESCRIPTION
修 [dev-board#354](https://github.com/zeweihan/dev-board/issues/354)。

## 结论先说

Bug 是真的，而且比卡上估计的严重：**不是冒烟脚本的偶发，是线上安装器里那个 ✕ 一直就是死的**。
用户打开安装器又改主意，只能去任务管理器杀进程。一键 UI 上线至今都是这样。
桌面端与 Office 插件端共用同一个引擎，两边都中招。

## 复现（先复现，没有直接改引擎）

新加的 `-CloseOnly` 用例：单起一个进程，欢迎卡一出来就点右上角 ✕，
不经过任何对话框、不点任何别的热区。
[run 33473126507](https://github.com/zeweihan/aiworkdeck/actions/runs/33473126507)（**引擎未改动**）稳定复现：
点完等 3 秒，进程还活着，窗口还是原样 760x500，截图 `close/02-still-open.png` 里卡片纹丝未动。

同一轮里两条对照把结论钉死，一轮 CI 就定案：

| 探针 | 结果 | 排除了什么 |
|---|---|---|
| ✕ 热区 (732,24) | 3 秒后进程仍在，窗口 760x500 | — 就是症状本身 |
| 最小化热区 (688,24)，同一行、左边 44px | `IsIconic=True` | 点击定位、热区几何、z 序 |
| 从外部发 `WM_COMMAND`/`IDCANCEL` | `HasExited=True` | NSIS 的退出通道被堵 |

即：**点击确实落在热区上，`AwdCloseClick` 也确实跑了，是 `Quit` 没生效。**

## 根因

`nsDialogs::Show` 跑的是它自己的消息循环：

```c
while (g_dialog.hwDialog) {
  GetMessage(&msg, NULL, 0, 0);          // 返回值被忽略
  if (!IsDialogMessage(...)) { TranslateMessage(&msg); DispatchMessage(&msg); }
}
```

它不看 `GetMessage` 的返回值，只看对话框句柄还在不在。而 NSIS 的 `Quit` 编译成
`g_quit_flag++` + `PostQuitMessage(0)`——那条 `WM_QUIT` 被这个循环取走后直接丢弃，
循环照转，安装器关不掉。

这也解释了为什么完成卡的 ✕ 一直好使：它走 `WM_COMMAND`，NSIS 页面机会**销毁对话框**，
而那正是这个循环的退出条件。`AwdCloseClick` 是整个引擎里唯一一处用 `Quit` 的地方。

## 改法

`Quit` → `SendMessage $HWNDPARENT ${WM_COMMAND} 2 0`（取消），与完成卡两个按钮同族的写法，
那条路早被 zh/en 两条冒烟流程实跑覆盖。三个安装器（桌面 / 插件 / harness）都没有定义
`MUI_ABORTWARNING`，不会多弹一个确认框——已逐个 grep 确认。

## 自验证

[run 33473462790](https://github.com/zeweihan/aiworkdeck/actions/runs/33473462790) 五条实跑流程全绿：
zh / **close** / en / nospace（#350 的闸仍然拦得住）/ addin。
关窗那条的日志是 `close flow completed: welcome card close button exited the installer`，
且全程没有出现 `line of sight` / `killing overlay`——**没有按过 ESC**，退出确实归因于那一下点击。

**用例是真的依赖这个补丁**：红绿两轮之间 `installer-smoke.ps1` 的 `-CloseOnly` 代码块
sha 完全一致（`7d89b3f9…`），驱动脚本的唯一差异是 `-ExpectBlocked` 里一段注释，
功能改动只有引擎那一行。红→绿完全由补丁驱动。

## 一处需要留意的行为变化

进程退出码从 0 变成 1（NSIS 的「用户取消」）。已 grep 确认**没有任何东西消费安装器的退出码**，
静默安装 `/S`（自动更新那条路）根本不进 GUI 代码；而且对「点 ✕ 取消」来说 1 本来就是更正确的语义。

## 顺带

- `-ExpectBlocked` 里那段引用「未验证的 Quit」的注释已更新。
- 地雷与那套两条对照的诊断配方记进 `.claude/agents/eng-infra.md` 6.5.4——
  自定义页的 `${NSD_OnClick}` 回调里一律不要用 `Quit`。
- `-CloseOnly` 这条用例本身留在 CI 里：这条路径此前是零覆盖，这是本卡的最低限度交付。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
