### PR TITLE
feat(mobile): 小程序虚拟支付透传 + 注销传导到官网（dev-board#427/#434）

### DIFF
--- a/.claude/agents/mobile-sync.md
+++ b/.claude/agents/mobile-sync.md
@@ -221,9 +221,10 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
 云后端一个字都不存。
 
 - `service/mobile/MobileBillingClient` + `HttpMobileBillingClient` — POST 官网
-  `/api/internal/account`，头 `X-Internal-Secret`，四个 action：`resolve`（按已验证
+  `/api/internal/account`，头 `X-Internal-Secret`，五个 action：`resolve`（按已验证
   手机号或邮箱换 accountId，二选一恰好一个，**带 `create` 位**）/ `balance` /
-  `create-recharge` / `query`。
+  `create-recharge`（可带 `channel="wxvp"` + `productId` + `wxCode`，dev-board#427）/
+  `query` / `delete-account`（注销传导，dev-board#434）。
   形状照抄 `HttpTransferBillingClient`：配置 `mobile.billing.base-url/secret`
   （env `MOBILE_BILLING_BASE_URL`/`MOBILE_BILLING_SECRET`，**与 TRANSFER_BILLING_SECRET
   是两把不同的密钥**），任一未配 → DISABLED 短路，不发请求。
@@ -231,7 +232,8 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
   默认 false，落在 `MobileBillingService`**（复审 N1）。关时 `createRecharge` / `queryRecharge`
   在做任何别的事情之前抛 `DISABLED`——不校参数、不解析身份、**不会走到 `create=true`**、
   不发上游请求。`GET /balance` 是只读的（`create=false`，永不建号），**不受这个开关影响**。
-  **这个开关要等 dev-board#434（官网账户注销传导）落地后才允许打开**，理由见红线 8。
+  Java 侧的注销传导已随 dev-board#434 落地，**打开这个开关前还要确认官网那侧的
+  `delete-account` action 已上线**，理由见红线 8。
 - `service/mobile/MobileBillingKind` — **失败判别位的唯一来源**，八个值同时是
   `openapi/mobile-v1.yaml` 里 `Envelope.kind` 的取值集合，四端按它分支。
   `service/mobile/MobileBillingFailureException` 带 kind + outTradeNo，
@@ -286,11 +288,16 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
    `createRecharge`（用户显式发起充值）为 true，`balance`/`queryRecharge` 一律 false。
    第一版是无条件建号的，而 iOS 设置页的 `.task` 无条件读一次余额——「新用户打开设置页」
    这个纯读动作就会在官网建出一行含明文手机号的真账户，用户全程无感知、未同意；
-   而 App 的注销流程（`AccountDeletionService`）只删 Java 侧的 `app_users` 与
+   而当时 App 的注销流程（`AccountDeletionService`）只删 Java 侧的 `app_users` 与
    `account_binding`，**从不通知官网**，内部口也没有 delete action，于是 App 自己建的账号
    App 内没有任何路径能删掉——直接撞 App Store 5.1.1(v) 与个人信息保护法的删除权。
-   第二期做充值界面时，`create=true` 的那条路要同时补上「注销时通知官网」或
-   「建号前明确告知并取得同意」，否则这条红线只是被推迟了。
+   **dev-board#434 已把传导补上**：`AccountDeletionService` 在删本地表**之前**，
+   有 `account_binding` 就先调 `MobileBillingClient.deleteAccount(accountId)`——
+   官网 `deleted:true` 或带 body 的 404（那边本来就没有）才继续删本地；
+   `deleted:false` 用官网给的 message 报 REJECTED，官网不可达/5xx/本机未配 `mobile.billing.*`
+   报 UNAVAILABLE，**两种都不删本地**（宁可注销失败一次让用户重试，也不能留下官网侧的孤儿账户
+   ——本地那行绑定是「哪个 accountId 属于这个人」的唯一记录）。没有绑定的用户一次上游请求都不发。
+   护栏 `AccountDeletionServiceTest`。
 
    **二轮复审 N1 补的护栏**：上面这句「本期没有充值界面所以一次号都不会建」**不是护栏**——
    `POST /api/mobile/billing/recharge` 是随本期一起上线的活端点，也是全站唯一的 `create=true`
@@ -298,8 +305,9 @@ find-or-create，影子项目从 `/api/projects/my` 滤掉）。绑定后两条�
    触发点只是从「打开设置页」搬到了「直接打这个端点」。所以加了服务端开关
    `mobile.billing.recharge-enabled`（默认 **false**）：关时下单与查单在到达 `create=true`
    之前短路成 `DISABLED`，不发任何上游请求。
-   **打开的前提是 dev-board#434（官网账户注销传导）已落地**：注销能传导到官网、官网内部口有
-   delete action 之后，才把它置 true。在那之前打开 = 把 App Store 5.1.1(v) 重新放出来。
+   **打开的前提是注销传导整条链路通**：Java 侧已就位（上面那段），剩下的是官网内部口的
+   `delete-account` action 真的上线、本机 `mobile.billing.base-url/secret` 配好，都齐了才置 true。
+   在那之前打开 = 把 App Store 5.1.1(v) 重新放出来。
    护栏：`MobileBillingRechargeDisabledTest`（不配这个键，走 application.yml 的生产默认值）
    与 `MobileBillingServiceTest`（显式 `=true`，测开关开着时行为不变）。
 9. **失败一律带机器可读的 `kind`，客户端禁止匹配 message 措辞**。message 经 `LangText`

--- a/backend/src/main/java/com/checkba/controller/MobileBillingController.java
+++ b/backend/src/main/java/com/checkba/controller/MobileBillingController.java
@@ -21,8 +21,9 @@ import java.util.Map;
  * 响应风格也随那一组：成功回<b>裸对象</b>（同 {@code /api/mobile/media/usage}），
  * 业务错误由全局处理器压成 200 + {@code {code:1,message}}。
  *
- * <p><b>本期只有服务端通路，没有任何客户端支付界面</b>：iOS 内购 / 小程序虚拟支付 /
- * 安卓微信支付是后面几期的事（dev-board#426/#427/#428）。
+ * <p>第一期（dev-board#425）只有服务端通路；小程序虚拟支付（dev-board#427）在
+ * {@link RechargeRequest} 上加了 channel/productId/wxCode 三个可选字段，
+ * 缺省即第一期行为。iOS 内购 / 安卓微信支付仍是后面几期的事（dev-board#426/#428）。
  */
 @RestController
 @RequestMapping("/api/mobile/billing")
@@ -54,9 +55,21 @@ public class MobileBillingController {
          * App 被杀/弱网重试会在官网留下一串悬挂 pending 单。缺失即 code:1 报错。
          */
         private String idempotencyKey;
+        /**
+         * 支付通道（dev-board#427）。缺省 = 站点默认通道（第一期行为）；
+         * {@code "wxvp"} = 小程序虚拟支付，此时 productId / wxCode 必填。
+         */
+        private String channel;
+        /** {@code channel=wxvp} 时必填：微信道具 id（价格权威在官网，这里只做形态校验）。 */
+        private String productId;
+        /** {@code channel=wxvp} 时必填：{@code wx.login()} 的一次性 code，官网拿它换 openid。 */
+        private String wxCode;
     }
 
-    /** POST /recharge → {present, outTradeNo, amountCents, codeUrl?, qrCode?, redirectUrl?}。 */
+    /**
+     * POST /recharge → {present, outTradeNo, amountCents, codeUrl?, qrCode?, redirectUrl?,
+     * signData?, paySig?, signature?}。
+     */
     @PostMapping("/recharge")
     public Map<String, Object> recharge(
             @RequestBody(required = false) RechargeRequest request,
@@ -64,15 +77,22 @@ public class MobileBillingController {
         Long userId = requireUser(sessionId);
         MobileBillingClient.RechargeOrder order = service.createRecharge(userId,
                 request == null ? null : request.getAmountCents(),
-                request == null ? null : request.getIdempotencyKey());
+                request == null ? null : request.getIdempotencyKey(),
+                request == null ? null : request.getChannel(),
+                request == null ? null : request.getProductId(),
+                request == null ? null : request.getWxCode());
         Map<String, Object> out = new LinkedHashMap<>();
         out.put("present", order.present());
         out.put("outTradeNo", order.outTradeNo());
         out.put("amountCents", order.amountCents());
-        // 三个可选字段按 present 二选一有值，为 null 时不出现在响应里（契约里也是非必填）
+        // 六个可选字段按 present 分组有值，为 null 时不出现在响应里（契约里也是非必填）：
+        // qrcode → codeUrl/qrCode，redirect → redirectUrl，virtual → signData/paySig/signature
         putIfPresent(out, "codeUrl", order.codeUrl());
         putIfPresent(out, "qrCode", order.qrCode());
         putIfPresent(out, "redirectUrl", order.redirectUrl());
+        putIfPresent(out, "signData", order.signData());
+        putIfPresent(out, "paySig", order.paySig());
+        putIfPresent(out, "signature", order.signature());
         return out;
     }
 

--- a/backend/src/main/java/com/checkba/service/account/AccountDeletionService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountDeletionService.java
@@ -3,6 +3,7 @@
 
 package com.checkba.service.account;
 
+import com.checkba.model.entity.AccountBinding;
 import com.checkba.model.entity.MobileMediaInbox;
 import com.checkba.repository.AccountBindingRepository;
 import com.checkba.repository.DeviceTokenRepository;
@@ -12,6 +13,10 @@ import com.checkba.repository.MobileProjectDirRepository;
 import com.checkba.repository.MobileTransferRequestRepository;
 import com.checkba.repository.UserRepository;
 import com.checkba.repository.UserSessionRepository;
