### PR TITLE
feat(insight): 解析实体 Cmd/Ctrl 点击弹浮窗预览、右侧分屏新标签打开；新增「文档」DOC 实体类型（dev-board#541）

### DIFF
--- a/.claude/agents/doc-insight.md
+++ b/.claude/agents/doc-insight.md
@@ -321,7 +321,7 @@ DOC 实体的 `detail`（命中项目文件时；`GET /entities/{id}` 才下发�
 - `frontend/src/utils/insightDetail.js` —— 纯函数：把 COMPANY/LAW/CASE 三种 `detail` 整形成可渲染的行，外加 `authoritative`（权威条文原文）/ `caseRecognition`（案号识别行）/ `citationDetail`（两类引用发现）。上游形状是别人家的，一律「认得的列出来、认不得的落原文兜底」。
 - `frontend/src/components/InsightHoverCard.vue` / `InsightEntityDetailPane.vue` / `InsightEntityBody.vue` —— 实体浮窗、实体详情标签页，以及**两者共用的一份正文渲染**（dev-board#541）。字段整形全部来自 `insightDetail.js`，不许再抄一份解析。
 - `frontend/src/utils/insightPopup.js` —— 纯函数：`guestPointToHost`（客体页 clientX/clientY + 画布 rect → 宿主页面坐标）、`hoverCardPosition`（贴点击点、靠边翻转、绝不出屏）。同 `insightMatch.js` 的口径：不许 import Vue/uni/i18n。
-- `frontend/src/pages/project-overview/insightEntityTab.js` —— 方法组：`insightEntityTabId` + `openInsightEntityTab`（外置是为了能拿假 this 单测「强制开分屏」与「单例」两条）。
+- `frontend/src/pages/project-overview/insightEntityTab.js` —— 方法组：`insightEntityTabId` + `openInsightEntityTab` + `openInsightDocFile`（外置是为了能拿假 this 单测「强制开分屏」与「单例」两条）。
 - `frontend/src/config/panelRegistry.js` —— `insight` 一条（`defaultDock:'right'`、`allowedDocks:['left','right']`，**不给 bottom**：底栏放不下判决书全文）。
 - `frontend/src/services/api.js` —— `parseDocInsight` / `getDocInsight` / `getDocInsightEntity` / `refreshDocInsightEntity`。
 - 宿主接线在 `frontend/src/pages/project-overview/project-overview.vue`（右栏 `rightPaneKey==='insight'` / 左栏 `leftPaneKey==='insight'` 两条显式分支 + `isInsightDoc` / `getInsightExecutor` / `onOpenInsight` / `onInsightEntities` / `setInsightIndex` / `insightSubscribedFor` / `prefetchInsightIndex` / `onEditorCursorContext` / `openInsightHoverCard` / `closeInsightHoverCard`；浮窗在**根节点**渲染，实体详情标签在左右两条 `v-else-if` 链里各一份）。
@@ -372,6 +372,17 @@ DOC 实体的 `detail`（命中项目文件时；`GET /entities/{id}` 才下发�
 - 浮窗与标签页**共用 `InsightEntityBody`** 一份渲染（浮窗档 `compact`：截长正文、不列其余候选、不铺原始 JSON）。
   同步给宿主的实体索引是**瘦身**的（名字 + 几个短标量），**出处 `mentions` 不进索引**——
   标签页要出处时自己打一次 `GET /entities/{id}`（EntityView 里就有）。
+- **DOC 实体的展示与「打开文件」**（#541）：`KIND_ORDER` 第四位（漏了它 `entityGroups` 会把 DOC 兜底归进公司组），
+  分组标题/徽标 i18n 在 `insight.kind.DOC` / `insight.entityKind.DOC`。命中项目文件时列文件名 + 路径 +
+  「打开文件」，一路 `open-doc-file{fileId,fileName}` 上抛到宿主 `openInsightDocFile`：
+  **未分屏先开分屏、落右侧**再走既有 `openFile`（已在任一侧开着的只激活、不动分屏；
+  文件对象从 `$refs.fileTree.allFiles` 反查，查不到给一句 `insight.docMissing` 的 toast）。
+  浮窗对 DOC 的底部主按钮就是「打开文件」（**不给「在新标签页打开」**——实体详情标签对它没有意义，
+  打开文件本身就落在右侧分屏），没命中时底栏整条不出。字段整形走 `insightDetail.js` 的 `projectFile`。
+  **DOC 一律不给「重试」**（`showRetry` 对 `kind==='DOC'` 恒 false）：它的检索是与静态文件树比对，
+  后端 refresh 对 DOC 是空操作；未命中的说明沿用后端的 `retrievalNote`「项目中未找到该文件」。
+  宿主的三处 `@open-doc-file`（InsightPane 两处挂载点 / InsightHoverCard / InsightEntityDetailPane 左右两处）
+  漏一处 `check:emits` 直接红。
 - 面板里的 Cmd/Ctrl 点击**不再展开面板内详情**：用户的视线在正文上，把他引到侧栏去找刚点的那一条是多余的一步。
 
 ### 定位与一键修改的口径（硬约束）
@@ -402,7 +413,7 @@ DOC 实体的 `detail`（命中项目文件时；`GET /entities/{id}` 才下发�
 ### 前端验证
 
 ```
-cd frontend && npm run test:insight        # 108 条（纯函数 58 + 组件级 33 + 浮窗坐标 10 + 实体标签 7）
+cd frontend && npm run test:insight        # 115 条（纯函数 58 + 组件级 36 + 浮窗坐标 10 + 实体标签 11）
 cd frontend && npm run test:panel-dock     # 注册表自洽 + 停靠回落
 cd frontend && npm run check:emits && npm run check:nav && npm run check:locales
 cd frontend && npm run build:h5 && npm run build:zetaoffice   # 改 editor-main.js 后必须重建 glue

--- a/.claude/agents/doc-insight.md
+++ b/.claude/agents/doc-insight.md
@@ -297,9 +297,12 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
 - `frontend/src/components/InsightPane.vue` + 同目录外置样式 `insight-pane.scss` —— 「依据」窗格本体，两个 tab（外部检索 / 一致性校验）。
 - `frontend/src/utils/insightMatch.js` —— 纯函数：`cursorWindow` / `matchEntityAt`（光标邻域命中实体）、`buildFixedQuote` / `fixSuggestions` / `fixBlockReason` / `findingLocateQuote`（一键修改的替换串）。**不许 import Vue/uni/i18n**（`node --test` 直接导入，且客体页 `editor-main.js` 也 import 它取 `CURSOR_RADIUS`）。
 - `frontend/src/utils/insightDetail.js` —— 纯函数：把 COMPANY/LAW/CASE 三种 `detail` 整形成可渲染的行，外加 `authoritative`（权威条文原文）/ `caseRecognition`（案号识别行）/ `citationDetail`（两类引用发现）。上游形状是别人家的，一律「认得的列出来、认不得的落原文兜底」。
+- `frontend/src/components/InsightHoverCard.vue` / `InsightEntityDetailPane.vue` / `InsightEntityBody.vue` —— 实体浮窗、实体详情标签页，以及**两者共用的一份正文渲染**（dev-board#541）。字段整形全部来自 `insightDetail.js`，不许再抄一份解析。
+- `frontend/src/utils/insightPopup.js` —— 纯函数：`guestPointToHost`（客体页 clientX/clientY + 画布 rect → 宿主页面坐标）、`hoverCardPosition`（贴点击点、靠边翻转、绝不出屏）。同 `insightMatch.js` 的口径：不许 import Vue/uni/i18n。
+- `frontend/src/pages/project-overview/insightEntityTab.js` —— 方法组：`insightEntityTabId` + `openInsightEntityTab`（外置是为了能拿假 this 单测「强制开分屏」与「单例」两条）。
 - `frontend/src/config/panelRegistry.js` —— `insight` 一条（`defaultDock:'right'`、`allowedDocks:['left','right']`，**不给 bottom**：底栏放不下判决书全文）。
 - `frontend/src/services/api.js` —— `parseDocInsight` / `getDocInsight` / `getDocInsightEntity` / `refreshDocInsightEntity`。
-- 宿主接线在 `frontend/src/pages/project-overview/project-overview.vue`（右栏 `rightPaneKey==='insight'` / 左栏 `leftPaneKey==='insight'` 两条显式分支 + `isInsightDoc` / `getInsightExecutor` / `onOpenInsight` / `onInsightEntities` / `onEditorCursorContext`）。
+- 宿主接线在 `frontend/src/pages/project-overview/project-overview.vue`（右栏 `rightPaneKey==='insight'` / 左栏 `leftPaneKey==='insight'` 两条显式分支 + `isInsightDoc` / `getInsightExecutor` / `onOpenInsight` / `onInsightEntities` / `setInsightIndex` / `insightSubscribedFor` / `prefetchInsightIndex` / `onEditorCursorContext` / `openInsightHoverCard` / `closeInsightHoverCard`；浮窗在**根节点**渲染，实体详情标签在左右两条 `v-else-if` 链里各一份）。
 - 编辑器侧：`EditorToolbar.vue` 的「解析」按钮（`toggle-insight`）→ `LibreOfficeEditor.vue` `onToggleInsight` → `open-insight` → 宿主。
 
 ### 事件流
@@ -311,14 +314,43 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
 面板 → @entities{docFileId,entities[]} → 宿主 _insightIndex（非响应式，同 _libreRefs 口径）
 
 画布单击 / 光标移动 → 客体页 editor-main.js（**仅在订阅打开时**）get_cursor_context
-   → lo-relay {type:'cursor-context', payload:{before,after,paragraph,meta:{metaKey,ctrlKey}}}
-   → LibreOfficeEditor $emit('cursor-context') → 宿主 onEditorCursorContext（先用 _insightIndex 匹配一遍）
-   → :cursor-context prop → 面板 matchEntityAt → Cmd/Ctrl 点击=选中并展开详情；普通点击/光标移动=被动高亮
+   → lo-relay {type:'cursor-context', payload:{before,after,paragraph,
+                meta:{metaKey,ctrlKey,clientX,clientY}}}      ← 点击那一路才有坐标
+   → LibreOfficeEditor withHostPoint（画布 rect **每次现取**）→ meta 里补 {hostX,hostY}
+   → $emit('cursor-context') → 宿主 onEditorCursorContext（先用 _insightIndex 匹配一遍）
+   → 窗格开着且绑着这份文档：:cursor-context prop → 面板 matchEntityAt
+        · 普通点击/光标移动 = 被动高亮
+        · Cmd/Ctrl 点击     = @open-hover{entity,x,y} → 宿主 openInsightHoverCard
+   → 窗格没开：宿主只处理 Cmd/Ctrl 那一支，直接 openInsightHoverCard
+浮窗「在新标签页打开」 → openInsightEntityTab → 右侧分屏 tabType 'insight-entity'
 ```
 
 订阅开关是宿主 → 客体页的下行消息 `{__lo:'lo-relay', type:'insight-sub', enabled}`，
 由 `LibreOfficeEditor` 的 `insightSubscribed` prop 驱动（`ready` 时补发一次）。
-**不订阅时客体页一次 `get_cursor_context` 都不打**——没开窗格的用户零开销。
+判据在宿主的 `insightSubscribedFor(file)`：**窗格开着且绑在它上面，或这份文档已经解析出实体**
+（dev-board#541 把订阅与窗格显隐解耦——否则窗格一关，正文 Cmd 点击就没反应）。
+索引由 `prefetchInsightIndex`（文档标签激活时拉一次 `GET /insight`，一份文档只拉一次、
+失败不写缓存）与窗格的 `@entities` 共同填，唯一写入点是 `setInsightIndex`
+（写非响应式的 `_insightIndex` + 响应式计数镜像 `insightEntityCounts`，模板要用后者）。
+**没解析过的文档仍然一次 `get_cursor_context` 都不打**——「零开销」那条口径对它们没变。
+
+### 实体浮窗与实体标签页（dev-board#541）
+
+- 正文里 **Cmd（mac）/ Ctrl 点击**命中实体 → 贴着点击处弹 `InsightHoverCard`：类型徽标 + 名称 +
+  检索状态/来源/note + 核心字段摘要 + 底部「在新标签页打开」。遮罩点击或 **Esc** 关闭。
+- **浮窗挂在页面根节点**（不在面板里）：编辑器画布是独立合成层的 `<webview>`，
+  浮层只有在根级 + 高 z-index（同 `FileTree` 右键菜单的 9999/10000）才压得住。
+  桌面端还要进 `desktopOverlayActive`——另一侧开着浏览器标签时 BrowserView 是原生层，会盖住 DOM。
+- **拿不到坐标就不弹**：`guestPointToHost` 在 rect 缺失 / 客体页没带 clientX/clientY 时返回 null，
+  `openInsightHoverCard` 据此直接 return。弹到屏幕角落比不弹更糟——用户会以为自己点错了地方。
+- 「在新标签页打开」→ `openInsightEntityTab`：**未分屏先开分屏**、`focusedPane='right'`、
+  单例 id `insight-entity_<kind>_<id>`（跨两侧查重，已开的只激活不重建）。
+  落右侧是硬要求：开在左边会把用户正在读的那份文档顶掉。
+  `tabType 'insight-entity'` 必须在 `pages/project-overview/fileKind.js` 的 `NON_FILE_TAB_TYPES` 里。
+- 浮窗与标签页**共用 `InsightEntityBody`** 一份渲染（浮窗档 `compact`：截长正文、不列其余候选、不铺原始 JSON）。
+  同步给宿主的实体索引是**瘦身**的（名字 + 几个短标量），**出处 `mentions` 不进索引**——
+  标签页要出处时自己打一次 `GET /entities/{id}`（EntityView 里就有）。
+- 面板里的 Cmd/Ctrl 点击**不再展开面板内详情**：用户的视线在正文上，把他引到侧栏去找刚点的那一条是多余的一步。
 
 ### 定位与一键修改的口径（硬约束）
 
@@ -337,7 +369,7 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
   带 `retrievalHint` 的**不给「重试」**，给引导按钮（`noteAction` → `open-settings {nav:'account'}`，NO_CREDENTIAL 只出一行 `.ip-note-h` 文案）；
   没有 hint 的才给「重试」（`showRetry` = `canParse && !retrievalHint`，`POST /entities/{id}/refresh`，要写权限）。
   面板自己不 `uni.navigateTo`：设置由宿主 `openSettingsTab` 就地开中栏标签（与 `@open-url` 同一条口径），
-  **两处挂载点（左栏 / 右 dock）都要绑 `@open-settings`**，漏一处 `check:emits` 直接红。
+  **两处挂载点（左栏 / 右 dock）都要绑 `@open-settings`**（`@open-hover` 同理），漏一处 `check:emits` 直接红。
   NOT_FOUND 用**中性灰**（`.ip-dot.st-NOT_FOUND` / `.ip-note.st-NOT_FOUND`），不用告警色：
   文档里写了一家不存在的公司，是文档的问题，不是我们的故障。
 - 两类引用发现（CITATION_*）在一致性 tab 里只列不改：`fixSuggestions` 看的是 `detail.claims`，引用 detail 没有这一段，天然落不到「修改建议」那一支；点条目仍按 `detail.quote` 定位。CITATION_MISMATCH 的「引用条文」是折叠段（`citedOpen`）。
@@ -348,7 +380,7 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
 ### 前端验证
 
 ```
-cd frontend && npm run test:insight        # 91 条（纯函数 58 + 组件级 33）
+cd frontend && npm run test:insight        # 108 条（纯函数 58 + 组件级 33 + 浮窗坐标 10 + 实体标签 7）
 cd frontend && npm run test:panel-dock     # 注册表自洽 + 停靠回落
 cd frontend && npm run check:emits && npm run check:nav && npm run check:locales
 cd frontend && npm run build:h5 && npm run build:zetaoffice   # 改 editor-main.js 后必须重建 glue

--- a/.claude/agents/doc-insight.md
+++ b/.claude/agents/doc-insight.md
@@ -1,14 +1,14 @@
 ---
 name: doc-insight
-description: 文档「解析」与「依据」窗格领域。任务涉及实体抽取（企业/法规/案例）、外部库检索（企查查 REST+MCP、北大法宝 MCP、判决书通道）、文档内部一致性校验（数量前后矛盾、统一社会信用代码硬错）、doc_insight_* 三张表与 /api/projects/{pid}/insight 时，先读本文档再动代码。
+description: 文档「解析」与「依据」窗格领域。任务涉及实体抽取（企业/法规/案例/项目内文档）、外部库检索（企查查 REST+MCP、北大法宝 MCP、判决书通道）、文档内部一致性校验（数量前后矛盾、统一社会信用代码硬错）、doc_insight_* 三张表与 /api/projects/{pid}/insight 时，先读本文档再动代码。
 ---
 
 # 文档解析 / 依据窗格 领域地图
 
-职责边界：用户在编辑器点「解析」之后的<b>后端全链路</b>——通读文档 → 抽三类实体 → 逐个打外部库 → 同时做文档内部一致性校验 → 落库供前端「依据」窗格轮询。
+职责边界：用户在编辑器点「解析」之后的<b>后端全链路</b>——通读文档 → 抽四类实体 → 逐个打外部库（DOC 那类打的是本项目文件树）→ 同时做文档内部一致性校验 → 落库供前端「依据」窗格轮询。
 不含：编辑器侧的定位与一键替换（属 ai-doc-bridge），AI 对话里的 `qichacha_query` / `law_*` 工具（属 ai-chat，与本领域<b>共用下游、不共用代码</b>）。
 
-dev-board#181（后端部分）+ #182。
+dev-board#181（后端部分）+ #182 + #541（DOC 第四类实体）。
 
 ## 关键文件
 
@@ -44,7 +44,7 @@ dev-board#181（后端部分）+ #182。
 `doc_insight_run`：id / project_id / doc_file_id / status(RUNNING|DONE|FAILED) / phase（可读进度短语，前端直接显示）/ error / model / started_at / finished_at。
 索引 `(project_id, doc_file_id, started_at)`。
 
-`doc_insight_entity`：id / run_id / project_id / doc_file_id / kind(COMPANY|LAW|CASE) / name（展示名）/ norm_key（归一键，去重与缓存都按它）/ mentions_json / retrieval_status / retrieval_source / retrieval_json(TEXT) / retrieval_note / retrieval_hint / fetched_at。
+`doc_insight_entity`：id / run_id / project_id / doc_file_id / kind(COMPANY|LAW|CASE|DOC) / name（展示名）/ norm_key（归一键，去重与缓存都按它）/ mentions_json / retrieval_status / retrieval_source / retrieval_json(TEXT) / retrieval_note / retrieval_hint / fetched_at。
 索引 `(run_id)` 与 `(project_id, kind, norm_key, fetched_at)`（后者是 7 天缓存命中查询）。
 
 `doc_insight_finding`：id / run_id / project_id / doc_file_id / kind(COUNT_MISMATCH|USCC_INVALID|CITATION_NOT_FOUND|CITATION_MISMATCH) / severity(warn|error) / title / detail_json(TEXT) / created_at。
@@ -55,9 +55,9 @@ LAW 的 `authoritative`（权威条文原文）、CASE 的 `recognition`（案�
 **`retrieval_status` 五态的语义分工（最容易写错的一处）**
 | 值 | 含义 | 典型来源 |
 |---|---|---|
-| PENDING | 还没轮到它 | 实体刚落库 |
+| PENDING | 还没轮到它 | 实体刚落库（DOC 除外：它在落库时就判完了） |
 | OK | 拿到结果 | 上游 200 |
-| **NOT_FOUND** | **查完了，上游明确说没有**——一次成功的检索 | 企查查两条路都没查到、网关回「【有效请求】查询无结果」、法宝回空数组 |
+| **NOT_FOUND** | **查完了，上游明确说没有**——一次成功的检索 | 企查查两条路都没查到、网关回「【有效请求】查询无结果」、法宝回空数组、**DOC 在项目文件树里没有对应文件** |
 | **UNAVAILABLE** | **通道不可用**——不是「查无此项」 | 本机没凭证、法宝点数耗尽（401）、案例通道未配置、`GatewayException`（NOT_FOUND 那一类除外） |
 | ERROR | 打了但失败（异常、形状不认得） | 企查查全称重打时抛的非网关异常 |
 
@@ -92,11 +92,14 @@ NO_CREDENTIAL 不给按钮是刻意的：官方版没有法宝凭据输入框（
 startParse（同步）：写权限 → 文件校验 → 单飞闸 → 落 RUNNING 行 → 返回 runId
   ↓ executor（专用 2 线程池，整段包在 PlatformAiUserScope.run(userId, …) 里）
 ① 读取文档   DocumentTextService.extractText，超 insight.max-chars 截断并在 phase 里写明
-② 确定性预抽取  案号正则 + 书名号法规正则（正则那条腿保证下限，永不漏不编）
+② 确定性预抽取  案号正则 + 书名号法规正则 + 书名号文档正则（正则那条腿保证下限，永不漏不编）
 ③ 逐块 LLM 抽取  chunk-chars=10000 / overlap=500，每块一次 getAuxChatModel().generate
                 单块失败只跳过这一块；每块记一笔 token_usage
 ④ 合并去重   按 (kind, normKey)，出处累加（上限 max-mentions），展示名取最长的
-⑤ 逐个检索   命中 7 天缓存则复制；否则打上游。**每个实体检索完立刻 save**
+④' 文档匹配   resolveDocFiles：DOC 候选对项目文件树，命中的 normKey 改写成 `file:<id>` 后**再合并一次**
+              （多处提到同一份文件 = 一条实体）；OK/NOT_FOUND 在 persistEntities 里就写死
+⑤ 逐个检索   命中 7 天缓存则复制；否则打上游。**每个实体检索完立刻 save**。
+              **DOC 在 retrieveOne 开头整段跳过**（既不打上游也不读缓存）
 ⑥ 法条引用校验 insight.citation-server 配了才跑（法宝 adjust_provisions）：逐个 LAW 实体
               （有条号 + 条号能转成阿拉伯数字，上限 30 个）→ 回填 authoritative +
               产出 CITATION_NOT_FOUND / CITATION_MISMATCH。**单条失败只跳过这一条**
@@ -109,6 +112,10 @@ startParse（同步）：写权限 → 文件校验 → 单飞闸 → 落 RUNNIN
 - COMPANY：去括号内容 → `EvidenceChecks.compact`（NFKC + 去空白 + 大写）→ 剥组织形式后缀。
 - LAW：`compact(书名号内标题) + "#" + compact(条号)`。
 - CASE：案号（全角括号转半角 + 去空白）；没案号时用标题。
+- DOC：`DocInsightExtraction.normalizeDocTitle`——去书名号 → 去括号注记 → 去扩展名 →
+  去序号前缀（`^[\d一二三四五六七八九十]+[-.、）)]`）→ `compact`。**正文标题与文件名两边用同一个函数**。
+  命中项目文件后归一键**改写成 `file:<id>`**（这是与前端的契约：多处提到同一份文件只出一条实体）；
+  没命中的保留标题键。**不要复用企业的 `stripOrgSuffix`**：文件名里的「合同」「协议」正是主干。
 
 **检索路由**
 法宝那三行（LAW / CASE / 引用校验）**一律经 `PkulawChannel`**：平台档下 op = 法宝工具名、
@@ -120,6 +127,7 @@ service = `pkulaw`，端点写死在官网网关；自备 Key 档才落到 `McpC
 | COMPANY | `QichachaService.queryEciInfoJson` → 查不到再 `qichacha-company` MCP 的 `get_company_by_query` 模糊搜索拿全称 → 用全称重打 REST | REST 只认工商全称，非全称回 Status 201 无结果；MCP 那把是**另一套凭证** |
 | LAW | 有条号 → `pkulaw-semantic` / `get_article`；无条号 → `pkulaw-keyword` / `get_law_list` | |
 | CASE | **先导步**：`insight.case-number-server` / `-tool`（yml 默认 `pkulaw-case-number` / `anhao_recognition`，参数 `text`）把案号标准化并给出法院/判决书标题/法宝链接 → 用**标题**去打 `insight.case-server` / `-tool` / `-arg`（yml 默认 `pkulaw-case-semantic` / `search_case` / `text`） | 识别只做加法：未配置 / 报错 / 空数组一律**静默走原路**（拿案号原文检索）。识别命中而全文检索失败 → 仍记 **OK**，`retrievalJson` 只有 `recognition`、note 写「仅返回案号识别结果」。换别家案例 MCP 只改配置；代码内缺省全为空。法宝另有关键词档 `pkulaw-case-keyword`（`get_case_list`）备用 |
