### PR TITLE
fix(litviz): 出图 kickoff 第一步落在读取工具上、完成判据挂末位且保留 checkpoint 停顿（dev-board#456）

### DIFF
--- a/.claude/agents/litigation-visual.md
+++ b/.claude/agents/litigation-visual.md
@@ -124,6 +124,28 @@ JSON 对不对，不取决于模型对像素多聪明——这是上游的核心
 **改 skill/工具时别把这两段话当文案删掉，它们是契约**，由
 `backend/src/test/java/com/checkba/service/ai/tools/LitigationVisualFlowTest.java` 钉住。
 
+**kickoff prompt 的两条形状约束**（`LitigationVisualPanelService.buildKickoffPrompt`，
+dev-board#456）：真机上点「股权结构」，模型读完材料在对话里给了一张 markdown 表格就收工，
+一个 `litigation_*` 都没调，追问才补出图。两个成因都在这段 prompt 的形状里：
+- **第一步必须落在工具上**。原来写的是「通读材料做抽取，在心里/回复里写出语义地图 JSON」——
+  按它自己的措辞，把抽取结果写进回复就算做完了第一步。现在改成
+  「用 extract_file_text / search_project_files 通读材料……不要把它写进回复；
+  材料摘要、来源对照表也不是本轮的交付物」，与时间轴分支的第 1 步同构。
+- **完成判据挂末位**。每次工具成功后编排器都在消息末位喊「任务完成就立刻输出 `<final>`」
+  （`AgentOrchestrator` 的 XML 兜底分支），而这段 prompt 原来的最后一句是 write_file 禁令，
+  「必须出图」埋在中间。现在两条分支的最后一段都是完成判据常量
+  （`COMPLETION_CRITERION_MAP` / `COMPLETION_CRITERION_TIMELINE`）。
+  **判据必须写成「两种合法结束方式」**：`litigation_checkpoint` 三问后停下等用户，
+  或 render 成功返回。写成「不出图不许结束」会把人工确认那一停也禁掉，逼出
+  「未经确认直接出草稿图」——草稿闸与红色授权制都挂在 checkpoint 上，那比少一张图更糟。
+  口径与 `LitigationVisualTools.CHECKPOINT_NEXT_STEPS` 第 1 条、prompt.md §3 一致。
+  由 `backend/src/test/java/com/checkba/service/LitigationKickoffPromptTest.java` 钉住
+  （连带钉住 write_file/read_file 禁令没被这轮改写顺手删掉）。
+  注意这仍是概率性的：`ContextAssemblerService` 会在用户消息后追加「当前已打开文档」提醒，
+  所以 prompt 的末位不等于整条用户消息的末位。确定性兜底仍然缺位——面板侧「本轮没出图」
+  的提示按钮做不了，因为 `sendExternalPrompt` 在 POST ack 就返回（真正的流走另一条 SSE），
+  面板拿不到「这一轮结束了、调了哪些工具」的信号。
+
 **会话级幂等**：`LitigationVisualTools.TURN_STATES`（conversationId → TurnState，LRU 封顶 200）。
 同一份地图重复调 checkpoint 不重跑脚本、返回同一份三问并计次提示；同一指纹
 （地图+图名+落点+模式+格式）重复调 render 直接回上次的交付说明、不重复出图。

