### PR TITLE
feat(auth): 微信手机号一键登录端点 /api/auth/wx-phone-login（dev-board#534）

### DIFF
--- a/backend/src/main/java/com/checkba/controller/AuthController.java
+++ b/backend/src/main/java/com/checkba/controller/AuthController.java
@@ -34,6 +34,12 @@ public class AuthController {
     private final com.checkba.service.mail.MailAuthService mailAuthService;
     private final com.checkba.service.auth.SecondFactorService secondFactorService;
     private final com.checkba.service.UserSessionService userSessionService;
+    /**
+     * 微信手机号一键登录（dev-board#534）用的内部记账口客户端。与统一账户余额/充值共用
+     * 同一套 {@code mobile.billing.base-url/secret}——官网那边也是同一条
+     * {@code /api/internal/account}，只是多了一个 {@code wx-phone} 动作。
+     */
+    private final com.checkba.service.mobile.MobileBillingClient mobileBillingClient;
     /** 单机免登模式。设备令牌的会话签发路径只在这一模式下存在（见 issueLocalDeviceToken）。 */
     private final boolean localMode;
     /** 存量账号补绑手机号的三态闸；未接线的调用方传 null 表示不设闸。 */
@@ -75,6 +81,14 @@ public class AuthController {
      */
     private static final String ACCOUNT_LOGIN_RATE_KEY = "::account-login";
 
+    /**
+     * 微信一键登录的限速维度（dev-board#534），同上带冒号避开真实用户名空间。
+     *
+     * <p>不按手机号分桶：手机号是这条路的<b>产出</b>而不是入参，请求进来时还不知道是谁。
+     * 按 IP 计的这一档护的是「拿一堆伪造 code 猛打官网换号口」。
+     */
+    private static final String WX_PHONE_LOGIN_RATE_KEY = "::wx-phone-login";
+
     private static UserService staticUserService;
     private static com.checkba.service.DeviceTokenService staticDeviceTokenService;
     private static com.checkba.service.LocalIdentityService staticLocalIdentityService;
@@ -107,7 +121,8 @@ public class AuthController {
                           @org.springframework.beans.factory.annotation.Value("${security.local-mode:false}")
                           boolean localMode,
                           PhoneLoginGuard phoneLoginGuard,
-                          com.checkba.service.account.AccountDeletionService accountDeletionService) {
+                          com.checkba.service.account.AccountDeletionService accountDeletionService,
+                          com.checkba.service.mobile.MobileBillingClient mobileBillingClient) {
         this.userService = userService;
         this.clientInvitationService = clientInvitationService;
         this.adminAccessService = adminAccessService;
@@ -121,6 +136,7 @@ public class AuthController {
         this.userSessionService = userSessionService;
         this.localMode = localMode;
         this.phoneLoginGuard = phoneLoginGuard;
+        this.mobileBillingClient = mobileBillingClient;
         staticUserService = userService;
     }
 
@@ -828,6 +844,68 @@ public class AuthController {
     }
 
     /**
+     * 微信手机号一键登录（dev-board#534，spec
+     * {@code aiworkdeck_mobile/docs/specs/2026-09-09-miniprogram-entry-and-wx-login.md} §2）。
+     *
+     * <p>小程序 {@code button open-type="getPhoneNumber"} 拿到的一次性 code 上来，经官网内部
+     * 记账口的 {@code wx-phone} 动作换成<b>已验证的</b>手机号，之后与 {@link #smsLoginVerify}
+     * 逐字同一条路：{@code findOrCreateByPhone} → {@code issue} → 同形的 LoginResult。
+     * 微信侧的号码验证与短信验证码是同一等级的控制权证明，所以这里同样注册登录合一。
+     *
+     * <p>云后端<b>不持有</b>小程序 AppSecret，也不碰 session_key：换号那一步全在官网，
+     * 本端只是管道（与虚拟支付 dev-board#427 同一立场）。
+     *
+     * <p>失败一律 code 1 + 可读 message（无 kind，与 sms-login 那条同形）：文案由
+     * {@code HttpMobileBillingClient.wxPhone} 按官网 error 串翻好，这里原样回显——
+     * 小程序据此 toast 并展开短信登录表单。
+     */
+    @PostMapping("/wx-phone-login")
+    public Map<String, Object> wxPhoneLogin(@RequestBody WxPhoneLoginRequest request,
+                                            jakarta.servlet.http.HttpServletRequest http) {
+        String ip = http.getRemoteAddr();
+        Map<String, Object> result = new HashMap<>();
+        try {
+            authAbuseGuard.checkLoginAttempt(ip, WX_PHONE_LOGIN_RATE_KEY);
+        } catch (IllegalArgumentException e) {
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+            return result;
+        }
+        String phone;
+        try {
+            phone = mobileBillingClient.wxPhone(request.getCode());
+        } catch (com.checkba.service.mobile.MobileBillingClient.MobileBillingException e) {
+            // 只有「官网拒了这张 code」才计失败：未开通/上游故障是服务器的事，
+            // 拿它把这台机器上的一键登录锁十分钟，等于故障期间再踹用户一脚。
+            if (e.getKind() == com.checkba.service.mobile.MobileBillingKind.REJECTED) {
+                authAbuseGuard.recordLoginFailure(ip, WX_PHONE_LOGIN_RATE_KEY);
+            }
+            result.put("code", 1);
+            result.put("message", e.getMessage());
+            return result;
+        }
+        UserService.PhoneAccount account = userService.findOrCreateByPhone(phone);
+        User user = account.user();
+        authAbuseGuard.recordLoginSuccess(ip, WX_PHONE_LOGIN_RATE_KEY);
+        String newSessionId = userSessionService.issue(user.getId());
+        result.put("code", 0);
+        result.put("message", LangText.of("登录成功", "Signed in successfully"));
+        result.put("data", Map.of(
+                "sessionId", newSessionId,
+                "isNewUser", account.created(),
+                "user", Map.of(
+                        "id", user.getId(),
+                        "username", user.getUsername(),
+                        "displayName", user.getDisplayName(),
+                        "avatarUrl", user.getAvatarUrl() != null ? user.getAvatarUrl() : "",
+                        "role", user.getRole(),
+                        "subscriptionType", user.getSubscriptionType()
+                )
+        ));
+        return result;
+    }
+
+    /**
      * 客户登录（使用访问码）
      */
     @PostMapping("/client-login")
@@ -1178,6 +1256,14 @@ public class AuthController {
 
         public String getPhone() { return phone; }
         public void setPhone(String phone) { this.phone = phone; }
+        public String getCode() { return code; }
+        public void setCode(String code) { this.code = code; }
+    }
+
+    /** 微信手机号一键登录：只有 {@code getPhoneNumber} 回调里那张一次性 code。 */
+    static class WxPhoneLoginRequest {
+        private String code;
+
         public String getCode() { return code; }
         public void setCode(String code) { this.code = code; }
     }

--- a/backend/src/main/java/com/checkba/service/mobile/HttpMobileBillingClient.java
+++ b/backend/src/main/java/com/checkba/service/mobile/HttpMobileBillingClient.java
@@ -142,6 +142,64 @@ public class HttpMobileBillingClient implements MobileBillingClient {
     }
 
     /**
+     * 微信 code 换手机号（action=wx-phone，dev-board#534）。走不重试的 {@link #call}——
+     * code 一次性，带同一 body 重试只会让官网再换一次 code 而必败。
+     *
+     * <p>失败要翻成<b>登录场景</b>的话：这条路上用户看到的是登录页，共用计费那套
+     * 「充值请求被拒绝，请联系客服」只会让人不知所措。三类可预期的失败各给一句，
+     * 判据是官网回的 {@code error} 串（{@link #parse} 已把它带进异常）。
+     *
+     * <p>官网回的手机号形状不对（空、非大陆号）按上游故障处理：宁可让用户改用短信登录，
+     * 也不能拿一个来路不明的串去 {@code findOrCreateByPhone} 建号。
+     */
+    @Override
+    public String wxPhone(String code) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("action", "wx-phone");
+        body.put("code", code);
+        JsonNode json;
+        try {
+            json = call(body);
+        } catch (MobileBillingException e) {
+            throw remapWxPhoneFailure(e);
+        }
+        String phone = textOrNull(json, "phone");
+        if (phone == null || !phone.matches("^1\\d{10}$")) {
+            log.warn("微信一键登录：官网回的手机号形状不对，按上游故障处理");
+            throw unavailable();
+        }
+        return phone;
+    }
+
+    /** wx-phone 的失败翻译，见 {@link #wxPhone}。认不出的失败原样抛回。 */
+    private MobileBillingException remapWxPhoneFailure(MobileBillingException e) {
+        String err = e.getMachineError();
+        // 本机没配 base-url/secret（DISABLED），与官网没配小程序 AppSecret（503 wx_not_configured）
+        // 对用户是同一件事：这台服务器上没有这条登录路，去用短信。
+        if (e.getKind() == MobileBillingKind.DISABLED || "wx_not_configured".equals(err)) {
+            return new MobileBillingException(MobileBillingKind.DISABLED,
+                    LangText.of("本服务器未开通微信一键登录，请用短信验证码登录",
+                            "WeChat one-tap sign-in is not enabled on this server; please sign in with an SMS code"),
+                    err);
+        }
+        if (e.getKind() == MobileBillingKind.REJECTED) {
+            if ("unsupported_region".equals(err)) {
+                return new MobileBillingException(MobileBillingKind.REJECTED,
+                        LangText.of("目前仅支持中国大陆手机号",
+                                "Only Chinese mainland phone numbers are supported"),
+                        err);
+            }
+            // 401 invalid_wx_code，以及官网其余 4xx：对用户都是「这张 code 没换成」，
+            // 下一步都是重新授权或改用短信，不该分叉出第三种说法。
+            return new MobileBillingException(MobileBillingKind.REJECTED,
+                    LangText.of("微信授权已过期，请重试",
+                            "The WeChat authorization has expired, please try again"),
+                    err);
+        }
+        return e;
+    }
+
+    /**
      * 删账号（action=delete-account，dev-board#434）。只读语义的反面：<b>失败必须响亮</b>，
      * 所以走不重试的 {@link #call}——重试一次删除请求换不来什么，反而会把「官网到底删没删」
      * 搅得更不清楚；调用方拿到异常就中止本地删除，用户稍后再试即可。
@@ -327,7 +385,9 @@ public class HttpMobileBillingClient implements MobileBillingClient {
                     machineError);
         }
         log.warn("统一账户记账口调用失败: status={}, body={}", status, resp.body());
-        throw unavailable();
+        // machineError 带上：5xx 也可能是官网明确的业务状态（如 wx-phone 的 503
+        // wx_not_configured），调用方要据它翻文案；对其余 5xx 它本来就是 null。
+        throw unavailable(machineError);
     }
 
     /** 解析不出 JSON（空体、HTML 错误页）就回 null——判据本身要能区分"没有 body"与"body 里没有 error"。 */
@@ -344,9 +404,14 @@ public class HttpMobileBillingClient implements MobileBillingClient {
     }
 
     private MobileBillingException unavailable() {
+        return unavailable(null);
+    }
+
+    private MobileBillingException unavailable(String machineError) {
         return new MobileBillingException(MobileBillingKind.UNAVAILABLE,
                 LangText.of("账户服务暂不可用，请稍后再试",
-                        "Account service is temporarily unavailable, please try again later"));
+                        "Account service is temporarily unavailable, please try again later"),
+                machineError);
     }
 
     /** send() 内部标记网络层失败（连不上/超时/中断），与"连上了但业务报错"区分开，只有前者会重试。 */

