### PR TITLE
feat(auth): 审核账号旁路支持多个标识——Apple 用邮箱、微信用手机号并存（dev-board#347）

### DIFF
--- a/backend/src/main/java/com/checkba/config/ReviewAccountGate.java
+++ b/backend/src/main/java/com/checkba/config/ReviewAccountGate.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * App 审核专用账号的固定验证码。
@@ -20,21 +24,26 @@ import java.security.MessageDigest;
  * <p><b>这是一个认证旁路，按认证旁路对待：</b>
  * <ul>
  *   <li>默认关。两个配置项任意一个为空即全关，不存在「配了一半」的中间态。</li>
- *   <li>只对<b>配置里那一个</b>标识生效，别的手机号/邮箱一律走原路。</li>
+ *   <li>只对<b>配置里列出的</b>标识生效，别的手机号/邮箱一律走原路。</li>
  *   <li>只开在免密登录（signin）那条路上，绑定手机号/绑定邮箱不走这里。</li>
  *   <li>码写错格式就<b>拒绝启动</b>——照 {@link PhoneLoginGuard} 的同一口径。
  *       一个配歪了的旁路比没有旁路更糟：它会以「审核员登不进去」的形式在
  *       几天后才暴露，而那时排查方向已经跑到客户端去了。</li>
  * </ul>
  *
- * <p><b>运维要求：</b>审核账号里不要放真实数据。谁拿到那 6 位码就能登进这一个
- * 账号，而这个码是写在 ASC 备注里给外部人看的。审核结束后把
+ * <p><b>运维要求：</b>审核账号里不要放真实数据。谁拿到那 6 位码就能登进这些
+ * 账号，而这个码是写在审核备注里给外部人看的。审核结束后把
  * {@code auth.review-account.identity} 清空即可关掉。
+ *
+ * <p><b>为什么标识是一个列表。</b>各家审核同时在跑，且要的形状不一样：Apple 要
+ * 邮箱（国际版），微信小程序审核要中国大陆手机号（小程序只有短信登录一条路）。
+ * 一次只能配一个的话，两家撞档期就得二选一，而「临时改成另一家」意味着前一家
+ * 的审核员会在毫无预兆的情况下登不进去。多个标识共用同一个码即可。
  *
  * <p>配置（服务器 env / application.yml，别入库）：
  * <pre>
- *   auth.review-account.identity: appreview@example.com   # 手机号或邮箱，写规范化后的形式
- *   auth.review-account.code: "246813"                    # 6 位数字
+ *   auth.review-account.identity: appreview@example.com,13800138000   # 逗号分隔，写规范化后的形式
+ *   auth.review-account.code: "246813"                                # 6 位数字，所有标识共用
  * </pre>
  */
 @Component
