### PR TITLE
fix(installer): 一键安装器点「立即安装」后不缩成角落进度卡——SHOW 钩子被路过的页吃掉（dev-board#356）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -93,6 +93,32 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    一发 `WM_COMMAND`/`IDCANCEL`，证明**退出通道本身是通的**——两条对照一起把结论
    钉死在「关窗动作写错了」而不是「点击没命中」。用例：`installer-smoke.ps1 -CloseOnly`
    （smoke 工作流的「Drive zh harness close button」步骤），是这条路径唯一的覆盖。
+6.5.5. **NSIS 地雷：`MUI_PAGE_CUSTOMFUNCTION_SHOW` 会被「路过的页」在编译期抢走**
+   （dev-board#356，实机翻车、CI 全绿）：MUI2 的 `Pages.nsh` 里
+   `MUI_PAGE_FUNCTION_CUSTOM` 展开成 `Call <fn>` **紧跟一句 `!undef`**——这个 define
+   是「谁先展开谁吃掉」的一次性货。一键 UI 原先把安装页的 SHOW 回调
+   （`AwdInstFilesShow`，负责把主窗收成 360×132 角落进度卡）挂在 `AWD_UI_PAGE_WELCOME`
+   宏里，赌「紧随其后的就是 `MUI_PAGE_INSTFILES`」。ui-harness 里确实如此，
+   **桌面端真产物不是**：electron-builder 的 `assistedInstaller.nsh` 页序是
+   `customWelcomePage → [licensePage] → PAGE_INSTALL_MODE → [MUI_PAGE_DIRECTORY]
+   → customPageAfterChangeDir → MUI_PAGE_INSTFILES`，中间那张「安装模式」页
+   （`perMachine=false` 才有）先把 SHOW 吃掉；更阴的是它自己又被我们的
+   `customInstallMode`（`$isForceCurrentInstall=1`）在 PRE 里 `Abort` 跳过，
+   那句 `Call` 连跑都不会跑。两头都不响 = 安装页塌回 NSIS 原生向导
+   （进度条贴顶、原生「上一步」飘在窗口中间、装完停在「已完成」不走完成卡）。
+   现在的写法：引擎导出 `AWD_UI_INSTFILES_HOOK`（只 define）与
+   `AWD_UI_PAGE_INSTFILES`（钩子 + 页的原子宏）。**自己掌握页序的调用方
+   （ui-harness、Office 插件安装器）一律用原子宏**；桌面端页序在 electron-builder
+   手里，钩子挂 `customPageAfterChangeDir`——那是唯一紧贴 INSTFILES 之前的钩子，
+   **升级 electron-builder 要回头核一眼这个页序还成不成立**。
+   回归护栏：`ui-harness.nsi` 的 `-DEB_PAGE_ORDER` 复刻那张「运行期被 Abort 跳过、
+   编译期照吃 MUI 定义」的页，smoke 工作流多编一个 `harness-eborder.exe` 实跑；
+   同时 `installer-smoke.ps1` 在「点完立即安装」后**真做断言**了（此前只截图：
+   窗口宽度必须缩到小卡片、原生「上一步」按钮 IDC 3 必须不可见）——
+   老坑之所以能瞒过八个月，就是因为那一步只截图不断言。
+   **教训**：`ui-harness` 只覆盖引擎，不覆盖「引擎怎么被真产物接线」；
+   凡是与 electron-builder 模板契约有关的改动，用例必须复刻它的页序。
+
 6.6. **`dmg-builder` 补丁（`desktop/scripts/patch-dmg-builder.js` + package.json `postinstall`，安装器 UI 重设计新增）**：macOS 26.2+ 起 Finder 拒读 dmgbuild 写入 `.DS_Store` 的 `pBBk` 背景书签，导致桌面端主 DMG 背景不显示（electron-builder#9072 / dmgbuild#273，同版 Obsidian/Podman Desktop 同期中招）。`npm ci`/`npm install` 后自动对 `node_modules/dmg-builder/vendor/dmgbuild/core.py` 做定点补丁（跳过 Bookmark 生成，`icvp` 里的 alias 通道保留，老系统照常工作）。**升级 electron-builder 后若补丁脚本报「结构已变」**：先确认新版是否已自带该修复，再决定要不要删掉本补丁，不要盲目跳过。
 
 ## 测试命令总表

