### PR TITLE
ci(desktop): macOS 签名与公证改用境内主体（dev-board#447）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -18,8 +18,28 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 0. **版本规则 0.X.Y**（docs/INCREMENTAL_UPDATE_DESIGN.md）：X=大版本全量安装包；Y=小版本应用内补丁（overlay 机制，组件=backend-app/frontend-h5/zetaoffice-wrapper/pysvc-src）。小版本 tag 触发 CI `patch-gate` job（desktop/scripts/patch-gate.sh）：改壳（desktop/）、pom、LOWA 引擎、requirements.lock 都会被拒——这些只能随大版本走。补丁产物+签名 manifest 由 build-patch-assets.js 在 windows job 生成（私钥=secret UPDATE_SIGNING_KEY，备份 ~/.ssh/aiworkdeck_update_signing.pem；公钥内置 update-service.js，换钥须发大版本）；镜像同步 deploy/update-mirror-sync.sh 在官网 ECS 跑。
 1. 版本号**单一来源 `desktop/package.json` version**（backend 拆为 backend/app.jar + backend/lib/，启动 `java -cp "app.jar:lib/*" com.checkba.CheckbaApplication`，见 backend-service.js javaLaunchArgs；frontend version 不参与）。
 2. `git tag v<ver> && git push origin v<ver>` → 触发 desktop-build 双平台。auto 模式下 tag 推送不被分支保护拦；可用 Monitor 等 PR 合并后自动打 tag（v0.8.0 配方）。
-3. 产物：mac 仅 dmg（**arm64 only**，已放弃 Intel）；win 仅 nsis exe——**单包双架构**（dev-board#341）：主体 x64 全量 + 纯 arm64 Electron 壳（desktop-build.yml 在打包前 `electron-builder --dir --arm64` 产出、剪掉 resources/ 后由 installer.nsh 的 customInstall 在 ARM64 机器上覆盖进安装目录；壳约 260MB 未压缩、装器 +约 106MB）。ARM64 上渲染与 LOWA WASM 原生、JVM/Python 走转译层（javacv/torch 无 windows-arm64 natives，这是为什么不出纯 arm64 包）；x64 机器行为不变；本地构建无壳目录自动降级纯 x64。electron-builder 配置在 desktop/package.json "build" 字段（appId com.aiworkdeck.desktop、extraResources 打入 frontend/dist、backend.jar、jre、python、pysvc.tar.gz+meta、**graphviz、skills（随包内置 skill，v0.11.1 以前漏打）、litviz（诉讼可视化引擎）**；notarize teamId X9B97KVA84；entitlements desktop/build/entitlements.mac.plist）。**win 侧 `nsis` 字段（2026-08-31 起搜狗式一键 UI，dev-board#339）**：`oneClick:false` 但页面全部换装 `build/win/awd-oneclick-ui.nsh` 引擎——无边框大卡片（立即安装大按钮/协议链接/「自定义安装」展开路径行），点击后主窗收起为桌面右上角小进度卡，完成卡「立即体验」；`allowToChangeInstallationDirectory:false`（目录选择收进卡片，engine 强制追加 `AI WorkDeck` 子目录）；`include: build/installer.nsh` 只做桌面端接线（customWelcomePage/customInstallMode/customFinishPage 三钩子）。引擎设 `ManifestDPIAware`（根治高分屏点阵字）+ `CRCCheck off`（去掉大包启动前 verifying 长进度）；**卸载器仍走 MUI 经典页**，`installerSidebar`/`installerHeader` BMP 只为它保留；**静默安装（/S，自动更新路径）不进 GUI 代码**。改卡片布局必须同步改引擎 AWDUI_* 常量与 `build/win/oneclick-*.html` 的绝对定位（两边同一 96dpi 基准）。
+3. 产物：mac 仅 dmg（**arm64 only**，已放弃 Intel）；win 仅 nsis exe——**单包双架构**（dev-board#341）：主体 x64 全量 + 纯 arm64 Electron 壳（desktop-build.yml 在打包前 `electron-builder --dir --arm64` 产出、剪掉 resources/ 后由 installer.nsh 的 customInstall 在 ARM64 机器上覆盖进安装目录；壳约 260MB 未压缩、装器 +约 106MB）。ARM64 上渲染与 LOWA WASM 原生、JVM/Python 走转译层（javacv/torch 无 windows-arm64 natives，这是为什么不出纯 arm64 包）；x64 机器行为不变；本地构建无壳目录自动降级纯 x64。electron-builder 配置在 desktop/package.json "build" 字段（appId com.aiworkdeck.desktop、extraResources 打入 frontend/dist、backend.jar、jre、python、pysvc.tar.gz+meta、**graphviz、skills（随包内置 skill，v0.11.1 以前漏打）、litviz（诉讼可视化引擎）**；notarize teamId **8WKHZVR2W8**（境内主体北京京微资易，2026-09-05 起；此前是香港主体 X9B97KVA84，dev-board#447）；entitlements desktop/build/entitlements.mac.plist）。**win 侧 `nsis` 字段（2026-08-31 起搜狗式一键 UI，dev-board#339）**：`oneClick:false` 但页面全部换装 `build/win/awd-oneclick-ui.nsh` 引擎——无边框大卡片（立即安装大按钮/协议链接/「自定义安装」展开路径行），点击后主窗收起为桌面右上角小进度卡，完成卡「立即体验」；`allowToChangeInstallationDirectory:false`（目录选择收进卡片，engine 强制追加 `AI WorkDeck` 子目录）；`include: build/installer.nsh` 只做桌面端接线（customWelcomePage/customInstallMode/customFinishPage 三钩子）。引擎设 `ManifestDPIAware`（根治高分屏点阵字）+ `CRCCheck off`（去掉大包启动前 verifying 长进度）；**卸载器仍走 MUI 经典页**，`installerSidebar`/`installerHeader` BMP 只为它保留；**静默安装（/S，自动更新路径）不进 GUI 代码**。改卡片布局必须同步改引擎 AWDUI_* 常量与 `build/win/oneclick-*.html` 的绝对定位（两边同一 96dpi 基准）。
 4. 签名抖动：Apple 时间戳抖动 = rerun 即可（连挂两次也 rerun）；公证轮询抖动排查见 ci-macos 记录。
