### PR TITLE
fix(ocr): 截图框选选区改回半透明、提示条贴底居中（dev-board#474）

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -105,6 +105,7 @@ IP 拦回环/内网，而 app-e2e 要用本机起的两页小站验这条链路�
 local-mode 下本机后端把每个请求都当本机用户，等于把本机管理端口暴露给被访问的网页。
 
 **截图**：入口 `checkbaDesktop.ocr.captureScreen`；desktop main.js 透明覆盖框选窗 ~:389-571（BrowserView 模式仅限其区域内框选 ~:426）、capturePage 抓取 ~:577/:585/:709、IPC：ocr-capture-screen/desktop/window/view + ocr-start-selection。**推荐链路是 ocr-capture-view（当前 BrowserView，免 macOS 录屏权限）**；无独立后端端点，产物统一走 OCR。
+  渲染层浮层（project-overview.vue `.ocr-overlay`，样式在 project-overview.scss）的底图是一张冻结帧截图，叠在上面的 `.ocr-selection` / 提示条**必须用半透明字面量**，不能引用 `--awd-*-soft` 这类主题令牌（浅色下是不透明色，PR#657 令牌化曾把选区变成一整块 #EFF6FF，框住的内容全没了，dev-board#474）；提示条贴底居中，别钉左上角压交通灯与项目名。契约测试 `npm run test:ocr-overlay`。
 
 **剪贴板**：`ClipboardPanel.vue`；desktop main.js 轮询监听 clipboardWatchTimer ~:117-232（指纹去重 ~:110，首 tick 只记指纹）、推送 `checkba:clipboard-copied`；后端 `controller/ClipboardController.java`（/api/clipboard：GET /、POST /text、POST /file、GET /{id}/file、DELETE /{id}）。
   **采集链路的登录态红线（dev-board#455）**：**桌面免登（PR-A 去登录）后 `checkba_user`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Clipboard capture gate + delete chain (dev-board#455)
         working-directory: frontend
         run: npm run test:clipboard
+      - name: OCR overlay style contract (dev-board#474)
+        working-directory: frontend
+        run: npm run test:ocr-overlay
       - name: Build H5
         working-directory: frontend
         run: npm run build:h5

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,8 @@
     "test:insight": "node --test tests/insight/*.test.mjs",
     "test:clipboard": "node --test tests/clipboard/*.test.mjs",
     "test:revision-view": "node --test tests/revision-view/*.test.mjs",
-    "test:md-table": "node --test tests/markdown-table/*.test.mjs"
+    "test:md-table": "node --test tests/markdown-table/*.test.mjs",
+    "test:ocr-overlay": "node --test tests/ocr-overlay/*.test.mjs"
   },
   "dependencies": {
     "@codemirror/commands": "^6.11.0",

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -3063,15 +3063,19 @@ $color-accent: #5BD197; // Mint Green
 .ocr-selection {
   position: fixed;
   border: 2px solid var(--awd-info);
-  background: var(--awd-info-soft);
+  /* 选区叠在冻结帧上，必须半透明；--awd-info-soft 浅色下是不透明 #EFF6FF，会把框住的内容整块盖掉（dev-board#474） */
+  background: rgba(37, 99, 235, 0.12);
   border-radius: 6px;
   pointer-events: none;
 }
 
 .ocr-overlay-hintline {
   position: fixed;
-  left: 14px;
-  top: 14px;
+  /* 贴底居中：左上角是交通灯与项目标题，提示条压上去像界面坏了（dev-board#474） */
+  left: 50%;
+  bottom: 40px;
+  transform: translateX(-50%);
+  white-space: nowrap;
   padding: 6px 10px;
   background: var(--awd-surface);
   border: 1px solid var(--awd-border);

--- a/frontend/tests/ocr-overlay/ocr-overlay-style.test.mjs
+++ b/frontend/tests/ocr-overlay/ocr-overlay-style.test.mjs
@@ -1,0 +1,36 @@
+// 截图框选浮层的样式契约（dev-board#474）。
+// 浮层的底图是一张冻结帧截图，框选矩形与提示条都叠在它上面：
+//  (a) 选区背景必须半透明——PR#657 令牌化时换成 var(--awd-info-soft)，浅色主题下
+//      该令牌是不透明 #EFF6FF，用户框住的内容整块被盖掉，只剩一片浅蓝；
+//  (b) 提示条不能钉在左上角——那里是交通灯与项目标题，压上去像是界面坏了。
+// 样式在 .scss 里，组件无法真渲染（本仓 node:test 一贯限制），按源码文本断言。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const scss = readFileSync(new URL('../../src/pages/project-overview/project-overview.scss', import.meta.url), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '')
+
+const block = (selector) => {
+  const start = scss.indexOf(`\n${selector} {`)
+  assert.ok(start >= 0, `找不到 ${selector} 规则`)
+  const end = scss.indexOf('\n}', start)
+  return scss.slice(start, end)
+}
+
+test('.ocr-selection 背景是半透明字面量，不引用可能不透明的主题令牌', () => {
+  const b = block('.ocr-selection')
+  assert.doesNotMatch(b, /--awd-info-soft/, '浅色主题下 --awd-info-soft 是不透明的 #EFF6FF，会盖住冻结帧')
+  const m = b.match(/background:\s*rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*(0?\.\d+)\s*\)/)
+  assert.ok(m, '选区背景必须写成 rgba(r,g,b,a) 字面量')
+  assert.ok(Number(m[1]) <= 0.3, `选区背景 alpha 必须 <= 0.3，实际 ${m[1]}`)
+})
+
+test('.ocr-overlay-hintline 提示条离开窗口标题区（不再 left:14px/top:14px 压交通灯与项目名）', () => {
+  const b = block('.ocr-overlay-hintline')
+  assert.doesNotMatch(b, /\btop:\s*14px/, '提示条不能贴在窗口顶部标题区')
+  assert.match(b, /\bbottom:\s*\d+px/, '提示条应贴在底部')
+  assert.match(b, /left:\s*50%/, '提示条应水平居中')
+  assert.match(b, /translateX\(-50%\)/, '提示条应水平居中')
+})


### PR DESCRIPTION
## 现象
v0.35.0 开截图、框选中间文字后：框选范围内的内容整块消失只剩浅蓝；左上角「拖动框选 · 单击/ESC 退出」提示条压在交通灯与项目标题上。

## 根因
- PR #657（深色模式收口）把 `project-overview.scss` 的 `.ocr-selection` 背景从 `rgba(37,99,235,0.12)` 换成 `var(--awd-info-soft)`，浅色主题下该令牌是不透明 `#EFF6FF`，直接盖住冻结帧里被框选的内容。
- `.ocr-overlay-hintline` 固定 `left:14px/top:14px`，正好是窗口标题区。

## 修法
- 选区背景改回半透明字面量。
- 提示条贴底居中。
- 新增 `tests/ocr-overlay/ocr-overlay-style.test.mjs` 源码契约（先红后绿），`npm run test:ocr-overlay` 接进 CI。
- `utility-tools.md` 记录「叠在冻结帧上的样式不能引用 *-soft 令牌」这条地雷。

## 验证
- `npm run test:ocr-overlay`：修前 2 red，修后 2 pass。
- `npm run test:project-home`：373 pass。
- 未真机走查，复测提示见 dev-board#474。

台账：dev-board#474（合并后转待复测，不自动关卡）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)