### PR TITLE
feat(identity): 展示名与头像以官网为权威源，桌面端可改昵称头像，用户名退成内部标识（dev-board#564-567）

### DIFF
--- a/.claude/agents/licensing-billing.md
+++ b/.claude/agents/licensing-billing.md
@@ -47,6 +47,10 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 - `backend/src/main/java/com/checkba/config/LocalModeAccessFilter.java` — 免登模式的每请求准入闸（回环校验 + 反代痕迹拒绝 + 跨站 Origin 硬拦截）。
 - `backend/src/main/java/com/checkba/config/LocalModeLoopbackGuard.java` — 启动强不变式：local-mode 必须绑回环地址，否则拒绝启动。
 - `AuthController.getUserIdFromSession()` 在 local-mode 下把任何请求解析为本机用户（90 余处调用方一行未改）。
+- **`LocalIdentityService` 从不给真实账号改名，但展示名会随官网刷新**（spec 2026-09-10 §5）：
+  `commit()` 那处改名只收窄到 `username=admin`（系统默认账号，「管理员」不是用户自己起的名字）；
+  真实账号的 `displayName` 由 `AccountIdentitySync` 按**官网这个唯一权威源**刷新，
+  不是「一个字都不动」而是「不被本机改名，只随权威源刷新」。两者不冲突：一个是本机替用户做主，一个是随权威源同步。
 - **「本机用户」是库里恒存的中文哨兵，界面语言只在读出来时替换**（`LocalIdentityService.displayNameOf`，
   v0.30.0 + dev-board#351）。库里存的值一个字都不动——改写入侧会让同一个人在中英文界面下留下两种身份。
   出口全集（新增读出口要跟着补，别再漏）：`/api/auth/me`、`/api/local-identity/{status,candidates}`、
@@ -58,11 +62,16 @@ description: 授权与计费领域。任务涉及解锁门（试用码/账户 Ke
 
 **账户连接（PR-B）**
 - `backend/src/main/java/com/checkba/service/account/AccountService.java` — 与官网账户的唯一连接方式是 `awdk_` Key。
-  `~/.aiworkdeck/account.json`（0600）；`connect/disconnect/status/fetchProfile/fetchEntitlements/fetchLedger/fetchAiUsage/fetchAiKey/currentKeyOrNull`。
+  `~/.aiworkdeck/account.json`（0600，字段 `key/username/accountId/displayName/connectedAt/lastSyncAt`）；
+  `connect/disconnect/status/fetchProfile/fetchEntitlements/fetchLedger/fetchAiUsage/fetchAiKey/currentKeyOrNull`，
+  以及个人档案那一组 `profileIdentity/updateDisplayName/uploadAvatar/deleteAvatar`（见下方「身份展示」一节）。
 - `service/account/AccountTransport.java` + `HttpAccountTransport.java` — 出站 HTTP 缝（单测打桩不依赖网络）；固定 HTTP/1.1。
+  `sendMultipart(method,url,bearer,Multipart)` 是头像上传那条路，**默认实现直接抛**——
+  给个默认返回值会让「桩根本没接这条路」在测试里表现成一次成功的上传。
 - `service/account/AccountEndpoint.java` — 授权服务器地址的协议校验（https，回环 http 例外），`LicenseService` 与 `AccountService` 共用。
 - `service/account/AccountException.java` — `Kind`：NETWORK / UNAUTHORIZED / CONFLICT / NOT_CONNECTED / MALFORMED。
-- `backend/src/main/java/com/checkba/controller/AccountController.java` — `/api/account/{status,connect,disconnect,usage}`。
+- `backend/src/main/java/com/checkba/controller/AccountController.java` — `/api/account/{status,connect,disconnect,usage}`
+  以及个人档案 `/api/account/profile`（GET/PUT）与 `/api/account/avatar`（POST multipart/DELETE）。
 - `service/account/AccountSwitchCleanup.java` — **换账户后作废动作的唯一出口**（`afterConnect` / `afterDisconnect`）：
   权益缓存 + 平台 AI 密钥缓存 + 余额判定 + 用量基线四样一起清，disconnect 还要 `demotePlatformProvider()`。
   连接账户有**两个**入口（设置页 `AccountController.connect`、解锁页 `LicenseController.activate` 粘 `awdk_`），
@@ -447,7 +456,11 @@ security.license.trial-code.legacy-grace-until: "2026-09-30"
 | 端点 | 鉴权 | 桌面调用点 |
 |---|---|---|
 | `POST /api/license/verify-key` → `{valid, plan}` | 匿名 | `LicenseService.callVerifyKey` |
-| `GET /api/account/me` → `{username, displayName, balanceCents, plan, createdAt}` | Bearer | `connect()` 校验 Key、`fetchProfile()` 取余额 |
+| `GET /api/account/me` → `{accountId, username, displayName, balanceCents, plan, createdAt, avatarUpdatedAt, displayNameIsDefault}` | Bearer | `connect()` 校验 Key、`fetchProfile()` 取余额、`profileIdentity()` 取身份视图 |
+| `PATCH /api/account/profile` `{displayName?, bio?}` → `{displayName, bio}` | Cookie 或 Bearer | `updateDisplayName()`；400 `invalid_display_name` |
+| `POST /api/account/avatar` multipart `file` → `{avatarUpdatedAt}` | Cookie 或 Bearer | `uploadAvatar()`；4xx `too_large`/`invalid_image`/`unsupported_format` |
+| `DELETE /api/account/avatar` → `{avatarUpdatedAt:null}` | Cookie 或 Bearer | `deleteAvatar()` |
+| `GET /api/avatar/{accountId}?v=` | 匿名 | 头像地址由桌面端按 `accountId` + `avatarUpdatedAt` 拼好下发 |
 | `GET /api/account/entitlements` → `{entitlements:[{feature, purchasedAt, orderId}]}` | Bearer | `fetchEntitlements()` |
 | `GET /api/account/ledger?limit=50` → `{entries:[...]}` | Bearer | `fetchLedger()`，桌面只挑 `kind=ai_alloc` 显示 |
 | `GET /api/account/ai-usage`(*) → `{configured, hasKey, limitUsd, usageUsd, remainingUsd, keyMasked}` | Bearer | `fetchAiUsage()` |
@@ -524,7 +537,9 @@ cost 为 null 原样保留 —— 对账未完成时显示「待结算」，绝�
    选择结果存 `SystemSetting` 而不是 `~/.aiworkdeck/identity.json`：存的是指向同一个库里 user 表的外键，
    放进被指向的库才能与数据同生共死（还原旧库时指针跟着回退）；license/account 描述的是机器授权，独立于库是刻意的。
    测试账号前缀白名单（`qa_bot_` / `claude-e2e` / `e2e_keepalive`）**保守到只排除脚手架自造账号**，
-   真实账号一个都不许被误排。`displayName` 改名收窄到 `username=admin`——改真实账号的名字会让用户在选择页里认不出自己。
+   真实账号一个都不许被误排。`displayName` 改名收窄到 `username=admin`——本机替用户改名会让他在选择页里认不出自己。
+   注意口径（2026-09-10 改写）：真实账号的展示名**不被 `LocalIdentityService` 改名，但会随官网刷新**
+   （`AccountIdentitySync`，官网是唯一权威源）。这条不是「一个字都不动」。
 5. **免费额度只隐藏、不删数据**。这是本领域最硬的一条红线：剪贴板是**查询侧过滤**（超出的行留在库里，
    解锁后原样可见），缓存区是**移入时拒绝**（区内已有文件一个都不动，移出方向永不拦截）。
    全 diff 里没有任何 delete/purge 路径被额度逻辑触发，任何「顺手清理超额记录」的改动都是回归。
@@ -1118,6 +1133,44 @@ return 404 兜底，云后端从 127.0.0.1 直连 Next。云侧唯一出口
 失败绝不免费放行）。**没有新增 ledger kind**（service_spend + meta.service=transfer）。
 细节见 mobile-sync.md「跨设备文件传输」节与官网仓 DEPLOY.md §7.4。
 
+## 身份展示：展示名与头像以官网为唯一权威源（2026-09-10，dev-board#564-#567）
+
+设计 `docs/superpowers/specs/2026-09-10-identity-display-source-design.md`。治的是这个病：
+手机号注册的官网账户自动生成用户名 `u`+随机串、展示名打码手机号，而桌面端 `account.json` 与案件库
+`awd_` 用户在连接/桥接那一刻抄一份展示名之后**永不刷新**，头像各存各的。
+
+**唯一权威源是官网**，本机与案件库都只读、随官网刷新；用户名退成内部标识（**不改名**、任何界面不当名字显示）。
+
+桌面侧（local-mode）四个端点，一律转发官网 + 把结果同步回本机 `User` 行：
+
+| 方法 | 本机路径 | 出站 | 回什么 |
+|---|---|---|---|
+| GET | `/api/account/profile` | `GET /api/account/me` | `{accountId, displayName, avatarUrl, displayNameIsDefault}`，**不回 username** |
+| PUT | `/api/account/profile` | `PATCH /api/account/profile` | 官网回包 `{displayName, bio}` 原样透传 |
+| POST | `/api/account/avatar` | `POST /api/account/avatar`（multipart `file`） | `{avatarUpdatedAt, avatarUrl}` |
+| DELETE | `/api/account/avatar` | `DELETE /api/account/avatar` | `{avatarUpdatedAt:null, avatarUrl:null}` |
+
+要点：
+
+- **本机 PUT / 出站 PATCH** 是刻意偏差，与团队那组同源（uni.request 的 method 枚举里没有 PATCH）。
+- `avatarUrl` 由桌面端按 `accountId` + `avatarUpdatedAt` 拼成 `{base}/api/avatar/{accountId}?v=...`，
+  **没传过头像（`avatarUpdatedAt` 为 null）就回 null**——硬拼一个必然 404 的地址只会让界面白等一次网络请求。
+  `accountId` 连接时落进 `account.json`，老盘没有这一项时补拉一次 `/me` 回填。
+- **同步唯一出口是 `service/account/AccountIdentitySync`**（`refresh` / `refreshQuietly` /
+  `applyDisplayName` / `applyAvatarUrl`），落点四处：连接账户时、每次 `GET /api/account/status`
+  （应用启动会拉）、`GET /api/account/profile`、三个写动作之后。
+  两条红线：**未连接 / 官网不可达时不动本机行也不报错**；**非 local-mode 整条短路**
+  （团队案件库与插件云上账户是机器级状态，按它改某一个租户的 `User` 行是张冠李戴，同 `TeamUsageUploadService` 第二道闸）。
+- `LocalIdentityService` 那条「真实账号 displayName 不动」的纪律**改写为**：不被本机改名，
+  但随官网这个权威源刷新（见「关键文件地图」与地雷 4）。
+- 既有 `POST /api/users/avatar`（本机上传落本机表）**保留给自建服务器**，local-mode 下前端不再调它。
+- `GET /api/account/status` 的回包多一个 `accountId`（就是公开头像地址里的那个 id，不是凭据）。
+- 案件库侧（server，profile `case`）四处一并改：`AwdkLoginService.resolveUser` 每次桥接刷新展示名、
+  `CollaboratorAdmission` 名录回查时刷新、`ProjectMemberController.getMembers` 的头像改走
+  `ProjectMemberService.avatarUrlFor`、`VersionController.userName` 改用展示名（见 version-control.md）。
+  `UserService.refreshDisplayNameFromWebsite` 是这三处共用的唯一写入点：**非空且不同才写，username 一个字不动**。
+- 官网侧的 `displayNameIsDefault` 只用于引导「填写你的姓名」，桌面端不据它做任何拦截。
+
 ## 窄权限内部口第三条：同事名录（2026-09-10，dev-board#550 #551）
 
 官网内部口现在有**三条**，形状完全一致（同机 127.0.0.1 直连 Next、头 `X-Internal-Secret`、
@@ -1141,6 +1194,7 @@ return 404 兜底，云后端从 127.0.0.1 直连 Next。云侧唯一出口
   `service/LicenseServiceTest`、`service/TrialCodeVerifierTest`、`service/LocalIdentityServiceTest`、
   `service/LocalIdentityRealShapeIntegrationTest`（真机形态种子库跑选择链路）、
   `service/account/AccountServiceTest`、`service/account/AccountEndpointTest`、
+  `service/account/AccountIdentitySyncTest`、`controller/AccountControllerProfileTest`（身份展示那一组），
   `service/entitlement/EntitlementServiceTest`、`service/entitlement/FeatureCatalogTest`、
   `service/quota/StageQuotaServiceTest`、`service/storage/StorageLocationServiceTest`、
   `service/ClipboardQuotaTest`、`service/ai/PlatformUsageAccountantTest`、`service/ai/ChatModelFactoryTest`、

--- a/.claude/agents/version-control.md
+++ b/.claude/agents/version-control.md
@@ -202,6 +202,27 @@ description: 项目级版本记录领域。任务涉及版本记录/工作段（
 护栏测试：`ProjectRepoHistoryTest.localUserAuthorIsLocalizedOnReadWithoutRewritingHistory`
 （同一个仓库中/英/中读三遍，值必须来回切得回去，证明提交对象没被改写）。
 
+**新写入的署名是展示名，不是用户名**（spec 2026-09-10 §4，dev-board#564-#567）：
+`VersionController.userName(userId)` 由「`username`，取不到才回『用户』」改成
+「`displayName` → 空则 `username` → 都空才回『用户』」。以前手机号注册的同事在时间线与文档修订里
+就是一串 `awd_upoxwcdtg`——用户名现在是内部标识，任何界面都不再当名字显示。
+**已写入的历史 `authorName` 不回填**（Git 提交对象不重写，同上一条纪律）。
+护栏测试 `version/VersionAuthorNameTest`（两条：展示名优先、空展示名回落用户名）。
+
+**参与人列表的头像与展示名也随官网刷新**（同一份 spec §4）：
+`ProjectMemberController.getMembers`（成员行与 owner 行）的 `avatarUrl` 改走
+**public** 的 `ProjectMemberService.avatarUrlFor(user)`——本机上传过就用本机那份（自建服务器的人工账号），
+否则按 `account_binding` 拼 `{ai.account.base-url}/api/avatar/{accountId}`，两样都没有才是 null，
+与「加同事」确认卡同一个口径。桥接进来的同事本机表里根本没有头像，旧的 `user.getAvatarUrl()`
+在参与人列表里就是一片空白首字母。`username` 字段**保留一版**给老客户端，前端不再读它。
+展示名的刷新点有两处：`AwdkLoginService.resolveUser`（每次桥接）与 `CollaboratorAdmission`
+（每次名录回查，用 `DirectoryReply.account().displayName`），共用唯一写入点
+`UserService.refreshDisplayNameFromWebsite`（**非空且不同才写，username 一个字不动**）。
+`CloudSyncService.proxyMembers` 透传不改。
+护栏测试：`service/ProjectMemberAvatarSourceTest`（真 service + 真 controller 跑 getMembers 四条）、
+`service/account/AwdkLoginServiceTest` 的展示名三条、`service/collab/CollaboratorAdmissionTest` 的刷新两条。
+桌面侧的编辑入口与同步落点见 licensing-billing.md「身份展示」一节。
+
 ## 已知地雷
 
 1. **历史永不重写**——硬不变量，理由与 Git 自己一致，为将来推云端仓库（v2）打基础。唯一例外是删除工作段/稿的分支引用（`deleteBranch(force=true)`）——**删的是引用不是历史**：从未合并的那种（`discardSession`/`abandonDraft`）连内容一起丢是本来的语义，已经合并进主线的那种（`endSession` 两条路径、`adoptDraft`）每一笔提交都还从 master 可达，删掉只是不再留一条对律师本就不可见的分支名。护栏测试：`RepoMaintenanceTest.gcPreservesEveryReachableVersion`，GC 前后逐条比对每个 `VersionEntry.sha()`。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Member invite lookup + case-library share rules
         working-directory: frontend
         run: npm run test:member-invite
