### PR TITLE
feat(api): /api/mobile OpenAPI 真源 + 契约测试（dev-board#392）

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -123,6 +123,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-mockmvc</artifactId>
+            <version>2.44.9</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- LangChain4j + Ollama -->
         <dependency>

--- a/backend/src/main/resources/openapi/mobile-v1.yaml
+++ b/backend/src/main/resources/openapi/mobile-v1.yaml
@@ -69,13 +69,13 @@ components:
         subscriptionType: { type: string, nullable: true }
     LoginData:
       type: object
-      required: [sessionId, user]
+      required: [sessionId, isNewUser, user]
       description: |
-        注意：服务端不返回 isNewUser。小程序 api.ts 的 LoginResult 声明了 isNewUser，
-        实际永远 undefined；iOS 侧已是可选。客户端应按可选处理（记录于 2026-09-02，不在服务端改）。
+        sms-login/verify 成功时的 data。isNewUser 由服务端恒返回（account.created）。
       properties:
         sessionId: { type: string }
-        mustBindPhone: { type: boolean }
+        isNewUser: { type: boolean }
+        mustBindPhone: { type: boolean, description: 由 account-login / mail-login 等门控登录流设置；sms-login/verify 不返回 }
         user: { $ref: '#/components/schemas/AccountUser' }
     LoginEnvelope:
       type: object
@@ -269,7 +269,12 @@ paths:
                         deviceId: { type: string }
                         deviceName: { type: string, nullable: true }
                         online: { type: boolean }
-                        projects: { type: array, items: { $ref: '#/components/schemas/RelayProject' } }
+                        projects:
+                          type: array
+                          items:
+                            type: object
+                            required: [key, name]
+                            properties: { key: { type: string }, name: { type: string } }
                   - $ref: '#/components/schemas/Envelope'
   /api/mobile/inbox:
     get:
@@ -306,10 +311,12 @@ paths:
         - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
       responses:
         "200":
-          description: 字节流
+          description: 字节流；未登录为 JSON Envelope(4010)
           content:
             application/octet-stream:
               schema: { type: string, format: binary }
+            application/json:
+              schema: { $ref: '#/components/schemas/Envelope' }
   /api/mobile/inbox/{id}/ack:
     post:
       summary: 桌面端：确认落盘，置 deliveredAt 并立即删 blob（本期不校验）

