### PR TITLE
手机端统一账户余额与充值通路（dev-board#425）

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -214,6 +214,107 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
   定价 `service_pricing` 行 transfer/relay=60 Credits/GB（迁移 24）；流水 kind 仍是
   `service_spend`（meta.service=transfer），**没有新增 ledger kind**。
 
+## 统一账户余额与充值（dev-board#425，spec：aiworkdeck_mobile docs/specs/2026-09-04-mobile-recharge-design.md §3.2）
+
+**本期只有服务端通路，没有任何客户端支付界面**（iOS 内购 #426 / 小程序虚拟支付 #427 /
+安卓微信支付 #428 是后面几期）。余额权威只在官网仓（credit_lots + wallet_ledger），
+云后端一个字都不存。
+
+- `service/mobile/MobileBillingClient` + `HttpMobileBillingClient` — POST 官网
+  `/api/internal/account`，头 `X-Internal-Secret`，四个 action：`resolve`（按已验证
+  手机号或邮箱换 accountId，二选一恰好一个，**带 `create` 位**）/ `balance` /
+  `create-recharge` / `query`。
+  形状照抄 `HttpTransferBillingClient`：配置 `mobile.billing.base-url/secret`
+  （env `MOBILE_BILLING_BASE_URL`/`MOBILE_BILLING_SECRET`，**与 TRANSFER_BILLING_SECRET
+  是两把不同的密钥**），任一未配 → DISABLED 短路，不发请求。
+- **充值总开关 `mobile.billing.recharge-enabled`（env `MOBILE_BILLING_RECHARGE_ENABLED`），
+  默认 false，落在 `MobileBillingService`**（复审 N1）。关时 `createRecharge` / `queryRecharge`
+  在做任何别的事情之前抛 `DISABLED`——不校参数、不解析身份、**不会走到 `create=true`**、
+  不发上游请求。`GET /balance` 是只读的（`create=false`，永不建号），**不受这个开关影响**。
+  **这个开关要等 dev-board#434（官网账户注销传导）落地后才允许打开**，理由见红线 8。
+- `service/mobile/MobileBillingKind` — **失败判别位的唯一来源**，八个值同时是
+  `openapi/mobile-v1.yaml` 里 `Envelope.kind` 的取值集合，四端按它分支。
+  `service/mobile/MobileBillingFailureException` 带 kind + outTradeNo，
+  `GlobalExceptionHandler.handleMobileBilling` 压成 `{code:1, kind, outTradeNo?, message}`。
+- `service/mobile/MobileBillingService` — 身份解析与红线，见下。余额带 30 秒 TTL 缓存，
+  **键是 userId**；`query` 查到 paid 即作废该用户缓存。
+- `controller/MobileBillingController` — `/api/mobile/billing/{balance,recharge,recharge/status}`，
+  鉴权与响应风格同 `MobileRelayController`（`X-Session-Id`；成功裸对象，业务错误
+  200 + `{code:1,kind,message}`，未登录 4010）。契约写进 `openapi/mobile-v1.yaml`，
+  `MobileApiContractTest.billingEndpointsMatchSpec` 守着。
+
+### 失败分类：判据是「响应体里有没有 `error` 字段」，不是状态码
+
+官网对**鉴权/配置失败**（`AWD_MOBILE_BILLING_SECRET` 未配、header 不符）刻意回**空体 404**
+而不是 401/403（对外部探测者与「路由不存在」不可区分）。它与「accountId 查无此人」曾经是
+同一个响应，于是**密钥配错一个字符 → 全量用户被告知「还没关联统一账户」，日志里一条痕迹都没有**。
+现在两类分开：
+
+| 上游响应 | kind | 备注 |
+|---|---|---|
+| 空体 / 非 JSON 的 404 | `UNAVAILABLE` | **必须 `log.warn` 并点名密钥/env**，这是运维唯一的线索 |
+| 带 `{error:…}` 的 404 | `NOT_FOUND` | 真业务查无此物；resolve 那条再翻成 `NOT_CONNECTED` |
+| 409 `order_already_paid` | `ALREADY_PAID` | **连 `outTradeNo` 一起带走**，客户端据此转去查单 |
+| 409 `idempotency_conflict` | `IDEMPOTENCY_CONFLICT` | 同上 |
+| 其余 4xx | `REJECTED` | `error` 串只进日志 |
+| 5xx / 网络 / 解析失败 | `UNAVAILABLE` | **只有 create-recharge 带同一幂等键重试一次** |
+
+### 红线（护栏 `MobileBillingServiceTest`）
+
+1. **绝不复用 `AccountController`/`AccountService`/`MachineAccountGuard` 那条路**：那是机器级
+   单例（`~/.aiworkdeck/account.json`），充的是「这台服务器连的那个账户」，与调用者 userId
+   无关，server 模式只对 admin 开放。手机端是多租户，复用等于把 A 的钱记到 B 头上。
+2. **accountId 只有两个来源**：`account_binding` 里已有的绑定，或用**服务端 User 实体上
+   已验证的** phone/verifiedEmail 向官网 resolve 换来的。**绝不接受请求体传入**——
+   否则等于对外开了手机号枚举/任意建号的口子（做法同
+   `MobileTransferService.requireAccountId`）。资料字段 `email` 不算，只认 `verifiedEmail`。
+3. **User 既无手机号也无已验证邮箱 → 报错，不回落任何机器级账户**（licensing-billing.md
+   第 17 条的口径，充值比 AI 额度更不能有回落分支）。
+4. **审核账号（`ReviewAccountGate`，`auth.review-account.identity`）不许桥接、不许充值**，
+   且判定排在绑定查询**之前**——放它去 resolve 等于按审核员的手机号/邮箱在官网建出一个真
+   账户，之后那把写在 ASC 审核备注里给外部人看的 6 位固定码就成了进真账户的钥匙。
+5. **resolve 出的 accountId 已绑给别的 userId → 拒绝，绝不改绑**（`account_binding` 对
+   external_account_id 有唯一约束）。撞唯一约束的并发首调读回对方已提交的行；`saveBinding`
+   刻意不带 `@Transactional`，理由同地雷 6（外层事务会被标 rollback-only）。
+6. **`idempotencyKey` 必须客户端传入**（发起前落盘，扛 App 被杀），缺失即报错，
+   **服务端不代生成**——代生成等于没有幂等键，弱网重试会在官网留下一串各自绑着独立二维码的
+   悬挂 pending 单，而官网**没有**针对充值 pending 单的过期回收任务。桌面端
+   `AccountController.recharge` 每次 `UUID.randomUUID()` 现生成的写法**不要照抄**。
+7. **上游故障绝不能被吞成「余额 0」或「没有账户」**：八个 kind 各有各的用户可读文案，
+   失败不写缓存。空体 404 归 UNAVAILABLE 就是这条的直接落点。
+8. **读余额永不建号**（dev-board#425 复审 C1）。`resolve` 的 `create` 位只在
+   `createRecharge`（用户显式发起充值）为 true，`balance`/`queryRecharge` 一律 false。
+   第一版是无条件建号的，而 iOS 设置页的 `.task` 无条件读一次余额——「新用户打开设置页」
+   这个纯读动作就会在官网建出一行含明文手机号的真账户，用户全程无感知、未同意；
+   而 App 的注销流程（`AccountDeletionService`）只删 Java 侧的 `app_users` 与
+   `account_binding`，**从不通知官网**，内部口也没有 delete action，于是 App 自己建的账号
+   App 内没有任何路径能删掉——直接撞 App Store 5.1.1(v) 与个人信息保护法的删除权。
+   第二期做充值界面时，`create=true` 的那条路要同时补上「注销时通知官网」或
+   「建号前明确告知并取得同意」，否则这条红线只是被推迟了。
+
+   **二轮复审 N1 补的护栏**：上面这句「本期没有充值界面所以一次号都不会建」**不是护栏**——
+   `POST /api/mobile/billing/recharge` 是随本期一起上线的活端点，也是全站唯一的 `create=true`
+   调用方，任何持有有效 `X-Session-Id` 的人直接打它就会在官网建出真账户并发注册赠额，
+   触发点只是从「打开设置页」搬到了「直接打这个端点」。所以加了服务端开关
+   `mobile.billing.recharge-enabled`（默认 **false**）：关时下单与查单在到达 `create=true`
+   之前短路成 `DISABLED`，不发任何上游请求。
+   **打开的前提是 dev-board#434（官网账户注销传导）已落地**：注销能传导到官网、官网内部口有
+   delete action 之后，才把它置 true。在那之前打开 = 把 App Store 5.1.1(v) 重新放出来。
+   护栏：`MobileBillingRechargeDisabledTest`（不配这个键，走 application.yml 的生产默认值）
+   与 `MobileBillingServiceTest`（显式 `=true`，测开关开着时行为不变）。
+9. **失败一律带机器可读的 `kind`，客户端禁止匹配 message 措辞**。message 经 `LangText`
+   在英文部署下会整条变成英文，`code` 又恒为 1——第一版只送 message，于是安卓逐字硬编码
+   中文串做分支、小程序判 `code === -1`（云后端业务失败一律 200+code:1，那个分支永远进不去），
+   两套都判错。新增失败情形先往 `MobileBillingKind` 加值并同步 yaml 与移动仓
+   `contract/fixtures/billing.json`，别在 message 里塞标记。
+10. **标识选择要能回退，绑定要能自愈**。同时有手机号与已验证邮箱的用户，手机号被官网按
+   站点能力拒（`400 phone_not_supported_on_site`）时改用邮箱再试一次；
+   **只在 REJECTED 时回退，NOT_FOUND 绝不回退**——那是官网权威地回答「按这个身份没有账户」，
+   回退过去等于把用户悄悄关联到另一个官网账户上。绑定指向的官网账户被注销后，
+   `balance`/`createRecharge` 收到 NOT_FOUND 会清掉那行绑定重解析一次
+   （`AwdkLoginService.resolveUser` 早有同款自愈分支，方向相反）；`queryRecharge` 不自愈，
+   它的 404 分不出是「账户没了」还是「单号不属于你」。
+
 ## 排查「手机端一个项目都读不到」的顺序（dev-board#75 实测路径）
 
 空数组是**合法响应**，没有报错也没有 4010，所以必须按下面的顺序把「哪一环是空的」逐段夹出来：
@@ -240,5 +341,9 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
 ## 验证
 
 - `mvn test -Dtest='MobileRelay*Test,AwdkLoginServiceTest,MediaFileTypeReconcilerTest'`（JDK 21）。
+- 统一账户充值（JDK 21）：`JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test -Dtest='MobileBillingServiceTest,MobileBillingRechargeDisabledTest,HttpMobileBillingClientTest,MobileApiContractTest'`。
+  本机 `mvn` 默认走 Homebrew JDK 26，Byte Buddy 不支持，带 @MockBean 的 Spring 上下文会全部加载失败、看起来像代码坏了。
+  `HttpMobileBillingClientTest` 用 JDK 自带 `HttpServer` 起本机桩服务回真状态码——空体 404 与
+  带 body 的 404 的判据就在 HTTP 层，用 mock 绕过去等于没测。
 - 云端冒烟：`curl https://addin.aiworkdeck.com/api/mobile/projects` 无凭据应 401。
 - iOS 侧改动跑 `aiworkdeck_mobile` 仓的构建 + TestFlight 通道（fastlane）。

--- a/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/checkba/config/GlobalExceptionHandler.java
@@ -96,6 +96,33 @@ public class GlobalExceptionHandler {
         return ResponseEntity.ok().body(result);
     }
 
