### PR TITLE
build(desktop): 安装包瘦身 P1——构建管线纯裁剪（dev-board#528）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -192,6 +192,12 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    绿 https://github.com/zeweihan/aiworkdeck/actions/runs/33576754273 。
 
 6.6. **`dmg-builder` 补丁（`desktop/scripts/patch-dmg-builder.js` + package.json `postinstall`，安装器 UI 重设计新增）**：macOS 26.2+ 起 Finder 拒读 dmgbuild 写入 `.DS_Store` 的 `pBBk` 背景书签，导致桌面端主 DMG 背景不显示（electron-builder#9072 / dmgbuild#273，同版 Obsidian/Podman Desktop 同期中招）。`npm ci`/`npm install` 后自动对 `node_modules/dmg-builder/vendor/dmgbuild/core.py` 做定点补丁（跳过 Bookmark 生成，`icvp` 里的 alias 通道保留，老系统照常工作）。**升级 electron-builder 后若补丁脚本报「结构已变」**：先确认新版是否已自带该修复，再决定要不要删掉本补丁，不要盲目跳过。
+6.7. **安装包瘦身 P1（dev-board#528，规格 `docs/superpowers/specs/2026-09-09-installer-slimming-design.md`）**，四条新地雷：
+   ① `prepare-backend.js` 拆包后调 `trim-driver-bundle.js` 把 Playwright `driver-bundle-*.jar` 重写成只含 `driver/<本平台>/`（mac-arm64 / win32_x64，字符串必须与 `DriverJar#platformDir` 逐字一致，161MB→31MB）；zip 条目级原样搬运不重压，找不到本平台目录直接抛错。
+   ② `backend/pom.xml` 的 `javacv-platform` 已换成 `javacv` + `ffmpeg-platform`（全仓唯一调用方 `MeetingAudioTranscoder`）；**不要再引回聚合体**，opencv/leptonica/tesseract 没有任何调用方。
+   ③ mac 语言包靠 `desktop/scripts/after-pack.js`（`build.afterPack`）在签名前删 Framework 里非 en/zh_CN 的 `*.lproj`（−36MB）；`electronLanguages` 在 mac 上只裁 `Contents/Resources` 的空壳。**升级 electron-builder 要回头核 `platformPackager.js` 里 afterPack 仍早于 doSignAfterPack**；`afterPack` 相对路径按 cwd 解析，必须在 `desktop/` 里跑。
+   ④ `installer.nsh` 顶部 `SetCompressor /SOLID lzma` 盖掉 electron-builder 用 `-X` 下发的 zlib（ARM64 壳的 `File /r` 走它）；`nsis.differentialPackage=false` 关掉为 electron-updater 差量准备的 dict 1MB/非固实 7z。`installer-ui-smoke.yml` 不覆盖 installer.nsh，只有 desktop-build.yml 的 Windows 腿能验；固实压缩会让 makensis 变慢。
+   ⑤ `prepare-python-service.js` 的 `prune()` 扩表（torch/include|test|share、bin/magika|ruff、pocketsphinx-data、一级包 tests/|test/、gradio *.js.map）；**`testing/` 不能删**（`torch/__init__` eager import 它），`dist-info/RECORD` 不能删。
 
 ## 测试命令总表
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -227,11 +227,21 @@
         </dependency>
 
 
-        <!-- JavaCV (FFmpeg wrapper) for Video Processing -->
+        <!-- JavaCV (FFmpeg wrapper)：全仓唯一用途是 MeetingAudioTranscoder 把
+             会议录音 webm/opus 转 16kHz 单声道 mp3。原先引的聚合体 javacv-platform
+             会把 opencv/openblas/leptonica/tesseract/librealsense2 与一堆摄像头驱动
+             一并拖进 backend/lib（mac 51MB、win 101MB），而这些库一个调用方都没有。
+             改成 javacv 本体 + ffmpeg-platform：-Djavacpp.platform=<平台> 照旧把
+             ffmpeg 的原生 jar 收敛到单平台（安装包瘦身 dev-board#528）。 -->
         <dependency>
             <groupId>org.bytedeco</groupId>
-            <artifactId>javacv-platform</artifactId>
+            <artifactId>javacv</artifactId>
             <version>1.5.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>ffmpeg-platform</artifactId>
+            <version>6.1.1-1.5.10</version>
         </dependency>
 
         <!-- Apache POI for DOCX Processing -->

--- a/desktop/build/installer.nsh
+++ b/desktop/build/installer.nsh
@@ -11,6 +11,22 @@
 ; 卸载器不走一键 UI，保持 MUI 经典页（installerSidebar/uninstallerSidebar 仍在用）。
 ; 静默安装（/S，自动更新路径）不进 GUI 代码，行为与从前一致。
 
+; 压缩器（安装包瘦身 dev-board#528）：electron-builder 把 `SetCompressor zlib` 当作
+; makensis 的**命令行** -X 参数下发（NsisTarget.js executeMakensis：先 -D 定义、
+; 再 -X 命令、最后一个 "-" 表示脚本从 stdin 读），所以它先于整份脚本执行；
+; 本 include 又在生成脚本的最前部展开，于是这里重设一次就能盖掉它——electron-builder
+; 没有用 /FINAL，NSIS 允许在任何 Section/Function/PageEx 之前重设。
+; 本机实测（electron-builder 自带的 mac makensis 3.0.4.1，-WX -INPUTCHARSET UTF8
+; "-XSetCompressor zlib" 加一份带本行的 stdin 脚本）：输出为
+; "Using lzma (compress whole) compression."，且不产生任何警告（-WX 下不会误伤）；
+; 去掉本行的对照组输出 "Using zlib compression."。
+; 收益落在 customInstall 里那份用 NSIS 原生 File /r 塞进来的 ARM64 Electron 壳
+;（约 260MB 未压缩，zlib 约 41.7%、固实 LZMA 约 27.3%，本机实测系数）。
+; 主载荷 app-64.7z 早已是 7z/LZMA，再压一遍不会变小也不会变大多少，代价是编译更慢。
+; 位置必须留在本文件最顶部：SetCompressor 只能出现在任何 Section/Function/PageEx 之前，
+; 而下面 !include 的 awd-oneclick-ui.nsh 会定义 Function。
+SetCompressor /SOLID lzma
+
 !define AWD_UI_ART "${BUILD_RESOURCES_DIR}/win/generated"
 !define AWD_UI_DIR_CHOICE
 !define AWD_UI_DIR_LEAF "AI WorkDeck"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/port-chain-contract.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/main-window-lifecycle.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/workflow-release-gating.test.js tests/share-file.test.js tests/product-identity-ua.test.js"
+    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/port-chain-contract.test.js tests/model-manager.test.js tests/pysvc-runtime.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/main-window-lifecycle.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/trim-driver-bundle.test.js tests/after-pack.test.js tests/workflow-release-gating.test.js tests/share-file.test.js tests/product-identity-ua.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
@@ -33,6 +33,11 @@
       "main/**",
       "preload/**"
     ],
+    "electronLanguages": [
+      "en-US",
+      "zh-CN"
+    ],
+    "afterPack": "scripts/after-pack.js",
     "extraResources": [
       {
         "from": "../frontend/dist/build/h5",
@@ -127,7 +132,8 @@
       "installerHeader": "build/win/installerHeader.bmp",
       "shortcutName": "AI WorkDeck",
       "include": "build/installer.nsh",
-      "deleteAppDataOnUninstall": false
+      "deleteAppDataOnUninstall": false,
+      "differentialPackage": false
     }
   }
 }

