### PR TITLE
chore(release): v0.31.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
自 v0.30.0 起的内容：

- **安装器三修**（dev-board#350 / #354 / #356）：磁盘空间闸、欢迎大卡片右上角 ✕ 关不掉、**点「立即安装」后不缩成角落进度卡**（真机塌回 NSIS 原生向导——最后一条是实机翻车，CI 一直全绿，护栏已补）；
- **登录**（dev-board#347 + PR#687）：邮箱免密登录改为注册登录合一；审核账号旁路支持 Apple 邮箱与微信手机号并存；
- **i18n**（dev-board#351）：本机用户中文名在「变量库创建者」与「版本时间线署名」两处的快照式泄漏；
- **前端**（dev-board#349）：uni-h5 scroll-view 卸载后仍写 scrollTop 的补丁。

大版本（X）而非小版本：`desktop/build` 有改动（安装器 NSIS 脚本），patch-gate 会拒小版本 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
