### PR TITLE
chore(release): v0.37.0 全量发布 / full release

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
将桌面端版本升至 0.37.0，发布 v0.36.0 之后已合并的文件导入、文档与工作台修复、能力包、团队统计及组件许可更新。仅修改版本的单一来源 `desktop/package.json`；桌面壳与捆绑依赖有变更，按现行规则采用全量版本。

Bump the desktop version to 0.37.0 for the merged file-import, editor/workbench, capability-pack, team-statistics and bundled-license updates since v0.36.0. Only the canonical version field changes. Shell and bundled dependency changes require a full release.

验证 / Validation:
- JDK21 backend: 3388 tests, 0 failures/errors, 14 skipped; Linux production jar built.
- Desktop: 101 passed, 0 failed, 1 skipped. Frontend project-home 416/416, commands 21/21 and static gates/builds passed.
- App-e2e: 141 passed, 0 failed; J9/J10 file-ID assumption fixed separately in PR#768. English UI verified; the initially skipped tool-card check was subsequently verified with a real List files call after dragging the legacy Feedback overlay away (tracked separately as dev-board#522).
- LOWA real engine: 547 passed, 0 failed; en-US boot confirms ooLocale=en-US.
- Office/WPS: 307 tests passed; both macOS plugin installers notarized and Gatekeeper accepted; Windows plugin build succeeded.

Tracking: https://github.com/zeweihan/dev-board/issues/519
