### PR TITLE
fix(clipboard): 桌面免登下采集桥不再被空登录态关掉；删除确认不自动收起、失败走原生弹窗（dev-board#455）

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -107,6 +107,24 @@ local-mode 下本机后端把每个请求都当本机用户，等于把本机管
 **截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
 
 **剪贴板**：`ClipboardPanel.vue`；desktop main.js 轮询监听 clipboardWatchTimer ~:117-232（指纹去重 ~:110，首 tick 只记指纹）、推送 `checkba:clipboard-copied`；后端 `controller/ClipboardController.java`（/api/clipboard：GET /、POST /text、POST /file、GET /{id}/file、DELETE /{id}）。
+  **采集链路的登录态红线（dev-board#455）**：**桌面免登（PR-A 去登录）后 `checkba_user`
+  这个本地存储恒空，任何面板都不能拿它当登录态判据**。`getCurrentUser()` 只是
+  `uni.getStorageSync('checkba_user')`，全前端只有登录页 `saveSession` 与设置页
+  `setSessionUser` 写它，桌面 launch → unlock → 工作台一次都不写。采集桥
+  `clipboardBridge.js` 的 `bindClipboardListener()` 开头曾是 `if (!user) return`，
+  于是整座桥（桌面 IPC 订阅 + H5 copy/paste/keydown 三路兜底）在第一行就关掉，
+  Cmd+C / pbcopy 一条都不入库；而后端在 local-mode 下无视 header 一律解析为本机用户
+  （`AuthController`），GET / 照常返回存量，症状伪装成「最新条目停在某一天」。
+  现在的闸是 `if (!isDesktopHost() && !getCurrentUser()) return`——浏览器态仍必须挡住，
+  否则未登录时每次复制都打一次 4010。**同一条闸也意味着桌面端入库失败不能直弹 toast**：
+  主进程是 1 秒轮询系统剪贴板、捕获的是机器级每一次复制，指向团队案件库服务器却没有
+  有效凭证时 401 在 `status !== 200` 处就被 reject，照直弹就是每按一次 Cmd+C 弹一个
+  toast——所以失败提示按 `window.__checkbaClipSaveFailNotified` 每会话只出一次。
+  **删除失败提示走 `host.app.confirm` 原生弹窗**（同收藏面板：toast 在 DOM 层、被原生
+  BrowserView 整个盖住），删除确认气泡也**不再 5 秒自动收起**——超时后用户点「确定」
+  点到的是卡片本身的 `@tap="copy(it.text)"`，表现正是「卡片仍在、什么也没发生」。
+  注意 `ProjectFavoritesPanel.vue` / `VariablePanel.vue` 的删除气泡仍是同款 5 秒自动收起，
+  是同一个坑的未修实例。回归用例 `frontend/tests/clipboard/`（`npm run test:clipboard`）。
   **免费额度（PR-C）**：未拥有 `clipboard.unlimited` 时 GET / 只返回「最近 20 条 且 3 天内」，两条同时生效取更严者。**实现是查询侧过滤，绝不删除记录**——超出的行留在库里，解锁后原样可见。GET / 返回体从裸数组改为 `{items, limited, hiddenCount, maxItems, retentionDays}`（`ClipboardListResult`），hiddenCount 只算「因额度看不见」的（= 总数 − min(3天内条数, 20)），不含被分页 limit 挡住的。常量在 `ClipboardService.FREE_MAX_ITEMS/FREE_RETENTION_DAYS`。**额度只在 local-mode（桌面单机版）执行**：`EntitlementService` 是按本机的（无 userId 维度），团队案件库服务器上权益恒为空集，照执行会把每个接入成员截到 20 条且永远无法解锁。
 
 **收藏夹**：`ProjectFavoritesPanel.vue`；网页选中收藏经 `checkba:webmark`（preload ~:26）→ project-overview 订阅入库（~:2003）；后端 `controller/WebFavoriteController.java`（/api/favorites/my、/api/projects/{id}/favorites、DELETE、image）。
@@ -290,6 +308,10 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
 - **给网页标签加保活池要分宿主**：Web 走组件池，桌面走 BrowserView detach；两边都开等于
   桌面端把多个 BrowserView 同时挂上窗口。
 - 剪贴板去重靠指纹+window 级状态，改动监听逻辑先读 PR#148/#151 教训。
