### PR TITLE
fix(editor): 页边模式导出错位、批注幽灵修订、流式落字署名（dev-board#367）

### DIFF
--- a/.claude/agents/ai-doc-bridge.md
+++ b/.claude/agents/ai-doc-bridge.md
@@ -257,7 +257,9 @@ txt/md/markdown 自 dev-board#37 起不进 LOWA（前端走 PlainTextEditor.vue�
 - **新增 doc_* 工具四件套**：DocumentEditTools 加 @Tool + EDITOR_ACTIONS 白名单加 action + office_thread.js 加实现 + toolDisplayNames.js 加中文名。漏任何一环都是静默失败（PR#180 教训）。
 - **worker 失败返回必须带 `error` 字段**：前端 `handleEditorCommand` 只把 `result.error` 回传后端（`result.message` 不看），只写 `message` 的话模型收到 `{"error": "null"}`——判得出失败但拿不到原因，白白浪费一轮。`doc_table_*` 用 `tableFail()` 统一写两个字段。
 - **表格删行/删列不进修订**（真机实测 LO 24.2）：`XTableRows/XTableColumns.removeByIndex` 走 API 路线直接删除，RecordChanges 开着也是 `redlineDelta=0`——AI 删表格行的安全网是 doc_undo 与文档检查点，不是修订面板，工具描述里已对模型明说。生效判定仍按"行列数变化 OR 修订条数变化"双口径（防将来引擎改口径），别只看 `getRows().getCount()`。
-- **区间批注必须走 `.uno:InsertAnnotation` 派发**；LO API 路线（addAnnotation）会抛虚假异常且只批注锚点（PR#191）。
+- **区间批注必须走 `.uno:InsertAnnotation` 派发**；LO API 路线（addAnnotation）会抛虚假异常且只批注锚点（PR#191）。派发要在 RecordChanges 关闭下做（worker `withRecordChangesOff`，dev-board#367）：否则引擎把批注字段记成一条空插入修订，Word 里多出一条作者 AI WorkDeck、正文为空的幽灵气泡。
+- **`doc_add_comment` 之后视图光标失效**（dev-board#367 真机探针）：焦点落进批注窗口，之后 `doc_insert_at_cursor` / `doc_goto` / `doc_replace_selection` / 流式落字都会以 RuntimeException 失败，直到用户点一下画布；`doc_replace_at_anchor` / `doc_modify_paragraph` / 再加批注不受影响。模型在同一轮里应先做正文改动、最后再挂批注，或全程用锚点定位。
+- **「【修訂理由】…」不是我们加的前缀**：代码里没有这段文字（后端/前端/prompt 全 grep 过），是模型自己写进 `doc_add_comment` 的 comment 里的（system_prompt.md §"解释类文字用批注" 只要求把理由挂成批注，没规定格式）。
 - **replace_selection 仅在 RecordChanges 开启时启用最小修订路径**；修订应用必须从右到左，否则前面的编辑使后面的偏移失效（PR#188）。
 - **office 线程会被 export 冻结**：长 export 期间同步命令假死是已知模式，autoSave 需让路（PR#182）。
 - **桥超时按 action 分级**（dev-board#108）：`EditorBridgeService.ACTION_TIMEOUT_SECONDS`（doc_open_file_sync/export_document 180s，find_replace/apply_house_style/apply_style_profile/resolve_all_revisions/resolve_revisions 120s，其余 30s），与前端两处 `ACTION_BUDGET_MS` 同表。新增会跑很久的批量原语要三处一起加，否则后端先放弃、模型重发一次造成双改。`find_replace` 全部替换走引擎原生 replaceAll 一次完成（150 命中 0.2s），纯插入型回退逐命中路径并在命中 > 50 时分批回传进度；`apply_house_style` 在 worker 内分批并回传进度（契约见 doc-editor.md），结果可能带 `cancelled:true`（用户中途取消）——工具描述里已告诉模型不要重复调用。

