### PR TITLE
fix(models): 语音/转写模型改为优先从 ModelScope 下载，修国内网络下 LocalEntryNotFoundError（dev-board#583）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -282,6 +282,7 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
   下游 fetch-lowa-assets.js 对 data 只查「长度 ≥1024」，兜不住双重压缩）。
   落盘先落 web root 之外的暂存区、校验通过再 rename 换入，旧版本自动备份到 `/root/lowa-engine-backup/`。
 - 官网部署在独立仓库（website/，gitignore 掉），服务器 ssh -i ~/.ssh/aiworkdeck_ops root@47.92.111.102；ECS 8.137.95.63(~/.ssh/checkba_ecs)。
+- **kokoro/asr 模型下载源顺序（dev-board#583）**：先 ModelScope，失败再回落 hf-mirror 的 `snapshot_download`（`CHECKBA_MODEL_SOURCE=modelscope|hf` 强制单源）。原因：hf-mirror 只代理元数据，大文件 302 到 HF 官方 CDN（cas-bridge.xethub.hf.co），国内无代理必挂 `LocalEntryNotFoundError`。ModelScope 路径是 `desktop/main/services/model-fetch.py`（纯标准库，按 HF 缓存布局落 `HF_HOME/hub/models--*/{blobs/<sha256>, snapshots/<ModelScope commit>, refs/main}`，续传临时文件 `blobs/<sha256>.incomplete`，refs/main 最后写——所以旧的半截缓存里 refs/main 指向不存在的 snapshot 也能直接续下），运行侧 pack 的 app.py 不用改。**地雷**：脚本随 `main/**` 进 app.asar，Python 读不了，model-manager 每次下载前把它拷到 `~/.aiworkdeck/models/.model-fetch.py` 再跑。mineru 仍走 MinerU 官方 CLI（`-s modelscope`），不动。
 - 模型不进包：mineru/kokoro/asr 模型首启在"组件管理"下载（下载进度按字节级整体，PR#142）。asr 的 faster-whisper medium 约 1.5GB，依赖闭包 182MB（压缩后约 57MB 进安装包，大头是 onnxruntime 70MB + PyAV 44MB，两者都是 faster-whisper 的硬依赖）。
 
 ## 已知地雷

