### PR TITLE
fix(i18n): 反馈浮钮避开主操作区 + 英文设置页网络依据双语（dev-board#574 #575）

### DIFF
--- a/.claude/agents/feedback-optimizer.md
+++ b/.claude/agents/feedback-optimizer.md
@@ -108,6 +108,14 @@ optimizer.*」——普通用户永远 enabled=false，只看得到下面的「�
   而框选覆盖窗一定会抢焦点 → 条件等待集体假超时（现象是「截图没出来」，实际早就出来了）。
 - 多构造器的 Spring bean（`VoiceTranscriptionService`/`FeedbackTriageService`）
   必须给公开构造器打 `@Autowired`，否则整个上下文起不来。
+- **浮钮的「让路」契约 `data-awd-keep-clear`（dev-board#574）**：入口浮钮是 fixed 常驻层，
+  任何固定坐标都会在某种布局下压住别人的主操作（#213 压过沉底发送键，挪到右缘 60% 后又压住
+  英文空会话折行后的居中输入卡）。现在由主操作区容器自己打 `data-awd-keep-clear`，
+  `FeedbackWidget.updateKeepClear()` 每 800ms / resize / 拖动松手后只沿竖直方向避开
+  （几何在 `utils/keepClear.js`，`tests/feedback-widget/keep-clear.test.mjs` 覆盖）。
+  让路只是显示偏移，不写回 `launcherPos`、不持久化。**新面板的主操作按钮若贴右缘，
+  要自己加这个属性**，浮钮不会自动识别可点元素。app-e2e J12 在点发送前断言
+  `elementFromPoint` 命中按钮自身，被盖住直接判红（原来记 skip，门禁形同虚设）。
 
 ## 验证
 

--- a/backend/src/main/java/com/checkba/service/ai/NetworkRegionService.java
+++ b/backend/src/main/java/com/checkba/service/ai/NetworkRegionService.java
@@ -3,6 +3,7 @@
 
 package com.checkba.service.ai;
 
+import com.checkba.service.LangText;
 import com.checkba.service.SystemSettingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,10 +110,16 @@ public class NetworkRegionService {
         return mainland ? AllowedModels.Region.GLOBAL : AllowedModels.Region.INTERNATIONAL;
     }
 
-    /** 供设置页展示判定依据，让用户能看懂为什么国际模型不见了。 */
+    /**
+     * 供设置页展示判定依据，让用户能看懂为什么国际模型不见了。
+     * 这串直接拼进前端文案（admin.regionSummary / chat.networkBasis），得跟着界面语言走（dev-board#575）。
+     */
     public String detectionBasis() {
-        return "系统国家/地区=" + orDash(Locale.getDefault().getCountry())
-                + "，时区=" + orDash(TimeZone.getDefault().getID());
+        String country = orDash(Locale.getDefault().getCountry());
+        String zone = orDash(TimeZone.getDefault().getID());
+        return LangText.of(
+                "系统国家/地区=" + country + "，时区=" + zone,
+                "system country/region=" + country + ", time zone=" + zone);
     }
 
     private static String orDash(String s) {

--- a/backend/src/test/java/com/checkba/service/ai/NetworkRegionServiceTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/NetworkRegionServiceTest.java
@@ -3,6 +3,8 @@
 
 package com.checkba.service.ai;
 
+import com.checkba.service.AppLanguageService;
+import com.checkba.service.LangText;
 import com.checkba.service.SystemSettingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -155,6 +157,32 @@ class NetworkRegionServiceTest {
             assertTrue(basis.contains("CN"), "判定依据应含国家/地区，实际: " + basis);
             assertTrue(basis.contains("Asia/Shanghai"), "判定依据应含时区，实际: " + basis);
         });
