### PR TITLE
fix(release): 修复 Windows 运行时包冒烟路径 / fix pack smoke paths

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -177,6 +177,8 @@ jobs:
           set -euo pipefail
           SVC="${{ steps.svc.outputs.name }}"
           ROOT="$RUNNER_TEMP/packroot"
+          # RUNNER_TEMP 在 Windows 是 D:\...；GNU tar -C 要 Git Bash 的 POSIX 路径。
+          if [ "${{ matrix.plat }}" = "win-x64" ]; then ROOT="$(cygpath -u "$ROOT")"; fi
           rm -rf "$ROOT"; mkdir -p "$ROOT"
           # 按桌面端 resolveServiceRoot 的落盘布局解开：<root>/lib 与 <root>/app
           for f in pack-out/${{ matrix.plat }}/*-lib-*.tar.gz; do
@@ -199,6 +201,8 @@ jobs:
             PY="$PWD/desktop/bundled/win-x64/python/python.exe"
           fi
           export PYTHONPATH="$ROOT/lib"
+          # 环境变量直接交给原生 Python，不能沿用 /d/... 的 Bash 路径。
+          if [ "${{ matrix.plat }}" = "win-x64" ]; then export PYTHONPATH="$(cygpath -w "$PYTHONPATH")"; fi
           BODY_GREP=""
           EXTRA_URL=""
           EXTRA_GREP=""

--- a/desktop/tests/workflow-release-gating.test.js
+++ b/desktop/tests/workflow-release-gating.test.js
@@ -253,6 +253,36 @@ test('pack-release.yml：runtime 腿必须真起一次服务打 /health，不能
   assert.match(PACK_RELEASE, /\/health|\/docs/)
 })
 
+// 执行实际冒烟准备代码：GNU tar 要 POSIX 路径，原生 Python 的环境变量要 Windows 路径。
+// 本机没有 cygpath，仅替换这个平台边界与文件系统写操作；服务启动仍由真实双平台 CI 验证。
+for (const plat of ['win-x64', 'mac-arm64']) {
+  test(`pack smoke paths reach tar and native Python in their platform format (${plat})`, () => {
+    const step = PACK_RELEASE_DOC.jobs.runtime.steps.find((s) => s.name === 'Smoke test from pack layout')
+    const setup = step.run.slice(0, step.run.indexOf('BODY_GREP='))
+      .replace(/\$\{\{ matrix.plat \}\}/g, plat)
+      .replace(/\$\{\{ steps.svc.outputs.name \}\}/g, 'asr-service')
+    const result = require('child_process').spawnSync('bash', ['-e', '-c', `
+      rm() { :; }; mkdir() { :; }; cp() { :; }
+      cygpath() {
+        case "$1:$2" in
+          '-u:D:\\a\\runner temp/packroot') printf '%s' '/d/a/runner temp/packroot' ;;
+          '-w:/d/a/runner temp/packroot/lib') printf '%s' 'D:\\a\\runner temp\\packroot\\lib' ;;
+          *) return 71 ;;
+        esac
+      }
+      ${setup}
+      printf '%s\\n' "$ROOT" "$PYTHONPATH"
+    `], {
+      cwd: require('os').tmpdir(), encoding: 'utf8',
+      env: { PATH: process.env.PATH, RUNNER_TEMP: plat === 'win-x64' ? 'D:\\a\\runner temp' : '/tmp/runner temp' },
+    })
+    assert.equal(result.status, 0, result.stderr)
+    assert.deepStrictEqual(result.stdout.trim().split('\n'), plat === 'win-x64'
+      ? ['/d/a/runner temp/packroot', 'D:\\a\\runner temp\\packroot\\lib']
+      : ['/tmp/runner temp/packroot', '/tmp/runner temp/packroot/lib'])
+  })
+}
+
 test('pack-release.yml：不缓存 pysvc（pack 产物必须每次从 requirements.lock 真装一遍）', () => {
   assert.doesNotMatch(PACK_RELEASE, /actions\/cache@[^\n]*\n[\s\S]{0,400}?pysvc/)
 })


### PR DESCRIPTION
四个运行时包首次发布时，Windows 冒烟把 `RUNNER_TEMP=D:\a\_temp` 直接传给 Git Bash 的 GNU tar，解压在启动服务之前失败。为 tar 将临时包根目录转换为 POSIX 路径，交给原生 Python 的 `PYTHONPATH` 则显式转回 Windows 路径。

The first runtime-pack release failed before service startup because GNU tar could not consume the Windows-form `RUNNER_TEMP` path. Normalize the pack root for Bash/tar and use a native Windows path for Python's environment.

验证 / Validation:
- 新增执行真实工作流准备代码的路径回归，Windows 用例先红后绿，Mac 路径及空格保留通过。
- 24 条定向打包与工作流测试通过；`git diff --check` 通过。
- 原始失败：https://github.com/zeweihan/aiworkdeck/actions/runs/34334310293
- asr-runtime 真实 Mac/Windows 打包、服务冒烟和 prerelease 全通过：https://github.com/zeweihan/aiworkdeck/actions/runs/34334848011 。双站发布仍等待本修复合并。

Tracks https://github.com/zeweihan/dev-board/issues/544 . No application tag or service business-code changes.