+| DOC | **不打任何外部库**：`ProjectFileRepository.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc` 取存活文件（**排除文件夹**），文件名同口径归一后 相等优先、其次两向包含；多个命中取相等、再取 `filePath` 最短的 | 抽取只走确定性正则（`DocInsightExtraction.DOC_TITLE`），**LLM 提示词一个字没动**。同一个书名号只能落一类：法规体裁先被 `LAW_TITLE` 吃掉（按匹配起点排重），剩下的才是 DOC |
 | LAW 引用校验 | `insight.citation-server` / `-tool`（yml 默认 `pkulaw-citation-validator` / `adjust_provisions`） | 见「法条引用校验」一节。代码内缺省为空 = 整步跳过 |
 
 ## REST 契约（前端照这个接）
@@ -176,6 +184,14 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
                           "snippet":"…（截 200 字）","url":"https://www.pkulaw.com/…"}],
            "note":"候选可能来自旧版法规（存在条文重编号），请人工核对现行版本","fixable":false}}
 ```
+
+DOC 实体的 `detail`（命中项目文件时；`GET /entities/{id}` 才下发，列表里只有 `hasDetail:true`）：
+```json
+{"source":"project-file","fileId":21,"fileName":"房屋租赁合同.docx","filePath":"/p/1/房屋租赁合同.docx"}
+```
+前端据 `fileId` 直接打开那份文件。**没命中的落 NOT_FOUND**（note「项目中未找到该文件」、
+`retrievalHint` 为 null、`retrievalJson` 为 null → `hasDetail:false`），窗格**不给「重试」**：
+重试一百次还是同一句话，且这条本身就是尽调线索（文档提到但项目里缺这份），不是我们的故障。
 
 实体 `detail` 里的两个升级件字段（`GET /entities/{id}` 才下发）：
 ```json
@@ -287,7 +303,13 @@ USCC_INVALID 的 detail 形状不同（没有 claims）：
    不卡住就是间歇红——#394 的教训）。`DocInsightServiceTest.中间态与单飞` 是现成的写法。
 8. `Response.from(AiMessage.from(text))` **不带 tokenUsage**，记账断言会永远是空的。单测里用带 usage 的重载
    （`DocInsightServiceTest.modelReply`）。
-9. 本轮**不加 AI 工具**：UI 直连 REST，`AgentOrchestrator` / `ToolRegistry` / `RealToolBeans` 一行没动。
+9. **DOC 必须在 `retrieveOne` 开头整段返回**（dev-board#541）。它的「检索」是与项目文件树比对，
+   在 `persistEntities` 里就判完了。漏了这条守卫有两个后果：① switch 的 `default` 分支把已判好的
+   OK / NOT_FOUND 覆盖成 `UNAVAILABLE`「未知实体类型」——一句彻头彻尾的假故障；
+   ② `copyFromCache` 会拿 7 天前的 OK 盖掉「这份文件现在已经不在项目里了」。
+   `refreshEntity` 走的是同一个方法，所以「重新检索」对 DOC 天然是空操作。
+   `DocInsightServiceTest` 里删掉那一行会直接红三条（2026-09-09 对拍过）。
+10. 本轮**不加 AI 工具**：UI 直连 REST，`AgentOrchestrator` / `ToolRegistry` / `RealToolBeans` 一行没动。
    将来要给模型开一个 `doc_insight` 工具，记得同步 `RealToolBeans.instantiateAll()`（ai-chat 领域的既有地雷）。
 
 ## 前端（dev-board#182）
@@ -395,7 +417,7 @@ cd frontend && npm run build:h5 && npm run build:zetaoffice   # 改 editor-main.
 ## 验证
 
 ```
-cd backend && mvn test -Dtest='DocInsight*,LawArticle*'   # 65 条
+cd backend && mvn test -Dtest='DocInsight*,LawArticle*'   # 70 条
 cd backend && mvn test -Dtest='*Mcp*Test'                 # 含 StreamableHttpMcpProviderCredentialTest（空凭证不发请求）
 cd backend && mvn clean test                      # 全量（跨类常量内联，验证阶段一律 clean）
 ```
@@ -403,12 +425,15 @@ cd backend && mvn clean test                      # 全量（跨类常量内联�
   后缀剥离等价、USCC 校验位与去重、**fixable 三条降级分支**、空输入。
 - `LawArticleNumbersTest`（7）：十/百/千组合与「零」、`之N`、已是阿拉伯数字（含全角）、
   **转不动一律 null**、引文剥引用字样取内容线索。
-- `DocInsightServiceTest`（33）：RUNNING 中间态（CountDownLatch）、单飞、企查查降级链、网关失败落 UNAVAILABLE、
+- `DocInsightServiceTest`（38）：RUNNING 中间态（CountDownLatch）、单飞、企查查降级链、网关失败落 UNAVAILABLE、
   **平台档法宝四条通道全部走网关且一次法宝 MCP 都不打 / 网关失败仍 UNAVAILABLE / 本机没凭证说「未配置」不说「本次不可用」/
   上游明确回空 = NOT_FOUND 且按「跑完了」计进摘要**、
   法宝不可用不连坐、案例通道从「未配置」到「配上就接入」、**案号识别命中改用标题检索 / 识别失败静默走原路 /
   识别命中但全文失败仍 OK**、**引用校验三种判定 + 通道未配置整步跳过 + 通道报错不报发现 + 上限 30**、
   7 天缓存与 refresh 绕过、列表瘦身/发现不瘦身、**配置类失败带结构化 `retrievalHint`（未连接账户 / 余额不足 / 本机没凭据）
   且 note 不说「本次不可用」，瞬时失败不带原因码**、
-  读不出文字与辅助模型未配置 → FAILED、单块坏输出不炸整轮、鉴权与跨项目 IDOR。
+  读不出文字与辅助模型未配置 → FAILED、单块坏输出不炸整轮、鉴权与跨项目 IDOR、
+  **DOC（#541）：书名号分流（法规仍归 LAW）/ 相等·去序号前缀·去括号注记三种命中且 detail 带 fileId /
+  同名文件夹不算命中 → NOT_FOUND 且 note 不提重试 / 多处提到同一份文件合并成一条 /
+  重新检索是空操作、不把状态覆盖成 UNAVAILABLE**。
 - `DocInsightControllerTest`（6）：4010 信封、code=1、参数透传、响应形状、路由不互相吃。

--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -595,6 +595,23 @@ DdFilesPanel / ShareholderMeetingPanel。新面板照抄这套，不要再自定
   单测 `frontend/tests/tab-visibility/file-kind.test.mjs` 里那条「三处一一对上」的
   断言会拦下只改一头的改法（`npm run test:tab-visibility`）。
 
+## 非文件标签 `insight-entity`（dev-board#541）
+
+「依据」实体浮窗上的「在新标签页打开」会在中栏开一个实体详情标签：
+`tabType:'insight-entity'`、id `insight-entity_<kind>_<id>`、单例（跨两侧查重）、
+直接 push 进 `rightFiles` 绕过 `isFileTypeSupported`——与 `market-detail` / 浏览器 tab 同法，
+渲染分流在左右两条 `v-else-if` 链里各一份 `<InsightEntityDetailPane>`。
+
+两条与外壳有关的口径：
+- **未分屏时强制开分屏并落右侧**（`splitMode=true` + `focusedPane='right'`）。
+  这个动作的意义就是「正文与详情并排看」，开在左边会把用户正在读的那份文档顶掉。
+- `'insight-entity'` 必须进 `pages/project-overview/fileKind.js` 的 `NON_FILE_TAB_TYPES`，
+  否则标签会被按扩展名上色。
+
+开法本身外置在 `pages/project-overview/insightEntityTab.js`（方法组，同 tabDragSplit.js 的先例），
+单测 `frontend/tests/insight/insightEntityTab.test.mjs`（`npm run test:insight`）。
+浮窗本身**不是标签**：它挂在页面根节点、position:fixed 贴点击点，详见 doc-insight.md。
+
 ## 相关文件
 
 - `frontend/src/services/host.js` — **访问桌面壳能力的唯一出口**（浏览器面板/截图/剪贴板/组件下载/自动更新/本地文件对话框/应用菜单等）。业务代码一律 `import { host } from '@/services/host.js'`，**不要再写 `window.checkbaDesktop`**；「是不是桌面壳」用 `isDesktopHost()`。桌面态逐字段透传、Web 态缺席，所以既有的 `if (host.browser && ...)` 子对象守卫必须保留（守卫就是能力探测）。详见 doc-editor.md 的「宿主能力层与编辑器容器」。

--- a/backend/src/main/java/com/checkba/model/entity/DocInsightEntity.java
+++ b/backend/src/main/java/com/checkba/model/entity/DocInsightEntity.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 /**
- * 文档里抽出来的一个实体（企业 / 法规 / 案例）及其外部库检索结果（dev-board#182）。
+ * 文档里抽出来的一个实体（企业 / 法规 / 案例 / 本项目内的另一份文档）及其检索结果（dev-board#182、#541）。
  *
  * <p><b>检索状态五态</b>：PENDING（还没打上游）、OK（拿到结果）、NOT_FOUND（<b>查完了，上游明确说没有</b>——
  * 这是一次成功的检索，不是故障）、UNAVAILABLE（通道不可用——未配置、点数耗尽、网关未开放；
@@ -42,6 +42,12 @@ public class DocInsightEntity {
     public static final String KIND_COMPANY = "COMPANY";
     public static final String KIND_LAW = "LAW";
     public static final String KIND_CASE = "CASE";
+    /**
+     * 正文里用书名号提到的<b>本项目里的另一份文件</b>（dev-board#541）。
+     * 「检索」是与项目文件树比对，不打任何外部库：命中写 {@code retrievalJson.fileId} 供窗格直接打开，
+     * 没命中落 NOT_FOUND（「文档提到但项目里缺这份」——尽调里这本身就是一条线索，不是故障）。
+     */
+    public static final String KIND_DOC = "DOC";
 
     public static final String RETRIEVAL_PENDING = "PENDING";
     public static final String RETRIEVAL_OK = "OK";

--- a/backend/src/main/java/com/checkba/service/insight/DocInsightExtraction.java
+++ b/backend/src/main/java/com/checkba/service/insight/DocInsightExtraction.java
@@ -11,9 +11,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -200,15 +202,35 @@ final class DocInsightExtraction {
             "《([^《》]{2,60}?(?:法|条例|办法|规定|规则|细则|解释|准则|通知|意见|决定|批复|公告|标准|指引))》"
                     + "(?:\\s*第([一二三四五六七八九十百千零〇\\d]{1,10})条)?");
 
