### PR TITLE
chore(release): 版本号 0.33.2（dev-board#420）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
补丁 tag v0.33.2 打在 release/v0.33.1 + cherry-pick(#722/#723) 旁支上（master 含 #718 desktop/build 图标改动会被 patch-gate 拦）；本 PR 只把版本号记账进 master。

🤖 Generated with [Claude Code](https://claude.com/claude-code)