+import com.checkba.service.LangText;
+import com.checkba.service.mobile.MobileBillingClient;
+import com.checkba.service.mobile.MobileBillingFailureException;
+import com.checkba.service.mobile.MobileBillingKind;
 import com.checkba.service.mobile.MobileRelayBlobStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 注销账号：把这个用户在云端的东西一次删干净。
@@ -29,12 +35,29 @@ import java.util.List;
  *
  * <p><b>删的范围</b>——手机端用户在云端占的全部：
  * <ul>
+ *   <li><b>官网侧的统一账户</b>（有 {@code account_binding} 时先传导，见下）</li>
  *   <li>中转区影像：先删 blob 再删行。blob 删不掉只 warn 不中断，剩下的由对象存储
  *       生命周期兜底——为了一个删不掉的文件把整个注销卡住，对用户是更坏的结果。</li>
  *   <li>项目目录镜像、设备心跳、传输请求</li>
  *   <li>会话（删完当场失效）、账号绑定、设备令牌</li>
  *   <li>最后删 app_users 行本身</li>
  * </ul>
+ *
+ * <p><b>注销要传导到官网</b>（dev-board#434）：充值路径会用已验证手机号在官网
+ * {@code resolve(create=true)} 建出一行含明文手机号的真账户。只删 Java 侧本地表的话，
+ * <b>App 自己建的账号 App 内没有任何路径能删掉</b>，直接撞 App Store 5.1.1(v)
+ * 与个人信息保护法的删除权。所以有 {@code account_binding} 时先调官网内部口
+ * {@code delete-account}，<b>再</b>删本地：
+ * <ul>
+ *   <li>官网删成功、或官网本来就查无此账户 → 继续删本地。</li>
+ *   <li>官网明确拒绝（余额可退等）→ 抛可读业务错误，<b>本地一行都不删</b>，
+ *       把官网给的原因原样告诉用户。</li>
+ *   <li>官网不可达 / 5xx / 本机没配 {@code mobile.billing.*} → 同样中止，
+ *       让用户稍后再试。<b>宁可让注销失败一次，也不能留下官网侧的孤儿账户</b>——
+ *       本地删掉之后就再没有任何东西记得那个 accountId 了。</li>
+ * </ul>
+ * 没有 {@code account_binding} 的用户（从没碰过充值/余额，也包括整个服务器没配统一账户的
+ * 部署）不受影响：一次上游请求都不发，照常删。
  *
  * <p><b>不碰手机本地的影像。</b>这是取证工具，现场不可复现；把用户手机上的原图一并
  * 销毁不是「清理」而是毁证。注销只清云端，本地留在设备上，由用户自己决定删不删