--- a/desktop/scripts/after-pack.js
+++ b/desktop/scripts/after-pack.js
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// electron-builder 的 afterPack 钩子（安装包瘦身 dev-board#528）。
+//
+// ── 为什么需要它 ──
+// package.json 的 `electronLanguages: ["en-US", "zh-CN"]` 在 mac 上**只裁**
+// `Contents/Resources/*.lproj`——那批目录里除了 InfoPlist.strings 什么都没有，
+// 删掉几乎不省体积。真正的语言包在
+// `Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/*.lproj`
+// 里（每个 lproj 一份 locale.pak），Electron 30.5.1 上是 55 个、合计约 37 MB，
+// electron-builder 的 electronLanguages 完全不碰它。
+// 所以这一刀只能自己补。
+//
+// ── 为什么放在 afterPack ──
+// app-builder-lib 24.13.3 的 `out/platformPackager.js` 里，
+// 第 232 行 `await this.info.afterPack(packContext)` 早于
+// 第 239 行 `await this.doSignAfterPack(...)`；mac 的 universal 分支同理，
+// `out/macPackager.js` 第 125 行 afterPack、第 126 行 doSignAfterPack。
+// 也就是钩子跑完才签名，删文件不会破坏 code signature。
+// **升级 electron-builder 后要回头核这两处的先后**——若签名跑到前面，
+// 这个钩子会把签好的 framework 改脏，Gatekeeper 直接判无效。
+//
+// 只在 darwin 上动手：Windows 的语言包是 `locales/*.pak` 平铺在 resources 旁边，
+// electron-builder 的 electronLanguages 已经裁得掉，不需要这一刀。
+
+const fs = require('fs');
+const path = require('path');
+
+/** 保留的语言目录。Base.lproj 当前 Electron 版本里没有，留着是防它哪天回来。 */
+const KEEP_LPROJ = ['en.lproj', 'zh_CN.lproj', 'Base.lproj'];
+
+const FRAMEWORK_RESOURCES = path.join(
+    'Contents',
+    'Frameworks',
+    'Electron Framework.framework',
+    'Versions',
+    'A',
+    'Resources',
+);
+
+/** 递归求一个目录的字节数（lproj 里目前只有 locale.pak，但不假设）。 */
+function dirBytes(dir) {
+    let total = 0;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) total += dirBytes(full);
+        else if (entry.isFile()) total += fs.statSync(full).size;
+    }
+    return total;
+}
+
+/**
+ * 删掉 resourcesDir 下 keep 之外的所有 *.lproj。
+ *
+ * @param {string} resourcesDir Electron Framework 的 Versions/A/Resources 目录
+ * @param {string[]} keep 要保留的目录名（形如 'en.lproj'）
+ * @returns {{ removed: string[], keptCount: number, bytes: number }}
+ *          removed = 被删掉的目录名，keptCount = 保留下来的 lproj 个数，
+ *          bytes = 删掉的字节数
+ *
+ * 目录不存在直接抛：这一步默默 no-op 的话，Electron 改了布局也没人知道，
+ * 37 MB 的回归会一路混进发版包（这类"只做不断言"的步骤在本仓栽过）。
+ */
+function pruneFrameworkLocales(resourcesDir, keep = KEEP_LPROJ) {
+    if (!fs.existsSync(resourcesDir)) {
+        throw new Error(`Electron Framework Resources not found: ${resourcesDir}`);
+    }
+    const keepSet = new Set(keep);
+    const removed = [];
+    let keptCount = 0;
+    let bytes = 0;
+
+    for (const name of fs.readdirSync(resourcesDir)) {
+        if (!name.endsWith('.lproj')) continue;
+        if (keepSet.has(name)) {
+            keptCount++;
+            continue;
+        }
+        const full = path.join(resourcesDir, name);
+        bytes += dirBytes(full);
+        fs.rmSync(full, { recursive: true, force: true });
+        removed.push(name);
+    }
+    return { removed, keptCount, bytes };
+}
+
+/** electron-builder afterPack 钩子。 */
+module.exports = async (context) => {
+    if (context.electronPlatformName !== 'darwin') return;
+
+    const resourcesDir = path.join(
+        context.appOutDir,
+        `${context.packager.appInfo.productFilename}.app`,
+        FRAMEWORK_RESOURCES,
+    );
+    const { removed, keptCount, bytes } = pruneFrameworkLocales(resourcesDir, KEEP_LPROJ);
+    console.log(
+        `  • prune framework locales  removed=${removed.length} kept=${keptCount} ` +
+            `freed=${(bytes / 1024 / 1024).toFixed(1)} MB`,
+    );
+};
+
+module.exports.pruneFrameworkLocales = pruneFrameworkLocales;
+module.exports.KEEP_LPROJ = KEEP_LPROJ;

--- a/desktop/scripts/prepare-backend.js
+++ b/desktop/scripts/prepare-backend.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { driverPlatformDir, findDriverBundleJar, trimDriverBundleJar } = require('./trim-driver-bundle');
 
 // Module set = `jdeps --print-module-deps` over the backend fat jar, widened
 // to java.se (aggregator), plus modules jdeps cannot see (reflection/JPMS
@@ -105,6 +106,20 @@ fs.rmSync(work, { recursive: true, force: true });
 const libCount = fs.readdirSync(path.join(backendDir, 'lib')).length;
 console.log(`Backend split: app.jar ${(fs.statSync(appJar).size / 1048576).toFixed(1)}MB + lib/ ${libCount} jars`);
 
+// 1b) Playwright driver-bundle 只留本平台驱动（安装包瘦身 dev-board#528）：
+// 上游 jar 里并排放着五套平台驱动，运行时只读 driver/<platformDir>/ 那一套
+// （见 trim-driver-bundle.js 顶部注释）。跨平台构建这里按目标平台名裁剪。
+const driverJar = findDriverBundleJar(path.join(backendDir, 'lib'));
+if (driverJar) {
+    const keep = driverPlatformDir(process.platform, process.arch);
+    const r = trimDriverBundleJar(driverJar, keep);
+    console.log(`Playwright driver-bundle trimmed to driver/${keep}: `
+        + `${(r.beforeBytes / 1048576).toFixed(1)}MB -> ${(r.afterBytes / 1048576).toFixed(1)}MB `
+        + `(dropped ${r.removedEntries} entries)`);
+} else {
+    console.log('Playwright driver-bundle jar not found in lib/ — skipping driver trim');
+}
+
 // 2) Trimmed runtime
 const jlink = path.join(javaHome, 'bin', process.platform === 'win32' ? 'jlink.exe' : 'jlink');
 const jreDir = path.join(outDir, 'jre');
@@ -115,7 +130,7 @@ execFileSync(jlink, [
     '--strip-debug',
     '--no-man-pages',
     '--no-header-files',
-    '--compress', 'zip-6',
+    '--compress', 'zip-9',
     '--output', jreDir
 ], { stdio: 'inherit' });
 

--- a/desktop/scripts/prepare-python-service.js
+++ b/desktop/scripts/prepare-python-service.js
@@ -118,8 +118,41 @@ function copyAppSource(srcDir, appDir) {
   })
 }
 
+// 包内固定路径的非运行时目录（安装包瘦身 dev-board#528）。
+// torch/include 是 C++ 扩展的头文件（61MB×两个服务），只有 torch.utils.cpp_extension
+// 现场编译扩展才要；torch/test 是 C++ 单测；torch/share 是 cmake 配置。
+// **torch/lib 不在表内**——那是 libtorch 本体，删了 import torch 直接完蛋。
+// speech_recognition/pocketsphinx-data 是离线英文声学模型（37MB），本仓走的是
+// 听悟/faster-whisper 两条转写通道，pocketsphinx 一行代码都没调。
+const PRUNE_PATHS = [
+  'torch/include',
+  'torch/test',
+  'torch/share',
+  'speech_recognition/pocketsphinx-data'
+]
+
+// bin/（pip --target 的 console_scripts 落点）里两个独立可执行文件：
+// magika 27MB 是 Rust CLI（markitdown 走的是 `import magika` 的 Python API，
+// 不 fork 这个二进制）、ruff 24MB 是 lint 工具，运行期都不会被调用。
+// 其余 bin/ 条目是几百字节的 Python 入口脚本，留着不占地方也免得误伤。
+const PRUNE_BIN_EXECUTABLES = ['magika', 'ruff']
+
+/**
+ * 逐个一级包目录下的测试套件。**只删 tests/ 与 test/，不删 testing/**：
+ * torch/__init__.py 里有一行 `testing as testing`（torch 2.12 的 :2317），
+ * 删掉 torch/testing 会让 `import torch` 当场炸掉，kokoro 与 mineru 一起死；
+ * numpy.testing / sqlalchemy.testing / sympy.testing 同样是对外 API。
+ * 这一类加起来只有约 12MB，不值得为它冒整条服务起不来的险。
+ */
+const PRUNE_PKG_TEST_DIRS = ['tests', 'test']
+
+function rmIfExists(p) {
+  if (fs.existsSync(p)) fs.rmSync(p, { recursive: true, force: true })
+}
+
 function prune(libDir) {
-  // 体积裁剪：字节码缓存（保守起见不动 dist-info——pip/importlib.metadata 需要）
+  // 体积裁剪：字节码缓存（保守起见不动 dist-info——pip/importlib.metadata 需要，
+  // 尤其是 RECORD：删了它 importlib.metadata 的 files() 与后续 pip 操作都会瞎）
   const stack = [libDir]
   while (stack.length) {
     const dir = stack.pop()
@@ -137,6 +170,33 @@ function prune(libDir) {
   if (fs.existsSync(srDir)) {
     for (const entry of fs.readdirSync(srDir)) {
       if (entry.startsWith('flac-')) fs.rmSync(path.join(srDir, entry), { recursive: true, force: true })
+    }
+  }
+  for (const rel of PRUNE_PATHS) rmIfExists(path.join(libDir, ...rel.split('/')))
+  // pip --target 在 POSIX 上把入口脚本放 bin/，Windows 上放 Scripts/
+  for (const binDir of ['bin', 'Scripts']) {
+    for (const name of PRUNE_BIN_EXECUTABLES) {
+      rmIfExists(path.join(libDir, binDir, name))
+      rmIfExists(path.join(libDir, binDir, `${name}.exe`))
+    }
+  }
+  for (const entry of fs.readdirSync(libDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.endsWith('.dist-info')) continue
+    for (const name of PRUNE_PKG_TEST_DIRS) rmIfExists(path.join(libDir, entry.name, name))
+  }
+  // gradio 的前端产物带着 1000 多个 sourcemap（mineru 实测 118MB）。mineru 走的是
+  // `-m mineru.cli.fast_api`，gradio 的 Web UI 根本不启动，何况 sourcemap 只服务浏览器
+  // devtools，删掉对任何运行路径都没有影响。
+  const gradioDir = path.join(libDir, 'gradio')
+  if (fs.existsSync(gradioDir)) {
+    const gstack = [gradioDir]
+    while (gstack.length) {
+      const dir = gstack.pop()
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, entry.name)
+        if (entry.isDirectory()) gstack.push(p)
+        else if (entry.name.endsWith('.js.map')) fs.rmSync(p, { force: true })
+      }
     }
   }
 }
