### PR TITLE
fix(file-tree): 桌面端拖入外部文件改为复制进项目目录，上传失败不留空白占位（dev-board#409）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -195,6 +195,34 @@ drop 的同步阶段取）+ `claimExternalDrop(native)`（同一原生事件在�
 drop 现在**对落点在 `.file-tree` 里的事件让路**——拖文件夹进目录节点是上传进去。
 单测 `tests/project-home/file-tree-external-drop.test.mjs`（`npm run test:project-home`）。
 
+**落点定了之后分两条路（dev-board#409，2026-09-03）**：桌面端凡是能解析出本机绝对路径的
+单个文件（`host.fs.getPathForFile`，Electron 的 webUtils），走
+**`POST /api/projects/{id}/files/import-local`**（`{sourcePath, parentId}`，
+`ProjectFileController.importLocal` → `ProjectFileService.importLocalFile`），
+让后端把那个文件**复制**进项目目录；其余（浏览器 H5、解析不出路径、**整个文件夹拖进来**
+——`relativePath` 带目录前缀的一律留给 confirmUpload，import-local 一次只收一个文件、
+不建目录，走它会把目录结构拍平）仍走 `confirmUpload`。
+理由是老路那两颗雷：① 微信/Finder 拖过来的 File 指向那一次拖拽的临时目录，等
+`createFile` 那一趟往返回来 blob 常常已经失效（Chromium `ERR_UPLOAD_FILE_CHANGED`，
+xhr 只给一句 `Network Error`，后端看到 `ClientAbortException`），三次重试全挂；
+② `createFile` 早就按模板物化出一份空白 docx 躺在用户目录里，那行还点得开，
+编辑器把空白模板当正文加载、自动保存再写回磁盘——同名时是**静默的内容丢失**。
+桌面端项目本来就是本机的一个文件夹，同机 copy 既没有这个窗口，也不必让 5GB 证据包
+绕一圈 HTTP。import-local **只在 `security.local-mode=true` 开放**（它让调用方指名
+服务器磁盘上的绝对路径，只有「服务器就是用户这台电脑」时才成立；同 open-local 那道闸的
+理由），拒符号链接/目录/不存在的路径，同名仍是**报错**（与普通上传逐字一致，不改名不覆盖），
+行由 `createFile` 建、后置钩子（RAG 增量索引 + 自动打标签）与上传完成时同源。
+**这条路径不插乐观行**——没有传输阶段，返回时字节已经在目录里，`loadFiles()` 一刷即最终形态。
+
+**分片上传通道（H5/远端仍在用）同轮加固两处**：重试用尽后 `discardFailedUpload` 会把
+`createFile` 建出的**空白占位行删掉**（此前刻意保留以便重试，代价是用户目录里长期躺着
+5KB 假文件）；`handleItemClick` 顶部新增闸——`uploadStatusMap[id].progress < 100` 的行
+**不发 `file-select`**（模板里那条 `text-muted` 只是视觉提示，闸必须在唯一出口上）。
+另外裸 body 分片请求不再把 `getAuthHeaders()` 的 `application/json` 一起抄进去
+（XHR 的 `setRequestHeader` 对同名头是追加不是覆盖，此前实际发出的是
+`application/json, application/octet-stream`）。
+后端测试 `ProjectFileServiceImportLocalTest` / `ProjectFileControllerImportLocalTest`。
+
 ## 顶栏头像与统一「设置」标签（2026-08-19 立，2026-08-20 并，2026-08-21 撤下拉）
 
 rail 底部的**齿轮与用户头像都撤了**，收进顶栏右上角「活动记录」右侧的

--- a/backend/src/main/java/com/checkba/controller/ProjectFileController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectFileController.java
@@ -23,12 +23,23 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/projects/{projectId}/files")
 @RequiredArgsConstructor
