### PR TITLE
chore(deploy): 官方案件库部署包（dev-board#441）

### DIFF
--- a/backend/src/main/resources/application-case.yml
+++ b/backend/src/main/resources/application-case.yml
@@ -1,0 +1,99 @@
+# 官方案件库（case.aiworkdeck.com）专用 profile —— dev-board#441。
+#
+# 它是**第三个**部署形态，与另外两个的关系：
+#   application-cloud.yml  插件云后端（addin.aiworkdeck.com）：Office/WPS 插件的桥接与
+#                          AI 对话、反馈收件箱、手机影像中转。
+#   application-prod.yml   团队服务器（MySQL，restart-backend.sh 在用）。
+#   application-case.yml   本文件。团队案件库：只做 git smart-HTTP 托管 + 项目/成员/
+#                          设备令牌。不跑 AI、不收反馈、不做手机中转。
+#
+# 为什么不复用 cloud profile + 环境变量覆盖（决策记录）：
+#   1. 两个实例跑在同一台机器上、同一份 backend.jar。复用意味着任何一次为 addin 改
+#      application-cloud.yml 的动作都会静默改到案件库——而案件库存的是律师的案卷，
+#      是这台机器上最不该被"顺手改到"的东西。
+#   2. 复用要靠 env 覆盖 10 项以上（端口、库、存储根、CORS、反馈开关…），
+#      读配置时得在 yml 与 env 之间来回对照才知道生效值是什么，审计成本高。
+#   3. cloud 里 feedback.ingest.enabled=true 是"这台是收件箱"的语义，
+#      漏关一次就会出现两个收件箱。显式独立文件不会漏。
+#
+# 启动方式：java -jar backend.jar --spring.profiles.active=case
+#
+# 必配环境变量（见 deploy/case/env.example）：
+#   DB_PASSWORD               PostgreSQL 专用账号 aiworkdeck_case 的口令
+#   AWD_PLATFORM_KEY_SECRET   per-user 平台 AI key 的落库加密密钥。
+#                             awdk-login-enabled=true 时缺失 → PlatformAiKeyCipher
+#                             直接拒绝启动（刻意的强不变式，不做明文降级）。
+#                             **迁移时必须原样带走**：换了值，已落库的 key 全部解不开。
+
+server:
+  port: 9797
+  # 只监听回环。对外一律经 nginx 反代（TLS 终结在 nginx）。
+  # 9696 已被同机的插件云后端（cloud profile）占用，不能撞。
+  address: 127.0.0.1
+  # 反代后还原真实客户端 IP（RemoteIpValve，只信回环来源的 X-Forwarded-For）。
+  # 不开的话 getRemoteAddr() 恒为 127.0.0.1，AuthAbuseGuard 的按 IP 失败锁定
+  # 会退化成全站共享一把锁：任何人连错 5 次口令，所有律师的连接都被锁 10 分钟。
+  forward-headers-strategy: native
+
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/aiworkdeck_case
+    username: aiworkdeck_case
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+security:
+  # server 模式（多租户）：local-mode 的免登/回环闸整套不生效。
+  # 顺带效果：EntitlementService 按本机权益的额度全部不执行（StageQuotaService /
+  # ClipboardService 的既有口径——本机权益对服务器成员没有意义）。
+  local-mode: false
+  # 关闭自助注册：账号只经 awdk_ 桥接（官网账户）建立。
+  registration-mode: closed
+  # 官网账户 Key（awdk_）一键桥接。案件库的用户身份来源就是官网账号，
+  # 桥接签发的是 awdt_ 设备令牌，与 /api/auth/device-token 出的是同一种凭据，
+  # git Basic 的 password 位吃的也是它（GitAccessService.resolveUser）。
+  awdk-login-enabled: true
+  # 浏览器会话滑动过期。案件库没有浏览器客户端，这项几乎用不到，
+  # 但与 cloud 保持同一姿态：公网实例不用桌面的 365 天"常驻"语义。
+  session-idle-days: 7
+  # conversationId 强制服务端签发（公网多租户防空会话抢占）
+  conversation-issuance-required: true
+  cors:
+    # 案件库不服务任何浏览器：桌面端是本机后端做服务端到服务端调用（无 Origin 头），
+    # git 客户端也不带 Origin。所以白名单留空即可（CorsConfig 仍默认放行 localhost，
+    # 那条是开发态兜底，不构成对外开放面）。allow-all 绝不能开。
+    allowed-origins: ""
+
+storage:
+  type: local
+  # 全部数据落在一个可整体搬走的根下（迁移单元，见 deploy/case/README.md）。
+  # repos/（裸库）、projects/（托管工作区）、template.docx 都在 root-path 之下：
+  #   ProjectRepoService: gitDir  = {globalRoot}/repos/project-{id}.git
+  #   MemoryRepoService:  gitDir  = {globalRoot}/repos/{repoKey}.git
+  #   ProjectStorageResolver:     = {globalRoot}/projects/{id}
+  local:
+    root-path: /data/aiworkdeck-case/store
+    template-path: /data/aiworkdeck-case/store/template.docx
+
+ai:
+  packs:
+    # 案件库不跑 AI，也就不需要原生资源包。关掉总开关 = 安装、自动补下载、
+    # 封禁表同步全部旁路，这台机器不会为了 pack 去连官网。
+    enabled: false
+
+# 反馈收件箱在插件云后端那台（addin.aiworkdeck.com），不是这台。
+# 两台都开 = 同一条反馈落两份记录。
+feedback:
+  ingest:
+    enabled: false
+  upload:
+    enabled: false
+
+# 优化者跑在维护者自己的机器上（deploy/optimizer/README.md），任何服务器实例都不开。
+optimizer:
+  enabled: false