@@ -57,6 +80,8 @@ public class AccountDeletionService {
     private final AccountBindingRepository bindingRepository;
     private final DeviceTokenRepository deviceTokenRepository;
     private final MobileRelayBlobStore blobStore;
+    /** 官网统一账户的内部记账口，注销传导用（dev-board#434）。 */
+    private final MobileBillingClient billing;
 
     public AccountDeletionService(UserRepository userRepository,
                                   UserSessionRepository sessionRepository,
@@ -66,7 +91,8 @@ public class AccountDeletionService {
                                   MobileTransferRequestRepository transferRepository,
                                   AccountBindingRepository bindingRepository,
                                   DeviceTokenRepository deviceTokenRepository,
-                                  MobileRelayBlobStore blobStore) {
+                                  MobileRelayBlobStore blobStore,
+                                  MobileBillingClient billing) {
         this.userRepository = userRepository;
         this.sessionRepository = sessionRepository;
         this.inboxRepository = inboxRepository;
@@ -76,6 +102,7 @@ public class AccountDeletionService {
         this.bindingRepository = bindingRepository;
         this.deviceTokenRepository = deviceTokenRepository;
         this.blobStore = blobStore;
+        this.billing = billing;
     }
 
     /** 删除结果，仅用于日志与回包里的计数（不回具体内容）。 */
@@ -86,6 +113,9 @@ public class AccountDeletionService {
         if (userId == null || userRepository.findById(userId).isEmpty()) {
             throw new IllegalArgumentException("账号不存在或已注销");
         }
+
+        // 官网侧先删（dev-board#434）：失败即中止，本地一行都不动
+        propagateToUnifiedAccount(userId);
 
         List<MobileMediaInbox> items = inboxRepository.findByUserId(userId);
         for (MobileMediaInbox item : items) {
@@ -105,5 +135,44 @@ public class AccountDeletionService {
         log.info("账号已注销 userId={}：影像 {}、项目目录 {}、设备 {}、传输请求 {}、会话 {}",
                 userId, media, projects, devices, transfers, sessions);
         return new Result((int) media, projects, devices, transfers, sessions);
+    }
+
+    /**
+     * 把删除传导到官网（dev-board#434）。没有绑定就什么都不做——那种用户在官网侧根本没有账户，
+     * 发一次请求只会在没配统一账户的部署上把注销变成必然失败。
+     *
+     * <p>三条失败路径都<b>不删本地</b>，理由是同一条：本地的 {@code account_binding} 是
+     * 「哪个 accountId 属于这个人」的唯一记录，删掉它之后官网那行含明文手机号的账户就再也
+     * 没人认领得了。注销失败一次用户还能重试，孤儿账户没人能收拾。
+     */
+    private void propagateToUnifiedAccount(Long userId) {
+        Optional<AccountBinding> binding = bindingRepository.findByUserId(userId);
+        if (binding.isEmpty()) {
+            return;
+        }
+        String accountId = binding.get().getExternalAccountId();
+
+        MobileBillingClient.DeleteAccountResult result;
+        try {
+            result = billing.deleteAccount(accountId);
+        } catch (MobileBillingClient.MobileBillingException e) {
+            // DISABLED（本机没配 mobile.billing.*，但这个人偏偏有绑定）与 UNAVAILABLE 都归这里：
+            // 都是「说不清官网那边到底怎么样」，一律不删本地
+            log.warn("注销传导到官网失败，已中止本地注销：userId={}, kind={}", userId, e.getKind());
+            throw new MobileBillingFailureException(MobileBillingKind.UNAVAILABLE, LangText.of(
+                    "账户服务暂不可用，暂时无法注销，请稍后再试",
+                    "Account service is temporarily unavailable; please try deleting your account later"));
+        }
+
+        if (!result.deleted()) {
+            log.warn("官网拒绝删除统一账户，已中止本地注销：userId={}, blocker={}",
+                    userId, result.blocker());
+            String message = result.message() == null || result.message().isBlank()
+                    ? LangText.of("统一账户暂时无法注销，请联系客服",
+                            "Your unified account cannot be deleted right now; please contact support")
+                    : result.message();
+            throw new MobileBillingFailureException(MobileBillingKind.REJECTED, message);
+        }
+        log.info("统一账户已随注销一并删除：userId={}", userId);
     }
 }

--- a/backend/src/main/java/com/checkba/service/mobile/HttpMobileBillingClient.java
+++ b/backend/src/main/java/com/checkba/service/mobile/HttpMobileBillingClient.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * （dev-board#425，spec §3.2）。形状照抄 {@link HttpTransferBillingClient}。
  *
  * <p>base-url/secret 任一未配置（桌面/本地默认空）视为该服务器未开通统一账户充值，
- * 四个方法一律短路抛 DISABLED，<b>不发请求</b>——不静默放行、也不装作有余额。
+ * 每个方法都短路抛 DISABLED，<b>不发请求</b>——不静默放行、也不装作有余额。
  *
  * <p>网络失败（连不上/超时/中断，不含"连上了但业务报错"）只有 create-recharge 带同一
  * 幂等键重试一次；resolve/balance/query 是只读查询，失败直接报 UNAVAILABLE，不重试。
@@ -97,20 +97,35 @@ public class HttpMobileBillingClient implements MobileBillingClient {
     }
 
     @Override
-    public RechargeOrder createRecharge(String accountId, long amountCents, String idempotencyKey) {
+    public RechargeOrder createRecharge(String accountId, long amountCents, String idempotencyKey,
+                                        String channel, String productId, String wxCode) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("action", "create-recharge");
         body.put("accountId", accountId);
         body.put("amountCents", amountCents);
         body.put("idempotencyKey", idempotencyKey);
-        JsonNode json = callWithRetry(body);
+        // 通道三兄弟只在指定了 channel 时上行：不传 = 官网走站点默认通道（第一期行为），
+        // 传一串 null 上去只会让官网多几个要判空的字段
+        if (channel != null && !channel.isBlank()) {
+            body.put("channel", channel);
+            body.put("productId", productId);
+            body.put("wxCode", wxCode);
+        }
+        // wxvp 的 wxCode 是一次性的：第一发若已到达官网、只是响应丢了，带同一 body 重试会让官网
+        // 再换一次 code 而失败。所以 wxvp 只发一次，网络失败回 UNAVAILABLE，由小程序重新
+        // wx.login 拿新 code、带同一 idempotencyKey 再来（官网对命中幂等键的 pending 单用新 code 重签）。
+        boolean wxvp = "wxvp".equals(channel);
+        JsonNode json = wxvp ? call(body) : callWithRetry(body);
         return new RechargeOrder(
                 json.path("present").asText(null),
                 json.path("outTradeNo").asText(null),
                 json.path("amountCents").asLong(0),
                 textOrNull(json, "codeUrl"),
                 textOrNull(json, "qrCode"),
-                textOrNull(json, "redirectUrl"));
+                textOrNull(json, "redirectUrl"),
+                textOrNull(json, "signData"),
+                textOrNull(json, "paySig"),
+                textOrNull(json, "signature"));
     }
 
     @Override
@@ -124,6 +139,38 @@ public class HttpMobileBillingClient implements MobileBillingClient {
                 json.path("status").asText(null),
                 json.path("paid").asBoolean(false),
                 json.path("amountCents").asLong(0));
+    }
+
+    /**
+     * 删账号（action=delete-account，dev-board#434）。只读语义的反面：<b>失败必须响亮</b>，
+     * 所以走不重试的 {@link #call}——重试一次删除请求换不来什么，反而会把「官网到底删没删」
+     * 搅得更不清楚；调用方拿到异常就中止本地删除，用户稍后再试即可。
+     *
+     * <p>官网回带 body 的 404（{@code account_not_found}）不是失败：那边本来就没有这个账户，
+     * 与「刚刚删掉了」对本地是同一个结论，回 {@code deleted=true}。
+     * <b>空体 404 仍是配置/鉴权问题</b>（{@link #parse}），照样抛 UNAVAILABLE——
+     * 把它当成「已经删了」等于密钥配错时全量用户的官网账户被静默留下。
+     */
+    @Override
+    public DeleteAccountResult deleteAccount(String accountId) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", "delete-account");
+        body.put("accountId", accountId);
+        JsonNode json;
+        try {
+            json = call(body);
+        } catch (MobileBillingException e) {
+            if (e.getKind() == MobileBillingKind.NOT_FOUND) {
+                log.info("官网侧统一账户已不存在，注销传导视为完成: error={}", e.getMachineError());
+                return new DeleteAccountResult(true, null, null);
+            }
+            throw e;
+        }
+        boolean deleted = json.path("deleted").asBoolean(false);
+        if (!deleted) {
+            log.warn("官网拒绝删除统一账户: blocker={}", textOrNull(json, "blocker"));
+        }
+        return new DeleteAccountResult(deleted, textOrNull(json, "blocker"), textOrNull(json, "message"));
     }
 
     // ==================== 内部 ====================
@@ -210,6 +257,9 @@ public class HttpMobileBillingClient implements MobileBillingClient {
      *       ALREADY_PAID / IDEMPOTENCY_CONFLICT，且<b>把官网一并回的 {@code outTradeNo} 带走</b>
      *       （复审 C4）。这是「App 被杀后没存下单号」的恢复路径，丢了它用户既拿不到货
      *       也查不到单。</li>
+     *   <li><b>400</b> {@code product_mismatch}（dev-board#427）→ REJECTED，但给「请更新小程序」
+     *       那句专用文案：价格权威在官网，这条错只会在小程序拿着过期档位表下单时出现，
+     *       用户能自救，不该被引去联系客服。</li>
      *   <li>其余 4xx → REJECTED（error 串只进日志）；5xx 与解析失败 → UNAVAILABLE。</li>
      * </ul>
      */
@@ -256,6 +306,17 @@ public class HttpMobileBillingClient implements MobileBillingClient {
                     LangText.of("该充值请求与已有订单不一致，请重新发起",
                             "This top-up request conflicts with an existing order; please start a new one"),
                     machineError, outTradeNo);
+        }
+
+        // 档位与金额不符（dev-board#427）：价格权威在官网，云后端只做形态校验。走到这里
+        // 说明小程序拿的是过期的档位表，用户能自救的动作是更新小程序，所以单给一句文案，
+        // 而不是与「官网拒绝了这笔充值」共用那句「请联系客服」。
+        if (status == 400 && "product_mismatch".equals(machineError)) {
+            log.warn("充值档位与金额不符: status={}, error={}", status, machineError);
+            throw new MobileBillingException(MobileBillingKind.REJECTED,
+                    LangText.of("充值档位与金额不符，请更新小程序后重试",
+                            "Top-up tier and amount do not match; please update the mini program and try again"),
+                    machineError);
         }
 
         if (status >= 400 && status < 500) {

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingClient.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingClient.java
@@ -33,14 +33,29 @@ public interface MobileBillingClient {
     record BalanceResult(long balanceCents, String currency, String plan) {}
 
     /**
-     * 充值单。{@code present} = {@code "qrcode"}（codeUrl/qrCode 有值）或
-     * {@code "redirect"}（redirectUrl 有值）；不适用的字段为 null。
+     * 充值单。{@code present} = {@code "qrcode"}（codeUrl/qrCode 有值）、
+     * {@code "redirect"}（redirectUrl 有值）或 {@code "virtual"}
+     * （小程序虚拟支付，signData/paySig/signature 三者都有值）；不适用的字段为 null。
+     *
+     * <p>三个 virtual 字段是 {@code wx.requestVirtualPayment} 的入参，由官网算出来后原样透传：
+     * 云后端<b>不持有</b>虚拟支付 AppKey，也不碰小程序 session_key，全程只当管道
+     * （dev-board#427，spec {@code 2026-09-09-miniprogram-virtual-payment-plan.md} §1）。
      */
     record RechargeOrder(String present, String outTradeNo, long amountCents,
-                         String codeUrl, String qrCode, String redirectUrl) {}
+                         String codeUrl, String qrCode, String redirectUrl,
+                         String signData, String paySig, String signature) {}
 
     /** 充值单状态：status ∈ {pending, paid, closed, expired}。 */
     record RechargeStatus(String status, boolean paid, long amountCents) {}
+
+    /**
+     * 注销传导的结果（dev-board#434）。
+     *
+     * @param deleted 官网侧账户已删除（含「官网查无此账户」的 404：那边本来就没有，等价于已删）
+     * @param blocker 官网拒绝删除的机器可读原因（{@code deleted=false} 时有值），只进日志
+     * @param message 官网给的用户可读原因（{@code deleted=false} 时有值），原样回显给用户
+     */
+    record DeleteAccountResult(boolean deleted, String blocker, String message) {}
 
     /**
      * 按<b>已验证</b>的手机号或邮箱解析官网 accountId（action=resolve）。
@@ -70,11 +85,36 @@ public interface MobileBillingClient {
      * <p>{@code idempotencyKey} 由<b>客户端</b>生成并落盘后传入（官网 orders 表有
      * {@code UNIQUE(userId, idempotencyKey)} 兜底），服务端不代生成——代生成等于没有幂等键，
      * 弱网重试会在官网库里留下一串各自绑定独立二维码的悬挂 pending 单。
+     *
+     * @param channel   支付通道；{@code null} 走站点默认通道（第一期行为），
+     *                  {@code "wxvp"} 是小程序虚拟支付（dev-board#427）
+     * @param productId {@code channel="wxvp"} 时必填：微信道具 id。
+     *                  <b>价格权威在官网</b>，云后端只做形态校验不判价——档位与金额不符时
+     *                  官网回 400 {@code product_mismatch}，见 {@link HttpMobileBillingClient}
+     * @param wxCode    {@code channel="wxvp"} 时必填：{@code wx.login()} 的一次性 code，
+     *                  官网拿它换 openid + session_key 算签名。<b>不落库、不进日志</b>
      */
-    RechargeOrder createRecharge(String accountId, long amountCents, String idempotencyKey);
+    RechargeOrder createRecharge(String accountId, long amountCents, String idempotencyKey,
+                                 String channel, String productId, String wxCode);
 
     /** 查充值单（action=query）。 */
     RechargeStatus queryRecharge(String accountId, String outTradeNo);
+
+    /**
+     * 删除官网侧的统一账户（action=delete-account，dev-board#434）。
+     *
+     * <p><b>为什么必须有</b>：手机端一旦能在官网建号（充值前先要有 accountId），就落入
+     * App Store 5.1.1(v)「App 内能建的账号必须能在 App 内删」与个人信息保护法的删除权。
+     * 在这个方法出现之前，{@code AccountDeletionService} 只删 Java 侧本地表，官网那行
+     * 含明文手机号的账户<b>App 内无路可删</b>——这也正是
+     * {@code mobile.billing.recharge-enabled} 默认关、要等本方法落地才允许打开的原因。
+     *
+     * <p>失败语义对调用方很关键：官网不可达/5xx/未配置一律抛
+     * {@link MobileBillingException}（UNAVAILABLE / DISABLED），
+     * 调用方<b>必须据此中止本地删除</b>——宁可让用户稍后再试，也不能留下官网侧的孤儿账户。
+     * 「官网查无此账户」不是失败，回 {@code deleted=true}（那边本来就没有）。
+     */
+    DeleteAccountResult deleteAccount(String accountId);
 
     /**
      * 计费失败分类，翻成用户可读文案的活交给 {@link MobileBillingService}——本类只负责把

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingService.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingService.java
@@ -50,17 +50,20 @@ import java.util.regex.Pattern;
  * {@link #createRecharge}（用户显式发起充值）这一条路上为 true，{@link #balance} 与
  * {@link #queryRecharge} 一律 false。第一版是无条件建号的，而 iOS 设置页的 {@code .task}
  * 无条件读一次余额——「新用户打开设置页」这个纯读动作就会在官网建出一行含明文手机号的真账户，
- * 用户全程无感知、未同意；更糟的是 App 的注销流程只删 Java 侧的 app_users 与 account_binding，
+ * 用户全程无感知、未同意；更糟的是当时 App 的注销流程只删 Java 侧的 app_users 与 account_binding，
  * 从不通知官网，内部口也没有 delete action，于是<b>App 自己建的账号，App 内没有任何路径能删掉</b>，
- * 直接撞 App Store 5.1.1(v) 与个人信息保护法的删除权。本期没有充值界面，所以实际上一次号都不会建。
+ * 直接撞 App Store 5.1.1(v) 与个人信息保护法的删除权。这条注销传导已由 dev-board#434 补上
+ * （{@code AccountDeletionService} 先调 {@link MobileBillingClient#deleteAccount} 再删本地），
+ * 但「读余额永不建号」这条不因此放宽：纯读动作不该替用户建号。
  *
  * <p><b>充值总开关</b>（复审 N1）：{@code mobile.billing.recharge-enabled} 默认 false，
  * 关时 {@link #createRecharge} 与 {@link #queryRecharge} 在做<b>任何</b>别的事情之前短路成
  * {@link MobileBillingKind#DISABLED}，不解析身份、不发上游请求。上一条说的「本期没有充值界面
  * 所以一次号都不会建」<b>不是护栏</b>——{@code POST /api/mobile/billing/recharge} 是活的端点，
  * 任何持有有效 {@code X-Session-Id} 的人直接打它就会走到 {@code create=true}。
- * <b>这个开关要等 dev-board#434（官网账户注销传导）落地后才允许打开</b>，
- * 在那之前打开就等于把 App Store 5.1.1(v) 那条重新放出来。
+ * <b>这个开关的前置条件是 dev-board#434（官网账户注销传导）</b>：Java 侧的传导已经就位，
+ * 但它要官网内部口真的有 {@code delete-account} action 才有效，所以开关仍默认关，
+ * 等官网那侧上线、{@code mobile.billing.base-url/secret} 配好之后再打开。
  *
  * <p>失败一律带 {@link MobileBillingKind} 判别位（复审 C2），信封里是 {@code kind} 字段，
  * 四端按它分支——第一版只送 message，三端于是各自去猜（安卓硬编码中文串、小程序判
@@ -87,6 +90,16 @@ public class MobileBillingService {
 
     /** 商户订单号围栏：官网侧生成的形态，只做长度与字符集把关。 */
     private static final Pattern OUT_TRADE_NO = Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
+
+    /**
+     * 微信虚拟支付通道（dev-board#427）。{@code channel} 为空 = 站点默认通道（第一期行为）；
+     * 只认这一个显式取值，别的串一律拒——静默当成默认通道等于用户以为在走虚拟支付，
+     * 实际拿回一张扫码单。
+     */
+    private static final String CHANNEL_WXVP = "wxvp";
+
+    /** 微信道具 id 围栏。只做形态把关，<b>价格权威在官网</b>（不符时官网回 product_mismatch）。 */
+    private static final Pattern PRODUCT_ID = Pattern.compile("^[a-z0-9_]{1,64}$");
 
     private final MobileBillingClient billing;
     private final AccountBindingRepository accountBindingRepository;
@@ -148,8 +161,16 @@ public class MobileBillingService {
      * <p><b>总开关先行</b>（复审 N1）：{@code mobile.billing.recharge-enabled} 关时（默认）
      * 第一行就抛 DISABLED，参数校验、身份解析、上游请求一律不发生。「本期四端还没有充值界面」
      * 只是没人调，不是护栏——这个端点是活的。
+     *
+     * <p><b>通道</b>（dev-board#427，spec {@code 2026-09-09-miniprogram-virtual-payment-plan.md} §4）：
+     * {@code channel} 为空即第一期行为（站点默认通道）；{@code "wxvp"} 是小程序虚拟支付，
+     * 此时 {@code productId} / {@code wxCode} 必填。<b>金额与档位是否匹配不在这里判</b>——
+     * 价格权威在官网，两处各写一份价格表迟早会对不上；不符时官网回 400 {@code product_mismatch}，
+     * 由 {@link HttpMobileBillingClient} 译成 REJECTED + 「请更新小程序」。
      */
-    public MobileBillingClient.RechargeOrder createRecharge(Long userId, Long amountCents, String idempotencyKey) {
+    public MobileBillingClient.RechargeOrder createRecharge(Long userId, Long amountCents,
+                                                            String idempotencyKey, String channel,
+                                                            String productId, String wxCode) {
         requireRechargeEnabled();
         if (amountCents == null || amountCents <= 0) {
             throw new IllegalArgumentException(LangText.of(
@@ -161,8 +182,35 @@ public class MobileBillingService {
                     "缺少或非法的 idempotencyKey，请升级客户端后重试",
                     "Missing or invalid idempotencyKey; please update the app and try again"));
         }
+
+        String ch = trimToNull(channel);
+        String product = null;
+        String code = null;
+        if (ch != null) {
+            if (!CHANNEL_WXVP.equals(ch)) {
+                throw new IllegalArgumentException(LangText.of(
+                        "不支持的支付通道，请升级客户端后重试",
+                        "Unsupported payment channel; please update the app and try again"));
+            }
+            product = trimToNull(productId);
+            code = trimToNull(wxCode);
+            if (product == null || !PRODUCT_ID.matcher(product).matches()) {
+                throw new IllegalArgumentException(LangText.of(
+                        "缺少或非法的充值档位，请更新小程序后重试",
+                        "Missing or invalid top-up product; please update the mini program and try again"));
+            }
+            if (code == null) {
+                // wx.login() 的 code 是一次性的，缺了它官网换不到 openid，签不出 paySig
+                throw new IllegalArgumentException(LangText.of(
+                        "缺少微信登录凭证，请重新进入充值页",
+                        "Missing WeChat login code; please reopen the top-up page"));
+            }
+        }
+
+        final String finalProduct = product;
+        final String finalCode = code;
         return callWithAccount(userId, true, true,
-                accountId -> billing.createRecharge(accountId, amountCents, key));
+                accountId -> billing.createRecharge(accountId, amountCents, key, ch, finalProduct, finalCode));
     }
 
     /**
@@ -278,15 +326,15 @@ public class MobileBillingService {
      * <p>为什么需要它：{@code POST /api/mobile/billing/recharge} 是全站唯一走
      * {@code create=true} 的调用方，随本期一起上线且是活的——任何持有有效
      * {@code X-Session-Id} 的人直接打它，就会在官网建出一行含明文手机号的真账户并发注册赠额。
-     * 而 {@code AccountDeletionService} 依旧只删 Java 侧本地表、不通知官网，官网内部口也还
-     * 没有 delete action，于是 App 自己建的账号 App 内没有任何路径能删掉——就是复审 C1 要堵的
-     * App Store 5.1.1(v) 场景，只是触发点从「打开设置页」搬到了「直接打这个端点」。
-     * 本期四端都没有充值界面，「没人调」是社会性约束而不是服务端护栏，所以要有这一行。
+     * 第一版写这一行时 {@code AccountDeletionService} 还只删 Java 侧本地表、不通知官网，
+     * 官网内部口也没有 delete action，于是 App 自己建的账号 App 内没有任何路径能删掉——就是
+     * 复审 C1 要堵的 App Store 5.1.1(v) 场景，只是触发点从「打开设置页」搬到了「直接打这个端点」。
+     * 四端有没有充值界面是社会性约束而不是服务端护栏，所以这一行留着。
      *
-     * <p><b>什么时候才允许打开</b>：等 dev-board#434（官网账户注销传导）落地——注销时能把删除
-     * 传导到官网、官网内部口有 delete action 之后，把
-     * {@code mobile.billing.recharge-enabled}（env {@code MOBILE_BILLING_RECHARGE_ENABLED}）
-     * 置 true。在那之前打开等于把 5.1.1(v) 重新放出来。
+     * <p><b>什么时候才允许打开</b>：dev-board#434 已经把注销传导补上（注销先调官网
+     * {@code delete-account} 再删本地，官网不可达就不删），剩下的前置条件是官网那侧的
+     * action 真的上线、本机 {@code mobile.billing.base-url/secret} 配好；都齐了再把
+     * {@code mobile.billing.recharge-enabled}（env {@code MOBILE_BILLING_RECHARGE_ENABLED}）置 true。
      */
     private void requireRechargeEnabled() {
         if (!rechargeEnabled) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -585,13 +585,13 @@ mobile:
   billing:
     base-url: ${MOBILE_BILLING_BASE_URL:}
     secret: ${MOBILE_BILLING_SECRET:}
-    # 充值下单/查单的总开关（dev-board#425 二轮复审 N1）。默认关，且在
-    # **dev-board#434（官网账户注销传导）落地之前一律不许打开**。
+    # 充值下单/查单的总开关（dev-board#425 二轮复审 N1）。默认关。
     # 理由：POST /api/mobile/billing/recharge 是全站唯一 create=true 的调用方——任何持有
     # 有效 X-Session-Id 的人直接打它，就会在官网建出一行含明文手机号的真账户并发注册赠额；
-    # 而 AccountDeletionService 只删 Java 侧本地表、不通知官网，官网内部口也还没有 delete
-    # action，于是「App 自己建的账号 App 内删不掉」，直接撞 App Store 5.1.1(v) 与个人信息
-    # 保护法的删除权。本期四端都没有充值界面，靠「没人调」挡不住，所以要有这个服务端开关。
+    # 这个账户必须删得掉，否则直接撞 App Store 5.1.1(v) 与个人信息保护法的删除权。
+    # Java 侧的注销传导已经落地（dev-board#434：AccountDeletionService 先调官网内部口
+    # delete-account 再删本地，官网不可达就不删），**打开这个开关前还要确认官网那侧的
+    # delete-account action 已经上线**，否则传导必然失败、用户反而注销不掉。
     # 关时 /recharge 与 /recharge/status 在到达 create=true 之前短路成 kind=DISABLED，
     # 不发任何上游请求；GET /balance 是只读的（create=false，永不建号），不受本开关影响。
     recharge-enabled: ${MOBILE_BILLING_RECHARGE_ENABLED:false}

--- a/backend/src/main/resources/openapi/mobile-v1.yaml
+++ b/backend/src/main/resources/openapi/mobile-v1.yaml
@@ -153,16 +153,23 @@ components:
     RechargeOrder:
       type: object
       description: |
-        充值单。present=qrcode 时 codeUrl/qrCode 有值，present=redirect 时 redirectUrl 有值；
-        不适用的字段不出现在响应里。
+        充值单。present=qrcode 时 codeUrl/qrCode 有值，present=redirect 时 redirectUrl 有值，
+        present=virtual 时 signData/paySig/signature 三者都有值；不适用的字段不出现在响应里。
+
+        present=virtual 是小程序虚拟支付（dev-board#427）：三个字段由官网算出后经云后端原样透传，
+        小程序拿它们调 wx.requestVirtualPayment({signData, paySig, signature, mode:'short_series_goods'})。
+        云后端不持有虚拟支付 AppKey、不碰 session_key，全程只当管道。
       required: [present, outTradeNo, amountCents]
       properties:
-        present: { type: string, enum: [qrcode, redirect] }
+        present: { type: string, enum: [qrcode, redirect, virtual] }
         outTradeNo: { type: string, description: 商户订单号，查状态用 }
         amountCents: { type: integer, format: int64, description: 下单金额，整数分 }
         codeUrl: { type: string, description: present=qrcode：支付链接原文 }
         qrCode: { type: string, description: present=qrcode：二维码图（data URI） }
         redirectUrl: { type: string, description: present=redirect：跳转地址 }
+        signData: { type: string, description: 'present=virtual 必有：待签名 JSON 串（offerId/buyQuantity/env/currencyType/productId/goodsPrice/outTradeNo/attach）' }
+        paySig: { type: string, description: 'present=virtual 必有：hex(hmac_sha256(appKey, "requestVirtualPayment&" + signData))' }
+        signature: { type: string, description: 'present=virtual 必有：hex(hmac_sha256(session_key, signData))' }
     RechargeStatus:
       type: object
       required: [status, paid, amountCents]
@@ -452,6 +459,25 @@ paths:
                   description: |
                     **客户端生成并落盘后传入**（扛 App 被杀）。服务端不代生成，缺失即 code 1。
                     官网 orders 表有 UNIQUE(userId, idempotencyKey) 兜底。
+                channel:
+                  type: string
+                  enum: [wxvp]
+                  description: |
+                    支付通道（dev-board#427）。**缺省 = 站点默认通道**（第一期行为，扫码/跳转）；
+                    wxvp = 微信小程序虚拟支付，**channel=wxvp 时 channel/productId/wxCode 三者必填**，
+                    响应为 present=virtual。别的取值一律 code 1（通用 handler，无 kind）。
+                productId:
+                  type: string
+                  pattern: '^[a-z0-9_]{1,64}$'
+                  description: |
+                    channel=wxvp 时必填：微信道具 id（credits_cny_10 / credits_cny_50 / credits_cny_100）。
+                    **价格权威在官网**，云后端只校形态；档位与金额不符时官网回 400 product_mismatch
+                    → 信封 kind=REJECTED + 「请更新小程序后重试」。
+                wxCode:
+                  type: string
+                  description: |
+                    channel=wxvp 时必填：wx.login() 拿到的一次性 code，官网用它换 openid + session_key
+                    算签名。**session_key 只在官网内存里用，不落库、不打日志**，云后端只透传 code。
       responses:
         "200":
           description: 裸对象；未登录 Envelope(4010)；业务错误 Envelope(code 1)

--- a/backend/src/test/java/com/checkba/MobileApiContractTest.java
+++ b/backend/src/test/java/com/checkba/MobileApiContractTest.java
@@ -30,9 +30,11 @@ import java.util.Map;
 
 import static com.atlassian.oai.validator.mockmvc.OpenApiValidationMatchers.openApi;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -165,9 +167,17 @@ class MobileApiContractTest {
 
         when(billing.balance(anyString()))
                 .thenReturn(new MobileBillingClient.BalanceResult(12345L, "CNY", "paid"));
-        when(billing.createRecharge(anyString(), anyLong(), anyString()))
+        when(billing.createRecharge(anyString(), anyLong(), anyString(), isNull(), isNull(), isNull()))
                 .thenReturn(new MobileBillingClient.RechargeOrder(
-                        "qrcode", "OT-contract-1", 5000L, "weixin://wxpay/bizpayurl?pr=x", null, null));
+                        "qrcode", "OT-contract-1", 5000L, "weixin://wxpay/bizpayurl?pr=x", null, null,
+                        null, null, null));
+        // 小程序虚拟支付（dev-board#427）：present=virtual 时多出 signData/paySig/signature 三个键，
+        // 它们必须先写进 YAML——校验器默认 additionalProperties:false，漏一个这里就红
+        when(billing.createRecharge(anyString(), anyLong(), anyString(),
+                eq("wxvp"), anyString(), anyString()))
+                .thenReturn(new MobileBillingClient.RechargeOrder(
+                        "virtual", "OT-contract-vp", 1000L, null, null, null,
+                        "{\"offerId\":\"1450637533\",\"buyQuantity\":1}", "a1b2c3", "d4e5f6"));
         when(billing.queryRecharge(anyString(), anyString()))
                 .thenReturn(new MobileBillingClient.RechargeStatus("pending", false, 5000L));
 
@@ -190,6 +200,45 @@ class MobileApiContractTest {
                 .andExpect(jsonPath("$.status").value("pending"))
                 .andExpect(openApi().isValid(validator));
 
+        // present=virtual 的成功形状（dev-board#427）：三个签名串出现在响应里，
+        // 扫码那三兄弟一个都不出现（不适用的字段不进响应，与 present=qrcode 时正好相反）
+        mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"amountCents":1000,"idempotencyKey":"idem-contract-vp01",\
+                                "channel":"wxvp","productId":"credits_cny_10","wxCode":"0a1b2c3d4e"}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.present").value("virtual"))
+                .andExpect(jsonPath("$.outTradeNo").value("OT-contract-vp"))
+                .andExpect(jsonPath("$.signData").exists())
+                .andExpect(jsonPath("$.paySig").value("a1b2c3"))
+                .andExpect(jsonPath("$.signature").value("d4e5f6"))
+                .andExpect(jsonPath("$.codeUrl").doesNotExist())
+                .andExpect(openApi().isValid(validator));
+
+        // 新请求字段的校验也走通用信封：不认识的通道 → code 1（无 kind，通用 handler）
+        mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"amountCents":1000,"idempotencyKey":"idem-contract-vp02",\
+                                "channel":"alipay","productId":"credits_cny_10","wxCode":"0a1b2c3d4e"}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.kind").doesNotExist())
+                .andExpect(openApi().isValid(validator));
+
+        // channel=wxvp 但缺 productId / wxCode → 同样 code 1，绝不当成默认通道悄悄下单
+        for (String bad : new String[]{
+                "{\"amountCents\":1000,\"idempotencyKey\":\"idem-contract-vp03\",\"channel\":\"wxvp\"}",
+                "{\"amountCents\":1000,\"idempotencyKey\":\"idem-contract-vp04\",\"channel\":\"wxvp\","
+                        + "\"productId\":\"credits_cny_10\"}"}) {
+            mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
+                            .contentType(APPLICATION_JSON).content(bad))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(1))
+                    .andExpect(openApi().isValid(validator));
+        }
+
         // 业务错误也在契约里：缺 idempotencyKey → 200 + Envelope(code 1)
         mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
                         .contentType(APPLICATION_JSON)
@@ -202,7 +251,8 @@ class MobileApiContractTest {
         // 机器可读判别位（dev-board#425 复审 C2）：四端按 kind 分支，不许猜 message 措辞
         doThrow(new MobileBillingClient.MobileBillingException(
                 MobileBillingKind.UNAVAILABLE, "账户服务暂不可用，请稍后再试"))
-                .when(billing).createRecharge(anyString(), anyLong(), eq("idem-contract-down1"));
+                .when(billing).createRecharge(anyString(), anyLong(), eq("idem-contract-down1"),
+                        any(), any(), any());
         mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
                         .contentType(APPLICATION_JSON)
                         .content("""
@@ -216,7 +266,8 @@ class MobileApiContractTest {
         doThrow(new MobileBillingClient.MobileBillingException(
                 MobileBillingKind.ALREADY_PAID, "这笔充值已经支付成功，请查看订单状态",
                 "order_already_paid", "RECHARGE20260904X"))
-                .when(billing).createRecharge(anyString(), anyLong(), eq("idem-contract-paid1"));
+                .when(billing).createRecharge(anyString(), anyLong(), eq("idem-contract-paid1"),
+                        any(), any(), any());
         mvc.perform(post("/api/mobile/billing/recharge").header("X-Session-Id", sid)
                         .contentType(APPLICATION_JSON)
                         .content("""

--- a/backend/src/test/java/com/checkba/service/account/AccountDeletionServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountDeletionServiceTest.java
@@ -3,12 +3,17 @@
 
 package com.checkba.service.account;
 
+import com.checkba.model.entity.AccountBinding;
 import com.checkba.model.entity.MobileMediaInbox;
 import com.checkba.model.entity.User;
 import com.checkba.repository.*;
+import com.checkba.service.mobile.MobileBillingClient;
+import com.checkba.service.mobile.MobileBillingFailureException;
+import com.checkba.service.mobile.MobileBillingKind;
 import com.checkba.service.mobile.MobileRelayBlobStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,8 +23,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * 注销是不可逆动作，所以两件事最值得测：该删的一样不落、blob 删不掉时不能把整个
- * 注销卡死（否则用户永远注销不掉，反而更糟）。
+ * 注销是不可逆动作，所以三件事最值得测：该删的一样不落、blob 删不掉时不能把整个
+ * 注销卡死（否则用户永远注销不掉，反而更糟）、以及官网侧的传导（dev-board#434）——
+ * 传导失败时<b>本地一行都不能删</b>，否则官网那行含明文手机号的账户就成了没人认领的孤儿。
  */
 class AccountDeletionServiceTest {
 
@@ -28,9 +34,15 @@ class AccountDeletionServiceTest {
                            UserSessionRepository sessions, MobileProjectDirRepository dirs,
                            MobileDeviceStateRepository devices,
                            MobileTransferRequestRepository transfers,
-                           AccountBindingRepository bindings, DeviceTokenRepository tokens) {}
+                           AccountBindingRepository bindings, DeviceTokenRepository tokens,
+                           MobileBillingClient billing) {}
 
     private Fixture fixture(List<MobileMediaInbox> items) {
+        return fixture(items, null);
+    }
+
+    /** @param externalAccountId 非 null 时给这个用户放一行 account_binding（= 官网侧有账户） */
+    private Fixture fixture(List<MobileMediaInbox> items, String externalAccountId) {
         UserRepository users = mock(UserRepository.class);
         when(users.findById(7L)).thenReturn(Optional.of(new User()));
         MobileMediaInboxRepository inbox = mock(MobileMediaInboxRepository.class);
@@ -42,9 +54,18 @@ class AccountDeletionServiceTest {
         MobileTransferRequestRepository transfers = mock(MobileTransferRequestRepository.class);
         AccountBindingRepository bindings = mock(AccountBindingRepository.class);
         DeviceTokenRepository tokens = mock(DeviceTokenRepository.class);
+        if (externalAccountId != null) {
+            AccountBinding row = new AccountBinding();
+            row.setUserId(7L);
+            row.setExternalAccountId(externalAccountId);
+            when(bindings.findByUserId(7L)).thenReturn(Optional.of(row));
+        } else {
+            when(bindings.findByUserId(7L)).thenReturn(Optional.empty());
+        }
+        MobileBillingClient billing = mock(MobileBillingClient.class);
         return new Fixture(new AccountDeletionService(users, sessions, inbox, dirs, devices,
-                transfers, bindings, tokens, blobs),
-                users, inbox, blobs, sessions, dirs, devices, transfers, bindings, tokens);
+                transfers, bindings, tokens, blobs, billing),
+                users, inbox, blobs, sessions, dirs, devices, transfers, bindings, tokens, billing);
     }
 
     private static MobileMediaInbox item(String path) {
@@ -101,5 +122,66 @@ class AccountDeletionServiceTest {
                 () -> f.svc().deleteAccount(7L));
         assertEquals("账号不存在或已注销", e.getMessage());
         verify(f.users(), never()).deleteById(any());
+    }
+
+    // ==================== 官网侧传导（dev-board#434） ====================
+
+    @Test
+    @DisplayName("有绑定：先把删除传导到官网，官网删成功才删本地")
+    void propagatesToUnifiedAccountBeforeDeletingLocally() {
+        Fixture f = fixture(List.of(), "acct-9");
+        when(f.billing().deleteAccount("acct-9"))
+                .thenReturn(new MobileBillingClient.DeleteAccountResult(true, null, null));
+
+        f.svc().deleteAccount(7L);
+
+        InOrder order = inOrder(f.billing(), f.users());
+        order.verify(f.billing()).deleteAccount("acct-9");
+        order.verify(f.users()).deleteById(7L);
+    }
+
+    @Test
+    @DisplayName("官网明确拒绝删除：本地一行都不删，且把官网给的原因原样告诉用户")
+    void blockedUpstreamDeletionAbortsLocalDeletion() {
+        Fixture f = fixture(List.of(item("relay/x.bin")), "acct-9");
+        when(f.billing().deleteAccount("acct-9")).thenReturn(
+                new MobileBillingClient.DeleteAccountResult(false, "refundable_balance",
+                        "账上还有可退余额，请先申请退款"));
+
+        MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
+                () -> f.svc().deleteAccount(7L));
+
+        assertEquals(MobileBillingKind.REJECTED, e.getKind());
+        assertEquals("账上还有可退余额，请先申请退款", e.getMessage());
+        verify(f.users(), never()).deleteById(any());
+        verify(f.bindings(), never()).deleteByUserId(any());
+        verify(f.blobs(), never()).deleteQuietly(any());
+    }
+
+    @Test
+    @DisplayName("官网不可达：同样中止——宁可注销失败一次，也不留下官网侧的孤儿账户")
+    void unreachableUpstreamAbortsLocalDeletion() {
+        Fixture f = fixture(List.of(), "acct-9");
+        when(f.billing().deleteAccount("acct-9")).thenThrow(
+                new MobileBillingClient.MobileBillingException(
+                        MobileBillingKind.UNAVAILABLE, "账户服务暂不可用，请稍后再试"));
+
+        MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
+                () -> f.svc().deleteAccount(7L));
+
+        assertEquals(MobileBillingKind.UNAVAILABLE, e.getKind());
+        verify(f.users(), never()).deleteById(any());
+        verify(f.bindings(), never()).deleteByUserId(any());
+    }
+
+    @Test
+    @DisplayName("没有绑定（含整台服务器没配统一账户）：一次上游请求都不发，照常删")
+    void unboundUserIsDeletedWithoutUpstreamCall() {
+        Fixture f = fixture(List.of());
+
+        f.svc().deleteAccount(7L);
+
+        verifyNoInteractions(f.billing());
+        verify(f.users()).deleteById(7L);
     }
 }

