### PR TITLE
fix(editor): 资料预览前收起原生菜单 / dismiss overlapping popup

### DIFF
--- a/frontend/src/composables/zetaOfficeCompletion.js
+++ b/frontend/src/composables/zetaOfficeCompletion.js
@@ -277,6 +277,15 @@ export function attachWritingAssistance({ canvas, input, execute, transport, foc
     e.preventDefault(); invalidate(); const gen = generation, point = { x: e.clientX, y: e.clientY }
     const ctx = await execute('get_completion_context', { radius: 160 }).catch(() => null)
     if (disposed || gen !== generation || !ctx?.success || !ctx.selectedText || !ctx.token || ctx.selectedText.length > 160) return
+    // A real canvas right-click has already opened Qt's native popup. Route
+    // Escape through Qt's keyboard handler: it dismisses that popup while
+    // preserving the selection/token. .uno:Escape would cancel the selection.
+    // Synthetic/input context menus have no Qt popup and must not receive it.
+    if (e.isTrusted && e.target === canvas) {
+      for (const type of ['keydown', 'keyup']) canvas.dispatchEvent(new view.KeyboardEvent(type, {
+        key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true, cancelable: true,
+      }))
+    }
     show('context', ctx.selectedText, point)
     const known = items.find((x) => x.text === ctx.selectedText)
     if (known?.entityId || known?.hasDetail) button(t.detail, () => detailRequest('detail', { entityId: known.entityId, id: known.id }, ctx.token))

--- a/frontend/tests/lowa-e2e/writing-ui.mjs
+++ b/frontend/tests/lowa-e2e/writing-ui.mjs
@@ -13,6 +13,10 @@ try {
   await exec('ui_command', { name: 'select_all' }); await exec('replace_selection', { text: '' })
   await page.evaluate(() => {
     window.__writingRequests = []
+    window.__writingNativeEscapes = 0
+    document.getElementById('qtcanvas').addEventListener('keydown', e => {
+      if (e.key === 'Escape' && !e.isTrusted) window.__writingNativeEscapes++
+    })
     window.addEventListener('message', e => {
       const m = e.data
       if (m?.type !== 'writing-request') return
@@ -47,11 +51,17 @@ try {
   await page.keyboard.press('Escape')
   await exec('ui_command', { name: 'select_all' }); await exec('replace_selection', { text: '北京当红晴天律师事务所' })
   await exec('ui_command', { name: 'select_all' })
+  const popupClip = { x: 165, y: 130, width: 305, height: 90 }
+  const unobstructed = await page.screenshot({ clip: popupClip })
   // 真鼠标右键落在已选中的第一行，验证引擎输入转发不会吞掉选区菜单。
   await page.mouse.click(160, 232, { button: 'right' })
   await page.waitForFunction(() => [...document.querySelectorAll('.awd-wa-panel button')].some(b => b.textContent === '查询机构工商信息'))
   await page.evaluate(() => [...document.querySelectorAll('.awd-wa-panel button')].find(b => b.textContent === '查询机构工商信息').click())
   await page.waitForSelector('.awd-wa-panel table')
+  await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))))
+  assert.deepEqual(await page.screenshot({ clip: popupClip }), unobstructed, 'Qt popup is dismissed instead of remaining behind the writing preview')
+  assert.equal(await page.evaluate(() => window.__writingNativeEscapes), 1)
+  assert.deepEqual(await exec('get_selection'), { success: true, text: '北京当红晴天律师事务所', hasSelection: true }, 'closing the Qt popup preserves the original selection')
   assert.equal(await text(), '北京当红晴天律师事务所', 'querying and previewing do not insert content')
   assert.equal(await page.evaluate(() => window.__writingRequests.filter(m => m.action === 'lookup').length), 1)
   await page.screenshot({ path: '/tmp/awd-538-writing-preview.png' })
@@ -59,5 +69,23 @@ try {
   await page.waitForFunction(() => document.querySelector('.awd-wa-panel')?.textContent.includes('已插入'))
   const exported = await page.evaluate(async () => { const r = await window.__loExecutor.executeCommand('export_document', { name: 'writing-ui.docx' }); return { success: r.success, size: r.bytes?.byteLength || r.bytes?.length || 0 } }); assert.ok(exported.success && exported.size > 0)
   await exec('undo'); assert.equal(await text(), '北京当红晴天律师事务所', 'table insertion preserves selected text and undoes in one step')
+  await page.click('.awd-wa-panel button[aria-label="关闭"]')
+  await exec('ui_command', { name: 'escape' })
+  await page.mouse.click(160, 232)
+  // The shorter, unselected-text menu opens below the pointer, unlike the
+  // selected-text menu that Qt shifts upward to fit in this viewport.
+  const normalClip = { x: 165, y: 245, width: 220, height: 80 }
+  const normalBackground = await page.screenshot({ clip: normalClip })
+  await page.mouse.click(160, 232, { button: 'right' })
+  assert.equal((await exec('get_selection')).hasSelection, false)
+  let nativeMenu
+  for (let attempt = 0; attempt < 20; attempt++) {
+    nativeMenu = await page.screenshot({ clip: normalClip })
+    if (!nativeMenu.equals(normalBackground)) break
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+  assert.equal(await page.evaluate(() => window.__writingNativeEscapes), 1, 'ordinary right-click without a selection does not dismiss Qt menus')
+  assert.notDeepEqual(nativeMenu, normalBackground, 'ordinary native context menu remains visible')
+  await page.screenshot({ path: '/tmp/awd-538-writing-native-menu.png' })
   console.log('PASS: real IME → local menu → arrows/Tab → undo; explicit right-click lookup → preview → table → export → undo; no automatic external lookup')
 } finally { await browser.close(); await new Promise(r => server.close(r)) }


### PR DESCRIPTION
选中文字后右键查询资料，Qt 原生菜单会留在写作预览后面。现在仅在真实 canvas 右键且已有有效选区时，把关闭菜单的键盘事件交给 Qt；选区和插入令牌保留，普通右键不受影响。

After a selected-text lookup, Qt's native menu could remain behind the writing preview. Dismiss it through Qt's keyboard handler only for a real canvas context menu with a valid selection. Preserve the selection and insertion token; leave ordinary context menus unchanged.

验证 / Validation: real LOWA screenshot assertion confirms no overlapping menu; selection unchanged, preview does not edit text, table insertion/export/single undo pass, ordinary context menu stays visible. Completion suite 47/47 and editor build pass. No backend or dependency changes.

Follow-up to #784; dev-board#538.
