### PR TITLE
fix(insight): 依据面板配置类检索失败带结构化原因码，给「去连接账户/去充值」引导而非重试（dev-board#458）

### DIFF
--- a/.claude/agents/doc-insight.md
+++ b/.claude/agents/doc-insight.md
@@ -44,7 +44,7 @@ dev-board#181（后端部分）+ #182。
 `doc_insight_run`：id / project_id / doc_file_id / status(RUNNING|DONE|FAILED) / phase（可读进度短语，前端直接显示）/ error / model / started_at / finished_at。
 索引 `(project_id, doc_file_id, started_at)`。
 
-`doc_insight_entity`：id / run_id / project_id / doc_file_id / kind(COMPANY|LAW|CASE) / name（展示名）/ norm_key（归一键，去重与缓存都按它）/ mentions_json / retrieval_status / retrieval_source / retrieval_json(TEXT) / retrieval_note / fetched_at。
+`doc_insight_entity`：id / run_id / project_id / doc_file_id / kind(COMPANY|LAW|CASE) / name（展示名）/ norm_key（归一键，去重与缓存都按它）/ mentions_json / retrieval_status / retrieval_source / retrieval_json(TEXT) / retrieval_note / retrieval_hint / fetched_at。
 索引 `(run_id)` 与 `(project_id, kind, norm_key, fetched_at)`（后者是 7 天缓存命中查询）。
 
 `doc_insight_finding`：id / run_id / project_id / doc_file_id / kind(COUNT_MISMATCH|USCC_INVALID|CITATION_NOT_FOUND|CITATION_MISMATCH) / severity(warn|error) / title / detail_json(TEXT) / created_at。
@@ -62,6 +62,23 @@ LAW 的 `authoritative`（权威条文原文）、CASE 的 `recognition`（案�
 | ERROR | 打了但失败（异常、形状不认得） | 企查查全称重打时抛的非网关异常 |
 
 后三态**必须**写 `retrieval_note`（可读中文）。窗格里显示「法规检索本次不可用：账号点数耗尽」远好过一个空白格子。
+
+**`retrieval_hint`：配置类失败的结构化原因码**（dev-board#458，length 32，可空，一路上到 REST 的 `retrievalHint`）。
+UNAVAILABLE 里还有第二刀要切：**重试有用的**（上游故障、网关不可达）与**重试一百次也没用的**（配置状态）。
+后者带原因码，前端据它把「下一步」摆成一个可点的按钮：
+
+| hint | 来源 | 窗格给什么 |
+|---|---|---|
+| NOT_CONNECTED | `GatewayException.Kind.NOT_CONNECTED`（本机没连账户，打包态桌面端的常态） | 「去连接账户」→ `open-settings {nav:'account'}` |
+| NO_CREDITS | `Kind.NO_CREDITS`（法宝与企查查两条路都会来） | 「去充值」→ 同一个设置页 |
+| UNAUTHORIZED | `Kind.UNAUTHORIZED`（账户 Key 无效/被吊销） | 「去连接账户」 |
+| NO_CREDENTIAL | `McpProvider.NO_CREDENTIAL_PREFIX`（自建部署缺服务端 `PKULAW_TOKEN`） | **只给文案**「凭据需由部署管理员在服务端配置」，不给按钮 |
+| null | 其余一切（含 SERVICE_DISABLED / UPSTREAM_FAILED / GATEWAY_UNREACHABLE / BAD_REQUEST，以及成功与 NOT_FOUND） | 照旧 note + 「重试」 |
+
+带 hint 的四种，note **只写原因**：不加「本次不可用」前缀（那是等不来的等待），也不拼 `userHint()` 的散文
+（「请先在设置中连接…」变成按钮，散文里再说一遍是噪音）。落点是 `DocInsightService.unavailableGateway`。
+判定必须走这个码，**前端绝不许拿 `retrievalNote` 做中文子串匹配**——note 双语（LangText），英文版一上线子串判定整条失效。
+NO_CREDENTIAL 不给按钮是刻意的：官方版没有法宝凭据输入框（BYOK 界面 #533 已撤），指一条不存在的路比不指更糟。
 
 **NOT_FOUND 与 UNAVAILABLE 分开是硬要求**（dev-board#395）：用户的下一步完全不同——
 前者是「文档里这家公司/这个条号可能写错了」，后者是「过一会儿再试 / 去查账」。