--- a/.github/workflows/installer-ui-smoke.yml
+++ b/.github/workflows/installer-ui-smoke.yml
@@ -45,6 +45,10 @@ jobs:
           makensis /INPUTCHARSET UTF8 /DHARNESS_LANG=English /DREQUIRED_KB=204800 "/DGENART=$ws\desktop\build\win\generated" "/DPAYLOAD=$ws\payload" "/DOUTFILE=$ws\harness-en.exe" desktop\build\win\ui-harness.nsi
           # 反向用例：所需空间约 858 GB，runner 上必然不足，走「拦下」分支
           makensis /INPUTCHARSET UTF8 /DHARNESS_LANG=SimpChinese /DREQUIRED_KB=900000000 "/DGENART=$ws\desktop\build\win\generated" "/DPAYLOAD=$ws\payload" "/DOUTFILE=$ws\harness-nospace.exe" desktop\build\win\ui-harness.nsi
+          # electron-builder 页序复刻（dev-board#356）：欢迎页与 INSTFILES 之间夹一张
+          # 运行期被 Abort 跳过、编译期照吃 MUI 定义的「安装模式」页。上面几个 harness
+          # 是欢迎页紧贴 INSTFILES 的理想页序，测不出这个坑；桌面端真产物走的是这一种。
+          makensis /INPUTCHARSET UTF8 /DHARNESS_LANG=SimpChinese /DREQUIRED_KB=204800 /DEB_PAGE_ORDER "/DGENART=$ws\desktop\build\win\generated" "/DPAYLOAD=$ws\payload" "/DOUTFILE=$ws\harness-eborder.exe" desktop\build\win\ui-harness.nsi
           Set-Content -Path dummy-manifest.xml -Value '<?xml version="1.0"?><OfficeApp/>'
           makensis /INPUTCHARSET UTF8 /DVERSION=0.0.1 "/DMANIFEST=$ws\dummy-manifest.xml" "/DOUTFILE=$ws\addin-smoke.exe" "/DARTDIR=$ws\office-addin\installer\win" "/DAWD_UI_ENGINE=$ws\desktop\build\win\awd-oneclick-ui.nsh" "/DGENART=$ws\office-addin\installer\win\generated" /DLEGALBASE=https://www.aiworkdeck.com office-addin\installer\win\installer.nsi
 
@@ -58,6 +62,12 @@ jobs:
         # 失败时日志里会带两条对照（同排的最小化热区是否生效、外部发 IDCANCEL 是否能关），
         # 直接分辨「点击没落到热区上」还是「关窗动作没生效」。
         run: pwsh -File desktop/scripts/installer-smoke.ps1 -Exe harness-zh.exe -OutDir shots/close -CloseOnly