+- **`checkba_user` 在桌面免登下恒空，不是登录态判据**：拿它当闸门会静默关掉整个功能，
+  而后端在 local-mode 无视 header 一律解析本机用户，读接口照常有数据，症状伪装成
+  「数据停在某一天」而不是「未登录」。剪贴板采集就这么断了半个月（dev-board#455），
+  详见上面剪贴板段的「采集链路的登录态红线」。
 - `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
 - Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。asr-models 的下载走同一条路，同样禁 xet。
 - **asr-service 不像 kokoro 那样把服务门在模型上**：kokoro 的 descriptor 有 `enabled`（没模型不起进程），asr-service **没有**。就绪探测必须能分开「服务没起」（重启应用）与「模型没下」（下 1.5GB），不起进程就只剩前一种结论，用户照提示重启一万次也不会有模型。
@@ -337,7 +359,10 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
   `browser-views.test.js` 钉住的就是上面那套记账：复用不重载、detach 不销毁、隐藏恢复只挂回前台、双开计数。
 - 后端相关单测：TtsServiceTest、FileControllerChunkedUploadTest、ProjectFileService*Test、
   **BrowserProxyControllerTest**（SSRF 例外名单默认关、注入脚本能解析、proxify 绝对地址 +
-  URL_CHANGED、JS 字面量转义、HTML 带 charset）等；剪贴板/收藏/搜索/OCR 暂无专属测试。
+  URL_CHANGED、JS 字面量转义、HTML 带 charset）等；收藏/搜索/OCR 暂无专属测试。
+- 剪贴板：`cd frontend && npm run test:clipboard`（`tests/clipboard/`，node:test）——采集桥的
+  登录态闸门（桌面免登下必须订阅、浏览器未登录仍不采集）、桌面失败提示每会话至多一次、
+  面板删除链路（DELETE → 重拉 → 列表不含该 id）、确认态不自动收起、失败走原生弹窗。
 - UI 链路：`cd frontend && npm run test:app-e2e`。其中 **J6.7 浏览器面板**覆盖 Web/H5 这条链路
   （harness 自起两页小站 → 开两个网页标签 → 页内点链接跳第二页 → 切走再切回来断言仍是同一个
   文档实例 + 地址正确）。跑它要给后端加

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Tab visibility contract (dev-board#394)
         working-directory: frontend
         run: npm run test:tab-visibility
+      - name: Clipboard capture gate + delete chain (dev-board#455)
+        working-directory: frontend
+        run: npm run test:clipboard
       - name: Build H5
         working-directory: frontend
         run: npm run build:h5

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "test:panel-dock": "node --test tests/panel-dock/*.test.mjs",
     "test:tab-visibility": "node --test tests/tab-visibility/*.test.mjs",
     "test:insight": "node --test tests/insight/*.test.mjs",
+    "test:clipboard": "node --test tests/clipboard/*.test.mjs",
     "test:revision-view": "node --test tests/revision-view/*.test.mjs",
     "test:md-table": "node --test tests/markdown-table/*.test.mjs"
   },

--- a/frontend/src/components/ClipboardPanel.vue
+++ b/frontend/src/components/ClipboardPanel.vue
@@ -77,6 +77,7 @@ import { getSessionId } from '@/utils/auth.js'
 import { ICONS } from '@/config/icons.js'
 import UnlockHint from '@/components/UnlockHint.vue'
 import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
+import { host } from '@/services/host.js'
 
 export default {
 
@@ -198,23 +199,20 @@ export default {
       uni.setClipboardData({ data: t })
       // #endif
     },
+    // 确认态刻意不自动收起：原先 5 秒后自己清空 confirmDeleteId，超时之后用户点
+    // 「确定」，点到的是卡片本身的 @tap="copy(it.text)"——表现正是「卡片仍在、
+    // 什么也没发生」（dev-board#455）。取消靠再点一次 ×、点「取消」，
+    // 或者点另一张卡片的 ×（confirmDeleteId 只认一个 id）。
     requestDelete(id) {
       if (this.confirmDeleteId === id) {
         this.confirmDeleteId = null
         return
       }
       this.confirmDeleteId = id
-      if (this._deleteTimer) clearTimeout(this._deleteTimer)
-      this._deleteTimer = setTimeout(() => {
-        if (this.confirmDeleteId === id) {
-          this.confirmDeleteId = null
-        }
-      }, 5000)
     },
-    
+
     cancelDelete() {
       this.confirmDeleteId = null
-      if (this._deleteTimer) clearTimeout(this._deleteTimer)
     },
 
     async confirmDelete(id) {
@@ -223,7 +221,13 @@ export default {
         await deleteClipboardItem(id)
         await this.refresh()
       } catch (e) {
-        uni.showToast({ title: this.$t('panels.cpDeleteFailed'), icon: 'none' })
+        // 失败提示走原生弹窗：工作台里开着浏览器标签时，toast 在 DOM 层、被原生
+        // BrowserView 整个盖住，删除失败等于毫无反馈（同 BrowserPane 收藏失败的修法）
+        if (host.app && host.app.confirm) {
+          host.app.confirm({ title: this.$t('panels.cpDeleteFailed'), content: (e && e.message) || '' }).catch(() => {})
+        } else {
+          uni.showToast({ title: (e && e.message) || this.$t('panels.cpDeleteFailed'), icon: 'none' })
+        }
       }
     },
     getImageUrl(it) {

--- a/frontend/src/pages/project-overview/clipboardBridge.js
+++ b/frontend/src/pages/project-overview/clipboardBridge.js
@@ -7,14 +7,19 @@
 
 import { saveClipboardText, saveClipboardFile } from '@/services/api.js'
 import { getCurrentUser } from '@/utils/auth.js'
-import { host } from '@/services/host.js'
+import { host, isDesktopHost } from '@/services/host.js'
 
 export const clipboardBridgeMethods = {
     bindClipboardListener() {
       // #ifdef H5
       if (this._clipboardBound) return
-      const user = getCurrentUser()
-      if (!user) return
+      // 登录态闸门只对纯浏览器态成立：桌面单机版免登后 checkba_user 这个本地存储
+      // 永远为空（project-overview.vue onLoad 里同一句注释写了两遍），拿它当判据
+      // 会把整座采集桥——桌面 IPC 订阅与下面的 H5 三路兜底——一起关掉，
+      // Cmd+C / pbcopy 一条都不入库（dev-board#455）。而后端在 local-mode 下无视
+      // header 一律解析为本机用户（AuthController），采集与列表用的是同一个身份，
+      // 前端再挡一道纯属多余。浏览器态仍必须挡住：没有会话时每次复制都会打一次 4010。
+      if (!isDesktopHost() && !getCurrentUser()) return
       this._clipboardBound = true
       // 统一的“写库 + 立即更新 UI”入口：避免 copy 事件多次触发导致重复入库
       // 去重状态挂 window 而非组件实例：本页经 navigateTo 反复进入时页面栈里会存在
@@ -126,7 +131,18 @@ export const clipboardBridgeMethods = {
           return saved
         } catch (saveErr) {
           console.error('记录剪贴板失败:', saveErr)
-          uni.showToast({ title: this.$t('workbenchOps.clipboardRecordFailed'), icon: 'none' })
+          // 桌面端每会话最多提示一次：主进程是 1 秒轮询系统剪贴板，捕获的是
+          // 机器级的每一次复制，后端一旦持续失败（如指向团队案件库服务器却没有
+          // 有效凭证，401 在 status !== 200 处就被 reject），照直弹就是每按一次
+          // Cmd+C 弹一个 toast。标志挂 window：页面栈里可能同时存在多个实例。
+          if (isDesktopHost()) {
+            if (typeof window !== 'undefined' && !window.__checkbaClipSaveFailNotified) {
+              window.__checkbaClipSaveFailNotified = true
+              uni.showToast({ title: this.$t('workbenchOps.clipboardRecordFailed'), icon: 'none' })
+            }
+          } else {
+            uni.showToast({ title: this.$t('workbenchOps.clipboardRecordFailed'), icon: 'none' })
+          }
           return null
         }
       }

--- a/frontend/tests/clipboard/bridge-binds-without-login.test.mjs
+++ b/frontend/tests/clipboard/bridge-binds-without-login.test.mjs
@@ -1,0 +1,110 @@
+// 剪贴板采集桥的登录态闸门（dev-board#455）。
+//
+// 病灶：bindClipboardListener() 第一件事是 `const user = getCurrentUser(); if (!user) return`，
+// 而桌面单机版免登后 checkba_user 这个本地存储永远为空（project-overview.vue 里同一句
+// 注释写了两遍）。于是整座桥——桌面 IPC 订阅与 H5 三路兜底——都在第 17 行之前就被关掉，
+// Cmd+C / pbcopy 一条都不入库；而 GET /api/clipboard 在 local-mode 下照常返回存量，
+// 表现就是「最新条目停在某一天」。
+//
+// 这里既钉行为也钉源码：
+//   - 行为：把 <script> 之外的模块体剥出来当普通对象跑（同 tests/_lib/review-panel-vm.mjs
+//     的路子），桌面宿主 + 无登录态时必须真的订阅到 host.clipboard.onCopied；
+//   - 源码：那条无条件的 `if (!user) return` 不许被写回来（锚点唯一）。
+// 只留源码正则是近乎恒真的（换个写法就绕过去了），所以行为断言才是主证。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/pages/project-overview/clipboardBridge.js', import.meta.url), 'utf8')
+
+// 依赖当形参喂进去；window/document/uni 一并作形参，避免污染 globalThis。
+function makeBridge(deps) {
+  const body = SRC
+    .replace(/^import\s[\s\S]*?from\s+'[^']+'\s*;?\s*$/gm, '')
+    .replace('export const clipboardBridgeMethods =', 'return')
+  const names = ['saveClipboardText', 'saveClipboardFile', 'getCurrentUser', 'host', 'isDesktopHost', 'window', 'document', 'uni']
+  // eslint-disable-next-line no-new-func
+  return new Function(...names, body)(...names.map((n) => deps[n]))
+}
+
+function makeEnv(over = {}) {
+  const calls = { saved: [], toasts: [], docListeners: [], winListeners: [], warns: [] }
+  const subs = []
+  const env = {
+    calls,
+    subs,
+    saveClipboardText: over.saveClipboardText || (async (t) => { calls.saved.push(t); return { data: { id: 1, text: t } } }),
+    saveClipboardFile: async () => ({ data: {} }),
+    getCurrentUser: over.getCurrentUser || (() => null),
+    isDesktopHost: over.isDesktopHost || (() => true),
+    host: {
+      clipboard: over.noClipboardHost ? undefined : { onCopied: (fn) => { subs.push(fn); return () => {} } },
+    },
+    window: { addEventListener: (n, f) => calls.winListeners.push(n) },
+    document: { addEventListener: (n, f) => calls.docListeners.push(n) },
+    uni: { showToast: (o) => calls.toasts.push(o) },
+  }
+  return env
+}
+
+function makeVm(methods, over = {}) {
+  return Object.assign({
+    isDesktopApp: over.isDesktopApp !== undefined ? over.isDesktopApp : true,
+    $t: (k) => k,
+    onClipboardSaved: () => {},
+  }, methods)
+}
+
+test('桌面宿主 + 无 checkba_user：仍然订阅 host.clipboard.onCopied（免登不等于未登录）', () => {
+  const env = makeEnv()
+  const vm = makeVm(makeBridge(env))
+  vm.bindClipboardListener()
+  assert.equal(env.subs.length, 1, '桌面订阅点必须被接上；为 0 说明登录态闸门又把整座桥关掉了')
+})
+
+test('桌面宿主 + 无 checkba_user：推送的文本真的走到 saveClipboardText', async () => {
+  const env = makeEnv()
+  const vm = makeVm(makeBridge(env))
+  vm.bindClipboardListener()
+  await env.subs[0]({ type: 'TEXT', text: 'hello-455', ts: 1 })
+  assert.deepEqual(env.calls.saved, ['hello-455'])
+})
+
+test('纯浏览器态 + 无登录：维持不采集（否则每次复制都打一次 4010）', () => {
+  const env = makeEnv({ isDesktopHost: () => false })
+  const vm = makeVm(makeBridge(env), { isDesktopApp: false })
+  vm.bindClipboardListener()
+  assert.deepEqual(env.calls.docListeners, [], '未登录的浏览器态不该挂 copy/paste 监听')
+  assert.deepEqual(env.calls.winListeners, [])
+})
+
+test('纯浏览器态 + 已登录：照旧挂三路兜底监听', () => {
+  const env = makeEnv({ isDesktopHost: () => false, getCurrentUser: () => ({ id: 1 }) })
+  const vm = makeVm(makeBridge(env), { isDesktopApp: false })
+  vm.bindClipboardListener()
+  assert.deepEqual(env.calls.docListeners, ['paste', 'copy'])
+  assert.deepEqual(env.calls.winListeners, ['keydown'])
+})
+
+test('桌面端入库失败不许 toast 风暴：主进程每秒轮询，一次机器级复制就是一次提示', async () => {
+  const env = makeEnv({ saveClipboardText: async () => { throw new Error('401') } })
+  const vm = makeVm(makeBridge(env))
+  vm.bindClipboardListener()
+  for (let i = 0; i < 5; i++) {
+    await env.subs[0]({ type: 'TEXT', text: 'boom-' + i, ts: i })
+  }
+  assert.ok(env.calls.toasts.length <= 1, `桌面端失败提示最多一次，实际 ${env.calls.toasts.length} 次`)
+})
+
+test('源码闸门：bindClipboardListener 体内不许再有无条件的 if (!user) return', () => {
+  // 锚点前面必须带换行 + 缩进，否则 unbindClipboardListener 会被当成第二处命中
+  const ANCHOR = '\n    bindClipboardListener() {'
+  const start = SRC.indexOf(ANCHOR)
+  assert.notEqual(start, -1, '锚点 bindClipboardListener() { 未找到')
+  assert.equal(SRC.indexOf(ANCHOR, start + 1), -1, '锚点必须唯一')
+  const end = SRC.indexOf('\n    onClipboardSaved(', start)
+  assert.ok(end > start, '锚点 onClipboardSaved 未找到')
+  const bodyText = SRC.slice(start, end)
+  assert.equal(/if\s*\(\s*!\s*user\s*\)\s*return/.test(bodyText), false,
+    '无条件的登录态闸门被写回来了：桌面免登下 checkba_user 恒空，这一行会关掉整座采集桥')
+})

--- a/frontend/tests/clipboard/panelDelete.test.mjs
+++ b/frontend/tests/clipboard/panelDelete.test.mjs
@@ -1,0 +1,101 @@
+// ClipboardPanel.vue 的删除链路（dev-board#455 复现 1「确认后卡片仍在」）。
+//
+// 把 <script> 剥出来当普通对象跑（同 tests/insight/insightPane.test.mjs 的路子），
+// 走完 requestDelete → confirmDelete → DELETE → refresh 这条真链，钉三条：
+//   ① 确认后真的发出 DELETE，并整表重拉，列表里不再有那一条；
+//   ② 确认态不再有 5 秒自动收起——超时后点「确定」点到的是卡片本身的
+//      @tap="copy(it.text)"，用户看到的就是「卡片仍在、什么也没发生」；
+//   ③ 删除失败走原生弹窗而不是 toast——工作台开着浏览器标签时 toast 被原生
+//      BrowserView 整个盖住（见 .claude/agents/utility-tools.md），失败等于无反馈。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import { shouldAcceptResponse } from '../../src/utils/requestGeneration.js'
+
+const SRC = readFileSync(new URL('../../src/components/ClipboardPanel.vue', import.meta.url), 'utf8')
+
+function makePanel(deps) {
+  const script = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import\s[\s\S]*?from\s+'[^']+'\s*;?\s*$/gm, '')
+  const names = [
+    'listClipboard', 'deleteClipboardItem', 'getApiBaseUrl', 'getClipboardTypeMeta',
+    'getSessionId', 'ICONS', 'UnlockHint', 'shouldAcceptResponse', 'host',
+    'uni', 'setTimeout', 'clearTimeout',
+  ]
+  // eslint-disable-next-line no-new-func
+  return new Function(...names, script.replace('export default', 'return'))(...names.map((n) => deps[n]))
+}
+
+function makeVm(over = {}) {
+  const calls = { list: [], del: [], toasts: [], native: [], timers: [] }
+  let rows = over.rows || [{ id: 1, type: 'TEXT', text: 'a' }, { id: 2, type: 'TEXT', text: 'b' }]
+  const deps = {
+    listClipboard: async (q, limit) => {
+      calls.list.push([q, limit])
+      return { items: rows.slice(), limited: false, hiddenCount: 0 }
+    },
+    deleteClipboardItem: async (id) => {
+      calls.del.push(id)
+      if (over.deleteFails) throw new Error('boom')
+      rows = rows.filter((r) => r.id !== id)
+      return { code: 0 }
+    },
+    getApiBaseUrl: () => '',
+    getClipboardTypeMeta: () => ({ label: 'TEXT', tone: 'neutral' }),
+    getSessionId: () => 's',
+    ICONS: {},
+    UnlockHint: {},
+    shouldAcceptResponse,
+    host: { app: { confirm: async (p) => { calls.native.push(p) } } },
+    uni: { showToast: (o) => calls.toasts.push(o), $on: () => {}, $off: () => {}, setClipboardData: () => {} },
+    setTimeout: (fn, ms) => { calls.timers.push([fn, ms]); return calls.timers.length },
+    clearTimeout: () => {},
+  }
+  const component = makePanel(deps)
+  const base = { $t: (k) => k, $emit: () => {} }
+  const vm = Object.assign(base, component.data.call(base), component.methods)
+  for (const [k, fn] of Object.entries(component.computed || {})) {
+    Object.defineProperty(vm, k, { get: () => fn.call(vm), configurable: true })
+  }
+  return { vm, calls, rows: () => rows }
+}
+
+test('确认删除：发出 DELETE → 重拉列表 → 该条不再出现', async () => {
+  const { vm, calls } = makeVm()
+  await vm.refresh()
+  assert.deepEqual(vm.items.map((i) => i.id), [1, 2])
+
+  vm.requestDelete(2)
+  assert.equal(vm.confirmDeleteId, 2, '× 应进入确认态')
+
+  await vm.confirmDelete(2)
+  assert.deepEqual(calls.del, [2], 'DELETE 必须真的发出去')
+  assert.equal(calls.list.length, 2, '删除后必须整表重拉一次')
+  assert.deepEqual(vm.items.map((i) => i.id), [1], '重拉后列表里不该还有被删的那条')
+  assert.equal(vm.confirmDeleteId, null)
+})
+
+test('再点一次 × 取消确认态', () => {
+  const { vm } = makeVm()
+  vm.requestDelete(1)
+  vm.requestDelete(1)
+  assert.equal(vm.confirmDeleteId, null)
+})
+
+test('确认态不自动收起：定时器不许把它清掉（超时后「确定」会点成卡片的复制）', () => {
+  const { vm, calls } = makeVm()
+  vm.requestDelete(1)
+  // 把 requestDelete 排过的定时器全部触发一遍，模拟等待任意长时间
+  for (const [fn] of calls.timers) fn()
+  assert.equal(vm.confirmDeleteId, 1, '确认态被自动收起了，用户点「确定」时点到的是卡片本身')
+})
+
+test('删除失败走原生弹窗（toast 会被原生 BrowserView 整个盖住）', async () => {
+  const { vm, calls } = makeVm({ deleteFails: true })
+  await vm.refresh()
+  vm.requestDelete(1)
+  await vm.confirmDelete(1)
+  assert.equal(calls.native.length, 1, '失败必须用 host.app.confirm 这类原生弹窗提示')
+  assert.deepEqual(calls.toasts, [], '不该再退回 uni.showToast')
+})


### PR DESCRIPTION
## 问题
剪贴板面板：Cmd+C / pbcopy 不再采集，最新条目停在 8 月 20 日；删除确认后卡片仍在、无反馈。

## 根因
- 采集：`clipboardBridge.js` 的 `bindClipboardListener` 第一行 `if (!getCurrentUser()) return`，而桌面免登后 `checkba_user` 永远为空（project-overview.vue 里同一句注释写了两遍），整座采集桥在闸门处被关掉；后端 local-mode 无视 header 一律解析本机用户，列表照常返回存量，看起来像「停在 8 月 20 日」。
- 删除：DELETE → refresh 链路没有代码级断点（vm 级测试改前即绿）。可见性缺陷两处：确认态 5 秒自动收起，超时后点「确定」点到的是卡片本身的复制；失败 toast 被原生 BrowserView 盖住。

## 修法
- 闸门改 `if (!isDesktopHost() && !getCurrentUser()) return`；桌面端入库失败每会话至多提示一次（主进程 1 秒轮询捕获机器级每次复制，指向团队服务器无凭证时 401 会变 toast 风暴）。
- 删除确认不再自动收起；失败提示走 host.app.confirm（BrowserPane 收藏失败同款）。
- 新增 `npm run test:clipboard`（10 用例，6 条改前红）并接进 CI。

## 验证
- test:clipboard 10/0；project-home 340/0、evidence 132/0、commands 21/0、panel-dock 9/0、insight 84/0；check:emits / check:locales / check:nav:full 通过。
- 真机未验证。复测提示：桌面端 Cmd+C 一段文字后面板应立即出新条目；注意 local-mode 无 clipboard.unlimited 时只显示最近 20 条且 3 天内，8 月存量会从可见变不可见，那是既有查询过滤不是删数据。删除若仍不生效，DevTools 里看有没有 DELETE /api/clipboard/{id}，现在失败会有原生弹窗。
- 顺带发现：收藏面板与变量面板的删除气泡是同款 5 秒自动收起，另开卡。

dev-board#455

🤖 Generated with [Claude Code](https://claude.com/claude-code)