### PR TITLE
fix(telemetry): 插件开发形态埋点改走 plugin.lifecycle，op 加 dev_ 前缀（dev-board#498）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/ai/PluginDevController.java
+++ b/backend/src/main/java/com/checkba/controller/ai/PluginDevController.java
@@ -52,7 +52,7 @@ public class PluginDevController {
             String id = body.get("id") == null ? null : String.valueOf(body.get("id")).trim();
             String name = body.get("name") == null ? null : String.valueOf(body.get("name"));
             Long folderId = pluginDevService.scaffold(projectId, userId, id, name);
-            telemetryService.record("plugin.dev", Map.of("pluginId", id, "op", "scaffold"));
+            telemetryService.record("plugin.lifecycle", Map.of("pluginId", id, "op", "dev_scaffold"));
             Map<String, Object> result = ok();
             result.put("folderId", folderId);
             return ResponseEntity.ok(result);
@@ -87,7 +87,7 @@ public class PluginDevController {
         }
         try {
             String id = pluginDevService.install(asLong(body.get("projectId")), asLong(body.get("folderId")));
-            telemetryService.record("plugin.dev", Map.of("pluginId", id, "op", "install"));
+            telemetryService.record("plugin.lifecycle", Map.of("pluginId", id, "op", "dev_install"));
             Map<String, Object> result = ok();
             result.put("id", id);
             return ResponseEntity.ok(result);
@@ -108,7 +108,7 @@ public class PluginDevController {
             String id = body == null ? null : body.get("id");
             pluginDevService.uninstall(id);
             if (id != null) {
-                telemetryService.record("plugin.dev", Map.of("pluginId", id, "op", "uninstall"));
+                telemetryService.record("plugin.lifecycle", Map.of("pluginId", id, "op", "dev_uninstall"));
             }
             return ResponseEntity.ok(ok());
         } catch (Exception e) {

--- a/backend/src/test/java/com/checkba/controller/ai/PluginDevControllerTelemetryTest.java
+++ b/backend/src/test/java/com/checkba/controller/ai/PluginDevControllerTelemetryTest.java
@@ -1,0 +1,76 @@
+package com.checkba.controller.ai;
+
+import com.checkba.controller.AuthController;
+import com.checkba.model.entity.User;
+import com.checkba.repository.UserRepository;
+import com.checkba.service.AdminAccessService;
+import com.checkba.service.ai.PluginDevService;
+import com.checkba.service.telemetry.TelemetryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 插件开发形态三个端点的埋点必须走白名单里已有的 plugin.lifecycle 事件
+ * （op 用 dev_ 前缀与市场安装区分）。历史上这里发的是 plugin.dev，
+ * 白名单没有这个事件名，TelemetryService 整条拒绝，三个事件从未落库（dev-board#498）。
+ */
+class PluginDevControllerTelemetryTest {
+
+    private PluginDevService pluginDevService;
+    private TelemetryService telemetryService;
+    private PluginDevController controller;
+
+    @BeforeEach
+    void setUp() {
+        pluginDevService = mock(PluginDevService.class);
+        telemetryService = mock(TelemetryService.class);
+        UserRepository users = mock(UserRepository.class);
+        AdminAccessService admin = mock(AdminAccessService.class);
+        User u = new User();
+        when(users.findById(anyLong())).thenReturn(Optional.of(u));
+        when(admin.isAdmin(any())).thenReturn(true);
+        controller = new PluginDevController(pluginDevService, users, admin, telemetryService);
+    }
+
+    @Test
+    void scaffoldRecordsPluginLifecycleWithDevOp() {
+        when(pluginDevService.scaffold(eq(1L), eq(7L), eq("my-plugin"), any())).thenReturn(99L);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            controller.scaffold(Map.of("projectId", 1, "id", "my-plugin"), "sess");
+        }
+        verify(telemetryService).record("plugin.lifecycle", Map.of("pluginId", "my-plugin", "op", "dev_scaffold"));
+        verifyNoMoreInteractions(telemetryService);
+    }
+
+    @Test
+    void installRecordsPluginLifecycleWithDevOp() {
+        when(pluginDevService.install(1L, 99L)).thenReturn("my-plugin");
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            controller.install(Map.of("projectId", 1, "folderId", 99), "sess");
+        }
+        verify(telemetryService).record("plugin.lifecycle", Map.of("pluginId", "my-plugin", "op", "dev_install"));
+        verifyNoMoreInteractions(telemetryService);
+    }
+
+    @Test
+    void uninstallRecordsPluginLifecycleWithDevOp() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(7L);
+            controller.uninstall(Map.of("id", "my-plugin"), "sess");
+        }
+        verify(pluginDevService).uninstall("my-plugin");
+        verify(telemetryService).record("plugin.lifecycle", Map.of("pluginId", "my-plugin", "op", "dev_uninstall"));
+        verifyNoMoreInteractions(telemetryService);
+    }
+}