@@ -120,7 +137,7 @@ service = `pkulaw`，端点写死在官网网关；自备 Key 档才落到 `McpC
           "startedAt":"2026-08-27T10:00:00","finishedAt":"2026-08-27T10:02:00"},
   "entities": [
     {"id":31,"kind":"COMPANY","name":"京微资易科技有限公司","normKey":"京微资易科技",
-     "retrievalStatus":"OK","retrievalSource":"qichacha+mcp","retrievalNote":null,
+     "retrievalStatus":"OK","retrievalSource":"qichacha+mcp","retrievalNote":null,"retrievalHint":null,
      "hasDetail":true,"fetchedAt":"2026-08-27T10:01:00",
      "mentions":[{"quote":"由京微资易科技持有","paragraph":null}],
      "detail":null}
@@ -257,8 +274,13 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
    同理任何新加的提示词模板都别用 `formatted`。
 4. **工具/上游返回的失败判据是 `"Error"` 前缀**（`McpClientService.callTool` 找不到 server / 未启用 / 传输失败都返回该前缀的字符串而**不抛异常**）。
    新接通道时照 `callAndStore` 的判据走，别只判异常。
-5. **`GatewayException` 不能被压成「查无此企业」**：它是平台代采网关的分类失败（余额不足 / 未开放 / 网关不可达），
-   必须落 UNAVAILABLE 并把 `userHint()` 带上。`QichachaService` 刻意没把它裹进自己的 `catch(Exception)`，本领域也别裹。
+5. **`GatewayException` 不能被压成「查无此企业」，`Kind` 也不能压成一句散文**：它是平台代采网关的分类失败
+   （余额不足 / 未开放 / 网关不可达），必须落 UNAVAILABLE。`QichachaService` 刻意没把它裹进自己的 `catch(Exception)`，本领域也别裹。
+   写法唯一出口是 `unavailableGateway(row, ge, prefix)`（dev-board#458）：
+   **配置类三档**（NOT_CONNECTED / NO_CREDITS / UNAUTHORIZED）→ 写 `retrieval_hint`、note 只留原因，
+   **不带**「本次不可用」前缀、**不拼** `userHint()`；**其余档**才照旧带前缀 + `userHint()` 的「稍后重试」。
+   别再写 `unavailable(row, prefix + join(ge.getMessage(), ge.userHint()))` ——`Kind` 一丢，窗格就只能对着一个
+   恒定状态摆「重试」，用户点一百次还是同一句话（#458 的病灶）。
 6. **崩溃会留下僵尸 RUNNING**。`reapOrReject` 按 `insight.stale-minutes`（30 分钟）收尸，
    否则一次进程崩溃会让这份文档**永远**解析不了。改单飞逻辑时别把这段删了。
 7. **测试断 RUNNING 中间态必须用 CountDownLatch 卡住后台 mock**（先落中间态再 submit 的服务，
@@ -311,7 +333,11 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
 - **工具栏「解析」对已经解析过的文档不重跑**（一次解析 = 一次 LLM + 一串外部库调用），只把面板开出来；`status==='FAILED'` 那次不算结论，照样重跑。面板里的「重新解析」是用户明示的，force 重跑。
 - `parseRequest` **必须带 fileId**：面板是 v-if 挂载的，点完解析才挂出来（watch 看不到变化，所以 mounted 也认一次）；不带 fileId 会让「在 A 文档点过解析、随后切到 B 开面板」把 B 也解析掉。
 - 列表瘦身的另一半在前端：`detail` 展开时才 `GET /entities/{id}` 并缓存在组件里；`hasDetail:false` 的一次都不打。
-- NOT_FOUND / UNAVAILABLE / ERROR 的 `retrievalNote` **必须显示**（`.ip-note`），旁边给「重试」（`POST /entities/{id}/refresh`，要写权限）。
+- NOT_FOUND / UNAVAILABLE / ERROR 的 `retrievalNote` **必须显示**（`.ip-note`）。旁边那个动作分两支（dev-board#458）：
+  带 `retrievalHint` 的**不给「重试」**，给引导按钮（`noteAction` → `open-settings {nav:'account'}`，NO_CREDENTIAL 只出一行 `.ip-note-h` 文案）；
+  没有 hint 的才给「重试」（`showRetry` = `canParse && !retrievalHint`，`POST /entities/{id}/refresh`，要写权限）。
+  面板自己不 `uni.navigateTo`：设置由宿主 `openSettingsTab` 就地开中栏标签（与 `@open-url` 同一条口径），
+  **两处挂载点（左栏 / 右 dock）都要绑 `@open-settings`**，漏一处 `check:emits` 直接红。
   NOT_FOUND 用**中性灰**（`.ip-dot.st-NOT_FOUND` / `.ip-note.st-NOT_FOUND`），不用告警色：
   文档里写了一家不存在的公司，是文档的问题，不是我们的故障。
 - 两类引用发现（CITATION_*）在一致性 tab 里只列不改：`fixSuggestions` 看的是 `detail.claims`，引用 detail 没有这一段，天然落不到「修改建议」那一支；点条目仍按 `detail.quote` 定位。CITATION_MISMATCH 的「引用条文」是折叠段（`citedOpen`）。
@@ -322,7 +348,7 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
 ### 前端验证
 
 ```
-cd frontend && npm run test:insight        # 84 条（纯函数 58 + 组件级 26）
+cd frontend && npm run test:insight        # 91 条（纯函数 58 + 组件级 33）
 cd frontend && npm run test:panel-dock     # 注册表自洽 + 停靠回落
 cd frontend && npm run check:emits && npm run check:nav && npm run check:locales
 cd frontend && npm run build:h5 && npm run build:zetaoffice   # 改 editor-main.js 后必须重建 glue
@@ -337,7 +363,7 @@ cd frontend && npm run build:h5 && npm run build:zetaoffice   # 改 editor-main.
 ## 验证
 
 ```
-cd backend && mvn test -Dtest='DocInsight*,LawArticle*'   # 62 条
+cd backend && mvn test -Dtest='DocInsight*,LawArticle*'   # 65 条
 cd backend && mvn test -Dtest='*Mcp*Test'                 # 含 StreamableHttpMcpProviderCredentialTest（空凭证不发请求）
 cd backend && mvn clean test                      # 全量（跨类常量内联，验证阶段一律 clean）
 ```
@@ -345,11 +371,12 @@ cd backend && mvn clean test                      # 全量（跨类常量内联�
   后缀剥离等价、USCC 校验位与去重、**fixable 三条降级分支**、空输入。
 - `LawArticleNumbersTest`（7）：十/百/千组合与「零」、`之N`、已是阿拉伯数字（含全角）、
   **转不动一律 null**、引文剥引用字样取内容线索。
-- `DocInsightServiceTest`（30）：RUNNING 中间态（CountDownLatch）、单飞、企查查降级链、网关失败落 UNAVAILABLE、
+- `DocInsightServiceTest`（33）：RUNNING 中间态（CountDownLatch）、单飞、企查查降级链、网关失败落 UNAVAILABLE、
   **平台档法宝四条通道全部走网关且一次法宝 MCP 都不打 / 网关失败仍 UNAVAILABLE / 本机没凭证说「未配置」不说「本次不可用」/
   上游明确回空 = NOT_FOUND 且按「跑完了」计进摘要**、
   法宝不可用不连坐、案例通道从「未配置」到「配上就接入」、**案号识别命中改用标题检索 / 识别失败静默走原路 /
   识别命中但全文失败仍 OK**、**引用校验三种判定 + 通道未配置整步跳过 + 通道报错不报发现 + 上限 30**、