--- a/deploy/case/README.md
+++ b/deploy/case/README.md
@@ -160,12 +160,21 @@ journalctl -u aiworkdeck-case -f
 
 ```bash
 # DNS：case.aiworkdeck.com A -> 8.152.169.44，生效后
-certbot certonly --webroot -w /opt/aiworkdeck/case/acme -d case.aiworkdeck.com
+certbot certonly --webroot -w /opt/aiworkdeck/case/acme -d case.aiworkdeck.com \
+  --server https://acme-v02.api.letsencrypt.org/directory \
+  --account dc142203f2ccc978150941001d83e226   # 北京机 certbot 有两个账号，不指定会报 Please choose an account；
+                                               # --account 要完整 id 且必须同时给 --server，短 id dc14 会报 does not exist
 # 宝塔机上落 vhost 目录
 cp deploy/case/nginx-case.conf.example \
    /www/server/panel/vhost/nginx/case.aiworkdeck.com.conf
 nginx -t && nginx -s reload
 ```
+
+先只铺示例文件里的 80 端口块（`sed -n 1,28p`）签证书，证书落地后再铺完整文件——443 块引用的
+证书不存在时 `nginx -t` 直接失败，别把整份先放上去。
+
+2026-09-05 实录：DNS 记录经 Alidns API 加（`awd-dl-cert` 策略的 AK），证书到 2026-12-04；
+实例启动 15s，稳态 cgroup 内存约 750M（启动瞬间 1.27G 是 jar 页缓存计入 cgroup）。
 
 `limit_req_zone ... zone=awd_auth` 在装插件云后端时已经加过，**不要重复定义**
 （`nginx -t` 会报 duplicate）。本域续期完全在北京机本地闭环。
@@ -266,7 +275,7 @@ systemctl enable --now aiworkdeck-case
 | 项 | 共机（现在） | 专机 |
 |---|---|---|
 | `-Xmx` | 1024m | 4g |
-| `MemoryHigh` / `MemoryMax` | 1280M / 1536M | 去掉 MemoryHigh，MemoryMax 6g |
+| `MemoryHigh` / `MemoryMax` | 1536M / 2048M | 去掉 MemoryHigh，MemoryMax 6g |
 | `CPUWeight` | 70 | 去掉（不再需要给官网让路） |
 | `pack.windowMemory` | 32m | 256m |
 | `pack.threads` | 1 | 2–4 |
@@ -368,5 +377,5 @@ du -sh /data/aiworkdeck-case/store/repos              # 盘占用（长得最快
   awdk 桥接的连接方式，要么在案件库上另开口子。本目录只准备部署侧，
   这一条属于客户端改造，需要主会话确认由谁做、什么时候做——**在它落地之前，
   案件库对普通用户是连不上的**。
-- 8G 共机的内存余量是纸面推算（addin `MemoryMax=2560M` + case `1536M` + PG + MySQL +
+- 8G 共机的内存余量是纸面推算（addin `MemoryMax=2560M` + case `2048M` + PG + MySQL +
   Next.js），上线前需要在机器上 `free -m` / `systemd-cgtop` 实核一次。