+4.1. **macOS 签名与公证的主体 = 境内 Team `8WKHZVR2W8`（北京京微资易），2026-09-05 起（dev-board#447）**。
+   两条链路各自的凭据：**签名**仍是 `CSC_LINK`（Developer ID Application 的 .p12 base64）+
+   `CSC_KEY_PASSWORD`，`desktop/scripts/sign-mac-natives.sh` 那一步与 electron-builder 各自
+   从它导一次；**公证改走 ASC API Key**，三个 secret `APPLE_API_KEY_B64`（.p8 的 base64）/
+   `APPLE_API_KEY_ID` / `APPLE_API_ISSUER`——旧的 `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` /
+   `APPLE_TEAM_ID` 已从 workflow 摘除。三个地雷：
+   ① electron-builder 认的 `APPLE_API_KEY` 是 **.p8 的文件路径**不是内容，所以 secret 只能存
+   base64、在 run 步骤里解码到 `$RUNNER_TEMP/AuthKey.p8` 再 `export`（`env:` 块拼不出 `$RUNNER_TEMP`）；
+   ② 它对这三个变量是「全有或全无」——见到任意一个非空就要求三个都在，否则
+   `InvalidConfigurationError`，三个全空才静默跳过公证，**fork PR 靠的就是全空这条路**，
+   所以解码那段必须包在 `[ -n "$APPLE_API_KEY_B64" ]` 里，`else` 分支还要 `unset` 另两个；
+   ③ 它先看 `APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`（option 1）再看 API Key（option 2），
+   两套同时给会走旧路——别为了「保险」把旧 env 留着。
+   `notarytool history/log` 同样改 `--key/--key-id/--issuer`，**API Key 认证不接 `--team-id`**
+   （团队由 issuer 唯一确定），此前那条「APPLE_TEAM_ID secret 会让 history API 报 403」的注释
+   只对 Apple ID 认证成立。团队号全仓只剩 `desktop/package.json` 的 `mac.notarize.teamId` 一处。
+   换主体对存量 mac 用户无影响：桌面端没有应用内自动更新（`build.publish` 为空、不带
+   electron-updater），也不用钥匙串/safeStorage，签名主体变了不会让旧版失效或掉数据。
+   **`office-addin/installer/build-installers.mjs` 不共用这套**：它在维护者 Mac 上取钥匙串里
+   **第一条** `Developer ID Application` 身份，两个主体的证书都装着时选到哪张不确定（见「已知地雷」）。
 4.5. **Office 插件安装器是发版硬步骤（2026-08-19 维护者定，自 v0.21.0 之后的发版起强制）**：
    每次发版都要重建并上架插件的 dmg+exe——在维护者 Mac 上
    `cd office-addin/installer && npm run build:installers`（版本自动取
