### PR TITLE
fix(nsis): 压缩器改非固实 lzma，修 Windows 打包 warning 8021（dev-board#528 热修）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -196,7 +196,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    ① `prepare-backend.js` 拆包后调 `trim-driver-bundle.js` 把 Playwright `driver-bundle-*.jar` 重写成只含 `driver/<本平台>/`（mac-arm64 / win32_x64，字符串必须与 `DriverJar#platformDir` 逐字一致，161MB→31MB）；zip 条目级原样搬运不重压，找不到本平台目录直接抛错。
    ② `backend/pom.xml` 的 `javacv-platform` 已换成 `javacv` + `ffmpeg-platform`（全仓唯一调用方 `MeetingAudioTranscoder`）；**不要再引回聚合体**，opencv/leptonica/tesseract 没有任何调用方。
    ③ mac 语言包靠 `desktop/scripts/after-pack.js`（`build.afterPack`）在签名前删 Framework 里非 en/zh_CN 的 `*.lproj`（−36MB）；`electronLanguages` 在 mac 上只裁 `Contents/Resources` 的空壳。**升级 electron-builder 要回头核 `platformPackager.js` 里 afterPack 仍早于 doSignAfterPack**；`afterPack` 相对路径按 cwd 解析，必须在 `desktop/` 里跑。
-   ④ `installer.nsh` 顶部 `SetCompressor /SOLID lzma` 盖掉 electron-builder 用 `-X` 下发的 zlib（ARM64 壳的 `File /r` 走它）；`nsis.differentialPackage=false` 关掉为 electron-updater 差量准备的 dict 1MB/非固实 7z。`installer-ui-smoke.yml` 不覆盖 installer.nsh，只有 desktop-build.yml 的 Windows 腿能验；固实压缩会让 makensis 变慢。
+   ④ `installer.nsh` 顶部 `SetCompressor lzma` + `SetCompressorDictSize 32` 盖掉 electron-builder 用 `-X` 下发的 zlib（ARM64 壳的 `File /r` 走它）；**不能加 `/SOLID`**：整体压缩模式下模板里的 `SetCompress off` 触发 warning 8021，-WX 下 makensis 直接失败（#772 合并后 Windows 腿实锤，热修 PR 见 git log）；`nsis.differentialPackage=false` 关掉为 electron-updater 差量准备的 dict 1MB/非固实 7z。`installer-ui-smoke.yml` 不覆盖 installer.nsh，只有 desktop-build.yml 的 Windows 腿能验；固实压缩会让 makensis 变慢。
    ⑤ `prepare-python-service.js` 的 `prune()` 扩表（torch/include|test|share、bin/magika|ruff、pocketsphinx-data、一级包 tests/|test/、gradio *.js.map）；**`testing/` 不能删**（`torch/__init__` eager import 它），`dist-info/RECORD` 不能删。
 
 ## 测试命令总表

--- a/desktop/build/installer.nsh
+++ b/desktop/build/installer.nsh
@@ -18,14 +18,21 @@
 ; 没有用 /FINAL，NSIS 允许在任何 Section/Function/PageEx 之前重设。
 ; 本机实测（electron-builder 自带的 mac makensis 3.0.4.1，-WX -INPUTCHARSET UTF8
 ; "-XSetCompressor zlib" 加一份带本行的 stdin 脚本）：输出为
-; "Using lzma (compress whole) compression."，且不产生任何警告（-WX 下不会误伤）；
+; "Using lzma compression."，且不产生任何警告（-WX 下不会误伤）；
 ; 去掉本行的对照组输出 "Using zlib compression."。
 ; 收益落在 customInstall 里那份用 NSIS 原生 File /r 塞进来的 ARM64 Electron 壳
-;（约 260MB 未压缩，zlib 约 41.7%、固实 LZMA 约 27.3%，本机实测系数）。
+;（约 260MB 未压缩，zlib 约 41.7%、LZMA 约 27-30%，本机实测系数）。
 ; 主载荷 app-64.7z 早已是 7z/LZMA，再压一遍不会变小也不会变大多少，代价是编译更慢。
 ; 位置必须留在本文件最顶部：SetCompressor 只能出现在任何 Section/Function/PageEx 之前，
 ; 而下面 !include 的 awd-oneclick-ui.nsh 会定义 Function。
-SetCompressor /SOLID lzma
+; **不能用 /SOLID**（PR#772 合并后 Windows 腿实锤，run 34323250825）：整体压缩模式下
+; electron-builder 模板 extractEmbeddedAppPackage 里的 `SetCompress off`（主载荷 app-64.7z
+; 本就是 7z，不该再压）会触发 NSIS warning 8021「Effectively ignored」，-WX 把它当错误，
+; makensis 直接退出。非固实 lzma 下 SetCompress off 正常生效：7z 主载荷原样存、ARM64 壳
+; 逐文件 LZMA（Electron 壳的体积集中在几个大文件上，逐文件与固实差距很小）。
+; 字典 32MB：默认 8MB 对 100MB 级二进制偏小；安装端解压内存也只多几十 MB。
+SetCompressor lzma
+SetCompressorDictSize 32
 
 !define AWD_UI_ART "${BUILD_RESOURCES_DIR}/win/generated"
 !define AWD_UI_DIR_CHOICE


### PR DESCRIPTION
#772 合并后 desktop-build 的 Windows 腿失败（run 34323250825）：`SetCompressor /SOLID lzma` 整体压缩模式下，electron-builder 模板 `extractEmbeddedAppPackage` 里的 `SetCompress off` 触发 NSIS warning 8021，`-WX` 当错误，makensis 退出。

修法：`SetCompressor lzma` + `SetCompressorDictSize 32`（非固实）。`SetCompress off` 正常生效，主载荷 7z 原样存，ARM64 壳逐文件 LZMA。本地用 electron-builder 自带 makensis 3.0.4.1 以 `-WX "-XSetCompressor zlib"` 复现 8021 后验证修复版无警告。

eng-infra.md 6.7 ④ 同步更正。验证：本 PR 的 desktop-build Windows 腿必须绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)