### PR TITLE
fix(identity): 版本署名统一取展示名 + 改名后刷新案件库展示名 + 两处小修（dev-board#564 #565 #566 #551）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -26,6 +26,14 @@ beforeUnmount 兜底，Office 没有）。
 （goAllProjects 允许直接 reLaunch 或走 leaveWorkbench，走出口时会连带校验出口里有
 flushDirtyEditors），单测见 `frontend/tests/project-home/flush-dirty-editors.test.mjs`。
 
+**工作台里渲染的组件要跳出工作台，也走这个出口**（v0.38.2 走查：协作抽屉「去团队设置」直接
+`uni.reLaunch`，防抖期内没落盘的文档改动随组件树一起没了）。组件拿不到页面实例，所以
+`project-overview.vue` 用 `provide()` 把 `leaveWorkbench` 注入下去，组件 `inject: { leaveWorkbench: { default: null } }`，
+有就走它、没有（宿主不是工作台，比如项目列表页里的加人弹窗）才直调。`check:nav` 扫 project-overview
+直接 import 的全部组件：出现 `uni.reLaunch/navigateTo/redirectTo` 的方法要么同方法里走了
+`this.leaveWorkbench(`，要么进脚本里的 `WORKBENCH_NAV_ALLOWLIST` 并写理由。名单里现有四处早于这条护栏
+（插件详情/侧栏跳账户页、技能下拉跳插件广场、切换本机身份），各有产品含义，待单独评估。
+
 ## project-overview.vue 内部地图（4939 行，主战场）
 
 > **下面这份 :xxx 行号地图早于「project-overview 分阶段拆分」，多数已漂（实测：

--- a/.claude/agents/version-control.md
+++ b/.claude/agents/version-control.md
@@ -206,6 +206,21 @@ description: 项目级版本记录领域。任务涉及版本记录/工作段（
 `VersionController.userName(userId)` 由「`username`，取不到才回『用户』」改成
 「`displayName` → 空则 `username` → 都空才回『用户』」。以前手机号注册的同事在时间线与文档修订里
 就是一串 `awd_upoxwcdtg`——用户名现在是内部标识，任何界面都不再当名字显示。
+**写进 Git 的作者名只有一个取法：`UserService.signatureName(User)`**（v0.38.2 发版走查补齐）：
+展示名 → 空则用户名 → 都空回 null，兜底文案（「用户」/「AI WorkDeck」）由调用方给。
+PR#797 当时只改了 `VersionController`，自动存档（`ProjectFileService.resolveUserName`）、
+自动开启的「初始版本」（`VersionLifecycleService.authorName`）、AI 改纯文本
+（`TextFileEditTools.resolveUserName`）、云端整合/裁决（`CloudController.userName`）四处仍取 username，
+时间线上一半「韩律师」一半 `admin`。**新增任何往版本库写作者名的入口都走这个方法，不要再手写一份。**
+护栏：`ChangeSignalWiringTest`、`VersionAutoEnableAuthorTest`、`TextFileEditToolsTest`、`CloudControllerTest` 各一条。
+
+**官方案件库上的自己的展示名也要跟官网走**：案件库只在桥接（`awdk-login` → `resolveUser`）时刷新展示名，
+而 `OfficialCloudService.connectOfficial` 指纹不变就一直复用旧连接。现在 `AccountIdentitySync` 每次按官网同步到
+展示名都发 `DisplayNameSynced` 事件，`OfficialCloudService.onDisplayNameSynced`（`@Async`）比对连接上的
+`displayName`，不一致就**就地重桥**（案件库侧没有新端点，旧案件库也兼容）并撤掉旧令牌
+（`CloudSyncService.revokeRemoteToken`，与断开连接共用）。重桥回来的名字若仍是旧的（旧版案件库），
+本机连接照样记官网那份——否则两边永远对不上，每次 `/api/account/status` 都会换一枚令牌。
+
 **已写入的历史 `authorName` 不回填**（Git 提交对象不重写，同上一条纪律）。
 护栏测试 `version/VersionAuthorNameTest`（两条：展示名优先、空展示名回落用户名）。
 