--- a/backend/src/main/java/com/checkba/service/LitigationVisualPanelService.java
+++ b/backend/src/main/java/com/checkba/service/LitigationVisualPanelService.java
@@ -345,6 +345,32 @@ public class LitigationVisualPanelService {
     }
 
     /**
+     * 末位完成判据（dev-board#456）。
+     *
+     * <p>真机上模型读完材料就在对话里给了一张 markdown 表格收工，一个 litigation_* 工具
+     * 都没调——每次工具成功后编排器都会在消息末位喊「任务完成就立刻输出 &lt;final&gt;」，
+     * 而这段 prompt 原来的最后一句是 write_file 禁令，「必须出图」埋在中间。仓内的经验是
+     * 约束要挂末位，所以把「本轮怎样才算结束」补在最后。
+     *
+     * <p><b>口径必须与人工确认那一停一致</b>：本功能的确认轮本来就是「三问发给用户后停下」，
+     * 写成「不出图不许结束」会把它一起禁掉，反而逼出「未经确认直接出草稿图」——那比少一张图
+     * 更糟（草稿闸与红色授权制都挂在 checkpoint 上）。所以这里给的是两种合法结束方式，
+     * 与 LitigationVisualTools.CHECKPOINT_NEXT_STEPS 第 1 条、skill prompt.md §3 同一口径。
+     */
+    private static final String COMPLETION_CRITERION_MAP =
+            "\n\n本轮只有两种正确的结束方式：一是调用 litigation_checkpoint 之后，"
+                    + "把它返回的三个确认问题原样发给我、停下等我回复；"
+                    + "二是我确认之后 litigation_render 成功返回，你再交付说明。"
+                    + "除此之外不要用总结、表格或 <final> 结束本轮。";
+
+    /** 时间轴大师那条管线的同款判据：中途的勾选清单同样是合法的停下点。 */
+    private static final String COMPLETION_CRITERION_TIMELINE =
+            "\n\n本轮只有两种正确的结束方式：一是把工具列出的勾选清单用 <question>+<option> "
+                    + "原样发给我、停下等我回复；"
+                    + "二是 litigation_timeline_render 成功返回，你再交付说明。"
+                    + "除此之外不要用总结、表格或 <final> 结束本轮。";
+
+    /**
      * 拼「开始出图」那句话。
      *
      * <p><b>触发词必须原样出现在正文里</b>——skill 注入靠 SkillRouter 在用户消息里
@@ -371,6 +397,7 @@ public class LitigationVisualPanelService {
             sb.append("\n3. 最后用 litigation_timeline_render 出图。");
             sb.append("\n中间产物（verdicts/parts/skeleton/items）一律经工具参数提交，"
                     + "不要用 write_file 存成项目文件。");
+            sb.append(COMPLETION_CRITERION_TIMELINE);
             return sb.toString();
         }
         // 工具链写成确定性的四步。这里不是啰嗦：真机上模型走过
@@ -378,7 +405,9 @@ public class LitigationVisualPanelService {
         // 也出现过确认完只更新地图、忘了调 litigation_render 就说"图好了"。
         // 语义地图本来就是两个工具的内联参数，用不着落文件。
         sb.append("\n\n请按这条工具链来，不要改顺序：");
-        sb.append("\n1. 通读材料做抽取，在心里/回复里写出语义地图 JSON。");
+        sb.append("\n1. 用 extract_file_text / search_project_files 通读材料做抽取，"
+                + "把语义地图 JSON 想清楚。它只作为下一步的工具参数存在，不要把它写进回复；"
+                + "材料摘要、来源对照表也不是本轮的交付物。");
         sb.append("\n2. 调 litigation_checkpoint（语义地图作参数直接传进去），");
         sb.append("把它返回的三个确认问题原样发给我，然后停下等我回复。");
         sb.append("\n3. 我回复后，把答复回填进同一份 JSON 的 checkpoint 字段，");
@@ -386,6 +415,7 @@ public class LitigationVisualPanelService {
         sb.append("\n4. 出图成功后再向我交付说明。");
         sb.append("\n\n语义地图全程作为工具参数内联传递：不要用 write_file 把它存成项目文件，");
         sb.append("也不要用 read_file 读回来。原文逐字保留，不要改动任何表述。");
+        sb.append(COMPLETION_CRITERION_MAP);
         return sb.toString();
     }
 

--- a/backend/src/test/java/com/checkba/service/LitigationKickoffPromptTest.java
+++ b/backend/src/test/java/com/checkba/service/LitigationKickoffPromptTest.java
@@ -1,0 +1,80 @@
+package com.checkba.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 「诉讼可视化」面板 kick-off prompt 的契约测试（dev-board#456）。
+ *
+ * <p>真机症状：点「股权结构」出图，模型读完材料就在对话里给了一张 markdown 表格收工，
+ * 一个 litigation_* 工具都没调，追问才补上 litigation_render。两条勾住的契约：
+ * <ol>
+ *   <li>第一步必须落在读取工具上，不能是「写进回复」的交付物；</li>
+ *   <li>完成判据挂在整段的末位（仓内「约束要挂消息末位」），并且必须与
+ *       litigation_checkpoint 的「三问发给用户后停下等回复」是同一个口径——
+ *       写成「不出图不许结束」会把人工确认那一停也一起禁掉。</li>
+ * </ol>
+ *
+ * <p>buildKickoffPrompt 不碰任何字段，构造器传 null 即可。
+ */
+class LitigationKickoffPromptTest {
+
+    private static final LitigationVisualPanelService SVC =
+            new LitigationVisualPanelService(null, null, null, null, null);
+
+    /** 整段的最后一个自然段（末位约束所在处）。 */
+    private static String lastParagraph(String prompt) {
+        String p = prompt.trim();
+        int i = p.lastIndexOf("\n\n");
+        return i < 0 ? p : p.substring(i + 2);
+    }
+
+    @Test
+    void semanticMapStepOneIsAToolCallNotAReplyDeliverable() {
+        String p = SVC.buildKickoffPrompt("本项目全部材料", "股权控制结构树");
+
+        assertFalse(p.contains("在心里/回复里"),
+                "第一步不能允许把语义地图写进回复当交付——真机上模型就是在这里收工的（dev-board#456）");
+        assertFalse(p.contains("回复里写出"), "同上：回复不是本轮的交付物");
+        assertTrue(p.contains("extract_file_text"),
+                "第一步必须落在具体的读取工具上，与时间轴分支的第 1 步同构");
+        assertTrue(p.contains("不是本轮的交付物") || p.contains("不要把它写进回复"),
+                "要显式说明材料摘要/对照表不是交付物，否则模型会拿它顶交付");
+    }
+
+    @Test
+    void completionCriterionSitsLastAndKeepsTheCheckpointStop() {
+        String p = SVC.buildKickoffPrompt("本项目全部材料", "股权控制结构树").trim();
+        String tail = lastParagraph(p);
+
+        assertTrue(p.lastIndexOf("litigation_render") > p.lastIndexOf("逐字"),
+                "完成判据必须排在 write_file/read_file 禁令之后，占住末位");
+        assertTrue(tail.contains("litigation_checkpoint") && tail.contains("停下等我回复"),
+                "末位那段必须先给出 checkpoint 三问后停下的合法结束方式，"
+                        + "否则与 LitigationVisualTools.CHECKPOINT_NEXT_STEPS 第 1 条打架");
+        assertTrue(tail.contains("litigation_render"), "另一种合法结束方式是 render 成功返回");
+        assertTrue(tail.contains("<final>"), "要明说不许直接以 <final> 收工");
+    }
+
+    @Test
+    void writeFileBanSurvivesTheRewrite() {
+        String p = SVC.buildKickoffPrompt("本项目全部材料", "股权控制结构树");
+        assertTrue(p.contains("write_file") && p.contains("read_file"),
+                "语义地图不落文件是三处同写的契约（.claude/agents/litigation-visual.md），改第一步时不许顺手删掉");
+        assertTrue(p.contains("litigation_checkpoint") && p.contains("litigation_render"),
+                "工具链本身不变");
+    }
+
+    @Test
+    void timelineBranchKeepsItsOwnPipelineAndAlsoEndsWithACompletionCriterion() {
+        String t = SVC.buildKickoffPrompt("本项目全部材料", "事实经过时间轴");
+
+        assertTrue(t.contains("litigation_timeline_start"), "时间轴走的是时间轴大师管线");
+        assertFalse(t.contains("litigation_checkpoint"), "两条路不许串");
+
+        String tail = lastParagraph(t.trim());
+        assertTrue(tail.contains("litigation_timeline_render"), "末位要给出 render 这个完成判据");
+        assertTrue(tail.contains("停下等我回复"), "勾选清单那一停同样是合法结束方式");
+    }
+}


