### PR TITLE
fix(shell): 面板拖拽上限按实测容器宽算，主窗口出生尺寸夹在工作区内（dev-board#459）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -532,6 +532,27 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
 - **awd-\* 类名约定**（King IDE 品牌清零后的通用弹窗/按钮样式，PR#171）：awd-dialog/-mask/-header/-title/-body/-footer、awd-btn/-primary/-secondary/-danger、awd-field/awd-input。**没有集中定义**——在 project-overview.vue（~:10180-10300）、ChatInterface.vue（~:2869 起）、FileTree.vue 各自 scoped 重复定义；改样式要多处同步。
 - 外壳布局类：.header-tools:6904、.rail-btn:7009、.sidebar-left:7403/7905、.workbench:7455、.bottom-panel:7283/7510、.compact-mode:7478、.is-resizing:7927。
 - **面板拖拽的跟手守卫是三件一套，删一件拖拽就会退化**（2026-08-20）：① `.is-resizing` 禁 transition；② `.is-resizing :deep(iframe)/:deep(webview)` 关 pointer-events——光标滑进嵌入文档父窗口就收不到 mousemove，拖拽会冻住；③ 桌面端浏览器 BrowserView 是原生层 CSS 管不到，靠 `desktopOverlayActive` 里那条 `resizing.active` 在拖拽期间隐藏。另外 `startResize/stopResize`（tabDragSplit.js）会锁/还原 body 的 cursor 与 user-select。编辑器窗格 `.editor-pane`/`.pane-content` 已拉平成方角（圆角卡片残留会在标签栏下沿与分栏缝露出底色弧口），别再给它们加 border-radius。
+- **面板拖拽的上限按「面板所在容器的实测宽」算，不按整窗宽算**（2026-09-05，dev-board#459）：
+  原来两支都是 `Math.floor(window.innerWidth * 0.75)`，可 `.side-panel-ai` 的父容器
+  `.workbench-main` 只拿到「整窗 − rail − 左栏」。`.side-panel{flex-shrink:0}` 让面板不肯
+  让宽、`.workbench{overflow:hidden}` 又把溢出裁掉，于是编辑区先塌成 0、面板右半边（输入框
+  与发送键）被裁在窗口右缘之外——**看上去就像 Electron 窗口被撑出了屏幕**，把窗口放大
+  正好能让它复原，所以很容易被报成窗口 bug。公式外置成零依赖纯函数
+  `pages/project-overview/panelWidthLimits.js`（`rightPanelMaxWidth` / `leftPanelMaxWidth` /
+  `EDITOR_MIN_WIDTH = 200`，同 `flushDirtyEditors.js` 的先例：本目录其余模块都 import 了
+  `@/` 别名，node 直接测不动）。容器几何在 `startResize` 里从 `element.parentElement` 实测
+  一次并缓存到 `this.resizing`（右侧量 `.workbench-main`；左栏量 `.main-layout` 再减去实测
+  的 `.left-rail` 与 `.side-panel-ai` 宽）——**不要改回硬编码 rail=50 一类常量**，边框、
+  紧凑模式与右侧 dock（#180）都会让常量漂。左右两支必须一起用新公式：只修右支的话，拖宽
+  左栏就能把同一个症状换个入口复现（接线用例钉着这一条）。**「遮挡就遮挡」的既有决策保留**：
+  只保证编辑区还剩 200px，不做窗口变窄时的回夹（`handleResponsiveResize` 一行未动）。
+  单测 `frontend/tests/project-home/panel-width-limits.test.mjs`（`npm run test:project-home`）。
+  同轮把桌面壳建窗尺寸夹进工作区（`desktop/main/main.js` 的 `createMainWindow`：
+  `Math.min(1400, screen.getPrimaryDisplay().workAreaSize.width)`，高度同理）——工作区窄于
+  1400x900 的屏上，裸常量会让窗口一出生就比屏幕大，而全仓没有任何 `mainWindow.setSize/
+  setBounds`，这是「窗口超出屏幕」唯一的代码成因。护栏 `desktop/tests/main-window-bounds.test.js`
+  （源码级断言，已挂进 `desktop/package.json` 的 test 脚本；main.js 一 require 就建窗拉服务，
+  只能照 `native-theme-light.test.js` 的口径测）。
 - **编辑器标签（`.tab-item`）在 project-overview.scss 里只有一份定义了**。此前有两份：
   靠前那份是 VS Code 式贴合标签，被靠后那份整个覆盖成死代码，实际生效的是一排
   10px 全圆角 + 四面描边 + `min-width:100px` 的「筛选 chip」，与下方编辑器完全断开。

