### PR TITLE
fix(mobile-sync): 手机中转落盘 file_type 改落扩展名，启动期对账修存量行（dev-board#417）

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -52,6 +52,10 @@ dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
 - `mediaType ∈ {image, video, audio}`（audio 自 dev-board#228）。桌面落盘根目录由它推导：
   audio → 「现场录音」，其余 → 「现场影像」；rootFolder 同时参与幂等判据与 storagePath
   拼接，改动必须两处同源（`MobileRelayClientService.landAndAck`）。
+  **但 `mediaType` 只决定目录，绝不能当 `project_file.file_type` 落库**（dev-board#417，
+  见地雷 9）：file_type 全仓语义是**文件扩展名**，落盘时一律走
+  `MobileRelayClientService.fileTypeOf(landedName, mediaType)`（有扩展名取扩展名，
+  没有才退回 mediaType）。
 - **每用户 3GB 配额**（dev-board#226）：只计未投递 blob（storagePath 非空行）的 fileSize
   之和，ACK 即删 = 释放配额。检查在写盘前按声明大小做（幂等重传先于配额检查，不占新
   空间不得拒）；并发上传可略超上限（最多一件，接受的软度）。拒绝走
@@ -139,6 +143,32 @@ dev-board#30）；更早的产品设计 `2026-08-17-mobile-clients-design.md`。
    `MobileRelayStoreServiceTest.emptyDirectoryPushDoesNotWipeExistingRows` /
    `.touchDeviceStoresDeviceNameForHeartbeatOnlyDevices`、
    `MobileRelayClientHttpTest.pushDirectorySkipsWhenLocalProjectListEmpty`。
+9. **`project_file.file_type` 是扩展名，不是 mediaType**（dev-board#417，2026-09-03 实测）：
+   `landAndAck` 原来把 `mediaType`（image/video/audio）直接当 fileType 落库，而全仓
+   （含 `ProjectFile` 的字段注释）对这一列只有一个语义——**文件扩展名**。后果不是报错，
+   是**静默的"证据丢了"**：字节完好躺在项目目录里，用户在文件树里点开手机传来的 jpg
+   只弹「无法打开文件：暂不支持打开此类型文件…文件类型：image」——前端
+   `fileOpenTabs.isFileTypeSupported` 的白名单里是 jpg/png/mp4，没有 image/video/audio。
+   同一个错还让 `FileTree.isAudioFile` 恒 false，资源管理器右键的「转写」
+   （dev-board#228）在手机传来的录音上**永远不出现**，等于那张卡白做。
+   现场取证：本机 H2 里 id=2248 的 `现场影像-20260902-191122-D160-d16044f3.jpg`
+   file_type='image'，而 `file` 看字节是货真价实的 iPhone JPEG。
+   同一个类里其余三条落地路径（`landDocumentAndAck`、传输 PUSH、
+   `MobileTransferService.saveToProject`）本来就落扩展名，**只有 landAndAck 落错**——
+   新增任何落盘路径都要照 `fileTypeOf(landedName, fallback)` 取值。
+   **存量脏行只能靠启动期对账救**：影像早已 ACK、中转区 blob 早已删除，取件轮询再也
+   不会碰它；本地目录项目的 `LocalProjectService` 重扫走 `createOrUpdateFile`，那个方法
+   只更新 fileSize/updatedAt，**不改 fileType**，也救不回来。于是有
+   `MediaFileTypeReconciler`（照 `OrphanPhoneSessionReconciler` 的成例做的
+   `CommandLineRunner`，只在 local-mode 跑）：把 file_type ∈ {image,video,audio} 且名字
+   带扩展名的文件行改回扩展名，幂等。护栏 `MobileRelayClientHttpTest.
+   pollInboxStoresExtensionNotMediaTypeAsFileType` / `.pollInboxStoresAudioExtensionAsFileType`
+   / `.pollInboxFallsBackToMediaTypeWhenNameHasNoExtension`、`MediaFileTypeReconcilerTest`、
+   `ProjectFileRepositoryTreeSkeletonTest.findsFilesByFileTypeExcludingFoldersAndDeletedRows`
+   （派生查询名真能被 Spring Data 解析，mock 证明不了这一点）。
+   唯一还认 fileType="image" 的消费方是 `ContextAssemblerService.isVisionCandidate`，
+   而它**只在文件名没有扩展名时**才看这一列——所以「有扩展名取扩展名、没有才退回
+   mediaType」的兜底不能省。
 
 ## 插件归档双镜像（dev-board#297/#298/#299，spec：docs/superpowers/specs/2026-08-30-addin-project-binding-and-mirrors-design.md）
 