--- a/backend/src/test/java/com/checkba/service/mobile/HttpMobileBillingClientTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/HttpMobileBillingClientTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -41,12 +42,21 @@ class HttpMobileBillingClientTest {
     private final AtomicReference<String> stubBody = new AtomicReference<>("{}");
     /** 最后一次收到的请求体，用来断言 create 位真的上行了。 */
     private final AtomicReference<String> lastRequest = new AtomicReference<>();
+    /** 桩服务收到的请求次数，用来断言 wxvp 不重试。 */
+    private final AtomicInteger hits = new AtomicInteger();
+    /** 置 true 时桩服务读完请求体直接断开、不回任何响应，模拟「请求已到达但响应丢了」的网络失败。 */
+    private final AtomicBoolean stubDrop = new AtomicBoolean(false);
 
     @BeforeEach
     void startStub() throws IOException {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/api/internal/account", exchange -> {
             lastRequest.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            hits.incrementAndGet();
+            if (stubDrop.get()) {
+                exchange.close();
+                return;
+            }
             String body = stubBody.get();
             byte[] out = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
             if (out.length == 0) {
@@ -88,7 +98,8 @@ class HttpMobileBillingClientTest {
             assertEquals(MobileBillingKind.DISABLED,
                     assertThrows(MobileBillingException.class, () -> c.balance("acct-x")).getKind());
             assertEquals(MobileBillingKind.DISABLED,
-                    assertThrows(MobileBillingException.class, () -> c.createRecharge("acct-x", 5000, "idem-0001")).getKind());
+                    assertThrows(MobileBillingException.class,
+                            () -> c.createRecharge("acct-x", 5000, "idem-0001", null, null, null)).getKind());
             assertEquals(MobileBillingKind.DISABLED,
                     assertThrows(MobileBillingException.class, () -> c.queryRecharge("acct-x", "no-1")).getKind());
         }
@@ -101,7 +112,8 @@ class HttpMobileBillingClientTest {
         assertEquals(MobileBillingKind.UNAVAILABLE,
                 assertThrows(MobileBillingException.class, () -> c.balance("acct-x")).getKind());
         assertEquals(MobileBillingKind.UNAVAILABLE,
-                assertThrows(MobileBillingException.class, () -> c.createRecharge("acct-x", 5000, "idem-0001")).getKind());
+                assertThrows(MobileBillingException.class,
+                        () -> c.createRecharge("acct-x", 5000, "idem-0001", null, null, null)).getKind());
     }
 
     @Test
@@ -164,7 +176,7 @@ class HttpMobileBillingClientTest {
         HttpMobileBillingClient c = stubbed(409,
                 "{\"error\":\"order_already_paid\",\"outTradeNo\":\"RECHARGE202609040001\"}");
         MobileBillingException e = assertThrows(MobileBillingException.class,
-                () -> c.createRecharge("acct-x", 5000, "idem-0001"));
+                () -> c.createRecharge("acct-x", 5000, "idem-0001", null, null, null));
         assertEquals(MobileBillingKind.ALREADY_PAID, e.getKind());
         assertEquals("RECHARGE202609040001", e.getOutTradeNo());
     }
