### PR TITLE
chore(release): 版本号 0.34.0（dev-board#451）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
dev-board#451。单文件 bump 0.33.2 → 0.34.0。

本版：版本记录默认开启（#438，含并发回归修复）、官方案件库零配置直连（#439）、按手机号邀请同事 + 参与人列表 JSONNull 修复（#444）、存量缺陷与分支回收（#442 #443）、案件库部署包（#441）、macOS 改境内主体签名公证（#447）。

判据：`desktop/build/win/oneclick-mini-*.html` 自 v0.33.2 有改动 → 不能走小版本。
**合并顺序**：等 #440（砍自建界面）合入后再合本 PR，tag 打在本 PR 合并之后。

🤖 Generated with [Claude Code](https://claude.com/claude-code)