### PR TITLE
chore(release): 版本号 0.35.0（dev-board#473）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
## 版本
0.34.0 → 0.35.0。`desktop/main/main.js` 自 v0.34.0 有改动（#459 建窗尺寸夹工作区），patch-gate 不许走小版本；`**/pom.xml` 无改动。

## 本版内容（自 v0.34.0）
09-05 真机 bug 清单的 13 条修复：#455 #456 #457 #458 #459 #460 #462 #463 #464 #465 #466 #467（桌面端）。

## 发版步骤
合并后打 tag v0.35.0 → desktop-build（mac 境内主体签名公证 + win）→ 镜像同步 → 云后台两台 + 案件库实例重铺 jar（backend/ 非空）。Office/WPS 插件 office-addin/ 与 NSIS 引擎无改动不发。

dev-board#473

🤖 Generated with [Claude Code](https://claude.com/claude-code)