-    /** 正则能认的两类实体（案号、书名号法规）。企业名没有确定形状，只能靠模型。 */
+    /**
+     * 书名号里的其余标题（dev-board#541）：与 {@link #LAW_TITLE} <b>互补</b>——
+     * 同一个书名号只能落一类，法规体裁的先被 LAW_TITLE 吃掉，剩下的才当「文中提到的另一份文件」。
+     * 不限定尾字：文件名是用户起的，《房屋租赁合同》《尽调清单》《附件二》都可能真有对应文件。
+     */
+    static final Pattern DOC_TITLE = Pattern.compile("《([^《》]{2,60})》");
+
+    /**
+     * 正则能认的三类实体（案号、书名号法规、书名号文档）。企业名没有确定形状，只能靠模型。
+     *
+     * <p>DOC 这一类<b>只走正则、不进提示词</b>：书名号是确定形状，正则永远不漏也不编，
+     * 而让模型去猜「这是不是项目里的一份文件」既贵又不稳（判定要看项目文件树，模型看不到）。
+     */
     static List<RawEntity> scanDeterministic(String text) {
         List<RawEntity> out = new ArrayList<>();
         if (text == null || text.isEmpty()) return out;
 
+        // 法规先扫，记下这些书名号的起点：同一个书名号不许再被当成文档
+        Set<Integer> lawStarts = new HashSet<>();
         Matcher m = LAW_TITLE.matcher(text);
         while (m.find()) {
+            lawStarts.add(m.start());
             String article = m.group(2) == null ? null : "第" + m.group(2) + "条";
             out.add(law("《" + m.group(1) + "》", article, around(text, m.start(), m.end())));
+        }
+        m = DOC_TITLE.matcher(text);
+        while (m.find()) {
+            if (lawStarts.contains(m.start())) continue;
+            out.add(docRef(m.group(1), around(text, m.start(), m.end())));
         }
         m = CASE_NO.matcher(text);
         while (m.find()) {
@@ -245,6 +267,35 @@ final class DocInsightExtraction {
         String display = no.isEmpty() ? title.trim() : no;
         return new RawEntity(DocInsightEntity.KIND_CASE, display,
                 normalizeCaseNo(no.isEmpty() ? title : no), null, mentions(quote));
+    }
+
+    /** 文中提到的另一份文档。normKey 先按标题归一，命中项目文件后由服务层改写成 {@code file:<id>}。 */
+    static RawEntity docRef(String title, String quote) {
+        String t = stripBookMarks(title);
+        return new RawEntity(DocInsightEntity.KIND_DOC, t, normalizeDocTitle(t), null, mentions(quote));
+    }
+
+    /** 文件名里的扩展名（真实文件才有，正文里的书名号标题通常没有）。 */
+    private static final Pattern EXTENSION = Pattern.compile("\\.[A-Za-z0-9]{1,8}$");
+    /** 「04-」「三、」「1.」这类人肉序号前缀，文件树里满地都是，正文引用时一般不带。 */
+    private static final Pattern ORDER_PREFIX = Pattern.compile("^[\\d一二三四五六七八九十]+[-.、）)]\\s*");
+    /** 括号里多半是版本 / 日期 / 份数注记（「（2021）」「(终稿)」），两边都去掉才对得上。 */
+    private static final Pattern BRACKETED = Pattern.compile("[（(][^（()）]*[)）]");
+
+    /**
+     * 文档标题归一（dev-board#541）：去书名号 → 去括号注记 → 去扩展名 → 去序号前缀 →
+     * {@link EvidenceChecks#compact}（NFKC + 去空白 + 大写）。
+     *
+     * <p>正文写的《房屋租赁合同》与文件树里的「04-房屋租赁合同（2021）.docx」要归到同一把钥匙上，
+     * 所以两边用<b>同一个函数</b>。企业那套 {@code stripOrgSuffix} 不能复用：
+     * 文件名里的「协议」「合同」正是它的主干，剥掉就什么都不剩了。
+     */
+    static String normalizeDocTitle(String s) {
+        String t = stripBookMarks(s);
+        t = BRACKETED.matcher(t).replaceAll("");
+        t = EXTENSION.matcher(t.trim()).replaceAll("");
+        t = ORDER_PREFIX.matcher(t.trim()).replaceFirst("");
+        return EvidenceChecks.compact(t);
     }
 
     /**

--- a/backend/src/main/java/com/checkba/service/insight/DocInsightService.java
+++ b/backend/src/main/java/com/checkba/service/insight/DocInsightService.java
@@ -62,8 +62,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * 文档「解析」管线（dev-board#181 后端 / #182）：通读一份文档 →
- * 抽实体（企业 / 法规 / 案例）→ 逐个打外部库 → 同时做文档内部一致性校验。
+ * 文档「解析」管线（dev-board#181 后端 / #182 / #541）：通读一份文档 →
+ * 抽实体（企业 / 法规 / 案例 / 本项目内的另一份文档）→ 逐个打外部库 → 同时做文档内部一致性校验。
+ *
+ * <p>DOC 这一类不打外部库：它的「检索」是把正文里书名号提到的标题<b>对到项目文件树上</b>
+ * （{@link #resolveDocFiles}），命中就把 fileId 交给窗格去开那份文件。
  * 结果供前端「依据」窗格轮询展示。
  *
  * <h3>三条硬口径</h3>
@@ -119,6 +122,11 @@ public class DocInsightService {
     /** 内容定位候选的摘要上限与条数上限。 */
     private static final int CANDIDATE_SNIPPET_LIMIT = 200;
     private static final int MAX_CANDIDATES = 3;
+
+    /** DOC 实体命中项目文件后的归一键前缀（多处提到同一份文件合并成一条）。 */
+    private static final String FILE_KEY_PREFIX = "file:";
+    /** DOC 的检索来源：项目文件树，不是任何外部库。 */
+    private static final String DOC_SOURCE = "project-file";
 
     /** 「《公司法》第二十条」→ title=公司法, article=第二十条。 */
     private static final Pattern LAW_NAME = Pattern.compile("^《([^《》]+)》\\s*(.*)$");
@@ -230,7 +238,9 @@ public class DocInsightService {
             extract(runId, text, raw, claims, projectId, userId);
 
             List<RawEntity> merged = DocInsightExtraction.merge(raw, props.getMaxMentions(), props.getMaxEntities());
-            List<DocInsightEntity> rows = persistEntities(runId, projectId, file.getId(), merged);
+            DocResolved resolved = resolveDocFiles(projectId, merged);
+            List<DocInsightEntity> rows = persistEntities(runId, projectId, file.getId(),
+                    resolved.entities(), resolved.hits());
 
             Retrieved retrieved = retrieveAll(runId, rows);
             List<DocInsightChecks.Finding> citations = validateCitations(runId, rows);
@@ -287,8 +297,12 @@ public class DocInsightService {
         }
     }
 
+    /**
+     * @param docHits DOC 实体的归一键 → 命中的项目文件（{@link #resolveDocFiles}）。
+     *                DOC 的「检索」在这里就判完了：命中写 OK + fileId，没命中写 NOT_FOUND。
+     */
     private List<DocInsightEntity> persistEntities(Long runId, Long projectId, Long docFileId,
-                                                   List<RawEntity> merged) {
+                                                   List<RawEntity> merged, Map<String, ProjectFile> docHits) {
         List<DocInsightEntity> out = new ArrayList<>(merged.size());
         for (RawEntity e : merged) {
             DocInsightEntity row = new DocInsightEntity();
@@ -300,9 +314,91 @@ public class DocInsightService {
             row.setNormKey(e.normKey());
             row.setMentionsJson(mentionsJson(e.mentions()));
             row.setRetrievalStatus(DocInsightEntity.RETRIEVAL_PENDING);
+            if (DocInsightEntity.KIND_DOC.equals(e.kind())) settleDoc(row, docHits.get(e.normKey()));
             out.add(entities.save(row));
         }
         return out;
+    }
+
+    /** 一轮 DOC 归并的结果：改写过归一键的实体表 + 归一键 → 命中文件。 */
+    private record DocResolved(List<RawEntity> entities, Map<String, ProjectFile> hits) {}
+
+    /**
+     * 把书名号候选对到项目文件树上（dev-board#541）。
+     *
+     * <p>命中的实体归一键改写成 {@code file:<id>} 后<b>再合并一次</b>——正文里
+     * 《房屋租赁合同》与《房屋租赁合同（2021）》指的是同一份文件，窗格里该只出现一条。
+     * 没命中的保留原键，落 NOT_FOUND：「文档提到但项目里缺这份」对尽调本身就是一条线索。
+     */
+    private DocResolved resolveDocFiles(Long projectId, List<RawEntity> merged) {
+        boolean any = merged.stream().anyMatch(e -> DocInsightEntity.KIND_DOC.equals(e.kind()));
+        if (!any) return new DocResolved(merged, Map.of());
+
+        List<ProjectFile> candidates = files.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(projectId)
+                .stream().filter(f -> !Boolean.TRUE.equals(f.getIsFolder())).toList();
+        Map<String, ProjectFile> hits = new LinkedHashMap<>();
+        List<RawEntity> rewritten = new ArrayList<>(merged.size());
+        for (RawEntity e : merged) {
+            if (!DocInsightEntity.KIND_DOC.equals(e.kind())) {
+                rewritten.add(e);
+                continue;
+            }
+            ProjectFile hit = matchFile(e.normKey(), candidates);
+            if (hit == null) {
+                rewritten.add(e);
+                continue;
+            }
+            String key = FILE_KEY_PREFIX + hit.getId();
+            hits.put(key, hit);
+            rewritten.add(new RawEntity(e.kind(), e.name(), key, e.article(), e.mentions()));
+        }
+        return new DocResolved(
+                DocInsightExtraction.merge(rewritten, props.getMaxMentions(), props.getMaxEntities()), hits);
+    }
+
+    /**
+     * 归一后<b>相等优先、其次互相包含</b>；同档里取路径最短的那个（越靠近根目录越可能是正本）。
+     * 包含匹配两个方向都收：正文可能写得比文件名长（《北京房屋租赁合同》），也可能更短。
+     */
+    private static ProjectFile matchFile(String key, List<ProjectFile> candidates) {
+        if (!StringUtils.hasText(key) || key.length() < 2) return null;
+        ProjectFile exact = null;
+        ProjectFile loose = null;
+        for (ProjectFile f : candidates) {
+            String fk = DocInsightExtraction.normalizeDocTitle(f.getName());
+            if (fk.length() < 2) continue;
+            if (fk.equals(key)) exact = shorterPath(exact, f);
+            else if (fk.contains(key) || key.contains(fk)) loose = shorterPath(loose, f);
+        }
+        return exact != null ? exact : loose;
+    }
+
+    private static ProjectFile shorterPath(ProjectFile a, ProjectFile b) {
+        if (a == null) return b;
+        if (b == null) return a;
+        int la = a.getFilePath() == null ? Integer.MAX_VALUE : a.getFilePath().length();
+        int lb = b.getFilePath() == null ? Integer.MAX_VALUE : b.getFilePath().length();
+        if (la != lb) return la < lb ? a : b;
+        return b.getId() != null && a.getId() != null && b.getId() < a.getId() ? b : a;
+    }
+
+    /** DOC 的终态：命中 = OK + fileId（窗格据它直接打开那份文件），没命中 = NOT_FOUND。 */
+    private void settleDoc(DocInsightEntity row, ProjectFile hit) {
+        row.setFetchedAt(LocalDateTime.now());
+        if (hit == null) {
+            notFound(row, DOC_SOURCE, LangText.of("项目中未找到该文件", "No such file in this project"));
+            return;
+        }
+        ObjectNode out = om.createObjectNode();
+        out.put("source", DOC_SOURCE);
+        out.put("fileId", hit.getId());
+        out.put("fileName", hit.getName());
+        out.put("filePath", hit.getFilePath());
+        row.setRetrievalStatus(DocInsightEntity.RETRIEVAL_OK);
+        row.setRetrievalSource(DOC_SOURCE);
+        row.setRetrievalJson(writeJson(out));
+        row.setRetrievalNote(null);
+        row.setRetrievalHint(null);
     }
 
     /** 一轮检索的完成情况。NOT_FOUND 也算<b>跑完了</b>——上游明确回「没有这一项」，不是故障。 */
@@ -353,6 +449,11 @@ public class DocInsightService {
 
     /** @param force true = 绕过 7 天缓存（单实体「重新检索」用） */
     private void retrieveOne(DocInsightEntity row, boolean force) {
+        // DOC 的「检索」= 与项目文件树比对，在 persistEntities 里就判完了，这里整段跳过：
+        // ① 落到 default 会把已判好的 OK / NOT_FOUND 覆盖成 UNAVAILABLE；
+        // ② 走 7 天缓存会拿上一轮的结论盖掉「这份文件现在不在项目里了」。
+        // 「重新检索」对 DOC 同样是空操作（窗格也不给这个按钮：重试一百次还是同一句话）。
+        if (DocInsightEntity.KIND_DOC.equals(row.getKind())) return;
         row.setRetrievalHint(null);   // 上一轮的原因码不许挂到这一轮（重新检索 / 缓存复用都走这里）
         if (!force && copyFromCache(row)) return;
         row.setFetchedAt(LocalDateTime.now());

--- a/backend/src/test/java/com/checkba/service/insight/DocInsightServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/insight/DocInsightServiceTest.java
@@ -851,6 +851,137 @@ class DocInsightServiceTest {
         assertTrue(law.getRetrievalNote().contains("稍后重试"), law.getRetrievalNote());
     }
 
+    // ---------------------------------------------------------------- 文档实体（DOC，dev-board#541）
+
+    /** 五处书名号：四份指向项目文件（含一份只在文件夹上同名），一处是法规。 */
+    static final String DOC_TEXT = """
+            本次交易的租赁安排见《房屋租赁合同》，另见《北京房屋租赁合同》补充说明，
+            表决程序见《股东会决议》，核查范围见《尽职调查清单》。
+            法律依据为《中华人民共和国公司法》，另有《海外架构备忘录》一份。
+            """;
+
+    /**
+     * 项目文件树：三份能对上的文件（相等 / 带序号前缀 / 带括号注记），外加一个<b>同名文件夹</b>
+     * ——文件夹不算数，《海外架构备忘录》照样得落「项目里缺这份」。
+     */
+    private void stubDocProject() throws Exception {
+        when(docText.extractText(any())).thenReturn(DOC_TEXT);
+        when(model.generate(anyList())).thenReturn(modelReply("{}"));
+        when(files.findByProjectIdAndIsDeletedFalseOrderBySortOrderAsc(PID)).thenReturn(List.of(
+                projectFile(21L, "房屋租赁合同.docx", "/p/1/房屋租赁合同.docx", false),
+                projectFile(22L, "04-股东会决议.docx", "/p/1/04-股东会决议.docx", false),
+                projectFile(23L, "尽职调查清单（2021）.xlsx", "/p/1/尽职调查清单（2021）.xlsx", false),
+                projectFile(24L, "海外架构备忘录", null, true)));
+        stubPkulawUnavailable();
+    }
+
+    private static ProjectFile projectFile(Long id, String name, String path, boolean folder) {
+        ProjectFile f = new ProjectFile();
+        f.setId(id);
+        f.setProjectId(PID);
+        f.setName(name);
+        f.setFilePath(path);
+        f.setIsFolder(folder);
+        f.setIsDeleted(false);
+        return f;
+    }
+
+    private List<DocInsightEntity> docEntities() {
+        return entityStore.values().stream()
+                .filter(e -> DocInsightEntity.KIND_DOC.equals(e.getKind()))
+                .sorted(Comparator.comparing(DocInsightEntity::getId)).toList();
+    }
+
+    private DocInsightEntity docEntity(String normKey) {
+        return docEntities().stream().filter(e -> normKey.equals(e.getNormKey())).findFirst()
+                .orElseThrow(() -> new AssertionError("没有 normKey=" + normKey + " 的 DOC 实体，实到 "
+                        + docEntities().stream().map(DocInsightEntity::getNormKey).toList()));
+    }
+
+    @Test
+    @DisplayName("书名号分流：法规体裁仍归 LAW，其余书名号才当 DOC 候选")
+    void 书名号分流() throws Exception {
+        stubDocProject();
+        awaitStatus(svc.startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        assertEquals("《中华人民共和国公司法》", entityOf(DocInsightEntity.KIND_LAW).getName());
+        assertTrue(docEntities().stream().noneMatch(e -> e.getName().contains("公司法")),
+                "同一个书名号只能落一类，《公司法》不许再被当成项目文件");
+        assertTrue(docEntities().stream().anyMatch(e -> e.getName().contains("房屋租赁合同")),
+                "《房屋租赁合同》要抽成 DOC 候选");
+        assertEquals("海外架构备忘录", docEntity("海外架构备忘录").getName(),
+                "展示名是文中的写法，不带书名号");
+    }
+
+    @Test
+    @DisplayName("候选对上项目文件：相等 / 去序号前缀 / 去括号注记三种都命中，detail 带 fileId")
+    void 文档命中项目文件() throws Exception {
+        stubDocProject();
+        awaitStatus(svc.startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        for (long fileId : new long[]{21L, 22L, 23L}) {
+            DocInsightEntity row = docEntity("file:" + fileId);
+            assertEquals(DocInsightEntity.RETRIEVAL_OK, row.getRetrievalStatus(), "file:" + fileId);
+            assertEquals("project-file", row.getRetrievalSource());
+            assertNull(row.getRetrievalHint());
+            assertTrue(row.getRetrievalJson().contains("\"fileId\":" + fileId), row.getRetrievalJson());
+        }
+        assertTrue(docEntity("file:22").getRetrievalJson().contains("04-股东会决议.docx"),
+                "detail 要带真实文件名，窗格照它显示");
+
+        EntityView view = svc.latest(UID, PID, DOC).entities().stream()
+                .filter(e -> "file:21".equals(e.normKey())).findFirst().orElseThrow();
+        assertTrue(view.hasDetail(), "命中的 DOC 行必须 hasDetail=true，前端才会去拿 fileId");
+        assertNull(view.detail(), "列表照旧瘦身");
+        assertNotNull(svc.entityDetail(UID, PID, view.id()).detail().get("fileId"));
+    }
+
+    @Test
+    @DisplayName("项目里没有对应文件（同名文件夹不算）：落 NOT_FOUND，不带原因码也不提重试")
+    void 文档未命中() throws Exception {
+        stubDocProject();
+        awaitStatus(svc.startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        DocInsightEntity miss = docEntity("海外架构备忘录");
+        assertEquals(DocInsightEntity.RETRIEVAL_NOT_FOUND, miss.getRetrievalStatus(),
+                "文档提到但项目里缺这份，是文档的线索不是通道故障");
+        assertTrue(miss.getRetrievalNote().contains("项目中未找到该文件"), miss.getRetrievalNote());
+        assertNull(miss.getRetrievalHint());
+        assertFalse(miss.getRetrievalNote().contains("重试"), miss.getRetrievalNote());
+        assertNull(miss.getRetrievalJson());
+    }
+
+    @Test
+    @DisplayName("多处提到同一份文件合并成一个实体，出处累加")
+    void 同一文件多处提及合并() throws Exception {
+        stubDocProject();
+        awaitStatus(svc.startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        assertEquals(4, docEntities().size(),
+                "《房屋租赁合同》与《北京房屋租赁合同》指的是同一份文件，窗格里只该有一条：实到 "
+                        + docEntities().stream().map(DocInsightEntity::getNormKey).toList());
+        DocInsightEntity row = docEntity("file:21");
+        assertTrue(row.getMentionsJson().contains("北京房屋租赁合同"), row.getMentionsJson());
+        assertTrue(row.getMentionsJson().contains("本次交易的租赁安排见"), row.getMentionsJson());
+    }
+
+    @Test
+    @DisplayName("重新检索对 DOC 是空操作：不打外部库，也不把已判好的状态覆盖成 UNAVAILABLE")
+    void 重新检索不覆盖文档状态() throws Exception {
+        stubDocProject();
+        awaitStatus(svc.startParse(UID, PID, DOC).runId(), DocInsightRun.STATUS_DONE);
+
+        EntityView hit = svc.refreshEntity(UID, PID, docEntity("file:21").getId());
+        assertEquals(DocInsightEntity.RETRIEVAL_OK, hit.retrievalStatus());
+        assertEquals(21, hit.detail().get("fileId").asLong());
+
+        EntityView miss = svc.refreshEntity(UID, PID, docEntity("海外架构备忘录").getId());
+        assertEquals(DocInsightEntity.RETRIEVAL_NOT_FOUND, miss.retrievalStatus(),
+                "落到 default 分支会说成「未知实体类型 / 本次不可用」——那是给用户的假故障");
+        assertTrue(miss.retrievalNote().contains("项目中未找到该文件"), miss.retrievalNote());
+        verify(qichacha, never()).queryEciInfoJson(startsWith("海外"));
+    }
+
     /** 法规实体的 REST 视图（原因码是给前端的契约，只断言实体字段不够）。 */
     private EntityView lawView() {
         return svc.latest(UID, PID, DOC).entities().stream()

--- a/frontend/src/components/InsightEntityBody.vue
+++ b/frontend/src/components/InsightEntityBody.vue
@@ -35,6 +35,15 @@
       </template>
     </template>
 
+    <!-- 文档：项目文件树里命中的那份文件（dev-board#541） -->
+    <template v-else-if="kind === 'DOC'">
+      <template v-if="doc">
+        <text class="ieb-title">{{ doc.fileName }}</text>
+        <text v-if="doc.filePath" class="ieb-meta">{{ doc.filePath }}</text>
+        <text class="ieb-link" @tap.stop="openDoc">{{ $t('insight.openDocFile') }}</text>
+      </template>
+    </template>
+
     <!-- 案例：案号识别（先导步）+ 判决书 -->
     <template v-else>
       <template v-if="rec">
@@ -57,7 +66,7 @@
 
     <!-- 认得的字段一个都没渲染出来时才亮原文兜底（不是每次都把 JSON 铺一遍） -->
     <text v-if="showRaw" class="ieb-raw">{{ raw }}</text>
-    <text v-if="empty" class="ieb-hint">{{ $t('insight.noDetail') }}</text>
+    <text v-if="empty" class="ieb-hint">{{ kind === 'DOC' ? $t('insight.docNotFound') : $t('insight.noDetail') }}</text>
   </view>
 </template>
 
@@ -73,7 +82,7 @@
 
 import {
   companyRows, companyShareholders, lawArticle, caseRecord, rawFallback,
-  authoritative, caseRecognition,
+  authoritative, caseRecognition, projectFile,
 } from '@/utils/insightDetail.js'
 
 // 浮窗里一段正文的字数上限：再长就该去新标签页看了。
@@ -84,7 +93,8 @@ const COMPACT_SHAREHOLDERS = 3
 
 export default {
   name: 'InsightEntityBody',
-  emits: ['open-url'],
+  // open-doc-file：DOC 实体命中的项目文件，一路上抛到宿主在右侧分屏打开。
+  emits: ['open-url', 'open-doc-file'],
   props: {
     entity: { type: Object, default: null },
     detail: { type: Object, default: null },
@@ -93,7 +103,7 @@ export default {
   computed: {
     kind() {
       const k = this.entity && this.entity.kind
-      return k === 'LAW' || k === 'CASE' ? k : 'COMPANY'
+      return k === 'LAW' || k === 'CASE' || k === 'DOC' ? k : 'COMPANY'
     },
     rows() {
       const all = companyRows(this.detail)
@@ -104,6 +114,7 @@ export default {
       return this.compact ? all.slice(0, COMPACT_SHAREHOLDERS) : all
     },
     law() { return lawArticle(this.detail) },
+    doc() { return projectFile(this.detail) },
     auth() { return authoritative(this.detail) },
     caseRec() { return caseRecord(this.detail) },
     rec() { return caseRecognition(this.detail) },
@@ -124,6 +135,7 @@ export default {
       if (this.compact) return false      // 浮窗不铺原始 JSON，看不懂也占满整张卡
       if (this.kind === 'COMPANY') return !companyRows(this.detail).length
       if (this.kind === 'LAW') return !this.law.title && !this.law.content && !this.auth
+      if (this.kind === 'DOC') return !this.doc
       return !this.caseRec.title && !this.caseRec.sections.length && !this.rec
     },
     raw() { return rawFallback(this.detail) },
@@ -141,6 +153,10 @@ export default {
     openUrl(url) {
       const u = url == null ? '' : String(url)
       if (u) this.$emit('open-url', u)
+    },
+    openDoc() {
+      const d = this.doc
+      if (d) this.$emit('open-doc-file', { fileId: d.fileId, fileName: d.fileName })
     },
   },
 }

--- a/frontend/src/components/InsightEntityBody.vue
+++ b/frontend/src/components/InsightEntityBody.vue
@@ -1,0 +1,171 @@
+<!-- SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<template>
+  <view class="ieb" :class="{ compact }">
+    <!-- 企业：工商基本情况表（键值两列） -->
+    <template v-if="kind === 'COMPANY'">
+      <view v-for="r in rows" :key="r.label" class="ieb-kv">
+        <text class="ieb-k">{{ r.label }}</text>
+        <text class="ieb-v">{{ r.value }}</text>
+      </view>
+      <template v-if="shareholders.length">
+        <text class="ieb-sub">{{ $t('insight.shareholders') }}</text>
+        <view v-for="(s, si) in shareholders" :key="'sh' + si" class="ieb-kv">
+          <text class="ieb-k">{{ s.name }}</text>
+          <text class="ieb-v">{{ [s.percent, s.capital].filter(Boolean).join(' / ') }}</text>
+        </view>
+      </template>
+    </template>
+
+    <!-- 法规：条文原文 + 引用校验回填的权威原文 -->
+    <template v-else-if="kind === 'LAW'">
+      <text v-if="law.title" class="ieb-title">{{ law.title }}{{ law.article }}</text>
+      <text v-if="law.timeliness" class="ieb-meta">{{ law.timeliness }}</text>
+      <text v-if="law.content" class="ieb-para">{{ clip(law.content) }}</text>
+      <template v-if="!compact && law.more.length">
+        <text class="ieb-sub">{{ $t('insight.moreCandidates') }}</text>
+        <text v-for="(m, mi) in law.more" :key="'lm' + mi" class="ieb-cand">{{ m }}</text>
+      </template>
+      <template v-if="auth">
+        <text class="ieb-sub">{{ $t('insight.authoritative') }}</text>
+        <text v-if="auth.title" class="ieb-title">{{ auth.title }}</text>
+        <text v-if="auth.date" class="ieb-meta">{{ $t('insight.implementDate', { date: auth.date }) }}</text>
+        <text v-if="auth.text" class="ieb-para">{{ clip(auth.text) }}</text>
+        <text v-if="auth.url" class="ieb-link" @tap.stop="openUrl(auth.url)">{{ $t('insight.openInPkulaw') }}</text>
+      </template>
+    </template>
+
+    <!-- 案例：案号识别（先导步）+ 判决书 -->
+    <template v-else>
+      <template v-if="rec">
+        <text class="ieb-sub">{{ $t('insight.recognition') }}</text>
+        <text v-if="rec.title" class="ieb-title">{{ rec.title }}</text>
+        <text v-if="recMeta" class="ieb-meta">{{ recMeta }}</text>
+        <text v-if="rec.url" class="ieb-link" @tap.stop="openUrl(rec.url)">{{ $t('insight.openInPkulaw') }}</text>
+      </template>
+      <text v-if="caseRec.title" class="ieb-title">{{ caseRec.title }}</text>
+      <text v-if="caseMeta" class="ieb-meta">{{ caseMeta }}</text>
+      <view v-for="s in sections" :key="s.key" class="ieb-block">
+        <text class="ieb-sub">{{ $t('insight.caseSection.' + s.key) }}</text>
+        <text class="ieb-para">{{ clip(s.text) }}</text>
+      </view>
+      <template v-if="!compact && caseRec.more.length">
+        <text class="ieb-sub">{{ $t('insight.moreCandidates') }}</text>
+        <text v-for="(m, mi) in caseRec.more" :key="'cm' + mi" class="ieb-cand">{{ m }}</text>
+      </template>
+    </template>
+
+    <!-- 认得的字段一个都没渲染出来时才亮原文兜底（不是每次都把 JSON 铺一遍） -->
+    <text v-if="showRaw" class="ieb-raw">{{ raw }}</text>
+    <text v-if="empty" class="ieb-hint">{{ $t('insight.noDetail') }}</text>
+  </view>
+</template>
+
+<script>
+// InsightEntityBody.vue — 一个实体的检索详情正文（dev-board#541）。
+//
+// 浮窗（InsightHoverCard）与新标签页（InsightEntityDetailPane）共用这一份渲染，
+// 免掉两套字段解析：字段整形全部来自 utils/insightDetail.js 的纯函数，
+// 这里只管「怎么摆」。compact = 浮窗档：截断长正文、不列其余候选。
+//
+// 与 InsightPane 内联的那份详情块的关系：形制一致但**不复用**——那边嵌在
+// 可展开行里、还带出处定位，把它抽出来会把面板的滚动/展开逻辑一起拖进来。
+
+import {
+  companyRows, companyShareholders, lawArticle, caseRecord, rawFallback,
+  authoritative, caseRecognition,
+} from '@/utils/insightDetail.js'
+
+// 浮窗里一段正文的字数上限：再长就该去新标签页看了。
+const COMPACT_CHARS = 220
+// 浮窗里最多列几行工商字段 / 几个股东。
+const COMPACT_ROWS = 6
+const COMPACT_SHAREHOLDERS = 3
+
+export default {
+  name: 'InsightEntityBody',
+  emits: ['open-url'],
+  props: {
+    entity: { type: Object, default: null },
+    detail: { type: Object, default: null },
+    compact: { type: Boolean, default: false },
+  },
+  computed: {
+    kind() {
+      const k = this.entity && this.entity.kind
+      return k === 'LAW' || k === 'CASE' ? k : 'COMPANY'
+    },
+    rows() {
+      const all = companyRows(this.detail)
+      return this.compact ? all.slice(0, COMPACT_ROWS) : all
+    },
+    shareholders() {
+      const all = companyShareholders(this.detail)
+      return this.compact ? all.slice(0, COMPACT_SHAREHOLDERS) : all
+    },
+    law() { return lawArticle(this.detail) },
+    auth() { return authoritative(this.detail) },
+    caseRec() { return caseRecord(this.detail) },
+    rec() { return caseRecognition(this.detail) },
+    recMeta() {
+      const r = this.rec
+      return r ? [r.caseNumber, r.court].filter(Boolean).join(' · ') : ''
+    },
+    caseMeta() {
+      const c = this.caseRec
+      return [c.caseNumber, c.court, c.date, c.caseType].filter(Boolean).join(' · ')
+    },
+    sections() {
+      const all = this.caseRec.sections
+      return this.compact ? all.slice(0, 1) : all
+    },
+    showRaw() {
+      if (!this.detail) return false
+      if (this.compact) return false      // 浮窗不铺原始 JSON，看不懂也占满整张卡
+      if (this.kind === 'COMPANY') return !companyRows(this.detail).length
+      if (this.kind === 'LAW') return !this.law.title && !this.law.content && !this.auth
+      return !this.caseRec.title && !this.caseRec.sections.length && !this.rec
+    },
+    raw() { return rawFallback(this.detail) },
+    empty() {
+      if (this.detail) return false
+      return true
+    },
+  },
+  methods: {
+    clip(text) {
+      const s = text == null ? '' : String(text)
+      if (!this.compact || s.length <= COMPACT_CHARS) return s
+      return s.slice(0, COMPACT_CHARS) + '…'
+    },
+    openUrl(url) {
+      const u = url == null ? '' : String(url)
+      if (u) this.$emit('open-url', u)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+// 浅色外壳 + --awd- 令牌（配色红线：不引入深色 chrome）。
+.ieb { display: flex; flex-direction: column; gap: 4px; }
+
+.ieb-kv { display: flex; gap: 8px; align-items: flex-start; }
+.ieb-k { flex: none; width: 78px; font-size: 11px; color: var(--awd-text-3); line-height: 1.6; }
+.ieb-v { flex: 1; min-width: 0; font-size: 11px; color: var(--awd-text); line-height: 1.6; word-break: break-all; }
+
+.ieb-sub { margin-top: 4px; font-size: 10px; font-weight: 700; color: var(--awd-text-3); }
+.ieb-title { font-size: 12px; font-weight: 600; color: var(--awd-text); line-height: 1.5; }
+.ieb-meta { font-size: 10px; color: var(--awd-text-3); line-height: 1.5; }
+.ieb-para { font-size: 11px; color: var(--awd-text-2); line-height: 1.7; white-space: pre-wrap; }
+.ieb-cand { font-size: 11px; color: var(--awd-text-2); line-height: 1.6; }
+.ieb-block { display: flex; flex-direction: column; gap: 2px; margin-top: 4px; }
+.ieb-link { align-self: flex-start; font-size: 11px; color: var(--awd-accent-text); text-decoration: underline; }
+.ieb-raw {
+  margin-top: 4px; padding: 6px; border-radius: 6px; background: var(--awd-surface-2);
+  font-size: 10px; color: var(--awd-text-3); line-height: 1.5; white-space: pre-wrap; word-break: break-all;
+}
+.ieb-hint { font-size: 11px; color: var(--awd-text-3); }
+
+.ieb.compact .ieb-para { max-height: 132px; overflow: hidden; }
+</style>

--- a/frontend/src/components/InsightEntityBody.vue
+++ b/frontend/src/components/InsightEntityBody.vue
@@ -40,7 +40,8 @@
       <template v-if="doc">
         <text class="ieb-title">{{ doc.fileName }}</text>
         <text v-if="doc.filePath" class="ieb-meta">{{ doc.filePath }}</text>
-        <text class="ieb-link" @tap.stop="openDoc">{{ $t('insight.openDocFile') }}</text>
+        <!-- 浮窗（compact）自己的底栏已有「打开文件」，这里不再重复一个入口 -->
+        <text v-if="!compact" class="ieb-link" @tap.stop="openDoc">{{ $t('insight.openDocFile') }}</text>
       </template>
     </template>
 
@@ -66,7 +67,8 @@
 
     <!-- 认得的字段一个都没渲染出来时才亮原文兜底（不是每次都把 JSON 铺一遍） -->
     <text v-if="showRaw" class="ieb-raw">{{ raw }}</text>
-    <text v-if="empty" class="ieb-hint">{{ kind === 'DOC' ? $t('insight.docNotFound') : $t('insight.noDetail') }}</text>
+    <!-- DOC 未命中在浮窗里由头部 retrievalNote 说明，compact 档不再重复一句 -->
+    <text v-if="empty && !(compact && kind === 'DOC')" class="ieb-hint">{{ kind === 'DOC' ? $t('insight.docNotFound') : $t('insight.noDetail') }}</text>
   </view>
 </template>
 

--- a/frontend/src/components/InsightEntityDetailPane.vue
+++ b/frontend/src/components/InsightEntityDetailPane.vue
@@ -20,6 +20,7 @@
         :entity="entity"
         :detail="detail"
         @open-url="$emit('open-url', $event)"
+        @open-doc-file="$emit('open-doc-file', $event)"
       />
 
       <template v-if="mentions.length">
@@ -50,7 +51,7 @@ function unwrap(resp) {
 export default {
   name: 'InsightEntityDetailPane',
   components: { InsightEntityBody },
-  emits: ['open-url'],
+  emits: ['open-url', 'open-doc-file'],
   props: {
     // { entity, detail } —— 标签页建出来时宿主塞进去的那份（detail 可能已经拉好了）
     spec: { type: Object, default: null },
@@ -71,7 +72,7 @@ export default {
     entity() { return Object.assign({}, (this.spec && this.spec.entity) || {}, this.view || {}) },
     kind() {
       const k = this.entity.kind
-      return k === 'LAW' || k === 'CASE' ? k : 'COMPANY'
+      return k === 'LAW' || k === 'CASE' || k === 'DOC' ? k : 'COMPANY'
     },
     mentions() {
       const m = this.entity.mentions

--- a/frontend/src/components/InsightEntityDetailPane.vue
+++ b/frontend/src/components/InsightEntityDetailPane.vue
@@ -9,7 +9,7 @@
       </view>
       <view class="iedp-status">
         <view class="iedp-dot" :class="'st-' + (entity.retrievalStatus || 'PENDING')"></view>
-        <text v-if="entity.retrievalSource" class="iedp-src">{{ entity.retrievalSource }}</text>
+        <text v-if="entity.retrievalSource" class="iedp-src">{{ sourceLabel }}</text>
       </view>
       <text v-if="entity.retrievalNote" class="iedp-note" :class="'st-' + (entity.retrievalStatus || 'PENDING')">{{ entity.retrievalNote }}</text>
 
@@ -42,6 +42,7 @@
 
 import InsightEntityBody from '@/components/InsightEntityBody.vue'
 import { getDocInsightEntity } from '@/services/api.js'
+import { retrievalSourceKey } from '@/utils/insightDetail.js'
 
 function unwrap(resp) {
   if (resp && typeof resp === 'object' && 'code' in resp && 'data' in resp) return resp.data
@@ -69,6 +70,12 @@ export default {
     }
   },
   computed: {
+    sourceLabel() {
+      const s = this.entity && this.entity.retrievalSource
+      if (!s) return ''
+      const k = retrievalSourceKey(s)
+      return k ? this.$t(k) : String(s)
+    },
     entity() { return Object.assign({}, (this.spec && this.spec.entity) || {}, this.view || {}) },
     kind() {
       const k = this.entity.kind

--- a/frontend/src/components/InsightEntityDetailPane.vue
+++ b/frontend/src/components/InsightEntityDetailPane.vue
@@ -1,0 +1,130 @@
+<!-- SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<template>
+  <scroll-view class="iedp" scroll-y>
+    <view class="iedp-inner">
+      <view class="iedp-head">
+        <text class="iedp-badge" :class="'k-' + kind">{{ $t('insight.entityKind.' + kind) }}</text>
+        <text class="iedp-name">{{ entity.name }}</text>
+      </view>
+      <view class="iedp-status">
+        <view class="iedp-dot" :class="'st-' + (entity.retrievalStatus || 'PENDING')"></view>
+        <text v-if="entity.retrievalSource" class="iedp-src">{{ entity.retrievalSource }}</text>
+      </view>
+      <text v-if="entity.retrievalNote" class="iedp-note" :class="'st-' + (entity.retrievalStatus || 'PENDING')">{{ entity.retrievalNote }}</text>
+
+      <text v-if="err" class="iedp-err">{{ err }}</text>
+      <text v-else-if="loading" class="iedp-hint">{{ $t('insight.loadingDetail') }}</text>
+      <InsightEntityBody
+        v-else
+        :entity="entity"
+        :detail="detail"
+        @open-url="$emit('open-url', $event)"
+      />
+
+      <template v-if="mentions.length">
+        <text class="iedp-sub">{{ $t('insight.mentionsTitle') }}</text>
+        <text v-for="(m, mi) in mentions" :key="'mn' + mi" class="iedp-quote">{{ m.quote }}</text>
+      </template>
+    </view>
+  </scroll-view>
+</template>
+
+<script>
+// InsightEntityDetailPane.vue — 一个实体的完整详情，作为中栏标签页（dev-board#541）。
+//
+// 由浮窗上的「在新标签页打开」开出来（宿主 openInsightEntityTab，tabType 'insight-entity'，
+// 强制落在右侧分屏）。正文渲染与浮窗共用 InsightEntityBody，这里只多出「文中出处」一段。
+//
+// 出处在这里**只列不定位**：定位要 LibreOffice executor，而标签页与哪份文档并列
+// 是用户拖出来的，绑不住一个确定的编辑器实例——定位仍走「依据」窗格那一条路。
+
+import InsightEntityBody from '@/components/InsightEntityBody.vue'
+import { getDocInsightEntity } from '@/services/api.js'
+
+function unwrap(resp) {
+  if (resp && typeof resp === 'object' && 'code' in resp && 'data' in resp) return resp.data
+  return resp
+}
+
+export default {
+  name: 'InsightEntityDetailPane',
+  components: { InsightEntityBody },
+  emits: ['open-url'],
+  props: {
+    // { entity, detail } —— 标签页建出来时宿主塞进去的那份（detail 可能已经拉好了）
+    spec: { type: Object, default: null },
+    projectId: { type: [Number, String], default: null },
+  },
+  data() {
+    return {
+      // spec.detail 是浮窗已经拉到的那份（有就先画上，免得开标签闪一下空白）
+      detail: (this.spec && this.spec.detail) || null,
+      // GET /entities/{id} 的完整 EntityView：出处（mentions）与最新的检索状态在这里，
+      // 宿主传下来的 entity 是瘦身索引，没有这些。
+      view: null,
+      loading: false,
+      err: '',
+    }
+  },
+  computed: {
+    entity() { return Object.assign({}, (this.spec && this.spec.entity) || {}, this.view || {}) },
+    kind() {
+      const k = this.entity.kind
+      return k === 'LAW' || k === 'CASE' ? k : 'COMPANY'
+    },
+    mentions() {
+      const m = this.entity.mentions
+      return Array.isArray(m) ? m.filter((x) => x && x.quote) : []
+    },
+  },
+  mounted() { this.loadView() },
+  methods: {
+    async loadView() {
+      const pid = Number(this.projectId) || null
+      const id = this.entity.id
+      if (!pid || !id) return
+      this.loading = !this.detail
+      try {
+        const v = unwrap(await getDocInsightEntity(pid, id)) || {}
+        this.view = v
+        if (v.detail) this.detail = v.detail
+      } catch (err) {
+        if (!this.detail) this.err = (err && err.message) || this.$t('insight.detailFailed')
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.iedp { height: 100%; background: var(--awd-surface); }
+.iedp-inner { display: flex; flex-direction: column; gap: 6px; padding: 14px 18px 24px; max-width: 720px; }
+
+.iedp-head { display: flex; align-items: center; gap: 8px; }
+.iedp-badge {
+  flex: none; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 600;
+  color: var(--awd-accent-text); background: var(--awd-accent-soft); border: 1px solid var(--awd-mint);
+}
+.iedp-name { flex: 1; min-width: 0; font-size: 15px; font-weight: 600; color: var(--awd-text); }
+
+.iedp-status { display: flex; align-items: center; gap: 6px; }
+.iedp-dot { flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--awd-border-strong); }
+.iedp-dot.st-OK { background: var(--awd-mint); }
+.iedp-dot.st-NOT_FOUND { background: var(--awd-text-3); }
+.iedp-dot.st-UNAVAILABLE, .iedp-dot.st-ERROR { background: var(--awd-danger); }
+.iedp-src { font-size: 11px; color: var(--awd-text-3); }
+
+.iedp-note { font-size: 12px; line-height: 1.6; color: var(--awd-danger-text); }
+.iedp-note.st-NOT_FOUND { color: var(--awd-text-3); }
+.iedp-err { font-size: 12px; color: var(--awd-danger-text); }
+.iedp-hint { font-size: 12px; color: var(--awd-text-3); }
+
+.iedp-sub { margin-top: 10px; font-size: 11px; font-weight: 700; color: var(--awd-text-3); }
+.iedp-quote {
+  padding: 6px 8px; border-radius: 6px; background: var(--awd-surface-2);
+  font-size: 12px; color: var(--awd-text-2); line-height: 1.6;
+}
+</style>

--- a/frontend/src/components/InsightHoverCard.vue
+++ b/frontend/src/components/InsightHoverCard.vue
@@ -29,11 +29,15 @@
           :detail="detail"
           compact
           @open-url="$emit('open-url', $event)"
+          @open-doc-file="openDoc"
         />
       </scroll-view>
 
-      <view class="ihc-foot">
-        <text class="ihc-open" @tap.stop="openTab">{{ $t('insight.openInNewTab') }}</text>
+      <!-- DOC 的主动作是「打开文件」（详情标签对它没有意义，打开文件本身就落在右侧分屏）；
+           项目里没有这份文件时一个按钮都不给。 -->
+      <view v-if="showFoot" class="ihc-foot">
+        <text v-if="kind === 'DOC'" class="ihc-open" @tap.stop="openDoc">{{ $t('insight.openDocFile') }}</text>
+        <text v-else class="ihc-open" @tap.stop="openTab">{{ $t('insight.openInNewTab') }}</text>
       </view>
     </view>
   </view>
@@ -51,6 +55,7 @@
 
 import InsightEntityBody from '@/components/InsightEntityBody.vue'
 import { getDocInsightEntity } from '@/services/api.js'
+import { projectFile } from '@/utils/insightDetail.js'
 import { hoverCardPosition } from '@/utils/insightPopup.js'
 
 const CARD_W = 320
@@ -67,7 +72,8 @@ export default {
   // open-tab：底部「在新标签页打开」，宿主据此在右侧分屏开一个 insight-entity 标签。
   //           带上已经拉到的 detail，新标签页就不必再打一次接口。
   // open-url：法宝外链交给宿主的浏览器面板（面板自己不 window.open）。
-  emits: ['close', 'open-tab', 'open-url'],
+  // open-doc-file：DOC 实体命中的项目文件（宿主在右侧分屏打开那份文件本身）。
+  emits: ['close', 'open-tab', 'open-url', 'open-doc-file'],
   props: {
     entity: { type: Object, required: true },
     // 宿主换算好的页面坐标（客体页 clientX/clientY + webview rect）
@@ -88,8 +94,11 @@ export default {
   computed: {
     kind() {
       const k = this.entity && this.entity.kind
-      return k === 'LAW' || k === 'CASE' ? k : 'COMPANY'
+      return k === 'LAW' || k === 'CASE' || k === 'DOC' ? k : 'COMPANY'
     },
+    doc() { return projectFile(this.detail) },
+    /** DOC 没命中项目文件时底栏整条不出：没有一个走得通的动作可给。 */
+    showFoot() { return this.kind !== 'DOC' || !!this.doc },
     pos() {
       return hoverCardPosition({
         x: this.x,
@@ -113,6 +122,10 @@ export default {
   methods: {
     close() { this.$emit('close') },
     openTab() { this.$emit('open-tab', { entity: this.entity, detail: this.detail }) },
+    openDoc() {
+      const d = this.doc
+      if (d) this.$emit('open-doc-file', { fileId: d.fileId, fileName: d.fileName })
+    },
     /** 真实高度量出来再定位一次：翻转判据要用真高度，不然靠近底边时会露出屏幕外。 */
     measure() {
       this.$nextTick(() => {

--- a/frontend/src/components/InsightHoverCard.vue
+++ b/frontend/src/components/InsightHoverCard.vue
@@ -16,7 +16,7 @@
 
       <view class="ihc-status">
         <view class="ihc-dot" :class="'st-' + (entity.retrievalStatus || 'PENDING')"></view>
-        <text v-if="entity.retrievalSource" class="ihc-src">{{ entity.retrievalSource }}</text>
+        <text v-if="entity.retrievalSource" class="ihc-src">{{ sourceLabel }}</text>
       </view>
       <text v-if="entity.retrievalNote" class="ihc-note" :class="'st-' + (entity.retrievalStatus || 'PENDING')">{{ entity.retrievalNote }}</text>
 
@@ -55,7 +55,7 @@
 
 import InsightEntityBody from '@/components/InsightEntityBody.vue'
 import { getDocInsightEntity } from '@/services/api.js'
-import { projectFile } from '@/utils/insightDetail.js'
+import { projectFile, retrievalSourceKey } from '@/utils/insightDetail.js'
 import { hoverCardPosition } from '@/utils/insightPopup.js'
 
 const CARD_W = 320
@@ -92,6 +92,12 @@ export default {
     }
   },
   computed: {
+    sourceLabel() {
+      const s = this.entity && this.entity.retrievalSource
+      if (!s) return ''
+      const k = retrievalSourceKey(s)
+      return k ? this.$t(k) : String(s)
+    },
     kind() {
       const k = this.entity && this.entity.kind
       return k === 'LAW' || k === 'CASE' || k === 'DOC' ? k : 'COMPANY'

--- a/frontend/src/components/InsightHoverCard.vue
+++ b/frontend/src/components/InsightHoverCard.vue
@@ -1,0 +1,200 @@
+<!-- SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<template>
+  <view class="ihc-mask" @tap="close" @contextmenu.prevent="close">
+    <view
+      ref="card"
+      class="ihc"
+      :style="{ left: pos.left + 'px', top: pos.top + 'px' }"
+      @tap.stop
+    >
+      <view class="ihc-head">
+        <text class="ihc-badge" :class="'k-' + kind">{{ $t('insight.entityKind.' + kind) }}</text>
+        <text class="ihc-name" :title="entity.name || ''">{{ entity.name }}</text>
+        <text class="ihc-x" @tap.stop="close">×</text>
+      </view>
+
+      <view class="ihc-status">
+        <view class="ihc-dot" :class="'st-' + (entity.retrievalStatus || 'PENDING')"></view>
+        <text v-if="entity.retrievalSource" class="ihc-src">{{ entity.retrievalSource }}</text>
+      </view>
+      <text v-if="entity.retrievalNote" class="ihc-note" :class="'st-' + (entity.retrievalStatus || 'PENDING')">{{ entity.retrievalNote }}</text>
+
+      <scroll-view class="ihc-body" scroll-y>
+        <text v-if="err" class="ihc-err">{{ err }}</text>
+        <text v-else-if="loading" class="ihc-hint">{{ $t('insight.loadingDetail') }}</text>
+        <InsightEntityBody
+          v-else
+          :entity="entity"
+          :detail="detail"
+          compact
+          @open-url="$emit('open-url', $event)"
+        />
+      </scroll-view>
+
+      <view class="ihc-foot">
+        <text class="ihc-open" @tap.stop="openTab">{{ $t('insight.openInNewTab') }}</text>
+      </view>
+    </view>
+  </view>
+</template>
+
+<script>
+// InsightHoverCard.vue — 正文里 Cmd/Ctrl 点中一个实体后贴着点击处弹出的浮窗（dev-board#541）。
+//
+// 骨架照 FileTree.vue 的右键菜单（全屏透明 mask + position:fixed 卡片 + 高 z-index）：
+// 编辑器画布是 <webview>（桌面壳）/ 同源 <iframe>（Web 版），浮层必须挂在宿主根节点
+// 才叠得上去，所以本组件由 project-overview.vue 在根级渲染，不挂在面板里。
+//
+// 内容渲染复用 InsightEntityBody（与新标签页同一份），字段整形复用 utils/insightDetail.js。
+// 落点坐标由 utils/insightPopup.js 的纯函数算（靠边翻转、始终不出屏）。
+
+import InsightEntityBody from '@/components/InsightEntityBody.vue'
+import { getDocInsightEntity } from '@/services/api.js'
+import { hoverCardPosition } from '@/utils/insightPopup.js'
+
+const CARD_W = 320
+const CARD_H_FALLBACK = 240
+
+function unwrap(resp) {
+  if (resp && typeof resp === 'object' && 'code' in resp && 'data' in resp) return resp.data
+  return resp
+}
+
+export default {
+  name: 'InsightHoverCard',
+  components: { InsightEntityBody },
+  // open-tab：底部「在新标签页打开」，宿主据此在右侧分屏开一个 insight-entity 标签。
+  //           带上已经拉到的 detail，新标签页就不必再打一次接口。
+  // open-url：法宝外链交给宿主的浏览器面板（面板自己不 window.open）。
+  emits: ['close', 'open-tab', 'open-url'],
+  props: {
+    entity: { type: Object, required: true },
+    // 宿主换算好的页面坐标（客体页 clientX/clientY + webview rect）
+    x: { type: Number, default: 0 },
+    y: { type: Number, default: 0 },
+    projectId: { type: [Number, String], default: null },
+    // 已经有详情时直接用（面板里展开过的那些），省一次往返
+    initialDetail: { type: Object, default: null },
+  },
+  data() {
+    return {
+      detail: this.initialDetail || null,
+      loading: false,
+      err: '',
+      cardH: CARD_H_FALLBACK,
+    }
+  },
+  computed: {
+    kind() {
+      const k = this.entity && this.entity.kind
+      return k === 'LAW' || k === 'CASE' ? k : 'COMPANY'
+    },
+    pos() {
+      return hoverCardPosition({
+        x: this.x,
+        y: this.y,
+        width: CARD_W,
+        height: this.cardH,
+        viewportWidth: typeof window !== 'undefined' ? window.innerWidth : 0,
+        viewportHeight: typeof window !== 'undefined' ? window.innerHeight : 0,
+      })
+    },
+  },
+  mounted() {
+    this.loadDetail()
+    this.measure()
+    this._onKey = (e) => { if (e && e.key === 'Escape') this.close() }
+    try { document.addEventListener('keydown', this._onKey, true) } catch (e) { /* 非 h5 端没有 document */ }
+  },
+  beforeUnmount() {
+    try { document.removeEventListener('keydown', this._onKey, true) } catch (e) { /* ignore */ }
+  },
+  methods: {
+    close() { this.$emit('close') },
+    openTab() { this.$emit('open-tab', { entity: this.entity, detail: this.detail }) },
+    /** 真实高度量出来再定位一次：翻转判据要用真高度，不然靠近底边时会露出屏幕外。 */
+    measure() {
+      this.$nextTick(() => {
+        try {
+          const ref = this.$refs.card
+          const el = ref && ref.$el ? ref.$el : ref
+          const h = el && el.getBoundingClientRect ? el.getBoundingClientRect().height : 0
+          if (h > 0) this.cardH = h
+        } catch (e) { /* 量不到就用兜底高度 */ }
+      })
+    },
+    async loadDetail() {
+      const pid = Number(this.projectId) || null
+      const e = this.entity
+      if (this.detail || !pid || !e || !e.id) { this.measure(); return }
+      if (e.hasDetail === false) { this.measure(); return }
+      this.loading = true
+      try {
+        const v = unwrap(await getDocInsightEntity(pid, e.id)) || {}
+        this.detail = v.detail || null
+      } catch (err) {
+        this.err = (err && err.message) || this.$t('insight.detailFailed')
+      } finally {
+        this.loading = false
+        this.measure()
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+// z-index 与 FileTree 右键菜单同档：编辑器画布是独立合成层，浮层必须压在最上面。
+.ihc-mask {
+  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 9999; background: transparent;
+}
+.ihc {
+  position: fixed; width: 320px; max-height: 420px;
+  display: flex; flex-direction: column;
+  background: var(--awd-surface); border: 1px solid var(--awd-border); border-radius: 8px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.16);
+  z-index: 10000; overflow: hidden;
+}
+
+.ihc-head {
+  display: flex; align-items: center; gap: 6px;
+  padding: 8px 10px 6px; border-bottom: 1px solid var(--awd-border);
+}
+.ihc-badge {
+  flex: none; padding: 1px 6px; border-radius: 10px; font-size: 10px; font-weight: 600;
+  color: var(--awd-accent-text); background: var(--awd-accent-soft); border: 1px solid var(--awd-mint);
+}
+.ihc-name {
+  flex: 1; min-width: 0; font-size: 12px; font-weight: 600; color: var(--awd-text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ihc-x { flex: none; width: 18px; text-align: center; font-size: 14px; color: var(--awd-text-3); }
+
+.ihc-status { display: flex; align-items: center; gap: 6px; padding: 5px 10px 0; }
+.ihc-dot { flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--awd-border-strong); }
+.ihc-dot.st-OK { background: var(--awd-mint); }
+// NOT_FOUND 用中性灰而不是告警色：文档里写了一家不存在的公司，是文档的问题，不是我们的故障。
+.ihc-dot.st-NOT_FOUND { background: var(--awd-text-3); }
+.ihc-dot.st-UNAVAILABLE, .ihc-dot.st-ERROR { background: var(--awd-danger); }
+.ihc-src { flex: 1; min-width: 0; font-size: 10px; color: var(--awd-text-3); }
+
+.ihc-note {
+  padding: 4px 10px 0; font-size: 11px; line-height: 1.5; color: var(--awd-danger-text);
+}
+.ihc-note.st-NOT_FOUND { color: var(--awd-text-3); }
+
+.ihc-body { flex: 1; min-height: 0; max-height: 300px; padding: 6px 10px 8px; }
+.ihc-hint { font-size: 11px; color: var(--awd-text-3); }
+.ihc-err { font-size: 11px; color: var(--awd-danger-text); line-height: 1.5; }
+
+.ihc-foot {
+  display: flex; justify-content: flex-end;
+  padding: 6px 10px; border-top: 1px solid var(--awd-border); background: var(--awd-bg);
+}
+.ihc-open {
+  padding: 3px 10px; border-radius: 10px; font-size: 11px; font-weight: 600;
+  color: var(--awd-accent-text); background: var(--awd-accent-soft); border: 1px solid var(--awd-mint);
+}
+</style>

--- a/frontend/src/components/InsightPane.vue
+++ b/frontend/src/components/InsightPane.vue
@@ -109,6 +109,16 @@
                   <text v-if="authOf(e).url" class="ip-link" @tap.stop="openUrl(authOf(e).url)">{{ $t('insight.openInPkulaw') }}</text>
                 </template>
               </template>
+              <!-- 文档：项目文件树里命中的那份文件（dev-board#541） -->
+              <template v-else-if="e.kind === 'DOC'">
+                <template v-if="docOf(e)">
+                  <text class="ip-title">{{ docOf(e).fileName }}</text>
+                  <text v-if="docOf(e).filePath" class="ip-meta">{{ docOf(e).filePath }}</text>
+                  <text class="ip-link" @tap.stop="openDocFile(e)">{{ $t('insight.openDocFile') }}</text>
+                </template>
+                <!-- 没命中：只说明情况，不给按钮（这条本身就是尽调线索，不是我们的故障） -->
+                <text v-else class="ip-detail-hint">{{ $t('insight.docNotFound') }}</text>
+              </template>
               <!-- 案例：判决书 -->
               <template v-else>
                 <!-- 案号识别（先导步）：标准化案号 / 法院 / 判决书标题 / 法宝链接 -->
@@ -249,11 +259,12 @@ import {
 import { matchEntityAt, fixSuggestions, fixBlockReason, findingLocateQuote } from '@/utils/insightMatch.js'
 import {
   companyRows, companyShareholders, lawArticle, caseRecord, rawFallback,
-  authoritative, caseRecognition, citationDetail,
+  authoritative, caseRecognition, citationDetail, projectFile,
 } from '@/utils/insightDetail.js'
 
 const POLL_MS = 2000
-const KIND_ORDER = ['COMPANY', 'LAW', 'CASE']
+// 分组顺序。**新 kind 必须进这张表**：entityGroups 对认不得的 kind 兜底归进 COMPANY 组。
+const KIND_ORDER = ['COMPANY', 'LAW', 'CASE', 'DOC']
 
 // request() 已把 {code:0,data} 整体 resolve 出来，这里统一剥一层（同 evidenceLinkActions）。
 function unwrap(resp) {
@@ -271,7 +282,8 @@ export default {
   // 面板自己不碰 uni.navigateTo，交给宿主 openSettingsTab —— 与 open-url 同一条口径。
   // open-hover：正文里 Cmd/Ctrl 点中一个实体（dev-board#541）。浮窗要压在编辑器
   // <webview> 之上，只能挂在宿主根节点，所以面板只上抛「点中了谁、在屏幕哪一点」。
-  emits: ['entities', 'open-url', 'open-settings', 'open-hover'],
+  // open-doc-file：DOC 实体命中的那份项目文件，交给宿主在右侧分屏打开（dev-board#541）。
+  emits: ['entities', 'open-url', 'open-settings', 'open-hover', 'open-doc-file'],
   props: {
     projectId: { type: [Number, String], default: null },
     // 当前活跃的 writer 文档；换文档时面板整体重载（跟随，不留旧结论）
@@ -491,8 +503,13 @@ export default {
     noteHint(e) {
       return e && e.retrievalHint === 'NO_CREDENTIAL' ? 'insight.hint.NO_CREDENTIAL' : ''
     },
-    /** 配置类失败重试不了：那四种是恒定状态，再打一次上游只是白花一次额度。 */
+    /**
+     * 配置类失败重试不了：那四种是恒定状态，再打一次上游只是白花一次额度。
+     * DOC 同理：它的「检索」是与项目文件树比对（后端 refresh 对 DOC 是空操作），
+     * 静态文件树不会因为重试就多出一份文件来。
+     */
     showRetry(e) {
+      if (e && e.kind === 'DOC') return false
       return this.canParse && !(e && e.retrievalHint)
     },
     runNoteAction(e) {
@@ -530,12 +547,20 @@ export default {
       const r = this.recOf(e)
       return r ? [r.caseNumber, r.court].filter(Boolean).join(' · ') : ''
     },
+    // DOC：命中的项目文件（没命中时 detail 压根没有，返回 null）
+    docOf(e) { return projectFile(this.details[e.id]) },
+    /** 打开命中的那份项目文件——宿主落到右侧分屏（面板自己不碰标签系统）。 */
+    openDocFile(e) {
+      const d = this.docOf(e)
+      if (d) this.$emit('open-doc-file', { fileId: d.fileId, fileName: d.fileName })
+    },
     // 认得的字段一个都没渲染出来时才亮原文兜底（不是每次都把 JSON 铺一遍）
     showRaw(e) {
       const d = this.details[e.id]
       if (!d) return false
       if (e.kind === 'COMPANY') return !companyRows(d).length
       if (e.kind === 'LAW') { const a = lawArticle(d); return !a.title && !a.content && !authoritative(d) }
+      if (e.kind === 'DOC') return !projectFile(d)
       const c = caseRecord(d)
       return !c.title && !c.sections.length && !caseRecognition(d)
     },

--- a/frontend/src/components/InsightPane.vue
+++ b/frontend/src/components/InsightPane.vue
@@ -52,7 +52,6 @@
           :key="e.id"
           class="ip-row"
           :class="{ on: expandedId === e.id, hl: highlightId === e.id }"
-          :id="'ip-ent-' + e.id"
         >
           <view class="ip-row-top" @tap="toggleEntity(e)">
             <view class="ip-dot" :class="'st-' + (e.retrievalStatus || 'PENDING')"></view>
@@ -270,7 +269,9 @@ export default {
   // 与 MarketDetailPane / ProjectFavoritesPanel 同一条既有事件。
   // open-settings：配置类检索失败（未连接账户 / 余额不足 / Key 失效）的「下一步」。
   // 面板自己不碰 uni.navigateTo，交给宿主 openSettingsTab —— 与 open-url 同一条口径。
-  emits: ['entities', 'open-url', 'open-settings'],
+  // open-hover：正文里 Cmd/Ctrl 点中一个实体（dev-board#541）。浮窗要压在编辑器
+  // <webview> 之上，只能挂在宿主根节点，所以面板只上抛「点中了谁、在屏幕哪一点」。
+  emits: ['entities', 'open-url', 'open-settings', 'open-hover'],
   props: {
     projectId: { type: [Number, String], default: null },
     // 当前活跃的 writer 文档；换文档时面板整体重载（跟随，不留旧结论）
@@ -383,7 +384,13 @@ export default {
         this.error = ''
         this.$emit('entities', {
           docFileId: forDoc,
-          entities: this.entities.map((e) => ({ id: e.id, kind: e.kind, name: e.name, normKey: e.normKey })),
+          // 瘦身索引：匹配用的两个名字 + 浮窗抬头要显示的几个短标量。
+          // **出处（mentions）不搬**——那是整段原文，索引只是给点击匹配用的。
+          entities: this.entities.map((e) => ({
+            id: e.id, kind: e.kind, name: e.name, normKey: e.normKey,
+            retrievalStatus: e.retrievalStatus, retrievalSource: e.retrievalSource,
+            retrievalNote: e.retrievalNote, hasDetail: e.hasDetail,
+          })),
         })
         if (this.isRunning) this.schedulePoll()
       } catch (e) {
@@ -618,9 +625,14 @@ export default {
     // ————————————————— 光标联动 —————————————————
     /**
      * 宿主推下来的光标邻域。命中实体时：
-     *   带 Cmd/Ctrl（meta.metaKey || meta.ctrlKey）→ 选中并展开详情（切到检索 tab）；
-     *   普通点击 / 光标移动         → 只被动高亮，不展开也不抢滚动。
+     *   带 Cmd/Ctrl（meta.metaKey || meta.ctrlKey）→ 上抛 open-hover，宿主在点击处弹浮窗；
+     *   普通点击 / 光标移动         → 只被动高亮，不抢 tab 也不抢滚动。
      * 未命中不清高亮——光标走出实体名就把高亮抹掉会让面板一直在闪。
+     *
+     * Cmd/Ctrl 那一支**不再在面板里展开详情**（dev-board#541）：用户的视线在正文上，
+     * 把它引到侧栏去找刚点的那一条是多余的一步；详情改由浮窗就地给。
+     * 坐标是宿主换算好的页面坐标（客体页 clientX/clientY + 画布 rect），
+     * 拿不到时宿主自己会退回「不弹」，这里原样传上去。
      */
     onCursorContext(ctx) {
       if (!ctx) return
@@ -629,19 +641,8 @@ export default {
       const meta = ctx.meta || {}
       this.highlightId = hit.id
       if (meta.metaKey || meta.ctrlKey) {
-        this.tab = 'retrieval'
-        this.expandedId = hit.id
-        this.loadDetail(hit)
-        this.scrollToEntity(hit.id)
+        this.$emit('open-hover', { entity: hit, x: meta.hostX, y: meta.hostY })
       }
-    },
-    scrollToEntity(id) {
-      this.$nextTick(() => {
-        try {
-          const el = typeof document !== 'undefined' ? document.getElementById('ip-ent-' + id) : null
-          if (el && typeof el.scrollIntoView === 'function') el.scrollIntoView({ block: 'nearest' })
-        } catch (e) { /* 非 h5 端没有 document：滚不过去也不影响展开 */ }
-      })
     },
   },
 }

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -153,6 +153,7 @@ import { DOC_MUTATED_EVENT } from '@/utils/docEvents.js'
 import { getResolvedTheme, APP_THEME_EVENT } from '@/utils/appTheme.js'
 import { stampApplication } from '@/utils/docxAppProps.js'
 import { documentStampApplication } from '@/utils/documentGeneratorSetting.js'
+import { guestPointToHost } from '@/utils/insightPopup.js'
 
 let seq = 0
 
@@ -487,6 +488,19 @@ export default {
      * 也就一次 get_cursor_context 都不打——没开窗格的用户完全不受影响。
      * ready 时补发一次：webview 重建/换文档后客体页的状态是全新的。
      */
+    /**
+     * 客体页的点击坐标（客体视口）换算成宿主页面坐标，供「依据」浮窗贴着点击点弹出
+     * （dev-board#541）。rect **每次现取**：分屏拖动/左栏收放/底栏开合都会挪动画布，
+     * 缓存下来的 rect 会让浮窗弹到上一次的位置。拿不到坐标时不写 hostX/hostY，
+     * 宿主据此退回「不弹浮窗」而不是弹到屏幕角落。
+     */
+    withHostPoint(meta) {
+      const m = meta && typeof meta === 'object' ? meta : {}
+      let rect = null
+      try { rect = this.webviewEl ? this.webviewEl.getBoundingClientRect() : null } catch (e) { rect = null }
+      const pt = guestPointToHost(rect, m.clientX, m.clientY)
+      return pt ? Object.assign({}, m, { hostX: pt.x, hostY: pt.y }) : m
+    },
     pushInsightSub() {
       if (!this._transportSend) return
       try {
@@ -728,7 +742,9 @@ export default {
         } else if (msg.type === 'cursor-context') {
           // 「依据」窗格的正文联动（dev-board#182）：客体页只在被订阅时才发这条。
           // 纯只读（get_cursor_context），不标脏、不刷工具栏。
-          this.$emit('cursor-context', Object.assign({ fileId: this.file && this.file.id }, msg.payload || {}))
+          const ctx = Object.assign({ fileId: this.file && this.file.id }, msg.payload || {})
+          ctx.meta = this.withHostPoint(ctx.meta)
+          this.$emit('cursor-context', ctx)
         } else if (msg.type === 'boot-log') {
           this.onBootLog(String(msg.msg || ''))
         } else if (msg.type === 'boot-failed') {

--- a/frontend/src/locales/en-US/insight.js
+++ b/frontend/src/locales/en-US/insight.js
@@ -49,6 +49,10 @@ export default {
   openDocFile: 'Open file',
   docNotFound: 'No such file in this project',
   docMissing: 'That file is no longer in this project',
+  source: {
+    projectFile: 'Project file',
+    qichacha: 'Qichacha',
+  },
 
   mentions: '{count} mention(s)',
   mentionsTitle: 'Mentions in this document',

--- a/frontend/src/locales/en-US/insight.js
+++ b/frontend/src/locales/en-US/insight.js
@@ -35,14 +35,20 @@ export default {
     COMPANY: 'Companies',
     LAW: 'Statutes',
     CASE: 'Cases',
+    // Fourth entity kind: a file of this project referenced in the text (dev-board#541)
+    DOC: 'Documents',
   },
   // Badge for a single entity (hover card / entity tab) — the group headings above are plural.
   entityKind: {
     COMPANY: 'Company',
     LAW: 'Statute',
     CASE: 'Case',
+    DOC: 'Document',
   },
   openInNewTab: 'Open in a new tab',
+  openDocFile: 'Open file',
+  docNotFound: 'No such file in this project',
+  docMissing: 'That file is no longer in this project',
 
   mentions: '{count} mention(s)',
   mentionsTitle: 'Mentions in this document',

--- a/frontend/src/locales/en-US/insight.js
+++ b/frontend/src/locales/en-US/insight.js
@@ -36,6 +36,13 @@ export default {
     LAW: 'Statutes',
     CASE: 'Cases',
   },
+  // Badge for a single entity (hover card / entity tab) — the group headings above are plural.
+  entityKind: {
+    COMPANY: 'Company',
+    LAW: 'Statute',
+    CASE: 'Case',
+  },
+  openInNewTab: 'Open in a new tab',
 
   mentions: '{count} mention(s)',
   mentionsTitle: 'Mentions in this document',

--- a/frontend/src/locales/zh-CN/insight.js
+++ b/frontend/src/locales/zh-CN/insight.js
@@ -37,6 +37,8 @@ export default {
     COMPANY: '公司',
     LAW: '法规',
     CASE: '案例',
+    // 第四类实体：正文里提到的、项目文件树里的那份文件（dev-board#541）
+    DOC: '文档',
   },
   // 单个实体的类型徽标（浮窗 / 实体详情标签页）。与上面 kind 的分组标题分开：
   // 分组标题在英文版是复数（Companies），当徽标读起来不对。
@@ -44,9 +46,14 @@ export default {
     COMPANY: '公司',
     LAW: '法规',
     CASE: '案例',
+    DOC: '文档',
   },
   // 正文 Cmd/Ctrl 点中实体后的浮窗（dev-board#541）
   openInNewTab: '在新标签页打开',
+  // DOC 实体：命中项目文件时直接打开那份文件（落右侧分屏），没命中只说明情况
+  openDocFile: '打开文件',
+  docNotFound: '项目中未找到该文件',
+  docMissing: '文件已不在项目中',
 
   mentions: '{count} 处',
   mentionsTitle: '文中出处',

--- a/frontend/src/locales/zh-CN/insight.js
+++ b/frontend/src/locales/zh-CN/insight.js
@@ -38,6 +38,15 @@ export default {
     LAW: '法规',
     CASE: '案例',
   },
+  // 单个实体的类型徽标（浮窗 / 实体详情标签页）。与上面 kind 的分组标题分开：
+  // 分组标题在英文版是复数（Companies），当徽标读起来不对。
+  entityKind: {
+    COMPANY: '公司',
+    LAW: '法规',
+    CASE: '案例',
+  },
+  // 正文 Cmd/Ctrl 点中实体后的浮窗（dev-board#541）
+  openInNewTab: '在新标签页打开',
 
   mentions: '{count} 处',
   mentionsTitle: '文中出处',

--- a/frontend/src/locales/zh-CN/insight.js
+++ b/frontend/src/locales/zh-CN/insight.js
@@ -54,6 +54,11 @@ export default {
   openDocFile: '打开文件',
   docNotFound: '项目中未找到该文件',
   docMissing: '文件已不在项目中',
+  // 检索来源的人话（浮窗 / 详情标签页的来源行）
+  source: {
+    projectFile: '项目文件',
+    qichacha: '企查查',
+  },
 
   mentions: '{count} 处',
   mentionsTitle: '文中出处',

--- a/frontend/src/pages/project-overview/fileKind.js
+++ b/frontend/src/pages/project-overview/fileKind.js
@@ -11,7 +11,7 @@
 // 非文件标签。它们的 fileType 要么缺席、要么与 tabType 同值（'version-compare'
 // / 'diff' / 'web'…），本来就落不进下面的映射表；这里显式挡一道，是为了让
 // 「非文件标签不着色」这条契约有个能被单测钉住的位置，而不是靠「扩展名恰好没撞上」。
-const NON_FILE_TAB_TYPES = ['web', 'browser', 'market-detail', 'admin-settings']
+const NON_FILE_TAB_TYPES = ['web', 'browser', 'market-detail', 'admin-settings', 'insight-entity']
 
 // 分组口径与 config/icons.js 的 fileGlyph 保持一致（csv 跟着 Excel 走）。
 const KIND_BY_EXT = {

--- a/frontend/src/pages/project-overview/insightEntityTab.js
+++ b/frontend/src/pages/project-overview/insightEntityTab.js
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// insightEntityTab.js — 「依据」实体详情标签页的开法（dev-board#541）。
+//
+// 外置成方法组（this 即 project-overview 页面实例，同 tabDragSplit.js 等 Phase 1-3
+// 的先例）是为了能被 node --test 拿一个假 this 跑：这段里有两条真会打扰用户的判断
+// ——**未分屏时强制开分屏并落到右侧**、**同一个实体不开第二个标签**——
+// 埋在 6000 行的 .vue 里就没人守得住。单测在 tests/insight/insightEntityTab.test.mjs。
+
+/** 标签类型。fileKind.js 的 NON_FILE_TAB_TYPES 里必须有它（不然标签会被按扩展名上色）。 */
+export const INSIGHT_ENTITY_TAB_TYPE = 'insight-entity'
+
+/** 单例标签 id：同一个实体在两侧任意一边开过，就不再开第二个。 */
+export function insightEntityTabId(entity) {
+  if (!entity || !entity.id) return ''
+  return `${INSIGHT_ENTITY_TAB_TYPE}_${entity.kind || 'COMPANY'}_${entity.id}`
+}
+
+export const insightEntityTabMethods = {
+  /**
+   * 浮窗上的「在新标签页打开」：在**右侧分屏**开一个实体详情标签。
+   *
+   * 未分屏时先把分屏打开——这个动作的意义就是「正文与详情并排看」，
+   * 开在左边会把用户正在读的那份文档顶掉。已经开过的标签只激活、不重建
+   * （重建 = 详情再拉一次，还会把用户在那一页的滚动位置抹掉）。
+   *
+   * 标签直接 push 进列表（绕过 isFileTypeSupported），同 openMarketDetail 的形制。
+   */
+  openInsightEntityTab(payload) {
+    const entity = (payload && payload.entity) || payload
+    const tabId = insightEntityTabId(entity)
+    if (!tabId) return
+    this.closeInsightHoverCard()
+    for (const pane of ['left', 'right']) {
+      const list = pane === 'left' ? this.leftFiles : this.rightFiles
+      const existing = list.find((f) => f.id === tabId)
+      if (existing) {
+        this[pane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'] = existing.id
+        this.focusedPane = pane
+        this.$nextTick(() => this.triggerWorkbenchResize())
+        return
+      }
+    }
+    if (!this.splitMode) this.splitMode = true
+    this.focusedPane = 'right'
+    this.rightFiles.push({
+      id: tabId,
+      tabType: INSIGHT_ENTITY_TAB_TYPE,
+      name: entity.name || tabId,
+      entitySpec: { entity, detail: (payload && payload.detail) || null },
+    })
+    this.activeFileIdRight = tabId
+    this.$nextTick(() => this.triggerWorkbenchResize())
+  },
+}

--- a/frontend/src/pages/project-overview/insightEntityTab.js
+++ b/frontend/src/pages/project-overview/insightEntityTab.js
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// insightEntityTab.js — 「依据」实体详情标签页的开法（dev-board#541）。
+// insightEntityTab.js — 「依据」实体详情标签页 / DOC 实体文件的开法（dev-board#541）。
 //
 // 外置成方法组（this 即 project-overview 页面实例，同 tabDragSplit.js 等 Phase 1-3
 // 的先例）是为了能被 node --test 拿一个假 this 跑：这段里有两条真会打扰用户的判断
@@ -51,5 +51,41 @@ export const insightEntityTabMethods = {
     })
     this.activeFileIdRight = tabId
     this.$nextTick(() => this.triggerWorkbenchResize())
+  },
+
+  /**
+   * DOC 实体的「打开文件」（dev-board#541）：把正文里提到、项目里确实有的那份文件
+   * 打开来对着看。**默认落右侧分屏**，理由与上面同一条——开在左边会把用户正在读的
+   * 那份文档顶掉。已经在任一侧开着的只激活，不重开也不动分屏。
+   *
+   * 文件对象从左栏文件树的平铺清单里反查（解析时命中的是同一棵树）；
+   * 查不到就是解析之后被删/被移走了，给一句可读提示，不静默什么都不做。
+   */
+  openInsightDocFile(payload) {
+    const fileId = Number(payload && payload.fileId) || null
+    if (!fileId) return
+    this.closeInsightHoverCard()
+    for (const pane of ['left', 'right']) {
+      if (pane === 'right' && !this.splitMode) continue
+      const list = (pane === 'left' ? this.leftFiles : this.rightFiles) || []
+      const existing = list.find((f) => Number(f.id) === fileId)
+      if (existing) {
+        this[pane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'] = existing.id
+        this.focusedPane = pane
+        this.$nextTick(() => this.triggerWorkbenchResize())
+        return
+      }
+    }
+    const tree = this.$refs && this.$refs.fileTree
+    const all = tree && Array.isArray(tree.allFiles) ? tree.allFiles : []
+    const file = all.find((f) => f && Number(f.id) === fileId)
+    if (!file) {
+      uni.showToast({ title: this.$t('insight.docMissing'), icon: 'none' })
+      return
+    }
+    if (!this.splitMode) this.splitMode = true
+    this.focusedPane = 'right'
+    // openFile 按 focusedPane 落位，并自己处理「另一侧已经开着这份文档」的情形
+    this.openFile(file)
   },
 }

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -794,6 +794,7 @@
             @open-hover="openInsightHoverCard($event)"
             @open-url="openBrowserTab($event)"
             @open-settings="openSettingsTab($event || {})"
+            @open-doc-file="openInsightDocFile($event)"
           />
           <!-- 有真前端入口（Web 插件）走 iframe 沙箱；纯工具/skill 插件走宿主渲染的
                启动面板（介绍 + 怎么用 + 一键动作发进 AI 对话），不再是「未配置入口地址」。 -->
@@ -1104,6 +1105,7 @@
                       :spec="activeFileLeft.entitySpec"
                       :project-id="projectId"
                       @open-url="openBrowserTab($event)"
+                      @open-doc-file="openInsightDocFile($event)"
                     />
                     <!-- 「设置」标签：与 pages/admin 薄壳页共用同一个 AdminPane
                          （照插件广场 market-detail 那套 tab 形制）。个人中心 2026-08-20
@@ -1263,6 +1265,7 @@
                       :spec="activeFileRight.entitySpec"
                       :project-id="projectId"
                       @open-url="openBrowserTab($event)"
+                      @open-doc-file="openInsightDocFile($event)"
                     />
                     <!-- 「设置」标签：见左窗格同名注释 -->
                     <AdminPane
@@ -1551,6 +1554,7 @@
                 @open-hover="openInsightHoverCard($event)"
                 @open-url="openBrowserTab($event)"
                 @open-settings="openSettingsTab($event || {})"
+                @open-doc-file="openInsightDocFile($event)"
               />
             </view>
 
@@ -1933,6 +1937,7 @@
       @close="closeInsightHoverCard"
       @open-tab="openInsightEntityTab($event)"
       @open-url="openBrowserTab($event)"
+      @open-doc-file="openInsightDocFile($event)"
     />
 
     <!-- 底部状态条（IDE 化：常驻工具入口 + 真实状态信号，等宽字体） -->

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -791,6 +791,7 @@
             :parse-request="insightParseRequest"
             :cursor-context="insightCursorContext"
             @entities="onInsightEntities"
+            @open-hover="openInsightHoverCard($event)"
             @open-url="openBrowserTab($event)"
             @open-settings="openSettingsTab($event || {})"
           />
@@ -993,7 +994,7 @@
                       @evidence-drop="onEvidenceDrop($event, 'left')"
                       @locator-consumed="onLocatorConsumed"
                       :insight-open="insightPaneOpen && insightDocFileId === file.id"
-                      :insight-subscribed="insightPaneOpen && insightDocFileId === file.id"
+                      :insight-subscribed="insightSubscribedFor(file)"
                       @open-insight="onOpenInsight($event, 'left')"
                       @cursor-context="onEditorCursorContext"
                     />
@@ -1022,7 +1023,7 @@
                       @evidence-drop="onEvidenceDrop($event, 'left')"
                       @locator-consumed="onLocatorConsumed"
                       :insight-open="!!(sp.file && insightPaneOpen && insightDocFileId === sp.file.id)"
-                      :insight-subscribed="!!(sp.file && insightPaneOpen && insightDocFileId === sp.file.id)"
+                      :insight-subscribed="insightSubscribedFor(sp.file)"
                       @open-insight="onOpenInsight($event, 'left')"
                       @cursor-context="onEditorCursorContext"
                     />
@@ -1093,6 +1094,15 @@
                       v-else-if="activeFileLeft.tabType === 'market-detail'"
                       :key="activeFileLeft.id"
                       :spec="activeFileLeft.marketSpec"
+                      @open-url="openBrowserTab($event)"
+                    />
+                    <!-- 实体详情标签（dev-board#541）：浮窗上「在新标签页打开」的落点。
+                         照 market-detail 那套 tab 形制（单例 id、直接 push 进列表）。 -->
+                    <InsightEntityDetailPane
+                      v-else-if="activeFileLeft.tabType === 'insight-entity'"
+                      :key="activeFileLeft.id"
+                      :spec="activeFileLeft.entitySpec"
+                      :project-id="projectId"
                       @open-url="openBrowserTab($event)"
                     />
                     <!-- 「设置」标签：与 pages/admin 薄壳页共用同一个 AdminPane
@@ -1179,7 +1189,7 @@
                       @evidence-drop="onEvidenceDrop($event, 'right')"
                       @locator-consumed="onLocatorConsumed"
                       :insight-open="insightPaneOpen && insightDocFileId === file.id"
-                      :insight-subscribed="insightPaneOpen && insightDocFileId === file.id"
+                      :insight-subscribed="insightSubscribedFor(file)"
                       @open-insight="onOpenInsight($event, 'right')"
                       @cursor-context="onEditorCursorContext"
                     />
@@ -1243,6 +1253,15 @@
                       v-else-if="activeFileRight.tabType === 'market-detail'"
                       :key="activeFileRight.id"
                       :spec="activeFileRight.marketSpec"
+                      @open-url="openBrowserTab($event)"
+                    />
+                    <!-- 实体详情标签（dev-board#541）：浮窗上「在新标签页打开」的落点。
+                         照 market-detail 那套 tab 形制（单例 id、直接 push 进列表）。 -->
+                    <InsightEntityDetailPane
+                      v-else-if="activeFileRight.tabType === 'insight-entity'"
+                      :key="activeFileRight.id"
+                      :spec="activeFileRight.entitySpec"
+                      :project-id="projectId"
                       @open-url="openBrowserTab($event)"
                     />
                     <!-- 「设置」标签：见左窗格同名注释 -->
@@ -1529,6 +1548,7 @@
                 :parse-request="insightParseRequest"
                 :cursor-context="insightCursorContext"
                 @entities="onInsightEntities"
+                @open-hover="openInsightHoverCard($event)"
                 @open-url="openBrowserTab($event)"
                 @open-settings="openSettingsTab($event || {})"
               />
@@ -1899,6 +1919,22 @@
       </view>
     </view>
 
+    <!-- 「依据」实体浮窗（dev-board#541）：正文里 Cmd/Ctrl 点中实体后贴着点击处弹出。
+         挂在页面根节点（不在面板里）——编辑器画布是独立合成层的 <webview>，
+         浮层只有在根级 + 高 z-index 才压得住，同 FileTree 的右键菜单。 -->
+    <InsightHoverCard
+      v-if="insightHover"
+      :key="insightHover.key"
+      :entity="insightHover.entity"
+      :x="insightHover.x"
+      :y="insightHover.y"
+      :project-id="projectId"
+      :initial-detail="insightHover.detail || null"
+      @close="closeInsightHoverCard"
+      @open-tab="openInsightEntityTab($event)"
+      @open-url="openBrowserTab($event)"
+    />
+
     <!-- 底部状态条（IDE 化：常驻工具入口 + 真实状态信号，等宽字体） -->
     <view class="status-bar" v-if="!isClientView">
       <view
@@ -1969,6 +2005,10 @@ import EasyVoicePane from '@/components/EasyVoicePane.vue'
 import DesensitizePane from '@/components/DesensitizePane.vue'
 import ClipboardPanel from '@/components/ClipboardPanel.vue'
 import InsightPane from '@/components/InsightPane.vue'
+// 正文 Cmd/Ctrl 点中实体后的浮窗 + 它的「在新标签页打开」落点（dev-board#541）。
+// 浮窗必须挂在页面根节点才叠得上编辑器 <webview>，所以宿主持有它而不是面板。
+import InsightHoverCard from '@/components/InsightHoverCard.vue'
+import InsightEntityDetailPane from '@/components/InsightEntityDetailPane.vue'
 import SearchPanel from '@/components/SearchPanel.vue'
 import VersionPanel from '@/components/version/VersionPanel.vue'
 // 异步组件：ProjectCalendarPane 静态 import 会把 FullCalendar 整包拖进工作台主
@@ -2020,7 +2060,8 @@ import {
   checkCloud, // 协作 chip 的联网刷新（cloudStatus 是不联网的本地快照）
   getCloudMembers, // 成员堆栈：案卷放进案件库后，同事在库那边的名单本机 /members 里没有
   getCurrentUser as getCurrentUserApi, // 顶栏头像：补一次真实接口，本地缓存只是首屏兜底
-  registerMeetingFromFile // 右键转写：音频文件注册进会议录音面板（dev-board#227）
+  registerMeetingFromFile, // 右键转写：音频文件注册进会议录音面板（dev-board#227）
+  getDocInsight // 「依据」实体索引预取：窗格关着也要能 Cmd 点正文（dev-board#541）
 } from '@/services/api.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
 import { signOut } from '@/utils/signOut.js'
@@ -2077,6 +2118,7 @@ import { fileOpenTabsMethods } from './fileOpenTabs.js'
 import { clipboardBridgeMethods } from './clipboardBridge.js'
 import { ocrActionMethods } from './ocrActions.js'
 import { ocrCaptureMethods } from './ocrCapture.js'
+import { insightEntityTabMethods } from './insightEntityTab.js'
 
 // 网页标签保活上限（只在 Web/H5 生效，桌面端保活是 BrowserView 的活，见 leftWebTabs）。
 // 为什么要有上限、而桌面端可以不要：从窗口摘下的 BrowserView 会被 Chromium 冻住渲染进程，
@@ -2100,6 +2142,8 @@ export default {
     FileStagingArea,
     ClipboardPanel,
     InsightPane,
+    InsightHoverCard,
+    InsightEntityDetailPane,
     DdFilesPanel,
     ShareholderMeetingPanel,
     MeetingRecordingPanel,
@@ -2344,6 +2388,11 @@ export default {
       // 实体索引在 _insightIndex（非响应式，同 _libreRefs 口径）——它只在事件处理里被读。
       insightParseRequest: null,
       insightCursorContext: null,
+      // 正文 Cmd/Ctrl 点中实体后的浮窗（dev-board#541）：{entity, x, y, detail}，null = 不显示。
+      insightHover: null,
+      // 每份文档抽出了几个实体。_insightIndex 是非响应式的，模板要用（决定要不要
+      // 给客体页开光标订阅）就得有个响应式镜像。
+      insightEntityCounts: {},
 
       // 文件状态 - 分两组管理
       leftFiles: [], // 左侧文件列表
@@ -2539,6 +2588,9 @@ export default {
         this.showFilePicker ||
         this.showInviteModal ||
         !!this.imagePreviewUrl ||
+        // 「依据」实体浮窗（dev-board#541）：另一侧开着浏览器标签时，BrowserView 是
+        // 原生层，会把浮窗盖住——同图片预览那条，弹出期间先把 BrowserView 藏掉
+        !!this.insightHover ||
         (this.fileLinkPicker && this.fileLinkPicker.visible)
       )
     },
@@ -3549,8 +3601,8 @@ export default {
     // 内嵌 LibreOffice 多实例保活：激活的 Office 标签记入 LRU（超上限触发
     // 淘汰），并把 AI 指令路由指针同步到当前活动实例（活跃实例指针，同
     // PR#151 WPS 编辑器模式）。
-    activeFileLeft(f) { this.onActiveOfficeFileChanged('left', f); this.touchWebKeepAlive('left', f) },
-    activeFileRight(f) { this.onActiveOfficeFileChanged('right', f); this.touchWebKeepAlive('right', f) },
+    activeFileLeft(f) { this.onActiveOfficeFileChanged('left', f); this.touchWebKeepAlive('left', f); this.prefetchInsightIndex(f) },
+    activeFileRight(f) { this.onActiveOfficeFileChanged('right', f); this.touchWebKeepAlive('right', f); this.prefetchInsightIndex(f) },
     focusedPane() { this.syncLibreExecutor() },
     // 关闭 tab 后清掉文件已不在左列表的过继备胎条目（closeFile 已 flush）
     'leftFiles.length'() { this.pruneClosedLibreSpares() },
@@ -3663,6 +3715,8 @@ export default {
     ...ocrActionMethods,
     // Phase 3c 外置的方法组
     ...ocrCaptureMethods,
+    // 「依据」实体详情标签（dev-board#541）
+    ...insightEntityTabMethods,
     // 右键「这份文件的历史」：切到版本面板并只显示这份文件的版本
     onFileHistory(file) {
       this.versionFileFilter = { fileId: file.id, name: file.name }
@@ -5524,25 +5578,93 @@ export default {
     },
     /** 窗格把实体清单同步上来（宿主据此在正文点击时做匹配）。 */
     onInsightEntities(payload) {
-      const idx = this._insightIndex || (this._insightIndex = {})
       const id = payload && payload.docFileId
       if (!id) return
-      idx[id] = Array.isArray(payload.entities) ? payload.entities : []
+      this.setInsightIndex(id, Array.isArray(payload.entities) ? payload.entities : [])
+    },
+    /** 索引 + 它的响应式计数镜像的唯一写入点。 */
+    setInsightIndex(docFileId, list) {
+      const idx = this._insightIndex || (this._insightIndex = {})
+      idx[docFileId] = list
+      this.insightEntityCounts = { ...this.insightEntityCounts, [docFileId]: list.length }
     },
     /**
-     * 客体页回传的光标邻域（只有窗格订阅着才会有）。宿主先自己匹配一遍：
-     * 命中才把上下文推给窗格（窗格再匹配一次决定展开还是被动高亮）——
-     * 没命中的光标移动不推，免得窗格每次移动都白跑一遍。
+     * 这份文档要不要给客体页开光标订阅（dev-board#541）。
+     * 原判据只有「窗格开着且绑在它上面」，于是窗格一关，正文里 Cmd 点击就没反应了。
+     * 现在多一条：**已经解析出实体**的文档也订阅——没解析过的文档仍然一次
+     * get_cursor_context 都不打，「没开窗格的用户零开销」那条口径对它们没变。
+     */
+    insightSubscribedFor(file) {
+      if (!file || !file.id) return false
+      if (this.insightPaneOpen && Number(this.insightDocFileId) === Number(file.id)) return true
+      return !!this.insightEntityCounts[file.id]
+    },
+    /**
+     * 文档标签激活时预取一次实体清单（dev-board#541）。窗格是 v-if 挂载的，
+     * 关着时没人拉过 GET /insight，_insightIndex 就是空的——Cmd 点击匹配不到任何东西。
+     * 一份文档只拉一次；失败不写缓存，下次激活会重试。非 writer 文档一次也不拉。
+     */
+    prefetchInsightIndex(file) {
+      if (!file || !this.projectId || !this.isInsightDoc(file)) return
+      const id = Number(file.id)
+      if (!id) return
+      if ((this._insightIndex || {})[id] !== undefined) return
+      const inflight = this._insightPrefetch || (this._insightPrefetch = {})
+      if (inflight[id]) return
+      inflight[id] = true
+      const done = () => { delete inflight[id] }
+      getDocInsight(this.projectId, id)
+        .then((resp) => {
+          const v = (resp && typeof resp === 'object' && 'data' in resp ? resp.data : resp) || {}
+          // 与窗格 emit 的索引同形：匹配用的名字 + 浮窗抬头的短标量，出处不进索引
+          const list = (Array.isArray(v.entities) ? v.entities : []).map((e) => ({
+            id: e.id, kind: e.kind, name: e.name, normKey: e.normKey,
+            retrievalStatus: e.retrievalStatus, retrievalSource: e.retrievalSource,
+            retrievalNote: e.retrievalNote, hasDetail: e.hasDetail,
+          }))
+          this.setInsightIndex(id, list)
+        })
+        .catch(() => { /* 还没解析过 / 拉不到：不写缓存，下次激活再试 */ })
+        .then(done, done)
+    },
+    /**
+     * 客体页回传的光标邻域。宿主先自己匹配一遍（索引在宿主手里，窗格可能根本没挂）：
+     *   窗格开着且绑着这份文档 → 原样推给窗格（它决定被动高亮，还是上抛 open-hover）；
+     *   窗格没开             → 只处理 Cmd/Ctrl 那一支，直接弹浮窗。
+     * 没命中的光标移动一律不推，免得窗格每次移动都白跑一遍。
      */
     onEditorCursorContext(ctx) {
-      if (!ctx || !this.insightPaneOpen) return
-      const fileId = ctx.fileId
-      if (fileId && Number(fileId) !== Number(this.insightDocFileId)) return
-      const list = (this._insightIndex || {})[this.insightDocFileId] || []
+      if (!ctx) return
+      const fileId = Number(ctx.fileId) || null
+      if (!fileId) return
+      const list = (this._insightIndex || {})[fileId] || []
       if (!list.length) return
-      if (!matchEntityAt(ctx, list)) return
-      this.insightCursorContext = ctx
+      const hit = matchEntityAt(ctx, list)
+      if (!hit) return
+      if (this.insightPaneOpen && Number(this.insightDocFileId) === fileId) {
+        this.insightCursorContext = ctx
+        return
+      }
+      const meta = ctx.meta || {}
+      if (meta.metaKey || meta.ctrlKey) {
+        this.openInsightHoverCard({ entity: hit, x: meta.hostX, y: meta.hostY })
+      }
     },
+    /**
+     * 弹实体浮窗（dev-board#541）。坐标是 LibreOfficeEditor 换算好的页面坐标；
+     * 换算不出来（拿不到画布 rect、或客体页没带坐标）就**不弹**——
+     * 弹到屏幕角落比不弹更糟，用户会以为自己点错了地方。
+     */
+    openInsightHoverCard(payload) {
+      const entity = payload && payload.entity
+      const x = Number(payload && payload.x)
+      const y = Number(payload && payload.y)
+      if (!entity || !entity.id) return
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return
+      // key 带时间戳：连点两个不同实体时强制重建（详情/定位都要重来一遍）
+      this.insightHover = { entity, x, y, detail: (payload && payload.detail) || null, key: entity.id + '@' + Date.now() }
+    },
+    closeInsightHoverCard() { this.insightHover = null },
 
     // #104: getEditor() adapter for VariablePanel — the five document-field
     // methods it expects, implemented over the LibreOffice executor's var_*

--- a/frontend/src/utils/insightDetail.js
+++ b/frontend/src/utils/insightDetail.js
@@ -290,3 +290,10 @@ export function rawFallback(detail, limit = 4000) {
     return ''
   }
 }
+
+// 检索来源的展示键（dev-board#541）：后端 retrievalSource 是技术串（project-file / qichacha+mcp），
+// 浮窗与详情标签页要显示成人话。认不出来的来源返回 null，调用方原样显示。
+const SOURCE_I18N = { 'project-file': 'insight.source.projectFile', 'qichacha+mcp': 'insight.source.qichacha' }
+export function retrievalSourceKey(src) {
+  return (src && SOURCE_I18N[String(src)]) || null
+}

--- a/frontend/src/utils/insightDetail.js
+++ b/frontend/src/utils/insightDetail.js
@@ -5,6 +5,7 @@
 // 三种 detail 的形状（后端 DocInsightService 落库时定的，见 .claude/agents/doc-insight.md）：
 //   COMPANY  {source, basic:{企业名称:…, 统一社会信用代码:…, …}, shareholders:[{股东,持股比例,认缴出资}], raw?}
 //   LAW/CASE {source, tool, query, result:<上游 JSON 或原文字符串>}
+//   DOC      {source:'project-file', fileId, fileName, filePath}（没命中项目文件时压根没有 detail）
 //
 // **上游形状是别人家的**（法宝/企查查随时可能改字段名、外面还可能裹一层 MCP content 信封），
 // 所以这里一律「有什么渲染什么」：认得的字段按顺序列出来，认不得的整体落到原文兜底，
@@ -221,6 +222,23 @@ export function caseRecognition(detail) {
     url: pick(r, REC_URL),
   }
   return out.caseNumber || out.court || out.title || out.url ? out : null
+}
+
+/**
+ * DOC：解析在项目文件树里命中的那份文件（dev-board#541）。
+ * 后端命中时 detail = {source:'project-file', fileId, fileName, filePath}；
+ * 没命中的实体是 NOT_FOUND、压根没有 detail，这里返回 null（窗格照 retrievalNote 说话）。
+ */
+export function projectFile(detail) {
+  const d = detail && typeof detail === 'object' ? detail : null
+  if (!d) return null
+  const id = Number(d.fileId)
+  if (!id) return null
+  return {
+    fileId: id,
+    fileName: pick(d, ['fileName', 'file_name', '文件名']),
+    filePath: pick(d, ['filePath', 'file_path', '路径']),
+  }
 }
 
 /**

--- a/frontend/src/utils/insightPopup.js
+++ b/frontend/src/utils/insightPopup.js
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// insightPopup.js — 「依据」实体浮窗的两组坐标纯函数（dev-board#541）。
+//
+//   ① guestPointToHost：客体页（webview / 同源 iframe）视口坐标 → 宿主页面坐标；
+//   ② hoverCardPosition：贴着点击点摆一张固定尺寸的卡片，靠边自动翻转、始终不出屏。
+//
+// 放在 utils 里是为了能被 node --test 直接导入（tests/insight/），
+// **不许 import Vue / uni / @/i18n**——照 insightMatch.js 的先例。
+
+/** 卡片相对点击点的默认偏移（px）：错开一点，别把刚点的那个词盖住。 */
+export const HOVER_OFFSET = 12
+/** 卡片与视口边缘的最小留白（px）。 */
+export const HOVER_MARGIN = 8
+
+function finite(v) {
+  // null / undefined / '' 一律算「没给」——Number(null) 是 0，放过去就会把
+  // 「客体页没带坐标」当成「点在 (0, 0)」，浮窗弹到屏幕左上角。
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * 客体页里的 clientX/clientY 换算成宿主页面坐标。
+ *
+ * 编辑器画布在宿主里是一个 <webview>（桌面壳）或同源 <iframe>（Web 版），
+ * 客体页视口的原点就是那个元素的左上角，所以加一次 rect 的左上角即可。
+ * **rect 必须每次现取**（getBoundingClientRect），不能缓存：分屏拖动、左栏收放、
+ * 底部抽屉开合都会挪动它。
+ *
+ * rect 缺失或坐标不是有限数时返回 null——调用方据此退回「不弹浮窗」而不是弹到 (0,0)。
+ */
+export function guestPointToHost(rect, clientX, clientY) {
+  const x = finite(clientX)
+  const y = finite(clientY)
+  if (x === null || y === null) return null
+  const left = rect ? finite(rect.left) : null
+  const top = rect ? finite(rect.top) : null
+  if (left === null || top === null) return null
+  return { x: left + x, y: top + y }
+}
+
+/**
+ * 浮窗的 position:fixed 落点。
+ *
+ * 默认摆在点击点的右下方；右边/下边放不下就翻到左边/上边；翻过去还是放不下
+ * （视口比卡片还窄）就贴边并夹进视口——**任何情况下都不许出屏**，出屏等于点了没反应。
+ *
+ * @returns {{left:number, top:number, flipX:boolean, flipY:boolean}}
+ */
+export function hoverCardPosition(opts) {
+  const o = opts || {}
+  const x = finite(o.x) || 0
+  const y = finite(o.y) || 0
+  const w = Math.max(0, finite(o.width) || 0)
+  const h = Math.max(0, finite(o.height) || 0)
+  const vw = Math.max(0, finite(o.viewportWidth) || 0)
+  const vh = Math.max(0, finite(o.viewportHeight) || 0)
+  const offset = finite(o.offset) != null ? finite(o.offset) : HOVER_OFFSET
+  const margin = finite(o.margin) != null ? finite(o.margin) : HOVER_MARGIN
+
+  const place = (pos, size, viewport) => {
+    let start = pos + offset
+    let flipped = false
+    if (start + size > viewport - margin) {
+      const alt = pos - offset - size
+      // 翻过去比原位放得下才翻（视口两边都不够时保持原方向再夹）
+      if (alt >= margin) { start = alt; flipped = true }
+    }
+    const max = Math.max(margin, viewport - margin - size)
+    if (start > max) start = max
+    if (start < margin) start = margin
+    return { start, flipped }
+  }
+
+  const hx = place(x, w, vw)
+  const hy = place(y, h, vh)
+  return { left: hx.start, top: hy.start, flipX: hx.flipped, flipY: hy.flipped }
+}

--- a/frontend/src/zetaoffice/editor-main.js
+++ b/frontend/src/zetaoffice/editor-main.js
@@ -287,7 +287,7 @@ function relayCursorContext(meta) {
         payload: {
           before: r.before || '', after: r.after || '', paragraph: r.paragraph || '',
           selectedText: r.selectedText || '', hasSelection: !!r.hasSelection,
-          meta: meta || { metaKey: false, ctrlKey: false },
+          meta: meta || { metaKey: false, ctrlKey: false, clientX: null, clientY: null },
           at: Date.now(),
         },
       })
@@ -365,7 +365,11 @@ startEditorEndpoint({
       setTimeout(async () => {
         // (dev-board#182) 依据窗格的正文联动：单击落定后问一次光标邻域。
         // 与超链接那条并行、互不阻塞（两者都是只读原语，谁先回来都不影响对方）。
-        relayCursorContext({ metaKey: d.metaKey, ctrlKey: d.ctrlKey })
+        // clientX/clientY 是**客体页视口**里的坐标（mousedown 记下的那一对，
+        // 不用 mouseup 的：拖动被上面 5px 判据挡掉了，两者本来就该一致）。
+        // 宿主 LibreOfficeEditor 收到后按 webview/iframe 的 rect 换算成页面坐标，
+        // 「依据」浮窗据此贴着点击处弹出（dev-board#541）。
+        relayCursorContext({ metaKey: d.metaKey, ctrlKey: d.ctrlKey, clientX: d.x, clientY: d.y })
         try {
           const r = await endpoint.executor.executeCommand('get_hyperlink_at_cursor', {})
           if (r && r.success && r.url) {

--- a/frontend/tests/insight/insightEntityTab.test.mjs
+++ b/frontend/tests/insight/insightEntityTab.test.mjs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 「依据」实体详情标签页的开法（dev-board#541）。
+//
+// 锁两条真会打扰用户的判断：
+//   ① 未分屏时**强制开分屏并落到右侧**——开在左边会把用户正在读的那份文档顶掉；
+//   ② 同一个实体不开第二个标签（跨两侧查重），已开的只激活不重建。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { insightEntityTabId, insightEntityTabMethods, INSIGHT_ENTITY_TAB_TYPE } from '../../src/pages/project-overview/insightEntityTab.js'
+
+function makeHost(over = {}) {
+  const host = {
+    leftFiles: over.leftFiles || [],
+    rightFiles: over.rightFiles || [],
+    activeFileIdLeft: over.activeFileIdLeft || null,
+    activeFileIdRight: over.activeFileIdRight || null,
+    splitMode: !!over.splitMode,
+    focusedPane: over.focusedPane || 'left',
+    hoverClosed: 0,
+    resized: 0,
+    closeInsightHoverCard() { this.hoverClosed++ },
+    triggerWorkbenchResize() { this.resized++ },
+    $nextTick(fn) { if (fn) fn(); return Promise.resolve() },
+  }
+  Object.assign(host, insightEntityTabMethods)
+  return host
+}
+
+const ENT = { id: 31, kind: 'COMPANY', name: '京微资易科技有限公司' }
+
+test('标签 id：按 kind + id 单例；缺 id 拿不到 id', () => {
+  assert.equal(insightEntityTabId(ENT), 'insight-entity_COMPANY_31')
+  assert.equal(insightEntityTabId({ id: 7, kind: 'LAW' }), 'insight-entity_LAW_7')
+  assert.equal(insightEntityTabId({ id: 7 }), 'insight-entity_COMPANY_7', 'kind 缺省当公司')
+  assert.equal(insightEntityTabId(null), '')
+  assert.equal(insightEntityTabId({ name: 'x' }), '')
+})
+
+test('未分屏：先把分屏开出来，标签落右侧并激活', () => {
+  const h = makeHost({ leftFiles: [{ id: 10, name: 'a.docx' }], activeFileIdLeft: 10 })
+  h.openInsightEntityTab({ entity: ENT, detail: { basic: {} } })
+
+  assert.equal(h.splitMode, true, '未分屏时必须开分屏')
+  assert.equal(h.focusedPane, 'right')
+  assert.equal(h.rightFiles.length, 1)
+  assert.equal(h.rightFiles[0].id, 'insight-entity_COMPANY_31')
+  assert.equal(h.rightFiles[0].tabType, INSIGHT_ENTITY_TAB_TYPE)
+  assert.equal(h.rightFiles[0].name, ENT.name)
+  assert.deepEqual(h.rightFiles[0].entitySpec.entity, ENT)
+  assert.deepEqual(h.rightFiles[0].entitySpec.detail, { basic: {} })
+  assert.equal(h.activeFileIdRight, 'insight-entity_COMPANY_31')
+  assert.equal(h.activeFileIdLeft, 10, '左侧那份文档不许被顶掉')
+  assert.equal(h.hoverClosed, 1, '开标签的同时收掉浮窗')
+})
+
+test('已分屏：不动 splitMode，照样落右侧', () => {
+  const h = makeHost({ splitMode: true, focusedPane: 'left' })
+  h.openInsightEntityTab({ entity: ENT })
+  assert.equal(h.splitMode, true)
+  assert.equal(h.focusedPane, 'right')
+  assert.equal(h.rightFiles.length, 1)
+})
+
+test('单例：同一个实体再点一次只激活，不开第二个标签', () => {
+  const h = makeHost()
+  h.openInsightEntityTab({ entity: ENT })
+  h.activeFileIdRight = 'other'
+  h.openInsightEntityTab({ entity: ENT, detail: { basic: {} } })
+  assert.equal(h.rightFiles.length, 1)
+  assert.equal(h.activeFileIdRight, 'insight-entity_COMPANY_31')
+  assert.equal(h.rightFiles[0].entitySpec.detail, null, '已开的标签不重建，也不覆盖它自己拉到的详情')
+})
+
+test('单例：标签被拖到左侧后再点，激活左侧那个而不是在右边再开一个', () => {
+  const h = makeHost({
+    splitMode: true,
+    leftFiles: [{ id: 'insight-entity_COMPANY_31', tabType: INSIGHT_ENTITY_TAB_TYPE, name: 'x' }],
+  })
+  h.openInsightEntityTab({ entity: ENT })
+  assert.equal(h.rightFiles.length, 0)
+  assert.equal(h.activeFileIdLeft, 'insight-entity_COMPANY_31')
+  assert.equal(h.focusedPane, 'left')
+})
+
+test('实体无效：一个标签都不开（也不动分屏）', () => {
+  const h = makeHost()
+  h.openInsightEntityTab(null)
+  h.openInsightEntityTab({ entity: { name: '没有 id' } })
+  assert.equal(h.rightFiles.length, 0)
+  assert.equal(h.splitMode, false)
+  assert.equal(h.hoverClosed, 0)
+})
+
+test('不同 kind 同 id 是两个标签（后端三类实体各自编号）', () => {
+  const h = makeHost({ splitMode: true })
+  h.openInsightEntityTab({ entity: { id: 31, kind: 'COMPANY', name: 'A' } })
+  h.openInsightEntityTab({ entity: { id: 31, kind: 'LAW', name: 'B' } })
+  assert.equal(h.rightFiles.length, 2)
+})

--- a/frontend/tests/insight/insightEntityTab.test.mjs
+++ b/frontend/tests/insight/insightEntityTab.test.mjs
@@ -10,6 +10,10 @@ import assert from 'node:assert/strict'
 
 import { insightEntityTabId, insightEntityTabMethods, INSIGHT_ENTITY_TAB_TYPE } from '../../src/pages/project-overview/insightEntityTab.js'
 
+// openInsightDocFile 走 uni.showToast（宿主方法组里的既有口径）
+const toasts = []
+globalThis.uni = { showToast: (o) => toasts.push(o) }
+
 function makeHost(over = {}) {
   const host = {
     leftFiles: over.leftFiles || [],
@@ -20,6 +24,10 @@ function makeHost(over = {}) {
     focusedPane: over.focusedPane || 'left',
     hoverClosed: 0,
     resized: 0,
+    opened: [],
+    $t: (k) => k,
+    $refs: { fileTree: { allFiles: over.allFiles || [] } },
+    openFile(file) { this.opened.push(file) },
     closeInsightHoverCard() { this.hoverClosed++ },
     triggerWorkbenchResize() { this.resized++ },
     $nextTick(fn) { if (fn) fn(); return Promise.resolve() },
@@ -98,4 +106,54 @@ test('不同 kind 同 id 是两个标签（后端三类实体各自编号）', (
   h.openInsightEntityTab({ entity: { id: 31, kind: 'COMPANY', name: 'A' } })
   h.openInsightEntityTab({ entity: { id: 31, kind: 'LAW', name: 'B' } })
   assert.equal(h.rightFiles.length, 2)
+})
+
+// ————————————————— DOC 实体的「打开文件」（dev-board#541） —————————————————
+
+const DOC_FILE = { id: 21, name: '房屋租赁合同.docx', fileType: 'docx' }
+
+test('DOC：未分屏时开分屏、落右侧，交给 openFile 按 focusedPane 放', () => {
+  const h = makeHost({ leftFiles: [{ id: 10, name: 'a.docx' }], activeFileIdLeft: 10, allFiles: [DOC_FILE] })
+  toasts.length = 0
+  h.openInsightDocFile({ fileId: 21, fileName: '房屋租赁合同.docx' })
+
+  assert.equal(h.splitMode, true, '默认在右侧分屏打开——开在左边会把正在读的那份顶掉')
+  assert.equal(h.focusedPane, 'right')
+  assert.deepEqual(h.opened, [DOC_FILE])
+  assert.equal(h.activeFileIdLeft, 10, '左侧那份文档不许被顶掉')
+  assert.equal(h.hoverClosed, 1, '打开文件的同时收掉浮窗')
+  assert.equal(toasts.length, 0)
+})
+
+test('DOC：已经开着的只激活，不重开也不动分屏', () => {
+  const h = makeHost({
+    splitMode: true, focusedPane: 'right',
+    leftFiles: [{ id: 21, name: '房屋租赁合同.docx' }],
+    allFiles: [DOC_FILE],
+  })
+  h.openInsightDocFile({ fileId: 21 })
+  assert.deepEqual(h.opened, [], '已经开着就不该再 openFile 一次')
+  assert.equal(h.activeFileIdLeft, 21)
+  assert.equal(h.focusedPane, 'left')
+  assert.equal(h.splitMode, true)
+})
+
+test('DOC：文件已不在项目里 → 一句可读提示，不开标签也不开分屏', () => {
+  const h = makeHost({ allFiles: [{ id: 99, name: '别的.docx' }] })
+  toasts.length = 0
+  h.openInsightDocFile({ fileId: 21, fileName: '房屋租赁合同.docx' })
+  assert.deepEqual(h.opened, [])
+  assert.equal(h.splitMode, false)
+  assert.equal(toasts.length, 1, '静默什么都不做 = 用户以为点坏了')
+  assert.equal(toasts[0].title, 'insight.docMissing')
+})
+
+test('DOC：payload 没有 fileId → 一动不动（连浮窗都不收）', () => {
+  const h = makeHost({ allFiles: [DOC_FILE] })
+  toasts.length = 0
+  h.openInsightDocFile(null)
+  h.openInsightDocFile({ fileName: '没有 id' })
+  assert.deepEqual(h.opened, [])
+  assert.equal(h.hoverClosed, 0)
+  assert.equal(toasts.length, 0)
 })

--- a/frontend/tests/insight/insightPane.test.mjs
+++ b/frontend/tests/insight/insightPane.test.mjs
@@ -14,7 +14,7 @@ import { readFileSync } from 'node:fs'
 import { matchEntityAt, fixSuggestions, fixBlockReason, findingLocateQuote } from '../../src/utils/insightMatch.js'
 import {
   companyRows, companyShareholders, lawArticle, caseRecord, rawFallback,
-  authoritative, caseRecognition, citationDetail,
+  authoritative, caseRecognition, citationDetail, projectFile,
 } from '../../src/utils/insightDetail.js'
 
 function makeVm(overrides = {}) {
@@ -26,7 +26,7 @@ function makeVm(overrides = {}) {
     refreshDocInsightEntity: async (pid, id) => { calls.refresh.push([pid, id]); return { code: 0, data: { retrievalStatus: 'OK', hasDetail: true, detail: { basic: {} } } } },
     matchEntityAt, fixSuggestions, fixBlockReason, findingLocateQuote,
     companyRows, companyShareholders, lawArticle, caseRecord, rawFallback,
-    authoritative, caseRecognition, citationDetail,
+    authoritative, caseRecognition, citationDetail, projectFile,
   }
   const src = readFileSync(new URL('../../src/components/InsightPane.vue', import.meta.url), 'utf8')
   const script = src.match(/<script>([\s\S]*?)<\/script>/)[1].replace(/^import [\s\S]*?from .*$/gm, '')
@@ -275,6 +275,50 @@ test('实体按 公司 → 法规 → 案例 分组（顺序固定，不跟后�
   const { vm } = makeVm({ latest: { run: { status: 'DONE' }, entities: ENTS, findings: [] } })
   await vm.load()
   assert.deepEqual(vm.entityGroups.map((g) => g.kind), ['COMPANY', 'LAW', 'CASE'])
+})
+
+// ————————————————— 第四类实体 DOC（dev-board#541） —————————————————
+
+const DOC_HIT = {
+  id: 4, kind: 'DOC', name: '房屋租赁合同.docx', normKey: 'file:21',
+  retrievalStatus: 'OK', retrievalSource: 'project-file', hasDetail: true, mentions: [{ quote: '见《房屋租赁合同》' }],
+}
+const DOC_MISS = {
+  id: 5, kind: 'DOC', name: '补充协议', normKey: '补充协议',
+  retrievalStatus: 'NOT_FOUND', retrievalNote: '项目中未找到该文件', retrievalHint: null,
+  hasDetail: false, mentions: [],
+}
+
+test('DOC 自成一组，且排在案例之后（KIND_ORDER 漏了它就会被兜底归进公司组）', async () => {
+  const { vm } = makeVm({ latest: { run: { status: 'DONE' }, entities: [...ENTS, DOC_HIT], findings: [] } })
+  await vm.load()
+  assert.deepEqual(vm.entityGroups.map((g) => g.kind), ['COMPANY', 'LAW', 'CASE', 'DOC'])
+  const doc = vm.entityGroups.find((g) => g.kind === 'DOC')
+  assert.deepEqual(doc.items.map((e) => e.id), [4])
+})
+
+test('DOC 不给「重试」：它的检索是与项目文件树比对，重试一百次也不会多出一份文件', async () => {
+  const { vm } = makeVm({ latest: { run: { status: 'DONE' }, entities: [DOC_HIT, DOC_MISS], findings: [] } })
+  await vm.load()
+  assert.equal(vm.canParse, true, '前提：写权限在、没在跑——其余实体这时是给「重试」的')
+  assert.equal(vm.showRetry(vm.entities[0]), false)
+  assert.equal(vm.showRetry(vm.entities[1]), false, '未命中同样不给——那是文档的线索，不是我们的故障')
+  assert.equal(vm.noteAction(DOC_MISS), null, '未命中没有 hint，也不该指向设置页')
+})
+
+test('DOC 命中：「打开文件」上抛 open-doc-file{fileId,fileName}；未命中不给按钮', async () => {
+  const { vm, emitted, component } = makeVm({ latest: { run: { status: 'DONE' }, entities: [DOC_HIT, DOC_MISS], findings: [] } })
+  await vm.load()
+  assert.ok(component.emits.includes('open-doc-file'), '没声明的话宿主的 @open-doc-file 收不到')
+
+  vm.details = { 4: { source: 'project-file', fileId: 21, fileName: '房屋租赁合同.docx', filePath: '/p/1/房屋租赁合同.docx' }, 5: null }
+  assert.deepEqual(vm.docOf(DOC_HIT), { fileId: 21, fileName: '房屋租赁合同.docx', filePath: '/p/1/房屋租赁合同.docx' })
+  vm.openDocFile(DOC_HIT)
+  assert.deepEqual(emitted.filter((e) => e[0] === 'open-doc-file'), [['open-doc-file', { fileId: 21, fileName: '房屋租赁合同.docx' }]])
+
+  assert.equal(vm.docOf(DOC_MISS), null)
+  vm.openDocFile(DOC_MISS)
+  assert.equal(emitted.filter((e) => e[0] === 'open-doc-file').length, 1, '没命中的一条一个事件都不许发')
 })
 
 test('实体清单同步给宿主（宿主据此做正文点击匹配）', async () => {

--- a/frontend/tests/insight/insightPane.test.mjs
+++ b/frontend/tests/insight/insightPane.test.mjs
@@ -314,8 +314,8 @@ test('详情懒加载：展开才拉，且同一条只拉一次；hasDetail=fals
   assert.equal(calls.entity.length, 1)
 })
 
-test('光标联动：Cmd/Ctrl 点击 → 选中并展开；普通点击 → 只高亮', async () => {
-  const { vm, calls } = makeVm({ latest: { run: { status: 'DONE' }, entities: ENTS, findings: [] } })
+test('光标联动：Cmd/Ctrl 点击 → 上抛 open-hover；普通点击 → 只高亮（dev-board#541）', async () => {
+  const { vm, calls, emitted } = makeVm({ latest: { run: { status: 'DONE' }, entities: ENTS, findings: [] } })
   await vm.load()
   vm.tab = 'checks'
 
@@ -323,12 +323,16 @@ test('光标联动：Cmd/Ctrl 点击 → 选中并展开；普通点击 → 只�
   assert.equal(vm.highlightId, 2)
   assert.equal(vm.expandedId, null, '普通点击不该抢展开')
   assert.equal(vm.tab, 'checks', '普通点击不该抢 tab')
+  assert.equal(emitted.filter((e) => e[0] === 'open-hover').length, 0)
 
-  vm.onCursorContext({ before: '由京微资易', after: '科技有限公司持有', meta: { metaKey: true } })
-  assert.equal(vm.expandedId, 2)
-  assert.equal(vm.tab, 'retrieval')
+  vm.onCursorContext({ before: '由京微资易', after: '科技有限公司持有', meta: { metaKey: true, hostX: 420, hostY: 310 } })
+  const hover = emitted.filter((e) => e[0] === 'open-hover').pop()
+  assert.equal(hover[1].entity.id, 2)
+  assert.deepEqual([hover[1].x, hover[1].y], [420, 310], '坐标要原样带上去，浮窗才贴得住点击处')
   await new Promise((r) => setTimeout(r, 0))
-  assert.equal(calls.entity.length, 1)
+  assert.equal(vm.expandedId, null, '详情改由浮窗就地给，面板不再抢展开')
+  assert.equal(vm.tab, 'checks', '也不再抢 tab')
+  assert.equal(calls.entity.length, 0, '面板不该再为这一次点击去打一遍详情接口')
 })
 
 test('光标联动：没命中就什么都不动（不清高亮，免得面板一直闪）', async () => {
@@ -337,7 +341,6 @@ test('光标联动：没命中就什么都不动（不清高亮，免得面板�
   vm.highlightId = 2
   vm.onCursorContext({ before: '本次交易的对价为', after: '人民币一亿元', meta: { metaKey: true } })
   assert.equal(vm.highlightId, 2)
-  assert.equal(vm.expandedId, null)
   vm.onCursorContext(null)
   assert.equal(vm.highlightId, 2)
 })

--- a/frontend/tests/insight/insightPopup.test.mjs
+++ b/frontend/tests/insight/insightPopup.test.mjs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 「依据」实体浮窗的坐标纯函数（dev-board#541）。
+//
+// 锁两条：① 客体页坐标必须加上画布 rect 才是宿主页面坐标（缺一样就不弹，别弹到屏幕角落）；
+//         ② 靠边时翻转 / 夹进视口——浮窗出屏等于「Cmd 点了没反应」。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { guestPointToHost, hoverCardPosition, HOVER_OFFSET, HOVER_MARGIN } from '../../src/utils/insightPopup.js'
+
+// ————————————————— 客体页 → 宿主坐标 —————————————————
+
+test('换算：客体页坐标 + 画布 rect = 宿主页面坐标', () => {
+  assert.deepEqual(guestPointToHost({ left: 300, top: 120 }, 40, 60), { x: 340, y: 180 })
+  // rect 是负的（画布被滚上去了一部分）也照加
+  assert.deepEqual(guestPointToHost({ left: -20, top: -5 }, 40, 60), { x: 20, y: 55 })
+})
+
+test('换算：rect 或坐标缺一样就返回 null（调用方据此不弹浮窗）', () => {
+  assert.equal(guestPointToHost(null, 40, 60), null)
+  assert.equal(guestPointToHost({ left: 10 }, 40, 60), null, 'rect 少 top 也不能当 0 用')
+  assert.equal(guestPointToHost({ left: 10, top: 10 }, undefined, 60), null)
+  assert.equal(guestPointToHost({ left: 10, top: 10 }, 40, null), null)
+  assert.equal(guestPointToHost({ left: 10, top: 10 }, NaN, 60), null)
+})
+
+test('换算：坐标 0 是合法坐标，不能被当成缺失', () => {
+  assert.deepEqual(guestPointToHost({ left: 0, top: 0 }, 0, 0), { x: 0, y: 0 })
+})
+
+// ————————————————— 落点与翻转 —————————————————
+
+const VP = { viewportWidth: 1200, viewportHeight: 800 }
+const CARD = { width: 320, height: 240 }
+
+test('落点：地方够就摆在点击点的右下方', () => {
+  const p = hoverCardPosition({ x: 400, y: 300, ...CARD, ...VP })
+  assert.deepEqual(p, { left: 400 + HOVER_OFFSET, top: 300 + HOVER_OFFSET, flipX: false, flipY: false })
+})
+
+test('落点：右边放不下就翻到点击点左侧', () => {
+  const p = hoverCardPosition({ x: 1100, y: 300, ...CARD, ...VP })
+  assert.equal(p.flipX, true)
+  assert.equal(p.left, 1100 - HOVER_OFFSET - CARD.width)
+  assert.equal(p.flipY, false)
+})
+
+test('落点：下边放不下就翻到点击点上方', () => {
+  const p = hoverCardPosition({ x: 400, y: 700, ...CARD, ...VP })
+  assert.equal(p.flipY, true)
+  assert.equal(p.top, 700 - HOVER_OFFSET - CARD.height)
+})
+
+test('落点：右下角两边一起翻', () => {
+  const p = hoverCardPosition({ x: 1150, y: 780, ...CARD, ...VP })
+  assert.equal(p.flipX, true)
+  assert.equal(p.flipY, true)
+  assert.ok(p.left + CARD.width <= 1200 - HOVER_MARGIN)
+  assert.ok(p.top + CARD.height <= 800 - HOVER_MARGIN)
+})
+
+test('落点：翻过去也放不下（视口比卡片还小）就贴边夹住，绝不出屏', () => {
+  const p = hoverCardPosition({ x: 10, y: 10, width: 320, height: 240, viewportWidth: 200, viewportHeight: 150 })
+  assert.equal(p.left, HOVER_MARGIN)
+  assert.equal(p.top, HOVER_MARGIN)
+  assert.equal(p.flipX, false, '翻过去更糟就别翻')
+})
+
+test('落点：靠左上边缘点击时不会被推成负坐标', () => {
+  const p = hoverCardPosition({ x: 0, y: 0, ...CARD, ...VP })
+  assert.ok(p.left >= HOVER_MARGIN)
+  assert.ok(p.top >= HOVER_MARGIN)
+})
+
+test('落点：任何点击点都留在视口内（扫一遍边界）', () => {
+  for (const x of [0, 1, 599, 1199, 1200, 5000]) {
+    for (const y of [0, 1, 399, 799, 800, 5000]) {
+      const p = hoverCardPosition({ x, y, ...CARD, ...VP })
+      assert.ok(p.left >= HOVER_MARGIN, `left ${p.left} @(${x},${y})`)
+      assert.ok(p.top >= HOVER_MARGIN, `top ${p.top} @(${x},${y})`)
+      assert.ok(p.left + CARD.width <= VP.viewportWidth - HOVER_MARGIN, `right @(${x},${y})`)
+      assert.ok(p.top + CARD.height <= VP.viewportHeight - HOVER_MARGIN, `bottom @(${x},${y})`)
+    }
+  }
+})


### PR DESCRIPTION
## 改动
**浮窗预览**
- 客体页点击路径随 `cursor-context` 透传 `clientX/clientY`，宿主按 webview/iframe rect 换算成页面坐标。
- 新增 `InsightHoverCard`（贴点击处、靠边翻转、Esc/遮罩关闭）与 `InsightEntityDetailPane`，共用 `InsightEntityBody` 渲染，字段整形全走 `insightDetail.js`。
- 「在新标签页打开」→ `openInsightEntityTab`：未分屏则开分屏落右侧，单例标签跨两侧查重；`tabType` `insight-entity` 入 `NON_FILE_TAB_TYPES`。
- 实体索引在文档标签激活时预取，「依据」窗格关着也能 Cmd 点击；未解析文档零开销。浮窗期间计入 `desktopOverlayActive`。

**「文档」DOC 实体（后端）**
- `DOC_TITLE` 正则与 `LAW_TITLE` 互补，同一书名号只落一类；不改 LLM 提示词。
- pipeline 在 merge 后 `resolveDocFiles`：文件名归一后相等优先、包含次之，命中 normKey 改写 `file:<id>` 合并多处提及，detail 带 `fileId/fileName/filePath`；未命中 NOT_FOUND「项目中未找到该文件」。`retrieveOne` 对 DOC 整段 return。

**DOC（前端）**
- 依据窗格 DOC 分组（排在案例之后）、不给重试；浮窗命中显示「打开文件」→ 默认右侧分屏 `openFile`，已开只激活。

## 验证
- `npm run test:insight` 115/115（新增 24 例，还原病灶转红核对）；`mvn test` 全量 3436 通过（DocInsight* 70）；check:emits/locales/spdx 通过；`build:h5`、`build:zetaoffice` DONE。
- 未验证：真机 Cmd 点击端到端（客体页坐标 → 浮窗落点）、浮窗压 `<webview>` 的观感。老文档需「重新解析」才会出现 DOC 类。

dev-board#541

🤖 Generated with [Claude Code](https://claude.com/claude-code)