### PR TITLE
feat(components): 可选组件支持后台下载（dev-board#581）

### DIFF
--- a/frontend/src/components/ChatInterface.vue
+++ b/frontend/src/components/ChatInterface.vue
@@ -683,13 +683,17 @@
     />
 
     <!-- 可选组件缺失（设计 §4.2）：确认前把体积、解锁什么、不装则什么不可用都说全，
-         确认后卡片就地跳进度，装完自动重发原消息。 -->
+         确认后卡片就地跳进度，装完自动重发原消息。下载中可「后台下载」收起卡片继续用对话
+         （dev-board#581），装完是否重发见 useComponentRequired.shouldAutoResend。 -->
     <view v-if="componentGateItem" class="chat-component-gate">
       <view class="cg-panel">
         <text class="cg-title">{{ $t('components.chatTitle') }}</text>
         <OptionalComponentCard :item="componentGateItem" :selectable="false" :busy="true" />
         <view v-if="componentGateResolved" class="cg-installing">
           <text class="cg-installing-text">{{ $t('components.chatInstalling') }}</text>
+          <view class="cg-actions">
+            <view class="cg-btn cg-background" @tap="backgroundComponentGate">{{ $t('components.backgroundDownload') }}</view>
+          </view>
         </view>
         <view v-else class="cg-actions">
           <view class="cg-btn primary" @tap="resolveComponentGate(true)">{{ $t('components.chatConfirm') }}</view>
@@ -708,17 +712,15 @@ import AgentInbox from './AgentInbox.vue'
 import MemoryBrowser from './MemoryBrowser.vue'
 import { useAgentStream } from '@/composables/useAgentStream.js'
 import { parseToolBlock } from '@/composables/agentTagProtocol.mjs'
-import { ref, reactive, watch, onMounted, nextTick, getCurrentInstance, computed } from 'vue'
+import { ref, watch, onMounted, onBeforeUnmount, nextTick, getCurrentInstance, computed } from 'vue'
 import { createFile, getProjectFiles, getApiBaseUrl, rollbackConversation, performPptGeneration, getSkills, fetchAiModels, getAiConfig, cancelBackgroundTask, listPluginJobs, cancelPluginJob } from '@/services/api.js'
 import { getAuthHeaders } from '@/utils/auth.js'
 import { getAppLanguage } from '@/utils/appLanguage.js'
 import { t } from '@/i18n'
 import { ICONS } from '@/config/icons.js'
 import OptionalComponentCard from '@/components/OptionalComponentCard.vue'
