### PR TITLE
fix(installer): 一键安装器三张卡片可拖动、进度卡不再像卡死（dev-board#366）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -127,6 +127,48 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    老坑之所以能瞒过八个月，就是因为那一步只截图不断言。
    **教训**：`ui-harness` 只覆盖引擎，不覆盖「引擎怎么被真产物接线」；
    凡是与 electron-builder 模板契约有关的改动，用例必须复刻它的页序。
+6.5.6. **无边框卡片的拖动：nsDialogs 页靠 STN_CLICKED，instfiles 页只能靠真标题带**
+   （dev-board#366）。用户反馈「进度卡不能拖、点不了、像卡死」，两个症状一个根：
+   `AwdGuiInit` 把 `WS_CAPTION` 剥掉做无边框，系统从此不给任何可拖的区域，而进度卡的
+   位图上本来就一个可点的东西都没有（mini-install 美术只有品牌行、状态行、进度轨道），
+   于是「点不了」=「拖不了」。**消息泵不是嫌疑人**：Section 跑在 NSIS 自己开的
+   `install_thread` 上（`Source/exehead/Ui.c` 的 `WM_NOTIFY_START` → `CreateThread`），
+   UI 线程照常泵消息，1.7GB 解压期间进度条也是这么动起来的；红一轮的日志里
+   `SendMessageTimeout(WM_NULL)` 在安装期间 3 秒内有应答，把这条钉死了。
+   两条路各自的约束：
+   - **欢迎卡/完成卡是 nsDialogs 页**，脚本能跑。背景位图加 `SS_NOTIFY`，static 控件的
+     `STN_CLICKED` 是在 `WM_LBUTTONDOWN` 里发的（与 BUTTON 抬起才发 `BN_CLICKED` 不同，
+     Wine `static.c` 与 Windows 同款），回调里鼠标还按着，`ReleaseCapture` +
+     `SendMessage $HWNDPARENT WM_NCLBUTTONDOWN HTCAPTION 0` 就把这一按交给系统的模态
+     拖动循环，抬起才回来。**z 序地雷（第二轮 CI 实锤）**：Win32 子窗口创建时插在
+     z 序**最底**（Wine `win32u/window.c`：`insert_after = WS_CHILD ? HWND_BOTTOM : HWND_TOP`，
+     注释原话「yes, even if the CBT hook was called with HWND_TOP」），也就是后建的在
+     **下面**——引擎里原先那句「创建序在位图之后 = z 序在其上」是反的，此前没露馅只因
+     没 `SS_NOTIFY` 的 static 对命中测试是 `HTTRANSPARENT`，点击穿过位图落到下面的热区。
+     一加 `SS_NOTIFY` 位图变 `HTCLIENT`，拖动通了、随后「自定义安装」「立即安装」全哑
+     （run 33576325194）。所以位图的 `SetWindowPos(HWND_BOTTOM)` 必须放在**所有控件建完
+     之后、`nsDialogs::Show` 之前**，建完位图立刻压底是无效的（那时它本来就在底）。
+   - **进度卡（instfiles 页）脚本一行都不能跑**：同一套执行引擎、同一个栈，UI 线程若在
+     Section 执行期间再进 NSIS 代码就是两条线程并发踩 `$0`-`$9`；nsDialogs 在这一页也没有
+     落脚点。所以 `AwdInstFilesShow` 把 `WS_CAPTION` 加回来当拖动带（不带 `WS_SYSMENU`，
+     无图标无按钮），Win11 用 `DwmSetWindowAttribute` 35/36/34 把标题带、文字、边框染成
+     卡片色（看起来只是卡片顶上多一条空白），Win10 显示系统标题带；外框尺寸用
+     `AdjustWindowRectEx` 实算别手抄；`SetWindowPos` 必须带 `SWP_FRAMECHANGED`。
+     进完成卡 `AwdFinishCreate` 再剥掉，先 `ClientToScreen` 记下客户区原点再换样式，
+     卡片内容不跳。
+   - 「自定义安装」展开改 `SWP_NOMOVE`：原先用初始化时记的坐标重定位，卡片能拖之后
+     那就成了「一点自定义安装就弹回屏幕中央」。
+   **否决过的路**：System 插件的回调是同线程协程（只在 `System::Call` 里等着的那次调用
+   能收到），做不了 WndProc 子类化；往 RWX 内存写一段 x86 WndProc 能跑但等于在未签名
+   安装器里放 shellcode；自编插件 DLL 要三条 workflow 各加编译步骤。
+   回归护栏：`installer-smoke.ps1` 的 `DragAssert` 对三张卡各拖一次（真实鼠标
+   `mouse_event` 按下、分步绝对移动、抬起，断言窗口矩形位移 ≥ 指针位移一半、进程活着）、
+   `AssertResponsive` 在安装期间发 `WM_NULL`、展开自定义安装后断言左上角没动。
+   三轮 CI 同一份测试脚本（f9af58b0 之后 `installer-smoke.ps1` 一字未动）：红
+   https://github.com/zeweihan/aiworkdeck/actions/runs/33575900306（三张卡 `moved (0,0)`）、
+   半红 https://github.com/zeweihan/aiworkdeck/actions/runs/33576325194（欢迎卡拖动
+   `moved (100,40)` 但热区被位图挡住、进不了进度卡——就是上面的 z 序地雷）、
+   绿 https://github.com/zeweihan/aiworkdeck/actions/runs/33576754273 。
 
 6.6. **`dmg-builder` 补丁（`desktop/scripts/patch-dmg-builder.js` + package.json `postinstall`，安装器 UI 重设计新增）**：macOS 26.2+ 起 Finder 拒读 dmgbuild 写入 `.DS_Store` 的 `pBBk` 背景书签，导致桌面端主 DMG 背景不显示（electron-builder#9072 / dmgbuild#273，同版 Obsidian/Podman Desktop 同期中招）。`npm ci`/`npm install` 后自动对 `node_modules/dmg-builder/vendor/dmgbuild/core.py` 做定点补丁（跳过 Bookmark 生成，`icvp` 里的 alias 通道保留，老系统照常工作）。**升级 electron-builder 后若补丁脚本报「结构已变」**：先确认新版是否已自带该修复，再决定要不要删掉本补丁，不要盲目跳过。
 