--- a/deploy/case/README.md
+++ b/deploy/case/README.md
@@ -1,0 +1,372 @@
+# 官方案件库部署（case.aiworkdeck.com）
+
+dev-board#441。「案件库」= 团队服务器 = **另一个完整的 AI WorkDeck 后端实例**，
+跑的是同一份 `backend.jar`，只是换了 profile。它对外只提供两件事：
+
+- **git smart-HTTP**（`GitHttpController`，`/git/{repo}.git/*`）——案卷仓库的托管；
+- **一小撮 API**——换设备令牌、建项目、成员、`prepare-remote`、云端同步状态。
+
+它**不**跑 AI 对话、不收用户反馈、不做手机影像中转、不服务任何浏览器页面。
+
+| 决策项 | 结论 |
+|---|---|
+| 机器 | 先不买新 ECS。落在既有北京 ECS `8.152.169.44`（4c8G），与官网 Next.js、插件云后端、PG14、MySQL、宝塔共机 |
+| 域名 | `case.aiworkdeck.com`（专用，certbot 本机独立签，不进新加坡续期主控） |
+| 数据库 | 既有 PostgreSQL 14 新建独立库 `aiworkdeck_case` + 同名账号 |
+| 端口 | `127.0.0.1:9797`（9696 已被插件云后端占用） |
+| 进程管理 | systemd `aiworkdeck-case.service`，**专用系统账号 `aiworkdeck-case`** |
+| profile | 新建 `application-case.yml`（不复用 cloud，理由写在该文件头部） |
+| 身份来源 | 官网账号经 `awdk_` 桥接（`security.awdk-login-enabled=true`），自助注册关闭 |
+| 凭据 | `awdt_` 设备令牌。git Basic 的 password 位吃的就是它 |
+
+**红线**：与官网（PM2 :3000）、globalventure（:3001）、插件云后端、宝塔、MySQL 共机，
+**既有站点与配置一个字都不动**，nginx 只新增 server 块。
+
+**本方案是按"将来整体搬到专用机器"设计的**——先看下面的「迁移单元」一节再动手，
+所有目录选择都是为它服务的。
+
+---
+
+## 一、服务器布局
+
+程序与数据**严格分离**。
+
+```
+/opt/aiworkdeck/case/            <- 程序与配置，可重建，不属于迁移单元
+  backend.jar                    <- mvn package 产物（本地构建，服务器不编译）
+  env                            <- EnvironmentFile（0600 root:aiworkdeck-case），见 env.example
+  acme/                          <- certbot webroot
+
+/data/aiworkdeck-case/           <- **迁移单元（数据侧）**。现在是普通目录；
+  │                                 将来加数据盘就是挂载点，rsync 一次即迁。
+  store/                         <- storage.local.root-path
+    repos/                       <- 裸库：project-{id}.git、user-{id}-memory.git、
+    │                               project-{id}-memory.git（案件库唯一不可重建的资产）
+    repos/memory-worktrees/      <- 记忆仓库的内部物化区
+    projects/{id}/               <- 托管项目工作区
+    template.docx                <- 新建文档模板（仓库 docs/template.docx）
+  home/                          <- 服务账号 HOME：~/.aiworkdeck 状态 + ~/.gitconfig
+  var/                           <- systemd WorkingDirectory；plugins/ packs/ skills/
+  │                               这几个相对目录落这里（案件库都用不上，但别让它们
+  │                               散到 /opt 去，否则迁移会漏）
+  backups/                       <- 本机备份落点（备份不出本机，见第五节）
+```
+
+**绝不**与 `/opt/aiworkdeck/cloud/data`（插件云后端的数据）混放。两个实例的数据
+必须各自独立成堆，否则将来搬案件库时要在同一棵目录树里挑拣文件——那是一定会出错的活。
+
+---
+
+## 二、首次部署
+
+### 1. 本地构建（worktree 内，JDK 21）
+
+```bash
+cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) \
+  mvn -B -DskipTests -Djavacpp.platform=linux-x86_64 package
+```
+
+`-Djavacpp.platform=linux-x86_64` 不能省：`javacv-platform` 不带这个属性会把
+**所有**平台的 natives 都打进去，产物从 424 MB 涨到 1.04 GB。产物大小可以当校验。
+
+### 2. 服务器准备（root）
+
+```bash
+# 系统账号（无登录 shell，HOME 指向数据根下）
+useradd -r -s /usr/sbin/nologin -d /data/aiworkdeck-case/home aiworkdeck-case
+
+mkdir -p /opt/aiworkdeck/case/acme
+mkdir -p /data/aiworkdeck-case/{store,home,var,backups}
+chown -R aiworkdeck-case:aiworkdeck-case /data/aiworkdeck-case
+chmod 700 /data/aiworkdeck-case          # 与同机的 aiworkdeck（addin）互不可读
+
+# JRE 已随插件云后端装过，确认一下即可
+java -version   # 需要 21
+```
+
+PostgreSQL（`sudo -u postgres psql`）：
+
+```sql
+CREATE USER aiworkdeck_case WITH PASSWORD '...';
+CREATE DATABASE aiworkdeck_case OWNER aiworkdeck_case;
+\c aiworkdeck_case
+CREATE EXTENSION vector;   -- .so 在装插件云后端时已源码编译过，这里只是建扩展
+```
+
+`CREATE EXTENSION vector` 严格说是可选的：`PgVectorConfig` 建不出 store 会**静默回退
+到进程内存**，案件库又不跑语义检索，功能上无感。建它只是为了让启动日志干净、
+不留一条会被误当故障排查的 WARN。
+
+表结构靠 `ddl-auto: update` 自动建，无手动迁移。
+
+### 3. 上传产物
+
+```bash
+scp backend/target/backend-*.jar root@8.152.169.44:/opt/aiworkdeck/case/backend.jar
+scp docs/template.docx           root@8.152.169.44:/data/aiworkdeck-case/store/template.docx
+chown aiworkdeck-case:aiworkdeck-case /data/aiworkdeck-case/store/template.docx
+```
+
+### 4. env
+
+```bash
+cp deploy/case/env.example /opt/aiworkdeck/case/env   # 填真实值
+chown root:aiworkdeck-case /opt/aiworkdeck/case/env
+chmod 640 /opt/aiworkdeck/case/env
+```
+
+`AWD_PLATFORM_KEY_SECRET` 用 `openssl rand -base64 32` 现场生成，**与插件云后端那把
+不复用**，并且**立刻离线抄一份**（丢了 = 存量密文全废，见第五节）。
+
+### 5. JGit 内存护栏（必做，不是可选调优）
+
+这台机器只有 8G 且共机，而 JGit 的 `PackConfig` 默认 `windowMemory=0`（**不限**）。
+一个大案卷的首次 clone 会让 delta 搜索把堆吃穿，systemd 的 `MemoryMax` 随后把整个
+unit 杀掉——用户看到的是"clone 到一半连接断了"，服务端 journal 里只有一行 oom。
+所以在服务账号的 `~/.gitconfig` 里钉死上限：
+
+```bash
+install -o aiworkdeck-case -g aiworkdeck-case -m 644 /dev/stdin \
+  /data/aiworkdeck-case/home/.gitconfig <<'EOF'
+[pack]
+	windowMemory = 32m
+	threads = 1
+	window = 10
+	depth = 50
+[core]
+	bigFileThreshold = 20m
+EOF
+```
+
+JGit 的配置链是 system → global(`$HOME/.gitconfig`) → repo，所以写在这里对所有
+仓库生效，不用逐个裸库配。
+
+> 诚实标注：这几个值来自 JGit `PackConfig` 的默认值与本机 8G 的余量推算，
+> **我没有在服务器上实测过**。上线后跑一次真实大案卷的 clone，看 `journalctl -u
+> aiworkdeck-case` 有没有 `OutOfMemoryError` 或 cgroup oom，再回来调。
+
+### 6. systemd
+
+```bash
+cp deploy/case/aiworkdeck-case.service /etc/systemd/system/
+systemctl daemon-reload && systemctl enable --now aiworkdeck-case
+journalctl -u aiworkdeck-case -f
+```
+
+首启日志里取随机 admin 初始口令（`journalctl -u aiworkdeck-case | grep 初始口令`），
+记下来收好——案件库没有浏览器界面，这个账号只在需要直接调 admin API 时才用得上。
+
+### 7. nginx + 证书
+
+```bash
+# DNS：case.aiworkdeck.com A -> 8.152.169.44，生效后
+certbot certonly --webroot -w /opt/aiworkdeck/case/acme -d case.aiworkdeck.com
+# 宝塔机上落 vhost 目录
+cp deploy/case/nginx-case.conf.example \
+   /www/server/panel/vhost/nginx/case.aiworkdeck.com.conf
+nginx -t && nginx -s reload
+```
+
+`limit_req_zone ... zone=awd_auth` 在装插件云后端时已经加过，**不要重复定义**
+（`nginx -t` 会报 duplicate）。本域续期完全在北京机本地闭环。
+
+---
+
+## 三、验收清单
+
+按顺序走，每条都要真做，不要"看着像通了"：
+
+1. **启动强不变式**：临时删掉 env 里的 `AWD_PLATFORM_KEY_SECRET` 重启一次，
+   服务必须**拒绝启动**（`PlatformAiKeyCipher`）。恢复后再启。
+2. `curl https://case.aiworkdeck.com/api/admin/wizard` 通（匿名探活端点）。
+3. `curl https://case.aiworkdeck.com/` 返回 404（不该有任何欢迎页）。
+4. **注册闸**：`POST /api/auth/register` 被拒。
+5. **桥接**：真实 `awdk_` 打 `POST /api/auth/awdk-login` 换到 `awdt_`，
+   再带它 `GET /api/projects/my` 通。
+6. **git 401 契约**（最容易被 nginx 配置弄坏的一条）：
+   ```bash
+   curl -i "https://case.aiworkdeck.com/git/1.git/info/refs?service=git-upload-pack"
+   ```
+   必须是 **401** 且响应头里有 `WWW-Authenticate: Basic realm="AIWorkdeck Git"`。
+   收到 403 → 多半被宝塔的防恶意 UA 规则拦了；收到自定义错误页 → `proxy_intercept_errors`
+   被打开了。这两种情况下 git 客户端都不会回头送凭据，用户侧表现是"密码没用"。
+7. **端到端真跑一遍**：桌面端连接案件库 → 「放进案件库」一个真实案卷（带几十 MB 附件）
+   → 换一台机器/另一个账号「取一份案卷」→ 双方各改一处 → 交稿合并。
+   只验接口不验这条链等于没验。
+8. **大体积**：推一个 > 500 MB 的案卷，确认没有 413、没有超时、
+   `/data` 余量与 `journalctl` 都干净。撞 413 就调 nginx 的 `client_max_body_size`。
+
+---
+
+## 四、迁移到专用机器
+
+### 迁移单元是什么
+
+**三样东西，缺一不可，而且必须是同一时刻的快照：**
+
+| # | 内容 | 说明 |
+|---|---|---|
+| 1 | `/data/aiworkdeck-case/` 整目录 | 裸库 + 工作区 + HOME 状态 + gitconfig。整目录 rsync |
+| 2 | PG 库 `aiworkdeck_case` 的 dump | 项目、成员、设备令牌、`ProjectRemote` 映射 |
+| 3 | `/opt/aiworkdeck/case/env` 里的 `AWD_PLATFORM_KEY_SECRET` | 换值 = 存量密文全废 |
+
+**不属于迁移单元**（新机重建即可）：`backend.jar`（重新构建或直接 scp 一份）、
+systemd unit、nginx conf、Let's Encrypt 证书（新机 certbot 重签）、`DB_PASSWORD`（可换新）。
+
+### 为什么客户端能零改动
+
+桌面端本地存的是 `CloudConnection.serverUrl` = `https://case.aiworkdeck.com`（**域名**，
+不是 IP），git 的 origin 是 `https://case.aiworkdeck.com/git/{remoteProjectId}.git`
+（`CloudSyncService.shareToCloud` 里拼的）。所以只要满足三个前提，换机器对用户完全无感、
+不需要发版、不需要用户重新连接：
+
+1. **域名不变**，换机只改 A 记录；
+2. **项目 id 不变**——这就是为什么第 2 项必须是整库 dump/restore。
+   重建库或让 PG 重新分配序列，等于所有人本地存的 origin URL 全部指向不存在的仓库，
+   而桌面端**没有任何自愈路径**；
+3. **设备令牌不变**——令牌哈希在同一个库里，整库迁移自然保住。
+
+这三条是硬红线。任何"顺便清理一下数据重来"的念头都会让全部存量用户失联。
+
+### 迁移步骤
+
+```bash
+# —— 停机前：先热同步一轮，把停机窗口压到分钟级 ——
+rsync -aHAX --numeric-ids /data/aiworkdeck-case/ new:/data/aiworkdeck-case/
+
+# —— 停机窗口开始 ——
+systemctl stop aiworkdeck-case                       # 旧机
+
+sudo -u postgres pg_dump -Fc aiworkdeck_case > /data/aiworkdeck-case/backups/migrate.dump
+rsync -aHAX --numeric-ids --delete /data/aiworkdeck-case/ new:/data/aiworkdeck-case/
+
+# —— 新机 ——
+# 前置：JRE21 / PG14(+vector) / nginx / useradd aiworkdeck-case / 目录属主
+sudo -u postgres createuser aiworkdeck_case
+sudo -u postgres createdb  aiworkdeck_case -O aiworkdeck_case
+sudo -u postgres pg_restore -d aiworkdeck_case /data/aiworkdeck-case/backups/migrate.dump
+# env：AWD_PLATFORM_KEY_SECRET 原样抄过来，DB_PASSWORD 可换新
+systemctl enable --now aiworkdeck-case
+# nginx conf 照搬（改 proxy_pass 端口如有变化），certbot 签新证书
+
+# —— 切流量 ——
+# 提前 24h 把 case.aiworkdeck.com 的 TTL 调到 60s，此刻改 A 记录
+# —— 停机窗口结束 ——
+```
+
+切完之后按第三节的 1/2/6/7 条重跑一遍验收（尤其第 7 条：拿一个**存量**案卷做
+「取一份案卷」，这是唯一能证明 id 与令牌都没坏的检查）。
+
+**旧机留一周只读再删**，不要当天清理。
+
+### 迁移时可以顺手调大的东西
+
+上专机（假设 ≥16G 独占）后：
+
+| 项 | 共机（现在） | 专机 |
+|---|---|---|
+| `-Xmx` | 1024m | 4g |
+| `MemoryHigh` / `MemoryMax` | 1280M / 1536M | 去掉 MemoryHigh，MemoryMax 6g |
+| `CPUWeight` | 70 | 去掉（不再需要给官网让路） |
+| `pack.windowMemory` | 32m | 256m |
+| `pack.threads` | 1 | 2–4 |
+| nginx `client_max_body_size` (/git/) | 4g | 按数据盘余量定 |
+
+---
+
+## 五、备份
+
+### 为什么必须单独说
+
+官网那套 `backup-data.mjs`（两台机的 cron）**不覆盖案件库**：它的 `--extra` 只加了
+`/www/wwwroot/plugin-packs` 与 `/opt/aiworkdeck/cloud/data`。案件库的数据在
+`/data/aiworkdeck-case/`，现在处于**零备份状态**——上线前必须补上。
+
+（本节按要求只写"要备什么、怎么验"，不写脚本。）
+
+### 备什么
+
+| 优先级 | 内容 | 可重建？ |
+|---|---|---|
+| P0 | `/data/aiworkdeck-case/store/repos/` | **不可重建**。律师的案卷全文与全部历史，丢了就是丢了 |
+| P0 | PG 库 `aiworkdeck_case` | 不可重建。丢了 = 项目 id / 成员 / 设备令牌全废，等于全部用户失联 |
+| P0 | `AWD_PLATFORM_KEY_SECRET` | 不可重建。**离线单独保管，不和数据放一起** |
+| P1 | `/data/aiworkdeck-case/home/.aiworkdeck/` | 账户/权益状态文件 |
+| P2 | `/data/aiworkdeck-case/store/projects/` | 托管项目工作区。理论上能从裸库物化回来，但省事就一起备 |
+
+### 口径红线（沿用既有服务器备份口径）
+
+- **备份不出本机**。北京机的用户数据同步到境外 = 数据出境，与隐私政策"承诺全境内"
+  冲突。产物落 `/data/aiworkdeck-case/backups/`，权限 0600。
+- **保留份数只许调小不许调大**（受隐私政策保留期承诺约束）。
+- 机器级灾难兜底靠迁移演练（第四节）与云盘快照，不做异地全量。
+
+### 增量，不要每天全量 tar
+
+`repos/` 会长到几十 GB，每天 tar 一次既写穿磁盘也写穿保留窗口。建议形状：
+
+- **每日**：`repos/` 用 rsync 到本机 `backups/repos-daily/`（`--link-dest` 做硬链接
+  增量，一份全量的空间开销换 N 天的历史）；PG 每日 `pg_dump -Fc`。
+- **每周**：一次 `tar` 全量归档，便于整份带走。
+
+### 一致性：dump 必须早于 rsync
+
+git 裸库和 PG 库是**两个必须互相对得上**的东西。理想做法是 `systemctl stop` 之后再备
+（案件库不是 7×24 的交互服务，凌晨停 2 分钟没人受影响）。若坚持热备，**顺序必须是
+先 pg_dump 再 rsync repos**：
+
+- 先 DB(T1) 后仓库(T2>T1)：恢复后仓库里有一些 DB 不知道的新 ref —— 多余数据，无害。
+- 反过来：DB 里记着一个 T1 时还不存在的 ref —— 桌面端一取就报"取不到"，**真的坏**。
+
+### 恢复怎么验
+
+不是"文件在不在"，是**内容级对账**。备份前先记下基线：
+
+```bash
+# 基线：挑一个活跃项目，记下它主线的 sha
+curl -H "Authorization: Basic <base64 user:awdt_...>" \
+  "https://case.aiworkdeck.com/git/{id}.git/info/refs?service=git-upload-pack" | head
+```
+
+恢复演练（在一台干净机器上，**不要在生产上试**）：
+
+1. restore PG dump + 展开 `repos/` 备份；
+2. 起服务，`GET /api/admin/wizard` 通；
+3. 用一个**真实的存量设备令牌** `git clone https://<演练机>/git/{id}.git`，
+   拿到的 HEAD sha 必须与基线逐字相同；
+4. 打开 clone 出来的案卷，随机抽一个文件对比字节。
+
+第 3 步是关键：它同时证明了 PG（令牌与成员判定）、裸库（对象与 ref）、
+以及两者的一致性。只验第 1、2 步等于什么都没验。
+
+---
+
+## 六、日常运维
+
+```bash
+journalctl -u aiworkdeck-case -f                      # 日志
+systemctl restart aiworkdeck-case                     # 重启
+du -sh /data/aiworkdeck-case/store/repos              # 盘占用（长得最快的就是它）
+```
+
+- **更新后端**：本地重新 `package`（带 `-Djavacpp.platform=linux-x86_64`）→
+  scp 覆盖 `/opt/aiworkdeck/case/backend.jar` → `systemctl restart aiworkdeck-case`。
+  判据同插件云后端：`git diff v<上一版>..v<本版> -- backend/` 非空就要更新。
+  **两个实例是各自独立的 jar 文件，更新一个不会更新另一个**——很容易只发了 addin
+  忘了 case，发版清单里要分两行写。
+- **仓库 GC**：`RepoMaintenanceJob` 每天 03:30 自动跑（重打包 + 清不可达对象），
+  不做任何历史清理。它跟备份的 cron 时间要错开。
+
+---
+
+## 七、还没定的事
+
+- 桌面端「连接团队案件库」当前走 `CloudSyncService.connect` →
+  `POST /api/auth/device-token`（**账号 + 口令**）。而案件库开了
+  `registration-mode: closed` + `awdk-login-enabled: true`，经桥接建的账号是**无口令
+  账号**（`UserService` 的口令哨兵前缀），这条路走不通。所以要么桌面端补一条
+  awdk 桥接的连接方式，要么在案件库上另开口子。本目录只准备部署侧，
+  这一条属于客户端改造，需要主会话确认由谁做、什么时候做——**在它落地之前，
+  案件库对普通用户是连不上的**。
+- 8G 共机的内存余量是纸面推算（addin `MemoryMax=2560M` + case `1536M` + PG + MySQL +
+  Next.js），上线前需要在机器上 `free -m` / `systemd-cgtop` 实核一次。