+    }
+
+    @Test
+    @DisplayName("detectionBasis 中文界面给中文说法")
+    void detectionBasisChinese() {
+        withLanguage(false, () -> withEnv(Locale.CHINA, "Asia/Singapore", () ->
+                assertEquals("系统国家/地区=CN，时区=Asia/Singapore", service.detectionBasis())));
+    }
+
+    @Test
+    @DisplayName("detectionBasis 英文界面不许夹中文（dev-board#575）")
+    void detectionBasisEnglish() {
+        withLanguage(true, () -> withEnv(Locale.CHINA, "Asia/Singapore", () ->
+                assertEquals("system country/region=CN, time zone=Asia/Singapore", service.detectionBasis())));
+    }
+
+    /** LangText 是静态桥：登记一个指定语言的实例跑完断言后必须 reset，不然会串到别的测试类。 */
+    private void withLanguage(boolean english, Runnable body) {
+        AppLanguageService lang = mock(AppLanguageService.class);
+        when(lang.isEnglish()).thenReturn(english);
+        LangText.register(lang);
+        try {
+            body.run();
+        } finally {
+            LangText.reset();
+        }
     }
 
     /**

--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -311,7 +311,8 @@
 
        <!-- Center: Input -->
        <view class="empty-middle-section">
-          <view class="input-card centered-style">
+          <!-- data-awd-keep-clear：右下角反馈浮钮会主动避开这块（utils/keepClear.js，dev-board#574） -->
+          <view class="input-card centered-style" data-awd-keep-clear>
               <view v-if="isDragging" class="drop-overlay">
                  <text>Drop files here</text>
               </view>
@@ -528,7 +529,7 @@
                <text class="token-detail">({{ tokenUsage.promptTokens.toLocaleString() }} / {{ tokenUsage.completionTokens.toLocaleString() }})</text>
            </view> -->
        </view>
-       <view class="input-card">
+       <view class="input-card" data-awd-keep-clear>
           <view v-if="isDragging" class="drop-overlay">
              <text>Drop files here</text>
           </view>

--- a/frontend/src/components/FeedbackWidget.vue
+++ b/frontend/src/components/FeedbackWidget.vue
@@ -188,6 +188,7 @@ import { getLastProjectId } from '@/utils/recentProjects.js'
 import { openExternalUrl } from '@/utils/externalLink.js'
 import { t as t$ } from '@/i18n'
 import { shouldAcceptResponse } from '@/utils/requestGeneration.js'
+import { KEEP_CLEAR_ATTR, resolveLauncherTop } from '@/utils/keepClear.js'
 
 const MAX_IMAGES = 10
 const MAX_RECORD_SECONDS = 120
@@ -252,6 +253,9 @@ export default {
       dragging: false,
       // 入口按钮的位置。null = 没挪过，走 CSS 里的右下角默认值
       launcherPos: null,
+      // 让路后的 top（null = 没压住任何 data-awd-keep-clear 区域，按原位显示）。
+      // 只是显示层的偏移，不写回 launcherPos、不持久化：主操作区挪走后按钮就回原位
+      keepClearTop: null,
       moving: false,
       showContext: false,
       status: '',
@@ -290,11 +294,15 @@ export default {
       return this.$t('feedback.headDefaultTitle')
     },
     launcherStyle() {
-      if (!this.launcherPos) return {}
+      const top = this.keepClearTop
+      if (!this.launcherPos) {
+        // 默认位（CSS 的 right/bottom）只在让路时改竖直坐标，水平仍贴右缘
+        return top == null ? {} : { top: top + 'px', bottom: 'auto' }
+      }
       // 挪过之后改成左上角定位，得把 CSS 里的 right/bottom 显式解掉
       return {
         left: this.launcherPos.left + 'px',
-        top: this.launcherPos.top + 'px',
+        top: (top == null ? this.launcherPos.top : top) + 'px',
         right: 'auto',
         bottom: 'auto',
       }
@@ -322,12 +330,21 @@ export default {
     try { uni.$on('awd:open-feedback', this._openFromMenu) } catch (e) { /* ignore */ }
     this.restoreLauncherPos()
     // 窗口缩小后旧坐标可能整个落到视口外，缩一次窗就再也点不到那个按钮了
-    this._onWinResize = () => { if (this.launcherPos) this.launcherPos = this.clampPos(this.launcherPos) }
+    this._onWinResize = () => {
+      if (this.launcherPos) this.launcherPos = this.clampPos(this.launcherPos)
+      this.updateKeepClear()
+    }
     try { window.addEventListener('resize', this._onWinResize) } catch (e) { /* ignore */ }