--- a/desktop/build/win/awd-oneclick-ui.nsh
+++ b/desktop/build/win/awd-oneclick-ui.nsh
@@ -27,6 +27,19 @@
 ; 坐标契约：所有热区坐标必须与 oneclick-*.html 里的绝对定位一致（两边都以 96dpi
 ; 基准像素书写，运行期统一乘 $AwdScale）。改布局要两处同步改。
 ;
+; 可拖动契约（dev-board#366）：三张卡都是去掉了 WS_CAPTION 的无边框窗，系统不再给
+; 任何可拖的标题带，所以「能拖」要自己接：
+;   - 欢迎卡 / 完成卡是 nsDialogs 页，背景位图带 SS_NOTIFY，STN_CLICKED 在鼠标**按下**
+;     那一刻就发（static 控件对 WM_LBUTTONDOWN 的处理，与 BUTTON 抬起才发 BN_CLICKED
+;     不同），回调里 ReleaseCapture + 给主窗发 WM_NCLBUTTONDOWN/HTCAPTION，把还按着的
+;     这一下交给系统的模态拖动循环——按在任何热区之外的地方都能拖走整张卡；
+;   - 进度卡期间脚本一个字都跑不了（Section 在 NSIS 的 install_thread 上执行，UI 线程
+;     的消息泵是活的、但同一套执行引擎不许两条线程并发进 NSIS 代码，nsDialogs 在
+;     instfiles 页也没有落脚点），所以这一段把 WS_CAPTION 加回来当拖动带：无 WS_SYSMENU
+;     即无图标无按钮，Win11 用 DWM 把标题带与文字染成卡片白（看起来只是卡片顶上多了
+;     一条空白），老系统显示系统标题带。进完成卡再去掉。
+;   installer-ui-smoke 对三张卡各拖一次并断言窗口矩形跟着走。
+;
 ; 静默安装（/S，桌面端自动更新走这条路）不进任何 GUI 代码，行为不受影响。
 
 !ifndef AWD_ONECLICK_UI_INCLUDED
@@ -118,6 +131,12 @@ ManifestDPIAware true
 !ifndef WS_BORDER
   !define WS_BORDER 0x00800000
 !endif
+!ifndef WM_NCLBUTTONDOWN
+  !define WM_NCLBUTTONDOWN 0x00A1
+!endif
+; WS_CAPTION（= WS_BORDER|WS_DLGFRAME）：初始化时剥掉，进度卡期间加回当拖动带
+!define AWDUI_WS_CAPTION 0x00C00000
+!define AWDUI_HTCAPTION 2
 
 !define MUI_CUSTOMFUNCTION_GUIINIT AwdGuiInit
 
@@ -133,8 +152,6 @@ Var AwdDirEdit
 Var AwdBrowseBtn
 Var AwdSpaceLabel
 !endif