@@ -175,7 +187,7 @@ class HttpMobileBillingClientTest {
         HttpMobileBillingClient c = stubbed(409,
                 "{\"error\":\"idempotency_conflict\",\"outTradeNo\":\"RECHARGE202609040002\"}");
         MobileBillingException e = assertThrows(MobileBillingException.class,
-                () -> c.createRecharge("acct-x", 5000, "idem-0001"));
+                () -> c.createRecharge("acct-x", 5000, "idem-0001", null, null, null));
         assertEquals(MobileBillingKind.IDEMPOTENCY_CONFLICT, e.getKind());
         assertEquals("RECHARGE202609040002", e.getOutTradeNo());
     }
@@ -192,6 +204,125 @@ class HttpMobileBillingClientTest {
         HttpMobileBillingClient down = stubbed(500, "{\"error\":\"internal_error\"}");
         assertEquals(MobileBillingKind.UNAVAILABLE,
                 assertThrows(MobileBillingException.class, () -> down.balance("acct-x")).getKind());
+    }
+
+    // ==================== 小程序虚拟支付（dev-board#427） ====================
+
+    @Test
+    @DisplayName("channel=wxvp：三个字段上行，signData/paySig/signature 解回记录")
+    void wxvpFieldsGoUpAndSignaturesComeBack() {
+        HttpMobileBillingClient c = stubbed(200,
+                "{\"present\":\"virtual\",\"outTradeNo\":\"OT-vp-1\",\"amountCents\":1000,"
+                        + "\"signData\":\"{}\",\"paySig\":\"aa11\",\"signature\":\"bb22\"}");
+
+        MobileBillingClient.RechargeOrder order = c.createRecharge("acct-x", 1000, "idem-0001",
+                "wxvp", "credits_cny_10", "0a1b2c3d4e");
+
+        assertEquals("virtual", order.present());
+        assertEquals("aa11", order.paySig());
+        assertEquals("bb22", order.signature());
+        assertNull(order.codeUrl());
+        String sent = lastRequest.get();
+        assertTrue(sent.contains("\"channel\":\"wxvp\""), sent);
+        assertTrue(sent.contains("\"productId\":\"credits_cny_10\""), sent);
+        assertTrue(sent.contains("\"wxCode\":\"0a1b2c3d4e\""), sent);
+    }
+
+    @Test
+    @DisplayName("channel=wxvp 网络失败只发一次（wxCode 一次性，重试同一 body 必败）；默认通道仍重试一次")
+    void wxvpDoesNotRetryOnNetworkFailure() {
+        HttpMobileBillingClient c = stubbed(200, "{}");
+        stubDrop.set(true);
+
+        MobileBillingException e = assertThrows(MobileBillingException.class,
+                () -> c.createRecharge("acct-x", 1000, "idem-0001", "wxvp", "credits_cny_10", "0a1b2c3d4e"));
+        assertEquals(MobileBillingKind.UNAVAILABLE, e.getKind());
+        assertEquals(1, hits.get(), "wxvp 不许重试");
+
+        hits.set(0);
+        assertThrows(MobileBillingException.class,
+                () -> c.createRecharge("acct-x", 5000, "idem-0002", null, null, null));
+        assertEquals(2, hits.get(), "默认通道维持第一期的重试一次");
+    }
+
+    @Test
+    @DisplayName("不带 channel（第一期形态）：通道三兄弟一个都不上行")
+    void defaultChannelSendsNoChannelFields() {
+        HttpMobileBillingClient c = stubbed(200,
+                "{\"present\":\"qrcode\",\"outTradeNo\":\"OT-1\",\"amountCents\":5000,\"codeUrl\":\"weixin://x\"}");
+
+        assertEquals("weixin://x",
+                c.createRecharge("acct-x", 5000, "idem-0001", null, null, null).codeUrl());
+        String sent = lastRequest.get();
+        assertFalse(sent.contains("channel"), sent);
+        assertFalse(sent.contains("productId"), sent);
+        assertFalse(sent.contains("wxCode"), sent);
+    }
+
+    @Test
+    @DisplayName("400 product_mismatch：REJECTED，但给的是「请更新小程序」而不是「联系客服」")
+    void productMismatchHasItsOwnMessage() {
+        HttpMobileBillingClient c = stubbed(400, "{\"error\":\"product_mismatch\"}");
+
+        MobileBillingException e = assertThrows(MobileBillingException.class,
+                () -> c.createRecharge("acct-x", 9900, "idem-0001", "wxvp", "credits_cny_10", "0a1b"));
+
+        assertEquals(MobileBillingKind.REJECTED, e.getKind());
+        assertEquals("product_mismatch", e.getMachineError());
+        assertEquals("充值档位与金额不符，请更新小程序后重试", e.getMessage());
+    }
+
+    // ==================== 注销传导（dev-board#434） ====================
+
+    @Test
+    @DisplayName("delete-account 200 {deleted:true}：删成功，action 与 accountId 上行")
+    void deleteAccountSuccess() {
+        HttpMobileBillingClient c = stubbed(200, "{\"deleted\":true}");
+
+        MobileBillingClient.DeleteAccountResult r = c.deleteAccount("acct-x");
+
+        assertTrue(r.deleted());
+        assertNull(r.blocker());
+        assertTrue(lastRequest.get().contains("\"action\":\"delete-account\""), lastRequest.get());
+        assertTrue(lastRequest.get().contains("\"accountId\":\"acct-x\""), lastRequest.get());
+    }
+
+    @Test
+    @DisplayName("delete-account 200 {deleted:false}：带 blocker 与官网给的可读 message 回来")
+    void deleteAccountBlockedCarriesReason() {
+        HttpMobileBillingClient c = stubbed(200,
+                "{\"deleted\":false,\"blocker\":\"refundable_balance\",\"message\":\"账上还有可退余额\"}");
+
+        MobileBillingClient.DeleteAccountResult r = c.deleteAccount("acct-x");
+
+        assertFalse(r.deleted());
+        assertEquals("refundable_balance", r.blocker());
+        assertEquals("账上还有可退余额", r.message());
+    }
+
+    @Test
+    @DisplayName("delete-account 带 body 的 404：官网本来就没有这个账户 = 已删，不是失败")
+    void deleteAccountNotFoundCountsAsDeleted() {
+        HttpMobileBillingClient c = stubbed(404, "{\"error\":\"account_not_found\"}");
+        assertTrue(c.deleteAccount("acct-x").deleted());
+    }
+
+    @Test
+    @DisplayName("delete-account 空体 404 / 5xx / 连不上：一律抛 UNAVAILABLE，绝不当成「已经删了」")
+    void deleteAccountFailuresAreLoud() {
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class,
+                        () -> stubbed(404, null).deleteAccount("acct-x")).getKind());
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class,
+                        () -> stubbed(502, "{\"error\":\"key_disable_failed\"}").deleteAccount("acct-x")).getKind());
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class,
+                        () -> new HttpMobileBillingClient(DEAD_BASE, "secret", om).deleteAccount("acct-x"))
+                        .getKind());
+        assertEquals(MobileBillingKind.DISABLED,
+                assertThrows(MobileBillingException.class,
+                        () -> new HttpMobileBillingClient("", "", om).deleteAccount("acct-x")).getKind());
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/mobile/MobileBillingRechargeDisabledTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileBillingRechargeDisabledTest.java
@@ -89,12 +89,13 @@ class MobileBillingRechargeDisabledTest {
         User u = phoneUser();
 
         MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
-                () -> service.createRecharge(u.getId(), 5000L, "idem-off-0001"));
+                () -> service.createRecharge(u.getId(), 5000L, "idem-off-0001", null, null, null));
 
         assertEquals(MobileBillingKind.DISABLED, e.getKind());
         // 一个上游请求都没发出去——建号那一位当然更没被置过 true
         verify(billing, never()).resolveAccountId(any(), any(), anyBoolean());