+    // 主操作区的位置随页面状态变（空会话输入卡垂直居中 → 有消息后沉底、切面板、
+    // 文案折行），没有能统一订阅的事件，所以低频轮询：每次只是一个 querySelectorAll
+    // 加几次 getBoundingClientRect，代价可以忽略。
+    this.$nextTick(() => this.updateKeepClear())
+    this._keepClearTimer = setInterval(() => this.updateKeepClear(), 800)
   },
   beforeUnmount() {
     try { uni.$off('awd:open-feedback', this._openFromMenu) } catch (e) { /* ignore */ }
     try { window.removeEventListener('resize', this._onWinResize) } catch (e) { /* ignore */ }
+    clearInterval(this._keepClearTimer)
     this.detachLauncherDrag()
     this.stopRecording(true)
     this.stopPlay()
@@ -350,6 +367,22 @@ export default {
         left: Math.min(Math.max(pos.left, M), Math.max(M, vw - w - M)),
         top: Math.min(Math.max(pos.top, M), Math.max(M, vh - h - M)),
       }
+    },
+    // 浮钮不许压住主操作区（dev-board#574）：任何固定坐标都会在某种布局下压住别人的
+    // 发送键，所以由主操作区自己打 data-awd-keep-clear 声明，这里每次落位前避开。
+    // 只算竖直方向——水平挪动会让贴边的按钮跑进内容区中间。
+    updateKeepClear() {
+      if (this.open || this.moving || typeof document === 'undefined') return
+      const vw = window.innerWidth || 1280
+      const vh = window.innerHeight || 800
+      const { w, h } = this.launcherSize()
+      // 没挪过时的原位由 CSS 决定（right:16px; bottom:40vh），这里按同一公式换算
+      const base = this.launcherPos || { left: vw - 16 - w, top: vh - vh * 0.4 - h }
+      const obstacles = [...document.querySelectorAll('[' + KEEP_CLEAR_ATTR + ']')]
+        .map((el) => el.getBoundingClientRect())
+      const top = resolveLauncherTop({ left: base.left, top: base.top, width: w, height: h }, obstacles, vh)
+      const next = top === base.top ? null : top
+      if (next !== this.keepClearTop) this.keepClearTop = next
     },
     restoreLauncherPos() {
       try {
@@ -388,6 +421,8 @@ export default {
         && Math.abs(e.clientY - this._drag.y0) < 4) return
       this._drag.moved = true
       this.moving = true
+      // 拖动中按钮必须跟手，让路偏移先撤掉；松手后再重新判一次
+      this.keepClearTop = null
       this.launcherPos = this.clampPos({
         left: e.clientX - this._drag.dx,
         top: e.clientY - this._drag.dy,
@@ -402,6 +437,7 @@ export default {
         return
       }
       try { uni.setStorageSync(LAUNCHER_POS_KEY, this.launcherPos) } catch (e) { /* ignore */ }
+      this.updateKeepClear()
     },
     detachLauncherDrag() {
       if (this._onLauncherMove) window.removeEventListener('pointermove', this._onLauncherMove)

--- a/frontend/src/utils/keepClear.js
+++ b/frontend/src/utils/keepClear.js
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 反馈浮钮的「让路」几何（dev-board#574）。
+//
+// 浮钮是 fixed 定位、盖在一切页面之上的常驻入口，停在任何固定坐标都会在某种布局下
+// 压住别人的主操作：默认位先在右下角压过 AI 输入区的发送键（#213），挪到右缘 60% 高度
+// 后又压住空会话时垂直居中的输入卡（英文占位折行把发送键推下来约 10px 就撞上了）。
+// 再换一个固定坐标只是换一处撞，所以改成反过来：主操作区域自己声明「这里别盖」，
+// 浮钮每次落位前避开所有声明区域。
+//
+// 契约：给主操作区域的容器加 data-awd-keep-clear 属性即可（整块输入卡而不是只标一个
+// 按钮——模型选择器、模式选择器同样是主操作）。本模块只做纯几何，不碰 DOM，
+// 由 FeedbackWidget.vue 采集矩形后调用，便于 node --test 直接覆盖。
+
+export const KEEP_CLEAR_ATTR = 'data-awd-keep-clear'
+
+/** 两个矩形（{left, top, width, height}）是否相交；gap 是额外留的间距。 */
+export function intersects(a, b, gap = 0) {
+  return a.left < b.left + b.width + gap
+    && b.left < a.left + a.width + gap
+    && a.top < b.top + b.height + gap
+    && b.top < a.top + a.height + gap
+}
+
+/**
+ * 只沿竖直方向给浮钮找一个不压任何障碍的 top，取离原位最近的那个。
+ * 候选位只有三类：原位、每个障碍的正上方、正下方（各隔 gap）——最近的可行位必然落在
+ * 这些边界上，没必要逐像素扫。找不到可行位（障碍铺满整条竖线）就留在原位，
+ * 不把按钮推出视口：看不见的入口比压住一点内容更糟。
+ */
+export function resolveLauncherTop(rect, obstacles, viewportHeight, opts = {}) {
+  const margin = opts.margin == null ? 8 : opts.margin
+  const gap = opts.gap == null ? 8 : opts.gap
+  const list = (obstacles || []).filter((o) => o && o.width > 0 && o.height > 0)
+  const free = (top) => {
+    if (top < margin || top + rect.height > viewportHeight - margin) return false
+    const probe = { left: rect.left, top, width: rect.width, height: rect.height }
+    return !list.some((o) => intersects(probe, o, gap))
+  }
+  if (free(rect.top)) return rect.top
+  const candidates = []
+  for (const o of list) {
+    candidates.push(o.top - gap - rect.height, o.top + o.height + gap)
+  }
+  let best = null
+  for (const c of candidates) {
+    if (!free(c)) continue
+    if (best === null || Math.abs(c - rect.top) < Math.abs(best - rect.top)) best = c
+  }
+  return best === null ? rect.top : best
+}

--- a/frontend/tests/app-e2e/run.mjs
+++ b/frontend/tests/app-e2e/run.mjs
@@ -2311,10 +2311,39 @@ try {
       await shot('j12-en-ai-panel')
     })
 
-    await step('J12 英文指令过程卡工具名不含中文', async () => {
+    // 「点不中发送键」与「模型没选工具」必须分开判（dev-board#574）：以前发送键被右下角
+    // 反馈浮钮盖住时，这里的点击落在浮钮上（点开的是反馈面板），消息根本没发出去，
+    // 下一步照样等满 120s 记成「模型未产出工具调用」的 skip——发版门形同虚设。
+    // 现在：按钮中心被别的元素盖住 / 点了没发出去 → 判红；发出去了但模型这一轮
+    // 没调工具 → 照旧 skip。
+    const J12_PROMPT = 'List the files in this project, then reply with just: E2E OK'
+    const j12Sent = await step('J12 发送按钮未被遮挡且点击确实发出消息', async () => {
       await mouseClickSel('.chat-input-rich')
-      await page.keyboard.type('List the files in this project, then reply with just: E2E OK', { delay: 10 })
-      await mouseClickSel('.send-btn')
+      await page.keyboard.type(J12_PROMPT, { delay: 10 })
+      const hit = await page.evaluate(() => {
+        const btn = [...document.querySelectorAll('.send-btn')].find((b) => b.getBoundingClientRect().width > 0)
+        if (!btn) return { ok: false, top: '（没有可见的 .send-btn）' }
+        const r = btn.getBoundingClientRect()
+        const x = r.x + r.width / 2
+        const y = r.y + r.height / 2
+        const top = document.elementFromPoint(x, y)
+        const desc = top
+          ? top.tagName + '.' + String(top.className || '').trim().replace(/\s+/g, '.') + ' "' + (top.innerText || '').trim().slice(0, 30) + '"'
+          : 'null'
+        return { ok: !!top && (top === btn || btn.contains(top)), x, y, top: desc }
+      })
+      if (!hit.ok) throw new Error('发送按钮中心被遮挡，elementFromPoint 命中 ' + hit.top)
+      await page.mouse.click(hit.x, hit.y)
+      // 发出去的判据：进入流式（发送键变停止键），或输入框已清空且提问落进了消息区
+      await page.waitForFunction((p) => {
+        if (document.querySelector('.send-btn.stopping')) return true
+        const input = document.querySelector('.chat-input-rich')
+        const inputEmpty = !input || !(input.innerText || '').trim()
+        return inputEmpty && (document.body.innerText || '').includes(p)
+      }, { timeout: 20000, polling: 250 }, J12_PROMPT)
+    })
+
+    if (j12Sent) await step('J12 英文指令过程卡工具名不含中文', async () => {
       // 工具名是否出现取决于模型这一轮选不选工具——这是 LLM 不确定性，不该让发版门
       // 因此变红。所以这一步是「出现了就必须英文」：等到有工具名就断言无 CJK；
       // 一直没有则记 skip 信号（人工按信号复看），不判失败。

--- a/frontend/tests/feedback-widget/keep-clear.test.mjs
+++ b/frontend/tests/feedback-widget/keep-clear.test.mjs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 反馈浮钮让路几何（dev-board#574）。数值取自真实复现：1440x900 视口、en-US 空会话，
+// 输入卡 [1105,401,311,151]，浮钮默认位 [1326,512,96,28]（right:16px, bottom:40vh）。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { intersects, resolveLauncherTop } from '../../src/utils/keepClear.js'
+
+const VH = 900
+const launcher = { left: 1326, top: 512, width: 96, height: 28 }
+const enComposer = { left: 1105, top: 401, width: 311, height: 151 }
+
+test('复现：默认位与英文空会话输入卡相交', () => {
+  assert.equal(intersects(launcher, enComposer), true)
+})
+
+test('压住输入卡时挪到离原位最近的空位，且不再相交', () => {
+  const top = resolveLauncherTop(launcher, [enComposer], VH)
+  // 输入卡底边 552 + gap 8 = 560，比挪到上方（401-8-28=365）近
+  assert.equal(top, 560)
+  assert.equal(intersects({ ...launcher, top }, enComposer, 8), false)
+})
+
+test('没压住任何东西时原地不动', () => {
+  const farAway = { left: 100, top: 100, width: 300, height: 150 }
+  assert.equal(resolveLauncherTop(launcher, [farAway], VH), 512)
+  assert.equal(resolveLauncherTop(launcher, [], VH), 512)
+})
+
+test('下方放不下时往上让', () => {
+  const low = { left: 1105, top: 480, width: 311, height: 400 }
+  const top = resolveLauncherTop(launcher, [low], VH)
+  assert.equal(top, 480 - 8 - 28)
+})
+
+test('多个障碍：跳过被另一个障碍占着的候选位', () => {
+  const below = { left: 1300, top: 556, width: 140, height: 40 }
+  const top = resolveLauncherTop(launcher, [enComposer, below], VH)
+  // 560 被 below 占了、520 又压回输入卡；剩下 604（below 底边 596+8，距原位 92）
+  // 与 365（输入卡上方，距原位 147），取近的
+  assert.equal(top, 604)
+})
+
+test('整条竖线都被占满时留在原位，不推出视口', () => {
+  const wall = { left: 1200, top: 0, width: 240, height: VH }
+  assert.equal(resolveLauncherTop(launcher, [wall], VH), 512)
+})
+
+test('宽高为零的障碍（display:none 的元素）不算', () => {
+  const hidden = { left: 1105, top: 401, width: 0, height: 0 }
+  assert.equal(resolveLauncherTop(launcher, [hidden], VH), 512)
+})


### PR DESCRIPTION
## 内容
- **#574** 英文界面 AI 面板空会话时发送按钮被右下角 Feedback 浮钮遮挡（v0.38.1 起即存在）。主操作区容器声明 `data-awd-keep-clear`，浮钮只沿竖直方向让路；让路是显示偏移，不写回拖动坐标、不持久化。
- **门禁**：app-e2e J12 点击前断言 `elementFromPoint` 命中发送键，被遮挡判红；原来记 skip，工具名断言从未真执行。
- **#575** `NetworkRegionService.detectionBasis` 双语化。

## 验证
- app-e2e 全量：修复前（仅新门禁）140 通过 1 失败（`elementFromPoint 命中 SPAN "Feedback"`）；修复后 142 通过 0 失败，J12 工具名断言真执行。
- `node --test tests/feedback-widget/keep-clear.test.mjs` 7/7。
- `NetworkRegionServiceTest` 红（英文期望拿到中文）→ 绿。
- 真渲染 en/zh × 1440x900/1280x720，发送键中心 elementFromPoint 均命中按钮自身。

补丁边界内（仅 frontend/ backend/src），随 v0.38.2 发（dev-board#571）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)