### PR TITLE
fix(workbench): 工具栏/标签栏横向滚动与细滑轨、活动标签滚入视野、跨分屏拖拽改为移动（dev-board#543 #542）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -179,6 +179,17 @@ dev-board#97 的「中键关闭标签」就这么静默失效了一整轮：auxc
 先确认这一类在不在上面那四个补字段分支里；`tabDragSplit.js` 的 `onTabDragStart`
 就是靠 `if (evt && evt.dataTransfer)` 兜住的（拖拽状态记在组件上，不依赖 dataTransfer）。
 
+**wheel 也一样丢字段（dev-board#543，2026-09-09）**：`wheel` 不在那四个补字段分支里，
+回调拿到的事件**没有 `deltaX/deltaY`**，`scroller.scrollLeft += evt.deltaY` 得到 NaN，
+横滚静默失效——编辑器工具栏（`EditorToolbar.onToolbarWheel`）与编辑器标签栏
+（`tabDragSplit.onTabsWheel`）当时又同时把滚动条整条藏掉，于是「窄窗口下右半截命令
+够不着」「标签开多了看不出还有更多」两件事一起发生（回归自 PR#759 / dev-board#502）。
+位移的唯一出处是 **`frontend/src/utils/wheelDelta.js` 的 `wheelDeltaOf(evt)`**
+（回调自带 delta 优先，否则回退 `window.event`；`|deltaX| > |deltaY|` 取 deltaX；
+都没有返回 0，调用方据此不动）。`altKey` 同理——标签拖拽的修饰键判定在
+`tabDragSplit.js` 的 `altKeyOf`，且**只能在 dragstart 那一下取**（dragover/drop
+阶段连原生事件都没有），起手记进 `draggingTab.copy`，drop 时读那一份。
+
 **drag 系事件是重灾区（dev-board#363，2026-09-02）**：`dragover/drop/dragleave` 的
 `dataTransfer` / `relatedTarget` 在 `<view>` 上一律拿不到——文件树内部拖拽一直是靠
 `document.__checkbaDraggedFile` 那个全局兜底在跑，`FileStagingArea.onDrop` 为 #74 加的
@@ -580,6 +591,51 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
   uni-h5 的 `<view>` 默认 inheritAttrs，原生 `auxclick` 直接落到 `<uni-view>` 上。
   标签没有「固定/不可关」概念，所以没有例外分支；要加固定标签时先在这里加判断。
   app-e2e J6.3 末尾用 `page.mouse.click(..., { button: 'middle' })` 关设置标签兼作覆盖。
+- **标签栏与工具栏的悬浮细滑轨 `.awd-hairline-scroll`（2026-09-09，dev-board#543）**：
+  定义在 **`App.vue` 的全局 `<style>`**（不是 scoped——uni `<scroll-view>` 真正
+  overflow 的是内层 `div.uni-scroll-view`，组件的 scope id 只落在 `<uni-scroll-view>`
+  根元素上），6px 轨、thumb 静止透明、容器 `:hover` 才用 `--awd-border-strong` 显形。
+  用在 `.etb-scroll`（EditorToolbar）与左右两条 `.tabs-scroll`；`:show-scrollbar="false"`
+  与那几条 `display:none` 兜底一起删掉了（它们会让 uni 给内层元素挂
+  `.uni-scroll-view-scrollbar-hidden`，把细滑轨也灭掉）。
+  **标准属性 `scrollbar-width` 被关在 `@supports not selector(::-webkit-scrollbar)` 里**：
+  Chromium 一看到它就整个忽略 `::-webkit-scrollbar` 那套，6px 会退化成 thin（约 8px），
+  把按 6px 算好的两处偏移带歪。
+  滑轨占的 6px 是从内容盒里扣的，两处各自的补偿不一样，**改高度前先看这两条**：
+  `.etb-scroll` 是 `height: calc(100% - 6px)` + `margin-bottom: -6px`（外边距盒恒为
+  26px，`align-items:center` 之后内容盒恰好 y6..32，与 `.etb-right` 对齐，且**有没有
+  滑轨都一样**——不定高的话两种情况会各偏 3px，正是 #502 那种错位）；`.tabs-scroll`
+  是 `height: calc(100% + 6px)` + `position: relative; z-index: 1`（`.tab-item` 是写死的
+  36px，内容盒少 6px 会被 uni 挂的 `overflow-y:hidden` 裁掉激活标签那块白底；多出的
+  6px 溢出到 `.editors-container` 头上，而它 `position:relative` 且有背景色，不抬一层
+  就把滑轨整条盖掉）。z-index 只给 `.tabs-scroll`，**不要给 `.etb-scroll` 或 `.etb-wrap`**
+  ——工具栏下拉是 `position:fixed` 弹层，多一个层叠上下文就把它们框住了。
+- **`.tab-item` 必须有 `flex-shrink: 0`（dev-board#543）**：没有它，标签一多是整行被
+  压扁而不是溢出，滚动条永远不出现。`max-width` 同轮从 200px 收到 160px。
+- **活动标签滚入视野（dev-board#543）**：两条 `.tabs-scroll` 各有一个
+  `:scroll-into-view="tabsScrollIntoView{Left,Right}"` + `scroll-with-animation`，
+  锚点是每个 `.tab-item` 上的 `:id="tabDomId(pane, file.id)"`（`fileOpenTabs.js`
+  的模块级纯函数，非法字符换下划线——uni 对这个 id 的形状有硬要求
+  `/^[_a-zA-Z][-_a-zA-Z0-9:]*$/`，不合只 `console.error` 然后什么都不做）。
+  驱动挂在 **`activeFileIdLeft/Right` 的 watcher** 上，不是 `activateTab` 里：
+  `openFile`、`moveTabTo`、`closeFile` 的相邻接管、按模式恢复都是直接写
+  `activeFileId*` 的，watcher 才是唯一入口。`ensureActiveTabVisible` 先把值清空再在
+  `$nextTick` 里赋（同一个 id 再次激活时属性值不变，uni 那个 watch 不会重新触发），
+  并且**本来就整条可见就不滚**（scroll-into-view 是对齐到容器最左，点一个眼前的标签
+  也会把整条抽一下）。
+  **`tabDomId` 刻意不 export**：`tab-middle-click-close` 一类测试用
+  `new Function` 把整个 mixin 源码包起来跑，模块级 `export` 会让那个工厂语法出错。
+- **标签跨窗格拖拽 = 移动，按住 Alt/Option 才是复制（2026-09-09，dev-board#542）**：
+  `moveTabTo(fileId, fromPane, toPane, beforeFileId, opts = { copy: false })`。
+  默认从源列表 splice 掉再插进目标（源侧若移走的是活动标签，按 `closeFile` 同一条
+  `min(idx, len-1)` 规则让相邻的顶上，空了置 null）；`copy:true` 才 `{ ...source }`
+  留下双开那一份（`.tab-dual-open` 样式与 `isOpenInOtherPane` 保持不变，`closeFile`
+  里那条「另一侧还开着就不销毁 BrowserView」的判断照旧成立）。
+  修饰键在 dragstart 记进 `draggingTab.copy` 并写进 dataTransfer payload。
+  **跨窗格移动前必须先落盘**（`flushTabBeforePaneMove`，两个 drop 落点共用的
+  `commitTabDrop` 调它）：移动会把源侧的编辑器实例卸掉，而
+  `LibreOfficeEditor.beforeUnmount` 自己写着「export 需要活的 webview，从这里保存
+  已经太晚」——落不下来就不搬，toast `editor.moveTabSaveFailed`。
 - **标签按文件类型着色（2026-09-09，dev-board#504）**：Word 蓝 / PPT 橙 / Excel 绿 /
   PDF 红 / Markdown 灰 / 图片紫，六色令牌 `--awd-file-*` 在 App.vue 里浅深各一套
   （也进了 `appTheme.js` 的 `THEME_TOKEN_NAMES`）。fileType → kind key 的**唯一出处**
@@ -783,6 +839,9 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
 ## 验证
 
 - `cd frontend && npm run check:emits`（死绑定护栏）+ `npm run test:app-e2e`（登录→项目→上传→打开文件→独立页面全旅程）。
+- 改标签栏/工具栏滚动、标签拖拽语义加跑 `npm run test:project-home`（相关三个文件：
+  `wheel-delta.test.mjs` / `tab-strip-overflow.test.mjs` / `tab-drag-move.test.mjs`，
+  外加 `editor-toolbar-layout.test.mjs` 的 #502/#543 那半边）。
 - 改面板停靠/注册表加跑 `npm run test:panel-dock`（`resolveDocks` 回落规则与注册表自洽）。
 - 改导航/入口/设置页结构加跑 `npm run check:nav` 与 `npm run check:nav:full`（导航契约静态护栏，
   含「头像下拉只剩一项」「个人组四栏各自有人加载数据」「薄壳页挂的是统一设置面板」等断言）；

--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -179,14 +179,25 @@ dev-board#97 的「中键关闭标签」就这么静默失效了一整轮：auxc
 先确认这一类在不在上面那四个补字段分支里；`tabDragSplit.js` 的 `onTabDragStart`
 就是靠 `if (evt && evt.dataTransfer)` 兜住的（拖拽状态记在组件上，不依赖 dataTransfer）。
 
-**wheel 也一样丢字段（dev-board#543，2026-09-09）**：`wheel` 不在那四个补字段分支里，
-回调拿到的事件**没有 `deltaX/deltaY`**，`scroller.scrollLeft += evt.deltaY` 得到 NaN，
-横滚静默失效——编辑器工具栏（`EditorToolbar.onToolbarWheel`）与编辑器标签栏
-（`tabDragSplit.onTabsWheel`）当时又同时把滚动条整条藏掉，于是「窄窗口下右半截命令
-够不着」「标签开多了看不出还有更多」两件事一起发生（回归自 PR#759 / dev-board#502）。
-位移的唯一出处是 **`frontend/src/utils/wheelDelta.js` 的 `wheelDeltaOf(evt)`**
+**wheel 是最狠的一个：`currentTarget` 被换成普通对象，`@wheel` 整条没救
+（dev-board#543，2026-09-09）**。重建后的 `currentTarget` 是
+`{ id, dataset, offsetTop, offsetLeft }`——不是 DOM，没有 `querySelectorAll`、
+没有 `scrollWidth`；`wheel` 又不在那四个补字段分支里，连 `deltaX/deltaY` 都没有。
+于是「从 currentTarget 找滚动容器」第一道守卫就 return，横滚彻底是死的。
+真渲染对照实验：同一套算法用原生 `addEventListener` 挂到真实 DOM 上，同一次滚轮
+`scrollLeft` 0 → 600；走模板 `@wheel` 时 0 → 0。
+**所以横滚一律不写模板事件**，改成 **`frontend/src/utils/horizontalWheel.js` 的
+`bindHorizontalWheel(el)`**（返回 unbind，按元素幂等——重复绑定返回同一个函数；
+内部先 `wheelDeltaOf(evt)` 取位移，再找真正 overflow 的元素，**滚不动就不
+`preventDefault`**；`{ passive: false }` 不能省，否则 Chromium 按 passive 处理，
+横滚的同时页面还会纵向滚一下）。两个挂载点：`EditorToolbar` 的
+`mounted → bindToolbarWheel`（`this.$el.querySelector('.etb-scroll')`）、
+工作台的 `mounted → rebindTabsWheel`（`tabDragSplit.js`，
+`bindHorizontalWheelAll(this.$el, '.tabs-scroll')`，**`splitMode` 的 watcher 里还要
+再挂一次**——右侧那条标签栏是分屏开关新建出来的元素，老监听留在旧元素上），
+两处都在 `beforeUnmount` 摘。位移本身仍在 `utils/wheelDelta.js` 的 `wheelDeltaOf`
 （回调自带 delta 优先，否则回退 `window.event`；`|deltaX| > |deltaY|` 取 deltaX；
-都没有返回 0，调用方据此不动）。`altKey` 同理——标签拖拽的修饰键判定在
+都没有返回 0）。`altKey` 同理——标签拖拽的修饰键判定在
 `tabDragSplit.js` 的 `altKeyOf`，且**只能在 dragstart 那一下取**（dragover/drop
 阶段连原生事件都没有），起手记进 `draggingTab.copy`，drop 时读那一份。
 
@@ -594,24 +605,42 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
 - **标签栏与工具栏的悬浮细滑轨 `.awd-hairline-scroll`（2026-09-09，dev-board#543）**：
   定义在 **`App.vue` 的全局 `<style>`**（不是 scoped——uni `<scroll-view>` 真正
   overflow 的是内层 `div.uni-scroll-view`，组件的 scope id 只落在 `<uni-scroll-view>`
-  根元素上），6px 轨、thumb 静止透明、容器 `:hover` 才用 `--awd-border-strong` 显形。
-  用在 `.etb-scroll`（EditorToolbar）与左右两条 `.tabs-scroll`；`:show-scrollbar="false"`
-  与那几条 `display:none` 兜底一起删掉了（它们会让 uni 给内层元素挂
-  `.uni-scroll-view-scrollbar-hidden`，把细滑轨也灭掉）。
+  根元素上），**4px** 轨、thumb 圆角、静止透明、容器 `:hover` 才用
+  `--awd-border-strong` 显形。用在 `.etb-scroll`（EditorToolbar）与左右两条
+  `.tabs-scroll`；`:show-scrollbar="false"` 与那几条 `display:none` 兜底一起删掉了
+  （它们会让 uni 给内层元素挂 `.uni-scroll-view-scrollbar-hidden`，把细滑轨也灭掉）。
   **标准属性 `scrollbar-width` 被关在 `@supports not selector(::-webkit-scrollbar)` 里**：
-  Chromium 一看到它就整个忽略 `::-webkit-scrollbar` 那套，6px 会退化成 thin（约 8px），
-  把按 6px 算好的两处偏移带歪。
-  滑轨占的 6px 是从内容盒里扣的，两处各自的补偿不一样，**改高度前先看这两条**：
-  `.etb-scroll` 是 `height: calc(100% - 6px)` + `margin-bottom: -6px`（外边距盒恒为
-  26px，`align-items:center` 之后内容盒恰好 y6..32，与 `.etb-right` 对齐，且**有没有
-  滑轨都一样**——不定高的话两种情况会各偏 3px，正是 #502 那种错位）；`.tabs-scroll`
-  是 `height: calc(100% + 6px)` + `position: relative; z-index: 1`（`.tab-item` 是写死的
-  36px，内容盒少 6px 会被 uni 挂的 `overflow-y:hidden` 裁掉激活标签那块白底；多出的
-  6px 溢出到 `.editors-container` 头上，而它 `position:relative` 且有背景色，不抬一层
-  就把滑轨整条盖掉）。z-index 只给 `.tabs-scroll`，**不要给 `.etb-scroll` 或 `.etb-wrap`**
-  ——工具栏下拉是 `position:fixed` 弹层，多一个层叠上下文就把它们框住了。
+  Chromium 一看到它就整个忽略 `::-webkit-scrollbar` 那套，4px 会退化成 thin（约 8px），
+  把按 4px 算好的两处偏移带歪。
+  滑轨占的 4px 是从内容盒里扣的，两处各自的补偿不一样，**改这个数前先看这两条**：
+  - `.etb-scroll` 是 `height: calc(100% - 8px)` + `margin-bottom: -4px`。按
+    「行高 38 / 行内内容 26 / 滑轨 4」算：边框盒 = 26+4 = 30px（= `100% - 8px`），
+    负外边距让外边距盒回到 26px，`align-items:center` 之后内容盒恰好 y6..32，与
+    `.etb-right` 对齐，且**有没有滑轨都一样**（不定高的话两种情况会各偏，正是 #502
+    那种错位）。三个数任何一个变了都要重算，别只改滑轨那一项。
+  - `.tabs-scroll` 是 `height: calc(100% + 4px)` + `position: relative; **z-index: 2**`
+    （`.tab-item` 是写死的 36px，内容盒少 4px 会被 uni 挂的 `overflow-y:hidden` 裁掉
+    激活标签那块白底；多出的 4px 溢出到编辑区头上，`.editors-container` 与
+    `.editor-pane` 都是 `position:relative` 且有背景色、排在更后面，**z-index 只到 1
+    时下面 3px 会被盖掉**——真渲染对照实测：z2 时 hover 后 y79.0..82.5 全是
+    `#CBD5E1`，改回 z1 只剩 y79.0..79.5 那 1px，其余是编辑器白底）。
+  z-index 只给 `.tabs-scroll`，**不要给 `.etb-scroll` 或 `.etb-wrap`**——工具栏下拉是
+  `position:fixed` 弹层，多一个层叠上下文就把它们框住了。
+  **验证滑轨只能抓真实屏幕**：CDP 截图（puppeteer `page.screenshot`，`fromSurface`
+  两种都试过）**根本拍不到 `::-webkit-scrollbar`**——纯 HTML 对照页里一条写死红色的
+  4px thumb，CDP 截图零个红像素，同一画面 macOS `screencapture` 有 1200 个。
+  用 `screencapture -x -o -R x,y,w,h`，坐标别信 `window.screenX/screenY`（这台机器上
+  对不上），往页面里临时刷一块洋红标记整屏抓一次、用它的外接框反推偏移。
+- **工具栏那一行里带边框的定高控件必须 `box-sizing: border-box`（dev-board#543）**：
+  本仓没有全局 `* { box-sizing }`（uni 只给 `uni-page-wrapper/uni-page-body` 设了），
+  `.etb-field` 与 `.etb-stepper` 写的是 `height: 26px` + `1px` 边框，边框盒因此是 28px，
+  成了 `.etb-row` 里最高的一件，把整行撑到 28、26px 的按钮在里面一居中就比右侧
+  `.etb-right` 低 1px（走查实测 leftTop 93 / rightTop 92；两个都加 border-box 之后
+  940 / 1240 / 1640 三种窗口宽下差值都是 0）。往这一行加新控件时照此办理。
 - **`.tab-item` 必须有 `flex-shrink: 0`（dev-board#543）**：没有它，标签一多是整行被
