### PR TITLE
fix(files): 服务层归一并校验父节点 + 启动期对账修存量孤儿行（dev-board#457）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -660,6 +660,23 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
   页面路由埋点在 App.vue onLaunch 的 uni.addInterceptor（唯一收口，别在 50 处调用点逐个埋）；
   面板切换埋点在 panelSwitching.js 的 toggleLeftPane（区分 staging/收展/切换三分支）。
 - sed 子串替换改类名会误伤（king-*→awd-* 迁移教训，PR#171）。
+- **`parent_id` 的 `0` 与 `NULL` 在前后端不是一回事，归一只有服务层一个出处**
+  （dev-board#457）。前端 `utils/fileTreeBuild.js` 的 `normalizeParentId` 把
+  `null/undefined/0` 一律当「根」画；后端的同名查重却是
+  `(:parentId IS NULL AND pf.parentId IS NULL OR pf.parentId = :parentId)`——`0` 与 `NULL`
+  是两个不同的父节点，根下同名的那个不算冲突。Agent 的 `create_folder` 把「放根目录」
+  写成 `parentFolderId=0`（LLM 的惯用写法）就会落一批 `parent_id=0` 的孤儿行：
+  资源管理器顶部看着多出一个「空的」重复文件夹，刷新重启都在（孤儿那条的物理路径在
+  缺失的父节点处断链、正好落回根，目录确实存在，本地对账的删除同步就判它「还在」，
+  永不清理），而没能落到磁盘的那几个孤儿会在几十秒后被同一次对账静默软删除。
+  归一与校验现在只有 `ProjectFileService.resolveParentId` 一处（`createFolder` /
+  `createFile` / `move` 三个入口首行调用，`0`/`null` → 根，其余必须是本项目里一个活着的
+  文件夹）；`ProjectFileController.checkParentFolder` 只是 HTTP 路径上更早的一道，
+  AI 工具、插件宿主、内部落盘服务都不经过它。**新写「读了 parentId 再自己查同级」的
+  代码，先过一遍 `resolveParentId`**（`LitigationVisualTools.createFolderTolerant`
+  就是这么栽的：不归一的话兜底查同级永远查空，本该复用同名文件夹变成硬报错）。
+  存量脏行由启动期对账 `service/maintenance/OrphanParentReconciler` 一次性修复
+  （归位 / 并进根下同名文件夹 / 去掉指向同一份字节的重复行，只动数据库不碰磁盘）。
 - **左栏面板要给 AI 面板发 prompt，一律走 `resolveChatInterface()`**（工作台 methods）。
   它做三件事：`showAiPanel` 为 false 时先走既有的 `toggleAiPanel()`（顺带刷 AI 上下文 +
   拉历史，不能绕过去直接改标志位）→ 有界轮询 ~3s（30×100ms）等 `$refs.chatInterface`

--- a/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
+++ b/backend/src/main/java/com/checkba/repository/ProjectFileRepository.java
@@ -152,5 +152,30 @@ public interface ProjectFileRepository extends JpaRepository<ProjectFile, Long> 
      * fileType 是扩展名，正常值里不可能出现这三个词，所以按它取行既精确又不会误伤。
      */
     List<ProjectFile> findByFileTypeInAndIsFolderFalseAndIsDeletedFalse(List<String> fileTypes);
+
+    /**
+     * 按父节点 ID 取行（含软删除）。给 {@code OrphanParentReconciler} 用：
+     * 取 parent_id=0 的孤儿行（dev-board#457），以及取某个孤儿文件夹下的子项。
+     * 注意与上面那些 {@code (:parentId IS NULL AND ...)} 的查询不同，这里的
+     * parentId 必须是非 null 的具体值。
+     */
+    List<ProjectFile> findByParentId(Long parentId);
+
+    /**
+     * 同一项目内被多条存活文件行共用的物理路径，返回 [projectId, filePath]。
+     *
+     * <p>正常情况下路径由「父链 + 文件名」算出来，不可能撞；撞了就说明某条父链断了
+     * （dev-board#457 的 parent_id=0 孤儿就是这样：路径解析在缺失的父节点处断链、
+     * 落回项目根，与根下那条真行算出同一个路径），两条行从此指向同一份字节，
+     * 改名/删除任何一条都会影响另一条。用聚合查询挑出来，不整表 hydrate。
+     */
+    @org.springframework.data.jpa.repository.Query(
+            "SELECT pf.projectId, pf.filePath FROM ProjectFile pf "
+            + "WHERE pf.isFolder = false AND pf.isDeleted = false AND pf.filePath IS NOT NULL "
+            + "GROUP BY pf.projectId, pf.filePath HAVING COUNT(pf.id) > 1")
+    List<Object[]> findDuplicateLiveFilePaths();
+
+    /** 上一条挑出来的路径对应的那几行（存活的文件行）。 */
+    List<ProjectFile> findByProjectIdAndFilePathAndIsDeletedFalse(Long projectId, String filePath);
 }
 

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -83,6 +83,7 @@ public class ProjectFileService {
         if (projectId == null) {
             throw new IllegalArgumentException(LangText.of("项目 ID 不能为空", "Project ID must not be empty"));
         }
+        parentId = resolveParentId(projectId, parentId);
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException(LangText.of("文件夹名称不能为空", "Folder name must not be empty"));
         }