-Var AwdWinX       ; 大卡片左上角（展开时保持不动）
-Var AwdWinY
 !ifdef AWD_UI_REQUIRED_KB
 Var AwdFreeMb     ; 目标盘可用空间（MB）；"" = 读不出来
 Var AwdNeedMb     ; 本次安装所需空间（MB）
@@ -239,8 +256,6 @@ Function AwdGuiInit
   IntOp $R0 $R0 - $3
   IntOp $R0 $R0 / 2
   IntOp $R0 $R0 + $6
-  StrCpy $AwdWinX $9
-  StrCpy $AwdWinY $R0
   System::Call 'user32::SetWindowPos(p $HWNDPARENT, i 0, i r9, i R0, i r2, i r3, i 0x24)'
 FunctionEnd
 
@@ -291,10 +306,15 @@ Function AwdWelcomeCreate
   SetCtlColors $AwdDialog "" 0xFFFFFF
   System::Call 'user32::SetWindowPos(p $AwdDialog, i 0, i 0, i 0, i R7, i R8, i 0x14)'
 
-  ; 背景大图（含按钮/文案的全部视觉）
-  nsDialogs::CreateControl STATIC ${WS_VISIBLE}|${WS_CHILD}|${WS_CLIPSIBLINGS}|${SS_BITMAP} 0 0 0 $R7 $R8 ""
+  ; 背景大图（含按钮/文案的全部视觉）。带 SS_NOTIFY 是为了拖动：按在热区之外的任何
+  ; 地方，位图的 STN_CLICKED 把这一按交给 AwdDragClick。显式压到 z 序最底，别赌
+  ; 创建顺序——没有 SS_NOTIFY 的 static 对命中测试是透明的，有了就不是，位图一旦
+  ; 浮到热区之上会把「立即安装」的点击吃掉。
+  nsDialogs::CreateControl STATIC ${WS_VISIBLE}|${WS_CHILD}|${WS_CLIPSIBLINGS}|${SS_BITMAP}|${SS_NOTIFY} 0 0 0 $R7 $R8 ""
   Pop $1
   ${NSD_SetImage} $1 "$PLUGINSDIR\awd-hero.bmp" $AwdImgHero
+  System::Call 'user32::SetWindowPos(p r1, p 1, i 0, i 0, i 0, i 0, i 0x13)'
+  ${NSD_OnClick} $1 AwdDragClick
 
   ; 热区（创建序在位图之后 = z 序在其上）
   ${AwdHotspot} $2 ${AWDUI_CTA_X} ${AWDUI_CTA_Y} ${AWDUI_CTA_W} ${AWDUI_CTA_H}
@@ -375,6 +395,17 @@ Function AwdMinClick
   ShowWindow $HWNDPARENT ${SW_MINIMIZE}
 FunctionEnd
 
+; 无边框卡片的拖动（dev-board#366）。挂在背景位图的 OnClick 上：static 控件的
+; STN_CLICKED 是在 WM_LBUTTONDOWN 里发的，回调跑到这里时鼠标还按着，
+; ReleaseCapture 后给主窗发 WM_NCLBUTTONDOWN/HTCAPTION，DefWindowProc 就当用户按住了
+; 标题栏，进入系统自己的模态拖动循环，抬起才回来——与 WinForms 无边框窗的经典写法
+; 同一条路。SendMessage 是同步的，整段拖动都在这一句里完成。
+Function AwdDragClick
+  Pop $0
+  System::Call 'user32::ReleaseCapture()'
+  SendMessage $HWNDPARENT ${WM_NCLBUTTONDOWN} ${AWDUI_HTCAPTION} 0
+FunctionEnd
+
 !ifdef AWD_UI_DIR_CHOICE
 Function AwdToggleCustom
   Pop $0
@@ -395,7 +426,9 @@ Function AwdToggleCustom
     ${AwdPx} $R6 ${AWDUI_H}
   ${EndIf}
   ${AwdPx} $R5 ${AWDUI_W}
-  System::Call 'user32::SetWindowPos(p $HWNDPARENT, i 0, i $AwdWinX, i $AwdWinY, i R5, i R6, i 0x24)'
+  ; SWP_NOMOVE：只改高度，左上角留在原地。卡片现在能拖，用初始化时记的坐标重定位
+  ; 会把用户刚拖走的卡片弹回屏幕中央。
+  System::Call 'user32::SetWindowPos(p $HWNDPARENT, i 0, i 0, i 0, i R5, i R6, i 0x26)'
 FunctionEnd
 
 Function AwdBrowseClick