-  压扁而不是溢出，滚动条永远不出现。`max-width` 同轮从 200px 收到 160px。
+  压扁而不是溢出，滚动条永远不出现。`max-width` 同轮从 200px 收到 160px——它是
+  **content-box**，不含左右 20px 内边距与 1px 右边框，实测渲染宽 181px，按「标签实际
+  多宽」调的时候要连带算上那 21px。
 - **活动标签滚入视野（dev-board#543）**：两条 `.tabs-scroll` 各有一个
   `:scroll-into-view="tabsScrollIntoView{Left,Right}"` + `scroll-with-animation`，
   锚点是每个 `.tab-item` 上的 `:id="tabDomId(pane, file.id)"`（`fileOpenTabs.js`
@@ -839,9 +868,10 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
 ## 验证
 
 - `cd frontend && npm run check:emits`（死绑定护栏）+ `npm run test:app-e2e`（登录→项目→上传→打开文件→独立页面全旅程）。
-- 改标签栏/工具栏滚动、标签拖拽语义加跑 `npm run test:project-home`（相关三个文件：
-  `wheel-delta.test.mjs` / `tab-strip-overflow.test.mjs` / `tab-drag-move.test.mjs`，
-  外加 `editor-toolbar-layout.test.mjs` 的 #502/#543 那半边）。
+- 改标签栏/工具栏滚动、标签拖拽语义加跑 `npm run test:project-home`（相关四个文件：
+  `horizontal-wheel.test.mjs`（挂载幂等/摘除/passive:false，假 DOM）、`wheel-delta.test.mjs`、
+  `tab-strip-overflow.test.mjs`、`tab-drag-move.test.mjs`，外加
+  `editor-toolbar-layout.test.mjs` 的 #502/#543 那半边）。
 - 改面板停靠/注册表加跑 `npm run test:panel-dock`（`resolveDocks` 回落规则与注册表自洽）。
 - 改导航/入口/设置页结构加跑 `npm run check:nav` 与 `npm run check:nav:full`（导航契约静态护栏，
   含「头像下拉只剩一项」「个人组四栏各自有人加载数据」「薄壳页挂的是统一设置面板」等断言）；

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -398,6 +398,49 @@ html {
     --awd-panel-accent-2: var(--awd-mint);
     --awd-panel-accent-wash: var(--awd-accent-wash);
 }
