### PR TITLE
chore(release): 版本号 0.33.1（dev-board#420）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
补丁 tag v0.33.1 打在 v0.33.0 + cherry-pick(#717/#719/#720) 旁支上（master 混入 #718 desktop/build 图标改动会被 patch-gate 拦，沿用 v0.26.3 先例）；本 PR 只把版本号记账进 master。

🤖 Generated with [Claude Code](https://claude.com/claude-code)