@@ -164,4 +224,4 @@ if (require.main === module) {
   main()
 }
 
-module.exports = { isPythonRuntimeComplete, pythonBin, pythonMarker }
+module.exports = { isPythonRuntimeComplete, pythonBin, pythonMarker, prune }

--- a/desktop/scripts/trim-driver-bundle.js
+++ b/desktop/scripts/trim-driver-bundle.js
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Playwright 的 driver-bundle-<ver>.jar 里塞了五套平台驱动
+//（mac / mac-arm64 / win32_x64 / linux / linux-arm64，各含一个 node 二进制 +
+// 三百多个 package/ 文件，1.43.0 上合计 161MB），而运行时只会用其中一套：
+// com.microsoft.playwright.impl.driver.jar.DriverJar#getDriverResourceURI 拿的是
+// ClassLoader.getResource("driver/" + platformDir())，platformDir() 按 os.name/os.arch
+// 返回上面五个名字之一，随后只对那一个目录 Files.walk 解压。
+// 所以打包时把其余四套删掉对运行时零影响，安装包直接少一百多兆。
+//
+// 做法是 zip 条目级的「原样搬运」：按中央目录逐条判定去留，保留的条目连同它的
+// 本地头与**已压缩的数据字节**整块复制到新文件，只改中央目录里的相对偏移。
+// 不解压也不重压，因此压缩方式与压缩率与上游 jar 完全一致（不会退化成 store），
+// node 二进制的可执行位（external attributes）也原样保留。
+
+const fs = require('fs');
+const path = require('path');
+
+const EOCD_SIG = 0x06054b50;
+const CD_SIG = 0x02014b50;
+const LFH_SIG = 0x04034b50;
+const ZIP64_EOCD_LOCATOR_SIG = 0x07064b50;
+
+/** DriverJar#platformDir 的等价实现（字符串必须逐字一致，否则运行时找不到驱动）。 */
+function driverPlatformDir(platform = process.platform, arch = process.arch) {
+    if (platform === 'win32') return 'win32_x64';
+    if (platform === 'linux') return arch === 'arm64' ? 'linux-arm64' : 'linux';
+    if (platform === 'darwin') return arch === 'arm64' ? 'mac-arm64' : 'mac';
+    throw new Error(`unsupported platform for playwright driver: ${platform}/${arch}`);
+}
+
+/** lib/ 里的 driver-bundle-*.jar；没有就返回 null（依赖被移除时不要炸构建）。 */
+function findDriverBundleJar(libDir) {
+    if (!fs.existsSync(libDir)) return null;
+    const hit = fs.readdirSync(libDir).find((n) => /^driver-bundle-.*\.jar$/.test(n));
+    return hit ? path.join(libDir, hit) : null;
+}
+
+/**
+ * 条目去留：driver/ 之外的一律保留（DriverJar.class、META-INF、.gitignore 等）；
+ * driver/ 下只保留 keep 那一套（含 "driver/" 与 "driver/<keep>" 两个目录条目本身
+ * ——ClassLoader.getResource 要靠目录条目才能解析出 jar: URI）。
+ */
+function shouldKeepEntry(name, keep) {
+    if (!name.startsWith('driver/')) return true;
+    const rest = name.slice('driver/'.length);
+    if (rest === '') return true;
+    return rest === keep || rest.startsWith(`${keep}/`);
+}
+
+function findEocd(buf) {
+    const max = Math.min(buf.length, 0xffff + 22);
+    for (let i = buf.length - 22; i >= buf.length - max; i--) {
+        if (i < 0) break;
+        if (buf.readUInt32LE(i) === EOCD_SIG && i + 22 + buf.readUInt16LE(i + 20) === buf.length) return i;
+    }
+    throw new Error('EOCD not found: not a zip/jar file');
+}
+
+/**
+ * 重写 jar，只留 keep 这一套驱动。返回 { keptEntries, removedEntries, beforeBytes, afterBytes }。
+ * keep 目录不存在时抛错——那说明平台名对不上，静默放过会打出一个 browse_url 必挂的安装包。
+ */
+function trimDriverBundleJar(jarPath, keep) {
+    const buf = fs.readFileSync(jarPath);
+    const beforeBytes = buf.length;
+    const eocd = findEocd(buf);
+    if (eocd >= 20 && buf.readUInt32LE(eocd - 20) === ZIP64_EOCD_LOCATOR_SIG) {
+        throw new Error('zip64 jar is not supported by trim-driver-bundle');
+    }
+    const total = buf.readUInt16LE(eocd + 10);
+    let p = buf.readUInt32LE(eocd + 16);
+
+    const kept = [];
+    let removedEntries = 0;
+    let sawKeepDir = false;
+    for (let i = 0; i < total; i++) {
+        if (buf.readUInt32LE(p) !== CD_SIG) throw new Error(`bad central directory signature at entry ${i}`);
+        const flags = buf.readUInt16LE(p + 8);
+        if (flags & 0x08) throw new Error('entries with data descriptors are not supported by trim-driver-bundle');
+        const compressedSize = buf.readUInt32LE(p + 20);
+        const nameLen = buf.readUInt16LE(p + 28);
+        const extraLen = buf.readUInt16LE(p + 30);
+        const commentLen = buf.readUInt16LE(p + 32);
+        const localOffset = buf.readUInt32LE(p + 42);
+        const recordLen = 46 + nameLen + extraLen + commentLen;
+        const name = buf.toString('utf8', p + 46, p + 46 + nameLen);
+
+        if (shouldKeepEntry(name, keep)) {
+            if (name === `driver/${keep}` || name.startsWith(`driver/${keep}/`)) sawKeepDir = true;
+            if (buf.readUInt32LE(localOffset) !== LFH_SIG) throw new Error(`bad local header for ${name}`);
+            const localNameLen = buf.readUInt16LE(localOffset + 26);
+            const localExtraLen = buf.readUInt16LE(localOffset + 28);
+            const localEnd = localOffset + 30 + localNameLen + localExtraLen + compressedSize;
+            kept.push({ record: buf.subarray(p, p + recordLen), localStart: localOffset, localEnd });
+        } else {
+            removedEntries++;
+        }
+        p += recordLen;
+    }
+    if (!sawKeepDir) throw new Error(`driver/${keep} not found in ${path.basename(jarPath)}`);
+
+    const tmp = `${jarPath}.trim`;
+    const fd = fs.openSync(tmp, 'w');
+    try {
+        let offset = 0;
+        for (const entry of kept) {
+            const chunk = buf.subarray(entry.localStart, entry.localEnd);
+            fs.writeSync(fd, chunk, 0, chunk.length, offset);
+            entry.newOffset = offset;
+            offset += chunk.length;
+        }
+        const cdStart = offset;
+        for (const entry of kept) {
+            const record = Buffer.from(entry.record);
+            record.writeUInt32LE(entry.newOffset, 42);
+            fs.writeSync(fd, record, 0, record.length, offset);
+            offset += record.length;
+        }
+        const eocdBuf = Buffer.alloc(22);
+        eocdBuf.writeUInt32LE(EOCD_SIG, 0);
+        eocdBuf.writeUInt16LE(kept.length, 8);
+        eocdBuf.writeUInt16LE(kept.length, 10);
+        eocdBuf.writeUInt32LE(offset - cdStart, 12);
+        eocdBuf.writeUInt32LE(cdStart, 16);
+        fs.writeSync(fd, eocdBuf, 0, eocdBuf.length, offset);
+        offset += eocdBuf.length;
+    } finally {
+        fs.closeSync(fd);
+    }
+    fs.rmSync(jarPath);
+    fs.renameSync(tmp, jarPath);
+    return { keptEntries: kept.length, removedEntries, beforeBytes, afterBytes: fs.statSync(jarPath).size };
+}
+
+module.exports = { driverPlatformDir, findDriverBundleJar, shouldKeepEntry, trimDriverBundleJar };

