### PR TITLE
fix(ai): #798 走查缺陷——SSE 不占 DB 连接、记忆编辑器解除 140 字、立即发送界面跟上、队列避让浮钮（dev-board#559 #562 #563）

### DIFF
--- a/.claude/agents/ai-chat.md
+++ b/.claude/agents/ai-chat.md
@@ -238,6 +238,24 @@ template :1-539；script :541-1879（模式/模型选择 :648-766、文件变更
 
 ## 已知地雷
 
+- **SSE 长连接端点不许持有 JPA EntityManager（v0.38.3 走查 D1）**：`spring.jpa.open-in-view` 从未配置、走默认 true，
+  OSIV 会把 connect 里归属校验拿到的 JDBC 连接一直占到流结束（Spring 下 Hibernate 是 DELAYED_ACQUISITION_AND_HOLD），
+  客户端断开走 onError 时 OSIV 甚至不关 EntityManager，连接永久泄漏；池子 10 条，切几次会话后端整体卡死。
+  现由 `config/OpenEntityManagerInViewConfig` 替换 Boot 自动配置的拦截器并排除 `/api/agent/connect/**`（其余路径 OSIV 不变，
+  **不要全局关 OSIV**）。新增任何 SseEmitter / 长轮询端点必须加进 `LONG_LIVED_STREAM_PATHS`。护栏 `SseConnectPoolReleaseTest`
+  （真 Tomcat + Hikari 活跃数）。另：Spring 6.1 的 `ResponseBodyEmitter.complete()` 在 I/O 发送失败后是空操作，
+  断线收尾靠容器 onError 分派，`SseEmitterService.emitTo` 里的 complete() 只兜非 I/O 失败。
+- **uni-h5 的 `<textarea>`/`<input>` 缺省 maxlength=140，且 v-model 有 100ms 节流**：新增输入控件必须显式 `:maxlength`
+  （记忆编辑器 -1 + 保存时按 128 KiB UTF-8 校验）；「打完字立刻点按钮」的提交路径要读 confirm 事件值或控件 DOM 值
+  （`MemoryBrowser.liveFieldValue`，同 `utils/identityProfile.js` 的 submittedInputValue）。e2e 必须真按键输入，
+  原生 value setter 会绕过这两类缺陷。
+- **「立即发送」会恢复停住的队列**：停止时本地 SSE 已断开，`useAgentStream.updateInbox` 对 `submissionMode=steer`
+  的补丁先 `connectSSE` 再发 PATCH（前端不带 Last-Event-ID，连晚了会丢 input_applied）。
+- **队列自动接续不许先关流**：正常收尾由 `AgentOrchestrator.endRunAndDrain` 在 inbox 锁内判断——还有下一条待处理就
+  **不关流**，接续那一轮沿用同一条连接（`beginRun` 记的是当前代次，它自己收尾时再关）；队列跑空才 `closeSse`。
+  曾经是「bubble_end → closeSse → drain」，接续那一轮的事件全部发进没有 emitter 的会话，前端看不到、条目一直挂在待处理。
+  护栏 `AgentOrchestratorInboxTest.finishingWithQueuedFollowUpKeepsTheStreamOpenForTheContinuedRun`。
+
 - **改 AgentOrchestrator 构造器必须同步 EvalHarness**（已踩三次；现构造器末三参是
   TelemetryService/TelemetryTurnTracker/MatterClassifierService）。
 - **编排器里凡是「会话级」的写操作，一律走 `markRunState` / `sendRunEvent` / `closeSse(guard)`，不要直接调

--- a/backend/src/main/java/com/checkba/config/OpenEntityManagerInViewConfig.java
+++ b/backend/src/main/java/com/checkba/config/OpenEntityManagerInViewConfig.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Open-EntityManager-in-View，但 SSE 长连接端点除外（v0.38.3 走查 D1）。
+ *
+ * <p>spring.jpa.open-in-view 在本仓从来没配，走的是 Boot 默认的 true：每个请求绑一个
+ * EntityManager，控制器里一旦查过库，那条 JDBC 连接就跟着 EntityManager 活到请求结束
+ * （Spring 下 Hibernate 的连接模式是 DELAYED_ACQUISITION_AND_HOLD）。普通请求几十毫秒，
+ * 无所谓；{@code GET /api/agent/connect/{id}} 是 SseEmitter 异步请求，归属校验查一次库，
+ * 连接就被占到整条流结束——流开着占 30 分钟，客户端断开走 onError 路径时 OSIV 的
+ * AsyncRequestInterceptor 根本不关 EntityManager（DeferredResult 自己的生命周期拦截器先
+ * 返回 false，OSIV 的 handleError 轮不到），连接从此不还。池子一共 10 条，
+ * 切几次会话就满，之后所有接口先等 30 秒再 500（SseConnectPoolReleaseTest 复现）。
+ *
+ * <p>刻意<b>不全局关闭</b> OSIV：别处可能依赖视图层懒加载，全关会在意想不到的地方抛
+ * LazyInitializationException。这里只是替换 Boot 自动配置的那个拦截器——Boot 的
+ * JpaWebConfiguration 带 {@code @ConditionalOnMissingBean(OpenEntityManagerInViewInterceptor)}，
+ * 我们声明了同类型 bean 它就自动退让；注册时排除 SSE 路径，其余路径行为与原来完全一致。
+ * 条件与 Boot 原配置同口径：有人显式把 open-in-view 关掉时，本配置也不生效。
+ *
+ * <p>SSE 端点不再持有 EntityManager 后，connect 里的查询各自走仓储方法自带的只读事务，
+ * 查完即还连接。connect 只读实体的基本字段，不存在懒加载。
+ */
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnProperty(prefix = "spring.jpa", name = "open-in-view", havingValue = "true", matchIfMissing = true)
+public class OpenEntityManagerInViewConfig implements WebMvcConfigurer {
+
+    /** 长连接异步端点：不许在流的生命周期里持有 EntityManager（及其 JDBC 连接）。 */
+    static final String[] LONG_LIVED_STREAM_PATHS = {"/api/agent/connect/**"};
+
+    @Bean
+    public OpenEntityManagerInViewInterceptor openEntityManagerInViewInterceptor() {
+        return new OpenEntityManagerInViewInterceptor();
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addWebRequestInterceptor(openEntityManagerInViewInterceptor())
+                .excludePathPatterns(LONG_LIVED_STREAM_PATHS);
+    }
+}