-        verify(billing, never()).createRecharge(anyString(), anyLong(), anyString());
+        verify(billing, never()).createRecharge(anyString(), anyLong(), anyString(),
+                any(), any(), any());
         verifyNoInteractions(billing);
         assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
     }
@@ -120,7 +121,8 @@ class MobileBillingRechargeDisabledTest {
         for (Object[] bad : new Object[][]{{null, null}, {0L, "short"}, {-1L, "has space!!"}}) {
             assertEquals(MobileBillingKind.DISABLED,
                     assertThrows(MobileBillingFailureException.class,
-                            () -> service.createRecharge(u.getId(), (Long) bad[0], (String) bad[1])).getKind());
+                            () -> service.createRecharge(u.getId(), (Long) bad[0], (String) bad[1],
+                                    null, null, null)).getKind());
         }
         assertEquals(MobileBillingKind.DISABLED,
                 assertThrows(MobileBillingFailureException.class,

--- a/backend/src/test/java/com/checkba/service/mobile/MobileBillingServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/MobileBillingServiceTest.java
@@ -148,7 +148,8 @@ class MobileBillingServiceTest {
             assertTrue(assertThrows(IllegalArgumentException.class,
                     () -> service.balance(u.getId())).getMessage().contains("审核演示账号"));
             assertTrue(assertThrows(IllegalArgumentException.class,
-                    () -> service.createRecharge(u.getId(), 5000L, "idem-review-01")).getMessage()
+                    () -> service.createRecharge(u.getId(), 5000L, "idem-review-01", null, null, null))
+                    .getMessage()
                     .contains("审核演示账号"));
             assertTrue(accountBindingRepository.findByUserId(u.getId()).isEmpty());
         }
@@ -195,10 +196,10 @@ class MobileBillingServiceTest {
 
         for (String bad : new String[]{null, "", "   ", "short", "has space!!"}) {
             String msg = assertThrows(IllegalArgumentException.class,
-                    () -> service.createRecharge(u.getId(), 5000L, bad)).getMessage();
+                    () -> service.createRecharge(u.getId(), 5000L, bad, null, null, null)).getMessage();
             assertTrue(msg.contains("idempotencyKey"), msg);
         }
-        verify(billing, never()).createRecharge(any(), anyLong(), any());
+        verify(billing, never()).createRecharge(any(), anyLong(), any(), any(), any(), any());
     }
 
     @Test
