### PR TITLE
feat(provenance): 文档 Application 元数据（可关）+ 出站 UA 收敛到 ProductIdentity（dev-board#511 #512）

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -215,9 +215,19 @@ HOUSE 不再是常量：`buildHouse(profile)` 从画像 JSON 派生写端常量�
 - `adopt_legacy_links` 不能把 TextPortion 直接喂 `insertTextContent`（抛 IllegalArgumentException），要 `createTextCursorByRange(start)` + `gotoRange(end, true)` 在正文上造区间游标；且先收集目标再插书签，枚举中改段落会让 portion 枚举失效。
 - `headingChainOf` 用 `XTextRangeCompare` 定位段落，表格单元格内的书签跨 story 比较会抛 → `sectionPath` 空、`paragraphIndex -1`（P0 接受）。
 
+## 文档 Generator 元数据（可溯源性设计规范附录 B4）
+
+保存出去的 docx/xlsx/pptx 在 `docProps/app.xml` 的 `<Application>` 里写 `AI WorkDeck <version>`（Word / WPS / LibreOffice 都写这个标准字段，我们此前是唯一不写的）。**只写产品名与版本，不写作者/单位/机器名**；开关 `document.generator.enabled` 缺省开，设置页「文档属性」一栏可关（交付前要 scrub 元数据的律所用）。
+
+- **引擎 API 改不到这个字段**（2026-09-09 真机探针，24.2.8-zhcn-r4，三种试法全否）：`getDocumentProperties()` 上**没有** `setGenerator/getGenerator` 方法（zetajs 把 `Generator` 暴露成属性）；属性写法 `dp.Generator = '...'` **写得进也读得回**，但导出件的 `<Application>` 纹丝不动，仍是 `ZetaOffice/24.2.8.0.beta1$Emscripten_x86 LibreOffice_project/<buildid>`；`UserDefinedProperties.addProperty('Application', …)` 只多出一个 `docProps/custom.xml`，标准字段照旧。结论：oox 导出器硬写 `utl::DocInfoHelper::GetGeneratorString()`。**别再试 API 路线**，引擎哪天改了 lowa-e2e 组 32 第 5 项的「基线」那条会红。
+- 实现在**宿主侧**：`frontend/src/utils/docxAppProps.js` 的 `stampApplication(bytes, application)`（async——引擎导出的条目全是 DEFLATE、带 data descriptor，读 app.xml 要 `DecompressionStream('deflate-raw')`），只换 `docProps/app.xml` 这一个条目（新条目 STORED、自算 CRC32），其余条目的本地头与数据**逐字节原样拷贝**、只重写中央目录偏移；ZIP64 / 非 zip / 没有 EOCD / app.xml 里没有 `<Application>` 元素（**只替换不插入**）/ 自检不过——**一律原样返回入参**。不引 jszip：那会把整包重压一遍，大文档在保存路径上不可接受。
+- 接线：`LibreOfficeEditor.saveDocument` 在 `uploadBytes` 之前调 `stampGeneratorMetadata(u8)`，开关与串从 `GET /api/document/generator/settings` 取一次、`utils/documentGeneratorSetting.js` 按会话缓存（**读失败不入缓存**，后端刚起来那几秒读不到是常态）。打标链路任何异常都退回导出原字节，绝不影响保存。
+- 覆盖边界：lowa-e2e 跑的是 dist 的 editor-main.js，**打标那一步经不过来**——纯函数由 `tests/lowa-unit/docxAppProps.test.mjs` 守，宿主接线由 `tests/project-home/libre-save-generator-stamp.test.mjs` 守（删掉 saveDocument 里那一行即转红），真产物+真引擎回读由 lowa-e2e 组 32 第 5 项守。
+- 后端 POI 落盘路径同口径：`DocumentGeneratorStamp.apply(doc, documentGeneratorSettings)` 一行，已接 SensitiveService / MeetingRecordingService / LitigationTimelineTools / DdExportService(xlsx) / DocumentEditTools(xlsx)。**docx4j 的两条路径（`doc_start_stream` 建空白 docx、DdExportService 的 markdown→docx）没接**——docx4j 不走 POI 的属性 API，且前者随即由编辑器接管保存、自然会被宿主打上。
+
 ## 验证
 
-- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，33 组人机模拟，2026-09-02 基线 541 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
+- 核心回归：`cd frontend && npm run test:lowa-e2e`（真引擎 puppeteer-core 无头，33 组人机模拟，2026-09-09 基线 547 步；前置 `npm run build:zetaoffice` + `node ../desktop/scripts/fetch-lowa-assets.js` 或设 LOWA_ENGINE_DIR）。
 - 修订视图三态的接线契约（白名单 / 三态命令序列 / 换文档复位）：`npm run test:revision-view`（node --test，不需要引擎）。
 - 大文档性能：`npm run test:lowa-big`（同一套启动件 `tests/lowa-e2e/_boot.mjs`；端口被别的 worktree 占着时设 `LOWA_E2E_PORT`）。
 - 涉桌面壳/webview：`npm run test:desktop-e2e`（弹 dev Electron 窗口，验证保存落盘链路）。

--- a/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
+++ b/backend/src/main/java/com/checkba/controller/BrowserProxyController.java
@@ -4,6 +4,7 @@
 package com.checkba.controller;
 
 import com.checkba.service.LangText;
+import com.checkba.util.ProductIdentity;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -126,7 +127,7 @@ public class BrowserProxyController {
                         .GET()
                         // 单跳超时取「剩余总预算」与 20 秒的较小值：跳数再多也不会累加成分钟级占用
                         .timeout(budget.compareTo(Duration.ofSeconds(20)) < 0 ? budget : Duration.ofSeconds(20))
-                        .header("User-Agent", "checkba-browser/1.0")
+                        .header("User-Agent", ProductIdentity.userAgent("browser-proxy"))
                         .build();
                 // 流式接收而不是 ofByteArray()：正文要不要收、收多少由下面的体积闸说了算
                 resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofInputStream());

--- a/backend/src/main/java/com/checkba/controller/DocumentGeneratorController.java
+++ b/backend/src/main/java/com/checkba/controller/DocumentGeneratorController.java
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package com.checkba.controller;
+
+import com.checkba.service.document.DocumentGeneratorSettings;
+import com.checkba.util.ProductIdentity;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 文档 Generator 元数据开关的读写口（可溯源性设计规范附录 B4）。
+ *
+ * <p>GET 给设置页与编辑器保存路径共用：{@code application} 就是要写进 docProps/app.xml
+ * 的那个串，前端不许自己拼版本号。鉴权口径照 {@link TelemetryController}——读不设门槛
+ * （返回的只有一个布尔与产品名），写要求已登录。
+ */
+@RestController
+@RequestMapping("/api/document/generator")
+@RequiredArgsConstructor
+public class DocumentGeneratorController {
+
+    private final DocumentGeneratorSettings settings;
+
+    @GetMapping("/settings")
+    public Map<String, Object> getSettings() {
+        Map<String, Object> r = new HashMap<>();
+        r.put("code", 0);
+        r.put("enabled", settings.enabled());
+        r.put("application", ProductIdentity.applicationName());
+        return r;
+    }
+
+    @PutMapping("/settings")
+    public Map<String, Object> updateSettings(
+            @RequestBody SettingsRequest request,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        Long userId = AuthController.getUserIdFromSession(sessionId);
+        if (userId == null) throw new IllegalArgumentException("未登录");
+        if (request.getEnabled() != null) settings.setEnabled(request.getEnabled());
+        return getSettings();
+    }
+
+    @Data
+    public static class SettingsRequest {
+        private Boolean enabled;
+    }
+}

--- a/backend/src/main/java/com/checkba/service/DdExportService.java
+++ b/backend/src/main/java/com/checkba/service/DdExportService.java
@@ -70,6 +70,11 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class DdExportService {
 
+    // 文档 Generator 元数据（可溯源性设计规范附录 B4）：只写 docProps/app.xml 的
+    // Application，不含任何用户身份。required = false 是给手工 new 出来的单测留的口子。
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.document.DocumentGeneratorSettings documentGeneratorSettings;
+
     public static final String KIND_DOCKET = "docket";
     public static final String KIND_VERIFY_PLAN = "verify-plan";
     public static final String KIND_GAPS = "gaps";
@@ -418,6 +423,7 @@ public class DdExportService {
                 }
             }
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            com.checkba.util.DocumentGeneratorStamp.apply(wb, documentGeneratorSettings);
             wb.write(bos);
             return bos.toByteArray();
         }

