### PR TITLE
test(meeting): 修 MeetingTranscriptionTimeoutTest.startTranscriptionStampsAnchor 间歇性红（dev-board#545）

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -965,6 +965,17 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
     两者混成 0 的后果是：刚跑完一场两小时转写的用户看到「本月 0 Credits」，
     他的下一步是来问账是不是没记上。
 
+43. **测 `startTranscription` 时，先把后台线程卡住再断言状态**。`save` 桩原样返回入参，
+    返回值与测试持有的实体是**同一个可变实例**；提交后 `executor` 里的 submit 第一步
+    `findById` 拿到同一实例，紧接着因桩里没有音频文件走 `failMeeting` 写成 FAILED，
+    与断言抢跑。本机断言总是先做完永远复现不出，CI 上已经三次翻红（08-30 / 09-03 /
+    09-09，三条不同用例，每次都是 expected TRANSCRIBING but was FAILED）。生产没有
+    这个竞态（JPA 给后台线程另一份实例），所以修在测试：在 `findById` 桩里按线程身份
+    把非调用线程 `await` 在一把 latch 上，断言做完 `finally` 放行——
+    `MeetingTranscriptionTimeoutTest.startTranscriptionStampsAnchor` 与
+    `MeetingTranscriptionServiceTest.concurrentStartTranscriptionOnlySubmitsOnce` 是现成写法。
+    要「还原病灶」就在断言前插 200ms 睡眠，必红。
+
 ## 团队通道（2026-09-07，dev-board#496）
 
 律所管理者在 IDE 内看全所使用统计。设计 `docs/superpowers/specs/2026-09-07-law-firm-team-usage-design.md`

--- a/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionTimeoutTest.java
+++ b/backend/src/test/java/com/checkba/service/meeting/MeetingTranscriptionTimeoutTest.java
@@ -19,6 +19,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -206,12 +208,30 @@ class MeetingTranscriptionTimeoutTest {
         m.setTitle("会议 09-09 10:00");
         m.setStatus(MeetingRecording.STATUS_RECORDED);
         m.setCreatedBy(10001L);
-        when(meetingRepository.findById(7L)).thenReturn(Optional.of(m));
+        // save 原样返回入参，startTranscription 的返回值与 m 是同一个可变实例。提交后
+        // executor 里的 submitToTingwu 第一步就是 findById，紧接着因为桩里没有音频文件
+        // 走 failMeeting 把这同一个实例写成 FAILED——它与下面的断言抢跑，本机机器快、
+        // 断言总是先做完所以从不复现，CI 上 2026-09-09 两次翻红（expected TRANSCRIBING
+        // but was FAILED）。把后台线程卡在 findById 上直到断言做完，这个与被测语义
+        // （进入转写中时写下锚点）无关的写入就进不来。生产上不存在这个竞态：JPA 给
+        // 后台线程的是另一份实例。
+        Thread caller = Thread.currentThread();
+        CountDownLatch releaseBackground = new CountDownLatch(1);
+        when(meetingRepository.findById(7L)).thenAnswer(inv -> {
+            if (Thread.currentThread() != caller) {
+                releaseBackground.await(5, TimeUnit.SECONDS);
+            }
+            return Optional.of(m);
+        });
 
-        MeetingRecording out = service().startTranscription(7L);
-        assertEquals(MeetingRecording.STATUS_TRANSCRIBING, out.getStatus());
-        assertNotNull(out.getTranscribingStartedAt(), "没有这个锚点，卡死判定就无从算起");
-        assertTrue(out.getTranscribingStartedAt().isAfter(LocalDateTime.now().minusMinutes(1)));
+        try {
+            MeetingRecording out = service().startTranscription(7L);
+            assertEquals(MeetingRecording.STATUS_TRANSCRIBING, out.getStatus());
+            assertNotNull(out.getTranscribingStartedAt(), "没有这个锚点，卡死判定就无从算起");
+            assertTrue(out.getTranscribingStartedAt().isAfter(LocalDateTime.now().minusMinutes(1)));
+        } finally {
+            releaseBackground.countDown();
+        }
     }
 
     // ==================== 进度提示 ====================


### PR DESCRIPTION
## 现象
CI Backend (mvn test) 间歇性红，固定是 `MeetingTranscriptionTimeoutTest.startTranscriptionStampsAnchor`：`expected: <TRANSCRIBING> but was: <FAILED>`。2026-09-09 master 27637ea0 与 PR #782 各一次，重跑即绿。

## 根因
`save` 桩原样返回入参，`startTranscription` 的返回值与测试持有的 `m` 是同一个可变实例。提交后 `executor` 里的 `submitToTingwu` 第一步 `findById` 拿到同一实例，紧接着因桩里没有音频文件走 `failMeeting` 写成 FAILED，与断言抢跑。

- 本机 JDK 21 循环 30 次：0/30 复现（断言总是先做完）。
- 在断言前插 200ms 间隔：3/3 必红，错误文本与 CI 一字不差。锁定病灶。
- 生产不存在这个竞态：JPA 给后台线程的是另一份实例，`startTranscription` 返回的对象不会被后台改写。所以不动生产代码。

同一竞态此前已在 `MeetingTranscriptionServiceTest` 翻过两次（08-30、09-03），各自局部修掉，这次是第三条用例。

## 修法
与 `concurrentStartTranscriptionOnlySubmitsOnce` 同一套路：`findById` 桩按线程身份把非调用线程 `await` 在 latch 上（5 秒兜底），断言做完 `finally` 放行。测试不再依赖调度时序。

顺手在 `licensing-billing.md` 加地雷 43，记下这个写法与「插 200ms 必红」的还原配方。

## 验证（JDK 21，`mvn -o test -Dtest=...`）
- 修后 + 强制 200ms 间隔：5/5 绿（证明是 gate 在起作用，不是时序运气）
- 修后去掉间隔：30/30 绿
- `com.checkba.service.meeting.*Test` 9 个类 94 条全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)