--- a/deploy/case/aiworkdeck-case.service
+++ b/deploy/case/aiworkdeck-case.service
@@ -1,0 +1,64 @@
+# /etc/systemd/system/aiworkdeck-case.service
+# 官方案件库（case.aiworkdeck.com）。dev-board#441。
+#
+# 与同机的插件云后端（aiworkdeck-cloud.service）是**两个独立实例**：
+# 不同系统账号、不同端口、不同 PG 库、不同数据根。共用的只有 backend.jar 的代码。
+#
+# 为什么不复用 aiworkdeck 账号（cloud 用的那个）：
+#   1. 数据敏感度不同。案件库里是律师的案卷全文与全部历史，是这台机器上最敏感的
+#      资产；同 uid 意味着插件云后端一旦被攻破，攻击者直接读得到案卷与 case 的 env。
+#      分账号 + /data/aiworkdeck-case 0700 是一道零成本的隔离。
+#   2. 迁移时新机只要建一个账号，不用连带把 addin 那套身份也搬过去。
+
+[Unit]
+Description=AI WorkDeck Case Library (case.aiworkdeck.com)
+After=network.target postgresql@14-main.service
+Wants=postgresql@14-main.service
+
+[Service]
+Type=simple
+User=aiworkdeck-case
+Group=aiworkdeck-case
+# WorkingDirectory 决定 ai.plugins.dir / ai.packs.dir / ai.skills.dir 这几个
+# **相对路径**落在哪。放进数据根，rsync 一次就把它们一起带走。
+# （程序与配置仍在 /opt/aiworkdeck/case/，那边是可重建的。）
+WorkingDirectory=/data/aiworkdeck-case/var
+# 密钥全走 EnvironmentFile（0600，root:aiworkdeck-case 属主），不进 unit 文件
+EnvironmentFile=/opt/aiworkdeck/case/env
+ExecStart=/usr/bin/java -Xms256m -Xmx1024m \
+  -XX:+ExitOnOutOfMemoryError \
+  -jar /opt/aiworkdeck/case/backend.jar --spring.profiles.active=case
+Restart=always
+RestartSec=5
+
+# ---- 共享 4c8G 机器上的资源护栏 ----
+# 同机还有：官网 Next.js(PM2 :3000)、globalventure(:3001)、插件云后端(MemoryMax 2560M)、
+# PostgreSQL 14、MySQL、宝塔面板。所以这里刻意给小。
+#
+# 堆为什么是 768m：JGit 的常驻内存不是大头（core.packedGitLimit 默认只有 10MB，
+# 换出去的 pack 窗口很小），真正的峰值在 UploadPack 打包时的 delta 搜索——
+# PackConfig 默认 window=10 / depth=50 / **windowMemory=0（不限）**，
+# 一个大案卷的首次 clone 能把堆吃穿。所以堆给小，同时在服务账号的 ~/.gitconfig 里
+# 把 pack.windowMemory 钉死（见 deploy/case/README.md「JGit 内存护栏」，这是必做步骤，
+# 不是可选调优）。
+#
+# MemoryHigh 先做回收压制，MemoryMax 才是硬杀。留这道台阶是为了让"案件库自己变慢"
+# 优先于"cgroup 直接 OOM 掉整个 unit"。
+MemoryHigh=1280M
+MemoryMax=1536M
+CPUWeight=70
+# JGit 会同时开着多个 pack/idx 文件；仓库多了以后默认 1024 不够用
+LimitNOFILE=65535
+
+# ---- 文件系统收口：只有数据根与自己的 acme 目录可写 ----
+ProtectSystem=full
+PrivateTmp=true
+NoNewPrivileges=true
+ReadWritePaths=/data/aiworkdeck-case
+
+# 日志走 journald：journalctl -u aiworkdeck-case
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/case/aiworkdeck-case.service
+++ b/deploy/case/aiworkdeck-case.service
@@ -44,8 +44,8 @@ RestartSec=5
 #
 # MemoryHigh 先做回收压制，MemoryMax 才是硬杀。留这道台阶是为了让"案件库自己变慢"
 # 优先于"cgroup 直接 OOM 掉整个 unit"。