+      - name: Display-name-only identity contract (dev-board#564–#567)
+        working-directory: frontend
+        run: npm run test:identity
       - name: Desensitize pane custom-words entry (dev-board#531)
         working-directory: frontend
         run: npm run test:desensitize

--- a/backend/src/main/java/com/checkba/controller/AccountController.java
+++ b/backend/src/main/java/com/checkba/controller/AccountController.java
@@ -6,6 +6,7 @@ package com.checkba.controller;
 import com.checkba.model.entity.TokenUsage;
 import com.checkba.repository.TokenUsageRepository;
 import com.checkba.service.account.AccountException;
+import com.checkba.service.account.AccountIdentitySync;
 import com.checkba.service.account.AccountService;
 import com.checkba.service.account.AccountSwitchCleanup;
 import com.checkba.service.account.MachineAccountGuard;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.util.Comparator;
@@ -43,6 +45,8 @@ import java.util.UUID;
  *   <li>POST /api/account/connect    {"key":"awdk_..."} 校验并落盘</li>
  *   <li>POST /api/account/disconnect 断开并清空权益缓存、平台 AI 密钥缓存</li>
  *   <li>GET  /api/account/usage      平台结算（官网）+ 本地统计（TokenUsage）两套口径</li>
+ *   <li>GET/PUT /api/account/profile 个人档案（展示名/头像地址），PUT 出站到官网是 PATCH</li>
+ *   <li>POST/DELETE /api/account/avatar 头像上传与删除（multipart 转发官网）</li>
  *   <li>GET  /api/account/balance    轻端点，供顶栏高频轮询（内部带 TTL 缓存）</li>
  *   <li>GET  /api/account/membership 会员等级/积分全量转发</li>
  *   <li>POST /api/account/recharge   {"amountCents":N} 发起充值，转发官网 payment/create</li>
@@ -76,6 +80,7 @@ public class AccountController {
     private final com.checkba.service.team.TeamUsageSettings teamUsageSettings;
     private final com.checkba.service.team.TeamUsageUploadService teamUsageUploadService;
     private final com.checkba.service.team.TeamSettingsCache teamSettingsCache;
+    private final AccountIdentitySync identitySync;
 
     public AccountController(AccountService accountService,
                              PlatformAiChannel platformAiChannel,
@@ -85,7 +90,8 @@ public class AccountController {
                              EntitlementService entitlementService,
                              com.checkba.service.team.TeamUsageSettings teamUsageSettings,
                              com.checkba.service.team.TeamUsageUploadService teamUsageUploadService,
-                             com.checkba.service.team.TeamSettingsCache teamSettingsCache) {
+                             com.checkba.service.team.TeamSettingsCache teamSettingsCache,
+                             AccountIdentitySync identitySync) {
         this.accountService = accountService;
         this.platformAiChannel = platformAiChannel;
         this.accountSwitchCleanup = accountSwitchCleanup;
@@ -95,6 +101,7 @@ public class AccountController {
         this.teamUsageSettings = teamUsageSettings;
         this.teamUsageUploadService = teamUsageUploadService;
         this.teamSettingsCache = teamSettingsCache;
+        this.identitySync = identitySync;
     }
 
     /**
@@ -110,6 +117,9 @@ public class AccountController {
     public Map<String, Object> status(
             @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
         requireUser(sessionId);
+        // 应用启动会拉这条：顺手把官网的展示名/头像刷到本机 User 行与 account.json
+        // （spec 2026-09-10 §5）。未连接账户或官网不可达时静默跳过，绝不因此让状态查询失败。
+        identitySync.refreshQuietly();
         Map<String, Object> data = new LinkedHashMap<>(accountService.status());
         // 平台 AI 通道是否可选（未连接账户时前端不展示该供应商）
         data.put("platformAiAvailable", platformAiChannel.isAvailable());
@@ -126,6 +136,9 @@ public class AccountController {
         // 换账户后旧账户的权益、平台密钥、余额判定与用量基线必须立刻作废，不能等下一次刷新。
         // 解锁页那条连接路径共用这一处（AccountSwitchCleanup），别在这里再抄一遍动作
         accountSwitchCleanup.afterConnect();
+        // 新账户的展示名/头像立刻落到本机行：不然刚连上账户的那一刻，参与人列表里
+        // 还是「本机用户」，得等下一次启动才对（spec 2026-09-10 §5）
+        identitySync.refreshQuietly();
         return ok(status);
     }
 
@@ -319,6 +332,88 @@ public class AccountController {
         data.put("feature", purchased.get("feature"));
         data.put("balanceCents", purchased.get("balanceCents"));
         return ok(data);
+    }
+
+    // ==================== 个人档案与头像（spec 2026-09-10 §5） ====================
+    //
+    // 官网的展示名与头像是唯一权威源，这四个端点只是它的一个编辑入口：一律转发官网，
+    // 写成功之后把结果同步回本机 User 行（{@link AccountIdentitySync}）。
+    // 既有的 POST /api/users/avatar（本机上传）保留给自建服务器，local-mode 下前端不再调它。
+
+    /** 头像大小上限，与官网 2MB 同——本机先拦一道，省得把一个大文件白传一趟。 */
+    private static final long MAX_AVATAR_BYTES = 2L * 1024 * 1024;
+
+    /**
+     * 身份视图 {@code {accountId, displayName, avatarUrl, displayNameIsDefault}}。
+     * <b>不回 username</b>：用户名退成内部标识，任何界面都不再当名字显示。
+     * 顺手把这份身份同步到本机 User 行。
+     */
+    @GetMapping("/profile")
+    public Map<String, Object> profile(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
+        return ok(identitySync.refresh());
+    }
+
+    /**
+     * 改昵称：body {@code {displayName}}。本机是 PUT，出站到官网是 PATCH——
+     * 前端只有 uni.request 一个出口，它的 method 枚举里没有 PATCH（同团队那组的刻意偏差）。
+     * 长度与字符的判据在官网，这里只拦「空」。
+     */
+    @PutMapping("/profile")
+    public Map<String, Object> updateProfile(
+            @RequestBody(required = false) Map<String, String> body,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
+        String displayName = body == null ? null : body.get("displayName");
+        if (displayName == null || displayName.isBlank()) {
+            // 文案不含「登录/未授权/请先」，不会被 api.js 误判成掉线
+            throw new IllegalArgumentException(LangText.of("昵称不能为空", "The display name cannot be empty"));
+        }
+        Map<String, Object> updated = accountService.updateDisplayName(displayName);
+        Object next = updated.get("displayName");
+        identitySync.applyDisplayName(next == null ? displayName.trim() : String.valueOf(next));
+        return ok(updated);
+    }
+
+    /** 传头像：multipart 字段 {@code file}，原样转发官网；回 {@code {avatarUpdatedAt, avatarUrl}}。 */
+    @PostMapping("/avatar")
+    public Map<String, Object> uploadAvatar(
+            @RequestParam("file") MultipartFile file,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException(LangText.of("请选择一张图片", "Pick an image first"));
+        }
+        if (file.getSize() > MAX_AVATAR_BYTES) {
+            // 复用官网那张错误码表，两边说同一句话
+            throw new AccountException(AccountException.Kind.REJECTED,
+                    AccountService.rejectedMessage("too_large"), "too_large");
+        }
+        byte[] content;
+        try {
+            content = file.getBytes();
+        } catch (java.io.IOException e) {
+            throw new IllegalArgumentException(LangText.of("读取图片失败，换一张再试", "Could not read that image, try another one"));
+        }
+        Map<String, Object> uploaded = accountService.uploadAvatar(
+                content, file.getOriginalFilename(), file.getContentType());
+        identitySync.applyAvatarUrl(str(uploaded.get("avatarUrl")));
+        return ok(uploaded);
+    }
+
+    /** 删头像：转发官网；回 {@code {avatarUpdatedAt:null, avatarUrl:null}}，本机行的头像一并清空。 */
+    @DeleteMapping("/avatar")
+    public Map<String, Object> deleteAvatar(
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        requireUser(sessionId);
+        Map<String, Object> deleted = accountService.deleteAvatar();
+        identitySync.applyAvatarUrl(str(deleted.get("avatarUrl")));
+        return ok(deleted);
+    }
+
+    private static String str(Object value) {
+        return value == null ? null : String.valueOf(value);
     }
 
     // ==================== 团队（dev-board#496） ====================

--- a/backend/src/main/java/com/checkba/controller/ProjectMemberController.java
+++ b/backend/src/main/java/com/checkba/controller/ProjectMemberController.java
@@ -53,10 +53,13 @@ public class ProjectMemberController {
             map.put("role", member.getRole());
             map.put("joinedAt", member.getJoinedAt());
             if (user != null) {
+                // username 保留一版给老客户端，前端不再读它（spec 2026-09-10 §4/§5：
+                // 用户名退成内部标识，任何界面都不再当名字显示）
                 map.put("username", user.getUsername());
                 // local-mode 下项目 owner/成员可能是库里存了中文哨兵值的本机用户，按界面语言本地化
                 map.put("displayName", LocalIdentityService.displayNameOf(user.getDisplayName()));
-                map.put("avatarUrl", user.getAvatarUrl());
+                // 本机有就本机，否则官网 /api/avatar/{accountId}——与「加同事」确认卡同一个口径
+                map.put("avatarUrl", projectMemberService.avatarUrlFor(user));
             }
             return map;
         }).collect(Collectors.toList());
@@ -72,7 +75,7 @@ public class ProjectMemberController {
                 ownerMap.put("joinedAt", null);
                 ownerMap.put("username", owner.getUsername());
                 ownerMap.put("displayName", LocalIdentityService.displayNameOf(owner.getDisplayName()));
-                ownerMap.put("avatarUrl", owner.getAvatarUrl());
+                ownerMap.put("avatarUrl", projectMemberService.avatarUrlFor(owner));
                 resultList.add(0, ownerMap); // Add to top
             }
         }

--- a/backend/src/main/java/com/checkba/service/ProjectMemberService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectMemberService.java
@@ -303,8 +303,12 @@ public class ProjectMemberService {
      * 头像地址：本机上传过就用本机那份（自建服务器的人工账号），否则按官网账户绑定
      * 拼出官网的公开头像地址。没有绑定就给 null——硬拼一个必然 404 的地址只会让
      * 界面白等一次网络请求，前端本来就有首字母降级。
+     *
+     * <p>public：查人卡片与参与人列表（{@code ProjectMemberController.getMembers}，含 owner 那行）
+     * 共用这一处口径（spec 2026-09-10 §4）。桥接进来的同事本机表里根本没有头像，
+     * 直接回 {@code user.avatarUrl} 的那一版在参与人列表里就是一片空白首字母。
      */
-    private String avatarUrlFor(User user) {
+    public String avatarUrlFor(User user) {
         if (user.getAvatarUrl() != null && !user.getAvatarUrl().isBlank()) {
             return user.getAvatarUrl();
         }

--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -295,6 +295,26 @@ public class UserService {
     }
 
     /**
+     * 展示名随官网刷新（spec 2026-09-10 §4/§5：官网的展示名是唯一权威源）。
+     *
+     * <p>只在官网给了非空值、且与本地这行不同时才写；<b>username 一个字都不动</b>——
+     * 它是内部标识，改名会断掉 {@code /u/用户名} 与 Skill 归属链接。
+     * 官网给空（老账户还没填名字）时保留本地已有的那份，不清成空白。
+     *
+     * <p>这条与 {@code LocalIdentityService.commit} 的「真实账号的 displayName 不动」不冲突：
+     * 那条禁的是本机按 admin 心智替用户改名，这里是随权威源刷新。
+     */
+    public User refreshDisplayNameFromWebsite(User user, String websiteDisplayName) {
+        if (user == null) return null;
+        String next = websiteDisplayName == null ? "" : websiteDisplayName.trim();
+        if (next.isEmpty() || next.equals(user.getDisplayName())) return user;
+        if (next.length() > 128) next = next.substring(0, 128);  // 列宽 128
+        user.setDisplayName(next);
+        user.setUpdatedAt(LocalDateTime.now());
+        return userRepository.save(user);
+    }
+
+    /**
      * 更新用户头像
      */
     public User updateAvatar(Long userId, String avatarUrl) {

--- a/backend/src/main/java/com/checkba/service/account/AccountIdentitySync.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountIdentitySync.java
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.service.account;
+
+import com.checkba.model.entity.User;
+import com.checkba.service.LocalIdentityService;
+import com.checkba.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 官网身份 → 本机 {@code User} 行的**唯一同步点**（spec 2026-09-10 §5）。
+ *
+ * <p>官网的展示名与头像是唯一权威源，本机那份只是它的一份可刷新的副本。落地点有四处：
+ * 连接账户时、每次 {@code GET /api/account/status}（应用启动会拉）、
+ * {@code GET /api/account/profile}，以及个人设置里三个写动作之后。
+ *
+ * <p>与 {@code LocalIdentityService.commit} 那条「真实账号的 displayName 一个字都不动」不冲突：
+ * 那条禁的是本机按 admin 心智替用户改名，这里是随权威源刷新。
+ *
+ * <p>红线：
+ * <ul>
+ *   <li><b>未连接账户 / 官网不可达：不动本机行，也不报错</b>——同步是顺手动作，
+ *       为它把应用启动或设置页搞失败不划算；</li>
+ *   <li><b>非 local-mode 整条短路</b>：团队案件库与插件云上账户是<b>机器级</b>状态，
+ *       按它去改某一个租户的 User 行是张冠李戴（同 TeamUsageUploadService 的第二道闸）。</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+public class AccountIdentitySync {
+
+    private final AccountService accountService;
+    private final LocalIdentityService localIdentityService;
+    private final UserService userService;
+
+    public AccountIdentitySync(AccountService accountService,
+                               LocalIdentityService localIdentityService,
+                               UserService userService) {
+        this.accountService = accountService;
+        this.localIdentityService = localIdentityService;
+        this.userService = userService;
+    }
+
+    /**
+     * 拉官网档案、同步到本机行，返回身份视图
+     * {@code {accountId, displayName, avatarUrl, displayNameIsDefault}}。
+     *
+     * @throws AccountException 未连接（NOT_CONNECTED）/ 官网不可达 —— 调用方要么上抛给用户，
+     *                          要么用 {@link #refreshQuietly()}
+     */
+    public Map<String, Object> refresh() {
+        Map<String, Object> view = accountService.profileIdentity();
+        write(str(view.get("displayName")), true, str(view.get("avatarUrl")));
+        return view;
+    }
+
+    /**
+     * 静默版：连接账户时与 {@code GET /api/account/status}（应用启动会拉）用。失败返回 null。
+     *
+     * <p>非 local-mode 直接短路，连出站都不发：那里同步无处可落，
+     * 而 status 是个会被反复调用的端点，白打一趟官网没有任何意义。
+     */
+    public Map<String, Object> refreshQuietly() {
+        if (!localIdentityService.isLocalMode() || !accountService.isConnected()) {
+            return null;
+        }
+        try {
+            return refresh();
+        } catch (RuntimeException e) {
+            log.debug("身份同步跳过（官网不可达或返回异常）: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /** 改完昵称之后：官网已经写成功了，本机行跟着走。只刷展示名，不碰头像。 */
+    public void applyDisplayName(String displayName) {
+        write(displayName, false, null);
+    }
+
+    /** 传/删完头像之后。{@code null} 表示删掉了——官网没有就是没有。只刷头像，不碰展示名。 */
+    public void applyAvatarUrl(String avatarUrl) {
+        write(null, true, avatarUrl);
+    }
+
+    /**
+     * 唯一写入口。{@code displayName} 为空表示这一项不动（官网也可能确实没有名字，
+     * 那种情况同样保留本机已有的那份，不清成空白）；头像要不要动由 {@code touchAvatar} 说了算，
+     * 因为「清成空」本身就是一种合法的新值。
+     */
+    private void write(String displayName, boolean touchAvatar, String avatarUrl) {
+        if (!localIdentityService.isLocalMode()) {
+            return;
+        }
+        try {
+            Long userId = localIdentityService.localUserId();
+            if (userId == null) return;
+            User user = userService.getUserById(userId);
+            if (user == null) return;
+            if (displayName != null && !displayName.isBlank()) {
+                userService.refreshDisplayNameFromWebsite(user, displayName);
+            }
+            if (touchAvatar && !Objects.equals(user.getAvatarUrl(), avatarUrl)) {
+                userService.updateAvatar(userId, avatarUrl);
+            }
+        } catch (RuntimeException e) {
+            // 本机行同步失败不该冒泡：官网那边已经是对的，下一次启动还会再同步一次
+            log.warn("本机身份行同步失败（不影响官网侧结果）: {}", e.toString());
+        }
+    }
+
+    private static String str(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/account/AccountService.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountService.java
@@ -74,6 +74,8 @@ public class AccountService {
     static class State {
         public String key;
         public String username;
+        /** 官网的稳定账户 id。头像地址 {@code /api/avatar/{accountId}} 要用，省得每次再拉一趟 /me。 */
+        public String accountId;
         public String displayName;
         public String connectedAt;
         public String lastSyncAt;
@@ -102,6 +104,7 @@ public class AccountService {
         State state = new State();
         state.key = key;
         state.username = str(me.get("username"));
+        state.accountId = str(me.get("accountId"));
         state.displayName = str(me.get("displayName"));
         state.connectedAt = Instant.now().toString();
         state.lastSyncAt = state.connectedAt;
@@ -137,6 +140,7 @@ public class AccountService {
         result.put("connected", connected);
         if (connected) {
             result.put("username", state.username);
+            result.put("accountId", state.accountId);
             result.put("displayName", state.displayName);
             result.put("connectedAt", state.connectedAt);
             result.put("lastSyncAt", state.lastSyncAt);
@@ -291,6 +295,132 @@ public class AccountService {
                     LangText.of("官网返回的 AI 通道密钥为空，请稍后重试", "The website returned an empty AI channel key, please retry shortly"));
         }
         return body;
+    }
+
+    // ==================== 个人档案与头像（spec 2026-09-10 §5） ====================
+    //
+    // 官网的展示名与头像是**唯一权威源**，桌面端只是它的一个编辑入口：本机不存第二份真相，
+    // 每一次写都直接打官网，写完把结果同步回本机 User 行（那一步在 AccountIdentitySync）。
+    // 本机 `POST /api/users/avatar` 留给自建服务器，local-mode 下前端不再调它。
+
+    /**
+     * GET /api/account/me 的**身份视图**：{@code {accountId, displayName, avatarUrl, displayNameIsDefault}}。
+     *
+     * <p><b>不含 username</b>：用户名退成内部标识，任何界面都不再当名字显示（spec §2 裁决 5）。
+     * 走 60 秒 profile 缓存（与顶栏余额端点同一份）——应用启动的 status 与个人设置页
+     * 打开的一瞬间会连着问好几次，没必要每次都出网。
+     */
+    public synchronized Map<String, Object> profileIdentity() {
+        String owner = accountFingerprintOrNull();
+        if (owner == null) {
+            // 未连接时 requireKey() 抛 NOT_CONNECTED；连着而指纹算不出来（SHA-256 不可用）时兜个哨兵
+            requireKey();
+            owner = "unknown";
+        }
+        Map<String, Object> me = cachedProfile(owner);
+        rememberIdentity(str(me.get("accountId")), str(me.get("displayName")));
+        return identityView(str(me.get("accountId")), str(me.get("displayName")),
+                str(me.get("avatarUpdatedAt")), Boolean.TRUE.equals(me.get("displayNameIsDefault")));
+    }
+
+    /**
+     * PATCH /api/account/profile —— 改昵称。
+     *
+     * <p>本机那一跳是 PUT（uni.request 的 method 枚举里没有 PATCH），出站到官网仍是 PATCH，
+     * 与团队那组同一处刻意偏差（护栏 {@code AccountServiceTest.teamHierarchyOutboundShape}）。
+     * 长度/字符的判据在官网（400 {@code invalid_display_name}），这里不抄一份。
+     */
+    public Map<String, Object> updateDisplayName(String displayName) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("displayName", displayName == null ? "" : displayName.trim());
+        Map<String, Object> res = sendJson("PATCH", "/api/account/profile", body);
+        String next = str(res.get("displayName"));
+        rememberIdentity(null, next);
+        // 缓存里那份 displayName 已经旧了；下一次 profileIdentity() 必须看到新名字
+        clearBalanceCache();
+        return res;
+    }
+
+    /**
+     * POST /api/account/avatar —— multipart 转发头像。
+     * 回 {@code {avatarUpdatedAt, avatarUrl}}：官网只回版本号，地址在这里按 accountId 拼好，
+     * 省得前端为了一个地址再拉一趟 /me。2MB 上限与格式判据都在官网（{@code too_large} 等）。
+     */
+    public Map<String, Object> uploadAvatar(byte[] content, String filename, String contentType) {
+        String key = requireKey();
+        AccountTransport.Reply reply = transport.sendMultipart(
+                "POST", baseUrl() + "/api/account/avatar", key,
+                new AccountTransport.Multipart("file", filename, contentType, content));
+        if (reply.networkFailure()) {
+            throw networkError();
+        }
+        Map<String, Object> body = handle(reply);
+        String updatedAt = str(body.get("avatarUpdatedAt"));
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("avatarUpdatedAt", updatedAt);
+        result.put("avatarUrl", avatarUrl(accountIdOrFetch(), updatedAt));
+        return result;
+    }
+
+    /** DELETE /api/account/avatar —— 删头像，回 {@code {avatarUpdatedAt:null, avatarUrl:null}}。 */
+    public Map<String, Object> deleteAvatar() {
+        sendJson("DELETE", "/api/account/avatar", null);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("avatarUpdatedAt", null);
+        result.put("avatarUrl", null);
+        return result;
+    }
+
+    /** 身份视图的唯一拼法，profileIdentity 与写入回包共用。 */
+    private Map<String, Object> identityView(String accountId, String displayName,
+                                             String avatarUpdatedAt, boolean displayNameIsDefault) {
+        Map<String, Object> view = new LinkedHashMap<>();
+        view.put("accountId", accountId);
+        view.put("displayName", displayName);
+        view.put("avatarUrl", avatarUrl(accountId, avatarUpdatedAt));
+        view.put("displayNameIsDefault", displayNameIsDefault);
+        return view;
+    }
+
+    /**
+     * 官网公开头像地址。{@code avatarUpdatedAt} 为空表示这个账户根本没传过头像——
+     * 回 null 而不是一个必然 404 的地址（前端本来就有首字母降级）。
+     * {@code ?v=} 是缓存版本号，改了头像地址就变，浏览器不会拿旧的那张。
+     */
+    private String avatarUrl(String accountId, String avatarUpdatedAt) {
+        if (accountId == null || accountId.isBlank()) return null;
+        if (avatarUpdatedAt == null || avatarUpdatedAt.isBlank() || "null".equals(avatarUpdatedAt)) return null;
+        return baseUrl() + "/api/avatar/" + java.net.URLEncoder.encode(accountId, StandardCharsets.UTF_8)
+                + "?v=" + java.net.URLEncoder.encode(avatarUpdatedAt, StandardCharsets.UTF_8);
+    }
+
+    /** account.json 里的 accountId；老版本落的盘没有这一项时补拉一次 /me。 */
+    private String accountIdOrFetch() {
+        State state = loadState();
+        if (state.accountId != null && !state.accountId.isBlank()) return state.accountId;
+        Map<String, Object> me = fetchProfile();
+        String accountId = str(me.get("accountId"));
+        rememberIdentity(accountId, str(me.get("displayName")));
+        return accountId;
+    }
+
+    /**
+     * 把官网那份身份落回 account.json。null 表示这一项不动
+     * （改昵称只知道新名字，不该顺手把 accountId 清掉）。
+     */
+    private synchronized void rememberIdentity(String accountId, String displayName) {
+        State state = loadState();
+        if (state.key == null || state.key.isBlank()) return;
+        boolean changed = false;
+        if (accountId != null && !accountId.isBlank() && !accountId.equals(state.accountId)) {
+            state.accountId = accountId;
+            changed = true;
+        }
+        if (displayName != null && !displayName.isBlank() && !displayName.equals(state.displayName)) {
+            state.displayName = displayName;
+            changed = true;
+        }
+        if (changed) saveState(state);
     }
 
     // ==================== 会员与充值（dev-board#183/#184） ====================
@@ -808,7 +938,7 @@ public class AccountService {
      * 业务机器码的人话（团队端点契约见官网 doc/desktop-contract.md「团队」节）。
      * 文案红线同 {@link #unauthorizedMessage()}：不得含「登录」「未授权」「请先」。
      */
-    static String rejectedMessage(String code) {
+    public static String rejectedMessage(String code) {
         return switch (code) {
             case "phone_required" -> LangText.of("需要在官网账户绑定手机号后，才能创建或加入团队", "Bind a phone number to your website account before creating or joining a team");
             case "already_in_team" -> LangText.of("这个账户已经在一个团队里了", "This account already belongs to a team");
@@ -823,6 +953,11 @@ public class AccountService {
             case "bad_role" -> LangText.of("角色不合法", "That role is not allowed");
             case "bad_name" -> LangText.of("名称不能为空", "The name cannot be empty");
             case "rate_limited" -> LangText.of("操作太频繁，稍后再试", "Too many requests, try again shortly");
+            // 个人档案与头像（spec 2026-09-10 §5，官网 /api/account/profile 与 /api/account/avatar）
+            case "invalid_display_name" -> LangText.of("昵称不合规，换一个（1-24 个字）", "That display name is not allowed; try another one (1-24 characters)");
+            case "too_large" -> LangText.of("图片太大，换一张 2MB 以内的", "That image is too large; pick one under 2MB");
+            case "invalid_image" -> LangText.of("这不是一张能识别的图片", "That file is not a readable image");
+            case "unsupported_format" -> LangText.of("图片格式不支持，用 JPG / PNG / WebP", "That image format is not supported; use JPG, PNG or WebP");
             case "payload_too_large" -> LangText.of("上报数据过大", "The upload is too large");
             default -> LangText.of("官网拒绝了这次操作（", "The website rejected this request (") + code + LangText.of("）", ")");
         };

--- a/backend/src/main/java/com/checkba/service/account/AccountTransport.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountTransport.java
@@ -27,4 +27,17 @@ public interface AccountTransport {
      * @param jsonBody   请求体，null 表示无体
      */
     Reply send(String method, String url, String bearerKey, String jsonBody);
+
+    /** multipart 里的那一个文件部件（头像上传只有一个，没必要做成通用多部件）。 */
+    record Multipart(String fieldName, String filename, String contentType, byte[] content) {}
+
+    /**
+     * multipart/form-data 出站（当前只有头像上传一处）。
+     *
+     * <p>默认实现直接抛：绝大多数打桩 transport 只关心 JSON 那条路，给个默认值
+     * （比如返回 200）会让「桩根本没接这条路」在测试里表现成一次成功的上传。
+     */
+    default Reply sendMultipart(String method, String url, String bearerKey, Multipart part) {
+        throw new UnsupportedOperationException("本 transport 不支持 multipart 出站");
+    }
 }

--- a/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
+++ b/backend/src/main/java/com/checkba/service/account/AwdkLoginService.java
@@ -285,6 +285,10 @@ public class AwdkLoginService {
             AccountBinding binding = existing.get();
             try {
                 User user = userService.getUserById(binding.getUserId());
+                // 展示名以官网为唯一权威源（spec 2026-09-10 §4）：桥接那一刻抄一份、
+                // 之后永不刷新，会让手机号注册的同事在参与人列表与时间线里一直挂着
+                // 官网早就改掉的打码手机号。username 不动——它是内部标识。
+                user = userService.refreshDisplayNameFromWebsite(user, displayName);
                 binding.setLastLoginAt(LocalDateTime.now());
                 bindingRepository.save(binding);
                 return user;

--- a/backend/src/main/java/com/checkba/service/account/HttpAccountTransport.java
+++ b/backend/src/main/java/com/checkba/service/account/HttpAccountTransport.java
@@ -60,4 +60,58 @@ public class HttpAccountTransport implements AccountTransport {
             return new Reply(Reply.NETWORK_FAILURE, null);
         }
     }
+
+    /**
+     * multipart/form-data 出站（头像上传，spec 2026-09-10 §5）。
+     *
+     * <p>JDK HttpClient 没有 multipart 编码器，这里手工拼一份**单部件**报文。
+     * 分隔符用随机串：内容是用户挑的图片二进制，固定分隔符万一在图片里出现，
+     * 服务端会在半截处截断，表现成一张莫名其妙损坏的头像。
+     */
+    @Override
+    public Reply sendMultipart(String method, String url, String bearerKey, Multipart part) {
+        try {
+            String boundary = "----awdk" + java.util.UUID.randomUUID().toString().replace("-", "");
+            String filename = part.filename() == null || part.filename().isBlank() ? "avatar" : part.filename();
+            // 文件名里的引号/换行会破坏头部结构；只留一个安全的形态
+            filename = filename.replaceAll("[\r\n\"\\\\]", "_");
+            String contentType = part.contentType() == null || part.contentType().isBlank()
+                    ? "application/octet-stream" : part.contentType();
+            String head = "--" + boundary + "\r\n"
+                    + "Content-Disposition: form-data; name=\"" + part.fieldName() + "\"; filename=\"" + filename + "\"\r\n"
+                    + "Content-Type: " + contentType + "\r\n\r\n";
+            String tail = "\r\n--" + boundary + "--\r\n";
+            byte[] body = concat(head.getBytes(StandardCharsets.UTF_8),
+                    part.content() == null ? new byte[0] : part.content(),
+                    tail.getBytes(StandardCharsets.UTF_8));
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(TIMEOUT)
+                    .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                    .method(method, HttpRequest.BodyPublishers.ofByteArray(body));
+            if (bearerKey != null) {
+                builder.header("Authorization", "Bearer " + bearerKey);
+            }
+            HttpResponse<String> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            return new Reply(response.statusCode(), response.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new Reply(Reply.NETWORK_FAILURE, null);
+        } catch (Exception e) {
+            log.debug("账户 multipart 请求失败 {} {}: {}", method, url, e.toString());
+            return new Reply(Reply.NETWORK_FAILURE, null);
+        }
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int total = 0;
+        for (byte[] p : parts) total += p.length;
+        byte[] out = new byte[total];
+        int at = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, at, p.length);
+            at += p.length;
+        }
+        return out;
+    }
 }

--- a/backend/src/main/java/com/checkba/service/collab/CollaboratorAdmission.java
+++ b/backend/src/main/java/com/checkba/service/collab/CollaboratorAdmission.java
@@ -6,6 +6,7 @@ package com.checkba.service.collab;
 import com.checkba.model.entity.AccountBinding;
 import com.checkba.model.entity.User;
 import com.checkba.repository.AccountBindingRepository;
+import com.checkba.service.UserService;
 import com.checkba.service.account.AwdkLoginService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,15 +36,18 @@ public class CollaboratorAdmission {
     private final CollaborationPolicy policy;
     private final AccountBindingRepository bindingRepository;
     private final AwdkLoginService awdkLoginService;
+    private final UserService userService;
 
     public CollaboratorAdmission(AccountDirectoryClient directory,
                                  CollaborationPolicy policy,
                                  AccountBindingRepository bindingRepository,
-                                 AwdkLoginService awdkLoginService) {
+                                 AwdkLoginService awdkLoginService,
+                                 UserService userService) {
         this.directory = directory;
         this.policy = policy;
         this.bindingRepository = bindingRepository;
         this.awdkLoginService = awdkLoginService;
+        this.userService = userService;
     }
 
     /** 准入结果：要么给出可以加进案卷的人，要么给出一个说得清下一步的拒绝理由。 */
@@ -81,8 +85,12 @@ public class CollaboratorAdmission {
             }
             DirectoryReply reply = directory.lookupByAccountId(requesterAccountId, candidateAccountId);
             Verdict verdict = policy.check(reply.requester(), reply.candidate());
-            return verdict.allowed() ? new Admission(local.get(), null)
-                    : new Admission(null, verdict.denial());
+            if (!verdict.allowed()) {
+                return new Admission(null, verdict.denial());
+            }
+            // 每次名录回查顺手刷新展示名（spec 2026-09-10 §4）：官网是唯一权威源，
+            // 而桥接那一刻抄下来的那份可能已经是几个月前的打码手机号了。
+            return new Admission(refreshDisplayName(local.get(), reply), null);
         }
 
         DirectoryReply reply = directory.lookupByIdentifier(requesterAccountId, identifier);
@@ -98,6 +106,19 @@ public class CollaboratorAdmission {
                 account.accountId(), account.username(), account.displayName(), account.phone());
         log.info("按官网名录预建协作用户: accountId={} -> userId={}", account.accountId(), bridged.getId());
         return new Admission(bridged, null);
+    }
+
+    /**
+     * 用名录回包里的展示名刷新本机这行。名录 {@code found:true} 时总带 {@code account}，
+     * 但缺了也不该炸——身份行本身是好的，只是名字没能刷新。
+     */
+    private User refreshDisplayName(User user, DirectoryReply reply) {
+        DirectoryAccount account = reply.account();
+        if (account == null) {
+            return user;
+        }
+        User refreshed = userService.refreshDisplayNameFromWebsite(user, account.displayName());
+        return refreshed != null ? refreshed : user;
     }
 
     private String externalAccountId(Long userId) {

--- a/backend/src/main/java/com/checkba/version/VersionController.java
+++ b/backend/src/main/java/com/checkba/version/VersionController.java
@@ -644,12 +644,23 @@ public class VersionController {
         return userId;
     }
 
+    /**
+     * 版本记录里的署名（spec 2026-09-10 §4）：**展示名优先，空了才回落用户名**。
+     *
+     * <p>以前直接写 username，手机号注册的同事在时间线与文档修订里就是一串
+     * {@code awd_upoxwcdtg}——用户名现在是内部标识，任何界面都不再当名字显示。
+     * 已经写进 Git 提交对象的历史 authorName 不回填。
+     */
     private String userName(Long userId) {
         try {
             var u = userService.getUserById(userId);
-            if (u != null && u.getUsername() != null) return u.getUsername();
+            if (u != null) {
+                String display = u.getDisplayName();
+                if (display != null && !display.isBlank()) return display.trim();
+                if (u.getUsername() != null) return u.getUsername();
+            }
         } catch (Exception e) {
-            log.warn("取用户名失败: userId={}", userId, e);
+            log.warn("取署名失败: userId={}", userId, e);
         }
         return LangText.of("用户", "User");
     }

--- a/backend/src/test/java/com/checkba/controller/AccountControllerMachineScopeTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerMachineScopeTest.java
@@ -86,7 +86,8 @@ class AccountControllerMachineScopeTest {
                 entitlementService,
                 mock(com.checkba.service.team.TeamUsageSettings.class),
                 mock(com.checkba.service.team.TeamUsageUploadService.class),
-                mock(com.checkba.service.team.TeamSettingsCache.class));
+                mock(com.checkba.service.team.TeamSettingsCache.class),
+                mock(com.checkba.service.account.AccountIdentitySync.class));
         entitlementController = new EntitlementController(entitlementService, guard);
     }
 

--- a/backend/src/test/java/com/checkba/controller/AccountControllerProfileTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerProfileTest.java
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.controller;
+
+import com.checkba.repository.TokenUsageRepository;
+import com.checkba.service.account.AccountIdentitySync;
+import com.checkba.service.account.AccountService;
+import com.checkba.service.account.AccountSwitchCleanup;
+import com.checkba.service.account.MachineAccountGuard;
+import com.checkba.service.ai.PlatformAiChannel;
+import com.checkba.service.entitlement.EntitlementService;
+import com.checkba.service.team.TeamSettingsCache;
+import com.checkba.service.team.TeamUsageSettings;
+import com.checkba.service.team.TeamUsageUploadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 个人档案与头像的本机透传层（spec 2026-09-10 §5）。
+ *
+ * <p>四个端点一律「转发官网 + 把结果同步回本机 User 行」，本机不存第二份真相。
+ * 动词上有一处刻意偏差：本机是 PUT，出站到官网是 PATCH（uni.request 没有 PATCH），
+ * 与团队那组同源。
+ */
+class AccountControllerProfileTest {
+
+    AccountController controller;
+    AccountService accountService;
+    AccountIdentitySync identitySync;
+
+    @BeforeEach
+    void setUp() {
+        AuthController.registerLocalIdentityService(null);
+        accountService = mock(AccountService.class);
+        identitySync = mock(AccountIdentitySync.class);
+        controller = new AccountController(accountService, mock(PlatformAiChannel.class),
+                mock(AccountSwitchCleanup.class), mock(TokenUsageRepository.class),
+                mock(MachineAccountGuard.class), mock(EntitlementService.class),
+                mock(TeamUsageSettings.class), mock(TeamUsageUploadService.class),
+                mock(TeamSettingsCache.class), identitySync);
+    }
+
+    private static Map<String, Object> view() {
+        Map<String, Object> v = new LinkedHashMap<>();
+        v.put("accountId", "acc_9f3a");
+        v.put("displayName", "185****5325");
+        v.put("avatarUrl", null);
+        v.put("displayNameIsDefault", true);
+        return v;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> data(Map<String, Object> envelope) {
+        assertEquals(0, envelope.get("code"));
+        return (Map<String, Object>) envelope.get("data");
+    }
+
+    @Test
+    @DisplayName("GET /profile：回身份视图，顺手同步本机行；**不回 username**")
+    void getProfileReturnsTheIdentityViewAndSyncs() {
+        when(identitySync.refresh()).thenReturn(view());
+
+        Map<String, Object> data = data(controller.profile(null));
+
+        assertEquals("acc_9f3a", data.get("accountId"));
+        assertEquals("185****5325", data.get("displayName"));
+        assertTrue(data.containsKey("avatarUrl"));
+        assertEquals(Boolean.TRUE, data.get("displayNameIsDefault"));
+        assertFalse(data.containsKey("username"),
+                "用户名退成内部标识，任何界面都不再当名字显示");
+        verify(identitySync).refresh();
+    }
+
+    @Test
+    @DisplayName("PUT /profile：出站改昵称，成功后把新名字同步到本机行")
+    void putProfileForwardsAndSyncs() {
+        when(accountService.updateDisplayName("韩泽伟"))
+                .thenReturn(Map.of("displayName", "韩泽伟"));
+
+        Map<String, Object> data = data(controller.updateProfile(Map.of("displayName", "韩泽伟"), null));
+
+        assertEquals("韩泽伟", data.get("displayName"));
+        verify(accountService).updateDisplayName("韩泽伟");
+        verify(identitySync).applyDisplayName("韩泽伟");
+    }
+
+    @Test
+    @DisplayName("PUT /profile 昵称为空：业务错误，一次出站都不发")
+    void putProfileRejectsBlankName() {
+        assertThrows(IllegalArgumentException.class,
+                () -> controller.updateProfile(Map.of("displayName", "   "), null));
+
+        verify(accountService, never()).updateDisplayName(any());
+        verifyNoInteractions(identitySync);
+    }
+
+    @Test
+    @DisplayName("POST /avatar：multipart 原样转发，成功后把新头像地址同步到本机行")
+    void postAvatarForwardsAndSyncs() throws Exception {
+        Map<String, Object> uploaded = new LinkedHashMap<>();
+        uploaded.put("avatarUpdatedAt", "2026-09-10T09:00:00.000Z");
+        uploaded.put("avatarUrl", "https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=x");
+        when(accountService.uploadAvatar(any(), eq("me.png"), eq("image/png"))).thenReturn(uploaded);
+        MockMultipartFile file = new MockMultipartFile("file", "me.png", "image/png",
+                "PNGDATA".getBytes());
+
+        Map<String, Object> data = data(controller.uploadAvatar(file, null));
+
+        assertEquals("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=x", data.get("avatarUrl"));
+        verify(identitySync).applyAvatarUrl("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=x");
+    }
+
+    @Test
+    @DisplayName("POST /avatar 空文件：业务错误，不把一个 0 字节的东西传上去")
+    void postAvatarRejectsEmptyFile() {
+        MockMultipartFile empty = new MockMultipartFile("file", "me.png", "image/png", new byte[0]);
+
+        assertThrows(IllegalArgumentException.class, () -> controller.uploadAvatar(empty, null));
+
+        verifyNoInteractions(identitySync);
+    }
+
+    @Test
+    @DisplayName("DELETE /avatar：出站删除，本机行的头像跟着清空")
+    void deleteAvatarForwardsAndSyncs() {
+        Map<String, Object> deleted = new LinkedHashMap<>();
+        deleted.put("avatarUpdatedAt", null);
+        deleted.put("avatarUrl", null);
+        when(accountService.deleteAvatar()).thenReturn(deleted);
+
+        Map<String, Object> data = data(controller.deleteAvatar(null));
+
+        assertTrue(data.containsKey("avatarUrl"));
+        assertNull(data.get("avatarUrl"));
+        verify(identitySync).applyAvatarUrl(null);
+    }
+
+    @Test
+    @DisplayName("GET /status：应用启动那一拉顺手把官网身份刷到本机行，官网不可达也不报错")
+    void statusRefreshesIdentityQuietly() {
+        when(accountService.status()).thenReturn(new LinkedHashMap<>(Map.of("connected", true)));
+        when(identitySync.refreshQuietly()).thenReturn(null);
+
+        Map<String, Object> data = data(controller.status(null));
+
+        assertEquals(Boolean.TRUE, data.get("connected"));
+        verify(identitySync).refreshQuietly();
+    }
+}

--- a/backend/src/test/java/com/checkba/controller/AccountControllerPurchaseSkuTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerPurchaseSkuTest.java
@@ -50,7 +50,8 @@ class AccountControllerPurchaseSkuTest {
                 entitlementService,
                 mock(com.checkba.service.team.TeamUsageSettings.class),
                 mock(com.checkba.service.team.TeamUsageUploadService.class),
-                mock(com.checkba.service.team.TeamSettingsCache.class));
+                mock(com.checkba.service.team.TeamSettingsCache.class),
+                mock(com.checkba.service.account.AccountIdentitySync.class));
     }
 
     // ==================== 白名单 ====================

--- a/backend/src/test/java/com/checkba/controller/AccountControllerRechargeTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerRechargeTest.java
@@ -52,7 +52,8 @@ class AccountControllerRechargeTest {
                 mock(com.checkba.service.entitlement.EntitlementService.class),
                 mock(com.checkba.service.team.TeamUsageSettings.class),
                 mock(com.checkba.service.team.TeamUsageUploadService.class),
-                mock(com.checkba.service.team.TeamSettingsCache.class));
+                mock(com.checkba.service.team.TeamSettingsCache.class),
+                mock(com.checkba.service.account.AccountIdentitySync.class));
     }
 
     // ==================== recharge 参数校验：拒绝但绝不 4xx/4010 ====================

--- a/backend/src/test/java/com/checkba/controller/AccountControllerTeamTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerTeamTest.java
@@ -57,7 +57,8 @@ class AccountControllerTeamTest {
         controller = new AccountController(accountService, mock(PlatformAiChannel.class),
                 mock(AccountSwitchCleanup.class), mock(TokenUsageRepository.class),
                 mock(MachineAccountGuard.class), mock(EntitlementService.class),
-                teamUsageSettings, teamUsageUploadService, teamSettingsCache);
+                teamUsageSettings, teamUsageUploadService, teamSettingsCache,
+                mock(com.checkba.service.account.AccountIdentitySync.class));
     }
 
     // ==================== 透传 ====================

--- a/backend/src/test/java/com/checkba/controller/AccountControllerUsageMalformedLedgerTest.java
+++ b/backend/src/test/java/com/checkba/controller/AccountControllerUsageMalformedLedgerTest.java
@@ -42,7 +42,8 @@ class AccountControllerUsageMalformedLedgerTest {
                 mock(com.checkba.service.entitlement.EntitlementService.class),
                 mock(com.checkba.service.team.TeamUsageSettings.class),
                 mock(com.checkba.service.team.TeamUsageUploadService.class),
-                mock(com.checkba.service.team.TeamSettingsCache.class));
+                mock(com.checkba.service.team.TeamSettingsCache.class),
+                mock(com.checkba.service.account.AccountIdentitySync.class));
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/src/test/java/com/checkba/service/ProjectMemberAddByContactTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectMemberAddByContactTest.java
@@ -160,7 +160,7 @@ class ProjectMemberAddByContactTest {
         when(bindings.findByUserId(any())).thenReturn(Optional.empty());
         AwdkLoginService awdk = mock(AwdkLoginService.class);
         service.setCollaboratorAdmissionForTest(new CollaboratorAdmission(
-                directory, new SameFirmOrTeamPolicy(), bindings, awdk));
+                directory, new SameFirmOrTeamPolicy(), bindings, awdk, mock(UserService.class)));
         return awdk;
     }
 

--- a/backend/src/test/java/com/checkba/service/ProjectMemberAvatarSourceTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectMemberAvatarSourceTest.java
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.service;
+
+import com.checkba.model.entity.AccountBinding;
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.ProjectMember;
+import com.checkba.model.entity.User;
+import com.checkba.repository.AccountBindingRepository;
+import com.checkba.repository.ProjectInvitationRepository;
+import com.checkba.repository.ProjectMemberRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.UserRepository;
+import com.checkba.controller.AuthController;
+import com.checkba.controller.ProjectMemberController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * 参与人列表的头像来源（spec 2026-09-10 §4）：桥接进来的同事本机表里根本没有头像，
+ * 直接回 {@code user.avatarUrl} 就是一片空白首字母。改走
+ * {@link ProjectMemberService#avatarUrlFor}——本机有就本机，否则按官网账户绑定
+ * 拼出官网公开头像地址，与「加同事」确认卡同一个口径。
+ *
+ * <p>{@code username} 字段**保留一版**给老客户端，前端不再读它。
+ */
+class ProjectMemberAvatarSourceTest {
+
+    private static final long PROJECT = 7L;
+    private static final long OWNER = 1L;
+    private static final long COLLEAGUE = 4242L;
+    private static final String ACCOUNT_BASE = "https://www.aiworkdeck.com";
+
+    private ProjectMemberRepository memberRepository;
+    private UserRepository userRepository;
+    private ProjectRepository projectRepository;
+    private AccountBindingRepository bindingRepository;
+    private ProjectMemberController controller;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(ProjectMemberRepository.class);
+        userRepository = mock(UserRepository.class);
+        projectRepository = mock(ProjectRepository.class);
+        bindingRepository = mock(AccountBindingRepository.class);
+        ProjectMemberService service = new ProjectMemberService(memberRepository, userRepository,
+                projectRepository, mock(ProjectInvitationRepository.class));
+        service.setAccountLookupForTest(bindingRepository, ACCOUNT_BASE);
+        controller = new ProjectMemberController(service, mock(ClientInvitationService.class),
+                mock(AuthAbuseGuard.class));
+
+        Project project = new Project();
+        project.setId(PROJECT);
+        project.setUserId(OWNER);
+        when(projectRepository.findById(PROJECT)).thenReturn(Optional.of(project));
+        when(userRepository.findById(OWNER)).thenReturn(Optional.of(owner()));
+        when(bindingRepository.findByUserId(any())).thenReturn(Optional.empty());
+    }
+
+    private static User owner() {
+        User u = new User();
+        u.setId(OWNER);
+        u.setUsername("hanzewei");
+        u.setDisplayName("韩泽伟");
+        return u;
+    }
+
+    /** 手机号注册、由「加同事」预建出来的桥接用户：本机没有头像，官网有。 */
+    private static User colleague() {
+        User u = new User();
+        u.setId(COLLEAGUE);
+        u.setUsername("awd_upoxwcdtg");
+        u.setDisplayName("李思");
+        return u;
+    }
+
+    private void hasMember(User user) {
+        ProjectMember member = new ProjectMember();
+        member.setId(11L);
+        member.setProjectId(PROJECT);
+        member.setUserId(user.getId());
+        member.setRole("PARTICIPANT");
+        when(memberRepository.findByProjectId(PROJECT)).thenReturn(List.of(member));
+        when(userRepository.findAllById(any())).thenReturn(List.of(user));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> members() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(OWNER);
+            Map<String, Object> res = controller.getMembers(PROJECT, "sess");
+            assertEquals(0, res.get("code"));
+            return (List<Map<String, Object>>) res.get("data");
+        }
+    }
+
+    private static Map<String, Object> row(List<Map<String, Object>> rows, long userId) {
+        return rows.stream().filter(r -> Long.valueOf(userId).equals(r.get("userId")))
+                .findFirst().orElseThrow(() -> new AssertionError("名单里没有 userId=" + userId));
+    }
+
+    @Test
+    @DisplayName("桥接同事本机没头像：回官网 /api/avatar/{accountId}，不是 null")
+    void bridgedColleagueGetsTheWebsiteAvatar() {
+        User lisi = colleague();
+        hasMember(lisi);
+        AccountBinding binding = new AccountBinding();
+        binding.setUserId(COLLEAGUE);
+        binding.setExternalAccountId("acc-9f");
+        when(bindingRepository.findByUserId(COLLEAGUE)).thenReturn(Optional.of(binding));
+
+        Map<String, Object> row = row(members(), COLLEAGUE);
+
+        assertEquals(ACCOUNT_BASE + "/api/avatar/acc-9f", row.get("avatarUrl"));
+        assertEquals("李思", row.get("displayName"));
+        assertEquals("awd_upoxwcdtg", row.get("username"), "username 保留一版给老客户端");
+    }
+
+    @Test
+    @DisplayName("本机上传过头像（自建服务器的人工账号）：本机那份优先")
+    void localAvatarWins() {
+        User lisi = colleague();
+        lisi.setAvatarUrl("http://127.0.0.1:5269/api/users/avatar/4242_1.png");
+        hasMember(lisi);
+        AccountBinding binding = new AccountBinding();
+        binding.setUserId(COLLEAGUE);
+        binding.setExternalAccountId("acc-9f");
+        when(bindingRepository.findByUserId(COLLEAGUE)).thenReturn(Optional.of(binding));
+
+        assertEquals("http://127.0.0.1:5269/api/users/avatar/4242_1.png",
+                row(members(), COLLEAGUE).get("avatarUrl"));
+    }
+
+    @Test
+    @DisplayName("负责人那一行同享这条：owner 也走官网头像，不是本机的 null")
+    void ownerRowUsesTheSameSource() {
+        hasMember(colleague());
+        AccountBinding binding = new AccountBinding();
+        binding.setUserId(OWNER);
+        binding.setExternalAccountId("acc-me");
+        when(bindingRepository.findByUserId(OWNER)).thenReturn(Optional.of(binding));
+
+        Map<String, Object> row = row(members(), OWNER);
+
+        assertEquals(ACCOUNT_BASE + "/api/avatar/acc-me", row.get("avatarUrl"));
+        assertEquals("ADMIN", row.get("role"));
+    }
+
+    @Test
+    @DisplayName("没有官网绑定也没有本机头像：null，不硬拼一个必然 404 的地址")
+    void noBindingNoAvatar() {
+        hasMember(colleague());
+        assertNull(row(members(), COLLEAGUE).get("avatarUrl"));
+    }
+}

--- a/backend/src/test/java/com/checkba/service/ProjectMemberLookupTest.java
+++ b/backend/src/test/java/com/checkba/service/ProjectMemberLookupTest.java
@@ -214,7 +214,8 @@ class ProjectMemberLookupTest {
             }
         };
         service.setCollaboratorAdmissionForTest(new CollaboratorAdmission(
-                directory, new SameFirmOrTeamPolicy(), bindingRepository, awdkLoginService));
+                directory, new SameFirmOrTeamPolicy(), bindingRepository, awdkLoginService,
+                mock(UserService.class)));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/account/AccountIdentitySyncTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountIdentitySyncTest.java
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.service.account;
+
+import com.checkba.model.entity.User;
+import com.checkba.service.LocalIdentityService;
+import com.checkba.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * 官网身份 → 本机 User 行的唯一同步点（spec 2026-09-10 §5）。
+ *
+ * <p>三条不能退的线：
+ * <ul>
+ *   <li>**未连接账户 / 官网不可达：不动本机行，也不报错**——同步是顺手动作，
+ *       为它把设置页或应用启动搞失败不划算；</li>
+ *   <li>非 local-mode（团队案件库、插件云）整条短路：那里的账户是机器级状态，
+ *       按它去改某一个租户的 User 行是张冠李戴；</li>
+ *   <li>官网展示名为空时保留本机那份，头像则以官网为准（没传过就是没有）。</li>
+ * </ul>
+ */
+class AccountIdentitySyncTest {
+
+    private static final long LOCAL_USER = 42L;
+
+    private AccountService accountService;
+    private LocalIdentityService localIdentityService;
+    private UserService userService;
+    private AccountIdentitySync sync;
+    private User localUser;
+
+    @BeforeEach
+    void setUp() {
+        accountService = mock(AccountService.class);
+        localIdentityService = mock(LocalIdentityService.class);
+        userService = mock(UserService.class);
+        sync = new AccountIdentitySync(accountService, localIdentityService, userService);
+
+        localUser = new User();
+        localUser.setId(LOCAL_USER);
+        localUser.setUsername("hanzewei");
+        localUser.setDisplayName("本机用户");
+
+        lenient().when(localIdentityService.isLocalMode()).thenReturn(true);
+        lenient().when(localIdentityService.localUserId()).thenReturn(LOCAL_USER);
+        lenient().when(userService.getUserById(LOCAL_USER)).thenReturn(localUser);
+        lenient().when(accountService.isConnected()).thenReturn(true);
+    }
+
+    private static Map<String, Object> view(String displayName, String avatarUrl) {
+        Map<String, Object> v = new LinkedHashMap<>();
+        v.put("accountId", "acc_9f3a");
+        v.put("displayName", displayName);
+        v.put("avatarUrl", avatarUrl);
+        v.put("displayNameIsDefault", false);
+        return v;
+    }
+
+    @Test
+    @DisplayName("已连接：官网的展示名与头像一起刷到本机行，视图原样返回")
+    void refreshWritesBothFields() {
+        when(accountService.profileIdentity())
+                .thenReturn(view("韩泽伟", "https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=1"));
+
+        Map<String, Object> got = sync.refresh();
+
+        assertEquals("韩泽伟", got.get("displayName"));
+        verify(userService).refreshDisplayNameFromWebsite(localUser, "韩泽伟");
+        verify(userService).updateAvatar(LOCAL_USER, "https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=1");
+    }
+
+    @Test
+    @DisplayName("官网没有头像：本机那份也清掉——官网是唯一权威源")
+    void refreshClearsAvatarWhenTheWebsiteHasNone() {
+        localUser.setAvatarUrl("http://127.0.0.1:5269/api/users/avatar/42_1.png");
+        when(accountService.profileIdentity()).thenReturn(view("韩泽伟", null));
+
+        sync.refresh();
+
+        verify(userService).updateAvatar(LOCAL_USER, null);
+    }
+
+    @Test
+    @DisplayName("头像没变：不白写一次库")
+    void unchangedAvatarIsNotRewritten() {
+        localUser.setAvatarUrl("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=1");
+        when(accountService.profileIdentity())
+                .thenReturn(view("韩泽伟", "https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=1"));
+
+        sync.refresh();
+
+        verify(userService, never()).updateAvatar(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("未连接账户：不出网、不动本机行、不报错")
+    void notConnectedIsAQuietNoop() {
+        when(accountService.isConnected()).thenReturn(false);
+
+        assertNull(sync.refreshQuietly());
+
+        verify(accountService, never()).profileIdentity();
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("官网不可达：静默版返回 null，本机行一个字不动")
+    void unreachableWebsiteLeavesTheRowAlone() {
+        when(accountService.profileIdentity()).thenThrow(
+                new AccountException(AccountException.Kind.NETWORK, "无法连接 AI WorkDeck 服务器"));
+
+        assertNull(sync.refreshQuietly());
+
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("非 local-mode（团队案件库/插件云）：账户是机器级状态，绝不按它改某个租户的行")
+    void serverModeNeverTouchesAnyRow() {
+        when(localIdentityService.isLocalMode()).thenReturn(false);
+        when(accountService.profileIdentity()).thenReturn(view("韩泽伟", null));
+
+        assertNotNull(sync.refresh(), "视图照常返回，只是不落到本机行");
+        assertNull(sync.refreshQuietly(), "status 那条路直接短路，连出站都不发");
+
+        verifyNoInteractions(userService);
+        verify(accountService, times(1)).profileIdentity();
+    }
+
+    @Test
+    @DisplayName("改完昵称：只刷展示名，不碰头像")
+    void applyDisplayNameOnlyTouchesTheName() {
+        sync.applyDisplayName("韩律师");
+
+        verify(userService).refreshDisplayNameFromWebsite(localUser, "韩律师");
+        verify(userService, never()).updateAvatar(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("传/删完头像：只刷头像，不碰展示名")
+    void applyAvatarOnlyTouchesTheAvatar() {
+        localUser.setAvatarUrl("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=1");
+
+        sync.applyAvatarUrl(null);
+
+        verify(userService).updateAvatar(LOCAL_USER, null);
+        verify(userService, never()).refreshDisplayNameFromWebsite(any(), any());
+    }
+}

--- a/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountServiceTest.java
@@ -61,6 +61,21 @@ class AccountServiceTest {
             }
             return replies.poll();
         }
+
+        /** 最近一次 multipart 出站的那一份，供头像上传的形状断言用。 */
+        Multipart lastPart;
+
+        @Override
+        public Reply sendMultipart(String method, String url, String bearerKey, Multipart part) {
+            calls.add(method + " " + url);
+            bodies.add("");
+            lastBearer = bearerKey;
+            lastPart = part;
+            if (replies.isEmpty()) {
+                throw new AssertionError("桩没有为 " + method + " " + url + " 准备响应");
+            }
+            return replies.poll();
+        }
     }
 
     private StubTransport transport;
@@ -73,7 +88,8 @@ class AccountServiceTest {
 
     private AccountService connected() {
         transport = new StubTransport().enqueue(200,
-                "{\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\",\"balanceCents\":1980,\"plan\":\"paid\"}");
+                "{\"accountId\":\"acc_9f3a\",\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\","
+                        + "\"balanceCents\":1980,\"plan\":\"paid\"}");
         AccountService service = service();
         service.connect(KEY);
         return service;
@@ -447,7 +463,7 @@ class AccountServiceTest {
         transport.enqueue(409, "{\"error\":\"no_allocation\"}");
         AccountException noAllocationEx = assertThrows(AccountException.class, service::fetchAiKey);
 
-        var accountController = new com.checkba.controller.AccountController(null, null, null, null, null, null, null, null, null);
+        var accountController = new com.checkba.controller.AccountController(null, null, null, null, null, null, null, null, null, null);
         var keyController = new com.checkba.controller.PlatformAiKeyController(null, null);
         for (AccountException e : new AccountException[] {notConnectedEx, noAllocationEx}) {
             assertEquals(1, accountController.handleAccountException(e).getBody().get("code"),
@@ -822,6 +838,163 @@ class AccountServiceTest {
                 transport.calls.get(1));
         assertEquals("GET https://www.aiworkdeck.com/api/account/team/summary?range=30&scope=firm",
                 transport.calls.get(2));
+    }
+
+    /** 文案红线：不得含「登录」「未授权」「请先」——api.js 用这三个子串判掉线并清会话。 */
+    private static void assertNotMistakenForLogout(String message) {
+        assertNotNull(message);
+        assertFalse(message.contains("登录"), "文案不得含「登录」: " + message);
+        assertFalse(message.contains("未授权"), "文案不得含「未授权」: " + message);
+        assertFalse(message.contains("请先"), "文案不得含「请先」: " + message);
+    }
+
+    // ==================== 个人档案与头像（spec 2026-09-10 §5） ====================
+
+    private static final String PROFILE_ME =
+            "{\"accountId\":\"acc_9f3a\",\"username\":\"upoxwcdtg\",\"displayName\":\"185****5325\","
+                    + "\"avatarUpdatedAt\":\"2026-09-10T03:04:05.000Z\",\"displayNameIsDefault\":true}";
+
+    @Test
+    @DisplayName("身份视图：一次 GET /me 拉齐，avatarUrl 按 accountId + 版本拼，**不回 username**")
+    void profileIdentityShape() {
+        AccountService service = connected();
+        transport.enqueue(200, PROFILE_ME);
+
+        Map<String, Object> view = service.profileIdentity();
+
+        assertEquals("GET https://www.aiworkdeck.com/api/account/me", transport.calls.get(1));
+        assertEquals("acc_9f3a", view.get("accountId"));
+        assertEquals("185****5325", view.get("displayName"));
+        assertEquals("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=2026-09-10T03%3A04%3A05.000Z",
+                view.get("avatarUrl"));
+        assertEquals(Boolean.TRUE, view.get("displayNameIsDefault"));
+        assertFalse(view.containsKey("username"),
+                "用户名退成内部标识，身份视图里一个字都不回（spec 2026-09-10 §2 裁决 5）");
+    }
+
+    @Test
+    @DisplayName("没传过头像：avatarUpdatedAt 为 null → avatarUrl 为 null，不拼一个必然 404 的地址")
+    void profileIdentityWithoutAvatar() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"accountId\":\"acc_9f3a\",\"displayName\":\"韩泽伟\",\"avatarUpdatedAt\":null}");
+
+        Map<String, Object> view = service.profileIdentity();
+
+        assertNull(view.get("avatarUrl"));
+        assertEquals(Boolean.FALSE, view.get("displayNameIsDefault"), "缺字段按 false，不当成默认名去骚扰用户");
+    }
+
+    @Test
+    @DisplayName("改昵称：本机 PUT，出站到官网必须是 PATCH /api/account/profile（uni.request 没有 PATCH）")
+    void updateDisplayNameOutboundShape() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"displayName\":\"韩泽伟\",\"bio\":null}");
+
+        Map<String, Object> res = service.updateDisplayName("  韩泽伟  ");
+
+        assertEquals("PATCH https://www.aiworkdeck.com/api/account/profile", transport.calls.get(1));
+        assertTrue(transport.bodies.get(1).contains("韩泽伟"), transport.bodies.get(1));
+        assertFalse(transport.bodies.get(1).contains("  韩泽伟"), "首尾空白要去掉");
+        assertEquals("韩泽伟", res.get("displayName"));
+        assertEquals("韩泽伟", service.status().get("displayName"), "account.json 里那份也要跟着刷新");
+    }
+
+    @Test
+    @DisplayName("昵称不合规：官网 400 invalid_display_name 要说人话，别折叠成「Key 无效」")
+    void invalidDisplayNameIsABusinessRejection() {
+        AccountService service = connected();
+        transport.enqueue(400, "{\"error\":\"invalid_display_name\"}");
+
+        AccountException e = assertThrows(AccountException.class, () -> service.updateDisplayName("x".repeat(99)));
+
+        assertEquals(AccountException.Kind.REJECTED, e.getKind());
+        assertEquals("invalid_display_name", e.getReason());
+        assertTrue(e.getMessage().contains("昵称"), e.getMessage());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("传头像：multipart 字段名固定 file，出站带 Bearer，回包给出新的 avatarUrl")
+    void uploadAvatarOutboundShape() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"avatarUpdatedAt\":\"2026-09-10T09:00:00.000Z\"}");
+
+        Map<String, Object> res = service.uploadAvatar("PNGDATA".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                "me.png", "image/png");
+
+        assertEquals("POST https://www.aiworkdeck.com/api/account/avatar", transport.calls.get(1));
+        assertEquals(KEY, transport.lastBearer);
+        assertEquals("file", transport.lastPart.fieldName(), "官网收的字段名就是 file");
+        assertEquals("me.png", transport.lastPart.filename());
+        assertEquals("image/png", transport.lastPart.contentType());
+        assertEquals("2026-09-10T09:00:00.000Z", res.get("avatarUpdatedAt"));
+        assertEquals("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=2026-09-10T09%3A00%3A00.000Z",
+                res.get("avatarUrl"));
+    }
+
+    @Test
+    @DisplayName("老 account.json 里没有 accountId：补拉一次 /me，不把头像地址拼成半截")
+    void uploadAvatarBackfillsAccountIdForLegacyState() {
+        // 本次改造之前落的盘只有 key/username/displayName
+        transport = new StubTransport().enqueue(200, "{\"username\":\"hanzewei\",\"displayName\":\"韩泽伟\"}");
+        AccountService service = service();
+        service.connect(KEY);
+        transport.enqueue(200, "{\"avatarUpdatedAt\":\"2026-09-10T09:00:00.000Z\"}")
+                .enqueue(200, PROFILE_ME);
+
+        Map<String, Object> res = service.uploadAvatar(new byte[]{1}, "me.png", "image/png");
+
+        assertEquals("GET https://www.aiworkdeck.com/api/account/me", transport.calls.get(2));
+        assertEquals("https://www.aiworkdeck.com/api/avatar/acc_9f3a?v=2026-09-10T09%3A00%3A00.000Z",
+                res.get("avatarUrl"));
+        assertEquals("acc_9f3a", service.status().get("accountId"), "补拉到的 accountId 要落盘，下次不用再问");
+    }
+
+    @Test
+    @DisplayName("图片太大：官网 413 too_large 也要说人话")
+    void oversizedAvatarIsABusinessRejection() {
+        AccountService service = connected();
+        transport.enqueue(413, "{\"error\":\"too_large\"}");
+
+        AccountException e = assertThrows(AccountException.class,
+                () -> service.uploadAvatar(new byte[]{1}, "big.png", "image/png"));
+
+        assertEquals(AccountException.Kind.REJECTED, e.getKind());
+        assertEquals("too_large", e.getReason());
+        assertNotMistakenForLogout(e.getMessage());
+    }
+
+    @Test
+    @DisplayName("删头像：DELETE 到官网，回 avatarUpdatedAt=null / avatarUrl=null")
+    void deleteAvatarOutboundShape() {
+        AccountService service = connected();
+        transport.enqueue(200, "{\"avatarUpdatedAt\":null}");
+
+        Map<String, Object> res = service.deleteAvatar();
+
+        assertEquals("DELETE https://www.aiworkdeck.com/api/account/avatar", transport.calls.get(1));
+        assertTrue(res.containsKey("avatarUpdatedAt"));
+        assertNull(res.get("avatarUpdatedAt"));
+        assertTrue(res.containsKey("avatarUrl"));
+        assertNull(res.get("avatarUrl"));
+    }
+
+    @Test
+    @DisplayName("未连接账户：四个动作一律 NOT_CONNECTED，一次出站都不发")
+    void profileActionsRequireAConnectedAccount() {
+        transport = new StubTransport();
+        AccountService service = service();
+
+        assertEquals(AccountException.Kind.NOT_CONNECTED,
+                assertThrows(AccountException.class, service::profileIdentity).getKind());
+        assertEquals(AccountException.Kind.NOT_CONNECTED,
+                assertThrows(AccountException.class, () -> service.updateDisplayName("张三")).getKind());
+        assertEquals(AccountException.Kind.NOT_CONNECTED,
+                assertThrows(AccountException.class,
+                        () -> service.uploadAvatar(new byte[]{1}, "a.png", "image/png")).getKind());
+        assertEquals(AccountException.Kind.NOT_CONNECTED,
+                assertThrows(AccountException.class, service::deleteAvatar).getKind());
+        assertTrue(transport.calls.isEmpty(), "未连接时不该有任何出站: " + transport.calls);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AwdkLoginServiceTest.java
@@ -286,6 +286,54 @@ class AwdkLoginServiceTest {
         assertEquals(second.userId(), bindingsByAccountId.get("acc_9f3a").getUserId());
     }
 
+    // ==================== 展示名随官网刷新（spec 2026-09-10 §4） ====================
+
+    @Test
+    @DisplayName("再次桥接：官网改过的展示名刷到本机行，username 不动")
+    void repeatLoginRefreshesDisplayNameFromWebsite() {
+        transport.enqueue(200, ME_OK)
+                .enqueue(200, "{\"accountId\":\"acc_9f3a\",\"username\":\"hanzewei\",\"displayName\":\"韩律师\"}");
+        AwdkLoginService svc = service(true);
+
+        AwdkLoginService.BridgeSession first = svc.login(KEY);
+        assertEquals("韩泽伟", usersById.get(first.userId()).getDisplayName());
+
+        AwdkLoginService.BridgeSession second = svc.login(KEY);
+
+        assertEquals(first.userId(), second.userId(), "还是同一行，不许因为改名另建一个人");
+        assertEquals("韩律师", usersById.get(second.userId()).getDisplayName());
+        assertEquals("韩律师", second.displayName(), "回包里也得是新名字");
+        assertEquals("awd_hanzewei", usersById.get(second.userId()).getUsername(),
+                "username 是内部标识，改名会断 /u/用户名 与 Skill 归属链接");
+    }
+
+    @Test
+    @DisplayName("官网展示名为空：保留本机已有的那份，不清成空白")
+    void blankWebsiteDisplayNameNeverClobbersLocal() {
+        transport.enqueue(200, ME_OK)
+                .enqueue(200, "{\"accountId\":\"acc_9f3a\",\"username\":\"hanzewei\",\"displayName\":\"  \"}");
+        AwdkLoginService svc = service(true);
+
+        AwdkLoginService.BridgeSession first = svc.login(KEY);
+        AwdkLoginService.BridgeSession second = svc.login(KEY);
+
+        assertEquals(first.userId(), second.userId());
+        assertEquals("韩泽伟", usersById.get(second.userId()).getDisplayName());
+    }
+
+    @Test
+    @DisplayName("ensureBridgedUser 同享这条刷新：名录回来的展示名也要落到已有的那行")
+    void ensureBridgedUserRefreshesDisplayName() {
+        transport.enqueue(200, ME_OK);
+        AwdkLoginService svc = service(true);
+        AwdkLoginService.BridgeSession first = svc.login(KEY);
+
+        User again = svc.ensureBridgedUser("acc_9f3a", "hanzewei", "韩律师", null);
+
+        assertEquals(first.userId(), again.getId());
+        assertEquals("韩律师", usersById.get(first.userId()).getDisplayName());
+    }
+
     // ==================== per-user 平台 AI key（2026-08-07） ====================
 
     @Test

--- a/backend/src/test/java/com/checkba/service/collab/CollaboratorAdmissionTest.java
+++ b/backend/src/test/java/com/checkba/service/collab/CollaboratorAdmissionTest.java
@@ -6,6 +6,7 @@ package com.checkba.service.collab;
 import com.checkba.model.entity.AccountBinding;
 import com.checkba.model.entity.User;
 import com.checkba.repository.AccountBindingRepository;
+import com.checkba.service.UserService;
 import com.checkba.service.account.AwdkLoginService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +65,7 @@ class CollaboratorAdmissionTest {
     private StubDirectory directory;
     private AccountBindingRepository bindingRepository;
     private AwdkLoginService awdkLoginService;
+    private UserService userService;
     private CollaboratorAdmission admission;
 
     @BeforeEach
@@ -72,8 +74,9 @@ class CollaboratorAdmissionTest {
         bindingRepository = mock(AccountBindingRepository.class);
         when(bindingRepository.findByUserId(anyLong())).thenReturn(Optional.empty());
         awdkLoginService = mock(AwdkLoginService.class);
+        userService = mock(UserService.class);
         admission = new CollaboratorAdmission(directory, new SameFirmOrTeamPolicy(),
-                bindingRepository, awdkLoginService);
+                bindingRepository, awdkLoginService, userService);
     }
 
     private static User user(long id, String name) {
@@ -151,6 +154,38 @@ class CollaboratorAdmissionTest {
                 "没有官网身份的人不可能在任何团队里，理由要落在对方身上，不能让律师去查自己的团队");
     }
 
+    @Test
+    @DisplayName("名录回查命中本地已有用户：顺手把官网的展示名刷到本机行（spec 2026-09-10 §4）")
+    void localUserDisplayNameIsRefreshedFromTheDirectoryReply() {
+        bind(REQUESTER, "acc-me");
+        bind(CANDIDATE, "acc-9f");
+        directory.reply = found("team-a", "firm-1", "team-b", "firm-1");
+        User local = user(CANDIDATE, "awd_lisi");
+        local.setDisplayName("138****8000");   // 手机号注册时官网自动生成的打码名
+        when(userService.refreshDisplayNameFromWebsite(local, "李思")).thenAnswer(inv -> {
+            local.setDisplayName("李思");
+            return local;
+        });
+
+        CollaboratorAdmission.Admission a =
+                admission.admit(Optional.of(local), "13800138000", REQUESTER);
+
+        assertSame(local, a.user());
+        assertEquals("李思", a.user().getDisplayName());
+        verify(userService).refreshDisplayNameFromWebsite(local, "李思");
+    }
+
+    @Test
+    @DisplayName("没有官网绑定那一支：不出网，也就没有可刷新的展示名")
+    void localUserWithoutBindingIsNeverRefreshed() {
+        bind(REQUESTER, "acc-me");
+        User local = user(CANDIDATE, "admin");
+
+        admission.admit(Optional.of(local), "admin", REQUESTER);
+
+        verifyNoInteractions(userService);
+    }
+
     // ==================== 本地没有账号 ====================
 
     @Test
@@ -226,7 +261,7 @@ class CollaboratorAdmissionTest {
             }
         };
         CollaboratorAdmission a = new CollaboratorAdmission(broken, new SameFirmOrTeamPolicy(),
-                bindingRepository, awdkLoginService);
+                bindingRepository, awdkLoginService, userService);
 
         assertThrows(DirectoryUnavailableException.class,
                 () -> a.admit(Optional.empty(), "13800138000", REQUESTER));
@@ -237,7 +272,7 @@ class CollaboratorAdmissionTest {
     @DisplayName("open 策略：官网找到就允许，照样预建桥接用户")
     void openPolicyAdmitsAnyoneTheDirectoryKnows() {
         CollaboratorAdmission open = new CollaboratorAdmission(directory, new OpenPolicy(),
-                bindingRepository, awdkLoginService);
+                bindingRepository, awdkLoginService, userService);
         directory.reply = found(null, null, null, null);
         User bridged = user(77L, "awd_lisi");
         when(awdkLoginService.ensureBridgedUser(anyString(), any(), any(), any())).thenReturn(bridged);

--- a/backend/src/test/java/com/checkba/version/VersionAuthorNameTest.java
+++ b/backend/src/test/java/com/checkba/version/VersionAuthorNameTest.java
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.version;
+
+import com.checkba.controller.AuthController;
+import com.checkba.model.entity.User;
+import com.checkba.service.ProjectFileService;
+import com.checkba.service.ProjectMemberService;
+import com.checkba.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * 版本时间线的署名（spec 2026-09-10 §4）：写进 Git 提交对象的作者名以前是 **username**，
+ * 手机号注册的同事在时间线与文档修订里就是一串 {@code awd_upoxwcdtg}。
+ * 改成展示名，展示名为空才回落用户名。已写入的历史 authorName 不回填。
+ */
+@ExtendWith(MockitoExtension.class)
+class VersionAuthorNameTest {
+
+    private static final long PROJECT = 7L;
+    private static final long USER = 1L;
+
+    @Mock private ProjectRepoService repoService;
+    @Mock private WorkSessionService sessionService;
+    @Mock private ProjectMemberService projectMemberService;
+    @Mock private UserService userService;
+    @Mock private ProjectFileService projectFileService;
+    @Mock private com.checkba.service.telemetry.TelemetryService telemetryService;
+    @Mock private VersionLifecycleService lifecycleService;
+
+    @InjectMocks private VersionController controller;
+
+    @BeforeEach
+    void allowWrites() {
+        when(projectMemberService.hasReadPermission(PROJECT, USER)).thenReturn(true);
+        when(projectMemberService.hasWritePermission(PROJECT, USER)).thenReturn(true);
+    }
+
+    private static User user(String username, String displayName) {
+        User u = new User();
+        u.setId(USER);
+        u.setUsername(username);
+        u.setDisplayName(displayName);
+        return u;
+    }
+
+    private void enableAs(User u) {
+        when(userService.getUserById(USER)).thenReturn(u);
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(USER);
+            controller.enable(PROJECT, "sess");
+        }
+    }
+
+    @Test
+    @DisplayName("署名用展示名，不用桥接自动生成的用户名")
+    void authorNameIsTheDisplayName() {
+        enableAs(user("awd_upoxwcdtg", "李思"));
+        verify(sessionService).enableVersionRecording(eq(PROJECT), eq("李思"), anyString());
+    }
+
+    @Test
+    @DisplayName("展示名为空：回落用户名，不留一条没有作者的记录")
+    void blankDisplayNameFallsBackToUsername() {
+        enableAs(user("awd_upoxwcdtg", "  "));
+        verify(sessionService).enableVersionRecording(eq(PROJECT), eq("awd_upoxwcdtg"), anyString());
+    }
+}

--- a/docs/superpowers/specs/2026-09-10-identity-display-source-design.md
+++ b/docs/superpowers/specs/2026-09-10-identity-display-source-design.md
@@ -1,0 +1,96 @@
+# 身份展示统一：展示名与头像以官网为唯一权威源，用户名退成内部标识（dev-board#564 #565 #566 #567）
+
+日期：2026-09-10。涉及官网仓 `aiworkdeck_website` 与本仓（案件库 server、桌面端后端与前端）。
+
+## 1. 问题
+
+手机号注册的官网账户自动生成：用户名 `u`+随机串（如 `upoxwcdtg`），展示名打码手机号（`185****5325`）。
+线上 25 个账户 14 个如此。现状：
+
+- 用户名两边都改不了；展示名只有官网账户页能改；头像官网能改、桌面端也能改但传到本机表，与官网无关。
+- 桌面端 `account.json` 与案件库 `awd_` 用户在连接/桥接那一刻抄一份展示名，之后永不刷新。
+- 同事看到的字段不一致：加人确认卡用展示名 + 官网头像（对）；参与人列表 `displayName || username`、头像用本机那份（桥接用户没有）；
+  **版本时间线作者与文档批注/修订作者直接写用户名**——手机号注册的同事在时间线和修订里就是一串随机字母。
+
+## 2. 维护者裁决（2026-09-10）
+
+1. 官网的展示名与头像是**唯一权威源**，其他地方只读、随官网刷新。
+2. 案件库每次桥接、每次名录回查刷新展示名；参与人列表、版本作者、批注/修订作者一律展示名；头像统一按 accountId 取官网。
+3. 桌面端「个人设置」可改昵称、传头像，**写到官网**；官网补 Bearer awdk_ 版接口；桌面端本机头像上传只留给自建服务器。
+4. 手机号注册默认展示名仍是打码号时，官网与桌面端引导「填写你的姓名」。
+5. 用户名按 uid 处理：**不改名**（改名断 `/u/用户名` 与 Skill 归属链接）、**任何界面不再当名字显示**（含 `@用户名` 小字），
+   用契约测试守住。用户分不清用户名与展示名，那就只给他看一个。
+
+## 3. 官网侧契约（`aiworkdeck_website`）
+
+| 方法 | 路径 | 鉴权 | 变化 |
+|---|---|---|---|
+| GET | `/api/account/me` | Bearer awdk_ | 新增 `avatarUpdatedAt: string \| null`、`displayNameIsDefault: boolean` |
+| PATCH | `/api/account/profile` | **Cookie 或 Bearer**（`resolveSessionOrKeyUser`） | body `{displayName?, bio?}` 不变；回 `{displayName, bio}` |
+| POST | `/api/account/avatar` | Cookie 或 Bearer | multipart `file`，不变；回 `{avatarUpdatedAt}` |
+| DELETE | `/api/account/avatar` | Cookie 或 Bearer | 回 `{avatarUpdatedAt: null}` |
+| GET | `/api/avatar/{accountId}?v=` | 匿名 | 不变 |
+
+`displayNameIsDefault` 的判定放 `lib/users.ts` 单一函数 `isDefaultDisplayName(user)`：展示名为空、等于 `maskPhoneForName(phone)`、
+等于 `maskEmailForName(email)`、或等于 `username`（密码注册留空时的默认）之一。官网账户页 `ProfileCard` 在为真时顶部给一条
+「填写你的姓名，同事在案卷里看到的就是它」横幅，点开即现有 `ProfileDialog`。
+
+`doc/desktop-contract.md` 与 `scripts/contract-check.mts` 同步：`/me` 两个新字段；profile / avatar 三个端点进契约并标「Cookie 或 Bearer」。
+verify 脚本：`verify-profile.mts` 加 Bearer 路径用例（PATCH 昵称、POST/DELETE 头像、`/me` 两字段、默认名判定的四种形态）。
+
+用户名：官网侧**不新增改名接口**；`ProfileCard` 的 `@username · email` 一行去掉 `@username`（邮箱保留，手机号注册的邮箱为空时整行不显示）；
+公开主页 `/u/[username]` 的 `@handle` 小字去掉，URL 不动。
+
+## 4. 案件库 server 侧（本仓 backend，profile `case`）
+
+- `AwdkLoginService.resolveUser`：binding 已存在时，若官网给的 `displayName` 非空且与本地不同，**更新本地 displayName**（username 不动）。
+  `login`、`ensureBridgedUser` 同享。`CollaboratorAdmission` 命中本地已有用户走 `lookupByAccountId` 时，也用回包的 `account.displayName` 刷新
+  （`DirectoryReply.account` 在 `found:true` 时总带）。
+- `ProjectMemberController.getMembers`（含 owner）：`displayName` 照旧，`avatarUrl` 改用 `ProjectMemberService.avatarUrlFor(user)`
+  （本机有就本机，否则官网 `/api/avatar/{accountId}`），**`username` 字段保留一版**给老客户端，前端不再读。
+- `VersionController.userName(userId)`：改为 `displayName`，空则 `username`。已写入的历史 `authorName` 不回填。
+- `CloudSyncService.proxyMembers` 透传不改。
+
+## 5. 桌面端后端（本仓 backend，local-mode）
+
+新增 `AccountProfileController`（或并入既有账户控制器，按 licensing-billing.md 的布局）：
+
+| 方法 | 本机路径 | 出站到官网 | 说明 |
+|---|---|---|---|
+| GET | `/api/account/profile` | `GET /me` | 回 `{accountId, displayName, avatarUrl, displayNameIsDefault}`；`avatarUrl` = `{base}/api/avatar/{accountId}?v={avatarUpdatedAt}`，无头像为 null。**不回 username** |
+| PUT | `/api/account/profile` | `PATCH /api/account/profile` | body `{displayName}`；uni.request 无 PATCH，本机用 PUT（同团队接口先例，`AccountServiceTest.teamHierarchyOutboundShape` 那条纪律） |
+| POST | `/api/account/avatar` | `POST /api/account/avatar` | multipart 转发；2MB 上限沿用官网的错误码 |
+| DELETE | `/api/account/avatar` | `DELETE /api/account/avatar` | |
+
+每次成功写入后、以及 **连接账户时与每次 `GET /api/account/status`（应用启动会拉）** 时，把官网 `displayName`/`avatarUrl` 同步到本机 `User` 行
+（`LocalIdentityService` 的「真实账号 displayName 一个字不动」纪律只针对本机 admin 改名，这里是随权威源刷新，在 licensing-billing.md 改写那条说明）。
+`account.json` 里的 `displayName` 一并刷新。未连接账户或官网不可达：不动本机行，不报错。
+
+既有 `POST /api/users/avatar`（本机上传）保留给自建服务器（非 local-mode）；local-mode 下前端不再调它。
+
+## 6. 桌面端前端（本仓 frontend）
+
+- **个人设置**（`PersonalSettingsPanel.vue`「基本信息」）：头像可点上传/删除，昵称可编辑（上限 24，与官网一致）。
+  local-mode 且已连接账户 → 走 §5 四个端点；自建服务器 → 昵称不可编辑（服务器侧无接口，本期不做）、头像走既有 `POST /api/users/avatar`。
+- **姓名引导**：`displayNameIsDefault` 为真时，个人设置「基本信息」顶部与设置「账户」分区各给一条「填写你的姓名」内联提示，
+  点了就聚焦昵称输入；首次连接账户成功后弹一次（`uni.showModal` 级别即可，可「稍后」）。
+- **用户名清零**：`AdminPane.vue` 侧栏用户卡去掉 `@username` 一行；`CollabDialog.vue` 参与人行 `m.displayName || m.username` 改为
+  `m.displayName || $t(...)`（用既有的兜底文案键，找不到就加 `version.unnamedColleague`「同事」）；`LibreOfficeEditor.currentAuthorName`
+  改为 `displayName || nickname || name`，**不再回落 username**（空则回 `''`，让引擎用默认作者）；`VersionTimeline.vue` 不改（吃后端 authorName）。
+- **契约测试** `frontend/tests/identity/display-name-only.test.mjs`：扫描 `src/**/*.vue`，凡模板插值或 `||` 回落里出现 `.username`
+  即失败；允许名单只放登录表单输入、后台用户管理列表、以及 `AdminPane` 账户分区那一处（如仍需展示登录名给自建服务器用户）——名单写在测试旁的
+  `display-name-only.allowlist.json`，每条带理由。
+
+## 7. 顺序与发版
+
+1. 官网 PR 先合（契约先落地、自动部署）。
+2. 本仓一个 PR 承载 §4 §5 §6；合并后案件库换 jar（§4 立刻生效）。桌面端改动随集中发版。
+3. 复测：手机号注册的同事被加进案卷后，参与人列表、时间线新条目、批注作者都显示展示名；官网改名后重开桌面端两处都跟着变；
+   桌面端个人设置改昵称、传头像，官网账户页立刻一致；默认名时两端都看到「填写你的姓名」。
+
+## 8. 非目标
+
+- 不做用户名改名；不改 `/u/[username]` 路由。
+- 不回填历史版本条目与既有文档里的作者名。
+- 自建服务器（非 local-mode）用户的昵称编辑本期不做。
+- 不改手机号注册的默认生成规则本身（先引导填写，够用）。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,7 @@
     "test:capabilities": "node --test tests/capabilities/*.test.mjs",
     "test:team": "node --test tests/team/*.test.mjs",
     "test:member-invite": "node --test tests/member-invite/*.test.mjs",
+    "test:identity": "node --test tests/identity/*.test.mjs",
     "test:optional-components": "node --test tests/optional-components/*.test.mjs",
     "test:desensitize": "node --test tests/desensitize/*.test.mjs"
   },

--- a/frontend/src/components/LibreOfficeEditor.vue
+++ b/frontend/src/components/LibreOfficeEditor.vue
@@ -161,12 +161,14 @@ import { guestPointToHost } from '@/utils/insightPopup.js'
 
 let seq = 0
 
-// 当前登录用户名。两个地方要用同一个串：随 load_document 传给引擎（用户本人的
+// 当前用户的展示名。两个地方要用同一个串：随 load_document 传给引擎（用户本人的
 // 修订以此署名）与审阅面板的「我」这一桶（dev-board#377）。抽成一处，免得哪天
 // 一边加了兜底另一边没加，用户自己的修订被归成「其他人」。
+// **不许回落 username**（Spec §6）：手机号注册的用户名是 `u`+随机串，落进批注与修订
+// 就是永久的——历史条目不回填。取不到名字宁可给空串，让引擎用它自己的默认作者。
 function currentAuthorName() {
   const u = getCurrentUser() || {}
-  return String(u.name || u.nickname || u.username || '')
+  return String(u.displayName || u.nickname || u.name || '')
 }
 
 export default {

--- a/frontend/src/components/admin/AdminPane.vue
+++ b/frontend/src/components/admin/AdminPane.vue
@@ -21,7 +21,8 @@
       <view class="admin-sidebar">
         <!-- 用户信息卡取代了原来的纯 logo 头部（2026-08-20 个人中心并进本页）：
              这一页现在同时是「我的」和「系统的」，顶上摆的应该是「我是谁」。
-             头像可点，走的还是原个人中心那条 uni.chooseImage + uploadAvatar。 -->
+             头像可点：local-mode 且已连接账户时写官网（展示名与头像的唯一权威源），
+             自建服务器仍走原来那条 uni.chooseImage + uploadAvatar。 -->
         <view class="sidebar-user">
           <view class="user-avatar-wrapper" @tap="triggerAvatarUpload">
             <image
@@ -35,7 +36,6 @@
             </view>
           </view>
           <text class="user-name">{{ userInfo.displayName || $t('account.defaultUserName') }}</text>
-          <text class="user-handle">@{{ userInfo.username || userInfo.id || 'unknown' }}</text>
           <view class="user-role-tag">
             <text class="role-text">{{ $t('account.standardUserRole') }}</text>
           </view>
@@ -391,17 +391,22 @@
                 <text class="section-subtitle">{{ $t('admin.accountConnectedSubtitle') }}</text>
               </view>
               <view class="section-body">
-                <!-- 账户卡（dev-board#200/#205）：一行排布——左边身份（头像/显示名/用户名），
+                <!-- 账户卡（dev-board#200/#205）：一行排布——左边身份（头像/展示名），
                      右边两个动作按齐。「断开连接」已统一成「退出登录」（utils/signOut.js
-                     唯一编排：摘账户连接，账户模式顺带清授权票据，回启动页重跑分流）。 -->
+                     唯一编排：摘账户连接，账户模式顺带清授权票据，回启动页重跑分流）。
+                     用户名一行已按 Spec §6 去掉：它是 uid，不是名字，用户分不清两者。 -->
                 <view class="provider-card account-card">
+                  <!-- 姓名引导：手机号注册的默认展示名是打码手机号，同事在案卷里看到的就是它 -->
+                  <view v-if="accountProfile.displayNameIsDefault" class="account-name-nudge" @tap="goFillName">
+                    <text class="account-name-nudge-text">{{ $t('account.nameNudgeText') }}</text>
+                  </view>
                   <view class="account-row">
                     <view class="account-avatar">
-                      <text class="account-avatar-text">{{ getInitial(account.displayName || account.username) || 'U' }}</text>
+                      <text class="account-avatar-text">{{ getInitial(account.displayName) || 'U' }}</text>
                     </view>
                     <view class="account-identity">
-                      <text class="provider-name">{{ account.displayName || account.username || $t('admin.accountTitle') }}</text>
-                      <text class="account-sub">{{ account.username }}<text v-if="accountPlanLabel"> · {{ accountPlanLabel }}</text></text>
+                      <text class="provider-name">{{ account.displayName || $t('admin.accountTitle') }}</text>
+                      <text v-if="accountPlanLabel" class="account-sub">{{ accountPlanLabel }}</text>
                     </view>
                     <view class="account-actions">
                       <button class="comp-btn" :disabled="entitlementBusy" @tap="onRefreshEntitlements">
@@ -1066,6 +1071,7 @@ import {
   getStorageLocation, moveStorageLocation, resetStorageLocation,
   getLocalIdentityCandidates, selectLocalIdentity,
   getCurrentUser as fetchCurrentUser, uploadAvatar,
+  uploadAccountAvatar,
   getTelemetrySettings, updateTelemetrySettings, getTelemetrySummary,
   getCapabilities, selectCapability, rollbackCapability, setCapabilityDevMode,
   fetchAiModels,
@@ -1082,6 +1088,8 @@ import { host } from '@/services/host.js'
 import { signOut } from '@/utils/signOut.js'
 import { setGlobalOverlay } from '@/utils/overlayState.js'
 import { refreshEntitlements, isEnabled, FEATURES } from '@/composables/useEntitlement.js'
+import { loadIdentityProfile, readNudgeDismissed, markNudgeDismissed, PROFILE_SOURCE } from '@/services/accountProfile.js'
+import { shouldPromptNameNudge } from '@/utils/identityProfile.js'
 import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
 import UnlockHint from '@/components/UnlockHint.vue'
 import RechargeDialog from '@/components/RechargeDialog.vue'
@@ -1288,7 +1296,10 @@ export default {
       siteBusy: false,
       // 账户与用量（商业化 PR-B）
       // status 是纯本地读盘（不含余额），余额与额度都在 usage 的 platform 段
-      account: { connected: false, username: '', displayName: '', keyMasked: '' },
+      account: { connected: false, displayName: '', keyMasked: '' },
+      // 官网那份资料（Spec §5 的 GET /api/account/profile）。source 决定头像点下去写哪儿：
+      // ACCOUNT=写官网（唯一权威源），LOCAL=自建服务器，仍写本机 /api/users/avatar。
+      accountProfile: { source: PROFILE_SOURCE.LOCAL, accountId: '', displayNameIsDefault: false },
       accountUsage: null, // { local: {...}, platform: {...} }，形状见 api.js getAccountUsage
       // 会员钱包卡（dev-board#183）。walletData 来自轻端点 getAccountBalance（余额），
       // membershipData 来自 getAccountMembership（等级/成长值/七档表），分开取分开失败
@@ -1548,10 +1559,18 @@ export default {
       }
     }
     uni.$on('awd:wallet-refresh', this._onWalletRefresh)
+    // 个人设置那边改了昵称/头像：侧栏用户卡与账户卡都要跟着变（同一份权威源）
+    this._onIdentityUpdated = () => {
+      this.loadUserInfo()
+      this.loadAccountProfile()
+    }
+    uni.$on('awd:identity-updated', this._onIdentityUpdated)
     if (this.isDesktop) {
       // AI 面板的「AI WorkDeck 云端」选项是否可选，取决于是否已连接账户。
       // status 是后端纯本地读盘，不打官网，可以随页面加载
       this.loadPlatformAiAvailability()
+      // 名字与头像归谁管 + 默认名时引导一次（每个 accountId 只弹一次）
+      this.loadAccountProfile().then(() => this.maybePromptNameNudge())
       // 模型下载进度不在这里单独订阅：控制器的 installModel 自己挂同一条流，
       // 并把百分比写进卡片的 item.percent（两处订阅只会互相覆盖同一个数字）。
       this.loadComponents()
@@ -1571,6 +1590,10 @@ export default {
     if (this._onWalletRefresh) {
       uni.$off('awd:wallet-refresh', this._onWalletRefresh)
       this._onWalletRefresh = null
+    }
+    if (this._onIdentityUpdated) {
+      uni.$off('awd:identity-updated', this._onIdentityUpdated)
+      this._onIdentityUpdated = null
     }
     if (this._updateEventUnsub) {
       this._updateEventUnsub()
@@ -1752,6 +1775,11 @@ export default {
       this.loadModelCatalog()
       this.loadTelemetry()
     },
+    /**
+     * 侧栏用户卡的头像。路由规则与个人设置那处必须一致（Spec §6）：
+     * local-mode 且已连接账户 → 写官网（唯一权威源），本机 User 行由后端随写入刷新，
+     * 所以这里重新拉一次 /api/auth/me 就能让侧栏跟上；否则（自建服务器）走本机上传。
+     */
     triggerAvatarUpload() {
       uni.chooseImage({
         count: 1,
@@ -1761,13 +1789,19 @@ export default {
           const tempFilePath = res.tempFilePaths[0]
           try {
             uni.showLoading({ title: this.$t('account.uploadingTitle') })
-            const result = await uploadAvatar(tempFilePath)
-            if (result.data && result.data.avatarUrl) {
-              this.userInfo = { ...this.userInfo, avatarUrl: result.data.avatarUrl }
-              // Update local storage/session
-              setSessionUser(this.userInfo)
-              uni.showToast({ title: this.$t('account.avatarUpdateSuccess'), icon: 'success' })
+            if (this.accountProfile.source === PROFILE_SOURCE.ACCOUNT) {
+              await uploadAccountAvatar(tempFilePath)
+              await this.loadUserInfo()
+              await this.loadAccountProfile()
+            } else {
+              const result = await uploadAvatar(tempFilePath)
+              if (result.data && result.data.avatarUrl) {
+                this.userInfo = { ...this.userInfo, avatarUrl: result.data.avatarUrl }
+                // Update local storage/session
+                setSessionUser(this.userInfo)
+              }
             }
+            uni.showToast({ title: this.$t('account.avatarUpdateSuccess'), icon: 'success' })
           } catch (e) {
             console.error('Avatar upload failed', e)
             uni.showToast({ title: this.$t('account.avatarUploadFailed', { message: e.message }), icon: 'none' })
@@ -1776,6 +1810,47 @@ export default {
           }
         },
       })
+    },
+    /**
+     * 「名字与头像归谁管」。头像点击与账户卡那条姓名引导都读它，
+     * 拉不到一律降级成 LOCAL（老后端还没上这四个端点时就是这条路）。
+     */
+    async loadAccountProfile() {
+      const { source, profile } = await loadIdentityProfile()
+      this.accountProfile = {
+        source,
+        accountId: (profile && profile.accountId) || '',
+        displayNameIsDefault: !!(profile && profile.displayNameIsDefault),
+      }
+      return this.accountProfile
+    },
+    /**
+     * 「填写你的姓名」弹窗：每个 accountId 只弹一次（已读落 storage）。
+     * 弹出来就记已读——两个按钮都算打发过，不然点「稍后」的人下次进来还要再看一遍。
+     */
+    maybePromptNameNudge() {
+      const p = this.accountProfile
+      if (!shouldPromptNameNudge({
+        displayNameIsDefault: p.displayNameIsDefault,
+        accountId: p.accountId,
+        dismissedIds: readNudgeDismissed(),
+      })) return
+      markNudgeDismissed(p.accountId)
+      uni.showModal({
+        title: this.$t('account.nameNudgeTitle'),
+        content: this.$t('account.nameNudgeText'),
+        confirmText: this.$t('account.nameNudgeConfirm'),
+        cancelText: this.$t('common.later'),
+        success: (r) => { if (r.confirm) this.goFillName() },
+      })
+    },
+    /**
+     * 去个人设置填名字。个人设置面板是 v-else-if 挂上来的，切栏这一帧它还不存在，
+     * 所以聚焦事件要等它挂完再发（nextTick 之后 PersonalSettingsPanel 的 mounted 已订阅）。
+     */
+    goFillName() {
+      this.onNavTap({ key: 'personal_settings' })
+      this.$nextTick(() => uni.$emit('awd:focus-display-name'))
     },
     onNavTap(nav) {
       this.activeNav = nav.key
@@ -2266,18 +2341,18 @@ export default {
         this.platformAiAvailable = !!(s && s.platformAiAvailable)
         this.account = {
           connected: !!(s && s.connected),
-          username: (s && s.username) || '',
           displayName: (s && s.displayName) || '',
           keyMasked: (s && s.keyMasked) || '',
         }
       } catch (e) {
         // 旧后端没有该端点 / 请求失败：按未连接展示引导，不弹错打断
-        this.account = { connected: false, username: '', displayName: '', keyMasked: '' }
+        this.account = { connected: false, displayName: '', keyMasked: '' }
         this.platformAiAvailable = false
       }
       if (this.account.connected) {
         await this.loadAccountUsage()
         this.loadTeamLine()
+        this.loadAccountProfile()
       } else {
         this.accountUsage = null
         this.teamLine = { loaded: false, teamName: '', firmName: '' }
@@ -2471,6 +2546,9 @@ export default {
         await connectAccount(key)
         this.accountKeyInput = ''
         await this.loadAccount()
+        // 首次连接成功后引导一次「填写你的姓名」（手机号注册的默认展示名是打码手机号）
+        await this.loadAccountProfile()
+        this.maybePromptNameNudge()
         // 已购功能解锁随账户走，连接后必须让权益缓存失效重取
         await refreshEntitlements(true)
         this.notifyMarketAccountChanged()
@@ -2747,12 +2825,7 @@ $brand-accent: $brand-mint;
     font-size: 18px;
     font-weight: 600;
     color: var(--awd-text);
-    margin-bottom: 4px;
-}
-
-.user-handle {
-    font-size: 13px;
-    color: var(--awd-text-2);
+    /* 10px 原本由 @username 那一行的下边距提供，那行随「用户名不当名字显示」去掉了 */
     margin-bottom: 10px;
 }
 
@@ -3306,6 +3379,22 @@ $brand-accent: $brand-mint;
 .account-sub {
   font-size: 12px;
   color: var(--awd-text-2);
+}
+
+/* 姓名引导条：与「不可达提示」同一档的弱强调，不抢账户卡主体 */
+.account-name-nudge {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--awd-accent-soft);
+  border-radius: 6px;
+  background: var(--awd-accent-wash);
+  cursor: pointer;
+}
+
+.account-name-nudge-text {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--awd-text);
 }
 
 .account-team-row {

--- a/frontend/src/components/collab/CollabDialog.vue
+++ b/frontend/src/components/collab/CollabDialog.vue
@@ -98,7 +98,7 @@
             <view v-else-if="!members.length" class="collab-note">{{ $t('version.onlyYouInCaseFile') }}</view>
             <view v-else class="collab-member-list">
               <view v-for="m in members" :key="m.username || m.id" class="collab-member-row">
-                <text class="collab-member-name">{{ m.displayName || m.username }}</text>
+                <text class="collab-member-name">{{ m.displayName || $t('version.unnamedColleague') }}</text>
                 <text class="collab-member-role">{{ roleLabel(m.role) }}</text>
               </view>
             </view>

--- a/frontend/src/components/userprofile/PersonalSettingsPanel.vue
+++ b/frontend/src/components/userprofile/PersonalSettingsPanel.vue
@@ -14,16 +14,41 @@
     <view class="settings-form">
       <view class="form-group">
         <text class="group-title">{{ $t('account.basicInfoGroupTitle') }}</text>
+        <!-- 姓名引导（Spec §6）：手机号注册的默认展示名是打码手机号，
+             而同事在案卷参与人列表、时间线、批注作者里看到的就是这个字段 -->
+        <view v-if="accountProfile.displayNameIsDefault" class="name-nudge" @tap="focusDisplayName">
+          <text class="name-nudge-text">{{ $t('account.nameNudgeText') }}</text>
+        </view>
         <view class="form-row">
           <text class="form-label">{{ $t('account.avatarLabel') }}</text>
-          <view class="avatar-preview">
-            <text class="avatar-char">{{ getInitial(userInfo.displayName) || 'U' }}</text>
+          <view class="avatar-preview tappable" @tap="onAvatarTap">
+            <image v-if="userInfo.avatarUrl" class="avatar-image" :src="userInfo.avatarUrl" mode="aspectFill" />
+            <text v-else class="avatar-char">{{ getInitial(userInfo.displayName) || 'U' }}</text>
           </view>
+          <!-- 删除只有官网那条路有对应端点（DELETE /api/account/avatar）；
+               自建服务器只有上传，没有删除，就不画这个入口 -->
+          <text v-if="canEditProfile && userInfo.avatarUrl" class="bind-link" @tap="onRemoveAvatar">
+            {{ $t('account.avatarRemoveAction') }}
+          </text>
         </view>
         <view class="form-row">
           <text class="form-label">{{ $t('account.nicknameLabel') }}</text>
-          <text class="form-value">{{ userInfo.displayName }}</text>
+          <!-- 自建服务器（非 local-mode / 未连接账户）服务端没有改名接口，保持只读 -->
+          <input
+            v-if="canEditProfile"
+            class="bind-input"
+            v-model="displayNameInput"
+            maxlength="24"
+            :focus="displayNameFocus"
+            :disabled="displayNameSaving"
+            :placeholder="$t('account.nicknamePlaceholder')"
+            @blur="saveDisplayName"
+            @confirm="saveDisplayName"
+          />
+          <text v-else class="form-value">{{ userInfo.displayName }}</text>
+          <text v-if="displayNameSaving" class="bind-link">{{ $t('account.nicknameSaving') }}</text>
         </view>
+        <text v-if="displayNameError" class="form-error">{{ displayNameError }}</text>
       </view>
 
       <!-- 账号安全（server 模式；认证器恒可用，短信取决于通道配置） -->
@@ -217,7 +242,9 @@ import {
   sendSmsCode, bindPhone, sendMailCode, bindEmail,
   totpSetup, totpActivate, totpDisable,
   issueLocalDeviceToken, listDeviceTokens, revokeDeviceToken,
+  uploadAvatar, updateAccountProfile, uploadAccountAvatar, deleteAccountAvatar,
 } from '@/services/api.js'
+import { loadIdentityProfile, PROFILE_SOURCE } from '@/services/accountProfile.js'
 import { getDocumentGeneratorSettings, updateDocumentGeneratorSettings } from '@/services/api.js'
 import { resetDocumentStampCache } from '@/utils/documentGeneratorSetting.js'
 import AwdSwitch from '@/components/AwdSwitch.vue'
@@ -235,6 +262,13 @@ export default {
     isDesktop() {
       return isDesktopHost()
     },
+    /**
+     * 昵称能不能改、头像能不能删（Spec §6）：只有「local-mode 且已连接账户」这条路
+     * 有官网那三个写端点。自建服务器本期不做改名，头像仍可传（走本机 /api/users/avatar）。
+     */
+    canEditProfile() {
+      return this.accountProfile.source === PROFILE_SOURCE.ACCOUNT
+    },
   },
   data() {
     return {
@@ -244,6 +278,15 @@ export default {
         displayName: this.$t('account.defaultUserName'),
         avatarUrl: null,
       },
+
+      // 名字与头像归谁管（services/accountProfile.js）。拉不到一律按 LOCAL 画，
+      // 也就是今天这套只读形态——绝不先画出一个必然失败的输入框。
+      accountProfile: { source: PROFILE_SOURCE.LOCAL, accountId: '', displayNameIsDefault: false },
+      displayNameInput: '',
+      displayNameSaving: false,
+      displayNameError: '',
+      displayNameFocus: false,
+      avatarBusy: false,
 
       // 授权状态（桌面端）：{ unlocked, mode, plan, activatedAt?, accountConnected, edition }
       licenseInfo: {},
@@ -298,7 +341,12 @@ export default {
   },
   mounted() {
     this.loadUserInfo()
+    this.loadAccountProfile()
     this.loadDocGeneratorSetting()
+    // 设置页别处（账户分区的姓名引导、连接成功后的弹窗）点「去填写」时把光标送到这里。
+    // 那两处切栏之后本组件才挂上来，所以只能靠事件，不能靠 prop。
+    this._onFocusDisplayName = () => this.focusDisplayName()
+    uni.$on('awd:focus-display-name', this._onFocusDisplayName)
     if (this.isDesktop) {
       this.loadLicenseInfo()
       this.loadDeviceTokens()
@@ -314,6 +362,10 @@ export default {
     if (this.bindEmailCountdownTimer) {
       clearInterval(this.bindEmailCountdownTimer)
       this.bindEmailCountdownTimer = null
+    }
+    if (this._onFocusDisplayName) {
+      uni.$off('awd:focus-display-name', this._onFocusDisplayName)
+      this._onFocusDisplayName = null
     }
   },
   methods: {
@@ -363,6 +415,109 @@ export default {
         }
       } catch (error) {
         console.error('获取用户信息失败:', error)
+      }
+      // 输入框只在这里跟随权威源；用户正在编辑时本方法不会被调用（只在挂载与写入成功后跑）
+      this.displayNameInput = this.userInfo.displayName || ''
+    },
+    async loadAccountProfile() {
+      const { source, profile } = await loadIdentityProfile()
+      this.accountProfile = {
+        source,
+        accountId: (profile && profile.accountId) || '',
+        displayNameIsDefault: !!(profile && profile.displayNameIsDefault),
+      }
+    },
+    /** 姓名引导点下去：把光标送进昵称输入框（uni 的 focus 是 prop，要先落回 false 才能再次触发） */
+    focusDisplayName() {
+      if (!this.canEditProfile) return
+      this.displayNameFocus = false
+      this.$nextTick(() => { this.displayNameFocus = true })
+    },
+    /**
+     * 存昵称。@blur 与 @confirm 都会调到这里（回车之后紧接着失焦），
+     * 所以「没变就什么都不做」这条不是优化，是防止一次编辑发两次写请求。
+     */
+    async saveDisplayName() {
+      if (!this.canEditProfile || this.displayNameSaving) return
+      const current = String(this.userInfo.displayName || '')
+      const next = String(this.displayNameInput || '').trim()
+      if (!next || next === current) {
+        // 清空不算「改成空名」：空展示名同事那边照样看不出是谁，回落到原值
+        this.displayNameInput = current
+        this.displayNameError = ''
+        return
+      }
+      if (next.length > 24) {
+        this.displayNameError = this.$t('account.nicknameTooLong')
+        return
+      }
+      this.displayNameSaving = true
+      this.displayNameError = ''
+      try {
+        const data = await updateAccountProfile(next)
+        const saved = (data && data.displayName) || next
+        this.userInfo = { ...this.userInfo, displayName: saved }
+        this.displayNameInput = saved
+        setSessionUser(this.userInfo)
+        // displayNameIsDefault 跟着变（引导条随之消失），所以要重拉而不是本地推断
+        await this.loadAccountProfile()
+        uni.$emit('awd:identity-updated')
+      } catch (e) {
+        this.displayNameError = this.$t('account.nicknameSaveFailed', { message: (e && e.message) || '' })
+        this.displayNameInput = current
+      } finally {
+        this.displayNameSaving = false
+      }
+    },
+    /**
+     * 头像：路由规则与 AdminPane 侧栏那处同源（services/accountProfile.js）。
+     * 写官网之后本机 User 行由后端刷新，所以重拉一次 /api/auth/me 就能拿到新头像。
+     */
+    onAvatarTap() {
+      if (this.avatarBusy) return
+      uni.chooseImage({
+        count: 1,
+        sizeType: ['compressed'],
+        sourceType: ['album', 'camera'],
+        success: async (res) => {
+          const filePath = res.tempFilePaths[0]
+          this.avatarBusy = true
+          try {
+            uni.showLoading({ title: this.$t('account.uploadingTitle') })
+            if (this.canEditProfile) {
+              await uploadAccountAvatar(filePath)
+              await this.loadUserInfo()
+            } else {
+              const result = await uploadAvatar(filePath)
+              const url = result && result.data && result.data.avatarUrl
+              if (url) {
+                this.userInfo = { ...this.userInfo, avatarUrl: url }
+                setSessionUser(this.userInfo)
+              }
+            }
+            uni.$emit('awd:identity-updated')
+            uni.showToast({ title: this.$t('account.avatarUpdateSuccess'), icon: 'success' })
+          } catch (e) {
+            uni.showToast({ title: this.$t('account.avatarUploadFailed', { message: (e && e.message) || '' }), icon: 'none' })
+          } finally {
+            uni.hideLoading()
+            this.avatarBusy = false
+          }
+        },
+      })
+    },
+    async onRemoveAvatar() {
+      if (this.avatarBusy || !this.canEditProfile) return
+      this.avatarBusy = true
+      try {
+        await deleteAccountAvatar()
+        await this.loadUserInfo()
+        uni.$emit('awd:identity-updated')
+        uni.showToast({ title: this.$t('account.avatarRemoveSuccess'), icon: 'none' })
+      } catch (e) {
+        uni.showToast({ title: this.$t('account.avatarRemoveFailed', { message: (e && e.message) || '' }), icon: 'none' })
+      } finally {
+        this.avatarBusy = false
       }
     },
     async loadLicenseInfo() {
@@ -734,6 +889,39 @@ $text-secondary: #6C757D;
   justify-content: center;
   color: white;
   font-size: 20px;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  &.tappable { cursor: pointer; }
+}
+
+.avatar-image {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.form-error {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--awd-danger-text);
+}
+
+/* 姓名引导条：弱强调，不抢「基本信息」本身 */
+.name-nudge {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--awd-accent-soft);
+  border-radius: 6px;
+  background: var(--awd-accent-wash);
+  cursor: pointer;
+}
+
+.name-nudge-text {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--awd-text);
 }
 
 /* 界面语言（从设置页「系统配置」搬来）。单选样式独立写一份：admin 那套

--- a/frontend/src/locales/en-US/account.js
+++ b/frontend/src/locales/en-US/account.js
@@ -53,6 +53,17 @@ export default {
   uploadingTitle: 'Uploading…',
   avatarUpdateSuccess: 'Avatar updated',
   avatarUploadFailed: 'Upload failed: {message}',
+  avatarRemoveAction: 'Remove Avatar',
+  avatarRemoveSuccess: 'Avatar removed',
+  avatarRemoveFailed: 'Remove failed: {message}',
+  nicknamePlaceholder: 'Enter your name',
+  nicknameSaving: 'Saving…',
+  nicknameSaveFailed: 'Save failed: {message}',
+  nicknameTooLong: 'A name can be at most 24 characters',
+  // Name nudge (Spec §6): phone sign-ups default to a masked phone number as the display name
+  nameNudgeText: 'Add your name — it is what colleagues see on a case file',
+  nameNudgeTitle: 'Add Your Name',
+  nameNudgeConfirm: 'Add It Now',
 
   // ---- userprofile.vue: settings - account security (authenticator/phone/email) ----
   accountSecurityGroupTitle: 'Account Security',

--- a/frontend/src/locales/en-US/version.js
+++ b/frontend/src/locales/en-US/version.js
@@ -96,6 +96,8 @@ export default {
   draftsInProgress: 'Drafts in Progress',
   newDraft: 'New Draft',
   unnamedDraft: 'Untitled Draft',
+  // Fallback name in the members list: never fall back to the username (it is a uid, not a name)
+  unnamedColleague: 'Colleague',
   switchToDraft: 'Switch to This Draft',
   switchDraftFailed: 'Failed to switch. Please try again later.',
 

--- a/frontend/src/locales/zh-CN/account.js
+++ b/frontend/src/locales/zh-CN/account.js
@@ -52,6 +52,17 @@ export default {
   uploadingTitle: '上传中...',
   avatarUpdateSuccess: '头像更新成功',
   avatarUploadFailed: '上传失败: {message}',
+  avatarRemoveAction: '删除头像',
+  avatarRemoveSuccess: '头像已删除',
+  avatarRemoveFailed: '删除失败: {message}',
+  nicknamePlaceholder: '填写你的姓名',
+  nicknameSaving: '保存中...',
+  nicknameSaveFailed: '保存失败: {message}',
+  nicknameTooLong: '姓名最多 24 个字',
+  // 姓名引导（Spec §6）：手机号注册的默认展示名是打码手机号，同事在案卷里看到的就是它
+  nameNudgeText: '填写你的姓名，同事在案卷里看到的就是它',
+  nameNudgeTitle: '填写你的姓名',
+  nameNudgeConfirm: '去填写',
 
   // ---- userprofile.vue：设置 - 账号安全（认证器/手机/邮箱） ----
   accountSecurityGroupTitle: '账号安全',

--- a/frontend/src/locales/zh-CN/version.js
+++ b/frontend/src/locales/zh-CN/version.js
@@ -95,6 +95,8 @@ export default {
   draftsInProgress: '进行中的稿',
   newDraft: '另起一稿',
   unnamedDraft: '未命名稿',
+  // 参与人行的兜底名：展示名为空时也不许退回用户名（那是 uid，不是名字）
+  unnamedColleague: '同事',
   switchToDraft: '切到这一稿',
   switchDraftFailed: '切换失败，请稍后重试',
 

--- a/frontend/src/pages/newproject/index.vue
+++ b/frontend/src/pages/newproject/index.vue
@@ -33,7 +33,6 @@
               </view>
             </view>
             <text class="user-name">{{ userDisplayName }}</text>
-            <text class="user-handle">@{{ username || 'user' }}</text>
             <view class="user-role-tag">
               <text class="role-text">{{ $t('account.standardUserRole') }}</text>
             </view>
@@ -142,7 +141,6 @@ export default {
   data() {
     return {
       userDisplayName: this.$t('account.defaultUserName'),
-      username: '',
       userAvatarUrl: '',
       busy: false,
       busyText: this.$t('account.busyOpeningProject'),
@@ -155,8 +153,7 @@ export default {
   onLoad(query) {
     const user = getCurrentUser()
     if (user) {
-      this.userDisplayName = user.displayName || user.username || this.$t('account.defaultUserName')
-      this.username = user.username
+      this.userDisplayName = user.displayName || this.$t('account.defaultUserName')
       this.userAvatarUrl = user.avatarUrl
     }
     // 应用菜单「新建项目文件夹…」跳入时自动拉起流程
@@ -343,12 +340,7 @@ $brand-dark: #212629;    /* Dark BG */
   font-size: 20px;
   font-weight: 600;
   color: var(--awd-text);
-  margin-bottom: 4px;
-}
-
-.user-handle {
-  font-size: 14px;
-  color: var(--awd-text-2);
+  /* 12px 原本由 @username 那一行的下边距提供，那行随「用户名不当名字显示」去掉了 */
   margin-bottom: 12px;
 }
 

--- a/frontend/src/pages/project-list/project-list.vue
+++ b/frontend/src/pages/project-list/project-list.vue
@@ -655,7 +655,7 @@ export default {
       const filled = this.profileValue(project, 'client')
       if (filled) return filled
       const names = this.getClientMembers(project)
-        .map((m) => m.displayName || m.username)
+        .map((m) => m.displayName)
         .filter(Boolean)
       if (names.length) return names.join('、')
       const listed = project.listedCompanyName

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -3163,7 +3163,7 @@ export default {
 
     const user = getCurrentUser()
     if (user) {
-      this.userDisplayName = user.displayName || user.username
+      this.userDisplayName = user.displayName || this.userDisplayName
       this.currentUser = user
     }
     // 本地缓存只是首屏兜底：local-mode 免登下 checkba_user 永远为空，头像会
@@ -3658,7 +3658,7 @@ export default {
         const res = await getCurrentUserApi()
         if (res && res.code === 0 && res.data) {
           this.currentUser = { ...this.currentUser, ...res.data }
-          this.userDisplayName = this.currentUser.displayName || this.currentUser.username || this.userDisplayName
+          this.userDisplayName = this.currentUser.displayName || this.userDisplayName
         }
       } catch (e) {
         // 拿不到就用本地缓存那份，不拦路

--- a/frontend/src/services/accountProfile.js
+++ b/frontend/src/services/accountProfile.js
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * 「展示名与头像该写去哪儿」的取数与已读记录（判定本身在 utils/identityProfile.js，
+ * 那边不许 import，才跑得了 node --test）。
+ *
+ * 侧栏用户卡（AdminPane）与个人设置（PersonalSettingsPanel）两处共用：两处的头像
+ * 点击必须落到同一条路上，分开各写一份迟早会一边写官网一边写本机。
+ */
+import { getLocalIdentityStatus, getAccountStatus, getAccountProfile } from '@/services/api.js'
+import {
+  PROFILE_SOURCE, resolveProfileSource,
+  NAME_NUDGE_STORAGE_KEY, withNudgeDismissed,
+} from '@/utils/identityProfile.js'
+
+export { PROFILE_SOURCE }
+
+// local-mode 是一台机器的装机形态，一次进程内不会变（同 InviteMemberDialog 的缓存理由）。
+let localModeCache = null
+async function readLocalMode() {
+  if (localModeCache !== null) return localModeCache
+  try {
+    // 这个端点回裸 JSON（没有 code/data 包装），见 api.js 的注释
+    const identity = await getLocalIdentityStatus()
+    localModeCache = !!(identity && identity.localMode)
+  } catch (e) {
+    // 读不到按「不是 local-mode」处理：那条路最差只是昵称不可改、头像传去本机，
+    // 反过来（误判成 local-mode）会给自建服务器用户一个必然 404 的输入框。
+    localModeCache = false
+  }
+  return localModeCache
+}
+
+/**
+ * 拉一次「我是谁、名字与头像归谁管」。
+ *
+ * 回 { source, profile }：
+ *  · source === ACCOUNT 时 profile 是官网那份 { accountId, displayName, avatarUrl, displayNameIsDefault }；
+ *  · source === LOCAL 时 profile 为 null（本机 /api/auth/me 那份由调用方自己拿）。
+ * 全程不抛：官网不可达、老后端没有这个端点，一律降级成 LOCAL，界面回到只读形态。
+ */
+export async function loadIdentityProfile() {
+  const localMode = await readLocalMode()
+  let connected = false
+  try {
+    const status = await getAccountStatus()
+    connected = !!(status && status.connected)
+  } catch (e) {
+    connected = false
+  }
+  if (resolveProfileSource({ localMode, connected }) !== PROFILE_SOURCE.ACCOUNT) {
+    return { source: PROFILE_SOURCE.LOCAL, profile: null }
+  }
+  try {
+    const profile = await getAccountProfile()
+    if (!profile) return { source: PROFILE_SOURCE.LOCAL, profile: null }
+    return { source: PROFILE_SOURCE.ACCOUNT, profile }
+  } catch (e) {
+    // 后端还没上这个端点（桌面端与后端不同步发布时的常态）：按自建服务器那套画，
+    // 用户看到的是今天的只读形态，不是一个报错。
+    return { source: PROFILE_SOURCE.LOCAL, profile: null }
+  }
+}
+
+/** 已经打发过「填写你的姓名」弹窗的 accountId 列表。读不到就当空。 */
+export function readNudgeDismissed() {
+  try {
+    const raw = uni.getStorageSync(NAME_NUDGE_STORAGE_KEY)
+    return Array.isArray(raw) ? raw : []
+  } catch (e) {
+    return []
+  }
+}
+
+/** 记下这个账户已打发过。写不进去不报错——最坏是下次再弹一次，不该为此打断用户。 */
+export function markNudgeDismissed(accountId) {
+  try {
+    uni.setStorageSync(NAME_NUDGE_STORAGE_KEY, withNudgeDismissed(readNudgeDismissed(), accountId))
+  } catch (e) {
+    /* 存不下就算了 */
+  }
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1293,6 +1293,81 @@ export function disconnectAccount() {
   }).then(unwrapEnvelope);
 }
 
+// ---------- 账户资料：展示名与头像（Spec §5，dev-board#564–#567） ----------
+//
+// 官网是展示名与头像的**唯一权威源**。本机后端把官网那三个写端点收敛成下面四个
+// 本机端点（Key 与 Bearer 都留在后端），前端一律只跟本机后端说话。
+// 只在 local-mode 且已连接账户时可用——两条判定见 utils/identityProfile.js
+// 的 resolveProfileSource；自建服务器仍走 uploadAvatar() 那条本机上传。
+
+// { accountId, displayName, avatarUrl|null, displayNameIsDefault }
+// 刻意**不回 username**：用户名按 uid 处理，任何界面不再当名字显示。
+// 未连接账户时后端回 code:1（request 层转 reject），调用方按「不可编辑」降级即可。
+export function getAccountProfile() {
+  return request({
+    url: '/api/account/profile',
+    method: 'GET',
+  }).then(unwrapEnvelope);
+}
+
+// 改展示名 → 官网 PATCH /api/account/profile。
+// 本机这一层用 PUT 而不是 PATCH：uni.request 没有 PATCH（团队接口先例）。
+export function updateAccountProfile(displayName) {
+  return request({
+    url: '/api/account/profile',
+    method: 'PUT',
+    data: { displayName },
+    header: {
+      'Content-Type': 'application/json',
+    },
+  }).then(unwrapEnvelope);
+}
+
+// 传头像 → 官网 POST /api/account/avatar。multipart 字段名 file，与 uploadAvatar() 同形。
+export function uploadAccountAvatar(filePath) {
+  const baseUrl = getApiBaseUrl()
+  const url = `${baseUrl}/api/account/avatar`
+  const sessionId = getSessionId()
+
+  return new Promise((resolve, reject) => {
+    uni.uploadFile({
+      url: url,
+      filePath: filePath,
+      name: 'file',
+      header: {
+        'X-Session-Id': sessionId
+      },
+      success: (uploadFileRes) => {
+        if (uploadFileRes.statusCode === 200) {
+          try {
+            const data = JSON.parse(uploadFileRes.data)
+            if (data.code === 0) {
+              resolve(unwrapEnvelope(data))
+            } else {
+              reject(new Error(data.message || t('common.uploadFailed')))
+            }
+          } catch (e) {
+            reject(new Error(t('common.parseResponseFailed')))
+          }
+        } else {
+          reject(new Error('HTTP Error ' + uploadFileRes.statusCode))
+        }
+      },
+      fail: (err) => {
+        reject(err)
+      }
+    })
+  })
+}
+
+// 删头像 → 官网 DELETE /api/account/avatar
+export function deleteAccountAvatar() {
+  return request({
+    url: '/api/account/avatar',
+    method: 'DELETE',
+  }).then(unwrapEnvelope);
+}
+
 // 用量：两套口径分开返回（Spec §3），前端不做合并。
 // {
 //   local:    { records, promptTokens, completionTokens, totalTokens,

--- a/frontend/src/utils/identityProfile.js
+++ b/frontend/src/utils/identityProfile.js
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * 展示名与头像该写去哪儿、以及「填写你的姓名」那条引导弹不弹的纯判定
+ * （设计见 docs/superpowers/specs/2026-09-10-identity-display-source-design.md §6）。
+ *
+ * 单独成文件是为了能被 node --test 直接跑（tests/identity/）：这两条判定错了都是静默的——
+ * 源判错会把昵称写进本机 User 行而官网纹丝不动（用户改完名，同事看到的还是打码手机号），
+ * 弹窗判错则要么一次都不弹、要么每次开机都弹。
+ *
+ * 与 utils/memberLookup.js 同一条纪律：**这里不许 import 任何东西**（含 uni），
+ * 一引别名 node 就解析不了，这套测试只能退化成源码字符串断言。
+ */
+
+/** 展示名/头像的写入目标。 */
+export const PROFILE_SOURCE = {
+  /** 官网账户（唯一权威源）：走本机后端的 /api/account/* 四个端点转发。 */
+  ACCOUNT: 'ACCOUNT',
+  /** 自建服务器：本机用户表就是权威源，头像走既有 POST /api/users/avatar，昵称本期不可改。 */
+  LOCAL: 'LOCAL',
+}
+
+/**
+ * 只有「桌面端单机 local-mode」且「已连接官网账户」两条同时成立，才写官网。
+ *
+ * 少一条就必须回落 LOCAL：自建服务器根本没有官网 Key，local-mode 但没连账户时
+ * 后端那四个端点会回「未连接账户」——把界面按官网态画出来等于给用户一个必然失败的输入框。
+ */
+export function resolveProfileSource({ localMode, connected } = {}) {
+  return localMode && connected ? PROFILE_SOURCE.ACCOUNT : PROFILE_SOURCE.LOCAL
+}
+
+/** 「填写你的姓名」弹窗的已读记录（按 accountId 记）落盘用的 storage key。 */
+export const NAME_NUDGE_STORAGE_KEY = 'awd_name_nudge_dismissed'
+
+/**
+ * 这一次该不该弹「填写你的姓名」。
+ *
+ * 三条都要成立：确实还是默认名、认得出是哪个账户、这个账户还没打发过这条弹窗。
+ * accountId 缺失时**不弹**——记不下「已读」的弹窗会变成每次都弹。
+ */
+export function shouldPromptNameNudge({ displayNameIsDefault, accountId, dismissedIds } = {}) {
+  if (!displayNameIsDefault) return false
+  const id = String(accountId == null ? '' : accountId)
+  if (!id) return false
+  return !toIdList(dismissedIds).includes(id)
+}
+
+/**
+ * 记下「这个账户已经打发过了」。回新数组，调用方直接落盘。
+ * 上限 50 条：一台机器上换过的账户再多也就这个量级，无上限会把 storage 撑成垃圾场。
+ */
+export function withNudgeDismissed(dismissedIds, accountId) {
+  const id = String(accountId == null ? '' : accountId)
+  const list = toIdList(dismissedIds)
+  if (!id || list.includes(id)) return list
+  return list.concat(id).slice(-50)
+}
+
+/** storage 里读回来的东西可能是任何形状（老版本写过别的、被人手改过）：一律归一成字符串数组。 */
+function toIdList(value) {
+  if (!Array.isArray(value)) return []
+  return value.map((v) => String(v == null ? '' : v)).filter(Boolean)
+}

--- a/frontend/tests/identity/display-name-only.allowlist.json
+++ b/frontend/tests/identity/display-name-only.allowlist.json
@@ -1,0 +1,27 @@
+[
+  {
+    "file": "src/components/admin/AdminPane.vue",
+    "pattern": "item.displayName || item.username",
+    "reason": "本机工作区身份列表与「切换身份」确认弹窗。同一台机器上的多个本地账号展示名可能重名甚至为空，用户名是这里唯一能把它们区分开的东西；这是用户在选自己的哪个本机账号，不是同事看到的名字。"
+  },
+  {
+    "file": "src/components/admin/AdminPane.vue",
+    "pattern": "username: item.username",
+    "reason": "同上那份本机身份列表的元信息行（admin.identityMeta：用户名 · N 个项目 · N 个文件），项目数与文件数正是靠它来认哪个账号是自己在用的那个。"
+  },
+  {
+    "file": "src/components/admin/AdminPane.vue",
+    "pattern": "fb.username",
+    "reason": "后台「用户反馈」看板的提交人列。管理员要按登录名把反馈定位到具体账号，不是协作界面，看的人只有管理员自己。"
+  },
+  {
+    "file": "src/pages/identity/identity.vue",
+    "pattern": "item.username",
+    "reason": "本机工作区选择页（local-mode 首启分流）。这一页存在的意义就是让用户在同机的几个本地账号里挑一个，展示名区分不开时只剩用户名可认。"
+  },
+  {
+    "file": "src/pages/login/login.vue",
+    "pattern": "this.registerForm.displayName || this.registerForm.username",
+    "reason": "自建服务器的注册表单：显示名是选填项，留空时拿用户名当初始展示名写进新账号。这是一次性的建号取值，不是把用户名当名字显示——之后用户改了展示名，这里再也不参与。"
+  }
+]

--- a/frontend/tests/identity/display-name-only.test.mjs
+++ b/frontend/tests/identity/display-name-only.test.mjs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * 契约：用户名（username）是 uid，任何界面都不再当名字显示
+ * （设计见 docs/superpowers/specs/2026-09-10-identity-display-source-design.md §2 第 5 条）。
+ *
+ * 为什么要一条扫描式的测试而不是逐处断言：这个病是**一次退化就再也没人发现**的类型——
+ * 手机号注册的同事，用户名是 `u`+随机串，展示名是打码手机号。哪天有人在参与人列表、
+ * 时间线、批注作者那里顺手加一句 `|| m.username` 兜底，界面上不报错、测试不红，
+ * 只是同事在案卷里变成一串随机字母。所以守的是「整棵 src 里一处都不许有」，
+ * 而不是「这三个文件对」。
+ *
+ * 两条规则：
+ *  ① 模板插值 {{ ... }} 里出现 username；
+ *  ② 任何位置的 `|| xxx.username` 兜底（比较式 `|| u.username === 'admin'` 不算，
+ *     那是判定不是显示）。
+ * 例外写在同目录的 display-name-only.allowlist.json，每条必须带理由。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const SRC = path.resolve(HERE, '../../src')
+const ALLOWLIST_PATH = path.join(HERE, 'display-name-only.allowlist.json')
+
+/** {{ ... }} 里出现 username（含 `@{{ x.username }}` 这种小字 handle）。 */
+const INTERPOLATION = /\{\{(?:(?!\}\})[\s\S])*\}\}/g
+/** `|| a.b.username`，但后面不跟比较符（`=== 'admin'` 那种是权限判定，不是展示）。 */
+const USERNAME_FALLBACK = /\|\|\s*[A-Za-z_$][\w$]*(?:\s*\??\.\s*[A-Za-z_$][\w$]*)*\s*\.\s*username\b(?!\s*[=!]=)/g
+
+function listVueFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...listVueFiles(full))
+    else if (entry.endsWith('.vue')) out.push(full)
+  }
+  return out.sort()
+}
+
+function findViolations(relPath, source) {
+  const violations = []
+  const lines = source.split('\n')
+  // ① 插值：先在全文里找出每个 {{ }}（可能跨行），再换算回行号
+  for (const m of source.matchAll(INTERPOLATION)) {
+    if (!/\busername\b/.test(m[0])) continue
+    const line = source.slice(0, m.index).split('\n').length
+    violations.push({ file: relPath, line, rule: 'interpolation', snippet: m[0].replace(/\s+/g, ' ').trim() })
+  }
+  // ② `|| x.username` 兜底：模板与脚本一视同仁
+  lines.forEach((text, i) => {
+    for (const m of text.matchAll(USERNAME_FALLBACK)) {
+      violations.push({ file: relPath, line: i + 1, rule: 'fallback', snippet: text.trim(), matched: m[0] })
+    }
+  })
+  return violations
+}
+
+/** 命中允许名单：同一个文件、且名单里那段 pattern 出现在这一行（或这段插值）里。 */
+function isAllowed(violation, allowlist, lineText) {
+  return allowlist.some((entry) =>
+    entry.file === violation.file &&
+    typeof entry.pattern === 'string' && entry.pattern.length > 0 &&
+    (lineText.includes(entry.pattern) || violation.snippet.includes(entry.pattern)))
+}
+
+test('src/**/*.vue 里不许把 username 当名字显示', () => {
+  const allowlist = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'))
+  for (const entry of allowlist) {
+    assert.ok(entry.reason && entry.reason.trim().length >= 8,
+      `允许名单每条都要写清理由：${entry.file} / ${entry.pattern}`)
+  }
+
+  const offenders = []
+  for (const full of listVueFiles(SRC)) {
+    const rel = path.relative(path.resolve(HERE, '../..'), full).split(path.sep).join('/')
+    const source = readFileSync(full, 'utf8')
+    const lines = source.split('\n')
+    for (const v of findViolations(rel, source)) {
+      if (isAllowed(v, allowlist, lines[v.line - 1] || '')) continue
+      offenders.push(`${v.file}:${v.line} [${v.rule}] ${v.snippet}`)
+    }
+  }
+
+  assert.deepEqual(offenders, [],
+    '用户名是 uid，不是名字：改用 displayName，兜底用文案键（如 version.unnamedColleague）。\n' +
+    '确属内部用途（登录表单、后台用户管理、本机工作区选择）就加进 ' +
+    'tests/identity/display-name-only.allowlist.json 并写清理由。\n' + offenders.join('\n'))
+})
+
+test('允许名单里的每一条都还对得上真实代码（名单不许烂在这里）', () => {
+  const allowlist = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'))
+  const root = path.resolve(HERE, '../..')
+  for (const entry of allowlist) {
+    const source = readFileSync(path.join(root, entry.file), 'utf8')
+    assert.ok(source.includes(entry.pattern),
+      `允许名单里的 ${entry.file} / ${entry.pattern} 在代码里已经不存在了，删掉这条`)
+  }
+})

--- a/frontend/tests/identity/profile-source.test.mjs
+++ b/frontend/tests/identity/profile-source.test.mjs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 展示名/头像写去哪儿、姓名引导弹不弹（src/utils/identityProfile.js）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  PROFILE_SOURCE, resolveProfileSource,
+  shouldPromptNameNudge, withNudgeDismissed, NAME_NUDGE_STORAGE_KEY,
+} from '../../src/utils/identityProfile.js'
+
+test('local-mode 且已连接账户 → 写官网', () => {
+  assert.equal(resolveProfileSource({ localMode: true, connected: true }), PROFILE_SOURCE.ACCOUNT)
+})
+
+test('缺任一条件一律回落本机', () => {
+  assert.equal(resolveProfileSource({ localMode: true, connected: false }), PROFILE_SOURCE.LOCAL)
+  assert.equal(resolveProfileSource({ localMode: false, connected: true }), PROFILE_SOURCE.LOCAL)
+  assert.equal(resolveProfileSource({ localMode: false, connected: false }), PROFILE_SOURCE.LOCAL)
+  // 状态还没读回来（undefined / 整个参数缺席）也算不成立：宁可显示成自建服务器那套只读形态，
+  // 也不要先画出一个会失败的输入框
+  assert.equal(resolveProfileSource({}), PROFILE_SOURCE.LOCAL)
+  assert.equal(resolveProfileSource(), PROFILE_SOURCE.LOCAL)
+})
+
+test('默认名 + 没打发过 → 弹一次', () => {
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, accountId: 'acc_1', dismissedIds: [] }), true)
+})
+
+test('已经打发过就不再弹（这条就是「别每次开机都弹」）', () => {
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, accountId: 'acc_1', dismissedIds: ['acc_1'] }), false)
+  // 换个账户仍然要弹：已读是按 accountId 记的
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, accountId: 'acc_2', dismissedIds: ['acc_1'] }), true)
+})
+
+test('名字已经填过、或认不出是哪个账户 → 不弹', () => {
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: false, accountId: 'acc_1', dismissedIds: [] }), false)
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, accountId: '', dismissedIds: [] }), false)
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, dismissedIds: [] }), false)
+  assert.equal(shouldPromptNameNudge(), false)
+})
+
+test('storage 里是垃圾数据时按「没打发过」算，不炸', () => {
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, accountId: 'acc_1', dismissedIds: null }), true)
+  assert.equal(shouldPromptNameNudge({ displayNameIsDefault: true, accountId: 'acc_1', dismissedIds: 'acc_1' }), true)
+  assert.deepEqual(withNudgeDismissed('nonsense', 'acc_1'), ['acc_1'])
+  assert.deepEqual(withNudgeDismissed([null, 'acc_0'], 'acc_1'), ['acc_0', 'acc_1'])
+})
+
+test('已读记录追加且不重复、有上限', () => {
+  assert.deepEqual(withNudgeDismissed([], 'acc_1'), ['acc_1'])
+  assert.deepEqual(withNudgeDismissed(['acc_1'], 'acc_1'), ['acc_1'])
+  assert.deepEqual(withNudgeDismissed(['acc_1'], ''), ['acc_1'])
+  const many = Array.from({ length: 60 }, (_, i) => `acc_${i}`)
+  const next = withNudgeDismissed(many, 'acc_new')
+  assert.equal(next.length, 50)
+  assert.equal(next[next.length - 1], 'acc_new')
+})
+
+test('storage key 是契约的一部分：改了等于把所有人的已读记录清空', () => {
+  assert.equal(NAME_NUDGE_STORAGE_KEY, 'awd_name_nudge_dismissed')
+})