@@ -561,18 +594,43 @@ Function AwdInstFilesShow
   ; 拷完直接滑到完成卡，不停在「已完成，请点下一步」
   SetAutoClose true
 
-  ; 缩到小卡片并钉到工作区右上角
+  ; 缩到小卡片并钉到工作区右上角。进度卡期间脚本一行都跑不了（见文件头「可拖动契约」），
+  ; 拖动带只能是真标题栏：把初始化时剥掉的 WS_CAPTION 加回来（不带 WS_SYSMENU，
+  ; 无图标无按钮）。外框 = 客户区 + 标题带 + 边框，由 AdjustWindowRectEx 按当前样式
+  ; 实算，别手抄 31px——不同系统、不同 DPI 都不一样。
   ${AwdPx} $2 ${AWDUI_MINI_W}
   ${AwdPx} $3 ${AWDUI_MINI_H}
+  System::Call 'user32::GetWindowLong(p $HWNDPARENT, i -16) i .r0'
+  IntOp $0 $0 | ${AWDUI_WS_CAPTION}
+  System::Call 'user32::SetWindowLong(p $HWNDPARENT, i -16, i r0)'
+  ; Win11：标题带与文字染成卡片白、边框染成位图自带的 1px 框色 #DCE5DF，看起来只是
+  ; 卡片顶上多了一条空白。DWMWA_CAPTION_COLOR=35 / TEXT_COLOR=36 / BORDER_COLOR=34，
+  ; 值是 COLORREF（BGR）；Win10 及更早不认这几个属性，调用失败无害，显示系统标题带。
+  System::Call '*(i 0x00FFFFFF) p .r1'
+  System::Call 'dwmapi::DwmSetWindowAttribute(p $HWNDPARENT, i 35, p r1, i 4)'
+  System::Call 'dwmapi::DwmSetWindowAttribute(p $HWNDPARENT, i 36, p r1, i 4)'
+  System::Free $1
+  System::Call '*(i 0x00DFE5DC) p .r1'
+  System::Call 'dwmapi::DwmSetWindowAttribute(p $HWNDPARENT, i 34, p r1, i 4)'
+  System::Free $1
+  System::Call 'user32::GetWindowLong(p $HWNDPARENT, i -20) i .r1'
+  System::Call '*(i 0, i 0, i r2, i r3) p .r4'
+  System::Call 'user32::AdjustWindowRectEx(p r4, i r0, i 0, i r1)'
+  System::Call '*$4(i .r5, i .r6, i .r7, i .r8)'
+  System::Free $4
+  IntOp $R1 $7 - $5     ; 外框宽
+  IntOp $R2 $8 - $6     ; 外框高
   System::Call '*(i, i, i, i) p .r4'
   System::Call 'user32::SystemParametersInfo(i 0x30, i 0, p r4, i 0)'
   System::Call '*$4(i .r5, i .r6, i .r7, i .r8)'
   System::Free $4
   ${AwdPx} $0 16
-  IntOp $9 $7 - $2
+  IntOp $9 $7 - $R1
   IntOp $9 $9 - $0
   IntOp $R0 $6 + $0
-  System::Call 'user32::SetWindowPos(p $HWNDPARENT, i 0, i r9, i R0, i r2, i r3, i 0x24)'
+  ; 0x34 = SWP_FRAMECHANGED|SWP_NOACTIVATE|SWP_NOZORDER：改过样式必须带 FRAMECHANGED，
+  ; 否则非客户区不重算，标题带画不出来
+  System::Call 'user32::SetWindowPos(p $HWNDPARENT, i 0, i r9, i R0, i R1, i R2, i 0x34)'
 
   StrCpy $R7 $2
   StrCpy $R8 $3
@@ -615,9 +673,19 @@ FunctionEnd
 Function AwdFinishCreate
   Call AwdHideChrome
 
-  ; 尺寸位置沿用安装页（重申一遍，防御直接跳到本页的路径）
+  ; 去掉进度卡期间加回的标题带，回到无边框（直接跳到本页的路径上它本来就没有，
+  ; 再剥一次无害）。客户区左上角留在原地——用户可能已经把进度卡拖到别处，
+  ; 卡片内容不该因为标题带消失而跳一下。
+  System::Call '*(i 0, i 0) p .r1'
+  System::Call 'user32::ClientToScreen(p $HWNDPARENT, p r1)'
+  System::Call '*$1(i .r2, i .r3)'
+  System::Free $1
+  System::Call 'user32::GetWindowLong(p $HWNDPARENT, i -16) i .r0'
+  IntOp $0 $0 & 0xFF37FFFF
+  System::Call 'user32::SetWindowLong(p $HWNDPARENT, i -16, i r0)'
   ${AwdPx} $R7 ${AWDUI_MINI_W}
   ${AwdPx} $R8 ${AWDUI_MINI_H}