### PR DESCRIPTION
## 问题
诉讼可视化「股权结构」第一次不出图：模型读完材料在对话里输出 markdown 表格后 run 结束，一个 litigation_* 工具都没调，追问才出 drawio。

## 根因
`LitigationVisualPanelService.buildKickoffPrompt` 语义地图分支第一步写的是「通读材料做抽取，在心里/回复里写出语义地图 JSON」——按它自己的措辞，把抽取结果写进回复就算做完第一步；而整段的最后一句是 write_file 禁令，「必须出图」埋在中间，被编排器每次工具成功后追加在末位的「任务完成就立刻输出 <final>」盖过。

## 修法
- 第一步改为工具调用措辞（extract_file_text / search_project_files 通读，语义地图只作为工具参数存在，摘要与对照表不是交付物）。
- 两条分支末位各加完成判据常量。**没有照抄「不出图不许结束」**：那会把 checkpoint 三问后停下等用户这一停也禁掉，逼出未经确认的草稿图。写成两种合法结束方式，与 CHECKPOINT_NEXT_STEPS 第 1 条、skill prompt.md §3 同口径。
- 领域文档补记 kickoff prompt 的两条形状约束。
- 不做 tool_choice（无 plumbing）；面板侧「本轮未出图 → 继续」兜底需要新的 run-finished 契约，另开卡。

## 验证
- 新增 LitigationKickoffPromptTest 4 用例，先红 3 后绿 4。
- `mvn -Dtest='Litigation*,BuiltinSkillsTest,SkillRegistryTest,SkillRouterTest' test`：98 run / 0 fail / 4 skip（无随包字体按设计跳过）。
- 行为面未验证：这是概率性失误，复测请在真机上股权结构/关系图/流程图各跑 3 次看首轮调用率。

dev-board#456

🤖 Generated with [Claude Code](https://claude.com/claude-code)