--- a/backend/src/main/java/com/checkba/service/SensitiveService.java
+++ b/backend/src/main/java/com/checkba/service/SensitiveService.java
@@ -34,6 +34,11 @@ import java.util.regex.Matcher;
 @Slf4j
 public class SensitiveService {
 
+    // 文档 Generator 元数据（可溯源性设计规范附录 B4）：只写 docProps/app.xml 的
+    // Application，不含任何用户身份。required = false 是给手工 new 出来的单测留的口子。
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.document.DocumentGeneratorSettings documentGeneratorSettings;
+
     public String processFile(String filePath, List<String> strategies) throws Exception {
         File file = new File(filePath);
         if (!file.exists()) {
@@ -120,6 +125,7 @@ public class SensitiveService {
             // 文本框内容，需要手写 w:txbxContent 的原始 XML 遍历才能做，本次不做，如果文本框里
             // 塞了敏感信息不会被脱敏，需要人工核查。
 
+            com.checkba.util.DocumentGeneratorStamp.apply(doc, documentGeneratorSettings);
             try (FileOutputStream out = new FileOutputStream(dest)) {
                 doc.write(out);
             }

--- a/backend/src/main/java/com/checkba/service/ai/OpenRouterStreamingChatModel.java
+++ b/backend/src/main/java/com/checkba/service/ai/OpenRouterStreamingChatModel.java
@@ -3,6 +3,7 @@
 
 package com.checkba.service.ai;
 
+import com.checkba.util.ProductIdentity;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -142,7 +143,7 @@ public final class OpenRouterStreamingChatModel implements StreamingChatLanguage
                 .url(endpoint)
                 .header("Authorization", "Bearer " + (apiKey == null ? "" : apiKey))
                 .header("Accept", "text/event-stream")
-                .header("User-Agent", "AI-WorkDeck")
+                .header("User-Agent", ProductIdentity.userAgent("ai-gateway"))
                 .post(RequestBody.create(body, JSON))
                 .build();
 

--- a/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/DocumentEditTools.java
@@ -37,6 +37,11 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DocumentEditTools implements AgentToolComponent {
 
+    // 文档 Generator 元数据（可溯源性设计规范附录 B4）：只写 docProps/app.xml 的
+    // Application，不含任何用户身份。required = false 是给手工 new 出来的单测留的口子。
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.document.DocumentGeneratorSettings documentGeneratorSettings;
+
     private final ProjectFileService projectFileService;
     private final ProjectFileRepository projectFileRepository;
     private final EditorBridgeService editorBridgeService;
@@ -2115,6 +2120,7 @@ public class DocumentEditTools implements AgentToolComponent {
                 try (org.apache.poi.xssf.usermodel.XSSFWorkbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook();
                      java.io.OutputStream os = java.nio.file.Files.newOutputStream(target)) {
                     wb.createSheet("Sheet1");
+                    com.checkba.util.DocumentGeneratorStamp.apply(wb, documentGeneratorSettings);
                     wb.write(os);
                 }
             });

--- a/backend/src/main/java/com/checkba/service/ai/tools/LitigationTimelineTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/LitigationTimelineTools.java
@@ -61,6 +61,11 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class LitigationTimelineTools implements AgentToolComponent {
 
+    // 文档 Generator 元数据（可溯源性设计规范附录 B4）：只写 docProps/app.xml 的
+    // Application，不含任何用户身份。required = false 是给手工 new 出来的单测留的口子。
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.document.DocumentGeneratorSettings documentGeneratorSettings;
+
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LitigationTimelineTools.class);
 
     /** 模型可提交的文件名白名单——管线认识的那几份，别的名字一律拒收。 */
@@ -338,7 +343,8 @@ public class LitigationTimelineTools implements AgentToolComponent {
             // 溯源索引：管线里那条 node 路线在桌面端不可用（不随包分发 node/docx 包），
             // 由服务端按 trace.json 用 POI 出同一份 Word 三线表。已有 docx 时不重复出。
             if (traceJson != null && paths.stream().noneMatch(p -> p.getFileName().toString().endsWith(".docx"))) {
-                Path docx = buildTraceDocx(traceJson, safeName);
+                Path docx = buildTraceDocx(traceJson, safeName,
+                        com.checkba.util.DocumentGeneratorStamp.enabled(documentGeneratorSettings));
                 if (docx != null) paths.add(docx);
             }
 
@@ -478,6 +484,11 @@ public class LitigationTimelineTools implements AgentToolComponent {
      * 出不来只损失这一份附件，绝不拖垮整次交付。
      */
     static Path buildTraceDocx(Path traceJson, String figureName) {
+        return buildTraceDocx(traceJson, figureName, true);
+    }
+
+    /** {@code stampEnabled}：文档 Generator 元数据开关（B4）。静态方法拿不到注入字段，由调用方求值传入。 */
+    static Path buildTraceDocx(Path traceJson, String figureName, boolean stampEnabled) {
         try {
             JSONObject payload = JSONUtil.parseObj(Files.readString(traceJson, StandardCharsets.UTF_8));
             JSONArray rows = payload.getJSONArray("rows");
@@ -522,6 +533,7 @@ public class LitigationTimelineTools implements AgentToolComponent {
                 }
 
                 Path out = traceJson.getParent().resolve(figureName + "-溯源索引.docx");
+                com.checkba.util.DocumentGeneratorStamp.apply(doc, stampEnabled);
                 try (OutputStream os = Files.newOutputStream(out)) {
                     doc.write(os);
                 }

--- a/backend/src/main/java/com/checkba/service/capability/CapabilitySourceFetchService.java
+++ b/backend/src/main/java/com/checkba/service/capability/CapabilitySourceFetchService.java
@@ -4,6 +4,7 @@
 package com.checkba.service.capability;
 
 import com.checkba.service.LangText;
+import com.checkba.util.ProductIdentity;
 import com.checkba.util.SsrfGuard;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -235,7 +236,7 @@ public class CapabilitySourceFetchService {
             }
             HttpRequest req = HttpRequest.newBuilder(URI.create(current))
                     .timeout(Duration.ofSeconds(60))
-                    .header("User-Agent", "AI-WorkDeck-Capability-Installer")
+                    .header("User-Agent", ProductIdentity.userAgent("capability-installer"))
                     .GET().build();
             HttpResponse<InputStream> resp;
             try {

--- a/backend/src/main/java/com/checkba/service/document/DocumentGeneratorSettings.java
+++ b/backend/src/main/java/com/checkba/service/document/DocumentGeneratorSettings.java
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package com.checkba.service.document;
+
+import com.checkba.service.SystemSettingService;
+import org.springframework.stereotype.Service;
+
+/**
+ * 文档 Generator 元数据开关（可溯源性设计规范附录 B4）。
+ *
+ * <p>语义：开启时，我们生成或另存的 OOXML 文件在 {@code docProps/app.xml} 里带上
+ * {@code <Application>AI WorkDeck &lt;version&gt;</Application>}。只写产品名与版本，
+ * 不含任何用户身份信息。关掉之后一个字段都不写（有些律所交付前要清除文档元数据）。
+ *
+ * <p>写法照 {@code TelemetrySettings}：一个 SystemSettingService 键，缺省 true。
+ */
+@Service
+public class DocumentGeneratorSettings {
+
+    public static final String KEY_ENABLED = "document.generator.enabled";
+
+    private final SystemSettingService settings;
+
+    public DocumentGeneratorSettings(SystemSettingService settings) {
+        this.settings = settings;
+    }
+
+    public boolean enabled() {
+        return Boolean.parseBoolean(settings.get(KEY_ENABLED, "true"));
+    }
+
+    public void setEnabled(boolean v) {
+        settings.set(KEY_ENABLED, Boolean.toString(v));
+    }
+}

--- a/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
+++ b/backend/src/main/java/com/checkba/service/meeting/MeetingRecordingService.java
@@ -38,6 +38,11 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class MeetingRecordingService {
 
+    // 文档 Generator 元数据（可溯源性设计规范附录 B4）：只写 docProps/app.xml 的
+    // Application，不含任何用户身份。required = false 是给手工 new 出来的单测留的口子。
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private com.checkba.service.document.DocumentGeneratorSettings documentGeneratorSettings;
+
     /**
      * 存放录音与转写稿的项目文件夹名。**两个名字都是「正名」**，不是新旧关系：
      * 建档时按界面语言取一个（{@link #folderName()}），查找时两个都认（{@link #ensureFolder}）。
@@ -394,6 +399,7 @@ public class MeetingRecordingService {
                 XWPFParagraph p = doc.createParagraph();
                 p.createRun().setText(line);
             }
+            com.checkba.util.DocumentGeneratorStamp.apply(doc, documentGeneratorSettings);
             doc.write(out);
             return out.toByteArray();
         } catch (Exception e) {

--- a/backend/src/main/java/com/checkba/util/DocumentGeneratorStamp.java
+++ b/backend/src/main/java/com/checkba/util/DocumentGeneratorStamp.java
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package com.checkba.util;
+
+import com.checkba.service.document.DocumentGeneratorSettings;
+import org.apache.poi.ooxml.POIXMLDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 往我们生成的 OOXML 文件里写 extended properties 的 Application（可溯源性设计规范附录 B4）。
+ *
+ * <p>写的是 OOXML 标准字段 {@code docProps/app.xml} 的 {@code <Application>}，Word / WPS / Pages
+ * 全都读得懂并原样保留，右键属性即可见——对用户完全透明，不改正文一个字节。
+ *
+ * <p>红线：<b>只写 Application</b>。Company / Manager / creator / lastModifiedBy 这些可能携带
+ * 用户身份的字段一个都不碰（POI 默认就是空，这里也不去填）。值统一从
+ * {@link ProductIdentity#applicationName()} 派生，调用处不许再拼字面量。
+ *
+ * <p>开关是 {@code document.generator.enabled}（缺省开）：有些律所对文档元数据敏感，
+ * 交付前要 scrub，关掉之后这里一个字段都不写。
+ */
+public final class DocumentGeneratorStamp {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentGeneratorStamp.class);
+
+    private DocumentGeneratorStamp() {}
+
+    /**
+     * 在 write 之前调用一次。{@code enabled} 为 false 或 doc 为 null 时什么都不做。
+     *
+     * <p>写元数据失败绝不能连累文档本身的落盘——这条链路上游是脱敏输出、会议纪要、
+     * 时间轴导出这些真业务产物，为了一个可选的标识把文件写坏是本末倒置。
+     */
+    public static void apply(POIXMLDocument doc, boolean enabled) {
+        if (doc == null || !enabled) return;
+        try {
+            doc.getProperties().getExtendedProperties().getUnderlyingProperties()
+                    .setApplication(ProductIdentity.applicationName());
+        } catch (Exception e) {
+            log.debug("写入文档 Application 元数据失败，跳过（不影响文档本身）", e);
+        }
+    }
+
+    /**
+     * 调用处的一行式重载：直接把注入进来的开关服务递过来。
+     *
+     * <p>{@code settings} 为 null 时按缺省的「开」处理——只有脱离 Spring 容器手工 new 出来的
+     * 单测对象才会是 null（{@code @Autowired(required = false)} 字段没被填），产品运行时永远有 bean。
+     */
+    public static void apply(POIXMLDocument doc, DocumentGeneratorSettings settings) {
+        apply(doc, enabled(settings));
+    }
+
+    /** 开关求值，语义同上（null 即缺省的「开」）。给拿不到注入字段的静态方法用。 */
+    public static boolean enabled(DocumentGeneratorSettings settings) {
+        return settings == null || settings.enabled();
+    }
+}

--- a/backend/src/main/java/com/checkba/util/ProductIdentity.java
+++ b/backend/src/main/java/com/checkba/util/ProductIdentity.java
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package com.checkba.util;
+
+/**
+ * 产品标识的唯一来源（可溯源性设计规范附录 B3 / B4）。
+ *
+ * <p>两处对外可见的字符串都从这里派生，别在调用处再拼字面量：
+ * <ul>
+ *   <li>出站 HTTP User-Agent：{@code AIWorkDeck/<version> (<component>)}，见 {@link #userAgent(String)}；</li>
+ *   <li>写进文档 core/extended properties 的 Application：{@code AI WorkDeck <version>}，见 {@link #applicationName()}。</li>
+ * </ul>
+ *
+ * <p>版本号单一来源是 desktop/package.json：桌面壳启动后端时经 {@code AWD_APP_VERSION} 注入
+ * （与 application.yml 的 telemetry.app-version 同源），开发态没有注入就是 {@code dev}。
+ * 这里刻意不走 Spring 注入——调用点里有不受容器管理的对象（如手工 new 的模型客户端），
+ * 静态读环境变量对所有调用点一视同仁。测试可用系统属性 {@code awd.app.version} 覆盖。
+ *
+ * <p>红线：只写产品名与版本，绝不携带用户身份、机器信息或任何可识别个人的内容。
+ */
+public final class ProductIdentity {
+
+    /** 面向人的产品名（文档属性用）。 */
+    public static final String PRODUCT_NAME = "AI WorkDeck";
+
+    /** User-Agent 里的产品记号（RFC 9110 product token 不能带空格）。 */
+    public static final String UA_PRODUCT = "AIWorkDeck";
+
+    private static final String VERSION_PROPERTY = "awd.app.version";
+    private static final String VERSION_ENV = "AWD_APP_VERSION";
+    private static final String DEFAULT_VERSION = "dev";
+
+    private ProductIdentity() {}
+
+    /** 应用版本号；优先系统属性（测试用），其次 AWD_APP_VERSION，都没有则 dev。 */
+    public static String version() {
+        String v = System.getProperty(VERSION_PROPERTY);
+        if (v == null || v.isBlank()) v = System.getenv(VERSION_ENV);
+        if (v == null || v.isBlank()) return DEFAULT_VERSION;
+        return v.trim();
+    }
+
+    /** 出站请求的 User-Agent：{@code AIWorkDeck/0.36.0 (browser-proxy)}。component 用小写连字符短词。 */
+    public static String userAgent(String component) {
+        if (component == null || component.isBlank()) {
+            throw new IllegalArgumentException("component must not be blank");
+        }
+        return UA_PRODUCT + "/" + version() + " (" + component.trim() + ")";
+    }
+
+    /** 文档 Application 属性：{@code AI WorkDeck 0.36.0}。 */
+    public static String applicationName() {
+        return PRODUCT_NAME + " " + version();
+    }
+}

--- a/backend/src/test/java/com/checkba/service/SensitiveServiceRedactionTest.java
+++ b/backend/src/test/java/com/checkba/service/SensitiveServiceRedactionTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,6 +83,12 @@ class SensitiveServiceRedactionTest {
                     .map(XWPFParagraph::getText)
                     .collect(Collectors.joining());
             assertFalse(text.contains("13800001111"), "跨 run 的手机号必须被脱敏");
+            // B4 接线：脱敏输出是我们生成的新文件，docProps/app.xml 的 Application 必须是产品标识
+            // （手工 new 的 service 没注入开关，按缺省的「开」走）。源文件是 POI 空建的，POI 默认写的是
+            // 「Apache POI」，所以这条断言不会被输入文件「顺带」满足（还原病灶时读回的正是 Apache POI）。
+            assertEquals(com.checkba.util.ProductIdentity.applicationName(),
+                    out.getProperties().getExtendedProperties().getApplication(),
+                    "脱敏输出的 Application 元数据必须来自 ProductIdentity");
         }
     }
 

--- a/backend/src/test/java/com/checkba/util/DocumentGeneratorStampTest.java
+++ b/backend/src/test/java/com/checkba/util/DocumentGeneratorStampTest.java
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package com.checkba.util;
+
+import org.apache.poi.ooxml.POIXMLProperties;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * B4：POI 落盘路径写 extended properties 的 Application。
+ *
+ * 两条红线都在这里守：① 值必须等于 {@link ProductIdentity#applicationName()}（调用处
+ * 不许拼字面量）；② Company / Manager / creator / lastModifiedBy 这些可能带身份的字段
+ * 不许因为这次打标而改变——判据是「开关开与关两份产物里这些字段完全一致」，不是
+ * 「它们必须为空」：POI 自己就会把 creator 写成 "Apache POI"，那是既有行为，与我们无关。
+ */
+class DocumentGeneratorStampTest {
+
+    private static final String VERSION_PROPERTY = "awd.app.version";
+    private String previousVersion;
+
+    @BeforeEach
+    void setUp() {
+        previousVersion = System.getProperty(VERSION_PROPERTY);
+        System.setProperty(VERSION_PROPERTY, "9.9.9-test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (previousVersion == null) System.clearProperty(VERSION_PROPERTY);
+        else System.setProperty(VERSION_PROPERTY, previousVersion);
+    }
+
+    private byte[] writeDocx(boolean enabled) throws Exception {
+        try (XWPFDocument doc = new XWPFDocument(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            doc.createParagraph().createRun().setText("正文");
+            DocumentGeneratorStamp.apply(doc, enabled);
+            doc.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] writeXlsx(boolean enabled) throws Exception {
+        try (XSSFWorkbook wb = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            wb.createSheet("Sheet1");
+            DocumentGeneratorStamp.apply(wb, enabled);
+            wb.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    @Test
+    void docx_writes_application_when_enabled() throws Exception {
+        try (XWPFDocument reopened = new XWPFDocument(new ByteArrayInputStream(writeDocx(true)))) {
+            POIXMLProperties props = reopened.getProperties();
+            assertEquals("AI WorkDeck 9.9.9-test",
+                    props.getExtendedProperties().getUnderlyingProperties().getApplication());
+        }
+        assertOnlyApplicationDiffers(identityOf(writeDocx(false), true), identityOf(writeDocx(true), true));
+    }
+
+    @Test
+    void docx_writes_nothing_when_disabled() throws Exception {
+        try (XWPFDocument reopened = new XWPFDocument(new ByteArrayInputStream(writeDocx(false)))) {
+            String app = reopened.getProperties().getExtendedProperties()
+                    .getUnderlyingProperties().getApplication();
+            assertTrue(app == null || app.isEmpty() || !app.contains("AI WorkDeck"),
+                    "开关关掉后不许出现产品标识，实际: " + app);
+        }
+    }
+
+    @Test
+    void xlsx_writes_application_when_enabled() throws Exception {
+        try (XSSFWorkbook reopened = new XSSFWorkbook(new ByteArrayInputStream(writeXlsx(true)))) {
+            POIXMLProperties props = reopened.getProperties();
+            assertEquals(ProductIdentity.applicationName(),
+                    props.getExtendedProperties().getUnderlyingProperties().getApplication());
+        }
+        assertOnlyApplicationDiffers(identityOf(writeXlsx(false), false), identityOf(writeXlsx(true), false));
+    }
+
+    @Test
+    void xlsx_writes_nothing_when_disabled() throws Exception {
+        try (XSSFWorkbook reopened = new XSSFWorkbook(new ByteArrayInputStream(writeXlsx(false)))) {
+            String app = reopened.getProperties().getExtendedProperties()
+                    .getUnderlyingProperties().getApplication();
+            assertTrue(app == null || app.isEmpty() || !app.contains("AI WorkDeck"),
+                    "开关关掉后不许出现产品标识，实际: " + app);
+        }
+    }
+
+    @Test
+    void null_document_is_a_no_op() {
+        assertDoesNotThrow(() -> DocumentGeneratorStamp.apply(null, true));
+    }
+
+    @Test
+    void null_settings_means_enabled() {
+        assertTrue(DocumentGeneratorStamp.enabled(null));
+    }
+
+    /** 身份类字段快照：Company / Manager / creator / lastModifiedBy。 */
+    private java.util.Map<String, String> identityOf(byte[] bytes, boolean docx) throws Exception {
+        try (var doc = docx
+                ? (org.apache.poi.ooxml.POIXMLDocument) new XWPFDocument(new ByteArrayInputStream(bytes))
+                : new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            POIXMLProperties props = doc.getProperties();
+            var ext = props.getExtendedProperties().getUnderlyingProperties();
+            var m = new java.util.LinkedHashMap<String, String>();
+            m.put("Company", String.valueOf(ext.getCompany()));
+            m.put("Manager", String.valueOf(ext.getManager()));
+            m.put("creator", String.valueOf(props.getCoreProperties().getCreator()));
+            m.put("lastModifiedBy", String.valueOf(props.getCoreProperties().getLastModifiedByUser()));
+            return m;
+        }
+    }
+
+    /** 打标只许动 Application：身份四件套两份产物里必须一模一样。 */
+    private void assertOnlyApplicationDiffers(java.util.Map<String, String> off,
+                                              java.util.Map<String, String> on) {
+        assertEquals(off, on, "打标不许碰任何可能带身份的字段");
+        for (var e : on.entrySet()) {
+            assertFalse(String.valueOf(e.getValue()).contains("AI WorkDeck"),
+                    e.getKey() + " 里不该出现产品标识，实际: " + e.getValue());
+        }
+    }
+}

--- a/backend/src/test/java/com/checkba/util/ProductIdentityTest.java
+++ b/backend/src/test/java/com/checkba/util/ProductIdentityTest.java
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package com.checkba.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 出站产品标识的两条契约（可溯源性设计规范附录 A9 / B3）。
+ *
+ * <p><b>格式契约</b>：{@link ProductIdentity#userAgent(String)} 的形状是
+ * {@code AIWorkDeck/<version> (<component>)}，{@link ProductIdentity#applicationName()} 是
+ * {@code AI WorkDeck <version>}。这两个串对外可见（服务端日志、文档属性），是黑盒可判别的胎记，
+ * 形状漂了就对不上号。
+ *
+ * <p><b>字面量契约</b>：出站 UA 只许从 {@link ProductIdentity} 派生，不许在调用处再拼字面量。
+ * 收敛前散着 {@code checkba-browser/1.0} / {@code AI-WorkDeck} / {@code AI-WorkDeck-Capability-Installer}
+ * 三种写法，谁也说不清一共有几处。这条靠扫源码守住——反射看不见「有人又抄了一个字面量进来」。
+ *
+ * <p>白名单只有两处，都是<b>刻意模仿浏览器</b>的 UA，不是产品标识：
+ * {@code WebTools}（Playwright 抓页，冒充 Chrome 才拿得到正常页面）与
+ * {@code CninfoAnnouncementService}（巨潮反爬）。把它们换成产品 UA 是功能改动，不是整洁化。
+ */
+class ProductIdentityTest {
+
+    // ---------------------------------------------------------------- 格式契约
+
+    private static final String VERSION_PROPERTY = "awd.app.version";
+
+    @Test
+    @DisplayName("userAgent / applicationName 的形状固定，版本号可被系统属性覆盖")
+    void identityStringsHaveFixedShape() {
+        String before = System.getProperty(VERSION_PROPERTY);
+        try {
+            System.clearProperty(VERSION_PROPERTY);
+            assertTrue(ProductIdentity.userAgent("x").matches("^AIWorkDeck/[^ ]+ \\(x\\)$"),
+                    "UA 形状必须是 AIWorkDeck/<version> (<component>)，实际: " + ProductIdentity.userAgent("x"));
+
+            System.setProperty(VERSION_PROPERTY, "1.2.3");
+            assertEquals("AIWorkDeck/1.2.3 (x)", ProductIdentity.userAgent("x"));
+            assertEquals("AI WorkDeck 1.2.3", ProductIdentity.applicationName());
+        } finally {
+            if (before == null) System.clearProperty(VERSION_PROPERTY);
+            else System.setProperty(VERSION_PROPERTY, before);
+        }
+    }
+
+    // -------------------------------------------------------------- 字面量契约
+
+    /** surefire 的工作目录是 backend/。 */
+    private static final Path MAIN_JAVA = Path.of("src/main/java");
+
+    /** 收敛掉的旧字面量：再出现就是有人绕过了 ProductIdentity。 */
+    private static final List<String> RETIRED_LITERALS =
+            List.of("checkba-browser/1.0", "\"AI-WorkDeck\"", "AI-WorkDeck-Capability");
+
+    /** 只有这两个文件许用自己的 USER_AGENT 常量——它们冒充的是浏览器，不是我们的产品。 */
+    private static final Set<String> BROWSER_UA_FILES =
+            Set.of("WebTools.java", "CninfoAnnouncementService.java");
+
+    /** 抓 "User-Agent" 后面那个实参（同一行内），{@code .header(...)} 与 {@code singletonMap(...)} 两种写法都吃。 */
+    private static final Pattern UA_ARGUMENT = Pattern.compile("\"User-Agent\"\\s*,\\s*([^\\r\\n]+)");
+
+    private static List<Path> mainSources() throws IOException {
+        assertTrue(Files.isDirectory(MAIN_JAVA),
+                "测试工作目录须为 backend/，找不到 " + MAIN_JAVA.toAbsolutePath());
+        try (Stream<Path> walk = Files.walk(MAIN_JAVA)) {
+            List<Path> files = walk.filter(p -> p.toString().endsWith(".java")).sorted().toList();
+            // 空断言护栏：扫描本身塌掉时（路径错、过滤写反）不许静静地全绿
+            assertTrue(files.size() > 300, "只扫到 " + files.size() + " 个源文件，扫描八成塌了");
+            return files;
+        }
+    }
+
+    @Test
+    @DisplayName("收敛掉的旧 UA 字面量不许再出现在 backend 主源码里")
+    void retiredUserAgentLiteralsAreGone() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        for (Path f : mainSources()) {
+            String src = Files.readString(f, StandardCharsets.UTF_8);
+            for (String literal : RETIRED_LITERALS) {
+                if (src.contains(literal)) offenders.add(f + " 含 " + literal);
+            }
+        }
+        assertTrue(offenders.isEmpty(),
+                "出站 UA 必须走 ProductIdentity.userAgent(...)，别再拼字面量:\n  "
+                        + String.join("\n  ", offenders));
+    }
+
+    @Test
+    @DisplayName("每一处 User-Agent 实参要么来自 ProductIdentity，要么是两个浏览器伪装文件的 USER_AGENT")
+    void everyUserAgentComesFromProductIdentity() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        int fromProductIdentity = 0;
+        int fromBrowserDisguise = 0;
+
+        for (Path f : mainSources()) {
+            String name = f.getFileName().toString();
+            if (name.equals("ProductIdentity.java")) continue; // 只是 javadoc 里提到 User-Agent
+            Matcher m = UA_ARGUMENT.matcher(Files.readString(f, StandardCharsets.UTF_8));
+            while (m.find()) {
+                String arg = m.group(1).trim();
+                if (arg.startsWith("ProductIdentity.userAgent(")) {
+                    fromProductIdentity++;
+                } else if (arg.startsWith("USER_AGENT") && BROWSER_UA_FILES.contains(name)) {
+                    fromBrowserDisguise++;
+                } else {
+                    offenders.add(f + " -> " + arg);
+                }
+            }
+        }
+
+        assertTrue(offenders.isEmpty(),
+                "出站 User-Agent 只许从 ProductIdentity.userAgent(...) 取；"
+                        + "浏览器伪装 UA 只许出现在 " + BROWSER_UA_FILES + ":\n  "
+                        + String.join("\n  ", offenders));
+        // 空断言护栏：正则一旦匹配不上，上面的 offenders 也会是空的
+        assertTrue(fromProductIdentity >= 3,
+                "只认出 " + fromProductIdentity + " 处产品 UA，至少应有 3 处"
+                        + "（browser-proxy / capability-installer / ai-gateway），正则八成没匹配上");
+        assertTrue(fromBrowserDisguise >= 4,
+                "只认出 " + fromBrowserDisguise + " 处浏览器伪装 UA，至少应有 4 处"
+                        + "（WebTools 1 处 + CninfoAnnouncementService 3 处），正则八成没匹配上");
+    }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/port-chain-contract.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/main-window-lifecycle.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js tests/share-file.test.js"
+    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/port-chain-contract.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/main-window-lifecycle.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js tests/share-file.test.js tests/product-identity-ua.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/scripts/fetch-drawio-assets.js
+++ b/desktop/scripts/fetch-drawio-assets.js
@@ -39,6 +39,11 @@ const DRAWIO_VERSION = 'v31.1.8';
 const DEFAULT_WAR_URL =
   `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`;
 
+// 出站 User-Agent。格式与后端 ProductIdentity.userAgent() 严格一致：
+// AIWorkDeck/<version> (<component>)。Node 脚本引不了 Java 常量，两边的一致性由
+// desktop/tests/product-identity-ua.test.js 守住。版本号单一来源是 desktop/package.json。
+const USER_AGENT = `AIWorkDeck/${require('../package.json').version} (build-script)`;
+
 const OUT_DIR = path.join(__dirname, '../../frontend/dist/drawio');
 const VERSION_FILE = path.join(OUT_DIR, '.drawio-version');
 
@@ -122,7 +127,7 @@ function download(url, redirects = 0) {
   return new Promise((resolve, reject) => {
     const mod = url.startsWith('http:') ? http : https;
     mod
-      .get(url, { headers: { 'User-Agent': 'aiworkdeck-build' } }, (res) => {
+      .get(url, { headers: { 'User-Agent': USER_AGENT } }, (res) => {
         const sc = res.statusCode || 0;
         if (sc >= 300 && sc < 400 && res.headers.location && redirects < 5) {
           res.resume();

--- a/desktop/tests/product-identity-ua.test.js
+++ b/desktop/tests/product-identity-ua.test.js
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// 构建脚本出站 UA 的格式契约（可溯源性设计规范附录 A9 / B3）。
+//
+// 后端那半由 ProductIdentityTest 守；Node 脚本引不了 Java 常量，只能两边各写一遍
+// 同一个格式 `AIWorkDeck/<version> (<component>)`，靠这个用例把它们钉在一起。
+// 版本号单一来源是 desktop/package.json——UA 里出现别的版本来源就是接错了线。
+//
+// fetch-drawio-assets.js 在模块顶层就 main()，require 进来会真去下 53MB 的 draw.war，
+// 所以这里读源码、只把 USER_AGENT 那一行的表达式取出来求值，require 用指向脚本目录的
+// 替身，免得「测试目录的 ../package.json 恰好也是同一个文件」这种巧合把错误接线放过去。
+
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const SCRIPT = path.join(__dirname, '../scripts/fetch-drawio-assets.js')
+const PKG = require('../package.json')
+
+function evalUserAgent() {
+  const src = fs.readFileSync(SCRIPT, 'utf8')
+  const m = src.match(/^const USER_AGENT = (.+);$/m)
+  assert.ok(m, 'fetch-drawio-assets.js 里找不到 `const USER_AGENT = ...;`（一行写完的形式）')
+  const scriptRequire = (id) => require(path.resolve(path.dirname(SCRIPT), id))
+  return new Function('require', `return ${m[1]}`)(scriptRequire)
+}
+
+test('构建脚本的 UA 与 AIWorkDeck/<package.json version> (build-script) 严格相等', () => {
+  assert.strictEqual(evalUserAgent(), `AIWorkDeck/${PKG.version} (build-script)`)
+})
+
+test('构建脚本的 UA 形状与后端 ProductIdentity.userAgent() 一致', () => {
+  assert.match(evalUserAgent(), /^AIWorkDeck\/[^ ]+ \(build-script\)$/)
+})
+
+test('旧字面量 aiworkdeck-build 已从构建脚本里消失', () => {
+  const src = fs.readFileSync(SCRIPT, 'utf8')
+  assert.ok(src.includes('draw.war'), '空断言护栏：连脚本都没读到就别谈「不含旧字面量」')
+  assert.ok(!src.includes('aiworkdeck-build'), '出站 UA 必须走 USER_AGENT 常量，别再拼字面量')
+})
+
+test('UA 真的接到了下载函数上，不是个没人用的常量', () => {
+  const src = fs.readFileSync(SCRIPT, 'utf8')
+  assert.match(src, /headers:\s*\{\s*'User-Agent':\s*USER_AGENT\s*\}/)
+})

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -151,6 +151,8 @@ import { createAnchorChecker, resolveKeepText } from '@/composables/useEvidenceA
 import { EVIDENCE_CHANGED_EVENT } from '@/utils/evidenceEvents.js'
 import { DOC_MUTATED_EVENT } from '@/utils/docEvents.js'
 import { getResolvedTheme, APP_THEME_EVENT } from '@/utils/appTheme.js'
+import { stampApplication } from '@/utils/docxAppProps.js'
+import { documentStampApplication } from '@/utils/documentGeneratorSetting.js'
 
 let seq = 0
 
@@ -1317,6 +1319,7 @@ export default {
           this.appendLog('save aborted: 正在重载后端最新内容，丢弃这一笔在途导出')
           return false
         }
+        u8 = await this.stampGeneratorMetadata(u8)
         this.appendLog('  ← exported ' + u8.length + ' bytes, uploading…')
         await this.uploadBytes(getFileUploadUrl(fileId), u8, name)
         this.appendLog('  ← saved to backend (fileId=' + fileId + ')')
@@ -1332,6 +1335,24 @@ export default {
         clearTimeout(this._slowSaveTimer)
         // 只收回自己挂上去的「保存中…」；失败态是 catch 里刚设的，必须留着
         if (this.statusKey === 'saving') this.statusKey = prevStatusKey
+      }
+    },
+    // 文档 Generator 元数据（可溯源性设计规范附录 B4）：把导出件 docProps/app.xml 的
+    // <Application> 换成「AI WorkDeck <版本>」。引擎 API 改不到这个字段（oox 导出器硬写
+    // GetGeneratorString()，真机探针实证），只能在拿到字节之后打补丁——细节见 docxAppProps.js。
+    //
+    // 这条链路上任何异常都不许影响保存：开关读不到、字节不是 zip、补丁自检不过，
+    // 一律拿回原样的字节继续上传。
+    async stampGeneratorMetadata(u8) {
+      try {
+        const application = await documentStampApplication()
+        if (!application) return u8
+        const stamped = await stampApplication(u8, application)
+        if (stamped !== u8) this.appendLog('  ← stamped Application=' + application)
+        return stamped && stamped.length ? stamped : u8
+      } catch (e) {
+        this.appendLog('stamp skipped: ' + (e && e.message ? e.message : e))
+        return u8
       }
     },
     // Authed multipart POST — the upload twin of fetchArrayBuffer (backend

--- a/frontend/src/components/userprofile/PersonalSettingsPanel.vue
+++ b/frontend/src/components/userprofile/PersonalSettingsPanel.vue
@@ -155,6 +155,26 @@
         <text v-if="!deviceTokens.length" class="bind-tip">{{ $t('account.noTokensYet') }}</text>
       </view>
 
+      <!-- 文档属性里的产品标识（可溯源性设计规范附录 B4）。默认开：Word / WPS /
+           LibreOffice 保存文档时都会写这个标准字段，我们此前是唯一不写的那个。
+           只写产品名与版本，不写作者/单位/机器名——所以它不是隐私项，是「交付前
+           要不要清元数据」的开关。 -->
+      <view class="form-group">
+        <text class="group-title">{{ $t('account.docGeneratorGroupTitle') }}</text>
+        <view class="form-row doc-generator-row">
+          <text class="form-label doc-generator-label">{{ $t('account.docGeneratorLabel') }}</text>
+          <AwdSwitch
+            :checked="docGeneratorEnabled"
+            :disabled="docGeneratorBusy"
+            @change="onToggleDocGenerator"
+          />
+        </view>
+        <text class="bind-tip">{{ $t('account.docGeneratorHint') }}</text>
+        <text v-if="docGeneratorEnabled && docGeneratorApplication" class="bind-tip">
+          {{ $t('account.docGeneratorCurrent', { application: docGeneratorApplication }) }}
+        </text>
+      </view>
+
       <!-- 界面语言。2026-08-18 从设置页「系统配置」搬来：语言是每个人自己的
            偏好（storage 权威源、人人可改、不要 admin 权限）。
            独立保存链（setAppLanguage 直写），与本栏其它字段无关。 -->
@@ -198,6 +218,9 @@ import {
   totpSetup, totpActivate, totpDisable,
   issueLocalDeviceToken, listDeviceTokens, revokeDeviceToken,
 } from '@/services/api.js'
+import { getDocumentGeneratorSettings, updateDocumentGeneratorSettings } from '@/services/api.js'
+import { resetDocumentStampCache } from '@/utils/documentGeneratorSetting.js'
+import AwdSwitch from '@/components/AwdSwitch.vue'
 import { isDesktopHost } from '@/services/host.js'
 import { getCurrentUser, setSessionUser } from '@/utils/auth.js'
 import { signOut } from '@/utils/signOut.js'
@@ -207,6 +230,7 @@ import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 
 export default {
   name: 'PersonalSettingsPanel',
+  components: { AwdSwitch },
   computed: {
     isDesktop() {
       return isDesktopHost()
@@ -236,6 +260,12 @@ export default {
         { value: 'zh-CN', label: '简体中文' },
         { value: 'en-US', label: 'English' },
       ],
+
+      // 文档属性里的产品标识（B4）：默认按「开」渲染，拉到后端值再纠正——
+      // 缺省就是开，先画成关会在加载瞬间闪一下。
+      docGeneratorEnabled: true,
+      docGeneratorApplication: '',
+      docGeneratorBusy: false,
 
       // 认证器（TOTP）绑定
       showTotpPanel: false,
@@ -268,6 +298,7 @@ export default {
   },
   mounted() {
     this.loadUserInfo()
+    this.loadDocGeneratorSetting()
     if (this.isDesktop) {
       this.loadLicenseInfo()
       this.loadDeviceTokens()
@@ -288,6 +319,36 @@ export default {
   methods: {
     // Options API 模板拿不到裸导入函数，包一层 method 才能在模板里当 getInitial(...) 调用
     getInitial,
+    async loadDocGeneratorSetting() {
+      try {
+        const res = await getDocumentGeneratorSettings()
+        if (res && res.code === 0) {
+          this.docGeneratorEnabled = res.enabled !== false
+          this.docGeneratorApplication = res.application || ''
+        }
+      } catch (e) {
+        // 读不到就保持默认显示，不打扰用户：这个开关不影响任何正在进行的工作
+      }
+    },
+    async onToggleDocGenerator(next) {
+      if (this.docGeneratorBusy) return
+      const prev = this.docGeneratorEnabled
+      this.docGeneratorBusy = true
+      this.docGeneratorEnabled = next
+      try {
+        const res = await updateDocumentGeneratorSettings({ enabled: next })
+        if (!res || res.code !== 0) throw new Error('save failed')
+        this.docGeneratorEnabled = res.enabled !== false
+        this.docGeneratorApplication = res.application || this.docGeneratorApplication
+        // 编辑器的保存路径按会话缓存这个开关，改完必须让它重取，否则要等下次启动才生效
+        resetDocumentStampCache()
+      } catch (e) {
+        this.docGeneratorEnabled = prev
+        uni.showToast({ title: this.$t('account.docGeneratorSaveFailed'), icon: 'none' })
+      } finally {
+        this.docGeneratorBusy = false
+      }
+    },
     async loadUserInfo() {
       const user = getCurrentUser()
       if (user) {
@@ -796,6 +857,14 @@ $text-secondary: #6C757D;
     color: var(--awd-text-on-accent);
     font-size: 13px;
     cursor: pointer;
+}
+.doc-generator-row {
+    justify-content: space-between;
+}
+.doc-generator-label {
+    width: auto;
+    flex: 1;
+    color: var(--awd-text);
 }
 .bind-tip {
     display: block;

--- a/frontend/src/locales/en-US/account.js
+++ b/frontend/src/locales/en-US/account.js
@@ -133,6 +133,12 @@ export default {
   logoutNothingTitle: 'Not signed in',
   logoutNothingContent: 'This machine is unlocked by a trial code and is not connected to an AI WorkDeck account, so there is no sign-in to leave. To return to the locked state, use "Deactivate License" under License below.',
   logoutFailed: 'Log out failed, please try again',
+  // 文档 Generator 元数据开关（可溯源性设计规范附录 B4）
+  docGeneratorGroupTitle: 'Document properties',
+  docGeneratorLabel: 'Write the product name into saved documents',
+  docGeneratorHint: 'When on, documents you save or export show AI WorkDeck and its version under Properties - Application. This is the standard field Word and WPS also write; it carries no personal information (no author, organisation or machine name). Turn it off if you need to strip document metadata before delivery.',
+  docGeneratorCurrent: 'Currently written: {application}',
+  docGeneratorSaveFailed: 'Could not save the setting, please try again',
   logoutGroupTitle: 'Sign-in',
   logoutGroupHint: 'Returns to the sign-in screen so you can use a different account. Your local projects and files stay where they are.',
 

--- a/frontend/src/locales/zh-CN/account.js
+++ b/frontend/src/locales/zh-CN/account.js
@@ -134,6 +134,12 @@ export default {
   logoutNothingTitle: '当前没有登录账户',
   logoutNothingContent: '本机是用试用码解锁的，还没有连接 AI WorkDeck 账户，没有可退出的登录。要回到未解锁状态，用下面「授权」里的「解除授权」。',
   logoutFailed: '退出登录失败，请重试',
+  // 文档 Generator 元数据开关（可溯源性设计规范附录 B4）
+  docGeneratorGroupTitle: '文档属性',
+  docGeneratorLabel: '在保存的文档里写入产品标识',
+  docGeneratorHint: '开启后，保存或导出的文档在「属性 - 应用程序」里显示 AI WorkDeck 与版本号。这是 Word 与 WPS 都会写的标准字段，不含任何个人信息（不写作者、单位、机器名）。如果交付前需要清除文档元数据，可以关掉。',
+  docGeneratorCurrent: '当前写入：{application}',
+  docGeneratorSaveFailed: '设置保存失败，请稍后重试',
   logoutGroupTitle: '登录',
   logoutGroupHint: '退出后回到登录页，可换一个账户登录。本机的项目与文件保留在原处。',
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2613,6 +2613,24 @@ export function updateTelemetrySettings(payload) {
   })
 }
 
+// 文档 Generator 元数据开关（可溯源性设计规范附录 B4）。GET 同时下发 application——
+// 要写进 docProps/app.xml 的那个串由后端从 ProductIdentity 派生，前端不许自己拼版本号。
+export function getDocumentGeneratorSettings() {
+  return request({
+    url: '/api/document/generator/settings',
+    method: 'GET'
+  })
+}
+
+export function updateDocumentGeneratorSettings(payload) {
+  return request({
+    url: '/api/document/generator/settings',
+    method: 'PUT',
+    data: payload,
+    header: { 'Content-Type': 'application/json' }
+  })
+}
+
 export function getTelemetrySummary(days = 30) {
   return request({
     url: `/api/telemetry/summary?days=${days}`,

--- a/frontend/src/utils/documentGeneratorSetting.js
+++ b/frontend/src/utils/documentGeneratorSetting.js
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { getDocumentGeneratorSettings } from '@/services/api.js'
+
+/**
+ * 「保存时要不要给文档打产品标识」的一次性缓存（可溯源性设计规范附录 B4）。
+ *
+ * 保活池里同时活着好几个 LibreOfficeEditor 实例，每一次自动保存都要问一次开关，
+ * 所以缓存放在模块级、按整个会话只拉一次。
+ *
+ * 读不到就当**关**（返回 null，不打标、不报错）：这是保存链路，宁可少一个可选的
+ * 元数据字段，也不能因为一个设置项读不到就让保存报错或卡住。**只有读成功才入缓存**
+ * ——后端刚起来的那几秒读不到是常态，缓存住的话这一整个会话都不再打标了。
+ */
+let cachedPromise = null
+
+/** @returns {Promise<string|null>} 要写的 Application 串；null = 不打标 */
+export function documentStampApplication() {
+  if (cachedPromise) return cachedPromise
+  const p = (async () => {
+    const res = await getDocumentGeneratorSettings()
+    if (!res || res.code !== 0) throw new Error('document generator settings unavailable')
+    if (!res.enabled) return null
+    const app = typeof res.application === 'string' ? res.application.trim() : ''
+    return app || null
+  })().catch(() => {
+    if (cachedPromise === p) cachedPromise = null // 读失败不入缓存，下次保存再试
+    return null
+  })
+  cachedPromise = p
+  return p
+}
+
+/** 设置页改完开关后调用，让下一次保存重新问一次。 */
+export function resetDocumentStampCache() {
+  cachedPromise = null
+}

--- a/frontend/src/utils/docxAppProps.js
+++ b/frontend/src/utils/docxAppProps.js
@@ -92,6 +92,7 @@ function readCentral(b) {
   if (eocdAt >= 20 && u32(b, eocdAt - 20) === ZIP64_LOCATOR_SIG) return null
 
   const entries = []
+  const seen = new Set()
   let p = cdOffset
   const dec = new TextDecoder('utf-8')
   for (let i = 0; i < total; i++) {
@@ -107,8 +108,13 @@ function readCentral(b) {
     const localOffset = u32(b, p + 42)
     if (compSize === U32_MAX || uncompSize === U32_MAX || localOffset === U32_MAX) return null
     if (localOffset >= cdOffset) return null
+    const name = dec.decode(b.subarray(p + 46, p + 46 + nameLen))
+    // 重名条目：下面的偏移表按名字建键，重名会让两条中央目录指到同一个新偏移。
+    // OOXML 不允许重名，引擎也不会产出，遇到就整体放弃打标。
+    if (seen.has(name)) return null
+    seen.add(name)
     entries.push({
-      name: dec.decode(b.subarray(p + 46, p + 46 + nameLen)),
+      name,
       method: u16(b, p + 10),
       compSize,
       localOffset,

--- a/frontend/src/utils/docxAppProps.js
+++ b/frontend/src/utils/docxAppProps.js
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * 给编辑器导出的 OOXML 字节打产品标识（可溯源性设计规范附录 B4）。
+ *
+ * 为什么在宿主侧做 zip 定点补丁，而不是让引擎写：真机探针实测（2026-09-09，
+ * 引擎 24.2.8-zhcn-r4）——
+ *   · `xModel.getDocumentProperties()` 上根本没有 setGenerator/getGenerator 方法
+ *     （zetajs 把 XDocumentProperties 的 Generator 暴露成属性）；
+ *   · 属性写法 `dp.Generator = 'AI WorkDeck 0.36.0'` **写得进也读得回**，但导出件的
+ *     `docProps/app.xml` 里 `<Application>` 纹丝不动，仍是
+ *     `ZetaOffice/24.2.8.0.beta1$Emscripten_x86 LibreOffice_project/<buildid>`；
+ *   · `UserDefinedProperties.addProperty('Application', ...)` 只会多出一个
+ *     `docProps/custom.xml`，标准的 `<Application>` 字段照旧不受影响。
+ * 也就是说 oox 导出器把 Application 硬写成 `utl::DocInfoHelper::GetGeneratorString()`，
+ * UNO API 够不着。要写只能在拿到字节之后改。
+ *
+ * 为什么是 async：引擎导出的每个条目都是 DEFLATE（真机实测 method=8、flag=0x0808，
+ * 即带 data descriptor + UTF-8 名），要改 app.xml 的文字就得先解压。解压走浏览器/Node
+ * 自带的 `DecompressionStream('deflate-raw')`（Chrome 103+ / Node 20+），是异步流 API；
+ * 不引 jszip 之类的库——那会把整包重新压一遍，大文档在保存路径上不可接受。
+ * 新写回的 app.xml 用 STORED（不压缩），省掉一次压缩、也省掉压缩参数的不确定性。
+ *
+ * 红线：**保存链路是数据安全红线**。这个函数宁可不打标，也绝不许弄坏用户的文件——
+ * 任何一步不如预期（不是 zip、找不到 EOCD、ZIP64、没有 app.xml、解析抛异常、
+ * 自检不过）一律原样返回输入字节。除 `docProps/app.xml` 外的每一个条目，其本地头
+ * 与数据都逐字节原样拷贝（不重新压缩），只重写中央目录里的偏移量。
+ */
+
+const LOCAL_SIG = 0x04034b50
+const CENTRAL_SIG = 0x02014b50
+const EOCD_SIG = 0x06054b50
+const ZIP64_LOCATOR_SIG = 0x07064b50
+const APP_XML = 'docProps/app.xml'
+const U32_MAX = 0xffffffff
+
+// ---------------------------------------------------------------- CRC-32
+let CRC_TABLE = null
+function crcTable() {
+  if (CRC_TABLE) return CRC_TABLE
+  const t = new Int32Array(256)
+  for (let i = 0; i < 256; i++) {
+    let c = i
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    t[i] = c
+  }
+  CRC_TABLE = t
+  return t
+}
+function crc32(u8) {
+  const t = crcTable()
+  let c = -1
+  for (let i = 0; i < u8.length; i++) c = t[(c ^ u8[i]) & 0xff] ^ (c >>> 8)
+  return (c ^ -1) >>> 0
+}
+
+// ---------------------------------------------------------------- 读写小工具
+const u16 = (b, o) => b[o] | (b[o + 1] << 8)
+const u32 = (b, o) => ((b[o] | (b[o + 1] << 8) | (b[o + 2] << 16)) + b[o + 3] * 0x1000000) >>> 0
+function putU16(b, o, v) { b[o] = v & 0xff; b[o + 1] = (v >>> 8) & 0xff }
+function putU32(b, o, v) {
+  b[o] = v & 0xff; b[o + 1] = (v >>> 8) & 0xff
+  b[o + 2] = (v >>> 16) & 0xff; b[o + 3] = (v >>> 24) & 0xff
+}
+
+/** EOCD 起点；找不到返回 -1。zip 注释最长 65535，所以只回扫 65557 字节。 */
+function findEocd(b) {
+  const min = Math.max(0, b.length - 65557)
+  for (let i = b.length - 22; i >= min; i--) {
+    if (u32(b, i) === EOCD_SIG) return i
+  }
+  return -1
+}
+
+/**
+ * 解析中央目录。任何不支持的形态（ZIP64、多卷、条目数超 16 位）返回 null。
+ * 返回 { entries, cdOffset, cdSize, eocdAt, comment }，entries 按中央目录原序。
+ */
+function readCentral(b) {
+  const eocdAt = findEocd(b)
+  if (eocdAt < 0) return null
+  if (u16(b, eocdAt + 4) !== 0 || u16(b, eocdAt + 6) !== 0) return null // 多卷
+  const total = u16(b, eocdAt + 10)
+  if (u16(b, eocdAt + 8) !== total) return null
+  if (total === 0 || total === 0xffff) return null // 0xffff 只可能是 ZIP64
+  const cdSize = u32(b, eocdAt + 12)
+  const cdOffset = u32(b, eocdAt + 16)
+  if (cdSize === U32_MAX || cdOffset === U32_MAX) return null
+  if (cdOffset + cdSize > b.length) return null
+  // ZIP64 end-of-central-directory locator 紧挨在 EOCD 之前
+  if (eocdAt >= 20 && u32(b, eocdAt - 20) === ZIP64_LOCATOR_SIG) return null
+
+  const entries = []
+  let p = cdOffset
+  const dec = new TextDecoder('utf-8')
+  for (let i = 0; i < total; i++) {
+    if (p + 46 > cdOffset + cdSize) return null
+    if (u32(b, p) !== CENTRAL_SIG) return null
+    const nameLen = u16(b, p + 28)
+    const extraLen = u16(b, p + 30)
+    const commentLen = u16(b, p + 32)
+    const headLen = 46 + nameLen + extraLen + commentLen
+    if (p + headLen > cdOffset + cdSize) return null
+    const compSize = u32(b, p + 20)
+    const uncompSize = u32(b, p + 24)
+    const localOffset = u32(b, p + 42)
+    if (compSize === U32_MAX || uncompSize === U32_MAX || localOffset === U32_MAX) return null
+    if (localOffset >= cdOffset) return null
+    entries.push({
+      name: dec.decode(b.subarray(p + 46, p + 46 + nameLen)),
+      method: u16(b, p + 10),
+      compSize,
+      localOffset,
+      centralAt: p,
+      centralLen: headLen,
+    })
+    p += headLen
+  }
+  if (p !== cdOffset + cdSize) return null
+  const comment = b.subarray(eocdAt + 22, eocdAt + 22 + u16(b, eocdAt + 20))
+  if (eocdAt + 22 + comment.length !== b.length) return null
+  return { entries, cdOffset, cdSize, eocdAt, comment }
+}
+
+/**
+ * 每个条目在文件里占的区间 [start, end)：按本地头偏移排序，下一条的起点即本条的终点，
+ * 最后一条到中央目录起点为止。这样连 data descriptor、对齐填充都原样带过去，
+ * 不需要去猜本地头里那些可能与中央目录不一致的长度字段。
+ */
+function regionsOf(entries, cdOffset, b) {
+  const sorted = entries.slice().sort((x, y) => x.localOffset - y.localOffset)
+  for (let i = 0; i < sorted.length; i++) {
+    const start = sorted[i].localOffset
+    const end = i + 1 < sorted.length ? sorted[i + 1].localOffset : cdOffset
+    if (end <= start) return null
+    if (u32(b, start) !== LOCAL_SIG) return null
+    sorted[i].start = start
+    sorted[i].end = end
+  }
+  return sorted
+}
+
+// ---------------------------------------------------------------- app.xml 改写
+function xmlEscape(s) {
+  return String(s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** 只换 <Application> 的文字；文件里没有这个元素就返回 null（此时整体放弃打标）。 */
+function rewriteAppXml(text, application) {
+  const re = /<Application>[\s\S]*?<\/Application>/
+  if (!re.test(text)) return null
+  return text.replace(re, '<Application>' + xmlEscape(application) + '</Application>')
+}
+
+// ---------------------------------------------------------------- 主函数
+/**
+ * 把 OOXML（docx/xlsx/pptx）字节里的 docProps/app.xml 的 `<Application>` 换成
+ * `application`，其余条目逐字节原样保留。
+ *
+ * @param {Uint8Array} bytes 原始 zip 字节
+ * @param {string} application 形如 `AI WorkDeck 0.36.0`
+ * @returns {Promise<Uint8Array>} 打过标的新字节；任何一步不满足就是**原样的入参**
+ */
+export async function stampApplication(bytes, application) {
+  try {
+    if (!(bytes instanceof Uint8Array) || bytes.length < 22) return bytes
+    if (typeof application !== 'string' || !application.trim()) return bytes
+    if (bytes[0] !== 0x50 || bytes[1] !== 0x4b) return bytes // 'PK'
+
+    const cd = readCentral(bytes)
+    if (!cd) return bytes
+    const target = cd.entries.find((e) => e.name === APP_XML)
+    if (!target) return bytes
+
+    const regions = regionsOf(cd.entries, cd.cdOffset, bytes)
+    if (!regions) return bytes
+
+    const appText = await readEntryText(bytes, target)
+    if (appText == null) return bytes
+    const newText = rewriteAppXml(appText, application)
+    if (newText == null) return bytes
+    const newData = new TextEncoder().encode(newText)
+    const nameBytes = new TextEncoder().encode(APP_XML)
+    const newCrc = crc32(newData)
+
+    // ---- 拼新文件：本地条目按原文件顺序，app.xml 换成自造的 STORED 条目
+    const parts = []
+    let offset = 0
+    const newOffsets = new Map()
+    for (const e of regions) {
+      newOffsets.set(e.name, offset)
+      if (e.name === APP_XML) {
+        const lh = new Uint8Array(30 + nameBytes.length)
+        putU32(lh, 0, LOCAL_SIG)
+        putU16(lh, 4, 20)          // version needed
+        putU16(lh, 6, 0)           // flags：清掉 data descriptor / UTF-8 位（名字是纯 ASCII）
+        putU16(lh, 8, 0)           // method = stored
+        putU16(lh, 10, u16(bytes, e.localOffset + 10)) // mod time 沿用原值
+        putU16(lh, 12, u16(bytes, e.localOffset + 12)) // mod date 沿用原值
+        putU32(lh, 14, newCrc)
+        putU32(lh, 18, newData.length)
+        putU32(lh, 22, newData.length)
+        putU16(lh, 26, nameBytes.length)
+        putU16(lh, 28, 0)          // extra len
+        lh.set(nameBytes, 30)
+        parts.push(lh, newData)
+        offset += lh.length + newData.length
+      } else {
+        const region = bytes.subarray(e.start, e.end)
+        parts.push(region)
+        offset += region.length
+      }
+    }
+
+    // ---- 中央目录：原序、原字节，只改偏移；app.xml 那条重建
+    const newCdOffset = offset
+    for (const e of cd.entries) {
+      const newOff = newOffsets.get(e.name)
+      if (newOff === undefined) return bytes
+      if (e.name === APP_XML) {
+        const ch = new Uint8Array(46 + nameBytes.length)
+        const src = e.centralAt
+        putU32(ch, 0, CENTRAL_SIG)
+        putU16(ch, 4, u16(bytes, src + 4))   // version made by
+        putU16(ch, 6, 20)                    // version needed
+        putU16(ch, 8, 0)                     // flags
+        putU16(ch, 10, 0)                    // method = stored
+        putU16(ch, 12, u16(bytes, src + 12)) // mod time
+        putU16(ch, 14, u16(bytes, src + 14)) // mod date
+        putU32(ch, 16, newCrc)
+        putU32(ch, 20, newData.length)
+        putU32(ch, 24, newData.length)
+        putU16(ch, 28, nameBytes.length)
+        putU16(ch, 30, 0)                    // extra len
+        putU16(ch, 32, 0)                    // comment len
+        putU16(ch, 34, 0)                    // disk start
+        putU16(ch, 36, u16(bytes, src + 36)) // internal attrs
+        putU32(ch, 38, u32(bytes, src + 38)) // external attrs
+        putU32(ch, 42, newOff)
+        ch.set(nameBytes, 46)
+        parts.push(ch)
+        offset += ch.length
+      } else {
+        const ch = bytes.slice(e.centralAt, e.centralAt + e.centralLen)
+        putU32(ch, 42, newOff)
+        parts.push(ch)
+        offset += ch.length
+      }
+    }
+    const newCdSize = offset - newCdOffset
+
+    const eocd = new Uint8Array(22 + cd.comment.length)
+    putU32(eocd, 0, EOCD_SIG)
+    putU16(eocd, 8, cd.entries.length)
+    putU16(eocd, 10, cd.entries.length)
+    putU32(eocd, 12, newCdSize)
+    putU32(eocd, 16, newCdOffset)
+    putU16(eocd, 20, cd.comment.length)
+    eocd.set(cd.comment, 22)
+    parts.push(eocd)
+    offset += eocd.length
+    if (offset > U32_MAX) return bytes
+
+    const out = new Uint8Array(offset)
+    let at = 0
+    for (const part of parts) { out.set(part, at); at += part.length }
+
+    // ---- 自检：把自己的产物再解析一遍，任何一条对不上就退回原件
+    const verify = readCentral(out)
+    if (!verify) return bytes
+    if (verify.entries.length !== cd.entries.length) return bytes
+    if (verify.entries.map((e) => e.name).join('\n') !== cd.entries.map((e) => e.name).join('\n')) return bytes
+    if (!regionsOf(verify.entries, verify.cdOffset, out)) return bytes
+    const back = verify.entries.find((e) => e.name === APP_XML)
+    if (!back || back.method !== 0) return bytes
+    if ((await readEntryText(out, back)) !== newText) return bytes
+    // 未改动的条目：数据区必须与原件逐字节相等
+    for (const e of cd.entries) {
+      if (e.name === APP_XML) continue
+      const b2 = verify.entries.find((x) => x.name === e.name)
+      const src = regions.find((x) => x.name === e.name)
+      if (!b2 || !src) return bytes
+      const len = src.end - src.start
+      if (!sameBytes(bytes, src.start, out, b2.localOffset, len)) return bytes
+    }
+    return out
+  } catch (e) {
+    return bytes
+  }
+}
+
+/** 条目的原始数据区（本地头之后、compSize 长）；越界返回 null。 */
+function rawDataOf(b, entry) {
+  const lo = entry.localOffset
+  if (lo + 30 > b.length) return null
+  if (u32(b, lo) !== LOCAL_SIG) return null
+  const start = lo + 30 + u16(b, lo + 26) + u16(b, lo + 28)
+  const end = start + entry.compSize
+  if (end > b.length) return null
+  return b.subarray(start, end)
+}
+
+/** 取条目的 UTF-8 文本；只支持 STORED(0) 与 DEFLATE(8)，其余（含加密）返回 null。 */
+async function readEntryText(b, entry) {
+  const raw = rawDataOf(b, entry)
+  if (!raw) return null
+  if (entry.method === 0) return new TextDecoder('utf-8').decode(raw)
+  if (entry.method !== 8) return null
+  if (typeof DecompressionStream !== 'function') return null
+  try {
+    const ds = new DecompressionStream('deflate-raw')
+    const stream = new Blob([raw]).stream().pipeThrough(ds)
+    const buf = new Uint8Array(await new Response(stream).arrayBuffer())
+    return new TextDecoder('utf-8').decode(buf)
+  } catch (e) {
+    return null
+  }
+}
+
+function sameBytes(a, aOff, b, bOff, len) {
+  if (aOff + len > a.length || bOff + len > b.length) return false
+  for (let i = 0; i < len; i++) if (a[aOff + i] !== b[bOff + i]) return false
+  return true
+}

--- a/frontend/tests/lowa-e2e/run.mjs
+++ b/frontend/tests/lowa-e2e/run.mjs
@@ -32,6 +32,10 @@ import { here, preflight, loadPuppeteer, startServer, launchBrowser, openEditor 
 // 证明「引擎给的串 → 面板显示的类型」「引擎给的坐标 → 批注挂到哪条修订」这两段
 // 映射在真数据上成立——单测里用的是手写夹具，只有这里能验夹具本身没编错。
 import { revisionTypeKey, linkCommentsToRevisions } from '../../src/utils/reviewGrouping.js'
+// B4：宿主保存路径给导出件打的产品标识（可溯源性设计规范附录 B4）。这里用真引擎的
+// 导出字节喂真函数，再让引擎把打完标的文件重新打开——纯函数的单测在
+// tests/lowa-unit/docxAppProps.test.mjs，这里补的是「真产物 + 真引擎回读」那一段。
+import { stampApplication } from '../../src/utils/docxAppProps.js'
 
 // ---------- preflight ----------
 preflight()
@@ -2329,6 +2333,40 @@ try {
     check('最终稿导出件的 settings.xml 里没有 w:revisionView',
       marksFinal.settings.indexOf('revisionView') < 0, marksFinal.settings.slice(0, 300))
     await exec('set_revision_view', { mode: 'all' })
+
+    // ---- 第 5 项：B4 产品标识（真引擎导出件 → 真 stampApplication → 引擎回读）----
+    // 覆盖边界：lowa-e2e 跑的是 dist/zetaoffice 的 editor-main.js（客体页），打标发生在
+    // Vue 宿主 LibreOfficeEditor.saveDocument 里，这条链路经不过来。所以这里断言的是
+    //「真引擎导出的字节喂给真函数之后，app.xml 对了、引擎还能原样打开」；
+    // 宿主的接线由 tests/project-home/libre-save-generator-stamp.test.mjs 守。
+    await exec('debug_fresh_document', { visible: true })
+    await exec('debug_set_record_changes', { on: false })
+    await exec('ui_command', { name: 'select_all' })
+    await exec('replace_selection', { text: '产品标识回读用的正文。' })
+    const rawExport = await exportBytes()
+    const rawU8 = Uint8Array.from(rawExport.map((b) => b & 0xff))
+    const rawZip = await JSZip.loadAsync(Buffer.from(rawU8))
+    const rawApp = await rawZip.file('docProps/app.xml').async('string')
+    check('基线：引擎自己写的 Application 是 ZetaOffice/LibreOffice',
+      /<Application>[^<]*(ZetaOffice|LibreOffice)[^<]*<\/Application>/.test(rawApp), rawApp.slice(0, 300))
+
+    const APP_STR = 'AI WorkDeck 0.0.0-e2e'
+    const stampedU8 = await stampApplication(rawU8, APP_STR)
+    check('stampApplication 产出了新字节', stampedU8 !== rawU8 && stampedU8.length > 0)
+    const stampedZip = await JSZip.loadAsync(Buffer.from(stampedU8), { checkCRC32: true })
+    const stampedApp = await stampedZip.file('docProps/app.xml').async('string')
+    check('打标后 app.xml 的 Application 是 AI WorkDeck',
+      stampedApp.indexOf('<Application>' + APP_STR + '</Application>') >= 0, stampedApp.slice(0, 300))
+    check('打标只动 app.xml：word/document.xml 逐字节不变',
+      Buffer.compare(
+        await rawZip.file('word/document.xml').async('nodebuffer'),
+        await stampedZip.file('word/document.xml').async('nodebuffer')) === 0)
+
+    const reload = await exec('load_document',
+      { bytes: Array.from(stampedU8), name: 'stamped.docx', authorName: '测试用户' })
+    check('引擎能重新打开打过标的 docx', reload && reload.success === true, JSON.stringify(reload))
+    const stampedBody = (await exec('get_document_text')).paragraphs.map((x) => x.text).join('|')
+    check('打标后正文一字不差', stampedBody === '产品标识回读用的正文。', stampedBody)
   }
 
   // ---- 组 33：审阅窗格的作者/类型/理由三维度（dev-board#377）----------------

--- a/frontend/tests/lowa-unit/docxAppProps.test.mjs
+++ b/frontend/tests/lowa-unit/docxAppProps.test.mjs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// docxAppProps.stampApplication 的契约（可溯源性设计规范附录 B4）：
+//   ① docProps/app.xml 的 <Application> 换成给定的串；
+//   ② 其余条目**逐个**解出来与原件字节相等（这条是数据安全红线：保存链路上
+//      弄坏用户文档比不打标严重得多）；
+//   ③ 任何坏输入原样返回入参（同一个对象引用，证明连拷贝都没做）。
+// 夹具用 lowa-e2e 的两份真 OOXML（docx 与 pptx），不手搓 zip。
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import JSZip from 'jszip'
+import { stampApplication } from '../../src/utils/docxAppProps.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const fixture = (n) => new Uint8Array(fs.readFileSync(path.join(here, '../lowa-e2e/fixtures', n)))
+const APP = 'AI WorkDeck 9.9.9'
+
+// flexmark-table.docx 的 app.xml 是 docx4j 出的空壳（自闭合 <properties:Properties/>，
+// 里面根本没有 <Application> 元素）。本函数的契约是**只替换不插入**——碰不到元素就
+// 原样返回，这条单独断言（见末尾用例）。docx 这一侧的正例用它当底座、把 Application
+// 补进去再重新打包（jszip 出的包没有 data descriptor，与引擎导出的形态互补）。
+async function docxWithApplication() {
+  const zip = await JSZip.loadAsync(Buffer.from(fixture('flexmark-table.docx')))
+  zip.file('docProps/app.xml',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+    + '<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">'
+    + '<Template></Template><TotalTime>0</TotalTime>'
+    + '<Application>ZetaOffice/24.2.8.0.beta1$Emscripten_x86 LibreOffice_project/dced3bc</Application>'
+    + '<AppVersion>15.0000</AppVersion><Pages>1</Pages><Words>7</Words></Properties>')
+  return new Uint8Array(await zip.generateAsync({ type: 'uint8array' }))
+}
+
+async function entriesOf(bytes) {
+  const zip = await JSZip.loadAsync(Buffer.from(bytes))
+  const out = new Map()
+  for (const name of Object.keys(zip.files)) {
+    if (zip.files[name].dir) continue
+    out.set(name, new Uint8Array(await zip.files[name].async('uint8array')))
+  }
+  return out
+}
+
+const SOURCES = [
+  ['docx（补了 Application 的 flexmark-table）', docxWithApplication],
+  ['pptx（impress-smoke，原件带 Microsoft PowerPoint 的 Application）', async () => fixture('impress-smoke.pptx')],
+]
+
+for (const [name, load] of SOURCES) {
+  test(name + '：只有 app.xml 变，其余条目内容逐字节相等', async () => {
+    const input = await load()
+    const before = await entriesOf(input)
+    assert.ok(before.has('docProps/app.xml'), '夹具本身要带 docProps/app.xml')
+
+    const out = await stampApplication(input, APP)
+    assert.notEqual(out, input, '应该产出了新字节')
+
+    const after = await entriesOf(out)
+    assert.deepEqual([...after.keys()].sort(), [...before.keys()].sort(), '条目名单不许变')
+
+    for (const [k, v] of before) {
+      if (k === 'docProps/app.xml') continue
+      assert.deepEqual(after.get(k), v, '未改动条目的内容必须逐字节相等: ' + k)
+    }
+
+    const appXml = new TextDecoder().decode(after.get('docProps/app.xml'))
+    assert.match(appXml, new RegExp('<Application>' + APP + '</Application>'))
+    assert.equal((appXml.match(/<Application>/g) || []).length, 1, '只能有一个 Application 元素')
+    // 统计字段等其余内容原样保留（Word 的「属性」面板要用）
+    const oldXml = new TextDecoder().decode(before.get('docProps/app.xml'))
+    const strip = (s) => s.replace(/<Application>[\s\S]*?<\/Application>/, '')
+    assert.equal(strip(appXml), strip(oldXml), 'app.xml 里除 Application 外一个字符都不该动')
+  })
+
+  test(name + '：产出件的 CRC 与结构自洽（jszip 能无警告解开）', async () => {
+    const out = await stampApplication(await load(), APP)
+    // jszip 默认按 CRC 校验；checkCRC32 显式打开，坏 CRC 会抛
+    const zip = await JSZip.loadAsync(Buffer.from(out), { checkCRC32: true })
+    assert.ok(zip.file('docProps/app.xml'))
+  })
+}
+
+test('幂等：对已打过标的字节再打一次，结果仍只有一个 Application 且可解', async () => {
+  const once = await stampApplication(await docxWithApplication(), APP)
+  const twice = await stampApplication(once, APP)
+  const after = await entriesOf(twice)
+  const appXml = new TextDecoder().decode(after.get('docProps/app.xml'))
+  assert.equal((appXml.match(/<Application>/g) || []).length, 1)
+  assert.match(appXml, new RegExp('<Application>' + APP + '</Application>'))
+})
+
+test('XML 特殊字符被转义', async () => {
+  const out = await stampApplication(await docxWithApplication(), 'A & B <x> 1.0')
+  const after = await entriesOf(out)
+  const appXml = new TextDecoder().decode(after.get('docProps/app.xml'))
+  assert.match(appXml, /<Application>A &amp; B &lt;x&gt; 1\.0<\/Application>/)
+})
+
+test('坏输入一律原样返回入参对象本身', async () => {
+  const good = await docxWithApplication()
+  const cases = [
+    ['非 zip（不以 PK 开头）', new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3])],
+    ['太短', new Uint8Array([0x50, 0x4b, 3, 4])],
+    ['空数组', new Uint8Array(0)],
+    ['PK 开头但没有 EOCD', (() => { const b = new Uint8Array(200); b[0] = 0x50; b[1] = 0x4b; return b })()],
+    ['尾部被截断（EOCD 指向的中央目录越界）', good.slice(0, good.length - 40)],
+  ]
+  for (const [label, input] of cases) {
+    const out = await stampApplication(input, APP)
+    assert.equal(out, input, label + ' 应原样返回入参')
+  }
+  // application 串本身不合法
+  for (const bad of [null, undefined, '', '   ', 42]) {
+    assert.equal(await stampApplication(good, bad), good, 'application=' + String(bad) + ' 应原样返回')
+  }
+  // 不是 Uint8Array
+  const buf = Buffer.from(good) // Buffer 是 Uint8Array 子类，仍应正常处理
+  assert.notEqual(await stampApplication(buf, APP), buf)
+  const arr = Array.from(good.slice(0, 30))
+  assert.equal(await stampApplication(arr, APP), arr, '普通数组应原样返回')
+})
+
+test('没有 docProps/app.xml 的 zip 原样返回', async () => {
+  const zip = new JSZip()
+  zip.file('hello.txt', 'hi')
+  const bytes = new Uint8Array(await zip.generateAsync({ type: 'uint8array' }))
+  assert.equal(await stampApplication(bytes, APP), bytes)
+})
+
+test('app.xml 里没有 <Application> 元素时原样返回（只替换，不插入）', async () => {
+  const raw = fixture('flexmark-table.docx')
+  assert.doesNotMatch(
+    new TextDecoder().decode((await entriesOf(raw)).get('docProps/app.xml')),
+    /<Application>/,
+    '夹具前提：这份 docx 的 app.xml 里确实没有 Application 元素')
+  assert.equal(await stampApplication(raw, APP), raw)
+})
+
+test('中央目录被人为改坏时原样返回（自检兜底）', async () => {
+  const good = await docxWithApplication()
+  const broken = good.slice()
+  // 把第一个中央目录条目的签名打掉：readCentral 会拒绝
+  const eocdAt = (() => {
+    for (let i = broken.length - 22; i >= 0; i--) {
+      if (broken[i] === 0x50 && broken[i + 1] === 0x4b && broken[i + 2] === 5 && broken[i + 3] === 6) return i
+    }
+    return -1
+  })()
+  assert.ok(eocdAt > 0, '夹具里应能找到 EOCD')
+  const cdOffset = broken[eocdAt + 16] | (broken[eocdAt + 17] << 8) | (broken[eocdAt + 18] << 16) | (broken[eocdAt + 19] * 0x1000000)
+  broken[cdOffset] = 0x00
+  assert.equal(await stampApplication(broken, APP), broken)
+})

--- a/frontend/tests/project-home/libre-save-generator-stamp.test.mjs
+++ b/frontend/tests/project-home/libre-save-generator-stamp.test.mjs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// B4 的接线用例：LibreOfficeEditor 的保存路径必须「导出 → 打标 → 上传」这个次序，
+// 上传出去的是**打过标的**字节，不是导出的原字节。
+//
+// 为什么必须有这一条：lowa-e2e 跑的是 dist/zetaoffice 的 editor-main.js（客体页），
+// 打标发生在 Vue 宿主的 saveDocument 里，e2e 那条链路根本经不过来——纯函数由
+// tests/lowa-unit/docxAppProps.test.mjs 守，接线只能在这里守。
+// 还原病灶（把 saveDocument 里的 stampGeneratorMetadata 一行删掉）本文件即转红。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(new URL('../../src/components/LibreOfficeEditor.vue', import.meta.url), 'utf8')
+const BODY = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
+  .replace(/^import .*$/gm, '').replace(/export default \{/, 'return {')
+
+/**
+ * @param stamp  桩掉的 stampApplication（(bytes, app) => bytes'）
+ * @param appOf  桩掉的 documentStampApplication（() => Promise<string|null>）
+ */
+function makeVm({ stamp, appOf, exportBytes }) {
+  const uploads = []
+  const options = new Function(
+    'ReviewPanel', 'EditorToolbar', 'EvidenceStaleBar', 'getFileUploadUrl',
+    'stampApplication', 'documentStampApplication', BODY)(
+    null, null, null, (id) => '/upload/' + id, stamp, appOf)
+  const vm = {
+    ready: true, file: { id: 7, name: '合同.docx' }, statusKey: 'ready',
+    dirty: true, saving: false, _dirtySince: Date.now(),
+    appendLog() {}, scheduleAnchorCheck() {}, $t: (k) => k,
+    executor: { executeCommand: async () => ({ success: true, bytes: exportBytes }) },
+    uploadBytes: async (url, u8) => { uploads.push(u8) },
+  }
+  for (const [k, fn] of Object.entries(options.methods)) vm[k] = fn.bind(vm)
+  Object.assign(vm, { appendLog() {}, scheduleAnchorCheck() {} })
+  vm.uploadBytes = async (url, u8) => { uploads.push(u8) }
+  return { vm, uploads }
+}
+
+test('开关开着：上传的是打过标的字节，且 application 串来自后端下发的值', async () => {
+  const calls = []
+  const { vm, uploads } = makeVm({
+    exportBytes: [1, 2, 3, 4],
+    appOf: async () => 'AI WorkDeck 0.36.0',
+    stamp: async (bytes, app) => { calls.push([Array.from(bytes), app]); return new Uint8Array([9, 9]) },
+  })
+  assert.equal(await vm.saveDocument(), true)
+  assert.equal(calls.length, 1, 'stampApplication 必须被调用一次')
+  assert.deepEqual(calls[0][0], [1, 2, 3, 4], '喂给打标的必须是导出的原字节')
+  assert.equal(calls[0][1], 'AI WorkDeck 0.36.0', '串必须是后端给的，不许前端自己拼')
+  assert.equal(uploads.length, 1)
+  assert.deepEqual(Array.from(uploads[0]), [9, 9], '上传出去的必须是打标后的字节')
+})
+
+test('开关关着：一次 stampApplication 都不调，上传导出原字节', async () => {
+  let stamped = 0
+  const { vm, uploads } = makeVm({
+    exportBytes: [1, 2, 3, 4],
+    appOf: async () => null,
+    stamp: async (bytes) => { stamped++; return bytes },
+  })
+  assert.equal(await vm.saveDocument(), true)
+  assert.equal(stamped, 0)
+  assert.deepEqual(Array.from(uploads[0]), [1, 2, 3, 4])
+})
+
+test('打标抛异常不许影响保存：照旧上传导出原字节并成功', async () => {
+  const { vm, uploads } = makeVm({
+    exportBytes: [5, 6, 7],
+    appOf: async () => 'AI WorkDeck 0.36.0',
+    stamp: async () => { throw new Error('zip parse blew up') },
+  })
+  assert.equal(await vm.saveDocument(), true)
+  assert.equal(vm.statusKey, 'ready')
+  assert.deepEqual(Array.from(uploads[0]), [5, 6, 7])
+})
+
+test('开关读不到（documentStampApplication 抛）也不许影响保存', async () => {
+  const { vm, uploads } = makeVm({
+    exportBytes: [5, 6, 7],
+    appOf: async () => { throw new Error('backend down') },
+    stamp: async () => new Uint8Array([0]),
+  })
+  assert.equal(await vm.saveDocument(), true)
+  assert.deepEqual(Array.from(uploads[0]), [5, 6, 7])
+})
+
+test('打标返回空字节时退回导出原字节（绝不上传空文件）', async () => {
+  const { vm, uploads } = makeVm({
+    exportBytes: [5, 6, 7],
+    appOf: async () => 'AI WorkDeck 0.36.0',
+    stamp: async () => new Uint8Array(0),
+  })
+  assert.equal(await vm.saveDocument(), true)
+  assert.deepEqual(Array.from(uploads[0]), [5, 6, 7])
+})

--- a/frontend/tests/project-home/libre-save-recovery.test.mjs
+++ b/frontend/tests/project-home/libre-save-recovery.test.mjs
@@ -9,7 +9,12 @@ const source = readFileSync(new URL('../../src/components/LibreOfficeEditor.vue'
 const body = source.match(/<script>([\s\S]*?)<\/script>/)[1]
   .replace(/^import .*$/gm, '').replace(/export default \{/, 'return {')
 function makeVm(extra = {}) {
-  const options = new Function('ReviewPanel', 'EditorToolbar', 'EvidenceStaleBar', 'getFileUploadUrl', body)(null, null, null, id => '/upload/' + id)
+  // stampApplication / documentStampApplication 是 B4 的打标链路，这里喂成「开关关着」，
+  // 保存行为与打标前完全一致；打标本身另有 libre-save-generator-stamp.test.mjs。
+  const options = new Function('ReviewPanel', 'EditorToolbar', 'EvidenceStaleBar', 'getFileUploadUrl',
+    'stampApplication', 'documentStampApplication', body)(
+    null, null, null, id => '/upload/' + id,
+    async (bytes) => bytes, async () => null)
   const vm = {
     ready: true, file: { id: 7, name: '证据清单.docx' }, statusKey: 'ready',
     dirty: true, saving: false, _dirtySince: Date.now(),

--- a/frontend/tests/project-home/personal-settings-reentrancy.test.mjs
+++ b/frontend/tests/project-home/personal-settings-reentrancy.test.mjs
@@ -16,6 +16,9 @@ const SRC = readFileSync(
 function makeVm(deps, uniStub) {
   const script = SRC.match(/<script>([\s\S]*?)<\/script>/)[1]
   const importRe = /import\s*\{([\s\S]*?)\}\s*from\s*'[^']+'\s*;?/g
+  // 默认导入（组件之类：import AwdSwitch from '@/components/AwdSwitch.vue'）也要剥掉，
+  // 否则 new Function 里留一行 import 就是「Cannot use import statement outside a module」。
+  const defaultImportRe = /import\s+([A-Za-z_$][\w$]*)\s+from\s*'[^']+'\s*;?/g
   const locals = []
   let m
   while ((m = importRe.exec(script)) !== null) {
@@ -25,10 +28,11 @@ function makeVm(deps, uniStub) {
       locals.push(/\sas\s/.test(t) ? t.split(/\s+as\s+/)[1].trim() : t)
     }
   }
+  while ((m = defaultImportRe.exec(script)) !== null) locals.push(m[1])
   const preamble = locals
     .map((n) => `const ${n} = deps[${JSON.stringify(n)}] || (() => { throw new Error('未打桩: ${n}') });`)
     .join('\n')
-  const body = script.replace(importRe, '').replace('export default', 'return')
+  const body = script.replace(importRe, '').replace(defaultImportRe, '').replace('export default', 'return')
   // eslint-disable-next-line no-new-func
   const component = new Function('deps', 'uni', preamble + '\n' + body)(deps, uniStub)
   const base = { $t: (k) => k }


### PR DESCRIPTION
可溯源性设计规范附录 B3（出站 UA 收敛）与 B4（文档 Generator 元数据）。dev-board#511（B4）、#512（B3）。

## B4：保存文档时写 Application = `AI WorkDeck <version>`
- 编辑器保存路径：真机探针实证 LOWA 引擎 API 改不到 `docProps/app.xml` 的 `<Application>`（`setGenerator` 不存在；`Generator` 属性写得进、导出件纹丝不动；UserDefinedProperties 只多出 custom.xml），所以在宿主侧 `LibreOfficeEditor.saveDocument` 导出后、上传前做 zip 定点补丁 `docxAppProps.stampApplication`：只换 app.xml 一个条目（STORED + 自算 CRC32），其余条目逐字节原样拷贝、重写中央目录偏移；任何不如预期（非 zip / ZIP64 / 重名 / 无 app.xml / 自检不过）一律原样返回，零新依赖。
- 后端 POI 路径：`DocumentGeneratorStamp.apply` 一行接 SensitiveService / MeetingRecordingService / LitigationTimelineTools / DdExportService(xlsx) / DocumentEditTools(xlsx)。此前这些文件的 Application 是 POI 默认的「Apache POI」。
- 开关 `document.generator.enabled`（缺省开）+ `GET/PUT /api/document/generator/settings`；设置页「个人」组新增「文档属性」开关，zh-CN / en-US。只写产品名与版本，不写任何用户身份。
- docx4j 的两条后端路径（`doc_start_stream` 空白 docx、DdExportService 的 markdown→docx）未接，见 doc-editor.md 新增一节。

## B3：出站 UA 收敛到 `ProductIdentity.userAgent()`，格式 `AIWorkDeck/<version> (<component>)`
- 三处 Java 字面量（browser-proxy / capability-installer / ai-gateway）+ desktop 构建脚本（build-script，从 package.json 读版本）。
- 改前实测 12 个外部目标（OpenRouter models 与真 chat 调用、codeload 全量下载、api.github、qcc、pkulaw、gov.cn、wenshu、baidu、flk.npc、drawio 发布件）旧/新 UA 状态码与体积一致：无 UA 白名单。企查查 / Tushare 走 hutool 默认 UA、MCP 与平台网关不发 UA，本 PR 未动。
- `WebTools` / `CninfoAnnouncementService` 的浏览器伪装 UA 刻意保留（改了是功能改动），契约测试把它们列为白名单。
- 契约测试：`ProductIdentityTest`（格式 + 源码扫描字面量）、`desktop/tests/product-identity-ua.test.js`。

## 验证
- `mvn -B test`：3383 passed, 0 failed（JDK 21）
- `npm run test:lowa-e2e`（自建引擎 24.2.8-zhcn-r4）：547 passed, 0 failed（基线 541 + 6）
- `test:lowa-unit` 26 / `test:project-home` 426 / `test:commands` 21 / `check:locales` / `check:emits` / `check:nav:full` / `check-spdx` 全过；`desktop npm test` 100 例 99 过 1 跳过
- 还原病灶：删宿主打标行 → 接线用例转红；注释掉 SensitiveService 的 apply → 断言读回「Apache POI」转红；改回旧 UA 字面量 → 契约测试转红
- 真实导出件 `unzip -p out.docx docProps/app.xml` → `<Application>AI WorkDeck 0.36.0</Application>`，`unzip -t` 无错
- 未验证：Word / WPS 真机打开打标件；设置页开关真机点击

🤖 Generated with [Claude Code](https://claude.com/claude-code)
