### PR TITLE
fix(files): 上传队列只剩已中断任务时底栏不再谎称「正在上传 (0/1) 0%」（dev-board#462）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -223,6 +223,27 @@ xhr 只给一句 `Network Error`，后端看到 `ClientAbortException`），三�
 `application/json, application/octet-stream`）。
 后端测试 `ProjectFileServiceImportLocalTest` / `ProjectFileControllerImportLocalTest`。
 
+**上传底栏不许把死任务算成「正在上传」（dev-board#462，2026-09-05）**：左下角那条
+`.upload-status-footer-fixed` 是 FileTree 自己的上传队列，**与手机端中转无关**
+（`frontend/src` 里没有一行 mobile-relay 代码，手机落盘全在后端 `MobileRelayClientService`）。
+此前 `uploadedCount` / `totalUploadCount` 直接数整张 `uploadStatusMap`，队列里只剩
+已中断/出错的任务时就得到「正在上传... (0/1)」，而 `globalUploadProgress` 明明过滤掉了
+死任务返回 `null`，模板那句 `Math.floor(globalUploadProgress || 0)` 又把它画成 0%。
+现在三个计数统一走新的 `activeUploads`（`!error && status !== 'interrupted'`，与
+`globalUploadProgress` 同一个口径），只剩死任务时（`showInterruptedOnly`）底栏不画进度环、
+改说「N 个上传已中断」——**条目本身留着**，悬浮列表里的 ↻ 重试与 × 删除、常驻的
+「取消全部」一个都没动。批量上传途中队列瞬时清空（条目延迟 1s 删）仍走进度环，
+所以判据是 `totalUploadCount === 0 && interruptedUploadCount > 0` 而不是单看前者。
+`restoreUploadState` 同时补两条：`progress >= 100` 的恢复条目**直接丢弃并落盘**
+（`completeUpload` 那 1s 延迟删除没赶上而已，留着会让底栏永远说「正在上传 (1/1)」，
+且 `saveUploadState` 不落 error 标志，下次挂载又原样复活）；未完成的条目（含
+`status:'pending'` 的排队项）一律标 interrupted。**刻意不做**启动时自动
+`deleteFilePerm` 删占位文件——那会毁掉跨重启续传（`resumeUpload` 策略 2 的重选文件
++ `processChunkedUpload` 开头的服务端 offset 探测是设计好的能力），而且
+`projectId` watcher（`immediate: true`）与 `FilePickerDialog` 里的第二个 FileTree 实例
+共用同一个 `upload_state_v2_project_<id>` 键，删除动作会在项目来回切时误伤在传的文件。
+单测 `frontend/tests/project-home/file-tree-upload-zombie.test.mjs`（`npm run test:project-home`）。
+
 ## 顶栏头像与统一「设置」标签（2026-08-19 立，2026-08-20 并，2026-08-21 撤下拉）
 
 rail 底部的**齿轮与用户头像都撤了**，收进顶栏右上角「活动记录」右侧的

--- a/frontend/src/components/FileTree.vue
+++ b/frontend/src/components/FileTree.vue
@@ -837,17 +837,24 @@
             </view>
           </view> -->
           <!-- 圆形进度条 -->
-          <CircularProgress
-            :percentage="globalUploadProgress || 0"
-            :size="48"
-            :strokeWidth="4"
-            color="#2563eb"
-          >
-            <text style="font-size: 12px; font-weight: bold;">{{ Math.floor(globalUploadProgress || 0) }}%</text>
-          </CircularProgress>
-          <view class="upload-status-text" style="display: flex; flex-direction: column; flex: 1;">
-             <text class="status-title" style="font-size: 12px; color: #333;">{{ $t('fileTree.uploadingProgress', { done: uploadedCount, total: totalUploadCount }) }}</text>
-             <text class="status-detail" v-if="globalUploadProgress !== null" style="font-size: 10px; color: #666;">{{ Math.floor(globalUploadProgress) }}%</text>
+          <!-- dev-board#462：队列里只剩已中断的任务时不画进度环、也不说「正在上传」 -->
+          <template v-if="!showInterruptedOnly">
+            <CircularProgress
+              :percentage="globalUploadProgress || 0"
+              :size="48"
+              :strokeWidth="4"
+              color="#2563eb"
+            >
+              <text style="font-size: 12px; font-weight: bold;">{{ Math.floor(globalUploadProgress || 0) }}%</text>
+            </CircularProgress>
+            <view class="upload-status-text" style="display: flex; flex-direction: column; flex: 1;">
+               <text class="status-title" style="font-size: 12px; color: #333;">{{ $t('fileTree.uploadingProgress', { done: uploadedCount, total: totalUploadCount }) }}</text>
+               <text class="status-detail" v-if="globalUploadProgress !== null" style="font-size: 10px; color: #666;">{{ Math.floor(globalUploadProgress) }}%</text>
+            </view>
+          </template>
+          <view v-else class="upload-status-text" style="display: flex; flex-direction: column; flex: 1;">
+             <text class="status-title" style="font-size: 12px; color: #ef4444;">{{ $t('fileTree.uploadsInterrupted', { count: interruptedUploadCount }) }}</text>
+             <text class="status-detail" style="font-size: 10px; color: #666;">{{ $t('fileTree.uploadsInterruptedHint') }}</text>
           </view>
           <text
             style="font-size: 11px; color: #ef4444; cursor: pointer; padding: 4px 10px; border: 1px solid #fecaca; border-radius: 4px; background: #fef2f2; flex-shrink: 0;"