--- a/backend/src/main/java/com/checkba/service/mobile/MobileBillingClient.java
+++ b/backend/src/main/java/com/checkba/service/mobile/MobileBillingClient.java
@@ -76,6 +76,27 @@ public interface MobileBillingClient {
      */
     String resolveAccountId(String phone, String email, boolean create);
 
+    /**
+     * 微信手机号一键登录：拿小程序 {@code getPhoneNumber} 的一次性 code 换手机号
+     * （action=wx-phone，dev-board#534，spec
+     * {@code 2026-09-09-miniprogram-entry-and-wx-login.md} §2）。
+     *
+     * <p>与充值那几个动作共用同一条内部记账口与同一把 secret，但语义无关计费：官网只做
+     * 「code → 手机号」这一步，<b>不建官网账户、不发赠额</b>（那是官网公开路由
+     * {@code /api/auth/wx-phone} 的事）。云后端不持有小程序 AppSecret，也不碰 session_key。
+     *
+     * <p>code 是一次性的：网络失败<b>不重试</b>（重试同一 code 在官网侧必败），
+     * 由小程序重新拿一张 code 再来。
+     *
+     * @return 官网 {@code normalizePhone} 后的大陆手机号（{@code ^1\d{10}$}）
+     * @throws MobileBillingException DISABLED = 本机或官网未开通微信一键登录
+     *                                （本机 base-url/secret 未配 / 官网 503 {@code wx_not_configured}）；
+     *                                REJECTED = 官网 401 {@code invalid_wx_code} 或 400
+     *                                {@code unsupported_region}；UNAVAILABLE = 上游故障。
+     *                                message 已是可直接回显的用户可读文案。
+     */
+    String wxPhone(String code);
+
     /** 读余额（action=balance）。只读，网络失败不重试。 */
     BalanceResult balance(String accountId);
 

--- a/backend/src/main/resources/openapi/mobile-v1.yaml
+++ b/backend/src/main/resources/openapi/mobile-v1.yaml
@@ -117,11 +117,12 @@ components:
       type: object
       required: [sessionId, isNewUser, user]
       description: |
-        sms-login/verify 成功时的 data。isNewUser 由服务端恒返回（account.created）。
+        sms-login/verify 与 wx-phone-login 成功时的 data（两条路逐字同形）。
+        isNewUser 由服务端恒返回（account.created）。
       properties:
         sessionId: { type: string }
         isNewUser: { type: boolean }
-        mustBindPhone: { type: boolean, description: 由 account-login / mail-login 等门控登录流设置；sms-login/verify 不返回 }
+        mustBindPhone: { type: boolean, description: 由 account-login / mail-login 等门控登录流设置；sms-login/verify 与 wx-phone-login 不返回 }
         user: { $ref: '#/components/schemas/AccountUser' }
     LoginEnvelope:
       type: object
@@ -231,6 +232,32 @@ paths:
       responses:
         "200":
           description: code 0 带 data；否则 code 非 0 且 data 缺失
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/LoginEnvelope' }
+  /api/auth/wx-phone-login:
+    post:
+      summary: 微信手机号一键登录（匿名）
+      description: |
+        小程序 button open-type="getPhoneNumber" 回调里的一次性 code 换手机号并签发会话
+        （dev-board#534）。换号在官网侧完成（内部记账口 action=wx-phone），云后端不持有
+        小程序 AppSecret。成功响应与 sms-login/verify 逐字同形（LoginData，含 isNewUser）。
+
+        失败一律 200 + code 1 + message，**不带 kind**：客户端 toast 该 message 并展开
+        短信登录表单即可，不需要按机器可读位分支（与 /api/mobile/billing/* 不同）。
+        三种可预期的失败——本服务器/官网未开通微信登录、code 已过期、非中国大陆手机号。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [code]
+              properties:
+                code: { type: string, description: getPhoneNumber 回调的 e.detail.code，一次性 }
+      responses:
+        "200":
+          description: code 0 带 data；否则 code 1 且 data 缺失
           content:
             application/json:
               schema: { $ref: '#/components/schemas/LoginEnvelope' }

--- a/backend/src/test/java/com/checkba/MobileApiContractTest.java
+++ b/backend/src/test/java/com/checkba/MobileApiContractTest.java
@@ -280,6 +280,44 @@ class MobileApiContractTest {
     }
 
     @Test
+    void wxPhoneLoginEnvelopesMatchSpec() throws Exception {
+        // 成功：与 sms-login/verify 逐字同形（sessionId + isNewUser + user），data 受 LoginData 约束。
+        // 号码用一个本测试专属的段，避免与别的用例抢同一行 users
+        when(billing.wxPhone("wx-code-ok")).thenReturn("13800000123");
+        mvc.perform(post("/api/auth/wx-phone-login").contentType(APPLICATION_JSON)
+                        .content("{\"code\":\"wx-code-ok\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data.sessionId").isNotEmpty())
+                .andExpect(jsonPath("$.data.isNewUser").value(true))
+                .andExpect(openApi().isValid(validator));
+
+        // 未开通（本机 mobile.billing.* 没配 / 官网没配小程序 AppSecret）：code 1、无 kind，
+        // message 指路短信登录。客户端不按 kind 分支，所以这里也不许多出一个 kind 字段。
+        when(billing.wxPhone("wx-code-off")).thenThrow(new MobileBillingClient.MobileBillingException(
+                MobileBillingKind.DISABLED, "本服务器未开通微信一键登录，请用短信验证码登录"));
+        mvc.perform(post("/api/auth/wx-phone-login").contentType(APPLICATION_JSON)
+                        .content("{\"code\":\"wx-code-off\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.kind").doesNotExist())
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.message").value("本服务器未开通微信一键登录，请用短信验证码登录"))
+                .andExpect(openApi().isValid(validator));
+
+        // 官网 401 invalid_wx_code：同一个 code 1 信封，只是换一句话
+        when(billing.wxPhone("wx-code-expired")).thenThrow(new MobileBillingClient.MobileBillingException(
+                MobileBillingKind.REJECTED, "微信授权已过期，请重试", "invalid_wx_code"));
+        mvc.perform(post("/api/auth/wx-phone-login").contentType(APPLICATION_JSON)
+                        .content("{\"code\":\"wx-code-expired\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.kind").doesNotExist())
+                .andExpect(jsonPath("$.message").value("微信授权已过期，请重试"))
+                .andExpect(openApi().isValid(validator));
+    }
+
+    @Test
     void smsLoginEnvelopesMatchSpec() throws Exception {
         // 不真发短信：非法号码走 code 1 分支，信封形状仍受契约约束
         mvc.perform(post("/api/auth/sms-login/send-code").contentType(APPLICATION_JSON)

--- a/backend/src/test/java/com/checkba/controller/AuthControllerCurrentUserLocalizationTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerCurrentUserLocalizationTest.java
@@ -58,7 +58,7 @@ class AuthControllerCurrentUserLocalizationTest {
         AdminAccessService adminAccessService = mock(AdminAccessService.class);
         return new AuthController(userService, null, adminAccessService, null,
                 null, null, null, null, null, sessions, localMode, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
     }
 
     private static User user(long id, String username, String displayName) {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerGetUsernameLoggingTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerGetUsernameLoggingTest.java
@@ -67,7 +67,7 @@ class AuthControllerGetUsernameLoggingTest {
         // 构造即注册 staticUserService（构造器里的既有副作用，其它测试同样依赖这个模式）
         new AuthController(userService, null, null, null, null, null, null, null, null,
                 sessions, true, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         ch.qos.logback.classic.Logger logbackLogger =
                 (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(AuthController.class);

--- a/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerHardeningTest.java
@@ -64,7 +64,7 @@ class AuthControllerHardeningTest {
         UserService userService = mock(UserService.class);
         AuthController controller = new AuthController(
                 userService, null, null, null, serverGuard("closed"), null, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -81,7 +81,7 @@ class AuthControllerHardeningTest {
                 .thenReturn(user(1L, "alice"));
         AuthController controller = new AuthController(
                 userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -97,7 +97,7 @@ class AuthControllerHardeningTest {
         AuthAbuseGuard localGuard = new AuthAbuseGuard(true, "closed");
         AuthController controller = new AuthController(
                 userService, null, null, null, localGuard, null, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         Map<String, Object> result = controller.register(registerRequest(), http());
 
@@ -112,7 +112,7 @@ class AuthControllerHardeningTest {
                 .thenThrow(new IllegalArgumentException("用户名或密码错误"));
         AuthController controller = new AuthController(
                 userService, null, null, null, serverGuard("open"), null, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         AuthController.LoginRequest request = new AuthController.LoginRequest();
         request.setUsername("alice");
@@ -136,7 +136,7 @@ class AuthControllerHardeningTest {
                 .thenReturn(new AwdkLoginService.BridgeSession("awdt_x", 7L, "awd_hanzewei", "韩泽伟", 31L));
         AuthController controller = new AuthController(
                 null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -161,7 +161,7 @@ class AuthControllerHardeningTest {
                 .thenReturn(new AwdkLoginService.BridgeSession("awdt_x", 7L, "awd_hanzewei", null, null));
         AuthController controller = new AuthController(
                 null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -179,7 +179,7 @@ class AuthControllerHardeningTest {
                 .thenThrow(new IllegalArgumentException("本服务器未开启账户桥接功能"));
         AuthController controller = new AuthController(
                 null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         Map<String, Object> result = controller.awdkLogin(Map.of("key", "awdk_abc"), http());
 
@@ -199,7 +199,7 @@ class AuthControllerHardeningTest {
                 AccountException.Kind.UNAUTHORIZED, "账户 Key 无效或已被撤销，请到官网账户页重新生成"));
         AuthController controller = new AuthController(
                 null, null, null, null, serverGuard("open"), awdkLoginService, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
 
         for (int i = 0; i < 5; i++) {
             assertEquals(1, controller.awdkLogin(Map.of("key", "awdk_bad"), http()).get("code"));
@@ -216,7 +216,7 @@ class AuthControllerHardeningTest {
     private static AuthController controller(AwdkLoginService awdkLoginService, AuthAbuseGuard guard) {
         return new AuthController(
                 null, null, null, null, guard, awdkLoginService, null, null, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerLocalDeviceTokenTest.java
@@ -55,7 +55,7 @@ class AuthControllerLocalDeviceTokenTest {
                 org.mockito.Mockito.mock(com.checkba.repository.UserSessionRepository.class), 365);
         return new AuthController(userService, null, null, deviceTokenService,
                 null, null, null, null, null, sessions, localMode, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
     }
 
     private static User user(long id, String username, String displayName) {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerMailTest.java
@@ -51,7 +51,7 @@ class AuthControllerMailTest {
                                              MailAuthService mailAuthService) {
         return new AuthController(userService, null, null, null, guard, null, null,
                 mailAuthService, null, sessions(), false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
     }
 
     private static AuthController.MailSendCodeRequest sendCodeRequest(String scene, String email) {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerPhoneGateTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerPhoneGateTest.java
@@ -82,7 +82,7 @@ class AuthControllerPhoneGateTest {
         return new AuthController(userService, null, null, deviceTokenService,
                 mock(AuthAbuseGuard.class), null, null, mailAuthService, null, sessions,
                 false, phoneLoginGuard,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
     }
 
     private static UserSessionService sessions() {

--- a/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
+++ b/backend/src/test/java/com/checkba/controller/AuthControllerSmsTest.java
@@ -63,7 +63,7 @@ class AuthControllerSmsTest {
                 mock(com.checkba.repository.UserSessionRepository.class), 365);
         return new AuthController(userService, null, null, null, guard, null, smsAuthService,
                 mock(com.checkba.service.mail.MailAuthService.class), secondFactor, sessions, false, null,
-                mock(com.checkba.service.account.AccountDeletionService.class));
+                mock(com.checkba.service.account.AccountDeletionService.class), null);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/mobile/HttpMobileBillingClientTest.java
+++ b/backend/src/test/java/com/checkba/service/mobile/HttpMobileBillingClientTest.java
@@ -325,6 +325,68 @@ class HttpMobileBillingClientTest {
                         () -> new HttpMobileBillingClient("", "", om).deleteAccount("acct-x")).getKind());
     }
 
+    // ==================== 微信手机号一键登录（dev-board#534） ====================
+
+    @Test
+    @DisplayName("wx-phone 成功：action/code 上行，回大陆手机号")
+    void wxPhoneSuccess() {
+        HttpMobileBillingClient c = stubbed(200, "{\"phone\":\"13800000001\"}");
+
+        assertEquals("13800000001", c.wxPhone("0a1b2c3d4e"));
+
+        String sent = lastRequest.get();
+        assertTrue(sent.contains("\"action\":\"wx-phone\""), sent);
+        assertTrue(sent.contains("\"code\":\"0a1b2c3d4e\""), sent);
+    }
+
+    @Test
+    @DisplayName("wx-phone 的三种失败各自翻成登录场景的话，绝不共用计费那句「联系客服」")
+    void wxPhoneFailuresSpeakLoginLanguage() {
+        // 本机没配 base-url/secret：短路，且这一条的文案是登录场景的，不是「未开通统一账户充值」
+        MobileBillingException localOff = assertThrows(MobileBillingException.class,
+                () -> new HttpMobileBillingClient("", "", om).wxPhone("0a1b"));
+        assertEquals(MobileBillingKind.DISABLED, localOff.getKind());
+        assertTrue(localOff.getMessage().contains("未开通微信一键登录"), localOff.getMessage());
+        assertEquals(0, hits.get(), "未配置不许发请求");
+
+        // 官网未配小程序 AppSecret：503 wx_not_configured 与本机没配是同一个结论
+        MobileBillingException notConfigured = assertThrows(MobileBillingException.class,
+                () -> stubbed(503, "{\"error\":\"wx_not_configured\"}").wxPhone("0a1b"));
+        assertEquals(MobileBillingKind.DISABLED, notConfigured.getKind());
+        assertTrue(notConfigured.getMessage().contains("未开通微信一键登录"), notConfigured.getMessage());
+
+        // code 无效 → 401
+        MobileBillingException expired = assertThrows(MobileBillingException.class,
+                () -> stubbed(401, "{\"error\":\"invalid_wx_code\"}").wxPhone("0a1b"));
+        assertEquals(MobileBillingKind.REJECTED, expired.getKind());
+        assertEquals("invalid_wx_code", expired.getMachineError());
+        assertTrue(expired.getMessage().contains("微信授权已过期"), expired.getMessage());
+
+        // 非大陆号 → 400
+        MobileBillingException region = assertThrows(MobileBillingException.class,
+                () -> stubbed(400, "{\"error\":\"unsupported_region\"}").wxPhone("0a1b"));
+        assertEquals(MobileBillingKind.REJECTED, region.getKind());
+        assertTrue(region.getMessage().contains("仅支持中国大陆手机号"), region.getMessage());
+    }
+
+    @Test
+    @DisplayName("wx-phone：code 一次性，网络失败只发一次；官网回的号形状不对按上游故障处理")
+    void wxPhoneNeverRetriesAndValidatesShape() {
+        HttpMobileBillingClient c = stubbed(200, "{}");
+        stubDrop.set(true);
+        assertEquals(MobileBillingKind.UNAVAILABLE,
+                assertThrows(MobileBillingException.class, () -> c.wxPhone("0a1b")).getKind());
+        assertEquals(1, hits.get(), "code 一次性，不许重试");
+
+        stubDrop.set(false);
+        for (String bad : new String[]{"{}", "{\"phone\":\"\"}", "{\"phone\":\"+8613800000001\"}"}) {
+            assertEquals(MobileBillingKind.UNAVAILABLE,
+                    assertThrows(MobileBillingException.class,
+                            () -> stubbed(200, bad).wxPhone("0a1b")).getKind(),
+                    bad);
+        }
+    }
+
     @Test
     @DisplayName("plan 是 paid/free 的计费档位，不是套餐名；上游不给才是 null")
     void planIsBillingTierNotPlanName() {


### PR DESCRIPTION
## 做了什么
- `POST /api/auth/wx-phone-login {code}`（匿名）：把小程序 `getPhoneNumber` 的一次性 code 交官网内部口 `wx-phone` 换手机号，再走与 `sms-login/verify` **逐字相同**的成功路径（`findOrCreateByPhone` → `userSessionService.issue` → `LoginResult`）。云后端不持小程序 AppSecret。
- 失败一律 code 1 无 kind：未配 `mobile.billing.*` 或官网 503 →「本服务器未开通微信一键登录，请用短信验证码登录」；官网 401 →「微信授权已过期，请重试」；400 unsupported_region →「目前仅支持中国大陆手机号」。频控按 IP + `::wx-phone-login`，只有官网拒 code 才计失败，服务器没配好不锁人。
- `HttpMobileBillingClient.wxPhone` 不重试（code 一次性）；官网回的手机号不合 `^1\d{10}$` 不建号。
- `mobile-v1.yaml` 新端点（移动仓合并后 `pull-api.mjs` 重钉）。

## 测试
```
mvn -o test -Dtest='HttpMobileBillingClientTest,MobileApiContractTest,AuthController*Test' → Tests run: 78, Failures: 0, Errors: 0
mvn -o test（全量）→ Tests run: 3408, Failures: 0, Errors: 0, Skipped: 14
```

## 未验证
与官网 zeweihan/aiworkdeck_website#168（已合并）的真实联调；真微信 code。方案：移动仓 `docs/specs/2026-09-09-miniprogram-entry-and-wx-login.md` §2。

🤖 Generated with [Claude Code](https://claude.com/claude-code)