@@ -292,6 +312,11 @@ stash 误 pop 之类）之后，5174 上的页面可能变成**整页无样式**
   兜底。改动这三份文件之一时，自查该 PR 的 Detect 步骤输出应为 FULL。
 - 发版有个跨仓的时间差：镜像脚本删旧包 vs 官网页面 ISR 缓存。两边任何一边改保留策略/缓存时长前，先看 `deploy/update-mirror-sync.sh` 里 prune_old_installers 的注释。
 - macOS CI 红要当真查（Apple 协议过期事件后恢复）；`--admin` 合并与 worktree 删分支技巧见 ci-macos 记录。
+- **`office-addin/installer/build-installers.mjs` 挑签名身份靠「第一条 Developer ID Application」**
+  （`security find-identity -v -p codesigning` 的输出顺序，不是按主体筛的）。维护者 Mac 上
+  同时装着香港 `X9B97KVA84` 与境内 `8WKHZVR2W8` 两张 Developer ID Application 之后，
+  插件安装器签到哪个主体名下就不确定了。出插件 dmg 前先 `security find-identity -v -p codesigning`
+  核一眼落在第一条的是谁；要钉死主体得给脚本加显式身份参数（尚未做）。
 - iCloud 驱逐会掏空本地文件（打包/测试环境两次踩）；EMFILE 用抬 ulimit 解。
 - **iCloud 上「读一下」不是免费的**：被驱逐的文件是 dataless 占位，`stat` 秒回真实大小但
   `st_blocks=0`，**一 read 就同步触发下载**（本机实测 23KB 文件首次 read 耗 1.28 秒，延迟

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -493,9 +493,13 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # 公证走 App Store Connect API Key（境内主体 8WKHZVR2W8 起，dev-board#447），
+          # 不再用 Apple ID + App 专用密码。electron-builder / @electron/notarize 认
+          # APPLE_API_KEY（.p8 的**文件路径**）/ APPLE_API_KEY_ID / APPLE_API_ISSUER，
+          # 路径没法在 env: 里拼 $RUNNER_TEMP，所以 secret 存 base64、下面解码落盘再 export。
+          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           # GitHub never exposes secrets to fork PRs, so CSC_LINK is empty
           # there — and force-signing with an empty CSC_LINK makes
           # electron-builder fail ("not a file"). Only force signing when the
@@ -503,6 +507,17 @@ jobs:
           # electron-builder's default unsigned PR build.
           CSC_FOR_PULL_REQUEST: ${{ secrets.CSC_LINK != '' }}
         run: |
+          # 公证凭据：三个环境变量要么全有要么全无——electron-builder 只要见到其中
+          # 任意一个非空就要求三个都在，否则抛 InvalidConfigurationError；三个全空
+          # 才会静默跳过公证（fork PR 走的就是这条路）。
+          if [ -n "$APPLE_API_KEY_B64" ]; then
+            printf '%s' "$APPLE_API_KEY_B64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+            chmod 600 "$RUNNER_TEMP/AuthKey.p8"
+            export APPLE_API_KEY="$RUNNER_TEMP/AuthKey.p8"
+          else
+            echo "No ASC API key (fork PR) — notarization will be skipped"
+            unset APPLE_API_KEY_ID APPLE_API_ISSUER
+          fi
           # mineru lib（transformers 等）有数万个小文件，macOS 默认 fd 上限 256 会让
           # electron-builder 在打包/装订阶段 EMFILE。65536 实测仍复现——内核级
           # kern.maxfilesperproc（默认 61440）同样要抬，三层一起调并打印生效值
