### PR TITLE
fix(test): 本机文件编号兜底 / local file ID fallback in version e2e

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -209,6 +209,8 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
 | `npm run test:feedback-e2e` | frontend/ | 反馈浮窗全链路（dev Electron + CDP：真走主进程框选截图、Chromium 假麦克风录音、提交后从 API 回读附件字节）。需 dev:h5 + local-mode 后端，同 desktop-e2e 的端口约定 |
 | `npm run test:desktop-e2e` | frontend/ | 桌面保存链路（弹 dev Electron 窗口，webview 真 LOWA 插文本→保存→API 下载验内容；PR-A 后免登直达，provision 会自动用试用码解锁+置向导）。`APP_E2E_BACKEND` 的端口会经 `CHECKBA_BACKEND_PORT` 传给 Electron 壳——渲染层的基址是壳注入的，只改 `VITE_API_BASE_URL` 对它无效 |
 
+**app-e2e 文件编号（dev-board#521）**：`createFile` 新建的测试文件允许 `wpsFileId=null`；J9/J10 的字节覆盖助手必须与 J4/真实编辑器一致，用 `wpsFileId || id` 调上传端点。强制要求 `wpsFileId` 会让合法落盘文件被判不存在，随后 MODIFY、分稿与协作步骤连锁失败。
+
 每日全量 QA：`scripts/qa-nightly.sh`（crontab，跑在 ~/aiworkdeck-qa/repo 专用克隆，报告 ~/aiworkdeck-qa/reports/，失败 gh 开 issue 标签 qa-nightly，引擎取自已安装 app）。
 
 ## 端口体系（2026-08 起）

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -1402,19 +1402,20 @@ try {
   // MODIFY；FileTree 右键菜单也没有"替换/重新上传"这类入口（同名上传会被后端
   // ProjectFileService.createFile 的同名校验拒绝），UI 上真做不出一次 MODIFY。
   // 改用与 J6.5/J8 一致的裸 REST 手段：先正常上传一份测试文件并结束（ADD 落进
-  // 历史），再直接 POST 到同一个 wpsFileId 的上传端点覆盖字节（FileController
-  // .uploadFile 对已存在 wpsFileId 的裸覆盖上传和 UI 上传走的是同一段
-  // signalChange 逻辑，产生的是同一种真实变更信号，不是伪造断言）。
+  // 历史），再直接 POST 到同一个文件的上传端点覆盖字节（wpsFileId 为空时用数字 id；
+  // createFile 新建的本机文件允许无 wpsFileId，与 J4 和真实编辑器的兜底一致）。FileController
+  // .uploadFile 对已存在文件的覆盖写入走的是同一段
+  // signalChange 逻辑，产生的是同一种真实变更信号，不是伪造断言。
   await step('追加工作：上传单文件历史/MODIFY 测试用文件', () =>
     runWorkSession(versionFileC, 'qa-版本测试', '端到端测试稿三'))
 
   await step('REST 直传覆盖同一文件产生 MODIFY 变更', async () => {
     const list = await api('/api/projects/' + QA.projectId + '/files')
     const f = (Array.isArray(list) ? list : []).find((x) => x.name === 'qa-版本测试.txt')
-    if (!f || !f.wpsFileId) throw new Error('找不到 qa-版本测试.txt 或其 wpsFileId: ' + JSON.stringify(list).slice(0, 200))
+    if (!f || !f.id) throw new Error('找不到 qa-版本测试.txt 或其 id: ' + JSON.stringify(list).slice(0, 200))
     const form = new FormData()
     form.append('file', new Blob(['QA 版本记录旅程测试文件（已修改，用于 MODIFY 断言）\n'], { type: 'text/plain' }), 'qa-版本测试.txt')
-    const r = await fetch(BACKEND + '/api/files/' + f.wpsFileId + '/upload', {
+    const r = await fetch(BACKEND + '/api/files/' + (f.wpsFileId || f.id) + '/upload', {
       method: 'POST',
       headers: QA.sid ? { 'X-Session-Id': QA.sid } : {},
       body: form,
@@ -1534,22 +1535,22 @@ try {
   fs.writeFileSync(j10Base, 'QA J10 垫底文件内容\n')
   fs.writeFileSync(j10DraftOnly, 'QA J10 稿专属文件（只应在稿上看到）\n')
 
-  // 裸 REST 覆盖同一 wpsFileId 的字节——与 J9 造 MODIFY 同一手段，这里用来在两条线
+  // 裸 REST 覆盖同一文件的字节（wpsFileId 为空则用数字 id）——与 J9 造 MODIFY 同一手段，在两条线
   // 上分别改同一个文件、制造一次真实的三方合并冲突（同一段文本两边改成不同内容）。
   const restOverwrite = async (fileName, content) => {
     const list = await api('/api/projects/' + QA.projectId + '/files')
     const f = (Array.isArray(list) ? list : []).find((x) => x.name === fileName)
-    if (!f || !f.wpsFileId) throw new Error('找不到 ' + fileName + ' 或其 wpsFileId: ' + JSON.stringify(list).slice(0, 200))
+    if (!f || !f.id) throw new Error('找不到 ' + fileName + ' 或其 id: ' + JSON.stringify(list).slice(0, 200))
     const form = new FormData()
     form.append('file', new Blob([content], { type: 'text/plain' }), fileName)
-    const r = await fetch(BACKEND + '/api/files/' + f.wpsFileId + '/upload', {
+    const r = await fetch(BACKEND + '/api/files/' + (f.wpsFileId || f.id) + '/upload', {
       method: 'POST',
       headers: QA.sid ? { 'X-Session-Id': QA.sid } : {},
       body: form,
     })
     const j = await r.json()
     if (!j || j.code !== 0) throw new Error('REST 直传失败: ' + JSON.stringify(j))
-    return f.wpsFileId
+    return f.wpsFileId || f.id
   }
 
   // ---- 1. 开启版本记录（J9 已开）→ 一段命名工作垫底，给后面的另起一稿一个基点 ----


### PR DESCRIPTION
资源管理器端到端测试改用 `createFile` 创建本机文件后，`wpsFileId` 可以为空，但 J9/J10 的覆盖写入助手仍强制它非空，导致真实文件已落盘时版本修改、分稿和协作测试连锁失败。现场复现的文件 id=7、名称和路径均存在，只有 `wpsFileId=null`。

覆盖写入现在与 J4 和生产编辑器一致，使用 `wpsFileId || id`，保持原有字节写入、版本变更和对比断言不变；补记对应测试地雷。

After the Explorer test switched to `createFile`, locally created files can legitimately have no `wpsFileId`. The J9/J10 overwrite helpers now use the same `wpsFileId || id` fallback as J4 and the production editor, preserving all write/history/diff assertions.

验证 / Validation:
- 原故障已在隔离后端复现；修复后全新隔离数据库完整 app-e2e：141 passed, 0 failed。
- J9 MODIFY/文本对比、J10 真实冲突/采纳、J11 协作全部通过；J12 英文界面锚点通过，模型未调用工具所以过程卡工具名检查显式跳过。
- JavaScript syntax、diff checks 和 CI（backend/frontend/desktop dependencies/SPDX）通过。
- 产品运行时代码无变化 / No production runtime changes.

Tracking: https://github.com/zeweihan/dev-board/issues/521
