### PR TITLE
fix(ci): 复用已准备的 macOS 签名钥匙串 / reuse signing keychain

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -40,6 +40,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    electron-updater），也不用钥匙串/safeStorage，签名主体变了不会让旧版失效或掉数据。
    **`office-addin/installer/build-installers.mjs` 不共用这套**：它在维护者 Mac 上取钥匙串里
    **第一条** `Developer ID Application` 身份，两个主体的证书都装着时选到哪张不确定（见「已知地雷」）。
+4.2. **最终 macOS 打包复用前置签名钥匙串（dev-board#523）**：`Sign bundled backend natives` 已导入证书到 `$RUNNER_TEMP/awd-sign.keychain-db`；最终打包显式解锁它，设置 `CSC_KEYCHAIN` 并 `unset CSC_LINK`。electron-builder 24.13.3 新建随机口令钥匙串后，`importCerts` 却把 P12 口令传给 `set-key-partition-list -k`，可报 `SecKeychainUnlock`；不要把这个错误误判成证书口令失效而轮换 secrets。`CSC_LINK` 未清会优先走旧导入链，`CSC_KEYCHAIN` 不生效。无凭据的 fork 路径不设置钥匙串；ASC 公证流程不变。失败诊断里的 notary history 可能是旧版记录，须核上传时间，不能当本轮已公证的证据。
 4.5. **Office 插件安装器是发版硬步骤（2026-08-19 维护者定，自 v0.21.0 之后的发版起强制）**：
    每次发版都要重建并上架插件的 dmg+exe——在维护者 Mac 上
    `cd office-addin/installer && npm run build:installers`（版本自动取

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -511,6 +511,13 @@ jobs:
           # electron-builder's default unsigned PR build.
           CSC_FOR_PULL_REQUEST: ${{ secrets.CSC_LINK != '' }}
         run: |
+          # 复用前一步正确导入的钥匙串：electron-builder 24.13.3 的导入链
+          # 错把 P12 口令传给 set-key-partition-list，导致 SecKeychainUnlock。
+          if [ -n "$CSC_LINK" ]; then
+            export CSC_KEYCHAIN="$RUNNER_TEMP/awd-sign.keychain-db"
+            security unlock-keychain -p "awd-tmp-keychain" "$CSC_KEYCHAIN"
+            unset CSC_LINK
+          fi
           # 公证凭据：三个环境变量要么全有要么全无——electron-builder 只要见到其中
           # 任意一个非空就要求三个都在，否则抛 InvalidConfigurationError；三个全空
           # 才会静默跳过公证（fork PR 走的就是这条路）。

--- a/desktop/tests/workflow-release-gating.test.js
+++ b/desktop/tests/workflow-release-gating.test.js
@@ -190,3 +190,44 @@ test('desktop-build.yml：Windows 腿必须在跑单元测试之前给 Temp 加 
   assert.equal(step['continue-on-error'], true,
     'Defender 排除项失败不许中断构建（continue-on-error 必须为 true）')
 })
+
+// 执行真实打包步骤的 shell，仅替换系统签名和打包命令，避免测试接触真实密钥。
+for (const [signed, unlockFails] of [[true, false], [false, false], [true, true]]) {
+  test(`macOS packaging keychain (credentials: ${signed}, unlock failure: ${unlockFails})`, () => {
+    const step = loadWorkflow('desktop-build.yml').jobs.build.steps.find((s) =>
+      s.name === 'Package installers (macOS, signed & notarized)')
+    const harness = `
+      sudo() { :; }
+      ulimit() { printf '1024\\n'; }
+      security() {
+        if [ "$UNLOCK_FAILS" = true ]; then return 75; fi
+        [ "$1" = unlock-keychain ] && [ "$2" = -p ] &&
+        [ "$3" = awd-tmp-keychain ] && [ "$4" = "$RUNNER_TEMP/awd-sign.keychain-db" ] || return 71
+        export UNLOCKED_KEYCHAIN="$4"
+      }
+      npx() {
+        [ "$1" = electron-builder ] || return 72
+        if [ "$EXPECT_SIGNED" = true ]; then
+          [ -z "\${CSC_LINK:-}" ] &&
+          [ "\${CSC_KEYCHAIN:-}" = "$RUNNER_TEMP/awd-sign.keychain-db" ] &&
+          [ "\${UNLOCKED_KEYCHAIN:-}" = "$CSC_KEYCHAIN" ] || return 73
+        else
+          [ -z "\${CSC_KEYCHAIN:-}" ] && [ -z "\${CSC_LINK:-}" ] || return 74
+        fi
+      }
+    `
+    const result = require('child_process').spawnSync('bash', ['-e', '-c', harness + step.run], {
+      encoding: 'utf8',
+      env: {
+        PATH: process.env.PATH,
+        RUNNER_TEMP: '/tmp/release keychain test',
+        CSC_LINK: signed ? 'fixture-p12-base64' : '',
+        CSC_KEY_PASSWORD: 'fixture-p12-password',
+        APPLE_API_KEY_B64: '',
+        EXPECT_SIGNED: String(signed),
+        UNLOCK_FAILS: String(unlockFails),
+      },
+    })
+    assert.equal(result.status, unlockFails ? 75 : 0, result.stderr || result.stdout)
+  })
+}


### PR DESCRIPTION
macOS 正式发版在 electron-builder 的临时钥匙串导入环节报 `SecKeychainUnlock`：24.13.3 创建钥匙串使用随机口令，后续 `set-key-partition-list` 却使用 P12 口令。此前组件签名已成功，证书本身无需更换。

最终打包改为显式解锁并复用已准备的 `awd-sign.keychain-db`，设置 `CSC_KEYCHAIN` 后清除优先级更高的 `CSC_LINK`。签名主体、证书、API Key 公证、无凭据 fork 行为均保持原有路径；解锁失败立即终止。

The macOS release failed while electron-builder initialized its temporary signing keychain. Reuse the successfully prepared native-signing keychain through `CSC_KEYCHAIN` and remove the higher-priority `CSC_LINK` import path. Keep signing, notarization and credential-free fork behavior intact; fail immediately if unlocking fails.

验证 / Validation:
- CI run 34309900738 的真实失败日志与锁定依赖源码逐行对上。
- 执行真实 workflow shell 的回归：旧流程签名路径失败（exit 73）；修复后正式签名/无凭据/解锁失败三分支通过，workflow tests 12/12。
- Desktop 全套 104 passed, 0 failed, 1 skipped；独立复核 workflow12/12通过。
- 运行时代码、捆绑资源和版本号均不变。

Upstream evidence: https://github.com/electron-userland/electron-builder/blob/v24.13.3/packages/app-builder-lib/src/codeSign/macCodeSign.ts#L164-L189
Tracking: https://github.com/zeweihan/dev-board/issues/523