@@ -1208,11 +1215,25 @@ export default {
     checkedCount() {
       return this.checkedIds.length
     },
+    // dev-board#462：已中断/出错的任务不算「正在上传」。此前计数直接数整张 uploadStatusMap，
+    // 队列里只剩死任务时底栏就永远停在「正在上传... (0/1)」+ 那个假的 0%。
+    // globalUploadProgress 早就是这么过滤的，计数与它同一个口径。
+    activeUploads() {
+        return Object.values(this.uploadStatusMap).filter(s => !s.error && s.status !== 'interrupted')
+    },
     uploadedCount() {
-        return Object.values(this.uploadStatusMap).filter(s => s.progress === 100).length
+        return this.activeUploads.filter(s => s.progress === 100).length
     },
     totalUploadCount() {
-        return Object.keys(this.uploadStatusMap).length
+        return this.activeUploads.length
+    },
+    // 底栏在没有活跃任务时改说「N 个上传已中断」，条目本身留着（↻ 重试 / × 删除仍要够得着）
+    interruptedUploadCount() {
+        return Object.keys(this.uploadStatusMap).length - this.activeUploads.length
+    },
+    // 队列里只剩死任务时才换文案；批量上传途中队列瞬时清空（条目延迟 1s 删）仍走进度环
+    showInterruptedOnly() {
+        return this.totalUploadCount === 0 && this.interruptedUploadCount > 0
     },
     marqueeStyle() {
       const m = this.marquee
@@ -1299,20 +1320,13 @@ export default {
         return Math.min(100, (this.batchUploadFinishedSize + currentUploaded) * 100 / this.batchUploadTotalSize)
       }
 
-      const keys = Object.keys(this.uploadStatusMap).filter(k => {
-          const item = this.uploadStatusMap[k]
-          // Filter out interrupted items from "active" progress calculation?
-          // If we show them in the list, we might want to count them or not.
-          // User says "indicator shows 0/23 but not starting".
-          // Better to filter them out of the "Active" count.
-          return !item.error && item.status !== 'interrupted'
-      })
-      if (keys.length === 0) return null
+      // 已中断/出错的任务不参与进度计算（与 uploadedCount / totalUploadCount 同一个口径）
+      const active = this.activeUploads
+      if (active.length === 0) return null
 
       let total = 0
       let uploaded = 0
-      keys.forEach(key => {
-        const info = this.uploadStatusMap[key]
+      active.forEach(info => {
         total += info.size
         uploaded += info.uploaded
       })
@@ -4179,18 +4193,27 @@ export default {
             const state = JSON.parse(data)
             // 恢复时，检查是否有正在进行的任务。由于刷新导致 File 对象丢失，无法自动继续。
             // 必须将这些任务标记为中断/失败，避免 UI 假死。
+            let dropped = 0
             for (const fileId in state) {
                 const item = state[fileId]
-                // 如果任务未完成 (progress < 100)，标记为 error
-                if (item.progress < 100) {
-                    item.error = true
-                    item.status = 'interrupted' // Add explicitly status
-                    item.errorMessage = this.$t('fileTree.refreshInterrupted')
-                    // 确保 xhr 是空的
-                    item.xhr = null
+                // dev-board#462：progress 已经 100 的条目没有「可恢复」的东西
+                //（completeUpload 那 1s 延迟删除没赶上而已），留着只会让底栏永远说「正在上传」。
+                if (item.progress >= 100) {
+                    delete state[fileId]
+                    dropped += 1
+                    continue
                 }
+                // 未完成的任务（含 status:'pending' 的排队项）：内存里的 File 对象随页面一起没了，
+                // 一律标成中断，等用户点 ↻ 重选文件续传。
+                item.error = true
+                item.status = 'interrupted' // Add explicitly status
+                item.errorMessage = this.$t('fileTree.refreshInterrupted')
+                // 确保 xhr 是空的
+                item.xhr = null
             }
             this.uploadStatusMap = state
+            // 丢掉的条目要同步落盘，否则下次挂载又被原样复活（「常驻不消失」的另一半）
+            if (dropped > 0) this.saveUploadState()
         } catch (e) {}
     },
 

--- a/frontend/src/locales/en-US/fileTree.js
+++ b/frontend/src/locales/en-US/fileTree.js
@@ -78,6 +78,8 @@ export default {
   resumeUploadTitle: 'Resume Upload',
   cancelUploadTitle: 'Cancel Upload',
   uploadingProgress: 'Uploading... ({done}/{total})',
+  uploadsInterrupted: '{count} upload(s) interrupted',
+  uploadsInterruptedHint: 'Open the list to retry or remove',
   etaAbout: 'about {time}',
   etaDone: 'done',
   // Document compare

--- a/frontend/src/locales/zh-CN/fileTree.js
+++ b/frontend/src/locales/zh-CN/fileTree.js
@@ -78,6 +78,8 @@ export default {
   resumeUploadTitle: '继续上传',
   cancelUploadTitle: '取消上传',
   uploadingProgress: '正在上传... ({done}/{total})',
+  uploadsInterrupted: '{count} 个上传已中断',
+  uploadsInterruptedHint: '点开列表可重试或删除',
   etaAbout: '约 {time}',
   etaDone: '完成',
   // 文档对比

--- a/frontend/tests/project-home/file-tree-upload-zombie.test.mjs
+++ b/frontend/tests/project-home/file-tree-upload-zombie.test.mjs
@@ -1,0 +1,170 @@
+// dev-board#462：桌面端左下角「正在上传... (0/1) 0%」常驻不消失。
+//   cd frontend && npm run test:project-home
+//
+// 这条底栏与手机端中转无关（frontend 里没有一行 mobile-relay 代码），是 FileTree 自己的
+// 上传队列在说谎：uploadStatusMap 里只剩已中断/出错的死任务时，
+//   uploadedCount   = filter(progress===100)      → 0
+//   totalUploadCount= Object.keys(map).length     → 1   ← 「(0/1)」里的那个 1
+//   globalUploadProgress 明明过滤掉了死任务返回 null，模板 Math.floor(null||0) 又把它画成 0%
+// 而 saveUploadState 不落 error 标志、restoreUploadState 每次挂载都把它复活成 interrupted，
+// 于是这条「正在上传」永远不消失。
+//
+// FileTree.vue 是 Options API，照 file-tree-external-drop.test.mjs 的套路把 <script> 抠出来
+// new Function 求值，真跑 computed 与 restoreUploadState。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/FileTree.vue', import.meta.url), 'utf8')
+
+const IMPORT_NAMES = [
+  'getProjectFiles', 'createFolder', 'createFile', 'renameFile', 'deleteFile', 'deleteFilePerm',
+  'restoreFileApi', 'getRecycleBinFiles', 'moveFile', 'batchDeleteFiles', 'batchMoveFiles',
+  'batchCopyFiles', 'getApiBaseUrl', 'getContributedTemplates', 'createFileFromContributedTemplate',
+  'getAuthHeaders', 'getSessionId', 'host', 'findTopmostDeletedAncestor', 'summarizeDeleteResults',
+  'groupByParent', 'buildTreeFromGroups', 'evidenceRefCounts', 'createRefCountsFetcher',
+  'CircularProgress', 'warmDragImage', 'applyDragImage', 'FileTypeIcon', 'TagChip', 'TagSelector',
+  'TagManager', 'AwdDatePicker', 'ICONS', 'getProjectTags', 'addTagToFile', 'removeTagFromFile',
+  'createTag', 'createTask', 'importLocalFile',
+  'nativeDataTransfer', 'isExternalFileDrag', 'collectDroppedFiles', 'claimExternalDrop',
+]
+
+function loadOptions() {
+  const body = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import\s[\s\S]*?from\s+['"][^'"]+['"]\s*$/gm, '')
+    .replace(/export default \{/, 'return {')
+  const factory = new Function(...IMPORT_NAMES, body)
+  return factory(...IMPORT_NAMES.map(() => () => {}))
+}
+
+// computed 装成真访问器，methods 绑到同一个 vm 上，这样 restoreUploadState 里的
+// this.saveUploadState() 走的是真实现（落盘行为是本用例的断言对象之一）。
+function makeVm(data = {}) {
+  const opts = loadOptions()
+  const vm = Object.assign({}, opts.data.call({}), data)
+  for (const [k, fn] of Object.entries(opts.computed)) {
+    Object.defineProperty(vm, k, { get: () => fn.call(vm), configurable: true })
+  }
+  for (const [k, fn] of Object.entries(opts.methods)) vm[k] = fn.bind(vm)
+  vm.$t = (k, p) => (p ? `${k}:${JSON.stringify(p)}` : k)
+  vm.$emit = () => {}
+  return vm
+}
+
+// 一份可读可写的 uni.storage 桩：restoreUploadState 的「丢弃」必须真的落盘，
+// 否则下次挂载又原样复活（「常驻不消失」的根）。
+function installStorage(initial = {}) {
+  const prior = globalThis.uni
+  const store = { ...initial }
+  globalThis.uni = {
+    getStorageSync: (k) => (k in store ? store[k] : ''),
+    setStorageSync: (k, v) => { store[k] = v },
+    removeStorageSync: (k) => { delete store[k] },
+    showToast() {}, $emit() {}, $on() {}, $off() {},
+  }
+  return { store, restore: () => { globalThis.uni = prior } }
+}
+
+const KEY = 'upload_state_v2_project_7'
+
+// ---------- A：已中断的任务不许算成「正在上传」 ----------
+
+test('队列里只剩已中断的任务时：不算正在上传，底栏改说「N 个上传已中断」', () => {
+  const s = installStorage()
+  try {
+    const vm = makeVm({
+      projectId: 7,
+      isBatchUploading: false,
+      uploadStatusMap: {
+        z: { fileId: 'z', name: 'IMG_0001.jpg', size: 1048576, uploaded: 0, progress: 0, error: true, status: 'interrupted' },
+      },
+    })
+    assert.equal(vm.totalUploadCount, 0, '「(0/1)」里的那个 1 不许再出现')
+    assert.equal(vm.uploadedCount, 0)
+    assert.equal(vm.globalUploadProgress, null, 'null 才能让模板不画那个假的 0%')
+    assert.equal(vm.interruptedUploadCount, 1, '底栏要说清楚：1 个上传已中断')
+    assert.equal(vm.showInterruptedOnly, true)
+  } finally { s.restore() }
+})
+
+test('批量上传途中队列瞬时清空（条目延迟 1s 删）：仍走进度环，不许闪出「0 个上传已中断」', () => {
+  const s = installStorage()
+  try {
+    const vm = makeVm({
+      projectId: 7,
+      isBatchUploading: true,
+      batchUploadTotalSize: 1000,
+      batchUploadFinishedSize: 400,
+      uploadStatusMap: {},
+    })
+    assert.equal(vm.interruptedUploadCount, 0)
+    assert.equal(vm.showInterruptedOnly, false)
+    assert.equal(vm.globalUploadProgress, 40)
+  } finally { s.restore() }
+})
+
+test('活着的任务照旧计数：中断的只从计数里剔除，不影响真在传的', () => {
+  const s = installStorage()
+  try {
+    const vm = makeVm({
+      projectId: 7,
+      isBatchUploading: false,
+      uploadStatusMap: {
+        dead: { fileId: 'dead', name: 'a.jpg', size: 100, uploaded: 0, progress: 0, error: true, status: 'interrupted' },
+        live: { fileId: 1, name: 'b.docx', size: 200, uploaded: 100, progress: 50 },
+        done: { fileId: 2, name: 'c.docx', size: 200, uploaded: 200, progress: 100 },
+      },
+    })
+    assert.equal(vm.totalUploadCount, 2)
+    assert.equal(vm.uploadedCount, 1)
+    assert.equal(vm.interruptedUploadCount, 1)
+    assert.equal(Math.round(vm.globalUploadProgress), 75, '(100+200)/(200+200)')
+  } finally { s.restore() }
+})
+
+// ---------- B：重启后 pending 排队项被标成中断，而不是继续冒充「正在上传」 ----------
+
+test('恢复 pending 排队项（内存里的 File 对象已随页面消失）：标成已中断，不再计入正在上传', () => {
+  const s = installStorage({
+    [KEY]: JSON.stringify({
+      pending_1: { fileId: 'pending_1', name: 'IMG_0001.jpg', size: 1048576, uploaded: 0, progress: 0, startTime: 1 },
+    }),
+  })
+  try {
+    const vm = makeVm({ projectId: 7, isBatchUploading: false, uploadStatusMap: {} })
+    vm.uploadFileObjects = {}
+    vm.restoreUploadState()
+    const item = vm.uploadStatusMap.pending_1
+    assert.ok(item, '条目本身要留着，↻ 重试与 × 删除仍要够得着')
+    assert.equal(item.status, 'interrupted')
+    assert.equal(item.error, true)
+    assert.equal(vm.totalUploadCount, 0, '不许再说「正在上传 (0/1)」')
+    assert.equal(vm.interruptedUploadCount, 1)
+  } finally { s.restore() }
+})
+
+// ---------- C：progress 已 100 的恢复条目直接丢弃 ----------
+
+test('恢复 progress===100 的条目：直接丢弃并落盘，第二次挂载不会再复活', () => {
+  const s = installStorage({
+    [KEY]: JSON.stringify({
+      42: { fileId: 42, wpsFileId: 'w42', name: 'done.docx', size: 200, uploaded: 200, progress: 100, startTime: 1 },
+      pending_1: { fileId: 'pending_1', name: 'x.jpg', size: 100, uploaded: 0, progress: 0, startTime: 1 },
+    }),
+  })
+  try {
+    const vm = makeVm({ projectId: 7, isBatchUploading: false, uploadStatusMap: {} })
+    vm.uploadFileObjects = {}
+    vm.restoreUploadState()
+    assert.deepEqual(Object.keys(vm.uploadStatusMap), ['pending_1'], '已完成的没有可恢复的东西')
+    assert.equal(vm.totalUploadCount, 0)
+
+    // 第二次挂载（projectId watcher / FilePickerDialog 里的第二个实例）读到的必须已经是清过的
+    const persisted = JSON.parse(s.store[KEY])
+    assert.deepEqual(Object.keys(persisted), ['pending_1'], '丢弃要落盘，否则下次挂载又原样复活')
+    const vm2 = makeVm({ projectId: 7, isBatchUploading: false, uploadStatusMap: {} })
+    vm2.uploadFileObjects = {}
+    vm2.restoreUploadState()
+    assert.deepEqual(Object.keys(vm2.uploadStatusMap), ['pending_1'])
+  } finally { s.restore() }
+})


### PR DESCRIPTION
## 问题
桌面端左下角「正在上传 (0/1) 0%」常驻不消失。

## 根因
与手机中转无关（前端零 mobile-sync 代码）。是 FileTree 自己的上传队列：`uploadedCount` / `totalUploadCount` 直接数整张 `uploadStatusMap`，队列里只剩已中断/出错的死任务时得出 (0/1)；`globalUploadProgress` 过滤死任务返回 null，模板 `Math.floor(null || 0)` 画成 0%。`saveUploadState` 不落 error 标志、`restoreUploadState` 每次挂载都把它复活成 interrupted，没有任何路径自动清掉。

## 修法
- computed `activeUploads`，三处计数同口径；队列只剩死任务时底栏改显示「N 个上传已中断」+「点开列表可重试或删除」，↻ 重试 / × 删除 / 取消全部入口不动。判据是「没有活的且有死的」，批量上传途中 1s 延迟删条目的瞬时空窗不会闪出中断文案。
- 恢复：progress 已 100 的条目直接丢弃并落盘；未完成条目（含 pending 排队项）一律标中断。
- 不做启动时自动删占位文件（会破坏刻意做的跨重启续传）。

## 验证
- 新增 file-tree-upload-zombie.test.mjs 5 用例，改前 4 红，改后 5 绿。
- test:project-home 345/0；check:emits / check:locales / check:nav 通过；模板用 vue compiler 编译无错。
- 真机未走查；build:h5 由 CI 兜底。复测提示：重启桌面端后底栏若仍有条目，应显示「1 个上传已中断」而不是「正在上传 0%」，点 × 或「取消全部」可清掉。

dev-board#462

🤖 Generated with [Claude Code](https://claude.com/claude-code)