--- a/desktop/tests/after-pack.test.js
+++ b/desktop/tests/after-pack.test.js
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const afterPack = require('../scripts/after-pack')
+const { pruneFrameworkLocales } = afterPack
+
+// 安装包瘦身 dev-board#528：electronLanguages 在 mac 上只裁 Contents/Resources/*.lproj，
+// 真正的语言包（Electron Framework 里的 55 个 lproj / 约 37MB）要靠 afterPack 自己删。
+// 这组用例守两件事：① 只有白名单里的 lproj 留下来，其余连同字节一起消失；
+// ② 非 darwin 的构建一个文件都不许动——Windows 的 locales/*.pak 归 electronLanguages 管，
+// 这里再插一手只会删错东西。
+
+const FRAMEWORK_RESOURCES = path.join(
+  'Contents', 'Frameworks', 'Electron Framework.framework', 'Versions', 'A', 'Resources',
+)
+
+/** 造一份最小的 .app：五个 lproj 各放一个 locale.pak，外加一个非 lproj 的邻居。 */
+function makeApp(root, productFilename = 'AI WorkDeck') {
+  const resourcesDir = path.join(root, `${productFilename}.app`, FRAMEWORK_RESOURCES)
+  fs.mkdirSync(resourcesDir, { recursive: true })
+  const sizes = { 'en.lproj': 10, 'zh_CN.lproj': 20, 'Base.lproj': 30, 'ja.lproj': 40, 'de.lproj': 50 }
+  for (const [name, size] of Object.entries(sizes)) {
+    fs.mkdirSync(path.join(resourcesDir, name))
+    fs.writeFileSync(path.join(resourcesDir, name, 'locale.pak'), Buffer.alloc(size, 1))
+  }
+  // lproj 之外的东西必须原样留下
+  fs.writeFileSync(path.join(resourcesDir, 'Info.plist'), 'plist')
+  fs.mkdirSync(path.join(resourcesDir, 'MainMenu.nib'))
+  fs.writeFileSync(path.join(resourcesDir, 'MainMenu.nib', 'keyedobjects.nib'), 'nib')
+  return { resourcesDir, sizes }
+}
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'awd-after-pack-'))
+}
+
+test('pruneFrameworkLocales 留白名单、删其余，返回删除清单与字节数', () => {
+  const root = mkTmp()
+  try {
+    const { resourcesDir } = makeApp(root)
+    const res = pruneFrameworkLocales(resourcesDir, ['en.lproj', 'zh_CN.lproj', 'Base.lproj'])
+
+    assert.deepStrictEqual(res.removed.sort(), ['de.lproj', 'ja.lproj'])
+    assert.strictEqual(res.keptCount, 3)
+    assert.strictEqual(res.bytes, 40 + 50)
+
+    const left = fs.readdirSync(resourcesDir).sort()
+    assert.deepStrictEqual(left, [
+      'Base.lproj', 'Info.plist', 'MainMenu.nib', 'en.lproj', 'zh_CN.lproj',
+    ].sort())
+    // 保留的 lproj 内容原封不动
+    assert.strictEqual(fs.readFileSync(path.join(resourcesDir, 'en.lproj', 'locale.pak')).length, 10)
+    assert.strictEqual(fs.readFileSync(path.join(resourcesDir, 'Info.plist'), 'utf8'), 'plist')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('白名单里没有的目录不存在时不报错（Base.lproj 当前 Electron 版本里就没有）', () => {
+  const root = mkTmp()
+  try {
+    const { resourcesDir } = makeApp(root)
+    fs.rmSync(path.join(resourcesDir, 'Base.lproj'), { recursive: true })
+    const res = pruneFrameworkLocales(resourcesDir, afterPack.KEEP_LPROJ)
+    assert.strictEqual(res.keptCount, 2)
+    assert.deepStrictEqual(res.removed.sort(), ['de.lproj', 'ja.lproj'])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('Resources 目录不存在时抛错，不静默 no-op', () => {
+  const root = mkTmp()
+  try {
+    assert.throws(
+      () => pruneFrameworkLocales(path.join(root, 'nope'), ['en.lproj']),
+      /Electron Framework Resources not found/,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('afterPack 钩子在 darwin 上裁掉多余语言包', async () => {
+  const root = mkTmp()
+  try {
+    const { resourcesDir } = makeApp(root)
+    await afterPack({
+      appOutDir: root,
+      electronPlatformName: 'darwin',
+      packager: { appInfo: { productFilename: 'AI WorkDeck' } },
+    })
+    assert.deepStrictEqual(
+      fs.readdirSync(resourcesDir).filter((n) => n.endsWith('.lproj')).sort(),
+      ['Base.lproj', 'en.lproj', 'zh_CN.lproj'],
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('afterPack 钩子在非 darwin 上一个文件都不动', async () => {
+  const root = mkTmp()
+  try {
+    const { resourcesDir } = makeApp(root)
+    const before = fs.readdirSync(resourcesDir).sort()
+    for (const platform of ['win32', 'linux']) {
+      await afterPack({
+        appOutDir: root,
+        electronPlatformName: platform,
+        packager: { appInfo: { productFilename: 'AI WorkDeck' } },
+      })
+    }
+    assert.deepStrictEqual(fs.readdirSync(resourcesDir).sort(), before)
+    assert.strictEqual(before.filter((n) => n.endsWith('.lproj')).length, 5)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/desktop/tests/prepare-python-service.test.js
+++ b/desktop/tests/prepare-python-service.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert')
 const fs = require('node:fs')
 const path = require('node:path')
 const os = require('node:os')
-const { isPythonRuntimeComplete, pythonBin, pythonMarker } = require('../scripts/prepare-python-service')
+const { isPythonRuntimeComplete, pythonBin, pythonMarker, prune } = require('../scripts/prepare-python-service')
 
 // dev-board#74 稳定性审计：ensurePython() 原来的缓存判据只看 python3.11 二进制在不在。
 // tar 中途被打断（Ctrl-C/OOM-kill/磁盘满，或 CI 任务被取消/重跑但 workspace 保留）时，
@@ -64,6 +64,123 @@ test('只有 marker、二进制缺失（比如运行时被误删）也必须判�
     fs.mkdirSync(pyRoot, { recursive: true })
     fs.writeFileSync(pythonMarker(pyRoot), '')
     assert.strictEqual(isPythonRuntimeComplete(pyRoot), false)
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+// ---- prune() 体积裁剪（安装包瘦身 dev-board#528）----
+// pysvc.tar.gz 796MB（解压 2.9GB）里有一大块是运行期永远不会被读到的东西：
+// torch 的 C++ 头文件、magika/ruff 两个独立可执行文件、pocketsphinx 的离线声学模型、
+// 各包自带的测试套件、gradio 的前端 sourcemap。这组用例守两头：该删的删了，
+// 以及**该留的一个都没少**——删错一样东西的代价是整个服务起不来，而这只会在
+// CI 冒烟或用户机上才暴露。
+
+function mkFile(p, content = 'x') {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, content)
+}
+
+/** 造一棵有代表性的 site-packages：既有该删的，也有长得很像但必须留下的。 */
+function makeLibTree(libDir) {
+  const f = (...seg) => path.join(libDir, ...seg)
+  // 删：torch 的非运行时目录
+  mkFile(f('torch', 'include', 'ATen', 'ATen.h'))
+  mkFile(f('torch', 'test', 'test_api.cpp'))
+  mkFile(f('torch', 'share', 'cmake', 'Torch', 'TorchConfig.cmake'))
+  // 留：torch 本体
+  mkFile(f('torch', 'lib', 'libtorch_cpu.dylib'))
+  mkFile(f('torch', '__init__.py'))
+  // 留：torch/testing 是 torch/__init__.py 里 `testing as testing` 那一行的目标
+  mkFile(f('torch', 'testing', '__init__.py'))
+  // 删：bin/ 里两个独立可执行文件；留：其余入口脚本
+  mkFile(f('bin', 'magika'))
+  mkFile(f('bin', 'ruff'))
+  mkFile(f('bin', 'magika.exe'))
+  mkFile(f('bin', 'uvicorn'))
+  mkFile(f('bin', 'mineru'))
+  // 删：pocketsphinx 离线模型；留：speech_recognition 本体
+  mkFile(f('speech_recognition', 'pocketsphinx-data', 'en-US', 'language-model.lm.bin'))
+  mkFile(f('speech_recognition', '__init__.py'))
+  // 删：一级包下的测试套件
+  mkFile(f('pandas', 'tests', 'test_frame.py'))
+  mkFile(f('pandas', '__init__.py'))
+  mkFile(f('youtube_transcript_api', 'test', 'test_api.py'))
+  // 留：testing/ 是对外 API，不许碰
+  mkFile(f('numpy', 'testing', '__init__.py'))
+  mkFile(f('sqlalchemy', 'testing', 'plugin.py'))
+  // 留：嵌套在包内部的 tests/（只扫一级，不递归乱删）
+  mkFile(f('sympy', 'core', 'tests', 'test_expr.py'))
+  // 删：gradio 的 sourcemap；留：它旁边的 js 本体
+  mkFile(f('gradio', 'templates', 'node', 'build', 'PlotlyPlot.js.map'))
+  mkFile(f('gradio', 'templates', 'node', 'build', 'PlotlyPlot.js'))
+  mkFile(f('gradio', '__init__.py'))
+  // 留：dist-info 全套，尤其 RECORD
+  mkFile(f('torch-2.12.1.dist-info', 'RECORD'))
+  mkFile(f('torch-2.12.1.dist-info', 'METADATA'))
+  // 删：老规矩，字节码缓存与 flac 转码器
+  mkFile(f('pandas', '__pycache__', '__init__.cpython-311.pyc'))
+  mkFile(f('speech_recognition', 'flac-mac'))
+}
+
+test('prune() 删掉运行期用不到的东西，且一个该留的都没少', () => {
+  const outDir = mkTmpOut()
+  try {
+    const libDir = path.join(outDir, 'lib')
+    makeLibTree(libDir)
+    const exists = (...seg) => fs.existsSync(path.join(libDir, ...seg))
+
+    // 前置条件：还原病灶——所有待删项此刻确实在场，否则这条用例证明不了任何事
+    for (const gone of [
+      ['torch', 'include', 'ATen', 'ATen.h'],
+      ['bin', 'magika'],
+      ['gradio', 'templates', 'node', 'build', 'PlotlyPlot.js.map'],
+      ['pandas', 'tests', 'test_frame.py']
+    ]) assert.ok(exists(...gone), `前置条件：${gone.join('/')} 应当存在`)
+
+    prune(libDir)
+
+    // 该删的
+    assert.ok(!exists('torch', 'include'), 'torch/include')
+    assert.ok(!exists('torch', 'test'), 'torch/test')
+    assert.ok(!exists('torch', 'share'), 'torch/share')
+    assert.ok(!exists('bin', 'magika'), 'bin/magika')
+    assert.ok(!exists('bin', 'magika.exe'), 'bin/magika.exe')
+    assert.ok(!exists('bin', 'ruff'), 'bin/ruff')
+    assert.ok(!exists('speech_recognition', 'pocketsphinx-data'), 'pocketsphinx-data')
+    assert.ok(!exists('pandas', 'tests'), 'pandas/tests')
+    assert.ok(!exists('youtube_transcript_api', 'test'), 'youtube_transcript_api/test')
+    assert.ok(!exists('gradio', 'templates', 'node', 'build', 'PlotlyPlot.js.map'), 'gradio sourcemap')
+    assert.ok(!exists('pandas', '__pycache__'), '__pycache__')
+    assert.ok(!exists('speech_recognition', 'flac-mac'), 'flac-mac')
+
+    // 该留的（删错这里任何一条，服务就起不来了）
+    assert.ok(exists('torch', 'lib', 'libtorch_cpu.dylib'), 'torch/lib 是 libtorch 本体')
+    assert.ok(exists('torch', '__init__.py'), 'torch/__init__.py')
+    assert.ok(exists('torch', 'testing', '__init__.py'),
+      'torch/testing 被 torch/__init__.py 直接 import，删掉 import torch 就炸')
+    assert.ok(exists('numpy', 'testing', '__init__.py'), 'numpy.testing 是对外 API')
+    assert.ok(exists('sqlalchemy', 'testing', 'plugin.py'), 'sqlalchemy.testing 是对外 API')
+    assert.ok(exists('sympy', 'core', 'tests', 'test_expr.py'), '只扫一级包，不递归删嵌套 tests/')
+    assert.ok(exists('bin', 'uvicorn') && exists('bin', 'mineru'), 'bin/ 里的入口脚本')
+    assert.ok(exists('speech_recognition', '__init__.py'), 'speech_recognition 本体')
+    assert.ok(exists('gradio', 'templates', 'node', 'build', 'PlotlyPlot.js'), 'gradio 的 js 本体')
+    assert.ok(exists('gradio', '__init__.py'), 'gradio 本体')
+    assert.ok(exists('torch-2.12.1.dist-info', 'RECORD'),
+      'dist-info/RECORD 一律不动——importlib.metadata 与后续 pip 操作都要它')
+    assert.ok(exists('torch-2.12.1.dist-info', 'METADATA'), 'dist-info/METADATA')
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('prune() 对没有这些目录的精简树也能跑完（asr 那种小依赖集）', () => {
+  const outDir = mkTmpOut()
+  try {
+    const libDir = path.join(outDir, 'lib')
+    mkFile(path.join(libDir, 'faster_whisper', '__init__.py'))
+    prune(libDir)
+    assert.ok(fs.existsSync(path.join(libDir, 'faster_whisper', '__init__.py')))
   } finally {
     fs.rmSync(outDir, { recursive: true, force: true })
   }

--- a/desktop/tests/trim-driver-bundle.test.js
+++ b/desktop/tests/trim-driver-bundle.test.js
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const zlib = require('node:zlib')
+const { execFileSync } = require('node:child_process')
+const { driverPlatformDir, findDriverBundleJar, shouldKeepEntry, trimDriverBundleJar } =
+  require('../scripts/trim-driver-bundle')
+
+// 安装包瘦身 dev-board#528：Playwright 的 driver-bundle jar 并排装着五套平台驱动，
+// 运行时只读 driver/<platformDir>/ 那一套（DriverJar#getDriverResourceURI）。
+// 这组用例守两件事：① 只有本平台目录留下来，其余平台一条不剩；
+// ② driver/ 以外的条目（DriverJar.class、META-INF/…）与本平台目录下的每个字节原样保留，
+// 且压缩方式不退化成 store——退化会让 jar 反而变大，是这类"重写 zip"最容易犯的错。
+
+// ---- 合成 zip（不依赖 zip/jar 外部命令，Windows runner 上也能跑）----
+const CRC_TABLE = (() => {
+  const t = new Int32Array(256)
+  for (let n = 0; n < 256; n++) {
+    let c = n
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    t[n] = c
+  }
+  return t
+})()
+
+function crc32(buf) {
+  let c = 0 ^ -1
+  for (let i = 0; i < buf.length; i++) c = (c >>> 8) ^ CRC_TABLE[(c ^ buf[i]) & 0xff]
+  return ((c ^ -1) >>> 0)
+}
+
+/** entries: [{ name, data?, store? }]；name 以 / 结尾即目录条目。 */
+function writeZip(file, entries) {
+  const locals = []
+  const centrals = []
+  let offset = 0
+  for (const e of entries) {
+    const name = Buffer.from(e.name, 'utf8')
+    const raw = e.data == null ? Buffer.alloc(0) : Buffer.from(e.data)
+    const store = e.store || raw.length === 0
+    const data = store ? raw : zlib.deflateRawSync(raw, { level: 9 })
+    const method = store ? 0 : 8
+    const lfh = Buffer.alloc(30)
+    lfh.writeUInt32LE(0x04034b50, 0)
+    lfh.writeUInt16LE(20, 4)
+    lfh.writeUInt16LE(0x0800, 6)
+    lfh.writeUInt16LE(method, 8)
+    lfh.writeUInt32LE(crc32(raw), 14)
+    lfh.writeUInt32LE(data.length, 18)
+    lfh.writeUInt32LE(raw.length, 22)
+    lfh.writeUInt16LE(name.length, 26)
+    locals.push(lfh, name, data)
+
+    const cd = Buffer.alloc(46)
+    cd.writeUInt32LE(0x02014b50, 0)
+    cd.writeUInt16LE(20, 4)
+    cd.writeUInt16LE(20, 6)
+    cd.writeUInt16LE(0x0800, 8)
+    cd.writeUInt16LE(method, 10)
+    cd.writeUInt32LE(crc32(raw), 16)
+    cd.writeUInt32LE(data.length, 20)
+    cd.writeUInt32LE(raw.length, 24)
+    cd.writeUInt16LE(name.length, 28)
+    cd.writeUInt32LE((((e.name.endsWith('/') ? 0o40755 : 0o100644) << 16) >>> 0), 38)
+    cd.writeUInt32LE(offset, 42)
+    centrals.push(cd, name)
+    offset += lfh.length + name.length + data.length
+  }
+  const cdBuf = Buffer.concat(centrals)
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(entries.length, 8)
+  eocd.writeUInt16LE(entries.length, 10)
+  eocd.writeUInt32LE(cdBuf.length, 12)
+  eocd.writeUInt32LE(offset, 16)
+  fs.writeFileSync(file, Buffer.concat([Buffer.concat(locals), cdBuf, eocd]))
+}
+
+/** 读回 zip：返回 { name -> { method, externalAttrs, content } }。 */
+function readZip(file) {
+  const buf = fs.readFileSync(file)
+  let i = buf.length - 22
+  while (i >= 0 && buf.readUInt32LE(i) !== 0x06054b50) i--
+  assert.ok(i >= 0, 'EOCD 必须存在')
+  const n = buf.readUInt16LE(i + 10)
+  let p = buf.readUInt32LE(i + 16)
+  const out = {}
+  for (let k = 0; k < n; k++) {
+    assert.strictEqual(buf.readUInt32LE(p), 0x02014b50, `中央目录条目 ${k} 签名`)
+    const method = buf.readUInt16LE(p + 10)
+    const compSize = buf.readUInt32LE(p + 20)
+    const uncompSize = buf.readUInt32LE(p + 24)
+    const nameLen = buf.readUInt16LE(p + 28)
+    const extraLen = buf.readUInt16LE(p + 30)
+    const commentLen = buf.readUInt16LE(p + 32)
+    const externalAttrs = buf.readUInt32LE(p + 38)
+    const off = buf.readUInt32LE(p + 42)
+    const name = buf.toString('utf8', p + 46, p + 46 + nameLen)
+    assert.strictEqual(buf.readUInt32LE(off), 0x04034b50, `${name} 的本地头签名`)
+    const ds = off + 30 + buf.readUInt16LE(off + 26) + buf.readUInt16LE(off + 28)
+    const raw = buf.subarray(ds, ds + compSize)
+    const content = method === 0 ? raw : zlib.inflateRawSync(raw)
+    assert.strictEqual(content.length, uncompSize, `${name} 解压后长度`)
+    out[name] = { method, externalAttrs, content }
+    p += 46 + nameLen + extraLen + commentLen
+  }
+  return out
+}
+
+// 每套平台驱动给一段"能压得动"的可辨认内容，用来验证留下来的字节没被串位
+function platformPayload(tag) {
+  return Buffer.from(`#!/usr/bin/env node\n// ${tag} driver payload\n`.repeat(200))
+}
+
+function makeBundle(dir) {
+  const jar = path.join(dir, 'driver-bundle-1.43.0.jar')
+  const entries = [
+    { name: 'META-INF/MANIFEST.MF', data: 'Manifest-Version: 1.0\n' },
+    { name: 'com/microsoft/playwright/impl/driver/jar/DriverJar.class', data: Buffer.from([0xca, 0xfe, 0xba, 0xbe, 1, 2, 3]) },
+    { name: '.gitignore', data: '*\n' },
+    { name: 'driver/', store: true },
+  ]
+  for (const p of ['mac', 'mac-arm64', 'win32_x64', 'linux', 'linux-arm64']) {
+    entries.push({ name: `driver/${p}/`, store: true })
+    entries.push({ name: `driver/${p}/node`, data: platformPayload(p) })
+    entries.push({ name: `driver/${p}/package/`, store: true })
+    entries.push({ name: `driver/${p}/package/cli.js`, data: `console.log('${p}')\n` })
+  }
+  writeZip(jar, entries)
+  return jar
+}
+
+function withTmp(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trim-driver-bundle-test-'))
+  try { return fn(dir) } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+}
+
+test('platformDir 与 Playwright DriverJar#platformDir 的字符串逐字一致', () => {
+  assert.strictEqual(driverPlatformDir('darwin', 'arm64'), 'mac-arm64')
+  assert.strictEqual(driverPlatformDir('darwin', 'x64'), 'mac')
+  assert.strictEqual(driverPlatformDir('win32', 'x64'), 'win32_x64')
+  assert.strictEqual(driverPlatformDir('linux', 'x64'), 'linux')
+  assert.strictEqual(driverPlatformDir('linux', 'arm64'), 'linux-arm64')
+  assert.throws(() => driverPlatformDir('aix', 'ppc64'), /unsupported platform/)
+})
+
+test('shouldKeepEntry：只放行本平台目录，别的平台一律拦下', () => {
+  assert.strictEqual(shouldKeepEntry('com/microsoft/playwright/impl/driver/jar/DriverJar.class', 'mac-arm64'), true)
+  assert.strictEqual(shouldKeepEntry('driver/', 'mac-arm64'), true)
+  assert.strictEqual(shouldKeepEntry('driver/mac-arm64/', 'mac-arm64'), true)
+  assert.strictEqual(shouldKeepEntry('driver/mac-arm64/package/cli.js', 'mac-arm64'), true)
+  // 前缀相近的两个目录不能互相误伤（mac 与 mac-arm64）
+  assert.strictEqual(shouldKeepEntry('driver/mac/node', 'mac-arm64'), false)
+  assert.strictEqual(shouldKeepEntry('driver/mac-arm64/node', 'mac'), false)
+  assert.strictEqual(shouldKeepEntry('driver/linux-arm64/node', 'linux'), false)
+})
+
+test('重写后只剩本平台驱动，其余条目原样保留且压缩没退化', () => withTmp((dir) => {
+  const jar = makeBundle(dir)
+  const before = readZip(jar)
+  const beforeSize = fs.statSync(jar).size
+
+  const r = trimDriverBundleJar(jar, 'mac-arm64')
+
+  const after = readZip(jar)
+  const names = Object.keys(after)
+  // 四套外平台一条不剩
+  for (const p of ['mac', 'win32_x64', 'linux', 'linux-arm64']) {
+    assert.ok(!names.some((n) => n.startsWith(`driver/${p}/`)), `driver/${p}/ 必须被删干净：${names}`)
+  }
+  // 本平台目录条目（getResource("driver/mac-arm64") 靠它解析 jar: URI）与内容都在
+  assert.deepStrictEqual(names.sort(), [
+    '.gitignore',
+    'META-INF/MANIFEST.MF',
+    'com/microsoft/playwright/impl/driver/jar/DriverJar.class',
+    'driver/',
+    'driver/mac-arm64/',
+    'driver/mac-arm64/node',
+    'driver/mac-arm64/package/',
+    'driver/mac-arm64/package/cli.js',
+  ])
+  // 字节级一致（内容 + 压缩方式 + 权限位）
+  for (const n of names) {
+    assert.deepStrictEqual(after[n].content, before[n].content, `${n} 内容`)
+    assert.strictEqual(after[n].method, before[n].method, `${n} 压缩方式`)
+    assert.strictEqual(after[n].externalAttrs, before[n].externalAttrs, `${n} 外部属性（可执行位）`)
+  }
+  // 压缩没退化成 store：能压的那两个条目仍是 deflate
+  assert.strictEqual(after['driver/mac-arm64/node'].method, 8)
+  assert.strictEqual(after['META-INF/MANIFEST.MF'].method, 8)
+  assert.strictEqual(r.keptEntries, 8)
+  assert.strictEqual(r.removedEntries, 16)
+  assert.strictEqual(r.beforeBytes, beforeSize)
+  assert.ok(r.afterBytes < beforeSize, `重写后应当变小：${r.afterBytes} < ${beforeSize}`)
+}))
+
+test('平台名对不上时必须报错，不能静默产出没有驱动的 jar', () => withTmp((dir) => {
+  const jar = makeBundle(dir)
+  assert.throws(() => trimDriverBundleJar(jar, 'mac-x64'), /driver\/mac-x64 not found/)
+}))
+
+test('findDriverBundleJar：认得出 lib/ 里的 driver-bundle-*.jar，认不出别的', () => withTmp((dir) => {
+  const lib = path.join(dir, 'lib')
+  fs.mkdirSync(lib)
+  assert.strictEqual(findDriverBundleJar(lib), null)
+  fs.writeFileSync(path.join(lib, 'playwright-1.43.0.jar'), '')
+  assert.strictEqual(findDriverBundleJar(lib), null)
+  fs.writeFileSync(path.join(lib, 'driver-bundle-1.43.0.jar'), '')
+  assert.strictEqual(findDriverBundleJar(lib), path.join(lib, 'driver-bundle-1.43.0.jar'))
+  assert.strictEqual(findDriverBundleJar(path.join(dir, 'nope')), null)
+}))
+
+// 真 JDK 在场时用 `jar -tf` 复核一遍：自研 zip 写出来的东西必须是 Java 认的 jar，
+// 不然"我的读法自洽"证明不了运行时能用（DriverJar 走的是 JDK 的 zipfs）。
+test('产物能被 JDK 的 jar 工具读出来（无 JDK 时跳过）', { skip: !process.env.JAVA_HOME }, () => withTmp((dir) => {
+  const jar = makeBundle(dir)
+  trimDriverBundleJar(jar, 'linux')
+  const jarTool = path.join(process.env.JAVA_HOME, 'bin', process.platform === 'win32' ? 'jar.exe' : 'jar')
+  if (!fs.existsSync(jarTool)) return
+  const listed = execFileSync(jarTool, ['-tf', jar], { encoding: 'utf8' }).split(/\r?\n/).filter(Boolean).sort()
+  assert.deepStrictEqual(listed, [
+    '.gitignore',
+    'META-INF/MANIFEST.MF',
+    'com/microsoft/playwright/impl/driver/jar/DriverJar.class',
+    'driver/',
+    'driver/linux/',
+    'driver/linux/node',
+    'driver/linux/package/',
+    'driver/linux/package/cli.js',
+  ])
+}))

--- a/docs/superpowers/specs/2026-09-09-installer-slimming-design.md
+++ b/docs/superpowers/specs/2026-09-09-installer-slimming-design.md
@@ -1,0 +1,135 @@
+# 安装包瘦身设计（dev-board#526 总卡；实施卡 #528 / #529 / #530）
+
+日期：2026-09-09。拍板人：韩泽伟。执行：Fable 主会话统筹，Opus 子代理实施。
+
+## 0. 目标与拍板
+
+- 目标：mac DMG 1486MB / win exe 1714MB（v0.37.0）→ 300–500MB 量级。
+- 拍板：① pptx-service 也按需下载（做）；② LOWA 编辑器引擎与 CJK 字体保持随包（不做按需）；
+  ③ Windows 保持单包双架构（ARM64 壳不拆，但其压缩方式可改）。
+- 用户硬性要求：**首次安装登录后**与**前端首次触发对应模块时**都要提示是否下载；
+  提示必须写明**影响范围**（下载什么、多大、解锁哪些功能、不下载哪些功能不可用）。
+- 预期落点：P1 后 mac ≈1235 / win ≈1298；P2 后 mac ≈440 / win ≈396。安装后磁盘从
+  「1.6GB + 2.9GB pysvc 解压树」降到约 1GB。
+
+## 1. 体积构成（实测 v0.37.0，mac 安装后 1650MB）
+
+| 组件 | 体积 | 根因 |
+|---|---|---|
+| Resources/pysvc.tar.gz | 797MB gzip（解压 2.9GB） | 四个 venv 零共享：torch×2、cv2×2、onnxruntime×3（三个版本）；mineru 带 gradio 196MB；pptx 带火山 SDK 131MB；`__pycache__` 92MB；bin/magika+ruff 76MB；torch/include 61MB×2 |
+| backend/lib | 370MB | Playwright `driver-bundle-1.43.0.jar` 161MB 含五套平台驱动；`javacv-platform` 拖进 opencv/openblas/leptonica/tesseract（mac 51MB、win 101MB），全仓只有 `MeetingAudioTranscoder` 用 ffmpeg |
+| Electron Framework | 222MB（压缩后 ~93） | 164 个 lproj 37MB 未裁 |
+| frontend/dist/zetaoffice | 116MB | LOWA 64MB（已 brotli）+ CJK 字体 51MB —— **保持随包** |
+| jre / python | 67 / 66MB | 已 jlink zip-6、已剥 stdlib test |
+| win 专属 | ARM64 壳 +106MB | NSIS 默认 differential-aware（dict 1MB、非固实）；壳走 zlib |
+
+四个 Python 服务都是活功能：pptx（AI 生成 PPT、PDF 转 Word、扫描件 OCR 路由）、mineru（扫描件解析，
+经 pptx 转发，无直接前端入口）、kokoro（语音合成唯一实现）、asr（会议转写「录音不出本机」第三档，
+faster-whisper）。mineru/kokoro 在模型未下时本就不启动；asr 故意常驻以区分「服务没起」与「模型没下」。
+
+## 2. P1 构建管线纯裁剪（#528）——零产品变化
+
+全部随大版本 0.38.0（patch-gate 拦 pom / desktop/package.json / desktop/build）。
+
+1. **Playwright 单平台**：`prepare-backend.js` 拆包后重写 `driver-bundle-*.jar`，只保留
+   `driver/<本平台>/`（mac-arm64 / win32_x64），其余四个平台目录删除。验证：`browse_url` 工具真抓一次页面。
+2. **javacv 只留 ffmpeg**：`backend/pom.xml` 的 `org.bytedeco:javacv-platform` 换成
+   `org.bytedeco:javacv` + `org.bytedeco:ffmpeg-platform`（或 ffmpeg + classifier），
+   `-Djavacpp.platform` 继续生效。验证：`MeetingAudioTranscoder` 真转码一段 webm → mp3；`mvn -B test` 全绿。
+3. **electronLanguages**：`desktop/package.json` build 加 `"electronLanguages": ["en-US", "zh-CN"]`。
+4. **NSIS 压缩**：`nsis.differentialPackage: false`；`desktop/build/installer.nsh` 在 ARM64 壳
+   `File /r` 之前 `SetCompressor /SOLID lzma`（本项目不用 electron-updater 差量；`build.publish` 为空）。
+   验证：`installer-ui-smoke.yml` 绿；ARM64 覆盖安装路径不变。
+5. **prune 扩表**：`prepare-python-service.js` 的 `prune()` 追加删除：`torch/include`、`torch/test`、
+   `torch/share`、`lib/bin/magika`、`lib/bin/ruff`、`speech_recognition/pocketsphinx-data`、
+   各包 `tests/`、`testing/` 目录、`gradio/**/*.js.map`、`*.dist-info/RECORD` 不删。
+   验证：`desktop/tests/prepare-python-service.test.js` 扩用例；四个服务 CI 冒烟不变。
+6. **jlink** `--compress zip-9`。
+7. 不做：DMG 换 UDBZ（实测仅 4 个百分点）；字体子集化；zstd `--long=31`。
+
+## 3. P2 四个 Python 服务搬 native pack（#529）
+
+### 3.1 pack 划分与命名
+- 一服务一 pack，id：`pptx-runtime`、`mineru-runtime`、`kokoro-runtime`、`asr-runtime`。
+  独立 semver 从 `1.0.0` 起；`minAppVersion: 0.38.0`；`engineApi: 1`。
+- 每个 pack 的 components：
+  - `lib`：`platforms: [mac-arm64]` / `[win-x64]` 各一个压缩包，内容 = `prepare-python-service.js` 产出的
+    `pysvc/<service>/lib`（已 prune），`unpackDir: lib`。
+  - `app`：`platforms: ["*"]`，内容 = `pysvc/<service>/app`（mineru 无此组件），`unpackDir: app`。
+  - 落盘 `~/.aiworkdeck/packs/<id>/<version>/{lib,app}`，与现有 `pysvc/<service>/{lib,app}` 布局同构，
+    服务 js 只换根目录。
+- 压缩格式沿用 tar.gz（Java 侧解包代码不动、不引新依赖）；zstd 留作后续。
+- `NativePackService` 的单包上限从 5000 条目 / 500MB 抬到 **150000 条目 / 2.5GB**
+  （manifest 有 Ed25519 签名，zip-bomb 只能来自我们自己的构建；torch 一个包就超旧上限）。
+- 模型（`mineru-models` 3GB / `kokoro-models` 300MB / `asr-models` 1.5GB）仍走 `model-manager.js`，
+  不并入 pack；「组件」在 UI 上呈现为「运行时 + 模型」一次下载，底层两条通道顺序执行。
+- CPython 运行时（`Resources/python` 66MB）继续随包（四个服务与 litviz 共用）。
+
+### 3.2 桌面壳与后端接线
+- `desktop/main/services/pysvc-runtime.js`：新增 `resolveServiceRoot(ctx, service)`：
+  打包态 → `~/.aiworkdeck/packs/<service>-runtime/current.json` 指向且带 `.pack-complete` 的目录；
+  开发态 → 现有 `desktop/bundled/<os>-<arch>/pysvc/<service>`。首启解压 `pysvc.tar.gz` 的逻辑整段删除
+  （`main.js` `ensurePysvcReady` 与 splash「约一分钟」文案）。
+- 四个 `*-service.js`：`enabled` 一律先判 runtime pack 在场；mineru/kokoro 再判模型；asr 改为
+  pack 在场即启动（`/health` 仍回 `modelReady`）。`LocalAsrClient.probe()` 扩成四态：
+  `RUNTIME_MISSING / SERVICE_DOWN / MODEL_MISSING / READY`。
+- 后端 `NativePackService` 已装/在场判定复用；`PackAutoInstaller` 不对这四个 pack 自动补下
+  （用户要求提示后再下）。新增只读接口 `GET /api/packs/optional-components`：返回四个组件的
+  id、版本、压缩体积、解压体积、是否已装、模型是否已装、功能清单键（供前端文案）。
+- `PptxTools` / `PdfTools`：服务不可达且 pack 未装 → 通过 `EditorBridgeService` 发
+  `component_required` 动作（`{ packId, modelId?, sizeMb, features: [...] }`），工具返回给模型的文本
+  说明「已请用户确认下载」，不再报「稍后重试」。
+
+### 3.3 打包与发布
+- `desktop/scripts/build-pack.js` 增加四个 pack 的组件定义（源目录 = `desktop/bundled/<os>-<arch>/pysvc/<service>`）。
+- `.github/workflows/pack-release.yml`：tag `pack-<id>-v<ver>` 触发，矩阵 mac-arm64 + win-x64 各跑
+  `prepare-python-service` → `build-pack`，汇总 job merge manifest；`prerelease: true` 保持。
+  冒烟：从 pack 布局启动服务打 `/health`（与 desktop-build.yml 现有四个冒烟同款）。
+- `desktop-build.yml`：摘掉四步 `prepare-python-service`、pysvc 冒烟、`pack-pysvc`；
+  `desktop/package.json` extraResources 摘掉 `pysvc.tar.gz` / `pysvc.meta.json`。
+- `build-patch-assets.js` 的 `pysvc-src` 组件废除：服务源码修复走 pack 新版本（24h 自动追新）。
+  `patch-gate.sh` 中 requirements.lock 那条改为「lock 改动走 pack 发版」。
+- 发布走 `deploy/publish-pack.sh`（签名私钥只在官网机），两站镜像对账。
+
+### 3.4 升级与兼容
+- 老用户升级到 0.38.0：随包 pysvc 不再存在，四个服务在 pack 未装时不启动；首次登录后弹「可选组件」面板
+  （§4），模型已装的组件默认勾选（用户此前已选择过该功能）。不做静默下载。
+- 离线部署：`ai.packs.enabled=false` 已有旁路；另出「离线整包」变体属于后续，不在本轮。
+
+## 4. 两处提示与影响范围（#530）
+
+### 4.1 首次安装登录后：「可选组件」面板
+- 触发：桌面端，登录成功后（或本机免登身份解析完成后），`optional-components` 里存在未装组件且
+  本机未标记 `optionalComponentsPrompted`（存 `~/.aiworkdeck/prefs` 或 electron-store，不是 localStorage，
+  重装才重置）。每次大版本升级后若出现新组件再提示一次。
+- 内容：四张卡片各写 名称 / 下载体积（运行时 + 模型分开列）/ 解锁功能 / 不装时哪些功能不可用；
+  复选框；「立即下载所选」（逐个顺序下载，带总进度）与「稍后再说」（可从 设置→组件管理 再来）。
+- 同一组件卡片组件复用到 设置→组件管理（替换现有只列模型的三行）。
+
+### 4.2 首次触发模块
+- AI 对话：收到 `component_required` → 弹窗（复用 DrawioEditor `installPack*` 文案与交互）→
+  确认后 `POST /api/packs/{id}/install` 带进度 → 若有 `modelId` 接着走 model-manager 下载 →
+  `host.services.ensure(service)` → 自动把原消息重发一次。
+- 语音合成面板：现有 `EasyVoicePane` 下载状态机从「只下模型」扩成「运行时 + 模型」。
+- 录音「不出本机」开关：打开时探测四态；`RUNTIME_MISSING` 弹同款提示。
+
+### 4.3 文案模板（zh-CN / en 双语，落 `frontend/src/locales/*/components.js`）
+> 需要下载〈组件名〉（约 N MB；含模型约 M MB）。落盘于 ~/.aiworkdeck，可在「设置→组件管理」卸载释放。
+> 它用于：……。不下载则：……不可用；其余功能不受影响。
+
+| 组件 | 运行时 | 模型 | 解锁功能 | 不装的影响 |
+|---|---|---|---|---|
+| PPT 与 PDF 组件（pptx-runtime） | ≈165MB | 无 | AI 生成 PPT、PPTX 读/改格式、PDF 转 Word（版式级）、扫描件 OCR 入口 | 上述功能不可用；PDF 仍可预览与结构级转换 |
+| 文档解析引擎（mineru-runtime） | ≈250MB | 3GB | 扫描件 PDF 转 Word / OCR 解析 | 扫描件转换退回云端 MinerU 或不可用 |
+| 语音合成（kokoro-runtime） | ≈200MB | 300MB | 语音面板「语音合成」 | 语音合成不可用 |
+| 本机语音识别（asr-runtime） | ≈40MB | 1.5GB | 录音转写「录音不出本机」档 | 只能用云端听悟两档 |
+
+（体积以 pack 构建实测为准，UI 从 manifest `size` 读，不写死。）
+
+## 5. 验证口径
+- P1：mac 本地 `electron-builder --dir` 量 Resources 与 Frameworks；CI Windows 腿产物体积；
+  `mvn -B test`；会议录音真转码；`browse_url` 真抓取；`installer-ui-smoke.yml`。
+- P2：四个 pack 在两平台从 pack 布局启动过 `/health`；桌面端 `desktop/tests` 新增
+  `pysvc-runtime.pack-resolve.test.js`；后端 `PackController` 与 `PptxTools` 单测；
+  前端 `components` 面板单测；真机走查：新装 → 首次登录面板 → 稍后再说 → AI 生成 PPT 触发提示 → 下载 → 自动重试成功。
+- 发版：0.38.0 大版本；四个 pack 先于 0.38.0 发布到两站镜像（否则新装用户无处可下）。


### PR DESCRIPTION
dev-board#528（总卡 #526）。零产品变化，只改构建产物。规格：docs/superpowers/specs/2026-09-09-installer-slimming-design.md §2。

## 改动
- Playwright `driver-bundle-1.43.0.jar` 只保留本平台驱动：161MB→31MB（新 `desktop/scripts/trim-driver-bundle.js`，zip 条目级原样搬运，不重压）。
- `javacv-platform` → `javacv` + `ffmpeg-platform`：剔除无任何调用方的 opencv/openblas/leptonica/tesseract 与相机 SDK 原生库（mac −33MB，win −77MB）。唯一调用方 `MeetingAudioTranscoder` 真转码验证通过。
- `electronLanguages` en-US/zh-CN + `after-pack.js` 在签名前删 mac Framework 里非 en/zh_CN 的 `*.lproj`（55→2，−36MB）。
- NSIS：`differentialPackage: false`（本仓不用 electron-updater 差量）；`installer.nsh` 顶部 `SetCompressor /SOLID lzma`，ARM64 壳的 `File /r` 从 zlib 改固实 LZMA。
- `prepare-python-service.js` prune 扩表（torch/include|test|share、bin/magika|ruff、pocketsphinx-data、一级包 tests/|test/、gradio *.js.map），解压树 dry-run −400MB；`testing/` 刻意不删（torch eager import）。
- jlink `--compress zip-9`。
- eng-infra.md 补 6.7 五条地雷。

## 验证
- backend `mvn -B test`（JDK 21）：Tests run: 3388, Failures: 0, Errors: 0, Skipped: 14。
- desktop `npm test`：118 tests, 117 pass, 1 skip（无 JDK 时的 jar 校验，JDK 21 下 6/6 过）。
- 真跑：裁剪后的 classpath 起 Playwright 抓 example.com 200；webm/opus → mp3 转码产出合法 MP3。
- 本机 `electron-builder --dir --mac --arm64`：backend/lib 370→206MB，Framework lproj 37MB→0.9MB，app 能起到窗口。
- 未验证：Windows 腿真实体积与 `/SOLID lzma` 的编译耗时，由本 PR 的 desktop-build Windows 腿验证；mac 完整签名+公证链路随 0.38.0 tag 验证。

注意：本 PR 的改动全部被 patch-gate 拦在小版本之外，只能随大版本 0.38.0 发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)