### PR TITLE
docs(eng-infra): 插件安装器出包路径与双站上架口径入档（dev-board#356 发版实测）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -57,7 +57,16 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    **本机 makensis 不能用来预检**（2026-09-01 实测，Darwin 27）：homebrew 的 v3.12 与
    electron-builder 缓存的 v3.04 两个 mac 构建都一样——非 ASCII 源码报 `Bad text encoding`，
    纯 ASCII 脚本走到写产物时 `std::bad_alloc` 崩。**未改动的 HEAD 文件同样复现**，不是谁改坏的，
-   别在这上面查半天。改 NSIS 只能靠 installer-ui-smoke。
+   别在这上面查半天。改 NSIS 只能靠 installer-ui-smoke。**要出插件安装器 exe 走
+   `.github/workflows/addin-installer.yml`**（workflow_dispatch，Windows runner 上跑
+   `build-installers.mjs --skip-mac`，按 `desktop/package.json` 的版本号出国内/国际两份，
+   分目录上传避免同名覆盖）——v0.31.0 发版实测：引擎修好了本机却出不了包，这条路是补上的。
+   mac 那一半（swiftc + Developer ID 签名 + 公证）仍只能在维护者 Mac 上跑 `--skip-win`。
+   **两份变体必须分别上架到两台机**：北京 `8.152.169.44` 与新加坡 `8.219.94.204` 各有一份
+   `/opt/aiworkdeck/cloud/web/office-addin/dl/`，托管地址焙进包内 manifest，不是通用包；
+   0.30.0 那次两台挂的是同一份（字节数一模一样），国际用户装到的包指向 addin.aiworkdeck.com，
+   已在 0.31.0 纠正。**核对法：两站 `curl -L .../AI-WorkDeck-Office-Addin.exe` 的字节数应当不同**
+   （URL 长度差压缩后约 2 字节），一样就是挂错了。
 6.5.2. **磁盘空间闸**（dev-board#350）：引擎新增两个可选契约 `AWD_UI_REQUIRED_KB` /
    `AWD_UI_REQUIRED_EXTRA_KB`，只有设了前者才编译出闸（插件端装的是一份清单，不设）。
    桌面端在 `build/installer.nsh` 里直接把 **electron-builder 的 `-D APP_64_UNPACKED_SIZE`**


### PR DESCRIPTION
v0.31.0 发版时实测暴露、已经处理掉的两条，入档 `.claude/agents/eng-infra.md` 6.5.1：

1. **本机 makensis 坏这件事早就记着了，但没写「那插件安装器怎么出包」**。结果引擎（dev-board#350/#354/#356 三修）修好了，插件端却没有出包路径。已补 `.github/workflows/addin-installer.yml`（Windows runner，workflow_dispatch）。mac 半边仍只能本机 `--skip-win`。
2. **国内/国际是两份不同的包，北京与新加坡各有一份 `dl/` 要分别上架**。核对时发现 **0.30.0 那次两台挂的是同一份**（字节数一模一样 2,093,829），国际用户装到的包指向 `addin.aiworkdeck.com`。0.31.0 已分别上架纠正（现在两站字节数 2029281 / 2029279 不同）。核对法写进文档了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
