### PR TITLE
fix(workbench): 工作台里「去团队设置 / 去账户」开设置标签，不再跳出独立设置页（dev-board#582）

### DIFF
--- a/.claude/agents/sidebar-shell.md
+++ b/.claude/agents/sidebar-shell.md
@@ -31,8 +31,14 @@ flushDirtyEditors），单测见 `frontend/tests/project-home/flush-dirty-editor
 `project-overview.vue` 用 `provide()` 把 `leaveWorkbench` 注入下去，组件 `inject: { leaveWorkbench: { default: null } }`，
 有就走它、没有（宿主不是工作台，比如项目列表页里的加人弹窗）才直调。`check:nav` 扫 project-overview
 直接 import 的全部组件：出现 `uni.reLaunch/navigateTo/redirectTo` 的方法要么同方法里走了
-`this.leaveWorkbench(`，要么进脚本里的 `WORKBENCH_NAV_ALLOWLIST` 并写理由。名单里现有四处早于这条护栏
-（插件详情/侧栏跳账户页、技能下拉跳插件广场、切换本机身份），各有产品含义，待单独评估。
+`this.leaveWorkbench(`，要么进脚本里的 `WORKBENCH_NAV_ALLOWLIST` 并写理由。名单里现有两处早于这条护栏
+（技能下拉跳插件广场、切换本机身份），各有产品含义，待单独评估。
+
+**目的地是设置页的根本不该离开工作台**（dev-board#582：加人弹窗「去团队设置」跳出独立设置页，
+用户点名「设置应以标签页存在」）。`provide()` 同时注入 `openSettingsTab`，组件
+`inject: { openSettingsTab: { default: null } }`，有就 `this.openSettingsTab({ nav })` 开设置标签，
+没有（项目列表页等工作台之外的宿主）才跳 `/pages/admin/admin?nav=xxx`。现有四处：加人弹窗与
+协作抽屉的 `goTeamSettings`、插件侧栏与插件详情的 `goToAccountSettings`，`check:nav` 逐个钉住。
 
 ## project-overview.vue 内部地图（4939 行，主战场）
 

--- a/frontend/scripts/check-navigation-contract.mjs
+++ b/frontend/scripts/check-navigation-contract.mjs
@@ -797,11 +797,11 @@ checkFull('app-e2e 走三级跳而不是把个人中心当必经之路', () => {
 // 规则：project-overview 把 leaveWorkbench provide 出去；它直接 import 的组件里，
 // 凡是出现 uni.reLaunch / navigateTo / redirectTo 的方法，要么同一个方法里优先走注入的
 // this.leaveWorkbench(...)（直调只作为「宿主不是工作台」时的回落），要么进下面的名单并写明理由。
+// 目的地是设置页的，同一个方法里优先走注入的 this.openSettingsTab(...)（工作台里设置是标签，
+// 根本不该离开，dev-board#582）也算合规。
 const WORKBENCH_NAV_ALLOWLIST = {
-  // 以下四处早于本条护栏，行为（navigateTo 保留工作台在栈里 / 切身份整站重走启动链）
+  // 以下两处早于本条护栏，行为（navigateTo 保留工作台在栈里 / 切身份整站重走启动链）
   // 各有产品含义，改动要单独评估，先记名在此不许再新增。
-  'components/MarketSidebarPanel.vue#goToAccountSettings': '预存在：插件详情跳账户页，待单独评估',
-  'components/MarketDetailPane.vue#goToAccountSettings': '预存在：插件详情跳账户页，待单独评估',
   'components/ChatInterface.vue#goToSkillManagement': '预存在：技能下拉跳插件广场，待单独评估',
   'components/admin/AdminPane.vue#onSwitchIdentity': '预存在：切换本机身份后整站回启动链重建',
 }
@@ -811,7 +811,26 @@ check('工作台 provide 出 leaveWorkbench，给里面的组件用', () => {
   const provide = extractMethodBody(src, 'provide()')
   if (!provide) return 'project-overview 没有 provide()'
   if (!provide.includes('leaveWorkbench')) return 'provide() 里没有 leaveWorkbench'
+  if (!provide.includes('openSettingsTab')) return 'provide() 里没有 openSettingsTab'
   return null
+})
+
+check('工作台里「去团队设置 / 去账户」开设置标签，不跳出独立设置页（dev-board#582）', () => {
+  const sites = [
+    ['src/components/InviteMemberDialog.vue', 'goTeamSettings()'],
+    ['src/components/collab/CollabDialog.vue', 'goTeamSettings()'],
+    ['src/components/MarketSidebarPanel.vue', 'goToAccountSettings()'],
+    ['src/components/MarketDetailPane.vue', 'goToAccountSettings()'],
+  ]
+  const bad = []
+  for (const [rel, marker] of sites) {
+    const src = readVue(rel)
+    const body = extractMethodBody(src, marker)
+    if (!body || !body.includes('this.openSettingsTab(') || !/openSettingsTab:\s*\{\s*default:\s*null/.test(src)) {
+      bad.push(rel + '#' + marker)
+    }
+  }
+  return bad.length ? '没走注入的 openSettingsTab: ' + bad.join(', ') : null
 })
 
 check('工作台里渲染的组件跳出工作台必须走 leaveWorkbench（先落盘）', () => {
@@ -836,7 +855,7 @@ check('工作台里渲染的组件跳出工作台必须走 leaveWorkbench（先�
       const key = rel + '#' + name
       if (WORKBENCH_NAV_ALLOWLIST[key]) continue
       const body = name ? extractMethodBody(src, name + '(') : null
-      if (body && body.includes('this.leaveWorkbench(')) continue
+      if (body && (body.includes('this.leaveWorkbench(') || body.includes('this.openSettingsTab('))) continue
       bad.push(key)
     }
   }

--- a/frontend/src/components/InviteMemberDialog.vue
+++ b/frontend/src/components/InviteMemberDialog.vue
@@ -276,8 +276,8 @@ export default {
     }
   },
   emits: ['update:visible', 'close', 'success'],
-  // 工作台 provide 的离开出口（先落盘再 reLaunch）；挂在项目列表页时为 null
-  inject: { leaveWorkbench: { default: null } },
+  // 工作台 provide 的离开出口（先落盘再 reLaunch）与设置标签入口；挂在项目列表页时为 null
+  inject: { leaveWorkbench: { default: null }, openSettingsTab: { default: null } },
   data() {
     return {
       activeTab: 'MEMBER', // 'MEMBER' | 'CLIENT'
@@ -525,11 +525,12 @@ export default {
      * 深链形制同仓里既有的 `/pages/admin/admin?nav=account`（MarketPane 那几处）。
      *
      * 这个弹窗挂在两处：项目列表页（工作台之外，照「个人中心」按钮的既有形制用
-     * navigateTo，设置页看完能退回列表），以及工作台成员堆栈的「+」——那里要走工作台
-     * provide 的 leaveWorkbench（先落盘再 reLaunch），navigateTo 会把工作台留在栈里。
+     * navigateTo，设置页看完能退回列表），以及工作台成员堆栈的「+」——工作台里设置是
+     * 一个标签，直接开标签、不离开工作台（dev-board#582）；leaveWorkbench 只剩兜底。
      */
     goTeamSettings() {
       this.close()
+      if (this.openSettingsTab) return this.openSettingsTab({ nav: 'team' })
       const url = '/pages/admin/admin?nav=team'
       if (this.leaveWorkbench) this.leaveWorkbench(url)
       else uni.navigateTo({ url })

--- a/frontend/src/components/MarketDetailPane.vue
+++ b/frontend/src/components/MarketDetailPane.vue
@@ -327,6 +327,8 @@ export default {
     },
   },
   emits: ['open-url'],
+  // 工作台 provide 的设置标签入口；宿主不是工作台时为 null
+  inject: { openSettingsTab: { default: null } },
   data() {
     return {
       loading: true,
@@ -780,6 +782,8 @@ export default {
       openExternalUrl(purchaseUrl(this.spec.kind, this.spec.id))
     },
     goToAccountSettings() {
+      // 工作台里设置是标签，不跳页（dev-board#582）
+      if (this.openSettingsTab) return this.openSettingsTab({ nav: 'account' })
       uni.navigateTo({ url: '/pages/admin/admin?nav=account' })
     },
     /**

--- a/frontend/src/components/MarketSidebarPanel.vue
+++ b/frontend/src/components/MarketSidebarPanel.vue
@@ -219,6 +219,8 @@ function fmtDownloads(n) {
 export default {
   name: 'MarketSidebarPanel',
   emits: ['open-detail'],
+  // 工作台 provide 的设置标签入口；宿主不是工作台时为 null
+  inject: { openSettingsTab: { default: null } },
   data() {
     return {
       searchText: '',
@@ -421,6 +423,8 @@ export default {
       uni.showToast({ title: this.$t('market.openedPurchasePage'), icon: 'none' })
     },
     goToAccountSettings() {
+      // 工作台里设置是标签，不跳页（dev-board#582）
+      if (this.openSettingsTab) return this.openSettingsTab({ nav: 'account' })
       uni.navigateTo({ url: '/pages/admin/admin?nav=account' })
     },
     async reloadAll() {

--- a/frontend/src/components/collab/CollabDialog.vue
+++ b/frontend/src/components/collab/CollabDialog.vue
@@ -267,8 +267,8 @@ export default {
   // changed：云端状态可能变了，页面重新拉一次。reload-files：磁盘被改写，重载打开中的编辑器。
   // conflict：撞上了要逐份选择的情况，页面把人送到裁决现场。
   emits: ['update:visible', 'changed', 'reload-files', 'conflict'],
-  // 工作台 provide 的离开出口（先落盘再 reLaunch）；宿主不是工作台时为 null
-  inject: { leaveWorkbench: { default: null } },
+  // 工作台 provide 的离开出口（先落盘再 reLaunch）与设置标签入口；宿主不是工作台时为 null
+  inject: { leaveWorkbench: { default: null }, openSettingsTab: { default: null } },
   data() {
     return {
       activeTab: 'casefile',
@@ -528,12 +528,14 @@ export default {
      * 「去团队设置」：设置页的「团队」分区，深链 `?nav=team`——nav key 与 AdminPane 里
      * 「账户与用量」那条「前往团队」同一个，深链形制同仓里既有的 `?nav=account`。
      *
-     * 这个弹窗挂在工作台（pages/project-overview）里，按导航总规则「凡是工作台参与的
-     * 跳转一律 reLaunch」（sidebar-shell.md）：navigateTo 会把工作台连同它的全局订阅
-     * 一起留在页面栈里，回头再进工作台就是第二个实例。
+     * 这个弹窗挂在工作台（pages/project-overview）里，工作台里设置是一个标签：
+     * 直接开「设置」标签定位到团队分区，不离开工作台（dev-board#582）。
+     * 下面的跳页只是拿不到注入时的兜底，按导航总规则「凡是工作台参与的跳转一律
+     * reLaunch」（sidebar-shell.md）：navigateTo 会把工作台留在页面栈里。
      */
     goTeamSettings() {
       this.close()
+      if (this.openSettingsTab) return this.openSettingsTab({ nav: 'team' })
       const url = '/pages/admin/admin?nav=team'
       // 直接 reLaunch 会连同防抖期内还没落盘的文档改动一起销毁（sidebar-shell.md
       // 「离开工作台前必须落盘」），所以走工作台的统一出口

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -2151,8 +2151,12 @@ const WEB_KEEPALIVE_MAX = 5
 export default {
   // 工作台里渲染的组件（协作抽屉、加人弹窗……）要跳出工作台时，也得走同一个出口：
   // 先落盘再 reLaunch。组件拿不到页面实例，只能靠注入（check:nav 钉着）。
+  // 要去的是设置页时不用离开：工作台里设置是一个标签（dev-board#582），组件走 openSettingsTab。
   provide() {
-    return { leaveWorkbench: (url) => this.leaveWorkbench(url) }
+    return {
+      leaveWorkbench: (url) => this.leaveWorkbench(url),
+      openSettingsTab: (opts) => this.openSettingsTab(opts || {}),
+    }
   },
   components: {
     LibreOfficeEditor,

--- a/frontend/src/pages/project-overview/project-overview.vue
+++ b/frontend/src/pages/project-overview/project-overview.vue
@@ -5071,7 +5071,14 @@ export default {
         const list = pane === 'left' ? this.leftFiles : this.rightFiles
         const existing = list.find(f => f.id === tabId)
         if (existing) {
-          if (nav) existing.adminNav = nav
+          if (nav && existing.adminNav === nav) {
+            // 同值写回不触发 AdminPane 的 initialNav watcher：用户手动切到别的分区后再点
+            // 「去团队设置」会停在原地（dev-board#582 走查实锤）。先清空、下一拍再写回。
+            existing.adminNav = ''
+            this.$nextTick(() => { existing.adminNav = nav })
+          } else if (nav) {
+            existing.adminNav = nav
+          }
           if (service) existing.adminService = service
           this[pane === 'left' ? 'activeFileIdLeft' : 'activeFileIdRight'] = existing.id
           this.focusedPane = pane


### PR DESCRIPTION
## 问题
dev-board#582：在项目（工作台）里邀请人，点「去团队设置」跳出了独立设置页；工作台里设置本来是一个标签。

## 修法
- `project-overview.vue` 的 `provide()` 新增 `openSettingsTab`。
- 加人弹窗、协作抽屉的 `goTeamSettings`，插件侧栏、插件详情的 `goToAccountSettings`：注入到就开设置标签并定位分区（team / account），工作台之外的宿主（项目列表页）仍回落独立设置页。
- `openSettingsTab` 复用已开标签且 nav 同值时先清空、下一拍写回——否则用户手动切走后再点，AdminPane 的 initialNav watcher 不触发，停在原地（走查抓到）。
- `check:nav`：openSettingsTab 视为合规出口，名单移除已修好的两处 Market*，新增一条逐个钉住四处；`sidebar-shell.md` 同步。

## 验证
- `node scripts/check-navigation-contract.mjs` 通过；把 CollabDialog 的新分支删掉后新检查转红，恢复后转绿。
- `node --test tests/member-invite/*.test.mjs`：27/27。
- UI 真渲染走查（dev H5 + 真实本机后端数据，puppeteer）：工作台内加人弹窗真点「去团队设置」→ 留在工作台、单个设置标签停在「团队」；协作抽屉 / 插件侧栏 / 插件详情（实例调用）同样开标签；设置标签已开且手动切到「工作记录」后再触发，切回「团队」（修复前 FAIL，修复后 PASS）；项目列表页回落独立设置页不变。

## 未验证
- 协作抽屉按钮与插件「需账户」按钮在现有数据下不渲染，这两处用组件实例调用验证；分屏右窗格未测；未在打包 Electron 壳内实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)