### PR DESCRIPTION
## 背景
手机号注册账户用户名是随机串、展示名是打码手机号（线上 14/25）；案件库与桌面端各抄一份不再同步；版本时间线与文档批注/修订作者直接写用户名。维护者裁决见 `docs/superpowers/specs/2026-09-10-identity-display-source-design.md`。官网侧 zeweihan/aiworkdeck_website#171 已合并部署。卡：zeweihan/dev-board#564 #565 #566 #567。

## 改动
- **案件库**：桥接与名录回查刷新展示名（username 永不动）；参与人列表头像走 `avatarUrlFor`（桥接用户取官网）；版本作者改 displayName。
- **桌面端后端**：`GET/PUT /api/account/profile`、`POST/DELETE /api/account/avatar` 经 Bearer 透传官网；`AccountIdentitySync` 在连接/status/写入后把官网身份同步到本机 User 行与 account.json；官网不可达静默跳过。
- **桌面端前端**：个人设置头像可传可删、昵称可编辑（自建服务器保持只读）；默认名引导；去掉所有把 username 当名字显示的地方；`tests/identity` 契约测试进 CI（允许名单五条各带理由）。
- 文档：licensing-billing.md / version-control.md 同步。

## 验证
- 后端 `mvn -B test`：3572 项，0 失败；目标集 149 项。
- 前端 `test:identity` 10、`test:member-invite` 27、`check:nav:full` / `check:locales` / `check:emits`、`build:h5` 全绿；七个 SFC 编译通过。
- multipart 编码用 jshell 打到 Node `Request.formData()` 解析器：字段 file、文件名清洗、image/png、3000 字节、sha 一致，Bearer 在。
- 破坏性核对：去掉 resolveUser 的展示名刷新 → 2 用例转红；参与人行放回 `|| m.username` → 契约测试转红。
- 未做：真渲染走查（随集中发版前做）；四个本地端点未对真实桌面后端端到端跑。

## 上线
合并后案件库换 jar（展示名刷新与参与人头像立刻生效）。桌面端随集中发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)