--- a/backend/src/main/resources/openapi/mobile-v1.yaml
+++ b/backend/src/main/resources/openapi/mobile-v1.yaml
@@ -1,0 +1,324 @@
+openapi: 3.0.3
+info:
+  title: AI Workdeck Mobile Relay API
+  version: "1.0.0"
+  description: |
+    手机端（iOS / 小程序 / 安卓 / 鸿蒙）与桌面端共用的中转接口。真源在本文件；
+    移动仓 contract/api/mobile-v1.yaml 是钉版副本。鉴权一律请求头 X-Session-Id。
+    未登录不是 401，而是 HTTP 200 + {code: 4010} 信封——客户端按信封判鉴权失败。
+servers:
+  - url: https://addin.aiworkdeck.com
+    description: 大陆版（北京）
+  - url: https://addin.workdeck.ai
+    description: 国际版（新加坡）
+components:
+  parameters:
+    SessionId:
+      name: X-Session-Id
+      in: header
+      required: false
+      schema: { type: string }
+      description: 登录会话或 awdt_ 设备令牌。缺失或失效 → 200 + Envelope(code 4010)。
+  schemas:
+    Envelope:
+      type: object
+      required: [code]
+      properties:
+        code: { type: integer, description: "0 成功；4010 未登录；1 业务错误" }
+        message: { type: string, nullable: true }
+        data: { nullable: true }
+    RelayProject:
+      type: object
+      required: [deviceId, key, name]
+      properties:
+        deviceId: { type: string, description: 桌面机 UUID }
+        deviceName: { type: string, nullable: true }
+        key: { type: string, description: 桌面机本地库项目 id；跨机同号不同物，必须连 deviceId }
+        name: { type: string }
+    MediaStatus:
+      type: object
+      required: [clientMediaId, delivered, waitingSeconds]
+      properties:
+        clientMediaId: { type: string }
+        delivered: { type: boolean, description: 桌面端已 ACK 落盘（中转区已删） }
+        waitingSeconds: { type: integer, format: int64, description: 已投递为 0 }
+        expiresAt: { type: string, description: 中转区到期时刻（ISO 本地时间），仅未投递件带 }
+    MediaUsage:
+      type: object
+      required: [usedBytes, quotaBytes]
+      properties:
+        usedBytes: { type: integer, format: int64 }
+        quotaBytes: { type: integer, format: int64 }
+    UploadResult:
+      type: object
+      required: [code, id, clientMediaId, delivered]
+      properties:
+        code: { type: integer, enum: [0] }
+        id: { type: integer, format: int64 }
+        clientMediaId: { type: string }
+        delivered: { type: boolean, description: 幂等重传命中已投递记录时为 true }
+    AccountUser:
+      type: object
+      required: [id, username, displayName]
+      properties:
+        id: { type: integer, format: int64 }
+        username: { type: string }
+        displayName: { type: string }
+        avatarUrl: { type: string, description: 无头像时为空串 }
+        role: { type: string }
+        subscriptionType: { type: string, nullable: true }
+    LoginData:
+      type: object
+      required: [sessionId, user]
+      description: |
+        注意：服务端不返回 isNewUser。小程序 api.ts 的 LoginResult 声明了 isNewUser，
+        实际永远 undefined；iOS 侧已是可选。客户端应按可选处理（记录于 2026-09-02，不在服务端改）。
+      properties:
+        sessionId: { type: string }
+        mustBindPhone: { type: boolean }
+        user: { $ref: '#/components/schemas/AccountUser' }
+    LoginEnvelope:
+      type: object
+      required: [code]
+      properties:
+        code: { type: integer }
+        message: { type: string, nullable: true }
+        data: { $ref: '#/components/schemas/LoginData' }
+    CaptureManifest:
+      type: object
+      description: |
+        客户端随影像生成的取证清单（与 iOS CaptureManifest.swift 逐字段一致）。当前服务端只接收
+        clientMediaId / capturedAt / fileName / mediaType 四个字段（multipart 参数），其余留在客户端；
+        接 TSA 后 tsaToken 上行，结构不变。
+      required: [clientMediaId, sha256, capturedAt, deviceModel, osVersion, appVersion, fromCamera]
+      properties:
+        clientMediaId: { type: string, format: uuid, description: 幂等键 }
+        sha256: { type: string, minLength: 64, maxLength: 64 }
+        capturedAt: { type: string, format: date-time, description: 设备时钟 }
+        serverReceivedAt: { type: string, format: date-time, nullable: true }
+        latitude: { type: number, nullable: true }
+        longitude: { type: number, nullable: true }
+        horizontalAccuracy: { type: number, nullable: true, description: 米 }
+        deviceModel: { type: string }
+        osVersion: { type: string }
+        appVersion: { type: string }
+        fromCamera: { type: boolean, description: 是否强制来自相机 }
+        tsaToken: { type: string, nullable: true, description: 可信时间戳，当前恒 null }
+paths:
+  /api/auth/sms-login/send-code:
+    post:
+      summary: 发送短信验证码
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [phone]
+              properties: { phone: { type: string, pattern: '^1\d{10}$' } }
+      responses:
+        "200":
+          description: code 0 已发送；code 1 业务拒绝（频率、号码格式、人机门）
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Envelope' }
+  /api/auth/sms-login/verify:
+    post:
+      summary: 校验验证码并签发会话
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [phone, code]
+              properties:
+                phone: { type: string }
+                code: { type: string }
+      responses:
+        "200":
+          description: code 0 带 data；否则 code 非 0 且 data 缺失
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/LoginEnvelope' }
+  /api/mobile/projects:
+    get:
+      summary: 手机端：该账号全部设备的项目目录并集（裸数组）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      responses:
+        "200":
+          description: 裸数组；未登录为 Envelope(4010)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items: { $ref: '#/components/schemas/RelayProject' }
+                  - $ref: '#/components/schemas/Envelope'
+    put:
+      summary: 桌面端：项目目录全量替换（本期不校验）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [deviceId, projects]
+              properties:
+                deviceId: { type: string }
+                deviceName: { type: string, nullable: true }
+                projects:
+                  type: array
+                  items:
+                    type: object
+                    required: [key, name]
+                    properties: { key: { type: string }, name: { type: string } }
+      responses:
+        "200":
+          description: code 0 + count/totalCount/truncated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    required: [code, count, totalCount, truncated]
+                    properties:
+                      code: { type: integer, enum: [0] }
+                      count: { type: integer }
+                      totalCount: { type: integer }
+                      truncated: { type: boolean }
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/media:
+    post:
+      summary: 手机端：上传一件现场影像到中转区（幂等键 clientMediaId）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file, deviceId, projectKey, clientMediaId, fileName, mediaType]
+              properties:
+                file: { type: string, format: binary }
+                deviceId: { type: string }
+                projectKey: { type: string }
+                clientMediaId: { type: string }
+                fileName: { type: string }
+                mediaType: { type: string, enum: [image, video, audio] }
+                capturedAt: { type: string, description: ISO-8601，可选 }
+      responses:
+        "200":
+          description: 成功 UploadResult；未登录 Envelope(4010)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UploadResult'
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/media/status:
+    get:
+      summary: 手机端：查询影像投递状态（裸数组）
+      parameters:
+        - { $ref: '#/components/parameters/SessionId' }
+        - name: clientMediaIds
+          in: query
+          required: true
+          schema: { type: string }
+          description: 逗号分隔
+      responses:
+        "200":
+          description: 裸数组；未登录 Envelope(4010)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items: { $ref: '#/components/schemas/MediaStatus' }
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/media/usage:
+    get:
+      summary: 手机端：中转区用量与配额（裸对象）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      responses:
+        "200":
+          description: 裸对象；未登录 Envelope(4010)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/MediaUsage'
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/devices:
+    get:
+      summary: 插件端：设备清单（本期不校验）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      responses:
+        "200":
+          description: 裸数组
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      type: object
+                      required: [deviceId, online, projects]
+                      properties:
+                        deviceId: { type: string }
+                        deviceName: { type: string, nullable: true }
+                        online: { type: boolean }
+                        projects: { type: array, items: { $ref: '#/components/schemas/RelayProject' } }
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/inbox:
+    get:
+      summary: 桌面端：本设备待取件（本期不校验）
+      parameters:
+        - { $ref: '#/components/parameters/SessionId' }
+        - { name: deviceId, in: query, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: 裸数组
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      type: object
+                      required: [id, projectKey, clientMediaId, fileName, mediaType, fileSize, createdAt]
+                      properties:
+                        id: { type: integer, format: int64 }
+                        projectKey: { type: string }
+                        clientMediaId: { type: string }
+                        fileName: { type: string }
+                        mediaType: { type: string }
+                        fileSize: { type: integer, format: int64 }
+                        capturedAt: { type: string, nullable: true }
+                        createdAt: { type: string }
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/inbox/{id}/content:
+    get:
+      summary: 桌面端：取件字节流。契约红线：成功必须 2xx + application/octet-stream 裸字节，不许 302（本期不校验）
+      parameters:
+        - { $ref: '#/components/parameters/SessionId' }
+        - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+      responses:
+        "200":
+          description: 字节流
+          content:
+            application/octet-stream:
+              schema: { type: string, format: binary }
+  /api/mobile/inbox/{id}/ack:
+    post:
+      summary: 桌面端：确认落盘，置 deliveredAt 并立即删 blob（本期不校验）
+      parameters:
+        - { $ref: '#/components/parameters/SessionId' }
+        - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+      responses:
+        "200":
+          description: code 0
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Envelope' }

--- a/backend/src/main/resources/openapi/mobile-v1.yaml
+++ b/backend/src/main/resources/openapi/mobile-v1.yaml
@@ -6,6 +6,9 @@ info:
     手机端（iOS / 小程序 / 安卓 / 鸿蒙）与桌面端共用的中转接口。真源在本文件；
     移动仓 contract/api/mobile-v1.yaml 是钉版副本。鉴权一律请求头 X-Session-Id。
     未登录不是 401，而是 HTTP 200 + {code: 4010} 信封——客户端按信封判鉴权失败。
+
+    校验器（swagger-request-validator）默认 additionalProperties: false：本文件是响应字段的
+    **穷举白名单**，服务端新增任何响应字段都必须先写进这里，否则契约测试红。
 servers:
   - url: https://addin.aiworkdeck.com
     description: 大陆版（北京）
@@ -27,6 +30,11 @@ components:
         code: { type: integer, description: "0 成功；4010 未登录；1 业务错误" }
         message: { type: string, nullable: true }
         data: { nullable: true }
+        feature: { type: string, description: "GlobalExceptionHandler code=4001/4003 附带的功能 id" }
+        configured: { type: boolean, description: "code=4001（功能未配置）附带" }
+        usage: { type: object, additionalProperties: true, description: "code=4003（额度已满）附带的用量明细" }
+        gatewayKind: { type: string, description: "code=1（平台网关失败）附带" }
+        canUseOwnKey: { type: boolean, description: "code=1（平台网关失败）附带，是否可用自备 Key 绕过" }
     RelayProject:
       type: object
       required: [deviceId, key, name]
@@ -46,6 +54,9 @@ components:
     MediaUsage:
       type: object
       required: [usedBytes, quotaBytes]
+      description: |
+        usedBytes 只统计 inbox 待取件字节（sumPendingBytes）；而配额执行（storeMedia 时的 3GB 判断）
+        同时计入 inbox 与 transfer。手机端设置页显示的用量可能低于实际被计费的量。服务端行为，本轮不改。
       properties:
         usedBytes: { type: integer, format: int64 }
         quotaBytes: { type: integer, format: int64 }
@@ -268,6 +279,7 @@ paths:
                       properties:
                         deviceId: { type: string }
                         deviceName: { type: string, nullable: true }
+                        lastSeenAt: { type: string, nullable: true, description: 最后心跳时刻（ISO 本地时间），无心跳为 null }
                         online: { type: boolean }
                         projects:
                           type: array

--- a/backend/src/test/java/com/checkba/MobileApiContractTest.java
+++ b/backend/src/test/java/com/checkba/MobileApiContractTest.java
@@ -24,12 +24,15 @@ import static com.atlassian.oai.validator.mockmvc.OpenApiValidationMatchers.open
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * API 契约测试：手机端调用的六个端点，真实响应必须合 src/main/resources/openapi/mobile-v1.yaml。
  * 只校验响应（请求级别 IGNORE，multipart 请求校验在该库里不稳）。
  * 环境配方同 MobileRelayEndpointIntegrationTest。移动仓 contract/api/ 钉的是这份 YAML 的副本。
+ * <p>校验器（swagger-request-validator）默认 additionalProperties: false：mobile-v1.yaml 是响应字段的
+ * 穷举白名单，服务端新增任何响应字段都必须先写进那份 YAML，否则本测试红。
  */
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:h2:mem:mobile-api-contract;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
@@ -77,6 +80,7 @@ class MobileApiContractTest {
         // 未登录信封也在契约里
         mvc.perform(get("/api/mobile/projects"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(4010))
                 .andExpect(openApi().isValid(validator));
 
         // 桌面推目录，让 GET /projects 有内容
@@ -84,10 +88,12 @@ class MobileApiContractTest {
                         .contentType(APPLICATION_JSON)
                         .content("""
                                 {"deviceId":"dev-c","deviceName":"Mac","projects":[{"key":"1","name":"契约项目"}]}"""))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0));
 
         mvc.perform(get("/api/mobile/projects").header("X-Session-Id", sid))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].key").value("1"))
                 .andExpect(openApi().isValid(validator));
 
         MockMultipartFile file = new MockMultipartFile(
@@ -100,15 +106,18 @@ class MobileApiContractTest {
                         .param("capturedAt", "2026-09-02T17:00:00Z")
                         .header("X-Session-Id", sid))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
                 .andExpect(openApi().isValid(validator));
 
         mvc.perform(get("/api/mobile/media/status").param("clientMediaIds", mediaId)
                         .header("X-Session-Id", sid))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].clientMediaId").value(mediaId))
                 .andExpect(openApi().isValid(validator));
 
         mvc.perform(get("/api/mobile/media/usage").header("X-Session-Id", sid))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.quotaBytes").isNumber())
                 .andExpect(openApi().isValid(validator));
     }
 

