### PR TITLE
chore(cloud): 插件云后端 profile 关闭版本记录自动开启（dev-board#438 补漏）

### DIFF
--- a/backend/src/main/resources/application-cloud.yml
+++ b/backend/src/main/resources/application-cloud.yml
@@ -71,3 +71,9 @@ feedback:
 # 优化者跑在维护者自己的机器上，经 /api/feedback/pending 取件（deploy/optimizer/README.md）。
 optimizer:
   enabled: false
+
+version:
+  # 插件云后端不是案件库：插件归档绑定会在这台上建影子项目，若让 #438 的自动开启在这里生效，
+  # 每个影子项目都会在 /opt/aiworkdeck/cloud/data/repos 下长出一个 git 仓库（40G 系统盘）。
+  # 官方案件库在 application-case.yml 单独一台实例。
+  auto-enable: false


### PR DESCRIPTION
#438 的自动开启默认对所有 profile 生效；addin 插件云后端上的归档影子项目不该长 git 仓库（与官网共机的 40G 系统盘）。官方案件库在 `application-case.yml` 单独实例（那边已关）。纯配置，一行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)