-MemoryHigh=1280M
-MemoryMax=1536M
+MemoryHigh=1536M
+MemoryMax=2048M
 CPUWeight=70
 # JGit 会同时开着多个 pack/idx 文件；仓库多了以后默认 1024 不够用
 LimitNOFILE=65535

--- a/deploy/case/env.example
+++ b/deploy/case/env.example
@@ -1,0 +1,32 @@
+# /opt/aiworkdeck/case/env —— systemd EnvironmentFile（权限必须 0600，属主 root:aiworkdeck-case）
+# 真实值只存在服务器上，本文件是占位模板。
+#
+# 这个文件是**迁移单元的一部分，但要和数据分开保管**：它里面的
+# AWD_PLATFORM_KEY_SECRET 一旦丢失，已落库的 per-user 平台 AI key 全部解不开。
+
+# PostgreSQL 专用账号口令（库 aiworkdeck_case，账号 aiworkdeck_case）
+# 迁移到新机可以换新口令——它只保护数据库连接，不参与任何落库加密。
+DB_PASSWORD=CHANGE_ME
+
+# per-user 平台 AI key 的落库加密密钥：openssl rand -base64 32
+# 启动强不变式：awdk-login-enabled=true 时缺失则 PlatformAiKeyCipher 直接拒绝启动。
+# 三条红线：
+#   - 与官网侧 AWD_KEY_ENCRYPTION_SECRET 是两把互不相干的密钥，绝不复用同一个值；
+#   - 与插件云后端（/opt/aiworkdeck/cloud/env）那把也**不复用**，两个实例各一把；
+#   - 迁移换机时**必须原样带走**，换值 = 存量密文全部作废。
+AWD_PLATFORM_KEY_SECRET=CHANGE_ME
+
+# 服务账号 HOME。~/.aiworkdeck 的状态文件与 JGit 读的 ~/.gitconfig 都落这里，
+# 所以它必须在数据根之下（迁移单元的一部分）。
+HOME=/data/aiworkdeck-case/home
+
+# ---- 以下都不配（案件库刻意不做的事，留在这里是为了说明"为什么没有"）----
+#
+# 手机影像云中转 MOBILE_RELAY_OSS_*：中转在插件云后端那台，案件库不参与。
+#
+# 短信 SMS_* / TWILIO_*：账号身份全部来自官网 awdk_ 桥接，案件库自己不发验证码。
+#
+# 反馈 FEEDBACK_OPTIMIZER_TOKEN：收件箱在 addin 那台，profile 里 ingest 已关。
+#
+# 外部数据服务 BOCHA_API_KEY / QICHACHA_* / TUSHARE_TOKEN / PKULAW_TOKEN：
+#   案件库不跑 AI 工具调用，配了也没有调用方。