-import { host } from '@/services/host.js'
-import { optionalComponents, packInstall, packStatus, packInfo } from '@/services/api.js'
-import { createOptionalComponentsController } from '@/composables/useOptionalComponents.js'
-import { createComponentRequiredHandler } from '@/composables/useComponentRequired.js'
+import { componentDownloads } from '@/services/componentDownloads.js'
+import { createComponentRequiredHandler, shouldAutoResend } from '@/composables/useComponentRequired.js'
 import { pendingInboxItems } from '@/composables/agentInboxState.mjs'
 import {
   beginChatSubmission,
@@ -790,24 +792,52 @@ export default {
       deleteInbox,
     } = useAgentStream()
 
-    // 可选组件缺失闸（设计 §4.2）。控制器与首次登录面板、组件管理页同一份编排：
-    // 顺序 pack → 模型 → ensure(service)，顺序不能换。
-    const optionalController = createOptionalComponentsController({
-      state: reactive({}),
-      optionalComponents,
-      packInstall,
-      packStatus,
-      packInfo,
-      modelDownload: (id) => host.model.download(id),
-      onModelProgress: (cb) => host.model.onProgress(cb),
-      ensureService: (name) => host.services.ensure(name),
-    })
+    // 可选组件缺失闸（设计 §4.2）。下载走应用级单例（dev-board#581）：与首次登录面板、
+    // 组件管理页同一份编排、同一份进度，顺序 pack → 模型 → ensure(service) 不能换。
     const componentGateItem = ref(null)
     const componentGateResolved = ref(false)
     const componentGateResolve = ref(null)
+    // 前台认领：对话组件活着就由它交代结果（重发或提示可重试）；卸载时释放，交给全局提示
+    const componentClaims = new Map()
+    const backgroundedPacks = new Set()
+    let chatAlive = true
+    const userMessageCount = () =>
+      bubbles.value.filter((b) => b && String(b.role).toUpperCase() === 'USER').length
+    const releaseComponentClaim = (packId) => {
+      const release = componentClaims.get(packId)
+      if (release) release()
+      componentClaims.delete(packId)
+      backgroundedPacks.delete(packId)
+    }
+    /** 只收起属于这个 packId 的卡片：后台装完时卡片上可能已经换成了另一个组件 */
+    const closeComponentGate = (packId) => {
+      if (componentGateItem.value && componentGateItem.value.packId === packId) componentGateItem.value = null
+    }
     const componentRequiredHandler = createComponentRequiredHandler({
-      installOne: (item) => optionalController.installOne(item),
-      fillSizes: (item) => optionalController.fillSizes(item),
+      adopt: (item) => componentDownloads.adopt(item),
+      isInstalling: (packId) => componentDownloads.isInstalling(packId),
+      // 别的入口已经在下这个组件：卡片直接进「下载中」，不再问一遍
+      attach: (item) => {
+        componentGateItem.value = item
+        componentGateResolved.value = true
+      },
+      installOne: (item) => {
+        if (!componentClaims.has(item.packId)) componentClaims.set(item.packId, componentDownloads.claim(item.packId))
+        return componentDownloads.installOne(item)
+      },
+      fillSizes: (item) => componentDownloads.fillSizes(item),
+      mark: () => userMessageCount(),
+      shouldResend: (mark, item) => shouldAutoResend({
+        alive: chatAlive,
+        backgrounded: backgroundedPacks.has(item.packId),
+        streaming: isStreaming.value,
+        userCountAtGate: mark,
+        userCountNow: userMessageCount(),
+      }),
+      readyNotice: (item) => {
+        closeComponentGate(item.packId)
+        if (chatAlive) uni.showToast({ title: t('components.chatReadyRetry'), icon: 'none', duration: 3500 })
+      },
       // 弹窗确认：把 item 挂上去，等模板里的按钮 resolve
       confirm: (item) => new Promise((resolve) => {
         componentGateItem.value = item
@@ -821,8 +851,8 @@ export default {
         }
         return ''
       },
-      resend: async (text) => {
-        componentGateItem.value = null
+      resend: async (text, item) => {
+        closeComponentGate(item.packId)
         uni.showToast({ title: t('components.chatResending'), icon: 'none' })
         await sendMessage({
           prompt: text,
@@ -833,10 +863,23 @@ export default {
         })
         scrollToBottom()
       },
-      toast: (msg) => {
-        componentGateItem.value = null
-        uni.showToast({ title: t('components.stateFailed', { msg }), icon: 'none' })
+      toast: (msg, item) => {
+        closeComponentGate(item.packId)
+        // 已卸载时认领早已释放，失败由全局提示交代
+        if (chatAlive) uni.showToast({ title: t('components.stateFailed', { msg }), icon: 'none' })
       },
+    })
+    /** 「后台下载」：收起卡片继续用对话；装完时按 shouldAutoResend 决定重发还是只提示 */
+    const backgroundComponentGate = () => {
+      const item = componentGateItem.value
+      if (!item) return
+      backgroundedPacks.add(item.packId)
+      componentGateItem.value = null
+      uni.showToast({ title: t('components.backgroundStarted'), icon: 'none', duration: 3000 })
+    }
+    onBeforeUnmount(() => {
+      chatAlive = false
+      for (const packId of [...componentClaims.keys()]) releaseComponentClaim(packId)
     })
     /** 确认走下载（弹窗留着，卡片就地跳进度）；取消则直接收起 */
     const resolveComponentGate = (ok) => {
@@ -858,7 +901,9 @@ export default {
            // 可选组件缺失（设计 §4.2）：就地弹窗 → 装 → 自动重发原消息。
            // 刻意不往下 emit：它不是编辑器命令，执行器只会回 Unknown action。
            componentRequiredHandler.onAction(action).then((r) => {
-              if (!r.resent) componentGateItem.value = null
+              if (r.duplicate) return
+              closeComponentGate(action.packId)
+              releaseComponentClaim(action.packId)
            })
         } else {
            emit('client-action', action)
@@ -2703,6 +2748,7 @@ export default {
        componentGateItem,
        componentGateResolved,
        resolveComponentGate,
+       backgroundComponentGate,
        inputPrompt,
        richInput,
        showMemoryBrowser,

--- a/frontend/src/components/EasyVoicePane.vue
+++ b/frontend/src/components/EasyVoicePane.vue
@@ -158,9 +158,7 @@
 import { getTtsVoices, generateTtsAudio, promptFeatureNotConfigured } from '@/services/api.js'
 import { ICONS } from '@/config/icons.js'
 import { host } from '@/services/host.js'
-import { reactive } from 'vue'
-import { createOptionalComponentsController } from '@/composables/useOptionalComponents.js'
-import { optionalComponents, packInstall, packStatus, packInfo } from '@/services/api.js'
+import { componentDownloads } from '@/services/componentDownloads.js'
 
 // 本机语音引擎 = 运行时 pack + 模型两件事（设计 §3.1）。0.38.0 起运行时也是按需下载的，
 // 面板上仍然只是一个按钮，底层顺序执行两条通道（pack → 模型 → ensure，顺序不能换：
@@ -190,17 +188,8 @@ export default {
       runtimeInstalled: true,
       componentItem: null,
       installing: false,
-      controller: createOptionalComponentsController({
-        // state 在构造时就要是响应式的：控制器内部的写走闭包变量，事后包 reactive 无效
-        state: reactive({}),
-        optionalComponents,
-        packInstall,
-        packStatus,
-        packInfo,
-        modelDownload: (id) => host.model.download(id),
-        onModelProgress: (cb) => host.model.onProgress(cb),
-        ensureService: (name) => host.services.ensure(name),
-      }),
+      // 应用级下载单例（dev-board#581）：别的入口正在下的，这里接上同一份进度
+      controller: componentDownloads,
       // 语速以「百分之几倍」存（100 = 原速），下发时除以 100 变成 Kokoro 的 speed
       rate: 100,
       generating: false,
@@ -291,6 +280,8 @@ export default {
   },
   beforeUnmount() {
     this._unmounted = true
+    // 在途的组件下载不停，只是不再由本面板交代结果
+    if (this._releaseClaim) { this._releaseClaim(); this._releaseClaim = null }
     this.stopAudio()
     // 卸载时手上可能还攥着一个已经生成好、但还没播的 blob URL，必须一并释放，
     // 否则每次"生成完切走面板"都会泄漏一个 blob。
@@ -477,6 +468,8 @@ export default {
           await this.controller.fillSizes(item)
           this.componentItem = item
           this.runtimeInstalled = !!item.installed
+          // 别的入口（首次登录面板、组件管理）正在装这个组件：接上同一个任务
+          if (this.controller.isInstalling(TTS_PACK_ID) && !this.installing) this.followInstall()
         }
       } catch (e) {
         console.warn('[EasyVoicePane] 读取语音组件状态失败', e)
@@ -493,9 +486,16 @@ export default {
         uni.showToast({ title: this.$t('panels.evDownloadStartFailed'), icon: 'none' })
         return
       }
+      await this.followInstall()
+    },
+    /** 发起或接上应用级下载管理里的同一个任务（在途时 installOne 返回同一个 Promise）。 */
+    async followInstall() {
       this.installing = true
+      // 面板开着就由它交代结果；切走面板时释放（beforeUnmount），结果交给全局提示
+      this._releaseClaim = this.controller.claim(TTS_PACK_ID)
       try {
         const ok = await this.controller.installOne(this.componentItem)
+        if (this._unmounted) return
         this.runtimeInstalled = !!this.componentItem.installed
         if (!ok) {
           uni.showToast({ title: this.$t('components.stateFailed', { msg: this.componentItem.error || '' }), icon: 'none' })
@@ -504,8 +504,9 @@ export default {
         this.modelState = 'installed'
         await this.fetchVoices()
       } finally {
+        if (this._releaseClaim) { this._releaseClaim(); this._releaseClaim = null }
         this.installing = false
-        await this.loadModelState()
+        if (!this._unmounted) await this.loadModelState()
       }
     },
     async onCancelModel() {

--- a/frontend/src/components/MeetingRecordingPanel.vue
+++ b/frontend/src/components/MeetingRecordingPanel.vue
@@ -308,9 +308,7 @@ import {
   localTierReady, localAsrProbeResult, refreshLocalAsrReadiness
 } from '@/config/platformServices.js'
 import { host } from '@/services/host.js'
-import { reactive } from 'vue'
-import { createOptionalComponentsController } from '@/composables/useOptionalComponents.js'
-import { optionalComponents, packInstall, packStatus, packInfo } from '@/services/api.js'
+import { componentDownloads } from '@/services/componentDownloads.js'
 import AwdSwitch from '@/components/AwdSwitch.vue'
 import AwdSelect from '@/components/AwdSelect.vue'
 
@@ -410,19 +408,10 @@ export default {
       // 平台档用户不该每次开面板都看见一块「模型没下载」
       localGateOpen: false,
       // asr-runtime 这一条组件（运行时 + 1.5GB 模型），与首次登录面板同一份编排。
-      // state 在构造时就要是响应式的：控制器内部的写走闭包变量，事后包 reactive 无效。
       asrItem: null,
       installingRuntime: false,
-      controller: createOptionalComponentsController({
-        state: reactive({}),
-        optionalComponents,
-        packInstall,
-        packStatus,
-        packInfo,
-        modelDownload: (id) => host.model.download(id),
-        onModelProgress: (cb) => host.model.onProgress(cb),
-        ensureService: (name) => host.services.ensure(name),
-      }),
+      // 应用级下载单例（dev-board#581）：别的入口正在下的，这里接上同一份进度
+      controller: componentDownloads,
       _modelProgressUnsub: null,
       _player: null,
       _audioUrl: null,
@@ -563,6 +552,9 @@ export default {
     }
   },
   beforeUnmount() {
+    this._unmounted = true
+    // 在途的组件下载不停，只是不再由本面板交代结果
+    if (this._releaseClaim) { this._releaseClaim(); this._releaseClaim = null }
     if (this._pollTimer) clearInterval(this._pollTimer)
     try { if (this._onStopped) uni.$off('awd:meeting-recording-stopped', this._onStopped) } catch (e) { /* ignore */ }
     if (this._onDeviceChange && navigator.mediaDevices && navigator.mediaDevices.removeEventListener) {
@@ -676,13 +668,20 @@ export default {
       if (this.installingRuntime) return
       if (!this.asrItem) await this.loadAsrComponent()
       if (!this.asrItem) return
+      await this.followAsrInstall()
+    },
+    /** 发起或接上应用级下载管理里的同一个任务（在途时 installOne 返回同一个 Promise）。 */
+    async followAsrInstall() {
       this.installingRuntime = true
+      // 面板开着就由它交代结果；切走面板时释放（beforeUnmount），结果交给全局提示
+      this._releaseClaim = this.controller.claim('asr-runtime')
       try {
         const ok = await this.controller.installOne(this.asrItem)
-        if (!ok) {
+        if (!ok && !this._unmounted) {
           uni.showToast({ title: this.$t('components.stateFailed', { msg: this.asrItem.error || '' }), icon: 'none' })
         }
       } finally {
+        if (this._releaseClaim) { this._releaseClaim(); this._releaseClaim = null }
         this.installingRuntime = false
         await refreshLocalAsrReadiness()
         await this.loadModelState()
@@ -695,6 +694,8 @@ export default {
         if (item) {
           await this.controller.fillSizes(item)
           this.asrItem = item
+          // 别的入口（首次登录面板、组件管理）正在装这个组件：接上同一个任务
+          if (this.controller.isInstalling('asr-runtime') && !this.installingRuntime) this.followAsrInstall()
         }
       } catch (e) {
         console.warn('[MeetingRecordingPanel] 读取本机转写组件状态失败', e)

--- a/frontend/src/components/OptionalComponentsDialog.vue
+++ b/frontend/src/components/OptionalComponentsDialog.vue
@@ -9,6 +9,10 @@
 
   「提示过」的标记落 electron prefs（~/.aiworkdeck/prefs.json），不是 localStorage：
   那个随浏览器数据一起被清，也不区分重装。
+
+  下载走应用级单例（services/componentDownloads.js，dev-board#581）：下载中可「后台下载」
+  关面板，「稍后再说」/点遮罩在下载中也只是转后台、不中断；进度在 设置 → 组件管理 接着看，
+  完成或失败时全局提示。
 -->
 <template>
   <view class="ocd-mask" @tap.self="onLater">
@@ -39,7 +43,10 @@
       </view>
 
       <view class="ocd-actions">
-        <view class="ocd-btn primary" :class="{ disabled: !anySelected || controller.state.running }" @tap="onInstall">
+        <view v-if="controller.state.running" class="ocd-btn primary ocd-background" @tap="onBackground">
+          {{ $t('components.backgroundDownload') }}
+        </view>
+        <view v-else class="ocd-btn primary" :class="{ disabled: !anySelected }" @tap="onInstall">
           {{ $t('components.installSelected') }}
         </view>
         <view class="ocd-btn" @tap="onLater">{{ $t('components.later') }}</view>
@@ -50,11 +57,10 @@
 </template>
 
 <script>
-import { reactive } from 'vue'
 import OptionalComponentCard from '@/components/OptionalComponentCard.vue'
 import { host } from '@/services/host.js'
-import { optionalComponents, packInstall, packStatus, packInfo } from '@/services/api.js'
-import { createOptionalComponentsController, PROMPTED_PREF_KEY } from '@/composables/useOptionalComponents.js'
+import { componentDownloads } from '@/services/componentDownloads.js'
+import { PROMPTED_PREF_KEY } from '@/composables/useOptionalComponents.js'
 
 export default {
   name: 'OptionalComponentsDialog',
@@ -65,17 +71,8 @@ export default {
   emits: ['close'],
   data() {
     return {
-      controller: createOptionalComponentsController({
-        // 状态容器在这里就要是响应式的：控制器内部的写走闭包，事后包 reactive 无效
-        state: reactive({}),
-        optionalComponents,
-        packInstall,
-        packStatus,
-        packInfo,
-        modelDownload: (id) => host.model.download(id),
-        onModelProgress: (cb) => host.model.onProgress(cb),
-        ensureService: (name) => host.services.ensure(name),
-      }),
+      // 应用级单例：状态不跟这个面板走，面板关了下载照样继续
+      controller: componentDownloads,
     }
   },
   computed: {
@@ -99,6 +96,10 @@ export default {
       if (item.phase !== 'ready' && item.modelId && item.modelInstalled) item.selected = true
     }
   },
+  beforeUnmount() {
+    // 被 reLaunch 带走或关掉：结果改由全局提示交代
+    this.releaseClaims()
+  },
   methods: {
     onToggle(packId, checked) {
       const it = this.controller.state.items.find((i) => i.packId === packId)
@@ -106,14 +107,33 @@ export default {
     },
     async onInstall() {
       if (!this.anySelected || this.controller.state.running) return
-      await this.controller.installAll(this.controller.state.items.filter((i) => i.selected))
+      // 面板在前台看着：装完由面板自己交代（全成功关面板、有失败留着原地重试）
+      this._claims = this.controller.state.items.filter((i) => i.selected)
+        .map((i) => this.controller.claim(i.packId))
+      // 用户已经作答，先落标记：转后台之后面板就卸载了，等装完再写就写不上
       await this.markPrompted()
+      await this.controller.installAll(this.controller.state.items.filter((i) => i.selected))
+      if (this._backgrounded) return
+      this.releaseClaims()
       // 有失败的就把面板留着，用户能在卡片上原地重试；全成功才关
       if (this.controller.state.items.every((i) => i.phase !== 'failed')) this.$emit('close')
     },
+    /** 下载继续、面板关闭；进度在「设置 → 组件管理」，完成或失败时全局提示 */
+    onBackground() {
+      this._backgrounded = true
+      this.releaseClaims()
+      uni.showToast({ title: this.$t('components.backgroundStarted'), icon: 'none', duration: 3000 })
+      this.$emit('close')
+    },
     async onLater() {
+      // 下载中「稍后再说」/点遮罩不许中断下载：等同于转后台
+      if (this.controller.state.running) return this.onBackground()
       await this.markPrompted()
       this.$emit('close')
+    },
+    releaseClaims() {
+      for (const release of this._claims || []) release()
+      this._claims = []
     },
     /** 标记落 electron prefs：重装才重置，下个大版本会再问一次 */
     async markPrompted() {

--- a/frontend/src/components/admin/AdminPane.vue
+++ b/frontend/src/components/admin/AdminPane.vue
@@ -628,7 +628,7 @@
                 <OptionalComponentCard
                   :item="item"
                   :selectable="false"
-                  :busy="optional.state.running"
+                  :busy="optional.state.activeCount > 0"
                   @install="onInstallComponent"
                   @retry="onInstallComponent"
                 />
@@ -1075,7 +1075,6 @@
 </template>
 
 <script>
-import { reactive } from 'vue'
 import {
   getAdminConfig, saveAdminConfig,
   getAccountStatus, connectAccount, getAccountUsage,
@@ -1090,7 +1089,7 @@ import {
   getFeedbackList, getFeedbackDetail, getOptimizerStatus, runOptimizer, getApiBaseUrl,
   getSiteStatus, selectSite,
   getPlatformServices, getPlatformServiceRemote, savePlatformBudget,
-  optionalComponents, packInstall, packStatus, packInfo, packUninstall,
+  packUninstall,
 } from '@/services/api.js'
 import { getCurrentUser, getSessionId, setSessionUser } from '@/utils/auth.js'
 import { getInitial } from '@/utils/textInitial.js'
@@ -1114,7 +1113,7 @@ import PersonalSettingsPanel from '@/components/userprofile/PersonalSettingsPane
 import TeamPanel from '@/components/admin/TeamPanel.vue'
 import OptionalComponentCard from '@/components/OptionalComponentCard.vue'
 import MemoryBrowser from '@/components/MemoryBrowser.vue'
-import { createOptionalComponentsController } from '@/composables/useOptionalComponents.js'
+import { componentDownloads } from '@/services/componentDownloads.js'
 
 /**
  * 缓存里的登录用户是不是管理员。isAdmin 由 /api/auth/me 下发（桌面单机=全员管理员；
@@ -1235,18 +1234,9 @@ export default {
         lastRunAt: '',
         lastReportText: '',
       },
-      // 组件管理与首次登录面板共用同一份编排与同一张卡片。state 必须在构造时就是
-      // 响应式的：控制器内部的写走闭包变量，事后再包 reactive 拿到的是个不触发重渲染的壳。
-      optional: createOptionalComponentsController({
-        state: reactive({}),
-        optionalComponents,
-        packInstall,
-        packStatus,
-        packInfo,
-        modelDownload: (id) => host.model.download(id),
-        onModelProgress: (cb) => host.model.onProgress(cb),
-        ensureService: (name) => host.services.ensure(name),
-      }),
+      // 组件管理与首次登录面板共用同一张卡片，下载走应用级单例（dev-board#581）：
+      // 别的入口转入后台的下载，进这一页就能看到同一份实时进度。
+      optional: componentDownloads,
       // 软件更新状态（主进程 update-service 快照；事件推送增量刷新）
       update: {
         phase: 'idle',
@@ -1729,13 +1719,9 @@ export default {
      */
     async onInstallComponent(packId) {
       const item = this.optional.state.items.find((i) => i.packId === packId)
-      if (!item || this.optional.state.running) return
-      this.optional.state.running = true
-      try {
-        await this.optional.installOne(item)
-      } finally {
-        this.optional.state.running = false
-      }
+      // 在途数由应用级下载管理记（首次登录面板、AI 对话发起的也算）：一次只装一个
+      if (!item || this.optional.state.activeCount > 0) return
+      await this.optional.installOne(item)
     },
     /** 卸载 = 删模型 + 删 pack 目录（规范 §6：确认框注明可释放体积） */
     handleComponentRemove(item) {

--- a/frontend/src/composables/useComponentDownloads.js
+++ b/frontend/src/composables/useComponentDownloads.js
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 可选组件的应用级下载管理（dev-board#581「组件下载应该支持后台下载」）。
+//
+// 此前五个入口（首次登录面板 / AI 对话拦截卡 / 设置→组件管理 / 语音面板 / 录音面板）
+// 各自 new 一个 useOptionalComponents 控制器，进度状态跟着组件实例走：面板一关、
+// 页面一 reLaunch，进度就看不到了，从另一个入口再点还会重复发起。真正的下载本来就不在
+// 前端跑（pack 在 Java 后端、模型在 Electron 主进程），所以只要把「状态」提到模块级，
+// 关界面就不影响任何事。
+//
+// 本文件是纯工厂（依赖全部注入，node --test 直接跑）；应用里唯一的实例在
+// services/componentDownloads.js。编排本身仍是 useOptionalComponents 那一份
+// （pack → 模型 → ensure，顺序不能换），这里只加四件事：
+//   1. 每个 packId 一个规范 item：各入口拿到的是同一个对象，进度天然共享；
+//   2. 在途去重：同一 packId 在途时再点只返回同一个 Promise，不重复发起；
+//   3. load() 合并而不是覆盖：半路重新拉清单不会把在途进度打回 idle、不抹掉失败原因；
+//   4. claim(packId)：有入口在前台盯着时由它自己交代结果；没人盯着（后台下载、
+//      入口已卸载）时，完成/失败走 deps.notify 给全局提示。
+
+import { createOptionalComponentsController, overallPercentOf } from './useOptionalComponents.js'
+
+const SIZE_FIELDS = ['downloadBytes', 'unpackedBytes', 'modelBytes']
+
+export function createComponentDownloadManager(deps) {
+  // 与控制器同一条规矩：状态容器必须在构造时就是调用方给的那个响应式代理
+  const state = Object.assign(deps.state || {}, {
+    items: [],
+    loading: false,
+    error: '',
+    // 批量（首次登录面板「立即下载所选」）的进度，与单个任务的在途状态分开记
+    running: false,
+    doneCount: 0,
+    totalCount: 0,
+    batchIds: [],
+    // 在途任务数：组件管理页据此锁住其它卡片的下载按钮（下载是带宽密集，不并发）
+    activeCount: 0,
+  })
+  // 私有控制器只借它的编排；它自己的 state 不对外，清单以本管理器的 state.items 为准
+  const ctl = createOptionalComponentsController({ ...deps, state: {} })
+  const inflight = new Map()
+  const claims = new Map()
+
+  // 一律经 state 取：调用方注入 reactive 时，拿到的才是会触发重渲染的代理
+  const find = (packId) => state.items.find((i) => i.packId === packId)
+
+  function fillMissingSizes(cur, from) {
+    for (const k of SIZE_FIELDS) {
+      if (!(cur[k] > 0) && from[k] > 0) cur[k] = from[k]
+    }
+  }
+
+  /** 把任意入口手里的 item（如 AI 对话从 payload 拼的）换成规范 item。 */
+  function adopt(item) {
+    if (!item || !item.packId) return item
+    const cur = find(item.packId)
+    if (cur) {
+      fillMissingSizes(cur, item)
+      return cur
+    }
+    state.items.push(item)
+    return find(item.packId)
+  }
+
+  async function load() {
+    state.loading = true
+    state.error = ''
+    try {
+      const fresh = await ctl.load()
+      state.error = ctl.state.error
+      const out = []
+      for (const f of fresh) {
+        const cur = find(f.packId)
+        if (!cur) {
+          out.push(f)
+          continue
+        }
+        if (inflight.has(f.packId) || (cur.phase === 'failed' && f.phase !== 'ready')) {
+          // 在途：后端此刻仍说「未安装」，照抄会把进度打回 0；
+          // 失败：照抄会把失败原因抹成「未安装」，用户找不到重试入口
+          fillMissingSizes(cur, f)
+        } else {
+          Object.assign(cur, f, { selected: cur.selected })
+        }
+        out.push(cur)
+      }
+      // 清单里没有、但正在装的（接口临时失败时）不能从界面上消失
+      for (const it of state.items) {
+        if (!out.includes(it) && inflight.has(it.packId)) out.push(it)
+      }
+      state.items = out
+    } finally {
+      state.loading = false
+    }
+    return state.items
+  }
+
+  function fillSizes(item) {
+    return ctl.fillSizes(adopt(item))
+  }
+
+  /** 装一个组件；同一 packId 在途时返回同一个 Promise。**不抛**（同 installOne）。 */
+  function installOne(item) {
+    const cur = adopt(item)
+    const id = cur.packId
+    if (inflight.has(id)) return inflight.get(id)
+    state.activeCount += 1
+    const p = ctl.installOne(cur).then((ok) => {
+      inflight.delete(id)
+      state.activeCount -= 1
+      if (!((claims.get(id) || 0) > 0) && deps.notify) {
+        try { deps.notify(cur, ok) } catch (e) { /* 提示失败不影响结果 */ }
+      }
+      return ok
+    })
+    inflight.set(id, p)
+    return p
+  }
+
+  /** 批量逐个顺序装。批次状态在模块级：面板关掉之后照样装完剩下的。 */
+  async function installAll(items) {
+    const list = (items || []).filter(Boolean).map(adopt)
+    state.running = true
+    state.totalCount = list.length
+    state.doneCount = 0
+    state.batchIds = list.map((i) => i.packId)
+    try {
+      for (const it of list) {
+        await installOne(it)
+        state.doneCount += 1 // 失败也算处理完，否则总进度会永远停在那里
+      }
+    } finally {
+      state.running = false
+    }
+    return list.every((i) => i.phase === 'ready')
+  }
+
+  /** 总进度只算本批（清单里早就装好的组件不该把百分比撑高）。 */
+  function overallPercent() {
+    return overallPercentOf(state.batchIds.map(find).filter(Boolean))
+  }
+
+  function isInstalling(packId) {
+    return inflight.has(packId)
+  }
+
+  /**
+   * 前台认领：返回释放函数（幂等）。认领期间任务结束不弹全局提示——由认领的入口
+   * 自己交代（面板关自己、AI 对话重发或提示可重试、语音面板刷新音色）。
+   * 入口点「后台下载」或被卸载时释放，结果就交给全局提示。
+   */
+  function claim(packId) {
+    claims.set(packId, (claims.get(packId) || 0) + 1)
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      claims.set(packId, (claims.get(packId) || 1) - 1)
+    }
+  }
+
+  return { state, load, fillSizes, adopt, installOne, installAll, overallPercent, isInstalling, claim }
+}

--- a/frontend/src/composables/useComponentRequired.js
+++ b/frontend/src/composables/useComponentRequired.js
@@ -9,11 +9,26 @@
 //
 // 装完**自动重发原消息**：让用户装完组件还得把刚才那句话再打一遍，
 // 等于把失败的代价原样转嫁给他。
+// 例外（dev-board#581）：用户点了「后台下载」收起卡片、继续用对话之后，装完时
+// 对话里已经有了新消息或正在生成——这时重发会插进用户正在进行的事情里，
+// 只提示「组件已就绪，可以重试」（判据见 shouldAutoResend）。
 //
 // 依赖同样全部注入（与 useOptionalComponents 同源），单测不需要真后端与 Electron。
 // 这里用相对路径 import 而不是 @/ 别名：node --test 不认那个别名。
 
 import { PACK_LOCALE_KEY } from './useOptionalComponents.js'
+
+/**
+ * 装完要不要自动重发原消息。
+ * - 对话组件已卸载（离开了工作台）：不重发，没有地方可发；
+ * - 卡片一直在前台：照旧重发；
+ * - 已转后台：拦截之后没有新的用户消息、且当前不在生成中，才重发。
+ */
+export function shouldAutoResend({ alive, backgrounded, streaming, userCountAtGate, userCountNow }) {
+  if (!alive) return false
+  if (!backgrounded) return true
+  return !streaming && userCountNow === userCountAtGate
+}
 
 export function createComponentRequiredHandler(deps) {
   const inFlight = new Set()
@@ -39,22 +54,37 @@ export function createComponentRequiredHandler(deps) {
 
   async function onAction(p) {
     if (!p || !p.packId) return { installed: false, resent: false }
-    // 工具可能在同一轮里连报两次（check_service 之后紧跟 generate）：只处理一次
-    if (inFlight.has(p.packId)) return { installed: false, resent: false }
+    // 工具可能在同一轮里连报两次（check_service 之后紧跟 generate）：只处理一次。
+    // duplicate 标给调用方：这一次什么都没做，不能据此收起第一次挂出来的卡片
+    if (inFlight.has(p.packId)) return { installed: false, resent: false, duplicate: true }
     inFlight.add(p.packId)
     try {
-      const item = itemFromPayload(p)
-      await deps.fillSizes(item)          // sizeMb 为 0（后端没缓存）时补一次
-      if (!(await deps.confirm(item))) return { installed: false, resent: false }
+      // 换成应用级下载管理里的规范 item：别的入口正在下载时，卡片上显示的是同一份进度
+      const raw = itemFromPayload(p)
+      const item = deps.adopt ? deps.adopt(raw) : raw
+      // 重发的是拦截这一刻的原消息；装完时对话里最新的一条可能已经是用户后来发的
+      const text = deps.lastUserMessage()
+      const mark = deps.mark ? deps.mark(item) : null
+
+      if (deps.isInstalling && deps.isInstalling(item.packId)) {
+        // 已经在别的入口下载中：不再问一遍，直接挂上进度
+        if (deps.attach) deps.attach(item)
+      } else {
+        await deps.fillSizes(item)          // sizeMb 为 0（后端没缓存）时补一次
+        if (!(await deps.confirm(item))) return { installed: false, resent: false }
+      }
 
       const ok = await deps.installOne(item)
       if (!ok) {
-        deps.toast(item.error || '')
+        deps.toast(item.error || '', item)
         return { installed: false, resent: false }
       }
-      const text = deps.lastUserMessage()
       if (!text) return { installed: true, resent: false }
-      await deps.resend(text)
+      if (deps.shouldResend && !deps.shouldResend(mark, item)) {
+        if (deps.readyNotice) deps.readyNotice(item)
+        return { installed: true, resent: false }
+      }
+      await deps.resend(text, item)
       return { installed: true, resent: true }
     } finally {
       inFlight.delete(p.packId)

--- a/frontend/src/composables/useOptionalComponents.js
+++ b/frontend/src/composables/useOptionalComponents.js
@@ -190,19 +190,24 @@ export function createOptionalComponentsController(deps) {
   function overallPercent() {
     const list = state.items.filter((i) => i.selected || i.phase !== 'idle')
     const scope = list.length ? list : state.items
-    if (!scope.length) return 0
-    let sum = 0
-    for (const i of scope) {
-      if (i.phase === 'ready') { sum += 100; continue }
-      if (i.phase === 'failed') { sum += 100; continue } // 失败也不再前进，按处理完计
-      if (i.phase === 'runtime') sum += WEIGHT.runtime * (i.percent / 100)
-      else if (i.phase === 'model') sum += WEIGHT.runtime + WEIGHT.model * (i.percent / 100)
-      else if (i.phase === 'starting') sum += WEIGHT.runtime + WEIGHT.model
-    }
-    return Math.round(sum / scope.length)
+    return overallPercentOf(scope)
   }
 
   return { state, load, fillSizes, installOne, installAll, overallPercent }
+}
+
+/** 一组组件的总进度（应用级下载管理按「本批」复用这一份算法）。 */
+export function overallPercentOf(scope) {
+  if (!scope.length) return 0
+  let sum = 0
+  for (const i of scope) {
+    if (i.phase === 'ready') { sum += 100; continue }
+    if (i.phase === 'failed') { sum += 100; continue } // 失败也不再前进，按处理完计
+    if (i.phase === 'runtime') sum += WEIGHT.runtime * (i.percent / 100)
+    else if (i.phase === 'model') sum += WEIGHT.runtime + WEIGHT.model * (i.percent / 100)
+    else if (i.phase === 'starting') sum += WEIGHT.runtime + WEIGHT.model
+  }
+  return Math.round(sum / scope.length)
 }
 
 export const PROMPTED_PREF_KEY = 'optionalComponentsPromptedVersion'

--- a/frontend/src/locales/en-US/components.js
+++ b/frontend/src/locales/en-US/components.js
@@ -28,6 +28,12 @@ export default {
   chatCancel: 'Not now',
   chatInstalling: 'Preparing the component…',
   chatResending: 'The component is ready. Continuing your request…',
+  chatReadyRetry: 'The component is ready. You can resend your request.',
+
+  backgroundDownload: 'Download in background',
+  backgroundStarted: 'Downloading in the background. Track progress in Settings → Components.',
+  backgroundDone: '{name} is ready to use.',
+  backgroundFailed: '{name} failed to download: {msg}',
 
   asrRuntimeMissingAction: 'Download on-device speech recognition',
 

--- a/frontend/src/locales/zh-CN/components.js
+++ b/frontend/src/locales/zh-CN/components.js
@@ -31,6 +31,13 @@ export default {
   chatCancel: '暂不下载',
   chatInstalling: '正在准备组件…',
   chatResending: '组件已就绪，正在继续刚才的请求…',
+  chatReadyRetry: '组件已就绪，可以重新发送刚才的请求。',
+
+  // 后台下载（dev-board#581）：关掉面板/收起卡片后下载继续，完成或失败时全局提示
+  backgroundDownload: '后台下载',
+  backgroundStarted: '已转入后台下载，可在「设置 → 组件管理」查看进度。',
+  backgroundDone: '{name}已下载完成，可以使用了。',
+  backgroundFailed: '{name}下载失败：{msg}',
 
   asrRuntimeMissingAction: '下载本机语音识别组件',
 

--- a/frontend/src/services/componentDownloads.js
+++ b/frontend/src/services/componentDownloads.js
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 可选组件下载管理的应用级单例（dev-board#581）。五个入口一律 import 这一个实例，
+// 不再各自 new 控制器——状态挂在模块上，组件卸载、页面 reLaunch 都不影响在途任务
+// （桌面端前端是 uni-app H5 单页，reLaunch 走前端路由，不重新加载模块）。
+// 工厂与判据在 composables/useComponentDownloads.js（纯函数，有单测），这里只做接线。
+
+import { reactive } from 'vue'
+import { host } from '@/services/host.js'
+import { optionalComponents, packInstall, packStatus, packInfo } from '@/services/api.js'
+import { t } from '@/i18n'
+import { createComponentDownloadManager } from '@/composables/useComponentDownloads.js'
+
+function componentName(item) {
+  return t('components.' + (item.localeKey || item.packId) + '.name')
+}
+
+export const componentDownloads = createComponentDownloadManager({
+  state: reactive({}),
+  optionalComponents,
+  packInstall,
+  packStatus,
+  packInfo,
+  modelDownload: (id) => host.model.download(id),
+  onModelProgress: (cb) => host.model.onProgress(cb),
+  ensureService: (name) => host.services.ensure(name),
+  // 没有入口在前台盯着时的全局提示。uni-toast 挂在 document.body 上，
+  // 用户停在哪个页面都看得到（层级已由 App.vue 统一抬到弹窗遮罩之上）。
+  notify: (item, ok) => {
+    const title = ok
+      ? t('components.backgroundDone', { name: componentName(item) })
+      : t('components.backgroundFailed', { name: componentName(item), msg: item.error || '' })
+    uni.showToast({ title, icon: 'none', duration: 4000 })
+  },
+})

--- a/frontend/tests/optional-components/admin-reuse.test.mjs
+++ b/frontend/tests/optional-components/admin-reuse.test.mjs
@@ -13,8 +13,8 @@ test('组件管理复用 OptionalComponentCard，而不是自己再写一套 com
   assert.match(src, /<OptionalComponentCard/)
 })
 
-test('组件管理走 useOptionalComponents 的编排（顺序 pack → 模型 → ensure）', () => {
-  assert.match(src, /createOptionalComponentsController/)
+test('组件管理走应用级下载单例（内部仍是 useOptionalComponents 的顺序 pack → 模型 → ensure）', () => {
+  assert.match(src, /componentDownloads/)
   assert.match(src, /installOne/)
 })
 

--- a/frontend/tests/optional-components/background-downloads.test.mjs
+++ b/frontend/tests/optional-components/background-downloads.test.mjs
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// 组件后台下载（dev-board#581）：五个入口共用一个应用级下载管理。
+// 钉住的是「状态不跟组件实例走」这件事的五个后果：同一 packId 不重复发起、
+// 入口卸载后任务照跑、进度在各入口之间是同一份、失败可重试、完成时没人盯着就给全局提示。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createComponentDownloadManager } from '../../src/composables/useComponentDownloads.js'
+import { createComponentRequiredHandler, shouldAutoResend } from '../../src/composables/useComponentRequired.js'
+
+const COMPONENTS = [
+  { packId: 'pptx-runtime', service: 'pptx-service', installed: false, downloadBytes: 1000,
+    unpackedBytes: 0, modelId: null, modelInstalled: false, modelBytes: 0, featureKeys: [] },
+  { packId: 'kokoro-runtime', service: 'kokoro-service', installed: false, downloadBytes: 2000,
+    unpackedBytes: 0, modelId: 'kokoro-models', modelInstalled: false, modelBytes: 3000, featureKeys: [] },
+]
+
+/**
+ * pack 段用「手动闸门」驱动：packStatus 在闸门状态改成 ready/failed 之前一直回 downloading，
+ * 测试可以在任务半路做事（卸载入口、从别的入口再点一次、重新 load）。
+ */
+function deps(over = {}) {
+  const calls = []
+  const notes = []
+  const listeners = new Set()
+  const gates = {}
+  const gate = (id) => {
+    if (!gates[id]) gates[id] = { state: 'downloading', bytes: 0, error: '' }
+    return gates[id]
+  }
+  return {
+    calls, notes, gates, gate,
+    state: {},
+    optionalComponents: async () => ({ components: COMPONENTS.map((c) => ({ ...c })) }),
+    packInstall: async (id) => { calls.push('install:' + id) },
+    packStatus: async (id) => {
+      const g = gate(id)
+      return { status: { state: g.state, bytesDownloaded: g.bytes, bytesTotal: 100, error: g.error } }
+    },
+    packInfo: async () => ({}),
+    modelDownload: async (id) => {
+      calls.push('model:' + id)
+      for (const cb of [...listeners]) cb({ id, phase: 'done' })
+    },
+    onModelProgress: (cb) => { listeners.add(cb); return () => listeners.delete(cb) },
+    ensureService: async (name) => { calls.push('ensure:' + name); return { ok: true } },
+    notify: (item, ok) => notes.push((ok ? 'ok:' : 'fail:') + item.packId),
+    // 轮询的 sleep 等一拍即可；闸门没改就一直 downloading
+    sleep: () => new Promise((r) => setImmediate(r)),
+    ...over,
+  }
+}
+
+const tick = () => new Promise((r) => setImmediate(r))
+async function until(fn, n = 200) {
+  for (let i = 0; i < n; i++) { if (fn()) return; await tick() }
+  throw new Error('等待超时')
+}
+
+test('去重：同一 packId 在途时第二个入口再点，不重新发起、拿到同一个结果', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  const a = m.installOne(m.state.items[0])
+  const b = m.installOne({ ...COMPONENTS[0] }) // 另一个入口手里是自己拼的 item（如 AI 对话的 payload）
+  assert.equal(m.isInstalling('pptx-runtime'), true)
+  d.gate('pptx-runtime').state = 'ready'
+  const [ra, rb] = await Promise.all([a, b])
+  assert.equal(ra, true)
+  assert.equal(rb, true)
+  assert.equal(d.calls.filter((c) => c === 'install:pptx-runtime').length, 1, 'pack 被重复发起了')
+  assert.equal(m.isInstalling('pptx-runtime'), false)
+})
+
+test('进度共享：不同入口拿到的是同一个对象，半路重新 load 不会把进度打回 idle', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  const fromDialog = m.state.items[0]
+  const run = m.installOne(fromDialog)
+  const g = d.gate('pptx-runtime')
+  g.bytes = 40
+  await until(() => fromDialog.percent === 40)
+  // 设置 → 组件管理 打开：重新拉清单（后端此刻仍说未安装）
+  const items = await m.load()
+  const fromAdmin = items.find((i) => i.packId === 'pptx-runtime')
+  assert.equal(fromAdmin, fromDialog, '两个入口看到的不是同一份状态')
+  assert.equal(fromAdmin.phase, 'runtime')
+  assert.equal(fromAdmin.percent, 40)
+  // AI 对话拿 payload 来认领，同样落到这一份
+  assert.equal(m.adopt({ ...COMPONENTS[0], downloadBytes: 0 }), fromDialog)
+  g.state = 'ready'
+  await run
+  assert.equal(fromAdmin.phase, 'ready')
+})
+
+test('入口卸载后任务照跑，完成时因为没人盯着而给全局提示', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  const release = m.claim('pptx-runtime') // 面板打开、在前台看着
+  const run = m.installOne(m.state.items[0])
+  release() // 点「后台下载」/ 面板被 reLaunch 卸载
+  release() // 重复释放是无害的
+  d.gate('pptx-runtime').state = 'ready'
+  assert.equal(await run, true)
+  assert.equal(m.state.items[0].phase, 'ready')
+  assert.deepEqual(d.notes, ['ok:pptx-runtime'])
+})
+
+test('有入口在前台盯着时完成回调不弹全局提示（由那个入口自己交代）', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  const release = m.claim('pptx-runtime')
+  const run = m.installOne(m.state.items[0])
+  d.gate('pptx-runtime').state = 'ready'
+  await run
+  release()
+  assert.deepEqual(d.notes, [])
+})
+
+test('失败给全局提示、卡片停在 failed（重新 load 也不抹掉），重试会真的重新发起', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  const item = m.state.items[0]
+  const g = d.gate('pptx-runtime')
+  g.state = 'failed'
+  g.error = '镜像不可达'
+  assert.equal(await m.installOne(item), false)
+  assert.equal(item.phase, 'failed')
+  assert.deepEqual(d.notes, ['fail:pptx-runtime'])
+  await m.load()
+  assert.equal(m.state.items[0].phase, 'failed', '失败原因被重新 load 抹掉了，用户找不到重试')
+  assert.match(m.state.items[0].error, /镜像不可达/)
+  g.state = 'ready'
+  assert.equal(await m.installOne(item), true)
+  assert.equal(d.calls.filter((c) => c === 'install:pptx-runtime').length, 2)
+  assert.equal(item.phase, 'ready')
+})
+
+test('批量：面板关掉之后批次照样逐个装完，总进度只算本批', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  for (const i of m.state.items) i.selected = true
+  d.gate('pptx-runtime').state = 'ready'
+  d.gate('kokoro-runtime').state = 'ready'
+  const all = m.installAll(m.state.items.filter((i) => i.selected))
+  assert.equal(m.state.running, true)
+  assert.equal(m.state.totalCount, 2)
+  assert.equal(await all, true)
+  assert.equal(m.state.running, false)
+  assert.equal(m.state.doneCount, 2)
+  assert.equal(m.overallPercent(), 100)
+  // 先 pack 后模型再 ensure 的顺序不因换了编排入口而变
+  const k = d.calls.filter((c) => /kokoro/.test(c))
+  assert.deepEqual(k, ['install:kokoro-runtime', 'model:kokoro-models', 'ensure:kokoro-service'])
+  assert.deepEqual(d.notes.sort(), ['ok:kokoro-runtime', 'ok:pptx-runtime'])
+})
+
+test('activeCount 反映在途任务数（组件管理的卡片据此锁按钮）', async () => {
+  const d = deps()
+  const m = createComponentDownloadManager(d)
+  await m.load()
+  const run = m.installOne(m.state.items[0])
+  assert.equal(m.state.activeCount, 1)
+  d.gate('pptx-runtime').state = 'ready'
+  await run
+  assert.equal(m.state.activeCount, 0)
+})
+
+// ---------- AI 对话：后台下载与重发判据 ----------
+
+test('重发判据：前台装完照旧重发；后台装完只有「没新消息且没在生成」才重发', () => {
+  assert.equal(shouldAutoResend({ alive: true, backgrounded: false, streaming: true, userCountAtGate: 1, userCountNow: 1 }), true)
+  assert.equal(shouldAutoResend({ alive: true, backgrounded: true, streaming: false, userCountAtGate: 1, userCountNow: 1 }), true)
+  assert.equal(shouldAutoResend({ alive: true, backgrounded: true, streaming: true, userCountAtGate: 1, userCountNow: 1 }), false)
+  assert.equal(shouldAutoResend({ alive: true, backgrounded: true, streaming: false, userCountAtGate: 1, userCountNow: 2 }), false)
+  assert.equal(shouldAutoResend({ alive: false, backgrounded: false, streaming: false, userCountAtGate: 1, userCountNow: 1 }), false)
+})
+
+test('后台装完但用户已经发了新消息：不重发，只提示「已就绪可重试」', async () => {
+  const calls = []
+  const h = createComponentRequiredHandler({
+    installOne: async (item) => { item.phase = 'ready'; return true },
+    fillSizes: async () => {},
+    confirm: async () => true,
+    lastUserMessage: () => '做一份 PPT',
+    resend: async (t) => calls.push('resend:' + t),
+    toast: () => {},
+    mark: () => 1,
+    shouldResend: (mark) => mark === 2,
+    readyNotice: () => calls.push('ready'),
+  })
+  const r = await h.onAction({ packId: 'pptx-runtime', service: 'pptx-service', sizeMb: 1 })
+  assert.deepEqual(r, { installed: true, resent: false })
+  assert.deepEqual(calls, ['ready'])
+})
+
+test('重发的是拦截那一刻的原消息，而不是装完时对话里最新的一条', async () => {
+  const calls = []
+  let last = '做一份 PPT'
+  const h = createComponentRequiredHandler({
+    installOne: async (item) => { last = '另一句话'; item.phase = 'ready'; return true },
+    fillSizes: async () => {},
+    confirm: async () => true,
+    lastUserMessage: () => last,
+    resend: async (t) => calls.push('resend:' + t),
+    toast: () => {},
+  })
+  await h.onAction({ packId: 'pptx-runtime', service: 'pptx-service', sizeMb: 1 })
+  assert.deepEqual(calls, ['resend:做一份 PPT'])
+})
+
+test('组件已经在别的入口下载中：不再问一遍，直接挂上进度等它装完', async () => {
+  const calls = []
+  const h = createComponentRequiredHandler({
+    installOne: async (item) => { calls.push('install'); item.phase = 'ready'; return true },
+    fillSizes: async () => {},
+    confirm: async () => { calls.push('confirm'); return true },
+    isInstalling: () => true,
+    attach: () => calls.push('attach'),
+    lastUserMessage: () => '做一份 PPT',
+    resend: async () => calls.push('resend'),
+    toast: () => {},
+  })
+  const r = await h.onAction({ packId: 'pptx-runtime', service: 'pptx-service', sizeMb: 1 })
+  assert.equal(r.installed, true)
+  assert.deepEqual(calls, ['attach', 'install', 'resend'])
+})
+
+test('同一轮重复报的那一次标 duplicate：调用方不能据此收起第一次挂出来的卡片', async () => {
+  let release
+  const h = createComponentRequiredHandler({
+    installOne: async () => true,
+    fillSizes: async () => {},
+    confirm: () => new Promise((r) => { release = r }),
+    lastUserMessage: () => '',
+    resend: async () => {},
+    toast: () => {},
+  })
+  const p = { packId: 'pptx-runtime', service: 'pptx-service', sizeMb: 1 }
+  const first = h.onAction(p)
+  const second = await h.onAction(p)
+  assert.equal(second.duplicate, true)
+  release(false)
+  assert.equal((await first).duplicate, undefined)
+})
+
+// ---------- 接线（源码断言：五个入口确实都接到了单例上） ----------
+
+const read = (p) => readFileSync(new URL('../../src/' + p, import.meta.url), 'utf8')
+const ENTRIES = ['components/OptionalComponentsDialog.vue', 'components/ChatInterface.vue',
+  'components/admin/AdminPane.vue', 'components/EasyVoicePane.vue', 'components/MeetingRecordingPanel.vue']
+
+test('五个入口都用应用级单例，没有谁再自己 new 控制器', () => {
+  for (const p of ENTRIES) {
+    const s = read(p)
+    assert.match(s, /import \{ componentDownloads \} from '@\/services\/componentDownloads\.js'/, p)
+    assert.ok(!/createOptionalComponentsController\(/.test(s), p + ' 仍在自己 new 控制器')
+  }
+})
+
+test('首次登录面板：下载中给「后台下载」，「稍后再说」/遮罩在下载中转后台而不是中断', () => {
+  const s = read('components/OptionalComponentsDialog.vue')
+  assert.match(s, /@tap="onBackground"[\s\S]*?components\.backgroundDownload/)
+  assert.match(s, /async onLater\(\) \{[^}]*?if \(this\.controller\.state\.running\) return this\.onBackground\(\)/)
+  assert.match(s, /components\.backgroundStarted/)
+})
+
+test('AI 对话拦截卡：下载中给「后台下载」，装完按 shouldAutoResend 判重发', () => {
+  const s = read('components/ChatInterface.vue')
+  assert.match(s, /@tap="backgroundComponentGate"/)
+  assert.match(s, /shouldResend: \(mark, item\) => shouldAutoResend\(/)
+})
+
+test('全局提示的四条文案两语言齐全', async () => {
+  const zh = (await import('../../src/locales/zh-CN/components.js')).default
+  const en = (await import('../../src/locales/en-US/components.js')).default
+  for (const k of ['backgroundDownload', 'backgroundStarted', 'backgroundDone', 'backgroundFailed', 'chatReadyRetry']) {
+    assert.ok(zh[k], 'zh-CN 缺 components.' + k)
+    assert.ok(en[k], 'en-US 缺 components.' + k)
+  }
+  assert.ok(zh.backgroundDone.includes('{name}') && en.backgroundDone.includes('{name}'))
+  assert.ok(zh.backgroundFailed.includes('{msg}') && en.backgroundFailed.includes('{msg}'))
+})

--- a/frontend/tests/optional-components/voice-gate.test.mjs
+++ b/frontend/tests/optional-components/voice-gate.test.mjs
@@ -14,16 +14,14 @@ const script = source.match(/<script>([\s\S]*?)<\/script>/)[1]
   .replace(/^import\s[\s\S]*?from\s+'[^']+'\s*;?\s*$/gm, '')
 
 // 顶层 import 被剥掉之后，脚本里引用到的名字要靠形参补回来（与 recorder-gate 同型）。
-const HARNESS_ARGS = ['host', 'ICONS', 'reactive', 'createOptionalComponentsController',
-  'optionalComponents', 'packInstall', 'packStatus', 'packInfo']
+const HARNESS_ARGS = ['host', 'ICONS', 'componentDownloads']
 
 function pane(over) {
   const factory = new Function(...HARNESS_ARGS, script.replace('export default', 'return'))
   const component = factory(
     { model: {}, services: {} }, {},
-    (o) => o,
-    () => ({ state: { items: [] }, load: async () => {}, fillSizes: async () => {}, installOne: async () => true }),
-    async () => ({ components: [] }), async () => ({}), async () => ({}), async () => ({}),
+    { state: { items: [] }, load: async () => {}, fillSizes: async () => {}, installOne: async () => true,
+      isInstalling: () => false, claim: () => () => {} },
   )
   const vm = Object.assign(component.data(), component.methods, { $t: (k) => k }, over)
   for (const [key, fn] of Object.entries(component.computed)) {


### PR DESCRIPTION
## 问题
dev-board#581：组件下载应该支持后台下载。原先五个下载入口各自持有进度状态，关掉面板就看不到进度，换个入口再点会重复发起。

## 修法
- 新增应用级单例 `frontend/src/services/componentDownloads.js`（纯工厂 `composables/useComponentDownloads.js`，编排仍复用 useOptionalComponents 的 pack→模型→ensure 顺序）：按 packId 共享 item、在途去重、load 合并不覆盖在途/失败状态、`claim` 引用计数决定由前台入口还是全局提示交代结果。
- 首次登录面板：下载中「后台下载」；「稍后再说」/遮罩在下载中不中断下载；「已提示」标记改在开始下载时写。
- AI 对话拦截卡：下载中可「后台下载」；后台装完只在拦截后无新用户消息且不在生成中时自动重发原消息，否则提示「组件已就绪，可以重新发送」。顺修：同一轮重复 `component_required` 会把第一张待确认卡关掉。
- 设置→组件管理、语音、录音面板：共享单例，进入即接上在途进度。
- zh-CN / en-US locale 各补 5 个键。

## 验证
- `npm run test:optional-components`：74/74（改动前基线 58/58；新用例在旧代码上 ERR_MODULE_NOT_FOUND 转红；去重 / load 合并 / claim 三处逐一破坏均转红，还原后全绿）。
- `check:nav`、`check:locales`、`check:emits`、`build:h5` 通过。
- 真渲染走查（puppeteer + dev H5，/api 打桩推进 pack 状态）：面板开始下载→「后台下载」→面板关闭并提示→reLaunch 到设置·组件管理看到同一进度且未重复发起安装→完成后全局提示；下载中点「稍后再说」同样装完并提示。23 条断言全过。

## 未验证
- AI 对话拦截卡、语音/录音面板的 UI 走查（仅单测与源码断言覆盖）。
- 真 Electron + 真后端 + 真 pack 的端到端下载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)