+
+/* ---- 悬浮细滑轨（.awd-hairline-scroll，dev-board#543） ----
+   VS Code 式：静止时只有轨道没有滑块（thumb 透明），鼠标进到容器里才显形。
+   给横向可滚的窄条（编辑器工具栏主命令区 .etb-scroll、编辑器标签栏 .tabs-scroll）
+   用——原生 15px 滚动条会把 38px 的一行撑成 41px（dev-board#502），而整条藏掉
+   又等于把「这里还能往右滚」这件事从界面上抹掉（#543 复发的正是这一步）。
+
+   写成全局类而不是各自 scoped：uni-h5 的 <scroll-view> 真正 overflow 的是内层
+   那个 div.uni-scroll-view（组件的 scope id 只落在 <uni-scroll-view> 根元素上），
+   scoped 样式够不着它，非要写就得逐处 :deep 复制一份。
+
+   Chromium 一旦看到 scrollbar-width，就整个忽略 ::-webkit-scrollbar 那套，6px 的
+   确定高度会退化成 thin（约 8px），把按上面 6px 算好的居中偏移带歪。所以标准属性
+   只留给没有 webkit 伪元素的浏览器。 */
+.awd-hairline-scroll::-webkit-scrollbar,
+.awd-hairline-scroll ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+.awd-hairline-scroll::-webkit-scrollbar-track,
+.awd-hairline-scroll ::-webkit-scrollbar-track {
+    background: transparent;
+}
+.awd-hairline-scroll::-webkit-scrollbar-thumb,
+.awd-hairline-scroll ::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 999px;
+}
+.awd-hairline-scroll:hover::-webkit-scrollbar-thumb,
+.awd-hairline-scroll:hover ::-webkit-scrollbar-thumb {
+    background: var(--awd-border-strong);
+}
+@supports not selector(::-webkit-scrollbar) {
+    .awd-hairline-scroll,
+    .awd-hairline-scroll .uni-scroll-view {
+        scrollbar-width: thin;
+        scrollbar-color: transparent transparent;
+    }
+    .awd-hairline-scroll:hover,
+    .awd-hairline-scroll:hover .uni-scroll-view {
+        scrollbar-color: var(--awd-border-strong) transparent;
+    }
+}
 /* mac：三颗交通灯占住左上角（右缘约 70px，留 18px 呼吸） */
 html.is-mac {
     --awd-titlebar-safe-inline-start: 88px;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -409,13 +409,16 @@ html {
    那个 div.uni-scroll-view（组件的 scope id 只落在 <uni-scroll-view> 根元素上），
    scoped 样式够不着它，非要写就得逐处 :deep 复制一份。
 
-   Chromium 一旦看到 scrollbar-width，就整个忽略 ::-webkit-scrollbar 那套，6px 的
-   确定高度会退化成 thin（约 8px），把按上面 6px 算好的居中偏移带歪。所以标准属性
+   4px：两处宿主各自按这个数补偿高度（.etb-scroll 的 calc(100% - 8px)/-4px、
+   .tabs-scroll 的 calc(100% + 4px)），改这里要连带改那两处。
+
+   Chromium 一旦看到 scrollbar-width，就整个忽略 ::-webkit-scrollbar 那套，4px 的
+   确定高度会退化成 thin（约 8px），把按上面 4px 算好的居中偏移带歪。所以标准属性
    只留给没有 webkit 伪元素的浏览器。 */
 .awd-hairline-scroll::-webkit-scrollbar,
 .awd-hairline-scroll ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 4px;
+    height: 4px;
 }
 .awd-hairline-scroll::-webkit-scrollbar-track,
 .awd-hairline-scroll ::-webkit-scrollbar-track {

--- a/frontend/src/components/EditorToolbar.vue
+++ b/frontend/src/components/EditorToolbar.vue
@@ -6,10 +6,13 @@
     <!-- 主命令区：窄了就横向滚动，不换行（换行会把画布挤下去）。
          原生横向滚动条有 15px 高，会把这一段撑到 41px、在 38px 的行里被
          align-items:center 顶得比右侧常驻区高半格（dev-board#502），但整条藏掉
-         又等于把「这里还能往右滚」从界面上抹掉（dev-board#543）——所以改成 6px
-         悬浮细滑轨（.awd-hairline-scroll，定义在 App.vue 全局样式里），横滚同时
-         接滚轮（与标签栏 .tabs-scroll 同一套做法）。 -->
-    <scroll-view class="etb-scroll awd-hairline-scroll" scroll-x @wheel.prevent="onToolbarWheel">
+         又等于把「这里还能往右滚」从界面上抹掉（dev-board#543）——所以改成 4px
+         悬浮细滑轨（.awd-hairline-scroll，定义在 App.vue 全局样式里）。
+         滚轮转横滚**不能写成这里的 @wheel**：uni 会把事件重建成普通对象，
+         currentTarget 不是 DOM、连 delta 都没有，整条是死的（dev-board#543 复发的
+         正是这一步）——改在 mounted 里用原生 addEventListener 挂，见
+         utils/horizontalWheel.js 与本组件的 bindToolbarWheel。 -->
+    <scroll-view class="etb-scroll awd-hairline-scroll" scroll-x>
       <view class="etb-row">
         <!-- 撤销 / 重做 -->
         <view class="etb-btn" :class="{ off: undoDisabled }" :title="$t('editor.toolbar.undo')" @tap.stop="run('undo')">
@@ -299,7 +302,7 @@
 //   3) 本组件自己发完命令之后
 // 没有轮询：以上三路已经覆盖了用户能让光标动起来的所有途径。
 
-import { wheelDeltaOf } from '@/utils/wheelDelta.js'
+import { bindHorizontalWheel } from '@/utils/horizontalWheel.js'
 
 const ICONS = {
   undo: ['M9 14 4 9l5-5', 'M4 9h10a6 6 0 0 1 0 12h-3'],
@@ -461,6 +464,16 @@ export default {
     executor: { handler() { this.bootstrap() }, immediate: true },
     refreshKey() { this.refresh() },
   },
+  mounted() {
+    // 滚轮横滚只能在真实 DOM 上挂（见 methods.bindToolbarWheel）。工具栏自己不会
+    // 重建 .etb-scroll，挂一次即可；组件被父级 v-if 掉时走 beforeUnmount 摘掉。
+    this.$nextTick(() => this.bindToolbarWheel())
+  },
+
+  beforeUnmount() {
+    if (this._toolbarWheelOff) { this._toolbarWheelOff(); this._toolbarWheelOff = null }
+  },
+
   methods: {
     async call(action, params) {
       if (!this.executor) return null
@@ -516,25 +529,14 @@ export default {
       return { position: 'fixed', left: left + 'px', top: this.popPos.top + 'px', zIndex: 900 }
     },
     closeMenus() { this.menu = ''; this.insertMode = ''; this.insertErr = '' },
-    // 纵向滚轮映射成横向滚动，否则窄窗口下右半截命令只能靠拖那条 6px 细滑轨
-    // （dev-board#502，与标签栏 onTabsWheel 同一实现）。scroll-view 真正 overflow
-    // 的是 uni-h5 渲染出的内层元素，不是根元素本身，按 scrollWidth 找。
-    // 位移一律经 wheelDeltaOf 取：uni 重建过的事件对象上没有 deltaX/deltaY，
-    // 直接读会得到 NaN，横滚静默失效（dev-board#543）。
-    onToolbarWheel(evt) {
-      const root = evt && evt.currentTarget
-      if (!root || typeof root.querySelectorAll !== 'function') return
-      const delta = wheelDeltaOf(evt)
-      if (!delta) return
-      let scroller = null
-      if (root.scrollWidth > root.clientWidth) scroller = root
-      if (!scroller) {
-        for (const el of root.querySelectorAll('*')) {
-          if (el.scrollWidth > el.clientWidth + 1) { scroller = el; break }
-        }
-      }
-      if (!scroller) return
-      scroller.scrollLeft += delta
+    // 纵向滚轮映射成横向滚动，否则窄窗口下右半截命令只能靠拖那条 4px 细滑轨
+    // （dev-board#502 / #543，与标签栏 rebindTabsWheel 同一实现）。必须用原生
+    // addEventListener 挂在 uni 渲染出的真实元素上——模板上的 @wheel 收到的是
+    // uni 重建过的普通对象，第一道守卫就 return（理由写在 horizontalWheel.js）。
+    bindToolbarWheel() {
+      const root = this.$el
+      const el = root && typeof root.querySelector === 'function' ? root.querySelector('.etb-scroll') : null
+      if (el) this._toolbarWheelOff = bindHorizontalWheel(el)
     },
 
     // ---- 插入菜单 ----
@@ -774,18 +776,22 @@ export default {
 .etb-find-b.on { background: var(--awd-accent-soft); border-color: var(--awd-mint); color: var(--awd-accent-text); }
 .etb-find-x { margin-left: auto; padding: 3px 9px; font-size: 12px; color: var(--awd-text-2); flex-shrink: 0; }
 .etb-err.bar { margin: 0; border-radius: 0; padding: 4px 10px; }
-/* 6px 悬浮细滑轨：样式本体在 .awd-hairline-scroll（App.vue 全局），这里只处理
-   它占的那 6px 高度。滑轨是从内容盒里扣掉的，主命令区因此会长到 26+6=32px，被
-   .etb 的 align-items:center 一居中，左半边按钮就比右侧常驻区高 3px——正是
+/* 4px 悬浮细滑轨：样式本体在 .awd-hairline-scroll（App.vue 全局），这里只处理
+   它占的那 4px 高度。滑轨是从内容盒里扣掉的，不补偿的话主命令区会长到 26+4=30px，
+   被 .etb 的 align-items:center 一居中，左半边按钮就比右侧常驻区高 2px——正是
    dev-board#502 修的那种错位。
 
-   定高 calc(100% - 6px)（= 32px）+ margin-bottom:-6px：外边距盒回到 26px，被居中后
-   边框盒从 y6 起，内容盒恰好 y6..32，与右侧常驻区严丝合缝——**溢出与否都一样**。
-   不定高的话（内容多高就多高）只在有滑轨时对得上，命令放得下时又会反向偏 3px。
-   行内最高的是 26px 的 .etb-btn/.etb-field，有滑轨时内容盒正好 26px，不会裁到。
+   两个数按「行高 38、行内内容 26、滑轨 4」算，改任何一个都要重算：
+   边框盒 = 26 + 4 = 30px（写成 calc(100% - 8px)，跟着 .etb 那 38px 走），
+   margin-bottom:-4px 让外边距盒回到 26px，align-items:center 之后边框盒从 y6 起，
+   内容盒恰好 y6..32，与右侧常驻区严丝合缝——**溢出与否都一样**。不定高的话
+   （内容多高就多高）只在有滑轨时对得上，命令放得下时又会反向偏。
+   行内最高的是 26px 的 .etb-btn/.etb-field/.etb-stepper（后两者靠 box-sizing:
+   border-box 把 1px 边框收进 26 里，否则它们 28px 会把整行连同按钮顶低 1px，
+   dev-board#543 走查实测）。
    这里刻意不设 z-index：会造出层叠上下文，把工具栏下拉那些 fixed 弹层框住（同
    .etb-wrap 那条）。 */
-.etb-scroll { flex: 1; min-width: 0; white-space: nowrap; height: calc(100% - 6px); margin-bottom: -6px; }
+.etb-scroll { flex: 1; min-width: 0; white-space: nowrap; height: calc(100% - 8px); margin-bottom: -4px; }
 .etb-row { display: flex; align-items: center; gap: 2px; }
 .etb-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; padding-left: 6px;
   border-left: 1px solid var(--awd-border); }
@@ -808,7 +814,10 @@ export default {
 .etb-swatch { position: absolute; left: 4px; right: 4px; bottom: 3px; height: 3px; border-radius: 2px;
   border: 1px solid rgba(0, 0, 0, 0.08); }
 
+/* box-sizing:border-box：没有它，1px 边框会让边框盒变成 28px，.etb-row 跟着变 28，
+   26px 的按钮在里面一居中就比右侧常驻区低 1px（dev-board#543 走查实测）。 */
 .etb-field { display: flex; align-items: center; justify-content: space-between; gap: 4px; height: 26px;
+  box-sizing: border-box;
   padding: 0 6px; border: 1px solid var(--awd-border); border-radius: 5px; background: var(--awd-surface); }
 .etb-field:hover { border-color: var(--awd-border-strong); }
 .etb-field-t { font-size: 12px; color: var(--awd-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -856,7 +865,10 @@ export default {
 .etb-chip.none::after { content: ''; position: absolute; left: 1px; right: 1px; top: 8px; height: 1px;
   background: var(--awd-danger); transform: rotate(-45deg); }
 
-.etb-stepper { display: flex; align-items: center; height: 26px; border: 1px solid var(--awd-border); border-radius: 5px;
+/* box-sizing 同 .etb-field：26px + 1px 边框 = 28px 的边框盒会成为 .etb-row 里最高的
+   一件，把整行连同 26px 的按钮顶低 1px（dev-board#543 走查实测的那 1px）。 */
+.etb-stepper { display: flex; align-items: center; height: 26px; box-sizing: border-box;
+  border: 1px solid var(--awd-border); border-radius: 5px;
   background: var(--awd-surface); flex-shrink: 0; }
 .etb-step-b { width: 20px; text-align: center; font-size: 14px; color: var(--awd-text-2); line-height: 24px; }
 .etb-step-b:hover { color: var(--awd-accent-text); background: var(--awd-surface-2); }

--- a/frontend/src/components/EditorToolbar.vue
+++ b/frontend/src/components/EditorToolbar.vue
@@ -4,10 +4,12 @@
   <view class="etb-wrap">
   <view class="etb" @tap="closeMenus">
     <!-- 主命令区：窄了就横向滚动，不换行（换行会把画布挤下去）。
-         滚动条整条隐藏、横滚交给滚轮（与标签栏 .tabs-scroll 同一套做法，
-         dev-board#502）：原生横向滚动条有 15px 高，会把这一段撑到 41px、
-         在 38px 的行里被 align-items:center 顶得比右侧常驻区高半格。 -->
-    <scroll-view class="etb-scroll" scroll-x :show-scrollbar="false" @wheel.prevent="onToolbarWheel">
+         原生横向滚动条有 15px 高，会把这一段撑到 41px、在 38px 的行里被
+         align-items:center 顶得比右侧常驻区高半格（dev-board#502），但整条藏掉
+         又等于把「这里还能往右滚」从界面上抹掉（dev-board#543）——所以改成 6px
+         悬浮细滑轨（.awd-hairline-scroll，定义在 App.vue 全局样式里），横滚同时
+         接滚轮（与标签栏 .tabs-scroll 同一套做法）。 -->
+    <scroll-view class="etb-scroll awd-hairline-scroll" scroll-x @wheel.prevent="onToolbarWheel">
       <view class="etb-row">
         <!-- 撤销 / 重做 -->
         <view class="etb-btn" :class="{ off: undoDisabled }" :title="$t('editor.toolbar.undo')" @tap.stop="run('undo')">
@@ -297,6 +299,8 @@
 //   3) 本组件自己发完命令之后
 // 没有轮询：以上三路已经覆盖了用户能让光标动起来的所有途径。
 
+import { wheelDeltaOf } from '@/utils/wheelDelta.js'
+
 const ICONS = {
   undo: ['M9 14 4 9l5-5', 'M4 9h10a6 6 0 0 1 0 12h-3'],
   redo: ['M15 14l5-5-5-5', 'M20 9H10a6 6 0 0 0 0 12h3'],
@@ -512,12 +516,16 @@ export default {
       return { position: 'fixed', left: left + 'px', top: this.popPos.top + 'px', zIndex: 900 }
     },
     closeMenus() { this.menu = ''; this.insertMode = ''; this.insertErr = '' },
-    // 滚动条藏了，纵向滚轮就得映射成横向滚动，否则窄窗口下右半截命令够不着
+    // 纵向滚轮映射成横向滚动，否则窄窗口下右半截命令只能靠拖那条 6px 细滑轨
     // （dev-board#502，与标签栏 onTabsWheel 同一实现）。scroll-view 真正 overflow
     // 的是 uni-h5 渲染出的内层元素，不是根元素本身，按 scrollWidth 找。
+    // 位移一律经 wheelDeltaOf 取：uni 重建过的事件对象上没有 deltaX/deltaY，
+    // 直接读会得到 NaN，横滚静默失效（dev-board#543）。
     onToolbarWheel(evt) {
       const root = evt && evt.currentTarget
       if (!root || typeof root.querySelectorAll !== 'function') return
+      const delta = wheelDeltaOf(evt)
+      if (!delta) return
       let scroller = null
       if (root.scrollWidth > root.clientWidth) scroller = root
       if (!scroller) {
@@ -526,7 +534,6 @@ export default {
         }
       }
       if (!scroller) return
-      const delta = Math.abs(evt.deltaX) > Math.abs(evt.deltaY) ? evt.deltaX : evt.deltaY
       scroller.scrollLeft += delta
     },
 
@@ -767,14 +774,18 @@ export default {
 .etb-find-b.on { background: var(--awd-accent-soft); border-color: var(--awd-mint); color: var(--awd-accent-text); }
 .etb-find-x { margin-left: auto; padding: 3px 9px; font-size: 12px; color: var(--awd-text-2); flex-shrink: 0; }
 .etb-err.bar { margin: 0; border-radius: 0; padding: 4px 10px; }
-/* 滚动条整条隐藏（dev-board#502）。show-scrollbar=false 会让 uni-h5 给真正 overflow
-   的内层元素挂上 .uni-scroll-view-scrollbar-hidden，那条规则在 h5 产物的 uni.css 里
-   是实打实存在的；下面这几行是同一目的的兜底——本组件的 scoped 属性只落在
-   <uni-scroll-view> 根元素上，内层那个 div 不带 scope id，得靠 :deep 才够得着。 */
-.etb-scroll { flex: 1; min-width: 0; white-space: nowrap; scrollbar-width: none; }
-.etb-scroll::-webkit-scrollbar { display: none; }
-.etb-scroll :deep(*) { scrollbar-width: none; }
-.etb-scroll :deep(*::-webkit-scrollbar) { display: none; }
+/* 6px 悬浮细滑轨：样式本体在 .awd-hairline-scroll（App.vue 全局），这里只处理
+   它占的那 6px 高度。滑轨是从内容盒里扣掉的，主命令区因此会长到 26+6=32px，被
+   .etb 的 align-items:center 一居中，左半边按钮就比右侧常驻区高 3px——正是
+   dev-board#502 修的那种错位。
+
+   定高 calc(100% - 6px)（= 32px）+ margin-bottom:-6px：外边距盒回到 26px，被居中后
+   边框盒从 y6 起，内容盒恰好 y6..32，与右侧常驻区严丝合缝——**溢出与否都一样**。
+   不定高的话（内容多高就多高）只在有滑轨时对得上，命令放得下时又会反向偏 3px。
+   行内最高的是 26px 的 .etb-btn/.etb-field，有滑轨时内容盒正好 26px，不会裁到。
+   这里刻意不设 z-index：会造出层叠上下文，把工具栏下拉那些 fixed 弹层框住（同
+   .etb-wrap 那条）。 */
+.etb-scroll { flex: 1; min-width: 0; white-space: nowrap; height: calc(100% - 6px); margin-bottom: -6px; }
 .etb-row { display: flex; align-items: center; gap: 2px; }
 .etb-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; padding-left: 6px;
   border-left: 1px solid var(--awd-border); }

--- a/frontend/src/locales/en-US/editor.js
+++ b/frontend/src/locales/en-US/editor.js
@@ -10,6 +10,7 @@ export default {
   unsavedCloseTitle: 'Document has unsaved changes',
   unsavedCloseBody: 'Saving has not completed. Keep editing and retry saving, or discard unsaved changes and close. Content already saved to disk will be kept.',
   discardAndClose: 'Discard and Close',
+  moveTabSaveFailed: 'Saving has not completed - the tab was not moved to the other pane',
   keepEditing: 'Keep Editing',
 
   status: {

--- a/frontend/src/locales/zh-CN/editor.js
+++ b/frontend/src/locales/zh-CN/editor.js
@@ -10,6 +10,7 @@ export default {
   unsavedCloseTitle: '文档尚未保存完成',
   unsavedCloseBody: '保存未能完成。你可以继续编辑并重试保存，或放弃尚未保存的更改并关闭。已保存到磁盘的内容会保留。',
   discardAndClose: '放弃并关闭',
+  moveTabSaveFailed: '保存尚未完成，标签暂不移动到另一侧',
   keepEditing: '继续编辑',
 
   status: {

--- a/frontend/src/pages/project-overview/fileOpenTabs.js
+++ b/frontend/src/pages/project-overview/fileOpenTabs.js
@@ -25,6 +25,14 @@ function mouseButtonOf(e) {
   return native && typeof native.button === 'number' ? native.button : -1
 }
 
+// 标签在 DOM 里的 id：uni <scroll-view> 的 scroll-into-view 用它定位要滚到的元素，
+// 而它对 id 的形状有硬要求（/^[_a-zA-Z][-_a-zA-Z0-9:]*$/，不合就 console.error 后
+// 什么都不做）。标签 id 五花八门（数字主键、`vcmp-<sha>-<ts>`、`diff-a-b-ts`、
+// 浏览器/设置这类虚拟标签），非法字符统一换成下划线。
+function tabDomId(pane, fileId) {
+  return 'tab-' + pane + '-' + String(fileId == null ? '' : fileId).replace(/[^A-Za-z0-9_-]/g, '_')
+}
+
 export const fileOpenTabsMethods = {
     handleFileTreeSelect(file) {
       if (!file || file.isFolder) return
@@ -181,6 +189,45 @@ export const fileOpenTabsMethods = {
       this.$nextTick(() => this.triggerWorkbenchResize())
     },
 
+    /** 模板里给每个 .tab-item 打 id 用（scroll-into-view 的锚点） */
+    tabDomId(pane, fileId) {
+      return tabDomId(pane, fileId)
+    },
+
+    // 活动标签滚入视野（dev-board#543）。挂在 activeFileId* 的 watcher 上而不是
+    // activateTab 里：openFile 是自己直接写 activeFileId* 的（不走 activateTab），
+    // moveTabTo、closeFile 的相邻接管、按模式恢复也都是，watcher 才是唯一入口。
+    ensureActiveTabVisible(pane) {
+      const prop = pane === 'left' ? 'tabsScrollIntoViewLeft' : 'tabsScrollIntoViewRight'
+      const activeId = pane === 'left' ? this.activeFileIdLeft : this.activeFileIdRight
+      // 先清空：同一个 id 再次激活时属性值不变，uni 那个 watch 不会重新触发。
+      this[prop] = ''
+      if (!activeId) return
+      const domId = tabDomId(pane, activeId)
+      this.$nextTick(() => {
+        // 本来就整条看得见就不动。scroll-into-view 是把元素对齐到容器最左，
+        // 点一个眼前的标签也会把整条标签栏抽一下。
+        if (this.isTabFullyVisible(domId)) return
+        this[prop] = domId
+      })
+    },
+
+    isTabFullyVisible(domId) {
+      if (typeof document === 'undefined') return false
+      const el = document.getElementById(domId)
+      if (!el || typeof el.getBoundingClientRect !== 'function') return false
+      // 只在这条标签栏内部往上找，别一路找到页面级的横向滚动容器上去。
+      let scroller = el.parentElement
+      while (scroller && !(scroller.scrollWidth > scroller.clientWidth + 1)) {
+        if (scroller.tagName === 'UNI-SCROLL-VIEW') { scroller = null; break }
+        scroller = scroller.parentElement
+      }
+      if (!scroller) return true // 没有溢出，谈不上要滚
+      const box = scroller.getBoundingClientRect()
+      const rect = el.getBoundingClientRect()
+      return rect.left >= box.left - 1 && rect.right <= box.right + 1
+    },
+
     activateTab(file, pane) {
       // 点击 Tab 时，切换对应窗格的激活文件，并聚焦该窗格
       this.focusPane(pane)
@@ -331,7 +378,8 @@ export const fileOpenTabsMethods = {
       }
       // 浏览器标签：BrowserPane 卸载时只把 BrowserView 摘下（保活，为的是切标签
       // 不丢网页内容），真正销毁只发生在标签关闭——也就是这里，以及页面卸载。
-      // 跨窗格拖拽是「在另一侧也打开同一个标签」（同 id 双开，见 tabDragSplit），
+      // 按住 Alt/Option 跨窗格拖拽是「在另一侧也打开同一个标签」（同 id 双开，
+      // 见 tabDragSplit；普通拖拽是移动，不会造出第二份），
       // 所以另一侧还开着的时候不能销毁——那是把人家正看着的网页拔掉。
       if (this.isBrowserTab(file) && !this.isOpenInOtherPane(fileId, pane)) {
         this.destroyBrowserView(file.id)

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -1844,24 +1844,25 @@ $color-accent: #5BD197; // Mint Green
 .tabs-scroll {
   width: 100%;
 
-  /* VS Code 式标签栏：6px 悬浮细滑轨（.awd-hairline-scroll，样式本体在 App.vue
-     全局），横滚同时接滚轮（onTabsWheel）。滑轨整条藏掉的话，标签一多就再没有
-     任何「右边还有」的提示（dev-board#543）。
+  /* VS Code 式标签栏：4px 悬浮细滑轨（.awd-hairline-scroll，样式本体在 App.vue
+     全局），横滚同时接滚轮（原生挂上去的，见 tabDragSplit.rebindTabsWheel）。
+     滑轨整条藏掉的话，标签一多就再没有任何「右边还有」的提示（dev-board#543）。
 
-     高度写 calc(100% + 6px) 而不是 100%：滑轨占的 6px 是从内容盒里扣的，
-     100% 会让内容盒只剩 30px，而 .tab-item 是写死的 36px，底下 6px 会被 uni 给
+     高度写 calc(100% + 4px) 而不是 100%：滑轨占的 4px 是从内容盒里扣的，
+     100% 会让内容盒只剩 32px，而 .tab-item 是写死的 36px，底下 4px 会被 uni 给
      内层元素挂的 overflow-y:hidden 裁掉（激活标签那块白底会在贴着编辑器的一侧
-     断开 6px，正好毁掉「标签与正文连成一体」这个形制）。多给 6px，标签仍是完整
-     36px，滑轨落在标签栏下沿那 6px 里。
+     断开，正好毁掉「标签与正文连成一体」这个形制）。多给 4px，标签仍是完整
+     36px，滑轨落在标签栏下沿之外那 4px 里。
 
-     那 6px 溢出到 .tabs-bar 之外，落在 .editors-container 头上——后者是
-     position:relative 且有背景色，按绘制顺序排在普通流内容之后，会把滑轨整条盖掉。
-     所以这里自己也定位起来并抬一层。z-index 只给 .tabs-scroll 不给 .tabs-bar：
-     层叠上下文越小越好，这一层里只有标签本身，没有任何要往外飞的弹层。
+     那 4px 溢出到 .tabs-bar 之外，落在编辑区头上——`.editors-container` 与
+     `.editor-pane` 都是 position:relative 且有背景色，排在普通流里更靠后，
+     z-index 只到 1 时会把滑轨整条盖掉（#543 走查实测：注入 height:100% 立刻
+     就能看见 thumb）。所以这里自己定位起来并抬到 2。z-index 只给 .tabs-scroll
+     不给 .tabs-bar：层叠上下文越小越好，这一层里只有标签本身，没有要往外飞的弹层。
      被盖住的是编辑器工具栏那 38px 行的上边距（按钮在 y6..32），点不着按钮的风险没有。 */
-  height: calc(100% + 6px);
+  height: calc(100% + 4px);
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
 .tabs-list {
@@ -1914,6 +1915,8 @@ $color-accent: #5BD197; // Mint Green
   /* 标签多了要溢出成横滚，不是被整批压扁（dev-board#543）：没有 flex-shrink:0
      时 .tabs-list 这一行会把每个标签越挤越窄，滚动条永远不出现。 */
   flex-shrink: 0;
+  /* content-box：这 160px 不含左右 20px 内边距与 1px 右边框，实测渲染宽 181px。
+     想按「标签实际多宽」调，改这里要连带算上那 21px。 */
   max-width: 160px;
   user-select: none;
   transition: background-color 0.15s ease;

--- a/frontend/src/pages/project-overview/project-overview.scss
+++ b/frontend/src/pages/project-overview/project-overview.scss
@@ -1843,20 +1843,25 @@ $color-accent: #5BD197; // Mint Green
 
 .tabs-scroll {
   width: 100%;
-  height: 100%;
 
-  /* VS Code 式标签栏：滚动条整条隐藏（横滚靠滚轮，onTabsWheel）。
-     真正 overflow 的是 uni-h5 scroll-view 的内层元素（不带本组件 scope id），要 :deep 兜住。 */
-  scrollbar-width: none;
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  :deep(*) {
-    scrollbar-width: none;
-  }
-  :deep(*::-webkit-scrollbar) {
-    display: none;
-  }
+  /* VS Code 式标签栏：6px 悬浮细滑轨（.awd-hairline-scroll，样式本体在 App.vue
+     全局），横滚同时接滚轮（onTabsWheel）。滑轨整条藏掉的话，标签一多就再没有
+     任何「右边还有」的提示（dev-board#543）。
+
+     高度写 calc(100% + 6px) 而不是 100%：滑轨占的 6px 是从内容盒里扣的，
+     100% 会让内容盒只剩 30px，而 .tab-item 是写死的 36px，底下 6px 会被 uni 给
+     内层元素挂的 overflow-y:hidden 裁掉（激活标签那块白底会在贴着编辑器的一侧
+     断开 6px，正好毁掉「标签与正文连成一体」这个形制）。多给 6px，标签仍是完整
+     36px，滑轨落在标签栏下沿那 6px 里。
+
+     那 6px 溢出到 .tabs-bar 之外，落在 .editors-container 头上——后者是
+     position:relative 且有背景色，按绘制顺序排在普通流内容之后，会把滑轨整条盖掉。
+     所以这里自己也定位起来并抬一层。z-index 只给 .tabs-scroll 不给 .tabs-bar：
+     层叠上下文越小越好，这一层里只有标签本身，没有任何要往外飞的弹层。
+     被盖住的是编辑器工具栏那 38px 行的上边距（按钮在 y6..32），点不着按钮的风险没有。 */
+  height: calc(100% + 6px);
+  position: relative;
+  z-index: 1;
 }
 
 .tabs-list {
@@ -1906,7 +1911,10 @@ $color-accent: #5BD197; // Mint Green
   background: transparent;
   border-right: 1px solid var(--awd-border);
   cursor: pointer;
-  max-width: 200px;
+  /* 标签多了要溢出成横滚，不是被整批压扁（dev-board#543）：没有 flex-shrink:0
+     时 .tabs-list 这一行会把每个标签越挤越窄，滚动条永远不出现。 */
+  flex-shrink: 0;
+  max-width: 160px;
   user-select: none;
   transition: background-color 0.15s ease;
 

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -853,7 +853,7 @@
               <!-- 左侧窗格的 Tabs -->
               <view class="tabs-pane tabs-pane-left" :class="{ 'half-width': splitMode }">
                 <scroll-view class="tabs-scroll awd-hairline-scroll" scroll-x scroll-with-animation
-                  :scroll-into-view="tabsScrollIntoViewLeft" @wheel.prevent="onTabsWheel">
+                  :scroll-into-view="tabsScrollIntoViewLeft">
                   <view
                     class="tabs-list"
                     @dragover.prevent="onTabDropZoneDragOver('left')"
@@ -895,7 +895,7 @@
               <!-- 右侧窗格的 Tabs (仅在分屏时显示) -->
               <view v-if="splitMode" class="tabs-pane tabs-pane-right">
                 <scroll-view class="tabs-scroll awd-hairline-scroll" scroll-x scroll-with-animation
-                  :scroll-into-view="tabsScrollIntoViewRight" @wheel.prevent="onTabsWheel">
+                  :scroll-into-view="tabsScrollIntoViewRight">
                   <view
                     class="tabs-list"
                     @dragover.prevent="onTabDropZoneDragOver('right')"
@@ -2962,6 +2962,7 @@ export default {
   },
   beforeUnmount() {
     this.disposeThemeSwitch()
+    this.unbindTabsWheel()
     // 多实例守卫：只清掉指向自己的活跃指针；返回上一个本页实例时由其 onShow 重新接管
     if (typeof window !== 'undefined' && window.__checkbaActiveOverviewVm === this) {
       window.__checkbaActiveOverviewVm = null
@@ -3295,6 +3296,9 @@ export default {
     // mounted 绑定了全局（ipcRenderer/window 级）监听；全局事件只让最近展示的实例
     // 处理，否则一次事件触发 N 份副作用（与 PR#148 剪贴板重复入库同源）
     if (typeof window !== 'undefined') window.__checkbaActiveOverviewVm = this
+    // 标签栏的滚轮横滚：只能原生挂（模板 @wheel 收到的是 uni 重建过的普通对象，
+    // 见 utils/horizontalWheel.js），所以 DOM 就绪后挂一次，beforeUnmount 摘掉。
+    this.$nextTick(() => this.rebindTabsWheel())
     // 余额刷新事件（充值弹窗 / SKU 购买成功后 emit）。页面栈多实例地雷：mounted 挂、
     // beforeUnmount 必须按引用 $off，否则每回来一次多一份订阅。
     this._onWalletRefresh = () => this.loadWalletBalance()
@@ -3597,7 +3601,9 @@ export default {
     sidebarCollapsed() { this.pushMenuState() },
     showToolsPanel() { this.pushMenuState() },
     showAiPanel() { this.pushMenuState() },
-    splitMode() { this.pushMenuState() },
+    // 分屏开关会把右侧那条标签栏整个建/拆，滚轮横滚是原生挂上去的，得跟着重挂
+    // （幂等，见 tabDragSplit.rebindTabsWheel）。
+    splitMode() { this.pushMenuState(); this.$nextTick(() => this.rebindTabsWheel()) },
     activeToolKey() { this.pushMenuState() },
     leftPaneKey() { this.pushMenuState() },
     isRecording() { this.pushMenuState() },

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -852,7 +852,8 @@
             <view class="tabs-bar">
               <!-- 左侧窗格的 Tabs -->
               <view class="tabs-pane tabs-pane-left" :class="{ 'half-width': splitMode }">
-                <scroll-view class="tabs-scroll" scroll-x :show-scrollbar="false" @wheel.prevent="onTabsWheel">
+                <scroll-view class="tabs-scroll awd-hairline-scroll" scroll-x scroll-with-animation
+                  :scroll-into-view="tabsScrollIntoViewLeft" @wheel.prevent="onTabsWheel">
                   <view
                     class="tabs-list"
                     @dragover.prevent="onTabDropZoneDragOver('left')"
@@ -862,6 +863,7 @@
                       v-for="file in leftFiles"
                       :key="file.id"
                       v-show="isTabVisible(file)"
+                      :id="tabDomId('left', file.id)"
                       class="tab-item"
                       :class="[tabKindClass(file), {
                         active: activeFileIdLeft === file.id,
@@ -892,7 +894,8 @@
 
               <!-- 右侧窗格的 Tabs (仅在分屏时显示) -->
               <view v-if="splitMode" class="tabs-pane tabs-pane-right">
-                <scroll-view class="tabs-scroll" scroll-x :show-scrollbar="false" @wheel.prevent="onTabsWheel">
+                <scroll-view class="tabs-scroll awd-hairline-scroll" scroll-x scroll-with-animation
+                  :scroll-into-view="tabsScrollIntoViewRight" @wheel.prevent="onTabsWheel">
                   <view
                     class="tabs-list"
                     @dragover.prevent="onTabDropZoneDragOver('right')"
@@ -902,6 +905,7 @@
                       v-for="file in rightFiles"
                       :key="file.id"
                       v-show="isTabVisible(file)"
+                      :id="tabDomId('right', file.id)"
                       class="tab-item"
                       :class="[tabKindClass(file), {
                         active: activeFileIdRight === file.id,
@@ -2416,8 +2420,12 @@ export default {
       pageEnterTime: 0,
 
       // Tabs 拖拽状态
-      draggingTab: null, // { fileId, fromPane }
+      draggingTab: null, // { fileId, fromPane, copy }
       tabDragOver: null, // { fileId, pane }
+      // 活动标签滚入视野（dev-board#543）：uni <scroll-view> 的 scroll-into-view 认
+      // 元素 id，赋值即滚。两个窗格各一份，由 activeFileId* 的 watcher 统一驱动。
+      tabsScrollIntoViewLeft: '',
+      tabsScrollIntoViewRight: '',
 
       // Epic #43: embedded LibreOffice editor. When active, backend AI commands
       // route to it (handleEditorCommand).
@@ -3580,12 +3588,12 @@ export default {
   watch: {
     // IDE 化窗口标题：「文件名 — 项目名 — AI WorkDeck」（Electron 窗口标题跟随 document.title）
     'project.name'() { this.updateWindowTitle() },
-    activeFileIdLeft() { this.updateWindowTitle(); this.pushMenuState() },
+    activeFileIdLeft() { this.updateWindowTitle(); this.pushMenuState(); this.ensureActiveTabVisible('left') },
     // 菜单栏的勾选/置灰跟着这些走。编辑器与 AI 面板内部的状态走 @menu-state
     // 事件（见对应组件），这里只管工作台自己的。桥那边有浅比较+去抖，
     // 这些 watcher 只管「叫一声」，不必自己节流。
     'project.id'() { this.pushMenuState() },
-    activeFileIdRight() { this.pushMenuState() },
+    activeFileIdRight() { this.pushMenuState(); this.ensureActiveTabVisible('right') },
     sidebarCollapsed() { this.pushMenuState() },
     showToolsPanel() { this.pushMenuState() },
     showAiPanel() { this.pushMenuState() },

--- a/frontend/src/pages/project-overview/tabDragSplit.js
+++ b/frontend/src/pages/project-overview/tabDragSplit.js
@@ -1,20 +1,34 @@
 // SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// project-overview.vue 的标签页拖拽与分栏布局：tab 跨窗格拖拽（跨窗格是"双开"不是"移动"）、
+// project-overview.vue 的标签页拖拽与分栏布局：tab 跨窗格拖拽（普通拖拽是"移动"，
+// 按住 Alt/Option 才是"在另一侧再开一份"，dev-board#542）、
 // 三向面板拖拽改尺寸（rAF 节流 + 直接改 DOM，停手时才同步回 Vue 状态）、分屏开关与窗格聚焦。
 // 经展开进组件 methods（纯搬移，Phase 2 外置），`this` 即 project-overview 页面实例。
 
 import { activityTracker } from '@/utils/activityTracker.js'
 import { rightPanelMaxWidth, leftPanelMaxWidth } from './panelWidthLimits.js'
+import { wheelDeltaOf } from '@/utils/wheelDelta.js'
+
+// 取拖拽起手时有没有按住 Alt/Option。同 fileOpenTabs.js 的 mouseButtonOf：uni-h5 把
+// <view> 上的原生事件重建成普通对象，只给 click / mouse 系 / touch / 键盘四类补字段，
+// 补的也只是坐标，altKey 一类一概没有——所以要回退到当前正在派发的原生事件。
+function altKeyOf(e) {
+  if (e && typeof e.altKey === 'boolean') return e.altKey
+  const native = typeof window !== 'undefined' ? window.event : null
+  return !!(native && native.altKey)
+}
 
 export const tabDragSplitMethods = {
     onTabDragStart(evt, file, fromPane) {
-      this.draggingTab = { fileId: file.id, fromPane }
+      // 修饰键只在 dragstart 这一下有原生事件可读（dragover/drop 阶段 uni 重建的
+      // 对象上更没有），所以起手就记下来，drop 时读这份。
+      const copy = altKeyOf(evt)
+      this.draggingTab = { fileId: file.id, fromPane, copy }
       this.tabDragOver = null
       try {
         if (evt && evt.dataTransfer) {
-          evt.dataTransfer.effectAllowed = 'move'
-          evt.dataTransfer.setData('application/json', JSON.stringify({ fileId: file.id, fromPane }))
+          evt.dataTransfer.effectAllowed = copy ? 'copyMove' : 'move'
+          evt.dataTransfer.setData('application/json', JSON.stringify({ fileId: file.id, fromPane, copy }))
         }
       } catch (e) {
         // ignore
@@ -35,27 +49,72 @@ export const tabDragSplitMethods = {
       }
     },
 
-    onTabDropOnZone(evt, targetPane) {
+    async onTabDropOnZone(evt, targetPane) {
       const payload = this.getTabDragPayload(evt) || this.draggingTab
       if (!payload || !payload.fileId) return
       // drop 到空白区域：插入到末尾
-      this.moveTabTo(payload.fileId, payload.fromPane, targetPane, null)
-      this.onTabDragEnd()
+      await this.commitTabDrop(payload, targetPane, null)
     },
 
-    onTabDropOnItem(evt, targetFile, targetPane) {
+    async onTabDropOnItem(evt, targetFile, targetPane) {
       const payload = this.getTabDragPayload(evt) || this.draggingTab
       if (!payload || !payload.fileId) return
 
-      this.moveTabTo(payload.fileId, payload.fromPane, targetPane, targetFile.id)
+      await this.commitTabDrop(payload, targetPane, targetFile.id)
+    },
+
+    // 两个 drop 落点共用的收尾：先按需落盘，再改列表。
+    async commitTabDrop(payload, targetPane, beforeFileId) {
+      const copy = !!payload.copy
+      if (!copy && payload.fromPane !== targetPane) {
+        const ok = await this.flushTabBeforePaneMove(payload.fileId, payload.fromPane)
+        if (!ok) {
+          uni.showToast({ title: this.$t('editor.moveTabSaveFailed'), icon: 'none' })
+          this.onTabDragEnd()
+          return
+        }
+      }
+      this.moveTabTo(payload.fileId, payload.fromPane, targetPane, beforeFileId, { copy })
       this.onTabDragEnd()
     },
 
+    // 跨窗格「移动」会把源侧那个编辑器实例卸掉，而 LibreOfficeEditor.beforeUnmount
+    // 自己写着「export 需要活的 webview，从这里保存已经太晚」——所以搬走之前必须
+    // 先落盘，同 closeFile 的那道闸。落不下来就不搬，把话说清楚（静默丢几秒改动
+    // 是这个仓里反复踩过的坑）。
+    async flushTabBeforePaneMove(fileId, fromPane) {
+      const list = fromPane === 'left' ? this.leftFiles : this.rightFiles
+      const file = (list || []).find(f => f.id === fileId)
+      if (!file) return true
+      if (this.useLibreEditor(file)) {
+        const inst = (this._libreRefs || {})[fromPane + ':' + fileId]
+        if (inst && inst.ready && !inst.docLoadFailed && inst.file && (inst.dirty || inst.saving)) {
+          try { return (await inst.flushSave({ timeoutMs: 10000 })) !== false } catch (e) {
+            console.warn('[ProjectOverview] move flush-save failed:', e)
+            return false
+          }
+        }
+      } else if (this.isPlainTextFile(file)) {
+        const inst = (this._plainTextRefs || {})[fromPane]
+        if (inst && inst.file && inst.file.id === fileId && (inst.dirty || inst.saving)) {
+          try { return (await inst.flushSave()) !== false && !inst.dirty && !inst.saving } catch (e) {
+            console.warn('[ProjectOverview] move flush-save (text) failed:', e)
+            return false
+          }
+        }
+      }
+      return true
+    },
+
     onTabsWheel(evt) {
-      // VS Code 式标签栏：滚动条整条隐藏，纵向滚轮映射为横向滚动。
+      // VS Code 式标签栏：纵向滚轮映射为横向滚动（滑轨只有 6px，不该逼着人去拖它）。
       // scroll-view 真正 overflow 的是 uni-h5 渲染出的内层元素，不是根元素本身，按 scrollWidth 找。
+      // 位移一律经 wheelDeltaOf 取：uni 重建过的事件对象上没有 deltaX/deltaY，
+      // 直接读会得到 NaN，横滚静默失效（dev-board#543）。
       const root = evt?.currentTarget
       if (!root || typeof root.querySelectorAll !== 'function') return
+      const delta = wheelDeltaOf(evt)
+      if (!delta) return
       let scroller = null
       if (root.scrollWidth > root.clientWidth) scroller = root
       if (!scroller) {
@@ -64,7 +123,6 @@ export const tabDragSplitMethods = {
         }
       }
       if (!scroller) return
-      const delta = Math.abs(evt.deltaX) > Math.abs(evt.deltaY) ? evt.deltaX : evt.deltaY
       scroller.scrollLeft += delta
     },
 
@@ -78,7 +136,10 @@ export const tabDragSplitMethods = {
       }
     },
 
-    moveTabTo(fileId, fromPane, toPane, beforeFileId) {
+    // opts.copy=true：跨窗格时「在另一侧再开一份」（左右双开，.tab-dual-open 那套），
+    // 由拖拽时按住 Alt/Option 触发。默认（普通拖拽）是**移动**：从源列表摘掉再插进
+    // 目标列表（dev-board#542）。同窗格换序永远是移动，与 opts 无关。
+    moveTabTo(fileId, fromPane, toPane, beforeFileId, opts = {}) {
       if (!fileId || !fromPane || !toPane) return
       if (!this.splitMode && toPane === 'right') return
 
@@ -89,9 +150,9 @@ export const tabDragSplitMethods = {
       if (fromIdx < 0) return
 
       const source = fromList[fromIdx]
-      // 关键修复：跨窗格拖拽不“移动”，而是“在另一侧打开同一文件”（允许左右双开）
       const isCrossPane = fromPane !== toPane
-      const moved = isCrossPane ? { ...source } : fromList.splice(fromIdx, 1)[0]
+      const copy = isCrossPane && !!opts.copy
+      const moved = copy ? { ...source } : fromList.splice(fromIdx, 1)[0]
 
       // 目标索引：插入到 beforeFileId 前面（如果没有则追加末尾）
       let toIdx = -1
@@ -111,6 +172,19 @@ export const tabDragSplitMethods = {
           toList.push(moved)
         } else {
           toList.splice(toIdx, 0, moved)
+        }
+      }
+
+      // 源侧的激活态：搬走的正好是那一侧的活动标签时，按关闭标签的同一条规则
+      // 让相邻的顶上（都搬空了就置 null，窗格回到既有的空状态）。
+      if (!copy && isCrossPane) {
+        const fromIdProp = fromPane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'
+        if (this[fromIdProp] === fileId) {
+          const next = fromList.length > 0 ? fromList[Math.min(fromIdx, fromList.length - 1)].id : null
+          this[fromIdProp] = next
+          const mode = this.leftPaneKey || 'files'
+          this.lastActiveIdsByMode[fromPane][mode] = next
+          this.saveActiveIdsByMode()
         }
       }
 

--- a/frontend/src/pages/project-overview/tabDragSplit.js
+++ b/frontend/src/pages/project-overview/tabDragSplit.js
@@ -7,7 +7,7 @@
 
 import { activityTracker } from '@/utils/activityTracker.js'
 import { rightPanelMaxWidth, leftPanelMaxWidth } from './panelWidthLimits.js'
-import { wheelDeltaOf } from '@/utils/wheelDelta.js'
+import { bindHorizontalWheelAll } from '@/utils/horizontalWheel.js'
 
 // 取拖拽起手时有没有按住 Alt/Option。同 fileOpenTabs.js 的 mouseButtonOf：uni-h5 把
 // <view> 上的原生事件重建成普通对象，只给 click / mouse 系 / touch / 键盘四类补字段，
@@ -106,24 +106,20 @@ export const tabDragSplitMethods = {
       return true
     },
 
-    onTabsWheel(evt) {
-      // VS Code 式标签栏：纵向滚轮映射为横向滚动（滑轨只有 6px，不该逼着人去拖它）。
-      // scroll-view 真正 overflow 的是 uni-h5 渲染出的内层元素，不是根元素本身，按 scrollWidth 找。
-      // 位移一律经 wheelDeltaOf 取：uni 重建过的事件对象上没有 deltaX/deltaY，
-      // 直接读会得到 NaN，横滚静默失效（dev-board#543）。
-      const root = evt?.currentTarget
-      if (!root || typeof root.querySelectorAll !== 'function') return
-      const delta = wheelDeltaOf(evt)
-      if (!delta) return
-      let scroller = null
-      if (root.scrollWidth > root.clientWidth) scroller = root
-      if (!scroller) {
-        for (const el of root.querySelectorAll('*')) {
-          if (el.scrollWidth > el.clientWidth + 1) { scroller = el; break }
-        }
-      }
-      if (!scroller) return
-      scroller.scrollLeft += delta
+    // VS Code 式标签栏：纵向滚轮映射为横向滚动（滑轨只有 4px，不该逼着人去拖它）。
+    // 必须用原生 addEventListener 挂在 uni 渲染出的真实元素上——模板上的 @wheel
+    // 收到的是 uni 重建过的普通对象，currentTarget 不是 DOM、连 delta 都没有，
+    // 整条横滚是死的（dev-board#543，理由与对照实验写在 utils/horizontalWheel.js）。
+    // 幂等：分屏开关会把右侧那条标签栏整个建/拆，回来后重跑一遍即可。
+    rebindTabsWheel() {
+      if (!this._tabsWheelOffs) this._tabsWheelOffs = new Set()
+      bindHorizontalWheelAll(this.$el, '.tabs-scroll', this._tabsWheelOffs)
+    },
+
+    unbindTabsWheel() {
+      if (!this._tabsWheelOffs) return
+      for (const off of this._tabsWheelOffs) off()
+      this._tabsWheelOffs.clear()
     },
 
     getTabDragPayload(evt) {

--- a/frontend/src/utils/horizontalWheel.js
+++ b/frontend/src/utils/horizontalWheel.js
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 「纵向滚轮 → 横向滚动」的唯一实现（编辑器工具栏主命令区、编辑器标签栏两处在用）。
+//
+// 为什么不写成模板上的 `@wheel`（dev-board#543 复发的那一步）：uni-h5 对内置元素
+// （`<view>` / `<scroll-view>` …）上的原生事件走 `$nne` → `createNativeEvent`，把事件
+// **重建成一个普通对象**——`currentTarget` 被换成 `{ id, dataset, offsetTop, offsetLeft }`，
+// 既不是 DOM 元素（没有 querySelectorAll / scrollWidth），`wheel` 又不在它补字段的四个
+// 分支（click / mouse 系 / touch 系 / 键盘）里，连 deltaX/deltaY 都没有。于是「从
+// currentTarget 找滚动容器」这一步第一道守卫就 return，横滚整条是死的。
+// 真渲染对照实验：同一套算法用原生 addEventListener 挂到真实 DOM 上，同一次滚轮
+// scrollLeft 0 → 600；走模板 @wheel 时 0 → 0。
+//
+// 所以位置固定：组件 mounted（以及会重建 scroller 的状态变化后的 nextTick）里，
+// 拿到 uni 渲染出来的真实元素，用原生 addEventListener 挂，beforeUnmount 摘掉。
+import { wheelDeltaOf } from './wheelDelta.js'
+
+// 同一个元素只挂一次：分屏开关、标签增删都会让调用方重新跑一遍绑定，
+// 重复挂的后果是一次滚轮滚两倍。
+const BOUND = new WeakMap()
+
+/**
+ * 找到真正 overflow 的那个元素。uni `<scroll-view>` 真正滚的是内层
+ * `div.uni-scroll-view`，不是我们挂 class 的根元素本身。
+ * @param {any} root 绑定的根元素
+ * @returns {any} 可横向滚动的元素；没有就 null（此时不该拦截滚轮）
+ */
+export function findHorizontalScroller(root) {
+  if (!root) return null
+  if (root.scrollWidth > root.clientWidth + 1) return root
+  if (typeof root.querySelectorAll !== 'function') return null
+  for (const el of root.querySelectorAll('*')) {
+    if (el.scrollWidth > el.clientWidth + 1) return el
+  }
+  return null
+}
+
+/**
+ * 给一个元素挂上「滚轮转横滚」，返回摘除函数（幂等：重复绑定返回同一个）。
+ * @param {any} root uni 渲染出的真实元素（如 <uni-scroll-view class="tabs-scroll">）
+ * @returns {() => void} unbind
+ */
+export function bindHorizontalWheel(root) {
+  if (!root || typeof root.addEventListener !== 'function') return () => {}
+  const already = BOUND.get(root)
+  if (already) return already.unbind
+
+  const handler = (evt) => {
+    const delta = wheelDeltaOf(evt)
+    if (!delta) return
+    const scroller = findHorizontalScroller(root)
+    // 滚不动就别拦：这一条既让宽窗口下的滚轮照常滚页面，也让 passive:false
+    // 只在真的要横滚时才付出代价。
+    if (!scroller) return
+    if (typeof evt.preventDefault === 'function') evt.preventDefault()
+    scroller.scrollLeft += delta
+  }
+  const unbind = () => {
+    if (BOUND.get(root) !== rec) return
+    BOUND.delete(root)
+    root.removeEventListener('wheel', handler)
+  }
+  const rec = { handler, unbind }
+  BOUND.set(root, rec)
+  // passive:false：不声明的话 Chromium 对 wheel 默认按 passive 处理，
+  // preventDefault 会被忽略，横滚的同时页面还会跟着纵向滚一下。
+  root.addEventListener('wheel', handler, { passive: false })
+  return unbind
+}
+
+/**
+ * 按选择器给 root 下的每个匹配元素挂上（数量随分屏开关变化，所以要能反复跑）。
+ * @param {any} root 组件根元素
+ * @param {string} selector 例 '.tabs-scroll'
+ * @param {Set<Function>} [sink] 收集 unbind 的集合（同一元素返回同一个函数，天然去重）
+ * @returns {Set<Function>} sink
+ */
+export function bindHorizontalWheelAll(root, selector, sink = new Set()) {
+  if (!root || typeof root.querySelectorAll !== 'function') return sink
+  for (const el of root.querySelectorAll(selector)) sink.add(bindHorizontalWheel(el))
+  return sink
+}

--- a/frontend/src/utils/wheelDelta.js
+++ b/frontend/src/utils/wheelDelta.js
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 滚轮位移的取值口径：uni-app H5 会把 <view>/<scroll-view> 上的原生事件交给
+// createNativeEvent 重建成一个普通对象，只有 { type, timeStamp, target,
+// currentTarget, detail } 加两个转发方法；随后按类型补字段，而补的分支只有
+// click / mouse 系 / touch 系 / 键盘四类，补的也只是坐标。`wheel` 不在这四类里，
+// 于是回调拿到的事件**没有 deltaX/deltaY**，`scrollLeft += evt.deltaY` 得到 NaN，
+// 整条横滚静默失效（dev-board#543，回归自 PR#759）。
+// 同 fileOpenTabs.js 的 mouseButtonOf：键位/位移一律从**当前正在派发的原生事件**
+// （window.event）上取，回调自带时优先用回调的（事件没被包装的平台走那条）。
+
+/**
+ * 取一次滚轮的横向位移量（纵向滚轮映射为横向滚动）。
+ * @param {any} evt uni 回调里的事件对象（可能已被重建、丢掉 delta 字段）
+ * @returns {number} 位移像素；取不到任何 delta 时返回 0（调用方据此不动）
+ */
+export function wheelDeltaOf(evt) {
+  const src = hasDelta(evt) ? evt : nativeWheelEvent()
+  if (!hasDelta(src)) return 0
+  const dx = numberOr0(src.deltaX)
+  const dy = numberOr0(src.deltaY)
+  return Math.abs(dx) > Math.abs(dy) ? dx : dy
+}
+
+function hasDelta(e) {
+  return !!e && (typeof e.deltaY === 'number' || typeof e.deltaX === 'number')
+}
+
+function nativeWheelEvent() {
+  return typeof window !== 'undefined' ? window.event : null
+}
+
+function numberOr0(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+}

--- a/frontend/tests/project-home/editor-toolbar-layout.test.mjs
+++ b/frontend/tests/project-home/editor-toolbar-layout.test.mjs
@@ -12,9 +12,11 @@
 // 撑到 41px，align-items:center 于是把左半边顶得比右侧常驻区高半格。
 // #543 是它的续集：当时的修法是把滚动条整条藏掉（show-scrollbar=false + 一串
 // display:none），于是「这里还能往右滚」在界面上没有任何痕迹，而唯一的替代
-// ——滚轮横滚——又因为 uni 重建事件丢 delta 而是死的（见 wheel-delta.test.mjs），
-// 主命令区右半截彻底够不着。现在守的是「6px 悬浮细滑轨（.awd-hairline-scroll）」
-// +「横滚经 wheelDeltaOf 仍然可用」+「那一行还是 38px、两侧仍然对齐」。
+// ——滚轮横滚——写成了模板上的 @wheel，收到的是 uni 重建过的普通对象（currentTarget
+// 不是 DOM、连 delta 都没有），同样是死的（见 wheel-delta.test.mjs / horizontal-wheel
+// .test.mjs），主命令区右半截彻底够不着。现在守的是「4px 悬浮细滑轨
+// （.awd-hairline-scroll）」+「横滚原生挂在真实元素上」+「那一行还是 38px、两侧
+// 仍然对齐（含 .etb-field 的 border-box：不写它整行会变 28px，把按钮顶低 1px）」。
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
@@ -75,7 +77,7 @@ test('查找/替换的功能没被这次布局改动动过', () => {
 
 // ---------- dev-board#502：滚动条藏掉，横滚改走滚轮 ----------
 
-test('主命令区用 6px 悬浮细滑轨，不再整条藏掉滚动条', () => {
+test('主命令区用 4px 悬浮细滑轨，不再整条藏掉滚动条', () => {
   const tag = /<scroll-view[^>]*class="[^"]*etb-scroll[^"]*"[^>]*>/.exec(TEMPLATE)
   assert.ok(tag, '找不到 .etb-scroll 那个 scroll-view')
   assert.match(tag[0], /class="[^"]*\bawd-hairline-scroll\b/,
@@ -86,34 +88,50 @@ test('主命令区用 6px 悬浮细滑轨，不再整条藏掉滚动条', () => 
     '组件里还留着把滚动条 display:none 的兜底规则，细滑轨看不见（dev-board#543）')
 })
 
-test('细滑轨占的 6px 不许把 38px 那一行的两侧顶歪', () => {
-  // 滑轨是从内容盒里扣的：不定高的话，有滑轨时主命令区长到 26+6=32px、
-  // 被 align-items:center 一居中就比右侧常驻区高 3px；命令放得下、没有滑轨时
-  // 又反向偏 3px。定高 32 + 负外边距 6，让外边距盒恒为 26px，两种情况都对齐。
-  assert.ok(declares('etb-scroll', 'height', 'calc\\(100% - 6px\\)'),
-    '.etb-scroll 要定高 calc(100% - 6px)，才能不管有没有滑轨都跟右侧常驻区对齐')
-  assert.ok(declares('etb-scroll', 'margin-bottom', '-6px'),
-    '.etb-scroll 少了 margin-bottom:-6px，滑轨那 6px 会把左半边按钮顶高（同 dev-board#502 的错位）')
+test('细滑轨占的 4px 不许把 38px 那一行的两侧顶歪', () => {
+  // 滑轨是从内容盒里扣的：不定高的话，有滑轨时主命令区长到 26+4=30px、
+  // 被 align-items:center 一居中就比右侧常驻区高 2px；命令放得下、没有滑轨时
+  // 又反向偏。边框盒 26+4=30（= calc(100% - 8px)）+ 负外边距 4，让外边距盒恒为
+  // 26px，两种情况都对齐。
+  assert.ok(declares('etb-scroll', 'height', 'calc\\(100% - 8px\\)'),
+    '.etb-scroll 要定高 calc(100% - 8px)（= 26 + 4px 滑轨），才能不管有没有滑轨都跟右侧常驻区对齐')
+  assert.ok(declares('etb-scroll', 'margin-bottom', '-4px'),
+    '.etb-scroll 少了 margin-bottom:-4px，滑轨那 4px 会把左半边按钮顶高（同 dev-board#502 的错位）')
   assert.ok(!rulesFor('etb-scroll').some((b) => /z-index\s*:/.test(b)),
     '.etb-scroll 不要设 z-index：会造出层叠上下文，框住工具栏下拉用的 fixed 弹层')
 })
 
-test('横滚仍然能用（滚轮映射成横向，且位移经 wheelDeltaOf 取）', () => {
+test('行里带边框的定高控件都要 border-box：否则整行变 28px，26px 的按钮跟着低 1px', () => {
+  // 走查实测：左侧命令按钮顶边比右侧常驻区低 1px（leftTop 93 / rightTop 92）。
+  // 根因是 .etb-field 与 .etb-stepper 都写了 height:26px + 1px 边框而没有
+  // border-box（本仓没有全局 * { box-sizing }），边框盒 28px 成了 .etb-row 里最高
+  // 的一件，26px 的按钮在里面一居中就整体下移 1px。往行里加带边框的定高控件
+  // 都要走这一条。
+  for (const cls of ['etb-field', 'etb-stepper']) {
+    assert.ok(declares(cls, 'box-sizing', 'border-box'),
+      '.' + cls + ' 少了 box-sizing:border-box（dev-board#543 的 1px 错位）')
+    assert.ok(declares(cls, 'height', '26px'), '.' + cls + ' 的定高不再是 26px，两侧对齐要重算')
+  }
+})
+
+test('横滚仍然能用（滚轮映射成横向），且是原生挂在真实元素上', () => {
   const tag = /<scroll-view[^>]*class="[^"]*etb-scroll[^"]*"[^>]*>/.exec(TEMPLATE)
-  assert.match(tag[0], /@wheel\.prevent="onToolbarWheel"/,
-    '滑轨只有 6px，不接滚轮等于逼着人去拖那条线')
-  assert.match(SRC, /onToolbarWheel\s*\(evt\)\s*\{/, '缺少 onToolbarWheel 实现')
-  assert.match(SRC, /wheelDeltaOf\(evt\)/,
-    '位移要经 wheelDeltaOf 取：uni 重建过的事件上没有 deltaX/deltaY，直接读恒 NaN（dev-board#543）')
-  assert.match(SRC, /scroller\.scrollLeft\s*\+=\s*delta/, 'onToolbarWheel 没有真的横向滚动')
+  assert.ok(!/@wheel/.test(tag[0]),
+    '模板上的 @wheel 是死的：uni 把 currentTarget 换成了普通对象，第一道守卫就 return')
+  assert.match(SRC, /bindToolbarWheel\s*\(\)\s*\{/, '缺少 bindToolbarWheel 实现')
+  assert.match(SRC, /querySelector\('\.etb-scroll'\)/,
+    'bindToolbarWheel 要在本组件的 DOM 子树里找 .etb-scroll，不是 document 全局找')
+  assert.match(SRC, /bindHorizontalWheel\(el\)/, '没有真的挂上原生 wheel 监听')
+  assert.match(SRC, /mounted\(\)[\s\S]{0,400}?bindToolbarWheel\(\)/, 'mounted 里没有挂')
+  assert.match(SRC, /beforeUnmount\(\)[\s\S]{0,300}?_toolbarWheelOff\(\)/, 'beforeUnmount 里没有摘')
 })
 
 test('主命令区与右侧常驻区在同一行里居中对齐', () => {
   assert.ok(declares('etb', 'align-items', 'center'), '.etb 丢了 align-items:center')
   assert.ok(declares('etb', 'height', '38px'), '.etb 的行高被改了；两侧对齐是按这一行的高度算的')
-  // .etb-scroll 的定高只许是「行高减去滑轨」——写死像素或写满 100%，
-  // 都会在有/没有滑轨的两种情况里各偏 3px（见上一条）。
+  // .etb-scroll 的定高只许跟着 .etb 那一行走——写死像素或写满 100%，
+  // 都会在有/没有滑轨的两种情况里各偏（见上面那条）。
   const h = rulesFor('etb-scroll').map((b) => /(?:^|;)\s*height\s*:\s*([^;]+)/.exec(b)).find(Boolean)
-  assert.ok(h && /calc\(100% - 6px\)/.test(h[1]),
-    '.etb-scroll 的高度要跟着 .etb 那一行走（calc(100% - 6px)），实际 ' + (h && h[1]))
+  assert.ok(h && /calc\(100% - 8px\)/.test(h[1]),
+    '.etb-scroll 的高度要跟着 .etb 那一行走（calc(100% - 8px)），实际 ' + (h && h[1]))
 })

--- a/frontend/tests/project-home/editor-toolbar-layout.test.mjs
+++ b/frontend/tests/project-home/editor-toolbar-layout.test.mjs
@@ -9,8 +9,12 @@
 // 布局高度的浮层之后，同样 10 次开关 0 帧）。所以这里守的是「查找栏不进文档流」。
 //
 // #502（滚动条过粗、与右侧控件不齐）：38px 的一行里，原生横向滚动条会把主命令区
-// 撑到 41px，align-items:center 于是把左半边顶得比右侧常驻区高半格。守「滚动条被
-// 藏掉」+「横滚仍然可用」。
+// 撑到 41px，align-items:center 于是把左半边顶得比右侧常驻区高半格。
+// #543 是它的续集：当时的修法是把滚动条整条藏掉（show-scrollbar=false + 一串
+// display:none），于是「这里还能往右滚」在界面上没有任何痕迹，而唯一的替代
+// ——滚轮横滚——又因为 uni 重建事件丢 delta 而是死的（见 wheel-delta.test.mjs），
+// 主命令区右半截彻底够不着。现在守的是「6px 悬浮细滑轨（.awd-hairline-scroll）」
+// +「横滚经 wheelDeltaOf 仍然可用」+「那一行还是 38px、两侧仍然对齐」。
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
@@ -71,30 +75,45 @@ test('查找/替换的功能没被这次布局改动动过', () => {
 
 // ---------- dev-board#502：滚动条藏掉，横滚改走滚轮 ----------
 
-test('主命令区关掉原生滚动条', () => {
-  const tag = /<scroll-view[^>]*class="etb-scroll"[^>]*>/.exec(TEMPLATE)
+test('主命令区用 6px 悬浮细滑轨，不再整条藏掉滚动条', () => {
+  const tag = /<scroll-view[^>]*class="[^"]*etb-scroll[^"]*"[^>]*>/.exec(TEMPLATE)
   assert.ok(tag, '找不到 .etb-scroll 那个 scroll-view')
-  assert.match(tag[0], /:show-scrollbar="false"/,
-    'show-scrollbar=false 才会让 uni-h5 给真正 overflow 的内层元素挂上隐藏滚动条的类')
-  // scoped 属性只落在 <uni-scroll-view> 根元素上，内层那个 div 不带 scope id，
-  // 兜底规则必须走 :deep 才够得着。
-  assert.match(STYLE, /\.etb-scroll\s*:deep\(\*::-webkit-scrollbar\)\s*\{[^}]*display:\s*none/,
-    '缺少 :deep 兜底：只写 .etb-scroll::-webkit-scrollbar 打不到真正滚动的那个元素')
+  assert.match(tag[0], /class="[^"]*\bawd-hairline-scroll\b/,
+    '主命令区要挂 .awd-hairline-scroll（全局细滑轨，样式在 App.vue）')
+  assert.ok(!/:show-scrollbar="false"/.test(tag[0]),
+    'show-scrollbar=false 会让 uni-h5 给真正滚动的内层元素挂上隐藏类，把细滑轨也一起灭掉')
+  assert.ok(!/\.etb-scroll[^{]*::-webkit-scrollbar[^{]*\{[^}]*display:\s*none/.test(STYLE),
+    '组件里还留着把滚动条 display:none 的兜底规则，细滑轨看不见（dev-board#543）')
 })
 
-test('滚动条藏了之后横滚仍然能用（滚轮映射成横向）', () => {
-  const tag = /<scroll-view[^>]*class="etb-scroll"[^>]*>/.exec(TEMPLATE)
+test('细滑轨占的 6px 不许把 38px 那一行的两侧顶歪', () => {
+  // 滑轨是从内容盒里扣的：不定高的话，有滑轨时主命令区长到 26+6=32px、
+  // 被 align-items:center 一居中就比右侧常驻区高 3px；命令放得下、没有滑轨时
+  // 又反向偏 3px。定高 32 + 负外边距 6，让外边距盒恒为 26px，两种情况都对齐。
+  assert.ok(declares('etb-scroll', 'height', 'calc\\(100% - 6px\\)'),
+    '.etb-scroll 要定高 calc(100% - 6px)，才能不管有没有滑轨都跟右侧常驻区对齐')
+  assert.ok(declares('etb-scroll', 'margin-bottom', '-6px'),
+    '.etb-scroll 少了 margin-bottom:-6px，滑轨那 6px 会把左半边按钮顶高（同 dev-board#502 的错位）')
+  assert.ok(!rulesFor('etb-scroll').some((b) => /z-index\s*:/.test(b)),
+    '.etb-scroll 不要设 z-index：会造出层叠上下文，框住工具栏下拉用的 fixed 弹层')
+})
+
+test('横滚仍然能用（滚轮映射成横向，且位移经 wheelDeltaOf 取）', () => {
+  const tag = /<scroll-view[^>]*class="[^"]*etb-scroll[^"]*"[^>]*>/.exec(TEMPLATE)
   assert.match(tag[0], /@wheel\.prevent="onToolbarWheel"/,
-    '藏了滚动条又不接滚轮，窄窗口下右半截命令就够不着了')
+    '滑轨只有 6px，不接滚轮等于逼着人去拖那条线')
   assert.match(SRC, /onToolbarWheel\s*\(evt\)\s*\{/, '缺少 onToolbarWheel 实现')
+  assert.match(SRC, /wheelDeltaOf\(evt\)/,
+    '位移要经 wheelDeltaOf 取：uni 重建过的事件上没有 deltaX/deltaY，直接读恒 NaN（dev-board#543）')
   assert.match(SRC, /scroller\.scrollLeft\s*\+=\s*delta/, 'onToolbarWheel 没有真的横向滚动')
 })
 
 test('主命令区与右侧常驻区在同一行里居中对齐', () => {
   assert.ok(declares('etb', 'align-items', 'center'), '.etb 丢了 align-items:center')
   assert.ok(declares('etb', 'height', '38px'), '.etb 的行高被改了；两侧对齐是按这一行的高度算的')
-  // 不给 .etb-scroll 定高：内容多高它就多高，交给 align-items:center 居中。
-  // 一旦原生滚动条回来，这个高度会变成 26+15px，左半边就被顶高半格。
-  assert.ok(!rulesFor('etb-scroll').some((b) => /(^|;)\s*height\s*:/.test(b)),
-    '.etb-scroll 不要定高，让它跟着内容走')
+  // .etb-scroll 的定高只许是「行高减去滑轨」——写死像素或写满 100%，
+  // 都会在有/没有滑轨的两种情况里各偏 3px（见上一条）。
+  const h = rulesFor('etb-scroll').map((b) => /(?:^|;)\s*height\s*:\s*([^;]+)/.exec(b)).find(Boolean)
+  assert.ok(h && /calc\(100% - 6px\)/.test(h[1]),
+    '.etb-scroll 的高度要跟着 .etb 那一行走（calc(100% - 6px)），实际 ' + (h && h[1]))
 })

--- a/frontend/tests/project-home/horizontal-wheel.test.mjs
+++ b/frontend/tests/project-home/horizontal-wheel.test.mjs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// bindHorizontalWheel 的挂载契约（dev-board#543 回修）。
+//
+// 病灶：上一轮把「滚轮转横滚」写成模板上的 @wheel。uni-h5 对内置元素（<scroll-view>）
+// 走 $nne → createNativeEvent，把 currentTarget 换成 { id, dataset, offsetTop,
+// offsetLeft } 这样一个普通对象，于是「从 currentTarget 找滚动容器」第一道守卫
+// （typeof root.querySelectorAll !== 'function'）就 return —— 真渲染走查实测
+// scrollLeft 0 → 0，而同一套算法用原生 addEventListener 挂到真实 DOM 上是 0 → 600。
+// 所以这里守的是「挂在真实元素上、passive:false、幂等、能摘干净」。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { bindHorizontalWheel, findHorizontalScroller } from '../../src/utils/horizontalWheel.js'
+
+/** 够用的假元素：只实现被测代码真正会碰的那几样。 */
+function fakeEl({ scrollWidth = 100, clientWidth = 100, children = [] } = {}) {
+  const el = {
+    scrollWidth, clientWidth, scrollLeft: 0,
+    listeners: [], removed: [],
+    querySelectorAll: () => children,
+    addEventListener(type, fn, opts) { el.listeners.push({ type, fn, opts }) },
+    removeEventListener(type, fn) { el.removed.push({ type, fn }) },
+  }
+  return el
+}
+const wheel = (deltaY) => {
+  const e = { type: 'wheel', deltaX: 0, deltaY, prevented: 0 }
+  e.preventDefault = () => { e.prevented++ }
+  return e
+}
+const fire = (el, evt) => { for (const l of el.listeners) if (l.type === 'wheel') l.fn(evt) }
+
+test('挂的是原生 wheel 监听，且 passive:false（否则 preventDefault 被忽略，横滚时页面还会纵向滚一下）', () => {
+  const el = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  bindHorizontalWheel(el)
+  assert.equal(el.listeners.length, 1)
+  assert.equal(el.listeners[0].type, 'wheel')
+  assert.equal(el.listeners[0].opts && el.listeners[0].opts.passive, false)
+})
+
+test('纵向滚轮转成横向滚动', () => {
+  const el = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  bindHorizontalWheel(el)
+  fire(el, wheel(300))
+  assert.equal(el.scrollLeft, 300)
+  fire(el, wheel(-120))
+  assert.equal(el.scrollLeft, 180)
+})
+
+test('真正 overflow 的是内层元素时，滚的是内层（uni scroll-view 的形状）', () => {
+  const inner = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  const root = fakeEl({ scrollWidth: 300, clientWidth: 300, children: [inner] })
+  bindHorizontalWheel(root)
+  fire(root, wheel(120))
+  assert.equal(inner.scrollLeft, 120)
+  assert.equal(root.scrollLeft, 0)
+  assert.equal(findHorizontalScroller(root), inner)
+})
+
+test('滚不动就不拦截：宽窗口下滚轮照常滚页面', () => {
+  const el = fakeEl({ scrollWidth: 300, clientWidth: 300 })
+  bindHorizontalWheel(el)
+  const e = wheel(300)
+  fire(el, e)
+  assert.equal(e.prevented, 0, '没有可横滚的容器却调了 preventDefault')
+  assert.equal(el.scrollLeft, 0)
+})
+
+test('真横滚时要 preventDefault（不然页面跟着纵向滚一下）', () => {
+  const el = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  bindHorizontalWheel(el)
+  const e = wheel(120)
+  fire(el, e)
+  assert.equal(e.prevented, 1)
+})
+
+test('取不到 delta 就什么都不做（不是把 NaN 加进 scrollLeft）', () => {
+  const el = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  bindHorizontalWheel(el)
+  fire(el, { type: 'wheel' })
+  assert.equal(el.scrollLeft, 0)
+})
+
+test('幂等：同一个元素重复绑定只挂一次（分屏开关会让调用方反复重挂，挂两次就滚两倍）', () => {
+  const el = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  const off1 = bindHorizontalWheel(el)
+  const off2 = bindHorizontalWheel(el)
+  assert.equal(el.listeners.length, 1)
+  assert.equal(off1, off2, '重复绑定要返回同一个摘除函数，否则 Set 去重不掉')
+  fire(el, wheel(100))
+  assert.equal(el.scrollLeft, 100, '挂了两次的话这里会是 200')
+  off1()
+})
+
+test('摘除：removeEventListener 用的是同一个 handler，摘完能重新挂', () => {
+  const el = fakeEl({ scrollWidth: 900, clientWidth: 300 })
+  const off = bindHorizontalWheel(el)
+  const handler = el.listeners[0].fn
+  off()
+  assert.equal(el.removed.length, 1)
+  assert.equal(el.removed[0].fn, handler, '摘的必须是挂上去的那个函数引用')
+  off() // 重复摘不许再摘一次别人的
+  assert.equal(el.removed.length, 1)
+  bindHorizontalWheel(el)
+  assert.equal(el.listeners.length, 2, '摘干净之后应该能重新挂上')
+})
+
+test('传进来的不是元素（uni 重建过的那个普通对象）就安全退出', () => {
+  const rebuilt = { id: '', dataset: {}, offsetTop: 0, offsetLeft: 0 }
+  assert.doesNotThrow(() => bindHorizontalWheel(rebuilt)())
+  assert.doesNotThrow(() => bindHorizontalWheel(null)())
+  assert.equal(findHorizontalScroller(rebuilt), null)
+})

--- a/frontend/tests/project-home/tab-drag-move.test.mjs
+++ b/frontend/tests/project-home/tab-drag-move.test.mjs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 标签跨窗格拖拽的语义（dev-board#542）。
+//
+// 原来 moveTabTo 里写死 `isCrossPane ? { ...source } : splice`：把标签拖到另一侧，
+// 源侧那一份还留着，等于「复制」。产品决策改成——普通拖拽是**移动**（源列表摘掉），
+// 按住 Alt/Option 才是「在另一侧再开一份」（保留双开与 .tab-dual-open 那套样式）。
+//
+// 修饰键必须在 dragstart 那一下记：uni-h5 把 <view> 上的事件重建成普通对象，
+// altKey 一类一概不补（同 fileOpenTabs.js 的 mouseButtonOf），dragover/drop 阶段
+// 更没有原生事件可读。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../../src/pages/project-overview/tabDragSplit.js', import.meta.url), 'utf8')
+
+function loadMethods(win) {
+  const body = SRC
+    .replace(/^\s*import[\s\S]*?from\s*'[^']*'\s*$/gm, '')
+    .replace(/export const tabDragSplitMethods = \{/, 'return {')
+  const factory = new Function(
+    'activityTracker', 'rightPanelMaxWidth', 'leftPanelMaxWidth', 'wheelDeltaOf', 'uni', 'window', body)
+  return factory({ track: () => {} }, () => 0, () => 0, () => 0, { showToast: () => {} }, win)
+}
+const methods = loadMethods({ event: null })
+
+function makeVm(left, right, opts = {}) {
+  const vm = {
+    splitMode: true,
+    focusedPane: 'left',
+    leftPaneKey: 'files',
+    leftFiles: left,
+    rightFiles: right,
+    activeFileIdLeft: opts.activeLeft ?? (left[0] && left[0].id) ?? null,
+    activeFileIdRight: opts.activeRight ?? (right[0] && right[0].id) ?? null,
+    lastActiveIdsByMode: { left: {}, right: {} },
+    saveActiveIdsByMode() {},
+    triggerWorkbenchResize() {},
+    $nextTick(fn) { fn && fn() },
+  }
+  vm.moveTabTo = methods.moveTabTo.bind(vm)
+  vm.onTabDragStart = methods.onTabDragStart.bind(vm)
+  return vm
+}
+const ids = (list) => list.map(f => f.id)
+
+test('跨窗格默认是移动：源列表少一项、目标多一项，且是同一个对象', () => {
+  const a = { id: 'a', name: 'a.docx' }
+  const vm = makeVm([a, { id: 'b' }], [])
+  vm.moveTabTo('a', 'left', 'right', null)
+  assert.deepEqual(ids(vm.leftFiles), ['b'], '源侧没把标签摘掉，还是老的「复制」语义')
+  assert.deepEqual(ids(vm.rightFiles), ['a'])
+  assert.equal(vm.rightFiles[0], a, '移动应当搬同一个对象过去，不是拷一份')
+  assert.equal(vm.activeFileIdRight, 'a')
+  assert.equal(vm.focusedPane, 'right')
+})
+
+test('copy:true 时源侧保留一份（Alt/Option 拖拽 = 左右双开）', () => {
+  const a = { id: 'a', name: 'a.docx' }
+  const vm = makeVm([a, { id: 'b' }], [])
+  vm.moveTabTo('a', 'left', 'right', null, { copy: true })
+  assert.deepEqual(ids(vm.leftFiles), ['a', 'b'], 'Alt 拖拽必须保留源侧那一份')
+  assert.deepEqual(ids(vm.rightFiles), ['a'])
+  assert.notEqual(vm.rightFiles[0], a, '双开的两份是各自的对象（各自维护 pendingLocator 等）')
+})
+
+test('目标窗格已经开着同一个 id：只激活，不重复插入', () => {
+  const vm = makeVm([{ id: 'a' }, { id: 'b' }], [{ id: 'a' }, { id: 'c' }], { activeRight: 'c' })
+  vm.moveTabTo('a', 'left', 'right', null)
+  assert.deepEqual(ids(vm.rightFiles), ['a', 'c'], '目标侧不许出现两个同 id 标签')
+  assert.deepEqual(ids(vm.leftFiles), ['b'], '移动语义下源侧仍要摘掉')
+  assert.equal(vm.activeFileIdRight, 'a')
+})
+
+test('搬走的是源侧活动标签：按关闭标签的同一条规则让相邻的顶上', () => {
+  const vm = makeVm([{ id: 'a' }, { id: 'b' }, { id: 'c' }], [], { activeLeft: 'b' })
+  vm.moveTabTo('b', 'left', 'right', null)
+  assert.deepEqual(ids(vm.leftFiles), ['a', 'c'])
+  assert.equal(vm.activeFileIdLeft, 'c', '取被搬走那一格的后继（同 closeFile 的 min(idx, len-1)）')
+  assert.equal(vm.lastActiveIdsByMode.left.files, 'c', '按模式记忆的活动标签也要跟着改')
+})
+
+test('把源侧最后一个标签搬走：源侧活动标签置 null，回到既有的空窗格状态', () => {
+  const vm = makeVm([{ id: 'a' }], [{ id: 'z' }], { activeLeft: 'a' })
+  vm.moveTabTo('a', 'left', 'right', null)
+  assert.deepEqual(ids(vm.leftFiles), [])
+  assert.equal(vm.activeFileIdLeft, null)
+})
+
+test('搬走的不是源侧活动标签：源侧激活态不动', () => {
+  const vm = makeVm([{ id: 'a' }, { id: 'b' }], [], { activeLeft: 'a' })
+  vm.moveTabTo('b', 'left', 'right', null)
+  assert.equal(vm.activeFileIdLeft, 'a')
+})
+
+test('同窗格换序不受 copy 影响，永远是移动', () => {
+  const vm = makeVm([{ id: 'a' }, { id: 'b' }, { id: 'c' }], [])
+  vm.moveTabTo('c', 'left', 'left', 'a', { copy: true })
+  assert.deepEqual(ids(vm.leftFiles), ['c', 'a', 'b'])
+})
+
+test('未分屏时不许往右窗格搬（既有护栏没被 opts 破坏）', () => {
+  const vm = makeVm([{ id: 'a' }], [])
+  vm.splitMode = false
+  vm.moveTabTo('a', 'left', 'right', null)
+  assert.deepEqual(ids(vm.leftFiles), ['a'])
+  assert.deepEqual(ids(vm.rightFiles), [])
+})
+
+// ---------- 修饰键的采集口径 ----------
+
+test('dragstart：uni 重建的事件没有 altKey，从 window.event 上取', () => {
+  const m = loadMethods({ event: { altKey: true } })
+  const vm = { draggingTab: null, tabDragOver: null }
+  m.onTabDragStart.call(vm, { type: 'dragstart', target: {} }, { id: 'a' }, 'left')
+  assert.equal(vm.draggingTab.copy, true, 'Alt 按着起手，却没记成 copy')
+})
+
+test('dragstart：没按 Alt 就是移动', () => {
+  const m = loadMethods({ event: { altKey: false } })
+  const vm = { draggingTab: null, tabDragOver: null }
+  m.onTabDragStart.call(vm, { type: 'dragstart', target: {} }, { id: 'a' }, 'left')
+  assert.equal(vm.draggingTab.copy, false)
+})
+
+test('dragstart：回调自带 altKey 时优先用回调的', () => {
+  const m = loadMethods({ event: { altKey: false } })
+  const vm = { draggingTab: null, tabDragOver: null }
+  m.onTabDragStart.call(vm, { altKey: true, target: {} }, { id: 'a' }, 'left')
+  assert.equal(vm.draggingTab.copy, true)
+})
+
+test('drop 两个落点都经 commitTabDrop 把 copy 传给 moveTabTo', () => {
+  assert.match(SRC, /moveTabTo\(payload\.fileId, payload\.fromPane, targetPane, beforeFileId, \{ copy \}\)/,
+    'commitTabDrop 没把 copy 传下去，Alt 复制就退化成移动了')
+  for (const h of ['onTabDropOnZone', 'onTabDropOnItem']) {
+    assert.match(SRC, new RegExp(h + '[\\s\\S]{0,400}?commitTabDrop\\('), h + ' 没走 commitTabDrop')
+  }
+})
+
+test('跨窗格移动前先落盘：源侧编辑器实例会被卸掉，从 beforeUnmount 保存已经太晚', () => {
+  assert.match(SRC, /flushTabBeforePaneMove/, '缺少移动前的落盘闸')
+  assert.match(SRC, /await this\.flushTabBeforePaneMove\(payload\.fileId, payload\.fromPane\)/)
+  assert.match(SRC, /inst\.flushSave\(\{ timeoutMs: 10000 \}\)/, 'Libre 实例要按 closeFile 同一口径 flush')
+})

--- a/frontend/tests/project-home/tab-strip-overflow.test.mjs
+++ b/frontend/tests/project-home/tab-strip-overflow.test.mjs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 标签栏「开多了就滚不动、也看不出还有更多」（dev-board#543）的三条结构契约。
+// 病灶三件套：① .tab-item 没有 flex-shrink:0，标签一多是整批被压扁而不是溢出，
+// 滚动条压根不会出现；② 滚动条被 show-scrollbar=false + display:none 整条藏掉，
+// 溢出了也没有任何痕迹；③ 唯一的替代（滚轮横滚）因为 uni 重建事件丢 delta 而是死的
+// （那半边守在 wheel-delta.test.mjs）。外加「活动标签要能自己滚进视野」。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const VUE = readFileSync(
+  new URL('../../src/pages/project-overview/project-overview.vue', import.meta.url), 'utf8')
+const SCSS = readFileSync(
+  new URL('../../src/pages/project-overview/project-overview.scss', import.meta.url), 'utf8')
+const TABS = readFileSync(
+  new URL('../../src/pages/project-overview/fileOpenTabs.js', import.meta.url), 'utf8')
+const APP = readFileSync(new URL('../../src/App.vue', import.meta.url), 'utf8')
+
+/** 取某个 class 选择器名下的规则体（scss 嵌套：只取到第一层闭合前的声明） */
+function bodyOf(src, cls) {
+  const i = src.indexOf('.' + cls + ' {')
+  assert.ok(i >= 0, '找不到 .' + cls + ' 的规则')
+  return src.slice(i, src.indexOf('\n}', i))
+}
+
+test('.tab-item 不许被压扁：标签多了要溢出成横滚', () => {
+  const body = bodyOf(SCSS, 'tab-item')
+  assert.match(body, /flex-shrink:\s*0/,
+    '没有 flex-shrink:0，.tabs-list 这一行会把每个标签越挤越窄，滚动条永远不出现')
+  const max = /max-width:\s*(\d+)px/.exec(body)
+  assert.ok(max && Number(max[1]) <= 160, '.tab-item 的 max-width 要收到 160px 以内，实际 ' + (max && max[1]))
+  assert.match(body, /text-overflow:\s*ellipsis/, '.tab-name 仍要省略号收尾')
+})
+
+test('两个窗格的标签栏都换成 6px 悬浮细滑轨，不再整条藏掉', () => {
+  const tags = [...VUE.matchAll(/<scroll-view[^>]*class="[^"]*tabs-scroll[^"]*"[\s\S]{0,200}?>/g)].map(m => m[0])
+  assert.equal(tags.length, 2, '左右窗格各一条标签栏，实际找到 ' + tags.length)
+  for (const t of tags) {
+    assert.match(t, /class="[^"]*\bawd-hairline-scroll\b/, '标签栏要挂 .awd-hairline-scroll')
+    assert.ok(!/:show-scrollbar="false"/.test(t),
+      'show-scrollbar=false 会让 uni-h5 给真正滚动的内层元素挂上隐藏类，细滑轨一起没了')
+    assert.match(t, /@wheel\.prevent="onTabsWheel"/, '标签栏要接滚轮横滚')
+  }
+  assert.ok(!/display:\s*none/.test(bodyOf(SCSS, 'tabs-scroll')),
+    '.tabs-scroll 里还留着藏滚动条的 display:none')
+  // 滑轨占的 6px 是从内容盒里扣的，height:100% 会让 36px 的 .tab-item 被
+  // uni 给内层元素挂的 overflow-y:hidden 裁掉底下 6px。
+  const scroll = bodyOf(SCSS, 'tabs-scroll')
+  assert.match(scroll, /height:\s*calc\(100% \+ 6px\)/,
+    '.tabs-scroll 要多留 6px 给滑轨，否则标签底部会被裁掉')
+  // 那 6px 溢出到 .editors-container 头上，而它是 position:relative + 有背景，
+  // 按绘制顺序会把滑轨整条盖掉。
+  assert.match(scroll, /position:\s*relative/)
+  assert.match(scroll, /z-index:\s*1/,
+    '.tabs-scroll 不抬一层的话，溢出的 6px 滑轨会被 .editors-container 的背景盖掉')
+})
+
+test('.awd-hairline-scroll 定义在全局样式里，静止透明、悬停才显形', () => {
+  assert.match(APP, /\.awd-hairline-scroll[^{]*::-webkit-scrollbar[^{]*\{[^}]*height:\s*6px/,
+    'App.vue 里没有 .awd-hairline-scroll 的 6px 滑轨定义')
+  assert.match(APP, /\.awd-hairline-scroll[^{]*::-webkit-scrollbar-thumb[^{]*\{[^}]*background:\s*transparent/,
+    '静止时 thumb 要是透明的')
+  assert.match(APP, /\.awd-hairline-scroll:hover[^{]*::-webkit-scrollbar-thumb[^{]*\{[^}]*var\(--awd-border-strong\)/,
+    '悬停时 thumb 要用 --awd-border-strong 显形（跟随主题，不写死颜色）')
+})
+
+test('活动标签自动滚入视野：每个标签有 id，两个窗格各一个 scroll-into-view', () => {
+  for (const pane of ['left', 'right']) {
+    assert.ok(VUE.includes(`:id="tabDomId('${pane}', file.id)"`), pane + ' 窗格的标签没有 scroll-into-view 用的 id')
+  }
+  assert.match(VUE, /:scroll-into-view="tabsScrollIntoViewLeft"/)
+  assert.match(VUE, /:scroll-into-view="tabsScrollIntoViewRight"/)
+  assert.match(VUE, /<scroll-view[^>]*class="[^"]*tabs-scroll[\s\S]{0,200}?scroll-with-animation/)
+  // 挂在 watcher 上而不是 activateTab 里：openFile / moveTabTo / closeFile 的相邻
+  // 接管都是直接写 activeFileId*，不走 activateTab。
+  assert.match(VUE, /activeFileIdLeft\(\)[^\n]*ensureActiveTabVisible\('left'\)/)
+  assert.match(VUE, /activeFileIdRight\(\)[^\n]*ensureActiveTabVisible\('right'\)/)
+})
+
+test('tabDomId 产出的 id 过得了 uni 那道正则（不合就只 console.error，什么都不滚）', () => {
+  // fileOpenTabs.js 带 @/ 别名 import，node 直接 import 不动；tabDomId 又刻意不导出
+  // （模块级 export 会让别的测试那套 new Function 工厂语法出错），所以源码级取函数体。
+  const fn = new Function(/function tabDomId[\s\S]*?\n\}/.exec(TABS)[0] + '; return tabDomId')()
+  const ok = /^[_a-zA-Z][-_a-zA-Z0-9:]*$/
+  for (const id of [123, 'vcmp-a1b2c3d4-1700000000', 'diff-9-10-1700000000', 'admin-settings',
+                    'a/b c.docx', '中文文件名', '', null]) {
+    const domId = fn('left', id)
+    assert.match(domId, ok, '这个 id 会被 uni 的 scroll-into-view 直接拒掉：' + domId)
+  }
+  assert.notEqual(fn('left', 1), fn('right', 1), '左右窗格同一个文件的 id 不能撞')
+})

--- a/frontend/tests/project-home/tab-strip-overflow.test.mjs
+++ b/frontend/tests/project-home/tab-strip-overflow.test.mjs
@@ -15,6 +15,8 @@ const SCSS = readFileSync(
   new URL('../../src/pages/project-overview/project-overview.scss', import.meta.url), 'utf8')
 const TABS = readFileSync(
   new URL('../../src/pages/project-overview/fileOpenTabs.js', import.meta.url), 'utf8')
+const DRAG = readFileSync(
+  new URL('../../src/pages/project-overview/tabDragSplit.js', import.meta.url), 'utf8')
 const APP = readFileSync(new URL('../../src/App.vue', import.meta.url), 'utf8')
 
 /** 取某个 class 选择器名下的规则体（scss 嵌套：只取到第一层闭合前的声明） */
@@ -33,34 +35,52 @@ test('.tab-item 不许被压扁：标签多了要溢出成横滚', () => {
   assert.match(body, /text-overflow:\s*ellipsis/, '.tab-name 仍要省略号收尾')
 })
 
-test('两个窗格的标签栏都换成 6px 悬浮细滑轨，不再整条藏掉', () => {
+test('两个窗格的标签栏都换成 4px 悬浮细滑轨，不再整条藏掉', () => {
   const tags = [...VUE.matchAll(/<scroll-view[^>]*class="[^"]*tabs-scroll[^"]*"[\s\S]{0,200}?>/g)].map(m => m[0])
   assert.equal(tags.length, 2, '左右窗格各一条标签栏，实际找到 ' + tags.length)
   for (const t of tags) {
     assert.match(t, /class="[^"]*\bawd-hairline-scroll\b/, '标签栏要挂 .awd-hairline-scroll')
     assert.ok(!/:show-scrollbar="false"/.test(t),
       'show-scrollbar=false 会让 uni-h5 给真正滚动的内层元素挂上隐藏类，细滑轨一起没了')
-    assert.match(t, /@wheel\.prevent="onTabsWheel"/, '标签栏要接滚轮横滚')
+    assert.ok(!/@wheel/.test(t),
+      '模板上的 @wheel 是死的（uni 把 currentTarget 换成了普通对象），横滚要原生挂')
   }
   assert.ok(!/display:\s*none/.test(bodyOf(SCSS, 'tabs-scroll')),
     '.tabs-scroll 里还留着藏滚动条的 display:none')
-  // 滑轨占的 6px 是从内容盒里扣的，height:100% 会让 36px 的 .tab-item 被
-  // uni 给内层元素挂的 overflow-y:hidden 裁掉底下 6px。
+  // 滑轨占的 4px 是从内容盒里扣的，height:100% 会让 36px 的 .tab-item 被
+  // uni 给内层元素挂的 overflow-y:hidden 裁掉底下 4px。
   const scroll = bodyOf(SCSS, 'tabs-scroll')
-  assert.match(scroll, /height:\s*calc\(100% \+ 6px\)/,
-    '.tabs-scroll 要多留 6px 给滑轨，否则标签底部会被裁掉')
-  // 那 6px 溢出到 .editors-container 头上，而它是 position:relative + 有背景，
-  // 按绘制顺序会把滑轨整条盖掉。
+  assert.match(scroll, /height:\s*calc\(100% \+ 4px\)/,
+    '.tabs-scroll 要多留 4px 给滑轨，否则标签底部会被裁掉')
+  // 那 4px 溢出到编辑区头上，而 .editors-container / .editor-pane 都是
+  // position:relative + 有背景、排在更后面，z-index 只到 1 时会把滑轨整条盖掉
+  // （#543 走查实测：注入 height:100% 立刻就能看见 thumb）。
   assert.match(scroll, /position:\s*relative/)
-  assert.match(scroll, /z-index:\s*1/,
-    '.tabs-scroll 不抬一层的话，溢出的 6px 滑轨会被 .editors-container 的背景盖掉')
+  const z = /z-index:\s*(\d+)/.exec(scroll)
+  assert.ok(z && Number(z[1]) >= 2,
+    '.tabs-scroll 的 z-index 要 >= 2，否则溢出的 4px 滑轨会被编辑区背景盖掉，实际 ' + (z && z[1]))
+})
+
+test('滚轮横滚改成原生 addEventListener 挂在真实元素上，且会摘干净', () => {
+  assert.match(DRAG, /rebindTabsWheel\s*\(\)\s*\{/, 'tabDragSplit.js 缺少 rebindTabsWheel')
+  assert.match(DRAG, /bindHorizontalWheelAll\(this\.\$el, '\.tabs-scroll'/,
+    'rebindTabsWheel 要按 .tabs-scroll 在本实例的 DOM 子树里找元素')
+  assert.match(DRAG, /unbindTabsWheel\s*\(\)\s*\{/, 'tabDragSplit.js 缺少 unbindTabsWheel')
+  assert.ok(!/onTabsWheel/.test(DRAG + VUE), '模板事件版的 onTabsWheel 还没删干净')
+  assert.match(VUE, /mounted\(\)[\s\S]{0,1200}?rebindTabsWheel\(\)/, 'mounted 里没有挂')
+  assert.match(VUE, /beforeUnmount\(\)[\s\S]{0,400}?unbindTabsWheel\(\)/, 'beforeUnmount 里没有摘')
+  // 分屏开关会把右侧那条标签栏整个建/拆，回来要重挂（bind 是幂等的）
+  assert.match(VUE, /splitMode\(\)[^\n]*rebindTabsWheel\(\)/,
+    'splitMode 变化后没有重挂：右侧标签栏是新建出来的元素，老监听在旧元素上')
 })
 
 test('.awd-hairline-scroll 定义在全局样式里，静止透明、悬停才显形', () => {
-  assert.match(APP, /\.awd-hairline-scroll[^{]*::-webkit-scrollbar[^{]*\{[^}]*height:\s*6px/,
-    'App.vue 里没有 .awd-hairline-scroll 的 6px 滑轨定义')
+  assert.match(APP, /\.awd-hairline-scroll[^{]*::-webkit-scrollbar[^{]*\{[^}]*height:\s*4px/,
+    'App.vue 里没有 .awd-hairline-scroll 的 4px 滑轨定义')
   assert.match(APP, /\.awd-hairline-scroll[^{]*::-webkit-scrollbar-thumb[^{]*\{[^}]*background:\s*transparent/,
     '静止时 thumb 要是透明的')
+  assert.match(APP, /\.awd-hairline-scroll[^{]*::-webkit-scrollbar-thumb[^{]*\{[^}]*border-radius:\s*999px/,
+    'thumb 要圆角（4px 的方块线条在浅色外壳上很硌眼）')
   assert.match(APP, /\.awd-hairline-scroll:hover[^{]*::-webkit-scrollbar-thumb[^{]*\{[^}]*var\(--awd-border-strong\)/,
     '悬停时 thumb 要用 --awd-border-strong 显形（跟随主题，不写死颜色）')
 })

--- a/frontend/tests/project-home/wheel-delta.test.mjs
+++ b/frontend/tests/project-home/wheel-delta.test.mjs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// wheelDeltaOf 的取值口径（dev-board#543）。
+//
+// 病灶：uni-h5 的 createNativeEvent 把 <scroll-view> 上的 wheel 事件重建成一个普通
+// 对象，补字段的分支只有 click / mouse 系 / touch 系 / 键盘四类，wheel 不在其中——
+// 回调拿到的事件**没有 deltaX/deltaY**，`scrollLeft += evt.deltaY` 得到 NaN，
+// 编辑器工具栏与标签栏的横滚一起静默失效（回归自 PR#759）。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { wheelDeltaOf } from '../../src/utils/wheelDelta.js'
+
+function withWindowEvent(evt, fn) {
+  const had = 'window' in globalThis
+  const prev = had ? globalThis.window : undefined
+  globalThis.window = { event: evt }
+  try { return fn() } finally {
+    if (had) globalThis.window = prev
+    else delete globalThis.window
+  }
+}
+
+test('回调事件缺 delta 字段时，回退到正在派发的原生事件', () => {
+  // uni 重建后的形状：只有这几个字段，没有任何 delta
+  const rebuilt = { type: 'wheel', timeStamp: 1, target: {}, currentTarget: {}, detail: {} }
+  const got = withWindowEvent({ deltaX: 0, deltaY: 120 }, () => wheelDeltaOf(rebuilt))
+  assert.equal(got, 120)
+})
+
+test('回调事件自带 delta 时优先用回调的（事件没被包装的平台）', () => {
+  const got = withWindowEvent({ deltaX: 0, deltaY: 999 }, () => wheelDeltaOf({ deltaX: 0, deltaY: -40 }))
+  assert.equal(got, -40)
+})
+
+test('两处都取不到 delta 就返回 0（调用方据此不动，而不是加一个 NaN）', () => {
+  const rebuilt = { type: 'wheel', target: {} }
+  assert.equal(withWindowEvent(null, () => wheelDeltaOf(rebuilt)), 0)
+  assert.equal(withWindowEvent({ type: 'wheel' }, () => wheelDeltaOf(rebuilt)), 0)
+  assert.equal(wheelDeltaOf(undefined), 0)
+})
+
+test('横向分量更大时取 deltaX（触控板横扫）', () => {
+  assert.equal(wheelDeltaOf({ deltaX: -85, deltaY: 12 }), -85)
+  assert.equal(wheelDeltaOf({ deltaX: 12, deltaY: -85 }), -85)
+})
+
+test('NaN / 非数字的 delta 不会被原样加到 scrollLeft 上', () => {
+  assert.equal(wheelDeltaOf({ deltaX: NaN, deltaY: NaN }), 0)
+  assert.equal(wheelDeltaOf({ deltaY: 60, deltaX: undefined }), 60)
+})
+
+// ---------- 两个调用方确实换成了它 ----------
+
+import { readFileSync } from 'node:fs'
+
+const TOOLBAR = readFileSync(new URL('../../src/components/EditorToolbar.vue', import.meta.url), 'utf8')
+const TABS = readFileSync(new URL('../../src/pages/project-overview/tabDragSplit.js', import.meta.url), 'utf8')
+
+test('onToolbarWheel / onTabsWheel 都走 wheelDeltaOf，不再直接读 evt.delta*', () => {
+  for (const [name, src] of [['EditorToolbar.vue', TOOLBAR], ['tabDragSplit.js', TABS]]) {
+    assert.match(src, /wheelDeltaOf\(evt\)/, name + ' 没有调用 wheelDeltaOf')
+    assert.match(src, /from '@\/utils\/wheelDelta\.js'/, name + ' 没有 import wheelDeltaOf')
+    assert.ok(!/Math\.abs\(evt\.deltaX\)/.test(src),
+      name + ' 还在直接读 evt.deltaX：uni 重建过的事件上没有这个字段，恒 NaN')
+  }
+})

--- a/frontend/tests/project-home/wheel-delta.test.mjs
+++ b/frontend/tests/project-home/wheel-delta.test.mjs
@@ -49,18 +49,29 @@ test('NaN / 非数字的 delta 不会被原样加到 scrollLeft 上', () => {
   assert.equal(wheelDeltaOf({ deltaY: 60, deltaX: undefined }), 60)
 })
 
-// ---------- 两个调用方确实换成了它 ----------
+// ---------- 唯一的调用方是 horizontalWheel.js，两个宿主都改走原生挂载 ----------
 
 import { readFileSync } from 'node:fs'
 
+const HWHEEL = readFileSync(new URL('../../src/utils/horizontalWheel.js', import.meta.url), 'utf8')
 const TOOLBAR = readFileSync(new URL('../../src/components/EditorToolbar.vue', import.meta.url), 'utf8')
 const TABS = readFileSync(new URL('../../src/pages/project-overview/tabDragSplit.js', import.meta.url), 'utf8')
+const PAGE = readFileSync(
+  new URL('../../src/pages/project-overview/project-overview.vue', import.meta.url), 'utf8')
 
-test('onToolbarWheel / onTabsWheel 都走 wheelDeltaOf，不再直接读 evt.delta*', () => {
+test('位移只在 horizontalWheel.js 里取，宿主不再自己读 evt.delta*', () => {
+  assert.match(HWHEEL, /wheelDeltaOf\(evt\)/, 'horizontalWheel.js 没有调用 wheelDeltaOf')
+  assert.match(HWHEEL, /from '\.\/wheelDelta\.js'/, 'horizontalWheel.js 没有 import wheelDeltaOf')
   for (const [name, src] of [['EditorToolbar.vue', TOOLBAR], ['tabDragSplit.js', TABS]]) {
-    assert.match(src, /wheelDeltaOf\(evt\)/, name + ' 没有调用 wheelDeltaOf')
-    assert.match(src, /from '@\/utils\/wheelDelta\.js'/, name + ' 没有 import wheelDeltaOf')
     assert.ok(!/Math\.abs\(evt\.deltaX\)/.test(src),
       name + ' 还在直接读 evt.deltaX：uni 重建过的事件上没有这个字段，恒 NaN')
+    assert.match(src, /horizontalWheel\.js'/, name + ' 没有改走 horizontalWheel.js')
+  }
+})
+
+test('模板里不许再挂 @wheel：uni 重建过的对象上 currentTarget 不是 DOM，第一道守卫就 return', () => {
+  for (const [name, src] of [['EditorToolbar.vue', TOOLBAR], ['project-overview.vue', PAGE]]) {
+    assert.ok(!/@wheel[.\w]*="/.test(src.slice(0, src.lastIndexOf('</template>'))),
+      name + ' 的模板里还留着 @wheel（dev-board#543 走查实测：scrollLeft 0 → 0）')
   }
 })


### PR DESCRIPTION
## 根因
- `<scroll-view>` 上的 `@wheel` 经 uni-h5 重建后 `currentTarget` 是普通对象、也没有 `deltaX/deltaY`，工具栏与标签栏两处滚轮转横滚从未真正执行；PR #759 又把滚动条整条藏掉，于是彻底滚不动。
- `.tab-item` 没有 `flex-shrink:0`，标签一多整批被压扁而不是溢出。
- 跨分屏拖拽标签在 `moveTabTo` 里被写死成浅拷贝（刻意的双开），用户要的是移动。

## 改动
- 新增 `utils/horizontalWheel.js`：mounted 时用原生 `addEventListener({passive:false})` 挂到真实滚动元素（幂等、可摘、滚不动不拦截），分屏开关后重挂；模板 `@wheel` 删除。
- 全局 `.awd-hairline-scroll`：4px 细滑轨、静止透明、hover 显形（对齐 VS Code）；工具栏行高保持 38px、左右按钮齐平；`.tabs-scroll` z-index 2（否则被 `.editor-pane` 盖住）。
- `.tab-item` `flex-shrink:0`；活动标签变化时 `scroll-into-view`，已可见不滚。
- 跨分屏拖拽默认移动（源侧活动标签按关闭规则选相邻），Alt/Option 拖拽才复制；移动前先落盘未保存编辑，落不下来不搬并提示。

## 验证
- `test:project-home` 453/453、`test:insight` 115/115、`test:lowa-unit` 37/37（rebase 到最新 master 后重跑）；check:emits/locales/spdx 通过；`build:h5` DONE。
- 有头 Chrome 真渲染复验：标签栏/工具栏滚轮 scrollLeft 0→300；4px 滑轨浅/深两主题 hover 显形、静止透明；工具栏 38+1px、左右按钮 top 差 0；拖拽移动/Alt 复制两侧列表长度核对；控制台无 pageerror。
- 未验证：Electron 外壳内 BrowserView 覆盖层下标签栏溢出的 4px；Windows 滚轮倍率。

dev-board#543 dev-board#542

🤖 Generated with [Claude Code](https://claude.com/claude-code)