### PR TITLE
fix(kokoro): 英文音色运行时零出网——pack 内置 en_core_web_sm 并拒绝现场下载（dev-board#591）

### DIFF
--- a/.claude/agents/utility-tools.md
+++ b/.claude/agents/utility-tools.md
@@ -364,6 +364,7 @@ FilePickerDialog :298 / EasyVoicePane :537 / DesensitizePane :543 / SearchPanel 
   详见上面剪贴板段的「采集链路的登录态红线」。
 - `checkba:fs-read-file` 有敏感路径拦截，别为新功能开任意路径读写。
 - Kokoro 大陆网络 401 = hf_xet 绕镜像问题，禁 xet 修（PR#142）。asr-models 的下载走同一条路，同样禁 xet。
+- **Kokoro 英文音色的运行时出网（dev-board#591）**：misaki 的 `en.G2P` 缺 `en_core_web_sm` 时会 `spacy.cli.download`（先 GET raw.githubusercontent.com 的 compatibility.json，再 `pip install` 进 `sys.executable` 的 site-packages，也就是 App 包内），`HF_HUB_OFFLINE=1` 管不到。kokoro-runtime 1.0.0 的 lib 就缺它（实测离线时 af_/bf_ 合成 500，中文不受影响）。现在三道闸：lock 钉死模型 wheel、`app.py` 的 `_require_en_spacy_model()` 缺模型直接拒绝、pack-release 冒烟在死端口代理下真跑 `en.G2P()`（契约测试 `desktop/tests/kokoro-offline-english.test.js`）。**lock 改动要走 pack 发版才到用户手里**。中文 pipeline 的 `ZHG2P` 没传 `en_callable`，不碰 spaCy。
 - **asr-service 不像 kokoro 那样把服务门在模型上**：kokoro 的 descriptor 有 `enabled`（没模型不起进程），asr-service **没有**。就绪探测必须能分开「服务没起」（重启应用）与「模型没下」（下 1.5GB），不起进程就只剩前一种结论，用户照提示重启一万次也不会有模型。
 - **`POST /api/files/{id}/upload` 同时是编辑器自动保存的落点**（`LibreOfficeEditor.uploadBytes`
   不带 `X-File-Total-Size` 头，命中 `FileController` 的 legacy 分支）。挂在那条分支上的

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -220,6 +220,11 @@ jobs:
                 "$PY" -m mineru.cli.fast_api --host 127.0.0.1 --port 8098 > "$RUNNER_TEMP/smoke.log" 2>&1 &
               URL=http://127.0.0.1:8098/docs ;;
             kokoro-runtime)
+              # 英文 G2P 必须离线可初始化：lib 缺 en_core_web_sm 时 misaki 会现场
+              # spacy.cli.download 出网（dev-board#591）。代理指向死端口，任何出网都会失败
+              HTTPS_PROXY=http://127.0.0.1:9 HTTP_PROXY=http://127.0.0.1:9 NO_PROXY= \
+                "$PY" -c "from misaki import en; en.G2P(trf=False, british=False, fallback=None, unk='')" \
+                || { echo "misaki en.G2P failed offline: en_core_web_sm missing from kokoro lib"; exit 1; }
               PORT=8881 "$PY" "$ROOT/app/app.py" > "$RUNNER_TEMP/smoke.log" 2>&1 &
               URL=http://127.0.0.1:8881/health
               # 与 desktop-build.yml 同款：光起得来不够，音色表里必须有 zf_001

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
     "dev": "cross-env AIWORKDECK_DESKTOP_DEV=1 electron .",
     "start": "electron .",
     "build": "electron-builder",
