### PR TITLE
chore(release): 版本号 0.33.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
v0.32.0 之后合入：#711（文件右键「发送…」，改了 desktop/ → 大版本）、#712（/api/mobile OpenAPI 真源）、#713（任务清单/标签页/依据窗格/OCR 四修，dev-board#393-#396）。

门禁见 #713 评论：mvn 3033/0、app-e2e 132/0、desktop 88/88、前端 CI 组全绿。

合并后打 tag v0.33.0 触发桌面双平台构建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)