@@ -112,6 +113,41 @@ public class ProjectFileService {
         ProjectFile savedFolder = projectFileRepository.save(folder);
         signalChange(projectId, userId);
         return savedFolder;
+    }
+
+    /**
+     * 归一并校验父节点 ID：{@code null} 与 {@code 0} 都是「项目根」，其余必须是本项目里
+     * 一个活着的文件夹，否则当场报错。
+     *
+     * <p>为什么必须放在服务层（dev-board#457）：同样的检查此前只长在
+     * {@code ProjectFileController.checkParentFolder} 上，AI 工具、插件宿主、内部落盘服务
+     * 都不经过 HTTP 那一层。Agent 的 {@code create_folder} 把「放根目录」写成
+     * {@code parentFolderId=0}（LLM 的惯用写法），库里并没有 id=0 这一行，于是：
+     * 前端 {@code normalizeParentId} 把 0 当根画出来，看着是一个普通的根文件夹；
+     * 后端的同名查重 {@code (:parentId IS NULL AND pf.parentId IS NULL OR pf.parentId = :parentId)}
+     * 却把 0 与 NULL 当两个不同的父节点，根下同名的那个不算冲突。本地文件夹对账器
+     * 随后按 {@code rowKey("root/名字")} 找不到这条 parent_id=0 的行，就再建一条真正的根行
+     * ——资源管理器顶部于是多出一个重复节点，刷新重启都在（孤儿那条的物理路径在断链处
+     * 落回根目录，目录确实存在，删除同步就判它「还在」，永不清理）。
+     *
+     * <p>0 归一成 null 而不是报错：它表达的意思本来就是「根」，报错只会让模型再猜一轮。
+     * 不存在/别的项目/不是文件夹/已删除的父节点则一律拒绝——那些落库之后都是谁也点不开
+     * 的孤儿行。
+     */
+    public Long resolveParentId(Long projectId, Long parentId) {
+        if (parentId == null || parentId == 0L) {
+            return null;
+        }
+        ProjectFile parent = projectFileRepository.findById(parentId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        LangText.of("目标文件夹不存在或已被删除: ", "Target folder does not exist or has been deleted: ") + parentId));
+        if (!Objects.equals(projectId, parent.getProjectId())
+                || !Boolean.TRUE.equals(parent.getIsFolder())
+                || Boolean.TRUE.equals(parent.getIsDeleted())) {
+            throw new IllegalArgumentException(
+                    LangText.of("目标文件夹不存在或已被删除: ", "Target folder does not exist or has been deleted: ") + parentId);
+        }
+        return parentId;
     }
 
     /**
@@ -231,6 +267,7 @@ public class ProjectFileService {
         if (projectId == null) {
             throw new IllegalArgumentException(LangText.of("项目 ID 不能为空", "Project ID must not be empty"));
         }
+        parentId = resolveParentId(projectId, parentId);
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException(LangText.of("文件名不能为空", "File name must not be empty"));
         }
@@ -640,6 +677,10 @@ public class ProjectFileService {
 
         // 权限检查已移至 Controller 层，这里不再检查创建者身份
 
+        // 目标父节点归一并校验（0/null 都是根）。要取到 file 才知道项目 ID，所以不在方法首行，
+        // 但必须早于下面每一处用到 newParentId 的地方——额度闸、同名查重、落库都读它。
+        newParentId = resolveParentId(file.getProjectId(), newParentId);
+
         // 文件缓存区免费额度：单文件移入同样要过闸。此前额度只挂在 batchMove 上，
         // 而这条路径也能把文件移进 __staging_area__——一次拖一个就能无限塞，
         // 付费闸等于没有。目标不是缓存区时 checkAdmission 直接放行，其它移动不受影响。
@@ -757,6 +798,11 @@ public class ProjectFileService {
             // 防御性校验
             throw new IllegalArgumentException(LangText.of("projectId 不能为空", "projectId must not be empty"));
         }
+        // 复制这条路径自己拼行、不经过 createFolder/createFile，父节点归一得在这里做一次
+        // （dev-board#457）。顺带修掉一个连带问题：targetParentId=0 时下面那句
+        // Objects.equals(source.getParentId(), targetParentId) 对根下的源文件恒为 false，
+        // 「【副本】」前缀不会加，复制出来的就是一个同名行。
+        Long targetParentId = resolveParentId(projectId, request.getTargetParentId());
         List<ProjectFile> createdRoots = new ArrayList<>();
         for (Long id : request.getFileIds()) {
             if (id == null) continue;
@@ -765,7 +811,7 @@ public class ProjectFileService {
             if (!Objects.equals(source.getProjectId(), projectId)) {
                 throw new IllegalArgumentException(LangText.of("跨项目复制不支持", "Cross-project copy is not supported"));
             }
-            createdRoots.add(copyRecursive(projectId, source, request.getTargetParentId(), userId));
+            createdRoots.add(copyRecursive(projectId, source, targetParentId, userId));
         }
         signalChange(projectId, userId);
         return createdRoots;

--- a/backend/src/main/java/com/checkba/service/ai/tools/LitigationVisualTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LitigationVisualTools.java
@@ -444,6 +444,10 @@ public class LitigationVisualTools implements AgentToolComponent {
 
     /** 同名文件夹已存在时复用而不是报错——同一张图重出一版是常态。 */
     ProjectFile createFolderTolerant(Long projectId, Long parentId, String name) {
+        // 先按 createFolder 的口径归一父节点（模型常把「根目录」写成 0，见 dev-board#457）：
+        // 不归一的话，下面那次兜底查同级会拿 parentId=0 去查，永远查空，
+        // 于是「同名已存在」这条本该复用的路径变成硬失败「出图失败」。
+        parentId = projectFileService.resolveParentId(projectId, parentId);
         try {
             return projectFileService.createFolder(projectId, parentId, name, AGENT_USER_ID);
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/checkba/service/maintenance/OrphanParentReconciler.java
+++ b/backend/src/main/java/com/checkba/service/maintenance/OrphanParentReconciler.java
@@ -1,0 +1,207 @@
+package com.checkba.service.maintenance;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 启动期对账：修 {@code project_file.parent_id = 0} 留下的孤儿行与它们催生的重复节点
+ * （dev-board#457）。
+ *
+ * <h3>坏数据是怎么来的</h3>
+ * Agent 的 {@code create_folder} 把「放项目根目录」写成 {@code parentFolderId=0}
+ * （LLM 的惯用写法），而服务层此前不校验父节点，于是落了一批 {@code parent_id=0} 的行——
+ * 库里并没有 id=0 这一行。前端 {@code normalizeParentId} 把 0 当根画出来，看着像普通根文件夹；
+ * 后端的同名查重却把 0 与 NULL 当两个不同的父节点。本地文件夹对账器随后按
+ * {@code rowKey("root/名字")} 找不到这条孤儿行，就再建一条真正的根行——资源管理器顶部
+ * 于是多出一个重复节点，刷新、重启都在。写入侧的闸已经补上
+ * （{@code ProjectFileService.resolveParentId}），但**存量行救不回来**：那批行就躺在
+ * 每一台已经让 Agent 整理过文件的机器上。本仓没有 SQL 迁移框架（ddl-auto: update），
+ * 所以照 {@code MediaFileTypeReconciler} 的成例做成启动期对账。
+ *
+ * <h3>做三件事，都只动数据库、一个字节都不碰磁盘</h3>
+ * <ol>
+ *   <li><b>归位</b>：{@code parent_id=0} 的行，根下没有同名同类的存活行时，直接把
+ *       parent_id 改成 null——它本来要的就是「根」；</li>
+ *   <li><b>并档</b>：根下已经有同名文件夹（那条正是对账器补出来的重复节点）时，
+ *       把孤儿文件夹的子项挂到根文件夹下，子项同名冲突时保留根文件夹里已有的那份、
+ *       软删除孤儿这份，最后软删除空掉的孤儿文件夹；</li>
+ *   <li><b>去重</b>：同一项目内 file_path 相同的多条存活文件行只留 id 最小的一条，
+ *       其余软删除——它们指向同一份字节，留着改名/删除任何一条都会伤到另一条。</li>
+ * </ol>
+ *
+ * <p><b>为什么不用搬文件</b>：孤儿行的物理路径在缺失的父节点处就断链了
+ * （{@code buildPhysicalPath} 查不到 id=0 便 break），算出来的正是「根 / 文件夹名 / 文件名」，
+ * 与并档目标那条根行算出的字符串逐字相同。归位与并档因此都不改变任何一行的 file_path，
+ * 磁盘上的目录与文件原封不动。
+ *
+ * <p><b>回收站里的孤儿只归位不并档</b>：它们已经是删除态，界面上看不见，没有并档的必要；
+ * 但把 0 归成 null 能保证律师从回收站还原它时不会又得到一条谁也点不开的孤儿行。
+ * 根下已有同名存活行时连归位也不做——那属于还原时才该让用户看见的普通重名。
+ *
+ * <p>幂等：跑完一遍之后 parent_id=0 的行与重复路径都不存在了，之后每次启动都是 0 条，
+ * 健康安装里连一条 INFO 都不会打。失败只 warn，不拖垮启动。
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrphanParentReconciler {
+
+    /** 模型/前端表达「项目根」的另一种写法，库里并没有这一行。 */
+    private static final long ORPHAN_PARENT_ID = 0L;
+
+    private final ProjectFileRepository projectFileRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onStartup() {
+        try {
+            reconcile();
+        } catch (RuntimeException e) {
+            // 对账是顺手活，读不到文件表不该拦住启动
+            log.warn("孤儿父节点对账跳过：{}", e.toString());
+        }
+    }
+
+    /** @return 被改写（含软删除）的行数，供测试与日志用 */
+    public int reconcile() {
+        int changed = healOrphanRows() + dedupeByFilePath();
+        if (changed > 0) {
+            log.info("孤儿父节点对账完成：共处理 {} 行", changed);
+        }
+        return changed;
+    }
+
+    // ---- (a)(b) parent_id = 0 的孤儿行 ----
+
+    private int healOrphanRows() {
+        List<ProjectFile> orphans = projectFileRepository.findByParentId(ORPHAN_PARENT_ID);
+        int changed = 0;
+        for (ProjectFile orphan : orphans) {
+            ProjectFile twin = liveRootTwinOf(orphan);
+            if (Boolean.TRUE.equals(orphan.getIsDeleted())) {
+                if (twin == null) {
+                    changed += moveToRoot(orphan, "回收站行");
+                }
+                continue;
+            }
+            if (twin == null) {
+                changed += moveToRoot(orphan, "根下无同名行");
+                continue;
+            }
+            if (Boolean.TRUE.equals(orphan.getIsFolder())) {
+                changed += mergeFolderInto(orphan, twin);
+            } else {
+                // 文件孤儿与根下同名文件指向同一份字节（路径断链后算出的是同一个字符串），
+                // 保留根下那条真行，孤儿这条进回收站；字节不动。
+                changed += softDelete(orphan, "与根下同名文件重复（file_path 相同）");
+            }
+        }
+        return changed;
+    }
+
+    /** 根下同名同类（文件夹对文件夹、文件对文件）的存活行。 */
+    private ProjectFile liveRootTwinOf(ProjectFile orphan) {
+        List<ProjectFile> rootRows =
+                projectFileRepository.findByProjectIdAndParentIdOrderBySortOrderAsc(orphan.getProjectId(), null);
+        for (ProjectFile r : rootRows) {
+            if (!r.getId().equals(orphan.getId())
+                    && r.getName() != null && r.getName().equals(orphan.getName())
+                    && Boolean.TRUE.equals(r.getIsFolder()) == Boolean.TRUE.equals(orphan.getIsFolder())) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    private int moveToRoot(ProjectFile orphan, String why) {
+        orphan.setParentId(null);
+        orphan.setUpdatedAt(LocalDateTime.now());
+        projectFileRepository.save(orphan);
+        log.info("孤儿父节点对账：{} {}（{}）parent_id 0 → null（{}）",
+                Boolean.TRUE.equals(orphan.getIsFolder()) ? "文件夹" : "文件",
+                orphan.getId(), orphan.getName(), why);
+        return 1;
+    }
+
+    /**
+     * 把孤儿文件夹并进根下那个同名文件夹：子项改挂过去（同名的让位给已有那份），
+     * 然后软删除空掉的孤儿。两个文件夹同名，物理路径不变，不搬任何文件。
+     */
+    private int mergeFolderInto(ProjectFile orphan, ProjectFile target) {
+        int changed = 0;
+        // 复制一份：下面 add 进来的是「刚改挂过去的子项」，要参与后续同名判断
+        List<ProjectFile> targetChildren = new ArrayList<>(
+                projectFileRepository.findByProjectIdAndParentIdOrderBySortOrderAsc(target.getProjectId(), target.getId()));
+        for (ProjectFile child : projectFileRepository.findByParentId(orphan.getId())) {
+            if (Boolean.TRUE.equals(child.getIsDeleted())) continue;
+            boolean taken = targetChildren.stream().anyMatch(
+                    t -> t.getName() != null && t.getName().equals(child.getName()));
+            if (taken) {
+                changed += softDeleteRecursively(child, "并档时与目标文件夹里已有的同名项重复");
+            } else {
+                child.setParentId(target.getId());
+                child.setUpdatedAt(LocalDateTime.now());
+                projectFileRepository.save(child);
+                targetChildren.add(child);
+                changed++;
+                log.info("孤儿父节点对账：{}（{}）从孤儿文件夹 {} 改挂到根下同名文件夹 {}",
+                        Boolean.TRUE.equals(child.getIsFolder()) ? "文件夹" : "文件",
+                        child.getId(), orphan.getId(), target.getId());
+            }
+        }
+        changed += softDelete(orphan, "已并入根下同名文件夹 " + target.getId());
+        return changed;
+    }
+
+    // ---- (c) 同一项目内重复的 file_path ----
+
+    private int dedupeByFilePath() {
+        int changed = 0;
+        for (Object[] row : projectFileRepository.findDuplicateLiveFilePaths()) {
+            Long projectId = (Long) row[0];
+            String filePath = (String) row[1];
+            List<ProjectFile> rows = new ArrayList<>(
+                    projectFileRepository.findByProjectIdAndFilePathAndIsDeletedFalse(projectId, filePath));
+            rows.removeIf(f -> Boolean.TRUE.equals(f.getIsFolder()));
+            rows.sort(Comparator.comparing(ProjectFile::getId));
+            for (int i = 1; i < rows.size(); i++) {
+                changed += softDelete(rows.get(i),
+                        "与文件行 " + rows.get(0).getId() + " 指向同一份字节 " + filePath);
+            }
+        }
+        return changed;
+    }
+
+    // ---- 软删除（只翻标志位，磁盘文件保留，用户可从回收站还原）----
+
+    private int softDelete(ProjectFile row, String why) {
+        if (Boolean.TRUE.equals(row.getIsDeleted())) return 0;
+        row.setIsDeleted(true);
+        row.setDeletedAt(LocalDateTime.now());
+        row.setUpdatedAt(LocalDateTime.now());
+        projectFileRepository.save(row);
+        log.info("孤儿父节点对账：{}（{}）移入回收站（{}）；磁盘文件保留",
+                Boolean.TRUE.equals(row.getIsFolder()) ? "文件夹" : "文件", row.getId(), why);
+        return 1;
+    }
+
+    /** 文件夹连同其下存活的子孙一起软删除，避免又造出一批父节点已删的孤儿。 */
+    private int softDeleteRecursively(ProjectFile row, String why) {
+        int changed = softDelete(row, why);
+        if (!Boolean.TRUE.equals(row.getIsFolder())) return changed;
+        for (ProjectFile child : projectFileRepository.findByParentId(row.getId())) {
+            if (Boolean.TRUE.equals(child.getIsDeleted())) continue;
+            changed += softDeleteRecursively(child, "父文件夹 " + row.getId() + " 已随并档移入回收站");
+        }
+        return changed;
+    }
+}

--- a/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/LocalProjectServiceTest.java
@@ -377,6 +377,32 @@ class LocalProjectServiceTest {
         }
     }
 
+    /**
+     * dev-board#457：Agent 的 create_folder 把「放项目根目录」写成 parentFolderId=0，
+     * 库里没有 id=0 这一行。前端 normalizeParentId 把 0 当根画出来，后端的查重却把
+     * 0 当成另一个父节点——文件一落进磁盘上那个目录，对账按 rowKey("root/名字") 找不到
+     * 这条 parent_id=0 的行，就再建一条真正的根行，资源管理器顶部于是多出一个重复节点，
+     * 刷新/重启都在（孤儿那条的物理路径解析在缺失的父节点处断链，正好落回根，
+     * 目录存在 → 删除同步判它「还在」→ 永不清理）。
+     */
+    @Test
+    void zeroParentFolderDoesNotSpawnDuplicateRootRow(@TempDir Path folder) throws Exception {
+        Long projectId = svc.openLocalFolder(folder.toString(), false, null, null, 1L).project().getId();
+
+        projectFileService.createFolder(projectId, 0L, "01-主体资格与章程", 1L);
+        Files.createDirectories(folder.resolve("01-主体资格与章程"));
+        Files.writeString(folder.resolve("01-主体资格与章程/公司章程.docx"), "x");
+
+        svc.reconcileProject(projectId);
+
+        List<ProjectFile> live = projectFileRepository.findByProjectId(projectId).stream()
+                .filter(f -> !Boolean.TRUE.equals(f.getIsDeleted()))
+                .filter(f -> "01-主体资格与章程".equals(f.getName()))
+                .toList();
+        assertEquals(1, live.size(), "同一个文件夹在资源管理器里只能有一个节点: " + live);
+        assertNull(live.get(0).getParentId(), "它就该是一条普通的根行，parent_id 必须是 null");
+    }
+
     @Test
     void rejectsRelativeAndRootPaths() {
         assertThrows(IllegalArgumentException.class, () -> svc.openLocalFolder("relative/path", false, null, null, 1L));

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceArchiveTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceArchiveTest.java
@@ -19,6 +19,7 @@ import org.springframework.core.io.ByteArrayResource;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,6 +57,13 @@ class ProjectFileServiceArchiveTest {
 
     private static final long ARCHIVE_ID = 10L;
     private static final long PROJECT_ID = 1L;
+
+    /**
+     * 假的「库里现有的行」。解压建出来的文件夹要能被 findById 查到——
+     * 真库里 save 完当然查得到，父节点校验（ProjectFileService.resolveParentId，
+     * dev-board#457）与 buildPhysicalPath 都要走这一步。
+     */
+    private final Map<Long, ProjectFile> rows = new HashMap<>();
 
     // ---- fixtures -----------------------------------------------------------
 
@@ -125,7 +133,9 @@ class ProjectFileServiceArchiveTest {
         pf.setFileType(type);
         pf.setFileSize((long) bytes.length);
         pf.setFilePath("projects/1/" + name);
-        when(projectFileRepository.findById(ARCHIVE_ID)).thenReturn(Optional.of(pf));
+        rows.put(ARCHIVE_ID, pf);
+        when(projectFileRepository.findById(anyLong()))
+                .thenAnswer(inv -> Optional.ofNullable(rows.get(inv.<Long>getArgument(0))));
         when(storageServiceFactory.getStorageService()).thenReturn(storageService);
         try {
             when(storageService.load("projects/1/" + name)).thenReturn(new ByteArrayResource(bytes));
@@ -212,6 +222,7 @@ class ProjectFileServiceArchiveTest {
             ProjectFile f = inv.getArgument(0);
             if (f.getId() == null) f.setId(ids.incrementAndGet());
             saved.add(f);
+            rows.put(f.getId(), f);
             return f;
         });
         // createFile 里的 load（模板物化）与解压时的 save 都打到 mock 上
@@ -260,6 +271,7 @@ class ProjectFileServiceArchiveTest {
             ProjectFile f = inv.getArgument(0);
             if (f.getId() == null) f.setId(ids.incrementAndGet());
             saved.add(f);
+            rows.put(f.getId(), f);
             return f;
         });
         lenient().when(storageService.save(any(), any(java.io.InputStream.class))).thenAnswer(inv -> inv.getArgument(0));

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceCreateConflictTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceCreateConflictTest.java
@@ -4,6 +4,7 @@ import com.checkba.model.entity.ProjectFile;
 import com.checkba.repository.ProjectFileRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -11,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -41,6 +43,9 @@ class ProjectFileServiceCreateConflictTest {
     private com.checkba.storage.StorageServiceFactory storageServiceFactory;
     @Mock
     private com.checkba.service.telemetry.TelemetryService telemetryService;
+    /** move 会先过缓存区额度闸，不给这个 mock 就是一个与本类无关的 NPE。 */
+    @Mock
+    private com.checkba.service.quota.StageQuotaService stageQuotaService;
 
     @Mock
     private com.checkba.storage.StorageService storageService;
@@ -54,6 +59,20 @@ class ProjectFileServiceCreateConflictTest {
     @org.junit.jupiter.api.BeforeEach
     void wireStorage() {
         when(storageServiceFactory.getStorageService()).thenReturn(storageService);
+    }
+
+    /**
+     * 父文件夹必须是本项目里一个活着的文件夹（dev-board#457 起由 resolveParentId 校验），
+     * 所以 mock 库里得真有 PARENT_ID 这一行——顺带它也是 buildPhysicalPath 的一级路径段。
+     */
+    @org.junit.jupiter.api.BeforeEach
+    void wireParentFolder() {
+        ProjectFile parent = new ProjectFile();
+        parent.setId(PARENT_ID);
+        parent.setProjectId(PROJECT_ID);
+        parent.setIsFolder(true);
+        parent.setName("sub");
+        when(projectFileRepository.findById(PARENT_ID)).thenReturn(java.util.Optional.of(parent));
     }
 
     /** 模拟数据库里（含回收站，不过滤 isDeleted）是否有同名行——RENAME 策略走的查询。 */
@@ -147,10 +166,10 @@ class ProjectFileServiceCreateConflictTest {
         dbHas("a.pdf", false);
         dbHas("a (1).pdf", false);
         dbHas("a (2).pdf", false);
-        // buildPhysicalPath 在 mock 仓库下（父目录查不到）得到 projects/1/<name>
-        when(storageService.exists("projects/1/a.pdf")).thenReturn(true);
-        when(storageService.exists("projects/1/a (1).pdf")).thenReturn(true);
-        when(storageService.exists("projects/1/a (2).pdf")).thenReturn(false);
+        // buildPhysicalPath 走父文件夹链，PARENT_ID 那一行叫 sub
+        when(storageService.exists("projects/1/sub/a.pdf")).thenReturn(true);
+        when(storageService.exists("projects/1/sub/a (1).pdf")).thenReturn(true);
+        when(storageService.exists("projects/1/sub/a (2).pdf")).thenReturn(false);
         when(projectFileRepository.maxSortOrder(PROJECT_ID, PARENT_ID)).thenReturn(null);
         when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -158,9 +177,9 @@ class ProjectFileServiceCreateConflictTest {
                 ProjectFileService.ConflictPolicy.RENAME);
 
         assertEquals("a (2).pdf", saved.getName());
-        assertEquals("projects/1/a (2).pdf", saved.getFilePath());
-        verify(storageService).exists("projects/1/a.pdf");
-        verify(storageService).exists("projects/1/a (1).pdf");
+        assertEquals("projects/1/sub/a (2).pdf", saved.getFilePath());
+        verify(storageService).exists("projects/1/sub/a.pdf");
+        verify(storageService).exists("projects/1/sub/a (1).pdf");
     }
 
     @Test
@@ -175,5 +194,103 @@ class ProjectFileServiceCreateConflictTest {
         assertEquals(8, folder.getSortOrder());
         verify(projectFileRepository).maxSortOrder(PROJECT_ID, null);
         verify(projectFileRepository, never()).findByProjectIdAndParentIdOrderBySortOrderAsc(anyLong(), any());
+    }
+
+    // ---- 父节点归一与校验（dev-board#457）----
+
+    /** 模型把「放根目录」写成 parentFolderId=0；库里没有 id=0 这一行，落库的 parent_id 必须是 null。 */
+    @Test
+    void createFolderTreatsZeroParentAsRoot() {
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                eq(PROJECT_ID), isNull(), eq("01-主体资格与章程"), eq(-1L))).thenReturn(false);
+        when(projectFileRepository.maxSortOrder(PROJECT_ID, null)).thenReturn(null);
+        when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        projectFileService.createFolder(PROJECT_ID, 0L, "01-主体资格与章程", 2L);
+
+        ArgumentCaptor<ProjectFile> saved = ArgumentCaptor.forClass(ProjectFile.class);
+        verify(projectFileRepository).save(saved.capture());
+        assertNull(saved.getValue().getParentId(),
+                "parent_id=0 会被前端画在根、被后端当成另一个父节点，落库前必须归一成 null");
+        verify(projectFileRepository).existsByProjectIdAndParentIdAndNameAndIdNot(PROJECT_ID, null, "01-主体资格与章程", -1L);
+        verify(projectFileRepository, never()).findById(0L);
+    }
+
+    /** 归一之后，根下已有的同名文件夹才算得上冲突——这正是 #457 里第二个节点没被拦住的地方。 */
+    @Test
+    void createFolderWithZeroParentConflictsWithRootFolderOfSameName() {
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                eq(PROJECT_ID), isNull(), eq("01-主体资格与章程"), eq(-1L))).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.createFolder(PROJECT_ID, 0L, "01-主体资格与章程", 2L));
+        verify(projectFileRepository, never()).save(any(ProjectFile.class));
+    }
+
+    /** 不存在的父节点必须当场报错，而不是落一条谁也点不开的孤儿行。 */
+    @Test
+    void createFolderRejectsMissingParent() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.createFolder(PROJECT_ID, 404L, "新文件夹", 2L));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("目标文件夹"));
+        verify(projectFileRepository, never()).save(any(ProjectFile.class));
+    }
+
+    /** 别的项目的文件夹同样不是合法父节点（越权写入的另一张面孔）。 */
+    @Test
+    void createFolderRejectsParentFromAnotherProject() {
+        ProjectFile foreign = new ProjectFile();
+        foreign.setId(77L);
+        foreign.setProjectId(999L);
+        foreign.setIsFolder(true);
+        foreign.setName("别人的文件夹");
+        when(projectFileRepository.findById(77L)).thenReturn(java.util.Optional.of(foreign));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.createFolder(PROJECT_ID, 77L, "新文件夹", 2L));
+        verify(projectFileRepository, never()).save(any(ProjectFile.class));
+    }
+
+    /** write_docx / registerArtifact 也会把模型给的 parentFolderId 直通到 createFile，同一个洞。 */
+    @Test
+    void createFileTreatsZeroParentAsRoot() {
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                eq(PROJECT_ID), isNull(), eq("报告.docx"), eq(-1L))).thenReturn(false);
+        when(projectFileRepository.maxSortOrder(PROJECT_ID, null)).thenReturn(null);
+        when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ProjectFile saved = projectFileService.createFile(
+                PROJECT_ID, 0L, "报告.docx", "docx", 10L, null, null, 1L);
+
+        assertNull(saved.getParentId());
+        assertEquals("projects/1/报告.docx", saved.getFilePath());
+        verify(projectFileRepository, never()).findById(0L);
+    }
+
+    @Test
+    void createFileRejectsMissingParent() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> projectFileService.createFile(PROJECT_ID, 404L, "报告.docx", "docx", 10L, null, null, 1L));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("目标文件夹"));
+        verify(projectFileRepository, never()).save(any(ProjectFile.class));
+    }
+
+    /** 移动的目标父节点同样要过这道闸（拖拽、插件 SDK 的 move 都落在这里）。 */
+    @Test
+    void moveTreatsZeroParentAsRootAndRejectsMissingParent() {
+        ProjectFile folder = new ProjectFile();
+        folder.setId(30L);
+        folder.setProjectId(PROJECT_ID);
+        folder.setIsFolder(true);
+        folder.setName("卷宗");
+        when(projectFileRepository.findById(30L)).thenReturn(java.util.Optional.of(folder));
+        when(projectFileRepository.existsByProjectIdAndParentIdAndNameAndIdNot(
+                eq(PROJECT_ID), isNull(), eq("卷宗"), eq(30L))).thenReturn(false);
+        when(projectFileRepository.save(any(ProjectFile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ProjectFile moved = projectFileService.move(30L, 0L, null, 1L);
+        assertNull(moved.getParentId(), "移到 parent 0 就是移到根，不能留一个悬空父节点");
+
+        assertThrows(IllegalArgumentException.class, () -> projectFileService.move(30L, 404L, null, 1L));
     }
 }

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceEnsureFolderPathTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceEnsureFolderPathTest.java
@@ -58,6 +58,8 @@ class ProjectFileServiceEnsureFolderPathTest {
     void reusesExistingAndCreatesMissing() {
         ProjectFile a = node(10L, null, "a", true);
         when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(1L, null, "a")).thenReturn(Optional.of(a));
+        // 父节点校验（resolveParentId，dev-board#457）会 findById 确认 a 真的是本项目的活文件夹
+        when(repo.findById(10L)).thenReturn(Optional.of(a));
         when(repo.findByProjectIdAndParentIdAndNameAndIsDeletedFalse(1L, 10L, "b")).thenReturn(Optional.empty());
         when(repo.maxSortOrder(anyLong(), any())).thenReturn(null);
         when(repo.save(any(ProjectFile.class))).thenAnswer(inv -> {

--- a/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectFileServiceIdorTest.java
@@ -76,6 +76,13 @@ class ProjectFileServiceIdorTest {
         own.setIsFolder(false);
         own.setName("a.docx");
         when(projectFileRepository.findById(42L)).thenReturn(Optional.of(own));
+        // 目标缓存区文件夹得真在库里——移动前先过父节点校验（resolveParentId，dev-board#457）
+        ProjectFile staging = new ProjectFile();
+        staging.setId(9L);
+        staging.setProjectId(1L);
+        staging.setIsFolder(true);
+        staging.setName("__staging_area__");
+        when(projectFileRepository.findById(9L)).thenReturn(Optional.of(staging));
         doThrow(new com.checkba.exception.StageQuotaExceededException("超额", 20, 0, 20, 1L))
                 .when(stageQuotaService).checkAdmission(eq(9L), anyList());
 

--- a/backend/src/test/java/com/checkba/service/maintenance/OrphanParentReconcilerTest.java
+++ b/backend/src/test/java/com/checkba/service/maintenance/OrphanParentReconcilerTest.java
@@ -1,0 +1,179 @@
+package com.checkba.service.maintenance;
+
+import com.checkba.model.entity.ProjectFile;
+import com.checkba.repository.ProjectFileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 存量 parent_id=0 孤儿行的一次性修复口径（dev-board#457，H2 真库——重复 file_path
+ * 那条是 GROUP BY ... HAVING 聚合查询，mock 不出真实语义）。
+ *
+ * <p>这几条断言就是「这段会在每一台存量机器上自动跑一次的代码到底动了谁」的定义。
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:orphan-parent-test;MODE=PostgreSQL;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class OrphanParentReconcilerTest {
+
+    private static final long PROJECT_ID = 235L;
+
+    @Autowired private ProjectFileRepository repo;
+
+    private OrphanParentReconciler reconciler;
+
+    @BeforeEach
+    void setUp() {
+        repo.deleteAll();
+        reconciler = new OrphanParentReconciler(repo);
+    }
+
+    private ProjectFile row(Long parentId, boolean folder, String name, String path) {
+        ProjectFile f = new ProjectFile();
+        f.setProjectId(PROJECT_ID);
+        f.setParentId(parentId);
+        f.setIsFolder(folder);
+        f.setName(name);
+        f.setFilePath(path);
+        f.setSortOrder(0);
+        f.setUserId(1L);
+        f.setIsDeleted(false);
+        f.setCreatedAt(LocalDateTime.now());
+        f.setUpdatedAt(LocalDateTime.now());
+        return repo.save(f);
+    }
+
+    private ProjectFile reload(ProjectFile f) {
+        return repo.findById(f.getId()).orElseThrow();
+    }
+
+    private boolean deleted(ProjectFile f) {
+        return Boolean.TRUE.equals(reload(f).getIsDeleted());
+    }
+
+    /** 快照：用来断言「再跑一遍什么都不变」。 */
+    private String snapshot() {
+        return repo.findByProjectId(PROJECT_ID).stream()
+                .sorted((a, b) -> Long.compare(a.getId(), b.getId()))
+                .map(f -> f.getId() + ":" + f.getParentId() + ":" + f.getName() + ":" + Boolean.TRUE.equals(f.getIsDeleted()))
+                .collect(Collectors.joining("|"));
+    }
+
+    /** (a) 根下没有同名行时，孤儿就是一条本该待在根上的普通行——归位即可。 */
+    @Test
+    void orphanWithoutRootTwinIsMovedToRoot() {
+        ProjectFile orphan = row(0L, true, "05-劳动人事", null);
+
+        assertEquals(1, reconciler.reconcile());
+
+        assertNull(reload(orphan).getParentId());
+        assertFalse(deleted(orphan), "归位不等于删除，行还在，磁盘目录也在");
+    }
+
+    /**
+     * (b) 事故现场的形状：孤儿文件夹 + 对账器补出来的根下同名文件夹，两边各有一份
+     * 公司章程.docx（file_path 逐字相同）。并档之后资源管理器里只剩一个节点。
+     */
+    @Test
+    void orphanFolderIsMergedIntoRootTwinAndChildrenFollow() {
+        String base = "projects/" + PROJECT_ID + "/01-主体资格与章程/";
+        ProjectFile orphan = row(0L, true, "01-主体资格与章程", null);
+        ProjectFile orphanCharter = row(orphan.getId(), false, "公司章程.docx", base + "公司章程.docx");
+        ProjectFile orphanOnly = row(orphan.getId(), false, "营业执照.pdf", base + "营业执照.pdf");
+        ProjectFile rootTwin = row(null, true, "01-主体资格与章程", null);
+        ProjectFile twinCharter = row(rootTwin.getId(), false, "公司章程.docx", base + "公司章程.docx");
+
+        reconciler.reconcile();
+
+        List<ProjectFile> liveNamed = repo.findByProjectId(PROJECT_ID).stream()
+                .filter(f -> !Boolean.TRUE.equals(f.getIsDeleted()))
+                .filter(f -> "01-主体资格与章程".equals(f.getName()))
+                .toList();
+        assertEquals(1, liveNamed.size(), "资源管理器里只能剩一个节点: " + liveNamed);
+        assertEquals(rootTwin.getId(), liveNamed.get(0).getId(), "留下的应是根下那条真行");
+
+        assertTrue(deleted(orphan), "空掉的孤儿文件夹进回收站");
+        assertTrue(deleted(orphanCharter), "同名子项让位给目标文件夹里已有的那份");
+        assertFalse(deleted(twinCharter), "目标文件夹里已有的那份不动");
+        assertEquals(rootTwin.getId(), reload(orphanOnly).getParentId(), "不冲突的子项改挂到根下同名文件夹");
+        assertFalse(deleted(orphanOnly));
+        assertEquals(base + "营业执照.pdf", reload(orphanOnly).getFilePath(),
+                "两个文件夹同名，物理路径不变——对账一个字节都不搬");
+    }
+
+    /** (c) 同一项目内指向同一份字节的多条存活文件行，只留 id 最小的一条。 */
+    @Test
+    void duplicateFilePathKeepsTheOldestRow() {
+        String path = "projects/" + PROJECT_ID + "/合同.docx";
+        ProjectFile first = row(null, false, "合同.docx", path);
+        ProjectFile second = row(null, false, "合同.docx", path);
+        ProjectFile other = row(null, false, "备忘录.docx", "projects/" + PROJECT_ID + "/备忘录.docx");
+
+        assertEquals(1, reconciler.reconcile());
+
+        assertFalse(deleted(first));
+        assertTrue(deleted(second));
+        assertFalse(deleted(other), "路径不重复的行一律不碰");
+    }
+
+    /**
+     * 回收站里的孤儿：只把 0 归成 null（还原时不会又得到一条孤儿行），
+     * 根下已有同名存活行时连归位也不做，更不会被"复活"。
+     */
+    @Test
+    void deletedOrphansAreNormalizedButNeverResurrected() {
+        ProjectFile lonely = row(0L, true, "07-诉讼与合规", null);
+        lonely.setIsDeleted(true);
+        lonely.setDeletedAt(LocalDateTime.now());
+        repo.save(lonely);
+
+        ProjectFile shadowed = row(0L, true, "02-股权与出资", null);
+        shadowed.setIsDeleted(true);
+        shadowed.setDeletedAt(LocalDateTime.now());
+        repo.save(shadowed);
+        row(null, true, "02-股权与出资", null);
+
+        reconciler.reconcile();
+
+        assertNull(reload(lonely).getParentId());
+        assertTrue(deleted(lonely), "归位不得把回收站里的行变回存活");
+        assertEquals(0L, reload(shadowed).getParentId(), "根下已有同名存活行时不动它");
+        assertTrue(deleted(shadowed));
+    }
+
+    /** 健康安装零改动；跑两遍结果一致（幂等）。 */
+    @Test
+    void isIdempotentAndNoOpOnHealthyData() {
+        row(null, true, "01-主体资格与章程", null);
+        row(null, false, "合同.docx", "projects/" + PROJECT_ID + "/合同.docx");
+        assertEquals(0, reconciler.reconcile(), "健康安装一行不动");
+
+        ProjectFile orphan = row(0L, true, "05-劳动人事", null);
+        assertTrue(reconciler.reconcile() > 0);
+        String after = snapshot();
+
+        assertEquals(0, reconciler.reconcile(), "第二遍应无事可做");
+        assertEquals(after, snapshot(), "跑两遍结果必须一致");
+        assertNull(reload(orphan).getParentId());
+    }
+}


### PR DESCRIPTION
## 问题
Agent 整理文件后资源管理器顶部多出一个空的重复「01-主体资格与章程」节点，磁盘只有一个，刷新重启仍在。

## 根因
`FileTools.create_folder` 把模型给的 `parentFolderId=0`（LLM 表达「根目录」的惯用写法）直接传给 `ProjectFileService.createFolder`，服务层不校验父节点（存在性检查只长在 HTTP 控制器上，工具路径绕过）。前端 `normalizeParentId` 把 0 当根渲染；后端同名查重 `(:parentId IS NULL AND pf.parentId IS NULL OR pf.parentId = :parentId)` 把 0 与 NULL 当两个父节点；本地对账器按 `rowKey(null, name)` 找不到孤儿行，再建一条真根行 → 重复节点。孤儿的物理路径在断链处落回根、目录确实存在，删除同步永远判它「还在」。`createFile` 有同款漏洞（write_docx / 模板工具 / 出图归档都会带模型给的 parentId）。

## 修法
- `ProjectFileService.resolveParentId(projectId, parentId)`：null/0 → null；否则必须存在、同项目、是文件夹、未删除，否则 IllegalArgumentException（LangText 双语）。在 createFolder / createFile / move / batchCopy 入口调用（batchCopy 顺带修 targetParentId=0 时「【副本】」前缀不加的连带问题）。
- `LitigationVisualTools.createFolderTolerant` 先归一，否则同名兜底查同级会拿 0 去查永远查空、变成硬失败。
- 新增 `OrphanParentReconciler`（ApplicationReadyEvent，照 MediaFileTypeReconciler 形制）：parent_id=0 且根下无同名 → 归位；根下已有同名文件夹 → 子项改挂（同名让位）后软删空孤儿；同项目内相同 file_path 的存活文件行只留 id 最小一条。只动库不动字节，幂等，异常只 warn。回收站里的孤儿只归位不并档、不复活。
- ARG_ALIASES（name/parentId）已在 #466 的 PR 里补。

## 验证
- ProjectFileServiceCreateConflictTest 7 新用例改前红；LocalProjectServiceTest.zeroParentFolderDoesNotSpawnDuplicateRootRow 复现 tester 库里 2256/2264 那两行改前红；OrphanParentReconcilerTest（H2 真库）5 用例，病灶还原 5 红后复原。
- `mvn -Dtest='ProjectFileService*,LocalProjectService*,*Reconciler*,LitigationVisual*'` 99/0；后端全量 3225/0/14 skip。
- 行为变更：往不存在/已删/别项目/是文件的父节点写，以前静默落孤儿行，现在抛异常；全量测试无依赖旧行为。
- 复测提示：升级后**重启桌面端**（对账器启动期跑一遍）再看资源管理器，重复节点应消失、02-08 子文件夹回到正确位置；再让 Agent 整理一次不应再出现。

dev-board#457

🤖 Generated with [Claude Code](https://claude.com/claude-code)