--- a/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
+++ b/backend/src/main/java/com/checkba/service/ai/AgentOrchestrator.java
@@ -271,14 +271,20 @@ public class AgentOrchestrator {
     private void endRunAndDrain(RunGuard guard) {
         AgentInboxService inbox = this.inboxService;
         if (inbox == null) {
+            closeSse(guard);
             endRun(guard);
             return;
         }
         synchronized (inbox.conversationLock(guard.conversationId)) {
+            java.util.Optional<com.checkba.model.entity.AgentInboxItem> next = inbox.nextPending(guard.conversationId);
+            // 还有下一条要自动接续时不许关流（v0.38.3 走查 D3）：接续那一轮沿用同一条连接
+            // （beginRun 记下的是当前代次），它的 inbox_updated / input_applied / 正文都要发到这条流上。
+            // 先关再接续的话，前端收不到接续那一轮的任何事件，已执行的条目一直挂在「待处理」里。
+            // 必须在摘掉本轮登记之前判断：closeSse 只对当前轮次生效。
+            if (next.isEmpty()) closeSse(guard);
             activeRuns.remove(guard.conversationId, guard);
             skillRouter.clearRun(guard.runId);
-            inbox.nextPending(guard.conversationId)
-                    .ifPresent(next -> acceptInboxSubmission(next.getId()));
+            next.ifPresent(item -> acceptInboxSubmission(item.getId()));
         }
     }
 
@@ -1577,8 +1583,7 @@ public class AgentOrchestrator {
             markRunState(guard, AgentRunStateService.RunStatus.FINISHED);
             // 发送 bubble_end 表示整个循环真正结束
             sendRunEvent(guard, "bubble_end", "{\"status\":\"finished\"}");
-            closeSse(guard);
-            // 清理本轮登记
+            // 清理本轮登记；队列跑空才关流（见 endRunAndDrain）
             endRunAndDrain(guard);
           } catch (Exception e) {
             // 确保异常时也能正确结束 bubble，避免前端一直显示加载状态。

--- a/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
+++ b/backend/src/main/java/com/checkba/service/ai/SseEmitterService.java
@@ -250,6 +250,12 @@ public class SseEmitterService {
             // 两种情况该 emitter 都已失效，一并丢弃，避免异常逃逸打断推事件的调用线程。
             log.warn("Failed to send SSE event to {} ({}), removing emitter.", connectionId, e.getClass().getSimpleName());
             emitters.remove(connectionId, emitter);
+            // 摘出映射之后再没有人会收尾这个 emitter（close() 按映射查找），不 complete 的话
+            // 它的异步请求要挂到 30 分钟超时。只 complete 失败的这一个实例，与重连后映射里的
+            // 新 emitter 无关，不存在代次竞态。注意：I/O 失败（含 AsyncRequestNotUsableException）
+            // 之后 Spring 6.1 的 complete() 是空操作，那条路由容器的 onError 分派收尾；
+            // 这里兜的是非 I/O 失败（IllegalStateException 等）。
+            try { emitter.complete(); } catch (Exception ignored) { /* 已失效 */ }
         }
     }
 

--- a/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorInboxTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/AgentOrchestratorInboxTest.java
@@ -59,6 +59,11 @@ class AgentOrchestratorInboxTest {
             return null;
         })
                 .when(sse).send(any(), any(), any());
+        // 关流也记进同一条时间线：自动接续的那一轮必须在一条还开着的流上发事件
+        doAnswer(inv -> {
+            sseEvents.add("close:" + inv.getArgument(0, String.class));
+            return null;
+        }).when(sse).close(any(), anyLong());
         AgentRunStateService runState = mock(AgentRunStateService.class);
         inbox = new AgentInboxService(repo, sse, runState);
 
@@ -264,6 +269,57 @@ class AgentOrchestratorInboxTest {
         int appliedIndex = indexOfEvent("input_applied", queued.getId());
         assertTrue(snapshotIndex >= 0 && appliedIndex > snapshotIndex,
                 "new-run snapshot must precede applied event: " + sseEvents);
+    }
+
+    /**
+     * v0.38.3 走查 D3：一轮正常结束、队列里还有待处理条目时，收尾曾经先关流再接续下一条——
+     * 接续那一轮的 inbox_updated / input_applied / 正文全部发进一个已经没有 emitter 的会话，
+     * 前端既没有新气泡也没有停止键，已执行的条目一直挂在「待处理」里。
+     * 还有下一条要跑时不许关流；关流只发生在队列真正跑空之后。
+     */
+    @Test
+    void finishingWithQueuedFollowUpKeepsTheStreamOpenForTheContinuedRun() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        CountDownLatch firstReady = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        StreamingChatLanguageModel model = new StreamingChatLanguageModel() {
+            @Override public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+                complete(handler);
+            }
+            @Override public void generate(List<ChatMessage> messages, List<ToolSpecification> specifications,
+                                           StreamingResponseHandler<AiMessage> handler) {
+                complete(handler);
+            }
+            private void complete(StreamingResponseHandler<AiMessage> handler) {
+                if (calls.incrementAndGet() == 1) {
+                    firstReady.countDown();
+                    await(releaseFirst);
+                }
+                handler.onNext("done " + calls.get());
+                handler.onComplete(Response.from(AiMessage.from("done " + calls.get())));
+            }
+        };
+        when(modelFactory.getStreamingChatModel(MODEL)).thenReturn(model);
+
+        AgentInboxItem first = inbox.submit(request("first", "keep-open-first", "steer"), 7L);
+        Thread run = new Thread(() -> orchestrator.acceptInboxSubmission(first.getId(), false));
+        run.start();
+        assertTrue(firstReady.await(5, TimeUnit.SECONDS));
+        AgentInboxItem queued = inbox.submit(request("follow-up", "keep-open-queued", "queue"), 7L);
+        releaseFirst.countDown();
+        run.join(5000);
+
+        assertEquals(2, calls.get());
+        int appliedIndex = indexOfEvent("input_applied", queued.getId());
+        int firstClose = -1;
+        for (int i = 0; i < sseEvents.size(); i++) {
+            if (sseEvents.get(i).startsWith("close:")) { firstClose = i; break; }
+        }
+        assertTrue(appliedIndex >= 0, "queued run must emit input_applied: " + sseEvents);
+        assertTrue(firstClose > appliedIndex,
+                "stream was closed before the continued run started emitting: " + sseEvents);
+        assertEquals(1, sseEvents.stream().filter(e -> e.startsWith("close:")).count(),
+                "the stream closes once, after the queue drains: " + sseEvents);
     }
 
     @Test

