### PR TITLE
test(ai-alignment-e2e): 等历史列表与记忆空间加载完再点，修两处抢时序

### DIFF
--- a/frontend/tests/ai-alignment-e2e/run.mjs
+++ b/frontend/tests/ai-alignment-e2e/run.mjs
@@ -231,6 +231,12 @@ try {
     await page.mouse.click(point.x, point.y)
   }
   const clickHistoryEntry = async () => {
+    // 下拉每次打开都重拉历史，拉取期间只有一行「加载中...」；先等真实条目出来，
+    // 否则下面「只剩一行就点它」的兜底会点在加载占位上，点击无效、下一步超时
+    await page.waitForFunction(() => {
+      const rows = [...document.querySelectorAll('.ai-dropdown-panel .menu-item:not(.header)')]
+      return rows.length > 0 && !rows.some((node) => /加载中|Loading/i.test(node.innerText))
+    }, { timeout: 10000 })
     const point = await page.evaluate((marker) => {
       const rows = [...document.querySelectorAll('.ai-dropdown-panel .menu-item:not(.header)')]
       const row = rows.find((node) => node.innerText.includes(marker)) || (rows.length === 1 ? rows[0] : null)
@@ -318,6 +324,11 @@ try {
 
   await click('.memory-header-btn')
   await page.waitForSelector('.memory-dialog', { timeout: 10000 })
+  // 记忆空间列表是弹窗打开后异步拉的，直接找会赶在列表出来之前
+  if (memorySpace.scope === 'project') {
+    await page.waitForFunction((projectName) => [...document.querySelectorAll('.memory-space')]
+      .some((node) => node.innerText.includes(projectName)), { timeout: 10000 }, project.name)
+  }
   const projectScopePoint = await page.evaluate((projectName) => {
     const item = [...document.querySelectorAll('.memory-space')]
       .find((node) => node.innerText.includes(projectName))


### PR DESCRIPTION
## 问题
PR#798 带来的 `npm run test:ai-alignment-e2e` 在 v0.38.3 发版门禁里 2/2 红（01967bfb），在 #798 自身提交 556b9f62 上同样 2/2 红，不是合 master 引入。
- 历史下拉每次打开都重拉列表，加载期间只有一行「加载中...」，`clickHistoryEntry` 的 `rows.length === 1` 兜底点在占位上，点击无效，`run.mjs:276` 等 `.user-bubble` 超时。
- 记忆弹窗的空间列表异步加载，找项目空间时列表还没出来（`project memory scope is missing`）。

插桩在点击前等待后整条旅程通过（插话、队列编辑排序立即发送、历史回挂同一任务、Markdown 记忆保存读回），功能本身无回归。

## 修复
只改测试：点历史前等真实条目出现且无「加载中/Loading」行（兜底保留，但只在加载完后生效）；找项目记忆空间前等它出现。

## 验证
修复版连续 3 次 + 原版对照 1 次，在全新隔离环境上跑，结果补在下面评论里；验证完成前不合并。发版卡 dev-board#579。

🤖 Generated with [Claude Code](https://claude.com/claude-code)