--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -126,7 +126,11 @@ description: 文档编辑器（LOWA/zetaoffice）领域。任务涉及 LibreOffi
 - **触控板捏合必须在 canvas 上 `preventDefault`**：Chromium 把捏合报成 `ctrl+wheel`，不拦就是浏览器缩放整个 webview 页面（工具栏跟着放大、画布发糊、IME 像素映射基准作废）。拦下来改派 `set_zoom`（`ViewSettings.ZoomValue`，先切 `ZoomType=BY_VALUE` 否则自动模式会把值算回去；两个属性都是 sal_Int16，必须 `shortAny()`）。
 - **保存状态胶囊只在「慢」和「失败」时出声**：成功保存不报「已保存」（维护者反馈：经常闪变、打扰）。浮层要钉在**画布**上而不是编辑器外层——审阅面板是并排挤宽的，钉外层会压住面板标题行。
 - `npm run build:zetaoffice` 会清空 dist 并删掉已 fetch 的引擎——本地反复跑 e2e 用 `LOWA_ENGINE_DIR` 规避，或从兄弟 worktree 复制引擎（CDN 挂时的配方）。
-- 修订作者：params 带 `__agent:true` → 署名 "AI WorkDeck"。
+- 修订作者：params 带 `__agent:true` → 署名 "AI WorkDeck"（worker `execCommand` 每条命令前按标记切 `/org.openoffice.UserProfile/Data` 的 givenname，`setRedlineAuthor`；引擎 `SwModule` 收到配置变更通知即重取作者，真机实证双向切换即时生效）。**宿主每一条 AI 发起的写命令都要带标记**：`handleEditorCommand` 与 PluginPane 一直带，流式落字 `flushDocStreamBuffer`/`handleDocStreamEnd`（`stream_insert`/`stream_flush`）曾漏掉，AI 起草的整篇内容全记在用户名下（dev-board#367）；单测 `tests/project-home/doc-stream-agent-author.test.mjs` 锁住。用户自己的 IME 输入 / 快捷键 / 工具栏不带标记，署当前登录用户名（`load_document` 的 `authorName`）。
+- **页边模式下 `export_document` 必须临时关页边 + `xModel.refresh()`**（`withMarginOff`，dev-board#367 真机探针）：ShowChangesInMargin=true 时删除文本被并出版面，docx 导出器却按并合后的正文套修订区间——字符级替换（删「乙」插「丁」）导出成「丁」被删、「乙」消失，多段文档还会把别处的插入标成删除；重新打开 / Word 里看到的修订是错的，且自动保存、版本记录、对比全走这条导出。只关不 `refresh()` 仍错位（探针 R2），导完要恢复页边再 `refresh()` 一次。e2e 组 30 锁住导出→重开的修订与正文一致。
+- **`.uno:InsertAnnotation` 必须在 RecordChanges 关闭下派发**（`withRecordChangesOff`，`add_comment` / `add_comment_at_selection` / `reply_comment` 三处）：修订记录开着时引擎把批注字段本身记成一条空文本插入修订（说明字段「已添加批注」），导出成包着批注标记的 `<w:ins>`——Word 里是一条作者 AI WorkDeck、正文为空、时间与真批注相同的幽灵气泡；审阅面板也多一张「插入（空）」卡。关掉派发不影响批注的区间标记 / 作者 / 内容（探针 Q5）。`set_comment_resolved` 走 API 属性，不产生修订。
+- **`.uno:InsertAnnotation` 之后视图光标失效**（真机探针 R3/S4）：焦点进了批注窗口，`ctrl.getViewCursor()` 的 `getText()`/`gotoRange()`/插入一律抛 RuntimeException，`ctrl.getSelection()` 为 null——`insert_at_cursor` / `goto` / `replace_selection` / `stream_insert`（都走视图光标）在用户点一下画布之前全部失败；锚点/段落索引类原语（`replace_at_position`、`modify_paragraph`、`add_comment`）不受影响。`set_selection`、`ctrl.select()`、重取 controller、给窗口 setFocus、派发 `.uno:Escape`/`.uno:GoToStartOfDoc` 都救不回来；唯一试出来的恢复手段是派发两次 `.uno:ShowAnnotations`（藏再显）。未上线——只有一次探针实证，先记在这里。
+- **批注边栏宽度与锚线在引擎里没有配置项**：宽度 = 缩放比 × 1.8 px 硬编码（`sw/source/uibase/docvw/PostItMgr.cxx` `GetSidebarWidth`，60% 缩放 ≈ 108px），r4 引擎注册表里只有 `ShowNotes`/`ShowChangesInMargin`，没有任何 Sidebar/Notes 宽度键；锚线由 `AnchorOverlayObject` 恒画（`AnnotationWin2.cxx` `SetAnchorState(All)`），只有「隐藏全部批注」时才退成三角。适合页宽会把边栏算进页宽（`viewmdi.cxx` `SetZoom_` 在 `HasNotes && ShowNotes` 时 `AdjustWidth(GetSidebarWidth)`）。要更宽只能改缩放，或在自建引擎里改这个系数重烧。
 - **ShowChangesInMargin 依赖自建引擎 ≥24.2.8-zhcn-r3**：原生 LO 把页边删除文本画在锚点所在 frame 左侧，表格内 frame=单元格会叠画左邻格正文；r3 焙入 frmpaint.cxx 表格锚点补丁（`desktop/lowa-build/patches`，锚 FindTabFrame 整表左缘）后才能开。页边模式非纯视图设置：开=删除文本移入 redline 对象（getString 可取、正文不含），关=留正文流且 redline getString 抛异常——debug_revisions 已带 RedlineText/区间双路取回，两种模式都能读。已知残留局限：同一表格行多格删除会在页边同 Y 相互叠（上游按行画、无跨格协调）。批注侧栏与此设置无关。
 - **审阅面板原语的光标摆位是硬约束**（`resolve_revision`，真机逐个试出来）：插入型修订必须**跨选**整个 redline 区间才被 `.uno:AcceptTrackedChange` 命中；删除型（页边模式下文本不在正文流）必须**塌陷**到区间起点，跨选反而打空。摆错不报错——dispatch 静默失效甚至凭空多一条空插入修订，所以处置一律用 redline 条数变化复核，别信 dispatch 的返回。
 - **批注删除三个前提**（`delete_comment`）：`.uno:DeleteComment` 必须带 `Id`（批注的 `Name` 属性）；文档必须**可见**（Hidden 打开的文档没有批注窗口，按 Id 找不到）；已解决（Resolved）的批注要先取消解决态。API 路线 `dispose()` / `removeTextContent()` 在有些上下文里是「不抛异常也不生效」的假成功，不能据其返回值报成功。