--- a/backend/src/main/java/com/checkba/controller/CloudController.java
+++ b/backend/src/main/java/com/checkba/controller/CloudController.java
@@ -387,8 +387,8 @@ public class CloudController {
 
     private String userName(Long userId) {
         try {
-            var u = userService.getUserById(userId);
-            if (u != null && u.getUsername() != null) return u.getUsername();
+            String name = UserService.signatureName(userService.getUserById(userId));
+            if (name != null) return name;
         } catch (Exception e) {
             log.warn("取用户名失败: userId={}", userId, e);
         }

--- a/backend/src/main/java/com/checkba/service/ProjectFileService.java
+++ b/backend/src/main/java/com/checkba/service/ProjectFileService.java
@@ -1604,8 +1604,8 @@ public class ProjectFileService {
     private String resolveUserName(Long userId) {
         if (userId == null) return LangText.of("用户", "User");
         try {
-            var u = userService.getUserById(userId);
-            if (u != null && u.getUsername() != null) return u.getUsername();
+            String name = UserService.signatureName(userService.getUserById(userId));
+            if (name != null) return name;
         } catch (Exception e) {
             log.warn("解析用户名失败: userId={}", userId, e);
         }

--- a/backend/src/main/java/com/checkba/service/UserService.java
+++ b/backend/src/main/java/com/checkba/service/UserService.java
@@ -295,6 +295,21 @@ public class UserService {
     }
 
     /**
+     * 版本署名用的名字（spec 2026-09-10 §4）：展示名优先，空才回落用户名，两样都没有回 null，
+     * 兜底写「用户」还是「AI WorkDeck」由调用方决定。
+     *
+     * <p>写进 Git 提交对象的作者名全部走这里——手动开启、自动开启、自动存档、AI 改文本、
+     * 云端整合，以前五处各写一份、只改了一处，时间线上就一半是「韩律师」一半是 {@code admin}。
+     */
+    public static String signatureName(User user) {
+        if (user == null) return null;
+        String display = user.getDisplayName();
+        if (display != null && !display.isBlank()) return display.trim();
+        String username = user.getUsername();
+        return username == null || username.isBlank() ? null : username;
+    }
+
+    /**
      * 展示名随官网刷新（spec 2026-09-10 §4/§5：官网的展示名是唯一权威源）。
      *
      * <p>只在官网给了非空值、且与本地这行不同时才写；<b>username 一个字都不动</b>——

--- a/backend/src/main/java/com/checkba/service/account/AccountIdentitySync.java
+++ b/backend/src/main/java/com/checkba/service/account/AccountIdentitySync.java
@@ -7,6 +7,7 @@ import com.checkba.model.entity.User;
 import com.checkba.service.LocalIdentityService;
 import com.checkba.service.UserService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -37,13 +38,23 @@ public class AccountIdentitySync {
     private final AccountService accountService;
     private final LocalIdentityService localIdentityService;
     private final UserService userService;
+    private final ApplicationEventPublisher events;
+
+    /**
+     * 本机行刚按官网展示名同步过。官方团队案件库那边的展示名只在桥接时刷新，
+     * 由 {@code OfficialCloudService} 听这个事件决定要不要重桥（v0.38.2 发版走查：
+     * 改完昵称，案件库参与人列表里自己仍是打码手机号）。
+     */
+    public record DisplayNameSynced(Long userId, String displayName) {}
 
     public AccountIdentitySync(AccountService accountService,
                                LocalIdentityService localIdentityService,
-                               UserService userService) {
+                               UserService userService,
+                               ApplicationEventPublisher events) {
         this.accountService = accountService;
         this.localIdentityService = localIdentityService;
         this.userService = userService;
+        this.events = events;
     }
 
     /**
@@ -103,6 +114,9 @@ public class AccountIdentitySync {
             if (user == null) return;
             if (displayName != null && !displayName.isBlank()) {
                 userService.refreshDisplayNameFromWebsite(user, displayName);
+                // 每次都发（不只「本机行变了」时）：升级上来的机器本机行早就是新名字，
+                // 案件库连接却还停在旧值，只有这样下次启动才会收敛。听的一方自己比对、没变不动。
+                events.publishEvent(new DisplayNameSynced(userId, displayName.trim()));
             }
             if (touchAvatar && !Objects.equals(user.getAvatarUrl(), avatarUrl)) {
                 userService.updateAvatar(userId, avatarUrl);

--- a/backend/src/main/java/com/checkba/service/ai/tools/TextFileEditTools.java
+++ b/backend/src/main/java/com/checkba/service/ai/tools/TextFileEditTools.java
@@ -221,8 +221,8 @@ public class TextFileEditTools implements AgentToolComponent {
     private String resolveUserName(Long userId) {
         if (userId != null) {
             try {
-                var u = userService.getUserById(userId);
-                if (u != null && u.getUsername() != null) return u.getUsername();
+                String name = com.checkba.service.UserService.signatureName(userService.getUserById(userId));
+                if (name != null) return name;
             } catch (Exception e) {
                 log.warn("解析用户名失败: userId={}", userId, e);
             }

--- a/backend/src/main/java/com/checkba/version/CloudSyncService.java
+++ b/backend/src/main/java/com/checkba/version/CloudSyncService.java
@@ -132,22 +132,28 @@ public class CloudSyncService {
     /** 断开一个云端连接：尽力撤远端令牌 + 删本地连接与所有关联的项目绑定。 */
     public void disconnect(long connectionId, Long userId) {
         connectionRepository.findById(connectionId).filter(c -> ownedBy(c, userId)).ifPresent(conn -> {
-            if (conn.getTokenId() != null) {
-                try {
-                    JSONObject resp = JSONUtil.parseObj(httpPost(
-                            conn.getServerUrl() + "/api/auth/device-token/" + conn.getTokenId() + "/revoke",
-                            "{}", conn.getDeviceToken()));
-                    if (resp.getInt("code", 1) != 0) {
-                        log.warn("远端撤销设备令牌未成功: connection={}, message={}",
-                                connectionId, resp.getStr("message"));
-                    }
-                } catch (Exception e) {
-                    log.warn("远端撤销设备令牌失败，仅做本地断开: connection={}", connectionId, e);
-                }
-            }
+            revokeRemoteToken(conn.getServerUrl(), conn.getTokenId(), conn.getDeviceToken());
             remoteRepository.findByConnectionId(connectionId).forEach(remoteRepository::delete);
             connectionRepository.delete(conn);
         });
+    }
+
+    /**
+     * 尽力撤掉远端一枚长期设备令牌：断开连接、官方连接重桥换令牌之后共用。失败只记日志——
+     * 撤不掉最多是远端多一枚不再有人用的令牌，不值得为它让断开或改名失败。
+     */
+    void revokeRemoteToken(String serverUrl, Long tokenId, String sessionToken) {
+        if (tokenId == null) return;
+        try {
+            JSONObject resp = JSONUtil.parseObj(httpPost(
+                    serverUrl + "/api/auth/device-token/" + tokenId + "/revoke", "{}", sessionToken));
+            if (resp.getInt("code", 1) != 0) {
+                log.warn("远端撤销设备令牌未成功: server={}, tokenId={}, message={}",
+                        serverUrl, tokenId, resp.getStr("message"));
+            }
+        } catch (Exception e) {
+            log.warn("远端撤销设备令牌失败: server={}, tokenId={}", serverUrl, tokenId, e);
+        }
     }
 
     public java.util.List<CloudConnection> listConnections(Long userId) {

--- a/backend/src/main/java/com/checkba/version/OfficialCloudService.java
+++ b/backend/src/main/java/com/checkba/version/OfficialCloudService.java
@@ -10,10 +10,13 @@ import cn.hutool.json.JSONUtil;
 import com.checkba.model.entity.CloudConnection;
 import com.checkba.repository.CloudConnectionRepository;
 import com.checkba.service.LangText;
+import com.checkba.service.account.AccountIdentitySync;
 import com.checkba.service.account.AccountService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -117,6 +120,54 @@ public class OfficialCloudService {
     public Map<String, Object> shareProject(long projectId, Long userId, Long connectionId) {
         long target = connectionId != null ? connectionId : connectOfficial(userId).getId();
         return cloudSyncService.shareToCloud(projectId, target, userId);
+    }
+
+    /**
+     * 本机展示名随官网刷新之后（{@link AccountIdentitySync} 的事件：连接账户、每次
+     * {@code GET /api/account/status}、改昵称之后），把官方案件库那边的也跟上。
+     */
+    @EventListener
+    @Async("taskExecutor")
+    public void onDisplayNameSynced(AccountIdentitySync.DisplayNameSynced event) {
+        refreshDisplayName(event.userId(), event.displayName());
+    }
+
+    /**
+     * 官方连接上的展示名与官网不一致时就地重桥（v0.38.2 发版走查）。
+     *
+     * <p>案件库侧没有单独的「刷新我的展示名」端点，现成的入口就是桥接本身——
+     * {@code awdk-login} 每次都按官网 /me 刷新服务端用户的展示名（PR#797）。
+     * 而 {@link #connectOfficial} 在指纹不变时一直复用旧连接、从不重桥，于是改完昵称
+     * 案件库参与人列表里自己还是旧名字，本机合并署名 {@code conn.displayName} 也是旧值。
+     *
+     * <p>重桥会换一枚新令牌，旧的那枚随即撤掉（不然每改一次名远端就多一枚长期凭据）。
+     * 桥接回来的名字若仍是旧的（旧版案件库不刷新展示名），本机连接照样记官网那份：
+     * 合并署名以官网为准，也不会因为两边一直对不上而每次 status 都重桥一次。
+     *
+     * <p>尽力而为：没有官方连接、没有账户 Key、官网或案件库不可达，一律安静跳过。
+     * {@code synchronized}：连发的两次事件并发重桥会多换出一枚没人撤的令牌。
+     */
+    synchronized void refreshDisplayName(Long userId, String displayName) {
+        if (displayName == null || displayName.isBlank()) return;
+        String name = displayName.trim();
+        CloudConnection existing = existingOfficial(userId);
+        if (existing == null || name.equals(existing.getDisplayName())) return;
+        String key = accountService.currentKeyOrNull();
+        if (key == null) return;
+        Long oldTokenId = existing.getTokenId();
+        try {
+            CloudConnection conn = bridge(officialBaseUrl, userId, key,
+                    accountService.accountFingerprintOrNull(), existing);
+            if (!name.equals(conn.getDisplayName())) {
+                conn.setDisplayName(name);
+                conn = connectionRepository.save(conn);
+            }
+            if (oldTokenId != null && !oldTokenId.equals(conn.getTokenId())) {
+                cloudSyncService.revokeRemoteToken(officialBaseUrl, oldTokenId, conn.getDeviceToken());
+            }
+        } catch (RuntimeException e) {
+            log.warn("官方案件库展示名刷新跳过（下次同步再试）: user={} {}", userId, e.getMessage());
+        }
     }
 
     // ==================== 内部 ====================

--- a/backend/src/main/java/com/checkba/version/VersionController.java
+++ b/backend/src/main/java/com/checkba/version/VersionController.java
@@ -653,12 +653,8 @@ public class VersionController {
      */
     private String userName(Long userId) {
         try {
-            var u = userService.getUserById(userId);
-            if (u != null) {
-                String display = u.getDisplayName();
-                if (display != null && !display.isBlank()) return display.trim();
-                if (u.getUsername() != null) return u.getUsername();
-            }
+            String name = UserService.signatureName(userService.getUserById(userId));
+            if (name != null) return name;
         } catch (Exception e) {
             log.warn("取署名失败: userId={}", userId, e);
         }

--- a/backend/src/main/java/com/checkba/version/VersionLifecycleService.java
+++ b/backend/src/main/java/com/checkba/version/VersionLifecycleService.java
@@ -7,6 +7,7 @@ import com.checkba.model.entity.Project;
 import com.checkba.repository.ProjectRemoteRepository;
 import com.checkba.repository.ProjectRepository;
 import com.checkba.repository.UserRepository;
+import com.checkba.service.UserService;
 import com.checkba.service.LangText;
 import com.checkba.service.ProjectService;
 import org.slf4j.Logger;
@@ -237,8 +238,7 @@ public class VersionLifecycleService {
         Long id = userId != null ? userId : project.getUserId();
         if (id == null) return LangText.of("用户", "User");
         return userRepository.findById(id)
-                .map(u -> u.getUsername())
-                .filter(n -> n != null && !n.isBlank())
+                .map(UserService::signatureName)
                 .orElse(LangText.of("用户", "User"));
     }
 

--- a/backend/src/test/java/com/checkba/controller/CloudControllerTest.java
+++ b/backend/src/test/java/com/checkba/controller/CloudControllerTest.java
@@ -272,6 +272,28 @@ class CloudControllerTest {
         }
     }
 
+    /** 整合落下的合并提交署名：展示名优先（spec 2026-09-10 §4），与 VersionController 同一口径。 */
+    @Test
+    void updateSignsWithTheDisplayNameRatherThanTheUsername() {
+        try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {
+            auth.when(() -> AuthController.getUserIdFromSession("sess")).thenReturn(USER_ID);
+            when(projectMemberService.hasReadPermission(PROJECT_ID, USER_ID)).thenReturn(true);
+            when(projectMemberService.isClient(PROJECT_ID, USER_ID)).thenReturn(false);
+            when(projectMemberService.hasWritePermission(PROJECT_ID, USER_ID)).thenReturn(true);
+            var user = new com.checkba.model.entity.User();
+            user.setUsername("awd_upoxwcdtg");
+            user.setDisplayName("韩律师");
+            when(userService.getUserById(USER_ID)).thenReturn(user);
+            when(cloudSyncService.updateFromCloud(anyLong(), any(), any()))
+                    .thenReturn(new CloudSyncService.UpdateResult(
+                            CloudSyncService.UpdateStatus.UPDATED, List.of(), null));
+
+            controller.update(PROJECT_ID, "sess");
+
+            verify(cloudSyncService).updateFromCloud(PROJECT_ID, USER_ID, "韩律师");
+        }
+    }
+
     @Test
     void resolveParsesValidResolutionsAndForwards() {
         try (MockedStatic<AuthController> auth = mockStatic(AuthController.class)) {

--- a/backend/src/test/java/com/checkba/service/account/AccountIdentitySyncTest.java
+++ b/backend/src/test/java/com/checkba/service/account/AccountIdentitySyncTest.java
@@ -38,6 +38,7 @@ class AccountIdentitySyncTest {
     private LocalIdentityService localIdentityService;
     private UserService userService;
     private AccountIdentitySync sync;
+    private org.springframework.context.ApplicationEventPublisher events;
     private User localUser;
 
     @BeforeEach
@@ -45,7 +46,8 @@ class AccountIdentitySyncTest {
         accountService = mock(AccountService.class);
         localIdentityService = mock(LocalIdentityService.class);
         userService = mock(UserService.class);
-        sync = new AccountIdentitySync(accountService, localIdentityService, userService);
+        events = mock(org.springframework.context.ApplicationEventPublisher.class);
+        sync = new AccountIdentitySync(accountService, localIdentityService, userService, events);
 
         localUser = new User();
         localUser.setId(LOCAL_USER);
@@ -145,6 +147,23 @@ class AccountIdentitySyncTest {
 
         verify(userService).refreshDisplayNameFromWebsite(localUser, "韩律师");
         verify(userService, never()).updateAvatar(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("同步到了展示名：发事件，让案件库连接跟着刷新（v0.38.2 走查）")
+    void syncedDisplayNameIsPublishedForTheCaseLibrary() {
+        when(accountService.profileIdentity()).thenReturn(view("韩律师", null));
+
+        sync.refresh();
+
+        verify(events).publishEvent(new AccountIdentitySync.DisplayNameSynced(LOCAL_USER, "韩律师"));
+    }
+
+    @Test
+    @DisplayName("只动头像：不发展示名事件")
+    void avatarOnlyWriteDoesNotPublish() {
+        sync.applyAvatarUrl(null);
+        verify(events, never()).publishEvent(any(Object.class));
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/tools/TextFileEditToolsTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/tools/TextFileEditToolsTest.java
@@ -83,6 +83,28 @@ class TextFileEditToolsTest {
     }
 
     @Test
+    @DisplayName("版本信号的署名用展示名，不用用户名（spec 2026-09-10 §4）")
+    void changeSignalIsSignedWithTheDisplayName() throws Exception {
+        com.checkba.service.UserService users = Mockito.mock(com.checkba.service.UserService.class);
+        com.checkba.model.entity.User u = new com.checkba.model.entity.User();
+        u.setId(3L);
+        u.setUsername("admin");
+        u.setDisplayName("韩律师");
+        when(users.getUserById(3L)).thenReturn(u);
+        StorageServiceFactory factory = Mockito.mock(StorageServiceFactory.class);
+        when(factory.getStorageService()).thenReturn(storage);
+        TextFileEditTools signed = new TextFileEditTools(repo, factory, workSessions, bridge, users);
+        ProjectContextHolder.setUserId(3L);
+        ProjectFile pf = textFile(12L, "备忘二.txt", "txt");
+        when(repo.findById(12L)).thenReturn(Optional.of(pf));
+        stubContent(pf, "甲方");
+
+        signed.text_find_replace(12L, "甲方", "乙方", true);
+
+        verify(workSessions).onChangeSignal(7L, 3L, "韩律师");
+    }
+
+    @Test
     @DisplayName("find_replace 命中：替换全部并落盘，触发版本信号与前端刷新")
     void findReplaceHitWritesBackAndSignals() throws Exception {
         ProjectFile pf = textFile(11L, "备忘.txt", "txt");

--- a/backend/src/test/java/com/checkba/version/ChangeSignalWiringTest.java
+++ b/backend/src/test/java/com/checkba/version/ChangeSignalWiringTest.java
@@ -66,6 +66,25 @@ class ChangeSignalWiringTest {
         projectFileService.permDelete(folder.getId(), 1L);
     }
 
+    /**
+     * 自动存档的署名与结束工作同一口径：展示名优先（spec 2026-09-10 §4）。
+     * 用户名是内部标识（桥接账号是 awd_xxx，单机是 admin），时间线上不能再出现它。
+     */
+    @Test
+    void changeSignalCarriesDisplayNameRatherThanUsername() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("admin");
+        user.setDisplayName("韩律师");
+        when(userService.getUserById(1L)).thenReturn(user);
+
+        ProjectFile folder = projectFileService.createFolder(7L, null, "新建文件夹四", 1L);
+
+        verify(workSessionService, atLeastOnce())
+                .onChangeSignal(eq(7L), eq(1L), eq("韩律师"));
+        projectFileService.permDelete(folder.getId(), 1L);
+    }
+
     /** 查不到用户（或查询异常）时必须退回兜底名「用户」，不能抛异常阻断文件操作。 */
     @Test
     void changeSignalFallsBackToGenericNameWhenUserLookupFails() {

--- a/backend/src/test/java/com/checkba/version/OfficialCloudServiceTest.java
+++ b/backend/src/test/java/com/checkba/version/OfficialCloudServiceTest.java
@@ -264,4 +264,89 @@ class OfficialCloudServiceTest {
         assertEquals(Boolean.FALSE, s.get("connected"));
         assertNull(s.get("username"));
     }
+
+    // ---- 展示名跟随官网（v0.38.2 走查：改了昵称，案件库参与人列表仍是打码手机号）----
+    // 案件库只在桥接（awdk-login → resolveUser）时刷新展示名，而指纹不变时连接一直复用、
+    // 从不重桥；本机的合并署名 conn.displayName 也停在旧值。
+
+    private void renamedOnCase(String displayName) {
+        canned = "{\"code\":0,\"data\":{\"token\":\"awdt_second\",\"userId\":9,"
+                + "\"username\":\"awd_hanzewei\",\"displayName\":\"" + displayName + "\",\"tokenId\":32}}";
+    }
+
+    @Test
+    void aRenamedAccountRebridgesInPlaceAndRevokesTheOldToken() {
+        connectedAccount("awdk_abc", "fp-1");
+        OfficialCloudService svc = mainland();
+        CloudConnection conn = svc.connectOfficial(ME);
+        renamedOnCase("韩律师");
+
+        svc.refreshDisplayName(ME, "韩律师");
+
+        assertEquals(2, httpCalls, "展示名变了要重桥一次，案件库那边才会刷新");
+        assertEquals(1, rows.size(), "就地重桥，不留第二条连接");
+        assertEquals("韩律师", conn.getDisplayName());
+        assertEquals("awdt_second", conn.getDeviceToken());
+        verify(cloudSyncService).revokeRemoteToken(OFFICIAL, 31L, "awdt_second");
+    }
+
+    @Test
+    void anUnchangedNameDoesNotRebridge() {
+        connectedAccount("awdk_abc", "fp-1");
+        OfficialCloudService svc = mainland();
+        svc.connectOfficial(ME);
+
+        svc.refreshDisplayName(ME, "韩泽伟");
+
+        assertEquals(1, httpCalls);
+        verify(cloudSyncService, never()).revokeRemoteToken(any(), any(), any());
+    }
+
+    /** 旧案件库的桥接不刷新展示名：只许重桥一次，不能每次 status 都换一枚令牌。 */
+    @Test
+    void anOldCaseLibraryKeepingTheStaleNameDoesNotCauseARebridgeLoop() {
+        connectedAccount("awdk_abc", "fp-1");
+        OfficialCloudService svc = mainland();
+        CloudConnection conn = svc.connectOfficial(ME);
+        renamedOnCase("韩泽伟");
+
+        svc.refreshDisplayName(ME, "韩律师");
+        svc.refreshDisplayName(ME, "韩律师");
+
+        assertEquals(2, httpCalls);
+        assertEquals("韩律师", conn.getDisplayName(), "本机合并署名以官网为准");
+    }
+
+    @Test
+    void withoutAnOfficialConnectionThereIsNothingToRefresh() {
+        connectedAccount("awdk_abc", "fp-1");
+        mainland().refreshDisplayName(ME, "韩律师");
+        assertEquals(0, httpCalls);
+    }
+
+    @Test
+    void aFailedRefreshIsSwallowedAndLeavesTheConnectionUntouched() {
+        connectedAccount("awdk_abc", "fp-1");
+        OfficialCloudService svc = mainland();
+        CloudConnection conn = svc.connectOfficial(ME);
+        canned = "{\"code\":1,\"message\":\"限速\"}";
+
+        assertDoesNotThrow(() -> svc.refreshDisplayName(ME, "韩律师"));
+        assertEquals("awdt_first", conn.getDeviceToken());
+        assertEquals("韩泽伟", conn.getDisplayName());
+        verify(cloudSyncService, never()).revokeRemoteToken(any(), any(), any());
+    }
+
+    @Test
+    void theIdentitySyncEventDrivesTheRefresh() {
+        connectedAccount("awdk_abc", "fp-1");
+        OfficialCloudService svc = mainland();
+        svc.connectOfficial(ME);
+        renamedOnCase("韩律师");
+
+        svc.onDisplayNameSynced(
+                new com.checkba.service.account.AccountIdentitySync.DisplayNameSynced(ME, "韩律师"));
+
+        assertEquals(2, httpCalls);
+    }
 }

--- a/backend/src/test/java/com/checkba/version/VersionAutoEnableAuthorTest.java
+++ b/backend/src/test/java/com/checkba/version/VersionAutoEnableAuthorTest.java
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.version;
+
+import com.checkba.model.entity.Project;
+import com.checkba.model.entity.User;
+import com.checkba.repository.ProjectRemoteRepository;
+import com.checkba.repository.ProjectRepository;
+import com.checkba.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 自动开启落下的「初始版本」署名（spec 2026-09-10 §4）：与 VersionController 手动开启同一口径——
+ * 展示名优先，空才回落用户名。以前取的是 username，时间线第一条就是 {@code admin}。
+ */
+class VersionAutoEnableAuthorTest {
+
+    private static final long PROJECT = 5L;
+    private static final long OWNER = 9L;
+
+    private WorkSessionService sessionService;
+    private UserRepository userRepository;
+    private VersionLifecycleService lifecycle;
+
+    @BeforeEach
+    void setUp(@TempDir Path tmp) {
+        sessionService = mock(WorkSessionService.class);
+        doAnswer(i -> { ((Runnable) i.getArgument(1)).run(); return null; })
+                .when(sessionService).runLocked(anyLong(), any(Runnable.class));
+        ProjectRepoService repoService = mock(ProjectRepoService.class);
+        when(repoService.isInitialized(PROJECT)).thenReturn(false);
+        when(repoService.workTree(PROJECT)).thenReturn(tmp);
+        ProjectRepository projects = mock(ProjectRepository.class);
+        Project p = new Project();
+        p.setId(PROJECT);
+        p.setUserId(OWNER);
+        when(projects.findById(PROJECT)).thenReturn(Optional.of(p));
+        userRepository = mock(UserRepository.class);
+        lifecycle = new VersionLifecycleService(sessionService, repoService, projects, userRepository,
+                mock(ProjectRemoteRepository.class), Runnable::run);
+    }
+
+    private void owner(String username, String displayName) {
+        User u = new User();
+        u.setId(OWNER);
+        u.setUsername(username);
+        u.setDisplayName(displayName);
+        when(userRepository.findById(OWNER)).thenReturn(Optional.of(u));
+    }
+
+    @Test
+    void initialVersionIsSignedWithTheDisplayName() {
+        owner("admin", "韩律师");
+        lifecycle.autoEnableNow(PROJECT, null, null);
+        verify(sessionService).enableVersionRecording(eq(PROJECT), eq("韩律师"), anyString());
+    }
+
+    @Test
+    void blankDisplayNameFallsBackToTheUsername() {
+        owner("admin", " ");
+        lifecycle.autoEnableNow(PROJECT, null, null);
+        verify(sessionService).enableVersionRecording(eq(PROJECT), eq("admin"), anyString());
+    }
+}

--- a/frontend/scripts/check-navigation-contract.mjs
+++ b/frontend/scripts/check-navigation-contract.mjs
@@ -791,6 +791,58 @@ checkFull('app-e2e 走三级跳而不是把个人中心当必经之路', () => {
   return null
 })
 
+// 工作台里渲染的组件自己跳页，同样是「离开工作台」（2026-09-10，走查抓到 CollabDialog
+// 「去团队设置」直接 reLaunch）：上面几条只看 project-overview.vue 自己的方法，组件里的
+// 跳转从来没人管，防抖窗口里没落盘的文档改动就这么随组件树一起销毁。
+// 规则：project-overview 把 leaveWorkbench provide 出去；它直接 import 的组件里，
+// 凡是出现 uni.reLaunch / navigateTo / redirectTo 的方法，要么同一个方法里优先走注入的
+// this.leaveWorkbench(...)（直调只作为「宿主不是工作台」时的回落），要么进下面的名单并写明理由。
+const WORKBENCH_NAV_ALLOWLIST = {
+  // 以下四处早于本条护栏，行为（navigateTo 保留工作台在栈里 / 切身份整站重走启动链）
+  // 各有产品含义，改动要单独评估，先记名在此不许再新增。
+  'components/MarketSidebarPanel.vue#goToAccountSettings': '预存在：插件详情跳账户页，待单独评估',
+  'components/MarketDetailPane.vue#goToAccountSettings': '预存在：插件详情跳账户页，待单独评估',
+  'components/ChatInterface.vue#goToSkillManagement': '预存在：技能下拉跳插件广场，待单独评估',
+  'components/admin/AdminPane.vue#onSwitchIdentity': '预存在：切换本机身份后整站回启动链重建',
+}
+
+check('工作台 provide 出 leaveWorkbench，给里面的组件用', () => {
+  const src = readVue('src/pages/project-overview/project-overview.vue')
+  const provide = extractMethodBody(src, 'provide()')
+  if (!provide) return 'project-overview 没有 provide()'
+  if (!provide.includes('leaveWorkbench')) return 'provide() 里没有 leaveWorkbench'
+  return null
+})
+
+check('工作台里渲染的组件跳出工作台必须走 leaveWorkbench（先落盘）', () => {
+  const host = readVue('src/pages/project-overview/project-overview.vue')
+  const imported = [...host.matchAll(/from '@\/(components\/[^']+\.vue)'/g)].map((m) => m[1])
+  const NAV = /uni\.(reLaunch|navigateTo|redirectTo)\(/g
+  // 方法头：选项式 `  name(...) {` / `  async name(...) {`，组合式 `const name = (...) => {`
+  const HEADER = /^\s*(?:async\s+)?([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{|^\s*const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\([^)]*\)\s*=>\s*\{/
+  const bad = []
+  for (const rel of [...new Set(imported)]) {
+    const src = readVueOrNull('src/' + rel)
+    if (!src) continue
+    const lines = src.split('\n')
+    let m
+    while ((m = NAV.exec(src))) {
+      const lineNo = src.slice(0, m.index).split('\n').length - 1
+      let name = null
+      for (let i = lineNo; i >= 0 && !name; i--) {
+        const h = lines[i].match(HEADER)
+        if (h && !/^\s*(if|for|while|switch|catch|function)\b/.test(lines[i])) name = h[1] || h[2]
+      }
+      const key = rel + '#' + name
+      if (WORKBENCH_NAV_ALLOWLIST[key]) continue
+      const body = name ? extractMethodBody(src, name + '(') : null
+      if (body && body.includes('this.leaveWorkbench(')) continue
+      bad.push(key)
+    }
+  }
+  return bad.length ? '直接跳页、没走注入的 leaveWorkbench: ' + [...new Set(bad)].join(', ') : null
+})
+
 // ---- 追加位：后续任务把新的 check(...) 加在这一行之前 ----
 
 if (failures.length) {

--- a/frontend/src/components/InviteMemberDialog.vue
+++ b/frontend/src/components/InviteMemberDialog.vue
@@ -276,6 +276,8 @@ export default {
     }
   },
   emits: ['update:visible', 'close', 'success'],
+  // 工作台 provide 的离开出口（先落盘再 reLaunch）；挂在项目列表页时为 null
+  inject: { leaveWorkbench: { default: null } },
   data() {
     return {
       activeTab: 'MEMBER', // 'MEMBER' | 'CLIENT'
@@ -522,13 +524,15 @@ export default {
      * AdminPane 里「账户与用量」那条「前往团队」（onNavTap({ key: 'team' })）同一个，
      * 深链形制同仓里既有的 `/pages/admin/admin?nav=account`（MarketPane 那几处）。
      *
-     * 这个弹窗**只挂在项目列表页**（工作台里的加人走 CollabDialog），不是工作台参与的
-     * 跳转，所以照项目列表页「个人中心」按钮的既有形制用 navigateTo：设置页看完能退回
-     * 列表，弹窗那一步的上下文还在。
+     * 这个弹窗挂在两处：项目列表页（工作台之外，照「个人中心」按钮的既有形制用
+     * navigateTo，设置页看完能退回列表），以及工作台成员堆栈的「+」——那里要走工作台
+     * provide 的 leaveWorkbench（先落盘再 reLaunch），navigateTo 会把工作台留在栈里。
      */
     goTeamSettings() {
       this.close()
-      uni.navigateTo({ url: '/pages/admin/admin?nav=team' })
+      const url = '/pages/admin/admin?nav=team'
+      if (this.leaveWorkbench) this.leaveWorkbench(url)
+      else uni.navigateTo({ url })
     },
     copyInviteLink() {
       uni.setClipboardData({

--- a/frontend/src/components/collab/CollabDialog.vue
+++ b/frontend/src/components/collab/CollabDialog.vue
@@ -267,6 +267,8 @@ export default {
   // changed：云端状态可能变了，页面重新拉一次。reload-files：磁盘被改写，重载打开中的编辑器。
   // conflict：撞上了要逐份选择的情况，页面把人送到裁决现场。
   emits: ['update:visible', 'changed', 'reload-files', 'conflict'],
+  // 工作台 provide 的离开出口（先落盘再 reLaunch）；宿主不是工作台时为 null
+  inject: { leaveWorkbench: { default: null } },
   data() {
     return {
       activeTab: 'casefile',
@@ -532,7 +534,11 @@ export default {
      */
     goTeamSettings() {
       this.close()
-      uni.reLaunch({ url: '/pages/admin/admin?nav=team' })
+      const url = '/pages/admin/admin?nav=team'
+      // 直接 reLaunch 会连同防抖期内还没落盘的文档改动一起销毁（sidebar-shell.md
+      // 「离开工作台前必须落盘」），所以走工作台的统一出口
+      if (this.leaveWorkbench) this.leaveWorkbench(url)
+      else uni.reLaunch({ url })
     },
     copyInviteLink() {
       uni.setClipboardData({

--- a/frontend/src/components/userprofile/PersonalSettingsPanel.vue
+++ b/frontend/src/components/userprofile/PersonalSettingsPanel.vue
@@ -245,6 +245,7 @@ import {
   uploadAvatar, updateAccountProfile, uploadAccountAvatar, deleteAccountAvatar,
 } from '@/services/api.js'
 import { loadIdentityProfile, PROFILE_SOURCE } from '@/services/accountProfile.js'
+import { submittedInputValue } from '@/utils/identityProfile.js'
 import { getDocumentGeneratorSettings, updateDocumentGeneratorSettings } from '@/services/api.js'
 import { resetDocumentStampCache } from '@/utils/documentGeneratorSetting.js'
 import AwdSwitch from '@/components/AwdSwitch.vue'
@@ -426,10 +427,21 @@ export default {
         accountId: (profile && profile.accountId) || '',
         displayNameIsDefault: !!(profile && profile.displayNameIsDefault),
       }
+      // 「去填写」赶在资料回来之前发的聚焦请求，在这里兑现
+      if (this._pendingNameFocus) {
+        this._pendingNameFocus = false
+        if (this.canEditProfile) this.focusDisplayName()
+      }
     },
     /** 姓名引导点下去：把光标送进昵称输入框（uni 的 focus 是 prop，要先落回 false 才能再次触发） */
     focusDisplayName() {
-      if (!this.canEditProfile) return
+      if (!this.canEditProfile) {
+        // 设置页别处点「去填写」时本组件刚挂上，资料还在路上（canEditProfile 暂时为 false）：
+        // 直接 return 会把请求丢掉，所以先记下，loadAccountProfile 回来后兑现
+        this._pendingNameFocus = true
+        return
+      }
+      this._pendingNameFocus = false
       this.displayNameFocus = false
       this.$nextTick(() => { this.displayNameFocus = true })
     },
@@ -437,10 +449,11 @@ export default {
      * 存昵称。@blur 与 @confirm 都会调到这里（回车之后紧接着失焦），
      * 所以「没变就什么都不做」这条不是优化，是防止一次编辑发两次写请求。
      */
-    async saveDisplayName() {
+    async saveDisplayName(e) {
       if (!this.canEditProfile || this.displayNameSaving) return
       const current = String(this.userInfo.displayName || '')
-      const next = String(this.displayNameInput || '').trim()
+      // 用事件带的值：v-model 有 100ms 节流，打完字立刻回车时 displayNameInput 还是上一拍
+      const next = String(submittedInputValue(e, this.displayNameInput) || '').trim()
       if (!next || next === current) {
         // 清空不算「改成空名」：空展示名同事那边照样看不出是谁，回落到原值
         this.displayNameInput = current

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -2147,6 +2147,11 @@ import DocumentLinkPreview from '@/components/DocumentLinkPreview.vue'
 const WEB_KEEPALIVE_MAX = 5
 
 export default {
+  // 工作台里渲染的组件（协作抽屉、加人弹窗……）要跳出工作台时，也得走同一个出口：
+  // 先落盘再 reLaunch。组件拿不到页面实例，只能靠注入（check:nav 钉着）。
+  provide() {
+    return { leaveWorkbench: (url) => this.leaveWorkbench(url) }
+  },
   components: {
     LibreOfficeEditor,
     BrowserPane,

--- a/frontend/src/utils/identityProfile.js
+++ b/frontend/src/utils/identityProfile.js
@@ -57,6 +57,17 @@ export function withNudgeDismissed(dismissedIds, accountId) {
   return list.concat(id).slice(-50)
 }
 
+/**
+ * 输入框 confirm/blur 那一刻用户真正提交的文字。
+ *
+ * uni-h5 的 v-model 有 100ms 节流：打完最后一个字立刻回车，绑定的 data 还是上一拍的值，
+ * 只有事件自己带的 detail.value 是最新的。事件不带字符串值时回落绑定值。
+ */
+export function submittedInputValue(event, fallback) {
+  const value = event && event.detail ? event.detail.value : undefined
+  return typeof value === 'string' ? value : fallback
+}
+
 /** storage 里读回来的东西可能是任何形状（老版本写过别的、被人手改过）：一律归一成字符串数组。 */
 function toIdList(value) {
   if (!Array.isArray(value)) return []

--- a/frontend/tests/identity/nickname-input.test.mjs
+++ b/frontend/tests/identity/nickname-input.test.mjs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 昵称输入框的两处时序缺口（v0.38.2 发版走查抓到）。
+//  ① 打完字立刻回车：uni-h5 的 v-model 有 100ms 节流，confirm 那一刻 displayNameInput
+//     还是上一拍的值，存上去的少最后一个字。改用 confirm/blur 事件自己带的 detail.value。
+//  ② 「去填写」聚焦：请求发出时面板的资料还没拉回来（canEditProfile 为 false），
+//     旧实现直接 return 把请求丢了。要挂起，资料就绪再兑现。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { submittedInputValue } from '../../src/utils/identityProfile.js'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const PANEL = readFileSync(
+  path.resolve(HERE, '../../src/components/userprofile/PersonalSettingsPanel.vue'), 'utf8')
+
+test('事件带了值就用事件的值（v-model 节流期内它才是最新的）', () => {
+  assert.equal(submittedInputValue({ detail: { value: '韩律师二' } }, '韩律师'), '韩律师二')
+  // 用户把框清空后回车：空串也是事件的真值，不能回落成旧值
+  assert.equal(submittedInputValue({ detail: { value: '' } }, '韩律师'), '')
+})
+
+test('没有事件或事件不带字符串值 → 回落 v-model 的值', () => {
+  assert.equal(submittedInputValue(undefined, '韩律师'), '韩律师')
+  assert.equal(submittedInputValue({}, '韩律师'), '韩律师')
+  assert.equal(submittedInputValue({ detail: {} }, '韩律师'), '韩律师')
+  assert.equal(submittedInputValue({ detail: { value: 3 } }, '韩律师'), '韩律师')
+})
+
+function methodBody(src, marker) {
+  const i = src.indexOf(marker)
+  assert.ok(i >= 0, '找不到 ' + marker)
+  const start = src.indexOf('{', i)
+  let depth = 0
+  for (let j = start; j < src.length; j++) {
+    if (src[j] === '{') depth++
+    else if (src[j] === '}' && --depth === 0) return src.slice(i, j + 1)
+  }
+  return ''
+}
+
+test('saveDisplayName 读的是事件值，不是节流中的 v-model', () => {
+  const body = methodBody(PANEL, 'async saveDisplayName(')
+  assert.match(body, /submittedInputValue\(/)
+})
+
+test('资料未就绪时的聚焦请求要挂起，loadAccountProfile 之后兑现', () => {
+  // 带缩进与花括号定位方法定义本身（mounted 与 loadAccountProfile 里都有 this.focusDisplayName() 调用）
+  const focus = methodBody(PANEL, '    focusDisplayName() {')
+  assert.match(focus, /_pendingNameFocus\s*=\s*true/, '不可编辑时要记下请求而不是直接丢掉')
+  const load = methodBody(PANEL, 'async loadAccountProfile(')
+  assert.match(load, /_pendingNameFocus/, '资料拉回来之后要兑现挂起的聚焦')
+})

--- a/frontend/tests/member-invite/member-lookup.test.mjs
+++ b/frontend/tests/member-invite/member-lookup.test.mjs
@@ -178,10 +178,14 @@ test('工作台弹窗的「去团队设置」接上了跳转', () => {
   assert.match(collabSrc, /\/pages\/admin\/admin\?nav=team/)
 })
 
-test('工作台里的跳转必须 reLaunch——navigateTo 会把工作台连同它的全局订阅留在页面栈里', () => {
+test('工作台里的跳转走 leaveWorkbench（先落盘再 reLaunch）——navigateTo 会把工作台留在页面栈里', () => {
   const jump = /goTeamSettings\s*\(\)\s*\{[\s\S]*?\n    \}/.exec(collabSrc)
   assert.ok(jump, '找不到 goTeamSettings 的方法体')
-  assert.match(jump[0], /uni\.reLaunch\(\{\s*url:\s*'\/pages\/admin\/admin\?nav=team'/)
+  // 优先走工作台 provide 的出口：直接 reLaunch 会丢掉防抖期内没落盘的文档改动（v0.38.2 走查）
+  assert.match(jump[0], /this\.leaveWorkbench\(url\)/)
+  assert.match(jump[0], /'\/pages\/admin\/admin\?nav=team'/)
+  // 回落（宿主不是工作台）也只许 reLaunch
+  assert.match(jump[0], /uni\.reLaunch\(\{\s*url\s*\}\)/)
   assert.doesNotMatch(jump[0], /navigateTo|redirectTo|navigateBack/)
 })
 


### PR DESCRIPTION
## 背景
v0.38.2 发版前真渲染走查（真后端 + 本机假官网/假案件库，不拦前端请求）发现 PR#797/#795 的遗漏：2 中 2 低 1 风险。

## 修复
| 卡 | 问题 | 修法 |
|---|---|---|
| #564 | 自动存档、初始版本作者仍显示 `admin` | `UserService.signatureName` 统一五处 Git 作者名 |
| #564 | 改昵称后案件库参与人里自己仍是打码手机号 | `DisplayNameSynced` 事件 → `OfficialCloudService` 比对后重桥并撤旧令牌 |
| #566 | 「去填写」不聚焦昵称框 | 资料未就绪时挂起聚焦请求 |
| #565 | 打完字立刻回车昵称存不全 | 取 confirm 事件自带值 |
| #551 | 「去团队设置」直接 reLaunch 不落盘 | 工作台 provide `leaveWorkbench`，两个弹窗注入使用；`check:nav` 覆盖组件 |

## 验证
- 新测试修复前红（Wanted but not invoked / 编译失败 / fail 1 / check:nav 报直接跳页），修复后绿。
- 主会话复跑：6 个相关后端测试类 72/72；`test:identity` 14/14；`test:member-invite` 27/27；`check:nav` 与 `check:nav:full` 通过。
- 子代理后端全量 `mvn test` 3585 通过 0 失败 14 跳过。
- 真渲染复走：新项目初始版本与自动存档署名「韩律师」；改名后案件库参与人行跟随；昵称框获焦；快速回车存全；去团队设置只调用一次 leaveWorkbench。老项目的历史条目不回填（契约）。
- 撤旧令牌：`DeviceTokenService.revoke` 按调用者 userId 过滤，同一用户新令牌可撤旧令牌；真实环境撤销仅单测覆盖。

补丁边界内（仅 backend/src、frontend、领域文档），随 v0.38.2 发（dev-board#571）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)