-  7 天缓存与 refresh 绕过、列表瘦身/发现不瘦身、
+  7 天缓存与 refresh 绕过、列表瘦身/发现不瘦身、**配置类失败带结构化 `retrievalHint`（未连接账户 / 余额不足 / 本机没凭据）
+  且 note 不说「本次不可用」，瞬时失败不带原因码**、
   读不出文字与辅助模型未配置 → FAILED、单块坏输出不炸整轮、鉴权与跨项目 IDOR。
 - `DocInsightControllerTest`（6）：4010 信封、code=1、参数透传、响应形状、路由不互相吃。

--- a/backend/src/main/java/com/checkba/model/entity/DocInsightEntity.java
+++ b/backend/src/main/java/com/checkba/model/entity/DocInsightEntity.java
@@ -48,6 +48,20 @@ public class DocInsightEntity {
     public static final String RETRIEVAL_UNAVAILABLE = "UNAVAILABLE";
     public static final String RETRIEVAL_ERROR = "ERROR";
 
+    /**
+     * {@link #retrievalHint} 的四个配置类取值（dev-board#458）。
+     *
+     * <p>它们和其余失败的分别在于：<b>重试一次也不会变</b>。窗格据此把「下一步」摆成
+     * 一个按钮（去连接账户 / 去充值），而不是一句散文加一个没用的「重试」。
+     * 判定必须走这个码，不许在前端拿 retrievalNote 做中文子串匹配——note 是双语的
+     * （LangText），英文版一上线子串判定整条失效。
+     */
+    public static final String HINT_NOT_CONNECTED = "NOT_CONNECTED";
+    public static final String HINT_NO_CREDITS = "NO_CREDITS";
+    public static final String HINT_UNAUTHORIZED = "UNAUTHORIZED";
+    /** 本机（自建部署 / 非 local-mode）没有该通道凭证：只能由部署管理员在服务端补。 */
+    public static final String HINT_NO_CREDENTIAL = "NO_CREDENTIAL";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -91,6 +105,14 @@ public class DocInsightEntity {
     /** 不可用/失败的可读原因，直接显示给用户。 */
     @Column(name = "retrieval_note", length = 1000)
     private String retrievalNote;
+
+    /**
+     * 结构化的失败原因码（dev-board#458），只在配置类失败时非空：
+     * NOT_CONNECTED / NO_CREDITS / UNAUTHORIZED / NO_CREDENTIAL。
+     * 为空 = 瞬时错误或成功，窗格照旧只显示 note + 「重试」。
+     */
+    @Column(name = "retrieval_hint", length = 32)
+    private String retrievalHint;
 
     @Column(name = "fetched_at")
     private LocalDateTime fetchedAt;

--- a/backend/src/main/java/com/checkba/service/insight/DocInsightService.java
+++ b/backend/src/main/java/com/checkba/service/insight/DocInsightService.java
@@ -350,6 +350,7 @@ public class DocInsightService {
 
     /** @param force true = 绕过 7 天缓存（单实体「重新检索」用） */
     private void retrieveOne(DocInsightEntity row, boolean force) {
+        row.setRetrievalHint(null);   // 上一轮的原因码不许挂到这一轮（重新检索 / 缓存复用都走这里）
         if (!force && copyFromCache(row)) return;
         row.setFetchedAt(LocalDateTime.now());
         switch (row.getKind()) {
@@ -399,7 +400,7 @@ public class DocInsightService {
         } catch (GatewayException ge) {
             // 「查询无结果」继续往下走模糊搜索：文中写的多半是简称，那条路正是为它准备的
             if (!emptyUpstream(ge.getMessage())) {
-                unavailable(row, join(ge.getMessage(), ge.userHint()));
+                unavailableGateway(row, ge, "");
                 return;
             }
             first = ge.getMessage();
@@ -426,7 +427,7 @@ public class DocInsightService {
             if (emptyUpstream(ge.getMessage())) {
                 notFound(row, "qichacha+mcp", ge.getMessage());
             } else {
-                unavailable(row, join(ge.getMessage(), ge.userHint()));
+                unavailableGateway(row, ge, "");
             }
         } catch (Exception e) {
             row.setRetrievalStatus(DocInsightEntity.RETRIEVAL_ERROR);
@@ -651,6 +652,9 @@ public class DocInsightService {
         row.setRetrievalSource(props.getCaseNumberServer());
         row.setRetrievalJson(writeJson(out));
         row.setRetrievalNote(note);
+        // 全文检索那一半刚落过原因码（可能是余额不足），但这一行最终是 OK：
+        // 留着它窗格就会对着一条拿到结果的案例摆「去充值」。
+        row.setRetrievalHint(null);
     }
 
     /**
@@ -674,7 +678,7 @@ public class DocInsightService {
         try {
             raw = pkulawChannel.callTool(server, tool, args);
         } catch (GatewayException ge) {
-            unavailable(row, unavailablePrefix + join(ge.getMessage(), ge.userHint()));
+            unavailableGateway(row, ge, unavailablePrefix);
             return false;
         } catch (Exception e) {
             unavailable(row, unavailablePrefix + readable(e));
@@ -683,7 +687,8 @@ public class DocInsightService {
         if (StringUtils.hasText(raw) && raw.startsWith(McpProvider.NO_CREDENTIAL_PREFIX)) {
             unavailable(row, LangText.of("本机未配置该检索通道的凭证（",
                     "This machine has no credential for this lookup channel (")
-                    + server + LangText.of("），本次未检索", "); nothing was queried"));
+                    + server + LangText.of("），本次未检索", "); nothing was queried"),
+                    DocInsightEntity.HINT_NO_CREDENTIAL);
             return false;
         }
         if (!StringUtils.hasText(raw) || raw.startsWith(ERROR_PREFIX)) {
@@ -708,6 +713,7 @@ public class DocInsightService {
         row.setRetrievalStatus(DocInsightEntity.RETRIEVAL_OK);
         row.setRetrievalJson(writeJson(out));
         row.setRetrievalNote(null);
+        row.setRetrievalHint(null);
         return true;
     }
 
@@ -745,9 +751,41 @@ public class DocInsightService {
         return new String[]{s, ""};
     }
 
+    /** 通道不可用，但原因是瞬时的（上游故障 / 网关不可达 / 通道没配）：只有可读原因，没有原因码。 */
     private void unavailable(DocInsightEntity row, String note) {
+        unavailable(row, note, null);
+    }
+
+    private void unavailable(DocInsightEntity row, String note, String hint) {
         row.setRetrievalStatus(DocInsightEntity.RETRIEVAL_UNAVAILABLE);
         row.setRetrievalNote(note);
+        row.setRetrievalHint(hint);
+    }
+
+    /**
+     * 网关分类失败落 UNAVAILABLE（dev-board#458）。
+     *
+     * <p>分两档写，别再压成一句散文：
+     * <ul>
+     *   <li><b>配置类</b>（未连接账户 / 余额不足 / Key 失效）→ 带原因码，note <b>只写原因</b>：
+     *       不加「本次不可用」前缀（那是等不来的等待），也不拼 {@code userHint()}——
+     *       「去连接账户 / 去充值」由窗格摆成一个可点的按钮，散文里再说一遍只是噪音；</li>
+     *   <li><b>瞬时类</b>（服务未开放 / 上游故障 / 网关不可达 / 请求不合法）→ 无原因码，
+     *       保留前缀与 {@code userHint()} 的「稍后重试」提示，窗格照旧给「重试」。</li>
+     * </ul>
+     */
+    private void unavailableGateway(DocInsightEntity row, GatewayException ge, String transientPrefix) {
+        String hint = switch (ge.getKind()) {
+            case NOT_CONNECTED -> DocInsightEntity.HINT_NOT_CONNECTED;
+            case NO_CREDITS -> DocInsightEntity.HINT_NO_CREDITS;
+            case UNAUTHORIZED -> DocInsightEntity.HINT_UNAUTHORIZED;
+            default -> null;
+        };
+        if (hint != null) {
+            unavailable(row, ge.getMessage(), hint);
+        } else {
+            unavailable(row, transientPrefix + join(ge.getMessage(), ge.userHint()));
+        }
     }
 
     /** 查完了、上游说没有。note 里<b>不带任何「稍后重试 / 联系客服」</b>：这不是故障。 */
@@ -755,6 +793,7 @@ public class DocInsightService {
         row.setRetrievalStatus(DocInsightEntity.RETRIEVAL_NOT_FOUND);
         row.setRetrievalSource(source);
         row.setRetrievalNote(note);
+        row.setRetrievalHint(null);
     }
 
     /** 上游那句话是不是「查完了，没有」。企查查的原话是「【有效请求】查询无结果」。 */
@@ -985,7 +1024,7 @@ public class DocInsightService {
         boolean hasDetail = StringUtils.hasText(e.getRetrievalJson());
         return new EntityView(e.getId(), e.getKind(), e.getName(), e.getNormKey(),
                 e.getRetrievalStatus(), e.getRetrievalSource(), e.getRetrievalNote(),
-                hasDetail, e.getFetchedAt(), mentions(e.getMentionsJson()),
+                e.getRetrievalHint(), hasDetail, e.getFetchedAt(), mentions(e.getMentionsJson()),
                 withDetail ? readJson(e.getRetrievalJson()) : null);
     }
 

--- a/backend/src/main/java/com/checkba/service/insight/DocInsightViews.java
+++ b/backend/src/main/java/com/checkba/service/insight/DocInsightViews.java
@@ -28,9 +28,15 @@ public final class DocInsightViews {
     public record MentionView(String quote, Integer paragraph) {
     }
 
+    /**
+     * {@code retrievalHint}：配置类失败的结构化原因码（dev-board#458），
+     * 取值 NOT_CONNECTED / NO_CREDITS / UNAUTHORIZED / NO_CREDENTIAL，其余情况为 null。
+     * 前端据它把「下一步」摆成按钮（去连接账户 / 去充值），<b>不许拿 retrievalNote 做子串匹配</b>
+     * ——note 双语，英文版一上线子串判定就失效。
+     */
     public record EntityView(Long id, String kind, String name, String normKey,
                              String retrievalStatus, String retrievalSource, String retrievalNote,
-                             boolean hasDetail, LocalDateTime fetchedAt,
+                             String retrievalHint, boolean hasDetail, LocalDateTime fetchedAt,
                              List<MentionView> mentions, JsonNode detail) {
     }
 

--- a/backend/src/test/java/com/checkba/controller/DocInsightControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/DocInsightControllerTest.java
@@ -61,7 +61,7 @@ class DocInsightControllerTest {
                         "qwen/qwen3.7-flash", LocalDateTime.of(2026, 8, 27, 10, 0),
                         LocalDateTime.of(2026, 8, 27, 10, 2)),
                 List.of(new EntityView(31L, "COMPANY", "京微资易科技有限公司", "京微资易科技",
-                        "OK", "qichacha+mcp", null, true, LocalDateTime.of(2026, 8, 27, 10, 1),
+                        "OK", "qichacha+mcp", null, null, true, LocalDateTime.of(2026, 8, 27, 10, 1),
                         List.of(new MentionView("由京微资易科技持有", null)), null)),
                 List.of(new FindingView(41L, "COUNT_MISMATCH", "warn", "标的公司 的「房产」前后不一致：58项 / 39项",
                         om.readTree("""
@@ -144,7 +144,7 @@ class DocInsightControllerTest {
             auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(9L);
             EntityView detail = new EntityView(31L, "LAW", "《中华人民共和国公司法》第二十条", "中华人民共和国公司法#第二十条",
                     "UNAVAILABLE", "pkulaw-semantic", "法规检索本次不可用：401 checking remaining points",
-                    false, LocalDateTime.of(2026, 8, 27, 10, 1), List.of(), null);
+                    null, false, LocalDateTime.of(2026, 8, 27, 10, 1), List.of(), null);
             when(svc.entityDetail(9L, 1L, 31L)).thenReturn(detail);
             when(svc.refreshEntity(9L, 1L, 31L)).thenReturn(detail);
 

--- a/backend/src/test/java/com/checkba/service/insight/DocInsightServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/insight/DocInsightServiceTest.java
@@ -320,7 +320,7 @@ class DocInsightServiceTest {
     }
 
     @Test
-    @DisplayName("网关失败是 UNAVAILABLE（不是查无此企业），并带上「下一步」提示")
+    @DisplayName("网关失败是 UNAVAILABLE（不是查无此企业），并带结构化原因码 hint=NO_CREDITS")
     void 网关失败落不可用() throws Exception {
         when(qichacha.queryEciInfoJson(anyString()))
                 .thenThrow(new GatewayException(GatewayException.Kind.NO_CREDITS, "账户 Credits 余额不足"));
@@ -329,7 +329,8 @@ class DocInsightServiceTest {
         awaitStatus(svc.startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
         DocInsightEntity company = entityOf(DocInsightEntity.KIND_COMPANY);
         assertEquals(DocInsightEntity.RETRIEVAL_UNAVAILABLE, company.getRetrievalStatus());
-        assertTrue(company.getRetrievalNote().contains("充值"), company.getRetrievalNote());
+        assertEquals(DocInsightEntity.HINT_NO_CREDITS, company.getRetrievalHint());
+        assertTrue(company.getRetrievalNote().contains("余额不足"), company.getRetrievalNote());
         verify(mcp, never()).callTool(eq(DocInsightService.QICHACHA_MCP_SERVER), anyString(), anyMap());
     }
 
@@ -443,6 +444,24 @@ class DocInsightServiceTest {
         assertEquals("pkulaw-case-number", c.getRetrievalSource());
         assertTrue(c.getRetrievalNote().contains("仅返回案号识别结果"), c.getRetrievalNote());
         assertTrue(c.getRetrievalJson().contains("https://www.pkulaw.com/pfnl/abc"), c.getRetrievalJson());
+    }
+
+    @Test
+    @DisplayName("全文检索因余额不足失败、识别命中 → 记 OK 且原因码清掉（别对一条有结果的案例摆「去充值」）")
+    void 识别命中后不留旧原因码() throws Exception {
+        when(qichacha.queryEciInfoJson(anyString())).thenReturn(QCC_FULL);
+        when(providerResolver.resolve(ExternalServiceProvider.PKULAW))
+                .thenReturn(ExternalServiceProvider.PLATFORM);
+        stubCaseChannel();
+        stubGatewayRaw(ANHAO_HIT);
+        when(gateway.call(eq("pkulaw"), eq("search_case"), anyMap(), anyInt()))
+                .thenThrow(new GatewayException(GatewayException.Kind.NO_CREDITS, "账户 Credits 余额不足"));
+
+        awaitStatus(newService().startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        DocInsightEntity c = entityOf(DocInsightEntity.KIND_CASE);
+        assertEquals(DocInsightEntity.RETRIEVAL_OK, c.getRetrievalStatus());
+        assertNull(c.getRetrievalHint(), "这一行最终是 OK，配置类引导不该挂在它上面");
     }
 
     // ---------------------------------------------------------------- 法条引用校验
@@ -739,7 +758,7 @@ class DocInsightServiceTest {
     }
 
     @Test
-    @DisplayName("平台档网关失败：UNAVAILABLE 且带「下一步」，不当成查无此条文")
+    @DisplayName("平台档余额不足：UNAVAILABLE + hint=NO_CREDITS，原因保留，不当成查无此条文")
     void 平台档网关失败落不可用() throws Exception {
         when(qichacha.queryEciInfoJson(anyString())).thenReturn(QCC_FULL);
         when(providerResolver.resolve(ExternalServiceProvider.PKULAW))
@@ -751,7 +770,27 @@ class DocInsightServiceTest {
 
         DocInsightEntity law = entityOf(DocInsightEntity.KIND_LAW);
         assertEquals(DocInsightEntity.RETRIEVAL_UNAVAILABLE, law.getRetrievalStatus());
-        assertTrue(law.getRetrievalNote().contains("充值"), law.getRetrievalNote());
+        assertEquals(DocInsightEntity.HINT_NO_CREDITS, law.getRetrievalHint());
+        assertTrue(law.getRetrievalNote().contains("余额不足"), law.getRetrievalNote());
+        assertFalse(law.getRetrievalNote().contains("本次不可用"), law.getRetrievalNote());
+        assertEquals(DocInsightEntity.HINT_NO_CREDITS, lawView().retrievalHint(), "原因码必须上到 REST 视图");
+    }
+
+    @Test
+    @DisplayName("平台档未连接账户：配置类失败不说「本次不可用」（恒定状态，等不来）")
+    void 未连接账户不说本次不可用() throws Exception {
+        when(qichacha.queryEciInfoJson(anyString())).thenReturn(QCC_FULL);
+        when(providerResolver.resolve(ExternalServiceProvider.PKULAW))
+                .thenReturn(ExternalServiceProvider.PLATFORM);
+        when(gateway.call(eq("pkulaw"), anyString(), anyMap(), anyInt()))
+                .thenThrow(new GatewayException(GatewayException.Kind.NOT_CONNECTED, "尚未连接 AI WorkDeck 账户"));
+
+        awaitStatus(newService().startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        DocInsightEntity law = entityOf(DocInsightEntity.KIND_LAW);
+        assertEquals(DocInsightEntity.RETRIEVAL_UNAVAILABLE, law.getRetrievalStatus());
+        assertFalse(law.getRetrievalNote().contains("本次不可用"), law.getRetrievalNote());
+        assertEquals(DocInsightEntity.HINT_NOT_CONNECTED, lawView().retrievalHint());
     }
 
     @Test
@@ -768,6 +807,7 @@ class DocInsightServiceTest {
         assertEquals(DocInsightEntity.RETRIEVAL_UNAVAILABLE, law.getRetrievalStatus());
         assertTrue(law.getRetrievalNote().contains("未配置"), law.getRetrievalNote());
         assertFalse(law.getRetrievalNote().contains("本次不可用"), law.getRetrievalNote());
+        assertEquals(DocInsightEntity.HINT_NO_CREDENTIAL, lawView().retrievalHint());
     }
 
     @Test
@@ -788,6 +828,30 @@ class DocInsightServiceTest {
                 "未命中必须单列，否则用户读到的是「一次都没查成」：" + done.getPhase());
         assertFalse(entityOf(DocInsightEntity.KIND_LAW).getRetrievalNote().contains("hi@aiworkdeck.com"),
                 "查无此条文不该指向客服");
+    }
+
+    @Test
+    @DisplayName("瞬时失败（上游故障）不带原因码：窗格照旧给「本次不可用」+ 重试")
+    void 瞬时失败不带原因码() throws Exception {
+        when(qichacha.queryEciInfoJson(anyString())).thenReturn(QCC_FULL);
+        when(providerResolver.resolve(ExternalServiceProvider.PKULAW))
+                .thenReturn(ExternalServiceProvider.PLATFORM);
+        when(gateway.call(eq("pkulaw"), anyString(), anyMap(), anyInt()))
+                .thenThrow(new GatewayException(GatewayException.Kind.UPSTREAM_FAILED, "上游供应商超时"));
+
+        awaitStatus(newService().startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        DocInsightEntity law = entityOf(DocInsightEntity.KIND_LAW);
+        assertEquals(DocInsightEntity.RETRIEVAL_UNAVAILABLE, law.getRetrievalStatus());
+        assertNull(law.getRetrievalHint(), "瞬时故障重试是真出路，不许摆成配置引导");
+        assertTrue(law.getRetrievalNote().contains("本次不可用"), law.getRetrievalNote());
+        assertTrue(law.getRetrievalNote().contains("稍后重试"), law.getRetrievalNote());
+    }
+
+    /** 法规实体的 REST 视图（原因码是给前端的契约，只断言实体字段不够）。 */
+    private EntityView lawView() {
+        return svc.latest(UID, PID, DOC).entities().stream()
+                .filter(e -> DocInsightEntity.KIND_LAW.equals(e.kind())).findFirst().orElseThrow();
     }
 
     private void stubExternalsOk() {

--- a/frontend/src/components/InsightPane.vue
+++ b/frontend/src/components/InsightPane.vue
@@ -60,10 +60,16 @@
           </view>
 
           <!-- 通道不可用/查无：note 必须显示出来（「法宝检索本次不可用：账号点数耗尽」
-               远好过一个空白格子），并给一个重试。 -->
+               远好过一个空白格子）。旁边那个动作分两种：**配置类失败**（没连账户 / 余额不足 /
+               Key 失效 / 本机没凭据）给一条走得通的引导，其余才给「重试」——对一个恒定状态
+               摆「重试」，用户点一百次还是同一句话（dev-board#458）。 -->
           <view v-if="e.retrievalNote" class="ip-note" :class="'st-' + (e.retrievalStatus || 'PENDING')">
-            <text class="ip-note-t">{{ e.retrievalNote }}</text>
-            <text v-if="canParse" class="ip-act" @tap.stop="refreshEntity(e)">{{ $t('insight.retry') }}</text>
+            <view class="ip-note-body">
+              <text class="ip-note-t">{{ e.retrievalNote }}</text>
+              <text v-if="noteHint(e)" class="ip-note-h">{{ $t(noteHint(e)) }}</text>
+            </view>
+            <text v-if="noteAction(e)" class="ip-act" @tap.stop="runNoteAction(e)">{{ $t(noteAction(e).label) }}</text>
+            <text v-else-if="showRetry(e)" class="ip-act" @tap.stop="refreshEntity(e)">{{ $t('insight.retry') }}</text>
           </view>
 
           <view v-if="expandedId === e.id" class="ip-detail">
@@ -260,7 +266,9 @@ export default {
   // 不知道用户点了画布哪里，宿主不知道有哪些实体——索引必须交给宿主一份）。
   // open-url：法宝链接（权威条文 / 案号识别 / 引用候选）交给宿主的浏览器面板打开，
   // 与 MarketDetailPane / ProjectFavoritesPanel 同一条既有事件。
-  emits: ['entities', 'open-url'],
+  // open-settings：配置类检索失败（未连接账户 / 余额不足 / Key 失效）的「下一步」。
+  // 面板自己不碰 uni.navigateTo，交给宿主 openSettingsTab —— 与 open-url 同一条口径。
+  emits: ['entities', 'open-url', 'open-settings'],
   props: {
     projectId: { type: [Number, String], default: null },
     // 当前活跃的 writer 文档；换文档时面板整体重载（跟随，不留旧结论）
@@ -451,6 +459,37 @@ export default {
         this.detailLoading = { ...this.detailLoading, [e.id]: false }
       }
     },
+    /**
+     * 配置类失败的「下一步」（dev-board#458）。判定只看后端下发的结构化 retrievalHint，
+     * **绝不拿 retrievalNote 做中文子串匹配**：note 是双语的（后端 LangText），
+     * 英文版一上线子串判定整条失效（api.js 里那条「只认 code 不认中文子串」的教训）。
+     *
+     * NO_CREDENTIAL 不给按钮：官方版没有法宝凭据输入框（BYOK 界面 #533 已撤），
+     * 那是自建部署的服务端 PKULAW_TOKEN，只能由部署管理员补——指一条不存在的路比不指更糟。
+     */
+    noteAction(e) {
+      switch (e && e.retrievalHint) {
+        case 'NOT_CONNECTED':
+        case 'UNAUTHORIZED':
+          return { label: 'insight.goConnectAccount', nav: 'account' }
+        case 'NO_CREDITS':
+          return { label: 'insight.goRecharge', nav: 'account' }
+        default:
+          return null
+      }
+    },
+    /** 没有按钮可给、但要多说一句的那一档（目前只有 NO_CREDENTIAL）。 */
+    noteHint(e) {
+      return e && e.retrievalHint === 'NO_CREDENTIAL' ? 'insight.hint.NO_CREDENTIAL' : ''
+    },
+    /** 配置类失败重试不了：那四种是恒定状态，再打一次上游只是白花一次额度。 */
+    showRetry(e) {
+      return this.canParse && !(e && e.retrievalHint)
+    },
+    runNoteAction(e) {
+      const act = this.noteAction(e)
+      if (act) this.$emit('open-settings', { nav: act.nav })
+    },
     async refreshEntity(e) {
       if (!this.pid || !e || !e.id || !this.canWrite) return
       this.detailLoading = { ...this.detailLoading, [e.id]: true }
@@ -458,7 +497,7 @@ export default {
       try {
         const v = unwrap(await refreshDocInsightEntity(this.pid, e.id)) || {}
         const next = this.entities.map((x) => (x.id === e.id
-          ? { ...x, retrievalStatus: v.retrievalStatus, retrievalSource: v.retrievalSource, retrievalNote: v.retrievalNote, hasDetail: v.hasDetail, fetchedAt: v.fetchedAt }
+          ? { ...x, retrievalStatus: v.retrievalStatus, retrievalSource: v.retrievalSource, retrievalNote: v.retrievalNote, retrievalHint: v.retrievalHint || null, hasDetail: v.hasDetail, fetchedAt: v.fetchedAt }
           : x))
         this.entities = next
         this.details = { ...this.details, [e.id]: v.detail || null }

--- a/frontend/src/components/insight-pane.scss
+++ b/frontend/src/components/insight-pane.scss
@@ -106,7 +106,10 @@
 .ip-note.st-NOT_FOUND { background: var(--awd-bg); border-color: var(--awd-border); }
 .ip-note.st-NOT_FOUND .ip-note-t { color: var(--awd-text-2); }
 .ip-note.st-ERROR { background: var(--awd-danger-soft); border-color: var(--awd-danger); }
+.ip-note-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .ip-note-t { flex: 1; min-width: 0; font-size: 11px; color: var(--awd-text); line-height: 1.5; }
+// 没有按钮可给的那一档（自建部署缺服务端凭据）：多说一句「找谁」，弱化一级。
+.ip-note-h { font-size: 10px; color: var(--awd-text-2); line-height: 1.5; }
 .ip-note.st-ERROR .ip-note-t { color: var(--awd-danger-text); }
 .ip-act {
   flex: none; padding: 0 7px; border-radius: 10px; font-size: 10px;

--- a/frontend/src/locales/en-US/insight.js
+++ b/frontend/src/locales/en-US/insight.js
@@ -17,6 +17,13 @@ export default {
   refreshFailed: 'Could not re-run the lookup',
   retry: 'Retry',
 
+  // Next step for configuration failures (dev-board#458). Retrying cannot fix any of these.
+  goConnectAccount: 'Connect account',
+  goRecharge: 'Add credits',
+  hint: {
+    NO_CREDENTIAL: 'This lookup channel needs a credential configured on the server by your administrator.',
+  },
+
   tab: {
     retrieval: 'Lookups',
     checks: 'Consistency',

--- a/frontend/src/locales/zh-CN/insight.js
+++ b/frontend/src/locales/zh-CN/insight.js
@@ -18,6 +18,14 @@ export default {
   refreshFailed: '重新检索失败',
   retry: '重试',
 
+  // 配置类检索失败的「下一步」（dev-board#458）。这四种重试不了，给的是路不是按钮上的安慰。
+  goConnectAccount: '去连接账户',
+  goRecharge: '去充值',
+  hint: {
+    // 官方版没有法宝凭据输入框（BYOK 界面已撤），自建部署只能由管理员在服务端补。
+    NO_CREDENTIAL: '该检索通道的凭据需要由部署管理员在服务端配置。',
+  },
+
   tab: {
     retrieval: '外部检索',
     checks: '一致性校验',

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -799,6 +799,7 @@
             :cursor-context="insightCursorContext"
             @entities="onInsightEntities"
             @open-url="openBrowserTab($event)"
+            @open-settings="openSettingsTab($event || {})"
           />
           <!-- 有真前端入口（Web 插件）走 iframe 沙箱；纯工具/skill 插件走宿主渲染的
                启动面板（介绍 + 怎么用 + 一键动作发进 AI 对话），不再是「未配置入口地址」。 -->
@@ -1534,6 +1535,7 @@
                 :cursor-context="insightCursorContext"
                 @entities="onInsightEntities"
                 @open-url="openBrowserTab($event)"
+                @open-settings="openSettingsTab($event || {})"
               />
             </view>
 

--- a/frontend/tests/insight/insightPane.test.mjs
+++ b/frontend/tests/insight/insightPane.test.mjs
@@ -384,3 +384,78 @@ test('NOT_FOUND 是中性态：note 照常显示，且样式表里为它单列�
   assert.ok(/\.ip-note\.st-NOT_FOUND\s*\{/.test(scss), 'ip-note 缺 NOT_FOUND 一档')
   assert.ok(!/\.ip-note\.st-NOT_FOUND[^\n]*awd-warning/.test(scss), 'NOT_FOUND 不该用告警色')
 })
+
+
+// ————————————————— 配置类失败的引导（dev-board#458） —————————————————
+//
+// 「重试」对「没连账户 / 余额不足 / Key 失效 / 本机没凭据」一点用都没有：那四种是恒定状态，
+// 再点一百次还是同一句话。判定必须走后端下发的结构化 retrievalHint，**不许拿 retrievalNote
+// 做中文子串匹配**——note 是双语的，英文版一上线子串判定整条失效（api.js:285 的同款教训）。
+
+function unavailableEntity(hint, note = '原因一句话') {
+  return {
+    id: 6, kind: 'LAW', name: '《中华人民共和国公司法》第二十条', retrievalStatus: 'UNAVAILABLE',
+    retrievalHint: hint, retrievalNote: note, hasDetail: false, mentions: [],
+  }
+}
+
+async function loadWith(entity) {
+  const made = makeVm({ latest: { run: { status: 'DONE' }, entities: [entity], findings: [] } })
+  await made.vm.load()
+  made.entity = made.vm.entities[0]
+  return made
+}
+
+test('未连接账户：给「去连接账户」按钮，且不给「重试」', async () => {
+  const { vm, entity, emitted } = await loadWith(unavailableEntity('NOT_CONNECTED'))
+  const act = vm.noteAction(entity)
+  assert.ok(act, '配置类失败必须给一个可点的下一步')
+  assert.equal(act.label, 'insight.goConnectAccount')
+  assert.equal(vm.showRetry(entity), false, '重试改不了「没连账户」')
+  vm.runNoteAction(entity)
+  assert.deepEqual(emitted.filter((e) => e[0] === 'open-settings'), [['open-settings', { nav: 'account' }]])
+})
+
+test('账户 Key 失效：同样指向账户设置', async () => {
+  const { vm, entity, emitted } = await loadWith(unavailableEntity('UNAUTHORIZED'))
+  assert.equal(vm.noteAction(entity).label, 'insight.goConnectAccount')
+  assert.equal(vm.showRetry(entity), false)
+  vm.runNoteAction(entity)
+  assert.deepEqual(emitted.filter((e) => e[0] === 'open-settings'), [['open-settings', { nav: 'account' }]])
+})
+
+test('余额不足：按钮是「去充值」，不是「重试」', async () => {
+  const { vm, entity, emitted } = await loadWith(unavailableEntity('NO_CREDITS'))
+  assert.equal(vm.noteAction(entity).label, 'insight.goRecharge')
+  assert.equal(vm.showRetry(entity), false)
+  vm.runNoteAction(entity)
+  assert.deepEqual(emitted.filter((e) => e[0] === 'open-settings'), [['open-settings', { nav: 'account' }]])
+})
+
+test('本机没凭据（自建部署）：只给文案，既不给按钮也不给重试', async () => {
+  const { vm, entity, emitted } = await loadWith(unavailableEntity('NO_CREDENTIAL'))
+  assert.equal(vm.noteAction(entity), null, '官方版没有法宝凭据输入框，指一条不存在的路比不指更糟')
+  assert.equal(vm.showRetry(entity), false)
+  assert.equal(vm.noteHint(entity), 'insight.hint.NO_CREDENTIAL')
+  vm.runNoteAction(entity)
+  assert.equal(emitted.filter((e) => e[0] === 'open-settings').length, 0)
+})
+
+test('瞬时失败（没有原因码）：照旧只给「重试」', async () => {
+  const { vm, entity } = await loadWith(unavailableEntity(null, '法规检索本次不可用：上游超时'))
+  assert.equal(vm.noteAction(entity), null)
+  assert.equal(vm.noteHint(entity), '')
+  assert.equal(vm.showRetry(entity), true, '上游故障重试是真出路')
+})
+
+test('只读成员：配置类引导仍显示，重试仍然没有（权限与原因是两回事）', async () => {
+  const { vm, entity } = await loadWith(unavailableEntity('NO_CREDITS'))
+  vm.canWrite = false
+  assert.ok(vm.noteAction(entity))
+  assert.equal(vm.showRetry(entity), false)
+})
+
+test('open-settings 必须在 emits 里声明，否则宿主的 @open-settings 收不到', () => {
+  const { component } = makeVm()
+  assert.ok(component.emits.includes('open-settings'))
+})


### PR DESCRIPTION
## 问题
「依据」面板在法宝/企查查通道未就绪时把 401 Missing Credentials、「余额不足」原文打给律师看，旁边只有一个点了也没用的「重试」。

## 根因
`DocInsightService.callAndStore` / `retrieveCompany` 把 `GatewayException.Kind` 压成一句 `retrievalNote` 散文，`DocInsightEntity` 与 `EntityView` 没有结构化原因字段，面板对四种重试不会变的恒定状态（NOT_CONNECTED / NO_CREDITS / UNAUTHORIZED / NO_CREDENTIAL）只能打印字符串。上游 PkulawChannel 的 javadoc 明确要求保留 Kind，这里是第一处丢掉它的地方。

## 修法
- 新增 `retrieval_hint`（length 32，可空）端到端：Entity → `unavailableGateway`（网关失败落 UNAVAILABLE 的唯一出口）→ EntityView → 前端。
- 配置类三档 note 只写原因、不加「本次不可用」前缀、不拼 userHint；瞬时类照旧前缀 + userHint + 重试。
- InsightPane 按 hint 给按钮：NOT_CONNECTED/UNAUTHORIZED → 「去连接账户」，NO_CREDITS → 「去充值」（emit open-settings，宿主 `openSettingsTab({nav:'account'})`，左栏与右 dock 两处挂载都绑）；NO_CREDENTIAL 只显示「需部署管理员在服务端配置」。官方版不加法宝凭据输入框。
- 顺带修：案号识别命中但全文检索余额不足时，OK 行会挂着 NO_CREDITS（`okRecognitionOnly` 清 hint）。
- 既有断言「note 含充值」有意识改写为 hint=NO_CREDITS；doc-insight.md 地雷 #5 与「其它口径」同步改写。

## 验证
- 后端 RED-A 改前红；`mvn -Dtest='DocInsight*'` 58/0，`'*Insight*,*Pkulaw*,*Mcp*Test,*Gateway*Test'` 110/0；两次病灶还原均转红后复原。
- 前端 test:insight 91/0（7 条改前红）；check:emits / check:locales / check:nav 通过。
- 未做打包态 UI 走查；真实 MySQL 上 ddl-auto 加列未实跑（老行 hint 为 null 即旧行为）。复测提示：打包桌面端不连账户，解析一份带法条的文档，法规行应显示一行原因 + 「去连接账户」且没有「重试」，点击落到设置「账户与用量」。
- 未扩：SERVICE_DISABLED / BAD_REQUEST / BUDGET_EXCEEDED 仍走瞬时档（有「重试」），另议。

dev-board#458

🤖 Generated with [Claude Code](https://claude.com/claude-code)