### PR TITLE
docs(eng-infra): 发版清单纳入 native pack、广场官方插件与 LOWA 引擎（dev-board#592）

### DIFF
--- a/.claude/agents/eng-infra.md
+++ b/.claude/agents/eng-infra.md
@@ -73,6 +73,21 @@ description: 工程基建领域。任务涉及构建、发版、CI workflow、�
    `systemctl restart aiworkdeck-cloud` → 冒烟：journal 无 ERROR、新端点返回体
    不再与「不存在的端点」相同（后者恒为 `{"code":1,"message":"服务器内部错误"}` + 200，
    这也是判「接口没上」最快的探法）。表结构靠 `ddl-auto: update` 自动建，无手动迁移。
+4.7. **独立发布件逐项查、有更新随发版一起发（2026-09-11 维护者定，dev-board#592）**：
+   五个 native pack（`pptx/mineru/kokoro/asr-runtime` + `litigation-visual`）、广场官方插件
+   （`due-diligence` 在私有仓 `zeweihan/aiworkdeck-dd-plugin`、`hr-template-pack`）、LOWA 引擎
+   **都不随 `v*` tag 自动发**，`<svc>-service/` 与 `litviz/` 的改动合进 master 后用户手里不会变。
+   pack 判据：`git log $(git tag -l 'pack-<id>-v*' --sort=-v:refname | head -1)..origin/master --
+   <源目录> desktop/scripts/build-pack.js`（runtime 再加 `prepare-python-service.js`；litviz 再加
+   `prepare-graphviz.js`、`fetch-drawio-assets.js`）只作初筛，**以内容为准复核**：`git archive origin/master
+   <源目录>` 与已发布版（本机 `~/.aiworkdeck/packs/<id>/<current>/` 或 Release 组件）`diff -r`，
+   只差 SPDX 头/tests 算无更新——pack-release 从 master 当时 HEAD 出包，tag 可能落后于实际出包提交
+   （litigation-visual 1.1.1 实测）。确有差异 → `pack-release.yml`
+   出新版本 + `deploy/publish-pack.sh`，**先于打 tag** verify 通过；已装用户靠 `PackUpdater` 24h 内自动追新。
+   官方插件判据：源 `manifest.json` 版本高于 `/api/registry/plugins` → 北京 `publish-plugin.mjs` 上架 +
+   国际站同步；声明了更高 `minHostVersion` 的要等桌面正式版发出后再上。LOWA：`desktop-build.yml`
+   的 `LOWA_BASE_URL` 变了 → `publish-lowa-engine.sh publish/verify` 先于打 tag。
+   内置 skill（`backend/skills/*`，脱敏等）随安装包/补丁走，不在此列。
 5. **EN 走查（打 tag 前必过）**：① 以英文语言设置跑 app-e2e 全量（含 J12 英文旅程：切 en-US 断言工作台四列英文锚点 + AI 过程卡工具名无中文，语言键 `awd_app_language`，切语言必须整页 reload）；② 编辑器 boot 用 `?uilang=en-US` 并以 office_thread.js 的 ooLocale 诊断确认 en-US 生效（issue #66 的诊断口径）；③ 人工过一遍英文主界面截图（工作台/设置/AI 面板）。
 6. DMG 安装窗口视觉（PR#204）：`build.dmg` 里的 `contents` 坐标是**图标中心、原点在窗口内容区左上角（不含标题栏）**；默认窗口尺寸由 `build.dmg.window` 显式钉在 660x420（**外框**，含约 32pt 标题栏，dmgbuild 写进 `.DS_Store` 的 `bwsp.WindowBounds`；不写就拿背景图 1x 尺寸当窗口）。**背景图刻意比窗口大（dev-board#580）**：Finder 按原尺寸把背景贴在左上角、不拉伸，图外是白底，用户拉大窗口就露白；所以画布 3840x2160（2x 7680x4320），设计主体只占左上 660x420，其余是同一组渐变的 px 锚定延续（DMG 只多约 1.5MB，代价是打开时 Finder 多吃约 140MB 解码内存）。Office 插件 DMG（`office-addin/installer/art/dmg-background.html`，`render-art.mjs` 的 `DMG_CANVAS`）同一做法。背景图 `desktop/build/background.png` + `background@2x.png` 由 electron-builder 自动合成 hidpi TIFF，源文件是 `desktop/build/dmg-background.html`（顶部注释有 headless Chrome 重新生成命令）。改图标落位必须同步改 HTML 里的光晕/箭头位置，否则错位；改 HTML 的渐变别写回百分比（会随画布尺寸漂移，主体区跟着变）。
 6.5. **win 安装器美术管线**（`desktop/scripts/render-win-installer-art.mjs`，安装器 UI 重设计新增）：`build/win/*.html`（美术源文件）→ headless Chrome 截图 → ImageMagick 转 24 位 BMP3 入库为 `installerSidebar.bmp`/`installerHeader.bmp`。**sips 只能出 32 位 BMP，NSIS/MUI2 只认无 alpha 的经典 BMP，必须用 `magick`**——这是个地雷，脚本会校验 BM 头与色深不合格宁可失败也不入库。只有维护者改美术时手动跑一次，产物入库后 CI 与用户构建都不需要 Chrome/ImageMagick。


### PR DESCRIPTION
维护者 2026-09-11 指示：发版时除已有各端外，官方维护的插件/资源包也要逐项查、有更新就一起发，从下次发版起执行。

## 改动
`.claude/agents/eng-infra.md` 发版链路新增 4.7：
- 五个 native pack（pptx/mineru/kokoro/asr-runtime + litigation-visual）、广场官方插件（due-diligence、hr-template-pack）、LOWA 引擎不随 `v*` tag 自动发
- pack 判据：`git log <上个 pack tag>..origin/master -- <源目录>` 初筛，**以与已发布版的内容 diff 为准**（pack-release 从 master HEAD 出包，tag 可能落后；litigation-visual 1.1.1 实测 tag 之后的提交已在包里）；确有差异 → pack-release.yml + publish-pack.sh，先于打 tag；已装用户由 PackUpdater 24h 内自动追新
- 官方插件：源 manifest 版本高于 registry → 北京 publish-plugin + 国际站同步；声明更高 minHostVersion 的等桌面正式版发出后再上
- LOWA：LOWA_BASE_URL 变了 → publish-lowa-engine.sh 先于打 tag
- 内置 skill（backend/skills/*，脱敏等）随安装包/补丁走，不在此列

## 2026-09-11 盘点结果
- kokoro-runtime：有更新（#813），下次发版出 1.0.1
- litigation-visual：只差 SPDX 头，无更新
- asr/pptx/mineru-runtime：tag 后零提交，无更新
- due-diligence：仓 0.6.1 = registry 0.6.1，无更新

纯文档改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)