--- a/desktop/main/main.js
+++ b/desktop/main/main.js
@@ -346,9 +346,13 @@ function createMainWindow() {
   // 渲染层 api.js 优先读它，取代原先写死的 9696。
   const backendPort = (services && services.ports && services.ports.backend)
     || Number(process.env.CHECKBA_BACKEND_PORT || (app.isPackaged ? 5269 : 9696))
+  // 出生尺寸夹在显示器工作区内（dev-board#459）：工作区窄于 1400x900 的屏上，
+  // 裸常量会让窗口一出生就比屏幕大，只能靠「窗口 → 缩放」救回来。
+  // workAreaSize 已经扣掉菜单栏/Dock，不要再自行减。
+  const workArea = screen.getPrimaryDisplay().workAreaSize
   mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
+    width: Math.min(1400, workArea.width),
+    height: Math.min(900, workArea.height),
     icon: path.join(__dirname, '../../frontend/src/static/icon.png'),
     // 无边框：窗口控件并进渲染层已有的 .project-header（42px），系统标题栏不再单占
     // 一条。设计见 docs/superpowers/specs/2026-08-16-desktop-chrome-and-command-menu.md。

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js tests/share-file.test.js"
+    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js tests/share-file.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/tests/main-window-bounds.test.js
+++ b/desktop/tests/main-window-bounds.test.js
@@ -1,0 +1,49 @@
+// 主窗口出生尺寸必须夹在显示器工作区内（dev-board#459）。
+//
+// 病灶：createMainWindow 写死 width:1400 / height:900，既没有 x/y 也没有按
+// screen.getPrimaryDisplay().workAreaSize 夹一次。工作区比 1400×900 窄的显示器上，
+// 窗口一出生就比屏幕大，只能靠「窗口 → 缩放」（app-menu.js 的 role:'zoom'）救回来。
+// 全仓找不到第二条能让主窗口变大的代码路径——没有任何 setSize/setBounds 打在
+// mainWindow 上，所以这是「窗口超出屏幕」唯一的代码成因。
+//
+// main.js 起手就 new BrowserWindow / 拉服务，node 直接 require 不进来，
+// 因此与 native-theme-light.test.js 同口径做源码级断言。
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const SRC = fs.readFileSync(path.join(__dirname, '../main/main.js'), 'utf8')
+const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+function createMainWindowBody() {
+  const start = CODE.indexOf('function createMainWindow()')
+  assert.ok(start >= 0, '找不到 createMainWindow')
+  const end = CODE.indexOf('webPreferences', start)
+  assert.ok(end > start, '截不到 new BrowserWindow 的尺寸段')
+  return CODE.slice(start, end)
+}
+
+test('从 electron 引入 screen（夹取工作区尺寸靠它）', () => {
+  const line = CODE.split('\n').find((l) => l.includes("require('electron')"))
+  assert.ok(line, "找不到顶层 require('electron')")
+  assert.match(line, /\bscreen\b/, '不引入 screen 就读不到工作区尺寸')
+})
+
+test('建窗尺寸取自 workAreaSize，而不是裸常量', () => {
+  const body = createMainWindowBody()
+  assert.match(body, /getPrimaryDisplay\(\)\s*\.\s*workAreaSize/,
+    '要按主显示器工作区夹（workAreaSize 已扣掉菜单栏/Dock，不要自己再减）')
+  assert.match(body, /width:\s*Math\.min\(/, 'width 必须夹一次')
+  assert.match(body, /height:\s*Math\.min\(/, 'height 必须夹一次')
+  assert.ok(!/width:\s*1400\s*,/.test(body), 'width 不能再是裸的 1400')
+  assert.ok(!/height:\s*900\s*,/.test(body), 'height 不能再是裸的 900')
+})
+
+test('工作区尺寸在 new BrowserWindow 之前就取好', () => {
+  const body = createMainWindowBody()
+  const wa = body.indexOf('workAreaSize')
+  const win = body.indexOf('new BrowserWindow')
+  assert.ok(wa >= 0 && win >= 0)
+  assert.ok(wa < win, '要先量工作区再建窗')
+})

--- a/frontend/src/pages/project-overview/panelWidthLimits.js
+++ b/frontend/src/pages/project-overview/panelWidthLimits.js
@@ -1,0 +1,49 @@
+// 左右两侧面板的拖拽上限（dev-board#459）。
+//
+// 病灶：applyResizeFrame 原来按 `window.innerWidth * 0.75` 限宽，可是面板并不住在整窗
+// 里——.side-panel-ai 的父容器 .workbench-main 只拿到「整窗 − rail − 左栏」。
+// .side-panel{flex-shrink:0} 让面板不肯让宽，.workbench{overflow:hidden} 又把溢出裁掉：
+// 编辑区先塌成 0，接着面板右半边被裁在窗口右缘之外（输入框/发送键看不见也点不着），
+// 看上去就像窗口被撑出了屏幕。左栏那支是同一个缺陷的镜像。
+//
+// 修法是「按实测容器宽算」而不是「按整窗宽推算」：容器宽在 startResize 里从面板的
+// 父元素量一次（见 tabDragSplit.js）。这里刻意不写 rail 宽、边框宽这类常量——边框、
+// 紧凑模式、右侧 dock（dev-board#180）都会让常量漂。
+//
+// 保留的既有取向：只保证编辑区还剩 EDITOR_MIN_WIDTH，不做「窗口变窄时回夹面板」
+// （project-overview.vue handleResponsiveResize 那句「遮挡就遮挡」是既有产品决策）。
+//
+// 零依赖纯函数、只收数值参数，好在 node:test 里真跑一遍（同目录 flushDirtyEditors.js
+// 的先例：本目录其余模块都 import 了 @/ 别名，node 直接 import 不动）。
+
+// 编辑区最小可用宽度。定得小是刻意的：多数用户从没撞上这个上限，
+// 定大了等于悄悄改掉他们本来能拖到的范围。
+export const EDITOR_MIN_WIDTH = 200
+
+const px = (v) => {
+  const n = Math.floor(Number(v))
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+/**
+ * 右侧 AI 面板的拖拽上限。
+ * @param {number} containerWidth 面板父容器（.workbench-main）的实测 clientWidth
+ * @param {number} min            面板自身的最小宽（不足时的兜底返回值）
+ */
+export function rightPanelMaxWidth(containerWidth, min = 240) {
+  const floor = px(min)
+  return Math.max(floor, px(containerWidth) - EDITOR_MIN_WIDTH)
+}
+
+/**
+ * 左栏的拖拽上限：整条主布局宽里还坐着 rail 与右侧 AI 面板。
+ * @param {number} layoutWidth   左栏父容器（.main-layout）的实测 clientWidth
+ * @param {number} railWidth     rail 的实测宽（隐藏/不存在时传 0）
+ * @param {number} aiPanelWidth  右侧面板当前实测宽（收起时传 0）
+ * @param {number} min           左栏自身的最小宽
+ */
+export function leftPanelMaxWidth(layoutWidth, railWidth, aiPanelWidth, min = 160) {
+  const floor = px(min)
+  const avail = px(layoutWidth) - px(railWidth) - px(aiPanelWidth)
+  return Math.max(floor, avail - EDITOR_MIN_WIDTH)
+}

--- a/frontend/src/pages/project-overview/tabDragSplit.js
+++ b/frontend/src/pages/project-overview/tabDragSplit.js
@@ -3,6 +3,7 @@
 // 经展开进组件 methods（纯搬移，Phase 2 外置），`this` 即 project-overview 页面实例。
 
 import { activityTracker } from '@/utils/activityTracker.js'
+import { rightPanelMaxWidth, leftPanelMaxWidth } from './panelWidthLimits.js'
 
 export const tabDragSplitMethods = {
     onTabDragStart(evt, file, fromPane) {
@@ -156,6 +157,24 @@ export const tabDragSplitMethods = {
          this.resizing.element = this.$refs.bottomPanel ? (this.$refs.bottomPanel.$el || this.$refs.bottomPanel) : null
       }
 
+      // 拖拽上限按面板真正所在的容器算（dev-board#459），几何在这里实测一次：
+      // 右侧面板的父容器是 .workbench-main（编辑区 + 面板），左栏的父容器是
+      // .main-layout（rail + 左栏 + workbench）。不写 rail 宽这类常量——边框、
+      // 紧凑模式、右侧 dock 都会让常量漂。
+      this.resizing.containerWidth = 0
+      this.resizing.railWidth = 0
+      this.resizing.otherPanelWidth = 0
+      const container = this.resizing.element ? this.resizing.element.parentElement : null
+      if (container) {
+        this.resizing.containerWidth = container.clientWidth || 0
+        if (target === 'left' && typeof container.querySelector === 'function') {
+          const rail = container.querySelector('.left-rail')
+          this.resizing.railWidth = rail ? rail.offsetWidth : 0
+          const aiPanel = container.querySelector('.side-panel-ai')
+          this.resizing.otherPanelWidth = aiPanel ? aiPanel.offsetWidth : 0
+        }
+      }
+
       if (evt && typeof evt.preventDefault === 'function') {
         evt.preventDefault()
       }
@@ -211,11 +230,17 @@ export const tabDragSplitMethods = {
         const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
         const vh = typeof window !== 'undefined' ? window.innerHeight : 800
 
-        // Cursor 体验：拖动范围尽量大，不强行保证中间工作区可用（遮挡就遮挡）
+        // Cursor 体验：拖动范围尽量大，只给编辑区留最后一点可用宽（dev-board#459）。
+        // 上限按 startResize 实测到的容器宽算，不按整窗宽算——整窗里还有 rail、左栏
+        // 与另一侧面板，按 window.innerWidth 限宽会把面板推出容器右缘，被
+        // .workbench{overflow:hidden} 裁在窗口外面。量不到容器时退回整窗宽兜底。
+        // 「遮挡就遮挡」的既有取向保留：这里不做窗口变窄时的回夹。
+        const containerW = this.resizing.containerWidth || vw
         const leftMin = 160
-        const leftMax = Math.max(leftMin, Math.floor(vw * 0.75))
+        const leftMax = leftPanelMaxWidth(
+          containerW, this.resizing.railWidth, this.resizing.otherPanelWidth, leftMin)
         const rightMin = 240
-        const rightMax = Math.max(rightMin, Math.floor(vw * 0.75))
+        const rightMax = rightPanelMaxWidth(containerW, rightMin)
         const headerH = 56
         const tabsH = 40
         const bottomMin = 140

--- a/frontend/tests/project-home/panel-width-limits.test.mjs
+++ b/frontend/tests/project-home/panel-width-limits.test.mjs
@@ -1,0 +1,90 @@
+// 面板拖拽上限必须按面板所在的容器算，不能按整窗宽算（dev-board#459）。
+//
+// 病灶：applyResizeFrame 用 `Math.floor(window.innerWidth * 0.75)` 当左右两侧面板的
+// 拖拽上限，可是 .side-panel-ai 的父容器 .workbench-main 只拿到「整窗 − 50px rail −
+// 左栏宽」。.side-panel{flex-shrink:0} 让面板不肯让宽，.workbench{overflow:hidden} 又
+// 把溢出裁掉——于是编辑区先塌成 0，随后 AI 面板右半边被裁在窗口右缘之外（输入框/发送
+// 键看不见也点不着），看上去就像「窗口被撑出屏幕」。把窗口放大（窗口→缩放）会让
+// .workbench 变宽、裁切消失，正是复测者找到的恢复手法。
+//
+// 左栏那支是同一个缺陷的镜像：拖宽左栏同样能把 AI 面板顶出容器。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  EDITOR_MIN_WIDTH,
+  rightPanelMaxWidth,
+  leftPanelMaxWidth
+} from '../../src/pages/project-overview/panelWidthLimits.js'
+
+const DRAG = readFileSync(
+  new URL('../../src/pages/project-overview/tabDragSplit.js', import.meta.url), 'utf8')
+
+const RIGHT_MIN = 240
+const LEFT_MIN = 160
+
+test('右侧面板：上限 + 编辑区下限不超过容器宽（容器不够时退回 min）', () => {
+  for (const containerWidth of [320, 420, 440, 600, 930, 1090, 1350, 1870]) {
+    const max = rightPanelMaxWidth(containerWidth, RIGHT_MIN)
+    if (max + EDITOR_MIN_WIDTH > containerWidth) {
+      // 唯一允许溢出的情形：容器连 min + 编辑区下限都装不下，此时只能退回 min
+      assert.equal(max, RIGHT_MIN,
+        `容器 ${containerWidth}：装不下时只允许退回 min，实得 ${max}`)
+      assert.ok(containerWidth < RIGHT_MIN + EDITOR_MIN_WIDTH,
+        `容器 ${containerWidth} 明明装得下，不该走兜底`)
+    }
+  }
+})
+
+test('左侧栏：rail + 左栏上限 + AI 面板 + 编辑区下限不超过整条主布局宽', () => {
+  const rail = 50
+  for (const layoutWidth of [1000, 1280, 1400, 1920]) {
+    for (const aiPanelWidth of [0, 360, 700, 1050]) {
+      const max = leftPanelMaxWidth(layoutWidth, rail, aiPanelWidth, LEFT_MIN)
+      if (max === LEFT_MIN) continue
+      assert.ok(rail + max + aiPanelWidth + EDITOR_MIN_WIDTH <= layoutWidth,
+        `布局 ${layoutWidth} / AI ${aiPanelWidth}：左栏上限 ${max} 溢出`)
+    }
+  }
+})
+
+test('可用宽度不足时退回 min（宁可遮挡，也不给出负数/0 宽的上限）', () => {
+  assert.equal(rightPanelMaxWidth(300, RIGHT_MIN), RIGHT_MIN)
+  assert.equal(rightPanelMaxWidth(0, RIGHT_MIN), RIGHT_MIN)
+  assert.equal(leftPanelMaxWidth(600, 50, 500, LEFT_MIN), LEFT_MIN)
+  assert.equal(leftPanelMaxWidth(0, 0, 0, LEFT_MIN), LEFT_MIN)
+})
+
+test('病灶定点：1400px 窗口 + 420px 左栏，AI 面板上限不再是 1050', () => {
+  // .workbench-main 实测宽 = 1400 − 50 rail − 420 左栏 = 930
+  const container = 930
+  const oldFormula = Math.max(RIGHT_MIN, Math.floor(1400 * 0.75)) // 现行公式
+  assert.equal(oldFormula, 1050, '现行公式确实给出会溢出容器的 1050')
+  const max = rightPanelMaxWidth(container, RIGHT_MIN)
+  assert.ok(max <= 730, `新上限应 ≤ 730（930 − 200），实得 ${max}`)
+  assert.ok(max < oldFormula)
+})
+
+test('非法/缺失入参不炸，且不会给出比 min 还小的上限', () => {
+  assert.equal(rightPanelMaxWidth(undefined, RIGHT_MIN), RIGHT_MIN)
+  assert.equal(rightPanelMaxWidth(NaN, RIGHT_MIN), RIGHT_MIN)
+  assert.equal(rightPanelMaxWidth(-500, RIGHT_MIN), RIGHT_MIN)
+  assert.equal(leftPanelMaxWidth(NaN, NaN, NaN, LEFT_MIN), LEFT_MIN)
+})
+
+test('接线：tabDragSplit 真的改用了这个模块，且两支都不再按整窗宽算', () => {
+  assert.match(DRAG, /from\s+'\.\/panelWidthLimits\.js'/,
+    'tabDragSplit.js 必须 import panelWidthLimits')
+  assert.ok(!/vw\s*\*\s*0\.75/.test(DRAG),
+    '左右两支的 `vw * 0.75` 都要换掉——只改右支的话，拖宽左栏能把同一个症状换个入口复现')
+  assert.match(DRAG, /rightPanelMaxWidth\(/, '右支要用容器感知的上限')
+  assert.match(DRAG, /leftPanelMaxWidth\(/, '左支要用容器感知的上限')
+})
+
+test('接线：容器几何在 startResize 里实测，不硬编码 rail 宽等常量', () => {
+  const body = DRAG.slice(DRAG.indexOf('startResize(target, evt)'), DRAG.indexOf('onResizeMove(evt)'))
+  assert.ok(body.length > 0, '截不到 startResize 函数体')
+  assert.match(body, /parentElement/, '容器宽要从面板的父元素实测（边框、紧凑模式都会让常量漂）')
+  assert.match(body, /clientWidth/, '要读实际渲染宽度')
+  assert.match(body, /containerWidth/, '量到的宽度要缓存到 this.resizing 上给 applyResizeFrame 用')
+})


### PR DESCRIPTION
## 问题
右侧 AI 面板拖到很宽后，面板右侧（输入框/发送键）被裁在窗口右缘之外，看起来像 Electron 窗口超出屏幕，只能用「窗口 → 缩放」恢复。

## 根因
`tabDragSplit.js` 拖拽上限按 `window.innerWidth * 0.75` 算，而 `.side-panel-ai` 的父容器 `.workbench-main` 只有整窗减 rail 减左栏；`.side-panel{flex-shrink:0}` 加 `.workbench{overflow:hidden}` 把溢出裁掉。左栏拖动是同款镜像缺陷。全仓没有任何代码 resize 主窗口；唯一能让窗口比屏幕大的是建窗写死 1400x900 不夹工作区。

## 修法
- 新增零依赖纯函数 `panelWidthLimits.js`；`startResize` 时实测面板父容器 clientWidth（左栏再减实测 rail 与 AI 面板宽），不硬编码常量；编辑区最少留 200px。
- 保留「遮挡就遮挡」：不做窗口变窄时的回夹。
- desktop 建窗尺寸 `Math.min(1400, workArea.width)` / `Math.min(900, workArea.height)`。

## 验证
- 新增 panel-width-limits.test.mjs 7 用例（不变式、min 回落、病灶定点 1400/420 上限不再是 1050、两支接线断言），改前红、并做过两次病灶还原确认会转红。
- 新增 desktop/tests/main-window-bounds.test.js 源码级断言，挂进 npm test。
- test:project-home 347/0，desktop npm test 92/0，check:emits / check:nav 通过。
- 真机拖拽未走查；复测提示：把左栏拖到 400px 以上再拖宽 AI 面板，面板右缘应停在窗口内、编辑区至少留约 200px。

dev-board#459

🤖 Generated with [Claude Code](https://claude.com/claude-code)