@@ -514,23 +529,31 @@ jobs:
       - name: Notarization failure log (macOS)
         if: failure() && runner.os == 'macOS'
         env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          # NOT the APPLE_TEAM_ID secret: notarytool history rejects it with
-          # 403 (it works for submission but not for the history API); the
-          # team id is public anyway (package.json mac.notarize.teamId)
-          TEAM_ID: X9B97KVA84
+          # 与打包步骤同一把 ASC API Key（境内主体 8WKHZVR2W8）。API Key 认证不接
+          # --team-id（团队由 issuer 唯一确定）；旧写法用 Apple ID + App 专用密码时
+          # 才需要它，且当时必须写死 team id——APPLE_TEAM_ID secret 会让 history API
+          # 报 403。团队号现在只在 package.json mac.notarize.teamId 一处。
+          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
           # Surface Apple's per-file rejection reasons; without this the build
           # log only says "Invalid"
-          HISTORY=$(xcrun notarytool history --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$TEAM_ID" \
+          if [ -z "$APPLE_API_KEY_B64" ]; then
+            echo "No ASC API key (fork PR) — cannot query notarization history"
+            exit 0
+          fi
+          KEY="$RUNNER_TEMP/AuthKey-notarylog.p8"
+          printf '%s' "$APPLE_API_KEY_B64" | base64 --decode > "$KEY"
+          chmod 600 "$KEY"
+          HISTORY=$(xcrun notarytool history --key "$KEY" \
+            --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
             --output-format json || true)
           echo "$HISTORY" | head -c 2000; echo
           for SUB_ID in $(echo "$HISTORY" | jq -r '.history[0:2][].id // empty'); do
             echo "=== notarization log for $SUB_ID"
-            xcrun notarytool log "$SUB_ID" --apple-id "$APPLE_ID" \
-              --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$TEAM_ID" \
+            xcrun notarytool log "$SUB_ID" --key "$KEY" \
+              --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
               "$RUNNER_TEMP/notary-log-$SUB_ID.json" || true
             cat "$RUNNER_TEMP/notary-log-$SUB_ID.json" || true
             echo

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -88,7 +88,7 @@
         "NSMicrophoneUsageDescription": "麦克风用于两件事：会议录音插件录制会议音频（保存到你的项目文件，用于转写与纪要），以及反馈浮窗“说一段”的语音留言。均为你主动点击才开始，不会在后台采集。 The microphone is used for the meeting-recording plugin (audio saved to your project for transcription and minutes) and for the in-app feedback voice note. Recording starts only when you click, never in the background."
       },
       "notarize": {
-        "teamId": "X9B97KVA84"
+        "teamId": "8WKHZVR2W8"
       }
     },
     "dmg": {


### PR DESCRIPTION
dev-board#447。用户决定 Mac 桌面端改用境内主体（北京京微资易，Team `8WKHZVR2W8`）签名与公证，停用香港主体。

## 改动
- `build.mac.notarize.teamId` → `8WKHZVR2W8`。
- 公证改走 ASC API Key：`APPLE_API_KEY_B64`（解码落盘后 export `APPLE_API_KEY`）/ `APPLE_API_KEY_ID` / `APPLE_API_ISSUER`；三个全空才跳过，fork PR 显式 unset。失败日志步骤同步改 `--key/--key-id/--issuer`。
- eng-infra 文档同步 + 新地雷（插件安装器签名身份/公证凭据可能分属两主体）。

## 合并前提（草稿原因）
1. Account Holder 在网页用 `x-apple-jwzy/devid.csr` 创建 Developer ID Application 证书。
2. 合成带 G2 中间 CA 的 p12，本地 `security find-identity` 自检恰好一条 `(8WKHZVR2W8)`。
3. 换 `CSC_LINK`/`CSC_KEY_PASSWORD`，新建三个 API Key secrets。旧三个 secret 留到首个境内签名版本验收后再删。

已核：桌面端无应用内自动更新、不用钥匙串/safeStorage，换主体不影响存量用户。

🤖 Generated with [Claude Code](https://claude.com/claude-code)