### PR TITLE
chore(release): v0.41.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiworkdeck-desktop",
   "private": true,
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "AI WorkDeck desktop shell (Electron)",
   "author": "AI WorkDeck contributors",
   "main": "main/main.js",


### PR DESCRIPTION
桌面端 v0.41.0：Word 式原生审阅（LOWA 引擎 24.2.8-zhcn-r5）与 0.40.0 中文确认/右键菜单回归修复，见 #819。引擎来源变更，按 patch-gate 发大版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)