@@ -209,6 +239,6 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
 
 ## 验证
 
-- `mvn test -Dtest='MobileRelay*Test,AwdkLoginServiceTest'`（JDK 21）。
+- `mvn test -Dtest='MobileRelay*Test,AwdkLoginServiceTest,MediaFileTypeReconcilerTest'`（JDK 21）。
 - 云端冒烟：`curl https://addin.aiworkdeck.com/api/mobile/projects` 无凭据应 401。
 - iOS 侧改动跑 `aiworkdeck_mobile` 仓的构建 + TestFlight 通道（fastlane）。

--- a/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
@@ -143,5 +143,14 @@ public interface ProjectFileRepository extends JpaRepository<ProjectFile, Long> 
             + "WHERE pf.projectId = :projectId AND pf.isDeleted = false")
     List<Object[]> findTreeSkeletonByProjectId(
             @org.springframework.data.repository.query.Param("projectId") Long projectId);
+
+    /**
+     * 按 fileType 精确取文件行（不含文件夹与软删除）。
+     *
+     * <p>只有一个用处：{@code MediaFileTypeReconciler} 修 dev-board#417 留下的存量脏行
+     * （file_type 被写成 image/video/audio 这类 mediaType 而不是扩展名）。
+     * fileType 是扩展名，正常值里不可能出现这三个词，所以按它取行既精确又不会误伤。
+     */
+    List<ProjectFile> findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(List<String> fileTypes);
 }
 