@@ -176,7 +180,7 @@ HOUSE 不再是常量：`buildHouse(profile)` 从画像 JSON 派生写端常量�
 
 ## 验证
 
-- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，29 组人机模拟，2026-08-22 基线 458 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
+- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，30 组人机模拟，2026-09-02 基线 479 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
 - 大文档性能：`npm run test:lowa-big`（同一套启动件 `tests/lowa-e2e/_boot.mjs`；端口被别的 worktree 占着时设 `LOWA_E2E_PORT`）。
 - 涉桌面壳/webview：`npm run test:desktop-e2e`（弹 dev Electron 窗口，验证保存落盘链路）。
 - 全应用：`npm run test:app-e2e`。改编辑器三件套（原语/白名单/worker）必跑 lowa-e2e。

--- a/frontend/src/pages/project-overview/agentClientActions.js
+++ b/frontend/src/pages/project-overview/agentClientActions.js
@@ -119,7 +119,9 @@ export const agentClientActionMethods = {
         try {
             // stream_insert：worker 端按行剥离 markdown 标记并按标准格式落字
             //（楷体_GB2312/Arial、段后 18 磅、首行缩进 2 字符、表格 Grid 1.5 磅等）
-            await this.libreOfficeExecutor.executeCommand('stream_insert', { text })
+            // __agent：流式落字是 AI 写的，修订要署名 AI WorkDeck——与 handleEditorCommand
+            // 同一标记；漏了它，这一路的修订全记在用户名下（dev-board#367）。
+            await this.libreOfficeExecutor.executeCommand('stream_insert', { text, __agent: true })
         } catch (e) {
             console.error('[ProjectOverview] doc stream insert error:', e)
         } finally {
@@ -146,7 +148,8 @@ export const agentClientActionMethods = {
         }
         if (this.libreOfficeActive && this.libreOfficeExecutor) {
             try {
-                await this.libreOfficeExecutor.executeCommand('stream_flush', {})
+                // 收尾会把未换行的尾行/尾表真正写进文档，同样是 AI 的笔迹
+                await this.libreOfficeExecutor.executeCommand('stream_flush', { __agent: true })
             } catch (e) {
                 console.error('[ProjectOverview] doc stream flush error:', e)
             }

--- a/frontend/src/zetaoffice/public/office_thread.js
+++ b/frontend/src/zetaoffice/public/office_thread.js
@@ -1787,6 +1787,37 @@ function showDeletionsInMargin() {
   try { ctrl.getViewSettings().setPropertyValue('ShowChangesInMargin', true); }
   catch (e) { log('ShowChangesInMargin 设置失败 / failed: ' + errStr(e)); }
 }
+// 页边模式下 docx 导出会错位（dev-board#367 真机探针，2026-09-02）：ShowChangesInMargin
+// 开着时删除文本被并出版面，而导出器按并合后的正文套用修订区间——字符级替换
+// （删「乙」插「丁」）导出成「丁」被删、「乙」消失；多段文档里更会把别处的插入标成
+// 删除。重新打开 / Word 里看到的修订就是错的。导出期间临时关掉页边显示并 refresh()
+// 强制重排（只关不重排仍错位，探针 R2 实证），导完恢复并再重排一次，让后续
+// get_document_text 等读取仍按页边语义（正文不含删除文本）。非 Writer 文档没有
+// 这个视图设置，原样执行。
+function withMarginOff(fn) {
+  let vs = null, was = false;
+  try { vs = ctrl.getViewSettings(); was = !!vs.getPropertyValue('ShowChangesInMargin'); } catch (e) { vs = null; }
+  if (!vs || !was) return fn();
+  vs.setPropertyValue('ShowChangesInMargin', false);
+  try { xModel.refresh(); } catch (e) {}
+  try { return fn(); }
+  finally {
+    try { vs.setPropertyValue('ShowChangesInMargin', true); } catch (e) {}
+    try { xModel.refresh(); } catch (e) {}
+  }
+}
+// 批注插入不该被记成修订：RecordChanges 开着时 .uno:InsertAnnotation 会额外记一条
+// 空文本的插入修订（说明字段「已添加批注」），导出 docx 后成了包着批注标记的
+// <w:ins>——Word 里就是那条作者 AI WorkDeck、正文为空的幽灵气泡（dev-board#367
+// 第 6 项），审阅面板也会多一张「插入（空）」卡。派发期间关掉修订记录，完了恢复；
+// 批注本身（区间标记、作者、内容）不受影响，真机探针 Q5 实证。
+function withRecordChangesOff(fn) {
+  let was = false;
+  try { was = !!xModel.getPropertyValue('RecordChanges'); } catch (e) {}
+  if (was) { try { xModel.setPropertyValue('RecordChanges', false); } catch (e) { was = false; } }
+  try { return fn(); }
+  finally { if (was) { try { xModel.setPropertyValue('RecordChanges', true); } catch (e) {} } }
+}
 
 // ---- boot: open a fresh BLANK Writer doc ----------------------------------
 // Production: a brand-new / empty document must show a clean blank page (the
@@ -3005,7 +3036,7 @@ const EXEC = {
     const wasModified = (() => { try { return !!xModel.isModified(); } catch (e) { return false; } })();
     exportInFlight = true;
     try {
-      xModel.storeToURL('private:stream', props);
+      withMarginOff(function () { xModel.storeToURL('private:stream', props); });
     } finally {
       exportInFlight = false;
       try { if (!!xModel.isModified() !== wasModified) xModel.setModified(wasModified); } catch (e) { /* 只读文档等场景可能拒绝，忽略 */ }
@@ -4089,9 +4120,11 @@ const EXEC = {
     const annotatedText = (range.getString() || '').slice(0, 120);
     // 拟人：选中并滚动到被批注的位置——选区同时就是批注的附着区间
     if (!selectVisibly(range)) return { success: false, message: 'could not select anchor: ' + anchorId };
-    css.frame.DispatchHelper.create(context).executeDispatch(
-      ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
-      [mkProp('Text', comment), mkProp('Author', AI_AUTHOR)]);
+    withRecordChangesOff(function () {
+      css.frame.DispatchHelper.create(context).executeDispatch(
+        ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
+        [mkProp('Text', comment), mkProp('Author', AI_AUTHOR)]);
+    });
     return {
       success: true, anchor: anchorId, author: AI_AUTHOR, comment: comment,
       annotatedText: annotatedText,
@@ -4111,9 +4144,11 @@ const EXEC = {
     if (!annotatedText.length) return tableFail('请先选中要批注的文字');
     const author = humanAuthor || '';
     const before = countComments();
-    css.frame.DispatchHelper.create(context).executeDispatch(
-      ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
-      [mkProp('Text', comment), mkProp('Author', author)]);
+    withRecordChangesOff(function () {
+      css.frame.DispatchHelper.create(context).executeDispatch(
+        ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
+        [mkProp('Text', comment), mkProp('Author', author)]);
+    });
     // 派发不报错也可能没命中——用批注条数变化确认，别对用户谎报成功
     const after = countComments();
     if (after <= before) return tableFail('批注未被插入（引擎未命中）');
@@ -4562,9 +4597,11 @@ const EXEC = {
       }
     } catch (e) {}
     const replyContent = (parentAuthor ? ('回复 ' + parentAuthor + '：') : '') + text;
-    css.frame.DispatchHelper.create(context).executeDispatch(
-      ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
-      [mkProp('Text', replyContent), mkProp('Author', AI_AUTHOR)]);
+    withRecordChangesOff(function () {
+      css.frame.DispatchHelper.create(context).executeDispatch(
+        ctrl.getFrame(), '.uno:InsertAnnotation', '', 0,
+        [mkProp('Text', replyContent), mkProp('Author', AI_AUTHOR)]);
+    });
     let newField = null, newName = '';
     try {
       const en2 = xModel.getTextFields().createEnumeration();

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -1989,6 +1989,73 @@ try {
     check('纸外区域真的重绘（深色亮度显著低于浅色）', darkLum < lightLum - 80, JSON.stringify({ darkLum, lightLum }))
   }
 
+  // ---------- 组 30：页边模式导出保真 / 批注不记修订 / 流式署名（dev-board#367）----------
+  // 真机探针（2026-09-02）实锤三件事：① ShowChangesInMargin 开着时 export_document
+  // 把字符级替换导出成「新字被删、旧字消失」（多段文档还会把别处的插入标成删除），
+  // 重新打开 / Word 里修订全是错的——export 现在导出期间临时关页边 + refresh；
+  // ② RecordChanges 开着时 .uno:InsertAnnotation 多记一条空插入修订（「已添加批注」），
+  // Word 里是一条作者 AI WorkDeck、正文为空的幽灵气泡；③ stream_insert 按 __agent 署名。
+  console.log('\n[30] 页边模式导出保真 / 批注不记修订 / 流式署名（dev-board#367）')
+  {
+    const fresh30 = await exec('debug_fresh_document', { visible: true })
+    check('换新文档成功', fresh30 && fresh30.success === true, JSON.stringify(fresh30))
+    const setText30 = async (t) => {
+      await exec('debug_set_record_changes', { on: false })
+      await exec('ui_command', { name: 'select_all' })
+      await exec('replace_selection', { text: t })
+      await exec('goto', { type: 'end' })
+      await exec('debug_set_record_changes', { on: true })
+    }
+    const sig = (rv) => (rv.redlines || []).map((r) => String(r.type)[0] + ':' + r.text).sort().join(' ')
+    const docText = async () => (await exec('get_document_text')).paragraphs.map((x) => x.text)
+    await setText30('第一条 甲方应于三十日内付款。\n第二条 乙方应当按期交付货物。')
+    const a30 = await exec('find_text_locations', { keyword: '三十' })
+    await exec('replace_at_position', { anchor: a30.matches[0].anchorId, newText: '四十五', __agent: true })
+    const b30 = await exec('find_text_locations', { keyword: '按期交付货物' })
+    await exec('replace_at_position', { anchor: b30.matches[0].anchorId, newText: '按期交付全部货物', __agent: true })
+    const before30 = sig(await exec('debug_revisions'))
+    check('改前修订：删「三十」/ 插「四十五」/ 插「全部」', before30 === ['D:三十', 'I:四十五', 'I:全部'].sort().join(' '), before30)
+    const bytes30 = await page.evaluate(async () => {
+      const r = await window.__loExecutor.executeCommand('export_document', {})
+      return r && r.bytes ? Array.from(r.bytes) : null
+    })
+    check('页边模式下导出成功', Array.isArray(bytes30) && bytes30.length > 0)
+    const docAfterExport = await docText()
+    check('导出后正文仍按页边语义（不含被删的「三十」）', docAfterExport[0] === '第一条 甲方应于四十五日内付款。', JSON.stringify(docAfterExport))
+    await exec('debug_fresh_document', { visible: true })
+    const ld30 = await exec('load_document', { bytes: bytes30, name: 'margin-roundtrip.docx', authorName: '测试用户' })
+    check('导出件可重新打开', ld30.success === true, JSON.stringify(ld30))
+    const after30 = sig(await exec('debug_revisions'))
+    check('重新打开后修订与改前一致（页边模式导出不再错位）', after30 === before30, after30 + ' vs ' + before30)
+    const docR = await docText()
+    check('重新打开后正文正确', docR[0] === '第一条 甲方应于四十五日内付款。' && docR[1] === '第二条 乙方应当按期交付全部货物。', JSON.stringify(docR))
+
+    // ② 批注不记修订
+    const c30 = await exec('find_text_locations', { keyword: '付款' })
+    const nBefore = (await exec('debug_revisions')).redlines.length
+    const cm30 = await exec('add_comment', { anchor: c30.matches[0].anchorId, comment: '【修订理由】测试', __agent: true })
+    check('add_comment 成功', cm30.success === true, JSON.stringify(cm30))
+    const rvC = await exec('debug_revisions')
+    check('add_comment 不新增修订（无「已添加批注」幽灵插入）',
+      rvC.redlines.length === nBefore && !rvC.redlines.some((r) => r.comment === '已添加批注'), JSON.stringify(rvC.redlines))
+    check('修订记录开关在批注后恢复开启', (await exec('set_track_changes')).recordChanges === true)
+    const lc30 = await exec('list_comments')
+    check('批注本身正常（署名 / 内容 / 锚定区间）',
+      lc30.success && lc30.count === 1 && lc30.comments[0].author === 'AI WorkDeck'
+        && lc30.comments[0].content === '【修订理由】测试' && lc30.comments[0].anchorText === '付款', JSON.stringify(lc30))
+
+    // ③ 流式署名（宿主 flushDocStreamBuffer / handleDocStreamEnd 打 __agent，单测锁住；这里锁 worker 侧语义）
+    await exec('debug_fresh_document', { visible: true })
+    await exec('load_document', { authorName: '测试用户' })   // 只注入作者名
+    await setText30('署名。')
+    await exec('stream_insert', { text: '流式无标记\n' }); await exec('stream_flush', {})
+    await exec('stream_insert', { text: '流式带标记\n', __agent: true }); await exec('stream_flush', { __agent: true })
+    const rvS = await exec('debug_revisions')
+    const authorOf = (t) => ((rvS.redlines || []).find((r) => (r.text || '').includes(t)) || {}).author
+    check('stream_insert 带 __agent → 署名 AI WorkDeck', authorOf('流式带标记') === 'AI WorkDeck', JSON.stringify(rvS.redlines))
+    check('stream_insert 不带标记 → 署当前用户名', authorOf('流式无标记') === '测试用户', JSON.stringify(rvS.redlines))
+  }
+
   console.log('\n结果 / result: ' + passed + ' passed, ' + failed + ' failed')
 } finally {
   await browser.close()

--- a/frontend/tests/project-home/doc-stream-agent-author.test.mjs
+++ b/frontend/tests/project-home/doc-stream-agent-author.test.mjs
@@ -1,0 +1,56 @@
+// dev-board#367：AI 流式落字（doc_start_stream → doc_stream_data → stream_insert）
+// 这一路曾经不带 __agent 标记，worker 据此把修订署成当前用户名——用户在 Word 里
+// 看到 AI 写的内容记在自己名下，分不清哪些是 AI 改的。handleEditorCommand 一直带
+// 标记，只有流式这条漏了。锁住：stream_insert / stream_flush 下发的参数必须带
+// __agent:true。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createSerialQueue } from '../../src/utils/asyncSerialize.js'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/agentClientActions.js', import.meta.url), 'utf8')
+
+function loadMethods() {
+  // shouldFlushDocStream 留在函数体内（flushDocStreamBuffer 要调它判目标文件一致）
+  const body = SRC
+    .replace(/^import .*$/gm, '')
+    .replace(/export function shouldFlushDocStream/, 'function shouldFlushDocStream')
+    .replace(/export const agentClientActionMethods = \{/, 'return {')
+  const factory = new Function('sendEditorResult', 'getFileDetail', 'createSerialQueue', 'uni', body)
+  return factory(async () => {}, async () => null, createSerialQueue, { showToast: () => {} })
+}
+
+function makeVm(calls) {
+  const vm = {
+    projectId: 1,
+    libreOfficeActive: true,
+    libreOfficeExecutor: { executeCommand: async (action, params) => { calls.push({ action, params }); return { success: true } } },
+    resolveLibreExecutorFileId: () => 7,
+    _docStreamTargetFileId: 7,
+    $refs: {},
+    $t: (k) => k,
+  }
+  for (const [k, fn] of Object.entries(loadMethods())) vm[k] = fn.bind(vm)
+  return vm
+}
+
+test('stream_insert 下发的参数带 __agent:true（修订署名 AI WorkDeck）', async () => {
+  const calls = []
+  const vm = makeVm(calls)
+  vm._docStreamBuffer = '第一条 服务内容\n'
+  await vm.flushDocStreamBuffer()
+  const ins = calls.filter((c) => c.action === 'stream_insert')
+  assert.equal(ins.length, 1)
+  assert.equal(ins[0].params.text, '第一条 服务内容\n')
+  assert.equal(ins[0].params.__agent, true)
+})
+
+test('stream_flush 收尾同样带 __agent:true（尾行/尾表也是 AI 写的）', async () => {
+  const calls = []
+  const vm = makeVm(calls)
+  await vm.handleDocStreamEnd()
+  const fl = calls.filter((c) => c.action === 'stream_flush')
+  assert.equal(fl.length, 1)
+  assert.equal(fl[0].params.__agent, true)
+})


### PR DESCRIPTION
dev-board#367 调查修订边栏时捞出的三处真机实锤（LO 24.2.8 r4 引擎，lowa-e2e 新组 30，13 断言）。

1. P0 页边模式导出错位：ShowChangesInMargin 开着时（自 PR#235 起 boot 与每次 load_document 都开），export_document 把字符级替换导出成「新字被删、旧字消失」（删「乙」插「丁」→ docx 里 <w:del>丁</w:del>、「乙」不见；多段文档里别处的插入被标成删除）。导出器按并合后的正文套修订区间；只关页边不重排仍错，关页边 + refresh 再导出正确。修：withMarginOff 包住 storeToURL，导完恢复并再 refresh。自动保存/版本记录/对比全走这条导出，影响面另开卡记录。
2. 空批注（用户在 Word 里看到作者 AI WorkDeck、正文为空的气泡）：RecordChanges 开着时 .uno:InsertAnnotation 把批注字段记成一条空文本插入修订，导出成包着 commentReference 的 <w:ins>。修：三处批注派发包 withRecordChangesOff，批注区间/作者/内容不受影响。
3. 流式落字署名：stream_insert / stream_flush 没带 __agent 标记，AI 起草的整篇内容修订全记在用户名下（用户在 Word 里看到修订作者是自己、批注作者是 AI 的根因之一）。修：agentClientActions 两处补标记。

验证：lowa-e2e 479/479（真引擎）；project-home 298/298；新增 doc-stream-agent-author.test.mjs。主会话独立复现：把 withMarginOff 短路后在 dist 上跑全套 e2e → 2 红（重开后修订 D:四十五 vs 预期 D:三十 I:四十五；正文丢「三十」），恢复后全绿。地雷：e2e 服务的是 dist 不是 src，短路 src 是假绿。

调查其余结论（边栏宽度 zoom×1.8 引擎硬编码、锚线不可配、审阅窗格差距）在卡 #367。

🤖 Generated with [Claude Code](https://claude.com/claude-code)