+    /**
+     * 手机端统一账户余额/充值失败：{@code code=1} + <b>机器可读的 {@code kind}</b>
+     * （dev-board#425 复审 C2）。
+     *
+     * <p>不接这条的话，这一族错误会落到下面的 IllegalArgumentException handler，
+     * 只剩一句 message——而 message 经 {@link com.checkba.service.LangText} 在英文部署下
+     * 会变成英文，客户端拿它做分支必然落空（安卓那版逐字硬编码中文串、小程序判 code===-1，
+     * 两套都判错了）。八个 kind 的取值集合钉在
+     * {@link com.checkba.service.mobile.MobileBillingKind} 与 {@code openapi/mobile-v1.yaml}。
+     *
+     * <p>{@code outTradeNo} 只在 ALREADY_PAID / IDEMPOTENCY_CONFLICT 时出现：官网连同 409
+     * 一起回的既有单号，是「App 被杀后没存下单号」的恢复路径，客户端据此转去查单。
+     */
+    @ExceptionHandler(com.checkba.service.mobile.MobileBillingFailureException.class)
+    public ResponseEntity<Map<String, Object>> handleMobileBilling(
+            com.checkba.service.mobile.MobileBillingFailureException e) {
+        log.warn("手机端统一账户失败 kind={} outTradeNo={}: {}", e.getKind(), e.getOutTradeNo(), e.getMessage());
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", 1);
+        result.put("kind", e.getKind().name());
+        if (e.getOutTradeNo() != null && !e.getOutTradeNo().isEmpty()) {
+            result.put("outTradeNo", e.getOutTradeNo());
+        }
+        result.put("message", e.getMessage());
+        return ResponseEntity.ok().body(result);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("GlobalExceptionHandler caught IllegalArgumentException: {}", e.getMessage());

--- a/backend/src/main/java/com/checkba/controller/MobileBillingController.java
+++ b/backend/src/main/java/com/checkba/controller/MobileBillingController.java
@@ -1,0 +1,102 @@
+package com.checkba.controller;
+
+import com.checkba.exception.UnauthorizedException;
+import com.checkba.service.mobile.MobileBillingClient;
+import com.checkba.service.mobile.MobileBillingService;
+import lombok.Data;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 手机端统一账户余额与充值（dev-board#425，spec
+ * {@code aiworkdeck_mobile/docs/specs/2026-09-04-mobile-recharge-design.md} §3.2）。
+ *
+ * <p>鉴权同 {@link MobileRelayController} 那一组：{@code X-Session-Id}，
+ * 未登录走 {@link UnauthorizedException} → 200 + code 4010 信封。
+ * 响应风格也随那一组：成功回<b>裸对象</b>（同 {@code /api/mobile/media/usage}），
+ * 业务错误由全局处理器压成 200 + {@code {code:1,message}}。
+ *
+ * <p><b>本期只有服务端通路，没有任何客户端支付界面</b>：iOS 内购 / 小程序虚拟支付 /
+ * 安卓微信支付是后面几期的事（dev-board#426/#427/#428）。
+ */
+@RestController
+@RequestMapping("/api/mobile/billing")
+public class MobileBillingController {
+
+    private final MobileBillingService service;
+
+    public MobileBillingController(MobileBillingService service) {
+        this.service = service;
+    }
+
+    /** GET /balance → {balanceCents, currency, plan}。 */
+    @GetMapping("/balance")
+    public Map<String, Object> balance(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        MobileBillingClient.BalanceResult r = service.balance(requireUser(sessionId));
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("balanceCents", r.balanceCents());
+        out.put("currency", r.currency());
+        out.put("plan", r.plan());
+        return out;
+    }
+
+    @Data
+    public static class RechargeRequest {
+        private Long amountCents;
+        /**
+         * 客户端生成并<b>落盘后</b>传入的幂等键。服务端刻意不代生成——代生成等于没有幂等键，
+         * App 被杀/弱网重试会在官网留下一串悬挂 pending 单。缺失即 code:1 报错。
+         */
+        private String idempotencyKey;
+    }
+
+    /** POST /recharge → {present, outTradeNo, amountCents, codeUrl?, qrCode?, redirectUrl?}。 */
+    @PostMapping("/recharge")
+    public Map<String, Object> recharge(
+            @RequestBody(required = false) RechargeRequest request,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = requireUser(sessionId);
+        MobileBillingClient.RechargeOrder order = service.createRecharge(userId,
+                request == null ? null : request.getAmountCents(),
+                request == null ? null : request.getIdempotencyKey());
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("present", order.present());
+        out.put("outTradeNo", order.outTradeNo());
+        out.put("amountCents", order.amountCents());
+        // 三个可选字段按 present 二选一有值，为 null 时不出现在响应里（契约里也是非必填）
+        putIfPresent(out, "codeUrl", order.codeUrl());
+        putIfPresent(out, "qrCode", order.qrCode());
+        putIfPresent(out, "redirectUrl", order.redirectUrl());
+        return out;
+    }
+
+    /** GET /recharge/status?outTradeNo= → {status, paid, amountCents}。 */
+    @GetMapping("/recharge/status")
+    public Map<String, Object> rechargeStatus(
+            @RequestParam(value = "outTradeNo", required = false) String outTradeNo,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        MobileBillingClient.RechargeStatus s = service.queryRecharge(requireUser(sessionId), outTradeNo);
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("status", s.status());
+        out.put("paid", s.paid());
+        out.put("amountCents", s.amountCents());
+        return out;
+    }
+
+    private static void putIfPresent(Map<String, Object> out, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            out.put(key, value);
+        }
+    }
+
+    private Long requireUser(String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            throw new UnauthorizedException("请先登录");
+        }
+        return userId;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/HttpMobileBillingClient.java
+++ b/backend/src/main/java/com/checkba/service/mobile/HttpMobileBillingClient.java
@@ -1,0 +1,294 @@
+package com.checkba.service.mobile;
+
+import com.checkba.service.LangText;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * {@link MobileBillingClient} 的生产实现：POST {@code {base}/api/internal/account}，
+ * 鉴权 header {@code X-Internal-Secret}，body {@code {action, ...}}
+ * （dev-board#425，spec §3.2）。形状照抄 {@link HttpTransferBillingClient}。
+ *
+ * <p>base-url/secret 任一未配置（桌面/本地默认空）视为该服务器未开通统一账户充值，
+ * 四个方法一律短路抛 DISABLED，<b>不发请求</b>——不静默放行、也不装作有余额。
+ *
+ * <p>网络失败（连不上/超时/中断，不含"连上了但业务报错"）只有 create-recharge 带同一
+ * 幂等键重试一次；resolve/balance/query 是只读查询，失败直接报 UNAVAILABLE，不重试。
+ *
+ * <p>失败分类见 {@link #parse}：判据是<b>响应体里有没有 {@code error} 字段</b>，
+ * 空体 404（官网 env 未配/secret 不符）与带 body 的 404（真查无此账户）必须分开，
+ * 否则密钥配错会被全量用户看成「还没关联统一账户」（复审 C3）。
+ */
+@Component
+@Slf4j
+public class HttpMobileBillingClient implements MobileBillingClient {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+
+    private final String baseUrl;
+    private final String secret;
+    private final ObjectMapper om;
+
+    /** 固定 HTTP/1.1，理由与 HttpTransferBillingClient 逐字相同：明文地址走 h2c 升级会被 Next 开发服务器吞掉。 */
+    private final HttpClient client = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    public HttpMobileBillingClient(
+            @Value("${mobile.billing.base-url:}") String baseUrl,
+            @Value("${mobile.billing.secret:}") String secret,
+            ObjectMapper om) {
+        this.baseUrl = baseUrl == null ? "" : baseUrl.trim();
+        this.secret = secret == null ? "" : secret.trim();
+        this.om = om;
+    }
+
+    @Override
+    public String resolveAccountId(String phone, String email, boolean create) {
+        boolean hasPhone = phone != null && !phone.isBlank();
+        boolean hasEmail = email != null && !email.isBlank();
+        if (hasPhone == hasEmail) {
+            // 契约是"二选一恰好一个"。两个都给或都不给是调用方的编程错误，不是用户输入错误，
+            // 所以直接 IllegalStateException 而不是走 MobileBillingException 那套用户可读文案。
+            throw new IllegalStateException("resolve 必须且只能给 phone 与 email 中的一个");
+        }
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", "resolve");
+        if (hasPhone) {
+            body.put("phone", phone.trim());
+        } else {
+            body.put("email", email.trim());
+        }
+        // 显式传，不靠官网的默认值：官网 create 默认 false，但这里传死了才能在读日志/抓包时
+        // 一眼看出"这次调用到底允不允许建号"。false 时官网只查不建，查无此人回带 body 的 404。
+        body.put("create", create);
+        return call(body).path("accountId").asText(null);
+    }
+
+    @Override
+    public BalanceResult balance(String accountId) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", "balance");
+        body.put("accountId", accountId);
+        JsonNode json = call(body);
+        return new BalanceResult(
+                json.path("balanceCents").asLong(0),
+                json.path("currency").asText("CNY"),
+                json.hasNonNull("plan") ? json.path("plan").asText() : null);
+    }
+
+    @Override
+    public RechargeOrder createRecharge(String accountId, long amountCents, String idempotencyKey) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", "create-recharge");
+        body.put("accountId", accountId);
+        body.put("amountCents", amountCents);
+        body.put("idempotencyKey", idempotencyKey);
+        JsonNode json = callWithRetry(body);
+        return new RechargeOrder(
+                json.path("present").asText(null),
+                json.path("outTradeNo").asText(null),
+                json.path("amountCents").asLong(0),
+                textOrNull(json, "codeUrl"),
+                textOrNull(json, "qrCode"),
+                textOrNull(json, "redirectUrl"));
+    }
+
+    @Override
+    public RechargeStatus queryRecharge(String accountId, String outTradeNo) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", "query");
+        body.put("accountId", accountId);
+        body.put("outTradeNo", outTradeNo);
+        JsonNode json = call(body);
+        return new RechargeStatus(
+                json.path("status").asText(null),
+                json.path("paid").asBoolean(false),
+                json.path("amountCents").asLong(0));
+    }
+
+    // ==================== 内部 ====================
+
+    private static String textOrNull(JsonNode json, String field) {
+        return json.hasNonNull(field) ? json.path(field).asText() : null;
+    }
+
+    private void requireConfigured() {
+        if (baseUrl.isEmpty() || secret.isEmpty()) {
+            throw new MobileBillingException(MobileBillingKind.DISABLED,
+                    LangText.of("此服务器未开通统一账户充值",
+                            "Unified account top-up is not enabled on this server"));
+        }
+    }
+
+    /** 只读动作用：单次调用，网络失败不重试。 */
+    private JsonNode call(Map<String, Object> body) {
+        requireConfigured();
+        try {
+            return parse(send(writeJson(body)));
+        } catch (NetworkFailure e) {
+            log.warn("统一账户记账口请求失败（网络）: {}", e.getCause() == null ? e.toString() : e.getCause().toString());
+            throw unavailable();
+        }
+    }
+
+    /** create-recharge 用：网络失败带同一幂等键（body 原样）重试一次。 */
+    private JsonNode callWithRetry(Map<String, Object> body) {
+        requireConfigured();
+        String json = writeJson(body);
+        try {
+            return parse(send(json));
+        } catch (NetworkFailure first) {
+            try {
+                return parse(send(json));
+            } catch (NetworkFailure second) {
+                log.warn("统一账户记账口请求失败（网络，已重试一次）: {}",
+                        second.getCause() == null ? second.toString() : second.getCause().toString());
+                throw unavailable();
+            }
+        }
+    }
+
+    private String writeJson(Map<String, Object> body) {
+        try {
+            return om.writeValueAsString(body);
+        } catch (Exception e) {
+            throw unavailable();
+        }
+    }
+
+    private HttpResponse<String> send(String json) {
+        try {
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/api/internal/account"))
+                    .timeout(TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .header("X-Internal-Secret", secret)
+                    .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8))
+                    .build();
+            return client.send(req, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new NetworkFailure(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new NetworkFailure(e);
+        }
+    }
+
+    /**
+     * 200 按成功解析；其余按<b>响应体里有没有 {@code error} 字段</b>再分：
+     *
+     * <ul>
+     *   <li><b>空体 404</b> → {@link MobileBillingKind#UNAVAILABLE} + {@code log.warn}（复审 C3）。
+     *       官网对「{@code AWD_MOBILE_BILLING_SECRET} 未配置 / header 不符」刻意回空体 404
+     *       （对外部探测者与「这条路由不存在」不可区分，这一点不改），它与「accountId 查无此人」
+     *       曾经是同一个响应——于是密钥配错一个字符，全量用户会被告知「还没关联统一账户」，
+     *       而日志里一条痕迹都没有。这正是 mobile-sync.md 红线 7 禁止的「上游故障被吞成没有账户」。</li>
+     *   <li><b>带 JSON body 的 404</b>（{@code {"error":"account_not_found"}} 等）→ 真业务
+     *       {@link MobileBillingKind#NOT_FOUND}。持有正确 secret 的调用方只有我们自己的
+     *       Java 后端，能区分不构成对外探测面。</li>
+     *   <li><b>409</b> {@code order_already_paid} / {@code idempotency_conflict} →
+     *       ALREADY_PAID / IDEMPOTENCY_CONFLICT，且<b>把官网一并回的 {@code outTradeNo} 带走</b>
+     *       （复审 C4）。这是「App 被杀后没存下单号」的恢复路径，丢了它用户既拿不到货
+     *       也查不到单。</li>
+     *   <li>其余 4xx → REJECTED（error 串只进日志）；5xx 与解析失败 → UNAVAILABLE。</li>
+     * </ul>
+     */
+    private JsonNode parse(HttpResponse<String> resp) {
+        int status = resp.statusCode();
+        if (status == 200) {
+            try {
+                return om.readTree(resp.body());
+            } catch (Exception e) {
+                log.warn("统一账户记账口响应解析失败: body={}", resp.body());
+                throw unavailable();
+            }
+        }
+
+        JsonNode body = tryReadTree(resp.body());
+        // 官网的 fail() 恒带 error；没有 error 就说明这不是官网的业务响应
+        String machineError = body == null ? null : textOrNull(body, "error");
+        String outTradeNo = body == null ? null : textOrNull(body, "outTradeNo");
+
+        if (status == 404) {
+            if (machineError == null) {
+                log.warn("统一账户记账口回空体 404：这不是「查无此账户」，而是鉴权/配置问题——"
+                                + "核对本机 mobile.billing.secret 与官网 env AWD_MOBILE_BILLING_SECRET 是否一致、"
+                                + "官网是否配了该 env（base-url={}）",
+                        baseUrl);
+                throw unavailable();
+            }
+            log.warn("统一账户记账口回 404: error={}", machineError);
+            throw new MobileBillingException(MobileBillingKind.NOT_FOUND,
+                    LangText.of("未找到对应的统一账户", "No matching unified account was found"),
+                    machineError);
+        }
+
+        if (status == 409 && "order_already_paid".equals(machineError)) {
+            log.info("统一账户充值单已支付，回放单号供客户端查单: outTradeNo={}", outTradeNo);
+            throw new MobileBillingException(MobileBillingKind.ALREADY_PAID,
+                    LangText.of("这笔充值已经支付成功，请查看订单状态",
+                            "This top-up has already been paid; please check the order status"),
+                    machineError, outTradeNo);
+        }
+        if (status == 409 && "idempotency_conflict".equals(machineError)) {
+            log.warn("统一账户充值幂等键冲突: outTradeNo={}", outTradeNo);
+            throw new MobileBillingException(MobileBillingKind.IDEMPOTENCY_CONFLICT,
+                    LangText.of("该充值请求与已有订单不一致，请重新发起",
+                            "This top-up request conflicts with an existing order; please start a new one"),
+                    machineError, outTradeNo);
+        }
+
+        if (status >= 400 && status < 500) {
+            log.warn("统一账户记账口被拒: status={}, error={}", status, machineError);
+            throw new MobileBillingException(MobileBillingKind.REJECTED,
+                    LangText.of("充值请求被拒绝，请稍后重试或联系客服",
+                            "The top-up request was rejected. Please try again later or contact support."),
+                    machineError);
+        }
+        log.warn("统一账户记账口调用失败: status={}, body={}", status, resp.body());
+        throw unavailable();
+    }
+
+    /** 解析不出 JSON（空体、HTML 错误页）就回 null——判据本身要能区分"没有 body"与"body 里没有 error"。 */
+    private JsonNode tryReadTree(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode node = om.readTree(body);
+            return node == null || node.isMissingNode() ? null : node;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private MobileBillingException unavailable() {
+        return new MobileBillingException(MobileBillingKind.UNAVAILABLE,
+                LangText.of("账户服务暂不可用，请稍后再试",
+                        "Account service is temporarily unavailable, please try again later"));
+    }
+
+    /** send() 内部标记网络层失败（连不上/超时/中断），与"连上了但业务报错"区分开，只有前者会重试。 */
+    private static class NetworkFailure extends RuntimeException {
+        NetworkFailure(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingClient.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingClient.java
@@ -1,0 +1,122 @@
+package com.checkba.service.mobile;
+
+/**
+ * 手机端「统一账户」余额与充值口（dev-board#425，spec
+ * {@code aiworkdeck_mobile/docs/specs/2026-09-04-mobile-recharge-design.md} §3.2）。
+ *
+ * <p>余额权威只在官网仓（credit_lots + wallet_ledger），云后端没有、也不应该有任何
+ * 能直连官网用户态的凭据。本接口打的是官网新增的窄权限内部记账口
+ * {@code POST /api/internal/account}，形状与 {@link TransferBillingClient} 同源
+ * （同机直连 + {@code X-Internal-Secret}），权限只有「按 accountId 读余额 / 建充值单 /
+ * 查充值单」与「按已验证手机号或邮箱解析 accountId」四件事。
+ *
+ * <p><b>已否决</b>手机端自持官网 {@code awdk_} Bearer 直连的方案：那是该账户的无范围
+ * 凭据，且官网 api_keys 满槽（3 把）淘汰最旧，手机端每次登录都会挤掉桌面端在用的那把。
+ *
+ * <p>接口存在的理由同 {@link TransferBillingClient}：给测试用桩，生产实现见
+ * {@link HttpMobileBillingClient}。
+ */
+public interface MobileBillingClient {
+
+    /**
+     * 余额。
+     *
+     * @param balanceCents 整数分
+     * @param currency     站点币种（CNY / USD），由部署站点决定
+     * @param plan         计费档位。权威侧 {@code lib/wallet.ts} 的 {@code getPlan()}
+     *                     只返回 {@code paid} / {@code free}，<b>不是套餐名，也基本不会为 null</b>
+     *                     （只有上游没给这个字段时才是 null）。各端不要当套餐名直接渲染。
+     */
+    record BalanceResult(long balanceCents, String currency, String plan) {}
+
+    /**
+     * 充值单。{@code present} = {@code "qrcode"}（codeUrl/qrCode 有值）或
+     * {@code "redirect"}（redirectUrl 有值）；不适用的字段为 null。
+     */
+    record RechargeOrder(String present, String outTradeNo, long amountCents,
+                         String codeUrl, String qrCode, String redirectUrl) {}
+
+    /** 充值单状态：status ∈ {pending, paid, closed, expired}。 */
+    record RechargeStatus(String status, boolean paid, long amountCents) {}
+
+    /**
+     * 按<b>已验证</b>的手机号或邮箱解析官网 accountId（action=resolve）。
+     *
+     * <p>契约要求 phone / email <b>恰好给一个</b>，另一个传 null。
+     *
+     * <p><b>红线</b>（spec §3.2）：入参只能取自服务端会话对应的 User 实体，
+     * <b>绝不接受请求体传入</b>——否则等于对外开了一个手机号枚举/任意建号的口子。
+     * 调用点收敛在 {@link MobileBillingService#requireAccountId}。
+     *
+     * @param create <b>是否允许官网按这个身份建号</b>（复审 C1）。
+     *               {@code false}（读余额、查单）时官网只查不建，查无此人回带 body 的 404
+     *               → {@link MobileBillingKind#NOT_FOUND}。
+     *               {@code true} 只允许出现在<b>用户显式发起充值</b>这一个动作上：
+     *               「打开设置页」这种纯读动作若能在官网静默建出一行含明文手机号的真账户，
+     *               就撞上 App Store 5.1.1(v)（App 内能创建的账号必须能在 App 内删除）
+     *               与个人信息保护法的删除权——而 App 的注销流程只删 Java 侧，删不掉官网那行。
+     */
+    String resolveAccountId(String phone, String email, boolean create);
+
+    /** 读余额（action=balance）。只读，网络失败不重试。 */
+    BalanceResult balance(String accountId);
+
+    /**
+     * 建充值单（action=create-recharge）。
+     *
+     * <p>{@code idempotencyKey} 由<b>客户端</b>生成并落盘后传入（官网 orders 表有
+     * {@code UNIQUE(userId, idempotencyKey)} 兜底），服务端不代生成——代生成等于没有幂等键，
+     * 弱网重试会在官网库里留下一串各自绑定独立二维码的悬挂 pending 单。
+     */
+    RechargeOrder createRecharge(String accountId, long amountCents, String idempotencyKey);
+
+    /** 查充值单（action=query）。 */
+    RechargeStatus queryRecharge(String accountId, String outTradeNo);
+
+    /**
+     * 计费失败分类，翻成用户可读文案的活交给 {@link MobileBillingService}——本类只负责把
+     * 「在用户眼里长得一样、下一步却完全不同」的几种情况分开，理由同
+     * {@link TransferBillingClient.TransferBillingException}。
+     *
+     * <p>判别位用共享枚举 {@link MobileBillingKind}：它同时是信封里 {@code kind} 字段的
+     * 取值集合，四端按它分支（复审 C2）。本类能产出的子集是
+     * DISABLED / UNAVAILABLE / NOT_FOUND / REJECTED / ALREADY_PAID / IDEMPOTENCY_CONFLICT；
+     * NOT_CONNECTED 与 REVIEW_ACCOUNT 是服务层的判定，不由 HTTP 层产生。
+     */
+    class MobileBillingException extends RuntimeException {
+
+        private final MobileBillingKind kind;
+        /** 官网回的 {@code error} 字段（机器可读串），只进日志不回显给用户。 */
+        private final String machineError;
+        /** 仅 ALREADY_PAID / IDEMPOTENCY_CONFLICT 有值：官网连同 409 一起回的既有单号。 */
+        private final String outTradeNo;
+
+        public MobileBillingException(MobileBillingKind kind, String message) {
+            this(kind, message, null, null);
+        }
+
+        public MobileBillingException(MobileBillingKind kind, String message, String machineError) {
+            this(kind, message, machineError, null);
+        }
+
+        public MobileBillingException(MobileBillingKind kind, String message,
+                                      String machineError, String outTradeNo) {
+            super(message);
+            this.kind = kind;
+            this.machineError = machineError;
+            this.outTradeNo = outTradeNo;
+        }
+
+        public MobileBillingKind getKind() {
+            return kind;
+        }
+
+        public String getMachineError() {
+            return machineError;
+        }
+
+        public String getOutTradeNo() {
+            return outTradeNo;
+        }
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingFailureException.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingFailureException.java
@@ -1,0 +1,41 @@
+package com.checkba.service.mobile;
+
+/**
+ * {@code /api/mobile/billing/*} 的业务失败，带 {@link MobileBillingKind} 判别位
+ * （dev-board#425 复审 C2）。
+ *
+ * <p>{@code GlobalExceptionHandler} 有专门的 handler，压成
+ * {@code 200 + {code:1, kind, outTradeNo?, message}}——{@code kind} 就是给客户端分支用的，
+ * 客户端<b>不许</b>再去匹配 message 措辞。
+ *
+ * <p><b>为什么继承 {@link IllegalArgumentException}</b>：这一族错误原本就是以
+ * IllegalArgumentException 的形式落到全局处理器的 {@code code:1} 分支，继承保证
+ * 「万一 handler 漏注册」时行为退化成改造前的样子（少一个 kind，而不是变成 500）。
+ * Spring 的 {@code ExceptionHandlerMethodResolver} 按继承距离选最具体的 handler，
+ * 所以本类照样走自己那个。
+ */
+public class MobileBillingFailureException extends IllegalArgumentException {
+
+    private final MobileBillingKind kind;
+
+    /** 仅 {@link MobileBillingKind#ALREADY_PAID} / {@link MobileBillingKind#IDEMPOTENCY_CONFLICT} 有值。 */
+    private final String outTradeNo;
+
+    public MobileBillingFailureException(MobileBillingKind kind, String message) {
+        this(kind, message, null);
+    }
+
+    public MobileBillingFailureException(MobileBillingKind kind, String message, String outTradeNo) {
+        super(message);
+        this.kind = kind;
+        this.outTradeNo = outTradeNo;
+    }
+
+    public MobileBillingKind getKind() {
+        return kind;
+    }
+
+    public String getOutTradeNo() {
+        return outTradeNo;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingKind.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingKind.java
@@ -1,0 +1,60 @@
+package com.checkba.service.mobile;
+
+/**
+ * 统一账户余额/充值失败的<b>机器可读判别位</b>（dev-board#425 复审 C2）。
+ *
+ * <p>存在的理由是一条踩出来的教训：这一族失败在用户眼里长得都一样（都是一句红字），
+ * 下一步却完全不同——「本服务器没开通」要收起入口，「官网挂了」要让用户稍后重试，
+ * 「还没有统一账户」要连余额那一行都不渲染，「这单已经付过了」要带着单号转去查单。
+ * 第一版只把 message 送到客户端，于是三端各自去猜：安卓逐字硬编码中文 message 做分支
+ * （服务端 {@link com.checkba.service.LangText} 在英文部署下会把同一条消息变成英文，
+ * 匹配全部落空），小程序判 {@code code === -1}（云后端业务失败一律 200 + code:1，
+ * 那个分支永远进不去）。
+ *
+ * <p>所以：<b>枚举名是四端共享的契约</b>，写在
+ * {@code openapi/mobile-v1.yaml} 的 {@code Envelope.kind} 里，
+ * 各端<b>一律按它分支，禁止匹配 message 措辞</b>。message 只用于兜底展示。
+ * 改名/新增值 = 契约变更，必须同步 yaml 与移动仓 {@code contract/fixtures/billing.json}。
+ */
+public enum MobileBillingKind {
+
+    /** 本服务器未配 {@code mobile.billing.base-url/secret}，压根没开通。客户端应收起充值入口。 */
+    DISABLED,
+
+    /**
+     * 上游不可用：网络失败、官网 5xx、响应解析失败，以及<b>官网回的空体 404</b>
+     * （官网对「env 未配置 / secret 不符」刻意回空体 404 而不是 401/403，见 C3）。
+     * <b>绝不能被吞成「没有账户」或「余额 0」</b>（mobile-sync.md 红线 7）。
+     */
+    UNAVAILABLE,
+
+    /**
+     * 这个登录账号还没有统一账户：没有已验证的手机号/邮箱，或官网按该身份查无账户
+     * （读余额一律 {@code create=false}，不建号）。客户端<b>不渲染余额那一行</b>。
+     */
+    NOT_CONNECTED,
+
+    /**
+     * 官网明确回「查无此物」的带 body 404：accountId 已注销、或单号不属于该账户。
+     * 与 {@link #UNAVAILABLE} 的空体 404 是两件事，判据是响应体里有没有 {@code error} 字段。
+     */
+    NOT_FOUND,
+
+    /** 官网明确拒绝的业务错误（非 404/409 的 4xx），或本地判定的拒绝（如统一账户已绑给别人）。 */
+    REJECTED,
+
+    /** App 审核专用账号（{@link com.checkba.config.ReviewAccountGate}）：不桥接、不充值。 */
+    REVIEW_ACCOUNT,
+
+    /**
+     * 同一把幂等键的单子已支付（官网 409 {@code order_already_paid}）。
+     * 信封里带 {@code outTradeNo}：App 被杀后没存下单号时，靠它转去查单而不是重新下单。
+     */
+    ALREADY_PAID,
+
+    /**
+     * 同一把幂等键换了金额/类型（官网 409 {@code idempotency_conflict}）。
+     * 同样带 {@code outTradeNo}。
+     */
+    IDEMPOTENCY_CONFLICT
+}

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingService.java
@@ -1,0 +1,444 @@
+package com.checkba.service.mobile;
+
+import com.checkba.config.ReviewAccountGate;
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.User;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.LangText;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * 手机端统一账户余额与充值（dev-board#425，spec
+ * {@code aiworkdeck_mobile/docs/specs/2026-09-04-mobile-recharge-design.md} §3.2）。
+ *
+ * <p><b>这条路与 {@code AccountController}/{@code AccountService} 是两回事</b>：那条是
+ * 机器级单例（{@code ~/.aiworkdeck/account.json}，{@code MachineAccountGuard} 在 server 模式下
+ * 只放行 admin），充的是"这台服务器连的那个账户"，与调用者的 userId 无关。手机端是多租户，
+ * 复用它等于给 A 的钱记到 B 头上，所以这里从头到尾按 userId 走独立路径。
+ *
+ * <p>多租户纪律沿用 licensing-billing.md 第 17 条并且更严——充值涉及真金白银，比 AI 额度
+ * 更不能有"拿错账户扣钱"的回落分支：
+ * <ul>
+ *   <li>accountId 只有两个来源：{@code account_binding} 里已有的绑定，或用<b>服务端 User 实体上
+ *       已验证的</b>手机号/邮箱向官网 resolve 换来的。<b>绝不接受请求体传入</b>
+ *       （做法同 {@link MobileTransferService#requireAccountId}）。</li>
+ *   <li>User 既无手机号也无已验证邮箱 → 报错，<b>不回落任何机器级账户</b>。</li>
+ *   <li>App 审核专用账号（{@link ReviewAccountGate}）不允许桥接、不允许充值——否则会给
+ *       Apple/微信的审核员在官网建出一个真账户。</li>
+ *   <li>解析出的 accountId 若已绑给别的 userId，<b>拒绝，不改绑</b>。</li>
+ * </ul>
+ *
+ * <p><b>读余额永不建号</b>（复审 C1）：{@code resolve} 的 {@code create} 位只在
+ * {@link #createRecharge}（用户显式发起充值）这一条路上为 true，{@link #balance} 与
+ * {@link #queryRecharge} 一律 false。第一版是无条件建号的，而 iOS 设置页的 {@code .task}
+ * 无条件读一次余额——「新用户打开设置页」这个纯读动作就会在官网建出一行含明文手机号的真账户，
+ * 用户全程无感知、未同意；更糟的是 App 的注销流程只删 Java 侧的 app_users 与 account_binding，
+ * 从不通知官网，内部口也没有 delete action，于是<b>App 自己建的账号，App 内没有任何路径能删掉</b>，
+ * 直接撞 App Store 5.1.1(v) 与个人信息保护法的删除权。本期没有充值界面，所以实际上一次号都不会建。
+ *
+ * <p><b>充值总开关</b>（复审 N1）：{@code mobile.billing.recharge-enabled} 默认 false，
+ * 关时 {@link #createRecharge} 与 {@link #queryRecharge} 在做<b>任何</b>别的事情之前短路成
+ * {@link MobileBillingKind#DISABLED}，不解析身份、不发上游请求。上一条说的「本期没有充值界面
+ * 所以一次号都不会建」<b>不是护栏</b>——{@code POST /api/mobile/billing/recharge} 是活的端点，
+ * 任何持有有效 {@code X-Session-Id} 的人直接打它就会走到 {@code create=true}。
+ * <b>这个开关要等 dev-board#434（官网账户注销传导）落地后才允许打开</b>，
+ * 在那之前打开就等于把 App Store 5.1.1(v) 那条重新放出来。
+ *
+ * <p>失败一律带 {@link MobileBillingKind} 判别位（复审 C2），信封里是 {@code kind} 字段，
+ * 四端按它分支——第一版只送 message，三端于是各自去猜（安卓硬编码中文串、小程序判
+ * {@code code === -1}），全都判错。
+ *
+ * <p>余额读取带 30 秒 TTL 缓存，<b>缓存键是 userId</b>。现有 {@code AccountService} 用机器指纹
+ * 做缓存 owner 校验，那套在多用户场景下会串账，一个字都不能照搬。
+ */
+@Service
+@Slf4j
+public class MobileBillingService {
+
+    /** 余额缓存 TTL：短到"充完值刷一下就看得见"，长到能挡住列表页的连续刷新。 */
+    static final Duration BALANCE_TTL = Duration.ofSeconds(30);
+
+    /** 缓存条目上限：超过就顺手清一遍过期项，别让长跑进程攒出一张只增不减的表。 */
+    private static final int MAX_CACHE_ENTRIES = 10_000;
+
+    /**
+     * 幂等键围栏：它会进官网 {@code orders} 表的 {@code UNIQUE(userId, idempotencyKey)}，
+     * 收口成 UUID/短串形态，理由同 {@code MobileTransferService.REQUEST_ID}。
+     */
+    private static final Pattern IDEMPOTENCY_KEY = Pattern.compile("^[A-Za-z0-9_-]{8,64}$");
+
+    /** 商户订单号围栏：官网侧生成的形态，只做长度与字符集把关。 */
+    private static final Pattern OUT_TRADE_NO = Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
+
+    private final MobileBillingClient billing;
+    private final AccountBindingRepository accountBindingRepository;
+    private final UserRepository userRepository;
+    private final ReviewAccountGate reviewAccount;
+
+    /** 充值下单/查单的总开关，默认关，见 {@link #requireRechargeEnabled()}。 */
+    private final boolean rechargeEnabled;
+
+    private final Map<Long, CachedBalance> balanceCache = new ConcurrentHashMap<>();
+
+    private record CachedBalance(MobileBillingClient.BalanceResult value, long expiresAtMillis) {
+        boolean fresh(long nowMillis) {
+            return expiresAtMillis > nowMillis;
+        }
+    }
+
+    public MobileBillingService(MobileBillingClient billing,
+                                AccountBindingRepository accountBindingRepository,
+                                UserRepository userRepository,
+                                ReviewAccountGate reviewAccount,
+                                @Value("${mobile.billing.recharge-enabled:false}") boolean rechargeEnabled) {
+        this.billing = billing;
+        this.accountBindingRepository = accountBindingRepository;
+        this.userRepository = userRepository;
+        this.reviewAccount = reviewAccount;
+        this.rechargeEnabled = rechargeEnabled;
+    }
+
+    // ==================== 对外 ====================
+
+    /**
+     * 余额（带 30 秒 TTL 缓存，键为 userId）。
+     *
+     * <p><b>纯读动作，{@code create=false}：查无此账户就报 NOT_CONNECTED，绝不建号。</b>
+     */
+    public MobileBillingClient.BalanceResult balance(Long userId) {
+        long now = System.currentTimeMillis();
+        CachedBalance hit = balanceCache.get(userId);
+        if (hit != null && hit.fresh(now)) {
+            return hit.value();
+        }
+        MobileBillingClient.BalanceResult result =
+                callWithAccount(userId, false, true, billing::balance);
+        cacheBalance(userId, result, now);
+        return result;
+    }
+
+    /**
+     * 建充值单。
+     *
+     * <p>{@code idempotencyKey} <b>必须由客户端传入</b>（发起前落盘，扛得住 App 被杀），
+     * 缺失即报错——服务端现生成等于没有幂等键，弱网重试会在官网库里留下一串各自绑着独立
+     * 二维码的悬挂 pending 单，而官网<b>没有</b>针对充值 pending 单的过期回收任务。
+     *
+     * <p>这是<b>唯一</b>允许在官网建号的入口（{@code create=true}）：用户显式发起充值，
+     * 建号是这个动作的应有之义。
+     *
+     * <p><b>总开关先行</b>（复审 N1）：{@code mobile.billing.recharge-enabled} 关时（默认）
+     * 第一行就抛 DISABLED，参数校验、身份解析、上游请求一律不发生。「本期四端还没有充值界面」
+     * 只是没人调，不是护栏——这个端点是活的。
+     */
+    public MobileBillingClient.RechargeOrder createRecharge(Long userId, Long amountCents, String idempotencyKey) {
+        requireRechargeEnabled();
+        if (amountCents == null || amountCents <= 0) {
+            throw new IllegalArgumentException(LangText.of(
+                    "充值金额必须大于 0", "Top-up amount must be greater than 0"));
+        }
+        String key = idempotencyKey == null ? "" : idempotencyKey.trim();
+        if (!IDEMPOTENCY_KEY.matcher(key).matches()) {
+            throw new IllegalArgumentException(LangText.of(
+                    "缺少或非法的 idempotencyKey，请升级客户端后重试",
+                    "Missing or invalid idempotencyKey; please update the app and try again"));
+        }
+        return callWithAccount(userId, true, true,
+                accountId -> billing.createRecharge(accountId, amountCents, key));
+    }
+
+    /**
+     * 查充值单状态。到账即作废余额缓存，让下一次 balance 打真源。
+     *
+     * <p>与下单同一把总开关（复审 N1）：功能关着时查单也没有意义，且下单被挡住时不应该还留着
+     * 一个能拿单号打上游的口子。
+     *
+     * <p>{@code create=false}（查单不是建号的理由），且<b>不做绑定自愈</b>：这条路的 404
+     * 既可能是"账户没了"也可能是"单号不属于你"，分不出来就不要动绑定行——真出现账户被注销，
+     * 用户读一次余额就会自愈。
+     */
+    public MobileBillingClient.RechargeStatus queryRecharge(Long userId, String outTradeNo) {
+        requireRechargeEnabled();
+        String no = outTradeNo == null ? "" : outTradeNo.trim();
+        if (!OUT_TRADE_NO.matcher(no).matches()) {
+            throw new IllegalArgumentException(LangText.of(
+                    "缺少或非法的 outTradeNo", "Missing or invalid outTradeNo"));
+        }
+        MobileBillingClient.RechargeStatus status = callWithAccount(userId, false, false,
+                accountId -> billing.queryRecharge(accountId, no));
+        if (status.paid()) {
+            balanceCache.remove(userId);
+        }
+        return status;
+    }
+
+    // ==================== 身份解析 ====================
+
+    /**
+     * 取该用户的官网 accountId（只查不建）。对外保留这个签名给旁路调用；
+     * 建号的那条通路只从 {@link #createRecharge} 走。
+     */
+    public String requireAccountId(Long userId) {
+        return requireAccountId(userId, false);
+    }
+
+    /**
+     * 取该用户的官网 accountId：已绑定就用绑定，未绑定就拿<b>服务端 User 实体上已验证的</b>
+     * 手机号/邮箱向官网 resolve 换一个并写入 {@code account_binding}。
+     *
+     * <p>审核账号先于一切被挡掉：即便它不知怎么已经有了绑定，也不许走充值。
+     *
+     * @param create 是否允许官网按该身份建号，见 {@link MobileBillingClient#resolveAccountId}
+     */
+    String requireAccountId(Long userId, boolean create) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(LangText.of(
+                        "账号不存在", "Account not found")));
+        requireNotReviewAccount(user);
+
+        Optional<AccountBinding> existing = accountBindingRepository.findByUserId(userId);
+        if (existing.isPresent()) {
+            return existing.get().getExternalAccountId();
+        }
+        return bindFromVerifiedIdentity(user, create);
+    }
+
+    /**
+     * 解析 accountId 后执行一次上游调用；上游回 NOT_FOUND 且这次用的是<b>既有绑定</b>时，
+     * 清掉那行绑定重解析一次（绑定自愈）。
+     *
+     * <p>为什么需要自愈：{@link #requireAccountId} 命中既有绑定就直接返回，官网那侧账户被
+     * 注销之后这行绑定永远指向一个不存在的账户，用户此后<b>永久</b>只能看到「未找到对应的
+     * 统一账户」，App 里没有任何自救路径。{@code AwdkLoginService.resolveUser} 对
+     * 「绑定指向的用户已被删除」早有同款自愈分支，这里照抄它的思路，只是方向相反
+     * （那边是本地用户没了，这边是官网账户没了）。
+     *
+     * <p>只重试<b>一次</b>：重解析回来的若还是同一个 accountId（官网账户其实还在，404 来自
+     * 别的原因），第二次照样失败就如实报错，不做无限循环。
+     *
+     * <p>删绑定会顺带影响 {@code MobileTransferService.tryRefund}（它按 userId 找绑定退款）：
+     * 但走到这里的前提是官网侧那个账户已经不存在，退款本来就退不回去，而「永久卡死」是更坏的结果。
+     */
+    private <T> T callWithAccount(Long userId, boolean create, boolean healStaleBinding,
+                                  Function<String, T> call) {
+        boolean fromExistingBinding = accountBindingRepository.findByUserId(userId).isPresent();
+        String accountId = requireAccountId(userId, create);
+        try {
+            return call.apply(accountId);
+        } catch (MobileBillingClient.MobileBillingException e) {
+            boolean stale = healStaleBinding
+                    && fromExistingBinding
+                    && e.getKind() == MobileBillingKind.NOT_FOUND
+                    && dropStaleBinding(userId, accountId);
+            if (!stale) {
+                throw translate(e);
+            }
+            log.warn("绑定指向的统一账户在官网已不存在，清掉绑定并重新解析：userId={}", userId);
+            String refreshed = requireAccountId(userId, create);
+            try {
+                return call.apply(refreshed);
+            } catch (MobileBillingClient.MobileBillingException retry) {
+                throw translate(retry);
+            }
+        }
+    }
+
+    /** 删掉这行绑定；只在它仍然指向我们刚用过的那个 accountId 时删（避免误删并发新建的行）。 */
+    private boolean dropStaleBinding(Long userId, String accountId) {
+        Optional<AccountBinding> row = accountBindingRepository.findByUserId(userId);
+        if (row.isEmpty() || !accountId.equals(row.get().getExternalAccountId())) {
+            return false;
+        }
+        accountBindingRepository.delete(row.get());
+        return true;
+    }
+
+    /**
+     * 充值总开关（复审 N1）。关时下单与查单一律 {@link MobileBillingKind#DISABLED}，
+     * <b>在到达 {@code create=true} 之前短路</b>，不解析身份也不发任何上游请求。
+     *
+     * <p>为什么需要它：{@code POST /api/mobile/billing/recharge} 是全站唯一走
+     * {@code create=true} 的调用方，随本期一起上线且是活的——任何持有有效
+     * {@code X-Session-Id} 的人直接打它，就会在官网建出一行含明文手机号的真账户并发注册赠额。
+     * 而 {@code AccountDeletionService} 依旧只删 Java 侧本地表、不通知官网，官网内部口也还
+     * 没有 delete action，于是 App 自己建的账号 App 内没有任何路径能删掉——就是复审 C1 要堵的
+     * App Store 5.1.1(v) 场景，只是触发点从「打开设置页」搬到了「直接打这个端点」。
+     * 本期四端都没有充值界面，「没人调」是社会性约束而不是服务端护栏，所以要有这一行。
+     *
+     * <p><b>什么时候才允许打开</b>：等 dev-board#434（官网账户注销传导）落地——注销时能把删除
+     * 传导到官网、官网内部口有 delete action 之后，把
+     * {@code mobile.billing.recharge-enabled}（env {@code MOBILE_BILLING_RECHARGE_ENABLED}）
+     * 置 true。在那之前打开等于把 5.1.1(v) 重新放出来。
+     */
+    private void requireRechargeEnabled() {
+        if (!rechargeEnabled) {
+            throw new MobileBillingFailureException(MobileBillingKind.DISABLED, LangText.of(
+                    "此服务器未开通统一账户充值",
+                    "Unified account top-up is not enabled on this server"));
+        }
+    }
+
+    /**
+     * App 审核专用账号一律拒绝。
+     *
+     * <p>它是一条认证旁路上的空账号（{@link ReviewAccountGate}，固定验证码写在审核备注里给
+     * 外部人看），放它去 resolve 等于按审核员的手机号/邮箱在官网建出一个真账户，
+     * 之后那把公开的 6 位码就成了进那个真账户的钥匙。
+     */
+    private void requireNotReviewAccount(User user) {
+        if (reviewAccount.matches(user.getPhone()) || reviewAccount.matches(user.getVerifiedEmail())) {
+            log.warn("审核演示账号请求统一账户功能，已拒绝：userId={}", user.getId());
+            throw new MobileBillingFailureException(MobileBillingKind.REVIEW_ACCOUNT, LangText.of(
+                    "审核演示账号不支持余额与充值",
+                    "Balance and top-up are not available for the review demo account"));
+        }
+    }
+
+    /**
+     * 未绑定：用已验证身份 resolve 并落绑定。手机号优先（大陆主路径），其次已验证邮箱。
+     *
+     * <p><b>标识回退</b>（复审）：第一版无条件 {@code phone != null ? null : email}，于是
+     * 「同时有手机号和已验证邮箱」的用户在国际站被硬拒——官网对不匹配站点能力的标识回
+     * {@code 400 phone_not_supported_on_site}，而那条路没有第二次机会。现在按顺序试，
+     * <b>只有 REJECTED 才换下一个标识</b>：那是官网在拒绝这个"标识"本身（站点不把手机号
+     * 当账号、号码/邮箱形态不合法），这个标识从来就用不了，换一个不构成"换了个人"。
+     * <b>NOT_FOUND 绝不回退</b>——那是官网权威地回答"按这个身份没有账户"，回退过去等于把
+     * 用户悄悄关联到另一个官网账户上。
+     */
+    private String bindFromVerifiedIdentity(User user, boolean create) {
+        String phone = trimToNull(user.getPhone());
+        // 资料字段 email 不唯一也未必验过，只认 verifiedEmail
+        String email = trimToNull(user.getVerifiedEmail());
+        if (phone == null && email == null) {
+            throw new MobileBillingFailureException(MobileBillingKind.NOT_CONNECTED, LangText.of(
+                    "该账号还没有已验证的手机号或邮箱，无法关联统一账户",
+                    "This account has no verified phone or email yet, so it cannot be linked to a unified account"));
+        }
+
+        // {phone, email}：恰好一个非 null，顺序即优先级
+        List<String[]> attempts = new ArrayList<>(2);
+        if (phone != null) attempts.add(new String[]{phone, null});
+        if (email != null) attempts.add(new String[]{null, email});
+
+        String accountId = null;
+        for (int i = 0; i < attempts.size(); i++) {
+            try {
+                accountId = billing.resolveAccountId(attempts.get(i)[0], attempts.get(i)[1], create);
+                break;
+            } catch (MobileBillingClient.MobileBillingException e) {
+                if (e.getKind() == MobileBillingKind.REJECTED && i + 1 < attempts.size()) {
+                    log.info("统一账户 resolve 拒绝了第 {} 个标识，换下一个再试：userId={}, error={}",
+                            i + 1, user.getId(), e.getMachineError());
+                    continue;
+                }
+                throw resolveFailure(e);
+            }
+        }
+
+        if (!StringUtils.hasText(accountId)) {
+            // 200 但没给 accountId：上游异常，不是"这个人没有账户"（红线 7）
+            log.warn("官网 resolve 未返回 accountId：userId={}", user.getId());
+            throw new MobileBillingFailureException(MobileBillingKind.UNAVAILABLE, LangText.of(
+                    "账户关联失败，请稍后重试", "Failed to link the account, please try again later"));
+        }
+        return saveBinding(user.getId(), accountId.trim());
+    }
+
+    /**
+     * resolve 的失败翻译：官网回"按这个身份查无账户"（{@code create=false} 时的带 body 404）
+     * 表示<b>这个登录账号还没有统一账户</b>，那是 NOT_CONNECTED 而不是 NOT_FOUND——
+     * NOT_FOUND 的语义留给"绑定指向的账户没了"。其余原样透传。
+     */
+    private MobileBillingFailureException resolveFailure(MobileBillingClient.MobileBillingException e) {
+        if (e.getKind() == MobileBillingKind.NOT_FOUND) {
+            return new MobileBillingFailureException(MobileBillingKind.NOT_CONNECTED, LangText.of(
+                    "该账号还没有关联的统一账户",
+                    "This account is not linked to a unified account yet"));
+        }
+        return translate(e);
+    }
+
+    /**
+     * 落绑定。{@code account_binding} 对 external_account_id 有唯一约束：
+     * 已被<b>别的</b> userId 绑走时直接拒绝，绝不改绑——改绑就是把充值记到另一个人头上。
+     *
+     * <p>本方法刻意不带 {@code @Transactional}：撞唯一约束后要能在同一次调用里读回对方
+     * 已提交的行，外层若有事务会被标 rollback-only（教训见 mobile-sync.md 地雷 6）。
+     */
+    private String saveBinding(Long userId, String accountId) {
+        Optional<AccountBinding> owner = accountBindingRepository.findByExternalAccountId(accountId);
+        if (owner.isPresent()) {
+            if (userId.equals(owner.get().getUserId())) {
+                return accountId;
+            }
+            log.warn("统一账户已绑定到另一个用户，拒绝改绑：userId={} 已绑 userId={}",
+                    userId, owner.get().getUserId());
+            throw new MobileBillingFailureException(MobileBillingKind.REJECTED, LangText.of(
+                    "该统一账户已与另一个登录账号关联，请用原账号登录后充值",
+                    "This unified account is already linked to another login; please sign in with that account"));
+        }
+        AccountBinding row = new AccountBinding();
+        row.setUserId(userId);
+        row.setExternalAccountId(accountId);
+        row.setCreatedAt(LocalDateTime.now());
+        try {
+            accountBindingRepository.save(row);
+        } catch (DataIntegrityViolationException e) {
+            // 并发首调：另一个请求已写入，读回它的结果即可
+            return accountBindingRepository.findByUserId(userId)
+                    .map(AccountBinding::getExternalAccountId)
+                    .orElseThrow(() -> new MobileBillingFailureException(MobileBillingKind.UNAVAILABLE,
+                            LangText.of("账户关联失败，请稍后重试",
+                                    "Failed to link the account, please try again later")));
+        }
+        log.info("手机端统一账户绑定建立：userId={}", userId);
+        return accountId;
+    }
+
+    // ==================== 内部 ====================
+
+    private void cacheBalance(Long userId, MobileBillingClient.BalanceResult value, long nowMillis) {
+        if (balanceCache.size() >= MAX_CACHE_ENTRIES) {
+            balanceCache.entrySet().removeIf(e -> !e.getValue().fresh(nowMillis));
+        }
+        balanceCache.put(userId, new CachedBalance(value, nowMillis + BALANCE_TTL.toMillis()));
+    }
+
+    /** 测试与"换账号"场景用：作废某个用户的余额缓存。 */
+    void invalidateBalance(Long userId) {
+        balanceCache.remove(userId);
+    }
+
+    /**
+     * 换壳成 {@link MobileBillingFailureException}（全局处理器 →
+     * HTTP 200 + {@code {code:1, kind, outTradeNo?, message}}）。
+     *
+     * <p><b>kind 与 outTradeNo 必须原样带过去</b>（复审 C2/C4）。第一版这里只留 message，
+     * 把 Kind 和官网 409 一起回的 outTradeNo 全丢了——用户刚付过钱却被告知"充值请求被拒绝"，
+     * 且再也拿不到单号去查单；三端则只能去猜中文串。
+     */
+    private MobileBillingFailureException translate(MobileBillingClient.MobileBillingException e) {
+        return new MobileBillingFailureException(e.getKind(), e.getMessage(), e.getOutTradeNo());
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) return null;
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -565,6 +565,24 @@ mobile:
     billing:
       base-url: ${TRANSFER_BILLING_BASE_URL:}
       secret: ${TRANSFER_BILLING_SECRET:}
+  # 手机端统一账户余额/充值的内部记账口（dev-board#425）：官网
+  # POST {base-url}/api/internal/account，头 X-Internal-Secret。两个键任一为空 = 本服务器
+  # 未开通，/api/mobile/billing/* 一律给可读 code:1「此服务器未开通统一账户充值」且不发请求。
+  # secret 与 TRANSFER_BILLING_SECRET 是两把不同的密钥，不要复用（官网侧
+  # AWD_MOBILE_BILLING_SECRET，只在服务器 env 里配，别入库）。
+  billing:
+    base-url: ${MOBILE_BILLING_BASE_URL:}
+    secret: ${MOBILE_BILLING_SECRET:}
+    # 充值下单/查单的总开关（dev-board#425 二轮复审 N1）。默认关，且在
+    # **dev-board#434（官网账户注销传导）落地之前一律不许打开**。
+    # 理由：POST /api/mobile/billing/recharge 是全站唯一 create=true 的调用方——任何持有
+    # 有效 X-Session-Id 的人直接打它，就会在官网建出一行含明文手机号的真账户并发注册赠额；
+    # 而 AccountDeletionService 只删 Java 侧本地表、不通知官网，官网内部口也还没有 delete
+    # action，于是「App 自己建的账号 App 内删不掉」，直接撞 App Store 5.1.1(v) 与个人信息
+    # 保护法的删除权。本期四端都没有充值界面，靠「没人调」挡不住，所以要有这个服务端开关。
+    # 关时 /recharge 与 /recharge/status 在到达 create=true 之前短路成 kind=DISABLED，
+    # 不发任何上游请求；GET /balance 是只读的（create=false，永不建号），不受本开关影响。
+    recharge-enabled: ${MOBILE_BILLING_RECHARGE_ENABLED:false}
 
 # 文件存储配置
 storage:

--- a/backend/src/main/resources/openapi/mobile-v1.yaml
+++ b/backend/src/main/resources/openapi/mobile-v1.yaml
@@ -35,6 +35,41 @@ components:
         usage: { type: object, additionalProperties: true, description: "code=4003（额度已满）附带的用量明细" }
         gatewayKind: { type: string, description: "code=1（平台网关失败）附带" }
         canUseOwnKey: { type: boolean, description: "code=1（平台网关失败）附带，是否可用自备 Key 绕过" }
+        kind:
+          type: string
+          enum: [DISABLED, UNAVAILABLE, NOT_CONNECTED, NOT_FOUND, REJECTED, REVIEW_ACCOUNT, ALREADY_PAID, IDEMPOTENCY_CONFLICT]
+          description: |
+            code=1 时 /api/mobile/billing/* 附带的**机器可读判别位**（dev-board#425）。
+            **四端一律按它分支，禁止匹配 message 措辞**——message 经服务端 LangText 在英文部署下
+            会整条变成英文，按中文串做分支必然落空；code 也永远是 1，判 code 分不出这八种情况。
+            message 只用于兜底展示。
+
+            每条末尾方括号里是**余额那一行**的渲染裁定，唯一来源是移动仓
+            contract/schema/billing.schema.json 的说明段（四端逐条对齐，各自有测试钉住）。
+            判据是**这一态会不会自己恢复**：终态一律整行不渲染，绝不能渲染成
+            「余额暂时读不到，稍后再试」——那是让用户去重试一句永不改变的报错。
+              DISABLED             本服务器没配 mobile.billing.*，压根没开通
+                                   [整行不渲染，充值入口一并收起]。**未配 env 即此态，也就是四端一发版时的默认生产状态**
+              UNAVAILABLE          上游不可用（网络/5xx/官网空体 404 即密钥或 env 配错）
+                                   [显示 balance.unavailable，稍后重试]，**绝不能显示成「没有账户」或「余额 0」**
+              NOT_CONNECTED        这个登录账号还没有统一账户（无已验证身份，或官网按该身份查无账户）
+                                   [整行不渲染]。读余额一律 create=false，服务端不会替用户建号
+              NOT_FOUND            官网明确回「查无此物」（accountId 已注销 / 单号不属于该账户）
+                                   [显示 balance.unavailable]
+              REJECTED             官网明确拒绝的业务错误，或统一账户已绑给别的登录账号
+                                   [显示 balance.unavailable]
+              REVIEW_ACCOUNT       App 审核演示账号，余额与充值一律不可用
+                                   [整行不渲染]。审核员进设置页看到的必须是干净的一页，不是一行报错
+              ALREADY_PAID         该幂等键的单子已支付 → 带 outTradeNo 转去查单，别重新下单
+                                   [与余额无关：只出现在下单/查单路径]
+              IDEMPOTENCY_CONFLICT 同一把幂等键换了金额/类型 → 带 outTradeNo [同上]
+              （kind 缺席）        非 billing 专有的失败走通用 handler
+                                   [显示 balance.unavailable]，不得当成「没有账户」
+        outTradeNo:
+          type: string
+          description: |
+            仅 kind=ALREADY_PAID / IDEMPOTENCY_CONFLICT 时出现：官网连同 409 一起回的既有商户订单号。
+            这是「App 被杀、本地没存下单号」的恢复路径，客户端拿它调 /recharge/status 查单。
     RelayProject:
       type: object
       required: [deviceId, key, name]
@@ -95,6 +130,46 @@ components:
         code: { type: integer }
         message: { type: string, nullable: true }
         data: { $ref: '#/components/schemas/LoginData' }
+    BillingBalance:
+      type: object
+      description: |
+        统一账户余额（dev-board#425）。权威在官网仓（credit_lots + wallet_ledger），
+        云后端经内部记账口 POST /api/internal/account 读取，服务端带 30 秒 TTL 缓存。
+
+        **展示口径（四端逐字符一致）**：符号 + balanceCents/100 固定两位小数、**不带千分位**、
+        **不跟随设备 locale**；符号按 currency 取（CNY→¥、USD→$），任何一端都不得写死 ¥。
+        唯一来源是移动仓 contract/schema/billing.schema.json，期望串在 fixtures/billing.json
+        的 balance[].display（三端各自的格式化函数与它对拍）。
+      required: [balanceCents, currency, plan]
+      properties:
+        balanceCents: { type: integer, format: int64, description: 余额，整数分（Credits 1 元 = 100 分） }
+        currency: { type: string, enum: [CNY, USD], description: 站点币种，由部署站点决定 }
+        plan:
+          type: string
+          nullable: true
+          description: |
+            计费档位，权威侧 lib/wallet.ts 的 getPlan() 只返回 `paid` / `free`——**不是套餐名**，
+            也基本不会为 null（只有上游没给这个字段时才是 null）。任何一端都不要把它当套餐名直接渲染。
+    RechargeOrder:
+      type: object
+      description: |
+        充值单。present=qrcode 时 codeUrl/qrCode 有值，present=redirect 时 redirectUrl 有值；
+        不适用的字段不出现在响应里。
+      required: [present, outTradeNo, amountCents]
+      properties:
+        present: { type: string, enum: [qrcode, redirect] }
+        outTradeNo: { type: string, description: 商户订单号，查状态用 }
+        amountCents: { type: integer, format: int64, description: 下单金额，整数分 }
+        codeUrl: { type: string, description: present=qrcode：支付链接原文 }
+        qrCode: { type: string, description: present=qrcode：二维码图（data URI） }
+        redirectUrl: { type: string, description: present=redirect：跳转地址 }
+    RechargeStatus:
+      type: object
+      required: [status, paid, amountCents]
+      properties:
+        status: { type: string, enum: [pending, paid, closed, expired] }
+        paid: { type: boolean, description: 已到账；置 true 后服务端作废该用户的余额缓存 }
+        amountCents: { type: integer, format: int64 }
     CaptureManifest:
       type: object
       description: |
@@ -341,3 +416,63 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Envelope' }
+  /api/mobile/billing/balance:
+    get:
+      summary: 手机端：统一账户余额（裸对象）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      responses:
+        "200":
+          description: |
+            裸对象；未登录 Envelope(4010)；未绑定/无已验证身份/审核账号/官网不可达
+            一律 Envelope(code 1) + kind + 可读 message（绝不用余额 0 冒充）。
+            **读余额永不在官网建号**（内部口 resolve 传 create=false）：查无此账户回
+            kind=NOT_CONNECTED，客户端据此不渲染余额那一行。建号只发生在用户显式发起充值时。
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/BillingBalance'
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/billing/recharge:
+    post:
+      summary: 手机端：创建充值单（裸对象）
+      parameters: [{ $ref: '#/components/parameters/SessionId' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [amountCents, idempotencyKey]
+              properties:
+                amountCents: { type: integer, format: int64, description: 充值金额，整数分，须 > 0 }
+                idempotencyKey:
+                  type: string
+                  pattern: '^[A-Za-z0-9_-]{8,64}$'
+                  description: |
+                    **客户端生成并落盘后传入**（扛 App 被杀）。服务端不代生成，缺失即 code 1。
+                    官网 orders 表有 UNIQUE(userId, idempotencyKey) 兜底。
+      responses:
+        "200":
+          description: 裸对象；未登录 Envelope(4010)；业务错误 Envelope(code 1)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RechargeOrder'
+                  - $ref: '#/components/schemas/Envelope'
+  /api/mobile/billing/recharge/status:
+    get:
+      summary: 手机端：查充值单状态（裸对象）
+      parameters:
+        - { $ref: '#/components/parameters/SessionId' }
+        - { name: outTradeNo, in: query, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: 裸对象；未登录 Envelope(4010)；业务错误 Envelope(code 1)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RechargeStatus'
+                  - $ref: '#/components/schemas/Envelope'

--- a/backend/src/test/java/com/checkba/MobileApiContractTest.java
+++ b/backend/src/test/java/com/checkba/MobileApiContractTest.java
@@ -3,7 +3,11 @@ package com.checkba;
 import com.atlassian.oai.validator.OpenApiInteractionValidator;
 import com.atlassian.oai.validator.report.LevelResolver;
 import com.atlassian.oai.validator.report.ValidationReport;
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.repository.AccountBindingRepository;
 import com.checkba.service.ai.tools.WebTools;
+import com.checkba.service.mobile.MobileBillingClient;
+import com.checkba.service.mobile.MobileBillingKind;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,17 +22,23 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import static com.atlassian.oai.validator.mockmvc.OpenApiValidationMatchers.openApi;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * API 契约测试：手机端调用的六个端点，真实响应必须合 src/main/resources/openapi/mobile-v1.yaml。
+ * API 契约测试：手机端调用的各端点，真实响应必须合 src/main/resources/openapi/mobile-v1.yaml。
  * 只校验响应（请求级别 IGNORE，multipart 请求校验在该库里不稳）。
  * 环境配方同 MobileRelayEndpointIntegrationTest。移动仓 contract/api/ 钉的是这份 YAML 的副本。
  * <p>校验器（swagger-request-validator）默认 additionalProperties: false：mobile-v1.yaml 是响应字段的
@@ -37,7 +47,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:h2:mem:mobile-api-contract;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
         "security.local-mode=false",
-        "storage.local.root-path=${java.io.tmpdir}/mobile-api-contract-store"
+        "storage.local.root-path=${java.io.tmpdir}/mobile-api-contract-store",
+        // 充值总开关生产默认是关（复审 N1，等 dev-board#434 才允许开）；这里显式打开，
+        // 否则 /recharge 与 /recharge/status 的成功响应形状就没有任何地方对着 YAML 校验了。
+        // 关着时的响应是 Envelope(code:1,kind:DISABLED)，形状与下面已经校过的 UNAVAILABLE 一模一样，
+        // 开关本身的行为由 MobileBillingRechargeDisabledTest 守。
+        "mobile.billing.recharge-enabled=true"
 })
 @AutoConfigureMockMvc
 @ActiveProfiles("desktop")
@@ -47,7 +62,11 @@ class MobileApiContractTest {
 
     @Autowired private MockMvc mvc;
     @Autowired private ObjectMapper om;
+    @Autowired private AccountBindingRepository accountBindingRepository;
     @MockBean private WebTools webTools;
+    // 统一账户余额/充值（dev-board#425）的上游是官网内部记账口，契约测试只关心响应形状，
+    // 用桩给出三个成功形状即可，不打网络
+    @MockBean private MobileBillingClient billing;
 
     @BeforeAll
     static void loadSpec() throws Exception {
@@ -118,6 +137,91 @@ class MobileApiContractTest {
         mvc.perform(get("/api/mobile/media/usage").header("X-Session-Id", sid))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.quotaBytes").isNumber())
+                .andExpect(openApi().isValid(validator));
+    }
+
+    @Test
+    void billingEndpointsMatchSpec() throws Exception {
+        String sid = register("contract_billing_" + System.nanoTime());
+        Long userId = om.readTree(mvc.perform(get("/api/auth/me").header("X-Session-Id", sid))
+                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString())
+                .path("data").path("id").asLong();
+
+        // 未登录信封（这一组也走 4010）
+        mvc.perform(get("/api/mobile/billing/balance"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(4010))
+                .andExpect(openApi().isValid(validator));
+
+        // 已桥接用户：直接放一行绑定，绕开 resolve（resolve 的红线在 MobileBillingServiceTest 里护）
+        AccountBinding binding = new AccountBinding();
+        binding.setUserId(userId);
+        binding.setExternalAccountId("acct-contract-" + userId);
+        binding.setCreatedAt(LocalDateTime.now());
+        accountBindingRepository.save(binding);
+
+        when(billing.balance(anyString()))
+                .thenReturn(new MobileBillingClient.BalanceResult(12345L, "CNY", "paid"));
+        when(billing.createRecharge(anyString(), anyLong(), anyString()))
+                .thenReturn(new MobileBillingClient.RechargeOrder(
+                        "qrcode", "OT-contract-1", 5000L, "weixin://wxpay/bizpayurl?pr=x", null, null));
+        when(billing.queryRecharge(anyString(), anyString()))
+                .thenReturn(new MobileBillingClient.RechargeStatus("pending", false, 5000L));
+
+        mvc.perform(get("/api/mobile/billing/balance").header("X-Session-Id", sid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balanceCents").value(12345))
+                .andExpect(openApi().isValid(validator));
+
+        mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"amountCents":5000,"idempotencyKey":"idem-contract-0001"}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.outTradeNo").value("OT-contract-1"))
+                .andExpect(openApi().isValid(validator));
+
+        mvc.perform(get("/api/mobile/billing/recharge/status")
+                        .param("outTradeNo", "OT-contract-1").header("X-Session-Id", sid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("pending"))
+                .andExpect(openApi().isValid(validator));
+
+        // 业务错误也在契约里：缺 idempotencyKey → 200 + Envelope(code 1)
+        mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"amountCents":5000}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(openApi().isValid(validator));
+
+        // 机器可读判别位（dev-board#425 复审 C2）：四端按 kind 分支，不许猜 message 措辞
+        doThrow(new MobileBillingClient.MobileBillingException(
+                MobileBillingKind.UNAVAILABLE, "账户服务暂不可用，请稍后再试"))
+                .when(billing).createRecharge(anyString(), anyLong(), eq("idem-contract-down1"));
+        mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"amountCents":5000,"idempotencyKey":"idem-contract-down1"}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.kind").value("UNAVAILABLE"))
+                .andExpect(openApi().isValid(validator));
+
+        // 已付单的 409 要连 outTradeNo 一起进信封（复审 C4）：App 被杀后靠它转去查单
+        doThrow(new MobileBillingClient.MobileBillingException(
+                MobileBillingKind.ALREADY_PAID, "这笔充值已经支付成功，请查看订单状态",
+                "order_already_paid", "RECHARGE20260904X"))
+                .when(billing).createRecharge(anyString(), anyLong(), eq("idem-contract-paid1"));
+        mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"amountCents":5000,"idempotencyKey":"idem-contract-paid1"}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.kind").value("ALREADY_PAID"))
+                .andExpect(jsonPath("$.outTradeNo").value("RECHARGE20260904X"))
                 .andExpect(openApi().isValid(validator));
     }
 

--- a/backend/src/test/java/com/checkba/service/mobile/HttpMobileBillingClientTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/HttpMobileBillingClientTest.java
@@ -1,0 +1,203 @@
+package com.checkba.service.mobile;
+
+import com.checkba.service.mobile.MobileBillingClient.MobileBillingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@link HttpMobileBillingClient} 的纯单测（不起 Spring）：未配置即短路、连不上即 UNAVAILABLE、
+ * resolve 的"二选一恰好一个"前置条件，以及<b>失败分类</b>。护的是 dev-board#425 最容易退化的几条——
+ * 未配置时偷偷发请求、上游故障被吞成"没有账户"、409 的 outTradeNo 被丢掉。
+ *
+ * <p>失败分类用 JDK 自带的 {@link HttpServer} 起一个本机桩服务，回真实的状态码与响应体：
+ * 这几条的判据就在 HTTP 层（空体 vs 带 body 的 404），用 mock 绕过去等于没测。
+ */
+class HttpMobileBillingClientTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    /** 端口 1 恒连不上，用来制造"连得上地址、连不上服务"的网络失败。 */
+    private static final String DEAD_BASE = "http://127.0.0.1:1";
+
+    private HttpServer server;
+    private String base;
+    /** 桩服务当次要回的 {状态码, 响应体（null = 空体）}。 */
+    private final AtomicInteger stubStatus = new AtomicInteger(200);
+    private final AtomicReference<String> stubBody = new AtomicReference<>("{}");
+    /** 最后一次收到的请求体，用来断言 create 位真的上行了。 */
+    private final AtomicReference<String> lastRequest = new AtomicReference<>();
+
+    @BeforeEach
+    void startStub() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/internal/account", exchange -> {
+            lastRequest.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            String body = stubBody.get();
+            byte[] out = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+            if (out.length == 0) {
+                // -1 = 明确的"没有响应体"，即官网对 env 未配/secret 不符回的那种空体 404
+                exchange.sendResponseHeaders(stubStatus.get(), -1);
+            } else {
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(stubStatus.get(), out.length);
+                exchange.getResponseBody().write(out);
+            }
+            exchange.close();
+        });
+        server.start();
+        base = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopStub() {
+        server.stop(0);
+    }
+
+    private HttpMobileBillingClient stubbed(int status, String body) {
+        stubStatus.set(status);
+        stubBody.set(body);
+        return new HttpMobileBillingClient(base, "secret", om);
+    }
+
+    // ==================== 短路与网络 ====================
+
+    @Test
+    @DisplayName("base-url/secret 任一未配置：四个动作一律 DISABLED，且不发请求")
+    void unconfiguredShortCircuitsToDisabled() {
+        for (HttpMobileBillingClient c : new HttpMobileBillingClient[]{
+                new HttpMobileBillingClient("", "", om),
+                new HttpMobileBillingClient(DEAD_BASE, "", om),
+                new HttpMobileBillingClient("", "s", om)}) {
+            assertEquals(MobileBillingKind.DISABLED,
+                    assertThrows(MobileBillingException.class, () -> c.resolveAccountId("13900000000", null, false)).getKind());
+            assertEquals(MobileBillingKind.DISABLED,
+                    assertThrows(MobileBillingException.class, () -> c.balance("acct-x")).getKind());
+            assertEquals(MobileBillingKind.DISABLED,
+                    assertThrows(MobileBillingException.class, () -> c.createRecharge("acct-x", 5000, "idem-0001")).getKind());
+            assertEquals(MobileBillingKind.DISABLED,
+                    assertThrows(MobileBillingException.class, () -> c.queryRecharge("acct-x", "no-1")).getKind());
+        }
+    }
+
+    @Test
+    @DisplayName("官网连不上：UNAVAILABLE，绝不退化成 NOT_FOUND / 余额 0")
+    void unreachableUpstreamIsUnavailable() {
+        HttpMobileBillingClient c = new HttpMobileBillingClient(DEAD_BASE, "secret", om);
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class, () -> c.balance("acct-x")).getKind());
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class, () -> c.createRecharge("acct-x", 5000, "idem-0001")).getKind());
+    }
+
+    @Test
+    @DisplayName("resolve 的 phone/email 必须恰好给一个：给两个或都不给是调用方编程错误")
+    void resolveRequiresExactlyOneIdentity() {
+        HttpMobileBillingClient c = new HttpMobileBillingClient(DEAD_BASE, "secret", om);
+        assertThrows(IllegalStateException.class, () -> c.resolveAccountId("13900000000", "a@example.com", false));
+        assertThrows(IllegalStateException.class, () -> c.resolveAccountId(null, null, false));
+        assertThrows(IllegalStateException.class, () -> c.resolveAccountId("  ", " ", false));
+    }
+
+    // ==================== create 位（复审 C1） ====================
+
+    @Test
+    @DisplayName("resolve 把 create 位显式上行：读路径必须是 false，别指望官网的默认值")
+    void resolveSendsCreateFlagExplicitly() {
+        HttpMobileBillingClient c = stubbed(200, "{\"accountId\":\"acct-1\"}");
+
+        assertEquals("acct-1", c.resolveAccountId("13900000000", null, false));
+        assertTrue(lastRequest.get().contains("\"create\":false"), lastRequest.get());
+
+        assertEquals("acct-1", c.resolveAccountId("13900000000", null, true));
+        assertTrue(lastRequest.get().contains("\"create\":true"), lastRequest.get());
+    }
+
+    // ==================== 404 的两类（复审 C3） ====================
+
+    @Test
+    @DisplayName("空体 404 = 鉴权/配置失败：UNAVAILABLE，绝不是「没有账户」")
+    void emptyBody404IsUnavailableNotNotFound() {
+        HttpMobileBillingClient c = stubbed(404, null);
+        MobileBillingException e =
+                assertThrows(MobileBillingException.class, () -> c.balance("acct-x"));
+        assertEquals(MobileBillingKind.UNAVAILABLE, e.getKind());
+    }
+
+    @Test
+    @DisplayName("带 body 的 404 = 真业务查无此物：NOT_FOUND，machineError 留给日志")
+    void jsonBody404IsNotFound() {
+        HttpMobileBillingClient c = stubbed(404, "{\"error\":\"account_not_found\"}");
+        MobileBillingException e =
+                assertThrows(MobileBillingException.class, () -> c.balance("acct-x"));
+        assertEquals(MobileBillingKind.NOT_FOUND, e.getKind());
+        assertEquals("account_not_found", e.getMachineError());
+    }
+
+    @Test
+    @DisplayName("404 回了一页 HTML（反代/网关）：按不可解析处理，仍是 UNAVAILABLE")
+    void html404IsUnavailable() {
+        HttpMobileBillingClient c = stubbed(404, "<html><body>404 Not Found</body></html>");
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class, () -> c.balance("acct-x")).getKind());
+    }
+
+    // ==================== 409 与 outTradeNo（复审 C4） ====================
+
+    @Test
+    @DisplayName("409 order_already_paid：ALREADY_PAID 且把 outTradeNo 带出来")
+    void alreadyPaidCarriesOutTradeNo() {
+        HttpMobileBillingClient c = stubbed(409,
+                "{\"error\":\"order_already_paid\",\"outTradeNo\":\"RECHARGE202609040001\"}");
+        MobileBillingException e = assertThrows(MobileBillingException.class,
+                () -> c.createRecharge("acct-x", 5000, "idem-0001"));
+        assertEquals(MobileBillingKind.ALREADY_PAID, e.getKind());
+        assertEquals("RECHARGE202609040001", e.getOutTradeNo());
+    }
+
+    @Test
+    @DisplayName("409 idempotency_conflict：IDEMPOTENCY_CONFLICT 且带 outTradeNo")
+    void idempotencyConflictCarriesOutTradeNo() {
+        HttpMobileBillingClient c = stubbed(409,
+                "{\"error\":\"idempotency_conflict\",\"outTradeNo\":\"RECHARGE202609040002\"}");
+        MobileBillingException e = assertThrows(MobileBillingException.class,
+                () -> c.createRecharge("acct-x", 5000, "idem-0001"));
+        assertEquals(MobileBillingKind.IDEMPOTENCY_CONFLICT, e.getKind());
+        assertEquals("RECHARGE202609040002", e.getOutTradeNo());
+    }
+
+    @Test
+    @DisplayName("其余 4xx → REJECTED；5xx → UNAVAILABLE")
+    void otherFailuresKeepTheirOwnKind() {
+        HttpMobileBillingClient rejected = stubbed(400, "{\"error\":\"phone_not_supported_on_site\"}");
+        MobileBillingException e = assertThrows(MobileBillingException.class,
+                () -> rejected.resolveAccountId("13900000000", null, false));
+        assertEquals(MobileBillingKind.REJECTED, e.getKind());
+        assertEquals("phone_not_supported_on_site", e.getMachineError());
+
+        HttpMobileBillingClient down = stubbed(500, "{\"error\":\"internal_error\"}");
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class, () -> down.balance("acct-x")).getKind());
+    }
+
+    @Test
+    @DisplayName("plan 是 paid/free 的计费档位，不是套餐名；上游不给才是 null")
+    void planIsBillingTierNotPlanName() {
+        assertEquals("paid", stubbed(200,
+                "{\"balanceCents\":123,\"currency\":\"CNY\",\"plan\":\"paid\"}").balance("a").plan());
+        assertEquals("free", stubbed(200,
+                "{\"balanceCents\":0,\"currency\":\"CNY\",\"plan\":\"free\"}").balance("a").plan());
+        assertNull(stubbed(200, "{\"balanceCents\":0,\"currency\":\"CNY\"}").balance("a").plan());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileBillingRechargeDisabledTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileBillingRechargeDisabledTest.java
@@ -1,0 +1,139 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.User;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.service.UserService;
+import com.checkba.service.ai.tools.WebTools;
+import com.checkba.service.mobile.MobileBillingClient.BalanceResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * 充值总开关<b>关着</b>（= application.yml 的生产默认值）时的行为（dev-board#425 复审 N1）。
+ *
+ * <p>本类刻意<b>不配</b> {@code mobile.billing.recharge-enabled}：它测的就是「什么都不配的
+ * 服务器上，充值是关的」。开关开着的那一半在 {@link MobileBillingServiceTest}
+ * （那边显式配了 {@code =true}）。两个类的属性集不同，因此各自一个 Spring 上下文——这是刻意
+ * 付的代价：默认值是这条护栏的全部意义，用一个「传了 false 进构造器」的纯单测证不了它。
+ *
+ * <p>为什么要有这个开关：{@code POST /api/mobile/billing/recharge} 是全站唯一走
+ * {@code create=true} 的调用方，随本期一起上线且是活的端点。任何持有有效 {@code X-Session-Id}
+ * 的人直接打它，就会在官网建出一行含明文手机号的真账户并发注册赠额；而注销只删 Java 侧、
+ * 不通知官网，App 自己建的账号 App 内删不掉——就是复审 C1 那条 App Store 5.1.1(v)，
+ * 只是触发点从「打开设置页」搬到了「直接打这个端点」。四端没有充值界面 = 没人调，不是护栏。
+ *
+ * <p><b>开关要等 dev-board#434（官网账户注销传导）落地后才允许打开。</b>
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:mobile-billing-off-test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.local-mode=false",
+        "storage.local.root-path=${java.io.tmpdir}/mobile-billing-off-test-store"
+})
+@ActiveProfiles("desktop")
+class MobileBillingRechargeDisabledTest {
+
+    @Autowired
+    private MobileBillingService service;
+    @Autowired
+    private AccountBindingRepository accountBindingRepository;
+    @Autowired
+    private UserService userService;
+
+    @MockBean
+    private MobileBillingClient billing;
+    // 同 MobileBillingServiceTest：完整上下文会让 WebTools 尝试联网初始化搜索工具
+    @MockBean
+    private WebTools webTools;
+
+    private static final AtomicInteger SEQ = new AtomicInteger(0);
+
+    private User phoneUser() {
+        return userService.findOrCreateByPhone(String.format("137%08d", 20_000_000 + SEQ.incrementAndGet()))
+                .user();
+    }
+
+    private void bind(Long userId, String accountId) {
+        AccountBinding row = new AccountBinding();
+        row.setUserId(userId);
+        row.setExternalAccountId(accountId);
+        row.setCreatedAt(LocalDateTime.now());
+        accountBindingRepository.save(row);
+    }
+
+    @Test
+    @DisplayName("默认关：下单在到达 create=true 之前短路成 DISABLED，不 resolve、不建号、不落绑定")
+    void createRechargeIsDisabledBeforeReachingCreateTrue() {
+        User u = phoneUser();
+
+        MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
+                () -> service.createRecharge(u.getId(), 5000L, "idem-off-0001"));
+
+        assertEquals(MobileBillingKind.DISABLED, e.getKind());
+        // 一个上游请求都没发出去——建号那一位当然更没被置过 true
+        verify(billing, never()).resolveAccountId(any(), any(), anyBoolean());
+        verify(billing, never()).createRecharge(anyString(), anyLong(), anyString());
+        verifyNoInteractions(billing);
+        assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("默认关：查单同样 DISABLED，不打上游")
+    void queryRechargeIsDisabled() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-off-query-" + u.getId());
+
+        assertEquals(MobileBillingKind.DISABLED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.queryRecharge(u.getId(), "OT-off-1")).getKind());
+        verifyNoInteractions(billing);
+    }
+
+    @Test
+    @DisplayName("开关先于一切：参数怎么填都是 DISABLED，不会先报 idempotencyKey / 金额的错")
+    void switchShortCircuitsBeforeArgumentValidation() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-off-args-" + u.getId());
+
+        for (Object[] bad : new Object[][]{{null, null}, {0L, "short"}, {-1L, "has space!!"}}) {
+            assertEquals(MobileBillingKind.DISABLED,
+                    assertThrows(MobileBillingFailureException.class,
+                            () -> service.createRecharge(u.getId(), (Long) bad[0], (String) bad[1])).getKind());
+        }
+        assertEquals(MobileBillingKind.DISABLED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.queryRecharge(u.getId(), "非法单号!!")).getKind());
+        verifyNoInteractions(billing);
+    }
+
+    @Test
+    @DisplayName("余额不受这个开关影响：只读、create=false、本期就是要它能用")
+    void balanceStillWorksWhileRechargeIsOff() {
+        User u = phoneUser();
+        String accountId = "acct-off-balance-" + u.getId();
+        bind(u.getId(), accountId);
+        when(billing.balance(accountId)).thenReturn(new BalanceResult(12345L, "CNY", "paid"));
+
+        assertEquals(12345L, service.balance(u.getId()).balanceCents());
+        verify(billing).balance(accountId);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/mobile/MobileBillingServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileBillingServiceTest.java
@@ -1,0 +1,497 @@
+package com.checkba.service.mobile;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.User;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.UserService;
+import com.checkba.service.ai.tools.WebTools;
+import com.checkba.service.mobile.MobileBillingClient.BalanceResult;
+import com.checkba.service.mobile.MobileBillingClient.MobileBillingException;
+import com.checkba.service.mobile.MobileBillingClient.RechargeOrder;
+import com.checkba.service.mobile.MobileBillingClient.RechargeStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 手机端统一账户余额/充值服务（dev-board#425，spec §3.2）：账户桥接的四条红线
+ * （只用服务端已验证身份 resolve、审核账号拒、无身份拒、绝不改绑）、幂等键必须客户端传、
+ * 官网不可达的降级、余额缓存按 userId。
+ *
+ * <p>装配同 {@link MobileTransferServiceTest} 的 H2 配方；{@link MobileBillingClient}
+ * 用 @MockBean 换成可控桩，不真的打网络。审核账号旁路在本上下文里<b>开着</b>
+ * （auth.review-account.*），否则「审核账号被拒」这条根本走不到判据。
+ *
+ * <p><b>本类把充值总开关打开</b>（{@code mobile.billing.recharge-enabled=true}，复审 N1），
+ * 测的是「开关开着时的行为」——顺带钉住这个配置键真的能把功能打开（键名写错的话下面所有
+ * 充值用例会一起变成 DISABLED）。生产默认是<b>关</b>，那一半在
+ * {@link MobileBillingRechargeDisabledTest}（刻意不配这个键，走 application.yml 的默认值）。
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:mobile-billing-test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.local-mode=false",
+        "storage.local.root-path=${java.io.tmpdir}/mobile-billing-test-store",
+        "auth.review-account.identity=appreview@example.com,13800138000",
+        "auth.review-account.code=246813",
+        "mobile.billing.recharge-enabled=true"
+})
+@ActiveProfiles("desktop")
+class MobileBillingServiceTest {
+
+    @Autowired
+    private MobileBillingService service;
+    @Autowired
+    private AccountBindingRepository accountBindingRepository;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private MobileBillingClient billing;
+    // 完整上下文会让 WebTools 尝试联网初始化搜索工具，同 MobileTransferServiceTest 一样 mock 掉
+    @MockBean
+    private WebTools webTools;
+
+    /** 每个用例用独立的手机号/邮箱/accountId：上下文按配置缓存复用，同一个 H2 贯穿全类。 */
+    private static final AtomicInteger SEQ = new AtomicInteger(0);
+
+    @BeforeEach
+    void setUp() {
+        reset(billing);
+    }
+
+    private User phoneUser() {
+        return userService.findOrCreateByPhone(nextPhone()).user();
+    }
+
+    private static String nextPhone() {
+        return String.format("139%08d", 10_000_000 + SEQ.incrementAndGet());
+    }
+
+    private void bind(Long userId, String accountId) {
+        AccountBinding row = new AccountBinding();
+        row.setUserId(userId);
+        row.setExternalAccountId(accountId);
+        row.setCreatedAt(LocalDateTime.now());
+        accountBindingRepository.save(row);
+    }
+
+    // ==================== 桥接 ====================
+
+    @Test
+    @DisplayName("未绑定用户首次调用：拿服务端 User 上的手机号 resolve，并写入 account_binding")
+    void firstCallResolvesByServerSidePhoneAndCreatesBinding() {
+        User u = phoneUser();
+        String accountId = "acct-first-" + u.getId();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false))).thenReturn(accountId);
+        when(billing.balance(accountId)).thenReturn(new BalanceResult(12345L, "CNY", "pro"));
+
+        BalanceResult r = service.balance(u.getId());
+
+        assertEquals(12345L, r.balanceCents());
+        assertEquals("CNY", r.currency());
+        assertEquals("pro", r.plan());
+        // resolve 的入参只能来自服务端 User 实体（手机号优先，email 位必须是 null）
+        verify(billing).resolveAccountId(u.getPhone(), null, false);
+        assertEquals(accountId,
+                accountBindingRepository.findByUserId(u.getId()).orElseThrow().getExternalAccountId());
+    }
+
+    @Test
+    @DisplayName("只有已验证邮箱的用户：按邮箱 resolve（phone 位为 null）")
+    void emailOnlyUserResolvesByVerifiedEmail() {
+        String email = "bill" + SEQ.incrementAndGet() + "@example.com";
+        User u = userService.findOrCreateByEmail(email).user();
+        String accountId = "acct-mail-" + u.getId();
+        when(billing.resolveAccountId(isNull(), eq(email), eq(false))).thenReturn(accountId);
+        when(billing.balance(accountId)).thenReturn(new BalanceResult(0L, "USD", null));
+
+        assertEquals("USD", service.balance(u.getId()).currency());
+        verify(billing).resolveAccountId(null, email, false);
+    }
+
+    @Test
+    @DisplayName("已绑定用户：直接复用绑定，不再 resolve")
+    void existingBindingIsReusedWithoutResolve() {
+        User u = phoneUser();
+        String accountId = "acct-bound-" + u.getId();
+        bind(u.getId(), accountId);
+        when(billing.balance(accountId)).thenReturn(new BalanceResult(500L, "CNY", null));
+
+        assertEquals(500L, service.balance(u.getId()).balanceCents());
+        verify(billing, never()).resolveAccountId(any(), any(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("审核账号（手机号形态与邮箱形态）：桥接与充值一律拒，绝不去官网建号")
+    void reviewAccountIsRefusedAndNeverReachesUpstream() {
+        User byPhone = userService.findOrCreateByPhone("13800138000").user();
+        User byMail = userService.findOrCreateReviewAccount("appreview@example.com");
+
+        for (User u : new User[]{byPhone, byMail}) {
+            assertTrue(assertThrows(IllegalArgumentException.class,
+                    () -> service.balance(u.getId())).getMessage().contains("审核演示账号"));
+            assertTrue(assertThrows(IllegalArgumentException.class,
+                    () -> service.createRecharge(u.getId(), 5000L, "idem-review-01")).getMessage()
+                    .contains("审核演示账号"));
+            assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
+        }
+        verifyNoInteractions(billing);
+    }
+
+    @Test
+    @DisplayName("User 既无手机号也无已验证邮箱：拒绝，且不回落任何机器级账户")
+    void userWithoutVerifiedIdentityIsRefused() {
+        User u = userService.registerExternal("billnoid" + SEQ.incrementAndGet(), "无身份");
+
+        String msg = assertThrows(IllegalArgumentException.class,
+                () -> service.balance(u.getId())).getMessage();
+        assertTrue(msg.contains("已验证的手机号或邮箱"), msg);
+        verifyNoInteractions(billing);
+        assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("resolve 出来的 accountId 已绑给别的用户：拒绝，绝不改绑")
+    void accountAlreadyBoundToAnotherUserIsRefused() {
+        User owner = phoneUser();
+        User other = phoneUser();
+        String accountId = "acct-shared-" + owner.getId();
+        bind(owner.getId(), accountId);
+        when(billing.resolveAccountId(eq(other.getPhone()), isNull(), eq(false))).thenReturn(accountId);
+
+        String msg = assertThrows(IllegalArgumentException.class,
+                () -> service.balance(other.getId())).getMessage();
+        assertTrue(msg.contains("已与另一个登录账号关联"), msg);
+        // 原绑定一个字都没动
+        assertEquals(owner.getId(),
+                accountBindingRepository.findByExternalAccountId(accountId).orElseThrow().getUserId());
+        assertTrue(accountBindingRepository.findByUserId(other.getId()).isEmpty());
+    }
+
+    // ==================== 充值 ====================
+
+    @Test
+    @DisplayName("idempotencyKey 缺失/非法：报错，服务端绝不代生成，也不发请求")
+    void missingIdempotencyKeyIsRefusedAndNeverGenerated() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-idem-" + u.getId());
+
+        for (String bad : new String[]{null, "", "   ", "short", "has space!!"}) {
+            String msg = assertThrows(IllegalArgumentException.class,
+                    () -> service.createRecharge(u.getId(), 5000L, bad)).getMessage();
+            assertTrue(msg.contains("idempotencyKey"), msg);
+        }
+        verify(billing, never()).createRecharge(any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("金额必须是正整数分")
+    void nonPositiveAmountIsRefused() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-amt-" + u.getId());
+
+        for (Long bad : new Long[]{null, 0L, -1L}) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.createRecharge(u.getId(), bad, "idem-amount-01"));
+        }
+        verify(billing, never()).createRecharge(any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("建单：客户端传来的幂等键原样上行")
+    void clientIdempotencyKeyIsPassedThrough() {
+        User u = phoneUser();
+        String accountId = "acct-pay-" + u.getId();
+        bind(u.getId(), accountId);
+        when(billing.createRecharge(accountId, 5000L, "idem-abc-0001"))
+                .thenReturn(new RechargeOrder("qrcode", "OT123", 5000L, "weixin://x", null, null));
+
+        RechargeOrder order = service.createRecharge(u.getId(), 5000L, "idem-abc-0001");
+
+        assertEquals("qrcode", order.present());
+        assertEquals("OT123", order.outTradeNo());
+        assertEquals(5000L, order.amountCents());
+        verify(billing).createRecharge(accountId, 5000L, "idem-abc-0001");
+    }
+
+    // ==================== 缓存与降级 ====================
+
+    @Test
+    @DisplayName("余额按 userId 缓存；查单查到已到账即作废该用户的缓存")
+    void balanceIsCachedPerUserAndInvalidatedWhenPaid() {
+        User u = phoneUser();
+        String accountId = "acct-cache-" + u.getId();
+        bind(u.getId(), accountId);
+        when(billing.balance(accountId)).thenReturn(new BalanceResult(100L, "CNY", null));
+
+        service.balance(u.getId());
+        service.balance(u.getId());
+        verify(billing, times(1)).balance(accountId);
+
+        // 未到账不动缓存
+        when(billing.queryRecharge(accountId, "OT-pending")).thenReturn(new RechargeStatus("pending", false, 5000L));
+        service.queryRecharge(u.getId(), "OT-pending");
+        service.balance(u.getId());
+        verify(billing, times(1)).balance(accountId);
+
+        // 到账后作废，下一次必须打真源
+        when(billing.queryRecharge(accountId, "OT-paid")).thenReturn(new RechargeStatus("paid", true, 5000L));
+        service.queryRecharge(u.getId(), "OT-paid");
+        service.balance(u.getId());
+        verify(billing, times(2)).balance(accountId);
+    }
+
+    @Test
+    @DisplayName("缓存不串户：A 的余额不会被 B 读到")
+    void balanceCacheIsNotSharedBetweenUsers() {
+        User a = phoneUser();
+        User b = phoneUser();
+        bind(a.getId(), "acct-a-" + a.getId());
+        bind(b.getId(), "acct-b-" + b.getId());
+        when(billing.balance("acct-a-" + a.getId())).thenReturn(new BalanceResult(111L, "CNY", null));
+        when(billing.balance("acct-b-" + b.getId())).thenReturn(new BalanceResult(222L, "CNY", null));
+
+        assertEquals(111L, service.balance(a.getId()).balanceCents());
+        assertEquals(222L, service.balance(b.getId()).balanceCents());
+        assertEquals(111L, service.balance(a.getId()).balanceCents());
+    }
+
+    @Test
+    @DisplayName("官网不可达：给可读错误，绝不用余额 0 冒充，也不写缓存")
+    void upstreamUnavailableIsReadableErrorNotZeroBalance() {
+        User u = phoneUser();
+        String accountId = "acct-down-" + u.getId();
+        bind(u.getId(), accountId);
+        // 这里必须用 doThrow/doReturn 改桩：when(...) 会真的再调一次已被打桩成"抛异常"的方法
+        doThrow(new MobileBillingException(
+                MobileBillingKind.UNAVAILABLE, "账户服务暂不可用，请稍后再试"))
+                .when(billing).balance(accountId);
+
+        assertEquals("账户服务暂不可用，请稍后再试",
+                assertThrows(IllegalArgumentException.class, () -> service.balance(u.getId())).getMessage());
+        // 失败不进缓存：恢复后第一次调用就应该拿到真值
+        doReturn(new BalanceResult(777L, "CNY", null)).when(billing).balance(accountId);
+        assertEquals(777L, service.balance(u.getId()).balanceCents());
+    }
+
+    @Test
+    @DisplayName("本服务器未开通（DISABLED）：可读错误，不是 500")
+    void disabledBillingIsReadableError() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-off-" + u.getId());
+        when(billing.balance(anyString())).thenThrow(new MobileBillingException(
+                MobileBillingKind.DISABLED, "此服务器未开通统一账户充值"));
+
+        assertEquals("此服务器未开通统一账户充值",
+                assertThrows(IllegalArgumentException.class, () -> service.balance(u.getId())).getMessage());
+    }
+
+    @Test
+    @DisplayName("resolve 阶段官网不可达：不建绑定，下次可重试")
+    void resolveFailureLeavesNoBinding() {
+        User u = phoneUser();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false))).thenThrow(new MobileBillingException(
+                MobileBillingKind.UNAVAILABLE, "账户服务暂不可用，请稍后再试"));
+
+        assertThrows(IllegalArgumentException.class, () -> service.balance(u.getId()));
+        assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
+    }
+
+    // ==================== 读余额永不建号（复审 C1） ====================
+
+    @Test
+    @DisplayName("读余额一律 create=false：官网查无此账户 → NOT_CONNECTED，不建号也不落绑定")
+    void balanceNeverCreatesAccountUpstream() {
+        User u = phoneUser();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false)))
+                .thenThrow(new MobileBillingException(MobileBillingKind.NOT_FOUND, "未找到对应的统一账户",
+                        "account_not_found"));
+
+        MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
+                () -> service.balance(u.getId()));
+        // resolve 的「按这个身份没有账户」是「还没关联」，不是「绑定指向的账户没了」
+        assertEquals(MobileBillingKind.NOT_CONNECTED, e.getKind());
+        // 建号那一位从来没有被置过 true
+        verify(billing, never()).resolveAccountId(any(), any(), eq(true));
+        assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("查单也不建号（create=false）")
+    void queryNeverCreatesAccountUpstream() {
+        User u = phoneUser();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false)))
+                .thenThrow(new MobileBillingException(MobileBillingKind.NOT_FOUND, "未找到对应的统一账户",
+                        "account_not_found"));
+
+        assertEquals(MobileBillingKind.NOT_CONNECTED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.queryRecharge(u.getId(), "OT-x")).getKind());
+        verify(billing, never()).resolveAccountId(any(), any(), eq(true));
+    }
+
+    @Test
+    @DisplayName("只有「用户显式发起充值」这一条路允许官网建号：create=true")
+    void onlyRechargeMayCreateAccountUpstream() {
+        User u = phoneUser();
+        String accountId = "acct-create-" + u.getId();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(true))).thenReturn(accountId);
+        when(billing.createRecharge(accountId, 5000L, "idem-create-01"))
+                .thenReturn(new RechargeOrder("qrcode", "OT-create", 5000L, "weixin://x", null, null));
+
+        assertEquals("OT-create",
+                service.createRecharge(u.getId(), 5000L, "idem-create-01").outTradeNo());
+        verify(billing).resolveAccountId(u.getPhone(), null, true);
+    }
+
+    // ==================== 标识选择与回退 ====================
+
+    @Test
+    @DisplayName("手机号被官网按站点能力拒（REJECTED）：回退试已验证邮箱")
+    void rejectedIdentityFallsBackToTheOther() {
+        User u = bothIdentitiesUser();
+        String accountId = "acct-fallback-" + u.getId();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false)))
+                .thenThrow(new MobileBillingException(MobileBillingKind.REJECTED,
+                        "充值请求被拒绝，请稍后重试或联系客服", "phone_not_supported_on_site"));
+        when(billing.resolveAccountId(isNull(), eq(u.getVerifiedEmail()), eq(false))).thenReturn(accountId);
+        when(billing.balance(accountId)).thenReturn(new BalanceResult(88L, "USD", "free"));
+
+        assertEquals(88L, service.balance(u.getId()).balanceCents());
+        verify(billing).resolveAccountId(u.getPhone(), null, false);
+        verify(billing).resolveAccountId(null, u.getVerifiedEmail(), false);
+    }
+
+    @Test
+    @DisplayName("手机号 NOT_FOUND 时绝不回退到邮箱：那是把用户悄悄关联到另一个官网账户")
+    void notFoundIdentityDoesNotFallBack() {
+        User u = bothIdentitiesUser();
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false)))
+                .thenThrow(new MobileBillingException(MobileBillingKind.NOT_FOUND, "未找到对应的统一账户",
+                        "account_not_found"));
+
+        assertEquals(MobileBillingKind.NOT_CONNECTED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(u.getId())).getKind());
+        verify(billing, never()).resolveAccountId(isNull(), anyString(), anyBoolean());
+        assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
+    }
+
+    // ==================== 绑定自愈 ====================
+
+    @Test
+    @DisplayName("绑定指向的官网账户已注销：清掉绑定重解析，不再永久卡在「未找到」")
+    void staleBindingSelfHeals() {
+        User u = phoneUser();
+        String dead = "acct-dead-" + u.getId();
+        String fresh = "acct-fresh-" + u.getId();
+        bind(u.getId(), dead);
+        doThrow(new MobileBillingException(MobileBillingKind.NOT_FOUND, "未找到对应的统一账户",
+                "account_not_found")).when(billing).balance(dead);
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false))).thenReturn(fresh);
+        doReturn(new BalanceResult(66L, "CNY", "paid")).when(billing).balance(fresh);
+
+        assertEquals(66L, service.balance(u.getId()).balanceCents());
+        assertEquals(fresh,
+                accountBindingRepository.findByUserId(u.getId()).orElseThrow().getExternalAccountId());
+    }
+
+    @Test
+    @DisplayName("自愈只重试一次：重解析回同一个死账户就如实报错，不死循环")
+    void staleBindingHealRetriesOnlyOnce() {
+        User u = phoneUser();
+        String dead = "acct-dead2-" + u.getId();
+        bind(u.getId(), dead);
+        doThrow(new MobileBillingException(MobileBillingKind.NOT_FOUND, "未找到对应的统一账户",
+                "account_not_found")).when(billing).balance(dead);
+        when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(false))).thenReturn(dead);
+
+        assertEquals(MobileBillingKind.NOT_FOUND,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(u.getId())).getKind());
+        verify(billing, times(2)).balance(dead);
+    }
+
+    // ==================== kind / outTradeNo 透传（复审 C2、C4） ====================
+
+    @Test
+    @DisplayName("已付单的 409：ALREADY_PAID 与 outTradeNo 一路带到服务层，不再被丢掉")
+    void alreadyPaidKeepsKindAndOutTradeNo() {
+        User u = phoneUser();
+        String accountId = "acct-paid-" + u.getId();
+        bind(u.getId(), accountId);
+        doThrow(new MobileBillingException(MobileBillingKind.ALREADY_PAID,
+                "这笔充值已经支付成功，请查看订单状态", "order_already_paid", "RECHARGE20260904"))
+                .when(billing).createRecharge(accountId, 5000L, "idem-paid-0001");
+
+        MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
+                () -> service.createRecharge(u.getId(), 5000L, "idem-paid-0001"));
+        assertEquals(MobileBillingKind.ALREADY_PAID, e.getKind());
+        assertEquals("RECHARGE20260904", e.getOutTradeNo());
+    }
+
+    @Test
+    @DisplayName("服务层自己判定的失败也带 kind：审核账号 / 无身份 / 已绑给别人")
+    void serviceLevelFailuresCarryKind() {
+        User review = userService.findOrCreateByPhone("13800138000").user();
+        assertEquals(MobileBillingKind.REVIEW_ACCOUNT,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(review.getId())).getKind());
+
+        User noId = userService.registerExternal("billkind" + SEQ.incrementAndGet(), "无身份");
+        assertEquals(MobileBillingKind.NOT_CONNECTED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(noId.getId())).getKind());
+
+        User owner = phoneUser();
+        User other = phoneUser();
+        String shared = "acct-kind-shared-" + owner.getId();
+        bind(owner.getId(), shared);
+        when(billing.resolveAccountId(eq(other.getPhone()), isNull(), eq(false))).thenReturn(shared);
+        assertEquals(MobileBillingKind.REJECTED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(other.getId())).getKind());
+    }
+
+    @Test
+    @DisplayName("上游 UNAVAILABLE / DISABLED 的 kind 原样透传，不被压成一句 message")
+    void upstreamKindsArePassedThrough() {
+        User u = phoneUser();
+        String accountId = "acct-kind-" + u.getId();
+        bind(u.getId(), accountId);
+
+        doThrow(new MobileBillingException(MobileBillingKind.UNAVAILABLE, "账户服务暂不可用，请稍后再试"))
+                .when(billing).balance(accountId);
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(u.getId())).getKind());
+
+        doThrow(new MobileBillingException(MobileBillingKind.DISABLED, "此服务器未开通统一账户充值"))
+                .when(billing).balance(accountId);
+        assertEquals(MobileBillingKind.DISABLED,
+                assertThrows(MobileBillingFailureException.class,
+                        () -> service.balance(u.getId())).getKind());
+    }
+
+    /** 同时有手机号和已验证邮箱的用户（国际站存量形态）。 */
+    private User bothIdentitiesUser() {
+        String email = "both" + SEQ.incrementAndGet() + "@example.com";
+        User u = userService.findOrCreateByEmail(email).user();
+        u.setPhone(nextPhone());
+        return userRepository.save(u);
+    }
+}