+@lombok.extern.slf4j.Slf4j
 public class ProjectFileController {
 
     private final ProjectFileService projectFileService;
     private final ProjectMemberService projectMemberService;
     private final FileTagService fileTagService;
     private final com.checkba.service.quota.StageQuotaService stageQuotaService;
+    /** 导入本机文件后的后置钩子，与 FileController.uploadFile 上传完成时同源。 */
+    private final com.checkba.service.ai.ProjectRagService projectRagService;
+    private final com.checkba.service.ai.AutoTaggingService autoTaggingService;
+
+    /**
+     * 单机模式判别位。import-local 让调用方指名服务器磁盘上的绝对路径，
+     * 只有「服务器就是用户这台电脑」时才成立，故仅 desktop profile 打开。
+     */
+    @org.springframework.beans.factory.annotation.Value("${security.local-mode:false}")
+    private boolean localMode;
 
     /**
      * 文件缓存区用量（前端顶部用量条的数据源）。
@@ -237,6 +248,56 @@ public class ProjectFileController {
                 request.getWpsFileId(),
                 userId
         );
+    }
+
+    /**
+     * 从本机绝对路径复制一个文件进项目（桌面端「拖入资源管理器 = 复制进项目目录」，dev-board#409）。
+     * POST /api/projects/{projectId}/files/import-local  body: { sourcePath, parentId }
+     *
+     * <p>只在单机模式（{@code security.local-mode=true}）开放。这条接口让调用方指名一个
+     * 服务器上的绝对路径去读，只有在「服务器就是用户自己这台电脑」时才成立——local-mode
+     * 由 {@code LocalModeLoopbackGuard} 强制绑回环、{@code LocalModeAccessFilter} 逐请求
+     * 校验来源，请求只可能来自本机。团队服务器上开着它，等于让任意成员把服务器磁盘上的
+     * 任意文件复制进自己的项目（同 open-local 那道闸的理由）。
+     *
+     * <p>返回创建出来的文件行；后置钩子（RAG 增量索引 + 自动打标签）与
+     * {@code FileController.uploadFile} 上传完成时完全一致。
+     */
+    @PostMapping("/import-local")
+    public ProjectFile importLocal(
+            @PathVariable Long projectId,
+            @RequestBody ImportLocalRequest request,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = getUserIdFromSession(sessionId);
+        if (userId == null) {
+            throw new UnauthorizedException("请先登录");
+        }
+        if (!localMode) {
+            throw new IllegalArgumentException(com.checkba.service.LangText.of(
+                    "当前部署不支持从本机路径导入文件", "This deployment does not support importing files from a local path"));
+        }
+        checkFileWriteAccess(projectId, userId);
+        checkParentFolder(request.getParentId(), projectId);
+
+        ProjectFile created = projectFileService.importLocalFile(
+                projectId, request.getParentId(), request.getSourcePath(), userId);
+
+        // 与上传完成后同一套异步钩子（同步跑会把大文档的索引耗时挂在这次请求上）
+        final String storagePath = created.getFilePath();
+        final Long fileId = created.getId();
+        java.util.concurrent.CompletableFuture.runAsync(() -> {
+            try {
+                projectRagService.refreshProjectKnowledgeIncremental(String.valueOf(projectId), storagePath);
+            } catch (Exception e) {
+                log.error("导入本机文件后 RAG 索引失败: {}", storagePath, e);
+            }
+            try {
+                autoTaggingService.autoTagFile(projectId, fileId, storagePath, userId);
+            } catch (Exception e) {
+                log.error("导入本机文件后自动打标签失败: {}", storagePath, e);
+            }
+        });
+        return created;
     }
 
     /**
@@ -479,6 +540,16 @@ public class ProjectFileController {
         public void setFileSize(Long fileSize) { this.fileSize = fileSize; }
         public String getWpsFileId() { return wpsFileId; }
         public void setWpsFileId(String wpsFileId) { this.wpsFileId = wpsFileId; }
+    }
+
+    static class ImportLocalRequest {
+        private String sourcePath;
+        private Long parentId;
+
+        public String getSourcePath() { return sourcePath; }
+        public void setSourcePath(String sourcePath) { this.sourcePath = sourcePath; }
+        public Long getParentId() { return parentId; }
+        public void setParentId(Long parentId) { this.parentId = parentId; }
     }
 
     static class RenameRequest {

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -285,6 +285,91 @@ public class ProjectFileService {
         return savedFile;
     }
 
+    /** 单个项目的文件总量上限，与 FileController.uploadFile 那道闸同一个数（20GB）。 */
+    private static final long PROJECT_TOTAL_SIZE_LIMIT = 20L * 1024 * 1024 * 1024;
+
+    /**
+     * 从本机绝对路径复制一份进项目目录（dev-board#409：桌面端「拖入 = 复制进来」）。
+     *
+     * <p>为什么不走 HTTP 上传：桌面端项目就是本机的一个文件夹，而微信/Finder 拖过来的
+     * File 对象指向的是那一次拖拽的临时目录——等 createFile 那一趟往返回来，blob 常常
+     * 已经失效（Chromium 报 ERR_UPLOAD_FILE_CHANGED，xhr 只给一句 Network Error），
+     * 于是三次重试全挂，而 createFile 已经按模板物化出的空白 docx 就那么留在用户目录里。
+     * 同一台机器上把字节 copy 过去既没有这个窗口，也不必让 5GB 的证据包在本机绕一圈 HTTP。
+     *
+     * <p>除了字节来源，其余一律与「一次传完的上传」等同：行由 {@link #createFile} 建
+     * （filePath 服务端生成、同名仍是 FAIL、signalChange 照发），随后覆盖模板落盘并回写
+     * 大小与修改时间。落盘失败时把模板文件删掉再抛——事务回滚掉数据库行，用户目录里
+     * 也不留空白占位。
+     */
+    @Transactional
+    public ProjectFile importLocalFile(Long projectId, Long parentId, String sourcePath, Long userId) {
+        if (projectId == null) {
+            throw new IllegalArgumentException(LangText.of("项目 ID 不能为空", "Project ID must not be empty"));
+        }
+        if (userId == null) {
+            throw new IllegalArgumentException(LangText.of("用户 ID 不能为空", "User ID must not be empty"));
+        }
+        if (!StringUtils.hasText(sourcePath)) {
+            throw new IllegalArgumentException(LangText.of("源文件路径不能为空", "Source path must not be empty"));
+        }
+        java.nio.file.Path source;
+        try {
+            source = java.nio.file.Paths.get(sourcePath).normalize();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(LangText.of("源文件路径非法: ", "Invalid source path: ") + sourcePath);
+        }
+        if (!source.isAbsolute()) {
+            throw new IllegalArgumentException(LangText.of("源文件路径必须是绝对路径: ", "Source path must be absolute: ") + sourcePath);
+        }
+        // 符号链接不跟随：跟随了就等于允许调用方拿一个链接把项目目录外的任意文件复制进来。
+        // 只看末段——祖先目录是链接是常态（macOS 的 /var -> /private/var 就是），拿
+        // toRealPath 去比会把正常的临时目录路径一并误伤。
+        if (java.nio.file.Files.isSymbolicLink(source)) {
+            throw new IllegalArgumentException(LangText.of("不支持导入符号链接: ", "Symbolic links are not supported: ") + sourcePath);
+        }
+        if (!java.nio.file.Files.isRegularFile(source, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+            // 目录与不存在的路径都落在这里：这条通道一次只收一个普通文件
+            throw new IllegalArgumentException(LangText.of("源文件不存在或不是普通文件: ", "Source file does not exist or is not a regular file: ") + sourcePath);
+        }
+        long size;
+        try {
+            size = java.nio.file.Files.size(source);
+        } catch (java.io.IOException e) {
+            throw new IllegalArgumentException(LangText.of("无法读取源文件: ", "Cannot read source file: ") + sourcePath);
+        }
+        Long total = projectFileRepository.sumSizeByProjectId(projectId);
+        if (total != null && total + size > PROJECT_TOTAL_SIZE_LIMIT) {
+            throw new IllegalArgumentException(LangText.of("项目文件总大小超过20GB限制", "Project file storage exceeds the 20GB limit"));
+        }
+
+        String name = source.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        String ext = dot > 0 ? name.substring(dot + 1).toLowerCase() : "";
+        // wpsFileId 的形状与前端上传通道生成的一致（project_{pid}_doc_{ts}_{rand}），
+        // 编辑器/上传接口的双查逻辑对两条路径没有区别
+        String wpsFileId = "project_" + projectId + "_doc_" + System.currentTimeMillis()
+                + "_" + UUID.randomUUID().toString().substring(0, 7);
+
+        ProjectFile created = createFile(projectId, parentId, name, ext, size, null, wpsFileId, userId);
+
+        try (java.io.InputStream in = java.nio.file.Files.newInputStream(source)) {
+            storageServiceFactory.getStorageService().save(created.getFilePath(), in);
+        } catch (Exception e) {
+            log.warn("导入本机文件失败，回滚: source={}, target={}", sourcePath, created.getFilePath(), e);
+            try {
+                storageServiceFactory.getStorageService().delete(created.getFilePath());
+            } catch (Exception ignored) {
+                // 删不掉不影响「这次导入失败」这个结论
+            }
+            throw new IllegalArgumentException(LangText.of("复制文件失败: ", "Failed to copy file: ") + name);
+        }
+
+        created.setFileSize(size);
+        created.setUpdatedAt(LocalDateTime.now());
+        return projectFileRepository.save(created);
+    }
+
     /**
      * RENAME 策略：同名时在扩展名前插入 " (n)" 直到不冲突，上限 1000 次尝试
      * （超出后大概率是查询本身有问题，抛错比死循环/无限重试更安全）。

--- a/backend/src/test/java/com/checkba/controller/ProjectFileControllerImportLocalTest.java
+++ b/backend/src/test/java/com/checkba/controller/ProjectFileControllerImportLocalTest.java
@@ -1,0 +1,119 @@
+package com.checkba.controller;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.service.FileTagService;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ProjectMemberService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * import-local 的两道闸（dev-board#409）：
+ * - 部署模式：让调用方指名服务器磁盘上的绝对路径，只有单机模式才成立；
+ * - 归属：parentId 是全局 id，落在他人项目上必须被拒（同本控制器其余接口）。
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectFileControllerImportLocalTest {
+
+    @Mock private ProjectFileService projectFileService;
+    @Mock private ProjectMemberService projectMemberService;
+    @Mock private FileTagService fileTagService;
+    @Mock private com.checkba.service.quota.StageQuotaService stageQuotaService;
+    @Mock private com.checkba.service.ai.ProjectRagService projectRagService;
+    @Mock private com.checkba.service.ai.AutoTaggingService autoTaggingService;
+
+    @InjectMocks
+    private ProjectFileController controller;
+
+    private ProjectFileController.ImportLocalRequest req(String path, Long parentId) {
+        ProjectFileController.ImportLocalRequest r = new ProjectFileController.ImportLocalRequest();
+        r.setSourcePath(path);
+        r.setParentId(parentId);
+        return r;
+    }
+
+    private void allowMember() {
+        when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+        when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+        when(projectMemberService.hasWritePermission(1L, 1L)).thenReturn(true);
+    }
+
+    @Test
+    void rejectedWhenNotLocalMode() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.importLocal(1L, req("/Users/me/证据.pdf", null), "sess"));
+            verify(projectFileService, never()).importLocalFile(anyLong(), any(), anyString(), anyLong());
+        }
+    }
+
+    @Test
+    void rejectsParentFolderFromAnotherProject() {
+        ReflectionTestUtils.setField(controller, "localMode", true);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowMember();
+            ProjectFile foreign = new ProjectFile();
+            foreign.setId(777L);
+            foreign.setProjectId(999L);
+            foreign.setIsFolder(true);
+            when(projectFileService.getFile(777L)).thenReturn(foreign);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.importLocal(1L, req("/Users/me/证据.pdf", 777L), "sess"));
+            verify(projectFileService, never()).importLocalFile(anyLong(), any(), anyString(), anyLong());
+        }
+    }
+
+    @Test
+    void rejectsReadOnlyMember() {
+        ReflectionTestUtils.setField(controller, "localMode", true);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            when(projectMemberService.hasReadPermission(1L, 1L)).thenReturn(true);
+            when(projectMemberService.isClient(1L, 1L)).thenReturn(false);
+            when(projectMemberService.hasWritePermission(1L, 1L)).thenReturn(false);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> controller.importLocal(1L, req("/Users/me/证据.pdf", null), "sess"));
+            verify(projectFileService, never()).importLocalFile(anyLong(), any(), anyString(), anyLong());
+        }
+    }
+
+    @Test
+    void localModeImportsAndReturnsRow() {
+        ReflectionTestUtils.setField(controller, "localMode", true);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(1L);
+            allowMember();
+            ProjectFile created = new ProjectFile();
+            created.setId(42L);
+            created.setProjectId(1L);
+            created.setName("证据.pdf");
+            created.setFilePath("projects/1/证据.pdf");
+            when(projectFileService.importLocalFile(1L, null, "/Users/me/证据.pdf", 1L)).thenReturn(created);
+
+            ProjectFile out = controller.importLocal(1L, req("/Users/me/证据.pdf", null), "sess");
+
+            assertEquals(42L, out.getId());
+            verify(projectFileService).importLocalFile(1L, null, "/Users/me/证据.pdf", 1L);
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceImportLocalTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceImportLocalTest.java
@@ -1,0 +1,141 @@
+package com.checkba.service;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.storage.LocalFileStorageService;
+import com.checkba.storage.ProjectStorageResolver;
+import com.checkba.storage.StorageProperties;
+import com.checkba.storage.StorageServiceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 「拖入 = 复制进项目目录」的落盘语义（dev-board#409，H2 真库 + 真本地存储）。
+ *
+ * 用真的 LocalFileStorageService 而不是 mock：这条通道的全部价值就在于
+ * 「字节真的到了项目目录里、大小对得上」，mock 掉存储等于什么都没验。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:import-local-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class ProjectFileServiceImportLocalTest {
+
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private ProjectFileRepository projectFileRepository;
+
+    private ProjectFileService svc;
+    private Path projectRoot;
+    private Long projectId;
+
+    @BeforeEach
+    void setUp(@TempDir Path tmp) {
+        projectRoot = tmp.resolve("案卷");
+        Project p = new Project();
+        p.setName("案卷");
+        p.setProjectType("BLANK");
+        p.setListedCompanyName("");
+        p.setTargetCompanyName("");
+        p.setUserId(1L);
+        p.setLocalRoot(projectRoot.toAbsolutePath().toString());
+        projectId = projectRepository.save(p).getId();
+
+        StorageProperties props = new StorageProperties();
+        props.getLocal().setRootPath(tmp.resolve("appdata").toAbsolutePath().toString());
+        // 模板文件刻意指向不存在的路径：createFromTemplate 会退化为「建一个空文件」，
+        // 正好是本用例要覆盖的形态（随后被真正的字节覆盖）
+        props.getLocal().setTemplatePath(tmp.resolve("no-such-template.docx").toAbsolutePath().toString());
+        ProjectStorageResolver resolver = new ProjectStorageResolver(props, projectRepository);
+
+        StorageServiceFactory factory = mock(StorageServiceFactory.class);
+        when(factory.getStorageService()).thenReturn(new LocalFileStorageService(resolver));
+
+        svc = new ProjectFileService(
+                projectFileRepository,
+                mock(com.checkba.service.ai.ProjectRagService.class),
+                factory,
+                mock(com.checkba.version.WorkSessionService.class),
+                mock(UserService.class),
+                mock(com.checkba.service.quota.StageQuotaService.class),
+                mock(com.checkba.service.telemetry.TelemetryService.class),
+                mock(com.checkba.service.evidence.EvidenceLinkService.class));
+    }
+
+    @Test
+    void copiesBytesIntoProjectFolderAndReturnsRow(@TempDir Path srcDir) throws Exception {
+        Path source = srcDir.resolve("证据.pdf");
+        byte[] bytes = "PDF-BYTES-证据".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        Files.write(source, bytes);
+
+        ProjectFile row = svc.importLocalFile(projectId, null, source.toAbsolutePath().toString(), 1L);
+
+        assertEquals("证据.pdf", row.getName());
+        assertEquals("pdf", row.getFileType());
+        assertEquals(bytes.length, row.getFileSize());
+        assertEquals("projects/" + projectId + "/证据.pdf", row.getFilePath());
+        assertFalse(Boolean.TRUE.equals(row.getIsFolder()));
+        assertNotNull(row.getWpsFileId());
+
+        Path copied = projectRoot.resolve("证据.pdf");
+        assertTrue(Files.exists(copied), "字节必须真的落在项目目录里: " + copied);
+        assertArrayEquals(bytes, Files.readAllBytes(copied));
+    }
+
+    @Test
+    void rejectsDirectory(@TempDir Path srcDir) throws Exception {
+        Path dir = srcDir.resolve("一整个文件夹");
+        Files.createDirectories(dir);
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.importLocalFile(projectId, null, dir.toAbsolutePath().toString(), 1L));
+        assertTrue(projectFileRepository.findByProjectId(projectId).isEmpty(), "不许留下任何行");
+    }
+
+    @Test
+    void rejectsMissingFile(@TempDir Path srcDir) {
+        Path missing = srcDir.resolve("不存在.docx");
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.importLocalFile(projectId, null, missing.toAbsolutePath().toString(), 1L));
+        assertTrue(projectFileRepository.findByProjectId(projectId).isEmpty());
+    }
+
+    @Test
+    void rejectsRelativePath() {
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.importLocalFile(projectId, null, "证据.pdf", 1L));
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.importLocalFile(projectId, null, "  ", 1L));
+    }
+
+    /** 同名处置与普通上传（REST createFile）逐字一致：报错，不静默改名也不覆盖。 */
+    @Test
+    void duplicateNameFailsLikeANormalUpload(@TempDir Path srcDir) throws Exception {
+        Path source = srcDir.resolve("合同.docx");
+        Files.writeString(source, "v1");
+        svc.importLocalFile(projectId, null, source.toAbsolutePath().toString(), 1L);
+
+        Files.writeString(source, "v2");
+        assertThrows(IllegalArgumentException.class,
+                () -> svc.importLocalFile(projectId, null, source.toAbsolutePath().toString(), 1L));
+        assertEquals("v1", Files.readString(projectRoot.resolve("合同.docx")), "原件不许被盖掉");
+    }
+}

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -3961,7 +3961,8 @@ export default {
     async discardFailedUpload(fileId) {
         try {
             const projectId = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
-            if (projectId && fileId) await deleteFile(projectId, fileId)
+            // 占位行从来没有过正文，直接永久删，别让一份空白 docx 再躺进回收站
+            if (projectId && fileId) await deleteFilePerm(projectId, fileId)
         } catch (e) {
             console.warn('清理上传失败的占位文件时出错:', e)
         }

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -934,7 +934,7 @@
 </template>
 
 <script>
-import { getProjectFiles, createFolder, createFile, renameFile, deleteFile, deleteFilePerm, restoreFile as restoreFileApi, getRecycleBinFiles, moveFile, batchDeleteFiles, batchMoveFiles, batchCopyFiles, getApiBaseUrl, getContributedTemplates, createFileFromContributedTemplate } from '@/services/api.js'
+import { getProjectFiles, createFolder, createFile, renameFile, deleteFile, deleteFilePerm, restoreFile as restoreFileApi, getRecycleBinFiles, moveFile, batchDeleteFiles, batchMoveFiles, batchCopyFiles, getApiBaseUrl, getContributedTemplates, createFileFromContributedTemplate, importLocalFile } from '@/services/api.js'
 import { getAuthHeaders, getSessionId } from '@/utils/auth.js'
 import { host } from '@/services/host.js'
 import { findTopmostDeletedAncestor, summarizeDeleteResults } from '@/utils/fileTreeRecycle.js'
@@ -2185,6 +2185,15 @@ export default {
     handleItemClick(item, event) {
       if (!item) return
 
+      // 上传中的占位行不许打开（dev-board#409）：字节还没到，磁盘上躺着的是 createFile
+      // 物化出来的空白模板，编辑器会把它当正文加载、自动保存再把空白写回去。模板里那条
+      // text-muted 只是视觉提示，真正的闸必须在这里——它才是 file-select 的唯一出口。
+      const uploading = this.uploadStatusMap[item.id]
+      if (uploading && uploading.progress < 100) {
+        uni.showToast({ title: this.$t('fileTree.uploadingCannotOpen'), icon: 'none' })
+        return
+      }
+
       const now = Date.now()
       // Double Click Detection: Toggle Folder
       if (this.lastClickItemId === item.id && (now - this.lastClickTime < 350)) {
@@ -2999,9 +3008,16 @@ export default {
       this.rootDropActive = false
       this.dragOverIndex = -1
     },
-    // 落点确定之后统一走这里：复用 confirmUpload（读 selectedFiles / selectedUploadParent，
-    // 上传对话框与暂存区 onStagingDropFiles 走的也是它），分片续传/并发/建目录/完成后
-    // loadFiles 全在那条通道里，不另起一套。
+    // 落点确定之后统一走这里。分两条路：
+    // ① 桌面端（拿得到本机绝对路径）→ import-local，后端把那个文件复制进项目目录。
+    //    桌面端的项目就是本机的一个文件夹，「拖入 = 复制进来」本来就是用户的心理模型；
+    //    而走 HTTP 上传会先建一份空白模板行、再把已经失效的临时 blob 传上去——微信/
+    //    Finder 的拖拽临时文件在 createFile 那一趟往返之后常常就没了，Chromium 报
+    //    ERR_UPLOAD_FILE_CHANGED、xhr 只给一句 Network Error，三次重试全挂，用户目录里
+    //    留下一份 5KB 空白 docx（dev-board#409）。
+    // ② 其余（浏览器 H5、拿不到路径、整个文件夹拖进来）→ 仍走 confirmUpload（读
+    //    selectedFiles / selectedUploadParent，与上传对话框、暂存区 onStagingDropFiles
+    //    同一条路），分片续传/并发/建目录/完成后 loadFiles 全在那条通道里。
     async uploadExternalDrop(dt, targetParentId) {
       const native = typeof window !== 'undefined' ? window.event : null
       if (!claimExternalDrop(native)) return
@@ -3010,10 +3026,62 @@ export default {
       const items = await collectDroppedFiles(dt)
       if (!items.length) return
       if (targetParentId != null && this.showTree) this.expandedFolders.add(targetParentId)
-      this.selectedFiles = items
+
+      const localEntries = []
+      const rest = []
+      for (const item of items) {
+        // 整个文件夹拖进来的（relativePath 带目录前缀）一律留给 confirmUpload：
+        // import-local 一次只收一个文件、不建目录，让它们走这条路会把目录结构拍平。
+        const nested = !!(item.relativePath && item.relativePath.indexOf('/') !== -1)
+        const path = nested ? '' : this.resolveDroppedFilePath(item.fileObject)
+        if (path) localEntries.push({ item, path })
+        else rest.push(item)
+      }
+
+      if (localEntries.length) {
+        await this.importDroppedLocalFiles(localEntries, targetParentId)
+      }
+      if (!rest.length) return
+      this.selectedFiles = rest
       this.selectedUploadParent = targetParentId
-      this.isFolderUpload = items.some(f => f.relativePath && f.relativePath.indexOf('/') !== -1)
+      this.isFolderUpload = rest.some(f => f.relativePath && f.relativePath.indexOf('/') !== -1)
       await this.confirmUpload()
+    },
+    // File → 本机绝对路径。只有桌面壳给得出（Electron 32 起 File.path 没了，走 webUtils），
+    // 浏览器端 host.fs 整个缺席，恒返回空串 = 退回上传通道。
+    resolveDroppedFilePath(fileObject) {
+      try {
+        if (!fileObject || !host.fs || typeof host.fs.getPathForFile !== 'function') return ''
+        return host.fs.getPathForFile(fileObject) || ''
+      } catch (e) {
+        return ''
+      }
+    },
+    // 逐个调 import-local。不做乐观插行：这条路径没有「传输中」这个阶段，
+    // 后端返回时字节已经在项目目录里，loadFiles 一刷就是最终形态。
+    async importDroppedLocalFiles(entries, targetParentId) {
+      const projectId = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
+      let successCount = 0
+      let failCount = 0
+      let lastError = ''
+      for (const entry of entries) {
+        try {
+          await importLocalFile(projectId, entry.path, targetParentId)
+          successCount++
+        } catch (e) {
+          failCount++
+          lastError = (e && e.message) || ''
+          console.error('导入本机文件失败:', entry.item.name, e)
+        }
+      }
+      await this.loadFiles()
+      if (failCount === 0) {
+        uni.showToast({ title: this.$t('fileTree.uploadSuccessCount', { count: successCount }), icon: 'success', duration: 2000 })
+      } else if (successCount === 0) {
+        this.showErrorModal(lastError || this.$t('fileTree.uploadFileFailedRetry'), this.$t('fileTree.uploadFailed'))
+      } else {
+        uni.showToast({ title: this.$t('fileTree.uploadPartialResult', { success: successCount, fail: failCount }), icon: 'none', duration: 2500 })
+      }
     },
     // 非H5端触摸拖拽方法
     handleTouchStart(e, index) {
@@ -3802,8 +3870,14 @@ export default {
 
                    xhr.open('POST', `${this.getApiBaseUrl()}/api/files/${status.wpsFileId}/upload`)
 
+                   // getAuthHeaders() 里带着 application/json（它是给 uni.request 的
+                   // JSON 接口用的）。XHR 的 setRequestHeader 对同名头是「追加」不是
+                   // 「覆盖」，照抄一遍再设 octet-stream 会发出
+                   // "application/json, application/octet-stream" 这种自相矛盾的头。
+                   // 与 api.js 里其余裸 body 请求同口径：只带 X-Session-Id。
                    const headers = this.getAuthHeaders()
                    for (const key in headers) {
+                       if (key.toLowerCase() === 'content-type') continue
                        xhr.setRequestHeader(key, headers[key])
                    }
                    xhr.setRequestHeader('Content-Type', 'application/octet-stream')
@@ -3872,12 +3946,29 @@ export default {
            // 显示具体的错误信息（使用模态对话框）
            const errorMessage = error.message || this.$t('fileTree.uploadInterruptedRetry')
            this.showErrorModal(errorMessage, this.$t('fileTree.uploadFailed'))
-           // 不要删除 status，保留进度条以允许重试
            status.error = true
            status.errorMessage = errorMessage
-           // 保存失败状态
            this.saveUploadState()
+           // 重试用尽了才走到这里：createFile 已经按模板物化出一份空白 docx，留着它
+           // 就是在用户的项目目录里放一个 5KB 的假文件（点开还能被编辑器当正文加载、
+           // 自动保存再写回磁盘）。行删掉，重传由上传对话框重新走一遍 createFile。
+           // dev-board#409。
+           await this.discardFailedUpload(fileId)
        }
+    },
+
+    // 上传彻底失败后的清理：删占位行 + 清进度状态 + 从两个列表里摘掉。
+    async discardFailedUpload(fileId) {
+        try {
+            const projectId = typeof this.projectId === 'string' ? Number(this.projectId) : this.projectId
+            if (projectId && fileId) await deleteFile(projectId, fileId)
+        } catch (e) {
+            console.warn('清理上传失败的占位文件时出错:', e)
+        }
+        delete this.uploadStatusMap[fileId]
+        this.files = this.files.filter(f => f.id !== fileId)
+        this.allFiles = this.allFiles.filter(f => f.id !== fileId)
+        this.saveUploadState()
     },
 
     updateProgress(fileId, uploaded, total) {

--- a/frontend/src/locales/en-US/fileTree.js
+++ b/frontend/src/locales/en-US/fileTree.js
@@ -133,6 +133,7 @@ export default {
   uploadPartialResult: '{success} succeeded, {fail} failed',
   uploadFileFailedRetry: 'Failed to upload the file, please try again',
   uploadFailed: 'Upload failed',
+  uploadingCannotOpen: 'This file is still uploading; it can be opened once the upload finishes',
   chunkUnsupportedNonH5: 'Chunked resumable upload is not supported on this platform',
   uploadInterruptedRetry: 'Upload interrupted, please try again',
   uploadCanceled: 'Upload canceled',

--- a/frontend/src/locales/zh-CN/fileTree.js
+++ b/frontend/src/locales/zh-CN/fileTree.js
@@ -133,6 +133,7 @@ export default {
   uploadPartialResult: '成功 {success} 个，失败 {fail} 个',
   uploadFileFailedRetry: '文件上传失败，请重试',
   uploadFailed: '上传失败',
+  uploadingCannotOpen: '文件还在上传中，传完才能打开',
   chunkUnsupportedNonH5: '非H5端暂不支持分片断点续传',
   uploadInterruptedRetry: '上传中断，请重试',
   uploadCanceled: '已取消上传',

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1697,6 +1697,22 @@ export function createFile(projectId, parentId, name, fileType, fileSize, filePa
   });
 }
 
+// 从本机绝对路径复制一个文件进项目目录（桌面端拖入资源管理器，dev-board#409）。
+// 只有单机模式的后端接受它；浏览器端拿不到路径，走 createFile + /upload 那条老路。
+export function importLocalFile(projectId, sourcePath, parentId) {
+  return request({
+    url: `/api/projects/${projectId}/files/import-local`,
+    method: 'POST',
+    data: {
+      sourcePath,
+      parentId,
+    },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
 // 重命名文件或文件夹
 export function renameFile(projectId, fileId, name) {
   return request({
@@ -2683,6 +2699,7 @@ export default {
   getProjectFiles,
   createFolder,
   createFile,
+  importLocalFile,
   renameFile,
   deleteFile,
   moveFile,

--- a/frontend/tests/project-home/file-tree-external-drop.test.mjs
+++ b/frontend/tests/project-home/file-tree-external-drop.test.mjs
@@ -35,7 +35,7 @@ const IMPORT_NAMES = [
   'groupByParent', 'buildTreeFromGroups', 'evidenceRefCounts', 'createRefCountsFetcher',
   'CircularProgress', 'warmDragImage', 'applyDragImage', 'FileTypeIcon', 'TagChip', 'TagSelector',
   'TagManager', 'AwdDatePicker', 'ICONS', 'getProjectTags', 'addTagToFile', 'removeTagFromFile',
-  'createTag', 'createTask',
+  'createTag', 'createTask', 'importLocalFile',
   'nativeDataTransfer', 'isExternalFileDrag', 'collectDroppedFiles', 'claimExternalDrop',
 ]
 
@@ -48,13 +48,22 @@ function loadOptions(stubs) {
   return factory(...args)
 }
 
-function makeVm({ moveFile, createFolder } = {}) {
-  const calls = { moveFile: [], confirmUpload: 0 }
+// desktopPaths: File 对象 → 本机绝对路径的映射（桌面壳 host.fs.getPathForFile 的桩）。
+// 不传 = 浏览器态，host.fs 整个缺席，恒退回 confirmUpload。
+function makeVm({ moveFile, createFolder, desktopPaths, importLocalFails } = {}) {
+  const calls = { moveFile: [], confirmUpload: 0, importLocal: [], loadFiles: 0, emits: [] }
   const stubs = {
     moveFile: async (...a) => { calls.moveFile.push(a); return { parentId: a[2] } },
     createFolder: createFolder || (async () => ({ id: 999 })),
     ICONS: {},
-    host: {},
+    host: desktopPaths
+      ? { fs: { getPathForFile: (f) => desktopPaths.get(f) || '' } }
+      : {},
+    importLocalFile: async (...a) => {
+      calls.importLocal.push(a)
+      if (importLocalFails) throw new Error('boom')
+      return { id: 100 + calls.importLocal.length }
+    },
     nativeDataTransfer, isExternalFileDrag, collectDroppedFiles, claimExternalDrop,
   }
   if (moveFile) stubs.moveFile = moveFile
@@ -63,10 +72,11 @@ function makeVm({ moveFile, createFolder } = {}) {
   for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
   vm.projectId = 42
   vm.$t = (k) => k
-  vm.$emit = () => {}
+  vm.$emit = (...a) => { calls.emits.push(a) }
   vm.$el = null
-  vm.loadFiles = async () => {}
+  vm.loadFiles = async () => { calls.loadFiles += 1 }
   vm.confirmUpload = async () => { calls.confirmUpload += 1 }
+  vm.showErrorModal = () => {}
   vm.calls = calls
   return vm
 }
@@ -300,5 +310,116 @@ test('dragenter 带外部文件时点亮 externalDragActive（根投放区据此
     globalThis.window.event = { relatedTarget: null }
     vm.onTreeDragLeave(wrappedEvent())
     assert.equal(vm.externalDragActive, false)
+  } finally { restore() }
+})
+
+// ---------- 桌面端：拖入 = 复制进项目目录（dev-board#409） ----------
+
+test('桌面端拖入单个文件：走 import-local 复制进项目目录，不碰 confirmUpload，也不插乐观行', async () => {
+  const restore = installGlobals()
+  try {
+    const file = osFile('证据.pdf')
+    const vm = makeVm({ desktopPaths: new Map([[file, '/Users/me/tmp/证据.pdf']]) })
+    vm.windowedDisplayFiles = [folder, doc]
+    vm.displayFiles = [folder, doc]
+    vm.files = []
+    vm.allFiles = []
+
+    await vm.handleDrop(wrappedEvent({ dataTransfer: osDataTransfer([file]) }), 0)
+
+    assert.deepEqual(vm.calls.importLocal, [[42, '/Users/me/tmp/证据.pdf', 7]],
+      'projectId / 绝对路径 / 落点目录三样都要传对')
+    assert.equal(vm.calls.confirmUpload, 0, '不许再走 HTTP 上传那条路')
+    assert.equal(vm.calls.loadFiles, 1, '复制完刷新文件树')
+    assert.deepEqual(vm.files, [], '没有传输阶段就没有占位行')
+    assert.deepEqual(vm.allFiles, [])
+    assert.equal(Object.keys(vm.uploadStatusMap).length, 0, '不进上传列表')
+    assert.equal(vm.expandedFolders.has(7), true)
+  } finally { restore() }
+})
+
+test('桌面端拖到根投放区：parentId 传 null', async () => {
+  const restore = installGlobals()
+  try {
+    const file = osFile('a.pdf')
+    const vm = makeVm({ desktopPaths: new Map([[file, '/Users/me/a.pdf']]) })
+    await vm.onRootDrop(wrappedEvent({ dataTransfer: osDataTransfer([file]) }))
+    assert.deepEqual(vm.calls.importLocal, [[42, '/Users/me/a.pdf', null]])
+    assert.equal(vm.calls.confirmUpload, 0)
+  } finally { restore() }
+})
+
+test('浏览器端（拿不到路径）与 getPathForFile 返回空串：原样退回 confirmUpload', async () => {
+  const restore = installGlobals()
+  try {
+    // 浏览器：host.fs 整个缺席
+    const vm = makeVm()
+    vm.windowedDisplayFiles = [folder]
+    vm.displayFiles = [folder]
+    await vm.handleDrop(wrappedEvent({ dataTransfer: osDataTransfer([osFile('a.pdf')]) }), 0)
+    assert.equal(vm.calls.confirmUpload, 1)
+    assert.deepEqual(vm.calls.importLocal, [])
+
+    // 桌面壳在，但这个 File 解析不出路径（webUtils 返回空串）
+    const file = osFile('b.pdf')
+    const vm2 = makeVm({ desktopPaths: new Map() })
+    vm2.windowedDisplayFiles = [folder]
+    vm2.displayFiles = [folder]
+    await vm2.handleDrop(wrappedEvent({ dataTransfer: osDataTransfer([file]) }), 0)
+    assert.equal(vm2.calls.confirmUpload, 1)
+    assert.deepEqual(vm2.calls.importLocal, [])
+  } finally { restore() }
+})
+
+test('桌面端拖入整个文件夹：仍走 confirmUpload 建目录，不被 import-local 拍平', async () => {
+  const restore = installGlobals()
+  try {
+    const inner = osFile('1.pdf')
+    const entry = {
+      isFile: false, isDirectory: true, name: '证据',
+      createReader: () => {
+        let served = false
+        return { readEntries: (ok) => { const b = served ? [] : [{ isFile: true, isDirectory: false, name: '1.pdf', file: (cb) => cb(inner) }]; served = true; ok(b) } }
+      },
+    }
+    const vm = makeVm({ desktopPaths: new Map([[inner, '/Users/me/证据/1.pdf']]) })
+    vm.windowedDisplayFiles = [folder]
+    vm.displayFiles = [folder]
+    const dt = osDataTransfer([osFile('证据')], [{ kind: 'file', webkitGetAsEntry: () => entry }])
+    await vm.handleDrop(wrappedEvent({ dataTransfer: dt }), 0)
+    assert.deepEqual(vm.calls.importLocal, [], '带目录前缀的条目不能走 import-local')
+    assert.equal(vm.calls.confirmUpload, 1)
+    assert.deepEqual(vm.selectedFiles.map(f => f.relativePath), ['证据/1.pdf'])
+    assert.equal(vm.isFolderUpload, true)
+  } finally { restore() }
+})
+
+test('import-local 失败：照样刷新文件树，且不偷偷退回 HTTP 上传', async () => {
+  const restore = installGlobals()
+  try {
+    const file = osFile('证据.pdf')
+    const vm = makeVm({ desktopPaths: new Map([[file, '/Users/me/证据.pdf']]), importLocalFails: true })
+    await vm.onRootDrop(wrappedEvent({ dataTransfer: osDataTransfer([file]) }))
+    assert.equal(vm.calls.importLocal.length, 1)
+    assert.equal(vm.calls.confirmUpload, 0)
+    assert.equal(vm.calls.loadFiles, 1)
+  } finally { restore() }
+})
+
+// ---------- 上传中的占位行不许打开（dev-board#409） ----------
+
+test('上传进度 < 100 的行点不开：不发 file-select', () => {
+  const restore = installGlobals()
+  try {
+    const vm = makeVm()
+    vm.uploadStatusMap[doc.id] = { progress: 42 }
+    vm.handleItemClick(doc, {})
+    assert.deepEqual(vm.calls.emits.filter(e => e[0] === 'file-select'), [], '字节还没到，不许交给编辑器打开')
+    assert.notEqual(vm.selectedFileId, doc.id)
+
+    // 传完了照常能打开
+    vm.uploadStatusMap[doc.id] = { progress: 100 }
+    vm.handleItemClick(doc, {})
+    assert.equal(vm.calls.emits.filter(e => e[0] === 'file-select').length, 1)
   } finally { restore() }
 })


### PR DESCRIPTION
## 病灶（截图 + backend.log 16:38 取证）
从访达/微信拖一个 .docx 进资源管理器 → 上传列表「Network Error」0%、树里一行灰名、点开是空白页。

根因两层叠在一起：
1. **同一块磁盘上的文件被绕道 localhost HTTP 上传**：`uploadExternalDrop` 把外部拖入直接喂给 `confirmUpload` 分片路径，先 `createFile` 落 DB 行 + **空白模板物理文件**，再 raw-body 分片 POST。拖入来源是微信的每次拖拽重建的临时目录，await 完 createFile 后 blob 已过期，Chromium `ERR_UPLOAD_FILE_CHANGED` → xhr.onerror → axios「Network Error」，三次重试 30ms 内全挂；后端看到的是 `ClientAbortException: EOFException`（头到了、body 没来）。
2. **空白占位可点**：灰行只是 CSS 变灰，点一下就 openFile → LOWA 载入 5KB 模板 → 12 秒后编辑器自动保存把空白 docx 焊进用户文件夹（重名时就是静默丢内容）。
副：raw-body 请求 Content-Type 被拼成 `application/json, application/octet-stream`（getAuthHeaders 的 JSON 类型没覆盖掉）。文件名（繁体/括号/长名）无辜。

## 修
- 后端新增 `POST /api/projects/{id}/files/import-local {sourcePath,parentId}`：**仅 `security.local-mode` 开放**（桌面端后端就是用户这台机；团队部署上等于让任意成员读服务器磁盘），校验绝对路径/常规文件/非符号链接/20GB 配额，走既有 `createFile` 建行（重名策略与上传一致）再把字节直接复制进项目目录，后置钩子（RAG 增量 + 自动打标签）与上传完成同源。
- 前端 `uploadExternalDrop`：桌面端用 preload 已有的 `host.fs.getPathForFile` 同步拿到路径 → 调 import-local 复制 → 刷新树，不建乐观行、没有传输阶段；拿不到路径（H5）或**带目录的拖入**（import-local 单文件不接 relativePath，走它会把目录树拍平）仍走 confirmUpload。
- 分片路径加固：重试耗尽后删掉自己建的占位行（`DELETE /api/projects/{id}/files/{fileId}`）；`handleItemClick` 里 progress<100 的行不可打开（不只 CSS）；raw-body 请求显式覆盖 Content-Type。

## 门禁
- backend：`ProjectFile*Test,FileController*Test` + 新增 `ProjectFileServiceImportLocalTest`（真 H2 + 真 LocalFileStorageService，断言字节真落进项目目录）/ `ProjectFileControllerImportLocalTest`（local-mode 关拒绝、目录/缺失拒绝、IDOR）58/0；全量 mvn 见评论
- frontend：`file-tree-external-drop.test.mjs` +6（桌面端走 import-local 且不调 confirmUpload、根投放区、失败提示、目录拖入仍走上传、progress<100 不可开）；破坏性校验：强制 path='' 三条转红、恢复全绿；check:emits / check:locales / check:nav 过；全组 + build:h5 + app-e2e 见评论

🤖 Generated with [Claude Code](https://claude.com/claude-code)