+  System::Call 'user32::SetWindowPos(p $HWNDPARENT, i 0, i r2, i r3, i R7, i R8, i 0x34)'
   Call AwdFillPageArea
 
   nsDialogs::Create 1018
@@ -628,9 +696,12 @@ Function AwdFinishCreate
   SetCtlColors $AwdDialog "" 0xFFFFFF
   System::Call 'user32::SetWindowPos(p $AwdDialog, i 0, i 0, i 0, i R7, i R8, i 0x14)'
 
-  nsDialogs::CreateControl STATIC ${WS_VISIBLE}|${WS_CHILD}|${WS_CLIPSIBLINGS}|${SS_BITMAP} 0 0 0 $R7 $R8 ""
+  ; 背景位图同欢迎卡：SS_NOTIFY + 压底 + OnClick 拖动
+  nsDialogs::CreateControl STATIC ${WS_VISIBLE}|${WS_CHILD}|${WS_CLIPSIBLINGS}|${SS_BITMAP}|${SS_NOTIFY} 0 0 0 $R7 $R8 ""
   Pop $1
   ${NSD_SetImage} $1 "$PLUGINSDIR\awd-mini-done.bmp" $AwdImgHero
+  System::Call 'user32::SetWindowPos(p r1, p 1, i 0, i 0, i 0, i 0, i 0x13)'
+  ${NSD_OnClick} $1 AwdDragClick
 
   ${AwdHotspot} $2 ${AWDUI_DONEBTN_X} ${AWDUI_DONEBTN_Y} ${AWDUI_DONEBTN_W} ${AWDUI_DONEBTN_H}
   ${NSD_OnClick} $2 AwdLaunchClick

--- a/desktop/build/win/awd-oneclick-ui.nsh
+++ b/desktop/build/win/awd-oneclick-ui.nsh
@@ -146,6 +146,7 @@ Var AwdFont       ; 高 DPI 适配的雅黑句柄（真控件用）
 Var AwdDialog
 Var AwdImgHero
 Var AwdImgMini
+Var AwdBgWnd      ; 当前 nsDialogs 页的背景位图控件（建完所有控件后压底用）
 Var AwdExpanded
 !ifdef AWD_UI_DIR_CHOICE
 Var AwdDirEdit
@@ -307,16 +308,18 @@ Function AwdWelcomeCreate
   System::Call 'user32::SetWindowPos(p $AwdDialog, i 0, i 0, i 0, i R7, i R8, i 0x14)'
 
   ; 背景大图（含按钮/文案的全部视觉）。带 SS_NOTIFY 是为了拖动：按在热区之外的任何
-  ; 地方，位图的 STN_CLICKED 把这一按交给 AwdDragClick。显式压到 z 序最底，别赌
-  ; 创建顺序——没有 SS_NOTIFY 的 static 对命中测试是透明的，有了就不是，位图一旦
-  ; 浮到热区之上会把「立即安装」的点击吃掉。
+  ; 地方，位图的 STN_CLICKED 把这一按交给 AwdDragClick。
+  ; **z 序地雷**：子窗口创建时是插到 z 序**最底**的（后建的在下面，不是在上面），
+  ; 以前位图没有 SS_NOTIFY、对命中测试透明，点击穿过它落到下面的热区，所以没露馅；
+  ; 一加 SS_NOTIFY 位图就变成 HTCLIENT，会把「立即安装」的点击整个吃掉
+  ;（installer-ui-smoke 实锤：拖动通了、随后所有热区全哑）。所以位图必须在
+  ; **所有控件都建完之后**再压到 HWND_BOTTOM（见 nsDialogs::Show 之前那句）。
   nsDialogs::CreateControl STATIC ${WS_VISIBLE}|${WS_CHILD}|${WS_CLIPSIBLINGS}|${SS_BITMAP}|${SS_NOTIFY} 0 0 0 $R7 $R8 ""
-  Pop $1
-  ${NSD_SetImage} $1 "$PLUGINSDIR\awd-hero.bmp" $AwdImgHero
-  System::Call 'user32::SetWindowPos(p r1, p 1, i 0, i 0, i 0, i 0, i 0x13)'
-  ${NSD_OnClick} $1 AwdDragClick
+  Pop $AwdBgWnd
+  ${NSD_SetImage} $AwdBgWnd "$PLUGINSDIR\awd-hero.bmp" $AwdImgHero
+  ${NSD_OnClick} $AwdBgWnd AwdDragClick
 