### PR DESCRIPTION
## 背景

用户 2026-09-04 指示：让手机端支持往统一账户充值。调研与设计见手机端仓
`docs/specs/2026-09-04-mobile-recharge-design.md`，开通清单见 `docs/ops/2026-09-04-recharge-service-activation.md`。

这是**第一期**：打通服务端账户映射与订单通路，四端只展示余额、**不放任何充值入口**。
后面还有小程序虚拟支付（#427）、iOS 内购（#426）、安卓（#428）、鸿蒙。

## 三个仓一起看

- 官网（余额权威）：zeweihan/aiworkdeck_website#163
- Java 云后端：本 PR
- 手机端四端：zeweihan/aiworkdeck-mobile 的 `claude/mobile-unified-account-recharge-6f8a50`

## 质量过程

三轮：实现 → 四路对抗复审（1 critical + 一批 important）→ 修复 → 逐条复验 →
二轮收口（N1-N7）→ 复验判定可提交。复验者自己动手复现验证，包括把守卫改坏确认测试真会红。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 本仓改了什么

手机端会话经 `account_binding` 映射到官网 accountId，再打官网窄权限内部口。
三个端点：`/api/mobile/billing/balance`、`/recharge`、`/recharge/status`。

**没有复用 `AccountController`/`AccountService`**——那条路的账户状态是机器级单例
`~/.aiworkdeck/account.json`，与调用者 userId 无关，云上只对 admin 开放，
用它充值等于给「服务器当前连的那个账户」充钱。

护栏：accountId 严格来自绑定表不接受请求体传入；读余额只查不建；
充值有默认关的总开关 `MOBILE_BILLING_RECHARGE_ENABLED`（要等 dev-board#434 才允许打开）；
审核账号一律拒绝；空体 404 归 UNAVAILABLE 并 log.warn（红线 7）；
Envelope 加 kind 判别位让四端不必匹配中文措辞；绑定指向已注销账户时自愈。

42 项测试全绿（**注意用 JDK 21**，本机 mvn 默认 JDK 26 会因 Byte Buddy 假红）。