@@ -209,9 +210,9 @@ class MobileBillingServiceTest {
 
         for (Long bad : new Long[]{null, 0L, -1L}) {
             assertThrows(IllegalArgumentException.class,
-                    () -> service.createRecharge(u.getId(), bad, "idem-amount-01"));
+                    () -> service.createRecharge(u.getId(), bad, "idem-amount-01", null, null, null));
         }
-        verify(billing, never()).createRecharge(any(), anyLong(), any());
+        verify(billing, never()).createRecharge(any(), anyLong(), any(), any(), any(), any());
     }
 
     @Test
@@ -220,15 +221,91 @@ class MobileBillingServiceTest {
         User u = phoneUser();
         String accountId = "acct-pay-" + u.getId();
         bind(u.getId(), accountId);
-        when(billing.createRecharge(accountId, 5000L, "idem-abc-0001"))
-                .thenReturn(new RechargeOrder("qrcode", "OT123", 5000L, "weixin://x", null, null));
+        when(billing.createRecharge(accountId, 5000L, "idem-abc-0001", null, null, null))
+                .thenReturn(new RechargeOrder("qrcode", "OT123", 5000L, "weixin://x", null, null,
+                        null, null, null));
 
-        RechargeOrder order = service.createRecharge(u.getId(), 5000L, "idem-abc-0001");
+        RechargeOrder order = service.createRecharge(u.getId(), 5000L, "idem-abc-0001",
+                null, null, null);
 
         assertEquals("qrcode", order.present());
         assertEquals("OT123", order.outTradeNo());
         assertEquals(5000L, order.amountCents());
-        verify(billing).createRecharge(accountId, 5000L, "idem-abc-0001");
+        verify(billing).createRecharge(accountId, 5000L, "idem-abc-0001", null, null, null);
+    }
+
+    // ==================== 小程序虚拟支付通道（dev-board#427） ====================
+
+    @Test
+    @DisplayName("channel=wxvp：productId / wxCode 原样上行，signData 三兄弟原样带回")
+    void wxvpChannelIsPassedThroughBothWays() {
+        User u = phoneUser();
+        String accountId = "acct-wxvp-" + u.getId();
+        bind(u.getId(), accountId);
+        when(billing.createRecharge(accountId, 1000L, "idem-wxvp-0001",
+                "wxvp", "credits_cny_10", "0a1b2c3d4e"))
+                .thenReturn(new RechargeOrder("virtual", "OT-wxvp", 1000L, null, null, null,
+                        "{\"offerId\":\"1450637533\"}", "paysig-hex", "sig-hex"));
+
+        RechargeOrder order = service.createRecharge(u.getId(), 1000L, "idem-wxvp-0001",
+                "wxvp", "credits_cny_10", "0a1b2c3d4e");
+
+        assertEquals("virtual", order.present());
+        assertEquals("paysig-hex", order.paySig());
+        assertEquals("sig-hex", order.signature());
+        assertNull(order.codeUrl());
+        verify(billing).createRecharge(accountId, 1000L, "idem-wxvp-0001",
+                "wxvp", "credits_cny_10", "0a1b2c3d4e");
+    }
+
+    @Test
+    @DisplayName("channel=wxvp 缺 productId / wxCode 或 productId 形态不对：拒绝，不发上游")
+    void wxvpRequiresProductIdAndWxCode() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-wxvp-bad-" + u.getId());
+
+        // {productId, wxCode}
+        String[][] bad = {
+                {null, "0a1b2c3d4e"}, {"", "0a1b2c3d4e"}, {"Credits CNY 10", "0a1b2c3d4e"},
+                {"credits_cny_10", null}, {"credits_cny_10", "   "}};
+        for (String[] args : bad) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.createRecharge(u.getId(), 1000L, "idem-wxvp-bad1",
+                            "wxvp", args[0], args[1]));
+        }
+        verify(billing, never()).createRecharge(any(), anyLong(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("不认识的 channel：拒绝，绝不静默退回站点默认通道")
+    void unknownChannelIsRefusedNotSilentlyDowngraded() {
+        User u = phoneUser();
+        bind(u.getId(), "acct-wxvp-ch-" + u.getId());
+
+        for (String ch : new String[]{"alipay", "WXVP", "wxpay"}) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> service.createRecharge(u.getId(), 1000L, "idem-wxvp-ch01",
+                            ch, "credits_cny_10", "0a1b2c3d4e"));
+        }
+        verify(billing, never()).createRecharge(any(), anyLong(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("金额与档位是否相符不在这里判：官网的 product_mismatch 原样译成 REJECTED")
+    void productMismatchFromUpstreamStaysRejected() {
+        User u = phoneUser();
+        String accountId = "acct-wxvp-mm-" + u.getId();
+        bind(u.getId(), accountId);
+        doThrow(new MobileBillingException(MobileBillingKind.REJECTED,
+                "充值档位与金额不符，请更新小程序后重试", "product_mismatch"))
+                .when(billing).createRecharge(accountId, 9900L, "idem-wxvp-mm01",
+                        "wxvp", "credits_cny_10", "0a1b2c3d4e");
+
+        MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
+                () -> service.createRecharge(u.getId(), 9900L, "idem-wxvp-mm01",
+                        "wxvp", "credits_cny_10", "0a1b2c3d4e"));
+        assertEquals(MobileBillingKind.REJECTED, e.getKind());
+        assertEquals("充值档位与金额不符，请更新小程序后重试", e.getMessage());
     }
 
     // ==================== 缓存与降级 ====================
@@ -353,11 +430,13 @@ class MobileBillingServiceTest {
         User u = phoneUser();
         String accountId = "acct-create-" + u.getId();
         when(billing.resolveAccountId(eq(u.getPhone()), isNull(), eq(true))).thenReturn(accountId);
-        when(billing.createRecharge(accountId, 5000L, "idem-create-01"))
-                .thenReturn(new RechargeOrder("qrcode", "OT-create", 5000L, "weixin://x", null, null));
+        when(billing.createRecharge(accountId, 5000L, "idem-create-01", null, null, null))
+                .thenReturn(new RechargeOrder("qrcode", "OT-create", 5000L, "weixin://x", null, null,
+                        null, null, null));
 
         assertEquals("OT-create",
-                service.createRecharge(u.getId(), 5000L, "idem-create-01").outTradeNo());
+                service.createRecharge(u.getId(), 5000L, "idem-create-01", null, null, null)
+                        .outTradeNo());
         verify(billing).resolveAccountId(u.getPhone(), null, true);
     }
 
@@ -439,10 +518,10 @@ class MobileBillingServiceTest {
         bind(u.getId(), accountId);
         doThrow(new MobileBillingException(MobileBillingKind.ALREADY_PAID,
                 "这笔充值已经支付成功，请查看订单状态", "order_already_paid", "RECHARGE20260904"))
-                .when(billing).createRecharge(accountId, 5000L, "idem-paid-0001");
+                .when(billing).createRecharge(accountId, 5000L, "idem-paid-0001", null, null, null);
 
         MobileBillingFailureException e = assertThrows(MobileBillingFailureException.class,
-                () -> service.createRecharge(u.getId(), 5000L, "idem-paid-0001"));
+                () -> service.createRecharge(u.getId(), 5000L, "idem-paid-0001", null, null, null));
         assertEquals(MobileBillingKind.ALREADY_PAID, e.getKind());
         assertEquals("RECHARGE20260904", e.getOutTradeNo());
     }