--- a/deploy/case/nginx-case.conf.example
+++ b/deploy/case/nginx-case.conf.example
@@ -1,0 +1,173 @@
+# case.aiworkdeck.com —— 官方案件库（dev-board#441）
+# 部署在北京 ECS（8.152.169.44），与官网、插件云后端共机。只新增本 server 块，
+# 不改任何既有配置。宝塔机上落 /www/server/panel/vhost/nginx/case.aiworkdeck.com.conf。
+#
+# 与 nginx-addin.conf.example 的根本差异：**这台不服务浏览器**。
+# 没有 h5、没有 LOWA 编辑器、没有 office-addin 静态页、没有 feedback-console，
+# 因此也就没有 COOP/COEP 全站头 —— addin 那边"location 里出现任意 add_header
+# 就会丢弃上层继承的 add_header"的坑在这里天然不存在。
+# 反过来说：将来若在本文件里加了任何全站 add_header，每个带 add_header 的
+# location 都必须把它重复一遍，否则会漏。
+#
+# 宝塔坑：不要往本 server 块里 include 宝塔的默认片段（enable-php.conf、
+# 防盗链/防恶意 UA 规则）。git 客户端的 User-Agent 形如 `git/2.43.0` 或 `JGit/6.x`，
+# 命中 UA 黑名单的表现是 clone 直接 403 —— 而不是 git 客户端认识的 401，
+# 用户看到的是"没有权限"而不是"要输凭据"，极难往 nginx 上想。
+
+server {
+    listen 80;
+    server_name case.aiworkdeck.com;
+    # certbot webroot 验证
+    location /.well-known/acme-challenge/ {
+        root /opt/aiworkdeck/case/acme;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name case.aiworkdeck.com;
+    ssl_certificate     /etc/letsencrypt/live/case.aiworkdeck.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/case.aiworkdeck.com/privkey.pem;
+
+    # 后端 Spring Boot 只监听 127.0.0.1:9797（9696 是同机的插件云后端）
+    # 本站没有 root/index：不服务任何静态文件。
+
+    # ================= git smart-HTTP =================
+    # 端点：GitHttpController
+    #   GET  /git/{repo}.git/info/refs?service=git-upload-pack|git-receive-pack
+    #   POST /git/{repo}.git/git-upload-pack     （clone / fetch，长响应）
+    #   POST /git/{repo}.git/git-receive-pack    （push，大请求体）
+    # {repo} = 纯数字（项目文档仓库）| user-{id}-memory | project-{id}-memory
+    location /git/ {
+        proxy_pass http://127.0.0.1:9797;
+
+        # 必须 1.1：git 的 pack 请求体用 chunked 传输编码。上游若是 HTTP/1.0，
+        # nginx 为了算出 Content-Length 会**照样把整个请求体缓冲下来**——
+        # 下面那条 proxy_request_buffering off 会被静默忽略（不报错，只是不生效），
+        # 大案卷首推依旧会先落一份盘。这是最容易漏掉一行就白配的地方。
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # ---- Authorization 透传（这一条是 git 能不能用的开关）----
+        # nginx 默认就会把 Authorization 传给上游，这里显式写出来是为了：
+        #   1) 自我说明——读配置的人一眼看到凭据是要透传的，别顺手清掉；
+        #   2) 免疫上层 server/http 块里可能存在的 proxy_set_header Authorization ""。
+        # 配套两条红线：
+        #   - 本 location **绝不能**加 auth_basic。加了等于 nginx 自己把 Basic
+        #     凭据吃掉，后端永远收不到设备令牌。
+        #   - **绝不能**开 proxy_intercept_errors / 给 401 配 error_page。
+        #     后端的 401 带着 WWW-Authenticate: Basic realm="AIWorkdeck Git"，
+        #     git 客户端就是靠这个头才回头重发带凭据的请求；被 nginx 改写成自定义
+        #     错误页之后，客户端会直接放弃，表现为"输了密码也没用"。
+        proxy_set_header Authorization $http_authorization;
+
+        # ---- 请求体：不缓冲 ----
+        # push 时整个 pack 走一个 POST。开着请求缓冲的话 nginx 会先把它整份落到
+        # client_body_temp 再转发：多一份磁盘 I/O、多一倍时延，而且大案卷首推
+        # 能把 /var 的临时盘写满。关掉之后 nginx 直接边收边转。
+        # 附带的安全收益：后端在读 body 之前就先做鉴权（GitHttpController 先
+        # authorizeTarget 再进 ReceivePack），未授权的巨大推送不会先在本机落一份盘。
+        proxy_request_buffering off;
+
+        # ---- 响应体：不缓冲 ----
+        # clone 的响应是后端一边打包一边吐的流。开着缓冲会先攒到 proxy_temp 再发，
+        # 用户侧表现为"卡住不动很久然后突然跑完"，大案卷还会把临时盘写满。
+        proxy_buffering off;
+        proxy_cache off;
+
+        # ---- 体积上限 ----
+        # 首次"放进案件库"推的是整段历史（shareToCloud → pushMainlineToOrigin），
+        # 一个带扫描件的案卷首推几百 MB 到几 GB 都正常，addin 那边的 200m 远远不够。
+        # 给 4g 而不是 0（不限）：有限值超出时客户端拿到的是明确的 413，
+        # 不限则是一条谁也说不清上限在哪的通道。真的撞上 413 就在这里往上调，
+        # 并同步核一眼数据盘余量。
+        # 注意宝塔的 http 块里通常有一条全局 client_max_body_size（常见 50m），
+        # 本 location 的值会覆盖它——但只覆盖本 location，别指望它管到 /api/。
+        client_max_body_size 4g;
+
+        # ---- 超时 ----
+        # clone 一份大案卷是长响应：后端要遍历历史、做 delta 打包，
+        # 期间可能长时间没有字节流出。默认 60s 会在打包阶段就把连接掐了。
+        proxy_read_timeout  3600s;
+        proxy_send_timeout  3600s;
+        proxy_connect_timeout 30s;
+        # 慢上行链路（律所网络上传常年只有几 Mbps）下的读间隔容忍
+        client_body_timeout 300s;
+
+        # git 送出来的已经是压缩过的 pack，再 gzip 一遍纯耗 CPU
+        gzip off;
+    }
+
+    # ================= 后端 API =================
+    # 桌面端要打的：/api/auth/awdk-login、/api/auth/device-token、/api/projects/*、
+    # /api/cloud/*、/api/projects/{id}/version/prepare-remote、/api/admin/wizard（探活）
+    location /api/ {
+        proxy_pass http://127.0.0.1:9797;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        # 文件上传（案卷附件走 API 而非 git 的路径）
+        client_max_body_size 2g;
+    }
+
+    # ---- 登录/桥接端点限频 ----
+    # 三条都是"用凭据换长期设备令牌"的入口，是这台机器上唯一值得爆破的面。
+    # AuthAbuseGuard 在应用层还有一道按 IP 的失败锁定，这里是它的前置闸
+    # （前提是 server.forward-headers-strategy=native 已开，否则应用层看到的
+    #  IP 恒为 127.0.0.1，那道锁会退化成全站共享一把）。
+    location = /api/auth/awdk-login {
+        limit_req zone=awd_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:9797;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    # 桌面端「连接团队案件库」当前走的就是这条（CloudSyncService.connect），
+    # 它发出去的是**长期**凭据，限频比普通登录更要紧。
+    location = /api/auth/device-token {
+        limit_req zone=awd_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:9797;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location = /api/auth/login {
+        limit_req zone=awd_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:9797;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # ================= 其余一律 404 =================
+    # 案件库没有任何面向浏览器的内容。根路径不给重定向、不给欢迎页，
+    # 不留任何"这台机器上有什么"的探测面。
+    location / {
+        return 404;
+    }
+}
+
+# 放到 http{} 级别的限频 zone。**与插件云后端共用同一个 zone 名**：
+# 宝塔机上 addin 那次已经加过下面这一行，不要重复定义（nginx -t 会报 duplicate）。
+# 没加过才加（进 /www/server/nginx/conf/nginx.conf 的 http 块，或单独 conf.d 文件）：
+#   limit_req_zone $binary_remote_addr zone=awd_auth:10m rate=10r/m;


### PR DESCRIPTION
dev-board#441。用户拍板：先不买新 ECS，案件库作为**第二个后端实例**跑在现有北京机上，配置做成好迁移的。

## 内容
- `backend/src/main/resources/application-case.yml`：独立 profile（不复用 cloud——同机同 jar，改 addin 不许静默改到案卷）。9797 / `aiworkdeck_case` / `/data/aiworkdeck-case/store`；closed 注册 + awdk 桥 + 非 local-mode；packs/feedback/optimizer 显式关。
- `deploy/case/aiworkdeck-case.service`：独立账号 `aiworkdeck-case`，数据根做 cwd，`-Xmx1024m` / `MemoryMax=1536M`。
- `deploy/case/nginx-case.conf.example`：`/git/` 的 http/1.1 + 双向不缓冲 + 4g + 3600s + Authorization 透传；禁 `auth_basic` / `proxy_intercept_errors`。
- `deploy/case/README.md`：部署步骤、迁移单元（目录 + pg_dump + 平台密钥）与迁移配方、客户端零改动三前提、备份口径与恢复验证。
- `deploy/case/env.example`。

## 未做
纯配置，服务器侧未部署（#441 下一步）。桌面端连案件库现在只会走账号+口令（`/api/auth/device-token`），而案件库账号是 awdk 桥接的无口令账号——客户端的 awdk 连接路径属 dev-board#439。

🤖 Generated with [Claude Code](https://claude.com/claude-code)