--- a/backend/src/test/java/com/checkba/MobileApiContractTest.java
+++ b/backend/src/test/java/com/checkba/MobileApiContractTest.java
@@ -1,0 +1,128 @@
+package com.checkba;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.report.LevelResolver;
+import com.atlassian.oai.validator.report.ValidationReport;
+import com.checkba.service.ai.tools.WebTools;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static com.atlassian.oai.validator.mockmvc.OpenApiValidationMatchers.openApi;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * API 契约测试：手机端调用的六个端点，真实响应必须合 src/main/resources/openapi/mobile-v1.yaml。
+ * 只校验响应（请求级别 IGNORE，multipart 请求校验在该库里不稳）。
+ * 环境配方同 MobileRelayEndpointIntegrationTest。移动仓 contract/api/ 钉的是这份 YAML 的副本。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:mobile-api-contract;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.local-mode=false",
+        "storage.local.root-path=${java.io.tmpdir}/mobile-api-contract-store"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("desktop")
+class MobileApiContractTest {
+
+    private static OpenApiInteractionValidator validator;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper om;
+    @MockBean private WebTools webTools;
+
+    @BeforeAll
+    static void loadSpec() throws Exception {
+        String spec = new String(
+                MobileApiContractTest.class.getResourceAsStream("/openapi/mobile-v1.yaml").readAllBytes(),
+                StandardCharsets.UTF_8);
+        validator = OpenApiInteractionValidator.createForInlineApiSpecification(spec)
+                .withLevelResolver(LevelResolver.create()
+                        .withLevel("validation.request", ValidationReport.Level.IGNORE)
+                        .build())
+                .build();
+    }
+
+    private String register(String username) throws Exception {
+        String body = om.writeValueAsString(Map.of(
+                "username", username, "password", "pw123456", "displayName", username));
+        MvcResult r = mvc.perform(post("/api/auth/register").contentType(APPLICATION_JSON).content(body))
+                .andExpect(status().isOk()).andReturn();
+        JsonNode json = om.readTree(r.getResponse().getContentAsString());
+        String sid = json.path("data").path("sessionId").asText();
+        assertFalse(sid.isEmpty(), "注册应返回 sessionId：" + r.getResponse().getContentAsString());
+        return sid;
+    }
+
+    @Test
+    void handsetEndpointsMatchSpec() throws Exception {
+        String sid = register("contract_" + System.nanoTime());
+        String mediaId = "0a1b2c3d-2222-4333-8444-555566667777";
+
+        // 未登录信封也在契约里
+        mvc.perform(get("/api/mobile/projects"))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+
+        // 桌面推目录，让 GET /projects 有内容
+        mvc.perform(put("/api/mobile/projects").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"deviceId":"dev-c","deviceName":"Mac","projects":[{"key":"1","name":"契约项目"}]}"""))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/api/mobile/projects").header("X-Session-Id", sid))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "现场影像-20260902-170000-0a1b.jpg", "application/octet-stream", "JPEG".getBytes());
+        mvc.perform(multipart("/api/mobile/media").file(file)
+                        .param("deviceId", "dev-c").param("projectKey", "1")
+                        .param("clientMediaId", mediaId)
+                        .param("fileName", "现场影像-20260902-170000-0a1b.jpg")
+                        .param("mediaType", "image")
+                        .param("capturedAt", "2026-09-02T17:00:00Z")
+                        .header("X-Session-Id", sid))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+
+        mvc.perform(get("/api/mobile/media/status").param("clientMediaIds", mediaId)
+                        .header("X-Session-Id", sid))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+
+        mvc.perform(get("/api/mobile/media/usage").header("X-Session-Id", sid))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+    }
+
+    @Test
+    void smsLoginEnvelopesMatchSpec() throws Exception {
+        // 不真发短信：非法号码走 code 1 分支，信封形状仍受契约约束
+        mvc.perform(post("/api/auth/sms-login/send-code").contentType(APPLICATION_JSON)
+                        .content("{\"phone\":\"123\"}"))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+
+        mvc.perform(post("/api/auth/sms-login/verify").contentType(APPLICATION_JSON)
+                        .content("{\"phone\":\"13800000000\",\"code\":\"000000\"}"))
+                .andExpect(status().isOk())
+                .andExpect(openApi().isValid(validator));
+    }
+}


### PR DESCRIPTION
## 摘要
- 手写 `backend/src/main/resources/openapi/mobile-v1.yaml`（OpenAPI 3.0.3）覆盖 `/api/mobile/*` 与短信登录；未登录 200+4010 信封入契约。校验器默认 additionalProperties:false，本文件是响应字段的穷举白名单。
- `MobileApiContractTest` 用 swagger-request-validator-mockmvc 2.44.9 校验手机端六端点真实响应，并用 jsonPath 钉死成功分支（信封分支不能假绿）。
- 不改任何控制器；两处已知服务端行为记进 description（MediaUsage 用量口径与配额口径不一致；transfer/* 端点下一轮补入契约）。
- 评审修正过的三处 YAML 与实现不符：devices 项形状与 lastSeenAt、LoginData 恒返回 isNewUser、inbox/{id}/content 的 JSON 信封分支。

配套：移动仓 `docs/specs/2026-09-02-contract-design.md` §7；合并后移动仓跑 `node contract/tools/pull-api.mjs` 钉版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)