-  ; 热区（创建序在位图之后 = z 序在其上）
+  ; 热区（都建在位图之后，最后再把位图压底）
   ${AwdHotspot} $2 ${AWDUI_CTA_X} ${AWDUI_CTA_Y} ${AWDUI_CTA_W} ${AWDUI_CTA_H}
   ${NSD_OnClick} $2 AwdInstallClick
   ${AwdHotspot} $2 ${AWDUI_TERMS_X} ${AWDUI_TERMS_Y} ${AWDUI_LINK_W} ${AWDUI_LINK_H}
@@ -365,6 +368,8 @@ Function AwdWelcomeCreate
     SetCtlColors $AwdSpaceLabel 0x8A9590 0xFFFFFF
   !endif
 
+  ; 位图压到 z 序最底：所有热区/真控件都已建好，这一句之后它们才真的在位图之上
+  System::Call 'user32::SetWindowPos(p $AwdBgWnd, p 1, i 0, i 0, i 0, i 0, i 0x13)'
   nsDialogs::Show
 FunctionEnd
 
@@ -696,18 +701,18 @@ Function AwdFinishCreate
   SetCtlColors $AwdDialog "" 0xFFFFFF
   System::Call 'user32::SetWindowPos(p $AwdDialog, i 0, i 0, i 0, i R7, i R8, i 0x14)'
 
-  ; 背景位图同欢迎卡：SS_NOTIFY + 压底 + OnClick 拖动
+  ; 背景位图同欢迎卡：SS_NOTIFY + OnClick 拖动，热区建完再压底（z 序地雷见欢迎卡）
   nsDialogs::CreateControl STATIC ${WS_VISIBLE}|${WS_CHILD}|${WS_CLIPSIBLINGS}|${SS_BITMAP}|${SS_NOTIFY} 0 0 0 $R7 $R8 ""
-  Pop $1
-  ${NSD_SetImage} $1 "$PLUGINSDIR\awd-mini-done.bmp" $AwdImgHero
-  System::Call 'user32::SetWindowPos(p r1, p 1, i 0, i 0, i 0, i 0, i 0x13)'
-  ${NSD_OnClick} $1 AwdDragClick
+  Pop $AwdBgWnd
+  ${NSD_SetImage} $AwdBgWnd "$PLUGINSDIR\awd-mini-done.bmp" $AwdImgHero
+  ${NSD_OnClick} $AwdBgWnd AwdDragClick
 
   ${AwdHotspot} $2 ${AWDUI_DONEBTN_X} ${AWDUI_DONEBTN_Y} ${AWDUI_DONEBTN_W} ${AWDUI_DONEBTN_H}
   ${NSD_OnClick} $2 AwdLaunchClick
   ${AwdHotspot} $2 ${AWDUI_MCLOSE_X} ${AWDUI_MCLOSE_Y} ${AWDUI_MCLOSE_W} ${AWDUI_MCLOSE_H}
   ${NSD_OnClick} $2 AwdFinishCloseClick
 
+  System::Call 'user32::SetWindowPos(p $AwdBgWnd, p 1, i 0, i 0, i 0, i 0, i 0x13)'
   nsDialogs::Show
 FunctionEnd
 