--- a/desktop/main/services/model-fetch.py
+++ b/desktop/main/services/model-fetch.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""从 ModelScope 下载一个模型仓，落成标准 HuggingFace 缓存布局（dev-board#583）。
+
+为什么不直接用 huggingface_hub.snapshot_download 走 hf-mirror.com：镜像只代理元数据，
+大文件 302 到 HF 官方 CDN（cas-bridge.xethub.hf.co），国内无代理网络连不上，报
+LocalEntryNotFoundError。ModelScope 上同名仓的大文件由 cdn-lfs-cn-*.modelscope.cn 直出。
+
+为什么落成 HF 缓存布局：运行侧（asr/kokoro 服务，在 runtime pack 里）以 HF_HUB_OFFLINE=1
+按 repo id 读 HF_HOME，只认 hub/models--{org}--{name}/{refs/main, snapshots/<rev>/...}。
+
+只用标准库（pack 里没有 modelscope SDK；asr pack 连 requests 都没有），certifi 有就用
+（python-build-standalone 在 macOS 上找不到系统 CA）。
+
+用法：python model-fetch.py --repo Systran/faster-whisper-medium --hf-home <dir>
+进度：父进程按目录字节数算，这里只把字节写进目录；stdout 最后一行给人看。
+"""
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ENDPOINT = "https://www.modelscope.cn"
+CHUNK = 1 << 20
+RETRIES = 4
+TIMEOUT = 60
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+HOSTS = []  # 实际访问过的主机（含重定向目标），收尾打印，证明全程不碰 HF 域名
+
+
+class ChecksumError(Exception):
+    pass
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def _note_host(url):
+    host = urllib.parse.urlsplit(url).hostname
+    if host and host not in HOSTS:
+        HOSTS.append(host)
+
+
+class _TrackRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _note_host(newurl)
+        # 自带实现会把 req.headers（含 Range）带到新地址
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _ssl_context():
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
+_OPENER = urllib.request.build_opener(
+    urllib.request.HTTPSHandler(context=_ssl_context()), _TrackRedirect
+)
+
+
+def _open(url, headers=None):
+    _note_host(url)
+    req = urllib.request.Request(url, headers={"User-Agent": "AIWorkDeck-model-fetch", **(headers or {})})
+    return _OPENER.open(req, timeout=TIMEOUT)
+
+
+def list_files(repo):
+    """返回 (revision, [blob 条目])。revision 取仓内最新一次提交（40 位十六进制）。"""
+    url = f"{ENDPOINT}/api/v1/models/{repo}/repo/files?Revision=master&Recursive=true"
+    with _open(url) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    if body.get("Code") != 200 or not isinstance(body.get("Data"), dict):
+        raise RuntimeError(f"ModelScope file list failed for {repo}: {str(body)[:200]}")
+    files = [f for f in body["Data"].get("Files") or [] if f.get("Type") == "blob"]
+    if not files:
+        raise RuntimeError(f"ModelScope returned no files for {repo}")
+    latest = max(files, key=lambda f: f.get("CommittedDate") or 0)
+    rev = str(latest.get("Revision") or "").lower()
+    if not HEX40.match(rev):
+        # 目录名只要稳定且是 40 位十六进制即可（运行侧经 refs/main 找到它）
+        digest = "\n".join(sorted(f"{f['Path']}:{f.get('Sha256', '')}" for f in files))
+        rev = hashlib.sha1(digest.encode("utf-8")).hexdigest()
+    return rev, files
+
+
+def _sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        while True:
+            b = fh.read(CHUNK)
+            if not b:
+                break
+            h.update(b)
+    return h.hexdigest()
+
+
+def fetch_blob(repo, entry, blobs_dir, label):
+    """下载一个文件到 blobs/<sha256>（断点续传 + 校验 + 重试），返回 blob 路径。"""
+    rel = entry["Path"]
+    size = int(entry.get("Size") or 0)
+    sha = str(entry.get("Sha256") or "").lower()
+    sha = sha if HEX64.match(sha) else None
+    if sha:
+        blob = os.path.join(blobs_dir, sha)
+        if os.path.isfile(blob) and os.path.getsize(blob) == size:
+            return blob
+    # 命名与 huggingface_hub 的 LFS 临时文件一致（blobs/<etag>.incomplete，LFS 的 etag 即 sha256）；
+    # 本脚本自己中断后重跑会从这里续传
+    tmp_name = sha or ("ms-" + hashlib.sha1(rel.encode("utf-8")).hexdigest())
+    tmp = os.path.join(blobs_dir, tmp_name + ".incomplete")
+    url = f"{ENDPOINT}/models/{repo}/resolve/master/{urllib.parse.quote(rel)}"
+
+    last_err = None
+    for attempt in range(1, RETRIES + 1):
+        try:
+            have = os.path.getsize(tmp) if os.path.exists(tmp) else 0
+            if have > size:
+                os.remove(tmp)
+                have = 0
+            if have < size or size == 0:
+                headers = {"Range": f"bytes={have}-"} if have else {}
+                with _open(url, headers) as resp:
+                    if have and resp.status != 206:
+                        have = 0  # 服务端没理 Range：从头来
+                    done, last_print = have, 0.0
+                    with open(tmp, "ab" if have else "wb") as out:
+                        while True:
+                            b = resp.read(CHUNK)
+                            if not b:
+                                break
+                            out.write(b)
+                            done += len(b)
+                            now = time.monotonic()
+                            if now - last_print > 5:
+                                last_print = now
+                                log(f"{label} {rel} {done >> 20}/{max(size, 1) >> 20} MB")
+            got = os.path.getsize(tmp)
+            if got != size:
+                raise ChecksumError(f"{rel}: size {got} != expected {size}")
+            actual = _sha256_of(tmp)
+            if sha and actual != sha:
+                os.remove(tmp)  # 内容坏了，续传只会接着坏
+                raise ChecksumError(f"{rel}: sha256 mismatch")
+            blob = os.path.join(blobs_dir, sha or actual)
+            os.replace(tmp, blob)
+            return blob
+        except ChecksumError as e:
+            last_err = e
+        except OSError as e:
+            # URLError / 超时 / SSL 错误都是 OSError 的子类；磁盘满重试没有意义
+            if getattr(e, "errno", None) == 28:
+                raise
+            last_err = e
+        if attempt < RETRIES:
+            log(f"{label} {rel} retry {attempt}/{RETRIES - 1}: {type(last_err).__name__}: {last_err}")
+            time.sleep(2 ** attempt)
+    raise last_err
+
+
+def place(blob, snap_path):
+    """snapshots/<rev>/<path> 指向 blob：能建相对软链就建（与 huggingface_hub 一致）；
+    建不了（Windows 无软链权限）就把 blob 挪进去——这也是 huggingface_hub 在
+    are_symlinks_supported() 为 False 时的做法（file_download._create_symlink 的
+    shutil.move 分支），离线读取只看 snapshots 下的文件。"""
+    os.makedirs(os.path.dirname(snap_path), exist_ok=True)
+    if os.path.lexists(snap_path):
+        os.remove(snap_path)
+    try:
+        os.symlink(os.path.relpath(blob, os.path.dirname(snap_path)), snap_path)
+    except OSError:
+        os.replace(blob, snap_path)
+
+
+def fetch_repo(repo, hf_home):
+    org, name = repo.split("/", 1)
+    storage = os.path.join(hf_home, "hub", f"models--{org}--{name}")
+    blobs_dir = os.path.join(storage, "blobs")
+    os.makedirs(blobs_dir, exist_ok=True)
+
+    rev, files = list_files(repo)
+    snap_root = os.path.join(storage, "snapshots", rev)
+    pending = []
+    for f in files:
+        snap = os.path.join(snap_root, *f["Path"].split("/"))
+        # isfile 跟随软链：软链指向的 blob 在、大小对才算已就位
+        if os.path.isfile(snap) and os.path.getsize(snap) == int(f.get("Size") or 0):
+            continue
+        pending.append(f)
+
+    need = sum(int(f.get("Size") or 0) for f in pending)
+    free = shutil.disk_usage(blobs_dir).free
+    if need > free:
+        raise OSError(28, f"No space left on device: need {need >> 20} MB, free {free >> 20} MB")
+
+    log(f"ModelScope {repo}@{rev[:8]}: {len(files) - len(pending)}/{len(files)} files present, "
+        f"{need >> 20} MB to fetch")
+    for i, f in enumerate(pending, 1):
+        blob = fetch_blob(repo, f, blobs_dir, f"[{i}/{len(pending)}]")
+        place(blob, os.path.join(snap_root, *f["Path"].split("/")))
+
+    # 最后才写 refs/main：旧的半截缓存里 refs/main 可能指向一个根本不存在的 snapshot，
+    # 这里整体覆盖；中途失败则保持旧值，不会指向半成品
+    refs = os.path.join(storage, "refs")
+    os.makedirs(refs, exist_ok=True)
+    tmp_ref = os.path.join(refs, "main.tmp")
+    with open(tmp_ref, "w") as fh:
+        fh.write(rev)
+    os.replace(tmp_ref, os.path.join(refs, "main"))
+    return rev, len(files)
+
+
+def _classify(e):
+    if isinstance(e, OSError) and getattr(e, "errno", None) == 28:
+        return "disk"
+    if isinstance(e, ChecksumError):
+        return "checksum"
+    if isinstance(e, OSError):  # URLError / 超时 / SSL / 连接被拒
+        return "network"
+    return "error"
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--hf-home", default=os.environ.get("HF_HOME"))
+    args = ap.parse_args(argv)
+    if not args.hf_home:
+        ap.error("--hf-home (or HF_HOME) is required")
+    try:
+        rev, n = fetch_repo(args.repo, args.hf_home)
+    except Exception as e:  # noqa: BLE001 —— 最后一行给父进程归类、给人看
+        log("hosts contacted: " + ", ".join(HOSTS))
+        log(f"error[{_classify(e)}]: {type(e).__name__}: {e}")
+        return 1
+    log("hosts contacted: " + ", ".join(HOSTS))
+    log(f"done: {args.repo}@{rev[:8]} ({n} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/main/services/model-manager.js
+++ b/desktop/main/services/model-manager.js
@@ -45,6 +45,76 @@ function pyBin(resourcesPath) {
     : path.join(resourcesPath || '', 'python', 'bin', 'python3.11')
 }
 
+// ModelScope 下载脚本随 main/** 打进 app.asar（package.json build.files），Python 读不了 asar；
+// Electron 的 fs 能读，所以每次下载前把它拷到数据目录再交给打包 Python。
+const FETCH_SCRIPT = path.join(__dirname, 'model-fetch.py')
+
+function stagedFetchScript(ctx) {
+  const dst = path.join(ctx.dataDir, 'models', '.model-fetch.py')
+  const src = fs.readFileSync(FETCH_SCRIPT, 'utf8')
+  let cur = null
+  try { cur = fs.readFileSync(dst, 'utf8') } catch (e) { /* 首次 */ }
+  if (cur !== src) {
+    fs.mkdirSync(path.dirname(dst), { recursive: true })
+    fs.writeFileSync(dst, src)
+  }
+  return dst
+}
+
+// kokoro / asr 的模型下载源（dev-board#583），按顺序尝试：
+//   modelscope —— model-fetch.py 从 ModelScope 同名仓直下，落成标准 HF 缓存布局；
+//   hf         —— huggingface_hub.snapshot_download 走 hf-mirror.com。
+// 为什么 ModelScope 在前：hf-mirror 只代理元数据，大文件 302 到 HF 官方 CDN
+// （cas-bridge.xethub.hf.co），国内无代理网络连不上，报 LocalEntryNotFoundError。
+// hf 留作回落给海外用户（ModelScope 在海外可能慢或不通）。
+// CHECKBA_MODEL_SOURCE=modelscope|hf 强制单一来源（测试/排障用）。
+const HF_SOURCES = ['modelscope', 'hf']
+const SOURCE_LABELS = {
+  modelscope: { zh: 'ModelScope', en: 'ModelScope' },
+  hf: { zh: 'HuggingFace 镜像', en: 'HuggingFace mirror' }
+}
+
+function hfRepoSpec(ctx, service, repo, source) {
+  const dir = path.join(ctx.dataDir, 'models', service.replace(/-service$/, ''))
+  const base = { ...process.env, PYTHONPATH: libDirFor(ctx, service), HF_HOME: dir }
+  if (source === 'modelscope') {
+    return {
+      cmd: pyBin(ctx.resourcesPath),
+      args: [stagedFetchScript(ctx), '--repo', repo, '--hf-home', dir],
+      env: base,
+      cwd: dir
+    }
+  }
+  return {
+    cmd: pyBin(ctx.resourcesPath),
+    args: ['-c', `from huggingface_hub import snapshot_download; snapshot_download('${repo}')`],
+    env: {
+      ...base,
+      HF_ENDPOINT: process.env.CHECKBA_HF_ENDPOINT || 'https://hf-mirror.com',
+      // 打包内带 hf_xet：Xet 路径绕过 HF_ENDPOINT 直连 HF 官方 CAS
+      // (cas-server.xethub.hf.co)，镜像签发的凭证在那边必 401——大陆用户
+      // 无梯子即挂。禁用 xet 走镜像的普通 HTTP 下载（真机 401 实证）。
+      HF_HUB_DISABLE_XET: '1'
+    },
+    cwd: dir
+  }
+}
+
+// 所有源都失败后给用户看的话：先说原因和该怎么办，再附各源的原始异常便于排障。
+// 前端会再套一层「下载失败：{msg}」（components.stateFailed），所以这里不重复「下载失败」。
+function humanDownloadError(attempts) {
+  const disk = attempts.some((a) => /error\[disk\]|No space left|Errno 28|ENOSPC/i.test(a.detail))
+  const labels = attempts.map((a) => t(SOURCE_LABELS[a.source])).join(' / ')
+  const head = disk
+    ? t({ zh: '磁盘空间不足，请清理出空间后重试。', en: 'Not enough disk space. Free up some space and try again.' })
+    : t({
+      zh: `无法连接模型下载源（${labels}），请检查网络后重试。`,
+      en: `Could not reach the model download sources (${labels}). Check your network and try again.`
+    })
+  const details = attempts.map((a) => `${a.source}: ${a.detail.slice(0, 220)}`).join('; ')
+  return `${head}${t({ zh: '原始错误：', en: ' Details: ' })}${details}`
+}
+
 // 组件注册表：MinerU pipeline 模型 + Kokoro 语音模型 + 本地转写模型
 //
 // name 写成 { zh, en } 对，由 status() 用 app-language 的 t() 取值——**必须在 status() 里取，
@@ -90,31 +160,13 @@ const COMPONENTS = [
     id: 'kokoro-models',
     runtimeService: 'kokoro-service',
     name: { zh: '语音合成模型（Kokoro）', en: 'Speech Synthesis Model (Kokoro)' },
-    sizeHint: '300 MB',
-    estBytes: 300 * 1024 * 1024,
+    // 全仓实测约 376MB（含 100 个音色文件与 samples）；写小了进度会在 80% 处提前封顶 99%
+    sizeHint: '380 MB',
+    estBytes: 380 * 1024 * 1024,
     dir: (ctx) => path.join(ctx.dataDir, 'models', 'kokoro'),
-    // huggingface_hub snapshot（走国内镜像，env 可覆盖）；运行侧 HF_HOME 与此一致
-    spawnSpec: (ctx) => {
-      const dir = path.join(ctx.dataDir, 'models', 'kokoro')
-      return {
-        cmd: pyBin(ctx.resourcesPath),
-        args: [
-          '-c',
-          "from huggingface_hub import snapshot_download; snapshot_download('hexgrad/Kokoro-82M-v1.1-zh')"
-        ],
-        env: {
-          ...process.env,
-          PYTHONPATH: libDirFor(ctx, 'kokoro-service'),
-          HF_HOME: dir,
-          HF_ENDPOINT: process.env.CHECKBA_HF_ENDPOINT || 'https://hf-mirror.com',
-          // 打包内带 hf_xet：Xet 路径绕过 HF_ENDPOINT 直连 HF 官方 CAS
-          // (cas-server.xethub.hf.co)，镜像签发的凭证在那边必 401——大陆用户
-          // 无梯子即挂。禁用 xet 走镜像的普通 HTTP 下载（真机 401 实证）。
-          HF_HUB_DISABLE_XET: '1'
-        },
-        cwd: dir
-      }
-    }
+    // 先 ModelScope 再 hf-mirror（见 HF_SOURCES）；两条路都落标准 HF 缓存，运行侧 HF_HOME 与此一致
+    sources: HF_SOURCES,
+    spawnSpec: (ctx, source) => hfRepoSpec(ctx, 'kokoro-service', 'hexgrad/Kokoro-82M-v1.1-zh', source)
   },
   {
     id: 'asr-models',
@@ -123,29 +175,19 @@ const COMPONENTS = [
     sizeHint: '1.5 GB',
     estBytes: 1.5 * 1024 * 1024 * 1024,
     dir: (ctx) => path.join(ctx.dataDir, 'models', 'asr'),
-    // 与 kokoro 同一条 huggingface_hub snapshot 路径；运行侧 HF_HOME 与此一致。
+    // 与 kokoro 同样先 ModelScope 再 hf-mirror；运行侧 HF_HOME 与此一致。
     // 模型不进安装包：1.5GB 会让安装包体积翻几倍，而只有开了「录音不出本机」的用户才需要它。
-    spawnSpec: (ctx) => {
-      const dir = path.join(ctx.dataDir, 'models', 'asr')
-      return {
-        cmd: pyBin(ctx.resourcesPath),
-        args: [
-          '-c',
-          "from huggingface_hub import snapshot_download; snapshot_download('Systran/faster-whisper-medium')"
-        ],
-        env: {
-          ...process.env,
-          PYTHONPATH: libDirFor(ctx, 'asr-service'),
-          HF_HOME: dir,
-          HF_ENDPOINT: process.env.CHECKBA_HF_ENDPOINT || 'https://hf-mirror.com',
-          // 同 kokoro：Xet 路径绕过 HF_ENDPOINT 直连 HF 官方 CAS，镜像签发的凭证在那边必 401
-          HF_HUB_DISABLE_XET: '1'
-        },
-        cwd: dir
-      }
-    }
+    sources: HF_SOURCES,
+    spawnSpec: (ctx, source) => hfRepoSpec(ctx, 'asr-service', 'Systran/faster-whisper-medium', source)
   }
 ]
+
+// 本次下载要依次尝试的来源；没有 sources 的组件（mineru）只有一次、source 为 null
+function sourcesFor(c) {
+  if (!c.sources) return [null]
+  const forced = process.env.CHECKBA_MODEL_SOURCE
+  return forced && c.sources.includes(forced) ? [forced] : c.sources
+}
 
 class ModelManager {
   constructor(opts) {
@@ -208,15 +250,13 @@ class ModelManager {
 
     const dir = this.dirOf(id)
     fs.mkdirSync(dir, { recursive: true })
-    const spec = this.spawnSpecOverride ? this.spawnSpecOverride(c, this.ctx) : c.spawnSpec(this.ctx)
-    const child = spawn(spec.cmd, spec.args, { cwd: spec.cwd, env: spec.env, stdio: ['ignore', 'pipe', 'pipe'] })
-    this.active.set(id, child)
+    const sources = sourcesFor(c)
+    const attempts = [] // 失败过的来源：{ source, detail, raw }
 
     // stdout/stderr 只取"最近一行"当状态文案；百分比不再取自下载器输出——
     // 那是单个文件的 tqdm，十几个模型文件会反复 0→100%（真机反馈"下载完又
     // 从 0 开始"）。整体进度 = 已落盘字节 / estBytes，按固定间隔轮询目录。
     let lastLine = ''
-    const onLine = (line) => { lastLine = line }
     const estBytes = c.estBytes || 0
     const poller = setInterval(() => {
       const percent = estBytes > 0
@@ -224,44 +264,88 @@ class ModelManager {
         : undefined
       this.onProgress({ id, phase: 'progress', percent, message: lastLine.slice(0, 200) })
     }, this.progressPollMs)
-    const hook = (stream) => {
-      let buf = ''
-      stream.on('data', (d) => {
-        buf += d.toString()
-        // tqdm 用 \r 刷新进度，按 \r 和 \n 一起切行
-        const parts = buf.split(/[\r\n]+/)
-        buf = parts.pop()
-        for (const p of parts) if (p.trim()) onLine(p.trim())
-      })
-    }
-    hook(child.stdout)
-    hook(child.stderr)
 
-    child.on('exit', (code, signal) => {
-      clearInterval(poller)
-      const wasCancelled = child._awdCancelled
-      this.active.delete(id)
-      if (wasCancelled) {
-        this.onProgress({ id, phase: 'progress', percent: 0, message: 'cancelled' })
-        return
-      }
-      if (code === 0) {
-        fs.writeFileSync(path.join(dir, MARKER), new Date().toISOString())
-        this.onProgress({ id, phase: 'done' })
-      } else {
-        const msg = `download exited ${code ?? signal}: ${lastLine}`.slice(0, 500)
-        this.errors.set(id, msg)
-        this.onProgress({ id, phase: 'error', message: msg })
-      }
-    })
-    child.on('error', (e) => {
+    const finishError = (msg) => {
       clearInterval(poller)
       this.active.delete(id)
-      const msg = String(e && e.message ? e.message : e)
       this.errors.set(id, msg)
       this.onProgress({ id, phase: 'error', message: msg })
-    })
+    }
 
+    const runAttempt = (idx) => {
+      const source = sources[idx]
+      let spec
+      try {
+        spec = this.spawnSpecOverride ? this.spawnSpecOverride(c, this.ctx, source) : c.spawnSpec(this.ctx, source)
+      } catch (e) {
+        return settleFailure(idx, String(e && e.message ? e.message : e))
+      }
+      lastLine = ''
+      // Python 异常的说明可能跨多行，最后一行未必带异常类名与根因（hf 的
+      // LocalEntryNotFoundError 就是这样）；另记最后一条「异常头」行，报错时优先用它
+      let errLine = ''
+      const child = spawn(spec.cmd, spec.args, { cwd: spec.cwd, env: spec.env, stdio: ['ignore', 'pipe', 'pipe'] })
+      this.active.set(id, child)
+      const hook = (stream) => {
+        let buf = ''
+        stream.on('data', (d) => {
+          buf += d.toString()
+          // tqdm 用 \r 刷新进度，按 \r 和 \n 一起切行
+          const parts = buf.split(/[\r\n]+/)
+          buf = parts.pop()
+          // 回落之后上一个来源的残余输出不能盖掉当前来源的状态行
+          for (const p of parts) {
+            const line = p.trim()
+            if (!line || this.active.get(id) !== child) continue
+            lastLine = line
+            if (/^(error\[\w+\]:|[\w.]+(Error|Exception)\b)/.test(line)) errLine = line
+          }
+        })
+      }
+      hook(child.stdout)
+      hook(child.stderr)
+
+      let settled = false
+      const settle = (ok, raw) => {
+        if (settled) return
+        settled = true
+        if (child._awdCancelled) {
+          // 取消 = 用户的决定，不再回落到下一个来源
+          clearInterval(poller)
+          if (this.active.get(id) === child) this.active.delete(id)
+          this.onProgress({ id, phase: 'progress', percent: 0, message: 'cancelled' })
+          return
+        }
+        if (ok) {
+          clearInterval(poller)
+          this.active.delete(id)
+          fs.writeFileSync(path.join(dir, MARKER), new Date().toISOString())
+          this.onProgress({ id, phase: 'done' })
+          return
+        }
+        settleFailure(idx, raw, errLine || lastLine)
+      }
+      // 用 close 不用 exit：close 在 stdio 读完之后才发，最后一行（错误原因）不会丢
+      child.on('close', (code, signal) => settle(code === 0, `download exited ${code ?? signal}: ${lastLine}`))
+      child.on('error', (e) => settle(false, String(e && e.message ? e.message : e)))
+    }
+
+    const settleFailure = (idx, raw, line) => {
+      const source = sources[idx]
+      attempts.push({ source, raw, detail: line || raw })
+      if (idx + 1 < sources.length) {
+        const next = sources[idx + 1]
+        lastLine = t({
+          zh: `${t(SOURCE_LABELS[source])} 下载失败，改用 ${t(SOURCE_LABELS[next])}…`,
+          en: `${t(SOURCE_LABELS[source])} failed, trying ${t(SOURCE_LABELS[next])}...`
+        })
+        return runAttempt(idx + 1)
+      }
+      // mineru 没有多来源：保持原来的报错口径
+      finishError(source === null ? raw.slice(0, 500) : humanDownloadError(attempts))
+    }
+
+    runAttempt(0)
     return { ok: true }
   }
 

--- a/desktop/tests/model-manager.test.js
+++ b/desktop/tests/model-manager.test.js
@@ -121,6 +121,132 @@ test('remove clears installed state', async () => {
   assert.strictEqual(mm.status().find((c) => c.id === 'mineru-models').state, 'absent')
 })
 
+// ── 下载源顺序（dev-board#583）：kokoro/asr 先 ModelScope，失败再回落 hf-mirror ──
+// 假下载器按 source 决定成败，并把每次被调起的 source 记进 calls.log
+const MS_FAIL_LINE = 'error[network]: URLError: <urlopen error boom-ms>'
+const HF_FAIL_LINE = 'huggingface_hub.errors.LocalEntryNotFoundError: boom-hf'
+
+function makeSourcedManager(dataDir, behavior, events) {
+  const logFile = path.join(dataDir, 'calls.log')
+  const mm = createModelManager({
+    dataDir,
+    resourcesPath: null,
+    packaged: false,
+    onProgress: (e) => events.push(e),
+    progressPollMs: 50,
+    spawnSpecOverride: (component, ctx, source) => {
+      const mode = behavior[source] || 'fail'
+      const failLine = mode === 'disk'
+        ? 'error[disk]: OSError: [Errno 28] No space left on device'
+        : (source === 'hf' ? HF_FAIL_LINE : MS_FAIL_LINE)
+      const body = mode === 'ok'
+        ? `console.log('done'); process.exit(0)`
+        : mode === 'hang'
+          ? `console.log('starting'); setInterval(() => {}, 1000)`
+          : `console.log(${JSON.stringify(failLine)}); process.exit(1)`
+      return {
+        cmd: process.execPath,
+        args: ['-e', `require('fs').appendFileSync(${JSON.stringify(logFile)}, ${JSON.stringify(String(source))} + '\\n'); ${body}`],
+        env: process.env,
+        cwd: dataDir
+      }
+    }
+  })
+  const calls = () => {
+    try { return fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean) } catch (e) { return [] }
+  }
+  return { mm, calls }
+}
+
+test('kokoro/asr: ModelScope 成功就不走 hf 回落', async () => {
+  const dataDir = tmpDataDir()
+  const events = []
+  const { mm, calls } = makeSourcedManager(dataDir, { modelscope: 'ok', hf: 'ok' }, events)
+  await mm.download('asr-models')
+  await waitFor(() => mm.isInstalled('asr-models'))
+  assert.deepStrictEqual(calls(), ['modelscope'])
+})
+
+test('kokoro/asr: ModelScope 失败回落 hf-mirror，回落成功即装好', async () => {
+  const dataDir = tmpDataDir()
+  const events = []
+  const { mm, calls } = makeSourcedManager(dataDir, { modelscope: 'fail', hf: 'ok' }, events)
+  await mm.download('kokoro-models')
+  await waitFor(() => mm.isInstalled('kokoro-models'))
+  assert.deepStrictEqual(calls(), ['modelscope', 'hf'])
+  assert.ok(!events.some((e) => e.phase === 'error'), '回落成功时不该发 error')
+})
+
+test('kokoro/asr: 两个源都失败时 message 是人话且附原始异常', async () => {
+  const dataDir = tmpDataDir()
+  const events = []
+  const { mm, calls } = makeSourcedManager(dataDir, { modelscope: 'fail', hf: 'fail' }, events)
+  await mm.download('asr-models')
+  await waitFor(() => events.some((e) => e.phase === 'error'))
+  assert.deepStrictEqual(calls(), ['modelscope', 'hf'])
+  const st = mm.status().find((c) => c.id === 'asr-models')
+  assert.strictEqual(st.state, 'error')
+  assert.match(st.message, /无法连接模型下载源|Could not reach the model download sources/)
+  assert.match(st.message, /ModelScope/)
+  assert.doesNotMatch(st.message, /^download exited/)
+  assert.ok(st.message.includes('boom-ms'), 'ModelScope 的原始异常要附上')
+  assert.ok(st.message.includes('LocalEntryNotFoundError: boom-hf'), 'hf 的原始异常要附上')
+  const err = events.find((e) => e.phase === 'error')
+  assert.strictEqual(err.message, st.message)
+})
+
+test('磁盘满时提示空间不足而不是网络', async () => {
+  const dataDir = tmpDataDir()
+  const events = []
+  const { mm } = makeSourcedManager(dataDir, { modelscope: 'disk', hf: 'fail' }, events)
+  await mm.download('asr-models')
+  await waitFor(() => events.some((e) => e.phase === 'error'))
+  assert.match(mm.status().find((c) => c.id === 'asr-models').message, /磁盘空间不足|Not enough disk space/)
+})
+
+test('CHECKBA_MODEL_SOURCE=hf 强制只走 hf', async (t) => {
+  const prev = process.env.CHECKBA_MODEL_SOURCE
+  process.env.CHECKBA_MODEL_SOURCE = 'hf'
+  t.after(() => { if (prev === undefined) delete process.env.CHECKBA_MODEL_SOURCE; else process.env.CHECKBA_MODEL_SOURCE = prev })
+  const dataDir = tmpDataDir()
+  const { mm, calls } = makeSourcedManager(dataDir, { modelscope: 'ok', hf: 'ok' }, [])
+  await mm.download('kokoro-models')
+  await waitFor(() => mm.isInstalled('kokoro-models'))
+  assert.deepStrictEqual(calls(), ['hf'])
+})
+
+test('CHECKBA_MODEL_SOURCE=modelscope 失败时不回落', async (t) => {
+  const prev = process.env.CHECKBA_MODEL_SOURCE
+  process.env.CHECKBA_MODEL_SOURCE = 'modelscope'
+  t.after(() => { if (prev === undefined) delete process.env.CHECKBA_MODEL_SOURCE; else process.env.CHECKBA_MODEL_SOURCE = prev })
+  const dataDir = tmpDataDir()
+  const events = []
+  const { mm, calls } = makeSourcedManager(dataDir, { modelscope: 'fail', hf: 'ok' }, events)
+  await mm.download('kokoro-models')
+  await waitFor(() => events.some((e) => e.phase === 'error'))
+  assert.deepStrictEqual(calls(), ['modelscope'])
+})
+
+test('ModelScope 下载中取消：不回落 hf、状态回 absent', async () => {
+  const dataDir = tmpDataDir()
+  const events = []
+  const { mm, calls } = makeSourcedManager(dataDir, { modelscope: 'hang', hf: 'ok' }, events)
+  await mm.download('asr-models')
+  await waitFor(() => calls().length === 1)
+  await mm.cancel('asr-models')
+  await new Promise((r) => setTimeout(r, 400))
+  assert.deepStrictEqual(calls(), ['modelscope'])
+  assert.strictEqual(mm.status().find((c) => c.id === 'asr-models').state, 'absent')
+})
+
+test('mineru 仍是单一来源，一次调起', async () => {
+  const dataDir = tmpDataDir()
+  const { mm, calls } = makeSourcedManager(dataDir, { null: 'ok', undefined: 'ok' }, [])
+  await mm.download('mineru-models')
+  await waitFor(() => mm.isInstalled('mineru-models'))
+  assert.strictEqual(calls().length, 1)
+})
+
 test('runtime pack 未装时，模型下载当场失败并说清要先装哪个组件', async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mm-nopack-'))
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))

--- a/legal/PRIVACY.md
+++ b/legal/PRIVACY.md
@@ -1,6 +1,6 @@
 # AI WorkDeck 隐私说明
 
-更新日期：2026-08-17
+更新日期：2026-09-10
 
 本说明描述 AI WorkDeck 桌面应用的两件事：
 
@@ -43,6 +43,8 @@
 **这六家供应商全部在境内**，平台代采不涉及向境外提供个人信息。
 
 **语音合成不在这张表里**：它只有本机一档，随包内置的引擎在你的机器上合成，不出本机，也没有云端通路。
+
+**可选组件的模型文件从公开模型站下载，同样不经过我们的服务器。** 文档解析、语音合成、本机转写这几个可选组件的模型不随安装包分发，只在你主动点「下载」时，由你的机器直接从 ModelScope（modelscope.cn）下载；连不上时改从 HuggingFace 镜像（hf-mirror.com）下载，其中较大的文件可能由 HuggingFace 官方 CDN 提供。下载请求只包含要取的模型名与文件名，不上传任何文档、对话或其他用户数据。
 
 ## 三、会留下的记录：账务流水
 
@@ -141,7 +143,7 @@
 
 # AI WorkDeck Privacy Note
 
-Last updated: 2026-08-17
+Last updated: 2026-09-10
 
 ## Part 1 — Platform services
 
@@ -159,6 +161,8 @@ Last updated: 2026-08-17
 | Statute and case law search | The query | PKULaw | No | Nothing kept past the call |
 
 **Meeting audio is the only item written to disk on our side.** The desktop app uploads it directly to our object storage (bypassing the application server); the object is deleted by code once transcription finishes or the task fails, and a 24-hour lifecycle rule on the bucket clears anything the code misses. The transcript is not retained after it is returned to the desktop app. Every other service passes content through only at call time: request content is not logged, not stored, and not used to train any model. All six vendors are inside mainland China, so the platform-sourced tier involves no transfer of personal information abroad. Speech synthesis is absent from the table: it has an on-device tier only, synthesizing in the bundled engine with no cloud path at all.
+
+**Optional-component models come from public model hubs, not from our servers.** The models for the optional components (document parsing, speech synthesis, on-device transcription) are not shipped in the installer. Only when you choose to download one does your machine fetch it directly from ModelScope (modelscope.cn); if that cannot be reached it falls back to a HuggingFace mirror (hf-mirror.com), where larger files may be served by HuggingFace's own CDN. The requests carry only the model and file names being fetched; no documents, conversations, or other user data are uploaded.
 
 **What is kept: billing entries.** Each platform-sourced call leaves one ledger entry under your account recording the service name, operation, quantity (minutes / pages / calls / thousand characters), amount charged, timestamp, and idempotency key. It contains no request content, no result content, and no file names. These are financial records, kept for the life of the account, and visible to you under Settings → Account and Usage.
 


### PR DESCRIPTION
## 问题
dev-board#583：下载语音组件失败，`download exited 1: huggingface_hub.errors.LocalEntryNotFoundError`。

## 根因
`hf-mirror.com` 只代理元数据，大文件（whisper `model.bin` 1.5GB、kokoro `.pth` 327MB）302 到 HF 官方 CDN `cas-bridge.xethub.hf.co`；国内无代理网络连不上，`hf_hub_download` 把连接失败包装成 `LocalEntryNotFoundError`。用户机器上 asr 目录停在只有 refs/trees 元数据、没有任何 blob 的状态，与此吻合。

## 修法
- 新增 `desktop/main/services/model-fetch.py`（仅标准库）：ModelScope 文件列表 API + resolve 下载（大文件走 `cdn-lfs-cn-1.modelscope.cn`），Range 断点续传、sha256 校验、每文件 4 次重试，按标准 HF 缓存布局落盘（`blobs/<sha256>` + snapshots 相对软链 + 最后写 `refs/main`）。运行侧 pack 不改、不用重发。脚本在 app.asar 内，下载前拷到 `~/.aiworkdeck/models/.model-fetch.py` 执行。
- `model-manager.js`：kokoro / asr 先 ModelScope、失败回落原 hf-mirror 路径（海外用户兜底）；`CHECKBA_MODEL_SOURCE=modelscope|hf` 可强制单源；取消不回落；改用 `close` 事件保证最后一行错误不丢。MinerU 不动。
- 失败提示改人话（中英），附各源原始异常；磁盘不足单独提示。
- kokoro 体积提示 300MB → 380MB（实测 376MB）。
- `legal/PRIVACY.md` 中英各补一段：可选组件模型只在用户主动下载时从 ModelScope / HuggingFace 镜像拉取，不上传任何用户数据（此前未声明，违反仓库出站红线）。

## 验证
- `desktop` 全量 `npm test`：152 pass / 0 fail / 1 skip（无 JDK 跳过的旧用例）；新增 8 个用例在旧代码上 7 红。
- 真下载（本机打包 Python + runtime pack lib，`env -i`）：kokoro 全仓 113 文件、asr 全仓 7 文件均成功，访问主机只有 `www.modelscope.cn`、`cdn-lfs-cn-1.modelscope.cn`。
- `HF_HUB_OFFLINE=1` 运行侧加载：WhisperModel 加载并转写成功；KPipeline(lang z) 加载并合成成功。
- 用户同款半截缓存（refs/main 指向不存在的 snapshot）：续下成功，refs/main 更新，离线加载成功。
- 断点续传：预置 700MB `.incomplete`，从 701/1457MB 续上，sha256 与 ModelScope 一致。
- 两源都不可达（死代理）：约 1 秒失败，message 为「无法连接模型下载源（ModelScope / HuggingFace 镜像），请检查网络后重试。原始错误：…」。

## 未验证
- 国内无代理网络实测（本机流量全走 VPN）；只能证明 ModelScope 路径全程不碰 huggingface 域名。
- Windows 上无软链分支、打包 Electron 内从 asar 拷出脚本的完整路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)