--- a/backend/src/main/java/com/checkba/service/mobile/MediaFileTypeReconciler.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MediaFileTypeReconciler.java
@@ -1,0 +1,90 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 启动期对账：把手机中转落盘时写错的 {@code project_file.file_type} 改回扩展名（dev-board#417）。
+ *
+ * <h3>要治的是什么</h3>
+ * {@code MobileRelayClientService.landAndAck} 曾把中转件的 {@code mediaType}
+ * （{@code image}/{@code video}/{@code audio}）当成 fileType 落库，而 fileType 在全仓
+ * 只有一个语义——**文件扩展名**（见 {@link ProjectFile} 的字段注释）。后果不是报错，
+ * 是文件在文件树里躺得好好的、字节也完好，点开却弹「无法打开文件：暂不支持打开此类型文件…
+ * 文件类型：image」——前端 {@code isFileTypeSupported} 的白名单里是 jpg/png/mp4，
+ * 没有 image/video/audio。同一个错还让 {@code isAudioFile} 恒 false，
+ * 资源管理器右键的「转写」（dev-board#228）在手机传来的录音上永远不出现。
+ *
+ * <p>写入侧已经改成落扩展名，但**存量行救不回来**：影像早已 ACK、中转区 blob 早已删除，
+ * 取件轮询再也不会碰到它们。本仓没有 SQL 迁移框架（ddl-auto: update），
+ * 所以照 {@link OrphanPhoneSessionReconciler} 的成例做成启动期对账。
+ *
+ * <h3>为什么按 fileType 取行是安全的</h3>
+ * image/video/audio 三个词不可能是任何真实文件的扩展名，命中的必然是这个 bug 的产物。
+ * 改动也只发生在「名字里确实有扩展名」时——名字没有扩展名的行保持原样，
+ * 那正是 {@code ContextAssemblerService.isVisionCandidate} 唯一还认 fileType=image 的一档。
+ *
+ * <p>只在 {@code security.local-mode=true}（单机桌面版）跑：中转客户端本来就只在桌面端活动，
+ * 脏行只可能在桌面端本地库里；云后端与团队服务器上跑等于白扫一遍全表。
+ *
+ * <p>幂等：改过之后再也匹配不到，之后每次启动都是 0 条。
+ */
+@Service
+@Slf4j
+public class MediaFileTypeReconciler implements CommandLineRunner {
+
+    /** 曾被误当 fileType 落库的 mediaType 取值（MobileRelayStoreService 的白名单前三个）。 */
+    private static final List<String> BAD_FILE_TYPES = List.of("image", "video", "audio");
+
+    private final boolean localMode;
+    private final ProjectFileRepository projectFileRepository;
+
+    public MediaFileTypeReconciler(@Value("${security.local-mode:false}") boolean localMode,
+                                   ProjectFileRepository projectFileRepository) {
+        this.localMode = localMode;
+        this.projectFileRepository = projectFileRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        reconcile();
+    }
+
+    /** @return 被改写的行数（供测试与日志用） */
+    public int reconcile() {
+        if (!localMode) return 0;
+        List<ProjectFile> rows;
+        try {
+            rows = projectFileRepository.findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(BAD_FILE_TYPES);
+        } catch (RuntimeException e) {
+            // 对账是顺手活，读不到文件表不该拦住启动
+            log.warn("影像 fileType 对账跳过：读取文件表失败 {}", e.toString());
+            return 0;
+        }
+        int fixed = 0;
+        for (ProjectFile f : rows) {
+            String ext = MobileRelayClientService.fileTypeOf(f.getName(), null);
+            if (ext == null || ext.equals(f.getFileType())) continue;
+            try {
+                String before = f.getFileType();
+                f.setFileType(ext);
+                projectFileRepository.save(f);
+                fixed++;
+                log.info("影像 fileType 对账：文件 {}（{}）{} → {}，此前在文件树里点开会被判「不支持的类型」",
+                        f.getId(), f.getName(), before, ext);
+            } catch (RuntimeException e) {
+                log.warn("影像 fileType 对账：文件 {} 改写失败 {}", f.getId(), e.toString());
+            }
+        }
+        if (fixed > 0) {
+            log.info("影像 fileType 对账完成：修正 {} 行", fixed);
+        }
+        return fixed;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileRelayClientService.java
@@ -308,9 +308,17 @@ public class MobileRelayClientService {
             try (InputStream in = content.body()) {
                 storageServiceFactory.getStorageService().save(storagePath, in);
             }
+            // fileType 落**扩展名**，不是 mediaType（dev-board#417）。project_file.file_type
+            // 在全仓的语义只有一个：文件扩展名。前端整条「这份文件能怎么用」的判定都读它——
+            // isFileTypeSupported（白名单里是 jpg/png/mp4…，没有 image/video/audio）、
+            // isAudioFile（右键「转写」，dev-board#228）、FileTypeIcon。写成 "image" 的后果
+            // 是手机传上来的照片在文件树里点开只弹「无法打开文件：暂不支持打开此类型文件…
+            // 文件类型：image」，而字节本身完好无损——用户看到的是"证据丢了"。
+            // 同一文件的其余三条落地路径（landDocumentAndAck / 传输 PUSH / MobileTransferService
+            // .saveToProject）本来就落扩展名，只有这里落错。
             ProjectFile record = projectFileService.createFile(
                     projectId, day.getId(), landedName,
-                    mediaType,
+                    fileTypeOf(landedName, mediaType),
                     item.path("fileSize").asLong(0),
                     storagePath, null, userId);
             // storagePath 是照着 ProjectFileService.buildPhysicalPath 的格式手拼的，
@@ -402,6 +410,20 @@ public class MobileRelayClientService {
                 .filter(f -> Boolean.TRUE.equals(f.getIsFolder()) && name.equals(f.getName()))
                 .findFirst();
         return existing.orElseGet(() -> projectFileService.createFolder(projectId, parentId, name, userId));
+    }
+
+    /**
+     * 落库的 fileType：文件名的扩展名（小写）；名字没有扩展名时退回 fallback（mediaType），
+     * 不写空串——ContextAssemblerService 那条「无扩展名时才认 fileType=image」的视觉判定
+     * 正好靠它兜底。
+     */
+    static String fileTypeOf(String fileName, String fallback) {
+        if (fileName == null) return fallback;
+        int dot = fileName.lastIndexOf('.');
+        if (dot > 0 && dot < fileName.length() - 1) {
+            return fileName.substring(dot + 1).toLowerCase();
+        }
+        return fallback;
     }
 
     /** 落盘文件名 = 原名 + clientMediaId 前 8 位：既可读，又是跨轮重试的幂等锚点。 */

--- a/backend/src/test/java/com/checkba/repository/ProjectFileRepositoryTreeSkeletonTest.java
+++ b/backend/src/test/java/com/checkba/repository/ProjectFileRepositoryTreeSkeletonTest.java
@@ -45,6 +45,11 @@ class ProjectFileRepositoryTreeSkeletonTest {
         return repository.save(f);
     }
 
+    private void typed(ProjectFile f, String fileType) {
+        f.setFileType(fileType);
+        repository.save(f);
+    }
+
     @Test
     void returnsFourColumnSkeletonOfLivingRowsOfOneProjectOnly() {
         ProjectFile folder = row(7L, null, true, "合同", false);
@@ -71,5 +76,27 @@ class ProjectFileRepositoryTreeSkeletonTest {
                 .orElseThrow();
         assertEquals(null, root[1]);
         assertEquals(Boolean.TRUE, root[2]);
+    }
+
+    /**
+     * MediaFileTypeReconciler（dev-board#417）靠这条派生查询捞存量脏行。派生查询的方法名
+     * 是否真能被 Spring Data 解析、isFolder/isDeleted 两个布尔条件是否真的生效，
+     * mock 出来的 repository 一个字都证明不了——必须对着真 H2 跑一遍。
+     */
+    @Test
+    void findsFilesByFileTypeExcludingFoldersAndDeletedRows() {
+        typed(row(9L, null, false, "现场影像-20260902-191122-D160-d16044f3.jpg", false), "image");
+        typed(row(9L, null, false, "现场影像-20260817-173704.mov", false), "video");
+        typed(row(9L, null, false, "已删.jpg", true), "image");
+        typed(row(9L, null, true, "现场影像", false), "image");
+        typed(row(9L, null, false, "正常.jpg", false), "jpg");
+
+        List<ProjectFile> dirty = repository
+                .findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(List.of("image", "video", "audio"));
+
+        assertEquals(2, dirty.size(), "只该捞到未删除的两个文件行，实际: "
+                + dirty.stream().map(ProjectFile::getName).toList());
+        assertEquals(List.of("现场影像-20260817-173704.mov", "现场影像-20260902-191122-D160-d16044f3.jpg"),
+                dirty.stream().map(ProjectFile::getName).sorted().toList());
     }
 }

--- a/backend/src/test/java/com/checkba/service/mobile/MediaFileTypeReconcilerTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MediaFileTypeReconcilerTest.java
@@ -1,0 +1,115 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+/**
+ * 手机中转影像 fileType 存量对账（dev-board#417）。
+ *
+ * <p>现场（本机 H2，2026-09-03 取证）：手机 9-02 传上来的
+ * {@code 现场影像-20260902-191122-D160-d16044f3.jpg} 落库时 file_type 是
+ * {@code image}，字节本身是完好的 JPEG。前端 {@code isFileTypeSupported} 的白名单里
+ * 只有 jpg/jpeg/png…，于是文件树里点开它只弹「无法打开文件」。
+ * 写入侧已改成落扩展名，但那张照片早已 ACK、中转区 blob 早已删除，
+ * 取件轮询再也不会碰它——存量只能靠启动期对账救。
+ */
+class MediaFileTypeReconcilerTest {
+
+    private ProjectFile file(Long id, String name, String fileType) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(235L);
+        f.setName(name);
+        f.setIsFolder(false);
+        f.setIsDeleted(false);
+        f.setFileType(fileType);
+        return f;
+    }
+
+    private MediaFileTypeReconciler reconciler(ProjectFileRepository repo) {
+        return new MediaFileTypeReconciler(true, repo);
+    }
+
+    @Test
+    @DisplayName("存量脏行按文件名扩展名改回来：image→jpg / video→mov / audio→m4a")
+    void rewritesMediaTypeRowsToExtension() {
+        ProjectFileRepository repo = mock(ProjectFileRepository.class);
+        ProjectFile jpg = file(2248L, "现场影像-20260902-191122-D160-d16044f3.jpg", "image");
+        ProjectFile mov = file(1752L, "现场影像-20260817-173704-A1A8-a1a83a84.mov", "video");
+        ProjectFile m4a = file(2253L, "现场录音-20260903-181645-4D63-4d632ecb.m4a", "audio");
+        when(repo.findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(anyList()))
+                .thenReturn(List.of(jpg, mov, m4a));
+
+        assertEquals(3, reconciler(repo).reconcile());
+
+        assertEquals("jpg", jpg.getFileType());
+        assertEquals("mov", mov.getFileType());
+        assertEquals("m4a", m4a.getFileType());
+        verify(repo, times(3)).save(any(ProjectFile.class));
+    }
+
+    @Test
+    @DisplayName("名字没有扩展名的行保持原样：那正是视觉判定还认 fileType=image 的唯一一档")
+    void leavesExtensionlessNamesAlone() {
+        ProjectFileRepository repo = mock(ProjectFileRepository.class);
+        ProjectFile noExt = file(900L, "扫描件", "image");
+        when(repo.findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(anyList()))
+                .thenReturn(List.of(noExt));
+
+        assertEquals(0, reconciler(repo).reconcile());
+        assertEquals("image", noExt.getFileType());
+        verify(repo, never()).save(any(ProjectFile.class));
+    }
+
+    @Test
+    @DisplayName("非 local-mode（云后端 / 团队服务器）一行都不扫：脏行只可能在桌面端本地库")
+    void skipsOutsideLocalMode() {
+        ProjectFileRepository repo = mock(ProjectFileRepository.class);
+
+        assertEquals(0, new MediaFileTypeReconciler(false, repo).reconcile());
+        verify(repo, never()).findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(anyList());
+    }
+
+    @Test
+    @DisplayName("幂等：改过之后再也匹配不到，重复启动是 0 行")
+    void idempotentWhenNothingDirty() {
+        ProjectFileRepository repo = mock(ProjectFileRepository.class);
+        when(repo.findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(anyList()))
+                .thenReturn(List.of());
+
+        assertEquals(0, reconciler(repo).reconcile());
+    }
+
+    @Test
+    @DisplayName("对账是顺手活：读文件表炸了也不能拦住启动")
+    void survivesRepositoryFailure() {
+        ProjectFileRepository repo = mock(ProjectFileRepository.class);
+        when(repo.findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(anyList()))
+                .thenThrow(new RuntimeException("db down"));
+
+        assertDoesNotThrow(() -> assertEquals(0, reconciler(repo).reconcile()));
+    }
+
+    @Test
+    @DisplayName("单行改写失败不能中断整轮对账")
+    void oneFailureDoesNotAbortTheSweep() {
+        ProjectFileRepository repo = mock(ProjectFileRepository.class);
+        ProjectFile bad = file(1L, "a.jpg", "image");
+        ProjectFile good = file(2L, "b.png", "image");
+        when(repo.findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(anyList()))
+                .thenReturn(List.of(bad, good));
+        when(repo.save(bad)).thenThrow(new RuntimeException("boom"));
+
+        assertEquals(1, reconciler(repo).reconcile());
+        assertEquals("png", good.getFileType());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileRelayClientHttpTest.java
@@ -200,6 +200,9 @@ class MobileRelayClientHttpTest {
                 .thenAnswer(inv -> {
                     callOrder.add("createFile:" + inv.getArgument(2));
                     ProjectFile f = addNode(inv.getArgument(1), inv.getArgument(2), false);
+                    // 第 4 个入参就是落库的 fileType，假树必须原样记下来：前端整条
+                    // 「能不能打开」的判定读的就是它（dev-board#417）
+                    f.setFileType(inv.getArgument(3));
                     f.setFilePath("projects/42/" + f.getName());
                     return f;
                 });
@@ -221,6 +224,7 @@ class MobileRelayClientHttpTest {
                 .thenAnswer(inv -> {
                     callOrder.add("createOrUpdateFile:" + inv.getArgument(2));
                     ProjectFile f = addNode(inv.getArgument(1), inv.getArgument(2), false);
+                    f.setFileType(inv.getArgument(3));
                     f.setFilePath(inv.getArgument(5));
                     return f;
                 });
@@ -370,6 +374,50 @@ class MobileRelayClientHttpTest {
         assertTrue(savedStorageKeys.get(0).startsWith("projects/42/现场录音/2026-08-19/"),
                 "storagePath 必须与 ensureFolder 的目录同构，实际: " + savedStorageKeys.get(0));
         assertEquals(List.of("/api/mobile/inbox/11/ack"), acked);
+    }
+
+    @Test
+    @DisplayName("落库 fileType 必须是扩展名而不是 mediaType（dev-board#417）：写成 image/video/audio 时前端整条打开链路判定不支持，点开只弹「无法打开文件」")
+    void pollInboxStoresExtensionNotMediaTypeAsFileType() {
+        inboxJson = "[{\"id\":9,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"IMG_0001.jpg\",\"mediaType\":\"image\",\"fileSize\":10,"
+                + "\"capturedAt\":\"2026-08-19T21:00:00\"}]";
+        service().pollInbox();
+
+        ProjectFile landed = tree.stream()
+                .filter(f -> "IMG_0001-0a1b2c3d.jpg".equals(f.getName()))
+                .findFirst().orElseThrow(() -> new AssertionError("影像没落库"));
+        assertEquals("jpg", landed.getFileType(),
+                "project_file.file_type 全仓语义是扩展名（前端 isFileTypeSupported / isAudioFile / "
+                        + "FileTypeIcon 都按扩展名判），落 mediaType 会让手机传来的照片点不开");
+    }
+
+    @Test
+    @DisplayName("落库 fileType（音频）：m4a 而不是 audio，否则资源管理器右键「转写」永远不出现（dev-board#228 白做）")
+    void pollInboxStoresAudioExtensionAsFileType() {
+        inboxJson = "[{\"id\":11,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"现场谈话.m4a\",\"mediaType\":\"audio\",\"fileSize\":10,"
+                + "\"capturedAt\":\"2026-08-19T21:00:00\"}]";
+        service().pollInbox();
+
+        ProjectFile landed = tree.stream()
+                .filter(f -> "现场谈话-0a1b2c3d.m4a".equals(f.getName()))
+                .findFirst().orElseThrow(() -> new AssertionError("录音没落库"));
+        assertEquals("m4a", landed.getFileType());
+    }
+
+    @Test
+    @DisplayName("落库 fileType：文件名没有扩展名时退回 mediaType，不写空串")
+    void pollInboxFallsBackToMediaTypeWhenNameHasNoExtension() {
+        inboxJson = "[{\"id\":12,\"projectKey\":\"42\",\"clientMediaId\":\"" + MEDIA_ID + "\","
+                + "\"fileName\":\"noext\",\"mediaType\":\"image\",\"fileSize\":10,"
+                + "\"capturedAt\":\"2026-08-19T21:00:00\"}]";
+        service().pollInbox();
+
+        ProjectFile landed = tree.stream()
+                .filter(f -> "noext-0a1b2c3d".equals(f.getName()))
+                .findFirst().orElseThrow(() -> new AssertionError("影像没落库"));
+        assertEquals("image", landed.getFileType());
     }
 
     @Test


### PR DESCRIPTION
## 问题
手机传上来的 jpg 在桌面端文件树点开弹「无法打开文件：暂不支持打开此类型文件…文件类型：image」（dev-board#417）。

## 根因
`MobileRelayClientService.landAndAck` 把中转件的 `mediaType`（image/video/audio）当成 `project_file.file_type` 落库，而该列全仓语义是文件扩展名。前端 `isFileTypeSupported` 白名单是 jpg/png/mp4…，没有 image，必然落进「不支持」分支。字节本身是标准 JPEG（本机样本 `file` 输出确认，HEIC 冒充假设排除）。同一个错让 `isAudioFile` 恒 false，手机录音右键永远不出现「转写」（dev-board#228 入口）。同类里其余三条落地路径本来就落扩展名，只有这里落错。

## 修法
- 落盘 fileType 走 `fileTypeOf(landedName, mediaType)`：有扩展名取小写扩展名，没有才退回 mediaType（`ContextAssemblerService` 无扩展名时才认 `fileType=image` 的视觉判定靠它兜底）。
- 存量脏行救不回来（影像已 ACK、blob 已删、目录重扫的 `createOrUpdateFile` 不改 fileType），照 `OrphanPhoneSessionReconciler` 成例加 `MediaFileTypeReconciler` 启动期对账：仅 `security.local-mode=true`、按 `file_type in (image,video,audio)` 精确取行、幂等、单行失败只 log。
- `ProjectFileRepository` 加一条派生查询，对着真 H2 跑过。

## 验证
- `MobileRelayClientHttpTest` 新增 3 用例先红（`expected: <jpg> but was: <image>`）后绿；`MediaFileTypeReconcilerTest` 6 用例，还原病灶（reconcile 首行 return 0）即转红。
- `mvn test -Dtest='com.checkba.service.mobile.*Test,ProjectFileRepositoryTreeSkeletonTest,DesktopContextSmokeTest'`：87/0。
- 领域文档 `mobile-sync.md` 补契约红线与地雷第 9 条。

未验证：桌面端真机点开（复测建议：新拍一张验写入侧 + 2026-09-02 那张老的验对账器，对账器需重启桌面端后生效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)