--- a/desktop/scripts/installer-smoke.ps1
+++ b/desktop/scripts/installer-smoke.ps1
@@ -35,6 +35,7 @@ public class W {
   [DllImport("user32.dll")] public static extern bool PostMessage(IntPtr h, uint msg, IntPtr wp, IntPtr lp);
   [DllImport("user32.dll")] public static extern IntPtr GetDlgItem(IntPtr h, int id);
   [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr SendMessageTimeout(IntPtr h, uint msg, IntPtr wp, IntPtr lp, uint flags, uint timeout, out IntPtr result);
   public struct RECT { public int L, T, R, B; }
   public struct POINT { public int x, y; }
 }
@@ -130,6 +131,56 @@ function ClickAt([int]$bx, [int]$by) {
   Start-Sleep -Milliseconds 250
 }
 
+# 绝对坐标的真实鼠标移动（MOUSEEVENTF_MOVE|ABSOLUTE，归一到主屏 0..65535）。拖窗必须走
+# 真输入：无边框窗口的移动靠系统的模态拖动循环，它只认输入队列里的鼠标消息，
+# SetWindowPos 之类从外部挪窗口证明不了「用户能拖」。
+$screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+function MoveAbs([int]$x, [int]$y) {
+  $nx = [uint32][math]::Round($x * 65535 / ($screen.Width - 1))
+  $ny = [uint32][math]::Round($y * 65535 / ($screen.Height - 1))
+  [W]::mouse_event(0x8001, $nx, $ny, 0, [UIntPtr]::Zero)
+}
+
+# 可拖动断言（dev-board#366）：在窗口相对点 (bx,by) 按下真实鼠标、分步拖 (dx,dy)、抬起，
+# 断言窗口矩形跟着走了，且进程全程活着。失败不当场 throw——三张卡各拖一次，
+# 一次红就中断会把后面两张卡的结论一起吞掉，全部记下来最后一并报。
+$dragFailures = @()
+function DragAssert([string]$stage, [int]$bx, [int]$by, [int]$dx, [int]$dy) {
+  $r = Get-Rect
+  Clear-Overlay ($r.L + $bx) ($r.T + $by)
+  $r = Get-Rect
+  $sx = $r.L + $bx; $sy = $r.T + $by
+  MoveAbs $sx $sy
+  Start-Sleep -Milliseconds 150
+  [W]::mouse_event(2, 0, 0, 0, [UIntPtr]::Zero)   # LEFTDOWN
+  Start-Sleep -Milliseconds 200
+  for ($i = 1; $i -le 10; $i++) {
+    MoveAbs ($sx + [int]($dx * $i / 10)) ($sy + [int]($dy * $i / 10))
+    Start-Sleep -Milliseconds 40
+  }
+  Start-Sleep -Milliseconds 200
+  [W]::mouse_event(4, 0, 0, 0, [UIntPtr]::Zero)   # LEFTUP
+  Start-Sleep -Milliseconds 500
+  if ($p.HasExited) { throw "installer exited during the $stage card drag" }
+  $r2 = Get-Rect
+  $mx = $r2.L - $r.L; $my = $r2.T - $r.T
+  Write-Host "drag[$stage]: pressed at ($bx,$by), dragged ($dx,$dy) -> window moved ($mx,$my)"
+  # 位移至少要走到指针位移的一半：绝对坐标归一有 1px 级误差，但「一动不动」就是没接上
+  if ([math]::Abs($mx) -lt [math]::Abs($dx) / 2 -or [math]::Abs($my) -lt [math]::Abs($dy) / 2) {
+    $script:dragFailures += "$stage card did not follow the mouse drag (moved $mx,$my; expected about $dx,$dy)"
+  }
+}
+
+# UI 线程活着的判据：SendMessageTimeout(WM_NULL, SMTO_ABORTIFHUNG) 3 秒内有应答。
+# 安装期间的 Section 跑在 NSIS 自己开的 install_thread 上（Ui.c 的 WM_NOTIFY_START），
+# 消息泵本来就不会停——这条把它钉成用例，免得下次再往「消息泵卡死」上猜。
+function AssertResponsive([string]$stage) {
+  $res = [IntPtr]::Zero
+  $ok = [W]::SendMessageTimeout($h, 0, [IntPtr]::Zero, [IntPtr]::Zero, 0x2, 3000, [ref]$res)
+  if ($ok -eq [IntPtr]::Zero) { throw "$stage card: UI thread did not answer WM_NULL within 3s (message pump stalled)" }
+  Write-Host "$stage card: UI thread answered WM_NULL"
+}
+
 # 1. 大卡片首页
 Shot '01-welcome'
 
@@ -175,10 +226,22 @@ if ($CloseOnly) {
   throw "installer did not exit after clicking the welcome card close button"
 }
 
+# 1b. 拖大卡片（dev-board#366）：按在没有任何热区的空白处（380,240），拖 (100,40)。
+# 位移刻意小：runner 常见 1024x768，大卡片 760 宽居中后右侧只剩百来像素余量。
+DragAssert 'welcome' 380 240 100 40
+Shot '01b-welcome-dragged'
+
 # 2. 展开自定义安装（AWDUI_TOGGLE 44,448,130,26 → 中心 109,461）
+# 展开只许向下长高，不许把刚拖走的卡片弹回初始居中位（引擎里曾用初始化时记下的坐标
+# 重定位，拖动接上之后那就成了「一点自定义安装卡片就跳回去」）。
+$rBeforeToggle = Get-Rect
 ClickAt 109 461
 Start-Sleep -Milliseconds 600
 Shot '02-expanded'
+$rAfterToggle = Get-Rect
+if ($rAfterToggle.L -ne $rBeforeToggle.L -or $rAfterToggle.T -ne $rBeforeToggle.T) {
+  $dragFailures += "expanding custom install moved the welcome card from ($($rBeforeToggle.L),$($rBeforeToggle.T)) to ($($rAfterToggle.L),$($rAfterToggle.T)); it must only grow downward"
+}
 # 3. 点「立即安装」（AWDUI_CTA 460,414,260,72 → 中心 590,450）
 ClickAt 590 450
 
@@ -227,11 +290,18 @@ if ($wp -gt 700) {
 if ($backVisible) {
   throw "native wizard chrome is showing on the install page (back button visible) - AwdInstFilesShow did not run"
 }
-Start-Sleep -Milliseconds 2500
+# 3b. 进度卡期间（Section 还在 install_thread 上跑）：UI 线程必须有应答，且卡片必须能被
+# 真实鼠标拖走（dev-board#366：用户反馈的「像卡死了」就是这张卡既没标题栏也拖不动）。
+# 按在窗口顶部 12px 处、向左下拖：卡片钉在工作区右上角，往右上拖会出屏。
+AssertResponsive 'progress'
+DragAssert 'progress' 180 12 -200 120
+Start-Sleep -Milliseconds 1500
 Shot '04-progress2'
 # 4. 等安装收尾进完成卡（payload + 3x2s Sleep，10 秒余量）
 Start-Sleep -Seconds 10
 Shot '05-done'
+# 4b. 完成卡也要能拖：按在副标题文字上（120,60，不在「立即体验」与 ✕ 的热区里）
+DragAssert 'done' 120 60 -150 100
 # 5. 点完成卡右上角 ✕（AWDUI_MCLOSE 320,6,34,28 → 中心 337,20）
 ClickAt 337 20
 Start-Sleep -Seconds 2
@@ -239,5 +309,8 @@ if (-not $p.HasExited) {
   Shot '06-should-have-closed'
   $p.Kill()
   throw "installer did not exit after closing finish card"
+}
+if ($dragFailures.Count -gt 0) {
+  throw ("drag assertions failed (dev-board#366):`n - " + ($dragFailures -join "`n - "))
 }
 Write-Host 'smoke flow completed, installer exited cleanly'


### PR DESCRIPTION
dev-board#366：点「立即安装」后右上角进度卡不能拖、点不了、像卡死。

根因：
- 不能拖：AwdGuiInit 去掉 WS_CAPTION 后系统没有任何标题命中区，引擎也没补——红轮 CI 三张卡真实鼠标拖动全部 moved (0,0)。
- 像卡死：不是消息泵问题（NSIS 的 Section 跑在 install_thread，UI 线程照常泵；红轮日志里安装中 WM_NULL 3 秒内应答）。进度卡美术本来就没有可交互元素，「点不了」与「拖不了」是同一症状。
- CI 半红又揪出第二个 bug：Win32 子窗口插在 z 序底部，引擎原注释「创建序在位图之后 = z 序在其上」反了，之前能用只因非 SS_NOTIFY 的 static 是 HTTRANSPARENT；位图加了 SS_NOTIFY 后变 HTCLIENT 吞掉所有热区点击。

修：欢迎/完成卡位图加 SS_NOTIFY，STN_CLICKED 时 ReleaseCapture + WM_NCLBUTTONDOWN HTCAPTION 交给系统移动循环，位图压到 HWND_BOTTOM；进度卡（instfiles 页无脚本可跑）重新加 WS_CAPTION 当拖动条（无 WS_SYSMENU），Win11 用 DwmSetWindowAttribute 把标题栏染成卡片白，完成卡再去掉；AwdToggleCustom 改 SWP_NOMOVE 不再把拖过的卡弹回中央。AWDUI_* 与 oneclick-*.html 坐标未动。

验证走 installer-ui-smoke 三轮，测试脚本 sha 一致：红 https://github.com/zeweihan/aiworkdeck/actions/runs/33575900306 → 半红 https://github.com/zeweihan/aiworkdeck/actions/runs/33576325194 → 绿 https://github.com/zeweihan/aiworkdeck/actions/runs/33576754273（smoke 与 smoke-arm 都绿）。新增 DragAssert（真鼠标拖、窗口 rect 位移≥指针位移一半、进程存活）、AssertResponsive、「展开自定义安装不得移动卡片」。

视觉取舍：安装期间进度卡高约 31px 的标题条（Win11 为空白卡片白，Win10 为系统标题栏显示 AI WorkDeck Setup），无原生代码下不可避免。

地雷入档 .claude/agents/eng-infra.md 6.5.6。

🤖 Generated with [Claude Code](https://claude.com/claude-code)