--- a/backend/src/test/java/com/checkba/service/ai/SseConnectPoolReleaseTest.java
+++ b/backend/src/test/java/com/checkba/service/ai/SseConnectPoolReleaseTest.java
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.checkba.service.ai;
+
+import com.checkba.service.ai.tools.WebTools;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.sql.DataSource;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SSE 长连接不许占住数据库连接（v0.38.3 真渲染走查 D1：连接池被占满、后端整体卡死）。
+ *
+ * <p>病灶：spring.jpa.open-in-view 默认开启，OSIV 拦截器给每个请求绑一个 EntityManager；
+ * connect 端点做归属校验（canUseConversation 查库）时它拿到一条 JDBC 连接，而 Spring 下
+ * Hibernate 的连接模式是 DELAYED_ACQUISITION_AND_HOLD——要到 EntityManager 关闭才还。
+ * 异步请求（SseEmitter）里这个 EntityManager 活到整条流结束，流开着就一直占着；
+ * 客户端断开走的是 onError 路径，连接同样没有还回来。连接池一共 10 条，
+ * 切几次会话就满，之后所有接口先等 30 秒再 500。
+ *
+ * <p>真实 Tomcat + 真实 Hikari + 默认 OSIV 配置跑完整链路，只看连接池活跃数。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "spring.datasource.url=jdbc:h2:mem:sse-pool;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1",
+        "security.license.dir=${java.io.tmpdir}/awd-sse-pool-license"
+})
+@ActiveProfiles("desktop")
+class SseConnectPoolReleaseTest {
+
+    private static final int STREAMS = 4;
+
+    /** 同 DesktopContextSmokeTest：desktop profile 的本机身份会静态注册到 AuthController，收尾要清掉 */
+    @AfterAll
+    static void resetLocalIdentityStatic() {
+        com.checkba.controller.AuthController.registerLocalIdentityService(null);
+    }
+
+    /** 真 WebTools 的 @PostConstruct 会起线程预热 Playwright，测试里挡掉 */
+    @MockBean
+    private WebTools webTools;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private SseEmitterService sseEmitterService;
+
+    private int baseline;
+
+    @BeforeEach
+    void captureBaseline() throws Exception {
+        // 启动期的定时任务可能正借着连接：等一会儿再取基线。取「当前值」而不是假定 0，
+        // 两个用例共用一个容器，前一个用例在修复前会留下被占的连接。
+        waitUntil(() -> active() == 0, 5_000);
+        baseline = active();
+    }
+
+    @Test
+    void openStreamsDoNotHoldDatabaseConnections() throws Exception {
+        List<Socket> sockets = openStreams();
+        try {
+            boolean released = waitUntil(() -> active() <= baseline, 5_000);
+            assertTrue(released, "SSE 流开着时占住了数据库连接：基线 " + baseline
+                    + "，开 " + STREAMS + " 条流后活跃 " + active());
+        } finally {
+            closeAll(sockets);
+        }
+    }
+
+    @Test
+    void disconnectedStreamsGiveTheirConnectionsBack() throws Exception {
+        closeAll(openStreams());
+        // 服务端要等下一次写才发现断线：心跳多扫几轮
+        // （第一次写可能还能进内核缓冲，后面才吃到 Broken pipe）
+        for (int round = 0; round < 3; round++) {
+            sseEmitterService.heartbeatSweep();
+            Thread.sleep(300);
+        }
+        boolean released = waitUntil(() -> active() <= baseline, 10_000);
+        assertTrue(released, "客户端断开、心跳探出断线后数据库连接仍未还回连接池：基线 " + baseline
+                + "，现在活跃 " + active());
+    }
+
+    private int active() {
+        try {
+            return dataSource.unwrap(HikariDataSource.class).getHikariPoolMXBean().getActiveConnections();
+        } catch (java.sql.SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private List<Socket> openStreams() throws Exception {
+        List<Socket> sockets = new ArrayList<>();
+        for (int i = 0; i < STREAMS; i++) {
+            sockets.add(openStream("conv-pool-" + System.nanoTime() + "-" + i));
+        }
+        return sockets;
+    }
+
+    private static void closeAll(List<Socket> sockets) {
+        for (Socket s : sockets) {
+            try { s.close(); } catch (Exception ignored) { /* 已关 */ }
+        }
+    }
+
+    /** 建一条 SSE 流并读到 run_state 事件为止（此时控制器已返回、异步处理已开始） */
+    private Socket openStream(String conversationId) throws Exception {
+        Socket socket = new Socket("127.0.0.1", port);
+        socket.setSoTimeout(10_000);
+        OutputStream out = socket.getOutputStream();
+        out.write(("GET /api/agent/connect/" + conversationId + " HTTP/1.1\r\n"
+                + "Host: 127.0.0.1:" + port + "\r\n"
+                + "Accept: text/event-stream\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+        out.flush();
+        InputStream in = socket.getInputStream();
+        StringBuilder seen = new StringBuilder();
+        byte[] buf = new byte[1024];
+        while (!seen.toString().contains("run_state")) {
+            int n = in.read(buf);
+            if (n < 0) break;
+            seen.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+        }
+        String head = seen.toString();
+        assertTrue(head.startsWith("HTTP/1.1 200"), "connect 应返回 200：" + head);
+        assertTrue(head.contains("connected"), "应收到 connected 事件：" + head);
+        return socket;
+    }
+
+    private static boolean waitUntil(BooleanSupplier cond, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (cond.getAsBoolean()) return true;
+            Thread.sleep(100);
+        }
+        return cond.getAsBoolean();
+    }
+}

--- a/frontend/src/components/AgentInbox.vue
+++ b/frontend/src/components/AgentInbox.vue
@@ -1,7 +1,8 @@
 <!-- SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors -->
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
-  <view v-if="items.length" class="agent-inbox">
+  <!-- data-awd-keep-clear：队列在输入卡外面，右下角反馈浮钮要一并避开（utils/keepClear.js） -->
+  <view v-if="items.length" class="agent-inbox" data-awd-keep-clear>
     <view class="agent-inbox-head">
       <text class="agent-inbox-title">{{ $t('chat.inboxTitle') }}</text>
       <text class="agent-inbox-count">{{ items.length }}</text>
@@ -13,8 +14,9 @@
           v-model="editText"
           class="agent-inbox-edit"
           type="text"
+          :maxlength="-1"
           :focus="true"
-          @confirm="saveEdit(item)"
+          @confirm="saveEdit(item, $event)"
         />
         <text v-else class="agent-inbox-message">{{ item.displayText || item.message }}</text>
         <text class="agent-inbox-mode">{{ item.submissionMode === 'steer' ? $t('chat.inboxSteer') : $t('chat.inboxQueued') }}</text>
@@ -46,8 +48,15 @@ export default {
       this.editingId = item.id
       this.editText = item.message || ''
     },
-    saveEdit(item) {
-      const message = this.editText.trim()
+    // uni 的 v-model 有 100ms 节流：打完字立刻点保存时 editText 还是旧值，改动会整个丢掉。
+    // 取值优先级：confirm 事件自带的值 → 输入框当下的 DOM 值 → v-model 的值。
+    saveEdit(item, event) {
+      const submitted = event && event.detail ? event.detail.value : undefined
+      const field = this.$el && typeof this.$el.querySelector === 'function'
+        ? this.$el.querySelector('.agent-inbox-edit input, input.agent-inbox-edit') : null
+      const live = typeof submitted === 'string' ? submitted
+        : field && typeof field.value === 'string' ? field.value : this.editText
+      const message = live.trim()
       if (!message) return
       this.$emit('edit', { item, message })
       this.editingId = null

--- a/frontend/src/components/MemoryBrowser.vue
+++ b/frontend/src/components/MemoryBrowser.vue
@@ -36,7 +36,7 @@
             <text v-if="activeSpace && activeSpace.writable" class="memory-link" @tap="showCreate = true">{{ $t('chat.memoryNewTopic') }}</text>
           </view>
           <view v-if="showCreate" class="memory-create">
-            <input v-model="newTopic" class="memory-create-input" :placeholder="$t('chat.memoryTopicPlaceholder')" @confirm="createTopic" />
+            <input ref="topicInput" v-model="newTopic" class="memory-create-input" :maxlength="-1" :placeholder="$t('chat.memoryTopicPlaceholder')" @confirm="createTopic" />
             <text class="memory-link" @tap="createTopic">{{ $t('chat.memoryCreate') }}</text>
           </view>
           <view
@@ -55,8 +55,11 @@
           <template v-if="current">
             <view class="memory-meta">
               <text>{{ activeSpace.label || scopeLabel(activeSpace.scope) }} / {{ current.path }}</text>
-              <text>{{ $t('chat.memoryRevision', { revision: current.revision }) }} · {{ formatUpdated(current.updatedAt) }}</text>
+              <text>
+                <text v-if="hasUnsavedChanges" class="memory-unsaved">{{ $t('chat.memoryUnsaved') }} · </text>{{ $t('chat.memoryRevision', { revision: current.revision }) }} · {{ formatUpdated(current.updatedAt) }}
+              </text>
             </view>
+            <view v-if="draftTooLarge" class="memory-conflict">{{ $t('chat.memoryTooLarge') }}</view>
             <view v-if="!canWrite" class="memory-readonly">
               {{ activeSpace.reason || $t('chat.memoryReadOnly') }}
             </view>
@@ -67,7 +70,8 @@
                 <text class="memory-link" @tap="saveCurrent">{{ $t('chat.memorySaveMine') }}</text>
               </view>
             </view>
-            <textarea v-model="draft" class="memory-textarea" :disabled="!canWrite"></textarea>
+            <!-- maxlength=-1：uni-h5 的 textarea 缺省只许 140 字；上限按契约 128 KiB 在保存时校验 -->
+            <textarea ref="editor" v-model="draft" class="memory-textarea" :maxlength="-1" :disabled="!canWrite"></textarea>
             <view v-if="relativeLinks.length" class="memory-related">
               <text class="memory-related-label">{{ $t('chat.memoryLinkedFiles') }}</text>
               <text v-for="link in relativeLinks" :key="link.path" class="memory-link" @tap="openFile(link.path)">{{ link.label }}</text>
@@ -96,6 +100,8 @@ import {
 } from '@/services/api.js'
 import { markdownFileLinks } from '@/composables/memoryBrowserState.mjs'
 
+const MAX_MEMORY_BYTES = 128 * 1024
+
 export default {
   name: 'MemoryBrowser',
   emits: ['close'],
@@ -115,6 +121,13 @@ export default {
     canWrite() {
       return !!(this.activeSpace && this.activeSpace.writable && this.current
         && this.currentSpaceId === this.activeSpace.id && this.current.writable !== false)
+    },
+    hasUnsavedChanges() {
+      return !!this.current && this.draft !== this.serverDraft
+    },
+    // 与后端 MemoryDocumentService 同一口径：UTF-8 字节数不超过 128 KiB
+    draftTooLarge() {
+      return new TextEncoder().encode(this.draft || '').length > MAX_MEMORY_BYTES
     },
     relativeLinks() {
       return this.current
@@ -221,8 +234,22 @@ export default {
         }
       }
     },
-    async createTopic() {
+    // uni 的 v-model 有 100ms 节流：打完字立刻点保存/创建时 data 里还是旧值，末尾几个字会丢。
+    // 取值优先级：confirm 事件自带的值（同 utils/identityProfile.js 的 submittedInputValue）
+    // → 控件当下的 DOM 值 → v-model 的值。
+    liveFieldValue(refName, fallback, event) {
+      const submitted = event && event.detail ? event.detail.value : undefined
+      if (typeof submitted === 'string') return submitted
+      const ref = this.$refs && this.$refs[refName]
+      const root = ref && (ref.$el || ref)
+      const field = !root ? null
+        : typeof root.matches === 'function' && root.matches('textarea, input') ? root
+          : typeof root.querySelector === 'function' ? root.querySelector('textarea, input') : null
+      return field && typeof field.value === 'string' ? field.value : fallback
+    },
+    async createTopic(event) {
       if (!this.activeSpace || !this.activeSpace.writable) return
+      this.newTopic = this.liveFieldValue('topicInput', this.newTopic, event)
       let path = this.newTopic.trim().replace(/\\/g, '/')
       if (!path) return
       if (!path.toLowerCase().endsWith('.md')) path += '.md'
@@ -255,6 +282,11 @@ export default {
       if (!this.canWrite || this.saving) return
       const target = this.currentTarget()
       if (!target) return
+      this.draft = this.liveFieldValue('editor', this.draft)
+      if (this.draftTooLarge) {
+        uni.showToast({ title: this.$t('chat.memoryTooLarge'), icon: 'none' })
+        return
+      }
       const content = this.draft
       this.saving = true
       try {
@@ -368,6 +400,7 @@ export default {
 .memory-create-input { min-width: 0; flex: 1; height: 26px; padding: 0 6px; border: 1px solid var(--awd-border); border-radius: 5px; background: var(--awd-surface); font-size: 11px; }
 .memory-editor { min-width: 0; flex: 1; display: flex; flex-direction: column; padding: 14px; }
 .memory-meta { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 8px; color: var(--awd-text-3); font-size: 11px; }
+.memory-unsaved { color: var(--awd-accent-text); }
 .memory-readonly,.memory-conflict { margin-bottom: 8px; padding: 7px 9px; border-radius: 6px; background: var(--awd-warning-soft, #fff6df); color: var(--awd-text-2); font-size: 11px; }
 .memory-conflict { display: flex; justify-content: space-between; gap: 10px; }
 .memory-conflict-actions { display: flex; gap: 10px; }

--- a/frontend/src/composables/useAgentStream.js
+++ b/frontend/src/composables/useAgentStream.js
@@ -1303,9 +1303,10 @@ export function useAgentStream() {
 
                 // 3. Process the full snapshot
                 // Treat it like a huge chunk of text
+                // 与 text_delta 走同一个解析入口（此前调的 parseTags 从未定义，
+                // 切回运行中的会话就抛 ReferenceError，快照整段丢失）
                 if (d.content) {
-                    parserBuffer += d.content
-                    parseTags()
+                    processTextStream(d.content)
                 }
 
             } catch (e) {
@@ -1908,6 +1909,13 @@ export function useAgentStream() {
         const conversationId = currentConversationId.value
         if (!conversationId || !messageId) return null
         const request = captureInboxRequest(conversationId)
+        // 「立即发送」（submissionMode=steer）会让停住的队列恢复执行。停止时本地 SSE 已经断开，
+        // 不重连的话后端跑完一整轮，前端既没有停止键也没有新气泡，已执行的条目还挂在待处理里。
+        // 必须先连上再发 PATCH：恢复那一轮的 input_applied 可能在 PATCH 返回前就发出，
+        // 前端不带 Last-Event-ID，连晚了就补不回来。
+        if (patch && patch.submissionMode === 'steer' && !isConnected.value) {
+            try { await connectSSE(conversationId) } catch (e) { console.warn('[AgentStream] reconnect before send-now failed', e) }
+        }
         try {
             const updated = await updateAgentInboxItem(conversationId, messageId, patch)
             if (!canApplyInboxResponse(request)) return null

--- a/frontend/src/locales/en-US/chat.js
+++ b/frontend/src/locales/en-US/chat.js
@@ -137,6 +137,8 @@ export default {
   memoryLoadFailed: 'Could not load memory',
   memorySaveFailed: 'Could not save memory',
   memorySaved: 'Memory saved',
+  memoryUnsaved: 'Unsaved',
+  memoryTooLarge: 'This file is over the 128 KiB limit and cannot be saved. Shorten it and try again.',
   memoryInvalidPath: 'Use a safe relative Markdown path',
   memoryDeleteTitle: 'Delete memory topic',
   memoryDeleteConfirm: 'Delete {path}?',

--- a/frontend/src/locales/zh-CN/chat.js
+++ b/frontend/src/locales/zh-CN/chat.js
@@ -137,6 +137,8 @@ export default {
   memoryLoadFailed: '记忆加载失败',
   memorySaveFailed: '记忆保存失败',
   memorySaved: '记忆已保存',
+  memoryUnsaved: '未保存',
+  memoryTooLarge: '内容超过 128 KiB 上限，无法保存，请删减后再试',
   memoryInvalidPath: '文件名必须是安全的相对 Markdown 路径',
   memoryDeleteTitle: '删除记忆主题',
   memoryDeleteConfirm: '确定删除 {path}？',

--- a/frontend/tests/ai-alignment-e2e/run.mjs
+++ b/frontend/tests/ai-alignment-e2e/run.mjs
@@ -144,7 +144,8 @@ try {
   if (!memorySpace) throw new Error('no writable memory space')
   await api('/api/ai/memory/file', {
     method: 'PUT',
-    body: { spaceId: memorySpace.id, path: 'preferences.md', content: '# Preferences\n\nInitial fixture value.\n', expectedRevision: 0 },
+    // 刻意超过 140 字：uni-h5 的 textarea 缺省 maxlength=140，短夹具测不出「超过 140 字就打不进去」
+    body: { spaceId: memorySpace.id, path: 'preferences.md', content: `# Preferences\n\nInitial fixture value.\n${'Long preference line kept past the 140 character default. '.repeat(4)}\n`, expectedRevision: 0 },
   })
 
   let page
@@ -299,12 +300,10 @@ try {
   await page.screenshot({ path: path.join(OUT, 'queue-running-360px.png') })
 
   await clickRowAction('queued follow up', 'Edit').catch(() => clickRowAction('queued follow up', '编辑'))
-  await page.$eval('.agent-inbox-edit', (editor, value) => {
-    const input = editor.matches('input') ? editor : editor.querySelector('input')
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set
-    setter.call(input, value)
-    input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }))
-  }, 'queued follow up edited')
+  // 真按键输入：原生 setter 绕过了 uni 输入控件的 maxlength 与 100ms 节流，测不出这两类缺陷
+  await click('.agent-inbox-edit')
+  await page.keyboard.press('End')
+  await page.keyboard.type(' edited', { delay: 2 })
   await clickRowAction('queued follow up edited', 'Save').catch(() => clickRowAction('queued follow up edited', '保存'))
   await page.waitForFunction(() => [...document.querySelectorAll('.agent-inbox-message')]
     .some((node) => node.innerText.includes('queued follow up edited')), { timeout: 10000 })
@@ -321,6 +320,11 @@ try {
     const snapshot = await api(`/api/agent/inbox/${conversationId}`)
     return snapshot.status === 'FINISHED' && !snapshot.items.some((item) => item.state === 'pending')
   }, 30000)
+  // 停止后本地 SSE 已断开：「立即发送」恢复执行的这一轮，界面也必须跟上——
+  // 待处理面板清空、恢复执行的那条出现在对话里（只看后端会漏掉前端完全不更新的缺陷）
+  await page.waitForFunction(() => document.querySelectorAll('.agent-inbox-row').length === 0, { timeout: 15000 })
+  await page.waitForFunction(() => [...document.querySelectorAll('.user-bubble')]
+    .some((node) => node.innerText.includes('queued follow up edited')), { timeout: 15000 })
 
   await click('.memory-header-btn')
   await page.waitForSelector('.memory-dialog', { timeout: 10000 })
@@ -355,14 +359,22 @@ try {
     const editor = document.querySelector('.memory-textarea')
     return (editor?.value || editor?.querySelector('textarea')?.value || '').includes('Initial fixture value')
   }, { timeout: 10000 })
-  const beforeSave = await page.$eval('.memory-textarea', (editor, marker) => {
+  // 真按键输入到超过 140 字的文件末尾，打完立刻点保存（落在 uni v-model 的 100ms 节流窗口里）
+  const editorValue = () => page.$eval('.memory-textarea', (editor) =>
+    (editor.matches('textarea') ? editor : editor.querySelector('textarea')).value)
+  const initialValue = await editorValue()
+  await click('.memory-textarea')
+  await page.$eval('.memory-textarea', (editor) => {
     const textarea = editor.matches('textarea') ? editor : editor.querySelector('textarea')
-    const next = `${textarea.value}\nRetained exactly: ${marker}`
-    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set
-    setter.call(textarea, next)
-    textarea.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: next }))
-    return next
-  }, MARKER)
+    textarea.focus()
+    textarea.selectionStart = textarea.selectionEnd = textarea.value.length
+  })
+  const appended = `\nRetained exactly: ${MARKER}`
+  await page.keyboard.type(appended, { delay: 2 })
+  const beforeSave = await editorValue()
+  if (beforeSave !== initialValue + appended) {
+    throw new Error(`typing into the memory editor was blocked: ${initialValue.length} -> ${beforeSave.length} chars`)
+  }
   await click('.memory-button.primary')
   await page.waitForFunction((expected) => {
     const editor = document.querySelector('.memory-textarea')

--- a/frontend/tests/ai-alignment/memoryBrowserAsync.test.mjs
+++ b/frontend/tests/ai-alignment/memoryBrowserAsync.test.mjs
@@ -161,3 +161,85 @@ test('a delete refresh superseded by navigation does not issue another read in t
 
   assert.deepEqual(reads, [['team:1', 'team.md']])
 })
+
+// v0.38.3 走查 D5：uni 的 v-model 有 100ms 节流，打完字立刻点保存/创建，
+// data 里还是旧值，末尾几个字就丢了。保存与创建必须读控件当下的值。
+const liveRef = (value) => ({ $el: { querySelector: () => ({ value }) } })
+
+test('D5: save right after typing sends what the editor shows, not the throttled v-model value', async () => {
+  const saves = []
+  const vm = makeVm({
+    saveMemoryFile: async (payload) => { saves.push(payload); return { ...payload, revision: 2, writable: true } },
+    getMemoryFiles: async () => [{ path: 'remember.md' }],
+  })
+  vm.activeSpace = space('personal')
+  vm.current = file('personal', 1)
+  vm.currentSpaceId = 'personal'
+  vm.draft = 'personal content'
+  vm.$refs = { editor: liveRef('personal content plus the last words') }
+
+  await vm.saveCurrent()
+
+  assert.equal(saves.length, 1)
+  assert.equal(saves[0].content, 'personal content plus the last words')
+  assert.equal(vm.draft, 'personal content plus the last words')
+})
+
+test('D5: creating a topic right after typing uses the input value shown on screen', async () => {
+  const saves = []
+  const vm = makeVm({
+    saveMemoryFile: async (payload) => { saves.push(payload); return { path: payload.path, revision: 1, content: payload.content } },
+    getMemoryFiles: async () => [],
+    getMemoryFile: async (spaceId, path) => ({ path, revision: 1, content: '', writable: true }),
+  })
+  vm.activeSpace = space('personal')
+  vm.newTopic = 'client-pre'
+  vm.$refs = { topicInput: liveRef('client-preferences') }
+
+  await vm.createTopic({ detail: { x: 1, y: 2 } })
+
+  assert.equal(saves[0]?.path, 'client-preferences.md')
+})
+
+test('D5: the confirm event value wins over a stale v-model value', async () => {
+  const saves = []
+  const vm = makeVm({
+    saveMemoryFile: async (payload) => { saves.push(payload); return { path: payload.path, revision: 1, content: payload.content } },
+    getMemoryFiles: async () => [],
+    getMemoryFile: async (spaceId, path) => ({ path, revision: 1, content: '', writable: true }),
+  })
+  vm.activeSpace = space('personal')
+  vm.newTopic = 'deadl'
+
+  await vm.createTopic({ detail: { value: 'deadlines' } })
+
+  assert.equal(saves[0]?.path, 'deadlines.md')
+})
+
+test('D2: content over the 128 KiB contract is refused locally with a message instead of a failed request', async () => {
+  const saves = []
+  const toasts = []
+  const vm = makeVm({ saveMemoryFile: async (payload) => { saves.push(payload); return payload } },
+    { showToast(options) { toasts.push(options.title) }, showModal() {} })
+  vm.activeSpace = space('personal')
+  vm.current = file('personal', 1)
+  vm.currentSpaceId = 'personal'
+  vm.draft = '中'.repeat(50000) // 150000 UTF-8 bytes
+  vm.$refs = {}
+
+  assert.equal(vm.draftTooLarge, true)
+  await vm.saveCurrent()
+
+  assert.equal(saves.length, 0)
+  assert.deepEqual(toasts, ['chat.memoryTooLarge'])
+})
+
+test('unsaved edits are flagged until the save lands', async () => {
+  const vm = makeVm({})
+  vm.current = file('personal', 1)
+  vm.draft = 'personal content'
+  vm.serverDraft = 'personal content'
+  assert.equal(vm.hasUnsavedChanges, false)
+  vm.draft = 'personal content edited'
+  assert.equal(vm.hasUnsavedChanges, true)
+})

--- a/frontend/tests/ai-alignment/walkDefects0383.test.mjs
+++ b/frontend/tests/ai-alignment/walkDefects0383.test.mjs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// v0.38.3 真渲染走查查出的前端缺陷（PR#798 分层记忆 / 执行中插话 / 任务队列）。
+//
+// useAgentStream.js 带 @/ 别名与 uni 全局，node 直接 import 不进来，与 tests/project-home
+// 下既有用例同口径做源码级契约断言；真渲染复走在 v0.38.3 走查证据目录里。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), 'utf8')
+const stripComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+const STREAM = stripComments(read('../../src/composables/useAgentStream.js'))
+const INBOX = read('../../src/components/AgentInbox.vue')
+const MEMORY = read('../../src/components/MemoryBrowser.vue')
+
+// 从 `const name = ... => {` 起按花括号配平截取函数体
+function fnBody(code, name) {
+  const start = code.search(new RegExp(`const ${name} = (async )?\\([^)]*\\) => \\{`))
+  if (start < 0) return null
+  let depth = 0
+  for (let i = code.indexOf('{', start); i < code.length; i++) {
+    if (code[i] === '{') depth++
+    else if (code[i] === '}') { depth--; if (depth === 0) return code.slice(start, i + 1) }
+  }
+  return null
+}
+
+const KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'catch', 'return', 'typeof', 'function', 'new'])
+const GLOBALS = new Set(['JSON', 'Array', 'Object', 'String', 'Number', 'Date', 'Math', 'Boolean', 'Promise', 'setTimeout', 'clearTimeout'])
+const isDeclared = (code, name) =>
+  new RegExp(`(?:const|let|var|function)\\s+${name}\\b`).test(code)
+  || new RegExp(`\\{[^}]*\\b${name}\\b[^}]*\\}\\s*(?:=|from)`).test(code)
+
+test('D6: state_recovery 处理器里调用的每个本地函数都真实存在（parseTags 未定义曾抛 ReferenceError）', () => {
+  const body = fnBody(STREAM, 'handleStateRecovery')
+  assert.ok(body, '找不到 handleStateRecovery')
+  const calls = [...body.matchAll(/(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g)].map((m) => m[1])
+  const undefinedCalls = [...new Set(calls)]
+    .filter((name) => !KEYWORDS.has(name) && !GLOBALS.has(name) && !isDeclared(STREAM, name))
+  assert.deepEqual(undefinedCalls, [], `handleStateRecovery 调用了未声明的函数：${undefinedCalls.join(', ')}`)
+  assert.match(body, /processTextStream\(/, '快照要走与 text_delta 同一个解析入口 processTextStream')
+})
+
+test('D3: 「立即发送」恢复执行前，本地没有 SSE 就先重连，再发 PATCH', () => {
+  const body = fnBody(STREAM, 'updateInbox')
+  assert.ok(body, '找不到 updateInbox')
+  const connectAt = body.search(/await connectSSE\(conversationId\)/)
+  const patchAt = body.indexOf('updateAgentInboxItem(')
+  assert.ok(connectAt >= 0, '恢复执行的补丁（submissionMode=steer）必须确保本地 SSE 在线：停止时本地流已断开，'
+    + '不重连的话后端跑完一整轮前端都收不到任何事件')
+  assert.ok(connectAt < patchAt, '必须先连上再发 PATCH：后端恢复的那一轮的 input_applied 可能在 PATCH 返回前就发出，'
+    + '连晚了就丢了（前端不带 Last-Event-ID，不会补发）')
+  assert.match(body.slice(0, connectAt), /submissionMode\s*===\s*'steer'/, '只有让队列恢复执行的补丁才需要重连')
+  assert.match(body.slice(0, connectAt), /isConnected\.value/, '已经在线时不许重复建连')
+})
+
+test('D4: 队列面板声明 data-awd-keep-clear，反馈浮钮要避开它', () => {
+  const root = INBOX.match(/<template>(?:\s|<!--[\s\S]*?-->)*(<view\b[^>]*>)/)
+  assert.ok(root, '找不到 AgentInbox 根节点')
+  assert.match(root[1], /class="agent-inbox"/)
+  assert.match(root[1], /data-awd-keep-clear/, '队列在输入卡外面，输入卡的声明管不到它')
+})
+
+test('D2: #798 新增的每个 textarea/input 都显式声明 maxlength（uni-h5 缺省 140 字）', () => {
+  for (const [name, src] of [['AgentInbox.vue', INBOX], ['MemoryBrowser.vue', MEMORY]]) {
+    const tags = src.match(/<(?:textarea|input)\b[^>]*>/g) || []
+    assert.ok(tags.length > 0, `${name} 里应有输入控件`)
+    for (const tag of tags) {
+      assert.match(tag, /:?maxlength=/, `${name} 的 ${tag} 没声明 maxlength，uni-h5 会按 140 截断输入`)
+    }
+  }
+})
+
+// 真按键 e2e 抓到的同族缺陷：队列行内编辑打完字立刻点保存，v-model 还是旧值，改动整个丢掉
+function inboxVm(liveValue) {
+  const script = INBOX.match(/<script>([\s\S]*?)<\/script>/)[1].replace(/export\s+default/, 'return')
+  const options = new Function(script)()
+  const emitted = []
+  const vm = Object.assign({ $emit: (name, payload) => emitted.push([name, payload]) }, options.data())
+  for (const [name, method] of Object.entries(options.methods)) vm[name] = method.bind(vm)
+  vm.$el = { querySelector: () => (liveValue == null ? null : { value: liveValue }) }
+  return { vm, emitted }
+}
+
+test('D5: queue row Save right after typing emits what the input shows, not the throttled v-model value', () => {
+  const { vm, emitted } = inboxVm('queued follow up edited')
+  const item = { id: 'm1', message: 'queued follow up' }
+  vm.beginEdit(item)
+  vm.saveEdit(item)
+  assert.deepEqual(emitted, [['edit', { item, message: 'queued follow up edited' }]])
+})
+
+test('D5: queue row confirm event value wins over a stale v-model value', () => {
+  const { vm, emitted } = inboxVm(null)
+  const item = { id: 'm1', message: 'queued follow up' }
+  vm.beginEdit(item)
+  vm.saveEdit(item, { detail: { value: 'queued follow up via enter' } })
+  assert.deepEqual(emitted, [['edit', { item, message: 'queued follow up via enter' }]])
+})


### PR DESCRIPTION
## 背景
v0.38.3 发版前对 PR#798 做真渲染走查（真后端 + 真模型 deepseek-v4-flash + 本机假官网），查出 6 个缺陷，其中 2 个阻塞发版。

## 修复
| # | 问题 | 修法 |
|---|---|---|
| D1 | SSE connect 在 OSIV 下占 JDBC 连接，断开后永不归还，切会话十来次打满连接池、全接口 30 秒超时（v0.38.2 同样存在） | 自注册 `OpenEntityManagerInViewInterceptor` 排除 `/api/agent/connect/**`（Boot 自动配置退让，其余路径不变，不全局关闭）；`emitTo` 失败补 `complete()` |
| D2 | 记忆编辑器满 140 字后无法输入（uni-h5 缺省 maxlength） | 编辑器、新主题、队列行编辑 `:maxlength="-1"`；保存按 128 KiB 校验 |
| D3 | 停止后「立即发送」后端跑完、界面不更新 | 前端 steer 前重连 SSE；后端队列非空时不关流，接续轮沿用同一连接 |
| D4 | 反馈浮钮压住队列按钮 | `AgentInbox` 根节点 `data-awd-keep-clear` |
| D5 | 100ms 内保存/创建丢末尾字符 | 读事件/DOM 最新值，加未保存提示 |
| D6 | `state_recovery` 调用未定义的 `parseTags` | 改走 `processTextStream` |

## 验证
- 每条先写测试确认修前红（如 `SseConnectPoolReleaseTest`：断开后活跃 8；`finishingWithQueuedFollowUpKeepsTheStreamOpenForTheContinuedRun`：流在接续前被关），修后绿。
- D1 同实验三版对比：v0.38.2 断开后仍占 6、master 修前 3、修后 0。
- 后端全量 3639 / 0 失败 / 14 跳过；主会话复跑相关 79/79。前端 ai-alignment 等 80/80；check:emits、check:nav:full、check:locales 通过。
- ai-alignment-e2e 改真按键后：修后通过；同份 e2e 在未修复 master 前端上红（run.mjs:308）。
- 真渲染复走 D1–D5 全部通过（证据 /private/tmp/claude-501/rel-0383-evidence/fix/）。
- 审查：`endRunAndDrain` 唯一调用点是正常结束路径（原先紧前 closeSse），错误/取消/提问路径各自关流不受影响。

补丁边界内（backend/src、frontend、领域文档）。随 v0.38.3 发（dev-board#579）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)