@@ -42,18 +51,22 @@ public class ReviewAccountGate {
 
     private static final Logger log = LoggerFactory.getLogger(ReviewAccountGate.class);
 
-    private final String identity;
+    private final Set<String> identities;
     private final byte[] code;
 
     public ReviewAccountGate(
             @Value("${auth.review-account.identity:}") String identity,
             @Value("${auth.review-account.code:}") String code) {
 
-        String id = identity == null ? "" : identity.trim().toLowerCase();
+        Set<String> ids = identity == null ? Set.of()
+                : Arrays.stream(identity.split(","))
+                        .map(s -> s.trim().toLowerCase())
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
         String cd = code == null ? "" : code.trim();
 
-        if (id.isEmpty() || cd.isEmpty()) {
-            this.identity = null;
+        if (ids.isEmpty() || cd.isEmpty()) {
+            this.identities = Set.of();
             this.code = null;
             return;
         }
@@ -63,11 +76,12 @@ public class ReviewAccountGate {
                             + "客户端的验证码输入框只收 6 位数字，配成别的形式等于这条旁路"
                             + "永远走不通，而症状要等审核员登不进去才看得见。");
         }
-        this.identity = id;
+        this.identities = ids;
         this.code = cd.getBytes(StandardCharsets.UTF_8);
         // 生产上开着这条口子是有意为之还是配漏了，只能靠这行日志区分。
         log.warn("App 审核账号旁路已启用：{} 可用固定验证码登录。审核结束后清空 "
-                + "auth.review-account.identity 关闭。", masked(id));
+                + "auth.review-account.identity 关闭。",
+                ids.stream().map(ReviewAccountGate::masked).collect(Collectors.joining(", ")));
     }
 
     /**
@@ -81,7 +95,7 @@ public class ReviewAccountGate {
 
     /** 这条旁路是否开着。 */
     public boolean enabled() {
-        return identity != null;
+        return !identities.isEmpty();
     }
 
     /**
@@ -95,7 +109,7 @@ public class ReviewAccountGate {
         if (!enabled() || normalizedIdentity == null) {
             return false;
         }
-        return identity.equals(normalizedIdentity.trim().toLowerCase());
+        return identities.contains(normalizedIdentity.trim().toLowerCase());
     }
 
     /**

--- a/backend/src/test/java/com/checkba/config/ReviewAccountGateTest.java
+++ b/backend/src/test/java/com/checkba/config/ReviewAccountGateTest.java
@@ -41,7 +41,7 @@ class ReviewAccountGateTest {
     }
 
     @Test
-    @DisplayName("只对配置里那一个标识生效")
+    @DisplayName("只对配置里列出的标识生效")
     void onlyMatchesConfiguredIdentity() {
         ReviewAccountGate gate = new ReviewAccountGate("appreview@example.com", "246813");
         assertTrue(gate.matches("appreview@example.com"));
@@ -49,6 +49,25 @@ class ReviewAccountGateTest {
         assertFalse(gate.matches("someoneelse@example.com"));
         assertFalse(gate.matches(""));
         assertFalse(gate.matches(null));
+    }
+
+    @Test
+    @DisplayName("逗号分隔的多个标识共用同一个码：Apple 用邮箱、微信用手机号，两家并存")
+    void matchesEveryConfiguredIdentity() {
+        ReviewAccountGate gate = new ReviewAccountGate("appreview@example.com, 13800138000 ", "246813");
+        assertTrue(gate.accepts("appreview@example.com", "246813"));
+        assertTrue(gate.accepts("13800138000", "246813"), "加进来的手机号不该挤掉原有的邮箱");
+        assertFalse(gate.accepts("13900000000", "246813"), "没列出的标识拿到码也不放行");
+    }
+
+    @Test
+    @DisplayName("列表里的空项被丢弃，全空等于关闭")
+    void ignoresBlankEntries() {
+        ReviewAccountGate gate = new ReviewAccountGate("a@b.com,,  ,", "246813");
+        assertTrue(gate.enabled());
+        assertTrue(gate.matches("a@b.com"));
+        assertFalse(gate.matches(""), "空标识永远不是审核账号");
+        assertFalse(new ReviewAccountGate(" , ,", "246813").enabled());
     }
 
     @Test


### PR DESCRIPTION
## 为什么

微信小程序 0.30.0 提审的「测试账号」栏要一个能登进去的账号，而小程序只有手机号短信验证码一条登录路——审核员收不到我们的短信。已有的审核账号旁路（`ReviewAccountGate`）正好在这条链路上（`SmsAuthService.sendSigninCode/verifySigninCode`），但 `auth.review-account.identity` 只收**一个**值，而它此刻正被 Apple 审核占用（邮箱标识，两个 App 在审）。两家撞档期就得二选一，临时改成另一家等于让前一家的审核员毫无预兆地登不进去。

## 改了什么

`identity` 从单值改成逗号分隔的列表（`Set<String>`，保序去重），多个标识共用同一个 6 位码。

语义与红线一个字没动：任一配置项为空即全关、码非 6 位数字仍然拒绝启动、只开在免密登录那条路上、未列出的标识一律走原路。`sendSigninCode` 对审核账号短路不发短信这条也不变——所以列表里放测试号**不会给真人发短信**。

## 自验证

`ReviewAccountGateTest` / `SmsAuthServiceTest` / `MailAuthServiceTest` 共 30 个用例全绿（新增 2 个：多标识并存、空项丢弃）。

## 部署说明

**本地 `mvn package` 产出 989M，而服务器在跑的 jar 是 405M——构建口径不一致，不要直接覆盖。** 差异来自 opencv 三平台原生库与 driver-bundle（本地全量打进来了）。本次上线采用最小侵入方式：只把 `BOOT-INF/classes/com/checkba/config/ReviewAccountGate.class` 打进服务器现有 jar（公开方法签名未变，与已在 jar 里的调用方二进制兼容），其余字节不动。下次整包部署时该改动随 master 一起进去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)