-    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/port-chain-contract.test.js tests/model-manager.test.js tests/service-pack-gate.test.js tests/pysvc-extract-removed.test.js tests/pysvc-runtime.pack-resolve.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/main-window-lifecycle.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/trim-driver-bundle.test.js tests/after-pack.test.js tests/workflow-release-gating.test.js tests/share-file.test.js tests/product-identity-ua.test.js tests/prefs.test.js"
+    "test": "node --test tests/service-manager.test.js tests/backend-reuse-gate.test.js tests/port-chain-contract.test.js tests/model-manager.test.js tests/service-pack-gate.test.js tests/pysvc-extract-removed.test.js tests/pysvc-runtime.pack-resolve.test.js tests/overlay.test.js tests/update-service.test.js tests/drawio-server.test.js tests/browser-views.test.js tests/native-theme-light.test.js tests/main-window-bounds.test.js tests/main-window-lifecycle.test.js tests/build-pack.test.js tests/fetch-lowa-assets.test.js tests/prepare-python-service.test.js tests/trim-driver-bundle.test.js tests/after-pack.test.js tests/workflow-release-gating.test.js tests/share-file.test.js tests/product-identity-ua.test.js tests/prefs.test.js tests/kokoro-offline-english.test.js"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/desktop/tests/kokoro-offline-english.test.js
+++ b/desktop/tests/kokoro-offline-english.test.js
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 北京京微资易科技有限公司 and AI WorkDeck contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// dev-board#591：Kokoro 英文音色（af_/bf_）首次合成时，misaki 的 en.G2P 发现缺
+// en_core_web_sm 就 spacy.cli.download——向 raw.githubusercontent.com 出网，
+// HF_HUB_OFFLINE=1 管不到，联网时还会 pip install 进 App 包内 site-packages。
+// 实测（kokoro-runtime 1.0.0）：离线时英文合成 500，中文不受影响。
+//
+// 三道闸，缺一道这里就红：
+//   1. requirements.in 钉死模型 wheel，lock 里同一行（pack 发版照 lock 装进 lib）；
+//   2. app.py 在建英文 pipeline 前检查模型在不在，缺了直接报错、不许下载；
+//   3. pack-release.yml 的 kokoro 冒烟在「出网必失败」的环境里真跑一次 en.G2P 初始化。
+// 真实行为验证在 CI 冒烟（第 3 条）；本文件守的是三处接线不被悄悄删掉。
+
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ROOT = path.join(__dirname, '..', '..')
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8')
+
+const MODEL_REQ = 'en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl'
+
+test('requirements.in 与 requirements.lock 都钉了 en_core_web_sm 的同一个 wheel', () => {
+  const lines = (rel) => read(rel).split('\n').map((l) => l.trim())
+  assert.ok(lines('kokoro-service/requirements.in').includes(MODEL_REQ), 'requirements.in 缺 en-core-web-sm')
+  assert.ok(lines('kokoro-service/requirements.lock').includes(MODEL_REQ),
+    'requirements.lock 缺 en-core-web-sm（改完 .in 要重跑 uv pip compile）')
+})
+
+test('app.py 在建英文 pipeline 前检查模型，且自身从不调 spacy 下载', () => {
+  const src = read('kokoro-service/app.py')
+  assert.match(src, /EN_SPACY_MODEL = "en_core_web_sm"/)
+  assert.match(src, /spacy\.util\.is_package\(EN_SPACY_MODEL\)/)
+  const fn = src.slice(src.indexOf('def _pipeline('), src.indexOf('def _lang_for_voice('))
+  const guard = fn.indexOf('_require_en_spacy_model()')
+  assert.ok(guard !== -1, '_pipeline 没有调用 _require_en_spacy_model')
+  assert.ok(guard < fn.indexOf('KPipeline(lang_code='), '模型检查必须在构造 KPipeline 之前')
+  assert.doesNotMatch(src, /spacy\.cli\.download\(|from spacy(\.cli)? import (cli|download)/,
+    'app.py 不许调用 spacy 的下载入口')
+})
+
+test('pack-release.yml 的 kokoro 冒烟在出网必失败的环境里初始化 en.G2P', () => {
+  const wf = read('.github/workflows/pack-release.yml')
+  const block = wf.slice(wf.indexOf('kokoro-runtime)'), wf.indexOf('asr-runtime)', wf.indexOf('kokoro-runtime)')))
+  assert.match(block, /HTTPS_PROXY=http:\/\/127\.0\.0\.1:9/)
+  assert.match(block, /from misaki import en; en\.G2P\(/)
+  assert.match(block, /\|\| \{ echo [^}]*exit 1; \}/, 'G2P 失败必须让冒烟失败')
+})

--- a/kokoro-service/app.py
+++ b/kokoro-service/app.py
@@ -42,10 +42,25 @@ app = FastAPI(title="Kokoro Local TTS", version="1.0.0")
 
 _pipelines = {}
 
+# misaki 英文 G2P 依赖的 spaCy 模型，随 pack 的 requirements.lock 装进 lib
+EN_SPACY_MODEL = "en_core_web_sm"
+
+
+def _require_en_spacy_model():
+    """misaki 的 en.G2P 发现缺模型会 spacy.cli.download 现场出网（HF_HUB_OFFLINE 管不到，
+    联网时还会 pip install 进 App 包）。运行时零出网是红线：缺了就明确报错，不让它下（dev-board#591）"""
+    import spacy.util
+    if not spacy.util.is_package(EN_SPACY_MODEL):
+        raise RuntimeError(
+            f"{EN_SPACY_MODEL} is missing from the kokoro runtime pack; "
+            "English voices are unavailable (runtime download refused)")
+
 
 def _pipeline(lang_code: str):
     """按语言缓存 KPipeline（模型懒加载，进程内单例）"""
     if lang_code not in _pipelines:
+        if lang_code in ("a", "b"):
+            _require_en_spacy_model()
         from kokoro import KPipeline  # 延迟 import：/health 不碰 torch
         logger.info("Initializing KPipeline lang=%s repo=%s", lang_code, REPO_ID)
         _pipelines[lang_code] = KPipeline(lang_code=lang_code, repo_id=REPO_ID)

--- a/kokoro-service/requirements.in
+++ b/kokoro-service/requirements.in
@@ -4,3 +4,6 @@ fastapi>=0.110
 uvicorn>=0.29
 soundfile>=0.12
 espeakng-loader>=0.2
+# misaki 英文 G2P 要这个 spaCy 模型；缺了它会在首次英文合成时 spacy.cli.download 现场出网
+# （HF_HUB_OFFLINE 管不到），违反运行时零出网。必须随 pack 装进 lib（dev-board#591）
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl

--- a/kokoro-service/requirements.lock
+++ b/kokoro-service/requirements.lock
@@ -76,6 +76,8 @@ dlinfo==2.0.0
     # via phonemizer-fork
 docopt==0.6.2
     # via num2words
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+    # via -r requirements.in
 espeakng-loader==0.2.4
     # via
     #   -r requirements.in


### PR DESCRIPTION
## 问题
kokoro-runtime 1.0.0 的 lib 不含 `en_core_web_sm`。英文音色（af_maple / bf_vale）首次合成时，misaki 的 `en.G2P` 调 `spacy.cli.download`：先 GET `raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json`，再 `pip install` 进 `sys.executable` 的 site-packages（即 App 包内）。`HF_HUB_OFFLINE=1` 管不到。违反「不新增 legal/PRIVACY.md 未声明的出站请求」红线；离线机器上英文合成直接 500。中文音色不碰 spaCy，不受影响。

## 复现（本机 App 0.39.0 自带 Python + pack 1.0.0 lib，出网走记录并拒绝的本地代理）
- 修复前 af_maple / bf_vale：代理记录 `CONNECT raw.githubusercontent.com:443`，合成 500；zf_001 200、零出网
- 修复后缺模型：`en_core_web_sm is missing from the kokoro runtime pack; English voices are unavailable (runtime download refused)`，零出网
- 修复后 lib 带模型：af_maple 200（144044 字节），零出网

## 改动
- `kokoro-service/requirements.in/lock`：钉死 en_core_web_sm 3.8.0 wheel（12.8MB；lock 只增两行）
- `kokoro-service/app.py`：`_require_en_spacy_model()` 在建英文 KPipeline 前检查，缺模型拒绝下载
- `pack-release.yml`：kokoro 冒烟在死端口代理下初始化 `misaki.en.G2P()`，缺模型发版即红
- `desktop/tests/kokoro-offline-english.test.js`：三处接线的契约测试（四种还原病灶各自只让对应用例转红）
- `.claude/agents/utility-tools.md`：记地雷

## 验证
- `node --test tests/kokoro-offline-english.test.js` 3/3
- desktop `npm test` 其余用例：本 worktree 缺 electron/js-yaml 的三个文件在干净 HEAD 同样失败；借主检出 node_modules 跑 workflow-release-gating 21/21、model-manager 15/15、share-file 7/7

## 上线
app.py 与 lib 都在 kokoro-runtime pack 里，合并后需重发 pack（pack-release.yml → deploy/publish-pack.sh）才到用户手里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)