+
+      - name: Drive eborder harness (electron-builder 页序，dev-board#356)
+        shell: pwsh
+        # 与桌面端真产物同一种页序。走的是正常流程，断言在 installer-smoke.ps1 里：
+        # 点完「立即安装」窗口必须缩成角落小进度卡、原生「上一步」按钮必须不可见。
+        run: pwsh -File desktop/scripts/installer-smoke.ps1 -Exe harness-eborder.exe -OutDir shots/eborder
 
       - name: Drive en harness with screenshots
         shell: pwsh

--- a/desktop/build/installer.nsh
+++ b/desktop/build/installer.nsh
@@ -57,6 +57,22 @@
   !insertmacro AWD_UI_PAGE_WELCOME
 !macroend
 
+; 安装页的 SHOW 回调（点「立即安装」后主窗收成角落小进度卡）必须挂在
+; electron-builder 生成脚本里那一句 !insertmacro MUI_PAGE_INSTFILES 上。
+; assistedInstaller.nsh 的页序是：
+;   customWelcomePage → [licensePage] → PAGE_INSTALL_MODE → [MUI_PAGE_DIRECTORY]
+;   → customPageAfterChangeDir → MUI_PAGE_INSTFILES → customFinishPage
+; customPageAfterChangeDir 是**唯一紧贴 INSTFILES 之前**的钩子，所以挂这里。
+; 挂在 customWelcomePage 里不行（dev-board#356 实机翻车）：中间那张
+; 「安装模式」页（perMachine=false 才有）会在编译期把 MUI_PAGE_CUSTOMFUNCTION_SHOW
+; 吃掉，而它自己又被我们的 customInstallMode 在 PRE 里 Abort 跳过——回调既没挂到
+; 安装页、也没被跳过的那页跑到，安装页于是露出 NSIS 原生向导（进度条贴顶、
+; 「上一步」按钮飘在中间）。这一段是与 electron-builder 模板的契约，升级
+; electron-builder 后要回头核一眼 assistedInstaller.nsh 的页序还是不是这样。
+!macro customPageAfterChangeDir
+  !insertmacro AWD_UI_INSTFILES_HOOK
+!macroend
+
 !macro customInstallMode
   ; 桌面端始终按当前用户安装（历史默认即 perMachine=false），跳过安装模式选择页
   StrCpy $isForceCurrentInstall "1"

--- a/desktop/build/win/awd-oneclick-ui.nsh
+++ b/desktop/build/win/awd-oneclick-ui.nsh
@@ -17,10 +17,12 @@
 ;   !define AWD_UI_TERMS_URL / AWD_UI_PRIVACY_URL
 ;   !macro AwdUiOnLaunch                       ; 可选：完成卡「立即体验」的动作（缺省=仅关闭）
 ; 然后在页面序列里插：
-;   !insertmacro AWD_UI_PAGE_WELCOME           ; 大卡片首页（内部给紧随其后的 MUI_PAGE_INSTFILES
-;                                              ;   挂 SHOW 回调，把窗口变成角落小卡片）
-;   <MUI_PAGE_INSTFILES 由调用方/electron-builder 插入>
+;   !insertmacro AWD_UI_PAGE_WELCOME           ; 大卡片首页
+;   !insertmacro AWD_UI_PAGE_INSTFILES         ; 角落进度卡（= SHOW 钩子 + MUI_PAGE_INSTFILES）
 ;   !insertmacro AWD_UI_PAGE_FINISH            ; 角落完成卡
+; 页序由 electron-builder 之类的外部模板掌握、MUI_PAGE_INSTFILES 不归调用方插时，
+; 改插 !insertmacro AWD_UI_INSTFILES_HOOK，且**必须紧贴那句 MUI_PAGE_INSTFILES 之前**
+;（原因见文件末尾 AWD_UI_INSTFILES_HOOK 的注释，dev-board#356）。
 ;
 ; 坐标契约：所有热区坐标必须与 oneclick-*.html 里的绝对定位一致（两边都以 96dpi
 ; 基准像素书写，运行期统一乘 $AwdScale）。改布局要两处同步改。
@@ -654,8 +656,24 @@ FunctionEnd
 ; ---------- 页面插入宏 ----------
 !macro AWD_UI_PAGE_WELCOME
   Page custom AwdWelcomeCreate
-  ; 紧随其后的 MUI_PAGE_INSTFILES 会消费这个 SHOW 回调（自定义 Page 不消费 MUI 定义）
+!macroend
+
+; 安装页的 SHOW 回调（把窗口变成角落小进度卡）。
+;
+; **必须紧贴 MUI_PAGE_INSTFILES 之前插，中间不许再夹任何 MUI 页**——
+; MUI_PAGE_CUSTOMFUNCTION_SHOW 是「谁先展开谁吃掉」的一次性 define：MUI2 的
+; Pages.nsh 里 MUI_PAGE_FUNCTION_CUSTOM 展开成 `Call <fn>` + 紧跟一句 `!undef`，
+; 所以夹在中间的任何 MUI 页都会在**编译期**把它抢走，安装页就此没有 SHOW 回调。
+; 更阴的是抢走它的那个页在运行期还可能被 Abort 跳过（electron-builder 的「安装模式」
+; 页就是），于是那句 Call 连跑都不会跑——两头都不响，界面塌成原生向导（dev-board#356）。
+!macro AWD_UI_INSTFILES_HOOK
   !define MUI_PAGE_CUSTOMFUNCTION_SHOW AwdInstFilesShow
+!macroend
+
+; 自己掌握页序的调用方（测试壳、插件安装器）用这个：钩子和页在同一个宏里，抢不走。
+!macro AWD_UI_PAGE_INSTFILES
+  !insertmacro AWD_UI_INSTFILES_HOOK
+  !insertmacro MUI_PAGE_INSTFILES
 !macroend
 
 !macro AWD_UI_PAGE_FINISH
@@ -665,6 +683,8 @@ FunctionEnd
 !else
 ; 卸载器构建通道：一键 UI 只作用于安装器，卸载器保持 MUI 经典页（仍受益于 DPI 声明）
 !macro AWD_UI_PAGE_WELCOME
+!macroend
+!macro AWD_UI_INSTFILES_HOOK
 !macroend
 !macro AWD_UI_PAGE_FINISH
 !macroend

--- a/desktop/build/win/ui-harness.nsi
+++ b/desktop/build/win/ui-harness.nsi
@@ -4,9 +4,11 @@
 ; 编译参数：
 ;   makensis -INPUTCHARSET UTF8 -DHARNESS_LANG=SimpChinese|English
 ;            -DGENART=<位图目录> -DPAYLOAD=<假 payload 目录> -DOUTFILE=<exe>
-;            [-DREQUIRED_KB=<n>] ui-harness.nsi
+;            [-DREQUIRED_KB=<n>] [-DEB_PAGE_ORDER] ui-harness.nsi
 ; REQUIRED_KB 打开磁盘空间闸（dev-board#350）：给个小值走「够用」分支，给个大到
 ; 不可能满足的值走「拦下」分支——installer-ui-smoke 两个分支都编译并实跑截图。
+; EB_PAGE_ORDER 复刻 electron-builder 的页序（欢迎页与 INSTFILES 之间夹一张运行期被
+; Abort 跳过、编译期照吃 MUI 定义的页），是 dev-board#356 的回归用例。
 Unicode true
 !include "MUI2.nsh"
 
@@ -29,6 +31,25 @@ InstallDir "$LOCALAPPDATA\AWDUIHarness"
 !include "awd-oneclick-ui.nsh"
 
 !insertmacro AWD_UI_PAGE_WELCOME
+!ifdef EB_PAGE_ORDER
+  ; 复刻 electron-builder（assisted 安装器 + perMachine=false）的真实页序：欢迎页与
+  ; INSTFILES 之间夹着 multiUserUi.nsh 的「安装模式」页。这张页在运行期被 PRE 里的
+  ; Abort 跳过（桌面端的 customInstallMode 强制按当前用户装），但它在**编译期**照样
+  ; 展开 MUI_PAGE_FUNCTION_CUSTOM SHOW，把 MUI_PAGE_CUSTOMFUNCTION_SHOW 吃掉并 !undef。
+  ; 下面这段与 multiUserUi.nsh 的结构逐句对应（MUI_PAGE_INIT → PageEx custom →
+  ; PRE 里先 Abort、后两句 MUI_PAGE_FUNCTION_CUSTOM），是 dev-board#356 的病灶复刻：
+  ; SHOW 钩子只要不是紧贴 INSTFILES 挂的，这条流水线就必须红。
+  !insertmacro MUI_PAGE_INIT
+  Function AwdHarnessInstallModePre
+    Abort
+    !insertmacro MUI_PAGE_FUNCTION_CUSTOM PRE
+    !insertmacro MUI_PAGE_FUNCTION_CUSTOM SHOW
+  FunctionEnd
+  PageEx custom
+    PageCallbacks AwdHarnessInstallModePre
+    Caption " "
+  PageExEnd
+!endif
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro AWD_UI_PAGE_FINISH
 !insertmacro MUI_LANGUAGE "${HARNESS_LANG}"

--- a/desktop/build/win/ui-harness.nsi
+++ b/desktop/build/win/ui-harness.nsi
@@ -50,7 +50,7 @@ InstallDir "$LOCALAPPDATA\AWDUIHarness"
     Caption " "
   PageExEnd
 !endif
-!insertmacro MUI_PAGE_INSTFILES
+!insertmacro AWD_UI_PAGE_INSTFILES
 !insertmacro AWD_UI_PAGE_FINISH
 !insertmacro MUI_LANGUAGE "${HARNESS_LANG}"
 

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -33,6 +33,8 @@ public class W {
   [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr h);
   [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int cmd);
   [DllImport("user32.dll")] public static extern bool PostMessage(IntPtr h, uint msg, IntPtr wp, IntPtr lp);
+  [DllImport("user32.dll")] public static extern IntPtr GetDlgItem(IntPtr h, int id);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
   public struct RECT { public int L, T, R, B; }
   public struct POINT { public int x, y; }
 }
@@ -208,6 +210,23 @@ if ($ExpectBlocked) {
 
 Start-Sleep -Milliseconds 1500
 Shot '03-progress'
+# 断言真的进了「角落小进度卡」形态（dev-board#356）。此前这一步只截图不断言，
+# 于是真机上安装页塌回 NSIS 原生向导、流水线照样全绿。两条判据各堵一头：
+#   宽度——大卡片 760、小进度卡 360，没缩就是 AwdInstFilesShow 根本没跑；
+#   原生「上一步」按钮（IDC 3）——AwdHideChrome 每页都压一遍，它可见就说明
+#   这一页压根没经过我们的 SHOW 回调（用户实机截图上飘在窗口中间的就是它）。
+$rp = Get-Rect
+$wp = $rp.R - $rp.L
+$hp = $rp.B - $rp.T
+$back = [W]::GetDlgItem($h, 3)
+$backVisible = ($back -ne [IntPtr]::Zero) -and [W]::IsWindowVisible($back)
+Write-Host "progress card: $wp x $hp, native back button visible=$backVisible"
+if ($wp -gt 700) {
+  throw "install started but the window never shrank to the corner progress card ($wp x $hp, expected 360x132) - AwdInstFilesShow did not run"
+}
+if ($backVisible) {
+  throw "native wizard chrome is showing on the install page (back button visible) - AwdInstFilesShow did not run"
+}
 Start-Sleep -Milliseconds 2500
 Shot '04-progress2'
 # 4. 等安装收尾进完成卡（payload + 3x2s Sleep，10 秒余量）

--- a/office-addin/installer/win/installer.nsi
+++ b/office-addin/installer/win/installer.nsi
@@ -42,7 +42,10 @@ VIAddVersionKey /LANG=1033 "LegalCopyright" "AI WorkDeck"
 !include "${AWD_UI_ENGINE}"
 
 !insertmacro AWD_UI_PAGE_WELCOME
-!insertmacro MUI_PAGE_INSTFILES
+; AWD_UI_PAGE_INSTFILES = 「角落进度卡的 SHOW 钩子 + MUI_PAGE_INSTFILES」原子宏。
+; 别拆成两句、更别把钩子挪到欢迎页宏里：夹在中间的任何 MUI 页都会在编译期把
+; MUI_PAGE_CUSTOMFUNCTION_SHOW 吃掉（dev-board#356）。
+!insertmacro AWD_UI_PAGE_INSTFILES
 !insertmacro AWD_UI_PAGE_FINISH
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_INSTFILES


### PR DESCRIPTION
真机症状（用户 Mac 上的 Windows 虚拟机）：欢迎大卡片正常，**点完「立即安装」界面塌回 NSIS 原生向导**——进度条贴顶、原生「上一步(P)」按钮飘在窗口中间、窗口还是 760 宽的大卡片尺寸。原始需求是对齐搜狗：点完应当收成桌面右上角 360x132 的小进度卡。

## 根因

MUI2 的 `MUI_PAGE_CUSTOMFUNCTION_SHOW` 是「谁先展开谁吃掉」的一次性 define——`Pages.nsh` 里 `MUI_PAGE_FUNCTION_CUSTOM` 展开成 `Call <fn>` 紧跟一句 `!undef`。引擎原先把安装页的 SHOW 回调 `AwdInstFilesShow`（负责把主窗收成角落小卡片）挂在 `AWD_UI_PAGE_WELCOME` 宏里，赌「紧随其后的就是 `MUI_PAGE_INSTFILES`」。

Office 插件安装器确实如此，**桌面端不是**。electron-builder 的 `assistedInstaller.nsh` 页序是：

```
customWelcomePage → [licensePage] → PAGE_INSTALL_MODE → [MUI_PAGE_DIRECTORY]
→ customPageAfterChangeDir → MUI_PAGE_INSTFILES → customFinishPage
```

中间那张「安装模式」页（`perMachine=false` 才有）在**编译期**先把 SHOW 吃掉并 `!undef`；而它自己又被本仓的 `customInstallMode`（`$isForceCurrentInstall=1`）在 PRE 里 `Abort` 跳过，那句 `Call AwdInstFilesShow` 连跑都不会跑。两头都不响，回调从未执行——安装页于是保持 NSIS 原生形态。

CI 一直全绿是因为 `ui-harness` 走的是「欢迎页紧贴 INSTFILES」的理想页序，且「点完立即安装」那一步**只截图不断言**。

## 修法

- 引擎拆出 `AWD_UI_INSTFILES_HOOK`（只 define）与 `AWD_UI_PAGE_INSTFILES`（钩子 + 页的原子宏），欢迎页宏不再偷偷挂钩子；
- `ui-harness` / Office 插件安装器改用原子宏，页序由自己掌握，抢不走；
- 桌面端页序在 electron-builder 手里，钩子挂 `customPageAfterChangeDir`——那是唯一紧贴 INSTFILES 之前的钩子。升级 electron-builder 要回核这个页序（注释里已写死这条契约）。

## 红绿两轮（同一份用例代码，测试代码未变）

| run | 引擎 | `harness-eborder` | 理想页序的 zh/en |
|---|---|---|---|
| [33479867391](https://github.com/zeweihan/aiworkdeck/actions/runs/33479867391) | 未改 | **红**：`progress card: 760 x 568, native back button visible=True` | 绿 |
| [33480261799](https://github.com/zeweihan/aiworkdeck/actions/runs/33480261799) | 已修 | 绿：360x132 小进度卡 | 绿（含 ARM 腿） |

红轮的 `shots/eborder/03-progress.png` 与用户实机截图同形（进度条贴顶 + 「上一步」飘在中间）。

## 回归护栏

- `ui-harness.nsi` 新增 `-DEB_PAGE_ORDER`：按 `multiUserUi.nsh` 逐句复刻那张「运行期被 Abort 跳过、编译期照吃 MUI 定义」的页，smoke 工作流多编一个 `harness-eborder.exe` 实跑；
- `installer-smoke.ps1` 在「点完立即安装」后**真做断言**了：窗口宽度必须缩到小卡片，原生「上一步」按钮（IDC 3）必须不可见。老坑之所以能瞒过去，就是因为这一步只截图。

地雷入档 `.claude/agents/eng-infra.md` 6.5.5。

dev-board#356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
