### PR TITLE
chore(release): v0.38.0 版本准备 / prepare full release

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiworkdeck-desktop",
-  "version": "0.22.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiworkdeck-desktop",
-      "version": "0.22.0",
+      "version": "0.38.0",
       "devDependencies": {
         "cross-env": "^7.0.3",
         "electron": "^30.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
将桌面版本升至 0.38.0，并同步锁文件的根版本。主干已将四个 Python 服务改为按需组件，需要全量版本；此 PR 只准备版本，不创建应用 tag。四个 runtime pack v1.0.0 必须在两站发布并验证后，才能发布应用安装包。

Bump the desktop version and root lockfile versions to 0.38.0 for the full release following the optional Python runtime migration. This PR prepares the version only; the application tag remains gated on publishing and verifying all four runtime packs on both mirrors.

验证 / Validation: 22 targeted pack and workflow checks passed; full-release boundary check and diff check passed. CI and Windows build must pass before merge.

跟踪 / Tracking: https://github.com/zeweihan/dev-board/issues/544
