### PR TITLE
fix(release): 兼容 Bash 3.2 的独立资源包验证 / brace mirror URLs

### DIFF
--- a/deploy/publish-pack.sh
+++ b/deploy/publish-pack.sh
@@ -298,9 +298,9 @@ cmd_verify() {
   local id="$1" version="$2"
   valid_id "$id"; valid_version "$version"
   local rc=0
-  step "验证北京（$BJ_BASE_URL）"
+  step "验证北京（${BJ_BASE_URL}）"
   verify_mirror "$BJ_BASE_URL" "$id" "$version" || rc=1
-  step "验证新加坡（$SG_BASE_URL）"
+  step "验证新加坡（${SG_BASE_URL}）"
   verify_mirror "$SG_BASE_URL" "$id" "$version" || rc=1
   echo
   if [ $rc -eq 0 ]; then


### PR DESCRIPTION
macOS 自带 Bash 3.2 在 `set -u` 下把 `$BJ_BASE_URL）` 的全角右括号错误解析进变量名，独立 `publish-pack.sh verify` 在发起校验前就报 unbound variable。给北京、新加坡两个显示文本中的变量加花括号明确边界，校验逻辑不变。

On macOS Bash 3.2, the full-width closing parenthesis after an unbraced URL variable is parsed into the variable name. Brace both variables so the standalone verify command reaches both mirror checks. Only these two lines change.

验证 / Validation:
- `/bin/bash` 3.2.57 执行真实 `cmd_verify`、仅替换网络函数：修复前复现 unbound variable，修复后两个镜像检查均被正确调用并返回成功。
- `bash -n deploy/publish-pack.sh` 与 `git diff --check` 通过。
- 四包发布的完整 SHA 校验逻辑未变；当前发布使用已获授权的独立等价验证继续，不阻塞应用 tag。

Tracks https://github.com/zeweihan/dev-board/issues/544 .