### PR DESCRIPTION
## 做了什么
- `POST /api/mobile/billing/recharge` 请求加 `channel` / `productId` / `wxCode`（`channel=wxvp` 时三者必填，其它取值 code 1 无 kind）；响应透传官网算好的 `present=virtual` + `signData` / `paySig` / `signature`。云后端不持 AppKey、不碰 session_key。
- wxvp 通道网络失败**不重试**（wxCode 一次性，重试同一 body 必败），回 UNAVAILABLE 由小程序重新 wx.login 带同一幂等键再来；默认通道维持第一期重试一次。
- 官网 400 `product_mismatch` → `kind=REJECTED`「充值档位与金额不符，请更新小程序后重试」。
- **dev-board#434 注销传导**：`AccountDeletionService.deleteAccount` 有 `account_binding` 时先调官网 `delete-account`；`deleted:true` 或带 body 的 404 才删本地；`deleted:false` → REJECTED（官网 message）、不可达 / 5xx / 本机未配 → UNAVAILABLE，两者都不删本地。无绑定不发请求。
- `mobile-v1.yaml` 同步（移动仓合并后 `pull-api.mjs` 重钉）；`application.yml` 注释更新。

## 测试
JAVA_HOME=jdk-21（Homebrew JDK 26 上 lombok 崩）：
```
mvn -o test -Dtest='HttpMobileBillingClientTest'  → Tests run: 19, Failures: 0, Errors: 0
mvn -o test -Dtest='MobileApiContractTest,MobileBillingServiceTest,MobileBillingRechargeDisabledTest' → Tests run: 35, Failures: 0
mvn -o test -Dtest='AccountDeletionServiceTest' → Tests run: 8, Failures: 0
mvn -o test（全量，含 wxvp 不重试测试之前跑的）→ Tests run: 3403, Failures: 0, Errors: 0, Skipped: 14
```

## 未验证
未与真实官网联调（官网 PR zeweihan/aiworkdeck_website#167）。契约测试对请求体校验是 IGNORE（既有配置），新请求字段只靠单测钉住。

## 部署
北京 ECS `/opt/aiworkdeck/cloud/env` 已配 `MOBILE_BILLING_BASE_URL` / `MOBILE_BILLING_SECRET`；`MOBILE_BILLING_RECHARGE_ENABLED` 等官网 delete-account 上线后再开。方案：移动仓 `docs/specs/2026-09-09-miniprogram-virtual-payment-plan.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)