--- a/backend/src/test/java/com/checkba/service/telemetry/TelemetryServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/telemetry/TelemetryServiceTest.java
@@ -68,6 +68,24 @@ class TelemetryServiceTest {
     }
 
     @Test
+    void pluginDevOpsRideOnPluginLifecycleEvent() throws Exception {
+        // PluginDevController 的脚手架/直装/卸载共用 plugin.lifecycle，op 用 dev_ 前缀区分，
+        // 不另设事件名（否则官网仓 events 端点白名单也要跟着改）。dev-board#498
+        for (String op : new String[]{"dev_scaffold", "dev_install", "dev_uninstall"}) {
+            svc.record("plugin.lifecycle", Map.of("pluginId", "my-plugin", "op", op));
+        }
+        svc.flush();
+        ArgumentCaptor<TelemetryEvent> cap = ArgumentCaptor.forClass(TelemetryEvent.class);
+        verify(repo, times(3)).save(cap.capture());
+        for (TelemetryEvent ev : cap.getAllValues()) {
+            assertEquals("plugin.lifecycle", ev.getEventName());
+            assertTrue(ev.getAttrs().contains("\"op\":\"dev_"), ev.getAttrs());
+            assertTrue(ev.getAttrs().contains("my-plugin"));
+        }
+        assertEquals(0, svc.droppedCount());
+    }
+
+    @Test
     void overlongStringValueIsDropped() throws Exception {
         svc.record("ai.tool", Map.of("toolName", "x".repeat(65)));
         svc.flush();

--- a/docs/ANALYTICS_TELEMETRY_DESIGN.md
+++ b/docs/ANALYTICS_TELEMETRY_DESIGN.md
@@ -101,7 +101,7 @@
 | `editor.action` | `libreofficeExecutorClient.executeCommand`（前端，AI 与人工全收口） | action, agent(bool), success, durationMs, whitelistRejected |
 | `editor.bridge` | `EditorBridgeService.executeEditorCommand`（服务端往返与超时） | action, outcome(ok/timeout/error), durationMs |
 | `skill.activated` | `SkillRouter.activateForTurn` | skillId, how(pinned/matched) |
-| `skill.lifecycle` / `plugin.lifecycle` | `SkillRegistry.setEnabled`、`PluginController` 安装/卸载/启停 | id, op |
+| `skill.lifecycle` / `plugin.lifecycle` | `SkillRegistry.setEnabled`、`PluginController` 安装/卸载/启停、`PluginDevController` 开发形态脚手架/直装/卸载（op 取 `dev_scaffold` / `dev_install` / `dev_uninstall`，与市场安装区分；不另设事件名） | id, op |
 | `project.created` | `ProjectService.createProject` / `LocalProjectService.openLocalFolder` / `CloudSyncService.cloneFromCloud` | kind(managed/local/cloud), reused, importedCount |
 | `file.changed` | `ProjectFileService.signalChange` | （仅计数） |
 | `version.op` | `WorkSessionService.ensureSession/endSession` + `VersionController.onVersionError`（失败率） | op, ok |


### PR DESCRIPTION
## 问题

`PluginDevController` 三处 `telemetryService.record("plugin.dev", …)`，但 `TelemetryAttrWhitelist` 没有 `plugin.dev` 条目，`TelemetryService.recordInternal` 对未知事件名整条拒绝、只加 `dropped` 计数。插件开发形态的 scaffold / install / uninstall 三个事件从未落 `telemetry_event`、日聚合与本地用量摘要。

## 修法（选 b，不新增事件名）

改用既有 `plugin.lifecycle` 事件，op 取 `dev_scaffold` / `dev_install` / `dev_uninstall` 与市场安装区分。§5.4 是收口的 12 个事件分类法，新增事件名要同步官网仓 `lib/telemetry-store.ts` 白名单并单独部署；开发形态的装/卸在语义上就是插件生命周期，没必要另开一个事件。官网仓不需要动。

## 改动

- `PluginDevController`：三处事件名与 op
- `PluginDevControllerTelemetryTest`（新）：接线测试，锁事件名与 op；把控制器改回 `plugin.dev` 即转红（已实测）
- `TelemetryServiceTest.pluginDevOpsRideOnPluginLifecycleEvent`：三个 dev_ op 经真实白名单落库、dropped 为 0
- `docs/ANALYTICS_TELEMETRY_DESIGN.md` §5.4：`plugin.lifecycle` 行补 `PluginDevController` 插桩位置与 op 取值

## 验证

```
mvn -o test -Dtest='TelemetryServiceTest,PluginDevControllerTelemetryTest'
TelemetryServiceTest              tests=7 failures=0
PluginDevControllerTelemetryTest  tests=3 failures=0
```

Closes zeweihan/dev-board#498

🤖 Generated with [Claude Code](https://claude.com/claude-code)